### PR TITLE
redo patch for data (transfer) operations

### DIFF
--- a/man/fi_getinfo.3
+++ b/man/fi_getinfo.3
@@ -138,7 +138,7 @@ Optionally supplied endpoint attributes.
 Specifies the order in which the transport protocol processes headers.
 .IP "threading"
 This indicates the threading serialization model that the application and
-provider will adhere to.  The treading model only applies to data operations.
+provider will adhere to.  The treading model only applies to data transfer operations.
 (See the data_progress field for details.)
 .IP "control_progress"
 This field indicates the method that the provider uses to make progress


### PR DESCRIPTION
"data operations" was not defined or used anywhere else, whereas "data transfer operations" is/was.
