### PR TITLE
man: document fi_getinfo as a thread safe call

### DIFF
--- a/man/fi_getinfo.3
+++ b/man/fi_getinfo.3
@@ -709,5 +709,8 @@ call fi_freeinfo to release fi_info structures returned by fi_getinfo.
 .PP
 If neither node, service or hints are provided, then fi_getinfo simply returns
 the list all available communication interfaces.
+.PP
+Multiple threads may call 
+.BR fi_getinfo " simultaneously, without any requirement for serialization."
 .SH "SEE ALSO"
 fi_open(3), fi_domain(3), fi_endpoint(3)


### PR DESCRIPTION
Multiple threads should be able to call fi_getinfo
simultaneously without having to serialize their calls.
This is required to support use cases where multiple
threads may want to access the fabric but they are not aware
of the existence of other threads, or do not have any shared
resource to serialize on.
