### PR TITLE
man: clarify fi_cancel as time bounded

### DIFF
--- a/man/fi_endpoint.3
+++ b/man/fi_endpoint.3
@@ -227,7 +227,7 @@ The endpoint must have been configured to support cancelable operations --
 see FI_CANCEL flag -- in order for this call to succeed.  Canceling
 an operation causes the fabric provider to search for the operation
 and, if it is still pending, complete it as having been canceled.
-Cancel should return within a bounded period of time.
+The cancel operation will complete within a bounded period of time.
 .SS "fi_ep_sync"
 The sync function is used to indicate that all previously identified
 operations submitted on the specified endpoint or endpoint alias


### PR DESCRIPTION
fi_cancel should return within a bounded period of time,
i.e. it cannot block indefinitely. Some providers may need
to perform additional actions that may not be "immediate".

Based on OFIWG discussion on 9/2.
