### PR TITLE
include: fi_inject_atomic functions

### DIFF
--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -120,6 +120,12 @@ struct fi_ops_atomic {
 			enum fi_datatype datatype, enum fi_op op, void *context);
 	ssize_t	(*writemsg)(struct fid_ep *ep,
 			const struct fi_msg_atomic *msg, uint64_t flags);
+	ssize_t	(*inject)(struct fid_ep *ep, const void *buf, size_t count,
+			uint64_t addr, uint64_t key, enum fi_datatype datatype,
+			enum fi_op op);
+	ssize_t	(*injectto)(struct fid_ep *ep, const void *buf, size_t count,
+			const void *dest_addr, uint64_t addr, uint64_t key,
+			enum fi_datatype datatype, enum fi_op op);
 
 	ssize_t	(*readwrite)(struct fid_ep *ep,
 			const void *buf, size_t count, void *desc,
@@ -214,6 +220,24 @@ fi_atomicmsg(struct fid_ep *ep,
 	     const struct fi_msg_atomic *msg, uint64_t flags)
 {
 	return ep->atomic->writemsg(ep, msg, flags);
+}
+
+static inline ssize_t
+fi_inject_atomic(struct fid_ep *ep, const void *buf, size_t count,
+		uint64_t addr, uint64_t key, enum fi_datatype datatype,
+		enum fi_op op)
+{
+	return ep->atomic->inject(ep, buf, count, addr, key,
+			datatype, op);
+}
+
+static inline ssize_t
+fi_inject_atomicto(struct fid_ep *ep, const void *buf, size_t count,
+		const void *dest_addr, uint64_t addr, uint64_t key,
+		enum fi_datatype datatype, enum fi_op op)
+{
+	return ep->atomic->injectto(ep, buf, count, dest_addr, addr,
+			key, datatype, op);
 }
 
 static inline ssize_t

--- a/man/fi_atomic.3
+++ b/man/fi_atomic.3
@@ -51,6 +51,23 @@ Indicates if a provider supports a specific atomic operation
 .BI "ssize_t fi_atomicmsg(struct fid_ep *" ep ","
 .BI "const struct fi_msg_atomic * " msg ","
 .BI "uint64_t " flags ");"
+.HP
+.BI "ssize_t fi_inject_atomic(struct fid_ep *" ep ","
+.BI "const void *" buf ","
+.BI "size_t " count ","
+.BI "uint64_t " addr ","
+.BI "uint64_t " key ","
+.BI "enum fi_datatype " datatype ","
+.BI "enum fi_op " op ");"
+.HP
+.BI "ssize_t fi_inject_atomicto(struct fid_ep *" ep ","
+.BI "const void *" buf ","
+.BI "size_t " count ","
+.BI "const void *" dest_addr ","
+.BI "uint64_t " addr ","
+.BI "uint64_t " key ","
+.BI "enum fi_datatype " datatype ","
+.BI "enum fi_op " op ");"
 .PP
 .HP
 .BI "ssize_t fi_fetch_atomic(struct fid_ep *" ep ","
@@ -326,6 +343,16 @@ The fi_atomicv transfers the set of data buffers referenced by
 the ioc parameter to the remote node for processing.
 .PP
 The fi_atomicto function is equivalent to fi_atomic for unconnected endpoints.
+.PP
+The  fi_inject_atomic call is an optimized version of fi_atomic.  The
+fi_inject_atomic function behaves as if the FI_INJECT transfer flag were set,
+and FI_EVENT were not.  That is, the data buffer is available for reuse
+immediately on returning from from fi_inject_atomic, and no completion event
+will be generated for this atomic.  The completion event will be  suppressed
+even  if  the endpoint has not been configured with FI_EVENT.  See the flags
+discussion below for more details.
+.PP
+The fi_inject_atomicto is  equivalent to fi_inject_atomic for unconnected endpoints.
 .PP
 The fi_atomicmsg call supports atomic functions over both connected and unconnected
 endpoints, with the ability to control the atomic operation per call through the


### PR DESCRIPTION
The  fi_inject_atomic call is an optimized version of fi_atomic.  The
fi_inject_atomic function behaves as if the FI_INJECT transfer flag ere
set, and FI_EVENT were not.  That is, the data buffer is available for
reuse immediately on returning from from fi_inject_atomic, and no
completion vent will be generated for this atomic.  The completion event
will be uppressed even  if  the endpoint has not been configured with
FI_EVENT.  See the lags discussion below for more details.

The inject calls are similar to those that are already defined for RMA
and MSGQ.
