### PR TITLE
fabric: Add size field to ops structures

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -222,6 +222,7 @@ typedef struct fid *fid_t;
 struct fi_eq_attr;
 
 struct fi_ops {
+	size_t	size;
 	int	(*close)(struct fid *fid);
 	int	(*bind)(struct fid *fid, struct fid *bfid, uint64_t flags);
 	int	(*sync)(struct fid *fid, uint64_t flags, void *context);
@@ -251,6 +252,7 @@ struct fi_attr {
 void fi_query(const struct fi_info *info, struct fi_attr *attr, size_t *attrlen);
 
 struct fi_ops_fabric {
+	size_t	size;
 	int	(*domain)(struct fid_fabric *fabric, struct fi_info *info,
 			struct fid_domain **dom, void *context);
 	int	(*endpoint)(struct fid_fabric *fabric, struct fi_info *info,
@@ -268,6 +270,9 @@ struct fid_fabric {
 
 int fi_fabric(const char *name, uint64_t flags, struct fid_fabric **fabric,
 	      void *context);
+
+#define FI_CHECK_OP(ops, opstype, op) \
+	((ops->size > offsetof(opstype, op)) && ops->ops)
 
 static inline int
 fi_fopen(struct fid_fabric *fabric, const char *name, uint64_t flags,

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -105,6 +105,7 @@ struct fi_msg_atomic {
 };
 
 struct fi_ops_atomic {
+	size_t	size;
 	ssize_t	(*write)(struct fid_ep *ep,
 			const void *buf, size_t count, void *desc,
 			uint64_t addr, uint64_t key,

--- a/include/rdma/fi_cm.h
+++ b/include/rdma/fi_cm.h
@@ -42,6 +42,7 @@ extern "C" {
 
 
 struct fi_ops_cm {
+	size_t	size;
 	int	(*getname)(fid_t fid, void *addr, size_t *addrlen);
 	int	(*getpeer)(struct fid_ep *ep, void *addr, size_t *addrlen);
 	int	(*connect)(struct fid_ep *ep, const void *addr,

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -71,6 +71,7 @@ struct fi_av_attr {
 };
 
 struct fi_ops_av {
+	size_t	size;
 	int	(*insert)(struct fid_av *av, const void *addr, size_t count,
 			void **fi_addr, uint64_t flags);
 	int	(*remove)(struct fid_av *av, void *fi_addr, size_t count,
@@ -126,6 +127,7 @@ struct fi_wait_attr {
 };
 
 struct fi_ops_wait {
+	size_t	size;
 	int	(*wait)(struct fid_wait *waitset, int timeout);
 };
 
@@ -157,6 +159,7 @@ struct fi_poll_attr {
 };
 
 struct fi_ops_poll {
+	size_t	size;
 	int	(*poll)(struct fid_poll *pollset, void **context, int count);
 };
 
@@ -284,6 +287,7 @@ struct fi_eq_cm_entry {
 };
 
 struct fi_ops_eq {
+	size_t	size;
 	ssize_t	(*read)(struct fid_eq *eq, void *buf, size_t len);
 	ssize_t	(*readfrom)(struct fid_eq *eq, void *buf, size_t len,
 			void *src_addr, size_t *addrlen);
@@ -324,6 +328,7 @@ struct fi_cntr_attr {
 };
 
 struct fi_ops_cntr {
+	size_t	size;
 	uint64_t (*read)(struct fid_cntr *cntr);
 	int	(*add)(struct fid_cntr *cntr, uint64_t value);
 	int	(*set)(struct fid_cntr *cntr, uint64_t value);
@@ -373,6 +378,7 @@ struct fi_domain_attr {
 };
 
 struct fi_ops_domain {
+	size_t	size;
 	int	(*query)(struct fid_domain *domain, struct fi_domain_attr *attr,
 			size_t *attrlen);
 	int	(*av_open)(struct fid_domain *domain, struct fi_av_attr *attr,
@@ -397,6 +403,7 @@ struct fi_ops_domain {
 #define FI_MR_KEY		(1ULL << 3)	/* FI_USER_MR_KEY */
 
 struct fi_ops_mr {
+	size_t	size;
 	int	(*reg)(struct fid_domain *domain, const void *buf, size_t len,
 			uint64_t access, uint64_t offset, uint64_t requested_key,
 			uint64_t flags, struct fid_mr **mr, void *context);

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -50,6 +50,7 @@ extern "C" {
 #define FI_LIB_EXTENSION fi
 
 struct fi_ops_prov {
+	size_t	size;
 	int	(*getinfo)(const char *node, const char *service, uint64_t flags,
 			struct fi_info *hints, struct fi_info **info);
 	int	(*freeinfo)(struct fi_info *info);
@@ -66,10 +67,10 @@ static inline int fi_register(struct fi_ops_prov *ops)
 }
 
 
-
 #define FI_LIB_CLASS_NAME	"libfabric"
 
 struct fi_ops_lib {
+	size_t		size;
 	size_t		(*context_size)(void);
 	const char *	(*sysfs_path)(void);
 	int		(*read_file)(const char *dir, const char *file,

--- a/include/rdma/fi_rma.h
+++ b/include/rdma/fi_rma.h
@@ -68,6 +68,7 @@ struct fi_msg_rma {
 };
 
 struct fi_ops_rma {
+	size_t	size;
 	ssize_t	(*read)(struct fid_ep *ep, void *buf, size_t len, void *desc,
 			uint64_t addr, uint64_t key, void *context);
 	ssize_t	(*readv)(struct fid_ep *ep, const struct iovec *iov, void **desc,

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -57,6 +57,7 @@ struct fi_msg_tagged {
 };
 
 struct fi_ops_tagged {
+	size_t	size;
 	ssize_t (*recv)(struct fid_ep *ep, void *buf, size_t len, void *desc,
 			uint64_t tag, uint64_t ignore, void *context);
 	ssize_t (*recvv)(struct fid_ep *ep, const struct iovec *iov, void **desc,

--- a/prov/ibverbs/src/fi_verbs.c
+++ b/prov/ibverbs/src/fi_verbs.c
@@ -589,6 +589,7 @@ ibv_msg_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags)
 }
 
 static struct fi_ops_msg ibv_msg_ep_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
 	.recv = ibv_msg_ep_recv,
 	.recvv = ibv_msg_ep_recvv,
 	.recvfrom = ibv_msg_ep_recvfrom,
@@ -852,6 +853,7 @@ ibv_msg_ep_rma_writedatato(struct fid_ep *ep, const void *buf, size_t len,
 
 
 static struct fi_ops_rma ibv_msg_ep_rma_ops = {
+	.size = sizeof(struct fi_ops_rma),
 	.read = ibv_msg_ep_rma_read,
 	.readv = ibv_msg_ep_rma_readv,
 	.readfrom = ibv_msg_ep_rma_readfrom,
@@ -1353,6 +1355,7 @@ ibv_msg_ep_atomic_compwritevalid(struct fid_ep *ep, enum fi_datatype datatype,
 
 
 static struct fi_ops_atomic ibv_msg_ep_atomic_ops = {
+	.size		= sizeof(struct fi_ops_atomic),
 	.write		= ibv_msg_ep_atomic_write,
 	.writev		= ibv_msg_ep_atomic_writev,
 	.writeto	= ibv_msg_ep_atomic_writeto,
@@ -1423,6 +1426,7 @@ static int ibv_msg_ep_shutdown(struct fid_ep *ep, uint64_t flags)
 }
 
 static struct fi_ops_cm ibv_msg_ep_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
 	.connect = ibv_msg_ep_connect,
 	.accept = ibv_msg_ep_accept,
 	.reject = ibv_msg_ep_reject,
@@ -1493,6 +1497,7 @@ static ssize_t ibv_msg_ep_cancel(fid_t fid, void *context)
 }
 
 static struct fi_ops_ep ibv_msg_ep_base_ops = {
+	.size = sizeof(struct fi_ops_ep),
 	.enable = ibv_msg_ep_enable,
 	.cancel = ibv_msg_ep_cancel,
 	.getopt = ibv_msg_ep_getopt,
@@ -1512,6 +1517,7 @@ static int ibv_msg_ep_close(fid_t fid)
 }
 
 static struct fi_ops ibv_msg_ep_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = ibv_msg_ep_close,
 	.bind = ibv_msg_ep_bind
 };
@@ -1756,6 +1762,7 @@ ibv_eq_cm_strerror(struct fid_eq *eq, int prov_errno, const void *prov_data,
 }
 
 static struct fi_ops_eq ibv_eq_cm_data_ops = {
+	.size = sizeof(struct fi_ops_eq),
 	.read = ibv_eq_cm_read_data,
 	.readerr = ibv_eq_cm_readerr,
 	.condread = ibv_eq_cm_condread_data,
@@ -1797,6 +1804,7 @@ static int ibv_eq_cm_close(fid_t fid)
 }
 
 static struct fi_ops ibv_eq_cm_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = ibv_eq_cm_close,
 	.control = ibv_eq_cm_control,
 };
@@ -2080,6 +2088,7 @@ ibv_eq_comp_strerror(struct fid_eq *eq, int prov_errno, const void *prov_data,
 }
 
 static struct fi_ops_eq ibv_eq_comp_context_ops = {
+	.size = sizeof(struct fi_ops_eq),
 	.read = ibv_eq_comp_read_context,
 	.condread = ibv_eq_comp_condread_context,
 	.readerr = ibv_eq_comp_readerr,
@@ -2087,6 +2096,7 @@ static struct fi_ops_eq ibv_eq_comp_context_ops = {
 };
 
 static struct fi_ops_eq ibv_eq_comp_comp_ops = {
+	.size = sizeof(struct fi_ops_eq),
 	.read = ibv_eq_comp_read_comp,
 	.condread = ibv_eq_comp_condread_comp,
 	.readerr = ibv_eq_comp_readerr,
@@ -2094,6 +2104,7 @@ static struct fi_ops_eq ibv_eq_comp_comp_ops = {
 };
 
 static struct fi_ops_eq ibv_eq_comp_data_ops = {
+	.size = sizeof(struct fi_ops_eq),
 	.read = ibv_eq_comp_read_data,
 	.condread = ibv_eq_comp_condread_data,
 	.readerr = ibv_eq_comp_readerr,
@@ -2142,6 +2153,7 @@ static int ibv_eq_comp_close(fid_t fid)
 }
 
 static struct fi_ops ibv_eq_comp_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = ibv_eq_comp_close,
 	.control = ibv_eq_comp_control,
 };
@@ -2265,6 +2277,7 @@ static int ibv_mr_close(fid_t fid)
 }
 
 static struct fi_ops ibv_mr_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = ibv_mr_close
 };
 
@@ -2348,14 +2361,17 @@ static int ibv_open_device_by_name(struct ibv_domain *domain, const char *name)
 }
 
 static struct fi_ops ibv_fid_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = ibv_close,
 };
 
 static struct fi_ops_mr ibv_domain_mr_ops = {
+	.size = sizeof(struct fi_ops_mr),
 	.reg = ibv_mr_reg,
 };
 
 static struct fi_ops_domain ibv_domain_ops = {
+	.size = sizeof(struct fi_ops_domain),
 	.eq_open = ibv_eq_open,
 	.endpoint = ibv_open_ep,
 };
@@ -2398,6 +2414,7 @@ err:
 }
 
 static struct fi_ops_prov ibv_ops = {
+	.size = sizeof(struct fi_ops_prov),
 	.getinfo = ibv_getinfo,
 	.freeinfo = ibv_freeinfo,
 	.domain = ibv_domain,

--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -276,11 +276,13 @@ static int psmx_av_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 }
 
 static struct fi_ops psmx_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = psmx_av_close,
 	.bind = psmx_av_bind,
 };
 
 static struct fi_ops_av psmx_av_ops = {
+	.size = sizeof(struct fi_ops_av),
 	.insert = psmx_av_insert,
 	.remove = psmx_av_remove,
 	.lookup = psmx_av_lookup,

--- a/prov/psm/src/psmx_cm.c
+++ b/prov/psm/src/psmx_cm.c
@@ -138,6 +138,7 @@ static int psmx_cm_leave(struct fid_ep *ep, void *addr, void *fi_addr, uint64_t 
 }
 
 struct fi_ops_cm psmx_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
 	.getname = psmx_cm_getname,
 	.getpeer = psmx_cm_getpeer,
 	.connect = psmx_cm_connect,

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -234,6 +234,7 @@ static int psmx_cntr_control(fid_t fid, int command, void *arg)
 }
 
 static struct fi_ops psmx_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = psmx_cntr_close,
 	.bind = psmx_cntr_bind,
 	.sync = psmx_cntr_sync,
@@ -241,6 +242,7 @@ static struct fi_ops psmx_fi_ops = {
 };
 
 static struct fi_ops_cntr psmx_cntr_ops = {
+	.size = sizeof(struct fi_ops_cntr),
 	.read = psmx_cntr_read,
 	.add = psmx_cntr_add,
 	.set = psmx_cntr_set,

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -84,6 +84,7 @@ static int psmx_if_open(struct fid_domain *domain, const char *name, uint64_t fl
 }
 
 static struct fi_ops psmx_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = psmx_domain_close,
 	.bind = psmx_domain_bind,
 	.sync = psmx_domain_sync,
@@ -91,6 +92,7 @@ static struct fi_ops psmx_fi_ops = {
 };
 
 static struct fi_ops_domain psmx_domain_ops = {
+	.size = sizeof(struct fi_ops_domain),
 	.query = psmx_domain_query,
 	.av_open = psmx_av_open,
 	.eq_open = psmx_eq_open,

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -340,6 +340,7 @@ static int psmx_ep_control(fid_t fid, int command, void *arg)
 }
 
 static struct fi_ops psmx_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = psmx_ep_close,
 	.bind = psmx_ep_bind,
 	.sync = psmx_ep_sync,
@@ -347,6 +348,7 @@ static struct fi_ops psmx_fi_ops = {
 };
 
 static struct fi_ops_ep psmx_ep_ops = {
+	.size = sizeof(struct fi_ops_ep),
 	.cancel = psmx_ep_cancel,
 	.getopt = psmx_ep_getopt,
 	.setopt = psmx_ep_setopt,

--- a/prov/psm/src/psmx_eq.c
+++ b/prov/psm/src/psmx_eq.c
@@ -499,6 +499,7 @@ static int psmx_eq_control(fid_t fid, int command, void *arg)
 }
 
 static struct fi_ops psmx_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = psmx_eq_close,
 	.bind = psmx_eq_bind,
 	.sync = psmx_eq_sync,
@@ -506,6 +507,7 @@ static struct fi_ops psmx_fi_ops = {
 };
 
 static struct fi_ops_eq psmx_eq_ops = {
+	.size = sizeof(struct fi_ops_eq),
 	.read = psmx_eq_read,
 	.readfrom = psmx_eq_readfrom,
 	.readerr = psmx_eq_readerr,

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -269,6 +269,7 @@ err_out:
 }
 
 static struct fi_ops_prov psmx_ops = {
+	.size = sizeof(struct fi_ops_prov),
 	.getinfo = psmx_getinfo,
 	.domain = psmx_domain_open,
 };

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -203,6 +203,7 @@ static int psmx_mr_control(fid_t fid, int command, void *arg)
 }
 
 static struct fi_ops psmx_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = psmx_mr_close,
 	.bind = psmx_mr_bind,
 	.sync = psmx_mr_sync,
@@ -430,6 +431,7 @@ static int psmx_mr_regattr(struct fid_domain *domain, const struct fi_mr_attr *a
 }
 
 struct fi_ops_mr psmx_mr_ops = {
+	.size = sizeof(struct fi_ops_mr),
 	.reg = psmx_mr_reg,
 	.regv = psmx_mr_regv,
 	.regattr = psmx_mr_regattr,

--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -351,6 +351,7 @@ static ssize_t psmx_inject(struct fid_ep *ep, const void *buf, size_t len)
 }
 
 struct fi_ops_msg psmx_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
 	.recv = psmx_recv,
 	.recvv = psmx_recvv,
 	.recvfrom = psmx_recvfrom,

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -393,6 +393,7 @@ static ssize_t psmx_tagged_search(struct fid_ep *ep, uint64_t *tag, uint64_t ign
 }
 
 struct fi_ops_tagged psmx_tagged_ops = {
+	.size = sizeof(struct fi_ops_tagged),
 	.recv = psmx_tagged_recv,
 	.recvv = psmx_tagged_recvv,
 	.recvfrom = psmx_tagged_recvfrom,

--- a/prov/sockets/src/sock.c
+++ b/prov/sockets/src/sock.c
@@ -57,6 +57,7 @@ static int sock_getinfo(const char *node, const char *service, uint64_t flags,
 
 
 static struct fi_ops_prov sock_ops = {
+	.size = sizeof(struct fi_ops_prov),
 	.getinfo = sock_getinfo,
 	.freeinfo = NULL, /* use default */
 	.domain = sock_domain,

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -113,11 +113,13 @@ static int sock_av_close(struct fid *fid)
 }
 
 static struct fi_ops sock_av_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = sock_av_close,
 	.bind = sock_av_bind,
 };
 
 static struct fi_ops_av sock_am_ops = {
+	.size = sizeof(struct fi_ops_av),
 	.insert = sock_am_insert,
 	.remove = sock_am_remove,
 	.lookup = sock_am_lookup,
@@ -125,6 +127,7 @@ static struct fi_ops_av sock_am_ops = {
 };
 
 //static struct fi_ops_av sock_av_ops = {
+//	.size = sizeof(struct fi_ops_av),
 //	.insert = sock_av_insert,
 //	.remove = sock_av_remove,
 //	.lookup = sock_av_lookup,

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -115,6 +115,7 @@ static int sock_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 }
 
 static struct fi_ops sock_mr_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = sock_mr_close,
 	.bind = sock_mr_bind,
 };
@@ -196,10 +197,12 @@ static int sock_reg(struct fid_domain *domain, const void *buf, size_t len,
 }
 
 static struct fi_ops sock_dom_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = sock_dom_close,
 };
 
 static struct fi_ops_domain sock_dom_ops = {
+	.size = sizeof(struct fi_ops_domain),
 	.query = sock_dom_query,
 	.av_open = sock_av_open,
 	.eq_open = sock_eq_open,
@@ -210,6 +213,7 @@ static struct fi_ops_domain sock_dom_ops = {
 };
 
 static struct fi_ops_mr sock_dom_mr_ops = {
+	.size = sizeof(struct fi_ops_mr),
 	.reg = sock_reg,
 	.regv = sock_regv,
 	.regattr = sock_regattr,

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -41,6 +41,7 @@
 
 
 //static struct fi_ops sock_eq_fi_ops = {
+//	.size = sizeof(struct fi_ops),
 //	.close = sock_eq_close,
 //};
 
@@ -110,6 +111,7 @@ static int sock_cntr_close(struct fid *fid)
 }
 
 static struct fi_ops_cntr sock_cntr_ops = {
+	.size = sizeof(struct fi_ops_cntr),
 	.read = sock_cntr_read,
 	.add = sock_cntr_add,
 	.set = sock_cntr_set,
@@ -117,6 +119,7 @@ static struct fi_ops_cntr sock_cntr_ops = {
 };
 
 static struct fi_ops sock_cntr_fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = sock_cntr_close,
 };
 

--- a/prov/sockets/src/sock_poll.c
+++ b/prov/sockets/src/sock_poll.c
@@ -41,10 +41,12 @@
 
 
 //static struct fi_ops sock_wait_fi_ops = {
+//	.size = sizeof(struct fi_ops),
 //	.close = sock_wait_close,
 //};
 //
 //static struct fi_ops sock_poll_fi_ops = {
+//	.size = sizeof(struct fi_ops),
 //	.close = sock_poll_close,
 //};
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -513,6 +513,7 @@ __fi_eq_cm_strerror(struct fid_eq *eq, int prov_errno, const void *prov_data,
 }
 
 struct fi_ops_eq __fi_eq_cm_data_ops = {
+	.size = sizeof(struct fi_ops_eq),
 	.read = __fi_eq_cm_read_data,
 	.condread = __fi_eq_cm_condread_data,
 	.readerr = __fi_eq_cm_readerr,
@@ -554,6 +555,7 @@ static int __fi_eq_cm_control(fid_t fid, int command, void *arg)
 }
 
 struct fi_ops __fi_eq_cm_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = __fi_eq_cm_close,
 	.control = __fi_eq_cm_control,
 };
@@ -620,6 +622,7 @@ static int __fi_pep_listen(struct fid_pep *pep)
 }
 
 static struct fi_ops_cm __fi_pep_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
 	.listen = __fi_pep_listen,
 };
 
@@ -655,6 +658,7 @@ static int __fi_pep_close(fid_t fid)
 }
 
 static struct fi_ops __fi_pep_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = __fi_pep_close,
 	.bind = __fi_pep_bind
 };
@@ -713,6 +717,7 @@ static int __fi_fabric_close(fid_t fid)
 }
 
 static struct fi_ops __fi_ops = {
+	.size = sizeof(struct fi_ops),
 	.close = __fi_fabric_close,
 };
 
@@ -738,6 +743,7 @@ __fi_open(struct fid_fabric *fabric, const char *name, uint64_t flags,
 }
 
 static struct fi_ops_fabric __fi_ops_fabric = {
+	.size = sizeof(struct fi_ops_fabric),
 	.domain = __fi_domain,
 	.endpoint = __fi_endpoint,
 	.eq_open = __fi_eq_open,


### PR DESCRIPTION
Basically revert commit 3c4c4e21b169e5490989767660a5b1e8d70d7bca.
Add a size field to all ops structures.  This will allow
extensions to the ops structures in a compatible manner.

Signed-off-by: Sean Hefty sean.hefty@intel.com
