### PR TITLE
fabric: Move open_if operation to struct fi_ops

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -218,6 +218,8 @@ struct fi_ops {
 	int	(*bind)(struct fid *fid, struct fid *bfid, uint64_t flags);
 	int	(*sync)(struct fid *fid, uint64_t flags, void *context);
 	int	(*control)(struct fid *fid, int command, void *arg);
+	int	(*openif)(struct fid *fid, const char *name,
+			uint64_t flags, struct fid **fif, void *context);
 };
 
 /* All fabric interface descriptors must start with this structure */
@@ -250,8 +252,6 @@ struct fi_ops_fabric {
 			struct fid_pep **pep, void *context);
 	int	(*eq_open)(struct fid_fabric *fabric, const struct fi_eq_attr *attr,
 			struct fid_eq **eq, void *context);
-	int	(*if_open)(struct fid_fabric *fabric, const char *name,
-			uint64_t flags, struct fid **fif, void *context);
 };
 
 struct fid_fabric {
@@ -264,13 +264,6 @@ int fi_fabric(const char *name, uint64_t flags, struct fid_fabric **fabric,
 
 #define FI_CHECK_OP(ops, opstype, op) \
 	((ops->size > offsetof(opstype, op)) && ops->ops)
-
-static inline int
-fi_fopen(struct fid_fabric *fabric, const char *name, uint64_t flags,
-	 struct fid **fif, void *context)
-{
-	return fabric->ops->if_open(fabric, name, flags, fif, context);
-}
 
 static inline int fi_close(struct fid *fid)
 {
@@ -318,6 +311,13 @@ static inline int fi_alias(struct fid *fid, struct fid **alias_fid, uint64_t fla
 	alias.fid = alias_fid;
 	alias.flags = flags;
 	return fi_control(fid, FI_ALIAS, &alias);
+}
+
+static inline int
+fi_open(struct fid *fid, const char *name, uint64_t flags,
+	struct fid **fif, void *context)
+{
+	return fid->ops->openif(fid, name, flags, fif, context);
 }
 
 

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -56,8 +56,6 @@ struct fi_ops_prov {
 	int	(*freeinfo)(struct fi_info *info);
 	int	(*domain)(struct fid_fabric *fabric, struct fi_info *info,
 			struct fid_domain **dom, void *context);
-	int	(*if_open)(const char *res_name, const char *if_name,
-			uint64_t flags, struct fid **fid, void *context);
 };
 
 int fi_version_register(int version, struct fi_ops_prov *ops);

--- a/man/fi_domain.3
+++ b/man/fi_domain.3
@@ -19,7 +19,7 @@ fi_domain \- Open a fabric access domain
 .BI "int fi_domain_bind(struct fid_domain *" domain ", struct fid *" eq ", "
 .BI "uint64_t " flags ");"
 .HP
-.BI "int fi_open(struct fid_domain *" domain ", const char *" name ", uint64_t " flags ","
+.BI "int fi_open(struct fid *" domain ", const char *" name ", uint64_t " flags ","
 .BI "struct fid **" fif ", void *" context ");"
 .SH ARGUMENTS
 .IP "fabric" 12

--- a/man/fi_fabric.3
+++ b/man/fi_fabric.3
@@ -6,11 +6,6 @@ fi_fabric / fi_close
 .RS
 Open / close a fabric domain
 .RE
-.PP
-fi_fopen / fi_close
-.RS
-Open / close a fabric specific interface
-.RE
 .SH SYNOPSIS
 .B "#include <rdma/fabric.h>"
 .HP
@@ -18,19 +13,13 @@ Open / close a fabric specific interface
 .BI "struct fid_fabric **" fabric ", void *" context ");"
 .HP
 .BI "int fi_close(struct fid *" fabric ");"
-.PP
-.HP
-.BI "int fi_fopen(struct fid_fabric *" fabric ", const char *" name ", uint64_t " flags ","
-.BI "struct fid **" fif ", void *" context ");"
 .SH ARGUMENTS
 .IP "name" 12
-Name associated with the fabric or interface.
+Name associated with the fabric.
 .IP "flags" 12
 Control flags
 .IP "fabric" 12
 Fabric domain
-.IP "fif" 12
-Fabric interface
 .IP "context" 12
 User specified context associated with the opened object.  This context is
 returned as part of any associated asynchronous event.
@@ -49,11 +38,6 @@ current system are returned as part of the fi_getinfo call.
 .PP
 The fi_fabric call takes an operational flags parameter as input.  This
 is reserved for future extensions and must be set to 0.
-.SS "fi_fopen"
-fi_fopen is used to open any available fabric specific interfaces.
-Fabric interfaces may be used to access low-level resources and operations
-that are specific to the connected fabric network.  The details of fabric
-interfaces are outside the scope of this documentation.
 .SS "fi_close"
 The fi_close call is used to release all resources associated with a fabric
 domain or interface.  All items associated with the opened fabric must

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -723,33 +723,11 @@ static struct fi_ops __fi_ops = {
 	.close = __fi_fabric_close,
 };
 
-static int
-__fi_open(struct fid_fabric *fabric, const char *name, uint64_t flags,
-	  struct fid **fif, void *context)
-{
-	struct __fid_fabric *fab;
-	struct fi_prov *prov;
-	int ret = -FI_ENOSYS;
-
-	fab = container_of(fabric, struct __fid_fabric, fabric_fid);
-	for (prov = prov_head; prov; prov = prov->next) {
-		if (!prov->ops->if_open)
-			continue;
-
-		ret = prov->ops->if_open(fab->name, name, flags, fif, context);
-		if (!ret)
-			break;
-	}
-
-	return ret;
-}
-
 static struct fi_ops_fabric __fi_ops_fabric = {
 	.size = sizeof(struct fi_ops_fabric),
 	.domain = __fi_domain,
 	.endpoint = __fi_endpoint,
 	.eq_open = __fi_eq_open,
-	.if_open = __fi_open
 };
 
 int fi_fabric(const char *name, uint64_t flags, struct fid_fabric **fabric,


### PR DESCRIPTION
Allow any structure to support extended operations.

Signed-off-by: Sean Hefty sean.hefty@intel.com
