### PR TITLE
include: optional function availability by macros

### DIFF
--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -231,6 +231,8 @@ fi_inject_atomic(struct fid_ep *ep, const void *buf, size_t count,
 	return ep->atomic->inject(ep, buf, count, addr, key,
 			datatype, op);
 }
+#define FI_INJECT_ATOMIC(ep) \
+	FI_CHECK_OP(ep->atomic, struct fi_ops_atomic, inject)
 
 static inline ssize_t
 fi_inject_atomicto(struct fid_ep *ep, const void *buf, size_t count,
@@ -240,6 +242,8 @@ fi_inject_atomicto(struct fid_ep *ep, const void *buf, size_t count,
 	return ep->atomic->injectto(ep, buf, count, dest_addr, addr,
 			key, datatype, op);
 }
+#define FI_INJECT_ATOMICTO(ep) \
+	FI_CHECK_OP(ep->atomic, struct fi_ops_atomic, injectto)
 
 static inline ssize_t
 fi_fetch_atomic(struct fid_ep *ep,

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -404,6 +404,8 @@ fi_eq_readfrom(struct fid_eq *eq, void *buf, size_t len,
 {
 	return eq->ops->readfrom(eq, buf, len, src_addr, addrlen);
 }
+#define FI_EQ_READFROM(eq) \
+	FI_CHECK_OP(eq->ops, struct fi_ops_domain, readfrom)
 
 static inline ssize_t
 fi_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf, size_t len,
@@ -429,6 +431,8 @@ fi_eq_condreadfrom(struct fid_eq *eq, void *buf, size_t len,
 {
 	return eq->ops->condreadfrom(eq, buf, len, src_addr, addrlen, cond);
 }
+#define FI_EQ_CONDREADFROM(eq) \
+	FI_CHECK_OP(eq->ops, struct fi_ops_domain, condreadfrom)
 
 static inline const char *
 fi_eq_strerror(struct fid_eq *eq, int prov_errno, void *prov_data,

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -271,12 +271,16 @@ fi_inject(struct fid_ep *ep, const void *buf, size_t len)
 {
 	return ep->msg->inject(ep, buf, len);
 }
+#define FI_INJECT_MSG(ep) \
+	(FI_CHECK_OP(ep->msg, struct fi_ops_msg, inject))
 
 static inline ssize_t
 fi_injectto(struct fid_ep *ep, const void *buf, size_t len, const void *dest_addr)
 {
 	return ep->msg->injectto(ep, buf, len, dest_addr);
 }
+#define FI_INJECT_MSGTO(ep) \
+	FI_CHECK_OP(ep->msg, struct fi_ops_msg, injectto)
 
 static inline ssize_t
 fi_senddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,

--- a/include/rdma/fi_rma.h
+++ b/include/rdma/fi_rma.h
@@ -161,6 +161,8 @@ fi_inject_write(struct fid_ep *ep, const void *buf, size_t len,
 {
 	return ep->rma->inject(ep, buf, len, addr, key);
 }
+#define FI_INJECT_WRITE(ep) \
+	FI_CHECK_OP(ep->rma, struct fi_ops_rma, inject)
 
 static inline ssize_t
 fi_inject_writeto(struct fid_ep *ep, const void *buf, size_t len,
@@ -168,6 +170,8 @@ fi_inject_writeto(struct fid_ep *ep, const void *buf, size_t len,
 {
 	return ep->rma->injectto(ep, buf, len, dest_addr, addr, key);
 }
+#define FI_INJECT_WRITETO(ep) \
+	FI_CHECK_OP(ep->rma, struct fi_ops_rma, injectto)
 
 static inline ssize_t
 fi_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -151,6 +151,8 @@ fi_tinject(struct fid_ep *ep, const void *buf, size_t len, uint64_t tag)
 {
 	return ep->tagged->inject(ep, buf, len, tag);
 }
+#define FI_TINJECT(ep) \
+	FI_CHECK_OP(ep->tagged, struct fi_ops_tagged, inject)
 
 static inline ssize_t
 fi_tinjectto(struct fid_ep *ep, const void *buf, size_t len,
@@ -158,6 +160,8 @@ fi_tinjectto(struct fid_ep *ep, const void *buf, size_t len,
 {
 	return ep->tagged->injectto(ep, buf, len, dest_addr, tag);
 }
+#define FI_TINJECTTO(ep) \
+	FI_CHECK_OP(ep->tagged, struct fi_ops_tagged, injectto)
 
 static inline ssize_t
 fi_tsenddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,

--- a/man/fi_atomic.3
+++ b/man/fi_atomic.3
@@ -350,9 +350,14 @@ and FI_EVENT were not.  That is, the data buffer is available for reuse
 immediately on returning from from fi_inject_atomic, and no completion event
 will be generated for this atomic.  The completion event will be  suppressed
 even  if  the endpoint has not been configured with FI_EVENT.  See the flags
-discussion below for more details.
+discussion below for more details.  fi_inject_atomic is an optional function.
+The availability of fi_inject_atomic for an endpoint should be checked using the macro
+FI_INJECT_ATOMIC with the endpoint as the parameter. If the function is
+available, the macro evaluates to 1, if not it evaluates to 0.
 .PP
-The fi_inject_atomicto is  equivalent to fi_inject_atomic for unconnected endpoints.
+The fi_inject_atomicto is  equivalent to fi_inject_atomic for unconnected
+endpoints.  The macro FI_INJECT_ATOMICTO must be used in a similar manner to
+FI_INJECT_ATOMIC to determine the availability of this function.
 .PP
 The fi_atomicmsg call supports atomic functions over both connected and unconnected
 endpoints, with the ability to control the atomic operation per call through the

--- a/man/fi_direct.7
+++ b/man/fi_direct.7
@@ -56,5 +56,41 @@ for additional details.
 .IP "FI_DIRECT_DYNAMIC_MR"
 The provider sets FI_DYNAMIC_MR for fi_info:domain_cap.  See fi_getinfo
 for additional details.
+.SH "OPTIONAL FUNCTIONS"
+The checks for the availability of following optional functions are made
+using macros. The provider is required to define in such a manner that they
+evaluate to either 0 or 1 at compile time. When the function is available,
+the macro evaluates to 1, and when the function is not available, the macro
+evaluates to 0.
+.IP "FI_INJECT_MSG"
+Indicates that the provider supports the inject functions for message 
+data transfers for connected mode endpoints. See fi_msg for additional 
+details.
+.IP "FI_INJECT_MSGTO"
+Similar to FI_INJECT_MSG, but for unconnected endpoints.
+.IP "FI_TINJECT"
+Indicates that the provider supports the inject functions for tagged message 
+data transfers for connected mode endpoints.
+See fi_tagged for additional details.
+.IP "FI_TINJECTTO"
+Similar to FI_TINJECT, but for unconnected endpoints.
+.IP "FI_INJECT_WRITE"
+Indicates that the provider supports the inject functions for RMA 
+data transfers for connected mode endpoints.
+See fi_rma for additional details.
+.IP "FI_INJECT_WRITETO"
+Similar to FI_INJECT_WRITE, but for unconnected endpoints.
+.IP "FI_INJECT_ATOMIC"
+Indicates that the provider supports the inject functions for atomic
+data transfers for connected mode endpoints.
+See fi_atomic for additional details.
+.IP "FI_INJECT_ATOMICTO"
+Similar to FI_INJECT_ATOMIC, but for unconnected endpoints.
+.IP "FI_EQ_READFROM"
+Indicates that the provider supports the fi_eq_readfrom function on 
+event queues.  See fi_eq for additional details.
+.IP "FI_EQ_CONDREADFROM"
+Indicates that the provider supports the fi_eq_condreadfrom function 
+on event queues.  See fi_eq for additional details.
 .SH "SEE ALSO"
 fi_getinfo(3), fi_endpoint(3), fi_domain(3)

--- a/man/fi_eq.3
+++ b/man/fi_eq.3
@@ -325,7 +325,10 @@ event data from the EQ.  The format of the event data is based on the user
 specified options when the EQ was opened.  Multiple events may be retrieved
 from an EQ in a single call, provided that sufficient buffer space was
 provided.  The number of bytes successfully read from the EQ is returned
-by the calls.
+by the calls.  fi_eq_readfrom is an optional function.
+The availability of fi_eq_readfrom for an endpoint should be checked using the macro
+FI_EQ_READFROM with the event queue as the parameter. If the function is
+available, the macro evaluates to 1, if not it evaluates to 0.
 .PP
 The readfrom calls allow the EQ to return source address information to
 the user for any received data.  The format and size of the source address
@@ -348,6 +351,9 @@ The fi_eq_condread and fi_eq_condreadfrom calls are the blocking equivalent
 operations to fi_eq_read and fi_eq_readfrom.  Their behavior is similar to
 the non-blocking calls, with the exception that the calls will not return
 until either an event has been read from the EQ or an error occurs.
+fi_eq_condreadfrom is an optional function.
+The macro FI_EQ_CONDREADFROM must be used in a similar manner to 
+FI_EQ_READFROM to determine the availability of this function.
 .SS "fi_eq_readerr"
 The read error function, fi_eq_readerr, retrieves information regarding
 any asynchronous operation which has completed with an unexpected error.

--- a/man/fi_msg.3
+++ b/man/fi_msg.3
@@ -138,9 +138,14 @@ FI_EVENT were not.  That is, the data buffer is available for reuse
 immediately on returning from from fi_inject, and no completion event will
 be generated for this send.  The completion event will be suppressed even if
 the endpoint has not been configured with FI_EVENT.  See the flags
-discussion below for more details.
+discussion below for more details. fi_inject is an optional function.
+The availability of fi_inject for an endpoint should be checked using the macro
+FI_INJECT_MSG with the endpoint as the parameter. If the function is
+available, the macro evaluates to 1, if not it evaluates to 0.
 .SS "fi_injectto"
-This call is similar to fi_inject, but for unconnected endpoints.
+This call is similar to fi_inject, but for unconnected endpoints. The macro
+FI_INJECT_MSGTO must be used in a similar manner to FI_INJECT_MSG to determine
+the availability of this function.
 .SS "fi_senddata"
 The send data call is similar to fi_send, but allows for the sending of
 remote EQ data (see FI_REMOTE_EQ_DATA flag) as part of the transfer.

--- a/man/fi_rma.3
+++ b/man/fi_rma.3
@@ -163,9 +163,14 @@ FI_EVENT were not.  That is, the data buffer is available for reuse
 immediately on returning from from fi_inject_write, and no completion event will
 be generated for this write.  The completion event will be suppressed even if
 the endpoint has not been configured with FI_EVENT.  See the flags
-discussion below for more details.
+discussion below for more details.  fi_inject_write is an optional function.
+The availability of fi_inject_write for an endpoint should be checked using 
+the macro FI_INJECT_WRITE with the endpoint as the parameter. If the function is
+available, the macro evaluates to 1, if not it evaluates to 0.
 .SS "fi_inject_writeto"
-This call is similar to fi_inject_write, but for unconnected endpoints.
+This call is similar to fi_inject_write, but for unconnected endpoints. The macro
+FI_INJECT_WRITETO must be used in a similar manner to FI_INJECT_WRITE to determine
+the availability of this function.
 .SS "fi_writedata"
 The write data call is similar to fi_write, but allows for the sending of
 remote EQ data (see FI_REMOTE_EQ_DATA flag) as part of the transfer.

--- a/man/fi_tagged.3
+++ b/man/fi_tagged.3
@@ -177,9 +177,14 @@ set, and FI_EVENT were not.  That is, the data buffer is available for reuse
 immediately on returning from from fi_tinject, and no completion event will
 be generated for this send.  The completion event will be suppressed even if
 the endpoint has not been configured with FI_EVENT.  See the flags
-discussion below for more details.
+discussion below for more details.  fi_tinject is an optional function.
+The availability of fi_tinject for an endpoint should be checked using the macro
+FI_TINJECT with the endpoint as the parameter. If the function is
+available, the macro evaluates to 1, if not it evaluates to 0.
 .SS "fi_tinjectto"
-This call is similar to fi_tinject, but for unconnected endpoints.
+This call is similar to fi_tinject, but for unconnected endpoints. The macro
+FI_TINJECTTO must be used in a similar manner to FI_TINJECT to determine
+the availability of this function.
 .SS "fi_tsenddata"
 The tagged send data call is similar to fi_tsend, but allows for the sending of
 remote EQ data (see FI_REMOTE_EQ_DATA flag) as part of the transfer.


### PR DESCRIPTION
Some functions - inject, eq_readfrom, etc. are optional for
providers. This patch introduces macros that enable applications
to check if these functions are available.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
