### PR TITLE
include: rename FI_INJECT_MSG to FI_OP_INJECT etc.

### DIFF
--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -231,7 +231,7 @@ fi_inject_atomic(struct fid_ep *ep, const void *buf, size_t count,
 	return ep->atomic->inject(ep, buf, count, addr, key,
 			datatype, op);
 }
-#define FI_INJECT_ATOMIC(ep) \
+#define FI_OP_INJECT_ATOMIC(ep) \
 	FI_CHECK_OP(ep->atomic, struct fi_ops_atomic, inject)
 
 static inline ssize_t
@@ -242,7 +242,7 @@ fi_inject_atomicto(struct fid_ep *ep, const void *buf, size_t count,
 	return ep->atomic->injectto(ep, buf, count, dest_addr, addr,
 			key, datatype, op);
 }
-#define FI_INJECT_ATOMICTO(ep) \
+#define FI_OP_INJECT_ATOMICTO(ep) \
 	FI_CHECK_OP(ep->atomic, struct fi_ops_atomic, injectto)
 
 static inline ssize_t

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -404,7 +404,7 @@ fi_eq_readfrom(struct fid_eq *eq, void *buf, size_t len,
 {
 	return eq->ops->readfrom(eq, buf, len, src_addr, addrlen);
 }
-#define FI_EQ_READFROM(eq) \
+#define FI_OP_EQ_READFROM(eq) \
 	FI_CHECK_OP(eq->ops, struct fi_ops_domain, readfrom)
 
 static inline ssize_t
@@ -431,7 +431,7 @@ fi_eq_condreadfrom(struct fid_eq *eq, void *buf, size_t len,
 {
 	return eq->ops->condreadfrom(eq, buf, len, src_addr, addrlen, cond);
 }
-#define FI_EQ_CONDREADFROM(eq) \
+#define FI_OP_EQ_CONDREADFROM(eq) \
 	FI_CHECK_OP(eq->ops, struct fi_ops_domain, condreadfrom)
 
 static inline const char *

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -271,7 +271,7 @@ fi_inject(struct fid_ep *ep, const void *buf, size_t len)
 {
 	return ep->msg->inject(ep, buf, len);
 }
-#define FI_INJECT_MSG(ep) \
+#define FI_OP_INJECT(ep) \
 	(FI_CHECK_OP(ep->msg, struct fi_ops_msg, inject))
 
 static inline ssize_t
@@ -279,7 +279,7 @@ fi_injectto(struct fid_ep *ep, const void *buf, size_t len, const void *dest_add
 {
 	return ep->msg->injectto(ep, buf, len, dest_addr);
 }
-#define FI_INJECT_MSGTO(ep) \
+#define FI_OP_INJECTTO(ep) \
 	FI_CHECK_OP(ep->msg, struct fi_ops_msg, injectto)
 
 static inline ssize_t

--- a/include/rdma/fi_rma.h
+++ b/include/rdma/fi_rma.h
@@ -161,7 +161,7 @@ fi_inject_write(struct fid_ep *ep, const void *buf, size_t len,
 {
 	return ep->rma->inject(ep, buf, len, addr, key);
 }
-#define FI_INJECT_WRITE(ep) \
+#define FI_OP_INJECT_WRITE(ep) \
 	FI_CHECK_OP(ep->rma, struct fi_ops_rma, inject)
 
 static inline ssize_t
@@ -170,7 +170,7 @@ fi_inject_writeto(struct fid_ep *ep, const void *buf, size_t len,
 {
 	return ep->rma->injectto(ep, buf, len, dest_addr, addr, key);
 }
-#define FI_INJECT_WRITETO(ep) \
+#define FI_OP_INJECT_WRITETO(ep) \
 	FI_CHECK_OP(ep->rma, struct fi_ops_rma, injectto)
 
 static inline ssize_t

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -151,7 +151,7 @@ fi_tinject(struct fid_ep *ep, const void *buf, size_t len, uint64_t tag)
 {
 	return ep->tagged->inject(ep, buf, len, tag);
 }
-#define FI_TINJECT(ep) \
+#define FI_OP_TINJECT(ep) \
 	FI_CHECK_OP(ep->tagged, struct fi_ops_tagged, inject)
 
 static inline ssize_t
@@ -160,7 +160,7 @@ fi_tinjectto(struct fid_ep *ep, const void *buf, size_t len,
 {
 	return ep->tagged->injectto(ep, buf, len, dest_addr, tag);
 }
-#define FI_TINJECTTO(ep) \
+#define FI_OP_TINJECTTO(ep) \
 	FI_CHECK_OP(ep->tagged, struct fi_ops_tagged, injectto)
 
 static inline ssize_t

--- a/man/fi_atomic.3
+++ b/man/fi_atomic.3
@@ -352,12 +352,12 @@ will be generated for this atomic.  The completion event will be  suppressed
 even  if  the endpoint has not been configured with FI_EVENT.  See the flags
 discussion below for more details.  fi_inject_atomic is an optional function.
 The availability of fi_inject_atomic for an endpoint should be checked using the macro
-FI_INJECT_ATOMIC with the endpoint as the parameter. If the function is
+FI_OP_INJECT_ATOMIC with the endpoint as the parameter. If the function is
 available, the macro evaluates to 1, if not it evaluates to 0.
 .PP
 The fi_inject_atomicto is  equivalent to fi_inject_atomic for unconnected
-endpoints.  The macro FI_INJECT_ATOMICTO must be used in a similar manner to
-FI_INJECT_ATOMIC to determine the availability of this function.
+endpoints.  The macro FI_OP_INJECT_ATOMICTO must be used in a similar manner to
+FI_OP_INJECT_ATOMIC to determine the availability of this function.
 .PP
 The fi_atomicmsg call supports atomic functions over both connected and unconnected
 endpoints, with the ability to control the atomic operation per call through the

--- a/man/fi_eq.3
+++ b/man/fi_eq.3
@@ -327,7 +327,7 @@ from an EQ in a single call, provided that sufficient buffer space was
 provided.  The number of bytes successfully read from the EQ is returned
 by the calls.  fi_eq_readfrom is an optional function.
 The availability of fi_eq_readfrom for an endpoint should be checked using the macro
-FI_EQ_READFROM with the event queue as the parameter. If the function is
+FI_OP_EQ_READFROM with the event queue as the parameter. If the function is
 available, the macro evaluates to 1, if not it evaluates to 0.
 .PP
 The readfrom calls allow the EQ to return source address information to
@@ -352,8 +352,8 @@ operations to fi_eq_read and fi_eq_readfrom.  Their behavior is similar to
 the non-blocking calls, with the exception that the calls will not return
 until either an event has been read from the EQ or an error occurs.
 fi_eq_condreadfrom is an optional function.
-The macro FI_EQ_CONDREADFROM must be used in a similar manner to 
-FI_EQ_READFROM to determine the availability of this function.
+The macro FI_OP_EQ_CONDREADFROM must be used in a similar manner to 
+FI_OP_EQ_READFROM to determine the availability of this function.
 .SS "fi_eq_readerr"
 The read error function, fi_eq_readerr, retrieves information regarding
 any asynchronous operation which has completed with an unexpected error.

--- a/man/fi_getinfo.3
+++ b/man/fi_getinfo.3
@@ -246,6 +246,11 @@ data transfer operations and the 'inject' data transfer calls.  The
 minimum supported size of an inject operation that an endpoint 
 with this capability must support is 8-bytes.  Applications may access
 endpoint options (getopt/setopt) to determine injected transfer limits.
+An endpoint may not be able to support inject calls for all types of
+operations. Applications should use appropriate macros FI_OP_INJECT,
+FI_OP_INJECTTO, FI_OP_TINJECT, FI_OP_TINJECTO, FI_OP_WRITE, FI_OP_WRITETO,
+FI_OP_ATOMIC, FI_OP_ATOMICTO to determine if inject calls
+are supported for those operations.
 .IP "FI_MULTI_RECV"
 Specifies that the endpoint must support the FI_MULTI_RECV flag when
 posting receive buffers.

--- a/man/fi_msg.3
+++ b/man/fi_msg.3
@@ -140,11 +140,11 @@ be generated for this send.  The completion event will be suppressed even if
 the endpoint has not been configured with FI_EVENT.  See the flags
 discussion below for more details. fi_inject is an optional function.
 The availability of fi_inject for an endpoint should be checked using the macro
-FI_INJECT_MSG with the endpoint as the parameter. If the function is
+FI_OP_INJECT with the endpoint as the parameter. If the function is
 available, the macro evaluates to 1, if not it evaluates to 0.
 .SS "fi_injectto"
 This call is similar to fi_inject, but for unconnected endpoints. The macro
-FI_INJECT_MSGTO must be used in a similar manner to FI_INJECT_MSG to determine
+FI_OP_INJECTTO must be used in a similar manner to FI_OP_INJECT to determine
 the availability of this function.
 .SS "fi_senddata"
 The send data call is similar to fi_send, but allows for the sending of

--- a/man/fi_tagged.3
+++ b/man/fi_tagged.3
@@ -179,11 +179,11 @@ be generated for this send.  The completion event will be suppressed even if
 the endpoint has not been configured with FI_EVENT.  See the flags
 discussion below for more details.  fi_tinject is an optional function.
 The availability of fi_tinject for an endpoint should be checked using the macro
-FI_TINJECT with the endpoint as the parameter. If the function is
+FI_OP_TINJECT with the endpoint as the parameter. If the function is
 available, the macro evaluates to 1, if not it evaluates to 0.
 .SS "fi_tinjectto"
 This call is similar to fi_tinject, but for unconnected endpoints. The macro
-FI_TINJECTTO must be used in a similar manner to FI_TINJECT to determine
+FI_OP_TINJECTTO must be used in a similar manner to FI_OP_TINJECT to determine
 the availability of this function.
 .SS "fi_tsenddata"
 The tagged send data call is similar to fi_tsend, but allows for the sending of


### PR DESCRIPTION
Rename the macros to check the presence of functions
from FI_INJECT_MSG to FI_OP_INJECT to further clarify
that they check the presence of ops.

Also, updated the fi_getinfo manpage to indicate that
EP cap FI_INJECT may not imply that inject functions are
available for each type of operation.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
