### PR TITLE
fabric: Cleanup fi.h to remove unneeded definitions

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -134,23 +134,10 @@ typedef struct { volatile int val; } atomic_t;
 #define atomic_get(v) ((v)->val)
 #define atomic_set(v, s) ((v)->val = s)
 
-
 struct fi_prov {
 	struct fi_prov		*next;
 	struct fi_ops_prov	*ops;
 };
-
-struct uv_dev {
-	struct uv_dev		*next;
-	char			sysfs_name[FI_NAME_MAX];
-	char			dev_name[FI_NAME_MAX];
-	char			sysfs_path[FI_PATH_MAX];
-	char			dev_path[FI_PATH_MAX];
-};
-
-extern struct fid_fabric *g_fabric;
-extern int uv_abi_ver;
-extern struct uv_dev *udev_head, *udev_tail;
 
 int  fi_init(void);
 
@@ -173,13 +160,12 @@ void psmx_fini(void);
 #define psmx_fini()
 #endif
 
-int __fi_fabric(const char *name, uint64_t flags, struct fid_fabric **fabric,
-	void *context);
-const char *fi_sysfs_path(void);
 int fi_read_file(const char *dir, const char *file, char *buf, size_t size);
+int fi_poll_fd(int fd);
+
 struct fi_info *__fi_allocinfo(void);
 void __fi_freeinfo(struct fi_info *info);
-int fi_poll_fd(int fd);
+
 int fi_sockaddr_len(struct sockaddr *addr);
 size_t fi_datatype_size(enum fi_datatype datatype);
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -65,37 +65,6 @@
 static struct fi_prov *prov_head, *prov_tail;
 
 
-const char *fi_sysfs_path(void)
-{
-	static char *sysfs_path;
-	char *env = NULL;
-
-	if (sysfs_path)
-		return sysfs_path;
-
-	/*
-	 * Only follow path passed in through the calling user's
-	 * environment if we're not running SUID.
-	 */
-	if (getuid() == geteuid())
-		env = getenv("SYSFS_PATH");
-
-	if (env) {
-		int len;
-
-		sysfs_path = strndup(env, FI_PATH_MAX);
-		len = strlen(sysfs_path);
-		while (len > 0 && sysfs_path[len - 1] == '/') {
-			--len;
-			sysfs_path[len] = '\0';
-		}
-	} else {
-		sysfs_path = "/sys";
-	}
-
-	return sysfs_path;
-}
-
 int fi_read_file(const char *dir, const char *file, char *buf, size_t size)
 {
 	char *path;


### PR DESCRIPTION
Variables and structures remain that were part of supporting
the libibverbs build from within the source tree.  Remove
the unneeded code.

Signed-off-by: Sean Hefty sean.hefty@intel.com
