### PR TITLE
fabric: Replace max_tag_value with mem_tag_format

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -69,6 +69,7 @@ static inline uint64_t ntohll(uint64_t x) { return x; }
 #define max(a, b) ((a) > (b) ? a : b)
 #define min(a, b) ((a) < (b) ? a : b)
 
+#define FI_TAG_GENERIC	0xAAAAAAAAAAAAAAAAULL
 
 #if DEFINE_ATOMICS
 #define fastlock_t pthread_mutex_t
@@ -168,6 +169,8 @@ void __fi_freeinfo(struct fi_info *info);
 
 int fi_sockaddr_len(struct sockaddr *addr);
 size_t fi_datatype_size(enum fi_datatype datatype);
+uint64_t fi_tag_bits(uint64_t mem_tag_format);
+uint64_t fi_tag_format(uint64_t tag_bits);
 
 #ifndef SYSCONFDIR
 #define SYSCONFDIR "/etc"

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -155,7 +155,7 @@ struct fi_ep_attr {
 	size_t			max_order_raw_size;
 	size_t			max_order_war_size;
 	size_t			max_order_waw_size;
-	uint64_t		max_tag_value;
+	uint64_t		mem_tag_format;
 	uint64_t		msg_order;
 };
 

--- a/man/fi_endpoint.3
+++ b/man/fi_endpoint.3
@@ -1,4 +1,4 @@
-.TH "FI_ENDPOINT" 3 "2014-09-09" "libfabric" "Libfabric Programmer's Manual" libfabric
+.TH "FI_ENDPOINT" 3 "2014-09-11" "libfabric" "Libfabric Programmer's Manual" libfabric
 .SH NAME
 fi_endpoint \- Fabric endpoint operations
 .PP
@@ -335,7 +335,7 @@ struct fi_ep_attr {
 	size_t    max_order_raw_size;
 	size_t    max_order_war_size;
 	size_t    max_order_waw_size;
-	uint64_t  max_tag_value;
+	uint64_t  mem_tag_format;
 	uint64_t  msg_order;
 };
 .fi
@@ -415,11 +415,35 @@ second RMA or atomic write.
 .PP
 An order size value of 0 indicates that ordering is not guaranteed.  A value
 of -1 guarantees ordering for any data size.
-.SS "Maximum Tag Value"
-The maximum tag value is the largest application tag value supported by a
-provider over an endpoint.  A provider will ignore any tag bits or values
-larger than the max_tag_value.  This field only applies to endpoints that
-support the tagged message interfaces.
+.SS "Memory Tag Format"
+The memory tag format is a bit array used to convey the number of tagged bits
+supported by a provider.  Additionally, it may be used to divide the bit array
+into separate fields.  The mem_tag_format optionally begins with a series of
+bits set to 0, to signify bits which are ignored by the provider.  Following
+the initial prefix of ignored bits, the array will consist of alternating
+groups of bits set to all 1's or all 0's.  Each group of bits corresponds to a
+tagged field.  The implication of defining a tagged field is that when a mask
+is applied to the tagged bit array, all bits belonging to a single field will
+either be set to 1 or 0, collectively.
+.sp
+For example, a mem_tag_format of 0x30FF indicates support for 14 tagged bits,
+separated into 3 fields.  The first field consists of 2-bits, the second
+field 4-bits, and the final field 8-bits.  Valid masks for such a tagged field
+would be a bitwise OR'ing of zero or more of the following values:
+0x3000, 0x0F00, and 0x00FF.
+.sp
+By identifying fields within a tag, a provider may be able to optimize their
+search routines.  An application which requests tag fields must provide tag
+masks that either set all mask bits corresponding to a field to all 0 or all 1.
+When negotiating tag fields, an application can request a specific number of
+fields of a given size.  A provider must return a tag format that supports
+the requested number of fields, with each field being at least the size
+requested, or fail the request.  A provider may increase the size of the
+fields.
+.sp
+It is recommended that field sizes be ordered from smallest to largest.  A
+generic, unstructured tag and mask can be achieved by requesting a bit
+array consisting of alternating 1's and 0's. 
 .SS "Message Ordering"
 Message ordering refers to the order in which transport layer headers (as
 viewed by the application) are processed.  Relaxed message order enables

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -176,7 +176,7 @@ static int psmx_getinfo(int version, const char *node, const char *service,
 						PSMX_INJECT_SIZE);
 				goto err_out;
 			}
-			max_tag_value = hints->ep_attr->max_tag_value;
+			max_tag_value = fi_tag_bits(hints->ep_attr->mem_tag_format);
 		}
 
 		ep_cap = hints->ep_cap;
@@ -198,7 +198,7 @@ static int psmx_getinfo(int version, const char *node, const char *service,
 	psmx_info->ep_attr->max_msg_size = PSMX_MAX_MSG_SIZE;
 	psmx_info->ep_attr->inject_size = PSMX_INJECT_SIZE;
 	psmx_info->ep_attr->total_buffered_recv = ~(0ULL); /* that's how PSM handles it internally! */
-	psmx_info->ep_attr->max_tag_value = max_tag_value;
+	psmx_info->ep_attr->mem_tag_format = fi_tag_format(max_tag_value);
 	psmx_info->ep_attr->msg_order = FI_ORDER_SAS;
 
 	psmx_info->domain_attr->threading = FI_THREAD_PROGRESS;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -254,6 +254,17 @@ uint32_t fi_version(void)
 	return FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION);
 }
 
+uint64_t fi_tag_bits(uint64_t mem_tag_format)
+{
+	return UINT64_MAX >> (ffsll(htonll(mem_tag_format)) -1);
+}
+
+uint64_t fi_tag_format(uint64_t tag_bits)
+{
+	return FI_TAG_GENERIC >> (ffsll(htonll(tag_bits)) - 1);
+}
+
+
 #define FI_ERRNO_OFFSET	256
 #define FI_ERRNO_MAX	FI_EOPBADSTATE
 


### PR DESCRIPTION
The maximum tag value allows a provider to indicate the largest tag
that they can support.  Rather than reporting this, use a tag format
instead.  The advantage of a tag format allows the provider and
app to exchange information on not only the size of the tag, but
the general usage of it.  If a tag is used to convey fields of data,
rather than simply individual bits, then a provider may be able
to optimize its matching algorithm.  For example, each field can
represent a separate queue, which would allow for parallel searches,
plus reduce the list of waiting tags to check.

Signed-off-by: Sean Hefty sean.hefty@intel.com
