### PR TITLE
fabric: Remove data_flow_cnt EP attribute

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -150,7 +150,6 @@ enum fi_threading {
 
 struct fi_ep_attr {
 	uint64_t		protocol;
-	int			data_flow_cnt;
 	size_t			max_msg_size;
 	size_t			inject_size;
 	size_t			total_buffered_recv;

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -101,7 +101,6 @@ struct fi_msg_atomic {
 	enum fi_op		op;
 	void			*context;
 	uint64_t		data;
-	int			flow;
 };
 
 struct fi_ops_atomic {

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -86,7 +86,6 @@ struct fi_msg {
 	fi_addr_t		addr;
 	void			*context;
 	uint64_t		data;
-	int			flow;
 };
 
 /* Endpoint option levels */

--- a/include/rdma/fi_rma.h
+++ b/include/rdma/fi_rma.h
@@ -64,7 +64,6 @@ struct fi_msg_rma {
 	size_t			rma_iov_count;
 	void			*context;
 	uint64_t		data;
-	int			flow;
 };
 
 struct fi_ops_rma {

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -53,7 +53,6 @@ struct fi_msg_tagged {
 	uint64_t		ignore;
 	void			*context;
 	uint64_t		data;
-	int			flow;
 };
 
 struct fi_ops_tagged {

--- a/man/fi_atomic.3
+++ b/man/fi_atomic.3
@@ -375,7 +375,6 @@ struct fi_msg_atomic {
 	enum fi_op          op;       /* atomic operation */
 	void                *context; /* user-defined context */
 	uint64_t            data;     /* optional data */
-	int                 flow;     /* message steering */
 };
 
 struct fi_rma_ioc {

--- a/man/fi_endpoint.3
+++ b/man/fi_endpoint.3
@@ -314,9 +314,6 @@ Defines the total available space allocated to buffer received messages
 .IP "FI_OPT_MAX_MSG_SIZE - size_t"
 Defines the maximum size for an application data transfer as a
 single operation.
-.IP "FI_OPT_DATA_FLOW - int"
-Sets the default data flow associated with an endpoint or alias.  Data
-flows are referenced by index, from 0 to the endpoint attribute data_flow_cnt.
 .IP "FI_OPT_MIN_MULTI_RECV - size_t"
 Defines the minimum receive buffer space available when the receive buffer
 is automatically freed (see FI_MULTI_RECV).

--- a/man/fi_msg.3
+++ b/man/fi_msg.3
@@ -128,7 +128,6 @@ struct fi_msg {
 	const void         *addr;   /* optional endpoint address */
 	void               *context;/* user-defined context */
 	uint64_t           data;    /* optional message data */
-	int                flow;    /* message steering */
 };
 .fi
 .SS "fi_inject"

--- a/man/fi_rma.3
+++ b/man/fi_rma.3
@@ -147,7 +147,6 @@ struct fi_msg_rma {
 	size_t             rma_iov_count;/* # elements in rma_iov */
 	void               *context;     /* user-defined context */
 	uint64_t           data;         /* optional immediate data */
-	int                flow;         /* message steering */
 };
 
 struct fi_rma_iov {

--- a/man/fi_tagged.3
+++ b/man/fi_tagged.3
@@ -167,7 +167,6 @@ struct fi_msg_tagged {
 	uint64_t           ignore;   /* mask applied to tag for receives */
 	void               *context; /* user-defined context */
 	uint64_t           data;     /* optional immediate data */
-	int                flow;     /* message steering */
 };
 .fi
 .SS "fi_tinject"

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -156,12 +156,6 @@ static int psmx_getinfo(int version, const char *node, const char *service,
 		}
 
 		if (hints->ep_attr) {
-			if (hints->ep_attr->data_flow_cnt > 1) {
-				psmx_debug("%s: hints->ep_attr->data_flow_cnt=%d,"
-						"supported=1.\n", __func__,
-						hints->ep_attr->data_flow_cnt);
-				goto err_out;
-			}
 			if (hints->ep_attr->max_msg_size > PSMX_MAX_MSG_SIZE) {
 				psmx_debug("%s: hints->ep_attr->max_msg_size=%ld,"
 						"supported=%ld.\n", __func__,
@@ -194,7 +188,6 @@ static int psmx_getinfo(int version, const char *node, const char *service,
 	}
 
 	psmx_info->ep_attr->protocol = PSMX_OUI_INTEL << FI_OUI_SHIFT | PSMX_PROTOCOL;
-	psmx_info->ep_attr->data_flow_cnt = 1;
 	psmx_info->ep_attr->max_msg_size = PSMX_MAX_MSG_SIZE;
 	psmx_info->ep_attr->inject_size = PSMX_INJECT_SIZE;
 	psmx_info->ep_attr->total_buffered_recv = ~(0ULL); /* that's how PSM handles it internally! */


### PR DESCRIPTION
There's no useful definition for data flow.  Remove it from the
API.  It can be added later if needed.

Signed-off-by: Sean Hefty sean.hefty@intel.com
