### PR TITLE
fabric: Remove fi_mr_unreg

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,7 +135,6 @@ man_MANS = \
 	man/fi_mr_reg.3 \
 	man/fi_mr_regv.3 \
 	man/fi_mr_regattr.3 \
-	man/fi_mr_unreg.3 \
 	man/fi_mr_desc.3 \
 	man/fi_mr_key.3 \
 	man/fi_mr_bind.3 \

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -202,11 +202,6 @@ static inline uint64_t fi_mr_key(struct fid_mr *mr)
 	return mr->key;
 }
 
-static inline int fi_mr_unreg(struct fid_mr *mr)
-{
-	return fi_close(&mr->fid);
-}
-
 static inline int
 fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	   struct fid_av **av, void *context)

--- a/man/fi_mr.3
+++ b/man/fi_mr.3
@@ -7,7 +7,7 @@ fi_mr_reg / fi_mr_regv / fi_mr_regattr
 Register local memory buffers for direct fabric access
 .RE
 .PP
-fi_mr_unreg
+fi_close
 .RS
 Deregister registered memory buffers.
 .RE
@@ -44,7 +44,7 @@ Associate a registered memory region with an event collector.
 .BI "uint64_t " flags ", struct fid_mr **" mr ");"
 .PP
 .HP
-.BI "int fi_mr_unreg(struct fid_mr *" mr ");"
+.BI "int fi_close(struct fid *" mr ");"
 .PP
 .HP
 .BI "void * fi_mr_desc(struct fid_mr *" mr ");"
@@ -196,14 +196,14 @@ struct fi_mr_attr {
 	void               *context;      /* user-defined context */
 };
 .fi
-.SS "fi_mr_unreg"
-The fi_mr_unreg call is used to release all resources associated with a
+.SS "fi_close"
+Fi_close may be used to release all resources associated with a
 registering a memory region.  Once unregistered, further access to the
 registered memory is not guaranteed.  For performance reasons,
 unregistration processing may be done asynchronously or lazily.  To force
 all queued unregistration requests to complete, applications may call
-fi_domain_sync.  Upon completion of an fi_domain_sync call, all memory
-regions unregistered before fi_domain_sync was invoked will have completed,
+fi_sync on the domain.  Upon completion of a domain fi_sync call, all memory
+regions unregistered before fi_sync was invoked will have completed,
 and no further access to the registered region, either locally or remotely,
 via fabric resources will be possible. 
 .SS "fi_mr_desc / fi_mr_key"

--- a/man/fi_mr_unreg.3
+++ b/man/fi_mr_unreg.3
@@ -1,1 +1,0 @@
-.so man3/fi_mr.3


### PR DESCRIPTION
Use standard fi_close call directly.

Signed-off-by: Sean Hefty sean.hefty@intel.com
