### PR TITLE
fabric: Eliminate unnecessary endpoint options

### DIFF
--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -95,10 +95,6 @@ enum {
 
 /* FI_OPT_ENDPOINT option names */
 enum {
-	FI_OPT_MAX_INJECTED_SEND,	/* size_t */
-	FI_OPT_TOTAL_BUFFERED_RECV,	/* size_t */
-	FI_OPT_MAX_MSG_SIZE,		/* size_t */
-	FI_OPT_DATA_FLOW,		/* int */
 	FI_OPT_MIN_MULTI_RECV,		/* size_t */
 };
 

--- a/man/fi_endpoint.3
+++ b/man/fi_endpoint.3
@@ -304,16 +304,6 @@ endpoint.
 The following option levels and option names and parameters are defined.
 .IP "FI_OPT_ENDPOINT"
 .RS
-.IP "FI_OPT_MAX_INJECTED_SEND - size_t"
-Defines the maximum buffered send operation (see the FI_INJECT
-flag) that the endpoint currently supports.  This value applies per send
-operation.
-.IP "FI_OPT_TOTAL_BUFFERED_RECV - size_t"
-Defines the total available space allocated to buffer received messages
-(see the FI_BUFFERED_RECV flag) that the endpoint currently supports.
-.IP "FI_OPT_MAX_MSG_SIZE - size_t"
-Defines the maximum size for an application data transfer as a
-single operation.
 .IP "FI_OPT_MIN_MULTI_RECV - size_t"
 Defines the minimum receive buffer space available when the receive buffer
 is automatically freed (see FI_MULTI_RECV).
@@ -325,7 +315,6 @@ endpoint.
 .nf
 struct fi_ep_attr {
 	uint64_t  protocol;
-	int       data_flow_cnt;
 	size_t    max_msg_size;
 	size_t    inject_size;
 	size_t    total_buffered_recv;
@@ -354,14 +343,6 @@ The protocol runs over the Internet wide area RDMA protocol transport.
 The protocol runs over Infiniband unreliable-connected queue pairs.
 .IP "FI_PROTO_IB_UD"
 The protocol runs over Infiniband unreliable datagram queue pairs.
-.SS "Data Flow Count"
-Specifies the number of independent data flows to associate with the endpoint.
-A data flow conceptually represents independent hardware queues or paths
-through the fabric.  Data flows may be mapped to different command queues
-or fabric quality of service levels.  Data transfers may be associated with
-a specific data flow as part of the operation.  If a data flow is not
-specified, a data transfers will use the default flow associated with an
-endpoint.  
 .SS "Max Message Size"
 Defines the maximum size for an application data transfer as a
 single operation.

--- a/prov/ibverbs/src/fi_verbs.c
+++ b/prov/ibverbs/src/fi_verbs.c
@@ -351,8 +351,7 @@ static int ibv_msg_ep_create_qp(struct ibv_msg_ep *ep)
 	attr.cap.max_recv_wr = atoi(def_recv_wr);
 	attr.cap.max_send_sge = atoi(def_send_sge);
 	attr.cap.max_recv_sge = atoi(def_recv_sge);
-	if (!ep->inline_size)
-		ep->inline_size = atoi(def_inline_data);
+	ep->inline_size = atoi(def_inline_data);
 	attr.cap.max_inline_data = ep->inline_size;
 	attr.qp_context = ep;
 	attr.send_cq = ep->scq->cq;
@@ -1484,18 +1483,7 @@ ibv_msg_ep_getopt(fid_t fid, int level, int optname,
 
 	switch (level) {
 	case FI_OPT_ENDPOINT:
-		switch (optname) {
-		case FI_OPT_MAX_INJECTED_SEND:
-			if (*optlen < sizeof(size_t)) {
-				*optlen = sizeof(size_t);
-				return -FI_ETOOSMALL;
-			}
-			*((size_t *) optval) = (size_t) ep->inline_size;
-			*optlen = sizeof(size_t);
-			break;
-		default:
-			return -FI_ENOPROTOOPT;
-		}
+		return -FI_ENOPROTOOPT;
 	default:
 		return -FI_ENOPROTOOPT;
 	}
@@ -1511,17 +1499,7 @@ ibv_msg_ep_setopt(fid_t fid, int level, int optname,
 
 	switch (level) {
 	case FI_OPT_ENDPOINT:
-		switch (optname) {
-		case FI_OPT_MAX_INJECTED_SEND:
-			if (optlen != sizeof(size_t))
-				return -FI_EINVAL;
-			if (ep->id->qp)
-				return -FI_EOPBADSTATE;
-			ep->inline_size = (uint32_t) *(size_t *) optval;
-			break;
-		default:
-			return -FI_ENOPROTOOPT;
-		}
+		return -FI_ENOPROTOOPT;
 	default:
 		return -FI_ENOPROTOOPT;
 	}

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -57,8 +57,6 @@ static int psmx_ep_getopt(fid_t fid, int level, int optname,
 			void *optval, size_t *optlen)
 {
 	struct psmx_fid_ep *fid_ep;
-	uint32_t size;
-	int err;
 
 	fid_ep = container_of(fid, struct psmx_fid_ep, ep.fid);
 
@@ -66,52 +64,6 @@ static int psmx_ep_getopt(fid_t fid, int level, int optname,
 		return -ENOPROTOOPT;
 
 	switch (optname) {
-	case FI_OPT_MAX_INJECTED_SEND:
-		if (!optval)
-			return 0;
-
-		if (!optlen || *optlen < sizeof(size_t))
-			return -EINVAL;
-
-		if (!fid_ep->domain)
-			return -EBADF;
-
-		*(size_t *)optval = PSMX_INJECT_SIZE;
-		*optlen = sizeof(size_t);
-		break;
-
-	case FI_OPT_MAX_MSG_SIZE:
-		if (!optval)
-			return 0;
-
-		if (!optlen || *optlen < sizeof(size_t))
-			return -EINVAL;
-
-		if (!fid_ep->domain)
-			return -EBADF;
-
-		*(size_t *)optval = PSMX_MAX_MSG_SIZE;
-		*optlen = sizeof(size_t);
-		break;
-
-	case FI_OPT_TOTAL_BUFFERED_RECV:
-		if (!optval)
-			return 0;
-
-		if (!optlen || *optlen < sizeof(size_t))
-			return -EINVAL;
-
-		if (!fid_ep->domain)
-			return -EBADF;
-
-		err = psm_mq_getopt(fid_ep->domain->psm_mq, PSM_MQ_MAX_SYSBUF_MBYTES, &size);
-		if (err)
-			return psmx_errno(err);
-
-		*(size_t *)optval = size * 1048576;
-		*optlen = sizeof(size_t);
-		break;
-
 	case FI_OPT_MIN_MULTI_RECV:
 		*(size_t *)optval = fid_ep->min_multi_recv;
 		*optlen = sizeof(size_t);


### PR DESCRIPTION
Now that we have an endpoint attribute structure, it can be used
to configure portions of an endpoint.  Remove duplication endpoint
options used with getopt/setopt.

Cleanup the man pages to eliminate left-over data flow documentation.

Signed-off-by: Sean Hefty sean.hefty@intel.com
