### PR TITLE
Enable modular building of selected providers, disabled by default.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,10 +2,14 @@ AM_CPPFLAGS = -I$(srcdir)/include
 
 lib_LTLIBRARIES = src/libfabric.la
 
+pkglib_LTLIBRARIES =
+
 ACLOCAL_AMFLAGS = -I config
 AM_CFLAGS = -g -Wall -D_GNU_SOURCE 
 
-src_libfabric_la_CFLAGS = $(AM_CFLAGS) -DSYSCONFDIR=\"$(sysconfdir)\" -DRDMADIR=\"@rdmadir@\"
+src_libfabric_la_CFLAGS = $(AM_CFLAGS) -DSYSCONFDIR=\"$(sysconfdir)\" \
+				       -DRDMADIR=\"@rdmadir@\" \
+				       -DEXTDIR=\"$(libdir)/libfabric\"
 
 if HAVE_LD_VERSION_SCRIPT
     libfabric_version_script = -Wl,--version-script=$(srcdir)/libfabric.map
@@ -15,6 +19,10 @@ endif
 
 src_libfabric_la_SOURCES = \
 	src/fabric.c \
+	src/common.c
+
+if HAVE_SOCKETS
+_sockets_files = \
 	prov/sockets/src/sock_av.c \
 	prov/sockets/src/sock_dom.c \
 	prov/sockets/src/sock_eq.c \
@@ -23,12 +31,31 @@ src_libfabric_la_SOURCES = \
 	prov/sockets/src/sock.c \
 	prov/sockets/src/indexer.c
 
-if HAVE_VERBS
-src_libfabric_la_SOURCES += prov/verbs/src/fi_verbs.c
+if HAVE_SOCKETS_DL
+pkglib_LTLIBRARIES += libsockets-fi.la
+libsockets_fi_la_SOURCES = $(_sockets_files) src/common.c
+libsockets_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+else
+src_libfabric_la_SOURCES += $(_sockets_files)
 endif
 
+endif #HAVE_SOCKETS
+
+if HAVE_VERBS
+_verbs_files = prov/verbs/src/fi_verbs.c
+
+if HAVE_VERBS_DL
+pkglib_LTLIBRARIES += libibverbs-fi.la
+libibverbs_fi_la_SOURCES = $(_verbs_files) src/common.c
+libibverbs_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic -libverbs -lrdmacm
+else
+src_libfabric_la_SOURCES += $(_verbs_files)
+endif
+
+endif #HAVE_VERBS
+
 if HAVE_PSM
-src_libfabric_la_SOURCES += \
+_psm_files = \
 	prov/psm/src/psmx_init.c \
 	prov/psm/src/psmx_domain.c \
 	prov/psm/src/psmx_cq.c \
@@ -44,7 +71,16 @@ src_libfabric_la_SOURCES += \
 	prov/psm/src/psmx_am.c \
 	prov/psm/src/psmx_mr.c \
 	prov/psm/src/psmx_util.c
+
+if HAVE_PSM_DL
+pkglib_LTLIBRARIES += libpsmx-fi.la
+libpsmx_fi_la_SOURCES = $(_psm_files) src/common.c
+libpsmx_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic -libverbs -lrdmacm
+else
+src_libfabric_la_SOURCES += $(_psm_files)
 endif
+
+endif #HAVE_PSM
 
 src_libfabric_la_LDFLAGS = -version-info 1 -export-dynamic \
 			   $(libfabric_version_script)

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)
-AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects])
+AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects parallel-tests])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_ARG_ENABLE([debug],
@@ -24,7 +24,7 @@ AS_IF([test -z "$CFLAGS"],
 # <3), but it is necessary in AM 1.12.x.
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 
-AM_PROG_LIBTOOL
+LT_INIT([dlopen])
 
 AC_ARG_WITH([valgrind],
     AC_HELP_STRING([--with-valgrind],
@@ -57,6 +57,7 @@ AC_CHECK_DECLS([O_CLOEXEC],,[AC_DEFINE([O_CLOEXEC],[0],
 		#include <fcntl.h>
 		#endif
 	]])
+
 AC_CHECK_DECLS([SOCK_CLOEXEC],,[AC_DEFINE([SOCK_CLOEXEC],[0],
 	[Defined to 0 if not provided])],
 	[[
@@ -110,6 +111,28 @@ AC_CACHE_CHECK(whether ld accepts --version-script, ac_cv_version_script,
 
 AM_CONDITIONAL(HAVE_LD_VERSION_SCRIPT, test "$ac_cv_version_script" = "yes")
 
+AC_ARG_ENABLE([sockets],
+	      [AS_HELP_STRING([--enable-sockets],
+			      [Enable sockets provider @<:@default=yes@:>@])
+	      ],
+	      [],
+	      [enable_sockets=yes])
+
+AS_IF([test x"$enable_sockets" = x"dl"], [sockets_dl=yes; enable_sockets=yes])
+
+AS_IF([test x"$enable_sockets" = x"yes"],
+	[AC_DEFINE([HAVE_SOCKETS], [1],
+		[Define if sockets provider is enabled])
+	],
+	[AC_MSG_NOTICE(Sockets provider not enabled)])
+
+AM_CONDITIONAL([HAVE_SOCKETS], [test x"$enable_sockets" = x"yes"])
+
+AS_IF([test x"$sockets_dl" = x"yes"],
+      [AC_DEFINE([HAVE_SOCKETS_DL], [1], [Build sockets provider as module])])
+
+AM_CONDITIONAL([HAVE_SOCKETS_DL], [test x"$sockets_dl" = x"yes"])
+
 AC_ARG_ENABLE([verbs],
 	      [AS_HELP_STRING([--enable-verbs],
 			      [Enable verbs provider @<:@default=auto@:>@])
@@ -118,36 +141,35 @@ AC_ARG_ENABLE([verbs],
 	      [enable_verbs=auto])
 
 AS_CASE([$enable_verbs],
-	[auto], [AC_CHECK_LIB(rdmacm, rsocket,
-			[AC_CHECK_LIB(ibverbs, ibv_open_device,
+	[auto], [verbs_fail=no],
+	[yes],  [verbs_fail=yes],
+	[dl],   [verbs_dl=yes; enable_verbs=yes],
+	[no],   [],
+	[])
+
+AS_IF([test x"$enable_verbs" != x"no"],
+	[AC_CHECK_LIB(ibverbs, ibv_open_device,
+			[AC_CHECK_LIB(rdmacm, rsocket,
 				[enable_verbs=yes],
 				[enable_verbs=no])
 			],
 			[enable_verbs=no])
-		],
-	[yes],  [AC_CHECK_LIB(rdmacm, rsocket,
-			[AC_CHECK_LIB(ibverbs, ibv_open_device, [],
-				[AC_MSG_ERROR(libfabric requires libibverbs)])
-			],
-			[AC_MSG_ERROR(libfabric requires librdmacm 1.0.16 or greater)])
-		],
-	[no],   [],
-	[])
-
-AS_IF([test x"$enable_verbs" = x"yes"],
-	[AC_DEFINE([HAVE_VERBS], [1],
-		[Define if verbs provider is enabled])
 	],
 	[AC_MSG_NOTICE(Verbs provider not enabled)])
 
-if test x"$enable_verbs" = x"yes"; then
-	AC_CHECK_LIB(rdmacm, rsocket, [],
-		[AC_MSG_ERROR(libfabric requires librdmacm 1.0.16 or greater)])
-	AC_CHECK_LIB(ibverbs, ibv_open_device, [],
-		[AC_MSG_ERROR(libfabric requires libibverbs)])
-fi
+AS_IF([test x"$enable_verbs $verbs_fail" = x"no yes"],
+	[AC_MSG_ERROR(libfabric requires libibverbs, librdmacm 1.0.16 or greater)])
+
+AS_IF([test x"$enable_verbs" = x"yes"],
+	[AC_DEFINE([HAVE_VERBS], [1], [Define if verbs provider is enabled])
+         LIBS=" -libverbs -lrdmacm $LIBS"
+	])
+
+AS_IF([test x"$verbs_dl" = x"yes"],
+	[AC_DEFINE([HAVE_VERBS_DL], [1], [Define if verbs should be built as module])])
 
 AM_CONDITIONAL([HAVE_VERBS], [test x"$enable_verbs" = x"yes"])
+AM_CONDITIONAL([HAVE_VERBS_DL], [test x"$verbs_dl" = x"yes"])
 
 AC_ARG_ENABLE([psm],
 	      [AS_HELP_STRING([--enable-psm],
@@ -198,8 +220,14 @@ AS_CASE([$enable_psm],
 			],
 			[AC_MSG_ERROR([psm_init() not found. Provide the correct path to PSM --with-psm-lib])])
 		],
+	[dl],	[enable_psm=yes; psm_dl=yes],
 	[no],	[],
 	[])
+
+
+AS_IF([test x"$psm_dl" = x"yes"],
+	[AC_DEFINE([HAVE_PSM_DL], [1], [Define if PSM will be built as module])])
+
 
 AS_IF([test x"$enable_psm" = x"yes"],
 	[AC_DEFINE([HAVE_PSM], [1], [Define if PSM is enabled])
@@ -208,6 +236,7 @@ AS_IF([test x"$enable_psm" = x"yes"],
 	[AC_MSG_NOTICE(PSM not enabled)])
 
 AM_CONDITIONAL([HAVE_PSM], [test x"$enable_psm" = x"yes"])
+AM_CONDITIONAL([HAVE_PSM_DL], [test x"$psm_dl" = x"yes"])
 
 AC_ARG_ENABLE([direct],
 	[AS_HELP_STRING([--enable-direct=@<:@provider@:>@],

--- a/include/fi.h
+++ b/include/fi.h
@@ -132,10 +132,12 @@ typedef struct { volatile int val; } atomic_t;
 #define atomic_dec(v) (__sync_sub_and_fetch(&(v)->val, 1))
 #define atomic_init(v) ((v)->val = 0)
 #endif /* DEFINE_ATOMICS */
+
 #define atomic_get(v) ((v)->val)
 #define atomic_set(v, s) ((v)->val = s)
 
-int  fi_init(void);
+/* non exported symbols */
+int fi_init(void);
 
 int fi_read_file(const char *dir, const char *file, char *buf, size_t size);
 int fi_poll_fd(int fd, int timeout);
@@ -149,12 +151,18 @@ size_t fi_datatype_size(enum fi_datatype datatype);
 uint64_t fi_tag_bits(uint64_t mem_tag_format);
 uint64_t fi_tag_format(uint64_t tag_bits);
 
+int fi_version_register(uint32_t version, struct fi_provider *provider);
+
 #ifndef SYSCONFDIR
 #define SYSCONFDIR "/etc"
 #endif
 #ifndef RDMADIR
 #define RDMADIR "rdma"
 #endif
+#ifndef EXTDIR
+#define EXTDIR "/usr/lib/libfabric"
+#endif
+
 #define RDMA_CONF_DIR  SYSCONFDIR "/" RDMADIR
 #define FI_CONF_DIR RDMA_CONF_DIR "/fabric"
 

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -47,7 +47,10 @@ extern "C" {
  * (probably via libtool "-release" option).  For example a low-level
  * driver named "libfoo" should build a plug-in named "libfoo-fi.so".
  */
-#define FI_LIB_EXTENSION fi
+#define FI_LIB_EXTENSION "fi"
+#define FI_LIB_SUFFIX FI_LIB_EXTENSION ".so"
+
+#define FI_LIB_CLASS_NAME	"libfabric"
 
 struct fi_provider {
 	const char *name;
@@ -65,7 +68,6 @@ static inline int fi_register(struct fi_provider *provider)
 	return fi_version_register(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
 				   provider);
 }
-
 
 #ifdef __cplusplus
 }

--- a/libfabric.map
+++ b/libfabric.map
@@ -5,5 +5,6 @@ FABRIC_1.0 {
 		fi_fabric;
 		fi_version;
 		fi_strerror;
+		fi_version_register;
 	local: *;
 };

--- a/src/common.c
+++ b/src/common.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2004, 2005 Topspin Communications.  All rights reserved.
+ * Copyright (c) 2006 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013 Intel Corp., Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <poll.h>
+#include <pthread.h>
+
+#include <rdma/fi_errno.h>
+#include "fi.h"
+
+int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout)
+{
+	struct timespec ts;
+
+	if (timeout < 0)
+		return pthread_cond_wait(cond, mut);
+
+	clock_gettime(CLOCK_REALTIME, &ts);
+	ts.tv_sec += timeout / 1000;
+	ts.tv_nsec += (timeout % 1000) * 1000000;
+	return pthread_cond_timedwait(cond, mut, &ts);
+}
+
+int fi_read_file(const char *dir, const char *file, char *buf, size_t size)
+{
+	char *path;
+	int fd, len;
+
+	if (asprintf(&path, "%s/%s", dir, file) < 0)
+		return -1;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		free(path);
+		return -1;
+	}
+
+	len = read(fd, buf, size);
+	close(fd);
+	free(path);
+
+	if (len > 0 && buf[len - 1] == '\n')
+		buf[--len] = '\0';
+
+	return len;
+}
+
+int fi_poll_fd(int fd, int timeout)
+{
+	struct pollfd fds;
+
+	fds.fd = fd;
+	fds.events = POLLIN;
+	return poll(&fds, 1, timeout) < 0 ? -errno : 0;
+}
+
+struct fi_info *__fi_allocinfo(void)
+{
+	struct fi_info *info;
+
+	info = calloc(1, sizeof(*info));
+	if (!info)
+		return NULL;
+
+	info->ep_attr = calloc(1, sizeof(*info->ep_attr));
+	info->domain_attr = calloc(1, sizeof(*info->domain_attr));
+	info->fabric_attr = calloc(1, sizeof(*info->fabric_attr));
+	if (!info->ep_attr || !info->domain_attr || !info->fabric_attr)
+		goto err;
+
+	return info;
+err:
+	__fi_freeinfo(info);
+	return NULL;
+}
+
+void __fi_freeinfo(struct fi_info *info)
+{
+	free(info->src_addr);
+	free(info->dest_addr);
+	free(info->ep_attr);
+	if (info->domain_attr) {
+		free(info->domain_attr->name);
+		free(info->domain_attr);
+	}
+	if (info->fabric_attr) {
+		free(info->fabric_attr->name);
+		free(info->fabric_attr->prov_name);
+		free(info->fabric_attr);
+	}
+	free(info->data);
+	free(info);
+}
+
+uint64_t fi_tag_bits(uint64_t mem_tag_format)
+{
+	return UINT64_MAX >> (ffsll(htonll(mem_tag_format)) -1);
+}
+
+uint64_t fi_tag_format(uint64_t tag_bits)
+{
+	return FI_TAG_GENERIC >> (ffsll(htonll(tag_bits)) - 1);
+}
+


### PR DESCRIPTION
0, 1, 2, or 3 (all) providers can be built as loadable.
Any combination of loadable/built-in/not built should work, ie:

$ # build into libfabric.so: psm, sockets
$ # dlopen: libibverbs-fi.so, $libdir/libfabric/*fi.so
$ ./configure –enable-verbs=dl

$ # build libfabric.so: nothing
$ # dlopen: lib{sockets,psm,ibverbs}-fi.so, $libdir/libfabric/*fi.so
$ ./configure –enable-verbs=dl --enable-sockets=dl --enable-psm=dl

$ # everything built in as normal
$ # dlopen: $libdir/libfabric/*fi.so, if exists
$ ./configure
