### PR TITLE
include: naming convention for 'direct' files

### DIFF
--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -417,7 +417,7 @@ fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout)
 
 
 #else // FABRIC_DIRECT
-#include <rdma/fi_eq_domain.h>
+#include <rdma/fi_direct_eq_domain.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
In direct mode, include 'fi_direct_eq_domain.h'

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
