### PR TITLE
include: direct_eq.h not direct_eq_domain.h

### DIFF
--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -417,7 +417,7 @@ fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout)
 
 
 #else // FABRIC_DIRECT
-#include <rdma/fi_direct_eq_domain.h>
+#include <rdma/fi_direct_eq.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Sorry, didn't get the file name quite right in the last pull request.

The direct file name for fi_eq.h should be fi_direct_eq.h,
not fi_direct_eq_domain.h

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
