### PR TITLE
verbs: rename "ibverbs" provider to be "verbs"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ src_libfabric_la_SOURCES = \
 	prov/sockets/src/indexer.c
 
 if HAVE_VERBS
-src_libfabric_la_SOURCES += prov/ibverbs/src/fi_verbs.c
+src_libfabric_la_SOURCES += prov/verbs/src/fi_verbs.c
 endif
 
 if HAVE_PSM

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -2433,7 +2433,7 @@ int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void 
 }
 
 static struct fi_provider fi_ibv_prov = {
-	.name = "ibverbs",
+	.name = "verbs",
 	.version = FI_VERSION(0, 7),
 	.getinfo = fi_ibv_getinfo,
 	.freeinfo = fi_ibv_freeinfo,


### PR DESCRIPTION
Pretty simple change, actually.

Merging this will fix #120.
