### PR TITLE
prov/psm: fix the configuration script

### DIFF
--- a/prov/psm/configure.m4
+++ b/prov/psm/configure.m4
@@ -4,7 +4,7 @@ dnl Called to configure this provider
 AC_DEFUN([FI_PSM_CONFIGURE],[
 	AC_MSG_NOTICE([*** Configuring PSM provider])
 	AC_ARG_ENABLE([psm],
-	      [AS_HELP_STRING([--enable-psm],
+	      [AS_HELP_STRING([--enable-psm[[=yes|no|auto|DIR]]],
 			      [Enable PSM provider @<:@default=auto@:>@])
 	      ],
 	      [],
@@ -38,13 +38,14 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 	psm_happy=0
 	AS_IF([test "x$enable_psm" != "xno"],
 	      [psm_happy=1
+	       enable_psm=1
 	       AC_CHECK_HEADER([psm.h], [], [psm_happy=0])
-	       AC_CHECK_LIB([psm_infinipath], [psm_init], [], [psm_happy=0])
-	       ])
+	       AC_CHECK_LIB([psm_infinipath], [psm_init], [], [psm_happy=0])],
+	      [enable_psm=0])
 
 	# If psm was specifically requested but we can't build it,
 	# error.
-	AS_IF([test "$enable_psm $psm_happy" = "yes 0"],
+	AS_IF([test "$enable_psm $psm_happy" = "1 0"],
 	      [AC_MSG_WARN([psm provider was requested, but cannot be compiled])
 	       AC_MSG_ERROR([Cannot continue])
 	      ])
@@ -56,6 +57,9 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 	      ],
 	      [AC_MSG_NOTICE([psm provider disabled])])
 
+        AC_DEFINE_UNQUOTED([HAVE_PSM], [$enable_psm],
+		[Whether psm should be built])
+
 	AC_DEFINE_UNQUOTED([HAVE_PSM_DL], [$psm_dl],
 		[Whether psm should be built as as DSO])
 ])
@@ -63,6 +67,6 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 dnl A separate macro for AM CONDITIONALS, since they cannot be invoked
 dnl conditionally
 AC_DEFUN([FI_PSM_CONDITIONALS],[
-	AM_CONDITIONAL([HAVE_PSM], [test x"$enable_psm" = x"yes"])
-	AM_CONDITIONAL([HAVE_PSM_DL], [test x"$psm_dl" = x"yes"])
+	AM_CONDITIONAL([HAVE_PSM], [test $enable_psm -eq 1])
+	AM_CONDITIONAL([HAVE_PSM_DL], [test $psm_dl -eq 1])
 ])


### PR DESCRIPTION
There was a compiler warning for psmx_init.c because HAVE_PSM was undefined.
