### PR TITLE
Copy prov_name and prov_version when allocating new fi_info for incoming...

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -1630,6 +1630,10 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 
 	if (!(fi->fabric_attr->name = strdup("RDMA")))
 		goto err;
+	if (!(fi->fabric_attr->prov_name = strdup("verbs")))
+		goto err;
+	fi->fabric_attr->prov_version = FI_VERSION(0, 7);
+
 	if (!(fi->domain_attr->name = strdup(event->id->verbs->device->name)))
 		goto err;
 
@@ -1637,7 +1641,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 	fi->data = event->id;
 	return fi;
 err:
-	fi_freeinfo(fi);
+	__fi_freeinfo(fi);
 	return NULL;
 }
 


### PR DESCRIPTION
... connections. Use __fi_freeinfo() to prevent accessing fi->fabric_attr->prov_name when it is not set.

Signed-off-by: Arun C Ilango arun.ilango@intel.com
