### PR TITLE
include: const correct parameter types

### DIFF
--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -319,7 +319,7 @@ fi_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
 }
 
 static inline ssize_t
-fi_eq_write(struct fid_eq *eq, enum fi_eq_event event, void *buf,
+fi_eq_write(struct fid_eq *eq, enum fi_eq_event event, const void *buf,
 	    size_t len, uint64_t flags)
 {
 	return eq->ops->write(eq, event, buf, len, flags);
@@ -358,13 +358,13 @@ fi_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, size_t len,
 	return cq->ops->readerr(cq, buf, len, flags);
 }
 
-static inline ssize_t fi_cq_write(struct fid_cq *cq, void *buf, size_t len)
+static inline ssize_t fi_cq_write(struct fid_cq *cq, const void *buf, size_t len)
 {
 	return cq->ops->write(cq, buf, len);
 }
 
 static inline ssize_t
-fi_cq_sread(struct fid_cq *cq, void *buf, size_t len, void *cond, int timeout)
+fi_cq_sread(struct fid_cq *cq, void *buf, size_t len, const void *cond, int timeout)
 {
 	return cq->ops->sread(cq, buf, len, cond, timeout);
 }
@@ -377,7 +377,7 @@ fi_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t len,
 }
 
 static inline const char *
-fi_cq_strerror(struct fid_cq *cq, int prov_errno, void *err_data,
+fi_cq_strerror(struct fid_cq *cq, int prov_errno, const void *err_data,
 	       void *buf, size_t len)
 {
 	return cq->ops->strerror(cq, prov_errno, err_data, buf, len);


### PR DESCRIPTION
The function signatures differed from the ones in the EQ/CQ
object and static inlines.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
