### PR TITLE
verbs getinfo returns fatal errors

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -267,7 +267,7 @@ fi_ibv_getepinfo(const char *node, const char *service,
 		return -errno;
 
 	if (!(fi = __fi_allocinfo())) {
-		ret = FI_ENOMEM;
+		ret = -FI_ENOMEM;
 		goto err1;
 	}
 
@@ -277,7 +277,7 @@ fi_ibv_getepinfo(const char *node, const char *service,
 
 	ret = rdma_create_ep(id, rai, NULL, NULL);
 	if (ret) {
-		ret = -errno;
+		ret = -FI_ENODATA;
 		goto err2;
 	}
 	rdma_freeaddrinfo(rai);


### PR DESCRIPTION
Not all verbs providers provide RDMA (ours doesn't) so rdma_create_ep()
can fail, but should not cause fatal error to fi_getinfo, it should just
exclude the provider.  really, this check should only be made if RDMA is
requested, but thats another issue.

Signed-off-by: Reese Faucette rfaucett@cisco.com
