### PR TITLE
Add ability to specify message prefix on posted buffers

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -106,6 +106,9 @@ uint32_t fi_version(void);
 #define FI_PEEK			(1ULL << 30)
 #define FI_TRIGGER		(1ULL << 31)
 
+#define FI_SEND_PREFIX	(1ULL << 32)
+#define FI_RECV_PREFIX	(1ULL << 33)
+
 
 struct fi_ioc {
 	void			*addr;
@@ -181,6 +184,7 @@ struct fi_ep_attr {
 	uint64_t		msg_order;
 	size_t			tx_ctx_cnt;
 	size_t			rx_ctx_cnt;
+	size_t			msg_prefix_len;
 };
 
 struct fi_domain_attr {

--- a/man/fi_endpoint.3
+++ b/man/fi_endpoint.3
@@ -334,6 +334,7 @@ struct fi_ep_attr {
 	uint64_t  msg_order;
 	size_t    tx_ctx_cnt;
 	size_t    rx_ctx_cnt;
+	size_t    msg_prefix_len;
 };
 .fi
 .SS "Protocol"
@@ -501,6 +502,13 @@ configured.  Each receive context may be bound to a separate CQ, and no
 ordering is defined between contexts.  Additionally, no synchronization is
 needed when accessing contexts in parallel.  See the scalable endpoint
 section for additional details.
+.SS "msg_prefix_len - Message Prefix Length"
+This is an output value.  If FI_RECV_PREFIX or FI_SEND_PREFIX endpoint 
+attributes are supported by the fabric, this is the number of bytes that
+the provider will expect to available at the beginning of posted buffers
+for provider use. This value will always be a multiple of 8 bytes.
+See FI_RECV_PREFIX and FI_SEND_PREFIX in fi_getinfo(3)
+for more details.
 .SH "SCALABLE ENDPOINTS"
 A scalable endpoint is a communication portal that supports multiple
 transmit and receive contexts.  Scalable endpoints are loosely modeled

--- a/man/fi_getinfo.3
+++ b/man/fi_getinfo.3
@@ -294,6 +294,24 @@ appropriately.
 Indicates that the user desires the ability to cancel outstanding data
 transfer operations.  If FI_CANCEL is not set, a provider may optimize code
 paths with the assumption that fi_cancel will not be used by the application.
+.IP "FI_RECV_PREFIX"
+The provider supports a mode where packet header bytes are written into
+buffers posted for receive (e.g. via fi_recv()) ahead
+of the received data.  This is primarily
+a performance optimization for the provider, though some applications may use
+this to get access to the packet header information.  The number of bytes
+which must be reserved is specified by msg_prefix_len in endpoint attributes.
+When the user buffer address is requested to be present in CQ completion
+entries, a pointer to the actual start of the data will be returned, not the
+posted buffer address.
+.IP "FI_SEND_PREFIX"
+This is similar to FI_RECV_PREFIX, except that it applies to send functions.
+When an endpoint is opened with this flag, the provider is free to use the
+memory immediately preceeding the posted send address for its own purposes.
+If used, this is typically to build the packet header in this prefix area,
+collapsing the send to a single SGE without copying the user data to be sent.
+The number of bytes which must be reserved is specified by msg_prefix_len in
+endpoint attributes.
 .SH "DOMAIN CAPABILITIES"
 Domain capabilities are often used as output information from fi_getinfo,
 allowing applications to adjust their behavior based on the provider's


### PR DESCRIPTION
This is a proposed patch for #127 .  The PREFIX flags need to be part of
ep_cap (possibly renamed to ep_options or split into ep_cap + ep_attr::ep_flags,
TBD as part of larger rework of ep_cap).

The prefix size, msg_prefix_len, needs to be an ep_attr because its
value will depend on the transport protocol, which is in ep_attr.  i.e.
40 for IB, 48 for UDP.

Signed-off-by: Reese Faucette rfaucett@cisco.com
