### PR TITLE
prov/verbs: Return -FI_ENOMEM if fi_allocinfo fails

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -267,7 +267,7 @@ fi_ibv_getepinfo(const char *node, const char *service,
 		return -errno;
 
 	if (!(fi = __fi_allocinfo())) {
-		ret = FI_ENOMEM;
+		ret = -FI_ENOMEM;
 		goto err1;
 	}
 


### PR DESCRIPTION
Return a negative value, rather than positive value from
fi_ibv_getpeinfo.

Problem reported by: Reese Faucette rfaucett@cisco.com

Signed-off-by: Sean Hefty sean.hefty@intel.com
