### PR TITLE
compiler: do not use symbols with beginning with __

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -147,8 +147,8 @@ int fi_read_file(const char *dir, const char *file, char *buf, size_t size);
 int fi_poll_fd(int fd, int timeout);
 int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout);
 
-struct fi_info *__fi_allocinfo(void);
-void __fi_freeinfo(struct fi_info *info);
+struct fi_info *fi_allocinfo_internal(void);
+void fi_freeinfo_internal(struct fi_info *info);
 
 int fi_sockaddr_len(struct sockaddr *addr);
 size_t fi_datatype_size(enum fi_datatype datatype);

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -192,7 +192,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	if (psmx_reserve_tag_bits(&caps, &max_tag_value) < 0)
 		goto err_out;
 
-	psmx_info = __fi_allocinfo();
+	psmx_info = fi_allocinfo_internal();
 	if (!psmx_info) {
 		err = -ENOMEM;
 		goto err_out;

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -263,7 +263,7 @@ fi_ibv_getepinfo(const char *node, const char *service,
 	if (ret)
 		return -errno;
 
-	if (!(fi = __fi_allocinfo())) {
+	if (!(fi = fi_allocinfo_internal())) {
 		ret = -FI_ENOMEM;
 		goto err1;
 	}
@@ -298,7 +298,7 @@ fi_ibv_getepinfo(const char *node, const char *service,
 err3:
 	rdma_destroy_ep(*id);
 err2:
-	__fi_freeinfo(fi);
+	fi_freeinfo_internal(fi);
 err1:
 	rdma_freeaddrinfo(rai);
 	return ret;
@@ -1453,7 +1453,7 @@ fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		if (ret)
 			goto err;
 
-		__fi_freeinfo(fi);
+		fi_freeinfo_internal(fi);
 	} else {
 		_ep->id = info->connreq;
 	}
@@ -1499,7 +1499,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 {
 	struct fi_info *fi;
 
-	fi = __fi_allocinfo();
+	fi = fi_allocinfo_internal();
 	if (!fi)
 		return NULL;
 
@@ -1534,7 +1534,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 	fi->connreq = event->id;
 	return fi;
 err:
-	__fi_freeinfo(fi);
+	fi_freeinfo_internal(fi);
 	return NULL;
 }
 
@@ -2312,7 +2312,7 @@ fi_ibv_pendpoint(struct fid_fabric *fabric, struct fi_info *info,
 	if (ret)
 		goto err;
 
-	__fi_freeinfo(fi);
+	fi_freeinfo_internal(fi);
 	_pep->id->context = &_pep->pep_fid.fid;
 
 	_pep->pep_fid.fid.fclass = FI_CLASS_PEP;

--- a/src/common.c
+++ b/src/common.c
@@ -94,7 +94,7 @@ int fi_poll_fd(int fd, int timeout)
 	return poll(&fds, 1, timeout) < 0 ? -errno : 0;
 }
 
-struct fi_info *__fi_allocinfo(void)
+struct fi_info *fi_allocinfo_internal(void)
 {
 	struct fi_info *info;
 
@@ -113,11 +113,11 @@ struct fi_info *__fi_allocinfo(void)
 
 	return info;
 err:
-	__fi_freeinfo(info);
+	fi_freeinfo_internal(info);
 	return NULL;
 }
 
-void __fi_freeinfo(struct fi_info *info)
+void fi_freeinfo_internal(struct fi_info *info)
 {
 	free(info->src_addr);
 	free(info->dest_addr);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -200,7 +200,7 @@ void fi_freeinfo_(struct fi_info *info)
 		if (prov && prov->provider->freeinfo)
 			prov->provider->freeinfo(info);
 		else
-			__fi_freeinfo(info);
+			fi_freeinfo_internal(info);
 	}
 }
 default_symver(fi_freeinfo_, fi_freeinfo);
@@ -253,7 +253,7 @@ const char *fi_strerror_(int errnum)
 }
 default_symver(fi_strerror_, fi_strerror);
 
-static const size_t __fi_datatype_size[] = {
+static const size_t fi_datatype_size_table[] = {
 	[FI_INT8]   = sizeof(int8_t),
 	[FI_UINT8]  = sizeof(uint8_t),
 	[FI_INT16]  = sizeof(int16_t),
@@ -276,5 +276,5 @@ size_t fi_datatype_size(enum fi_datatype datatype)
 		errno = FI_EINVAL;
 		return 0;
 	}
-	return __fi_datatype_size[datatype];
+	return fi_datatype_size_table[datatype];
 }


### PR DESCRIPTION
Symbols beginning with double underscore are in the namespace of the
compiler.  Rename:
- __fi_allocinfo --> fi_allocinfo
- __fi_freeinfo --> fi_freeinfo_internal
- __fi_datatype_size --> fi_datatype_size_table
