### PR TITLE
build: fix build for enable direct

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -189,6 +189,18 @@ rdmainclude_HEADERS = \
 	$(top_srcdir)/include/rdma/fi_tagged.h \
 	$(top_srcdir)/include/rdma/fi_trigger.h
 
+if HAVE_DIRECT
+rdmainclude_HEADERS += \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_domain.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_endpoint.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_tagged.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_rma.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_atomic_def.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_atomic.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_cm.h
+endif
+
 man_MANS = \
 	man/fabric.7 \
 	man/fi_accept.3 \

--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -8,6 +8,7 @@ AC_DEFUN([FI_PROVIDER_INIT],[
 	PROVIDERS_TO_BUILD=
 	PROVIDERS_DL=
 	PROVIDERS_STATIC=
+	PROVIDERS_COUNT=
 ])
 
 dnl
@@ -74,6 +75,7 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 	# See if the provider configured successfully
 	AS_IF([test $$1_happy -eq 1],
 		[PROVIDERS_TO_BUILD="$PROVIDERS_TO_BUILD $1"
+		 PROVIDERS_COUNT=$((PROVIDERS_COUNT+1))
 		 AS_IF([test $$1_dl -eq 1],
 			[AC_MSG_NOTICE([$1 provider to be built as a DSO])
 			 PROVIDERS_DL="prov/$1/lib$1.la $PROVIDERS_DL"],
@@ -94,6 +96,12 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 	      [AC_MSG_WARN([$1 provider was requested, but cannot be compiled])
 	       AC_MSG_ERROR([Cannot continue])
 	      ])
+	# If this provider was requested for direct build, ensure that
+	# provider's fi_direct.h exists in tree. Error otherwise.
+	AS_IF([test x"$enable_direct" = x"$1"],
+		[AC_CHECK_FILE(prov/$1/include/rdma/fi_direct.h, [],
+			[AC_MSG_WARN([$1 provider was requested as direct, but is missing required files])
+			 AC_MSG_ERROR([Cannot continue])])])
 ])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -40,6 +40,7 @@ AC_ARG_ENABLE([direct],
 	[AS_HELP_STRING([--enable-direct=@<:@provider@:>@],
 		[Enable direct calls to a fabric provider @<:@default=no@:>@])
 	],
+	[],
 	[enable_direct=no])
 
 dnl Checks for programs
@@ -148,6 +149,16 @@ FI_PROVIDER_FINI
 AS_IF([test x"$PROVIDERS_TO_BUILD" = "x"],
       [AC_MSG_NOTICE([No providers were configured])
        AC_MSG_ERROR([Cannot continue])])
+
+# If the user requested to build in direct mode, but
+# we have more than one provider, error.
+AS_IF([test x"$enable_direct" != x"no"],
+      [AS_IF([test "$PROVIDERS_COUNT" -eq "1"],
+	     [AC_SUBST(PROVIDER_DIRECT, "$enable_direct")],
+	     [AC_MSG_NOTICE([Only one provider can be chosen when using --enable-direct])
+	     AC_MSG_ERROR(Cannot continue)])])
+
+AM_CONDITIONAL([HAVE_DIRECT], [test x"$enable_direct" != x"no"])
 
 AC_CONFIG_FILES([Makefile libfabric.spec])
 AC_OUTPUT


### PR DESCRIPTION
Only one provider can be built in direct mode, so we
keep a count. Also, additional headers need to be
installed.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
