### PR TITLE
usnic: check for <infiniband/verbs.h>

### DIFF
--- a/prov/usnic/configure.m4
+++ b/prov/usnic/configure.m4
@@ -12,6 +12,7 @@ AC_DEFUN([FI_USNIC_CONFIGURE],[
     usnic_happy=0
     AS_IF([test "x$enable_usnic" != "xno"],
 	[usnic_happy=1
+	 AC_CHECK_HEADER([infiniband/verbs.h], [], [usnic_happy=0])
 	 AC_CHECK_HEADER([linux/netlink.h], [], [usnic_happy=0], [
 #include <sys/types.h>
 #include <net/if.h>


### PR DESCRIPTION
The usnic provider uses `<infiniband/verbs.h>` to get some of the verbs kernel ABI enums, so check for it in the usnic configury.
