### PR TITLE
Warning fixes for Sockets provider

### DIFF
--- a/prov/sockets/src/list.c
+++ b/prov/sockets/src/list.c
@@ -39,21 +39,10 @@
 
 #define LIST_DEF_NUM_ENTRIES (128)
 
-#ifdef _LIST_USE_LOCKS_
-
 #define CREATE_LOCK(_x) pthread_mutex_init(&(_x->mutex), NULL)
 #define DESTROY_LOCK(_x) pthread_mutex_destroy(&((_x)->mutex))
 #define LOCK_LIST(_x) pthread_mutex_lock (&((_x)->mutex))
 #define UNLOCK_LIST(_x) pthread_mutex_unlock (&((_x)->mutex))
-
-#else
-
-#define CREATE_LOCK(_x) 0
-#define DESTROY_LOCK(_x) 0
-#define LOCK_LIST(_x) 0
-#define UNLOCK_LIST(_x) 0
-
-#endif
 
 #define ENQUEUE_LIST(_head, _tail, _elem) do{		\
 		(_elem)->next = NULL;			\

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -338,7 +338,7 @@ static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t len,
 	if(!sock_cq)
 		return -FI_ENOENT;
 
-	if (sock_cq->attr.wait_obj == FI_CQ_COND_THRESHOLD){
+	if (sock_cq->attr.wait_cond == FI_CQ_COND_THRESHOLD){
 		cq_threshold = (int64_t)cond;
 	}else{
 		cq_threshold = 1;


### PR DESCRIPTION
This patch fixes the warnings in list.c and also the one in sock_cq.
