### PR TITLE
Add certificate of origin and update authors

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,39 @@
+All patches submitted for inclusion must include a signed-off-by line.
+This mechanism is the same to that used by the Linux kernel:
+
+The signed-off-by is a line at the end of the explanation for the
+patch, which certifies that you wrote it or otherwise have the right to
+it on as an open-source patch.  The rules are simple: if you
+can certify the below:
+
+       Developer's Certificate of Origin 1.1
+ 
+       By making a contribution to this project, I certify that:
+ 
+       (a) The contribution was created in whole or in part by me and I
+           have the right to submit it under the open source license
+           indicated in the file; or
+ 
+       (b) The contribution is based upon previous work that, to the best
+           of my knowledge, is covered under an appropriate open source
+           license and I have the right under that license to submit that
+           work with modifications, whether created in whole or in part
+           by me, under the same open source license (unless I am
+           permitted to submit under a different license), as indicated
+           in the file; or
+ 
+       (c) The contribution was provided directly to me by some other
+           person who certified (a), (b) or (c) and I have not modified
+           it.
+ 
+       (d) I understand and agree that this project and the contribution
+           are public and that a record of the contribution (including all
+           personal information I submit with it, including my sign-off) is
+           maintained indefinitely and may be redistributed consistent with
+           this project or the open source license(s) involved.
+ 
+then you just add a line saying
+
+Signed-off-by: Random Developer <random@developer.example.org>
+
+using your real name.


### PR DESCRIPTION
Define the developer's certificate of origin, which specifies
what the signed-off-by line actually means.

Signed-off-by: Sean Hefty sean.hefty@intel.com
