### PR TITLE
verbs: DL filename should be "verbs", not "ibverbs"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -61,9 +61,9 @@ if HAVE_VERBS
 _verbs_files = prov/verbs/src/fi_verbs.c
 
 if HAVE_VERBS_DL
-pkglib_LTLIBRARIES += libibverbs-fi.la
-libibverbs_fi_la_SOURCES = $(_verbs_files) $(common_srcs)
-libibverbs_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic -libverbs -lrdmacm $(linkback)
+pkglib_LTLIBRARIES += libverbs-fi.la
+libverbs_fi_la_SOURCES = $(_verbs_files) $(common_srcs)
+libverbs_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic -libverbs -lrdmacm $(linkback)
 else !HAVE_VERBS_DL
 src_libfabric_la_SOURCES += $(_verbs_files)
 endif !HAVE_VERBS_DL


### PR DESCRIPTION
The provider name is "verbs" everywhere else.  Make the DL filename match / be consistent.
