### PR TITLE
include/fi.h: include string.h

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -40,6 +40,7 @@
 #include <byteswap.h>
 #include <endian.h>
 #include <semaphore.h>
+#include <string.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_prov.h>
 #include <rdma/fi_atomic.h>


### PR DESCRIPTION
ffsll requires string.h

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
