### PR TITLE
man: fi_cntr_wait, fi_cq_sread clarify timeout

### DIFF
--- a/man/fi_cntr.3
+++ b/man/fi_cntr.3
@@ -183,6 +183,9 @@ the counter will be greater than or equal to the input threshold value.
 If an operation associated with the counter encounters an error, it will
 increment the error value associated with the counter.  Any change in a
 counter's error value will unblock any thread inside fi_cntr_wait. 
+.sp
+If the call returns due to timeout, -FI_ETIMEDOUT will be returned.
+The error value associated with the counter remains unchanged.
 .SH "RETURN VALUES"
 Returns 0 on success.  On error, a negative value corresponding to
 fabric errno is returned.

--- a/man/fi_cq.3
+++ b/man/fi_cq.3
@@ -366,7 +366,7 @@ fi_cq_sread / fi_cq_sreadfrom
 .RS
 On success, returns the number of completion events retrieved from the
 completion queue.  On error, a negative value corresponding to fabric
-errno is returned.
+errno is returned. On timeout, -FI_ETIMEDOUT is returned.
 .RE
 fi_cq_write / fi_cq_writeerr
 .RS


### PR DESCRIPTION
When these calls return due to timeout, they should return a
specific value, vs. a generic error. This indicates to the app
that it doesn't have to read the error queue.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
