### PR TITLE
man: fix mismatch among fi_tagged(3) and fi_av(3)

### DIFF
--- a/man/fi_tagged.3
+++ b/man/fi_tagged.3
@@ -281,9 +281,10 @@ Indicates that an invalid argument was supplied by the user.
 Indicates that an unspecified error occurred.
 .SH "NOTES"
 .SS Any source
-The function fi_trecvfrom() may be used to receive a message from a specific
-source address.  If the user wishes to receive a message from any source on
-an unconnected fabric endpoint the function fi_recv() may be used.
+When using unconnected fabric endpoints, the function fi_trecvfrom() can
+be used to receive a message from any source. The address for 'any source'
+can be obtained by inserting a NULL value in the address vector. See
+fi_av(3).
 .SS Ordering
 The order in which tags are matched is only defined for a pair of sending and
 receiving endpoints.  The ordering is defined by the underlying protocol.


### PR DESCRIPTION
The manpage for AV was updated to state that addresses for
'any source' should be inserted into the AV with a value NULL.
This address should be used in recvfrom() when attempting to
receive from any source.

The older man page for tagged said that fi_recv() should be used
instead. This was an error, since connected mode calls cannot be
used for unconnected mode endpoint!

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
