### PR TITLE
man: fi_getinfo returned info clarification

### DIFF
--- a/man/fi_getinfo.3
+++ b/man/fi_getinfo.3
@@ -62,8 +62,8 @@ may be used to control the resulting output as indicated below.
 If node is not given, fi_getinfo will attempt to resolve the fabric addressing
 information based on the provided hints.
 .PP
-The caller must call fi_freeinfo to release fi_info structures returned
-by this call.
+The caller may not update any fields in fi_info structures returned by this call,
+and must free the fi_info structures by calling fi_freeinfo.
 .SH "FI_INFO"
 .nf
 struct fi_info {


### PR DESCRIPTION
Clarify to the user that any info structure returned
from fi_getinfo shouldn't be modified by them.

Modifying fi_info after it has returned may cause failures
later when using that fi_info to create other libfabric
structures like fabric, domain etc.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
