### PR TITLE
man: mention CQs in fi_endpoint(3)

### DIFF
--- a/man/fi_endpoint.3
+++ b/man/fi_endpoint.3
@@ -9,7 +9,7 @@ Allocate or close an endpoint.
 .PP
 fi_ep_bind
 .RS
-Associate an endpoint with an event queue, address vector, or
+Associate an endpoint with an event queue, completion queue, address vector, or
 memory region
 .RE
 .PP
@@ -85,7 +85,7 @@ Get or set endpoint options.
 .SH ARGUMENTS
 .IP "fid" 12
 On creation, specifies a fabric or access domain.  On bind, identifies the
-event queue or address vector to bind to the endpoint.
+event queue, completion queue or address vector to bind to the endpoint.
 .IP "info" 12
 Details about the fabric interface endpoint to be opened, obtained from
 fi_getinfo.
@@ -128,9 +128,9 @@ an endpoint into the enabled state, if it is not already active.
 .PP
 In order to transition an endpoint into an enabled state, it must be
 bound to one or more fabric resources.  An endpoint that
-will generate asynchronous events, either through data transfer operations
+will generate asynchronous completions, either through data transfer operations
 or communication establishment events, must be bound to the appropriate
-event collectors before being enabled.
+completion queues or event queues before being enabled.
 .PP
 Once an endpoint has been activated, it may be associated with memory
 regions and address vectors.  Receive buffers may be posted to it, and
@@ -155,31 +155,31 @@ Closes an endpoint and release all resources associated with it.
 .SS "fi_ep_bind"
 fi_ep_bind is used to associate an endpoint with hardware resources.
 The common use of fi_ep_bind is to direct asynchronous operations
-associated with an endpoint to an event queue.  An endpoint must be
-bound with EQs capable of reporting completions for any asynchronous
+associated with an endpoint to a completion queue.  An endpoint must be
+bound with CQs capable of reporting completions for any asynchronous
 operation initiated on the endpoint.  This is true even for endpoints
 which are configured to suppress successful completions, in order
 that operations that complete in error may be reported to the
-user.  For connection-oriented endpoints, this requires binding the
+user.  For passive endpoints, this requires binding the
 endpoint with an EQ that supports the communication management (CM)
 domain.
 .PP
-An active endpoint may direct asynchronous completions to different EQs, based
+An active endpoint may direct asynchronous completions to different CQs, based
 on the type of operation.  This is specified using fi_ep_bind flags.  The
 following flags may be used separately or OR'ed together when binding
-an endpoint to a completion domain EQ.
+an endpoint to a completion domain CQ.
 .RS
 .IP "FI_SEND"
 Directs the completion of outbound data transfer requests to the
-specified event queue.  This includes send message, RMA, and atomic
+specified completion queue.  This includes send message, RMA, and atomic
 operations.
 .IP "FI_RECV"  
 Directs the notification of inbound data transfers to the
-specified event queue.  This includes received messages.
+specified completion queue.  This includes received messages.
 .IP "FI_EVENT"
 If FI_EVENT is specified, the indicated data transfer operations
 won't generate entries for successful completions in the
-event queue unless FI_EVENT is set for that specific operation.
+completion queue unless FI_EVENT is set for that specific operation.
 FI_EVENT must be OR'ed with FI_SEND and/or FI_RECV flags.
 .sp
 When set the user must determine when a request that does NOT have
@@ -662,7 +662,7 @@ Applies to posted receive operations.  This flag allows the user to post a
 single buffer that will receive multiple incoming messages.  Received
 messages will be packed into the receive buffer until the buffer has been
 consumed.  Use of this flag may cause a single posted receive operation
-to generate multiple events as messages are placed into the buffer.
+to generate multiple completions as messages are placed into the buffer.
 The placement of received data into the buffer may be subjected to
 provider specific alignment restrictions.  The buffer will be freed from
 the endpoint when a message is received that cannot fit into the remaining
@@ -676,7 +676,7 @@ posted are lost.
 Indicates that a completion entry should be generated for data transfer
 operations.
 .IP "FI_REMOTE_SIGNAL"
-Indicates that a completion event at the target process should be generated
+Indicates that a completion entry at the target process should be generated
 for the given operation.  The remote endpoint must be configured with
 FI_REMOTE_SIGNAL, or this flag will be ignored by the target.  The local
 endpoint must be configured with the FI_REMOTE_SIGNAL capability in order
@@ -718,7 +718,7 @@ endpoint.
 Endpoints allocated with the FI_CONTEXT mode set must
 typically provide struct fi_context as their per operation context
 parameter.  (See fi_getinfo.3 for details.)  However, when FI_EVENT is
-enabled to suppress completion events, and an operation is initiated without
+enabled to suppress completion entries, and an operation is initiated without
 FI_EVENT flag set, then the context parameter is ignored.  An
 application does not need to pass in a valid struct fi_context into
 such data transfers.
@@ -767,8 +767,8 @@ Fabric errno values are defined in
 .IP "-FI_EDOMAIN"
 A resource domain was not bound to the endpoint or an attempt was made to
 bind multiple domains.
-.IP "-FI_ENOEC"
-The endpoint has not been configured with necessary event collectors.
+.IP "-FI_ENOEQ"
+The endpoint has not been configured with necessary event queue.
 .IP "-FI_EOPBADSTATE"
 The endpoint's state does not permit the requested operation.
 .SH "SEE ALSO"


### PR DESCRIPTION
The fi_endpoint man page wasn't distinguishing between CQs and EQs
per our recent change. The data transfer completions now appear in
CQs not EQs. Passive endpoints need EQs, but not active endpoints.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
