### PR TITLE
add support for async AV insertions

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -37,6 +37,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <string.h>
 #include <byteswap.h>
 #include <endian.h>
 #include <semaphore.h>

--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -477,12 +477,13 @@ ssize_t fi_no_tagged_search(struct fid_ep *ep, uint64_t *tag, uint64_t ignore,
  * fi_ops_av
  */
 int fi_no_av_insert(struct fid_av *av, const void *addr, size_t count,
-			fi_addr_t *fi_addr, uint64_t flags);
+			fi_addr_t *fi_addr, uint64_t flags, void *context);
 int fi_no_av_insertsvc(struct fid_av *av, const char *node,
-		const char *service, fi_addr_t *fi_addr, uint64_t flags);
+		const char *service, fi_addr_t *fi_addr, uint64_t flags,
+		void *context);
 int fi_no_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
 			const char *service, size_t svccnt, fi_addr_t *fi_addr,
-			uint64_t flags);
+			uint64_t flags, void *context);
 int fi_no_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 			uint64_t flags);
 

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -65,12 +65,13 @@ struct fi_av_attr {
 struct fi_ops_av {
 	size_t	size;
 	int	(*insert)(struct fid_av *av, const void *addr, size_t count,
-			fi_addr_t *fi_addr, uint64_t flags);
+			fi_addr_t *fi_addr, uint64_t flags, void *context);
 	int	(*insertsvc)(struct fid_av *av, const char *node,
-			const char *service, fi_addr_t *fi_addr, uint64_t flags);
+			const char *service, fi_addr_t *fi_addr,
+			uint64_t flags, void *context);
 	int	(*insertsym)(struct fid_av *av, const char *node, size_t nodecnt,
 			const char *service, size_t svccnt, fi_addr_t *fi_addr,
-			uint64_t flags);
+			uint64_t flags, void *context);
 	int	(*remove)(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 			uint64_t flags);
 	int	(*lookup)(struct fid_av *av, fi_addr_t fi_addr, void *addr,
@@ -204,24 +205,25 @@ fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 
 static inline int
 fi_av_insert(struct fid_av *av, const void *addr, size_t count,
-	     fi_addr_t *fi_addr, uint64_t flags)
+	     fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
-	return av->ops->insert(av, addr, count, fi_addr, flags);
+	return av->ops->insert(av, addr, count, fi_addr, flags, context);
 }
 
 static inline int
 fi_av_insertsvc(struct fid_av *av, const char *node, const char *service,
-		fi_addr_t *fi_addr, uint64_t flags)
+		fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
-	return av->ops->insertsvc(av, node, service, fi_addr, flags);
+	return av->ops->insertsvc(av, node, service, fi_addr, flags, context);
 }
 
 static inline int
 fi_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
 		const char *service, size_t svccnt,
-		fi_addr_t *fi_addr, uint64_t flags)
+		fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
-	return av->ops->insertsym(av, node, nodecnt, service, svccnt, fi_addr, flags);
+	return av->ops->insertsym(av, node, nodecnt, service, svccnt,
+			fi_addr, flags, context);
 }
 
 static inline int

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -121,11 +121,13 @@ enum {
 struct fi_eq_entry {
 	fid_t			fid;
 	void			*context;
+	uint64_t		data;
 };
 
 struct fi_eq_err_entry {
 	fid_t			fid;
 	void			*context;
+	uint64_t		data;
 	int			err;
 	int			prov_errno;
 	/* err_data is available until the next time the CQ is read */

--- a/man/fi_av.3
+++ b/man/fi_av.3
@@ -39,14 +39,15 @@ Convert an address into a printable string.
 .PP
 .HP
 .BI "int fi_av_insert(struct fid_av *" av ", void *" addr ", size_t " count ", "
-.BI "fi_addr_t *" fi_addr ", uint64_t " flags ");"
+.BI "fi_addr_t *" fi_addr ", uint64_t " flags ", void *" context ");"
 .HP
 .BI "int fi_av_insertsvc(struct fid_av *" av ", const char *" node ", "
-.BI "const char *" service ", fi_addr_t *" fi_addr ", uint64_t " flags ");"
+.BI "const char *" service ", fi_addr_t *" fi_addr ", uint64_t " flags ", "
+.BI "void *" context ");"
 .HP
 .BI "int fi_av_insertsym(struct fid_av *" av ", const char *" node ", "
 .BI "size_t " nodecnt ", const char *" service ", size_t " svccnt ", "
-.BI "fi_addr_t *" fi_addr ", uint64_t " flags ");"
+.BI "fi_addr_t *" fi_addr ", uint64_t " flags ", void *" context ");"
 .HP
 .BI "int fi_av_remove(struct fid_av *" av ", fi_addr_t " fi_addr ", size_t " count ", "
 .BI "uint64_t " flags ");"
@@ -69,7 +70,7 @@ Event queue
 .IP "attr"
 Address vector attributes
 .IP "context"
-User specified context associated with the address vector.
+User specified context associated with the address vector or insert opertion.
 .IP "addr"
 Buffer containing one or more addresses to insert into address vector.
 .IP "addrlen"
@@ -90,7 +91,11 @@ more natural for an application to use, into fabric specific addresses.
 The mapping of addresses is fabric and provider specific, but may involve
 lengthy address resolution and fabric management protocols.  AV operations
 are synchronous by default, but may be set to operate asynchronously by
-associating the AV with an event queue.
+specifying the FI_EVENT flag to
+.B fi_av_open.
+When requesting asynchronous operation, the
+application must first bind an event queue to the AV before inserting
+addresses.
 .SS "fi_av_open"
 fi_av_open allocates or opens an address vector.  The properties and behavior of
 the address vector are defined by struct fi_av_attr.
@@ -178,6 +183,28 @@ field is ignored if name is NULL.
 .IP "flags"
 The following flags may be used when opening an AV.
 .RS
+.IP "FI_EVENT"
+When the flag FI_EVENT is specified, all insert operations on this
+AV  will occur
+asynchronously.  There will be one EQ error entry generated for each
+failed address insertion, followed by one non-error event indicating that the
+insertion operation has completed.
+There will always be one non-error completion event for each
+insert operation, even if all addresses fail.  The context field in all
+completions will be the context specified to the insert call, and the data
+field in the final completion entry will report the number of addresses 
+successfully inserted.
+.sp
+If an AV is opened with FI_EVENT, any insertions attempted before an EQ
+is bound to the AV will fail with -FI_EINVAL.
+.sp
+Error completions for failed insertions will contain the index of the failed
+address in the index field of the error completion entry.
+.sp
+Note that the order of delivery of insert completions may not match
+the order in which the calls to fi_av_insert were made.  The only guarantee
+is that all error completions for a given call to fi_av_insert will preceed
+the single associated non-error completion.
 .IP "FI_READ"
 Opens an AV for read-only access.  An AV opened for read-only access
 must be named (name attribute specified), and the AV must exist.
@@ -199,7 +226,7 @@ AV indicates that the provider should perform all insertions asynchronously,
 with the completions reported through the event queue.  If an event queue
 is not bound to the AV, then insertion requests behave synchronously.
 .SS "fi_av_insert"
-The fi_av_insert call inserts one or more addresses into an AV.  The number
+The fi_av_insert call inserts zero or more addresses into an AV.  The number
 of addresses is specified through the count parameter.  The addr parameter
 references an array of addresses to insert into the AV.  Addresses
 inserted into an address vector must be in the same format as specified
@@ -226,6 +253,15 @@ remain valid until the insertion operation completes.  When addresses
 are inserted into an AV of type FI_AV_TABLE, the returned fi_addr values
 will be simple indices corresponding to the entry into the table where the
 address was inserted.  Addresses are indexed in order of their insertion.
+.IP "flags"
+The following flag may be passed to fi_av_insert
+.RS
+.IP "FI_MORE"
+In order to allow optimized address insertion, the application may
+specify the FI_MORE flag to the insert call to give a hint to the provider
+that more insertion requests will follow, allowing the provider to aggregate
+insertion requests if desired.  Providers are free to ignore FI_MORE.
+.RE
 .SS "fi_av_insertsvc"
 The fi_av_insertsvc call behaves similar to fi_av_insert, but allows the
 application to specify the node and service names, similar to the
@@ -300,11 +336,15 @@ a provider may begin resolving inserted addresses as soon as they have
 been added to an AV, even if asynchronous operation has been specified.
 Similarly, a provider may lazily release resources from removed entries. 
 .SH "RETURN VALUES"
-Returns 0 on success.  On error, a negative value corresponding to
-fabric errno is returned.
+The insert calls return the number of addresses successfully inserted or
+the number of asynchronous insertions initiated if FI_EVENT is set.
 .PP
+Other calls return 0 on success.
+.PP
+On error, a negative value corresponding to
+fabric errno is returned.
 Fabric errno values are defined in
 .IR "rdma/fi_errno.h".
 .SH "ERRORS"
 .SH "SEE ALSO"
-fi_getinfo(3), fi_endpoint(3), fi_domain(3)
+fi_getinfo(3), fi_endpoint(3), fi_domain(3), fi_eq(3)

--- a/man/fi_eq.3
+++ b/man/fi_eq.3
@@ -96,6 +96,7 @@ fi_eq_open allocates a new event queue.
 The properties and behavior of an event queue are defined by struct fi_eq_attr.
 .PP
 .nf
+
 struct fi_eq_attr {
 	size_t               size;      /* # entries for EQ */
 	uint64_t             flags;     /* operation flags */
@@ -103,6 +104,8 @@ struct fi_eq_attr {
 	int                  signaling_vector; /* interrupt affinity */
 	struct fid_wait     *wait_set;  /* optional wait set */
 };
+
+.fi
 .IP "size"
 Specifies the minimum size of an event queue.
 .IP "flags"
@@ -197,6 +200,7 @@ into the EQ.  The format of this structure is:
 struct fi_eq_entry {
 	fid_t            fid;        /* fid associated with request */
 	void            *context;    /* operation context */
+	uint32_t         data;       /* completion dependent data */
 };
 
 .fi
@@ -271,6 +275,7 @@ The format of this structure is defined below.
 struct fi_eq_err_entry {
 	fid_t            fid;        /* fid associated with error */
 	void            *context;    /* operation context */
+	uint32_t         index;      /* index for vector ops */
 	int              err;        /* positive error code */
 	int              prov_errno; /* provider error code */
 	void            *err_data;   /* additional error data */

--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -114,7 +114,7 @@ static int psmx_av_check_table_size(struct psmx_fid_av *av, size_t count)
 }
 
 static int psmx_av_insert(struct fid_av *av, const void *addr, size_t count,
-			  fi_addr_t *fi_addr, uint64_t flags)
+			  fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
 	struct psmx_fid_av *av_priv;
 	psm_error_t *errors;

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -45,7 +45,7 @@
 #include "sock.h"
 
 static int sock_at_insert(struct fid_av *av, const void *addr, size_t count,
-			  fi_addr_t *fi_addr, uint64_t flags)
+			  fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
 	int i;
 	struct sock_av *_av;
@@ -91,7 +91,7 @@ static const char * sock_at_straddr(struct fid_av *av, const void *addr,
 }
 
 static int sock_am_insert(struct fid_av *av, const void *addr, size_t count,
-			  fi_addr_t *fi_addr, uint64_t flags)
+			  fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
 	const struct sockaddr_in *sin;
 	struct sockaddr_in *fin;

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -36,6 +36,7 @@
 #ifndef _USDF_H_
 #define _USDF_H_
 
+#include <sys/queue.h>
 #include <pthread.h>
 
 #define USDF_FI_NAME "usnic"
@@ -65,6 +66,13 @@ struct usdf_domain {
 	atomic_t dom_refcnt;
 	struct usd_device   *dom_dev;
 	struct usd_device_attrs dom_dev_attrs;
+
+	/* progression */
+	pthread_t dom_thread;
+	int dom_exit;
+	int dom_eventfd;
+	atomic_t dom_pending_items;
+	pthread_spinlock_t dom_usd_lock;
 };
 #define dom_ftou(FDOM) container_of(FDOM, struct usdf_domain, dom_fid)
 #define dom_utof(DOM) (&(DOM)->dom_fid)
@@ -119,7 +127,7 @@ struct usdf_eq {
 
 	pthread_spinlock_t eq_lock;
 
-	struct fi_eq_entry *eq_ev_buf;
+	struct fi_eq_err_entry *eq_ev_buf;
 	struct usdf_event *eq_ev_ring;
 	struct usdf_event *eq_ev_head;
 	struct usdf_event *eq_ev_tail;
@@ -139,23 +147,50 @@ struct usdf_eq {
 #define eq_fidtou(FID) container_of(FID, struct usdf_eq, eq_fid.fid)
 #define eq_utof(EQ) (&(EQ)->eq_fid)
 
+struct usdf_av_insert_block;
+struct usdf_av_sync_list;
+
 struct usdf_av {
 	struct fid_av av_fid;
 	struct usdf_domain *av_domain;
+	uint64_t av_flags;
 	struct usdf_eq *av_eq;
 	atomic_t av_refcnt;
+	int av_closing;
+	atomic_t av_active_inserts;
+	pthread_spinlock_t av_lock;
 };
 #define av_ftou(FAV) container_of(FAV, struct usdf_av, av_fid)
 #define av_fidtou(FID) container_of(FID, struct usdf_av, av_fid.fid)
 #define av_utof(AV) (&(AV)->av_fid)
 
+struct usdf_av_insert {
+	struct usdf_av *avi_av;
+	uint32_t avi_pending_ops;
+	atomic_t avi_completed_ops;
+	atomic_t avi_successful_ops;
+	void *avi_context;
+};
+
+/* struct used for context to usd_create_dest_start - will go away */
+struct usdf_av_req {
+	struct usdf_av_insert *avr_insert;
+	fi_addr_t *avr_fi_addr;
+};
 
 /*
  * Prototypes
  */
 
-/* global progress */
-void usdf_progress(void);
+/* progression */
+void usdf_progress(struct usdf_domain *udp);
+void *usdf_progression_thread(void *v);
+int usdf_add_progression_item(struct usdf_domain *udp);
+void usdf_progression_item_complete(struct usdf_domain *udp);
+void usdf_av_progress(struct usdf_domain *udp);
+
+ssize_t usdf_eq_write_internal(struct usdf_eq *eq, uint32_t event,
+		const void *buf, size_t len, uint64_t flags);
 
 /* fi_ops_fabric */
 int usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -61,53 +61,194 @@
 
 #include "usnic_direct.h"
 #include "usdf.h"
+#include "usd_queue.h"
 
-/*
- * Reap completed AV insert operatins and generate EQ entries
- */
-void
-usdf_am_progress(struct usdf_av *av)
+static void
+usdf_av_insert_complete(struct usdf_av_insert *insert)
 {
+	struct fi_eq_entry entry;
+	struct usdf_av *av;
+
+	av = insert->avi_av;
+
+	entry.fid = &av->av_fid.fid;
+	entry.context = insert->avi_context;
+	entry.data = atomic_get(&insert->avi_successful_ops);
+	usdf_eq_write_internal(av->av_eq,
+		FI_COMPLETE, &entry, sizeof(entry), 0);
+
+	pthread_spin_lock(&av->av_lock);
+
+	atomic_dec(&av->av_active_inserts);
+	if (atomic_get(&av->av_active_inserts) == 0 && av->av_closing) {
+		free(av);
+	} else {
+		pthread_spin_unlock(&av->av_lock);
+	}
+
+	free(insert);
 }
 
+static void
+usdf_av_completion(struct usdf_av_req *req, int status, struct usd_dest *dest)
+{
+	struct fi_eq_err_entry err_entry;
+	struct usdf_av_insert *insert;
+	struct usdf_av *av;
+
+	insert = req->avr_insert;
+	av = insert->avi_av;
+
+	if (status == 0) {
+		*(struct usd_dest **)req->avr_fi_addr = dest;
+		atomic_inc(&insert->avi_successful_ops);
+	} else {
+		*req->avr_fi_addr = FI_ADDR_NOTAVAIL;
+
+		err_entry.fid = &av->av_fid.fid;
+		err_entry.context = insert->avi_context;
+		err_entry.data = req - (struct usdf_av_req *)(insert + 1);
+		err_entry.err = -status;
+
+		usdf_eq_write_internal(av->av_eq, FI_COMPLETE,
+			&err_entry, sizeof(err_entry),
+			USDF_EVENT_FLAG_ERROR);
+	}
+
+	/* decrement pending ops and generate event if all done */
+	atomic_inc(&insert->avi_completed_ops);
+	if (atomic_get(&insert->avi_completed_ops) == insert->avi_pending_ops) {
+		usdf_av_insert_complete(insert);
+	}
+	usdf_progression_item_complete(av->av_domain);
+}
+
+/*
+ * Called by progression thread to look for AV completions on this domain
+ */
+void
+usdf_av_progress(struct usdf_domain *udp)
+{
+	int ret;
+	int status;
+	void *context;
+	struct usd_dest *dest;
+	struct usdf_av_req *req;
+
+	do {
+
+		/* usd_dest_* not threadsafe... */
+		pthread_spin_lock(&udp->dom_usd_lock);
+		ret = usd_create_dest_poll(udp->dom_dev, &context, &status,
+				&dest);
+		pthread_spin_unlock(&udp->dom_usd_lock);
+
+		if (ret == 0) {
+			req = context;
+			usdf_av_completion(req, status, dest);
+		}
+	} while (ret == 0);
+}
+
+/*
+ * The first call to av_insert or the next call after a sync will start
+ * a sync_list.  This and each succeeding av_insert will create an insert_block
+ * and add it to the current sync_list until fi_sync(av) is called.
+ * Once av_sync is called, an event will be generated as soon as the last
+ * address in the sync_list is resolved.
+ */
 static int
 usdf_am_insert(struct fid_av *fav, const void *addr, size_t count,
-			  fi_addr_t *fi_addr, uint64_t flags)
+			  fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
 	const struct sockaddr_in *sin;
+	struct usdf_av_insert *insert;
+	struct usdf_av_req *req;
 	struct usdf_av *av;
+	struct usdf_domain *udp;
 	struct usd_dest *dest;
+	int ret_count;
 	int ret;
 	int i;
 
-	if (flags) {
+	if ((flags & ~FI_MORE) != 0) {
 		return -FI_EBADFLAGS;
 	}
 
 	av = av_ftou(fav);
+
+	ret_count = 0;
 	sin = addr;
-	if (av->av_eq != NULL) {
+
+	if (av->av_flags & FI_EVENT) {
+		if (av->av_eq == NULL) {
+			return -FI_EINVAL;
+		}
+		udp = av->av_domain;
+
+		/* allocate all we need in one go */
+		insert = malloc(sizeof(*insert) + count * sizeof(*req));
+		if (insert == NULL) {
+			return -errno;
+		}
+		insert->avi_av = av;
+		insert->avi_pending_ops = count;
+		atomic_init(&insert->avi_completed_ops);
+		atomic_init(&insert->avi_successful_ops);
+		insert->avi_context = context;
+
+		/* If no addresses, complete now */
+		if (count == 0) {
+			usdf_av_insert_complete(insert);
+			return 0;
+		}
+
+		atomic_inc(&av->av_active_inserts);
+
+		req = (struct usdf_av_req *)(insert + 1);
+
 		for (i = 0; i < count; i++) {
+			/* XXX this is temp approach, will ultimately do
+			 * address resolution natively instead of thru
+			 * usd_create_dest_start()
+			 */
+			req->avr_insert = insert;
+			req->avr_fi_addr = &fi_addr[i];
+
+			pthread_spin_lock(&udp->dom_usd_lock);
 			ret = usd_create_dest_start(av->av_domain->dom_dev,
 					sin->sin_addr.s_addr, sin->sin_port,
-					&fi_addr[i]);
+					req);
+			pthread_spin_unlock(&udp->dom_usd_lock);
 			if (ret != 0) {
-				return ret;
+				// XXX - no event... this will change
+				fi_addr[i] = FI_ADDR_NOTAVAIL;
+				atomic_inc(&insert->avi_completed_ops);
+			} else {
+				usdf_add_progression_item(av->av_domain);
 			}
+
+			++sin;
+			++req;
 		}
+		ret_count = count;
 	} else {
+		/* XXX parallelize */
 		for (i = 0; i < count; i++) {
 			ret = usd_create_dest(av->av_domain->dom_dev,
 					sin->sin_addr.s_addr, sin->sin_port,
 					&dest);
 			if (ret != 0) {
-				return ret;
+				fi_addr[i] = FI_ADDR_NOTAVAIL;
+			} else {
+				fi_addr[i] = (fi_addr_t)dest;
+				++ret_count;
 			}
-			fi_addr[i] = (fi_addr_t)dest;
+			++sin;
 		}
 	}
 
-	return 0;
+	return ret_count;
 }
 
 static int
@@ -175,6 +316,7 @@ usdf_av_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			return -FI_EINVAL;
 		}
 		av->av_eq = eq_fidtou(bfid);
+		atomic_inc(&av->av_eq->eq_refcnt);
 		break;
 	default:
 		return -FI_EINVAL;
@@ -193,8 +335,19 @@ usdf_av_close(struct fid *fid)
 		return -FI_EBUSY;
 	}
 
+	pthread_spin_lock(&av->av_lock);
+
+	if (av->av_eq != NULL) {
+		atomic_dec(&av->av_eq->eq_refcnt);
+	}
 	atomic_dec(&av->av_domain->dom_refcnt);
-	free(av);
+
+	if (atomic_get(&av->av_active_inserts) > 0) {
+		av->av_closing = 1;
+		pthread_spin_unlock(&av->av_lock);
+	} else {
+		free(av);
+	}
 	return 0;
 }
 
@@ -202,6 +355,9 @@ static struct fi_ops usdf_av_fi_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = usdf_av_close,
 	.bind = usdf_av_bind,
+	.control = fi_no_control,
+	.sync = fi_no_sync,
+	.ops_open = fi_no_ops_open,
 };
 
 static struct fi_ops_av usdf_am_ops = {
@@ -227,11 +383,10 @@ usdf_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	struct usdf_domain *udp;
 	struct usdf_av *av;
 
-	if (attr->name != NULL || attr->flags != 0) {
+	if (attr->name != NULL) {
 		return -FI_ENOSYS;
 	}
-
-	if (attr->type != FI_AV_MAP) {
+	if ((attr->flags & ~FI_EVENT) != 0) {
 		return -FI_ENOSYS;
 	}
 
@@ -250,8 +405,11 @@ usdf_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	av->av_fid.fid.fclass = FI_CLASS_AV;
 	av->av_fid.fid.context = context;
 	av->av_fid.fid.ops = &usdf_av_fi_ops;
+	av->av_flags = attr->flags;
+	pthread_spin_init(&av->av_lock, PTHREAD_PROCESS_PRIVATE);
 
 	atomic_init(&av->av_refcnt);
+	atomic_init(&av->av_active_inserts);
 	atomic_inc(&udp->dom_refcnt);
 	av->av_domain = udp;
 

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -183,9 +183,10 @@ usdf_cq_readfrom_context(struct fid_cq *fcq, void *buf, size_t count,
 			sin.sin_addr.s_addr = hdr->uh_ip.saddr;
 			sin.sin_port = hdr->uh_udp.source;
 
-			ret = fi_av_insert(av_utof(ep->ep_av), &sin, 1, src_addr, 0);
-			if (ret != 0) {
-				*src_addr = FI_ADDR_UNSPEC;
+			ret = fi_av_insert(av_utof(ep->ep_av), &sin, 1,
+					src_addr, 0, NULL);
+			if (ret != 1) {
+				*src_addr = FI_ADDR_NOTAVAIL;
 			}
 			++src_addr;
 		}

--- a/prov/usnic/src/usnic_direct/usd.h
+++ b/prov/usnic/src/usnic_direct/usd.h
@@ -43,6 +43,8 @@
 #ifndef _USD_H_
 #define _USD_H_
 
+#include <sys/queue.h>
+
 #include "kcompat.h"
 #include "vnic_rq.h"
 #include "vnic_wq.h"
@@ -90,7 +92,12 @@ struct usd_device {
     /* PD for this device */
     uint32_t ud_pd_handle;
 
+    /* destination related */
     int ud_arp_sockfd;          /* for ARP */
+    TAILQ_HEAD(, usd_dest_req) ud_pending_reqs;
+    TAILQ_HEAD(, usd_dest_req) ud_completed_reqs;
+
+    TAILQ_ENTRY(usd_device) ud_link;
 };
 
 /*

--- a/prov/usnic/src/usnic_direct/usd_dest.h
+++ b/prov/usnic/src/usnic_direct/usd_dest.h
@@ -52,7 +52,6 @@
  */
 typedef struct usd_dest_req udr_t;
 struct usd_dest_req {
-    struct usd_device *udr_dev;
     struct usd_dest *udr_dest;
 
     uint32_t udr_daddr_be;

--- a/prov/usnic/src/usnic_direct/usd_device.c
+++ b/prov/usnic/src/usnic_direct/usd_device.c
@@ -64,6 +64,9 @@ static pthread_once_t usd_init_once = PTHREAD_ONCE_INIT;
 static struct usd_ib_dev *usd_ib_dev_list;
 static int usd_init_error;
 
+TAILQ_HEAD(,usd_device) usd_device_list =
+    TAILQ_HEAD_INITIALIZER(usd_device_list);
+
 /*
  * Perform one-time initialization
  */
@@ -186,6 +189,8 @@ usd_close(
     struct usd_cq_group *cgp;
     struct usd_cq_group *next_cgp;
 
+    TAILQ_REMOVE(&usd_device_list, dev, ud_link);
+
     /* XXX - verify all other resources closed out */
     if (dev->ud_flags & USD_DEVF_CLOSE_CMD_FD)
         close(dev->ud_ib_dev_fd);
@@ -273,6 +278,8 @@ usd_open_with_fd(
     dev->ud_arp_sockfd = -1;
     dev->ud_flags = 0;
     dev->ud_next_cq_grp_id = 1;     /* CQ group IDs start at 1 */
+    TAILQ_INIT(&dev->ud_pending_reqs);
+    TAILQ_INIT(&dev->ud_completed_reqs);
 
     /* Save pointer to IB device */
     dev->ud_ib_dev = idp;
@@ -310,7 +317,9 @@ usd_open_with_fd(
         }
     }
 
+    TAILQ_INSERT_TAIL(&usd_device_list, dev, ud_link);
     *dev_o = dev;
+
     return 0;
 
   out:

--- a/prov/usnic/src/usnic_direct/usnic_direct.h
+++ b/prov/usnic/src/usnic_direct/usnic_direct.h
@@ -469,7 +469,7 @@ int usd_create_dest_start(struct usd_device *dev, uint32_t daddr_be,
 /*
  * Cancel resolution on a not-yet-completed create_dest request
  */
-int usd_create_dest_cancel(void *context);
+int usd_create_dest_cancel(struct usd_device *dev, void *context);
 
 /*
  * Extract dest port and IP from a destination
@@ -486,7 +486,7 @@ int usd_expand_dest(struct usd_dest *dest, uint32_t *dest_ip_be_o,
  *    -EAGAIN - nothing is complete
  *    other - negative errno code
  */
-int usd_create_dest_query(void *context, int *status,
+int usd_create_dest_query(struct usd_device *dev, void *context, int *status,
         struct usd_dest **dest_o);
 
 /*
@@ -499,7 +499,7 @@ int usd_create_dest_query(void *context, int *status,
  *    -EAGAIN - nothing is complete
  *    other - negative errno code
  */
-int usd_create_dest_poll(void **context_o, int *status,
+int usd_create_dest_poll(struct usd_device *dev, void **context_o, int *status,
         struct usd_dest **dest_o);
 
 

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -604,18 +604,19 @@ ssize_t fi_no_tagged_search(struct fid_ep *ep, uint64_t *tag, uint64_t ignore,
  * fi_ops_av
  */
 int fi_no_av_insert(struct fid_av *av, const void *addr, size_t count,
-			fi_addr_t *fi_addr, uint64_t flags)
+			fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
 	return -FI_ENOSYS;
 }
 int fi_no_av_insertsvc(struct fid_av *av, const char *node,
-		const char *service, fi_addr_t *fi_addr, uint64_t flags)
+		const char *service, fi_addr_t *fi_addr, uint64_t flags,
+		void *context)
 {
 	return -FI_ENOSYS;
 }
 int fi_no_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
 			const char *service, size_t svccnt, fi_addr_t *fi_addr,
-			uint64_t flags)
+			uint64_t flags, void *context)
 {
 	return -FI_ENOSYS;
 }


### PR DESCRIPTION
- add and document FI_EVENT flag for fi_av_open
- add context fields to av_insert calls
- add fields to fi_eq_entry and fi_eq_err_entry for completion of
  vectored operations
- update man pages
- implement async insrt in usnic provider

Signed-off-by: Reese Faucette rfaucett@cisco.com
