### PR TITLE
fi_getinfo: multiple tx/rx attr in hints + mode

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -207,6 +207,7 @@ enum {
 
 struct fi_tx_ctx_attr {
 	uint64_t		caps;
+	uint64_t		mode;
 	uint64_t		op_flags;
 	uint64_t		msg_order;
 	size_t			inject_size;
@@ -217,6 +218,7 @@ struct fi_tx_ctx_attr {
 
 struct fi_rx_ctx_attr {
 	uint64_t		caps;
+	uint64_t		mode;
 	uint64_t		op_flags;
 	uint64_t		msg_order;
 	size_t			total_buffered_recv;
@@ -276,7 +278,9 @@ struct fi_info {
 	void			*dest_addr;
 	fi_connreq_t		connreq;
 	struct fi_tx_ctx_attr	*tx_attr;
+	size_t			tx_attr_cnt;
 	struct fi_rx_ctx_attr	*rx_attr;
+	size_t			rx_attr_cnt;
 	struct fi_ep_attr	*ep_attr;
 	struct fi_domain_attr	*domain_attr;
 	struct fi_fabric_attr	*fabric_attr;

--- a/man/fi_endpoint.3
+++ b/man/fi_endpoint.3
@@ -542,6 +542,7 @@ assigned to the context through the attr parameter, if provided.
 .nf
 struct fi_tx_ctx_attr {
 	uint64_t  caps;
+	uint64_t  mode;
 	uint64_t  op_flags;
 	uint64_t  msg_order;
 	size_t    inject_size;
@@ -551,9 +552,11 @@ struct fi_tx_ctx_attr {
 };
 .fi
 .IP "caps"
-The requested capabilities of the context.  The capabilities must be a
-subset of those requested of the associated endpoint.  See the
-CAPABILITIES section if fi_getinfo(3) for capability details.
+The requested capabilities of the context. See the
+CAPABILITIES section of fi_getinfo(3) for capability details.
+.IP "mode"
+The operational mode bits of the context. See the MODE section of
+fi_getinfo(3) for details.
 .IP "op_flags"
 Flags that control the operation of operations submitted against the
 context.  Applicable flags are listed in the Operation Flags section.
@@ -608,6 +611,7 @@ assigned to the context through the attr parameter, if provided.
 .nf
 struct fi_rx_ctx_attr {
 	uint64_t  caps;
+	uint64_t  mode;
 	uint64_t  op_flags;
 	uint64_t  msg_order;
 	size_t    total_buffered_recv;
@@ -617,9 +621,11 @@ struct fi_rx_ctx_attr {
 };
 .fi
 .IP "caps"
-The requested capabilities of the context.  The capabilities must be a
-subset of those requested of the associated endpoint.  See the
+The requested capabilities of the context. See the
 CAPABILITIES section if fi_getinfo(3) for capability details. 
+.IP "mode"
+The operational mode bits of the context. See the MODE section of
+fi_getinfo(3) for details.
 .IP "op_flags"
 Flags that control the operation of operations submitted against the
 context.  Applicable flags are listed in the Operation Flags section.

--- a/man/fi_getinfo.3
+++ b/man/fi_getinfo.3
@@ -80,7 +80,9 @@ struct fi_info {
 	void                  *dest_addr;
 	fi_connreq_t          connreq;
 	struct fi_tx_ctx_attr *tx_attr;
+	size_t                tx_attr_cnt;
 	struct fi_rx_ctx_attr *rx_attr;
+	size_t                rx_attr_cnt;
 	struct fi_ep_attr     *ep_attr;
 	struct fi_domain_attr *domain_attr;
 	struct fi_fabric_attr *fabric_attr;
@@ -130,14 +132,22 @@ Transmit context attributes may be specified and returned as part of
 fi_getinfo.  When provided as hints, requested values of struct fi_tx_ctx_attr
 should be set.  On output, the actual transmit context attributes that can
 be provided will be returned.  Output values will be greater than or
-or equal to the requested input values.
+or equal to the requested input values. See SCALABLE ENDPOINTS section in
+fi_endpoint(3) for more details.
+.IP "tx_attr_cnt - Count of transmit context attributes."
+When provided as hints, indicate the number of transmit attribute structures.
+Output values are unchanged from the input.
 .IP "rx_attr - receive context attributes"
 Optionally supplied receive context attributes.
 Receive context attributes may be specified and returned as part of
 fi_getinfo.  When provided as hints, requested values of struct fi_rx_ctx_attr
 should be set.  On output, the actual receive context attributes that can
 be provided will be returned.  Output values will be greater than or
-or equal to the requested input values.
+or equal to the requested input values. See SCALABLE ENDPOINTS section in
+fi_endpoint(3) for more details.
+.IP "tx_attr_cnt - Count of receive context attributes."
+When provided as hints, indicate the number of receive attributes.
+Output values are unchanged from the input.
 .IP "ep_attr - endpoint attributes"
 Optionally supplied endpoint attributes.
 Endpoint attributes may be specified and returned as part of fi_getinfo.

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -265,18 +265,20 @@ static struct fi_info *fi_dupinfo_internal(const struct fi_info *info)
 		memcpy(dup->dest_addr, info->dest_addr, info->dest_addrlen);
 	}
 	if (info->tx_attr != NULL) {
-		dup->tx_attr = malloc(sizeof(*dup->tx_attr));
+		dup->tx_attr = malloc(sizeof(*dup->tx_attr) * info->tx_attr_cnt);
 		if (dup->tx_attr == NULL) {
 			goto fail;
 		}
-		*dup->tx_attr = *info->tx_attr;
+		memcpy(dup->tx_attr, info->tx_attr,
+				sizeof(*dup->tx_attr) * info->tx_attr_cnt);
 	}
 	if (info->rx_attr != NULL) {
-		dup->rx_attr = malloc(sizeof(*dup->rx_attr));
+		dup->rx_attr = malloc(sizeof(*dup->rx_attr) * info->rx_attr_cnt);
 		if (dup->rx_attr == NULL) {
 			goto fail;
 		}
-		*dup->rx_attr = *info->rx_attr;
+		memcpy(dup->rx_attr, info->rx_attr,
+				sizeof(*dup->rx_attr) * info->rx_attr_cnt);
 	}
 	if (info->ep_attr != NULL) {
 		dup->ep_attr = malloc(sizeof(*dup->ep_attr));


### PR DESCRIPTION
Applications may want to use 'mode' with the scalable endpoint
contexts. For example, MPI RMA does not require object allocation
for Put/Get. MPI might desire not to use FI_CONTEXT if a provider
can support communication without it.

Also, most apps might know their context parameters up front since
they were written to exploit those capabilities.
Let apps provide an array of tx/rx attributes so that the provider
knows up front all the various types of tx/rx attributes that will
be created.

This simplifies things for the user as they don't have to learn
what constitutes a subset of capabilities. Things can get tricky
with some parameters like ordering - if base endpoint has FI_ORDER_WAW,
then is FI_ORDER_WAR a subset?

It also simplifies a provider's job that it knows that an arbitrary
subset of ctx capabilities will not be presented to it in the future.

There's also an assumption being made that the base endpoint have
a superset of functionalities as the transmit receive context.
Previously, it was required since the TX/RX contexts could be created
on the fly. Now, if the TX/RX contexts attributes are declared in
getinfo, then is that restriction required? i.e. can't we have a NULL
intersection of features/flags used for base endpoint and a transmit
context. It might increase flexibility for the user.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
