### PR TITLE
Clean up mutex abstraction and atomic getter-setters in fi.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,14 +104,19 @@ AC_CHECK_LIB(rt, clock_gettime, [],
     AC_MSG_ERROR([clock_gettime() not found.  libfabric requires librt.]))
 
 dnl Check for gcc atomic intrinsics
-AC_MSG_CHECKING(compiler support for atomics)
-AC_TRY_LINK([int i = 0;],
-    [ return __sync_add_and_fetch(&i, 1) != __sync_sub_and_fetch(&i, 1); ],
-    [ AC_MSG_RESULT(yes) ],
+AC_MSG_CHECKING(compiler support for c11 atomics)
+AC_TRY_LINK([#include <stdatomic.h>],
+    [#ifdef __STDC_NO_ATOMICS__
+       return 1;
+     #else
+       return 0;
+     #endif
+    ],
     [
-        AC_MSG_RESULT(no)
-        AC_DEFINE(DEFINE_ATOMICS, 1, [Set to 1 to implement atomics])
-    ])
+	AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_ATOMICS, 1, [Set to 1 to use c11 atomic functions])
+    ],
+    [AC_MSG_RESULT(no)])
 
 if test "$with_valgrind" != "" && test "$with_valgrind" != "no"; then
 AC_CHECK_HEADER(valgrind/memcheck.h, [],

--- a/prov/sockets/src/list.h
+++ b/prov/sockets/src/list.h
@@ -33,7 +33,7 @@
 #ifndef _LIST_H_
 #define _LIST_H_
 
-#include <pthread.h>
+#include "fi.h"
 
 typedef struct _list_t list_t;
 typedef struct _list_element_t
@@ -50,7 +50,7 @@ struct _list_t
 	list_element_t *free_head, *free_tail;
 	size_t curr_len;
 	size_t max_len;
-	pthread_mutex_t mutex;
+	fastlock_t lock;
 };
 
 list_t *new_list(size_t length);

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -246,7 +246,7 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		return ret;
 #endif
 
-	atomic_init(&_av->ref);
+	atomic_init0(&_av->ref);
 	atomic_inc(&dom->ref);
 	_av->dom = dom;
 	_av->attr = *attr;

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -142,7 +142,7 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	if (ret)
 		goto err2;
 
-	atomic_init(&_cntr->ref);
+	atomic_init0(&_cntr->ref);
 	_cntr->cntr_fid.fid.fclass = FI_CLASS_CNTR;
 	_cntr->cntr_fid.fid.context = context;
 	_cntr->cntr_fid.fid.ops = &sock_cntr_fi_ops;

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -477,7 +477,7 @@ int sock_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (!sock_cq)
 		return -FI_ENOMEM;
 
-	atomic_init(&sock_cq->ref);
+	atomic_init0(&sock_cq->ref);
 	sock_cq->cq_fid.fid.fclass = FI_CLASS_CQ;
 	sock_cq->cq_fid.fid.context = context;
 	sock_cq->cq_fid.fid.ops = &sock_cq_fi_ops;

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -297,7 +297,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_ENOMEM;
 	
 	fastlock_init(&sock_domain->lock);
-	atomic_init(&sock_domain->ref);
+	atomic_init0(&sock_domain->ref);
 
 	sock_domain->dom_fid.fid.fclass = FI_CLASS_DOMAIN;
 	sock_domain->dom_fid.fid.context = context;

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -408,8 +408,8 @@ usdf_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	av->av_flags = attr->flags;
 	pthread_spin_init(&av->av_lock, PTHREAD_PROCESS_PRIVATE);
 
-	atomic_init(&av->av_refcnt);
-	atomic_init(&av->av_active_inserts);
+	atomic_init0(&av->av_active_inserts);
+	atomic_init0(&av->av_refcnt);
 	atomic_inc(&udp->dom_refcnt);
 	av->av_domain = udp;
 

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -146,7 +146,7 @@ usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	udp->dom_fabric = fab;
 	pthread_spin_init(&udp->dom_usd_lock, PTHREAD_PROCESS_PRIVATE);
-	atomic_init(&udp->dom_refcnt);
+	atomic_init0(&udp->dom_refcnt);
 	atomic_inc(&fab->fab_refcnt);
 
 	*domain = &udp->dom_fid;

--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -521,7 +521,7 @@ usdf_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	eq->eq_wait_obj = attr->wait_obj;
 
 	eq->eq_fabric = fab;
-	atomic_init(&eq->eq_refcnt);
+	atomic_init0(&eq->eq_refcnt);
 	ret = pthread_spin_init(&eq->eq_lock, PTHREAD_PROCESS_PRIVATE);
 	if (ret != 0) {
 		ret = -ret;
@@ -577,7 +577,7 @@ usdf_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	eq->eq_ev_tail = eq->eq_ev_ring;
 	eq->eq_ev_ring_size = attr->size;
 	eq->eq_ev_end = eq->eq_ev_ring + eq->eq_ev_ring_size;
-	atomic_init(&eq->eq_num_events);
+	atomic_init0(&eq->eq_num_events);
 
 	atomic_inc(&eq->eq_fabric->fab_refcnt);
 	*feq = eq_utof(eq);

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -392,7 +392,7 @@ usdf_fabric_open(struct fi_fabric_attr *fattrp, struct fid_fabric **fabric,
 	fp->fab_fid.fid.ops = &usdf_fi_ops;
 	fp->fab_fid.ops = &usdf_ops_fabric;
 
-	atomic_init(&fp->fab_refcnt);
+	atomic_init0(&fp->fab_refcnt);
 	*fabric = &fp->fab_fid;
 	return 0;
 


### PR DESCRIPTION
The snippet in configure.ac which checked for intrinsics was incorrectly always
failing so the atomic gcc intrinsics have never been compiled. Additionally this set
is deprecated as of GCC 4.7 which introduced a new set of intrinsics. Replace them
with test for the new c11 intrinsics + implementation, tested on gcc 4.9.1.

Replaced the semaphore implementation of a mutex with a plain old pthread mutex.
semaphore.h is part of posix/libc, just like pthreads which we require
explicitly-- so just use that.

Allow the mutex to be compile-time selected as either a mutex or a spinlock.

Signed-off-by: pmmccorm patrick.m.mccormick@intel.com
