### PR TITLE
fabric: Clean up mutex abstraction and atomic getter-setters in fi.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -104,14 +104,19 @@ AC_CHECK_LIB(rt, clock_gettime, [],
     AC_MSG_ERROR([clock_gettime() not found.  libfabric requires librt.]))
 
 dnl Check for gcc atomic intrinsics
-AC_MSG_CHECKING(compiler support for atomics)
-AC_TRY_LINK([int i = 0;],
-    [ return __sync_add_and_fetch(&i, 1) != __sync_sub_and_fetch(&i, 1); ],
-    [ AC_MSG_RESULT(yes) ],
+AC_MSG_CHECKING(compiler support for c11 atomics)
+AC_TRY_LINK([#include <stdatomic.h>],
+    [#ifdef __STDC_NO_ATOMICS__
+       return 1;
+     #else
+       return 0;
+     #endif
+    ],
     [
-        AC_MSG_RESULT(no)
-        AC_DEFINE(DEFINE_ATOMICS, 1, [Set to 1 to implement atomics])
-    ])
+	AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_ATOMICS, 1, [Set to 1 to use c11 atomic functions])
+    ],
+    [AC_MSG_RESULT(no)])
 
 if test "$with_valgrind" != "" && test "$with_valgrind" != "no"; then
 AC_CHECK_HEADER(valgrind/memcheck.h, [],

--- a/include/fi.h
+++ b/include/fi.h
@@ -40,12 +40,15 @@
 #include <string.h>
 #include <byteswap.h>
 #include <endian.h>
-#include <semaphore.h>
+#include <pthread.h>
 #include <string.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_prov.h>
 #include <rdma/fi_atomic.h>
 
+#ifdef HAVE_ATOMICS
+#  include <stdatomic.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,70 +87,95 @@ static inline uint64_t roundup_power_of_two(uint64_t n)
 
 #define FI_TAG_GENERIC	0xAAAAAAAAAAAAAAAAULL
 
-#if DEFINE_ATOMICS
+
+#if defined(PT_LOCK_SPIN)
+
+#define fastlock_t pthread_spinlock_t
+#define fastlock_init(lock) pthread_spin_init(lock, PTHREAD_PROCESS_PRIVATE)
+#define fastlock_destroy(lock) pthread_spin_destroy(lock)
+#define fastlock_acquire(lock) pthread_spin_lock(lock)
+#define fastlock_release(lock) pthread_spin_unlock(lock)
+
+#else
+
 #define fastlock_t pthread_mutex_t
 #define fastlock_init(lock) pthread_mutex_init(lock, NULL)
 #define fastlock_destroy(lock) pthread_mutex_destroy(lock)
 #define fastlock_acquire(lock) pthread_mutex_lock(lock)
 #define fastlock_release(lock) pthread_mutex_unlock(lock)
 
-typedef struct { pthread_mutex_t mut; int val; } atomic_t;
+#endif /* PT_LOCK_SPIN */
+
+
+#ifdef HAVE_ATOMICS
+typedef _Atomic int atomic_t;
+
+static inline int atomic_inc(atomic_t *atomic)
+{
+	return atomic_fetch_add_explicit(atomic, 1, memory_order_acq_rel) + 1;
+}
+
+static inline int atomic_dec(atomic_t *atomic)
+{
+	return atomic_fetch_sub_explicit(atomic, 1, memory_order_acq_rel) - 1;
+}
+
+static inline int atomic_set(atomic_t *atomic, int value)
+{
+	atomic_store(atomic, value);
+	return value;
+}
+
+static inline int atomic_get(atomic_t *atomic)
+{
+	return *atomic;
+}
+
+#else
+
+typedef struct { fastlock_t lock; int val; } atomic_t;
+
 static inline int atomic_inc(atomic_t *atomic)
 {
 	int v;
 
-	pthread_mutex_lock(&atomic->mut);
+	fastlock_acquire(&atomic->lock);
 	v = ++(atomic->val);
-	pthread_mutex_unlock(&atomic->mut);
+	fastlock_release(&atomic->lock);
 	return v;
 }
+
 static inline int atomic_dec(atomic_t *atomic)
 {
 	int v;
 
-	pthread_mutex_lock(&atomic->mut);
+	fastlock_acquire(&atomic->lock);
 	v = --(atomic->val);
-	pthread_mutex_unlock(&atomic->mut);
+	fastlock_release(&atomic->lock);
 	return v;
 }
-static inline void atomic_init(atomic_t *atomic)
+
+static inline int atomic_set(atomic_t *atomic, int value)
 {
-	pthread_mutex_init(&atomic->mut, NULL);
-	atomic->val = 0;
-}
-#else
-typedef struct {
-	sem_t sem;
-	volatile int cnt;
-} fastlock_t;
-static inline void fastlock_init(fastlock_t *lock)
-{
-	sem_init(&lock->sem, 0, 0);
-	lock->cnt = 0;
-}
-static inline void fastlock_destroy(fastlock_t *lock)
-{
-	sem_destroy(&lock->sem);
-}
-static inline void fastlock_acquire(fastlock_t *lock)
-{
-	if (__sync_add_and_fetch(&lock->cnt, 1) > 1)
-		sem_wait(&lock->sem);
-}
-static inline void fastlock_release(fastlock_t *lock)
-{
-	if (__sync_sub_and_fetch(&lock->cnt, 1) > 0)
-		sem_post(&lock->sem);
+	fastlock_acquire(&atomic->lock);
+	atomic->val = value;
+	fastlock_release(&atomic->lock);
+	return value;
 }
 
-typedef struct { volatile int val; } atomic_t;
-#define atomic_inc(v) (__sync_add_and_fetch(&(v)->val, 1))
-#define atomic_dec(v) (__sync_sub_and_fetch(&(v)->val, 1))
-#define atomic_init(v) ((v)->val = 0)
-#endif /* DEFINE_ATOMICS */
+static inline void atomic_init(atomic_t *atomic, int value)
+{
+	fastlock_init(&atomic->lock);
+	atomic->val = value;
+}
 
-#define atomic_get(v) ((v)->val)
-#define atomic_set(v, s) ((v)->val = s)
+static inline int atomic_get(atomic_t *atomic)
+{
+	return atomic->val;
+}
+
+#endif // HAVE_ATOMICS
+
 
 /* non exported symbols */
 int fi_init(void);

--- a/prov/sockets/src/list.h
+++ b/prov/sockets/src/list.h
@@ -33,7 +33,7 @@
 #ifndef _LIST_H_
 #define _LIST_H_
 
-#include <pthread.h>
+#include "fi.h"
 
 typedef struct _list_t list_t;
 typedef struct _list_element_t
@@ -50,7 +50,7 @@ struct _list_t
 	list_element_t *free_head, *free_tail;
 	size_t curr_len;
 	size_t max_len;
-	pthread_mutex_t mutex;
+	fastlock_t lock;
 };
 
 list_t *new_list(size_t length);

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -246,7 +246,7 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		return ret;
 #endif
 
-	atomic_init(&_av->ref);
+	atomic_init(&_av->ref, 0);
 	atomic_inc(&dom->ref);
 	_av->dom = dom;
 	_av->attr = *attr;

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -142,7 +142,7 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	if (ret)
 		goto err2;
 
-	atomic_init(&_cntr->ref);
+	atomic_init(&_cntr->ref, 0);
 	_cntr->cntr_fid.fid.fclass = FI_CLASS_CNTR;
 	_cntr->cntr_fid.fid.context = context;
 	_cntr->cntr_fid.fid.ops = &sock_cntr_fi_ops;

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -477,7 +477,7 @@ int sock_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (!sock_cq)
 		return -FI_ENOMEM;
 
-	atomic_init(&sock_cq->ref);
+	atomic_init(&sock_cq->ref, 0);
 	sock_cq->cq_fid.fid.fclass = FI_CLASS_CQ;
 	sock_cq->cq_fid.fid.context = context;
 	sock_cq->cq_fid.fid.ops = &sock_cq_fi_ops;

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -297,7 +297,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_ENOMEM;
 	
 	fastlock_init(&sock_domain->lock);
-	atomic_init(&sock_domain->ref);
+	atomic_init(&sock_domain->ref, 0);
 
 	sock_domain->dom_fid.fid.fclass = FI_CLASS_DOMAIN;
 	sock_domain->dom_fid.fid.context = context;

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -193,8 +193,8 @@ usdf_am_insert(struct fid_av *fav, const void *addr, size_t count,
 		}
 		insert->avi_av = av;
 		insert->avi_pending_ops = count;
-		atomic_init(&insert->avi_completed_ops);
-		atomic_init(&insert->avi_successful_ops);
+		atomic_init(&insert->avi_completed_ops, 0);
+		atomic_init(&insert->avi_successful_ops, 0);
 		insert->avi_context = context;
 
 		/* If no addresses, complete now */
@@ -408,8 +408,8 @@ usdf_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	av->av_flags = attr->flags;
 	pthread_spin_init(&av->av_lock, PTHREAD_PROCESS_PRIVATE);
 
-	atomic_init(&av->av_refcnt);
-	atomic_init(&av->av_active_inserts);
+	atomic_init(&av->av_active_inserts, 0);
+	atomic_init(&av->av_refcnt, 0);
 	atomic_inc(&udp->dom_refcnt);
 	av->av_domain = udp;
 

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -142,11 +142,11 @@ usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		ret = -ret;
 		goto fail;
 	}
-	atomic_init(&udp->dom_pending_items);
+	atomic_init(&udp->dom_pending_items, 0);
 
 	udp->dom_fabric = fab;
 	pthread_spin_init(&udp->dom_usd_lock, PTHREAD_PROCESS_PRIVATE);
-	atomic_init(&udp->dom_refcnt);
+	atomic_init(&udp->dom_refcnt, 0);
 	atomic_inc(&fab->fab_refcnt);
 
 	*domain = &udp->dom_fid;

--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -521,7 +521,7 @@ usdf_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	eq->eq_wait_obj = attr->wait_obj;
 
 	eq->eq_fabric = fab;
-	atomic_init(&eq->eq_refcnt);
+	atomic_init(&eq->eq_refcnt, 0);
 	ret = pthread_spin_init(&eq->eq_lock, PTHREAD_PROCESS_PRIVATE);
 	if (ret != 0) {
 		ret = -ret;
@@ -577,7 +577,7 @@ usdf_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	eq->eq_ev_tail = eq->eq_ev_ring;
 	eq->eq_ev_ring_size = attr->size;
 	eq->eq_ev_end = eq->eq_ev_ring + eq->eq_ev_ring_size;
-	atomic_init(&eq->eq_num_events);
+	atomic_init(&eq->eq_num_events, 0);
 
 	atomic_inc(&eq->eq_fabric->fab_refcnt);
 	*feq = eq_utof(eq);

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -392,7 +392,7 @@ usdf_fabric_open(struct fi_fabric_attr *fattrp, struct fid_fabric **fabric,
 	fp->fab_fid.fid.ops = &usdf_fi_ops;
 	fp->fab_fid.ops = &usdf_ops_fabric;
 
-	atomic_init(&fp->fab_refcnt);
+	atomic_init(&fp->fab_refcnt, 0);
 	*fabric = &fp->fab_fid;
 	return 0;
 


### PR DESCRIPTION
The snippet in configure.ac which checked for intrinsics was
always failing so the atomic gcc intrinsics have never been
compiled. Additionally this set is deprecated as of GCC 4.7
which introduced a new set of intrinsics. Replace them
with test for the new c11 intrinsics + implementation,
tested on gcc 4.9.1.

Replaced the semaphore implementation of a mutex with a plain
old pthread mutex.  semaphore.h is part of posix/libc, just
like pthreads which we require explicitly-- so just use that.

Allow the mutex to be compile-time selected as either a mutex or a spinlock.

Signed-off-by: pmmccorm patrick.m.mccormick@intel.com
Signed-off-by: Sean Hefty sean.hefty@intel.com
