### PR TITLE
usnic provider: suppress unused var warning

### DIFF
--- a/prov/usnic/src/usnic_direct/libnl_utils_common.c
+++ b/prov/usnic/src/usnic_direct/libnl_utils_common.c
@@ -251,6 +251,7 @@ int usnic_nl_rt_lookup(uint32_t src_addr, uint32_t dst_addr, int oif,
 	struct usnic_rt_cb_arg	arg;
 	int			err;
 
+	unlsk = NULL;
 	err = usnic_nl_sk_alloc(&unlsk, NETLINK_ROUTE);
 	if (err)
 		return err;


### PR DESCRIPTION
Fixes #265

Signed-off-by: Reese Faucette rfaucett@cisco.com
