### PR TITLE
fi_info - some enums named, some are not

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -140,7 +140,7 @@ struct fi_ioc {
 /*
  * Format for transport addresses: sendto, writeto, etc.
  */
-enum {
+enum fi_addr_format {
 	FI_ADDR_UNSPEC,		/* void * */
 	FI_SOCKADDR,		/* struct sockaddr */
 	FI_SOCKADDR_IN,		/* struct sockaddr_in */
@@ -188,7 +188,7 @@ enum fi_ep_type {
  * If two providers support the same protocol, then they shall interoperate
  * when the protocol capabilities match.
  */
-enum {
+enum fi_protocol {
 	FI_PROTO_UNSPEC,
 	FI_PROTO_RDMA_CM_IB_RC,
 	FI_PROTO_IWARP,
@@ -226,7 +226,7 @@ struct fi_rx_ctx_attr {
 };
 
 struct fi_ep_attr {
-	uint32_t		protocol;
+	enum fi_protocol	protocol;
 	size_t			max_msg_size;
 	size_t			inject_size;
 	size_t			total_buffered_recv;
@@ -269,7 +269,7 @@ struct fi_info {
 	uint64_t		caps;
 	uint64_t		mode;
 	enum fi_ep_type		ep_type;
-	uint32_t		addr_format;
+	enum fi_addr_format	addr_format;
 	size_t			src_addrlen;
 	size_t			dest_addrlen;
 	void			*src_addr;

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -419,7 +419,6 @@ char *fi_tostr_(const void *data, enum fi_type datatype)
 {
 	static __thread char *buf;
 	uint64_t val64 = *(const uint64_t *) data;
-	uint32_t val32 = *(const uint32_t *) data;
 	int enumval = *(const int *) data;
 
 	if (!data)
@@ -447,7 +446,7 @@ char *fi_tostr_(const void *data, enum fi_type datatype)
 		fi_tostr_flags(buf, val64);
 		break;
 	case FI_TYPE_ADDR_FORMAT:
-		fi_tostr_addr_format(buf, val32);
+		fi_tostr_addr_format(buf, enumval);
 		break;
 	case FI_TYPE_TX_ATTR:
 		fi_tostr_tx_attr(buf, data, "");
@@ -471,7 +470,7 @@ char *fi_tostr_(const void *data, enum fi_type datatype)
 		fi_tostr_progress(buf, enumval);
 		break;
 	case FI_TYPE_PROTOCOL:
-		fi_tostr_protocol(buf, val64);
+		fi_tostr_protocol(buf, enumval);
 		break;
 	case FI_TYPE_MSG_ORDER:
 		fi_tostr_order(buf, val64);


### PR DESCRIPTION
Add names to protocol and address format enums, and update fi_tostr to
use enumval.  removed now-unused "val32" from fi_tostr

Signed-off-by: Reese Faucette rfaucett@cisco.com

unless there is some reason these enums are treated differently, in  which case the size for "protocol" in fi_tostr still needs to be changed.  is currently treated as val64 but fi_ep_attr::protocol is uint32_t
