### PR TITLE
fi_dupinfo - jumping to fail with dup = NULL is bug, so much for

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -238,7 +238,7 @@ static struct fi_info *fi_dupinfo_internal(const struct fi_info *info)
 
 	dup = malloc(sizeof(*dup));
 	if (dup == NULL) {
-		goto fail;
+		return NULL;
 	}
 	*dup = *info;
 	dup->src_addr = NULL;


### PR DESCRIPTION
"future-proofing" !!

Signed-off-by: Reese Faucette rfaucett@cisco.com
