### PR TITLE
fi_av_insert in async mode with no EQ specified should return -FI_ENOEQ,

### DIFF
--- a/man/fi_av.3
+++ b/man/fi_av.3
@@ -196,7 +196,7 @@ field in the final completion entry will report the number of addresses
 successfully inserted.
 .sp
 If an AV is opened with FI_EVENT, any insertions attempted before an EQ
-is bound to the AV will fail with -FI_EINVAL.
+is bound to the AV will fail with -FI_ENOEQ.
 .sp
 Error completions for failed insertions will contain the index of the failed
 address in the index field of the error completion entry.

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -182,7 +182,7 @@ usdf_am_insert(struct fid_av *fav, const void *addr, size_t count,
 
 	if (av->av_flags & FI_EVENT) {
 		if (av->av_eq == NULL) {
-			return -FI_EINVAL;
+			return -FI_ENOEQ;
 		}
 		udp = av->av_domain;
 


### PR DESCRIPTION
not -FI_EINVAL

Signed-off-by: Reese Faucette rfaucett@cisco.com
