### PR TITLE
fi_ep_bind: call fi_bind with correct field

### DIFF
--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -153,7 +153,10 @@ fi_endpoint(struct fid_domain *domain, struct fi_info *info,
 	return domain->ops->endpoint(domain, info, ep, context);
 }
 
-#define fi_ep_bind(ep, fid, flags) fi_bind(ep, fid, flags)
+static inline int fi_ep_bind(struct fid_ep *ep, struct fid *bfid, uint64_t flags)
+{
+	return ep->fid.ops->bind(&ep->fid, bfid, flags);
+}
 
 static inline int fi_enable(struct fid_ep *ep)
 {

--- a/man/fi_endpoint.3
+++ b/man/fi_endpoint.3
@@ -59,7 +59,7 @@ Get or set endpoint options.
 .BI "int fi_close(struct fid *" ep ");"
 .PP
 .HP
-.BI "int fi_ep_bind(struct fid *" ep ", struct fid *" fid ", uint64_t " flags ");"
+.BI "int fi_ep_bind(struct fid_ep *" ep ", struct fid *" fid ", uint64_t " flags ");"
 .PP
 .HP
 .BI "int fi_enable(struct fid_ep *" ep ");"


### PR DESCRIPTION
Manpage says that fi_ep_bind has the following signature:

int fi_ep_bind(struct fid *ep, struct fid *fid, uint64_t flags);

and fi_bind has the following signature:

int fi_bind(struct fid *fid, struct fid *bfid, uint64_t flags);

The macro fi_ep_bind was passing the incorrect type to fi_bind
resulting in compiler warnings.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
