### PR TITLE
fi_tostr has wrong size for protocol

### DIFF
--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -471,7 +471,7 @@ char *fi_tostr_(const void *data, enum fi_type datatype)
 		fi_tostr_progress(buf, enumval);
 		break;
 	case FI_TYPE_PROTOCOL:
-		fi_tostr_protocol(buf, val64);
+		fi_tostr_protocol(buf, val32);
 		break;
 	case FI_TYPE_MSG_ORDER:
 		fi_tostr_order(buf, val64);


### PR DESCRIPTION
Is val64, should be val32 as fi_ep_attr::protocol is uint32_t

Signed-off-by: Reese Faucette rfaucett@cisco.com
