### PR TITLE
Makefile: install fi_direct_eq.h with HAVE_DIRECT

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -230,7 +230,8 @@ nodist_rdmainclude_HEADERS = \
 	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_rma.h \
 	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_atomic_def.h \
 	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_atomic.h \
-	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_cm.h
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_cm.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_eq.h
 endif HAVE_DIRECT
 
 man_MANS = \


### PR DESCRIPTION
fi_direct_eq.h should also be installed when HAVE_DIRECT is
enabled.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
