### PR TITLE
usdf_getinfo: prevent double-call to freeaddrinfo()

### DIFF
--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -322,23 +322,19 @@ next_dev:
 		usd_close(dev);
 		dev = NULL;
 	}
-	if (ai != NULL) {
-		freeaddrinfo(ai);
-	}
 
 	if (fi_first != NULL) {
 		*info = fi_first;
-		return 0;
+		ret = 0;
 	} else {
 		ret = -FI_ENODATA;
-		goto fail;
 	}
 
 fail:
 	if (dev != NULL) {
 		usd_close(dev);
 	}
-	if (fi_first != NULL) {
+	if (fi_first != NULL && ret != 0) {
 		fi_freeinfo(fi_first);
 	}
 	if (ai != NULL) {


### PR DESCRIPTION
Should repair #270
Signed-off-by: Reese Faucette rfaucett@cisco.com
