### PR TITLE
fi_info: add prov_info

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -280,6 +280,8 @@ struct fi_info {
 	struct fi_ep_attr	*ep_attr;
 	struct fi_domain_attr	*domain_attr;
 	struct fi_fabric_attr	*fabric_attr;
+	void			*prov_info;
+	size_t			prov_info_len;
 };
 
 enum {

--- a/src/common.c
+++ b/src/common.c
@@ -133,6 +133,7 @@ void fi_freeinfo_internal(struct fi_info *info)
 		free(info->fabric_attr->prov_name);
 		free(info->fabric_attr);
 	}
+	free(info->prov_info);
 	free(info);
 }
 uint64_t fi_tag_bits(uint64_t mem_tag_format)

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -248,6 +248,7 @@ static struct fi_info *fi_dupinfo_internal(const struct fi_info *info)
 	dup->ep_attr = NULL;
 	dup->domain_attr = NULL;
 	dup->fabric_attr = NULL;
+	dup->prov_info = NULL;
 	dup->next = NULL;
 
 	if (info->src_addr != NULL) {
@@ -319,6 +320,13 @@ static struct fi_info *fi_dupinfo_internal(const struct fi_info *info)
 				goto fail;
 			}
 		}
+	}
+	if (info->prov_info != NULL && info->prov_info_len > 0) {
+		dup->prov_info = malloc(info->prov_info_len);
+		if (dup->prov_info == NULL) {
+			goto fail;
+		}
+		memcpy(dup->prov_info, info->prov_info, info->prov_info_len);
 	}
 	return dup;
 


### PR DESCRIPTION
Add prov_info to allow provider to return provider-specific information.
Could theoretically also be used as hint information by provider-aware
apps.

Signed-off-by: Reese Faucette rfaucett@cisco.com
