### PR TITLE
Fix ringbuffer sread()

### DIFF
--- a/include/fi_rbuf.h
+++ b/include/fi_rbuf.h
@@ -261,7 +261,7 @@ static inline size_t rbfdsread(struct ringbuffd *rbfd, void *buf, size_t len,
 	int ret;
 
 	do {
-		avail = rbfdavail(rbfd);
+		avail = rbfdused(rbfd);
 		if (avail) {
 			len = MIN(len, avail);
 			rbfdread(rbfd, buf, len);


### PR DESCRIPTION
```
- Use rbused() instead of rbavail() for correctness
```

Signed-off-by: Jithin Jose jithin.jose@intel.com
