### PR TITLE
fi_trigger: direct include for trigger context

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -231,7 +231,8 @@ nodist_rdmainclude_HEADERS = \
 	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_atomic_def.h \
 	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_atomic.h \
 	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_cm.h \
-	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_eq.h
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_eq.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_trigger.h
 endif HAVE_DIRECT
 
 man_MANS = \

--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -51,6 +51,8 @@ struct fi_trigger_threshold {
 	size_t			threshold;
 };
 
+#ifndef FABRIC_DIRECT
+
 /* Size must match struct fi_context */
 struct fi_triggered_context {
 	enum fi_trigger_event	event_type;
@@ -59,6 +61,10 @@ struct fi_triggered_context {
 		void				*internal[3];
 	};
 };
+
+#else // FABRIC_DIRECT
+#include <rdma/fi_direct_trigger.h>
+#endif
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
The trigger context can be overriden by the provider in
with --enable-direct, similar to fi_context.

Install fi_direct_trigger.h file.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
