### PR TITLE
man: choose default value of CQ size

### DIFF
--- a/man/fi_cq.3
+++ b/man/fi_cq.3
@@ -126,7 +126,8 @@ struct fi_cq_attr {
 };
 .fi
 .IP "size"
-Specifies the minimum size of an event queue.
+Specifies the minimum size of an event queue. A value of 0 indicates that
+the provider may choose a default value.
 .IP "flags"
 Flags that control the configuration of the CQ.
 .RS


### PR DESCRIPTION
Apps wanting to just pick a default value of CQ size
can pass in '0' as the size, and let the provider pick
a sensible value.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
