### PR TITLE
man: Fix misspelled words in man pages

### DIFF
--- a/man/fi_av.3
+++ b/man/fi_av.3
@@ -70,7 +70,7 @@ Event queue
 .IP "attr"
 Address vector attributes
 .IP "context"
-User specified context associated with the address vector or insert opertion.
+User specified context associated with the address vector or insert operation.
 .IP "addr"
 Buffer containing one or more addresses to insert into address vector.
 .IP "addrlen"
@@ -206,7 +206,7 @@ address in the index field of the error completion entry.
 .sp
 Note that the order of delivery of insert completions may not match
 the order in which the calls to fi_av_insert were made.  The only guarantee
-is that all error completions for a given call to fi_av_insert will preceed
+is that all error completions for a given call to fi_av_insert will precede
 the single associated non-error completion.
 .IP "FI_READ"
 Opens an AV for read-only access.  An AV opened for read-only access

--- a/man/fi_eq.3
+++ b/man/fi_eq.3
@@ -84,7 +84,7 @@ Provider specific error value
 .IP "err_data"
 Provider specific error data related to a completion
 .IP "timeout"
-Timeout specified in miliseconds
+Timeout specified in milliseconds
 .SH "DESCRIPTION"
 Event queues are used to report events associated with control operations.
 They are associated with memory registration, address vectors, connection

--- a/man/fi_getinfo.3
+++ b/man/fi_getinfo.3
@@ -459,7 +459,7 @@ defined in
 .IR "rdma/fi_errno.h".
 .sp
 fi_dupinfo() duplicates a single fi_info structure and all the substructures
-within it and returns a pointer to the new fi_info strutcure.  This new fi_info
+within it and returns a pointer to the new fi_info structure.  This new fi_info
 structure must be freed via fi_freeinfo().  fi_dupinfo() returns NULL on error.
 .SH "ERRORS"
 .IP "FI_EBADFLAGS"

--- a/man/fi_mr.3
+++ b/man/fi_mr.3
@@ -108,7 +108,7 @@ Providers that lack this capability require that registered memory
 regions be backed by allocated memory pages.
 .PP
 The attributes of a registered memory region may be specified by either
-the provider or, if supported, the application.  Relevent attributes include
+the provider or, if supported, the application.  Relevant attributes include
 the MR key associated with the region and the address (offset) used by
 peer applications when accessing the region through RMA or atomic operations.
 The FI_PROV_MR_ATTR mode bit indicates if the provider will supply these


### PR DESCRIPTION
Signed-off-by: Sean Hefty sean.hefty@intel.com
