### PR TITLE
prov/usnic: ARP lookup on incorrect address

### DIFF
--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -273,7 +273,6 @@ usdf_am_insert_async(struct fid_av *fav, const void *addr, size_t count,
 			}
 
 		} else {
-			req->avr_daddr_be = sin->sin_addr.s_addr;
 			req->avr_dest = calloc(1, sizeof(*req->avr_dest));
 			if (req->avr_dest == NULL) {
 				ret = -FI_ENOMEM;


### PR DESCRIPTION
Incorrect address passed to arp_lookup when target is not local subnet

Signed-off-by: Reese Faucette rfaucett@cisco.com
