### PR TITLE
Clean up configure output, don't do unused checks.

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -77,16 +77,14 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 		[PROVIDERS_TO_BUILD="$PROVIDERS_TO_BUILD $1"
 		 PROVIDERS_COUNT=$((PROVIDERS_COUNT+1))
 		 AS_IF([test $$1_dl -eq 1],
-			[AC_MSG_NOTICE([$1 provider to be built as a DSO])
-			 PROVIDERS_DL="prov/$1/lib$1.la $PROVIDERS_DL"
+			[PROVIDERS_DL="prov/$1/lib$1.la $PROVIDERS_DL"
 			 AS_IF([test x"$enable_static" = x"yes" &&
 				test x"$enable_shared" = x"no"],
 				[AC_MSG_WARN([$1 provider was selected to be built as DL])
 				 AC_MSG_WARN([but libfabric is being built as static-only])
 				 AC_MSG_ERROR([This is an impossible situation. Cannot continue.])])
 			],
-			[AC_MSG_NOTICE([$1 provider to be built statically])
-			 PROVIDERS_STATIC="prov/$1/lib$1.la $PROVIDERS_STATIC"])
+			[PROVIDERS_STATIC="prov/$1/lib$1.la $PROVIDERS_STATIC"])
 		],
 		[AC_MSG_NOTICE([$1 provider disabled])])
 

--- a/configure.ac
+++ b/configure.ac
@@ -49,42 +49,11 @@ AC_PROG_CC
 dnl Checks for header files.
 AC_HEADER_STDC
 
-dnl Checks for typedefs, structures, and compiler characteristics.
-AC_C_CONST
-AC_CHECK_SIZEOF(long)
-
 dnl Only build on Linux
 AC_CHECK_HEADER([linux/types.h], [],
 	[AC_MSG_ERROR([libfabric only builds on Linux])])
 
 LT_INIT
-
-AC_CHECK_HEADERS([fcntl.h sys/socket.h])
-AC_CHECK_DECLS([O_CLOEXEC],,[AC_DEFINE([O_CLOEXEC],[0],
-	[Defined to 0 if not provided])],
-	[[
-		#ifdef HAVE_FCNTL_H
-		#include <fcntl.h>
-		#endif
-	]])
-
-AC_CHECK_DECLS([SOCK_CLOEXEC],,[AC_DEFINE([SOCK_CLOEXEC],[0],
-	[Defined to 0 if not provided])],
-	[[
-		#ifdef HAVE_SYS_SOCKET_H
-		#include <sys/socket.h>
-		#endif
-	]])
-
-AC_CACHE_CHECK(for close on exec modifier for fopen(),
-	ac_cv_feature_stream_cloexec_flag,
-	[if test $ac_cv_have_decl_O_CLOEXEC = yes ; then
-		if test $ac_cv_have_decl_SOCK_CLOEXEC = yes ; then
-			ac_cv_feature_stream_cloexec_flag="e"
-		fi
-	fi])
-AC_DEFINE_UNQUOTED([STREAM_CLOEXEC], "$ac_cv_feature_stream_cloexec_flag",
-	[fopen() modifier for setting close on exec flag])
 
 dnl dlopen support is optional
 AC_ARG_WITH([dlopen],
@@ -161,11 +130,6 @@ FI_PROVIDER_SETUP([verbs])
 FI_PROVIDER_SETUP([usnic])
 FI_PROVIDER_FINI
 
-# Make sure at least one provider was setup
-AS_IF([test x"$PROVIDERS_TO_BUILD" = "x"],
-      [AC_MSG_NOTICE([No providers were configured])
-       AC_MSG_ERROR([Cannot continue])])
-
 # If the user requested to build in direct mode, but
 # we have more than one provider, error.
 AS_IF([test x"$enable_direct" != x"no"],
@@ -178,3 +142,30 @@ AM_CONDITIONAL([HAVE_DIRECT], [test x"$enable_direct" != x"no"])
 
 AC_CONFIG_FILES([Makefile libfabric.spec])
 AC_OUTPUT
+
+dnl helpful output
+if test "$PROVIDERS_TO_BUILD" = ""; then
+	echo "***"
+	echo "*** No providers were configured. This may not be what you wanted."
+	echo "***"
+	exit 1
+fi
+
+echo "***"
+for i in $PROVIDERS_TO_BUILD; do
+	v=${i}_dl
+	if test `eval echo \\$${v}` != "1"; then
+		builtin="$i ${builtin}"
+	fi
+done
+echo -e "*** Built-in providers:\t${builtin}"
+echo "***"
+
+for i in $PROVIDERS_TO_BUILD; do
+	v=${i}_dl
+	if test `eval echo \\$${v}` == "1"; then
+		dso="$i ${dso}"
+	fi
+done
+echo -e "*** DSO providers:\t${dso}"
+echo "***"


### PR DESCRIPTION
Remove unused checks: *_CLOEXEC, AC_C_CONST, sizeof long.
Print which providers and how they are built after configure runs, don't error when no provider
is built: libfabric.so could be used with only out-of-tree providers. Print a big warning instead
and return 1. Output at end of configure looks like:

```
...
checking for linux/netlink.h... yes
checking for nl_connect in -lnl... no
configure: usnic provider disabled
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating libfabric.spec
config.status: creating config.h
config.status: config.h is unchanged
config.status: executing depfiles commands
config.status: executing libtool commands
***
*** Built-in providers: sockets verbs
*** DSO providers:
***
```

@jsquyres Does this look sane?

Signed-off-by: pmmccorm patrick.m.mccormick@intel.com
