### PR TITLE
fabric.h: separate class for scalable endpoints

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -77,6 +77,7 @@ struct fid_cntr;
 struct fid_ep;
 struct fid_pep;
 struct fid_stx;
+struct fid_sep;
 struct fid_mr;
 
 typedef struct fid *fid_t;
@@ -288,6 +289,7 @@ enum {
 	FI_CLASS_FABRIC,
 	FI_CLASS_DOMAIN,
 	FI_CLASS_EP,
+	FI_CLASS_SEP,
 	FI_CLASS_RX_CTX,
 	FI_CLASS_SRX_CTX,
 	FI_CLASS_TX_CTX,

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -119,6 +119,8 @@ struct fi_ops_domain {
 			struct fid_cq **cq, void *context);
 	int	(*endpoint)(struct fid_domain *domain, struct fi_info *info,
 			struct fid_ep **ep, void *context);
+	int	(*scalable_ep)(struct fid_domain *domain, struct fi_info *info,
+			struct fid_sep **sep, void *context);
 	int	(*cntr_open)(struct fid_domain *domain, struct fi_cntr_attr *attr,
 			struct fid_cntr **cntr, void *context);
 	int	(*wait_open)(struct fid_domain *domain, struct fi_wait_attr *attr,

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -71,10 +71,10 @@ struct fi_ops_ep {
 			void *optval, size_t *optlen);
 	int	(*setopt)(fid_t fid, int level, int optname,
 			const void *optval, size_t optlen);
-	int	(*tx_ctx)(struct fid_ep *ep, int index,
+	int	(*tx_ctx)(struct fid_ep *sep, int index,
 			struct fi_tx_ctx_attr *attr, struct fid_ep **tx_ep,
 			void *context);
-	int	(*rx_ctx)(struct fid_ep *ep, int index,
+	int	(*rx_ctx)(struct fid_ep *sep, int index,
 			struct fi_rx_ctx_attr *attr, struct fid_ep **rx_ep,
 			void *context);
 };
@@ -142,6 +142,12 @@ struct fid_stx {
 	struct fi_ops_ep	ops;
 };
 
+struct fid_sep {
+	struct fid		fid;
+	struct fi_ops_ep	*ops;
+	struct fi_ops_cm	*cm;
+};
+
 #ifndef FABRIC_DIRECT
 
 static inline int
@@ -156,6 +162,13 @@ fi_endpoint(struct fid_domain *domain, struct fi_info *info,
 	    struct fid_ep **ep, void *context)
 {
 	return domain->ops->endpoint(domain, info, ep, context);
+}
+
+static inline int
+fi_scalable_ep(struct fid_domain *domain, struct fi_info *info,
+	    struct fid_sep **sep, void *context)
+{
+	return domain->ops->scalable_ep(domain, info, sep, context);
 }
 
 static inline int fi_ep_bind(struct fid_ep *ep, struct fid *bfid, uint64_t flags)

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -44,6 +44,9 @@ fi_rx_context / fi_tx_context / fi_srx_context  / fi_stx_context
 int fi_endpoint(struct fid_domain *domain, struct fi_info *info,
     struct fid_ep **ep, void *context);
 
+int fi_scalable_ep(struct fid_domain *domain, struct fi_info *info,
+    struct fid_sep **ep, void *context);
+
 int fi_pendpoint(struct fi_fabric *fabric, struct fi_info *info,
     struct fid_pep **pep, void *context);
 
@@ -95,6 +98,9 @@ int fi_setopt(struct fid *ep, int level, int optname,
 
 *ep*
 : A fabric endpoint.
+
+*sep*
+: A scalable fabric endpoint.
 
 *fid*
 : Fabric identifier of an associated resource.
@@ -158,13 +164,14 @@ data and protocol options.  This allows the underlying provider to
 redirect function calls to implementations optimized to meet the
 desired application behavior.
 
-## fi_endpoint / fi_pendpoint
+## fi_endpoint / fi_pendpoint / fi_scalable_ep
 
 fi_endpoint allocates a new active endpoint.  fi_pendpoint allocates a
-new passive endpoint.  The properties and behavior of the endpoint are
-defined based on the provided struct fi_info.  See fi_getinfo for
-additional details on fi_info.  fi_info flags that control the
-operation of an endpoint are defined below.
+new passive endpoint.  fi_scalable_ep allocates a scalable endpoint.
+The properties and behavior of the endpoint are defined based on the
+provided struct fi_info.  See fi_getinfo for additional details on
+fi_info.  fi_info flags that control the operation of an endpoint are
+defined below. See section SCALABLE ENDPOINTS.
 
 If an active endpoint is associated with a connection request, the
 fi_info connreq must reference the corresponding request.
@@ -589,14 +596,15 @@ details.
 A scalable endpoint is a communication portal that supports multiple
 transmit and receive contexts.  Scalable endpoints are loosely modeled
 after the networking concept of transmit/receive side scaling, also
-known as multi-queue.  By default, an endpoint is associated with a
-single transmit and receive context.  Support for scalable endpoints
-is domain specific.  Scalable endpoints may improve the performance of
+known as multi-queue.  Support for scalable endpoints is domain
+specific.  Scalable endpoints may improve the performance of
 multi-threaded and parallel applications, by allowing threads to
 access independent transmit and receive queues.  A scalable endpoint
 has a single transport level address, which can reduce the memory
 requirements needed to store remote addressing data, versus using
-standard endpoints.
+standard endpoints. Scalable endpoints cannot be used directly for
+communication operations, and require the application to explicitly
+create transmit and receive contexts as described below.
 
 ## fi_tx_context
 


### PR DESCRIPTION
The scalable endpoint is a different type of endpoint, that
requires the application to create TX/RX CTX for communication.

Having a separate class for this type of endpoint will help
providers do a better job error-checking.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
