### PR TITLE
prov/sockets: add per domain connection map for sockets level connection.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,7 @@ _sockets_files = \
 	prov/sockets/src/sock_ctx.c \
 	prov/sockets/src/sock_util.c \
 	prov/sockets/src/sock_util.h \
+	prov/sockets/src/sock_conn.c \
 	prov/sockets/src/indexer.c \
 	prov/sockets/src/list.c \
 	prov/sockets/src/list.h

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -53,6 +53,8 @@
 #include <fi_rbuf.h>
 #include <fi_list.h>
 
+#include <netdb.h>
+
 #ifndef _SOCK_H_
 #define _SOCK_H_
 
@@ -92,7 +94,16 @@ struct sock_fabric{
 };
 
 struct sock_conn {
-        int sock_fd;
+	int sock_fd;
+	struct sockaddr_storage addr;
+	struct sock_pe_entry *pe_entry;
+};
+
+struct sock_conn_map {
+	struct sock_conn *table;
+	int used;
+	int size;
+	struct sock_domain *dom;
 };
 
 struct sock_domain {
@@ -107,6 +118,11 @@ struct sock_domain {
 
 	struct sock_pe *pe;
 	struct index_map mr_idm;
+	struct sock_conn_map u_cmap;
+	struct sock_conn_map r_cmap;
+	pthread_t listen_thread;
+	int	listening;
+	char service[NI_MAXSERV];
 };
 
 struct sock_cntr {
@@ -130,13 +146,22 @@ struct sock_mr {
 	struct iovec		mr_iov[1];
 };
 
+struct sock_av_addr {
+       uint16_t key;
+       struct sockaddr_storage addr;
+};
+
 struct sock_av {
 	struct fid_av		av_fid;
 	struct sock_domain	*dom;
 	atomic_t		ref;
 	struct fi_av_attr	attr;
-	size_t			count;
-	struct sockaddr_in	*table;
+	uint64_t		mask;
+	int				rx_ctx_bits;
+	size_t			stored;
+	struct index_map addr_idm;
+	socklen_t		addrlen;
+	struct sock_conn_map	*cmap;
 };
 
 struct sock_poll {
@@ -342,7 +367,6 @@ struct sock_ep {
 
 	list_t *send_list;
 	list_t *recv_list;
-	int port_num;
 };
 
 struct sock_pep {
@@ -562,9 +586,6 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		struct fid_av **av, void *context);
 fi_addr_t _sock_av_lookup(struct sock_av *av, struct sockaddr *addr);
-int sock_av_lookup_addr(struct sock_av *av, fi_addr_t addr, 
-			struct sock_conn **entry);
-
 
 int sock_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq, void *context);
@@ -617,6 +638,18 @@ int sock_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 		struct fid_poll **pollset);
 int sock_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
 		struct fid_wait **waitset);
+
+/* FIXME: handle shared ctx */
+#define SOCK_GET_RX_ID(_addr, _bits) (((uint64_t)_addr) >> (64 - _bits))
+struct sock_conn *sock_av_lookup_addr(struct sock_av *av, fi_addr_t addr);
+struct sock_conn *sock_conn_map_lookup_key(struct sock_conn_map *conn_map,
+		uint16_t key);
+uint16_t sock_conn_map_match_or_connect(struct sock_conn_map *map, struct
+		sockaddr_in *addr);
+int sock_conn_listen(struct sock_domain *domain);
+int sock_conn_map_clear_pe_entry(struct sock_conn *conn_entry, 
+		uint16_t key);
+void sock_conn_map_destroy(struct sock_conn_map *cmap);
 
 struct sock_pe *sock_pe_init(struct sock_domain *domain);
 int sock_pe_add_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *ctx);

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/ip.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+#include <ifaddrs.h>
+
+#include "sock.h"
+#include "sock_util.h"
+
+static int _init_map(struct sock_conn_map *map, int init_size) 
+{
+	map->table = (struct sock_conn*)calloc(init_size, 
+			sizeof(struct sock_conn));
+	if (!map->table) 
+		return -FI_ENOMEM;
+	map->used = 0;
+	map->size = init_size;
+	return 0;
+}
+
+static int _increase_map(struct sock_conn_map *map, int new_size) 
+{
+	if (map->used + new_size > map->size) {
+		void *_table = realloc(map->table, map->size * sizeof(struct
+					sock_conn));
+		if (!_table)
+			return -FI_ENOMEM;
+
+		map->size = MAX(map->size, new_size) * 2;
+		map->table = (struct sock_conn*) _table;
+	}
+
+	return 0;
+}
+
+void sock_conn_map_destroy(struct sock_conn_map *cmap)
+{
+	free(cmap->table);
+	cmap->table = NULL;
+	cmap->used = cmap->size = 0;
+}
+
+struct sock_conn *sock_conn_map_lookup_key(struct sock_conn_map *conn_map, 
+		uint16_t key) 
+{
+	if (key > conn_map->used) {
+		SOCK_LOG_ERROR("requested key is larger than conn_map size\n");
+		errno = EINVAL;
+		return NULL;
+	}
+
+	return &conn_map->table[key-1];
+}
+
+uint16_t sock_conn_map_match_or_connect(struct sock_conn_map *map, struct
+		sockaddr_in *addr)
+{
+	int i, conn_fd, arg, optval;
+	socklen_t optlen;
+	char entry_ip[INET_ADDRSTRLEN];
+	char sa_ip[INET_ADDRSTRLEN];
+	struct sockaddr_in *entry;
+	struct addrinfo *c_res = NULL;
+	struct addrinfo hints;
+	struct timeval tv;
+	fd_set fds;
+
+	memcpy(sa_ip, inet_ntoa(addr->sin_addr), INET_ADDRSTRLEN);
+	/* match */
+	for (i=0; i < map->used; i++) {
+		entry = (struct sockaddr_in *)&map->table[i].addr;
+		memcpy(entry_ip, inet_ntoa(entry->sin_addr), INET_ADDRSTRLEN);
+		if(!strcmp(entry_ip, sa_ip)) {
+			return i+1;
+		}
+	}
+
+	/* no matching entry, connect */
+	memset(&hints, 0, sizeof hints);
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	getaddrinfo(sa_ip, map->dom->service, &hints, &c_res);
+	conn_fd = socket(c_res->ai_family, c_res->ai_socktype, 0);
+	if (conn_fd < 0) {
+		SOCK_LOG_ERROR("failed to create conn_fd, errno: %d\n", errno);
+		return 0;
+	}
+	fcntl(conn_fd, F_SETFL, O_NONBLOCK);
+
+	if (connect(conn_fd, c_res->ai_addr, c_res->ai_addrlen) < 0) {
+		if (errno == EINPROGRESS) {
+			/* timeout after 5 secs */
+			tv.tv_sec = 5;
+			tv.tv_usec = 0;
+			FD_ZERO(&fds);
+			FD_SET(conn_fd, &fds);
+			if (select(conn_fd+1, NULL, &fds, NULL, &tv) > 0) {
+				optlen = sizeof(int);
+				getsockopt(conn_fd, SOL_SOCKET, SO_ERROR, &optval, &optlen);
+
+				if (optval) {
+					SOCK_LOG_ERROR("failed to connect %d - %s\n", optval,
+							strerror(optval));
+					close(conn_fd);
+					return 0;
+				}
+			} else {
+				SOCK_LOG_ERROR("Timeout or error to connect %d - %s\n", optval,
+						strerror(optval));
+				close(conn_fd);
+				return 0;
+			}
+		} else {
+			SOCK_LOG_ERROR("Error connecting %d - %s\n", errno,
+					strerror(errno));
+			close(conn_fd);
+			return 0;
+		}
+	}
+
+	arg = fcntl(conn_fd, F_GETFL, NULL);
+	arg &= (~O_NONBLOCK);
+	fcntl(conn_fd, F_SETFL, arg);
+
+	memcpy(&map->table[map->used].addr, c_res->ai_addr, c_res->ai_addrlen);
+	map->table[map->used].sock_fd = conn_fd;
+	map->used++;
+	return map->used;
+
+}
+
+static void * _sock_conn_listen(void *arg)
+{
+	struct sock_domain *domain = (struct sock_domain*) arg;
+	struct sock_conn_map *map = &domain->r_cmap;
+	struct addrinfo *s_res = NULL, *p;
+	struct addrinfo hints;
+	int optval;
+	int listen_fd, conn_fd;
+	struct sockaddr_in remote;
+	socklen_t addr_size;
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = AF_INET;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags = AI_PASSIVE;
+
+	if(getaddrinfo(NULL, domain->service, &hints, &s_res)) {
+		SOCK_LOG_ERROR("no available AF_INET address\n");
+		perror("no available AF_INET address");
+		return NULL;
+	}
+
+	for (p=s_res; p; p=p->ai_next) {
+		listen_fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
+		if (listen_fd >= 0) {
+			optval = 1;
+			setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof
+					optval);
+			if (!bind(listen_fd, s_res->ai_addr, s_res->ai_addrlen))
+				break;
+			close(listen_fd);
+			listen_fd = -1;
+		}
+	}
+
+	freeaddrinfo(s_res);
+	if (listen_fd < 0) {
+		SOCK_LOG_ERROR("failed to listen to port: %s\n", domain->service);
+		goto err;
+	}
+
+	if (listen(listen_fd, 128)) {
+		SOCK_LOG_ERROR("failed to listen socket: %d\n", errno);
+		goto err;
+	}
+ 
+	while(domain->listening) {
+		addr_size = sizeof(struct sockaddr_in);
+		conn_fd = accept(listen_fd, (struct sockaddr *)&remote, &addr_size);
+		SOCK_LOG_INFO("CONN: accepted conn-req: %d\n", conn_fd);
+		if (conn_fd < 0) {
+			SOCK_LOG_ERROR("failed to accept: %d\n", errno);
+			goto err;
+		}
+
+		/* TODO: lock for multi-threads */
+		if ((map->size - map->used) == 0) {
+			_increase_map(map, map->size*2);
+		}
+		memcpy(&map->table[map->used].addr, &remote, addr_size);
+		map->table[map->used].sock_fd = conn_fd;
+		map->used++;
+	}
+
+	close(listen_fd);
+	return NULL;
+
+err:
+	close(listen_fd);
+	perror("listening thread failed");
+	return NULL;
+}
+
+int sock_conn_listen(struct sock_domain *domain)
+{
+	_init_map(&domain->r_cmap, 128); /* TODO: init cmap size */
+	domain->listening = 1;
+	pthread_create(&domain->listen_thread, 0, _sock_conn_listen, domain);
+	return 0;
+}

--- a/prov/sockets/src/sock_dgram.c
+++ b/prov/sockets/src/sock_dgram.c
@@ -610,40 +610,8 @@ static ssize_t sockd_msg_recvv(struct fid_ep *ep, const struct iovec *iov, void 
 static ssize_t sockd_msg_recvfrom(struct fid_ep *ep, void *buf, size_t len, void *desc,
 		fi_addr_t src_addr, void *context)
 {
-	struct sock_ep *sock_ep;
-	struct sock_req_item *recv_req;
-
-	sock_ep = container_of(ep, struct sock_ep, ep);
-	if(!sock_ep)
-		return -FI_EINVAL;
-
-	recv_req = calloc(1, sizeof(struct sock_req_item));
-	if(!recv_req)
-		return -FI_ENOMEM;
-	
-	recv_req->item.buf = (void*)buf;
-	recv_req->req_type = SOCK_REQ_TYPE_RECV;
-	recv_req->comm_type = SOCK_COMM_TYPE_SENDTO;
-	recv_req->context = context;
-	recv_req->total_len = len;
-	recv_req->done_len = 0;
-
-	if (sock_ep->av->attr.type == FI_AV_MAP) {
-		memcpy(&recv_req->addr, (void*)src_addr, sizeof(struct sockaddr_in));
-	} else {
-		size_t idx;
-		idx = (size_t)src_addr;
-		if (idx > sock_ep->av->count-1 || idx < 0) {
-			return -EINVAL;
-		}	
-		memcpy(&recv_req->addr, &sock_ep->av->table[idx], sizeof(struct sockaddr_in));
-	}
-
-	if(0 != enqueue_item(sock_ep->recv_list, recv_req)){
-		free(recv_req);
-		return -FI_ENOMEM;	
-	}
-	return 0;
+	errno = FI_ENOSYS;
+	return -errno;
 }
 
 static ssize_t sockd_msg_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
@@ -670,40 +638,8 @@ static ssize_t sockd_msg_sendv(struct fid_ep *ep, const struct iovec *iov, void 
 static ssize_t sockd_msg_sendto(struct fid_ep *ep, const void *buf, size_t len, void *desc,
 		fi_addr_t dest_addr, void *context)
 {
-	struct sock_ep *sock_ep;
-	struct sock_req_item *send_req;
-
-	sock_ep = container_of(ep, struct sock_ep, ep);
-	if(!sock_ep)
-		return -FI_EINVAL;
-
-	send_req = calloc(1, sizeof(struct sock_req_item));
-	if(!send_req)
-		return -FI_ENOMEM;
-	
-	send_req->item.buf = (void*)buf;
-	send_req->req_type = SOCK_REQ_TYPE_SEND;
-	send_req->comm_type = SOCK_COMM_TYPE_SENDTO;
-	send_req->context = context;
-	send_req->total_len = len;
-	send_req->done_len = 0;
-
-	if (sock_ep->av->attr.type == FI_AV_MAP) {
-		memcpy(&send_req->addr, (void*)dest_addr, sizeof(struct sockaddr_in));
-	} else {
-		size_t idx;
-		idx = (size_t)dest_addr;
-		if (idx > sock_ep->av->count-1 || idx < 0) {
-			return -EINVAL;
-		}	
-		memcpy(&send_req->addr, &sock_ep->av->table[idx], sizeof(struct sockaddr_in));
-	}
-
-	if(0 != enqueue_item(sock_ep->send_list, send_req)){
-		free(send_req);
-		return -FI_ENOMEM;	
-	}
-	return 0;
+	errno = FI_ENOSYS;
+	return -errno;
 }
 
 static ssize_t sockd_msg_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
@@ -840,8 +776,6 @@ int sock_dgram_ep(struct fid_domain *domain, struct fi_info *info,
 		SOCK_LOG_ERROR("[sockd] %s: failed to bind sock_fd to port %d\n", __func__, ntohs(si_me.sin_port));
 		goto err2;
 	}
-
-	_ep->port_num		= ntohs(si_me.sin_port);
 
 	if(!(_ep->send_list = new_list(SOCK_CQ_DEF_SZ)))
 		goto err2;

--- a/prov/sockets/src/sock_rdm.c
+++ b/prov/sockets/src/sock_rdm.c
@@ -432,8 +432,8 @@ static ssize_t sock_rdm_sendmsg(struct sock_tx_ctx *tx_ctx, struct sock_av *av,
 
 	assert(tx_ctx->enabled && msg->iov_count <= SOCK_EP_MAX_IOV_LIMIT);
 
-	if ((ret = sock_av_lookup_addr(av, msg->addr, &conn)))
-		return ret;
+	if (!(conn = sock_av_lookup_addr(av, msg->addr)))
+		return -errno;
 
 	total_len = 0;
 	if (flags & FI_INJECT) {
@@ -697,8 +697,8 @@ static ssize_t sock_rdm_tsendmsg(struct sock_tx_ctx *tx_ctx, struct sock_av *av,
 
 	assert(tx_ctx->enabled && msg->iov_count <= SOCK_EP_MAX_IOV_LIMIT);
 
-	if ((ret = sock_av_lookup_addr(av, msg->addr, &conn)))
-		return ret;
+	if (!(conn = sock_av_lookup_addr(av, msg->addr)))
+		return -errno;
 
 	total_len = 0;
 	if (flags & FI_INJECT) {


### PR DESCRIPTION
Sockets provider update.
- Add per domain connection map to manage sockets level connection establishment.
- Update fi_av APIs implementation in sockets provider accordingly.
