### PR TITLE
fabric: create tx/rx ctx using scalable endpoints

### DIFF
--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -71,10 +71,10 @@ struct fi_ops_ep {
 			void *optval, size_t *optlen);
 	int	(*setopt)(fid_t fid, int level, int optname,
 			const void *optval, size_t optlen);
-	int	(*tx_ctx)(struct fid_ep *sep, int index,
+	int	(*tx_ctx)(struct fid_sep *sep, int index,
 			struct fi_tx_ctx_attr *attr, struct fid_ep **tx_ep,
 			void *context);
-	int	(*rx_ctx)(struct fid_ep *sep, int index,
+	int	(*rx_ctx)(struct fid_sep *sep, int index,
 			struct fi_rx_ctx_attr *attr, struct fid_ep **rx_ep,
 			void *context);
 };
@@ -176,6 +176,11 @@ static inline int fi_ep_bind(struct fid_ep *ep, struct fid *bfid, uint64_t flags
 	return ep->fid.ops->bind(&ep->fid, bfid, flags);
 }
 
+static inline int fi_scalable_ep_bind(struct fid_sep *sep, struct fid *bfid, uint64_t flags)
+{
+	return sep->fid.ops->bind(&sep->fid, bfid, flags);
+}
+
 static inline int fi_enable(struct fid_ep *ep)
 {
 	return ep->ops->enable(ep);
@@ -204,17 +209,17 @@ fi_getopt(fid_t fid, int level, int optname,
 }
 
 static inline int
-fi_tx_context(struct fid_ep *ep, int index, struct fi_tx_ctx_attr *attr,
+fi_tx_context(struct fid_sep *sep, int index, struct fi_tx_ctx_attr *attr,
 	      struct fid_ep **tx_ep, void *context)
 {
-	return ep->ops->tx_ctx(ep, index, attr, tx_ep, context);
+	return sep->ops->tx_ctx(sep, index, attr, tx_ep, context);
 }
 
 static inline int
-fi_rx_context(struct fid_ep *ep, int index, struct fi_rx_ctx_attr *attr,
+fi_rx_context(struct fid_sep *sep, int index, struct fi_rx_ctx_attr *attr,
 	      struct fid_ep **rx_ep, void *context)
 {
-	return ep->ops->rx_ctx(ep, index, attr, rx_ep, context);
+	return sep->ops->rx_ctx(sep, index, attr, rx_ep, context);
 }
 
 static inline int

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -16,6 +16,9 @@ fi_ep_bind
 :   Associate an endpoint with an event queue, completion queue, address
     vector, or memory region
 
+fi_scalable_ep_bind
+:   Associate a scalable endpoint with an address vector
+
 fi_enable
 :   Transitions an endpoint into an active state.
 
@@ -69,6 +72,8 @@ int fi_srx_context(struct fid_domain *domain,
 int fi_close(struct fid *ep);
 
 int fi_ep_bind(struct fid_ep *ep, struct fid *fid, uint64_t flags);
+
+int fi_scalable_ep_bind(struct fid_sep *sep, struct fid *fid, uint64_t flags);
 
 int fi_enable(struct fid_ep *ep);
 
@@ -258,6 +263,16 @@ binding an endpoint to a counter, the following flags may be specified.
   the given endpoint.
 
 Connectionless endpoints must be bound to a single address vector.
+
+## fi_scalable_ep_bind
+
+fi_scalable_ep_bind is used to associate a scalable endpoint with an
+address vector. See section on SCALABLE ENDPOINTS.  A scalable
+endpoint has a single transport level address and can support multiple
+transmit and receive contexts. The transmit and receive contexts share
+the transport-level address. Address vectors that are bound to
+scalable endpoints are implicitly bound to any transmit or receive
+contexts created using the scalable endpoint.
 
 ## fi_enable
 


### PR DESCRIPTION
This fixes some leftover issues in PR #340 that was
merged in c5a08e9.

The application creates a scalable endpoint, and must
use fid_sep in order to create the TX/RX contexts.

Also, include a separate fi_scalable_ep_bind() that
only documents binding an address vector to a scalable
endpoint.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
