### PR TITLE
fi_no_rx_ctx and fi_no_tx_ctx have wrong prototype

### DIFF
--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -274,10 +274,10 @@ int fi_no_getopt(fid_t fid, int level, int optname,
 		void *optval, size_t *optlen);
 int fi_no_setopt(fid_t fid, int level, int optname,
 		const void *optval, size_t optlen);
-int fi_no_tx_ctx(struct fid_ep *ep, int index,
+int fi_no_tx_ctx(struct fid_sep *sep, int index,
 		struct fi_tx_ctx_attr *attr, struct fid_ep **tx_ep,
 		void *context);
-int fi_no_rx_ctx(struct fid_ep *ep, int index,
+int fi_no_rx_ctx(struct fid_sep *sep, int index,
 		struct fi_rx_ctx_attr *attr, struct fid_ep **rx_ep,
 		void *context);
 

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -331,13 +331,13 @@ int fi_no_setopt(fid_t fid, int level, int optname,
 {
 	return -FI_ENOSYS;
 }
-int fi_no_tx_ctx(struct fid_ep *ep, int index,
+int fi_no_tx_ctx(struct fid_sep *sep, int index,
 		struct fi_tx_ctx_attr *attr, struct fid_ep **tx_ep,
 		void *context)
 {
 	return -FI_ENOSYS;
 }
-int fi_no_rx_ctx(struct fid_ep *ep, int index,
+int fi_no_rx_ctx(struct fid_sep *sep, int index,
 		struct fi_rx_ctx_attr *attr, struct fid_ep **rx_ep,
 		void *context)
 {


### PR DESCRIPTION
Some warnings remain in sockets provider, but i think the changes required are more extensive and i did not want to create merge conflicts for someone else.

Signed-off-by: Reese Faucette rfaucett@cisco.com
