### PR TITLE
fi_accept: connreq is specified as an arg in man pages but missing

### DIFF
--- a/man/fi_cm.3.md
+++ b/man/fi_cm.3.md
@@ -28,8 +28,7 @@ int fi_connect(struct fid_ep *ep, const void *addr,
 
 int fi_listen(struct fid_pep *pep);
 
-int fi_accept(struct fid_ep *ep, fi_connreq_t connreq,
-    const void *param, size_t paramlen);
+int fi_accept(struct fid_ep *ep, const void *param, size_t paramlen);
 
 int fi_reject(struct fid_pep *pep, fi_connreq_t connreq,
     const void *param, size_t paramlen);
@@ -110,12 +109,15 @@ address as part of the data transfer.
 The fi_accept and fi_reject calls are used on the passive (listening)
 side of a connection to accept or reject a connection request,
 respectively.  To accept a connection, the listening application first
-waits for a connection request event.  After receiving such an event, it
-allocates a new endpoint to accept the connection.  fi_accept is invoked
-with the newly allocated endpoint passed in as the fid parameter.  If
+waits for a connection request event (FI_CONNREQ).
+After receiving such an event, the application
+allocates a new endpoint to accept the connection.  This endpoint must
+be allocated using an fi_info structure referencing the connreq from this
+FI_CONNREQ event.  fi_accept is then invoked
+with the newly allocated endpoint.  If
 the listening application wishes to reject a connection request, it calls
-fi_reject with the listening endpoint passed in as the fid.
-fi_reject takes a reference to the connection request as an input parameter.
+fi_reject with the listening endpoint and
+a reference to the connection request.
 
 A successfully accepted connection request will result in the active
 (connecting) endpoint seeing an FI_CONNECTED event on its associated
@@ -125,6 +127,8 @@ the reason for the failed attempt.
 
 An FI_CONNECTED event will also be generated on the passive side for the
 accepting endpoint once the connection has been properly established.
+The fid of the FI_CONNECTED event will be that of the endpoint passed to
+fi_accept as opposed to the listening passive endpoint.
 Outbound data transfers cannot be initiated on a connection-oriented
 endpoint until an FI_CONNECTED event has been generated.  However, receive
 buffers may be associated with an endpoint anytime.

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -260,11 +260,14 @@ struct fi_eq_cm_entry {
   application is responsible for freeing this structure by calling
   fi_freeinfo when it is no longer needed.  The fi_info connreq field
   will reference the connection request associated with this event.
-  For an accepted connection, the connreq must be associated with an
-  endpoint when it is opened.  Typically, this is done by simply
+  To accept a connection, an endpoint must first be created by passing
+  an fi_info structure referencing this connreq field to fi_endpoint().
+  This endpoint is then passed to fi_accept() to complete the acceptance
+  of the connection attempt.
+  Creating the endpoint is most easily accomplished by
   passing the fi_info returned as part of the CM event into
-  fi_endpoint().  If the connection is rejected, the connreq must be
-  passed into the fi_reject call.
+  fi_endpoint().  If the connection is to be rejected, the connreq is
+  passed to fi_reject().
 
   Any application data exchanged as part of the connection request is
   placed beyond the fi_eq_cm_entry structure.  The amount of data


### PR DESCRIPTION
in the implementation

Signed-off-by: Reese Faucette rfaucett@cisco.com
