### PR TITLE
configure: force the use of a C99 compiler

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ AC_ARG_ENABLE([direct],
 	[enable_direct=no])
 
 dnl Checks for programs
-AC_PROG_CC
+AC_PROG_CC_C99
 
 dnl Checks for header files.
 AC_HEADER_STDC


### PR DESCRIPTION
This code base uses C99 constructs frequently (e.g., we use `struct foo bar { .baz = yow }` kinds of initialization all over the place), so force the compiler to be C99.

Signed-off-by: Jeff Squyres jsquyres@cisco.com
