### PR TITLE
Makefile.am: include missing PSM header file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -186,6 +186,7 @@ endif HAVE_USNIC
 
 if HAVE_PSM
 _psm_files = \
+	prov/psm/src/psm_am.h \
 	prov/psm/src/psmx.h \
 	prov/psm/src/psmx_init.c \
 	prov/psm/src/psmx_domain.c \


### PR DESCRIPTION
Must list all files in the Makefile.am so that they are included in the tarball.

Signed-off-by: Jeff Squyres jsquyres@cisco.com
