### PR TITLE
Build: Static constructors for built-in providers

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -88,7 +88,11 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 		],
 		[AC_MSG_NOTICE([$1 provider disabled])])
 
-	# Set conditionals for HAVE_<provider> and HAVE_<provider>_DL
+	AC_DEFINE_UNQUOTED([HAVE_]m4_translit([$1], [a-z], [A-Z]), $$1_happy, [$1 provider is built])
+	AC_DEFINE_UNQUOTED([HAVE_]m4_translit([$1], [a-z], [A-Z])[_DL], $$1_dl, [$1 provider is built as DSO])
+
+	# Set AM conditionals for HAVE_<provider> and HAVE_<provider>_DL
+	# as well as AC defines
 	AM_CONDITIONAL([HAVE_]m4_translit([$1], [a-z], [A-Z]),
 		[test $$1_happy -eq 1])
 	AM_CONDITIONAL([HAVE_]m4_translit([$1], [a-z], [A-Z])[_DL],

--- a/include/fi.h
+++ b/include/fi.h
@@ -176,10 +176,7 @@ static inline int atomic_get(atomic_t *atomic)
 
 #endif // HAVE_ATOMICS
 
-
 /* non exported symbols */
-int fi_init(void);
-
 int fi_read_file(const char *dir, const char *file, char *buf, size_t size);
 int fi_poll_fd(int fd, int timeout);
 int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout);
@@ -190,8 +187,6 @@ int fi_sockaddr_len(struct sockaddr *addr);
 size_t fi_datatype_size(enum fi_datatype datatype);
 uint64_t fi_tag_bits(uint64_t mem_tag_format);
 uint64_t fi_tag_format(uint64_t tag_bits);
-
-int fi_version_register(uint32_t version, struct fi_provider *provider);
 
 #define RDMA_CONF_DIR  SYSCONFDIR "/" RDMADIR
 #define FI_CONF_DIR RDMA_CONF_DIR "/fabric"

--- a/include/prov.h
+++ b/include/prov.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _PROV_H_
+#define _PROV_H_
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <rdma/fi_prov.h>
+
+/* Provider initialization function signature that built-in providers
+ * must specify. */
+#define INI_SIG(name) struct fi_provider* name(void)
+
+/* for each provider defines for three scenarios:
+ * dl: externally visible ctor with known name (see fi_prov.h)
+ * built-in: ctor function def, don't export symbols
+ * not built: no-op call for ctor
+*/
+
+#if (HAVE_VERBS) && (HAVE_VERBS_DL)
+#  define VERBS_INI FI_EXT_INI
+#  define VERBS_INIT NULL
+#elif (HAVE_VERBS)
+#  define VERBS_INI INI_SIG(fi_verbs_ini)
+#  define VERBS_INIT fi_verbs_ini()
+VERBS_INI ;
+#else
+#  define VERBS_INIT NULL
+#endif
+
+#if (HAVE_PSM) && (HAVE_PSM_DL)
+#  define PSM_INI FI_EXT_INI
+#  define PSM_INIT NULL
+#elif (HAVE_PSM)
+#  define PSM_INI INI_SIG(fi_psm_ini)
+#  define PSM_INIT fi_psm_ini()
+PSM_INI ;
+#else
+#  define PSM_INIT NULL
+#endif
+
+#if (HAVE_SOCKETS) && (HAVE_SOCKETS_DL)
+#  define SOCKETS_INI FI_EXT_INI
+#  define SOCKETS_INIT NULL
+#elif (HAVE_SOCKETS)
+#  define SOCKETS_INI INI_SIG(fi_sockets_ini)
+#  define SOCKETS_INIT fi_sockets_ini()
+SOCKETS_INI ;
+#else
+#  define SOCKETS_INIT NULL
+#endif
+
+#if (HAVE_USNIC) && (HAVE_USNIC_DL)
+#  define USNIC_INI FI_EXT_INI
+#  define USNIC_INIT NULL
+#elif (HAVE_USNIC)
+#  define USNIC_INI INI_SIG(fi_usnic_ini)
+#  define USNIC_INIT fi_usnic_ini()
+USNIC_INI ;
+#else
+#  define USNIC_INIT NULL
+#endif
+
+#endif /* _PROV_H_ */

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -43,30 +43,32 @@ extern "C" {
 #endif
 
 /*
- * Extension that low-level drivers should add to their .so filename
- * (probably via libtool "-release" option).  For example a low-level
- * driver named "libfoo" should build a plug-in named "libfoo-fi.so".
+ * Extension that dl-loaded providers should add to their .so filename
+ * (probably via libtool "-release" option). For example a provider
+ * driver named "foo" should build a plug-in named "libfoo-fi.so", and
+ * place it in $prefix/$libdir/libfabric/
  */
 #define FI_LIB_EXTENSION "fi"
 #define FI_LIB_SUFFIX FI_LIB_EXTENSION ".so"
 
-#define FI_LIB_CLASS_NAME	"libfabric"
+/*
+ * Dynamically loaded providers must export the following entry point.
+ * This is invoked by the libfabric framework when the provider library
+ * is loaded.
+ */
+#define FI_EXT_INI \
+	__attribute__((visibility ("default"))) struct fi_provider* fi_prov_ini(void)
 
 struct fi_provider {
-	const char *name;
 	uint32_t version;
+	uint32_t fi_version;
+	const char *name;
 	int	(*getinfo)(uint32_t version, const char *node, const char *service,
 			uint64_t flags, struct fi_info *hints, struct fi_info **info);
 	int	(*fabric)(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 			void *context);
+	void	(*cleanup)(void);
 };
-
-int fi_register_provider(uint32_t fi_version, struct fi_provider *provider);
-static inline int fi_register(struct fi_provider *provider)
-{
-	return fi_register_provider(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
-				    provider);
-}
 
 #ifdef __cplusplus
 }

--- a/libfabric.map
+++ b/libfabric.map
@@ -6,7 +6,6 @@ FABRIC_1.0 {
 		fi_fabric;
 		fi_version;
 		fi_strerror;
-		fi_register_provider;
 		fi_tostr;
 	local: *;
 };

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -37,6 +37,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "prov.h"
+
 #include "sock.h"
 #include "sock_util.h"
 
@@ -222,14 +224,21 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 	return ret;
 }
 
+static void fi_sockets_fini(void)
+{
+}
+
 struct fi_provider sock_prov = {
 	.name = "IP",
 	.version = FI_VERSION(SOCK_MAJOR_VERSION, SOCK_MINOR_VERSION), 
+	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
 	.getinfo = sock_getinfo,
 	.fabric = sock_fabric,
+	.cleanup = fi_sockets_fini
 };
 
-static void __attribute__((constructor)) sock_ini(void)
+
+SOCKETS_INI
 {
 	char *tmp = getenv("SFI_SOCK_DEBUG_LEVEL");
 	if (tmp) {
@@ -238,9 +247,5 @@ static void __attribute__((constructor)) sock_ini(void)
 		sock_log_level = SOCK_ERROR;
 	}
 
-	(void) fi_register(&sock_prov);
-}
-
-static void __attribute__((destructor)) sock_fini(void)
-{
+	return (&sock_prov);
 }

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -60,6 +60,7 @@
 #include <rdma/fi_errno.h>
 #include "fi.h"
 #include "fi_enosys.h"
+#include "prov.h"
 
 #include "usnic_direct.h"
 #include "libnl_utils.h"
@@ -835,20 +836,20 @@ fail:
 	return ret;
 }
 
+static void usdf_fini(void)
+{
+}
+
 static struct fi_provider usdf_ops = {
 	.name = USDF_PROV_NAME,
 	.version = USDF_PROV_VERSION,
+	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
 	.getinfo = usdf_getinfo,
 	.fabric = usdf_fabric_open,
+	.cleanup =  usdf_fini
 };
 
-static void __attribute__((constructor))
-usdf_ini(void)
+USNIC_INI
 {
-	(void) fi_register(&usdf_ops);
-}
-
-static void __attribute__((destructor)) 
-usdf_fini(void)
-{
+	return (&usdf_ops);
 }

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -54,8 +54,10 @@
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>
+
 #include "fi.h"
 #include "fi_enosys.h"
+#include "prov.h"
 
 #define PROV_NAME "verbs"
 #define PROV_VERS FI_VERSION(0,7)
@@ -2376,18 +2378,20 @@ int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void 
 	return 0;
 }
 
+static void fi_ibv_fini(void)
+{
+}
+
 static struct fi_provider fi_ibv_prov = {
 	.name = PROV_NAME,
 	.version = PROV_VERS,
+	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
 	.getinfo = fi_ibv_getinfo,
 	.fabric = fi_ibv_fabric,
+	.cleanup = fi_ibv_fini
 };
 
-static void __attribute__((constructor)) fi_ibv_ini(void)
+VERBS_INI
 {
-	(void) fi_register(&fi_ibv_prov);
-}
-
-static void __attribute__((destructor)) fi_ibv_fini(void)
-{
+	return &fi_ibv_prov;
 }

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -44,6 +44,7 @@
 
 #include <rdma/fi_errno.h>
 #include "fi.h"
+#include "prov.h"
 
 #ifdef HAVE_LIBDL
 #include <dlfcn.h>
@@ -57,38 +58,47 @@ struct fi_prov {
 	struct fi_provider	*provider;
 };
 
-static struct fi_prov *prov_head, *prov_tail;
-
 static struct fi_prov *fi_getprov(const char *prov_name);
 
+static struct fi_prov *prov_head, *prov_tail;
+static volatile int init = 0;
+static pthread_mutex_t ini_lock = PTHREAD_MUTEX_INITIALIZER;
 
-__attribute__((visibility ("default")))
-int fi_register_provider_(uint32_t fi_version, struct fi_provider *provider)
+
+static int fi_register_provider(struct fi_provider *provider)
 {
 	struct fi_prov *prov;
+	int ret;
 
-	if (FI_MAJOR(fi_version) != FI_MAJOR_VERSION ||
-	    FI_MINOR(fi_version) > FI_MINOR_VERSION)
-		return -FI_ENOSYS;
+	if (!provider)
+		return -FI_EINVAL;
 
-	/* If a provider with this name is already registered:
-	 * - if the new provider has a lower version number, just fail
-	 *   to register it
-	 * - otherwise, just overwrite the old prov entry
-	 * If the provider is a new/unique name, calloc() a new prov entry.
-	 */
+	if (FI_MAJOR(provider->fi_version) != FI_MAJOR_VERSION ||
+	    FI_MINOR(provider->fi_version) > FI_MINOR_VERSION) {
+		ret = -FI_ENOSYS;
+		goto cleanup;
+	}
+
 	prov = fi_getprov(provider->name);
 	if (prov) {
-		if (FI_VERSION_GE(prov->provider->version, provider->version))
-			return -FI_EALREADY;
+		/* If we have two versions of the same provider,
+		 * keep the most recent
+		 */
+		if (FI_VERSION_GE(prov->provider->version, provider->version)) {
+			ret = -FI_EALREADY;
+			goto cleanup;
+		}
 
+		prov->provider->cleanup();
 		prov->provider = provider;
 		return 0;
 	}
 
 	prov = calloc(sizeof *prov, 1);
-	if (!prov)
-		return -FI_ENOMEM;
+	if (!prov) {
+		ret = -FI_ENOMEM;
+		goto cleanup;
+	}
 
 	prov->provider = provider;
 	if (prov_tail)
@@ -97,10 +107,12 @@ int fi_register_provider_(uint32_t fi_version, struct fi_provider *provider)
 		prov_head = prov;
 	prov_tail = prov;
 	return 0;
-}
-default_symver(fi_register_provider_, fi_register_provider);
 
-#ifdef HAVE_LIBDL
+cleanup:
+	provider->cleanup();
+	return ret;
+}
+
 static int lib_filter(const struct dirent *entry)
 {
 	size_t l = strlen(entry->d_name);
@@ -112,12 +124,24 @@ static int lib_filter(const struct dirent *entry)
 		return 0;
 }
 
-static void __attribute__((constructor)) fi_ini(void)
+static void fi_ini(void)
 {
+	pthread_mutex_lock(&ini_lock);
+
+	if (init)
+		goto unlock;
+
+	fi_register_provider(VERBS_INIT);
+	fi_register_provider(PSM_INIT);
+	fi_register_provider(SOCKETS_INIT);
+	fi_register_provider(USNIC_INIT);
+
+#ifdef HAVE_LIBDL
 	struct dirent **liblist;
 	int n, want_warn = 0;
 	char *lib, *extdir = getenv("FI_EXTDIR");
 	void *dlhandle;
+	struct fi_provider* (*inif)(void);
 
 	if (extdir) {
 		/* Warn if user specified $FI_EXTDIR, but there's a
@@ -130,7 +154,7 @@ static void __attribute__((constructor)) fi_ini(void)
 	/* If dlopen fails, assume static linking and just return
 	   without error */
 	if (dlopen(NULL, RTLD_NOW) == NULL) {
-		return;
+		goto unlock;
 	}
 
 	n = scandir(extdir, &liblist, lib_filter, NULL);
@@ -139,13 +163,14 @@ static void __attribute__((constructor)) fi_ini(void)
 			FI_WARN("scandir error reading %s: %s\n",
 				extdir, strerror(errno));
 		}
-		return;
+		goto unlock;
 	}
 
 	while (n--) {
 		if (asprintf(&lib, "%s/%s", extdir, liblist[n]->d_name) < 0) {
 			FI_WARN("asprintf failed to allocate memory\n");
-			return;
+			free(liblist[n]);
+			goto unlock;
 		}
 
 		dlhandle = dlopen(lib, RTLD_NOW);
@@ -154,14 +179,25 @@ static void __attribute__((constructor)) fi_ini(void)
 
 		free(liblist[n]);
 		free(lib);
+
+		inif = dlsym(dlhandle, "fi_prov_ini");
+		if (inif == NULL)
+			FI_WARN("dlsym: %s\n", dlerror());
+		else
+			fi_register_provider((inif)());
 	}
 
 	free(liblist);
-}
 #endif
+	init = 1;
+unlock:
+	pthread_mutex_unlock(&ini_lock);
+}
 
 static void __attribute__((destructor)) fi_fini(void)
 {
+	for (struct fi_prov *prov = prov_head; prov; prov = prov->next)
+		prov->provider->cleanup();
 }
 
 static struct fi_prov *fi_getprov(const char *prov_name)
@@ -182,7 +218,10 @@ int fi_getinfo_(uint32_t version, const char *node, const char *service,
 {
 	struct fi_prov *prov;
 	struct fi_info *tail, *cur;
-	int ret = -ENOSYS;
+	int ret = -FI_ENOSYS;
+
+	if (!init)
+		fi_ini();
 
 	*info = tail = NULL;
 	for (prov = prov_head; prov; prov = prov->next) {
@@ -344,6 +383,9 @@ int fi_fabric_(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *co
 
 	if (!attr || !attr->prov_name || !attr->name)
 		return -FI_EINVAL;
+
+	if (!init)
+		fi_ini();
 
 	prov = fi_getprov(attr->prov_name);
 	if (!prov || !prov->provider->fabric)


### PR DESCRIPTION
Change how internal and external providers are built to fix static
build issues.  External providers are now required to export a
well known API that is invoked by the libfabric framework.  This
replaces the fi_register call that libfabric exported.

Update the build configuration to better handle building in-tree
providers as separate DLLs (for testing purposes).  When building
an in-tree provider as a separate DLL, it now needs to export
the required fi_prov_ini function.

Signed-off-by: pmmccorm patrick.m.mccormick@intel.com
Signed-off-by: Sean Hefty sean.hefty@intel.com

Replaces PR #335
