### PR TITLE
psm: calloc the size that is needed

### DIFF
--- a/prov/psm/src/psmx_util.c
+++ b/prov/psm/src/psmx_util.c
@@ -204,7 +204,7 @@ void *psmx_resolve_name(const char *servername, int port)
 		return NULL;
 	}
 
-	dest_addr = calloc(1,sizeof(*dest_addr));
+	dest_addr = calloc(1,sizeof(psm_epid_t));
 	if (!dest_addr) {
 		close(sockfd);
 		return NULL;


### PR DESCRIPTION
The code previously did a `sizeof(*dest_addr)`, but `dest_addr` is a `(void*)`, so the sizeof is meaningless.

I _think_ that you want `sizeof(psm_epid_t)` here, because that's what you read into this buffer a few lines later.

@j-xiong can you review?
