### PR TITLE
man: remove references to fi_sync

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -224,13 +224,6 @@ together when binding an endpoint to a completion domain CQ.
   performance by allowing the provider to avoid writing a completion
   entry for every operation.
 
-  The use of FI_COMPLETION is often paired with the call fi_sync.
-  FI_COMPLETION allows the user to suppress completions from being
-  generated.  In order for the application to ensure that all previous
-  operations have completed, the application may call fi_sync.  The
-  successful completion of fi_sync indicates that all prior operations
-  have completed successfully.
-
 An endpoint may also, or instead, be bound to a fabric counter.  When
 binding an endpoint to a counter, the following flags may be specified.
 

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -232,15 +232,9 @@ struct fi_mr_attr {
 
 ## fi_close
 
-Fi_close may be used to release all resources associated with a
+Fi_close is used to release all resources associated with a
 registering a memory region.  Once unregistered, further access to the
-registered memory is not guaranteed.  For performance reasons,
-unregistration processing may be done asynchronously or lazily.  To
-force all queued unregistration requests to complete, applications may
-call fi_sync on the domain.  Upon completion of a domain fi_sync call,
-all memory regions unregistered before fi_sync was invoked will have
-completed, and no further access to the registered region, either
-locally or remotely, via fabric resources will be possible.
+registered memory is not guaranteed.
 
 ## fi_mr_desc / fi_mr_key
 


### PR DESCRIPTION
Remove references to fi_sync in the manpages since it
has been removed from the API.

Applications can use counters directly to wait until issued
ops are completed.

The comment about lazy deregistration on fi_close(mr) was
also removed. Asynchronous registration is now handled using
domain events.

(Currently, it is not clear what event is caused during lazy
deregistration).

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
