### PR TITLE
man: clarification when both cntr and CQ attached

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -13,8 +13,8 @@ fi_endpoint / fi_scalable_ep / fi_passive_ep / fi_close
 :   Allocate or close an endpoint.
 
 fi_ep_bind
-:   Associate an endpoint with an event queue, completion queue, address
-    vector, or memory region
+:   Associate an endpoint with an event queue, completion queue,
+    counter, address vector, or memory region
 
 fi_scalable_ep_bind
 :   Associate a scalable endpoint with an address vector
@@ -924,6 +924,12 @@ such data transfers.
 Operations that complete in error that are not associated with valid
 operational context will use the endpoint context in any error
 reporting structures.
+
+Users can attach both counters and completion queues to an endpoint.
+When both counter and completion queue are attached, a successful
+completion increments the counter and does not generate a completion
+entry in the completion queue. Operations that complete with an error
+increment the error counter and generate a completion event.
 
 # RETURN VALUES
 


### PR DESCRIPTION
When both counter and CQ are attached to the endpoint it
makes sense to just update the counter on success and
generate completion entries for errors.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
