### PR TITLE
travis-ci integration for build testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+before_script:
+  - sudo apt-get update
+  - sudo apt-get install libibverbs-dev libnl-dev
+  # the system provided rdmacm is too old
+  - pushd /tmp && wget https://www.openfabrics.org/downloads/rdmacm/librdmacm-1.0.16.tar.gz && tar xvfz librdmacm-1.0.16.tar.gz && cd librdmacm-1.0.16 && ./configure CC=gcc && make -j && sudo make install && popd
+script: ./autogen.sh && ./configure && make -j && make check
+compiler:
+  - gcc
+  - clang
+
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/ofiwg/libfabric.svg?branch=master)](https://travis-ci.org/ofiwg/libfabric)
+
 libfabric
 =========
 


### PR DESCRIPTION
Adds build testing via Travis CI. Current setup builds the sockets, verbs, and usnic providers using gcc and clang.