### PR TITLE
Implement sendv functions for usdf

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Reese Faucette	<rfaucett@cisco.com>
 Jeff Squyres	<jsquyres@cisco.com>
 Jianxin Xiong	<jianxin.xiong@intel.com>
 Sayantan Sur	<sayantan.sur@intel.com>
+Xuyang Wang     <xuywang@cisco.com>

--- a/prov/usnic/src/usdf_dgram.h
+++ b/prov/usnic/src/usdf_dgram.h
@@ -63,5 +63,7 @@ ssize_t usdf_dgram_prefix_recvv(struct fid_ep *ep, const struct iovec *iov,
 	void **desc, size_t count, fi_addr_t src_addr, void *context);
 ssize_t usdf_dgram_prefix_send(struct fid_ep *ep, const void *buf, size_t len,
 	void *desc, fi_addr_t dest_addr, void *context);
+ssize_t usdf_dgram_prefix_sendv(struct fid_ep *fep, const struct iovec *iov,
+	void **desc, size_t count, fi_addr_t dest_addr, void *context);
 
 #endif /* _USDF_DGRAM_H_ */

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -260,7 +260,7 @@ usdf_ep_dgram_close(fid_t fid)
 	}
 	usdf_ep_dgram_deref_cq(ep->e.dg.ep_wcq);
 	usdf_ep_dgram_deref_cq(ep->e.dg.ep_rcq);
-	
+
 	free(ep);
 	return 0;
 }
@@ -293,8 +293,8 @@ static struct fi_ops_msg usdf_dgram_prefix_ops = {
 	.recv = usdf_dgram_prefix_recv,
 	.recvv = usdf_dgram_prefix_recvv,
 	.recvmsg = usdf_dgram_recvmsg,
-	.send = usdf_dgram_send,
-	.sendv = usdf_dgram_sendv,
+	.send = usdf_dgram_prefix_send,
+	.sendv = usdf_dgram_prefix_sendv,
 	.sendmsg = usdf_dgram_sendmsg,
 	.inject = usdf_dgram_inject,
 	.senddata = usdf_dgram_senddata,

--- a/prov/usnic/src/usnic_direct/usd.h
+++ b/prov/usnic/src/usnic_direct/usd.h
@@ -60,7 +60,7 @@
 #define USD_SF_ISSET(flags, flagname) \
     ((flags >> USD_SFS_##flagname) & 1)
 
-#define USD_SEND_MAX_COPY 1024
+#define USD_SEND_MAX_COPY 992
 #define USD_MAX_CQ_GROUP 1024
 #define USD_MAX_PRESEND 4
 

--- a/prov/usnic/src/usnic_direct/usd_poll.c
+++ b/prov/usnic/src/usnic_direct/usd_poll.c
@@ -88,9 +88,35 @@ usd_desc_to_rq_comp(
     if (bytes_written_flags & CQ_ENET_RQ_DESC_FLAGS_TRUNCATED ||
             (edesc->flags & ipudpok) != ipudpok) {
         if (((edesc->flags & CQ_ENET_RQ_DESC_FLAGS_FCS_OK) == 0) &&
-                bytes_written == 0)
-            comp->uc_status = USD_COMPSTAT_ERROR_TRUNC;
-        else
+                bytes_written == 0) {
+            size_t rcvbuf_len;
+            dma_addr_t bus_addr;
+            u16 len;
+            u8 type;
+            uint16_t i;
+
+            i = q_index;
+            rcvbuf_len = 0;
+            do {
+                rq_enet_desc_dec( (struct rq_enet_desc *)
+                        ((uintptr_t)rq->urq_vnic_rq.ring.descs + (i<<4)),
+                        &bus_addr, &type, &len);
+                rcvbuf_len += len;
+                i = (i - 1) & rq->urq_post_index_mask;
+            } while (type == RQ_ENET_TYPE_NOT_SOP);
+
+            /*
+             * If only the paddings to meet 64-byte minimum eth frame
+             * requirement are truncated, do not mark packet as
+             * error due to truncation.
+             * The usnic hdr should not be split into multiple receive buffer
+             */
+            if (ntohs(((struct usd_udp_hdr *)bus_addr)->uh_ip.tot_len)
+                        + sizeof(struct ether_header) > rcvbuf_len)
+                comp->uc_status = USD_COMPSTAT_ERROR_TRUNC;
+            else
+                comp->uc_status = USD_COMPSTAT_SUCCESS;
+        } else
             comp->uc_status = USD_COMPSTAT_ERROR_CRC;
     } else {
         comp->uc_status = USD_COMPSTAT_SUCCESS;

--- a/prov/usnic/src/usnic_direct/usd_post.c
+++ b/prov/usnic/src/usnic_direct/usd_post.c
@@ -100,7 +100,6 @@ usd_post_recv(
         vnic_rq_post(vrq, iovp[0].iov_base, 0,
                      (dma_addr_t) iovp[0].iov_base, iovp[0].iov_len, 0);
 
-
         for (i = 1; i < recv_list->urd_iov_cnt; ++i) {
 
             rq->urq_context[rq->urq_post_index] = recv_list->urd_context;

--- a/prov/usnic/src/usnic_direct/usd_post.h
+++ b/prov/usnic/src/usnic_direct/usd_post.h
@@ -43,6 +43,8 @@
 #ifndef _USD_POST_H_
 #define _USD_POST_H_
 
+#include <sys/uio.h>
+
 #include "usd.h"
 #include "usd_util.h"
 
@@ -94,7 +96,6 @@ _usd_post_send_two(
     struct vnic_wq *vwq;
     uint32_t index;
     struct wq_enet_desc *desc;
-    uint64_t wr;
     u_int8_t offload_mode = 0, eop;
     u_int16_t mss = 7, header_length = 0, vlan_tag = 0;
     u_int8_t vlan_tag_insert = 0, loopback = 0, fcoe_encap = 0;
@@ -119,13 +120,63 @@ _usd_post_send_two(
         vlan_tag_insert, vlan_tag, loopback);
     wmb();
 
-    wr = vnic_cached_posted_index((dma_addr_t)hdr, hdrlen, index);
-    iowrite64(wr, &vwq->ctrl->posted_index);
+    iowrite32(index, &vwq->ctrl->posted_index);
 
     wq->uwq_next_desc = (struct wq_enet_desc *)
         ((uintptr_t)wq->uwq_desc_ring + (index<<4));
     wq->uwq_post_index = (index+1) & wq->uwq_post_index_mask;
     wq->uwq_send_credits -= 2;
+
+    return index;
+}
+
+/*
+ * Consume iov count credits, assumes that iov[0] includes usnic header
+ */
+static inline uint32_t
+_usd_post_send_iov(
+    struct usd_qp *uqp,
+    const struct iovec *iov,
+    size_t count,
+    u_int8_t cq_entry)
+{
+    struct usd_wq *wq;
+    struct vnic_wq *vwq;
+    struct usd_qp_impl *qp;
+    uint32_t index;
+    struct wq_enet_desc *desc;
+    u_int8_t offload_mode = 0;
+    u_int16_t mss = 7, header_length = 0, vlan_tag = 0;
+    u_int8_t vlan_tag_insert = 0, loopback = 0, fcoe_encap = 0;
+    unsigned i;
+
+    qp = to_qpi(uqp);
+    wq = &qp->uq_wq;
+    vwq = &wq->uwq_vnic_wq;
+    desc = wq->uwq_next_desc;
+    index = wq->uwq_post_index;
+
+    for (i = 0; i < count - 1; i++) {
+        wq_enet_desc_enc(desc, (uintptr_t)(iov[i].iov_base),
+            iov[i].iov_len, mss, header_length, offload_mode,
+            0, 0, fcoe_encap, vlan_tag_insert, vlan_tag, loopback);
+        desc = (struct wq_enet_desc *) ((uintptr_t)wq->uwq_desc_ring
+                                            + (index<<4));
+        index = (index+1) & wq->uwq_post_index_mask;
+    }
+
+    wq_enet_desc_enc(desc, (uintptr_t)(iov[i].iov_base),
+	iov[i].iov_len, mss, header_length, offload_mode,
+	1, cq_entry, fcoe_encap, vlan_tag_insert, vlan_tag, loopback);
+
+    wmb();
+
+    iowrite32(index, &vwq->ctrl->posted_index);
+
+    wq->uwq_next_desc = (struct wq_enet_desc *)
+        ((uintptr_t)wq->uwq_desc_ring + (index<<4));
+    wq->uwq_post_index = (index+1) & wq->uwq_post_index_mask;
+    wq->uwq_send_credits -= count;
 
     return index;
 }


### PR DESCRIPTION
1. sendv function implementation for usdf. 
2. Bring in a usd bugfix for not reporting packet truncation due to posted receive buffer with size less than 64 byte. 
