### PR TITLE
usnic: remove unnecessary inclusion of config.h

### DIFF
--- a/prov/usnic/src/usnic_direct/libnl_utils_common.c
+++ b/prov/usnic/src/usnic_direct/libnl_utils_common.c
@@ -39,8 +39,6 @@
  *
  *
  */
-#include "config.h"
-
 #include <errno.h>
 #include <arpa/inet.h>
 #include <time.h>

--- a/prov/usnic/src/usnic_direct/usnic_ip_utils.c
+++ b/prov/usnic/src/usnic_direct/usnic_ip_utils.c
@@ -39,8 +39,6 @@
  *
  *
  */
-#include "config.h"
- 
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>


### PR DESCRIPTION
These includes are causing problems in the embedded copy of libfabric in Open MPI (because other files are named config.h).  They're not necessary here, so just remove them and avoid the problem.

Signed-off-by: Jeff Squyres jsquyres@cisco.com
