### PR TITLE
man: define FI_THREAD_DOMAIN

### DIFF
--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -171,6 +171,10 @@ interfaces enables a provider to eliminate lower-level locks.
   specific threads can reduce provider locking by using
   FI_THREAD_PROGRESS.
 
+*FI_THREAD_DOMAIN*
+: A domain serialization model requires applications to serialize
+  access to all objects belonging to a domain.
+
 ## Progress Models (control_progress / data_progress)
 
 Progress is the ability of the underlying implementation to complete


### PR DESCRIPTION
Define another threading model - FI_THREAD_DOMAIN.

In this model, the application serializes accesses to all
objects belonging to a particular domain.

This model allows the provider to share resources among
multiple EPs. Example - a shared list receive buffers for
implementing FI_BUFFERED_RECV.

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
