### PR TITLE
fabric: add FI_THREAD_DOMAIN

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -168,7 +168,8 @@ enum fi_progress {
 enum fi_threading {
 	FI_THREAD_UNSPEC,
 	FI_THREAD_SAFE,
-	FI_THREAD_PROGRESS
+	FI_THREAD_PROGRESS,
+	FI_THREAD_DOMAIN
 };
 
 #define FI_ORDER_RAR		(1 << 0)


### PR DESCRIPTION
Actually add FI_THREAD_DOMAIN to enum fi_threading.

This was mistakenly left out in PR#433

Signed-off-by: Sayantan Sur sayantan.sur@intel.com
