### PR TITLE
fabric: shared ctx across processes and threads

### DIFF
--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -110,6 +110,14 @@ struct fi_mr_attr {
 struct fi_cq_attr;
 struct fi_cntr_attr;
 
+/* Shared context flags */
+#define FI_SCTX_EXCL		(1ULL << 1)
+
+struct fi_sctx_attr {
+	size_t			ep_per_node;
+	const char		*name;
+	uint64_t		flags;
+};
 
 struct fi_ops_domain {
 	size_t	size;
@@ -128,11 +136,11 @@ struct fi_ops_domain {
 	int	(*poll_open)(struct fid_domain *domain, struct fi_poll_attr *attr,
 			struct fid_poll **pollset);
 	int	(*stx_ctx)(struct fid_domain *domain,
-			struct fi_tx_attr *attr, struct fid_stx **stx,
-			void *context);
+			struct fi_tx_attr *attr, struct fi_sctx_attr *sctx_attr,
+			struct fid_stx **stx, void *context);
 	int	(*srx_ctx)(struct fid_domain *domain,
-			struct fi_rx_attr *attr, struct fid_ep **rx_ep,
-			void *context);
+			struct fi_rx_attr *attr, struct fi_sctx_attr *sctx_attr,
+			struct fid_ep **rx_ep, void *context);
 };
 
 

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -219,16 +219,16 @@ fi_rx_context(struct fid_sep *sep, int index, struct fi_rx_attr *attr,
 
 static inline int
 fi_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,
-	       struct fid_stx **stx, void *context)
+	       struct fi_sctx_attr *sctx_attr, struct fid_stx **stx, void *context)
 {
-	return domain->ops->stx_ctx(domain, attr, stx, context);
+	return domain->ops->stx_ctx(domain, attr, sctx_attr, stx, context);
 }
 
 static inline int
 fi_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
-	       struct fid_ep **rx_ep, void *context)
+	       struct fi_sctx_attr *sctx_attr, struct fid_ep **rx_ep, void *context)
 {
-	return domain->ops->srx_ctx(domain, attr, rx_ep, context);
+	return domain->ops->srx_ctx(domain, attr, sctx_attr, rx_ep, context);
 }
 
 static inline ssize_t

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -62,12 +62,12 @@ int fi_rx_context(struct fid_ep *ep, int index,
     void *context);
 
 int fi_stx_context(struct fid_domain *domain,
-    struct fi_tx_attr *attr, struct fid_stx **stx,
-    void *context);
+    struct fi_tx_attr *attr, struct fi_sctx_attr *sctx_attr,
+    struct fid_stx **stx, void *context);
 
 int fi_srx_context(struct fid_domain *domain,
-    struct fi_rx_attr *attr, struct fid_ep **rx_ep,
-    void *context);
+    struct fi_rx_attr *attr, struct fi_sctx_attr *sctx_attr,
+    struct fid_ep **rx_ep, void *context);
 
 int fi_close(struct fid *ep);
 
@@ -777,7 +777,8 @@ struct fi_rx_attr {
 Shared contexts are transmit and receive contexts explicitly shared
 among one or more endpoints.  A sharable context allows an application
 to use a single dedicated provider resource among multiple transport
-addressable endpoints.  This can greatly reduce the resources needed
+addressable endpoints within a process and across multiple processes
+on the system. This can greatly reduce the resources needed
 to manage communication over multiple endpoints by multiplexing
 transmit and/or receive processing, with the potential cost of
 serializing access across multiple endpoints.  Support for sharable
@@ -803,6 +804,39 @@ same group of endpoints sharing a context of one type also share the
 context of an alternate type.  Furthermore, an endpoint may use a
 shared context of one type, but a scalable set of contexts of the
 alternate type.
+
+{% highlight c %}
+struct fi_sctx_attr {
+	size_t     ep_per_node;
+	const char *name;
+	uint64_t   flags;
+};
+{% endhighlight %}
+
+*ep_per_node*
+: This field indicates the number of endpoints that will be associated
+  with the shared context on the node.  If the number of
+  endpoints per node is unknown, this value should be set to 0.  The
+  provider uses this value to optimize resource allocations.  For
+  example, distributed, parallel applications may set this to the
+  number of processes allocated per node, times the number of
+  endpoints each process will open.
+
+*name*
+: An optional system name associated with the shared context to create
+  or open.  The name field allows the underlying provider to identify a
+  shared context.
+
+  If the name field is non-NULL and the context is not opened for
+  a named shared context will be created, if it does not already
+  exist.
+
+*flags*
+: The following flags may be used when opening a shared context.
+
+- *FI_SCTX_EXCL*
+: When the flag FI_SCTX_EXCL is specified, the shared context will only
+  be used by endpoints within the calling process.
 
 ## fi_stx_context
 

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -711,9 +711,11 @@ int sock_msg_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 
 
 int sock_stx_ctx(struct fid_domain *domain,
-		 struct fi_tx_attr *attr, struct fid_stx **stx, void *context);
+		 struct fi_tx_attr *attr, struct fi_sctx_attr *sctx_attr,
+		 struct fid_stx **stx, void *context);
 int sock_srx_ctx(struct fid_domain *domain,
-		 struct fi_rx_attr *attr, struct fid_ep **srx, void *context);
+		 struct fi_rx_attr *attr, struct fi_sctx_attr *sctx_attr,
+		 struct fid_ep **srx, void *context);
 
 
 int sock_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -896,7 +896,8 @@ struct fi_ops_cm sock_ep_cm_ops = {
 };
 
 int sock_stx_ctx(struct fid_domain *domain,
-		 struct fi_tx_attr *attr, struct fid_stx **stx, void *context)
+		 struct fi_tx_attr *attr, struct fi_sctx_attr *sctx_attr,
+		 struct fid_stx **stx, void *context)
 {
 	struct sock_domain *dom;
 	struct sock_tx_ctx *tx_ctx;
@@ -916,7 +917,8 @@ int sock_stx_ctx(struct fid_domain *domain,
 }
 
 int sock_srx_ctx(struct fid_domain *domain,
-		 struct fi_rx_attr *attr, struct fid_ep **srx, void *context)
+		 struct fi_rx_attr *attr, struct fi_sctx_attr *sctx_attr,
+		 struct fid_ep **srx, void *context)
 {
 	struct sock_domain *dom;
 	struct sock_rx_ctx *rx_ctx;


### PR DESCRIPTION
Apps may want to use shared contexts across processes within
a node, when number of processes > number contexts available.

Add a fi_sctx_attr structure (modeled after fi_av_attr) that allows the
processes to specify the name of a shared context and endpoints in the
node that might want to share the context. This will allow the provider
to size up the shared context appropriately.

Add a flag FI_SCTX_EXCL that allows a shared context to be created such
that multiple endpoints within a calling process may use the context. This
allows the provider to utilize the declared threading model to determine
where the serialization occurs. i.e. a shared context within a process
does not need provider level locking if FI_THREAD_PROGRESS (or
FI_THREAD_DOMAIN) is used.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>