### PR TITLE
API tweaks prior to 1.0 release cycle

### DIFF
--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -154,8 +154,6 @@ static struct fi_ops_cm X = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
-	.join = fi_no_join,
-	.leave = fi_no_leave,
 };
 */
 int fi_no_getname(fid_t fid, void *addr, size_t *addrlen);
@@ -167,10 +165,6 @@ int fi_no_accept(struct fid_ep *ep, const void *param, size_t paramlen);
 int fi_no_reject(struct fid_pep *pep, fi_connreq_t connreq,
 		const void *param, size_t paramlen);
 int fi_no_shutdown(struct fid_ep *ep, uint64_t flags);
-int fi_no_join(struct fid_ep *ep, void *addr, fi_addr_t *fi_addr,
-		uint64_t flags, void *context);
-int fi_no_leave(struct fid_ep *ep, void *addr, fi_addr_t fi_addr,
-		uint64_t flags);
 
 /*
 static struct fi_ops_av X = {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -97,7 +97,6 @@ typedef struct fid *fid_t;
 #define FI_RMA			(1ULL << 2)
 #define FI_TAGGED		(1ULL << 3)
 #define FI_ATOMICS		(1ULL << 4)
-#define FI_MULTICAST		(1ULL << 5)	/* multicast uses MSG ops */
 #define FI_DYNAMIC_MR		(1ULL << 7)
 #define FI_NAMED_RX_CTX		(1ULL << 8)
 #define FI_BUFFERED_RECV	(1ULL << 9)

--- a/include/rdma/fi_cm.h
+++ b/include/rdma/fi_cm.h
@@ -52,10 +52,6 @@ struct fi_ops_cm {
 	int	(*reject)(struct fid_pep *pep, fi_connreq_t connreq,
 			const void *param, size_t paramlen);
 	int	(*shutdown)(struct fid_ep *ep, uint64_t flags);
-	int	(*join)(struct fid_ep *ep, void *addr, fi_addr_t *fi_addr,
-			uint64_t flags, void *context);
-	int	(*leave)(struct fid_ep *ep, void *addr, fi_addr_t fi_addr,
-			uint64_t flags);
 };
 
 
@@ -100,19 +96,6 @@ fi_reject(struct fid_pep *pep, fi_connreq_t connreq,
 static inline int fi_shutdown(struct fid_ep *ep, uint64_t flags)
 {
 	return ep->cm->shutdown(ep, flags);
-}
-
-static inline int
-fi_join(struct fid_ep *ep, void *addr, fi_addr_t *fi_addr, uint64_t flags,
-	void *context)
-{
-	return ep->cm->join(ep, addr, fi_addr, flags, context);
-}
-
-static inline int
-fi_leave(struct fid_ep *ep, void *addr, fi_addr_t fi_addr, uint64_t flags)
-{
-	return ep->cm->leave(ep, addr, fi_addr, flags);
 }
 
 #else // FABRIC_DIRECT

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -115,9 +115,12 @@ struct fi_eq_attr {
 
 /* Standard EQ events */
 enum {
-	FI_COMPLETE,
+	FI_NOTIFY,
 	FI_CONNREQ,
-	FI_SHUTDOWN
+	FI_CONNECTED,
+	FI_SHUTDOWN,
+	FI_MR_COMPLETE,
+	FI_AV_COMPLETE,
 };
 
 struct fi_eq_entry {

--- a/man/fi_cm.3.md
+++ b/man/fi_cm.3.md
@@ -15,9 +15,6 @@ fi_connect / fi_listen / fi_accept / fi_reject / fi_shutdown
 fi_getname / fi_getpeer
 : Return local or peer endpoint address
 
-fi_join / fi_leave
-: Have an endpoint join or leave a multicast group.
-
 # SYNOPSIS
 
 {% highlight c %}
@@ -38,12 +35,6 @@ int fi_shutdown(struct fid_ep *ep, uint64_t flags);
 int fi_getname(fid_t fid, void *addr, size_t *addrlen);
 
 int fi_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen);
-
-int fi_join(struct fid_ep *ep, void *addr, fi_addr_t *fi_addr,
-    uint64_t flags, void *context);
-
-int fi_leave(struct fid_ep *ep, void *addr, fi_addr_t fi_addr,
-    uint64_t flags);
 {% endhighlight %}
 
 # ARGUMENTS
@@ -53,7 +44,7 @@ int fi_leave(struct fid_ep *ep, void *addr, fi_addr_t fi_addr,
 
 *addr*
 : Buffer to store queried address (get), or address to
-  connect/join/leave.  The address must be in the same format as that
+  connect.  The address must be in the same format as that
   specified using fi_info: addr_format when the endpoint was created.
 
 *addrlen*
@@ -68,9 +59,6 @@ int fi_leave(struct fid_ep *ep, void *addr, fi_addr_t fi_addr,
 
 *info*
 : Fabric information associated with a connection request.
-
-*fi_addr*
-: Fabric address associated with a multicast address.
 
 *flags*
 : Additional flags for controlling connection operation.
@@ -159,46 +147,9 @@ what can fit into the buffer, it will be truncated.  On output, addrlen
 is set to the size of the buffer needed to store the address, which may
 be larger than the input value.
 
-## fi_join / fi_leave
-
-fi_join and fi_leave are use to associate or dissociate an endpoint
-with a multicast group.  Join operations complete asynchronously, with
-the completion reported through the event queue associated with the
-endpoint or domain, if an event queue has not been bound to the
-endpoint.
-
-A fabric address will be provided as part of the join request.  The
-address will be written to the memory location referenced by the
-fi_addr parameter.  This address must be used when issuing data
-transfer operations to the multicast group.  Because join operations
-are asynchronous, the memory location referenced by the fi_addr
-parameter must remain valid until an event associated with the join is
-reported, or a corresponding call to leave the multicast group
-returns.  Fi_addr is not guaranteed to be set upon return from
-fi_join, and it is strongly recommended that fi_addr not be declared
-on the stack, as data corruption may result.
-
-The fi_leave call will result in an endpoint leaving a multicast
-group.  The fi_leave call may be called even if the join operation has
-not completed, in which case the join will be canceled if it has not
-yet completed.
-
 # FLAGS
 
-The fi_join call allows the user to specify flags requesting the type of
-join operation being requested.  Flags for fi_leave must be 0.
-
-*FI_SEND*
-: Setting FI_SEND, but not FI_RECV, indicates that the endpoint should
-  join the multicast group as a send-only member.  If FI_RECV is also
-  set or neither FI_SEND or FI_RECV are set, then the endpoint will
-  join the group with send and receive capabilities.
-
-*FI_RECV*
-: Setting FI_RECV, but not FI_SEND, indicates that the endpoint should
-  join the multicast group as a receive-only member.  If FI_SEND is
-  also set or neither FI_SEND or FI_RECV are set, then the endpoint
-  will join the group with send and receive capabilities.
+Flag values are reserved and must be 0.
 
 # RETURN VALUE
 

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -241,12 +241,14 @@ struct fi_eq_entry {
 {% endhighlight %}
 
   For the completion of basic asynchronous control operations, the
-  returned event will be to FI_COMPLETE.  The fid will reference the
-  fabric descriptor associated with the event.  For memory
-  registration, this will be the fid_mr, address resolution will
-  reference a fid_av, and CM events will refer to a fid_ep.  The
-  context field will be set to the context specified as part of the
-  operation.
+  returned event will indicate the operation that has completed, and
+  the fid will reference the fabric descriptor associated with
+  the event.  For memory registration, this will be an FI_MR_COMPLETE
+  event and the fid_mr, address resolution will reference an
+  FI_AV_COMPLETE event and fid_av, and CM events will refer to a
+  FI_CONNECTED event and fid_ep.  The context field will be set
+  to the context specified as part of the operation, if available,
+  otherwise the context will be associated with the fabric descriptor.
 
 *Connection Request Notification*
 : Connection requests are unsolicited notifications that a remote

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -227,7 +227,7 @@ information regarding the format associated with each event.
 : Asynchronous control operations are basic requests that simply need
   to generate an event to indicate that they have completed.  These
   include the following types of events: memory registration, address
-  vector resolution, connection established, and multicast join.
+  vector resolution, and connection established.
 
   Control requests report their completion by inserting a `struct
   fi_eq_entry` into the EQ.  The format of this structure is:

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -251,15 +251,6 @@ additional optimizations.
   FI_WRITE, FI_REMOTE_READ, and FI_REMOTE_WRITE flags to restrict the
   types of atomic operations supported by an endpoint.
 
-*FI_MULTICAST*
-: Indicates that the endpoint should support multicast data transfers.
-  Endpoints supporting this capability support multicast operations
-  defined by struct fi_ops_msg, when a multicast address is specified
-  as the destination address.  In the absence of any relevant flags,
-  FI_MULTICAST implies the ability to send and receive messages.
-  Applications can use the FI_SEND and FI_RECV flags to optimize an
-  endpoint as send-only or receive-only.
-
 *FI_DYNAMIC_MR*
 : The provider supports applications registering any range of
   addresses in their virtual address space, whether or not those

--- a/prov/psm/src/psmx_cm.c
+++ b/prov/psm/src/psmx_cm.c
@@ -60,7 +60,5 @@ struct fi_ops_cm psmx_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
-	.join = fi_no_join,
-	.leave = fi_no_leave,
 };
 

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -283,7 +283,7 @@ static int sock_regattr(struct fid_domain *domain, const struct fi_mr_attr *attr
 	if (dom->mr_eq) {
 		eq_entry.fid = &domain->fid;
 		eq_entry.context = attr->context;
-		return sock_eq_report_event(dom->mr_eq, FI_COMPLETE,
+		return sock_eq_report_event(dom->mr_eq, FI_MR_COMPLETE,
 					    &eq_entry, sizeof(eq_entry), 0);
 	}
 

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -488,8 +488,6 @@ struct fi_ops_cm sock_ep_cm_ops = {
 	.accept = sock_ep_cm_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
-	.join = fi_no_join,
-	.leave = fi_no_leave,
 };
 
 int sock_msg_endpoint(struct fid_domain *domain, struct fi_info *info,
@@ -642,8 +640,6 @@ static struct fi_ops_cm sock_pep_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = sock_pep_reject,
 	.shutdown = fi_no_shutdown,
-	.join = fi_no_join,
-	.leave = fi_no_leave,
 };
 
 int sock_msg_sep(struct fid_domain *domain, struct fi_info *info,

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -241,7 +241,7 @@ ssize_t sock_eq_fd_sread(struct fid_eq *eq, uint32_t *event, void *buf,
 			SOCK_LOG_ERROR("recvfrom value invalid: %d\n", ret);
 			return 0;
 		}
-		*event = FI_COMPLETE;
+		*event = FI_CONNECTED;
 		entry->info = NULL;
 		entry->fid = req->c_fid;
 		fid_ep = container_of(req->c_fid, struct fid_ep, fid);
@@ -284,7 +284,7 @@ ssize_t sock_eq_fd_sread(struct fid_eq *eq, uint32_t *event, void *buf,
 		break;
 	case SOCK_CONNECTED:
 		SOCK_LOG_INFO("received SOCK_CONNECTED\n");
-		*event = FI_COMPLETE;
+		*event = FI_CONNECTED;
 		entry->info = NULL;
 		entry->fid = req->s_fid;
 		fid_ep = container_of(req->s_fid, struct fid_ep, fid);

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -78,7 +78,7 @@ usdf_av_insert_async_complete(struct usdf_av_insert *insert)
 	entry.context = insert->avi_context;
 	entry.data = insert->avi_successes;
 	usdf_eq_write_internal(av->av_eq,
-		FI_COMPLETE, &entry, sizeof(entry), 0);
+		FI_AV_COMPLETE, &entry, sizeof(entry), 0);
 
 	pthread_spin_lock(&av->av_lock);
 

--- a/prov/usnic/src/usdf_cm.c
+++ b/prov/usnic/src/usdf_cm.c
@@ -112,7 +112,7 @@ usdf_cm_msg_accept_complete(struct usdf_connreq *crp)
 	/* post EQ entry */
 	entry.fid = ep_utofid(ep);
 	entry.info = NULL;
-	ret = usdf_eq_write_internal(ep->ep_eq, FI_COMPLETE, &entry,
+	ret = usdf_eq_write_internal(ep->ep_eq, FI_CONNECTED, &entry,
 			sizeof(entry), 0);
 	if (ret != sizeof(entry)) {
 		usdf_cm_msg_connreq_failed(crp, ret);
@@ -299,7 +299,7 @@ usdf_cm_msg_connect_cb_rd(void *v)
 		entry->fid = ep_utofid(ep);
 		entry->info = NULL;
 		memcpy(entry->data, reqp->creq_data, reqp->creq_datalen);
-		ret = usdf_eq_write_internal(ep->ep_eq, FI_COMPLETE, entry,
+		ret = usdf_eq_write_internal(ep->ep_eq, FI_CONNECTED, entry,
 				entry_len, 0);
 		free(entry);
 		if (ret != entry_len) {

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -592,8 +592,6 @@ static struct fi_ops_cm usdf_cm_msg_ops = {
 	.accept = usdf_cm_msg_accept,
 	.reject = fi_no_reject,
 	.shutdown = usdf_cm_msg_shutdown,
-	.join = fi_no_join,
-	.leave = fi_no_leave,
 };
 
 static struct fi_ops_msg usdf_msg_ops = {

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -649,8 +649,6 @@ static struct fi_ops_cm usdf_cm_rdm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
-	.join = fi_no_join,
-	.leave = fi_no_leave,
 };
 
 static struct fi_ops_msg usdf_rdm_ops = {

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -437,8 +437,6 @@ static struct fi_ops_cm usdf_pep_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = usdf_pep_reject,
 	.shutdown = fi_no_shutdown,
-	.join = fi_no_join,
-	.leave = fi_no_leave,
 };
 
 int

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -1699,8 +1699,6 @@ static struct fi_ops_cm fi_ibv_msg_ep_cm_ops = {
 	.accept = fi_ibv_msg_ep_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_ibv_msg_ep_shutdown,
-	.join = fi_no_join,
-	.leave = fi_no_leave,
 };
 
 static int
@@ -2593,8 +2591,6 @@ static struct fi_ops_cm fi_ibv_pep_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_ibv_msg_ep_reject,
 	.shutdown = fi_no_shutdown,
-	.join = fi_no_join,
-	.leave = fi_no_leave,
 };
 
 static int fi_ibv_pep_bind(fid_t fid, struct fid *bfid, uint64_t flags)

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -1883,7 +1883,7 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 		}
 		break;
 	case RDMA_CM_EVENT_ESTABLISHED:
-		*event = FI_COMPLETE;
+		*event = FI_CONNECTED;
 		entry->info = NULL;
 		break;
 	case RDMA_CM_EVENT_DISCONNECTED:

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -196,16 +196,6 @@ int fi_no_shutdown(struct fid_ep *ep, uint64_t flags)
 {
 	return -FI_ENOSYS;
 }
-int fi_no_join(struct fid_ep *ep, void *addr, fi_addr_t *fi_addr,
-		uint64_t flags, void *context)
-{
-	return -FI_ENOSYS;
-}
-int fi_no_leave(struct fid_ep *ep, void *addr, fi_addr_t fi_addr,
-		uint64_t flags)
-{
-	return -FI_ENOSYS;
-}
 
 /*
  * struct fi_ops_av

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -175,7 +175,6 @@ static void fi_tostr_caps(char *buf, uint64_t caps)
 	IFFLAGSTR(caps, FI_RMA);
 	IFFLAGSTR(caps, FI_TAGGED);
 	IFFLAGSTR(caps, FI_ATOMICS);
-	IFFLAGSTR(caps, FI_MULTICAST);
 	IFFLAGSTR(caps, FI_DYNAMIC_MR);
 	IFFLAGSTR(caps, FI_BUFFERED_RECV);
 	fi_tostr_flags(buf, caps);


### PR DESCRIPTION
Separate FI_COMPLETE into multiple events.
Remove multicast interfaces from 1.0 release cycle.