### PR TITLE
trigger: name a previously unnamed union

### DIFF
--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -59,7 +59,7 @@ struct fi_triggered_context {
 	union {
 		struct fi_trigger_threshold	threshold;
 		void				*internal[3];
-	};
+	} trigger;
 };
 
 #else // FABRIC_DIRECT

--- a/man/fi_trigger.3.md
+++ b/man/fi_trigger.3.md
@@ -54,7 +54,7 @@ struct fi_triggered_context {
 	union {
 		struct fi_trigger_threshold	threshold;
 		void                *internal[3]; /* reserved */
-	};
+	} trigger;
 };
 {% endhighlight %}
 


### PR DESCRIPTION
Unnamed unions are not supported in C99.

Fixes #457.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>