### PR TITLE
Final? set of changes prior to 1.0 alpha interface freeze

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ AM_CPPFLAGS = \
 	-D_GNU_SOURCE \
 	-DSYSCONFDIR=\"$(sysconfdir)\" \
 	-DRDMADIR=\"@rdmadir@\" \
-	-DEXTDIR=\"$(pkglibdir)\"
+	-DPROVDLDIR=\"$(pkglibdir)\"
 
 lib_LTLIBRARIES = src/libfabric.la
 

--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -66,6 +66,7 @@ static struct fi_ops_fabric X = {
 	.domain = fi_no_domain,
 	.endpoint = fi_no_passive_ep,
 	.eq_open = fi_no_eq_open,
+	.wait_open = fi_no_wait_open,
 };
 */
 int fi_no_domain(struct fid_fabric *fabric, struct fi_domain_attr *attr,
@@ -74,6 +75,8 @@ int fi_no_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		struct fid_pep **pep, void *context);
 int fi_no_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		struct fid_eq **eq, void *context);
+int fi_no_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		struct fid_wait **waitset);
 
 /*
 static struct fi_ops_atomic X = {
@@ -185,7 +188,6 @@ static struct fi_ops_domain X = {
 	.cq_open = fi_no_cq_open,
 	.endpoint = fi_no_endpoint,
 	.cntr_open = fi_no_cntr_open,
-	.wait_open = fi_no_wait_open,
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
@@ -199,8 +201,6 @@ int fi_no_endpoint(struct fid_domain *domain, struct fi_info *info,
 		struct fid_ep **ep, void *context);
 int fi_no_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		struct fid_cntr **cntr, void *context);
-int fi_no_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
-		struct fid_wait **waitset);
 int fi_no_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 		struct fid_poll **pollset);
 int fi_no_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2015 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -171,6 +171,7 @@ enum fi_threading {
 	FI_THREAD_DOMAIN
 };
 
+#define FI_ORDER_NONE		0
 #define FI_ORDER_RAR		(1 << 0)
 #define FI_ORDER_RAW		(1 << 1)
 #define FI_ORDER_RAS		(1 << 2)
@@ -180,6 +181,8 @@ enum fi_threading {
 #define FI_ORDER_SAR		(1 << 6)
 #define FI_ORDER_SAW		(1 << 7)
 #define FI_ORDER_SAS		(1 << 8)
+#define FI_ORDER_RECV		(1 << 9)
+#define FI_ORDER_STRICT		0xFFFFFFFF
 
 enum fi_ep_type {
 	FI_EP_UNSPEC,
@@ -215,6 +218,7 @@ struct fi_tx_attr {
 	uint64_t		mode;
 	uint64_t		op_flags;
 	uint64_t		msg_order;
+	uint64_t		comp_order;
 	size_t			inject_size;
 	size_t			size;
 	size_t			iov_limit;
@@ -225,6 +229,7 @@ struct fi_rx_attr {
 	uint64_t		mode;
 	uint64_t		op_flags;
 	uint64_t		msg_order;
+	uint64_t		comp_order;
 	size_t			total_buffered_recv;
 	size_t			size;
 	size_t			iov_limit;
@@ -242,6 +247,7 @@ struct fi_ep_attr {
 	size_t			max_order_waw_size;
 	uint64_t		mem_tag_format;
 	uint64_t		msg_order;
+	uint64_t		comp_order;
 	size_t			tx_ctx_cnt;
 	size_t			rx_ctx_cnt;
 };

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -315,6 +315,7 @@ enum {
 };
 
 struct fi_eq_attr;
+struct fi_wait_attr;
 
 struct fi_ops {
 	size_t	size;
@@ -347,6 +348,8 @@ struct fi_ops_fabric {
 			struct fid_pep **pep, void *context);
 	int	(*eq_open)(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 			struct fid_eq **eq, void *context);
+	int	(*wait_open)(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+			struct fid_wait **waitset);
 };
 
 struct fid_fabric {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -171,6 +171,12 @@ enum fi_threading {
 	FI_THREAD_DOMAIN
 };
 
+enum fi_resource_mgmt {
+	FI_RM_UNSPEC,
+	FI_RM_DISABLED,
+	FI_RM_ENABLED
+};
+
 #define FI_ORDER_NONE		0
 #define FI_ORDER_RAR		(1 << 0)
 #define FI_ORDER_RAW		(1 << 1)
@@ -258,6 +264,7 @@ struct fi_domain_attr {
 	enum fi_threading	threading;
 	enum fi_progress	control_progress;
 	enum fi_progress	data_progress;
+	enum fi_resource_mgmt	resource_mgmt;
 	size_t			mr_key_size;
 	size_t			cq_data_size;
 	size_t			cq_cnt;

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -123,8 +123,6 @@ struct fi_ops_domain {
 			struct fid_sep **sep, void *context);
 	int	(*cntr_open)(struct fid_domain *domain, struct fi_cntr_attr *attr,
 			struct fid_cntr **cntr, void *context);
-	int	(*wait_open)(struct fid_domain *domain, struct fi_wait_attr *attr,
-			struct fid_wait **waitset);
 	int	(*poll_open)(struct fid_domain *domain, struct fi_poll_attr *attr,
 			struct fid_poll **pollset);
 	int	(*stx_ctx)(struct fid_domain *domain,
@@ -193,12 +191,12 @@ fi_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 }
 
 static inline int
-fi_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
+fi_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 	     struct fid_wait **waitset)
 {
-	return domain->ops->wait_open(domain, attr, waitset);
+	return fabric->ops->wait_open(fabric, attr, waitset);
 }
-	
+
 static inline int
 fi_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 	     struct fid_poll **pollset)

--- a/man/fi_poll.3.md
+++ b/man/fi_poll.3.md
@@ -42,7 +42,7 @@ int fi_poll_del(struct fid_poll *pollset, struct fid *event_fid,
 
 int fi_poll(struct fid_poll *pollset, void **context, int count);
 
-int fi_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
+int fi_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
     struct fid_wait **waitset);
 
 int fi_close(struct fid *waitset);
@@ -51,6 +51,9 @@ int fi_wait(struct fid_wait *waitset, int timeout);
 {% endhighlight %}
 
 # ARGUMENTS
+
+*fabric*
+: Fabric provider
 
 *domain*
 : Resource domain

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -52,8 +52,7 @@ ssize_t fi_tsenddata(struct fid_ep *ep, const void *buf, size_t len,
 	void *context);
 
 ssize_t fi_tsearch(struct fid_ep *ep, uint64_t *tag, uint64_t ignore,
-	uint64_t flags, void *src_addr, size_t *src_addrlen,
-	size_t *len, void *context);
+	uint64_t flags, void *src_addr, size_t *len, void *context);
 {% endhighlight %}
 
 # ARGUMENTS

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -257,6 +257,7 @@ struct psmx_fid_fabric {
 
 struct psmx_fid_domain {
 	struct fid_domain	domain;
+	struct psmx_fid_fabric	*fabric;
 	psm_ep_t		psm_ep;
 	psm_epid_t		psm_epid;
 	psm_mq_t		psm_mq;
@@ -316,7 +317,7 @@ struct psmx_cq_event_queue {
 
 struct psmx_fid_wait {
 	struct fid_wait			wait;
-	struct psmx_fid_domain		*domain;
+	struct psmx_fid_fabric		*fabric;
 	int				type;
 	union {
 		int			fd[2];
@@ -572,6 +573,8 @@ extern struct psmx_env		psmx_env;
 
 int	psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			 struct fid_domain **domain, void *context);
+int	psmx_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		       struct fid_wait **waitset);
 int	psmx_ep_open(struct fid_domain *domain, struct fi_info *info,
 		     struct fid_ep **ep, void *context);
 int	psmx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
@@ -580,8 +583,6 @@ int	psmx_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		     struct fid_av **av, void *context);
 int	psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		       struct fid_cntr **cntr, void *context);
-int	psmx_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
-		       struct fid_wait **waitset);
 int	psmx_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 		       struct fid_poll **pollset);
 

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -357,6 +357,7 @@ int psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 
 	events = FI_CNTR_EVENTS_COMP;
 	flags = 0;
+	domain_priv = container_of(domain, struct psmx_fid_domain, domain);
 
 	switch (attr->events) {
 	case FI_CNTR_EVENTS_COMP:
@@ -387,7 +388,8 @@ int psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	case FI_WAIT_MUTEX_COND:
 		wait_attr.wait_obj = attr->wait_obj;
 		wait_attr.flags = 0;
-		err = psmx_wait_open(domain, &wait_attr, (struct fid_wait **)&wait);
+		err = psmx_wait_open(&domain_priv->fabric->fabric,
+				     &wait_attr, (struct fid_wait **)&wait);
 		if (err)
 			return err;
 		break;
@@ -398,7 +400,6 @@ int psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		return -FI_EINVAL;
 	}
 
-	domain_priv = container_of(domain, struct psmx_fid_domain, domain);
 	cntr_priv = (struct psmx_fid_cntr *) calloc(1, sizeof *cntr_priv);
 	if (!cntr_priv)
 		return -ENOMEM;

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -704,6 +704,7 @@ int psmx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	int entry_size;
 	int err;
 
+	domain_priv = container_of(domain, struct psmx_fid_domain, domain);
 	switch (attr->format) {
 	case FI_CQ_FORMAT_UNSPEC:
 		attr->format = FI_CQ_FORMAT_TAGGED;
@@ -750,7 +751,8 @@ int psmx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	case FI_WAIT_MUTEX_COND:
 		wait_attr.wait_obj = attr->wait_obj;
 		wait_attr.flags = 0;
-		err = psmx_wait_open(domain, &wait_attr, (struct fid_wait **)&wait);
+		err = psmx_wait_open(&domain_priv->fabric->fabric,
+				     &wait_attr, (struct fid_wait **)&wait);
 		if (err)
 			return err;
 		break;
@@ -774,7 +776,6 @@ int psmx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		}
 	}
 
-	domain_priv = container_of(domain, struct psmx_fid_domain, domain);
 	cq_priv = (struct psmx_fid_cq *) calloc(1, sizeof *cq_priv);
 	if (!cq_priv) {
 		if (wait)

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -82,7 +82,6 @@ static struct fi_ops_domain psmx_domain_ops = {
 	.cq_open = psmx_cq_open,
 	.endpoint = psmx_ep_open,
 	.cntr_open = psmx_cntr_open,
-	.wait_open = psmx_wait_open,
 	.poll_open = psmx_poll_open,
 };
 
@@ -111,6 +110,7 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain_priv->domain.ops = &psmx_domain_ops;
 	domain_priv->domain.mr = &psmx_mr_ops;
 	domain_priv->mode = info->mode;
+	domain_priv->fabric = container_of(fabric, struct psmx_fid_fabric, fabric);
 
 	psm_ep_open_opts_get_defaults(&opts);
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -270,6 +270,7 @@ static struct fi_ops psmx_fabric_fi_ops = {
 static struct fi_ops_fabric psmx_fabric_ops = {
 	.size = sizeof(struct fi_ops_fabric),
 	.domain = psmx_domain_open,
+	.wait_open = psmx_wait_open,
 };
 
 static int psmx_fabric(struct fi_fabric_attr *attr,

--- a/prov/psm/src/psmx_wait.c
+++ b/prov/psm/src/psmx_wait.c
@@ -184,15 +184,12 @@ static int psmx_wait_init(struct psmx_fid_wait *wait, int type)
 	return 0;
 }
 
-int psmx_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
+int psmx_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		   struct fid_wait **waitset)
 {
-	struct psmx_fid_domain *domain_priv;
 	struct psmx_fid_wait *wait_priv;
 	int type = FI_WAIT_FD;
 	int err;
-
-	domain_priv = container_of(domain, struct psmx_fid_domain, domain);
 
 	if (attr) {
 		switch (attr->wait_obj) {
@@ -222,11 +219,11 @@ int psmx_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
 		return err;
 	}
 
+	wait_priv->fabric = container_of(fabric, struct psmx_fid_fabric, fabric);
 	wait_priv->wait.fid.fclass = FI_CLASS_WAIT;
 	wait_priv->wait.fid.context = 0;
 	wait_priv->wait.fid.ops = &psmx_fi_ops;
 	wait_priv->wait.ops = &psmx_wait_ops;
-	wait_priv->domain = domain_priv;
 
 	*waitset = &wait_priv->wait;
 	return 0;

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -231,7 +231,7 @@ struct sock_poll {
 
 struct sock_wait {
 	struct fid_wait wait_fid;
-	struct sock_domain *domain;
+	struct sock_fabric *fab;
 	struct dlist_entry fid_list;
 	enum fi_wait_obj type;
 	union {
@@ -825,9 +825,7 @@ void sock_tx_ctx_abort(struct sock_tx_ctx *tx_ctx);
 
 int sock_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 		   struct fid_poll **pollset);
-int sock_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
-		   struct fid_wait **waitset);
-int sock_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
+int sock_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		   struct fid_wait **waitset);
 void sock_wait_signal(struct fid_wait *wait_fid);
 int sock_wait_get_obj(struct fid_wait *fid, void *arg);

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -275,6 +275,7 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	struct sock_fid_list *list_entry;
 	struct sock_wait *wait;
 	
+	dom = container_of(domain, struct sock_domain, dom_fid);
 	if (attr && sock_cntr_verify_attr(attr))
 		return -FI_ENOSYS;
 
@@ -302,7 +303,8 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	case FI_WAIT_FD:
 		wait_attr.flags = 0;
 		wait_attr.wait_obj = FI_WAIT_FD;
-		ret = sock_wait_open(domain, &wait_attr, &_cntr->waitset);
+		ret = sock_wait_open(&dom->fab->fab_fid, &wait_attr,
+				     &_cntr->waitset);
 		if (ret)
 			goto err1;
 		_cntr->signal = 1;
@@ -338,7 +340,6 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	_cntr->cntr_fid.fid.ops = &sock_cntr_fi_ops;
 	_cntr->cntr_fid.ops = &sock_cntr_ops;
 
-	dom = container_of(domain, struct sock_domain, dom_fid);
 	atomic_inc(&dom->ref);
 	_cntr->domain = dom;
 	*cntr = &_cntr->cntr_fid;

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -529,7 +529,7 @@ int sock_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	case FI_WAIT_MUTEX_COND:
 		wait_attr.flags = 0;
 		wait_attr.wait_obj = FI_WAIT_MUTEX_COND;
-		ret = sock_wait_open(&sock_dom->dom_fid, &wait_attr, 
+		ret = sock_wait_open(&sock_dom->fab->fab_fid, &wait_attr,
 				     &sock_cq->waitset);
 		if (ret)
 			goto err3;

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -386,7 +386,6 @@ static struct fi_ops_domain sock_dom_ops = {
 	.endpoint = sock_endpoint,
 	.scalable_ep = sock_scalable_ep,
 	.cntr_open = sock_cntr_open,
-	.wait_open = sock_wait_open,
 	.poll_open = sock_poll_open,
 	.stx_ctx = sock_stx_ctx,
 	.srx_ctx = sock_srx_ctx,

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -512,9 +512,7 @@ int sock_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	case FI_WAIT_MUTEX_COND:
 		wait_attr.flags = 0;
 		wait_attr.wait_obj = FI_WAIT_MUTEX_COND;
-		/* FIXME: waitset is a domain object, but not EQ. This needs to be 
-		 updated based on #394 */
-		ret = sock_wait_open(NULL, &wait_attr, &sock_eq->waitset);
+		ret = sock_wait_open(fabric, &wait_attr, &sock_eq->waitset);
 		if (ret)
 			goto err2;
 		sock_eq->signal = 1;

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -116,6 +116,7 @@ static struct fi_ops_fabric sock_fab_ops = {
 	.domain = sock_domain,
 	.passive_ep = sock_msg_passive_ep,
 	.eq_open = sock_eq_open,
+	.wait_open = sock_wait_open,
 };
 
 static int sock_fabric_close(fid_t fid)

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -2536,7 +2536,6 @@ static struct fi_ops_domain fi_ibv_domain_ops = {
 	.cq_open = fi_ibv_cq_open,
 	.endpoint = fi_ibv_open_ep,
 	.cntr_open = fi_no_cntr_open,
-	.wait_open = fi_no_wait_open,
 	.poll_open = fi_no_poll_open,
 };
 
@@ -2681,6 +2680,7 @@ static struct fi_ops_fabric fi_ibv_ops_fabric = {
 	.domain = fi_ibv_domain,
 	.passive_ep = fi_ibv_passive_ep,
 	.eq_open = fi_ibv_eq_open,
+	.wait_open = fi_no_wait_open,
 };
 
 int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context)

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -69,6 +69,11 @@ int fi_no_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 {
 	return -FI_ENOSYS;
 }
+int fi_no_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		struct fid_wait **waitset)
+{
+	return -FI_ENOSYS;
+}
 
 /*
  * struct fi_ops_atomic
@@ -221,11 +226,6 @@ int fi_no_endpoint(struct fid_domain *domain, struct fi_info *info,
 }
 int fi_no_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		struct fid_cntr **cntr, void *context)
-{
-	return -FI_ENOSYS;
-}
-int fi_no_wait_open(struct fid_domain *domain, struct fi_wait_attr *attr,
-		struct fid_wait **waitset)
 {
 	return -FI_ENOSYS;
 }

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -143,18 +143,10 @@ static void fi_ini(void)
 
 #ifdef HAVE_LIBDL
 	struct dirent **liblist;
-	int n, want_warn = 0;
-	char *lib, *extdir = getenv("FI_EXTDIR");
+	int n;
+	char *lib, *provdir;
 	void *dlhandle;
 	struct fi_provider* (*inif)(void);
-
-	if (extdir) {
-		/* Warn if user specified $FI_EXTDIR, but there's a
-		 * problem with the value */
-		want_warn = 1;
-	} else {
-		extdir = EXTDIR;
-	}
 
 	/* If dlopen fails, assume static linking and just return
 	   without error */
@@ -162,17 +154,13 @@ static void fi_ini(void)
 		goto done;
 	}
 
-	n = scandir(extdir, &liblist, lib_filter, NULL);
-	if (n < 0) {
-		if (want_warn) {
-			FI_WARN("scandir error reading %s: %s\n",
-				extdir, strerror(errno));
-		}
+	provdir = PROVDLDIR;
+	n = scandir(provdir, &liblist, lib_filter, NULL);
+	if (n < 0)
 		goto done;
-	}
 
 	while (n--) {
-		if (asprintf(&lib, "%s/%s", extdir, liblist[n]->d_name) < 0) {
+		if (asprintf(&lib, "%s/%s", provdir, liblist[n]->d_name) < 0) {
 			FI_WARN("asprintf failed to allocate memory\n");
 			free(liblist[n]);
 			goto done;


### PR DESCRIPTION
Addresses open issues marked with alpha release label.

Removes environment variable from libfabric framework.
Defines completion order.
Moves WaitSet from a child of the domain to the fabric
Defines resource management.