### PR TITLE
fid_stx: 'ops' should be a pointer not a struct

### DIFF
--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -134,7 +134,7 @@ struct fid_pep {
 
 struct fid_stx {
 	struct fid		fid;
-	struct fi_ops_ep	ops;
+	struct fi_ops_ep	*ops;
 };
 
 struct fid_sep {

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -886,7 +886,7 @@ int sock_stx_ctx(struct fid_domain *domain,
 		return -FI_ENOMEM;
 
 	tx_ctx->domain = dom;
-	tx_ctx->fid.stx.ops = sock_ep_ops;
+	tx_ctx->fid.stx.ops = &sock_ep_ops;
 	atomic_inc(&dom->ref);
 
 	*stx = &tx_ctx->fid.stx;


### PR DESCRIPTION
This was probably a typo.

'ops' should be a pointer to ops, not a struct keeping in
line with other such structures.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>