### PR TITLE
Fix rpm spec version v2

### DIFF
--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -107,7 +107,8 @@ close(IN);
 $config =~ m/AC_INIT\(\[libfabric\], \[(.+?)\]/;
 my $orig_version = $1;
 verbose("*** Got configure.ac version: $orig_version\n");
-my $version = "$orig_version-$gd";
+my $version = "$orig_version.$gd";
+$version =~ y/-/./;
 verbose("*** Nightly tarball version: $version\n");
 
 # Is there already a tarball of this version in the download

--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -105,20 +105,22 @@ close(IN);
 
 # Get the original version number
 $config =~ m/AC_INIT\(\[libfabric\], \[(.+?)\]/;
-my $version = $1;
-verbose("*** Got configure.ac version: $version\n");
+my $orig_version = $1;
+verbose("*** Got configure.ac version: $orig_version\n");
+my $version = "$orig_version-$gd";
+verbose("*** Nightly tarball version: $version\n");
 
 # Is there already a tarball of this version in the download
 # directory?  If so, just exit now without doing anything.
-if (-f "$download_dir_arg/libfabric-$version-$gd.tar.gz") {
-    verbose("*** Target tarball already exists: libfabric-$version-$gd.tar.gz\n");
+if (-f "$download_dir_arg/libfabric-$version.tar.gz") {
+    verbose("*** Target tarball already exists: libfabric-$version.tar.gz\n");
     verbose("*** Exiting without doing anything\n");
     exit(0);
 }
 
 # Update the version number with the output from "git describe"
 verbose("*** Re-writing configure.ac with git describe results...\n");
-$config =~ s/(AC_INIT\(\[libfabric\], \[.+?)\]/$1-$gd]/;
+$config =~ s/(AC_INIT\(\[libfabric\], \[).+?\]/$1$version]/;
 open(OUT, ">configure.ac");
 print OUT $config;
 close(OUT);
@@ -137,14 +139,14 @@ doit(0, "git checkout configure.ac");
 
 # Move the resulting tarballs to the downloads directory
 verbose("*** Placing tarballs in download directory...\n");
-doit(0, "mv libfabric-$version-$gd.tar.gz libfabric-$version-$gd.tar.bz2 $download_dir_arg");
+doit(0, "mv libfabric-$version.tar.gz libfabric-$version.tar.bz2 $download_dir_arg");
 
 # Make sym links to these newest tarballs
 chdir($download_dir_arg);
 unlink("libfabric-latest.tar.gz");
 unlink("libfabric-latest.tar.bz2");
-doit(0, "ln -s libfabric-$version-$gd.tar.gz libfabric-latest.tar.gz");
-doit(0, "ln -s libfabric-$version-$gd.tar.bz2 libfabric-latest.tar.bz2");
+doit(0, "ln -s libfabric-$version.tar.gz libfabric-latest.tar.gz");
+doit(0, "ln -s libfabric-$version.tar.bz2 libfabric-latest.tar.bz2");
 
 # Re-generate hashes
 verbose("*** Re-generating md5/sha1sums...\n");
@@ -155,7 +157,7 @@ doit(0, "sha1sum libfabric*tar* > sha1sums.txt");
 verbose("*** Re-creating latest.txt...\n");
 unlink("latest.txt");
 open(OUT, ">latest.txt") || die "Can't write to latest.txt";
-print OUT "libfabric-$version-$gd\n";
+print OUT "libfabric-$version\n";
 close(OUT);
 
 # All done


### PR DESCRIPTION
This pull request fixes issue #469, and has been tested on my system.  Note that this pull request only changes the nightly build script, but the user may also manually define `tarball_version` and `release_extra` to accomplish the same thing with a normal `make distcheck` tarball.

Changes from v1 (pull request #479):
 - Squash into two commits
 - Replace explicit `split`/`substr` with a regular expression, as suggested by @jsquyres
 - Prevent accidental interpolation of hashes in perl double-quoted strings
 - Insert prerelease into existing release number instead of replacing it
 - Use a separate `release_extra` rpm macro to define the prerelease version rather than changing the Release tag ourselves