### PR TITLE
Refine FI_THREAD_* definitions

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -167,8 +167,9 @@ enum fi_progress {
 enum fi_threading {
 	FI_THREAD_UNSPEC,
 	FI_THREAD_SAFE,
-	FI_THREAD_PROGRESS,
-	FI_THREAD_DOMAIN
+	FI_THREAD_FID,
+	FI_THREAD_DOMAIN,
+	FI_THREAD_COMPLETION
 };
 
 enum fi_resource_mgmt {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -169,7 +169,8 @@ enum fi_threading {
 	FI_THREAD_SAFE,
 	FI_THREAD_FID,
 	FI_THREAD_DOMAIN,
-	FI_THREAD_COMPLETION
+	FI_THREAD_COMPLETION,
+	FI_THREAD_ENDPOINT,
 };
 
 enum fi_resource_mgmt {

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -174,6 +174,14 @@ interfaces enables a provider to eliminate lower-level locks.
   Conceptually, FI_THREAD_FID maps well to providers that implement
   fabric services in hardware and provide separate command queues to
   different data flows.
+  
+*FI_THREAD_ENDPOINT*
+: The endpoint threading model is similar to FI_THREAD_FID, but with
+  the added restriction that serialization is required when accessing
+  the same endpoint, even if multiple transmit and receive contexts are
+  used.  Conceptualy, FI_THREAD_ENDPOINT maps well to providers that
+  implement fabric services in hardware but use a single command
+  queue to access different data flows.
 
 *FI_THREAD_COMPLETION*
   The completion threading model is intended for providers that make use

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -243,7 +243,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	psmx_info->ep_attr->tx_ctx_cnt = 1;
 	psmx_info->ep_attr->rx_ctx_cnt = 1;
 
-	psmx_info->domain_attr->threading = FI_THREAD_PROGRESS;
+	psmx_info->domain_attr->threading = FI_THREAD_COMPLETION;
 	psmx_info->domain_attr->control_progress = FI_PROGRESS_MANUAL;
 	psmx_info->domain_attr->data_progress = FI_PROGRESS_MANUAL;
 	psmx_info->domain_attr->name = strdup("psm");

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -69,7 +69,9 @@ int sock_verify_domain_attr(struct fi_domain_attr *attr)
 	switch(attr->threading){
 	case FI_THREAD_UNSPEC:
 	case FI_THREAD_SAFE:
-	case FI_THREAD_PROGRESS:
+	case FI_THREAD_FID:
+	case FI_THREAD_DOMAIN:
+	case FI_THREAD_COMPLETION:
 		break;
 	default:
 		SOCK_LOG_INFO("Invalid threading model!\n");

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -218,7 +218,9 @@ static int fi_ibv_check_domain_attr(struct fi_domain_attr *attr)
 	switch (attr->threading) {
 	case FI_THREAD_UNSPEC:
 	case FI_THREAD_SAFE:
-	case FI_THREAD_PROGRESS:
+	case FI_THREAD_FID:
+	case FI_THREAD_DOMAIN:
+	case FI_THREAD_COMPLETION:
 		break;
 	default:
 		VERBS_WARN("Invalid threading model\n");

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -149,6 +149,7 @@ static void fi_tostr_threading(char *buf, enum fi_threading threading)
 	CASEENUMSTR(FI_THREAD_FID);
 	CASEENUMSTR(FI_THREAD_DOMAIN);
 	CASEENUMSTR(FI_THREAD_COMPLETION);
+	CASEENUMSTR(FI_THREAD_ENDPOINT);
 	default:
 		strcatf(buf, "Unknown");
 		break;

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -146,7 +146,9 @@ static void fi_tostr_threading(char *buf, enum fi_threading threading)
 	switch (threading) {
 	CASEENUMSTR(FI_THREAD_UNSPEC);
 	CASEENUMSTR(FI_THREAD_SAFE);
-	CASEENUMSTR(FI_THREAD_PROGRESS);
+	CASEENUMSTR(FI_THREAD_FID);
+	CASEENUMSTR(FI_THREAD_DOMAIN);
+	CASEENUMSTR(FI_THREAD_COMPLETION);
 	default:
 		strcatf(buf, "Unknown");
 		break;


### PR DESCRIPTION
Separate FI_THREAD_PROGRESS into 2 explicit threading models (versus relying on the app also checking the progress type), and introduce a new threading model that is a restriction of one of the new models.