### PR TITLE
psm minor getinfo fixes

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -126,7 +126,6 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 		case FI_EP_UNSPEC:
 		case FI_EP_RDM:
 			break;
-			break;
 		default:
 			psmx_debug("%s: hints->ep_type=%d, supported=%d,%d.\n",
 					__func__, hints->ep_type, FI_EP_UNSPEC,

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -193,6 +193,13 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 			goto err_out;
 		}
 
+		if (hints->fabric_attr && hints->fabric_attr->prov_name &&
+		    strncmp(hints->fabric_attr->prov_name, "psm", 3)) {
+			psmx_debug("%s: hints->fabric_prov_name=%s, supported=psm\n",
+					__func__, hints->fabric_attr->prov_name);
+			goto err_out;
+		}
+
 		if (hints->domain_attr && hints->domain_attr->name &&
 		    strncmp(hints->domain_attr->name, "psm", 3)) {
 			psmx_debug("%s: hints->domain_name=%s, supported=psm\n",

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -107,7 +107,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	int ep_type = FI_EP_RDM;
 	int caps = 0;
 	uint64_t max_tag_value = 0;
-	int err = -ENODATA;
+	int err = -FI_ENODATA;
 
 	psmx_debug("%s\n", __func__);
 


### PR DESCRIPTION
3 minor fixes for the psm provider:

1. Use FI_ENODATA, not ENODATA
1. Remove extraneous "break"
1. Also check the fabric hints prov_name field

@jithinjosepkl Please review