### PR TITLE
Pr/sockets getinfo minor fixes

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -79,13 +79,26 @@ int sock_verify_info(struct fi_info *hints)
 	switch (hints->ep_type) {
 	case FI_EP_UNSPEC:
 	case FI_EP_MSG:
+		ret = sock_msg_verify_ep_attr(hints->ep_attr,
+					      hints->tx_attr,
+					      hints->rx_attr);
+		break;
 	case FI_EP_DGRAM:
+		ret = sock_dgram_verify_ep_attr(hints->ep_attr,
+						hints->tx_attr,
+						hints->rx_attr);
+		break;
 	case FI_EP_RDM:
+		ret = sock_rdm_verify_ep_attr(hints->ep_attr,
+					      hints->tx_attr,
+					      hints->rx_attr);
 		break;
 	default:
-		return -FI_ENODATA;
+		ret = -FI_ENODATA;
 	}
-	
+	if (ret)
+		return ret;
+
 	switch (hints->addr_format) {
 	case FI_FORMAT_UNSPEC:
 	case FI_SOCKADDR:
@@ -94,11 +107,6 @@ int sock_verify_info(struct fi_info *hints)
 	default:
 		return -FI_ENODATA;
 	}
-
-	if (!sock_rdm_verify_ep_attr(hints->ep_attr, hints->tx_attr, hints->rx_attr) ||
-	    !sock_dgram_verify_ep_attr(hints->ep_attr, hints->tx_attr, hints->rx_attr) ||
-	    !sock_msg_verify_ep_attr(hints->ep_attr, hints->tx_attr, hints->rx_attr))
-		return 0;
 
 	ret = sock_verify_domain_attr(hints->domain_attr);
 	if (ret) 


### PR DESCRIPTION
Minor fixes to the sockets provider:

1. Also check fabric->prov_name as part of the hints
1. Only check the EP hints of the desired type, and return if there's an error -- not success (which orphaned the fabric/domain checks).

@jithinjosepkl Please review.