### PR TITLE
getinfo prov name centralization

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -264,6 +264,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	psmx_info->src_addr = NULL;
 	psmx_info->dest_addr = dest_addr;
 	psmx_info->fabric_attr->name = strdup("psm");
+	psmx_info->fabric_attr->prov_name = strdup("psm");
 
 	psmx_info->tx_attr->caps = psmx_info->caps;
 	psmx_info->tx_attr->mode = psmx_info->mode;

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -193,13 +193,6 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 			goto err_out;
 		}
 
-		if (hints->fabric_attr && hints->fabric_attr->prov_name &&
-		    strncmp(hints->fabric_attr->prov_name, "psm", 3)) {
-			psmx_debug("%s: hints->fabric_prov_name=%s, supported=psm\n",
-					__func__, hints->fabric_attr->prov_name);
-			goto err_out;
-		}
-
 		if (hints->domain_attr && hints->domain_attr->name &&
 		    strncmp(hints->domain_attr->name, "psm", 3)) {
 			psmx_debug("%s: hints->domain_name=%s, supported=psm\n",

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -116,10 +116,6 @@ usdf_validate_hints(struct fi_info *hints, struct usd_device_attrs *dap)
 		    fattrp->prov_version != USDF_PROV_VERSION) {
 			return -FI_ENODATA;
 		}
-		if (fattrp->prov_name != NULL &&
-                    strcmp(fattrp->prov_name, USDF_PROV_NAME) != 0) {
-			return -FI_ENODATA;
-		}
 		if (fattrp->name != NULL &&
                     strcmp(fattrp->name, dap->uda_devname) != 0) {
 			return -FI_ENODATA;

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -204,9 +204,6 @@ static int fi_ibv_check_fabric_attr(struct fi_fabric_attr *attr)
 	    !strcmp(attr->name, VERBS_IWARP_FABRIC)))
 		return -FI_ENODATA;
 
-	if (attr->prov_name && strcmp(attr->prov_name, VERBS_PROV_NAME))
-		return -FI_ENODATA;
-
 	if (attr->prov_version > VERBS_PROV_VERS)
 		return -FI_ENODATA;
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -222,6 +222,10 @@ int fi_getinfo_(uint32_t version, const char *node, const char *service,
 		if (!prov->provider->getinfo)
 			continue;
 
+		if (hints->fabric_attr && hints->fabric_attr->prov_name &&
+		    strcmp(prov->provider->name, hints->fabric_attr->prov_name))
+			continue;
+
 		ret = prov->provider->getinfo(version, node, service, flags,
 					      hints, &cur);
 		if (ret) {


### PR DESCRIPTION
Per #492 and #493, centralize the fabric->prov_name check up in the fi_getinfo core.

Also, one minor nit to ensure to set fabric->prov_name in the psm provider's output.