### PR TITLE
gitignore: also ignore config/compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ libtool
 libfabric.spec
 
 config/ar-lib
+config/compile
 config/config.guess
 config/config.sub
 config/depcomp


### PR DESCRIPTION
Newer versions of the GNU Autotools use "compile" instead of "depcomp".

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>