### PR TITLE
Pr/sockets

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -155,8 +155,9 @@ struct sock_domain {
 	struct sock_conn_map r_cmap;
 	pthread_t listen_thread;
 	int listening;
-	char service[NI_MAXSERV];
+	int service;
 	int signal_fds[2];
+	struct sockaddr_storage src_addr;
 };
 
 struct sock_cntr {
@@ -845,9 +846,10 @@ int sock_av_compare_addr(struct sock_av *av,
 			 fi_addr_t addr1, fi_addr_t addr2);
 
 
-struct sock_conn *sock_conn_map_lookup_key(struct sock_conn_map *conn_map,
+struct sock_conn *sock_conn_map_lookup_key(struct sock_conn_map *conn_map, 
 					   uint16_t key);
-uint16_t sock_conn_map_match_or_connect(struct sock_conn_map *map, 
+uint16_t sock_conn_map_match_or_connect(struct sock_domain *dom,
+					struct sock_conn_map *map, 
 					struct sockaddr_in *addr, int match_only);
 int sock_conn_listen(struct sock_domain *domain);
 int sock_conn_map_clear_pe_entry(struct sock_conn *conn_entry, uint16_t key);

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -218,7 +218,7 @@ struct sock_av {
 	struct sock_av_table_hdr *table_hdr;
 	struct sock_av_addr *table;
 	uint16_t *key;
-	char name[FI_NAME_MAX];
+	char *name;
 	int shared_fd;
 };
 

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -63,7 +63,7 @@ static ssize_t sock_comm_send_socket(struct sock_conn *conn, const void *buf, si
 
 	while(rem > 0) {
 		len = MIN(rem, SOCK_COMM_BUF_SZ);
-		ret = send(conn->sock_fd, buf + offset, len, 0);
+		ret = send(conn->sock_fd, (char *)buf + offset, len, 0);
 		if (ret <= 0) 
 			break;
 		

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -98,24 +98,29 @@ struct sock_conn *sock_conn_map_lookup_key(struct sock_conn_map *conn_map,
 	return &conn_map->table[key-1];
 }
 
-uint16_t sock_conn_map_match_or_connect(struct sock_conn_map *map, struct
-		sockaddr_in *addr, int match_only)
+#define SOCK_ADDR_IN_PTR(sa)((struct sockaddr_in *)(sa))
+#define SOCK_ADDR_IN_FAMILY(sa)SOCK_ADDR_IN_PTR(sa)->sin_family
+#define SOCK_ADDR_IN_PORT(sa)SOCK_ADDR_IN_PTR(sa)->sin_port
+#define SOCK_ADDR_IN_ADDR(sa)SOCK_ADDR_IN_PTR(sa)->sin_addr
+
+uint16_t sock_conn_map_match_or_connect(struct sock_domain *dom,
+					struct sock_conn_map *map, 
+					struct sockaddr_in *addr, int match_only)
 {
 	int i, conn_fd, arg, optval;
 	socklen_t optlen;
-	char entry_ip[INET_ADDRSTRLEN];
 	char sa_ip[INET_ADDRSTRLEN];
 	struct sockaddr_in *entry;
 	struct timeval tv;
 	fd_set fds;
 	struct sock_conn *conn;
 
-	memcpy(sa_ip, inet_ntoa(addr->sin_addr), INET_ADDRSTRLEN);
 	/* match */
 	for (i=0; i < map->used; i++) {
-		entry = (struct sockaddr_in *)&map->table[i].addr;
-		memcpy(entry_ip, inet_ntoa(entry->sin_addr), INET_ADDRSTRLEN);
-		if(!strcmp(entry_ip, sa_ip)) {
+		entry = (struct sockaddr_in *)&(map->table[i].addr);
+		if ((SOCK_ADDR_IN_ADDR(entry).s_addr == 
+		     SOCK_ADDR_IN_ADDR(addr).s_addr) &&
+		    (SOCK_ADDR_IN_PORT(entry) == SOCK_ADDR_IN_PORT(addr))) {
 			return i+1;
 		}
 	}
@@ -129,7 +134,25 @@ uint16_t sock_conn_map_match_or_connect(struct sock_conn_map *map, struct
 		SOCK_LOG_ERROR("failed to create conn_fd, errno: %d\n", errno);
 		return 0;
 	}
+	
+	optval = 1;
+	setsockopt(conn_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof optval);
+	optval = 1;
+	setsockopt(conn_fd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof optval);
+
 	fcntl(conn_fd, F_SETFL, O_NONBLOCK);
+	memcpy(sa_ip, inet_ntoa(addr->sin_addr), INET_ADDRSTRLEN);
+	SOCK_LOG_INFO("Connecting to: %s:%d\n",
+		      sa_ip, ntohs(((struct sockaddr_in*)addr)->sin_port));
+	
+	if (bind(conn_fd, (struct sockaddr*)&dom->src_addr, 
+		 sizeof(struct sockaddr_in)) != 0) {
+		SOCK_LOG_ERROR("Cannot bind to src_addr\n");
+		return 0;
+	}
+	
+	SOCK_LOG_INFO("Binding conn_fd  to port: %d\n", 
+		      ntohs(((struct sockaddr_in*)&dom->src_addr)->sin_port));
 
 	if (connect(conn_fd, addr, sizeof *addr) < 0) {
 		if (errno == EINPROGRESS) {
@@ -174,7 +197,6 @@ uint16_t sock_conn_map_match_or_connect(struct sock_conn_map *map, struct
 
 	map->used++;
 	return map->used;
-
 }
 
 static void * _sock_conn_listen(void *arg)
@@ -183,25 +205,29 @@ static void * _sock_conn_listen(void *arg)
 	struct sock_conn_map *map = &domain->r_cmap;
 	struct addrinfo *s_res = NULL, *p;
 	struct addrinfo hints;
-	int optval, flags;
+	int optval, flags, tmp;
 	int listen_fd = 0, conn_fd;
 	struct sockaddr_in remote;
 	socklen_t addr_size;
 	struct sock_conn *conn;
 	struct pollfd poll_fds[2];
+	char service[NI_MAXSERV];
+	struct sockaddr_in addr;
+	char sa_ip[INET_ADDRSTRLEN];
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_INET;
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_flags = AI_PASSIVE;
 
-	if(getaddrinfo(NULL, domain->service, &hints, &s_res)) {
+	sprintf(service, "%d", domain->service);
+	if(getaddrinfo(NULL, service, &hints, &s_res)) {
 		SOCK_LOG_ERROR("no available AF_INET address\n");
 		perror("no available AF_INET address");
 		return NULL;
 	}
 
-	SOCK_LOG_INFO("Binding listener thread to port: %s\n", domain->service);
+	SOCK_LOG_INFO("Binding listener thread to port: %d\n", domain->service);
 	for (p=s_res; p; p=p->ai_next) {
 		listen_fd = socket(p->ai_family, p->ai_socktype, p->ai_protocol);
 		if (listen_fd >= 0) {
@@ -211,17 +237,30 @@ static void * _sock_conn_listen(void *arg)
 			optval = 1;
 			setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof
 					optval);
+			optval = 1;
+			setsockopt(listen_fd, SOL_SOCKET, SO_REUSEPORT, &optval, sizeof
+					optval);
+
+
 			if (!bind(listen_fd, s_res->ai_addr, s_res->ai_addrlen))
 				break;
 			close(listen_fd);
 			listen_fd = -1;
 		}
 	}
-
 	freeaddrinfo(s_res);
+
 	if (listen_fd < 0) {
-		SOCK_LOG_ERROR("failed to listen to port: %s\n", domain->service);
+		SOCK_LOG_ERROR("failed to listen to port: %d\n", domain->service);
 		goto err;
+	}
+	
+	if (domain->service == 0) {
+		addr_size = sizeof(struct sockaddr_in);
+		if (getsockname(listen_fd, (struct sockaddr*)&addr, &addr_size))
+			goto err;
+		domain->service = ntohs(addr.sin_port);
+		SOCK_LOG_INFO("Bound to port: %d\n", domain->service);
 	}
 
 	if (listen(listen_fd, 128)) {
@@ -229,13 +268,19 @@ static void * _sock_conn_listen(void *arg)
 		goto err;
 	}
 
+	((struct sockaddr_in*)&(domain->src_addr))->sin_port = 
+		htons(domain->service);
+	domain->listening = 1;
+
 	poll_fds[0].fd = listen_fd;
 	poll_fds[1].fd = domain->signal_fds[1];
 	poll_fds[0].events = poll_fds[1].events = POLLIN;
  	while(domain->listening) {
 		if (poll(poll_fds, 2, -1) > 0) {
-			if (!poll_fds[0].revents & POLLIN)
+			if (poll_fds[1].revents & POLLIN) {
+				read(domain->signal_fds[1], &tmp, 1);
 				continue;
+			}
 		} else
 			goto err;
 
@@ -246,6 +291,12 @@ static void * _sock_conn_listen(void *arg)
 			SOCK_LOG_ERROR("failed to accept: %d\n", errno);
 			goto err;
 		}
+		
+		addr_size = sizeof(struct sockaddr_in);
+		getpeername(conn_fd, &remote, &addr_size);
+
+		memcpy(sa_ip, inet_ntoa(remote.sin_addr), INET_ADDRSTRLEN);
+		SOCK_LOG_INFO("ACCEPT: %s, %d\n", sa_ip, ntohs(remote.sin_port));
 
 		/* TODO: lock for multi-threads */
 		if ((map->size - map->used) == 0) {
@@ -272,7 +323,6 @@ err:
 int sock_conn_listen(struct sock_domain *domain)
 {
 	_init_map(&domain->r_cmap, 128); /* TODO: init cmap size */
-	domain->listening = 1;
 	pthread_create(&domain->listen_thread, 0, _sock_conn_listen, domain);
 	return 0;
 }

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -56,34 +56,38 @@ extern const struct fi_fabric_attr sock_fabric_attr;
 extern const char const sock_fab_name[];
 extern const char const sock_dom_name[];
 
+static void sock_dequeue_tx_ctx(struct sock_tx_ctx *tx_ctx)
+{
+	fastlock_acquire(&tx_ctx->domain->pe->lock);
+	dlist_remove(&tx_ctx->pe_entry);
+	fastlock_release(&tx_ctx->domain->pe->lock);
+}
+
+static void sock_dequeue_rx_ctx(struct sock_rx_ctx *rx_ctx)
+{
+	fastlock_acquire(&rx_ctx->domain->pe->lock);
+	dlist_remove(&rx_ctx->pe_entry);
+	fastlock_release(&rx_ctx->domain->pe->lock);
+}
+
 static int sock_ctx_close(struct fid *fid)
 {
-	struct sock_ep *ep;
-	struct dlist_entry *entry;
 	struct sock_tx_ctx *tx_ctx;
 	struct sock_rx_ctx *rx_ctx;
 
 	switch (fid->fclass) {
 	case FI_CLASS_TX_CTX:
 		tx_ctx = container_of(fid, struct sock_tx_ctx, fid.ctx.fid);
-		
-		for (entry = tx_ctx->ep_list.next; entry != &tx_ctx->ep_list;
-		    entry = entry->next) {
-			ep = container_of(entry, struct sock_ep, tx_ctx_entry);
-			atomic_dec(&ep->num_tx_ctx);
-		}
+		sock_dequeue_tx_ctx(tx_ctx);
+		atomic_dec(&tx_ctx->ep->num_rx_ctx);
 		atomic_dec(&tx_ctx->domain->ref);
 		sock_tx_ctx_free(tx_ctx);
 		break;
 
 	case FI_CLASS_RX_CTX:
 		rx_ctx = container_of(fid, struct sock_rx_ctx, ctx.fid);
-		
-		for (entry = rx_ctx->ep_list.next; entry != &rx_ctx->ep_list;
-		    entry = entry->next) {
-			ep = container_of(entry, struct sock_ep, rx_ctx_entry);
-			atomic_dec(&ep->num_rx_ctx);
-		}
+		sock_dequeue_rx_ctx(rx_ctx);
+		atomic_dec(&rx_ctx->ep->num_rx_ctx);
 		atomic_dec(&rx_ctx->domain->ref);
 		sock_rx_ctx_free(rx_ctx);
 		break;
@@ -91,12 +95,14 @@ static int sock_ctx_close(struct fid *fid)
 	case FI_CLASS_STX_CTX:
 		tx_ctx = container_of(fid, struct sock_tx_ctx, fid.stx.fid);
 		atomic_dec(&tx_ctx->domain->ref);
+		sock_dequeue_tx_ctx(tx_ctx);
 		sock_tx_ctx_free(tx_ctx);
 		break;
 
 	case FI_CLASS_SRX_CTX:
 		rx_ctx = container_of(fid, struct sock_rx_ctx, ctx.fid);
 		atomic_dec(&rx_ctx->domain->ref);
+		sock_dequeue_rx_ctx(rx_ctx);
 		sock_rx_ctx_free(rx_ctx);
 		break;
 
@@ -495,12 +501,16 @@ static int sock_ep_close(struct fid *fid)
 		return -FI_EBUSY;
 
 	if (sock_ep->fclass != FI_CLASS_SEP && 
-	    sock_ep->ep_attr.tx_ctx_cnt != FI_SHARED_CONTEXT)
+	    sock_ep->ep_attr.tx_ctx_cnt != FI_SHARED_CONTEXT) {
+		sock_dequeue_tx_ctx(sock_ep->tx_array[0]);
 		sock_tx_ctx_free(sock_ep->tx_array[0]);
+	}
 
 	if (sock_ep->fclass != FI_CLASS_SEP && 
-	    sock_ep->ep_attr.rx_ctx_cnt != FI_SHARED_CONTEXT)
+	    sock_ep->ep_attr.rx_ctx_cnt != FI_SHARED_CONTEXT) {
+		sock_dequeue_rx_ctx(sock_ep->rx_array[0]);
 		sock_rx_ctx_free(sock_ep->rx_array[0]);
+	}
 
 	free(sock_ep->tx_array);
 	free(sock_ep->rx_array);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1087,6 +1087,8 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 			sock_ep->src_addr = calloc(1, sizeof(struct sockaddr_in));
 			memcpy(sock_ep->src_addr, info->src_addr, 
 			       sizeof(struct sockaddr_in));
+			((struct sockaddr_in*)sock_ep->src_addr)->sin_port = 
+				htons(sock_dom->service);
 		}
 		
 		if (info->dest_addr) {
@@ -1175,8 +1177,8 @@ err:
 struct sock_conn *sock_ep_lookup_conn(struct sock_ep *ep)
 {
 	if (!ep->key) {
-		ep->key = sock_conn_map_match_or_connect(&ep->domain->r_cmap,
-				ep->dest_addr, 0);
+		ep->key = sock_conn_map_match_or_connect(
+			ep->domain, &ep->domain->r_cmap, ep->dest_addr, 0);
 		if (!ep->key) {
 			SOCK_LOG_ERROR("failed to match or connect to addr\n");
 			errno = EINVAL;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1068,6 +1068,7 @@ int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx)
 		pe_entry.pe.rx.rx_iov[0].iov.addr = rx_posted->iov[0].iov.addr;
 		pe_entry.type = SOCK_PE_RX;
 		pe_entry.comp = rx_buffered->comp;
+		pe_entry.flags = 0;
 
 		if (rx_posted->flags & FI_MULTI_RECV) {
 			if (sock_rx_avail_len(rx_posted) < rx_ctx->min_multi_recv) {


### PR DESCRIPTION
- Bind connecting socket to src-addr port, to reuse connection.
- Remove rx/tx contexts from progress engine during ctx-close
- Avoid void* arithmetic
- Fix possible uninitialized variable use