### PR TITLE
verbs: remove redundant -libverbs -lrdmacm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,7 @@ _verbs_files = prov/verbs/src/fi_verbs.c
 if HAVE_VERBS_DL
 pkglib_LTLIBRARIES += libverbs-fi.la
 libverbs_fi_la_SOURCES = $(_verbs_files) $(common_srcs)
-libverbs_fi_la_LIBADD = -libverbs -lrdmacm $(linkback)
+libverbs_fi_la_LIBADD = $(linkback)
 libverbs_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
 libverbs_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_VERBS_DL


### PR DESCRIPTION
These libraries are already added to LIBS via the AC_CHECK_LIBs in prov/verbs/configure.m4.

That being said, when being built as a DL, it certainly would be nice/social if DL's didn't pollute the global LIBS with libraries that only the DL needs, but that's a different topic...

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@pmmccorm Please review.