### PR TITLE
configury: c11 atomic checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,8 +75,10 @@ AC_CHECK_LIB(rt, clock_gettime, [],
 dnl Check for gcc atomic intrinsics
 AC_MSG_CHECKING(compiler support for c11 atomics)
 AC_TRY_LINK([#include <stdatomic.h>],
-    [#ifdef __STDC_NO_ATOMICS__
-       return 1;
+    [atomic_int a;
+     atomic_init(&a, 0);
+     #ifdef __STDC_NO_ATOMICS__
+       #error c11 atomics are not supported
      #else
        return 0;
      #endif


### PR DESCRIPTION
 * correctly set the __STDC_NO_ATOMICS__ macro is not defined
 * test the existence of the atomic_init function/macro

This test is to correctly handle intel compilers since
c11 atomics are only implemented in c++ but not in c