### PR TITLE
Fixed a segfault bug due to kernel and usd have different vnic RES

### DIFF
--- a/prov/usnic/src/usnic_direct/usd_queues.c
+++ b/prov/usnic/src/usnic_direct/usd_queues.c
@@ -145,6 +145,15 @@ usd_map_vnic_res(struct usd_device *dev, struct usd_vf *vf,
             err = usd_map_one_res(dev, vf, &vfip->barres[i]);
             if (err)
                 return err;
+        } else {
+            /* Disable any other res not reported by kernel module */
+            struct vnic_dev_iomap_info iomap;
+            iomap.vaddr = 0;
+            iomap.bus_addr = vnic_dev_get_res_bus_addr(
+                                        vf->vf_vdev, i, 0);
+            iomap.len = vnic_dev_get_res_type_len(
+                                        vf->vf_vdev, i);
+            vnic_dev_upd_res_vaddr(vf->vf_vdev, &iomap);
         }
     }
 


### PR DESCRIPTION
type enum value

usd calls vnic_dev_discover_res to initiate vdev->res virtual addresses
based on whole bar io mapping, then later updates the virtual addresses
for vnic resources reported by kernel module. But if kernel and usd have
different RES enum values due to different build time, resulting
some resources not reported by kenerl but discovered by usd contain invalid
virtual addresses. This fix disables all resources not reported by kernel
by setting their virtual addresses to 0.

Signed-off-by: Xuyang Wang <xuywang@cisco.com>