### PR TITLE
man: add missing FI_PROTO_UDP and FI_PROTO_SOCK_TCP constants

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -420,6 +420,15 @@ protocol value set to one.
   performance scaled messaging.  PSMX is an extended version of the
   PSM protocol to support the libfabric interfaces.
 
+*FI_PROTO_UDP*
+: The protocol sends and receives UDP datagrams.  For example, an
+  endpoint using *FI_PROTO_UDP* will be able to communicate with a
+  remote peer that is using Berkeley *SOCK_DGRAM* sockets using
+  *IPPROTO_UDP*.
+
+*FI_PROTO_SOCK_TCP*
+: The protocol is layered over TCP packets.
+
 ## protocol_version - Protocol Version
 
 Identifies which version of the protocol is employed by the provider.


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@shefty @jithinjosepkl Is the "SOCK" in FI_PROTO_SOCK_TCP supposed to indicate that it uses userspace sockets?