### PR TITLE
remove fi_bind

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -376,11 +376,6 @@ static inline int fi_close(struct fid *fid)
 	return fid->ops->close(fid);
 }
 
-static inline int fi_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
-{
-	return fid->ops->bind(fid, bfid, flags);
-}
-
 struct fi_alias {
 	struct fid 		**fid;
 	uint64_t		flags;

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -171,6 +171,11 @@ static inline int fi_ep_bind(struct fid_ep *ep, struct fid *bfid, uint64_t flags
 	return ep->fid.ops->bind(&ep->fid, bfid, flags);
 }
 
+static inline int fi_pep_bind(struct fid_pep *pep, struct fid *bfid, uint64_t flags)
+{
+	return pep->fid.ops->bind(&pep->fid, bfid, flags);
+}
+
 static inline int fi_scalable_ep_bind(struct fid_sep *sep, struct fid *bfid, uint64_t flags)
 {
 	return sep->fid.ops->bind(&sep->fid, bfid, flags);


### PR DESCRIPTION
This function has been replaced with fi_ep_bind (and similar) functions.