### PR TITLE
sockets: Fix for fid.fclass not being set when a shared transmit context is created.

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -952,6 +952,8 @@ int sock_stx_ctx(struct fid_domain *domain,
 		return -FI_ENOMEM;
 
 	tx_ctx->domain = dom;
+	tx_ctx->fid.ctx.fid.fclass = FI_CLASS_STX_CTX;
+	
 	tx_ctx->fid.stx.fid.ops = &sock_ctx_ops;
 	tx_ctx->fid.stx.ops = &sock_ep_ops;
 	atomic_inc(&dom->ref);


### PR DESCRIPTION
sockets: Fix for fid.fclass not being set when a shared transmit context is created.

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>