### PR TITLE
Add FI_TYPE_VERSION to fi_tostr function

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -440,6 +440,7 @@ enum fi_type {
 	FI_TYPE_AV_TYPE,
 	FI_TYPE_ATOMIC_TYPE,
 	FI_TYPE_ATOMIC_OP,
+	FI_TYPE_VERSION,
 };
 
 char *fi_tostr(const void *data, enum fi_type datatype);

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -114,6 +114,10 @@ datatype or field value.
 *FI_TYPE_MSG_ORDER*
 : struct fi_ep_attr::msg_order field
 
+*FI_TYPE_VERSION*
+: Returns the library version of libfabric in string form.  The data
+  parameter is ignored.
+
 fi_tostr() will return a pointer to an internal libfabric buffer that
 should not be modified, and will be overwritten the next time
 fi_tostr() is invoked.  fi_tostr() is not thread safe.

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -487,6 +487,11 @@ static void fi_tostr_atomic_op(char *buf, enum fi_op op)
 	}
 }
 
+static void fi_tostr_version(char *buf)
+{
+	strcatf(buf, VERSION);
+}
+
 __attribute__((visibility ("default")))
 char *fi_tostr_(const void *data, enum fi_type datatype)
 {
@@ -559,6 +564,9 @@ char *fi_tostr_(const void *data, enum fi_type datatype)
 		break;
 	case FI_TYPE_ATOMIC_OP:
 		fi_tostr_atomic_op(buf, enumval);
+		break;
+	case FI_TYPE_VERSION:
+		fi_tostr_version(buf);
 		break;
 	default:
 		strcatf(buf, "Unknown type");


### PR DESCRIPTION
This allows printing the version of the library (as opposed to the API version), and is meant for use in application and middleware version output, to be given in bug reports.  This commit resolves issue #490.

Changes suggested by @jsquyres and @pmmccorm have been incorporated.  This has been separated from PR #482 at the request of @jsquyres.