### PR TITLE
src/common.c: helper functions

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -190,6 +190,11 @@ size_t fi_datatype_size(enum fi_datatype datatype);
 uint64_t fi_tag_bits(uint64_t mem_tag_format);
 uint64_t fi_tag_format(uint64_t tag_bits);
 
+int fi_send_allowed(uint64_t caps);
+int fi_recv_allowed(uint64_t caps);
+int fi_rma_initiate_allowed(uint64_t caps);
+int fi_rma_target_allowed(uint64_t caps);
+
 #define RDMA_CONF_DIR  SYSCONFDIR "/" RDMADIR
 #define FI_CONF_DIR RDMA_CONF_DIR "/fabric"
 

--- a/src/common.c
+++ b/src/common.c
@@ -155,3 +155,63 @@ size_t fi_datatype_size(enum fi_datatype datatype)
 	}
 	return fi_datatype_size_table[datatype];
 }
+
+int fi_send_allowed(uint64_t caps)
+{
+	if (caps & FI_MSG ||
+		caps & FI_TAGGED) {
+		if (caps & FI_SEND)
+			return 1;
+		if (caps & FI_RECV)
+			return 0;
+		return 1;
+	}
+
+	return 0;
+}
+
+int fi_recv_allowed(uint64_t caps)
+{
+	if (caps & FI_MSG ||
+		caps & FI_TAGGED) {
+		if (caps & FI_RECV)
+			return 1;
+		if (caps & FI_SEND)
+			return 0;
+		return 1;
+	}
+
+	return 0;
+}
+
+int fi_rma_initiate_allowed(uint64_t caps)
+{
+	if (caps & FI_RMA ||
+		caps & FI_ATOMICS) {
+		if (caps & FI_WRITE ||
+			caps & FI_READ)
+			return 1;
+		if (caps & FI_REMOTE_WRITE ||
+			caps & FI_REMOTE_READ)
+			return 0;
+		return 1;
+	}
+
+	return 0;
+}
+
+int fi_rma_target_allowed(uint64_t caps)
+{
+	if (caps & FI_RMA ||
+		caps & FI_ATOMICS) {
+		if (caps & FI_REMOTE_WRITE ||
+			caps & FI_REMOTE_READ)
+			return 1;
+		if (caps & FI_WRITE ||
+			caps & FI_READ)
+			return 0;
+		return 1;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
These functions can be used by providers to determine
whether the capabilities allow for send, or receive and
RMA initiator vs. target.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>