### PR TITLE
move rx/tx size_left code to basic ep ops

### DIFF
--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -235,6 +235,8 @@ static struct fi_ops_ep X = {
 	.setopt = fi_no_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
 };
 */
 int fi_no_enable(struct fid_ep *ep);
@@ -249,6 +251,8 @@ int fi_no_tx_ctx(struct fid_sep *sep, int index,
 int fi_no_rx_ctx(struct fid_sep *sep, int index,
 		struct fi_rx_attr *attr, struct fid_ep **rx_ep,
 		void *context);
+ssize_t fi_no_rx_size_left(struct fid_ep *ep);
+ssize_t fi_no_tx_size_left(struct fid_ep *ep);
 
 /*
 static struct fi_ops_msg X = {
@@ -262,8 +266,6 @@ static struct fi_ops_msg X = {
 	.inject = fi_no_msg_inject,
 	.senddata = fi_no_msg_senddata,
 	.injectdata = fi_no_msg_injectdata,
-	.rx_size_left = fi_no_msg_rx_size_left,
-	.tx_size_left = fi_no_msg_tx_size_left,
 };
 */
 ssize_t fi_no_msg_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
@@ -284,8 +286,6 @@ ssize_t fi_no_msg_senddata(struct fid_ep *ep, const void *buf, size_t len, void 
 		uint64_t data, fi_addr_t dest_addr, void *context);
 ssize_t fi_no_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 		uint64_t data, fi_addr_t dest_addr);
-ssize_t fi_no_msg_rx_size_left(struct fid_ep *ep);
-ssize_t fi_no_msg_tx_size_left(struct fid_ep *ep);
 
 /*
 static struct fi_ops_wait X = {

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -77,6 +77,8 @@ struct fi_ops_ep {
 	int	(*rx_ctx)(struct fid_sep *sep, int index,
 			struct fi_rx_attr *attr, struct fid_ep **rx_ep,
 			void *context);
+	ssize_t (*rx_size_left)(struct fid_ep *ep);
+	ssize_t (*tx_size_left)(struct fid_ep *ep);
 };
 
 struct fi_ops_msg {
@@ -99,8 +101,6 @@ struct fi_ops_msg {
 			uint64_t data, fi_addr_t dest_addr, void *context);
 	ssize_t	(*injectdata)(struct fid_ep *ep, const void *buf, size_t len,
 			uint64_t data, fi_addr_t dest_addr);
-	ssize_t (*rx_size_left)(struct fid_ep *ep);
-	ssize_t (*tx_size_left)(struct fid_ep *ep);
 };
 
 struct fi_ops_cm;
@@ -224,6 +224,18 @@ fi_rx_context(struct fid_sep *sep, int index, struct fi_rx_attr *attr,
 	return sep->ops->rx_ctx(sep, index, attr, rx_ep, context);
 }
 
+static inline ssize_t
+fi_rx_size_left(struct fid_ep *ep)
+{
+	return ep->ops->rx_size_left(ep);
+}
+
+static inline ssize_t
+fi_tx_size_left(struct fid_ep *ep)
+{
+	return ep->ops->tx_size_left(ep);
+}
+
 static inline int
 fi_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,
 	       struct fid_stx **stx, void *context)
@@ -296,18 +308,6 @@ fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 		uint64_t data, fi_addr_t dest_addr)
 {
 	return ep->msg->injectdata(ep, buf, len, data, dest_addr);
-}
-
-static inline ssize_t
-fi_rx_size_left(struct fid_ep *ep)
-{
-	return ep->msg->rx_size_left(ep);
-}
-
-static inline ssize_t
-fi_tx_size_left(struct fid_ep *ep)
-{
-	return ep->msg->tx_size_left(ep);
 }
 
 #else // FABRIC_DIRECT

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -37,6 +37,10 @@ fi_getopt / fi_setopt
 fi_rx_context / fi_tx_context / fi_srx_context  / fi_stx_context
 :   Open a transmit or receive context.
 
+fi_rx_size_left / fi_tx_size_left
+:   Query the lower bound on how many RX/TX operations may be posted without
+    an operation returning -FI_EAGAIN.
+
 # SYNOPSIS
 
 {% highlight c %}
@@ -88,6 +92,10 @@ int fi_getopt(struct fid_ *ep, int level, int optname,
 
 int fi_setopt(struct fid *ep, int level, int optname,
     const void *optval, size_t optlen);
+
+ssize_t fi_rx_size_left(struct fid_ep *ep);
+
+ssize_t fi_tx_size_left(struct fid_ep *ep);
 {% endhighlight %}
 
 # ARGUMENTS
@@ -366,6 +374,24 @@ The following option levels and option names and parameters are defined.
   receives posted after the value has been changed.  It is recommended
   that applications that want to override the default MIN_MULTI_RECV
   value set this option before enabling the corresponding endpoint.
+
+## fi_rx_size_left
+
+The fi_rx_size_left call returns a lower bound on the number of receive
+operations that may be posted to the given endpoint without that operation
+returning -FI_EAGAIN.  Depending on the specific details of the subsequently
+posted receive operations (e.g., number of iov entries, which receive function
+is called, etc.), it may be possible to post more receive operations than
+originally indicated by fi_rx_size_left.
+
+## fi_tx_size_left
+
+The fi_tx_size_left call returns a lower bound on the number of transmit
+operations that may be posted to the given endpoint without that operation
+returning -FI_EAGAIN.  Depending on the specific details of the subsequently
+posted transmit operations (e.g., number of iov entries, which transmit
+function is called, etc.), it may be possible to post more transmit operations
+than originally indicated by fi_tx_size_left.
 
 # ENDPOINT ATTRIBUTES
 

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -44,10 +44,6 @@ ssize_t fi_inject(struct fid_ep *ep, void *buf, size_t len,
 
 ssize_t fi_senddata(struct fid_ep *ep, void *buf, size_t len,
 	void *desc, uint64_t data, fi_addr_t dest_addr, void *context);
-
-ssize_t fi_rx_size_left(struct fid_ep *ep);
-
-ssize_t fi_tx_size_left(struct fid_ep *ep);
 {% endhighlight %}
 
 # ARGUMENTS
@@ -109,10 +105,6 @@ post a data buffer to an endpoint to receive inbound messages.
 Similar to the send operations, receive operations operate
 asynchronously.  Users should not touch the posted data buffer(s)
 until the receive operation has completed.
-
-The "size_left" functions -- fi_rx_size_left, fi_tx_size_left -- return a
-lower bound on the number of receive/send operations that may be posted to the
-given endpoint without returning -FI_EAGAIN.
 
 Completed message operations are reported to the user through one or
 more event collectors associated with the endpoint.  Users provide
@@ -194,24 +186,6 @@ The fi_recvmsg call supports posting buffers over both connected and
 unconnected endpoints, with the ability to control the receive
 operation per call through the use of flags.  The fi_recvmsg function
 takes a struct fi_msg as input.
-
-## fi_rx_size_left
-
-The fi_rx_size_left call returns a lower bound on the number of receive
-operations that may be posted to the given endpoint without that operation
-returning -FI_EAGAIN.  Depending on the specific details of the subsequently
-posted receive operations (e.g., number of iov entries, which receive function
-is called, etc.), it may be possible to post more receive operations than
-originally indicated by fi_rx_size_left.
-
-## fi_tx_size_left
-
-The fi_tx_size_left call returns a lower bound on the number of send
-operations that may be posted to the given endpoint without that operation
-returning -FI_EAGAIN.  Depending on the specific details of the subsequently
-posted send operations (e.g., number of iov entries, which send function is
-called, etc.), it may be possible to post more send operations than originally
-indicated by fi_tx_size_left.
 
 # FLAGS
 

--- a/man/fi_rx_size_left.3
+++ b/man/fi_rx_size_left.3
@@ -1,1 +1,1 @@
-.so man3/fi_msg.3
+.so man3/fi_endpoint.3

--- a/man/fi_tx_size_left.3
+++ b/man/fi_tx_size_left.3
@@ -1,1 +1,1 @@
-.so man3/fi_msg.3
+.so man3/fi_endpoint.3

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -288,6 +288,8 @@ static struct fi_ops_ep psmx_ep_ops = {
 	.enable = psmx_ep_enable,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
 };
 
 int psmx_ep_open(struct fid_domain *domain, struct fi_info *info,

--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -359,7 +359,5 @@ struct fi_ops_msg psmx_msg_ops = {
 	.inject = psmx_inject,
 	.senddata = fi_no_msg_senddata,
 	.injectdata = fi_no_msg_injectdata,
-	.rx_size_left = fi_no_msg_rx_size_left,
-	.tx_size_left = fi_no_msg_tx_size_left,
 };
 

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -626,7 +626,5 @@ struct fi_ops_msg psmx_msg2_ops = {
 	.inject = psmx_inject2,
 	.senddata = fi_no_msg_senddata,
 	.injectdata = fi_no_msg_injectdata,
-	.rx_size_left = fi_no_msg_rx_size_left,
-	.tx_size_left = fi_no_msg_tx_size_left,
 };
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -463,6 +463,8 @@ struct fi_ops_ep sock_ctx_ep_ops = {
 	.setopt = sock_ctx_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
 };
 
 static int sock_ep_close(struct fid *fid)
@@ -970,6 +972,8 @@ struct fi_ops_ep sock_ep_ops ={
 	.setopt = sock_ep_setopt,
 	.tx_ctx = sock_ep_tx_ctx,
 	.rx_ctx = sock_ep_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
 };
 
 static int sock_verify_tx_attr(const struct fi_tx_attr *attr)

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -317,8 +317,6 @@ struct fi_ops_msg sock_ep_msg_ops = {
 	.sendmsg = sock_ep_sendmsg,
 	.inject = sock_ep_inject,
 	.senddata = sock_ep_senddata,
-	.rx_size_left = fi_no_msg_rx_size_left,
-	.tx_size_left = fi_no_msg_tx_size_left,
 };
 
 static ssize_t sock_ep_trecvmsg(struct fid_ep *ep, 

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -581,6 +581,8 @@ static struct fi_ops_ep usdf_base_msg_ops = {
 	.setopt = usdf_ep_msg_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
 };
 
 static struct fi_ops_cm usdf_cm_msg_ops = {

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -638,6 +638,8 @@ static struct fi_ops_ep usdf_base_rdm_ops = {
 	.setopt = usdf_ep_rdm_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
 };
 
 static struct fi_ops_cm usdf_cm_rdm_ops = {

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -908,8 +908,6 @@ static struct fi_ops_msg fi_ibv_msg_ep_msg_ops = {
 	.inject = fi_no_msg_inject,
 	.senddata = fi_ibv_msg_ep_senddata,
 	.injectdata = fi_no_msg_injectdata,
-	.rx_size_left = fi_no_msg_rx_size_left,
-	.tx_size_left = fi_no_msg_tx_size_left,
 };
 
 static ssize_t
@@ -1730,6 +1728,8 @@ static struct fi_ops_ep fi_ibv_msg_ep_base_ops = {
 	.cancel = fi_no_cancel,
 	.getopt = fi_ibv_msg_ep_getopt,
 	.setopt = fi_ibv_msg_ep_setopt,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
 };
 
 static int fi_ibv_msg_ep_close(fid_t fid)

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -300,6 +300,14 @@ int fi_no_rx_ctx(struct fid_sep *sep, int index,
 {
 	return -FI_ENOSYS;
 }
+ssize_t fi_no_rx_size_left(struct fid_ep *ep)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_no_tx_size_left(struct fid_ep *ep)
+{
+	return -FI_ENOSYS;
+}
 
 /*
  * struct fi_ops_msg
@@ -346,14 +354,6 @@ ssize_t fi_no_msg_senddata(struct fid_ep *ep, const void *buf, size_t len, void 
 }
 ssize_t fi_no_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 		uint64_t data, fi_addr_t dest_addr)
-{
-	return -FI_ENOSYS;
-}
-ssize_t fi_no_msg_rx_size_left(struct fid_ep *ep)
-{
-	return -FI_ENOSYS;
-}
-ssize_t fi_no_msg_tx_size_left(struct fid_ep *ep)
 {
 	return -FI_ENOSYS;
 }


### PR DESCRIPTION
Per @shefty's request in #539 