### PR TITLE
man: clarifications on fi_close

### DIFF
--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -246,6 +246,10 @@ address vector.  Note that any events queued on an event queue referencing
 the AV are left untouched.  It is recommended that callers retrieve all
 events associated with the AV before closing it.
 
+When closing the address vector, there must be no opened endpoints associated
+with the AV.  If resources are still associated with the AV when attempting to
+close, the call will return -FI_EBUSY.
+
 ## fi_av_bind
 
 Associates an event queue with the AV.  If an AV has been opened with

--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -164,9 +164,12 @@ struct fi_cntr_attr {
 
 ## fi_close
 
-The fi_close call releases all resources associated with a counter.
-The counter must not be bound to any other resources prior to being
-freed.
+The fi_close call releases all resources associated with a counter.  When
+closing the counter, there must be no opened endpoints, transmit contexts,
+receive contexts or memory regions associated with the counter.  If resources
+are still associated with the counter when attempting to close, the call will
+return -FI_EBUSY.
+
 
 ## fi_cntr_control
 

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -299,9 +299,12 @@ struct fi_cq_tagged_entry {
 ## fi_close
 
 The fi_close call releases all resources associated with a completion
-queue.  The CQ must not be bound to any other resources prior to being
-closed.  Any completions which remain on the CQ when it is closed are
+queue. Any completions which remain on the CQ when it is closed are
 lost.
+
+When closing the CQ, there must be no opened endpoints, transmit contexts, or
+receive contexts associated with the CQ.  If resources are still associated
+with the CQ when attempting to close, the call will return -FI_EBUSY.
 
 ## fi_control
 

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -90,9 +90,9 @@ then memory registration requests complete synchronously.
 
 ## fi_close
 
-The fi_close call is used to release all resources associated with a
-domain or interface.  All items associated with the opened domain must
-be released prior to calling fi_close.
+The fi_close call is used to release all resources associated with a domain or
+interface.  All objects associated with the opened domain must be released
+prior to calling fi_close, otherwise the call will return -FI_EBUSY.
 
 # DOMAIN ATTRIBUTES
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -193,6 +193,11 @@ fi_info connreq must reference the corresponding request.
 
 Closes an endpoint and release all resources associated with it.
 
+When closing a scalable endpoint, there must be no opened transmit contexts, or
+receive contexts associated with the scalable endpoint.  If resources are still
+associated with the scalable endpoint when attempting to close, the call will
+return -FI_EBUSY.
+
 ## fi_ep_bind
 
 fi_ep_bind is used to associate an endpoint with hardware resources.

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -181,9 +181,11 @@ struct fi_eq_attr {
 
 ## fi_close
 
-The fi_close call releases all resources associated with an event
-queue.  The EQ must not be bound to any other resources prior to being
-closed.  Any events which remain on the EQ when it is closed are lost.
+The fi_close call releases all resources associated with an event queue.  Any
+events which remain on the EQ when it is closed are lost.
+
+The EQ must not be bound to any other objects prior to being closed, otherwise
+the call will return -FI_EBUSY.
 
 ## fi_control
 

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -246,6 +246,10 @@ Fi_close is used to release all resources associated with a
 registering a memory region.  Once unregistered, further access to the
 registered memory is not guaranteed.
 
+When closing the MR, there must be no opened endpoints or counters associated
+with the MR.  If resources are still associated with the MR when attempting to
+close, the call will return -FI_EBUSY.
+
 ## fi_mr_desc / fi_mr_key
 
 The local memory descriptor and remote protection key associated with

--- a/man/fi_poll.3.md
+++ b/man/fi_poll.3.md
@@ -102,7 +102,7 @@ struct fi_poll_attr {
 
 The fi_close call releases all resources associated with a poll set.
 The poll set must not be associated with any other resources prior to
-being closed.
+being closed, otherwise the call will return -FI_EBUSY.
 
 ## fi_poll_add
 
@@ -171,7 +171,7 @@ struct fi_wait_attr {
 
 The fi_close call releases all resources associated with a wait set.
 The wait set must not be bound to any other opened resources prior to
-being closed.
+being closed, otherwise the call will return -FI_EBUSY.
 
 ## fi_wait
 


### PR DESCRIPTION
For each object that supports close, document that if
they are closed when objects are still bound to them,
the call will return -FI_EBUSY.

Fixes #545.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>