### PR TITLE
usnic: install fi_usnic.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -154,7 +154,7 @@ libusnic_direct_sources = \
 
 _usnic_files = \
 	$(libusnic_direct_sources) \
-	prov/usnic/src/fi_usnic.h \
+	prov/usnic/src/fi_ext_usnic.h \
 	prov/usnic/src/usdf.h \
 	prov/usnic/src/usdf_av.c \
 	prov/usnic/src/usdf_av.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,10 @@ else !HAVE_LD_VERSION_SCRIPT
     libfabric_version_script =
 endif !HAVE_LD_VERSION_SCRIPT
 
+rdmaincludedir = $(includedir)/rdma
+
+rdmainclude_HEADERS =
+
 # internal utility functions shared by in-tree providers:
 common_srcs = \
 	src/common.c \
@@ -189,6 +193,9 @@ _usnic_cppflags = \
         -DHAVE_LIBNL3=$(HAVE_LIBNL3) $(USNIC_LIBNL_CPPFLAGS) \
         -I$(top_srcdir)/prov/usnic/src/usnic_direct
 
+rdmainclude_HEADERS += \
+	prov/usnic/src/fi_ext_usnic.h
+
 if HAVE_USNIC_DL
 pkglib_LTLIBRARIES += libusnic-fi.la
 libusnic_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(_usnic_cppflags)
@@ -242,9 +249,7 @@ src_libfabric_la_LDFLAGS = -version-info 1 -export-dynamic \
 			   $(libfabric_version_script)
 src_libfabric_la_DEPENDENCIES = $(srcdir)/libfabric.map
 
-rdmaincludedir = $(includedir)/rdma
-
-rdmainclude_HEADERS = \
+rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fabric.h \
 	$(top_srcdir)/include/rdma/fi_atomic.h \
 	$(top_srcdir)/include/rdma/fi_cm.h \

--- a/prov/usnic/src/fi_ext_usnic.h
+++ b/prov/usnic/src/fi_ext_usnic.h
@@ -38,10 +38,12 @@
 
 #define FI_PROTO_RUDP 100
 
+#define FI_USNIC_INFO_VERSION 1
+
 /*
  * usNIC specific info
  */
-struct fi_usnic_info {
+struct fi_usnic_info_v1 {
 	uint32_t ui_link_speed;
 	uint32_t ui_netmask_be;
 	char ui_ifname[IFNAMSIZ];
@@ -49,6 +51,13 @@ struct fi_usnic_info {
 	uint32_t ui_num_vf;
 	uint32_t ui_qp_per_vf;
 	uint32_t ui_cq_per_vf;
+};
+
+struct fi_usnic_info {
+	uint32_t ui_version;
+	union {
+		struct fi_usnic_info_v1 v1;
+	} ui;
 };
 
 /*

--- a/prov/usnic/src/fi_ext_usnic.h
+++ b/prov/usnic/src/fi_ext_usnic.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_USNIC_H_
-#define _FI_USNIC_H_
+#ifndef _FI_EXT_USNIC_H_
+#define _FI_EXT_USNIC_H_
 
 #include <stdint.h>
 #include <net/if.h>
@@ -69,4 +69,4 @@ struct fi_usnic_ops_av {
 	int (*get_distance)(struct fid_av *av, void *addr, int *metric);
 };
 
-#endif /* _FI_USNIC_H_ */
+#endif /* _FI_EXT_USNIC_H_ */

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -63,8 +63,7 @@
 #include "usdf_av.h"
 #include "usdf_timer.h"
 
-/* would like to move to include/rdma */
-#include "fi_usnic.h"
+#include "fi_ext_usnic.h"
 
 static void
 usdf_av_insert_async_complete(struct usdf_av_insert *insert)

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -66,7 +66,7 @@
 #include "libnl_utils.h"
 
 #include "usdf.h"
-#include "fi_usnic.h"
+#include "fi_ext_usnic.h"
 #include "usdf_progress.h"
 #include "usdf_timer.h"
 #include "usdf_dgram.h"

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -780,12 +780,12 @@ usdf_usnic_getinfo(struct fid_fabric *fabric, struct fi_usnic_info *uip)
 	fp = fab_ftou(fabric);
 	dap = fp->fab_dev_attrs;
 
-	uip->ui_link_speed = dap->uda_bandwidth;
-	uip->ui_netmask_be = dap->uda_netmask_be;
-	strcpy(uip->ui_ifname, dap->uda_ifname);
-	uip->ui_num_vf = dap->uda_num_vf;
-	uip->ui_qp_per_vf = dap->uda_qp_per_vf;
-	uip->ui_cq_per_vf = dap->uda_cq_per_vf;
+	uip->ui.v1.ui_link_speed = dap->uda_bandwidth;
+	uip->ui.v1.ui_netmask_be = dap->uda_netmask_be;
+	strcpy(uip->ui.v1.ui_ifname, dap->uda_ifname);
+	uip->ui.v1.ui_num_vf = dap->uda_num_vf;
+	uip->ui.v1.ui_qp_per_vf = dap->uda_qp_per_vf;
+	uip->ui.v1.ui_cq_per_vf = dap->uda_cq_per_vf;
 
 	return 0;
 }

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -58,7 +58,7 @@
 #include "fi.h"
 #include "fi_enosys.h"
 
-#include "fi_usnic.h"
+#include "fi_ext_usnic.h"
 #include "usnic_direct.h"
 #include "usd.h"
 #include "usdf.h"


### PR DESCRIPTION
fi_usnic.h is the usnic-specific extensions.

Still needs a Cisco internal review.

But we wanted to post this to GH so that @shefty and others can comment on the general idea: installing `fi_PROVIDER.h`.  Is that a sufficient name?  Or should it be `fi_ext_PROVIDER.h`?  Or `fi_prov_PROVIDER.h`?  Or ...?