### PR TITLE
Fix for sockets provider MSG EP.

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -133,6 +133,7 @@ typedef struct fid *fid_t;
 #define FI_MORE			(1ULL << 29)
 #define FI_PEEK			(1ULL << 30)
 #define FI_TRIGGER		(1ULL << 31)
+#define FI_FENCE		(1ULL << 32)
 
 
 struct fi_ioc {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -221,6 +221,7 @@ enum {
 #define FI_LOCAL_MR		(1ULL << 1)
 #define FI_PROV_MR_ATTR		(1ULL << 2)
 #define FI_MSG_PREFIX		(1ULL << 3)
+#define FI_ASYNC_IOV		(1ULL << 4)
 
 struct fi_tx_attr {
 	uint64_t		caps;

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -231,6 +231,7 @@ struct fi_tx_attr {
 	size_t			inject_size;
 	size_t			size;
 	size_t			iov_limit;
+	size_t			rma_iov_limit;
 };
 
 struct fi_rx_attr {

--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -487,6 +487,11 @@ with atomic message calls.
   into a local buffer and transfer out of that buffer.  The use of
   output result buffers are not affected by this flag.
 
+*FI_FENCE*
+: Indicates that the requested operation, also
+  known as the fenced operation, be deferred until all previous operations
+  targeting the same target endpoint have completed.
+
 # RETURN VALUE
 
 Returns 0 on success. On error, a negative value corresponding to fabric

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -762,6 +762,7 @@ struct fi_tx_attr {
 	size_t    inject_size;
 	size_t    size;
 	size_t    iov_limit;
+	size_t    rma_iov_limit;
 };
 {% endhighlight %}
 
@@ -806,6 +807,16 @@ struct fi_tx_attr {
 *iov_limit*
 : This is the maximum number of IO vectors (scatter-gather elements)
   that a single posted operation may reference.
+
+*rma_iov_limit*
+: This is the maximum number of RMA IO vectors (scatter-gather elements)
+  that an RMA or atomic operation may reference.  The rma_iov_limit
+  corresponds to the rma_iov_count values in RMA and atomic operations.
+  See struct fi_msg_rma and struct fi_msg_atomic in fi_rma.3 and
+  fi_atomic.3, for additional details.  This limit applies to both the
+  number of RMA IO vectors that may be specified when initiating an
+  operation from the local endpoint, as well as the maximum number of
+  IO vectors that may be carried in a single request from a remote endpoint.
 
 ## fi_rx_context
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -450,6 +450,18 @@ below.
   a base address of 0.  Applications can request that providers select
   MR attributes by forcing this bit set after fi_getinfo returns.
 
+*FI_ASYNC_IOV*
+: Applications can reference multiple data buffers as part of a single
+  transmit operation through the use of IO vectors (SGEs).  Typically,
+  the contents of an IO vector are copied by the provider into an
+  internal buffer area, or directly to the underlying hardware.
+  However, when a large number of IOV entries are supported,
+  IOV buffering may have a negative impact on performance and memory
+  consumption.  The FI_ASYNC_IOV mode indicates that the application
+  must provide the buffering needed for the IO vectors.  When set,
+  an application must not modify an IO vector until the associated
+  operation has completed.
+
 # ENDPOINT TYPES
 
 *FI_EP_UNSPEC*

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -359,6 +359,14 @@ additional optimizations.
   Endpoints support this capability must meet the usage model as
   described by fi_trigger.3.
 
+*FI_FENCE*
+: Indicates that the endpoint support the FI_FENCE flag on data
+  transfer operations.  Support requires tracking that all previous
+  transmit requests to a specified remote endpoint complete prior
+  to initiating the fenced operation.  Fenced operations are often
+  used to enforce ordering between operations that are not otherwise
+  guaranteed by the underlying provider or protocol.
+
 # MODE
 
 The operational mode bits are used to convey requirements that an

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -243,6 +243,11 @@ fi_sendmsg.
 : Applies to fi_sendmsg.  Indicates that a completion should not be
   generated until the operation has completed on the remote side.
 
+*FI_FENCE*
+: Applies to transmits.  Indicates that the requested operation, also
+  known as the fenced operation, be deferred until all previous operations
+  targeting the same target endpoint have completed.
+
 # RETURN VALUE
 
 Returns 0 on success. On error, a negative value corresponding to fabric

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -252,6 +252,11 @@ fi_writemsg.
 : Applies to fi_writemsg.  Indicates that a completion should not be
   generated until the operation has completed on the remote side.
 
+*FI_FENCE*
+: Indicates that the requested operation, also
+  known as the fenced operation, be deferred until all previous operations
+  targeting the same target endpoint have completed.
+
 # RETURN VALUE
 
 Returns 0 on success. On error, a negative value corresponding to fabric

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -275,6 +275,11 @@ and/or fi_tsendmsg.
 : Applies to fi_tsendmsg.  Indicates that a completion should not be
   generated until the operation has completed on the remote side.
 
+*FI_FENCE*
+: Applies to transmits.  Indicates that the requested operation, also
+  known as the fenced operation, be deferred until all previous operations
+  targeting the same target endpoint have completed.
+
 The following flags may be used with fi_tsearch.
 
 *FI_CLAIM*

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -156,7 +156,7 @@ struct sock_domain {
 	struct sock_conn_map r_cmap;
 	pthread_t listen_thread;
 	int listening;
-	int service;
+	char service[NI_MAXSERV];
 	int signal_fds[2];
 	struct sockaddr_storage src_addr;
 };
@@ -798,7 +798,7 @@ ssize_t sock_eq_report_event(struct sock_eq *sock_eq, uint32_t event,
 			     const void *buf, size_t len, uint64_t flags);
 ssize_t sock_eq_report_error(struct sock_eq *sock_eq, fid_t fid, void *context,
 			     int err, int prov_errno, void *err_data);
-int sock_eq_openwait(struct sock_eq *eq, char *service);
+int sock_eq_openwait(struct sock_eq *eq, const char *service);
 struct fi_info * sock_ep_msg_process_info(struct sock_conn_req *req);
 
 int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -265,9 +265,10 @@ static void *_sock_conn_listen(void *arg)
 	hints.ai_flags = AI_PASSIVE;
 
 	sprintf(service, "%d", domain->service);
-	if(getaddrinfo(NULL, service, &hints, &s_res)) {
-		SOCK_LOG_ERROR("no available AF_INET address\n");
-		perror("no available AF_INET address");
+	ret = getaddrinfo(NULL, service, &hints, &s_res);
+	if (ret) {
+		SOCK_LOG_ERROR("no available AF_INET address, service %s, %s\n",
+				service, gai_strerror(ret));
 		return NULL;
 	}
 

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -409,7 +409,6 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 		struct fid_domain **dom, void *context)
 {
 	int ret, flags;
-	char service[NI_MAXSERV];
 	struct sock_domain *sock_domain;
 
 	if(info && info->domain_attr){
@@ -427,11 +426,11 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 
 	if(info && info->src_addr) {
 		if (getnameinfo(info->src_addr, info->src_addrlen, NULL, 0,
-				service, sizeof(service), NI_NUMERICSERV)) {
+				sock_domain->service, sizeof(sock_domain->service),
+				NI_NUMERICSERV)) {
 			SOCK_LOG_ERROR("could not resolve src_addr\n");
 			goto err;
 		}
-		sock_domain->service = atoi(service);
 		sock_domain->info = *info;
 		memcpy(&sock_domain->src_addr, info->src_addr, 
 		       sizeof(struct sockaddr_in));

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -546,7 +546,7 @@ static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		eq = container_of(bfid, struct sock_eq, eq.fid);
 		ep->eq = eq;
 		if ((eq->attr.wait_obj == FI_WAIT_FD) && (eq->wait_fd < 0))
-			sock_eq_openwait(eq, (char *)&ep->domain->service);
+			sock_eq_openwait(eq, ep->domain->service);
 		break;
 
 	case FI_CLASS_MR:
@@ -1183,7 +1183,7 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 			memcpy(sock_ep->src_addr, info->src_addr, 
 			       sizeof(struct sockaddr_in));
 			((struct sockaddr_in*)sock_ep->src_addr)->sin_port = 
-				htons(sock_dom->service);
+				htons(atoi(sock_dom->service));
 			((struct sockaddr_in*)sock_ep->src_addr)->sin_family = 
 				sock_ep->ep_id;
 		}

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -610,7 +610,7 @@ static int sock_pep_fi_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	}
 	pep->eq = eq;
 	if ((eq->attr.wait_obj == FI_WAIT_FD) && (eq->wait_fd < 0))
-		sock_eq_openwait(eq, (char *)&pep->service);
+		sock_eq_openwait(eq, pep->service);
 
 	return 0;
 }

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -790,6 +790,9 @@ struct fi_info * sock_ep_msg_process_info(struct sock_conn_req *req)
 	req->info.ep_attr = &req->ep_attr;
 	req->info.domain_attr = &req->domain_attr;
 	req->info.fabric_attr = &req->fabric_attr;
+	req->info.domain_attr->name = NULL;
+	req->info.fabric_attr->name = NULL;
+	req->info.fabric_attr->prov_name = NULL;
 	if (sock_verify_info(&req->info)) {
 		SOCK_LOG_INFO("incoming conn_req not supported\n");
 		errno = EINVAL;

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -274,7 +274,7 @@ ssize_t sock_eq_fd_sread(struct fid_eq *eq, uint32_t *event, void *buf,
 			goto out;
 		}
 		ret = sizeof *entry;
-		break;
+		return ret;
 
 	case SOCK_REJECT:
 		SOCK_LOG_INFO("received SOCK_REJECT\n");

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -419,7 +419,7 @@ static struct fi_eq_attr _sock_eq_def_attr ={
 	.wait_set = NULL,
 };
 
-int sock_eq_openwait(struct sock_eq *eq, char *service)
+int sock_eq_openwait(struct sock_eq *eq, const char *service)
 {
 	SOCK_LOG_INFO("enter\n");
 	struct addrinfo *s_res = NULL, *p;

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -41,6 +41,7 @@
 #include <fcntl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <netdb.h>
 #include <fi_list.h>
 
 #include "sock.h"
@@ -423,7 +424,7 @@ int sock_eq_openwait(struct sock_eq *eq, char *service)
 	SOCK_LOG_INFO("enter\n");
 	struct addrinfo *s_res = NULL, *p;
 	struct addrinfo hints;
-	int optval;
+	int optval, ret;
 
 	if (eq->wait_fd > 0 && !strncmp((char *)&eq->service, service, NI_MAXSERV))
 	{
@@ -440,9 +441,10 @@ int sock_eq_openwait(struct sock_eq *eq, char *service)
 	hints.ai_flags = AI_PASSIVE;
 	hints.ai_protocol = IPPROTO_UDP;
 
-	if(getaddrinfo(NULL, service, &hints, &s_res)) {
-		SOCK_LOG_ERROR("no available AF_INET address\n");
-		perror("no available AF_INET address");
+	ret = getaddrinfo(NULL, service, &hints, &s_res);
+	if (ret) {
+		SOCK_LOG_ERROR("no available AF_INET address service:%s, %s\n",
+				service, gai_strerror(ret));
 		return -FI_EINVAL;
 	}
 


### PR DESCRIPTION
1. Add initialization of domain_attr name and fabric_attr name/prov_name before verifying incoming connection request.
2. Avoid double free of connection request.