### PR TITLE
prov/sockets: fix errors for MSG EP.

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -790,6 +790,9 @@ struct fi_info * sock_ep_msg_process_info(struct sock_conn_req *req)
 	req->info.ep_attr = &req->ep_attr;
 	req->info.domain_attr = &req->domain_attr;
 	req->info.fabric_attr = &req->fabric_attr;
+	req->info.domain_attr->name = NULL;
+	req->info.fabric_attr->name = NULL;
+	req->info.fabric_attr->prov_name = NULL;
 	if (sock_verify_info(&req->info)) {
 		SOCK_LOG_INFO("incoming conn_req not supported\n");
 		errno = EINVAL;

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -273,7 +273,7 @@ ssize_t sock_eq_fd_sread(struct fid_eq *eq, uint32_t *event, void *buf,
 			goto out;
 		}
 		ret = sizeof *entry;
-		break;
+		return ret;
 
 	case SOCK_REJECT:
 		SOCK_LOG_INFO("received SOCK_REJECT\n");


### PR DESCRIPTION
1.	Add initialization of domain_attr name and fabric_attr name/prov_name before verifying incoming connection request.
2.	Avoid double free of connection request.
