### PR TITLE
Merge usnic_direct changes from parent repository

### DIFF
--- a/prov/usnic/src/usnic_direct/usd.h
+++ b/prov/usnic/src/usnic_direct/usd.h
@@ -201,6 +201,9 @@ struct usd_rq {
 
     char *urq_rxbuf;
     char **urq_post_addr;
+    uint32_t urq_recv_credits;  /* number of available descriptors */
+    struct rq_enet_desc *urq_desc_ring;
+    struct rq_enet_desc *urq_next_desc;
     uint32_t urq_post_index;    /* next rxbuf to post */
     uint32_t urq_post_index_mask;
     uint32_t urq_last_comp;

--- a/prov/usnic/src/usnic_direct/usd_poll.c
+++ b/prov/usnic/src/usnic_direct/usd_poll.c
@@ -99,7 +99,7 @@ usd_desc_to_rq_comp(
             rcvbuf_len = 0;
             do {
                 rq_enet_desc_dec( (struct rq_enet_desc *)
-                        ((uintptr_t)rq->urq_vnic_rq.ring.descs + (i<<4)),
+                        ((uintptr_t)rq->urq_desc_ring + (i<<4)),
                         &bus_addr, &type, &len);
                 rcvbuf_len += len;
                 i = (i - 1) & rq->urq_post_index_mask;
@@ -127,7 +127,7 @@ usd_desc_to_rq_comp(
      * reported as released until next RX
      */
     credits = (q_index - rq->urq_last_comp) & rq->urq_post_index_mask;
-    rq->urq_vnic_rq.ring.desc_avail += credits;
+    rq->urq_recv_credits += credits;
     rq->urq_last_comp = q_index;
 
     return 0;

--- a/prov/usnic/src/usnic_direct/usd_post.h
+++ b/prov/usnic/src/usnic_direct/usd_post.h
@@ -162,8 +162,8 @@ _usd_post_send_iov(
     }
 
     wq_enet_desc_enc(desc, (uintptr_t)(iov[i].iov_base),
-	iov[i].iov_len, mss, header_length, offload_mode,
-	1, cq_entry, fcoe_encap, vlan_tag_insert, vlan_tag, loopback);
+            iov[i].iov_len, mss, header_length, offload_mode,
+	        1, cq_entry, fcoe_encap, vlan_tag_insert, vlan_tag, loopback);
 
     wmb();
 

--- a/prov/usnic/src/usnic_direct/vnic_dev.c
+++ b/prov/usnic/src/usnic_direct/vnic_dev.c
@@ -110,6 +110,7 @@ struct vnic_dev {
 	struct vnic_intr_coal_timer_info intr_coal_timer_info;
 	struct devcmd2_controller *devcmd2;
 	int (*devcmd_rtn)(struct vnic_dev *vdev, enum vnic_devcmd_cmd cmd, int wait);
+	struct vnic_gen_stats gen_stats;
 };
 
 #define VNIC_MAX_RES_HDR_SIZE \

--- a/prov/usnic/src/usnic_direct/vnic_stats.h
+++ b/prov/usnic/src/usnic_direct/vnic_stats.h
@@ -86,6 +86,11 @@ struct vnic_rx_stats {
 	u64 rsvd[16];
 };
 
+/* Generic statistics */
+struct vnic_gen_stats {
+	u64 dma_map_error;
+};
+
 struct vnic_stats {
 	struct vnic_tx_stats tx;
 	struct vnic_rx_stats rx;

--- a/prov/usnic/src/usnic_direct/vnic_wq.c
+++ b/prov/usnic/src/usnic_direct/vnic_wq.c
@@ -102,11 +102,14 @@ static int vnic_wq_alloc_bufs(struct vnic_wq *wq)
 				wq->ring.desc_size * buf->index;
 			if (buf->index + 1 == count) {
 				buf->next = wq->bufs[0];
+				buf->next->prev = buf;
 				break;
 			} else if (j + 1 == VNIC_WQ_BUF_BLK_ENTRIES(count)) {
 				buf->next = wq->bufs[i + 1];
+				buf->next->prev = buf;
 			} else {
 				buf->next = buf + 1;
+				buf->next->prev = buf;
 				buf++;
 			}
 		}

--- a/prov/usnic/src/usnic_direct/vnic_wq.h
+++ b/prov/usnic/src/usnic_direct/vnic_wq.h
@@ -88,6 +88,7 @@ struct vnic_wq_buf {
 	uint8_t cq_entry; /* Gets completion event from hw */
 	uint8_t desc_skip_cnt; /* Num descs to occupy */
 	uint8_t compressed_send; /* Both hdr and payload in one desc */
+	struct vnic_wq_buf *prev;
 };
 
 /* Break the vnic_wq_buf allocations into blocks of 32/64 entries */


### PR DESCRIPTION
Included changes are:
* Refactor post recv code path to use native rq descriptor ring buffer
  to replace vnic_dev ring buffer
* Reverse sequence of verbs QP creation and wq copy ring buffer allocation
  and registration in usd qp creation routine
* vnic common code changes made for other Cisco drivers

Signed-off-by: Xuyang Wang <xuywang@cisco.com>