### PR TITLE
fabric: Replace fid_sep with fid_ep

### DIFF
--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -245,10 +245,10 @@ int fi_no_getopt(fid_t fid, int level, int optname,
 		void *optval, size_t *optlen);
 int fi_no_setopt(fid_t fid, int level, int optname,
 		const void *optval, size_t optlen);
-int fi_no_tx_ctx(struct fid_sep *sep, int index,
+int fi_no_tx_ctx(struct fid_ep *sep, int index,
 		struct fi_tx_attr *attr, struct fid_ep **tx_ep,
 		void *context);
-int fi_no_rx_ctx(struct fid_sep *sep, int index,
+int fi_no_rx_ctx(struct fid_ep *sep, int index,
 		struct fi_rx_attr *attr, struct fid_ep **rx_ep,
 		void *context);
 ssize_t fi_no_rx_size_left(struct fid_ep *ep);

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -77,7 +77,6 @@ struct fid_cntr;
 struct fid_ep;
 struct fid_pep;
 struct fid_stx;
-struct fid_sep;
 struct fid_mr;
 
 typedef struct fid *fid_t;

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -120,7 +120,7 @@ struct fi_ops_domain {
 	int	(*endpoint)(struct fid_domain *domain, struct fi_info *info,
 			struct fid_ep **ep, void *context);
 	int	(*scalable_ep)(struct fid_domain *domain, struct fi_info *info,
-			struct fid_sep **sep, void *context);
+			struct fid_ep **sep, void *context);
 	int	(*cntr_open)(struct fid_domain *domain, struct fi_cntr_attr *attr,
 			struct fid_cntr **cntr, void *context);
 	int	(*poll_open)(struct fid_domain *domain, struct fi_poll_attr *attr,

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -71,10 +71,10 @@ struct fi_ops_ep {
 			void *optval, size_t *optlen);
 	int	(*setopt)(fid_t fid, int level, int optname,
 			const void *optval, size_t optlen);
-	int	(*tx_ctx)(struct fid_sep *sep, int index,
+	int	(*tx_ctx)(struct fid_ep *sep, int index,
 			struct fi_tx_attr *attr, struct fid_ep **tx_ep,
 			void *context);
-	int	(*rx_ctx)(struct fid_sep *sep, int index,
+	int	(*rx_ctx)(struct fid_ep *sep, int index,
 			struct fi_rx_attr *attr, struct fid_ep **rx_ep,
 			void *context);
 	ssize_t (*rx_size_left)(struct fid_ep *ep);
@@ -139,12 +139,6 @@ struct fid_stx {
 	struct fi_ops_ep	*ops;
 };
 
-struct fid_sep {
-	struct fid		fid;
-	struct fi_ops_ep	*ops;
-	struct fi_ops_cm	*cm;
-};
-
 #ifndef FABRIC_DIRECT
 
 static inline int
@@ -163,7 +157,7 @@ fi_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 static inline int
 fi_scalable_ep(struct fid_domain *domain, struct fi_info *info,
-	    struct fid_sep **sep, void *context)
+	    struct fid_ep **sep, void *context)
 {
 	return domain->ops->scalable_ep(domain, info, sep, context);
 }
@@ -178,7 +172,7 @@ static inline int fi_pep_bind(struct fid_pep *pep, struct fid *bfid, uint64_t fl
 	return pep->fid.ops->bind(&pep->fid, bfid, flags);
 }
 
-static inline int fi_scalable_ep_bind(struct fid_sep *sep, struct fid *bfid, uint64_t flags)
+static inline int fi_scalable_ep_bind(struct fid_ep *sep, struct fid *bfid, uint64_t flags)
 {
 	return sep->fid.ops->bind(&sep->fid, bfid, flags);
 }
@@ -211,17 +205,17 @@ fi_getopt(fid_t fid, int level, int optname,
 }
 
 static inline int
-fi_tx_context(struct fid_sep *sep, int index, struct fi_tx_attr *attr,
+fi_tx_context(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
 	      struct fid_ep **tx_ep, void *context)
 {
-	return sep->ops->tx_ctx(sep, index, attr, tx_ep, context);
+	return ep->ops->tx_ctx(ep, index, attr, tx_ep, context);
 }
 
 static inline int
-fi_rx_context(struct fid_sep *sep, int index, struct fi_rx_attr *attr,
+fi_rx_context(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 	      struct fid_ep **rx_ep, void *context)
 {
-	return sep->ops->rx_ctx(sep, index, attr, rx_ep, context);
+	return ep->ops->rx_ctx(ep, index, attr, rx_ep, context);
 }
 
 static inline ssize_t

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -55,16 +55,16 @@ int fi_endpoint(struct fid_domain *domain, struct fi_info *info,
     struct fid_ep **ep, void *context);
 
 int fi_scalable_ep(struct fid_domain *domain, struct fi_info *info,
-    struct fid_sep **ep, void *context);
+    struct fid_ep **sep, void *context);
 
 int fi_passive_ep(struct fi_fabric *fabric, struct fi_info *info,
     struct fid_pep **pep, void *context);
 
-int fi_tx_context(struct fid_ep *ep, int index,
+int fi_tx_context(struct fid_ep *sep, int index,
     struct fi_tx_attr *attr, struct fid_ep **tx_ep,
     void *context);
 
-int fi_rx_context(struct fid_ep *ep, int index,
+int fi_rx_context(struct fid_ep *sep, int index,
     struct fi_rx_attr *attr, struct fid_ep **rx_ep,
     void *context);
 
@@ -80,7 +80,7 @@ int fi_close(struct fid *ep);
 
 int fi_ep_bind(struct fid_ep *ep, struct fid *fid, uint64_t flags);
 
-int fi_scalable_ep_bind(struct fid_sep *sep, struct fid *fid, uint64_t flags);
+int fi_scalable_ep_bind(struct fid_ep *sep, struct fid *fid, uint64_t flags);
 
 int fi_pep_bind(struct fid_pep *pep, struct fid *fid, uint64_t flags);
 

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -370,7 +370,7 @@ struct sock_comp {
 struct sock_ep {
 	union {
 		struct fid_ep ep;
-		struct fid_sep sep;
+		struct fid_ep sep;
 		struct fid_pep pep;
 	} fid;
 	size_t fclass;
@@ -764,17 +764,17 @@ struct sock_conn *sock_ep_lookup_conn(struct sock_ep *ep);
 int sock_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 		struct fid_ep **ep, void *context);
 int sock_rdm_sep(struct fid_domain *domain, struct fi_info *info,
-		 struct fid_sep **sep, void *context);
+		 struct fid_ep **sep, void *context);
 
 int sock_dgram_ep(struct fid_domain *domain, struct fi_info *info,
 		  struct fid_ep **ep, void *context);
 int sock_dgram_sep(struct fid_domain *domain, struct fi_info *info,
-		   struct fid_sep **sep, void *context);
+		   struct fid_ep **sep, void *context);
 
 int sock_msg_ep(struct fid_domain *domain, struct fi_info *info,
 		struct fid_ep **ep, void *context);
 int sock_msg_sep(struct fid_domain *domain, struct fi_info *info,
-		 struct fid_sep **sep, void *context);
+		 struct fid_ep **sep, void *context);
 int sock_msg_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 			struct fid_pep **pep, void *context);
 

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -364,7 +364,7 @@ int sock_endpoint(struct fid_domain *domain, struct fi_info *info,
 }
 
 int sock_scalable_ep(struct fid_domain *domain, struct fi_info *info,
-		     struct fid_sep **sep, void *context)
+		     struct fid_ep **sep, void *context)
 {
 	switch (info->ep_type) {
 	case FI_EP_RDM:

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -896,7 +896,7 @@ static int sock_ep_setopt(fid_t fid, int level, int optname,
 	return 0;
 }
 
-static int sock_ep_tx_ctx(struct fid_sep *ep, int index, struct fi_tx_attr *attr,
+static int sock_ep_tx_ctx(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
 			  struct fid_ep **tx_ep, void *context)
 {
 	struct sock_ep *sock_ep;
@@ -929,7 +929,7 @@ static int sock_ep_tx_ctx(struct fid_sep *ep, int index, struct fi_tx_attr *attr
 	return 0;
 }
 
-static int sock_ep_rx_ctx(struct fid_sep *ep, int index, struct fi_rx_attr *attr,
+static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 		    struct fid_ep **rx_ep, void *context)
 {
 	struct sock_ep *sock_ep;

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -468,7 +468,7 @@ int sock_dgram_ep(struct fid_domain *domain, struct fi_info *info,
 }
 
 int sock_dgram_sep(struct fid_domain *domain, struct fi_info *info,
-		struct fid_sep **sep, void *context)
+		struct fid_ep **sep, void *context)
 {
 	int ret;
 	struct sock_ep *endpoint;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -689,7 +689,7 @@ static struct fi_ops_cm sock_pep_cm_ops = {
 };
 
 int sock_msg_sep(struct fid_domain *domain, struct fi_info *info,
-		 struct fid_sep **sep, void *context)
+		 struct fid_ep **sep, void *context)
 {
 	int ret;
 	struct sock_ep *endpoint;

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -461,7 +461,7 @@ int sock_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 }
 
 int sock_rdm_sep(struct fid_domain *domain, struct fi_info *info,
-		 struct fid_sep **sep, void *context)
+		 struct fid_ep **sep, void *context)
 {
 	int ret;
 	struct sock_ep *endpoint;

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -288,13 +288,13 @@ int fi_no_setopt(fid_t fid, int level, int optname,
 {
 	return -FI_ENOSYS;
 }
-int fi_no_tx_ctx(struct fid_sep *sep, int index,
+int fi_no_tx_ctx(struct fid_ep *sep, int index,
 		struct fi_tx_attr *attr, struct fid_ep **tx_ep,
 		void *context)
 {
 	return -FI_ENOSYS;
 }
-int fi_no_rx_ctx(struct fid_sep *sep, int index,
+int fi_no_rx_ctx(struct fid_ep *sep, int index,
 		struct fi_rx_attr *attr, struct fid_ep **rx_ep,
 		void *context)
 {


### PR DESCRIPTION
The scalable endpoint fabric descriptor was changed from
fid_ep to fid_sep to clarify how it could be used.  However,
there is a desire to mix both scalable endpoints with
shared endpoints (for example, having multiple transmit
contexts, but using a shared receive context, and vice-versa).
This is almost possible, but if a scalable endpoint with
multiple receive contexts attempt to bind to a shared
transmit context, the result is that there is no FID onto
which to hang the send operations.

Neither fid_sep or fid_stx contains any data transfer ops.
The fix is to include data transfer ops as part of fid_sep,
which would make fid_sep identical to fid_ep.  Simply remove
the fid_sep structure and use fid_ep directly.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>