### PR TITLE
fabric: add common logging macros

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,10 +31,12 @@ src_libfabric_la_SOURCES = \
 	include/fi_enosys.h \
 	include/fi_indexer.h \
 	include/fi_list.h \
+	include/fi_log.h \
 	include/fi_rbuf.h \
 	include/prov.h \
 	src/fabric.c \
 	src/fi_tostr.c \
+	src/log.c \
 	$(common_srcs)
 
 if HAVE_SOCKETS

--- a/configure.ac
+++ b/configure.ac
@@ -13,8 +13,13 @@ AC_ARG_ENABLE([debug],
 	      [AS_HELP_STRING([--enable-debug],
 			      [Enable debugging @<:@default=no@:>@])
 	      ],
-	      [CFLAGS="$CFLAGS -g -O0 -Wall"],
-	      [enable_debug=no])
+	      [CFLAGS="$CFLAGS -g -O0 -Wall"
+	       dbg=1],
+	      [enable_debug=no
+               dbg=0])
+
+AC_DEFINE_UNQUOTED([ENABLE_DEBUG],[$dbg],
+                   [defined to 1 if libfabric was configured with --enable-debug, 0 otherwise])
 
 dnl Fix autoconf's habit of adding -g -O2 by default
 AS_IF([test -z "$CFLAGS"],

--- a/include/fi_log.h
+++ b/include/fi_log.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#if !defined(FI_LOG_H)
+#define FI_LOG_H
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+extern int fi_log_level;
+
+void fi_log_init(void);
+void fi_warn_impl(const char *prov, const char *fmt, ...);
+void fi_log_impl(int level, const char *prov, const char *fmt, ...);
+void fi_debug_impl(const char *prov, const char *fmt, ...);
+
+/* Callers are responsible for including their own trailing "\n".  Non-provider
+ * code should pass prov=NULL.
+ */
+#define FI_WARN(prov, ...) fi_warn_impl(prov, __VA_ARGS__)
+
+#define FI_LOG(level, prov, ...) \
+	do { \
+		if ((level) <= fi_log_level) \
+			fi_log_impl(level, prov, __VA_ARGS__); \
+	} while (0)
+
+#if ENABLE_DEBUG
+#  define FI_DEBUG(prov, ...) fi_debug_impl(prov, __VA_ARGS__)
+#else
+#  define FI_DEBUG(prov, ...) do {} while (0)
+#endif
+
+#endif /* !defined(FI_LOG_H) */

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "fi.h"
+#include "fi_log.h"
+
+/* General implementation note: these functions currently use multiple fprintfs
+ * in a row, which can render in an ugly fashion for multithreaded code and for
+ * some mpirun implementations.  If this bugs anyone enough then we can convert
+ * them to snprintf to build up the printout in a single buffer.
+ */
+
+int fi_log_level = INT_MIN;
+
+void fi_log_init(void)
+{
+	int ret;
+
+	if (getenv("FI_LOG_LEVEL") != NULL) {
+		errno = 0;
+		ret = strtol(getenv("FI_LOG_LEVEL"), NULL, 10);
+		if (errno != 0)
+			fprintf(stderr,
+				"%s: invalid value specified for FI_LOG_LEVEL (%s)\n",
+				PACKAGE, strerror(errno));
+		else
+			fi_log_level = (int)ret;
+	}
+}
+
+void fi_warn_impl(const char *prov, const char *fmt, ...)
+{
+	va_list vargs;
+
+	if (prov != NULL)
+		fprintf(stderr, "%s:%s: ", PACKAGE, prov);
+	else
+		fprintf(stderr, "%s: ", PACKAGE);
+	va_start(vargs, fmt);
+	vfprintf(stderr, fmt, vargs);
+	va_end(vargs);
+}
+
+void fi_log_impl(int level, const char *prov, const char *fmt, ...)
+{
+	va_list vargs;
+
+	if (prov != NULL)
+		fprintf(stderr, "%s:%s:<%d> ", PACKAGE, prov, level);
+	else
+		fprintf(stderr, "%s:<%d> ", PACKAGE, level);
+	va_start(vargs, fmt);
+	vfprintf(stderr, fmt, vargs);
+	va_end(vargs);
+}
+
+void fi_debug_impl(const char *prov, const char *fmt, ...)
+{
+	va_list vargs;
+
+	if (prov != NULL)
+		fprintf(stderr, "%s:%s:<DBG> ", PACKAGE, prov);
+	else
+		fprintf(stderr, "%s:<DBG> ", PACKAGE);
+	va_start(vargs, fmt);
+	vfprintf(stderr, fmt, vargs);
+	va_end(vargs);
+}


### PR DESCRIPTION
Add FI_WARN/FI_LOG/FI_DEBUG macros that log information to stderr.  Also
replace the old, non-common FI_WARN macro in fabric.c and add a few
helpful uses of the new macros to show that things are working.

Fixes #527.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@pmmccorm please review.  There are a lot of options when implementing logging macros.  I made a few arbitrary choices and otherwise tried to match up with your desires in #527.