### PR TITLE
Fine-grained provider C preprocessor, linker, and library flags

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -207,7 +207,7 @@ _usnic_files = \
 
 _usnic_cppflags = \
         -D__LIBUSNIC__ \
-        -DHAVE_LIBNL3=$(HAVE_LIBNL3) $(USNIC_LIBNL_CPPFLAGS) \
+        -DHAVE_LIBNL3=$(HAVE_LIBNL3) $(usnic_libnl_CPPFLAGS) \
         -I$(top_srcdir)/prov/usnic/src/usnic_direct
 
 rdmainclude_HEADERS += \
@@ -217,12 +217,13 @@ if HAVE_USNIC_DL
 pkglib_LTLIBRARIES += libusnic-fi.la
 libusnic_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(_usnic_cppflags)
 libusnic_fi_la_SOURCES = $(_usnic_files) $(common_srcs)
-libusnic_fi_la_LIBADD = $(linkback)
 libusnic_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+libusnic_fi_la_LIBADD = $(linkback) $(usnic_libnl_LIBS)
 libusnic_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_USNIC_DL
-AM_CPPFLAGS += $(_usnic_cppflags)
 src_libfabric_la_SOURCES += $(_usnic_files)
+src_libfabric_la_CPPFLAGS += $(_usnic_cppflags)
+src_libfabric_la_LIBADD += $(usnic_libnl_LIBS)
 endif !HAVE_USNIC_DL
 
 endif HAVE_USNIC

--- a/Makefile.am
+++ b/Makefile.am
@@ -244,11 +244,16 @@ _psm_files = \
 if HAVE_PSM_DL
 pkglib_LTLIBRARIES += libpsmx-fi.la
 libpsmx_fi_la_SOURCES = $(_psm_files) $(common_srcs)
-libpsmx_fi_la_LIBADD = $(linkback)
-libpsmx_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+libpsmx_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(psm_CPPFLAGS)
+libpsmx_fi_la_LDFLAGS = \
+    -module -avoid-version -shared -export-dynamic $(psm_LDFLAGS)
+libpsmx_fi_la_LIBADD = $(linkback) $(psm_LIBS)
 libpsmx_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_PSM_DL
 src_libfabric_la_SOURCES += $(_psm_files)
+src_libfabric_la_CPPFLAGS += $(psm_CPPFLAGS)
+src_libfabric_la_LDFLAGS += $(psm_LDFLAGS)
+src_libfabric_la_LIBADD += $(psm_LIBS)
 endif !HAVE_PSM_DL
 
 endif HAVE_PSM

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,3 +1,5 @@
+# Makefile.am for libfabric
+
 AM_CPPFLAGS = \
 	-I$(srcdir)/include \
 	-D_GNU_SOURCE \
@@ -42,6 +44,10 @@ src_libfabric_la_SOURCES = \
 	src/fi_tostr.c \
 	src/log.c \
 	$(common_srcs)
+
+src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)
+src_libfabric_la_LDFLAGS =
+src_libfabric_la_LIBADD =
 
 if HAVE_SOCKETS
 _sockets_files = \
@@ -247,7 +253,7 @@ endif !HAVE_PSM_DL
 
 endif HAVE_PSM
 
-src_libfabric_la_LDFLAGS = -version-info 1 -export-dynamic \
+src_libfabric_la_LDFLAGS += -version-info 1 -export-dynamic \
 			   $(libfabric_version_script)
 src_libfabric_la_DEPENDENCIES = $(srcdir)/libfabric.map
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -94,11 +94,20 @@ _verbs_files = prov/verbs/src/fi_verbs.c
 if HAVE_VERBS_DL
 pkglib_LTLIBRARIES += libverbs-fi.la
 libverbs_fi_la_SOURCES = $(_verbs_files) $(common_srcs)
-libverbs_fi_la_LIBADD = $(linkback)
-libverbs_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+# Technically, verbs_ibverbs_CPPFLAGS and verbs_rdmacm_CPPFLAGS could
+# be different, but it is highly unlikely that they ever will be.  So
+# only list verbs_ibverbs_CPPFLAGS here.  Same with verbs_*_LDFLAGS,
+# below.
+libverbs_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(verbs_ibverbs_CPPFLAGS)
+libverbs_fi_la_LDFLAGS = \
+    -module -avoid-version -shared -export-dynamic $(verbs_ibverbs_LDFLAGS)
+libverbs_fi_la_LIBADD = $(linkback) $(verbs_rdmacm_LIBS) $(verbs_ibverbs_LIBS)
 libverbs_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_VERBS_DL
 src_libfabric_la_SOURCES += $(_verbs_files)
+src_libfabric_la_CPPFLAGS += $(verbs_ibverbs_CPPFLAGS)
+src_libfabric_la_LDFLAGS += $(verbs_ibverbs_LDFLAGS)
+src_libfabric_la_LIBADD += $(verbs_rdmacm_LIBS) $(verbs_ibverbs_LIBS)
 endif !HAVE_VERBS_DL
 
 endif HAVE_VERBS

--- a/config/fi_check_package.m4
+++ b/config/fi_check_package.m4
@@ -1,0 +1,215 @@
+dnl -*- m4 -*-
+dnl
+dnl Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+dnl                         University Research and Technology
+dnl                         Corporation.  All rights reserved.
+dnl Copyright (c) 2004-2005 The University of Tennessee and The University
+dnl                         of Tennessee Research Foundation.  All rights
+dnl                         reserved.
+dnl Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+dnl                         University of Stuttgart.  All rights reserved.
+dnl Copyright (c) 2004-2005 The Regents of the University of California.
+dnl                         All rights reserved.
+dnl Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
+dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl
+dnl This file derived from config/opal_check_package.m4 in Open MPI.
+dnl
+
+dnl _FI_CHECK_PACKAGE_HEADER(prefix, header, dir-prefix,
+dnl                            [action-if-found], [action-if-not-found],
+dnl                            includes)
+dnl --------------------------------------------------------------------
+AC_DEFUN([_FI_CHECK_PACKAGE_HEADER], [
+    # This is stolen from autoconf to peek under the covers to get the
+    # cache variable for the library check.
+    AS_VAR_PUSHDEF([fi_Header], [ac_cv_header_$2])
+
+    # There's unfortunately no way to get through the progression of
+    # header includes without killing off the cache variable and
+    # trying again...
+    unset fi_Header
+
+    fi_check_package_header_happy="no"
+    AS_IF([test "$3" = "/usr" || test "$3" = "/usr/local"],
+           [ # try as is...
+            AC_VERBOSE([looking for header without includes])
+            AC_CHECK_HEADERS([$2], [fi_check_package_header_happy="yes"], [])
+            AS_IF([test "$fi_check_package_header_happy" = "no"],
+                  [# no go on the as is - reset the cache and try again
+                   unset fi_Header])])
+
+    AS_IF([test "$fi_check_package_header_happy" = "no"],
+          [AS_IF([test "$3" != ""],
+                 [$1_CPPFLAGS="$$1_CPPFLAGS -I$3/include"
+                  CPPFLAGS="$CPPFLAGS -I$3/include"])
+          AC_CHECK_HEADERS([$2], [fi_check_package_header_happy="yes"], [], [$6])
+          AS_IF([test "$fi_check_package_header_happy" = "yes"], [$4], [$5])],
+          [$4])
+    unset fi_check_package_header_happy
+
+    AS_VAR_POPDEF([fi_Header])dnl
+])
+
+
+dnl _FI_CHECK_PACKAGE_LIB(prefix, library, function, extra-libraries,
+dnl                         dir-prefix, libdir,
+dnl                         [action-if-found], [action-if-not-found]])
+dnl --------------------------------------------------------------------
+AC_DEFUN([_FI_CHECK_PACKAGE_LIB], [
+    # This is stolen from autoconf to peek under the covers to get the
+    # cache variable for the library check.
+    AS_LITERAL_IF([$2],
+                  [AS_VAR_PUSHDEF([fi_Lib], [ac_cv_lib_$2_$3])],
+                  [AS_VAR_PUSHDEF([fi_Lib], [ac_cv_lib_$2''_$3])])dnl
+
+    # See comment above
+    unset fi_Lib
+    fi_check_package_lib_happy="no"
+    AS_IF([test "$6" != ""],
+          [ # libdir was specified - search only there
+           $1_LDFLAGS="$$1_LDFLAGS -L$6"
+           LDFLAGS="$LDFLAGS -L$6"
+           AC_CHECK_LIB([$2], [$3],
+                        [fi_check_package_lib_happy="yes"],
+                        [fi_check_package_lib_happy="no"], [$4])
+           AS_IF([test "$fi_check_package_lib_happy" = "no"],
+                 [LDFLAGS="$fi_check_package_$1_save_LDFLAGS"
+                  $1_LDFLAGS="$fi_check_package_$1_orig_LDFLAGS"
+                  unset fi_Lib])],
+          [ # libdir was not specified - go through search path
+           fi_check_package_libdir="$5"
+           AS_IF([test "$fi_check_package_libdir" = "" || \
+                  test "$fi_check_package_libdir" = "/usr" || \
+                  test "$fi_check_package_libdir" = "/usr/local"],
+               [ # try as is...
+                AC_VERBOSE([looking for library without search path])
+                AC_CHECK_LIB([$2], [$3],
+                        [fi_check_package_lib_happy="yes"],
+                        [fi_check_package_lib_happy="no"], [$4])
+                AS_IF([test "$fi_check_package_lib_happy" = "no"],
+                    [ # no go on the as is..  see what happens later...
+                     LDFLAGS="$fi_check_package_$1_save_LDFLAGS"
+                     $1_LDFLAGS="$fi_check_package_$1_orig_LDFLAGS"
+                     unset fi_Lib])])
+
+           AS_IF([test "$fi_check_package_lib_happy" = "no"],
+               [AS_IF([test "$fi_check_package_libdir" != ""],
+                    [$1_LDFLAGS="$$1_LDFLAGS -L$fi_check_package_libdir/lib"
+                     LDFLAGS="$LDFLAGS -L$fi_check_package_libdir/lib"
+                     AC_VERBOSE([looking for library in lib])
+                     AC_CHECK_LIB([$2], [$3],
+                               [fi_check_package_lib_happy="yes"],
+                               [fi_check_package_lib_happy="no"], [$4])
+                     AS_IF([test "$fi_check_package_lib_happy" = "no"],
+                         [ # no go on the as is..  see what happens later...
+                          LDFLAGS="$fi_check_package_$1_save_LDFLAGS"
+                          $1_LDFLAGS="$fi_check_package_$1_orig_LDFLAGS"
+                          unset fi_Lib])])])
+
+           AS_IF([test "$fi_check_package_lib_happy" = "no"],
+               [AS_IF([test "$fi_check_package_libdir" != ""],
+                    [$1_LDFLAGS="$$1_LDFLAGS -L$fi_check_package_libdir/lib64"
+                     LDFLAGS="$LDFLAGS -L$fi_check_package_libdir/lib64"
+                     AC_VERBOSE([looking for library in lib64])
+                     AC_CHECK_LIB([$2], [$3],
+                               [fi_check_package_lib_happy="yes"],
+                               [fi_check_package_lib_happy="no"], [$4])
+                     AS_IF([test "$fi_check_package_lib_happy" = "no"],
+                         [ # no go on the as is..  see what happens later...
+                          LDFLAGS="$fi_check_package_$1_save_LDFLAGS"
+                          $1_LDFLAGS="$fi_check_package_$1_orig_LDFLAGS"
+                          unset fi_Lib])])])])
+
+    AS_IF([test "$fi_check_package_lib_happy" = "yes"],
+          [$1_LIBS="-l$2 $4"
+           $7], [$8])
+
+    AS_VAR_POPDEF([fi_Lib])dnl
+])
+
+
+dnl FI_CHECK_PACKAGE(prefix,
+dnl                    header,
+dnl                    library,
+dnl                    function,
+dnl                    extra-libraries,
+dnl                    dir-prefix,
+dnl                    libdir-prefix,
+dnl                    [action-if-found], [action-if-not-found],
+dnl                    includes)
+dnl -----------------------------------------------------------
+dnl Check for package defined by header and libs, and probably
+dnl located in dir-prefix, possibly with libs in libdir-prefix.
+dnl Both dir-prefix and libdir-prefix can be empty.  Will set
+dnl prefix_{CPPFLAGS, LDFLAGS, LIBS} as needed.
+dnl
+dnl The general intent of this macro is to provide finer-grained scoping
+dnl of C preprocessor flags, linker flags, and libraries (as opposed to
+dnl unconditionally adding to the top-level CPFLAGS, LDFLAGS, and LIBS,
+dnl which get used to compile/link *everything*).
+dnl
+dnl Here's a breakdown of the parameters:
+dnl
+dnl * prefix: the macro sets $prefix_CPPFLAGS, $prefix_LDFLAGS, and
+dnl   $prefix_LIBS (and AC_SUBSTs all of them).  For example, if a
+dnl   provider uses this macro to check for a header/library that it
+dnl   needs, it might well set prefix to be its provider name.
+dnl * header_filename: the foo.h file to check for
+dnl * library_name / function_name: check for function function_name in
+dnl   -llibrary_name.  Specifically, for library_name, use the "foo" form,
+dnl   as opposed to "libfoo".
+dnl * extra_libraries: if the library_name you are checking for requires
+dnl   additonal -l arguments to link successfully, list them here.
+dnl * dir_prefix: if the header/library is located in a non-standard
+dnl   location (e.g., /opt/foo as opposed to /usr), list it here
+dnl * libdir_prefix: if the library is not under $dir_prefix/lib or
+dnl   $dir_prefix/lib64, list it here.
+dnl * action_if_found: if both the header and library are found and
+dnl   usable, execute action_if_found
+dnl * action_if_not_found: otherwise, execute action_if_not_found
+dnl * extra_includes: if including header_filename requires additional
+dnl   headers to be included first, list them here
+dnl
+dnl The output _CPPFLAGS, _LDFLAGS, and _LIBS can be used to limit the
+dnl scope various flags in Makefiles.
+dnl
+AC_DEFUN([FI_CHECK_PACKAGE],[
+    fi_check_package_$1_save_CPPFLAGS="$CPPFLAGS"
+    fi_check_package_$1_save_LDFLAGS="$LDFLAGS"
+    fi_check_package_$1_save_LIBS="$LIBS"
+
+    fi_check_package_$1_orig_CPPFLAGS="$$1_CPPFLAGS"
+    fi_check_package_$1_orig_LDFLAGS="$$1_LDFLAGS"
+    fi_check_package_$1_orig_LIBS="$$1_LIBS"
+
+    _FI_CHECK_PACKAGE_HEADER([$1], [$2], [$6],
+          [_FI_CHECK_PACKAGE_LIB([$1], [$3], [$4], [$5], [$6], [$7],
+                [fi_check_package_happy="yes"],
+                [fi_check_package_happy="no"])],
+          [fi_check_package_happy="no"],
+          [$10])
+
+    AS_IF([test "$fi_check_package_happy" = "yes"],
+          [$8],
+          [$1_CPPFLAGS="$fi_check_package_$1_orig_CPPFLAGS"
+           $1_LDFLAGS="$fi_check_package_$1_orig_LDFLAGS"
+           $1_LIBS="$fi_check_package_$1_orig_LIBS"
+           $9])
+
+    AC_SUBST($1_CPPFLAGS)
+    AC_SUBST($1_LDFLAGS)
+    AC_SUBST($1_LIBS)
+
+    CPPFLAGS="$fi_check_package_$1_save_CPPFLAGS"
+    LDFLAGS="$fi_check_package_$1_save_LDFLAGS"
+    LIBS="$fi_check_package_$1_save_LIBS"
+])

--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -9,6 +9,8 @@ AC_DEFUN([FI_PROVIDER_INIT],[
 	PROVIDERS_DL=
 	PROVIDERS_STATIC=
 	PROVIDERS_COUNT=
+
+	m4_include(config/fi_check_package.m4)
 ])
 
 dnl

--- a/prov/psm/configure.m4
+++ b/prov/psm/configure.m4
@@ -11,9 +11,16 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 	# Determine if we can support the psm provider
 	psm_happy=0
 	AS_IF([test x"$enable_psm" != x"no"],
-	      [psm_happy=1
-	       AC_CHECK_HEADER([psm.h], [], [psm_happy=0])
-	       AC_CHECK_LIB([psm_infinipath], [psm_init], [], [psm_happy=0])])
+	      [FI_CHECK_PACKAGE([psm],
+				[psm.h],
+				[psm_infinipath],
+				[psm_init],
+				[],
+				[],
+				[],
+				[psm_happy=1],
+				[psm_happy=0])
+	      ])
 
 	AS_IF([test $psm_happy -eq 1], [$1], [$2])
 ])

--- a/prov/usnic/configure.m4
+++ b/prov/usnic/configure.m4
@@ -113,11 +113,12 @@ AC_DEFUN([FI_USNIC_CONFIGURE],[
     AS_IF([test "x$enable_usnic" != "xno"],
 	[usnic_happy=1
 	 AC_CHECK_HEADER([infiniband/verbs.h], [], [usnic_happy=0])
-	 CHECK_LIBNL3([USNIC_LIBNL_CPPFLAGS],
-		      [USNIC_LIBNL_LIBS], [0])
-	 AS_IF([test "$USNIC_LIBNL_LIBS" != ""],
-	       [CPPFLAGS="$USNIC_LIBNL_CPPFLAGS $CPPFLAGS"
-	        LIBS="$USNIC_LIBNL_LIBS $LIBS"],
+	 CHECK_LIBNL3([usnic_libnl_CPPFLAGS],
+		      [usnic_libnl_LIBS], [0])
+	 AC_SUBST(usnic_libnl_CPPFLAGS)
+	 AC_SUBST(usnic_libnl_LIBS)
+
+	 AS_IF([test "$usnic_libnl_LIBS" = ""],
 	       [usnic_happy=0])
 	])
 ])

--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -9,14 +9,30 @@ dnl $2: action if not configured successfully
 dnl
 AC_DEFUN([FI_VERBS_CONFIGURE],[
 	# Determine if we can support the verbs provider
-	verbs_happy=0
+	verbs_ibverbs_happy=0
+	verbs_rdmacm_happy=0
 	AS_IF([test x"$enable_verbs" != x"no"],
-	      [verbs_happy=1
-	       AC_CHECK_HEADER([infiniband/verbs.h], [], [verbs_happy=0])
-	       AC_CHECK_HEADER([rdma/rsocket.h], [], [verbs_happy=0])
-	       AC_CHECK_LIB([ibverbs], [ibv_open_device], [], [verbs_happy=0])
-	       AC_CHECK_LIB([rdmacm], [rsocket], [], [verbs_happy=0])
+	      [FI_CHECK_PACKAGE([verbs_ibverbs],
+				[infiniband/verbs.h],
+				[ibverbs],
+				[ibv_open_device],
+				[],
+				[],
+				[],
+				[verbs_ibverbs_happy=1],
+				[verbs_ibverbs_happy=0])
+
+	       FI_CHECK_PACKAGE([verbs_rdmacm],
+				[rdma/rsocket.h],
+				[rdmacm],
+				[rsocket],
+				[],
+				[],
+				[],
+				[verbs_rdmacm_happy=1],
+				[verbs_rdmacm_happy=0])
 	      ])
 
-	AS_IF([test $verbs_happy -eq 1], [$1], [$2])
+	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
+	       test $verbs_rdmacm_happy -eq 1], [$1], [$2])
 ])


### PR DESCRIPTION
Per #118, provide configury help to allow linking provider DLs against their dependent libraries.

For example: when the PSM provider is compiled as a DL, then link the PSM provider DL against libpsm_infinipath, as opposed to *also* linking libfabric itself against libpsm_infinipath.

As a concrete example (note that I can only build the sockets, verbs, and usnic providers):

1. Build a single consolidated libfabric.so:

```shell
$ ./configure --prefix=$HOME/bogus && make clean && make -j 32 install
[...snip...]
$ ldd $HOME/bogus/lib/libfabric.so
	linux-vdso.so.1 =>  (0x00002aaaaaaab000)
>>> librdmacm.so.1 => /usr/lib64/librdmacm.so.1 (0x00002aaaaad14000)
>>> libibverbs.so.1 => /usr/lib64/libibverbs.so.1 (0x00002aaaaaf28000)
>>> libnl.so.1 => /lib64/libnl.so.1 (0x00002aaaab137000)
	librt.so.1 => /lib64/librt.so.1 (0x00002aaaab38a000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00002aaaab592000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00002aaaab7af000)
	libc.so.6 => /lib64/libc.so.6 (0x00002aaaab9b4000)
	/lib64/ld-linux-x86-64.so.2 (0x0000003491200000)
	libm.so.6 => /lib64/libm.so.6 (0x00002aaaabd48000)
```

Notice the three artificially-marked libraries in the ldd output: libfabric.so links against the provider-specific libraries librdmacm, libibverbs, and libnl, which are from the verbs and usnic providers.

2. Build usnic and verbs providers as DLs:

```shell
$ rm -rf $HOME/bogus
$ ./configure --prefix=$HOME/bogus --enable-usnic=dl --enable-verbs=dl && make clean && make -j 32 install
[...snip...]
$ ldd $HOME/bogus/lib/libfabric.so
	linux-vdso.so.1 =>  (0x00002aaaaaaab000)
	librt.so.1 => /lib64/librt.so.1 (0x00002aaaaacf0000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00002aaaaaef8000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00002aaaab115000)
	libc.so.6 => /lib64/libc.so.6 (0x00002aaaab31a000)
	/lib64/ld-linux-x86-64.so.2 (0x0000003491200000)
$ ldd $bogus/lib/libfabric/libusnic-fi.so
	linux-vdso.so.1 =>  (0x00002aaaaaaab000)
>>>	libnl.so.1 => /lib64/libnl.so.1 (0x00002aaaaace9000)
	libfabric.so.1 => /home/jsquyres/bogus/lib/libfabric.so.1 (0x00002aaaaaf3b000)
	librt.so.1 => /lib64/librt.so.1 (0x00002aaaab162000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00002aaaab36b000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00002aaaab588000)
	libc.so.6 => /lib64/libc.so.6 (0x00002aaaab78c000)
	libm.so.6 => /lib64/libm.so.6 (0x00002aaaabb21000)
	/lib64/ld-linux-x86-64.so.2 (0x0000003491200000)
$ ldd $bogus/lib/libfabric/libverbs-fi.so
	linux-vdso.so.1 =>  (0x00002aaaaaaab000)
	libfabric.so.1 => /home/jsquyres/bogus/lib/libfabric.so.1 (0x00002aaaaacb8000)
>>>	librdmacm.so.1 => /usr/lib64/librdmacm.so.1 (0x00002aaaaaefa000)
>>>	libibverbs.so.1 => /usr/lib64/libibverbs.so.1 (0x00002aaaab10e000)
	librt.so.1 => /lib64/librt.so.1 (0x00002aaaab31e000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00002aaaab526000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00002aaaab743000)
	libc.so.6 => /lib64/libc.so.6 (0x00002aaaab948000)
	/lib64/ld-linux-x86-64.so.2 (0x0000003491200000)
```

Now note that libfabric.so, itself, does not link against the provider-needed libraries.

Only libusnic-fi.so links against libnl, and only libibverbs-fi.so links against libibverbs and librdmacm.