### PR TITLE
prov/socket: Remove unneeded rlock release in tx_ctx_abort

### DIFF
--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -153,7 +153,6 @@ void sock_tx_ctx_commit(struct sock_tx_ctx *tx_ctx)
 void sock_tx_ctx_abort(struct sock_tx_ctx *tx_ctx)
 {
 	rbfdabort(&tx_ctx->rbfd);
-	fastlock_release(&tx_ctx->rlock);
 	fastlock_release(&tx_ctx->wlock);
 }
 


### PR DESCRIPTION
Only wlock needs to be released.  rlock is not acquired
for write transactions against the tx context.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

Fixes #566 