### PR TITLE
usnic: change an errant #if to #ifdef

### DIFF
--- a/prov/usnic/src/usnic_direct/vnic_rq.c
+++ b/prov/usnic/src/usnic_direct/vnic_rq.c
@@ -46,7 +46,7 @@
 #include <linux/errno.h>
 #include <linux/types.h>
 #include <linux/pci.h>
-#if __KERNEL__
+#ifdef __KERNEL__
 #include <linux/delay.h>
 #include <linux/slab.h>
 #endif


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>