### PR TITLE
Fix minor issues that trigger warnings in OS X. 

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -447,11 +447,11 @@ static int sock_av_close(struct fid *fid)
 	if (!av->name) 
 		free(av->table_hdr);
 	else {
+		shm_unlink(av->name);
 		free(av->name);
 		munmap(av->table_hdr, sizeof(struct sock_av_table_hdr) +
 		       av->attr.count * sizeof(struct sock_av_addr));
 		close(av->shared_fd);
-		shm_unlink(av->name);
 	}
 
 	atomic_dec(&av->domain->ref);
@@ -561,8 +561,8 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		
 		if (ftruncate(_av->shared_fd, table_sz) == -1) {
 			SOCK_LOG_ERROR("ftruncate failed\n");
-			free(_av);
 			shm_unlink(_av->name);
+			free(_av);
 			return -FI_EINVAL;
 		}
 		
@@ -578,8 +578,8 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 
 		if (_av->table_hdr == MAP_FAILED) {
 			SOCK_LOG_ERROR("mmap failed\n");
-			free(_av);
 			shm_unlink(_av->name);
+			free(_av);
 			return -FI_EINVAL;
 		}
 	} else {

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -177,7 +177,7 @@ uint16_t sock_conn_map_connect(struct sock_domain *dom,
 	memcpy(&map->curr_addr, addr, sizeof(struct sockaddr_in));
 	fastlock_release(&map->lock);
 
-	if (connect(conn_fd, addr, sizeof *addr) < 0) {
+	if (connect(conn_fd, (struct sockaddr *) addr, sizeof *addr) < 0) {
 		if (errno == EINPROGRESS) {
 			/* timeout after 5 secs */
 			tv.tv_sec = 5;
@@ -355,7 +355,7 @@ static void *_sock_conn_listen(void *arg)
 		}
 		
 		addr_size = sizeof(struct sockaddr_in);
-		getpeername(conn_fd, &remote, &addr_size);
+		getpeername(conn_fd, (struct sockaddr *) &remote, &addr_size);
 		memcpy(sa_ip, inet_ntoa(remote.sin_addr), INET_ADDRSTRLEN);
 		SOCK_LOG_INFO("ACCEPT: %s, %d\n", sa_ip, ntohs(remote.sin_port));
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -53,9 +53,9 @@ extern struct fi_ops_ep sock_ctx_ep_ops;
 extern const struct fi_domain_attr sock_domain_attr;
 extern const struct fi_fabric_attr sock_fabric_attr;
 
-extern const char const sock_fab_name[];
-extern const char const sock_dom_name[];
-extern const char const sock_prov_name[];
+extern const char sock_fab_name[];
+extern const char sock_dom_name[];
+extern const char sock_prov_name[];
 
 const struct fi_tx_attr sock_stx_attr = {
 	.caps = SOCK_EP_RDM_CAP,

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -469,7 +469,8 @@ static int sock_ep_cm_send_msg(int sock_fd,
 		      sa_ip, ntohs(addr->sin_port));
 
 	while (retry < SOCK_EP_MAX_RETRY) {
-		ret = sendto(sock_fd, (char *)msg, len, 0, addr, sizeof *addr);
+		ret = sendto(sock_fd, (char *)msg, len, 0,
+			     (struct sockaddr *) addr, sizeof *addr);
 		SOCK_LOG_INFO("Total Sent: %d\n", ret);
 		if (ret < 0) 
 			return -1;
@@ -482,7 +483,7 @@ static int sock_ep_cm_send_msg(int sock_fd,
 
 		addr_len = sizeof(struct sockaddr_in);
 		ret = recvfrom(sock_fd, &response, sizeof(response), 0,
-			       &from_addr, &addr_len);
+			       (struct sockaddr *) &from_addr, &addr_len);
 		SOCK_LOG_INFO("Received ACK: %d\n", ret);
 		if (ret == sizeof(response))
 			return 0;
@@ -497,7 +498,7 @@ static int sock_ep_cm_send_ack(int sock_fd, struct sockaddr_in *addr)
 
 	while(!ack_sent && retry < SOCK_EP_MAX_RETRY) {
 		ret = sendto(sock_fd, &response, sizeof(response), 0,
-			     addr, sizeof *addr);
+			     (struct sockaddr *) addr, sizeof *addr);
 		retry++;
 
 		SOCK_LOG_INFO("ack: %d\n", ret);
@@ -548,7 +549,7 @@ static void *sock_msg_ep_listener_thread (void *data)
 		addr_len = sizeof(struct sockaddr_in);
 		ret = recvfrom(ep->socket, (char*)conn_response, 
 			       sizeof(*conn_response) + SOCK_EP_MAX_CM_DATA_SZ,
-			       0, &from_addr, &addr_len);
+			       0, (struct sockaddr *) &from_addr, &addr_len);
 		if (ret <= 0)
 			continue;
 		
@@ -911,7 +912,7 @@ static void *sock_pep_listener_thread (void *data)
 		addr_len = sizeof(struct sockaddr_in);
 		ret = recvfrom(pep->socket, (char*)conn_req, 
 			       sizeof(*conn_req) + SOCK_EP_MAX_CM_DATA_SZ, 0, 
-			       &from_addr, &addr_len);
+			       (struct sockaddr *) &from_addr, &addr_len);
 		if (ret <= 0)
 			continue;
 		memcpy(&conn_req->from_addr, &from_addr, sizeof(struct sockaddr_in));

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -42,9 +42,9 @@
 #include "sock.h"
 #include "sock_util.h"
 
-const char const sock_fab_name[] = "IP";
-const char const sock_dom_name[] = "sockets";
-const char const sock_prov_name[] = "sockets";
+const char sock_fab_name[] = "IP";
+const char sock_dom_name[] = "sockets";
+const char sock_prov_name[] = "sockets";
 
 const struct fi_fabric_attr sock_fabric_attr = {
 	.fabric = NULL,

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -576,7 +576,7 @@ static int sock_pe_process_rx_read(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 					pe_entry->pe.rx.rx_iov[i].iov.len,
 					FI_REMOTE_READ);
 		if (!mr) {
-			SOCK_LOG_ERROR("Remote memory access error: %p, %lu, %lu\n",
+			SOCK_LOG_ERROR("Remote memory access error: %p, %lu, %" PRIu64 "\n",
 				       (void*)pe_entry->pe.rx.rx_iov[i].iov.addr,
 				       pe_entry->pe.rx.rx_iov[i].iov.len,
 				       pe_entry->pe.rx.rx_iov[i].iov.key);
@@ -633,7 +633,7 @@ static int sock_pe_process_rx_write(struct sock_pe *pe, struct sock_rx_ctx *rx_c
 						pe_entry->pe.rx.rx_iov[i].iov.len,
 						FI_REMOTE_WRITE);
 			if (!mr) {
-				SOCK_LOG_ERROR("Remote memory access error: %p, %lu, %lu\n",
+				SOCK_LOG_ERROR("Remote memory access error: %p, %lu, %" PRIu64 "\n",
 					       (void*)pe_entry->pe.rx.rx_iov[i].iov.addr,
 					       pe_entry->pe.rx.rx_iov[i].iov.len,
 					       pe_entry->pe.rx.rx_iov[i].iov.key);
@@ -1047,7 +1047,7 @@ static int sock_pe_process_rx_atomic(struct sock_pe *pe, struct sock_rx_ctx *rx_
 						pe_entry->pe.rx.rx_iov[i].ioc.count * datatype_sz,
 						FI_REMOTE_WRITE);
 			if (!mr) {
-				SOCK_LOG_ERROR("Remote memory access error: %p, %lu, %lu\n",
+				SOCK_LOG_ERROR("Remote memory access error: %p, %lu, %" PRIu64 "\n",
 					       (void*)pe_entry->pe.rx.rx_iov[i].ioc.addr,
 					       pe_entry->pe.rx.rx_iov[i].ioc.count * datatype_sz,
 					       pe_entry->pe.rx.rx_iov[i].ioc.key);
@@ -1405,7 +1405,7 @@ static int sock_pe_peek_hdr(struct sock_pe *pe,
 	msg_hdr->pe_entry_id = ntohs(msg_hdr->pe_entry_id);
 	msg_hdr->ep_id = ntohs(msg_hdr->ep_id);
 	
-	SOCK_LOG_INFO("PE RX (Hdr peek): MsgLen: %lu, TX-ID: %d, Type: %d\n", 
+	SOCK_LOG_INFO("PE RX (Hdr peek): MsgLen:  %" PRIu64 ", TX-ID: %d, Type: %d\n", 
 		      msg_hdr->msg_len, msg_hdr->rx_id, msg_hdr->op_type);
 	return 0;
 }
@@ -1463,7 +1463,7 @@ static int sock_pe_read_hdr(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 	msg_hdr->ep_id = ntohs(msg_hdr->ep_id);
 	pe_entry->pe.rx.header_read = 1;
 	
-	SOCK_LOG_INFO("PE RX (Hdr read): MsgLen: %lu, TX-ID: %d, Type: %d\n", 
+	SOCK_LOG_INFO("PE RX (Hdr read): MsgLen:  %" PRIu64 ", TX-ID: %d, Type: %d\n", 
 		      msg_hdr->msg_len, msg_hdr->rx_id, msg_hdr->op_type);
 	return 0;
 }

--- a/prov/sockets/src/sock_util.h
+++ b/prov/sockets/src/sock_util.h
@@ -38,6 +38,7 @@
 #define _SOCK_UTIL_H_
 
 #include <stdio.h>
+#include <inttypes.h>
 
 #define SOCK_ERROR (1)
 #define SOCK_WARN (2)


### PR DESCRIPTION
Mostly involves format strings, and duplicate const declarations. 

Other things that look possibly incorrect, but I didn't have a fix for: 
* [This](https://github.com/ofiwg/libfabric/blob/master/prov/sockets/src/sock_av.c#L298) line in sock_av_lookup doesn't look like it persists. I could be wrong but I think the intention was to either change the value, or make it a double pointer and change the pointer.  
* In sock_msg_passive_ep there is a path where the return value of [ret](https://github.com/ofiwg/libfabric/blob/master/prov/sockets/src/sock_ep_msg.c#L1172) is not initialized. I don't know what the proper initialization value would be. 
* An interesting pattern that appears often in the sock_progress.c file is setting the len variable (defined within function) after anything will ever read it. Is this intentional? [Here](https://github.com/ofiwg/libfabric/blob/master/prov/sockets/src/sock_progress.c#L374) is an example. It also happens on line (1067, 1524, 1580, 1628, and 1667)