### PR TITLE
usnic: add some usNIC-specific prov_errno values

### DIFF
--- a/include/rdma/fi_errno.h
+++ b/include/rdma/fi_errno.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2015 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -40,6 +41,8 @@ extern "C" {
 #endif
 
 /* FI directly mapped errno values */
+
+#define	FI_SUCCESS		0
 
 //#define	FI_EPERM		EPERM		/* Operation not permitted */
 #define	FI_ENOENT		ENOENT		/* No such file or directory */
@@ -183,6 +186,8 @@ extern "C" {
 #define FI_ENOEQ		261		/* Missing or unavailable event queue */
 #define FI_EDOMAIN		262		/* Invalid resource domain */
 #define FI_ENOCQ		263		/* Missing or unavailable completion queue */
+#define FI_ECRC			264		/* CRC error */
+#define FI_ETRUNC		265		/* Truncation error */
 
 const char *fi_strerror(int errnum);
 

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -82,7 +82,23 @@ usdf_cq_readerr(struct fid_cq *fcq, struct fi_cq_err_entry *entry,
 	entry->op_context = cq->cq_comp.uc_context;
 	entry->flags = 0;
 	entry->err = FI_EIO;
-	entry->prov_errno = cq->cq_comp.uc_status;
+	switch (cq->cq_comp.uc_status) {
+	case USD_COMPSTAT_SUCCESS:
+		entry->prov_errno = FI_SUCCESS;
+		break;
+	case USD_COMPSTAT_ERROR_CRC:
+		entry->prov_errno = FI_ECRC;
+		break;
+	case USD_COMPSTAT_ERROR_TRUNC:
+		entry->prov_errno = FI_ETRUNC;
+		break;
+	case USD_COMPSTAT_ERROR_TIMEOUT:
+		entry->prov_errno = FI_ETIMEDOUT;
+		break;
+	case USD_COMPSTAT_ERROR_INTERNAL:
+		entry->prov_errno = FI_EOTHER;
+		break;
+	}
 
 	cq->cq_comp.uc_status = 0;
 


### PR DESCRIPTION
There did not seem to be any suitable FI_* constants for the types of errors that usnic wants to report upward.  So create our own.

@shefty The goal here is to return a sensible error code to the caller in prov_errno (right now, the usnic provider is returning USD_* constants, which are internal).  There did not seem to be any relevant FI_* constants we could re-use, so we created our own (FI_EXT_USNIC_*).  Thoughts?

@goodell Please review
