### PR TITLE
Build on OS X

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,6 +45,15 @@ src_libfabric_la_SOURCES = \
 	src/log.c \
 	$(common_srcs)
 
+if MACOS
+src_libfabric_la_SOURCES += src/osx/osd.c
+src_libfabric_la_SOURCES += include/osx/osd.h
+endif
+
+if LINUX
+src_libfabric_la_SOURCES += include/linux/osd.h
+endif
+
 src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)
 src_libfabric_la_LDFLAGS =
 src_libfabric_la_LIBADD =

--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,26 @@ AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects parallel-tests])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
+AC_CANONICAL_HOST
+
+macos=0
+linux=0
+
+case $host_os in
+*darwin*)
+	macos=1
+	;;
+*linux*)
+	linux=1
+	;;
+*)
+	AC_MSG_ERROR([libfabric only builds on Linux & OS X])
+	;;
+esac
+
+AM_CONDITIONAL([MACOS], [test "x$macos" = "x1"])
+AM_CONDITIONAL([LINUX], [test "x$linux" = "x1"])
+
 AC_ARG_ENABLE([debug],
 	      [AS_HELP_STRING([--enable-debug],
 			      [Enable debugging @<:@default=no@:>@])
@@ -54,10 +74,6 @@ AC_PROG_CC_C99
 dnl Checks for header files.
 AC_HEADER_STDC
 
-dnl Only build on Linux
-AC_CHECK_HEADER([linux/types.h], [],
-	[AC_MSG_ERROR([libfabric only builds on Linux])])
-
 LT_INIT
 
 dnl dlopen support is optional
@@ -74,8 +90,21 @@ AC_CHECK_LIB(dl, dlopen, [],
 dnl Checks for libraries
 AC_CHECK_LIB(pthread, pthread_mutex_init, [],
     AC_MSG_ERROR([pthread_mutex_init() not found.  libfabric requires libpthread.]))
-AC_CHECK_LIB(rt, clock_gettime, [],
-    AC_MSG_ERROR([clock_gettime() not found.  libfabric requires librt.]))
+
+have_clock_gettime=0
+have_host_get_clock_service=0
+
+AC_SEARCH_LIBS([clock_gettime],[rt],
+		[have_clock_gettime=1],
+		[AC_CHECK_FUNCS([host_get_clock_service],
+			[have_host_get_clock_service=1],
+			[AC_MSG_ERROR([clock_gettime or host_get_clock_service
+			 not found.])])])
+
+AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
+		   [Define HAVE_CLOCK_GETTIME to 1 if available.])
+AC_DEFINE_UNQUOTED(HAVE_HOST_GET_CLOCK_SERVICE, [$have_host_get_clock_service],
+		   [Define HAVE_HOST_GET_CLOCK_SERVICE to 1 if available.])
 
 dnl Check for gcc atomic intrinsics
 AC_MSG_CHECKING(compiler support for c11 atomics)
@@ -128,6 +157,18 @@ AC_CACHE_CHECK(for .symver assembler support, ac_cv_asm_symver_support,
 if test x$ac_cv_asm_symver_support = xyes; then
 	AC_DEFINE([HAVE_SYMVER_SUPPORT], 1, [assembler has .symver support])
 fi
+
+AC_LINK_IFELSE(
+	[AC_LANG_SOURCE[
+		int foo(int arg);
+		int foo(int arg) { return arg + 3; };
+		int foo2(int arg) __attribute__ (( __alias__("foo")));
+	]],
+	[ac_cv_prog_cc_alias_symbols=1],
+	[ac_cv_prog_cc_alias_symbols=0])
+
+AC_DEFINE_UNQUOTED([HAVE_ALIAS_ATTRIBUTE], [$ac_cv_prog_cc_alias_symbols],
+	  	   [Define to 1 if the linker supports alias attribute.])
 
 dnl Provider-specific checks
 FI_PROVIDER_INIT

--- a/configure.ac
+++ b/configure.ac
@@ -199,21 +199,17 @@ if test "$PROVIDERS_TO_BUILD" = ""; then
 	exit 1
 fi
 
-echo "***"
-for i in $PROVIDERS_TO_BUILD; do
-	v=${i}_dl
-	if test `eval echo \\$${v}` != "1"; then
-		builtin="$i ${builtin}"
-	fi
-done
-echo -e "*** Built-in providers:\t${builtin}"
-echo "***"
-
 for i in $PROVIDERS_TO_BUILD; do
 	v=${i}_dl
 	if test `eval echo \\$${v}` == "1"; then
 		dso="$i ${dso}"
+	else
+		builtin="$i ${builtin}"
 	fi
 done
-echo -e "*** DSO providers:\t${dso}"
-echo "***"
+cat <<EOF
+***
+*** Built-in providers:	${builtin}
+*** DSO providers:	${dso}
+***
+EOF

--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <byteswap.h>
+#include <endian.h>

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _MACH_CLOCK_GETTIME_H_
+#define _MACH_CLOCK_GETTIME_H_
+
+#include <sys/time.h>
+#include <time.h>
+#include <mach/clock.h>
+#include <mach/mach.h>
+
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+
+#include <pthread.h>
+
+#define CLOCK_REALTIME CALENDAR_CLOCK
+#define CLOCK_MONOTONIC SYSTEM_CLOCK
+
+#define pthread_yield pthread_yield_np
+
+#define bswap_64 OSSwapInt64
+
+#ifdef _POSIX_HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#else
+#define HOST_NAME_MAX 255
+#endif
+
+typedef int clockid_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/include/rdma/fi_errno.h
+++ b/include/rdma/fi_errno.h
@@ -169,7 +169,7 @@ extern "C" {
 //#define	FI_ENOMEDIUM		ENOMEDIUM	/* No medium found */
 //#define	FI_EMEDIUMTYPE		EMEDIUMTYPE	/* Wrong medium type */
 #define	FI_ECANCELED		ECANCELED	/* Operation Canceled */
-#define	FI_ENOKEY		ENOKEY		/* Required key not available */
+
 //#define	FI_EKEYEXPIRED		EKEYEXPIRED	/* Key has expired */
 //#define	FI_EKEYREVOKED		EKEYREVOKED	/* Key has been revoked */
 #define	FI_EKEYREJECTED		EKEYREJECTED	/* Key was rejected by service */
@@ -188,6 +188,7 @@ extern "C" {
 #define FI_ENOCQ		263		/* Missing or unavailable completion queue */
 #define FI_ECRC			264		/* CRC error */
 #define FI_ETRUNC		265		/* Truncation error */
+#define FI_ENOKEY		266		/* Required key not available */
 
 const char *fi_strerror(int errnum);
 

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -34,6 +34,8 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <pthread.h>
+
 #include <rdma/fabric.h>
 #include <rdma/fi_atomic.h>
 #include <rdma/fi_cm.h>

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -38,6 +38,7 @@
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
@@ -125,7 +126,8 @@ struct sock_conn *sock_av_lookup_addr(struct sock_av *av,
 			av->domain, av->cmap, 
 			(struct sockaddr_in*)&av_addr->addr);
 		if (!av->key[idx]) {
-			SOCK_LOG_ERROR("failed to match or connect to addr %lu\n", addr);
+			SOCK_LOG_ERROR("failed to match or connect to addr %"
+					PRIu64 "\n", addr);
 			errno = EINVAL;
 			return NULL;
 		}

--- a/src/common.c
+++ b/src/common.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2004, 2005 Topspin Communications.  All rights reserved.
  * Copyright (c) 2006 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013 Intel Corp., Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -244,7 +244,7 @@ static struct fi_prov *fi_getprov(const char *prov_name)
 }
 
 __attribute__((visibility ("default")))
-void fi_freeinfo_(struct fi_info *info)
+void DEFAULT_SYMVER_PRE(fi_freeinfo)(struct fi_info *info)
 {
 	struct fi_info *next;
 
@@ -268,10 +268,10 @@ void fi_freeinfo_(struct fi_info *info)
 		free(info);
 	}
 }
-default_symver(fi_freeinfo_, fi_freeinfo);
+DEFAULT_SYMVER(fi_freeinfo_, fi_freeinfo);
 
 __attribute__((visibility ("default")))
-int fi_getinfo_(uint32_t version, const char *node, const char *service,
+int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const char *service,
 	       uint64_t flags, struct fi_info *hints, struct fi_info **info)
 {
 	struct fi_prov *prov;
@@ -299,7 +299,7 @@ int fi_getinfo_(uint32_t version, const char *node, const char *service,
 				continue;
 			} else {
 				/* a provider has an error, clean up and bail */
-				fi_freeinfo_(*info);
+				fi_freeinfo(*info);
 				*info = NULL;
 				return ret;
 			}
@@ -319,10 +319,10 @@ int fi_getinfo_(uint32_t version, const char *node, const char *service,
 
 	return *info ? 0 : ret;
 }
-default_symver(fi_getinfo_, fi_getinfo);
+DEFAULT_SYMVER(fi_getinfo_, fi_getinfo);
 
 __attribute__((visibility ("default")))
-struct fi_info *fi_dupinfo_(const struct fi_info *info)
+struct fi_info *DEFAULT_SYMVER_PRE(fi_dupinfo)(const struct fi_info *info)
 {
 	struct fi_info *dup;
 
@@ -416,10 +416,10 @@ fail:
 	fi_freeinfo(dup);
 	return NULL;
 }
-default_symver(fi_dupinfo_, fi_dupinfo);
+DEFAULT_SYMVER(fi_dupinfo_, fi_dupinfo);
 
 __attribute__((visibility ("default")))
-int fi_fabric_(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context)
+int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context)
 {
 	struct fi_prov *prov;
 
@@ -435,14 +435,14 @@ int fi_fabric_(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *co
 
 	return prov->provider->fabric(attr, fabric, context);
 }
-default_symver(fi_fabric_, fi_fabric);
+DEFAULT_SYMVER(fi_fabric_, fi_fabric);
 
 __attribute__((visibility ("default")))
-uint32_t fi_version_(void)
+uint32_t DEFAULT_SYMVER_PRE(fi_version)(void)
 {
 	return FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION);
 }
-default_symver(fi_version_, fi_version);
+DEFAULT_SYMVER(fi_version_, fi_version);
 
 #define FI_ERRNO_OFFSET	256
 #define FI_ERRNO_MAX	FI_ENOCQ
@@ -458,10 +458,11 @@ static const char *const errstr[] = {
 	[FI_ENOCQ - FI_ERRNO_OFFSET] = "Missing or unavailable completion queue",
 	[FI_ECRC - FI_ERRNO_OFFSET] = "CRC error",
 	[FI_ETRUNC - FI_ERRNO_OFFSET] = "Truncation error",
+	[FI_ENOKEY - FI_ERRNO_OFFSET] = "Required key not available",
 };
 
 __attribute__((visibility ("default")))
-const char *fi_strerror_(int errnum)
+const char *DEFAULT_SYMVER_PRE(fi_strerror)(int errnum)
 {
 	if (errnum < FI_ERRNO_OFFSET)
 		return strerror(errnum);
@@ -470,6 +471,6 @@ const char *fi_strerror_(int errnum)
 	else
 		return errstr[FI_EOTHER - FI_ERRNO_OFFSET];
 }
-default_symver(fi_strerror_, fi_strerror);
+DEFAULT_SYMVER(fi_strerror_, fi_strerror);
 
 

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -493,7 +493,7 @@ static void fi_tostr_version(char *buf)
 }
 
 __attribute__((visibility ("default")))
-char *fi_tostr_(const void *data, enum fi_type datatype)
+char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 {
 	static char *buf = NULL;
 	uint64_t val64 = *(const uint64_t *) data;
@@ -574,7 +574,7 @@ char *fi_tostr_(const void *data, enum fi_type datatype)
 	}
 	return buf;
 }
-default_symver(fi_tostr_, fi_tostr);
+DEFAULT_SYMVER(fi_tostr_, fi_tostr);
 
 #undef CASEENUMSTR
 #undef IFFLAGSTR

--- a/src/osx/osd.c
+++ b/src/osx/osd.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "osx/osd.h"
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp) {
+	int retval;
+
+	clock_serv_t cclock;
+	mach_timespec_t mts;
+
+	host_get_clock_service(mach_host_self(), clk_id, &cclock);
+	retval = clock_get_time(cclock, &mts);
+	mach_port_deallocate(mach_task_self(), cclock);
+
+	tp->tv_sec = mts.tv_sec;
+	tp->tv_nsec = mts.tv_nsec;
+
+	return retval;
+}


### PR DESCRIPTION
Various fixes that enable building on OS X. Tested on OS X 10.9.5. 

Changes that needed to be made: 
- Add a clock_gettime implementation since it is missing on OS X. This is in src/mach_clock_gettime.c. 
- Wrap htonll and ntohll definitions in ifndef gaurds.
- Rename flsll to fi_flsll since OS X has an flsll implementation but it is not the same. 
- Define le32toh, htole32, bswap_64 with OS X compatible headers (if on OS X). 
- Change FI_ENOKEY to be project specific error rather than using ENOKEY from errno.h (not POSIX error code and not defined on OS X & BSD). 
- Change HOST_NAME_MAX to be defined as _POSIX_HOST_NAME_MAX if defined or to 255 if neither is defined. 
- Use pthread_yield_np on OS X instead of pthread_yield
- Don't use attribute alias on OS X by defining default_symver_pre macro and checking for attribute support in configure.ac. 

@hppritcha @jsquyres  