### PR TITLE
verbs: work around usnic+rdma_cm EP_MSG brokenness

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -57,6 +57,7 @@
 
 #include "fi.h"
 #include "fi_enosys.h"
+#include "fi_log.h"
 #include "prov.h"
 #include "fi_log.h"
 
@@ -614,6 +615,12 @@ fi_ibv_getepinfo(const char *node, const char *service,
 	ret = rdma_create_ep(id, rai, NULL, NULL);
 	if (ret) {
 		ret = -errno;
+		if (ret == -ENOENT) {
+			FI_LOG(1, "verbs",
+				"rdma_create_ep()-->ENOENT; likely usnic bug, "
+				"skipping verbs provider.\n");
+			ret = -FI_ENODATA;
+		}
 		goto err2;
 	}
 


### PR DESCRIPTION
rdma_cm support with usnic devices is currently broken in a way that I
haven't been able to fully track down.  All currently released versions
of the usnic drivers were never intended to be used with rdma_cm, so
this brokenness isn't surprising.  This commit just works around this
known problem for now until we can fully debug the issue.

The symptoms look like this:
```
$ FI_LOG_LEVEL=5 ./simple/fi_msg_pingpong 10.200.2.120
libfabric:<2> registering provider: usnic (1.0)
libfabric:<2> registering provider: verbs (1.0)
libfabric:<2> registering provider: sockets (1.0)
libfabric:<1> fi_getinfo: provider verbs returned -2 (No such file or directory)
fi_getinfo(): -2 (No such file or directory)
```

This comes from rdma_cm, way down in the kernel.  The flow is a bit
tricky, but it looks like this (some intermediate frames/paths omitted):
```
fi_getinfo()
  fi_ibv_getepinfo()
    rdma_create_ep()
      rdma_resolve_addr2(src_addr=0x0, dst_addr=10.200.2.120) // dst is expected, usnic_0 of dg1
        write() // user/kernel boundary
        | ucma_resolve_addr()
        |   rdma_resolve_addr()
        |     rdma_resolve_ip()
        |       addr_resolve()
        |       queue_req()
        |         // enqueued work, so children below are not proper children
        |         process_req()  // <-- work queue handler, runs under "ib_addr" kernel process
        |           addr_resolve()  // <-- only if prior addr_resolve() returned -ENODATA
        |           addr_handler()  // <-- callback specified by rdma_resolve_addr
        |             cma_acquire_dev()
        |               rdma_port_get_link_layer()
        |               rdma_node_get_transport()
        |               rdma_port_get_link_layer()
        |               ib_find_cached_gid()  // <-- returning -ENOENT
        |               rdma_port_get_link_layer()
        |               rdma_node_get_transport()
        |               ib_find_cached_gid()  // <-- returning -ENOENT
        |
        ucma_complete()
          rdma_get_cm_event()  // <-- likely from rdma_resolve_addr()
            write()  // <--- user/kernel boundary
              ucma_get_event()
                ucma_event_handler()  // ends up returning -ENOENT that was set in the addr_handler()
```
The above flow is for RHEL 6.5, kernel 2.6.32-431.1.2.el6.x86_64.  I
have not tried other kernels, but it's likely that they also will have
problems.

We'll continue trying to figure out whether ib_find_cached_gid() is
being passed a bad GID or if bad GIDs are present in the cache, but we
have no ETA for complete diagnosis, let alone a fix.

With this change, the test run looks like this:
```
$ FI_LOG_LEVEL=5 ./simple/fi_msg_pingpong 10.200.2.120
libfabric:<2> registering provider: usnic (1.0)
libfabric:<2> registering provider: verbs (1.0)
libfabric:<2> registering provider: sockets (1.0)
libfabric:verbs:<1> rdma_create_ep() returned ENOENT.  We are likely dealing with a usnic_X device that has rdma_cm bugs, so skip the verbs provider instead.
libfabric:<1> fi_getinfo: provider verbs returned -61 (No data available)
name      bytes   iters   total       time     Gb/sec    usec/xfer
64_lat    64      100k    12m         0.61s      0.17       3.04
[...]
```

Signed-off-by: Dave Goodell <dgoodell@cisco.com>