### PR TITLE
Merge three bugfixes for usnic_direct from parent repository

### DIFF
--- a/prov/usnic/src/usnic_direct/usd_mem.c
+++ b/prov/usnic/src/usnic_direct/usd_mem.c
@@ -121,10 +121,11 @@ usd_alloc_mr(
     void *base_addr;
     struct usd_mr *mr;
     size_t true_size;
+    size_t metadata_size;
     int ret;
 
-    true_size = size + sizeof(struct usd_mr) + 2 * sizeof(uintptr_t) +
-        sysconf(_SC_PAGESIZE) - 1;
+    metadata_size = sizeof(struct usd_mr) + 2 * sizeof(uintptr_t);
+    true_size = size + metadata_size + sysconf(_SC_PAGESIZE) - 1;
     base_addr = mmap(NULL, true_size, PROT_READ | PROT_WRITE,
                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     if (base_addr == NULL || base_addr == MAP_FAILED) {
@@ -133,7 +134,7 @@ usd_alloc_mr(
     }
     mr = base_addr;
     vaddr =
-        (void *) ALIGN((uintptr_t) base_addr + sizeof(*mr) + sizeof(mr),
+        (void *) ALIGN((uintptr_t) base_addr + metadata_size,
                        sysconf(_SC_PAGESIZE));
     ((uintptr_t *) vaddr)[-1] = (uintptr_t) mr;
     ((uintptr_t *) vaddr)[-2] = true_size;

--- a/prov/usnic/src/usnic_direct/usd_queues.c
+++ b/prov/usnic/src/usnic_direct/usd_queues.c
@@ -801,6 +801,7 @@ usd_finish_create_cq(
                 cq_intr_enable, cq_entry_enable, cq_msg_enable,
                 cq_intr_offset, cq_msg_addr);
     }
+    cq->ucq_state |= USD_QS_VNIC_INITIALIZED;
 
     return 0;
 }
@@ -962,6 +963,8 @@ usd_destroy_qp(
         usd_free_mr(wq->uwq_copybuf);
     if (wq->uwq_desc_ring != NULL)
         usd_free_mr(wq->uwq_desc_ring);
+    if (rq->urq_desc_ring != NULL)
+        usd_free_mr(rq->urq_desc_ring);
 
     free(qp);
 


### PR DESCRIPTION
* Make usd_alloc_mr() calculate user buffer virtual address correctly
* Free and deregister rq descriptor ring buffer at QP destory
* Mark cq state as VNIC_INITIALIZED at the end of usd_finish_create_cq()

Signed-off-by: Xuyang Wang <xuywang@cisco.com>