### PR TITLE
prov/sockets: Support connected endpoints with tsend

### DIFF
--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -437,7 +437,11 @@ static ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 	}
 
 	assert(tx_ctx->enabled && msg->iov_count <= SOCK_EP_MAX_IOV_LIMIT);
-	conn = sock_av_lookup_addr(tx_ctx->av, msg->addr);
+	if (sock_ep->connected) {
+		conn = sock_ep_lookup_conn(sock_ep);
+	} else {
+		conn = sock_av_lookup_addr(tx_ctx->av, msg->addr);
+	}
 	if (!conn)
 		return -FI_EAGAIN;
 


### PR DESCRIPTION
Connected endpoints will not have an AV.  Target all
transfers to the connected peer.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>