### PR TITLE
prov/sockets: fix a bug in sock av_lookup

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -295,7 +295,7 @@ static int sock_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	}
 
 	av_addr = idm_lookup(&_av->addr_idm, index);
-	addr = &av_addr->addr;
+        memcpy(addr, &av_addr->addr, MIN(*addrlen, _av->addrlen));
 	*addrlen = _av->addrlen;
 	return 0;
 }


### PR DESCRIPTION
The sock av_lookup was not returning the address
being looked up.  This commit fixes this bug.

Thanks to @bturrubiates for finding this problem -
see PR #582.

Verified with a patched rdm_pingpong.c which tests
the fi_av_lookup method that the address is returned.

A patchfile for [rdma_pingpong.c](https://github.com/ofiwg/fabtests/blob/master/simple/rdm_pingpong.c) can be found at [here](https://gist.github.com/hppritcha/a6e18321a02c365cb783#file-0019-add-simple-av_lookup-sanity-check-to-rdm-pingpong-patch).

@jithinjosepkl  please check this

Signed-off-by: Howard Pritchard <howardp@lanl.gov>