### PR TITLE
improve AUTHORS

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Ben Turrubiates <bturrubiates@lanl.gov> <ben@turrubiat.es>
+Dave Goodell <dgoodell@cisco.com> <davidjgoodell@gmail.com>
+Howard Pritchard <howardp@lanl.gov> <hppritcha@gmail.com>
+Jeff Squyres <jsquyres@cisco.com> <jsquyres@users.noreply.github.com>
+Patrick McCormick <patrick.m.mccormick@intel.com>
+Reese Faucette <rfaucett@cisco.com> <rfaucett@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Jianxin Xiong	<jianxin.xiong@intel.com>
 Sayantan Sur	<sayantan.sur@intel.com>
 Xuyang Wang     <xuywang@cisco.com>
 Patrick McCormick <patrick.m.mccormick@intel.com>
+Dave Goodell    <dgoodell@cisco.com>


### PR DESCRIPTION
Add myself to the AUTHORS list and fix some cosmetic issues in the git author+committer history with a `.mailmap` file (https://www.kernel.org/pub/software/scm/git/docs/git-shortlog.html).