### PR TITLE
Added a version parameter in getinfo() for extended usnic ops

### DIFF
--- a/prov/usnic/src/fi_ext_usnic.h
+++ b/prov/usnic/src/fi_ext_usnic.h
@@ -38,7 +38,7 @@
 
 #define FI_PROTO_RUDP 100
 
-#define FI_USNIC_INFO_VERSION 1
+#define FI_EXT_USNIC_INFO_VERSION 1
 
 /*
  * usNIC specific info
@@ -66,7 +66,8 @@ struct fi_usnic_info {
 #define FI_USNIC_FABRIC_OPS_1 "fabric_ops 1"
 struct fi_usnic_ops_fabric {
 	size_t size;
-	int (*getinfo)(struct fid_fabric *fabric, struct fi_usnic_info *info);
+	int (*getinfo)(uint32_t version, struct fid_fabric *fabric,
+				struct fi_usnic_info *info);
 };
 
 /*

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -772,13 +772,18 @@ usdf_fabric_close(fid_t fid)
 }
 
 static int
-usdf_usnic_getinfo(struct fid_fabric *fabric, struct fi_usnic_info *uip)
+usdf_usnic_getinfo(uint32_t version, struct fid_fabric *fabric,
+			struct fi_usnic_info *uip)
 {
 	struct usdf_fabric *fp;
 	struct usd_device_attrs *dap;
 
 	fp = fab_ftou(fabric);
 	dap = fp->fab_dev_attrs;
+
+	if (version > FI_EXT_USNIC_INFO_VERSION) {
+		return -FI_EINVAL;
+	}
 
 	uip->ui.v1.ui_link_speed = dap->uda_bandwidth;
 	uip->ui.v1.ui_netmask_be = dap->uda_netmask_be;


### PR DESCRIPTION
usdf_usnic_getinfo can return usnic_info accordingly according the version passed in, or to return error if the version number is incompatible with the provider. 

Signed-off-by: Xuyang Wang <xuywang@cisco.com>