### PR TITLE
usnic: fix EP_MSG data integrity

### DIFF
--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -339,6 +339,7 @@ usdf_msg_send_segment(struct usdf_tx *tx, struct usdf_ep *ep)
 		hdr->msg.m.rc_data.seqno = htons(ep->e.msg.ep_next_tx_seq);
 		++ep->e.msg.ep_next_tx_seq;
 
+		sge_len = resid;
 		ptr = (uint8_t *)(hdr + 1);
 		while (resid > 0) {
 			memcpy(ptr, cur_ptr, cur_resid);
@@ -350,7 +351,6 @@ usdf_msg_send_segment(struct usdf_tx *tx, struct usdf_ep *ep)
 		}
 
 		/* add packet lengths */
-		sge_len = resid;
 		hdr->hdr.uh_ip.tot_len = htons(
 				sge_len + sizeof(struct rudp_pkt) -
 				sizeof(struct ether_header));
@@ -360,7 +360,7 @@ usdf_msg_send_segment(struct usdf_tx *tx, struct usdf_ep *ep)
 				 sizeof(struct iphdr)) + sge_len);
 
 		index = _usd_post_send_one(wq, hdr,
-				resid + sizeof(*hdr), 1);
+				sge_len + sizeof(*hdr), 1);
 	} else {
 		struct vnic_wq *vwq;
 		u_int8_t offload_mode = 0, eop;


### PR DESCRIPTION
We ended up sending all zeros for small messages because we were
incorrectly computing the packet length that was actually being posted.
The VIC would then pad out the frame with zeros to a valid 64-byte
Ethernet frame.

ofiwg/fabtests needs some data integrity love; this issue isn't caught
by the current tests, AFAICT.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@jsquyres please review

@rfaucett you might be interested, not expecting your review though