### PR TITLE
fabric: fi_control(FI_ENABLE) instead of ep->ops->enable

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -398,6 +398,7 @@ enum {
 	 */
 	FI_ALIAS,		/* struct fi_alias * */
 	FI_GETWAIT,		/* void * wait object */
+	FI_ENABLE,		/* NULL */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -65,7 +65,6 @@ enum {
 
 struct fi_ops_ep {
 	size_t	size;
-	int	(*enable)(struct fid_ep *ep);
 	ssize_t	(*cancel)(fid_t fid, void *context);
 	int	(*getopt)(fid_t fid, int level, int optname,
 			void *optval, size_t *optlen);
@@ -179,7 +178,7 @@ static inline int fi_scalable_ep_bind(struct fid_ep *sep, struct fid *bfid, uint
 
 static inline int fi_enable(struct fid_ep *ep)
 {
-	return ep->ops->enable(ep);
+	return ep->fid.ops->control(&ep->fid, FI_ENABLE, NULL);
 }
 
 static inline ssize_t fi_cancel(fid_t fid, void *context)

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -265,6 +265,9 @@ static int psmx_ep_control(fid_t fid, int command, void *arg)
 			return -EINVAL;
 		*(uint64_t *)arg = ep->flags;
 		break;
+	case FI_ENABLE:
+		return psmx_ep_enable(ep);
+		break;
 
 	default:
 		return -ENOSYS;
@@ -285,7 +288,6 @@ static struct fi_ops_ep psmx_ep_ops = {
 	.cancel = psmx_ep_cancel,
 	.getopt = psmx_ep_getopt,
 	.setopt = psmx_ep_setopt,
-	.enable = psmx_ep_enable,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = fi_no_rx_size_left,

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -264,8 +264,40 @@ static int sock_ctx_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 
 }
 
+static int sock_ctx_enable(struct fid_ep *ep)
+{
+	struct sock_tx_ctx *tx_ctx;
+	struct sock_rx_ctx *rx_ctx;
+
+	switch (ep->fid.fclass) {
+	case FI_CLASS_RX_CTX:
+		rx_ctx = container_of(ep, struct sock_rx_ctx, ctx.fid);
+		rx_ctx->enabled = 1;
+		if (!rx_ctx->progress) {
+			sock_pe_add_rx_ctx(rx_ctx->domain->pe, rx_ctx);
+			rx_ctx->progress = 1;
+		}
+		return 0;
+
+	case FI_CLASS_TX_CTX:
+		tx_ctx = container_of(ep, struct sock_tx_ctx, fid.ctx.fid);
+		tx_ctx->enabled = 1;
+		if (!tx_ctx->progress) {
+			sock_pe_add_tx_ctx(tx_ctx->domain->pe, tx_ctx);
+			tx_ctx->progress = 1;
+		}
+		return 0;
+
+	default:
+		SOCK_LOG_ERROR("Invalid CTX\n");
+		break;
+	}
+	return -FI_EINVAL;
+}
+
 static int sock_ctx_control(struct fid *fid, int command, void *arg)
 {
+	struct fid_ep *ep;
 	struct sock_tx_ctx *tx_ctx;
 	struct sock_rx_ctx *rx_ctx;
 
@@ -278,6 +310,10 @@ static int sock_ctx_control(struct fid *fid, int command, void *arg)
 			break;
 		case FI_SETOPSFLAG:
 			tx_ctx->attr.op_flags = (uint64_t)arg;
+			break;
+		case FI_ENABLE:
+			ep = container_of(fid, struct fid_ep, fid);
+			return sock_ctx_enable(ep);
 			break;
 		default:
 			return -FI_EINVAL;
@@ -292,6 +328,10 @@ static int sock_ctx_control(struct fid *fid, int command, void *arg)
 			break;
 		case FI_SETOPSFLAG:
 			rx_ctx->attr.op_flags = (uint64_t)arg;
+			break;
+		case FI_ENABLE:
+			ep = container_of(fid, struct fid_ep, fid);
+			return sock_ctx_enable(ep);
 			break;
 		default:
 			return -FI_EINVAL;
@@ -325,37 +365,6 @@ static struct fi_ops sock_ctx_ops = {
 	.bind = sock_ctx_bind,
 	.control = sock_ctx_control,
 };
-
-static int sock_ctx_enable(struct fid_ep *ep)
-{
-	struct sock_tx_ctx *tx_ctx;
-	struct sock_rx_ctx *rx_ctx;
-
-	switch (ep->fid.fclass) {
-	case FI_CLASS_RX_CTX:
-		rx_ctx = container_of(ep, struct sock_rx_ctx, ctx.fid);
-		rx_ctx->enabled = 1;
-		if (!rx_ctx->progress) {
-			sock_pe_add_rx_ctx(rx_ctx->domain->pe, rx_ctx);
-			rx_ctx->progress = 1;
-		}
-		return 0;
-
-	case FI_CLASS_TX_CTX:
-		tx_ctx = container_of(ep, struct sock_tx_ctx, fid.ctx.fid);
-		tx_ctx->enabled = 1;
-		if (!tx_ctx->progress) {
-			sock_pe_add_tx_ctx(tx_ctx->domain->pe, tx_ctx);
-			tx_ctx->progress = 1;
-		}
-		return 0;
-
-	default:
-		SOCK_LOG_ERROR("Invalid CTX\n");
-		break;
-	}
-	return -FI_EINVAL;
-}
 
 static int sock_ctx_getopt(fid_t fid, int level, int optname,
 		       void *optval, size_t *optlen)
@@ -454,7 +463,6 @@ static ssize_t sock_ep_cancel(fid_t fid, void *context)
 
 struct fi_ops_ep sock_ctx_ep_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = sock_ctx_enable,
 	.cancel = sock_ep_cancel,
 	.getopt = sock_ctx_getopt,
 	.setopt = sock_ctx_setopt,
@@ -723,6 +731,7 @@ static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 
 static int sock_ep_control(struct fid *fid, int command, void *arg)
 {
+	struct fid_ep *ep_fid;
 	struct fi_alias *alias;
 	struct sock_ep *ep, *new_ep;
 
@@ -757,6 +766,9 @@ static int sock_ep_control(struct fid *fid, int command, void *arg)
 	case FI_SETOPSFLAG:
 		ep->op_flags = (uint64_t)arg;
 		break;
+	case FI_ENABLE:
+		ep_fid = container_of(fid, struct fid_ep, fid);
+		return sock_ep_enable(ep_fid);
 
 	default:
 		return -FI_EINVAL;
@@ -939,7 +951,6 @@ static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 
 struct fi_ops_ep sock_ep_ops ={
 	.size = sizeof(struct fi_ops_ep),
-	.enable = sock_ep_enable,
 	.cancel = sock_ep_cancel,
 	.getopt = sock_ep_getopt,
 	.setopt = sock_ep_setopt,

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -282,7 +282,6 @@ usdf_ep_dgram_close(fid_t fid)
 
 static struct fi_ops_ep usdf_base_dgram_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = usdf_ep_dgram_enable,
 	.cancel = fi_no_cancel,
 	.getopt = fi_no_getopt,
 	.setopt = fi_no_setopt,
@@ -294,7 +293,6 @@ static struct fi_ops_ep usdf_base_dgram_ops = {
 
 static struct fi_ops_ep usdf_base_dgram_prefix_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = usdf_ep_dgram_enable,
 	.cancel = fi_no_cancel,
 	.getopt = fi_no_getopt,
 	.setopt = fi_no_setopt,
@@ -336,11 +334,31 @@ static struct fi_ops_cm usdf_cm_dgram_ops = {
 	.shutdown = fi_no_shutdown,
 };
 
+static int usdf_ep_dgram_control(struct fid *fid, int command, void *arg)
+{
+	struct fid_ep *ep;
+
+	switch (fid->fclass) {
+	case FI_CLASS_EP:
+		ep = container_of(fid, struct fid_ep, fid);
+		switch (command) {
+		case FI_ENABLE:
+			return usdf_ep_dgram_enable(ep);
+			break;
+		default:
+			return -FI_EINVAL;
+		}
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+}
+
 static struct fi_ops usdf_ep_dgram_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = usdf_ep_dgram_close,
 	.bind = usdf_ep_dgram_bind,
-	.control = fi_no_control,
+	.control = usdf_ep_dgram_control,
 	.ops_open = fi_no_ops_open
 };
 

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -575,7 +575,6 @@ usdf_ep_msg_close(fid_t fid)
 
 static struct fi_ops_ep usdf_base_msg_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = usdf_ep_msg_enable,
 	.cancel = usdf_ep_msg_cancel,
 	.getopt = usdf_ep_msg_getopt,
 	.setopt = usdf_ep_msg_setopt,
@@ -609,11 +608,31 @@ static struct fi_ops_msg usdf_msg_ops = {
 	.injectdata = fi_no_msg_injectdata,
 };
 
+static int usdf_ep_msg_control(struct fid *fid, int command, void *arg)
+{
+	struct fid_ep *ep;
+
+	switch (fid->fclass) {
+	case FI_CLASS_EP:
+		ep = container_of(fid, struct fid_ep, fid);
+		switch (command) {
+		case FI_ENABLE:
+			return usdf_ep_msg_enable(ep);
+			break;
+		default:
+			return -FI_EINVAL;
+		}
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+}
+
 static struct fi_ops usdf_ep_msg_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = usdf_ep_msg_close,
 	.bind = usdf_ep_msg_bind,
-	.control = fi_no_control,
+	.control = usdf_ep_msg_control,
 	.ops_open = fi_no_ops_open
 };
 

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -632,7 +632,6 @@ usdf_ep_rdm_close(fid_t fid)
 
 static struct fi_ops_ep usdf_base_rdm_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = usdf_ep_rdm_enable,
 	.cancel = usdf_ep_rdm_cancel,
 	.getopt = usdf_ep_rdm_getopt,
 	.setopt = usdf_ep_rdm_setopt,
@@ -666,11 +665,31 @@ static struct fi_ops_msg usdf_rdm_ops = {
 	.injectdata = fi_no_msg_injectdata,
 };
 
+static int usdf_ep_rdm_control(struct fid *fid, int command, void *arg)
+{
+	struct fid_ep *ep;
+
+	switch (fid->fclass) {
+	case FI_CLASS_EP:
+		ep = container_of(fid, struct fid_ep, fid);
+		switch (command) {
+		case FI_ENABLE:
+			return usdf_ep_rdm_enable(ep);
+			break;
+		default:
+			return -FI_EINVAL;
+		}
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+}
+
 static struct fi_ops usdf_ep_rdm_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = usdf_ep_rdm_close,
 	.bind = usdf_ep_rdm_bind,
-	.control = fi_no_control,
+	.control = usdf_ep_rdm_control,
 	.ops_open = fi_no_ops_open
 };
 

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -420,7 +420,6 @@ struct fi_ops usdf_pep_ops = {
 
 static struct fi_ops_ep usdf_pep_base_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = fi_no_enable,
 	.cancel = usdf_pep_cancel,
 	.getopt = fi_no_getopt,
 	.setopt = fi_no_setopt,


### PR DESCRIPTION
fi_control(command=FI_ENABLE) can be used to enable any endpoints vs
having enable as a special EP op.

This reduces the endpoint structure a bit, and is more generic since we
may have other objects (in the future) that may need to be enabled that
can reuse the same command.

i.e.

Currently:

static inline int fi_enable(struct fid_ep *ep)
{
        return ep->ops->enable(ep);
}

Proposed:

static inline int fi_enable(struct fid_ep *ep)
{
        return ep->fid.ops->control(&ep->fid, FI_ENABLE, NULL);
}

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>