### PR TITLE
[RFC] Add pkg-config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ config.log
 config.status
 configure
 libtool
+libfabric.pc
 libfabric.spec
 
 config/ar-lib

--- a/Makefile.am
+++ b/Makefile.am
@@ -410,7 +410,10 @@ nroff:
 	    config/md2nroff.pl --source=$$file.md; \
 	done
 
-EXTRA_DIST = libfabric.map libfabric.spec.in config/distscript.pl $(man_MANS)
+EXTRA_DIST = libfabric.map libfabric.pc.in libfabric.spec.in config/distscript.pl $(man_MANS)
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libfabric.pc
 
 dist-hook: libfabric.spec
 	cp libfabric.spec $(distdir)

--- a/configure.ac
+++ b/configure.ac
@@ -142,7 +142,7 @@ AS_IF([test x"$enable_direct" != x"no"],
 
 AM_CONDITIONAL([HAVE_DIRECT], [test x"$enable_direct" != x"no"])
 
-AC_CONFIG_FILES([Makefile libfabric.spec])
+AC_CONFIG_FILES([Makefile libfabric.pc libfabric.spec])
 AC_OUTPUT
 
 dnl helpful output

--- a/libfabric.pc.in
+++ b/libfabric.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+includedir=@includedir@
+libdir=@libdir@
+
+Name: libfabric
+Description: A modern library for direct userspace use of RDMA hardware
+Version: @VERSION@
+Libs: -L${libdir} -lfabric
+Cflags: -I${includedir}


### PR DESCRIPTION
This is more of a nice-to-have than a necessity, but I figured if we are going to pull this in we should try to do so before 1.0 so that we have it from day 1.  At the end of the day, this is just a single file that we install into the user's pkg-config path so that downstream projects have an easy way to detect and use libfabric.

From the [pkg-config website] (http://www.freedesktop.org/wiki/Software/pkg-config/): "pkg-config is a helper tool used when compiling applications and libraries. It helps you insert the correct compiler options on the command line."

Providing a pkg-config file is suggested by the systemd developers as a best practice in their [libabc] (https://git.kernel.org/cgit/linux/kernel/git/kay/libabc.git/plain/README) sample library, and allows consumers of libfabric to use pkg-config in their autotools setup to locate and pull in libfabric.

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>