### PR TITLE
verbs: Fix fi_getinfo with src_addr but no dst_addr hint

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -593,8 +593,10 @@ fi_ibv_getepinfo(const char *node, const char *service,
 	if (ret)
 		return ret;
 
-	if (!node && !rai_hints.ai_src_addr && !rai_hints.ai_dst_addr) {
-		node = local_node;
+	if (!node && !rai_hints.ai_dst_addr) {
+		if (!rai_hints.ai_src_addr) {
+			node = local_node;
+		}
 		rai_hints.ai_flags |= RAI_PASSIVE;
 	}
 


### PR DESCRIPTION
This PR fixes a bug in fi_getinfo() for the verbs provider w.r.t. passing src_addr in hints.

The verbs provider would return -FI_EINVAL from fi_getinfo if node and
hints->dst_addr were NULL but src_addr was specified.  This occurred
because the verbs provider did not set the RAI_PASSIVE flag in its call
to rdma_getaddrinfo() in this case.  This commit fixes this issue by
setting the RAI_PASSIVE flag in this case.

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>