### PR TITLE
Fix post-rc daily build versions

### DIFF
--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -98,9 +98,10 @@ doit(0, "git clean -df");
 doit(0, "git checkout .");
 doit(0, "git pull");
 
-# Get a git describe id
+# Get a git describe id (minus the initial 'v' in the tag name, if any)
 my $gd = `git describe --tags --always`;
 chomp($gd);
+$gd =~ s/^v//;
 verbose("*** Git describe: $gd\n");
 
 # Read in configure.ac
@@ -114,8 +115,8 @@ close(IN);
 # Get the original version number
 $config =~ m/AC_INIT\(\[libfabric\], \[(.+?)\]/;
 my $orig_version = $1;
-verbose("*** Got configure.ac version: $orig_version\n");
-my $version = "$orig_version.$gd";
+verbose("*** Replacing configure.ac version: $orig_version\n");
+my $version = $gd;
 $version =~ y/-/./;
 verbose("*** Nightly tarball version: $version\n");
 


### PR DESCRIPTION
When the daily build script was first written, the version in configure.ac and the
only tag in the repository were bogus and did not match each other.  Now
that we have an rc release properly tagged, versions generated by this
script will look like "1.0.0rc1.v1.0.0rc1.xyz.gabcdefab", which is a bit
redundant.  To fix this, use the git tag version as the main RPM version
instead of appending it to the version in configure.ac, since they
should always match (this patch also adds a sanity check to make sure
that this is in fact true).

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>