### PR TITLE
man: add fi_control(3) man page

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -353,6 +353,7 @@ dummy_man_pages = \
         man/fi_compare_atomicmsg.3 \
         man/fi_compare_atomicv.3 \
         man/fi_connect.3 \
+        man/fi_control.3 \
         man/fi_cq_open.3 \
         man/fi_cq_read.3 \
         man/fi_cq_readerr.3 \

--- a/man/fi_control.3
+++ b/man/fi_control.3
@@ -1,0 +1,7 @@
+\" fi_control is actually documented in multiple places:
+\" - fi_endpoint(3)
+\" - fi_cq(3)
+\" - fi_eq(3)
+\" and it is mentioned in numerous other man pages.  Direct users to
+\" fi_endpoint(3) for now, so that at least they can find the prototype.
+.so man3/fi_endpoint.3

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -379,6 +379,11 @@ assigned to an endpoint.
   the type of data transfer that the flags should apply to, with other
   flags OR'ed in.  Valid control flags are defined below.
 
+fi_control can also be used with some non-endpoint objects.  For usage
+relevant to those types, see [`fi_cntr`(3)](fi_cntr.3.html),
+[`fi_cm`(3)](fi_cm.3.html), [`fi_cq`(3)](fi_cq.3.html), and
+[`fi_eq`(3)](fi_eq.3.html).
+
 ## fi_getopt / fi_setopt
 
 Endpoint protocol operations may be retrieved using fi_getopt or set


### PR DESCRIPTION
For now just redirect fi_control(3) to fi_endpoint(3) and throw in some
"see also" text.  At some point we may want to give fi_control its own
proper page and list cross references to all the other pages for
detailed usage with each object type.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>