### PR TITLE
fabric: fi_control(FI_ENABLE) instead of ep->ops->enable

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -398,6 +398,7 @@ enum {
 	 */
 	FI_ALIAS,		/* struct fi_alias * */
 	FI_GETWAIT,		/* void * wait object */
+	FI_ENABLE,		/* NULL */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -65,7 +65,6 @@ enum {
 
 struct fi_ops_ep {
 	size_t	size;
-	int	(*enable)(struct fid_ep *ep);
 	ssize_t	(*cancel)(fid_t fid, void *context);
 	int	(*getopt)(fid_t fid, int level, int optname,
 			void *optval, size_t *optlen);
@@ -179,7 +178,7 @@ static inline int fi_scalable_ep_bind(struct fid_ep *sep, struct fid *bfid, uint
 
 static inline int fi_enable(struct fid_ep *ep)
 {
-	return ep->ops->enable(ep);
+	return ep->fid.ops->control(&ep->fid, FI_ENABLE, NULL);
 }
 
 static inline ssize_t fi_cancel(fid_t fid, void *context)

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -136,11 +136,6 @@ static int psmx_ep_setopt(fid_t fid, int level, int optname,
 	return 0;
 }
 
-static int psmx_ep_enable(struct fid_ep *ep)
-{
-	return 0;
-}
-
 static int psmx_ep_close(fid_t fid)
 {
 	struct psmx_fid_ep *ep;
@@ -266,6 +261,9 @@ static int psmx_ep_control(fid_t fid, int command, void *arg)
 		*(uint64_t *)arg = ep->flags;
 		break;
 
+	case FI_ENABLE:
+		return 0;
+
 	default:
 		return -FI_ENOSYS;
 	}
@@ -285,7 +283,6 @@ static struct fi_ops_ep psmx_ep_ops = {
 	.cancel = psmx_ep_cancel,
 	.getopt = psmx_ep_getopt,
 	.setopt = psmx_ep_setopt,
-	.enable = psmx_ep_enable,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = fi_no_rx_size_left,

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -282,7 +282,6 @@ usdf_ep_dgram_close(fid_t fid)
 
 static struct fi_ops_ep usdf_base_dgram_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = usdf_ep_dgram_enable,
 	.cancel = fi_no_cancel,
 	.getopt = fi_no_getopt,
 	.setopt = fi_no_setopt,
@@ -294,7 +293,6 @@ static struct fi_ops_ep usdf_base_dgram_ops = {
 
 static struct fi_ops_ep usdf_base_dgram_prefix_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = usdf_ep_dgram_enable,
 	.cancel = fi_no_cancel,
 	.getopt = fi_no_getopt,
 	.setopt = fi_no_setopt,
@@ -336,11 +334,31 @@ static struct fi_ops_cm usdf_cm_dgram_ops = {
 	.shutdown = fi_no_shutdown,
 };
 
+static int usdf_ep_dgram_control(struct fid *fid, int command, void *arg)
+{
+	struct fid_ep *ep;
+
+	switch (fid->fclass) {
+	case FI_CLASS_EP:
+		ep = container_of(fid, struct fid_ep, fid);
+		switch (command) {
+		case FI_ENABLE:
+			return usdf_ep_dgram_enable(ep);
+			break;
+		default:
+			return -FI_ENOSYS;
+		}
+		break;
+	default:
+		return -FI_ENOSYS;
+	}
+}
+
 static struct fi_ops usdf_ep_dgram_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = usdf_ep_dgram_close,
 	.bind = usdf_ep_dgram_bind,
-	.control = fi_no_control,
+	.control = usdf_ep_dgram_control,
 	.ops_open = fi_no_ops_open
 };
 

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -575,7 +575,6 @@ usdf_ep_msg_close(fid_t fid)
 
 static struct fi_ops_ep usdf_base_msg_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = usdf_ep_msg_enable,
 	.cancel = usdf_ep_msg_cancel,
 	.getopt = usdf_ep_msg_getopt,
 	.setopt = usdf_ep_msg_setopt,
@@ -609,11 +608,31 @@ static struct fi_ops_msg usdf_msg_ops = {
 	.injectdata = fi_no_msg_injectdata,
 };
 
+static int usdf_ep_msg_control(struct fid *fid, int command, void *arg)
+{
+	struct fid_ep *ep;
+
+	switch (fid->fclass) {
+	case FI_CLASS_EP:
+		ep = container_of(fid, struct fid_ep, fid);
+		switch (command) {
+		case FI_ENABLE:
+			return usdf_ep_msg_enable(ep);
+			break;
+		default:
+			return -FI_ENOSYS;
+		}
+		break;
+	default:
+		return -FI_ENOSYS;
+	}
+}
+
 static struct fi_ops usdf_ep_msg_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = usdf_ep_msg_close,
 	.bind = usdf_ep_msg_bind,
-	.control = fi_no_control,
+	.control = usdf_ep_msg_control,
 	.ops_open = fi_no_ops_open
 };
 

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -632,7 +632,6 @@ usdf_ep_rdm_close(fid_t fid)
 
 static struct fi_ops_ep usdf_base_rdm_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = usdf_ep_rdm_enable,
 	.cancel = usdf_ep_rdm_cancel,
 	.getopt = usdf_ep_rdm_getopt,
 	.setopt = usdf_ep_rdm_setopt,
@@ -666,11 +665,31 @@ static struct fi_ops_msg usdf_rdm_ops = {
 	.injectdata = fi_no_msg_injectdata,
 };
 
+static int usdf_ep_rdm_control(struct fid *fid, int command, void *arg)
+{
+	struct fid_ep *ep;
+
+	switch (fid->fclass) {
+	case FI_CLASS_EP:
+		ep = container_of(fid, struct fid_ep, fid);
+		switch (command) {
+		case FI_ENABLE:
+			return usdf_ep_rdm_enable(ep);
+			break;
+		default:
+			return -FI_ENOSYS;
+		}
+		break;
+	default:
+		return -FI_ENOSYS;
+	}
+}
+
 static struct fi_ops usdf_ep_rdm_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = usdf_ep_rdm_close,
 	.bind = usdf_ep_rdm_bind,
-	.control = fi_no_control,
+	.control = usdf_ep_rdm_control,
 	.ops_open = fi_no_ops_open
 };
 

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -420,7 +420,6 @@ struct fi_ops usdf_pep_ops = {
 
 static struct fi_ops_ep usdf_pep_base_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = fi_no_enable,
 	.cancel = usdf_pep_cancel,
 	.getopt = fi_no_getopt,
 	.setopt = fi_no_setopt,

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -1668,7 +1668,7 @@ fi_ibv_msg_ep_connect(struct fid_ep *ep, const void *addr,
 
 	_ep = container_of(ep, struct fi_ibv_msg_ep, ep_fid);
 	if (!_ep->id->qp) {
-		ret = ep->ops->enable(ep);
+		ret = ep->fid.ops->control(&ep->fid, FI_ENABLE, NULL);
 		if (ret)
 			return ret;
 	}
@@ -1694,7 +1694,7 @@ fi_ibv_msg_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 
 	_ep = container_of(ep, struct fi_ibv_msg_ep, ep_fid);
 	if (!_ep->id->qp) {
-		ret = ep->ops->enable(ep);
+		ret = ep->fid.ops->control(&ep->fid, FI_ENABLE, NULL);
 		if (ret)
 			return ret;
 	}
@@ -1776,7 +1776,6 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 
 static struct fi_ops_ep fi_ibv_msg_ep_base_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.enable = fi_ibv_msg_ep_enable,
 	.cancel = fi_no_cancel,
 	.getopt = fi_ibv_msg_ep_getopt,
 	.setopt = fi_ibv_msg_ep_setopt,
@@ -1796,11 +1795,31 @@ static int fi_ibv_msg_ep_close(fid_t fid)
 	return 0;
 }
 
+static int fi_ibv_msg_ep_control(struct fid *fid, int command, void *arg)
+{
+	struct fid_ep *ep;
+
+	switch (fid->fclass) {
+	case FI_CLASS_EP:
+		ep = container_of(fid, struct fid_ep, fid);
+		switch (command) {
+		case FI_ENABLE:
+			return fi_ibv_msg_ep_enable(ep);
+			break;
+		default:
+			return -FI_ENOSYS;
+		}
+		break;
+	default:
+		return -FI_ENOSYS;
+	}
+}
+
 static struct fi_ops fi_ibv_msg_ep_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = fi_ibv_msg_ep_close,
 	.bind = fi_ibv_msg_ep_bind,
-	.control = fi_no_control,
+	.control = fi_ibv_msg_ep_control,
 	.ops_open = fi_no_ops_open,
 };
 


### PR DESCRIPTION
fi_control(command=FI_ENABLE) can be used to enable any endpoints vs
having enable as a special EP op.

This reduces the endpoint structure a bit, and is more generic since we
may have other objects (in the future) that may need to be enabled that
can reuse the same command.

i.e.

Currently:

static inline int fi_enable(struct fid_ep *ep)
{
        return ep->ops->enable(ep);
}

Proposed:

static inline int fi_enable(struct fid_ep *ep)
{
        return ep->fid.ops->control(&ep->fid, FI_ENABLE, NULL);
}

Return FI_ENOSYS for control operations not supported by the
provider or values which aren't defined.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>
Signed-off-by: Sean Hefty <sean.hefty@intel.com>