### PR TITLE
fi_tostr: don't access *data before checking for NULL

### DIFF
--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -496,12 +496,16 @@ __attribute__((visibility ("default")))
 char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 {
 	static char *buf = NULL;
-	uint64_t val64 = *(const uint64_t *) data;
-	uint32_t val32 = *(const uint32_t *) data;
-	int enumval = *(const int *) data;
+	uint64_t val64;
+	uint32_t val32;
+	int enumval;
 
 	if (!data)
 		return NULL;
+
+	val64 = *(const uint64_t *) data;
+	val32 = *(const uint32_t *) data;
+	enumval = *(const int *) data;
 
 	if (!buf) {
 		buf = calloc(BUFSIZ, 1);


### PR DESCRIPTION
This was Open MPI CID 1270230.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>