### PR TITLE
prov/sockets: Fix dependency on shm_open

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -87,11 +87,12 @@ _sockets_files = \
 if HAVE_SOCKETS_DL
 pkglib_LTLIBRARIES += libsockets-fi.la
 libsockets_fi_la_SOURCES = $(_sockets_files) $(common_srcs)
-libsockets_fi_la_LIBADD = $(linkback)
+libsockets_fi_la_LIBADD = $(linkback) $(sockets_shm_LIBS)
 libsockets_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
 libsockets_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_SOCKETS_DL
 src_libfabric_la_SOURCES += $(_sockets_files)
+src_libfabric_la_LIBADD += $(sockets_shm_LIBS)
 endif !HAVE_SOCKETS_DL
 
 endif HAVE_SOCKETS

--- a/prov/sockets/configure.m4
+++ b/prov/sockets/configure.m4
@@ -9,11 +9,23 @@ dnl $2: action if not configured successfully
 dnl
 AC_DEFUN([FI_SOCKETS_CONFIGURE],[
 	# Determine if we can support the sockets provider
-	sockets_happy=0
+	sockets_h_happy=0
+	sockets_shm_happy=0
 	AS_IF([test x"$enable_sockets" != x"no"],
-	      [sockets_happy=1
-	       AC_CHECK_HEADER([sys/socket.h], [], [sockets_happy=0])
+	      [AC_CHECK_HEADER([sys/socket.h], [sockets_h_happy=1],
+	                       [sockets_h_happy=0])
+
+	       FI_CHECK_PACKAGE([sockets_shm],
+				[sys/mman.h],
+				[rt],
+				[shm_open],
+				[],
+				[],
+				[],
+				[sockets_shm_happy=1],
+				[sockets_shm_happy=0])
 	      ])
 
-	AS_IF([test $sockets_happy -eq 1], [$1], [$2])
+	AS_IF([test $sockets_h_happy -eq 1 && \
+	       test $sockets_shm_happy -eq 1], [$1], [$2])
 ])


### PR DESCRIPTION
@shefty: IMHO this should be targeted for rc2 since it may impact building on RHEL 7, which I believe is targeted by OFED 3.18.  This fix was tested on Fedora 21.

Newer versions of glibc define clock_gettime in libc (it has
traditionally been in librt).  This means that librt is not
automatically pulled in by the check for clock_gettime, which causes
link errors for downstream projects trying to link against libfabric
under newer Linux versions (this issue was observed on Fedora 21).

This commit fixes the issue by adding an explicit check for shm_open in
the socket provider's configure-time checks.

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>