### PR TITLE
dlopen fixes

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -178,9 +178,11 @@ static void fi_ini(void)
 
 	/* If dlopen fails, assume static linking and just return
 	   without error */
-	if (dlopen(NULL, RTLD_NOW) == NULL) {
+	dlhandle = dlopen(NULL, RTLD_NOW);
+	if (dlhandle == NULL) {
 		goto done;
 	}
+	dlclose(dlhandle);
 
 	provdir = PROVDLDIR;
 	n = scandir(provdir, &liblist, lib_filter, NULL);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -198,16 +198,18 @@ static void fi_ini(void)
 		FI_DEBUG(NULL, "opening provider lib %s\n", lib);
 
 		dlhandle = dlopen(lib, RTLD_NOW);
-		if (dlhandle == NULL)
-			FI_WARN(NULL, "dlopen(%s): %s\n", lib, dlerror());
-
 		free(liblist[n]);
 		free(lib);
+		if (dlhandle == NULL) {
+			FI_WARN(NULL, "dlopen(%s): %s\n", lib, dlerror());
+			continue;
+		}
 
 		inif = dlsym(dlhandle, "fi_prov_ini");
-		if (inif == NULL)
+		if (inif == NULL) {
 			FI_WARN(NULL, "dlsym: %s\n", dlerror());
-		else
+			dlclose(dlhandle);
+		} else
 			fi_register_provider((inif)(), dlhandle);
 	}
 


### PR DESCRIPTION
This started as a pair of coverity fixes, but I also found a 3rd issue.

All of these fixes are around the dlopen code in fabric.c.  It is likely easiest to look at the individual commits to understand the changes (vs. looking at the union of the commits).

@shefty @pmmccorm please review