### PR TITLE
Verbs coverity patches

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -2117,7 +2117,8 @@ fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	case FI_WAIT_NONE:
 		break;
 	default:
-		return -ENOSYS;
+		ret = -FI_ENOSYS;
+		goto err1;
 	}
 
 	_eq->flags = attr->flags;
@@ -2436,7 +2437,8 @@ fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	case FI_WAIT_NONE:
 		break;
 	default:
-		return -FI_ENOSYS;
+		ret = -FI_ENOSYS;
+		goto err1;
 	}
 
 	_cq->cq = ibv_create_cq(_cq->domain->verbs, attr->size, _cq,

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -2103,7 +2103,11 @@ fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 			ret = -errno;
 			goto err1;
 		}
-		fcntl(_eq->channel->fd, F_GETFL, &flags);
+		flags = fcntl(_eq->channel->fd, F_GETFL);
+		if (flags < 0) {
+			ret = -errno;
+			goto err2;
+		}
 		ret = fcntl(_eq->channel->fd, F_SETFL, flags | O_NONBLOCK);
 		if (ret) {
 			ret = -errno;
@@ -2418,11 +2422,15 @@ fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 			goto err1;
 		}
 
-		fcntl(_cq->channel->fd, F_GETFL, &flags);
+		flags = fcntl(_cq->channel->fd, F_GETFL);
+		if (flags < 0) {
+			ret = -errno;
+			goto err2;
+		}
 		ret = fcntl(_cq->channel->fd, F_SETFL, flags | O_NONBLOCK);
 		if (ret) {
 			ret = -errno;
-			goto err1;
+			goto err2;
 		}
 		break;
 	case FI_WAIT_NONE:


### PR DESCRIPTION
This PR just fixes four defects identified by Coverity.  Two of the defects are somewhat serious in that they unintentionally clear any fd flags on the EQ and CQ file descriptors.

Fixes issue #637 as well as the coverity IDs referenced in the individual commit messages.