### PR TITLE
Check for shm_open without librt first

### DIFF
--- a/prov/sockets/configure.m4
+++ b/prov/sockets/configure.m4
@@ -15,7 +15,15 @@ AC_DEFUN([FI_SOCKETS_CONFIGURE],[
 	      [AC_CHECK_HEADER([sys/socket.h], [sockets_h_happy=1],
 	                       [sockets_h_happy=0])
 
-	       FI_CHECK_PACKAGE([sockets_shm],
+
+	       # check if shm_open is already present
+	       AC_CHECK_FUNC([shm_open],
+			     [sockets_shm_happy=1],
+			     [sockets_shm_happy=0])
+
+	       # look for shm_open in librt if not already present
+	       AS_IF([test $sockets_shm_happy -eq 0],
+		     [FI_CHECK_PACKAGE([sockets_shm],
 				[sys/mman.h],
 				[rt],
 				[shm_open],
@@ -23,7 +31,7 @@ AC_DEFUN([FI_SOCKETS_CONFIGURE],[
 				[],
 				[],
 				[sockets_shm_happy=1],
-				[sockets_shm_happy=0])
+				[sockets_shm_happy=0])])
 	      ])
 
 	AS_IF([test $sockets_h_happy -eq 1 && \


### PR DESCRIPTION
This fixes a build regression on Mac OS X due to the added check for
shm_open in librt.  Mac OS X does not have librt, so check for shm_open
in the already-loaded libraries first before looking for librt.

Fixes: github #647
Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>