### PR TITLE
mr: more general memory registration on fid

### DIFF
--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -216,14 +216,14 @@ static struct fi_ops_mr X = {
 	.regattr = fi_no_mr_regattr,
 };
 */
-int fi_no_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
+int fi_no_mr_reg(struct fid *fid, const void *buf, size_t len,
 		uint64_t access, uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr, void *context);
-int fi_no_mr_regv(struct fid_domain *domain, const struct iovec *iov,
+int fi_no_mr_regv(struct fid *fid, const struct iovec *iov,
 		size_t count, uint64_t access,
 		uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr, void *context);
-int fi_no_mr_regattr(struct fid_domain *domain, const struct fi_mr_attr *attr,
+int fi_no_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		uint64_t flags, struct fid_mr **mr);
 
 /*

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -140,14 +140,14 @@ struct fi_ops_domain {
 
 struct fi_ops_mr {
 	size_t	size;
-	int	(*reg)(struct fid_domain *domain, const void *buf, size_t len,
+	int	(*reg)(struct fid *fid, const void *buf, size_t len,
 			uint64_t access, uint64_t offset, uint64_t requested_key,
 			uint64_t flags, struct fid_mr **mr, void *context);
-	int	(*regv)(struct fid_domain *domain, const struct iovec *iov,
+	int	(*regv)(struct fid *fid, const struct iovec *iov,
 			size_t count, uint64_t access,
 			uint64_t offset, uint64_t requested_key,
 			uint64_t flags, struct fid_mr **mr, void *context);
-	int	(*regattr)(struct fid_domain *domain, const struct fi_mr_attr *attr,
+	int	(*regattr)(struct fid *fid, const struct fi_mr_attr *attr,
 			uint64_t flags, struct fid_mr **mr);
 };
 
@@ -209,7 +209,7 @@ fi_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
 	  uint64_t access, uint64_t offset, uint64_t requested_key,
 	  uint64_t flags, struct fid_mr **mr, void *context)
 {
-	return domain->mr->reg(domain, buf, len, access, offset,
+	return domain->mr->reg(&domain->fid, buf, len, access, offset,
 			       requested_key, flags, mr, context);
 }
 

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -261,13 +261,19 @@ static void psmx_mr_normalize_iov(struct iovec *iov, size_t *count)
 	*count = i;
 }
 
-static int psmx_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
+static int psmx_mr_reg(struct fid *fid, const void *buf, size_t len,
 			uint64_t access, uint64_t offset, uint64_t requested_key,
 			uint64_t flags, struct fid_mr **mr, void *context)
 {
+	struct fid_domain *domain;
 	struct psmx_fid_domain *domain_priv;
 	struct psmx_fid_mr *mr_priv;
 	uint64_t key;
+
+	if (fid->fclass != FI_CLASS_DOMAIN) {
+		return -FI_EINVAL;
+	}
+	domain = container_of(fid, struct fid_domain, fid);
 
 	domain_priv = container_of(domain, struct psmx_fid_domain, domain);
 	if (flags & FI_MR_KEY) {
@@ -311,15 +317,21 @@ static int psmx_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
 	return 0;
 }
 
-static int psmx_mr_regv(struct fid_domain *domain,
+static int psmx_mr_regv(struct fid *fid,
 			const struct iovec *iov, size_t count,
 			uint64_t access, uint64_t offset, uint64_t requested_key,
 			uint64_t flags, struct fid_mr **mr, void *context)
 {
+	struct fid_domain *domain;
 	struct psmx_fid_domain *domain_priv;
 	struct psmx_fid_mr *mr_priv;
 	int i;
 	uint64_t key;
+
+	if (fid->fclass != FI_CLASS_DOMAIN) {
+		return -FI_EINVAL;
+	}
+	domain = container_of(fid, struct fid_domain, fid);
 
 	domain_priv = container_of(domain, struct psmx_fid_domain, domain);
 	if (flags & FI_MR_KEY) {
@@ -369,13 +381,19 @@ static int psmx_mr_regv(struct fid_domain *domain,
 	return 0;
 }
 
-static int psmx_mr_regattr(struct fid_domain *domain, const struct fi_mr_attr *attr,
+static int psmx_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 			uint64_t flags, struct fid_mr **mr)
 {
+	struct fid_domain *domain;
 	struct psmx_fid_domain *domain_priv;
 	struct psmx_fid_mr *mr_priv;
 	int i;
 	uint64_t key;
+
+	if (fid->fclass != FI_CLASS_DOMAIN) {
+		return -FI_EINVAL;
+	}
+	domain = container_of(fid, struct fid_domain, fid);
 
 	domain_priv = container_of(domain, struct psmx_fid_domain, domain);
 	if (flags & FI_MR_KEY) {

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -241,13 +241,21 @@ struct sock_mr *sock_mr_verify_desc(struct sock_domain *domain, void *desc,
 	return sock_mr_verify_key(domain, key, buf, len, access);
 }
 
-static int sock_regattr(struct fid_domain *domain, const struct fi_mr_attr *attr,
+static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		uint64_t flags, struct fid_mr **mr)
 {
 	struct fi_eq_entry eq_entry;
 	struct sock_domain *dom;
 	struct sock_mr *_mr;
 	uint64_t key;
+	struct fid_domain *domain;
+
+	if (fid->fclass != FI_CLASS_DOMAIN) {
+		SOCK_LOG_ERROR("memory registration only supported "
+				"for struct fid_domain\n");
+		return -FI_EINVAL;
+	}
+	domain = container_of(fid, struct fid_domain, fid);
 
 	dom = container_of(domain, struct sock_domain, dom_fid);
 	if (!(dom->info.mode & FI_PROV_MR_ATTR) && 
@@ -300,7 +308,7 @@ err:
 	return -errno;
 }
 
-static int sock_regv(struct fid_domain *domain, const struct iovec *iov,
+static int sock_regv(struct fid *fid, const struct iovec *iov,
 		size_t count, uint64_t access,
 		uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr, void *context)
@@ -313,10 +321,10 @@ static int sock_regv(struct fid_domain *domain, const struct iovec *iov,
 	attr.offset = offset;
 	attr.requested_key = requested_key;
 	attr.context = context;
-	return sock_regattr(domain, &attr, flags, mr);
+	return sock_regattr(fid, &attr, flags, mr);
 }
 
-static int sock_reg(struct fid_domain *domain, const void *buf, size_t len,
+static int sock_reg(struct fid *fid, const void *buf, size_t len,
 		uint64_t access, uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr, void *context)
 {
@@ -324,7 +332,7 @@ static int sock_reg(struct fid_domain *domain, const void *buf, size_t len,
 
 	iov.iov_base = (void *) buf;
 	iov.iov_len = len;
-	return sock_regv(domain, &iov, 1, access,  offset, requested_key,
+	return sock_regv(fid, &iov, 1, access,  offset, requested_key,
 			 flags, mr, context);
 }
 

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -396,7 +396,7 @@ int usdf_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 
 
 /* fi_ops_mr */
-int usdf_reg_mr(struct fid_domain *domain, const void *buf, size_t len,
+int usdf_reg_mr(struct fid *fid, const void *buf, size_t len,
 	uint64_t access, uint64_t offset, uint64_t requested_key,
 	uint64_t flags, struct fid_mr **mr_o, void *context);
 

--- a/prov/usnic/src/usdf_mem.c
+++ b/prov/usnic/src/usdf_mem.c
@@ -80,17 +80,25 @@ static struct fi_ops usdf_mr_ops = {
 };
 
 int
-usdf_reg_mr(struct fid_domain *domain, const void *buf, size_t len,
+usdf_reg_mr(struct fid *fid, const void *buf, size_t len,
 	   uint64_t access, uint64_t offset, uint64_t requested_key,
 	   uint64_t flags, struct fid_mr **mr_o, void *context)
 {
 	struct usdf_mr *mr;
 	struct usdf_domain *udp;
 	int ret;
+	struct fid_domain *domain;
 
 	if (flags != 0) {
 		return -FI_EBADFLAGS;
 	}
+
+	if (fid->fclass != FI_CLASS_DOMAIN) {
+		USDF_DEBUG("memory registration only supported "
+				"for struct fid_domain\n");
+		return -FI_EINVAL;
+	}
+	domain = container_of(fid, struct fid_domain, fid);
 
 	mr = calloc(1, sizeof *mr);
 	if (mr == NULL) {

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -2506,15 +2506,21 @@ static struct fi_ops fi_ibv_mr_ops = {
 };
 
 static int
-fi_ibv_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
+fi_ibv_mr_reg(struct fid *fid, const void *buf, size_t len,
 	   uint64_t access, uint64_t offset, uint64_t requested_key,
 	   uint64_t flags, struct fid_mr **mr, void *context)
 {
 	struct fi_ibv_mem_desc *md;
 	int fi_ibv_access;
+	struct fid_domain *domain;
 
 	if (flags)
 		return -FI_EBADFLAGS;
+
+	if (fid->fclass != FI_CLASS_DOMAIN) {
+		return -FI_EINVAL;
+	}
+	domain = container_of(fid, struct fid_domain, fid);
 
 	md = calloc(1, sizeof *md);
 	if (!md)

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -248,20 +248,20 @@ int fi_no_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 /*
  * struct fi_ops_mr
  */
-int fi_no_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
+int fi_no_mr_reg(struct fid *fid, const void *buf, size_t len,
 		uint64_t access, uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr, void *context)
 {
 	return -FI_ENOSYS;
 }
-int fi_no_mr_regv(struct fid_domain *domain, const struct iovec *iov,
+int fi_no_mr_regv(struct fid *fid, const struct iovec *iov,
 		size_t count, uint64_t access,
 		uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr, void *context)
 {
 	return -FI_ENOSYS;
 }
-int fi_no_mr_regattr(struct fid_domain *domain, const struct fi_mr_attr *attr,
+int fi_no_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		uint64_t flags, struct fid_mr **mr)
 {
 	return -FI_ENOSYS;


### PR DESCRIPTION
Currently memory registration can only be called on a domain object.

This patch removes this restriction and makes memory registration
available for any FI object. For example, memory may be registered on a
fabric object, endpoint object and so on.  This will keep OFI more
generic and flexible.

The static inline for memory registration by the apps remains unchanged.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>