### PR TITLE
man/cm: Fix documentation of CM event entry

### DIFF
--- a/man/fi_cm.3.md
+++ b/man/fi_cm.3.md
@@ -117,14 +117,6 @@ Outbound data transfers cannot be initiated on a connection-oriented
 endpoint until an FI_CONNECTED event has been generated.  However, receive
 buffers may be associated with an endpoint anytime.
 
-For connection-oriented endpoints, the param buffer will be sent as
-part of the connection request or response, subject to the constraints of
-the underlying connection protocol.  Applications may use fi_control
-to determine the size of application data that may be exchanged as
-part of a connection request or response.  The fi_connect, fi_accept, and
-fi_reject calls will silently truncate any application data which cannot
-fit into underlying protocol messages.
-
 ## fi_shutdown
 
 The fi_shutdown call is used to gracefully disconnect an endpoint from
@@ -137,6 +129,10 @@ may still be retrieved from the corresponding event queues.
 
 An FI_SHUTDOWN event will be generated for an endpoint when the remote
 peer issues a disconnect using fi_shutdown or abruptly closes the endpoint.
+Note that in the abrupt close case, an FI_SHUTDOWN event will only be
+generated if the peer system is reachable and a service or kernel agent
+on the peer system is able to notify the local endpoint that the connection
+has been aborted.
 
 ## fi_getname / fi_getpeer
 
@@ -162,6 +158,16 @@ errno is returned. Fabric errno values are defined in
 
 # NOTES
 
+For connection-oriented endpoints, the param buffer will be sent as
+part of the connection request or response, subject to the constraints of
+the underlying connection protocol.  Applications may use fi_control
+to determine the size of application data that may be exchanged as
+part of a connection request or response.  The fi_connect, fi_accept, and
+fi_reject calls will silently truncate any application data which cannot
+fit into underlying protocol messages.  User data exchanged as part of
+the connection process is available as part of the fi_eq_cm_entry
+structure, for FI_CONNREQ and FI_CONNECTED events, or as additional
+err_data to fi_eq_err_entry, in the case of a rejected connection.
 
 # SEE ALSO
 


### PR DESCRIPTION
All CM events use the fi_eq_cm_entry structure to report
data.  This is necessary in order to report user data
associated with the FI_CONNECTED event.  The man pages
incorrectly refer to the fi_eq_entry structure.

This addresses issue #650.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>