### PR TITLE
fabric: Redefine fi_connreq_t to allow compiler type checking

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -48,6 +48,9 @@ extern "C" {
 	((type *) ((char *)ptr - offsetof(type, field)))
 #endif
 
+#define FI_DEFINE_HANDLE(name) struct name##_s { int dummy; }; \
+				typedef struct name##_s *name
+
 enum {
 	FI_MAJOR_VERSION	= 1,
 	FI_MINOR_VERSION	= 0,
@@ -158,7 +161,7 @@ enum {
 #define FI_ADDR_NOTAVAIL	UINT64_MAX
 #define FI_SHARED_CONTEXT	UINT64_MAX
 typedef uint64_t		fi_addr_t;
-typedef void *			fi_connreq_t;
+FI_DEFINE_HANDLE(fi_connreq_t);
 
 enum fi_progress {
 	FI_PROGRESS_UNSPEC,

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -1716,7 +1716,8 @@ static int
 fi_ibv_msg_ep_reject(struct fid_pep *pep, fi_connreq_t connreq,
 		  const void *param, size_t paramlen)
 {
-	return rdma_reject(connreq, param, (uint8_t) paramlen) ? -errno : 0;
+	return rdma_reject((struct rdma_cm_id *) connreq, param,
+			   (uint8_t) paramlen) ? -errno : 0;
 }
 
 static int fi_ibv_msg_ep_shutdown(struct fid_ep *ep, uint64_t flags)
@@ -1850,7 +1851,7 @@ fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 
 		fi_freeinfo(fi);
 	} else {
-		_ep->id = info->connreq;
+		_ep->id = (struct rdma_cm_id *) info->connreq;
 	}
 	_ep->id->context = &_ep->ep_fid.fid;
 
@@ -1911,7 +1912,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 
 	fi_ibv_fill_info_attr(event->id->verbs, NULL, fi);
 
-	fi->connreq = event->id;
+	fi->connreq = (fi_connreq_t) event->id;
 	return fi;
 err:
 	fi_freeinfo(fi);


### PR DESCRIPTION
Compilers cannot properly type check typedefs that reference
void *.  Redefine fi_connreq_t so that the compilers can.

Fixes #669.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>