### PR TITLE
prov/psm: various updates and bug fixes

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -219,6 +219,7 @@ struct psmx_multi_recv {
 struct psmx_fid_fabric {
 	struct fid_fabric	fabric;
 	struct psmx_fid_domain	*active_domain;
+	psm_uuid_t		uuid;
 };
 
 struct psmx_fid_domain {
@@ -227,8 +228,6 @@ struct psmx_fid_domain {
 	psm_ep_t		psm_ep;
 	psm_epid_t		psm_epid;
 	psm_mq_t		psm_mq;
-	pthread_t		ns_thread;
-	int			ns_port;
 	struct psmx_fid_ep	*tagged_ep;
 	struct psmx_fid_ep	*msg_ep;
 	struct psmx_fid_ep	*rma_ep;

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -80,6 +80,8 @@ enum psmx_context_type {
 	PSMX_SEND_CONTEXT,
 	PSMX_RECV_CONTEXT,
 	PSMX_MULTI_RECV_CONTEXT,
+	PSMX_TSEND_CONTEXT,
+	PSMX_TRECV_CONTEXT,
 	PSMX_WRITE_CONTEXT,
 	PSMX_READ_CONTEXT,
 	PSMX_INJECT_CONTEXT,
@@ -183,6 +185,7 @@ struct psmx_am_request {
 			void 	*result;
 		} atomic;
 	};
+	uint64_t cq_flags;
 	struct fi_context fi_context;
 	struct psmx_fid_ep *ep;
 	int state;

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -381,6 +381,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	struct psmx_fid_mr *mr;
 	struct psmx_fid_ep *target_ep;
 	void *tmp_buf;
+	uint64_t cq_flags;
 
 	switch (args[0].u32w0 & PSMX_AM_OP_MASK) {
 	case PSMX_AM_REQ_ATOMIC_WRITE:
@@ -404,7 +405,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 						mr->cq,
 						0, /* context */
 						addr,
-						0, /* flags */
+						FI_REMOTE_WRITE | FI_ATOMIC,
 						len,
 						0, /* data */
 						0, /* tag */
@@ -438,9 +439,12 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		key = args[3].u64;
 		datatype = args[4].u32w0;
 		op = args[4].u32w1;
+		cq_flags = FI_REMOTE_WRITE | FI_ATOMIC;
 
-		if (op == FI_ATOMIC_READ)
+		if (op == FI_ATOMIC_READ) {
 			len = fi_datatype_size(datatype) * count;
+			cq_flags = FI_REMOTE_READ | FI_ATOMIC;
+		}
 
 		assert(len == fi_datatype_size(datatype) * count);
 
@@ -463,7 +467,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 							mr->cq,
 							0, /* context */
 							addr,
-							0, /* flags */
+							cq_flags,
 							len,
 							0, /* data */
 							0, /* tag */
@@ -535,7 +539,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 						mr->cq,
 						0, /* context */
 						addr,
-						0, /* flags */
+						FI_REMOTE_WRITE | FI_ATOMIC,
 						len,
 						0, /* data */
 						0, /* tag */
@@ -578,7 +582,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 					req->ep->send_cq,
 					req->atomic.context,
 					req->atomic.buf,
-					0, /* flags */
+					req->cq_flags,
 					req->atomic.len,
 					0, /* data */
 					0, /* tag */
@@ -610,7 +614,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 					req->ep->send_cq,
 					req->atomic.context,
 					req->atomic.buf,
-					0, /* flags */
+					req->cq_flags,
 					req->atomic.len,
 					0, /* data */
 					0, /* tag */
@@ -653,6 +657,7 @@ static int psmx_atomic_self(int am_cmd,
 	int err = 0;
 	int op_error;
 	int access;
+	uint64_t cq_flags = 0;
 
 	if (am_cmd == PSMX_AM_REQ_ATOMIC_WRITE)
 		access = FI_REMOTE_WRITE;
@@ -672,18 +677,24 @@ static int psmx_atomic_self(int am_cmd,
 	case PSMX_AM_REQ_ATOMIC_WRITE:
 		err = psmx_atomic_do_write((void *)addr, (void *)buf,
 					   (int)datatype, (int)op, (int)count);
+		cq_flags = FI_WRITE | FI_ATOMIC;
 		break;
 
 	case PSMX_AM_REQ_ATOMIC_READWRITE:
 		err = psmx_atomic_do_readwrite((void *)addr, (void *)buf,
 					       (void *)result, (int)datatype,
 					       (int)op, (int)count);
+		if (op == FI_ATOMIC_READ)
+			cq_flags = FI_READ | FI_ATOMIC;
+		else
+			cq_flags = FI_WRITE | FI_ATOMIC;
 		break;
 
 	case PSMX_AM_REQ_ATOMIC_COMPWRITE:
 		err = psmx_atomic_do_compwrite((void *)addr, (void *)buf,
 					       (void *)compare, (void *)result,
 					       (int)datatype, (int)op, (int)count);
+		cq_flags = FI_WRITE | FI_ATOMIC;
 		break;
 	}
 
@@ -693,7 +704,7 @@ static int psmx_atomic_self(int am_cmd,
 					mr->cq,
 					0, /* context */
 					(void *)addr,
-					0, /* flags */
+					FI_REMOTE_WRITE | FI_ATOMIC,
 					len,
 					0, /* data */
 					0, /* tag */
@@ -735,7 +746,7 @@ gen_local_event:
 				ep->send_cq,
 				context,
 				(void *)buf,
-				0, /* flags */
+				cq_flags,
 				len,
 				0, /* data */
 				0, /* tag */
@@ -867,6 +878,7 @@ ssize_t _psmx_atomic_write(struct fid_ep *ep,
 	req->atomic.key = key;
 	req->atomic.context = context;
 	req->ep = ep_priv;
+	req->cq_flags = FI_WRITE | FI_ATOMIC;
 
 	args[0].u32w0 = PSMX_AM_REQ_ATOMIC_WRITE;
 	args[0].u32w1 = count;
@@ -1054,6 +1066,10 @@ ssize_t _psmx_atomic_readwrite(struct fid_ep *ep,
 	req->atomic.context = context;
 	req->atomic.result = result;
 	req->ep = ep_priv;
+	if (op == FI_ATOMIC_READ)
+		req->cq_flags = FI_READ | FI_ATOMIC;
+	else
+		req->cq_flags = FI_WRITE | FI_ATOMIC;
 
 	args[0].u32w0 = PSMX_AM_REQ_ATOMIC_READWRITE;
 	args[0].u32w1 = count;
@@ -1269,6 +1285,7 @@ ssize_t _psmx_atomic_compwrite(struct fid_ep *ep,
 	req->atomic.context = context;
 	req->atomic.result = result;
 	req->ep = ep_priv;
+	req->cq_flags = FI_WRITE | FI_ATOMIC;
 
 	args[0].u32w0 = PSMX_AM_REQ_ATOMIC_COMPWRITE;
 	args[0].u32w1 = count;

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -133,26 +133,62 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 	struct fi_context *fi_context = psm_status->context;
 	void *op_context, *buf;
 	int is_recv = 0;
+	uint64_t flags;
 
 	switch((int)PSMX_CTXT_TYPE(fi_context)) {
 	case PSMX_SEND_CONTEXT:
 		op_context = fi_context;
 		buf = PSMX_CTXT_USER(fi_context);
+		flags = FI_SEND | FI_MSG;
 		break;
 	case PSMX_RECV_CONTEXT:
 		op_context = fi_context;
 		buf = PSMX_CTXT_USER(fi_context);
+		flags = FI_RECV | FI_MSG;
 		is_recv = 1;
 		break;
 	case PSMX_MULTI_RECV_CONTEXT:
 		op_context = fi_context;
 		req = PSMX_CTXT_USER(fi_context);
 		buf = req->buf + req->offset;
+		flags = FI_RECV | FI_MSG;
 		is_recv = 1;
+		break;
+	case PSMX_TSEND_CONTEXT:
+		op_context = fi_context;
+		buf = PSMX_CTXT_USER(fi_context);
+		flags = FI_SEND | FI_TAGGED;
+		break;
+	case PSMX_TRECV_CONTEXT:
+		op_context = fi_context;
+		buf = PSMX_CTXT_USER(fi_context);
+		flags = FI_RECV | FI_TAGGED;
+		is_recv = 1;
+		break;
+	case PSMX_READ_CONTEXT:
+		op_context = PSMX_CTXT_USER(fi_context);
+		buf = NULL;
+		flags = FI_READ | FI_RMA;
+		break;
+	case PSMX_WRITE_CONTEXT:
+		op_context = PSMX_CTXT_USER(fi_context);
+		buf = NULL;
+		flags = FI_WRITE | FI_RMA;
+		break;
+	case PSMX_REMOTE_READ_CONTEXT:
+		op_context = PSMX_CTXT_USER(fi_context);
+		buf = NULL;
+		flags = FI_REMOTE_READ | FI_RMA;
+		break;
+	case PSMX_REMOTE_WRITE_CONTEXT:
+		op_context = PSMX_CTXT_USER(fi_context);
+		buf = NULL;
+		flags = FI_REMOTE_WRITE | FI_RMA;
 		break;
 	default:
 		op_context = PSMX_CTXT_USER(fi_context);
 		buf = NULL;
+		flags = 0;
 		break;
 	}
 
@@ -180,6 +216,7 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 
 	if (psm_status->error_code) {
 		event->cqe.err.op_context = op_context;
+		event->cqe.err.flags = flags;
 		event->cqe.err.err = -psmx_errno(psm_status->error_code);
 		event->cqe.err.prov_errno = psm_status->error_code;
 		event->cqe.err.tag = psm_status->msg_tag;
@@ -196,14 +233,14 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 
 	case FI_CQ_FORMAT_MSG:
 		event->cqe.msg.op_context = op_context;
-		event->cqe.msg.flags = 0;
+		event->cqe.msg.flags = flags;
 		event->cqe.msg.len = psm_status->nbytes;
 		break;
 
 	case FI_CQ_FORMAT_DATA:
 		event->cqe.data.op_context = op_context;
 		event->cqe.data.buf = buf;
-		event->cqe.data.flags = 0;
+		event->cqe.data.flags = flags;
 		event->cqe.data.len = psm_status->nbytes;
 		if (data)
 			event->cqe.data.data = data;
@@ -212,7 +249,7 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 	case FI_CQ_FORMAT_TAGGED:
 		event->cqe.tagged.op_context = op_context;
 		event->cqe.tagged.buf = buf;
-		event->cqe.tagged.flags = 0;
+		event->cqe.tagged.flags = flags;
 		event->cqe.tagged.len = psm_status->nbytes;
 		event->cqe.tagged.tag = psm_status->msg_tag;
 		if (data)
@@ -323,11 +360,13 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 				break;
 
 			case PSMX_SEND_CONTEXT:
+			case PSMX_TSEND_CONTEXT:
 				tmp_cq = tmp_ep->send_cq;
 				tmp_cntr = tmp_ep->send_cntr;
 				break;
 
 			case PSMX_RECV_CONTEXT:
+			case PSMX_TRECV_CONTEXT:
 				tmp_cq = tmp_ep->recv_cq;
 				tmp_cntr = tmp_ep->recv_cntr;
 				break;

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -41,11 +41,6 @@ static int psmx_domain_close(fid_t fid)
 
 	psmx_am_fini(domain);
 
-	if (domain->ns_thread) {
-		pthread_cancel(domain->ns_thread);
-		pthread_join(domain->ns_thread, NULL);
-	}
-
 #if 0
 	/* AM messages could arrive after MQ is finalized, causing segfault
 	 * when trying to dereference the MQ pointer. There is no mechanism
@@ -94,7 +89,6 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct psmx_fid_fabric *fabric_priv;
 	struct psmx_fid_domain *domain_priv;
 	struct psm_ep_open_opts opts;
-	psm_uuid_t uuid;
 	int err = -FI_ENOMEM;
 
 	PSMX_DEBUG("%s\n", __func__);
@@ -107,8 +101,6 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	if (!info->domain_attr->name || strncmp(info->domain_attr->name, "psm", 3))
 		return -FI_EINVAL;
-
-	psmx_query_mpi();
 
 	domain_priv = (struct psmx_fid_domain *) calloc(1, sizeof *domain_priv);
 	if (!domain_priv)
@@ -124,8 +116,7 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	psm_ep_open_opts_get_defaults(&opts);
 
-	psmx_get_uuid(uuid);
-	err = psm_ep_open(uuid, &opts,
+	err = psm_ep_open(fabric_priv->uuid, &opts,
 			  &domain_priv->psm_ep, &domain_priv->psm_epid);
 	if (err != PSM_OK) {
 		PSMX_WARN("%s: psm_ep_open returns %d, errno=%d\n",
@@ -143,21 +134,7 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err_out_close_ep;
 	}
 
-	domain_priv->ns_port = psmx_uuid_to_port(uuid);
-
-	if (psmx_env.name_server)
-		err = pthread_create(&domain_priv->ns_thread, NULL, psmx_name_server, (void *)domain_priv);
-	else
-		err = -1;
-
-	if (err)
-		domain_priv->ns_thread = 0;
-
 	if (psmx_domain_enable_ep(domain_priv, NULL) < 0) {
-		if (domain_priv->ns_thread) {
-			pthread_cancel(domain_priv->ns_thread);
-			pthread_join(domain_priv->ns_thread, NULL);
-		}
 		psm_mq_finalize(domain_priv->psm_mq);
 		goto err_out_close_ep;
 	}

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -308,6 +308,8 @@ static int psmx_fabric(struct fi_fabric_attr *attr,
 		       struct fid_fabric **fabric, void *context)
 {
 	struct psmx_fid_fabric *fabric_priv;
+	pthread_t thread;
+	pthread_attr_t thread_attr;
 
 	PSMX_DEBUG("%s\n", __func__);
 
@@ -322,6 +324,17 @@ static int psmx_fabric(struct fi_fabric_attr *attr,
 	fabric_priv->fabric.fid.context = context;
 	fabric_priv->fabric.fid.ops = &psmx_fabric_fi_ops;
 	fabric_priv->fabric.ops = &psmx_fabric_ops;
+
+	psmx_get_uuid(fabric_priv->uuid);
+
+	if (psmx_env.name_server) {
+		pthread_attr_init(&thread_attr);
+		pthread_attr_setdetachstate(&thread_attr,PTHREAD_CREATE_DETACHED);
+		pthread_create(&thread, &thread_attr, psmx_name_server, (void *)fabric_priv);
+	}
+
+	psmx_query_mpi();
+
 	*fabric = &fabric_priv->fabric;
 	return 0;
 }

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -221,7 +221,7 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 						req->ep->recv_cq,
 						req->recv.context,
 						req->recv.buf,
-						0, /* flags */
+						req->cq_flags,
 						req->recv.len_received,
 						0, /* data */
 						0, /* tag */
@@ -275,7 +275,7 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 						req->ep->send_cq,
 						req->send.context,
 						req->send.buf,
-						0, /* flags */
+						req->cq_flags,
 						req->send.len,
 						0, /* data */
 						0, /* tag */
@@ -391,6 +391,7 @@ static ssize_t _psmx_recv2(struct fid_ep *ep, void *buf, size_t len,
 	req->recv.context = context;
 	req->recv.src_addr = (void *)src_addr;
 	req->ep = ep_priv;
+	req->cq_flags = FI_RECV | FI_MSG;
 
 	if (ep_priv->recv_cq_event_flag && !(flags & FI_COMPLETION))
 		req->no_event = 1;
@@ -429,7 +430,7 @@ static ssize_t _psmx_recv2(struct fid_ep *ep, void *buf, size_t len,
 					req->ep->recv_cq,
 					req->recv.context,
 					req->recv.buf,
-					0, /* flags */
+					req->cq_flags,
 					req->recv.len_received,
 					0, /* data */
 					0, /* tag */
@@ -547,6 +548,7 @@ static ssize_t _psmx_send2(struct fid_ep *ep, const void *buf, size_t len,
 	req->send.len_sent = msg_size;
 	req->send.dest_addr = (void *)dest_addr;
 	req->ep = ep_priv;
+	req->cq_flags = FI_SEND | FI_MSG;
 
 	if ((ep_priv->send_cq_event_flag && !(flags & FI_COMPLETION)) ||
 	     (context == &ep_priv->sendimm_context))

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -110,7 +110,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 							mr->cq,
 							0, /* context */
 							rma_addr,
-							0, /* flags */
+							FI_REMOTE_WRITE | FI_RMA | (has_data ? FI_REMOTE_CQ_DATA : 0),
 							rma_len,
 							has_data ? args[4].u64 : 0,
 							0, /* tag */
@@ -256,7 +256,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 						req->ep->send_cq,
 						req->write.context,
 						req->write.buf,
-						0, /* flags */
+						req->cq_flags,
 						req->write.len,
 						0, /* data */
 						0, /* tag */
@@ -292,7 +292,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 						req->ep->send_cq,
 						req->read.context,
 						req->read.buf,
-						0, /* flags */
+						req->cq_flags,
 						req->read.len_read,
 						0, /* data */
 						0, /* tag */
@@ -331,13 +331,16 @@ static ssize_t psmx_rma_self(int am_cmd,
 	int op_error = 0;
 	int access;
 	void *dst, *src;
+	uint64_t cq_flags;
 
 	switch (am_cmd) {
 	case PSMX_AM_REQ_WRITE:
 		access = FI_REMOTE_WRITE;
+		cq_flags = FI_WRITE | FI_RMA;
 		break;
 	case PSMX_AM_REQ_READ:
 		access = FI_REMOTE_READ;
+		cq_flags = FI_READ | FI_RMA;
 		break;
 	default:
 		return -FI_EINVAL;
@@ -366,7 +369,7 @@ static ssize_t psmx_rma_self(int am_cmd,
 					mr->cq,
 					0, /* context */
 					(void *)addr,
-					0, /* flags */
+					FI_REMOTE_WRITE | FI_RMA | (flags & FI_REMOTE_CQ_DATA),
 					len,
 					flags & FI_REMOTE_CQ_DATA ? data : 0,
 					0, /* tag */
@@ -392,7 +395,7 @@ static ssize_t psmx_rma_self(int am_cmd,
 				ep->send_cq,
 				context,
 				(void *)buf,
-				0, /* flags */
+				cq_flags,
 				len,
 				0, /* data */
 				0, /* tag */
@@ -514,6 +517,7 @@ ssize_t _psmx_read(struct fid_ep *ep, void *buf, size_t len,
 	req->read.key = key; 	/* needed? */
 	req->read.context = context;
 	req->ep = ep_priv;
+	req->cq_flags = FI_READ | FI_RMA;
 	PSMX_CTXT_TYPE(&req->fi_context) = PSMX_READ_CONTEXT;
 	PSMX_CTXT_USER(&req->fi_context) = context;
 	PSMX_CTXT_EP(&req->fi_context) = ep_priv;
@@ -705,6 +709,7 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 	req->write.key = key; 	/* needed? */
 	req->write.context = context;
 	req->ep = ep_priv;
+	req->cq_flags = FI_WRITE | FI_RMA;
 	PSMX_CTXT_USER(&req->fi_context) = context;
 	PSMX_CTXT_EP(&req->fi_context) = ep_priv;
 

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -90,7 +90,7 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 
 		fi_context = context;
 		user_fi_context= 1;
-		PSMX_CTXT_TYPE(fi_context) = PSMX_RECV_CONTEXT;
+		PSMX_CTXT_TYPE(fi_context) = PSMX_TRECV_CONTEXT;
 		PSMX_CTXT_USER(fi_context) = buf;
 		PSMX_CTXT_EP(fi_context) = ep_priv;
 	}
@@ -125,7 +125,7 @@ ssize_t psmx_tagged_recv_no_flag_av_map(struct fid_ep *ep, void *buf,
 	psm_tagsel = (~ignore) | ep_priv->domain->reserved_tag_bits;
 
 	fi_context = context;
-	PSMX_CTXT_TYPE(fi_context) = PSMX_RECV_CONTEXT;
+	PSMX_CTXT_TYPE(fi_context) = PSMX_TRECV_CONTEXT;
 	PSMX_CTXT_USER(fi_context) = buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
@@ -157,7 +157,7 @@ ssize_t psmx_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf,
 	psm_tagsel = (~ignore) | ep_priv->domain->reserved_tag_bits;
 
 	fi_context = context;
-	PSMX_CTXT_TYPE(fi_context) = PSMX_RECV_CONTEXT;
+	PSMX_CTXT_TYPE(fi_context) = PSMX_TRECV_CONTEXT;
 	PSMX_CTXT_USER(fi_context) = buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
@@ -432,7 +432,7 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 		fi_context = context;
 		if (fi_context != &ep_priv->sendimm_context) {
 			user_fi_context = 1;
-			PSMX_CTXT_TYPE(fi_context) = PSMX_SEND_CONTEXT;
+			PSMX_CTXT_TYPE(fi_context) = PSMX_TSEND_CONTEXT;
 			PSMX_CTXT_USER(fi_context) = (void *)buf;
 			PSMX_CTXT_EP(fi_context) = ep_priv;
 		}
@@ -468,7 +468,7 @@ ssize_t psmx_tagged_send_no_flag_av_map(struct fid_ep *ep, const void *buf,
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
 
 	fi_context = context;
-	PSMX_CTXT_TYPE(fi_context) = PSMX_SEND_CONTEXT;
+	PSMX_CTXT_TYPE(fi_context) = PSMX_TSEND_CONTEXT;
 	PSMX_CTXT_USER(fi_context) = (void *)buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
@@ -507,7 +507,7 @@ ssize_t psmx_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
 
 	fi_context = context;
-	PSMX_CTXT_TYPE(fi_context) = PSMX_SEND_CONTEXT;
+	PSMX_CTXT_TYPE(fi_context) = PSMX_TSEND_CONTEXT;
 	PSMX_CTXT_USER(fi_context) = (void *)buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 

--- a/prov/psm/src/psmx_util.c
+++ b/prov/psm/src/psmx_util.c
@@ -147,7 +147,8 @@ void *psmx_name_server(void *args)
 			connfd = accept(listenfd, NULL, 0);
 			if (connfd >= 0) {
 				pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
-				write(connfd, &domain->psm_epid, sizeof(psm_epid_t));
+				if (write(connfd, &domain->psm_epid, sizeof(psm_epid_t)) != sizeof(psm_epid_t))
+					PSMX_WARN("%s: error sending address info to the client\n", __func__);
 				close(connfd);
 				pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 			}

--- a/prov/psm/src/psmx_wait.c
+++ b/prov/psm/src/psmx_wait.c
@@ -188,7 +188,8 @@ void psmx_wait_signal(struct fid_wait *wait)
 		break;
 
 	case FI_WAIT_FD:
-		write(wait_priv->fd[1], &c, 1);
+		if (write(wait_priv->fd[1], &c, 1) != 1)
+			PSMX_WARN("%s: error signaling wait object\n", __func__);
 		break;
 
 	case FI_WAIT_MUTEX_COND:


### PR DESCRIPTION
(1) check the return value of write() to suppress compiler warnings;
(2) tweak the name server implementation to avoid an memory management related error with SHMEM;
(3) report op type in completion data.