### PR TITLE
prov/psm: handle a corner case in fi_av_insert

### DIFF
--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -174,7 +174,7 @@ static int psmx_av_insert(struct fid_av *av, const void *addr, size_t count,
 		if (!mask[i])
 			continue;
 
-		if (errors[i] == PSM_OK) {
+		if (errors[i] == PSM_OK || errors[i] == PSM_EPID_ALREADY_CONNECTED) {
 			psmx_set_epaddr_context(av_priv->domain,
 						((psm_epid_t *) addr)[i],
 						((psm_epaddr_t *) fi_addr)[i]);


### PR DESCRIPTION
Although a mask is used to prevent making duplicated connection
requests to the same target, it has been observed that under
certain conditions psm_ep_connect may return the error code
PSM_EPID_ALREADY_CONNECTED instead of PSM_OK. This error code
needs to be treated the same way as PSM_OK.