### PR TITLE
fabric: Further define shutdown/close semantics

### DIFF
--- a/man/fi_cm.3.md
+++ b/man/fi_cm.3.md
@@ -121,9 +121,19 @@ buffers may be associated with an endpoint anytime.
 
 The fi_shutdown call is used to gracefully disconnect an endpoint from
 its peer.  The flags parameter is reserved and must be 0.
-Any queued completions associated with asynchronous operations
-may still be retrieved from the corresponding event queues after an
-endpoint has been shutdown.
+
+Outstanding operations posted to the endpoint when fi_shutdown is
+called will be canceled or discarded.  Notification of canceled operations
+will be reported by the provider to the corresponding completion
+queue(s).  Discarded operations will silently be dropped, with no
+completions generated.  The choice of canceling, versus discarding
+operations, is provider dependent.  However, all canceled completions
+will be written before fi_shutdown returns.
+
+When called, fi_shutdown does not affect completions already written to a
+completion queue.  Any queued completions associated with asynchronous
+operations posted to the endpoint may still be retrieved from the
+corresponding completion queue(s) after an endpoint has been shutdown.
 
 An FI_SHUTDOWN event will be generated for an endpoint when the remote
 peer issues a disconnect using fi_shutdown or abruptly closes the endpoint.

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -212,6 +212,12 @@ receive contexts associated with the scalable endpoint.  If resources are still
 associated with the scalable endpoint when attempting to close, the call will
 return -FI_EBUSY.
 
+Outstanding operations posted to the endpoint when fi_close is
+called will be discarded.  Discarded operations will silently be dropped,
+with no completions reported.  Additionally, a provider may discard previously
+completed operations from the associated completion queue(s).  The
+behavior to discard completed operations is provider specific.
+
 ## fi_ep_bind
 
 fi_ep_bind is used to associate an endpoint with hardware resources.


### PR DESCRIPTION
Document what happens to outstanding operations when an EP
is shut down or closed.

See issue #677

Signed-off-by: Sean Hefty <sean.hefty@intel.com>