### PR TITLE
Fix some minor assertion issues

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -35,7 +35,6 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <assert.h>
 #include <sys/socket.h>
 
 #ifdef __cplusplus

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -33,7 +33,6 @@
 #ifndef _FI_ATOMIC_H_
 #define _FI_ATOMIC_H_
 
-#include <assert.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>

--- a/include/rdma/fi_rma.h
+++ b/include/rdma/fi_rma.h
@@ -33,7 +33,6 @@
 #ifndef _FI_RMA_H_
 #define _FI_RMA_H_
 
-#include <assert.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_endpoint.h>
 

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -33,7 +33,6 @@
 #ifndef _FI_TAGGED_H_
 #define _FI_TAGGED_H_
 
-#include <assert.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_endpoint.h>
 

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -9,6 +9,7 @@ extern "C" {
 #include <config.h>
 #endif
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -34,6 +34,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -34,6 +34,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -34,6 +34,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -33,6 +33,7 @@
 #if HAVE_CONFIG_H
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -34,6 +34,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -354,7 +354,11 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 	}
 
 	if (hints && hints->src_addr) {
-		assert(hints->src_addrlen == sizeof(struct sockaddr_in));
+		if (hints->src_addrlen != sizeof(struct sockaddr_in)) {
+			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be sizeof(struct sockaddr_in); got %zu\n",
+					hints->src_addrlen);
+			return -FI_ENODATA;
+		}
 		memcpy(src_addr, hints->src_addr, hints->src_addrlen);
 	}
 
@@ -366,7 +370,11 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 		}
-		assert(hints->dest_addrlen == sizeof(struct sockaddr_in));
+		if (hints->dest_addrlen != sizeof(struct sockaddr_in)) {
+			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be sizeof(struct sockaddr_in); got %zu\n",
+					hints->dest_addrlen);
+			return -FI_ENODATA;
+		}
 		memcpy(dest_addr, hints->dest_addr, hints->dest_addrlen);
 	}
 

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -34,6 +34,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -34,6 +34,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -34,6 +34,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -34,6 +34,7 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>


### PR DESCRIPTION
This PR removes assertions on `fi_getinfo()` input from the sockets provider, and removes the inclusions of `assert.h` from public header files to avoid polluting the global namespace for applications, since none of the public header files themselves use assertions.  This required moving the `assert.h` inclusions into the providers that do use assertions.

@shantonu @jithinjosepkl @j-xiong: Please review the (minor) modifications to your respective providers.