### PR TITLE
fabric: Move ep_type from fi_info into ep_attr

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -250,6 +250,7 @@ struct fi_rx_attr {
 };
 
 struct fi_ep_attr {
+	enum fi_ep_type		type;
 	uint32_t		protocol;
 	uint32_t		protocol_version;
 	size_t			max_msg_size;
@@ -292,7 +293,6 @@ struct fi_info {
 	struct fi_info		*next;
 	uint64_t		caps;
 	uint64_t		mode;
-	enum fi_ep_type		ep_type;
 	uint32_t		addr_format;
 	size_t			src_addrlen;
 	size_t			dest_addrlen;

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -436,20 +436,45 @@ an endpoint.
 
 {% highlight c %}
 struct fi_ep_attr {
-	uint32_t  protocol;
-	uint32_t  protocol_version;
-	size_t    max_msg_size;
-	size_t    msg_prefix_size;
-	size_t    max_order_raw_size;
-	size_t    max_order_war_size;
-	size_t    max_order_waw_size;
-	uint64_t  mem_tag_format;
-	uint64_t  msg_order;
-	uint64_t  comp_order;
-	size_t    tx_ctx_cnt;
-	size_t    rx_ctx_cnt;
+	enum fi_ep_type ep_type;
+	uint32_t        protocol;
+	uint32_t        protocol_version;
+	size_t          max_msg_size;
+	size_t          msg_prefix_size;
+	size_t          max_order_raw_size;
+	size_t          max_order_war_size;
+	size_t          max_order_waw_size;
+	uint64_t        mem_tag_format;
+	uint64_t        msg_order;
+	uint64_t        comp_order;
+	size_t          tx_ctx_cnt;
+	size_t          rx_ctx_cnt;
 };
 {% endhighlight %}
+
+## type - Endpoint Type
+  If specified, indicates the type of fabric interface communication
+  desired.  Supported types are:
+
+*FI_EP_UNSPEC*
+: The type of endpoint is not specified.  This is usually provided as
+  input, with other attributes of the endpoint or the provider
+  selecting the type.
+
+*FI_EP_MSG*
+: Provides a reliable, connection-oriented data transfer service with
+  flow control that maintains message boundaries.
+
+*FI_EP_DGRAM*
+: Supports a connectionless, unreliable datagram communication.
+  Message boundaries are maintained, but the maximum message size may
+  be limited to the fabric MTU.  Flow control is not guaranteed.
+
+*FI_EP_RDM*
+: Reliable datagram message.  Provides a reliable, unconnected data
+  transfer service with flow control that maintains message
+  boundaries.
+
 
 ## Protocol
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -107,7 +107,6 @@ struct fi_info {
 	struct fi_info        *next;
 	uint64_t              caps;
 	uint64_t              mode;
-	enum fi_ep_type       ep_type;
 	uint32_t              addr_format;
 	size_t                src_addrlen;
 	size_t                dest_addrlen;
@@ -133,11 +132,6 @@ struct fi_info {
 
 *mode*
 : Operational modes supported by the application.  See the _Mode_
-  section below.
-
-*ep_type - endpoint type*
-: If specified, indicates the type of fabric interface communication
-  desired.  Supported types are listed in the _Endpoint types_
   section below.
 
 *addr_format - address format*
@@ -463,27 +457,6 @@ below.
   must provide the buffering needed for the IO vectors.  When set,
   an application must not modify an IO vector until the associated
   operation has completed.
-
-# ENDPOINT TYPES
-
-*FI_EP_UNSPEC*
-: The type of endpoint is not specified.  This is usually provided as
-  input, with other attributes of the endpoint or the provider
-  selecting the type.
-
-*FI_EP_MSG*
-: Provides a reliable, connection-oriented data transfer service with
-  flow control that maintains message boundaries.
-
-*FI_EP_DGRAM*
-: Supports a connectionless, unreliable datagram communication.
-  Message boundaries are maintained, but the maximum message size may
-  be limited to the fabric MTU.  Flow control is not guaranteed.
-
-*FI_EP_RDM*
-: Reliable datagram message.  Provides a reliable, unconnected data
-  transfer service with flow control that maintains message
-  boundaries.
 
 # ADDRESSING FORMATS
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -118,18 +118,18 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 		dest_addr = psmx_resolve_name(node, 0);
 
 	if (hints) {
-		switch (hints->ep_type) {
-		case FI_EP_UNSPEC:
-		case FI_EP_RDM:
-			break;
-		default:
-			PSMX_DEBUG("hints->ep_type=%d, supported=%d,%d.\n",
-					hints->ep_type, FI_EP_UNSPEC,
-					FI_EP_RDM);
-			goto err_out;
-		}
-
 		if (hints->ep_attr) {
+			switch (hints->ep_attr->type) {
+			case FI_EP_UNSPEC:
+			case FI_EP_RDM:
+				break;
+			default:
+				PSMX_DEBUG("hints->ep_attr->type=%d, supported=%d,%d.\n",
+						hints->ep_attr->type, FI_EP_UNSPEC,
+						FI_EP_RDM);
+				goto err_out;
+			}
+
 			switch (hints->ep_attr->protocol) {
 			case FI_PROTO_UNSPEC:
 			case FI_PROTO_PSMX:
@@ -232,6 +232,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 		goto err_out;
 	}
 
+	psmx_info->ep_attr->type = ep_type;
 	psmx_info->ep_attr->protocol = FI_PROTO_PSMX;
 	psmx_info->ep_attr->max_msg_size = PSMX_MAX_MSG_SIZE;
 	psmx_info->ep_attr->mem_tag_format = fi_tag_format(max_tag_value);
@@ -246,7 +247,6 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	psmx_info->domain_attr->name = strdup("psm");
 
 	psmx_info->next = NULL;
-	psmx_info->ep_type = ep_type;
 	psmx_info->caps = (hints && hints->caps) ? hints->caps : caps;
 	psmx_info->mode = PSMX_MODE;
 	psmx_info->addr_format = FI_ADDR_PSMX;

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -363,7 +363,7 @@ int sock_dom_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 int sock_endpoint(struct fid_domain *domain, struct fi_info *info,
 			 struct fid_ep **ep, void *context)
 {
-	switch (info->ep_type) {
+	switch (info->ep_attr->type) {
 	case FI_EP_RDM:
 		return sock_rdm_ep(domain, info, ep, context);
 	case FI_EP_DGRAM:
@@ -378,7 +378,7 @@ int sock_endpoint(struct fid_domain *domain, struct fi_info *info,
 int sock_scalable_ep(struct fid_domain *domain, struct fi_info *info,
 		     struct fid_ep **sep, void *context)
 {
-	switch (info->ep_type) {
+	switch (info->ep_attr->type) {
 	case FI_EP_RDM:
 		return sock_rdm_sep(domain, info, sep, context);
 	case FI_EP_DGRAM:

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1131,7 +1131,6 @@ struct fi_info *sock_fi_info(enum fi_ep_type ep_type,
 	_info->src_addr = calloc(1, sizeof(struct sockaddr_in));
 	_info->dest_addr = calloc(1, sizeof(struct sockaddr_in));
 	
-	_info->ep_type = ep_type;
 	_info->mode = SOCK_MODE;
 	_info->addr_format = FI_SOCKADDR_IN;
 	_info->dest_addrlen =_info->src_addrlen = sizeof(struct sockaddr_in);
@@ -1158,6 +1157,7 @@ struct fi_info *sock_fi_info(enum fi_ep_type ep_type,
 			*(_info->rx_attr) = *(hints->rx_attr);
 	}
 
+	_info->ep_attr->type = ep_type;
 	*(_info->domain_attr) = sock_domain_attr;
 	*(_info->fabric_attr) = sock_fabric_attr;
 
@@ -1225,7 +1225,7 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 	fastlock_release(&sock_dom->lock);
 
 	if (info) {
-		sock_ep->ep_type = info->ep_type;
+		sock_ep->ep_type = info->ep_attr->type;
 		sock_ep->info.caps = info->caps;
 		sock_ep->info.addr_format = FI_SOCKADDR_IN;
 		

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -56,6 +56,7 @@
 #include "sock.h"
 
 const struct fi_ep_attr sock_dgram_ep_attr = {
+	.type = FI_EP_DGRAM,
 	.protocol = FI_PROTO_SOCK_TCP,
 	.max_msg_size = SOCK_EP_MAX_MSG_SZ,
 	.max_order_raw_size = SOCK_EP_MAX_ORDER_RAW_SZ,

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -57,6 +57,7 @@
 #include "sock_util.h"
 
 const struct fi_ep_attr sock_msg_ep_attr = {
+	.type = FI_EP_MSG,
 	.protocol = FI_PROTO_SOCK_TCP,
 	.max_msg_size = SOCK_EP_MAX_MSG_SZ,
 	.max_order_raw_size = SOCK_EP_MAX_ORDER_RAW_SZ,
@@ -760,8 +761,7 @@ static int sock_ep_cm_connect(struct fid_ep *ep, const void *addr,
 	if (!_eq || paramlen > SOCK_EP_MAX_CM_DATA_SZ) 
 		return -FI_EINVAL;
 
-	req = (struct sock_conn_req*)calloc(1, 
-					    sizeof(*req) + paramlen);
+	req = (struct sock_conn_req*)calloc(1, sizeof(*req) + paramlen);
 	if (!req)
 		return -FI_ENOMEM;
 
@@ -775,14 +775,14 @@ static int sock_ep_cm_connect(struct fid_ep *ep, const void *addr,
 	req->ep_id = _ep->ep_id;
 	req->hdr.c_fid = &ep->fid;
 	req->hdr.s_fid = 0;
-	memcpy(&req->info, &_ep->info, sizeof(struct fi_info));
+	req->info = _ep->info;
 	memcpy(&req->src_addr, _ep->src_addr, sizeof(struct sockaddr_in));
 	memcpy(&req->dest_addr, _ep->info.dest_addr, sizeof(struct sockaddr_in));
-	memcpy(&req->tx_attr, _ep->info.tx_attr, sizeof(struct fi_tx_attr));
-	memcpy(&req->rx_attr, _ep->info.rx_attr, sizeof(struct fi_rx_attr));
-	memcpy(&req->ep_attr, _ep->info.ep_attr, sizeof(struct fi_ep_attr));
-	memcpy(&req->domain_attr, _ep->info.domain_attr, sizeof(struct fi_domain_attr));
-	memcpy(&req->fabric_attr, _ep->info.fabric_attr, sizeof(struct fi_fabric_attr));
+	req->tx_attr = *_ep->info.tx_attr;
+	req->rx_attr = *_ep->info.rx_attr;
+	req->ep_attr = *_ep->info.ep_attr;
+	req->domain_attr = *_ep->info.domain_attr;
+	req->fabric_attr = *_ep->info.fabric_attr;
 	if (param && paramlen)
 		memcpy(&req->user_data, param, paramlen);
 	

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -57,6 +57,7 @@
 #include "sock_util.h"
 
 const struct fi_ep_attr sock_rdm_ep_attr = {
+	.type = FI_EP_RDM,
 	.protocol = FI_PROTO_SOCK_TCP,
 	.max_msg_size = SOCK_EP_MAX_MSG_SZ,
 	.max_order_raw_size = SOCK_EP_MAX_ORDER_RAW_SZ,

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -75,11 +75,14 @@ int sock_verify_fabric_attr(struct fi_fabric_attr *attr)
 
 int sock_verify_info(struct fi_info *hints)
 {
+	enum fi_ep_type ep_type;
 	int ret;
+
 	if (!hints)
 		return 0;
 
-	switch (hints->ep_type) {
+	ep_type = hints->ep_attr ? hints->ep_attr->type : FI_EP_UNSPEC;
+	switch (ep_type) {
 	case FI_EP_UNSPEC:
 	case FI_EP_MSG:
 		ret = sock_msg_verify_ep_attr(hints->ep_attr,
@@ -182,8 +185,8 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 	if (ret) 
 		return ret;
 	
-	if (hints) {
-		switch (hints->ep_type) {
+	if (hints && hints->ep_attr) {
+		switch (hints->ep_attr->type) {
 		case FI_EP_RDM:
 			return sock_rdm_getinfo(version, node, service, flags,
 						hints, info);

--- a/prov/usnic/src/usdf_endpoint.c
+++ b/prov/usnic/src/usdf_endpoint.c
@@ -87,7 +87,7 @@ int
 usdf_endpoint_open(struct fid_domain *domain, struct fi_info *info,
 	    struct fid_ep **ep_o, void *context)
 {
-	switch (info->ep_type) {
+	switch (info->ep_attr->type) {
 	case FI_EP_DGRAM:
 		return usdf_ep_dgram_open(domain, info, ep_o, context);
 	case FI_EP_MSG:

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -228,7 +228,7 @@ usdf_fill_info_dgram(
 		fi->mode = USDF_DGRAM_SUPP_MODE;
 		addr_format = FI_FORMAT_UNSPEC;
 	}
-	fi->ep_type = FI_EP_DGRAM;
+	fi->ep_attr->type = FI_EP_DGRAM;
 
 	ret = usdf_fill_addr_info(fi, addr_format, src, dest, dap);
 	if (ret != 0) {
@@ -392,7 +392,7 @@ usdf_fill_info_msg(
 		fi->mode = USDF_MSG_SUPP_MODE;
 		addr_format = FI_FORMAT_UNSPEC;
 	}
-	fi->ep_type = FI_EP_MSG;
+	fi->ep_attr->type = FI_EP_MSG;
 
 
 	ret = usdf_fill_addr_info(fi, addr_format, src, dest, dap);
@@ -496,7 +496,7 @@ usdf_fill_info_rdm(
 		fi->mode = USDF_RDM_SUPP_MODE;
 		addr_format = FI_FORMAT_UNSPEC;
 	}
-	fi->ep_type = FI_EP_RDM;
+	fi->ep_attr->type = FI_EP_RDM;
 
 	ret = usdf_fill_addr_info(fi, addr_format, src, dest, dap);
 	if (ret != 0) {
@@ -712,7 +712,8 @@ usdf_getinfo(uint32_t version, const char *node, const char *service,
 				continue;
 			}
 
-			ep_type = hints->ep_type;
+			ep_type = hints->ep_attr ? hints->ep_attr->type :
+				  FI_EP_UNSPEC;
 		} else {
 			ep_type = FI_EP_UNSPEC;
 		}

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -122,7 +122,7 @@ usdf_pep_conn_info(struct usdf_connreq *crp)
 
 		ip->caps = USDF_MSG_CAPS;
 		ip->mode = USDF_MSG_SUPP_MODE;
-		ip->ep_type = FI_EP_MSG;
+		ip->ep_attr->type = FI_EP_MSG;
 
 		ip->addr_format = FI_SOCKADDR_IN;
 		ip->src_addrlen = sizeof(struct sockaddr_in);
@@ -451,7 +451,7 @@ usdf_pep_open(struct fid_fabric *fabric, struct fi_info *info,
 	int ret;
 	int optval;
 
-	if (info->ep_type != FI_EP_MSG) {
+	if (info->ep_attr->type != FI_EP_MSG) {
 		return -FI_ENODEV;
 	}
 

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -325,6 +325,9 @@ static void fi_tostr_ep_attr(char *buf, const struct fi_ep_attr *attr, const cha
 	}
 
 	strcatf(buf, "%sfi_ep_attr:\n", prefix);
+	strcatf(buf, "%sep_type: ", TAB);
+	fi_tostr_ep_type(buf, attr->type);
+	strcatf(buf, "\n");
 	strcatf(buf, "%s%sprotocol: ", prefix, TAB);
 	fi_tostr_protocol(buf, attr->protocol);
 	strcatf(buf, "\n");
@@ -398,9 +401,6 @@ static void fi_tostr_info(char *buf, const struct fi_info *info)
 	fi_tostr_mode(buf, info->mode);
 	strcatf(buf, " ]\n");
 
-	strcatf(buf, "%sep_type: ", TAB);
-	fi_tostr_ep_type(buf, info->ep_type);
-	strcatf(buf, "\n");
 	strcatf(buf, "%sfi_addr_format: ", TAB);
 	fi_tostr_addr_format(buf, info->addr_format);
 	strcatf(buf, "\n");


### PR DESCRIPTION
Conceptually, this is a simple change, but the impact is significant.  Please review the provider code to see that what was changed is correct and that nothing was missed!

@goodell @jithinjosepkl  @j-xiong @shantonu @a-ilango 