### PR TITLE
Resource leak fix and assert removal for ep_rdm and ep_dgram

### DIFF
--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -33,7 +33,6 @@
 #if HAVE_CONFIG_H
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
-#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -255,7 +254,7 @@ int sock_dgram_getinfo(uint32_t version, const char *node, const char *service,
 		ret = getaddrinfo(node ? node : hostname, service, 
 				  &sock_hints, &result_ptr);
 		if (ret != 0) {
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			SOCK_LOG_INFO("getaddrinfo failed!\n");
 			goto err;
 		}
@@ -286,7 +285,7 @@ int sock_dgram_getinfo(uint32_t version, const char *node, const char *service,
 
 		ret = getaddrinfo(node, service, &sock_hints, &result_ptr);
 		if (ret != 0) {
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			SOCK_LOG_INFO("getaddrinfo failed!\n");
 			goto err;
 		}
@@ -322,7 +321,7 @@ int sock_dgram_getinfo(uint32_t version, const char *node, const char *service,
 			      result->ai_addrlen);
 		if ( ret != 0) {
 			SOCK_LOG_ERROR("Failed to create udp socket\n");
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			goto err;
 		}
 
@@ -335,7 +334,7 @@ int sock_dgram_getinfo(uint32_t version, const char *node, const char *service,
 		ret = getsockname(udp_sock, (struct sockaddr*)src_addr, &len);
 		if (ret != 0) {
 			SOCK_LOG_ERROR("getsockname failed\n");
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			goto err;
 		}
 		close(udp_sock);
@@ -345,7 +344,13 @@ int sock_dgram_getinfo(uint32_t version, const char *node, const char *service,
 	}
 
 	if (hints && hints->src_addr) {
-		assert(hints->src_addrlen == sizeof(struct sockaddr_in));
+		if((hints->src_addrlen != 0) && 
+				(hints->src_addrlen != sizeof(struct sockaddr_in))){
+			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n", 
+					hints->src_addrlen);
+			ret = -FI_ENODATA;
+			goto err;
+		}
 		memcpy(src_addr, hints->src_addr, hints->src_addrlen);
 	}
 
@@ -357,7 +362,13 @@ int sock_dgram_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 		}
-		assert(hints->dest_addrlen == sizeof(struct sockaddr_in));
+		if((hints->dest_addrlen != 0) && 
+				(hints->dest_addrlen != sizeof(struct sockaddr_in))){
+			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n", 
+					hints->dest_addrlen);
+			ret = -FI_ENODATA;
+			goto err;
+		}
 		memcpy(dest_addr, hints->dest_addr, hints->dest_addrlen);
 	}
 
@@ -375,7 +386,7 @@ int sock_dgram_getinfo(uint32_t version, const char *node, const char *service,
 
 	_info = sock_dgram_fi_info(hints, src_addr, dest_addr);
 	if (!_info) {
-		ret = FI_ENOMEM;
+		ret = -FI_ENOMEM;
 		goto err;
 	}
 

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -344,9 +344,8 @@ int sock_dgram_getinfo(uint32_t version, const char *node, const char *service,
 	}
 
 	if (hints && hints->src_addr) {
-		if((hints->src_addrlen != 0) && 
-				(hints->src_addrlen != sizeof(struct sockaddr_in))){
-			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n", 
+		if(hints->src_addrlen != sizeof(struct sockaddr_in)){
+			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be sizeof(struct sockaddr_in); got %zu\n", 
 					hints->src_addrlen);
 			ret = -FI_ENODATA;
 			goto err;
@@ -362,9 +361,8 @@ int sock_dgram_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 		}
-		if((hints->dest_addrlen != 0) && 
-				(hints->dest_addrlen != sizeof(struct sockaddr_in))){
-			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n", 
+		if(hints->dest_addrlen != sizeof(struct sockaddr_in)){
+			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be sizeof(struct sockaddr_in); got %zu\n", 
 					hints->dest_addrlen);
 			ret = -FI_ENODATA;
 			goto err;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -346,8 +346,9 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 	}
 
 	if (hints && hints->src_addr) {
-		if (hints->src_addrlen != sizeof(struct sockaddr_in)) {
-			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be sizeof(struct sockaddr_in); got %zu\n",
+		if ((hints->src_addrlen != 0) && 
+				(hints->src_addrlen != sizeof(struct sockaddr_in))) {
+			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n",
 					hints->src_addrlen);
 			ret = -FI_ENODATA;
 			goto err;
@@ -363,8 +364,9 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 		}
-		if (hints->dest_addrlen != sizeof(struct sockaddr_in)) {
-			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be sizeof(struct sockaddr_in); got %zu\n",
+		if ((hints->dest_addrlen != 0) && 
+				(hints->dest_addrlen != sizeof(struct sockaddr_in))) {
+			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n",
 					hints->dest_addrlen);
 			ret = -FI_ENODATA;
 			goto err;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -256,7 +256,7 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 		ret = getaddrinfo(node ? node : hostname, service, 
 				  &sock_hints, &result_ptr);
 		if (ret != 0) {
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			SOCK_LOG_INFO("getaddrinfo failed!\n");
 			goto err;
 		}
@@ -287,7 +287,7 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 
 		ret = getaddrinfo(node, service, &sock_hints, &result_ptr);
 		if (ret != 0) {
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			SOCK_LOG_INFO("getaddrinfo failed!\n");
 			goto err;
 		}
@@ -323,7 +323,7 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 			      result->ai_addrlen);
 		if ( ret != 0) {
 			SOCK_LOG_ERROR("Failed to create udp socket\n");
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			goto err;
 		}
 
@@ -336,7 +336,7 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 		ret = getsockname(udp_sock, (struct sockaddr*)src_addr, &len);
 		if (ret != 0) {
 			SOCK_LOG_ERROR("getsockname failed\n");
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			goto err;
 		}
 		close(udp_sock);
@@ -349,7 +349,8 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 		if (hints->src_addrlen != sizeof(struct sockaddr_in)) {
 			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be sizeof(struct sockaddr_in); got %zu\n",
 					hints->src_addrlen);
-			return -FI_ENODATA;
+			ret = -FI_ENODATA;
+			goto err;
 		}
 		memcpy(src_addr, hints->src_addr, hints->src_addrlen);
 	}
@@ -365,7 +366,8 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 		if (hints->dest_addrlen != sizeof(struct sockaddr_in)) {
 			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be sizeof(struct sockaddr_in); got %zu\n",
 					hints->dest_addrlen);
-			return -FI_ENODATA;
+			ret = -FI_ENODATA;
+			goto err;
 		}
 		memcpy(dest_addr, hints->dest_addr, hints->dest_addrlen);
 	}
@@ -384,7 +386,7 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 
 	_info = sock_msg_fi_info(hints, src_addr, dest_addr);
 	if (!_info) {
-		ret = FI_ENOMEM;
+		ret = -FI_ENOMEM;
 		goto err;
 	}
 

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -346,9 +346,8 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 	}
 
 	if (hints && hints->src_addr) {
-		if ((hints->src_addrlen != 0) && 
-				(hints->src_addrlen != sizeof(struct sockaddr_in))) {
-			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n",
+		if (hints->src_addrlen != sizeof(struct sockaddr_in)) {
+			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be sizeof(struct sockaddr_in); got %zu\n",
 					hints->src_addrlen);
 			ret = -FI_ENODATA;
 			goto err;
@@ -364,9 +363,8 @@ int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 		}
-		if ((hints->dest_addrlen != 0) && 
-				(hints->dest_addrlen != sizeof(struct sockaddr_in))) {
-			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n",
+		if (hints->dest_addrlen != sizeof(struct sockaddr_in)) {
+			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be sizeof(struct sockaddr_in); got %zu\n",
 					hints->dest_addrlen);
 			ret = -FI_ENODATA;
 			goto err;

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -389,9 +389,8 @@ int sock_rdm_getinfo(uint32_t version, const char *node, const char *service,
 	}
 
 	if (hints && hints->src_addr) {
-		if((hints->src_addrlen != 0) && 
-				(hints->src_addrlen != sizeof(struct sockaddr_in))){
-			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n", 
+		if(hints->src_addrlen != sizeof(struct sockaddr_in)){
+			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be sizeof(struct sockaddr_in); got %zu\n", 
 					hints->src_addrlen);
 			ret = -FI_ENODATA;
 			goto err;
@@ -407,9 +406,8 @@ int sock_rdm_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 		}
-		if((hints->dest_addrlen != 0) && 
-				(hints->dest_addrlen != sizeof(struct sockaddr_in))){
-			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n", 
+		if(hints->dest_addrlen != sizeof(struct sockaddr_in)){
+			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be sizeof(struct sockaddr_in); got %zu\n", 
 					hints->dest_addrlen);
 			ret = -FI_ENODATA;
 			goto err;

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -34,7 +34,6 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -300,7 +299,7 @@ int sock_rdm_getinfo(uint32_t version, const char *node, const char *service,
 		ret = getaddrinfo(node ? node : hostname, service, 
 				  &sock_hints, &result_ptr);
 		if (ret != 0) {
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			SOCK_LOG_INFO("getaddrinfo failed!\n");
 			goto err;
 		}
@@ -331,7 +330,7 @@ int sock_rdm_getinfo(uint32_t version, const char *node, const char *service,
 
 		ret = getaddrinfo(node, service, &sock_hints, &result_ptr);
 		if (ret != 0) {
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			SOCK_LOG_INFO("getaddrinfo failed!\n");
 			goto err;
 		}
@@ -367,7 +366,7 @@ int sock_rdm_getinfo(uint32_t version, const char *node, const char *service,
 			      result->ai_addrlen);
 		if ( ret != 0) {
 			SOCK_LOG_ERROR("Failed to create udp socket\n");
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			goto err;
 		}
 
@@ -380,7 +379,7 @@ int sock_rdm_getinfo(uint32_t version, const char *node, const char *service,
 		ret = getsockname(udp_sock, (struct sockaddr*)src_addr, &len);
 		if (ret != 0) {
 			SOCK_LOG_ERROR("getsockname failed\n");
-			ret = FI_ENODATA;
+			ret = -FI_ENODATA;
 			goto err;
 		}
 		close(udp_sock);
@@ -390,7 +389,13 @@ int sock_rdm_getinfo(uint32_t version, const char *node, const char *service,
 	}
 
 	if (hints && hints->src_addr) {
-		assert(hints->src_addrlen == sizeof(struct sockaddr_in));
+		if((hints->src_addrlen != 0) && 
+				(hints->src_addrlen != sizeof(struct sockaddr_in))){
+			SOCK_LOG_ERROR("Sockets provider requires src_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n", 
+					hints->src_addrlen);
+			ret = -FI_ENODATA;
+			goto err;
+		}
 		memcpy(src_addr, hints->src_addr, hints->src_addrlen);
 	}
 
@@ -402,7 +407,13 @@ int sock_rdm_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 		}
-		assert(hints->dest_addrlen == sizeof(struct sockaddr_in));
+		if((hints->dest_addrlen != 0) && 
+				(hints->dest_addrlen != sizeof(struct sockaddr_in))){
+			SOCK_LOG_ERROR("Sockets provider requires dest_addrlen to be 0 or sizeof(struct sockaddr_in); got %zu\n", 
+					hints->dest_addrlen);
+			ret = -FI_ENODATA;
+			goto err;
+		}
 		memcpy(dest_addr, hints->dest_addr, hints->dest_addrlen);
 	}
 
@@ -420,7 +431,7 @@ int sock_rdm_getinfo(uint32_t version, const char *node, const char *service,
 
 	_info = sock_rdm_fi_info(hints, src_addr, dest_addr);
 	if (!_info) {
-		ret = FI_ENOMEM;
+		ret = -FI_ENOMEM;
 		goto err;
 	}
 


### PR DESCRIPTION
- Fixed resource leak for error-case exit path in fi_getinfo found by Coverity Scan
- Completed removal of assertion for RDM and DGRAM based on #693 
- Added a check that allows 0 as src_addrlen/dest_addrlen which can be passed by user as hints, suggested by @jithinjosepkl 
- Corrected error values where it was returning positive values