### PR TITLE
Add av_type field to domain_attr

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -161,6 +161,12 @@ enum {
 typedef uint64_t		fi_addr_t;
 FI_DEFINE_HANDLE(fi_connreq_t);
 
+enum fi_av_type {
+	FI_AV_UNSPEC,
+	FI_AV_MAP,
+	FI_AV_TABLE
+};
+
 enum fi_progress {
 	FI_PROGRESS_UNSPEC,
 	FI_PROGRESS_AUTO,
@@ -271,6 +277,7 @@ struct fi_domain_attr {
 	enum fi_progress	control_progress;
 	enum fi_progress	data_progress;
 	enum fi_resource_mgmt	resource_mgmt;
+	enum fi_av_type		av_type;
 	size_t			mr_key_size;
 	size_t			cq_data_size;
 	size_t			cq_cnt;

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -47,11 +47,6 @@ extern "C" {
  * Maps and stores transport/network addresses.
  */
 
-enum fi_av_type {
-	FI_AV_MAP,
-	FI_AV_TABLE
-};
-
 struct fi_av_attr {
 	enum fi_av_type		type;
 	int			rx_ctx_bits;

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -107,6 +107,7 @@ struct fi_domain_attr {
 	enum fi_progress      control_progress;
 	enum fi_progress      data_progress;
 	enum fi_resource_mgmt resource_mgmt;
+	enum fi_av_type       av_type;
 	size_t                mr_key_size;
 	size_t                cq_data_size;
 	size_t                cq_cnt;
@@ -357,13 +358,36 @@ the endpoint must be re-enabled before it will accept new data transfer
 operations.  For connected endpoints, the connection is torn down and
 must be re-established.
 
-## MR Key Size
+## AV Type (av_type)
+
+Specifies the type of address vectors that are usable with this domain.
+For additional details on AV type, see [`fi_av`(3)](fi_av.3.html).
+The following values may be specified.
+
+*FI_AV_UNSPEC*
+: Any address vector format is requested and supported.
+
+*FI_AV_MAP*
+: Only address vectors of type AV map are requested or supported.
+
+*FI_AV_TABLE*
+: Only address vectors of type AV index are requested or supported.
+
+Address vectors are only used by connectionless endpoints.  Applications
+that require the use of a specific type of address vector should set the
+domain attribute av_type to the necessary value when calling fi_getinfo.
+The value FI_AV_UNSPEC may be used to indicate that the provider can support
+either address vector format.  In this case, a provider may return
+FI_AV_UNSPEC to indicate that either format is supportable, or may return
+another AV type to indicate the optimal AV type supported by this domain. 
+
+## MR Key Size (mr_key_size)
 
 Size of the memory region remote access key, in bytes.  Applications
 that request their own MR key must select a value within the range
 specified by this value.
 
-## CQ Data Size
+## CQ Data Size (cq_data_size)
 
 Applications may include a small message with a data transfer that
 is placed directly into a remote completion queue as part of a completion

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -140,15 +140,15 @@ struct fi_info {
   in the _Addressing formats_ section below.
 
 *src_addrlen - source address length*
-: Indicates the length of the source address (must be specified if
-  *src_addr* is specified).  This field will be ignored in hints if
-  FI_SOURCE is specified.
+: Indicates the length of the source address.  This value must be > 0
+  if *src_addr* is non-NULL.  This field will be ignored in hints if
+  FI_SOURCE is specified, or *src_addr* is NULL.
 
 *dest_addrlen - destination address length*
-: Indicates the length of the destination address (must be specified
-  if *dest_addr* is specified).  This field will be ignored in hints
+: Indicates the length of the destination address.  This value must be > 0
+  if *dest_addr* is non-NULL.  This field will be ignored in hints
   unless the node and service parameters are NULL or FI_SOURCE is
-  specified.
+  specified, or if *dst_addr* is NULL.
 
 *src_addr - source address*
 : If specified, indicates the source address.  This field will be


### PR DESCRIPTION
Providers are currently required to support both AV tables and
maps on the same domain.  Although that is still possible, forcing
this could lead to implementation issues.  For example, a CQ
must be prepared to handle endpoints bound to either type.
Optimizations may be possible if the provider knows what type of
addressing the application requires up front.

Add an av_type field as a domain attribute.  Applications can
provide this as input regarding the type of AV that they intend
to use.  And providers can indicate if a specific AV type is
required.

PR also contains a minor clarification in the man pages.