### PR TITLE
prov/psm: allow multiple shared openings of fabric and domain

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -222,6 +222,7 @@ struct psmx_multi_recv {
 
 struct psmx_fid_fabric {
 	struct fid_fabric	fabric;
+	int			refcnt;
 	struct psmx_fid_domain	*active_domain;
 	psm_uuid_t		uuid;
 };
@@ -229,6 +230,7 @@ struct psmx_fid_fabric {
 struct psmx_fid_domain {
 	struct fid_domain	domain;
 	struct psmx_fid_fabric	*fabric;
+	int			refcnt;
 	psm_ep_t		psm_ep;
 	psm_epid_t		psm_epid;
 	psm_mq_t		psm_mq;
@@ -541,6 +543,7 @@ extern struct fi_ops_rma	psmx_rma_ops;
 extern struct fi_ops_atomic	psmx_atomic_ops;
 extern struct psm_am_parameters psmx_am_param;
 extern struct psmx_env		psmx_env;
+extern struct psmx_fid_fabric	*psmx_active_fabric;
 
 int	psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			 struct fid_domain **domain, void *context);


### PR DESCRIPTION
PSM currently only support one endpoint per process. The PSM
endpoint is managed at the domain level, that means there can be
only one domain object (and one fabric object) be opened per
process. Some applications may use multiple middleware libraries
at the same time and each of the library needs to open its own
fabric and domain objects.

This patch partially addresses this issue by allowing the same
fabric and domain object be returned by multiple opening calls.
As a result, multiple middleware libraries can get shared access
to the same PSM endpoint. The limitation is that the OFI endpoints
opened over this shared domain can't use overlapping communication
APIs, i.e., any of these OFI endpoints can use a combination of
tagged messaging, non-tagged messaging, RMA, or atomics, but each
of these APIs can only be used by one OFI endpoint.

See #699 and ofiwg/fabtests#168
