### PR TITLE
manpages: fix mixup of cq with eq in fi_msg.3 etc.

### DIFF
--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -441,7 +441,7 @@ will operate on.
 Completed atomic operations are reported to the user through one or
 more event collectors associated with the endpoint.  Users provide
 context which are associated with each operation, and is returned to
-the user as part of the event completion.  See fi_eq for completion
+the user as part of the event completion.  See fi_cq for completion
 event details.
 
 Updates to the target buffer of an atomic operation are visible to
@@ -515,5 +515,5 @@ errno is returned. Fabric errno values are defined in
 [`fi_getinfo`(3)](fi_getinfo.3.html),
 [`fi_endpoint`(3)](fi_endpoint.3.html),
 [`fi_domain`(3)](fi_domain.3.html),
-[`fi_eq`(3)](fi_eq.3.html),
+[`fi_cq`(3)](fi_cq.3.html),
 [`fi_rma`(3)](fi_rma.3.html)

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -109,7 +109,7 @@ until the receive operation has completed.
 Completed message operations are reported to the user through one or
 more event collectors associated with the endpoint.  Users provide
 context which are associated with each operation, and is returned to
-the user as part of the event completion.  See fi_eq for completion
+the user as part of the event completion.  See fi_cq for completion
 event details.
 
 ## fi_send
@@ -269,4 +269,4 @@ errno is returned. Fabric errno values are defined in
 [`fi_getinfo`(3)](fi_getinfo.3.html),
 [`fi_endpoint`(3)](fi_endpoint.3.html),
 [`fi_domain`(3)](fi_domain.3.html),
-[`fi_eq`(3)](fi_eq.3.html)
+[`fi_cq`(3)](fi_cq.3.html)

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -278,4 +278,4 @@ errno is returned. Fabric errno values are defined in
 [`fi_getinfo`(3)](fi_getinfo.3.html),
 [`fi_endpoint`(3)](fi_endpoint.3.html),
 [`fi_domain`(3)](fi_domain.3.html),
-[`fi_eq`(3)](fi_eq.3.html)
+[`fi_cq`(3)](fi_cq.3.html)

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -137,7 +137,7 @@ the send and receive buffers.
 Completed message operations are reported to the user through one or
 more event collectors associated with the endpoint.  Users provide
 context which are associated with each operation, and is returned to
-the user as part of the event completion.  See fi_eq for completion
+the user as part of the event completion.  See fi_cq for completion
 event details.
 
 ## fi_tsend
@@ -336,4 +336,4 @@ src_addr, and src_addrlen parameters.
 [`fi_getinfo`(3)](fi_getinfo.3.html),
 [`fi_endpoint`(3)](fi_endpoint.3.html),
 [`fi_domain`(3)](fi_domain.3.html),
-[`fi_eq`(3)](fi_eq.3.html)
+[`fi_cq`(3)](fi_cq.3.html)


### PR DESCRIPTION
Looks like fi_msg.3, fi_atomics.3, fi_rma.3 and
fi_tagged.3 man pages were referencing fi_eq
man page when they should have been referencing
the fi_cq man page.

@shefty 
@jsquyres 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>