### PR TITLE
prov/verbs: Add missing flag on remote CQ data

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -2267,7 +2267,7 @@ static uint64_t fi_ibv_comp_flags(struct ibv_wc *wc)
 		flags |= FI_RECV | FI_MSG;
 		break;
 	case IBV_WC_RECV_RDMA_WITH_IMM:
-		flags = FI_RMA | FI_REMOTE_WRITE;
+		flags |= FI_RMA | FI_REMOTE_WRITE;
 		break;
 	default:
 		break;


### PR DESCRIPTION
The fi_cq(3) man page states that the FI_REMOTE_CQ_DATA bit will be set in flags to indicate that a completion has remote RQ data associated with it.  Commit e03a3a8 added the fi_ibv_comp_flags function to set the appropriate flags on a completion event.  However, as written, this function sets the FI_REMOTE_CQ_DATA bit if the verbs completion claims to have immediate data, but then immediately overwrites it if the completion type was a received RDMA_WRITE_WITH_IMM.  This breaks any application which checked this flag to determine if a completion had remote CQ data.

@shefty @a-ilango 

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>