### PR TITLE
fi_av/fi_eq: more description of async operations

### DIFF
--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -215,6 +215,14 @@ struct fi_av_attr {
   field in all completions will be the context specified to the insert
   call, and the data field in the final completion entry will report
   the number of addresses successfully inserted.
+  If an error occurs during the asynchronous insertion, an error
+  completion entry is returned (see [`fi_av`(3)](fi_av.3.html) for a
+  discussion of the fi_eq_err_entry error completion struct).  The
+  context field of the error completion will be the context that was
+  specified in the insert call; the data field will contain the index
+  of the failed address.  There will be one error completion returned
+  for each address that fails to insert into the AV.
+
 : &nbsp;
 : If an AV is opened with FI_EVENT, any insertions attempted before an
   EQ is bound to the AV will fail with -FI_ENOEQ.

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -247,7 +247,7 @@ information regarding the format associated with each event.
 struct fi_eq_entry {
 	fid_t            fid;        /* fid associated with request */
 	void            *context;    /* operation context */
-	uint32_t         data;       /* completion dependent data */
+	uint64_t         data;       /* completion-specific data */
 };
 {% endhighlight %}
 
@@ -259,6 +259,10 @@ struct fi_eq_entry {
   FI_AV_COMPLETE event and fid_av.  The context field will be set
   to the context specified as part of the operation, if available,
   otherwise the context will be associated with the fabric descriptor.
+  The data field will be set as described in the man page for the
+  corresponding object type (e.g., see [`fi_av`(3)](fi_av.3.html) for
+  a description of how asynchronous address vector insertions are
+  completed).
 
 *Connection Notification*
 : Connection notifications are connection management notifications
@@ -347,6 +351,7 @@ fi_eq_err_entry.  The format of this structure is defined below.
 struct fi_eq_err_entry {
 	fid_t            fid;        /* fid associated with error */
 	void            *context;    /* operation context */
+	uint64_t         data;       /* completion-specific data */
 	uint32_t         index;      /* index for vector ops */
 	int              err;        /* positive error code */
 	int              prov_errno; /* provider error code */
@@ -360,6 +365,11 @@ event.  For memory registration, this will be the fid_mr, address
 resolution will reference a fid_av, and CM events will refer to a
 fid_ep.  The context field will be set to the context specified as
 part of the operation.
+
+The data field will be set as described in the man page for the
+corresponding object type (e.g., see [`fi_av`(3)](fi_av.3.html) for a
+description of how asynchronous address vector insertions are
+completed).
 
 The general reason for the error is provided through the err field.
 Provider or operational specific error information may also be available


### PR DESCRIPTION
Fix the "data" members of the fi_av/fi_eq man pages.  Also have fi_eq.3.md reference the other man pages that describe the contents of the data fields in the eq/eq_err completions.

Finally, make fi_av.3.md explicit on the contents of its error completions.

Fixes #733.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>