### PR TITLE
usnic: SIOCGARP returning ENXIO means "use the ARP, Luke..."

### DIFF
--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -164,7 +164,7 @@ usdf_av_insert_progress(void *v)
 		ret = usnic_arp_lookup(dap->uda_ifname,
 				req->avr_daddr_be, fp->fab_arp_sockfd, eth);
 
-		/* anything besides -EAGAIN means request is completed */
+		/* anything besides EAGAIN means request is completed */
 		if (ret != EAGAIN) {
 			TAILQ_REMOVE(&insert->avi_req_list, req, avr_link);
 			req->avr_status = -ret;

--- a/prov/usnic/src/usnic_direct/usnic_ip_utils.c
+++ b/prov/usnic/src/usnic_direct/usnic_ip_utils.c
@@ -77,6 +77,8 @@ int usnic_arp_lookup(char *ifname, uint32_t ipaddr, int sockfd, uint8_t *macaddr
 		memcpy(macaddr, req.arp_ha.sa_data, 6);
 	else if (status != -1) /* req.arp_flags & ATF_COM == 0 */
 		err = EAGAIN;
+	else if (errno == ENXIO) /* ENXIO means no ARP entry was found */
+		err = EAGAIN;
 	else /* status == -1 */
 		err = errno;
 


### PR DESCRIPTION
Reading kernel code, SIOCGARP definitely returns ENXIO when there is no corresponding ARP table entry.  So also translate that case into "EAGAIN" here in this higher-level function (i.e., it's not a hard failure -- just try again).

This fixes CSCut30093.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@rfaucett please review