### PR TITLE
core: add provider include/exclude env vars

### DIFF
--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -157,6 +157,16 @@ A fabric identifier.
 
 The name of the underlying fabric provider.
 
+For debugging and administrative purposes, environment variables can be used
+to control which fabric providers will be registered with libfabric.
+Specifying "FI_PROVIDER=foo,bar" will allow any providers with the names "foo"
+or "bar" to be registered.  Similarly, specifying "FI_PROVIDER=^foo,bar" will
+prevent any providers with the names "foo" or "bar" from being registered.
+Providers which are not registered will not appear in fi_getinfo results.
+Applications which need a specific set of providers should implement
+their own filtering of fi_getinfo's results rather than relying on these
+environment variables in a production setting.
+
 ## prov_version
 
 Version information for the fabric provider.


### PR DESCRIPTION
This is a proposal for adding provider selection logic via environment variables.  Let's use it as the basis for some discussion on the topic.

FI_PROV_INCL and FI_PROV_EXCL allow a user to restrict the set of
providers that will be returned by fi_getinfo().  A user can specify one
or the other, or neither, but not both at the same time.  The provider
names are not checked for validity, so specifying
`FI_PROV_INCL=bogus,usnic` will exclude the "usnic" provider without any
warnings about "bogus".

Signed-off-by: Dave Goodell <dgoodell@cisco.com>