### PR TITLE
usnic: fix typo

### DIFF
--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -405,7 +405,7 @@ usdf_pep_close(fid_t fid)
 
 	usdf_pep_free_cr_lists(pep);
 	close(pep->pep_sock);
-	if (&pep->pep_eq != NULL) {
+	if (pep->pep_eq != NULL) {
 		atomic_dec(&pep->pep_eq->eq_refcnt);
 	}
 	atomic_dec(&pep->pep_fabric->fab_refcnt);


### PR DESCRIPTION
Fix an obvious typo.

Reviewed by @goodell 

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>