### PR TITLE
fi_provider.m4: display whether the provider is built or not

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -85,10 +85,12 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 				[AC_MSG_WARN([$1 provider was selected to be built as DL])
 				 AC_MSG_WARN([but libfabric is being built as static-only])
 				 AC_MSG_ERROR([This is an impossible situation. Cannot continue.])])
+			 AC_MSG_NOTICE([$1 provider: build as plugin])
 			],
-			[PROVIDERS_STATIC="prov/$1/lib$1.la $PROVIDERS_STATIC"])
+			[PROVIDERS_STATIC="prov/$1/lib$1.la $PROVIDERS_STATIC"
+			 AC_MSG_NOTICE([$1 provider: include in libfabric])])
 		],
-		[AC_MSG_NOTICE([$1 provider disabled])])
+		[AC_MSG_NOTICE([$1 provider: disabled])])
 
 	AC_DEFINE_UNQUOTED([HAVE_]m4_translit([$1], [a-z], [A-Z]), $$1_happy, [$1 provider is built])
 	AC_DEFINE_UNQUOTED([HAVE_]m4_translit([$1], [a-z], [A-Z])[_DL], $$1_dl, [$1 provider is built as DSO])


### PR DESCRIPTION
Always display the final disposition of the provider's build status:

* include in libfabric
* build as plugin
* disabled

Rationale: it is easier on the human brain to have a final signal as to whether a given provider will be built or not (vs. only a negative signal if the provider is *not* to be built).

I seem to recall that there was	discussion about messages like this before and they	were voted down, but I'd like to ask again if they can be displayed.  I just spent a long time	debugging a complex provider build issue, and it was	very, very helpful for my poor brain to	always be able	to look	for an indication in the output	as to whether a	given provider was to	be built or not	(vs. only being	able to	see a confirmation message if	the provider was *not* to be built).
