### PR TITLE
usnic: add --with-libnl and --with-libnl3 configure options

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -216,7 +216,7 @@ _usnic_files = \
 
 _usnic_cppflags = \
         -D__LIBUSNIC__ \
-        -DHAVE_LIBNL3=$(HAVE_LIBNL3) $(usnic_libnl_CPPFLAGS) \
+        -DHAVE_LIBNL3=$(HAVE_LIBNL3) $(usnic_nl_CPPFLAGS) \
         -I$(top_srcdir)/prov/usnic/src/usnic_direct
 
 rdmainclude_HEADERS += \
@@ -226,13 +226,16 @@ if HAVE_USNIC_DL
 pkglib_LTLIBRARIES += libusnic-fi.la
 libusnic_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(_usnic_cppflags)
 libusnic_fi_la_SOURCES = $(_usnic_files) $(common_srcs)
-libusnic_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
-libusnic_fi_la_LIBADD = $(linkback) $(usnic_libnl_LIBS)
+libusnic_fi_la_LDFLAGS = \
+        $(usnic_ln_LDFLAGS) \
+        -module -avoid-version -shared -export-dynamic
+libusnic_fi_la_LIBADD = $(linkback) $(usnic_nl_LIBS)
 libusnic_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_USNIC_DL
 src_libfabric_la_SOURCES += $(_usnic_files)
 src_libfabric_la_CPPFLAGS += $(_usnic_cppflags)
-src_libfabric_la_LIBADD += $(usnic_libnl_LIBS)
+src_libfabric_la_LDFLAGS += $(usnic_nl_LDFLAGS)
+src_libfabric_la_LIBADD += $(usnic_nl_LIBS)
 endif !HAVE_USNIC_DL
 
 endif HAVE_USNIC

--- a/man/fi_usnic.7.md
+++ b/man/fi_usnic.7.md
@@ -32,8 +32,8 @@ libfabric provider:
   * If you have libnl (either v1 or v3) installed in a non-standard
     location (e.g., not in /usr/lib or /usr/lib64), you may need to
     tell libfabric's configure where to find libnl via the
-    `--with-libnl=DIR` or `--with-libnl3=DIR` command line options (for
-    libnl v1 and v3, respectively).
+    `--with-libnl=DIR` command line option (where DIR is the
+    installation prefix of the libnl package).
 * The most common way to use the libfabric usnic provider is via an
   MPI implementation that uses libfabric (and the usnic provider) as a
   lower layer transport.  MPI applications do not need to know

--- a/prov/usnic/configure.m4
+++ b/prov/usnic/configure.m4
@@ -1,104 +1,95 @@
+dnl
+dnl Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+dnl
+dnl This software is available to you under a choice of one of two
+dnl licenses.  You may choose to be licensed under the terms of the GNU
+dnl General Public License (GPL) Version 2, available from the file
+dnl COPYING in the main directory of this source tree, or the
+dnl BSD license below:
+dnl
+dnl     Redistribution and use in source and binary forms, with or
+dnl     without modification, are permitted provided that the following
+dnl     conditions are met:
+dnl
+dnl      - Redistributions of source code must retain the above
+dnl        copyright notice, this list of conditions and the following
+dnl        disclaimer.
+dnl
+dnl      - Redistributions in binary form must reproduce the above
+dnl        copyright notice, this list of conditions and the following
+dnl        disclaimer in the documentation and/or other materials
+dnl        provided with the distribution.
+dnl
+dnl THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+dnl "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+dnl LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+dnl FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+dnl COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+dnl INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+dnl BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+dnl LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+dnl CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+dnl LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+dnl ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+dnl POSSIBILITY OF SUCH DAMAGE.
+dnl
+
 dnl Configury specific to the libfabric usNIC provider
 
-dnl
-dnl Check for libnl; prefer version 3 instead of version 1.  Abort (i.e.,
-dnl AC_MSG_ERROR) if neither libnl v1 or v3 can be found.
-dnl
-dnl Outputs:
-dnl
-dnl - Set $1 to the CPPFLAGS necessary to compile with libnl
-dnl - Set $2 to the LIBS necessary to link with libnl
-dnl - If $3 is 1, AC_MSG_ERROR (i.e., abort) if neither libnl or
-dnl   libnl3 can be found
-dnl - Set HAVE_LIBNL3 to 1 if libnl3 will be used; 0 if libnl1 will be used
-dnl - AC_SUBST $HAVE_LIBNL3
-dnl - AC_DEFINE HAVE_LIBNL3
-dnl
-AC_DEFUN([CHECK_LIBNL3],[
-       # More libnl v1/v3 sadness: the two versions are not compatible
-       # and will not work correctly if simultaneously linked into the
-       # same applications.  Unfortunately, they *will* link into the
-       # same image!  On platforms like SLES 12, libibverbs depends on
-       # libnl-3.so.200 and friends, while a naive implementation of
-       # our configure logic would link libnl.so.1 to libdaplusnic,
-       # resulting in both versions in the dependency map at the same
-       # time.  As a coarse fix, just check for libnl-3 first and use
-       # it if present on the system.
+dnl libnl is sadness, but we have to use it.  The majority of this
+dnl configure.m4 is just to deal with libnl.  :-(
 
-       # GROSS: libnl wants us to either use pkg-config (which we
-       # can't assume is always present) or we need to look in a
-       # particular directory for the right libnl3 include files.  For
-       # now, just hard code the special path into this logic.
+dnl libnl has two versions: libnl (i.e., version 1) and libnl3.
 
-       save_CPPFLAGS=$CPPFLAGS
-       save_LIBS=$LIBS
+dnl These two versions have many of the same symbols, but they are
+dnl incompatible with each other.  We can handle this in the C code, but
+dnl we must know which version to compile file (i.e., configure must
+dnl figure this out).  Additionally, if both versions get linked into
+dnl the same process, they will disrupt each other's global state, and
+dnl Random Bad Things happen.  We can't always prevent this -- e.g., if we
+dnl link against libnl vX and some other middleware links against libnl vY
+dnl (and X != Y), prepare for unpleasentness.  You have been warned.
 
-       $1="-I/usr/include/libnl3"
-       CPPFLAGS="$$1 $CPPFLAGS"
-       AC_MSG_CHECKING([for /usr/include/libnl3])
-       AS_IF([test -d "/usr/include/libnl3"],
-             [AC_MSG_RESULT([present])
-              AC_CHECK_HEADER(
-                [netlink/version.h],
-                [AC_COMPILE_IFELSE(
-                    [AC_LANG_PROGRAM([[
-#include <netlink/netlink.h>
-#include <netlink/version.h>
-#ifndef LIBNL_VER_MAJ
-#error "LIBNL_VER_MAJ not defined!"
-#endif
-/* to the best of our knowledge, version.h only exists in libnl3 */
-#if LIBNL_VER_MAJ < 3
-#error "LIBNL_VER_MAJ < 3, this is very unusual"
-#endif
-                        ]],[[/* empty body */]])],
-                    [HAVE_LIBNL3=1],    dnl our program compiled
-                    [HAVE_LIBNL3=0])],  dnl our program failed to compile
-                [HAVE_LIBNL3=0],  dnl AC_CHECK_HEADER failed
-                [#include <netlink/netlink.h>
-                ])],
-             [AC_MSG_RESULT([missing])
-              HAVE_LIBNL3=0])  dnl "/usr/include/libnl3" doesn't exist
+dnl As of this writing (March 2015), most Linux distros seem to be
+dnl encouraging packages to prefer libnl v3 over libnl v1.
 
-       # nl_recvmsgs_report is a symbol that is only present in v3
-       AS_IF([test "$HAVE_LIBNL3" -eq 1],
-             [AC_SEARCH_LIBS([nl_recvmsgs_report], [nl-3],
-                             [# We also need libnl-route-3
-                              AC_SEARCH_LIBS([nl_rtgen_request], [nl-route-3],
-                                             [$2="-lnl-3 -lnl-route-3"
-                                              HAVE_LIBNL3=1],
-                                             [HAVE_LIBNL3=0])],
-                             [HAVE_LIBNL3=0])])
+dnl libnl wants us to use pkg-config to find CPPFLAGS and LDFLAGS and
+dnl LIBS, but pkg-config isn't always available.  So we have to test here.
+dnl It gets more complicated because libnl changed several things between v1
+dnl and v3:
 
-       AS_IF([test "$HAVE_LIBNL3" -eq 1],
-             [AC_MSG_NOTICE([using libnl-3])],
-             [# restore $1 since we are falling back to libnl (v1)
-              $1=""
-              AC_SEARCH_LIBS([nl_connect], [nl],
-                             [$2="-lnl"],
-                             [AC_MSG_WARN([Cannot find libnl-3 nor libnl])
-                              AS_IF([test "$3" = "1"],
-                                    [AC_MSG_ERROR([Cannot continue])])
-                             ])
-              AC_MSG_NOTICE([using libnl (v1)])])
+dnl v1:
+dnl - Header files (e.g., <netlink/netlink.h> are in $prefix/include
+dnl - Library is in $prefix/lib[64]
+dnl - Library is named libnl.<suffix>
 
-       # libnl_utils.h does not include configure-generated config.h,
-       # so it may not see the HAVE_LIBNL3 #define.  Hence, we set
-       # HAVE_LIBNL3 as both a C preprocessor macro (in case some
-       # other file includes config.h before libnl_utils.h) and a
-       # Makefile macro (so that the app can set HAVE_LIBNL3 via
-       # CPPFLAGS).  Also, this macro may be used in multiple
-       # different libraries; setting HAVE_LIBNL3 both ways lets the
-       # application choose which way to set it.
-       AC_SUBST([HAVE_LIBNL3])
-       AC_DEFINE_UNQUOTED([HAVE_LIBNL3],[$HAVE_LIBNL3],
-                          [set to 1 if should use libnl v3, set to 0 for libnl v11])
+dnl v3:
+dnl - Header files (e.g., <netlink/netlink.h> are in $prefix/include/libnl3
+dnl   *** NOTE: This means that a -I<dir> switch is REQUIRED to find
+dnl             the libnl3 headers (!)
+dnl - Library is in $prefix/lib[64]
+dnl - Library is named libnl-3.<suffix>
+dnl - We *also* need the libnl-route-3 library
 
-       LIBS=$save_LIBS
-       AS_UNSET([save_LIBS])
-       CPPFLAGS=$save_CPPFLAGS
-       AS_UNSET([save_CPPFLAGS])
-])
+dnl These differing requirements make the configure/m4 tests a bit of
+dnl a nightmare.  :-(
+
+dnl ---------------------------------------------------------------------------
+
+dnl This configure.m4 script supports the following CLI options:
+
+dnl --with-libnl[=dir]
+dnl If specified, look for libnl support.  If it is not found,
+dnl error/abort configure.  If dir is specified, look in that
+dnl directory (configure will first look for libnl v3 in that tree, and if
+dnl it is not found, look for libnl v1 in that tree).  If no dir is
+dnl specified, this option is redundant with --with-usnic.
+
+dnl --without-libnl
+dnl Do not look for libnl support.  This means that the usnic provider
+dnl will not be built (since the usnic provider *requires* libnl support).
+
+dnl ---------------------------------------------------------------------------
 
 dnl Called to configure this provider
 dnl
@@ -111,14 +102,211 @@ AC_DEFUN([FI_USNIC_CONFIGURE],[
     # Determine if we can support the usnic provider
     usnic_happy=0
     AS_IF([test "x$enable_usnic" != "xno"],
-	[usnic_happy=1
-	 AC_CHECK_HEADER([infiniband/verbs.h], [], [usnic_happy=0])
-	 CHECK_LIBNL3([usnic_libnl_CPPFLAGS],
-		      [usnic_libnl_LIBS], [0])
-	 AC_SUBST(usnic_libnl_CPPFLAGS)
-	 AC_SUBST(usnic_libnl_LIBS)
+	  [AC_CHECK_HEADER([infiniband/verbs.h], [usnic_happy=1])
+	   AS_IF([test $usnic_happy -eq 1],
+	       [USNIC_CHECK_LIBNL_SADNESS])
+	  ])
+])
 
-	 AS_IF([test "$usnic_libnl_LIBS" = ""],
-	       [usnic_happy=0])
-	])
+dnl
+dnl Helper function to parse --with-libnl* options
+dnl
+dnl $1: variable name
+dnl $2: --with-<foo> value
+dnl
+AC_DEFUN([USNIC_PARSE_WITH],[
+	case "$2" in
+	no)
+		# Nope, don't want it
+		usnic_want_$1=no
+		;;
+	yes)
+		# Yes, definitely want it
+		usnic_want_$1=yes
+		;;
+	default)
+		# Default case -- try and see if we can find it
+		usnic_want_$1=default
+		usnic_$1_location=/usr
+		;;
+	*)
+		# Yes, definitely want it -- at a specific location
+		usnic_want_$1=yes
+		usnic_$1_location="$2"
+		;;
+	esac
+])
+
+dnl
+dnl Shared macro
+dnl
+AC_DEFUN([USNIC_CHECK_LIBNL_SADNESS],[
+	AC_ARG_WITH([libnl],
+		[AC_HELP_STRING([--with-libnl(=DIR)],
+			[Directory prefix for libnl (typically only necessary if libnl is installed in a location that the compiler/linker will not search by default)])],
+		[], [with_libnl=default])
+
+	# The --with options carry two pieces of information: 1) do
+	# you want a specific version of libnl, and 2) where that
+	# version of libnl lives.  For simplicity, let's separate
+	# those two pieces of information.
+	USNIC_PARSE_WITH([libnl], [$with_libnl])
+
+	# Default to a numeric value (this value gets AC_DEFINEd)
+	HAVE_LIBNL3=0
+
+	###################################################
+	# NOTE: We *must* check for libnl3 before libnl.
+	###################################################
+
+	AS_IF([test "$usnic_want_libnl" != "no"],
+	      [USNIC_CHECK_LIBNL3([$usnic_libnl_location], [usnic_nl])])
+	AS_IF([test "$usnic_want_libnl" != "no" &&
+	       test "$usnic_nl_LIBS" = ""],
+	      [USNIC_CHECK_LIBNL([$usnic_libnl_location], [usnic_nl])])
+
+	AS_IF([test "$usnic_want_libnl" = "yes" &&
+	       test "$usnic_nl_LIBS" = ""],
+	      [AC_MSG_WARN([--with-libnl specified, but not found])
+	       AC_MSG_ERROR([Cannot continue])])
+
+	# Final result
+	AC_SUBST([HAVE_LIBNL3])
+	AC_DEFINE_UNQUOTED([HAVE_LIBNL3], [$HAVE_LIBNL3],
+	      [Whether we have libl or libnl3])
+
+	AC_SUBST([usnic_nl_CPPFLAGS])
+	AC_SUBST([usnic_nl_LDFLAGS])
+	AC_SUBST([usnic_nl_LIBS])
+
+	AS_IF([test "$usnic_nl_LIBS" = ""],
+	      [usnic_happy=0])
+])
+
+dnl
+dnl Check for libnl-3.
+dnl
+dnl Inputs:
+dnl
+dnl $1: prefix where to look for libnl-3
+dnl $2: var name prefix of _CPPFLAGS and _LDFLAGS and _LIBS
+dnl
+dnl Outputs:
+dnl
+dnl - Set $2_CPPFLAGS necessary to compile with libnl-3
+dnl - Set $2_LDFLAGS necessary to link with libnl-3
+dnl - Set $2_LIBS necessary to link with libnl-3
+dnl - Set HAVE_LIBNL3 1 if libnl-3 will be used
+dnl
+AC_DEFUN([USNIC_CHECK_LIBNL3],[
+	AC_MSG_NOTICE([checking for libnl3])
+
+	AC_MSG_CHECKING([for libnl3 prefix])
+	AC_MSG_RESULT([$1])
+	AC_MSG_CHECKING([for $1/include/libnl3])
+	AS_IF([test -d "$1/include/libnl3"],
+	      [usnic_libnl3_happy=1
+	       AC_MSG_RESULT([found])],
+	      [usnic_libnl3_happy=0
+	       AC_MSG_RESULT([not found])])
+
+	# Random note: netlink/version.h is only in libnl3 - it is not in libnl.
+	# Also, nl_recvmsgs_report is only in libnl3.
+	CPPFLAGS_save=$CPPFLAGS
+	usnic_tmp_CPPFLAGS="-I$1/include/libnl3"
+	CPPFLAGS="$usnic_tmp_CPPFLAGS $CPPFLAGS"
+	AS_IF([test $usnic_libnl3_happy -eq 1],
+	      [FI_CHECK_PACKAGE([$2],
+				[netlink/version.h],
+				[nl-3],
+				[nl_recvmsgs_report],
+				[],
+				[$1],
+				[],
+				[usnic_libnl3_happy=1],
+				[usnic_libnl3_happy=0])
+
+		# Note that FI_CHECK_PACKAGE is going to add
+		# -I$dir/include into $2_CPPFLAGS.  But because libnl3
+		# puts the headers in $dir/libnl3, we need to
+		# overwrite $2_CPPFLAGS with -I$dir/libnl3.  We can do
+		# this unconditionally; we don't have to check for
+		# success (checking for success occurs below).
+		$2_CPPFLAGS=$usnic_tmp_CPPFLAGS])
+
+	# If we found libnl-3, we *also* need libnl-route-3
+	LIBS_save=$LIBS
+	LDFLAGS_save=$LDFLAGS
+	AS_IF([test "$$2_LDFLAGS" != ""],
+	      [LDFLAGS="$$2_LDFLAGS $LDFLAGS"])
+	AS_IF([test $usnic_libnl3_happy -eq 1],
+	      [AC_SEARCH_LIBS([nl_rtgen_request],
+			      [nl-route-3],
+			      [usnic_libnl3_happy=1],
+			      [usnic_libnl3_happy=0])])
+	LIBS=$LIBS_save
+	LDFLAGS=$LDFLAGS_save
+
+	# Just because libnl* is evil, double check that the
+	# netlink/version.h we found was for libnl3.  As far as we
+	# know, netlink/version.h only first appeared in version
+	# 3... but let's really be sure.
+	AS_IF([test $usnic_libnl3_happy -eq 1],
+	      [AC_MSG_CHECKING([to ensure these really are libnl3 headers])
+	       CPPFLAGS="$$2_CPPFLAGS $CPPFLAGS"
+	       AC_COMPILE_IFELSE(
+			[AC_LANG_PROGRAM([[
+#include <netlink/netlink.h>
+#include <netlink/version.h>
+#ifndef LIBNL_VER_MAJ
+#error "LIBNL_VER_MAJ not defined!"
+#endif
+/* to the best of our knowledge, version.h only exists in libnl3 */
+#if LIBNL_VER_MAJ != 3
+#error "LIBNL_VER_MAJ != 3, I am sad"
+#endif
+		]])],
+		[AC_MSG_RESULT([yes])],
+		[AC_MSG_RESULT([no])
+		 usnic_libnl3_happy=0]
+		)])
+	CPPFLAGS=$CPPFLAGS_save
+
+	# If we found everything
+	AS_IF([test $usnic_libnl3_happy -eq 1],
+	      [$2_LIBS="-lnl-3 -lnl-route-3"
+	       HAVE_LIBNL3=1])
+])
+
+dnl
+dnl Check for libnl.
+dnl
+dnl Inputs:
+dnl
+dnl $1: prefix where to look for libnl
+dnl $2: var name prefix of _CPPFLAGS and _LDFLAGS and _LIBS
+dnl
+dnl Outputs:
+dnl
+dnl - Set $2_CPPFLAGS necessary to compile with libnl
+dnl - Set $2_LDFLAGS necessary to link with libnl
+dnl - Set $2_LIBS necessary to link with libnl
+dnl - Set HAVE_LIBNL3 0 if libnl will be used
+dnl
+AC_DEFUN([USNIC_CHECK_LIBNL],[
+	AC_MSG_NOTICE([checking for libnl])
+
+	FI_CHECK_PACKAGE([$2],
+			[netlink/netlink.h],
+			[nl],
+			[nl_connect],
+			[-lm],
+			[$1],
+			[],
+			[usnic_libnl_happy=1],
+			[usnic_libnl_happy=0])
+
+	AS_IF([test $usnic_libnl_happy -eq 1],
+	      [$2_LIBS="-lnl -lm"
+	       HAVE_LIBNL3=0])
 ])


### PR DESCRIPTION
@bturrubiates discovered yesterday that the usnic provider would not build if you had a manually-installed version of libnl (v1 or v3) in a non-standard location (i.e., outside of /usr).

After much discussion, it seems that the only solution is to add two CLI options to configure:

* `--with-libnl(=dir)`: search for libnl v1 support, and abort configure if it can't be found.  If dir is specified, look for libnl  support in that tree (i.e., include, and lib or lib64)
* `--with-libnl3(=dir)`: search for libnl v3 support, and abort  configure if it cannot be found.  If dir is specified (which is  *required* if libnl3 is installed anywhere other than /usr), look  for libnl3 support in that tree (i.e., include/libnl3, and lib or  lib64).

If both `--with-libnl` and `--with-libnl3` are specified, configure will abort.

The negatives of these switches can be specified, too, to disable support for libnl v1 and/or libnl v3 (i.e., `--without-libnl` and `--without-libnl3`, respectively).

I also took this opportunity to document all the sadness / colloquial knowledge that we have gained about libnl (v1 and v3) in comments in `prov/usnic/configure.m4`.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@goodell Please review
@bturrubiates Please test on your system