### PR TITLE
cron-make-nightly-tarball: fix redirection

### DIFF
--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -75,12 +75,12 @@ sub doit {
     my $cmd = shift;
     my $stdout_file = shift;
 
-    # Redirect stdout if requested or not verbose
+    # Redirect stdout if requested
     if (defined $stdout_file) {
         $stdout_file = "$logfile_dir_arg/$stdout_file.log";
         unlink($stdout_file);
         $cmd .= " >$stdout_file";
-    } elsif (!$verbose_arg) {
+    } elsif (!$verbose_arg && $cmd !~ />/) {
         $cmd .= " >/dev/null";
     }
     $cmd .= " 2>&1";


### PR DESCRIPTION
A previous commit broke the md5sum/sha1sum file generation.  This commit fixes it by not redirecting to /dev/null when there's a ">" in the command to be executed.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@patrickmacarthur please review