### PR TITLE
prov/psm: tweaks for better inject and rma performance

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -85,8 +85,6 @@ enum psmx_context_type {
 	PSMX_TRECV_CONTEXT,
 	PSMX_WRITE_CONTEXT,
 	PSMX_READ_CONTEXT,
-	PSMX_INJECT_CONTEXT,
-	PSMX_INJECT_WRITE_CONTEXT,
 	PSMX_REMOTE_WRITE_CONTEXT,
 	PSMX_REMOTE_READ_CONTEXT,
 };
@@ -490,8 +488,6 @@ struct psmx_fid_ep {
 	uint64_t		caps;
 	struct fi_context	nocomp_send_context;
 	struct fi_context	nocomp_recv_context;
-	struct fi_context	sendimm_context;
-	struct fi_context	writeimm_context;
 	size_t			min_multi_recv;
 };
 

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -349,16 +349,6 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 				tmp_cntr = tmp_ep->read_cntr;
 				break;
 
-			case PSMX_INJECT_CONTEXT:
-				tmp_cntr = tmp_ep->send_cntr;
-				free(fi_context);
-				break;
-
-			case PSMX_INJECT_WRITE_CONTEXT:
-				tmp_cntr = tmp_ep->write_cntr;
-				free(fi_context);
-				break;
-
 			case PSMX_SEND_CONTEXT:
 			case PSMX_TSEND_CONTEXT:
 				tmp_cq = tmp_ep->send_cq;

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -326,10 +326,6 @@ int psmx_ep_open(struct fid_domain *domain, struct fi_info *info,
 	PSMX_CTXT_EP(&ep_priv->nocomp_send_context) = ep_priv;
 	PSMX_CTXT_TYPE(&ep_priv->nocomp_recv_context) = PSMX_NOCOMP_RECV_CONTEXT;
 	PSMX_CTXT_EP(&ep_priv->nocomp_recv_context) = ep_priv;
-	PSMX_CTXT_TYPE(&ep_priv->sendimm_context) = PSMX_INJECT_CONTEXT;
-	PSMX_CTXT_EP(&ep_priv->sendimm_context) = ep_priv;
-	PSMX_CTXT_TYPE(&ep_priv->writeimm_context) = PSMX_INJECT_WRITE_CONTEXT;
-	PSMX_CTXT_EP(&ep_priv->writeimm_context) = ep_priv;
 
 	if (ep_cap & FI_TAGGED)
 		ep_priv->ep.tagged = &psmx_tagged_ops;

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -405,7 +405,7 @@ PSM_INI
 
 	psmx_env.name_server	= psmx_get_int_env("OFI_PSM_NAME_SERVER", 1);
 	psmx_env.am_msg		= psmx_get_int_env("OFI_PSM_AM_MSG", 0);
-	psmx_env.tagged_rma	= psmx_get_int_env("OFI_PSM_TAGGED_RMA", 0);
+	psmx_env.tagged_rma	= psmx_get_int_env("OFI_PSM_TAGGED_RMA", 1);
 	psmx_env.warning	= psmx_get_int_env("OFI_PSM_WARNING", 1);
 	psmx_env.uuid		= getenv("OFI_PSM_UUID");
 	if (!psmx_env.uuid)

--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -269,12 +269,10 @@ ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 			return -FI_EINVAL;
 
 		fi_context = context;
-		if (fi_context != &ep_priv->sendimm_context) {
-			user_fi_context = 1;
-			PSMX_CTXT_TYPE(fi_context) = PSMX_SEND_CONTEXT;
-			PSMX_CTXT_USER(fi_context) = (void *)buf;
-			PSMX_CTXT_EP(fi_context) = ep_priv;
-		}
+		user_fi_context = 1;
+		PSMX_CTXT_TYPE(fi_context) = PSMX_SEND_CONTEXT;
+		PSMX_CTXT_USER(fi_context) = (void *)buf;
+		PSMX_CTXT_EP(fi_context) = ep_priv;
 	}
 
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, send_flag,

--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -42,7 +42,6 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
 	struct fi_context *fi_context;
-	int user_fi_context = 0;
 	int err;
 	int recv_flag = 0;
 	size_t idx;
@@ -99,7 +98,6 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 			return -FI_EINVAL;
 
 		fi_context = context;
-		user_fi_context = 1;
 		if (flags & FI_MULTI_RECV) {
 			struct psmx_multi_recv *req;
 
@@ -131,7 +129,7 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 	if (err != PSM_OK)
 		return psmx_errno(err);
 
-	if (user_fi_context)
+	if (fi_context == context)
 		PSMX_CTXT_REQ(fi_context) = psm_req;
 
 	return 0;
@@ -201,7 +199,6 @@ ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
 	struct fi_context * fi_context;
-	int user_fi_context = 0;
 	int err;
 	size_t idx;
 
@@ -269,7 +266,6 @@ ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 			return -FI_EINVAL;
 
 		fi_context = context;
-		user_fi_context = 1;
 		PSMX_CTXT_TYPE(fi_context) = PSMX_SEND_CONTEXT;
 		PSMX_CTXT_USER(fi_context) = (void *)buf;
 		PSMX_CTXT_EP(fi_context) = ep_priv;
@@ -281,7 +277,7 @@ ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 	if (err != PSM_OK)
 		return psmx_errno(err);
 
-	if (user_fi_context)
+	if (fi_context == context)
 		PSMX_CTXT_REQ(fi_context) = psm_req;
 
 	return 0;

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -551,7 +551,7 @@ static ssize_t _psmx_send2(struct fid_ep *ep, const void *buf, size_t len,
 	req->cq_flags = FI_SEND | FI_MSG;
 
 	if ((ep_priv->send_cq_event_flag && !(flags & FI_COMPLETION)) ||
-	     (context == &ep_priv->sendimm_context))
+	     (flags & FI_INJECT))
 		req->no_event = 1;
 
 	args[0].u32w0 = PSMX_AM_REQ_SEND | (msg_size == len ? PSMX_AM_EOM : 0);
@@ -639,7 +639,7 @@ static ssize_t psmx_inject2(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	/* TODO: optimize it & guarantee buffered */
-	return _psmx_send2(ep, buf, len, NULL, dest_addr, &ep_priv->sendimm_context,
+	return _psmx_send2(ep, buf, len, NULL, dest_addr, NULL,
 			   ep_priv->flags | FI_INJECT);
 }
 

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -677,6 +677,9 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 				     addr, key, context, flags, data);
 
 	if (flags & FI_INJECT) {
+		if (len > PSMX_INJECT_SIZE)
+			return -FI_EMSGSIZE;
+
 		req = malloc(sizeof(*req) + len);
 		if (!req)
 			return -FI_ENOMEM;
@@ -685,7 +688,6 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 		memcpy((void *)req + sizeof(*req), (void *)buf, len);
 		buf = (void *)req + sizeof(*req);
 
-		PSMX_CTXT_TYPE(&req->fi_context) = PSMX_INJECT_WRITE_CONTEXT;
 		req->no_event = 1;
 	}
 	else {

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -435,12 +435,10 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 			return -FI_EINVAL;
 
 		fi_context = context;
-		if (fi_context != &ep_priv->sendimm_context) {
-			user_fi_context = 1;
-			PSMX_CTXT_TYPE(fi_context) = PSMX_TSEND_CONTEXT;
-			PSMX_CTXT_USER(fi_context) = (void *)buf;
-			PSMX_CTXT_EP(fi_context) = ep_priv;
-		}
+		user_fi_context = 1;
+		PSMX_CTXT_TYPE(fi_context) = PSMX_TSEND_CONTEXT;
+		PSMX_CTXT_USER(fi_context) = (void *)buf;
+		PSMX_CTXT_EP(fi_context) = ep_priv;
 	}
 
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,


### PR DESCRIPTION
Use blocking psm send for inject send. Turn on tagged messaging based RMA. 