### PR TITLE
fi.h: fix atomic get for !HAVE_ATOMICS

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -187,7 +187,11 @@ static inline void atomic_init(atomic_t *atomic, int value)
 
 static inline int atomic_get(atomic_t *atomic)
 {
-	return atomic->val;
+	int v;
+	fastlock_acquire(&atomic->lock);
+	v = atomic->val;
+	fastlock_release(&atomic->lock);
+	return v;
 }
 
 #endif // HAVE_ATOMICS


### PR DESCRIPTION
When HAVE_ATOMICS is not turned on, the atomic_get
function wasn't locking before getting the value.

This is not what the function name implies, although
a read may be implemented by the platform in an atomic
fashion. Just put locks around it to be certain.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>