### PR TITLE
fi_domain.3: clarify that fi_domain_bind() is on any fid

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -407,6 +407,7 @@ dummy_man_pages = \
         man/man3/fi_open.3 \
         man/man3/fi_open_ops.3 \
         man/man3/fi_passive_ep.3 \
+        man/man3/fi_pep_bind.3 \
         man/man3/fi_poll_add.3 \
         man/man3/fi_poll_del.3 \
         man/man3/fi_poll_open.3 \
@@ -419,6 +420,7 @@ dummy_man_pages = \
         man/man3/fi_reject.3 \
         man/man3/fi_rx_addr.3 \
         man/man3/fi_rx_size_left.3 \
+        man/man3/fi_scalable_ep_bind.3 \
         man/man3/fi_send.3 \
         man/man3/fi_senddata.3 \
         man/man3/fi_sendmsg.3 \

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -88,6 +88,13 @@ asynchronously, with the completion reported through the event queue.
 If an event queue is not bound to the domain with the FI_REG_MR flag,
 then memory registration requests complete synchronously.
 
+See [`fi_av_bind`(3)](fi_av_bind.3.html),
+[`fi_ep_bind`(3)](fi_ep_bind.3.html),
+[`fi_mr_bind`(3)](fi_mr_bind.3.html),
+[`fi_pep_bind`(3)](fi_pep_bind.3.html), and
+[`fi_scalable_ep_bind`(3)](fi_scalable_ep_bind.3.html) for more
+information.
+
 ## fi_close
 
 The fi_close call is used to release all resources associated with a domain or
@@ -468,5 +475,6 @@ vectors.
 [`fi_getinfo`(3)](fi_getinfo.3.html),
 [`fi_endpoint`(3)](fi_endpoint.3.html),
 [`fi_av`(3)](fi_av.3.html),
+[`fi_ep`(3)](fi_ep.3.html),
 [`fi_eq`(3)](fi_eq.3.html),
 [`fi_mr`(3)](fi_mr.3.html)

--- a/man/man3/fi_pep_bind.3
+++ b/man/man3/fi_pep_bind.3
@@ -1,0 +1,1 @@
+.so man3/fi_endpoint.3

--- a/man/man3/fi_scalable_ep_bind.3
+++ b/man/man3/fi_scalable_ep_bind.3
@@ -1,0 +1,1 @@
+.so man3/fi_endpoint.3


### PR DESCRIPTION
Minor clarification that fi_domain_bind() can bind *any* fid, but currently, the only permissible fid is a domain.

Fixes #757

@shefty Look ok?