### PR TITLE
fi.h: remove prototype for non-existant function

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -197,7 +197,6 @@ int fi_read_file(const char *dir, const char *file, char *buf, size_t size);
 int fi_poll_fd(int fd, int timeout);
 int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout);
 
-int fi_sockaddr_len(struct sockaddr *addr);
 size_t fi_datatype_size(enum fi_datatype datatype);
 uint64_t fi_tag_bits(uint64_t mem_tag_format);
 uint64_t fi_tag_format(uint64_t tag_bits);


### PR DESCRIPTION
This function no longer exists.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>