### PR TITLE
Makefile.am: log.c must be in $(common_srcs) or DL builds fail

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,8 @@ rdmainclude_HEADERS =
 # internal utility functions shared by in-tree providers:
 common_srcs = \
 	src/common.c \
-	src/enosys.c
+	src/enosys.c \
+	src/log.c
 
 # ensure dl-built providers link back to libfabric
 linkback = $(top_builddir)/src/libfabric.la
@@ -42,7 +43,6 @@ src_libfabric_la_SOURCES = \
 	include/prov.h \
 	src/fabric.c \
 	src/fi_tostr.c \
-	src/log.c \
 	$(common_srcs)
 
 if MACOS


### PR DESCRIPTION
It's an unfortunate model that was chosen (that we compile the same
common sources multiple times -- once in each provider), but move
log.c into $(common_srcs) to conform to that model.  This fixes the
problem of DL builds running into problems with missing symbols (the
fi_log_* symbols, in particular).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>