### PR TITLE
man: mistake in field name in man page

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -436,7 +436,7 @@ an endpoint.
 
 {% highlight c %}
 struct fi_ep_attr {
-	enum fi_ep_type ep_type;
+	enum fi_ep_type type;
 	uint32_t        protocol;
 	uint32_t        protocol_version;
 	size_t          max_msg_size;


### PR DESCRIPTION
sync with what's in the header file

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>