### PR TITLE
fabric: Define return value for EQ/CQ read of an empty queue

### DIFF
--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -478,7 +478,8 @@ fi_cq_read / fi_cq_readfrom / fi_cq_readerr
 fi_cq_sread / fi_cq_sreadfrom
 : On success, returns the number of completion events retrieved from
   the completion queue.  On error, a negative value corresponding to
-  fabric errno is returned. On timeout, -FI_ETIMEDOUT is returned.
+  fabric errno is returned.  If no completions are available to
+  return from the CQ, -FI_EAGAIN will be returned.
 
 fi_cq_write / fi_cq_writeerr
 : On success, returns the number of bytes read from or written to the

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -383,12 +383,16 @@ fi_eq_open
 : Returns 0 on success.  On error, a negative value corresponding to
   fabric errno is returned.
 
-fi_eq_read / fi_eq_readerr
-fi_eq_sread
-fi_eq_write
-: On success, returns the number of bytes read from or written to the
+fi_eq_read / fi_eq_readerr / fi_eq_sread
+: On success, returns the number of bytes read from the
   event queue.  On error, a negative value corresponding to fabric
-  errno is returned.  On timeout, fi_eq_sread returns -FI_ETIMEDOUT.
+  errno is returned.  If no data is available to be read from the
+  event queue, -FI_EAGAIN is returned.
+
+fi_eq_write
+: On success, returns the number of bytes written to the
+  event queue.  On error, a negative value corresponding to fabric
+  errno is returned.
 
 fi_eq_strerror
 : Returns a character string interpretation of the provider specific

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -536,7 +536,7 @@ static ssize_t psmx_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 		}
 	}
 
-	return read_count;
+	return read_count ? read_count : -FI_EAGAIN;
 }
 
 static ssize_t psmx_cq_read(struct fid_cq *cq, void *buf, size_t count)


### PR DESCRIPTION
The return value is unclear from the man pages.  Clarify that
reading from an empty queue will return -FI_EAGAIN.  This
aligns (mostly) with the POSIX read/recv functionality when
dealing with nonblocking sockets. 

Also require that -FI_EAGAIN be returned even for the blocking
sread calls.  This keeps the behavior consistent between read and
sread, and avoids any confusion if sread is called with a timeout
of 0, or sread is unblocked because the thread is signaled using
some other mechanism.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>