### PR TITLE
[RFC] prov/verbs: Add FI_INJECT flag support

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -375,11 +375,6 @@ static int fi_ibv_check_tx_attr(struct fi_tx_attr *attr, struct fi_info *info)
 		return -FI_ENODATA;
 	}
 
-	if (attr->inject_size > verbs_tx_attr.inject_size) {
-		VERBS_INFO("Given tx_attr->inject_size exceeds supported size\n");
-		return -FI_ENODATA;
-	}
-
 	return 0;
 }
 
@@ -507,11 +502,14 @@ static int fi_ibv_rai_to_fi(struct rdma_addrinfo *rai, struct fi_info *fi)
  	return 0;
 }
 
-static int fi_ibv_fill_info_attr(struct ibv_context *ctx, struct fi_info *hints,
+static int fi_ibv_fill_info_attr(struct ibv_context *ctx, struct ibv_qp *qp,
+				 struct fi_info *hints,
 				 struct fi_info *fi)
 {
+	struct ibv_qp_init_attr qp_init_attr;
 	struct ibv_device_attr device_attr;
 	struct ibv_port_attr port_attr;
+	struct ibv_qp_attr qp_attr;
 	union ibv_gid gid;
 	size_t name_len;
 	int ret;
@@ -530,6 +528,17 @@ static int fi_ibv_fill_info_attr(struct ibv_context *ctx, struct fi_info *hints,
 			return -FI_ENOMEM;
 
 		return 0;
+	}
+
+	if (qp) {
+		ret = ibv_query_qp(qp, &qp_attr, IBV_QP_CAP, &qp_init_attr);
+		if (ret)
+			return -ret;
+		fi->tx_attr->inject_size = qp_attr.cap.max_inline_data;
+	} else {
+		fi_read_file(FI_CONF_DIR, "def_inline_data",
+			def_inline_data, sizeof def_inline_data);
+		fi->tx_attr->inject_size = atoi(def_inline_data);
 	}
 
 	ibv_query_gid(ctx, 1, 0, &gid);
@@ -652,6 +661,19 @@ static int fi_ibv_getinfo(uint32_t version, const char *node, const char *servic
 	if (ret)
 		return ret;
 
+	if (id->verbs) {
+		fi_ibv_msg_ep_qp_init_attr(NULL, &qp_init_attr);
+		if (hints && hints->tx_attr)
+			qp_init_attr.cap.max_inline_data = hints->tx_attr->inject_size;
+
+		ret = rdma_create_qp(id, NULL, &qp_init_attr);
+		if (ret) {
+			FI_LOG(3, "verbs", "Could not create queue pair with requested attributes\n");
+			ret = -FI_ENODATA;
+			goto err1;
+		}
+	}
+
 	if (!(fi = fi_allocinfo())) {
 		ret = -FI_ENOMEM;
 		goto err1;
@@ -661,18 +683,22 @@ static int fi_ibv_getinfo(uint32_t version, const char *node, const char *servic
 	if (ret)
 		goto err2;
 
-	ret = fi_ibv_fill_info_attr(id->verbs, hints, fi);
+	ret = fi_ibv_fill_info_attr(id->verbs, id->qp, hints, fi);
 	if (ret)
 		goto err2;
 
 	*info = fi;
 
+	if (id->verbs)
+		rdma_destroy_qp(id);
 	rdma_destroy_ep(id);
 	rdma_freeaddrinfo(rai);
 	return 0;
 err2:
 	fi_freeinfo(fi);
 err1:
+	if (id->verbs)
+		rdma_destroy_qp(id);
 	rdma_destroy_ep(id);
 	rdma_freeaddrinfo(rai);
 	return ret;
@@ -691,14 +717,11 @@ static int fi_ibv_msg_ep_create_qp(struct fi_ibv_msg_ep *ep)
 			def_send_sge, sizeof def_send_sge);
 	fi_read_file(FI_CONF_DIR, "def_recv_sge",
 			def_recv_sge, sizeof def_recv_sge);
-	fi_read_file(FI_CONF_DIR, "def_inline_data",
-			def_inline_data, sizeof def_inline_data);
 
 	attr.cap.max_send_wr = atoi(def_send_wr);
 	attr.cap.max_recv_wr = atoi(def_recv_wr);
 	attr.cap.max_send_sge = atoi(def_send_sge);
 	attr.cap.max_recv_sge = atoi(def_recv_sge);
-	ep->inline_size = atoi(def_inline_data);
 	attr.cap.max_inline_data = ep->inline_size;
 	attr.qp_context = ep;
 	attr.send_cq = ep->scq->cq;
@@ -1873,6 +1896,14 @@ fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->ep_fid.rma = &fi_ibv_msg_ep_rma_ops;
 	_ep->ep_fid.atomic = &fi_ibv_msg_ep_atomic_ops;
 
+	if (info->tx_attr) {
+		_ep->inline_size = info->tx_attr->inject_size;
+	} else {
+		fi_read_file(FI_CONF_DIR, "def_inline_data",
+			def_inline_data, sizeof def_inline_data);
+		_ep->inline_size = atoi(def_inline_data);
+	}
+
 	*ep = &_ep->ep_fid;
 	return 0;
 err:
@@ -1919,7 +1950,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 		goto err;
 	memcpy(fi->dest_addr, rdma_get_peer_addr(event->id), fi->dest_addrlen);
 
-	fi_ibv_fill_info_attr(event->id->verbs, NULL, fi);
+	fi_ibv_fill_info_attr(event->id->verbs, NULL, NULL, fi);
 
 	fi->connreq = (fi_connreq_t) event->id;
 	return fi;

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -821,8 +821,12 @@ fi_ibv_msg_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flag
 		for (len = 0, i = 0; i < msg->iov_count; i++) {
 			sge[i].addr = (uintptr_t) msg->msg_iov[i].iov_base;
 			sge[i].length = (uint32_t) msg->msg_iov[i].iov_len;
-			sge[i].lkey = (uint32_t) (uintptr_t) (msg->desc[i]);
 			len += sge[i].length;
+		}
+		if (!(flags & FI_INJECT)) {
+			for (i = 0; i < msg->iov_count; i++) {
+				sge[i].lkey = (uint32_t)(uintptr_t)(msg->desc[i]);
+			}
 		}
 
 		wr.sg_list = sge;
@@ -987,8 +991,12 @@ fi_ibv_msg_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		for (len = 0, i = 0; i < msg->iov_count; i++) {
 			sge[i].addr = (uintptr_t) msg->msg_iov[i].iov_base;
 			sge[i].length = (uint32_t) msg->msg_iov[i].iov_len;
-			sge[i].lkey = (uint32_t) (uintptr_t) (msg->desc[i]);
 			len += sge[i].length;
+		}
+		if (!(flags & FI_INJECT)) {
+			for (i = 0; i < msg->iov_count; i++) {
+				sge[i].lkey = (uint32_t)(uintptr_t)(msg->desc[i]);
+			}
 		}
 
 		wr.send_flags = (len <= _ep->inline_size) ? IBV_SEND_INLINE : 0;
@@ -1239,7 +1247,9 @@ fi_ibv_msg_ep_atomic_writemsg(struct fid_ep *ep,
 
 	sge.addr = (uintptr_t) msg->msg_iov->addr;
 	sge.length = (uint32_t) sizeof(uint64_t);
-	sge.lkey = (uint32_t) (uintptr_t) msg->desc[0];
+	if (!(flags & FI_INJECT)) {
+		sge.lkey = (uint32_t) (uintptr_t) msg->desc[0];
+	}
 
 	wr.wr_id = (uintptr_t) msg->context;
 	wr.next = NULL;
@@ -1369,7 +1379,9 @@ fi_ibv_msg_ep_atomic_readwritemsg(struct fid_ep *ep,
 
 	sge.addr = (uintptr_t) resultv->addr;
 	sge.length = (uint32_t) sizeof(uint64_t);
-	sge.lkey = (uint32_t) (uintptr_t) result_desc[0];
+	if (!(flags & FI_INJECT)) {
+		sge.lkey = (uint32_t) (uintptr_t) result_desc[0];
+	}
 
 	_ep = container_of(ep, struct fi_ibv_msg_ep, ep_fid);
 
@@ -1495,7 +1507,9 @@ fi_ibv_msg_ep_atomic_compwritemsg(struct fid_ep *ep,
 
 	sge.addr = (uintptr_t) resultv->addr;
 	sge.length = (uint32_t) sizeof(uint64_t);
-	sge.lkey = (uint32_t) (uintptr_t) result_desc[0];
+	if (!(flags & FI_INJECT)) {
+		sge.lkey = (uint32_t) (uintptr_t) result_desc[0];
+	}
 
 	_ep = container_of(ep, struct fi_ibv_msg_ep, ep_fid);
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -853,7 +853,7 @@ fi_ibv_msg_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flag
 		}
 
 		wr.sg_list = sge;
-		wr.send_flags = (len <= _ep->inline_size) ? IBV_SEND_INLINE : 0;
+		wr.send_flags = (flags & FI_INJECT) ? IBV_SEND_INLINE : 0;
 	} else {
 		wr.send_flags = 0;
 	}
@@ -1022,7 +1022,7 @@ fi_ibv_msg_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 			}
 		}
 
-		wr.send_flags = (len <= _ep->inline_size) ? IBV_SEND_INLINE : 0;
+		wr.send_flags = (flags & FI_INJECT) ? IBV_SEND_INLINE : 0;
 	}
 	wr.sg_list = sge;
 
@@ -1278,7 +1278,7 @@ fi_ibv_msg_ep_atomic_writemsg(struct fid_ep *ep,
 	wr.next = NULL;
 	wr.sg_list = &sge;
 	wr.num_sge = 1;
-	wr.send_flags = (sge.length <= _ep->inline_size) ? IBV_SEND_INLINE : 0;
+	wr.send_flags = (flags & FI_INJECT) ? IBV_SEND_INLINE : 0;
 	wr.send_flags |= IBV_SEND_FENCE; 
 
 	return -ibv_post_send(_ep->id->qp, &wr, &bad);


### PR DESCRIPTION
This PR adds `FI_INJECT` flag support to the `fi_sendmsg()`, `fi_writemsg()`, ... calls in the verbs provider in terms of the inline feature.  This PR also allows the user to specify `inject_size` as input to `fi_getinfo()` when creating an active (connecting) endpoint.  However, there is currently no support for doing so on the passive endpoint, because there is no non-hackish way of attempting to create a queue pair for a passive endpoint, which is required to test a given inject (inline) size.

This means that in order to supply an inline size when accepting a connection, the user must currently manually modify `info->tx_attr->inject_size` when constructing the endpoint, but this parameter is only checked when `fi_enable()` is called on the endpoint.  Otherwise, they get the default/administratively set value.

@a-ilango 

This addresses issue #774.