### PR TITLE
usnic: update libusnic_direct to SVN r218222

### DIFF
--- a/prov/usnic/src/usnic_direct/kcompat.h
+++ b/prov/usnic/src/usnic_direct/kcompat.h
@@ -248,6 +248,7 @@ static inline bool skb_flow_dissect(const struct sk_buff *skb, struct flow_keys 
 #define __vlan_hwaccel_put_tag(a, b, c) __vlan_hwaccel_put_tag(a, c);
 #endif /* KERNEL < 3.9.0 */
 
+#ifndef __VMKLNX__
 #if ((LINUX_VERSION_CODE <= KERNEL_VERSION(3, 4, 0)) &&		\
      (!RHEL_RELEASE_CODE || RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6, 0)))
 #define net_warn_ratelimited(fmt, ...)			\
@@ -262,6 +263,7 @@ static inline bool skb_flow_dissect(const struct sk_buff *skb, struct flow_keys 
 #else
 #define enic_pci_dma_mapping_error(pdev, dma) pci_dma_mapping_error(pdev, dma)
 #endif /* Kernel version <= 2.6.26 */
+#endif
 
 /* Kernel version-specific definitions */
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 14))

--- a/prov/usnic/src/usnic_direct/usnic_abi.h
+++ b/prov/usnic/src/usnic_direct/usnic_abi.h
@@ -94,7 +94,17 @@ struct usnic_ib_create_qp_cmd_v0 {
 struct usnic_ib_create_qp_cmd {
 	struct usnic_transport_spec	spec;
 	u32				cmd_version;
+	union {
+		struct {
+			/* length in bytes of resources array */
+			u32		resources_len;
+
+			/* ptr to array of struct usnic_vnic_barres_info */
+			u64		resources;
+		} v1;
+	} u;
 };
+
 
 /*
  * infomation of vnic bar resource
@@ -128,10 +138,14 @@ struct usnic_ib_create_qp_resp_v0 {
 
 struct usnic_ib_create_qp_resp {
 	USNIC_IB_CREATE_QP_RESP_V0_FIELDS
-	u32				cmd_version;
-	u32				num_barres;
-	u32				pad_to_8byte;
-	struct usnic_vnic_barres_info	resources[0];
+	/* the above fields end on 4-byte alignment boundary */
+	u32 cmd_version;
+	union {
+		struct {
+			u32 num_barres;
+			u32 pad_to_8byte;
+		} v1;
+	} u;
 };
 
 #define USNIC_CTX_RESP_VERSION 1

--- a/prov/usnic/src/usnic_direct/vnic_dev.h
+++ b/prov/usnic/src/usnic_direct/vnic_dev.h
@@ -264,10 +264,12 @@ int vnic_dev_set_mac_addr(struct vnic_dev *vdev, u8 *mac_addr);
 int vnic_dev_classifier(struct vnic_dev *vdev, u8 cmd, u16 *entry,
 	struct filter *data);
 #ifdef ENIC_VXLAN
-int vnic_dev_overlay_offload_enable_disable(struct vnic_dev *vdev,
+int vnic_dev_overlay_offload_ctrl(struct vnic_dev *vdev,
 	u8 overlay, u8 config);
 int vnic_dev_overlay_offload_cfg(struct vnic_dev *vdev, u8 overlay,
 	u16 vxlan_udp_port_number);
+int vnic_dev_get_supported_feature_ver(struct vnic_dev *vdev,
+	u8 feature, u64 *supported_versions);
 #endif
 #ifndef ENIC_PMD
 int vnic_dev_init_devcmdorig(struct vnic_dev *vdev);

--- a/prov/usnic/src/usnic_direct/vnic_devcmd.h
+++ b/prov/usnic/src/usnic_direct/vnic_devcmd.h
@@ -479,14 +479,23 @@ enum vnic_devcmd_cmd {
 	 */
 	CMD_QP_STATS_CLEAR = _CMDC(_CMD_DIR_WRITE, _CMD_VTYPE_ENET, 63),
 
+	/* Use this devcmd for agreeing on the highest common version supported
+	 * by both driver and fw for features who need such a facility.
+	 * in:  (u64) a0 = feature (driver requests for the supported versions on
+	 * 	this feature)
+	 * out: (u64) a0 = bitmap of all supported versions for that feature
+	 */
+	CMD_GET_SUPP_FEATURE_VER = _CMDC(_CMD_DIR_RW, _CMD_VTYPE_ENET, 69),
+
 	/*
-	 * Enable/Disable overlay offloads on the given vnic
+	 * Control (Enable/Disable) overlay offloads on the given vnic
 	 * in: (u8) a0 = OVERLAY_FEATURE_NVGRE : NVGRE
 	 *          a0 = OVERLAY_FEATURE_VXLAN : VxLAN
-	 * in: (u8) a1 = OVERLAY_OFFLOAD_ENABLE : Enable
-	 *          a1 = OVERLAY_OFFLOAD_DISABLE : Disable
+	 * in: (u8) a1 = OVERLAY_OFFLOAD_ENABLE : Enable or
+	 *          a1 = OVERLAY_OFFLOAD_DISABLE : Disable or
+	 *          a1 = OVERLAY_OFFLOAD_ENABLE_V2 : Enable with version 2
 	 */
-	CMD_OVERLAY_OFFLOAD_ENABLE_DISABLE =
+	CMD_OVERLAY_OFFLOAD_CTRL =
 		_CMDC(_CMD_DIR_WRITE, _CMD_VTYPE_ENET, 72),
 
 	/*
@@ -777,8 +786,20 @@ typedef enum {
 	OVERLAY_FEATURE_MAX,
 } overlay_feature_t;
 
-#define OVERLAY_OFFLOAD_ENABLE 0
-#define OVERLAY_OFFLOAD_DISABLE 1
+#define OVERLAY_OFFLOAD_ENABLE          0
+#define OVERLAY_OFFLOAD_DISABLE         1
+#define OVERLAY_OFFLOAD_ENABLE_V2       2
 
 #define OVERLAY_CFG_VXLAN_PORT_UPDATE 0
+
+/*
+ * Use this enum to get the supported versions for each of these features
+ * If you need to use the devcmd_get_supported_feature_version(), add
+ * the new feature into this enum and install function handler in devcmd.c
+ */
+typedef enum {
+	VIC_FEATURE_VXLAN,
+	VIC_FEATURE_MAX,
+} vic_feature_t;
+	
 #endif /* _VNIC_DEVCMD_H_ */

--- a/prov/usnic/src/usnic_direct/vnic_stats.h
+++ b/prov/usnic/src/usnic_direct/vnic_stats.h
@@ -86,10 +86,12 @@ struct vnic_rx_stats {
 	u64 rsvd[16];
 };
 
+#ifndef __VMKLNX__
 /* Generic statistics */
 struct vnic_gen_stats {
 	u64 dma_map_error;
 };
+#endif
 
 struct vnic_stats {
 	struct vnic_tx_stats tx;

--- a/prov/usnic/src/usnic_direct/vnic_wq.c
+++ b/prov/usnic/src/usnic_direct/vnic_wq.c
@@ -102,14 +102,20 @@ static int vnic_wq_alloc_bufs(struct vnic_wq *wq)
 				wq->ring.desc_size * buf->index;
 			if (buf->index + 1 == count) {
 				buf->next = wq->bufs[0];
+#ifndef __VMKLNX__
 				buf->next->prev = buf;
+#endif
 				break;
 			} else if (j + 1 == VNIC_WQ_BUF_BLK_ENTRIES(count)) {
 				buf->next = wq->bufs[i + 1];
+#ifndef __VMKLNX__
 				buf->next->prev = buf;
+#endif
 			} else {
 				buf->next = buf + 1;
+#ifndef __VMKLNX__
 				buf->next->prev = buf;
+#endif
 				buf++;
 			}
 		}

--- a/prov/usnic/src/usnic_direct/vnic_wq.h
+++ b/prov/usnic/src/usnic_direct/vnic_wq.h
@@ -88,7 +88,9 @@ struct vnic_wq_buf {
 	uint8_t cq_entry; /* Gets completion event from hw */
 	uint8_t desc_skip_cnt; /* Num descs to occupy */
 	uint8_t compressed_send; /* Both hdr and payload in one desc */
+#ifndef __VMKLNX__
 	struct vnic_wq_buf *prev;
+#endif
 };
 
 /* Break the vnic_wq_buf allocations into blocks of 32/64 entries */


### PR DESCRIPTION
Update the code that comes from "libusnic_direct" to match the Cisco
internal SVN repository at r218222.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@jsquyres please review