### PR TITLE
fabric: Implement logging with fine grained control over output.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -38,7 +38,6 @@ src_libfabric_la_SOURCES = \
 	include/fi_enosys.h \
 	include/fi_indexer.h \
 	include/fi_list.h \
-	include/fi_log.h \
 	include/fi_rbuf.h \
 	include/prov.h \
 	src/fabric.c \
@@ -290,6 +289,7 @@ rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fi_cm.h \
 	$(top_srcdir)/include/rdma/fi_domain.h \
 	$(top_srcdir)/include/rdma/fi_eq.h \
+	$(top_srcdir)/include/rdma/fi_log.h \
 	$(top_srcdir)/include/rdma/fi_prov.h \
 	$(top_srcdir)/include/rdma/fi_rma.h \
 	$(top_srcdir)/include/rdma/fi_endpoint.h \

--- a/include/fi.h
+++ b/include/fi.h
@@ -43,6 +43,7 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_prov.h>
 #include <rdma/fi_atomic.h>
+#include <rdma/fi_log.h>
 
 #ifdef __APPLE__
 #include <osx/osd.h>
@@ -89,6 +90,26 @@ static inline uint64_t ntohll(uint64_t x) { return x; }
 
 #define MIN(a, b) ((a) < (b) ? a : b)
 #define MAX(a, b) ((a) > (b) ? a : b)
+
+/* Restrict to size of struct fi_context */
+struct fi_prov_context {
+	int disable_logging;
+};
+
+struct fi_filter {
+	char **names;
+	int negated;
+};
+
+extern struct fi_filter prov_log_filter;
+
+void fi_create_filter(struct fi_filter *filter, const char *env_name);
+void fi_free_filter(struct fi_filter *filter);
+int fi_apply_filter(struct fi_filter *filter, const char *name);
+
+void fi_log_init();
+void fi_log_fini();
+
 
 /* flsll is defined on BSD systems, but is different. */
 static inline int fi_flsll(long long int i)

--- a/include/rdma/fi_log.h
+++ b/include/rdma/fi_log.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2015, Intel Corp., Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,36 +32,68 @@
  *
  */
 
-#if !defined(FI_LOG_H)
-#define FI_LOG_H
+#ifndef _FI_LOG_H_
+#define _FI_LOG_H_
 
-#if HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
+#include <rdma/fabric.h>
+#include <rdma/fi_prov.h>
 
-extern int fi_log_level;
-
-void fi_log_init(void);
-void fi_warn_impl(const char *prov, const char *fmt, ...);
-void fi_log_impl(int level, const char *prov, const char *func, int line,
-		 const char *fmt, ...);
-void fi_debug_impl(const char *prov, const char *func, int line, const char *fmt, ...);
-
-/* Callers are responsible for including their own trailing "\n".  Non-provider
- * code should pass prov=NULL.
- */
-#define FI_WARN(prov, ...) fi_warn_impl(prov, __VA_ARGS__)
-
-#define FI_LOG(level, prov, ...) \
-	do { \
-		if ((level) <= fi_log_level) \
-			fi_log_impl(level, prov, __func__, __LINE__, __VA_ARGS__); \
-	} while (0)
-
-#if ENABLE_DEBUG
-#  define FI_DEBUG(prov, ...) fi_debug_impl(prov, __func__, __LINE__, __VA_ARGS__)
-#else
-#  define FI_DEBUG(prov, ...) do {} while (0)
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-#endif /* !defined(FI_LOG_H) */
+enum fi_log_subsys {
+	FI_LOG_CORE,
+	FI_LOG_FABRIC,
+	FI_LOG_DOMAIN,
+	FI_LOG_EP_CTRL,
+	FI_LOG_EP_DATA,
+	FI_LOG_AV,
+	FI_LOG_CQ,
+	FI_LOG_EQ,
+	FI_LOG_MR,
+	FI_LOG_SUBSYS_MAX
+};
+
+enum fi_log_level {
+	FI_LOG_WARN,
+	FI_LOG_TRACE,
+	FI_LOG_INFO,
+	FI_LOG_DEBUG,
+	FI_LOG_MAX
+};
+
+int fi_log_enabled(const struct fi_provider *prov, enum fi_log_level level,
+		   enum fi_log_subsys subsys);
+void fi_log(const struct fi_provider *prov, enum fi_log_level level,
+	    enum fi_log_subsys subsys, const char *func, int line,
+	    const char *fmt, ...);
+
+#define FI_LOG(prov, level, subsystem, ...)				\
+	do {								\
+		if (fi_log_enabled(prov, subsystem, level)) 		\
+			fi_log(prov, level, subsystem,			\
+				__func__, __LINE__, __VA_ARGS__);	\
+	} while (0)
+
+#define FI_WARN(prov, subsystem, ...)					\
+	FI_LOG(prov, FI_LOG_WARN, subsystem, __VA_ARGS__)
+
+#define FI_TRACE(prov, subsystem, ...)					\
+	FI_LOG(prov, FI_LOG_TRACE, subsystem, __VA_ARGS__)
+
+#define FI_INFO(prov, subsystem, ...)					\
+	FI_LOG(prov, FI_LOG_INFO, subsystem, __VA_ARGS__)
+
+#if ENABLE_DEBUG
+#define FI_DBG(prov, subsystem, ...)					\
+	FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
+#else
+#define FI_DBG(prov_name, subsystem, ...)
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*_FI_LOG_H_ */

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -62,6 +62,7 @@ extern "C" {
 struct fi_provider {
 	uint32_t version;
 	uint32_t fi_version;
+	struct fi_context context;
 	const char *name;
 	int	(*getinfo)(uint32_t version, const char *node, const char *service,
 			uint64_t flags, struct fi_info *hints, struct fi_info **info);

--- a/libfabric.map
+++ b/libfabric.map
@@ -7,5 +7,7 @@ FABRIC_1.0 {
 		fi_version;
 		fi_strerror;
 		fi_tostr;
+		fi_log_enabled;
+		fi_log;
 	local: *;
 };

--- a/man/fabric.7.md
+++ b/man/fabric.7.md
@@ -168,6 +168,76 @@ interfaces are defined by libfabric.
   operations are aware of the data formatting at the target memory
   region.
 
+# LOGGING INTERFACE
+
+Logging can be controlled using the FI_LOG_LEVEL, FI_LOG_PROV, and
+FI_LOG_SUBSYSTEMS environment variables.
+
+*FI_LOG_LEVEL*
+: FI_LOG_LEVEL controls the amount of logging data that is output.  The
+  following log levels are defined.
+
+- *Warn*
+: Warn is the least verbose setting and is intended for reporting errors
+  or warnings.
+
+- *Trace*
+: Trace is more verbose and is meant to include non-detailed output helpful to
+  tracing program execution.
+
+- *Info*
+: Info is high traffic and meant for detailed output.
+
+- *Debug*
+: Debug is high traffic and is likely to impact application performance.
+  Debug output is only available if the library has been compiled with
+  debugging enabled.
+
+*FI_LOG_PROV*
+: The FI_LOG_PROV environment variable enables or disables logging from
+  specific providers. Providers can be enabled by listing them in a comma
+  separated fashion. If the list begins with the '^' symbol, then the list will
+  be negated. By default all providers are enabled.
+
+  Example: To enable logging from the psm and sockets provider:
+	FI_LOG_PROV="psm,sockets"
+
+  Example: To enable logging from providers other than psm:
+	FI_LOG_PROV="^psm"
+
+*FI_LOG_SUBSYS*
+: The FI_LOG_SUBSYS environment variable enables or disables logging at the
+  subsystem level.  The syntax for enabling or disabling subsystems is similar to
+  that used for FI_LOG_PROV.  The following subsystems are defined.
+
+- *core*
+: Provides output related to the core framework and its management of providers.
+
+- *fabric*
+: Provides output specific to interactions associated with the fabric object.
+
+- *domain*
+: Provides outout specific to interactions associated with the domain object.
+
+- *ep_ctrl*
+: Provides outout specific to endpoint non-data transfer operations,
+  such as CM operations.
+
+- *ep_data*
+: Provides outout specific to endpoint data transfer operations.
+
+- *av*
+: Provides outout specific to address vector operations.
+
+- *cq*
+: Provides outout specific to completion queue operations.
+
+- *eq*
+: Provides outout specific to event queue operations.
+
+- *mr*
+: Provides outout specific to memory registration.
+
 # SEE ALSO
 
 [`fi_provider`(7)](fi_provider.7.html),

--- a/man/fi_provider.7.md
+++ b/man/fi_provider.7.md
@@ -92,6 +92,44 @@ parameters and need not meet these requirements).
   functions added after the provider was written.  Any unknown
   functions must be set to NULL.
 
+# LOGGING INTERFACE
+
+Logging is performed using the FI_ERR, FI_LOG, and FI_DEBUG macros.
+
+## DEFINITIONS
+
+{% highlight c %}
+#define FI_ERR(prov_name, subsystem, ...)
+
+#define FI_LOG(prov_name, prov, level, subsystem, ...)
+
+#define FI_DEBUG(prov_name, subsystem, ...)
+{% endhighlight %}
+
+## ARGUMENTS
+*prov_name*
+: String representing the provider name.
+
+*prov*
+: Provider context structure.
+
+*level*
+: Log level associated with log statement.
+
+*subsystem*
+: Subsystem being logged from.
+
+## DESCRIPTION
+*FI_ERR*
+: Always logged.
+
+*FI_LOG*
+: Logged if the intended provider, log level, and subsystem parameters match
+  the user supplied values.
+
+*FI_DEBUG*
+: Logged if configured with the --enable-debug flag.
+
 # SEE ALSO
 
 [`fi_psm`(7)](fi_psm.7.html),

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -39,13 +39,13 @@ extern "C" {
 #include "fi.h"
 #include "fi_enosys.h"
 #include "fi_list.h"
-#include "fi_log.h"
+#include <rdma/fi_log.h>
 
 #define PSMX_PROVNAME "psm"
 #define PSMX_DEFAULT_UUID	"0FFF0FFF-0000-0000-0000-0FFF0FFF0FFF"
 
-#define PSMX_DEBUG(...) FI_LOG(2, PSMX_PROVNAME, __VA_ARGS__)
-#define PSMX_WARN(...)	FI_WARN(PSMX_PROVNAME, __VA_ARGS__)
+#define PSMX_DEBUG(...)
+#define PSMX_WARN(...)
 
 #define PSMX_TIME_OUT	120
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -429,9 +429,10 @@ PSM_INI
 	check_version = psmx_get_int_env("OFI_PSM_VERSION_CHECK", 1);
 
 	if (check_version && major != PSM_VERNO_MAJOR) {
-		FI_WARN(PSMX_PROVNAME, "%s: PSM version mismatch: header %d.%d, library %d.%d.\n",
-			__func__, PSM_VERNO_MAJOR, PSM_VERNO_MINOR, major, minor);
-		FI_WARN(PSMX_PROVNAME, "\tSet envar OFI_PSM_VERSION_CHECK=0 to bypass version check.\n");
+		PSMX_WARN("%s: PSM version mismatch: header %d.%d, library %d.%d.\n",
+			__func__, PSM_VERNO_MAJOR, PSM_VERNO_MINOR, major,
+			minor);
+		PSMX_WARN("\tSet envar OFI_PSM_VERSION_CHECK=0 to bypass version check.\n");
 		return NULL;
 	}
 

--- a/prov/sockets/src/sock_util.h
+++ b/prov/sockets/src/sock_util.h
@@ -33,22 +33,17 @@
 #ifndef _SOCK_UTIL_H_
 #define _SOCK_UTIL_H_
 
-#include "fi_log.h"
-
-#define SOCK_ERROR (1)
-#define SOCK_WARN (2)
-#define SOCK_INFO (3)
+#include <rdma/fi_log.h>
 
 extern useconds_t sock_progress_thread_wait;
 
 extern const char sock_fab_name[];
 extern const char sock_dom_name[];
 extern const char sock_prov_name[];
+extern int sock_handle;
 
-#define SOCK_LOG_INFO(...) FI_LOG(SOCK_INFO, sock_prov_name, __VA_ARGS__)
-
-#define SOCK_LOG_WARN(...) FI_WARN(sock_prov_name, __VA_ARGS__)
-
-#define SOCK_LOG_ERROR(...) FI_WARN(sock_prov_name, __VA_ARGS__)
+#define SOCK_LOG_INFO(...)
+#define SOCK_LOG_WARN(...)
+#define SOCK_LOG_ERROR(...)
 
 #endif

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -39,19 +39,20 @@
 #include <sys/queue.h>
 #include <pthread.h>
 
-#include "fi_log.h"
+#include <rdma/fi_log.h>
 
 #include "usdf_progress.h"
 #include "usd.h"
+
 
 #define USDF_PROV_NAME "usnic"
 #define USDF_MAJOR_VERS 1
 #define USDF_MINOR_VERS 0
 #define USDF_PROV_VERSION FI_VERSION(USDF_MAJOR_VERS, USDF_MINOR_VERS)
 
-#define USDF_WARN(...) FI_WARN("usnic", __VA_ARGS__)
-#define USDF_INFO(...) FI_LOG(3, "usnic", __VA_ARGS__)
-#define USDF_DEBUG(...) FI_DEBUG("usnic", __VA_ARGS__)
+#define USDF_WARN(...)
+#define USDF_INFO(...)
+#define USDF_DEBUG(...)
 
 #define USDF_HDR_BUF_ENTRY 64
 #define USDF_EP_CAP_PIO (1ULL << 63)

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -57,16 +57,15 @@
 
 #include "fi.h"
 #include "fi_enosys.h"
-#include "fi_log.h"
+#include <rdma/fi_log.h>
 #include "prov.h"
-#include "fi_log.h"
 
 #define VERBS_PROV_NAME "verbs"
 #define VERBS_PROV_VERS FI_VERSION(1,0)
 
-#define VERBS_WARN(...) FI_WARN(VERBS_PROV_NAME, __VA_ARGS__)
-#define VERBS_INFO(...) FI_LOG(2, VERBS_PROV_NAME, __VA_ARGS__)
-#define VERBS_DEBUG(...) FI_DEBUG(VERBS_PROV_NAME, __VA_ARGS__)
+#define VERBS_WARN(...)
+#define VERBS_INFO(...)
+#define VERBS_DEBUG(...)
 
 #define VERBS_MSG_SIZE (1ULL << 31)
 #define VERBS_IB_PREFIX "IB-0x"
@@ -632,9 +631,8 @@ fi_ibv_create_ep(const char *node, const char *service,
 	if (ret) {
 		ret = -errno;
 		if (ret == -ENOENT) {
-			FI_LOG(1, "verbs",
-				"rdma_create_ep()-->ENOENT; likely usnic bug, "
-				"skipping verbs provider.\n");
+			VERBS_WARN("rdma_create_ep()-->ENOENT; "
+				   "likely usnic bug, skipping verbs provider.\n");
 			ret = -FI_ENODATA;
 		}
 		goto err;

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2015, Intel Corp., Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -36,71 +37,121 @@
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
 
+#include <rdma/fi_errno.h>
 #include "fi.h"
-#include "fi_log.h"
+#include <rdma/fi_log.h>
 
-/* General implementation note: these functions currently use multiple fprintfs
- * in a row, which can render in an ugly fashion for multithreaded code and for
- * some mpirun implementations.  If this bugs anyone enough then we can convert
- * them to snprintf to build up the printout in a single buffer.
- */
 
-int fi_log_level = INT_MIN;
+static const char * const log_subsys[] = {
+	[FI_LOG_CORE] = "core",
+	[FI_LOG_FABRIC] = "fabric",
+	[FI_LOG_DOMAIN] = "domain",
+	[FI_LOG_EP_CTRL] = "ep_ctrl",
+	[FI_LOG_EP_DATA] = "ep_data",
+	[FI_LOG_AV] = "av",
+	[FI_LOG_CQ] = "cq",
+	[FI_LOG_EQ] = "eq",
+	[FI_LOG_MR] = "mr",
+	[FI_LOG_SUBSYS_MAX] = NULL
+};
+
+static const char * const log_levels[] = {
+	[FI_LOG_WARN] = "warn",
+	[FI_LOG_TRACE] = "trace",
+	[FI_LOG_INFO] = "info",
+	[FI_LOG_DEBUG] = "debug",
+	[FI_LOG_MAX] = NULL
+};
+
+enum {
+	FI_LOG_SUBSYS_OFFSET	= FI_LOG_MAX,
+	FI_LOG_PROV_OFFSET	= FI_LOG_SUBSYS_OFFSET + FI_LOG_SUBSYS_MAX,
+	FI_LOG_LEVEL_MASK	= ((1 << FI_LOG_MAX) - 1),
+	FI_LOG_SUBSYS_MASK	= (((1 << FI_LOG_SUBSYS_MAX) - 1) <<
+				   FI_LOG_SUBSYS_OFFSET),
+//	FI_LOG_PROV_MASK	= (((1 << (64 - FI_LOG_PROV_OFFSET)) - 1) <<
+//				   FI_LOG_PROV_OFFSET)
+};
+
+#define FI_LOG_TAG(prov, level, subsys) \
+	(((uint64_t) prov << FI_LOG_PROV_OFFSET) | \
+	 ((uint64_t) (1 << (subsys + FI_LOG_SUBSYS_OFFSET))) | \
+	 ((uint64_t) (1 << level)))
+
+uint64_t log_mask;
+struct fi_filter prov_log_filter;
+
+
+static int fi_read_value(const char *env_name, const char * const names[])
+{
+	const char *value;
+	int i;
+
+	value = getenv(env_name);
+	if (!value)
+		return -1;
+
+	for (i = 0; names[i]; i++) {
+		if (!strcasecmp(value, names[i]))
+			return i;
+	}
+	return 0;
+}
 
 void fi_log_init(void)
 {
-	int ret;
+	struct fi_filter subsys_filter;
+	int level, i;
 
-	if (getenv("FI_LOG_LEVEL") != NULL) {
-		errno = 0;
-		ret = strtol(getenv("FI_LOG_LEVEL"), NULL, 10);
-		if (errno != 0)
-			fprintf(stderr,
-				"%s: invalid value specified for FI_LOG_LEVEL (%s)\n",
-				PACKAGE, strerror(errno));
-		else
-			fi_log_level = (int)ret;
+	level = fi_read_value("FI_LOG_LEVEL", log_levels);
+	if (level >= 0)
+		log_mask = ((1 << (level + 1)) - 1);
+
+	fi_create_filter(&prov_log_filter, "FI_LOG_PROV");
+	/* providers are selectively disabled */
+
+	fi_create_filter(&subsys_filter, "FI_LOG_SUBSYS");
+	for (i = 0; i < FI_LOG_SUBSYS_MAX; i++) {
+		if (!fi_apply_filter(&subsys_filter, log_subsys[i]))
+			log_mask |= (1 << (i + FI_LOG_SUBSYS_OFFSET));
 	}
+	fi_free_filter(&subsys_filter);
 }
 
-void fi_warn_impl(const char *prov, const char *fmt, ...)
+void fi_log_fini(void)
 {
-	va_list vargs;
-
-	if (prov != NULL)
-		fprintf(stderr, "%s:%s: ", PACKAGE, prov);
-	else
-		fprintf(stderr, "%s: ", PACKAGE);
-	va_start(vargs, fmt);
-	vfprintf(stderr, fmt, vargs);
-	va_end(vargs);
+	fi_free_filter(&prov_log_filter);
 }
 
-void fi_log_impl(int level, const char *prov, const char *func, int line, 
-		 const char *fmt, ...)
+int fi_log_enabled(const struct fi_provider *prov, enum fi_log_level level,
+		   enum fi_log_subsys subsys)
 {
-	va_list vargs;
+	struct fi_prov_context *ctx;
 
-	if (prov != NULL)
-		fprintf(stderr, "%s:%s:%s():%d<%d> ", PACKAGE, prov, 
-			func, line, level);
-	else
-		fprintf(stderr, "%s:%s():%d<%d> ", PACKAGE, func, line, level);
-	va_start(vargs, fmt);
-	vfprintf(stderr, fmt, vargs);
-	va_end(vargs);
+	ctx = (struct fi_prov_context *) &prov->context;
+	return ((FI_LOG_TAG(ctx->disable_logging, subsys, level) & log_mask) ==
+		FI_LOG_TAG(ctx->disable_logging, subsys, level));
 }
 
-void fi_debug_impl(const char *prov, const char *func, int line, const char *fmt, ...)
+void fi_log(const struct fi_provider *prov, enum fi_log_level level,
+	    enum fi_log_subsys subsys, const char *func, int line,
+	    const char *fmt, ...)
 {
+	char buf[1024];
+	int size;
+
 	va_list vargs;
 
-	if (prov != NULL)
-		fprintf(stderr, "%s:%s:%s():%d<DBG> ", PACKAGE, prov, func, line);
-	else
-		fprintf(stderr, "%s:%s():%d<DBG> ", PACKAGE, func, line);
+	size = snprintf(buf, sizeof(buf), "%s:%s:%s:%s():%d<%s> ", PACKAGE,
+			prov->name, log_subsys[subsys], func, line,
+			log_levels[level]);
+
 	va_start(vargs, fmt);
-	vfprintf(stderr, fmt, vargs);
+	vsnprintf(buf + size, sizeof(buf) - size, fmt, vargs);
 	va_end(vargs);
+
+	fprintf(stderr, "%s", buf);
 }


### PR DESCRIPTION
Introduce logging framework usable by both internal and external
providers.  Two new functions are exported from the library.

fi_log_enabled - returns true if a message should be logged
fi_log - display logging message in a consistent format

Logging output is controlled by 3 separate fields:

Provider | Subsystem | Log Level

Logging levels
  - WARN : Intended for warnings.
  - TRACE: Intended for non-detailed output meant to trace execution or
    provide useful information.
  - INFO : Higher traffig logging meant for detailed output.
  - DEBUG: Detailed debugging only available with debug build

Subsystems
  - CORE
  - FABRIC
  - DOMAIN
  - EP_CTRL
  - EP_DATA
  - AV
  - CQ
  - EQ
  - MR

Logging output is controlled using environment variables
  - FI_LOG_SUBSYS: Controls subsystem output.
  - FI_LOG_LEVEL: Controls log levels.
  - FI_LOG_PROV: Controls the provider output.

To support external providers hooking into the logging facilities,
the log level and subsystem definitions are exported by the library.

Signed-off-by: Ben Turrubiates <bturrubiates@lanl.gov>
Signed-off-by: Sean Hefty <sean.hefty@intel.com>