### PR TITLE
Return ENODATA more.

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -411,7 +411,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 {
 	struct fi_prov *prov;
 	struct fi_info *tail, *cur;
-	int ret = -FI_ENOSYS;
+	int ret = -FI_ENODATA;
 
 	if (!init)
 		fi_ini();


### PR DESCRIPTION
Return when a provider does not support the requested caps, or
It does but there is no hardware available.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>