### PR TITLE
prov/psm: support FI_REMORE_COMPLETE flag for RMA over tagged messge

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -110,6 +110,7 @@ union psmx_pi {
 #define PSMX_AM_FLAG_MASK	0xFFFF0000
 #define PSMX_AM_EOM		0x40000000
 #define PSMX_AM_DATA		0x20000000
+#define PSMX_AM_FORCE_ACK	0x10000000
 
 #ifndef PSMX_AM_USE_SEND_QUEUE
 #define PSMX_AM_USE_SEND_QUEUE	0
@@ -148,6 +149,8 @@ struct psmx_am_request {
 			uint64_t addr;
 			uint64_t key;
 			void	*context;
+			void	*peer_context;
+			void	*peer_addr;
 			uint64_t data;
 		} write;
 		struct {
@@ -595,6 +598,8 @@ int	psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
 int	psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
+
+void	psmx_am_ack_rma(struct psmx_am_request *req);
 
 struct	psmx_fid_mr *psmx_mr_hash_get(uint64_t key);
 int	psmx_mr_validate(struct psmx_fid_mr *mr, uint64_t addr, size_t len, uint64_t access);

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -327,6 +327,9 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 
 			fi_context = psm_status.context;
 
+			if (!fi_context)
+				continue;
+
 			tmp_ep = PSMX_CTXT_EP(fi_context);
 			tmp_cq = NULL;
 			tmp_cntr = NULL;
@@ -383,6 +386,11 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 				  struct psmx_fid_mr *mr;
 				  struct psmx_am_request *req;
 				  req = container_of(fi_context, struct psmx_am_request, fi_context);
+				  if (req->op & PSMX_AM_FORCE_ACK) {
+					req->error = psmx_errno(psm_status.error_code);
+					psmx_am_ack_rma(req);
+				  }
+
 				  mr = PSMX_CTXT_USER(fi_context);
 				  if (mr->cq) {
 					event = psmx_cq_create_event_from_status(


### PR DESCRIPTION
RMA over tagged message is the mechanism to improve RMA performance
for large size transfers. Previously the completion was generated
when the tagged send was completed. However, this didn't gurantee
the FI_REMOTE_COMPLETION semantics.

This patch adds a force acknoledgement to RMA write over tagged
message when the FI_REMOTE_COMPLETE flag is specified. The
completion is only generated when the acknowledgement is received.

The pure Active Message based RMA has always been acknowledged. RMA
read over tagged message doesn't need to be acknowledged because the
initiator is the data sink.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>