### PR TITLE
Fix fi_log_enabled check

### DIFF
--- a/include/rdma/fi_log.h
+++ b/include/rdma/fi_log.h
@@ -71,7 +71,7 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 
 #define FI_LOG(prov, level, subsystem, ...)				\
 	do {								\
-		if (fi_log_enabled(prov, subsystem, level)) 		\
+		if (fi_log_enabled(prov, level, subsystem))		\
 			fi_log(prov, level, subsystem,			\
 				__func__, __LINE__, __VA_ARGS__);	\
 	} while (0)

--- a/src/log.c
+++ b/src/log.c
@@ -76,7 +76,7 @@ enum {
 //				   FI_LOG_PROV_OFFSET)
 };
 
-#define FI_LOG_TAG(prov, level, subsys) \
+#define FI_LOG_TAG(prov, subsys, level) \
 	(((uint64_t) prov << FI_LOG_PROV_OFFSET) | \
 	 ((uint64_t) (1 << (subsys + FI_LOG_SUBSYS_OFFSET))) | \
 	 ((uint64_t) (1 << level)))


### PR DESCRIPTION
Arguments to fi_log_enabled and FI_LOG_TAG  were swapped.
This patch fixes it.

@bturrubiates, @shefty - Please have a look.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>