### PR TITLE
prov/usnic: Re-enable logging for usnic

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -50,9 +50,11 @@
 #define USDF_MINOR_VERS 0
 #define USDF_PROV_VERSION FI_VERSION(USDF_MAJOR_VERS, USDF_MINOR_VERS)
 
-#define USDF_WARN(...)
-#define USDF_INFO(...)
-#define USDF_DEBUG(...)
+extern struct fi_provider usdf_ops;
+
+#define USDF_WARN(...) FI_WARN(&usdf_ops, FI_LOG_CORE, __VA_ARGS__ )
+#define USDF_INFO(...) FI_INFO(&usdf_ops, FI_LOG_CORE, __VA_ARGS__ )
+#define USDF_DEBUG(...) FI_DBG(&usdf_ops, FI_LOG_CORE, __VA_ARGS__ )
 
 #define USDF_HDR_BUF_ENTRY 64
 #define USDF_EP_CAP_PIO (1ULL << 63)

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -990,7 +990,7 @@ static void usdf_fini(void)
 {
 }
 
-static struct fi_provider usdf_ops = {
+struct fi_provider usdf_ops = {
 	.name = USDF_PROV_NAME,
 	.version = USDF_PROV_VERSION,
 	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),


### PR DESCRIPTION
Hook into the logging framework.  Report all log messages under the 'core'
logging subsystem, so that the existing USNIC macros can be kept.

This can be updated later after confirming with Cisco on how they want to
handle their logging output.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>