### PR TITLE
prov/psm: allow completion be generated when FI_INJECT is used

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -78,6 +78,9 @@ extern struct fi_provider psmx_prov;
 #define PSMX_MSG_BIT	(0x1ULL << 63)
 #define PSMX_RMA_BIT	(0x1ULL << 62)
 
+/* Bits 60 .. 63 of the flag are provider specific */
+#define PSMX_NO_COMPLETION	(1ULL << 60)
+
 enum psmx_context_type {
 	PSMX_NOCOMP_SEND_CONTEXT = 1,
 	PSMX_NOCOMP_RECV_CONTEXT,

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -552,8 +552,8 @@ static ssize_t _psmx_send2(struct fid_ep *ep, const void *buf, size_t len,
 	req->ep = ep_priv;
 	req->cq_flags = FI_SEND | FI_MSG;
 
-	if ((ep_priv->send_cq_event_flag && !(flags & FI_COMPLETION)) ||
-	     (flags & FI_INJECT))
+	if ((flags & PSMX_NO_COMPLETION) || 
+	    (ep_priv->send_cq_event_flag && !(flags & FI_COMPLETION)))
 		req->no_event = 1;
 
 	args[0].u32w0 = PSMX_AM_REQ_SEND | (msg_size == len ? PSMX_AM_EOM : 0);
@@ -642,7 +642,7 @@ static ssize_t psmx_inject2(struct fid_ep *ep, const void *buf, size_t len,
 
 	/* TODO: optimize it & guarantee buffered */
 	return _psmx_send2(ep, buf, len, NULL, dest_addr, NULL,
-			   ep_priv->flags | FI_INJECT);
+			   ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION);
 }
 
 struct fi_ops_msg psmx_msg2_ops = {

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -389,7 +389,7 @@ static ssize_t psmx_rma_self(int am_cmd,
 			psmx_cntr_inc(cntr);
 	}
 
-	no_event = (flags & FI_INJECT) ||
+	no_event = (flags & PSMX_NO_COMPLETION) ||
 		   (ep->send_cq_event_flag && !(flags & FI_COMPLETION));
 
 	if (ep->send_cq && !no_event) {
@@ -644,6 +644,7 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 	uint64_t psm_tag;
 	size_t idx;
 	void *psm_context;
+	int no_event;
 
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
@@ -695,6 +696,9 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 				     ep_priv, (void *)buf, len, desc,
 				     addr, key, context, flags, data);
 
+	no_event = (flags & PSMX_NO_COMPLETION) ||
+		   (ep_priv->send_cq_event_flag && !(flags & FI_COMPLETION));
+
 	if (flags & FI_INJECT) {
 		if (len > PSMX_INJECT_SIZE)
 			return -FI_EMSGSIZE;
@@ -706,23 +710,18 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 		memset((void *)req, 0, sizeof(*req));
 		memcpy((void *)req + sizeof(*req), (void *)buf, len);
 		buf = (void *)req + sizeof(*req);
-
-		req->no_event = 1;
 	}
 	else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;
 
-		if (ep_priv->send_cq_event_flag && !(flags & FI_COMPLETION)) {
-			PSMX_CTXT_TYPE(&req->fi_context) = PSMX_NOCOMP_WRITE_CONTEXT;
-			req->no_event = 1;
-		}
-		else {
-			PSMX_CTXT_TYPE(&req->fi_context) = PSMX_WRITE_CONTEXT;
-		}
+		PSMX_CTXT_TYPE(&req->fi_context) = no_event ?
+						   PSMX_NOCOMP_WRITE_CONTEXT :
+						   PSMX_WRITE_CONTEXT;
 	}
 
+	req->no_event = no_event;
 	req->op = PSMX_AM_REQ_WRITE;
 	req->write.buf = (void *)buf;
 	req->write.len = len;
@@ -847,7 +846,7 @@ static ssize_t psmx_inject(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_write(ep, buf, len, NULL, dest_addr, addr, key,
-			   NULL, ep_priv->flags | FI_INJECT, 0);
+			   NULL, ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION, 0);
 }
 
 static ssize_t psmx_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -259,7 +259,7 @@ static ssize_t psmx_tagged_recvmsg(struct fid_ep *ep, const struct fi_msg_tagged
 				 msg->context, flags);
 }
 
-static ssize_t psmx_tagged_recv_no_flag(struct fid_ep *ep, void *buf, 
+static ssize_t psmx_tagged_recv_no_flag(struct fid_ep *ep, void *buf,
 					size_t len, void *desc, fi_addr_t src_addr,
 					uint64_t tag, uint64_t ignore,
 					void *context)
@@ -269,7 +269,7 @@ static ssize_t psmx_tagged_recv_no_flag(struct fid_ep *ep, void *buf,
 					tag, ignore, context);
 }
 
-static ssize_t psmx_tagged_recv_no_event(struct fid_ep *ep, void *buf, 
+static ssize_t psmx_tagged_recv_no_event(struct fid_ep *ep, void *buf,
 					size_t len, void *desc, fi_addr_t src_addr,
 					uint64_t tag, uint64_t ignore,
 					void *context)
@@ -362,6 +362,8 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 	struct fi_context *fi_context;
 	int err;
 	size_t idx;
+	int no_completion = 0;
+	struct psmx_cq_event *event;
 
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
@@ -411,6 +413,10 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
 
+	if ((flags & PSMX_NO_COMPLETION) ||
+	    (ep_priv->send_cq_event_flag && !(flags & FI_COMPLETION)))
+		no_completion = 1;
+
 	if (flags & FI_INJECT) {
 		if (len > PSMX_INJECT_SIZE)
 			return -FI_EMSGSIZE;
@@ -424,10 +430,24 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 		if (ep_priv->send_cntr)
 			psmx_cntr_inc(ep_priv->send_cntr);
 
+		if (ep_priv->send_cq && !no_completion) {
+			event = psmx_cq_create_event(
+					ep_priv->send_cq,
+					context, (void *)buf, flags, len,
+					0 /* data */, psm_tag,
+					0 /* olen */,
+					0 /* err */);
+
+			if (event)
+				psmx_cq_enqueue_event(ep_priv->send_cq, event);
+			else
+				return -FI_ENOMEM;
+		}
+
 		return 0;
 	}
 
-	if (ep_priv->send_cq_event_flag && !(flags & FI_COMPLETION) && !context) {
+	if (no_completion && !context) {
 		fi_context = &ep_priv->nocomp_send_context;
 	}
 	else {
@@ -812,7 +832,7 @@ static ssize_t psmx_tagged_inject(struct fid_ep *ep, const void *buf, size_t len
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_tagged_send(ep, buf, len, NULL, dest_addr, tag, NULL,
-				 ep_priv->flags | FI_INJECT);
+				 ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION);
 }
 
 static ssize_t psmx_tagged_search(struct fid_ep *ep, uint64_t *tag, uint64_t ignore,


### PR DESCRIPTION
Although the fi_inject calls always suppress completion, the
FI_INJECT flag doesn't imply this behavior.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>