### PR TITLE
usnic: return -FI_ENODATA when ib_uverbs is missing

### DIFF
--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -658,6 +658,10 @@ usdf_getinfo(uint32_t version, const char *node, const char *service,
 	if (__usdf_devinfo == NULL) {
 		ret = usdf_get_devinfo();
 		if (ret != 0) {
+			USDF_WARN("failed to usdf_get_devinfo, ret=%d (%s)\n",
+					ret, fi_strerror(-ret));
+			if (ret == -FI_ENODEV)
+				ret = -FI_ENODATA;
 			goto fail;
 		}
 	}


### PR DESCRIPTION
Failures to open the usnic devices should not cause fi_getinfo to return
-FI_ENODEV.

Fixes #828.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@jsquyres please review