### PR TITLE
verbs: fix old VERBS_INFO warning

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -408,7 +408,8 @@ static int fi_ibv_check_tx_attr(struct fi_tx_attr *attr, struct fi_info *info)
 	}
 
 	if (attr->op_flags & ~verbs_tx_attr.op_flags) {
-		VERBS_INFO("Given tx_attr->op_flags not supported\n");
+		FI_INFO(&fi_ibv_prov, FI_LOG_CORE,
+			"Given tx_attr->op_flags not supported\n");
 		return -FI_ENODATA;
 	}
 


### PR DESCRIPTION
This was giving a warning like:
```
prov/verbs/src/fi_verbs.c: In function 'fi_ibv_check_tx_attr':
prov/verbs/src/fi_verbs.c:411:3: warning: implicit declaration of
function 'VERBS_INFO' [-Wimplicit-function-declaration]
   VERBS_INFO("Given tx_attr->op_flags not supported\n");
      ^
```

Signed-off-by: Dave Goodell <dgoodell@cisco.com>