### PR TITLE
Sockets: Set src_addr as wildcard address if src_addr = NULL and flags & FI_SOURCE

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -292,6 +292,7 @@ static int sock_ep_getinfo(const char *node, const char *service, uint64_t flags
 		ai.ai_flags |= AI_NUMERICHOST;
 
 	if (flags & FI_SOURCE) {
+		ai.ai_flags |= AI_PASSIVE;
 		ret = getaddrinfo(node, service, &ai, &rai);
 		if (ret) {
 			SOCK_LOG_INFO("getaddrinfo failed!\n");


### PR DESCRIPTION


    - Fixes #845

Signed-off-by: Jithin Jose <jithin.jose@intel.com>