### PR TITLE
usnic: empty "reject" func should return -FI_ENOSYS

### DIFF
--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -351,7 +351,7 @@ static int
 usdf_pep_reject(struct fid_pep *pep, fi_connreq_t connreq,
 		const void *param, size_t paramlen)
 {
-	return 0;
+	return -FI_ENOSYS;
 }
 
 static void


### PR DESCRIPTION
Better to let the user know when we are not respecting their wishes
instead of silently ignoring their request.  This behavior is now more
consistent with our documented limitations in fi_usnic(7).

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@jsquyres please review per our discussion earlier today