### PR TITLE
configure.ac: 1.0.0rc3 has been released, on to 1.0.0rc4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT([libfabric], [1.0.0rc3], [ofiwg@lists.openfabrics.org])
+AC_INIT([libfabric], [1.0.0rc4], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)


### PR DESCRIPTION
Even if there is no 1.0.0rc4 release, we don't want the version in git to say "1.0.0rc3" any more, because 1.0.0rc3 has been released.  Specifically: we just need the version in git to say *something* different than what was already released.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>