### PR TITLE
configure.ac: fix grammar of AC_DEFINE comments

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,7 +96,7 @@ AC_CHECK_FUNC([pthread_spin_init],
 	[have_spinlock=0])
 
 AC_DEFINE_UNQUOTED([PT_LOCK_SPIN], [$have_spinlock],
-	[Define PT_LOCK_SPIN to 1 if available.])
+	[Define to 1 if pthread_spin_init is available.])
 
 have_clock_gettime=0
 have_host_get_clock_service=0
@@ -109,9 +109,9 @@ AC_SEARCH_LIBS([clock_gettime],[rt],
 			 not found.])])])
 
 AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
-		   [Define HAVE_CLOCK_GETTIME to 1 if available.])
+		   [Define to 1 if clock_gettime is available.])
 AC_DEFINE_UNQUOTED(HAVE_HOST_GET_CLOCK_SERVICE, [$have_host_get_clock_service],
-		   [Define HAVE_HOST_GET_CLOCK_SERVICE to 1 if available.])
+		   [Define to 1 if host_clock_get_service is available.])
 
 dnl Check for gcc atomic intrinsics
 AC_MSG_CHECKING(compiler support for c11 atomics)


### PR DESCRIPTION
Trivial comment fixes.

These can wait until whatever is decided regarding the 1.0.0rc3 release from last night with the errant printf.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>