### PR TITLE
Pr/sockets

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -958,6 +958,7 @@ void sock_comm_buffer_finalize(struct sock_conn *conn);
 ssize_t sock_comm_send(struct sock_conn *conn, const void *buf, size_t len);
 ssize_t sock_comm_recv(struct sock_conn *conn, void *buf, size_t len);
 ssize_t sock_comm_peek(struct sock_conn *conn, void *buf, size_t len);
+ssize_t sock_comm_data_avail(struct sock_conn *conn);
 ssize_t sock_comm_flush(struct sock_conn *conn);
 
 #endif

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -696,7 +696,7 @@ struct sock_pe {
 	int num_free_entries;
 	struct sock_pe_entry pe_table[SOCK_PE_MAX_ENTRIES];
 	fastlock_t lock;
-	fastlock_t list_lock;
+	pthread_mutex_t list_lock;
 
 	struct dlist_entry free_list;
 	struct dlist_entry busy_list;

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -201,6 +201,12 @@ ssize_t sock_comm_peek(struct sock_conn *conn, void *buf, size_t len)
 	return 0;
 }
 
+ssize_t sock_comm_data_avail(struct sock_conn *conn)
+{
+	sock_comm_recv_buffer(conn);
+	return rbused(&conn->inbuf);
+}
+
 int sock_comm_buffer_init(struct sock_conn *conn)
 {
 	socklen_t size = SOCK_COMM_BUF_SZ;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2036,7 +2036,7 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe, struct sock_ep *ep,
 					      conn->sock_fd);
 				return ret;
 			}
-			data_avail = (ret == 1);
+			data_avail = (ret == 1 && sock_comm_data_avail(conn));
 		}
 		
 		if (data_avail && conn->rx_pe_entry == NULL &&

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1979,32 +1979,32 @@ static int sock_pe_new_tx_entry(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx)
 
 void sock_pe_add_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *ctx)
 {
-	fastlock_acquire(&pe->list_lock);
+	pthread_mutex_lock(&pe->list_lock);
 	dlistfd_insert_tail(&ctx->pe_entry, &pe->tx_list);
-	fastlock_release(&pe->list_lock);
+	pthread_mutex_unlock(&pe->list_lock);
 	SOCK_LOG_INFO("TX ctx added to PE\n");
 }
 
 void sock_pe_add_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *ctx)
 {
-	fastlock_acquire(&pe->list_lock);
+	pthread_mutex_lock(&pe->list_lock);
 	dlistfd_insert_tail(&ctx->pe_entry, &pe->rx_list);
-	fastlock_release(&pe->list_lock);
+	pthread_mutex_unlock(&pe->list_lock);
 	SOCK_LOG_INFO("RX ctx added to PE\n");
 }
 
 void sock_pe_remove_tx_ctx(struct sock_tx_ctx *tx_ctx)
 {
-	fastlock_acquire(&tx_ctx->domain->pe->list_lock);
+	pthread_mutex_lock(&tx_ctx->domain->pe->list_lock);
 	dlist_remove(&tx_ctx->pe_entry);
-	fastlock_release(&tx_ctx->domain->pe->list_lock);
+	pthread_mutex_unlock(&tx_ctx->domain->pe->list_lock);
 }
 
 void sock_pe_remove_rx_ctx(struct sock_rx_ctx *rx_ctx)
 {
-	fastlock_acquire(&rx_ctx->domain->pe->list_lock);
+	pthread_mutex_lock(&rx_ctx->domain->pe->list_lock);
 	dlist_remove(&rx_ctx->pe_entry);
-	fastlock_release(&rx_ctx->domain->pe->list_lock);
+	pthread_mutex_unlock(&rx_ctx->domain->pe->list_lock);
 }
 
 static int sock_pe_progress_rx_ep(struct sock_pe *pe, struct sock_ep *ep,
@@ -2160,7 +2160,7 @@ static void *sock_pe_progress_thread(void *data)
 			usleep(sock_progress_thread_wait * 1000);
 		}
 
-		fastlock_acquire(&pe->list_lock);		
+		pthread_mutex_lock(&pe->list_lock);		
 		if (!dlistfd_empty(&pe->tx_list)) {
 			for (entry = pe->tx_list.list.next;
 			     entry != &pe->tx_list.list; entry = entry->next) {
@@ -2169,7 +2169,7 @@ static void *sock_pe_progress_thread(void *data)
 				ret = sock_pe_progress_tx_ctx(pe, tx_ctx);
 				if (ret < 0) {
 					SOCK_LOG_ERROR("failed to progress TX\n");
-					fastlock_release(&pe->list_lock);
+					pthread_mutex_unlock(&pe->list_lock);
 					return NULL;
 				}
 			}
@@ -2183,12 +2183,12 @@ static void *sock_pe_progress_thread(void *data)
 				ret = sock_pe_progress_rx_ctx(pe, rx_ctx);
 				if (ret < 0) {
 					SOCK_LOG_ERROR("failed to progress RX\n");
-					fastlock_release(&pe->list_lock);
+					pthread_mutex_unlock(&pe->list_lock);
 					return NULL;
 				}
 			}
 		}
-		fastlock_release(&pe->list_lock);
+		pthread_mutex_unlock(&pe->list_lock);
 	}
 	
 	SOCK_LOG_INFO("Progress thread terminated\n");
@@ -2225,7 +2225,7 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 	dlistfd_head_init(&pe->tx_list);
 	dlistfd_head_init(&pe->rx_list);
 	fastlock_init(&pe->lock);
-	fastlock_init(&pe->list_lock);
+	pthread_mutex_init(&pe->list_lock, NULL);
 	pe->domain = domain;
 
 	if (domain->progress_mode == FI_PROGRESS_AUTO) {
@@ -2255,7 +2255,7 @@ void sock_pe_finalize(struct sock_pe *pe)
 	}
 	
 	fastlock_destroy(&pe->lock);
-	fastlock_destroy(&pe->list_lock);
+	pthread_mutex_destroy(&pe->list_lock);
 	dlistfd_head_free(&pe->tx_list);
 	dlistfd_head_free(&pe->rx_list);
 	free(pe);


### PR DESCRIPTION
- Minor updates
- Use pthread_mutex_lock instead of spinlock for progress engine list-lock