### PR TITLE
pr/sockets

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1765,7 +1765,7 @@ static int sock_pe_progress_rx_pe_entry(struct sock_pe *pe,
 	}
 	
 out:
-	if (pe_entry->is_complete) {
+	if (pe_entry->is_complete && !pe_entry->pe.rx.pending_send) {
 		sock_pe_release_entry(pe, pe_entry);
 		SOCK_LOG_INFO("[%p] RX done\n", pe_entry);
 	}


### PR DESCRIPTION
Fix random hang for RMA ops seen on 32-bit VMs
  - Add check for pending-send before releasing PE entry

Signed-off-by: Jithin Jose <jithin.jose@intel.com>