### PR TITLE
usnic: fix atomic_init for cq->refcnt missing

### DIFF
--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -868,6 +868,7 @@ usdf_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	cq->cq_fid.fid.fclass = FI_CLASS_CQ;
 	cq->cq_fid.fid.context = context;
 	cq->cq_fid.fid.ops = &usdf_cq_fi_ops;
+	atomic_init(&cq->cq_refcnt, 0);
 
 	switch (attr->format) {
 	case FI_CQ_FORMAT_CONTEXT:


### PR DESCRIPTION
For older gcc, for which HAVE_ATOMIC is not set, the tests would hang infinitely because
the cq->refcnt was not initialized.

Signed-off-by: Prankur Gupta <prankgup@cisco.com>

@goodell Please review