### PR TITLE
prov/psm: updates about RMA target side completions

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -509,7 +509,6 @@ struct psmx_fid_stx {
 struct psmx_fid_mr {
 	struct fid_mr		mr;
 	struct psmx_fid_domain	*domain;
-	struct psmx_fid_cq	*cq;
 	struct psmx_fid_cntr	*cntr;
 	uint64_t		access;
 	uint64_t		flags;

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -400,23 +400,6 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		if (!op_error) {
 			addr += mr->offset;
 			psmx_atomic_do_write(addr, src, datatype, op, count);
-			if (mr->cq) {
-				event = psmx_cq_create_event(
-						mr->cq,
-						0, /* context */
-						addr,
-						FI_REMOTE_WRITE | FI_ATOMIC,
-						len,
-						0, /* data */
-						0, /* tag */
-						0, /* olen */
-						0 /* err */);
-
-				if (event)
-					psmx_cq_enqueue_event(mr->cq, event);
-				else
-					err = -FI_ENOMEM;
-			}
 			if (mr->cntr)
 				psmx_cntr_inc(mr->cntr);
 
@@ -462,23 +445,6 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			else
 				err = -FI_ENOMEM;
 			if (op != FI_ATOMIC_READ) {
-				if (mr->cq) {
-					event = psmx_cq_create_event(
-							mr->cq,
-							0, /* context */
-							addr,
-							cq_flags,
-							len,
-							0, /* data */
-							0, /* tag */
-							0, /* olen */
-							0 /* err */);
-
-					if (event)
-						psmx_cq_enqueue_event(mr->cq, event);
-					else
-						err = -FI_ENOMEM;
-				}
 				if (mr->cntr)
 					psmx_cntr_inc(mr->cntr);
 			}
@@ -534,23 +500,6 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 							 tmp_buf, datatype, op, count);
 			else
 				err = -FI_ENOMEM;
-			if (mr->cq) {
-				event = psmx_cq_create_event(
-						mr->cq,
-						0, /* context */
-						addr,
-						FI_REMOTE_WRITE | FI_ATOMIC,
-						len,
-						0, /* data */
-						0, /* tag */
-						0, /* olen */
-						0 /* err */);
-
-				if (event)
-					psmx_cq_enqueue_event(mr->cq, event);
-				else
-					err = -FI_ENOMEM;
-			}
 			if (mr->cntr)
 				psmx_cntr_inc(mr->cntr);
 
@@ -699,23 +648,6 @@ static int psmx_atomic_self(int am_cmd,
 	}
 
 	if (op != FI_ATOMIC_READ) {
-		if (mr->cq) {
-			event = psmx_cq_create_event(
-					mr->cq,
-					0, /* context */
-					(void *)addr,
-					FI_REMOTE_WRITE | FI_ATOMIC,
-					len,
-					0, /* data */
-					0, /* tag */
-					0, /* olen */
-					0 /* err */);
-
-			if (event)
-				psmx_cq_enqueue_event(mr->cq, event);
-			else
-				err = -FI_ENOMEM;
-		}
 		if (mr->cntr)
 			psmx_cntr_inc(mr->cntr);
 	}

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -380,6 +380,8 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	struct psmx_cq_event *event;
 	struct psmx_fid_mr *mr;
 	struct psmx_fid_ep *target_ep;
+	struct psmx_fid_cntr *cntr = NULL;
+	struct psmx_fid_cntr *mr_cntr = NULL;
 	void *tmp_buf;
 	uint64_t cq_flags;
 
@@ -400,12 +402,16 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		if (!op_error) {
 			addr += mr->offset;
 			psmx_atomic_do_write(addr, src, datatype, op, count);
-			if (mr->cntr)
-				psmx_cntr_inc(mr->cntr);
 
 			target_ep = mr->domain->atomics_ep;
-			if (target_ep->remote_write_cntr)
-				psmx_cntr_inc(target_ep->remote_write_cntr);
+			cntr = target_ep->remote_write_cntr;
+			mr_cntr = mr->cntr;
+
+			if (cntr)
+				psmx_cntr_inc(cntr);
+
+			if (mr_cntr && mr_cntr != cntr)
+				psmx_cntr_inc(mr_cntr);
 		}
 
 		rep_args[0].u32w0 = PSMX_AM_REP_ATOMIC_WRITE;
@@ -444,27 +450,21 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 							 datatype, op, count);
 			else
 				err = -FI_ENOMEM;
-			if (op != FI_ATOMIC_READ) {
-				if (mr->cntr)
-					psmx_cntr_inc(mr->cntr);
-			}
 
 			target_ep = mr->domain->atomics_ep;
-			if (op == FI_ATOMIC_WRITE) {
-				if (target_ep->remote_write_cntr)
-					psmx_cntr_inc(target_ep->remote_write_cntr);
-			}
-			else if (op == FI_ATOMIC_READ) {
-				if (target_ep->remote_read_cntr)
-					psmx_cntr_inc(target_ep->remote_read_cntr);
+			if (op == FI_ATOMIC_READ) {
+				cntr = target_ep->remote_read_cntr;
 			}
 			else {
-				if (target_ep->remote_write_cntr)
-					psmx_cntr_inc(target_ep->remote_write_cntr);
-				if (target_ep->remote_read_cntr &&
-				    target_ep->remote_read_cntr != target_ep->remote_write_cntr)
-					psmx_cntr_inc(target_ep->remote_read_cntr);
+				cntr = target_ep->remote_write_cntr;
+				mr_cntr = mr->cntr;
 			}
+
+			if (cntr)
+				psmx_cntr_inc(cntr);
+
+			if (mr_cntr && mr_cntr != cntr)
+				psmx_cntr_inc(mr_cntr);
 		}
 		else {
 			tmp_buf = NULL;
@@ -500,15 +500,16 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 							 tmp_buf, datatype, op, count);
 			else
 				err = -FI_ENOMEM;
-			if (mr->cntr)
-				psmx_cntr_inc(mr->cntr);
 
 			target_ep = mr->domain->atomics_ep;
-			if (target_ep->remote_write_cntr)
-				psmx_cntr_inc(target_ep->remote_write_cntr);
-			if (target_ep->remote_read_cntr &&
-			    target_ep->remote_read_cntr != target_ep->remote_write_cntr)
-				psmx_cntr_inc(target_ep->remote_read_cntr);
+			cntr = target_ep->remote_write_cntr;
+			mr_cntr = mr->cntr;
+
+			if (cntr)
+				psmx_cntr_inc(cntr);
+
+			if (mr_cntr && mr_cntr != cntr)
+				psmx_cntr_inc(mr_cntr);
 		}
 		else {
 			tmp_buf = NULL;
@@ -601,6 +602,8 @@ static int psmx_atomic_self(int am_cmd,
 	struct psmx_fid_mr *mr;
 	struct psmx_cq_event *event;
 	struct psmx_fid_ep *target_ep;
+	struct psmx_fid_cntr *cntr = NULL;
+	struct psmx_fid_cntr *mr_cntr = NULL;
 	size_t len;
 	int no_event;
 	int err = 0;
@@ -647,28 +650,20 @@ static int psmx_atomic_self(int am_cmd,
 		break;
 	}
 
-	if (op != FI_ATOMIC_READ) {
-		if (mr->cntr)
-			psmx_cntr_inc(mr->cntr);
-	}
-
 	target_ep = mr->domain->atomics_ep;
-	if (op == FI_ATOMIC_WRITE) {
-		if (target_ep->remote_write_cntr)
-			psmx_cntr_inc(target_ep->remote_write_cntr);
-	}
-	else if (op == FI_ATOMIC_READ) {
-		if (target_ep->remote_read_cntr)
-			psmx_cntr_inc(target_ep->remote_read_cntr);
+	if (op == FI_ATOMIC_READ) {
+		cntr = target_ep->remote_read_cntr;
 	}
 	else {
-		if (target_ep->remote_write_cntr)
-			psmx_cntr_inc(target_ep->remote_write_cntr);
-		if (am_cmd != PSMX_AM_REQ_ATOMIC_WRITE &&
-		    target_ep->remote_read_cntr &&
-		    target_ep->remote_read_cntr != target_ep->remote_write_cntr)
-			psmx_cntr_inc(target_ep->remote_read_cntr);
+		cntr = target_ep->remote_write_cntr;
+		mr_cntr = mr->cntr;
 	}
+
+	if (cntr)
+		psmx_cntr_inc(cntr);
+
+	if (mr_cntr && mr_cntr != cntr)
+		psmx_cntr_inc(mr_cntr);
 
 gen_local_event:
 	no_event = ((flags & PSMX_NO_COMPLETION) ||

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -399,27 +399,6 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 				  }
 
 				  mr = PSMX_CTXT_USER(fi_context);
-				  if (mr->cq) {
-					event = psmx_cq_create_event_from_status(
-							mr->cq, &psm_status, req->write.data,
-							(mr->cq == cq) ? event_buffer : NULL,
-							count, src_addr);
-					if (!event)
-						return -FI_ENOMEM;
-
-					if (event == event_buffer) {
-						read_count++;
-						read_more = --count;
-						event_buffer = count ? event_buffer + cq->entry_size : NULL;
-						if (src_addr)
-							src_addr = count ? src_addr + 1 : NULL;
-					}
-					else {
-						psmx_cq_enqueue_event(mr->cq, event);
-						if (mr->cq == cq)
-							read_more = 0;
-					}
-				  }
 				  if (mr->domain->rma_ep->recv_cq && (req->cq_flags & FI_REMOTE_CQ_DATA)) {
 					event = psmx_cq_create_event_from_status(
 							mr->domain->rma_ep->recv_cq,

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -422,10 +422,12 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 							read_more = 0;
 					}
 				  }
-				  if (mr->cntr)
-					psmx_cntr_inc(mr->cntr);
+
 				  if (mr->domain->rma_ep->remote_write_cntr)
 					psmx_cntr_inc(mr->domain->rma_ep->remote_write_cntr);
+
+				  if (mr->cntr && mr->cntr != mr->domain->rma_ep->remote_write_cntr)
+					psmx_cntr_inc(mr->cntr);
 
 				  if (read_more)
 					continue;

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -184,7 +184,7 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 	case PSMX_REMOTE_WRITE_CONTEXT:
 		op_context = PSMX_CTXT_USER(fi_context);
 		buf = NULL;
-		flags = FI_REMOTE_WRITE | FI_RMA;
+		flags = FI_REMOTE_WRITE | FI_RMA | FI_REMOTE_CQ_DATA;
 		break;
 	default:
 		op_context = PSMX_CTXT_USER(fi_context);
@@ -417,6 +417,29 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 					else {
 						psmx_cq_enqueue_event(mr->cq, event);
 						if (mr->cq == cq)
+							read_more = 0;
+					}
+				  }
+				  if (mr->domain->rma_ep->recv_cq && (req->cq_flags & FI_REMOTE_CQ_DATA)) {
+					event = psmx_cq_create_event_from_status(
+							mr->domain->rma_ep->recv_cq,
+							&psm_status, req->write.data,
+							(mr->domain->rma_ep->recv_cq == cq) ?
+								event_buffer : NULL,
+							count, src_addr);
+					if (!event)
+						return -FI_ENOMEM;
+
+					if (event == event_buffer) {
+						read_count++;
+						read_more = --count;
+						event_buffer = count ? event_buffer + cq->entry_size : NULL;
+						if (src_addr)
+							src_addr = count ? src_addr + 1 : NULL;
+					}
+					else {
+						psmx_cq_enqueue_event(mr->domain->rma_ep->recv_cq, event);
+						if (mr->domain->rma_ep->recv_cq == cq)
 							read_more = 0;
 					}
 				  }

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -154,7 +154,6 @@ static int psmx_mr_close(fid_t fid)
 static int psmx_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
 	struct psmx_fid_mr *mr;
-	struct psmx_fid_cq *cq;
 	struct psmx_fid_ep *ep;
 	struct psmx_fid_cntr *cntr;
 
@@ -167,15 +166,6 @@ static int psmx_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		ep = container_of(bfid, struct psmx_fid_ep, ep.fid);
 		if (mr->domain != ep->domain)
 			return -FI_EINVAL;
-		break;
-
-	case FI_CLASS_CQ:
-		cq = container_of(bfid, struct psmx_fid_cq, cq.fid);
-		if (mr->cq && mr->cq != cq)
-			return -FI_EBUSY;
-		if (mr->domain != cq->domain)
-			return -FI_EINVAL;
-		mr->cq = cq;
 		break;
 
 	case FI_CLASS_CNTR:

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -104,24 +104,6 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			rma_addr += mr->offset;
 			memcpy(rma_addr, src, len);
 			if (eom) {
-				if (mr->cq) {
-					/* TODO: report the addr/len of the whole write */
-					event = psmx_cq_create_event(
-							mr->cq,
-							0, /* context */
-							rma_addr,
-							FI_REMOTE_WRITE | FI_RMA | (has_data ? FI_REMOTE_CQ_DATA : 0),
-							rma_len,
-							has_data ? args[4].u64 : 0,
-							0, /* tag */
-							0, /* olen */
-							0);
-
-					if (event)
-						psmx_cq_enqueue_event(mr->cq, event);
-					else
-						err = -FI_ENOMEM;
-				}
 				if (mr->domain->rma_ep->recv_cq && has_data) {
 					/* TODO: report the addr/len of the whole write */
 					event = psmx_cq_create_event(
@@ -385,23 +367,6 @@ static ssize_t psmx_rma_self(int am_cmd,
 
 		memcpy(dst, src, len);
 
-		if (mr->cq && am_cmd == PSMX_AM_REQ_WRITE) {
-			event = psmx_cq_create_event(
-					mr->cq,
-					0, /* context */
-					(void *)addr,
-					FI_REMOTE_WRITE | FI_RMA | (flags & FI_REMOTE_CQ_DATA),
-					len,
-					flags & FI_REMOTE_CQ_DATA ? data : 0,
-					0, /* tag */
-					0, /* olen */
-					0 /* err */);
-
-			if (event)
-				psmx_cq_enqueue_event(mr->cq, event);
-			else
-				err = -FI_ENOMEM;
-		}
 		if (mr->domain->rma_ep->recv_cq &&
 		    am_cmd == PSMX_AM_REQ_WRITE &&
 		    (flags & FI_REMOTE_CQ_DATA)) {


### PR DESCRIPTION
(1) Remove MR to CQ bindings. Plain RMA operations no longer generate completions on CQ.
(2) RMA write with data generates completion on recv CQ bound to the EP
(3) Counters can still be bound to EP and/or MR to track incoming RMA operations
(4) No duplicated update if the same counter is bound to both EP and MR