### PR TITLE
prov/psm: set the op_context of incoming RMA ops to NULL

### DIFF
--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -182,12 +182,12 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 		flags = FI_WRITE | FI_RMA;
 		break;
 	case PSMX_REMOTE_READ_CONTEXT:
-		op_context = PSMX_CTXT_USER(fi_context);
+		op_context = NULL;
 		buf = NULL;
 		flags = FI_REMOTE_READ | FI_RMA;
 		break;
 	case PSMX_REMOTE_WRITE_CONTEXT:
-		op_context = PSMX_CTXT_USER(fi_context);
+		op_context = NULL;
 		buf = NULL;
 		flags = FI_REMOTE_WRITE | FI_RMA | FI_REMOTE_CQ_DATA;
 		break;


### PR DESCRIPTION
Previously it was set to the MR descriptor. However, there is no
definition on what value it should be and NULL context seems to be
a more general assumption made by applications.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>