### PR TITLE
atomic_t: attempt to catch missed initializations

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -622,7 +622,7 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		goto err;
 	}
 
-	atomic_init(&_av->ref, 0);
+	atomic_initialize(&_av->ref, 0);
 	atomic_inc(&dom->ref);
 	_av->domain = dom;
 	switch (dom->info.addr_format) {

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -358,11 +358,11 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	pthread_mutex_init(&_cntr->mut, NULL);
 	fastlock_init(&_cntr->list_lock);
 
-	atomic_init(&_cntr->ref, 0);
-	atomic_init(&_cntr->err_cnt, 0);
+	atomic_initialize(&_cntr->ref, 0);
+	atomic_initialize(&_cntr->err_cnt, 0);
 
-	atomic_init(&_cntr->value, 0);
-	atomic_init(&_cntr->threshold, ~0);
+	atomic_initialize(&_cntr->value, 0);
+	atomic_initialize(&_cntr->threshold, ~0);
 
 	dlist_init(&_cntr->tx_list);
 	dlist_init(&_cntr->rx_list);

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -461,7 +461,7 @@ int sock_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (!sock_cq)
 		return -FI_ENOMEM;
 	
-	atomic_init(&sock_cq->ref, 0);
+	atomic_initialize(&sock_cq->ref, 0);
 	sock_cq->cq_fid.fid.fclass = FI_CLASS_CQ;
 	sock_cq->cq_fid.fid.context = context;
 	sock_cq->cq_fid.fid.ops = &sock_cq_fi_ops;

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -460,7 +460,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_ENOMEM;
 
 	fastlock_init(&sock_domain->lock);
-	atomic_init(&sock_domain->ref, 0);
+	atomic_initialize(&sock_domain->ref, 0);
 
 	if (info) {
 		sock_domain->info = *info;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1403,9 +1403,9 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 		sock_ep->info.handle = info->handle;
 	}
 	
-	atomic_init(&sock_ep->ref, 0);
-	atomic_init(&sock_ep->num_tx_ctx, 0);
-	atomic_init(&sock_ep->num_rx_ctx, 0);
+	atomic_initialize(&sock_ep->ref, 0);
+	atomic_initialize(&sock_ep->num_tx_ctx, 0);
+	atomic_initialize(&sock_ep->num_rx_ctx, 0);
 
 	if (sock_ep->ep_attr.tx_ctx_cnt == FI_SHARED_CONTEXT)
 		sock_ep->tx_shared = 1;

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -319,7 +319,7 @@ static int sock_fabric(struct fi_fabric_attr *attr,
 	fab->fab_fid.fid.ops = &sock_fab_fi_ops;
 	fab->fab_fid.ops = &sock_fab_ops;
 	*fabric = &fab->fab_fid;
-	atomic_init(&fab->ref, 0);
+	atomic_initialize(&fab->ref, 0);
 	sock_fab_add_to_list(fab);
 	return 0;
 }

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -590,9 +590,9 @@ usdf_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	av->av_flags = attr->flags;
 
 	pthread_spin_init(&av->av_lock, PTHREAD_PROCESS_PRIVATE);
-	atomic_init(&av->av_active_inserts, 0);
+	atomic_initialize(&av->av_active_inserts, 0);
 
-	atomic_init(&av->av_refcnt, 0);
+	atomic_initialize(&av->av_refcnt, 0);
 	atomic_inc(&udp->dom_refcnt);
 	av->av_domain = udp;
 

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -810,7 +810,7 @@ usdf_cq_make_soft(struct usdf_cq *cq)
 			hcq->cqh_ucq = ucq;
 			hcq->cqh_progress = rtn;
 
-			atomic_init(&hcq->cqh_refcnt,
+			atomic_initialize(&hcq->cqh_refcnt,
 					atomic_get(&cq->cq_refcnt));
 			TAILQ_INSERT_HEAD(&cq->c.soft.cq_list, hcq, cqh_link);
 		}
@@ -876,7 +876,7 @@ usdf_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	cq->cq_fid.fid.fclass = FI_CLASS_CQ;
 	cq->cq_fid.fid.context = context;
 	cq->cq_fid.fid.ops = &usdf_cq_fi_ops;
-	atomic_init(&cq->cq_refcnt, 0);
+	atomic_initialize(&cq->cq_refcnt, 0);
 
 	switch (attr->format) {
 	case FI_CQ_FORMAT_CONTEXT:

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -132,7 +132,7 @@ usdf_dom_rdc_alloc_data(struct usdf_domain *udp)
 		return -FI_ENOMEM;
 	}
 	SLIST_INIT(&udp->dom_rdc_free);
-	atomic_init(&udp->dom_rdc_free_cnt, 0);
+	atomic_initialize(&udp->dom_rdc_free_cnt, 0);
 	for (i = 0; i < USDF_RDM_FREE_BLOCK; ++i) {
 		rdc = calloc(1, sizeof(*rdc));
 		if (rdc == NULL) {
@@ -297,7 +297,7 @@ usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	udp->dom_fabric = fp;
 	LIST_INSERT_HEAD(&fp->fab_domain_list, udp, dom_link);
-	atomic_init(&udp->dom_refcnt, 0);
+	atomic_initialize(&udp->dom_refcnt, 0);
 	atomic_inc(&fp->fab_refcnt);
 
 	*domain = &udp->dom_fid;

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -444,7 +444,7 @@ usdf_ep_dgram_open(struct fid_domain *domain, struct fi_info *info,
 		ep->ep_fid.ops = &usdf_base_dgram_ops;
 		ep->ep_fid.msg = &usdf_dgram_ops;
 	}
-	atomic_init(&ep->ep_refcnt, 0);
+	atomic_initialize(&ep->ep_refcnt, 0);
 	atomic_inc(&udp->dom_refcnt);
 
 	*ep_o = ep_utof(ep);

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -426,7 +426,7 @@ usdf_ep_msg_bind_cq(struct usdf_ep *ep, struct usdf_cq *cq, uint64_t flags)
 			goto fail;
 		}
 		hcq->cqh_cq = cq;
-		atomic_init(&hcq->cqh_refcnt, 0);
+		atomic_initialize(&hcq->cqh_refcnt, 0);
 		hcq->cqh_progress = usdf_msg_hcq_progress;
 		switch (cq->cq_attr.format) {
 		default:
@@ -727,7 +727,7 @@ usdf_ep_msg_open(struct fid_domain *domain, struct fi_info *info,
 			goto fail;
 		}
 		tx->tx_fid.fid.fclass = FI_CLASS_TX_CTX;
-		atomic_init(&tx->tx_refcnt, 0);
+		atomic_initialize(&tx->tx_refcnt, 0);
 		tx->tx_domain = udp;
 		tx->tx_progress = usdf_msg_tx_progress;
 		atomic_inc(&udp->dom_refcnt);
@@ -762,7 +762,7 @@ usdf_ep_msg_open(struct fid_domain *domain, struct fi_info *info,
 			goto fail;
 		}
 		rx->rx_fid.fid.fclass = FI_CLASS_RX_CTX;
-		atomic_init(&rx->rx_refcnt, 0);
+		atomic_initialize(&rx->rx_refcnt, 0);
 		rx->rx_domain = udp;
 		atomic_inc(&udp->dom_refcnt);
 		if (info->rx_attr != NULL) {
@@ -781,7 +781,7 @@ usdf_ep_msg_open(struct fid_domain *domain, struct fi_info *info,
 		atomic_inc(&rx->rx_refcnt);
 	}
 
-	atomic_init(&ep->ep_refcnt, 0);
+	atomic_initialize(&ep->ep_refcnt, 0);
 	atomic_inc(&udp->dom_refcnt);
 
 	*ep_o = ep_utof(ep);

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -415,7 +415,7 @@ usdf_ep_rdm_bind_cq(struct usdf_ep *ep, struct usdf_cq *cq, uint64_t flags)
 			goto fail;
 		}
 		hcq->cqh_cq = cq;
-		atomic_init(&hcq->cqh_refcnt, 0);
+		atomic_initialize(&hcq->cqh_refcnt, 0);
 		hcq->cqh_progress = usdf_rdm_hcq_progress;
 		switch (cq->cq_attr.format) {
 		default:
@@ -761,10 +761,10 @@ usdf_ep_rdm_open(struct fid_domain *domain, struct fi_info *info,
 			goto fail;
 		}
 		tx->tx_fid.fid.fclass = FI_CLASS_TX_CTX;
-		atomic_init(&tx->tx_refcnt, 0);
+		atomic_initialize(&tx->tx_refcnt, 0);
 		tx->tx_domain = udp;
 		tx->tx_progress = usdf_rdm_tx_progress;
-		atomic_init(&tx->t.rdm.tx_next_msg_id, 1);
+		atomic_initialize(&tx->t.rdm.tx_next_msg_id, 1);
 		atomic_inc(&udp->dom_refcnt);
 
 		if (info->tx_attr != NULL) {
@@ -797,7 +797,7 @@ usdf_ep_rdm_open(struct fid_domain *domain, struct fi_info *info,
 		}
 
 		rx->rx_fid.fid.fclass = FI_CLASS_RX_CTX;
-		atomic_init(&rx->rx_refcnt, 0);
+		atomic_initialize(&rx->rx_refcnt, 0);
 		rx->rx_domain = udp;
 		rx->r.rdm.rx_tx = tx;
 		rx->r.rdm.rx_sock = -1;
@@ -827,7 +827,7 @@ usdf_ep_rdm_open(struct fid_domain *domain, struct fi_info *info,
 		atomic_inc(&rx->rx_refcnt);
 	}
 
-	atomic_init(&ep->ep_refcnt, 0);
+	atomic_initialize(&ep->ep_refcnt, 0);
 	atomic_inc(&udp->dom_refcnt);
 
 	*ep_o = ep_utof(ep);

--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -529,7 +529,7 @@ usdf_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	eq->eq_wait_obj = attr->wait_obj;
 
 	eq->eq_fabric = fab;
-	atomic_init(&eq->eq_refcnt, 0);
+	atomic_initialize(&eq->eq_refcnt, 0);
 	ret = pthread_spin_init(&eq->eq_lock, PTHREAD_PROCESS_PRIVATE);
 	if (ret != 0) {
 		ret = -ret;
@@ -588,7 +588,7 @@ usdf_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	eq->eq_ev_tail = eq->eq_ev_ring;
 	eq->eq_ev_ring_size = attr->size;
 	eq->eq_ev_end = eq->eq_ev_ring + eq->eq_ev_ring_size;
-	atomic_init(&eq->eq_num_events, 0);
+	atomic_initialize(&eq->eq_num_events, 0);
 
 	atomic_inc(&eq->eq_fabric->fab_refcnt);
 	*feq = eq_utof(eq);

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -988,7 +988,7 @@ usdf_fabric_open(struct fi_fabric_attr *fattrp, struct fid_fabric **fabric,
 		goto fail;
 	}
 
-	atomic_init(&fp->fab_refcnt, 0);
+	atomic_initialize(&fp->fab_refcnt, 0);
 	fattrp->fabric = fab_utof(fp);
 	fattrp->prov_version = USDF_PROV_VERSION;
 	*fabric = fab_utof(fp);

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -533,7 +533,7 @@ usdf_pep_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto fail;
 	}
 
-	atomic_init(&pep->pep_refcnt, 0);
+	atomic_initialize(&pep->pep_refcnt, 0);
 	atomic_inc(&fp->fab_refcnt);
 
 	*pep_o = pep_utof(pep);


### PR DESCRIPTION
When !defined(HAVE_ATOMICS), fi.h falls back to using "fastlock"s to
implement the atomicity.  If those fastlocks are implemented with
pthread spinlocks on x86_64 Linux then failing to initialize the
spinlock can lead to an infinite hang.  This already happened in the
usnic provider (see PR #870).

The debug error check in this commit is an imperfect scheme, but it
should catch the most common case where a caller callocs the storage
containing the atomic_t.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>