### PR TITLE
man/domain: Define cq_cnt attribute as an optimal value

### DIFF
--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -406,7 +406,7 @@ at least 4-bytes.
 
 ## Completion Queue Count (cq_cnt)
 
-The total number of completion queues supported by the domain, relative
+The optimal number of completion queues supported by the domain, relative
 to any specified or default CQ attributes.  The cq_cnt value may be a
 fixed value of the maximum number of CQs supported by the
 underlying provider, or may be a dynamic value, based on the default


### PR DESCRIPTION
The cq_cnt is not a maximum, but an optimal minimum value.  By
indicating that it is an optimal value, relative to system
defaults, a resource manager can make better decisions on how
CQs may be allocated.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>