### PR TITLE
prov/sockets

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -66,6 +66,7 @@
 #define SOCK_EP_MAX_ORDER_WAW_SZ SOCK_EP_MAX_MSG_SZ
 #define SOCK_EP_MEM_TAG_FMT (0)
 #define SOCK_EP_MAX_EP_CNT (128)
+#define SOCK_EP_MAX_CQ_CNT (32)
 #define SOCK_EP_MAX_TX_CNT (16)
 #define SOCK_EP_MAX_RX_CNT (16)
 #define SOCK_EP_MAX_IOV_LIMIT (8)
@@ -136,6 +137,7 @@ struct sock_fabric {
 	struct fid_fabric fab_fid;
 	atomic_t ref;
 	struct dlist_entry service_list;
+	struct dlist_entry fab_list_entry;
 	fastlock_t lock;
 };
 
@@ -171,6 +173,8 @@ struct sock_domain {
 	struct index_map mr_idm;
 	struct sock_pe *pe;
 	struct sock_conn_map r_cmap;
+	struct dlist_entry dom_list_entry;
+	struct fi_domain_attr attr;
 };
 
 struct sock_cntr {
@@ -818,6 +822,15 @@ void sock_fabric_add_service(struct sock_fabric *fab, int service);
 void sock_fabric_remove_service(struct sock_fabric *fab, int service);
 int sock_fabric_check_service(struct sock_fabric *fab, int service);
 
+void sock_dom_add_to_list(struct sock_domain *domain);
+int sock_dom_check_list(struct sock_domain *domain);
+void sock_dom_remove_from_list(struct sock_domain *domain);
+struct sock_domain *sock_dom_list_head(void);
+
+void sock_fab_add_to_list(struct sock_fabric *fabric);
+int sock_fab_check_list(struct sock_fabric *fabric);
+void sock_fab_remove_from_list(struct sock_fabric *fabric);
+struct sock_fabric *sock_fab_list_head(void);
 
 int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 			struct sock_ep **ep, void *context, size_t fclass);

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -77,6 +77,7 @@
 #define SOCK_EP_MIN_MULTI_RECV (64)
 #define SOCK_EP_MAX_ATOMIC_SZ (256)
 #define SOCK_EP_MAX_CTX_BITS (16)
+#define SOCK_EP_MSG_PREFIX_SZ (0)
 
 #define SOCK_PE_POLL_TIMEOUT (100000)
 #define SOCK_PE_MAX_ENTRIES (128)
@@ -114,6 +115,8 @@
 			   FI_ORDER_WAR | FI_ORDER_WAW | FI_ORDER_WAS |	\
 			   FI_ORDER_SAR | FI_ORDER_SAW | FI_ORDER_SAS)
 
+#define SOCK_EP_COMP_ORDER (FI_ORDER_STRICT | FI_ORDER_DATA)
+
 #define SOCK_MODE (0)
 #define SOCK_NO_COMPLETION (1ULL << 60)
 
@@ -127,6 +130,8 @@ enum {
 
 #define SOCK_MAJOR_VERSION 1
 #define SOCK_MINOR_VERSION 0
+
+#define SOCK_WIRE_PROTO_VERSION (0)
 
 struct sock_service_entry {
 	int service;
@@ -559,8 +564,6 @@ struct sock_tx_ctx {
 
 	struct fi_tx_attr attr;
 };
-
-#define SOCK_WIRE_PROTO_VERSION (0)
 
 struct sock_msg_hdr {
 	uint8_t version;

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -514,6 +514,10 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		return -FI_EINVAL;
 	
 	dom = container_of(domain, struct sock_domain, dom_fid);
+	if (dom->attr.av_type != FI_AV_UNSPEC && attr &&
+	    dom->attr.av_type != attr->type)
+		return -FI_EINVAL;
+
 	_av = calloc(1, sizeof(*_av));
 	if (!_av)
 		return -FI_ENOMEM;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -70,7 +70,7 @@ const struct fi_rx_attr sock_srx_attr = {
 	.caps = SOCK_EP_RDM_CAP,
 	.op_flags = 0,
 	.msg_order = SOCK_EP_MSG_ORDER,
-	.total_buffered_recv = SOCK_EP_MAX_BUFF_RECV,
+	.total_buffered_recv = 0,
 	.size = SOCK_EP_MAX_MSG_SZ,
 	.iov_limit = SOCK_EP_MAX_IOV_LIMIT,
 };
@@ -1074,9 +1074,6 @@ static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 	if (!rx_ctx)
 		return -FI_ENOMEM;
 
-	rx_ctx->attr.total_buffered_recv = rx_ctx->attr.total_buffered_recv ?
-		rx_ctx->attr.total_buffered_recv : SOCK_EP_MAX_BUFF_RECV;
-	
 	rx_ctx->rx_id = index;
 	rx_ctx->ep = sock_ep;
 	rx_ctx->domain = sock_ep->domain;
@@ -1190,10 +1187,7 @@ int sock_srx_ctx(struct fid_domain *domain,
 	rx_ctx->ctx.tagged = &sock_ep_tagged;
 	
 	/* default config */
-	rx_ctx->min_multi_recv = SOCK_EP_MIN_MULTI_RECV;
-	rx_ctx->attr.total_buffered_recv = rx_ctx->attr.total_buffered_recv ?
-		rx_ctx->attr.total_buffered_recv : SOCK_EP_MAX_BUFF_RECV;
-	
+	rx_ctx->min_multi_recv = SOCK_EP_MIN_MULTI_RECV;	
 	*srx = &rx_ctx->ctx;
 	atomic_inc(&dom->ref);
 	return 0;
@@ -1395,10 +1389,6 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 		if (info->rx_attr) {
 			sock_ep->rx_attr = *info->rx_attr;
 			sock_ep->op_flags |= info->rx_attr->op_flags;
-			sock_ep->rx_attr.total_buffered_recv = 
-				sock_ep->rx_attr.total_buffered_recv ?
-				sock_ep->rx_attr.total_buffered_recv : 
-				SOCK_EP_MAX_BUFF_RECV;
 		}
 		sock_ep->info.connreq = info->connreq;
 	}

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1037,7 +1037,7 @@ static int sock_ep_tx_ctx(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
 	struct sock_tx_ctx *tx_ctx;
 
 	sock_ep = container_of(ep, struct sock_ep, ep);
-	if (index >= sock_ep->ep_attr.tx_ctx_cnt)
+	if (sock_ep->fclass != FI_CLASS_SEP || index >= sock_ep->ep_attr.tx_ctx_cnt)
 		return -FI_EINVAL;
 
 	tx_ctx = sock_tx_ctx_alloc(&sock_ep->tx_attr, context);
@@ -1071,7 +1071,7 @@ static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 	struct sock_rx_ctx *rx_ctx;
 
 	sock_ep = container_of(ep, struct sock_ep, ep);
-	if (index >= sock_ep->ep_attr.rx_ctx_cnt)
+	if (sock_ep->fclass != FI_CLASS_SEP || index >= sock_ep->ep_attr.rx_ctx_cnt)
 		return -FI_EINVAL;
 
 	rx_ctx = sock_rx_ctx_alloc(attr ? attr : &sock_ep->rx_attr, context);

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -61,7 +61,9 @@
 const struct fi_ep_attr sock_dgram_ep_attr = {
 	.type = FI_EP_DGRAM,
 	.protocol = FI_PROTO_SOCK_TCP,
+	.protocol_version = SOCK_WIRE_PROTO_VERSION,
 	.max_msg_size = SOCK_EP_MAX_MSG_SZ,
+	.msg_prefix_size = SOCK_EP_MSG_PREFIX_SZ,
 	.max_order_raw_size = SOCK_EP_MAX_ORDER_RAW_SZ,
 	.max_order_war_size = SOCK_EP_MAX_ORDER_WAR_SZ,
 	.max_order_waw_size = SOCK_EP_MAX_ORDER_WAW_SZ,
@@ -72,17 +74,21 @@ const struct fi_ep_attr sock_dgram_ep_attr = {
 
 const struct fi_tx_attr sock_dgram_tx_attr = {
 	.caps = SOCK_EP_DGRAM_CAP,
+	.mode = SOCK_MODE,
 	.op_flags = FI_TRANSMIT_COMPLETE,
 	.msg_order = SOCK_EP_MSG_ORDER,
 	.inject_size = SOCK_EP_MAX_INJECT_SZ,
 	.size = SOCK_EP_TX_SZ,
 	.iov_limit = SOCK_EP_MAX_IOV_LIMIT,
+	.rma_iov_limit = 0,
 };
 
 const struct fi_rx_attr sock_dgram_rx_attr = {
 	.caps = SOCK_EP_DGRAM_CAP,
+	.mode = SOCK_MODE,
 	.op_flags = 0,
 	.msg_order = SOCK_EP_MSG_ORDER,
+	.comp_order = SOCK_EP_COMP_ORDER,
 	.total_buffered_recv = SOCK_EP_MAX_BUFF_RECV,
 	.size = SOCK_EP_RX_SZ,
 	.iov_limit = SOCK_EP_MAX_IOV_LIMIT,
@@ -97,6 +103,9 @@ static int sock_dgram_verify_rx_attr(const struct fi_rx_attr *attr)
 		return -FI_ENODATA;
 
 	if ((attr->msg_order | SOCK_EP_MSG_ORDER) != SOCK_EP_MSG_ORDER)
+		return -FI_ENODATA;
+
+	if ((attr->comp_order | SOCK_EP_COMP_ORDER) != SOCK_EP_COMP_ORDER)
 		return -FI_ENODATA;
 
 	if (attr->total_buffered_recv > sock_dgram_rx_attr.total_buffered_recv)
@@ -131,6 +140,9 @@ static int sock_dgram_verify_tx_attr(const struct fi_tx_attr *attr)
 	if (attr->iov_limit > sock_dgram_tx_attr.iov_limit)
 		return -FI_ENODATA;
 
+	if (attr->rma_iov_limit > sock_dgram_tx_attr.rma_iov_limit)
+		return -FI_ENODATA;
+
 	return 0;
 }
 
@@ -147,7 +159,13 @@ int sock_dgram_verify_ep_attr(struct fi_ep_attr *ep_attr,
 			return -FI_ENODATA;
 		}
 
+		if (ep_attr->protocol_version != sock_dgram_ep_attr.protocol_version)
+			return -FI_ENODATA;
+		
 		if (ep_attr->max_msg_size > sock_dgram_ep_attr.max_msg_size)
+			return -FI_ENODATA;
+
+		if (ep_attr->msg_prefix_size > sock_dgram_ep_attr.msg_prefix_size)
 			return -FI_ENODATA;
 
 		if (ep_attr->max_order_raw_size >

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -63,7 +63,9 @@
 static const struct fi_ep_attr sock_msg_ep_attr = {
 	.type = FI_EP_MSG,
 	.protocol = FI_PROTO_SOCK_TCP,
+	.protocol_version = SOCK_WIRE_PROTO_VERSION,
 	.max_msg_size = SOCK_EP_MAX_MSG_SZ,
+	.msg_prefix_size = SOCK_EP_MSG_PREFIX_SZ,
 	.max_order_raw_size = SOCK_EP_MAX_ORDER_RAW_SZ,
 	.max_order_war_size = SOCK_EP_MAX_ORDER_WAR_SZ,
 	.max_order_waw_size = SOCK_EP_MAX_ORDER_WAW_SZ,
@@ -74,17 +76,21 @@ static const struct fi_ep_attr sock_msg_ep_attr = {
 
 static const struct fi_tx_attr sock_msg_tx_attr = {
 	.caps = SOCK_EP_MSG_CAP,
+	.mode = SOCK_MODE,
 	.op_flags = FI_TRANSMIT_COMPLETE,
 	.msg_order = SOCK_EP_MSG_ORDER,
 	.inject_size = SOCK_EP_MAX_INJECT_SZ,
 	.size = SOCK_EP_TX_SZ,
 	.iov_limit = SOCK_EP_MAX_IOV_LIMIT,
+	.rma_iov_limit = SOCK_EP_MAX_IOV_LIMIT,
 };
 
 static const struct fi_rx_attr sock_msg_rx_attr = {
 	.caps = SOCK_EP_MSG_CAP,
+	.mode = SOCK_MODE,
 	.op_flags = 0,
 	.msg_order = SOCK_EP_MSG_ORDER,
+	.comp_order = SOCK_EP_COMP_ORDER,
 	.total_buffered_recv = SOCK_EP_MAX_BUFF_RECV,
 	.size = SOCK_EP_RX_SZ,
 	.iov_limit = SOCK_EP_MAX_IOV_LIMIT,
@@ -99,6 +105,9 @@ static int sock_msg_verify_rx_attr(const struct fi_rx_attr *attr)
 		return -FI_ENODATA;
 
 	if ((attr->msg_order | SOCK_EP_MSG_ORDER) != SOCK_EP_MSG_ORDER)
+		return -FI_ENODATA;
+
+	if ((attr->comp_order | SOCK_EP_COMP_ORDER) != SOCK_EP_COMP_ORDER)
 		return -FI_ENODATA;
 
 	if (attr->total_buffered_recv > sock_msg_rx_attr.total_buffered_recv)
@@ -133,6 +142,9 @@ static int sock_msg_verify_tx_attr(const struct fi_tx_attr *attr)
 	if (attr->iov_limit > sock_msg_tx_attr.iov_limit)
 		return -FI_ENODATA;
 
+	if (attr->rma_iov_limit > sock_msg_tx_attr.rma_iov_limit)
+		return -FI_ENODATA;
+
 	return 0;
 }
 
@@ -149,7 +161,13 @@ int sock_msg_verify_ep_attr(struct fi_ep_attr *ep_attr,
 			return -FI_ENODATA;
 		}
 
+		if (ep_attr->protocol_version != sock_msg_ep_attr.protocol_version)
+			return -FI_ENODATA;
+
 		if (ep_attr->max_msg_size > sock_msg_ep_attr.max_msg_size)
+			return -FI_ENODATA;
+
+		if (ep_attr->msg_prefix_size > sock_msg_ep_attr.msg_prefix_size)
 			return -FI_ENODATA;
 
 		if (ep_attr->max_order_raw_size >

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -62,7 +62,9 @@
 const struct fi_ep_attr sock_rdm_ep_attr = {
 	.type = FI_EP_RDM,
 	.protocol = FI_PROTO_SOCK_TCP,
+	.protocol_version = SOCK_WIRE_PROTO_VERSION,
 	.max_msg_size = SOCK_EP_MAX_MSG_SZ,
+	.msg_prefix_size = SOCK_EP_MSG_PREFIX_SZ,
 	.max_order_raw_size = SOCK_EP_MAX_ORDER_RAW_SZ,
 	.max_order_war_size = SOCK_EP_MAX_ORDER_WAR_SZ,
 	.max_order_waw_size = SOCK_EP_MAX_ORDER_WAW_SZ,
@@ -73,17 +75,21 @@ const struct fi_ep_attr sock_rdm_ep_attr = {
 
 const struct fi_tx_attr sock_rdm_tx_attr = {
 	.caps = SOCK_EP_RDM_CAP,
+	.mode = SOCK_MODE,
 	.op_flags = FI_TRANSMIT_COMPLETE,
 	.msg_order = SOCK_EP_MSG_ORDER,
 	.inject_size = SOCK_EP_MAX_INJECT_SZ,
 	.size = SOCK_EP_TX_SZ,
 	.iov_limit = SOCK_EP_MAX_IOV_LIMIT,
+	.rma_iov_limit = SOCK_EP_MAX_IOV_LIMIT,
 };
 
 const struct fi_rx_attr sock_rdm_rx_attr = {
 	.caps = SOCK_EP_RDM_CAP,
+	.mode = SOCK_MODE,
 	.op_flags = 0,
 	.msg_order = SOCK_EP_MSG_ORDER,
+	.comp_order = SOCK_EP_COMP_ORDER,
 	.total_buffered_recv = SOCK_EP_MAX_BUFF_RECV,
 	.size = SOCK_EP_RX_SZ,
 	.iov_limit = SOCK_EP_MAX_IOV_LIMIT,
@@ -101,6 +107,11 @@ static int sock_rdm_verify_rx_attr(const struct fi_rx_attr *attr)
 
 	if ((attr->msg_order | SOCK_EP_MSG_ORDER) != SOCK_EP_MSG_ORDER) {
 		SOCK_LOG_INFO("Unsuported rx message order\n");
+		return -FI_ENODATA;
+	}
+
+	if ((attr->comp_order | SOCK_EP_COMP_ORDER) != SOCK_EP_COMP_ORDER) {
+		SOCK_LOG_INFO("Unsuported rx completion order\n");
 		return -FI_ENODATA;
 	}
 
@@ -152,6 +163,11 @@ static int sock_rdm_verify_tx_attr(const struct fi_tx_attr *attr)
 		return -FI_ENODATA;
 	}
 
+	if (attr->rma_iov_limit > sock_rdm_tx_attr.rma_iov_limit) {
+		SOCK_LOG_INFO("RMA iov limit too large\n");
+		return -FI_ENODATA;
+	}
+
 	return 0;
 }
 
@@ -171,8 +187,18 @@ int sock_rdm_verify_ep_attr(struct fi_ep_attr *ep_attr,
 			return -FI_ENODATA;
 		}
 
+		if (ep_attr->protocol_version != sock_rdm_ep_attr.protocol_version) {
+			SOCK_LOG_INFO("Invalid protocol version\n");
+			return -FI_ENODATA;
+		}
+
 		if (ep_attr->max_msg_size > sock_rdm_ep_attr.max_msg_size) {
 			SOCK_LOG_INFO("Message size too large\n");
+			return -FI_ENODATA;
+		}
+
+		if (ep_attr->msg_prefix_size > sock_rdm_ep_attr.msg_prefix_size) {
+			SOCK_LOG_INFO("Msg prefix size not supported\n");
 			return -FI_ENODATA;
 		}
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2242,8 +2242,6 @@ do_wait:
 	FD_SET(pe->signal_fds[SOCK_SIGNAL_RD_FD], &rfds);
 	max_fds = MAX(pe->signal_fds[SOCK_SIGNAL_RD_FD], max_fds);
 	
-	SOCK_LOG_ERROR("Entering select : %d: %d\n", max_fds, 
-		       pe->signal_fds[SOCK_SIGNAL_RD_FD]);
 	if (select(max_fds + 1, &rfds, NULL, NULL, NULL) < 0) {
 		SOCK_LOG_ERROR ("select failed\n");
 		return;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2191,10 +2191,10 @@ static void sock_pe_poll(struct sock_pe *pe)
 	struct sock_conn_map *map;
 	struct sock_conn *conn;
 
+	FD_ZERO(&rfds);
 	if (dlistfd_empty(&pe->tx_list) && dlistfd_empty(&pe->rx_list))
 		goto do_wait;
 
-	FD_ZERO(&rfds);
 	pthread_mutex_lock(&pe->list_lock);
 	if (!dlistfd_empty(&pe->tx_list)) {
 		for (entry = pe->tx_list.list.next;

--- a/prov/sockets/src/sock_rx_entry.c
+++ b/prov/sockets/src/sock_rx_entry.c
@@ -81,8 +81,7 @@ struct sock_rx_entry *sock_rx_new_buffered_entry(struct sock_rx_ctx *rx_ctx,
 	struct sock_rx_entry *rx_entry;
 
 	if (rx_ctx->buffered_len + len >= rx_ctx->attr.total_buffered_recv) {
-		SOCK_LOG_ERROR("Reached max buffered recv limit\n");
-		return NULL;
+		SOCK_LOG_ERROR("Exceeded buffered recv limit\n");
 	}
 
 	rx_entry = calloc(1, sizeof(*rx_entry) + len);


### PR DESCRIPTION
- Add support for domain_attr::domain, fabric_attr::fabric
- Add check for AV type during av-open
- Disable buffered-recv by default
- Coverity scan fixes
- Updated EP/TX/RX attribute verifications
- Add check for ep-type during tx/rx creation