### PR TITLE
Enhance support for sockets over OFI

### DIFF
--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -150,6 +150,7 @@ int fi_no_atomic_compwritevalid(struct fid_ep *ep,
 /*
 static struct fi_ops_cm X = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = fi_no_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,
@@ -159,6 +160,7 @@ static struct fi_ops_cm X = {
 	.shutdown = fi_no_shutdown,
 };
 */
+int fi_no_setname(fid_t fid, void *addr, size_t *addrlen);
 int fi_no_getname(fid_t fid, void *addr, size_t *addrlen);
 int fi_no_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen);
 int fi_no_connect(struct fid_ep *ep, const void *addr,

--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -165,7 +165,7 @@ int fi_no_connect(struct fid_ep *ep, const void *addr,
 		const void *param, size_t paramlen);
 int fi_no_listen(struct fid_pep *pep);
 int fi_no_accept(struct fid_ep *ep, const void *param, size_t paramlen);
-int fi_no_reject(struct fid_pep *pep, fi_connreq_t connreq,
+int fi_no_reject(struct fid_pep *pep, fid_t handle,
 		const void *param, size_t paramlen);
 int fi_no_shutdown(struct fid_ep *ep, uint64_t flags);
 

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -47,9 +47,6 @@ extern "C" {
 	((type *) ((char *)ptr - offsetof(type, field)))
 #endif
 
-#define FI_DEFINE_HANDLE(name) struct name##_s { int dummy; }; \
-				typedef struct name##_s *name
-
 enum {
 	FI_MAJOR_VERSION	= 1,
 	FI_MINOR_VERSION	= 0,
@@ -161,7 +158,6 @@ enum {
 #define FI_ADDR_NOTAVAIL	UINT64_MAX
 #define FI_SHARED_CONTEXT	(-(size_t)1)
 typedef uint64_t		fi_addr_t;
-FI_DEFINE_HANDLE(fi_connreq_t);
 
 enum fi_av_type {
 	FI_AV_UNSPEC,
@@ -305,7 +301,7 @@ struct fi_info {
 	size_t			dest_addrlen;
 	void			*src_addr;
 	void			*dest_addr;
-	fi_connreq_t		connreq;
+	fid_t			handle;
 	struct fi_tx_attr	*tx_attr;
 	struct fi_rx_attr	*rx_attr;
 	struct fi_ep_attr	*ep_attr;

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -327,7 +327,8 @@ enum {
 	FI_CLASS_CQ,
 	FI_CLASS_CNTR,
 	FI_CLASS_WAIT,
-	FI_CLASS_POLL
+	FI_CLASS_POLL,
+	FI_CLASS_CONNREQ
 };
 
 struct fi_eq_attr;

--- a/include/rdma/fi_cm.h
+++ b/include/rdma/fi_cm.h
@@ -49,7 +49,7 @@ struct fi_ops_cm {
 			const void *param, size_t paramlen);
 	int	(*listen)(struct fid_pep *pep);
 	int	(*accept)(struct fid_ep *ep, const void *param, size_t paramlen);
-	int	(*reject)(struct fid_pep *pep, fi_connreq_t connreq,
+	int	(*reject)(struct fid_pep *pep, fid_t handle,
 			const void *param, size_t paramlen);
 	int	(*shutdown)(struct fid_ep *ep, uint64_t flags);
 };
@@ -87,10 +87,10 @@ fi_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 }
 
 static inline int
-fi_reject(struct fid_pep *pep, fi_connreq_t connreq,
+fi_reject(struct fid_pep *pep, fid_t handle,
 	  const void *param, size_t paramlen)
 {
-	return pep->cm->reject(pep, connreq, param, paramlen);
+	return pep->cm->reject(pep, handle, param, paramlen);
 }
 
 static inline int fi_shutdown(struct fid_ep *ep, uint64_t flags)

--- a/include/rdma/fi_cm.h
+++ b/include/rdma/fi_cm.h
@@ -43,6 +43,7 @@ extern "C" {
 
 struct fi_ops_cm {
 	size_t	size;
+	int	(*setname)(fid_t fid, void *addr, size_t *addrlen);
 	int	(*getname)(fid_t fid, void *addr, size_t *addrlen);
 	int	(*getpeer)(struct fid_ep *ep, void *addr, size_t *addrlen);
 	int	(*connect)(struct fid_ep *ep, const void *addr,
@@ -56,6 +57,12 @@ struct fi_ops_cm {
 
 
 #ifndef FABRIC_DIRECT
+
+static inline int fi_setname(fid_t fid, void *addr, size_t *addrlen)
+{
+	struct fid_ep *ep = container_of(fid, struct fid_ep, fid);
+	return ep->cm->setname(fid, addr, addrlen);
+}
 
 static inline int fi_getname(fid_t fid, void *addr, size_t *addrlen)
 {

--- a/man/fi_cm.3.md
+++ b/man/fi_cm.3.md
@@ -27,7 +27,7 @@ int fi_listen(struct fid_pep *pep);
 
 int fi_accept(struct fid_ep *ep, const void *param, size_t paramlen);
 
-int fi_reject(struct fid_pep *pep, fi_connreq_t connreq,
+int fi_reject(struct fid_pep *pep, fid_t handle,
     const void *param, size_t paramlen);
 
 int fi_shutdown(struct fid_ep *ep, uint64_t flags);
@@ -96,7 +96,7 @@ respectively.  To accept a connection, the listening application first
 waits for a connection request event (FI_CONNREQ).
 After receiving such an event, the application
 allocates a new endpoint to accept the connection.  This endpoint must
-be allocated using an fi_info structure referencing the connreq from this
+be allocated using an fi_info structure referencing the handle from this
 FI_CONNREQ event.  fi_accept is then invoked
 with the newly allocated endpoint.  If
 the listening application wishes to reject a connection request, it calls

--- a/man/fi_cm.3.md
+++ b/man/fi_cm.3.md
@@ -12,8 +12,8 @@ fi_cm - Connection management operations
 fi_connect / fi_listen / fi_accept / fi_reject / fi_shutdown
 : Manage endpoint connection state.
 
-fi_getname / fi_getpeer
-: Return local or peer endpoint address
+fi_setname / fi_getname / fi_getpeer
+: Set local, or return local or peer endpoint address.
 
 # SYNOPSIS
 
@@ -32,6 +32,8 @@ int fi_reject(struct fid_pep *pep, fid_t handle,
 
 int fi_shutdown(struct fid_ep *ep, uint64_t flags);
 
+int fi_setname(fid_t fid, void *addr, size_t *addrlen);
+
 int fi_getname(fid_t fid, void *addr, size_t *addrlen);
 
 int fi_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen);
@@ -43,9 +45,11 @@ int fi_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen);
 : Fabric endpoint on which to change connection state.
 
 *addr*
-: Buffer to store queried address (get), or address to
-  connect.  The address must be in the same format as that
-  specified using fi_info: addr_format when the endpoint was created.
+: Buffer to address.  On a set call, the endpoint will be assigned the
+  specified address.  On a get, the local address will be copied into the
+  buffer, up to the space provided.  For connect, this parameter indicates
+  the peer address to connect to.  The address must be in the same format as
+  that specified using fi_info: addr_format when the endpoint was created.
 
 *addrlen*
 : On input, specifies size of addr buffer.  On output, stores number
@@ -141,6 +145,25 @@ Note that in the abrupt close case, an FI_SHUTDOWN event will only be
 generated if the peer system is reachable and a service or kernel agent
 on the peer system is able to notify the local endpoint that the connection
 has been aborted.
+
+## fi_setname
+
+The fi_setname call may be used to modify or assign the address of the
+local endpoint.  It is conceptually similar to the socket bind operation.
+An endpoint may be assigned an address on its creation,
+through the fi_info structure.  The fi_setname call allows an endpoint to
+be created without being associated with a specific service (i.e. port
+number) and/or node (i.e. network) address, with the addressing assigned
+dynamically.  The format of the specified addressing data must match that
+specified through the fi_info structure when the endpoint was created.
+
+If no service address is specified and a service address
+has not yet been assigned to the endpoint, then the provider will allocate
+a service address and assign it to the endpoint.  If a node or service
+address is specified, then, upon successful completion of fi_setname,
+the endpoint will be assigned the given addressing.  If an address cannot
+be assigned, or the endpoint address cannot be modified, an appropriate
+fabric error number is returned.
 
 ## fi_getname / fi_getpeer
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -157,9 +157,10 @@ ssize_t fi_tx_size_left(struct fid_ep *ep);
 
 Endpoints are transport level communication portals.  There are two
 types of endpoints: active and passive.  Passive endpoints belong to a
-fabric domain and are used to listen for incoming connection requests.
-Active endpoints belong to access domains and can perform data
-transfers.
+fabric domain and are most often used to listen for incoming connection requests.
+However, a passive endpoint may be used to reserve a fabric address that
+can be granted to an active endpoint.  Active endpoints belong to access
+domains and can perform data transfers.
 
 Active endpoints may be connection-oriented or connectionless, and may
 provide data reliability.  The data transfer interfaces -- messages (fi_msg),
@@ -203,8 +204,16 @@ provided struct fi_info.  See fi_getinfo for additional details on
 fi_info.  fi_info flags that control the operation of an endpoint are
 defined below. See section SCALABLE ENDPOINTS.
 
-If an active endpoint is associated with a connection request, the
-fi_info connreq must reference the corresponding request.
+If an active endpoint is allocated in order to accept a connection request,
+the fi_info parameter must be the same as the fi_info structure provided with
+the connection request (FI_CONNREQ) event.
+
+An active endpoint may acquire the properties of a passive endpoint by setting
+the fi_info handle field to the passive endpoint fabric descriptor.  This is
+useful for applications that need to reserve the fabric address of an
+endpoint prior to knowing if the endpoint will be used on the active or passive
+side of a connection.  For example, this feature is useful for simulating
+socket semantics.
 
 ## fi_close
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -168,10 +168,16 @@ struct fi_info {
   ignored in hints unless the node and service parameters are NULL or
   FI_SOURCE is specified.
 
-*handle - request context handle*
-: References a specific connection request handle, otherwise the field must
-  be NULL.  This field is used when processing connection requests and
-  responses.  See fi_eq(3), fi_reject(3), and fi_endpoint(3).
+*handle - provider context handle*
+: References a provider specific handle.  The use of this field
+  is operation specific.  Unless its use is described for a given operation,
+  the handle field must be NULL.  It is commonly used by applications
+  that make use of connection-oriented endpoints.  For other applications,
+  the field should usually be NULL.
+
+  This field is used when processing connection requests and
+  responses.  It is also used to inherit endpoint's attributes.
+  See fi_eq(3), fi_reject(3), and fi_endpoint(3) .
 
 *tx_attr - transmit context attributes*
 : Optionally supplied transmit context attributes.  Transmit context

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -119,9 +119,9 @@ struct fi_info {
 	size_t                dest_addrlen;
 	void                  *src_addr;
 	void                  *dest_addr;
-	fi_connreq_t          connreq;
-	struct fi_tx_attr *tx_attr;
-	struct fi_rx_attr *rx_attr;
+	fid_t                 handle;
+	struct fi_tx_attr     *tx_attr;
+	struct fi_rx_attr     *rx_attr;
 	struct fi_ep_attr     *ep_attr;
 	struct fi_domain_attr *domain_attr;
 	struct fi_fabric_attr *fabric_attr;
@@ -168,8 +168,8 @@ struct fi_info {
   ignored in hints unless the node and service parameters are NULL or
   FI_SOURCE is specified.
 
-*connreq - connection request*
-: References a specific connection request, otherwise the field must
+*handle - request context handle*
+: References a specific connection request handle, otherwise the field must
   be NULL.  This field is used when processing connection requests and
   responses.  See fi_eq(3), fi_reject(3), and fi_endpoint(3).
 

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -796,6 +796,11 @@ enum {
 	SOCK_CONN_ACK
 };
 
+struct sock_conn_req_handle {
+	struct fid handle;
+	struct sock_conn_req *req;
+};
+
 int sock_verify_info(struct fi_info *hints);
 int sock_verify_fabric_attr(struct fi_fabric_attr *attr);
 int sock_verify_domain_attr(struct fi_domain_attr *attr);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1404,7 +1404,7 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 			sock_ep->rx_attr = *info->rx_attr;
 			sock_ep->op_flags |= info->rx_attr->op_flags;
 		}
-		sock_ep->info.connreq = info->connreq;
+		sock_ep->info.handle = info->handle;
 	}
 	
 	atomic_init(&sock_ep->ref, 0);

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -727,6 +727,7 @@ static int sock_ep_cm_shutdown(struct fid_ep *ep, uint64_t flags)
 
 struct fi_ops_cm sock_ep_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = sock_ep_cm_getname,
 	.getpeer = sock_ep_cm_getpeer,
 	.connect = sock_ep_cm_connect,

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -670,9 +670,9 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param, size_t paraml
 	if (!response)
 		return -FI_ENOMEM;
 
-	req = (struct sock_conn_req *) _ep->info.connreq;
+	req = (struct sock_conn_req *) _ep->info.handle;
 	if (!req) {
-		SOCK_LOG_ERROR("invalid connreq for cm_accept\n");
+		SOCK_LOG_ERROR("invalid handle for cm_accept\n");
 		free(response);
 		return -FI_EINVAL;
 	}
@@ -698,7 +698,7 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param, size_t paraml
 out:
 	free(req);
 	free(response);
-	_ep->info.connreq = NULL;
+	_ep->info.handle = NULL;
 	return ret;
 }
 
@@ -954,7 +954,7 @@ static void *sock_pep_listener_thread (void *data)
 			
 			cm_entry->fid = &pep->pep.fid;
 			cm_entry->info = sock_ep_msg_process_info(conn_req);
-			cm_entry->info->connreq = (fi_connreq_t) conn_req;
+			cm_entry->info->handle = (fid_t) conn_req;
 
 			memcpy(&cm_entry->data, &conn_req->user_data,
 			       user_data_sz);
@@ -1057,7 +1057,7 @@ static int sock_pep_listen(struct fid_pep *pep)
 	return sock_pep_create_listener_thread(_pep);
 }
 
-static int sock_pep_reject(struct fid_pep *pep, fi_connreq_t connreq,
+static int sock_pep_reject(struct fid_pep *pep, fid_t handle,
 		const void *param, size_t paramlen)
 {
 	struct sock_conn_req *req;
@@ -1067,7 +1067,7 @@ static int sock_pep_reject(struct fid_pep *pep, fi_connreq_t connreq,
 	int ret = 0;
 
 	_pep = container_of(pep, struct sock_pep, pep);
-	req = (struct sock_conn_req *)connreq;
+	req = (struct sock_conn_req *) handle;
 	if (!req)
 		return 0;
 	

--- a/prov/usnic/src/usdf_cm.c
+++ b/prov/usnic/src/usdf_cm.c
@@ -385,6 +385,7 @@ usdf_cm_msg_connect(struct fid_ep *fep, const void *addr,
 		goto fail;
 	}
 
+	crp->handle.fclass = FI_CLASS_CONNREQ;
 	crp->cr_sockfd = socket(AF_INET, SOCK_STREAM, 0);
 	if (crp->cr_sockfd == -1) {
 		ret = -errno;

--- a/prov/usnic/src/usdf_cm.h
+++ b/prov/usnic/src/usdf_cm.h
@@ -53,6 +53,7 @@ struct usdf_connreq_msg {
 } __attribute__((packed));
 
 struct usdf_connreq {
+	struct fid handle;
 	int cr_sockfd;
 	struct usdf_pep *cr_pep;
 	struct usdf_ep *cr_ep;

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -593,6 +593,7 @@ static struct fi_ops_ep usdf_base_msg_ops = {
 
 static struct fi_ops_cm usdf_cm_msg_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = fi_no_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = usdf_cm_msg_connect,

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -688,7 +688,7 @@ usdf_ep_msg_open(struct fid_domain *domain, struct fi_info *info,
 	ep->ep_domain = udp;
 	ep->ep_caps = info->caps;
 	ep->ep_mode = info->mode;
-	ep->e.msg.ep_connreq = (struct usdf_connreq *)info->connreq;
+	ep->e.msg.ep_connreq = (struct usdf_connreq *)info->handle;
 
 	ep->e.msg.ep_seq_credits = USDF_RUDP_SEQ_CREDITS;
 	TAILQ_INIT(&ep->e.msg.ep_posted_wqe);

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -157,7 +157,7 @@ usdf_pep_conn_info(struct usdf_connreq *crp)
 	sin->sin_port = reqp->creq_port;
 
 	ip->dest_addr = sin;
-	ip->connreq = (fi_connreq_t)crp;
+	ip->handle = (fid_t) crp;
 	return ip;
 fail:
 	fi_freeinfo(ip);
@@ -348,7 +348,7 @@ usdf_pep_cancel(fid_t fid, void *context)
 }
 
 static int
-usdf_pep_reject(struct fid_pep *pep, fi_connreq_t connreq,
+usdf_pep_reject(struct fid_pep *pep, fid_t handle,
 		const void *param, size_t paramlen)
 {
 	return -FI_ENOSYS;

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -385,6 +385,7 @@ usdf_pep_grow_backlog(struct usdf_pep *pep)
 		if (crp == NULL) {
 			return -FI_ENOMEM;
 		}
+		crp->handle.fclass = FI_CLASS_CONNREQ;
 		pthread_spin_lock(&pep->pep_cr_lock);
 		TAILQ_INSERT_TAIL(&pep->pep_cr_free, crp, cr_link);
 		++pep->pep_cr_alloced;

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -148,6 +148,11 @@ struct fi_ibv_msg_ep {
 	uint32_t		inline_size;
 };
 
+struct fi_ibv_connreq {
+	struct fid		handle;
+	struct rdma_cm_id	*id;
+};
+
 static const char *local_node = "localhost";
 static char def_send_wr[16] = "384";
 static char def_recv_wr[16] = "384";
@@ -1920,8 +1925,13 @@ static int
 fi_ibv_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 		  const void *param, size_t paramlen)
 {
-	return rdma_reject((struct rdma_cm_id *) handle, param,
-			   (uint8_t) paramlen) ? -errno : 0;
+	struct fi_ibv_connreq *connreq;
+	int ret;
+
+	connreq = container_of(handle, struct fi_ibv_connreq, handle);
+	ret = rdma_reject(connreq->id, param, (uint8_t) paramlen) ? -errno : 0;
+	free(connreq);
+	return ret;
 }
 
 static int fi_ibv_msg_ep_shutdown(struct fid_ep *ep, uint64_t flags)
@@ -2047,6 +2057,7 @@ fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 {
 	struct fi_ibv_domain *_domain;
 	struct fi_ibv_msg_ep *_ep;
+	struct fi_ibv_connreq *connreq;
 	int ret;
 
 	_domain = container_of(domain, struct fi_ibv_domain, domain_fid);
@@ -2061,9 +2072,13 @@ fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		ret = fi_ibv_create_ep(NULL, NULL, 0, info, NULL, &_ep->id);
 		if (ret)
 			goto err;
-
+	} else if (info->handle->fclass == FI_CLASS_CONNREQ) {
+		connreq = container_of(info->handle, struct fi_ibv_connreq, handle);
+		_ep->id = connreq->id;
+		free(connreq);
 	} else {
-		_ep->id = (struct rdma_cm_id *) info->handle;
+		ret = -FI_ENOSYS;
+		goto err;
 	}
 	_ep->id->context = &_ep->ep_fid.fid;
 
@@ -2116,6 +2131,7 @@ static struct fi_info *
 fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 {
 	struct fi_info *fi;
+	struct fi_ibv_connreq *connreq;
 
 	fi = fi_allocinfo();
 	if (!fi)
@@ -2136,7 +2152,13 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 
 	fi_ibv_fill_info_attr(event->id->verbs, NULL, NULL, fi);
 
-	fi->handle = (fid_t) event->id;
+	connreq = calloc(1, sizeof *connreq);
+	if (!connreq)
+		goto err;
+
+	connreq->handle.fclass = FI_CLASS_CONNREQ;
+	connreq->id = event->id;
+	fi->handle = &connreq->handle;
 	return fi;
 err:
 	fi_freeinfo(fi);

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -1943,6 +1943,7 @@ static int fi_ibv_msg_ep_shutdown(struct fid_ep *ep, uint64_t flags)
 
 static struct fi_ops_cm fi_ibv_msg_ep_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = fi_ibv_msg_ep_getname,
 	.getpeer = fi_ibv_msg_ep_getpeer,
 	.connect = fi_ibv_msg_ep_connect,

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -1917,10 +1917,10 @@ fi_ibv_msg_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 }
 
 static int
-fi_ibv_msg_ep_reject(struct fid_pep *pep, fi_connreq_t connreq,
+fi_ibv_msg_ep_reject(struct fid_pep *pep, fid_t handle,
 		  const void *param, size_t paramlen)
 {
-	return rdma_reject((struct rdma_cm_id *) connreq, param,
+	return rdma_reject((struct rdma_cm_id *) handle, param,
 			   (uint8_t) paramlen) ? -errno : 0;
 }
 
@@ -2057,13 +2057,13 @@ fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 	if (!_ep)
 		return -FI_ENOMEM;
 
-	if (!info->connreq) {
+	if (!info->handle) {
 		ret = fi_ibv_create_ep(NULL, NULL, 0, info, NULL, &_ep->id);
 		if (ret)
 			goto err;
 
 	} else {
-		_ep->id = (struct rdma_cm_id *) info->connreq;
+		_ep->id = (struct rdma_cm_id *) info->handle;
 	}
 	_ep->id->context = &_ep->ep_fid.fid;
 
@@ -2136,7 +2136,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 
 	fi_ibv_fill_info_attr(event->id->verbs, NULL, NULL, fi);
 
-	fi->connreq = (fi_connreq_t) event->id;
+	fi->handle = (fid_t) event->id;
 	return fi;
 err:
 	fi_freeinfo(fi);

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -192,7 +192,7 @@ int fi_no_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 {
 	return -FI_ENOSYS;
 }
-int fi_no_reject(struct fid_pep *pep, fi_connreq_t connreq,
+int fi_no_reject(struct fid_pep *pep, fid_t handle,
 		const void *param, size_t paramlen)
 {
 	return -FI_ENOSYS;

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -171,6 +171,10 @@ int fi_no_atomic_compwritevalid(struct fid_ep *ep,
 /*
  * struct fi_ops_cm
  */
+int fi_no_setname(fid_t fid, void *addr, size_t *addrlen)
+{
+	return -FI_ENOSYS;
+}
 int fi_no_getname(fid_t fid, void *addr, size_t *addrlen)
 {
 	return -FI_ENOSYS;

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -439,7 +439,7 @@ static void fi_tostr_info(char *buf, const struct fi_info *info)
 	strcatf(buf, "%sdest_addr: ", TAB);
 	fi_tostr_addr(buf, info->addr_format, info->dest_addr);
 	strcatf(buf, "\n");
-	strcatf(buf, "%sconnreq: %s\n", TAB, info->connreq);
+	strcatf(buf, "%shandle: %s\n", TAB, info->handle);
 
 	fi_tostr_tx_attr(buf, info->tx_attr, TAB);
 	fi_tostr_rx_attr(buf, info->rx_attr, TAB);


### PR DESCRIPTION
These patches introduce changes to the API to better support the implementation of socket APIs over OFI.

@patrickmacarthur - These are not quite ready for merging, but please look through the changes.  The sockets  and verbs providers would need to be updated to support the new functionality.