### PR TITLE
prov/sockets: Added env var SOCK_DGRAM_DROP_RATE

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -143,6 +143,9 @@ struct sock_service_entry {
 struct sock_fabric {
 	struct fid_fabric fab_fid;
 	atomic_t ref;
+#if ENABLE_DEBUG
+	uint64_t num_send_msg;
+#endif
 	struct dlist_entry service_list;
 	struct dlist_entry fab_list_entry;
 	fastlock_t lock;

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -189,7 +189,10 @@ static ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		return -FI_EINVAL;
 
 	if (!tx_ctx->enabled)
-		return -FI_EOPBADSTATE;
+		return -FI_EOPBADSTATE;	
+
+	if(sock_drop_packet(sock_ep))
+		return 0;
 
 	if (sock_ep->connected) {
 		conn = sock_ep_lookup_conn(sock_ep);
@@ -198,7 +201,7 @@ static ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 	if (!conn)
 		return -FI_EAGAIN;
-
+	
 	SOCK_LOG_INFO("New sendmsg on TX: %p using conn: %p\n", 
 		      tx_ctx, conn);
 
@@ -501,7 +504,10 @@ static ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
-
+	
+	if(sock_drop_packet(sock_ep))
+		return 0;
+	
 	if (sock_ep->connected) {
 		conn = sock_ep_lookup_conn(sock_ep);
 	} else {
@@ -509,7 +515,7 @@ static ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 	}
 	if (!conn)
 		return -FI_EAGAIN;
-
+	
 	if (flags & SOCK_USE_OP_FLAGS)
 		flags |= tx_ctx->attr.op_flags;
 

--- a/prov/sockets/src/sock_util.h
+++ b/prov/sockets/src/sock_util.h
@@ -34,15 +34,31 @@
 #define _SOCK_UTIL_H_
 
 #include <rdma/fi_log.h>
+#include "sock.h"
 
 extern const char sock_fab_name[];
 extern const char sock_dom_name[];
 extern const char sock_prov_name[];
 extern struct fi_provider sock_prov;
-
 extern int sock_pe_waittime;
+#if ENABLE_DEBUG
+extern int sock_dgram_drop_rate;
+#endif
 
 #define _SOCK_LOG_INFO(subsys, ...) FI_INFO(&sock_prov, subsys, __VA_ARGS__);
 #define _SOCK_LOG_ERROR(subsys, ...) FI_WARN(&sock_prov, subsys, __VA_ARGS__);
 
+static inline int sock_drop_packet(struct sock_ep *sock_ep)
+{	
+#if ENABLE_DEBUG	
+	if(sock_ep->ep_type == FI_EP_DGRAM && sock_dgram_drop_rate > 0) {
+	sock_ep->domain->fab->num_send_msg;
+		if(!(sock_ep->domain->fab->num_send_msg % sock_dgram_drop_rate))
+			return 1;
+	}
 #endif
+	return 0;
+}
+
+#endif
+


### PR DESCRIPTION
- Added env var SOCK_DGRAM_DROP_RATE to emulate DGRAM behavior. It's only enabled with debug build. If SOCK_DGRAM_DROP_RATE = n, then every nth send message is discarded.

@jithinjosepkl can you please review?

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>