### PR TITLE
Pr/sockets

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -82,6 +82,7 @@
 #define SOCK_PE_POLL_TIMEOUT (100000)
 #define SOCK_PE_MAX_ENTRIES (128)
 #define SOCK_PE_MIN_ENTRIES (1)
+#define SOCK_PE_WAITTIME (10)
 
 #define SOCK_EQ_DEF_SZ (1<<8)
 #define SOCK_CQ_DEF_SZ (1<<8)
@@ -712,6 +713,7 @@ struct sock_pe {
 	fastlock_t lock;
 	pthread_mutex_t list_lock;
 	int signal_fds[2];
+	uint64_t waittime;
 
 	struct dlist_entry free_list;
 	struct dlist_entry busy_list;

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -211,6 +211,14 @@ int sock_dgram_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 		(*info)->ep_attr->tx_ctx_cnt = hints->ep_attr->tx_ctx_cnt;
 	}
 
+	if (hints && hints->rx_attr) {
+		(*info)->rx_attr->op_flags |= hints->rx_attr->op_flags;
+	}
+
+	if (hints && hints->tx_attr) {
+		(*info)->tx_attr->op_flags |= hints->tx_attr->op_flags;
+	}
+
 	(*info)->caps = SOCK_EP_DGRAM_CAP|
 			(*info)->rx_attr->caps | (*info)->tx_attr->caps;
 	return 0;

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -206,6 +206,11 @@ int sock_dgram_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 	*(*info)->rx_attr = sock_dgram_rx_attr;
 	*(*info)->ep_attr = sock_dgram_ep_attr;
 
+	if (hints && hints->ep_attr) {
+		(*info)->ep_attr->rx_ctx_cnt = hints->ep_attr->rx_ctx_cnt;
+		(*info)->ep_attr->tx_ctx_cnt = hints->ep_attr->tx_ctx_cnt;
+	}
+
 	(*info)->caps = SOCK_EP_DGRAM_CAP|
 			(*info)->rx_attr->caps | (*info)->tx_attr->caps;
 	return 0;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -208,6 +208,11 @@ int sock_msg_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 	*(*info)->rx_attr = sock_msg_rx_attr;
 	*(*info)->ep_attr = sock_msg_ep_attr;
 
+	if (hints && hints->ep_attr) {
+		(*info)->ep_attr->rx_ctx_cnt = hints->ep_attr->rx_ctx_cnt;
+		(*info)->ep_attr->tx_ctx_cnt = hints->ep_attr->tx_ctx_cnt;
+	}
+
 	(*info)->caps = SOCK_EP_MSG_CAP |
 			(*info)->rx_attr->caps | (*info)->tx_attr->caps;
 	return 0;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -213,6 +213,14 @@ int sock_msg_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 		(*info)->ep_attr->tx_ctx_cnt = hints->ep_attr->tx_ctx_cnt;
 	}
 
+	if (hints && hints->rx_attr) {
+		(*info)->rx_attr->op_flags |= hints->rx_attr->op_flags;
+	}
+
+	if (hints && hints->tx_attr) {
+		(*info)->tx_attr->op_flags |= hints->tx_attr->op_flags;
+	}
+
 	(*info)->caps = SOCK_EP_MSG_CAP |
 			(*info)->rx_attr->caps | (*info)->tx_attr->caps;
 	return 0;

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -251,6 +251,11 @@ int sock_rdm_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 	*(*info)->rx_attr = sock_rdm_rx_attr;
 	*(*info)->ep_attr = sock_rdm_ep_attr;
 
+	if (hints && hints->ep_attr) {
+		(*info)->ep_attr->rx_ctx_cnt = hints->ep_attr->rx_ctx_cnt;
+		(*info)->ep_attr->tx_ctx_cnt = hints->ep_attr->tx_ctx_cnt;
+	}
+
 	(*info)->caps = SOCK_EP_RDM_CAP |
 			(*info)->rx_attr->caps | (*info)->tx_attr->caps;
 	return 0;

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -256,6 +256,14 @@ int sock_rdm_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 		(*info)->ep_attr->tx_ctx_cnt = hints->ep_attr->tx_ctx_cnt;
 	}
 
+	if (hints && hints->rx_attr) {
+		(*info)->rx_attr->op_flags |= hints->rx_attr->op_flags;
+	}
+
+	if (hints && hints->tx_attr) {
+		(*info)->tx_attr->op_flags |= hints->tx_attr->op_flags;
+	}
+
 	(*info)->caps = SOCK_EP_RDM_CAP |
 			(*info)->rx_attr->caps | (*info)->tx_attr->caps;
 	return 0;

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -50,6 +50,7 @@
 #define SOCK_LOG_INFO(...) _SOCK_LOG_INFO(FI_LOG_FABRIC, __VA_ARGS__)
 #define SOCK_LOG_ERROR(...) _SOCK_LOG_ERROR(FI_LOG_FABRIC, __VA_ARGS__)
 
+int sock_pe_waittime = SOCK_PE_WAITTIME;
 const char sock_fab_name[] = "IP";
 const char sock_dom_name[] = "sockets";
 const char sock_prov_name[] = "sockets";
@@ -564,6 +565,13 @@ struct fi_provider sock_prov = {
 
 SOCKETS_INI
 {
+	char *value;
+
+	if ((value = getenv("FI_SOCK_PE_WAITTIME"))) {
+		sock_pe_waittime = atoi(value);
+		SOCK_LOG_INFO("FI_SOCK_PE_WAITTIME = %d\n", sock_pe_waittime);
+	}
+	
 	fastlock_init(&sock_list_lock);
 	dlist_init(&sock_fab_list);
 	dlist_init(&sock_dom_list);

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -567,9 +567,9 @@ SOCKETS_INI
 {
 	char *value;
 
-	if ((value = getenv("FI_SOCK_PE_WAITTIME"))) {
+	if ((value = getenv("SOCK_PE_WAITTIME"))) {
 		sock_pe_waittime = atoi(value);
-		SOCK_LOG_INFO("FI_SOCK_PE_WAITTIME = %d\n", sock_pe_waittime);
+		SOCK_LOG_INFO("SOCK_PE_WAITTIME = %d\n", sock_pe_waittime);
 	}
 	
 	fastlock_init(&sock_list_lock);

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -243,7 +243,7 @@ static void sock_pe_report_remote_write(struct sock_rx_ctx *rx_ctx,
 	pe_entry->data_len = pe_entry->pe.rx.rx_iov[0].iov.len;
 	
 	if ((!pe_entry->comp->rem_write_cq && !pe_entry->comp->rem_write_cntr &&
-	     !(rx_ctx->attr.op_flags & FI_REMOTE_WRITE)))
+	     !(pe_entry->msg_hdr.flags & FI_REMOTE_WRITE)))
 		return;
 	
 	if (pe_entry->comp->rem_write_cq) {
@@ -289,7 +289,7 @@ static void sock_pe_report_remote_read(struct sock_rx_ctx *rx_ctx,
 	pe_entry->data_len = pe_entry->pe.rx.rx_iov[0].iov.len;
 	
 	if ((!pe_entry->comp->rem_read_cq && !pe_entry->comp->rem_read_cntr &&
-	     !(rx_ctx->attr.op_flags & FI_REMOTE_READ)))
+	     !(pe_entry->msg_hdr.flags & FI_REMOTE_READ)))
 		return;
 	
 	if (pe_entry->comp->rem_read_cq) {
@@ -1125,8 +1125,7 @@ ssize_t sock_rx_peek_recv(struct sock_rx_ctx *rx_ctx, fi_addr_t addr,
 		pe_entry.data_len = rx_buffered->total_len;
 		pe_entry.tag = rx_buffered->tag;
 		pe_entry.context = rx_buffered->context = (uintptr_t)context;
-		pe_entry.flags = (flags | rx_ctx->attr.op_flags);
-		pe_entry.flags |= (FI_MSG | FI_RECV);
+		pe_entry.flags = (flags | FI_MSG | FI_RECV);
 		if (is_tagged)
 			pe_entry.flags |= FI_TAGGED;
 		
@@ -1174,8 +1173,7 @@ ssize_t sock_rx_claim_recv(struct sock_rx_ctx *rx_ctx, void *context, uint64_t f
 		pe_entry.data_len = rx_buffered->total_len;
 		pe_entry.tag = rx_buffered->tag;
 		pe_entry.context = rx_buffered->context;
-		pe_entry.flags = (flags | rx_ctx->attr.op_flags);
-		pe_entry.flags |= (FI_MSG | FI_RECV);
+		pe_entry.flags = (flags | FI_MSG | FI_RECV);
 		if (is_tagged)
 			pe_entry.flags |= FI_TAGGED;
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2344,6 +2344,15 @@ static void sock_pe_poll(struct sock_pe *pe)
 	fastlock_release(&map->lock);
 
 do_wait:
+	if (!pe->waittime) {
+		pe->waittime = fi_gettime_ms();
+		return;
+	}
+
+	if (fi_gettime_ms() - pe->waittime < sock_pe_waittime)
+		return;
+		
+	pe->waittime = 0;
 	FD_SET(pe->signal_fds[SOCK_SIGNAL_RD_FD], &rfds);
 	max_fds = MAX(pe->signal_fds[SOCK_SIGNAL_RD_FD], max_fds);
 	

--- a/prov/sockets/src/sock_util.h
+++ b/prov/sockets/src/sock_util.h
@@ -40,6 +40,8 @@ extern const char sock_dom_name[];
 extern const char sock_prov_name[];
 extern struct fi_provider sock_prov;
 
+extern int sock_pe_waittime;
+
 #define _SOCK_LOG_INFO(subsys, ...) FI_INFO(&sock_prov, subsys, __VA_ARGS__);
 #define _SOCK_LOG_ERROR(subsys, ...) FI_WARN(&sock_prov, subsys, __VA_ARGS__);
 


### PR DESCRIPTION
- Set TX/RX ctx count in fi_getinfo() based on user input
- Return op-flags in fi-getinfo based on user input
- Add env parameter to control progress engine waittime
- Use mremap for resizing shared AV