### PR TITLE
prov/psm: add environment variable OFI_PSM_AM

### DIFF
--- a/man/fi_psm.7.md
+++ b/man/fi_psm.7.md
@@ -121,6 +121,16 @@ The *psm* provider checks for the following environment variables:
 
   This option is off by default. To turn it on set the variable to 1.
 
+*OFI_PSM_AM*
+: The *psm* provider implements RMA and atomcis operations over the PSM Active
+  Message functions. The Active Message handlers may incur minor overhead
+  even if unused. For applications that don't use RMA and atomics operations
+  at all the use of Active Message can be disabled.
+
+  This option is on by default. To turn it off set the variable to 0. When
+  it is turned off, the options OFI_PSM_TAGGED_RMA and OFI_PSM_AM_MSG are also
+  turned off automatically.
+
 *OFI_PSM_VERSION_CHECK*
 : The *psm* provider checks the version of the PSM library and fails if the
   major version doesn't match with the header it is compiled with. In some

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -550,6 +550,7 @@ struct psmx_epaddr_context {
 
 struct psmx_env {
 	int name_server;
+	int am;
 	int am_msg;
 	int tagged_rma;
 	char *uuid;

--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -48,6 +48,9 @@ int psmx_am_progress(struct psmx_fid_domain *domain)
 	struct slist_entry *item;
 	struct psmx_am_request *req;
 
+	if (!psmx_env.am)
+		return 0;
+
 #if PSMX_AM_USE_SEND_QUEUE
 	pthread_mutex_lock(&domain->send_queue.lock);
 	while (!slist_empty(&domain->send_queue.list)) {
@@ -112,6 +115,9 @@ int psmx_am_init(struct psmx_fid_domain *domain)
 	psm_ep_t psm_ep = domain->psm_ep;
 	size_t size;
 	int err = 0;
+
+	if (!psmx_env.am)
+		return 0;
 
 	if (!psmx_am_handlers_initialized) {
 		err = psm_am_get_parameters(psm_ep, &psmx_am_param,

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -166,6 +166,9 @@ err_out:
 
 int psmx_domain_check_features(struct psmx_fid_domain *domain, int ep_cap)
 {
+	if ((ep_cap & (FI_RMA | FI_ATOMICS)) && !psmx_env.am)
+		return -FI_EOPNOTSUPP;
+
 	if ((ep_cap & PSMX_CAPS) != ep_cap)
 		return -FI_EINVAL;
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -173,6 +173,12 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 			goto err_out;
 		}
 
+		if (!psmx_env.am && (hints->caps & (FI_RMA | FI_ATOMICS))) {
+			FI_INFO(&psmx_prov, FI_LOG_CORE,
+				"RMA and atomics are not supported because Active Message is turned off\n");
+			goto err_out;
+		}
+
 		if (hints->tx_attr) {
 			if ((hints->tx_attr->op_flags & PSMX_OP_FLAGS) !=
 			    hints->tx_attr->op_flags) {
@@ -417,11 +423,17 @@ PSM_INI
 	int err;
 
 	psmx_env.name_server	= psmx_get_int_env("OFI_PSM_NAME_SERVER", 1);
+	psmx_env.am		= psmx_get_int_env("OFI_PSM_AM", 1);
 	psmx_env.am_msg		= psmx_get_int_env("OFI_PSM_AM_MSG", 0);
 	psmx_env.tagged_rma	= psmx_get_int_env("OFI_PSM_TAGGED_RMA", 1);
 	psmx_env.uuid		= getenv("OFI_PSM_UUID");
 	if (!psmx_env.uuid)
 		psmx_env.uuid	= PSMX_DEFAULT_UUID;
+
+	if (!psmx_env.am) {
+		psmx_env.am_msg = 0;
+		psmx_env.tagged_rma = 0;
+	}
 
 	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
 
@@ -455,6 +467,8 @@ PSM_INI
 
 	FI_INFO(&psmx_prov, FI_LOG_CORE,
 		"OFI_PSM_NAME_SERVER = %d\n", psmx_env.name_server);
+	FI_INFO(&psmx_prov, FI_LOG_CORE,
+		"OFI_PSM_AM = %d\n", psmx_env.am);
 	FI_INFO(&psmx_prov, FI_LOG_CORE,
 		"OFI_PSM_AM_MSG = %d\n", psmx_env.am_msg);
 	FI_INFO(&psmx_prov, FI_LOG_CORE,


### PR DESCRIPTION
For applications that don't use RMA and atomics, there could be
slight performance gain by turning off the use of Active Message
funcitons.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>