### PR TITLE
usnic: improve RDM+MSG support

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -204,6 +204,7 @@ struct usdf_tx {
 
 			atomic_t tx_next_msg_id;
 			struct usdf_rdm_qe *tx_wqe_buf;
+			uint8_t *tx_inject_bufs;
 			TAILQ_HEAD(,usdf_rdm_qe) tx_free_wqe;
 			TAILQ_HEAD(,usdf_rdm_connection) tx_rdc_ready;
 			TAILQ_HEAD(,usdf_rdm_connection) tx_rdc_have_acks;
@@ -258,6 +259,9 @@ struct usdf_ep {
 	atomic_t ep_refcnt;
 	uint64_t ep_caps;
 	uint64_t ep_mode;
+
+	uint8_t ep_tx_dflt_signal_comp;
+	uint8_t ep_rx_dflt_signal_comp;
 
 	uint32_t ep_wqe;	/* requested queue sizes */
 	uint32_t ep_rqe;

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -193,6 +193,7 @@ struct usdf_tx {
 		struct {
 			struct usdf_cq_hard *tx_hcq;
 
+			uint8_t *tx_inject_bufs;
 			struct usdf_msg_qe *tx_wqe_buf;
 			TAILQ_HEAD(,usdf_msg_qe) tx_free_wqe;
 			TAILQ_HEAD(,usdf_ep) tx_ep_ready;

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -113,10 +113,20 @@ usdf_tx_msg_enable(struct usdf_tx *tx)
 		goto fail;
 	}
 
+	ret = usd_alloc_mr(tx->tx_domain->dom_dev,
+			tx->tx_attr.size * USDF_MSG_MAX_INJECT_SIZE,
+			(void **)&tx->t.msg.tx_inject_bufs);
+	if (ret) {
+		USDF_INFO("usd_alloc_mr failed (%s)\n", strerror(-ret));
+		goto fail;
+	}
+
 	/* populate free list */
 	TAILQ_INIT(&tx->t.msg.tx_free_wqe);
 	wqe = tx->t.msg.tx_wqe_buf;
 	for (i = 0; i < tx->tx_attr.size; ++i) {
+		wqe->ms_inject_buf =
+			&tx->t.msg.tx_inject_bufs[USDF_MSG_MAX_INJECT_SIZE * i];
 		TAILQ_INSERT_TAIL(&tx->t.msg.tx_free_wqe, wqe, ms_link);
 		++wqe;
 	}
@@ -131,6 +141,12 @@ fail:
 		TAILQ_INIT(&tx->t.msg.tx_free_wqe);
 		tx->t.msg.tx_num_free_wqe = 0;
 	}
+
+	if (tx->t.msg.tx_inject_bufs != NULL) {
+		usd_free_mr(tx->t.msg.tx_inject_bufs);
+		tx->t.msg.tx_inject_bufs = NULL;
+	}
+
 	if (tx->tx_qp != NULL) {
 		usd_destroy_qp(tx->tx_qp);
 	}
@@ -355,6 +371,13 @@ usdf_msg_fill_tx_attr(struct fi_tx_attr *txattr)
 	if (txattr->iov_limit == 0) {
 		txattr->iov_limit = USDF_MSG_DFLT_SGE;
 	}
+
+	if (txattr->op_flags & ~USDF_MSG_SUPP_SENDMSG_FLAGS) {
+		USDF_WARN("one or more flags in 0x%llx not supported\n",
+			txattr->op_flags);
+		return -FI_EOPNOTSUPP;
+	}
+
 	return 0;
 }
 
@@ -484,11 +507,19 @@ usdf_ep_msg_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	case FI_CLASS_CQ:
 		if (flags & FI_SEND) {
 			cq = cq_fidtou(bfid);
+			if (flags & FI_COMPLETION)
+				ep->ep_tx_dflt_signal_comp = 0;
+			else
+				ep->ep_tx_dflt_signal_comp = 1;
 			usdf_ep_msg_bind_cq(ep, cq, FI_SEND);
 		}
 
 		if (flags & FI_RECV) {
 			cq = cq_fidtou(bfid);
+			if (flags & FI_COMPLETION)
+				ep->ep_rx_dflt_signal_comp = 0;
+			else
+				ep->ep_rx_dflt_signal_comp = 1;
 			usdf_ep_msg_bind_cq(ep, cq, FI_RECV);
 		}
 		break;
@@ -556,6 +587,7 @@ usdf_msg_tx_ctx_close(fid_t fid)
 	}
 
 	if (tx->tx_qp != NULL) {
+		usd_free_mr(tx->t.msg.tx_inject_bufs);
 		free(tx->t.msg.tx_wqe_buf);
 		usd_destroy_qp(tx->tx_qp);
 	}
@@ -717,6 +749,8 @@ usdf_ep_msg_open(struct fid_domain *domain, struct fi_info *info,
 	ep->ep_caps = info->caps;
 	ep->ep_mode = info->mode;
 	ep->e.msg.ep_connreq = (struct usdf_connreq *)info->handle;
+	ep->ep_tx_dflt_signal_comp = 1;
+	ep->ep_rx_dflt_signal_comp = 1;
 
 	ep->e.msg.ep_seq_credits = USDF_RUDP_SEQ_CREDITS;
 	TAILQ_INIT(&ep->e.msg.ep_posted_wqe);

--- a/prov/usnic/src/usdf_msg.h
+++ b/prov/usnic/src/usdf_msg.h
@@ -41,12 +41,17 @@
 #define USDF_MSG_SUPP_MODE (FI_LOCAL_MR)
 #define USDF_MSG_REQ_MODE (FI_LOCAL_MR)
 
+#define USDF_MSG_SUPP_SENDMSG_FLAGS \
+	(FI_INJECT_COMPLETE | FI_TRANSMIT_COMPLETE | FI_INJECT | FI_COMPLETION)
+
 #define USDF_MSG_MAX_SGE 8
 #define USDF_MSG_DFLT_SGE 8
 #define USDF_MSG_MAX_CTX_SIZE 1024
 #define USDF_MSG_DFLT_CTX_SIZE 512
 
 #define USDF_MSG_MAX_MSG UINT_MAX
+
+#define USDF_MSG_MAX_INJECT_SIZE 64
 
 #define USDF_MSG_FAIRNESS_CREDITS 16
 
@@ -66,6 +71,11 @@ struct usdf_msg_qe {
 	const uint8_t *ms_cur_ptr;
 	size_t ms_resid;      	/* amount remaining in entire msg */
 	size_t ms_iov_resid;    /* amount remaining in current iov */
+
+	/* points at buffer no larger than USDF_MSG_MAX_INJECT_SIZE */
+	uint8_t *ms_inject_buf;
+
+	uint8_t ms_signal_comp;
 
 	TAILQ_ENTRY(usdf_msg_qe) ms_link;
 };

--- a/prov/usnic/src/usdf_rdm.h
+++ b/prov/usnic/src/usdf_rdm.h
@@ -41,12 +41,17 @@
 #define USDF_RDM_SUPP_MODE (FI_LOCAL_MR)
 #define USDF_RDM_REQ_MODE (FI_LOCAL_MR)
 
+#define USDF_RDM_SUPP_SENDMSG_FLAGS \
+	(FI_INJECT_COMPLETE | FI_TRANSMIT_COMPLETE | FI_INJECT | FI_COMPLETION)
+
 #define USDF_RDM_MAX_SGE 8
 #define USDF_RDM_DFLT_SGE 8
 #define USDF_RDM_MAX_CTX_SIZE 1024
 #define USDF_RDM_DFLT_CTX_SIZE 128
 
 #define USDF_RDM_MAX_MSG UINT_MAX
+
+#define USDF_RDM_MAX_INJECT_SIZE 64
 
 #define USDF_RDM_FREE_BLOCK (16 * 1024)
 #define USDF_RDM_HASH_SIZE (64 * 1024)
@@ -69,6 +74,11 @@ struct usdf_rdm_qe {
 	const uint8_t *rd_cur_ptr;
 	size_t rd_resid;      	/* amount remaining in entire rdm */
 	size_t rd_iov_resid;    /* amount remaining in current iov */
+
+	/* points at buffer no larger than USDF_RDM_MAX_INJECT_SIZE */
+	uint8_t *rd_inject_buf;
+
+	uint8_t rd_signal_comp;
 
 	TAILQ_ENTRY(usdf_rdm_qe) rd_link;
 


### PR DESCRIPTION
I'm sure that we are still missing proper support for certain flags or semantics, but this is significantly better than it was.

The RDM/MSG code requires changes from PR #916, so this PR also includes all the commits from #916.  Once #916 lands then I can rebase this so that only the last two commits are in this PR.

@jsquyres please review (the last two commits)