### PR TITLE
prov/psm: bug fix for EP capability checking

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -70,6 +70,9 @@ extern struct fi_provider psmx_prov;
 
 #define PSMX_CAPS2	((PSMX_CAPS | FI_DIRECTED_RECV) & ~FI_TAGGED)
 
+#define PSMX_SUB_CAPS	(FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE | \
+			 FI_SEND | FI_RECV)
+
 #define PSMX_MODE	(FI_CONTEXT)
 
 #define PSMX_MAX_MSG_SIZE	((0x1ULL << 32) - 1)

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -167,10 +167,10 @@ err_out:
 
 int psmx_domain_check_features(struct psmx_fid_domain *domain, int ep_cap)
 {
-	if ((domain->caps & ep_cap) != ep_cap) {
+	if ((domain->caps & ep_cap & ~PSMX_SUB_CAPS) != (ep_cap & ~PSMX_SUB_CAPS)) {
 		FI_INFO(&psmx_prov, FI_LOG_CORE,
-			"caps mismatch: domain->caps=%llx, ep->caps=%llx\n",
-			domain->caps, ep_cap);
+			"caps mismatch: domain->caps=%llx, ep->caps=%llx, mask=%llx\n",
+			domain->caps, ep_cap, ~PSMX_SUB_CAPS);
 		return -FI_EOPNOTSUPP;
 	}
 
@@ -200,10 +200,10 @@ int psmx_domain_enable_ep(struct psmx_fid_domain *domain, struct psmx_fid_ep *ep
 	if (ep)
 		ep_cap = ep->caps;
 
-	if ((domain->caps & ep_cap) != ep_cap) {
+	if ((domain->caps & ep_cap & ~PSMX_SUB_CAPS) != (ep_cap & ~PSMX_SUB_CAPS)) {
 		FI_INFO(&psmx_prov, FI_LOG_CORE,
-			"caps mismatch: domain->caps=%llx, ep->caps=%llx\n",
-			domain->caps, ep_cap);
+			"caps mismatch: domain->caps=%llx, ep->caps=%llx, mask=%llx\n",
+			domain->caps, ep_cap, ~PSMX_SUB_CAPS);
 		return -FI_EOPNOTSUPP;
 	}
 


### PR DESCRIPTION
Some capability bits (e.g. FI_READ) limit the scope of other
capability bits (e.g. FI_RMA). Such sub-capability bits need to be
excluded when requested EP capabilities are checked against the
domain capabilities.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>