### PR TITLE
usnic: implement size_left for EP_MSG and EP_RDM

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -197,6 +197,7 @@ struct usdf_tx {
 			TAILQ_HEAD(,usdf_msg_qe) tx_free_wqe;
 			TAILQ_HEAD(,usdf_ep) tx_ep_ready;
 			TAILQ_HEAD(,usdf_ep) tx_ep_have_acks;
+			size_t tx_num_free_wqe;
 		} msg;
 		struct {
 			struct usdf_cq_hard *tx_hcq;
@@ -206,6 +207,7 @@ struct usdf_tx {
 			TAILQ_HEAD(,usdf_rdm_qe) tx_free_wqe;
 			TAILQ_HEAD(,usdf_rdm_connection) tx_rdc_ready;
 			TAILQ_HEAD(,usdf_rdm_connection) tx_rdc_have_acks;
+			size_t tx_num_free_wqe;
 		} rdm;
 	} t;
 };
@@ -230,6 +232,7 @@ struct usdf_rx {
 			struct usdf_msg_qe *rx_rqe_buf;
 			TAILQ_HEAD(,usdf_msg_qe) rx_free_rqe;
 			TAILQ_HEAD(,usdf_msg_qe) rx_posted_rqe;
+			size_t rx_num_free_rqe;
 		} msg;
 		struct {
 			int rx_sock;
@@ -240,6 +243,7 @@ struct usdf_rx {
 			struct usdf_rdm_qe *rx_rqe_buf;
 			TAILQ_HEAD(,usdf_rdm_qe) rx_free_rqe;
 			TAILQ_HEAD(,usdf_rdm_qe) rx_posted_rqe;
+			size_t rx_num_free_rqe;
 		} rdm;
 	} r;
 };

--- a/prov/usnic/src/usdf_dgram.c
+++ b/prov/usnic/src/usdf_dgram.c
@@ -321,6 +321,8 @@ ssize_t usdf_dgram_rx_size_left(struct fid_ep *fep)
 {
 	struct usdf_ep *ep;
 
+	USDF_DBG_SYS(EP_DATA, "\n");
+
 	if (fep == NULL)
 		return -FI_EINVAL;
 
@@ -342,6 +344,8 @@ ssize_t usdf_dgram_rx_size_left(struct fid_ep *fep)
 ssize_t usdf_dgram_tx_size_left(struct fid_ep *fep)
 {
 	struct usdf_ep *ep;
+
+	USDF_DBG_SYS(EP_DATA, "\n");
 
 	if (fep == NULL)
 		return -FI_EINVAL;
@@ -526,6 +530,8 @@ ssize_t usdf_dgram_prefix_rx_size_left(struct fid_ep *fep)
 {
 	struct usdf_ep *ep;
 
+	USDF_DBG_SYS(EP_DATA, "\n");
+
 	if (fep == NULL)
 		return -FI_EINVAL;
 
@@ -543,6 +549,8 @@ ssize_t usdf_dgram_prefix_rx_size_left(struct fid_ep *fep)
 ssize_t usdf_dgram_prefix_tx_size_left(struct fid_ep *fep)
 {
 	struct usdf_ep *ep;
+
+	USDF_DBG_SYS(EP_DATA, "\n");
 
 	if (fep == NULL)
 		return -FI_EINVAL;

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -120,6 +120,7 @@ usdf_tx_msg_enable(struct usdf_tx *tx)
 		TAILQ_INSERT_TAIL(&tx->t.msg.tx_free_wqe, wqe, ms_link);
 		++wqe;
 	}
+	tx->t.msg.tx_num_free_wqe = tx->tx_attr.size;
 
 	return 0;
 
@@ -128,6 +129,7 @@ fail:
 		free(tx->t.msg.tx_wqe_buf);
 		tx->t.msg.tx_wqe_buf = NULL;
 		TAILQ_INIT(&tx->t.msg.tx_free_wqe);
+		tx->t.msg.tx_num_free_wqe = 0;
 	}
 	if (tx->tx_qp != NULL) {
 		usd_destroy_qp(tx->tx_qp);
@@ -208,6 +210,7 @@ usdf_rx_msg_enable(struct usdf_rx *rx)
 		TAILQ_INSERT_TAIL(&rx->r.msg.rx_free_rqe, rqe, ms_link);
 		++rqe;
 	}
+	rx->r.msg.rx_num_free_rqe = rx->rx_attr.size;
 
 	return 0;
 
@@ -216,6 +219,7 @@ fail:
 		free(rx->r.msg.rx_rqe_buf);
 		rx->r.msg.rx_rqe_buf = NULL;
 		TAILQ_INIT(&rx->r.msg.rx_free_rqe);
+		rx->r.msg.rx_num_free_rqe = 0;
 	}
 	if (rx->r.msg.rx_bufs != NULL) {
 		usd_free_mr(rx->r.msg.rx_bufs);
@@ -606,8 +610,8 @@ static struct fi_ops_ep usdf_base_msg_ops = {
 	.setopt = usdf_ep_msg_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
-	.rx_size_left = fi_no_rx_size_left,
-	.tx_size_left = fi_no_tx_size_left,
+	.rx_size_left = usdf_msg_rx_size_left,
+	.tx_size_left = usdf_msg_tx_size_left,
 };
 
 static struct fi_ops_cm usdf_cm_msg_ops = {

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -119,6 +119,7 @@ usdf_tx_rdm_enable(struct usdf_tx *tx)
 		TAILQ_INSERT_TAIL(&tx->t.rdm.tx_free_wqe, wqe, rd_link);
 		++wqe;
 	}
+	tx->t.rdm.tx_num_free_wqe = tx->tx_attr.size;
 
 	return 0;
 
@@ -127,6 +128,7 @@ fail:
 		free(tx->t.rdm.tx_wqe_buf);
 		tx->t.rdm.tx_wqe_buf = NULL;
 		TAILQ_INIT(&tx->t.rdm.tx_free_wqe);
+		tx->t.rdm.tx_num_free_wqe = 0;
 	}
 	if (tx->tx_qp != NULL) {
 		usd_destroy_qp(tx->tx_qp);
@@ -205,6 +207,7 @@ usdf_rx_rdm_enable(struct usdf_rx *rx)
 		TAILQ_INSERT_TAIL(&rx->r.rdm.rx_free_rqe, rqe, rd_link);
 		++rqe;
 	}
+	rx->r.rdm.rx_num_free_rqe = rx->rx_attr.size;
 
 	return 0;
 
@@ -213,6 +216,7 @@ fail:
 		free(rx->r.rdm.rx_rqe_buf);
 		rx->r.rdm.rx_rqe_buf = NULL;
 		TAILQ_INIT(&rx->r.rdm.rx_free_rqe);
+		rx->r.rdm.rx_num_free_rqe = 0;
 	}
 	if (rx->r.rdm.rx_bufs != NULL) {
 		usd_free_mr(rx->r.rdm.rx_bufs);
@@ -648,8 +652,8 @@ static struct fi_ops_ep usdf_base_rdm_ops = {
 	.setopt = usdf_ep_rdm_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
-	.rx_size_left = fi_no_rx_size_left,
-	.tx_size_left = fi_no_tx_size_left,
+	.rx_size_left = usdf_rdm_rx_size_left,
+	.tx_size_left = usdf_rdm_tx_size_left,
 };
 
 static struct fi_ops_cm usdf_cm_rdm_ops = {

--- a/prov/usnic/src/usdf_msg.h
+++ b/prov/usnic/src/usdf_msg.h
@@ -106,5 +106,7 @@ ssize_t usdf_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
 	fi_addr_t src_addr);
 	
 
+ssize_t usdf_msg_rx_size_left(struct fid_ep *fep);
+ssize_t usdf_msg_tx_size_left(struct fid_ep *fep);
 
 #endif /* _USDF_MSG_H_ */

--- a/prov/usnic/src/usdf_rdm.h
+++ b/prov/usnic/src/usdf_rdm.h
@@ -158,5 +158,7 @@ ssize_t usdf_rdm_inject(struct fid_ep *ep, const void *buf, size_t len,
 	fi_addr_t src_addr);
 	
 
+ssize_t usdf_rdm_rx_size_left(struct fid_ep *fep);
+ssize_t usdf_rdm_tx_size_left(struct fid_ep *fep);
 
 #endif /* _USDF_RDM_H_ */


### PR DESCRIPTION
Also beef up the debug logging across the board for the size_left
routines.

The unit/fi_size_left_test in fabtests was broken with usnic since
ofiwg/fabtests#213 changed the test to specifically request EP_RDM.
This commit fixes it.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@jsquyres please review