### PR TITLE
prov/psm: fix a hanging in fi_wait

### DIFF
--- a/prov/psm/src/psmx_wait.c
+++ b/prov/psm/src/psmx_wait.c
@@ -55,7 +55,8 @@ static void *psmx_wait_progress(void *args)
 
 	while (1) {
 		pthread_mutex_lock(&psmx_wait_mutex);
-		pthread_cond_wait(&psmx_wait_cond, &psmx_wait_mutex);
+		if (!psmx_wait_thread_enabled)
+			pthread_cond_wait(&psmx_wait_cond, &psmx_wait_mutex);
 		pthread_mutex_unlock(&psmx_wait_mutex);
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 


### PR DESCRIPTION
A progress thread is created when blocking wait function is called.
The progress thread is activated by a conditional variable. Due to the
timing issue, it is possible that the conditional variable be signaled
before it is waited on. That causes hanging. The fix checks the actual
condition before waiting on the conditional variable.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>