### PR TITLE
usnic: improve MR API mode+flag handling

### DIFF
--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -228,6 +228,19 @@ usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	USDF_TRACE_SYS(DOMAIN, "\n");
 
+	if (info->domain_attr != NULL) {
+		switch (info->domain_attr->mr_mode) {
+		case FI_MR_UNSPEC:
+		case FI_MR_BASIC:
+			break;
+		default:
+			/* the caller ignored our fi_getinfo results */
+			USDF_WARN_SYS(DOMAIN, "MR mode (%d) not supported\n",
+				info->domain_attr->mr_mode);
+			return -FI_ENODATA;
+		}
+	}
+
 	udp = calloc(1, sizeof *udp);
 	if (udp == NULL) {
 		USDF_DBG("unable to alloc mem for domain\n");

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -330,6 +330,7 @@ usdf_fill_info_dgram(
 	dattrp->control_progress = FI_PROGRESS_AUTO;
 	dattrp->data_progress = FI_PROGRESS_MANUAL;
 	dattrp->resource_mgmt = FI_RM_DISABLED;
+	dattrp->mr_mode = FI_MR_BASIC;
 
 	/* add to tail of list */
 	if (*fi_first == NULL) {
@@ -436,6 +437,7 @@ usdf_fill_info_msg(
 	dattrp->control_progress = FI_PROGRESS_AUTO;
 	dattrp->data_progress = FI_PROGRESS_MANUAL;
 	dattrp->resource_mgmt = FI_RM_DISABLED;
+	dattrp->mr_mode = FI_MR_BASIC;
 
 	/* add to tail of list */
 	if (*fi_first == NULL) {
@@ -540,6 +542,7 @@ usdf_fill_info_rdm(
 	dattrp->control_progress = FI_PROGRESS_AUTO;
 	dattrp->data_progress = FI_PROGRESS_MANUAL;
 	dattrp->resource_mgmt = FI_RM_DISABLED;
+	dattrp->mr_mode = FI_MR_BASIC;
 
 	/* add to tail of list */
 	if (*fi_first == NULL) {


### PR DESCRIPTION
PR #919 modified the way that memory registration flags and modes are
specified to libfabric.  This commit adds correct behavior for the usnic
provider w.r.t. fi_getinfo()/fi_domain().

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@jsquyres please review