### PR TITLE
fabric: Return 0 on successful asynchronous AV insertions

### DIFF
--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -407,13 +407,17 @@ resources from removed entries.
 
 # RETURN VALUES
 
-The insert calls return the number of addresses successfully inserted
-or the number of asynchronous insertions initiated if FI_EVENT is set.
+Insertion calls for an AV opened for synchronous operation will return
+the number of addresses that were successfully inserted.  In the case of
+failure, the return value will be less than the number of addresses that
+were specified.
 
-Other calls return 0 on success.
+Insertion calls for an AV opened for asynchronous operation (with FI_EVENT
+flag specified) will return 0 if the operation was successfully initiated.
+In the case of failure, a negative fabric errno will be returned.
 
-On error, a negative value corresponding to
-fabric errno is returned.
+All other calls return 0 on success, or a negative value corresponding to
+fabric errno on error.
 Fabric errno values are defined in
 `rdma/fi_errno.h`.
 

--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -248,7 +248,7 @@ static int psmx_av_insert(struct fid_av *av, const void *addr, size_t count,
 		return -FI_ENOMEM;
 
 	psmx_eq_enqueue_event(av_priv->eq, event);
-	return count;
+	return 0;
 }
 
 static int psmx_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -207,7 +207,7 @@ static int sock_check_table_in(struct sock_av *_av, struct sockaddr_in *addr,
 			}
 		}
 		sock_av_report_success(_av, context, ret, flags);
-		return ret;
+		return (_av->attr.flags & FI_EVENT) ? 0 : ret;
 	}
 
 	for (i = 0, ret = 0; i < count; i++) {
@@ -274,7 +274,7 @@ static int sock_check_table_in(struct sock_av *_av, struct sockaddr_in *addr,
 		ret++;
 	}
 	sock_av_report_success(_av, context, ret, flags);
-	return ret;
+	return (_av->attr.flags & FI_EVENT) ? 0 : ret;
 }
 
 static int sock_av_insert(struct fid_av *av, const void *addr, size_t count,
@@ -315,11 +315,6 @@ static int _sock_av_insertsvc(struct fid_av *av, const char *node,
 	struct addrinfo *result = NULL;
 	struct sock_av *_av;
 	
-	if (!service) {
-		SOCK_LOG_ERROR("Port not provided\n");
-		return -FI_EINVAL;
-	}
-	
 	_av = container_of(av, struct sock_av, av_fid);
 	memset(&sock_hints, 0, sizeof(struct addrinfo));
 	sock_hints.ai_family = AF_INET;
@@ -344,6 +339,11 @@ static int sock_av_insertsvc(struct fid_av *av, const char *node,
 		   const char *service, fi_addr_t *fi_addr,
 		   uint64_t flags, void *context)
 {
+	if (!service) {
+		SOCK_LOG_ERROR("Port not provided\n");
+		return -FI_EINVAL;
+	}
+
 	return _sock_av_insertsvc(av, node, service, fi_addr, flags, context, 0);
 }
 

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -315,7 +315,7 @@ usdf_am_insert_async(struct fid_av *fav, const void *addr, size_t count,
 	/* resolve all addresses we can */
 	usdf_av_insert_progress(insert);
 
-	return count;
+	return 0;
 
 fail:
 	if (insert != NULL) {


### PR DESCRIPTION
The man page is confusing on what value to return when
inserting addresses asynchronously into an AV, and as a
result the providers differ on their implementation.

Simplify this by having the AV insert return 0 on success
for asynchronous operations.  This makes it consistent with
other async calls.  Update the man page and providers to
handle this.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>