### PR TITLE
Fix a crash at startup where the sockets provider doesn't initialise

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -546,11 +546,16 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 		for (tail = cur; tail->next; tail = tail->next)
 			;
 	}
+	if (!*info) {
+		ret = -FI_ENODATA;
+		goto err_no_free;
+	}
 	return 0;
 
 err:
 	fi_freeinfo(*info);
 	*info = NULL;
+err_no_free:
 	return ret;
 }
 


### PR DESCRIPTION
This doesn't make sockets work on OS X but it does at least cause the
code to generate an error message rather than a segv.