### PR TITLE
Pr/sockets

### DIFF
--- a/include/fi_rbuf.h
+++ b/include/fi_rbuf.h
@@ -138,6 +138,12 @@ static inline void rbread(struct ringbuf *rb, void *buf, size_t len)
 	rb->rcnt += len;
 }
 
+static inline size_t rbdiscard(struct ringbuf *rb, size_t len)
+{
+	size_t used_len = MIN(rbused(rb), len);
+	rb->rcnt += used_len;
+	return used_len;
+}
 
 /*
  * Ring buffer with blocking read support using an fd

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -616,7 +616,8 @@ struct sock_atomic_req {
 struct sock_msg_response {
 	struct sock_msg_hdr msg_hdr;
 	uint16_t pe_entry_id;
-	uint8_t reserved[6];
+	int32_t err;
+	uint8_t reserved[2];
 };
 
 struct sock_rma_read_req {
@@ -694,11 +695,13 @@ struct sock_pe_entry {
 
 	uint8_t type;
 	uint8_t is_complete;
-	uint8_t reserved[6];
+	uint8_t is_error;
+	uint8_t reserved[5];
 
 	uint64_t done_len;
 	uint64_t total_len;
 	uint64_t data_len;
+	uint64_t rem;
 	struct sock_ep *ep;
 	struct sock_conn *conn;
 	struct sock_comp *comp;
@@ -1001,6 +1004,7 @@ void sock_comm_buffer_finalize(struct sock_conn *conn);
 ssize_t sock_comm_send(struct sock_conn *conn, const void *buf, size_t len);
 ssize_t sock_comm_recv(struct sock_conn *conn, void *buf, size_t len);
 ssize_t sock_comm_peek(struct sock_conn *conn, void *buf, size_t len);
+ssize_t sock_comm_discard(struct sock_conn *conn, size_t len);
 ssize_t sock_comm_data_avail(struct sock_conn *conn);
 ssize_t sock_comm_flush(struct sock_conn *conn);
 

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -416,6 +416,7 @@ struct sock_cm_entry {
 struct sock_conn_listener {
 	int sock;
 	int do_listen;
+	int is_ready;
 	int signal_fds[2];
 	pthread_t listener_thread;
 	char service[NI_MAXSERV];

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -201,6 +201,12 @@ ssize_t sock_comm_peek(struct sock_conn *conn, void *buf, size_t len)
 	return 0;
 }
 
+ssize_t sock_comm_discard(struct sock_conn *conn, size_t len)
+{
+	sock_comm_recv_buffer(conn);
+	return rbdiscard(&conn->inbuf, len);
+}
+
 ssize_t sock_comm_data_avail(struct sock_conn *conn)
 {
 	sock_comm_recv_buffer(conn);

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -158,13 +158,20 @@ int fd_set_nonblock(int fd)
 	return ret;
 }
 
-void sock_set_sockopts(int sock)
+static void sock_set_sockopt_reuseaddr(int sock)
 {
 	int optval;
 	optval = 1;
 	if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof optval))
 		SOCK_LOG_ERROR("setsockopt reuseaddr failed\n");
+}
 
+void sock_set_sockopts(int sock)
+{
+	int optval;
+	optval = 1;
+
+	sock_set_sockopt_reuseaddr(sock);
 	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof optval))
 		SOCK_LOG_ERROR("setsockopt nodelay failed\n");
 
@@ -181,15 +188,27 @@ uint16_t sock_conn_map_connect(struct sock_ep *ep,
 	struct timeval tv;
 	socklen_t optlen;
 	fd_set fds;
+	struct sockaddr_in src_addr;
 
 	conn_fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (conn_fd < 0) {
 		SOCK_LOG_ERROR("failed to create conn_fd, errno: %d\n", errno);
 		return 0;
 	}
+
+	memcpy(&src_addr, ep->src_addr, sizeof src_addr);
+	src_addr.sin_port = 0;
+	optlen = sizeof src_addr;
+
+	sock_set_sockopt_reuseaddr(conn_fd);
+	if (bind(conn_fd, (struct sockaddr*) &src_addr, optlen)) {
+		SOCK_LOG_ERROR("bind failed : %s\n", strerror(errno));
+		close(conn_fd);
+		return 0;
+	}
 	
-	SOCK_LOG_INFO("Connecting to: %s:%d\n", inet_ntoa(addr->sin_addr),
-		      ntohs(addr->sin_port));
+	SOCK_LOG_INFO("Connecting to: %s:%d from %s\n", inet_ntoa(addr->sin_addr),
+		      ntohs(addr->sin_port), inet_ntoa(src_addr.sin_addr));
 
 	if (connect(conn_fd, (struct sockaddr *) addr, sizeof *addr) < 0) {
 		if (errno == EINPROGRESS) {

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -591,7 +591,8 @@ static int sock_ep_close(struct fid *fid)
 		SOCK_LOG_INFO("Failed to signal\n");
 	}
 	
-	if (pthread_join(sock_ep->listener.listener_thread, NULL)) {
+	if (sock_ep->listener.listener_thread && 
+	    pthread_join(sock_ep->listener.listener_thread, NULL)) {
 		SOCK_LOG_ERROR("pthread join failed (%d)\n", errno);
 	}
 	
@@ -946,7 +947,8 @@ int sock_ep_enable(struct fid_ep *ep)
 			}
 		}
 	}
-	return 0;
+
+	return sock_conn_listen(sock_ep);
 }
 
 int sock_ep_disable(struct fid_ep *ep)
@@ -1461,9 +1463,6 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 	}
 
   	sock_ep->domain = sock_dom;
-	if (sock_conn_listen(sock_ep))
-		goto err;
-
 	fastlock_init(&sock_ep->cm.lock);
 	if (sock_ep->ep_type == FI_EP_MSG) {
 		dlist_init(&sock_ep->cm.msg_list);

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -257,6 +257,35 @@ static int sock_ep_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 	return 0;
 }
 
+static int sock_ep_cm_setnmae(fid_t fid, void *addr, size_t addrlen)
+{
+	struct sock_ep *sock_ep = NULL;
+	struct sock_pep *sock_pep = NULL;
+
+	if (addrlen != sizeof(struct sockaddr_in))
+		return -FI_EINVAL;
+
+	switch(fid->fclass) {
+	case FI_CLASS_EP:
+	case FI_CLASS_SEP:
+		sock_ep = container_of(fid, struct sock_ep, ep.fid);
+		if (sock_ep->listener.listener_thread)
+			return -FI_EINVAL;
+		memcpy(sock_ep->src_addr, addr, addrlen);
+		break;
+	case FI_CLASS_PEP:
+		sock_pep = container_of(fid, struct sock_pep, pep.fid);
+		if (sock_pep->cm.listener_thread)
+			return -FI_EINVAL;
+		memcpy(&sock_pep->src_addr, addr, addrlen);
+		break;
+	default:
+		SOCK_LOG_ERROR("Invalid argument\n");
+		return -FI_EINVAL;
+	}
+	return 0;
+}
+
 static int sock_ep_cm_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
 {
 	struct sock_ep *sock_ep;
@@ -742,7 +771,7 @@ static int sock_ep_cm_shutdown(struct fid_ep *ep, uint64_t flags)
 
 struct fi_ops_cm sock_ep_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
-	.setname = fi_no_setname,
+	.setname = sock_ep_cm_setnmae,
 	.getname = sock_ep_cm_getname,
 	.getpeer = sock_ep_cm_getpeer,
 	.connect = sock_ep_cm_connect,

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -659,6 +659,9 @@ static int sock_ep_cm_connect(struct fid_ep *ep, const void *addr,
 	if (!_eq || paramlen > SOCK_EP_MAX_CM_DATA_SZ) 
 		return -FI_EINVAL;
 
+	if (!_ep->listener.listener_thread && sock_conn_listen(_ep))
+		return -FI_EINVAL;
+
 	req = calloc(1, sizeof(*req) + paramlen);
 	if (!req)
 		return -FI_ENOMEM;
@@ -709,6 +712,9 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param, size_t paraml
 		return -FI_EINVAL;
 
 	if (_ep->is_disabled || _ep->cm.shutdown_received)
+		return -FI_EINVAL;
+
+	if (!_ep->listener.listener_thread && sock_conn_listen(_ep))
 		return -FI_EINVAL;
 
 	response = calloc(1, sizeof(*response) + paramlen);

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -376,8 +376,10 @@ void sock_fabric_remove_service(struct sock_fabric *fab, int service)
 	struct sock_service_entry *service_entry;
 	fastlock_acquire(&fab->lock);
 	service_entry = sock_fabric_find_service(fab, service);
-	dlist_remove(&service_entry->entry);
-	free(service_entry);
+	if (service_entry) {
+		dlist_remove(&service_entry->entry);
+		free(service_entry);
+	}
 	fastlock_release(&fab->lock);
 }
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -110,13 +110,10 @@ static void sock_pe_release_entry(struct sock_pe *pe,
 {
 	dlist_remove(&pe_entry->ctx_entry);
 
-	if (pe_entry->type == SOCK_PE_TX) {
-		if (pe_entry->conn->tx_pe_entry == pe_entry)
-			pe_entry->conn->tx_pe_entry = NULL;
-	} else {
-		if (pe_entry->conn->rx_pe_entry == pe_entry)
-			pe_entry->conn->rx_pe_entry = NULL;
-	}
+	if (pe_entry->conn->tx_pe_entry == pe_entry)
+		pe_entry->conn->tx_pe_entry = NULL;
+	if (pe_entry->conn->rx_pe_entry == pe_entry)
+		pe_entry->conn->rx_pe_entry = NULL;
 
 	pe->num_free_entries++;
 	pe_entry->conn = NULL;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -105,6 +105,23 @@ static inline ssize_t sock_pe_recv_field(struct sock_pe_entry *pe_entry,
 	return (ret == data_len) ? 0 : -1;
 }
 
+static inline void sock_pe_discard_field(struct sock_pe_entry *pe_entry)
+{
+	size_t ret;
+	if (!pe_entry->rem)
+		return;
+
+	SOCK_LOG_INFO("Remaining for %p: %ld\n", pe_entry, pe_entry->rem);
+	ret = sock_comm_discard(pe_entry->conn, pe_entry->rem);
+	SOCK_LOG_INFO("Discarded %ld\n", ret);
+       
+	pe_entry->rem -= ret;
+	if (pe_entry->done_len == pe_entry->total_len && !pe_entry->rem) {
+		SOCK_LOG_INFO("Discard complete for %p\n", pe_entry);
+		pe_entry->is_complete = 1;
+	}
+}
+
 static void sock_pe_release_entry(struct sock_pe *pe, 
 				  struct sock_pe_entry *pe_entry)
 {
@@ -123,8 +140,9 @@ static void sock_pe_release_entry(struct sock_pe *pe,
 	memset(&pe_entry->msg_hdr, 0, sizeof(pe_entry->msg_hdr));
 	memset(&pe_entry->response, 0, sizeof(pe_entry->response));
 
-	pe_entry->type =0;
+	pe_entry->type = 0;
 	pe_entry->is_complete = 0;
+	pe_entry->is_error = 0;
 	pe_entry->done_len = 0;
 	pe_entry->total_len = 0;
 	pe_entry->data_len = 0;
@@ -325,13 +343,31 @@ static void sock_pe_report_read_completion(struct sock_pe_entry *pe_entry)
 		sock_cntr_inc(pe_entry->comp->read_cntr);
 }
 
-static void sock_pe_report_error(struct sock_pe_entry *pe_entry, int rem)
+static void sock_pe_report_rx_error(struct sock_pe_entry *pe_entry, int rem)
 {
 	if (pe_entry->comp->recv_cntr)
 		sock_cntr_err_inc(pe_entry->comp->recv_cntr);
 	if (pe_entry->comp->recv_cq)
 		sock_cq_report_error(pe_entry->comp->recv_cq, pe_entry, rem, 
 				     FI_ENOSPC, -FI_ENOSPC, NULL);
+}
+
+static void sock_pe_report_tx_rma_read_err(struct sock_pe_entry *pe_entry, int err)
+{
+	if (pe_entry->comp->read_cntr)
+		sock_cntr_err_inc(pe_entry->comp->read_cntr);
+	if (pe_entry->comp->read_cq)
+		sock_cq_report_error(pe_entry->comp->read_cq, pe_entry, 0, 
+				     err, -err, NULL);
+}
+
+static void sock_pe_report_tx_rma_write_err(struct sock_pe_entry *pe_entry, int err)
+{
+	if (pe_entry->comp->write_cntr)
+		sock_cntr_err_inc(pe_entry->comp->write_cntr);
+	if (pe_entry->comp->write_cq)
+		sock_cq_report_error(pe_entry->comp->write_cq, pe_entry, 0, 
+				     err, -err, NULL);
 }
 
 static void sock_pe_progress_pending_ack(struct sock_pe *pe, 
@@ -386,7 +422,7 @@ static void sock_pe_progress_pending_ack(struct sock_pe *pe,
 		break;
 	}
 	
-	if (pe_entry->total_len == pe_entry->done_len) {
+	if (pe_entry->total_len == pe_entry->done_len && !pe_entry->rem) {
 		pe_entry->is_complete = 1;
 		pe_entry->pe.rx.pending_send = 0;
 		sock_comm_flush(pe_entry->conn);
@@ -397,12 +433,13 @@ static void sock_pe_progress_pending_ack(struct sock_pe *pe,
 static void sock_pe_send_response(struct sock_pe *pe, 
 				  struct sock_rx_ctx *rx_ctx,
 				  struct sock_pe_entry *pe_entry, 
-				  size_t data_len, uint8_t op_type)
+				  size_t data_len, uint8_t op_type, int err)
 {
 	struct sock_msg_response *response = &pe_entry->response;
 	memset(response, 0, sizeof(struct sock_msg_response));
 
 	response->pe_entry_id = htons(pe_entry->msg_hdr.pe_entry_id);
+	response->err = htonl(err);
 	response->msg_hdr.dest_iov_len = 0;
 	response->msg_hdr.flags = 0;
 	response->msg_hdr.msg_len = sizeof(*response) + data_len;
@@ -434,6 +471,7 @@ inline static int sock_pe_read_response(struct sock_pe_entry *pe_entry)
 				      data_len, len)))
 		return ret;
 	pe_entry->response.pe_entry_id = ntohs(pe_entry->response.pe_entry_id);
+	pe_entry->response.err = ntohl(pe_entry->response.err);
 	return 0;
 }
 
@@ -453,6 +491,40 @@ static int sock_pe_handle_ack(struct sock_pe *pe, struct sock_pe_entry *pe_entry
 	
 	assert(waiting_entry->type == SOCK_PE_TX);
 	sock_pe_report_tx_completion(waiting_entry);
+	waiting_entry->is_complete = 1;
+	pe_entry->is_complete = 1;
+	return 0;
+}
+
+static int sock_pe_handle_error(struct sock_pe *pe, struct sock_pe_entry *pe_entry)
+{
+	struct sock_pe_entry *waiting_entry;
+	struct sock_msg_response *response;
+
+	if (sock_pe_read_response(pe_entry))
+		return 0;
+
+	response = &pe_entry->response;
+	assert(response->pe_entry_id <= SOCK_PE_MAX_ENTRIES);
+	waiting_entry = &pe->pe_table[response->pe_entry_id];
+	SOCK_LOG_INFO("Received error for PE entry %p (index: %d)\n", 
+		      waiting_entry, response->pe_entry_id);
+	
+	assert(waiting_entry->type == SOCK_PE_TX);
+
+	switch (pe_entry->msg_hdr.op_type) {
+	case SOCK_OP_READ_ERROR:
+		sock_pe_report_tx_rma_read_err(waiting_entry, 
+					       pe_entry->response.err);
+		break;
+	case SOCK_OP_WRITE_ERROR:
+	case SOCK_OP_ATOMIC_ERROR:
+		sock_pe_report_tx_rma_write_err(waiting_entry, 
+						pe_entry->response.err);
+		break;
+	default:
+		SOCK_LOG_ERROR("Invalid op type\n");
+	}
 	waiting_entry->is_complete = 1;
 	pe_entry->is_complete = 1;
 	return 0;
@@ -585,9 +657,11 @@ static int sock_pe_process_rx_read(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 				       (void *) (uintptr_t) pe_entry->pe.rx.rx_iov[i].iov.addr,
 				       pe_entry->pe.rx.rx_iov[i].iov.len,
 				       pe_entry->pe.rx.rx_iov[i].iov.key);
+			pe_entry->is_error = 1;
+			pe_entry->rem = pe_entry->total_len - pe_entry->done_len;
 			sock_pe_send_response(pe, rx_ctx, pe_entry, 0, 
-					      SOCK_OP_READ_ERROR);
-			return -FI_EINVAL;
+					      SOCK_OP_READ_ERROR, FI_EACCES);
+			return 0;
 		}
 		
 		if (mr->domain->attr.mr_mode == FI_MR_SCALABLE)
@@ -600,7 +674,7 @@ static int sock_pe_process_rx_read(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 	pe_entry->flags |= (FI_RMA | FI_REMOTE_READ);
 	sock_pe_report_remote_read(rx_ctx, pe_entry);
 	sock_pe_send_response(pe, rx_ctx, pe_entry, data_len, 
-			      SOCK_OP_READ_COMPLETE);	
+			      SOCK_OP_READ_COMPLETE, 0);	
 	return 0;
 }
 
@@ -638,9 +712,11 @@ static int sock_pe_process_rx_write(struct sock_pe *pe, struct sock_rx_ctx *rx_c
 					       (void *) (uintptr_t) pe_entry->pe.rx.rx_iov[i].iov.addr,
 					       pe_entry->pe.rx.rx_iov[i].iov.len,
 					       pe_entry->pe.rx.rx_iov[i].iov.key);
+				pe_entry->is_error = 1;
+				pe_entry->rem = pe_entry->total_len - pe_entry->done_len;
 				sock_pe_send_response(pe, rx_ctx, pe_entry, 0, 
-						      SOCK_OP_WRITE_ERROR);
-				break;
+						      SOCK_OP_WRITE_ERROR, FI_EACCES);
+				return 0;
 			}
 			
 			if (mr->domain->attr.mr_mode == FI_MR_SCALABLE)
@@ -662,7 +738,7 @@ static int sock_pe_process_rx_write(struct sock_pe *pe, struct sock_rx_ctx *rx_c
 	
 	/* report error, if any */
 	if (rem) {
-		sock_pe_report_error(pe_entry, rem);
+		sock_pe_report_rx_error(pe_entry, rem);
 		goto out;
 	} else {
 		if (pe_entry->flags & FI_REMOTE_CQ_DATA) {
@@ -675,7 +751,7 @@ out:
 	sock_pe_report_remote_write(rx_ctx, pe_entry);
 	sock_pe_report_mr_completion(rx_ctx->domain, pe_entry);
 	sock_pe_send_response(pe, rx_ctx, pe_entry, 0, 
-			      SOCK_OP_WRITE_COMPLETE);	
+			      SOCK_OP_WRITE_COMPLETE, 0);	
 	return ret;
 }
 
@@ -1053,9 +1129,11 @@ static int sock_pe_process_rx_atomic(struct sock_pe *pe, struct sock_rx_ctx *rx_
 				       (void *) (uintptr_t) pe_entry->pe.rx.rx_iov[i].ioc.addr,
 				       pe_entry->pe.rx.rx_iov[i].ioc.count * datatype_sz,
 				       pe_entry->pe.rx.rx_iov[i].ioc.key);
+			pe_entry->is_error = 1;
+			pe_entry->rem = pe_entry->total_len - pe_entry->done_len;
 			sock_pe_send_response(pe, rx_ctx, pe_entry, 0, 
-					      SOCK_OP_ATOMIC_ERROR);
-			goto err;
+					      SOCK_OP_ATOMIC_ERROR, FI_EACCES);
+			return 0;
 		}
 		if (mr->domain->attr.mr_mode == FI_MR_SCALABLE)
 			pe_entry->pe.rx.rx_iov[i].ioc.addr += mr->offset;
@@ -1095,12 +1173,8 @@ static int sock_pe_process_rx_atomic(struct sock_pe *pe, struct sock_rx_ctx *rx_
 	sock_pe_report_mr_completion(rx_ctx->domain, pe_entry);
 	sock_pe_send_response(pe, rx_ctx, pe_entry, 
 			      pe_entry->pe.rx.rx_op.atomic.res_iov_len ? 
-			      entry_len : 0, SOCK_OP_ATOMIC_COMPLETE);
+			      entry_len : 0, SOCK_OP_ATOMIC_COMPLETE, 0);
 	return ret;
-	
-err:
-	sock_pe_report_error(pe_entry, 0);
-	return -FI_EINVAL;
 }
 
 ssize_t sock_rx_peek_recv(struct sock_rx_ctx *rx_ctx, fi_addr_t addr, 
@@ -1190,7 +1264,7 @@ ssize_t sock_rx_claim_recv(struct sock_rx_ctx *rx_ctx, void *context, uint64_t f
 
 		if (rem) {
 			SOCK_LOG_INFO("Not enough space in posted recv buffer\n");
-			sock_pe_report_error(&pe_entry, rem);
+			sock_pe_report_rx_error(&pe_entry, rem);
 		} else {
 			sock_pe_report_rx_completion(&pe_entry);
 		}
@@ -1284,7 +1358,7 @@ static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx)
 	
 		if (rem) {
 			SOCK_LOG_INFO("Not enough space in posted recv buffer\n");
-			sock_pe_report_error(&pe_entry, rem);
+			sock_pe_report_rx_error(&pe_entry, rem);
 			return 0;
 		} else {
 			sock_pe_report_rx_completion(&pe_entry);
@@ -1425,7 +1499,9 @@ static int sock_pe_process_rx_send(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 	/* report error, if any */
 	if (rem) {
 		SOCK_LOG_ERROR("Not enough space in posted recv buffer\n");
-		sock_pe_report_error(pe_entry, rem);
+		sock_pe_report_rx_error(pe_entry, rem);
+		pe_entry->is_error = 1;
+		pe_entry->rem = pe_entry->total_len - pe_entry->done_len;
 		goto out;
 	} else {
 		if (!rx_entry->is_buffered)
@@ -1435,7 +1511,7 @@ static int sock_pe_process_rx_send(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 out:
 	if (pe_entry->msg_hdr.flags & FI_TRANSMIT_COMPLETE) {
 		sock_pe_send_response(pe, rx_ctx, pe_entry, 0, 
-				      SOCK_OP_SEND_COMPLETE);
+				      SOCK_OP_SEND_COMPLETE, 0);
 	}
 		
 	if (!rx_entry->is_buffered &&
@@ -1491,7 +1567,7 @@ static int sock_pe_process_recv(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 	case SOCK_OP_WRITE_ERROR:
 	case SOCK_OP_READ_ERROR:
 	case SOCK_OP_ATOMIC_ERROR:
-		ret = sock_pe_handle_ack(pe, pe_entry);
+		ret = sock_pe_handle_error(pe, pe_entry);
 		break;
 	default:
 		ret = -FI_ENOSYS;
@@ -1562,6 +1638,7 @@ static int sock_pe_read_hdr(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 	msg_hdr->pe_entry_id = ntohs(msg_hdr->pe_entry_id);
 	pe_entry->pe.rx.header_read = 1;
 	pe_entry->flags = msg_hdr->flags;
+	pe_entry->total_len = msg_hdr->msg_len;
 	
 	SOCK_LOG_INFO("PE RX (Hdr read): MsgLen:  %" PRIu64 ", TX-ID: %d, Type: %d\n", 
 		      msg_hdr->msg_len, msg_hdr->rx_id, msg_hdr->op_type);
@@ -1876,6 +1953,9 @@ static int sock_pe_progress_rx_pe_entry(struct sock_pe *pe,
 		goto out;
 	}
 
+	if (pe_entry->is_error)
+		goto out;
+
 	if (!pe_entry->pe.rx.header_read) {
 		if (sock_pe_read_hdr(pe, rx_ctx, pe_entry) == -1) {
 			sock_pe_release_entry(pe, pe_entry);
@@ -1890,6 +1970,9 @@ static int sock_pe_progress_rx_pe_entry(struct sock_pe *pe,
 	}
 	
 out:
+	if (pe_entry->is_error)
+		sock_pe_discard_field(pe_entry);
+
 	if (pe_entry->is_complete && !pe_entry->pe.rx.pending_send) {
 		sock_pe_release_entry(pe, pe_entry);
 		SOCK_LOG_INFO("[%p] RX done\n", pe_entry);


### PR DESCRIPTION
- Bind conn-socket to src_addr before connect()
- Reset rx and tx connections while releasing progress table entry
- Add error-reporting for RMA operations
- Implement fi_setname in sockets provider
- Add check for fabric service entry before accessing it