### PR TITLE
usnic: prevent SEGV if fi_setname is called on a PEP

### DIFF
--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -336,6 +336,7 @@ static struct fi_ops_msg usdf_dgram_prefix_ops = {
 
 static struct fi_ops_cm usdf_cm_dgram_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = fi_no_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -690,6 +690,7 @@ static struct fi_ops_ep usdf_base_rdm_ops = {
 
 static struct fi_ops_cm usdf_cm_rdm_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = usdf_cm_rdm_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -444,6 +444,7 @@ static struct fi_ops_ep usdf_pep_base_ops = {
 
 static struct fi_ops_cm usdf_pep_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = fi_no_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,


### PR DESCRIPTION
This is just slightly more friendly, but still doesn't actually
implement this desirable functionality.  That task is being tracked in
issue #957.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>
