### PR TITLE
sockets: Set fi-setname in passive endpoint CM ops

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -1170,6 +1170,7 @@ out:
 
 static struct fi_ops_cm sock_pep_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = sock_ep_cm_setnmae,
 	.getname = sock_ep_cm_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,


### PR DESCRIPTION
Signed-off-by: Jithin Jose <jithin.jose@intel.com>