### PR TITLE
Add initilization of tail to slist_init.

### DIFF
--- a/include/fi_list.h
+++ b/include/fi_list.h
@@ -123,7 +123,7 @@ struct slist {
 
 static inline void slist_init(struct slist *list)
 {
-	list->head = NULL;
+	list->head = list->tail = NULL;
 }
 
 static inline int slist_empty(struct slist *list)


### PR DESCRIPTION
Very minor fix. Encountered a situation where the list wasn't behaving properly due to tail not being initialized.

Signed-off-by: Ben Turrubiates <bturrubiates@lanl.gov>