### PR TITLE
prov/verbs: Reset verbs_info to NULL after free.

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -3254,6 +3254,7 @@ err:
 static int fi_ibv_fabric_close(fid_t fid)
 {
 	fi_freeinfo(verbs_info);
+	verbs_info = NULL;
 	free(fid);
 	return 0;
 }


### PR DESCRIPTION
verbs_info needs to be reset to NULL after freeing it in fi_ibv_fabric_close.
Otherwise a subsequent call to fi_getinfo will be accessing unallocated
memory in verbs_info.

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>