### PR TITLE
usnic: fix too short recvs does not return -FI_ETRUNC

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ Sayantan Sur          <sayantan.sur@intel.com>
 Xuyang Wang           <xuywang@cisco.com>
 Patrick McCormick     <patrick.m.mccormick@intel.com>
 Dave Goodell          <dgoodell@cisco.com>
+Prankur Gupta         <prankgup@cisco.com>
 Jithin Jose           <jithin.jose@intel.com>
 Miao Luo              <miao.luo@intel.com>
 Arun C Ilango         <arun.ilango@intel.com>

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -331,9 +331,19 @@ struct usdf_cq_hard {
 	struct usd_cq *cqh_ucq;
 	atomic_t cqh_refcnt;
 	void (*cqh_progress)(struct usdf_cq_hard *hcq);
-	void (*cqh_post)(struct usdf_cq_hard *hcq, void *context, size_t len);
+	void (*cqh_post)(struct usdf_cq_hard *hcq, void *context, size_t len,
+			int prov_errno);
 	TAILQ_ENTRY(usdf_cq_hard) cqh_link;
 	TAILQ_ENTRY(usdf_cq_hard) cqh_dom_link;
+};
+
+struct usdf_cq_soft_entry {
+	void		*cse_context;
+	uint64_t	cse_flags;
+	size_t		cse_len;
+	void		*cse_buf;
+	uint64_t	cse_data;
+	int		cse_prov_errno;
 };
 
 struct usdf_cq {
@@ -347,10 +357,10 @@ struct usdf_cq {
 			struct usd_cq *cq_cq;
 		} hard;
 		struct {
-			void *cq_comps;
-			void *cq_end;
-			void *cq_head;
-			void *cq_tail;
+			struct usdf_cq_soft_entry *cq_comps;
+			struct usdf_cq_soft_entry *cq_end;
+			struct usdf_cq_soft_entry *cq_head;
+			struct usdf_cq_soft_entry *cq_tail;
 			TAILQ_HEAD(,usdf_cq_hard) cq_list;
 		} soft;
 	} c;

--- a/prov/usnic/src/usdf_cq.h
+++ b/prov/usnic/src/usdf_cq.h
@@ -40,15 +40,9 @@ int usdf_cq_is_soft(struct usdf_cq *cq);
 int usdf_cq_make_soft(struct usdf_cq *cq);
 int usdf_cq_create_cq(struct usdf_cq *cq);
 
-void usdf_progress_hard_cq_context(struct usdf_cq_hard *hcq);
-void usdf_progress_hard_cq_msg(struct usdf_cq_hard *hcq);
-void usdf_progress_hard_cq_data(struct usdf_cq_hard *hcq);
+void usdf_progress_hard_cq(struct usdf_cq_hard *hcq);
 
-void usdf_cq_post_soft_context(struct usdf_cq_hard *hcq, void *context,
-		size_t len);
-void usdf_cq_post_soft_msg(struct usdf_cq_hard *hcq, void *context,
-		size_t len);
-void usdf_cq_post_soft_data(struct usdf_cq_hard *hcq, void *context,
-		size_t len);
+void usdf_cq_post_soft(struct usdf_cq_hard *hcq, void *context,
+		size_t len, int prov_errno);
 
 #endif /* _USDF_CQ_H_ */

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -231,19 +231,7 @@ usdf_ep_dgram_deref_cq(struct usdf_cq *cq)
 	}
 	atomic_dec(&cq->cq_refcnt);
 
-        switch (cq->cq_attr.format) {
-        case FI_CQ_FORMAT_CONTEXT:
-                rtn = usdf_progress_hard_cq_context;
-                break;
-        case FI_CQ_FORMAT_MSG:
-                rtn = usdf_progress_hard_cq_msg;
-                break;
-        case FI_CQ_FORMAT_DATA:
-                rtn = usdf_progress_hard_cq_data;
-                break;
-        default:
-                return;
-        }
+	rtn = usdf_progress_hard_cq;
 
 	if (usdf_cq_is_soft(cq)) {
 		TAILQ_FOREACH(hcq, &cq->c.soft.cq_list, cqh_link) {

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -462,18 +462,7 @@ usdf_ep_msg_bind_cq(struct usdf_ep *ep, struct usdf_cq *cq, uint64_t flags)
 		hcq->cqh_cq = cq;
 		atomic_initialize(&hcq->cqh_refcnt, 0);
 		hcq->cqh_progress = usdf_msg_hcq_progress;
-		switch (cq->cq_attr.format) {
-		default:
-		case FI_CQ_FORMAT_CONTEXT:
-			hcq->cqh_post = usdf_cq_post_soft_context;
-			break;
-		case FI_CQ_FORMAT_MSG:
-			hcq->cqh_post = usdf_cq_post_soft_msg;
-			break;
-		case FI_CQ_FORMAT_DATA:
-			hcq->cqh_post = usdf_cq_post_soft_data;
-			break;
-		}
+		hcq->cqh_post = usdf_cq_post_soft;
 		TAILQ_INSERT_TAIL(&cq->c.soft.cq_list, hcq, cqh_link);
 
 		/* add to domain progression list */

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -444,18 +444,7 @@ usdf_ep_rdm_bind_cq(struct usdf_ep *ep, struct usdf_cq *cq, uint64_t flags)
 		hcq->cqh_cq = cq;
 		atomic_initialize(&hcq->cqh_refcnt, 0);
 		hcq->cqh_progress = usdf_rdm_hcq_progress;
-		switch (cq->cq_attr.format) {
-		default:
-		case FI_CQ_FORMAT_CONTEXT:
-			hcq->cqh_post = usdf_cq_post_soft_context;
-			break;
-		case FI_CQ_FORMAT_MSG:
-			hcq->cqh_post = usdf_cq_post_soft_msg;
-			break;
-		case FI_CQ_FORMAT_DATA:
-			hcq->cqh_post = usdf_cq_post_soft_data;
-			break;
-		}
+		hcq->cqh_post = usdf_cq_post_soft;
 		TAILQ_INSERT_TAIL(&cq->c.soft.cq_list, hcq, cqh_link);
 
 		/* add to domain progression list */

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -1109,7 +1109,7 @@ usdf_rdm_recv_complete(struct usdf_rx *rx, struct usdf_rdm_connection *rdc,
 
 	USDF_DBG_SYS(EP_DATA, "RECV complete ID=%u len=%lu\n", rdc->dc_rx_msg_id, rqe->rd_length);
 	hcq = rx->r.rdm.rx_hcq;
-	hcq->cqh_post(hcq, rqe->rd_context, rqe->rd_length);
+	hcq->cqh_post(hcq, rqe->rd_context, rqe->rd_length, FI_SUCCESS);
 
 	TAILQ_INSERT_HEAD(&rx->r.rdm.rx_free_rqe, rqe, rd_link);
 	++rx->r.msg.rx_num_free_rqe;
@@ -1284,7 +1284,7 @@ usdf_rdm_process_ack(struct usdf_rdm_connection *rdc,
 				USDF_DBG_SYS(EP_DATA, "send ID=%u complete\n", msg_id);
 				if (wqe->rd_signal_comp)
 					hcq->cqh_post(hcq, wqe->rd_context,
-							wqe->rd_length);
+							wqe->rd_length, FI_SUCCESS);
 
 				TAILQ_INSERT_HEAD(&tx->t.rdm.tx_free_wqe,
 					wqe, rd_link);


### PR DESCRIPTION
When we post a recieve buffer of smaller size than expected, the code
instead of returning -FI_ETRUNC, was returning -FI_EAGAIN.

Signed-off-by: Prankur Gupta <prankgup@cisco.com>

@goodell : Please review