### PR TITLE
prov/verbs: Fix passive endpoint fi_setname() segfault

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -3176,6 +3176,7 @@ static int fi_ibv_pep_listen(struct fid_pep *pep)
 
 static struct fi_ops_cm fi_ibv_pep_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = fi_ibv_pep_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,


### PR DESCRIPTION
This PR addresses the most serious part of issue #976, which is the segfault.  It does not actually implement fi_setname().

The setname ops entry was left NULL for passive endpoints, which
causes an application to segfault if it calls fi_setname() on a passive
endpoint.  This commit fixes the segfault by assigning the pointer to
fi_no_setname so the application gets -FI_ENOSYS instead.

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>

@a-ilango @shefty 