### PR TITLE
usnic: update libusnic_direct to SVN r223029

### DIFF
--- a/prov/usnic/src/usnic_direct/kcompat.h
+++ b/prov/usnic/src/usnic_direct/kcompat.h
@@ -56,6 +56,7 @@
 #include <linux/version.h>
 #include <linux/netdevice.h>
 #include <linux/skbuff.h>
+#include <linux/pci.h>
 
 #ifndef PCI_VENDOR_ID_CISCO
 #define PCI_VENDOR_ID_CISCO	0x1137
@@ -204,8 +205,19 @@ static inline bool skb_flow_dissect(const struct sk_buff *skb, struct flow_keys 
 #endif /*LINUX >= 3.3.0*/
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0))
+#if (!RHEL_RELEASE_CODE || (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(6, 6)))
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 12, 0))
+enum pkt_hash_types {
+	PKT_HASH_TYPE_NONE,	/* Undefined type */
+	PKT_HASH_TYPE_L2,	/* Input: src_MAC, dest_MAC */
+	PKT_HASH_TYPE_L3,	/* Input: src_IP, dst_IP */
+	PKT_HASH_TYPE_L4,	/* Input: src_IP, dst_IP, src_port, dst_port */
+};
+#endif /*kernel < 3.13 */
+#endif /*  !rhel or rhel < 6.6 */
 #define skb_get_hash_raw(skb) (skb)->rxhash
-#endif
+#define skb_set_hash(skb, hash, type) skb->rxhash = (type == PKT_HASH_TYPE_L4) ? hash : 0;
+#endif /* kernel < 3.14 */
 
 #if !defined(__VMKLNX__) && (LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 24))
 #define enic_wq_lock(wq_lock) spin_lock_irqsave(wq_lock, flags)

--- a/prov/usnic/src/usnic_direct/usnic_abi.h
+++ b/prov/usnic/src/usnic_direct/usnic_abi.h
@@ -134,6 +134,7 @@ struct usnic_vnic_barres_info {
 
 struct usnic_ib_create_qp_resp_v0 {
 	USNIC_IB_CREATE_QP_RESP_V0_FIELDS
+	u32				reserved[9];
 };
 
 struct usnic_ib_create_qp_resp {
@@ -146,6 +147,10 @@ struct usnic_ib_create_qp_resp {
 			u32 pad_to_8byte;
 		} v1;
 	} u;
+
+	/* v0 had a "reserved[9]" field, must not shrink the response or we can
+	 * corrupt newer clients running on older kernels */
+	u32				reserved[6];
 };
 
 #define USNIC_CTX_RESP_VERSION 1

--- a/prov/usnic/src/usnic_direct/usnic_direct.h
+++ b/prov/usnic/src/usnic_direct/usnic_direct.h
@@ -151,6 +151,9 @@ struct usd_qp_ops {
     int (*qo_post_send_iov)(struct usd_qp *qp,
             struct usd_dest *dest, const struct iovec* iov,
             size_t iov_count, uint32_t flags, void *context);
+    int (*qo_post_send_one_vlan)(struct usd_qp *qp,
+            struct usd_dest *dest, const void *buf, size_t len,
+            u_int16_t vlan, uint32_t flags, void *context);
 };
 
 /*
@@ -264,7 +267,7 @@ struct usd_device_entry {
  * Send flags
  */
 enum usd_send_flag_shift {
-    USD_SFS_SIGNAL
+    USD_SFS_SIGNAL,
 };
 #define USD_SF_SIGNAL (1 << USD_SFS_SIGNAL)
 
@@ -537,6 +540,28 @@ usd_post_send_one(
 {
     return qp->uq_ops.qo_post_send_one(
             qp, dest, buf, len, flags, context);
+}
+
+/*
+ * post a single-buffer send from registered memory to specified VLAN
+ * IN:
+ *     qp
+ *     dest
+ *     buf -
+ * Requires 2 send credits
+ */
+static inline int
+usd_post_send_one_vlan(
+    struct usd_qp *qp,
+    struct usd_dest *dest,
+    const void *buf,
+    size_t len,
+    u_int16_t vlan,
+    uint32_t flags,
+    void *context)
+{
+    return qp->uq_ops.qo_post_send_one_vlan(
+            qp, dest, buf, len, vlan, flags, context);
 }
 
 /*


### PR DESCRIPTION
Update the code that comes from "libusnic_direct" to match the Cisco
internal SVN repository at r223029.

In particular, this updates to the latest create_qp response ABI.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@jsquyres please review