### PR TITLE
Allow distscript.pl to take an dirty-tree override specified with unders...

### DIFF
--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -158,18 +158,8 @@ doit(0, "./autogen.sh", "autogen");
 verbose("*** Running configure...\n");
 doit(0, "./configure", "configure");
 
-# Note that distscript.pl, invoked by "make dist", checks for a dirty
-# git tree.  We have to tell it that a modified configure.ac is ok.
-# So take the sha1sum of configure.ac and put it in a magic
-# environment variable.
-my $sha1 = `sha1sum configure.ac`;
-chomp($sha1);
-$ENV{'LIBFABRIC_DISTSCRIPT_SHA1_configure.ac'} = $sha1;
-
 verbose("*** Running make distcheck...\n");
 doit(0, "AM_MAKEFLAGS=-j32 make distcheck", "distcheck");
-
-delete $ENV{'LIBFABRIC_DISTSCRIPT_SHA1_configure.ac'};
 
 # Restore configure.ac
 verbose("*** Restoring configure.ac...\n");

--- a/config/distscript.pl
+++ b/config/distscript.pl
@@ -50,46 +50,6 @@ sub subst {
 }
 
 ###############################################################################
-# Check to see that the source tree is clean / has no local changes
-###############################################################################
-
-if (-d ".git") {
-    open(GIT_STATUS, "git status --porcelain|") ||
-        die "Can't run git status to verify that the source tree is clean";
-    my $clean = 1;
-    while (<GIT_STATUS>) {
-        chomp;
-        if ($_ =~ m/^([^?! ].|.[^?! ]) (.+)$/) {
-            my $file = $2;
-            print "*** WARNING: found modified file in source tree: $file\n";
-
-            # There is one exception that is allowed: the nightly
-            # tarball script changes configure.ac to set the correct
-            # version number.  In this case, the nightly tarball
-            # script will set a magic environment variable with the
-            # SHA1 hash of the ok-to-be-modified file.  See if it is
-            # set, and if the SHA1 hash agrees.
-            if (exists($ENV{"LIBFABRIC_DISTSCRIPT_SHA1_$file"})) {
-                my $sha1 = `sha1sum $file`;
-                chomp($sha1);
-                if ($sha1 eq $ENV{"LIBFABRIC_DISTSCRIPT_SHA1_$file"}) {
-                    print "*** ...but an environment variable override says that this is ok!\n";
-                } else {
-                    $clean = 0;
-                }
-            } else {
-                $clean = 0;
-            }
-        }
-    }
-    close(GIT_STATUS);
-    if (!$clean) {
-        print "*** WARNING: Source tree is not clean.\n";
-        die "Refusing to make tarball";
-    }
-}
-
-###############################################################################
 # Change into the new distribution tree
 ###############################################################################
 


### PR DESCRIPTION
...cores.

The shell can't specify environment variables with dots in them. This change allows:
$ sh LIBFABRIC_DISTSCRIPT_SHA1_configure_ac=24171f66be43f31f3618e95d55dbef31d28a48ec  configure.ac make dist

As an alternative to specifying the env var with dots in the filename.
The functionality of the nightly cron tarball should not be affected.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>