### PR TITLE
fabric: update comment

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -134,7 +134,7 @@ struct fi_ioc {
 };
 
 /*
- * Format for transport addresses: sendto, writeto, etc.
+ * Format for transport addresses to insert into address vectors
  */
 enum {
 	FI_FORMAT_UNSPEC,	/* void * */


### PR DESCRIPTION
We don't have sendto functions any more. Also, the send/recv functions
take fi_addr_t that's obtained from AV insert. The comment seemed out of
date.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>