### PR TITLE
sockets: minor updates/fixes for atomic operations

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -702,7 +702,8 @@ struct sock_pe_entry {
 	uint8_t type;
 	uint8_t is_complete;
 	uint8_t is_error;
-	uint8_t reserved[5];
+	uint8_t mr_checked;
+	uint8_t reserved[4];
 
 	uint64_t done_len;
 	uint64_t total_len;

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -182,10 +182,12 @@ static ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 		dst_len += (tx_iov.ioc.count * datatype_sz);
 	}
 	
-	if (dst_len != src_len) {
+	if (msg->iov_count && dst_len != src_len) {
 		SOCK_LOG_ERROR("Buffer length mismatch\n");
 		ret = -FI_EINVAL;
 		goto err;
+	} else {
+		src_len = dst_len;
 	}
 
 	dst_len = 0;
@@ -228,6 +230,24 @@ err:
 static ssize_t sock_ep_atomic_writemsg(struct fid_ep *ep,
 			const struct fi_msg_atomic *msg, uint64_t flags)
 {
+	switch (msg->op) {
+	case FI_MIN:
+	case FI_MAX: 
+	case FI_SUM:
+	case FI_PROD:
+	case FI_LOR:
+	case FI_LAND:
+	case FI_BOR:
+	case FI_BAND:
+	case FI_LXOR: 
+	case FI_BXOR:
+	case FI_ATOMIC_WRITE:
+		break;
+	default:
+		SOCK_LOG_ERROR("Invalid operation type\n");
+		return -FI_EINVAL;
+	}
+
 	return sock_ep_tx_atomic(ep, msg, NULL, NULL, 0,
 				  NULL, NULL, 0, flags);
 }
@@ -324,6 +344,25 @@ static ssize_t sock_ep_atomic_readwritemsg(struct fid_ep *ep,
 					    struct fi_ioc *resultv, void **result_desc, 
 					    size_t result_count, uint64_t flags)
 {
+	switch (msg->op) {
+	case FI_MIN:
+	case FI_MAX: 
+	case FI_SUM:
+	case FI_PROD:
+	case FI_LOR:
+	case FI_LAND:
+	case FI_BOR:
+	case FI_BAND:
+	case FI_LXOR: 
+	case FI_BXOR:
+	case FI_ATOMIC_READ:
+	case FI_ATOMIC_WRITE:
+		break;
+	default:
+		SOCK_LOG_ERROR("Invalid operation type\n");
+		return -FI_EINVAL;
+	}
+
 	return sock_ep_tx_atomic(ep, msg, NULL, NULL, 0,
 				 resultv, result_desc, result_count, flags);
 }
@@ -399,6 +438,20 @@ static ssize_t sock_ep_atomic_compwritemsg(struct fid_ep *ep,
 			struct fi_ioc *resultv, void **result_desc, size_t result_count,
 			uint64_t flags)
 {
+	switch (msg->op) {
+	case FI_CSWAP:
+	case FI_CSWAP_NE:
+	case FI_CSWAP_LE:
+	case FI_CSWAP_LT:
+	case FI_CSWAP_GE:
+	case FI_CSWAP_GT:
+	case FI_MSWAP:
+		break;
+	default:
+		SOCK_LOG_ERROR("Invalid operation type\n");
+		return -FI_EINVAL;
+	}
+
 	return sock_ep_tx_atomic(ep, msg, comparev, compare_desc, compare_count,
 				 resultv, result_desc, result_count, flags);
 }


### PR DESCRIPTION
- Add check for op types in atomic operations
- Add check to avoid extra mr checks

Signed-off-by: Jithin Jose <jithin.jose@intel.com>