### PR TITLE
fabric: Limit FI_ATOMIC_READ to atomic::readwrite

### DIFF
--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -395,6 +395,11 @@ struct fi_rma_ioc {
 };
 {% endhighlight %}
 
+The following list of atomic operations are usable with base
+atomic operations: FI_MIN, FI_MAX, FI_SUM, FI_PROD,
+FI_LOR, FI_LAND, FI_BOR, FI_BAND, FI_LXOR, FI_BXOR,
+and FI_ATOMIC_WRITE.
+
 ## Fetch-Atomic Functions
 
 The fetch atomic functions -- fi_fetch_atomic, fi_fetch_atomicv,
@@ -405,8 +410,8 @@ value that was stored at the target to the user.  The initial value is
 read into the user provided result buffer.  The target buffer of
 fetch-atomic operations must be enabled for remote read access.
 
-The following list of atomic operations are usable with both the base
-atomic and fetch atomic operations: FI_MIN, FI_MAX, FI_SUM, FI_PROD,
+The following list of atomic operations are usable with
+fetch atomic operations: FI_MIN, FI_MAX, FI_SUM, FI_PROD,
 FI_LOR, FI_LAND, FI_BOR, FI_BAND, FI_LXOR, FI_BXOR, FI_ATOMIC_READ,
 and FI_ATOMIC_WRITE.
 

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -225,10 +225,6 @@ static int psmx_atomic_do_write(void *dest, void *src,
 				dest,src,count,PSMX_BXOR);
 		break;
 
-	case FI_ATOMIC_READ:
-		/* do nothing */
-		break;
-
 	case FI_ATOMIC_WRITE:
 		SWITCH_ALL_TYPE(datatype,PSMX_ATOMIC_WRITE,
 				dest,src,count,PSMX_COPY);
@@ -1315,7 +1311,6 @@ static int psmx_atomic_writevalid(struct fid_ep *ep,
 	case FI_BAND:
 	case FI_LXOR:
 	case FI_BXOR:
-	case FI_ATOMIC_READ:
 	case FI_ATOMIC_WRITE:
 		break;
 


### PR DESCRIPTION
FI_ATOMIC_READ is defined for both fi_atomic and
fi_fetch_atomic operations.  In the first case, fi_atomic
maps to an atomic::write() call.  This causes confusion
and results in branches in the provider.  The problem is
that the parameters passed into write() are used as the
source buffer in all cases, except for ATOMIC_READ, which
needs it as a destination.  Plus it's just odd that a
write() call results in a read...

Fix this by documenting that FI_ATOMIC_READ is only a
fetch atomic operation.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>