### PR TITLE
prov/verbs: Fix build warnings

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -816,7 +816,7 @@ err:
 static int fi_ibv_init_info()
 {
 	struct ibv_context **ctx_list;
-	struct fi_info *fi, *tail;
+	struct fi_info *fi = NULL, *tail = NULL;
 	int ret = 0, i, num_devices;
 
 	if (verbs_info)


### PR DESCRIPTION
prov/verbs/src/fi_verbs.c: In function ‘fi_ibv_init_info’:
prov/verbs/src/fi_verbs.c:819: warning: ‘tail’ may be used uninitialized in this function
prov/verbs/src/fi_verbs.c:819: warning: ‘fi’ may be used uninitialized in this function

Signed-off-by: Sean Hefty <sean.hefty@intel.com>