### PR TITLE
Makefile.am: ensure usnic provider has libibverbs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -215,6 +215,15 @@ _usnic_files = \
 
 if HAVE_VERBS
 _usnic_files += prov/usnic/src/usdf_fake_ibv.c
+
+# If the verbs or usnic providers are being built as a DL, then we
+# need to link libibverbs into the usnic provider
+if HAVE_VERBS_DL
+_usnic_libibverbs = -libverbs
+endif
+if HAVE_USNIC_DL
+_usnic_libibverbs = -libverbs
+endif
 endif
 
 _usnic_cppflags = \
@@ -232,13 +241,13 @@ libusnic_fi_la_SOURCES = $(_usnic_files) $(common_srcs)
 libusnic_fi_la_LDFLAGS = \
         $(usnic_ln_LDFLAGS) \
         -module -avoid-version -shared -export-dynamic
-libusnic_fi_la_LIBADD = $(linkback) $(usnic_nl_LIBS)
+libusnic_fi_la_LIBADD = $(linkback) $(_usnic_libibverbs) $(usnic_nl_LIBS)
 libusnic_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_USNIC_DL
 src_libfabric_la_SOURCES += $(_usnic_files)
 src_libfabric_la_CPPFLAGS += $(_usnic_cppflags)
 src_libfabric_la_LDFLAGS += $(usnic_nl_LDFLAGS)
-src_libfabric_la_LIBADD += $(usnic_nl_LIBS)
+src_libfabric_la_LIBADD += $(_usnic_libibverbs) $(usnic_nl_LIBS)
 endif !HAVE_USNIC_DL
 
 endif HAVE_USNIC


### PR DESCRIPTION
As noted in #1007, if you

```
$ ./configure --enable-usnic=yes --enable-verbs=dl
```

Then the usnic provider in libfabric does not end up linked against libibverbs.  Similarly, if you:

```
$ ./configure --enable-usnic=dl --enable-verbs=dl
```

Then the usnic provider DL does not end up linked against libibverbs.

Either way the usnic provider fails, because it calls `ibv_register_driver()`.

This commit fixes that problem by ensuring that if the verbs provider is to be built, if we're building either the verbs or usnic provider as a DL, then ensure we link against libibverbs.

@goodell @pmmccorm please review

Fixes #1007