### PR TITLE
configure.ac: bump version to v1.0.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT([libfabric], [1.0.0], [ofiwg@lists.openfabrics.org])
+AC_INIT([libfabric], [1.0.1], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)


### PR DESCRIPTION
Since v1.0.0 has been released, bump the version in configure.ac to a new version so that there is no confusion in nightly snapshot tarballs.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>