### PR TITLE
Fix small type-os.

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -681,7 +681,7 @@ details.
 
 # TRANSMIT CONTEXT ATTRIBUTES
 
-Attribute specific to the transmit capabilities of an endpoint are
+Attributes specific to the transmit capabilities of an endpoint are
 specified using struct fi_tx_attr.
 
 {% highlight c %}
@@ -805,7 +805,7 @@ completed transfers, allow acknowledgments to be sent over different
 fabric paths, and support more sophisticated retry mechanisms.
 This can result in lower-latency completions, particularly when
 using unconnected endpoints.  Strict completion ordering may require
-that providers queue completed operations or limit available optimizations
+that providers queue completed operations or limit available optimizations.
 
 For transmit requests, completion ordering depends on the endpoint
 communication type.  For unreliable communication, completion ordering
@@ -860,7 +860,7 @@ IO vectors that may be carried in a single request from a remote endpoint.
 
 # RECEIVE CONTEXT ATTRIBUTES
 
-Attribute specific to the receive capabilities of an endpoint are
+Attributes specific to the receive capabilities of an endpoint are
 specified using struct fi_rx_attr.
 
 {% highlight c %}


### PR DESCRIPTION
Fixing a few small type-os I found while reading the fi_endpoint man page.

While I'm here, I noticed that for FI_ORDER_STRICT completion ordering, the transmit side say "in the order submitted," where as the receive side says "in the order processed."  Is this intentional?  Sorry if I missed a discussion on this somewhere.  Just looking for justification (not sure if man page is the place for it tho).

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>