### PR TITLE
make dist: allow a list of files to bypass git clean checks

### DIFF
--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -160,11 +160,8 @@ doit(0, "./configure", "configure");
 
 # Note that distscript.pl, invoked by "make dist", checks for a dirty
 # git tree.  We have to tell it that a modified configure.ac is ok.
-# So take the sha1sum of configure.ac and put it in a magic
-# environment variable.
-my $sha1 = `sha1sum configure.ac`;
-chomp($sha1);
-$ENV{'LIBFABRIC_DISTSCRIPT_SHA1_configure.ac'} = $sha1;
+# Put the name "configure.ac" in a magic environment variable.
+$ENV{'LIBFABRIC_DISTSCRIPT_DIRTY_FILES'} = "configure.ac";
 
 verbose("*** Running make distcheck...\n");
 doit(0, "AM_MAKEFLAGS=-j32 make distcheck", "distcheck");


### PR DESCRIPTION
The environment variable LIBFABRIC_DISTSCRIPT_DIRTY_FILES can now be used to specify a whitespace-delimited list of files that will be allowed to be git dirty during "make dist[check]".  This allows the making of local distributions (mainly used for internal testing) with some dirty files, but still get the safety of the rest of the git cleanliness check.

Concrete example: local automated regression testing sets a release number in libfabric.spec.in.  That file is therefore ok to be dirty in this case -- the resulting tarball/RPM is only intended for local internal testing.

This PR replaces #993 and #1015.  The argument that @pmmccorm used to win me over to this idea is that he wants his automated testing to benefit from the git cleanliness check for all *other* files in the tree -- just not the libfabric.spec.in file (because they have modified the "release" value in it).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>