### PR TITLE
pr/sockets: bug fix - Return -FI_EAVAIL for fi_cntr_wait if error available

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -250,6 +250,7 @@ struct sock_cntr {
 	struct fid_wait *waitset;
 	int signal;
 	int is_waiting;
+	int err_flag;
 };
 
 struct sock_mr {


### PR DESCRIPTION
Return -FI_EAVAIL for fi_cntr_wait if error available

Signed-off-by: Jithin Jose <jithin.jose@intel.com>