### PR TITLE
configure.ac: require autoconf 2.60

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_PREREQ(2.57)
+AC_PREREQ([2.60])
 AC_INIT([libfabric], [1.0.1], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)


### PR DESCRIPTION
Per:

https://github.com/ofiwg/libfabric/issues/1026#issuecomment-101819467

it looks like we need at least autoconf 2.60.  There might be other
issues that will cause us to still require a version >2.60 at some
point.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@jsquyres please review