### PR TITLE
configury: check the psm_epconn_t type can be used

### DIFF
--- a/prov/psm/configure.m4
+++ b/prov/psm/configure.m4
@@ -21,6 +21,8 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 				[psm_happy=1],
 				[psm_happy=0])
 	      ])
+	AS_IF([test x"$psm_happy" = x"1"],
+   	      [AC_CHECK_TYPE([psm_epconn_t], [], [psm_happy=0], [[#include <psm.h>]])])
 
 	AS_IF([test $psm_happy -eq 1], [$1], [$2])
 ])


### PR DESCRIPTION
@jsquyres / @goodell  could you please review this ?

libfabric (both from ofiwg/libfabric/master and open-mpi/ompi/master) cannot be built on RHEL 6.2
(RHEL7 is fine) : it fails to build the psm provider.

the infinipath-psm-devel RPM is installed on both, but the psm_epconn_t type is not part of the RHEL 6.2 header. fwiw, on rhel 6.2, some symbols are defined in the libs but not in the headers.

though the root cause is likely a redhat packaging issue, this extra check make sure psm provider is not built if the psm_epconn_t is not defined.

this should be backported to open-mpi/ompi master