### PR TITLE
usnic: implement fi_cq_sread()

### DIFF
--- a/prov/usnic/src/usdf_cq.h
+++ b/prov/usnic/src/usdf_cq.h
@@ -36,6 +36,8 @@
 #ifndef _USDF_CQ_H_
 #define _USDF_CQ_H_
 
+#define SREAD_SLEEP_TIME_MS 5
+
 int usdf_cq_is_soft(struct usdf_cq *cq);
 int usdf_cq_make_soft(struct usdf_cq *cq);
 int usdf_cq_create_cq(struct usdf_cq *cq);


### PR DESCRIPTION
Added fi_cq_sread for hard and soft cq's. Ignoring the cond arguement for
now. This version of fi_cq_sread will accumulate the completions till
the timeout, specified by the user, rather than returning only 1
completion.
This fixes #943

Signed-off-by: Prankur Gupta <prankgup@cisco.com>

@goodell : Please review