### PR TITLE
COPYING: Add Cisco copyright, fix Intel copyright

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -3,7 +3,8 @@ licenses.  You may choose to be licensed under the terms of the the
 BSD license or the GNU General Public License (GPL) Version
 2, both included below.
 
-Copyright (c) 2005 Intel Corporation.  All rights reserved.
+Copyright (c) 2015 Intel Corporation.  All rights reserved.
+Copyright (c) 2015 Cisco Systems, Inc.  All rights reserved.
 
 ==================================================================
 


### PR DESCRIPTION
Trivial fix, but can someone from Intel verify that you really meant 2015, not 2005?