### PR TITLE
fi_tostr: fix typo that generated invalid YAML

### DIFF
--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -330,7 +330,7 @@ static void fi_tostr_ep_attr(char *buf, const struct fi_ep_attr *attr, const cha
 	}
 
 	strcatf(buf, "%sfi_ep_attr:\n", prefix);
-	strcatf(buf, "%sep_type: ", TAB);
+	strcatf(buf, "%s%sep_type: ", prefix, TAB);
 	fi_tostr_ep_type(buf, attr->type);
 	strcatf(buf, "\n");
 	strcatf(buf, "%s%sprotocol: ", prefix, TAB);


### PR DESCRIPTION
The `ep_type` key should be a child of `fi_ep_attr` (i.e., a key in
the hash which is the value for the `fi_ep_attr` key).

Attempting to parse with ruby 2.2 would give errors that look like:
```
/home/dgoodell/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/psych.rb:373:in `parse': (<unknown>): mapping values are not allowed in this context at line 27 column 17 (Psych::SyntaxError)
        from /home/dgoodell/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/psych.rb:373:in `parse_stream'
        from /home/dgoodell/.rvm/rubies/ruby-2.2.0/lib/ruby/2.2.0/psych.rb:456:in `load_stream'
        from -e:1:in `<main>'
```

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@pmmccorm since you seem to have some YAML experience, please review