### PR TITLE
prov/psm: better parameter checking for functions taking io vectors

### DIFF
--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -832,7 +832,7 @@ static ssize_t psmx_atomic_writemsg(struct fid_ep *ep,
 				const struct fi_msg_atomic *msg,
 				uint64_t flags)
 {
-	if (!msg || msg->iov_count != 1)
+	if (!msg || msg->iov_count != 1 || !msg->msg_iov || !msg->rma_iov)
 		return -FI_EINVAL;
 
 	return _psmx_atomic_write(ep, msg->msg_iov[0].addr,
@@ -1031,18 +1031,18 @@ static ssize_t psmx_atomic_readwritemsg(struct fid_ep *ep,
 	void *buf;
 	size_t count;
 
-	if (!msg)
+	if (!msg || !msg->rma_iov)
 		return -FI_EINVAL;
 
 	if (msg->op == FI_ATOMIC_READ) {
-		if (result_count != 1)
+		if (result_count != 1 || !resultv)
 			return -FI_EINVAL;
 
 		buf = NULL;
 		count = resultv[0].count;
 	}
 	else {
-		if (msg->iov_count != 1)
+		if (msg->iov_count != 1 || !msg->msg_iov)
 			return -FI_EINVAL;
 
 		buf = msg->msg_iov[0].addr;
@@ -1068,7 +1068,7 @@ static ssize_t psmx_atomic_readwritev(struct fid_ep *ep,
 				  enum fi_datatype datatype,
 				  enum fi_op op, void *context)
 {
-	if (!iov || count != 1)
+	if (!iov || count != 1 || !resultv)
 		return -FI_EINVAL;
 
 	return psmx_atomic_readwrite(ep, iov->addr, iov->count,
@@ -1250,7 +1250,7 @@ static ssize_t psmx_atomic_compwritemsg(struct fid_ep *ep,
 				    size_t result_count,
 				    uint64_t flags)
 {
-	if (!msg || msg->iov_count != 1)
+	if (!msg || msg->iov_count != 1 || !msg->msg_iov || !msg->rma_iov || !resultv)
 		return -FI_EINVAL;
 
 	return _psmx_atomic_compwrite(ep, msg->msg_iov[0].addr,
@@ -1279,7 +1279,7 @@ static ssize_t psmx_atomic_compwritev(struct fid_ep *ep,
 				  enum fi_datatype datatype,
 				  enum fi_op op, void *context)
 {
-	if (!iov || count != 1)
+	if (!iov || count != 1 || !comparev || !resultv)
 		return -FI_EINVAL;
 
 	return psmx_atomic_compwrite(ep, iov->addr, iov->count,

--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -150,10 +150,13 @@ static ssize_t psmx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_
 	void *buf;
 	size_t len;
 
-	if (!msg || msg->iov_count > 1)
+	if (!msg || (msg->iov_count && !msg->msg_iov))
 		return -FI_EINVAL;
 
-	if (msg->iov_count) {
+	if (msg->iov_count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
 	}
@@ -173,10 +176,13 @@ static ssize_t psmx_recvv(struct fid_ep *ep, const struct iovec *iov, void **des
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}
@@ -318,10 +324,13 @@ static ssize_t psmx_sendmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_
 	void *buf;
 	size_t len;
 
-	if (!msg || msg->iov_count > 1)
+	if (!msg || (msg->iov_count && !msg->msg_iov))
 		return -FI_EINVAL;
 
-	if (msg->iov_count) {
+	if (msg->iov_count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
 	}
@@ -341,10 +350,13 @@ static ssize_t psmx_sendv(struct fid_ep *ep, const struct iovec *iov, void **des
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -468,10 +468,13 @@ static ssize_t psmx_recvmsg2(struct fid_ep *ep, const struct fi_msg *msg,
 	void *buf;
 	size_t len;
 
-	if (!msg || msg->iov_count > 1)
+	if (!msg || (msg->iov_count && !msg->msg_iov))
 		return -FI_EINVAL;
 
-	if (msg->iov_count) {
+	if (msg->iov_count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
 	}
@@ -491,10 +494,13 @@ static ssize_t psmx_recvv2(struct fid_ep *ep, const struct iovec *iov,
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}
@@ -595,10 +601,13 @@ static ssize_t psmx_sendmsg2(struct fid_ep *ep, const struct fi_msg *msg,
 	void *buf;
 	size_t len;
 
-	if (!msg || msg->iov_count > 1)
+	if (!msg || (msg->iov_count && !msg->msg_iov))
 		return -FI_EINVAL;
 
-	if (msg->iov_count) {
+	if (msg->iov_count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
 	}
@@ -618,10 +627,13 @@ static ssize_t psmx_sendv2(struct fid_ep *ep, const struct iovec *iov,
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -617,7 +617,7 @@ static ssize_t psmx_read(struct fid_ep *ep, void *buf, size_t len,
 static ssize_t psmx_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 			uint64_t flags)
 {
-	if (!msg || msg->iov_count != 1)
+	if (!msg || msg->iov_count != 1 || !msg->msg_iov || !msg->rma_iov)
 		return -FI_EINVAL;
 
 	return _psmx_read(ep, msg->msg_iov[0].iov_base,
@@ -837,7 +837,7 @@ static ssize_t psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 static ssize_t psmx_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 			 uint64_t flags)
 {
-	if (!msg || msg->iov_count != 1)
+	if (!msg || msg->iov_count != 1 || !msg->msg_iov || !msg->rma_iov)
 		return -FI_EINVAL;
 
 	return _psmx_write(ep, msg->msg_iov[0].iov_base,

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -303,10 +303,13 @@ static ssize_t psmx_tagged_recvmsg(struct fid_ep *ep, const struct fi_msg_tagged
 	void *buf;
 	size_t len;
 
-	if (!msg || msg->iov_count > 1)
+	if (!msg || (msg->iov_count && !msg->msg_iov))
 		return -FI_EINVAL;
 
-	if (msg->iov_count) {
+	if (msg->iov_count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
 	}
@@ -348,10 +351,13 @@ static ssize_t psmx_tagged_recvv(struct fid_ep *ep, const struct iovec *iov, voi
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}
@@ -371,10 +377,13 @@ static ssize_t psmx_tagged_recvv_no_flag(struct fid_ep *ep, const struct iovec *
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}
@@ -395,10 +404,13 @@ static ssize_t psmx_tagged_recvv_no_event(struct fid_ep *ep, const struct iovec 
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}
@@ -747,10 +759,13 @@ static ssize_t psmx_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged
 	void *buf;
 	size_t len;
 
-	if (!msg || msg->iov_count > 1)
+	if (!msg || (msg->iov_count && !msg->msg_iov))
 		return -FI_EINVAL;
 
-	if (msg->iov_count) {
+	if (msg->iov_count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
 	}
@@ -770,10 +785,13 @@ static ssize_t psmx_tagged_sendv(struct fid_ep *ep, const struct iovec *iov, voi
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}
@@ -794,10 +812,13 @@ static ssize_t psmx_tagged_sendv_no_flag_av_map(struct fid_ep *ep, const struct 
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}
@@ -819,10 +840,13 @@ static ssize_t psmx_tagged_sendv_no_flag_av_table(struct fid_ep *ep, const struc
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}
@@ -844,10 +868,13 @@ static ssize_t psmx_tagged_sendv_no_event_av_map(struct fid_ep *ep, const struct
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}
@@ -869,10 +896,13 @@ static ssize_t psmx_tagged_sendv_no_event_av_table(struct fid_ep *ep, const stru
 	void *buf;
 	size_t len;
 
-	if (!iov || count > 1)
+	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count) {
+	if (count > 1) {
+		return -FI_EINVAL;
+	}
+	else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
 	}


### PR DESCRIPTION
Improvements:
(1) allows iov be NULL when iov_count is 0
(2) check all the dereferenced "iov" fields of a "fi_msg_xxx" structure

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>