### PR TITLE
prov/sockets: Fixed seg fault issue with FI_ATOMIC_READ

### DIFF
--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -390,8 +390,14 @@ static ssize_t sock_ep_atomic_readwrite(struct fid_ep *ep,
 	struct fi_ioc msg_iov;
 	struct fi_rma_ioc rma_iov;
 	struct fi_ioc resultv;
+	
+	if (!buf && op != FI_ATOMIC_READ)
+		return -FI_EINVAL;
+	if(op == FI_ATOMIC_READ)
+		msg_iov.addr = NULL;
+	else
+		msg_iov.addr = (void *)buf;
 
-	msg_iov.addr = (void *)buf;
 	msg_iov.count = count;
 	msg.msg_iov = &msg_iov;
 


### PR DESCRIPTION
FI_ATOMIC_READ is defined as fetch-atomic operation and it should take NULL as a valid value for local data buffer, buf. Added some checking to discard buf parameter during the data transfer.

@jithinjosepkl, @sayantansur can you please review?
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>