### PR TITLE
sockets: improve error reports when connect fails

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -1014,16 +1014,18 @@ int sock_compare_addr(struct sockaddr_in *addr1,
 
 struct sock_conn *sock_conn_map_lookup_key(struct sock_conn_map *conn_map, 
 					   uint16_t key);
-uint16_t sock_conn_map_connect(struct sock_ep *ep,
+int sock_conn_map_connect(struct sock_ep *ep,
 			       struct sock_domain *dom,
 			       struct sock_conn_map *map, 
-			       struct sockaddr_in *addr);
+			       struct sockaddr_in *addr,
+			       uint16_t *index);
 uint16_t sock_conn_map_lookup(struct sock_conn_map *map,
 			      struct sockaddr_in *addr);
-uint16_t sock_conn_map_match_or_connect(struct sock_ep *ep,
+int sock_conn_map_match_or_connect(struct sock_ep *ep,
 					struct sock_domain *dom,
 					struct sock_conn_map *map, 
-					struct sockaddr_in *addr);
+					struct sockaddr_in *addr,
+					uint16_t *index);
 int sock_conn_listen(struct sock_ep *ep);
 int sock_conn_map_clear_pe_entry(struct sock_conn *conn_entry, uint16_t key);
 void sock_conn_map_destroy(struct sock_conn_map *cmap);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -37,6 +37,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
 
 #include "sock.h"
 #include "sock_util.h"
@@ -1542,10 +1545,12 @@ err:
 
 struct sock_conn *sock_ep_lookup_conn(struct sock_ep *ep)
 {
+	int ret;
 	if (!ep->key) {
-		ep->key = sock_conn_map_match_or_connect(
-			ep, ep->domain, &ep->domain->r_cmap, ep->dest_addr);
-		if (!ep->key) {
+		ret = sock_conn_map_match_or_connect(
+			ep, ep->domain, &ep->domain->r_cmap, ep->dest_addr,
+			&ep->key);
+		if (ret) {
 			SOCK_LOG_ERROR("failed to match or connect to addr\n");
 			errno = EINVAL;
 			return NULL;

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -208,6 +208,10 @@ ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		conn = sock_ep_lookup_conn(sock_ep);
 	} else {
 		conn = sock_av_lookup_addr(sock_ep, tx_ctx->av, msg->addr);
+		if (!conn) {
+			SOCK_LOG_ERROR("Address lookup failed\n");
+			return -errno;
+		}
 	}
 	if (!conn)
 		return -FI_EAGAIN;
@@ -545,6 +549,10 @@ ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 		conn = sock_ep_lookup_conn(sock_ep);
 	} else {
 		conn = sock_av_lookup_addr(sock_ep, tx_ctx->av, msg->addr);
+		if (!conn) {
+			SOCK_LOG_ERROR("Address lookup failed\n");
+			return -errno;
+		}
 	}
 	if (!conn)
 		return -FI_EAGAIN;


### PR DESCRIPTION
Improve error reporting when trying to send to a target with which
connect fails. The provider was reporting -FI_EAGAIN when the
underlying connect fails for RDM type EP.

Also, inet_ntoa() cannot be called twice in a print function. It updates
a string in static storage, and if there are two calls, the second can
overwrite the buffer - order of expression evaluation isn't defined
in the C-standard. At least one print statement was printing the wrong
source address.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>

@jithinjosepkl @shantonu @shefty : Please review