### PR TITLE
sockets bug fix: remove rx entry from rx-buffered list in case of truncated recvs

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1363,7 +1363,6 @@ static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx)
 		if (rem) {
 			SOCK_LOG_INFO("Not enough space in posted recv buffer\n");
 			sock_pe_report_rx_error(&pe_entry, rem);
-			return 0;
 		} else {
 			sock_pe_report_rx_completion(&pe_entry);
 		}


### PR DESCRIPTION
bug fix - remove rx entry from rx-buffered list in case of truncated recvs

Signed-off-by: Jithin Jose <jithin.jose@intel.com>