### PR TITLE
RFC: add new var system

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,6 +42,7 @@ src_libfabric_la_SOURCES = \
 	src/fabric.c \
 	src/fi_tostr.c \
 	src/log.c \
+	src/var.c \
 	$(common_srcs)
 
 if MACOS
@@ -305,6 +306,7 @@ rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fi_domain.h \
 	$(top_srcdir)/include/rdma/fi_eq.h \
 	$(top_srcdir)/include/rdma/fi_log.h \
+	$(top_srcdir)/include/rdma/fi_var.h \
 	$(top_srcdir)/include/rdma/fi_prov.h \
 	$(top_srcdir)/include/rdma/fi_rma.h \
 	$(top_srcdir)/include/rdma/fi_endpoint.h \

--- a/include/rdma/fi_var.h
+++ b/include/rdma/fi_var.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef _FI_VAR_H_
+#define _FI_VAR_H_
+
+#include <rdma/fi_prov.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Registers a configuration variable for use with libfabric.
+ *
+ * Example: fi_register_var(provider, "foo", "Very important help
+ * string");
+ *
+ * This registers the configuration variable "foo" in the specified
+ * provider.
+ *
+ * The help string cannot be NULL or empty.
+ *
+ * The var_name and help_string parameters will be copied internally;
+ * they can be freed upon return from fi_var_register().
+ */
+int fi_var_register(const struct fi_provider *provider, const char *var_name,
+		const char *help_string);
+
+/* Get the string value of a configuration variable.
+ *
+ * Currently, configuration variables will only be read from the
+ * environment.  The environment variable names will be of the form
+ * upper_case(FI_<provider_name>_<var_name>).
+ *
+ * Someday this call could be expanded to also check config files.
+ *
+ * If the variable was previously registered and the user set a value,
+ * FI_SUCCESS is returned and (*value) points to the user's
+ * \0-terminated string value.  NOTE: The caller should not modify or
+ * free (*value).
+ *
+ * If the variable name was previously registered, but the user did
+ * not set a value, -FI_ENODATA is returned and the value of (*value)
+ * is unchanged.
+ *
+ * If the variable name was not previously registered via
+ * fi_var_register(), -FI_ENOENT will be returned and the value of
+ * (*value) is unchanged.
+ */
+int fi_var_get_str(struct fi_provider *provider, const char *var_name,
+	char **value);
+
+/* Similar to fi_var_get_str(), but the value is converted to an int.
+ * No checking is done to ensure that the value the user set is
+ * actually an integer -- atoi() is simply called on whatever value
+ * the user sets.
+ */
+int fi_var_get_int(struct fi_provider *provider, const char *var_name,
+	int *value);
+
+/* Similar to fi_var_get_str(), but the value is converted to a long.
+ * No checking is done to ensure that the value the user set is
+ * actually an integer -- strtol() is simply called on whatever value
+ * the user sets.
+ */
+int fi_var_get_long(struct fi_provider *provider, const char *var_name,
+	long *value);
+
+/* Similar to fi_var_get_str(), but the value is converted to an
+ * boolean (0 or 1) and returned in an int.  Accepted user values are:
+ *
+ * 0, off, false, no: these will all return 0 in (*value)
+ * 1, on, true, yes: these will all return 1 in (*value)
+ *
+ * Any other user value will return -FI_EINVAL, and (*value) will be
+ * unchanged.
+ */
+int fi_var_get_bool(struct fi_provider *provider, const char *var_name,
+	int *value);
+
+/* Clean up any resources used by the var system
+ */
+void fi_var_fini(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*_FI_VAR_H_ */

--- a/prov/sockets/src/sock_util.h
+++ b/prov/sockets/src/sock_util.h
@@ -43,7 +43,7 @@ extern const char sock_prov_name[];
 extern struct fi_provider sock_prov;
 extern int sock_pe_waittime;
 #if ENABLE_DEBUG
-extern int sock_dgram_drop_rate;
+extern long sock_dgram_drop_rate;
 #endif
 
 #define _SOCK_LOG_INFO(subsys, ...) FI_INFO(&sock_prov, subsys, __VA_ARGS__);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -46,6 +46,7 @@
 #include "fi.h"
 #include "prov.h"
 #include <rdma/fi_log.h>
+#include <rdma/fi_var.h>
 
 #ifdef HAVE_LIBDL
 #include <dlfcn.h>
@@ -401,6 +402,7 @@ static void __attribute__((destructor)) fi_fini(void)
 	}
 
 	fi_free_filter(&prov_filter);
+	fi_var_fini();
 	fi_log_fini();
 }
 

--- a/src/var.c
+++ b/src/var.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2015, Intel Corp., Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+#include <rdma/fi_errno.h>
+#include <rdma/fi_var.h>
+#include <rdma/fi_log.h>
+
+struct fi_var_t {
+	const struct fi_provider *provider;
+	char *var_name;
+	char *help_string;
+
+	char *env_var_name;
+
+	struct fi_var_t *next;
+};
+
+static struct fi_var_t *fi_vars = NULL;
+
+
+int fi_var_register(const struct fi_provider *provider, const char *var_name,
+		const char *help_string)
+{
+	int i;
+	struct fi_var_t *v;
+
+	// Check for bozo cases
+	if (provider == NULL || var_name == NULL || help_string == NULL ||
+		*help_string == '\0') {
+		FI_DBG(provider, FI_LOG_CORE,
+			"Failed to register %s variable: provider coding error\n",
+			var_name);
+		return -FI_EINVAL;
+	}
+
+	v = calloc(1, sizeof(*v));
+	if (!v) {
+		FI_DBG(provider, FI_LOG_CORE,
+			"Failed to register %s variable: ENOMEM\n", var_name);
+		return -FI_ENOMEM;
+	}
+
+	v->provider = provider;
+	v->var_name = strdup(var_name);
+	v->help_string = strdup(help_string);
+	asprintf(&v->env_var_name, "FI_%s_%s",
+		v->provider->name,
+		v->var_name);
+	if (!v->var_name || !v->help_string || !v->env_var_name) {
+		free(v);
+		FI_DBG(provider, FI_LOG_CORE,
+			"Failed to register %s variable: ENOMEM\n", var_name);
+		return -FI_ENOMEM;
+	}
+
+	for (i = 0; v->env_var_name[i]; ++i)
+		v->env_var_name[i] = toupper(v->env_var_name[i]);
+
+	v->next = fi_vars;
+	fi_vars = v;
+
+	FI_INFO(provider, FI_LOG_CORE, "registered var %s\n", var_name);
+
+	return FI_SUCCESS;
+}
+
+static int fi_var_get(struct fi_provider *provider, const char *var_name,
+		char **value)
+{
+	struct fi_var_t *v;
+
+	// Check for bozo cases
+	if (var_name == NULL || value == NULL) {
+		FI_DBG(provider, FI_LOG_CORE,
+			"Failed to read %s variable: provider coding error\n",
+			var_name);
+		return -FI_EINVAL;
+	}
+
+	for (v = fi_vars; v; v = v->next) {
+		if (strcmp(v->provider->name, provider->name) == 0 &&
+			strcmp(v->var_name, var_name) == 0) {
+			*value = getenv(v->env_var_name);
+
+			return FI_SUCCESS;
+		}
+	}
+
+	FI_DBG(provider, FI_LOG_CORE,
+		"Failed to read %s variable: was not registered\n", var_name);
+	return -FI_ENOENT;
+}
+
+int fi_var_get_str(struct fi_provider *provider, const char *var_name,
+		char **value)
+{
+	int ret;
+
+	ret = fi_var_get(provider, var_name, value);
+	if (ret == FI_SUCCESS) {
+		if (*value) {
+			FI_INFO(provider, FI_LOG_CORE,
+				"read string var %s=%s\n", var_name, *value);
+			ret = FI_SUCCESS;
+		} else {
+			FI_INFO(provider, FI_LOG_CORE,
+				"read string var %s=<not set>\n", var_name);
+			ret = -FI_ENODATA;
+		}
+	}
+
+	return ret;
+}
+
+int fi_var_get_int(struct fi_provider *provider, const char *var_name,
+		int *value)
+{
+	int ret;
+	char *str_value;
+
+	ret = fi_var_get(provider, var_name, &str_value);
+	if (ret == FI_SUCCESS) {
+		if (str_value) {
+			*value = atoi(str_value);
+			FI_INFO(provider, FI_LOG_CORE,
+				"read int var %s=%d\n", var_name, *value);
+			ret = FI_SUCCESS;
+		} else {
+			FI_INFO(provider, FI_LOG_CORE,
+				"read int var %s=<not set>\n", var_name);
+			ret = -FI_ENODATA;
+		}
+	}
+
+	return ret;
+}
+
+int fi_var_get_long(struct fi_provider *provider, const char *var_name,
+		long *value)
+{
+	int ret;
+	char *str_value;
+
+	ret = fi_var_get(provider, var_name, &str_value);
+	if (ret == FI_SUCCESS) {
+		if (str_value) {
+			*value = strtol(str_value, NULL, 10);
+			FI_INFO(provider, FI_LOG_CORE,
+				"read long var %s=%ld\n", var_name, *value);
+			ret = FI_SUCCESS;
+		} else {
+			FI_INFO(provider, FI_LOG_CORE,
+				"read long var %s=<not set>\n", var_name);
+			ret = -FI_ENODATA;
+		}
+	}
+
+	return ret;
+}
+
+int fi_var_get_bool(struct fi_provider *provider, const char *var_name,
+		int *value)
+{
+	int ret;
+	char *str_value;
+
+	ret = fi_var_get(provider, var_name, &str_value);
+	if (ret == FI_SUCCESS) {
+		if (str_value) {
+			if (strcmp(var_name, "0") == 0 ||
+				strcasecmp(var_name, "false") == 0 ||
+				strcasecmp(var_name, "no") == 0 ||
+				strcasecmp(var_name, "off") == 0) {
+				*value = 0;
+				FI_INFO(provider, FI_LOG_CORE,
+					"read boolean var %s=false\n", var_name);
+				ret = FI_SUCCESS;
+			} else if (strcmp(var_name, "1") == 0 ||
+				strcasecmp(var_name, "true") == 0 ||
+				strcasecmp(var_name, "yes") == 0 ||
+				strcasecmp(var_name, "on") == 0) {
+				*value = 1;
+				FI_INFO(provider, FI_LOG_CORE,
+					"read boolean var %s=true\n", var_name);
+				ret = FI_SUCCESS;
+			} else {
+				FI_INFO(provider, FI_LOG_CORE,
+					"read boolean var %s=<unknown> (%s)\n", var_name, str_value);
+				ret = -FI_EINVAL;
+			}
+		} else {
+			FI_INFO(provider, FI_LOG_CORE,
+				"read boolean var %s=<not set>\n", var_name);
+			ret = -FI_ENODATA;
+		}
+	}
+
+	return ret;
+}
+
+void fi_var_fini(void)
+{
+	struct fi_var_t *v, *v2;
+
+	for (v = fi_vars; v; v = v2) {
+		free(v->var_name);
+		free(v->help_string);
+		free(v->env_var_name);
+
+		v2 = v->next;
+		free(v);
+	}
+}


### PR DESCRIPTION
Stop the proliferation of unstandardized environment variables and use a standardized convention.

The first commit adds the var system: `fi_var_register()`, `fi_var_get()`, and `fi_var_fini()`.

The second commit converts the sockets provider to use the var interface:
* SOCK_PE_WAITTIME -> FI_SOCKETS_PE_WAITTIME
* SOCK_DGRAM_DROP_RATE -> FI_SOCKETS_DGRAM_DROP_RATE

@jithinjosepkl @shantonu please review

The third commit converts the PSM provider to use the var interface (note: I cannot compile/test this commit, and I'm quite sure that my help strings are totally wrong):
* OFI_PSM_NAME_SERVER -> FI_PSM_NAME_SERVER
* OFI_PSM_AM_MSG -> FI_PSM_AM_MSG
* OFI_PSM_TAGGED_RMA -> FI_PSM_TAGGED_RMA
* OFI_PSM_UUID -> FI_PSM_UUID

@j-xiong please review