### PR TITLE
specfile: determine BuildRequires at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -198,6 +198,9 @@ AC_TRY_LINK(
 AC_DEFINE_UNQUOTED([HAVE_ALIAS_ATTRIBUTE], [$ac_prog_cc_alias_symbols],
 	  	   [Define to 1 if the linker supports alias attribute.])
 
+dnl What will be substituted into the BuildRequires RPM specfile line
+FI_BUILD_REQUIRES=
+
 dnl Provider-specific checks
 FI_PROVIDER_INIT
 FI_PROVIDER_SETUP([psm])
@@ -205,6 +208,8 @@ FI_PROVIDER_SETUP([sockets])
 FI_PROVIDER_SETUP([verbs])
 FI_PROVIDER_SETUP([usnic])
 FI_PROVIDER_FINI
+
+AC_SUBST(FI_BUILD_REQUIRES)
 
 # If the user requested to build in direct mode, but
 # we have more than one provider, error.

--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -8,10 +8,7 @@ Url: http://www.github.com/ofiwg/libfabric
 Source: http://www.openfabrics.org/downloads/fabrics/%{name}-%{version}.tar.bz2
 Prefix: ${_prefix}
 
-BuildRequires: libnl-devel
-BuildRequires: librdmacm-devel
-BuildRequires: libibverbs-devel
-BuildRequires: infinipath-psm-devel
+BuildRequires: @FI_BUILD_REQUIRES@
 
 %description
 libfabric provides a user-space API to access high-performance fabric

--- a/prov/psm/configure.m4
+++ b/prov/psm/configure.m4
@@ -24,5 +24,8 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 	AS_IF([test x"$psm_happy" = x"1"],
    	      [AC_CHECK_TYPE([psm_epconn_t], [], [psm_happy=0], [[#include <psm.h>]])])
 
-	AS_IF([test $psm_happy -eq 1], [$1], [$2])
+	AS_IF([test $psm_happy -eq 1],
+	       [FI_BUILD_REQUIRES="infinipath-psm-devel $FI_BUILD_REQUIRES"
+	        $1],
+	       [$2])
 ])

--- a/prov/usnic/configure.m4
+++ b/prov/usnic/configure.m4
@@ -266,7 +266,8 @@ AC_DEFUN([USNIC_CHECK_LIBNL3],[
 #error "LIBNL_VER_MAJ != 3, I am sad"
 #endif
 		]])],
-		[AC_MSG_RESULT([yes])],
+		[FI_BUILD_REQUIRES="libnl3-devel $FI_BUILD_REQUIRES"
+		 AC_MSG_RESULT([yes])],
 		[AC_MSG_RESULT([no])
 		 usnic_libnl3_happy=0]
 		)])
@@ -307,6 +308,7 @@ AC_DEFUN([USNIC_CHECK_LIBNL],[
 			[usnic_libnl_happy=0])
 
 	AS_IF([test $usnic_libnl_happy -eq 1],
-	      [$2_LIBS="-lnl -lm"
+	      [FI_BUILD_REQUIRES="libnl-devel $FI_BUILD_REQUIRES"
+	       $2_LIBS="-lnl -lm"
 	       HAVE_LIBNL3=0])
 ])

--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -34,5 +34,8 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 	      ])
 
 	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
-	       test $verbs_rdmacm_happy -eq 1], [$1], [$2])
+	       test $verbs_rdmacm_happy -eq 1],
+	      [FI_BUILD_REQUIRES="librdmacm-devel libibverbs-devel $FI_BUILD_REQUIRES"
+	       $1],
+	      [$2])
 ])


### PR DESCRIPTION
Let each provider specify what it wants to be in the RPM specfile BuildRequires line.  This lets us skip providers that can't/won't be built.

Fixes #1065.

@bturrubiates @shefty please review