### PR TITLE
update libusnic_direct to SVN 22938

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -152,9 +152,9 @@ libusnic_direct_sources = \
 	prov/usnic/src/usnic_direct/usd_poll.c \
 	prov/usnic/src/usnic_direct/usd_post.c \
 	prov/usnic/src/usnic_direct/usd_post.h \
-	prov/usnic/src/usnic_direct/usd_post_raw_normal.c \
-	prov/usnic/src/usnic_direct/usd_post_udp_normal.c \
-	prov/usnic/src/usnic_direct/usd_post_udp_pio.c \
+	prov/usnic/src/usnic_direct/usd_post_ud_raw.c \
+	prov/usnic/src/usnic_direct/usd_post_ud_udp.c \
+	prov/usnic/src/usnic_direct/usd_post_ud_pio_udp.c \
 	prov/usnic/src/usnic_direct/usd_queue.h \
 	prov/usnic/src/usnic_direct/usd_queues.c \
 	prov/usnic/src/usnic_direct/usd_socket.c \

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -94,7 +94,7 @@ usdf_ep_dgram_enable(struct fid_ep *fep)
 	if (ep->ep_caps & USDF_EP_CAP_PIO) {
 		ret = usd_create_qp(ep->ep_domain->dom_dev,
 				USD_QTR_UDP,
-				USD_QTY_PIO,
+				USD_QTY_UD_PIO,
 				ep->e.dg.ep_wcq->c.hard.cq_cq,
 				ep->e.dg.ep_rcq->c.hard.cq_cq,
 				127,	// XXX
@@ -108,7 +108,7 @@ usdf_ep_dgram_enable(struct fid_ep *fep)
 	if (ret != 0) {
 		ret = usd_create_qp(ep->ep_domain->dom_dev,
 				USD_QTR_UDP,
-				USD_QTY_NORMAL,
+				USD_QTY_UD,
 				ep->e.dg.ep_wcq->c.hard.cq_cq,
 				ep->e.dg.ep_rcq->c.hard.cq_cq,
 				ep->ep_wqe,

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -91,7 +91,7 @@ usdf_tx_msg_enable(struct usdf_tx *tx)
 	filt.uf_filter.uf_udp.u_port = 0;
 	ret = usd_create_qp(udp->dom_dev,
 			USD_QTR_UDP,
-			USD_QTY_NORMAL,
+			USD_QTY_UD,
 			hcq->cqh_ucq,
 			hcq->cqh_ucq,
 			udp->dom_fabric->fab_dev_attrs->uda_max_send_credits,
@@ -179,7 +179,7 @@ usdf_rx_msg_enable(struct usdf_rx *rx)
 	filt.uf_filter.uf_udp.u_port = 0;
 	ret = usd_create_qp(udp->dom_dev,
 			USD_QTR_UDP,
-			USD_QTY_NORMAL,
+			USD_QTY_UD,
 			hcq->cqh_ucq,
 			hcq->cqh_ucq,
 			udp->dom_fabric->fab_dev_attrs->uda_max_send_credits,

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -92,7 +92,7 @@ usdf_tx_rdm_enable(struct usdf_tx *tx)
 	filt.uf_filter.uf_udp.u_port = 0;
 	ret = usd_create_qp(udp->dom_dev,
 			USD_QTR_UDP,
-			USD_QTY_NORMAL,
+			USD_QTY_UD,
 			hcq->cqh_ucq,
 			hcq->cqh_ucq,
 			udp->dom_fabric->fab_dev_attrs->uda_max_send_credits,
@@ -179,7 +179,7 @@ usdf_rx_rdm_enable(struct usdf_rx *rx)
 	filt.uf_filter.uf_udp_sock.u_sock = rx->r.rdm.rx_sock;
 	ret = usd_create_qp(udp->dom_dev,
 			USD_QTR_UDP,
-			USD_QTY_NORMAL,
+			USD_QTY_UD,
 			hcq->cqh_ucq,
 			hcq->cqh_ucq,
 			udp->dom_fabric->fab_dev_attrs->uda_max_send_credits,

--- a/prov/usnic/src/usnic_direct/usd.h
+++ b/prov/usnic/src/usnic_direct/usd.h
@@ -77,6 +77,9 @@
 struct usd_device {
     struct usd_ib_dev *ud_ib_dev;       /* parent IB dev */
     int ud_ib_dev_fd;           /* file desc for IB dev */
+    int ucmd_ib_dev_fd;         /* Another open file descriptor for IB dev
+                                 * used for encapusulating user commands through
+                                 * GET_CONTEXT IB command */
 
     uint32_t ud_flags;
     struct usd_device_attrs ud_attrs;
@@ -270,7 +273,7 @@ struct usd_dest {
     } ds_dest;
 };
 
-extern struct usd_qp_ops usd_qp_ops_udp_normal;
-extern struct usd_qp_ops usd_qp_ops_udp_pio;
-extern struct usd_qp_ops usd_qp_ops_raw_normal;
+extern struct usd_qp_ops usd_qp_ops_ud_udp;
+extern struct usd_qp_ops usd_qp_ops_ud_pio_udp;
+extern struct usd_qp_ops usd_qp_ops_ud_raw;
 #endif /* _USD_H_ */

--- a/prov/usnic/src/usnic_direct/usd_dest.c
+++ b/prov/usnic/src/usnic_direct/usd_dest.c
@@ -241,6 +241,11 @@ usd_create_udp_dest_start(
     uint32_t first_hop_daddr_be;
     int ret;
 
+    /* catch a mistake that will almost always lead to hung programs */
+    if (daddr_be == 0 || dport_be == 0) {
+        return -EINVAL;
+    }
+
     req = calloc(sizeof(*req), 1);
     dest = calloc(sizeof(*dest), 1);
     if (req == NULL || dest == NULL) {

--- a/prov/usnic/src/usnic_direct/usd_enum.c
+++ b/prov/usnic/src/usnic_direct/usd_enum.c
@@ -96,8 +96,8 @@ const char *usd_qp_transport_str(enum usd_qp_transport qpt)
 const char *usd_qp_type_str(enum usd_qp_type qpt)
 {
     switch (qpt) {
-    case USD_QTY_NORMAL: return "USD_QTY_NORMAL";
-    case USD_QTY_PIO:    return "USD_QTY_PIO";
+    case USD_QTY_UD: return "USD_QTY_UD";
+    case USD_QTY_UD_PIO:    return "USD_QTY_UD_PIO";
     default:             return "UNKNOWN";
     }
 }

--- a/prov/usnic/src/usnic_direct/usd_ib_cmd.h
+++ b/prov/usnic/src/usnic_direct/usd_ib_cmd.h
@@ -59,4 +59,6 @@ int usd_ib_cmd_modify_qp(struct usd_device *dev, struct usd_qp_impl *qp,
 int usd_ib_cmd_destroy_qp(struct usd_device *dev, struct usd_qp_impl *qp);
 
 int usd_ib_query_dev(struct usd_device *dev);
+int usd_ib_cmd_devcmd(struct usd_device *dev, enum vnic_devcmd_cmd devcmd,
+                        u64 *a0, u64 *a1, int wait);
 #endif /* _USD_IB_CMD_ */

--- a/prov/usnic/src/usnic_direct/usd_post_ud_pio_udp.c
+++ b/prov/usnic/src/usnic_direct/usd_post_ud_pio_udp.c
@@ -46,7 +46,7 @@
 #include "usd_post.h"
 
 static int
-usd_post_send_one_udp_pio(
+usd_post_send_one_ud_pio_udp(
     struct usd_qp *uqp,
     struct usd_dest *dest,
     const void *buf,
@@ -144,7 +144,7 @@ usd_post_send_one_udp_pio(
  * 2 WQEs - our header plus user header in 1st one, user packet in 2nd
  */
 static int
-usd_post_send_two_udp_pio(
+usd_post_send_two_ud_pio_udp(
     struct usd_qp *uqp,
     struct usd_dest *dest,
     const void *uhdr,
@@ -243,9 +243,9 @@ usd_post_send_two_udp_pio(
     return 0;
 }
 
-struct usd_qp_ops usd_qp_ops_udp_pio = {
-    .qo_post_send_one = usd_post_send_one_udp_pio,
-    .qo_post_send_one_prefixed = usd_post_send_one_udp_pio,
-    .qo_post_send_one_copy = usd_post_send_one_udp_pio,
-    .qo_post_send_two_copy = usd_post_send_two_udp_pio,
+struct usd_qp_ops usd_qp_ops_ud_pio_udp = {
+    .qo_post_send_one = usd_post_send_one_ud_pio_udp,
+    .qo_post_send_one_prefixed = usd_post_send_one_ud_pio_udp,
+    .qo_post_send_one_copy = usd_post_send_one_ud_pio_udp,
+    .qo_post_send_two_copy = usd_post_send_two_ud_pio_udp,
 };

--- a/prov/usnic/src/usnic_direct/usd_post_ud_raw.c
+++ b/prov/usnic/src/usnic_direct/usd_post_ud_raw.c
@@ -44,7 +44,7 @@
 #include "usd_post.h"
 
 static int
-usd_post_send_one_prefixed_raw_normal(
+usd_post_send_one_prefixed_ud_raw(
     struct usd_qp *uqp,
     struct usd_dest __attribute__ ((unused)) * dest,
     const void *buf,
@@ -70,6 +70,6 @@ usd_post_send_one_prefixed_raw_normal(
     return 0;
 }
 
-struct usd_qp_ops usd_qp_ops_raw_normal = {
-    .qo_post_send_one_prefixed = usd_post_send_one_prefixed_raw_normal,
+struct usd_qp_ops usd_qp_ops_ud_raw = {
+    .qo_post_send_one_prefixed = usd_post_send_one_prefixed_ud_raw,
 };

--- a/prov/usnic/src/usnic_direct/usd_post_ud_udp.c
+++ b/prov/usnic/src/usnic_direct/usd_post_ud_udp.c
@@ -46,7 +46,7 @@
 #include "usd_post.h"
 
 static int
-usd_post_send_one_udp_normal(
+usd_post_send_one_ud_udp(
     struct usd_qp *uqp,
     struct usd_dest *dest,
     const void *buf,
@@ -88,7 +88,7 @@ usd_post_send_one_udp_normal(
 }
 
 static int
-usd_post_send_one_vlan_udp_normal(
+usd_post_send_one_vlan_ud_udp(
     struct usd_qp *uqp,
     struct usd_dest *dest,
     const void *buf,
@@ -131,7 +131,7 @@ usd_post_send_one_vlan_udp_normal(
 }
 
 static int
-usd_post_send_one_copy_udp_normal(
+usd_post_send_one_copy_ud_udp(
     struct usd_qp *uqp,
     struct usd_dest *dest,
     const void *buf,
@@ -175,7 +175,7 @@ usd_post_send_one_copy_udp_normal(
 }
 
 static int
-usd_post_send_one_prefixed_udp_normal(
+usd_post_send_one_prefixed_ud_udp(
     struct usd_qp *uqp,
     struct usd_dest *dest,
     const void *buf,
@@ -219,7 +219,7 @@ usd_post_send_one_prefixed_udp_normal(
  * 2 WQEs - our header plus user header in 1st one, user packet in 2nd
  */
 static int
-usd_post_send_two_copy_udp_normal(
+usd_post_send_two_copy_ud_udp(
     struct usd_qp *uqp,
     struct usd_dest *dest,
     const void *uhdr,
@@ -268,7 +268,7 @@ usd_post_send_two_copy_udp_normal(
 }
 
 static int
-usd_post_send_iov_udp_normal(struct usd_qp *uqp,
+usd_post_send_iov_ud_udp(struct usd_qp *uqp,
             struct usd_dest *dest, const struct iovec* iov,
             size_t iov_count, uint32_t flags, void *context)
 {
@@ -315,11 +315,11 @@ usd_post_send_iov_udp_normal(struct usd_qp *uqp,
     return 0;
 }
 
-struct usd_qp_ops usd_qp_ops_udp_normal = {
-    .qo_post_send_one = usd_post_send_one_udp_normal,
-    .qo_post_send_one_prefixed = usd_post_send_one_prefixed_udp_normal,
-    .qo_post_send_one_copy = usd_post_send_one_copy_udp_normal,
-    .qo_post_send_two_copy = usd_post_send_two_copy_udp_normal,
-    .qo_post_send_iov = usd_post_send_iov_udp_normal,
-    .qo_post_send_one_vlan = usd_post_send_one_vlan_udp_normal,
+struct usd_qp_ops usd_qp_ops_ud_udp = {
+    .qo_post_send_one = usd_post_send_one_ud_udp,
+    .qo_post_send_one_prefixed = usd_post_send_one_prefixed_ud_udp,
+    .qo_post_send_one_copy = usd_post_send_one_copy_ud_udp,
+    .qo_post_send_two_copy = usd_post_send_two_copy_ud_udp,
+    .qo_post_send_iov = usd_post_send_iov_ud_udp,
+    .qo_post_send_one_vlan = usd_post_send_one_vlan_ud_udp,
 };

--- a/prov/usnic/src/usnic_direct/usd_vnic.h
+++ b/prov/usnic/src/usnic_direct/usd_vnic.h
@@ -43,8 +43,11 @@
 #ifndef _USD_VNIC_H_
 #define _USD_VNIC_H_
 
-int usd_get_devspec(struct usd_qp_impl *qp);
-
+int usd_vnic_dev_cmd(struct usd_device *dev, enum vnic_devcmd_cmd cmd,
+			            u64 *a0, u64 *a1, int wait);
+int usd_dev_spec(struct usd_device *dev, unsigned int offset,
+                size_t size, void *value);
+int usd_get_piopa(struct usd_qp_impl *qp);
 int usd_vnic_hang_notify(struct usd_qp *uqp);
 
 #endif /* _USD_VNIC_H_ */

--- a/prov/usnic/src/usnic_direct/usnic_direct.h
+++ b/prov/usnic/src/usnic_direct/usnic_direct.h
@@ -221,8 +221,8 @@ enum usd_qp_transport {
 };
 
 enum usd_qp_type {
-    USD_QTY_NORMAL,
-    USD_QTY_PIO,
+    USD_QTY_UD,
+    USD_QTY_UD_PIO,
 };
 
 /*

--- a/prov/usnic/src/usnic_direct/vnic_dev.h
+++ b/prov/usnic/src/usnic_direct/vnic_dev.h
@@ -69,7 +69,11 @@ static inline u64 readq(void __iomem *reg)
 static inline void writeq(u64 val, void __iomem *reg)
 {
 	writel(val & 0xffffffff, reg);
+#ifdef ENIC_PMD
+	writel((u32)(val >> 32), (char *)reg + 0x4UL);
+#else
 	writel(val >> 32, (char *)reg + 0x4UL);
+#endif
 }
 #endif
 
@@ -166,7 +170,11 @@ int vnic_dev_fw_info(struct vnic_dev *vdev,
 #ifndef FOR_UPSTREAM_KERNEL
 int vnic_dev_asic_info(struct vnic_dev *vdev, u16 *asic_type, u16 *asic_rev);
 #endif
+#ifdef ENIC_PMD
+int vnic_dev_spec(struct vnic_dev *vdev, unsigned int offset, size_t size,
+#else
 int vnic_dev_spec(struct vnic_dev *vdev, unsigned int offset, unsigned int size,
+#endif
 	void *value);
 #ifndef FOR_UPSTREAM_KERNEL
 int vnic_dev_stats_clear(struct vnic_dev *vdev);


### PR DESCRIPTION
Signed-off-by: Xuyang Wang <xuywang@cisco.com>

Update libusnic_verbs to the latest SVN repository. 

Also made some changes in usdfv to incorporate the changing from USNIC_QTY_NORMAL to USNIC_QTY_UD and USNIC_QTY_PIO to USNIC_QTY_UD_PIO.