### PR TITLE
Support custom ./configure options in rpmbuild command line.

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -8,10 +8,15 @@ Url: http://www.github.com/ofiwg/libfabric
 Source: http://www.openfabrics.org/downloads/fabrics/%{name}-%{version}.tar.bz2
 Prefix: ${_prefix}
 
-BuildRequires: libnl-devel
+%if 0%{?configopts:1}
+# skip BuildRequires for custom build
+%else
+%global configopts --enable-sockets --enable-verbs --enable-usnic --enable-psm
 BuildRequires: librdmacm-devel
 BuildRequires: libibverbs-devel
+BuildRequires: libnl-devel
 BuildRequires: infinipath-psm-devel
+%endif
 
 %description
 libfabric provides a user-space API to access high-performance fabric
@@ -30,8 +35,7 @@ Development files for the libfabric library.
 
 %build
 # defaults: with-dlopen and without-valgrind can be over-rode:
-%configure %{?_without_dlopen} %{?_with_valgrind} \
-	--enable-sockets --enable-verbs --enable-usnic --enable-psm
+%configure %{?_without_dlopen} %{?_with_valgrind} %{configopts}
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
Default to building all providers with dependencies that work for RHEL7 SLES12.

If a custom configure line is specified like:
rpmbuild --define 'configopts "--enable-psm=no"' -ba libfabric.spec

then pass it to configure and disable the BuildRequires.

If it is desired to build all providers with no dependency checks call rpmbuild with --nodeps

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>