### PR TITLE
prov/sockets: Fixed a race condidition in releasing rx_entry

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1520,8 +1520,8 @@ out:
 	if (!rx_entry->is_buffered &&
 	    (!(rx_entry->flags & FI_MULTI_RECV) ||
 	     (pe_entry->flags & FI_MULTI_RECV))) {
-		fastlock_acquire(&rx_ctx->lock);
 		sock_rx_release_entry(rx_entry);
+		fastlock_acquire(&rx_ctx->lock);
 		rx_ctx->num_left++;
 		fastlock_release(&rx_ctx->lock);
 	}

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1476,7 +1476,6 @@ static int sock_pe_process_rx_send(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 
 	pe_entry->is_complete = 1;
 	rx_entry->is_complete = 1;
-	rx_entry->is_busy = 0;
 
 	pe_entry->flags = rx_entry->flags;
 	if (pe_entry->msg_hdr.op_type == SOCK_OP_TSEND) 
@@ -1497,6 +1496,7 @@ static int sock_pe_process_rx_send(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 		if (!rx_entry->is_buffered)
 			dlist_remove(&rx_entry->entry);
 	}
+	rx_entry->is_busy = 0;
 	fastlock_release(&rx_ctx->lock);
 
 	/* report error, if any */
@@ -1520,8 +1520,8 @@ out:
 	if (!rx_entry->is_buffered &&
 	    (!(rx_entry->flags & FI_MULTI_RECV) ||
 	     (pe_entry->flags & FI_MULTI_RECV))) {
-		sock_rx_release_entry(rx_entry);
 		fastlock_acquire(&rx_ctx->lock);
+		sock_rx_release_entry(rx_entry);
 		rx_ctx->num_left++;
 		fastlock_release(&rx_ctx->lock);
 	}


### PR DESCRIPTION
fi_cancel tries to read rx_entry->is_busy and and progress resets before removing it from the link list. It caused a race condition where both the thread tried to free the same entry. 
- Added the reset operation inside a lock
- Added release operation inside a lock

@jithinjosepkl 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>