### PR TITLE
var: fix fi_var_register

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -79,7 +79,7 @@ int fi_var_register(const struct fi_provider *provider, const char *var_name,
 	v->provider = provider;
 	v->var_name = strdup(var_name);
 	v->help_string = strdup(help_string);
-	if (!v->var_name || !v->help_string || !v->env_var_name ||
+	if (!v->var_name || !v->help_string || 
 		asprintf(&v->env_var_name, "FI_%s_%s",
 			v->provider->name,
 			v->var_name) < 0) {


### PR DESCRIPTION
Fix issue in fi_var_register
    - remove an unnecessary check that caused this API to fail always.

@jsquyres - Please review. fi_var_register was failing always with -FI_ENOMEM.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>