### PR TITLE
Fix a bad memset sizeof.

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -575,7 +575,7 @@ static int fi_ibv_check_hints(const struct fi_info *hints,
 
 static int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags, struct rdma_addrinfo *rai)
 {
-	memset(rai, 0, sizeof *rai);
+	memset(rai, 0, sizeof rai);
 	if (flags & FI_SOURCE)
 		rai->ai_flags = RAI_PASSIVE;
 	if (flags & FI_NUMERICHOST)
@@ -1708,7 +1708,7 @@ fi_ibv_msg_ep_atomic_readwrite(struct fid_ep *ep, const void *buf, size_t count,
 	wr.next = NULL;
 	wr.sg_list = &sge;
 	wr.num_sge = 1;
-	wr.send_flags = IBV_SEND_FENCE; 
+	wr.send_flags = IBV_SEND_FENCE;
 	if (VERBS_INJECT(_ep, sizeof(uint64_t)))
 		wr.send_flags |= IBV_SEND_INLINE;
 	if (VERBS_COMP(_ep))
@@ -1787,7 +1787,7 @@ fi_ibv_msg_ep_atomic_readwritemsg(struct fid_ep *ep,
 	wr.next = NULL;
 	wr.sg_list = &sge;
 	wr.num_sge = 1;
-	wr.send_flags = IBV_SEND_FENCE; 
+	wr.send_flags = IBV_SEND_FENCE;
 	if (VERBS_INJECT_FLAGS(_ep, sizeof(uint64_t), flags))
 		wr.send_flags |= IBV_SEND_INLINE;
 	if (VERBS_COMP_FLAGS(_ep, flags))
@@ -1845,7 +1845,7 @@ fi_ibv_msg_ep_atomic_compwrite(struct fid_ep *ep, const void *buf, size_t count,
 	wr.next = NULL;
 	wr.sg_list = &sge;
 	wr.num_sge = 1;
-	wr.send_flags = IBV_SEND_FENCE; 
+	wr.send_flags = IBV_SEND_FENCE;
 	if (VERBS_INJECT(_ep, sizeof(uint64_t)))
 		wr.send_flags |= IBV_SEND_INLINE;
 	if (VERBS_COMP(_ep))
@@ -1923,7 +1923,7 @@ fi_ibv_msg_ep_atomic_compwritemsg(struct fid_ep *ep,
 	wr.next = NULL;
 	wr.sg_list = &sge;
 	wr.num_sge = 1;
-	wr.send_flags = IBV_SEND_FENCE; 
+	wr.send_flags = IBV_SEND_FENCE;
 	if (VERBS_INJECT_FLAGS(_ep, sizeof(uint64_t), flags))
 		wr.send_flags |= IBV_SEND_INLINE;
 	if (VERBS_COMP_FLAGS(_ep, flags))


### PR DESCRIPTION
Should properly zero out the entire structure, not just the first few bytes, causes problems in optimized builds.

 Signed-Off-By: zakattacktwitter ztaylor@twitter.com