### PR TITLE
Export fi_var_* functions as 1.0 API.

### DIFF
--- a/include/rdma/fi_var.h
+++ b/include/rdma/fi_var.h
@@ -40,6 +40,14 @@
 extern "C" {
 #endif
 
+struct fi_setting {
+	const char *prov_name;
+	const char *var_name;
+	const char *env_var_name;
+	const char *help_string;
+	const char *value;
+};
+
 /* Registers a configuration variable for use with libfabric.
  *
  * Example: fi_register_var(provider, "foo", "Very important help
@@ -111,6 +119,11 @@ int fi_var_get_bool(struct fi_provider *provider, const char *var_name,
 /* Clean up any resources used by the var system
  */
 void fi_var_fini(void);
+
+/* Get and free current settings.
+ */
+int fi_getsettings(struct fi_setting **settings, int *count);
+void fi_freesettings(struct fi_setting *settings);
 
 #ifdef __cplusplus
 }

--- a/libfabric.map
+++ b/libfabric.map
@@ -9,5 +9,12 @@ FABRIC_1.0 {
 		fi_tostr;
 		fi_log_enabled;
 		fi_log;
+		fi_var_register;
+		fi_var_get_str;
+		fi_var_get_int;
+		fi_var_get_long;
+		fi_var_get_bool;
+		fi_getsettings;
+		fi_freesettings;
 	local: *;
 };


### PR DESCRIPTION
This fixes dl-provider builds.

Also add fi_getvars(struct env **env, int *count) which
will allocate and return all current provider registered
environment variables.

The caller can free the env with free()

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>