### PR TITLE
verify-signed-off.rb: make the match be case insensitive

### DIFF
--- a/config/github-webhook/verify-signed-off.rb
+++ b/config/github-webhook/verify-signed-off.rb
@@ -83,7 +83,7 @@ post '/' do
     }
 
     # Look for a Signed-off-by string in this commit
-    if /Signed-off-by/.match commit['commit']['message']
+    if /Signed-off-by/i.match commit['commit']['message']
       status['state']       = 'success'
       status['description'] = 'This commit is signed off'
     else


### PR DESCRIPTION
As pointed out in #1085, a valid Signed-Off-By line was missed by the verify bot because the check wasn't case-insensitive (sorry, @zakattacktwitter!).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>