### PR TITLE
prov/psm: bug fix for incorrect length of MULTI_RECV completion

### DIFF
--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -501,7 +501,7 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 								req->buf,
 								FI_MULTI_RECV,
 								req->len,
-								req->len - req->offset, /* data */
+								psm_status.nbytes, /* data */
 								0,	/* tag */
 								0,	/* olen */
 								0);	/* err */


### PR DESCRIPTION
Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>