### PR TITLE
sockets: coverity fixes, move sanity checks in debug mode

### DIFF
--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -180,10 +180,12 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 		}
 	}
 
+#ifdef ENABLE_DEBUG
 	if (src_len > SOCK_EP_MAX_ATOMIC_SZ) {
 		ret = -FI_EINVAL;
 		goto err;
 	}
+#endif
 
 	dst_len = 0;
 	for (i = 0; i< msg->rma_iov_count; i++) {
@@ -210,11 +212,13 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 		dst_len += (tx_iov.ioc.count * datatype_sz);
 	}
 
+#ifdef ENABLE_DEBUG
 	if (result_count && (dst_len != src_len)) {
 		SOCK_LOG_ERROR("Buffer length mismatch\n");
 		ret = -FI_EINVAL;
 		goto err;
 	}
+#endif
 
 	dst_len = 0;
 	for (i = 0; i< compare_count; i++) {
@@ -224,11 +228,13 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 		dst_len += (tx_iov.ioc.count * datatype_sz);
 	}
 
+#ifdef ENABLE_DEBUG
 	if (compare_count && (dst_len != src_len)) {
 		SOCK_LOG_ERROR("Buffer length mismatch\n");
 		ret = -FI_EINVAL;
 		goto err;
 	}
+#endif
 	
 	sock_tx_ctx_commit(tx_ctx);
 	return 0;
@@ -242,6 +248,7 @@ err:
 static ssize_t sock_ep_atomic_writemsg(struct fid_ep *ep,
 			const struct fi_msg_atomic *msg, uint64_t flags)
 {
+#if ENABLE_DEBUG
 	switch (msg->op) {
 	case FI_MIN:
 	case FI_MAX: 
@@ -259,7 +266,7 @@ static ssize_t sock_ep_atomic_writemsg(struct fid_ep *ep,
 		SOCK_LOG_ERROR("Invalid operation type\n");
 		return -FI_EINVAL;
 	}
-
+#endif
 	return sock_ep_tx_atomic(ep, msg, NULL, NULL, 0,
 				  NULL, NULL, 0, flags);
 }

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -81,8 +81,10 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		return -FI_EINVAL;
 	}
 
+#ifdef ENABLE_DEBUG
 	if (msg->iov_count > SOCK_EP_MAX_IOV_LIMIT)
 		return -FI_EINVAL;
+#endif
 
 	if (!rx_ctx->enabled)
 		return -FI_EOPBADSTATE;
@@ -195,8 +197,10 @@ ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		return -FI_EINVAL;
 	}
 
+#ifdef ENABLE_DEBUG
 	if (msg->iov_count > SOCK_EP_MAX_IOV_LIMIT)
 		return -FI_EINVAL;
+#endif
 
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;	
@@ -413,8 +417,10 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 		return -FI_EINVAL;
 	}
 
+#ifdef ENABLE_DEBUG
 	if (msg->iov_count > SOCK_EP_MAX_IOV_LIMIT)
 		return -FI_EINVAL;
+#endif
 
 	if (!rx_ctx->enabled)
 		return -FI_EOPBADSTATE;
@@ -536,8 +542,10 @@ ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 		return -FI_EINVAL;
 	}
 
+#ifdef ENABLE_DEBUG
 	if (msg->iov_count > SOCK_EP_MAX_IOV_LIMIT)
 		return -FI_EINVAL;
+#endif
 
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2459,7 +2459,7 @@ do_wait:
 #ifndef __APPLE__
 static void sock_thread_set_affinity(char *s)
 {
-	char *saveptra, *saveptrb, *saveptrc;
+	char *saveptra = NULL, *saveptrb = NULL, *saveptrc = NULL;
 	char *a, *b, *c;
 	int j, first, last,stride;
 	cpu_set_t mycpuset;

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -86,9 +86,11 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		return -FI_EINVAL;
 	}
 
+#ifdef ENABLE_DEBUG
 	if (msg->iov_count > SOCK_EP_MAX_IOV_LIMIT ||
 		msg->rma_iov_count > SOCK_EP_MAX_IOV_LIMIT)
 		return -FI_EINVAL;
+#endif
 	
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
@@ -152,11 +154,13 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		dst_len += tx_iov.iov.len;
 	}
 
+#ifdef ENABLE_DEBUG
 	if (dst_len != src_len) {
 		SOCK_LOG_ERROR("Buffer length mismatch\n");
 		ret = -FI_EINVAL;
 		goto err;
 	}
+#endif
 	
 	sock_tx_ctx_commit(tx_ctx);
 	return 0;
@@ -248,9 +252,11 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		return -FI_EINVAL;
 	}
 
+#ifdef ENABLE_DEBUG
 	if (msg->iov_count > SOCK_EP_MAX_IOV_LIMIT || 
 		msg->rma_iov_count > SOCK_EP_MAX_IOV_LIMIT)
 		return -FI_EINVAL;
+#endif
 	
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
@@ -338,11 +344,13 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		dst_len += tx_iov.iov.len;
 	}
 	
+#ifdef ENABLE_DEBUG
 	if (dst_len != src_len) {
 		SOCK_LOG_ERROR("Buffer length mismatch\n");
 		ret = -FI_EINVAL;
 		goto err;
 	}
+#endif
 	
 	sock_tx_ctx_commit(tx_ctx);
 	return 0;


### PR DESCRIPTION
- Coverity scan fixes
- Do argument sanity checks only in debug mode