### PR TITLE
usnic: usdf getinfo

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -299,6 +299,9 @@ struct usdf_ep {
 			uint64_t tx_op_flags;
 			uint64_t rx_op_flags;
 
+			size_t tx_iov_limit;
+			size_t rx_iov_limit;
+
 			void *ep_hdr_buf;
 			struct usd_udp_hdr **ep_hdr_ptr;
 		} dg;

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -72,11 +72,6 @@ extern struct fi_provider usdf_ops;
 
 #define USDF_MAX_PEERS (16 * 1024)
 
-#define USDF_DGRAM_CAPS (FI_MSG | FI_SOURCE | FI_SEND | FI_RECV)
-
-#define USDF_DGRAM_SUPP_MODE (FI_LOCAL_MR | FI_MSG_PREFIX)
-#define USDF_DGRAM_REQ_MODE (FI_LOCAL_MR)
-
 /* usdf event flags */
 #define USDF_EVENT_FLAG_ERROR (1ULL << 62)
 #define USDF_EVENT_FLAG_FREE_BUF (1ULL << 63)

--- a/prov/usnic/src/usdf_dgram.c
+++ b/prov/usnic/src/usdf_dgram.c
@@ -309,10 +309,7 @@ usdf_dgram_sendv(struct fid_ep *fep, const struct iovec *iov, void **desc,
 		return -FI_ENOSPC;
 	}
 
-	/* Advertised iov_limit is USDF_DGRAM_DFLT_SGE. Header takes up one
-	 * space.
-	 */
-	if (count > (USDF_DGRAM_DFLT_SGE - 1)) {
+	if (count > ep->e.dg.tx_iov_limit) {
 		USDF_DBG_SYS(EP_DATA, "max iov count exceeded: %zu\n", count);
 		return -FI_ENOSPC;
 	}
@@ -348,9 +345,7 @@ usdf_dgram_sendmsg(struct fid_ep *fep, const struct fi_msg *msg, uint64_t flags)
 		return -FI_ENOSPC;
 	}
 
-	/* Advertised iov_limit is USDF_DGRAM_DFLT_SGE. Header takes up one.
-	 */
-	if (msg->iov_count > (USDF_DGRAM_DFLT_SGE - 1)) {
+	if (msg->iov_count > ep->e.dg.tx_iov_limit) {
 		USDF_DBG_SYS(EP_DATA, "max iov count exceeded: %zu\n",
 				msg->iov_count);
 		return -FI_ENOSPC;
@@ -406,14 +401,8 @@ ssize_t usdf_dgram_rx_size_left(struct fid_ep *fep)
 	if (ep->e.dg.ep_qp == NULL)
 		return -FI_EOPBADSTATE; /* EP not enabled */
 
-	/* NOTE-SIZE-LEFT: divide by constant right now, rather than keeping
-	 * track of the rx_attr->iov_limit value we gave to the user.  This
-	 * sometimes under-reports the number of RX ops that could be posted,
-	 * but it avoids touching a cache line that we don't otherwise need.
-	 *
-	 * sendv/recvv could potentially post iov_limit+1 descriptors
-	 */
-	return usd_get_recv_credits(ep->e.dg.ep_qp) / (USDF_DGRAM_DFLT_SGE + 1);
+	return usd_get_recv_credits(ep->e.dg.ep_qp) /
+		(ep->e.dg.rx_iov_limit + 1);
 }
 
 ssize_t usdf_dgram_tx_size_left(struct fid_ep *fep)
@@ -430,8 +419,8 @@ ssize_t usdf_dgram_tx_size_left(struct fid_ep *fep)
 	if (ep->e.dg.ep_qp == NULL)
 		return -FI_EOPBADSTATE; /* EP not enabled */
 
-	/* see NOTE-SIZE-LEFT */
-	return usd_get_send_credits(ep->e.dg.ep_qp) / (USDF_DGRAM_DFLT_SGE + 1);
+	return usd_get_send_credits(ep->e.dg.ep_qp) /
+		(ep->e.dg.tx_iov_limit + 1);
 }
 
 /*
@@ -600,10 +589,7 @@ usdf_dgram_prefix_sendv(struct fid_ep *fep, const struct iovec *iov,
 	len = _usdf_iov_len(iov, count);
 	padding = USDF_HDR_BUF_ENTRY - sizeof(struct usd_udp_hdr);
 
-	/*
-	 * USDF_DGRAM_DFLT_SGE is the advertised iov_limit.
-	 */
-	if (count > USDF_DGRAM_DFLT_SGE) {
+	if (count > ep->e.dg.tx_iov_limit) {
 		USDF_DBG_SYS(EP_DATA, "max iov count exceeded: %zu\n", count);
 		return -FI_ENOSPC;
 	}
@@ -648,9 +634,7 @@ usdf_dgram_prefix_sendmsg(struct fid_ep *fep, const struct fi_msg *msg,
 	completion = ep->ep_tx_dflt_signal_comp || (flags & FI_COMPLETION);
 	padding = USDF_HDR_BUF_ENTRY - sizeof(struct usd_udp_hdr);
 
-	/* USDF_DGRAM_DFLT_SGE is the advertised iov_limit.
-	 */
-	if (msg->iov_count > USDF_DGRAM_DFLT_SGE) {
+	if (msg->iov_count > ep->e.dg.tx_iov_limit) {
 		USDF_DBG_SYS(EP_DATA, "max iov count exceeded: %zu\n",
 				msg->iov_count);
 		return -FI_ENOSPC;
@@ -695,9 +679,8 @@ ssize_t usdf_dgram_prefix_rx_size_left(struct fid_ep *fep)
 		return -FI_EOPBADSTATE; /* EP not enabled */
 
 	/* prefix_recvv can post up to iov_limit descriptors
-	 *
-	 * also see NOTE-SIZE-LEFT */
-	return (usd_get_recv_credits(ep->e.dg.ep_qp) / USDF_DGRAM_DFLT_SGE);
+	 */
+	return (usd_get_recv_credits(ep->e.dg.ep_qp) / ep->e.dg.rx_iov_limit);
 }
 
 ssize_t usdf_dgram_prefix_tx_size_left(struct fid_ep *fep)
@@ -715,9 +698,6 @@ ssize_t usdf_dgram_prefix_tx_size_left(struct fid_ep *fep)
 		return -FI_EOPBADSTATE; /* EP not enabled */
 
 	/* prefix_sendvcan post up to iov_limit descriptors
-	 *
-	 * also see NOTE-SIZE-LEFT */
-	return (usd_get_send_credits(ep->e.dg.ep_qp) / USDF_DGRAM_DFLT_SGE);
+	 */
+	return (usd_get_send_credits(ep->e.dg.ep_qp) / ep->e.dg.tx_iov_limit);
 }
-
-

--- a/prov/usnic/src/usdf_dgram.h
+++ b/prov/usnic/src/usdf_dgram.h
@@ -39,6 +39,28 @@
 #define USDF_DGRAM_MAX_SGE 8
 #define USDF_DGRAM_DFLT_SGE 4
 
+#define USDF_DGRAM_CAPS (FI_MSG | FI_SOURCE | FI_SEND | FI_RECV)
+#define USDF_DGRAM_SUPP_MODE (FI_LOCAL_MR | FI_MSG_PREFIX)
+#define USDF_DGRAM_REQ_MODE (FI_LOCAL_MR)
+#define USDF_DGRAM_MSG_ORDER (FI_ORDER_NONE)
+#define USDF_DGRAM_COMP_ORDER (FI_ORDER_NONE)
+#define USDF_DGRAM_INJECT_SIZE                                                 \
+	(USD_SEND_MAX_COPY - sizeof(struct usd_udp_hdr))
+#define USDF_DGRAM_SUPP_SENDMSG_FLAGS                                          \
+	(FI_INJECT | FI_COMPLETION | FI_INJECT_COMPLETE | FI_TRANSMIT_COMPLETE)
+#define USDF_DGRAM_SUPP_RECVMSG_FLAGS (FI_COMPLETION)
+#define USDF_DGRAM_IOV_LIMIT (USDF_DGRAM_DFLT_SGE)
+#define USDF_DGRAM_RMA_IOV_LIMIT 0
+
+
+int usdf_dgram_fill_rx_attr(struct fi_info *hints,
+		struct fi_info *fi, struct usd_device_attrs *dap);
+int usdf_dgram_fill_tx_attr(struct fi_info *hints, struct fi_info *fi,
+		struct usd_device_attrs *dap);
+int usdf_dgram_fill_dom_attr(struct fi_info *hints, struct fi_info *fi);
+int usdf_dgram_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
+		struct usd_device_attrs *dap);
+
 /* fi_ops_msg for DGRAM */
 ssize_t usdf_dgram_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
 	fi_addr_t src_addr, void *context);

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -349,6 +349,305 @@ static struct fi_ops_cm usdf_cm_dgram_ops = {
 	.shutdown = fi_no_shutdown,
 };
 
+/*******************************************************************************
+ * Default values for dgram attributes
+ ******************************************************************************/
+static const struct fi_tx_attr dgram_dflt_tx_attr = {
+	.caps = USDF_DGRAM_CAPS,
+	.mode = USDF_DGRAM_SUPP_MODE,
+	.op_flags = 0,
+	.msg_order = USDF_DGRAM_MSG_ORDER,
+	.comp_order = USDF_DGRAM_COMP_ORDER,
+	.inject_size = USDF_DGRAM_INJECT_SIZE,
+	.iov_limit = USDF_DGRAM_IOV_LIMIT,
+	.rma_iov_limit = USDF_DGRAM_RMA_IOV_LIMIT
+};
+
+static const struct fi_rx_attr dgram_dflt_rx_attr = {
+	.caps = USDF_DGRAM_CAPS,
+	.mode = USDF_DGRAM_SUPP_MODE,
+	.op_flags = 0,
+	.msg_order = USDF_DGRAM_MSG_ORDER,
+	.comp_order = USDF_DGRAM_COMP_ORDER,
+	.total_buffered_recv = 0,
+	.iov_limit = USDF_DGRAM_IOV_LIMIT
+};
+
+static const struct fi_ep_attr dgram_dflt_ep_attr = {
+	.type = FI_EP_DGRAM,
+	.protocol = FI_PROTO_UDP,
+	.msg_prefix_size = 0,
+	.max_order_raw_size = 0,
+	.max_order_war_size = 0,
+	.max_order_waw_size = 0,
+	.mem_tag_format = 0,
+	.tx_ctx_cnt = 1,
+	.rx_ctx_cnt = 1
+};
+
+static const struct fi_domain_attr dgram_dflt_domain_attr = {
+	.threading = FI_THREAD_ENDPOINT,
+	.control_progress = FI_PROGRESS_AUTO,
+	.data_progress = FI_PROGRESS_MANUAL,
+	.resource_mgmt = FI_RM_DISABLED,
+	.mr_mode = FI_MR_BASIC
+};
+
+/*******************************************************************************
+ * Fill functions for attributes
+ ******************************************************************************/
+int usdf_dgram_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
+		struct usd_device_attrs *dap)
+{
+	struct fi_ep_attr defaults;
+
+	defaults = dgram_dflt_ep_attr;
+
+	defaults.max_msg_size = dap->uda_mtu - sizeof(struct usd_udp_hdr);
+
+	if (!hints || !hints->ep_attr)
+		goto out;
+
+	if (hints->mode & FI_MSG_PREFIX)
+		defaults.msg_prefix_size = USDF_HDR_BUF_ENTRY;
+
+	if (hints->ep_attr->max_msg_size > defaults.max_msg_size)
+		return -FI_ENODATA;
+
+	switch (hints->ep_attr->protocol) {
+	case FI_PROTO_UNSPEC:
+	case FI_PROTO_UDP:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	if (hints->ep_attr->tx_ctx_cnt > defaults.tx_ctx_cnt)
+		return -FI_ENODATA;
+	if (hints->ep_attr->rx_ctx_cnt > defaults.rx_ctx_cnt)
+		return -FI_ENODATA;
+
+	if (hints->ep_attr->max_order_raw_size > defaults.max_order_raw_size)
+		return -FI_ENODATA;
+	if (hints->ep_attr->max_order_war_size > defaults.max_order_war_size)
+		return -FI_ENODATA;
+	if (hints->ep_attr->max_order_waw_size > defaults.max_order_waw_size)
+		return -FI_ENODATA;
+
+out:
+	*fi->ep_attr = defaults;
+
+	return FI_SUCCESS;
+}
+
+int usdf_dgram_fill_dom_attr(struct fi_info *hints, struct fi_info *fi)
+{
+	struct fi_domain_attr defaults;
+
+	defaults = dgram_dflt_domain_attr;
+
+	if (!hints || !hints->domain_attr)
+		goto out;
+
+	switch (hints->domain_attr->threading) {
+	case FI_THREAD_UNSPEC:
+	case FI_THREAD_ENDPOINT:
+		break;
+	case FI_THREAD_FID:
+	case FI_THREAD_COMPLETION:
+	case FI_THREAD_DOMAIN:
+		defaults.threading = hints->domain_attr->threading;
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	switch (hints->domain_attr->control_progress) {
+	case FI_PROGRESS_UNSPEC:
+	case FI_PROGRESS_AUTO:
+		break;
+	case FI_PROGRESS_MANUAL:
+		defaults.control_progress =
+			hints->domain_attr->control_progress;
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	switch (hints->domain_attr->data_progress) {
+	case FI_PROGRESS_UNSPEC:
+	case FI_PROGRESS_MANUAL:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	switch (hints->domain_attr->resource_mgmt) {
+	case FI_RM_UNSPEC:
+	case FI_RM_DISABLED:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	switch (hints->domain_attr->mr_mode) {
+	case FI_MR_UNSPEC:
+	case FI_MR_BASIC:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+out:
+	*fi->domain_attr = defaults;
+
+	return FI_SUCCESS;
+}
+
+int usdf_dgram_fill_tx_attr(struct fi_info *hints, struct fi_info *fi,
+		struct usd_device_attrs *dap)
+{
+	struct fi_tx_attr defaults;
+	size_t entries;
+
+	defaults = dgram_dflt_tx_attr;
+
+	defaults.size = dap->uda_max_send_credits / defaults.iov_limit;
+
+	if (!hints || !hints->tx_attr)
+		goto out;
+
+	/* make sure we can support the capabilities that are requested */
+	if (hints->tx_attr->caps & ~USDF_DGRAM_CAPS)
+		return -FI_ENODATA;
+
+	/* clear the mode bits the app doesn't support */
+	if (hints->tx_attr->mode)
+		defaults.mode &= hints->tx_attr->mode;
+
+	/* make sure the app supports our required mode bits */
+	if ((defaults.mode & USDF_DGRAM_REQ_MODE) != USDF_DGRAM_REQ_MODE)
+		return -FI_ENODATA;
+
+	defaults.op_flags |= hints->tx_attr->op_flags;
+
+	if ((hints->tx_attr->msg_order | USDF_DGRAM_MSG_ORDER) !=
+			USDF_DGRAM_MSG_ORDER)
+		return -FI_ENODATA;
+	if ((hints->tx_attr->comp_order | USDF_DGRAM_COMP_ORDER) !=
+			USDF_DGRAM_COMP_ORDER)
+		return -FI_ENODATA;
+
+	if (hints->tx_attr->inject_size > defaults.inject_size)
+		return -FI_ENODATA;
+
+	if (hints->tx_attr->iov_limit > defaults.iov_limit)
+		return -FI_ENODATA;
+	if (hints->tx_attr->size > dap->uda_max_send_credits)
+		return -FI_ENODATA;
+
+	/* make sure the values for iov_limit and size are within appropriate
+	 * bounds. if only one of the two was given, then set the other based
+	 * on:
+	 * 	max_credits = size * iov_limit;
+	 */
+	if (hints->tx_attr->iov_limit && hints->tx_attr->size) {
+		entries = hints->tx_attr->size * hints->tx_attr->iov_limit;
+		if (entries > dap->uda_max_send_credits)
+			return -FI_ENODATA;
+
+		defaults.size = hints->tx_attr->size;
+		defaults.iov_limit = hints->tx_attr->iov_limit;
+	} else if (hints->tx_attr->iov_limit) {
+		defaults.iov_limit = hints->tx_attr->iov_limit;
+		defaults.size =
+			dap->uda_max_send_credits / defaults.iov_limit;
+	} else if (hints->tx_attr->size) {
+		defaults.size = hints->tx_attr->size;
+		defaults.iov_limit =
+			dap->uda_max_send_credits / defaults.size;
+	}
+
+	if (hints->tx_attr->rma_iov_limit > defaults.rma_iov_limit)
+		return -FI_ENODATA;
+
+out:
+	*fi->tx_attr = defaults;
+
+	return FI_SUCCESS;
+}
+
+int usdf_dgram_fill_rx_attr(struct fi_info *hints, struct fi_info *fi,
+		struct usd_device_attrs *dap)
+{
+	struct fi_rx_attr defaults;
+	size_t entries;
+
+	defaults = dgram_dflt_rx_attr;
+
+	defaults.size = dap->uda_max_recv_credits / defaults.iov_limit;
+
+	if (!hints || !hints->rx_attr)
+		goto out;
+
+	/* make sure we can support the capabilities that are requested */
+	if (hints->rx_attr->caps & ~USDF_DGRAM_CAPS)
+		return -FI_ENODATA;
+
+	/* clear the mode bits the app doesn't support */
+	if (hints->rx_attr->mode)
+		defaults.mode &= hints->rx_attr->mode;
+
+	/* make sure the app supports our required mode bits */
+	if ((defaults.mode & USDF_DGRAM_REQ_MODE) != USDF_DGRAM_REQ_MODE)
+		return -FI_ENODATA;
+
+	defaults.op_flags |= hints->rx_attr->op_flags;
+
+	if ((hints->rx_attr->msg_order | USDF_DGRAM_MSG_ORDER) !=
+			USDF_DGRAM_MSG_ORDER)
+		return -FI_ENODATA;
+	if ((hints->rx_attr->comp_order | USDF_DGRAM_COMP_ORDER) !=
+			USDF_DGRAM_COMP_ORDER)
+		return -FI_ENODATA;
+
+	if (hints->rx_attr->total_buffered_recv >
+			defaults.total_buffered_recv)
+		return -FI_ENODATA;
+
+	if (hints->rx_attr->iov_limit > defaults.iov_limit)
+		return -FI_ENODATA;
+	if (hints->rx_attr->size > dap->uda_max_send_credits)
+		return -FI_ENODATA;
+
+	/* make sure the values for iov_limit and size are within appropriate
+	 * bounds. if only one of the two was given, then set the other based
+	 * on:
+	 * 	max_credits = size * iov_limit;
+	 */
+	if (hints->rx_attr->iov_limit && hints->rx_attr->size) {
+		entries = hints->rx_attr->size * hints->rx_attr->iov_limit;
+		if (entries > dap->uda_max_send_credits)
+			return -FI_ENODATA;
+
+		defaults.size = hints->rx_attr->size;
+		defaults.iov_limit = hints->rx_attr->iov_limit;
+	} else if (hints->rx_attr->iov_limit) {
+		defaults.iov_limit = hints->rx_attr->iov_limit;
+		defaults.size =
+			dap->uda_max_send_credits / defaults.iov_limit;
+	} else if (hints->rx_attr->size) {
+		defaults.size = hints->rx_attr->size;
+		defaults.iov_limit =
+			dap->uda_max_send_credits / defaults.size;
+	}
+
+out:
+	*fi->rx_attr = defaults;
+
+	return FI_SUCCESS;
+}
+
 static int usdf_ep_dgram_control(struct fid *fid, int command, void *arg)
 {
 	struct fid_ep *ep;

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -63,10 +63,257 @@
 #include "usdf.h"
 #include "usdf_cm.h"
 #include "usdf_endpoint.h"
+#include "fi_ext_usnic.h"
 #include "usdf_rudp.h"
 #include "usdf_msg.h"
 #include "usdf_cq.h"
 #include "usdf_timer.h"
+
+/*******************************************************************************
+ * Default values for msg attributes
+ ******************************************************************************/
+static const struct fi_tx_attr msg_dflt_tx_attr = {
+	.caps = USDF_MSG_CAPS,
+	.mode = USDF_MSG_SUPP_MODE,
+	.op_flags = 0,
+	.msg_order = USDF_MSG_MSG_ORDER,
+	.comp_order = USDF_MSG_COMP_ORDER,
+	.inject_size = USDF_MSG_MAX_INJECT_SIZE,
+	.size = USDF_MSG_DFLT_CTX_SIZE,
+	.iov_limit = USDF_MSG_MAX_SGE,
+	.rma_iov_limit = USDF_MSG_RMA_IOV_LIMIT
+};
+
+static const struct fi_rx_attr msg_dflt_rx_attr = {
+	.caps = USDF_MSG_CAPS,
+	.mode = USDF_MSG_SUPP_MODE,
+	.op_flags = 0,
+	.msg_order = USDF_MSG_MSG_ORDER,
+	.comp_order = USDF_MSG_COMP_ORDER,
+	.size = USDF_MSG_DFLT_CTX_SIZE,
+	.total_buffered_recv = 0,
+	.iov_limit = USDF_MSG_IOV_LIMIT
+};
+
+static const struct fi_ep_attr msg_dflt_ep_attr = {
+	.type = FI_EP_MSG,
+	.protocol = FI_PROTO_RUDP,
+	.msg_prefix_size = 0,
+	.max_msg_size = USDF_MSG_MAX_MSG,
+	.max_order_raw_size = 0,
+	.max_order_war_size = 0,
+	.max_order_waw_size = 0,
+	.mem_tag_format = 0,
+	.tx_ctx_cnt = 1,
+	.rx_ctx_cnt = 1
+};
+
+static const struct fi_domain_attr msg_dflt_domain_attr = {
+	.threading = FI_THREAD_UNSPEC,
+	.control_progress = FI_PROGRESS_AUTO,
+	.data_progress = FI_PROGRESS_MANUAL,
+	.resource_mgmt = FI_RM_DISABLED,
+	.mr_mode = FI_MR_BASIC
+};
+
+/*******************************************************************************
+ * Fill functions for attributes
+ ******************************************************************************/
+int usdf_msg_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
+		struct usd_device_attrs *dap)
+{
+	struct fi_ep_attr defaults;
+
+	defaults = msg_dflt_ep_attr;
+
+	if (!hints || !hints->ep_attr)
+		goto out;
+
+	if (hints->ep_attr->max_msg_size > defaults.max_msg_size)
+		return -FI_ENODATA;
+
+	switch (hints->ep_attr->protocol) {
+	case FI_PROTO_UNSPEC:
+	case FI_PROTO_RUDP:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	if (hints->ep_attr->tx_ctx_cnt > defaults.tx_ctx_cnt)
+		return -FI_ENODATA;
+
+	if (hints->ep_attr->rx_ctx_cnt > defaults.rx_ctx_cnt)
+		return -FI_ENODATA;
+
+	if (hints->ep_attr->max_order_raw_size > defaults.max_order_raw_size)
+		return -FI_ENODATA;
+
+	if (hints->ep_attr->max_order_war_size > defaults.max_order_war_size)
+		return -FI_ENODATA;
+
+	if (hints->ep_attr->max_order_waw_size > defaults.max_order_waw_size)
+		return -FI_ENODATA;
+
+out:
+	*fi->ep_attr = defaults;
+
+	return FI_SUCCESS;
+}
+
+int usdf_msg_fill_dom_attr(struct fi_info *hints, struct fi_info *fi)
+{
+	struct fi_domain_attr defaults;
+
+	defaults = msg_dflt_domain_attr;
+
+	if (!hints || !hints->domain_attr)
+		goto out;
+
+	/* how to handle fi_thread_fid, fi_thread_completion, etc?
+	 */
+	switch (hints->domain_attr->threading) {
+	case FI_THREAD_UNSPEC:
+	case FI_THREAD_ENDPOINT:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	/* how to handle fi_progress_manual?
+	 */
+	switch (hints->domain_attr->control_progress) {
+	case FI_PROGRESS_UNSPEC:
+	case FI_PROGRESS_AUTO:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	switch (hints->domain_attr->data_progress) {
+	case FI_PROGRESS_UNSPEC:
+	case FI_PROGRESS_MANUAL:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	switch (hints->domain_attr->resource_mgmt) {
+	case FI_RM_UNSPEC:
+	case FI_RM_DISABLED:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+	switch (hints->domain_attr->mr_mode) {
+	case FI_MR_UNSPEC:
+	case FI_MR_BASIC:
+		break;
+	default:
+		return -FI_ENODATA;
+	}
+
+out:
+	*fi->domain_attr = defaults;
+
+	return FI_SUCCESS;
+}
+
+int usdf_msg_fill_tx_attr(struct fi_info *hints, struct fi_info *fi)
+{
+	struct fi_tx_attr defaults;
+
+	defaults = msg_dflt_tx_attr;
+
+	if (!hints || !hints->tx_attr)
+		goto out;
+
+	/* make sure we can support the caps that are requested*/
+	if (hints->tx_attr->caps & ~USDF_MSG_CAPS)
+		return -FI_ENODATA;
+
+	/* clear the mode bits the app doesn't support */
+	if (hints->tx_attr->mode)
+		defaults.mode &= hints->tx_attr->mode;
+
+	/* make sure the app supports our required mode bits */
+	if ((defaults.mode & USDF_MSG_REQ_MODE) != USDF_MSG_REQ_MODE)
+		return -FI_ENODATA;
+
+	defaults.op_flags |= hints->tx_attr->op_flags;
+
+	if ((hints->tx_attr->msg_order | USDF_MSG_MSG_ORDER) !=
+			USDF_MSG_MSG_ORDER)
+		return -FI_ENODATA;
+
+	if ((hints->tx_attr->comp_order | USDF_MSG_COMP_ORDER) !=
+			USDF_MSG_COMP_ORDER)
+		return -FI_ENODATA;
+
+	if (hints->tx_attr->inject_size > defaults.inject_size)
+		return -FI_ENODATA;
+
+	if (hints->tx_attr->iov_limit > defaults.iov_limit)
+		return -FI_ENODATA;
+
+	if (hints->tx_attr->rma_iov_limit > defaults.rma_iov_limit)
+		return -FI_ENODATA;
+
+	if (hints->tx_attr->size > defaults.size)
+		return -FI_ENODATA;
+
+out:
+	*fi->tx_attr = defaults;
+
+	return FI_SUCCESS;
+}
+
+int usdf_msg_fill_rx_attr(struct fi_info *hints, struct fi_info *fi)
+{
+	struct fi_rx_attr defaults;
+
+	defaults = msg_dflt_rx_attr;
+
+	if (!hints || !hints->rx_attr)
+		goto out;
+
+	/* make sure we can support the capabilities that are requested */
+	if (hints->rx_attr->caps & ~USDF_MSG_CAPS)
+		return -FI_ENODATA;
+
+	/* clear the mode bits the app doesn't support */
+	if (hints->rx_attr->mode)
+		defaults.mode &= hints->rx_attr->mode;
+
+	/* make sure the app supports our required mode bits */
+	if ((defaults.mode & USDF_MSG_REQ_MODE) != USDF_MSG_REQ_MODE)
+		return -FI_ENODATA;
+
+	defaults.op_flags |= hints->rx_attr->op_flags;
+
+	if ((hints->rx_attr->msg_order | USDF_MSG_MSG_ORDER) !=
+			USDF_MSG_MSG_ORDER)
+		return -FI_ENODATA;
+	if ((hints->rx_attr->comp_order | USDF_MSG_COMP_ORDER) !=
+			USDF_MSG_COMP_ORDER)
+		return -FI_ENODATA;
+
+	if (hints->rx_attr->total_buffered_recv >
+			defaults.total_buffered_recv)
+		return -FI_ENODATA;
+
+	if (hints->rx_attr->iov_limit > defaults.iov_limit)
+		return -FI_ENODATA;
+
+	if (hints->rx_attr->size > defaults.size)
+		return -FI_ENODATA;
+
+out:
+	*fi->rx_attr = defaults;
+
+	return FI_SUCCESS;
+}
 
 static int
 usdf_tx_msg_enable(struct usdf_tx *tx)
@@ -354,47 +601,6 @@ usdf_ep_msg_cancel(fid_t fid, void *context)
 {
 	USDF_TRACE_SYS(EP_CTRL, "\n");
 	/* XXX should this have a non-empty implementation? */
-	return 0;
-}
-
-int
-usdf_msg_fill_tx_attr(struct fi_tx_attr *txattr)
-{
-	if (txattr->size > USDF_MSG_MAX_CTX_SIZE ||
-	    txattr->iov_limit > USDF_MSG_MAX_SGE) {
-		return -FI_ENODATA;
-	}
-
-	if (txattr->size == 0) {
-		txattr->size = USDF_MSG_DFLT_CTX_SIZE;
-	}
-	if (txattr->iov_limit == 0) {
-		txattr->iov_limit = USDF_MSG_DFLT_SGE;
-	}
-
-	if (txattr->op_flags & ~USDF_MSG_SUPP_SENDMSG_FLAGS) {
-		USDF_WARN("one or more flags in 0x%llx not supported\n",
-			txattr->op_flags);
-		return -FI_EOPNOTSUPP;
-	}
-
-	return 0;
-}
-
-int
-usdf_msg_fill_rx_attr(struct fi_rx_attr *rxattr)
-{
-	if (rxattr->size > USDF_MSG_MAX_CTX_SIZE ||
-	    rxattr->iov_limit > USDF_MSG_MAX_SGE) {
-		return -FI_ENODATA;
-	}
-
-	if (rxattr->size == 0) {
-		rxattr->size = USDF_MSG_DFLT_CTX_SIZE;
-	}
-	if (rxattr->iov_limit == 0) {
-		rxattr->iov_limit = USDF_MSG_DFLT_SGE;
-	}
 	return 0;
 }
 
@@ -837,18 +1043,13 @@ usdf_ep_msg_open(struct fid_domain *domain, struct fi_info *info,
 		tx->tx_domain = udp;
 		tx->tx_progress = usdf_msg_tx_progress;
 		atomic_inc(&udp->dom_refcnt);
-		if (info->tx_attr != NULL) {
-			ret = usdf_msg_fill_tx_attr(info->tx_attr);
-			if (ret != 0) {
-				goto fail;
-			}
-			tx->tx_attr = *info->tx_attr;
-		} else {
-			ret = usdf_msg_fill_tx_attr(&tx->tx_attr);
-			if (ret != 0) {
-				goto fail;
-			}
-		}
+
+		/* use info as the hints structure, and the output structure */
+		ret = usdf_msg_fill_tx_attr(info, info);
+		if (ret != 0)
+			goto fail;
+		tx->tx_attr = *info->tx_attr;
+
 		TAILQ_INIT(&tx->t.msg.tx_free_wqe);
 		TAILQ_INIT(&tx->t.msg.tx_ep_ready);
 		TAILQ_INIT(&tx->t.msg.tx_ep_have_acks);
@@ -870,15 +1071,13 @@ usdf_ep_msg_open(struct fid_domain *domain, struct fi_info *info,
 		atomic_initialize(&rx->rx_refcnt, 0);
 		rx->rx_domain = udp;
 		atomic_inc(&udp->dom_refcnt);
-		if (info->rx_attr != NULL) {
-			ret = usdf_msg_fill_rx_attr(info->rx_attr);
-			if (ret != 0) {
-				goto fail;
-			}
-			rx->rx_attr = *info->rx_attr;
-		} else {
-			ret = usdf_msg_fill_rx_attr(&rx->rx_attr);
-		}
+
+		/* info serves as both the hints and the output */
+		ret = usdf_msg_fill_rx_attr(info, info);
+		if (ret != 0)
+			goto fail;
+		rx->rx_attr = *info->rx_attr;
+
 		TAILQ_INIT(&rx->r.msg.rx_free_rqe);
 		TAILQ_INIT(&rx->r.msg.rx_posted_rqe);
 

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -393,10 +393,6 @@ usdf_fill_info_rdm(
 {
 	struct fi_info *fi;
 	struct fi_fabric_attr *fattrp;
-	struct fi_domain_attr *dattrp;
-	struct fi_tx_attr *txattr;
-	struct fi_rx_attr *rxattr;
-	struct fi_ep_attr *eattrp;
 	uint32_t addr_format;
 	int ret;
 
@@ -443,34 +439,21 @@ usdf_fill_info_rdm(
 		goto fail;
 	}
 
-	/* TX attrs */
-	txattr = fi->tx_attr;
-	if (hints != NULL && hints->tx_attr != NULL) {
-		*txattr = *hints->tx_attr;
-	}
-	usdf_rdm_fill_tx_attr(txattr);
+	ret = usdf_rdm_fill_ep_attr(hints, fi, dap);
+	if (ret)
+		goto fail;
 
-	/* RX attrs */
-	rxattr = fi->rx_attr;
-	if (hints != NULL && hints->rx_attr != NULL) {
-		*rxattr = *hints->rx_attr;
-	}
-	usdf_rdm_fill_rx_attr(rxattr);
+	ret = usdf_rdm_fill_dom_attr(hints, fi);
+	if (ret)
+		goto fail;
 
-	/* endpoint attrs */
-	eattrp = fi->ep_attr;
-	eattrp->max_msg_size = USDF_RDM_MAX_MSG;
-	eattrp->protocol = FI_PROTO_RUDP;
-	eattrp->tx_ctx_cnt = 1;
-	eattrp->rx_ctx_cnt = 1;
+	ret = usdf_rdm_fill_tx_attr(hints, fi);
+	if (ret)
+		goto fail;
 
-	/* domain attrs */
-	dattrp = fi->domain_attr;
-	dattrp->threading = FI_THREAD_UNSPEC;
-	dattrp->control_progress = FI_PROGRESS_AUTO;
-	dattrp->data_progress = FI_PROGRESS_MANUAL;
-	dattrp->resource_mgmt = FI_RM_DISABLED;
-	dattrp->mr_mode = FI_MR_BASIC;
+	ret = usdf_rdm_fill_rx_attr(hints, fi);
+	if (ret)
+		goto fail;
 
 	/* add to tail of list */
 	if (*fi_first == NULL) {

--- a/prov/usnic/src/usdf_msg.h
+++ b/prov/usnic/src/usdf_msg.h
@@ -43,14 +43,18 @@
 
 #define USDF_MSG_SUPP_SENDMSG_FLAGS \
 	(FI_INJECT_COMPLETE | FI_TRANSMIT_COMPLETE | FI_INJECT | FI_COMPLETION)
+#define USDF_MSG_SUPP_RECVMSG_FLAGS (FI_COMPLETION)
 
-#define USDF_MSG_SUPP_RECVMSG_FLAGS \
-	(FI_COMPLETION)
+#define USDF_MSG_MSG_ORDER (FI_ORDER_NONE)
+#define USDF_MSG_COMP_ORDER (FI_ORDER_NONE)
 
 #define USDF_MSG_MAX_SGE 8
 #define USDF_MSG_DFLT_SGE 8
 #define USDF_MSG_MAX_CTX_SIZE 1024
 #define USDF_MSG_DFLT_CTX_SIZE 512
+
+#define USDF_MSG_IOV_LIMIT (USDF_MSG_DFLT_SGE)
+#define USDF_MSG_RMA_IOV_LIMIT 0
 
 #define USDF_MSG_MAX_MSG UINT_MAX
 
@@ -84,8 +88,13 @@ struct usdf_msg_qe {
 };
 
 int usdf_msg_post_recv(struct usdf_rx *rx, void *buf, size_t len);
-int usdf_msg_fill_tx_attr(struct fi_tx_attr *txattr);
-int usdf_msg_fill_rx_attr(struct fi_rx_attr *rxattr);
+
+int usdf_msg_fill_tx_attr(struct fi_info *hints, struct fi_info *fi);
+int usdf_msg_fill_rx_attr(struct fi_info *hints, struct fi_info *fi);
+int usdf_msg_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
+		struct usd_device_attrs *dap);
+int usdf_msg_fill_dom_attr(struct fi_info *hints, struct fi_info *fi);
+
 void usdf_msg_ep_timeout(void *vep);
 
 void usdf_msg_hcq_progress(struct usdf_cq_hard *hcq);

--- a/prov/usnic/src/usdf_rdm.h
+++ b/prov/usnic/src/usdf_rdm.h
@@ -43,6 +43,7 @@
 
 #define USDF_RDM_SUPP_SENDMSG_FLAGS \
 	(FI_INJECT_COMPLETE | FI_TRANSMIT_COMPLETE | FI_INJECT | FI_COMPLETION)
+#define USDF_RDM_SUPP_RECVMSG_FLAGS (FI_COMPLETION)
 
 #define USDF_RDM_MAX_SGE 8
 #define USDF_RDM_DFLT_SGE 8
@@ -52,6 +53,11 @@
 #define USDF_RDM_MAX_MSG UINT_MAX
 
 #define USDF_RDM_MAX_INJECT_SIZE 64
+#define USDF_RDM_IOV_LIMIT (USDF_RDM_DFLT_SGE)
+#define USDF_RDM_RMA_IOV_LIMIT 0
+
+#define USDF_RDM_MSG_ORDER (FI_ORDER_NONE)
+#define USDF_RDM_COMP_ORDER (FI_ORDER_NONE)
 
 #define USDF_RDM_FREE_BLOCK (16 * 1024)
 #define USDF_RDM_HASH_SIZE (64 * 1024)
@@ -132,9 +138,14 @@ struct usdf_rdm_connection {
 	struct usdf_rdm_connection *dc_hash_next;
 };
 
+
+int usdf_rdm_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
+		struct usd_device_attrs *dap);
+int usdf_rdm_fill_dom_attr(struct fi_info *hints, struct fi_info *fi);
+int usdf_rdm_fill_tx_attr(struct fi_info *hints, struct fi_info *fi);
+int usdf_rdm_fill_rx_attr(struct fi_info *hints, struct fi_info *fi);
+
 int usdf_rdm_post_recv(struct usdf_rx *rx, void *buf, size_t len);
-int usdf_rdm_fill_tx_attr(struct fi_tx_attr *txattr);
-int usdf_rdm_fill_rx_attr(struct fi_rx_attr *rxattr);
 int usdf_cq_rdm_poll(struct usd_cq *ucq, struct usd_completion *comp);
 void usdf_rdm_rdc_timeout(void *vrdc);
 


### PR DESCRIPTION
Properly fill / verify properties of getinfo. Can squash when done. Ordered into commits that make sense and can be inspected individually.

Closes #1044 

@goodell @jsquyres 