### PR TITLE
man/multi-recv: Clarify intent of CQ entries flagged with FI_MULTI_RECV

### DIFF
--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -434,8 +434,21 @@ operation.  The following completion flags are defined.
 *FI_MULTI_RECV*
 : This flag applies to receive buffers that were posted with the
   FI_MULTI_RECV flag set.  This completion flag indicates that the
-  receive buffer referenced by the completion has been consumed and
-  was released by the provider.
+  original receive buffer referenced by the completion has been
+  consumed and was released by the provider.  Providers may set
+  this flag on the last message that is received into the multi-
+  recv buffer, or may generate a separate completion that indicates
+  that the buffer has been freed.
+  
+  Applications can distinguish between these two cases by examining
+  the completion entry flags field.  If additional flags, such as
+  FI_RECV, are set, the completion is associated with a received message.  In
+  this case, the buf field will reference the location where the received
+  message was placed into the multi-recv buffer.  Other fields in the
+  completion entry will be determined based on the received message.
+  If other flag bits are zero, the provider is reporting that the multi-recv
+  buffer has been freed, and the completion entry is not associated
+  with a received message.
  
 # RETURN VALUES
 


### PR DESCRIPTION
The meaning of CQ entry fields is not clearly documented.  Clarify
their meaning, in particular when the FI_MULTI_RECV flag is set.
This will help avoid confusion with providers setting the fields
differently (as is currently done).

Signed-off-by: Sean Hefty <sean.hefty@intel.com>