### PR TITLE
Add -e option to fi_info to print environment vars.

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -125,6 +125,8 @@ no_vars:
 }
 DEFAULT_SYMVER(fi_getsettings_, fi_getsettings);
 
+
+__attribute__((visibility ("default")))
 void DEFAULT_SYMVER_PRE(fi_freesettings)(struct fi_setting *var)
 {
 	for (int i = 0; var[i].prov_name; ++i) {


### PR DESCRIPTION
Use like:

/fi_info -e
# psm: Whether to check PSM version number compatibility or not (default: yes)
# FI_PSM_VERSION_CHECK

# psm: Unique Job ID required by the PSM fabric
# FI_PSM_UUID

# psm: Whether to use tagged messages for large size RMA or not (default: yes)
# FI_PSM_TAGGED_RMA

# psm: Whether to use active message based messaging or not (default: no)
# FI_PSM_AM_MSG

# psm: Whether to turn on the name server or not (default: yes)
# FI_PSM_NAME_SERVER

# sockets: Drop every Nth dgram frame (debug only)
# FI_SOCKETS_DGRAM_DROP_RATE

# sockets: How many miliseconds to spin while waiting for progress
# FI_SOCKETS_PE_WAITTIME

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>