### PR TITLE
prov/sockets: Removed redundant handling of pe_entry attributes

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1404,9 +1404,8 @@ static int sock_pe_process_rx_send(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 		len += SOCK_CQ_DATA_SIZE;
 	}
 
+	data_len = pe_entry->msg_hdr.msg_len - len;
 	if (pe_entry->done_len == len && !pe_entry->pe.rx.rx_entry) {
-		data_len = pe_entry->msg_hdr.msg_len - len;
-
 		fastlock_acquire(&rx_ctx->lock);
 		sock_pe_progress_buffered_rx(rx_ctx);
 		
@@ -1429,7 +1428,6 @@ static int sock_pe_process_rx_send(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 			rx_entry->data = pe_entry->data;
 			rx_entry->ignore = 0;
 			rx_entry->comp = pe_entry->comp;
-			pe_entry->context = rx_entry->context;
 
 			if (pe_entry->msg_hdr.flags & FI_REMOTE_CQ_DATA)
 				rx_entry->flags |= FI_REMOTE_CQ_DATA;
@@ -1445,7 +1443,7 @@ static int sock_pe_process_rx_send(struct sock_pe *pe, struct sock_rx_ctx *rx_ct
 	
 	rx_entry = pe_entry->pe.rx.rx_entry;
 	done_data = pe_entry->done_len - len;
-	pe_entry->data_len = pe_entry->msg_hdr.msg_len - len;
+	pe_entry->data_len = data_len;
 	rem = pe_entry->data_len - done_data;
 	used = rx_entry->used;
 


### PR DESCRIPTION
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>