### PR TITLE
prov/psm: Fix for coverity ID 26854

### DIFF
--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -1183,8 +1183,10 @@ ssize_t _psmx_atomic_compwrite(struct fid_ep *ep,
 
 		if (compare != buf + len) {
 			tmp_buf = malloc(len * 2);
-			if (!tmp_buf)
+			if (!tmp_buf) {
+				free(req);
 				return -FI_ENOMEM;
+			}
 
 			memcpy(tmp_buf, buf, len);
 			memcpy(tmp_buf + len, compare, len);

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -417,8 +417,10 @@ int psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	}
 
 	cntr_priv = (struct psmx_fid_cntr *) calloc(1, sizeof *cntr_priv);
-	if (!cntr_priv)
-		return -FI_ENOMEM;
+	if (!cntr_priv) {
+		err = -FI_ENOMEM;
+		goto fail;
+	}
 
 	cntr_priv->domain = domain_priv;
 	cntr_priv->events = events;
@@ -434,5 +436,9 @@ int psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 
 	*cntr = &cntr_priv->cntr;
 	return 0;
+fail:
+	if (wait)
+		fi_close(&wait->wait.fid);
+	return err;
 }
 

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -119,6 +119,7 @@ struct psmx_cq_event *psmx_cq_create_event(struct psmx_fid_cq *cq,
 	default:
 		FI_WARN(&psmx_prov, FI_LOG_CQ,
 			"unsupported CQ format %d\n", cq->format);
+		slist_insert_tail(&event->list_entry, &cq->free_list);
 		return NULL;
 	}
 


### PR DESCRIPTION
Value of err is set to FI_ENOMEM, but saved value is not used.
Replace err with op_error, so that the operation can be reported
as failed.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>