### PR TITLE
What I hope are the final set of changes to the variable/settings/parameters

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -110,6 +110,7 @@ int fi_apply_filter(struct fi_filter *filter, const char *name);
 
 void fi_log_init(void);
 void fi_log_fini(void);
+void fi_param_init(void);
 void fi_param_fini(void);
 
 

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -457,8 +457,15 @@ enum fi_type {
 
 char *fi_tostr(const void *data, enum fi_type datatype);
 
+enum fi_param_type {
+	FI_PARAM_STRING,
+	FI_PARAM_INT,
+	FI_PARAM_BOOL
+};
+
 struct fi_param {
 	const char *name;
+	enum fi_param_type type;
 	const char *help_string;
 	const char *value;
 };

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -123,15 +123,6 @@ int fi_param_get_int(struct fi_provider *provider, const char *param_name,
 		     int *value);
 
 /*
- * Similar to fi_param_get_str(), but the value is converted to a long.
- * No checking is done to ensure that the value the user set is
- * actually an integer -- strtol() is simply called on whatever value
- * the user sets.
- */
-int fi_param_get_long(struct fi_provider *provider, const char *param_name,
-		    long *value);
-
-/*
  * Similar to fi_param_get_str(), but the value is converted to an
  * boolean (0 or 1) and returned in an int.  Accepted user values are:
  *

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -87,7 +87,7 @@ int fi_param_define(const struct fi_provider *provider, const char *param_name,
 		    enum fi_param_type type, const char *help_string);
 
 /*
- * Get the string value of a configuration variable.
+ * Get the value of a configuration variable.
  *
  * Currently, configuration parameter will only be read from the
  * environment.  The environment variable names will be of the form
@@ -95,43 +95,39 @@ int fi_param_define(const struct fi_provider *provider, const char *param_name,
  *
  * Someday this call could be expanded to also check config files.
  *
- * If the parameter was previously registered and the user set a value,
- * FI_SUCCESS is returned and (*value) points to the user's
- * \0-terminated string value.  NOTE: The caller should not modify or
- * free (*value).
+ * If the parameter was previously defined and the user set a value,
+ * FI_SUCCESS is returned and (*value) points to the retrieved
+ * value.
  *
- * If the parameter name was previously registered, but the user did
+ * If the parameter name was previously defined, but the user did
  * not set a value, -FI_ENODATA is returned and the value of (*value)
  * is unchanged.
  *
- * If the variable name was not previously registered via
- * fi_var_register(), -FI_ENOENT will be returned and the value of
+ * If the variable name was not previously defined via
+ * fi_param_define(), -FI_ENOENT will be returned and the value of
  * (*value) is unchanged.
  */
-int fi_param_get_str(struct fi_provider *provider, const char *param_name,
-		     char **value);
+int fi_param_get(struct fi_provider *provider, const char *param_name,
+		 void *value);
 
-/*
- * Similar to fi_param_get_str(), but the value is converted to an int.
- * No checking is done to ensure that the value the user set is
- * actually an integer -- atoi() is simply called on whatever value
- * the user sets.
- */
-int fi_param_get_int(struct fi_provider *provider, const char *param_name,
-		     int *value);
+static inline int
+fi_param_get_str(struct fi_provider *provider, const char *param_name, char **value)
+{
+	return fi_param_get(provider, param_name, value);
+}
 
-/*
- * Similar to fi_param_get_str(), but the value is converted to an
- * boolean (0 or 1) and returned in an int.  Accepted user values are:
- *
- * 0, off, false, no: these will all return 0 in (*value)
- * 1, on, true, yes: these will all return 1 in (*value)
- *
- * Any other user value will return -FI_EINVAL, and (*value) will be
- * unchanged.
- */
-int fi_param_get_bool(struct fi_provider *provider, const char *param_name,
-		      int *value);
+static inline int
+fi_param_get_int(struct fi_provider *provider, const char *param_name, int *value)
+{
+	return fi_param_get(provider, param_name, value);
+}
+
+static inline int
+fi_param_get_bool(struct fi_provider *provider, const char *param_name, int *value)
+{
+	return fi_param_get(provider, param_name, value);
+}
+
 
 #ifdef __cplusplus
 }

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -71,11 +71,9 @@ struct fi_provider {
 	void	(*cleanup)(void);
 };
 
+
 /*
- * Registers a configuration parameter for use with libfabric.
- *
- * Example: fi_param_register(provider, "foo", "Very important help
- * string");
+ * Defines a configuration parameter for use with libfabric.
  *
  * This registers the configuration variable "foo" in the specified
  * provider.
@@ -83,10 +81,10 @@ struct fi_provider {
  * The help string cannot be NULL or empty.
  *
  * The param_name and help_string parameters will be copied internally;
- * they can be freed upon return from fi_param_register().
+ * they can be freed upon return from fi_param_define().
  */
-int fi_param_register(const struct fi_provider *provider, const char *param_name,
-		      const char *help_string);
+int fi_param_define(const struct fi_provider *provider, const char *param_name,
+		    enum fi_param_type type, const char *help_string);
 
 /*
  * Get the string value of a configuration variable.

--- a/libfabric.map
+++ b/libfabric.map
@@ -9,7 +9,7 @@ FABRIC_1.0 {
 		fi_tostr;
 		fi_log_enabled;
 		fi_log;
-		fi_param_register;
+		fi_param_define;
 		fi_param_get_str;
 		fi_param_get_int;
 		fi_param_get_bool;

--- a/libfabric.map
+++ b/libfabric.map
@@ -10,9 +10,7 @@ FABRIC_1.0 {
 		fi_log_enabled;
 		fi_log;
 		fi_param_define;
-		fi_param_get_str;
-		fi_param_get_int;
-		fi_param_get_bool;
+		fi_param_get;
 		fi_getparams;
 		fi_freeparams;
 	local: *;

--- a/libfabric.map
+++ b/libfabric.map
@@ -12,7 +12,6 @@ FABRIC_1.0 {
 		fi_param_register;
 		fi_param_get_str;
 		fi_param_get_int;
-		fi_param_get_long;
 		fi_param_get_bool;
 		fi_getparams;
 		fi_freeparams;

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -473,19 +473,19 @@ PSM_INI
 
 	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
 
-	fi_param_register(&psmx_prov, "name_server",
+	fi_param_define(&psmx_prov, "name_server", FI_PARAM_BOOL,
 			"Whether to turn on the name server or not "
 			"(default: yes)");
 
-	fi_param_register(&psmx_prov, "am_msg",
+	fi_param_define(&psmx_prov, "am_msg", FI_PARAM_BOOL,
 			"Whether to use active message based messaging "
 			"or not (default: no)");
 
-	fi_param_register(&psmx_prov, "tagged_rma",
+	fi_param_define(&psmx_prov, "tagged_rma", FI_PARAM_BOOL,
 			"Whether to use tagged messages for large size "
 			"RMA or not (default: yes)");
 
-	fi_param_register(&psmx_prov, "uuid",
+	fi_param_define(&psmx_prov, "uuid", FI_PARAM_INT,
 			"Unique Job ID required by the fabric");
 
         psm_error_register_handler(NULL, PSM_ERRHANDLER_NO_HANDLER);

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -55,7 +55,7 @@ const char sock_fab_name[] = "IP";
 const char sock_dom_name[] = "sockets";
 const char sock_prov_name[] = "sockets";
 #if ENABLE_DEBUG
-long sock_dgram_drop_rate = 0;
+int sock_dgram_drop_rate = 0;
 #endif
 
 const struct fi_fabric_attr sock_fabric_attr = {
@@ -588,7 +588,7 @@ SOCKETS_INI
 #if ENABLE_DEBUG
 	fi_param_register(&sock_prov, "dgram_drop_rate",
 			"Drop every Nth dgram frame (debug only)");
-	fi_param_get_long(&sock_prov, "dgram_drop_rate", &sock_dgram_drop_rate);
+	fi_param_get_int(&sock_prov, "dgram_drop_rate", &sock_dgram_drop_rate);
 #endif
 	return (&sock_prov);
 }

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -578,7 +578,7 @@ struct fi_provider sock_prov = {
 
 SOCKETS_INI
 {
-	fi_param_register(&sock_prov, "pe_waittime",
+	fi_param_define(&sock_prov, "pe_waittime", FI_PARAM_INT,
                         "How many milliseconds to spin while waiting for progress");
 	fi_param_get_int(&sock_prov, "pe_waittime", &sock_pe_waittime);
 
@@ -586,7 +586,7 @@ SOCKETS_INI
 	dlist_init(&sock_fab_list);
 	dlist_init(&sock_dom_list);
 #if ENABLE_DEBUG
-	fi_param_register(&sock_prov, "dgram_drop_rate",
+	fi_param_define(&sock_prov, "dgram_drop_rate", FI_PARAM_INT,
 			"Drop every Nth dgram frame (debug only)");
 	fi_param_get_int(&sock_prov, "dgram_drop_rate", &sock_dgram_drop_rate);
 #endif

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2500,7 +2500,7 @@ static void sock_thread_set_affinity(char *s)
 static void sock_pe_set_affinity (void)
 {
 	char *s;
-	fi_param_register(&sock_prov, "pe_affinity",
+	fi_param_define(&sock_prov, "pe_affinity", FI_PARAM_INT,
 			"If specified, bind the progress thread to the indicated range(s) of Linux virtual processor ID(s). "
 			"This option is currently not supported on OS X. Usage: id_start[-id_end[:stride]][,]");
 	if (fi_param_get_str(&sock_prov, "pe_affinity", &s) != FI_SUCCESS)

--- a/prov/sockets/src/sock_util.h
+++ b/prov/sockets/src/sock_util.h
@@ -43,7 +43,7 @@ extern const char sock_prov_name[];
 extern struct fi_provider sock_prov;
 extern int sock_pe_waittime;
 #if ENABLE_DEBUG
-extern long sock_dgram_drop_rate;
+extern int sock_dgram_drop_rate;
 #endif
 
 #define _SOCK_LOG_DBG(subsys, ...) FI_DBG(&sock_prov, subsys, __VA_ARGS__);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -351,7 +351,7 @@ static void fi_ini(void)
 	fi_param_init();
 	fi_log_init();
 
-	fi_param_register(NULL, "provider",
+	fi_param_define(NULL, "provider", FI_PARAM_STRING,
 			"Only use specified provider (default: all available)");
 	fi_param_get_str(NULL, "provider", &param_val);
 	fi_create_filter(&prov_filter, param_val);
@@ -370,7 +370,7 @@ static void fi_ini(void)
 	}
 	dlclose(dlhandle);
 
-	fi_param_register(NULL, "provider_path",
+	fi_param_define(NULL, "provider_path", FI_PARAM_STRING,
 			"Search for providers in specific path (default: " PROVDLDIR ")");
 	fi_param_get_str(NULL, "provider_path", &provdir);
 	if (!provdir)

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -68,7 +68,7 @@ static struct fi_filter prov_filter;
 struct fi_provider core_prov = {
 	.name = "core",
 	.version = 1,
-	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION)
 };
 
 
@@ -276,12 +276,9 @@ void fi_free_filter(struct fi_filter *filter)
 	free_string_array(filter->names);
 }
 
-void fi_create_filter(struct fi_filter *filter, const char *env_name)
+void fi_create_filter(struct fi_filter *filter, const char *raw_filter)
 {
-	const char *raw_filter;
-
 	memset(filter, 0, sizeof *filter);
-	raw_filter = getenv(env_name);
 	if (raw_filter == NULL)
 		return;
 
@@ -293,7 +290,7 @@ void fi_create_filter(struct fi_filter *filter, const char *env_name)
 	filter->names = split_and_alloc(raw_filter, ",");
 	if (!filter->names)
 		FI_WARN(&core_prov, FI_LOG_CORE,
-			"unable to parse %s env var\n", env_name);
+			"unable to parse filter from: %s\n", raw_filter);
 }
 
 #ifdef HAVE_LIBDL
@@ -344,18 +341,24 @@ libdl_done:
 
 static void fi_ini(void)
 {
+	char *param_val = NULL;
+
 	pthread_mutex_lock(&ini_lock);
 
 	if (init)
 		goto unlock;
 
 	fi_log_init();
-	fi_create_filter(&prov_filter, "FI_PROVIDER");
+
+	fi_param_register(NULL, "provider",
+			"Only use specified provider (default: all available)");
+	fi_param_get_str(NULL, "provider", &param_val);
+	fi_create_filter(&prov_filter, param_val);
 
 #ifdef HAVE_LIBDL
 	int n = 0;
 	char **dirs;
-	char *provdir;
+	char *provdir = NULL;
 	void *dlhandle;
 
 	/* If dlopen fails, assume static linking and just return
@@ -366,9 +369,12 @@ static void fi_ini(void)
 	}
 	dlclose(dlhandle);
 
-	provdir = getenv("FI_PROVIDER_PATH");
+	fi_param_register(NULL, "provider_path",
+			"Search for providers in specific path (default: " PROVDLDIR ")");
+	fi_param_get_str(NULL, "provider_path", &provdir);
 	if (!provdir)
 		provdir = PROVDLDIR;
+
 	dirs = split_and_alloc(provdir, ":");
 	for (n = 0; dirs[n]; ++n) {
 		fi_ini_dir(dirs[n]);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -348,6 +348,7 @@ static void fi_ini(void)
 	if (init)
 		goto unlock;
 
+	fi_param_init();
 	fi_log_init();
 
 	fi_param_register(NULL, "provider",
@@ -407,8 +408,8 @@ static void __attribute__((destructor)) fi_fini(void)
 	}
 
 	fi_free_filter(&prov_filter);
-	fi_param_fini();
 	fi_log_fini();
+	fi_param_fini();
 }
 
 static struct fi_prov *fi_getprov(const char *prov_name)

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Intel Corp., Inc.  All rights reserved.
+ * Copyright (c) 2014-2015 Intel Corp., Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/log.c
+++ b/src/log.c
@@ -102,19 +102,19 @@ void fi_log_init(void)
 	int level, i;
 	char *levelstr = NULL, *provstr = NULL, *subsysstr = NULL;
 
-	fi_param_register(NULL, "log_level",
+	fi_param_define(NULL, "log_level", FI_PARAM_STRING,
 			"Specify logging level: warn, trace, info, debug (default: warn)");
 	fi_param_get_str(NULL, "log_level", &levelstr);
 	level = fi_convert_log_str(levelstr);
 	if (level >= 0)
 		log_mask = ((1 << (level + 1)) - 1);
 
-	fi_param_register(NULL, "log_prov",
+	fi_param_define(NULL, "log_prov", FI_PARAM_STRING,
 			"Specify specific provider to log (default: all)");
 	fi_param_get_str(NULL, "log_prov", &provstr);
 	fi_create_filter(&prov_log_filter, provstr);
 
-	fi_param_register(NULL, "log_subsys",
+	fi_param_define(NULL, "log_subsys", FI_PARAM_STRING,
 			"Specify specific subsystem to log (default: all)");
 	fi_param_get_str(NULL, "log_subsys", &subsysstr);
 	fi_create_filter(&subsys_filter, subsysstr);

--- a/src/log.c
+++ b/src/log.c
@@ -62,6 +62,8 @@ static const char * const log_levels[] = {
 	[FI_LOG_MAX] = NULL
 };
 
+extern struct fi_provider core_prov;
+
 enum {
 	FI_LOG_SUBSYS_OFFSET	= FI_LOG_MAX,
 	FI_LOG_PROV_OFFSET	= FI_LOG_SUBSYS_OFFSET + FI_LOG_SUBSYS_MAX,
@@ -80,18 +82,15 @@ enum {
 uint64_t log_mask;
 struct fi_filter prov_log_filter;
 
-
-static int fi_read_value(const char *env_name, const char * const names[])
+static int fi_convert_log_str(const char *value)
 {
-	const char *value;
 	int i;
 
-	value = getenv(env_name);
 	if (!value)
 		return -1;
 
-	for (i = 0; names[i]; i++) {
-		if (!strcasecmp(value, names[i]))
+	for (i = 0; log_levels[i]; i++) {
+		if (!strcasecmp(value, log_levels[i]))
 			return i;
 	}
 	return 0;
@@ -101,15 +100,24 @@ void fi_log_init(void)
 {
 	struct fi_filter subsys_filter;
 	int level, i;
+	char *levelstr = NULL, *provstr = NULL, *subsysstr = NULL;
 
-	level = fi_read_value("FI_LOG_LEVEL", log_levels);
+	fi_param_register(NULL, "log_level",
+			"Specify logging level: warn, trace, info, debug (default: warn)");
+	fi_param_get_str(NULL, "log_level", &levelstr);
+	level = fi_convert_log_str(levelstr);
 	if (level >= 0)
 		log_mask = ((1 << (level + 1)) - 1);
 
-	fi_create_filter(&prov_log_filter, "FI_LOG_PROV");
-	/* providers are selectively disabled */
+	fi_param_register(NULL, "log_prov",
+			"Specify specific provider to log (default: all)");
+	fi_param_get_str(NULL, "log_prov", &provstr);
+	fi_create_filter(&prov_log_filter, provstr);
 
-	fi_create_filter(&subsys_filter, "FI_LOG_SUBSYS");
+	fi_param_register(NULL, "log_subsys",
+			"Specify specific subsystem to log (default: all)");
+	fi_param_get_str(NULL, "log_subsys", &subsysstr);
+	fi_create_filter(&subsys_filter, subsysstr);
 	for (i = 0; i < FI_LOG_SUBSYS_MAX; i++) {
 		if (!fi_apply_filter(&subsys_filter, log_subsys[i]))
 			log_mask |= (1 << (i + FI_LOG_SUBSYS_OFFSET));

--- a/src/var.c
+++ b/src/var.c
@@ -57,38 +57,27 @@ struct fi_param_entry {
 	struct dlist_entry entry;
 };
 
+/* TODO: Add locking around param_list when adding dynamic removal */
 static struct dlist_entry param_list;
 
 
-static int fi_param_get(const struct fi_provider *provider, const char *param_name,
-		char **value)
+static struct fi_param_entry *
+fi_find_param(const struct fi_provider *provider, const char *param_name)
 {
 	struct fi_param_entry *param;
 	struct dlist_entry *entry;
-
-	if (!provider)
-		provider = &core_prov;
-
-	// Check for bozo cases
-	if (param_name == NULL || value == NULL) {
-		FI_DBG(provider, FI_LOG_CORE,
-			"Failed to read %s variable: provider coding error\n",
-			param_name);
-		return -FI_EINVAL;
-	}
 
 	for (entry = param_list.next; entry != &param_list; entry = entry->next) {
 		param = container_of(entry, struct fi_param_entry, entry);
 		if (param->provider == provider &&
 		    strcmp(param->name, param_name) == 0) {
-			*value = getenv(param->env_var_name);
-			return FI_SUCCESS;
+			return param;
 		}
 	}
 
 	FI_DBG(provider, FI_LOG_CORE,
-		"Failed to read %s variable: was not registered\n", param_name);
-	return -FI_ENOENT;
+		"Failed to find parameter %s: was not defined\n", param_name);
+	return NULL;
 }
 
 __attribute__((visibility ("default")))
@@ -97,7 +86,7 @@ int DEFAULT_SYMVER_PRE(fi_getparams)(struct fi_param **params, int *count)
 	struct fi_param *vhead = NULL;
 	struct fi_param_entry *param;
 	struct dlist_entry *entry;
-	int ret, cnt, i;
+	int cnt, i;
 	char *tmp;
 
 	for (entry = param_list.next, cnt = 0; entry != &param_list;
@@ -119,9 +108,7 @@ int DEFAULT_SYMVER_PRE(fi_getparams)(struct fi_param **params, int *count)
 		vhead[i].type = param->type;
 		vhead[i].help_string = strdup(param->help_string);
 
-		tmp = NULL;
-		ret = fi_param_get(param->provider, param->name, &tmp);
-		if (ret == FI_SUCCESS && tmp)
+		if ((tmp = getenv(param->env_var_name)))
 			vhead[i].value = strdup(tmp);
 
 		if (!vhead[i].name || !vhead[i].help_string) {
@@ -218,133 +205,81 @@ int DEFAULT_SYMVER_PRE(fi_param_define)(const struct fi_provider *provider,
 }
 DEFAULT_SYMVER(fi_param_define_, fi_param_define);
 
-__attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_param_get_str)(struct fi_provider *provider,
-		const char *param_name, char **value)
+static int fi_parse_bool(const char *str_value)
 {
-	int ret;
-
-	if (!provider)
-		provider = &core_prov;
-
-	ret = fi_param_get(provider, param_name, value);
-	if (ret == FI_SUCCESS) {
-		if (*value) {
-			FI_INFO(provider, FI_LOG_CORE,
-				"read string var %s=%s\n", param_name, *value);
-			ret = FI_SUCCESS;
-		} else {
-			FI_INFO(provider, FI_LOG_CORE,
-				"read string var %s=<not set>\n", param_name);
-			ret = -FI_ENODATA;
-		}
+	if (strcmp(str_value, "0") == 0 ||
+	    strcasecmp(str_value, "false") == 0 ||
+	    strcasecmp(str_value, "no") == 0 ||
+	    strcasecmp(str_value, "off") == 0) {
+		return 0;
 	}
 
-	return ret;
+	if (strcmp(str_value, "1") == 0 ||
+	    strcasecmp(str_value, "true") == 0 ||
+	    strcasecmp(str_value, "yes") == 0 ||
+	    strcasecmp(str_value, "on") == 0) {
+		return 1;
+	}
+
+	return -1;
 }
-DEFAULT_SYMVER(fi_param_get_str_, fi_param_get_str);
 
 __attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_param_get_int)(struct fi_provider *provider,
-		const char *param_name, int *value)
+int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
+		const char *param_name, void *value)
 {
-	int ret;
+	struct fi_param_entry *param;
 	char *str_value;
+	int ret = FI_SUCCESS;
 
 	if (!provider)
 		provider = &core_prov;
 
-	ret = fi_param_get(provider, param_name, &str_value);
-	if (ret == FI_SUCCESS) {
-		if (str_value) {
-			*value = atoi(str_value);
-			FI_INFO(provider, FI_LOG_CORE,
-				"read int var %s=%d\n", param_name, *value);
-			ret = FI_SUCCESS;
-		} else {
-			FI_INFO(provider, FI_LOG_CORE,
-				"read int var %s=<not set>\n", param_name);
-			ret = -FI_ENODATA;
-		}
+	if (!param_name || !value) {
+		FI_DBG(provider, FI_LOG_CORE,
+			"Failed to read %s variable: provider coding error\n",
+			param_name);
+		return -FI_EINVAL;
 	}
 
-	return ret;
-}
-DEFAULT_SYMVER(fi_param_get_int_, fi_param_get_int);
+	param = fi_find_param(provider, param_name);
+	if (!param)
+		return -FI_ENOENT;
 
-__attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_param_get_long)(struct fi_provider *provider,
-		const char *param_name, long *value)
-{
-	int ret;
-	char *str_value;
-
-	if (!provider)
-		provider = &core_prov;
-
-	ret = fi_param_get(provider, param_name, &str_value);
-	if (ret == FI_SUCCESS) {
-		if (str_value) {
-			*value = strtol(str_value, NULL, 10);
-			FI_INFO(provider, FI_LOG_CORE,
-				"read long var %s=%ld\n", param_name, *value);
-			ret = FI_SUCCESS;
-		} else {
-			FI_INFO(provider, FI_LOG_CORE,
-				"read long var %s=<not set>\n", param_name);
-			ret = -FI_ENODATA;
-		}
+	str_value = getenv(param->env_var_name);
+	if (!str_value) {
+		FI_INFO(provider, FI_LOG_CORE,
+			"variable %s=<not set>\n", param_name);
+		ret = -FI_ENODATA;
+		goto out;
 	}
 
-	return ret;
-}
-DEFAULT_SYMVER(fi_param_get_long_, fi_param_get_long);
-
-__attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_param_get_bool)(struct fi_provider *provider,
-		const char *param_name, int *value)
-{
-	int ret;
-	char *str_value;
-
-	if (!provider)
-		provider = &core_prov;
-
-	ret = fi_param_get(provider, param_name, &str_value);
-	if (ret == FI_SUCCESS) {
-		if (str_value) {
-			if (strcmp(param_name, "0") == 0 ||
-				strcasecmp(param_name, "false") == 0 ||
-				strcasecmp(param_name, "no") == 0 ||
-				strcasecmp(param_name, "off") == 0) {
-				*value = 0;
-				FI_INFO(provider, FI_LOG_CORE,
-					"read boolean var %s=false\n", param_name);
-				ret = FI_SUCCESS;
-			} else if (strcmp(param_name, "1") == 0 ||
-				strcasecmp(param_name, "true") == 0 ||
-				strcasecmp(param_name, "yes") == 0 ||
-				strcasecmp(param_name, "on") == 0) {
-				*value = 1;
-				FI_INFO(provider, FI_LOG_CORE,
-					"read boolean var %s=true\n", param_name);
-				ret = FI_SUCCESS;
-			} else {
-				FI_INFO(provider, FI_LOG_CORE,
-					"read boolean var %s=<unknown> (%s)\n",
-					param_name, str_value);
-				ret = -FI_EINVAL;
-			}
-		} else {
-			FI_INFO(provider, FI_LOG_CORE,
-				"read boolean var %s=<not set>\n", param_name);
-			ret = -FI_ENODATA;
-		}
+	switch (param->type) {
+	default:
+	case FI_PARAM_STRING:
+		* ((char **) value) = str_value;
+		FI_INFO(provider, FI_LOG_CORE,
+			"read string var %s=%s\n", param_name, *(char **) value);
+		break;
+	case FI_PARAM_INT:
+		* ((int *) value) = strtol(str_value, NULL, 0);
+		FI_INFO(provider, FI_LOG_CORE,
+			"read int var %s=%d\n", param_name, *(int *) value);
+		break;
+	case FI_PARAM_BOOL:
+		* ((int *) value) = fi_parse_bool(str_value);
+		FI_INFO(provider, FI_LOG_CORE,
+			"read bool var %s=%d\n", param_name, *(int *) value);
+		if (*(int *) value == -1)
+			ret = -FI_EINVAL;
+		break;
 	}
 
+out:
 	return ret;
 }
-DEFAULT_SYMVER(fi_param_get_bool_, fi_param_get_bool);
+DEFAULT_SYMVER(fi_param_get_, fi_param_get);
+
 
 void fi_param_init(void)
 {

--- a/src/var.c
+++ b/src/var.c
@@ -96,19 +96,18 @@ int DEFAULT_SYMVER_PRE(fi_getparams)(struct fi_param **params, int *count)
 	struct fi_param *vhead = NULL;
 	struct fi_param_entry *param;
 	struct dlist_entry *entry;
-	int ret, len = 0, i;
+	int ret, cnt, i;
 	char *tmp;
 
-	// just get a count
-	for (entry = param_list.next; entry != &param_list;
-	     entry = entry->next, len++)
-		continue;
+	for (entry = param_list.next, cnt = 0; entry != &param_list;
+	     entry = entry->next)
+		cnt++;
 
-	if (len == 0)
+	if (cnt == 0)
 		goto out;
 
 	// last extra entry will be all NULL
-	vhead = calloc(len + 1, sizeof (*vhead));
+	vhead = calloc(cnt + 1, sizeof (*vhead));
 	if (!vhead)
 		return -FI_ENOMEM;
 
@@ -130,7 +129,7 @@ int DEFAULT_SYMVER_PRE(fi_getparams)(struct fi_param **params, int *count)
 	}
 
 out:
-	*count = len;
+	*count = cnt;
 	*params = vhead;
 	return FI_SUCCESS;
 }

--- a/src/var.c
+++ b/src/var.c
@@ -51,6 +51,7 @@ extern struct fi_provider core_prov;
 struct fi_param_entry {
 	const struct fi_provider *provider;
 	char *name;
+	enum fi_param_type type;
 	char *help_string;
 	char *env_var_name;
 	struct dlist_entry entry;
@@ -115,6 +116,7 @@ int DEFAULT_SYMVER_PRE(fi_getparams)(struct fi_param **params, int *count)
 	     entry = entry->next, i++) {
 		param = container_of(entry, struct fi_param_entry, entry);
 		vhead[i].name = strdup(param->env_var_name);
+		vhead[i].type = param->type;
 		vhead[i].help_string = strdup(param->help_string);
 
 		tmp = NULL;
@@ -156,8 +158,9 @@ static void fi_free_param(struct fi_param_entry *param)
 }
 
 __attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_param_register)(const struct fi_provider *provider,
-		const char *param_name, const char *help_string)
+int DEFAULT_SYMVER_PRE(fi_param_define)(const struct fi_provider *provider,
+		const char *param_name, enum fi_param_type type,
+		const char *help_string)
 {
 	int i, ret;
 	struct fi_param_entry *v;
@@ -182,6 +185,7 @@ int DEFAULT_SYMVER_PRE(fi_param_register)(const struct fi_provider *provider,
 
 	v->provider = provider;
 	v->name = strdup(param_name);
+	v->type = type;
 	if (provider != &core_prov) {
 		ret = asprintf(&v->help_string, "%s: %s", provider->name, help_string);
 		if (ret < 0)
@@ -212,7 +216,7 @@ int DEFAULT_SYMVER_PRE(fi_param_register)(const struct fi_provider *provider,
 	FI_INFO(provider, FI_LOG_CORE, "registered var %s\n", param_name);
 	return FI_SUCCESS;
 }
-DEFAULT_SYMVER(fi_param_register_, fi_param_register);
+DEFAULT_SYMVER(fi_param_define_, fi_param_define);
 
 __attribute__((visibility ("default")))
 int DEFAULT_SYMVER_PRE(fi_param_get_str)(struct fi_provider *provider,

--- a/util/info.c
+++ b/util/info.c
@@ -73,7 +73,7 @@ static const char *help_strings[][2] = {
 	{"", ""}
 };
 
-void usage()
+static void usage(void)
 {
 	int i = 0;
 	const struct option *ptr = longopts;
@@ -93,7 +93,7 @@ void usage()
 #define ORCASE(SYM) \
 	do { if (strcmp(#SYM, inputstr) == 0) return SYM; } while (0);
 
-uint64_t str2cap(char *inputstr)
+static uint64_t str2cap(char *inputstr)
 {
 	ORCASE(FI_MSG);
 	ORCASE(FI_RMA);
@@ -128,7 +128,7 @@ uint64_t str2cap(char *inputstr)
 	return 0;
 }
 
-uint64_t str2mode(char *inputstr)
+static uint64_t str2mode(char *inputstr)
 {
 	ORCASE(FI_CONTEXT);
 	ORCASE(FI_LOCAL_MR);
@@ -139,7 +139,7 @@ uint64_t str2mode(char *inputstr)
 	return 0;
 }
 
-enum fi_ep_type str2ep_type(char *inputstr)
+static enum fi_ep_type str2ep_type(char *inputstr)
 {
 	ORCASE(FI_EP_UNSPEC);
 	ORCASE(FI_EP_MSG);
@@ -150,7 +150,7 @@ enum fi_ep_type str2ep_type(char *inputstr)
 	return FI_EP_UNSPEC;
 }
 
-uint32_t str2addr_format(char *inputstr)
+static uint32_t str2addr_format(char *inputstr)
 {
 	ORCASE(FI_FORMAT_UNSPEC);
 	ORCASE(FI_SOCKADDR);
@@ -162,7 +162,7 @@ uint32_t str2addr_format(char *inputstr)
 	return FI_FORMAT_UNSPEC;
 }
 
-uint64_t tokparse(char *caps, uint64_t (*str2flag) (char *inputstr))
+static uint64_t tokparse(char *caps, uint64_t (*str2flag) (char *inputstr))
 {
 	uint64_t flags = 0;
 	char *tok;
@@ -173,7 +173,8 @@ uint64_t tokparse(char *caps, uint64_t (*str2flag) (char *inputstr))
 	return flags;
 }
 
-int print_vars() {
+static int print_vars(void)
+{
 	int ret, count;
 	struct fi_param *params;
 	char delim;
@@ -201,7 +202,8 @@ int print_vars() {
 	return ret;
 }
 
-int print_short_info(struct fi_info *info) {
+static int print_short_info(struct fi_info *info)
+{
 	for (struct fi_info *cur = info; cur; cur = cur->next) {
 		printf("%s: %s\n", cur->fabric_attr->prov_name, cur->fabric_attr->name);
 		printf("    version: %d.%d\n", FI_MAJOR(cur->fabric_attr->prov_version),
@@ -212,7 +214,8 @@ int print_short_info(struct fi_info *info) {
 	return EXIT_SUCCESS;
 }
 
-int print_long_info(struct fi_info *info) {
+static int print_long_info(struct fi_info *info)
+{
 	for (struct fi_info *cur = info; cur; cur = cur->next) {
 		printf("---\n");
 		printf("%s", fi_tostr(cur, FI_TYPE_INFO));

--- a/util/info.c
+++ b/util/info.c
@@ -173,6 +173,20 @@ static uint64_t tokparse(char *caps, uint64_t (*str2flag) (char *inputstr))
 	return flags;
 }
 
+static const char *param_type(enum fi_param_type type)
+{
+	switch (type) {
+	case FI_PARAM_STRING:
+		return "String";
+	case FI_PARAM_INT:
+		return "Integer";
+	case FI_PARAM_BOOL:
+		return "Boolean (0/1, on/off, true/false, yes/no)";
+	default:
+		return "Unknown";
+	}
+}
+
 static int print_vars(void)
 {
 	int ret, count;
@@ -180,19 +194,17 @@ static int print_vars(void)
 	char delim;
 
 	ret = fi_getparams(&params, &count);
-
 	if (ret)
 		return ret;
 
 	for (int i = 0; i < count; ++i) {
+		printf("# %s: %s\n", params[i].name, param_type(params[i].type));
 		printf("# %s\n", params[i].help_string);
 
 		if (params[i].value) {
 			delim = strchr(params[i].value, ' ') ? '"' : '\0';
 			printf("%s=%c%s%c\n", params[i].name, delim,
 				params[i].value, delim);
-		} else {
-			printf("# %s\n", params[i].name);
 		}
 
 		printf("\n");


### PR DESCRIPTION
This series pulls in Patrick's patch that registers the core parameters (e.g. FI_LOG_LEVEL) with the parameter framework.  Additionally:

- Switches to using dlist for a double linked list.  This is in preparation for dynamic removal of parameters.
- Minor cleanups to the source
- Switch socket datagram drop rate from long to int, in order to remove long parameters.
- Changes register call to parameter define.  Includes the data type of the parameter with the call.  This allows fi_info -e to display the type of value that should be used with the parameter.  fi_info output is adjusted to display the parameter name and type first, followed by the help message, then any assigned value.
- Merge all fi_param_get calls into a single function.  Wrappers are provided to handle individual datatypes.

We still need a deregister call, but I think this can be handled internally, without exposing any new APIs.  The framework can 'undefine' all parameters for a provider before closing the provider.  (If this doesn't work, then we may need to expose an fi_param_undef call.)