### PR TITLE
prov/sockets: Improve error reporting when connection fails

### DIFF
--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -99,6 +99,10 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 		conn = sock_ep_lookup_conn(sock_ep);
 	} else {
 		conn = sock_av_lookup_addr(sock_ep, tx_ctx->av, msg->addr);
+		if (!conn) {
+                        SOCK_LOG_ERROR("Address lookup failed\n");
+                        return -errno;
+                }
 	}
 
 	if (!conn)

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -283,7 +283,6 @@ int sock_conn_map_connect(struct sock_ep *ep,
 	return 0;
 err:
 	close(conn_fd);
-	errno = FI_EOTHER;
 	return -errno;
 }
 

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -99,6 +99,10 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		conn = sock_ep_lookup_conn(sock_ep);
 	} else {
 		conn = sock_av_lookup_addr(sock_ep, tx_ctx->av, msg->addr);
+		if (!conn) {
+                        SOCK_LOG_ERROR("Address lookup failed\n");
+                        return -errno;
+                }
 	}
 
 	if (!conn)
@@ -265,6 +269,10 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		conn = sock_ep_lookup_conn(sock_ep);
 	} else {
 		conn = sock_av_lookup_addr(sock_ep, tx_ctx->av, msg->addr);
+		if (!conn) {
+                        SOCK_LOG_ERROR("Address lookup failed\n");
+                        return -errno;
+                }
 	}
 
 	if (!conn)


### PR DESCRIPTION
- Returned missing error code in rma and atomic operation when address lookup fails
- Returned the correct error code when socket connection fails

@sayantansur, @jithinjosepkl can you please review?
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>