### PR TITLE
sockets: optimizations, fix an incorrect env var type

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -620,6 +620,7 @@ struct sock_tx_ctx {
 	struct dlist_entry ep_list;
 
 	struct fi_tx_attr attr;
+	fastlock_t lock;
 };
 
 struct sock_msg_hdr {

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -164,6 +164,8 @@ struct sock_conn {
 	struct ringbuf inbuf;
 	struct ringbuf outbuf;
 	struct sock_ep *ep;
+	fi_addr_t av_index;
+	struct dlist_entry ep_entry;
 };
 
 struct sock_conn_map {
@@ -513,6 +515,8 @@ struct sock_ep {
 	int is_disabled;
 	struct sock_cm_entry cm;
 	struct sock_conn_listener listener;
+	struct dlist_entry conn_list;
+	fastlock_t lock;
 };
 
 struct sock_pep {

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -140,6 +140,14 @@ static int sock_conn_map_insert(struct sock_conn_map *map,
 	map->table[index].sock_fd = conn_fd;
 	map->table[index].ep = ep;
 	sock_comm_buffer_init(&map->table[index]);
+	map->table[index].av_index = (ep->av) ?
+		sock_av_lookup_key(ep->av, index):
+		FI_ADDR_NOTAVAIL;
+
+	fastlock_acquire(&ep->lock);
+	dlist_insert_tail(&map->table[index].ep_entry, &ep->conn_list);
+	fastlock_release(&ep->lock);
+
 	map->used++;
 	sock_pe_signal(ep->domain->pe);
 	return index + 1;

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -97,6 +97,7 @@ static struct sock_tx_ctx *sock_tx_context_alloc(const struct fi_tx_attr *attr,
 	
 	fastlock_init(&tx_ctx->rlock);
 	fastlock_init(&tx_ctx->wlock);
+	fastlock_init(&tx_ctx->lock);
 
 	switch (fclass) {
 	case FI_CLASS_TX_CTX:
@@ -129,6 +130,7 @@ void sock_tx_ctx_free(struct sock_tx_ctx *tx_ctx)
 {
 	fastlock_destroy(&tx_ctx->rlock);
 	fastlock_destroy(&tx_ctx->wlock);
+	fastlock_destroy(&tx_ctx->lock);
 	rbfdfree(&tx_ctx->rbfd);
 	free(tx_ctx);
 }

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -658,6 +658,7 @@ static int sock_ep_close(struct fid *fid)
 				   atoi(sock_ep->listener.service));
 
 	atomic_dec(&sock_ep->domain->ref);
+	fastlock_destroy(&sock_ep->lock);
 	free(sock_ep);
 	return 0;
 }
@@ -1494,6 +1495,8 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 	atomic_initialize(&sock_ep->ref, 0);
 	atomic_initialize(&sock_ep->num_tx_ctx, 0);
 	atomic_initialize(&sock_ep->num_rx_ctx, 0);
+	fastlock_init(&sock_ep->lock);
+	dlist_init(&sock_ep->conn_list);
 
 	if (sock_ep->ep_attr.tx_ctx_cnt == FI_SHARED_CONTEXT)
 		sock_ep->tx_shared = 1;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1077,13 +1077,6 @@ static int sock_pe_process_rx_atomic(struct sock_pe *pe, struct sock_rx_ctx *rx_
 	uint64_t offset, len, entry_len;
 	
 
-	if (pe->pe_atomic){
-		if (pe->pe_atomic != pe_entry)
-			return 0;
-	} else {
-		pe->pe_atomic = pe_entry;
-	}
-
 	len = sizeof(struct sock_msg_hdr);
 	if (sock_pe_recv_field(pe_entry, &pe_entry->pe.rx.rx_op, 
 			       sizeof(struct sock_op), len))
@@ -1147,6 +1140,13 @@ static int sock_pe_process_rx_atomic(struct sock_pe *pe, struct sock_rx_ctx *rx_
 				       entry_len, len))
 			return 0;
 		len += entry_len;
+	}
+
+	if (pe->pe_atomic){
+		if (pe->pe_atomic != pe_entry)
+			return 0;
+	} else {
+		pe->pe_atomic = pe_entry;
 	}
 		
 	offset = 0;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2009,7 +2009,7 @@ static int sock_pe_new_rx_entry(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 	if (ep->ep_type == FI_EP_MSG || !ep->av)
 		pe_entry->addr = FI_ADDR_NOTAVAIL;
 	else
-		pe_entry->addr = sock_av_lookup_key(ep->av, key);
+		pe_entry->addr = conn->av_index;
 
 	if (rx_ctx->ctx.fid.fclass == FI_CLASS_SRX_CTX) 
 		pe_entry->comp = &ep->comp;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2529,7 +2529,7 @@ static void sock_thread_set_affinity(char *s)
 static void sock_pe_set_affinity (void)
 {
 	char *s;
-	fi_param_define(&sock_prov, "pe_affinity", FI_PARAM_INT,
+	fi_param_define(&sock_prov, "pe_affinity", FI_PARAM_STRING,
 			"If specified, bind the progress thread to the indicated range(s) of Linux virtual processor ID(s). "
 			"This option is currently not supported on OS X. Usage: id_start[-id_end[:stride]][,]");
 	if (fi_param_get_str(&sock_prov, "pe_affinity", &s) != FI_SUCCESS)


### PR DESCRIPTION
Avoid reverse lookup for every received message
Avoid polling all connections while checking for incoming
Fix an incorrect var definition type