### PR TITLE
Add quick exit to fi_fini

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -400,6 +400,9 @@ static void __attribute__((destructor)) fi_fini(void)
 {
 	struct fi_prov *prov;
 
+	if (!init)
+		return;
+
 	while (prov_head) {
 		prov = prov_head;
 		prov_head = prov->next;


### PR DESCRIPTION
If the library has never been initialized, it makes little
sense to run the finalize functions.

Signed-off-by: James Swaro <jswaro@cray.com>

@bturrubiates @shefty @hppritcha 

addresses concerns from ofiwg/libfabric#1120