### PR TITLE
RFC: Fix inconsistency between send and recv paths when using FI_MSG_PREFIX.

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -49,7 +49,7 @@ extern "C" {
 
 enum {
 	FI_MAJOR_VERSION	= 1,
-	FI_MINOR_VERSION	= 0,
+	FI_MINOR_VERSION	= 1,
 	FI_PATH_MAX		= 256,
 	FI_NAME_MAX		= 64,
 	FI_VERSION_MAX		= 64
@@ -297,6 +297,7 @@ struct fi_info {
 	uint64_t		caps;
 	uint64_t		mode;
 	uint32_t		addr_format;
+	uint32_t		version;
 	size_t			src_addrlen;
 	size_t			dest_addrlen;
 	void			*src_addr;

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -427,6 +427,13 @@ below.
   provider generated packets that do not contain application data.
   Such received messages will indicate a transfer size of 0 bytes.
 
+  If using API version (1, 0) or older, then the pointer given to all send
+  operations must point to the start of the payload. Send operations in API
+  version (1, 1) or newer expect the buffer pointer to point to the start
+  of the prefix region of the buffer (as opposed to the payload). The
+  receive operations on both version expect a pointer to the start of the
+  prefix region of the buffer.
+
 *FI_ASYNC_IOV*
 : Applications can reference multiple data buffers as part of a single
   transmit operation through the use of IO vectors (SGEs).  Typically,

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -47,7 +47,7 @@
 
 #define USDF_PROV_NAME "usnic"
 #define USDF_MAJOR_VERS 1
-#define USDF_MINOR_VERS 0
+#define USDF_MINOR_VERS 1
 #define USDF_PROV_VERSION FI_VERSION(USDF_MAJOR_VERS, USDF_MINOR_VERS)
 
 extern struct fi_provider usdf_ops;
@@ -278,6 +278,8 @@ struct usdf_ep {
 
 	uint32_t ep_wqe;	/* requested queue sizes */
 	uint32_t ep_rqe;
+
+	uint32_t api_version;
 
 	struct usd_qp_attrs ep_qp_attrs;
 

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -442,6 +442,7 @@ usdf_ep_dgram_open(struct fid_domain *domain, struct fi_info *info,
 	ep->ep_domain = udp;
 	ep->ep_caps = info->caps;
 	ep->ep_mode = info->mode;
+	ep->api_version = info->version;
 	if (info->tx_attr != NULL && info->tx_attr->size != 0) {
 		ep->ep_wqe = info->tx_attr->size;
 	} else {

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -267,6 +267,7 @@ static int usdf_fill_domain_attr_dgram(
 
 static int
 usdf_fill_info_dgram(
+	uint32_t version,
 	struct fi_info *hints,
 	struct sockaddr_in *src,
 	struct sockaddr_in *dest,
@@ -290,6 +291,7 @@ usdf_fill_info_dgram(
 	}
 
 	fi->caps = USDF_DGRAM_CAPS;
+	fi->version = version;
 
 	if (hints != NULL) {
 		fi->mode = hints->mode & USDF_DGRAM_SUPP_MODE;
@@ -433,6 +435,7 @@ fail:
 
 static int
 usdf_fill_info_msg(
+	uint32_t version,
 	struct fi_info *hints,
 	struct sockaddr_in *src,
 	struct sockaddr_in *dest,
@@ -456,6 +459,7 @@ usdf_fill_info_msg(
 	}
 
 	fi->caps = USDF_MSG_CAPS;
+	fi->version = version;
 
 	if (hints != NULL) {
 		fi->mode = hints->mode & USDF_MSG_SUPP_MODE;
@@ -542,6 +546,7 @@ fail:
 
 static int
 usdf_fill_info_rdm(
+	uint32_t version,
 	struct fi_info *hints,
 	struct sockaddr_in *src,
 	struct sockaddr_in *dest,
@@ -565,6 +570,7 @@ usdf_fill_info_rdm(
 	}
 
 	fi->caps = USDF_RDM_CAPS;
+	fi->version = version;
 
 	if (hints != NULL) {
 		fi->mode = hints->mode & USDF_RDM_SUPP_MODE;
@@ -825,15 +831,15 @@ usdf_getinfo(uint32_t version, const char *node, const char *service,
 		}
 
 		if (ep_type == FI_EP_DGRAM || ep_type == FI_EP_UNSPEC) {
-			ret = usdf_fill_info_dgram(hints, src, dest, dap,
-					&fi_first, &fi_last);
+			ret = usdf_fill_info_dgram(version, hints, src, dest,
+					dap, &fi_first, &fi_last);
 			if (ret != 0 && ret != -FI_ENODATA) {
 				goto fail;
 			}
 		}
 
 		if (ep_type == FI_EP_MSG || ep_type == FI_EP_UNSPEC) {
-			ret = usdf_fill_info_msg(hints, src, dest, dap,
+			ret = usdf_fill_info_msg(version, hints, src, dest, dap,
 					&fi_first, &fi_last);
 			if (ret != 0 && ret != -FI_ENODATA) {
 				goto fail;
@@ -841,7 +847,7 @@ usdf_getinfo(uint32_t version, const char *node, const char *service,
 		}
 
 		if (ep_type == FI_EP_RDM || ep_type == FI_EP_UNSPEC) {
-			ret = usdf_fill_info_rdm(hints, src, dest, dap,
+			ret = usdf_fill_info_rdm(version, hints, src, dest, dap,
 					&fi_first, &fi_last);
 			if (ret != 0 && ret != -FI_ENODATA) {
 				goto fail;


### PR DESCRIPTION
This specific PR uses the API version to determine how to treat prefix buffers. I 
still need a better way to get the information into the EP code, but this is open 
for discussion.

This approach maintains binary compatibility and source compatibility.

See commit messages for more information. 

@goodell @shefty @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>