### PR TITLE
Allow fi_getparams to be called before fi_getinfo.

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -60,7 +60,7 @@ struct fi_prov {
 static struct fi_prov *fi_getprov(const char *prov_name);
 
 static struct fi_prov *prov_head, *prov_tail;
-static volatile int init = 0;
+int init = 0;
 static pthread_mutex_t ini_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static struct fi_filter prov_filter;
@@ -339,7 +339,7 @@ libdl_done:
 }
 #endif
 
-static void fi_ini(void)
+void fi_ini(void)
 {
 	char *param_val = NULL;
 

--- a/src/var.c
+++ b/src/var.c
@@ -48,6 +48,9 @@
 /* When given a NULL provider pointer, use core for logging and settings. */
 extern struct fi_provider core_prov;
 
+extern int init;
+extern void fi_ini();
+
 struct fi_param_entry {
 	const struct fi_provider *provider;
 	char *name;
@@ -88,6 +91,9 @@ int DEFAULT_SYMVER_PRE(fi_getparams)(struct fi_param **params, int *count)
 	struct dlist_entry *entry;
 	int cnt, i;
 	char *tmp;
+
+	if (!init)
+		fi_ini();
 
 	for (entry = param_list.next, cnt = 0; entry != &param_list;
 	     entry = entry->next)

--- a/util/info.c
+++ b/util/info.c
@@ -246,9 +246,7 @@ static int run(struct fi_info *hints, char *node, char *port)
 		return ret;
 	}
 
-	if (env)
-		ret = print_vars();
-	else if (verbose)
+	if (verbose)
 		ret = print_long_info(info);
 	else
 		ret = print_short_info(info);
@@ -321,7 +319,13 @@ int main(int argc, char **argv)
 		return EXIT_SUCCESS;
 	}
 
+	if (env) {
+		ret = print_vars();
+		goto out;
+	}
+
 	ret = run(use_hints ? hints : NULL, node, port);
+out:
 	fi_freeinfo(hints);
 	return -ret;
 }


### PR DESCRIPTION
Changed fi_info utility to do this. Note if vars are registered outside of a
provider's INI then they will not be represented here.

Also removed the volatile qualifier on the init var: the pthread mutex will read-barrier this so 
it is not necessary.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>