### PR TITLE
usnic: Check version compatibility in fi_getinfo.

### DIFF
--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -745,6 +745,9 @@ usdf_getinfo(uint32_t version, const char *node, const char *service,
 	src = NULL;
 	dest = NULL;
 
+	if (!FI_VERSION_GE(fi_version(), version))
+		return -FI_ENODATA;
+
 	/*
 	 * Get and cache usNIC device info
 	 */


### PR DESCRIPTION
- Return -FI_ENODATA in fi_getinfo if the requested version is
  unsupported.

@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>