### PR TITLE
Update libfabric to API version 1.1 to match ABI

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -49,7 +49,7 @@ extern "C" {
 
 enum {
 	FI_MAJOR_VERSION	= 1,
-	FI_MINOR_VERSION	= 0,
+	FI_MINOR_VERSION	= 1,
 	FI_PATH_MAX		= 256,
 	FI_NAME_MAX		= 64,
 	FI_VERSION_MAX		= 64

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -61,6 +61,8 @@ enum {
 #define FI_VERSION_GE(v1, v2)   ((FI_MAJOR(v1) > FI_MAJOR(v2)) || \
 				 (FI_MAJOR(v1) == FI_MAJOR(v2) && FI_MINOR(v1) == FI_MINOR(v2)) || \
 				 (FI_MAJOR(v1) == FI_MAJOR(v2) && FI_MINOR(v1) > FI_MINOR(v2)))
+#define FI_VERSION_LT(v1, v2)	((FI_MAJOR(v1) < FI_MAJOR(v2)) || \
+				 (FI_MAJOR(v1) == FI_MAJOR(v2) && FI_MINOR(v1) < FI_MINOR(v2)))
 
 uint32_t fi_version(void);
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -460,7 +460,7 @@ static void psmx_fini(void)
 struct fi_provider psmx_prov = {
 	.name = PSMX_PROV_NAME,
 	.version = FI_VERSION(0, 9),
-	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+	.fi_version = FI_VERSION(1, 1),
 	.getinfo = psmx_getinfo,
 	.fabric = psmx_fabric,
 	.cleanup = psmx_fini

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -567,7 +567,7 @@ static void fi_sockets_fini(void)
 struct fi_provider sock_prov = {
 	.name = sock_prov_name,
 	.version = FI_VERSION(SOCK_MAJOR_VERSION, SOCK_MINOR_VERSION), 
-	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+	.fi_version = FI_VERSION(1, 1),
 	.getinfo = sock_getinfo,
 	.fabric = sock_fabric,
 	.cleanup = fi_sockets_fini

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -493,9 +493,6 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 	char hostname[HOST_NAME_MAX];
 	int ret;
 
-	if (version != FI_VERSION(SOCK_MAJOR_VERSION, SOCK_MINOR_VERSION))
-		return -FI_ENODATA;
-
 	if (!(flags & FI_SOURCE) && hints && hints->src_addr &&
 	    (hints->src_addrlen != sizeof(struct sockaddr_in)))
 		return -FI_ENODATA;

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -1102,7 +1102,7 @@ static void usdf_fini(void)
 struct fi_provider usdf_ops = {
 	.name = USDF_PROV_NAME,
 	.version = USDF_PROV_VERSION,
-	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+	.fi_version = FI_VERSION(1, 1),
 	.getinfo = usdf_getinfo,
 	.fabric = usdf_fabric_open,
 	.cleanup =  usdf_fini

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -77,7 +77,7 @@ static void fi_ibv_fini(void);
 static struct fi_provider fi_ibv_prov = {
 	.name = VERBS_PROV_NAME,
 	.version = VERBS_PROV_VERS,
-	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+	.fi_version = FI_VERSION(1, 1),
 	.getinfo = fi_ibv_getinfo,
 	.fabric = fi_ibv_fabric,
 	.cleanup = fi_ibv_fini

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -465,6 +465,12 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 	if (!init)
 		fi_ini();
 
+	if (FI_VERSION_LT(fi_version(), version)) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Requested version is newer than library\n");
+		return -FI_ENOSYS;
+	}
+
 	*info = tail = NULL;
 	for (prov = prov_head; prov; prov = prov->next) {
 		if (!prov->provider->getinfo)

--- a/util/info.c
+++ b/util/info.c
@@ -240,7 +240,7 @@ static int run(struct fi_info *hints, char *node, char *port)
 	struct fi_info *info;
 	int ret;
 
-	ret = fi_getinfo(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION), node, port, 0, hints, &info);
+	ret = fi_getinfo(FI_VERSION(1, 1), node, port, 0, hints, &info);
 	if (ret) {
 		fprintf(stderr, "fi_getinfo: %d\n", ret);
 		return ret;


### PR DESCRIPTION
Update all providers to use hard-coded version values, so that they don't report versions that they don't support as a result of rebuilding.

Fix version check in sockets provider.

NOTE: Version checking can be added to the framework, with it assuming the responsibility of converting between the version that an application uses, versus the version that a provider uses.  This is not done at the moment, as there's no difference between 1.0 and 1.1 relative to the providers.