### PR TITLE
Misc

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -112,7 +112,7 @@ void fi_log_init(void);
 void fi_log_fini(void);
 void fi_param_init(void);
 void fi_param_fini(void);
-
+void fi_param_undefine(const struct fi_provider *provider);
 
 /* flsll is defined on BSD systems, but is different. */
 static inline int fi_flsll(long long int i)

--- a/include/fi_list.h
+++ b/include/fi_list.h
@@ -38,14 +38,13 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
 
-#include <fi.h>
 #include <rdma/fi_errno.h>
+
+#include "fi.h"
 
 /*
  * Double-linked list

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -96,8 +96,12 @@ int fi_apply_filter(struct fi_filter *filter, const char *name)
 
 static void cleanup_provider(struct fi_provider *provider, void *dlhandle)
 {
-	if (provider && provider->cleanup)
-		provider->cleanup();
+	if (provider) {
+		fi_param_undefine(provider);
+
+		if (provider->cleanup)
+			provider->cleanup();
+	}
 
 #ifdef HAVE_LIBDL
 	if (dlhandle)

--- a/src/var.c
+++ b/src/var.c
@@ -150,6 +150,21 @@ static void fi_free_param(struct fi_param_entry *param)
 	free(param);
 }
 
+void fi_param_undefine(const struct fi_provider *provider)
+{
+	struct fi_param_entry *param;
+	struct dlist_entry *entry;
+
+	for (entry = param_list.next; entry != &param_list; entry = entry->next) {
+		param = container_of(entry, struct fi_param_entry, entry);
+		if (param->provider == provider) {
+			FI_DBG(provider, FI_LOG_CORE, "Removing param: %s\n", param->name);
+			dlist_remove(entry);
+			fi_free_param(param);
+		}
+	}
+}
+
 __attribute__((visibility ("default")))
 int DEFAULT_SYMVER_PRE(fi_param_define)(const struct fi_provider *provider,
 		const char *param_name, enum fi_param_type type,


### PR DESCRIPTION
Add fi_param_undefine call that the framework can use when unloading providers.

No locking should be needed with this scheme.