### PR TITLE
prov/sockets: Check for disconnected sockets

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -158,6 +158,7 @@ struct sock_fabric {
 
 struct sock_conn {
         int sock_fd;
+        int disconnected;
         struct sockaddr_in addr;
         struct sock_pe_entry *rx_pe_entry;
         struct sock_pe_entry *tx_pe_entry;

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -130,7 +130,12 @@ static ssize_t sock_comm_recv_socket(struct sock_conn *conn, void *buf, size_t l
 {
 	ssize_t ret;
 	
-	ret = read(conn->sock_fd, buf, len);
+	ret = recv(conn->sock_fd, buf, len, 0);
+	if (ret == 0) {
+		conn->disconnected = 1;
+		return ret;
+	}
+
 	if (ret < 0) {
 		SOCK_LOG_DBG("read %s\n", strerror(errno));
 		ret = 0;


### PR DESCRIPTION
If a socket is disconnected by the remote peer, select() will
return POLLIN, indicating that reading from the socket will not
block.  A recv() call against the socket will return 0 in this
case.

The progress code currently ignores disconnect, and as a result
will busy spin checking for receive data on the socket.  This
can result in significant delays during shutdown, since the
progress thread never stops executing, holding locks for an
extended period of time.

Add a disconnect state to the sock_conn structure.  When a
socket has been disconnected, mark it as such and skip all
future checks trying to read from it.  This will allow the
progress thread to wait on only those sockets that are still
active.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>
Signed-off-by: Sean Hefty <sean.hefty@intel.com>