### PR TITLE
sockets: coverity fix, optimizations, resource leak fixes

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -536,7 +536,8 @@ struct sock_rx_entry {
 	uint8_t is_claimed;
 	uint8_t is_complete;
 	uint8_t is_tagged;
-	uint8_t reserved[3];
+	uint8_t is_pool_entry;
+	uint8_t reserved[2];
 
 	uint64_t used;
 	uint64_t total_len;
@@ -551,6 +552,8 @@ struct sock_rx_entry {
 	
 	union sock_iov iov[SOCK_EP_MAX_IOV_LIMIT];
 	struct dlist_entry entry;
+	struct slist_entry pool_entry;
+	struct sock_rx_ctx *rx_ctx;
 };
 
 struct sock_rx_ctx {
@@ -587,6 +590,8 @@ struct sock_rx_ctx {
 	fastlock_t lock;
 
 	struct fi_rx_attr attr;
+	struct sock_rx_entry *rx_entry_pool;
+	struct slist pool_list;
 };
 
 struct sock_tx_ctx {

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -768,7 +768,7 @@ struct sock_pe {
 	int num_free_entries;
 	struct sock_pe_entry pe_table[SOCK_PE_MAX_ENTRIES];
 	fastlock_t lock;
-	pthread_mutex_t list_lock;
+	fastlock_t list_lock;
 	int signal_fds[2];
 	uint64_t waittime;
 

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -470,12 +470,12 @@ int sock_conn_listen(struct sock_ep *ep)
 		sprintf(service, "%s", listener->service);
 		if (gethostname(hostname, sizeof hostname) != 0) {
 			SOCK_LOG_DBG("gethostname failed!\n");
-			return -FI_EINVAL;
+			goto err;
 		}
 		ret = getaddrinfo(hostname, service, &ai, &rai);
 		if (ret) {
 			SOCK_LOG_DBG("getaddrinfo failed!\n");
-			return -FI_EINVAL;
+			goto err;
 		}
 		memcpy(ep->src_addr, (struct sockaddr_in *)rai->ai_addr,
 		       sizeof *ep->src_addr);

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -89,6 +89,7 @@ void sock_conn_map_destroy(struct sock_conn_map *cmap)
 
 	for (i = 0; i < cmap->used; i++) {
 		sock_comm_buffer_finalize(&cmap->table[i]);
+		close(cmap->table[i].sock_fd);
 	}
 	free(cmap->table);
 	cmap->table = NULL;

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -85,6 +85,11 @@ static int sock_conn_map_increase(struct sock_conn_map *map, int new_size)
 
 void sock_conn_map_destroy(struct sock_conn_map *cmap)
 {
+	int i;
+
+	for (i = 0; i < cmap->used; i++) {
+		sock_comm_buffer_finalize(&cmap->table[i]);
+	}
 	free(cmap->table);
 	cmap->table = NULL;
 	cmap->used = cmap->size = 0;

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -71,6 +71,7 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr, void *conte
 void sock_rx_ctx_free(struct sock_rx_ctx *rx_ctx)
 {
 	fastlock_destroy(&rx_ctx->lock);
+	free(rx_ctx->rx_entry_pool);
 	free(rx_ctx);
 }
 

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -111,7 +111,9 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 					  msg->msg_iov, msg->iov_count);
 	}
 
+	fastlock_acquire(&rx_ctx->lock);
 	rx_entry = sock_rx_new_entry(rx_ctx);
+	fastlock_release(&rx_ctx->lock);
 	if (!rx_entry)
 		return -FI_ENOMEM;
 
@@ -449,7 +451,9 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 					  msg->msg_iov, msg->iov_count);
 	}
 
+	fastlock_acquire(&rx_ctx->lock);
 	rx_entry = sock_rx_new_entry(rx_ctx);
+	fastlock_release(&rx_ctx->lock);
 	if (!rx_entry)
 		return -FI_ENOMEM;
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1518,8 +1518,8 @@ out:
 	if (!rx_entry->is_buffered &&
 	    (!(rx_entry->flags & FI_MULTI_RECV) ||
 	     (pe_entry->flags & FI_MULTI_RECV))) {
-		sock_rx_release_entry(rx_entry);
 		fastlock_acquire(&rx_ctx->lock);
+		sock_rx_release_entry(rx_entry);
 		rx_ctx->num_left++;
 		fastlock_release(&rx_ctx->lock);
 	}

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2201,34 +2201,34 @@ void sock_pe_signal(struct sock_pe *pe)
 
 void sock_pe_add_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *ctx)
 {
-	pthread_mutex_lock(&pe->list_lock);
+	fastlock_acquire(&pe->list_lock);
 	dlistfd_insert_tail(&ctx->pe_entry, &pe->tx_list);
 	sock_pe_signal(pe);
-	pthread_mutex_unlock(&pe->list_lock);
+	fastlock_release(&pe->list_lock);
 	SOCK_LOG_DBG("TX ctx added to PE\n");
 }
 
 void sock_pe_add_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *ctx)
 {
-	pthread_mutex_lock(&pe->list_lock);
+	fastlock_acquire(&pe->list_lock);
 	dlistfd_insert_tail(&ctx->pe_entry, &pe->rx_list);
 	sock_pe_signal(pe);
-	pthread_mutex_unlock(&pe->list_lock);
+	fastlock_release(&pe->list_lock);
 	SOCK_LOG_DBG("RX ctx added to PE\n");
 }
 
 void sock_pe_remove_tx_ctx(struct sock_tx_ctx *tx_ctx)
 {
-	pthread_mutex_lock(&tx_ctx->domain->pe->list_lock);
+	fastlock_acquire(&tx_ctx->domain->pe->list_lock);
 	dlist_remove(&tx_ctx->pe_entry);
-	pthread_mutex_unlock(&tx_ctx->domain->pe->list_lock);
+	fastlock_release(&tx_ctx->domain->pe->list_lock);
 }
 
 void sock_pe_remove_rx_ctx(struct sock_rx_ctx *rx_ctx)
 {
-	pthread_mutex_lock(&rx_ctx->domain->pe->list_lock);
+	fastlock_acquire(&rx_ctx->domain->pe->list_lock);
 	dlist_remove(&rx_ctx->pe_entry);
-	pthread_mutex_unlock(&rx_ctx->domain->pe->list_lock);
+	fastlock_release(&rx_ctx->domain->pe->list_lock);
 }
 
 static int sock_pe_progress_rx_ep(struct sock_pe *pe, struct sock_ep *ep,
@@ -2416,14 +2416,14 @@ static void sock_pe_poll(struct sock_pe *pe)
 	if (dlistfd_empty(&pe->tx_list) && dlistfd_empty(&pe->rx_list))
 		goto do_wait;
 
-	pthread_mutex_lock(&pe->list_lock);
+	fastlock_acquire(&pe->list_lock);
 	if (!dlistfd_empty(&pe->tx_list)) {
 		for (entry = pe->tx_list.list.next;
 		     entry != &pe->tx_list.list; entry = entry->next) {
 			tx_ctx = container_of(entry, struct sock_tx_ctx, pe_entry);
 			if (!rbfdempty(&tx_ctx->rbfd) ||
 			    !dlist_empty(&tx_ctx->pe_entry_list)) {
-				pthread_mutex_unlock(&pe->list_lock);
+				fastlock_release(&pe->list_lock);
 				return;
 			}
 			FD_SET(tx_ctx->rbfd.fd[RB_READ_FD], &rfds);
@@ -2437,12 +2437,12 @@ static void sock_pe_poll(struct sock_pe *pe)
 			rx_ctx = container_of(entry, struct sock_rx_ctx, pe_entry);
 			if (!dlist_empty(&rx_ctx->rx_buffered_list) ||
 			    !dlist_empty(&rx_ctx->pe_entry_list)) {
-				pthread_mutex_unlock(&pe->list_lock);
+				fastlock_release(&pe->list_lock);
 				return;
 			}
 		}
 	}
-	pthread_mutex_unlock(&pe->list_lock);
+	fastlock_release(&pe->list_lock);
 
 	map = &pe->domain->r_cmap;
 	fastlock_acquire(&map->lock);
@@ -2557,7 +2557,7 @@ static void *sock_pe_progress_thread(void *data)
 		if (pe->domain->progress_mode == FI_PROGRESS_AUTO)
 			sock_pe_poll(pe);
 		
-		pthread_mutex_lock(&pe->list_lock);		
+		fastlock_acquire(&pe->list_lock);		
 		if (!dlistfd_empty(&pe->tx_list)) {
 			for (entry = pe->tx_list.list.next;
 			     entry != &pe->tx_list.list; entry = entry->next) {
@@ -2566,7 +2566,7 @@ static void *sock_pe_progress_thread(void *data)
 				ret = sock_pe_progress_tx_ctx(pe, tx_ctx);
 				if (ret < 0) {
 					SOCK_LOG_ERROR("failed to progress TX\n");
-					pthread_mutex_unlock(&pe->list_lock);
+					fastlock_release(&pe->list_lock);
 					return NULL;
 				}
 			}
@@ -2580,12 +2580,12 @@ static void *sock_pe_progress_thread(void *data)
 				ret = sock_pe_progress_rx_ctx(pe, rx_ctx);
 				if (ret < 0) {
 					SOCK_LOG_ERROR("failed to progress RX\n");
-					pthread_mutex_unlock(&pe->list_lock);
+					fastlock_release(&pe->list_lock);
 					return NULL;
 				}
 			}
 		}
-		pthread_mutex_unlock(&pe->list_lock);
+		fastlock_release(&pe->list_lock);
 	}
 	
 	SOCK_LOG_DBG("Progress thread terminated\n");
@@ -2622,7 +2622,7 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 	dlistfd_head_init(&pe->tx_list);
 	dlistfd_head_init(&pe->rx_list);
 	fastlock_init(&pe->lock);
-	pthread_mutex_init(&pe->list_lock, NULL);
+	fastlock_init(&pe->list_lock);
 	pe->domain = domain;
 
 	if (domain->progress_mode == FI_PROGRESS_AUTO) {
@@ -2662,7 +2662,7 @@ void sock_pe_finalize(struct sock_pe *pe)
 	}
 	
 	fastlock_destroy(&pe->lock);
-	pthread_mutex_destroy(&pe->list_lock);
+	fastlock_destroy(&pe->list_lock);
 	dlistfd_head_free(&pe->tx_list);
 	dlistfd_head_free(&pe->rx_list);
 	free(pe);


### PR DESCRIPTION
- coverity scan fix
- Use fastlock for progress engine list-lock
- Fix resource leak in comm buffer
- Add rx_entry pool

@shefty  - please review