### PR TITLE
Revert "sockets: Use fastlock for progress engine list-lock"

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -774,7 +774,7 @@ struct sock_pe {
 	int num_free_entries;
 	struct sock_pe_entry pe_table[SOCK_PE_MAX_ENTRIES];
 	fastlock_t lock;
-	fastlock_t list_lock;
+	pthread_mutex_t list_lock;
 	int signal_fds[2];
 	uint64_t waittime;
 


### PR DESCRIPTION
This reverts commit a4267476572755e49eb6f1ed4f8dfae9127fa8f7.

The conversion to use fastlock results in 18 of 31 fabtests
failing.  Reverting allows all tests to pass.  There is either
a problem with fastlock, or the code is structured such that
fastlock does not work.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>