### PR TITLE
replace usd_open with usd_open_for_attrs 

### DIFF
--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -680,7 +680,7 @@ usdf_get_devinfo(void)
 	for (d = 0; d < dp->uu_num_devs; ++d) {
 		dep = &dp->uu_info[d];
 
-		ret = usd_open(dp->uu_devs[d].ude_devname, &dep->ue_dev);
+		ret = usd_open_for_attrs(dp->uu_devs[d].ude_devname, &dep->ue_dev);
 		if (ret != 0) {
 			continue;
 		}


### PR DESCRIPTION
usd_open_for_attrs does not allocate PD underneath, so calling it instead of usd_open for fi_getinfo implementation

Signed-off-by: Xuyang Wang <xuywang@cisco.com>