### PR TITLE
man: add prefix region contiguity requirement

### DIFF
--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -429,7 +429,9 @@ below.
 
   The buffer pointer given to all send and receive operations must point
   to the start of the prefix region of the buffer (as opposed to the
-  payload).
+  payload).  For scatter-gather send/recv operations, the prefix buffer
+  must be a contiguous region, though it may or may not be directly
+  adjacent to the payload portion of the buffer.
 
 *FI_ASYNC_IOV*
 : Applications can reference multiple data buffers as part of a single


### PR DESCRIPTION
Without such a requirement, providers would need to introduce additional
branches and possibly memory copies in order to deal with a
noncontiguous prefix region, which is at odds with the motivation for
FI_MSG_PREFIX.  Additionally, such a requirement is not an onerous
restriction on the application.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>