### PR TITLE
usnic: Fix header lengths in prefix mode send path

### DIFF
--- a/prov/usnic/src/usdf_dgram.c
+++ b/prov/usnic/src/usdf_dgram.c
@@ -480,9 +480,11 @@ usdf_dgram_prefix_sendv(struct fid_ep *fep, const struct iovec *iov, void **desc
 	struct iovec send_iov[USDF_DGRAM_MAX_SGE];
 	size_t len;
 	unsigned i;
+	size_t padding;
 
 	ep = ep_ftou(fep);
 	dest = (struct usd_dest *)(uintptr_t) dest_addr;
+	padding = USDF_HDR_BUF_ENTRY - sizeof(struct usd_udp_hdr);
 
 	len = 0;
 	for (i = 0; i < count; i++) {
@@ -493,21 +495,21 @@ usdf_dgram_prefix_sendv(struct fid_ep *fep, const struct iovec *iov, void **desc
 		qp = to_qpi(ep->e.dg.ep_qp);
 		wq = &qp->uq_wq;
 		hdr = (struct usd_udp_hdr *) ((char *) iov[0].iov_base +
-			(USDF_HDR_BUF_ENTRY - sizeof(struct usd_udp_hdr)));
+				padding);
 		memcpy(hdr, &dest->ds_dest.ds_udp.u_hdr, sizeof(*hdr));
 
 		/* adjust lengths and insert source port */
-		hdr->uh_ip.tot_len = htons(len + sizeof(struct usd_udp_hdr) -
-			sizeof(struct ether_header));
-		hdr->uh_udp.len = htons((sizeof(struct usd_udp_hdr) -
-			sizeof(struct ether_header) -
-			sizeof(struct iphdr)) + len);
+		hdr->uh_ip.tot_len = htons(len - padding -
+				sizeof(struct ether_header));
+		hdr->uh_udp.len = htons(len - padding -
+				sizeof(struct ether_header) -
+				sizeof(struct iphdr));
 		hdr->uh_udp.source =
 			qp->uq_attrs.uqa_local_addr.ul_addr.ul_udp.u_addr.sin_port;
 
 		memcpy(send_iov, iov, sizeof(struct iovec) * count);
 		send_iov[0].iov_base = hdr;
-		send_iov[0].iov_len += sizeof(*hdr);
+		send_iov[0].iov_len -= padding;
 
 		last_post = _usd_post_send_iov(wq, send_iov, count, 1);
 		info = &wq->uwq_post_info[last_post];


### PR DESCRIPTION
Update usnic providers handling of prefix mode to comply with send/recv length requirements.

@goodell @jsquyres @shefty 