### PR TITLE
man: remove prefix 8-byte alignment requirement

### DIFF
--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -422,11 +422,10 @@ below.
   Applications that support prefix mode must supply buffer space
   before their own message data.  The size of space that must be
   provided is specified by the msg_prefix_size endpoint attribute.
-  Providers are required to define a msg_prefix_size that is a
-  multiple of 8 bytes.  Additionally, applications may receive
-  provider generated packets that do not contain application data.
-  Such received messages will indicate a transfer size of that is
-  equal to or smaller than msg_prefix_size.
+  Additionally, applications may receive provider generated packets
+  that do not contain application data.  Such received messages will
+  indicate a transfer size of that is equal to or smaller than
+  msg_prefix_size.
 
   The buffer pointer given to all send and receive operations must point
   to the start of the prefix region of the buffer (as opposed to the


### PR DESCRIPTION
This places an unnecessary burden on providers when implementing the RX
path for FI_MSG_PREFIX mode.  For example, the usnic provider uses a
42-byte UDP/IP/Ethernet header for its EP_DGRAM packets, but 42 is not a
multiple of 8 (or 4).  Requiring rounding this prefix size up to 48 (or
even 44) would work, but either wastefully transmits extra bytes or
requires additional lookups and multilevel pointer dereferences on RX to
determine whether the received completion arrived on an RQ that is in
FI_MSG_PREFIX mode.

Presumably the requirement was put in place to make it easier for
applications to align their payload buffers to 8-byte boundaries and
accelerate app-level memory copies?

Signed-off-by: Dave Goodell <dgoodell@cisco.com>