### PR TITLE
prov/sockets: Do not ignore dest_addr in hints

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -512,7 +512,7 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 		node = hostname;
 	}
 
-	if (!node && !service && !(flags & FI_SOURCE)) {
+	if (!node && !service && !(flags & FI_SOURCE) && !hints->dest_addr) {
 		gethostname(hostname, sizeof hostname);
 		node = hostname;
 	}


### PR DESCRIPTION
This PR should fix issue #1148; tested with the libfabric branch of UNH EXS.

Commit cad9e622b3b67d05031e8004e673161685449db6 introduced a regression when the user ran the following sequence of code:

```c
hints->dest_addr = address;
hints->dest_addrlen = address_len;
ret = fi_getinfo(EXS_FI_VERSION, NULL, NULL, 0, &hints, all_info);
```

The dest_addr supplied by the user is ignored and replaced with the address corresponding to the hostname for both source and destination address.  In my cluster setup, the RDMA interfaces use a
different naming scheme than the Ethernet management interfaces, so this causes the sockets provider to use the wrong interface for establishing connections.

This commit fixes the issue by not implicitly using the hostname if the user in fact specified a destination address in hints.

Signed-off-by: Patrick MacArthur <pmacarth@iol.unh.edu>