### PR TITLE
Update to atomic type definitions and configure fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,7 @@ AS_IF([test "$icc_symver_hack"],
 [
 
 AC_TRY_LINK([],
-	[__asm__(".symver main_, main@@ABIVER_1.0");],
+	[__asm__(".symver main_, main@ABIVER_1.0");],
 	[
 		AC_MSG_RESULT(yes)
 		ac_asm_symver_support=1


### PR DESCRIPTION
More formally define the atomic data types, in particular, long double.  Replace the existing floating point data types with size specific types (float32/64/96/128).  The existing enum values are mapped to the sized types.  Document that we have no idea what a float96 or float 128 actually is and that the app must just deal with the insanity.

Also provide a small fix to the configure script to fix a symver test issue.