### PR TITLE
prov/verbs: Set fabric_attr fields on incoming connection request

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -178,7 +178,6 @@ static char def_rx_iov_limit[16] = "4";
 static char def_inject_size[16] = "64";
 
 const struct fi_fabric_attr verbs_fabric_attr = {
-	.name			= VERBS_PROV_NAME,
 	.prov_version		= VERBS_PROV_VERS,
 };
 
@@ -2468,6 +2467,9 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 	info = fi_dupinfo(fi);
 	if (!info)
 		return NULL;
+
+	if (!(info->fabric_attr->prov_name = strdup(VERBS_PROV_NAME)))
+		goto err;
 
 	fi_ibv_update_info(NULL, info);
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -2468,6 +2468,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 	if (!info)
 		return NULL;
 
+	info->fabric_attr->fabric = &fab->fabric_fid;
 	if (!(info->fabric_attr->prov_name = strdup(VERBS_PROV_NAME)))
 		goto err;
 


### PR DESCRIPTION
This pull request contains changes that add a couple of fields to the info structure returned as part of a connection request event that were previously missing.  Without these fields, a fabric object cannot be created/derived from an incoming connection request.

@a-ilango Please review when you get a chance.