### PR TITLE
usnic: Prefix fixes for send path

### DIFF
--- a/prov/usnic/src/usdf_dgram.c
+++ b/prov/usnic/src/usdf_dgram.c
@@ -317,6 +317,13 @@ usdf_dgram_inject(struct fid_ep *fep, const void *buf, size_t len,
 	return 0;
 }
 
+ssize_t usdf_dgram_prefix_inject(struct fid_ep *fep, const void *buf,
+		size_t len, fi_addr_t dest_addr)
+{
+	return usdf_dgram_inject(fep, buf + USDF_HDR_BUF_ENTRY,
+			len - USDF_HDR_BUF_ENTRY, dest_addr);
+}
+
 ssize_t usdf_dgram_rx_size_left(struct fid_ep *fep)
 {
 	struct usdf_ep *ep;

--- a/prov/usnic/src/usdf_dgram.h
+++ b/prov/usnic/src/usdf_dgram.h
@@ -71,6 +71,8 @@ ssize_t usdf_dgram_prefix_sendv(struct fid_ep *fep, const struct iovec *iov,
 	void **desc, size_t count, fi_addr_t dest_addr, void *context);
 ssize_t usdf_dgram_prefix_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	uint64_t flags);
+ssize_t usdf_dgram_prefix_inject(struct fid_ep *ep, const void *buf, size_t len,
+	fi_addr_t dest_addr);
 ssize_t usdf_dgram_prefix_rx_size_left(struct fid_ep *ep);
 ssize_t usdf_dgram_prefix_tx_size_left(struct fid_ep *ep);
 

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -318,7 +318,7 @@ static struct fi_ops_msg usdf_dgram_prefix_ops = {
 	.send = usdf_dgram_prefix_send,
 	.sendv = usdf_dgram_prefix_sendv,
 	.sendmsg = usdf_dgram_prefix_sendmsg,
-	.inject = usdf_dgram_inject,
+	.inject = usdf_dgram_prefix_inject,
 	.senddata = usdf_dgram_senddata,
 	.injectdata = fi_no_msg_injectdata,
 };


### PR DESCRIPTION
This fixes two issues in the send path: sendv didn't properly handle prefix in one path, inject function didn't properly handle prefix at all.

@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>