### PR TITLE
usnic: fix "used uninitialized" warning

### DIFF
--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -203,7 +203,7 @@ usdf_cq_copy_cq_entry(void *dst, struct usd_completion *src,
 		data_entry->buf = 0; /* XXX */
 		data_entry->data = 0;
 
-		usdf_cq_adjust_len(src, &msg_entry->len);
+		usdf_cq_adjust_len(src, &data_entry->len);
 
 		break;
 	default:


### PR DESCRIPTION
This was caught by Coverity but would have also been caught by
`-Wall -Wextra` flags to GCC/Clang.

Fixes CID 101734

Signed-off-by: Dave Goodell <dgoodell@cisco.com>