### PR TITLE
sockets: optimizations, fixes

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -570,6 +570,7 @@ struct sock_rx_ctx {
 	uint16_t buffered_len;
 	uint16_t min_multi_recv;
 	uint16_t num_left;
+	uint8_t is_ctrl_ctx;
 	uint8_t reserved[5];
 
 	uint64_t addr;
@@ -612,6 +613,7 @@ struct sock_tx_ctx {
 
 	uint64_t addr;
 	struct sock_comp comp;
+	struct sock_rx_ctx *rx_ctrl_ctx;
 
 	struct sock_ep *ep;
 	struct sock_av *av;
@@ -985,6 +987,7 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr, void *conte
 void sock_rx_ctx_free(struct sock_rx_ctx *rx_ctx);
 
 struct sock_tx_ctx *sock_tx_ctx_alloc(const struct fi_tx_attr *attr, void *context);
+struct sock_tx_ctx *sock_stx_ctx_alloc(const struct fi_tx_attr *attr, void *context);
 void sock_tx_ctx_free(struct sock_tx_ctx *tx_ctx);
 void sock_tx_ctx_start(struct sock_tx_ctx *tx_ctx);
 void sock_tx_ctx_write(struct sock_tx_ctx *tx_ctx, const void *buf, size_t len);

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -1083,6 +1083,7 @@ ssize_t sock_comm_peek(struct sock_conn *conn, void *buf, size_t len);
 ssize_t sock_comm_discard(struct sock_conn *conn, size_t len);
 ssize_t sock_comm_data_avail(struct sock_conn *conn);
 ssize_t sock_comm_flush(struct sock_conn *conn);
+int sock_comm_tx_done(struct sock_conn *conn);
 
 ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, 
 			uint64_t flags);

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -102,6 +102,11 @@ ssize_t sock_comm_flush(struct sock_conn *conn)
 	return (ret1 > 0) ? ret1 + ret2 : 0;
 }
 
+int sock_comm_tx_done(struct sock_conn *conn)
+{
+	return rbempty(&conn->outbuf);
+}
+
 ssize_t sock_comm_send(struct sock_conn *conn, const void *buf, size_t len)
 {
 	ssize_t ret, used;

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -208,13 +208,11 @@ ssize_t sock_comm_peek(struct sock_conn *conn, void *buf, size_t len)
 
 ssize_t sock_comm_discard(struct sock_conn *conn, size_t len)
 {
-	sock_comm_recv_buffer(conn);
 	return rbdiscard(&conn->inbuf, len);
 }
 
 ssize_t sock_comm_data_avail(struct sock_conn *conn)
 {
-	sock_comm_recv_buffer(conn);
 	return rbused(&conn->inbuf);
 }
 

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -62,7 +62,7 @@ static ssize_t sock_comm_send_socket(struct sock_conn *conn, const void *buf, si
 {
 	ssize_t ret;
 	
-	ret = send(conn->sock_fd, buf, len, 0);
+	ret = write(conn->sock_fd, buf, len);
 	if (ret < 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {
 			ret = 0;

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -61,13 +61,15 @@
 static ssize_t sock_comm_send_socket(struct sock_conn *conn, const void *buf, size_t len)
 {
 	ssize_t ret;
-
-	ret = write(conn->sock_fd, buf, len);
+	
+	ret = send(conn->sock_fd, buf, len, 0);
 	if (ret < 0) {
-		SOCK_LOG_DBG("write %s\n", strerror(errno));
-		ret = 0;
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			ret = 0;
+		} else {
+			SOCK_LOG_DBG("write %s\n", strerror(errno));
+		}
 	}
-
 	SOCK_LOG_DBG("wrote to network: %lu\n", ret);
 	return ret;
 }

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -135,7 +135,11 @@ static ssize_t _sock_cq_write(struct sock_cq *cq, fi_addr_t addr,
 	rbcommit(&cq->addr_rb);
 
 	rbfdwrite(&cq->cq_rbfd, buf, len);
-	rbfdcommit(&cq->cq_rbfd);
+	if (cq->domain->progress_mode == FI_PROGRESS_MANUAL) {
+		rbcommit(&cq->cq_rbfd.rb);
+	} else {
+		rbfdcommit(&cq->cq_rbfd);
+	}
 	ret = len;
 
 	if (cq->signal) 
@@ -227,7 +231,11 @@ static inline void sock_cq_copy_overflow_list(struct sock_cq *cq, size_t count)
 		rbcommit(&cq->addr_rb);
 
 		rbfdwrite(&cq->cq_rbfd, &overflow_entry->cq_entry[0], overflow_entry->len);
-		rbfdcommit(&cq->cq_rbfd);
+		if (cq->domain->progress_mode == FI_PROGRESS_MANUAL) {
+			rbcommit(&cq->cq_rbfd.rb);
+		} else {
+			rbfdcommit(&cq->cq_rbfd);
+		}
 		dlist_remove(&overflow_entry->entry);
 		free(overflow_entry);
 	}

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -148,7 +148,11 @@ void sock_tx_ctx_write(struct sock_tx_ctx *tx_ctx, const void *buf, size_t len)
 
 void sock_tx_ctx_commit(struct sock_tx_ctx *tx_ctx)
 {
-	rbfdcommit(&tx_ctx->rbfd);
+	if (tx_ctx->domain->progress_mode == FI_PROGRESS_MANUAL) {
+		rbcommit(&tx_ctx->rbfd.rb);
+	} else {
+		rbfdcommit(&tx_ctx->rbfd);
+	}
 	fastlock_release(&tx_ctx->wlock);
 }
 

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -71,8 +71,7 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr, void *conte
 void sock_rx_ctx_free(struct sock_rx_ctx *rx_ctx)
 {
 	fastlock_destroy(&rx_ctx->lock);
-	if (rx_ctx->rx_entry_pool)
-		free(rx_ctx->rx_entry_pool);
+	free(rx_ctx->rx_entry_pool);
 	free(rx_ctx);
 }
 

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -71,7 +71,8 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr, void *conte
 void sock_rx_ctx_free(struct sock_rx_ctx *rx_ctx)
 {
 	fastlock_destroy(&rx_ctx->lock);
-	free(rx_ctx->rx_entry_pool);
+	if (rx_ctx->rx_entry_pool)
+		free(rx_ctx->rx_entry_pool);
 	free(rx_ctx);
 }
 
@@ -79,6 +80,7 @@ static struct sock_tx_ctx *sock_tx_context_alloc(const struct fi_tx_attr *attr,
 					     void *context, size_t fclass)
 {
 	struct sock_tx_ctx *tx_ctx;
+	struct fi_rx_attr rx_attr = {0};
 
 	tx_ctx = calloc(sizeof(*tx_ctx), 1);
 	if (!tx_ctx)
@@ -104,16 +106,23 @@ static struct sock_tx_ctx *sock_tx_context_alloc(const struct fi_tx_attr *attr,
 	case FI_CLASS_TX_CTX:
 		tx_ctx->fid.ctx.fid.fclass = FI_CLASS_TX_CTX;
 		tx_ctx->fid.ctx.fid.context = context;
+		tx_ctx->fclass = FI_CLASS_TX_CTX;
 		break;
 	case FI_CLASS_STX_CTX:
 		tx_ctx->fid.stx.fid.fclass = FI_CLASS_STX_CTX;
 		tx_ctx->fid.stx.fid.context = context;
+		tx_ctx->fclass = FI_CLASS_STX_CTX;
 		break;
 	default:
 		goto err;
 	}
 	tx_ctx->attr = *attr;		
 	tx_ctx->attr.op_flags |= FI_TRANSMIT_COMPLETE;
+
+	tx_ctx->rx_ctrl_ctx = sock_rx_ctx_alloc(&rx_attr, NULL);
+	if (!tx_ctx->rx_ctrl_ctx)
+		goto err;
+	tx_ctx->rx_ctrl_ctx->is_ctrl_ctx = 1;
 	return tx_ctx;
 
 err:
@@ -127,12 +136,18 @@ struct sock_tx_ctx *sock_tx_ctx_alloc(const struct fi_tx_attr *attr, void *conte
 	return sock_tx_context_alloc(attr, context, FI_CLASS_TX_CTX);
 }
 
+struct sock_tx_ctx *sock_stx_ctx_alloc(const struct fi_tx_attr *attr, void *context)
+{
+	return sock_tx_context_alloc(attr, context, FI_CLASS_STX_CTX);
+}
+
 void sock_tx_ctx_free(struct sock_tx_ctx *tx_ctx)
 {
 	fastlock_destroy(&tx_ctx->rlock);
 	fastlock_destroy(&tx_ctx->wlock);
 	fastlock_destroy(&tx_ctx->lock);
 	rbfdfree(&tx_ctx->rbfd);
+	sock_rx_ctx_free(tx_ctx->rx_ctrl_ctx);
 	free(tx_ctx);
 }
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1195,13 +1195,11 @@ int sock_stx_ctx(struct fid_domain *domain,
 
 	dom = container_of(domain, struct sock_domain, dom_fid);
 	
-	tx_ctx = sock_tx_ctx_alloc(attr ? attr : &sock_stx_attr, context);
+	tx_ctx = sock_stx_ctx_alloc(attr ? attr : &sock_stx_attr, context);
 	if (!tx_ctx)
 		return -FI_ENOMEM;
 
 	tx_ctx->domain = dom;
-	tx_ctx->fid.stx.fid.fclass = FI_CLASS_STX_CTX;
-
 	tx_ctx->fid.stx.fid.ops = &sock_ctx_ops;
 	tx_ctx->fid.stx.ops = &sock_ep_ops;
 	atomic_inc(&dom->ref);

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -74,10 +74,8 @@ static inline int sock_pe_is_data_msg(int msg_id)
 	case SOCK_OP_ATOMIC:
 		return 1;
 	default:
-		goto out;
+		return 0;
 	}
-out:
-	return 0;
 }
 
 static inline ssize_t sock_pe_send_field(struct sock_pe_entry *pe_entry,


### PR DESCRIPTION
- avoid rbuf signaling in manual-progress mode
- avoid extra recv() call in sock_comm_data_avail and sock_com
- add error checking for sock_comm_send
- mark tx entry as completed only if data is sent out to wire
- add rx-ctrl context for every tx context 
- set pep src address as hostname if user does not input it
- minor cleanups

@shefty, @shantonu - please review.