### PR TITLE
configure: Fix symver format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -164,7 +164,7 @@ AS_IF([test "$icc_symver_hack"],
 [
 
 AC_TRY_LINK([],
-	[__asm__(".symver main_, main@@ABIVER_1.0");],
+	[__asm__(".symver main_, main@ABIVER_1.0");],
 	[
 		AC_MSG_RESULT(yes)
 		ac_asm_symver_support=1


### PR DESCRIPTION
When using the clang/llvm compiler, libfabric fails to build.
The issue is the use of '@@' in the symver check.  Replace
with a single '@'.

Problem reported by Hal Finkel: <hfinkel@anl.gov>

Signed-off-by: Sean Hefty <sean.hefty@intel.com>