### PR TITLE
usnic: usdf_ep_dgram_bind: Update receive side completion handling.

### DIFF
--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -210,6 +210,9 @@ usdf_ep_dgram_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 				return -FI_EINVAL;
 			}
 
+			if (flags & FI_SELECTIVE_COMPLETION)
+				return -FI_EOPNOTSUPP;
+
 			ep->ep_rx_dflt_signal_comp =
 				(flags & FI_SELECTIVE_COMPLETION) ? 0 : 1;
 


### PR DESCRIPTION
The usnic provider does not currently support using
FI_SELECTIVE_COMPLETION on a completion queue bound for receive
operations.

Eventually, this will be fixed by adding FI_SELECTIVE_COMPLETION
support on the recv path, but that will take more time and thought than
expected.

@goodell @jsquyres

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>