### PR TITLE
fi_usnic.7.md: Document receive side completion length generation issue.

### DIFF
--- a/man/fi_usnic.7.md
+++ b/man/fi_usnic.7.md
@@ -62,6 +62,8 @@ low latency and other offload capabilities on Ethernet networks.
     * The tag matching interface is not supported.
     * *FI_MSG_PREFIX* is only supported on *FI_EP_DGRAM* and usage
       is limited to the 1.1 release.
+    * Posting a send operation with a buffer smaller than 18 bytes may
+      result in an incorrect completion length on the receiving end.
   * The usnic libfabric provider supports extensions that provide
     information and functionality beyond the standard libfabric
     interface.  See the "USNIC EXTENSIONS" section, below.


### PR DESCRIPTION
@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>