### PR TITLE
fi.h: don't define MIN, MAX if already defined

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -89,8 +89,19 @@ static inline uint64_t ntohll(uint64_t x) { return x; }
 
 #define sizeof_field(type, field) sizeof(((type *)0)->field)
 
-#define MIN(a, b) ((a) < (b) ? a : b)
-#define MAX(a, b) ((a) > (b) ? a : b)
+#ifndef MIN
+#define MIN(a, b) \
+	({ typeof (a) _a = (a); \
+		typeof (b) _b = (b); \
+		_a < _b ? _a : _b; })
+#endif
+
+#ifndef MAX
+#define MAX(a, b) \
+	({ typeof (a) _a = (a); \
+		typeof (b) _b = (b); \
+		_a > _b ? _a : _b; })
+#endif
 
 /* Restrict to size of struct fi_context */
 struct fi_prov_context {


### PR DESCRIPTION
/usr/include/sys/param.h defines MIN, MAX, and if a provider
includes sys/param.h before fi.h, compile breaks.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>