### PR TITLE
usnic: usdf_pep.c: Update setname and open to allow NULL arguments.

### DIFF
--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -605,7 +605,8 @@ usdf_pep_open(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_EINVAL;
 	}
 
-	if (info->src_addrlen != sizeof(struct sockaddr_in)) {
+	if (info->src_addrlen &&
+			info->src_addrlen != sizeof(struct sockaddr_in)) {
 		USDF_WARN_SYS(EP_CTRL, "unexpected src_addrlen\n");
 		return -FI_EINVAL;
 	}
@@ -651,8 +652,11 @@ usdf_pep_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto fail;
 	}
 
+	/* info->src_addrlen can only be 0 or sizeof(struct sockaddr_in) which
+	 * is the same as sizeof(pep->pep_src_addr).
+	 */
 	memcpy(&pep->pep_src_addr, (struct sockaddr_in *)info->src_addr,
-		sizeof(pep->pep_src_addr));
+		info->src_addrlen);
 
 	/* initialize connreq freelist */
 	ret = pthread_spin_init(&pep->pep_cr_lock, PTHREAD_PROCESS_PRIVATE);


### PR DESCRIPTION
Allow the creation of a passive endpoint with no source address and no
source address length. fi_setname can be used to adjust these after the
endpoint is open.

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>

@goodell @jsquyres 