### PR TITLE
Update usnic_direct to SVN r233646.

### DIFF
--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -499,7 +499,7 @@ usdf_get_devinfo(void)
 	for (d = 0; d < dp->uu_num_devs; ++d) {
 		dep = &dp->uu_info[d];
 
-		ret = usd_open(dp->uu_devs[d].ude_devname, &dep->ue_dev);
+		ret = usd_open_for_attrs(dp->uu_devs[d].ude_devname, &dep->ue_dev);
 		if (ret != 0) {
 			continue;
 		}

--- a/prov/usnic/src/usnic_direct/kcompat.h
+++ b/prov/usnic/src/usnic_direct/kcompat.h
@@ -270,6 +270,8 @@ enum pkt_hash_types {
 #define napi_hash_del(napi) do {} while(0)
 #define napi_hash_add(napi) do {} while(0)
 #define skb_mark_napi_id(skb, napi) do {} while(0)
+#elif (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(6, 6)))
+#define napi_gro_flush(a, b) napi_gro_flush(a)
 #endif /*CONFIG_NET_RX_BUSY_POLL*/
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 00))

--- a/prov/usnic/src/usnic_direct/usd_caps.c
+++ b/prov/usnic/src/usnic_direct/usd_caps.c
@@ -62,26 +62,6 @@ usd_get_cap(
         return 0;
     }
 
-    return dev->ud_caps[cap];
+    return dev->ud_ctx->ucx_caps[cap];
 }
 
-/*
- * go to various places to learn what capabilities we can export
- */
-#if 0
-int
-usd_read_caps(
-    struct usd_device *dev)
-{
-    int ret;
-
-    ret = usd_read_cap_ver(dev, "cq_sharing",
-            &dev->ud_caps[USD_CAP_CQ_SHARING]);
-    if (ret != 0) {
-        return ret;
-    }
-dev->ud_caps[USD_CAP_CQ_SHARING] = 1;
-
-    return 0;
-}
-#endif

--- a/prov/usnic/src/usnic_direct/usd_device.c
+++ b/prov/usnic/src/usnic_direct/usd_device.c
@@ -123,12 +123,11 @@ out:
  * Allocate a context from the driver
  */
 static int
-usd_get_context(
-    struct usd_device *dev)
+usd_open_ibctx(struct usd_context *uctx)
 {
     int ret;
 
-    ret = usd_ib_cmd_get_context(dev);
+    ret = usd_ib_cmd_get_context(uctx);
     return ret;
 }
 
@@ -180,63 +179,101 @@ usd_discover_device_attrs(
     return 0;
 }
 
-/*
- * Close a raw USNIC device
- */
-int
-usd_close(
-    struct usd_device *dev)
+static void
+usd_dev_free(struct usd_device *dev)
 {
-    TAILQ_REMOVE(&usd_device_list, dev, ud_link);
-
-    /* XXX - verify all other resources closed out */
-    if (dev->ud_flags & USD_DEVF_CLOSE_CMD_FD)
-        close(dev->ud_ib_dev_fd);
-    if (dev->ucmd_ib_dev_fd != -1)
-        close(dev->ucmd_ib_dev_fd);
     if (dev->ud_arp_sockfd != -1)
         close(dev->ud_arp_sockfd);
 
+    if (dev->ud_ctx != NULL &&
+            (dev->ud_flags & USD_DEVF_CLOSE_CTX)) {
+        usd_close_context(dev->ud_ctx);
+    }
     free(dev);
+}
+
+/*
+ * Allocate a usd_device without allocating a PD
+ */
+static int
+usd_dev_alloc_init(struct usd_context *context, const char *dev_name, int cmd_fd,
+                    int check_ready, struct usd_device **dev_o)
+{
+    struct usd_device *dev = NULL;
+    int ret;
+
+    dev = calloc(sizeof(*dev), 1);
+    if (dev == NULL) {
+        ret = -errno;
+        goto out;
+    }
+
+    dev->ud_flags = 0;
+    if (context == NULL) {
+        ret = usd_open_context(dev_name, cmd_fd, &dev->ud_ctx);
+        if (ret != 0) {
+            goto out;
+        }
+        dev->ud_flags |= USD_DEVF_CLOSE_CTX;
+    } else {
+        dev->ud_ctx = context;
+    }
+
+    dev->ud_arp_sockfd = -1;
+
+    TAILQ_INIT(&dev->ud_pending_reqs);
+    TAILQ_INIT(&dev->ud_completed_reqs);
+
+    if (context == NULL)
+        ret = usd_discover_device_attrs(dev, dev_name);
+    else
+        ret = usd_discover_device_attrs(dev, context->ucx_ib_dev->id_usnic_name);
+    if (ret != 0)
+        goto out;
+
+    dev->ud_attrs.uda_event_fd = dev->ud_ctx->event_fd;
+    dev->ud_attrs.uda_num_comp_vectors = dev->ud_ctx->num_comp_vectors;
+
+    if (check_ready) {
+        ret = usd_device_ready(dev);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    *dev_o = dev;
+    return 0;
+
+out:
+    if (dev != NULL)
+        usd_dev_free(dev);
+    return ret;
+}
+
+int
+usd_close_context(struct usd_context *ctx)
+{
+    /* XXX - verify all other resources closed out */
+    if (ctx->ucx_flags & USD_CTXF_CLOSE_CMD_FD)
+        close(ctx->ucx_ib_dev_fd);
+    if (ctx->ucmd_ib_dev_fd != -1)
+        close(ctx->ucmd_ib_dev_fd);
+
+    free(ctx);
 
     return 0;
 }
 
-/*
- * Open a raw USNIC device
- */
 int
-usd_open(
-    const char *dev_name,
-    struct usd_device **dev_o)
+usd_open_context(const char *dev_name, int cmd_fd,
+                struct usd_context **ctx_o)
 {
-    return usd_open_with_fd(dev_name, -1, 1, dev_o);
-}
-
-/*
- * Open a raw USNIC device
- */
-int
-usd_open_for_attrs(
-    const char *dev_name,
-    struct usd_device **dev_o)
-{
-    return usd_open_with_fd(dev_name, -1, 0, dev_o);
-}
-
-/*
- * Open a raw USNIC device
- */
-int
-usd_open_with_fd(
-    const char *dev_name,
-    int cmd_fd,
-    int check_ready,
-    struct usd_device **dev_o)
-{
+    struct usd_context *ctx = NULL;
     struct usd_ib_dev *idp;
-    struct usd_device *dev = NULL;
     int ret;
+
+    if (dev_name == NULL)
+        return -EINVAL;
 
     ret = usd_init();
     if (ret != 0) {
@@ -261,31 +298,28 @@ usd_open_with_fd(
     /*
      * Found matching device, open an instance
      */
-    dev = calloc(sizeof(*dev), 1);
-    if (dev == NULL) {
+    ctx = calloc(sizeof(*ctx), 1);
+    if (ctx == NULL) {
         ret = -errno;
         goto out;
     }
-    dev->ud_ib_dev_fd = -1;
-    dev->ucmd_ib_dev_fd = -1;
-    dev->ud_arp_sockfd = -1;
-    dev->ud_flags = 0;
-    TAILQ_INIT(&dev->ud_pending_reqs);
-    TAILQ_INIT(&dev->ud_completed_reqs);
+    ctx->ucx_ib_dev_fd = -1;
+    ctx->ucmd_ib_dev_fd = -1;
+    ctx->ucx_flags = 0;
 
     /* Save pointer to IB device */
-    dev->ud_ib_dev = idp;
+    ctx->ucx_ib_dev = idp;
 
     /* Open the fd we will be using for IB commands */
     if (cmd_fd == -1) {
-        dev->ud_ib_dev_fd = open(idp->id_dev_path, O_RDWR);
-        if (dev->ud_ib_dev_fd == -1) {
+        ctx->ucx_ib_dev_fd = open(idp->id_dev_path, O_RDWR);
+        if (ctx->ucx_ib_dev_fd == -1) {
             ret = -ENODEV;
             goto out;
         }
-        dev->ud_flags |= USD_DEVF_CLOSE_CMD_FD;
+        ctx->ucx_flags |= USD_CTXF_CLOSE_CMD_FD;
     } else {
-        dev->ud_ib_dev_fd = cmd_fd;
+        ctx->ucx_ib_dev_fd = cmd_fd;
     }
 
     /*
@@ -294,28 +328,83 @@ usd_open_with_fd(
      * that ib core does not allow multiple get_context call on one
      * file descriptor.
      */
-    dev->ucmd_ib_dev_fd = open(idp->id_dev_path, O_RDWR | O_CLOEXEC);
-    if (dev->ucmd_ib_dev_fd == -1) {
+    ctx->ucmd_ib_dev_fd = open(idp->id_dev_path, O_RDWR | O_CLOEXEC);
+    if (ctx->ucmd_ib_dev_fd == -1) {
         ret = -ENODEV;
         goto out;
     }
 
     /* allocate a context from driver */
-    ret = usd_get_context(dev);
-    if (ret != 0) {
-        goto out;
-    }
-    ret = usd_ib_cmd_alloc_pd(dev, &dev->ud_pd_handle);
+    ret = usd_open_ibctx(ctx);
     if (ret != 0) {
         goto out;
     }
 
-    ret = usd_discover_device_attrs(dev, dev_name);
-    if (ret != 0)
-        goto out;
+    *ctx_o = ctx;
+    return 0;
 
-    if (check_ready) {
-        ret = usd_device_ready(dev);
+out:
+    if (ctx != NULL)
+        usd_close_context(ctx);
+    return ret;
+}
+
+/*
+ * Close a raw USNIC device
+ */
+int
+usd_close(
+    struct usd_device *dev)
+{
+    TAILQ_REMOVE(&usd_device_list, dev, ud_link);
+    usd_dev_free(dev);
+
+    return 0;
+}
+
+/*
+ * Open a raw USNIC device
+ */
+int
+usd_open(
+    const char *dev_name,
+    struct usd_device **dev_o)
+{
+    return usd_open_with_fd(dev_name, -1, 1, 1, dev_o);
+}
+
+/*
+ * Open a raw USNIC device
+ */
+int
+usd_open_for_attrs(
+    const char *dev_name,
+    struct usd_device **dev_o)
+{
+    return usd_open_with_fd(dev_name, -1, 0, 0, dev_o);
+}
+
+/*
+ * previous generic usd open function, used by libusnic_verbs_d
+ */
+int
+usd_open_with_fd(
+    const char *dev_name,
+    int cmd_fd,
+    int check_ready,
+    int alloc_pd,
+    struct usd_device **dev_o)
+{
+    struct usd_device *dev = NULL;
+    int ret;
+
+    ret = usd_dev_alloc_init(NULL, dev_name, cmd_fd, check_ready, &dev);
+    if (ret != 0) {
+        goto out;
+    }
+
+    if (alloc_pd) {
+        ret = usd_ib_cmd_alloc_pd(dev, &dev->ud_pd_handle);
         if (ret != 0) {
             goto out;
         }
@@ -323,18 +412,44 @@ usd_open_with_fd(
 
     TAILQ_INSERT_TAIL(&usd_device_list, dev, ud_link);
     *dev_o = dev;
-
     return 0;
 
-  out:
-    if (dev != NULL) {
-        if (dev->ud_flags & USD_DEVF_CLOSE_CMD_FD
-            && dev->ud_ib_dev_fd != -1)
-            close(dev->ud_ib_dev_fd);
-        if (dev->ucmd_ib_dev_fd != -1)
-            close(dev->ucmd_ib_dev_fd);
-        free(dev);
+out:
+    if (dev != NULL)
+        usd_dev_free(dev);
+    return ret;
+
+}
+
+/*
+ * Most generic usd device open function
+ */
+int
+usd_open_with_ctx(struct usd_context *context, int alloc_pd, int check_ready,
+                    struct usd_device **dev_o)
+{
+    struct usd_device *dev = NULL;
+    int ret;
+
+    ret = usd_dev_alloc_init(context, NULL, -1, check_ready, &dev);
+    if (ret != 0) {
+        goto out;
     }
+
+    if (alloc_pd) {
+        ret = usd_ib_cmd_alloc_pd(dev, &dev->ud_pd_handle);
+        if (ret != 0) {
+            goto out;
+        }
+    }
+
+    TAILQ_INSERT_TAIL(&usd_device_list, dev, ud_link);
+    *dev_o = dev;
+    return 0;
+
+out:
+    if (dev != NULL)
+        usd_dev_free(dev);
     return ret;
 }
 

--- a/prov/usnic/src/usnic_direct/usd_ib_cmd.c
+++ b/prov/usnic/src/usnic_direct/usd_ib_cmd.c
@@ -60,8 +60,7 @@
 #include "usd_ib_cmd.h"
 
 int
-usd_ib_cmd_get_context(
-    struct usd_device *dev)
+usd_ib_cmd_get_context(struct usd_context *uctx)
 {
     struct usnic_get_context cmd;
     struct usnic_get_context_resp resp;
@@ -99,14 +98,14 @@ usd_ib_cmd_get_context(
     ucp->resp_version = 1;
     ucp->v1.num_caps = USNIC_CAP_CNT;
 
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(uctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }
 
     irp = &resp.ibv_resp;
-    dev->ud_attrs.uda_event_fd = irp->async_fd;
-    dev->ud_attrs.uda_num_comp_vectors = irp->num_comp_vectors;
+    uctx->event_fd = irp->async_fd;
+    uctx->num_comp_vectors = irp->num_comp_vectors;
 
     urp = &resp.usnic_resp;
 
@@ -118,19 +117,19 @@ usd_ib_cmd_get_context(
     if (urp->resp_version == 1) {
         if (urp->num_caps > USNIC_CAP_CQ_SHARING &&
             urp->cap_info[USNIC_CAP_CQ_SHARING] > 0) {
-            dev->ud_caps[USD_CAP_CQ_SHARING] = 1;
+            uctx->ucx_caps[USD_CAP_CQ_SHARING] = 1;
         }
         if (urp->num_caps > USNIC_CAP_MAP_PER_RES &&
             urp->cap_info[USNIC_CAP_MAP_PER_RES] > 0) {
-            dev->ud_caps[USD_CAP_MAP_PER_RES] = 1;
+            uctx->ucx_caps[USD_CAP_MAP_PER_RES] = 1;
         }
         if (urp->num_caps > USNIC_CAP_PIO &&
             urp->cap_info[USNIC_CAP_PIO] > 0) {
-            dev->ud_caps[USD_CAP_PIO] = 1;
+            uctx->ucx_caps[USD_CAP_PIO] = 1;
         }
         if (urp->num_caps > USNIC_CAP_CQ_INTR &&
             urp->cap_info[USNIC_CAP_CQ_INTR] > 0) {
-            dev->ud_caps[USD_CAP_CQ_INTR] = 1;
+            uctx->ucx_caps[USD_CAP_CQ_INTR] = 1;
         }
     }
 
@@ -152,7 +151,7 @@ usd_ib_cmd_devcmd(
     struct usnic_udevcmd_resp udevcmd_resp;
     int n;
 
-    if (dev->ucmd_ib_dev_fd < 0)
+    if (dev->ud_ctx->ucmd_ib_dev_fd < 0)
         return -ENOENT;
 
     /* clear cmd and response */
@@ -185,7 +184,7 @@ usd_ib_cmd_devcmd(
     ucp->v2.usnic_ucmd.outbuf = (uintptr_t) &udevcmd_resp;
     ucp->v2.usnic_ucmd.outlen = (u32)sizeof(udevcmd_resp);
 
-    n = write(dev->ucmd_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucmd_ib_dev_fd, &cmd, sizeof(cmd));
     urp = &resp.usnic_resp;
     /*
      * If returns success, it's an old kernel who does not understand
@@ -196,8 +195,8 @@ usd_ib_cmd_devcmd(
         usd_err(
             "The running usnic_verbs kernel module does not support "
             "encapsulating devcmd through IB GET_CONTEXT command\n");
-        close(dev->ucmd_ib_dev_fd);
-        dev->ucmd_ib_dev_fd = -1;
+        close(dev->ud_ctx->ucmd_ib_dev_fd);
+        dev->ud_ctx->ucmd_ib_dev_fd = -1;
         return -ENOTSUP;
     } else if (errno != ECHILD) {
         return -errno;
@@ -239,7 +238,7 @@ usd_ib_cmd_alloc_pd(
     icp->out_words = sizeof(resp) / 4;
     icp->response = (uintptr_t) & resp;
 
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }
@@ -280,7 +279,7 @@ usd_ib_cmd_reg_mr(
     icp->access_flags = IBV_ACCESS_LOCAL_WRITE;
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return errno;
     }
@@ -313,7 +312,7 @@ usd_ib_cmd_dereg_mr(
     icp->mr_handle = mr->umr_handle;
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }
@@ -328,6 +327,7 @@ int
 usd_ib_cmd_create_cq(
     struct usd_device *dev,
     struct usd_cq_impl *cq,
+    void *ibv_cq,
     int comp_channel,
     int comp_vector)
 {
@@ -346,7 +346,11 @@ usd_ib_cmd_create_cq(
     icp->out_words = sizeof(resp) / 4;
     icp->response = (uintptr_t) & resp;
 
-    icp->user_handle = (uintptr_t) cq;
+    if (ibv_cq == NULL)
+        icp->user_handle = (uintptr_t) cq;
+    else
+        icp->user_handle = (uintptr_t) ibv_cq;  /* Pass real verbs cq pointer to kernel
+                                                 * to make ibv_get_cq_event happy */
     icp->cqe = cq->ucq_num_entries;
     icp->comp_channel = comp_channel;
     icp->comp_vector = comp_vector;
@@ -355,7 +359,7 @@ usd_ib_cmd_create_cq(
     cmd.usnic_cmd.intr_arm_mode = USNIC_CQ_INTR_ARM_MODE_CONTINUOUS;
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }
@@ -389,7 +393,7 @@ usd_ib_cmd_destroy_cq(
     icp->cq_handle = cq->ucq_handle;
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }
@@ -479,7 +483,7 @@ usd_ib_cmd_create_qp(
     ucp->u.cur.resources = (u64)(uintptr_t)resources;
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         ret = -errno;
         goto out;
@@ -508,7 +512,7 @@ usd_ib_cmd_create_qp(
 
     if (urp->cmd_version == ucp->cmd_version) {
         /* got expected version */
-        if (dev->ud_caps[USD_CAP_MAP_PER_RES] > 0) {
+        if (dev->ud_ctx->ucx_caps[USD_CAP_MAP_PER_RES] > 0) {
             for (i = 0; i < MIN(RES_TYPE_MAX, urp->u.cur.num_barres); i++) {
                 enum vnic_res_type type = resources[i].type;
                 if (type < RES_TYPE_MAX) {
@@ -547,7 +551,7 @@ usd_ib_cmd_create_qp(
         /* special case, old kernel that won't tell us about individual barres
          * info but should otherwise work fine */
 
-        if (dev->ud_caps[USD_CAP_MAP_PER_RES] != 0) {
+        if (dev->ud_ctx->ucx_caps[USD_CAP_MAP_PER_RES] != 0) {
             /* should not happen, only the presence of never-released kernel
              * code should cause this case */
             usd_err("USD_CAP_MAP_PER_RES claimed but qp_create cmd_version == 0\n");
@@ -558,6 +562,14 @@ usd_ib_cmd_create_qp(
         usd_err("unexpected cmd_version (%u)\n", urp->cmd_version);
         ret = -ENXIO;
         goto out;
+    }
+
+    /* version 2 and beyond has interrupt support */
+    if (urp->cmd_version > 1) {
+        qp->uq_rq.urq_cq->intr_offset = urp->u.cur.rcq_intr_offset;
+        if (qp->uq_rq.urq_cq != qp->uq_wq.uwq_cq) {
+            qp->uq_wq.uwq_cq->intr_offset = urp->u.cur.wcq_intr_offset;
+        }
     }
 
     free(resources);
@@ -594,7 +606,7 @@ usd_ib_cmd_modify_qp(
     icp->qp_state = state;
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }
@@ -623,7 +635,7 @@ usd_ib_cmd_destroy_qp(
     icp->qp_handle = qp->uq_qp_handle;
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }
@@ -652,7 +664,7 @@ usd_ib_cmd_query_device(
     memset(irp, 0x00, sizeof(*irp));
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }
@@ -683,7 +695,7 @@ usd_ib_cmd_query_port(
     memset(irp, 0x00, sizeof(*irp));
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }
@@ -792,7 +804,7 @@ usd_ib_cmd_create_comp_channel(
     icp->response = (uintptr_t) & resp;
 
     /* Issue command to IB driver */
-    n = write(dev->ud_ib_dev_fd, &cmd, sizeof(cmd));
+    n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
         return -errno;
     }

--- a/prov/usnic/src/usnic_direct/usd_ib_cmd.h
+++ b/prov/usnic/src/usnic_direct/usd_ib_cmd.h
@@ -45,13 +45,13 @@
 
 #include "usd.h"
 
-int usd_ib_cmd_get_context(struct usd_device *dev);
+int usd_ib_cmd_get_context(struct usd_context *uctx);
 int usd_ib_cmd_alloc_pd(struct usd_device *dev, uint32_t * pd_handle_o);
 int usd_ib_cmd_reg_mr(struct usd_device *dev, void *vaddr, size_t length,
                       struct usd_mr *mr);
 int usd_ib_cmd_dereg_mr(struct usd_device *dev, struct usd_mr *mr);
 int usd_ib_cmd_create_cq(struct usd_device *dev, struct usd_cq_impl *cq,
-                         int comp_channel, int comp_vector);
+                        void *ibv_cq, int comp_channel, int comp_vector);
 int usd_ib_cmd_destroy_cq(struct usd_device *dev, struct usd_cq_impl *cq);
 int usd_ib_cmd_create_qp(struct usd_device *dev, struct usd_qp_impl *qp,
                          struct usd_vf_info *vfip);

--- a/prov/usnic/src/usnic_direct/usd_ib_sysfs.c
+++ b/prov/usnic/src/usnic_direct/usd_ib_sysfs.c
@@ -190,7 +190,7 @@ usd_get_mac(
     int fd;
     int n;
 
-    idp = dev->ud_ib_dev;
+    idp = dev->ud_ctx->ucx_ib_dev;
     snprintf(name, sizeof(name), "%s/ports/1/gids/0", idp->id_class_path);
 
     fd = open(name, O_RDONLY);
@@ -237,7 +237,7 @@ usd_get_iface(
     int fd;
     int n;
 
-    idp = dev->ud_ib_dev;
+    idp = dev->ud_ctx->ucx_ib_dev;
     snprintf(name, sizeof(name), "%s/iface", idp->id_class_path);
 
     fd = open(name, O_RDONLY);
@@ -275,7 +275,7 @@ usd_ib_sysfs_get_int(
     int fd;
     int n;
 
-    idp = dev->ud_ib_dev;
+    idp = dev->ud_ctx->ucx_ib_dev;
     snprintf(name, sizeof(name), "%s/%s", idp->id_class_path, entry);
 
     fd = open(name, O_RDONLY);
@@ -350,7 +350,7 @@ usd_get_firmware(
     int fd;
     int n;
 
-    idp = dev->ud_ib_dev;
+    idp = dev->ud_ctx->ucx_ib_dev;
     snprintf(name, sizeof(name), "%s/fw_ver", idp->id_class_path);
 
     fd = open(name, O_RDONLY);

--- a/prov/usnic/src/usnic_direct/usd_mem.c
+++ b/prov/usnic/src/usnic_direct/usd_mem.c
@@ -216,5 +216,5 @@ pci_name(
 
     dev = (struct usd_device *) pdev;
 
-    return dev->ud_ib_dev->id_usnic_name;
+    return dev->ud_ctx->ucx_ib_dev->id_usnic_name;
 }

--- a/prov/usnic/src/usnic_direct/usd_post.c
+++ b/prov/usnic/src/usnic_direct/usd_post.c
@@ -85,10 +85,10 @@ usd_post_recv(
     desc = rq->urq_next_desc;
     index = rq->urq_post_index;
 
-    iovp = recv_list->urd_iov;
     count = 0;
 
     while (recv_list != NULL) {
+        iovp = recv_list->urd_iov;
         rq->urq_context[index] = recv_list->urd_context;
         rq_enet_desc_enc(desc, (dma_addr_t) iovp[0].iov_base,
                          RQ_ENET_TYPE_ONLY_SOP, iovp[0].iov_len);

--- a/prov/usnic/src/usnic_direct/vnic_rq.h
+++ b/prov/usnic/src/usnic_direct/vnic_rq.h
@@ -44,10 +44,6 @@
 #ifndef _VNIC_RQ_H_
 #define _VNIC_RQ_H_
 
-#ifndef ENIC_PMD
-#include <linux/pci.h>
-#endif
-
 #include "vnic_dev.h"
 #include "vnic_cq.h"
 
@@ -123,19 +119,7 @@ struct vnic_rq {
 #endif
 
 #ifdef CONFIG_NET_RX_BUSY_POLL
-#define ENIC_POLL_STATE_IDLE		0
-#define ENIC_POLL_STATE_NAPI		(1 << 0) /* NAPI owns this poll */
-#define ENIC_POLL_STATE_POLL		(1 << 1) /* poll owns this poll */
-#define ENIC_POLL_STATE_NAPI_YIELD	(1 << 2) /* NAPI yielded this poll */
-#define ENIC_POLL_STATE_POLL_YIELD	(1 << 3) /* poll yielded this poll */
-#define ENIC_POLL_YIELD			(ENIC_POLL_STATE_NAPI_YIELD |	\
-					 ENIC_POLL_STATE_POLL_YIELD)
-#define ENIC_POLL_LOCKED		(ENIC_POLL_STATE_NAPI |		\
-					 ENIC_POLL_STATE_POLL)
-#define ENIC_POLL_USER_PEND		(ENIC_POLL_STATE_POLL |		\
-					 ENIC_POLL_STATE_POLL_YIELD)
-	unsigned int bpoll_state;
-	spinlock_t bpoll_lock;
+	atomic_t bpoll_state;
 #endif /*CONFIG_NET_RX_BUSY_POLL*/
 #ifdef ENIC_PMD
 	unsigned int socket_id;
@@ -345,108 +329,4 @@ int vnic_rq_mem_size(struct vnic_rq *rq, unsigned int desc_count,
 	unsigned int desc_size);
 #endif
 
-#ifndef ENIC_PMD
-#ifdef CONFIG_NET_RX_BUSY_POLL
-static inline void enic_busy_poll_init_lock(struct vnic_rq *rq)
-{
-	spin_lock_init(&rq->bpoll_lock);
-	rq->bpoll_state = ENIC_POLL_STATE_IDLE;
-}
-
-static inline bool enic_poll_lock_napi(struct vnic_rq *rq)
-{
-	bool rc = true;
-
-	spin_lock(&rq->bpoll_lock);
-	if (rq->bpoll_state & ENIC_POLL_LOCKED) {
-		WARN_ON(rq->bpoll_state & ENIC_POLL_STATE_NAPI);
-		rq->bpoll_state |= ENIC_POLL_STATE_NAPI_YIELD;
-		rc = false;
-	} else {
-		rq->bpoll_state = ENIC_POLL_STATE_NAPI;
-	}
-	spin_unlock(&rq->bpoll_lock);
-	return rc;
-}
-
-static inline bool enic_poll_unlock_napi(struct vnic_rq *rq)
-{
-	bool rc = false;
-
-	spin_lock(&rq->bpoll_lock);
-	WARN_ON(rq->bpoll_state &
-		(ENIC_POLL_STATE_POLL | ENIC_POLL_STATE_NAPI_YIELD));
-
-	if (rq->bpoll_state & ENIC_POLL_STATE_POLL_YIELD)
-		rc = true;
-	rq->bpoll_state = ENIC_POLL_STATE_IDLE;
-	spin_unlock(&rq->bpoll_lock);
-	return rc;
-}
-
-static inline bool enic_poll_lock_poll(struct vnic_rq *rq)
-{
-	bool rc = true;
-
-	spin_lock_bh(&rq->bpoll_lock);
-	if (rq->bpoll_state & ENIC_POLL_LOCKED) {
-		rq->bpoll_state |= ENIC_POLL_STATE_POLL_YIELD;
-		rc = false;
-	} else {
-		rq->bpoll_state |= ENIC_POLL_STATE_POLL;
-	}
-	spin_unlock_bh(&rq->bpoll_lock);
-	return rc;
-}
-
-static inline bool enic_poll_unlock_poll(struct vnic_rq *rq)
-{
-	bool rc = false;
-
-	spin_lock_bh(&rq->bpoll_lock);
-	WARN_ON(rq->bpoll_state & ENIC_POLL_STATE_NAPI);
-
-	if (rq->bpoll_state & ENIC_POLL_STATE_POLL_YIELD)
-		rc = true;
-	rq->bpoll_state = ENIC_POLL_STATE_IDLE;
-	spin_unlock_bh(&rq->bpoll_lock);
-	return rc;
-}
-
-static inline bool enic_poll_busy_polling(struct vnic_rq *rq)
-{
-	WARN_ON(!(rq->bpoll_state & ENIC_POLL_LOCKED));
-	return rq->bpoll_state & ENIC_POLL_USER_PEND;
-}
-#else
-static inline void enic_busy_poll_init_lock(struct vnic_rq *UNUSED(rq))
-{
-}
-
-static inline bool enic_poll_lock_napi(struct vnic_rq *UNUSED(rq))
-{
-	return true;
-}
-
-static inline bool enic_poll_unlock_napi(struct vnic_rq *UNUSED(rq))
-{
-	return false;
-}
-
-static inline bool enic_poll_lock_poll(struct vnic_rq *UNUSED(rq))
-{
-	return false;
-}
-
-static inline bool enic_poll_unlock_poll(struct vnic_rq *UNUSED(rq))
-{
-	return false;
-}
-
-static inline bool enic_poll_busy_polling(struct vnic_rq *UNUSED(rq))
-{
-	return false;
-}
-#endif /*CONFIG_NET_RX_BUSY_POLL*/
-#endif /* ENIC_PMD */
 #endif /* _VNIC_RQ_H_ */


### PR DESCRIPTION
1. Enable cq completion event in usd.
2. Add APIs to support verbs open_context call on top
3. Call usd_open_for_attribute for fi_info to avoid allocating VF resource

Signed-off-by: Xuyang Wang <xuywang@cisco.com>