### PR TITLE
Update usnic_direct to SVN 236263.

### DIFF
--- a/man/fi_usnic.7.md
+++ b/man/fi_usnic.7.md
@@ -62,8 +62,6 @@ low latency and other offload capabilities on Ethernet networks.
     * The tag matching interface is not supported.
     * *FI_MSG_PREFIX* is only supported on *FI_EP_DGRAM* and usage
       is limited to the 1.1 release.
-    * Posting a send operation with a buffer smaller than 18 bytes may
-      result in an incorrect completion length on the receiving end.
   * The usnic libfabric provider supports extensions that provide
     information and functionality beyond the standard libfabric
     interface.  See the "USNIC EXTENSIONS" section, below.

--- a/prov/usnic/src/usnic_direct/kcompat.h
+++ b/prov/usnic/src/usnic_direct/kcompat.h
@@ -270,7 +270,7 @@ enum pkt_hash_types {
 #define napi_hash_del(napi) do {} while(0)
 #define napi_hash_add(napi) do {} while(0)
 #define skb_mark_napi_id(skb, napi) do {} while(0)
-#elif (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE == RHEL_RELEASE_VERSION(6, 6)))
+#elif (RHEL_RELEASE_CODE && (RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(6, 6)) && (RHEL_RELEASE_CODE < RHEL_RELEASE_VERSION(7, 0)))
 #define napi_gro_flush(a, b) napi_gro_flush(a)
 #endif /*CONFIG_NET_RX_BUSY_POLL*/
 

--- a/prov/usnic/src/usnic_direct/usd_device.c
+++ b/prov/usnic/src/usnic_direct/usd_device.c
@@ -381,7 +381,7 @@ usd_open_for_attrs(
     const char *dev_name,
     struct usd_device **dev_o)
 {
-    return usd_open_with_fd(dev_name, -1, 0, 0, dev_o);
+    return usd_open_with_fd(dev_name, -1, 1, 0, dev_o);
 }
 
 /*


### PR DESCRIPTION
1. CSCus01571: [usnic_direct] improve truncation/corruption logic
1. CSCus01571: Added checking device readyness in usd_open_for_attrs

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
Signed-off-by: Reese Faucette <rfaucett@cisco.com>
Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>
Signed-off-by: Xuyang Wang <xuywang@cisco.com>
Signed-off-by: Dave Goodell <dgoodell@cisco.com>

Need @goodell and @bturrubiates to verify.

Also included an update to fi_usnic.7.md: removed the note about incorrect completion lengths.