### PR TITLE
prov/verbs: Add support for AF_IB addresses.

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -589,14 +589,25 @@ static int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags, struct rdm
 	switch(fi->addr_format) {
 	case FI_SOCKADDR_IN:
 		rai->ai_family = AF_INET;
+		rai->ai_flags |= RAI_FAMILY;
 		break;
 	case FI_SOCKADDR_IN6:
 		rai->ai_family = AF_INET6;
+		rai->ai_flags |= RAI_FAMILY;
 		break;
 	case FI_SOCKADDR_IB:
 		rai->ai_family = AF_IB;
+		rai->ai_flags |= RAI_FAMILY;
 		break;
 	case FI_SOCKADDR:
+		if (fi->src_addrlen) {
+			rai->ai_family = ((struct sockaddr *)fi->src_addr)->sa_family;
+			rai->ai_flags |= RAI_FAMILY;
+		} else if (fi->dest_addrlen) {
+			rai->ai_family = ((struct sockaddr *)fi->dest_addr)->sa_family;
+			rai->ai_flags |= RAI_FAMILY;
+		}
+		break;
 	case FI_FORMAT_UNSPEC:
 		break;
 	default:
@@ -944,16 +955,18 @@ fi_ibv_create_ep(const char *node, const char *service,
 	/* Remove ib_rai entries added by IBACM to prevent wrong
 	 * ib_connect_hdr from being sent in connect request.
 	 * TODO Choose ib_rai if we came here from fi_endpoint */
-	for (rai_current = &_rai; *rai_current;) {
-		struct rdma_addrinfo *rai_next;
-		if ((*rai_current)->ai_family == AF_IB) {
-			rai_next = (*rai_current)->ai_next;
-			(*rai_current)->ai_next = NULL;
-			rdma_freeaddrinfo(*rai_current);
-			*rai_current = rai_next;
-			continue;
+	if (hints->addr_format != FI_SOCKADDR_IB) {
+		for (rai_current = &_rai; *rai_current;) {
+			struct rdma_addrinfo *rai_next;
+			if ((*rai_current)->ai_family == AF_IB) {
+				rai_next = (*rai_current)->ai_next;
+				(*rai_current)->ai_next = NULL;
+				rdma_freeaddrinfo(*rai_current);
+				*rai_current = rai_next;
+				continue;
+			}
+			rai_current = &(*rai_current)->ai_next;
 		}
-		rai_current = &(*rai_current)->ai_next;
 	}
 
 	ret = rdma_create_ep(id, _rai, NULL, NULL);


### PR DESCRIPTION
Allow app to pass AF_IB addresses via fi_getinfo node argument.
The app should set the hints.addr_format to FI_SOCKADDR_IB. Server
should be bound to a specific AF_IB address and can't listen on a
wild card address.

Note:
1. Currently there is an issue with opensm so apps can't pass IB
   addresses yet. ibacm 1.1 is expected to have a workaround fix
   for the opensm issue. Till then, disable ibacm to pass AF_IB
   addresses.
2. Another potential issue with rdma_cm requires the app to
   pass FI_NUMERICHOST flag during fi_getinfo. This might be fixed
   in rdma_cm in the future.

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>