### PR TITLE
fabric.h: convert FI_MAJOR|MINOR_VERSION to be macros

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -47,9 +47,10 @@ extern "C" {
 	((type *) ((char *)ptr - offsetof(type, field)))
 #endif
 
+#define FI_MAJOR_VERSION 1
+#define FI_MINOR_VERSION 1
+
 enum {
-	FI_MAJOR_VERSION	= 1,
-	FI_MINOR_VERSION	= 1,
 	FI_PATH_MAX		= 256,
 	FI_NAME_MAX		= 64,
 	FI_VERSION_MAX		= 64


### PR DESCRIPTION
Per https://gcc.gnu.org/onlinedocs/gcc-2.95.3/cpp_1.html#SEC32, enum values cannot be used in preprocessor comparisons.  Hence, a check like this:

```c
#include <rdma/fabric.h>
#if FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION) < FI_VERSION(1, 1)
#    error your version of libfabric is too old
#endif
```

will always be true, because `FI_MAJOR_VERSION` and `FI_MINOR_VERSION` are enums (and therefore evaluated as 0).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@goodell @shefty please review