### PR TITLE
prov/psm: move processing of triggered ops outside AM handlers

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -274,6 +274,9 @@ struct psmx_fid_domain {
 	struct psmx_req_queue	recv_queue;
 	struct psmx_req_queue	unexp_queue;
 
+	/* triggered operations that are ready to be processed */
+	struct psmx_req_queue	trigger_queue;
+
 	/* certain bits in the tag space can be reserved for non tag-matching
 	 * purpose. The tag-matching functions automatically treat these bits
 	 * as 0. This field is a bit mask, with reserved bits valued as "1".
@@ -481,7 +484,8 @@ struct psmx_trigger {
 			uint64_t	flags;
 		} atomic_compwrite;
 	};
-	struct psmx_trigger *next;
+	struct psmx_trigger *next;	/* used for randomly accessed trigger list */
+	struct slist_entry list_entry;	/* used for ready-to-fire trigger queue */
 };
 
 struct psmx_fid_cntr {
@@ -636,6 +640,8 @@ int	psmx_am_process_send(struct psmx_fid_domain *domain,
 				struct psmx_am_request *req);
 int	psmx_am_process_rma(struct psmx_fid_domain *domain,
 				struct psmx_am_request *req);
+int	psmx_process_trigger(struct psmx_fid_domain *domain,
+				struct psmx_trigger *trigger);
 int	psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
 int	psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,

--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -47,6 +47,7 @@ int psmx_am_progress(struct psmx_fid_domain *domain)
 {
 	struct slist_entry *item;
 	struct psmx_am_request *req;
+	struct psmx_trigger *trigger;
 
 #if PSMX_AM_USE_SEND_QUEUE
 	pthread_mutex_lock(&domain->send_queue.lock);
@@ -76,6 +77,16 @@ int psmx_am_progress(struct psmx_fid_domain *domain)
 		}
 		pthread_mutex_unlock(&domain->rma_queue.lock);
 	}
+
+	pthread_mutex_lock(&domain->trigger_queue.lock);
+	while (!slist_empty(&domain->trigger_queue.list)) {
+		item = slist_remove_head(&domain->trigger_queue.list);
+		trigger = container_of(item, struct psmx_trigger, list_entry);
+		pthread_mutex_unlock(&domain->trigger_queue.lock);
+		psmx_process_trigger(domain, trigger);
+		pthread_mutex_lock(&domain->trigger_queue.lock);
+	}
+	pthread_mutex_unlock(&domain->trigger_queue.lock);
 
 	return 0;
 }
@@ -142,9 +153,11 @@ int psmx_am_init(struct psmx_fid_domain *domain)
 	slist_init(&domain->rma_queue.list);
 	slist_init(&domain->recv_queue.list);
 	slist_init(&domain->unexp_queue.list);
+	slist_init(&domain->trigger_queue.list);
 	pthread_mutex_init(&domain->rma_queue.lock, NULL);
 	pthread_mutex_init(&domain->recv_queue.lock, NULL);
 	pthread_mutex_init(&domain->unexp_queue.lock, NULL);
+	pthread_mutex_init(&domain->trigger_queue.lock, NULL);
 #if PSMX_AM_USE_SEND_QUEUE
 	slist_init(&domain->send_queue.list);
 	pthread_mutex_init(&domain->send_queue.lock, NULL);

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -32,8 +32,133 @@
 
 #include "psmx.h"
 
+int psmx_process_trigger(struct psmx_fid_domain *domain, struct psmx_trigger *trigger)
+{
+	switch (trigger->op) {
+	case PSMX_TRIGGERED_SEND:
+		_psmx_send(trigger->send.ep,
+			   trigger->send.buf,
+			   trigger->send.len,
+			   trigger->send.desc,
+			   trigger->send.dest_addr,
+			   trigger->send.context,
+			   trigger->send.flags);
+		break;
+	case PSMX_TRIGGERED_RECV:
+		_psmx_recv(trigger->recv.ep,
+			   trigger->recv.buf,
+			   trigger->recv.len,
+			   trigger->recv.desc,
+			   trigger->recv.src_addr,
+			   trigger->recv.context,
+			   trigger->recv.flags);
+		break;
+	case PSMX_TRIGGERED_TSEND:
+		_psmx_tagged_send(trigger->tsend.ep,
+				  trigger->tsend.buf,
+				  trigger->tsend.len,
+				  trigger->tsend.desc,
+				  trigger->tsend.dest_addr,
+				  trigger->tsend.tag,
+				  trigger->tsend.context,
+				  trigger->tsend.flags);
+		break;
+	case PSMX_TRIGGERED_TRECV:
+		_psmx_tagged_recv(trigger->trecv.ep,
+				  trigger->trecv.buf,
+				  trigger->trecv.len,
+				  trigger->trecv.desc,
+				  trigger->trecv.src_addr,
+				  trigger->trecv.tag,
+				  trigger->trecv.ignore,
+				  trigger->trecv.context,
+				  trigger->trecv.flags);
+		break;
+	case PSMX_TRIGGERED_WRITE:
+		_psmx_write(trigger->write.ep,
+			    trigger->write.buf,
+			    trigger->write.len,
+			    trigger->write.desc,
+			    trigger->write.dest_addr,
+			    trigger->write.addr,
+			    trigger->write.key,
+			    trigger->write.context,
+			    trigger->write.flags,
+			    trigger->write.data);
+		break;
+
+	case PSMX_TRIGGERED_READ:
+		_psmx_read(trigger->read.ep,
+			   trigger->read.buf,
+			   trigger->read.len,
+			   trigger->read.desc,
+			   trigger->read.src_addr,
+			   trigger->read.addr,
+			   trigger->read.key,
+			   trigger->read.context,
+			   trigger->read.flags);
+		break;
+
+	case PSMX_TRIGGERED_ATOMIC_WRITE:
+		_psmx_atomic_write(trigger->atomic_write.ep,
+				   trigger->atomic_write.buf,
+				   trigger->atomic_write.count,
+				   trigger->atomic_write.desc,
+				   trigger->atomic_write.dest_addr,
+				   trigger->atomic_write.addr,
+				   trigger->atomic_write.key,
+				   trigger->atomic_write.datatype,
+				   trigger->atomic_write.atomic_op,
+				   trigger->atomic_write.context,
+				   trigger->atomic_write.flags);
+		break;
+
+	case PSMX_TRIGGERED_ATOMIC_READWRITE:
+		_psmx_atomic_readwrite(trigger->atomic_readwrite.ep,
+					trigger->atomic_readwrite.buf,
+					trigger->atomic_readwrite.count,
+					trigger->atomic_readwrite.desc,
+					trigger->atomic_readwrite.result,
+					trigger->atomic_readwrite.result_desc,
+					trigger->atomic_readwrite.dest_addr,
+					trigger->atomic_readwrite.addr,
+					trigger->atomic_readwrite.key,
+					trigger->atomic_readwrite.datatype,
+					trigger->atomic_readwrite.atomic_op,
+					trigger->atomic_readwrite.context,
+					trigger->atomic_readwrite.flags);
+		break;
+
+	case PSMX_TRIGGERED_ATOMIC_COMPWRITE:
+		_psmx_atomic_compwrite(trigger->atomic_compwrite.ep,
+					trigger->atomic_compwrite.buf,
+					trigger->atomic_compwrite.count,
+					trigger->atomic_compwrite.desc,
+					trigger->atomic_compwrite.compare,
+					trigger->atomic_compwrite.compare_desc,
+					trigger->atomic_compwrite.result,
+					trigger->atomic_compwrite.result_desc,
+					trigger->atomic_compwrite.dest_addr,
+					trigger->atomic_compwrite.addr,
+					trigger->atomic_compwrite.key,
+					trigger->atomic_compwrite.datatype,
+					trigger->atomic_compwrite.atomic_op,
+					trigger->atomic_compwrite.context,
+					trigger->atomic_compwrite.flags);
+		break;
+	default:
+		FI_INFO(&psmx_prov, FI_LOG_CQ,
+			"%d unsupported op\n", trigger->op);
+		break;
+	}
+
+	free(trigger);
+	return 0;
+}
+
 void psmx_cntr_check_trigger(struct psmx_fid_cntr *cntr)
 {
+	struct psmx_fid_domain *domain = cntr->domain;
 	struct psmx_trigger *trigger;
 
 	if (!cntr->trigger)
@@ -47,125 +172,16 @@ void psmx_cntr_check_trigger(struct psmx_fid_cntr *cntr)
 			break;
 
 		cntr->trigger = trigger->next;
-		switch (trigger->op) {
-		case PSMX_TRIGGERED_SEND:
-			_psmx_send(trigger->send.ep,
-				   trigger->send.buf,
-				   trigger->send.len,
-				   trigger->send.desc,
-				   trigger->send.dest_addr,
-				   trigger->send.context,
-				   trigger->send.flags);
-			break;
-		case PSMX_TRIGGERED_RECV:
-			_psmx_recv(trigger->recv.ep,
-				   trigger->recv.buf,
-				   trigger->recv.len,
-				   trigger->recv.desc,
-				   trigger->recv.src_addr,
-				   trigger->recv.context,
-				   trigger->recv.flags);
-			break;
-		case PSMX_TRIGGERED_TSEND:
-			_psmx_tagged_send(trigger->tsend.ep,
-					  trigger->tsend.buf,
-					  trigger->tsend.len,
-					  trigger->tsend.desc,
-					  trigger->tsend.dest_addr,
-					  trigger->tsend.tag,
-					  trigger->tsend.context,
-					  trigger->tsend.flags);
-			break;
-		case PSMX_TRIGGERED_TRECV:
-			_psmx_tagged_recv(trigger->trecv.ep,
-					  trigger->trecv.buf,
-					  trigger->trecv.len,
-					  trigger->trecv.desc,
-					  trigger->trecv.src_addr,
-					  trigger->trecv.tag,
-					  trigger->trecv.ignore,
-					  trigger->trecv.context,
-					  trigger->trecv.flags);
-			break;
-		case PSMX_TRIGGERED_WRITE:
-			_psmx_write(trigger->write.ep,
-				    trigger->write.buf,
-				    trigger->write.len,
-				    trigger->write.desc,
-				    trigger->write.dest_addr,
-				    trigger->write.addr,
-				    trigger->write.key,
-				    trigger->write.context,
-				    trigger->write.flags,
-				    trigger->write.data);
-			break;
 
-		case PSMX_TRIGGERED_READ:
-			_psmx_read(trigger->read.ep,
-				   trigger->read.buf,
-				   trigger->read.len,
-				   trigger->read.desc,
-				   trigger->read.src_addr,
-				   trigger->read.addr,
-				   trigger->read.key,
-				   trigger->read.context,
-				   trigger->read.flags);
-			break;
-
-		case PSMX_TRIGGERED_ATOMIC_WRITE:
-			_psmx_atomic_write(trigger->atomic_write.ep,
-					   trigger->atomic_write.buf,
-					   trigger->atomic_write.count,
-					   trigger->atomic_write.desc,
-					   trigger->atomic_write.dest_addr,
-					   trigger->atomic_write.addr,
-					   trigger->atomic_write.key,
-					   trigger->atomic_write.datatype,
-					   trigger->atomic_write.atomic_op,
-					   trigger->atomic_write.context,
-					   trigger->atomic_write.flags);
-			break;
-
-		case PSMX_TRIGGERED_ATOMIC_READWRITE:
-			_psmx_atomic_readwrite(trigger->atomic_readwrite.ep,
-						trigger->atomic_readwrite.buf,
-						trigger->atomic_readwrite.count,
-						trigger->atomic_readwrite.desc,
-						trigger->atomic_readwrite.result,
-						trigger->atomic_readwrite.result_desc,
-						trigger->atomic_readwrite.dest_addr,
-						trigger->atomic_readwrite.addr,
-						trigger->atomic_readwrite.key,
-						trigger->atomic_readwrite.datatype,
-						trigger->atomic_readwrite.atomic_op,
-						trigger->atomic_readwrite.context,
-						trigger->atomic_readwrite.flags);
-			break;
-
-		case PSMX_TRIGGERED_ATOMIC_COMPWRITE:
-			_psmx_atomic_compwrite(trigger->atomic_compwrite.ep,
-						trigger->atomic_compwrite.buf,
-						trigger->atomic_compwrite.count,
-						trigger->atomic_compwrite.desc,
-						trigger->atomic_compwrite.compare,
-						trigger->atomic_compwrite.compare_desc,
-						trigger->atomic_compwrite.result,
-						trigger->atomic_compwrite.result_desc,
-						trigger->atomic_compwrite.dest_addr,
-						trigger->atomic_compwrite.addr,
-						trigger->atomic_compwrite.key,
-						trigger->atomic_compwrite.datatype,
-						trigger->atomic_compwrite.atomic_op,
-						trigger->atomic_compwrite.context,
-						trigger->atomic_compwrite.flags);
-			break;
-		default:
-			FI_INFO(&psmx_prov, FI_LOG_CQ,
-				"%d unsupported op\n", trigger->op);
-			break;
+		if (domain->am_initialized) {
+			pthread_mutex_lock(&domain->trigger_queue.lock);
+			slist_insert_tail(&trigger->list_entry, &domain->trigger_queue.list);
+			pthread_mutex_unlock(&domain->trigger_queue.lock);
+		}
+		else {
+			psmx_process_trigger(domain, trigger);
 		}
 
-		free(trigger);
 		trigger = cntr->trigger;
 	}
 


### PR DESCRIPTION
Most PSM functions cannot be called within an AM handler. Trying
to process triggered ops inside an AM handler would lead to dead
lock. Use a queue to hold the ready-to-fire triggered ops so that
they can be processed later.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>