### PR TITLE
spec: Remove BuildRequires dependencies from spec file

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -8,16 +8,6 @@ Url: http://www.github.com/ofiwg/libfabric
 Source: http://www.openfabrics.org/downloads/fabrics/%{name}-%{version}.tar.bz2
 Prefix: ${_prefix}
 
-%if 0%{?configopts:1}
-# skip BuildRequires for custom build
-%else
-%global configopts --enable-sockets --enable-verbs --enable-usnic --enable-psm
-BuildRequires: librdmacm-devel
-BuildRequires: libibverbs-devel
-BuildRequires: libnl-devel
-BuildRequires: infinipath-psm-devel
-%endif
-
 %description
 libfabric provides a user-space API to access high-performance fabric
 services, such as RDMA.


### PR DESCRIPTION
It is extremely unlikely that many users will have a
system with all devices supported by libfabric present.
Avoid build requirements in the spec file.  Instead allow the
configure script to automatically detect what can be built.
This fixes a build error when integrating libfabric with the
OFED build environment.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>