### PR TITLE
Script changes required to run fabtests through Coverity Scan nightly

### DIFF
--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -106,14 +106,18 @@ sub verbose {
         if ($verbose_arg);
 }
 
+sub git_cleanup {
+    verbose("*** Ensuring we have a clean git tree...\n");
+
+    doit(0, "git clean -dfx", "git-clean");
+    doit(0, "git reset --hard HEAD", "git-reset");
+    doit(0, "git pull", "git-pull");
+}
+
 #####################################################################
 
-# Git pull to get the latest; ensure we have a totally clean tree
-verbose("*** Ensuring we have a clean git tree...\n");
 chdir($source_dir_arg);
-doit(0, "git clean -dfx", "git-clean");
-doit(0, "git reset --hard HEAD", "git-reset");
-doit(0, "git pull", "git-pull");
+git_cleanup();
 
 # Get a git describe id (minus the initial 'v' in the tag name, if any)
 my $gd = `git describe --tags --always`;

--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -252,18 +252,22 @@ my $fabtests_version = get_git_version();
 my $rebuilt_fabtests = make_tarball("fabtests", $fabtests_dir_arg,
     $fabtests_version, $installdir);
 
-# Re-generate hashes
-verbose("*** Re-generating md5/sha1sums...\n");
-chdir($download_dir_arg);
-doit(0, "md5sum libfabric*tar* fabtests*tar* > md5sums.txt");
-doit(0, "sha1sum libfabric*tar* fabtests*tar* > sha1sums.txt");
+if ($rebuilt_libfabric || $rebuilt_fabtests) {
+    # Re-generate hashes
+    verbose("*** Re-generating md5/sha1sums...\n");
+    chdir($download_dir_arg);
+    doit(0, "md5sum libfabric*tar* fabtests*tar* > md5sums.txt");
+    doit(0, "sha1sum libfabric*tar* fabtests*tar* > sha1sums.txt");
+}
 
-# Re-write latest.txt
-verbose("*** Re-creating latest.txt...\n");
-unlink("latest.txt");
-open(OUT, ">latest.txt") || die "Can't write to latest.txt";
-print OUT "libfabric-$libfabric_version\n";
-close(OUT);
+if ($rebuilt_libfabric) {
+    # Re-write latest.txt
+    verbose("*** Re-creating latest.txt...\n");
+    unlink("latest.txt");
+    open(OUT, ">latest.txt") || die "Can't write to latest.txt";
+    print OUT "libfabric-$libfabric_version\n";
+    close(OUT);
+}
 
 # Run the coverity script if requested
 if (defined($libfabric_coverity_token_arg) && $rebuilt_libfabric) {

--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -33,7 +33,7 @@ use File::Temp qw/ tempdir /;
 use File::Basename;
 use Getopt::Long;
 
-my $source_dir_arg;
+my $libfabric_dir_arg;
 my $fabtests_dir_arg;
 my $download_dir_arg;
 my $libfabric_coverity_token_arg;
@@ -43,10 +43,10 @@ my $help_arg;
 my $verbose_arg;
 my $debug_arg;
 
-my $ok = Getopt::Long::GetOptions("source-dir=s" => \$source_dir_arg,
+my $ok = Getopt::Long::GetOptions("libfabric-source-dir=s" => \$libfabric_dir_arg,
                                   "fabtests-source-dir=s" => \$fabtests_dir_arg,
                                   "download-dir=s" => \$download_dir_arg,
-                                  "coverity-token=s" => \$libfabric_coverity_token_arg,
+                                  "libfabric-coverity-token=s" => \$libfabric_coverity_token_arg,
                                   "fabtests-coverity-token=s" => \$fabtests_coverity_token_arg,
                                   "logfile-dir=s" => \$logfile_dir_arg,
                                   "verbose" => \$verbose_arg,
@@ -55,18 +55,19 @@ my $ok = Getopt::Long::GetOptions("source-dir=s" => \$source_dir_arg,
                                   );
 
 if ($help_arg || !$ok) {
-    print "$0 --source-dir libfabric_git_tree --download-dir download_tree\n";
+    print "$0 --libfabric-source-dir libfabric_git_tree --fabtests-source-dir fabtests_git_tree --download-dir download_tree\n";
     exit(0);
 }
 
 # Sanity checks
-die "Must specify both --source-dir and --download-dir"
-    if (!defined($source_dir_arg) || $source_dir_arg eq "" ||
+die "Must specify --libfabric-source-dir, --fabtests-source-dir, and --download-dir"
+    if (!defined($libfabric_dir_arg) || $libfabric_dir_arg eq "" ||
+        !defined($fabtests_dir_arg) || $fabtests_dir_arg eq "" ||
         !defined($download_dir_arg) || $download_dir_arg eq "");
-die "$source_dir_arg is not a valid directory"
-    if (! -d $source_dir_arg);
-die "$source_dir_arg is not libfabric git clone"
-    if (! -d "$source_dir_arg/.git" || ! -f "$source_dir_arg/src/fi_tostr.c");
+die "$libfabric_dir_arg is not a valid directory"
+    if (! -d $libfabric_dir_arg);
+die "$libfabric_dir_arg is not libfabric git clone"
+    if (! -d "$libfabric_dir_arg/.git" || ! -f "$libfabric_dir_arg/src/fi_tostr.c");
 die "$download_dir_arg is not a valid directory"
     if (! -d $download_dir_arg);
 
@@ -95,7 +96,7 @@ sub doit {
         # If we die/fail, ensure to a) restore the git tree to a clean
         # state, and b) change out of the temp tree so that it can be
         # removed upon exit.
-        chdir($source_dir_arg);
+        chdir($libfabric_dir_arg);
         system("git clean -dfx");
         system("git reset --hard HEAD");
         chdir("/");
@@ -238,10 +239,10 @@ sub submit_to_coverity {
 my $installdir = tempdir(CLEANUP => 1);
 
 verbose("*** Building libfabric...\n");
-chdir($source_dir_arg);
+chdir($libfabric_dir_arg);
 git_cleanup();
 my $libfabric_version = get_git_version();
-my $rebuilt_libfabric = make_tarball("libfabric", $source_dir_arg,
+my $rebuilt_libfabric = make_tarball("libfabric", $libfabric_dir_arg,
     $libfabric_version, $installdir);
 
 verbose("\n\n*** Building fabtests...\n");

--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -114,16 +114,22 @@ sub git_cleanup {
     doit(0, "git pull", "git-pull");
 }
 
+sub get_git_version {
+    # Get a git describe id (minus the initial 'v' in the tag name, if any)
+    my $version = `git describe --tags --always`;
+    chomp($version);
+
+    verbose("*** Git describe: $version\n");
+    $version =~ s/^v//;
+    $version =~ y/-/./;
+    return $version;
+}
+
 #####################################################################
 
 chdir($source_dir_arg);
 git_cleanup();
-
-# Get a git describe id (minus the initial 'v' in the tag name, if any)
-my $gd = `git describe --tags --always`;
-chomp($gd);
-$gd =~ s/^v//;
-verbose("*** Git describe: $gd\n");
+my $version = get_git_version();
 
 # Read in configure.ac
 verbose("*** Reading version number from configure.ac...\n");
@@ -137,8 +143,6 @@ close(IN);
 $config =~ m/AC_INIT\(\[libfabric\], \[(.+?)\]/;
 my $orig_version = $1;
 verbose("*** Replacing configure.ac version: $orig_version\n");
-my $version = $gd;
-$version =~ y/-/./;
 verbose("*** Nightly tarball version: $version\n");
 
 # Is there already a tarball of this version in the download


### PR DESCRIPTION
@jsquyres Please review when you get a chance.  Not super urgent---the fabtests Coverity project has been created but is still pending approval.  So you should probably wait to merge this patch set until the project is approved.  I have tested the script using the latest fabtests master on flatbed and it successfully uploaded the scan results for fabtests, but they are inaccessible until the project is approved.