### PR TITLE
prov/psm: fix the return value of fi_cq_readerr

### DIFF
--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -589,10 +589,10 @@ static ssize_t psmx_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 		memcpy(buf, &cq_priv->pending_error->cqe, sizeof *buf);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
-		return sizeof *buf;
+		return 1;
 	}
 
-	return 0;
+	return -FI_EAGAIN;
 }
 
 static ssize_t psmx_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,


### PR DESCRIPTION
Return 1 on success and -FI_EAGAIN on empty

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>