### PR TITLE
prov/psm: call AM progress function only when AM is used

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -668,7 +668,8 @@ static inline void psmx_progress(struct psmx_fid_domain *domain)
 {
 	if (domain) {
 		psmx_cq_poll_mq(NULL, domain, NULL, 0, NULL);
-		psmx_am_progress(domain);
+		if (domain->am_initialized)
+			psmx_am_progress(domain);
 	}
 }
 

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -531,7 +531,8 @@ static ssize_t psmx_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 		if (ret > 0)
 			return ret;
 
-		psmx_am_progress(cq_priv->domain);
+		if (cq_priv->domain->am_initialized)
+			psmx_am_progress(cq_priv->domain);
 	}
 
 	if (cq_priv->pending_error)


### PR DESCRIPTION
Reduce the polling overhead by a small but visible amount when AM
is not used at all.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>