### PR TITLE
prov/psm: eliminate some unnecessary mutex lock/unlock calls

### DIFF
--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -50,23 +50,25 @@ int psmx_am_progress(struct psmx_fid_domain *domain)
 	struct psmx_trigger *trigger;
 
 #if PSMX_AM_USE_SEND_QUEUE
-	pthread_mutex_lock(&domain->send_queue.lock);
-	while (!slist_empty(&domain->send_queue.list)) {
-		item = slist_remove_head(&domain->send_queue.list);
-		req = container_of(item, struct psmx_am_request, list_entry);
-		if (req->state == PSMX_AM_STATE_DONE) {
-			free(req);
+	if (!slist_empty(&domain->send_queue.list)) {
+		pthread_mutex_lock(&domain->send_queue.lock);
+		while (!slist_empty(&domain->send_queue.list)) {
+			item = slist_remove_head(&domain->send_queue.list);
+			req = container_of(item, struct psmx_am_request, list_entry);
+			if (req->state == PSMX_AM_STATE_DONE) {
+				free(req);
+			}
+			else {
+				pthread_mutex_unlock(&domain->send_queue.lock);
+				psmx_am_process_send(domain, req);
+				pthread_mutex_lock(&domain->send_queue.lock);
+			}
 		}
-		else {
-			pthread_mutex_unlock(&domain->send_queue.lock);
-			psmx_am_process_send(domain, req);
-			pthread_mutex_lock(&domain->send_queue.lock);
-		}
+		pthread_mutex_unlock(&domain->send_queue.lock);
 	}
-	pthread_mutex_unlock(&domain->send_queue.lock);
 #endif
 
-	if (psmx_env.tagged_rma) {
+	if (psmx_env.tagged_rma && !slist_empty(&domain->rma_queue.list)) {
 		pthread_mutex_lock(&domain->rma_queue.lock);
 		while (!slist_empty(&domain->rma_queue.list)) {
 			item = slist_remove_head(&domain->rma_queue.list);
@@ -78,15 +80,17 @@ int psmx_am_progress(struct psmx_fid_domain *domain)
 		pthread_mutex_unlock(&domain->rma_queue.lock);
 	}
 
-	pthread_mutex_lock(&domain->trigger_queue.lock);
-	while (!slist_empty(&domain->trigger_queue.list)) {
-		item = slist_remove_head(&domain->trigger_queue.list);
-		trigger = container_of(item, struct psmx_trigger, list_entry);
-		pthread_mutex_unlock(&domain->trigger_queue.lock);
-		psmx_process_trigger(domain, trigger);
+	if (!slist_empty(&domain->trigger_queue.list)) {
 		pthread_mutex_lock(&domain->trigger_queue.lock);
+		while (!slist_empty(&domain->trigger_queue.list)) {
+			item = slist_remove_head(&domain->trigger_queue.list);
+			trigger = container_of(item, struct psmx_trigger, list_entry);
+			pthread_mutex_unlock(&domain->trigger_queue.lock);
+			psmx_process_trigger(domain, trigger);
+			pthread_mutex_lock(&domain->trigger_queue.lock);
+		}
+		pthread_mutex_unlock(&domain->trigger_queue.lock);
 	}
-	pthread_mutex_unlock(&domain->trigger_queue.lock);
 
 	return 0;
 }


### PR DESCRIPTION
Mutexes are used to protect a few delayed request queues. The queues
are processed in the AM progress function. There is no need to lock
and unlock a mutex when the queue protected by the mutex is empty.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>