### PR TITLE
cron-run-all-md2nroff: ensure the logfile dir is created

### DIFF
--- a/config/cron-run-all-md2nroff.pl
+++ b/config/cron-run-all-md2nroff.pl
@@ -89,7 +89,11 @@ $logfile_dir =
     sprintf("%s/cron-run-all-md2nroff-logs-%04d-%02d-%02d-%02d%02d",
             $logfile_dir_arg, $year + 1900, $mon + 1, $mday,
             $hour, $min);
-system("mkdir -p $logfile_dir");
+my $rc = system("mkdir $logfile_dir");
+if ($rc != 0 || ! -d $logfile_dir || ! -w $logfile_dir) {
+    chdir("/");
+    die "mkdir of $logfile_dir failed, or can't write to it";
+}
 
 # First, git clone the source branch of the repo
 verbose("*** Cloning repo: $repo_arg / $source_branch_arg...\n");


### PR DESCRIPTION
Fix minor problem identified by Florian Weimer (@fweimer).

Fixes #1210.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>