### PR TITLE
prov/psm: detect MPI runs and turns off name server automatically

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -46,6 +46,9 @@ struct psmx_env psmx_env = {
 
 static void psmx_init_env(void)
 {
+	if (getenv("OMPI_COMM_WORLD_RANK") || getenv("PMI_RANK"))
+		psmx_env.name_server = 0;
+
 	fi_param_get_bool(&psmx_prov, "name_server", &psmx_env.name_server);
 	fi_param_get_bool(&psmx_prov, "am_msg", &psmx_env.am_msg);
 	fi_param_get_bool(&psmx_prov, "tagged_rma", &psmx_env.tagged_rma);


### PR DESCRIPTION
The name server is for simple client-server style runs such as
fabtests. It's useless for MPI applications where a process manager
handles the name resolution and address exchange. This patch detects
MPI runs by checking exported environment variables and turns off
the name server accordingly.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>