### PR TITLE
prov/verbs: Delete ib_rai from the list only if caller requested rai

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -970,10 +970,11 @@ fi_ibv_create_ep(const char *node, const char *service,
 		goto out;
 	}
 
-	/* Remove ib_rai entries added by IBACM to prevent wrong
-	 * ib_connect_hdr from being sent in connect request.
-	 * TODO Choose ib_rai if we came here from fi_endpoint */
-	if (hints && hints->addr_format != FI_SOCKADDR_IB) {
+	/*
+	 * If caller requested rai, remove ib_rai entries added by IBACM to
+	 * prevent wrong ib_connect_hdr from being sent in connect request.
+	 */
+	if (rai && hints && (hints->addr_format != FI_SOCKADDR_IB)) {
 		for (rai_current = &_rai; *rai_current;) {
 			struct rdma_addrinfo *rai_next;
 			if ((*rai_current)->ai_family == AF_IB) {


### PR DESCRIPTION
Delete ib_rai from the returned list of rai only if the caller of
fi_ibv_create_ep requested rai to be returned.

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>