### PR TITLE
prov/sockets: Used strdup instead of calloc+stcpy, added length check

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -563,12 +563,11 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		_av->attr.count * sizeof(struct sock_av_addr);
 	
 	if (attr->name) {
-		_av->name = calloc(1, FI_NAME_MAX);
+		_av->name = strdup(attr->name);
 		if(!_av->name) {
 			ret = -FI_ENOMEM;
 			goto err2;
 		}
-		strcpy(_av->name, attr->name);
 		if (!(attr->flags & FI_READ))
 			flags |= O_CREAT;
 		


### PR DESCRIPTION
Minor fix in sock_av_open
- Replaced calloc+strcpy with strdup

Fixes #1207 

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>