### PR TITLE
prov/sockets: Check hints for NULL before dereferencing.

### DIFF
--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -227,7 +227,7 @@ int sock_dgram_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 
 	(*info)->caps = SOCK_EP_DGRAM_CAP |
                        (*info)->rx_attr->caps | (*info)->tx_attr->caps;
-        if (hints->caps)
+        if (hints && hints->caps)
                 (*info)->caps = SOCK_EP_DGRAM_SEC_CAP | hints->caps;
 
 	return 0;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -229,7 +229,7 @@ int sock_msg_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 
 	(*info)->caps = SOCK_EP_MSG_CAP |
                        (*info)->rx_attr->caps | (*info)->tx_attr->caps;
-        if (hints->caps)
+        if (hints && hints->caps)
                 (*info)->caps = SOCK_EP_MSG_SEC_CAP | hints->caps;
 
 	return 0;

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -272,7 +272,7 @@ int sock_rdm_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 
 	(*info)->caps = SOCK_EP_RDM_CAP |
 			(*info)->rx_attr->caps | (*info)->tx_attr->caps;
-	if (hints->caps)
+	if (hints && hints->caps)
 		(*info)->caps = SOCK_EP_RDM_SEC_CAP | hints->caps;
 
 	return 0;


### PR DESCRIPTION
Fixes SEGV when no options are given to fi_info.

@shefty @shantonu @goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>