### PR TITLE
nightly tarball: update fabtests project name

### DIFF
--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -276,7 +276,7 @@ if (defined($libfabric_coverity_token_arg) && $rebuilt_libfabric) {
             $libfabric_coverity_token_arg);
 }
 if (defined($fabtests_coverity_token_arg) && $rebuilt_fabtests) {
-    submit_to_coverity("ofiwg-fabtests", $fabtests_version,
+    submit_to_coverity("ofiwg%2Ffabtests", $fabtests_version,
             "CPPFLAGS=-I$installdir/include LDFLAGS=-L$installdir/lib",
             $fabtests_coverity_token_arg);
 }


### PR DESCRIPTION
The Coverity ofiwg fabtests project was linked to its github project, which slightly changed its official Coverity project name.

This commit updates the project name so that Coverity downloads and uploads will be linked to the correct authentication token.