### PR TITLE
usnic: Distinguish between a full queue and an empty queue.

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -381,11 +381,19 @@ struct usdf_cq {
 			struct usdf_cq_soft_entry *cq_end;
 			struct usdf_cq_soft_entry *cq_head;
 			struct usdf_cq_soft_entry *cq_tail;
+			/* Last operation used to distinguish full vs empty. */
+			uint8_t cq_last_op;
 			TAILQ_HEAD(,usdf_cq_hard) cq_list;
 		} soft;
 	} c;
 	struct usd_completion cq_comp;
 };
+
+enum {
+	USDF_SOFT_CQ_READ,
+	USDF_SOFT_CQ_WRITE
+};
+
 #define cq_ftou(FCQ) container_of(FCQ, struct usdf_cq, cq_fid)
 #define cq_fidtou(FID) container_of(FID, struct usdf_cq, cq_fid.fid)
 #define cq_utof(CQ) (&(CQ)->cq_fid)

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -740,7 +740,10 @@ usdf_cq_read_common_soft(struct fid_cq *fcq, void *buf, size_t count,
 			break;
 
 		if (tail->cse_prov_errno > 0) {
-			return -FI_EAVAIL;
+			if (entry > (uint8_t *) buf)
+				break;
+			else
+				return -FI_EAVAIL;
 		}
 		ret = usdf_cq_copy_soft_entry(entry, tail, format);
 		if (ret < 0) {


### PR DESCRIPTION
This adds a way to determine if the queue is full or empty when the tail and head pointers are the same. Fixes the hang seen in ofiwg/fabtests#340. Also fix a minor issue in the handling of completions with error status.

@goodell @rfaucett @jsquyres 