### PR TITLE
Pr/sockets: Fix CQ completions and cleanup

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -443,18 +443,10 @@ struct sock_eq {
 struct sock_comp {
 	uint8_t send_cq_event;
 	uint8_t recv_cq_event;
-	uint8_t read_cq_event;
-	uint8_t write_cq_event;
-	uint8_t rem_read_cq_event;
-	uint8_t rem_write_cq_event;
 	char reserved[2];
 
 	struct sock_cq	*send_cq;
 	struct sock_cq	*recv_cq;
-	struct sock_cq	*read_cq;
-	struct sock_cq	*write_cq;
-	struct sock_cq *rem_read_cq;
-	struct sock_cq *rem_write_cq;
 
 	struct sock_cntr *send_cntr;
 	struct sock_cntr *recv_cntr;
@@ -580,8 +572,6 @@ struct sock_rx_ctx {
 	uint8_t progress;
 
 	uint8_t recv_cq_event;
-	uint8_t rem_read_cq_event;
-	uint8_t rem_write_cq_event;
 	uint16_t buffered_len;
 	uint16_t min_multi_recv;
 	uint16_t num_left;
@@ -957,9 +947,6 @@ int sock_ep_enable(struct fid_ep *ep);
 int sock_ep_disable(struct fid_ep *ep);
 int sock_ep_is_send_cq_low(struct sock_comp *comp, uint64_t flags);
 int sock_ep_is_recv_cq_low(struct sock_comp *comp, uint64_t flags);
-int sock_ep_is_write_cq_low(struct sock_comp *comp, uint64_t flags);
-int sock_ep_is_read_cq_low(struct sock_comp *comp, uint64_t flags);
-
 
 int sock_stx_ctx(struct fid_domain *domain,
 		 struct fi_tx_attr *attr, struct fid_stx **stx, void *context);

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -112,7 +112,7 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 	if (flags & SOCK_USE_OP_FLAGS)
 		flags |= tx_ctx->attr.op_flags;
 
-	if (sock_ep_is_write_cq_low(&tx_ctx->comp, flags)) {
+	if (sock_ep_is_send_cq_low(&tx_ctx->comp, flags)) {
 		SOCK_LOG_ERROR("CQ size low\n");
 		return -FI_EAGAIN;
 	}

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -637,7 +637,6 @@ int sock_cq_check_size_ok(struct sock_cq *cq)
 	fastlock_acquire(&cq->lock);
 	if (rbfdavail(&cq->cq_rbfd) < sock_cq_entry_size(cq)) {
 		ret = 0;
-		SOCK_LOG_ERROR("Not enough space in CQ\n");
 	}
 	fastlock_release(&cq->lock);
 	return ret;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -141,18 +141,6 @@ static int sock_ctx_bind_cq(struct fid *fid, struct fid *bfid, uint64_t flags)
 				tx_ctx->comp.send_cq_event = 1;
 		}
 
-		if (flags & FI_READ) {
-			tx_ctx->comp.read_cq = sock_cq;
-			if (flags & FI_SELECTIVE_COMPLETION)
-				tx_ctx->comp.read_cq_event = 1;
-		}
-
-		if (flags & FI_WRITE) {
-			tx_ctx->comp.write_cq = sock_cq;
-			if (flags & FI_SELECTIVE_COMPLETION)
-				tx_ctx->comp.write_cq_event = 1;
-		}
-
 		fastlock_acquire(&sock_cq->list_lock);
 		dlist_insert_tail(&tx_ctx->cq_entry, &sock_cq->tx_list);
 		fastlock_release(&sock_cq->list_lock);
@@ -177,18 +165,6 @@ static int sock_ctx_bind_cq(struct fid *fid, struct fid *bfid, uint64_t flags)
 			tx_ctx->comp.send_cq = sock_cq;
 			if (flags & FI_SELECTIVE_COMPLETION)
 				tx_ctx->comp.send_cq_event = 1;
-		}
-
-		if (flags & FI_READ) {
-			tx_ctx->comp.read_cq = sock_cq;
-			if (flags & FI_SELECTIVE_COMPLETION)
-				tx_ctx->comp.read_cq_event = 1;
-		}
-
-		if (flags & FI_WRITE) {
-			tx_ctx->comp.write_cq = sock_cq;
-			if (flags & FI_SELECTIVE_COMPLETION)
-				tx_ctx->comp.write_cq_event = 1;
 		}
 
 		fastlock_acquire(&sock_cq->list_lock);
@@ -719,25 +695,13 @@ static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 				ep->comp.send_cq_event = 1;
 		}
 
-		if (flags & FI_READ) {
-			ep->comp.read_cq = cq;
-			if (flags & FI_SELECTIVE_COMPLETION)
-				ep->comp.read_cq_event = 1;
-		}
-
-		if (flags & FI_WRITE) {
-			ep->comp.write_cq = cq;
-			if (flags & FI_SELECTIVE_COMPLETION)
-				ep->comp.write_cq_event = 1;
-		}
-
 		if (flags & FI_RECV) {
 			ep->comp.recv_cq = cq;
 			if (flags & FI_SELECTIVE_COMPLETION)
 				ep->comp.recv_cq_event = 1;
 		}
 
-		if (flags & FI_SEND || flags & FI_WRITE || flags & FI_READ) {
+		if (flags & FI_SEND) {
 			for (i=0; i < ep->ep_attr.tx_ctx_cnt; i++) {
 				tx_ctx = ep->tx_array[i];
 				
@@ -1614,20 +1578,4 @@ int sock_ep_is_recv_cq_low(struct sock_comp *comp, uint64_t flags)
 	    (!comp->recv_cq_event || 
 	     (comp->recv_cq_event && (flags & FI_COMPLETION)))) &&
 		!sock_cq_check_size_ok(comp->recv_cq);
-}
-
-int sock_ep_is_write_cq_low(struct sock_comp *comp, uint64_t flags)
-{
-	return (comp && comp->write_cq && !(flags & SOCK_NO_COMPLETION) &&
-	    (!comp->write_cq_event || 
-	     (comp->write_cq_event && (flags & FI_COMPLETION)))) &&
-		!sock_cq_check_size_ok(comp->write_cq);
-}
-
-int sock_ep_is_read_cq_low(struct sock_comp *comp, uint64_t flags)
-{
-	return (comp && comp->read_cq && !(flags & SOCK_NO_COMPLETION) &&
-	    (!comp->read_cq_event || 
-	     (comp->read_cq_event && (flags & FI_COMPLETION)))) &&
-		!sock_cq_check_size_ok(comp->read_cq);
 }

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -524,7 +524,7 @@ static int sock_pe_handle_error(struct sock_pe *pe, struct sock_pe_entry *pe_ent
 	response = &pe_entry->response;
 	assert(response->pe_entry_id <= SOCK_PE_MAX_ENTRIES);
 	waiting_entry = &pe->pe_table[response->pe_entry_id];
-	SOCK_LOG_DBG("Received error for PE entry %p (index: %d)\n", 
+	SOCK_LOG_ERROR("Received error for PE entry %p (index: %d)\n", 
 		      waiting_entry, response->pe_entry_id);
 	
 	assert(waiting_entry->type == SOCK_PE_TX);

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -272,23 +272,10 @@ static void sock_pe_report_remote_write(struct sock_rx_ctx *rx_ctx,
 	pe_entry->buf = pe_entry->pe.rx.rx_iov[0].iov.addr;
 	pe_entry->data_len = pe_entry->pe.rx.rx_iov[0].iov.len;
 	
-	if ((!pe_entry->comp->rem_write_cq && !pe_entry->comp->rem_write_cntr &&
+	if ((!pe_entry->comp->rem_write_cntr &&
 	     !(pe_entry->msg_hdr.flags & FI_REMOTE_WRITE)))
 		return;
-	
-	if (pe_entry->comp->rem_write_cq) {
-		if (pe_entry->comp->rem_write_cq_event) {
-			if ( pe_entry->flags & FI_COMPLETION)
-				pe_entry->comp->rem_write_cq->report_completion(
-					pe_entry->comp->rem_write_cq, 
-					pe_entry->addr, pe_entry);
-		} else {
-			pe_entry->comp->rem_write_cq->report_completion(
-				pe_entry->comp->rem_write_cq, 
-				pe_entry->addr, pe_entry);
-		}
-	}
-	
+		
 	if (pe_entry->comp->rem_write_cntr)
 		sock_cntr_inc(pe_entry->comp->rem_write_cntr);
 }
@@ -296,15 +283,7 @@ static void sock_pe_report_remote_write(struct sock_rx_ctx *rx_ctx,
 static void sock_pe_report_write_completion(struct sock_pe_entry *pe_entry)
 {
 	if (!(pe_entry->flags & SOCK_NO_COMPLETION)) {
-		sock_pe_report_tx_completion(pe_entry);
-	
-		if (pe_entry->comp->write_cq && 
-		    (pe_entry->comp->send_cq != pe_entry->comp->write_cq) &&
-		    (!pe_entry->comp->write_cq_event || 
-		     (pe_entry->comp->write_cq_event && 
-		      (pe_entry->msg_hdr.flags & FI_COMPLETION)))) 
-			pe_entry->comp->write_cq->report_completion(
-				pe_entry->comp->write_cq, pe_entry->addr, pe_entry);
+		sock_pe_report_tx_completion(pe_entry);	
 	}
 	
 	if (pe_entry->comp->write_cntr && 
@@ -318,23 +297,10 @@ static void sock_pe_report_remote_read(struct sock_rx_ctx *rx_ctx,
 	pe_entry->buf = pe_entry->pe.rx.rx_iov[0].iov.addr;
 	pe_entry->data_len = pe_entry->pe.rx.rx_iov[0].iov.len;
 	
-	if ((!pe_entry->comp->rem_read_cq && !pe_entry->comp->rem_read_cntr &&
+	if ((!pe_entry->comp->rem_read_cntr &&
 	     !(pe_entry->msg_hdr.flags & FI_REMOTE_READ)))
 		return;
-	
-	if (pe_entry->comp->rem_read_cq) {
-		if (pe_entry->comp->rem_read_cq_event) {
-			if ( pe_entry->flags & FI_COMPLETION)
-				pe_entry->comp->rem_read_cq->report_completion(
-					pe_entry->comp->rem_read_cq, 
-					pe_entry->addr, pe_entry);
-		} else {
-			pe_entry->comp->rem_read_cq->report_completion(
-				pe_entry->comp->rem_read_cq, 
-				pe_entry->addr, pe_entry);
-		}
-	}
-	
+		
 	if (pe_entry->comp->rem_read_cntr)
 		sock_cntr_inc(pe_entry->comp->rem_read_cntr);
 }
@@ -342,15 +308,7 @@ static void sock_pe_report_remote_read(struct sock_rx_ctx *rx_ctx,
 static void sock_pe_report_read_completion(struct sock_pe_entry *pe_entry)
 {
 	if (!(pe_entry->flags & SOCK_NO_COMPLETION)) {
-		sock_pe_report_tx_completion(pe_entry);
-		
-		if (pe_entry->comp->read_cq && 
-		    (pe_entry->comp->read_cq != pe_entry->comp->send_cq) &&
-		    (!pe_entry->comp->read_cq_event || 
-		     (pe_entry->comp->read_cq_event && 
-		      (pe_entry->msg_hdr.flags & FI_COMPLETION)))) 
-			pe_entry->comp->read_cq->report_completion(
-				pe_entry->comp->read_cq, pe_entry->addr, pe_entry);
+		sock_pe_report_tx_completion(pe_entry);	
 	}
 	
 	if (pe_entry->comp->read_cntr &&
@@ -371,8 +329,8 @@ static void sock_pe_report_tx_rma_read_err(struct sock_pe_entry *pe_entry, int e
 {
 	if (pe_entry->comp->read_cntr)
 		sock_cntr_err_inc(pe_entry->comp->read_cntr);
-	if (pe_entry->comp->read_cq)
-		sock_cq_report_error(pe_entry->comp->read_cq, pe_entry, 0, 
+	if (pe_entry->comp->send_cq)
+		sock_cq_report_error(pe_entry->comp->send_cq, pe_entry, 0, 
 				     err, -err, NULL);
 }
 
@@ -380,8 +338,8 @@ static void sock_pe_report_tx_rma_write_err(struct sock_pe_entry *pe_entry, int 
 {
 	if (pe_entry->comp->write_cntr)
 		sock_cntr_err_inc(pe_entry->comp->write_cntr);
-	if (pe_entry->comp->write_cq)
-		sock_cq_report_error(pe_entry->comp->write_cq, pe_entry, 0, 
+	if (pe_entry->comp->send_cq)
+		sock_cq_report_error(pe_entry->comp->send_cq, pe_entry, 0, 
 				     err, -err, NULL);
 }
 

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -112,7 +112,7 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	if (flags & SOCK_USE_OP_FLAGS)
 		flags |= tx_ctx->attr.op_flags;	
 
-	if (sock_ep_is_read_cq_low(&tx_ctx->comp, flags)) {
+	if (sock_ep_is_send_cq_low(&tx_ctx->comp, flags)) {
 		SOCK_LOG_ERROR("CQ size low\n");
 		return -FI_EAGAIN;
 	}
@@ -282,7 +282,7 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	if (flags & SOCK_USE_OP_FLAGS)
 		flags |= tx_ctx->attr.op_flags;
 
-	if (sock_ep_is_write_cq_low(&tx_ctx->comp, flags)) {
+	if (sock_ep_is_send_cq_low(&tx_ctx->comp, flags)) {
 		SOCK_LOG_ERROR("CQ size low\n");
 		return -FI_EAGAIN;
 	}


### PR DESCRIPTION
According to manpage FI_SEND/FI_TRANSMIT handles send message, RMA and atomic operations. We don't need separate read/write cq.
- Removed read/write cq pointers and corresponding code
- Removed remote read/write cq pointers as it's no longer supported
- Corrected debug log to error log

Addresses issues reported #1225. @jithinjosepkl @svalat can you please review?