### PR TITLE
prov/sockets: Added empty string check in sock_av_insertsym

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -373,7 +373,7 @@ static int sock_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt
 	char tmp_port[FI_NAME_MAX] = {0};
 	int hostlen, offset = 0, fmt, i, j;
 
-	if (!node || !service) {
+	if (!node || !service || node[0] == '\0') {
 		SOCK_LOG_ERROR("Node/service not provided\n");
 		return -FI_EINVAL;
 	}


### PR DESCRIPTION
In sock_av_insertsym
- Added a check for empty string check for node parameter
- Used snprintf instead of sprintf so that the buffer doesn't overflow
- Added assert to catch the overflow

Fixes #1226. @fweimer can you please review?

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>