### PR TITLE
prov/psm: add PSM2 support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,8 @@ lib_LTLIBRARIES = src/libfabric.la
 
 pkglib_LTLIBRARIES = $(DL_PROVIDERS)
 
+noinst_LTLIBRARIES =
+
 ACLOCAL_AMFLAGS = -I config
 AM_CFLAGS = -g -Wall
 
@@ -64,6 +66,7 @@ endif
 src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)
 src_libfabric_la_LDFLAGS =
 src_libfabric_la_LIBADD =
+src_libfabric_la_DEPENDENCIES = $(srcdir)/libfabric.map
 
 if HAVE_SOCKETS
 _sockets_files = \
@@ -263,9 +266,9 @@ endif HAVE_USNIC
 
 if HAVE_PSM
 _psm_files = \
+	prov/psm/src/version.h \
 	prov/psm/src/psm_am.h \
 	prov/psm/src/psmx.h \
-	prov/psm/src/psm_am.h \
 	prov/psm/src/psmx_init.c \
 	prov/psm/src/psmx_domain.c \
 	prov/psm/src/psmx_cq.c \
@@ -294,18 +297,63 @@ libpsmx_fi_la_LDFLAGS = \
 libpsmx_fi_la_LIBADD = $(linkback) $(psm_LIBS)
 libpsmx_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_PSM_DL
-src_libfabric_la_SOURCES += $(_psm_files)
-src_libfabric_la_CPPFLAGS += $(psm_CPPFLAGS)
-src_libfabric_la_LDFLAGS += $(psm_LDFLAGS)
-src_libfabric_la_LIBADD += $(psm_LIBS)
+noinst_LTLIBRARIES += libpsmx.la
+libpsmx_la_SOURCES = $(_psm_files)
+libpsmx_la_CPPFLAGS = $(src_libfabric_la_CPPFLAGS) $(psm_CPPFLAGS)
+libpsmx_la_LDFLAGS = $(psm_LDFLAGS)
+libpsmx_la_LIBADD = $(psm_LIBS)
+src_libfabric_la_LIBADD += libpsmx.la
+src_libfabric_la_DEPENDENCIES += libpsmx.la
 endif !HAVE_PSM_DL
 
 endif HAVE_PSM
 
+if HAVE_PSM2
+_psm2_files = \
+	prov/psm2/src/makefile \
+	prov/psm2/src/version.h \
+	prov/psm2/src/psmx.h \
+	prov/psm2/src/psmx_init.c \
+	prov/psm2/src/psmx_domain.c \
+	prov/psm2/src/psmx_cq.c \
+	prov/psm2/src/psmx_eq.c \
+	prov/psm2/src/psmx_cntr.c \
+	prov/psm2/src/psmx_av.c \
+	prov/psm2/src/psmx_ep.c \
+	prov/psm2/src/psmx_cm.c \
+	prov/psm2/src/psmx_tagged.c \
+	prov/psm2/src/psmx_msg.c \
+	prov/psm2/src/psmx_msg2.c \
+	prov/psm2/src/psmx_rma.c \
+	prov/psm2/src/psmx_atomic.c \
+	prov/psm2/src/psmx_am.c \
+	prov/psm2/src/psmx_mr.c \
+	prov/psm2/src/psmx_wait.c \
+	prov/psm2/src/psmx_poll.c \
+	prov/psm2/src/psmx_util.c
+
+if HAVE_PSM2_DL
+pkglib_LTLIBRARIES += libpsmx2-fi.la
+libpsmx2_fi_la_SOURCES = $(_psm2_files) $(common_srcs)
+libpsmx2_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(psm2_CPPFLAGS)
+libpsmx2_fi_la_LDFLAGS = \
+    -module -avoid-version -shared -export-dynamic $(psm2_LDFLAGS)
+libpsmx2_fi_la_LIBADD = $(linkback) $(psm2_LIBS)
+libpsmx2_fi_la_DEPENDENCIES = $(linkback)
+else !HAVE_PSM2_DL
+noinst_LTLIBRARIES += libpsmx2.la
+libpsmx2_la_SOURCES = $(_psm2_files)
+libpsmx2_la_CPPFLAGS = $(src_libfabric_la_CPPFLAGS) $(psm2_CPPFLAGS)
+libpsmx2_la_LDFLAGS = $(psm2_LDFLAGS)
+libpsmx2_la_LIBADD = $(psm2_LIBS)
+src_libfabric_la_LIBADD += libpsmx2.la
+src_libfabric_la_DEPENDENCIES += libpsmx2.la
+endif !HAVE_PSM2_DL
+
+endif HAVE_PSM2
+
 src_libfabric_la_LDFLAGS += -version-info 2:0:1 -export-dynamic \
 			   $(libfabric_version_script)
-src_libfabric_la_DEPENDENCIES = $(srcdir)/libfabric.map
-
 rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fabric.h \
 	$(top_srcdir)/include/rdma/fi_atomic.h \

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,7 @@ AC_DEFINE_UNQUOTED([HAVE_ALIAS_ATTRIBUTE], [$ac_prog_cc_alias_symbols],
 dnl Provider-specific checks
 FI_PROVIDER_INIT
 FI_PROVIDER_SETUP([psm])
+FI_PROVIDER_SETUP([psm2])
 FI_PROVIDER_SETUP([sockets])
 FI_PROVIDER_SETUP([verbs])
 FI_PROVIDER_SETUP([usnic])

--- a/include/prov.h
+++ b/include/prov.h
@@ -71,6 +71,17 @@ PSM_INI ;
 #  define PSM_INIT NULL
 #endif
 
+#if (HAVE_PSM2) && (HAVE_PSM2_DL)
+#  define PSM2_INI FI_EXT_INI
+#  define PSM2_INIT NULL
+#elif (HAVE_PSM2)
+#  define PSM2_INI INI_SIG(fi_psm2_ini)
+#  define PSM2_INIT fi_psm2_ini()
+PSM2_INI ;
+#else
+#  define PSM2_INIT NULL
+#endif
+
 #if (HAVE_SOCKETS) && (HAVE_SOCKETS_DL)
 #  define SOCKETS_INI FI_EXT_INI
 #  define SOCKETS_INIT NULL

--- a/man/fi_psm.7.md
+++ b/man/fi_psm.7.md
@@ -11,7 +11,7 @@ The PSM Fabric Provider
 
 # OVERVIEW
 
-The *psm* provider runs over the PSM interface that is currently
+The *psm* provider runs over the PSM 1.x interface that is currently
 supported by the Intel TrueScale Fabric. PSM provides tag-matching
 message queue functions that are optimized for MPI implementations.
 PSM also has limited Active Message support, which is not officially
@@ -20,6 +20,18 @@ published but is quite stable and well documented in the source code
 tag-matching message queue functions and the Active Message functions
 to support a variety of libfabric data transfer APIs, including tagged
 message queue, message queue, RMA, and atomic operations.
+
+The *psm2* provider runs over the PSM 2.0 interface that is
+supported by the Intel Omni-Path Fabric. PSM 2.0 is fully backward
+compatible with PSM 1.x and adds some new functions with enhanced
+capability. PSM 2.0 also makes the Active Message support official.
+However, the official Active Message API is slightly different from
+the PSM 1.x version. As a result, the *psm2* provider only works with
+PSM 2.0 and the *psm* provider only works with PSM 1.x.
+
+Unless specifically indicated, the description of the *psm* provider
+in the remaining part of this document also applies to the *psm2*
+provider.
 
 # LIMITATIONS
 
@@ -43,7 +55,8 @@ Endpoint capabilities
 
   *FI_MULTI_RECV* is supported for non-tagged message queue only.
 
-  Other supported capabilities include *FI_TRIGGER*.
+  Other supported capabilities include *FI_TRIGGER*. The *psm2* provider
+  also supports *FI_REMOTE_CQ_DATA*.
 
 Modes
 : *FI_CONTEXT* is required. That means, all the requests that generate
@@ -64,9 +77,11 @@ Unsupported features
 
 # RUNTIME PARAMETERS
 
-The *psm* provider checks for the following environment variables:
+The *psm* provider checks for the following environment variables (
+different variable names are used for the *psm* provider and the
+*psm2* provider):
 
-*FI_PSM_UUID*
+*FI_PSM_UUID* / *FI_PSM2_UUID*
 : PSM requires that each job has a unique ID (UUID). All the processes
   in the same job need to use the same UUID in order to be able to
   talk to each other. The PSM reference manual advises to keep UUID
@@ -79,7 +94,7 @@ The *psm* provider checks for the following environment variables:
 
   The default UUID is 0FFF0FFF-0000-0000-0000-0FFF0FFF0FFF.
 
-*FI_PSM_NAME_SERVER*
+*FI_PSM_NAME_SERVER* / *FI_PSM2_NAME_SERVER*
 : The *psm* provider has a simple built-in name server that can be used
   to resolve an IP address or host name into a transport address needed
   by the *fi_av_insert* call. The main purpose of this name server is to
@@ -100,7 +115,10 @@ The *psm* provider checks for the following environment variables:
   variable to 0. This may save a small amount of resource since a separate
   thread is created when the name server is on.
 
-*FI_PSM_TAGGED_RMA*
+  The provider detects OpenMPI and MPICH runs and changes the default setting
+  to off.
+
+*FI_PSM_TAGGED_RMA* / *FI_PSM2_TAGGED_RMA*
 : The RMA functions are implemented on top of the PSM Active Message functions.
   The Active Message functions has limit on the size of data can be transferred
   in a single message. Large transfers can be divided into small chunks and
@@ -112,7 +130,7 @@ The *psm* provider checks for the following environment variables:
    
   The option is on by default. To turn it off set the variable to 0.
 
-*FI_PSM_AM_MSG*
+*FI_PSM_AM_MSG* / *FI_PSM2_AM_MSG*
 : The *psm* provider implements the non-tagged message queue over the PSM
   tag-matching message queue. One tag bit is reserved for this purpose.
   Alternatively, the non-tagged message queue can be implemented over

--- a/man/man7/fi_psm2.7
+++ b/man/man7/fi_psm2.7
@@ -1,0 +1,1 @@
+.so man7/fi_psm.7

--- a/prov/psm/configure.m4
+++ b/prov/psm/configure.m4
@@ -20,9 +20,33 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 				[],
 				[psm_happy=1],
 				[psm_happy=0])
+	       AS_IF([test $psm_happy -eq 1],
+		     [AC_MSG_CHECKING([if PSM version is 1.x])
+		      AC_RUN_IFELSE([AC_LANG_SOURCE(
+						    [[
+						    #include <psm.h>
+						    int main()
+						    {
+							return PSM_VERNO_MAJOR < 2 ? 0 : 1;
+						    }
+						    ]]
+						   )],
+				    [AC_MSG_RESULT([yes])],
+				    [AC_MSG_RESULT([no]); psm_happy=0])
+		     ])
+	       AS_IF([test $psm_happy -eq 1],
+		     [AC_CHECK_TYPE([psm_epconn_t],
+		                    [],
+				    [psm_happy=0],
+				    [[#include <psm.h>]])])
 	      ])
-	AS_IF([test x"$psm_happy" = x"1"],
-   	      [AC_CHECK_TYPE([psm_epconn_t], [], [psm_happy=0], [[#include <psm.h>]])])
 
 	AS_IF([test $psm_happy -eq 1], [$1], [$2])
+
+	psm_CPPFLAGS="$CPPFLAGS $psm_CPPFLAGS"
+	psm_LDFLAGS="$LDFLAGS $psm_LDFLAGS"
+	psm_LIBS="$LIBS $psm_LIBS"
+	CPPFLAGS=
+	LDFLAGS=
+	LIBS=
 ])

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -1,3 +1,35 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 #ifndef _FI_PSM_H
 #define _FI_PSM_H
 
@@ -32,21 +64,41 @@ extern "C" {
 #include <rdma/fi_trigger.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_errno.h>
+#include <rdma/fi_log.h>
+
+#include "version.h"
+#if (PSMX_VERSION >= 2)
+#include <psm2.h>
+#include <psm2_mq.h>
+#include <psm2_am.h>
+#else
 #include <psm.h>
 #include <psm_mq.h>
 #include "psm_am.h"
+#if (PSM_VERNO_MAJOR >= 2)
+#error "building PSM provider against PSM2 is not supported"
+#endif
+#endif
 
 #include "fi.h"
 #include "fi_enosys.h"
 #include "fi_list.h"
-#include <rdma/fi_log.h>
 
+#if (PSM_VERNO_MAJOR >= 2)
+#define PSMX_PROV_NAME		"psm2"
+#define PSMX_PROV_NAME_LEN	4
+#define PSMX_DOMAIN_NAME	"psm2"
+#define PSMX_DOMAIN_NAME_LEN	4
+#define PSMX_FABRIC_NAME	"psm2"
+#define PSMX_FABRIC_NAME_LEN	4
+#else
 #define PSMX_PROV_NAME		"psm"
 #define PSMX_PROV_NAME_LEN	3
 #define PSMX_DOMAIN_NAME	"psm"
 #define PSMX_DOMAIN_NAME_LEN	3
 #define PSMX_FABRIC_NAME	"psm"
 #define PSMX_FABRIC_NAME_LEN	3
+#endif
 
 #define PSMX_DEFAULT_UUID	"0FFF0FFF-0000-0000-0000-0FFF0FFF0FFF"
 
@@ -58,7 +110,11 @@ extern struct fi_provider psmx_prov;
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \
 			 FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)
 
+#if (PSM_VERNO_MAJOR >= 2)
+#define PSMX_CAP_EXT	(FI_REMOTE_CQ_DATA)
+#else
 #define PSMX_CAP_EXT	(0)
+#endif
 
 #define PSMX_CAPS	(FI_TAGGED | FI_MSG | FI_ATOMICS | \
 			 FI_RMA | FI_MULTI_RECV | \
@@ -68,7 +124,11 @@ extern struct fi_provider psmx_prov;
 			 FI_RMA_EVENT | \
 			 PSMX_CAP_EXT)
 
+#if (PSM_VERNO_MAJOR >= 2)
+#define PSMX_CAPS2	(PSMX_CAPS | FI_DIRECTED_RECV)
+#else
 #define PSMX_CAPS2	((PSMX_CAPS | FI_DIRECTED_RECV) & ~FI_TAGGED)
+#endif
 
 #define PSMX_SUB_CAPS	(FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE | \
 			 FI_SEND | FI_RECV)
@@ -109,6 +169,14 @@ union psmx_pi {
 #define PSMX_CTXT_TYPE(fi_context)	(((union psmx_pi *)&(fi_context)->internal[1])->i)
 #define PSMX_CTXT_USER(fi_context)	((fi_context)->internal[2])
 #define PSMX_CTXT_EP(fi_context)	((fi_context)->internal[3])
+
+#if (PSM_VERNO_MAJOR >= 2)
+#define PSMX_SET_TAG(tag96,tag64,tag32)	do { \
+						tag96.tag0 = (uint32_t)tag64; \
+						tag96.tag1 = (uint32_t)(tag64>>32); \
+						tag96.tag2 = tag32; \
+					} while (0)
+#endif
 
 #define PSMX_AM_RMA_HANDLER	0
 #define PSMX_AM_MSG_HANDLER	1
@@ -384,6 +452,9 @@ struct psmx_trigger {
 			fi_addr_t	dest_addr;
 			void		*context;
 			uint64_t	flags;
+#if (PSM_VERNO_MAJOR >= 2)
+			uint32_t	data;
+#endif
 		} send;
 		struct {
 			struct fid_ep	*ep;
@@ -403,6 +474,9 @@ struct psmx_trigger {
 			uint64_t	tag;
 			void		*context;
 			uint64_t	flags;
+#if (PSM_VERNO_MAJOR >= 2)
+			uint32_t	data;
+#endif
 		} tsend;
 		struct {
 			struct fid_ep	*ep;
@@ -563,6 +637,7 @@ struct psmx_env {
 	int am_msg;
 	int tagged_rma;
 	char *uuid;
+	int delay;
 };
 
 extern struct fi_ops_mr		psmx_mr_ops;
@@ -642,12 +717,21 @@ int	psmx_am_process_rma(struct psmx_fid_domain *domain,
 				struct psmx_am_request *req);
 int	psmx_process_trigger(struct psmx_fid_domain *domain,
 				struct psmx_trigger *trigger);
+#if (PSM_VERNO_MAJOR >= 2)
+int	psmx_am_msg_handler(psm_am_token_t token,
+				psm_amarg_t *args, int nargs, void *src, uint32_t len);
+int	psmx_am_rma_handler(psm_am_token_t token,
+				psm_amarg_t *args, int nargs, void *src, uint32_t len);
+int	psmx_am_atomic_handler(psm_am_token_t token,
+				psm_amarg_t *args, int nargs, void *src, uint32_t len);
+#else
 int	psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
 int	psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
 int	psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
+#endif
 
 void	psmx_am_ack_rma(struct psmx_am_request *req);
 
@@ -673,15 +757,27 @@ static inline void psmx_progress(struct psmx_fid_domain *domain)
 	}
 }
 
+#if (PSM_VERNO_MAJOR >= 2)
+ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
+		   void *desc, fi_addr_t dest_addr, void *context,
+		   uint64_t flags, uint32_t data);
+#else
 ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 		   void *desc, fi_addr_t dest_addr, void *context,
 		   uint64_t flags);
+#endif
 ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 		   void *desc, fi_addr_t src_addr, void *context,
 		   uint64_t flags);
+#if (PSM_VERNO_MAJOR >= 2)
+ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
+			  void *desc, fi_addr_t dest_addr, uint64_t tag,
+			  void *context, uint64_t flags, uint32_t data);
+#else
 ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 			  void *desc, fi_addr_t dest_addr, uint64_t tag,
 			  void *context, uint64_t flags);
+#endif
 ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 			  void *desc, fi_addr_t src_addr, uint64_t tag,
 			  uint64_t ignore, void *context, uint64_t flags);

--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -361,9 +361,15 @@ static void psmx_am_atomic_completion(void *buf)
 		free(buf);
 }
 
+#if (PSM_VERNO_MAJOR >= 2)
+int psmx_am_atomic_handler(psm_am_token_t token,
+			   psm_amarg_t *args, int nargs, void *src,
+			   uint32_t len)
+#else
 int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			   psm_amarg_t *args, int nargs, void *src,
 			   uint32_t len)
+#endif
 {
 	psm_amarg_t rep_args[8];
 	int count;
@@ -379,6 +385,11 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	struct psmx_fid_cntr *cntr = NULL;
 	struct psmx_fid_cntr *mr_cntr = NULL;
 	void *tmp_buf;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_epaddr_t epaddr;
+
+	psm_am_get_source(token, &epaddr);
+#endif
 
 	switch (args[0].u32w0 & PSMX_AM_OP_MASK) {
 	case PSMX_AM_REQ_ATOMIC_WRITE:

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -36,6 +36,16 @@ int psmx_process_trigger(struct psmx_fid_domain *domain, struct psmx_trigger *tr
 {
 	switch (trigger->op) {
 	case PSMX_TRIGGERED_SEND:
+#if (PSM_VERNO_MAJOR >= 2)
+		_psmx_send(trigger->send.ep,
+			   trigger->send.buf,
+			   trigger->send.len,
+			   trigger->send.desc,
+			   trigger->send.dest_addr,
+			   trigger->send.context,
+			   trigger->send.flags,
+			   trigger->send.data);
+#else
 		_psmx_send(trigger->send.ep,
 			   trigger->send.buf,
 			   trigger->send.len,
@@ -43,6 +53,7 @@ int psmx_process_trigger(struct psmx_fid_domain *domain, struct psmx_trigger *tr
 			   trigger->send.dest_addr,
 			   trigger->send.context,
 			   trigger->send.flags);
+#endif
 		break;
 	case PSMX_TRIGGERED_RECV:
 		_psmx_recv(trigger->recv.ep,
@@ -54,6 +65,17 @@ int psmx_process_trigger(struct psmx_fid_domain *domain, struct psmx_trigger *tr
 			   trigger->recv.flags);
 		break;
 	case PSMX_TRIGGERED_TSEND:
+#if (PSM_VERNO_MAJOR >= 2)
+			_psmx_tagged_send(trigger->tsend.ep,
+					  trigger->tsend.buf,
+					  trigger->tsend.len,
+					  trigger->tsend.desc,
+					  trigger->tsend.dest_addr,
+					  trigger->tsend.tag,
+					  trigger->tsend.context,
+					  trigger->tsend.flags,
+					  trigger->tsend.data);
+#else
 		_psmx_tagged_send(trigger->tsend.ep,
 				  trigger->tsend.buf,
 				  trigger->tsend.len,
@@ -62,6 +84,7 @@ int psmx_process_trigger(struct psmx_fid_domain *domain, struct psmx_trigger *tr
 				  trigger->tsend.tag,
 				  trigger->tsend.context,
 				  trigger->tsend.flags);
+#endif
 		break;
 	case PSMX_TRIGGERED_TRECV:
 		_psmx_tagged_recv(trigger->trecv.ep,

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -57,7 +57,7 @@ static int psmx_domain_close(fid_t fid)
 	/* workaround for:
 	 * Assertion failure at psm_ep.c:1059: ep->mctxt_master == ep
 	 */
-	sleep(1);
+	sleep(psmx_env.delay);
 
 	err = psm_ep_close(domain->psm_ep, PSM_EP_CLOSE_GRACEFUL,
 			   (int64_t) PSMX_TIME_OUT * 1000000000LL);

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -78,7 +78,11 @@ static void psmx_ep_optimize_ops(struct psmx_fid_ep *ep)
 static ssize_t psmx_ep_cancel(fid_t fid, void *context)
 {
 	struct psmx_fid_ep *ep;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_status2_t status;
+#else
 	psm_mq_status_t status;
+#endif
 	struct fi_context *fi_context = context;
 	uint64_t flags;
 	struct psmx_cq_event *event;
@@ -105,7 +109,11 @@ static ssize_t psmx_ep_cancel(fid_t fid, void *context)
 
 	err = psm_mq_cancel((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context));
 	if (err == PSM_OK) {
+#if (PSM_VERNO_MAJOR >= 2)
+		err = psm_mq_test2((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context), &status);
+#else
 		err = psm_mq_test((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context), &status);
+#endif
 		if (err == PSM_OK && ep->recv_cq) {
 			event = psmx_cq_create_event(
 					ep->recv_cq,

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -42,6 +42,7 @@ struct psmx_env psmx_env = {
 	.am_msg		= 0,
 	.tagged_rma	= 1,
 	.uuid		= PSMX_DEFAULT_UUID,
+	.delay		= 1,
 };
 
 static void psmx_init_env(void)
@@ -53,6 +54,7 @@ static void psmx_init_env(void)
 	fi_param_get_bool(&psmx_prov, "am_msg", &psmx_env.am_msg);
 	fi_param_get_bool(&psmx_prov, "tagged_rma", &psmx_env.tagged_rma);
 	fi_param_get_str(&psmx_prov, "uuid", &psmx_env.uuid);
+	fi_param_get_int(&psmx_prov, "delay", &psmx_env.delay);
 }
 
 static int psmx_reserve_tag_bits(int *caps, uint64_t *max_tag_value)
@@ -472,7 +474,11 @@ struct fi_provider psmx_prov = {
 	.cleanup = psmx_fini
 };
 
+#if (PSM_VERNO_MAJOR >= 2)
+PSM2_INI
+#else
 PSM_INI
+#endif
 {
 	int major, minor;
 	int err;
@@ -493,6 +499,9 @@ PSM_INI
 
 	fi_param_define(&psmx_prov, "uuid", FI_PARAM_STRING,
 			"Unique Job ID required by the fabric");
+
+	fi_param_define(&psmx_prov, "delay", FI_PARAM_INT,
+			"Delay (seconds) before finalization (for debugging)");
 
         psm_error_register_handler(NULL, PSM_ERRHANDLER_NO_HANDLER);
 

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -132,8 +132,13 @@ static struct psmx_unexp *psmx_am_search_and_dequeue_unexp(
  *	args[2].u64	recv_req
  */
 
+#if (PSM_VERNO_MAJOR >= 2)
+int psmx_am_msg_handler(psm_am_token_t token,
+			psm_amarg_t *args, int nargs, void *src, uint32_t len)
+#else
 int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			psm_amarg_t *args, int nargs, void *src, uint32_t len)
+#endif
 {
         psm_amarg_t rep_args[8];
         struct psmx_am_request *req;
@@ -146,6 +151,11 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	int err = 0;
 	int op_error = 0;
 	struct psmx_unexp *unexp;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_epaddr_t epaddr;
+
+	psm_am_get_source(token, &epaddr);
+#endif
 
 	epaddr_context = psm_epaddr_getctxt(epaddr);
 	if (!epaddr_context) {

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -72,8 +72,13 @@ static inline void psmx_am_enqueue_rma(struct psmx_fid_domain *domain,
  *	args[2].u64	offset
  */
 
+#if (PSM_VERNO_MAJOR >= 2)
+int psmx_am_rma_handler(psm_am_token_t token,
+			psm_amarg_t *args, int nargs, void *src, uint32_t len)
+#else
 int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			psm_amarg_t *args, int nargs, void *src, uint32_t len)
+#endif
 {
 	psm_amarg_t rep_args[8];
 	void *rma_addr;
@@ -86,6 +91,11 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	struct psmx_cq_event *event;
 	uint64_t offset;
 	struct psmx_fid_mr *mr;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_epaddr_t epaddr;
+
+	psm_am_get_source(token, &epaddr);
+#endif
 
 	cmd = args[0].u32w0 & PSMX_AM_OP_MASK;
 	eom = args[0].u32w0 & PSMX_AM_EOM;

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -38,7 +38,16 @@ ssize_t _psmx_tagged_peek(struct fid_ep *ep, void *buf, size_t len,
 			  void *context, uint64_t flags)
 {
 	struct psmx_fid_ep *ep_priv;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_status2_t psm_status2;
+	psm_mq_tag_t psm_tag2, psm_tagsel2;
+	psm_mq_req_t req;
+	struct psmx_fid_av *av;
+	size_t idx;
+	psm_epaddr_t psm_src_addr;
+#else
 	psm_mq_status_t psm_status;
+#endif
 	uint64_t psm_tag, psm_tagsel;
 	struct psmx_cq_event *event;
 	int err;
@@ -55,30 +64,75 @@ ssize_t _psmx_tagged_peek(struct fid_ep *ep, void *buf, size_t len,
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
 	psm_tagsel = (~ignore) | ep_priv->domain->reserved_tag_bits;
 
+#if (PSM_VERNO_MAJOR >= 2)
+	if (src_addr != FI_ADDR_UNSPEC) {
+		av = ep_priv->av;
+		if (av && av->type == FI_AV_TABLE) {
+			idx = (size_t)src_addr;
+			if (idx >= av->last)
+				return -FI_EINVAL;
+
+			psm_src_addr = av->psm_epaddrs[idx];
+		}
+		else {
+			psm_src_addr = (psm_epaddr_t)src_addr;
+		}
+	}
+	else {
+		psm_src_addr = NULL;
+	}
+
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
+
+	if (flags & (FI_CLAIM | FI_DISCARD))
+		err = psm_mq_improbe2(ep_priv->domain->psm_mq,
+				      psm_src_addr,
+				      &psm_tag2, &psm_tagsel2,
+				      &req, &psm_status2);
+	else
+		err = psm_mq_iprobe2(ep_priv->domain->psm_mq,
+				     psm_src_addr,
+				     &psm_tag2, &psm_tagsel2,
+				     &psm_status2);
+#else
 	if (flags & (FI_CLAIM | FI_DISCARD))
 		return -FI_EOPNOTSUPP;
 
 	err = psm_mq_iprobe(ep_priv->domain->psm_mq, psm_tag, psm_tagsel,
 			    &psm_status);
+#endif
 	switch (err) {
 	case PSM_OK:
 		if (ep_priv->recv_cq) {
+#if (PSM_VERNO_MAJOR >= 2)
+			if ((flags & FI_CLAIM) && context)
+				PSMX_CTXT_REQ((struct fi_context *)context) = req;
+
+			tag = psm_status2.msg_tag.tag0 | (((uint64_t)psm_status2.msg_tag.tag1) << 32);
+			len = psm_status2.msg_length;
+			src_addr = (fi_addr_t)psm_status2.msg_peer;
+#else
+			tag = psm_status.msg_tag;
+			len = psm_status.msg_length;
+			src_addr = 0;
+#endif
 			event = psmx_cq_create_event(
 					ep_priv->recv_cq,
 					context,		/* op_context */
 					NULL,			/* buf */
 					flags|FI_RECV|FI_TAGGED,/* flags */
-					psm_status.msg_length,	/* len */
+					len,			/* len */
 					0,			/* data */
-					psm_status.msg_tag,	/* tag */
-					psm_status.msg_length,	/* olen */
+					tag,			/* tag */
+					len,			/* olen */
 					0);			/* err */
-			if (event)
-				psmx_cq_enqueue_event(ep_priv->recv_cq, event);
-			else
+
+			if (!event)
 				return -FI_ENOMEM;
 
-			/* TODO: set message source to FI_ADDR_NOTAVAIL? */
+			event->source = src_addr;
+			psmx_cq_enqueue_event(ep_priv->recv_cq, event);
 		}
 		return 0;
 
@@ -98,6 +152,11 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2, psm_tagsel2;
+	struct psmx_fid_av *av;
+	size_t idx;
+#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -133,6 +192,29 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 		return 0;
 	}
 
+#if (PSM_VERNO_MAJOR >= 2)
+	if (flags & FI_CLAIM) {
+		if (!context)
+			return -FI_EINVAL;
+
+		/* TODO: handle FI_DISCARD */
+
+		fi_context = context;
+		psm_req = PSMX_CTXT_REQ(fi_context);
+		PSMX_CTXT_TYPE(fi_context) = PSMX_TRECV_CONTEXT;
+		PSMX_CTXT_USER(fi_context) = buf;
+		PSMX_CTXT_EP(fi_context) = ep_priv;
+
+		err = psm_mq_imrecv(ep_priv->domain->psm_mq, 0, /*flags*/
+				    buf, len, context, &psm_req);
+		if (err != PSM_OK)
+			return psmx_errno(err);
+
+		PSMX_CTXT_REQ(fi_context) = psm_req;
+		return 0;
+	}
+#endif
+
 	if (tag & ep_priv->domain->reserved_tag_bits) {
 		FI_WARN(&psmx_prov, FI_LOG_EP_DATA,
 			"using reserved tag bits."
@@ -156,9 +238,33 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 		PSMX_CTXT_EP(fi_context) = ep_priv;
 	}
 
+#if (PSM_VERNO_MAJOR >= 2)
+	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
+		av = ep_priv->av;
+		if (av && av->type == FI_AV_TABLE) {
+			idx = (size_t)src_addr;
+			if (idx >= av->last)
+				return -FI_EINVAL;
+
+			src_addr = (fi_addr_t)av->psm_epaddrs[idx];
+		}
+	}
+	else {
+		src_addr = 0;
+	}
+
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
+
+	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+			   (psm_epaddr_t)src_addr,
+			   &psm_tag2, &psm_tagsel2, 0, /* flags */
+			   buf, len, (void *)fi_context, &psm_req);
+#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
+#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -178,6 +284,9 @@ ssize_t psmx_tagged_recv_no_flag_av_map(struct fid_ep *ep, void *buf,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2, psm_tagsel2;
+#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -191,9 +300,22 @@ ssize_t psmx_tagged_recv_no_flag_av_map(struct fid_ep *ep, void *buf,
 	PSMX_CTXT_USER(fi_context) = buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
+#if (PSM_VERNO_MAJOR >= 2)
+	if (! ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC))
+		src_addr = 0;
+
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
+
+	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+			   (psm_epaddr_t)src_addr,
+			   &psm_tag2, &psm_tagsel2, 0, /* flags */
+			   buf, len, (void *)fi_context, &psm_req);
+#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
+#endif
 	if (err != PSM_OK)
 		return psmx_errno(err);
 
@@ -210,6 +332,12 @@ ssize_t psmx_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2, psm_tagsel2;
+	struct psmx_fid_av *av;
+	psm_epaddr_t psm_epaddr;
+	size_t idx;
+#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -223,9 +351,31 @@ ssize_t psmx_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf,
 	PSMX_CTXT_USER(fi_context) = buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
+#if (PSM_VERNO_MAJOR >= 2)
+	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
+		av = ep_priv->av;
+		idx = (size_t)src_addr;
+		if (idx >= av->last)
+			return -FI_EINVAL;
+
+		psm_epaddr = av->psm_epaddrs[idx];
+	}
+	else {
+		psm_epaddr = NULL;
+	}
+
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
+
+	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+			   psm_epaddr,
+			   &psm_tag2, &psm_tagsel2, 0, /* flags */
+			   buf, len, (void *)fi_context, &psm_req);
+#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
+#endif
 	if (err != PSM_OK)
 		return psmx_errno(err);
 
@@ -242,6 +392,9 @@ ssize_t psmx_tagged_recv_no_event_av_map(struct fid_ep *ep, void *buf,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2, psm_tagsel2;
+#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -252,9 +405,22 @@ ssize_t psmx_tagged_recv_no_event_av_map(struct fid_ep *ep, void *buf,
 
 	fi_context = &ep_priv->nocomp_recv_context;
 
+#if (PSM_VERNO_MAJOR >= 2)
+	if (! ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC))
+		src_addr = 0;
+
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
+
+	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+			   (psm_epaddr_t)src_addr,
+			   &psm_tag2, &psm_tagsel2, 0, /* flags */
+			   buf, len, (void *)fi_context, &psm_req);
+#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
+#endif
 
 	return psmx_errno(err);
 }
@@ -268,6 +434,12 @@ ssize_t psmx_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2, psm_tagsel2;
+	struct psmx_fid_av *av;
+	psm_epaddr_t psm_epaddr;
+	size_t idx;
+#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -278,9 +450,31 @@ ssize_t psmx_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf,
 
 	fi_context = &ep_priv->nocomp_recv_context;
 
+#if (PSM_VERNO_MAJOR >= 2)
+	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
+		av = ep_priv->av;
+		idx = (size_t)src_addr;
+		if (idx >= av->last)
+			return -FI_EINVAL;
+
+		psm_epaddr = av->psm_epaddrs[idx];
+	}
+	else {
+		psm_epaddr = NULL;
+	}
+
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
+
+	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+			   psm_epaddr,
+			   &psm_tag2, &psm_tagsel2, 0, /* flags */
+			   buf, len, (void *)fi_context, &psm_req);
+#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
+#endif
 
 	return psmx_errno(err);
 }
@@ -424,15 +618,24 @@ static ssize_t psmx_tagged_recvv_no_event(struct fid_ep *ep, const struct iovec 
 					tag, ignore, context);
 }
 
+#if (PSM_VERNO_MAJOR >= 2)
+ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
+			  void *desc, fi_addr_t dest_addr, uint64_t tag,
+			  void *context, uint64_t flags, uint32_t data)
+#else
 ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 			  void *desc, fi_addr_t dest_addr, uint64_t tag,
 			  void *context, uint64_t flags)
+#endif
 {
 	struct psmx_fid_ep *ep_priv;
 	struct psmx_fid_av *av;
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2;
+#endif
 	struct fi_context *fi_context;
 	int err;
 	size_t idx;
@@ -461,6 +664,9 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 		trigger->tsend.tag = tag;
 		trigger->tsend.context = context;
 		trigger->tsend.flags = flags & ~FI_TRIGGER;
+#if (PSM_VERNO_MAJOR >= 2)
+		trigger->tsend.data = data;
+#endif
 
 		psmx_cntr_add_trigger(trigger->cntr, trigger);
 		return 0;
@@ -486,6 +692,9 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 	}
 
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
+#if (PSM_VERNO_MAJOR >= 2)
+	PSMX_SET_TAG(psm_tag2, psm_tag, data);
+#endif
 
 	if ((flags & PSMX_NO_COMPLETION) ||
 	    (ep_priv->send_selective_completion && !(flags & FI_COMPLETION)))
@@ -495,8 +704,13 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 		if (len > PSMX_INJECT_SIZE)
 			return -FI_EMSGSIZE;
 
+#if (PSM_VERNO_MAJOR >= 2)
+		err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+				   &psm_tag2, buf, len);
+#else
 		err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, 0,
 				  psm_tag, buf, len);
+#endif
 
 		if (err != PSM_OK)
 			return psmx_errno(err);
@@ -508,7 +722,11 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 			event = psmx_cq_create_event(
 					ep_priv->send_cq,
 					context, (void *)buf, flags, len,
+#if (PSM_VERNO_MAJOR >= 2)
+					(uint64_t) data, psm_tag,
+#else
 					0 /* data */, psm_tag,
+#endif
 					0 /* olen */,
 					0 /* err */);
 
@@ -534,8 +752,13 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 		PSMX_CTXT_EP(fi_context) = ep_priv;
 	}
 
+#if (PSM_VERNO_MAJOR >= 2)
+	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+				&psm_tag2, buf, len, (void*)fi_context, &psm_req);
+#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 				psm_tag, buf, len, (void*)fi_context, &psm_req);
+#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -555,6 +778,9 @@ ssize_t psmx_tagged_send_no_flag_av_map(struct fid_ep *ep, const void *buf,
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2;
+#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -562,14 +788,22 @@ ssize_t psmx_tagged_send_no_flag_av_map(struct fid_ep *ep, const void *buf,
 
 	psm_epaddr = (psm_epaddr_t) dest_addr;
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
+#if (PSM_VERNO_MAJOR >= 2)
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+#endif
 
 	fi_context = context;
 	PSMX_CTXT_TYPE(fi_context) = PSMX_TSEND_CONTEXT;
 	PSMX_CTXT_USER(fi_context) = (void *)buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
+#if (PSM_VERNO_MAJOR >= 2)
+	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
+#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
+#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -588,6 +822,9 @@ ssize_t psmx_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2;
+#endif
 	struct fi_context *fi_context;
 	int err;
 	size_t idx;
@@ -601,14 +838,22 @@ ssize_t psmx_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 
 	psm_epaddr = av->psm_epaddrs[idx];
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
+#if (PSM_VERNO_MAJOR >= 2)
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+#endif
 
 	fi_context = context;
 	PSMX_CTXT_TYPE(fi_context) = PSMX_TSEND_CONTEXT;
 	PSMX_CTXT_USER(fi_context) = (void *)buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
+#if (PSM_VERNO_MAJOR >= 2)
+	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
+#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
+#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -626,6 +871,9 @@ ssize_t psmx_tagged_send_no_event_av_map(struct fid_ep *ep, const void *buf,
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2;
+#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -633,11 +881,19 @@ ssize_t psmx_tagged_send_no_event_av_map(struct fid_ep *ep, const void *buf,
 
 	psm_epaddr = (psm_epaddr_t) dest_addr;
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
+#if (PSM_VERNO_MAJOR >= 2)
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+#endif
 
 	fi_context = &ep_priv->nocomp_send_context;
 
+#if (PSM_VERNO_MAJOR >= 2)
+	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
+#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
+#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -655,6 +911,9 @@ ssize_t psmx_tagged_send_no_event_av_table(struct fid_ep *ep, const void *buf,
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2;
+#endif
 	struct fi_context *fi_context;
 	int err;
 	size_t idx;
@@ -668,11 +927,19 @@ ssize_t psmx_tagged_send_no_event_av_table(struct fid_ep *ep, const void *buf,
 
 	psm_epaddr = av->psm_epaddrs[idx];
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
+#if (PSM_VERNO_MAJOR >= 2)
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+#endif
 
 	fi_context = &ep_priv->nocomp_send_context;
 
+#if (PSM_VERNO_MAJOR >= 2)
+	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
+#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
+#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -686,6 +953,9 @@ ssize_t psmx_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf, si
 	struct psmx_fid_ep *ep_priv;
 	psm_epaddr_t psm_epaddr;
 	uint64_t psm_tag;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2;
+#endif
 	int err;
 
 	if (len > PSMX_INJECT_SIZE)
@@ -695,8 +965,15 @@ ssize_t psmx_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf, si
 
 	psm_epaddr = (psm_epaddr_t) dest_addr;
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
+#if (PSM_VERNO_MAJOR >= 2)
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+#endif
 
+#if (PSM_VERNO_MAJOR >= 2)
+	err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, 0, &psm_tag2, buf, len);
+#else
 	err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, 0, psm_tag, buf, len);
+#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -714,6 +991,9 @@ ssize_t psmx_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf, 
 	struct psmx_fid_av *av;
 	psm_epaddr_t psm_epaddr;
 	uint64_t psm_tag;
+#if (PSM_VERNO_MAJOR >= 2)
+	psm_mq_tag_t psm_tag2;
+#endif
 	int err;
 	size_t idx;
 
@@ -729,8 +1009,15 @@ ssize_t psmx_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf, 
 
 	psm_epaddr = av->psm_epaddrs[idx];
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
+#if (PSM_VERNO_MAJOR >= 2)
+	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
+#endif
 
+#if (PSM_VERNO_MAJOR >= 2)
+	err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, 0, &psm_tag2, buf, len);
+#else
 	err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, 0, psm_tag, buf, len);
+#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -749,8 +1036,13 @@ static ssize_t psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
+#if (PSM_VERNO_MAJOR >= 2)
+	return _psmx_tagged_send(ep, buf, len, desc, dest_addr, tag, context,
+				 ep_priv->flags, 0);
+#else
 	return _psmx_tagged_send(ep, buf, len, desc, dest_addr, tag, context,
 				 ep_priv->flags);
+#endif
 }
 
 static ssize_t psmx_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
@@ -774,9 +1066,15 @@ static ssize_t psmx_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged
 		len = 0;
 	}
 
+#if (PSM_VERNO_MAJOR >= 2)
 	return _psmx_tagged_send(ep, buf, len,
-				   msg->desc ? msg->desc[0] : NULL, msg->addr,
-				   msg->tag, msg->context, flags);
+				 msg->desc ? msg->desc[0] : NULL, msg->addr,
+				 msg->tag, msg->context, flags, (uint32_t) msg->data);
+#else
+	return _psmx_tagged_send(ep, buf, len,
+				 msg->desc ? msg->desc[0] : NULL, msg->addr,
+				 msg->tag, msg->context, flags);
+#endif
 }
 
 static ssize_t psmx_tagged_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
@@ -923,9 +1221,28 @@ static ssize_t psmx_tagged_inject(struct fid_ep *ep, const void *buf, size_t len
 
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
+#if (PSM_VERNO_MAJOR >= 2)
+	return _psmx_tagged_send(ep, buf, len, NULL, dest_addr, tag, NULL,
+				 ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION, 0);
+#else
 	return _psmx_tagged_send(ep, buf, len, NULL, dest_addr, tag, NULL,
 				 ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION);
+#endif
 }
+
+#if (PSM_VERNO_MAJOR >= 2)
+static ssize_t psmx_tagged_senddata(struct fid_ep *ep, const void *buf, size_t len,
+                                    void *desc, uint64_t data, fi_addr_t dest_addr,
+                                    uint64_t tag, void *context)
+{
+	struct psmx_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
+
+	return _psmx_tagged_send(ep, buf, len, desc, dest_addr, tag, context,
+				 ep_priv->flags,  (uint32_t)data);
+}
+#endif
 
 /* general case */
 struct fi_ops_tagged psmx_tagged_ops = {
@@ -937,7 +1254,11 @@ struct fi_ops_tagged psmx_tagged_ops = {
 	.sendv = psmx_tagged_sendv,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject,
+#if (PSM_VERNO_MAJOR >= 2)
+	.senddata = psmx_tagged_senddata,
+#else
 	.senddata = fi_no_tagged_senddata,
+#endif
 	.injectdata = fi_no_tagged_injectdata,
 };
 
@@ -951,7 +1272,11 @@ struct fi_ops_tagged psmx_tagged_ops_no_flag_av_map = {
 	.sendv = psmx_tagged_sendv_no_flag_av_map,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_map,
+#if (PSM_VERNO_MAJOR >= 2)
+	.senddata = psmx_tagged_senddata,
+#else
 	.senddata = fi_no_tagged_senddata,
+#endif
 	.injectdata = fi_no_tagged_injectdata,
 };
 
@@ -965,7 +1290,11 @@ struct fi_ops_tagged psmx_tagged_ops_no_flag_av_table = {
 	.sendv = psmx_tagged_sendv_no_flag_av_table,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_table,
+#if (PSM_VERNO_MAJOR >= 2)
+	.senddata = psmx_tagged_senddata,
+#else
 	.senddata = fi_no_tagged_senddata,
+#endif
 	.injectdata = fi_no_tagged_injectdata,
 };
 
@@ -979,7 +1308,11 @@ struct fi_ops_tagged psmx_tagged_ops_no_event_av_map = {
 	.sendv = psmx_tagged_sendv_no_event_av_map,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_map,
+#if (PSM_VERNO_MAJOR >= 2)
+	.senddata = psmx_tagged_senddata,
+#else
 	.senddata = fi_no_tagged_senddata,
+#endif
 	.injectdata = fi_no_tagged_injectdata,
 };
 
@@ -993,7 +1326,11 @@ struct fi_ops_tagged psmx_tagged_ops_no_event_av_table = {
 	.sendv = psmx_tagged_sendv_no_event_av_table,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_table,
+#if (PSM_VERNO_MAJOR >= 2)
+	.senddata = psmx_tagged_senddata,
+#else
 	.senddata = fi_no_tagged_senddata,
+#endif
 	.injectdata = fi_no_tagged_injectdata,
 };
 
@@ -1007,7 +1344,11 @@ struct fi_ops_tagged psmx_tagged_ops_no_send_event_av_map = {
 	.sendv = psmx_tagged_sendv_no_event_av_map,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_map,
+#if (PSM_VERNO_MAJOR >= 2)
+	.senddata = psmx_tagged_senddata,
+#else
 	.senddata = fi_no_tagged_senddata,
+#endif
 	.injectdata = fi_no_tagged_injectdata,
 };
 
@@ -1021,7 +1362,11 @@ struct fi_ops_tagged psmx_tagged_ops_no_send_event_av_table = {
 	.sendv = psmx_tagged_sendv_no_event_av_table,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_table,
+#if (PSM_VERNO_MAJOR >= 2)
+	.senddata = psmx_tagged_senddata,
+#else
 	.senddata = fi_no_tagged_senddata,
+#endif
 	.injectdata = fi_no_tagged_injectdata,
 };
 
@@ -1035,7 +1380,11 @@ struct fi_ops_tagged psmx_tagged_ops_no_recv_event_av_map = {
 	.sendv = psmx_tagged_sendv_no_flag_av_map,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_map,
+#if (PSM_VERNO_MAJOR >= 2)
+	.senddata = psmx_tagged_senddata,
+#else
 	.senddata = fi_no_tagged_senddata,
+#endif
 	.injectdata = fi_no_tagged_injectdata,
 };
 
@@ -1049,6 +1398,10 @@ struct fi_ops_tagged psmx_tagged_ops_no_recv_event_av_table = {
 	.sendv = psmx_tagged_sendv_no_flag_av_table,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_table,
+#if (PSM_VERNO_MAJOR >= 2)
+	.senddata = psmx_tagged_senddata,
+#else
 	.senddata = fi_no_tagged_senddata,
+#endif
 	.injectdata = fi_no_tagged_injectdata,
 };

--- a/prov/psm/src/psmx_util.c
+++ b/prov/psm/src/psmx_util.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/psm/src/version.h
+++ b/prov/psm/src/version.h
@@ -30,35 +30,10 @@
  * SOFTWARE.
  */
 
-#include "psmx.h"
+#ifndef _FI_PSM_VERSION_H_
+#define _FI_PSM_VERSION_H_
 
-static int psmx_cm_getname(fid_t fid, void *addr, size_t *addrlen)
-{
-	struct psmx_fid_ep *ep;
+#define PSMX_VERSION	1
 
-	ep = container_of(fid, struct psmx_fid_ep, ep.fid);
-	if (!ep->domain)
-		return -FI_EBADF;
-
-	if (*addrlen < sizeof(psm_epid_t)) {
-		*addrlen = sizeof(psm_epid_t);
-		return -FI_ETOOSMALL;
-	}
-
-	*(psm_epid_t *)addr = ep->domain->psm_epid;
-	*addrlen = sizeof(psm_epid_t);
-
-	return 0;
-}
-
-struct fi_ops_cm psmx_cm_ops = {
-	.size = sizeof(struct fi_ops_cm),
-	.getname = psmx_cm_getname,
-	.getpeer = fi_no_getpeer,
-	.connect = fi_no_connect,
-	.listen = fi_no_listen,
-	.accept = fi_no_accept,
-	.reject = fi_no_reject,
-	.shutdown = fi_no_shutdown,
-};
+#endif
 

--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -1,0 +1,34 @@
+dnl Configury specific to the libfabric PSM2 provider
+
+dnl Called to configure this provider
+dnl
+dnl Arguments:
+dnl
+dnl $1: action if configured successfully
+dnl $2: action if not configured successfully
+dnl
+AC_DEFUN([FI_PSM2_CONFIGURE],[
+	# Determine if we can support the psm2 provider
+	psm2_happy=0
+	AS_IF([test x"$enable_psm2" != x"no"],
+	      [FI_CHECK_PACKAGE([psm2],
+				[psm2.h],
+				[psm2],
+				[psm_init],
+				[],
+				[],
+				[],
+				[psm2_happy=1],
+				[psm2_happy=0])
+	      ])
+
+	AS_IF([test $psm2_happy -eq 1], [$1], [$2])
+
+	psm2_CPPFLAGS="$CPPFLAGS $psm2_CPPFLAGS"
+	psm2_LDFLAGS="$LDFLAGS $psm2_LDFLAGS"
+	psm2_LIBS="$LIBS $psm2_LIBS"
+	CPPFLAGS=
+	LDFLAGS=
+	LIBS=
+])
+

--- a/prov/psm2/src/psmx.h
+++ b/prov/psm2/src/psmx.h
@@ -1,0 +1,1 @@
+../../psm/src/psmx.h

--- a/prov/psm2/src/psmx_am.c
+++ b/prov/psm2/src/psmx_am.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_am.c

--- a/prov/psm2/src/psmx_atomic.c
+++ b/prov/psm2/src/psmx_atomic.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_atomic.c

--- a/prov/psm2/src/psmx_av.c
+++ b/prov/psm2/src/psmx_av.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_av.c

--- a/prov/psm2/src/psmx_cm.c
+++ b/prov/psm2/src/psmx_cm.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_cm.c

--- a/prov/psm2/src/psmx_cntr.c
+++ b/prov/psm2/src/psmx_cntr.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_cntr.c

--- a/prov/psm2/src/psmx_cq.c
+++ b/prov/psm2/src/psmx_cq.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_cq.c

--- a/prov/psm2/src/psmx_domain.c
+++ b/prov/psm2/src/psmx_domain.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_domain.c

--- a/prov/psm2/src/psmx_ep.c
+++ b/prov/psm2/src/psmx_ep.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_ep.c

--- a/prov/psm2/src/psmx_eq.c
+++ b/prov/psm2/src/psmx_eq.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_eq.c

--- a/prov/psm2/src/psmx_init.c
+++ b/prov/psm2/src/psmx_init.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_init.c

--- a/prov/psm2/src/psmx_mr.c
+++ b/prov/psm2/src/psmx_mr.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_mr.c

--- a/prov/psm2/src/psmx_msg.c
+++ b/prov/psm2/src/psmx_msg.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_msg.c

--- a/prov/psm2/src/psmx_msg2.c
+++ b/prov/psm2/src/psmx_msg2.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_msg2.c

--- a/prov/psm2/src/psmx_poll.c
+++ b/prov/psm2/src/psmx_poll.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_poll.c

--- a/prov/psm2/src/psmx_rma.c
+++ b/prov/psm2/src/psmx_rma.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_rma.c

--- a/prov/psm2/src/psmx_tagged.c
+++ b/prov/psm2/src/psmx_tagged.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_tagged.c

--- a/prov/psm2/src/psmx_util.c
+++ b/prov/psm2/src/psmx_util.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_util.c

--- a/prov/psm2/src/psmx_wait.c
+++ b/prov/psm2/src/psmx_wait.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_wait.c

--- a/prov/psm2/src/rename.h
+++ b/prov/psm2/src/rename.h
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_PSM_RENAME_H_
+#define _FI_PSM_RENAME_H_
+
+#define psmx_active_fabric psmx2_active_fabric
+#define psmx_am_ack_rma psmx2_am_ack_rma
+#define psmx_am_async_progress psmx2_am_async_progress
+#define psmx_am_atomic_completion psmx2_am_atomic_completion
+#define psmx_am_atomic_handler psmx2_am_atomic_handler
+#define psmx_am_enqueue_recv psmx2_am_enqueue_recv
+#define psmx_am_enqueue_rma psmx2_am_enqueue_rma
+#define psmx_am_enqueue_send psmx2_am_enqueue_send
+#define psmx_am_enqueue_unexp psmx2_am_enqueue_unexp
+#define psmx_am_fini psmx2_am_fini
+#define psmx_am_handlers psmx2_am_handlers
+#define psmx_am_handlers_idx psmx2_am_handlers_idx
+#define psmx_am_handlers_initialized psmx2_am_handlers_initialized
+#define psmx_am_init psmx2_am_init
+#define psmx_am_msg_handler psmx2_am_msg_handler
+#define psmx_am_param psmx2_am_param
+#define psmx_am_process_rma psmx2_am_process_rma
+#define psmx_am_process_send psmx2_am_process_send
+#define psmx_am_progress psmx2_am_progress
+#define psmx_am_request psmx2_am_request
+#define psmx_am_rma_handler psmx2_am_rma_handler
+#define psmx_am_search_and_dequeue_recv psmx2_am_search_and_dequeue_recv
+#define psmx_am_search_and_dequeue_unexp psmx2_am_search_and_dequeue_unexp
+#define _psmx_atomic_compwrite _psmx2_atomic_compwrite
+#define psmx_atomic_compwrite psmx2_atomic_compwrite
+#define psmx_atomic_compwritemsg psmx2_atomic_compwritemsg
+#define psmx_atomic_compwritev psmx2_atomic_compwritev
+#define psmx_atomic_compwritevalid psmx2_atomic_compwritevalid
+#define psmx_atomic_do_compwrite psmx2_atomic_do_compwrite
+#define psmx_atomic_do_readwrite psmx2_atomic_do_readwrite
+#define psmx_atomic_do_write psmx2_atomic_do_write
+#define psmx_atomic_inject psmx2_atomic_inject
+#define psmx_atomic_lock psmx2_atomic_lock
+#define psmx_atomic_ops psmx2_atomic_ops
+#define _psmx_atomic_readwrite _psmx2_atomic_readwrite
+#define psmx_atomic_readwrite psmx2_atomic_readwrite
+#define psmx_atomic_readwritemsg psmx2_atomic_readwritemsg
+#define psmx_atomic_readwritev psmx2_atomic_readwritev
+#define psmx_atomic_readwritevalid psmx2_atomic_readwritevalid
+#define psmx_atomic_self psmx2_atomic_self
+#define _psmx_atomic_write _psmx2_atomic_write
+#define psmx_atomic_write psmx2_atomic_write
+#define psmx_atomic_writemsg psmx2_atomic_writemsg
+#define psmx_atomic_writev psmx2_atomic_writev
+#define psmx_atomic_writevalid psmx2_atomic_writevalid
+#define psmx_av_bind psmx2_av_bind
+#define psmx_av_check_table_size psmx2_av_check_table_size
+#define psmx_av_close psmx2_av_close
+#define psmx_av_insert psmx2_av_insert
+#define psmx_av_lookup psmx2_av_lookup
+#define psmx_av_open psmx2_av_open
+#define psmx_av_ops psmx2_av_ops
+#define psmx_av_remove psmx2_av_remove
+#define psmx_av_straddr psmx2_av_straddr
+#define psmx_cm_getname psmx2_cm_getname
+#define psmx_cm_ops psmx2_cm_ops
+#define psmx_cntr_add psmx2_cntr_add
+#define psmx_cntr_add_trigger psmx2_cntr_add_trigger
+#define psmx_cntr_check_trigger psmx2_cntr_check_trigger
+#define psmx_cntr_close psmx2_cntr_close
+#define psmx_cntr_control psmx2_cntr_control
+#define psmx_cntr_inc psmx2_cntr_inc
+#define psmx_cntr_open psmx2_cntr_open
+#define psmx_cntr_ops psmx2_cntr_ops
+#define psmx_cntr_read psmx2_cntr_read
+#define psmx_cntr_readerr psmx2_cntr_readerr
+#define psmx_cntr_set psmx2_cntr_set
+#define psmx_cntr_wait psmx2_cntr_wait
+#define psmx_context_type psmx2_context_type
+#define psmx_cq_close psmx2_cq_close
+#define psmx_cq_control psmx2_cq_control
+#define psmx_cq_create_event psmx2_cq_create_event
+#define psmx_cq_create_event_from_status psmx2_cq_create_event_from_status
+#define psmx_cq_dequeue_event psmx2_cq_dequeue_event
+#define psmx_cq_enqueue_event psmx2_cq_enqueue_event
+#define psmx_cq_event psmx2_cq_event
+#define psmx_cq_get_event_src_addr psmx2_cq_get_event_src_addr
+#define psmx_cq_open psmx2_cq_open
+#define psmx_cq_ops psmx2_cq_ops
+#define psmx_cq_poll_mq psmx2_cq_poll_mq
+#define psmx_cq_read psmx2_cq_read
+#define psmx_cq_readerr psmx2_cq_readerr
+#define psmx_cq_readfrom psmx2_cq_readfrom
+#define psmx_cq_signal psmx2_cq_signal
+#define psmx_cq_sread psmx2_cq_sread
+#define psmx_cq_sreadfrom psmx2_cq_sreadfrom
+#define psmx_cq_strerror psmx2_cq_strerror
+#define psmx_domain_check_features psmx2_domain_check_features
+#define psmx_domain_close psmx2_domain_close
+#define psmx_domain_disable_ep psmx2_domain_disable_ep
+#define psmx_domain_enable_ep psmx2_domain_enable_ep
+#define psmx_domain_open psmx2_domain_open
+#define psmx_domain_ops psmx2_domain_ops
+#define psmx_env psmx2_env
+#define psmx_epaddr_context psmx2_epaddr_context
+#define psmx_ep_bind psmx2_ep_bind
+#define psmx_ep_cancel psmx2_ep_cancel
+#define psmx_ep_close psmx2_ep_close
+#define psmx_ep_control psmx2_ep_control
+#define psmx_ep_getopt psmx2_ep_getopt
+#define psmx_epid_to_epaddr psmx2_epid_to_epaddr
+#define psmx_ep_open psmx2_ep_open
+#define psmx_ep_ops psmx2_ep_ops
+#define psmx_ep_optimize_ops psmx2_ep_optimize_ops
+#define psmx_ep_setopt psmx2_ep_setopt
+#define psmx_eq_alloc_event psmx2_eq_alloc_event
+#define psmx_eq_close psmx2_eq_close
+#define psmx_eq_control psmx2_eq_control
+#define psmx_eq_create_event psmx2_eq_create_event
+#define psmx_eq_dequeue_error psmx2_eq_dequeue_error
+#define psmx_eq_dequeue_event psmx2_eq_dequeue_event
+#define psmx_eq_enqueue_event psmx2_eq_enqueue_event
+#define psmx_eq_event psmx2_eq_event
+#define psmx_eq_free_event psmx2_eq_free_event
+#define psmx_eq_open psmx2_eq_open
+#define psmx_eq_ops psmx2_eq_ops
+#define psmx_eq_peek_event psmx2_eq_peek_event
+#define psmx_eq_read psmx2_eq_read
+#define psmx_eq_readerr psmx2_eq_readerr
+#define psmx_eq_sread psmx2_eq_sread
+#define psmx_eq_strerror psmx2_eq_strerror
+#define psmx_eq_write psmx2_eq_write
+#define psmx_errno psmx2_errno
+#define psmx_errno_table psmx2_errno_table
+#define psmx_fabric psmx2_fabric
+#define psmx_fabric_close psmx2_fabric_close
+#define psmx_fabric_fi_ops psmx2_fabric_fi_ops
+#define psmx_fabric_ops psmx2_fabric_ops
+#define psmx_fid_av psmx2_fid_av
+#define psmx_fid_cntr psmx2_fid_cntr
+#define psmx_fid_cq psmx2_fid_cq
+#define psmx_fid_domain psmx2_fid_domain
+#define psmx_fid_ep psmx2_fid_ep
+#define psmx_fid_eq psmx2_fid_eq
+#define psmx_fid_fabric psmx2_fid_fabric
+#define psmx_fid_mr psmx2_fid_mr
+#define psmx_fid_poll psmx2_fid_poll
+#define psmx_fid_stx psmx2_fid_stx
+#define psmx_fid_wait psmx2_fid_wait
+#define psmx_fini psmx2_fini
+#define psmx_fi_ops psmx2_fi_ops
+#define psmx_fi_ops_stx psmx2_fi_ops_stx
+#define psmx_getinfo psmx2_getinfo
+#define psmx_get_uuid psmx2_get_uuid
+#define psmx_info psmx2_info
+#define psmx_init_count psmx2_init_count
+#define psmx_init_env psmx2_init_env
+#define psmx_inject psmx2_inject
+#define psmx_inject2 psmx2_inject2
+#define psmx_mr_bind psmx2_mr_bind
+#define psmx_mr_close psmx2_mr_close
+#define psmx_mr_hash psmx2_mr_hash
+#define psmx_mr_hash_add psmx2_mr_hash_add
+#define psmx_mr_hash_del psmx2_mr_hash_del
+#define psmx_mr_hash_entry psmx2_mr_hash_entry
+#define psmx_mr_hash_get psmx2_mr_hash_get
+#define psmx_mr_normalize_iov psmx2_mr_normalize_iov
+#define psmx_mr_ops psmx2_mr_ops
+#define psmx_mr_reg psmx2_mr_reg
+#define psmx_mr_regattr psmx2_mr_regattr
+#define psmx_mr_regv psmx2_mr_regv
+#define psmx_mr_validate psmx2_mr_validate
+#define psmx_msg2_ops psmx2_msg2_ops
+#define psmx_msg_ops psmx2_msg_ops
+#define psmx_multi_recv psmx2_multi_recv
+#define psmx_name_server psmx2_name_server
+#define psmx_pi psmx2_pi
+#define psmx_poll_add psmx2_poll_add
+#define psmx_poll_close psmx2_poll_close
+#define psmx_poll_del psmx2_poll_del
+#define psmx_poll_list psmx2_poll_list
+#define psmx_poll_open psmx2_poll_open
+#define psmx_poll_ops psmx2_poll_ops
+#define psmx_poll_poll psmx2_poll_poll
+#define psmx_process_trigger psmx2_process_trigger
+#define psmx_progress psmx2_progress
+#define psmx_prov psmx2_prov
+#define psmx_query_mpi psmx2_query_mpi
+#define _psmx_read _psmx2_read
+#define psmx_read psmx2_read
+#define psmx_readmsg psmx2_readmsg
+#define psmx_readv psmx2_readv
+#define _psmx_recv _psmx2_recv
+#define psmx_recv psmx2_recv
+#define _psmx_recv2 _psmx2_recv2
+#define psmx_recv2 psmx2_recv2
+#define psmx_recvmsg psmx2_recvmsg
+#define psmx_recvmsg2 psmx2_recvmsg2
+#define psmx_recvv psmx2_recvv
+#define psmx_recvv2 psmx2_recvv2
+#define psmx_req_queue psmx2_req_queue
+#define psmx_reserve_tag_bits psmx2_reserve_tag_bits
+#define psmx_resolve_name psmx2_resolve_name
+#define psmx_rma_ops psmx2_rma_ops
+#define psmx_rma_self psmx2_rma_self
+#define psmx_rx_size_left psmx2_rx_size_left
+#define _psmx_send _psmx2_send
+#define psmx_send psmx2_send
+#define _psmx_send2 _psmx2_send2
+#define psmx_send2 psmx2_send2
+#define psmx_senddata psmx2_senddata
+#define psmx_sendmsg psmx2_sendmsg
+#define psmx_sendmsg2 psmx2_sendmsg2
+#define psmx_sendv psmx2_sendv
+#define psmx_sendv2 psmx2_sendv2
+#define psmx_set_epaddr_context psmx2_set_epaddr_context
+#define psmx_string_to_uuid psmx2_string_to_uuid
+#define psmx_stx_close psmx2_stx_close
+#define psmx_stx_ctx psmx2_stx_ctx
+#define psmx_tagged_inject psmx2_tagged_inject
+#define psmx_tagged_inject_no_flag_av_map psmx2_tagged_inject_no_flag_av_map
+#define psmx_tagged_inject_no_flag_av_table psmx2_tagged_inject_no_flag_av_table
+#define psmx_tagged_ops psmx2_tagged_ops
+#define psmx_tagged_ops_no_event_av_map psmx2_tagged_ops_no_event_av_map
+#define psmx_tagged_ops_no_event_av_table psmx2_tagged_ops_no_event_av_table
+#define psmx_tagged_ops_no_flag_av_map psmx2_tagged_ops_no_flag_av_map
+#define psmx_tagged_ops_no_flag_av_table psmx2_tagged_ops_no_flag_av_table
+#define psmx_tagged_ops_no_recv_event_av_map psmx2_tagged_ops_no_recv_event_av_map
+#define psmx_tagged_ops_no_recv_event_av_table psmx2_tagged_ops_no_recv_event_av_table
+#define psmx_tagged_ops_no_send_event_av_map psmx2_tagged_ops_no_send_event_av_map
+#define psmx_tagged_ops_no_send_event_av_table psmx2_tagged_ops_no_send_event_av_table
+#define _psmx_tagged_peek _psmx2_tagged_peek
+#define _psmx_tagged_recv _psmx2_tagged_recv
+#define psmx_tagged_recv psmx2_tagged_recv
+#define psmx_tagged_recvmsg psmx2_tagged_recvmsg
+#define psmx_tagged_recv_no_event psmx2_tagged_recv_no_event
+#define psmx_tagged_recv_no_event_av_map psmx2_tagged_recv_no_event_av_map
+#define psmx_tagged_recv_no_event_av_table psmx2_tagged_recv_no_event_av_table
+#define psmx_tagged_recv_no_flag psmx2_tagged_recv_no_flag
+#define psmx_tagged_recv_no_flag_av_map psmx2_tagged_recv_no_flag_av_map
+#define psmx_tagged_recv_no_flag_av_table psmx2_tagged_recv_no_flag_av_table
+#define psmx_tagged_recvv psmx2_tagged_recvv
+#define psmx_tagged_recvv_no_event psmx2_tagged_recvv_no_event
+#define psmx_tagged_recvv_no_flag psmx2_tagged_recvv_no_flag
+#define _psmx_tagged_send _psmx2_tagged_send
+#define psmx_tagged_send psmx2_tagged_send
+#define psmx_tagged_senddata psmx2_tagged_senddata
+#define psmx_tagged_sendmsg psmx2_tagged_sendmsg
+#define psmx_tagged_send_no_event_av_map psmx2_tagged_send_no_event_av_map
+#define psmx_tagged_send_no_event_av_table psmx2_tagged_send_no_event_av_table
+#define psmx_tagged_send_no_flag_av_map psmx2_tagged_send_no_flag_av_map
+#define psmx_tagged_send_no_flag_av_table psmx2_tagged_send_no_flag_av_table
+#define psmx_tagged_sendv psmx2_tagged_sendv
+#define psmx_tagged_sendv_no_event_av_map psmx2_tagged_sendv_no_event_av_map
+#define psmx_tagged_sendv_no_event_av_table psmx2_tagged_sendv_no_event_av_table
+#define psmx_tagged_sendv_no_flag_av_map psmx2_tagged_sendv_no_flag_av_map
+#define psmx_tagged_sendv_no_flag_av_table psmx2_tagged_sendv_no_flag_av_table
+#define psmx_trigger psmx2_trigger
+#define psmx_triggered_op psmx2_triggered_op
+#define psmx_tx_size_left psmx2_tx_size_left
+#define psmx_unexp psmx2_unexp
+#define psmx_uuid_to_port psmx2_uuid_to_port
+#define psmx_wait_close psmx2_wait_close
+#define psmx_wait_cond psmx2_wait_cond
+#define psmx_wait_get_obj psmx2_wait_get_obj
+#define psmx_wait_init psmx2_wait_init
+#define psmx_wait_mutex psmx2_wait_mutex
+#define psmx_wait_open psmx2_wait_open
+#define psmx_wait_ops psmx2_wait_ops
+#define psmx_wait_progress psmx2_wait_progress
+#define psmx_wait_signal psmx2_wait_signal
+#define psmx_wait_start_progress psmx2_wait_start_progress
+#define psmx_wait_stop_progress psmx2_wait_stop_progress
+#define psmx_wait_thread psmx2_wait_thread
+#define psmx_wait_thread_busy psmx2_wait_thread_busy
+#define psmx_wait_thread_enabled psmx2_wait_thread_enabled
+#define psmx_wait_thread_ready psmx2_wait_thread_ready
+#define psmx_wait_wait psmx2_wait_wait
+#define _psmx_write _psmx2_write
+#define psmx_write psmx2_write
+#define psmx_writedata psmx2_writedata
+#define psmx_writemsg psmx2_writemsg
+#define psmx_writev psmx2_writev
+
+#endif

--- a/prov/psm2/src/update-rename-h.sh
+++ b/prov/psm2/src/update-rename-h.sh
@@ -1,3 +1,8 @@
+#!/bin/sh
+
+OUTFILE=rename.h
+
+cat <<EOF >$OUTFILE
 /*
  * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
  *
@@ -30,35 +35,17 @@
  * SOFTWARE.
  */
 
-#include "psmx.h"
+#ifndef _FI_PSM_RENAME_H_
+#define _FI_PSM_RENAME_H_
 
-static int psmx_cm_getname(fid_t fid, void *addr, size_t *addrlen)
-{
-	struct psmx_fid_ep *ep;
+EOF
 
-	ep = container_of(fid, struct psmx_fid_ep, ep.fid);
-	if (!ep->domain)
-		return -FI_EBADF;
+LIST=`grep --only-match --no-filename '[a-zA-Z0-9_]*psmx_[a-zA-Z0-9_]*' psmx*.[ch] | sort | uniq`
 
-	if (*addrlen < sizeof(psm_epid_t)) {
-		*addrlen = sizeof(psm_epid_t);
-		return -FI_ETOOSMALL;
-	}
+for ITEM in $LIST ; do
+	echo '#define' $ITEM ${ITEM/psmx_/psmx2_} >>$OUTFILE
+done
 
-	*(psm_epid_t *)addr = ep->domain->psm_epid;
-	*addrlen = sizeof(psm_epid_t);
-
-	return 0;
-}
-
-struct fi_ops_cm psmx_cm_ops = {
-	.size = sizeof(struct fi_ops_cm),
-	.getname = psmx_cm_getname,
-	.getpeer = fi_no_getpeer,
-	.connect = fi_no_connect,
-	.listen = fi_no_listen,
-	.accept = fi_no_accept,
-	.reject = fi_no_reject,
-	.shutdown = fi_no_shutdown,
-};
+echo >>$OUTFILE
+echo '#endif' >>$OUTFILE
 

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -30,35 +30,12 @@
  * SOFTWARE.
  */
 
-#include "psmx.h"
+#ifndef _FI_PSM_VERSION_H_
+#define _FI_PSM_VERSION_H_
 
-static int psmx_cm_getname(fid_t fid, void *addr, size_t *addrlen)
-{
-	struct psmx_fid_ep *ep;
+#define PSMX_VERSION	2
 
-	ep = container_of(fid, struct psmx_fid_ep, ep.fid);
-	if (!ep->domain)
-		return -FI_EBADF;
+#include "rename.h"
 
-	if (*addrlen < sizeof(psm_epid_t)) {
-		*addrlen = sizeof(psm_epid_t);
-		return -FI_ETOOSMALL;
-	}
-
-	*(psm_epid_t *)addr = ep->domain->psm_epid;
-	*addrlen = sizeof(psm_epid_t);
-
-	return 0;
-}
-
-struct fi_ops_cm psmx_cm_ops = {
-	.size = sizeof(struct fi_ops_cm),
-	.getname = psmx_cm_getname,
-	.getpeer = fi_no_getpeer,
-	.connect = fi_no_connect,
-	.listen = fi_no_listen,
-	.accept = fi_no_accept,
-	.reject = fi_no_reject,
-	.shutdown = fi_no_shutdown,
-};
+#endif
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -389,6 +389,7 @@ libdl_done:
 #endif
 
 	fi_register_provider(PSM_INIT, NULL);
+	fi_register_provider(PSM2_INIT, NULL);
 	fi_register_provider(USNIC_INIT, NULL);
 	fi_register_provider(VERBS_INIT, NULL);
         /* Initialize the sockets provider last.  This will result in


### PR DESCRIPTION
(1) use a common code bases for both PSM and PSM2;
(2) different provider names are used: "psm" and "psm2";
(3) the psm and psm2 providers can be enabled in the same build,
    as long as the proper path is specified in the "--enable"
    options;
(4) at run time, only one of the two providers can succeed in
    initialization, depending on the actual PSM library in use.

Sigoed-off-by: jianxin xiong <jianxin.xiong@intel.com>