### PR TITLE
Makefile.am: remove bogus psm2/src/makefile entry

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -310,7 +310,6 @@ endif HAVE_PSM
 
 if HAVE_PSM2
 _psm2_files = \
-	prov/psm2/src/makefile \
 	prov/psm2/src/version.h \
 	prov/psm2/src/psmx.h \
 	prov/psm2/src/psmx_init.c \


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@j-xiong FYI.  Looks like a stale entry left over from edits on PR #1242.