### PR TITLE
Cleanup atomic definitions

### DIFF
--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -292,42 +292,42 @@ addr[i] = buf[i]
 *FI_CSWAP*
 : Compare values and if equal swap with data
 {% highlight c %}
-if (addr[i] == compare[i])
+if (compare[i] == addr[i])
     addr[i] = buf[i]
 {% endhighlight %}
 
 *FI_CSWAP_NE*
 : Compare values and if not equal swap with data
 {% highlight c %}
-if (addr[i] != compare[i])
+if (compare[i] != addr[i])
     addr[i] = buf[i]
 {% endhighlight %}
 
 *FI_CSWAP_LE*
 : Compare values and if less than or equal swap with data
 {% highlight c %}
-if (addr[i] <= compare[i])
+if (compare[i] <= addr[i])
     addr[i] = buf[i]
 {% endhighlight %}
 
 *FI_CSWAP_LT*
 : Compare values and if less than swap with data
 {% highlight c %}
-if (addr[i] < compare[i])
+if (compare[i] < addr[i])
     addr[i] = buf[i]
 {% endhighlight %}
 
 *FI_CSWAP_GE*
 : Compare values and if greater than or equal swap with data
 {% highlight c %}
-if (addr[i] >= compare[i])
+if (compare[i] >= addr[i])
     addr[i] = buf[i]
 {% endhighlight %}
 
 *FI_CSWAP_GT*
 : Compare values and if greater than swap with data
 {% highlight c %}
-if (addr[i] > compare[i])
+if (compare[i] > addr[i])
     addr[i] = buf[i]
 {% endhighlight %}
 

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -150,7 +150,7 @@ static pthread_mutex_t	psmx_atomic_lock = PTHREAD_MUTEX_INITIALIZER;
 			pthread_mutex_lock(&psmx_atomic_lock); \
 			for (i=0; i<(cnt); i++) { \
 				r[i] = d[i]; \
-				if (d[i] CMP_OP c[i]) \
+				if (c[i] CMP_OP d[i]) \
 					d[i] = s[i]; \
 			} \
 			pthread_mutex_unlock(&psmx_atomic_lock); \


### PR DESCRIPTION
The PSM and sockets provider differ in their implementations
of the atomic compare-swap operations.  For example, the PSM
provider does this for CSWAP_LT:

   if remote buffer < compare value then
      remote buffer = data value

whereas the sockets provider implements:

   if compare value < remote buffer then
      remote buffer = data value

Other CSWAP functions are similar.  The PSM provider matches
the implementation defined by the man pages.  However, this
gets more confusing because the man pages define this for MIN

   if compare value < remote buffer then
      remote buffer = data value

MAX is similar.  So the man pages are inconsistent in how atomics
are defined, and the providers differ in the implementation.  The
'natural' or expected behavior for atomics is more closely aligned
with the MIN/MAX definition than the CSWAP definitions.

We use the socket provider implementation as the 'correct' behavior.
The man pages are updated to reflect the actual behavior, with the
PSM provider updated to support the new definitions.

There are no known users of the atomic definitions at this point,
so this should be a relatively 'safe' change.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>