### PR TITLE
sockets: avoid empty "if" body in macro expansion

### DIFF
--- a/include/rdma/fi_log.h
+++ b/include/rdma/fi_log.h
@@ -89,7 +89,8 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 #define FI_DBG(prov, subsystem, ...)					\
 	FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
 #else
-#define FI_DBG(prov_name, subsystem, ...)
+#define FI_DBG(prov_name, subsystem, ...)				\
+	do {} while (0)
 #endif
 
 #ifdef __cplusplus

--- a/prov/sockets/src/sock_util.h
+++ b/prov/sockets/src/sock_util.h
@@ -46,8 +46,8 @@ extern int sock_pe_waittime;
 extern int sock_dgram_drop_rate;
 #endif
 
-#define _SOCK_LOG_DBG(subsys, ...) FI_DBG(&sock_prov, subsys, __VA_ARGS__);
-#define _SOCK_LOG_ERROR(subsys, ...) FI_WARN(&sock_prov, subsys, __VA_ARGS__);
+#define _SOCK_LOG_DBG(subsys, ...) FI_DBG(&sock_prov, subsys, __VA_ARGS__)
+#define _SOCK_LOG_ERROR(subsys, ...) FI_WARN(&sock_prov, subsys, __VA_ARGS__)
 
 static inline int sock_drop_packet(struct sock_ep *sock_ep)
 {	


### PR DESCRIPTION
This prevents this warning from GCC with certain flags (or sometimes
certain versions):
```
warning: suggest braces around empty body in an 'if' statement [-Wempty-body]
```

Signed-off-by: Dave Goodell <dgoodell@cisco.com>