### PR TITLE
usnic: fix warning from keyword ordering

### DIFF
--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -891,7 +891,7 @@ usdf_msg_tx_progress(struct usdf_tx *tx)
 	}
 }
 
-static void inline
+static inline void
 usdf_msg_recv_complete_err(struct usdf_ep *ep, struct usdf_msg_qe *rqe,
 			int status)
 {
@@ -905,7 +905,7 @@ usdf_msg_recv_complete_err(struct usdf_ep *ep, struct usdf_msg_qe *rqe,
 	usdf_msg_put_rx_rqe(rx, rqe);
 }
 
-static void inline
+static inline void
 usdf_msg_recv_complete(struct usdf_ep *ep, struct usdf_msg_qe *rqe)
 {
 	struct usdf_cq_hard *hcq;

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -1137,7 +1137,7 @@ usdf_rdm_tx_progress(struct usdf_tx *tx)
 	}
 }
 
-static void inline
+static inline void
 usdf_rdm_recv_complete(struct usdf_rx *rx, struct usdf_rdm_connection *rdc,
 		struct usdf_rdm_qe *rqe)
 {


### PR DESCRIPTION
Fixes this warning:
```
prov/usnic/src/usdf_msg.c:894:1: warning: 'inline' is not at beginning of declaration [-Wold-style-declaration]
```

Signed-off-by: Dave Goodell <dgoodell@cisco.com>