### PR TITLE
prov/psm: resolve symbol conflict between PSM and PSM2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -286,6 +286,7 @@ _psm_files = \
 	prov/psm/src/psmx_mr.c \
 	prov/psm/src/psmx_wait.c \
 	prov/psm/src/psmx_poll.c \
+	prov/psm/src/psmx_dl.c \
 	prov/psm/src/psmx_util.c
 
 if HAVE_PSM_DL
@@ -329,6 +330,7 @@ _psm2_files = \
 	prov/psm2/src/psmx_mr.c \
 	prov/psm2/src/psmx_wait.c \
 	prov/psm2/src/psmx_poll.c \
+	prov/psm2/src/psmx_dl.c \
 	prov/psm2/src/psmx_util.c
 
 if HAVE_PSM2_DL

--- a/prov/psm/configure.m4
+++ b/prov/psm/configure.m4
@@ -10,6 +10,7 @@ dnl
 AC_DEFUN([FI_PSM_CONFIGURE],[
 	# Determine if we can support the psm provider
 	psm_happy=0
+	psm_orig_LIBS=$psm_LIBS
 	AS_IF([test x"$enable_psm" != x"no"],
 	      [FI_CHECK_PACKAGE([psm],
 				[psm.h],
@@ -43,9 +44,22 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 
 	AS_IF([test $psm_happy -eq 1], [$1], [$2])
 
+	AC_MSG_CHECKING([if use dlopen to load PSM library])
+	AC_RUN_IFELSE([AC_LANG_SOURCE(
+				      [[
+				      int main()
+				      {
+					#ifndef PSMX_DL
+					#define PSMX_DL 1
+					#endif
+					return PSMX_DL ? 0 : 1;
+				      }
+				      ]]
+				     )],
+			[AC_MSG_RESULT([yes]); psm_LIBS=$psm_orig_LIBS];
+			[AC_MSG_RESULT([no]); psm_LDFLAGS="$LDFLAGS $psm_LDFLAGS"])
+
 	psm_CPPFLAGS="$CPPFLAGS $psm_CPPFLAGS"
-	psm_LDFLAGS="$LDFLAGS $psm_LDFLAGS"
-	psm_LIBS="$LIBS $psm_LIBS"
 	CPPFLAGS="$psm_orig_CPPFLAGS"
 	LDFLAGS="$psm_orig_LDFLAGS"
 ])

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -84,7 +84,128 @@ extern "C" {
 #include "fi_enosys.h"
 #include "fi_list.h"
 
+#ifndef PSMX_DL
+#define PSMX_DL			1
+#endif
+
+#if PSMX_DL
+#include <dlfcn.h>
+#define PSMX_CALL(func)	(*psmx_lib.func)
+struct psmx_lib {
+	psm_error_t	(*psm_init)(int *major, int *minor);
+	psm_error_t	(*psm_finalize)(void);
+	psm_error_t 	(*psm_error_register_handler)(psm_ep_t ep,
+				const psm_ep_errhandler_t errhandler);
+	psm_error_t	(*psm_error_defer)(psm_error_token_t err_token);
+	const char *	(*psm_error_get_string)(psm_error_t error);
+	uint64_t	(*psm_epid_nid)(psm_epid_t epid);
+	uint64_t	(*psm_epid_context)(psm_epid_t epid);
+	uint64_t	(*psm_epid_port)(psm_epid_t epid);
+	psm_error_t	(*psm_ep_num_devunits)(uint32_t *num_units);
+	void		(*psm_uuid_generate)(psm_uuid_t uuid);
+	psm_error_t	(*psm_ep_open)(const psm_uuid_t uuid,
+				       const struct psm_ep_open_opts *opts,
+				       psm_ep_t *ep, psm_epid_t *epid);
+	psm_error_t	(*psm_ep_open_opts_get_defaults)(struct psm_ep_open_opts *opts);
+	psm_error_t	(*psm_ep_epid_share_memory)(psm_ep_t ep, psm_epid_t epid,
+						    int *result);
+	psm_error_t	(*psm_ep_close)(psm_ep_t ep, int mode, int64_t timeout);
+	psm_error_t	(*psm_map_nid_hostname)(int num, const uint64_t *nids,
+						const char **hostnames);
+	psm_error_t	(*psm_ep_connect)(psm_ep_t ep, int num,
+					  const psm_epid_t *epids, const int *masks,
+					  psm_error_t *errors, psm_epaddr_t *epaddrs,
+					  int64_t timeout);
+	psm_error_t	(*psm_poll)(psm_ep_t ep);
+	void		(*psm_epaddr_setlabel)(psm_epaddr_t epaddr, const char *label);
+	void		(*psm_epaddr_setctxt)(psm_epaddr_t epaddr, void *ctxt);
+	void *		(*psm_epaddr_getctxt)(psm_epaddr_t epaddr);
+	psm_error_t	(*psm_setopt)(psm_component_t component,
+				      const void *obj, int optname,
+				      const void *optval, uint64_t optlen);
+	psm_error_t	(*psm_getopt)(psm_component_t component,
+				      const void *obj, int optname, void *optval,
+				      uint64_t *optlen);
+	psm_error_t	(*psm_ep_query)(int *num, psm_epinfo_t *epinfos);
+	psm_error_t	(*psm_ep_epid_lookup)(psm_epid_t epid, psm_epconn_t *epconn);
+	psm_error_t	(*psm_mq_init)(psm_ep_t ep, uint64_t tag_order_mask,
+				       const struct psm_optkey *opts, int numopts,
+				       psm_mq_t *mq);
+	psm_error_t	(*psm_mq_finalize)(psm_mq_t mq);
+	psm_error_t	(*psm_mq_getopt)(psm_mq_t mq, int opt, void *val);
+	psm_error_t	(*psm_mq_setopt)(psm_mq_t mq, int opt, const void *val);
+	psm_error_t	(*psm_mq_irecv)(psm_mq_t mq, uint64_t rtag,
+				        uint64_t rtagsel, uint32_t flags, void *buf,
+				        uint32_t len, void *ctxt, psm_mq_req_t *req);
+	psm_error_t	(*psm_mq_send)(psm_mq_t mq, psm_epaddr_t dest,
+				       uint32_t flags, uint64_t stag, const void *buf,
+				       uint32_t len);
+	psm_error_t	(*psm_mq_isend)(psm_mq_t mq, psm_epaddr_t dest,
+					uint32_t flags, uint64_t stag, const void *buf,
+					uint32_t len, void *ctxt, psm_mq_req_t *req);
+	psm_error_t	(*psm_mq_iprobe)(psm_mq_t mq, uint64_t rtag,
+					 uint64_t rtagsel, psm_mq_status_t *status);
+	psm_error_t	(*psm_mq_ipeek)(psm_mq_t mq, psm_mq_req_t *req,
+					psm_mq_status_t *status);
+	psm_error_t	(*psm_mq_wait)(psm_mq_req_t *req, psm_mq_status_t *status);
+	psm_error_t	(*psm_mq_test)(psm_mq_req_t *req, psm_mq_status_t *status);
+	psm_error_t	(*psm_mq_cancel)(psm_mq_req_t *req);
+	void		(*psm_mq_get_stats)(psm_mq_t mq, psm_mq_stats_t *stats);
+	psm_error_t	(*psm_am_register_handlers)(psm_ep_t ep,
+					const psm_am_handler_fn_t *handlers,
+					int num_handlers, int *handlers_idx);
+	psm_error_t	(*psm_am_request_short)(psm_epaddr_t epaddr, psm_handler_t handler,
+						psm_amarg_t *args, int nargs, void *src,
+						size_t len, int flags,
+						psm_am_completion_fn_t completion_fn,
+						void *completion_ctxt);
+	psm_error_t	(*psm_am_reply_short)(psm_am_token_t token, psm_handler_t handler,
+					      psm_amarg_t *args, int nargs, void *src,
+					      size_t len, int flags,
+					      psm_am_completion_fn_t completion_fn,
+					      void *completion_ctxt);
+	psm_error_t	(*psm_am_get_parameters)(psm_ep_t ep, struct psm_am_parameters *params,
+						 size_t sizeof_parameters_in,
+						 size_t *sizeof_parameters_out);
 #if (PSM_VERNO_MAJOR >= 2)
+	psm_error_t	(*psm_mq_irecv2)(psm_mq_t mq, psm_epaddr_t src,
+					 psm_mq_tag_t *rtag, psm_mq_tag_t *rtagsel,
+					 uint32_t flags, void *buf, uint32_t len,
+					 void *ctxt, psm_mq_req_t *req);
+	psm_error_t	(*psm_mq_imrecv)(psm_mq_t mq, uint32_t flags, void *buf,
+					 uint32_t len, void *ctxt, psm_mq_req_t *req);
+	psm_error_t	(*psm_mq_send2)(psm_mq_t mq, psm_epaddr_t dest,
+					uint32_t flags, psm_mq_tag_t *stag,
+					const void *buf, uint32_t len);
+	psm_error_t	(*psm_mq_isend2)(psm_mq_t mq, psm_epaddr_t dest,
+					 uint32_t flags, psm_mq_tag_t *stag,
+					 const void *buf, uint32_t len, void *ctxt,
+					 psm_mq_req_t *req);
+	psm_error_t	(*psm_mq_iprobe2)(psm_mq_t mq, psm_epaddr_t src,
+					  psm_mq_tag_t *rtag, psm_mq_tag_t *rtagsel,
+					  psm_mq_status2_t *status);
+	psm_error_t	(*psm_mq_improbe)(psm_mq_t mq, uint64_t rtag,
+					  uint64_t rtagsel, psm_mq_req_t *req,
+					  psm_mq_status_t *status);
+	psm_error_t	(*psm_mq_improbe2)(psm_mq_t mq, psm_epaddr_t src,
+					   psm_mq_tag_t *rtag, psm_mq_tag_t *rtagsel,
+					   psm_mq_req_t *req, psm_mq_status2_t *status);
+	psm_error_t	(*psm_mq_ipeek2)(psm_mq_t mq, psm_mq_req_t *req,
+					 psm_mq_status2_t *status);
+	psm_error_t	(*psm_mq_wait2)(psm_mq_req_t *req, psm_mq_status2_t *status);
+	psm_error_t	(*psm_mq_test2)(psm_mq_req_t *req, psm_mq_status2_t *status);
+	psm_error_t	(*psm_am_get_source)(psm_am_token_t token, psm_epaddr_t *epaddr_out);
+#endif
+};
+extern struct psmx_lib	psmx_lib;
+int	psmx_dl_open(void);
+void	psmx_dl_close(void);
+#else
+#define PSMX_CALL(func)	func
+#endif
+
+#if (PSM_VERNO_MAJOR >= 2)
+#define PSMX_LIB_NAME		"libpsm2.so"
 #define PSMX_PROV_NAME		"psm2"
 #define PSMX_PROV_NAME_LEN	4
 #define PSMX_DOMAIN_NAME	"psm2"
@@ -92,6 +213,7 @@ extern "C" {
 #define PSMX_FABRIC_NAME	"psm2"
 #define PSMX_FABRIC_NAME_LEN	4
 #else
+#define PSMX_LIB_NAME		"libpsm_infinipath.so"
 #define PSMX_PROV_NAME		"psm"
 #define PSMX_PROV_NAME_LEN	3
 #define PSMX_DOMAIN_NAME	"psm"

--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -127,12 +127,12 @@ int psmx_am_init(struct psmx_fid_domain *domain)
 	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
 
 	if (!psmx_am_handlers_initialized) {
-		err = psm_am_get_parameters(psm_ep, &psmx_am_param,
+		err = PSMX_CALL(psm_am_get_parameters)(psm_ep, &psmx_am_param,
 						sizeof(psmx_am_param), &size);
 		if (err)
 			return psmx_errno(err);
 
-		err = psm_am_register_handlers(psm_ep, psmx_am_handlers, 3,
+		err = PSMX_CALL(psm_am_register_handlers)(psm_ep, psmx_am_handlers, 3,
 						psmx_am_handlers_idx);
 		if (err)
 			return psmx_errno(err);

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -388,7 +388,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 #if (PSM_VERNO_MAJOR >= 2)
 	psm_epaddr_t epaddr;
 
-	psm_am_get_source(token, &epaddr);
+	PSMX_CALL(psm_am_get_source)(token, &epaddr);
 #endif
 
 	switch (args[0].u32w0 & PSMX_AM_OP_MASK) {
@@ -423,7 +423,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		rep_args[0].u32w0 = PSMX_AM_REP_ATOMIC_WRITE;
 		rep_args[0].u32w1 = op_error;
 		rep_args[1].u64 = args[1].u64;
-		err = psm_am_reply_short(token, PSMX_AM_ATOMIC_HANDLER,
+		err = PSMX_CALL(psm_am_reply_short)(token, PSMX_AM_ATOMIC_HANDLER,
 				rep_args, 2, NULL, 0, 0,
 				NULL, NULL );
 		break;
@@ -476,7 +476,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		rep_args[0].u32w0 = PSMX_AM_REP_ATOMIC_READWRITE;
 		rep_args[0].u32w1 = op_error;
 		rep_args[1].u64 = args[1].u64;
-		err = psm_am_reply_short(token, PSMX_AM_ATOMIC_HANDLER,
+		err = PSMX_CALL(psm_am_reply_short)(token, PSMX_AM_ATOMIC_HANDLER,
 				rep_args, 2, tmp_buf, (tmp_buf?len:0), 0,
 				psmx_am_atomic_completion, tmp_buf );
 		break;
@@ -521,7 +521,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		rep_args[0].u32w0 = PSMX_AM_REP_ATOMIC_READWRITE;
 		rep_args[0].u32w1 = op_error;
 		rep_args[1].u64 = args[1].u64;
-		err = psm_am_reply_short(token, PSMX_AM_ATOMIC_HANDLER,
+		err = PSMX_CALL(psm_am_reply_short)(token, PSMX_AM_ATOMIC_HANDLER,
 				rep_args, 2, tmp_buf, (tmp_buf?len:0), 0,
 				psmx_am_atomic_completion, tmp_buf );
 		break;
@@ -772,7 +772,7 @@ ssize_t _psmx_atomic_write(struct fid_ep *ep,
 		return -FI_EINVAL;
 	}
 
-	epaddr_context = psm_epaddr_getctxt((void *)dest_addr);
+	epaddr_context = PSMX_CALL(psm_epaddr_getctxt)((void *)dest_addr);
 	if (epaddr_context->epid == ep_priv->domain->psm_epid)
 		return psmx_atomic_self(PSMX_AM_REQ_ATOMIC_WRITE,
 					ep_priv, buf, count, desc,
@@ -816,7 +816,7 @@ ssize_t _psmx_atomic_write(struct fid_ep *ep,
 	args[3].u64 = key;
 	args[4].u32w0 = datatype;
 	args[4].u32w1 = op;
-	psm_am_request_short((psm_epaddr_t) dest_addr,
+	PSMX_CALL(psm_am_request_short)((psm_epaddr_t) dest_addr,
 				PSMX_AM_ATOMIC_HANDLER, args, 5,
 				(void *)buf, len, am_flags, NULL, NULL);
 
@@ -959,7 +959,7 @@ ssize_t _psmx_atomic_readwrite(struct fid_ep *ep,
 		return -FI_EINVAL;
 	}
 
-	epaddr_context = psm_epaddr_getctxt((void *)dest_addr);
+	epaddr_context = PSMX_CALL(psm_epaddr_getctxt)((void *)dest_addr);
 	if (epaddr_context->epid == ep_priv->domain->psm_epid)
 		return psmx_atomic_self(PSMX_AM_REQ_ATOMIC_READWRITE,
 					ep_priv, buf, count, desc,
@@ -1007,7 +1007,7 @@ ssize_t _psmx_atomic_readwrite(struct fid_ep *ep,
 	args[3].u64 = key;
 	args[4].u32w0 = datatype;
 	args[4].u32w1 = op;
-	psm_am_request_short((psm_epaddr_t) dest_addr,
+	PSMX_CALL(psm_am_request_short)((psm_epaddr_t) dest_addr,
 				PSMX_AM_ATOMIC_HANDLER, args, 5,
 				(void *)buf, (buf?len:0), am_flags, NULL, NULL);
 
@@ -1165,7 +1165,7 @@ ssize_t _psmx_atomic_compwrite(struct fid_ep *ep,
 		return -FI_EINVAL;
 	}
 
-	epaddr_context = psm_epaddr_getctxt((void *)dest_addr);
+	epaddr_context = PSMX_CALL(psm_epaddr_getctxt)((void *)dest_addr);
 	if (epaddr_context->epid == ep_priv->domain->psm_epid)
 		return psmx_atomic_self(PSMX_AM_REQ_ATOMIC_COMPWRITE,
 					ep_priv, buf, count, desc,
@@ -1224,7 +1224,7 @@ ssize_t _psmx_atomic_compwrite(struct fid_ep *ep,
 	args[3].u64 = key;
 	args[4].u32w0 = datatype;
 	args[4].u32w1 = op;
-	psm_am_request_short((psm_epaddr_t) dest_addr,
+	PSMX_CALL(psm_am_request_short)((psm_epaddr_t) dest_addr,
 				PSMX_AM_ATOMIC_HANDLER, args, 5,
 				tmp_buf ? tmp_buf : (void *)buf,
 				len * 2, am_flags,

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -378,13 +378,13 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 	void *event_buffer = count ? event_in : NULL;
 
 	while (1) {
-		err = psm_mq_ipeek(domain->psm_mq, &psm_req, NULL);
+		err = PSMX_CALL(psm_mq_ipeek)(domain->psm_mq, &psm_req, NULL);
 
 		if (err == PSM_OK) {
 #if (PSM_VERNO_MAJOR >= 2)
-			err = psm_mq_test2(&psm_req, &psm_status);
+			err = PSMX_CALL(psm_mq_test2)(&psm_req, &psm_status);
 #else
-			err = psm_mq_test(&psm_req, &psm_status);
+			err = PSMX_CALL(psm_mq_test)(&psm_req, &psm_status);
 #endif
 
 			fi_context = psm_status.context;
@@ -534,7 +534,7 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 				req = PSMX_CTXT_USER(fi_context);
 				req->offset += psm_status.nbytes;
 				if (req->offset + req->min_buf_size <= req->len) {
-					err = psm_mq_irecv(tmp_ep->domain->psm_mq,
+					err = PSMX_CALL(psm_mq_irecv)(tmp_ep->domain->psm_mq,
 							   req->tag, req->tagsel, req->flag,
 							   req->buf + req->offset, 
 							   req->len - req->offset,
@@ -711,7 +711,7 @@ static int psmx_cq_signal(struct fid_cq *cq)
 static const char *psmx_cq_strerror(struct fid_cq *cq, int prov_errno, const void *prov_data,
 				    char *buf, size_t len)
 {
-	return psm_error_get_string(prov_errno);
+	return PSMX_CALL(psm_error_get_string)(prov_errno);
 }
 
 static int psmx_cq_close(fid_t fid)

--- a/prov/psm/src/psmx_dl.c
+++ b/prov/psm/src/psmx_dl.c
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "psmx.h"
+
+struct psmx_lib psmx_lib;
+void *psmx_lib_handle = NULL;
+
+#define PSMX_LOAD_FUNC(func) \
+	do { \
+		char *err; \
+		dlerror(); \
+		psmx_lib.func = dlsym(psmx_lib_handle, #func); \
+		if ((err = dlerror()) != NULL) { \
+			FI_WARN(&psmx_prov, FI_LOG_CORE, "dlsym(%s): %s\n", #func, err); \
+			return -1; \
+		} \
+	} while (0)
+
+int psmx_dl_open(void)
+{
+	if (psmx_lib_handle)
+		return 0;
+
+	psmx_lib_handle = dlopen(PSMX_LIB_NAME, RTLD_LAZY | RTLD_LOCAL);
+	if (!psmx_lib_handle) {
+		FI_WARN(&psmx_prov, FI_LOG_CORE,"dlopen(%s): %s\n",
+			PSMX_LIB_NAME, dlerror());
+		return -1;
+	}
+
+	PSMX_LOAD_FUNC(psm_init);
+	PSMX_LOAD_FUNC(psm_finalize);
+	PSMX_LOAD_FUNC(psm_error_register_handler);
+	PSMX_LOAD_FUNC(psm_error_defer);
+	PSMX_LOAD_FUNC(psm_epid_nid);
+	PSMX_LOAD_FUNC(psm_epid_context);
+	PSMX_LOAD_FUNC(psm_epid_port);
+	PSMX_LOAD_FUNC(psm_ep_num_devunits);
+	PSMX_LOAD_FUNC(psm_uuid_generate);
+	PSMX_LOAD_FUNC(psm_ep_open);
+	PSMX_LOAD_FUNC(psm_ep_open_opts_get_defaults);
+	PSMX_LOAD_FUNC(psm_ep_epid_share_memory);
+	PSMX_LOAD_FUNC(psm_ep_close);
+	PSMX_LOAD_FUNC(psm_map_nid_hostname);
+	PSMX_LOAD_FUNC(psm_ep_connect);
+	PSMX_LOAD_FUNC(psm_poll);
+	PSMX_LOAD_FUNC(psm_epaddr_setlabel);
+	PSMX_LOAD_FUNC(psm_epaddr_setctxt);
+	PSMX_LOAD_FUNC(psm_epaddr_getctxt);
+	PSMX_LOAD_FUNC(psm_setopt);
+	PSMX_LOAD_FUNC(psm_getopt);
+	PSMX_LOAD_FUNC(psm_ep_query);
+	PSMX_LOAD_FUNC(psm_ep_epid_lookup);
+	PSMX_LOAD_FUNC(psm_mq_init);
+	PSMX_LOAD_FUNC(psm_mq_finalize);
+	PSMX_LOAD_FUNC(psm_mq_getopt);
+	PSMX_LOAD_FUNC(psm_mq_setopt);
+	PSMX_LOAD_FUNC(psm_mq_irecv);
+	PSMX_LOAD_FUNC(psm_mq_send);
+	PSMX_LOAD_FUNC(psm_mq_isend);
+	PSMX_LOAD_FUNC(psm_mq_iprobe);
+	PSMX_LOAD_FUNC(psm_mq_ipeek);
+	PSMX_LOAD_FUNC(psm_mq_wait);
+	PSMX_LOAD_FUNC(psm_mq_test);
+	PSMX_LOAD_FUNC(psm_mq_cancel);
+	PSMX_LOAD_FUNC(psm_mq_get_stats);
+#if (PSM_VERNO_MAJOR >= 2)
+	PSMX_LOAD_FUNC(psm_mq_irecv2);
+	PSMX_LOAD_FUNC(psm_mq_imrecv);
+	PSMX_LOAD_FUNC(psm_mq_send2);
+	PSMX_LOAD_FUNC(psm_mq_isend2);
+	PSMX_LOAD_FUNC(psm_mq_iprobe2);
+	PSMX_LOAD_FUNC(psm_mq_improbe);
+	PSMX_LOAD_FUNC(psm_mq_improbe2);
+	PSMX_LOAD_FUNC(psm_mq_ipeek2);
+	PSMX_LOAD_FUNC(psm_mq_wait2);
+	PSMX_LOAD_FUNC(psm_mq_test2);
+#endif
+
+	return 0;
+}
+
+void psmx_dl_close(void)
+{
+	if (psmx_lib_handle) {
+		dlclose(psmx_lib_handle);
+		psmx_lib_handle = NULL;
+	}
+}
+

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -107,12 +107,12 @@ static ssize_t psmx_ep_cancel(fid_t fid, void *context)
 		return  -FI_EOPNOTSUPP;
 	}
 
-	err = psm_mq_cancel((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context));
+	err = PSMX_CALL(psm_mq_cancel)((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context));
 	if (err == PSM_OK) {
 #if (PSM_VERNO_MAJOR >= 2)
-		err = psm_mq_test2((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context), &status);
+		err = PSMX_CALL(psm_mq_test2)((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context), &status);
 #else
-		err = psm_mq_test((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context), &status);
+		err = PSMX_CALL(psm_mq_test)((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context), &status);
 #endif
 		if (err == PSM_OK && ep->recv_cq) {
 			event = psmx_cq_create_event(

--- a/prov/psm/src/psmx_eq.c
+++ b/prov/psm/src/psmx_eq.c
@@ -291,7 +291,7 @@ static ssize_t psmx_eq_write(struct fid_eq *eq, uint32_t event_num, const void *
 static const char *psmx_eq_strerror(struct fid_eq *eq, int prov_errno,
 				    const void *err_data, char *buf, size_t len)
 {
-	return psm_error_get_string(prov_errno);
+	return PSMX_CALL(psm_error_get_string)(prov_errno);
 }
 
 static int psmx_eq_close(fid_t fid)

--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -84,7 +84,7 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 
 			src_addr = (fi_addr_t)av->psm_epaddrs[idx];
 		}
-		epaddr_context = psm_epaddr_getctxt((void *)src_addr);
+		epaddr_context = PSMX_CALL(psm_epaddr_getctxt)((void *)src_addr);
 		psm_tag = epaddr_context->epid | PSMX_MSG_BIT;
 		psm_tagsel = -1ULL;
 	}
@@ -131,12 +131,12 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
 	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
 
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv2)(ep_priv->domain->psm_mq,
 			    (psm_epaddr_t)src_addr,
 			    &psm_tag2, &psm_tagsel2, recv_flag,
 			    buf, len, (void *)fi_context, &psm_req);
 #else
-	err = psm_mq_irecv(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv)(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, recv_flag,
 			   buf, len, (void *)fi_context, &psm_req);
 #endif
@@ -289,10 +289,10 @@ ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 			return -FI_EMSGSIZE;
 
 #if (PSM_VERNO_MAJOR >= 2)
-		err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, send_flag,
+		err = PSMX_CALL(psm_mq_send2)(ep_priv->domain->psm_mq, psm_epaddr, send_flag,
 				   &psm_tag2, buf, len);
 #else
-		err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, send_flag,
+		err = PSMX_CALL(psm_mq_send)(ep_priv->domain->psm_mq, psm_epaddr, send_flag,
 				  psm_tag, buf, len);
 #endif
 
@@ -337,10 +337,10 @@ ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 	}
 
 #if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, send_flag,
+	err = PSMX_CALL(psm_mq_isend2)(ep_priv->domain->psm_mq, psm_epaddr, send_flag,
 				&psm_tag2, buf, len, (void *)fi_context, &psm_req);
 #else
-	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, send_flag,
+	err = PSMX_CALL(psm_mq_isend)(ep_priv->domain->psm_mq, psm_epaddr, send_flag,
 				psm_tag, buf, len, (void *)fi_context, &psm_req);
 #endif
 

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -154,10 +154,10 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 #if (PSM_VERNO_MAJOR >= 2)
 	psm_epaddr_t epaddr;
 
-	psm_am_get_source(token, &epaddr);
+	PSMX_CALL(psm_am_get_source)(token, &epaddr);
 #endif
 
-	epaddr_context = psm_epaddr_getctxt(epaddr);
+	epaddr_context = PSMX_CALL(psm_epaddr_getctxt)(epaddr);
 	if (!epaddr_context) {
 		FI_WARN(&psmx_prov, FI_LOG_EP_DATA,
 			"NULL context for epaddr %p\n", epaddr);
@@ -208,7 +208,7 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				rep_args[0].u32w1 = 0;
 				rep_args[1].u64 = args[1].u64;
 				rep_args[2].u64 = (uint64_t)(uintptr_t)req;
-				err = psm_am_reply_short(token, PSMX_AM_MSG_HANDLER,
+				err = PSMX_CALL(psm_am_reply_short)(token, PSMX_AM_MSG_HANDLER,
 						rep_args, 3, NULL, 0, 0,
 						NULL, NULL );
 			}
@@ -256,7 +256,7 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			rep_args[0].u32w1 = op_error;
 			rep_args[1].u64 = args[1].u64;
 			rep_args[2].u64 = 0; /* done */
-			err = psm_am_reply_short(token, PSMX_AM_MSG_HANDLER,
+			err = PSMX_CALL(psm_am_reply_short)(token, PSMX_AM_MSG_HANDLER,
 					rep_args, 3, NULL, 0, 0,
 					NULL, NULL );
 		}
@@ -339,7 +339,7 @@ int psmx_am_process_send(struct psmx_fid_domain *domain, struct psmx_am_request 
 		args[2].u64 = (uint64_t)(uintptr_t)req->send.peer_context;
 		args[3].u64 = offset;
 
-		err = psm_am_request_short((psm_epaddr_t) req->send.dest_addr,
+		err = PSMX_CALL(psm_am_request_short)((psm_epaddr_t) req->send.dest_addr,
 					PSMX_AM_MSG_HANDLER, args, 4,
 					req->send.buf+offset, chunk_size,
 					am_flags, NULL, NULL);
@@ -357,7 +357,7 @@ int psmx_am_process_send(struct psmx_fid_domain *domain, struct psmx_am_request 
 	args[3].u64 = offset;
 
 	req->send.len_sent = offset + len;
-	err = psm_am_request_short((psm_epaddr_t) req->send.dest_addr,
+	err = PSMX_CALL(psm_am_request_short)((psm_epaddr_t) req->send.dest_addr,
 				PSMX_AM_MSG_HANDLER, args, 4,
 				(void *)req->send.buf+offset, len,
 				am_flags, NULL, NULL);
@@ -430,7 +430,7 @@ static ssize_t _psmx_recv2(struct fid_ep *ep, void *buf, size_t len,
 		args[0].u32w1 = 0;
 		args[1].u64 = unexp->sender_context;
 		args[2].u64 = recv_done ? 0 : (uint64_t)(uintptr_t)req;
-		err = psm_am_request_short(unexp->sender_addr,
+		err = PSMX_CALL(psm_am_request_short)(unexp->sender_addr,
 					   PSMX_AM_MSG_HANDLER,
 					   args, 3, NULL, 0, 0,
 					   NULL, NULL );
@@ -580,14 +580,14 @@ static ssize_t _psmx_send2(struct fid_ep *ep, const void *buf, size_t len,
 	args[2].u64 = 0;
 	args[3].u64 = 0;
 
-	err = psm_am_request_short((psm_epaddr_t) dest_addr,
+	err = PSMX_CALL(psm_am_request_short)((psm_epaddr_t) dest_addr,
 				PSMX_AM_MSG_HANDLER, args, 4,
 				(void *)buf, msg_size, am_flags, NULL, NULL);
 
 #if ! PSMX_AM_USE_SEND_QUEUE
 	if (len > msg_size) {
 		while (!req->send.peer_ready)
-			psm_poll(ep_priv->domain->psm_ep);
+			PSMX_CALL(psm_poll)(ep_priv->domain->psm_ep);
 
 		psmx_am_process_send(ep_priv->domain, req);
 	}

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -86,12 +86,12 @@ ssize_t _psmx_tagged_peek(struct fid_ep *ep, void *buf, size_t len,
 	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
 
 	if (flags & (FI_CLAIM | FI_DISCARD))
-		err = psm_mq_improbe2(ep_priv->domain->psm_mq,
+		err = PSMX_CALL(psm_mq_improbe2)(ep_priv->domain->psm_mq,
 				      psm_src_addr,
 				      &psm_tag2, &psm_tagsel2,
 				      &req, &psm_status2);
 	else
-		err = psm_mq_iprobe2(ep_priv->domain->psm_mq,
+		err = PSMX_CALL(psm_mq_iprobe2)(ep_priv->domain->psm_mq,
 				     psm_src_addr,
 				     &psm_tag2, &psm_tagsel2,
 				     &psm_status2);
@@ -99,7 +99,7 @@ ssize_t _psmx_tagged_peek(struct fid_ep *ep, void *buf, size_t len,
 	if (flags & (FI_CLAIM | FI_DISCARD))
 		return -FI_EOPNOTSUPP;
 
-	err = psm_mq_iprobe(ep_priv->domain->psm_mq, psm_tag, psm_tagsel,
+	err = PSMX_CALL(psm_mq_iprobe)(ep_priv->domain->psm_mq, psm_tag, psm_tagsel,
 			    &psm_status);
 #endif
 	switch (err) {
@@ -205,7 +205,7 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 		PSMX_CTXT_USER(fi_context) = buf;
 		PSMX_CTXT_EP(fi_context) = ep_priv;
 
-		err = psm_mq_imrecv(ep_priv->domain->psm_mq, 0, /*flags*/
+		err = PSMX_CALL(psm_mq_imrecv)(ep_priv->domain->psm_mq, 0, /*flags*/
 				    buf, len, context, &psm_req);
 		if (err != PSM_OK)
 			return psmx_errno(err);
@@ -256,12 +256,12 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
 	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
 
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv2)(ep_priv->domain->psm_mq,
 			   (psm_epaddr_t)src_addr,
 			   &psm_tag2, &psm_tagsel2, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #else
-	err = psm_mq_irecv(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv)(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #endif
@@ -307,12 +307,12 @@ ssize_t psmx_tagged_recv_no_flag_av_map(struct fid_ep *ep, void *buf,
 	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
 	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
 
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv2)(ep_priv->domain->psm_mq,
 			   (psm_epaddr_t)src_addr,
 			   &psm_tag2, &psm_tagsel2, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #else
-	err = psm_mq_irecv(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv)(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #endif
@@ -367,12 +367,12 @@ ssize_t psmx_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf,
 	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
 	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
 
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv2)(ep_priv->domain->psm_mq,
 			   psm_epaddr,
 			   &psm_tag2, &psm_tagsel2, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #else
-	err = psm_mq_irecv(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv)(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #endif
@@ -412,12 +412,12 @@ ssize_t psmx_tagged_recv_no_event_av_map(struct fid_ep *ep, void *buf,
 	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
 	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
 
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv2)(ep_priv->domain->psm_mq,
 			   (psm_epaddr_t)src_addr,
 			   &psm_tag2, &psm_tagsel2, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #else
-	err = psm_mq_irecv(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv)(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #endif
@@ -466,12 +466,12 @@ ssize_t psmx_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf,
 	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
 	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
 
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv2)(ep_priv->domain->psm_mq,
 			   psm_epaddr,
 			   &psm_tag2, &psm_tagsel2, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #else
-	err = psm_mq_irecv(ep_priv->domain->psm_mq,
+	err = PSMX_CALL(psm_mq_irecv)(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
 #endif
@@ -705,10 +705,10 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 			return -FI_EMSGSIZE;
 
 #if (PSM_VERNO_MAJOR >= 2)
-		err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+		err = PSMX_CALL(psm_mq_send2)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 				   &psm_tag2, buf, len);
 #else
-		err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, 0,
+		err = PSMX_CALL(psm_mq_send)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 				  psm_tag, buf, len);
 #endif
 
@@ -753,10 +753,10 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 	}
 
 #if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend2)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 				&psm_tag2, buf, len, (void*)fi_context, &psm_req);
 #else
-	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 				psm_tag, buf, len, (void*)fi_context, &psm_req);
 #endif
 
@@ -798,10 +798,10 @@ ssize_t psmx_tagged_send_no_flag_av_map(struct fid_ep *ep, const void *buf,
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
 #if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend2)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
 #else
-	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
 #endif
 
@@ -848,10 +848,10 @@ ssize_t psmx_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
 #if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend2)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
 #else
-	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
 #endif
 
@@ -888,10 +888,10 @@ ssize_t psmx_tagged_send_no_event_av_map(struct fid_ep *ep, const void *buf,
 	fi_context = &ep_priv->nocomp_send_context;
 
 #if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend2)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
 #else
-	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
 #endif
 
@@ -934,10 +934,10 @@ ssize_t psmx_tagged_send_no_event_av_table(struct fid_ep *ep, const void *buf,
 	fi_context = &ep_priv->nocomp_send_context;
 
 #if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend2)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
 #else
-	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
+	err = PSMX_CALL(psm_mq_isend)(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
 #endif
 
@@ -970,9 +970,9 @@ ssize_t psmx_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf, si
 #endif
 
 #if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, 0, &psm_tag2, buf, len);
+	err = PSMX_CALL(psm_mq_send2)(ep_priv->domain->psm_mq, psm_epaddr, 0, &psm_tag2, buf, len);
 #else
-	err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, 0, psm_tag, buf, len);
+	err = PSMX_CALL(psm_mq_send)(ep_priv->domain->psm_mq, psm_epaddr, 0, psm_tag, buf, len);
 #endif
 
 	if (err != PSM_OK)
@@ -1014,9 +1014,9 @@ ssize_t psmx_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf, 
 #endif
 
 #if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, 0, &psm_tag2, buf, len);
+	err = PSMX_CALL(psm_mq_send2)(ep_priv->domain->psm_mq, psm_epaddr, 0, &psm_tag2, buf, len);
 #else
-	err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, 0, psm_tag, buf, len);
+	err = PSMX_CALL(psm_mq_send)(ep_priv->domain->psm_mq, psm_epaddr, 0, psm_tag, buf, len);
 #endif
 
 	if (err != PSM_OK)

--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -10,6 +10,7 @@ dnl
 AC_DEFUN([FI_PSM2_CONFIGURE],[
 	# Determine if we can support the psm2 provider
 	psm2_happy=0
+	psm2_orig_LIBS=$psm2_LIBS
 	AS_IF([test x"$enable_psm2" != x"no"],
 	      [FI_CHECK_PACKAGE([psm2],
 				[psm2.h],
@@ -24,9 +25,22 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 
 	AS_IF([test $psm2_happy -eq 1], [$1], [$2])
 
+	AC_MSG_CHECKING([if use dlopen to load PSM2 library])
+	AC_RUN_IFELSE([AC_LANG_SOURCE(
+				      [[
+				      int main()
+				      {
+					#ifndef PSMX_DL
+					#define PSMX_DL 1
+					#endif
+					return PSMX_DL ? 0 : 1;
+				      }
+				      ]]
+				     )],
+			[AC_MSG_RESULT([yes]); psm2_LIBS=$psm2_orig_LIBS],
+			[AC_MSG_RESULT([no]); psm2_LDFLAGS="$LDFLAGS $psm2_LDFLAGS"])
+
 	psm2_CPPFLAGS="$CPPFLAGS $psm2_CPPFLAGS"
-	psm2_LDFLAGS="$LDFLAGS $psm2_LDFLAGS"
-	psm2_LIBS="$LIBS $psm2_LIBS"
 	CPPFLAGS="$psm2_orig_CPPFLAGS"
 	LDFLAGS="$psm2_orig_LDFLAGS"
 ])

--- a/prov/psm2/src/psmx_dl.c
+++ b/prov/psm2/src/psmx_dl.c
@@ -1,0 +1,1 @@
+../../psm/src/psmx_dl.c

--- a/prov/psm2/src/rename.h
+++ b/prov/psm2/src/rename.h
@@ -120,6 +120,8 @@
 #define psmx_cq_sread psmx2_cq_sread
 #define psmx_cq_sreadfrom psmx2_cq_sreadfrom
 #define psmx_cq_strerror psmx2_cq_strerror
+#define psmx_dl_close psmx2_dl_close
+#define psmx_dl_open psmx2_dl_open
 #define psmx_domain_check_features psmx2_domain_check_features
 #define psmx_domain_close psmx2_domain_close
 #define psmx_domain_disable_ep psmx2_domain_disable_ep
@@ -182,6 +184,8 @@
 #define psmx_init_env psmx2_init_env
 #define psmx_inject psmx2_inject
 #define psmx_inject2 psmx2_inject2
+#define psmx_lib psmx2_lib
+#define psmx_lib_handle psmx2_lib_handle
 #define psmx_mr_bind psmx2_mr_bind
 #define psmx_mr_close psmx2_mr_close
 #define psmx_mr_hash psmx2_mr_hash


### PR DESCRIPTION
The psm and psm2 providers are linked to PSM and PSM2 libraries,
respectively. These two libraries contain symbols with identical
names and cause symbols from the wrong library being used.

This patch uses dlopen to load the correct library at runtime, and
limits the symbol scope to RTLD_LOCAL. This way the two providers
can be activated at the same time.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>