### PR TITLE
implementation of complex types of atomics for socket provider.

### DIFF
--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -569,11 +569,17 @@ static int sock_ep_atomic_valid(struct fid_ep *ep, enum fi_datatype datatype,
 		    op == FI_BXOR || op == FI_MSWAP)
 			return -FI_ENOENT;
 		break;
-		
+
 	case FI_FLOAT_COMPLEX:
 	case FI_DOUBLE_COMPLEX:
 	case FI_LONG_DOUBLE_COMPLEX:
-		return -FI_ENOENT;
+		if (op == FI_BOR      || op == FI_BAND     ||
+		    op == FI_BXOR     || op == FI_MSWAP    ||
+		    op == FI_MIN      || op == FI_MAX      ||
+		    op == FI_CSWAP_LE || op == FI_CSWAP_LT ||
+		    op == FI_CSWAP_GE || op == FI_CSWAP_GT)
+			return -FI_ENOENT;
+        break;
 	default:
 		break;
 	}


### PR DESCRIPTION
used GCC/ICC built-in complex types

algorithms for data processing are implemented as macro, macro for
processing int types was used as reference

updated atomic implementation and sock_ep_atomic_valid functions, smoke tests are passed (used comex layer from Global Arrays library to operate with complex types, tested FI_SUM operations on double complex and float complex types)

this is second iteration for request https://github.com/ofiwg/libfabric/pull/1257 with fixes

Signed-off-by: Oblomov, Sergey <hoopoepg@gmail.com>