### PR TITLE
prov/sockets: Added description of env var in the manpage

### DIFF
--- a/man/fi_sockets.7.md
+++ b/man/fi_sockets.7.md
@@ -79,9 +79,9 @@ The sockets provider checks for the following environment variables -
 *FI_SOCKETS_PE_AFFINITY*
 : If specified, progress thread is bound to the indicated range(s) of Linux virtual processor ID(s). This option is currently not supported on OS X. The usage is - id_start[-id_end[:stride]][,].
 
-# MISCELLANEOUS
-
-For large scale runs one can use these environment variables to tweak the default sizes of the address vector(AV), completion queue (CQ), connection map etc. that satisfies the requriment of the particular benchmark. The recommended parameters for large scale runs are *FI_SOCKETS_MAX_CONN_RETRY*, *FI_SOCKETS_DEF_CONN_MAP_SZ*, *FI_SOCKETS_DEF_AV_SZ*, *FI_SOCKETS_DEF_CQ_SZ*, *FI_SOCKETS_DEF_EQ_SZ*.
+# LARGE SCALE JOBS
+ 
+For large scale runs one can use these environment variables to set the default parameters e.g. size of the address vector(AV), completion queue (CQ), connection map etc. that satisfies the requriment of the particular benchmark. The recommended parameters for large scale runs are *FI_SOCKETS_MAX_CONN_RETRY*, *FI_SOCKETS_DEF_CONN_MAP_SZ*, *FI_SOCKETS_DEF_AV_SZ*, *FI_SOCKETS_DEF_CQ_SZ*, *FI_SOCKETS_DEF_EQ_SZ*.
 
 # SEE ALSO
 

--- a/man/fi_sockets.7.md
+++ b/man/fi_sockets.7.md
@@ -51,6 +51,38 @@ performance numbers are lower compared to other providers implemented
 over high-speed fabric, and lower than what an application might see
 implementing to sockets directly.
 
+# RUNTIME PARAMETERS
+
+The sockets provider checks for the following environment variables -
+
+*FI_SOCKETS_PE_WAITTIME*
+: An integer value that specifies how many milliseconds to spin while waiting for progress in *FI_PROGRESS_AUTO* mode.
+
+*FI_SOCKETS_MAX_CONN_RETRY*
+: An integer value that specifies the number of socket connection retries before reporting as failure.
+
+*FI_SOCKETS_DEF_CONN_MAP_SZ*
+: An integer to specify the default connection map size. 
+
+*FI_SOCKETS_DEF_AV_SZ*
+: An integer to specify the default address vector size.
+
+*FI_SOCKETS_DEF_CQ_SZ*
+: An integer to specify the default completion queue size.
+
+*FI_SOCKETS_DEF_EQ_SZ*
+: An integer to specify the default event queue size.
+
+*FI_SOCKETS_DGRAM_DROP_RATE*
+: An integer value to specify the drop rate of dgram frame when endpoint is *FI_EP_DGRAM*. This is for debugging purpose only.
+
+*FI_SOCKETS_PE_AFFINITY*
+: If specified, progress thread is bound to the indicated range(s) of Linux virtual processor ID(s). This option is currently not supported on OS X. The usage is - id_start[-id_end[:stride]][,].
+
+# MISCELLANEOUS
+
+For large scale runs one can use these environment variables to tweak the default sizes of the address vector(AV), completion queue (CQ), connection map etc. that satisfies the requriment of the particular benchmark. The recommended parameters for large scale runs are *FI_SOCKETS_MAX_CONN_RETRY*, *FI_SOCKETS_DEF_CONN_MAP_SZ*, *FI_SOCKETS_DEF_AV_SZ*, *FI_SOCKETS_DEF_CQ_SZ*, *FI_SOCKETS_DEF_EQ_SZ*.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2547,17 +2547,13 @@ static void sock_thread_set_affinity(char *s)
 }
 #endif
 
-static void sock_pe_set_affinity (void)
+static void sock_pe_set_affinity(void)
 {
-	char *s;
-	fi_param_define(&sock_prov, "pe_affinity", FI_PARAM_STRING,
-			"If specified, bind the progress thread to the indicated range(s) of Linux virtual processor ID(s). "
-			"This option is currently not supported on OS X. Usage: id_start[-id_end[:stride]][,]");
-	if (fi_param_get_str(&sock_prov, "pe_affinity", &s) != FI_SUCCESS)
+	if (sock_pe_affinity_str == NULL)
 		return;
 	
 #ifndef __APPLE__
-	sock_thread_set_affinity(s);
+	sock_thread_set_affinity(sock_pe_affinity_str);
 #else
 	SOCK_LOG_ERROR("*** FI_SOCKETS_PE_AFFINITY is not supported on OS X\n");
 #endif

--- a/prov/sockets/src/sock_util.h
+++ b/prov/sockets/src/sock_util.h
@@ -47,6 +47,7 @@ extern int sock_cm_def_map_sz;
 extern int sock_av_def_sz;
 extern int sock_cq_def_sz;
 extern int sock_eq_def_sz;
+extern char *sock_pe_affinity_str;
 #if ENABLE_DEBUG
 extern int sock_dgram_drop_rate;
 #endif


### PR DESCRIPTION
- Added a section to describe available environment variables.
- Added FI_SOCKETS_PE_AFFINITY in SOCKETS_INI
- Added a function to read the default env parameters

@jithinjosepkl, can you please review?

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>