### PR TITLE
crontab: the ofiwg-bot user's crontab on flatbed

### DIFF
--- a/config/ofiwg-bot@flatbed:crontab.txt
+++ b/config/ofiwg-bot@flatbed:crontab.txt
@@ -1,0 +1,38 @@
+#
+# Update the git clone of libfabric
+#
+# Split this into two lines so that we can have it run every 15 minutes
+# *except* 3:00am (when the nightly tarball is created, which does
+# its own git pull).
+#
+# Update master:
+0,15,30,45 0-2,4-23 * * * (cd $HOME/cron/git/libfabric; git pull --rebase > /dev/null 2>&1; cd $HOME/cron/git/fabtests; git pull --rebase > /dev/null 2>&1)
+15,30,45 3 * * * (cd $HOME/cron/git/libfabric; git pull --rebase > /dev/null 2>&1; cd $HOME/cron/git/fabtests; git pull --rebase > /dev/null 2>&1)
+#
+# Update v1.1.x:
+1,16,31,46 0-2,4-23 * * * (cd $HOME/cron/git/libfabric-1.1.x; git pull --rebase > /dev/null 2>&1)
+15,30,45 3 * * * (cd $HOME/cron/git/libfabric-1.1.x; git pull --rebase > /dev/null 2>&1)
+#
+# Using the script from newly-updated libfabric master clone,
+# generate new man pages
+#
+5,20,35,50 * * * * (PATH=$HOME/cron/local/bin:$PATH; /home/ofiwg-bot/cron/git/libfabric/config/cron-run-all-md2nroff.pl --repo git@github.com:ofiwg/libfabric.git --source-branch master --pages-branch gh-pages --logfile-dir ~/cron/build-logs)
+#
+# Also update man pages on v1.x branch
+# Do not auto-publish the new pages to gh-pages
+#
+6,21,36,51 * * * * (PATH=$HOME/cron/local/bin:$PATH; /home/ofiwg-bot/cron/git/libfabric/config/cron-run-all-md2nroff.pl --repo git@github.com:ofiwg/libfabric.git --source-branch v1.1.x --logfile-dir ~/cron/build-logs/v1.1.x)
+#
+# Make a nightly tarball snapshot from:
+# - libfabric master
+# - fabtests master
+#
+0 3 * * * (PATH=$HOME/cron/local/bin:$PATH; $HOME/cron/git/libfabric/config/cron-make-nightly-tarball.pl --libfabric-source-dir $HOME/cron/git/libfabric --fabtests-source-dir $HOME/cron/git/fabtests --download-dir=/var/www/html/downloads/ofiwg/nightly_tarballs/v1.2.x --logfile-dir ~/cron/build-logs/v1.2.x --libfabric-coverity-token `cat ~/coverity-libfabric-token.txt` --fabtests-coverity-token `cat ~/coverity-fabtests-token.txt`)
+#
+# Make a nightly tarball snapshot from:
+# - libfabric v1.1.x branch
+# - fabtests master
+#
+# No Coverity submissions for this build.
+#
+15 3 * * * (PATH=$HOME/cron/local/bin:$PATH; $HOME/cron/git/libfabric/config/cron-make-nightly-tarball.pl --libfabric-source-dir $HOME/cron/git/libfabric-1.1.x --fabtests-source-dir $HOME/cron/git/fabtests --download-dir=/var/www/html/downloads/ofiwg/nightly_tarballs/v1.1.x --logfile-dir ~/cron/build-logs/v1.1.x)


### PR DESCRIPTION
Flatbed is the OFA's build server.  The ofiwg-bot user does a bunch of automated things for libfabric, so let's save a copy of this user's crontab, just in case that server blows up.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>