### PR TITLE
sockets, man pages: Updates to FI_PEEK

### DIFF
--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -272,8 +272,8 @@ The following flags may be used with fi_trecvmsg.
   allocated buffering enabled (see fi_rx_attr total_buffered_recv).
   Unlike standard receive operations, a receive operation with the FI_PEEK
   flag set does not remain queued with the provider until the peek completes
-  successfully.  If no data is available, the FI_PEEK receive will complete
-  with a status of FI_ENOMSG.
+  successfully.  If no data is available, the FI_PEEK receive will result in
+  a completion queue error entry with err field set to FI_ENOMSG.
 
   If a peek request locates a matching message, the operation will complete
   successfully.  The returned completion data will indicate the meta-data

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -271,9 +271,12 @@ The following flags may be used with fi_trecvmsg.
   A peek request is often useful on endpoints that have provider
   allocated buffering enabled (see fi_rx_attr total_buffered_recv).
   Unlike standard receive operations, a receive operation with the FI_PEEK
-  flag set does not remain queued with the provider until the peek completes
-  successfully.  If no data is available, the FI_PEEK receive will result in
-  a completion queue error entry with err field set to FI_ENOMSG.
+  flag set does not remain queued with the provider after the peek completes
+  successfully. The peek operation operates asynchronously, and the results 
+  of the peek operation are available in the completion queue associated with
+  the endpoint. If no message is found matching the tags specified in the peek
+  request, then a completion queue error entry with err field set to FI_ENOMSG
+  will be available.
 
   If a peek request locates a matching message, the operation will complete
   successfully.  The returned completion data will indicate the meta-data
@@ -281,14 +284,18 @@ The following flags may be used with fi_trecvmsg.
   available CQ data, tag, and source address.  The data available is subject to
   the completion entry format (e.g. struct fi_cq_tagged_entry).
 
-  An application may supply a buffer as part of the peek operation.  If
-  given, the provider may return a copy of the message data.  The returned data
-  is limited to the size of the input buffer(s) or the message size, if
-  smaller.  A provider indicates if data is available by setting the buf
-  field of the CQ entry to the user's first input buffer.  If buf is NULL, no
-  data was available to return.  A provider may return NULL even if the
-  peek operation completes successfully.  Note that the CQ entry len field
-  will reference the size of the message, not necessarily the size of the
+  An application may supply a buffer if it desires to receive data as
+  a part of the peek operation. In order to receive data as a part of
+  the peek operation, the buf and len fields must be available in the
+  CQ format. In particular, FI_CQ_FORMAT_CONTEXT and FI_CQ_FORMAT_MSG
+  cannot be used if peek operations desire to obtain a copy of the
+  data. The returned data is limited to the size of the input
+  buffer(s) or the message size, if smaller.  A provider indicates if
+  data is available by setting the buf field of the CQ entry to the
+  user's first input buffer.  If buf is NULL, no data was available to
+  return.  A provider may return NULL even if the peek operation
+  completes successfully.  Note that the CQ entry len field will
+  reference the size of the message, not necessarily the size of the
   returned data.
 
 *FI_CLAIM*

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1159,7 +1159,6 @@ ssize_t sock_rx_peek_recv(struct sock_rx_ctx *rx_ctx, fi_addr_t addr,
 			  uint64_t tag, uint64_t ignore, void *context, 
 			  uint64_t flags, uint8_t is_tagged)
 {
-	ssize_t ret = 0;
 	struct sock_rx_entry *rx_buffered;
 	struct sock_pe_entry pe_entry;
 
@@ -1168,16 +1167,18 @@ ssize_t sock_rx_peek_recv(struct sock_rx_ctx *rx_ctx, fi_addr_t addr,
 					(rx_ctx->attr.caps & FI_DIRECTED_RECV) ?
 						 addr : FI_ADDR_UNSPEC, 
 						 tag, ignore, is_tagged);
+
+	memset(&pe_entry, 0, sizeof pe_entry);
+	pe_entry.comp = &rx_ctx->comp;
+	pe_entry.context = (uintptr_t)context;
+	pe_entry.flags = (flags | FI_MSG | FI_RECV);
+	if (is_tagged)
+		pe_entry.flags |= FI_TAGGED;
+
 	if (rx_buffered) {
-		memset(&pe_entry, 0, sizeof pe_entry);
-		pe_entry.comp = &rx_ctx->comp;
 		pe_entry.data_len = rx_buffered->total_len;
 		pe_entry.tag = rx_buffered->tag;
-		pe_entry.context = rx_buffered->context = (uintptr_t)context;
-		pe_entry.flags = (flags | FI_MSG | FI_RECV);
-		if (is_tagged)
-			pe_entry.flags |= FI_TAGGED;
-		
+		rx_buffered->context = (uintptr_t)context;
 		if (flags & FI_CLAIM)
 			rx_buffered->is_claimed = 1;
 		
@@ -1187,10 +1188,11 @@ ssize_t sock_rx_peek_recv(struct sock_rx_ctx *rx_ctx, fi_addr_t addr,
 		}
 		sock_pe_report_rx_completion(&pe_entry);
 	} else {
-		ret = -FI_ENOMSG;
+		sock_cq_report_error(rx_ctx->comp.recv_cq, &pe_entry, 0, 
+				     FI_ENOMSG, -FI_ENOMSG, NULL);
 	}
 	fastlock_release(&rx_ctx->lock);
-	return ret;
+	return 0;
 }
 
 ssize_t sock_rx_claim_recv(struct sock_rx_ctx *rx_ctx, void *context, uint64_t flags, 


### PR DESCRIPTION
- Update sockets provider to make FI_PEEK asynchronous (for message not-found case)
- Man page clarification about FI_PEEK