### PR TITLE
usnic: Drop erroneous packets

### DIFF
--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -1127,6 +1127,9 @@ usdf_msg_handle_recv(struct usdf_domain *udp, struct usd_completion *comp)
 	}
 	rx = ep->ep_rx;
 
+	if (comp->uc_status != USD_COMPSTAT_SUCCESS)
+		goto dropit;
+
 	switch (opcode) {
 	case RUDP_OP_ACK:
 		usdf_msg_rx_ack(ep, pkt);

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -1510,6 +1510,9 @@ usdf_rdm_handle_recv(struct usdf_domain *udp, struct usd_completion *comp)
 	}
 //printf("RX opcode=%u\n", opcode);
 
+	if (comp->uc_status != USD_COMPSTAT_SUCCESS)
+		goto repost;
+
 	switch (opcode) {
 	case RUDP_OP_ACK:
 		usdf_rdm_rx_ack(rdc, rx->r.rdm.rx_tx, pkt);


### PR DESCRIPTION
Fixes the occasional data verification issues seen in Jenkins testing.

@jsquyres @goodell 