### PR TITLE
fabric: Ignore provider errors in fi_getinfo

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -490,14 +490,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 			FI_WARN(&core_prov, FI_LOG_CORE,
 			       "fi_getinfo: provider %s returned -%d (%s)\n",
 			       prov->provider->name, -ret, fi_strerror(-ret));
-			if (ret == -FI_ENODATA) {
-				continue;
-			} else {
-				/* a provider has an error, clean up and bail */
-				fi_freeinfo(*info);
-				*info = NULL;
-				return ret;
-			}
+			continue;
 		}
 
 		if (!*info)


### PR DESCRIPTION
A provider error can end up preventing other providers from
reporting results.  Although the original intent was to
report unexpected errors back to the app, minor bugs in the
providers can result in the app not seeing anything.

Instead, log errors and skip providers that have issues.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>