### PR TITLE
prov/psm: add environment varible to control psm_ep_close timeout

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -620,6 +620,7 @@ struct psmx_env {
 	int tagged_rma;
 	char *uuid;
 	int delay;
+	int timeout;
 };
 
 extern struct fi_ops_mr		psmx_mr_ops;

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -60,7 +60,7 @@ static int psmx_domain_close(fid_t fid)
 	sleep(psmx_env.delay);
 
 	err = psm_ep_close(domain->psm_ep, PSM_EP_CLOSE_GRACEFUL,
-			   (int64_t) PSMX_TIME_OUT * 1000000000LL);
+			   (int64_t) psmx_env.timeout * 1000000000LL);
 	if (err != PSM_OK)
 		psm_ep_close(domain->psm_ep, PSM_EP_CLOSE_FORCE, 0);
 
@@ -156,7 +156,7 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 err_out_close_ep:
 	if (psm_ep_close(domain_priv->psm_ep, PSM_EP_CLOSE_GRACEFUL,
-			 (int64_t) PSMX_TIME_OUT * 1000000000LL) != PSM_OK)
+			 (int64_t) psmx_env.timeout * 1000000000LL) != PSM_OK)
 		psm_ep_close(domain_priv->psm_ep, PSM_EP_CLOSE_FORCE, 0);
 
 err_out_free_domain:

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -43,6 +43,7 @@ struct psmx_env psmx_env = {
 	.tagged_rma	= 1,
 	.uuid		= PSMX_DEFAULT_UUID,
 	.delay		= 1,
+	.timeout	= PSMX_TIME_OUT,
 };
 
 static void psmx_init_env(void)
@@ -55,6 +56,7 @@ static void psmx_init_env(void)
 	fi_param_get_bool(&psmx_prov, "tagged_rma", &psmx_env.tagged_rma);
 	fi_param_get_str(&psmx_prov, "uuid", &psmx_env.uuid);
 	fi_param_get_int(&psmx_prov, "delay", &psmx_env.delay);
+	fi_param_get_int(&psmx_prov, "timeout", &psmx_env.timeout);
 }
 
 static int psmx_reserve_tag_bits(int *caps, uint64_t *max_tag_value)
@@ -611,6 +613,9 @@ PSM_INI
 
 	fi_param_define(&psmx_prov, "delay", FI_PARAM_INT,
 			"Delay (seconds) before finalization (for debugging)");
+
+	fi_param_define(&psmx_prov, "timeout", FI_PARAM_INT,
+			"Timeout (seconds) for gracefully closing the PSM endpoint");
 
         psm_error_register_handler(NULL, PSM_ERRHANDLER_NO_HANDLER);
 


### PR DESCRIPTION
Gracefully closing PSM endpoints can be slow sometimes. Add a new
environment variable FI_PSM_TIMEOUT to allow applications to
reduce the wait time and proceed to force closing.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>