### PR TITLE
prov/psm: properly terminate the name server thread

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -295,6 +295,7 @@ struct psmx_fid_fabric {
 	int			refcnt;
 	struct psmx_fid_domain	*active_domain;
 	psm_uuid_t		uuid;
+	pthread_t		name_server_thread;
 };
 
 struct psmx_fid_domain {

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -498,11 +498,32 @@ err_out:
 static int psmx_fabric_close(fid_t fid)
 {
 	struct psmx_fid_fabric *fabric;
+	void *exit_code;
+	int ret;
 
 	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
 
 	fabric = container_of(fid, struct psmx_fid_fabric, fabric.fid);
 	if (! --fabric->refcnt) {
+		if (psmx_env.name_server &&
+		    !pthread_equal(fabric->name_server_thread, pthread_self())) {
+			ret = pthread_cancel(fabric->name_server_thread);
+			if (ret) {
+				FI_INFO(&psmx_prov, FI_LOG_CORE,
+					"pthread_cancel returns %d\n", ret);
+			}
+			ret = pthread_join(fabric->name_server_thread, &exit_code);
+			if (ret) {
+				FI_INFO(&psmx_prov, FI_LOG_CORE,
+					"pthread_join returns %d\n", ret);
+			}
+			else {
+				FI_INFO(&psmx_prov, FI_LOG_CORE,
+					"name server thread exited with code %ld (%s)\n",
+					(uintptr_t)exit_code,
+					(exit_code == PTHREAD_CANCELED) ? "PTHREAD_CANCELED" : "?");
+			}
+		}
 		if (fabric->active_domain)
 			fi_close(&fabric->active_domain->domain.fid);
 		assert(fabric == psmx_active_fabric);
@@ -530,8 +551,7 @@ static int psmx_fabric(struct fi_fabric_attr *attr,
 		       struct fid_fabric **fabric, void *context)
 {
 	struct psmx_fid_fabric *fabric_priv;
-	pthread_t thread;
-	pthread_attr_t thread_attr;
+	int ret;
 
 	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
 
@@ -556,9 +576,13 @@ static int psmx_fabric(struct fi_fabric_attr *attr,
 	psmx_get_uuid(fabric_priv->uuid);
 
 	if (psmx_env.name_server) {
-		pthread_attr_init(&thread_attr);
-		pthread_attr_setdetachstate(&thread_attr,PTHREAD_CREATE_DETACHED);
-		pthread_create(&thread, &thread_attr, psmx_name_server, (void *)fabric_priv);
+		ret = pthread_create(&fabric_priv->name_server_thread, NULL,
+				     psmx_name_server, (void *)fabric_priv);
+		if (ret) {
+			FI_INFO(&psmx_prov, FI_LOG_CORE, "pthread_create returns %d\n", ret);
+			/* use the main thread's ID as invalid value for the new thread */
+			fabric_priv->name_server_thread = pthread_self();
+		}
 	}
 
 	psmx_query_mpi();


### PR DESCRIPTION
Instead of letting the name server thread running detached, terminate
it when the associated fabric object is closed. Since the thread is
started when the fabric object is opened, this change makes the life
cycle of these two better aligned.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>