### PR TITLE
prov/psm: cherry-picking bug fixes from the master branch

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -593,6 +593,7 @@ void 	*psmx_name_server(void *args);
 void	*psmx_resolve_name(const char *servername, int port);
 void	psmx_get_uuid(psm_uuid_t uuid);
 int	psmx_uuid_to_port(psm_uuid_t uuid);
+char	*psmx_uuid_to_string(psm_uuid_t uuid);
 int	psmx_errno(int err);
 int	psmx_epid_to_epaddr(struct psmx_fid_domain *domain,
 			    psm_epid_t epid, psm_epaddr_t *epaddr);

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -545,6 +545,7 @@ struct psmx_env {
 	int am_msg;
 	int tagged_rma;
 	char *uuid;
+	int timeout;
 };
 
 extern struct fi_ops_mr		psmx_mr_ops;

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -125,10 +125,6 @@ union psmx_pi {
 #define PSMX_AM_DATA		0x20000000
 #define PSMX_AM_FORCE_ACK	0x10000000
 
-#ifndef PSMX_AM_USE_SEND_QUEUE
-#define PSMX_AM_USE_SEND_QUEUE	0
-#endif
-
 enum {
 	PSMX_AM_REQ_WRITE = 1,
 	PSMX_AM_REQ_WRITE_LONG,
@@ -144,13 +140,6 @@ enum {
 	PSMX_AM_REP_ATOMIC_READWRITE,
 	PSMX_AM_REQ_ATOMIC_COMPWRITE,
 	PSMX_AM_REP_ATOMIC_COMPWRITE,
-};
-
-enum {
-	PSMX_AM_STATE_NEW,
-	PSMX_AM_STATE_QUEUED,
-	PSMX_AM_STATE_PROCESSED,
-	PSMX_AM_STATE_DONE
 };
 
 struct psmx_am_request {
@@ -203,7 +192,6 @@ struct psmx_am_request {
 	uint64_t cq_flags;
 	struct fi_context fi_context;
 	struct psmx_fid_ep *ep;
-	int state;
 	int no_event;
 	int error;
 	struct slist_entry list_entry;
@@ -258,19 +246,11 @@ struct psmx_fid_domain {
 
 	int			am_initialized;
 
-#if PSMX_AM_USE_SEND_QUEUE
-	pthread_cond_t		progress_cond;
-	pthread_mutex_t		progress_mutex;
-	pthread_t		progress_thread;
-#endif
-
 	/* incoming req queue for AM based RMA request. */
 	struct psmx_req_queue	rma_queue;
 
-#if PSMX_AM_USE_SEND_QUEUE
 	/* send queue for AM based messages. */
 	struct psmx_req_queue	send_queue;
-#endif
 
 	/* recv queue for AM based messages. */
 	struct psmx_req_queue	recv_queue;

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -227,6 +227,7 @@ struct psmx_fid_fabric {
 	int			refcnt;
 	struct psmx_fid_domain	*active_domain;
 	psm_uuid_t		uuid;
+	pthread_t		name_server_thread;
 };
 
 struct psmx_fid_domain {

--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -109,7 +109,7 @@ int psmx_am_init(struct psmx_fid_domain *domain)
 		    (psmx_am_handlers_idx[1] != PSMX_AM_MSG_HANDLER) ||
 		    (psmx_am_handlers_idx[2] != PSMX_AM_ATOMIC_HANDLER)) {
 			FI_WARN(&psmx_prov, FI_LOG_CORE,
-				"failed to register one or mroe AM handlers "
+				"failed to register one or more AM handlers "
 				"at indecies %d, %d, %d\n", PSMX_AM_RMA_HANDLER,
 				PSMX_AM_MSG_HANDLER, PSMX_AM_ATOMIC_HANDLER);
 			return -FI_EBUSY;

--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -49,22 +49,17 @@ int psmx_am_progress(struct psmx_fid_domain *domain)
 	struct psmx_am_request *req;
 	struct psmx_trigger *trigger;
 
-#if PSMX_AM_USE_SEND_QUEUE
-	pthread_mutex_lock(&domain->send_queue.lock);
-	while (!slist_empty(&domain->send_queue.list)) {
-		item = slist_remove_head(&domain->send_queue.list);
-		req = container_of(item, struct psmx_am_request, list_entry);
-		if (req->state == PSMX_AM_STATE_DONE) {
-			free(req);
-		}
-		else {
+	if (psmx_env.am_msg) {
+		pthread_mutex_lock(&domain->send_queue.lock);
+		while (!slist_empty(&domain->send_queue.list)) {
+			item = slist_remove_head(&domain->send_queue.list);
+			req = container_of(item, struct psmx_am_request, list_entry);
 			pthread_mutex_unlock(&domain->send_queue.lock);
 			psmx_am_process_send(domain, req);
 			pthread_mutex_lock(&domain->send_queue.lock);
 		}
+		pthread_mutex_unlock(&domain->send_queue.lock);
 	}
-	pthread_mutex_unlock(&domain->send_queue.lock);
-#endif
 
 	if (psmx_env.tagged_rma) {
 		pthread_mutex_lock(&domain->rma_queue.lock);
@@ -90,33 +85,6 @@ int psmx_am_progress(struct psmx_fid_domain *domain)
 
 	return 0;
 }
-
-#if PSMX_AM_USE_SEND_QUEUE
-static void *psmx_am_async_progress(void *args)
-{
-	struct psmx_fid_domain *domain = args;
-	struct timespec timeout;
-
-	timeout.tv_sec = 1;
-	timeout.tv_nsec = 1000;
-
-	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
-
-	while (1) {
-		pthread_mutex_lock(&domain->progress_mutex);
-		pthread_cond_wait(&domain->progress_cond, &domain->progress_mutex);
-		pthread_mutex_unlock(&domain->progress_mutex);
-		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
-
-		psmx_am_progress(domain);
-
-		pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
-	}
-
-	return NULL;
-}
-#endif
 
 int psmx_am_init(struct psmx_fid_domain *domain)
 {
@@ -154,32 +122,18 @@ int psmx_am_init(struct psmx_fid_domain *domain)
 	slist_init(&domain->recv_queue.list);
 	slist_init(&domain->unexp_queue.list);
 	slist_init(&domain->trigger_queue.list);
+	slist_init(&domain->send_queue.list);
 	pthread_mutex_init(&domain->rma_queue.lock, NULL);
 	pthread_mutex_init(&domain->recv_queue.lock, NULL);
 	pthread_mutex_init(&domain->unexp_queue.lock, NULL);
 	pthread_mutex_init(&domain->trigger_queue.lock, NULL);
-#if PSMX_AM_USE_SEND_QUEUE
-	slist_init(&domain->send_queue.list);
 	pthread_mutex_init(&domain->send_queue.lock, NULL);
-	pthread_mutex_init(&domain->progress_mutex, NULL);
-	pthread_cond_init(&domain->progress_cond, NULL);
-	err = pthread_create(&domain->progress_thread, NULL, psmx_am_async_progress, (void *)domain);
-#endif
 
 	return err;
 }
 
 int psmx_am_fini(struct psmx_fid_domain *domain)
 {
-#if PSMX_AM_USE_SEND_QUEUE
-        if (domain->progress_thread) {
-                pthread_cancel(domain->progress_thread);
-                pthread_join(domain->progress_thread, NULL);
-		pthread_mutex_destroy(&domain->progress_mutex);
-		pthread_cond_destroy(&domain->progress_cond);
-        }
-#endif
-
 	return 0;
 }
 

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -126,6 +126,8 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	psm_ep_open_opts_get_defaults(&opts);
 
+	FI_INFO(&psmx_prov, FI_LOG_CORE, "uuid: %s\n", psmx_uuid_to_string(fabric_priv->uuid));
+
 	err = psm_ep_open(fabric_priv->uuid, &opts,
 			  &domain_priv->psm_ep, &domain_priv->psm_epid);
 	if (err != PSM_OK) {
@@ -134,6 +136,8 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		err = psmx_errno(err);
 		goto err_out_free_domain;
 	}
+
+	FI_INFO(&psmx_prov, FI_LOG_CORE, "epid: 0x%016lx\n", domain_priv->psm_epid);
 
 	err = psm_mq_init(domain_priv->psm_ep, PSM_MQ_ORDERMASK_ALL,
 			  NULL, 0, &domain_priv->psm_mq);

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -60,7 +60,7 @@ static int psmx_domain_close(fid_t fid)
 	sleep(1);
 
 	err = psm_ep_close(domain->psm_ep, PSM_EP_CLOSE_GRACEFUL,
-			   (int64_t) PSMX_TIME_OUT * 1000000000LL);
+			   (int64_t) psmx_env.timeout * 1000000000LL);
 	if (err != PSM_OK)
 		psm_ep_close(domain->psm_ep, PSM_EP_CLOSE_FORCE, 0);
 
@@ -156,7 +156,7 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 err_out_close_ep:
 	if (psm_ep_close(domain_priv->psm_ep, PSM_EP_CLOSE_GRACEFUL,
-			 (int64_t) PSMX_TIME_OUT * 1000000000LL) != PSM_OK)
+			 (int64_t) psmx_env.timeout * 1000000000LL) != PSM_OK)
 		psm_ep_close(domain_priv->psm_ep, PSM_EP_CLOSE_FORCE, 0);
 
 err_out_free_domain:

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -42,6 +42,7 @@ struct psmx_env psmx_env = {
 	.am_msg		= 0,
 	.tagged_rma	= 1,
 	.uuid		= PSMX_DEFAULT_UUID,
+	.timeout	= PSMX_TIME_OUT,
 };
 
 static void psmx_init_env(void)
@@ -53,6 +54,7 @@ static void psmx_init_env(void)
 	fi_param_get_bool(&psmx_prov, "am_msg", &psmx_env.am_msg);
 	fi_param_get_bool(&psmx_prov, "tagged_rma", &psmx_env.tagged_rma);
 	fi_param_get_str(&psmx_prov, "uuid", &psmx_env.uuid);
+	fi_param_get_int(&psmx_prov, "timeout", &psmx_env.timeout);
 }
 
 static int psmx_reserve_tag_bits(int *caps, uint64_t *max_tag_value)
@@ -602,6 +604,9 @@ PSM_INI
 
 	fi_param_define(&psmx_prov, "uuid", FI_PARAM_STRING,
 			"Unique Job ID required by the fabric");
+
+	fi_param_define(&psmx_prov, "timeout", FI_PARAM_INT,
+			"Timeout (seconds) for gracefully closing the PSM endpoint");
 
         psm_error_register_handler(NULL, PSM_ERRHANDLER_NO_HANDLER);
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -496,11 +496,32 @@ err_out:
 static int psmx_fabric_close(fid_t fid)
 {
 	struct psmx_fid_fabric *fabric;
+	void *exit_code;
+	int ret;
 
 	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
 
 	fabric = container_of(fid, struct psmx_fid_fabric, fabric.fid);
 	if (! --fabric->refcnt) {
+		if (psmx_env.name_server &&
+		    !pthread_equal(fabric->name_server_thread, pthread_self())) {
+			ret = pthread_cancel(fabric->name_server_thread);
+			if (ret) {
+				FI_INFO(&psmx_prov, FI_LOG_CORE,
+					"pthread_cancel returns %d\n", ret);
+			}
+			ret = pthread_join(fabric->name_server_thread, &exit_code);
+			if (ret) {
+				FI_INFO(&psmx_prov, FI_LOG_CORE,
+					"pthread_join returns %d\n", ret);
+			}
+			else {
+				FI_INFO(&psmx_prov, FI_LOG_CORE,
+					"name server thread exited with code %ld (%s)\n",
+					(uintptr_t)exit_code,
+					(exit_code == PTHREAD_CANCELED) ? "PTHREAD_CANCELED" : "?");
+			}
+		}
 		if (fabric->active_domain)
 			fi_close(&fabric->active_domain->domain.fid);
 		assert(fabric == psmx_active_fabric);
@@ -528,8 +549,7 @@ static int psmx_fabric(struct fi_fabric_attr *attr,
 		       struct fid_fabric **fabric, void *context)
 {
 	struct psmx_fid_fabric *fabric_priv;
-	pthread_t thread;
-	pthread_attr_t thread_attr;
+	int ret;
 
 	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
 
@@ -554,9 +574,13 @@ static int psmx_fabric(struct fi_fabric_attr *attr,
 	psmx_get_uuid(fabric_priv->uuid);
 
 	if (psmx_env.name_server) {
-		pthread_attr_init(&thread_attr);
-		pthread_attr_setdetachstate(&thread_attr,PTHREAD_CREATE_DETACHED);
-		pthread_create(&thread, &thread_attr, psmx_name_server, (void *)fabric_priv);
+		ret = pthread_create(&fabric_priv->name_server_thread, NULL,
+				     psmx_name_server, (void *)fabric_priv);
+		if (ret) {
+			FI_INFO(&psmx_prov, FI_LOG_CORE, "pthread_create returns %d\n", ret);
+			/* use the main thread's ID as invalid value for the new thread */
+			fabric_priv->name_server_thread = pthread_self();
+		}
 	}
 
 	psmx_query_mpi();

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -500,7 +500,7 @@ static int psmx_fabric_close(fid_t fid)
 	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
 
 	fabric = container_of(fid, struct psmx_fid_fabric, fabric.fid);
-	if (--fabric->refcnt) {
+	if (! --fabric->refcnt) {
 		if (fabric->active_domain)
 			fi_close(&fabric->active_domain->domain.fid);
 		assert(fabric == psmx_active_fabric);

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -32,16 +32,13 @@
 
 #include "psmx.h"
 
-#if PSMX_AM_USE_SEND_QUEUE
 static inline void psmx_am_enqueue_send(struct psmx_fid_domain *domain,
 					struct psmx_am_request *req)
 {
 	pthread_mutex_lock(&domain->send_queue.lock);
-	req->state = PSMX_AM_STATE_QUEUED;
 	slist_insert_tail(&req->list_entry, &domain->send_queue.list);
 	pthread_mutex_unlock(&domain->send_queue.lock);
 }
-#endif
 
 static inline void psmx_am_enqueue_recv(struct psmx_fid_domain *domain,
 					struct psmx_am_request *req)
@@ -260,16 +257,10 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		if (args[2].u64) { /* more to send */
 			req->send.peer_context = (void *)(uintptr_t)args[2].u64;
 
-#if PSMX_AM_USE_SEND_QUEUE
 			/* psm_am_request_short() can't be called inside the handler.
 			 * put the request into a queue and process it later.
 			 */
 			psmx_am_enqueue_send(req->ep->domain, req);
-			if (req->ep->domain->progress_thread)
-				pthread_cond_signal(&req->ep->domain->progress_cond);
-#else
-			req->send.peer_ready = 1;
-#endif
 		}
 		else { /* done */
 			if (req->ep->send_cq && !req->no_event) {
@@ -292,10 +283,7 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			if (req->ep->send_cntr)
 				psmx_cntr_inc(req->ep->send_cntr);
 
-			if (req->state == PSMX_AM_STATE_QUEUED)
-				req->state = PSMX_AM_STATE_DONE;
-			else
-				free(req);
+			free(req);
 		}
 		break;
 
@@ -314,8 +302,6 @@ int psmx_am_process_send(struct psmx_fid_domain *domain, struct psmx_am_request 
 	size_t len;
 	uint64_t offset;
 	int err;
-
-	req->state = PSMX_AM_STATE_PROCESSED;
 
 	offset = req->send.len_sent;
 	len = req->send.len - offset;
@@ -573,15 +559,6 @@ static ssize_t _psmx_send2(struct fid_ep *ep, const void *buf, size_t len,
 	err = psm_am_request_short((psm_epaddr_t) dest_addr,
 				PSMX_AM_MSG_HANDLER, args, 4,
 				(void *)buf, msg_size, am_flags, NULL, NULL);
-
-#if ! PSMX_AM_USE_SEND_QUEUE
-	if (len > msg_size) {
-		while (!req->send.peer_ready)
-			psm_poll(ep_priv->domain->psm_ep);
-
-		psmx_am_process_send(ep_priv->domain, req);
-	}
-#endif
 
 	return psmx_errno(err);
 

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -36,7 +36,6 @@ static inline void psmx_am_enqueue_rma(struct psmx_fid_domain *domain,
 				       struct psmx_am_request *req)
 {
 	pthread_mutex_lock(&domain->rma_queue.lock);
-	req->state = PSMX_AM_STATE_QUEUED;
 	slist_insert_tail(&req->list_entry, &domain->rma_queue.list);
 	pthread_mutex_unlock(&domain->rma_queue.lock);
 }

--- a/prov/psm/src/psmx_util.c
+++ b/prov/psm/src/psmx_util.c
@@ -75,6 +75,21 @@ int psmx_uuid_to_port(psm_uuid_t uuid)
 	return (int)port;
 }
 
+char *psmx_uuid_to_string(psm_uuid_t uuid)
+{
+	static char s[40];
+
+	sprintf(s,
+		"%02hhX%02hhX%02hhX%02hhX-"
+		"%02hhX%02hhX-%02hhX%02hhX-%02hhX%02hhX-"
+		"%02hhX%02hhX%02hhX%02hhX%02hhX%02hhX",
+		uuid[0], uuid[1], uuid[2], uuid[3],
+		uuid[4], uuid[5], uuid[6], uuid[7], uuid[8], uuid[9],
+		uuid[10], uuid[11], uuid[12], uuid[13], uuid[14], uuid[15]);
+
+	return s;
+}
+
 /*************************************************************
  * A simple name resolution mechanism for client-server style
  * applications. The server side has to run first. The client

--- a/prov/psm/src/psmx_util.c
+++ b/prov/psm/src/psmx_util.c
@@ -236,7 +236,8 @@ void *psmx_resolve_name(const char *servername, int port)
 	}
 
 	if (read(sockfd, dest_addr, sizeof(psm_epid_t)) != sizeof(psm_epid_t)) {
-		perror(__func__);
+		FI_INFO(&psmx_prov, FI_LOG_CORE,
+			"error reading response from %s:%d\n", servername, port);
 		free(dest_addr);
 		close(sockfd);
 		return NULL;


### PR DESCRIPTION
prov/psm: convert a remaining "perror" to logging function
prov/psm: properly terminate the name server thread
prov/psm: fix inversed condition for freeing up fabric object
prov/psm: add UUID and PSM epid to debug output
prov/psm: fix a typo in log messages
prov/psm: add environment varible to control psm_ep_close timeout
prov/psm: code refactoring of the AM-based messaging
