### PR TITLE
sockets: bug fixes

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -485,12 +485,11 @@ struct sock_ep {
 	size_t fclass;
 	uint64_t op_flags;
 
-	uint8_t connected;
-	char reserved[1];
-	uint8_t tx_shared;
-	uint8_t rx_shared;
-	uint16_t buffered_len;
-	uint16_t min_multi_recv;
+	int connected;
+	int tx_shared;
+	int rx_shared;
+	size_t buffered_len;
+	size_t min_multi_recv;
 
 	atomic_t ref;
 	struct sock_comp comp;
@@ -570,16 +569,14 @@ struct sock_rx_ctx {
 	struct fid_ep ctx;
 
 	uint16_t rx_id;
-	uint8_t enabled;
-	uint8_t progress;
+	int enabled;
+	int progress;
+	int is_ctrl_ctx;
+	int recv_cq_event;
 
-	uint8_t recv_cq_event;
-	uint16_t buffered_len;
-	uint16_t min_multi_recv;
-	uint16_t num_left;
-	uint8_t is_ctrl_ctx;
-	uint8_t reserved[5];
-
+	size_t num_left;
+	size_t buffered_len;
+	size_t min_multi_recv;
 	uint64_t addr;
 	struct sock_comp comp;
 

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -227,9 +227,13 @@ int sock_dgram_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 
 	(*info)->caps = SOCK_EP_DGRAM_CAP |
                        (*info)->rx_attr->caps | (*info)->tx_attr->caps;
-        if (hints && hints->caps)
+        if (hints && hints->caps) {
                 (*info)->caps = SOCK_EP_DGRAM_SEC_CAP | hints->caps;
-
+		(*info)->rx_attr->caps = SOCK_EP_DGRAM_SEC_CAP |
+			((*info)->rx_attr->caps & (*info)->caps);
+		(*info)->tx_attr->caps = SOCK_EP_DGRAM_SEC_CAP |
+			((*info)->tx_attr->caps & (*info)->caps);
+	}
 	return 0;
 }
 

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -229,9 +229,13 @@ int sock_msg_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 
 	(*info)->caps = SOCK_EP_MSG_CAP |
                        (*info)->rx_attr->caps | (*info)->tx_attr->caps;
-        if (hints && hints->caps)
+        if (hints && hints->caps) {
                 (*info)->caps = SOCK_EP_MSG_SEC_CAP | hints->caps;
-
+		(*info)->rx_attr->caps = SOCK_EP_MSG_SEC_CAP |
+			((*info)->rx_attr->caps & (*info)->caps);
+		(*info)->tx_attr->caps = SOCK_EP_MSG_SEC_CAP |
+			((*info)->tx_attr->caps & (*info)->caps);
+	}
 	return 0;
 }
 

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -272,9 +272,13 @@ int sock_rdm_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 
 	(*info)->caps = SOCK_EP_RDM_CAP |
 			(*info)->rx_attr->caps | (*info)->tx_attr->caps;
-	if (hints && hints->caps)
+	if (hints && hints->caps) {
 		(*info)->caps = SOCK_EP_RDM_SEC_CAP | hints->caps;
-
+		(*info)->rx_attr->caps = SOCK_EP_RDM_SEC_CAP |
+			((*info)->rx_attr->caps & (*info)->caps);
+		(*info)->tx_attr->caps = SOCK_EP_RDM_SEC_CAP |
+			((*info)->tx_attr->caps & (*info)->caps);
+	}
 	return 0;
 }
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -801,38 +801,38 @@ out:
 		break;							\
 									\
 	case FI_CSWAP_NE:						\
+		_tmp = *_dst;						\
 		if (*_cmp != *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	case FI_CSWAP_LE:						\
+		_tmp = *_dst;						\
 		if (*_cmp <= *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	case FI_CSWAP_LT:						\
+		_tmp = *_dst;						\
 		if (*_cmp < *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	case FI_CSWAP_GE:						\
+		_tmp = *_dst;						\
 		if (*_cmp >= *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	case FI_CSWAP_GT:						\
+		_tmp = *_dst;						\
 		if (*_cmp > *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	case FI_MSWAP:							\
@@ -899,38 +899,38 @@ out:
 		break;							\
 									\
 	case FI_CSWAP_NE:						\
+		_tmp = *_dst;						\
 		if (*_cmp != *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	case FI_CSWAP_LE:						\
+		_tmp = *_dst;						\
 		if (*_cmp <= *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	case FI_CSWAP_LT:						\
+		_tmp = *_dst;						\
 		if (*_cmp < *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	case FI_CSWAP_GE:						\
+		_tmp = *_dst;						\
 		if (*_cmp >= *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	case FI_CSWAP_GT:						\
+		_tmp = *_dst;						\
 		if (*_cmp > *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	default:							\
@@ -979,10 +979,10 @@ out:
 		break;							\
 									\
 	case FI_CSWAP_NE:						\
+		_tmp = *_dst;						\
 		if (*_cmp != *_dst)					\
 			*_dst = *_src;					\
-		else							\
-			*_cmp = *_dst;					\
+		*_cmp = _tmp;						\
 		break;							\
 									\
 	default:							\
@@ -1062,7 +1062,7 @@ static int sock_pe_update_atomic(void *cmp, void *dst, void *src,
 
 	case FI_FLOAT:
 	{
-		float *_cmp, *_dst, *_src;
+		float *_cmp, *_dst, *_src, _tmp;
 		_cmp = cmp, _src = src, _dst = dst;
 		SOCK_ATOMIC_UPDATE_FLOAT(_cmp, _src, _dst);
 		break;
@@ -1070,7 +1070,7 @@ static int sock_pe_update_atomic(void *cmp, void *dst, void *src,
 
 	case FI_DOUBLE:
 	{
-		double *_cmp, *_dst, *_src;
+		double *_cmp, *_dst, *_src, _tmp;
 		_cmp = cmp, _src = src, _dst = dst;
 		SOCK_ATOMIC_UPDATE_FLOAT(_cmp, _src, _dst);
 		break;
@@ -1078,7 +1078,7 @@ static int sock_pe_update_atomic(void *cmp, void *dst, void *src,
 
 	case FI_LONG_DOUBLE:
 	{
-		long double *_cmp, *_dst, *_src;
+		long double *_cmp, *_dst, *_src, _tmp;
 		_cmp = cmp, _src = src, _dst = dst;
 		SOCK_ATOMIC_UPDATE_FLOAT(_cmp, _src, _dst);
 		break;
@@ -1086,7 +1086,7 @@ static int sock_pe_update_atomic(void *cmp, void *dst, void *src,
 
 	case FI_DOUBLE_COMPLEX:
 	{
-		double complex *_cmp, *_dst, *_src;
+		double complex *_cmp, *_dst, *_src, _tmp;
 		_cmp = cmp, _src = src, _dst = dst;
 		SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst);
 		break;
@@ -1094,7 +1094,7 @@ static int sock_pe_update_atomic(void *cmp, void *dst, void *src,
 
 	case FI_FLOAT_COMPLEX:
 	{
-		float complex *_cmp, *_dst, *_src;
+		float complex *_cmp, *_dst, *_src, _tmp;
 		_cmp = cmp, _src = src, _dst = dst;
 		SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst);
 		break;
@@ -1102,7 +1102,7 @@ static int sock_pe_update_atomic(void *cmp, void *dst, void *src,
 
 	case FI_LONG_DOUBLE_COMPLEX:
 	{
-		long double complex *_cmp, *_dst, *_src;
+		long double complex *_cmp, *_dst, *_src, _tmp;
 		_cmp = cmp, _src = src, _dst = dst;
 		SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst);
 		break;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -259,9 +259,6 @@ static void sock_pe_report_mr_completion(struct sock_domain *domain,
 		pe_entry->buf = pe_entry->pe.rx.rx_iov[i].iov.addr;
 		pe_entry->data_len = pe_entry->pe.rx.rx_iov[i].iov.len;
 		
-		if (mr->cq)
-			mr->cq->report_completion(mr->cq, 
-						  pe_entry->addr, pe_entry);
 		if (mr->cntr)
 			sock_cntr_inc(mr->cntr);
 	}


### PR DESCRIPTION
- Do not generate CQ events for remote MR update events
- Return initial values for cswap_* operations
- Enable rx/tx attr primary caps only if requested by app