### PR TITLE
man: Remove reference to RMA generating a CQ entry

### DIFF
--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -327,8 +327,7 @@ additional optimizations.
 
 *FI_RMA_EVENT*
 : Requests that an endpoint support the generation of completion events
-  when it is the target of an RMA and/or atomic operation.  If set, the
-  provider will support both completion queue and counter events.  This
+  when it is the target of an RMA and/or atomic operation.  This
   flag requires that FI_REMOTE_READ and/or FI_REMOTE_WRITE be enabled on
   the endpoint.
 


### PR DESCRIPTION
The man pages are unclear on FI_RMA_EVENT generating a
CQ entry in response to an RMA operation.  The issue is
that only counters were defined to respond to RMA events
(see fi_ep_bind).  Support for CQ events was removed from
the 1.0 release because of the negative impact to the
providers, but the man pages were left in a confusing
state.

Addresses issue #1300.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>