### PR TITLE
Add missing header to Makefile.am for psm2.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -310,6 +310,7 @@ endif HAVE_PSM
 
 if HAVE_PSM2
 _psm2_files = \
+	prov/psm2/src/rename.h \
 	prov/psm2/src/version.h \
 	prov/psm2/src/psmx.h \
 	prov/psm2/src/psmx_init.c \


### PR DESCRIPTION
Without this the RPM fails to build.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>