### PR TITLE
Re-wire the specfile configopts.

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -1,3 +1,5 @@
+%{!?configopts: %global configopts %{nil}}
+
 Name: libfabric
 Version: @VERSION@
 Release: 1%{?dist}


### PR DESCRIPTION
To make an RPM with a specific configure line do:
$ rpmbuild --define 'configopts --enable-psm --disable-sockets ...' -ba libfabric.spec

The default behavior is unchanged: run plain configure and build based
on libraries detected on the system. This also fixes this warning which
happens when doing any RPM build:

configure: WARNING: you should use --build, --host, --target
configure: WARNING: invalid host type: %{configopts}

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>