### PR TITLE
prov/psm: fix assertion failure due to unset psmx_active_fabric

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -587,6 +587,8 @@ static int psmx_fabric(struct fi_fabric_attr *attr,
 
 	fabric_priv->refcnt = 1;
 	*fabric = &fabric_priv->fabric;
+	psmx_active_fabric = fabric_priv;
+
 	return 0;
 }
 


### PR DESCRIPTION
The variable was not set to the opened fabric object. This not
only caused the assertion failure when closing the fabric onject,
but also prevented the intended sharing of fabric object between
different middlewares.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>