### PR TITLE
travis: make travis yml file smarter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ script:
         - ./configure --prefix=$HOME --with-libfabric=$HOME
         - make
         - make install
-        - make test
+        - if [ "$TRAVIS_OS_NAME" = "linux" ]; then make test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,18 @@ matrix:
   exclude:
     - os: osx
       compiler: gcc
-  fast_finish: true
-
-before_install:
-    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
-install: ./autogen.sh
-script: ./configure --prefix=${TRAVIS_BUILD_DIR}/install_dir &&
-         make install V=1 && ${TRAVIS_BUILD_DIR}/install_dir/bin/fi_info -v
+install:
+        - ./autogen.sh
+        - ./configure --prefix=$HOME
+        - make
+        - make install
+        - make test
+        - make distcheck
+script:
+        - git clone https://github.com/ofiwg/fabtests.git
+        - cd fabtests
+        - ./autogen.sh
+        - ./configure --prefix=$HOME --with-libfabric=$HOME
+        - make
+        - make install
+        - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,19 @@
 sudo: false
-install: ./autogen.sh
 language: c
 compiler:
     - clang
     - gcc
+os:
+    - linux
+    - osx
+matrix:
+  exclude:
+    - os: osx
+      compiler: gcc
+  fast_finish: true
+
+before_install:
+    - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
+install: ./autogen.sh
+script: ./configure --prefix=${TRAVIS_BUILD_DIR}/install_dir &&
+         make install V=1 && ${TRAVIS_BUILD_DIR}/install_dir/bin/fi_info -v


### PR DESCRIPTION
Introduction of a .travis.yml into upstream
broke some things for gni provider fork.

So why not make lemonade out of lemons?

This commit improves the travis script to
- test os-x
- run the fi_info smoke test as part of the
  script procedure

@bturrubiates @shefty @sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@34d54199d2c147de8a0c4eafc2e4fe50a1cdd942)

Conflicts:
	.travis.yml