### PR TITLE
man: clarify FI_RM_ENABLED and total_buffered_recv

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -940,10 +940,12 @@ the _Transmit Context Attribute_ section.
 
 ## total_buffered_recv
 
-Defines the total available space allocated by the provider to
-buffer messages that are received for which there is no matching
-receive operation.  If set to 0, any messages that arrive before a
-receive buffer has been posted are lost.
+Defines the total available space allocated by the provider to buffer messages
+that are received for which there is no matching receive operation.  If set to
+0, and the domain does not support FI_RM_ENABLED, any messages that arrive
+before a receive buffer has been posted are lost. When the domain supports
+FI_RM_ENABLED, the actual amount of buffering provided may exceed the value
+specified in total_buffered_recv.
 
 ## size
 


### PR DESCRIPTION
Clarify the behavior when total_buffered_recv is set to zero,
but FI_RM_ENABLED is set. FI_RM_ENABLED should be able to provide any
specific value set in total_buffered_recv by the application.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>