### PR TITLE
prov/psm: reduce the default timeout value for psm_ep_close

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -104,8 +104,6 @@ extern "C" {
 
 extern struct fi_provider psmx_prov;
 
-#define PSMX_TIME_OUT	120
-
 #define PSMX_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \
 			 FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -43,7 +43,7 @@ struct psmx_env psmx_env = {
 	.tagged_rma	= 1,
 	.uuid		= PSMX_DEFAULT_UUID,
 	.delay		= 1,
-	.timeout	= PSMX_TIME_OUT,
+	.timeout	= 5,
 };
 
 static void psmx_init_env(void)


### PR DESCRIPTION
The first call to psm_ep_close is with the graceful flag and tries
to do the cleanup job nicely. When it fails (timeout expired) it
is called again with the forced flag. The old default timeout value
(120 seconds) is too long and can cause large scale application to
hang for hours if something goes wrong in the finalization phase.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>