### PR TITLE
prov/psm: add a lock to the polling function for thread safety

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -331,6 +331,11 @@ struct psmx_fid_domain {
 	 * as 0. This field is a bit mask, with reserved bits valued as "1".
 	 */
 	uint64_t		reserved_tag_bits; 
+
+	/* lock to prevent the sequence of psm_mq_ipeek and psm_mq_test be
+	 * interleaved in a multithreaded environment.
+	 */
+	pthread_spinlock_t	poll_lock;
 };
 
 struct psmx_cq_event {


### PR DESCRIPTION
Protect the sequence "psm_mq_ipeek; psm_mq_test" with a lock so
that they cannot be interleaved when issued from multiple threads.
Without the protection, the call to psm_mq_test could try to
access an request that has already been freed.

This enables the addition of an auto progress thread.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>