### PR TITLE
prov/psm: add an environment variable to adjust progress interval

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -628,6 +628,7 @@ struct psmx_env {
 	char *uuid;
 	int delay;
 	int timeout;
+	int prog_intv;
 };
 
 extern struct fi_ops_mr		psmx_mr_ops;

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -37,10 +37,11 @@ static void *psmx_progress_func(void *args)
 	struct psmx_fid_domain *domain = args;
 
 	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
+
 	while (1) {
 		psmx_progress(domain);
 		pthread_testcancel();
-		usleep(1);
+		usleep(psmx_env.prog_intv);
 	}
 
 	return NULL;

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -44,6 +44,7 @@ struct psmx_env psmx_env = {
 	.uuid		= PSMX_DEFAULT_UUID,
 	.delay		= 1,
 	.timeout	= 5,
+	.prog_intv	= 1000,
 };
 
 static void psmx_init_env(void)
@@ -57,6 +58,7 @@ static void psmx_init_env(void)
 	fi_param_get_str(&psmx_prov, "uuid", &psmx_env.uuid);
 	fi_param_get_int(&psmx_prov, "delay", &psmx_env.delay);
 	fi_param_get_int(&psmx_prov, "timeout", &psmx_env.timeout);
+	fi_param_get_int(&psmx_prov, "prog_intv", &psmx_env.prog_intv);
 }
 
 static int psmx_reserve_tag_bits(int *caps, uint64_t *max_tag_value)
@@ -656,6 +658,10 @@ PSM_INI
 
 	fi_param_define(&psmx_prov, "timeout", FI_PARAM_INT,
 			"Timeout (seconds) for gracefully closing the PSM endpoint");
+
+	fi_param_define(&psmx_prov, "prog_intv", FI_PARAM_INT,
+			"Interval (microseconds) between progress calls made in the "
+			"progress thread (default: 1000)");
 
         psm_error_register_handler(NULL, PSM_ERRHANDLER_NO_HANDLER);
 


### PR DESCRIPTION
New envar FI_PSM_PROG_INTV / FI_PSM2_PROG_INTV set the interval
between progress calls made in the auto progress thread. The
default value is 1000 microseconds.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>