### PR TITLE
prov/verbs: Fix incorrect setting of node argument.

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -1018,7 +1018,7 @@ fi_ibv_create_ep(const char *node, const char *service,
 		goto out;
 
 	if (!node && !rai_hints.ai_dst_addr) {
-		if (!rai_hints.ai_src_addr) {
+		if (!rai_hints.ai_src_addr && !service) {
 			node = local_node;
 		}
 		rai_hints.ai_flags |= RAI_PASSIVE;


### PR DESCRIPTION
In the passive mode, rdma_getaddrinfo requires atleast one of node,
service or hints.ai_src_addr to be non-NULL. In case we have service
set, do not set node to localhost.