### PR TITLE
prov/psm: add option to set the CPU affinity of the progress thread

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -629,6 +629,7 @@ struct psmx_env {
 	int delay;
 	int timeout;
 	int prog_intv;
+	int prog_affinity;
 };
 
 extern struct fi_ops_mr		psmx_mr_ops;

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -45,6 +45,7 @@ struct psmx_env psmx_env = {
 	.delay		= 1,
 	.timeout	= 5,
 	.prog_intv	= 1000,
+	.prog_affinity	= -1,
 };
 
 static void psmx_init_env(void)
@@ -59,6 +60,7 @@ static void psmx_init_env(void)
 	fi_param_get_int(&psmx_prov, "delay", &psmx_env.delay);
 	fi_param_get_int(&psmx_prov, "timeout", &psmx_env.timeout);
 	fi_param_get_int(&psmx_prov, "prog_intv", &psmx_env.prog_intv);
+	fi_param_get_int(&psmx_prov, "prog_affinity", &psmx_env.prog_affinity);
 }
 
 static int psmx_reserve_tag_bits(int *caps, uint64_t *max_tag_value)
@@ -662,6 +664,13 @@ PSM_INI
 	fi_param_define(&psmx_prov, "prog_intv", FI_PARAM_INT,
 			"Interval (microseconds) between progress calls made in the "
 			"progress thread (default: 1000)");
+
+	fi_param_define(&psmx_prov, "prog_affinity", FI_PARAM_INT,
+			"CPU affinity setting for the progress thread. The value <n> can be:\n"
+			"0:  no affinity;\n"
+			">0: pin to the <n>th core from the lowest core numer;\n"
+			"<0: pin to the <n>th core from the highest core number;\n"
+			"(default: -1)\n");
 
         psm_error_register_handler(NULL, PSM_ERRHANDLER_NO_HANDLER);
 


### PR DESCRIPTION
For applications that purely rely on auto progress, the performance
can be quite bad if the main thread and the progress thread are
aggresively competing with each other (e.g. the main thread keeps
polling message buffer to detect completion). Setting CPU affinity
for the progress thread can lead to significant improvement.

The new environment variable "FI_PSM_PROG_AFFINITY" (or "FI_PSM2_
PROG_AFFINITY" for the psm2 provider) controls the affinity setting
of the progress thread. If the value is 0, affinity is disabled.
If the value is positive, the thread is pinned to the core counting
from the lowest numbered core (i.e. "1" means core 0). If the value
is negative, the thread is pinned to the core counting from the
highest numbered core. The default is "-1", which means the last
core.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>