### PR TITLE
usnic: return -FI_EOPNOTSUPP on domain_bind to FI_REG_MR

### DIFF
--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -67,6 +67,12 @@ usdf_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 
 	USDF_TRACE_SYS(DOMAIN, "\n");
 
+	if (flags & FI_REG_MR) {
+		USDF_WARN_SYS(DOMAIN,
+			"FI_REG_MR for EQs is not supported by the usnic provider");
+		return -FI_EOPNOTSUPP;
+	}
+
         udp = dom_fidtou(fid);
 
         switch (bfid->fclass) {


### PR DESCRIPTION
The usnic provider does not yet support asynchronous memory registration.  So return -FI_EOPNOTSUPP if binds an event queue to a domain with FI_REG_MR.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Reviewed by @bturrubiates @goodell 