### PR TITLE
AC_CHECK_FILE always fails when cross compiling

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -116,9 +116,12 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 	# If this provider was requested for direct build, ensure that
 	# provider's fi_direct.h exists in tree. Error otherwise.
 	AS_IF([test x"$enable_direct" = x"$1"],
-		[AC_CHECK_FILE(prov/$1/include/rdma/fi_direct.h, [],
-			[AC_MSG_WARN([$1 provider was requested as direct, but is missing required files])
-			 AC_MSG_ERROR([Cannot continue])])])
+		[AC_MSG_CHECKING(for prov/$1/include/rdma/fi_direct.h)
+		 AS_IF([test -f "prov/$1/include/rdma/fi_direct.h"],
+			[AC_MSG_RESULT(yes)],
+			[AC_MSG_RESULT(no)
+			  AC_MSG_ERROR([$1 provider was requested as direct, but is missing fi_direct.h])]
+			)])
 ])
 
 


### PR DESCRIPTION
Replace AC_CHECK_FILE with a test -f so that cross compiling with fabric
direct mode can be configured.

Signed-off-by: Andrew Friedley <andrew.friedley@intel.com>