### PR TITLE
prov/sockets: do not set prov name in fabric_attr

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1245,7 +1245,7 @@ static void sock_set_fabric_attr(const struct fi_fabric_attr *hint_attr,
 		attr->fabric = fabric ? &fabric->fab_fid : NULL;
 	}
 	attr->name = strdup(sock_fab_name);
-	attr->prov_name = strdup(sock_prov_name);
+	attr->prov_name = NULL;
 }
 
 static void sock_set_domain_attr(const struct fi_domain_attr *hint_attr,


### PR DESCRIPTION
fixes #1371

Signed-off-by: Jithin Jose <jithin.jose@intel.com>