### PR TITLE
prov/psm: don't set fabric_attr->prov_name in fi_getinfo

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -480,7 +480,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	psmx_info->src_addr = NULL;
 	psmx_info->dest_addr = dest_addr;
 	psmx_info->fabric_attr->name = strdup(PSMX_FABRIC_NAME);
-	psmx_info->fabric_attr->prov_name = strdup(PSMX_PROV_NAME);
+	psmx_info->fabric_attr->prov_name = NULL;
 
 	psmx_info->tx_attr->caps = psmx_info->caps;
 	psmx_info->tx_attr->mode = psmx_info->mode;


### PR DESCRIPTION
The framework would use the name from the provider definition and
discard the name set here, and thus result in memory leak.

See also #1371, #1374

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>