### PR TITLE
prov/sockets - Fix incorrect return values

### DIFF
--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -460,7 +460,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (info && info->domain_attr) {
 		ret = sock_verify_domain_attr(info->domain_attr);
 		if (ret)
-			return ret;
+			return -FI_EINVAL;
 	}
 
 	sock_domain = calloc(1, sizeof(*sock_domain));

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -251,19 +251,19 @@ static int sock_dgram_endpoint(struct fid_domain *domain, struct fi_info *info,
 						      info->tx_attr,
 						      info->rx_attr);
 			if (ret)
-				return ret;
+				return -FI_EINVAL;
 		}
 
 		if (info->tx_attr) {
 			ret = sock_dgram_verify_tx_attr(info->tx_attr);
 			if (ret)
-				return ret;
+				return -FI_EINVAL;
 		}
 
 		if (info->rx_attr) {
 			ret = sock_dgram_verify_rx_attr(info->rx_attr);
 			if (ret)
-				return ret;
+				return -FI_EINVAL;
 		}
 	}
 

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -885,19 +885,19 @@ static int sock_msg_endpoint(struct fid_domain *domain, struct fi_info *info,
 						      info->tx_attr,
 						      info->rx_attr);
 			if (ret)
-				return ret;
+				return -FI_EINVAL;
 		}
 
 		if (info->tx_attr) {
 			ret = sock_msg_verify_tx_attr(info->tx_attr);
 			if (ret)
-				return ret;
+				return -FI_EINVAL;
 		}
 
 		if (info->rx_attr) {
 			ret = sock_msg_verify_rx_attr(info->rx_attr);
 			if (ret)
-				return ret;
+				return -FI_EINVAL;
 		}
 	}
 

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -295,19 +295,19 @@ static int sock_rdm_endpoint(struct fid_domain *domain, struct fi_info *info,
 						      info->tx_attr,
 						      info->rx_attr);
 			if (ret)
-				return ret;
+				return -FI_EINVAL;
 		}
 
 		if (info->tx_attr) {
 			ret = sock_rdm_verify_tx_attr(info->tx_attr);
 			if (ret)
-				return ret;
+				return -FI_EINVAL;
 		}
 
 		if (info->rx_attr) {
 			ret = sock_rdm_verify_rx_attr(info->rx_attr);
 			if (ret)
-				return ret;
+				return -FI_EINVAL;
 		}
 	}
 

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -332,7 +332,7 @@ static int sock_fabric(struct fi_fabric_attr *attr,
 	struct sock_fabric *fab;
 
 	if (strcmp(attr->name, sock_fab_name))
-		return -FI_ENODATA;
+		return -FI_EINVAL;
 
 	fab = calloc(1, sizeof(*fab));
 	if (!fab)


### PR DESCRIPTION
- return -FI_EINVAL instead of -FI_ENODATA for fi_endpoint() in case of invalid attributes
- fix incorrect return value for fi_domain() and fi_fabric()