### PR TITLE
Update prov_name warning to include provider name

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -502,13 +502,15 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 		for (tail = cur; tail->next; tail = tail->next) {
 			if (tail->fabric_attr->prov_name != NULL)
 				FI_WARN(&core_prov, FI_LOG_CORE,
-					"provider name is not NULL\n");
+					"prov_name field is not NULL (%s)\n",
+					tail->fabric_attr->prov_name);
 			tail->fabric_attr->prov_name = strdup(prov->provider->name);
 			tail->fabric_attr->prov_version = prov->provider->version;
 		}
 		if (tail->fabric_attr->prov_name != NULL)
 			FI_WARN(&core_prov, FI_LOG_CORE,
-				"provider name is not NULL\n");
+				"prov_name field is not NULL (%s)\n",
+				tail->fabric_attr->prov_name);
 		tail->fabric_attr->prov_name = strdup(prov->provider->name);
 		tail->fabric_attr->prov_version = prov->provider->version;
 	}


### PR DESCRIPTION
I also changed the message to use the field name, since it read a little funny.

In response to comments from #1371

@shefty @bturrubiates 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>