### PR TITLE
prov/psm: properly destroy pthread mutex and conditional variables

### DIFF
--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -134,6 +134,12 @@ int psmx_am_init(struct psmx_fid_domain *domain)
 
 int psmx_am_fini(struct psmx_fid_domain *domain)
 {
+	pthread_mutex_destroy(&domain->rma_queue.lock);
+	pthread_mutex_destroy(&domain->recv_queue.lock);
+	pthread_mutex_destroy(&domain->unexp_queue.lock);
+	pthread_mutex_destroy(&domain->trigger_queue.lock);
+	pthread_mutex_destroy(&domain->send_queue.lock);
+
 	return 0;
 }
 

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -751,6 +751,8 @@ static int psmx_cq_close(fid_t fid)
 		free(item);
 	}
 
+	pthread_mutex_destroy(&cq->mutex);
+
 	if (cq->wait && cq->wait_is_local)
 		fi_close((fid_t)cq->wait);
 

--- a/prov/psm/src/psmx_eq.c
+++ b/prov/psm/src/psmx_eq.c
@@ -312,6 +312,8 @@ static int psmx_eq_close(fid_t fid)
 		free(item);
 	}
 
+	pthread_mutex_destroy(&eq->mutex);
+
 	if (eq->wait && eq->wait_is_local)
 		fi_close((fid_t)eq->wait);
 

--- a/prov/psm/src/psmx_wait.c
+++ b/prov/psm/src/psmx_wait.c
@@ -213,6 +213,11 @@ static int psmx_wait_close(fid_t fid)
 		close(wait->fd[0]);
 		close(wait->fd[1]);
 	}
+	else if (wait->type == FI_WAIT_MUTEX_COND) {
+		pthread_mutex_destroy(&wait->mutex);
+		pthread_cond_destroy(&wait->cond);
+	}
+
 	free(wait);
 	return 0;
 }


### PR DESCRIPTION
To ensure associated resources are released.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>