### PR TITLE
prov/psm: use fastlock instead of pthread mutex whenever suitable

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -273,7 +273,7 @@ struct psmx_unexp {
 };
 
 struct psmx_req_queue {
-	pthread_mutex_t	lock;
+	fastlock_t	lock;
 	struct slist	list;
 };
 
@@ -398,7 +398,7 @@ struct psmx_fid_cq {
 	size_t				event_count;
 	struct slist			event_queue;
 	struct slist			free_list;
-	pthread_mutex_t			mutex;
+	fastlock_t			lock;
 	struct psmx_cq_event		*pending_error;
 	struct psmx_fid_wait		*wait;
 	int				wait_cond;
@@ -411,7 +411,7 @@ struct psmx_fid_eq {
 	struct slist			event_queue;
 	struct slist			error_queue;
 	struct slist			free_list;
-	pthread_mutex_t			mutex;
+	fastlock_t			lock;
 	struct psmx_fid_wait		*wait;
 	int				wait_is_local;
 };
@@ -725,6 +725,8 @@ int	psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 int	psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
 #endif
+void	psmx_atomic_init(void);
+void	psmx_atomic_fini(void);
 
 void	psmx_am_ack_rma(struct psmx_am_request *req);
 

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -197,9 +197,9 @@ void psmx_cntr_check_trigger(struct psmx_fid_cntr *cntr)
 		cntr->trigger = trigger->next;
 
 		if (domain->am_initialized) {
-			pthread_mutex_lock(&domain->trigger_queue.lock);
+			fastlock_acquire(&domain->trigger_queue.lock);
 			slist_insert_tail(&trigger->list_entry, &domain->trigger_queue.list);
-			pthread_mutex_unlock(&domain->trigger_queue.lock);
+			fastlock_release(&domain->trigger_queue.lock);
 		}
 		else {
 			psmx_process_trigger(domain, trigger);

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -35,17 +35,17 @@
 static inline void psmx_am_enqueue_send(struct psmx_fid_domain *domain,
 					struct psmx_am_request *req)
 {
-	pthread_mutex_lock(&domain->send_queue.lock);
+	fastlock_acquire(&domain->send_queue.lock);
 	slist_insert_tail(&req->list_entry, &domain->send_queue.list);
-	pthread_mutex_unlock(&domain->send_queue.lock);
+	fastlock_release(&domain->send_queue.lock);
 }
 
 static inline void psmx_am_enqueue_recv(struct psmx_fid_domain *domain,
 					struct psmx_am_request *req)
 {
-	pthread_mutex_lock(&domain->recv_queue.lock);
+	fastlock_acquire(&domain->recv_queue.lock);
 	slist_insert_tail(&req->list_entry, &domain->recv_queue.list);
-	pthread_mutex_unlock(&domain->recv_queue.lock);
+	fastlock_release(&domain->recv_queue.lock);
 }
 
 static int match_recv(struct slist_entry *item, const void *src_addr)
@@ -65,10 +65,10 @@ static struct psmx_am_request *psmx_am_search_and_dequeue_recv(
 {
 	struct slist_entry *item;
 
-	pthread_mutex_lock(&domain->recv_queue.lock);
+	fastlock_acquire(&domain->recv_queue.lock);
 	item = slist_remove_first_match(&domain->recv_queue.list,
 					match_recv, src_addr);
-	pthread_mutex_unlock(&domain->recv_queue.lock);
+	fastlock_release(&domain->recv_queue.lock);
 
 	if (!item)
 		return NULL;
@@ -79,9 +79,9 @@ static struct psmx_am_request *psmx_am_search_and_dequeue_recv(
 static inline void psmx_am_enqueue_unexp(struct psmx_fid_domain *domain,
 					 struct psmx_unexp *unexp)
 {
-	pthread_mutex_lock(&domain->unexp_queue.lock);
+	fastlock_acquire(&domain->unexp_queue.lock);
 	slist_insert_tail(&unexp->list_entry, &domain->unexp_queue.list);
-	pthread_mutex_unlock(&domain->unexp_queue.lock);
+	fastlock_release(&domain->unexp_queue.lock);
 }
 
 static int match_unexp(struct slist_entry *item, const void *src_addr)
@@ -102,10 +102,10 @@ static struct psmx_unexp *psmx_am_search_and_dequeue_unexp(
 {
 	struct slist_entry *item;
 
-	pthread_mutex_lock(&domain->unexp_queue.lock);
+	fastlock_acquire(&domain->unexp_queue.lock);
 	item = slist_remove_first_match(&domain->unexp_queue.list,
 					match_unexp, src_addr);
-	pthread_mutex_unlock(&domain->unexp_queue.lock);
+	fastlock_release(&domain->unexp_queue.lock);
 
 	if (!item)
 		return NULL;

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -35,9 +35,9 @@
 static inline void psmx_am_enqueue_rma(struct psmx_fid_domain *domain,
 				       struct psmx_am_request *req)
 {
-	pthread_mutex_lock(&domain->rma_queue.lock);
+	fastlock_acquire(&domain->rma_queue.lock);
 	slist_insert_tail(&req->list_entry, &domain->rma_queue.list);
-	pthread_mutex_unlock(&domain->rma_queue.lock);
+	fastlock_release(&domain->rma_queue.lock);
 }
 
 /* RMA protocol:

--- a/prov/psm2/src/rename.h
+++ b/prov/psm2/src/rename.h
@@ -63,6 +63,8 @@
 #define psmx_atomic_do_compwrite psmx2_atomic_do_compwrite
 #define psmx_atomic_do_readwrite psmx2_atomic_do_readwrite
 #define psmx_atomic_do_write psmx2_atomic_do_write
+#define psmx_atomic_fini psmx2_atomic_fini
+#define psmx_atomic_init psmx2_atomic_init
 #define psmx_atomic_inject psmx2_atomic_inject
 #define psmx_atomic_lock psmx2_atomic_lock
 #define psmx_atomic_ops psmx2_atomic_ops
@@ -101,6 +103,7 @@
 #define psmx_cntr_set psmx2_cntr_set
 #define psmx_cntr_wait psmx2_cntr_wait
 #define psmx_context_type psmx2_context_type
+#define psmx_cq_alloc_event psmx2_cq_alloc_event
 #define psmx_cq_close psmx2_cq_close
 #define psmx_cq_control psmx2_cq_control
 #define psmx_cq_create_event psmx2_cq_create_event
@@ -108,6 +111,7 @@
 #define psmx_cq_dequeue_event psmx2_cq_dequeue_event
 #define psmx_cq_enqueue_event psmx2_cq_enqueue_event
 #define psmx_cq_event psmx2_cq_event
+#define psmx_cq_free_event psmx2_cq_free_event
 #define psmx_cq_get_event_src_addr psmx2_cq_get_event_src_addr
 #define psmx_cq_open psmx2_cq_open
 #define psmx_cq_ops psmx2_cq_ops
@@ -125,6 +129,8 @@
 #define psmx_domain_enable_ep psmx2_domain_enable_ep
 #define psmx_domain_open psmx2_domain_open
 #define psmx_domain_ops psmx2_domain_ops
+#define psmx_domain_start_progress psmx2_domain_start_progress
+#define psmx_domain_stop_progress psmx2_domain_stop_progress
 #define psmx_env psmx2_env
 #define psmx_epaddr_context psmx2_epaddr_context
 #define psmx_ep_bind psmx2_ep_bind
@@ -209,6 +215,8 @@
 #define psmx_poll_poll psmx2_poll_poll
 #define psmx_process_trigger psmx2_process_trigger
 #define psmx_progress psmx2_progress
+#define psmx_progress_func psmx2_progress_func
+#define psmx_progress_set_affinity psmx2_progress_set_affinity
 #define psmx_prov psmx2_prov
 #define psmx_query_mpi psmx2_query_mpi
 #define _psmx_read _psmx2_read


### PR DESCRIPTION
Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>