### PR TITLE
clarify mode bit handling

### DIFF
--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -98,6 +98,8 @@ requested value or fail the operation with -FI_ENODATA.  With the
 exception of mode bits, hints that are set to zero are treated as
 a wildcard.  A zeroed hint value results in providers either returning
 a default value or a value that works best for their implementation.
+Mode bits that are set to zero indicate the application does not support
+any modes.
 
 The caller must call fi_freeinfo to release fi_info structures returned
 by this call.
@@ -374,7 +376,8 @@ support.  On output, providers will clear mode bits that are not
 necessary to achieve high-performance.  Mode bits that remain set
 indicate application requirements for using the fabric interfaces
 created using the returned fi_info.  The set of modes are listed
-below.
+below.  If a NULL hints structure is provided, then the provider's
+supported set of modes will be returned in the info structure(s).
 
 *FI_CONTEXT*
 : Specifies that the provider requires that applications use struct

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -525,8 +525,7 @@ int usdf_dgram_fill_tx_attr(struct fi_info *hints, struct fi_info *fi,
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	if (hints->tx_attr->mode)
-		defaults.mode &= hints->tx_attr->mode;
+	defaults.mode &= (hints->mode | hints->tx_attr->mode);
 
 	/* make sure the app supports our required mode bits */
 	if ((defaults.mode & USDF_DGRAM_REQ_MODE) != USDF_DGRAM_REQ_MODE)
@@ -601,8 +600,7 @@ int usdf_dgram_fill_rx_attr(struct fi_info *hints, struct fi_info *fi,
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	if (hints->rx_attr->mode)
-		defaults.mode &= hints->rx_attr->mode;
+	defaults.mode &= (hints->mode | hints->rx_attr->mode);
 
 	/* make sure the app supports our required mode bits */
 	if ((defaults.mode & USDF_DGRAM_REQ_MODE) != USDF_DGRAM_REQ_MODE)

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -234,8 +234,7 @@ int usdf_msg_fill_tx_attr(struct fi_info *hints, struct fi_info *fi)
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	if (hints->tx_attr->mode)
-		defaults.mode &= hints->tx_attr->mode;
+	defaults.mode &= (hints->mode | hints->tx_attr->mode);
 
 	/* make sure the app supports our required mode bits */
 	if ((defaults.mode & USDF_MSG_REQ_MODE) != USDF_MSG_REQ_MODE)
@@ -283,8 +282,7 @@ int usdf_msg_fill_rx_attr(struct fi_info *hints, struct fi_info *fi)
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	if (hints->rx_attr->mode)
-		defaults.mode &= hints->rx_attr->mode;
+	defaults.mode &= (hints->mode | hints->rx_attr->mode);
 
 	/* make sure the app supports our required mode bits */
 	if ((defaults.mode & USDF_MSG_REQ_MODE) != USDF_MSG_REQ_MODE)

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -236,8 +236,7 @@ int usdf_rdm_fill_tx_attr(struct fi_info *hints, struct fi_info *fi)
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	if (hints->tx_attr->mode)
-		defaults.mode &= hints->tx_attr->mode;
+	defaults.mode &= (hints->mode | hints->tx_attr->mode);
 
 	/* make sure the app supports our required mode bits */
 	if ((defaults.mode & USDF_RDM_REQ_MODE) != USDF_RDM_REQ_MODE)
@@ -285,8 +284,7 @@ int usdf_rdm_fill_rx_attr(struct fi_info *hints, struct fi_info *fi)
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	if (hints->rx_attr->mode)
-		defaults.mode &= hints->rx_attr->mode;
+	defaults.mode &= (hints->mode | hints->rx_attr->mode);
 
 	/* make sure the app supports our required mode bits */
 	if ((defaults.mode & USDF_RDM_REQ_MODE) != USDF_RDM_REQ_MODE)


### PR DESCRIPTION
This PR clarifies the expected `fi_getinfo` behavior around mode bits and fixes the `usnic` provider to match this clarified behavior.

Already reviewed internally by @bturrubiates.  @shefty, does this (esp. the man page update) work for you?