### PR TITLE
man: Fix wording when using FI_CONTEXT

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -1156,7 +1156,7 @@ fabric endpoint.
 
 Endpoints allocated with the FI_CONTEXT mode set must typically
 provide struct fi_context as their per operation context parameter.
-(See fi_getinfo.3 for details.)  However, when FI_COMPLETION is
+(See fi_getinfo.3 for details.)  However, when FI_SELECTIVE_COMPLETION is
 enabled to suppress completion entries, and an operation is initiated
 without FI_COMPLETION flag set, then the context parameter is ignored.
 An application does not need to pass in a valid struct fi_context into


### PR DESCRIPTION
Replace FI_COMPLETION with FI_SELECTIVE_COMPLETION in the
description for FI_CONTEXT exceptions.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>