### PR TITLE
prov/psm: make sure FI_PSM_TIMEOUT=0 works as expected

### DIFF
--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -209,8 +209,12 @@ static int psmx_domain_close(fid_t fid)
 	 */
 	sleep(psmx_env.delay);
 
-	err = psm_ep_close(domain->psm_ep, PSM_EP_CLOSE_GRACEFUL,
-			   (int64_t) psmx_env.timeout * 1000000000LL);
+	if (psmx_env.timeout)
+		err = psm_ep_close(domain->psm_ep, PSM_EP_CLOSE_GRACEFUL,
+				   (int64_t) psmx_env.timeout * 1000000000LL);
+	else
+		err = PSM_EP_CLOSE_TIMEOUT;
+
 	if (err != PSM_OK)
 		psm_ep_close(domain->psm_ep, PSM_EP_CLOSE_FORCE, 0);
 


### PR DESCRIPTION
psm_ep_close treat timeout value 0 as infinity. We want this be 0.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>