### PR TITLE
cm: Add control option to set listen backlog

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -404,14 +404,10 @@ enum {
 	FI_SETFIDFLAG,		/* uint64_t flags */
 	FI_GETOPSFLAG,		/* uint64_t flags */
 	FI_SETOPSFLAG,		/* uint64_t flags */
-
-	/* Duplicate a fid_t.  This allows for 2 fids that refer to a single
-	 * HW resource.  Each fid may reference functions that are optimized
-	 * for different use cases.
-	 */
 	FI_ALIAS,		/* struct fi_alias * */
 	FI_GETWAIT,		/* void * wait object */
 	FI_ENABLE,		/* NULL */
+	FI_BACKLOG,		/* integer * */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -430,6 +430,10 @@ assigned to an endpoint.
   the type of data transfer that the flags should apply to, with other
   flags OR'ed in.  Valid control flags are defined below.
 
+**FI_BACKLOG - int *value**
+: This option only applies to passive endpoints.  It is used to set the
+  connection request backlog for listening endpoints.
+
 ## fi_getopt / fi_setopt
 
 Endpoint protocol operations may be retrieved using fi_getopt or set


### PR DESCRIPTION
Rsockets and ES-API require the ability to set the listen
backlog.  Add a control option to support this.

Fix #537

Signed-off-by: Sean Hefty <sean.hefty@intel.com>