### PR TITLE
prov/psm: fix the handling of context for ops w/o completion

### DIFF
--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -94,7 +94,7 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 		src_addr = 0;
 	}
 
-	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION) && !context) {
+	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION)) {
 		fi_context = &ep_priv->nocomp_recv_context;
 	}
 	else {

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -243,7 +243,7 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
 	psm_tagsel = (~ignore) | ep_priv->domain->reserved_tag_bits;
 
-	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION) && !context) {
+	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION)) {
 		fi_context = &ep_priv->nocomp_recv_context;
 	}
 	else {


### PR DESCRIPTION
According to the man pages, on EPs with FI_SELECTIVE_COMPLETION
flag set, the "context" parameter should be ignored for operations
without the FI_COMPLETION flag.

Previously, for recv ops only NULL context was ignored in such
case. The intention was to allow non-NULL context be passed for
the purpose of calling fi_cancel later. However, such behavior
doesn't conform to the spec and has the possibility of causing
memory corruption.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>