### PR TITLE
man/cq: Fix description of EPs bound to CQs and counters

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -1180,11 +1180,14 @@ Operations that complete in error that are not associated with valid
 operational context will use the endpoint context in any error
 reporting structures.
 
-Users can attach both counters and completion queues to an endpoint.
-When both counter and completion queue are attached, a successful
-completion increments the counter and does not generate a completion
-entry in the completion queue. Operations that complete with an error
-increment the error counter and generate a completion event.
+Although applications typically association individual completions with
+either completion queues or counters, an endpoint can be attached to
+both a counter and completion queue.  When combined with using
+selective completions, this allows an appliction to use counters to
+track successful completions, with a CQ used to report errors.
+Operations that complete with an error increment the error counter
+and generate a completion event.  The generation of entries going to
+the CQ can then be controlled using FI_SELECTIVE_COMPLETION.
 
 # RETURN VALUES
 


### PR DESCRIPTION
The man pages states that a EP that is bound to both a CQ
and a counter will not generate completions on the CQ except
in error cases.  The text should reference the use of the
FI_SELECTIVE_COMPLETION flag for supressing completions.
An EP bound to a CQ *will* generate completions by default
unless completions are disabled.

This updates the man page to match the desired intent, as
well as the implementation provided by the sockets and psm
providers.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>