### PR TITLE
usnic: improve fi_cq_sread performance

### DIFF
--- a/prov/usnic/src/usdf_cq.h
+++ b/prov/usnic/src/usdf_cq.h
@@ -36,7 +36,10 @@
 #ifndef _USDF_CQ_H_
 #define _USDF_CQ_H_
 
-#define SREAD_SLEEP_TIME_MS 5
+/* exponential backoff settings for fi_cq_sread */
+#define SREAD_EXP_BASE 2
+#define SREAD_INIT_SLEEP_TIME_US 1
+#define SREAD_MAX_SLEEP_TIME_US 5000
 
 int usdf_cq_is_soft(struct usdf_cq *cq);
 int usdf_cq_make_soft(struct usdf_cq *cq);


### PR DESCRIPTION
The usnic provider's fi_cq_sread performance was suboptimal before this
change.  It used a static 5 millisecond (not microsecond) sleep time
between polling the underlying CQ, resulting in terrible performance for
use cases where a completion would be arriving soon but was not actually
present yet in the CQ to be read upon initial entry into fi_cq_sread.

This commit changes the implementation to use an exponential back-off
strategy that starts small (2 microseconds) but doubles up to a cap
(currently 5 milliseconds).

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@bturrubiates please review