### PR TITLE
usnic: set ui_version union tag correctly

### DIFF
--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -748,6 +748,9 @@ usdf_usnic_getinfo(uint32_t version, struct fid_fabric *fabric,
 		return -FI_EINVAL;
 	}
 
+	/* this assignment was missing in libfabric v1.1.1 and earlier */
+	uip->ui_version = FI_EXT_USNIC_INFO_VERSION;
+
 	uip->ui.v1.ui_link_speed = dap->uda_bandwidth;
 	uip->ui.v1.ui_netmask_be = dap->uda_netmask_be;
 	strcpy(uip->ui.v1.ui_ifname, dap->uda_ifname);


### PR DESCRIPTION
fi_usnic_info::ui_version was not being set correctly upon return from
the fi_usnic_ops_fabric::getinfo() routine.  libfabric releases v1.1.1
and earlier will not set this field at all.  Clients who wish to operate
with <=v1.1.1 should set the ui_version field to 1 before calling
the getinfo extension.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>

@bturrubiates / @jsquyres please review