### PR TITLE
travis-ci: Enabled debug for linux with gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,13 @@ addons:
                         - rpm
 install:
         - ./autogen.sh
+        - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "gcc" ]]; then ./configure --prefix=$HOME --enable-debug && make -j2; fi
         - ./configure --prefix=$HOME
         - make -j2
         - make install
         - make test
         - make distcheck
-        - if [ "$TRAVIS_OS_NAME" = "linux" ]; then make rpm; fi
+        - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make rpm; fi
 script:
         - git clone https://github.com/ofiwg/fabtests.git
         - cd fabtests


### PR DESCRIPTION
Added --enable-debug in the configure line when building on linux with gcc

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>