### PR TITLE
fabric: Fix debug build and add asserts to lock routines

### DIFF
--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -191,10 +191,7 @@ static int psmx_domain_close(fid_t fid)
 
 	psmx_am_fini(domain);
 
-	err = fastlock_destroy(&domain->poll_lock);
-	if (err)
-		FI_WARN(&psmx_prov, FI_LOG_CORE,
-			"pthread_spin_destroy returns %d\n", err);
+	fastlock_destroy(&domain->poll_lock);
 
 #if 0
 	/* AM messages could arrive after MQ is finalized, causing segfault

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2388,8 +2388,7 @@ int sock_pe_progress_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx)
 	struct dlist_entry *entry;
 	struct sock_pe_entry *pe_entry;
 
-	if (fastlock_acquire(&pe->lock))
-		return 0;
+	fastlock_acquire(&pe->lock);
 
 	fastlock_acquire(&rx_ctx->lock);
 	sock_pe_progress_buffered_rx(rx_ctx);
@@ -2459,8 +2458,7 @@ int sock_pe_progress_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx)
 	struct dlist_entry *entry;
 	struct sock_pe_entry *pe_entry;
 
-	if (fastlock_acquire(&pe->lock))
-		return 0;
+	fastlock_acquire(&pe->lock);
 
 	fastlock_acquire(&tx_ctx->rlock);
 	if (!rbfdempty(&tx_ctx->rbfd) &&


### PR DESCRIPTION
Add assertions to the fastlock abstraction to check for
valid use.  Convert fastlock routines from returning int
to void, in order that optimized implementations may be
added (such as the original fastlock code) for better
performance, rather than assuming the pthread interface.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>