### PR TITLE
RFC: FI_PROV_ATTR_ONLY

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -125,6 +125,7 @@ typedef struct fid *fid_t;
 #define FI_DELIVERY_COMPLETE	(1ULL << 28)
 
 /* fi_getinfo()-specific flags/caps */
+#define FI_PROV_ATTR_ONLY	(1ULL << 54)
 #define FI_NUMERICHOST		(1ULL << 55)
 #define FI_RMA_EVENT		(1ULL << 56)
 #define FI_SOURCE		(1ULL << 57)

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -512,6 +512,15 @@ input flags.  Valid flags include the following.
   the node and/or service parameter must be non-NULL.  This flag is
   often used with passive endpoints.
 
+*FI_PROV_ATTR_ONLY*
+: Indicates that the caller is only querying for what providers are
+  potentially available.  All providers will return exactly one
+  fi_info struct, regardless of whether that provider is usable on the
+  current platform or not.  The returned fi_info struct will contain
+  default values for all members, with the exception of fabric_attr.
+  The fabric_attr member will have the prov_name and prov_version
+  values filled in.
+
 # RETURN VALUE
 
 fi_getinfo() returns 0 on success. On error, fi_getinfo() returns a


### PR DESCRIPTION
Add a new mode bit: FI_PROV_ATTR_ONLY

The intent is that you can call `fi_getinfo()` with the FI_PROV_ATTR_ONLY mode bit set in the hints.  This will cause all providers to return exactly one info instance with only the provider attributes set -- namely:

* info->fabric_attr.prov_name
* info->fabric_attr.prov_version

The primary use case is a new `--list` (or `-l`) option to `fi_info` that will list all available providers, regardless of what hardware is available in the current environment.  This is a direct result of user feedback -- e.g., users want to ensure that the libfabric on their system has a specific provider support included.

This PR contains updates for the sockets and usnic providers.  If we generally like this concept, I will expand the PR to add support for the mode bit to all in-tree providers.