### PR TITLE
eliminate temporaries in atomic macros

### DIFF
--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -142,12 +142,10 @@ void psmx_atomic_fini(void)
 			TYPE *d = (dst); \
 			TYPE *s = (src); \
 			TYPE *r = (res); \
-			TYPE tmp; \
 			fastlock_acquire(&psmx_atomic_lock); \
 			for (i=0; i<(cnt); i++) {\
-				tmp = d[i]; \
+				r[i] = d[i]; \
 				OP(d[i],s[i]); \
-				r[i] = tmp; \
 			} \
 			fastlock_release(&psmx_atomic_lock); \
 		} while (0)
@@ -159,13 +157,11 @@ void psmx_atomic_fini(void)
 			TYPE *s = (src); \
 			TYPE *c = (cmp); \
 			TYPE *r = (res); \
-			TYPE tmp; \
 			fastlock_acquire(&psmx_atomic_lock); \
 			for (i=0; i<(cnt); i++) { \
-				tmp = d[i]; \
+				r[i] = d[i]; \
 				if (c[i] CMP_OP d[i]) \
 					d[i] = s[i]; \
-				r[i] = tmp; \
 			} \
 			fastlock_release(&psmx_atomic_lock); \
 		} while (0)
@@ -177,12 +173,10 @@ void psmx_atomic_fini(void)
 			TYPE *s = (src); \
 			TYPE *c = (cmp); \
 			TYPE *r = (res); \
-			TYPE tmp; \
 			fastlock_acquire(&psmx_atomic_lock); \
 			for (i=0; i<(cnt); i++) { \
-				tmp = d[i]; \
+				r[i] = d[i]; \
 				d[i] = (s[i] & c[i]) | (d[i] & ~c[i]); \
-				r[i] = tmp; \
 			} \
 			fastlock_release(&psmx_atomic_lock); \
 		} while (0)


### PR DESCRIPTION
is there a reason to load the dest data into a temp and only
store it into the result after the atomic operation has
been evaluated?  the atomic op should not fail unless the
user has provided bad buffer (i.e. it will segfault)
and the elemental operations are not atomic.

perhaps it is to impede compiler optimizations?