### PR TITLE
verbs: First set of code changes to support RDM EPs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -113,7 +113,9 @@ if HAVE_VERBS
 _verbs_files = \
 	prov/verbs/src/fi_verbs.h \
 	prov/verbs/src/fi_verbs.c \
+	prov/verbs/src/uthash.h \
 	prov/verbs/src/verbs_atomic.c \
+	prov/verbs/src/verbs_av.c \
 	prov/verbs/src/verbs_cm.c \
 	prov/verbs/src/verbs_cq.c \
 	prov/verbs/src/verbs_domain.c \
@@ -121,7 +123,18 @@ _verbs_files = \
 	prov/verbs/src/verbs_info.c \
 	prov/verbs/src/verbs_msg.c \
 	prov/verbs/src/verbs_msg_ep.c \
-	prov/verbs/src/verbs_rma.c
+	prov/verbs/src/verbs_rma.c \
+	prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c \
+	prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c \
+	prov/verbs/src/ep_rdm/verbs_ep_rdm.c \
+	prov/verbs/src/ep_rdm/verbs_queuing.h \
+	prov/verbs/src/ep_rdm/verbs_rdm_cm.c \
+	prov/verbs/src/ep_rdm/verbs_rdm.h \
+	prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h \
+	prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c \
+	prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c \
+	prov/verbs/src/ep_rdm/verbs_utils.c \
+	prov/verbs/src/ep_rdm/verbs_utils.h
 
 if HAVE_VERBS_DL
 pkglib_LTLIBRARIES += libverbs-fi.la

--- a/include/fi_list.h
+++ b/include/fi_list.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2011-2015 Intel Corporation.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -95,24 +95,35 @@ static inline void dlist_remove(struct dlist_entry *item)
 }
 
 #define dlist_foreach(head, item) \
-	for (item = head->next; item != head; item = item->next)
+	for (item = (head)->next; item != head; item = item->next)
 
-typedef int dlist_match_func_t(struct dlist_entry *item, const void *arg);
+typedef int dlist_func_t(struct dlist_entry *item, const void *arg);
 
 static inline struct dlist_entry *
-dlist_remove_first_match(struct dlist_entry *head, dlist_match_func_t *match,
-			 const void *arg)
+dlist_find_first_match(struct dlist_entry *head, dlist_func_t *match,
+		       const void *arg)
 {
 	struct dlist_entry *item;
 
 	dlist_foreach(head, item) {
-		if (match(item, arg)) {
-			dlist_remove(item);
+		if (match(item, arg))
 			return item;
-		}
 	}
 
 	return NULL;
+}
+
+static inline struct dlist_entry *
+dlist_remove_first_match(struct dlist_entry *head, dlist_func_t *match,
+			 const void *arg)
+{
+	struct dlist_entry *item;
+
+	item = dlist_find_first_match(head, match, arg);
+	if (item)
+		dlist_remove(item);
+
+	return item;
 }
 
 /*
@@ -172,10 +183,10 @@ static inline struct slist_entry *slist_remove_head(struct slist *list)
 #define slist_foreach(list, item, prev) \
 	for (prev = NULL, item = list->head; item; prev = item, item = item->next)
 
-typedef int slist_match_func_t(struct slist_entry *item, const void *arg);
+typedef int slist_func_t(struct slist_entry *item, const void *arg);
 
 static inline struct slist_entry *
-slist_remove_first_match(struct slist *list, slist_match_func_t *match, const void *arg)
+slist_remove_first_match(struct slist *list, slist_func_t *match, const void *arg)
 {
 	struct slist_entry *item, *prev;
 

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <arpa/inet.h>
+#include <rdma/rdma_cma.h>
+
+#include "verbs_rdm.h"
+
+
+extern struct fi_provider fi_ibv_prov;
+extern struct fi_ibv_rdm_tagged_conn *fi_ibv_rdm_tagged_conn_hash;
+
+
+int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
+                                struct fi_ibv_rdm_tagged_conn *conn)
+{
+	struct rdma_cm_id *id;
+	struct sockaddr_in sock_addr;
+
+	if (conn->state != FI_VERBS_CONN_ALLOCATED)
+		return 0;
+
+	if (ep->is_closing) {
+		FI_IBV_ERROR("Attempt to start connection with addr "
+		FI_IBV_RDM_ADDR_STR_FORMAT" when ep is closing\n",
+		FI_IBV_RDM_ADDR_STR(conn->addr));
+		return -1;
+	}
+
+	conn->state = FI_VERBS_CONN_STARTED;
+	memcpy(&sock_addr.sin_addr.s_addr, conn->addr,
+		sizeof(sock_addr.sin_addr.s_addr));
+	memcpy(&sock_addr.sin_port, (char *) conn->addr +
+		sizeof(sock_addr.sin_addr.s_addr), sizeof(sock_addr.sin_port));
+	sock_addr.sin_port = htons(sock_addr.sin_port);
+	sock_addr.sin_family = AF_INET;
+
+	rdma_create_id(ep->cm_listener_ec, &id, conn, RDMA_PS_TCP);
+	if (conn->is_active)
+		conn->id = id;
+
+	rdma_resolve_addr(id, NULL, (struct sockaddr *) &sock_addr, 30000);
+	return 0;
+}
+
+int fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_ep *ep,
+                                   struct fi_ibv_rdm_tagged_conn *conn)
+{
+	int ret;
+
+	FI_INFO(&fi_ibv_prov, FI_LOG_AV,
+		"Closing connection %p, state %d\n", conn, conn->state);
+
+	if (conn->state == FI_VERBS_CONN_ESTABLISHED) {
+		conn->state = FI_VERBS_CONN_LOCAL_DISCONNECT;
+	} else {
+		assert(conn->state == FI_VERBS_CONN_REMOTE_DISCONNECT ||
+		conn->state == FI_VERBS_CONN_REJECTED);
+		conn->state = FI_VERBS_CONN_CLOSED;
+	}
+
+	ret = rdma_disconnect(conn->id);
+	assert(ret == 0);
+	return ret;
+}
+
+static int fi_ibv_rdm_av_insert(struct fid_av *av, const void *addr,
+                                size_t count, fi_addr_t * fi_addr,
+                                uint64_t flags, void *context)
+{
+	struct fi_ibv_av *fid_av = container_of(av, struct fi_ibv_av, av);
+	struct fi_ibv_rdm_ep *ep = fid_av->ep;
+	int i,  ret = 0;
+
+	pthread_mutex_lock(&ep->cm_lock);
+	for (i = 0; i < count; i++) {
+		struct fi_ibv_rdm_tagged_conn *conn = NULL;
+		void *addr_i = (char *) addr + i * ep->fi_ibv_rdm_addrlen;
+		int addr_cmp = memcmp(addr_i, ep->my_rdm_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+
+		if (!addr_cmp) {
+			FI_INFO(&fi_ibv_prov, FI_LOG_AV, "fi_av_insert: SELF\n");
+ 			fi_addr[i] = (uintptr_t) (void *) FI_IBV_RDM_CONN_SELF;
+			ret++;
+			continue;
+		}
+
+		HASH_FIND(hh, fi_ibv_rdm_tagged_conn_hash, addr_i,
+			FI_IBV_RDM_DFLT_ADDRLEN, conn);
+
+		if (!conn) {
+			/* If addr_i is not found in HASH then we malloc it.
+			 * It could be found if the connection was initiated by the remote
+			 * side.
+			 */
+			conn = memalign(64, sizeof *conn);
+			if (!conn)
+				return -FI_ENOMEM;
+
+			memset(conn, 0, sizeof *conn);
+			dlist_init(&conn->postponed_requests_head);
+			conn->state = FI_VERBS_CONN_ALLOCATED;
+			memcpy(conn->addr, addr_i, FI_IBV_RDM_DFLT_ADDRLEN);
+			HASH_ADD(hh, fi_ibv_rdm_tagged_conn_hash, addr,
+			FI_IBV_RDM_DFLT_ADDRLEN, conn);
+		}
+		conn->is_active = (addr_cmp > 0);
+
+		fi_addr[i] = (uintptr_t) (void *) conn;
+		FI_INFO(&fi_ibv_prov, FI_LOG_AV, "fi_av_insert: addr "
+			FI_IBV_RDM_ADDR_STR_FORMAT " conn %p\n",
+			FI_IBV_RDM_ADDR_STR(conn->addr), conn);
+
+		ret++;
+	}
+
+	pthread_mutex_unlock(&ep->cm_lock);
+	return ret;
+}
+
+static int fi_ibv_rdm_av_remove(struct fid_av *av, fi_addr_t * fi_addr,
+                                size_t count, uint64_t flags)
+{
+	struct fi_ibv_rdm_tagged_conn *conn;
+	int i;
+
+	for (i = 0; i < count; i++) {
+		conn = (struct fi_ibv_rdm_tagged_conn *) fi_addr[i];
+		if (conn == FI_IBV_RDM_CONN_SELF) {
+			FI_INFO(&fi_ibv_prov, FI_LOG_AV, "av_remove SELF\n");
+			// SELF
+			continue;
+		}
+
+		FI_INFO(&fi_ibv_prov, FI_LOG_AV,
+			"av_remove conn %p, addr " FI_IBV_RDM_ADDR_STR_FORMAT "\n",
+			conn, FI_IBV_RDM_ADDR_STR(conn->addr));
+		rdma_disconnect(conn->id);
+	}
+
+	return 0;
+}
+
+static struct fi_ops_av fi_ibv_rdm_av_ops = {
+	.size = sizeof(struct fi_ops_av),
+	.insert = fi_ibv_rdm_av_insert,
+	.remove = fi_ibv_rdm_av_remove,
+};
+
+int fi_ibv_rdm_set_av_ops(struct fi_ibv_av *av)
+{
+	av->av.ops = &fi_ibv_rdm_av_ops;
+	return 0;
+}

--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+
+#include <fi_enosys.h>
+#include <fi_list.h>
+#include "../fi_verbs.h"
+#include "verbs_queuing.h"
+
+
+extern struct fi_ibv_mem_pool fi_ibv_rdm_tagged_request_pool;
+
+
+static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
+                                             size_t count, fi_addr_t * src_addr)
+{
+	struct fi_ibv_cq *_cq = container_of(cq, struct fi_ibv_cq, cq_fid);
+	struct fi_cq_tagged_entry *entry = buf;
+	size_t i;
+
+	for (i = 0;
+	     i < count && !dlist_empty(&fi_ibv_rdm_tagged_request_ready_queue);
+	     ++i)
+	{
+		struct fi_ibv_rdm_tagged_request *completed_req =
+			container_of(fi_ibv_rdm_tagged_request_ready_queue.next,
+				     struct fi_ibv_rdm_tagged_request, queue_entry);
+
+		fi_ibv_rdm_tagged_remove_from_ready_queue(completed_req);
+
+		FI_DBG(&fi_ibv_prov, FI_LOG_CQ,
+		       "\t\t-> found match in ready: op_ctx %p, len %d, tag 0x%llx\n",
+		       completed_req->context, completed_req->len,
+		       (long long unsigned int) completed_req->tag);
+
+		src_addr[i] = (fi_addr_t) (uintptr_t) completed_req->conn;
+		entry[i].op_context = completed_req->context;
+		entry[i].flags = 0;
+		entry[i].len = completed_req->len;
+		entry[i].data = completed_req->imm;
+		entry[i].tag = completed_req->tag;
+
+		if (completed_req->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
+			FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", completed_req,
+						      FI_LOG_DEBUG);
+			fi_ibv_mem_pool_return(&completed_req->mpe,
+						&fi_ibv_rdm_tagged_request_pool);
+		} else {
+			completed_req->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
+		}
+	}
+
+	if (i == 0) {
+		int err = fi_ibv_rdm_tagged_poll(_cq->ep);
+		if (err < 0) {
+			FI_IBV_ERROR("fi_ibv_rdm_tagged_poll failed\n");
+		}
+	}
+
+	return i;
+}
+
+static ssize_t fi_ibv_rdm_tagged_cq_read(struct fid_cq *cq, void *buf,
+                                         size_t count)
+{
+	fi_addr_t src_addr;
+	return fi_ibv_rdm_tagged_cq_readfrom(cq, buf, count, &src_addr);
+}
+
+#if 0
+static const char *fi_ibv_cq_strerror(struct fid_cq *eq, int prov_errno,
+                                      const void *err_data, char *buf,
+                                      size_t len)
+{
+	if (buf && len)
+		strncpy(buf, ibv_wc_status_str(prov_errno), len);
+	return ibv_wc_status_str(prov_errno);
+}
+#endif                          /* 0 */
+
+static ssize_t
+fi_ibv_rdm_tagged_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *entry,
+                             uint64_t flags)
+{
+#if 0
+	struct fi_ibv_cq *_cq;
+	_cq = container_of(cq, struct fi_ibv_cq, cq_fid);
+#endif                          /* 0 */
+	/* TODO */
+	return sizeof(*entry);
+}
+
+static struct fi_ops_cq fi_ibv_rdm_tagged_cq_ops = {
+	.size = sizeof(struct fi_ops_cq),
+	.read = fi_ibv_rdm_tagged_cq_read,
+	.readfrom = fi_ibv_rdm_tagged_cq_readfrom,
+	.readerr = fi_ibv_rdm_tagged_cq_readerr,
+	.sread = fi_no_cq_sread,
+	.strerror = fi_cq_strerror
+};
+
+#if 0
+static int fi_ibv_cq_close(fid_t fid)
+{
+	struct fi_ibv_cq *cq;
+	int ret;
+
+	cq = container_of(fid, struct fi_ibv_cq, cq_fid.fid);
+	assert(cq->ep->type == FI_EP_RDM);
+	while (cq->ep->ep_rdm.conn_active) {
+		if (0 != (ret = fi_ibv_rdm_tagged_cm_progress(cq->ep)))
+			return ret;
+
+	}
+
+	while (cq->ep->ep_rdm.pend_send || cq->ep->ep_rdm.pend_recv)
+		fi_ibv_rdm_tagged_poll(cq->ep);
+
+	if (cq->cq) {
+		ret = ibv_destroy_cq(cq->cq);
+		if (ret) {
+			FI_IBV_ERROR("ibv_destroy_cq returned: "
+				     "ret %d, errno %d, errstr %s", ret,
+				     errno, strerror(errno));
+			return -ret;
+		}
+	}
+
+	free(cq);
+	return 0;
+}
+#endif
+
+int fi_ibv_rdm_tagged_set_cq_ops(struct fi_ibv_cq *cq)
+{
+	assert(cq->format == FI_CQ_FORMAT_TAGGED);
+	cq->cq_fid.ops = &fi_ibv_rdm_tagged_cq_ops;
+	cq->entry_size = sizeof(struct fi_cq_tagged_entry);
+	return 0;
+}

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -1,0 +1,620 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <ifaddrs.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <rdma/rdma_cma.h>
+
+#include <fi_list.h>
+#include <fi_enosys.h>
+#include "../fi_verbs.h"
+#include "verbs_queuing.h"
+#include "verbs_utils.h"
+
+
+extern struct fi_ops_tagged fi_ibv_rdm_tagged_ops;
+extern struct fi_ops_cm fi_ibv_rdm_tagged_ep_cm_ops;
+extern struct dlist_entry fi_ibv_rdm_tagged_recv_posted_queue;
+extern struct fi_ibv_mem_pool fi_ibv_rdm_tagged_request_pool;
+extern struct fi_ibv_mem_pool fi_ibv_rdm_tagged_unexp_buffers_pool;
+extern struct fi_provider fi_ibv_prov;
+
+struct fi_ibv_rdm_tagged_conn *fi_ibv_rdm_tagged_conn_hash = NULL;
+
+
+static int
+fi_ibv_rdm_tagged_find_max_inline_size(struct ibv_pd *pd,
+				       struct ibv_context *context)
+{
+	struct ibv_qp_init_attr qp_attr;
+	struct ibv_qp *qp = NULL;
+	struct ibv_cq *cq = ibv_create_cq(context, 1, NULL, NULL, 0);
+	assert(cq);
+	int max_inline = 2;
+	int rst = 0;
+
+	memset(&qp_attr, 0, sizeof(qp_attr));
+	qp_attr.send_cq = cq;
+	qp_attr.recv_cq = cq;
+	qp_attr.qp_type = IBV_QPT_RC;
+	qp_attr.cap.max_send_wr = 1;
+	qp_attr.cap.max_recv_wr = 1;
+	qp_attr.cap.max_send_sge = 1;
+	qp_attr.cap.max_recv_sge = 1;
+
+	do {
+		if (qp)
+			ibv_destroy_qp(qp);
+		qp_attr.cap.max_inline_data = max_inline;
+		qp = ibv_create_qp(pd, &qp_attr);
+		if (qp)
+			rst = max_inline;
+	} while (qp && (max_inline *= 2));
+
+	if (rst != 0) {
+		int pos = rst, neg = max_inline;
+		do {
+			max_inline = pos + (neg - pos) / 2;
+			if (qp)
+				ibv_destroy_qp(qp);
+
+			qp_attr.cap.max_inline_data = max_inline;
+			qp = ibv_create_qp(pd, &qp_attr);
+			if (qp)
+				pos = max_inline;
+			else
+				neg = max_inline;
+
+		} while (neg - pos > 2);
+
+		rst = pos;
+	}
+
+	if (qp) {
+		ibv_destroy_qp(qp);
+	}
+
+	if (cq) {
+		ibv_destroy_cq(cq);
+	}
+
+	return rst;
+}
+
+static int fi_ibv_rdm_tagged_ep_bind(struct fid *fid, struct fid *bfid,
+				     uint64_t flags)
+{
+	struct fi_ibv_rdm_ep *ep;
+	int ret;
+
+	ep = container_of(fid, struct fi_ibv_rdm_ep, ep_fid.fid);
+
+	switch (bfid->fclass) {
+	case FI_CLASS_CQ:
+		{
+			struct fi_ibv_cq *cq =
+			    container_of(bfid, struct fi_ibv_cq, cq_fid);
+			ret = fi_ibv_rdm_tagged_set_cq_ops(cq);
+			if (ret)
+				return ret;
+
+			if (flags & FI_RECV) {
+				if (ep->fi_rcq)
+					return -EINVAL;
+				ep->fi_rcq = cq;
+			}
+			if (flags & FI_SEND) {
+				if (ep->fi_scq)
+					return -EINVAL;
+				ep->fi_scq = cq;
+			}
+
+			cq->ep = ep;
+
+			break;
+		}
+	case FI_CLASS_AV:
+		{
+			struct fi_ibv_av *av =
+			    container_of(bfid, struct fi_ibv_av, av.fid);
+			ep->av = av;
+			ep->av->ep = ep;
+			fi_ibv_rdm_set_av_ops(av);
+			break;
+		}
+	default:
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+static ssize_t fi_ibv_rdm_tagged_ep_cancel(fid_t fid, void *ctx)
+{
+	struct fi_ibv_rdm_ep *fid_ep;
+	struct fi_context *context = (struct fi_context *)ctx;
+	int err = 1;
+
+	fid_ep = container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
+	if (!fid_ep->domain)
+		return -EBADF;
+
+	if (!context)
+		return -EINVAL;
+
+	if (context->internal[0] == NULL)
+		return 0;
+
+	struct fi_ibv_rdm_tagged_request *request = context->internal[0];
+
+	VERBS_DBG("ep_cancel, match %p, tag 0x%llx, len %d, ctx %p\n",
+		  request, (long long unsigned)request->tag,
+		  request->len, request->context);
+
+	struct dlist_entry *found =
+	    dlist_find_first_match(&fi_ibv_rdm_tagged_recv_posted_queue,
+				   fi_ibv_rdm_tagged_match_requests, request);
+
+	if (found) {
+		assert(container_of(found, struct fi_ibv_rdm_tagged_request,
+				    queue_entry) == request);
+
+		fi_ibv_rdm_tagged_remove_from_posted_queue(request, fid_ep);
+
+		assert(request->send_completions_wait == 0);
+		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
+					      FI_LOG_DEBUG);
+
+		fi_ibv_mem_pool_return(&request->mpe,
+				       &fi_ibv_rdm_tagged_request_pool);
+
+		VERBS_DBG("\t\t-> SUCCESS, pend recv %d\n", fid_ep->pend_recv);
+
+		err = 0;
+	}
+
+	return err;
+}
+
+static int fi_ibv_rdm_tagged_ep_getopt(fid_t fid, int level, int optname,
+				       void *optval, size_t * optlen)
+{
+	switch (level) {
+	case FI_OPT_ENDPOINT:
+		return -FI_ENOPROTOOPT;
+	default:
+		return -FI_ENOPROTOOPT;
+	}
+	return 0;
+}
+
+static int fi_ibv_rdm_tagged_setopt(fid_t fid, int level, int optname,
+				    const void *optval, size_t optlen)
+{
+	switch (level) {
+	case FI_OPT_ENDPOINT:
+		return -FI_ENOPROTOOPT;
+	default:
+		return -FI_ENOPROTOOPT;
+	}
+	return 0;
+}
+
+#if 0
+static int fi_ibv_ep_enable(struct fid_ep *ep)
+{
+	struct fi_ibv_rdm_ep *_ep;
+
+	_ep = container_of(ep, struct fi_ibv_rdm_ep, ep_fid);
+
+	assert(_ep->type == FI_EP_RDM);
+	return 0;
+}
+#endif /* 0 */
+
+static int fi_ibv_rdm_tagged_control(fid_t fid, int command, void *arg)
+{
+	switch (command) {
+	case FI_ENABLE:
+		return 0;
+	default:
+		return -FI_ENOSYS;
+	}
+
+	return 0;
+}
+
+struct fi_ops_ep fi_ibv_rdm_tagged_ep_base_ops = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = fi_ibv_rdm_tagged_ep_cancel,
+	.getopt = fi_ibv_rdm_tagged_ep_getopt,
+	.setopt = fi_ibv_rdm_tagged_setopt,
+	.tx_ctx = fi_no_tx_ctx,
+	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
+};
+
+static int _fi_ibv_rdm_tagged_cm_progress_running = 1;
+
+static void *fi_ibv_rdm_tagged_cm_progress_thread(void *ctx)
+{
+	struct fi_ibv_rdm_ep *ep = (struct fi_ibv_rdm_ep *)ctx;
+	while (_fi_ibv_rdm_tagged_cm_progress_running) {
+		if (fi_ibv_rdm_tagged_cm_progress(ep)) {
+			FI_IBV_ERROR("fi_ibv_rdm_cm_progress error\n");
+			abort();
+		}
+		usleep(FI_IBV_RDM_CM_THREAD_TIMEOUT);
+	}
+	return NULL;
+}
+
+static int fi_ibv_rdm_tagged_ep_close(fid_t fid)
+{
+	int ret = 0;
+	struct fi_ibv_rdm_ep *ep;
+	void *status;
+	ep = container_of(fid, struct fi_ibv_rdm_ep, ep_fid.fid);
+
+	ep->is_closing = 1;
+	// assert(ep->pend_send == 0);
+	// assert(ep->pend_recv == 0); //TODO
+	_fi_ibv_rdm_tagged_cm_progress_running = 0;
+	pthread_join(ep->cm_progress_thread, &status);
+	pthread_mutex_destroy(&ep->cm_lock);
+
+	struct fi_ibv_rdm_tagged_conn *conn, *tmp;
+
+	HASH_ITER(hh, fi_ibv_rdm_tagged_conn_hash, conn, tmp) {
+		HASH_DEL(fi_ibv_rdm_tagged_conn_hash, conn);
+		switch (conn->state) {
+		case FI_VERBS_CONN_ALLOCATED:
+			free(conn);
+			break;
+		case FI_VERBS_CONN_REMOTE_DISCONNECT:
+			fi_ibv_rdm_start_disconnection(ep, conn);
+			fi_ibv_rdm_tagged_conn_cleanup(ep, conn);
+			break;
+		case FI_VERBS_CONN_STARTED:
+			while (conn->state != FI_VERBS_CONN_ESTABLISHED &&
+			       conn->state != FI_VERBS_CONN_REJECTED) {
+				ret = fi_ibv_rdm_tagged_cm_progress(ep);
+				if (ret) {
+					FI_IBV_ERROR("cm progress failed\n");
+					return ret;
+				}
+			}
+		case FI_VERBS_CONN_ESTABLISHED:
+			fi_ibv_rdm_start_disconnection(ep, conn);
+			break;
+		default:
+			break;
+		}
+	}
+	while (ep->num_active_conns) {
+		ret = fi_ibv_rdm_tagged_cm_progress(ep);
+		if (ret) {
+			FI_IBV_ERROR("cm progress failed\n");
+			return ret;
+		}
+	}
+
+	assert(0 == HASH_COUNT(fi_ibv_rdm_tagged_conn_hash) &&
+	       NULL == fi_ibv_rdm_tagged_conn_hash);
+
+	FI_INFO(&fi_ibv_prov, FI_LOG_AV, "DISCONNECT complete\n");
+	rdma_destroy_id(ep->cm_listener);
+	ibv_destroy_cq(ep->scq);
+	ibv_destroy_cq(ep->rcq);
+
+	fi_ibv_mem_pool_fini(&fi_ibv_rdm_tagged_request_pool);
+	fi_ibv_mem_pool_fini(&fi_ibv_rdm_tagged_postponed_pool);
+	fi_ibv_mem_pool_fini(&fi_ibv_rdm_tagged_unexp_buffers_pool);
+
+	free(ep);
+
+	return 0;
+}
+
+#if 0
+static int fi_ibv_ep_sync(fid_t fid, uint64_t flags, void *context)
+{
+	struct fi_ibv_rdm_ep *ep;
+
+	ep = container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
+
+	if (ep->type == FI_EP_MSG) {
+		return 0;
+	} else if (ep->type == FI_EP_RDM) {
+		if (!flags || (flags & FI_SEND)) {
+			while (ep->pend_send) {
+				fi_ibv_rdm_tagged_poll(ep);
+			}
+		}
+
+		if (!flags || (flags & FI_RECV)) {
+			while (ep->pend_recv) {
+				fi_ibv_rdm_tagged_poll(ep);
+			}
+		}
+
+		if (!flags || (flags & FI_READ)) {
+		}
+
+		if (!flags || (flags & FI_WRITE) || (flags & FI_WRITE)) {
+		}
+	}
+	return 0;
+}
+#endif /* 0 */
+
+struct fi_ops fi_ibv_rdm_tagged_ep_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = fi_ibv_rdm_tagged_ep_close,
+	.bind = fi_ibv_rdm_tagged_ep_bind,
+	.control = fi_ibv_rdm_tagged_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static inline int fi_ibv_rdm_tagged_test_addr(const char *devname,
+					      struct sockaddr_in *addr)
+{
+	struct rdma_cm_id *test_id;
+	int test = 0;
+	if (rdma_create_id(NULL, &test_id, NULL, RDMA_PS_TCP)) {
+		FI_IBV_ERROR("Failed to create test rdma cm id: %s\n",
+			     strerror(errno));
+		return -1;
+	}
+
+	if (rdma_bind_addr(test_id, (struct sockaddr *)addr)) {
+		FI_WARN(&fi_ibv_prov, FI_LOG_CORE,
+			"Failed to bind cm listener to  addr : %s\n",
+			strerror(errno));
+		rdma_destroy_id(test_id);
+		return 0;
+	}
+
+	FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "device name: %s %s\n",
+		test_id->verbs->device->name, devname);
+
+	if (!strcmp(test_id->verbs->device->name, devname)) {
+		test = 1;
+	}
+
+	rdma_destroy_id(test_id);
+	return test;
+}
+
+/* find the IPoIB address of the device opened in the fi_domain call. The name
+ * of this device is _domain->verbs->device->name. The logic of the function is:
+ * iterate through all the available network interfaces, find those having "ib"
+ * in the name, then try to test the IB device that correspond to each address.
+ * If the name is the desired one then we're done.
+ */
+static inline int fi_ibv_rdm_tagged_find_ipoib_addr(struct fi_ibv_rdm_ep *ep,
+						    const char *devname)
+{
+	struct ifaddrs *addrs, *tmp;
+	getifaddrs(&addrs);
+	tmp = addrs;
+	int found = 0;
+
+	while (tmp) {
+		if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_INET) {
+			struct sockaddr_in *paddr =
+			    (struct sockaddr_in *) tmp->ifa_addr;
+			if (!strncmp(tmp->ifa_name, "ib", 2)) {
+				int ret;
+				ret = fi_ibv_rdm_tagged_test_addr(devname, paddr);
+				if (ret == 1) {
+					memcpy(&ep->my_ipoib_addr, paddr,
+						sizeof(struct sockaddr_in));
+					found = 1;
+					break;
+				} else if (ret < 0) {
+					return -1;
+				}
+			}
+		}
+
+		tmp = tmp->ifa_next;
+	}
+
+	if (found) {
+		if (ep->my_ipoib_addr.sin_family == AF_INET) {
+			inet_ntop(ep->my_ipoib_addr.sin_family,
+				  &ep->my_ipoib_addr.sin_addr.s_addr,
+				  ep->my_ipoib_addr_str, INET_ADDRSTRLEN);
+		} else {
+			assert(0);
+		}
+	}
+	return !found;
+}
+
+int fi_ibv_rdm_tagged_open_ep(struct fid_domain *domain, struct fi_info *info,
+			      struct fid_ep **ep, void *context)
+{
+	struct fi_ibv_domain *_domain;
+	int ret = 0;
+
+	_domain = container_of(domain, struct fi_ibv_domain, domain_fid);
+	if (strcmp(_domain->verbs->device->name, info->domain_attr->name)) {
+		return -FI_EINVAL;
+	}
+
+	struct fi_ibv_rdm_ep *_ep;
+	_ep = calloc(1, sizeof *_ep);
+	if (!_ep) {
+		return -FI_ENOMEM;
+	}
+
+	_ep->domain = _domain;
+	_ep->ep_fid.fid.fclass = FI_CLASS_EP;
+	_ep->ep_fid.fid.context = context;
+	_ep->ep_fid.fid.ops = &fi_ibv_rdm_tagged_ep_ops;
+	_ep->ep_fid.ops = &fi_ibv_rdm_tagged_ep_base_ops;
+	_ep->ep_fid.tagged = &fi_ibv_rdm_tagged_ops;
+	_ep->ep_fid.cm = &fi_ibv_rdm_tagged_ep_cm_ops;
+
+	if (fi_ibv_rdm_tagged_find_ipoib_addr
+	    (_ep, _domain->verbs->device->name)) {
+		ret = -FI_ENODEV;
+		FI_IBV_ERROR("Failed to find correct IPoIB address\n");
+		goto err;
+	}
+
+	FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "My IPoIB: %s\n",
+		_ep->my_ipoib_addr_str);
+	_ep->cm_listener_ec = rdma_create_event_channel();
+	if (!_ep->cm_listener_ec) {
+		FI_IBV_ERROR("Failed to create listener event channel: %s\n",
+			     strerror(errno));
+		goto err;
+	}
+
+	int fd = _ep->cm_listener_ec->fd;
+	int flags = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+	if (rdma_create_id(_ep->cm_listener_ec,
+			   &_ep->cm_listener, NULL, RDMA_PS_TCP)) {
+		FI_IBV_ERROR("Failed to create cm listener: %s\n",
+			     strerror(errno));
+		goto err;
+
+	}
+
+	if (rdma_bind_addr(_ep->cm_listener,
+			   (struct sockaddr *)&_ep->my_ipoib_addr)) {
+		FI_IBV_ERROR
+		    ("Failed to bind cm listener to my IPoIB addr %s: %s\n",
+		     _ep->my_ipoib_addr_str, strerror(errno));
+		goto err;
+
+	}
+	if (rdma_listen(_ep->cm_listener, 1024)) {
+		FI_IBV_ERROR("rdma_listen failed: %s\n", strerror(errno));
+		goto err;
+	}
+
+	_ep->cm_listener_port = ntohs(rdma_get_src_port(_ep->cm_listener));
+	FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "listener port: %d\n",
+		_ep->cm_listener_port);
+
+	size_t s1 = sizeof(_ep->my_ipoib_addr.sin_addr.s_addr);
+	size_t s2 = sizeof(_ep->cm_listener_port);
+	assert(FI_IBV_RDM_DFLT_ADDRLEN == s1 + s2);
+
+	memcpy(_ep->my_rdm_addr, &_ep->my_ipoib_addr.sin_addr.s_addr, s1);
+	memcpy(_ep->my_rdm_addr + s1, &_ep->cm_listener_port, s2);
+
+	FI_INFO(&fi_ibv_prov, FI_LOG_AV,
+		"My ep_addr: " FI_IBV_RDM_ADDR_STR_FORMAT "\n",
+		FI_IBV_RDM_ADDR_STR(_ep->my_rdm_addr));
+
+	_ep->n_buffs = FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM;
+	const int header_size = sizeof(struct fi_ibv_rdm_tagged_header);
+	_ep->buff_len = FI_IBV_RDM_TAGGED_DFLT_BUFFER_SIZE;
+	_ep->rndv_threshold = _ep->buff_len -
+	    FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE - header_size;
+
+	_ep->rq_wr_depth = FI_IBV_RDM_TAGGED_DFLT_RQ_SIZE;
+
+	/*
+	 * max number of WRs in SQ is n_buffer for send and
+	 * the same amount for buffer releasing from recv
+	 */
+	_ep->sq_wr_depth = 2 * (_ep->n_buffs + 1);
+
+	_ep->total_outgoing_send = 0;
+	_ep->pend_send = 0;
+	_ep->pend_recv = 0;
+	_ep->recv_preposted_threshold = MAX(0.2 * _ep->rq_wr_depth, 5);
+	VERBS_INFO(FI_LOG_CORE, "recv preposted threshold: %d\n",
+		   _ep->recv_preposted_threshold);
+
+	fi_ibv_mem_pool_init(&fi_ibv_rdm_tagged_request_pool,
+			     100, 100,
+			     sizeof(struct fi_ibv_rdm_tagged_request));
+
+	fi_ibv_mem_pool_init(&fi_ibv_rdm_tagged_postponed_pool,
+			     100, 100,
+			     sizeof(struct fi_ibv_rdm_tagged_postponed_entry));
+
+	fi_ibv_mem_pool_init(&fi_ibv_rdm_tagged_unexp_buffers_pool,
+			     100, 100, _ep->buff_len);
+
+	_ep->max_inline_rc =
+	    fi_ibv_rdm_tagged_find_max_inline_size(_ep->domain->pd,
+						   _ep->domain->verbs);
+	_ep->scq_depth = FI_IBV_RDM_TAGGED_DFLT_SCQ_SIZE;
+	_ep->rcq_depth = FI_IBV_RDM_TAGGED_DFLT_RCQ_SIZE;
+
+	_ep->scq = ibv_create_cq(_ep->domain->verbs, _ep->scq_depth, _ep,
+				 NULL, 0);
+	if (_ep->scq == NULL) {
+		FI_IBV_ERROR("Failed to create EP scq: errno %d : %s\n",
+			     errno, strerror(errno));
+	}
+
+	_ep->rcq =
+	    ibv_create_cq(_ep->domain->verbs, _ep->rcq_depth, _ep, NULL, 0);
+	if (_ep->rcq == NULL) {
+		FI_IBV_ERROR("Failed to create EP rcq: errno %d : %s\n",
+			     errno, strerror(errno));
+	}
+
+	*ep = &_ep->ep_fid;
+
+	_ep->is_closing = 0;
+	fi_ibv_rdm_tagged_req_hndls_init();
+
+	pthread_mutex_init(&_ep->cm_lock, NULL);
+	ret = pthread_create(&_ep->cm_progress_thread, NULL,
+			     &fi_ibv_rdm_tagged_cm_progress_thread,
+			     (void *)_ep);
+	if (ret) {
+		FI_IBV_ERROR("Failed to launch CM progress thread, err :%d\n",
+			     ret);
+	}
+
+	FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "Successfully done: %d\n", ret);
+
+	return ret;
+err:
+	free(_ep);
+	return ret;
+}

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _VERBS_QUEING_H
+#define _VERBS_QUEING_H
+
+#include <stdlib.h>
+#include <fi_list.h>
+#include "verbs_rdm.h"
+
+/* managing of queues
+ */
+
+extern struct dlist_entry fi_ibv_rdm_tagged_request_ready_queue;
+extern struct dlist_entry fi_ibv_rdm_tagged_recv_unexp_queue;
+extern struct dlist_entry fi_ibv_rdm_tagged_recv_posted_queue;
+extern struct dlist_entry fi_ibv_rdm_tagged_send_postponed_queue;
+
+extern struct fi_ibv_mem_pool fi_ibv_rdm_tagged_postponed_pool;
+
+
+static inline void
+fi_ibv_rdm_tagged_move_to_ready_queue(struct fi_ibv_rdm_tagged_request *request)
+{
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_ready_queue: ",
+				      request, FI_LOG_DEBUG);
+	dlist_insert_tail(&request->queue_entry,
+			  &fi_ibv_rdm_tagged_request_ready_queue);
+}
+
+static inline void
+fi_ibv_rdm_tagged_remove_from_ready_queue(
+		struct fi_ibv_rdm_tagged_request *request)
+{
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_ready_queue: ",
+				      request, FI_LOG_DEBUG);
+	dlist_remove(&request->queue_entry);
+}
+
+static inline void
+fi_ibv_rdm_tagged_move_to_unexpected_queue(
+		struct fi_ibv_rdm_tagged_request *request)
+{
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_unexpected_queue: ",
+				      request, FI_LOG_DEBUG);
+	dlist_insert_tail(&request->queue_entry,
+			  &fi_ibv_rdm_tagged_recv_unexp_queue);
+}
+
+static inline void
+fi_ibv_rdm_tagged_remove_from_unexp_queue(
+		struct fi_ibv_rdm_tagged_request *request)
+{
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_unexpected_queue: ", request,
+				      FI_LOG_DEBUG);
+	dlist_remove(&request->queue_entry);
+}
+
+static inline void
+fi_ibv_rdm_tagged_move_to_posted_queue(
+		struct fi_ibv_rdm_tagged_request *request,
+		struct fi_ibv_rdm_ep *ep)
+{
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_posted_queue: ", request,
+				      FI_LOG_DEBUG);
+	dlist_insert_tail(&request->queue_entry,
+			  &fi_ibv_rdm_tagged_recv_posted_queue);
+	ep->pend_recv++;
+}
+
+static inline void
+fi_ibv_rdm_tagged_remove_from_posted_queue(
+		struct fi_ibv_rdm_tagged_request *request,
+		struct fi_ibv_rdm_ep *ep)
+{
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_posted_queue: ", request,
+				      FI_LOG_DEBUG);
+	dlist_remove(&request->queue_entry);
+	ep->pend_recv--;
+}
+
+static inline void
+fi_ibv_rdm_tagged_move_to_postponed_queue(
+		struct fi_ibv_rdm_tagged_request *request)
+{
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_postponed_queue: ", request,
+				      FI_LOG_DEBUG);
+	assert(request->conn);
+
+	if (dlist_empty(&request->conn->postponed_requests_head)) {
+		struct fi_ibv_rdm_tagged_postponed_entry *entry =
+			(struct fi_ibv_rdm_tagged_postponed_entry *)
+			fi_verbs_mem_pool_get(&fi_ibv_rdm_tagged_postponed_pool);
+
+		entry->conn = request->conn;
+		entry->conn->postponed_entry = entry;
+		dlist_insert_tail(&entry->queue_entry,
+				  &fi_ibv_rdm_tagged_send_postponed_queue);
+	}
+	dlist_insert_tail(&request->queue_entry,
+			  &request->conn->postponed_requests_head);
+}
+
+static inline void
+fi_ibv_rdm_tagged_remove_from_postponed_queue(
+		struct fi_ibv_rdm_tagged_request *request)
+{
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_postponed_queue: ", request,
+				      FI_LOG_DEBUG);
+
+	assert(!dlist_empty(&request->conn->postponed_requests_head));
+
+	dlist_remove(&request->queue_entry);
+	if (dlist_empty(&request->conn->postponed_requests_head)) {
+		dlist_remove(&request->conn->postponed_entry->queue_entry);
+		request->conn->postponed_entry->conn = NULL;
+		fi_ibv_mem_pool_return(&request->conn->postponed_entry->mpe,
+					&fi_ibv_rdm_tagged_postponed_pool);
+		request->conn->postponed_entry = NULL;
+	}
+}
+
+#endif   // _VERBS_QUEING_H

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _VERBS_RDM_H
+#define _VERBS_RDM_H
+
+#include "../fi_verbs.h"
+#include "verbs_utils.h"
+#include "../uthash.h"
+#include "verbs_tagged_ep_rdm_states.h"
+
+
+#define FI_IBV_RDM_CONN_SELF ((struct fi_ibv_rdm_tagged_conn *) 0x1)
+
+#define FI_IBV_RDM_ADDR_STR_FORMAT "[%02x:%02x:%02x:%02x:%02x:%02x]"
+
+#define FI_IBV_RDM_ADDR_STR(addr)				   \
+        *((unsigned char*) addr), *((unsigned char*) addr + 1),	   \
+        *((unsigned char*) addr + 2),*((unsigned char*) addr + 3), \
+        *((unsigned char*) addr + 4),*((unsigned char*) addr + 5)
+
+#define FI_IBV_RDM_ST_PKTTYPE_MASK  ((uint32_t) 0xFF)
+#define FI_IBV_RDM_EAGER_PKT            0
+#define FI_IBV_RDM_RNDV_RTS_PKT         1
+#define FI_IBV_RDM_RNDV_ACK_PKT         2
+#define FI_IBV_RDM_SET_PKTTYPE(dest, type) (dest |= type)
+#define FI_IBV_RDM_GET_PKTTYPE(value) (value & FI_IBV_RDM_ST_PKTTYPE_MASK)
+
+
+/* ------- SERVICE_TAG layout ---------
+ * [ 24 bits - Unused at the moment ] [ 8 bits - pkt type ]
+ *                                    IBV_RDM_ST_PKTYPE_MASK
+ */
+
+// WR - work request
+#define FI_IBV_RDM_SERVICE_WR_MASK              ((uint64_t)0x1)
+#define FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(value) \
+        (value & FI_IBV_RDM_SERVICE_WR_MASK)
+
+#define FI_IBV_RDM_PACK_WR(value)               ((uint64_t)value)
+#define FI_IBV_RDM_UNPACK_WR(value)             ((void*)(uintptr_t)value)
+
+#define FI_IBV_RDM_PACK_SERVICE_WR(value)       \
+        (((uint64_t)(uintptr_t)(void*)value) | FI_IBV_RDM_SERVICE_WR_MASK)
+
+#define FI_IBV_RDM_UNPACK_SERVICE_WR(value)     \
+        ((void*)(uintptr_t)(value & (~(FI_IBV_RDM_SERVICE_WR_MASK))))
+
+struct fi_ibv_rdm_tagged_header {
+	uint64_t imm_data;          // TODO: not implemented
+	uint64_t tag;
+	uint32_t service_tag;
+	uint32_t padding;
+};
+
+struct fi_ibv_rdm_tagged_rndv_header {
+	struct fi_ibv_rdm_tagged_header base;
+	uint64_t src_addr;
+	void *id;
+	int len;
+	uint32_t mem_key;
+};
+
+struct fi_ibv_rdm_tagged_unexp_rbuff {
+	struct fi_ibv_mem_pool_entry mpe;
+	char payload[sizeof(void *)];
+};
+
+struct fi_ibv_rdm_tagged_request {
+	struct fi_ibv_mem_pool_entry mpe;
+
+	uint64_t tag;
+	uint64_t tagmask;
+
+	struct {
+		void *dest_buf;
+
+		union {
+			void *expected_recv_buf; // user level
+			struct fi_ibv_rdm_tagged_unexp_rbuff *unexp_rbuf;
+			void *sbuf;              // in terms of verbs
+		};
+		int send_completions_wait;
+
+		struct {
+			enum fi_ibv_rdm_tagged_request_eager_state eager;
+			enum fi_ibv_rdm_tagged_request_rndv_state rndv;
+		} state;
+	};
+
+	struct {
+		void *rndv_id;
+		struct ibv_mr *rndv_mr;
+		uint32_t rndv_remote_key;
+	};
+
+	const void *src_addr;
+	int len;
+	uint32_t imm;
+	struct fi_context *context;
+	struct fi_ibv_rdm_tagged_conn *conn;
+	/* Request can be an element of only one queue at the moment */
+	struct dlist_entry queue_entry;
+};
+
+static inline void
+fi_ibv_rdm_tagged_zero_request(struct fi_ibv_rdm_tagged_request *request)
+{
+	char *p = (char *)request;
+	memset(p + sizeof(request->mpe), 0, sizeof(*request) -
+					    sizeof(request->mpe));
+}
+
+void fi_ibv_rdm_tagged_print_request(char *buf,
+				     struct fi_ibv_rdm_tagged_request *request);
+
+struct fi_ibv_rdm_tagged_buf {
+	struct fi_ibv_rdm_tagged_header header;
+	char payload[sizeof(void *)];
+};
+
+struct fi_ibv_rdm_ep {
+	struct fid_ep ep_fid;
+	struct fi_ibv_domain *domain;
+	struct fi_ibv_cq *fi_scq;
+	struct fi_ibv_cq *fi_rcq;
+
+	struct sockaddr_in my_ipoib_addr;
+	char my_ipoib_addr_str[INET6_ADDRSTRLEN];
+	struct rdma_cm_id *cm_listener;
+	struct rdma_event_channel *cm_listener_ec;
+	uint16_t cm_listener_port;
+	struct fi_ibv_av *av;
+	int fi_ibv_rdm_addrlen;
+	char my_rdm_addr[FI_IBV_RDM_DFLT_ADDRLEN];
+
+	int buff_len;
+	int n_buffs;
+	int rq_wr_depth;    // RQ depth
+	int sq_wr_depth;    // SQ depth
+	int total_outgoing_send;
+	int pend_send;
+	int pend_recv;
+	int num_active_conns;
+	int max_inline_rc;
+	int rndv_threshold;
+	struct ibv_cq *scq;
+	struct ibv_cq *rcq;
+	int scq_depth;
+	int rcq_depth;
+	pthread_t cm_progress_thread;
+	pthread_mutex_t cm_lock;
+	int is_closing;
+	int recv_preposted_threshold;
+};
+
+#define FI_IBV_RDM_ALIGNMENT 64
+
+enum {
+	FI_VERBS_CONN_ALLOCATED,
+	FI_VERBS_CONN_STARTED,
+	FI_VERBS_CONN_REJECTED,
+	FI_VERBS_CONN_ESTABLISHED,
+	FI_VERBS_CONN_LOCAL_DISCONNECT,
+	FI_VERBS_CONN_REMOTE_DISCONNECT,
+	FI_VERBS_CONN_CLOSED
+};
+
+struct fi_ibv_rdm_tagged_conn {
+	struct ibv_qp *qp;
+	char addr[FI_IBV_RDM_DFLT_ADDRLEN];
+
+	struct rdma_cm_id *id;
+	int is_active;
+	int state;
+
+	char *sbuf_mem_reg;
+	char *sbuf_head;
+	char *sbuf_ack_head;
+
+	char *rbuf_mem_reg;
+	char *rbuf_head;
+
+	struct dlist_entry postponed_requests_head;
+	struct fi_ibv_rdm_tagged_postponed_entry *postponed_entry;
+
+	struct ibv_mr *s_mr;
+	struct ibv_mr *r_mr;
+
+	uint32_t remote_sbuf_rkey;
+	uint32_t remote_rbuf_rkey;
+
+	char *remote_sbuf_mem_reg;
+	char *remote_rbuf_mem_reg;
+	char *remote_sbuf_head;
+
+	int sends_outgoing;
+	int recv_preposted;
+	UT_hash_handle hh;
+#if ENABLE_DEBUG
+	size_t unexp_counter;
+	size_t exp_counter;
+#endif
+};
+
+struct fi_ibv_rdm_tagged_postponed_entry {
+	struct fi_ibv_mem_pool_entry mpe;
+	struct fi_ibv_rdm_tagged_conn *conn;
+
+	struct dlist_entry queue_entry;
+};
+
+enum fi_ibv_rdm_tagged_buffer_status {
+	BUF_STATUS_FREE = 0,
+	BUF_STATUS_BUSY
+};
+
+struct fi_ibv_rdm_tagged_buffer_service_data {
+	enum fi_ibv_rdm_tagged_buffer_status status;
+	int seq_number;
+};
+
+#define FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE                          \
+	(sizeof(struct fi_ibv_rdm_tagged_buffer_service_data)		  \
+		< FI_IBV_RDM_ALIGNMENT ? FI_IBV_RDM_ALIGNMENT		  \
+		: (sizeof(struct fi_ibv_rdm_tagged_buffer_service_data) + \
+		  (FI_IBV_RDM_ALIGNMENT -				  \
+		   sizeof(struct fi_ibv_rdm_tagged_buffer_service_data) % \
+		   FI_IBV_RDM_ALIGNMENT)))
+
+static inline struct fi_ibv_rdm_tagged_buffer_service_data *
+fi_ibv_rdm_tagged_get_buff_service_data(char *buff)
+{
+	return (struct fi_ibv_rdm_tagged_buffer_service_data *)
+		(buff - FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE);
+}
+
+static inline void
+fi_ibv_rdm_tagged_set_buffer_status(char *buff,
+                                    enum fi_ibv_rdm_tagged_buffer_status status)
+{
+	fi_ibv_rdm_tagged_get_buff_service_data(buff)->status = status;
+}
+
+static inline enum fi_ibv_rdm_tagged_buffer_status
+fi_ibv_rdm_tagged_get_buffer_status(char *buff)
+{
+	return fi_ibv_rdm_tagged_get_buff_service_data(buff)->status;
+}
+
+static inline uintptr_t
+fi_ibv_rdm_tagged_get_remote_addr(struct fi_ibv_rdm_tagged_conn *conn,
+                                  char *local_sbuff)
+{
+	return (uintptr_t) (conn->remote_rbuf_mem_reg +
+			    (local_sbuff - conn->sbuf_mem_reg));
+}
+
+static inline void
+fi_ibv_rdm_tagged_push_buff_pointer(char *area_start, size_t area_size,
+                                    char **buff, size_t offset)
+{
+	char *buff_tmp = (*buff) + offset;
+
+	VERBS_DBG("old_pointer: %p, sn = %d\n", *buff,
+		  fi_ibv_rdm_tagged_get_buff_service_data(*buff)->seq_number);
+
+	(*buff) = buff_tmp < (area_start + area_size) ?
+		  buff_tmp : area_start + FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE;
+
+	VERBS_DBG("new_pointer: %p, sn = %d\n", *buff,
+		  fi_ibv_rdm_tagged_get_buff_service_data(*buff)->seq_number);
+	assert(fi_ibv_rdm_tagged_get_buff_service_data(*buff)->seq_number ==
+		(((*buff) - (area_start + FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE)) /
+		  offset));
+}
+
+static inline void
+fi_ibv_rdm_tagged_push_sbuff_head(struct fi_ibv_rdm_tagged_conn *conn,
+                                  struct fi_ibv_rdm_ep *ep)
+{
+	fi_ibv_rdm_tagged_push_buff_pointer(conn->sbuf_mem_reg,
+					    ep->buff_len * ep->n_buffs,
+					    &conn->sbuf_head, ep->buff_len);
+}
+
+static inline struct fi_ibv_rdm_tagged_buf *
+fi_ibv_rdm_tagged_get_rbuf(struct fi_ibv_rdm_tagged_conn *conn,
+                           struct fi_ibv_rdm_ep *ep,
+                           int seq_num)
+{
+	char *rbuf = (conn->rbuf_mem_reg +
+		      FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE +
+		      (seq_num * ep->buff_len));
+	VERBS_DBG("recv buf %d\n", seq_num);
+	assert(fi_ibv_rdm_tagged_get_buff_service_data(rbuf)->seq_number ==
+		seq_num);
+	return (struct fi_ibv_rdm_tagged_buf *) rbuf;
+}
+
+static inline void
+fi_ibv_rdm_tagged_buffer_lists_init(struct fi_ibv_rdm_tagged_conn *conn,
+                                    struct fi_ibv_rdm_ep *ep)
+{
+	int i;
+
+	conn->sbuf_head = conn->sbuf_mem_reg +
+			  FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE;
+	conn->rbuf_head = conn->rbuf_mem_reg +
+			  FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE;
+	conn->sbuf_ack_head = conn->rbuf_head;      // used only service data
+
+	for (i = 0; i < ep->n_buffs; ++i) {
+		fi_ibv_rdm_tagged_set_buffer_status(conn->sbuf_head +
+			i * ep->buff_len, BUF_STATUS_FREE);
+		fi_ibv_rdm_tagged_set_buffer_status(conn->sbuf_ack_head +
+			i * ep->buff_len, BUF_STATUS_FREE);
+
+		fi_ibv_rdm_tagged_get_buff_service_data(conn->sbuf_head +
+			i * ep->buff_len)->seq_number = i;
+		fi_ibv_rdm_tagged_get_buff_service_data(conn->sbuf_ack_head +
+			i * ep->buff_len)->seq_number = i;
+	}
+}
+
+int fi_ibv_rdm_tagged_poll(struct fi_ibv_rdm_ep *ep);
+int fi_ibv_rdm_tagged_set_cq_ops(struct fi_ibv_cq *cq);
+int fi_ibv_rdm_set_av_ops(struct fi_ibv_av *av);
+int fi_ibv_rdm_tagged_cm_progress(struct fi_ibv_rdm_ep *ep);
+int fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_ep *ep,
+                                   struct fi_ibv_rdm_tagged_conn *conn);
+int fi_ibv_rdm_tagged_conn_cleanup(struct fi_ibv_rdm_ep *ep,
+                                   struct fi_ibv_rdm_tagged_conn *conn);
+int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
+                                struct fi_ibv_rdm_tagged_conn *conn);
+int fi_ibv_rdm_tagged_repost_receives(struct fi_ibv_rdm_tagged_conn *conn,
+                                      struct fi_ibv_rdm_ep *ep,
+                                      int num_to_post);
+int fi_ibv_rdm_tagged_open_ep(struct fid_domain *domain, struct fi_info *info,
+                              struct fid_ep **ep, void *context);
+int fi_ibv_rdm_tagged_prepare_send_resources(
+	struct fi_ibv_rdm_tagged_request *request, struct fi_ibv_rdm_ep *ep);
+
+#endif /* _VERBS_RDM_H */

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -1,0 +1,583 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <malloc.h>
+#include <rdma/rdma_cma.h>
+#include <fi_list.h>
+
+#include "../fi_verbs.h"
+#include "verbs_utils.h"
+#include "verbs_rdm.h"
+
+
+extern struct fi_provider fi_ibv_prov;
+extern struct fi_ibv_rdm_tagged_conn *fi_ibv_rdm_tagged_conn_hash;
+
+
+static inline struct ibv_mr *
+fi_ibv_rdm_tagged_malloc_and_register(struct fi_ibv_rdm_ep *ep, void **buf,
+				      size_t size)
+{
+	*buf = memalign(FI_IBV_RDM_MEM_ALIGNMENT, size);
+	if (!buf)
+		return NULL;
+
+	memset(*buf, 0, size);
+	return ibv_reg_mr(ep->domain->pd, *buf, size,
+			  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+}
+
+int fi_ibv_rdm_tagged_deregister_and_free(struct ibv_mr **mr, char **buff)
+{
+	int ret = ibv_dereg_mr(*mr);
+
+	if (ret == 0) {
+		*mr = NULL;
+		free(*buff);
+		*buff = NULL;
+	}
+
+	return ret;
+}
+
+static inline int
+fi_ibv_rdm_tagged_batch_repost_receives(struct fi_ibv_rdm_tagged_conn *conn,
+					struct fi_ibv_rdm_ep *ep,
+					int num_to_post)
+{
+	struct ibv_recv_wr *bad_wr = NULL;
+	struct ibv_recv_wr wr[num_to_post];
+	int ret = 0;
+	int last = num_to_post - 1;
+	int i;
+
+	for (i = 0; i < num_to_post; i++) {
+		wr[i].wr_id = (uintptr_t) conn;
+		wr[i].next = &wr[i + 1];
+		wr[i].sg_list = NULL;
+		wr[i].num_sge = 0;
+	}
+	wr[last].next = NULL;
+
+	if (ibv_post_recv(conn->qp, wr, &bad_wr) == 0) {
+		ret = num_to_post;
+	} else {
+		int found = 0;
+		for (i = 0; !found && (i < num_to_post); i++) {
+			found = (&wr[i] == bad_wr);
+		}
+
+		if (!found) {
+			FI_IBV_ERROR("Failed to post recv\n");
+		}
+
+		ret = i;
+	}
+	conn->recv_preposted += ret;
+	return ret;
+}
+
+int fi_ibv_rdm_tagged_repost_receives(struct fi_ibv_rdm_tagged_conn *conn,
+				      struct fi_ibv_rdm_ep *ep, int num_to_post)
+{
+	assert(num_to_post > 0);
+	const int batch_size = 100;
+
+	int rest = num_to_post;
+	while (rest) {
+		const int batch = MIN(rest, batch_size);
+		const int ret =
+		    fi_ibv_rdm_tagged_batch_repost_receives(conn, ep, batch);
+
+		rest -= ret;
+		if (ret != batch) {
+			break;
+		}
+	}
+
+	return num_to_post - rest;
+}
+
+static inline int
+fi_ibv_rdm_tagged_prepare_conn_memory(struct fi_ibv_rdm_ep *ep,
+				      struct fi_ibv_rdm_tagged_conn *conn)
+{
+	const size_t size = ep->buff_len * ep->n_buffs;
+	conn->s_mr = fi_ibv_rdm_tagged_malloc_and_register(ep,
+				(void **) &conn->sbuf_mem_reg, size);
+	assert(conn->s_mr);
+
+	conn->r_mr = fi_ibv_rdm_tagged_malloc_and_register(ep,
+				(void **) &conn->rbuf_mem_reg, size);
+	assert(conn->r_mr);
+
+	fi_ibv_rdm_tagged_buffer_lists_init(conn, ep);
+	return 0;
+}
+
+static inline void
+fi_ibv_rdm_tagged_init_qp_attributes(struct ibv_qp_init_attr *qp_attr,
+				     struct fi_ibv_rdm_ep *ep)
+{
+	memset(qp_attr, 0, sizeof(*qp_attr));
+	qp_attr->send_cq = ep->scq;
+	qp_attr->recv_cq = ep->rcq;
+	qp_attr->qp_type = IBV_QPT_RC;
+	qp_attr->cap.max_send_wr = ep->sq_wr_depth;
+	qp_attr->cap.max_recv_wr = ep->rq_wr_depth;
+	qp_attr->cap.max_send_sge = 1;
+	qp_attr->cap.max_recv_sge = 1;
+	qp_attr->cap.max_inline_data = ep->max_inline_rc;
+
+}
+
+static inline int
+fi_ibv_rdm_tagged_process_addr_resolved(struct rdma_cm_id *id,
+					struct fi_ibv_rdm_ep *ep)
+{
+	struct ibv_qp_init_attr qp_attr;
+	struct fi_ibv_rdm_tagged_conn *conn = id->context;
+
+	VERBS_INFO(FI_LOG_AV, "ADDR_RESOLVED conn %p, addr "
+		   FI_IBV_RDM_ADDR_STR_FORMAT "\n",
+		   conn, FI_IBV_RDM_ADDR_STR(conn->addr));
+
+	assert(id->verbs == ep->domain->verbs);
+	fi_ibv_rdm_tagged_init_qp_attributes(&qp_attr, ep);
+	if (rdma_create_qp(id, ep->domain->pd, &qp_attr)) {
+		fprintf(stderr, "rdma_create_qp failed\n");
+	}
+
+	if (conn->is_active) {
+		assert(id == conn->id);
+		fi_ibv_rdm_tagged_prepare_conn_memory(ep, conn);
+		conn->qp = id->qp;
+		if (ep->rq_wr_depth != fi_ibv_rdm_tagged_repost_receives(conn, ep,
+						      ep->rq_wr_depth)) {
+			fprintf(stderr, "repost receives failed\n");
+			/* TODO: replace with return and proper error handling */
+			abort();
+		}
+
+	}
+
+	if (rdma_resolve_route(id, FI_IBV_RDM_CM_RESOLVEADDR_TIMEOUT)) {
+		fprintf(stderr, " rdma_resolve_route failed\n");
+	}
+	return 0;
+}
+
+static inline int
+fi_ibv_rdm_tagged_process_connect_request(struct rdma_cm_event *event,
+					  struct fi_ibv_rdm_ep *ep)
+{
+	struct ibv_qp_init_attr qp_attr;
+	struct rdma_conn_param cm_params;
+	struct fi_ibv_rdm_tagged_conn *conn = NULL;
+	struct rdma_cm_id *id = event->id;
+
+	char *p = (char *) event->param.conn.private_data;
+
+	if (ep->is_closing) {
+		int rej_message = 0xdeadbeef;
+		if (rdma_reject(id, &rej_message, sizeof(int))) {
+			fprintf(stderr, "rdma_reject failed\n");
+			rdma_destroy_id(id);
+		}
+		return 0;
+	}
+
+	HASH_FIND(hh, fi_ibv_rdm_tagged_conn_hash, p, FI_IBV_RDM_DFLT_ADDRLEN,
+		  conn);
+
+	if (!conn) {
+		conn = memalign(FI_IBV_RDM_ALIGNMENT, sizeof *conn);
+		if (!conn)
+			return -FI_ENOMEM;
+
+		memset(conn, 0, sizeof(struct fi_ibv_rdm_tagged_conn));
+		memcpy(&conn->addr[0], p, FI_IBV_RDM_DFLT_ADDRLEN);
+
+		conn->state = FI_VERBS_CONN_ALLOCATED;
+		FI_INFO(&fi_ibv_prov, FI_LOG_AV,
+			"CONN REQUEST, NOT found in hash, new conn %p, addr "
+			FI_IBV_RDM_ADDR_STR_FORMAT ", HASH ADD\n", conn,
+			FI_IBV_RDM_ADDR_STR(conn->addr));
+
+		conn->is_active = memcmp(conn->addr, ep->my_rdm_addr,
+					 FI_IBV_RDM_DFLT_ADDRLEN) <= 0;
+		HASH_ADD(hh, fi_ibv_rdm_tagged_conn_hash, addr,
+			 FI_IBV_RDM_DFLT_ADDRLEN, conn);
+	} else {
+		FI_INFO(&fi_ibv_prov, FI_LOG_AV,
+			"CONN REQUEST,  FOUND in hash, conn %p, addr "
+			FI_IBV_RDM_ADDR_STR_FORMAT "\n", conn,
+			FI_IBV_RDM_ADDR_STR(conn->addr));
+	}
+	p += FI_IBV_RDM_DFLT_ADDRLEN;
+
+	if (conn->is_active) {
+		int rej_message = 0xdeadbeef;
+		if (rdma_reject(id, &rej_message, sizeof(int))) {
+			fprintf(stderr, "rdma_reject failed\n");
+			rdma_destroy_id(id);
+		}
+		if (conn->state == FI_VERBS_CONN_ALLOCATED) {
+			fi_ibv_rdm_start_connection(ep, conn);
+		}
+	} else {
+		assert(conn->state == FI_VERBS_CONN_ALLOCATED ||
+		       conn->state == FI_VERBS_CONN_STARTED);
+
+		conn->state = FI_VERBS_CONN_STARTED;
+
+		conn->id = id;
+		// Do it before rdma_create_qp since that call would modify
+		// event->param.conn.private_data buffer
+		conn->remote_rbuf_rkey = *(uint32_t *) (p);
+		p += sizeof(conn->r_mr->rkey);
+		conn->remote_rbuf_mem_reg = *(char **) (p);
+		p += sizeof(conn->remote_rbuf_mem_reg);
+
+		conn->remote_sbuf_rkey = *(uint32_t *) (p);
+		p += sizeof(conn->s_mr->rkey);
+		conn->remote_sbuf_mem_reg = *(char **) (p);
+		p += sizeof(conn->remote_sbuf_mem_reg);
+
+		conn->remote_sbuf_head = conn->remote_sbuf_mem_reg +
+		    FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE;
+
+		fi_ibv_rdm_tagged_prepare_conn_memory(ep, conn);
+		fi_ibv_rdm_tagged_init_qp_attributes(&qp_attr, ep);
+		rdma_create_qp(id, ep->domain->pd, &qp_attr);
+		conn->qp = id->qp;
+		if (ep->rq_wr_depth !=
+		    fi_ibv_rdm_tagged_repost_receives(conn, ep,
+						      ep->rq_wr_depth)) {
+			fprintf(stderr, "repost receives failed\n");
+			abort();
+		}
+		id->context = conn;
+
+		memset(&cm_params, 0, sizeof(struct rdma_conn_param));
+		cm_params.private_data_len = FI_IBV_RDM_DFLT_ADDRLEN;
+		cm_params.responder_resources = 2;
+		cm_params.initiator_depth = 2;
+
+		cm_params.private_data_len += sizeof(conn->r_mr->rkey) +
+		    sizeof(conn->remote_rbuf_mem_reg);
+		cm_params.private_data_len += sizeof(conn->s_mr->rkey) +
+		    sizeof(conn->remote_sbuf_mem_reg);
+
+		cm_params.private_data = malloc(cm_params.private_data_len);
+
+		char *p = (char *) cm_params.private_data;
+		memcpy(p, ep->my_rdm_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+		p += FI_IBV_RDM_DFLT_ADDRLEN;
+		memcpy(p, &conn->r_mr->rkey, sizeof(conn->r_mr->rkey));
+		p += sizeof(conn->r_mr->rkey);
+		memcpy(p, &conn->rbuf_mem_reg, sizeof(conn->rbuf_mem_reg));
+		p += sizeof(conn->rbuf_mem_reg);
+
+		memcpy(p, &conn->s_mr->rkey, sizeof(conn->s_mr->rkey));
+		p += sizeof(conn->s_mr->rkey);
+		memcpy(p, &conn->sbuf_mem_reg, sizeof(conn->sbuf_mem_reg));
+		p += sizeof(conn->sbuf_mem_reg);
+
+		rdma_accept(id, &cm_params);
+		free((void *) cm_params.private_data);
+	}
+	return 0;
+}
+
+/* TODO: extract out duplicated code from this function and one above */
+static inline int
+fi_ibv_rdm_tagged_process_route_resolved(struct rdma_cm_event *event,
+					 struct fi_ibv_rdm_ep *ep)
+{
+	struct fi_ibv_rdm_tagged_conn *conn = event->id->context;
+
+	if (conn->is_active) {
+		struct rdma_conn_param cm_params;
+		memset(&cm_params, 0, sizeof(struct rdma_conn_param));
+		cm_params.private_data_len = FI_IBV_RDM_DFLT_ADDRLEN;
+
+		cm_params.private_data_len += sizeof(conn->r_mr->rkey) +
+		    sizeof(conn->remote_rbuf_mem_reg);
+		cm_params.private_data_len += sizeof(conn->s_mr->rkey) +
+		    sizeof(conn->remote_sbuf_mem_reg);
+
+		cm_params.private_data = malloc(cm_params.private_data_len);
+
+		char *p = (char *)cm_params.private_data;
+		memcpy(p, ep->my_rdm_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+		p += FI_IBV_RDM_DFLT_ADDRLEN;
+		memcpy(p, &conn->r_mr->rkey, sizeof(conn->r_mr->rkey));
+		p += sizeof(conn->r_mr->rkey);
+		memcpy(p, &conn->rbuf_mem_reg, sizeof(conn->rbuf_mem_reg));
+		p += sizeof(conn->rbuf_mem_reg);
+
+		memcpy(p, &conn->s_mr->rkey, sizeof(conn->s_mr->rkey));
+		p += sizeof(conn->s_mr->rkey);
+		memcpy(p, &conn->sbuf_mem_reg, sizeof(conn->sbuf_mem_reg));
+		p += sizeof(conn->sbuf_mem_reg);
+
+		cm_params.responder_resources = 2;
+		cm_params.initiator_depth = 2;
+		VERBS_INFO(FI_LOG_AV,
+			"ROUTE RESOLVED, conn %p, addr "
+			FI_IBV_RDM_ADDR_STR_FORMAT "\n", conn,
+			FI_IBV_RDM_ADDR_STR(conn->addr));
+
+		rdma_connect(event->id, &cm_params);
+
+		free((void *)cm_params.private_data);
+	} else {
+		struct rdma_conn_param cm_params;
+		memset(&cm_params, 0, sizeof(struct rdma_conn_param));
+		cm_params.private_data_len = FI_IBV_RDM_DFLT_ADDRLEN;
+		cm_params.private_data = malloc(cm_params.private_data_len);
+		memcpy((void *)cm_params.private_data,
+			      ep->my_rdm_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+		cm_params.responder_resources = 2;
+		cm_params.initiator_depth = 2;
+		VERBS_INFO(FI_LOG_AV,
+			"ROUTE RESOLVED, conn %p, addr "
+			FI_IBV_RDM_ADDR_STR_FORMAT "\n", conn,
+			FI_IBV_RDM_ADDR_STR(conn->addr));
+
+		rdma_connect(event->id, &cm_params);
+
+		free((void *)cm_params.private_data);
+	}
+	return 0;
+}
+
+static inline int
+fi_ibv_rdm_tagged_process_event_established(struct rdma_cm_event *event,
+					    struct fi_ibv_rdm_ep *ep)
+{
+	struct fi_ibv_rdm_tagged_conn *conn =
+	    (struct fi_ibv_rdm_tagged_conn *)event->id->context;
+#if defined(ENABLE_DEBUG) && ENABLE_DEBUG > 0
+	if (conn->state != FI_VERBS_CONN_STARTED) {
+		fprintf(stderr, "state = %d, conn %p", conn->state, conn);
+		assert(0 && "Wrong state");
+	}
+#endif
+
+	if (conn->is_active) {
+		char *p = (char *)event->param.conn.private_data +
+		    FI_IBV_RDM_DFLT_ADDRLEN;
+
+		conn->remote_rbuf_rkey = *(uint32_t *) (p);
+		p += sizeof(conn->r_mr->rkey);
+		conn->remote_rbuf_mem_reg = *(char **)(p);
+		p += sizeof(conn->remote_rbuf_mem_reg);
+
+		conn->remote_sbuf_rkey = *(uint32_t *) (p);
+		p += sizeof(conn->s_mr->rkey);
+		conn->remote_sbuf_mem_reg = *(char **)(p);
+		p += sizeof(conn->remote_sbuf_mem_reg);
+
+		conn->remote_sbuf_head = conn->remote_sbuf_mem_reg +
+		    FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE;
+	}
+#if 0
+	conn->is_hot = 0;
+	if (conn->is_hot) {
+		conn->hot.seq_num = 1;
+		conn->hot.seq_num_expected = 1;
+		if (hot_conns == NULL) {
+			hot_conns = conn;
+			conn->hot.next = NULL;
+		} else {
+			conn->hot.next = hot_conns;
+			hot_conns = conn;
+		}
+	}
+#endif
+	FI_INFO(&fi_ibv_prov, FI_LOG_AV, "CONN ESTABLISHED,  conn %p, addr "
+		FI_IBV_RDM_ADDR_STR_FORMAT "\n",
+		conn, FI_IBV_RDM_ADDR_STR(conn->addr));
+	ep->num_active_conns++;
+	conn->state = FI_VERBS_CONN_ESTABLISHED;
+	assert(conn->id->context == conn);
+	return 0;
+}
+
+int fi_ibv_rdm_tagged_conn_cleanup(struct fi_ibv_rdm_ep *ep,
+				   struct fi_ibv_rdm_tagged_conn *conn)
+{
+	int ret;
+
+	VERBS_DBG(FI_LOG_AV, "conn %p, exp = %lld unexp = %lld\n", conn,
+		     conn->exp_counter, conn->unexp_counter);
+
+	rdma_destroy_qp(conn->id);
+	if ((ret = rdma_destroy_id(conn->id))) {
+		FI_IBV_ERROR("rdma_destroy_id failed, ret = %d\n", ret);
+	}
+	fi_ibv_rdm_tagged_deregister_and_free(&conn->s_mr, &conn->sbuf_mem_reg);
+	fi_ibv_rdm_tagged_deregister_and_free(&conn->r_mr, &conn->rbuf_mem_reg);
+
+	memset(conn, 0, sizeof(*conn));
+	free(conn);
+	return ret;
+}
+
+static inline int
+fi_ibv_rdm_tagged_process_event_disconnected(struct fi_ibv_rdm_ep *ep,
+					     struct rdma_cm_event *event)
+{
+	struct fi_ibv_rdm_tagged_conn *conn = event->id->context;
+
+	ep->num_active_conns--;
+
+	if (conn->state == FI_VERBS_CONN_ESTABLISHED) {
+		conn->state = FI_VERBS_CONN_REMOTE_DISCONNECT;
+	} else {
+		assert(conn->state == FI_VERBS_CONN_LOCAL_DISCONNECT);
+		conn->state = FI_VERBS_CONN_CLOSED;
+	}
+	VERBS_INFO(FI_LOG_AV,
+		   "Disconnected from conn %p, addr " FI_IBV_RDM_ADDR_STR_FORMAT
+		   "\n", conn, FI_IBV_RDM_ADDR_STR(conn->addr));
+	if (conn->state == FI_VERBS_CONN_CLOSED) {
+		fi_ibv_rdm_tagged_conn_cleanup(ep, conn);
+	}
+
+	return 0;
+}
+
+static inline int
+fi_ibv_rdm_tagged_process_event_rejected(struct fi_ibv_rdm_ep *ep,
+					 struct rdma_cm_event *event)
+{
+	struct fi_ibv_rdm_tagged_conn *conn = event->id->context;
+	int ret = 0;
+
+	if (NULL != event->param.conn.private_data &&
+	    *((int *)event->param.conn.private_data) == 0xdeadbeef) {
+		assert(!conn->is_active);
+		rdma_destroy_qp(event->id);
+		ret = rdma_destroy_id(event->id);
+		VERBS_INFO(FI_LOG_AV,
+			"Rejected from conn %p, addr "
+			FI_IBV_RDM_ADDR_STR_FORMAT " is_active %d, status %d\n",
+			conn, FI_IBV_RDM_ADDR_STR(conn->addr), conn->is_active,
+			event->status);
+	} else {
+		VERBS_INFO(FI_LOG_AV,
+			"Unexpected REJECT from conn %p, addr "
+			FI_IBV_RDM_ADDR_STR_FORMAT
+			" is_active %d, msg len %d, msg %x, status %d\n",
+			conn, FI_IBV_RDM_ADDR_STR(conn->addr), conn->is_active,
+			event->param.conn.private_data_len,
+			event->param.conn.private_data ?
+			*(int *)event->param.conn.private_data : 0,
+			event->status);
+		conn->state = FI_VERBS_CONN_REJECTED;
+
+	}
+	return ret;
+}
+
+static int fi_ibv_rdm_tagged_process_event(struct rdma_cm_event *event,
+					   struct fi_ibv_rdm_ep *ep)
+{
+	int ret;
+	switch (event->event) {
+	case RDMA_CM_EVENT_ADDR_RESOLVED:
+		ret = fi_ibv_rdm_tagged_process_addr_resolved(event->id, ep);
+		break;
+	case RDMA_CM_EVENT_ROUTE_RESOLVED:
+		ret = fi_ibv_rdm_tagged_process_route_resolved(event, ep);
+		break;
+	case RDMA_CM_EVENT_ESTABLISHED:
+		ret = fi_ibv_rdm_tagged_process_event_established(event, ep);
+		break;
+	case RDMA_CM_EVENT_DISCONNECTED:
+		ret = fi_ibv_rdm_tagged_process_event_disconnected(ep, event);
+		break;
+	case RDMA_CM_EVENT_CONNECT_REQUEST:
+		ret = fi_ibv_rdm_tagged_process_connect_request(event, ep);
+		break;
+	case RDMA_CM_EVENT_REJECTED:
+		ret = fi_ibv_rdm_tagged_process_event_rejected(ep, event);
+		break;
+	case RDMA_CM_EVENT_ADDR_ERROR:
+	case RDMA_CM_EVENT_ROUTE_ERROR:
+	case RDMA_CM_EVENT_CONNECT_ERROR:
+	case RDMA_CM_EVENT_UNREACHABLE:
+
+	default:
+		ret = FI_EOTHER;
+		FI_IBV_ERROR("got unexpected rdmacm event, %s\n",
+			     rdma_event_str(event->event));
+		abort();
+		break;
+	}
+	return ret;
+
+}
+
+int fi_ibv_rdm_tagged_cm_progress(struct fi_ibv_rdm_ep *ep)
+{
+	struct rdma_cm_event *event = NULL;
+	int ret = 0;
+
+	rdma_get_cm_event(ep->cm_listener_ec, &event);
+
+	while (event) {
+		pthread_mutex_lock(&ep->cm_lock);
+
+		void *data = NULL;
+		struct rdma_cm_event event_copy;
+		memcpy(&event_copy, event, sizeof(*event));
+		if (event->param.conn.private_data_len) {
+			data = malloc(event->param.conn.private_data_len);
+			memcpy(data, event->param.conn.private_data,
+				      event->param.conn.private_data_len);
+			event_copy.param.conn.private_data = data;
+			event_copy.param.conn.private_data_len =
+			    event->param.conn.private_data_len;
+		}
+		rdma_ack_cm_event(event);
+		ret = fi_ibv_rdm_tagged_process_event(&event_copy, ep);
+		free(data);
+		event = NULL;
+		pthread_mutex_unlock(&ep->cm_lock);
+		rdma_get_cm_event(ep->cm_listener_ec, &event);
+	}
+	return ret;
+}

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -1,0 +1,769 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <prov/verbs/src/fi_verbs.h>
+
+#include <config.h>
+
+#include <fi_list.h>
+#include <fi_enosys.h>
+#include <rdma/fi_tagged.h>
+
+#include "verbs_queuing.h"
+#include "verbs_tagged_ep_rdm_states.h"
+
+
+#if defined(__ICC) || defined(__INTEL_COMPILER) || \
+ defined(__GNUC__) || defined(__GNUG__)
+#include "xmmintrin.h"
+#endif /* ICC || GCC */
+
+
+DEFINE_LIST(fi_ibv_rdm_tagged_request_ready_queue);
+DEFINE_LIST(fi_ibv_rdm_tagged_recv_posted_queue);
+DEFINE_LIST(fi_ibv_rdm_tagged_recv_unexp_queue);
+DEFINE_LIST(fi_ibv_rdm_tagged_send_postponed_queue);
+
+struct fi_ibv_mem_pool fi_ibv_rdm_tagged_request_pool;
+struct fi_ibv_mem_pool fi_ibv_rdm_tagged_postponed_pool;
+struct fi_ibv_mem_pool fi_ibv_rdm_tagged_unexp_buffers_pool;
+
+static inline int fi_ibv_rdm_tagged_poll_send(struct fi_ibv_rdm_ep *ep);
+static inline int fi_ibv_rdm_tagged_poll_recv(struct fi_ibv_rdm_ep *ep);
+
+static inline int
+fi_ibv_rdm_tagged_init_request_sbuf(struct fi_ibv_rdm_tagged_request *request,
+				    struct fi_ibv_rdm_ep *ep);
+
+static inline void *fi_ibv_rdm_tagged_get_sbuf(struct fi_ibv_rdm_tagged_conn
+					       *conn, struct fi_ibv_rdm_ep *ep);
+
+int fi_ibv_rdm_tagged_prepare_send_resources(
+	struct fi_ibv_rdm_tagged_request *request, struct fi_ibv_rdm_ep *ep)
+{
+	if (request->conn->state != FI_VERBS_CONN_ESTABLISHED) {
+		pthread_mutex_lock(&ep->cm_lock);
+		if (request->conn->state == FI_VERBS_CONN_ALLOCATED) {
+			fi_ibv_rdm_start_connection(ep, request->conn);
+		}
+		pthread_mutex_unlock(&ep->cm_lock);
+		usleep(1000);
+		return 0;
+	}
+#if !ENABLE_DEBUG
+	return (!SEND_RESOURCES_IS_BUSY(request->conn, ep)) ?
+		fi_ibv_rdm_tagged_init_request_sbuf(request, ep) : 0;
+#else // ENABLE_DEBUG
+	int res = FI_IBV_RDM_TAGGED_SENDS_OUTGOING_ARE_LIMITED(request->conn, ep);
+	if (res) {
+		FI_IBV_RDM_TAGGED_DBG_REQUEST
+		    ("failed because SENDS_OUTGOING_ARE_LIMITED", request,
+		     FI_LOG_DEBUG);
+		return !res;
+	}
+	res = PEND_SEND_IS_LIMITED(ep);
+	if (res) {
+		FI_IBV_RDM_TAGGED_DBG_REQUEST
+		    ("failed because PEND_SEND_IS_LIMITED", request,
+		     FI_LOG_DEBUG);
+		return !res;
+	}
+	res = fi_ibv_rdm_tagged_init_request_sbuf(request, ep);
+	if (!res) {
+		FI_IBV_RDM_TAGGED_DBG_REQUEST("failed because sbuf error",
+					      request, FI_LOG_DEBUG);
+		return res;
+	}
+	return res;
+#endif // ENABLE_DEBUG
+}
+
+static int fi_ibv_rdm_tagged_getname(fid_t fid, void *addr, size_t * addrlen)
+{
+	struct fi_ibv_rdm_ep *ep =
+	    container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
+
+	if (FI_IBV_RDM_DFLT_ADDRLEN > *addrlen) {
+		*addrlen = FI_IBV_RDM_DFLT_ADDRLEN;
+		return -FI_ETOOSMALL;
+	}
+	memset(addr, 0, *addrlen);
+	memcpy(addr, ep->my_rdm_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+	ep->fi_ibv_rdm_addrlen = *addrlen;
+
+	return 0;
+}
+
+static ssize_t fi_ibv_rdm_tagged_recvfrom(struct fid_ep *ep_fid, void *buf,
+					  size_t len, void *desc,
+					  fi_addr_t src_addr, uint64_t tag,
+					  uint64_t ignore, void *context)
+{
+	int ret = 0;
+
+	struct fi_ibv_rdm_tagged_request *request =
+	    (struct fi_ibv_rdm_tagged_request *)
+	    fi_verbs_mem_pool_get(&fi_ibv_rdm_tagged_request_pool);
+	fi_ibv_rdm_tagged_zero_request(request);
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
+
+	struct fi_ibv_rdm_tagged_conn *conn = (src_addr == FI_ADDR_UNSPEC)
+	    ? NULL : (struct fi_ibv_rdm_tagged_conn *)src_addr;
+	struct fi_ibv_rdm_ep *ep = container_of(ep_fid,
+						struct fi_ibv_rdm_ep, ep_fid);
+
+	{
+		struct fi_ibv_rdm_tagged_recv_start_data req_data = {
+			.tag = tag,
+			.tagmask = ~ignore,
+			.context = context,
+			.dest_addr = buf,
+			.conn = conn,
+			.ep = ep,
+			.data_len = len
+		};
+
+		ret = fi_ibv_rdm_tagged_req_hndl(request,
+				FI_IBV_EVENT_RECV_START, &req_data);
+		if (ret || request->state.eager ==
+		    FI_IBV_STATE_EAGER_RECV_WAIT4PKT) {
+			goto out;
+		}
+	}
+
+	VERBS_DBG(FI_LOG_EP_DATA,
+	    "fi_recvfrom: conn %p, tag 0x%llx, len %d, rbuf %p, fi_ctx %p, "
+	     "pend_recv %d\n",
+	     conn, (long long unsigned int)tag, (int)len, buf, context,
+	     ep->pend_recv);
+
+	struct fi_ibv_recv_got_pkt_process_data data = {
+		.ep = ep
+	};
+
+	if (request->state.rndv == FI_IBV_STATE_RNDV_RECV_WAIT4RES) {
+		if (fi_ibv_rdm_tagged_prepare_send_resources(request, ep)) {
+			ret =
+			    fi_ibv_rdm_tagged_req_hndl(request,
+						       FI_IBV_EVENT_SEND_READY,
+						       &data);
+		}
+	} else {
+		ret =
+		    fi_ibv_rdm_tagged_req_hndl(request, FI_IBV_EVENT_RECV_START,
+					       &data);
+	}
+
+out:
+	return ret;
+}
+
+static ssize_t fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep,
+					 const struct fi_msg_tagged *msg,
+					 uint64_t flags)
+{
+	void *buf;
+	size_t len;
+
+	if (!msg || msg->iov_count > 1)
+		return -FI_EINVAL;
+
+	if (msg->iov_count) {
+		buf = msg->msg_iov[0].iov_base;
+		len = msg->msg_iov[0].iov_len;
+	} else {
+		buf = NULL;
+		len = 0;
+	}
+
+	return fi_ibv_rdm_tagged_recvfrom(ep, buf, len,
+					  msg->desc ? msg->desc[0] : NULL,
+					  msg->addr, msg->tag, msg->ignore,
+					  msg->context);
+}
+
+static ssize_t fi_ibv_rdm_tagged_sendto(struct fid_ep *fid, const void *buf,
+					size_t len, void *desc,
+					fi_addr_t dest_addr,
+					uint64_t tag, void *context);
+
+static inline ssize_t fi_ibv_rdm_tagged_inject(struct fid_ep *fid,
+					       const void *buf,
+					       size_t len,
+					       fi_addr_t dest_addr,
+					       uint64_t tag)
+{
+	struct fi_ibv_rdm_tagged_conn *conn =
+	    (struct fi_ibv_rdm_tagged_conn *) dest_addr;
+	struct fi_ibv_rdm_ep *ep =
+	    container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
+
+	const size_t size = len + sizeof(struct fi_ibv_rdm_tagged_header);
+
+	if (size > ep->max_inline_rc) {
+		goto out_again;
+	}
+
+	if (conn->state != FI_VERBS_CONN_ESTABLISHED) {
+		goto out_connect;
+	}
+
+	const int in_order = (conn->postponed_entry) ? 0 : 1;
+	if (in_order) {
+		void *raw_sbuf = fi_ibv_rdm_tagged_get_sbuf(conn, ep);
+		if (raw_sbuf) {
+			struct ibv_sge sge = { 0 };
+			struct ibv_send_wr wr = { 0 };
+			struct ibv_send_wr *bad_wr = NULL;
+			wr.wr_id = FI_IBV_RDM_PACK_SERVICE_WR(conn);
+			wr.sg_list = &sge;
+			wr.num_sge = 1;
+			wr.wr.rdma.remote_addr =
+			    fi_ibv_rdm_tagged_get_remote_addr(conn, raw_sbuf);
+			wr.wr.rdma.rkey = conn->remote_rbuf_rkey;
+			wr.send_flags = IBV_SEND_INLINE;
+			wr.imm_data =
+			    fi_ibv_rdm_tagged_get_buff_service_data(raw_sbuf)->
+			    seq_number;
+			wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+
+			sge.addr = (uintptr_t) (raw_sbuf);
+			sge.length = size;
+			sge.lkey = conn->s_mr->lkey;
+
+			struct fi_ibv_rdm_tagged_buf *sbuf =
+			    (struct fi_ibv_rdm_tagged_buf *)raw_sbuf;
+			void *payload = (void *)&(sbuf->payload[0]);
+
+			sbuf->header.tag = tag;
+			sbuf->header.service_tag = 0;
+			FI_IBV_RDM_SET_PKTTYPE(sbuf->header.service_tag,
+					       FI_IBV_RDM_EAGER_PKT);
+			if (buf && (len > 0)) {
+				memcpy(payload, buf, len);
+			}
+			//INCREASE_SEND_COUNTERS(conn, ep, wr.send_flags);
+			VERBS_DBG(FI_LOG_EP_DATA,
+				"posted %d bytes, conn %p, tag 0x%llx\n",
+				sge.length, conn, tag);
+			if (!ibv_post_send(conn->qp, &wr, &bad_wr)) {
+				return FI_SUCCESS;
+			}
+		}
+	}
+
+out_again:
+	fi_ibv_rdm_tagged_poll(ep);
+	return FI_EAGAIN;
+
+out_connect:
+	pthread_mutex_lock(&ep->cm_lock);
+	if (conn->state == FI_VERBS_CONN_ALLOCATED) {
+		fi_ibv_rdm_start_connection(ep, conn);
+	}
+	pthread_mutex_unlock(&ep->cm_lock);
+	goto out_again;
+}
+
+static ssize_t fi_ibv_rdm_tagged_senddatato(struct fid_ep *fid, const void *buf,
+					    size_t len, void *desc,
+					    uint64_t data,
+					    fi_addr_t dest_addr, uint64_t tag,
+					    void *context)
+{
+	struct fi_ibv_rdm_tagged_conn *conn =
+	    (struct fi_ibv_rdm_tagged_conn *) dest_addr;
+
+#if defined(__ICC) || defined(__INTEL_COMPILER) || \
+    defined(__GNUC__) || defined(__GNUG__)
+	_mm_prefetch((const char *)
+		     fi_ibv_rdm_tagged_get_buff_service_data(conn->sbuf_head),
+		     _MM_HINT_T0);
+#endif /* ICC || GCC */
+
+	struct fi_ibv_rdm_ep *ep =
+	    container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
+	struct fi_ibv_rdm_tagged_request *request =
+	    (struct fi_ibv_rdm_tagged_request *)
+	    fi_verbs_mem_pool_get(&fi_ibv_rdm_tagged_request_pool);
+	fi_ibv_rdm_tagged_zero_request(request);
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
+
+	int ret = 0;
+
+	int in_order = (conn->postponed_entry) ? 0 : 1;
+
+	{
+		struct fi_ibv_rdm_tagged_send_start_data req_data = {
+			.src_addr = buf,
+			.context = context,
+			.conn = conn,
+			.tag = tag,
+			.data_len = len,
+			.rndv_threshold = ep->rndv_threshold,
+			.imm = (uint32_t) data
+		};
+		ret =
+		    fi_ibv_rdm_tagged_req_hndl(request, FI_IBV_EVENT_SEND_START,
+					       &req_data);
+		if (ret) {
+			goto out;
+		}
+	}
+
+	if (in_order && fi_ibv_rdm_tagged_prepare_send_resources(request, ep)) {
+		struct fi_ibv_rdm_tagged_send_ready_data req_data = {.ep = ep };
+		ret =
+		    fi_ibv_rdm_tagged_req_hndl(request, FI_IBV_EVENT_SEND_READY,
+					       &req_data);
+	}
+
+out:
+	return ret;
+}
+
+static ssize_t fi_ibv_rdm_tagged_sendto(struct fid_ep *fid, const void *buf,
+					size_t len, void *desc,
+					fi_addr_t dest_addr,
+					uint64_t tag, void *context)
+{
+	return fi_ibv_rdm_tagged_senddatato(fid, buf, len, desc, 0, dest_addr,
+					    tag, context);
+}
+
+struct fi_ops_tagged fi_ibv_rdm_tagged_ops = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = fi_ibv_rdm_tagged_recvfrom,
+	.senddata = fi_ibv_rdm_tagged_senddatato,
+	.send = fi_ibv_rdm_tagged_sendto,
+	.recvmsg = fi_ibv_rdm_tagged_recvmsg,
+	.inject = fi_ibv_rdm_tagged_inject,
+	.injectdata = fi_no_tagged_injectdata,
+};
+
+struct fi_ops_cm fi_ibv_rdm_tagged_ep_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
+	.getname = fi_ibv_rdm_tagged_getname,	/* TODO */
+};
+
+static inline void
+fi_ibv_rdm_tagged_process_recv(struct fi_ibv_rdm_ep *ep,
+			       struct fi_ibv_rdm_tagged_conn *conn,
+			       int arrived_len,
+			       uint32_t imm_data,
+			       struct fi_ibv_rdm_tagged_buf *rbuf)
+{
+	struct fi_ibv_rdm_tagged_request *request = NULL;
+
+	int pkt_type = FI_IBV_RDM_GET_PKTTYPE(rbuf->header.service_tag);
+
+	if (pkt_type == FI_IBV_RDM_RNDV_ACK_PKT) {
+		memcpy(&request, rbuf->payload,
+		      sizeof(struct fi_ibv_rdm_tagged_request *));
+		assert(request);
+		VERBS_DBG(FI_LOG_EP_DATA,
+			"GOT RNDV ACK from conn %p, id %d\n", conn, request);
+	} else {
+		const int data_len =
+		    arrived_len - sizeof(struct fi_ibv_rdm_tagged_header);
+
+		struct fi_verbs_rdm_tagged_request_minfo minfo = {
+			.conn = conn,
+			.tag = rbuf->header.tag,
+			.tagmask = 0
+		};
+
+		struct dlist_entry *found_entry =
+		    dlist_find_first_match(&fi_ibv_rdm_tagged_recv_posted_queue,
+					   fi_verbs_rdm_tagged_match_request_by_minfo,
+					   &minfo);
+
+		if (found_entry) {
+			struct fi_ibv_rdm_tagged_request *found_request =
+			    container_of(found_entry,
+					 struct fi_ibv_rdm_tagged_request,
+					 queue_entry);
+
+			if (found_request->len < data_len) {
+				FI_IBV_ERROR
+				    ("%s: %d RECV TRUNCATE, data_len=%d, posted_len=%d, "
+				     "conn %p, tag 0x%llx, tagmask %llx\n",
+				     __FUNCTION__, __LINE__, data_len,
+				     found_request->len, found_request->conn,
+				     (long long unsigned int)found_request->tag,
+				     (long long unsigned int)found_request->
+				     tagmask);
+				abort();
+			}
+
+			fi_ibv_rdm_tagged_remove_from_posted_queue
+			    (found_request, ep);
+			request = found_request;
+		} else {
+			request = (struct fi_ibv_rdm_tagged_request *)
+			    fi_verbs_mem_pool_get
+			    (&fi_ibv_rdm_tagged_request_pool);
+			fi_ibv_rdm_tagged_zero_request(request);
+
+			FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ",
+						      request, FI_LOG_DEBUG);
+		}
+	}
+
+	struct fi_ibv_recv_got_pkt_preprocess_data p = {
+		.conn = conn,
+		.ep = ep,
+		.rbuf = rbuf,
+		.arrived_len = arrived_len,
+		.pkt_type = pkt_type,
+		.imm_data = imm_data
+	};
+
+	fi_ibv_rdm_tagged_req_hndl(request, FI_IBV_EVENT_RECV_GOT_PKT_PROCESS,
+				   &p);
+}
+
+static inline void
+fi_ibv_rdm_tagged_release_remote_sbuff(struct fi_ibv_rdm_tagged_conn *conn,
+				       struct fi_ibv_rdm_ep *ep, int seq_num)
+{
+	// not needed till nobody use service data of recv buffers
+	char *buff = conn->sbuf_ack_head + seq_num * ep->buff_len;
+	fi_ibv_rdm_tagged_set_buffer_status(buff, BUF_STATUS_FREE);
+#if ENABLE_DEBUG
+	char *rbuf = (char *)fi_ibv_rdm_tagged_get_rbuf(conn, ep, seq_num);
+	memset(rbuf, 0,
+	      ep->buff_len - FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE);
+#endif // ENABLE_DEBUG
+	struct ibv_sge sge;
+	sge.addr =
+	    (uintptr_t) &fi_ibv_rdm_tagged_get_buff_service_data(buff)->status;
+	sge.length = sizeof(enum fi_ibv_rdm_tagged_buffer_status);
+	sge.lkey = conn->r_mr->lkey;
+
+	struct ibv_send_wr *bad_wr = NULL;
+	struct ibv_send_wr wr = { 0 };
+
+	wr.wr_id = FI_IBV_RDM_PACK_SERVICE_WR(conn);
+	wr.sg_list = &sge;
+	wr.num_sge = 1;
+	wr.wr.rdma.remote_addr =
+	    (uintptr_t) &fi_ibv_rdm_tagged_get_buff_service_data(
+			    conn->remote_sbuf_head + seq_num * ep->buff_len)->status;
+	wr.wr.rdma.rkey = conn->remote_sbuf_rkey;
+	wr.send_flags = IBV_SEND_INLINE;
+	wr.opcode = IBV_WR_RDMA_WRITE;	// w/o imm - do not put it into recv
+	// completion queue
+
+	FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS(conn, ep, wr.send_flags);
+	VERBS_DBG(FI_LOG_EP_DATA,
+		"posted %d bytes, remote sbuff released %d\n", sge.length,
+		seq_num);
+	int ret = ibv_post_send(conn->qp, &wr, &bad_wr);
+	if (ret) {
+		FI_IBV_ERROR
+		    ("ibv_post_send fail, ret %d, errno %d, strerror %s", ret,
+		     errno, strerror(errno));
+		assert(0);
+	};
+
+	if (conn->sends_outgoing > ep->n_buffs) {
+		fi_ibv_rdm_tagged_poll_send(ep);
+	}
+}
+
+static inline
+void check_and_repost_receives(struct fi_ibv_rdm_ep *ep,
+				struct fi_ibv_rdm_tagged_conn *conn)
+{
+	if (conn->recv_preposted < ep->recv_preposted_threshold) {
+		int to_post = ep->rq_wr_depth - conn->recv_preposted;
+		if (fi_ibv_rdm_tagged_repost_receives(conn, ep, to_post) !=
+		    to_post) {
+			FI_IBV_ERROR("repost recv failed\n");
+			abort();
+		}
+		VERBS_DBG(FI_LOG_EP_DATA,
+			"reposted_recvs, posted %d, local_credits %d\n",
+			to_post, conn->recv_preposted);
+	}
+}
+
+static inline void
+fi_ibv_rdm_tagged_got_recv_completion(struct fi_ibv_rdm_ep *ep,
+				      struct fi_ibv_rdm_tagged_conn *conn,
+				      int arrived_len, uint32_t imm_data)
+{
+	assert(arrived_len > 0);
+	conn->recv_preposted--;
+	check_and_repost_receives(ep, conn);
+	struct fi_ibv_rdm_tagged_buf *rbuf =
+	    fi_ibv_rdm_tagged_get_rbuf(conn, ep, imm_data);
+	fi_ibv_rdm_tagged_process_recv(ep, conn, arrived_len, imm_data, rbuf);
+	fi_ibv_rdm_tagged_release_remote_sbuff(conn, ep, imm_data);
+}
+
+static inline int fi_ibv_rdm_tagged_poll_recv(struct fi_ibv_rdm_ep *ep)
+{
+	const int wc_count = ep->n_buffs;	// TODO: to set from upper level
+	struct ibv_wc wc[wc_count];
+	int i;
+	int ret;
+
+	do {
+		ret = ibv_poll_cq(ep->rcq, wc_count, wc);
+		for (i = 0; i < ret; ++i) {
+			if (wc[i].status == IBV_WC_SUCCESS
+			    && wc[i].opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
+				FI_IBV_DBG_OPCODE(wc[i].opcode, "RECV");
+
+				struct fi_ibv_rdm_tagged_conn *conn =
+				    (struct fi_ibv_rdm_tagged_conn *)(uintptr_t)
+				    wc[i].wr_id;
+
+				fi_ibv_rdm_tagged_got_recv_completion(ep, conn,
+								      wc[i].
+								      byte_len,
+								      wc[i].
+								      imm_data);
+			} else {
+				goto wc_error;
+			}
+		}
+	} while (ret == wc_count);
+
+	if (ret >= 0)		// Success
+	{
+		return 0;
+	}
+
+wc_error:
+	FI_IBV_ERROR("%s: ibv_poll_cq returned %d\n", __FUNCTION__, ret);
+
+	if (wc[i].status != IBV_WC_SUCCESS) {
+		FI_IBV_ERROR("%s: got ibv_wc.status = %d:%s\n",
+			     __FUNCTION__, wc[i].status,
+			     ibv_wc_status_str(wc[i].status));
+		assert(0);
+		return FI_EOTHER;
+	}
+
+	if (wc[i].opcode != IBV_WC_RECV_RDMA_WITH_IMM) {
+		FI_IBV_ERROR("%s: got ibv_wc[i].opcode = %d\n",
+			     __FUNCTION__, wc[i].opcode);
+	}
+
+	assert(0);
+
+	return FI_EOTHER;
+}
+
+static inline int fi_ibv_rdm_tagged_poll_send(struct fi_ibv_rdm_ep *ep)
+{
+	const int wc_count = ep->n_buffs;
+	struct ibv_wc wc[wc_count];
+	int i = 0;
+	int ret = 0;
+
+	if (ep->total_outgoing_send > 0) {
+		do {
+			ret = ibv_poll_cq(ep->scq, wc_count, wc);
+			for (i = 0; i < ret; ++i) {
+				if (wc[i].status == IBV_WC_SUCCESS) {
+					if (FI_IBV_RDM_CHECK_SERVICE_WR_FLAG
+					    (wc[i].wr_id)) {
+						VERBS_DBG(FI_LOG_EP_DATA,
+							"CQ COMPL: SEND -> 0x1\n");
+						struct fi_ibv_rdm_tagged_conn
+						    *conn =
+						    (struct
+						     fi_ibv_rdm_tagged_conn *)
+						    FI_IBV_RDM_UNPACK_SERVICE_WR
+						    (wc[i].wr_id);
+						FI_IBV_RDM_TAGGED_DEC_SEND_COUNTERS
+						    (conn, ep);
+					} else {
+						FI_IBV_DBG_OPCODE(wc[i].opcode,
+								  "SEND");
+						struct fi_ibv_rdm_tagged_request
+						    *request =
+						    (struct
+						     fi_ibv_rdm_tagged_request
+						     *)
+						    FI_IBV_RDM_UNPACK_WR(wc[i].
+									 wr_id);
+
+						struct fi_ibv_rdm_tagged_send_completed_data
+						    data = {
+							.ep = ep
+						};
+
+						fi_ibv_rdm_tagged_req_hndl
+						    (request,
+						     FI_IBV_EVENT_SEND_GOT_LC,
+						     &data);
+					}
+				} else {
+					goto wc_error;
+				}
+			}
+		} while (ret == wc_count);
+	}
+
+	struct fi_ibv_rdm_tagged_send_ready_data data = {.ep = ep };
+	struct dlist_entry *item;
+	dlist_foreach((&fi_ibv_rdm_tagged_send_postponed_queue), item)
+		fi_ibv_rdm_tagged_send_postponed_process(item, &data);
+
+	if (ret >= 0)		// Success
+	{
+		return 0;
+	}
+
+wc_error:
+	if (ret < 0 || wc[i].status != IBV_WC_SUCCESS) {
+		if (ret < 0) {
+			FI_IBV_ERROR("%s: ibv_poll_cq returned %d\n",
+				     __FUNCTION__, ret);
+			assert(0);
+		}
+
+		if (wc[i].status != IBV_WC_SUCCESS && ret != 0) {
+			struct fi_ibv_rdm_tagged_conn *conn =
+			    (FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wc[i].wr_id))
+			    ? (struct fi_ibv_rdm_tagged_conn *)
+			    FI_IBV_RDM_UNPACK_SERVICE_WR(wc[i].wr_id)
+			    : ((struct fi_ibv_rdm_tagged_request *)wc[i].
+			       wr_id)->conn;
+
+			FI_IBV_ERROR
+			    ("%s: got ibv_wc.status = %d:%s, pend_send: %d, "
+			     "connection: %p\n", __FUNCTION__, wc[i].status,
+			     ibv_wc_status_str(wc[i].status), ep->pend_send,
+			     (conn));
+			assert(0);
+		}
+	}
+	return FI_EOTHER;
+}
+
+int fi_ibv_rdm_tagged_poll(struct fi_ibv_rdm_ep *ep)
+{
+	int ret = fi_ibv_rdm_tagged_poll_send(ep);
+	if (ret) {
+		return ret;
+	}
+
+	return fi_ibv_rdm_tagged_poll_recv(ep);
+}
+
+static inline int
+fi_ibv_rdm_tagged_init_request_sbuf(struct fi_ibv_rdm_tagged_request *request,
+				    struct fi_ibv_rdm_ep *ep)
+{
+	assert(request->sbuf == NULL);
+	request->sbuf = fi_ibv_rdm_tagged_get_sbuf(request->conn, ep);
+	return !!request->sbuf;
+}
+
+static inline void *fi_ibv_rdm_tagged_get_sbuf(struct fi_ibv_rdm_tagged_conn
+					       *conn, struct fi_ibv_rdm_ep *ep)
+{
+	assert(conn);
+
+#if ENABLE_DEBUG
+	{
+		int i;
+		char s[1024];
+		char *p = s;
+		sprintf(p, "N:%1d ", ep->n_buffs);
+		p += 4;
+		for (i = 0; i < ep->n_buffs; ++i, p += 4) {
+			sprintf(p, "%1d:%1d ",
+				fi_ibv_rdm_tagged_get_buff_service_data(
+					conn->sbuf_mem_reg +
+					FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE +
+					i * ep->buff_len)->seq_number,
+				fi_ibv_rdm_tagged_get_buffer_status(
+					conn->sbuf_mem_reg +
+					FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE +
+					i * ep->buff_len));
+		}
+		VERBS_DBG(FI_LOG_EP_DATA,
+			"conn %p sbufs status before: %s\n", conn, s);
+	}
+#endif // ENABLE_DEBUG
+
+	void *sbuf = NULL;
+	if (fi_ibv_rdm_tagged_get_buffer_status(conn->sbuf_head) ==
+	    BUF_STATUS_FREE) {
+		fi_ibv_rdm_tagged_set_buffer_status(conn->sbuf_head,
+						    BUF_STATUS_BUSY);
+		sbuf = conn->sbuf_head;
+		fi_ibv_rdm_tagged_push_sbuff_head(conn, ep);
+	}
+#if ENABLE_DEBUG
+	assert(sbuf
+	       ? (fi_ibv_rdm_tagged_get_buffer_status(sbuf) == BUF_STATUS_BUSY)
+	       : 1);
+	{
+		int i;
+		char s[1024];
+		char *p = s;
+		sprintf(p, "N:%1d ", ep->n_buffs);
+		p += 4;
+		for (i = 0; i < ep->n_buffs; ++i, p += 4) {
+			sprintf(p, "%1d:%1d ",
+				fi_ibv_rdm_tagged_get_buff_service_data(
+					conn->sbuf_mem_reg +
+					FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE +
+					i * ep->buff_len)->seq_number,
+				fi_ibv_rdm_tagged_get_buffer_status(
+					conn->sbuf_mem_reg +
+					FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE +
+					i * ep->buff_len));
+		}
+		VERBS_DBG(FI_LOG_EP_DATA,
+			"conn %p sbufs status after:  %s\n", conn, s);
+	}
+#endif // ENABLE_DEBUG
+
+	VERBS_DBG(FI_LOG_EP_DATA,
+		     "conn %p sbuf allocated: %d:%p, head: %p, begin: %p\n",
+		     conn,
+		     (sbuf) ?
+		     fi_ibv_rdm_tagged_get_buff_service_data(sbuf)->
+		     seq_number : -1, sbuf, conn->sbuf_head,
+		     conn->sbuf_mem_reg);
+
+	return sbuf;
+}

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -1,0 +1,1073 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <inttypes.h>
+#include <stdlib.h>
+
+#include <fi_list.h>
+#include "../fi_verbs.h"
+#include "verbs_rdm.h"
+#include "verbs_queuing.h"
+#include "verbs_tagged_ep_rdm_states.h"
+
+extern struct dlist_entry fi_ibv_rdm_tagged_send_postponed_queue;
+extern struct fi_ibv_mem_pool fi_ibv_rdm_tagged_request_pool;
+extern struct fi_ibv_mem_pool fi_ibv_rdm_tagged_unexp_buffers_pool;
+
+typedef enum fi_rdm_tagged_req_hndl_ret (*fi_ep_rdm_request_handler_t)
+	(struct fi_ibv_rdm_tagged_request * request, void *data);
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_err_hndl(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_init_send_request(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_eager_send_ready(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_eager_send_lc(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_rts_send_ready(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_rts_lc(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_end(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_init_recv_request(struct fi_ibv_rdm_tagged_request *request,
+		    void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_init_unexp_recv_request(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_eager_recv_got_pkt(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_eager_recv_got_unexp_pkt(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_recv_post_read(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_recv_read_lc(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_recv_ack_lc(struct fi_ibv_rdm_tagged_request *request,
+		void *data);
+
+static fi_ep_rdm_request_handler_t
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_COUNT]
+	                          [FI_IBV_STATE_RNDV_COUNT]
+	                          [FI_IBV_EVENT_COUNT];
+
+enum fi_rdm_tagged_req_hndl_ret fi_ibv_rdm_tagged_req_hndls_init(void)
+{
+	size_t i, j, k;
+
+	for (i = 0; i < FI_IBV_STATE_EAGER_COUNT; ++i) {
+		for (j = 0; j < FI_IBV_STATE_RNDV_COUNT; ++j) {
+			for (k = 0; k < FI_IBV_EVENT_COUNT; ++k) {
+				fi_ibv_rdm_tagged_hndl_arr[i][j][k] =
+				    fi_ibv_rdm_tagged_err_hndl;
+			}
+		}
+	}
+
+	// EAGER_SEND stuff
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_BEGIN]
+	    [FI_IBV_STATE_RNDV_NOT_USED][FI_IBV_EVENT_SEND_START] =
+	    fi_ibv_rdm_tagged_init_send_request;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_SEND_POSTPONED]
+	    [FI_IBV_STATE_RNDV_NOT_USED][FI_IBV_EVENT_SEND_READY] =
+	    fi_ibv_rdm_tagged_eager_send_ready;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_SEND_WAIT4LC]
+	    [FI_IBV_STATE_RNDV_NOT_USED][FI_IBV_EVENT_SEND_GOT_LC] =
+	    fi_ibv_rdm_tagged_eager_send_lc;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_READY_TO_FREE]
+	    [FI_IBV_STATE_RNDV_NOT_USED][FI_IBV_EVENT_SEND_GOT_LC] =
+	    fi_ibv_rdm_tagged_eager_send_lc;
+
+	// EAGER_RECV stuff
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_BEGIN]
+	    [FI_IBV_STATE_RNDV_NOT_USED][FI_IBV_EVENT_RECV_START] =
+	    fi_ibv_rdm_tagged_init_recv_request;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_BEGIN]
+	    [FI_IBV_STATE_RNDV_NOT_USED][FI_IBV_EVENT_RECV_GOT_PKT_PROCESS] =
+	    fi_ibv_rdm_tagged_init_unexp_recv_request;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_RECV_WAIT4PKT]
+	    [FI_IBV_STATE_RNDV_NOT_USED][FI_IBV_EVENT_RECV_GOT_PKT_PROCESS] =
+	    fi_ibv_rdm_tagged_eager_recv_got_pkt;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_RECV_WAIT4RECV]
+	    [FI_IBV_STATE_RNDV_NOT_USED][FI_IBV_EVENT_RECV_START] =
+	    fi_ibv_rdm_tagged_eager_recv_got_unexp_pkt;
+
+	// RNDV_SEND stuff
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_BEGIN]
+	    [FI_IBV_STATE_RNDV_SEND_BEGIN][FI_IBV_EVENT_SEND_START] =
+	    fi_ibv_rdm_tagged_init_send_request;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_SEND_POSTPONED]
+	    [FI_IBV_STATE_RNDV_SEND_WAIT4SEND][FI_IBV_EVENT_SEND_READY] =
+	    fi_ibv_rdm_tagged_rndv_rts_send_ready;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_SEND_WAIT4LC]
+	    [FI_IBV_STATE_RNDV_SEND_WAIT4ACK][FI_IBV_EVENT_SEND_GOT_LC] =
+	    fi_ibv_rdm_tagged_rndv_rts_lc;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_READY_TO_FREE]
+	    [FI_IBV_STATE_RNDV_SEND_END][FI_IBV_EVENT_SEND_GOT_LC] =
+	    fi_ibv_rdm_tagged_rndv_rts_lc;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_SEND_WAIT4LC]
+	    [FI_IBV_STATE_RNDV_SEND_WAIT4ACK][FI_IBV_EVENT_RECV_GOT_PKT_PROCESS]
+	    = fi_ibv_rdm_tagged_rndv_end;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_SEND_END]
+	    [FI_IBV_STATE_RNDV_SEND_WAIT4ACK][FI_IBV_EVENT_RECV_GOT_PKT_PROCESS]
+	    = fi_ibv_rdm_tagged_rndv_end;
+
+	// RNDV_RECV stuff
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_BEGIN]
+	    [FI_IBV_STATE_RNDV_RECV_BEGIN][FI_IBV_EVENT_RECV_START] =
+	    fi_ibv_rdm_tagged_init_recv_request;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_RECV_END]
+	    [FI_IBV_STATE_RNDV_RECV_WAIT4RES][FI_IBV_EVENT_SEND_READY] =
+	    fi_ibv_rdm_tagged_rndv_recv_post_read;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_RECV_END]
+	    [FI_IBV_STATE_RNDV_RECV_WAIT4LC][FI_IBV_EVENT_SEND_GOT_LC] =
+	    fi_ibv_rdm_tagged_rndv_recv_read_lc;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_RECV_END]
+	    [FI_IBV_STATE_RNDV_RECV_WAIT4LC][FI_IBV_EVENT_SEND_READY] =
+	    fi_ibv_rdm_tagged_rndv_recv_read_lc;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_SEND_WAIT4LC]
+	    [FI_IBV_STATE_RNDV_RECV_END][FI_IBV_EVENT_SEND_GOT_LC] =
+	    fi_ibv_rdm_tagged_rndv_recv_ack_lc;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_READY_TO_FREE]
+	    [FI_IBV_STATE_RNDV_RECV_END][FI_IBV_EVENT_SEND_GOT_LC] =
+	    fi_ibv_rdm_tagged_rndv_recv_ack_lc;
+	fi_ibv_rdm_tagged_hndl_arr[FI_IBV_STATE_EAGER_RECV_END]
+	    [FI_IBV_STATE_RNDV_RECV_WAIT4LC][FI_IBV_EVENT_SEND_GOT_LC] =
+	    fi_ibv_rdm_tagged_rndv_recv_read_lc;
+
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+enum fi_rdm_tagged_req_hndl_ret fi_ibv_rdm_tagged_req_hndls_clean(void)
+{
+	size_t i, j, k;
+	for (i = 0; i < FI_IBV_STATE_EAGER_COUNT; ++i) {
+		for (j = 0; j < FI_IBV_STATE_RNDV_COUNT; ++j) {
+			for (k = 0; k < FI_IBV_EVENT_COUNT; ++k) {
+				fi_ibv_rdm_tagged_hndl_arr[i][j][k] = NULL;
+			}
+		}
+	}
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_req_hndl(struct fi_ibv_rdm_tagged_request * request,
+			   enum fi_ibv_rdm_tagged_request_event event, void *data)
+{
+	VERBS_DBG(FI_LOG_EP_DATA, "\t%p, eager_state = %s, rndv_state = %s, event = %s\n",
+		     request,
+		     fi_ibv_rdm_tagged_req_eager_state_to_str
+		     (request->state.eager),
+		     fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.
+							     rndv),
+		     fi_ibv_rdm_tagged_req_event_to_str(event));
+	assert(fi_ibv_rdm_tagged_hndl_arr[request->state.eager]
+	       [request->state.rndv]
+	       [event]);
+
+	return fi_ibv_rdm_tagged_hndl_arr[request->state.eager]
+	    [request->state.rndv]
+	    [event] (request, data);
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_err_hndl(struct fi_ibv_rdm_tagged_request *request,
+			   void *data)
+{
+	FI_IBV_ERROR("\t> IN\t< eager_state = %s, rndv_state = %s, len = %d\n",
+		     fi_ibv_rdm_tagged_req_eager_state_to_str
+		     (request->state.eager),
+		     fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.
+							     rndv),
+		     request->len);
+
+	assert(0);
+	return FI_EP_RDM_HNDL_NOT_INIT;
+}
+
+#if ENABLE_DEBUG
+
+enum fi_ibv_rdm_tagged_hndl_req_log_state {
+	hndl_req_log_state_in = 0,
+	hndl_req_log_state_out = 10000
+};
+
+#define FI_IBV_RDM_TAGGED_HANDLER_LOG_IN()                                  \
+enum fi_ibv_rdm_tagged_hndl_req_log_state state = hndl_req_log_state_in;    \
+do {                                                                        \
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("\t> IN\t< ", request, FI_LOG_DEBUG); \
+} while(0)
+
+#define FI_IBV_RDM_TAGGED_HANDLER_LOG() do {                            \
+	state++;                                                        \
+	char prefix[128];                                               \
+	snprintf(prefix, 128, "\t> %d\t< ", state);                     \
+	FI_IBV_RDM_TAGGED_DBG_REQUEST(prefix, request, FI_LOG_DEBUG);   \
+} while(0)
+
+#define FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT() do {                              \
+	assert(state < hndl_req_log_state_out);                               \
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("\t> OUT\t< ", request, FI_LOG_DEBUG);  \
+} while(0)
+
+#else // ENABLE_DEBUG
+#define FI_IBV_RDM_TAGGED_HANDLER_LOG_IN()
+#define FI_IBV_RDM_TAGGED_HANDLER_LOG()
+#define FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT()
+#endif // ENABLE_DEBUG
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_init_send_request(struct fi_ibv_rdm_tagged_request *request,
+				    void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+
+	struct fi_ibv_rdm_tagged_send_start_data *p = data;
+	request->tag = p->tag;
+	request->src_addr = p->src_addr;
+	request->len = p->data_len;
+	request->imm = p->imm;
+	request->context = p->context;
+	request->conn = p->conn;
+	request->state.eager = FI_IBV_STATE_EAGER_BEGIN;
+	request->state.rndv =
+	    (p->data_len + sizeof(struct fi_ibv_rdm_tagged_header)
+	     <= p->rndv_threshold)
+	    ? FI_IBV_STATE_RNDV_NOT_USED : FI_IBV_STATE_RNDV_SEND_BEGIN;
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG();
+
+	fi_ibv_rdm_tagged_move_to_postponed_queue(request);
+	request->state.eager = FI_IBV_STATE_EAGER_SEND_POSTPONED;
+	if (request->state.rndv == FI_IBV_STATE_RNDV_SEND_BEGIN) {
+		request->state.rndv = FI_IBV_STATE_RNDV_SEND_WAIT4SEND;
+	}
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_eager_send_ready(struct fi_ibv_rdm_tagged_request *request,
+				   void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+
+	assert(request->state.eager == FI_IBV_STATE_EAGER_SEND_POSTPONED);
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_NOT_USED);
+
+	fi_ibv_rdm_tagged_remove_from_postponed_queue(request);
+	struct fi_ibv_rdm_tagged_send_ready_data *p = data;
+
+	int ret = 0;
+	struct ibv_sge sge;
+
+	struct fi_ibv_rdm_tagged_conn *conn = request->conn;
+	int size = request->len + sizeof(struct fi_ibv_rdm_tagged_header);
+
+	assert(request->sbuf);
+
+	struct ibv_send_wr wr = { 0 };
+	struct ibv_send_wr *bad_wr = NULL;
+	wr.wr_id = (uintptr_t) request;
+
+	wr.sg_list = &sge;
+	wr.num_sge = 1;
+	wr.wr.rdma.remote_addr =
+	    fi_ibv_rdm_tagged_get_remote_addr(conn, request->sbuf);
+	wr.wr.rdma.rkey = conn->remote_rbuf_rkey;
+	wr.send_flags = 0;
+
+	sge.addr = (uintptr_t) request->sbuf;
+	sge.length = size;
+
+	if (sge.length <= p->ep->max_inline_rc) {
+		wr.send_flags |= IBV_SEND_INLINE;
+	}
+
+	sge.lkey = conn->s_mr->lkey;
+
+	wr.imm_data =
+	    fi_ibv_rdm_tagged_get_buff_service_data(request->sbuf)->seq_number;
+	wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+	struct fi_ibv_rdm_tagged_buf *sbuf =
+	    (struct fi_ibv_rdm_tagged_buf *)request->sbuf;
+	void *payload = (void *)&(sbuf->payload[0]);
+
+	sbuf->header.tag = request->tag;
+	sbuf->header.service_tag = 0;
+	FI_IBV_RDM_SET_PKTTYPE(sbuf->header.service_tag, FI_IBV_RDM_EAGER_PKT);
+	if (request->src_addr) {
+		memcpy(payload, request->src_addr, request->len);
+	}
+
+	FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS_REQ(request, p->ep, wr.send_flags);
+	VERBS_DBG(FI_LOG_EP_DATA, "posted %d bytes, conn %p, tag 0x%llx\n", sge.length,
+		     request->conn, request->tag);
+
+	ret = ibv_post_send(conn->qp, &wr, &bad_wr);
+	if (ret) {
+		FI_IBV_ERROR
+		    ("ibv_post_send fail, ret %d, errno %d, strerror %s", ret,
+		     errno, strerror(errno));
+		assert(0);
+	};
+
+	fi_ibv_rdm_tagged_move_to_ready_queue(request);
+	request->state.eager = FI_IBV_STATE_EAGER_SEND_WAIT4LC;
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+
+	return ret;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_eager_send_lc(struct fi_ibv_rdm_tagged_request *request,
+				void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+
+	assert(request->state.eager == FI_IBV_STATE_EAGER_SEND_WAIT4LC ||
+	       request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE);
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_NOT_USED);
+
+	VERBS_DBG(FI_LOG_EP_DATA, "conn %p, tag 0x%llx, len %d\n", request->conn,
+		     request->tag, request->len);
+
+	struct fi_ibv_rdm_tagged_send_completed_data *p = data;
+	FI_IBV_RDM_TAGGED_DEC_SEND_COUNTERS(request->conn, p->ep);
+
+	request->send_completions_wait--;
+
+	if (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
+		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
+					      FI_LOG_DEBUG);
+		fi_ibv_mem_pool_return(&request->mpe,
+				       &fi_ibv_rdm_tagged_request_pool);
+	} else {
+		fi_ibv_rdm_tagged_move_to_ready_queue(request);
+		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
+	}
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_rts_send_ready(struct fi_ibv_rdm_tagged_request *request,
+				      void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+
+	assert(request->state.eager == FI_IBV_STATE_EAGER_SEND_POSTPONED);
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_SEND_WAIT4SEND);
+	assert(request->sbuf);
+
+	VERBS_DBG(FI_LOG_EP_DATA, "conn %p, tag 0x%llx, len %d\n", request->conn,
+		     request->tag, request->len);
+
+	fi_ibv_rdm_tagged_remove_from_postponed_queue(request);
+	struct fi_ibv_rdm_tagged_send_ready_data *p = data;
+
+	struct ibv_sge sge;
+
+	struct fi_ibv_rdm_tagged_conn *conn = request->conn;
+	struct fi_ibv_rdm_tagged_rndv_header *header =
+	    (struct fi_ibv_rdm_tagged_rndv_header *)request->sbuf;
+	struct ibv_mr *mr = NULL;
+
+	struct ibv_send_wr wr, *bad_wr = NULL;
+	memset(&wr, 0, sizeof(wr));
+	wr.wr_id = (uintptr_t) request;
+	assert(FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wr.wr_id) == 0);
+
+	wr.sg_list = &sge;
+	wr.num_sge = 1;
+	wr.wr.rdma.remote_addr =
+	    fi_ibv_rdm_tagged_get_remote_addr(conn, request->sbuf);
+	wr.wr.rdma.rkey = conn->remote_rbuf_rkey;
+	wr.send_flags = 0;
+	wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+	wr.imm_data =
+	    fi_ibv_rdm_tagged_get_buff_service_data(request->sbuf)->seq_number;
+
+	sge.addr = (uintptr_t) request->sbuf;
+	sge.length = sizeof(struct fi_ibv_rdm_tagged_rndv_header);
+	sge.lkey = conn->s_mr->lkey;
+
+	header->base.tag = request->tag;
+	header->base.service_tag = 0;
+	header->len = request->len;
+	header->src_addr = (uint64_t) (uintptr_t) request->src_addr;
+
+	header->id = request;
+	request->rndv_id = request;
+
+	mr = ibv_reg_mr(p->ep->domain->pd, (void *)request->src_addr,
+			request->len, IBV_ACCESS_REMOTE_READ);
+	if (NULL == mr) {
+		FI_IBV_ERROR("%s ibv_reg_mr fail, buf %p, len %d,"
+			     " errno %d:%s", __FUNCTION__, request->src_addr,
+			     (int)request->len, errno, strerror(errno));
+		assert(0);
+		return FI_EOTHER;
+	}
+
+	header->mem_key = mr->rkey;
+	request->rndv_mr = mr;
+
+	struct fi_ibv_rdm_tagged_buf *sbuf = request->sbuf;
+
+	FI_IBV_RDM_SET_PKTTYPE(sbuf->header.service_tag,
+			       FI_IBV_RDM_RNDV_RTS_PKT);
+
+	VERBS_DBG(FI_LOG_EP_DATA,
+	     "fi_senddatato: RNDV conn %p, tag 0x%llx, len %d, src_addr %p,"
+	     "rkey 0x%lx, fi_ctx %p, imm %d, pend_send %d\n", conn,
+	     (long long unsigned int)request->tag, (int)request->len,
+	     request->src_addr, (long unsigned int)mr->rkey, request->context,
+	     (int)wr.imm_data, p->ep->pend_send);
+
+	FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS_REQ(request, p->ep, wr.send_flags);
+	VERBS_DBG(FI_LOG_EP_DATA, "posted %d bytes, conn %p, tag 0x%llx\n", sge.length,
+		     request->conn, request->tag);
+	int ret = ibv_post_send(conn->qp, &wr, &bad_wr);
+	if (ret) {
+		FI_IBV_ERROR
+		    ("ibv_post_send fail, ret %d, errno %d, strerror %s\n", ret,
+		     errno, strerror(errno));
+		assert(0);
+	};
+
+	request->state.eager = FI_IBV_STATE_EAGER_SEND_WAIT4LC;
+	request->state.rndv = FI_IBV_STATE_RNDV_SEND_WAIT4ACK;
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_rts_lc(struct fi_ibv_rdm_tagged_request *request,
+			      void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+	enum fi_rdm_tagged_req_hndl_ret ret = FI_EP_RDM_HNDL_SUCCESS;
+
+	assert(((request->state.eager == FI_IBV_STATE_EAGER_SEND_WAIT4LC) &&
+		(request->state.rndv == FI_IBV_STATE_RNDV_SEND_WAIT4ACK)) ||
+	       ((request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) &&
+		(request->state.rndv == FI_IBV_STATE_RNDV_SEND_END)));
+	assert(request->conn);
+
+	VERBS_DBG(FI_LOG_EP_DATA, "conn %p, tag 0x%llx, len %d\n", request->conn,
+		     request->tag, request->len);
+
+	struct fi_ibv_rdm_tagged_send_completed_data *p = data;
+
+	FI_IBV_RDM_TAGGED_DEC_SEND_COUNTERS(request->conn, p->ep);
+	request->send_completions_wait--;
+
+	if (request->state.eager == FI_IBV_STATE_EAGER_SEND_WAIT4LC) {
+		request->state.eager = FI_IBV_STATE_EAGER_SEND_END;
+	}
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+
+	return ret;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_end(struct fi_ibv_rdm_tagged_request *request,
+			   void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+	assert(request->state.eager == FI_IBV_STATE_EAGER_SEND_END ||
+	       (request->state.eager == FI_IBV_STATE_EAGER_SEND_WAIT4LC));
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_SEND_WAIT4ACK);
+
+#ifndef NDEBUG
+	struct fi_ibv_recv_got_pkt_preprocess_data *p = data;
+#endif /* NDEBUG */
+
+	assert((sizeof(struct fi_ibv_rdm_tagged_request *) +
+		sizeof(struct fi_ibv_rdm_tagged_header)) == p->arrived_len);
+	assert(request->rndv_mr);
+	assert(p->rbuf);
+
+	int ret = ibv_dereg_mr(request->rndv_mr);
+	if (ret) {
+		FI_IBV_ERROR("%s: ibv_dereg_mr failed: ret %d, errno %d : %s",
+			     __FUNCTION__, ret, errno, strerror(errno));
+	}
+
+	request->state.rndv = FI_IBV_STATE_RNDV_SEND_END;
+
+	fi_ibv_rdm_tagged_move_to_ready_queue(request);
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_init_recv_request(struct fi_ibv_rdm_tagged_request *request,
+				    void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+
+	struct fi_ibv_rdm_tagged_recv_start_data *p = data;
+
+	request->tag = p->tag;
+	request->tagmask = p->tagmask;
+	request->context = p->context;
+	request->context->internal[0] = (void *)request;
+	request->dest_buf = p->dest_addr;
+	request->conn = p->conn;
+	request->len = p->data_len;
+	request->state.eager = FI_IBV_STATE_EAGER_RECV_WAIT4PKT;
+	request->state.rndv = FI_IBV_STATE_RNDV_NOT_USED;
+
+	VERBS_DBG(FI_LOG_EP_DATA, "conn %p, tag 0x%llx, len %d\n", request->conn,
+		     request->tag, request->len);
+
+	struct fi_verbs_rdm_tagged_request_minfo minfo = {
+		.conn = p->conn,
+		.tag = p->tag,
+		.tagmask = p->tagmask
+	};
+
+	struct dlist_entry *found_entry =
+	    dlist_find_first_match(&fi_ibv_rdm_tagged_recv_unexp_queue,
+				   fi_verbs_rdm_tagged_match_request_by_minfo_with_tagmask,
+				   &minfo);
+
+	if (found_entry) {
+
+		struct fi_ibv_rdm_tagged_request *found_request =
+		    container_of(found_entry, struct fi_ibv_rdm_tagged_request,
+				 queue_entry);
+
+		if (request->len < found_request->len) {
+			FI_IBV_ERROR("%s: %d RECV TRUNCATE, unexp len %d, "
+				     "req->len=%d, conn %p, tag 0x%llx, "
+				     "tagmask %llx\n",
+				     __FUNCTION__, __LINE__, found_request->len,
+				     request->len, request->conn,
+				     (long long unsigned int)request->tag,
+				     (long long unsigned int)request->tagmask);
+			abort();
+		}
+
+		request->tag = found_request->tag;
+		request->len = found_request->len;
+		request->conn = found_request->conn;
+		request->unexp_rbuf = found_request->unexp_rbuf;
+		request->state.eager = found_request->state.eager;
+		request->state.rndv = found_request->state.rndv;
+
+		assert(request->state.eager ==
+		       FI_IBV_STATE_EAGER_RECV_WAIT4RECV);
+		if (request->state.rndv != FI_IBV_STATE_RNDV_NOT_USED) {
+			assert(request->state.rndv ==
+			       FI_IBV_STATE_RNDV_RECV_WAIT4RES);
+
+			request->rndv_remote_key =
+			    found_request->rndv_remote_key;
+			request->rndv_id = found_request->rndv_id;
+			request->src_addr = found_request->src_addr;
+		}
+		VERBS_DBG(FI_LOG_EP_DATA, "found req: len = %d, eager_state = %s, "
+			     "rndv_state = %s \n",
+			     found_request->len,
+			     fi_ibv_rdm_tagged_req_eager_state_to_str
+			     (found_request->state.eager),
+			     fi_ibv_rdm_tagged_req_rndv_state_to_str
+			     (found_request->state.rndv));
+
+		FI_IBV_RDM_TAGGED_HANDLER_LOG();
+
+		fi_ibv_rdm_tagged_remove_from_unexp_queue(found_request);
+
+		assert(found_request->send_completions_wait == 0);
+		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
+					      FI_LOG_DEBUG);
+		fi_ibv_mem_pool_return(&found_request->mpe,
+				       &fi_ibv_rdm_tagged_request_pool);
+
+		if (request->state.rndv == FI_IBV_STATE_RNDV_RECV_WAIT4RES) {
+			request->state.eager = FI_IBV_STATE_EAGER_RECV_END;
+			fi_ibv_rdm_tagged_move_to_postponed_queue(request);
+		}
+#if ENABLE_DEBUG
+		request->conn->unexp_counter++;
+#endif // ENABLE_DEBUG
+
+	} else {
+
+#if ENABLE_DEBUG
+		if (request->conn) {
+			request->conn->exp_counter++;
+		}
+#endif // ENABLE_DEBUG
+
+		fi_ibv_rdm_tagged_move_to_posted_queue(request, p->ep);
+	}
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_init_unexp_recv_request(
+		struct fi_ibv_rdm_tagged_request *request, void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+
+	assert(request->state.eager == FI_IBV_STATE_EAGER_BEGIN);
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_NOT_USED);
+
+	struct fi_ibv_recv_got_pkt_preprocess_data *p = data;
+	struct fi_ibv_rdm_tagged_buf *rbuf = p->rbuf;
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG();
+
+	switch (p->pkt_type) {
+	case FI_IBV_RDM_EAGER_PKT:
+		FI_IBV_RDM_TAGGED_HANDLER_LOG();
+		assert(p->arrived_len <= p->ep->rndv_threshold);
+
+		request->tag = rbuf->header.tag;
+		request->conn = p->conn;
+		request->len = p->arrived_len -
+		    sizeof(struct fi_ibv_rdm_tagged_header);
+		if (request->len > 0) {
+			request->unexp_rbuf =
+			    (struct fi_ibv_rdm_tagged_unexp_rbuff *)
+			    fi_verbs_mem_pool_get
+			    (&fi_ibv_rdm_tagged_unexp_buffers_pool);
+			memcpy(request->unexp_rbuf->payload,
+				rbuf->payload, request->len);
+		} else {
+			request->unexp_rbuf = NULL;
+		}
+		request->imm = p->imm_data;
+		request->state.eager = FI_IBV_STATE_EAGER_RECV_WAIT4RECV;
+		break;
+	case FI_IBV_RDM_RNDV_RTS_PKT:
+		FI_IBV_RDM_TAGGED_HANDLER_LOG();
+		assert(p->arrived_len ==
+		       sizeof(struct fi_ibv_rdm_tagged_rndv_header));
+		struct fi_ibv_rdm_tagged_rndv_header *h =
+		    (struct fi_ibv_rdm_tagged_rndv_header *)rbuf;
+
+		request->tag = h->base.tag;
+		request->src_addr = (void *)h->src_addr;
+		request->rndv_remote_key = h->mem_key;
+		request->len = h->len;
+		request->imm = p->imm_data;
+		request->conn = p->conn;
+		request->rndv_id = h->id;
+		request->state.eager = FI_IBV_STATE_EAGER_RECV_WAIT4RECV;
+		request->state.rndv = FI_IBV_STATE_RNDV_RECV_WAIT4RES;
+		break;
+	case FI_IBV_RDM_RNDV_ACK_PKT:
+		FI_IBV_RDM_TAGGED_DBG_REQUEST("Unexpected RNDV ack!!!",
+					      request, FI_LOG_INFO);
+		assert(0);
+		break;
+	default:
+		FI_IBV_ERROR("Got unknown unexpected pkt: %" PRIu64
+			     "\n", p->pkt_type);
+		assert(0);
+	}
+
+	fi_ibv_rdm_tagged_move_to_unexpected_queue(request);
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_eager_recv_got_pkt(struct fi_ibv_rdm_tagged_request *request,
+				     void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+	struct fi_ibv_recv_got_pkt_preprocess_data *p = data;
+	struct fi_ibv_rdm_tagged_buf *rbuf = p->rbuf;
+	assert(request->state.eager == FI_IBV_STATE_EAGER_RECV_WAIT4PKT);
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_NOT_USED);
+
+	switch (p->pkt_type) {
+	case FI_IBV_RDM_EAGER_PKT:
+		assert(p->pkt_type == FI_IBV_RDM_EAGER_PKT);
+		assert(p->arrived_len <= p->ep->rndv_threshold);
+		assert(p->arrived_len - sizeof(rbuf->header) <= request->len);
+
+		request->tag = rbuf->header.tag;
+		request->conn = p->conn;
+		request->len = p->arrived_len - sizeof(rbuf->header);
+		request->expected_recv_buf = rbuf->payload;
+		request->imm = p->imm_data;
+
+		if (request->dest_buf) {
+			assert(request->expected_recv_buf);
+			memcpy(request->dest_buf,
+				request->expected_recv_buf, request->len);
+		}
+
+		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
+		fi_ibv_rdm_tagged_move_to_ready_queue(request);
+		FI_IBV_RDM_TAGGED_HANDLER_LOG();
+		break;
+	case FI_IBV_RDM_RNDV_RTS_PKT:
+		assert(p->arrived_len ==
+		       sizeof(struct fi_ibv_rdm_tagged_rndv_header));
+
+		struct fi_ibv_rdm_tagged_rndv_header *rndv_header =
+		    (struct fi_ibv_rdm_tagged_rndv_header *)rbuf;
+
+		request->tag = rndv_header->base.tag;
+		request->src_addr = (void *)rndv_header->src_addr;
+		request->rndv_remote_key = rndv_header->mem_key;
+		request->len = rndv_header->len;
+		request->imm = p->imm_data;
+		request->conn = p->conn;
+		request->rndv_id = rndv_header->id;
+
+		fi_ibv_rdm_tagged_move_to_postponed_queue(request);
+
+		request->state.eager = FI_IBV_STATE_EAGER_RECV_END;
+		request->state.rndv = FI_IBV_STATE_RNDV_RECV_WAIT4RES;
+		FI_IBV_RDM_TAGGED_HANDLER_LOG();
+		break;
+	}
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_eager_recv_got_unexp_pkt(
+		struct fi_ibv_rdm_tagged_request *request, void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+	assert(request->state.eager == FI_IBV_STATE_EAGER_RECV_WAIT4RECV);
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_NOT_USED);
+
+	if (request->dest_buf && request->len != 0) {
+		memcpy(request->dest_buf, request->unexp_rbuf->payload,
+			request->len);
+	}
+
+	if (request->unexp_rbuf) {
+		fi_ibv_mem_pool_return(&request->unexp_rbuf->mpe,
+				       &fi_ibv_rdm_tagged_unexp_buffers_pool);
+		request->unexp_rbuf = NULL;
+	}
+
+	fi_ibv_rdm_tagged_move_to_ready_queue(request);
+	request->state.eager = FI_IBV_STATE_EAGER_RECV_END;
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_recv_post_read(struct fi_ibv_rdm_tagged_request *request,
+				      void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+	assert(request->state.eager == FI_IBV_STATE_EAGER_RECV_END);
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_RECV_WAIT4RES);
+
+	struct fi_ibv_rdm_tagged_send_ready_data *p = data;
+
+	fi_ibv_rdm_tagged_remove_from_postponed_queue(request);
+	VERBS_DBG(FI_LOG_EP_DATA, "\t REQUEST: conn %p, tag 0x%llx, len %d, dest_buf %p, "
+		     "src_addr %p, rkey 0x%lx\n",
+		     request->conn, (long long unsigned int)request->tag,
+		     request->len, request->dest_buf,
+		     request->src_addr,
+		     (long unsigned int)request->rndv_remote_key);
+
+	struct ibv_send_wr wr = { 0 };
+	struct ibv_send_wr *bad_wr = NULL;
+	struct ibv_sge sge;
+	int ret;
+
+	wr.wr_id = (uintptr_t) request;
+	assert(FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wr.wr_id) == 0);
+	wr.opcode = IBV_WR_RDMA_READ;
+	wr.sg_list = &sge;
+	wr.num_sge = 1;
+	wr.send_flags = 0;
+	wr.wr.rdma.remote_addr = (uintptr_t) request->src_addr;
+	wr.wr.rdma.rkey = request->rndv_remote_key;
+
+	request->rndv_mr = ibv_reg_mr(p->ep->domain->pd,
+				      request->dest_buf,
+				      request->len, IBV_ACCESS_LOCAL_WRITE);
+	assert(request->rndv_mr);
+
+	sge.addr = (uintptr_t) request->dest_buf;
+	sge.length = request->len;
+	sge.lkey = request->rndv_mr->lkey;
+
+	FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS_REQ(request, p->ep, wr.send_flags);
+	VERBS_DBG(FI_LOG_EP_DATA, "posted %d bytes, conn %p, tag 0x%llx\n", sge.length,
+		     request->conn, request->tag);
+	ret = ibv_post_send(request->conn->qp, &wr, &bad_wr);
+	if (ret) {
+		FI_IBV_ERROR
+		    ("ibv_post_send fail, ret %d, errno %d, strerror %s", ret,
+		     errno, strerror(errno));
+		assert(0);
+		return FI_EP_RDM_HNDL_ERROR;
+	};
+
+	request->state.eager = FI_IBV_STATE_EAGER_RECV_END;
+	request->state.rndv = FI_IBV_STATE_RNDV_RECV_WAIT4LC;
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_recv_read_lc(struct fi_ibv_rdm_tagged_request *request,
+				    void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+
+	struct fi_ibv_rdm_tagged_send_completed_data *p = data;
+
+	assert(request->len > (p->ep->rndv_threshold
+			       - sizeof(struct fi_ibv_rdm_tagged_header)));
+	assert(request->state.eager == FI_IBV_STATE_EAGER_RECV_END);
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_RECV_WAIT4LC);
+
+	FI_IBV_RDM_TAGGED_DEC_SEND_COUNTERS(request->conn, p->ep);
+
+	struct fi_ibv_rdm_tagged_conn *conn = request->conn;
+	assert(request->sbuf);
+
+	int ret = 0;
+	struct ibv_send_wr wr = { 0 };
+	struct ibv_sge sge = { 0 };
+	struct ibv_send_wr *bad_wr = NULL;
+
+	struct fi_ibv_rdm_tagged_buf *sbuf = request->sbuf;
+	sbuf->header.tag = 0;
+	sbuf->header.service_tag = 0;
+	FI_IBV_RDM_SET_PKTTYPE(sbuf->header.service_tag,
+			       FI_IBV_RDM_RNDV_ACK_PKT);
+
+	memcpy(sbuf->payload, &(request->rndv_id), sizeof(request->rndv_id));
+
+	wr.wr_id = ((uint64_t) (uintptr_t) (void *) request);
+	assert(FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wr.wr_id) == 0);
+
+	wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+	wr.send_flags = IBV_SEND_INLINE;
+	wr.sg_list = &sge;
+	wr.num_sge = 1;
+	wr.wr.rdma.remote_addr =
+	    fi_ibv_rdm_tagged_get_remote_addr(conn, request->sbuf);
+	wr.wr.rdma.rkey = conn->remote_rbuf_rkey;
+	wr.imm_data =
+	    fi_ibv_rdm_tagged_get_buff_service_data(request->sbuf)->seq_number;
+
+	sge.addr = (uintptr_t) sbuf;
+	sge.length = sizeof(struct fi_ibv_rdm_tagged_header) +
+	    sizeof(request->rndv_id);
+	sge.lkey = conn->s_mr->lkey;
+
+	FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS_REQ(request, p->ep, wr.send_flags);
+	VERBS_DBG(FI_LOG_EP_DATA,
+		"posted %d bytes, conn %p, tag 0x%llx, request %p\n",
+		sge.length, request->conn, request->tag, request);
+	ret = ibv_post_send(conn->qp, &wr, &bad_wr);
+	if (ret == 0) {
+		assert(request->rndv_mr);
+		ibv_dereg_mr(request->rndv_mr);
+		VERBS_DBG(FI_LOG_EP_DATA,
+			"SENDING RNDV ACK: conn %p, sends_outgoing = %d, "
+			"pend_send = %d\n", conn, conn->sends_outgoing,
+			p->ep->pend_send);
+	} else {
+		FI_IBV_ERROR
+		    ("ibv_post_send fail, ret %d, errno %d, strerror %s\n", ret,
+		     errno, strerror(errno));
+		assert(0);
+	}
+	request->state.eager = FI_IBV_STATE_EAGER_SEND_WAIT4LC;
+	request->state.rndv = FI_IBV_STATE_RNDV_RECV_END;
+	fi_ibv_rdm_tagged_move_to_ready_queue(request);
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+static enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_rndv_recv_ack_lc(struct fi_ibv_rdm_tagged_request *request,
+				   void *data)
+{
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
+	assert(request->state.eager == FI_IBV_STATE_EAGER_SEND_WAIT4LC ||
+	       request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE);
+	assert(request->state.rndv == FI_IBV_STATE_RNDV_RECV_END);
+
+	struct fi_ibv_rdm_tagged_send_completed_data *p = data;
+	FI_IBV_RDM_TAGGED_DEC_SEND_COUNTERS(request->conn, p->ep);
+
+	if (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
+		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
+					      FI_LOG_DEBUG);
+		fi_ibv_mem_pool_return(&request->mpe,
+				       &fi_ibv_rdm_tagged_request_pool);
+	} else {
+		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
+		request->state.rndv = FI_IBV_STATE_RNDV_RECV_END;
+	}
+
+	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
+	return FI_EP_RDM_HNDL_SUCCESS;
+}
+
+char *fi_ibv_rdm_tagged_req_eager_state_to_str(
+		enum fi_ibv_rdm_tagged_request_eager_state state)
+{
+	switch (state) {
+	case FI_IBV_STATE_EAGER_BEGIN:
+		return "STATE_EAGER_BEGIN";
+
+	case FI_IBV_STATE_EAGER_SEND_POSTPONED:
+		return "STATE_EAGER_SEND_POSTPONED";
+	case FI_IBV_STATE_EAGER_SEND_WAIT4LC:
+		return "STATE_EAGER_SEND_WAIT4LC";
+	case FI_IBV_STATE_EAGER_SEND_END:
+		return "STATE_EAGER_SEND_END";
+
+	case FI_IBV_STATE_EAGER_RECV_BEGIN:
+		return "STATE_EAGER_RECV_BEGIN";
+	case FI_IBV_STATE_EAGER_RECV_WAIT4PKT:
+		return "STATE_EAGER_RECV_WAIT4PKT";
+	case FI_IBV_STATE_EAGER_RECV_WAIT4RECV:
+		return "STATE_EAGER_RECV_WAIT4RECV";
+	case FI_IBV_STATE_EAGER_RECV_END:
+		return "STATE_EAGER_RECV_END";
+	case FI_IBV_STATE_EAGER_READY_TO_FREE:
+		return "STATE_EAGER_READY_TO_FREE";
+
+	case FI_IBV_STATE_EAGER_COUNT:
+		return "STATE_EAGER_COUNT";
+	default:
+		return "STATE_EAGER_UNKNOWN!!!";
+	}
+}
+
+char *fi_ibv_rdm_tagged_req_rndv_state_to_str(
+		enum fi_ibv_rdm_tagged_request_rndv_state state)
+{
+	switch (state) {
+	case FI_IBV_STATE_RNDV_NOT_USED:
+		return "STATE_RNDV_NOT_USED";
+	case FI_IBV_STATE_RNDV_SEND_BEGIN:
+		return "STATE_RNDV_SEND_BEGIN";
+	case FI_IBV_STATE_RNDV_SEND_WAIT4SEND:
+		return "STATE_RNDV_SEND_WAIT4SEND";
+	case FI_IBV_STATE_RNDV_SEND_WAIT4ACK:
+		return "STATE_RNDV_SEND_WAIT4ACK";
+	case FI_IBV_STATE_RNDV_SEND_END:
+		return "STATE_RNDV_SEND_END";
+
+	case FI_IBV_STATE_RNDV_RECV_BEGIN:
+		return "STATE_RNDV_RECV_BEGIN";
+	case FI_IBV_STATE_RNDV_RECV_WAIT4RES:
+		return "STATE_RNDV_RECV_WAIT4RES";
+	case FI_IBV_STATE_RNDV_RECV_WAIT4RECV:
+		return "STATE_RNDV_RECV_WAIT4RECV";
+	case FI_IBV_STATE_RNDV_RECV_WAIT4LC:
+		return "STATE_RNDV_RECV_WAIT4LC";
+	case FI_IBV_STATE_RNDV_RECV_END:
+		return "STATE_RNDV_RECV_END";
+	case FI_IBV_STATE_RNDV_COUNT:
+		return "STATE_RNDV_COUNT";
+	default:
+		return "STATE_RNDV_UNKNOWN!!!";
+	}
+}
+
+char *fi_ibv_rdm_tagged_req_event_to_str(
+		enum fi_ibv_rdm_tagged_request_event event)
+{
+	switch (event) {
+	case FI_IBV_EVENT_SEND_START:
+		return "EVENT_SEND_START";
+	case FI_IBV_EVENT_SEND_READY:
+		return "EVENT_SEND_READY";
+	case FI_IBV_EVENT_SEND_COMPLETED:
+		return "EVENT_SEND_COMPLETED";
+	case FI_IBV_EVENT_SEND_GOT_CTS:
+		return "EVENT_SEND_GOT_CTS";
+	case FI_IBV_EVENT_SEND_GOT_LC:
+		return "EVENT_SEND_GOT_LC";
+
+	case FI_IBV_EVENT_RECV_START:
+		return "EVENT_RECV_START";
+	case FI_IBV_EVENT_RECV_GOT_PKT_PREPROCESS:
+		return "EVENT_RECV_GOT_PKT_PREPROCESS";
+	case FI_IBV_EVENT_RECV_GOT_PKT_PROCESS:
+		return "EVENT_RECV_GOT_PKT_PROCESS";
+	case FI_IBV_EVENT_RECV_GOT_ACK:
+		return "EVENT_RECV_GOT_ACK";
+
+	case FI_IBV_EVENT_COUNT:
+		return "EVENT_COUNT";
+	default:
+		return "EVENT_UNKNOWN!!!";
+	}
+}

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _VERBS_TAGGED_EP_RDM_STATES_H
+#define _VERBS_TAGGED_EP_RDM_STATES_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+struct fi_ibv_rdm_tagged_request;
+
+enum fi_ibv_rdm_tagged_request_eager_state {
+	FI_IBV_STATE_EAGER_BEGIN = 0,      // must be 0
+
+	FI_IBV_STATE_EAGER_SEND_POSTPONED,
+	FI_IBV_STATE_EAGER_SEND_WAIT4LC,   // wait for local completion
+	FI_IBV_STATE_EAGER_SEND_END,
+
+	FI_IBV_STATE_EAGER_RECV_BEGIN,
+	FI_IBV_STATE_EAGER_RECV_WAIT4PKT,
+	FI_IBV_STATE_EAGER_RECV_WAIT4RECV,
+	FI_IBV_STATE_EAGER_RECV_END,
+
+	FI_IBV_STATE_EAGER_READY_TO_FREE,
+
+	FI_IBV_STATE_EAGER_COUNT           // must be last
+};
+
+char *fi_ibv_rdm_tagged_req_eager_state_to_str(
+		enum fi_ibv_rdm_tagged_request_eager_state state);
+
+enum fi_ibv_rdm_tagged_request_rndv_state {
+	FI_IBV_STATE_RNDV_NOT_USED = 0,    // must be 0
+	FI_IBV_STATE_RNDV_SEND_BEGIN,
+	//    FI_IBV_STATE_RNDV_SEND_WAIT4CTS, // not implemented yet
+	FI_IBV_STATE_RNDV_SEND_WAIT4SEND,
+	FI_IBV_STATE_RNDV_SEND_WAIT4ACK,
+	FI_IBV_STATE_RNDV_SEND_END,
+
+	FI_IBV_STATE_RNDV_RECV_BEGIN,
+	FI_IBV_STATE_RNDV_RECV_WAIT4RES,
+	FI_IBV_STATE_RNDV_RECV_WAIT4RECV,
+	FI_IBV_STATE_RNDV_RECV_WAIT4LC,
+	FI_IBV_STATE_RNDV_RECV_END,
+
+	FI_IBV_STATE_RNDV_COUNT            // must be last
+};
+
+char *fi_ibv_rdm_tagged_req_rndv_state_to_str(
+		enum fi_ibv_rdm_tagged_request_rndv_state state);
+
+enum fi_ibv_rdm_tagged_request_event {
+	FI_IBV_EVENT_SEND_START = 0,
+	FI_IBV_EVENT_SEND_READY,
+	FI_IBV_EVENT_SEND_COMPLETED,
+	FI_IBV_EVENT_SEND_GOT_CTS,
+	FI_IBV_EVENT_SEND_GOT_LC,
+
+	FI_IBV_EVENT_RECV_START,
+	FI_IBV_EVENT_RECV_GOT_PKT_PREPROCESS,
+	FI_IBV_EVENT_RECV_GOT_PKT_PROCESS,
+	FI_IBV_EVENT_RECV_GOT_ACK,
+
+	FI_IBV_EVENT_COUNT                 // must be last
+};
+
+char *fi_ibv_rdm_tagged_req_event_to_str(
+		enum fi_ibv_rdm_tagged_request_event event);
+
+// Send service data types
+
+struct fi_ibv_rdm_tagged_send_start_data {
+	const void *src_addr;
+	void *context;
+	struct fi_ibv_rdm_tagged_conn *conn;
+	size_t tag;
+	size_t data_len;
+	size_t rndv_threshold;
+	unsigned int imm;
+};
+
+struct fi_ibv_rdm_tagged_send_ready_data {
+	struct fi_ibv_rdm_ep *ep;
+};
+
+struct fi_ibv_rdm_tagged_send_completed_data {
+	struct fi_ibv_rdm_ep *ep;
+};
+
+// Recv service data types
+
+struct fi_ibv_rdm_tagged_recv_start_data {
+	size_t tag;
+	size_t tagmask;
+	struct fi_context *context;
+	void *dest_addr;
+	struct fi_ibv_rdm_tagged_conn *conn;
+	struct fi_ibv_rdm_ep *ep;
+	size_t data_len;
+};
+
+struct fi_ibv_recv_got_pkt_preprocess_data {
+	struct fi_ibv_rdm_tagged_conn *conn;
+	struct fi_ibv_rdm_ep *ep;
+	void *rbuf;
+	size_t arrived_len;
+	uint64_t pkt_type;
+	int imm_data;
+};
+
+struct fi_ibv_recv_got_pkt_process_data {
+	struct fi_ibv_rdm_ep *ep;
+} ;
+
+// Return codes
+
+enum fi_rdm_tagged_req_hndl_ret {
+    FI_EP_RDM_HNDL_SUCCESS = 0,
+    FI_EP_RDM_HNDL_DELETED_REQUEST = 1,
+    FI_EP_RDM_HNDL_ERROR = 2,
+    FI_EP_RDM_HNDL_NOT_INIT = (int)-1
+};
+
+// Interfaces
+
+enum fi_rdm_tagged_req_hndl_ret fi_ibv_rdm_tagged_req_hndls_init();
+enum fi_rdm_tagged_req_hndl_ret fi_ibv_rdm_tagged_req_hndls_clean();
+enum fi_rdm_tagged_req_hndl_ret
+fi_ibv_rdm_tagged_req_hndl(struct fi_ibv_rdm_tagged_request *request,
+			   enum fi_ibv_rdm_tagged_request_event event,
+			   void *data);
+
+// Send/Recv counters control
+
+#define FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS(_connection, _ep, _send_flags) \
+do {                                                                	\
+	(_connection)->sends_outgoing++;                                \
+	(_ep)->pend_send++;                                             \
+	(_ep)->total_outgoing_send++;                                   \
+	(_send_flags) |= IBV_SEND_SIGNALED;                             \
+									\
+	VERBS_DBG(FI_LOG_CQ, "SEND_COUNTER++, conn %p, sends_outgoing %d\n",    \
+		_connection,                                            \
+		(_connection)->sends_outgoing);                         \
+} while (0)
+
+#define FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS_REQ(_request, _ep, _send_flags)  \
+do {                                                                	\
+	(_request)->send_completions_wait++;                        	\
+	FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS((_request)->conn,       	\
+					    _ep, _send_flags);      	\
+								    	\
+	VERBS_DBG(FI_LOG_CQ, "SEND_COUNTER++, send_completions_wait %d\n",  	\
+		     (_request)->send_completions_wait);            	\
+} while (0)
+
+#define FI_IBV_RDM_TAGGED_DEC_SEND_COUNTERS(_connection, _ep)		\
+do {                                                                	\
+	(_connection)->sends_outgoing--;                                \
+	(_ep)->total_outgoing_send--;                                   \
+	(_ep)->pend_send--;                                             \
+									\
+	VERBS_DBG(FI_LOG_CQ, "SEND_COUNTER--, conn %p, sends_outgoing %d\n",    \
+			_connection, (_connection)->sends_outgoing);    \
+	assert((_ep)->pend_send >= 0);                                  \
+	assert((_connection)->sends_outgoing >= 0);                     \
+} while (0)
+
+#define FI_IBV_RDM_TAGGED_SENDS_OUTGOING_ARE_LIMITED(_connection, _ep)  \
+	((_connection)->sends_outgoing > 0.5*(_ep)->sq_wr_depth)
+
+#define PEND_SEND_IS_LIMITED(_ep)                                       \
+	((_ep)->pend_send > 0.5 * (_ep)->scq_depth)
+
+#define SEND_RESOURCES_IS_BUSY(_connection, _ep)                        \
+	(FI_IBV_RDM_TAGGED_SENDS_OUTGOING_ARE_LIMITED(_connection, _ep) ||  \
+	 PEND_SEND_IS_LIMITED(_ep))
+
+#endif /* _VERBS_TAGGED_EP_RDM_STATES_H */

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rdma/fi_errno.h>
+#include "../fi_verbs.h"
+#include "verbs_utils.h"
+#include "verbs_rdm.h"
+
+
+/* TODO: Use of const is inconsistent throughout call stack */
+
+int fi_ibv_rdm_tagged_match_requests(struct dlist_entry *item,
+				     const void *other)
+{
+	const struct fi_ibv_rdm_tagged_request *req = other;
+	return (item == &req->queue_entry);
+}
+
+int fi_verbs_rdm_tagged_match_request_by_minfo(struct dlist_entry *item,
+					       const void *other)
+{
+	struct fi_ibv_rdm_tagged_request *request =
+	    container_of(item, struct fi_ibv_rdm_tagged_request, queue_entry);
+
+	const struct fi_verbs_rdm_tagged_request_minfo *minfo = other;
+
+	return (((request->conn == NULL) || (request->conn == minfo->conn)) &&
+		((request->tag & request->tagmask) ==
+		 (minfo->tag & request->tagmask)));
+}
+
+int fi_verbs_rdm_tagged_match_request_by_minfo_with_tagmask(
+		struct dlist_entry *item, const void *other)
+{
+	struct fi_ibv_rdm_tagged_request *request =
+	    container_of(item, struct fi_ibv_rdm_tagged_request, queue_entry);
+
+	const struct fi_verbs_rdm_tagged_request_minfo *minfo = other;
+
+	return (((minfo->conn == NULL) || (request->conn == minfo->conn)) &&
+		((request->tag & minfo->tagmask) ==
+		 (minfo->tag & minfo->tagmask)));
+}
+
+void fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *item,
+					      const void *arg)
+{
+	const struct fi_ibv_rdm_tagged_send_ready_data *send_data = arg;
+
+	struct fi_ibv_rdm_tagged_postponed_entry *postponed_entry =
+	    container_of(item, struct fi_ibv_rdm_tagged_postponed_entry,
+			 queue_entry);
+
+	if (!dlist_empty(&postponed_entry->conn->postponed_requests_head)) {
+		struct fi_ibv_rdm_tagged_request *request =
+		    container_of(postponed_entry->conn->postponed_requests_head.
+				 next,
+				 struct fi_ibv_rdm_tagged_request,
+				 queue_entry);
+
+		int res = fi_ibv_rdm_tagged_prepare_send_resources(request,
+								   send_data->
+								   ep);
+		if (res) {
+			fi_ibv_rdm_tagged_req_hndl(request,
+						   FI_IBV_EVENT_SEND_READY,
+						   (void *) send_data);
+		}
+	}
+}

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _VERBS_UTILS_H
+#define _VERBS_UTILS_H
+
+#include <alloca.h>
+#include <malloc.h>
+#include <stddef.h>
+#include <string.h>
+#include <sys/types.h>
+
+#include <infiniband/verbs.h>
+
+#include <rdma/fi_log.h>
+#include "../fi_verbs.h"
+
+/* TODO: Merge anything useful into verbs_rdm.h */
+
+struct fi_ibv_msg_ep;
+
+#define FI_IBV_RDM_DFLT_ADDRLEN                                         \
+    (/*ep->my_ipoib_addr.sin_addr.s_addr)*/ sizeof(in_addr_t) +         \
+     /*ep->cm_listener_port */              sizeof(uint16_t))
+
+#define FI_IBV_RDM_CM_THREAD_TIMEOUT (100)
+#define FI_IBV_RDM_MEM_ALIGNMENT (4096)
+
+#define FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM (4)
+
+#define FI_IBV_RDM_TAGGED_DFLT_BUFFER_SIZE                              \
+	((8 * 1024 + FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE) +        \
+	 (8 * 1024 + FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE) %        \
+	  FI_IBV_RDM_MEM_ALIGNMENT)
+
+#define FI_IBV_RDM_TAGGED_DFLT_RQ_SIZE  (1000)
+
+/* TODO: CQs depths increased from 100 to 1000 to prevent
+ *      "Work Request Flushed Error" in stress tests like alltoall.
+ */
+#define FI_IBV_RDM_TAGGED_DFLT_SCQ_SIZE (1000)
+#define FI_IBV_RDM_TAGGED_DFLT_RCQ_SIZE (1000)
+
+#define FI_IBV_RDM_CM_RESOLVEADDR_TIMEOUT (30000)
+
+/* TODO: remove */
+#define FI_IBV_ERROR(format, ...) do {                                  \
+		char _hostname[100];                                    \
+		gethostname(_hostname, sizeof(_hostname));              \
+		fprintf(stderr, "[%s:%d] libfabric:verbs:%s:%d:<error>:"format, \
+		_hostname, getpid(),                                    \
+		__FUNCTION__, __LINE__, ##__VA_ARGS__);                 \
+	} while(0)
+
+
+/* TODO: Create and use a common abstraction */
+
+/* memory pool utils
+ */
+
+struct fi_ibv_mem_pool_entry {
+	struct fi_ibv_mem_pool_entry *next;
+	uint64_t is_malloced;
+};
+
+struct fi_ibv_mem_pool {
+	struct fi_ibv_mem_pool_entry *head;
+	int current_size;
+	int max_size;
+	int entry_size;
+	void *storage;
+};
+
+/* TODO: Remove overuse of static inlines */
+static inline void fi_ibv_mem_pool_init(struct fi_ibv_mem_pool *pool,
+                                        int init_size, int max_size,
+                                        int entry_size)
+{
+	int size = init_size < max_size ? init_size : max_size;
+	int i;
+
+	pool->head = memalign(FI_IBV_RDM_MEM_ALIGNMENT, entry_size * size);
+	memset(pool->head, 0, entry_size * size);
+	pool->storage = (void *)pool->head;
+	struct fi_ibv_mem_pool_entry *tmp = pool->head;
+	for (i = 1; i < size; i++) {
+		tmp->next = (struct fi_ibv_mem_pool_entry *)
+				((char *)tmp + entry_size);
+		tmp = tmp->next;
+	}
+	tmp->next = NULL;
+	pool->current_size = size;
+	pool->max_size = max_size;
+	pool->entry_size = entry_size;
+}
+
+static inline struct fi_ibv_mem_pool_entry *
+fi_verbs_mem_pool_get(struct fi_ibv_mem_pool *pool)
+{
+	struct fi_ibv_mem_pool_entry *rst;
+	if (pool->head != NULL) {
+		rst = pool->head;
+		pool->head = rst->next;
+	} else {
+		rst = (struct fi_ibv_mem_pool_entry *)calloc(1, pool->entry_size);
+		rst->is_malloced = 1;
+		pool->current_size++;
+		VERBS_DBG("MALLOCED: %p, %d\n", rst, pool->current_size);
+	}
+	return rst;
+}
+
+static inline void
+fi_ibv_mem_pool_return(struct fi_ibv_mem_pool_entry *entry,
+		       struct fi_ibv_mem_pool *pool)
+{
+	if (entry->is_malloced) {
+		pool->current_size--;
+		VERBS_DBG("FREED: %p, %d\n", entry, pool->current_size);
+		free(entry);
+	} else {
+		entry->next = pool->head;
+		pool->head = entry;
+	}
+}
+
+static inline void fi_ibv_mem_pool_fini(struct fi_ibv_mem_pool *pool)
+{
+	free(pool->storage);
+}
+
+#if ENABLE_DEBUG
+#define FI_IBV_PRINT_LIST(list, name) do {              \
+        int count;                                      \
+        struct fi_ibv_rdm_tagged_request *tmp;          \
+                                                        \
+        DL_COUNT(list, tmp, count);                     \
+        char str[1000];                                 \
+        sprintf(str, "list %s, head %p, count %d: ",    \
+                name, list, count);                     \
+                                                        \
+        DL_FOREACH(list, tmp)                           \
+        {                                               \
+            char str2[100];                             \
+            sprintf(str2, "%p, ", (void*)tmp);          \
+            strcat(str, str2);                          \
+        }                                               \
+                                                        \
+        VERBS_DBG("%s\n", str);                         \
+    } while(0)
+#else                           // ENABLE_DEBUG
+#define FI_IBV_PRINT_LIST(list, name)
+#endif                          // ENABLE_DEBUG
+
+/* TODO: Holy macro batman, use verbs calls */
+#define FI_IBV_DBG_OPCODE(wc_opcode, str)                                      \
+        VERBS_DBG(FI_LOG_CQ, "CQ COMPL: "str" -> %s\n",                        \
+        wc_opcode == IBV_WC_SEND       ? "IBV_WC_SEND"       :                 \
+        wc_opcode == IBV_WC_RDMA_WRITE ? "IBV_WC_RDMA_WRITE" :                 \
+        wc_opcode == IBV_WC_RDMA_READ  ? "IBV_WC_RDMA_READ"  :                 \
+        wc_opcode == IBV_WC_COMP_SWAP  ? "IBV_WC_COMP_SWAP"  :                 \
+        wc_opcode == IBV_WC_FETCH_ADD  ? "IBV_WC_FETCH_ADD"  :                 \
+        wc_opcode == IBV_WC_BIND_MW    ? "IBV_WC_BIND_MW"    :                 \
+        wc_opcode == IBV_WC_RECV       ? "IBV_WC_RECV"       :                 \
+        wc_opcode == IBV_WC_RECV_RDMA_WITH_IMM ? "IBV_WC_RECV_RDMA_WITH_IMM" : \
+        "IBV_WC_UNKNOWN!!!");
+
+#if ENABLE_DEBUG
+
+#define FI_IBV_RDM_TAGGED_DBG_REQUEST(prefix, request, level)               \
+do {                                                                        \
+    const size_t max_str_len = 1024;                                        \
+    char str[max_str_len];                                                  \
+    snprintf(str, max_str_len,                                              \
+            "%s request: %p, eager_state: %s, rndv_state: %s, tag: 0x%llx," \
+            "len: %d context: %p, connection: %p\n",                        \
+            prefix,                                                         \
+            request,                                                        \
+            fi_ibv_rdm_tagged_req_eager_state_to_str(request->state.eager), \
+            fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.rndv),   \
+            request->tag,                                                   \
+            request->len,                                                   \
+            request->context,                                               \
+            request->conn);                                                 \
+                                                                            \
+    switch (level)                                                          \
+    {                                                                       \
+        case FI_LOG_WARN:                                                   \
+        case FI_LOG_TRACE:                                                  \
+        case FI_LOG_INFO:                                                   \
+            fprintf(stderr, str);                                           \
+            break;                                                          \
+        case FI_LOG_DEBUG:                                                  \
+        default:                                                            \
+            VERBS_DBG(str);                                                 \
+            break;                                                          \
+    }                                                                       \
+} while (0);
+
+#else                           // ENABLE_DEBUG
+
+#define FI_IBV_RDM_TAGGED_DBG_REQUEST(prefix, request, level)
+
+#endif                          // ENABLE_DEBUG
+
+struct fi_verbs_rdm_tagged_request_minfo {
+	struct fi_ibv_rdm_tagged_conn *conn;
+	uint64_t                       tag;
+	size_t                         tagmask;
+} ;
+
+/* TODO: Get usable names */
+int fi_ibv_rdm_tagged_match_requests(struct dlist_entry *item,
+                                     const void *other);
+int fi_verbs_rdm_tagged_match_request_by_minfo(struct dlist_entry *item,
+                                               const void *other);
+int fi_verbs_rdm_tagged_match_request_by_minfo_with_tagmask(
+		struct dlist_entry *item, const void *other);
+void fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *item,
+                                              const void *arg);
+
+#endif /* _VERBS_UTILS_H */

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -30,6 +30,9 @@
  * SOFTWARE.
  */
 
+#ifndef FI_VERBS_H
+#define FI_VERBS_H
+
 #if HAVE_CONFIG_H
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
@@ -120,6 +123,14 @@ struct fi_ibv_eq {
 int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		   struct fid_eq **eq, void *context);
 
+struct fi_ibv_av {
+	struct fid_av		av;	/* TODO: rename to av_fid */
+	struct fi_ibv_domain	*domain;
+	struct fi_ibv_rdm_ep	*ep;	/* TODO: check usage */
+	int			type;	/* TODO: AV enum? */
+	size_t			count;
+};
+
 struct fi_ibv_pep {
 	struct fid_pep		pep_fid;
 	struct fi_ibv_eq	*eq;
@@ -147,6 +158,9 @@ struct fi_ibv_cq {
 	enum fi_cq_wait_cond	wait_cond;
 	struct ibv_wc		wc;
 	int			signal_fd[2];
+	/* RDM EP fields - TODO: check usage */
+	struct fi_ibv_rdm_ep	*ep;
+	int			format;
 };
 
 int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
@@ -272,3 +286,5 @@ ssize_t fi_ibv_send_iov_flags(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 #define fi_ibv_send_msg(ep, wr, msg, flags)				\
 	fi_ibv_send_iov_flags(ep, wr, msg->msg_iov, msg->desc,		\
 			msg->iov_count,	msg->context, flags)
+
+#endif /* FI_VERBS_H */

--- a/prov/verbs/src/uthash.h
+++ b/prov/verbs/src/uthash.h
@@ -1,0 +1,958 @@
+/*
+Copyright (c) 2003-2014, Troy D. Hanson     http://troydhanson.github.com/uthash/
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef UTHASH_H
+#define UTHASH_H
+
+#include <string.h>   /* memcmp,strlen */
+#include <stddef.h>   /* ptrdiff_t */
+#include <stdlib.h>   /* exit() */
+
+/* These macros use decltype or the earlier __typeof GNU extension.
+   As decltype is only available in newer compilers (VS2010 or gcc 4.3+
+   when compiling c++ source) this code uses whatever method is needed
+   or, for VS2008 where neither is available, uses casting workarounds. */
+#if defined(_MSC_VER)   /* MS compiler */
+#if _MSC_VER >= 1600 && defined(__cplusplus)  /* VS2010 or newer in C++ mode */
+#define DECLTYPE(x) (decltype(x))
+#else                   /* VS2008 or older (or VS2010 in C mode) */
+#define NO_DECLTYPE
+#define DECLTYPE(x)
+#endif
+#elif defined(__BORLANDC__) || defined(__LCC__) || defined(__WATCOMC__)
+#define NO_DECLTYPE
+#define DECLTYPE(x)
+#else                   /* GNU, Sun and other compilers */
+#define DECLTYPE(x) (__typeof(x))
+#endif
+
+#ifdef NO_DECLTYPE
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  char **_da_dst = (char**)(&(dst));                                             \
+  *_da_dst = (char*)(src);                                                       \
+} while(0)
+#else
+#define DECLTYPE_ASSIGN(dst,src)                                                 \
+do {                                                                             \
+  (dst) = DECLTYPE(dst)(src);                                                    \
+} while(0)
+#endif
+
+/* a number of the hash function use uint32_t which isn't defined on Pre VS2010 */
+#if defined (_WIN32)
+#if defined(_MSC_VER) && _MSC_VER >= 1600
+#include <stdint.h>
+#elif defined(__WATCOMC__)
+#include <stdint.h>
+#else
+typedef unsigned int uint32_t;
+typedef unsigned char uint8_t;
+#endif
+#else
+#include <stdint.h>
+#endif
+
+#define UTHASH_VERSION 1.9.9
+
+#ifndef uthash_fatal
+#define uthash_fatal(msg) exit(-1)        /* fatal error (out of memory,etc) */
+#endif
+#ifndef uthash_malloc
+#define uthash_malloc(sz) malloc(sz)      /* malloc fcn                      */
+#endif
+#ifndef uthash_free
+#define uthash_free(ptr,sz) free(ptr)     /* free fcn                        */
+#endif
+
+#ifndef uthash_noexpand_fyi
+#define uthash_noexpand_fyi(tbl)          /* can be defined to log noexpand  */
+#endif
+#ifndef uthash_expand_fyi
+#define uthash_expand_fyi(tbl)            /* can be defined to log expands   */
+#endif
+
+/* initial number of buckets */
+#define HASH_INITIAL_NUM_BUCKETS 32      /* initial number of buckets        */
+#define HASH_INITIAL_NUM_BUCKETS_LOG2 5  /* lg2 of initial number of buckets */
+#define HASH_BKT_CAPACITY_THRESH 10      /* expand when bucket count reaches */
+
+/* calculate the element whose hash handle address is hhe */
+#define ELMT_FROM_HH(tbl,hhp) ((void*)(((char*)(hhp)) - ((tbl)->hho)))
+
+#define HASH_FIND(hh,head,keyptr,keylen,out)                                     \
+do {                                                                             \
+  unsigned _hf_bkt,_hf_hashv;                                                    \
+  out=NULL;                                                                      \
+  if (head) {                                                                    \
+     HASH_FCN(keyptr,keylen, (head)->hh.tbl->num_buckets, _hf_hashv, _hf_bkt);   \
+     if (HASH_BLOOM_TEST((head)->hh.tbl, _hf_hashv)) {                           \
+       HASH_FIND_IN_BKT((head)->hh.tbl, hh, (head)->hh.tbl->buckets[ _hf_bkt ],  \
+                        keyptr,keylen,out);                                      \
+     }                                                                           \
+  }                                                                              \
+} while (0)
+
+#ifdef HASH_BLOOM
+#define HASH_BLOOM_BITLEN (1ULL << HASH_BLOOM)
+#define HASH_BLOOM_BYTELEN (HASH_BLOOM_BITLEN/8) + ((HASH_BLOOM_BITLEN%8) ? 1:0)
+#define HASH_BLOOM_MAKE(tbl)                                                     \
+do {                                                                             \
+  (tbl)->bloom_nbits = HASH_BLOOM;                                               \
+  (tbl)->bloom_bv = (uint8_t*)uthash_malloc(HASH_BLOOM_BYTELEN);                 \
+  if (!((tbl)->bloom_bv))  { uthash_fatal( "out of memory"); }                   \
+  memset((tbl)->bloom_bv, 0, HASH_BLOOM_BYTELEN);                                \
+  (tbl)->bloom_sig = HASH_BLOOM_SIGNATURE;                                       \
+} while (0)
+
+#define HASH_BLOOM_FREE(tbl)                                                     \
+do {                                                                             \
+  uthash_free((tbl)->bloom_bv, HASH_BLOOM_BYTELEN);                              \
+} while (0)
+
+#define HASH_BLOOM_BITSET(bv,idx) (bv[(idx)/8] |= (1U << ((idx)%8)))
+#define HASH_BLOOM_BITTEST(bv,idx) (bv[(idx)/8] & (1U << ((idx)%8)))
+
+#define HASH_BLOOM_ADD(tbl,hashv)                                                \
+  HASH_BLOOM_BITSET((tbl)->bloom_bv, (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1)))
+
+#define HASH_BLOOM_TEST(tbl,hashv)                                               \
+  HASH_BLOOM_BITTEST((tbl)->bloom_bv, (hashv & (uint32_t)((1ULL << (tbl)->bloom_nbits) - 1)))
+
+#else
+#define HASH_BLOOM_MAKE(tbl)
+#define HASH_BLOOM_FREE(tbl)
+#define HASH_BLOOM_ADD(tbl,hashv)
+#define HASH_BLOOM_TEST(tbl,hashv) (1)
+#define HASH_BLOOM_BYTELEN 0
+#endif
+
+#define HASH_MAKE_TABLE(hh,head)                                                 \
+do {                                                                             \
+  (head)->hh.tbl = (UT_hash_table*)uthash_malloc(                                \
+                  sizeof(UT_hash_table));                                        \
+  if (!((head)->hh.tbl))  { uthash_fatal( "out of memory"); }                    \
+  memset((head)->hh.tbl, 0, sizeof(UT_hash_table));                              \
+  (head)->hh.tbl->tail = &((head)->hh);                                          \
+  (head)->hh.tbl->num_buckets = HASH_INITIAL_NUM_BUCKETS;                        \
+  (head)->hh.tbl->log2_num_buckets = HASH_INITIAL_NUM_BUCKETS_LOG2;              \
+  (head)->hh.tbl->hho = (char*)(&(head)->hh) - (char*)(head);                    \
+  (head)->hh.tbl->buckets = (UT_hash_bucket*)uthash_malloc(                      \
+          HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));               \
+  if (! (head)->hh.tbl->buckets) { uthash_fatal( "out of memory"); }             \
+  memset((head)->hh.tbl->buckets, 0,                                             \
+          HASH_INITIAL_NUM_BUCKETS*sizeof(struct UT_hash_bucket));               \
+  HASH_BLOOM_MAKE((head)->hh.tbl);                                               \
+  (head)->hh.tbl->signature = HASH_SIGNATURE;                                    \
+} while(0)
+
+#define HASH_ADD(hh,head,fieldname,keylen_in,add)                                \
+        HASH_ADD_KEYPTR(hh,head,&((add)->fieldname),keylen_in,add)
+
+#define HASH_REPLACE(hh,head,fieldname,keylen_in,add,replaced)                   \
+do {                                                                             \
+  replaced=NULL;                                                                 \
+  HASH_FIND(hh,head,&((add)->fieldname),keylen_in,replaced);                     \
+  if (replaced!=NULL) {                                                          \
+     HASH_DELETE(hh,head,replaced);                                              \
+  };                                                                             \
+  HASH_ADD(hh,head,fieldname,keylen_in,add);                                     \
+} while(0)
+
+#define HASH_ADD_KEYPTR(hh,head,keyptr,keylen_in,add)                            \
+do {                                                                             \
+ unsigned _ha_bkt;                                                               \
+ (add)->hh.next = NULL;                                                          \
+ (add)->hh.key = (char*)(keyptr);                                                \
+ (add)->hh.keylen = (unsigned)(keylen_in);                                       \
+ if (!(head)) {                                                                  \
+    head = (add);                                                                \
+    (head)->hh.prev = NULL;                                                      \
+    HASH_MAKE_TABLE(hh,head);                                                    \
+ } else {                                                                        \
+    (head)->hh.tbl->tail->next = (add);                                          \
+    (add)->hh.prev = ELMT_FROM_HH((head)->hh.tbl, (head)->hh.tbl->tail);         \
+    (head)->hh.tbl->tail = &((add)->hh);                                         \
+ }                                                                               \
+ (head)->hh.tbl->num_items++;                                                    \
+ (add)->hh.tbl = (head)->hh.tbl;                                                 \
+ HASH_FCN(keyptr,keylen_in, (head)->hh.tbl->num_buckets,                         \
+         (add)->hh.hashv, _ha_bkt);                                              \
+ HASH_ADD_TO_BKT((head)->hh.tbl->buckets[_ha_bkt],&(add)->hh);                   \
+ HASH_BLOOM_ADD((head)->hh.tbl,(add)->hh.hashv);                                 \
+ HASH_EMIT_KEY(hh,head,keyptr,keylen_in);                                        \
+ HASH_FSCK(hh,head);                                                             \
+} while(0)
+
+#define HASH_TO_BKT( hashv, num_bkts, bkt )                                      \
+do {                                                                             \
+  bkt = ((hashv) & ((num_bkts) - 1));                                            \
+} while(0)
+
+/* delete "delptr" from the hash table.
+ * "the usual" patch-up process for the app-order doubly-linked-list.
+ * The use of _hd_hh_del below deserves special explanation.
+ * These used to be expressed using (delptr) but that led to a bug
+ * if someone used the same symbol for the head and deletee, like
+ *  HASH_DELETE(hh,users,users);
+ * We want that to work, but by changing the head (users) below
+ * we were forfeiting our ability to further refer to the deletee (users)
+ * in the patch-up process. Solution: use scratch space to
+ * copy the deletee pointer, then the latter references are via that
+ * scratch pointer rather than through the repointed (users) symbol.
+ */
+#define HASH_DELETE(hh,head,delptr)                                              \
+do {                                                                             \
+    unsigned _hd_bkt;                                                            \
+    struct UT_hash_handle *_hd_hh_del;                                           \
+    if ( ((delptr)->hh.prev == NULL) && ((delptr)->hh.next == NULL) )  {         \
+        uthash_free((head)->hh.tbl->buckets,                                     \
+                    (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket) ); \
+        HASH_BLOOM_FREE((head)->hh.tbl);                                         \
+        uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                      \
+        head = NULL;                                                             \
+    } else {                                                                     \
+        _hd_hh_del = &((delptr)->hh);                                            \
+        if ((delptr) == ELMT_FROM_HH((head)->hh.tbl,(head)->hh.tbl->tail)) {     \
+            (head)->hh.tbl->tail =                                               \
+                (UT_hash_handle*)((ptrdiff_t)((delptr)->hh.prev) +               \
+                (head)->hh.tbl->hho);                                            \
+        }                                                                        \
+        if ((delptr)->hh.prev) {                                                 \
+            ((UT_hash_handle*)((ptrdiff_t)((delptr)->hh.prev) +                  \
+                    (head)->hh.tbl->hho))->next = (delptr)->hh.next;             \
+        } else {                                                                 \
+            DECLTYPE_ASSIGN(head,(delptr)->hh.next);                             \
+        }                                                                        \
+        if (_hd_hh_del->next) {                                                  \
+            ((UT_hash_handle*)((ptrdiff_t)_hd_hh_del->next +                     \
+                    (head)->hh.tbl->hho))->prev =                                \
+                    _hd_hh_del->prev;                                            \
+        }                                                                        \
+        HASH_TO_BKT( _hd_hh_del->hashv, (head)->hh.tbl->num_buckets, _hd_bkt);   \
+        HASH_DEL_IN_BKT(hh,(head)->hh.tbl->buckets[_hd_bkt], _hd_hh_del);        \
+        (head)->hh.tbl->num_items--;                                             \
+    }                                                                            \
+    HASH_FSCK(hh,head);                                                          \
+} while (0)
+
+
+/* convenience forms of HASH_FIND/HASH_ADD/HASH_DEL */
+#define HASH_FIND_STR(head,findstr,out)                                          \
+    HASH_FIND(hh,head,findstr,strlen(findstr),out)
+#define HASH_ADD_STR(head,strfield,add)                                          \
+    HASH_ADD(hh,head,strfield[0],strlen(add->strfield),add)
+#define HASH_REPLACE_STR(head,strfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,strfield[0],strlen(add->strfield),add,replaced)
+#define HASH_FIND_INT(head,findint,out)                                          \
+    HASH_FIND(hh,head,findint,sizeof(int),out)
+#define HASH_ADD_INT(head,intfield,add)                                          \
+    HASH_ADD(hh,head,intfield,sizeof(int),add)
+#define HASH_REPLACE_INT(head,intfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,intfield,sizeof(int),add,replaced)
+#define HASH_FIND_PTR(head,findptr,out)                                          \
+    HASH_FIND(hh,head,findptr,sizeof(void *),out)
+#define HASH_ADD_PTR(head,ptrfield,add)                                          \
+    HASH_ADD(hh,head,ptrfield,sizeof(void *),add)
+#define HASH_REPLACE_PTR(head,ptrfield,add,replaced)                             \
+    HASH_REPLACE(hh,head,ptrfield,sizeof(void *),add,replaced)
+#define HASH_DEL(head,delptr)                                                    \
+    HASH_DELETE(hh,head,delptr)
+
+/* HASH_FSCK checks hash integrity on every add/delete when HASH_DEBUG is defined.
+ * This is for uthash developer only; it compiles away if HASH_DEBUG isn't defined.
+ */
+#ifdef HASH_DEBUG
+#define HASH_OOPS(...) do { fprintf(stderr,__VA_ARGS__); exit(-1); } while (0)
+#define HASH_FSCK(hh,head)                                                       \
+do {                                                                             \
+    unsigned _bkt_i;                                                             \
+    unsigned _count, _bkt_count;                                                 \
+    char *_prev;                                                                 \
+    struct UT_hash_handle *_thh;                                                 \
+    if (head) {                                                                  \
+        _count = 0;                                                              \
+        for( _bkt_i = 0; _bkt_i < (head)->hh.tbl->num_buckets; _bkt_i++) {       \
+            _bkt_count = 0;                                                      \
+            _thh = (head)->hh.tbl->buckets[_bkt_i].hh_head;                      \
+            _prev = NULL;                                                        \
+            while (_thh) {                                                       \
+               if (_prev != (char*)(_thh->hh_prev)) {                            \
+                   HASH_OOPS("invalid hh_prev %p, actual %p\n",                  \
+                    _thh->hh_prev, _prev );                                      \
+               }                                                                 \
+               _bkt_count++;                                                     \
+               _prev = (char*)(_thh);                                            \
+               _thh = _thh->hh_next;                                             \
+            }                                                                    \
+            _count += _bkt_count;                                                \
+            if ((head)->hh.tbl->buckets[_bkt_i].count !=  _bkt_count) {          \
+               HASH_OOPS("invalid bucket count %d, actual %d\n",                 \
+                (head)->hh.tbl->buckets[_bkt_i].count, _bkt_count);              \
+            }                                                                    \
+        }                                                                        \
+        if (_count != (head)->hh.tbl->num_items) {                               \
+            HASH_OOPS("invalid hh item count %d, actual %d\n",                   \
+                (head)->hh.tbl->num_items, _count );                             \
+        }                                                                        \
+        /* traverse hh in app order; check next/prev integrity, count */         \
+        _count = 0;                                                              \
+        _prev = NULL;                                                            \
+        _thh =  &(head)->hh;                                                     \
+        while (_thh) {                                                           \
+           _count++;                                                             \
+           if (_prev !=(char*)(_thh->prev)) {                                    \
+              HASH_OOPS("invalid prev %p, actual %p\n",                          \
+                    _thh->prev, _prev );                                         \
+           }                                                                     \
+           _prev = (char*)ELMT_FROM_HH((head)->hh.tbl, _thh);                    \
+           _thh = ( _thh->next ?  (UT_hash_handle*)((char*)(_thh->next) +        \
+                                  (head)->hh.tbl->hho) : NULL );                 \
+        }                                                                        \
+        if (_count != (head)->hh.tbl->num_items) {                               \
+            HASH_OOPS("invalid app item count %d, actual %d\n",                  \
+                (head)->hh.tbl->num_items, _count );                             \
+        }                                                                        \
+    }                                                                            \
+} while (0)
+#else
+#define HASH_FSCK(hh,head)
+#endif
+
+/* When compiled with -DHASH_EMIT_KEYS, length-prefixed keys are emitted to
+ * the descriptor to which this macro is defined for tuning the hash function.
+ * The app can #include <unistd.h> to get the prototype for write(2). */
+#ifdef HASH_EMIT_KEYS
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)                                   \
+do {                                                                             \
+    unsigned _klen = fieldlen;                                                   \
+    write(HASH_EMIT_KEYS, &_klen, sizeof(_klen));                                \
+    write(HASH_EMIT_KEYS, keyptr, fieldlen);                                     \
+} while (0)
+#else
+#define HASH_EMIT_KEY(hh,head,keyptr,fieldlen)
+#endif
+
+/* default to Jenkin's hash unless overridden e.g. DHASH_FUNCTION=HASH_SAX */
+#ifdef HASH_FUNCTION
+#define HASH_FCN HASH_FUNCTION
+#else
+#define HASH_FCN HASH_JEN
+#endif
+
+/* The Bernstein hash function, used in Perl prior to v5.6. Note (x<<5+x)=x*33. */
+#define HASH_BER(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _hb_keylen=keylen;                                                    \
+  char *_hb_key=(char*)(key);                                                    \
+  (hashv) = 0;                                                                   \
+  while (_hb_keylen--)  { (hashv) = (((hashv) << 5) + (hashv)) + *_hb_key++; }   \
+  bkt = (hashv) & (num_bkts-1);                                                  \
+} while (0)
+
+
+/* SAX/FNV/OAT/JEN hash functions are macro variants of those listed at
+ * http://eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx */
+#define HASH_SAX(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _sx_i;                                                                \
+  char *_hs_key=(char*)(key);                                                    \
+  hashv = 0;                                                                     \
+  for(_sx_i=0; _sx_i < keylen; _sx_i++)                                          \
+      hashv ^= (hashv << 5) + (hashv >> 2) + _hs_key[_sx_i];                     \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while (0)
+/* FNV-1a variation */
+#define HASH_FNV(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _fn_i;                                                                \
+  char *_hf_key=(char*)(key);                                                    \
+  hashv = 2166136261UL;                                                          \
+  for(_fn_i=0; _fn_i < keylen; _fn_i++)                                          \
+      hashv = hashv ^ _hf_key[_fn_i];                                            \
+      hashv = hashv * 16777619;                                                  \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while(0)
+
+#define HASH_OAT(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _ho_i;                                                                \
+  char *_ho_key=(char*)(key);                                                    \
+  hashv = 0;                                                                     \
+  for(_ho_i=0; _ho_i < keylen; _ho_i++) {                                        \
+      hashv += _ho_key[_ho_i];                                                   \
+      hashv += (hashv << 10);                                                    \
+      hashv ^= (hashv >> 6);                                                     \
+  }                                                                              \
+  hashv += (hashv << 3);                                                         \
+  hashv ^= (hashv >> 11);                                                        \
+  hashv += (hashv << 15);                                                        \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while(0)
+
+#define HASH_JEN_MIX(a,b,c)                                                      \
+do {                                                                             \
+  a -= b; a -= c; a ^= ( c >> 13 );                                              \
+  b -= c; b -= a; b ^= ( a << 8 );                                               \
+  c -= a; c -= b; c ^= ( b >> 13 );                                              \
+  a -= b; a -= c; a ^= ( c >> 12 );                                              \
+  b -= c; b -= a; b ^= ( a << 16 );                                              \
+  c -= a; c -= b; c ^= ( b >> 5 );                                               \
+  a -= b; a -= c; a ^= ( c >> 3 );                                               \
+  b -= c; b -= a; b ^= ( a << 10 );                                              \
+  c -= a; c -= b; c ^= ( b >> 15 );                                              \
+} while (0)
+
+#define HASH_JEN(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned _hj_i,_hj_j,_hj_k;                                                    \
+  unsigned char *_hj_key=(unsigned char*)(key);                                  \
+  hashv = 0xfeedbeef;                                                            \
+  _hj_i = _hj_j = 0x9e3779b9;                                                    \
+  _hj_k = (unsigned)(keylen);                                                      \
+  while (_hj_k >= 12) {                                                          \
+    _hj_i +=    (_hj_key[0] + ( (unsigned)_hj_key[1] << 8 )                      \
+        + ( (unsigned)_hj_key[2] << 16 )                                         \
+        + ( (unsigned)_hj_key[3] << 24 ) );                                      \
+    _hj_j +=    (_hj_key[4] + ( (unsigned)_hj_key[5] << 8 )                      \
+        + ( (unsigned)_hj_key[6] << 16 )                                         \
+        + ( (unsigned)_hj_key[7] << 24 ) );                                      \
+    hashv += (_hj_key[8] + ( (unsigned)_hj_key[9] << 8 )                         \
+        + ( (unsigned)_hj_key[10] << 16 )                                        \
+        + ( (unsigned)_hj_key[11] << 24 ) );                                     \
+                                                                                 \
+     HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                          \
+                                                                                 \
+     _hj_key += 12;                                                              \
+     _hj_k -= 12;                                                                \
+  }                                                                              \
+  hashv += keylen;                                                               \
+  switch ( _hj_k ) {                                                             \
+     case 11: hashv += ( (unsigned)_hj_key[10] << 24 );                          \
+     case 10: hashv += ( (unsigned)_hj_key[9] << 16 );                           \
+     case 9:  hashv += ( (unsigned)_hj_key[8] << 8 );                            \
+     case 8:  _hj_j += ( (unsigned)_hj_key[7] << 24 );                           \
+     case 7:  _hj_j += ( (unsigned)_hj_key[6] << 16 );                           \
+     case 6:  _hj_j += ( (unsigned)_hj_key[5] << 8 );                            \
+     case 5:  _hj_j += _hj_key[4];                                               \
+     case 4:  _hj_i += ( (unsigned)_hj_key[3] << 24 );                           \
+     case 3:  _hj_i += ( (unsigned)_hj_key[2] << 16 );                           \
+     case 2:  _hj_i += ( (unsigned)_hj_key[1] << 8 );                            \
+     case 1:  _hj_i += _hj_key[0];                                               \
+  }                                                                              \
+  HASH_JEN_MIX(_hj_i, _hj_j, hashv);                                             \
+  bkt = hashv & (num_bkts-1);                                                    \
+} while(0)
+
+/* The Paul Hsieh hash function */
+#undef get16bits
+#if (defined(__GNUC__) && defined(__i386__)) || defined(__WATCOMC__)             \
+  || defined(_MSC_VER) || defined (__BORLANDC__) || defined (__TURBOC__)
+#define get16bits(d) (*((const uint16_t *) (d)))
+#endif
+
+#if !defined (get16bits)
+#define get16bits(d) ((((uint32_t)(((const uint8_t *)(d))[1])) << 8)             \
+                       +(uint32_t)(((const uint8_t *)(d))[0]) )
+#endif
+#define HASH_SFH(key,keylen,num_bkts,hashv,bkt)                                  \
+do {                                                                             \
+  unsigned char *_sfh_key=(unsigned char*)(key);                                 \
+  uint32_t _sfh_tmp, _sfh_len = keylen;                                          \
+                                                                                 \
+  int _sfh_rem = _sfh_len & 3;                                                   \
+  _sfh_len >>= 2;                                                                \
+  hashv = 0xcafebabe;                                                            \
+                                                                                 \
+  /* Main loop */                                                                \
+  for (;_sfh_len > 0; _sfh_len--) {                                              \
+    hashv    += get16bits (_sfh_key);                                            \
+    _sfh_tmp       = (uint32_t)(get16bits (_sfh_key+2)) << 11  ^ hashv;          \
+    hashv     = (hashv << 16) ^ _sfh_tmp;                                        \
+    _sfh_key += 2*sizeof (uint16_t);                                             \
+    hashv    += hashv >> 11;                                                     \
+  }                                                                              \
+                                                                                 \
+  /* Handle end cases */                                                         \
+  switch (_sfh_rem) {                                                            \
+    case 3: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 16;                                                \
+            hashv ^= (uint32_t)(_sfh_key[sizeof (uint16_t)] << 18);              \
+            hashv += hashv >> 11;                                                \
+            break;                                                               \
+    case 2: hashv += get16bits (_sfh_key);                                       \
+            hashv ^= hashv << 11;                                                \
+            hashv += hashv >> 17;                                                \
+            break;                                                               \
+    case 1: hashv += *_sfh_key;                                                  \
+            hashv ^= hashv << 10;                                                \
+            hashv += hashv >> 1;                                                 \
+  }                                                                              \
+                                                                                 \
+    /* Force "avalanching" of final 127 bits */                                  \
+    hashv ^= hashv << 3;                                                         \
+    hashv += hashv >> 5;                                                         \
+    hashv ^= hashv << 4;                                                         \
+    hashv += hashv >> 17;                                                        \
+    hashv ^= hashv << 25;                                                        \
+    hashv += hashv >> 6;                                                         \
+    bkt = hashv & (num_bkts-1);                                                  \
+} while(0)
+
+#ifdef HASH_USING_NO_STRICT_ALIASING
+/* The MurmurHash exploits some CPU's (x86,x86_64) tolerance for unaligned reads.
+ * For other types of CPU's (e.g. Sparc) an unaligned read causes a bus error.
+ * MurmurHash uses the faster approach only on CPU's where we know it's safe.
+ *
+ * Note the preprocessor built-in defines can be emitted using:
+ *
+ *   gcc -m64 -dM -E - < /dev/null                  (on gcc)
+ *   cc -## a.c (where a.c is a simple test file)   (Sun Studio)
+ */
+#if (defined(__i386__) || defined(__x86_64__)  || defined(_M_IX86))
+#define MUR_GETBLOCK(p,i) p[i]
+#else /* non intel */
+#define MUR_PLUS0_ALIGNED(p) (((unsigned long)p & 0x3) == 0)
+#define MUR_PLUS1_ALIGNED(p) (((unsigned long)p & 0x3) == 1)
+#define MUR_PLUS2_ALIGNED(p) (((unsigned long)p & 0x3) == 2)
+#define MUR_PLUS3_ALIGNED(p) (((unsigned long)p & 0x3) == 3)
+#define WP(p) ((uint32_t*)((unsigned long)(p) & ~3UL))
+#if (defined(__BIG_ENDIAN__) || defined(SPARC) || defined(__ppc__) || defined(__ppc64__))
+#define MUR_THREE_ONE(p) ((((*WP(p))&0x00ffffff) << 8) | (((*(WP(p)+1))&0xff000000) >> 24))
+#define MUR_TWO_TWO(p)   ((((*WP(p))&0x0000ffff) <<16) | (((*(WP(p)+1))&0xffff0000) >> 16))
+#define MUR_ONE_THREE(p) ((((*WP(p))&0x000000ff) <<24) | (((*(WP(p)+1))&0xffffff00) >>  8))
+#else /* assume little endian non-intel */
+#define MUR_THREE_ONE(p) ((((*WP(p))&0xffffff00) >> 8) | (((*(WP(p)+1))&0x000000ff) << 24))
+#define MUR_TWO_TWO(p)   ((((*WP(p))&0xffff0000) >>16) | (((*(WP(p)+1))&0x0000ffff) << 16))
+#define MUR_ONE_THREE(p) ((((*WP(p))&0xff000000) >>24) | (((*(WP(p)+1))&0x00ffffff) <<  8))
+#endif
+#define MUR_GETBLOCK(p,i) (MUR_PLUS0_ALIGNED(p) ? ((p)[i]) :           \
+                            (MUR_PLUS1_ALIGNED(p) ? MUR_THREE_ONE(p) : \
+                             (MUR_PLUS2_ALIGNED(p) ? MUR_TWO_TWO(p) :  \
+                                                      MUR_ONE_THREE(p))))
+#endif
+#define MUR_ROTL32(x,r) (((x) << (r)) | ((x) >> (32 - (r))))
+#define MUR_FMIX(_h) \
+do {                 \
+  _h ^= _h >> 16;    \
+  _h *= 0x85ebca6b;  \
+  _h ^= _h >> 13;    \
+  _h *= 0xc2b2ae35l; \
+  _h ^= _h >> 16;    \
+} while(0)
+
+#define HASH_MUR(key,keylen,num_bkts,hashv,bkt)                        \
+do {                                                                   \
+  const uint8_t *_mur_data = (const uint8_t*)(key);                    \
+  const int _mur_nblocks = (keylen) / 4;                               \
+  uint32_t _mur_h1 = 0xf88D5353;                                       \
+  uint32_t _mur_c1 = 0xcc9e2d51;                                       \
+  uint32_t _mur_c2 = 0x1b873593;                                       \
+  uint32_t _mur_k1 = 0;                                                \
+  const uint8_t *_mur_tail;                                            \
+  const uint32_t *_mur_blocks = (const uint32_t*)(_mur_data+_mur_nblocks*4); \
+  int _mur_i;                                                          \
+  for(_mur_i = -_mur_nblocks; _mur_i; _mur_i++) {                      \
+    _mur_k1 = MUR_GETBLOCK(_mur_blocks,_mur_i);                        \
+    _mur_k1 *= _mur_c1;                                                \
+    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
+    _mur_k1 *= _mur_c2;                                                \
+                                                                       \
+    _mur_h1 ^= _mur_k1;                                                \
+    _mur_h1 = MUR_ROTL32(_mur_h1,13);                                  \
+    _mur_h1 = _mur_h1*5+0xe6546b64;                                    \
+  }                                                                    \
+  _mur_tail = (const uint8_t*)(_mur_data + _mur_nblocks*4);            \
+  _mur_k1=0;                                                           \
+  switch((keylen) & 3) {                                               \
+    case 3: _mur_k1 ^= _mur_tail[2] << 16;                             \
+    case 2: _mur_k1 ^= _mur_tail[1] << 8;                              \
+    case 1: _mur_k1 ^= _mur_tail[0];                                   \
+    _mur_k1 *= _mur_c1;                                                \
+    _mur_k1 = MUR_ROTL32(_mur_k1,15);                                  \
+    _mur_k1 *= _mur_c2;                                                \
+    _mur_h1 ^= _mur_k1;                                                \
+  }                                                                    \
+  _mur_h1 ^= (keylen);                                                 \
+  MUR_FMIX(_mur_h1);                                                   \
+  hashv = _mur_h1;                                                     \
+  bkt = hashv & (num_bkts-1);                                          \
+} while(0)
+#endif  /* HASH_USING_NO_STRICT_ALIASING */
+
+/* key comparison function; return 0 if keys equal */
+#define HASH_KEYCMP(a,b,len) memcmp(a,b,len)
+
+/* iterate over items in a known bucket to find desired item */
+#define HASH_FIND_IN_BKT(tbl,hh,head,keyptr,keylen_in,out)                       \
+do {                                                                             \
+ if (head.hh_head) DECLTYPE_ASSIGN(out,ELMT_FROM_HH(tbl,head.hh_head));          \
+ else out=NULL;                                                                  \
+ while (out) {                                                                   \
+    if ((out)->hh.keylen == keylen_in) {                                           \
+        if ((HASH_KEYCMP((out)->hh.key,keyptr,keylen_in)) == 0) break;             \
+    }                                                                            \
+    if ((out)->hh.hh_next) DECLTYPE_ASSIGN(out,ELMT_FROM_HH(tbl,(out)->hh.hh_next)); \
+    else out = NULL;                                                             \
+ }                                                                               \
+} while(0)
+
+/* add an item to a bucket  */
+#define HASH_ADD_TO_BKT(head,addhh)                                              \
+do {                                                                             \
+ head.count++;                                                                   \
+ (addhh)->hh_next = head.hh_head;                                                \
+ (addhh)->hh_prev = NULL;                                                        \
+ if (head.hh_head) { (head).hh_head->hh_prev = (addhh); }                        \
+ (head).hh_head=addhh;                                                           \
+ if (head.count >= ((head.expand_mult+1) * HASH_BKT_CAPACITY_THRESH)             \
+     && (addhh)->tbl->noexpand != 1) {                                           \
+       HASH_EXPAND_BUCKETS((addhh)->tbl);                                        \
+ }                                                                               \
+} while(0)
+
+/* remove an item from a given bucket */
+#define HASH_DEL_IN_BKT(hh,head,hh_del)                                          \
+    (head).count--;                                                              \
+    if ((head).hh_head == hh_del) {                                              \
+      (head).hh_head = hh_del->hh_next;                                          \
+    }                                                                            \
+    if (hh_del->hh_prev) {                                                       \
+        hh_del->hh_prev->hh_next = hh_del->hh_next;                              \
+    }                                                                            \
+    if (hh_del->hh_next) {                                                       \
+        hh_del->hh_next->hh_prev = hh_del->hh_prev;                              \
+    }
+
+/* Bucket expansion has the effect of doubling the number of buckets
+ * and redistributing the items into the new buckets. Ideally the
+ * items will distribute more or less evenly into the new buckets
+ * (the extent to which this is true is a measure of the quality of
+ * the hash function as it applies to the key domain).
+ *
+ * With the items distributed into more buckets, the chain length
+ * (item count) in each bucket is reduced. Thus by expanding buckets
+ * the hash keeps a bound on the chain length. This bounded chain
+ * length is the essence of how a hash provides constant time lookup.
+ *
+ * The calculation of tbl->ideal_chain_maxlen below deserves some
+ * explanation. First, keep in mind that we're calculating the ideal
+ * maximum chain length based on the *new* (doubled) bucket count.
+ * In fractions this is just n/b (n=number of items,b=new num buckets).
+ * Since the ideal chain length is an integer, we want to calculate
+ * ceil(n/b). We don't depend on floating point arithmetic in this
+ * hash, so to calculate ceil(n/b) with integers we could write
+ *
+ *      ceil(n/b) = (n/b) + ((n%b)?1:0)
+ *
+ * and in fact a previous version of this hash did just that.
+ * But now we have improved things a bit by recognizing that b is
+ * always a power of two. We keep its base 2 log handy (call it lb),
+ * so now we can write this with a bit shift and logical AND:
+ *
+ *      ceil(n/b) = (n>>lb) + ( (n & (b-1)) ? 1:0)
+ *
+ */
+#define HASH_EXPAND_BUCKETS(tbl)                                                 \
+do {                                                                             \
+    unsigned _he_bkt;                                                            \
+    unsigned _he_bkt_i;                                                          \
+    struct UT_hash_handle *_he_thh, *_he_hh_nxt;                                 \
+    UT_hash_bucket *_he_new_buckets, *_he_newbkt;                                \
+    _he_new_buckets = (UT_hash_bucket*)uthash_malloc(                            \
+             2 * tbl->num_buckets * sizeof(struct UT_hash_bucket));              \
+    if (!_he_new_buckets) { uthash_fatal( "out of memory"); }                    \
+    memset(_he_new_buckets, 0,                                                   \
+            2 * tbl->num_buckets * sizeof(struct UT_hash_bucket));               \
+    tbl->ideal_chain_maxlen =                                                    \
+       (tbl->num_items >> (tbl->log2_num_buckets+1)) +                           \
+       ((tbl->num_items & ((tbl->num_buckets*2)-1)) ? 1 : 0);                    \
+    tbl->nonideal_items = 0;                                                     \
+    for(_he_bkt_i = 0; _he_bkt_i < tbl->num_buckets; _he_bkt_i++)                \
+    {                                                                            \
+        _he_thh = tbl->buckets[ _he_bkt_i ].hh_head;                             \
+        while (_he_thh) {                                                        \
+           _he_hh_nxt = _he_thh->hh_next;                                        \
+           HASH_TO_BKT( _he_thh->hashv, tbl->num_buckets*2, _he_bkt);            \
+           _he_newbkt = &(_he_new_buckets[ _he_bkt ]);                           \
+           if (++(_he_newbkt->count) > tbl->ideal_chain_maxlen) {                \
+             tbl->nonideal_items++;                                              \
+             _he_newbkt->expand_mult = _he_newbkt->count /                       \
+                                        tbl->ideal_chain_maxlen;                 \
+           }                                                                     \
+           _he_thh->hh_prev = NULL;                                              \
+           _he_thh->hh_next = _he_newbkt->hh_head;                               \
+           if (_he_newbkt->hh_head) _he_newbkt->hh_head->hh_prev =               \
+                _he_thh;                                                         \
+           _he_newbkt->hh_head = _he_thh;                                        \
+           _he_thh = _he_hh_nxt;                                                 \
+        }                                                                        \
+    }                                                                            \
+    uthash_free( tbl->buckets, tbl->num_buckets*sizeof(struct UT_hash_bucket) ); \
+    tbl->num_buckets *= 2;                                                       \
+    tbl->log2_num_buckets++;                                                     \
+    tbl->buckets = _he_new_buckets;                                              \
+    tbl->ineff_expands = (tbl->nonideal_items > (tbl->num_items >> 1)) ?         \
+        (tbl->ineff_expands+1) : 0;                                              \
+    if (tbl->ineff_expands > 1) {                                                \
+        tbl->noexpand=1;                                                         \
+        uthash_noexpand_fyi(tbl);                                                \
+    }                                                                            \
+    uthash_expand_fyi(tbl);                                                      \
+} while(0)
+
+
+/* This is an adaptation of Simon Tatham's O(n log(n)) mergesort */
+/* Note that HASH_SORT assumes the hash handle name to be hh.
+ * HASH_SRT was added to allow the hash handle name to be passed in. */
+#define HASH_SORT(head,cmpfcn) HASH_SRT(hh,head,cmpfcn)
+#define HASH_SRT(hh,head,cmpfcn)                                                 \
+do {                                                                             \
+  unsigned _hs_i;                                                                \
+  unsigned _hs_looping,_hs_nmerges,_hs_insize,_hs_psize,_hs_qsize;               \
+  struct UT_hash_handle *_hs_p, *_hs_q, *_hs_e, *_hs_list, *_hs_tail;            \
+  if (head) {                                                                    \
+      _hs_insize = 1;                                                            \
+      _hs_looping = 1;                                                           \
+      _hs_list = &((head)->hh);                                                  \
+      while (_hs_looping) {                                                      \
+          _hs_p = _hs_list;                                                      \
+          _hs_list = NULL;                                                       \
+          _hs_tail = NULL;                                                       \
+          _hs_nmerges = 0;                                                       \
+          while (_hs_p) {                                                        \
+              _hs_nmerges++;                                                     \
+              _hs_q = _hs_p;                                                     \
+              _hs_psize = 0;                                                     \
+              for ( _hs_i = 0; _hs_i  < _hs_insize; _hs_i++ ) {                  \
+                  _hs_psize++;                                                   \
+                  _hs_q = (UT_hash_handle*)((_hs_q->next) ?                      \
+                          ((void*)((char*)(_hs_q->next) +                        \
+                          (head)->hh.tbl->hho)) : NULL);                         \
+                  if (! (_hs_q) ) break;                                         \
+              }                                                                  \
+              _hs_qsize = _hs_insize;                                            \
+              while ((_hs_psize > 0) || ((_hs_qsize > 0) && _hs_q )) {           \
+                  if (_hs_psize == 0) {                                          \
+                      _hs_e = _hs_q;                                             \
+                      _hs_q = (UT_hash_handle*)((_hs_q->next) ?                  \
+                              ((void*)((char*)(_hs_q->next) +                    \
+                              (head)->hh.tbl->hho)) : NULL);                     \
+                      _hs_qsize--;                                               \
+                  } else if ( (_hs_qsize == 0) || !(_hs_q) ) {                   \
+                      _hs_e = _hs_p;                                             \
+                      if (_hs_p){                                                \
+                        _hs_p = (UT_hash_handle*)((_hs_p->next) ?                \
+                                ((void*)((char*)(_hs_p->next) +                  \
+                                (head)->hh.tbl->hho)) : NULL);                   \
+                       }                                                         \
+                      _hs_psize--;                                               \
+                  } else if ((                                                   \
+                      cmpfcn(DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl,_hs_p)), \
+                             DECLTYPE(head)(ELMT_FROM_HH((head)->hh.tbl,_hs_q))) \
+                             ) <= 0) {                                           \
+                      _hs_e = _hs_p;                                             \
+                      if (_hs_p){                                                \
+                        _hs_p = (UT_hash_handle*)((_hs_p->next) ?                \
+                               ((void*)((char*)(_hs_p->next) +                   \
+                               (head)->hh.tbl->hho)) : NULL);                    \
+                       }                                                         \
+                      _hs_psize--;                                               \
+                  } else {                                                       \
+                      _hs_e = _hs_q;                                             \
+                      _hs_q = (UT_hash_handle*)((_hs_q->next) ?                  \
+                              ((void*)((char*)(_hs_q->next) +                    \
+                              (head)->hh.tbl->hho)) : NULL);                     \
+                      _hs_qsize--;                                               \
+                  }                                                              \
+                  if ( _hs_tail ) {                                              \
+                      _hs_tail->next = ((_hs_e) ?                                \
+                            ELMT_FROM_HH((head)->hh.tbl,_hs_e) : NULL);          \
+                  } else {                                                       \
+                      _hs_list = _hs_e;                                          \
+                  }                                                              \
+                  if (_hs_e) {                                                   \
+                  _hs_e->prev = ((_hs_tail) ?                                    \
+                     ELMT_FROM_HH((head)->hh.tbl,_hs_tail) : NULL);              \
+                  }                                                              \
+                  _hs_tail = _hs_e;                                              \
+              }                                                                  \
+              _hs_p = _hs_q;                                                     \
+          }                                                                      \
+          if (_hs_tail){                                                         \
+            _hs_tail->next = NULL;                                               \
+          }                                                                      \
+          if ( _hs_nmerges <= 1 ) {                                              \
+              _hs_looping=0;                                                     \
+              (head)->hh.tbl->tail = _hs_tail;                                   \
+              DECLTYPE_ASSIGN(head,ELMT_FROM_HH((head)->hh.tbl, _hs_list));      \
+          }                                                                      \
+          _hs_insize *= 2;                                                       \
+      }                                                                          \
+      HASH_FSCK(hh,head);                                                        \
+ }                                                                               \
+} while (0)
+
+/* This function selects items from one hash into another hash.
+ * The end result is that the selected items have dual presence
+ * in both hashes. There is no copy of the items made; rather
+ * they are added into the new hash through a secondary hash
+ * hash handle that must be present in the structure. */
+#define HASH_SELECT(hh_dst, dst, hh_src, src, cond)                              \
+do {                                                                             \
+  unsigned _src_bkt, _dst_bkt;                                                   \
+  void *_last_elt=NULL, *_elt;                                                   \
+  UT_hash_handle *_src_hh, *_dst_hh, *_last_elt_hh=NULL;                         \
+  ptrdiff_t _dst_hho = ((char*)(&(dst)->hh_dst) - (char*)(dst));                 \
+  if (src) {                                                                     \
+    for(_src_bkt=0; _src_bkt < (src)->hh_src.tbl->num_buckets; _src_bkt++) {     \
+      for(_src_hh = (src)->hh_src.tbl->buckets[_src_bkt].hh_head;                \
+          _src_hh;                                                               \
+          _src_hh = _src_hh->hh_next) {                                          \
+          _elt = ELMT_FROM_HH((src)->hh_src.tbl, _src_hh);                       \
+          if (cond(_elt)) {                                                      \
+            _dst_hh = (UT_hash_handle*)(((char*)_elt) + _dst_hho);               \
+            _dst_hh->key = _src_hh->key;                                         \
+            _dst_hh->keylen = _src_hh->keylen;                                   \
+            _dst_hh->hashv = _src_hh->hashv;                                     \
+            _dst_hh->prev = _last_elt;                                           \
+            _dst_hh->next = NULL;                                                \
+            if (_last_elt_hh) { _last_elt_hh->next = _elt; }                     \
+            if (!dst) {                                                          \
+              DECLTYPE_ASSIGN(dst,_elt);                                         \
+              HASH_MAKE_TABLE(hh_dst,dst);                                       \
+            } else {                                                             \
+              _dst_hh->tbl = (dst)->hh_dst.tbl;                                  \
+            }                                                                    \
+            HASH_TO_BKT(_dst_hh->hashv, _dst_hh->tbl->num_buckets, _dst_bkt);    \
+            HASH_ADD_TO_BKT(_dst_hh->tbl->buckets[_dst_bkt],_dst_hh);            \
+            (dst)->hh_dst.tbl->num_items++;                                      \
+            _last_elt = _elt;                                                    \
+            _last_elt_hh = _dst_hh;                                              \
+          }                                                                      \
+      }                                                                          \
+    }                                                                            \
+  }                                                                              \
+  HASH_FSCK(hh_dst,dst);                                                         \
+} while (0)
+
+#define HASH_CLEAR(hh,head)                                                      \
+do {                                                                             \
+  if (head) {                                                                    \
+    uthash_free((head)->hh.tbl->buckets,                                         \
+                (head)->hh.tbl->num_buckets*sizeof(struct UT_hash_bucket));      \
+    HASH_BLOOM_FREE((head)->hh.tbl);                                             \
+    uthash_free((head)->hh.tbl, sizeof(UT_hash_table));                          \
+    (head)=NULL;                                                                 \
+  }                                                                              \
+} while(0)
+
+#define HASH_OVERHEAD(hh,head)                                                   \
+ (size_t)((((head)->hh.tbl->num_items   * sizeof(UT_hash_handle))   +            \
+           ((head)->hh.tbl->num_buckets * sizeof(UT_hash_bucket))   +            \
+            (sizeof(UT_hash_table))                                 +            \
+            (HASH_BLOOM_BYTELEN)))
+
+#ifdef NO_DECLTYPE
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for((el)=(head), (*(char**)(&(tmp)))=(char*)((head)?(head)->hh.next:NULL);       \
+  el; (el)=(tmp),(*(char**)(&(tmp)))=(char*)((tmp)?(tmp)->hh.next:NULL))
+#else
+#define HASH_ITER(hh,head,el,tmp)                                                \
+for((el)=(head),(tmp)=DECLTYPE(el)((head)?(head)->hh.next:NULL);                 \
+  el; (el)=(tmp),(tmp)=DECLTYPE(el)((tmp)?(tmp)->hh.next:NULL))
+#endif
+
+/* obtain a count of items in the hash */
+#define HASH_COUNT(head) HASH_CNT(hh,head)
+#define HASH_CNT(hh,head) ((head)?((head)->hh.tbl->num_items):0)
+
+typedef struct UT_hash_bucket {
+   struct UT_hash_handle *hh_head;
+   unsigned count;
+
+   /* expand_mult is normally set to 0. In this situation, the max chain length
+    * threshold is enforced at its default value, HASH_BKT_CAPACITY_THRESH. (If
+    * the bucket's chain exceeds this length, bucket expansion is triggered).
+    * However, setting expand_mult to a non-zero value delays bucket expansion
+    * (that would be triggered by additions to this particular bucket)
+    * until its chain length reaches a *multiple* of HASH_BKT_CAPACITY_THRESH.
+    * (The multiplier is simply expand_mult+1). The whole idea of this
+    * multiplier is to reduce bucket expansions, since they are expensive, in
+    * situations where we know that a particular bucket tends to be overused.
+    * It is better to let its chain length grow to a longer yet-still-bounded
+    * value, than to do an O(n) bucket expansion too often.
+    */
+   unsigned expand_mult;
+
+} UT_hash_bucket;
+
+/* random signature used only to find hash tables in external analysis */
+#define HASH_SIGNATURE 0xa0111fe1
+#define HASH_BLOOM_SIGNATURE 0xb12220f2
+
+typedef struct UT_hash_table {
+   UT_hash_bucket *buckets;
+   unsigned num_buckets, log2_num_buckets;
+   unsigned num_items;
+   struct UT_hash_handle *tail; /* tail hh in app order, for fast append    */
+   ptrdiff_t hho; /* hash handle offset (byte pos of hash handle in element */
+
+   /* in an ideal situation (all buckets used equally), no bucket would have
+    * more than ceil(#items/#buckets) items. that's the ideal chain length. */
+   unsigned ideal_chain_maxlen;
+
+   /* nonideal_items is the number of items in the hash whose chain position
+    * exceeds the ideal chain maxlen. these items pay the penalty for an uneven
+    * hash distribution; reaching them in a chain traversal takes >ideal steps */
+   unsigned nonideal_items;
+
+   /* ineffective expands occur when a bucket doubling was performed, but
+    * afterward, more than half the items in the hash had nonideal chain
+    * positions. If this happens on two consecutive expansions we inhibit any
+    * further expansion, as it's not helping; this happens when the hash
+    * function isn't a good fit for the key domain. When expansion is inhibited
+    * the hash will still work, albeit no longer in constant time. */
+   unsigned ineff_expands, noexpand;
+
+   uint32_t signature; /* used only to find hash tables in external analysis */
+#ifdef HASH_BLOOM
+   uint32_t bloom_sig; /* used only to test bloom exists in external analysis */
+   uint8_t *bloom_bv;
+   char bloom_nbits;
+#endif
+
+} UT_hash_table;
+
+typedef struct UT_hash_handle {
+   struct UT_hash_table *tbl;
+   void *prev;                       /* prev element in app order      */
+   void *next;                       /* next element in app order      */
+   struct UT_hash_handle *hh_prev;   /* previous hh in bucket order    */
+   struct UT_hash_handle *hh_next;   /* next hh in bucket order        */
+   void *key;                        /* ptr to enclosing struct's key  */
+   unsigned keylen;                  /* enclosing struct's key len     */
+   unsigned hashv;                   /* result of hash-fcn(key)        */
+} UT_hash_handle;
+
+#endif /* UTHASH_H */

--- a/prov/verbs/src/verbs_av.c
+++ b/prov/verbs/src/verbs_av.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <fi_enosys.h>
+#include "fi_verbs.h"
+
+
+static int fi_ibv_av_insert(struct fid_av *av, const void *addr, size_t count,
+			    fi_addr_t * fi_addr, uint64_t flags, void *context)
+{
+	FI_WARN(&fi_ibv_prov, FI_LOG_AV,
+		"No endpoints are attached to the av\n");
+	return -FI_ENOSYS;
+}
+
+static int fi_ibv_av_remove(struct fid_av *av, fi_addr_t * fi_addr,
+			    size_t count, uint64_t flags)
+{
+	FI_WARN(&fi_ibv_prov, FI_LOG_AV,
+		"No endpoints are attached to the av\n");
+	return -FI_ENOSYS;
+
+}
+
+static int fi_ibv_av_close(fid_t fid)
+{
+	return 0;
+}
+
+static struct fi_ops fi_ibv_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = fi_ibv_av_close,
+	.bind = fi_no_bind,
+};
+
+static struct fi_ops_av fi_ibv_av_ops = {
+	.size = sizeof(struct fi_ops_av),
+	.insert = fi_ibv_av_insert,
+	.remove = fi_ibv_av_remove,
+};
+
+/* TODO: match rest of verbs code for variable naming */
+int fi_ibv_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+		   struct fid_av **av, void *context)
+{
+	struct fi_ibv_domain *fid_domain;
+	struct fi_ibv_av *fid_av;
+	int type = FI_AV_MAP;
+	size_t count = 64;
+
+	fid_domain = container_of(domain, struct fi_ibv_domain, domain_fid);
+
+	if (!attr)
+		return -FI_EINVAL;
+
+	switch (attr->type) {
+	case FI_AV_MAP:
+	case FI_AV_TABLE:
+		type = attr->type;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (attr->count)
+		count = attr->count;
+
+	fid_av = calloc(1, sizeof *fid_av);
+	if (!fid_av)
+		return -ENOMEM;
+
+	fid_av->domain = fid_domain;
+	fid_av->type = type;
+	fid_av->count = count;
+
+	fid_av->av.fid.fclass = FI_CLASS_AV;
+	fid_av->av.fid.context = context;
+	fid_av->av.fid.ops = &fi_ibv_fi_ops;
+	/* Note, this default APIs should be reset by EP in the bind call */
+	fid_av->av.ops = &fi_ibv_av_ops;
+
+	*av = &fid_av->av;
+	return 0;
+}


### PR DESCRIPTION
This merges in the patches from @evgeny-leksikov source tree to add RDM EP support to the verbs provider.  The changes to the verbs provider from Evgeny's tree were squashed into a single commit.  A separate commit updates the fi_list implementation.

The base changes are updated to apply over the updated master branch, which handled the refactoring of the existing verbs provider separately.  The resulting commit was also updated to more closely match the libfabric coding style (see the linux kernel coding style documentation: https://www.kernel.org/doc/Documentation/CodingStyle).  Specifically, the following changes were made:

typedef's for enums and structs were removed.  The enum and struct names are used directly.

Lindent was run against the code to fix spacing issues.  A manual cleanup of the resulting code followed.  Because of the length of some function and structure names, the end result is less than ideal.  But the functions and structures were not renamed at this time.

No significant changes to the code should have occurred.  But several TODO's were added into the code.  Of note:

As mentioned, many function and structure names are really too long (.e.g fi_verbs_rdm_tagged_match_request_by_minfo_with_tagmask), which negatively impacts the readability of the code.

The mempool abstraction should be generalized and moved into common code.

The error handling is minimal, with 'abort()' being called in several places.  I anticipate that there will be several errors reported by coverity and static code analysis scans.

All sleep calls should be removed.

There are places where the indentation is excessively deep, which affects code readability.

There's an excessive use of static inline.  Several very long functions are marked as static inline.

The use of const is inconsistent in the function prototypes.

The RDM support should have the same look and feel as the existing provider code.

Finally, this PR does NOT update the fi_getinfo call.  The updates to fi_getinfo weren't quite right, and forced the verbs provider to either support MSG EPs or RDM EPs, but not both at the same time.  That portion of the original series needs to be updated (but is a relatively small set of changes).

Since the RDM support is still disabled by this PR, I would like to see it merged, so that cleanups can go against the upstream code base.  I will work on a separate PR that will enable the RDM support.