### PR TITLE
prov/psm: more accurate setting of the FI_CONTEXT mode

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -99,8 +99,6 @@ extern struct fi_provider psmx_prov;
 #define PSMX_SUB_CAPS	(FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE | \
 			 FI_SEND | FI_RECV)
 
-#define PSMX_MODE	(FI_CONTEXT)
-
 #define PSMX_MAX_MSG_SIZE	((0x1ULL << 32) - 1)
 #define PSMX_INJECT_SIZE	(64)
 #define PSMX_MSG_ORDER	FI_ORDER_SAS


### PR DESCRIPTION
FI_CONTEXT mode is not needed for active message based funcitons
(RMA, atomics, and AM-based message). Don't set the mode if the
application only asks for these functions.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>