### PR TITLE
sockets: increase mr_key size

### DIFF
--- a/include/fi_indexer.h
+++ b/include/fi_indexer.h
@@ -48,30 +48,30 @@
 
 union idx_entry {
 	void *item;
-	int   next;
+	int64_t next;
 };
 
-#define IDX_INDEX_BITS 16
-#define IDX_ENTRY_BITS 10
-#define IDX_ENTRY_SIZE (1 << IDX_ENTRY_BITS)
-#define IDX_ARRAY_SIZE (1 << (IDX_INDEX_BITS - IDX_ENTRY_BITS))
-#define IDX_MAX_INDEX  ((1 << IDX_INDEX_BITS) - 1)
+#define IDX_INDEX_BITS 32
+#define IDX_ENTRY_BITS 26
+#define IDX_ENTRY_SIZE (0x1UL << IDX_ENTRY_BITS)
+#define IDX_ARRAY_SIZE (0x1UL << (IDX_INDEX_BITS - IDX_ENTRY_BITS))
+#define IDX_MAX_INDEX  ((0x1UL << IDX_INDEX_BITS) - 1)
 
 struct indexer
 {
 	union idx_entry *array[IDX_ARRAY_SIZE];
-	int		 free_list;
-	int		 size;
+	int64_t		 free_list;
+	int64_t		 size;
 };
 
 #define idx_array_index(index) (index >> IDX_ENTRY_BITS)
 #define idx_entry_index(index) (index & (IDX_ENTRY_SIZE - 1))
 
-int idx_insert(struct indexer *idx, void *item);
-void *idx_remove(struct indexer *idx, int index);
-void idx_replace(struct indexer *idx, int index, void *item);
+int64_t idx_insert(struct indexer *idx, void *item);
+void *idx_remove(struct indexer *idx, int64_t index);
+void idx_replace(struct indexer *idx, int64_t index, void *item);
 
-static inline void *idx_at(struct indexer *idx, int index)
+static inline void *idx_at(struct indexer *idx, int64_t index)
 {
 	return (idx->array[idx_array_index(index)] + idx_entry_index(index))->item;
 }
@@ -85,20 +85,20 @@ static inline void *idx_at(struct indexer *idx, int index)
 struct index_map
 {
 	void **array[IDX_ARRAY_SIZE];
-	int count[IDX_ARRAY_SIZE];
+	int64_t count[IDX_ARRAY_SIZE];
 };
 
-int idm_set(struct index_map *idm, int index, void *item);
-void *idm_clear(struct index_map *idm, int index);
+int64_t idm_set(struct index_map *idm, int64_t index, void *item);
+void *idm_clear(struct index_map *idm, int64_t index);
 
-static inline void *idm_at(struct index_map *idm, int index)
+static inline void *idm_at(struct index_map *idm, int64_t index)
 {
 	void **entry;
 	entry = idm->array[idx_array_index(index)];
 	return entry[idx_entry_index(index)];
 }
 
-static inline void *idm_lookup(struct index_map *idm, int index)
+static inline void *idm_lookup(struct index_map *idm, int64_t index)
 {
 	return ((index <= IDX_MAX_INDEX) && idm->array[idx_array_index(index)]) ?
 		idm_at(idm, index) : NULL;

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -978,11 +978,11 @@ int sock_cntr_err_inc(struct sock_cntr *cntr);
 int sock_cntr_progress(struct sock_cntr *cntr);
 
 
-struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint16_t key, 
+struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint32_t key, 
 				   void *buf, size_t len, uint64_t access);
 struct sock_mr *sock_mr_verify_desc(struct sock_domain *domain, void *desc, 
 				    void *buf, size_t len, uint64_t access);
-struct sock_mr * sock_mr_get_entry(struct sock_domain *domain, uint16_t key);
+struct sock_mr * sock_mr_get_entry(struct sock_domain *domain, uint32_t key);
 
 
 struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr, void *context);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -54,10 +54,10 @@
  * list without taking a lock during data lookups.
  */
 
-static int idx_grow(struct indexer *idx)
+static int64_t idx_grow(struct indexer *idx)
 {
 	union idx_entry *entry;
-	int i, start_index;
+	int64_t i, start_index;
 
 	if (idx->size >= IDX_ARRAY_SIZE)
 		goto nomem;
@@ -85,10 +85,10 @@ nomem:
 	return -1;
 }
 
-int idx_insert(struct indexer *idx, void *item)
+int64_t idx_insert(struct indexer *idx, void *item)
 {
 	union idx_entry *entry;
-	int index;
+	int64_t index;
 
 	if ((index = idx->free_list) == 0) {
 		if ((index = idx_grow(idx)) <= 0)
@@ -101,7 +101,7 @@ int idx_insert(struct indexer *idx, void *item)
 	return index;
 }
 
-void *idx_remove(struct indexer *idx, int index)
+void *idx_remove(struct indexer *idx, int64_t index)
 {
 	union idx_entry *entry;
 	void *item;
@@ -113,7 +113,7 @@ void *idx_remove(struct indexer *idx, int index)
 	return item;
 }
 
-void idx_replace(struct indexer *idx, int index, void *item)
+void idx_replace(struct indexer *idx, int64_t index, void *item)
 {
 	union idx_entry *entry;
 
@@ -122,7 +122,7 @@ void idx_replace(struct indexer *idx, int index, void *item)
 }
 
 
-static int idm_grow(struct index_map *idm, int index)
+static int64_t idm_grow(struct index_map *idm, int64_t index)
 {
 	idm->array[idx_array_index(index)] = calloc(IDX_ENTRY_SIZE, sizeof(void *));
 	if (!idm->array[idx_array_index(index)])
@@ -135,7 +135,7 @@ nomem:
 	return -1;
 }
 
-int idm_set(struct index_map *idm, int index, void *item)
+int64_t idm_set(struct index_map *idm, int64_t index, void *item)
 {
 	void **entry;
 
@@ -155,7 +155,7 @@ int idm_set(struct index_map *idm, int index, void *item)
 	return index;
 }
 
-void *idm_clear(struct index_map *idm, int index)
+void *idm_clear(struct index_map *idm, int64_t index)
 {
 	void **entry;
 	void *item;


### PR DESCRIPTION
idm - Increase idm key size from int to int64
prov/sockets: Increase mr_key size to 32-bit

@shefty - can you please review the changes?