### PR TITLE
fabric: add functions to free the resources allocated for indexer

### DIFF
--- a/include/fi_indexer.h
+++ b/include/fi_indexer.h
@@ -70,6 +70,7 @@ struct indexer
 int idx_insert(struct indexer *idx, void *item);
 void *idx_remove(struct indexer *idx, int index);
 void idx_replace(struct indexer *idx, int index, void *item);
+void idx_reset(struct indexer *idx);
 
 static inline void *idx_at(struct indexer *idx, int index)
 {
@@ -90,6 +91,7 @@ struct index_map
 
 int idm_set(struct index_map *idm, int index, void *item);
 void *idm_clear(struct index_map *idm, int index);
+void idm_reset(struct index_map *idm);
 
 static inline void *idm_at(struct index_map *idm, int index)
 {

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -121,6 +121,15 @@ void idx_replace(struct indexer *idx, int index, void *item)
 	entry[idx_entry_index(index)].item = item;
 }
 
+void idx_reset(struct indexer *idx)
+{
+	while (idx->size) {
+		free(idx->array[idx->size - 1]);
+		idx->array[idx->size - 1] = NULL;
+		idx->size--;
+	}
+	idx->free_list = 0;
+}
 
 static int idm_grow(struct index_map *idm, int index)
 {
@@ -169,3 +178,17 @@ void *idm_clear(struct index_map *idm, int index)
 	}
 	return item;
 }
+
+void idm_reset(struct index_map *idm)
+{
+	int i;
+
+	for (i=0; i<IDX_ARRAY_SIZE; i++) {
+		if (idm->array[i]) {
+			free(idm->array[i]);
+			idm->array[i] = NULL;
+			idm->count[i] = 0;
+		}
+	}
+}
+


### PR DESCRIPTION
The indexer and index_map functions allocate memory on demand. The
user of these functions would need to walk through the internal
data structure in order to free the allocated memory. These new
"reset" functions simplify the job.