### PR TITLE
prov/psm: add reference counting to the fabric and domain object

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -641,6 +641,19 @@ int	psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 int	psmx_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 		       struct fid_poll **pollset);
 
+static inline void psmx_fabric_acquire(struct psmx_fid_fabric *fabric)
+{
+	++fabric->refcnt;
+}
+
+void	psmx_fabric_release(struct psmx_fid_fabric *fabric);
+
+static inline void psmx_domain_acquire(struct psmx_fid_domain *domain)
+{
+	++domain->refcnt;
+}
+
+void	psmx_domain_release(struct psmx_fid_domain *domain);
 int	psmx_domain_check_features(struct psmx_fid_domain *domain, int ep_cap);
 int	psmx_domain_enable_ep(struct psmx_fid_domain *domain, struct psmx_fid_ep *ep);
 void	psmx_domain_disable_ep(struct psmx_fid_domain *domain, struct psmx_fid_ep *ep);

--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -329,7 +329,9 @@ static const char *psmx_av_straddr(struct fid_av *av, const void *addr,
 static int psmx_av_close(fid_t fid)
 {
 	struct psmx_fid_av *av;
+
 	av = container_of(fid, struct psmx_fid_av, av.fid);
+	psmx_domain_release(av->domain);
 	if (av->psm_epids)
 		free(av->psm_epids);
 	if (av->psm_epaddrs)
@@ -417,6 +419,8 @@ int psmx_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	av_priv = (struct psmx_fid_av *) calloc(1, sizeof *av_priv);
 	if (!av_priv)
 		return -FI_ENOMEM;
+
+	psmx_domain_acquire(domain_priv);
 
 	av_priv->domain = domain_priv;
 	av_priv->type = type;

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -340,6 +340,8 @@ static int psmx_cntr_close(fid_t fid)
 
 	cntr = container_of(fid, struct psmx_fid_cntr, cntr.fid);
 
+	psmx_domain_release(cntr->domain);
+
 	if (cntr->wait && cntr->wait_is_local)
 		fi_close((fid_t)cntr->wait);
 
@@ -460,6 +462,8 @@ int psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		err = -FI_ENOMEM;
 		goto fail;
 	}
+
+	psmx_domain_acquire(domain_priv);
 
 	cntr_priv->domain = domain_priv;
 	cntr_priv->events = events;

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -745,6 +745,8 @@ static int psmx_cq_close(fid_t fid)
 
 	cq = container_of(fid, struct psmx_fid_cq, cq.fid);
 
+	psmx_domain_release(cq->domain);
+
 	while (!slist_empty(&cq->free_list)) {
 		entry = slist_remove_head(&cq->free_list);
 		item = container_of(entry, struct psmx_cq_event, list_entry);
@@ -894,6 +896,8 @@ int psmx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 			free(wait);
 		return -FI_ENOMEM;
 	}
+
+	psmx_domain_acquire(domain_priv);
 
 	cq_priv->domain = domain_priv;
 	cq_priv->format = attr->format;

--- a/prov/psm/src/psmx_eq.c
+++ b/prov/psm/src/psmx_eq.c
@@ -306,6 +306,8 @@ static int psmx_eq_close(fid_t fid)
 
 	eq = container_of(fid, struct psmx_fid_eq, eq.fid);
 
+	psmx_fabric_release(eq->fabric);
+
 	while (!slist_empty(&eq->free_list)) {
 		entry = slist_remove_head(&eq->free_list);
 		item = container_of(entry, struct psmx_eq_event, list_entry);
@@ -409,6 +411,8 @@ int psmx_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 			free(wait);
 		return -FI_ENOMEM;
 	}
+
+	psmx_fabric_acquire(fabric_priv);
 
 	eq_priv->fabric = fabric_priv;
 	eq_priv->wait = wait;

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -114,6 +114,7 @@ static int psmx_mr_close(fid_t fid)
 
 	mr = container_of(fid, struct psmx_fid_mr, mr.fid);
 	psmx_mr_release_key(mr->domain, mr->mr.key);
+	psmx_domain_release(mr->domain);
 	free(mr);
 
 	return 0;
@@ -249,6 +250,8 @@ static int psmx_mr_reg(struct fid *fid, const void *buf, size_t len,
 		key = psmx_mr_reserve_any_key(domain_priv);
 	}
 
+	psmx_domain_acquire(domain_priv);
+
 	mr_priv->mr.fid.fclass = FI_CLASS_MR;
 	mr_priv->mr.fid.context = context;
 	mr_priv->mr.fid.ops = &psmx_fi_ops;
@@ -310,6 +313,8 @@ static int psmx_mr_regv(struct fid *fid,
 		key = psmx_mr_reserve_any_key(domain_priv);
 	}
 
+	psmx_domain_acquire(domain_priv);
+
 	mr_priv->mr.fid.fclass = FI_CLASS_MR;
 	mr_priv->mr.fid.context = context;
 	mr_priv->mr.fid.ops = &psmx_fi_ops;
@@ -368,6 +373,8 @@ static int psmx_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	} else {
 		key = psmx_mr_reserve_any_key(domain_priv);
 	}
+
+	psmx_domain_acquire(domain_priv);
 
 	mr_priv->mr.fid.fclass = FI_CLASS_MR;
 	mr_priv->mr.fid.context = attr->context;

--- a/prov/psm/src/psmx_poll.c
+++ b/prov/psm/src/psmx_poll.c
@@ -120,6 +120,8 @@ static int psmx_poll_close(fid_t fid)
 
 	poll = container_of(fid, struct psmx_fid_poll, poll.fid);
 
+	psmx_domain_release(poll->domain);
+
 	head = &poll->poll_list_head;
 	while (!dlist_empty(head)) {
 		p = head->next;
@@ -159,6 +161,8 @@ int psmx_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 	if (!poll_priv)
 		return -FI_ENOMEM;
 	
+	psmx_domain_acquire(domain_priv);
+
 	dlist_init(&poll_priv->poll_list_head);
 	poll_priv->poll.fid.fclass = FI_CLASS_POLL;
 	poll_priv->poll.fid.context = 0;

--- a/prov/psm2/src/rename.h
+++ b/prov/psm2/src/rename.h
@@ -123,12 +123,14 @@
 #define psmx_cq_sread psmx2_cq_sread
 #define psmx_cq_sreadfrom psmx2_cq_sreadfrom
 #define psmx_cq_strerror psmx2_cq_strerror
+#define psmx_domain_acquire psmx2_domain_acquire
 #define psmx_domain_check_features psmx2_domain_check_features
 #define psmx_domain_close psmx2_domain_close
 #define psmx_domain_disable_ep psmx2_domain_disable_ep
 #define psmx_domain_enable_ep psmx2_domain_enable_ep
 #define psmx_domain_open psmx2_domain_open
 #define psmx_domain_ops psmx2_domain_ops
+#define psmx_domain_release psmx2_domain_release
 #define psmx_domain_start_progress psmx2_domain_start_progress
 #define psmx_domain_stop_progress psmx2_domain_stop_progress
 #define psmx_env psmx2_env
@@ -163,9 +165,11 @@
 #define psmx_errno psmx2_errno
 #define psmx_errno_table psmx2_errno_table
 #define psmx_fabric psmx2_fabric
+#define psmx_fabric_acquire psmx2_fabric_acquire
 #define psmx_fabric_close psmx2_fabric_close
 #define psmx_fabric_fi_ops psmx2_fabric_fi_ops
 #define psmx_fabric_ops psmx2_fabric_ops
+#define psmx_fabric_release psmx2_fabric_release
 #define psmx_fid_av psmx2_fid_av
 #define psmx_fid_cntr psmx2_fid_cntr
 #define psmx_fid_cq psmx2_fid_cq


### PR DESCRIPTION
This allows the fids be closed in arbitary order (e.g. close the
domain before close the mr).

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>