### PR TITLE
prov/psm: support running psm provider over psm2-compat library

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -73,6 +73,10 @@ extern "C" {
 
 extern struct fi_provider psmx_prov;
 
+#if (PSM_VERNO_MAJOR == 1)
+extern int psmx_am_compat_mode;
+#endif
+
 #define PSMX_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \
 			 FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -592,12 +592,14 @@ PROVIDER_INI
 	FI_INFO(&psmx_prov, FI_LOG_CORE,
 		"PSM library version = (%d, %d)\n", major, minor);
 
+#if (PSM_VERNO_MAJOR == 1)
 	if (major != PSM_VERNO_MAJOR) {
-		FI_WARN(&psmx_prov, FI_LOG_CORE,
-			"PSM version mismatch: header %d.%d, library %d.%d.\n",
+		psmx_am_compat_mode = 1;
+		FI_INFO(&psmx_prov, FI_LOG_CORE,
+			"PSM AM compat mode enabled: appliation %d.%d, library %d.%d.\n",
 			PSM_VERNO_MAJOR, PSM_VERNO_MINOR, major, minor);
-		return NULL;
 	}
+#endif
 
 	psmx_init_count++;
 	return (&psmx_prov);

--- a/prov/psm2/src/rename.h
+++ b/prov/psm2/src/rename.h
@@ -37,11 +37,16 @@
 #define psmx_am_ack_rma psmx2_am_ack_rma
 #define psmx_am_atomic_completion psmx2_am_atomic_completion
 #define psmx_am_atomic_handler psmx2_am_atomic_handler
+#define psmx_am_compat_atomic_handler psmx2_am_compat_atomic_handler
+#define psmx_am_compat_mode psmx2_am_compat_mode
+#define psmx_am_compat_msg_handler psmx2_am_compat_msg_handler
+#define psmx_am_compat_rma_handler psmx2_am_compat_rma_handler
 #define psmx_am_enqueue_recv psmx2_am_enqueue_recv
 #define psmx_am_enqueue_rma psmx2_am_enqueue_rma
 #define psmx_am_enqueue_send psmx2_am_enqueue_send
 #define psmx_am_enqueue_unexp psmx2_am_enqueue_unexp
 #define psmx_am_fini psmx2_am_fini
+#define psmx_am_get_source psmx2_am_get_source
 #define psmx_am_handlers psmx2_am_handlers
 #define psmx_am_handlers_idx psmx2_am_handlers_idx
 #define psmx_am_handlers_initialized psmx2_am_handlers_initialized


### PR DESCRIPTION
The AM handler has different signature in PSM and PSM2. That
is the reason why the psm provider can't run with the psm2-compat
library even if the library is ABI compatible with the PSM
library (AM is not a public interface in PSM).

This patch adds an AM compatibility layer to the psm provider
so that it can work with both the original PSM library and the
psm2-compat library (on the respective supported HW, of course).

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>