### PR TITLE
verbs: fix warnings revealed by PR #1452

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -177,7 +177,8 @@ static ssize_t fi_ibv_rdm_tagged_ep_cancel(fid_t fid, void *ctx)
 
 	struct fi_ibv_rdm_tagged_request *request = context->internal[0];
 
-	VERBS_DBG("ep_cancel, match %p, tag 0x%llx, len %d, ctx %p\n",
+	VERBS_DBG(FI_LOG_EP_DATA,
+		  "ep_cancel, match %p, tag 0x%llx, len %d, ctx %p\n",
 		  request, (long long unsigned)request->tag,
 		  request->len, request->context);
 
@@ -198,7 +199,8 @@ static ssize_t fi_ibv_rdm_tagged_ep_cancel(fid_t fid, void *ctx)
 		fi_ibv_mem_pool_return(&request->mpe,
 				       &fi_ibv_rdm_tagged_request_pool);
 
-		VERBS_DBG("\t\t-> SUCCESS, pend recv %d\n", fid_ep->pend_recv);
+		VERBS_DBG(FI_LOG_EP_DATA,
+			  "\t\t-> SUCCESS, pend recv %d\n", fid_ep->pend_recv);
 
 		err = 0;
 	}

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -291,13 +291,13 @@ fi_ibv_rdm_tagged_push_buff_pointer(char *area_start, size_t area_size,
 {
 	char *buff_tmp = (*buff) + offset;
 
-	VERBS_DBG("old_pointer: %p, sn = %d\n", *buff,
+	VERBS_DBG(FI_LOG_EP_DATA, "old_pointer: %p, sn = %d\n", *buff,
 		  fi_ibv_rdm_tagged_get_buff_service_data(*buff)->seq_number);
 
 	(*buff) = buff_tmp < (area_start + area_size) ?
 		  buff_tmp : area_start + FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE;
 
-	VERBS_DBG("new_pointer: %p, sn = %d\n", *buff,
+	VERBS_DBG(FI_LOG_EP_DATA, "new_pointer: %p, sn = %d\n", *buff,
 		  fi_ibv_rdm_tagged_get_buff_service_data(*buff)->seq_number);
 	assert(fi_ibv_rdm_tagged_get_buff_service_data(*buff)->seq_number ==
 		(((*buff) - (area_start + FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE)) /
@@ -321,7 +321,7 @@ fi_ibv_rdm_tagged_get_rbuf(struct fi_ibv_rdm_tagged_conn *conn,
 	char *rbuf = (conn->rbuf_mem_reg +
 		      FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE +
 		      (seq_num * ep->buff_len));
-	VERBS_DBG("recv buf %d\n", seq_num);
+	VERBS_DBG(FI_LOG_EP_DATA, "recv buf %d\n", seq_num);
 	assert(fi_ibv_rdm_tagged_get_buff_service_data(rbuf)->seq_number ==
 		seq_num);
 	return (struct fi_ibv_rdm_tagged_buf *) rbuf;

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -36,6 +36,7 @@
 #include <alloca.h>
 #include <malloc.h>
 #include <stddef.h>
+#include <inttypes.h>
 #include <string.h>
 #include <sys/types.h>
 
@@ -134,7 +135,7 @@ fi_verbs_mem_pool_get(struct fi_ibv_mem_pool *pool)
 		rst = (struct fi_ibv_mem_pool_entry *)calloc(1, pool->entry_size);
 		rst->is_malloced = 1;
 		pool->current_size++;
-		VERBS_DBG("MALLOCED: %p, %d\n", rst, pool->current_size);
+		VERBS_DBG(FI_LOG_FABRIC, "MALLOCED: %p, %d\n", rst, pool->current_size);
 	}
 	return rst;
 }
@@ -145,7 +146,7 @@ fi_ibv_mem_pool_return(struct fi_ibv_mem_pool_entry *entry,
 {
 	if (entry->is_malloced) {
 		pool->current_size--;
-		VERBS_DBG("FREED: %p, %d\n", entry, pool->current_size);
+		VERBS_DBG(FI_LOG_FABRIC, "FREED: %p, %d\n", entry, pool->current_size);
 		free(entry);
 	} else {
 		entry->next = pool->head;
@@ -175,7 +176,7 @@ static inline void fi_ibv_mem_pool_fini(struct fi_ibv_mem_pool *pool)
             strcat(str, str2);                          \
         }                                               \
                                                         \
-        VERBS_DBG("%s\n", str);                         \
+        VERBS_DBG(FI_LOG_EP_DATA, "%s\n", str);         \
     } while(0)
 #else                           // ENABLE_DEBUG
 #define FI_IBV_PRINT_LIST(list, name)
@@ -201,8 +202,8 @@ do {                                                                        \
     const size_t max_str_len = 1024;                                        \
     char str[max_str_len];                                                  \
     snprintf(str, max_str_len,                                              \
-            "%s request: %p, eager_state: %s, rndv_state: %s, tag: 0x%llx," \
-            "len: %d context: %p, connection: %p\n",                        \
+            "%s request: %p, eager_state: %s, rndv_state: %s, "             \
+            "tag: 0x%" PRIx64 ", len: %d context: %p, connection: %p\n",    \
             prefix,                                                         \
             request,                                                        \
             fi_ibv_rdm_tagged_req_eager_state_to_str(request->state.eager), \
@@ -217,11 +218,11 @@ do {                                                                        \
         case FI_LOG_WARN:                                                   \
         case FI_LOG_TRACE:                                                  \
         case FI_LOG_INFO:                                                   \
-            fprintf(stderr, str);                                           \
+            fprintf(stderr, "%s", str);                                     \
             break;                                                          \
         case FI_LOG_DEBUG:                                                  \
         default:                                                            \
-            VERBS_DBG(str);                                                 \
+            VERBS_DBG(FI_LOG_EP_DATA, "%s", str);                           \
             break;                                                          \
     }                                                                       \
 } while (0);


### PR DESCRIPTION
If you build the verbs provider with `--enable-debug` and the warnings
enabled by PR #1452 then you will get a ton of printf/logging related
warnings from the compiler.  This commit fixes all the ones that Clang
pointed out on my system.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>