### PR TITLE
prov/psm: add parameter for progress thread suppression

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -601,6 +601,7 @@ struct psmx_env {
 	char *uuid;
 	int delay;
 	int timeout;
+	int prog_thread;
 	int prog_interval;
 	char *prog_affinity;
 };

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -295,7 +295,7 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain_priv->caps = info->caps;
 	domain_priv->fabric = fabric_priv;
 	domain_priv->progress_thread_enabled =
-		(info->domain_attr->data_progress == FI_PROGRESS_AUTO);
+		(info->domain_attr->data_progress == FI_PROGRESS_AUTO && psmx_env.prog_thread);
 
 	psm_ep_open_opts_get_defaults(&opts);
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -42,6 +42,7 @@ struct psmx_env psmx_env = {
 	.uuid		= PSMX_DEFAULT_UUID,
 	.delay		= 1,
 	.timeout	= 5,
+	.prog_thread	= 1,
 	.prog_interval	= -1,
 	.prog_affinity	= NULL,
 };
@@ -57,6 +58,7 @@ static void psmx_init_env(void)
 	fi_param_get_str(&psmx_prov, "uuid", &psmx_env.uuid);
 	fi_param_get_int(&psmx_prov, "delay", &psmx_env.delay);
 	fi_param_get_int(&psmx_prov, "timeout", &psmx_env.timeout);
+	fi_param_get_int(&psmx_prov, "prog_thread", &psmx_env.prog_thread);
 	fi_param_get_int(&psmx_prov, "prog_interval", &psmx_env.prog_interval);
 	fi_param_get_str(&psmx_prov, "prog_affinity", &psmx_env.prog_affinity);
 }
@@ -561,6 +563,10 @@ PROVIDER_INI
 
 	fi_param_define(&psmx_prov, "timeout", FI_PARAM_INT,
 			"Timeout (seconds) for gracefully closing the PSM endpoint");
+
+	fi_param_define(&psmx_prov, "prog_thread", FI_PARAM_BOOL,
+			"Whether to allow the creation of progress thread or not "
+			"(default: yes)");
 
 	fi_param_define(&psmx_prov, "prog_interval", FI_PARAM_INT,
 			"Interval (microseconds) between progress calls made in the "


### PR DESCRIPTION
By default, the progress thread is created if the application asks
for auto progress support. The progress thread has minor but still
measurable impact on the performance and the effect can be more
noticeable on certain platforms with slower cores. There are cases
that auto progress is not really needed but the application still
asks for it blindly. In such cases, turning of the progress thread
can improve the performance without affecting the functionality.

The parameter FI_PSM_PROG_THREAD / FI_PSM2_PROG_THREAD determines
if the progress thread is allowed to be created. When set to "no",
no progress thread is created even if auto progress is asked for.
The default setting is "yes" which means the progress thread can
be created when needed.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>