### PR TITLE
Bunch of cleanups for verbs/RDM

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -123,8 +123,10 @@ static int fi_ibv_rdm_av_insert(struct fid_av *av, const void *addr,
 			 * side.
 			 */
 			conn = memalign(64, sizeof *conn);
-			if (!conn)
-				return -FI_ENOMEM;
+			if (!conn) {
+				ret = -FI_ENOMEM;
+				goto out;
+			}
 
 			memset(conn, 0, sizeof *conn);
 			dlist_init(&conn->postponed_requests_head);
@@ -143,6 +145,7 @@ static int fi_ibv_rdm_av_insert(struct fid_av *av, const void *addr,
 		ret++;
 	}
 
+out:
 	pthread_mutex_unlock(&ep->cm_lock);
 	return ret;
 }

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -50,7 +50,7 @@ int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 		return 0;
 
 	if (ep->is_closing) {
-		FI_IBV_ERROR("Attempt to start connection with addr "
+		VERBS_INFO(FI_LOG_CORE, "Attempt to start connection with addr "
 		FI_IBV_RDM_ADDR_STR_FORMAT" when ep is closing\n",
 		FI_IBV_RDM_ADDR_STR(conn->addr));
 		return -1;

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -50,7 +50,7 @@ int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 		return 0;
 
 	if (ep->is_closing) {
-		VERBS_INFO(FI_LOG_CORE, "Attempt to start connection with addr "
+		VERBS_INFO(FI_LOG_AV, "Attempt to start connection with addr "
 		FI_IBV_RDM_ADDR_STR_FORMAT" when ep is closing\n",
 		FI_IBV_RDM_ADDR_STR(conn->addr));
 		return -1;

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -64,12 +64,13 @@ int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 	sock_addr.sin_port = htons(sock_addr.sin_port);
 	sock_addr.sin_family = AF_INET;
 
-	rdma_create_id(ep->cm_listener_ec, &id, conn, RDMA_PS_TCP);
+	if (rdma_create_id(ep->cm_listener_ec, &id, conn, RDMA_PS_TCP))
+		return -1;
+
 	if (conn->is_active)
 		conn->id = id;
 
-	rdma_resolve_addr(id, NULL, (struct sockaddr *) &sock_addr, 30000);
-	return 0;
+	return rdma_resolve_addr(id, NULL, (struct sockaddr *)&sock_addr, 30000);
 }
 
 int fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_ep *ep,

--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -93,8 +93,11 @@ static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
 static ssize_t fi_ibv_rdm_tagged_cq_read(struct fid_cq *cq, void *buf,
                                          size_t count)
 {
-	fi_addr_t src_addr;
-	return fi_ibv_rdm_tagged_cq_readfrom(cq, buf, count, &src_addr);
+	struct fi_ibv_cq *_cq = container_of(cq, struct fi_ibv_cq, cq_fid);
+	const size_t _count = _cq->ep->n_buffs;
+	fi_addr_t addr[_count];
+
+	return fi_ibv_rdm_tagged_cq_readfrom(cq, buf, MIN(_count, count), addr);
 }
 
 #if 0

--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -83,7 +83,7 @@ static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
 	if (i == 0) {
 		int err = fi_ibv_rdm_tagged_poll(_cq->ep);
 		if (err < 0) {
-			FI_IBV_ERROR("fi_ibv_rdm_tagged_poll failed\n");
+			VERBS_INFO(FI_LOG_CQ, "fi_ibv_rdm_tagged_poll failed\n");
 		}
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -509,7 +509,12 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 
 	int fd = _ep->cm_listener_ec->fd;
 	int flags = fcntl(fd, F_GETFL, 0);
-	fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+	ret = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+	if (ret == -1) {
+		VERBS_INFO_ERRNO(FI_LOG_CORE, "fcntl", errno);
+		ret = -FI_EOTHER;
+		goto err;
+	}
 
 	if (rdma_create_id(_ep->cm_listener_ec,
 			   &_ep->cm_listener, NULL, RDMA_PS_TCP)) {
@@ -517,7 +522,6 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 			     strerror(errno));
 		ret = -FI_EOTHER;
 		goto err;
-
 	}
 
 	if (rdma_bind_addr(_ep->cm_listener,

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -178,7 +178,7 @@ static ssize_t fi_ibv_rdm_tagged_ep_cancel(fid_t fid, void *ctx)
 
 	struct dlist_entry *found =
 	    dlist_find_first_match(&fi_ibv_rdm_tagged_recv_posted_queue,
-				   fi_ibv_rdm_tagged_match_requests, request);
+				   fi_ibv_rdm_tagged_req_match, request);
 
 	if (found) {
 		assert(container_of(found, struct fi_ibv_rdm_tagged_request,

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -313,6 +313,7 @@ static int fi_ibv_rdm_tagged_ep_close(fid_t fid)
 					return ret;
 				}
 			}
+			break;
 		case FI_VERBS_CONN_ESTABLISHED:
 			fi_ibv_rdm_start_disconnection(ep, conn);
 			break;

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -268,7 +268,8 @@ static void *fi_ibv_rdm_tagged_cm_progress_thread(void *ctx)
 	struct fi_ibv_rdm_ep *ep = (struct fi_ibv_rdm_ep *)ctx;
 	while (_fi_ibv_rdm_tagged_cm_progress_running) {
 		if (fi_ibv_rdm_tagged_cm_progress(ep)) {
-			FI_IBV_ERROR("fi_ibv_rdm_cm_progress error\n");
+			VERBS_INFO (FI_LOG_EP_DATA,
+			"fi_ibv_rdm_cm_progress error\n");
 			abort();
 		}
 		usleep(FI_IBV_RDM_CM_THREAD_TIMEOUT);
@@ -307,7 +308,8 @@ static int fi_ibv_rdm_tagged_ep_close(fid_t fid)
 			       conn->state != FI_VERBS_CONN_REJECTED) {
 				ret = fi_ibv_rdm_tagged_cm_progress(ep);
 				if (ret) {
-					FI_IBV_ERROR("cm progress failed\n");
+					VERBS_INFO(FI_LOG_AV,
+						"cm progress failed\n");
 					return ret;
 				}
 			}
@@ -321,7 +323,7 @@ static int fi_ibv_rdm_tagged_ep_close(fid_t fid)
 	while (ep->num_active_conns) {
 		ret = fi_ibv_rdm_tagged_cm_progress(ep);
 		if (ret) {
-			FI_IBV_ERROR("cm progress failed\n");
+			VERBS_INFO(FI_LOG_AV, "cm progress failed\n");
 			return ret;
 		}
 	}
@@ -329,7 +331,7 @@ static int fi_ibv_rdm_tagged_ep_close(fid_t fid)
 	assert(0 == HASH_COUNT(fi_ibv_rdm_tagged_conn_hash) &&
 	       NULL == fi_ibv_rdm_tagged_conn_hash);
 
-	FI_INFO(&fi_ibv_prov, FI_LOG_AV, "DISCONNECT complete\n");
+	VERBS_INFO(FI_LOG_AV, "DISCONNECT complete\n");
 	rdma_destroy_id(ep->cm_listener);
 	ibv_destroy_cq(ep->scq);
 	ibv_destroy_cq(ep->rcq);
@@ -389,20 +391,20 @@ static inline int fi_ibv_rdm_tagged_test_addr(const char *devname,
 	struct rdma_cm_id *test_id;
 	int test = 0;
 	if (rdma_create_id(NULL, &test_id, NULL, RDMA_PS_TCP)) {
-		FI_IBV_ERROR("Failed to create test rdma cm id: %s\n",
+		VERBS_INFO(FI_LOG_CORE, "Failed to create test rdma cm id: %s\n",
 			     strerror(errno));
 		return -1;
 	}
 
 	if (rdma_bind_addr(test_id, (struct sockaddr *)addr)) {
-		FI_WARN(&fi_ibv_prov, FI_LOG_CORE,
+		VERBS_INFO(FI_LOG_CORE,
 			"Failed to bind cm listener to  addr : %s\n",
 			strerror(errno));
 		rdma_destroy_id(test_id);
 		return 0;
 	}
 
-	FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "device name: %s %s\n",
+	VERBS_INFO(FI_LOG_CORE, "device name: %s %s\n",
 		test_id->verbs->device->name, devname);
 
 	if (!strcmp(test_id->verbs->device->name, devname)) {
@@ -489,16 +491,18 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	if (fi_ibv_rdm_tagged_find_ipoib_addr
 	    (_ep, _domain->verbs->device->name)) {
 		ret = -FI_ENODEV;
-		FI_IBV_ERROR("Failed to find correct IPoIB address\n");
+		VERBS_INFO(FI_LOG_CORE,
+			   "Failed to find correct IPoIB address\n");
 		goto err;
 	}
 
-	FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "My IPoIB: %s\n",
+	VERBS_INFO(FI_LOG_CORE, "My IPoIB: %s\n",
 		_ep->my_ipoib_addr_str);
 	_ep->cm_listener_ec = rdma_create_event_channel();
 	if (!_ep->cm_listener_ec) {
-		FI_IBV_ERROR("Failed to create listener event channel: %s\n",
-			     strerror(errno));
+		VERBS_INFO(FI_LOG_CORE,
+			"Failed to create listener event channel: %s\n",
+			strerror(errno));
 		goto err;
 	}
 
@@ -508,7 +512,7 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 
 	if (rdma_create_id(_ep->cm_listener_ec,
 			   &_ep->cm_listener, NULL, RDMA_PS_TCP)) {
-		FI_IBV_ERROR("Failed to create cm listener: %s\n",
+		VERBS_INFO(FI_LOG_CORE, "Failed to create cm listener: %s\n",
 			     strerror(errno));
 		goto err;
 
@@ -516,20 +520,20 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 
 	if (rdma_bind_addr(_ep->cm_listener,
 			   (struct sockaddr *)&_ep->my_ipoib_addr)) {
-		FI_IBV_ERROR
-		    ("Failed to bind cm listener to my IPoIB addr %s: %s\n",
-		     _ep->my_ipoib_addr_str, strerror(errno));
+		VERBS_INFO(FI_LOG_CORE,
+			"Failed to bind cm listener to my IPoIB addr %s: %s\n",
+			_ep->my_ipoib_addr_str, strerror(errno));
 		goto err;
 
 	}
 	if (rdma_listen(_ep->cm_listener, 1024)) {
-		FI_IBV_ERROR("rdma_listen failed: %s\n", strerror(errno));
+		VERBS_INFO(FI_LOG_CORE, "rdma_listen failed: %s\n",
+			strerror(errno));
 		goto err;
 	}
 
 	_ep->cm_listener_port = ntohs(rdma_get_src_port(_ep->cm_listener));
-	FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "listener port: %d\n",
-		_ep->cm_listener_port);
+	VERBS_INFO(FI_LOG_CORE, "listener port: %d\n", _ep->cm_listener_port);
 
 	size_t s1 = sizeof(_ep->my_ipoib_addr.sin_addr.s_addr);
 	size_t s2 = sizeof(_ep->cm_listener_port);
@@ -538,7 +542,7 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	memcpy(_ep->my_rdm_addr, &_ep->my_ipoib_addr.sin_addr.s_addr, s1);
 	memcpy(_ep->my_rdm_addr + s1, &_ep->cm_listener_port, s2);
 
-	FI_INFO(&fi_ibv_prov, FI_LOG_AV,
+	VERBS_INFO(FI_LOG_AV,
 		"My ep_addr: " FI_IBV_RDM_ADDR_STR_FORMAT "\n",
 		FI_IBV_RDM_ADDR_STR(_ep->my_rdm_addr));
 
@@ -583,15 +587,13 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->scq = ibv_create_cq(_ep->domain->verbs, _ep->scq_depth, _ep,
 				 NULL, 0);
 	if (_ep->scq == NULL) {
-		FI_IBV_ERROR("Failed to create EP scq: errno %d : %s\n",
-			     errno, strerror(errno));
+		VERBS_INFO_ERRNO(FI_LOG_CORE, "ibv_create_cq", errno);
 	}
 
 	_ep->rcq =
 	    ibv_create_cq(_ep->domain->verbs, _ep->rcq_depth, _ep, NULL, 0);
 	if (_ep->rcq == NULL) {
-		FI_IBV_ERROR("Failed to create EP rcq: errno %d : %s\n",
-			     errno, strerror(errno));
+		VERBS_INFO_ERRNO(FI_LOG_CORE, "ibv_create_cq", errno);
 	}
 
 	*ep = &_ep->ep_fid;
@@ -604,11 +606,9 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 			     &fi_ibv_rdm_tagged_cm_progress_thread,
 			     (void *)_ep);
 	if (ret) {
-		FI_IBV_ERROR("Failed to launch CM progress thread, err :%d\n",
-			     ret);
+		VERBS_INFO(FI_LOG_CORE,
+			"Failed to launch CM progress thread, err :%d\n", ret);
 	}
-
-	FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "Successfully done: %d\n", ret);
 
 	return ret;
 err:

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -97,7 +97,7 @@ fi_ibv_rdm_tagged_batch_repost_receives(struct fi_ibv_rdm_tagged_conn *conn,
 		}
 
 		if (!found) {
-			FI_IBV_ERROR("Failed to post recv\n");
+			VERBS_INFO(FI_LOG_EP_DATA, "Failed to post recv\n");
 		}
 
 		ret = i;
@@ -174,18 +174,17 @@ fi_ibv_rdm_tagged_process_addr_resolved(struct rdma_cm_id *id,
 	assert(id->verbs == ep->domain->verbs);
 	fi_ibv_rdm_tagged_init_qp_attributes(&qp_attr, ep);
 	if (rdma_create_qp(id, ep->domain->pd, &qp_attr)) {
-		fprintf(stderr, "rdma_create_qp failed\n");
+		VERBS_INFO(FI_LOG_AV, "rdma_create_qp failed\n");
 	}
 
 	if (conn->is_active) {
 		assert(id == conn->id);
 		fi_ibv_rdm_tagged_prepare_conn_memory(ep, conn);
 		conn->qp = id->qp;
-		if (ep->rq_wr_depth != fi_ibv_rdm_tagged_repost_receives(conn, ep,
-						      ep->rq_wr_depth)) {
-			fprintf(stderr, "repost receives failed\n");
-			/* TODO: replace with return and proper error handling */
-			abort();
+		if (ep->rq_wr_depth != fi_ibv_rdm_tagged_repost_receives(conn,
+			ep, ep->rq_wr_depth)) {
+			VERBS_INFO(FI_LOG_AV, "repost receives failed\n");
+			return -FI_ENOMEM;
 		}
 
 	}
@@ -445,7 +444,8 @@ int fi_ibv_rdm_tagged_conn_cleanup(struct fi_ibv_rdm_ep *ep,
 
 	rdma_destroy_qp(conn->id);
 	if ((ret = rdma_destroy_id(conn->id))) {
-		FI_IBV_ERROR("rdma_destroy_id failed, ret = %d\n", ret);
+		VERBS_INFO(FI_LOG_AV, 
+			"rdma_destroy_id failed, ret = %d\n", ret);
 	}
 	fi_ibv_rdm_tagged_deregister_and_free(&conn->s_mr, &conn->sbuf_mem_reg);
 	fi_ibv_rdm_tagged_deregister_and_free(&conn->r_mr, &conn->rbuf_mem_reg);
@@ -542,7 +542,7 @@ static int fi_ibv_rdm_tagged_process_event(struct rdma_cm_event *event,
 
 	default:
 		ret = FI_EOTHER;
-		FI_IBV_ERROR("got unexpected rdmacm event, %s\n",
+		VERBS_INFO(FI_LOG_AV, "got unexpected rdmacm event, %s\n",
 			     rdma_event_str(event->event));
 		abort();
 		break;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -48,12 +48,12 @@ fi_ibv_rdm_tagged_malloc_and_register(struct fi_ibv_rdm_ep *ep, void **buf,
 				      size_t size)
 {
 	*buf = memalign(FI_IBV_RDM_MEM_ALIGNMENT, size);
-	if (!buf)
-		return NULL;
-
-	memset(*buf, 0, size);
-	return ibv_reg_mr(ep->domain->pd, *buf, size,
-			  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+	if (*buf) {
+		memset(*buf, 0, size);
+		return ibv_reg_mr(ep->domain->pd, *buf, size,
+				  IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+	}
+	return NULL;
 }
 
 int fi_ibv_rdm_tagged_deregister_and_free(struct ibv_mr **mr, char **buff)

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -421,7 +421,7 @@ fi_ibv_rdm_tagged_process_recv(struct fi_ibv_rdm_ep *ep,
 					found_request->len, found_request->conn,
 					found_request->tag,
 					found_request->tagmask);
-//				return -FI_EOTHER;
+				assert(0);
 			}
 
 			fi_ibv_rdm_tagged_remove_from_posted_queue

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -393,9 +393,6 @@ fi_ibv_rdm_tagged_process_recv(struct fi_ibv_rdm_ep *ep,
 		VERBS_DBG(FI_LOG_EP_DATA,
 			"GOT RNDV ACK from conn %p, id %d\n", conn, request);
 	} else {
-		const int data_len =
-		    arrived_len - sizeof(struct fi_ibv_rdm_tagged_header);
-
 		struct fi_verbs_rdm_tagged_request_minfo minfo = {
 			.conn = conn,
 			.tag = rbuf->header.tag,
@@ -404,7 +401,7 @@ fi_ibv_rdm_tagged_process_recv(struct fi_ibv_rdm_ep *ep,
 
 		struct dlist_entry *found_entry =
 		    dlist_find_first_match(&fi_ibv_rdm_tagged_recv_posted_queue,
-					   fi_verbs_rdm_tagged_match_request_by_minfo,
+					   fi_ibv_rdm_tagged_req_match_by_info,
 					   &minfo);
 
 		if (found_entry) {
@@ -412,6 +409,9 @@ fi_ibv_rdm_tagged_process_recv(struct fi_ibv_rdm_ep *ep,
 			    container_of(found_entry,
 					 struct fi_ibv_rdm_tagged_request,
 					 queue_entry);
+
+			const int data_len = arrived_len -
+				sizeof(struct fi_ibv_rdm_tagged_header);
 
 			if (found_request->len < data_len) {
 				FI_IBV_ERROR

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -582,7 +582,7 @@ fi_ibv_rdm_tagged_init_recv_request(struct fi_ibv_rdm_tagged_request *request,
 
 	struct dlist_entry *found_entry =
 	    dlist_find_first_match(&fi_ibv_rdm_tagged_recv_unexp_queue,
-				   fi_verbs_rdm_tagged_match_request_by_minfo_with_tagmask,
+				   fi_ibv_rdm_tagged_req_match_by_info2,
 				   &minfo);
 
 	if (found_entry) {

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -218,12 +218,11 @@ static enum fi_rdm_tagged_req_hndl_ret
 fi_ibv_rdm_tagged_err_hndl(struct fi_ibv_rdm_tagged_request *request,
 			   void *data)
 {
-	FI_IBV_ERROR("\t> IN\t< eager_state = %s, rndv_state = %s, len = %d\n",
-		     fi_ibv_rdm_tagged_req_eager_state_to_str
-		     (request->state.eager),
-		     fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.
-							     rndv),
-		     request->len);
+	VERBS_INFO(FI_LOG_EP_DATA,
+		"\t> IN\t< eager_state = %s, rndv_state = %s, len = %d\n",
+		fi_ibv_rdm_tagged_req_eager_state_to_str(request->state.eager),
+		fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.rndv),
+		request->len);
 
 	assert(0);
 	return FI_EP_RDM_HNDL_NOT_INIT;
@@ -351,9 +350,8 @@ fi_ibv_rdm_tagged_eager_send_ready(struct fi_ibv_rdm_tagged_request *request,
 
 	ret = ibv_post_send(conn->qp, &wr, &bad_wr);
 	if (ret) {
-		FI_IBV_ERROR
-		    ("ibv_post_send fail, ret %d, errno %d, strerror %s", ret,
-		     errno, strerror(errno));
+		VERBS_INFO_ERRNO(FI_LOG_EP_DATA, "ibv_post_send", errno);
+
 		assert(0);
 	};
 
@@ -450,9 +448,7 @@ fi_ibv_rdm_tagged_rndv_rts_send_ready(struct fi_ibv_rdm_tagged_request *request,
 	mr = ibv_reg_mr(p->ep->domain->pd, (void *)request->src_addr,
 			request->len, IBV_ACCESS_REMOTE_READ);
 	if (NULL == mr) {
-		FI_IBV_ERROR("%s ibv_reg_mr fail, buf %p, len %d,"
-			     " errno %d:%s", __FUNCTION__, request->src_addr,
-			     (int)request->len, errno, strerror(errno));
+		VERBS_INFO_ERRNO(FI_LOG_EP_DATA, "ibv_reg_mr", errno);
 		assert(0);
 		return FI_EOTHER;
 	}
@@ -473,13 +469,11 @@ fi_ibv_rdm_tagged_rndv_rts_send_ready(struct fi_ibv_rdm_tagged_request *request,
 	     (int)wr.imm_data, p->ep->pend_send);
 
 	FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS_REQ(request, p->ep, wr.send_flags);
-	VERBS_DBG(FI_LOG_EP_DATA, "posted %d bytes, conn %p, tag 0x%llx\n", sge.length,
-		     request->conn, request->tag);
+	VERBS_DBG(FI_LOG_EP_DATA, "posted %d bytes, conn %p, tag 0x%llx\n",
+		sge.length, request->conn, request->tag);
 	int ret = ibv_post_send(conn->qp, &wr, &bad_wr);
 	if (ret) {
-		FI_IBV_ERROR
-		    ("ibv_post_send fail, ret %d, errno %d, strerror %s\n", ret,
-		     errno, strerror(errno));
+		VERBS_INFO_ERRNO(FI_LOG_EP_DATA, "ibv_post_send", errno);
 		assert(0);
 	};
 
@@ -540,8 +534,7 @@ fi_ibv_rdm_tagged_rndv_end(struct fi_ibv_rdm_tagged_request *request,
 
 	int ret = ibv_dereg_mr(request->rndv_mr);
 	if (ret) {
-		FI_IBV_ERROR("%s: ibv_dereg_mr failed: ret %d, errno %d : %s",
-			     __FUNCTION__, ret, errno, strerror(errno));
+		VERBS_INFO_ERRNO(FI_LOG_EP_DATA, "ibv_dereg_mr", errno);
 	}
 
 	request->state.rndv = FI_IBV_STATE_RNDV_SEND_END;
@@ -592,13 +585,12 @@ fi_ibv_rdm_tagged_init_recv_request(struct fi_ibv_rdm_tagged_request *request,
 				 queue_entry);
 
 		if (request->len < found_request->len) {
-			FI_IBV_ERROR("%s: %d RECV TRUNCATE, unexp len %d, "
-				     "req->len=%d, conn %p, tag 0x%llx, "
-				     "tagmask %llx\n",
-				     __FUNCTION__, __LINE__, found_request->len,
-				     request->len, request->conn,
-				     (long long unsigned int)request->tag,
-				     (long long unsigned int)request->tagmask);
+			VERBS_INFO(FI_LOG_EP_DATA,
+				"RECV TRUNCATE, unexp len %d, "
+				"req->len=%d, conn %p, tag 0x%llx, "
+				"tagmask %llx\n",
+				found_request->len, request->len, request->conn,
+				request->tag, request->tagmask);
 			abort();
 		}
 
@@ -689,8 +681,8 @@ fi_ibv_rdm_tagged_init_unexp_recv_request(
 			    (struct fi_ibv_rdm_tagged_unexp_rbuff *)
 			    fi_verbs_mem_pool_get
 			    (&fi_ibv_rdm_tagged_unexp_buffers_pool);
-			memcpy(request->unexp_rbuf->payload,
-				rbuf->payload, request->len);
+			memcpy(request->unexp_rbuf->payload, rbuf->payload,
+				request->len);
 		} else {
 			request->unexp_rbuf = NULL;
 		}
@@ -720,8 +712,9 @@ fi_ibv_rdm_tagged_init_unexp_recv_request(
 		assert(0);
 		break;
 	default:
-		FI_IBV_ERROR("Got unknown unexpected pkt: %" PRIu64
-			     "\n", p->pkt_type);
+		VERBS_INFO(FI_LOG_EP_DATA,
+			"Got unknown unexpected pkt: %" PRIu64 "\n",
+			p->pkt_type);
 		assert(0);
 	}
 
@@ -862,9 +855,7 @@ fi_ibv_rdm_tagged_rndv_recv_post_read(struct fi_ibv_rdm_tagged_request *request,
 		     request->conn, request->tag);
 	ret = ibv_post_send(request->conn->qp, &wr, &bad_wr);
 	if (ret) {
-		FI_IBV_ERROR
-		    ("ibv_post_send fail, ret %d, errno %d, strerror %s", ret,
-		     errno, strerror(errno));
+		VERBS_INFO_ERRNO(FI_LOG_EP_DATA, "ibv_post_send", errno);
 		assert(0);
 		return FI_EP_RDM_HNDL_ERROR;
 	};
@@ -938,9 +929,7 @@ fi_ibv_rdm_tagged_rndv_recv_read_lc(struct fi_ibv_rdm_tagged_request *request,
 			"pend_send = %d\n", conn, conn->sends_outgoing,
 			p->ep->pend_send);
 	} else {
-		FI_IBV_ERROR
-		    ("ibv_post_send fail, ret %d, errno %d, strerror %s\n", ret,
-		     errno, strerror(errno));
+		VERBS_INFO_ERRNO(FI_LOG_EP_DATA, "ibv_post_send", errno);
 		assert(0);
 	}
 	request->state.eager = FI_IBV_STATE_EAGER_SEND_WAIT4LC;

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -36,39 +36,40 @@
 #include "verbs_rdm.h"
 
 
-/* TODO: Use of const is inconsistent throughout call stack */
-
-int fi_ibv_rdm_tagged_match_requests(struct dlist_entry *item,
-				     const void *other)
+int fi_ibv_rdm_tagged_req_match(struct dlist_entry *item, const void *other)
 {
 	const struct fi_ibv_rdm_tagged_request *req = other;
 	return (item == &req->queue_entry);
 }
 
-int fi_verbs_rdm_tagged_match_request_by_minfo(struct dlist_entry *item,
-					       const void *other)
+int fi_ibv_rdm_tagged_req_match_by_info(struct dlist_entry *item,
+					  const void *info)
 {
 	struct fi_ibv_rdm_tagged_request *request =
 	    container_of(item, struct fi_ibv_rdm_tagged_request, queue_entry);
 
-	const struct fi_verbs_rdm_tagged_request_minfo *minfo = other;
+	const struct fi_verbs_rdm_tagged_request_minfo *minfo = info;
 
 	return (((request->conn == NULL) || (request->conn == minfo->conn)) &&
 		((request->tag & request->tagmask) ==
-		 (minfo->tag & request->tagmask)));
+		 (minfo->tag   & request->tagmask)));
 }
 
-int fi_verbs_rdm_tagged_match_request_by_minfo_with_tagmask(
-		struct dlist_entry *item, const void *other)
+/*
+ * The same as fi_ibv_rdm_tagged_req_match_by_info but conn and tagmask fields
+ * if info are used for matching instead of request's ones
+ */
+int fi_ibv_rdm_tagged_req_match_by_info2(struct dlist_entry *item,
+					 const void *info)
 {
 	struct fi_ibv_rdm_tagged_request *request =
 	    container_of(item, struct fi_ibv_rdm_tagged_request, queue_entry);
 
-	const struct fi_verbs_rdm_tagged_request_minfo *minfo = other;
+	const struct fi_verbs_rdm_tagged_request_minfo *minfo = info;
 
 	return (((minfo->conn == NULL) || (request->conn == minfo->conn)) &&
 		((request->tag & minfo->tagmask) ==
-		 (minfo->tag & minfo->tagmask)));
+		 (minfo->tag   & minfo->tagmask)));
 }
 
 void fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *item,

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -73,16 +73,6 @@ struct fi_ibv_msg_ep;
 
 #define FI_IBV_RDM_CM_RESOLVEADDR_TIMEOUT (30000)
 
-/* TODO: remove */
-#define FI_IBV_ERROR(format, ...) do {                                  \
-		char _hostname[100];                                    \
-		gethostname(_hostname, sizeof(_hostname));              \
-		fprintf(stderr, "[%s:%d] libfabric:verbs:%s:%d:<error>:"format, \
-		_hostname, getpid(),                                    \
-		__FUNCTION__, __LINE__, ##__VA_ARGS__);                 \
-	} while(0)
-
-
 /* TODO: Create and use a common abstraction */
 
 /* memory pool utils

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -208,7 +208,7 @@ do {                                                                        \
         case FI_LOG_WARN:                                                   \
         case FI_LOG_TRACE:                                                  \
         case FI_LOG_INFO:                                                   \
-            fprintf(stderr, "%s", str);                                     \
+            VERBS_INFO(FI_LOG_EP_DATA, "%s", str);                          \
             break;                                                          \
         case FI_LOG_DEBUG:                                                  \
         default:                                                            \

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -234,18 +234,16 @@ do {                                                                        \
 #endif                          // ENABLE_DEBUG
 
 struct fi_verbs_rdm_tagged_request_minfo {
-	struct fi_ibv_rdm_tagged_conn *conn;
-	uint64_t                       tag;
-	size_t                         tagmask;
+	struct fi_ibv_rdm_tagged_conn	*conn;
+	uint64_t			tag;
+	uint64_t			tagmask;
 } ;
 
-/* TODO: Get usable names */
-int fi_ibv_rdm_tagged_match_requests(struct dlist_entry *item,
-                                     const void *other);
-int fi_verbs_rdm_tagged_match_request_by_minfo(struct dlist_entry *item,
-                                               const void *other);
-int fi_verbs_rdm_tagged_match_request_by_minfo_with_tagmask(
-		struct dlist_entry *item, const void *other);
+int fi_ibv_rdm_tagged_req_match(struct dlist_entry *item, const void *other);
+int fi_ibv_rdm_tagged_req_match_by_info(struct dlist_entry *item,
+                                        const void *info);
+int fi_ibv_rdm_tagged_req_match_by_info2(struct dlist_entry *item,
+                                         const void *info);
 void fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *item,
                                               const void *arg);
 

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -432,22 +432,24 @@ int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		goto err3;
 	}
 
-    if (attr->format != FI_CQ_FORMAT_TAGGED) {
-        _cq->cq = ibv_create_cq(_cq->domain->verbs, attr->size, _cq,
-                    _cq->channel, attr->signaling_vector);
-        if (!_cq->cq) {
-            ret = -errno;
-            goto err3;
-        }
+	if (!_cq->domain->rdm) {
+		_cq->cq = ibv_create_cq(_cq->domain->verbs, attr->size, _cq,
+		_cq->channel, attr->signaling_vector);
 
-        if (_cq->channel) {
-            ret = ibv_req_notify_cq(_cq->cq, 0);
-            if (ret) {
-                FI_WARN(&fi_ibv_prov, FI_LOG_CQ, "ibv_req_notify_cq failed\n");
-                goto err4;
-            }
-        }
-    }
+		if (!_cq->cq) {
+			ret = -errno;
+			goto err3;
+		}
+
+		if (_cq->channel) {
+			ret = ibv_req_notify_cq(_cq->cq, 0);
+			if (ret) {
+				FI_WARN(&fi_ibv_prov, FI_LOG_CQ,
+					"ibv_req_notify_cq failed\n");
+				goto err4;
+			}
+		}
+	}
 
 	_cq->flags |= attr->flags;
 	_cq->wait_cond = attr->wait_cond;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -692,13 +692,13 @@ static int fi_ibv_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 
 	fi->caps		= ep_dom->caps;
 	fi->handle		= NULL;
-    if (ep_dom->type == FI_EP_RDM) {
-        fi->mode		= VERBS_RDM_MODE;
-        *(fi->tx_attr)	= verbs_tx_rdm_attr;
-    } else {
-        fi->mode		= VERBS_MODE;
-        *(fi->tx_attr)	= verbs_tx_attr;
-    }
+	if (ep_dom->type == FI_EP_RDM) {
+		fi->mode	= VERBS_RDM_MODE;
+		*(fi->tx_attr)	= verbs_tx_rdm_attr;
+	} else {
+		fi->mode	= VERBS_MODE;
+		*(fi->tx_attr)	= verbs_tx_attr;
+	}
 
 	*(fi->rx_attr)		= verbs_rx_attr;
 	*(fi->ep_attr)		= verbs_ep_attr;


### PR DESCRIPTION
Per commits:
1) CQ opening difference for RDM/MSG replaced by domain->rdm statement instead of attr->format
2) Rename request matching functions
3) Remove FI_IBV_ERROR macro, used VERBS_INFO. Add return code in case of unsuccessful repost receives
4) Error handling in fi_ibv_open_rdm_ep
5) Fix 6 coverity issues
6) verbs: verbs_util macros do not use fi_log correctly #1463