### PR TITLE
prov/psm2: use rbtree for mr key mapping

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -66,7 +66,7 @@ extern "C" {
 #include "fi.h"
 #include "fi_enosys.h"
 #include "fi_list.h"
-#include "fi_indexer.h"
+#include "rbtree.h"
 #include "version.h"
 
 extern struct fi_provider psmx2_prov;
@@ -298,7 +298,7 @@ struct psmx2_fid_domain {
 	enum fi_mr_mode		mr_mode;
 	fastlock_t		mr_lock;
 	uint64_t		mr_reserved_key;
-	struct index_map	mr_map;
+	RbtHandle		mr_map;
 
 	fastlock_t		vl_lock;
 	uint64_t		vl_map[(PSMX2_MAX_VL+1)/sizeof(uint64_t)];

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -190,8 +190,8 @@ void psmx2_domain_release(struct psmx2_fid_domain *domain)
 	psmx2_am_fini(domain);
 
 	fastlock_destroy(&domain->poll_lock);
-
-	idm_reset(&domain->mr_map);
+	fastlock_destroy(&domain->vl_lock);
+	rbtDelete(domain->mr_map);
 	fastlock_destroy(&domain->mr_lock);
 
 #if 0
@@ -255,6 +255,11 @@ static struct fi_ops_domain psmx2_domain_ops = {
 	.stx_ctx = psmx2_stx_ctx,
 	.srx_ctx = fi_no_srx_context,
 };
+
+static int psmx2_key_compare(void *key1, void *key2)
+{
+	return (uint64_t)key1 - (uint64_t)key2;
+}
 
 int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		      struct fid_domain **domain, void *context)
@@ -331,14 +336,21 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			"fastlock_init(mr_lock) returns %d\n", err);
 		goto err_out_finalize_mq;
 	}
-	memset(&domain_priv->mr_map, 0, sizeof(struct index_map));
+
+	domain_priv->mr_map = rbtNew(&psmx2_key_compare);
+	if (!domain_priv->mr_map) {
+		FI_WARN(&psmx2_prov, FI_LOG_CORE,
+			"rbtNew failed\n");
+		goto err_out_destroy_mr_lock;
+	}
+
 	domain_priv->mr_reserved_key = 1;
 	
 	err = fastlock_init(&domain_priv->vl_lock);
 	if (err) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"fastlock_init(vl_lock) returns %d\n", err);
-		goto err_out_finalize_mq;
+		goto err_out_delete_mr_map;
 	}
 	memset(domain_priv->vl_map, 0, sizeof(domain_priv->vl_map));
 	domain_priv->vl_alloc = 0;
@@ -347,7 +359,7 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (err) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"fastlock_init(poll_lock) returns %d\n", err);
-		goto err_out_finalize_mq;
+		goto err_out_destroy_vl_lock;
 	}
 
 	/* Set active domain before psmx2_domain_enable_ep() installs the
@@ -370,6 +382,16 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 err_out_reset_active_domain:
 	fabric_priv->active_domain = NULL;
+	fastlock_destroy(&domain_priv->poll_lock);
+
+err_out_destroy_vl_lock:
+	fastlock_destroy(&domain_priv->vl_lock);
+
+err_out_delete_mr_map:
+	rbtDelete(domain_priv->mr_map);
+
+err_out_destroy_mr_lock:
+	fastlock_destroy(&domain_priv->mr_lock);
 
 err_out_finalize_mq:
 	psm2_mq_finalize(domain_priv->psm2_mq);

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -401,7 +401,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	psmx2_info->domain_attr->av_type = av_type;
 	psmx2_info->domain_attr->mr_mode = mr_mode;
-	psmx2_info->domain_attr->mr_key_size = sizeof(uint16_t); /* limited by IDX_MAX_INDEX */
+	psmx2_info->domain_attr->mr_key_size = sizeof(uint64_t);
 	psmx2_info->domain_attr->cq_data_size = 4;
 	psmx2_info->domain_attr->cq_cnt = 65535;
 	psmx2_info->domain_attr->ep_cnt = 65535;


### PR DESCRIPTION
index_map based implementation limits the effective key size to
16 bit, and it can't be efficiently extended to support full
64-bit key.

rbtree based implementation doesn't have the limitation. The
trade-off is the average lookup time is O(log(n)) instead of O(1).
this is not significant when the total number of MRs are small,
which is the normal case.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>