### PR TITLE
prov/sockets: set mr-key in memory registration, cleanup compare function for rbtree

### DIFF
--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -338,6 +338,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	if (res != RBT_STATUS_OK)
 		goto err;
 
+	_mr->key = key;
 	_mr->mr_fid.key = key;
 	_mr->mr_fid.mem_desc = (void *) (uintptr_t) key;
 	fastlock_release(&dom->lock);
@@ -468,7 +469,16 @@ static struct fi_ops_mr sock_dom_mr_ops = {
 
 static int sock_compare_mr_keys(void *key1, void *key2)
 {
-	return (uint64_t)key1 - (uint64_t)key2;
+	uint64_t k1, k2;
+	k1 = (uint64_t) key1;
+	k2 = (uint64_t) key2;
+
+        if (k1 > k2)
+                return 1;
+        else if (k1 < k2)
+		return -1;
+        else
+                return 0;
 }
 
 int sock_domain(struct fid_fabric *fabric, struct fi_info *info,


### PR DESCRIPTION
set mr-key in memory registration, cleanup compare function for rbtree

Signed-off-by: Jithin Jose <jithin.jose@intel.com>