### PR TITLE
prov/psm2: fix the compare function used for mr key mapping

### DIFF
--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -258,7 +258,7 @@ static struct fi_ops_domain psmx2_domain_ops = {
 
 static int psmx2_key_compare(void *key1, void *key2)
 {
-	return (uint64_t)key1 - (uint64_t)key2;
+	return (key1 > key2) ?  1 : ((key1 < key2) ? -1 : 0);
 }
 
 int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,


### PR DESCRIPTION
Direct substraction can underflow or overflow. Use comparison
instead.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>