### PR TITLE
Zero target buffer before receiving data for better error checking

### DIFF
--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -654,6 +654,7 @@ Test(rdm_tagged_sr, multi_tsend_trecv) {
 		}
 
 		for (i = 0; i < num_msgs; i++) {
+			memset(target, 0, BUF_SZ);
 			ret = fi_trecv(ep[0], target, BUF_SZ,
 				       fi_mr_desc(loc_mr),
 				       gni_addr[1], rtag, ignore, NULL);


### PR DESCRIPTION
This also happens to silence a valgrind uninitialized memory error,
due to the buffer only being written by the call to fi_trecv().

taken from ofi-cray/libfabric-cray#544

@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@ef21f9b64f9666d2ff4dab12f164c28dd0187e27)