### PR TITLE
Silence compiler warning when calling free().

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -951,6 +951,7 @@ static int  __gnix_discard_request(struct gnix_fid_ep *ep,
 					addr, req->msg.imm, tag);
 
 		/* data has already been delivered, so just discard it */
+		free((void *) req->msg.recv_addr);
 		_gnix_fr_free(ep, req);
 	}
 


### PR DESCRIPTION
Merge of ofi-cray/libfabric-cray#533

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@6e07a876f4c01448d650b019f0e260a2bd0fd6fa)

Conflicts:
	prov/gni/src/gnix_msg.c