### PR TITLE
Fix bug in gnix_fab_req usage and do a bit of cleanup

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -463,7 +463,6 @@ struct gnix_fab_req {
 	struct gnix_vc            *vc;
 	int                       (*work_fn)(void *);
 	int                       modes;
-	int                       retries;
 	uint64_t                  flags;
 	void                      *txd;
 	uint32_t                  tx_failures;

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -153,6 +153,10 @@ _gnix_fr_alloc(struct gnix_fid_ep *ep)
 		fr->slist.next = NULL;  /* slist stuff isn't too smart */
 	}
 
+	/* reset common fields */
+	fr->modes = 0;
+	fr->tx_failures = 0;
+
 	return fr;
 }
 

--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -562,7 +562,6 @@ ssize_t _gnix_atomic(struct gnix_fid_ep *ep,
 	req->amo.datatype = msg->datatype;
 	req->amo.op = msg->op;
 	req->flags = flags;
-	req->tx_failures = 0;
 
 	/* Inject interfaces always suppress completions.  If
 	 * SELECTIVE_COMPLETION is set, honor any setting.  Otherwise, always

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -704,6 +704,7 @@ static int __smsg_rndzv_start(void *data, void *msg)
 		req->addr = vc->peer_addr;
 		req->gnix_ep = ep;
 		req->vc = vc;
+		req->tx_failures = 0;
 
 		req->msg.send_addr = hdr->addr;
 		req->msg.send_len = hdr->len;

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -450,7 +450,6 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 	req->rma.len = len;
 	req->rma.imm = data;
 	req->flags = flags;
-	req->tx_failures = 0;
 
 	if (req->flags & FI_INJECT) {
 		memcpy(req->inject_buf, (void *)loc_addr, len);


### PR DESCRIPTION
The gnix_fab_req structures are allocated out of a freelist, and the
field are not zero'ed between uses.  This commit zeros common fields
(tx_failures and modes) in _gnix_fr_alloc(), and removes similar
initialization near call sites.  The tx_failure field also needs to be
reset when reusing the gnix_fab_req for the rendezvous message.

While in there, I also removed the unused retries field.

Merge from ofi-cray/libfabric-cray#537

@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit 42b78049c9fa0f620bc5293553899d607a65dd41)