### PR TITLE
prov/gni: disable gni provider if not enough fmas

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -470,8 +470,18 @@ GNI_INI
 	} else {
 		GNIX_INFO(FI_LOG_FABRIC, "_gnix_nics_per_rank failed: %d\n", rc);
 	}
+
 	if (getenv("GNIX_MAX_NICS") != NULL)
 		gnix_max_nics_per_ptag = atoi(getenv("GNIX_MAX_NICS"));
+
+	/*
+	 * if for some reason we can't even allocate a single nic, bail.
+	 */
+
+	if (gnix_max_nics_per_ptag == 0) {
+		GNIX_WARN(FI_LOG_FABRIC, "Insufficient network resources\n");
+		provider = NULL;
+	}
 
 	return (provider);
 }


### PR DESCRIPTION
On Cray XC systems using slurm, if the user doesn't
ask for exclusive use of nodes, there can be some
cases where the number of Aries FMA resources assigned
to the ranks of the job is insufficient.  In this
case, disable the gni provider.

Merge of ofi-cray/libfabric-cray#547
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 1c268369b65590b5388fb022fe7aee8c466bf305)