### PR TITLE
remove compile time warnings in av.c

### DIFF
--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -319,11 +319,10 @@ static void straddr_test(void)
 {
 	int ret;
 	int i;
-	char *buf;
+	const char *buf;
 	char address[128];
 	fi_addr_t addresses[SIMPLE_ADDR_COUNT];
 	fi_addr_t *compare;
-	fi_addr_t found;
 	size_t addrlen = sizeof(struct gnix_ep_name);
 
 	/* insert addresses */


### PR DESCRIPTION
Merge of ofi-cray/libfabric-cray#549

    Signed-off-by: Howard Pritchard <howardp@lanl.gov>

(cherry picked from commit ofi-cray/libfabric-cray@3a6793e060e7532affb658861ccfa95b98e7f63a)