### PR TITLE
prov/psm2: bug fix for writedata

### DIFF
--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -184,7 +184,7 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 			req->write.peer_addr = (void *)epaddr;
 			req->write.vl = dst_vl;
 			req->write.peer_vl = src_vl;
-			req->write.data = has_data ? *(uint64_t *)src: 0;
+			req->write.data = has_data ? args[4].u64 : 0;
 			req->cq_flags = FI_REMOTE_WRITE | FI_RMA |
 					(has_data ? FI_REMOTE_CQ_DATA : 0),
 			PSMX2_CTXT_TYPE(&req->fi_context) = PSMX2_REMOTE_WRITE_CONTEXT;


### PR DESCRIPTION
As part of recent change to the "write long" protocol the immediate
data has been moved from the payload to "args". This location was
left out from previous update.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>