### PR TITLE
prov/psm: use rbtree for mr key mapping

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -66,7 +66,7 @@ extern "C" {
 #include "fi.h"
 #include "fi_enosys.h"
 #include "fi_list.h"
-#include "fi_indexer.h"
+#include "rbtree.h"
 #include "version.h"
 
 extern struct fi_provider psmx_prov;
@@ -282,7 +282,7 @@ struct psmx_fid_domain {
 	enum fi_mr_mode		mr_mode;
 	fastlock_t		mr_lock;
 	uint64_t		mr_reserved_key;
-	struct index_map	mr_map;
+	RbtHandle		mr_map;
 
 	int			am_initialized;
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -466,7 +466,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	psmx_info->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	psmx_info->domain_attr->av_type = av_type;
 	psmx_info->domain_attr->mr_mode = mr_mode;
-	psmx_info->domain_attr->mr_key_size = sizeof(uint16_t); /* limited by IDX_MAX_INDEX */
+	psmx_info->domain_attr->mr_key_size = sizeof(uint64_t);
 	psmx_info->domain_attr->cq_data_size = 4;
 	psmx_info->domain_attr->cq_cnt = 65535;
 	psmx_info->domain_attr->ep_cnt = 65535;

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -32,79 +32,63 @@
 
 #include "psmx.h"
 
-#define PSMX_MR_RESERVED	((void *)-1)
-#define PSMX_MR_MAX_KEY		IDX_MAX_INDEX
-
 struct psmx_fid_mr *psmx_mr_get(struct psmx_fid_domain *domain, uint64_t key)
 {
+	RbtIterator it;
 	struct psmx_fid_mr *mr;
 
-	if (key > PSMX_MR_MAX_KEY)
+	it = rbtFind(domain->mr_map, (void *)key);
+	if (!it)
 		return NULL;
 
-	fastlock_acquire(&domain->mr_lock);
-	mr = idm_lookup(&domain->mr_map, key);
-	fastlock_release(&domain->mr_lock);
-
-	return (mr != PSMX_MR_RESERVED) ? mr : NULL ;
-}
-
-static inline void psmx_mr_save_key(struct psmx_fid_domain *domain, uint64_t key, void *mr)
-{
-	fastlock_acquire(&domain->mr_lock);
-	idm_set(&domain->mr_map, key, mr);
-	fastlock_release(&domain->mr_lock);
+	rbtKeyValue(domain->mr_map, it, (void **)&key, (void **)&mr);
+	return mr;
 }
 
 static inline void psmx_mr_release_key(struct psmx_fid_domain *domain, uint64_t key)
 {
+	RbtIterator it;
+
 	fastlock_acquire(&domain->mr_lock);
-	idm_clear(&domain->mr_map, key);
+	it = rbtFind(domain->mr_map, (void *)key);
+	if (it)
+		rbtErase(domain->mr_map, it);
 	fastlock_release(&domain->mr_lock);
 }
 
-static int psmx_mr_reserve_key(struct psmx_fid_domain *domain, uint64_t key)
+static int psmx_mr_reserve_key(struct psmx_fid_domain *domain,
+			       uint64_t requested_key,
+			       uint64_t *assigned_key,
+			       void *mr)
 {
-	if (key > PSMX_MR_MAX_KEY) {
-		FI_INFO(&psmx_prov, FI_LOG_MR,
-			"request key 0x%llx is out of valid range [0..0x%x]\n",
-			key, PSMX_MR_MAX_KEY);
-		return -FI_EINVAL;
-	}
+	uint64_t key;
+	int i;
+	int try_count;
+	int err = -FI_ENOKEY;
 
 	fastlock_acquire(&domain->mr_lock);
-	if (idm_lookup(&domain->mr_map, key)) {
-		fastlock_release(&domain->mr_lock);
-		return -FI_ENOKEY;
+
+	if (domain->mr_mode == FI_MR_SCALABLE) {
+		key = requested_key;
+		try_count = 1;
 	}
-	idm_set(&domain->mr_map, key, PSMX_MR_RESERVED);
-	fastlock_release(&domain->mr_lock);
+	else {
+		key = domain->mr_reserved_key;
+		try_count = 10000; /* large enough */
+	}
 
-	return 0;
-}
-
-static int psmx_mr_reserve_any_key(struct psmx_fid_domain *domain, uint64_t *key)
-{
-	uint64_t try_key;
-	int err = 0;
-
-	fastlock_acquire(&domain->mr_lock);
-	try_key = domain->mr_reserved_key;
-	while (idm_lookup(&domain->mr_map, try_key)) {
-		try_key = (try_key + 1) % PSMX_MR_MAX_KEY;
-		if (try_key == domain->mr_reserved_key) {
-			FI_INFO(&psmx_prov, FI_LOG_MR,
-				"running out of keys in range [0..0x%x]\n",
-				PSMX_MR_MAX_KEY);
-			err = -FI_ENOKEY;
+	for (i=0; i<try_count; i++, key++) {
+		if (!rbtFind(domain->mr_map, (void *)key)) {
+			if (!rbtInsert(domain->mr_map, (void *)key, mr)) {
+				if (domain->mr_mode != FI_MR_SCALABLE)
+					domain->mr_reserved_key = key + 1;
+				*assigned_key = key;
+				err = 0;
+			}
 			break;
 		}
 	}
-	if (!err) {
-		idm_set(&domain->mr_map, try_key, PSMX_MR_RESERVED);
-		domain->mr_reserved_key = (try_key + 1) % PSMX_MR_MAX_KEY;
-		*key = try_key;
-	}
+
 	fastlock_release(&domain->mr_lock);
 
 	return err;
@@ -264,13 +248,7 @@ static int psmx_mr_reg(struct fid *fid, const void *buf, size_t len,
 	if (!mr_priv)
 		return -FI_ENOMEM;
 
-	if (domain_priv->mr_mode == FI_MR_SCALABLE) {
-		key = requested_key;
-		err = psmx_mr_reserve_key(domain_priv, key);
-	} else {
-		err = psmx_mr_reserve_any_key(domain_priv, &key);
-	}
-
+	err = psmx_mr_reserve_key(domain_priv, requested_key, &key, mr_priv);
 	if (err) {
 		free(mr_priv);
 		return err;
@@ -297,9 +275,7 @@ static int psmx_mr_reg(struct fid *fid, const void *buf, size_t len,
 				((uint64_t)mr_priv->iov[0].iov_base - offset) :
 				0;
 
-	psmx_mr_save_key(domain_priv, key, mr_priv);
 	*mr = &mr_priv->mr;
-
 	return 0;
 }
 
@@ -329,13 +305,7 @@ static int psmx_mr_regv(struct fid *fid,
 	if (!mr_priv)
 		return -FI_ENOMEM;
 
-	if (domain_priv->mr_mode == FI_MR_SCALABLE) {
-		key = requested_key;
-		err = psmx_mr_reserve_key(domain_priv, key);
-	} else {
-		err = psmx_mr_reserve_any_key(domain_priv, &key);
-	}
-
+	err = psmx_mr_reserve_key(domain_priv, requested_key, &key, mr_priv);
 	if (err) {
 		free(mr_priv);
 		return err;
@@ -359,9 +329,7 @@ static int psmx_mr_regv(struct fid *fid,
 				((uint64_t)mr_priv->iov[0].iov_base - offset) :
 				0;
 
-	psmx_mr_save_key(domain_priv, key, mr_priv);
 	*mr = &mr_priv->mr;
-
 	return 0;
 }
 
@@ -392,13 +360,7 @@ static int psmx_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	if (!mr_priv)
 		return -FI_ENOMEM;
 
-	if (domain_priv->mr_mode == FI_MR_SCALABLE) {
-		key = attr->requested_key;
-		err = psmx_mr_reserve_key(domain_priv, key);
-	} else {
-		err = psmx_mr_reserve_any_key(domain_priv, &key);
-	}
-
+	err = psmx_mr_reserve_key(domain_priv, attr->requested_key, &key, mr_priv);
 	if (err) {
 		free(mr_priv);
 		return err;
@@ -422,9 +384,7 @@ static int psmx_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 				((uint64_t)mr_priv->iov[0].iov_base - attr->offset) :
 				0;
 
-	psmx_mr_save_key(domain_priv, key, mr_priv);
 	*mr = &mr_priv->mr;
-
 	return 0;
 }
 


### PR DESCRIPTION
Similar to the corresponding psm2 update (commit 9e73e605).

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>