### PR TITLE
prov/psm2: remove tagged senddata/injectdata functions

### DIFF
--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -976,33 +976,6 @@ static ssize_t psmx2_tagged_inject(struct fid_ep *ep,
 					 0);
 }
 
-static ssize_t psmx2_tagged_senddata(struct fid_ep *ep, const void *buf,
-				     size_t len, void *desc, uint64_t data,
-				     fi_addr_t dest_addr,
-                                     uint64_t tag, void *context)
-{
-	struct psmx2_fid_ep *ep_priv;
-
-	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
-
-	return psmx2_tagged_send_generic(ep, buf, len, desc, dest_addr,
-					 tag, context, ep_priv->flags, data);
-}
-
-static ssize_t psmx2_tagged_injectdata(struct fid_ep *ep, const void *buf,
-				       size_t len, uint64_t data,
-				       fi_addr_t dest_addr, uint64_t tag)
-{
-	struct psmx2_fid_ep *ep_priv;
-
-	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
-
-	return psmx2_tagged_send_generic(ep, buf, len, NULL, dest_addr,
-					 tag, NULL,
-					 ep_priv->flags | FI_INJECT | PSMX2_NO_COMPLETION,
-					 data);
-}
-
 #define PSMX2_TAGGED_OPS(suffix,sendopt,recvopt,injopt)	\
 struct fi_ops_tagged psmx2_tagged_ops##suffix = {	\
 	.size = sizeof(struct fi_ops_tagged),		\
@@ -1013,8 +986,8 @@ struct fi_ops_tagged psmx2_tagged_ops##suffix = {	\
 	.sendv = psmx2_tagged_sendv##sendopt,		\
 	.sendmsg = psmx2_tagged_sendmsg,		\
 	.inject = psmx2_tagged_inject##injopt,		\
-	.senddata = psmx2_tagged_senddata,		\
-	.injectdata = psmx2_tagged_injectdata,		\
+	.senddata = fi_no_tagged_senddata,		\
+	.injectdata = fi_no_tagged_injectdata,		\
 };
 
 PSMX2_TAGGED_OPS(,,,)


### PR DESCRIPTION
Currently the functionality is not really supported. Use the fi_no_xxx
version instead.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>