### PR TITLE
configure: list all valid settings for the "--enable-xxx" options

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -53,8 +53,12 @@ dnl
 AC_DEFUN([FI_PROVIDER_SETUP],[
 	AC_MSG_NOTICE([*** Configuring $1 provider])
 	AC_ARG_ENABLE([$1],
-	      [AS_HELP_STRING([--enable-$1],
-			      [Enable $1 provider @<:@default=auto@:>@])
+	      [AS_HELP_STRING([--enable-$1@<:@=yes|no|auto|dl|PATH@:>@],
+			      [Enable $1 provider @<:@default=auto@:>@ 
+				(yes: enable $1 provider; no: disable $1 provider;
+				auto: enable $1 provider if possible;
+				dl: enable $1 provider and build as a loadable library;
+				PATH: enable $1 provider and use $1 installed under PATH)])
 	      ],
 	      [],
 	      [enable_$1=auto])


### PR DESCRIPTION
The "--enable-xxx" options (where "xxx" is the provider name) have
more choices than the standard yes|no|auto values. Listing all the
possible choices in the help text can be useful to new users.

As a special note, the option format "--enable-xxx=<PATH>" is the
equivalence of the "--with-xxx=<PATH>" option found elsewhere.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>