### PR TITLE
usnic: Update protocol value that EP_MSG and EP_RDM report.

### DIFF
--- a/prov/usnic/src/fi_ext_usnic.h
+++ b/prov/usnic/src/fi_ext_usnic.h
@@ -42,8 +42,6 @@
 #include <stdint.h>
 #include <net/if.h>
 
-#define FI_PROTO_RUDP 100
-
 #define FI_EXT_USNIC_INFO_VERSION 1
 
 /*

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -95,7 +95,7 @@ static const struct fi_rx_attr msg_dflt_rx_attr = {
 
 static const struct fi_ep_attr msg_dflt_ep_attr = {
 	.type = FI_EP_MSG,
-	.protocol = FI_PROTO_RUDP,
+	.protocol = FI_PROTO_UNSPEC,
 	.msg_prefix_size = 0,
 	.max_msg_size = USDF_MSG_MAX_MSG,
 	.max_order_raw_size = 0,
@@ -132,7 +132,6 @@ int usdf_msg_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
 
 	switch (hints->ep_attr->protocol) {
 	case FI_PROTO_UNSPEC:
-	case FI_PROTO_RUDP:
 		break;
 	default:
 		return -FI_ENODATA;

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -96,7 +96,7 @@ static const struct fi_rx_attr rdm_dflt_rx_attr = {
 
 static const struct fi_ep_attr rdm_dflt_ep_attr = {
 	.type = FI_EP_RDM,
-	.protocol = FI_PROTO_UDP,
+	.protocol = FI_PROTO_UNSPEC,
 	.max_msg_size = USDF_RDM_MAX_MSG,
 	.msg_prefix_size = 0,
 	.max_order_raw_size = 0,
@@ -133,7 +133,6 @@ int usdf_rdm_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
 
 	switch (hints->ep_attr->protocol) {
 	case FI_PROTO_UNSPEC:
-	case FI_PROTO_RUDP:
 		break;
 	default:
 		return -FI_ENODATA;

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -103,7 +103,6 @@ usdf_validate_hints(struct fi_info *hints, struct usd_device_attrs *dap)
 		switch (hints->ep_attr->protocol) {
 		case FI_PROTO_UNSPEC:
 		case FI_PROTO_UDP:
-		case FI_PROTO_RUDP:
 			break;
 		default:
 			return -FI_ENODATA;

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -136,8 +136,8 @@ usdf_pep_conn_info(struct usdf_connreq *crp)
 		sin->sin_family = AF_INET;
 		sin->sin_addr.s_addr = dap->uda_ipaddr_be;
 		ip->src_addr = sin;
-		
-		ip->ep_attr->protocol = FI_PROTO_RUDP;
+
+		ip->ep_attr->protocol = FI_PROTO_UNSPEC;
 
 		ip->fabric_attr->fabric = fab_utof(fp);
 		ip->fabric_attr->name = strdup(fp->fab_attr.name);


### PR DESCRIPTION
`EP_MSG` and `EP_RDM` have been reporting `FI_PROTO_RUDP`. Instead of
maintaining `FI_PROTO_RUDP`, remove it and use `FI_PROTO_UNSPEC` instead.

@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>