### PR TITLE
prov/psm2: bug fix for address resolution

### DIFF
--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -91,8 +91,17 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 
 	psmx2_init_env();
 
-	if (node && !(flags & FI_SOURCE))
+	if (node && !(flags & FI_SOURCE)) {
 		dest_addr = psmx2_resolve_name(node, 0);
+		if (dest_addr)
+			FI_INFO(&psmx2_prov, FI_LOG_CORE,
+				"node '%s' resolved to <epid=0x%llx, vl=%d>\n", node,
+				((struct psmx2_ep_name *)dest_addr)->epid,
+				((struct psmx2_ep_name *)dest_addr)->vlane);
+		else
+			FI_INFO(&psmx2_prov, FI_LOG_CORE,
+				"failed to resolve node '%s'.\n", node);
+	}
 
 	if (hints) {
 		switch (hints->addr_format) {
@@ -417,7 +426,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->mode = mode;
 	psmx2_info->addr_format = FI_ADDR_PSMX;
 	psmx2_info->src_addrlen = 0;
-	psmx2_info->dest_addrlen = sizeof(psm2_epid_t);
+	psmx2_info->dest_addrlen = sizeof(struct psmx2_ep_name);
 	psmx2_info->src_addr = NULL;
 	psmx2_info->dest_addr = dest_addr;
 	psmx2_info->fabric_attr->name = strdup(PSMX2_FABRIC_NAME);


### PR DESCRIPTION
Set correct value of the dest_addrlen field returned by fi_getinfo.
The address len has changed with the introdution of vlane support.
Add debugging output for the result of address resolution.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>