### PR TITLE
prov/gni: Disable slow tests in tags.c.

### DIFF
--- a/prov/gni/test/tags.c
+++ b/prov/gni/test/tags.c
@@ -1470,7 +1470,8 @@ Test(gnix_tags_basic_posted_list, multiple_1024_ipr_random_tag)
 			make_random_tags);
 }
 
-Test(gnix_tags_basic_posted_list, multiple_8192_ipr_random_tag)
+Test(gnix_tags_basic_posted_list, multiple_8192_ipr_random_tag,
+		.disabled = true)
 {
 	__test_multiple_type_ipr_reqs(8192, &default_list_attr,
 			make_random_tags);
@@ -1494,7 +1495,8 @@ Test(gnix_tags_basic_posted_list, multiple_1024_ipr_sequential_tag)
 			make_evenly_distributed_tags);
 }
 
-Test(gnix_tags_basic_posted_list, multiple_8192_ipr_sequential_tag)
+Test(gnix_tags_basic_posted_list, multiple_8192_ipr_sequential_tag,
+		.disabled = true)
 {
 	__test_multiple_type_ipr_reqs(8192, &default_list_attr,
 			make_evenly_distributed_tags);
@@ -1607,7 +1609,8 @@ Test(gnix_tags_basic_unexpected_list, multiple_1024_ipr_random_tag)
 			make_random_tags);
 }
 
-Test(gnix_tags_basic_unexpected_list, multiple_8192_ipr_random_tag)
+Test(gnix_tags_basic_unexpected_list, multiple_8192_ipr_random_tag,
+		.disabled = true)
 {
 	__test_multiple_type_ipr_reqs(8192, &default_list_attr,
 			make_random_tags);
@@ -1631,7 +1634,8 @@ Test(gnix_tags_basic_unexpected_list, multiple_1024_ipr_sequential_tag)
 			make_evenly_distributed_tags);
 }
 
-Test(gnix_tags_basic_unexpected_list, multiple_8192_ipr_sequential_tag)
+Test(gnix_tags_basic_unexpected_list, multiple_8192_ipr_sequential_tag,
+		.disabled = true)
 {
 	__test_multiple_type_ipr_reqs(8192, &default_list_attr,
 			make_evenly_distributed_tags);


### PR DESCRIPTION
Disable four tag matching tests to make the criterion test suite faster.  The
only remaining test which takes more than one second is endpoint/open_close,
which is unavoidably slow due to serial create/delete of the limit of CDMs.
The disabled tests took ~45 seconds together.  The test suite now runs in ~175
seconds.

Fixes ofi-cray/libfabric-cray#471.

@ztiffany 

Upstream merge of ofi-cray/libfabric-cray#550

Signed-off-by: Zach Tiffany <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@5b950b225980ec2f817e94fbb41f6a2509b46dd6)