### PR TITLE
makefile - add bin_SCRIPTS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,8 @@ linkback = $(top_builddir)/src/libfabric.la
 bin_PROGRAMS = \
 	util/fi_info
 
+bin_SCRIPTS =
+
 util_fi_info_SOURCES = \
 	util/info.c
 util_fi_info_LDADD = $(linkback)

--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -66,8 +66,8 @@ _gni_headers = \
 
 if HAVE_CRITERION
 bin_PROGRAMS += prov/gni/test/gnitest
-dist_bin_SCRIPTS = prov/gni/test/run_gnitest
-prov_gni_test_gnitest_SOURCES = \
+bin_SCRIPTS += prov/gni/test/run_gnitest
+nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/allocator.c \
 	prov/gni/test/av.c \
 	prov/gni/test/bitmap.c \


### PR DESCRIPTION
At some point there may be a use for adding scripts to bin
as part of install, as well as to have nodist directories.
By setting these to empty in the top level makefile, these
variables can be extended within submakefiles for provider
or component specific scripts, etc.

Updates ofi-cray/libfabric-cray#531

@shefty 
@goodell 
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>