### PR TITLE
prov/psm2: remove the hard cap on the AM chunk size

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -156,9 +156,6 @@ union psmx2_pi {
 #define PSMX2_AM_RMA_HANDLER	0
 #define PSMX2_AM_MSG_HANDLER	1
 #define PSMX2_AM_ATOMIC_HANDLER	2
-#define PSMX2_AM_CHUNK_SIZE	2032	/* The maximum that's actually working:
-					 * 2032 for inter-node, 2072 for intra-node.
-					 */
 
 #define PSMX2_AM_OP_MASK	0x000000FF
 #define PSMX2_AM_DST_MASK	0x0000FF00

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -805,7 +805,7 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 					 NULL, addr, key, datatype, op,
 					 context, flags);
 
-	chunk_size = MIN(PSMX2_AM_CHUNK_SIZE, psmx2_am_param.max_request_short);
+	chunk_size = psmx2_am_param.max_request_short;
 	len = fi_datatype_size(datatype)* count;
 	if (len > chunk_size)
 		return -FI_EMSGSIZE;
@@ -1002,7 +1002,7 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 					 result_desc, addr, key, datatype, op,
 					 context, flags);
 
-	chunk_size = MIN(PSMX2_AM_CHUNK_SIZE, psmx2_am_param.max_request_short);
+	chunk_size = psmx2_am_param.max_request_short;
 	len = fi_datatype_size(datatype) * count;
 	if (len > chunk_size)
 		return -FI_EMSGSIZE;
@@ -1219,7 +1219,7 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 					 addr, key, datatype, op,
 					 context, flags);
 
-	chunk_size = MIN(PSMX2_AM_CHUNK_SIZE, psmx2_am_param.max_request_short);
+	chunk_size = psmx2_am_param.max_request_short;
 	len = fi_datatype_size(datatype) * count;
 	if (len * 2 > chunk_size)
 		return -FI_EMSGSIZE;
@@ -1380,8 +1380,7 @@ static int psmx2_atomic_writevalid(struct fid_ep *ep,
 	}
 
 	if (count) {
-		chunk_size = MIN(PSMX2_AM_CHUNK_SIZE,
-				 psmx2_am_param.max_request_short);
+		chunk_size = psmx2_am_param.max_request_short;
 		*count = chunk_size / fi_datatype_size(datatype);
 	}
 	return 0;
@@ -1416,8 +1415,7 @@ static int psmx2_atomic_readwritevalid(struct fid_ep *ep,
 	}
 
 	if (count) {
-		chunk_size = MIN(PSMX2_AM_CHUNK_SIZE,
-				 psmx2_am_param.max_request_short);
+		chunk_size = psmx2_am_param.max_request_short;
 		*count = chunk_size / fi_datatype_size(datatype);
 	}
 	return 0;
@@ -1462,8 +1460,7 @@ static int psmx2_atomic_compwritevalid(struct fid_ep *ep,
 	}
 
 	if (count) {
-		chunk_size = MIN(PSMX2_AM_CHUNK_SIZE,
-				 psmx2_am_param.max_request_short);
+		chunk_size = psmx2_am_param.max_request_short;
 		*count = chunk_size / (2 * fi_datatype_size(datatype));
 	}
 	return 0;

--- a/prov/psm2/src/psmx2_msg2.c
+++ b/prov/psm2/src/psmx2_msg2.c
@@ -322,7 +322,7 @@ int psmx2_am_process_send(struct psmx2_fid_domain *domain,
 	offset = req->send.len_sent;
 	len = req->send.len - offset;
 
-	chunk_size = MIN(PSMX2_AM_CHUNK_SIZE, psmx2_am_param.max_request_short);
+	chunk_size = psmx2_am_param.max_request_short;
 
 	while (len > chunk_size) {
 		args[0].u32w0 = PSMX2_AM_REQ_SEND;
@@ -562,7 +562,7 @@ static ssize_t psmx2_send2_generic(struct fid_ep *ep, const void *buf,
 		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
-	chunk_size = MIN(PSMX2_AM_CHUNK_SIZE, psmx2_am_param.max_request_short);
+	chunk_size = psmx2_am_param.max_request_short;
 	msg_size = MIN(len, chunk_size);
 
 	req = calloc(1, sizeof(*req));

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -595,7 +595,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 		req->no_event = 1;
 	}
 
-	chunk_size = MIN(PSMX2_AM_CHUNK_SIZE, psmx2_am_param.max_reply_short);
+	chunk_size = psmx2_am_param.max_reply_short;
 
 	args[0].u32w0 = 0;
 	PSMX2_AM_SET_SRC(args[0].u32w0, ep_priv->vlane);
@@ -797,7 +797,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	PSMX2_CTXT_USER(&req->fi_context) = context;
 	PSMX2_CTXT_EP(&req->fi_context) = ep_priv;
 
-	chunk_size = MIN(PSMX2_AM_CHUNK_SIZE, psmx2_am_param.max_request_short);
+	chunk_size = psmx2_am_param.max_request_short;
 
 	args[0].u32w0 = 0;
 	PSMX2_AM_SET_SRC(args[0].u32w0, ep_priv->vlane);


### PR DESCRIPTION
The hard cap was placed as a workaround for an AM related bug in
some versions of PSM 1.x code. It's no longer needed for PSM2.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>