### PR TITLE
prov/psm2: move handling of aliasing out of the common code path

### DIFF
--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -142,12 +142,10 @@ void psmx2_atomic_fini(void)
 			TYPE *d = (dst); \
 			TYPE *s = (src); \
 			TYPE *r = (res); \
-			TYPE tmp; \
 			fastlock_acquire(&psmx2_atomic_lock); \
 			for (i=0; i<(cnt); i++) {\
-				tmp = d[i]; \
+				r[i] = d[i]; \
 				OP(d[i],s[i]); \
-				r[i] = tmp; \
 			} \
 			fastlock_release(&psmx2_atomic_lock); \
 		} while (0)
@@ -159,13 +157,11 @@ void psmx2_atomic_fini(void)
 			TYPE *s = (src); \
 			TYPE *c = (cmp); \
 			TYPE *r = (res); \
-			TYPE tmp; \
 			fastlock_acquire(&psmx2_atomic_lock); \
 			for (i=0; i<(cnt); i++) { \
-				tmp = d[i]; \
+				r[i] = d[i]; \
 				if (c[i] CMP_OP d[i]) \
 					d[i] = s[i]; \
-				r[i] = tmp; \
 			} \
 			fastlock_release(&psmx2_atomic_lock); \
 		} while (0)
@@ -177,12 +173,10 @@ void psmx2_atomic_fini(void)
 			TYPE *s = (src); \
 			TYPE *c = (cmp); \
 			TYPE *r = (res); \
-			TYPE tmp; \
 			fastlock_acquire(&psmx2_atomic_lock); \
 			for (i=0; i<(cnt); i++) { \
-				tmp = d[i]; \
+				r[i] = d[i]; \
 				d[i] = (s[i] & c[i]) | (d[i] & ~c[i]); \
-				r[i] = tmp; \
 			} \
 			fastlock_release(&psmx2_atomic_lock); \
 		} while (0)
@@ -626,6 +620,7 @@ static int psmx2_atomic_self(int am_cmd,
 	struct psmx2_cq_event *event;
 	struct psmx2_fid_cntr *cntr = NULL;
 	struct psmx2_fid_cntr *mr_cntr = NULL;
+	void *tmp_buf;
 	size_t len;
 	int no_event;
 	int err = 0;
@@ -655,9 +650,26 @@ static int psmx2_atomic_self(int am_cmd,
 		break;
 
 	case PSMX2_AM_REQ_ATOMIC_READWRITE:
-		err = psmx2_atomic_do_readwrite((void *)addr, (void *)buf,
-					        (void *)result, (int)datatype,
-					        (int)op, (int)count);
+		if (result != buf) {
+			err = psmx2_atomic_do_readwrite((void *)addr, (void *)buf,
+							(void *)result, (int)datatype,
+							(int)op, (int)count);
+		}
+		else {
+			tmp_buf = malloc(len);
+			if (tmp_buf) {
+				memcpy(tmp_buf, result, len);
+				err = psmx2_atomic_do_readwrite((void *)addr, (void *)buf,
+								tmp_buf, (int)datatype,
+								(int)op, (int)count);
+				memcpy(result, tmp_buf, len);
+				free(tmp_buf);
+			}
+			else {
+				err = -FI_ENOMEM;
+			}
+			
+		}
 		if (op == FI_ATOMIC_READ)
 			cq_flags = FI_READ | FI_ATOMIC;
 		else
@@ -665,9 +677,25 @@ static int psmx2_atomic_self(int am_cmd,
 		break;
 
 	case PSMX2_AM_REQ_ATOMIC_COMPWRITE:
-		err = psmx2_atomic_do_compwrite((void *)addr, (void *)buf,
-					        (void *)compare, (void *)result,
-					        (int)datatype, (int)op, (int)count);
+		if (result != buf && result != compare) {
+			err = psmx2_atomic_do_compwrite((void *)addr, (void *)buf,
+							(void *)compare, (void *)result,
+							(int)datatype, (int)op, (int)count);
+		}
+		else {
+			tmp_buf = malloc(len);
+			if (tmp_buf) {
+				memcpy(tmp_buf, result, len);
+				err = psmx2_atomic_do_compwrite((void *)addr, (void *)buf,
+								(void *)compare, tmp_buf,
+								(int)datatype, (int)op, (int)count);
+				memcpy(result, tmp_buf, len);
+				free(tmp_buf);
+			}
+			else {
+				err = -FI_ENOMEM;
+			}
+		}
 		cq_flags = FI_WRITE | FI_ATOMIC;
 		break;
 	}


### PR DESCRIPTION
Local buffer aliasing (result ~ src, result ~ compare) in atomic
operations is rare case and is errorous only for self targeted
operations. It's beneficial to handle such situation as special
case instead of having the overhead in the common code path.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>