### PR TITLE
Remove reference to non-existent seq_num variable.

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -459,8 +459,7 @@ fi_ibv_rdm_tagged_release_remote_sbuff(struct fi_ibv_rdm_tagged_conn *conn,
 
 	FI_IBV_RDM_TAGGED_INC_SEND_COUNTERS(conn, ep, wr.send_flags);
 	VERBS_DBG(FI_LOG_EP_DATA,
-		"posted %d bytes, remote sbuff released %d\n", sge.length,
-		seq_num);
+		"posted %d bytes, remote sbuff released\n", sge.length);
 	int ret = ibv_post_send(conn->qp, &wr, &bad_wr);
 	if (ret) {
 		VERBS_INFO_ERRNO(FI_LOG_EP_DATA, "ibv_post_send", errno);


### PR DESCRIPTION
The build is broken when compiling with `--enable-debug` after #1524. 

@ddurnov @shefty 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>