### PR TITLE
Prep the usnic provider for pkg-config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -274,7 +274,7 @@ endif
 
 _usnic_cppflags = \
         -D__LIBUSNIC__ -DWANT_DEBUG_MSGS=0 \
-        -DHAVE_LIBNL3=$(HAVE_LIBNL3) $(usnic_nl_CPPFLAGS) \
+        -DHAVE_LIBNL3=$(HAVE_LIBNL3) $(usnic_CPPFLAGS) \
         -I$(top_srcdir)/prov/usnic/src/usnic_direct
 
 rdmainclude_HEADERS += \
@@ -287,13 +287,13 @@ libusnic_fi_la_SOURCES = $(_usnic_files) $(common_srcs)
 libusnic_fi_la_LDFLAGS = \
         $(usnic_ln_LDFLAGS) \
         -module -avoid-version -shared -export-dynamic
-libusnic_fi_la_LIBADD = $(linkback) $(_usnic_libibverbs) $(usnic_nl_LIBS)
+libusnic_fi_la_LIBADD = $(linkback) $(_usnic_libibverbs) $(usnic_LIBS)
 libusnic_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_USNIC_DL
 src_libfabric_la_SOURCES += $(_usnic_files)
 src_libfabric_la_CPPFLAGS += $(_usnic_cppflags)
-src_libfabric_la_LDFLAGS += $(usnic_nl_LDFLAGS)
-src_libfabric_la_LIBADD += $(_usnic_libibverbs) $(usnic_nl_LIBS)
+src_libfabric_la_LDFLAGS += $(usnic_LDFLAGS)
+src_libfabric_la_LIBADD += $(_usnic_libibverbs) $(usnic_LIBS)
 endif !HAVE_USNIC_DL
 
 endif HAVE_USNIC

--- a/Makefile.am
+++ b/Makefile.am
@@ -261,15 +261,6 @@ _usnic_files = \
 
 if HAVE_VERBS
 _usnic_files += prov/usnic/src/usdf_fake_ibv.c
-
-# If the verbs or usnic providers are being built as a DL, then we
-# need to link libibverbs into the usnic provider
-if HAVE_VERBS_DL
-_usnic_libibverbs = -libverbs
-endif
-if HAVE_USNIC_DL
-_usnic_libibverbs = -libverbs
-endif
 endif
 
 _usnic_cppflags = \

--- a/configure.ac
+++ b/configure.ac
@@ -213,6 +213,8 @@ FI_PROVIDER_SETUP([psm])
 FI_PROVIDER_SETUP([psm2])
 FI_PROVIDER_SETUP([sockets])
 FI_PROVIDER_SETUP([verbs])
+dnl The usnic provider must be setup after the verbs provider.  See
+dnl prov/usnic/configure.m4 for details.
 FI_PROVIDER_SETUP([usnic])
 FI_PROVIDER_SETUP([mxm])
 FI_PROVIDER_SETUP([gni])

--- a/prov/usnic/configure.m4
+++ b/prov/usnic/configure.m4
@@ -175,9 +175,12 @@ AC_DEFUN([USNIC_CHECK_LIBNL_SADNESS],[
 	AC_DEFINE_UNQUOTED([HAVE_LIBNL3], [$HAVE_LIBNL3],
 	      [Whether we have libl or libnl3])
 
-	AC_SUBST([usnic_nl_CPPFLAGS])
-	AC_SUBST([usnic_nl_LDFLAGS])
-	AC_SUBST([usnic_nl_LIBS])
+	usnic_CPPFLAGS=$usnic_nl_CPPFLAGS
+	usnic_LDFLAGS=$usnic_nl_LDFLAGS
+	usnic_LIBS=$usnic_nl_LIBS
+	AC_SUBST([usnic_CPPFLAGS])
+	AC_SUBST([usnic_LDFLAGS])
+	AC_SUBST([usnic_LIBS])
 
 	AS_IF([test "$usnic_nl_LIBS" = ""],
 	      [usnic_happy=0])

--- a/prov/usnic/configure.m4
+++ b/prov/usnic/configure.m4
@@ -178,6 +178,22 @@ AC_DEFUN([USNIC_CHECK_LIBNL_SADNESS],[
 	usnic_CPPFLAGS=$usnic_nl_CPPFLAGS
 	usnic_LDFLAGS=$usnic_nl_LDFLAGS
 	usnic_LIBS=$usnic_nl_LIBS
+
+	# If the verbs or usnic providers are being built as a DL,
+	# then we need to add libibverbs to usnic_LIBS.  We can tell
+	# if verbs/usnic are being built as DL because fi_provider.m4
+	# will set $PROVIDER_dl to 1.  Also, per note in configure.ac,
+	# the verbs provider *must* be configured before the usnic
+	# provider explicitly for this case: so that $verbs_dl will be
+	# (potentially) set by the time we get here.
+
+	# NOTE: this decision whether to -libverbs or not used to be
+	# handled in Makefile.am via an AM_CONDITIONAL.  However, to
+	# properly support pkg-config, we have to make this decision
+	# here/now and AC SUBST the final result into usnic_LIBS.
+	AS_IF([test "$verbs_dl" = "1" || test "$usnic_dl" = "1"],
+	      [usnic_LIBS="$usnic_LIBS -libverbs"])
+
 	AC_SUBST([usnic_CPPFLAGS])
 	AC_SUBST([usnic_LDFLAGS])
 	AC_SUBST([usnic_LIBS])


### PR DESCRIPTION
This PR fixes the issue identified by #1544 / @disprosium8, and prepares the usnic provider for pkg-config.

@bturrubiates Please review.