### PR TITLE
gni: move rdmainclude_HEADERS inside AM conditional

### DIFF
--- a/prov/gni/Makefile.am
+++ b/prov/gni/Makefile.am
@@ -112,7 +112,8 @@ libgnix_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_GNI_DL
 src_libfabric_la_SOURCES += $(_gni_files) $(_gni_headers)
 endif !HAVE_GNI_DL
-endif
 
 rdmainclude_HEADERS += \
 	prov/gni/include/fi_ext_gni.h
+
+endif HAVE_GNI


### PR DESCRIPTION
This is a minor fix that I noticed while looking through the build system this morning:

* The `fi_ext_gni.h` file should not be installed unless the GNI provider is installed.
* Also, suffix the `endif` for the HAVE_GNI AM_CONDITIONAL.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@hppritcha @sungeunchoi please review