### PR TITLE
man: separate the man pages of the psm and psm2 providers.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -462,6 +462,7 @@ real_man_pages = \
         man/man7/fi_provider.7 \
         man/man7/fi_gni.7 \
         man/man7/fi_psm.7 \
+        man/man7/fi_psm2.7 \
         man/man7/fi_sockets.7 \
         man/man7/fi_usnic.7 \
         man/man7/fi_verbs.7 \

--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -1,32 +1,25 @@
 ---
 layout: page
-title: fi_psm(7)
+title: fi_psm2(7)
 tagline: Libfabric Programmer's Manual
 ---
 {% include JB/setup %}
 
 # NAME
 
-The PSM Fabric Provider
+The PSM2 Fabric Provider
 
 # OVERVIEW
 
-The *psm* provider runs over the PSM 1.x interface that is currently
-supported by the Intel TrueScale Fabric. PSM provides tag-matching
-message queue functions that are optimized for MPI implementations.
-PSM also has limited Active Message support, which is not officially
-published but is quite stable and well documented in the source code
-(part of the OFED release). The *psm* provider makes use of both the
-tag-matching message queue functions and the Active Message functions
-to support a variety of libfabric data transfer APIs, including tagged
-message queue, message queue, RMA, and atomic operations.
-
-The *psm* provider can work with the psm2-compat library, which exposes
-a PSM 1.x interface over the Intel Omni-Path Fabric. 
+The *psm2* provider runs over the PSM 2.x interface that is supported
+by the Intel Omni-Path Fabric. PSM 2.x has all the PSM 1.x features
+plus a set of new functions with enhanced capability. Since PSM 1.x
+and PSM 2.x are not ABI compatible the *psm2* provider only works with
+PSM 2.x and doesn't support Intel TrueScale Fabric.
 
 # LIMITATIONS
 
-The *psm* provider doesn't support all the features defined in the
+The *psm2* provider doesn't support all the features defined in the
 libfabric API. Here are some of the limitations:
 
 Endpoint types
@@ -37,16 +30,12 @@ Endpoint capabilities
   *FI_TAGGED*, *FI_MSG*, *FI_ATOMICS*, and *FI_RMA*. These capabilities
   can be further refined by *FI_SEND*, *FI_RECV*, *FI_READ*, *FI_WRITE*,
   *FI_REMOTE_READ*, and *FI_REMOTE_WRITE* to limit the direction of
-  operations. The limitation is that no two endpoints can have overlapping
-  receive or RMA target capabilities in any of the above categories. For
-  example it is fine to have two endpoints with *FI_TAGGED* | *FI_SEND*,
-  one endpoint with *FI_TAGGED* | *FI_RECV*, one endpoint with *FI_MSG*,
-  one endpoint with *FI_RMA* | *FI_ATOMICS*. But it is not allowed to
-  have two endpoints with *FI_TAGGED*, or two endpoints with *FI_RMA*.
+  operations.
 
   *FI_MULTI_RECV* is supported for non-tagged message queue only.
 
-  Other supported capabilities include *FI_TRIGGER*.
+  Other supported capabilities include *FI_TRIGGER*, *FI_REMOTE_CQ_DATA*,
+  and *FI_SOURCE*.
 
 Modes
 : *FI_CONTEXT* is required for the *FI_TAGGED* and *FI_MSG*
@@ -58,7 +47,7 @@ Modes
   the *FI_CONTEXT* mode is not required.
   
 Progress
-: The *psm* provider requires manual progress. The application is
+: The *psm2* provider requires manual progress. The application is
   expected to call *fi_cq_read* or *fi_cntr_read* function from time
   to time when no other libfabric function is called to ensure
   progress is made in a timely manner. The provider does support
@@ -69,13 +58,13 @@ Progress
 Unsupported features
 : These features are unsupported: connection management, 
   scalable endpoint, passive endpoint, shared receive context,
-  send/inject with immediate data.
+  and send/inject with immediate data over tagged message queue.
 
 # RUNTIME PARAMETERS
 
-The *psm* provider checks for the following environment variables:
+The *psm2* provider checks for the following environment variables:
 
-*FI_PSM_UUID*
+*FI_PSM2_UUID*
 : PSM requires that each job has a unique ID (UUID). All the processes
   in the same job need to use the same UUID in order to be able to
   talk to each other. The PSM reference manual advises to keep UUID
@@ -86,10 +75,10 @@ The *psm* provider checks for the following environment variables:
   issues with unknown reason, it is advisable to manually set the UUID
   to a value different from the default.
 
-  The default UUID is 0FFF0FFF-0000-0000-0000-0FFF0FFF0FFF.
+  The default UUID 00FF00FF-0000-0000-0000-00FF0F0F00FF.
 
-*FI_PSM_NAME_SERVER*
-: The *psm* provider has a simple built-in name server that can be used
+*FI_PSM2_NAME_SERVER*
+: The *psm2* provider has a simple built-in name server that can be used
   to resolve an IP address or host name into a transport address needed
   by the *fi_av_insert* call. The main purpose of this name server is to
   allow simple client-server type applications (such as those in *fabtest*)
@@ -112,47 +101,47 @@ The *psm* provider checks for the following environment variables:
   The provider detects OpenMPI and MPICH runs and changes the default setting
   to off.
 
-*FI_PSM_TAGGED_RMA*
+*FI_PSM2_TAGGED_RMA*
 : The RMA functions are implemented on top of the PSM Active Message functions.
   The Active Message functions has limit on the size of data can be transferred
   in a single message. Large transfers can be divided into small chunks and
   be pipe-lined. However, the bandwidth is sub-optimal by doing this way.
 
-  The *psm* provider use PSM tag-matching message queue functions to achieve
+  The *psm2* provider use PSM tag-matching message queue functions to achieve
   higher bandwidth for large size RMA. For this purpose, a bit is reserved from
   the tag space to separate the RMA traffic from the regular tagged message queue.
    
   The option is on by default. To turn it off set the variable to 0.
 
-*FI_PSM_AM_MSG*
-: The *psm* provider implements the non-tagged message queue over the PSM
+*FI_PSM2_AM_MSG*
+: The *psm2* provider implements the non-tagged message queue over the PSM
   tag-matching message queue. One tag bit is reserved for this purpose.
   Alternatively, the non-tagged message queue can be implemented over
   Active Message. This experimental feature has slightly larger latency.
 
   This option is off by default. To turn it on set the variable to 1.
 
-*FI_PSM_DELAY*
+*FI_PSM2_DELAY*
 : Time (seconds) to sleep before closing PSM endpoints. This is a workaround
   for a bug in some versions of PSM library.
 
   The default setting is 1.
 
-*FI_PSM_TIMEOUT*
+*FI_PSM2_TIMEOUT*
 : Timeout (seconds) for gracefully closing PSM endpoints. A forced closing
   will be issued if timeout expires.
 
   The default setting is 5.
 
-*FI_PSM_PROG_INTERVAL*
+*FI_PSM2_PROG_INTERVAL*
 : When auto progress is enabled (asked via the hints to *fi_getinfo*),
   a progress thread is created to make progress calls from time to time.
   This option set the tnterval (microseconds) between progress calls.
 
   The default setting is 1 if affininty is set, or 1000 if not. See
-  *FI_PSM_PROG_AFFINITY*.
+  *FI_PSM2_PROG_AFFINITY*.
 
-*FI_PSM_PROG_AFFINITY*
+*FI_PSM2_PROG_AFFINITY*
 : When set, specify the set of CPU cores to set the progress thread
   affinity to. The format is
   `<start>[:<end>[:<stride>]][,<start>[:<end>[:<stride>]]]*`, 
@@ -166,4 +155,4 @@ The *psm* provider checks for the following environment variables:
 
 [`fabric`(7)](fabric.7.html),
 [`fi_provider`(7)](fi_provider.7.html),
-[`fi_psm2`(7)](fi_psm2.7.html),
+[`fi_psm`(7)](fi_psm.7.html),


### PR DESCRIPTION
Related to  #1547 

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>