### PR TITLE
Provider updates for pkg-config

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -239,20 +239,11 @@ dummy_man_pages = \
         man/man3/fi_writemsg.3 \
         man/man3/fi_writev.3
 
-man_MANS = $(real_man_pages) $(dummy_man_pages)
-
 nroff:
 	@for file in $(real_man_pages); do \
 	    source=`echo $$file | sed -e 's@/man[0-9]@@'`; \
 	    config/md2nroff.pl --source=$$source.md; \
 	done
-
-EXTRA_DIST = \
-        NEWS.md \
-        libfabric.map \
-        libfabric.spec.in \
-        config/distscript.pl \
-        $(man_MANS)
 
 dist-hook: libfabric.spec
 	cp libfabric.spec $(distdir)
@@ -264,6 +255,9 @@ test:
 rpm: dist
 	rpmbuild -ta libfabric-*.tar.bz2
 
+prov_install_man_pages=
+prov_dist_man_pages=
+
 include prov/sockets/Makefile.include
 include prov/verbs/Makefile.include
 include prov/usnic/Makefile.include
@@ -271,3 +265,12 @@ include prov/psm/Makefile.include
 include prov/psm2/Makefile.include
 include prov/mxm/Makefile.include
 include prov/gni/Makefile.include
+
+man_MANS = $(real_man_pages) $(prov_install_man_pages) $(dummy_man_pages)
+
+EXTRA_DIST = \
+        NEWS.md \
+        libfabric.map \
+        libfabric.spec.in \
+        config/distscript.pl \
+        $(real_man_pages) $(prov_dist_man_pages) $(dummy_man_pages)

--- a/config/fi_check_package.m4
+++ b/config/fi_check_package.m4
@@ -159,24 +159,24 @@ dnl which get used to compile/link *everything*).
 dnl
 dnl Here's a breakdown of the parameters:
 dnl
-dnl * prefix: the macro sets $prefix_CPPFLAGS, $prefix_LDFLAGS, and
+dnl 1 prefix: the macro sets $prefix_CPPFLAGS, $prefix_LDFLAGS, and
 dnl   $prefix_LIBS (and AC_SUBSTs all of them).  For example, if a
 dnl   provider uses this macro to check for a header/library that it
 dnl   needs, it might well set prefix to be its provider name.
-dnl * header_filename: the foo.h file to check for
-dnl * library_name / function_name: check for function function_name in
+dnl 2 header_filename: the foo.h file to check for
+dnl 3 and 4 library_name / function_name: check for function function_name in
 dnl   -llibrary_name.  Specifically, for library_name, use the "foo" form,
 dnl   as opposed to "libfoo".
-dnl * extra_libraries: if the library_name you are checking for requires
+dnl 5 extra_libraries: if the library_name you are checking for requires
 dnl   additonal -l arguments to link successfully, list them here.
-dnl * dir_prefix: if the header/library is located in a non-standard
+dnl 6 dir_prefix: if the header/library is located in a non-standard
 dnl   location (e.g., /opt/foo as opposed to /usr), list it here
-dnl * libdir_prefix: if the library is not under $dir_prefix/lib or
+dnl 7 libdir_prefix: if the library is not under $dir_prefix/lib or
 dnl   $dir_prefix/lib64, list it here.
-dnl * action_if_found: if both the header and library are found and
+dnl 8 action_if_found: if both the header and library are found and
 dnl   usable, execute action_if_found
-dnl * action_if_not_found: otherwise, execute action_if_not_found
-dnl * extra_includes: if including header_filename requires additional
+dnl 9 action_if_not_found: otherwise, execute action_if_not_found
+dnl 10 extra_includes: if including header_filename requires additional
 dnl   headers to be included first, list them here
 dnl
 dnl The output _CPPFLAGS, _LDFLAGS, and _LIBS can be used to limit the

--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -63,10 +63,12 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 	      [],
 	      [enable_$1=auto])
 
-	# Save CPPFLAGS and LDFLAGS before they are modified by FI_CHECK_PREFIX_DIR
+	# Save CPPFLAGS and LDFLAGS before they are modified by FI_CHECK_PREFIX_DIR.
 	# Provider's local macros could use the value if needed.
+	# Also save LIBS, as a matter of principle.
 	$1_orig_CPPFLAGS=$CPPFLAGS
 	$1_orig_LDFLAGS=$LDFLAGS
+	$1_orig_LIBS=$LIBS
 
 	# Check the --enable-<$1> value
 	$1_dl=0
@@ -111,7 +113,7 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 	AM_CONDITIONAL([HAVE_]m4_translit([$1], [a-z], [A-Z])[_DL],
 		[test $$1_dl -eq 1])
 
-	# If this provier was specifically requested but we can't
+	# If this provider was specifically requested but we can't
 	# build it, error.
 	AS_IF([test "$enable_$1 $$1_happy" = "yes 0"],
 	      [AC_MSG_WARN([$1 provider was requested, but cannot be compiled])
@@ -126,6 +128,14 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 			[AC_MSG_RESULT(no)
 			  AC_MSG_ERROR([$1 provider was requested as direct, but is missing fi_direct.h])]
 			)])
+
+	# Restore CPPFLAGS/LDFLAGS/LIBS
+	CPPFLAGS=$$1_orig_CPPFLAGS
+	unset $1_orig_CPPFLAGS
+	LDFLAGS=$$1_orig_LDFLAGS
+	unset $1_orig_LDFLAGS
+	LIBS=$$1_orig_LIBS
+	unset $1_orig_LIBS
 ])
 
 

--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -76,7 +76,7 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 	[yes|no], [],
 	[dl],     [enable_$1=yes $1_dl=1],
 	[auto],   [],
-	[FI_CHECK_PREFIX_DIR([$enable_$1])
+	[FI_CHECK_PREFIX_DIR([$enable_$1], [$1])
 	 enable_$1=yes]
 	)
 
@@ -160,16 +160,16 @@ AC_DEFUN([FI_CHECK_PREFIX_DIR],[
 
 	# Check that base/include exists
 	 AS_IF([test -d "$1/include"],
-	       [CPPFLAGS="-I$1/include"],
+	       [$2_PREFIX="$1"],
 	       [AC_MSG_WARN([could not find "include" subdirectory in supplied "$1" directory"])
 	        AC_MSG_ERROR([Cannot continue])
 	       ])
 
 	# Check that base/lib or base/lib64 exists
 	 AS_IF([test -d "$1/lib"],
-	       [LDFLAGS="-L$1/lib"],
+	       [$2_LIBDIR="$1/lib"],
 	       [AS_IF([test -d "$1/lib64"],
-		      [LDFLAGS="-L$1/lib64"],
+		      [$2_LIBDIR="$1/lib64"],
 		      [AC_MSG_WARN([could not find "lib" or "lib64" subdirectories in supplied "$1" directory"])
 		       AC_MSG_ERROR([Cannot continue])
 		      ])

--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -54,7 +54,7 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 	AC_MSG_NOTICE([*** Configuring $1 provider])
 	AC_ARG_ENABLE([$1],
 	      [AS_HELP_STRING([--enable-$1@<:@=yes|no|auto|dl|PATH@:>@],
-			      [Enable $1 provider @<:@default=auto@:>@ 
+			      [Enable $1 provider @<:@default=auto@:>@
 				(yes: enable $1 provider; no: disable $1 provider;
 				auto: enable $1 provider if possible;
 				dl: enable $1 provider and build as a loadable library;

--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -122,6 +122,8 @@ endif !HAVE_GNI_DL
 rdmainclude_HEADERS += \
 	prov/gni/include/fi_ext_gni.h
 
-real_man_pages += man/man7/fi_gni.7
+prov_install_man_pages += man/man7/fi_gni.7
 
 endif HAVE_GNI
+
+prov_dist_man_pages += man/man7/fi_gni.7

--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -97,20 +97,26 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/wait.c \
 	prov/gni/test/common.c
 
-prov_gni_test_gnitest_LDFLAGS = $(CRAY_PMI_LIBS) -static
-prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(CRAY_PMI_CFLAGS)
+prov_gni_test_gnitest_LDFLAGS = $(gni_LDFLAGS) -static
+prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(gni_CPPFLAGS)
 prov_gni_test_gnitest_LDADD = -lcriterion \
-		$(linkback)
-endif
+		$(linkback) $(gni_LIBS)
+endif HAVE_CRITERION
 
 if HAVE_GNI_DL
 pkglib_LTLIBRARIES += libgnix-fi.la
+libgnix_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(gni_CPPFLAGS)
 libgnix_fi_la_SOURCES = $(_gni_files) $(_gni_headers) $(common_srcs)
-libgnix_fi_la_LIBADD = $(linkback)
-libgnix_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+libgnix_fi_la_LDFLAGS = \
+	$(gni_LDFLAGS) \
+	-module -avoid-version -shared -export-dynamic
+libgnix_fi_la_LIBADD = $(linkback) $(gni_LIBS)
 libgnix_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_GNI_DL
 src_libfabric_la_SOURCES += $(_gni_files) $(_gni_headers)
+src_libfabric_la_CPPFLAGS += $(gni_CPPFLAGS)
+src_libfabric_la_LDFLAGS += $(gni_LDFLAGS)
+src_libfabric_la_LIBADD += $(gni_LIBS)
 endif !HAVE_GNI_DL
 
 rdmainclude_HEADERS += \

--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -9,29 +9,32 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
         # have to pull in pkg.m4 manually
 	ugni_lib_happy=0
 	gni_header_happy=0
+	gni_CPPFLAGS=
+	gni_LDFLAGS=
+	gni_LIBS=
 	AS_IF([test x"$enable_gni" != x"no"],
 	      [FI_PKG_CHECK_MODULES([CRAY_UGNI], [cray-ugni],
                                  [ugni_lib_happy=1
-                                  CPPFLAGS="$CRAY_UGNI_CFLAGS $CPPFLAGS"
-                                  LDFLAGS="$CRAY_UGNI_LIBS $LDFLAGS"
+                                  gni_CPPFLAGS=$CRAY_UGNI_CFLAGS
+                                  gni_LDFLAGS=$CRAY_UGNI_LIBS
                                  ],
                                  [ugni_lib_happy=0])
                FI_PKG_CHECK_MODULES([CRAY_GNI_HEADERS], [cray-gni-headers],
                                  [gni_header_happy=1
-                                  CPPFLAGS="$CRAY_GNI_HEADERS_CFLAGS $CPPFLAGS"
-                                  LDFLAGS="$CRAY_GNI_HEADER_LIBS $LDFLAGS"
+                                  gni_CPPFLAGS="$CRAY_GNI_HEADERS_CFLAGS $gni_CPPFLAGS"
+                                  gni_LDFLAGS="$CRAY_GNI_HEADER_LIBS $gni_LDFLAGS"
                                  ],
                                  [gni_header_happy=0])
                FI_PKG_CHECK_MODULES_STATIC([CRAY_ALPS_LLI], [cray-alpslli],
                                  [alps_lli_happy=1
-                                  CPPFLAGS="$CRAY_ALPS_LLI_CFLAGS $CPPFLAGS"
-                                  LDFLAGS="$CRAY_ALPS_LLI_LIBS $LDFLAGS"
+                                  gni_CPPFLAGS="$CRAY_ALPS_LLI_CFLAGS $gni_CPPFLAGS"
+                                  gni_LDFLAGS="$CRAY_ALPS_LLI_LIBS $gni_LDFLAGS"
                                  ],
                                  [alps_lli_happy=0])
                FI_PKG_CHECK_MODULES([CRAY_ALPS_UTIL], [cray-alpsutil],
                                  [alps_util_happy=1
-                                  CPPFLAGS="$CRAY_ALPS_UTIL_CFLAGS $CPPFLAGS"
-                                  LDFLAGS="$CRAY_ALPS_UTIL_LIBS $LDFLAGS"
+                                  gni_CPPFLAGS="$CRAY_ALPS_UTIL_CFLAGS $gni_CPPFLAGS"
+                                  gni_LDFLAGS="$CRAY_ALPS_UTIL_LIBS $gni_LDFLAGS"
                                  ],
                                  [alps_util_happy=0])
 	       ])
@@ -46,12 +49,12 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
 		AC_MSG_CHECKING([criterion path])
 		if test -d "$with_criterion"; then
 			AC_MSG_RESULT([yes])
-			CPPFLAGS="-I$with_criterion/include $CPPFLAGS"
+			gni_CPPFLAGS="-I$with_criterion/include $gni_CPPFLAGS"
 			if test -d "$with_criterion/lib"; then
-				LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib $LDFLAGS"
+				gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib $gni_LDFLAGS"
 				have_criterion=true
 			elif test -d "$with_criterion/lib64"; then
-				LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib64 $LDFLAGS"
+				gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib64 $gni_LDFLAGS"
 				have_criterion=true
 			else
 				have_criterion=false
@@ -67,8 +70,10 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
 
 	AM_CONDITIONAL([HAVE_CRITERION], [test "x$have_criterion" = "xtrue"])
 
+	AC_SUBST(gni_CPPFLAGS)
+	AC_SUBST(gni_LDFLAGS)
+	AC_SUBST(gni_LIBS)
 
 	AS_IF([test $gni_header_happy -eq 1 -a $ugni_lib_happy -eq 1 \
                -a $alps_lli_happy -eq 1 -a $alps_util_happy -eq 1], [$1], [$2])
 ])
-

--- a/prov/mxm/Makefile.include
+++ b/prov/mxm/Makefile.include
@@ -12,10 +12,18 @@ _mxm_files = prov/mxm/src/mlxm.h \
 
 if HAVE_MXM_DL
 pkglib_LTLIBRARIES += libmlxm-fi.la
+libmlxm_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(mxm_CPPFLAGS)
 libmlxm_fi_la_SOURCES = $(_mxm_files) $(common_srcs)
-libmlxm_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic $(linkback)
+libmlxm_fi_la_LDFLAGS = \
+	$(mxm_LDFLAGS) \
+	-module -avoid-version -shared -export-dynamic
+libmlxm_fi_la_LIBADD = $(linkback) $(mxm_LIBS)
+libmlxm_fi_la_DEPENDENCIES = $(linkback)
 else
 src_libfabric_la_SOURCES += $(_mxm_files)
+src_libfabric_la_CPPFLAGS += $(mxm_CPPFLAGS)
+src_libfabric_la_LDFLAGS += $(mxm_LDFLAGS)
+src_libfabric_la_LIBADD += $(mxm_LIBS)
 endif
 
 endif #HAVE_MXM

--- a/prov/mxm/Makefile.include
+++ b/prov/mxm/Makefile.include
@@ -26,4 +26,8 @@ src_libfabric_la_LDFLAGS += $(mxm_LDFLAGS)
 src_libfabric_la_LIBADD += $(mxm_LIBS)
 endif
 
+prov_install_man_pages += man/man7/fi_mxm.7
+
 endif #HAVE_MXM
+
+prov_dist_man_pages += man/man7/fi_mxm.7

--- a/prov/mxm/configure.m4
+++ b/prov/mxm/configure.m4
@@ -8,7 +8,7 @@ dnl $1: action if configured successfully
 dnl $2: action if not configured successfully
 dnl
 AC_DEFUN([FI_MXM_CONFIGURE],[
-	# Determine if we can support the mxm provider
+    # Determine if we can support the mxm provider
     mxm_happy=0
     AS_IF([test x"$enable_mxm" != x"no"],
               [FI_CHECK_PACKAGE([mxm],
@@ -19,12 +19,12 @@ AC_DEFUN([FI_MXM_CONFIGURE],[
                     [],
                     [],
                     [mxm_happy=1],
-                    [mxm_happy=0])  
+                    [mxm_happy=0])
          ])
     AS_IF([test $mxm_happy -eq 1], [$1], [$2])
 
-	CPPFLAGS="$CPPFLAGS $mxm_CPPFLAGS"
-	LDFLAGS="$LDFLAGS $mxm_LDFLAGS"
-	LIBS="$LIBS $mxm_LIBS"
+    CPPFLAGS="$CPPFLAGS $mxm_CPPFLAGS"
+    LDFLAGS="$LDFLAGS $mxm_LDFLAGS"
+    LIBS="$LIBS $mxm_LIBS"
 ])
 

--- a/prov/mxm/configure.m4
+++ b/prov/mxm/configure.m4
@@ -22,9 +22,5 @@ AC_DEFUN([FI_MXM_CONFIGURE],[
                     [mxm_happy=0])
          ])
     AS_IF([test $mxm_happy -eq 1], [$1], [$2])
-
-    CPPFLAGS="$CPPFLAGS $mxm_CPPFLAGS"
-    LDFLAGS="$LDFLAGS $mxm_LDFLAGS"
-    LIBS="$LIBS $mxm_LIBS"
 ])
 

--- a/prov/mxm/configure.m4
+++ b/prov/mxm/configure.m4
@@ -16,8 +16,8 @@ AC_DEFUN([FI_MXM_CONFIGURE],[
                     [mxm],
                     [mxm_get_version],
                     [],
-                    [],
-                    [],
+                    [$mxm_PREFIX],
+                    [$mxm_LIBDIR],
                     [mxm_happy=1],
                     [mxm_happy=0])
          ])

--- a/prov/psm/Makefile.include
+++ b/prov/psm/Makefile.include
@@ -41,6 +41,8 @@ src_libfabric_la_LIBADD += libpsmx.la
 src_libfabric_la_DEPENDENCIES += libpsmx.la
 endif !HAVE_PSM_DL
 
-real_man_pages += man/man7/fi_psm.7
+prov_install_man_pages += man/man7/fi_psm.7
 
 endif HAVE_PSM
+
+prov_dist_man_pages += man/man7/fi_psm.7

--- a/prov/psm/configure.m4
+++ b/prov/psm/configure.m4
@@ -10,16 +10,27 @@ dnl
 AC_DEFUN([FI_PSM_CONFIGURE],[
 	# Determine if we can support the psm provider
 	psm_happy=0
+
+	# Save CPPFLAGS and LDFLAGS because if PSM is found, we need
+	# to do additional tests which require resetting them (and
+	# then we want to set them back to their original values when
+	# done).
+	psm_CPPFLAGS_SAVE=$CPPFLAGS
+	psm_LDFLAGS_SAVE=$LDFLAGS
+
 	AS_IF([test x"$enable_psm" != x"no"],
 	      [FI_CHECK_PACKAGE([psm],
 				[psm.h],
 				[psm_infinipath],
 				[psm_init],
 				[],
-				[],
-				[],
+				[$psm_PREFIX],
+				[$psm_LIBDIR],
 				[psm_happy=1],
 				[psm_happy=0])
+	       AS_IF([test $psm_happy -eq 1],
+		     [LDFLAGS="$LDFLAGS $psm_LDFLAGS"
+		      CPPFLAGS="$CPPFLAGS $psm_CPPFLAGS"])
 	       AS_IF([test $psm_happy -eq 1],
 		     [AC_CHECK_LIB([psm_infinipath],
 				   [psm_am_get_source],
@@ -34,4 +45,11 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 	      ])
 
 	AS_IF([test $psm_happy -eq 1], [$1], [$2])
+
+	# Reset CPPFLAGS and LDFLAGS back to their original values and
+	# tidy up
+	CPPFLAGS=$psm_CPPFLAGS_SAVE
+	unset psm_CPPFLAGS_SAVE
+	LDFLAGS=$psm_LDFLAGS_SAVE
+	unset psm_LDFLAGS_SAVE
 ])

--- a/prov/psm/configure.m4
+++ b/prov/psm/configure.m4
@@ -34,10 +34,4 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 	      ])
 
 	AS_IF([test $psm_happy -eq 1], [$1], [$2])
-
-	psm_CPPFLAGS="$CPPFLAGS $psm_CPPFLAGS"
-	psm_LDFLAGS="$LDFLAGS $psm_LDFLAGS"
-	psm_LIBS="$LIBS $psm_LIBS"
-	CPPFLAGS="$psm_orig_CPPFLAGS"
-	LDFLAGS="$psm_orig_LDFLAGS"
 ])

--- a/prov/psm2/Makefile.include
+++ b/prov/psm2/Makefile.include
@@ -40,6 +40,8 @@ src_libfabric_la_LIBADD += libpsmx2.la
 src_libfabric_la_DEPENDENCIES += libpsmx2.la
 endif !HAVE_PSM2_DL
 
-real_man_pages += man/man7/fi_psm2.7
+prov_install_man_pages += man/man7/fi_psm2.7
 
 endif HAVE_PSM2
+
+prov_dist_man_pages += man/man7/fi_psm2.7

--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -16,8 +16,8 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 				[psm2],
 				[psm2_init],
 				[],
-				[],
-				[],
+				[$psm2_PREFIX],
+				[$psm2_LIBDIR],
 				[psm2_happy=1],
 				[psm2_happy=0])
 	      ])

--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -23,11 +23,5 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 	      ])
 
 	AS_IF([test $psm2_happy -eq 1], [$1], [$2])
-
-	psm2_CPPFLAGS="$CPPFLAGS $psm2_CPPFLAGS"
-	psm2_LDFLAGS="$LDFLAGS $psm2_LDFLAGS"
-	psm2_LIBS="$LIBS $psm2_LIBS"
-	CPPFLAGS="$psm2_orig_CPPFLAGS"
-	LDFLAGS="$psm2_orig_LDFLAGS"
 ])
 

--- a/prov/sockets/Makefile.include
+++ b/prov/sockets/Makefile.include
@@ -36,6 +36,8 @@ src_libfabric_la_SOURCES += $(_sockets_files)
 src_libfabric_la_LIBADD += $(sockets_LIBS)
 endif !HAVE_SOCKETS_DL
 
-real_man_pages += man/man7/fi_sockets.7
+prov_install_man_pages += man/man7/fi_sockets.7
 
 endif HAVE_SOCKETS
+
+prov_dist_man_pages += man/man7/fi_sockets.7

--- a/prov/sockets/Makefile.include
+++ b/prov/sockets/Makefile.include
@@ -28,12 +28,12 @@ _sockets_files = \
 if HAVE_SOCKETS_DL
 pkglib_LTLIBRARIES += libsockets-fi.la
 libsockets_fi_la_SOURCES = $(_sockets_files) $(common_srcs)
-libsockets_fi_la_LIBADD = $(linkback) $(sockets_shm_LIBS)
+libsockets_fi_la_LIBADD = $(linkback) $(sockets_LIBS)
 libsockets_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
 libsockets_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_SOCKETS_DL
 src_libfabric_la_SOURCES += $(_sockets_files)
-src_libfabric_la_LIBADD += $(sockets_shm_LIBS)
+src_libfabric_la_LIBADD += $(sockets_LIBS)
 endif !HAVE_SOCKETS_DL
 
 real_man_pages += man/man7/fi_sockets.7

--- a/prov/sockets/configure.m4
+++ b/prov/sockets/configure.m4
@@ -23,7 +23,7 @@ AC_DEFUN([FI_SOCKETS_CONFIGURE],[
 
 	       # look for shm_open in librt if not already present
 	       AS_IF([test $sockets_shm_happy -eq 0],
-		     [FI_CHECK_PACKAGE([sockets_shm],
+		     [FI_CHECK_PACKAGE([sockets],
 				[sys/mman.h],
 				[rt],
 				[shm_open],

--- a/prov/usnic/Makefile.include
+++ b/prov/usnic/Makefile.include
@@ -95,20 +95,11 @@ _usnic_files = \
 
 if HAVE_VERBS
 _usnic_files += prov/usnic/src/usdf_fake_ibv.c
-
-# If the verbs or usnic providers are being built as a DL, then we
-# need to link libibverbs into the usnic provider
-if HAVE_VERBS_DL
-_usnic_libibverbs = -libverbs
-endif
-if HAVE_USNIC_DL
-_usnic_libibverbs = -libverbs
-endif
 endif
 
 _usnic_cppflags = \
         -D__LIBUSNIC__ -DWANT_DEBUG_MSGS=0 \
-        -DHAVE_LIBNL3=$(HAVE_LIBNL3) $(usnic_nl_CPPFLAGS) \
+        -DHAVE_LIBNL3=$(HAVE_LIBNL3) $(usnic_CPPFLAGS) \
         -I$(top_srcdir)/prov/usnic/src/usnic_direct
 
 rdmainclude_HEADERS += \
@@ -121,13 +112,13 @@ libusnic_fi_la_SOURCES = $(_usnic_files) $(common_srcs)
 libusnic_fi_la_LDFLAGS = \
         $(usnic_ln_LDFLAGS) \
         -module -avoid-version -shared -export-dynamic
-libusnic_fi_la_LIBADD = $(linkback) $(_usnic_libibverbs) $(usnic_nl_LIBS)
+libusnic_fi_la_LIBADD = $(linkback) $(usnic_LIBS)
 libusnic_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_USNIC_DL
 src_libfabric_la_SOURCES += $(_usnic_files)
 src_libfabric_la_CPPFLAGS += $(_usnic_cppflags)
-src_libfabric_la_LDFLAGS += $(usnic_nl_LDFLAGS)
-src_libfabric_la_LIBADD += $(_usnic_libibverbs) $(usnic_nl_LIBS)
+src_libfabric_la_LDFLAGS += $(usnic_LDFLAGS)
+src_libfabric_la_LIBADD += $(usnic_LIBS)
 endif !HAVE_USNIC_DL
 
 real_man_pages += man/man7/fi_usnic.7

--- a/prov/usnic/Makefile.include
+++ b/prov/usnic/Makefile.include
@@ -121,6 +121,8 @@ src_libfabric_la_LDFLAGS += $(usnic_LDFLAGS)
 src_libfabric_la_LIBADD += $(usnic_LIBS)
 endif !HAVE_USNIC_DL
 
-real_man_pages += man/man7/fi_usnic.7
+prov_install_man_pages += man/man7/fi_usnic.7
 
 endif HAVE_USNIC
+
+prov_dist_man_pages += man/man7/fi_usnic.7

--- a/prov/verbs/Makefile.include
+++ b/prov/verbs/Makefile.include
@@ -28,20 +28,16 @@ _verbs_files = \
 if HAVE_VERBS_DL
 pkglib_LTLIBRARIES += libverbs-fi.la
 libverbs_fi_la_SOURCES = $(_verbs_files) $(common_srcs)
-# Technically, verbs_ibverbs_CPPFLAGS and verbs_rdmacm_CPPFLAGS could
-# be different, but it is highly unlikely that they ever will be.  So
-# only list verbs_ibverbs_CPPFLAGS here.  Same with verbs_*_LDFLAGS,
-# below.
-libverbs_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(verbs_ibverbs_CPPFLAGS)
+libverbs_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(verbs_CPPFLAGS)
 libverbs_fi_la_LDFLAGS = \
-    -module -avoid-version -shared -export-dynamic $(verbs_ibverbs_LDFLAGS)
-libverbs_fi_la_LIBADD = $(linkback) $(verbs_rdmacm_LIBS) $(verbs_ibverbs_LIBS)
+    -module -avoid-version -shared -export-dynamic $(verbs_LDFLAGS)
+libverbs_fi_la_LIBADD = $(linkback) $(verbs_LIBS)
 libverbs_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_VERBS_DL
 src_libfabric_la_SOURCES += $(_verbs_files)
-src_libfabric_la_CPPFLAGS += $(verbs_ibverbs_CPPFLAGS)
-src_libfabric_la_LDFLAGS += $(verbs_ibverbs_LDFLAGS)
-src_libfabric_la_LIBADD += $(verbs_rdmacm_LIBS) $(verbs_ibverbs_LIBS)
+src_libfabric_la_CPPFLAGS += $(verbs_CPPFLAGS)
+src_libfabric_la_LDFLAGS += $(verbs_LDFLAGS)
+src_libfabric_la_LIBADD += $(verbs_LIBS)
 endif !HAVE_VERBS_DL
 
 real_man_pages += man/man7/fi_verbs.7

--- a/prov/verbs/Makefile.include
+++ b/prov/verbs/Makefile.include
@@ -40,6 +40,8 @@ src_libfabric_la_LDFLAGS += $(verbs_LDFLAGS)
 src_libfabric_la_LIBADD += $(verbs_LIBS)
 endif !HAVE_VERBS_DL
 
-real_man_pages += man/man7/fi_verbs.7
+prov_install_man_pages += man/man7/fi_verbs.7
 
 endif HAVE_VERBS
+
+prov_dist_man_pages += man/man7/fi_verbs.7

--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -35,4 +35,16 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 
 	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
 	       test $verbs_rdmacm_happy -eq 1], [$1], [$2])
+
+	# Technically, verbs_ibverbs_CPPFLAGS and
+	# verbs_rdmacm_CPPFLAGS could be different, but it is highly
+	# unlikely that they ever will be.  So only list
+	# verbs_ibverbs_CPPFLAGS here.  Same with verbs_*_LDFLAGS,
+	# below.
+	verbs_CPPFLAGS=$verbs_ibverbs_CPPFLAGS
+	verbs_LDFLAGS=$verbs_ibverbs_LDFLAGS
+	verbs_LIBS="$verbs_rdmacm_LIBS $verbs_ibverbs_LIBS"
+	AC_SUBST(verbs_CPPFLAGS)
+	AC_SUBST(verbs_LDFLAGS)
+	AC_SUBST(verbs_LIBS)
 ])

--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -17,8 +17,8 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 				[ibverbs],
 				[ibv_open_device],
 				[],
-				[],
-				[],
+				[$verbs_PREFIX],
+				[$verbs_LIBDIR],
 				[verbs_ibverbs_happy=1],
 				[verbs_ibverbs_happy=0])
 
@@ -27,8 +27,8 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 				[rdmacm],
 				[riowrite],
 				[],
-				[],
-				[],
+				[$verbs_PREFIX],
+				[$verbs_LIBDIR],
 				[verbs_rdmacm_happy=1],
 				[verbs_rdmacm_happy=0])
 	      ])


### PR DESCRIPTION
This PR updates the provider build systems for the pkg-config PR (#1544 @disprosium8).

To support pkg-config, each provider's configure/build system has to condense its compiler/linker flags down to the `PROVIDER_CPPFLAGS`, `PROVIDER_LDFLAGS`, and `PROVIDER_LIBS` macros.  This allows the pkg-config setup to find/use these standardized flags when creating the pkg-config metadata file.

This looks like a big change, but it's really a series of small changes -- so it isn't as scary as it initially looks (pro tip: look at the individual commits, not just the overall "files changed" tab).

Sidenote: this pkg-config update turned into a good forcing function.  It looks like a few of the providers were mis-using the top-level `CPPFLAGS`, `LDFLAGS`, and `LIBS`.  This was accidentally allowed by `config/fi_provider.m4` forgetting to reset `CPPFLAGS`/`LDFLAGS` back to their original values after configuring a provider.  This PR also fixes this issue: providers now *have* to set macros and `AC_SUBST` them in order to propagate them to their Makefile.include files.

***I do not have the ability to test most of these changes!***  This PR makes changes to the build systems of the GNI, MXM, PSM, PSM2, sockets, usnic, and verbs providers.  I can only test sockets, usnic, and verbs.  Overall, this PR needs testing+reviews from the following providers:

- [x] GNI provider
- [x] MXM provider
- [x] PSM provider
- [x] PSM2 provider
- [x] sockets provider
- [x] usnic provider
- [x] verbs provider