### PR TITLE
prov/gni: Fix criterion test for fi_no* change.

### DIFF
--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -597,10 +597,10 @@ Test(cq_wait_ops, fd, .init = cq_wait_fd_setup)
 {
 	cr_expect_neq(cq_priv->cq_fid.ops->signal, fi_no_cq_signal,
 		      "signal implementation not available.");
-	cr_expect_neq(cq_priv->cq_fid.ops->sread, fi_no_cq_sread,
-		      "sread implementation not available.");
-	cr_expect_neq(cq_priv->cq_fid.ops->sreadfrom, fi_no_cq_sreadfrom,
-		      "sreadfrom implementation not available.");
+	cr_expect_eq(cq_priv->cq_fid.ops->sread, fi_no_cq_sread,
+		     "sread implementation available.");
+	cr_expect_eq(cq_priv->cq_fid.ops->sreadfrom, fi_no_cq_sreadfrom,
+		     "sreadfrom implementation available.");
 	cr_expect_neq(cq_priv->cq_fid.fid.ops->control, fi_no_control,
 		      "control implementation not available.");
 }


### PR DESCRIPTION
upstream merge of ofi-cray/libfabric-cray#571

I must have screwed up my testing, because I missed this failing test.

@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@c2810e1dd8633c660b01b5f766f4b424bac30a81)