### PR TITLE
usnic: Update protocol handling and versioning for EP_RDM and EP_MSG.

### DIFF
--- a/prov/usnic/src/fi_ext_usnic.h
+++ b/prov/usnic/src/fi_ext_usnic.h
@@ -42,7 +42,7 @@
 #include <stdint.h>
 #include <net/if.h>
 
-#define FI_PROTO_RUDP 100
+#define FI_PROTO_RUDP (100 | FI_PROV_SPECIFIC)
 
 #define FI_EXT_USNIC_INFO_VERSION 1
 

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -93,9 +93,13 @@ static const struct fi_rx_attr msg_dflt_rx_attr = {
 	.iov_limit = USDF_MSG_IOV_LIMIT
 };
 
+/* The protocol for MSG is still under development. Version 0 does not provide
+ * any interoperability.
+ */
 static const struct fi_ep_attr msg_dflt_ep_attr = {
 	.type = FI_EP_MSG,
 	.protocol = FI_PROTO_RUDP,
+	.protocol_version = 0,
 	.msg_prefix_size = 0,
 	.max_msg_size = USDF_MSG_MAX_MSG,
 	.max_order_raw_size = 0,

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -94,9 +94,13 @@ static const struct fi_rx_attr rdm_dflt_rx_attr = {
 	.iov_limit = USDF_RDM_DFLT_SGE
 };
 
+/* The protocol for RDM is still under development. Version 0 does not provide
+ * any interoperability.
+ */
 static const struct fi_ep_attr rdm_dflt_ep_attr = {
 	.type = FI_EP_RDM,
-	.protocol = FI_PROTO_UDP,
+	.protocol = FI_PROTO_RUDP,
+	.protocol_version = 0,
 	.max_msg_size = USDF_RDM_MAX_MSG,
 	.msg_prefix_size = 0,
 	.max_order_raw_size = 0,


### PR DESCRIPTION
- EP_RDM should not be reporting UDP.
- Or FI_PROTO_RUDP with FI_PROV_SPECIFIC.
- Explicitly report version 0 with a comment indicating the situation.

@jsquyres @shefty 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>