### PR TITLE
verbs: Disable provider if RAI_FAMILY is not defined

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -25,7 +25,7 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 	       FI_CHECK_PACKAGE([verbs_rdmacm],
 				[rdma/rsocket.h],
 				[rdmacm],
-				[rsocket],
+				[riowrite],
 				[],
 				[],
 				[],


### PR DESCRIPTION
librdmacm version 1.0.16 and lower don't have RAI_FAMILY
constant defined. Disable verbs provider in such cases to
prevent compile issues.

This should fix #1553.