### PR TITLE
usnic: fi_shutdown is not supported.

### DIFF
--- a/man/fi_usnic.7.md
+++ b/man/fi_usnic.7.md
@@ -49,8 +49,8 @@ low latency and other offload capabilities on Ethernet networks.
       provider:
         * multicast operations are not supported on *FI_EP_DGRAM* and
           *FI_EP_RDM* endpoints.
-        * *FI_EP_MSG* endpoints only support connect, accept, getname, and
-          shutdown CM operations.
+        * *FI_EP_MSG* endpoints only support connect, accept, and getname
+          CM operations.
         * Passive endpoints only support listen, setname, and getname CM
           operations.
         * *FI_EP_DGRAM* endpoints support `fi_sendmsg()` and

--- a/prov/usnic/src/usdf_cm.c
+++ b/prov/usnic/src/usdf_cm.c
@@ -483,13 +483,6 @@ fail:
 	return ret;
 }
 
-int
-usdf_cm_msg_shutdown(struct fid_ep *ep, uint64_t flags)
-{
-	USDF_TRACE_SYS(EP_CTRL, "\n");
-	return -FI_ENOSYS;
-}
-
 /*
  * Return local address of an EP
  */

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -853,7 +853,7 @@ static struct fi_ops_cm usdf_cm_msg_ops = {
 	.listen = fi_no_listen,
 	.accept = usdf_cm_msg_accept,
 	.reject = fi_no_reject,
-	.shutdown = usdf_cm_msg_shutdown,
+	.shutdown = fi_no_shutdown,
 };
 
 static struct fi_ops_msg usdf_msg_ops = {

--- a/prov/usnic/src/usdf_msg.h
+++ b/prov/usnic/src/usdf_msg.h
@@ -105,7 +105,6 @@ void usdf_msg_tx_progress(struct usdf_tx *tx);
 int usdf_cm_msg_connect(struct fid_ep *ep, const void *addr,
 	const void *param, size_t paramlen);
 int usdf_cm_msg_accept(struct fid_ep *fep, const void *param, size_t paramlen);
-int usdf_cm_msg_shutdown(struct fid_ep *ep, uint64_t flags);
 
 /* fi_ops_msg for RC */
 ssize_t usdf_msg_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,


### PR DESCRIPTION
- Remove usdf_cm_msg_shutdown and replace with fi_no_shutdown in ops.
- Correct fi_usnic man page.

Found by #1567.

@jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>