### PR TITLE
Add some GNIX_WARN calls and curly braces

### DIFF
--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -260,17 +260,22 @@ check_again:
 	assert(p->progress_fn);
 
 	ret = p->progress_fn(p->data, &complete);
-	if (ret != FI_SUCCESS)
+	if (ret != FI_SUCCESS) {
 		GNIX_WARN(FI_LOG_EP_CTRL,
 			  "dgram prog fn returned %s\n",
-				  fi_strerror(-ret));
+			  fi_strerror(-ret));
+	}
 
 	if (complete == 1) {
 		if (p->completer_fn) {
 			ret = p->completer_fn(p->completer_data);
 			free(p);
-			if (ret != FI_SUCCESS)
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "dgram completer fn returned %s\n",
+					  fi_strerror(-ret));
 				goto err;
+			}
 		}
 		goto check_again;
 	} else {

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -346,12 +346,13 @@ int _gnix_dgram_bnd_post(struct gnix_datagram *d)
 	}
 
 	fastlock_acquire(&d->nic->lock);
-	if (d->pre_post_clbk_fn != NULL)
+	if (d->pre_post_clbk_fn != NULL) {
 		ret = d->pre_post_clbk_fn(d, &post);
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				"pre_post_callback_fn: %d\n",
 				ret);
+	}
 
 	if (post) {
 		/*
@@ -368,12 +369,13 @@ int _gnix_dgram_bnd_post(struct gnix_datagram *d)
 					   d->dgram_out_buf,
 					   GNI_DATAGRAM_MAXSIZE,
 					   (uint64_t)d);
-		if (d->post_post_clbk_fn != NULL)
+		if (d->post_post_clbk_fn != NULL) {
 			ret = d->post_post_clbk_fn(d, status);
 			if (ret != FI_SUCCESS)
 				GNIX_WARN(FI_LOG_EP_CTRL,
 				"post_post_callback_fn: %d\n",
 				ret);
+		}
 	}
 	fastlock_release(&d->nic->lock);
 
@@ -392,8 +394,9 @@ int _gnix_dgram_bnd_post(struct gnix_datagram *d)
 			 * datagram is active now, connecting
 			 */
 			d->state = GNIX_DGRAM_STATE_CONNECTING;
-		} else
+		} else {
 			ret = -FI_EBUSY;
+		}
 	}
 
 err:

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1239,6 +1239,9 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		if (flags & FI_SEND) {
 			/* don't allow rebinding */
 			if (ep->send_cntr) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "cannot rebind send counter (%p)\n",
+					  cntr);
 				ret = -FI_EINVAL;
 				break;
 			}
@@ -1250,6 +1253,9 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		if (flags & FI_RECV) {
 			/* don't allow rebinding */
 			if (ep->recv_cntr) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "cannot rebind recv counter (%p)\n",
+					  cntr);
 				ret = -FI_EINVAL;
 				break;
 			}
@@ -1261,6 +1267,9 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		if (flags & FI_READ) {
 			/* don't allow rebinding */
 			if (ep->read_cntr) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "cannot rebind read counter (%p)\n",
+					  cntr);
 				ret = -FI_EINVAL;
 				break;
 			}
@@ -1272,6 +1281,9 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		if (flags & FI_WRITE) {
 			/* don't allow rebinding */
 			if (ep->write_cntr) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					  "cannot rebind write counter (%p)\n",
+					  cntr);
 				ret = -FI_EINVAL;
 				break;
 			}
@@ -1286,9 +1298,12 @@ static int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		   option could be supported via Aries atomics
 		   or using SMSG cntrl messages */
 
-		if ((flags & FI_REMOTE_WRITE) ||
-			(flags & FI_REMOTE_READ))
+		if ((flags & FI_REMOTE_WRITE) || (flags & FI_REMOTE_READ)) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "unsupported counter flags (%p)\n",
+				  cntr);
 			ret = -FI_ENOSYS;
+		}
 		break;
 
 	case FI_CLASS_MR:/*TODO: got to figure this one out */

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -102,12 +102,14 @@ static int __gnix_rma_send_completion(struct gnix_fid_ep *ep,
 	}
 
 	if ((req->type == GNIX_FAB_RQ_RDMA_WRITE) &&
-	    ep->write_cntr)
+	    ep->write_cntr) {
 		cntr = ep->write_cntr;
+	}
 
 	if ((req->type == GNIX_FAB_RQ_RDMA_READ) &&
-	    ep->read_cntr)
+	    ep->read_cntr) {
 		cntr = ep->read_cntr;
+	}
 
 	if (cntr) {
 		rc = _gnix_cntr_inc(cntr);


### PR DESCRIPTION
Found these when tracking down another issue:

- Added GNIX_WARN calls as needed
- Added curly braces to single statement ifs, and a couple cases where
  missing the braces was actually wrong (tho benign)

upstream merge of ofi-cray/libfabric-cray#564

@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@fa37ca255a90baf1ea697f111fbf37df70b4c5f1)