### PR TITLE
prov/gni: get criterion working again

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -97,8 +97,8 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/wait.c \
 	prov/gni/test/common.c
 
-prov_gni_test_gnitest_LDFLAGS = $(gni_LDFLAGS) -static
-prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(gni_CPPFLAGS)
+prov_gni_test_gnitest_LDFLAGS = $(CRAY_PMI_LIBS) $(gni_LDFLAGS) -static
+prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(CRAY_PMI_CFLAGS) $(gni_CPPFLAGS)
 prov_gni_test_gnitest_LDADD = -lcriterion \
 		$(linkback) $(gni_LIBS)
 endif HAVE_CRITERION


### PR DESCRIPTION
get criterion working again.  criterion tests
take some extra libs not needed for pkg-config
.pc file contents.

@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>