### PR TITLE
sockets: Use fi_strerror for converting fi_errno values.

### DIFF
--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -353,8 +353,8 @@ static const char *sock_cq_strerror(struct fid_cq *cq, int prov_errno,
 			      const void *err_data, char *buf, size_t len)
 {
 	if (buf && len)
-		return strncpy(buf, strerror(-prov_errno), len);
-	return strerror(-prov_errno);
+		return strncpy(buf, fi_strerror(-prov_errno), len);
+	return fi_strerror(-prov_errno);
 }
 
 static int sock_cq_close(struct fid *fid)


### PR DESCRIPTION
While testing I noticed this output:

```
Completion error: [ERR:265][PROV_ERR:-265](Truncation error) - Unknown error 265
```

From looking at the socket providers code it seems to be using `FI_E*` error codes. Replace `strerror` with `fi_strerror` so the values can be properly converted to strings. I think this is the correct fix, but I'd appreciate if it were looked over and confirmed.

After this fix:

```
Completion error: [ERR:265][PROV_ERR:-265](Truncation error) - Truncation error
```

@shantonu @shefty @jithinjosepkl 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>