### PR TITLE
usnic: Report truncation error in RDM endpoint.

### DIFF
--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -96,7 +96,6 @@ usdf_cq_readerr(struct fid_cq *fcq, struct fi_cq_err_entry *entry,
 
 	entry->op_context = cq->cq_comp.uc_context;
 	entry->flags = 0;
-	entry->err = FI_EIO;
 	switch (cq->cq_comp.uc_status) {
 	case USD_COMPSTAT_SUCCESS:
 		entry->prov_errno = FI_SUCCESS;
@@ -111,9 +110,11 @@ usdf_cq_readerr(struct fid_cq *fcq, struct fi_cq_err_entry *entry,
 		entry->prov_errno = FI_ETIMEDOUT;
 		break;
 	case USD_COMPSTAT_ERROR_INTERNAL:
+	default:
 		entry->prov_errno = FI_EOTHER;
 		break;
 	}
+	entry->err = entry->prov_errno;
 
 	cq->cq_comp.uc_status = 0;
 
@@ -135,8 +136,8 @@ usdf_cq_readerr_soft(struct fid_cq *fcq, struct fi_cq_err_entry *entry,
 
 	entry->op_context = tail->cse_context;
 	entry->flags = 0;
-	entry->err = FI_EIO;
 	entry->prov_errno = tail->cse_prov_errno;
+	entry->err = entry->prov_errno;
 
 	tail++;
 	if (tail == cq->c.soft.cq_end) {

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -1112,15 +1112,16 @@ usdf_rdm_tx_progress(struct usdf_tx *tx)
 	}
 }
 
-static inline void
-usdf_rdm_recv_complete(struct usdf_rx *rx, struct usdf_rdm_connection *rdc,
-		struct usdf_rdm_qe *rqe)
+static inline void usdf_rdm_recv_complete(struct usdf_rx *rx,
+					  struct usdf_rdm_connection *rdc,
+					  struct usdf_rdm_qe *rqe, int status)
 {
 	struct usdf_cq_hard *hcq;
 
-	USDF_DBG_SYS(EP_DATA, "RECV complete ID=%u len=%lu\n", rdc->dc_rx_msg_id, rqe->rd_length);
+	USDF_DBG_SYS(EP_DATA, "RECV complete ID=%u len=%lu with status %d\n",
+		     rdc->dc_rx_msg_id, rqe->rd_length, status);
 	hcq = rx->r.rdm.rx_hcq;
-	hcq->cqh_post(hcq, rqe->rd_context, rqe->rd_length, FI_SUCCESS);
+	hcq->cqh_post(hcq, rqe->rd_context, rqe->rd_length, status);
 
 	usdf_rdm_put_rx_rqe(rx, rqe);
 
@@ -1544,10 +1545,11 @@ usdf_rdm_handle_recv(struct usdf_domain *udp, struct usd_completion *comp)
 	rqe->rd_resid = rd_resid;
 
 	if (rxlen > 0) {
+		USDF_DBG_SYS(EP_DATA, "RQE truncated by %zu bytes\n", rxlen);
 		rqe->rd_length -= rxlen;
-/* printf("RQE truncated XXX\n"); */
+		usdf_rdm_recv_complete(rx, rdc, rqe, FI_ETRUNC);
 	} else if (opcode & RUDP_OP_LAST) {
-		usdf_rdm_recv_complete(rx, rdc, rqe);
+		usdf_rdm_recv_complete(rx, rdc, rqe, FI_SUCCESS);
 	}
 
 repost:


### PR DESCRIPTION
- Update usdf_rdm_recv_complete to also handle posting error entries to
  the CQ.
- If rxlen is still left over then it is a truncation and should be
  reported as such.

@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>