### PR TITLE
prov/sockets: Use fi_strerror for converting fi_errno values EQ.

### DIFF
--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -250,8 +250,8 @@ static const char *sock_eq_strerror(struct fid_eq *eq, int prov_errno,
 			      const void *err_data, char *buf, size_t len)
 {
 	if (buf && len)
-		return strncpy(buf, strerror(-prov_errno), len);
-	return strerror(-prov_errno);
+		return strncpy(buf, fi_strerror(-prov_errno), len);
+	return fi_strerror(-prov_errno);
 }
 
 static struct fi_ops_eq sock_eq_ops = {


### PR DESCRIPTION
Use fi_strerror for converting fi_errno values EQ.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>