### PR TITLE
Explicitly specify types for constants

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -86,7 +86,7 @@ typedef struct fid *fid_t;
 /*
  * Provider specific values are indicated by setting the high-order bit.
  */
-#define FI_PROV_SPECIFIC	(1 << 31)
+#define FI_PROV_SPECIFIC	(1U << 31)
 
 /*
  * Flags

--- a/prov/usnic/src/fi_ext_usnic.h
+++ b/prov/usnic/src/fi_ext_usnic.h
@@ -42,7 +42,7 @@
 #include <stdint.h>
 #include <net/if.h>
 
-#define FI_PROTO_RUDP (100 | FI_PROV_SPECIFIC)
+#define FI_PROTO_RUDP (100U | FI_PROV_SPECIFIC)
 
 #define FI_EXT_USNIC_INFO_VERSION 1
 


### PR DESCRIPTION
From the discussion on #1562.

@shefty @goodell 