### PR TITLE
usnic: gracefully handle when nl_send() temporarily fails

### DIFF
--- a/prov/usnic/src/usnic_direct/libnl1_utils.h
+++ b/prov/usnic/src/usnic_direct/libnl1_utils.h
@@ -95,4 +95,17 @@ struct usnic_rt_cb_arg {
 	struct usnic_nl_sk	*unlsk;
 };
 
+/* libnl1 and libnl3 return kernel resource exhaustion in different
+ * ways.  Use this macro to abstract the differences away.
+ *
+ * In libnl1, nl_send() will return -ECONNREFUSED. */
+#define USD_NL_SEND(nlh, msg, ret, retry)				\
+	do {								\
+		retry = 0;						\
+		ret = nl_send((nlh), (msg));				\
+		if (ret == -ECONNREFUSED) {				\
+			retry = 1;					\
+		}							\
+	} while(0);
+
 #endif /* LIBNL1_UTILS_H */

--- a/prov/usnic/src/usnic_direct/libnl3_utils.h
+++ b/prov/usnic/src/usnic_direct/libnl3_utils.h
@@ -80,4 +80,18 @@ struct usnic_rt_cb_arg {
 	struct usnic_nl_sk	*unlsk;
 };
 
+/* libnl1 and libnl3 return kernel resource exhaustion in different
+ * ways.  Use this macro to abstract the differences away.
+ *
+ * In libnl3, nl_send() will return -NLE_FAILURE and
+ * errno==ECONNREFUSED. */
+#define USD_NL_SEND(nlh, msg, ret, retry)				\
+	do {								\
+		retry = 0;						\
+		ret = nl_send((nlh), (msg));				\
+		if (ret == -NLE_FAILURE && errno == ECONNREFUSED) {	\
+			retry = 1;					\
+		}							\
+	} while(0);
+
 #endif /* LIBNL3_UTILS_H */


### PR DESCRIPTION
If nl_send() fails with return==-1 and errno=ECONNREFUSED, it means that the libnl part of the kernel simply ran out of resources.  Delay a little bit to let kernel/libnl do some work and reclaim resources, and then try again.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@bturrubiates @goodell please review