### PR TITLE
prov/sockets: Initiate conn-msg on the same tx_ctx on which the tx op was initiated

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -1046,10 +1046,11 @@ int sock_av_get_addr_index(struct sock_av *av, struct sockaddr_in *addr);
 
 struct sock_conn *sock_ep_lookup_conn(struct sock_ep *ep, fi_addr_t index,
                                       struct sockaddr_in *addr);
-int sock_ep_get_conn(struct sock_ep *ep, fi_addr_t index,
-                     struct sock_conn **pconn);
+int sock_ep_get_conn(struct sock_ep *ep, struct sock_tx_ctx *tx_ctx, 
+		     fi_addr_t index, struct sock_conn **pconn);
 struct sock_conn *sock_ep_connect(struct sock_ep *ep, fi_addr_t index);
-ssize_t sock_conn_send_src_addr(struct sock_ep *sock_ep, struct sock_conn *conn);
+ssize_t sock_conn_send_src_addr(struct sock_ep *sock_ep, struct sock_tx_ctx *tx_ctx,
+				struct sock_conn *conn);
 int sock_conn_listen(struct sock_ep *ep);
 void sock_conn_map_destroy(struct sock_conn_map *cmap);
 void sock_set_sockopts(int sock);

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -93,7 +93,7 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
 
-	ret = sock_ep_get_conn(sock_ep, msg->addr, &conn);
+	ret = sock_ep_get_conn(sock_ep, tx_ctx, msg->addr, &conn);
 	if (ret)
 		return ret;
 

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -55,17 +55,12 @@
 #define SOCK_LOG_DBG(...) _SOCK_LOG_DBG(FI_LOG_EP_CTRL, __VA_ARGS__)
 #define SOCK_LOG_ERROR(...) _SOCK_LOG_ERROR(FI_LOG_EP_CTRL, __VA_ARGS__)
 
-ssize_t sock_conn_send_src_addr(struct sock_ep *sock_ep, struct sock_conn *conn)
+ssize_t sock_conn_send_src_addr(struct sock_ep *sock_ep, struct sock_tx_ctx *tx_ctx,
+				struct sock_conn *conn)
 {
 	int ret;
 	uint64_t total_len;
 	struct sock_op tx_op;
-	struct sock_tx_ctx *tx_ctx;
-
-	if (sock_ep->ep.fid.fclass == FI_CLASS_SEP)
-		tx_ctx = sock_ep->tx_array[0];
-	else
-		tx_ctx = sock_ep->tx_ctx;
 
 	memset(&tx_op, 0, sizeof(struct sock_op));
 	tx_op.op = SOCK_OP_CONN_MSG;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1594,8 +1594,8 @@ struct sock_conn *sock_ep_lookup_conn(struct sock_ep *ep, fi_addr_t index,
 	return conn;
 }
 
-int sock_ep_get_conn(struct sock_ep *ep, fi_addr_t index,
-			struct sock_conn **pconn)
+int sock_ep_get_conn(struct sock_ep *ep, struct sock_tx_ctx *tx_ctx,
+		     fi_addr_t index, struct sock_conn **pconn)
 {
 	struct sock_conn *conn;
 	uint64_t av_index = (ep->ep_type == FI_EP_MSG) ? 0 : index;
@@ -1621,7 +1621,7 @@ int sock_ep_get_conn(struct sock_ep *ep, fi_addr_t index,
 		return -errno;
 
 	*pconn = conn;
-	return conn->address_published ? 0 : sock_conn_send_src_addr(ep, conn);
+	return conn->address_published ? 0 : sock_conn_send_src_addr(ep, tx_ctx, conn);
 }
 
 int sock_ep_is_send_cq_low(struct sock_comp *comp, uint64_t flags)

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -209,7 +209,7 @@ ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	if (sock_drop_packet(sock_ep))
 		return 0;
 
-	ret = sock_ep_get_conn(sock_ep, msg->addr, &conn);
+	ret = sock_ep_get_conn(sock_ep, tx_ctx, msg->addr, &conn);
 	if (ret)
 		return ret;
 
@@ -550,7 +550,7 @@ ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 	if (sock_drop_packet(sock_ep))
 		return 0;
 
-	ret = sock_ep_get_conn(sock_ep, msg->addr, &conn);
+	ret = sock_ep_get_conn(sock_ep, tx_ctx, msg->addr, &conn);
 	if (ret)
 		return ret;
 

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -93,7 +93,7 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
 
-	ret = sock_ep_get_conn(sock_ep, msg->addr, &conn);
+	ret = sock_ep_get_conn(sock_ep, tx_ctx, msg->addr, &conn);
 	if (ret)
 		return ret;
 
@@ -257,7 +257,7 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
 
-	ret = sock_ep_get_conn(sock_ep, msg->addr, &conn);
+	ret = sock_ep_get_conn(sock_ep, tx_ctx, msg->addr, &conn);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
prov/sockets: Initiate conn-msg on the same tx_ctx on which the tx
operation was initiated in case of scalable-endpoints.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>