### PR TITLE
sockets: Fixes for scalable-ep av mask calculation and address lookup

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -585,7 +585,7 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	}
 	_av->rx_ctx_bits = attr->rx_ctx_bits;
 	_av->mask = attr->rx_ctx_bits ?
-		((uint64_t)1<<(64 - attr->rx_ctx_bits + 1))-1 : ~0;
+		((uint64_t)1 << (64 - attr->rx_ctx_bits)) - 1 : ~0;
 	*av = &_av->av_fid;
 	return 0;
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1598,7 +1598,7 @@ int sock_ep_get_conn(struct sock_ep *ep, struct sock_tx_ctx *tx_ctx,
 		     fi_addr_t index, struct sock_conn **pconn)
 {
 	struct sock_conn *conn;
-	uint64_t av_index = (ep->ep_type == FI_EP_MSG) ? 0 : index;
+	uint64_t av_index = (ep->ep_type == FI_EP_MSG) ? 0 : (index & ep->av->mask);
 	struct sockaddr_in *addr;
 
 	if (ep->ep_type == FI_EP_MSG)


### PR DESCRIPTION
- Fix av mask calculation for scalable endpoints
- Mask out context-id during connection lookup for scalable-endpoints