### PR TITLE
prov/gni: improve EP shutdown process

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -369,8 +369,6 @@ struct gnix_fid_ep {
 	int enabled;
 	int send_selective_completion;
 	int recv_selective_completion;
-	/* num. active read and write fab_reqs associated with this ep */
-	atomic_t active_fab_reqs;
 	/* note this free list will be initialized for thread safe */
 	struct gnix_s_freelist fr_freelist;
 	struct gnix_reference ref_cnt;

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -156,6 +156,7 @@ _gnix_fr_alloc(struct gnix_fid_ep *ep)
 	/* reset common fields */
 	fr->modes = 0;
 	fr->tx_failures = 0;
+	_gnix_ref_get(ep);
 
 	return fr;
 }
@@ -165,6 +166,7 @@ _gnix_fr_free(struct gnix_fid_ep *ep, struct gnix_fab_req *fr)
 {
 	assert(fr->gnix_ep == ep);
 	_gnix_sfe_free(&fr->slist, &ep->fr_freelist);
+	_gnix_ref_put(ep);
 }
 
 static inline int

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -294,6 +294,8 @@ static void  __cm_nic_destruct(void *obj)
 	gni_return_t status;
 	struct gnix_cm_nic *cm_nic = (struct gnix_cm_nic *)obj;
 
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
 	if (cm_nic->dgram_hndl != NULL) {
 		ret = _gnix_dgram_hndl_free(cm_nic->dgram_hndl);
 		if (ret != FI_SUCCESS)

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -509,11 +509,14 @@ static void __gnix_nic_tx_freelist_destroy(struct gnix_nic *nic)
 {
 	gni_return_t status;
 
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
 	status = GNI_MemDeregister(nic->gni_nic_hndl, &nic->int_bufs_mdh);
 	if (status != GNI_RC_SUCCESS)
 		GNIX_WARN(FI_LOG_DOMAIN, "GNI_MemDeregister() failed: %s\n",
 			  gni_err_str[status]);
 	free(nic->int_bufs);
+
 	free(nic->tx_desc_base);
 	fastlock_destroy(&nic->tx_desc_lock);
 }
@@ -527,6 +530,8 @@ static void __nic_destruct(void *obj)
 	int ret = FI_SUCCESS;
 	gni_return_t status = GNI_RC_SUCCESS;
 	struct gnix_nic *nic = (struct gnix_nic *) obj;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	__gnix_nic_tx_freelist_destroy(nic);
 

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -106,8 +107,6 @@ Test(endpoint, open_close)
 
 		/* Check fields (fill in as implemented) */
 		cr_assert(ep->nic, "NIC not allocated");
-		cr_assert_eq(atomic_get(&ep->active_fab_reqs), 0,
-			     "active_fab_reqs not initialized");
 		cr_assert(!_gnix_sfl_empty(&ep->fr_freelist),
 			  "gnix_fab_req freelist empty");
 	}


### PR DESCRIPTION
Make sure that GNI internally has completed
all outgoing transactions - GNI SMSG, etc. by
calling GNI_EpUnbind in the _gnix_vc_destroy method.

track outstanding fab-reqs associated with an
EP via get/put ref interface.  The ep destructor
is only called when all fab reqs associated
with an ep have been returned to the free list.

Upstream merge of ofi-cray/libfabric-cray#563

@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@87fc78dbf7016b6df68a5ce97112a9b2d18fc33b)