### PR TITLE
sockets: warning fixes for 32-bit build

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -785,6 +785,7 @@ struct sock_pe_entry {
 	uint64_t total_len;
 	uint64_t data_len;
 	uint64_t rem;
+	void *comm_addr;
 	struct sock_ep *ep;
 	struct sock_conn *conn;
 	struct sock_comp *comp;

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -197,7 +197,7 @@ static int sock_mr_close(struct fid *fid)
 	mr_key = mr->key;
 
 	fastlock_acquire(&dom->lock);
-	it = rbtFind(dom->mr_heap, (void *)&mr_key);
+	it = rbtFind(dom->mr_heap, &mr_key);
 	if (!it || ((res = rbtErase(dom->mr_heap, it)) != RBT_STATUS_OK))
 		SOCK_LOG_ERROR("Invalid mr\n");
 
@@ -253,11 +253,11 @@ struct sock_mr *sock_mr_get_entry(struct sock_domain *domain, uint64_t key)
 	void *value;
 	void *mr_key = &key;
 
-	it = rbtFind(domain->mr_heap, (void *)mr_key);
+	it = rbtFind(domain->mr_heap, mr_key);
 	if (!it)
 		return NULL;
 
-	rbtKeyValue(domain->mr_heap, it, (void **)&mr_key, (void **)&value);
+	rbtKeyValue(domain->mr_heap, it, &mr_key, &value);
 	return (struct sock_mr *) value;
 }
 
@@ -335,7 +335,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		sock_get_mr_key(dom) : attr->requested_key;
 
 	_mr->key = key;
-	res = rbtInsert(dom->mr_heap, (void *)&_mr->key, _mr);
+	res = rbtInsert(dom->mr_heap, &_mr->key, _mr);
 	if (res != RBT_STATUS_OK)
 		goto err;
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1593,12 +1593,12 @@ static int sock_pe_process_rx_conn_msg(struct sock_pe *pe,
 	struct sock_conn *conn;
 	uint64_t index;
 
-	if (!pe_entry->buf)
-		pe_entry->buf = (uint64_t) calloc(1, sizeof(struct sockaddr_in));
+	if (!pe_entry->comm_addr)
+		pe_entry->comm_addr = calloc(1, sizeof(struct sockaddr_in));
 
 	len = sizeof(struct sock_msg_hdr);
 	data_len = sizeof(struct sockaddr_in);
-	if (sock_pe_recv_field(pe_entry, (void *)pe_entry->buf, data_len, len)) {
+	if (sock_pe_recv_field(pe_entry, pe_entry->comm_addr, data_len, len)) {
 		return 0;
 	}
 
@@ -1606,12 +1606,12 @@ static int sock_pe_process_rx_conn_msg(struct sock_pe *pe,
 		inet_ntoa(((struct sockaddr_in *)&pe_entry->conn->addr)->sin_addr),
 		ntohs(((struct sockaddr_in *)&pe_entry->conn->addr)->sin_port));
 	SOCK_LOG_DBG("on behalf of %s:%d\n",
-		inet_ntoa(((struct sockaddr_in *)pe_entry->buf)->sin_addr),
-		ntohs(((struct sockaddr_in *)pe_entry->buf)->sin_port));
+		inet_ntoa(((struct sockaddr_in *)pe_entry->comm_addr)->sin_addr),
+		ntohs(((struct sockaddr_in *)pe_entry->comm_addr)->sin_port));
 
 	ep = pe_entry->conn->ep;
 	map = &ep->cmap;
-	addr = (struct sockaddr_in *) pe_entry->buf;
+	addr = (struct sockaddr_in *) pe_entry->comm_addr;
 	pe_entry->conn->addr = *addr;
 
 	index = (ep->ep_type == FI_EP_MSG) ? 0 : sock_av_get_addr_index(ep->av, addr);
@@ -1627,7 +1627,8 @@ static int sock_pe_process_rx_conn_msg(struct sock_pe *pe,
 
 	pe_entry->is_complete = 1;
 	pe_entry->pe.rx.pending_send = 0;
-	free((void *)pe_entry->buf);
+	free(pe_entry->comm_addr);
+	pe_entry->comm_addr = NULL;
 	return 0;
 }
 


### PR DESCRIPTION
- Update memory registration to support 32-bit builds
- Fix warnings in 32-bit build