### PR TITLE
prov/gni: check for GNI_VERSION_FMA_CHAIN_TRANS..

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -39,6 +39,17 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                                  [alps_util_happy=0])
 	       ])
 
+       gni_path_to_gni_pub=${CRAY_GNI_HEADERS_CFLAGS:2}
+dnl looks like we need to get rid of some white space
+       gni_path_to_gni_pub=${gni_path_to_gni_pub%?}/gni_pub.h
+
+       AC_CHECK_DECLS([GNI_VERSION_FMA_CHAIN_TRANSACTIONS],
+                       [],
+                       [AC_MSG_WARN([GNI provider requires CLE 5.2UP04 or higher. Disabling gni provider.])
+                       gni_header_happy=0
+                       ],
+                       [[#include "$gni_path_to_gni_pub"]])
+
 	have_criterion=false
 	criterion_tests_present=true
 


### PR DESCRIPTION
The GNI provider is making use of chained FMA post
operations, a feature than is only available in
CLE 5.2UP04 and newer.  Check for the presence
of a sentinel macro GNI_VERSION_FMA_CHAIN_TRANSACTIONS
in gni_pub.h. Configure GNI provider off if this
sentinel is not found in gni_pub.h

@sungeunchoi 

Fixes ofi-cray/libfabric-cray#553

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@840feb11b1670e581d0aab100e9fb118490cdfa1)

Conflicts:
	prov/gni/configure.m4