### PR TITLE
prov/gni: GNI provider checks the compiler's native atomic support.

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -12,6 +12,7 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
 	gni_CPPFLAGS=
 	gni_LDFLAGS=
 	gni_LIBS=
+
 	AS_IF([test x"$enable_gni" != x"no"],
 	      [FI_PKG_CHECK_MODULES([CRAY_UGNI], [cray-ugni],
                                  [ugni_lib_happy=1
@@ -88,6 +89,13 @@ dnl looks like we need to get rid of some white space
 	AC_SUBST(gni_CPPFLAGS)
 	AC_SUBST(gni_LDFLAGS)
 	AC_SUBST(gni_LIBS)
+
+        AC_CHECK_DECL([HAVE_ATOMICS],
+                        [],
+                        [cc_version=`$CC --version | head -n1`
+                        AC_MSG_WARN(["$cc_version" doesn't support native atomics.  Disabling GNI provider.])
+                        ugni_lib_happy=0]
+			)
 
 	AS_IF([test $gni_header_happy -eq 1 -a $ugni_lib_happy -eq 1 \
                -a $alps_lli_happy -eq 1 -a $alps_util_happy -eq 1], [$1], [$2])


### PR DESCRIPTION
If the compiler doesn't support native atomics a warning message is
printed and the GNI provider doesn't build.

upstream merge of PR ofi-cray/libfabric-cray#588

@sungeunchoi 

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@203a707bcd223f5c3c304768364de7a2838562f4)

Conflicts:
	prov/gni/configure.m4