### PR TITLE
prov/gni: Remove calls to _gnix_vc_destroy,

### DIFF
--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -300,9 +300,7 @@ Test(vc_management_auto, vc_connect)
 	ret = _gnix_vc_disconnect(vc_conn);
 	cr_assert_eq(ret, FI_SUCCESS);
 
-	ret = _gnix_vc_destroy(vc_conn);
-	cr_assert_eq(ret, FI_SUCCESS);
-
+	/* VC is destroyed by the EP */
 }
 
 Test(vc_management_auto, vc_connect2)
@@ -365,13 +363,8 @@ Test(vc_management_auto, vc_connect2)
 	ret = _gnix_vc_disconnect(vc_conn0);
 	cr_assert_eq(ret, FI_SUCCESS);
 
-	ret = _gnix_vc_destroy(vc_conn0);
-	cr_assert_eq(ret, FI_SUCCESS);
-
 	ret = _gnix_vc_disconnect(vc_conn1);
 	cr_assert_eq(ret, FI_SUCCESS);
 
-	ret = _gnix_vc_destroy(vc_conn1);
-	cr_assert_eq(ret, FI_SUCCESS);
-
+	/* VC is destroyed by the EP */
 }


### PR DESCRIPTION
as it is not called from the endpoint destructor.

upstream merge of ofi-cray/libfabric-cray#510

Fixes ofi-cray/libfabric-cray#558

@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@f25cf1f04c474ce84c69d75d6cc8277f1d33a25f)