### PR TITLE
build: update Libtool shared library version number

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,7 +76,7 @@ src_libfabric_la_LDFLAGS =
 src_libfabric_la_LIBADD =
 src_libfabric_la_DEPENDENCIES = $(srcdir)/libfabric.map
 
-src_libfabric_la_LDFLAGS += -version-info 2:0:1 -export-dynamic \
+src_libfabric_la_LDFLAGS += -version-info 2:1:1 -export-dynamic \
 			   $(libfabric_version_script)
 rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fabric.h \


### PR DESCRIPTION
Since the v1.1.1 release, the following functions have been added to the libfabric core:

* rbtree
* fashtash
* indexer
* enosys for cq_strerror

As far as I can tell, no interfaces have been deleted or had their behavior changed.

Hence, per https://www.gnu.org/software/libtool/manual/html_node/Updating-version-info.html, this commit changes the libfabric.la c:r:a from 2:0:1 to 2:1:1.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@goodell @shefty Please review.

Unfortunately, this should have been done for the v1.2.0 release (i.e., the v1.2.0 release will incorrectly overwrite a prior installed v1.1.1 library).

To help avoid issues like this for the next release, I started a release checklist on the wiki -- comments / edits welcome: https://github.com/ofiwg/libfabric/wiki/Release-procedures