### PR TITLE
libfabric.spec.in: remove extra libfabric.pc

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -46,7 +46,6 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root,-)
 %{_libdir}/lib*.so.*
-%{_libdir}/pkgconfig/libfabric.pc
 %{_bindir}/fi_info
 %dir %{_libdir}/libfabric/
 %doc AUTHORS COPYING README


### PR DESCRIPTION
The libfabric.pc file should really only be in the -devel RPM.

Fixes #1630.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>