### PR TITLE
Remove references to fi_cq_readcond and fi_cntr_readcond.

### DIFF
--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -130,7 +130,7 @@ struct fi_cntr_attr {
 
 - *FI_WAIT_UNSPEC*
 : Specifies that the user will only wait on the counter using fabric
-  interface calls, such as fi_cntr_readcond.  In this case, the
+  interface calls, such as fi_cntr_wait.  In this case, the
   underlying provider may select the most appropriate or highest
   performing wait object available, including custom wait mechanisms.
   Applications that select FI_WAIT_UNSPEC are not guaranteed to

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -225,7 +225,7 @@ struct fi_cq_tagged_entry {
 
 - *FI_WAIT_UNSPEC*
 : Specifies that the user will only wait on the CQ using fabric
-  interface calls, such as fi_cq_readcond or fi_cq_sreadfrom.  In this
+  interface calls, such as fi_cq_sread or fi_cq_sreadfrom.  In this
   case, the underlying provider may select the most appropriate or
   highest performing wait object available, including custom wait
   mechanisms.  Applications that select FI_WAIT_UNSPEC are not


### PR DESCRIPTION
fi_cq_readcond and fi_cntr_readcond do not exist in the API.

@shefty 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>