### PR TITLE
prov/gni: Update to Criterion v2.2.0

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -66,10 +66,10 @@ dnl looks like we need to get rid of some white space
 				AC_MSG_RESULT([yes])
 				gni_CPPFLAGS="-I$with_criterion/include $gni_CPPFLAGS"
 				if test -d "$with_criterion/lib"; then
-					gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib $gni_LDFLAGS"
+				        gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib -Wl,-rpath=$with_criterion/lib $gni_LDFLAGS"
 					have_criterion=true
 				elif test -d "$with_criterion/lib64"; then
-					gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib64 $gni_LDFLAGS"
+					gni_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib64 -Wl,-rpath=$with_criterion/lib64 $gni_LDFLAGS"
 					have_criterion=true
 				else
 					have_criterion=false

--- a/prov/gni/test/allocator.c
+++ b/prov/gni/test/allocator.c
@@ -238,7 +238,7 @@ Test(mbox_creation, alloc_mbox)
 	 * Write our test strings and make sure they're equal.
 	 */
 	memcpy(mail_box->base, test_string, sizeof(test_string));
-	cr_expect_strings_eq((char *) mail_box->base, test_string);
+	cr_expect_str_eq((char *) mail_box->base, test_string);
 
 	/*
 	 * Mailboxes haven't been returned so destroy will return -FI_EBUSY.

--- a/prov/gni/test/pmi_utils.c
+++ b/prov/gni/test/pmi_utils.c
@@ -38,7 +38,7 @@
 
 static int pmi_initialized;
 
-ReportHook(PRE_ALL)()
+ReportHook(PRE_ALL)(struct criterion_test_set *test)
 {
 	int rc, spawned;
 
@@ -50,7 +50,7 @@ ReportHook(PRE_ALL)()
 		pmi_initialized = 1;
 }
 
-ReportHook(POST_ALL)()
+ReportHook(POST_ALL)(struct criterion_global_stats *stats)
 {
 	if (pmi_initialized == 1)
 		PMI_Finalize();

--- a/prov/gni/test/run_gnitest
+++ b/prov/gni/test/run_gnitest
@@ -60,4 +60,4 @@ else
 fi
 
 # pass all command line args to gnitest
-$launcher $args $gnitest_bin "$@"
+$launcher $args $gnitest_bin -j1 "$@"


### PR DESCRIPTION
Update to using Criterion v2.2.0 with some patches to avoid having to specify LD_LIBRARY_PATH to libpcre.so.  PR in the works for the Criterion project.

@sungeunchoi 

this is an upstream merge of ofi-cray/libfabric-cray#590
