### PR TITLE
prov/gni: initial data progress work

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -105,14 +105,13 @@ struct gnix_nic_attr {
  * @var rx_cq_blk            GNI rx cq (blocking) bound to this nic
  * @var tx_cq                GNI tx cq (non-blocking) bound to this nic
  * @var tx_cq_blk            GNI tx cq (blocking) bound to this nic
+ * @var progress_thread      thread id of progress thread for this nic
  * @var tx_desc_active_list  linked list of active tx descriptors associated
  *                           with this nic
  * @var tx_desc_free_list    linked list of free tx descriptors associated
  *                           with this nic
  * @var tx_desc_base         base address for the block of memory from which
  *                           tx descriptors were allocated
- * @var outstanding_fab_reqs_nic number of outstanding (active) gnix_fab_reqs
- *                           associated with this nic
  * @var wq_lock              lock for serializing access to the nic's work queue
  * @var nic_wq               head of linked list of work queue elements
  *                           associated with this nic
@@ -141,6 +140,13 @@ struct gnix_nic_attr {
  * @var smsg_callbacks       pointer to table of GNI SMSG callback functions used
  *                           by this nic for processing incoming GNI SMS
  *                           messages
+ * @var err_txds             slist of error'd tx descriptors
+ * @var tx_cq_blk_post_cnt   count of outstanding tx desc's posted using tx_cq_blk
+ *                           GNI CQ.
+ * @var irq_mem_hndl         gni_mem_handle_t for mmap region registered with
+ *                           gni hw cq handle used for GNI_PostCqWrite
+ * @var irq_mmap_addr        base address of mmap associated with irq_dma_hndl
+ * @var irq_mmap_len         length of the mmap in bytes
  */
 struct gnix_nic {
 	struct dlist_entry gnix_nic_list; /* global NIC list */
@@ -153,11 +159,11 @@ struct gnix_nic {
 	gni_cq_handle_t rx_cq_blk;
 	gni_cq_handle_t tx_cq;
 	gni_cq_handle_t tx_cq_blk;
+	pthread_t progress_thread;
 	fastlock_t tx_desc_lock;
 	struct dlist_entry tx_desc_active_list;
 	struct dlist_entry tx_desc_free_list;
 	struct gnix_tx_descriptor *tx_desc_base;
-	atomic_t outstanding_fab_reqs_nic;
 	fastlock_t rx_vc_lock;
 	struct dlist_entry rx_vcs;
 	fastlock_t work_vc_lock;
@@ -183,6 +189,9 @@ struct gnix_nic {
 	struct slist err_txds;
 	void *int_bufs;
 	gni_mem_handle_t int_bufs_mdh;
+	gni_mem_handle_t irq_mem_hndl;
+	void *irq_mmap_addr;
+	size_t irq_mmap_len;
 };
 
 

--- a/prov/gni/include/gnix_rma.h
+++ b/prov/gni/include/gnix_rma.h
@@ -39,5 +39,20 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 		  uint64_t dest_addr, uint64_t rem_addr, uint64_t mkey,
 		  void *context, uint64_t flags, uint64_t data);
 
+/**
+ * @brief try to deliver an IRQ to peer
+ *
+ * This routine can be used to deliver an IRQ to the remote peer
+ * via a GNI_PostCqWrite.
+ *
+ * @param[in] vc       pointer to previously allocated gnix_vc struct which
+ *                     is in connected state
+ * @return FI_SUCCESS  GNI_PostCqWrite successfully posted.
+ * @return -FI_INVALID vc in invalid state or incorrect memory handle used
+ * @return -FI_ENOSPC  no free tx descriptors
+ */
+int _gnix_rma_post_irq(struct gnix_vc *vc);
+
+
 #endif /* _GNIX_RMA_H_ */
 

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -109,8 +109,12 @@ enum gnix_vc_conn_req_type {
  * @var vc_id                ID of this vc. Allows for rapid O(1) lookup
  *                           of the VC when using GNI_CQ_GET_INST_ID to get
  *                           the inst_id of a GNI CQE.
+ * @var peer_id              vc_id of peer.
  * @var modes                Used internally to track current state of
  *                           the VC not pertaining to the connection state.
+ * @var flags                Bitmap used to hold vc schedule state
+ * @var peer_irq_mem_hndl    peer GNI memhndl used for delivering
+ *                           GNI_PostCqWrite requests to remote peer
  */
 struct gnix_vc {
 	struct dlist_entry rx_list;	/* RX VC list entry */
@@ -135,9 +139,10 @@ struct gnix_vc {
 	enum gnix_vc_conn_state conn_state;
 	uint32_t post_state;
 	int vc_id;
+	int peer_id;
 	int modes;
-	struct dlist_entry pending_list;
 	gnix_bitmap_t flags; /* We're missing regular bit ops */
+	gni_mem_handle_t peer_irq_mem_hndl;
 };
 
 /*


### PR DESCRIPTION
Add support for data progress thread
for rendezvous send/receive path.

Verified that turning on interrupts
for the existing polling CQs drives
the short message latency up a lot -
from ~1.8 usecs osu 8 byte latency to ~2.4
usecs.  Current methodology avoids using
CQ interrupts for short, eager messages.

upstream merge of ofi-cray/libfabric-cray#589
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@282c6d5cc02d2e6cf0db335eb19a3fb84ee080e4)
(cherry picked from commit ofi-cray/libfabric-cray@9e456ea703945a92b2b4c0fcf5c22ea0a7bb5cfd)