### PR TITLE
Drop redundant assignment in sockets provider

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -733,7 +733,6 @@ out:
 }
 
 #define SOCK_ATOMIC_UPDATE_INT(_cmp, _src, _dst, _tmp) do {		\
-	_cmp = cmp, _dst = dst, _src = src;			        \
 	switch (op) {							\
 	case FI_MIN:							\
 		*_cmp = *_dst;						\
@@ -852,7 +851,6 @@ out:
 } while (0)
 
 #define SOCK_ATOMIC_UPDATE_FLOAT(_cmp, _src, _dst) do {			\
-	_cmp = cmp, _dst = dst, _src = src;			        \
 	switch (op) {							\
 	case FI_MIN:							\
 		*_cmp = *_dst;						\
@@ -944,7 +942,6 @@ out:
 } while (0)
 
 #define SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst) do {		\
-	_cmp = cmp, _dst = dst, _src = src;			        \
 	switch (op) {							\
 	case FI_SUM:							\
 		*_cmp = *_dst;						\


### PR DESCRIPTION
Drop redundant assignment of arguments in sockets provider atomic update
macros; args are already assigned prior to macro invocation.

Signed-off-by: James Dinan <james.dinan@intel.com>