### PR TITLE
usnic: libnl can temporarily fail on the receive side, too

### DIFF
--- a/prov/usnic/src/usnic_direct/libnl1_utils.h
+++ b/prov/usnic/src/usnic_direct/libnl1_utils.h
@@ -92,6 +92,7 @@ struct usnic_rt_cb_arg {
 	int			oif;
 	int			found;
 	int			msg_cnt;
+	int			retry;
 	struct usnic_nl_sk	*unlsk;
 };
 

--- a/prov/usnic/src/usnic_direct/libnl3_utils.h
+++ b/prov/usnic/src/usnic_direct/libnl3_utils.h
@@ -76,7 +76,6 @@ struct usnic_rt_cb_arg {
 	uint32_t		nh_addr;
 	int			oif;
 	int			found;
-	int			replied;
 	int			retry;
 	struct usnic_nl_sk	*unlsk;
 };

--- a/prov/usnic/src/usnic_direct/libnl3_utils.h
+++ b/prov/usnic/src/usnic_direct/libnl3_utils.h
@@ -77,6 +77,7 @@ struct usnic_rt_cb_arg {
 	int			oif;
 	int			found;
 	int			replied;
+	int			retry;
 	struct usnic_nl_sk	*unlsk;
 };
 


### PR DESCRIPTION
Just like we fixed up the send side of libnl communication in d4260d5 to be resistant to temporary libnl failures, we need to do the same on the receive side of libnl communications, too.

This PR is two commits:

1. Fortify the receive side of libnl communication (there's two cases)
1. Remove a trivial unused struct variable.

Reviewed by @goodell internally.