### PR TITLE
usnic: fix typo introduced in 656f12e

### DIFF
--- a/prov/usnic/src/usnic_direct/libnl_utils_common.c
+++ b/prov/usnic/src/usnic_direct/libnl_utils_common.c
@@ -329,7 +329,7 @@ retry:
 		if (err == EAGAIN) {
 			usleep(5);
 		}
-	} while (err != EAGAIN);
+	} while (err == EAGAIN);
 
 	/* If we got a reply back that indicated that the kernel was
 	 * too busy to handle this request, delay a little and try


### PR DESCRIPTION
Signed-off-by: Jeff Squyres <jsquyres@cisco.com>