### PR TITLE
prov/sockets: Coverity scan fix for map_addr calculation

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -325,6 +325,7 @@ struct sock_av {
 	struct sock_eq *eq;
 	struct sock_av_table_hdr *table_hdr;
 	struct sock_av_addr *table;
+	uint64_t *idx_arr;
 	char *name;
 	int shared_fd;
 };


### PR DESCRIPTION
- Fixed the address calculation of map_addr for shared av by adding index array to sock_av that keeps track of the remote addr indices.
- Cleaned up code by adding macros and function.

@jithinjosepkl 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>