### PR TITLE
prov/gni: add a buddy allocator

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -7,7 +7,7 @@ if HAVE_GNI
 # source code, so just add prov/gni to the include path
 # rather than prov/gni/ccan
 #
-AM_CFLAGS += -I$(top_srcdir)/prov/gni/include -I$(top_srcdir)/prov/gni -lm
+AM_CFLAGS += -I$(top_srcdir)/prov/gni/include -I$(top_srcdir)/prov/gni
 
 _gni_files = \
 	prov/gni/src/gnix_atomic.c \

--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -7,12 +7,13 @@ if HAVE_GNI
 # source code, so just add prov/gni to the include path
 # rather than prov/gni/ccan
 #
-AM_CFLAGS += -I$(top_srcdir)/prov/gni/include -I$(top_srcdir)/prov/gni
+AM_CFLAGS += -I$(top_srcdir)/prov/gni/include -I$(top_srcdir)/prov/gni -lm
 
 _gni_files = \
 	prov/gni/src/gnix_atomic.c \
 	prov/gni/src/gnix_av.c \
 	prov/gni/src/gnix_bitmap.c \
+	prov/gni/src/gnix_buddy_allocator.c \
 	prov/gni/src/gnix_cm.c \
 	prov/gni/src/gnix_cm_nic.c \
 	prov/gni/src/gnix_cntr.c \
@@ -42,6 +43,7 @@ _gni_headers = \
 	prov/gni/include/gnix_atomic.h \
 	prov/gni/include/gnix_av.h \
 	prov/gni/include/gnix_bitmap.h \
+	prov/gni/include/gnix_buddy_allocator.h \
 	prov/gni/include/gnix_cm_nic.h \
 	prov/gni/include/gnix_cntr.h \
 	prov/gni/include/gnix_cq.h \
@@ -71,6 +73,7 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/allocator.c \
 	prov/gni/test/av.c \
 	prov/gni/test/bitmap.c \
+	prov/gni/test/buddy_allocator.c \
 	prov/gni/test/cancel.c \
 	prov/gni/test/cntr.c \
 	prov/gni/test/cq.c \

--- a/prov/gni/include/gnix_buddy_allocator.h
+++ b/prov/gni/include/gnix_buddy_allocator.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNIX_BUDDY_ALLOCATOR_H_
+#define _GNIX_BUDDY_ALLOCATOR_H_
+
+#include "fi_list.h"
+#include "gnix_bitmap.h"
+#include "gnix_util.h"
+#include <math.h>
+#include <stdlib.h>
+
+/* evaluates to zero if X is not a power of two, otherwise evaluates to X - 1 */
+#define IS_NOT_POW_TWO(X) (((X) & (~(X) + 1)) ^ (X))
+
+/* Find the block size (in bytes) required for allocating LEN bytes */
+#define BLOCK_SIZE(LEN, MIN) ((LEN) <= (MIN) ? (MIN) :\
+			      (IS_NOT_POW_TWO(LEN)) ? (((LEN) << 1) & ~(LEN)) :\
+			      (LEN))
+
+/* Find the bitmap index for block X */
+#define BITMAP_INDEX(X, BASE, MIN, LEN) (size_t) ((size_t) ((X) - (BASE)) /\
+					 (MIN) + 2 * log2((LEN) / (MIN)))
+
+/*
+ * The following macro doesn't work when the base address starts at zero.
+ * #define BUDDY(X, SIZE_X, BASE) (void *) ((size_t) (X) ^ (SIZE_X))
+ */
+
+/* Find the address of X's buddy block:
+ * If the "index" of block X is even then the buddy must be to the right of X,
+ * otherwise the buddy is to the left of X.
+ */
+#define BUDDY(X, LEN, BASE) (void *) ((((size_t) (BASE) - (size_t) (X)) /\
+				       (LEN)) % 2 ? (size_t) (X) - (LEN) :\
+				      (size_t) (X) + (LEN))
+
+/* Calculate the offset of a free block, OFFSET = MIN * 2^MULT. */
+#define OFFSET(MIN, MULT) ((MIN) * (1 << (MULT)))
+
+/* Find the index into the free list with block size LEN. */
+#define LIST_INDEX(LEN, MIN) (size_t) (log2((LEN) / (double) (MIN)))
+
+/**
+ * Structure representing a buddy allocator.
+ *
+ * @var base		The base address of the buffer being managed.
+ * @var len		The length of the buffer the buddy allocator is managing.
+ * @var min		The smallest chunk of memory that can be allocated.
+ * @var max		The largest chunk of memory that can be allocated.
+ *
+ * @var nlists		The number of free lists.
+ * @var lists		The array of free lists ordered from smallest block size.
+ * at index 0 to largest block size at index nlists - 1.
+ *
+ * @var bitmap		Each bit is 1 if the block is allocated or split,
+ * otherwise the bit is 0.
+ */
+typedef struct gnix_buddy_alloc_handle {
+	void *base;
+	size_t len;
+	size_t min;
+	size_t max;
+
+	size_t nlists;
+	struct dlist_entry *lists;
+
+	gnix_bitmap_t bitmap;
+} *handle_t;
+
+/**
+ * Creates a buddy allocator
+ *
+ * @param[in] base		Base address of buffer to be managed by
+ * allocator.
+ *
+ * @param[in] len		Size of the buffer to be managed by allocator
+ * (must be a multiple of max).
+ *
+ * @param[in] max		Maximum amount of memory that can be allocated
+ * by a single call to _gnix_buddy_alloc (power 2).
+ *
+ * @param[in/out] alloc_handle	Handle to be used for when allocating/freeing
+ * memory managed by the buddy allocator.
+ *
+ * @return FI_SUCCESS		Upon successfully creating an allocator.
+ *
+ * @return -FI_EINVAL		Upon an invalid parameter.
+ *
+ * @return -FI_ENOMEM		Upon failure to allocate memory to create the
+ * buddy allocator.
+ */
+int _gnix_buddy_allocator_create(void *base, size_t len, size_t max,
+				 handle_t *alloc_handle);
+
+/**
+ * Releases all resources associated with a buddy allocator handle.
+ *
+ * @param[in] alloc_handle	Buddy alloc handle to destroy.
+ *
+ * @return FI_SUCCESS	 	Upon successfully destroying an allocator.
+ *
+ * @return -FI_EINVAL 		Upon an invalid parameter.
+ */
+int _gnix_buddy_allocator_destroy(handle_t alloc_handle);
+
+/**
+ * Allocate a buffer from the buddy allocator
+ *
+ * @param[in] alloc_handle 	Previously allocated GNI buddy_alloc_handle to
+ * use as allocator.
+ *
+ * @param[in/out] ptr		Pointer to an address where the address of the
+ * allocated buffer will be returned.
+ *
+ * @param[in] len		Size of buffer to allocate in bytes.
+ *
+ * @return FI_SUCCESS		Upon successfully allocating a buffer.
+ *
+ * @return -FI_ENOMEM 		Upon not being able to allocate a buffer of the
+ * requested size.
+ *
+ * @return -FI_EINVAL 		Upon an invalid parameters.
+ */
+int _gnix_buddy_alloc(handle_t alloc_handle, void **ptr, size_t len);
+
+/**
+ * Free a previously allocated buffer
+ *
+ * @param[in] alloc_handle 	Previously allocated GNI buddy_alloc_handle to
+ * use as allocator.
+ *
+ * @param[in/out] ptr		Pointer to an address where the address of the
+ * allocated buffer will be returned.
+ *
+ * @param[in] len		Size of buffer to allocate in bytes.
+ *
+ * @return FI_SUCCESS		Upon successfully allocating a buffer.
+ *
+ * @return -FI_EINVAL 		Upon an invalid parameters.
+ */
+int _gnix_buddy_free(handle_t alloc_handle, void *ptr, size_t len);
+#endif /* _GNIX_BUDDY_ALLOCATOR_H_ */

--- a/prov/gni/src/gnix_buddy_allocator.c
+++ b/prov/gni/src/gnix_buddy_allocator.c
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * The buddy allocator splits the "base" block being managed into smaller
+ * blocks.  Each block is a "power-of-two length".  These subblocks are kept
+ * track of in a doubly linked list, or free list.  Here are the structures
+ * and format of the data structures used in the buddy allocator.  For
+ * a description of each field please see gnix_buddy_allocator.h.
+ *
+ 		Handle structure:
+		┌──────┬──────┬─────┬─────┬────────┬───────┐
+		│ BASE │ len  │ min │ max │ nlists │ LISTS │
+		└──────┴──────┴─────┴─────┴────────┴───────┘
+ * The LISTS pointer points to an array of dlist structures, each containing a
+ * head pointer to the begging of a free list.  Note that the first element of
+ * LISTS is a pointer to the head of the "min block size" free list, the second
+ * element is the head of the "min * 2 block size" free list and so on.
+
+ 		Node format as stored in a free block:
+		┌──────┬──────┬──────────────────────┐
+		│ NEXT │ PREV │ Remaining free bytes │
+		└──────┴──────┴──────────────────────┘
+ * Each NEXT and PREV pointer is stored in the first 16 bytes of the free block.
+ * This means that there is a hard limit of 16 bytes on the minimum block size.
+ *
+ *		Bitmap layout with a min block size of 16:
+ 		┌──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┬──┐
+		│16│16│16│16│..│32│32│32│32│..│64│64│64│64│..│
+		└──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┴──┘
+ * Each number above (16, 32, and 64) represents a block size that can
+ * be split. The first two "32" blocks are redundantly mapped by the the first
+ * 64 block, all blocks are redundant mappings of the next block size.
+ *
+ * When a block is split or allocated, its bit will be set in the bitmap.
+ * When a block is coalesced or free'd its bit will be reset in the bitmap.
+ * This improves the performance of coalescing blocks by being able to tell
+ * whether a given block's buddy block is allocated or split in O(c).
+ *
+ * TODO: insert_sorted for fragmentation.
+ * TODO: lock alloc_handle
+ */
+
+#include "gnix_buddy_allocator.h"
+
+static inline int __gnix_buddy_create_lists(handle_t alloc_handle)
+{
+	size_t i, offset = 0;
+
+	alloc_handle->nlists = (size_t) log2(alloc_handle->max /
+					     (double) alloc_handle->min) + 1;
+	alloc_handle->lists = calloc(1, sizeof(struct dlist_entry) *
+				     alloc_handle->nlists);
+
+	if (!alloc_handle->lists) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Could not create buddy allocator lists.\n");
+		return -FI_ENOMEM;
+	}
+
+	for (i = 0; i < alloc_handle->nlists; i++) {
+		dlist_init(alloc_handle->lists + i);
+	}
+
+	/* Insert free blocks of size max in sorted order into last list */
+	for (i = 0; i < alloc_handle->len / alloc_handle->max; i++) {
+		dlist_insert_tail(alloc_handle->base + offset,
+				  alloc_handle->lists +
+				  alloc_handle->nlists - 1);
+		offset += alloc_handle->max;
+	}
+
+	return FI_SUCCESS;
+}
+
+/**
+ * Split a block in list "j" until list "i" is reached.
+ */
+static inline void __gnix_buddy_split(handle_t alloc_handle, size_t j, size_t i)
+{
+	void *tmp = NULL;
+
+	dlist_remove(tmp = alloc_handle->lists[j].next);
+
+	_gnix_set_bit(&alloc_handle->bitmap,
+		      BITMAP_INDEX(tmp, alloc_handle->base, alloc_handle->min,
+				   OFFSET(alloc_handle->min, j)));
+
+	/* Split the block until we reach list "i" */
+	for (j--; j > i; j--) {
+		_gnix_set_bit(&alloc_handle->bitmap,
+			      BITMAP_INDEX(tmp +
+					   OFFSET(alloc_handle->min, j),
+					   alloc_handle->base,
+					   alloc_handle->min,
+					   OFFSET(alloc_handle->min, j)));
+
+		dlist_insert_tail(tmp + OFFSET(alloc_handle->min, j),
+				  alloc_handle->lists + j);
+	}
+
+	/* Insert last block into list "i" */
+	dlist_insert_head(tmp, alloc_handle->lists + j);
+
+	/* Insert the buddy block of tmp into list "i" */
+	dlist_insert_tail(tmp + OFFSET(alloc_handle->min, j),
+			  alloc_handle->lists + j);
+}
+
+/**
+ * Find the first free block that can be split, then split it.
+ *
+ * @return 1  if the block cannot be found.
+ *
+ * @return 0 if the block is found.
+ */
+static inline int __gnix_buddy_find_block(handle_t alloc_handle, size_t i)
+{
+	size_t j;
+
+	for (j = i + 1; j < alloc_handle->nlists; j++) {
+		if (!dlist_empty(alloc_handle->lists + j)) {
+			__gnix_buddy_split(alloc_handle, j, i);
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+
+/**
+ * If the buddy block is on the free list then coalesce and insert into the next
+ * list until we reach an allocated or split buddy block, or the max list size.
+ */
+static inline void __gnix_buddy_coalesce(handle_t alloc_handle, void **ptr,
+					 size_t *bsize)
+{
+	while (*bsize < alloc_handle->max &&
+	       !_gnix_test_bit(&alloc_handle->bitmap,
+			       BITMAP_INDEX(BUDDY(*ptr, *bsize,
+						  alloc_handle->base),
+					    alloc_handle->base,
+					    alloc_handle->min,
+					    *bsize))) {
+
+		dlist_remove(BUDDY(*ptr, *bsize, alloc_handle->base));
+
+		/* Ensure ptr is the beginning of the new block */
+		if (*ptr > BUDDY(*ptr, *bsize, alloc_handle->base)) {
+			*ptr = BUDDY(*ptr, *bsize, alloc_handle->base);
+		}
+
+		*bsize *= 2;
+
+		_gnix_clear_bit(&alloc_handle->bitmap,
+				BITMAP_INDEX(*ptr, alloc_handle->base,
+					     alloc_handle->min, *bsize));
+	}
+}
+
+int _gnix_buddy_allocator_create(void *base, size_t len, size_t max,
+				 handle_t *alloc_handle)
+{
+	char err_buf[256] = {0}, *error = NULL;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	/* Ensure parameters are valid */
+	if (!base || !len || !max || max > len || !alloc_handle ||
+	    IS_NOT_POW_TWO(max) || (len % max)) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Invalid parameter to buddy_allocator_create.\n");
+		return -FI_EINVAL;
+	}
+
+	*alloc_handle = calloc(1, sizeof(struct gnix_buddy_alloc_handle));
+	if (!alloc_handle) {
+		error = strerror_r(errno, err_buf, sizeof(err_buf));
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Could not create buddy allocator handle.",
+			  error);
+		return -FI_ENOMEM;
+	}
+
+	alloc_handle[0]->base = base;
+	alloc_handle[0]->len = len;
+
+	alloc_handle[0]->min = 16;
+	alloc_handle[0]->max = max;
+
+	if (__gnix_buddy_create_lists(alloc_handle[0])) {
+		return -FI_ENOMEM;
+	}
+
+	return _gnix_alloc_bitmap(&alloc_handle[0]->bitmap,
+				      len / alloc_handle[0]->min * 2);
+}
+
+int _gnix_buddy_allocator_destroy(handle_t alloc_handle)
+{
+	int fi_errno;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (!alloc_handle) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Invalid parameter to buddy_allocator_destroy.\n");
+		return -FI_EINVAL;
+	}
+
+	free(alloc_handle->lists);
+
+	if ((fi_errno = _gnix_free_bitmap(&alloc_handle->bitmap))) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Failed to free buddy_allocator_handle bitmap.");
+		return fi_errno;
+	}
+
+	free(alloc_handle);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_buddy_alloc(handle_t alloc_handle, void **ptr, size_t len)
+{
+	size_t bsize, i = 0;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (!alloc_handle || !ptr || !len || len > alloc_handle->max) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Invalid parameter to buddy_allocator_alloc.\n");
+		return -FI_EINVAL;
+	}
+
+	bsize = BLOCK_SIZE(len, alloc_handle->min);
+	i = (size_t) LIST_INDEX(bsize, alloc_handle->min);
+
+	if (dlist_empty(alloc_handle->lists + i) &&
+	    __gnix_buddy_find_block(alloc_handle, i)) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Could not allocate buddy block.\n");
+		return -FI_ENOMEM;
+	}
+
+	/*
+	 * Remove the block from opposite sides of adjacent lists to reduce
+	 * fragmentation and improve coalescing
+	 */
+	if (i % 2) {
+		dlist_remove(*ptr = alloc_handle->lists[i].prev);
+	} else {
+		dlist_remove(*ptr = alloc_handle->lists[i].next);
+	}
+
+	_gnix_set_bit(&alloc_handle->bitmap,
+		      BITMAP_INDEX(*ptr, alloc_handle->base, alloc_handle->min,
+				   bsize));
+
+	return FI_SUCCESS;
+}
+
+int _gnix_buddy_free(handle_t alloc_handle, void *ptr, size_t len)
+{
+	size_t bsize;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (!alloc_handle || !len || len > alloc_handle->max ||
+	    ptr >= alloc_handle->base + alloc_handle->len  ||
+	    ptr < alloc_handle->base) {
+
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "Invalid parameter to buddy_allocator_free.\n");
+		return -FI_EINVAL;
+	}
+
+	bsize = BLOCK_SIZE(len, alloc_handle->min);
+
+	_gnix_clear_bit(&alloc_handle->bitmap,
+			BITMAP_INDEX(ptr, alloc_handle->base, alloc_handle->min,
+				     bsize));
+
+	__gnix_buddy_coalesce(alloc_handle, &ptr, &bsize);
+
+	dlist_insert_tail(ptr, alloc_handle->lists +
+			  LIST_INDEX(bsize, alloc_handle->min));
+
+	return FI_SUCCESS;
+}

--- a/prov/gni/test/buddy_allocator.c
+++ b/prov/gni/test/buddy_allocator.c
@@ -38,7 +38,7 @@
 #define MIN_LEN 16		/* buddy_handle->min */
 
 long *buf = NULL;		/* buddy_handle->base */
-handle_t buddy_handle = NULL;
+handle_t *buddy_handle = NULL;
 void **ptr = NULL;		/* ptrs alloc'd by _gnix_buddy_alloc */
 
 
@@ -142,7 +142,7 @@ Test(buddy_allocator, alloc_free)
 	int i = MIN_LEN;
 
 	/* Sequential alloc and frees */
-	for (; i <= MIN_LEN * 2; i *= 2) {
+	for (i = MIN_LEN; i <= MAX_LEN; i *= 2) {
 		do_alloc(i);
 		do_free(i);
 	}
@@ -168,6 +168,7 @@ Test(buddy_allocator, alloc_free_error)
 Test(buddy_allocator, parameter_error)
 {
 	int ret;
+
 	buddy_allocator_setup_error();
 	buddy_allocator_teardown_error();
 

--- a/prov/gni/test/buddy_allocator.c
+++ b/prov/gni/test/buddy_allocator.c
@@ -38,7 +38,7 @@
 #define MIN_LEN 16		/* buddy_handle->min */
 
 long *buf = NULL;		/* buddy_handle->base */
-handle_t *buddy_handle = NULL;
+gnix_buddy_alloc_handle_t *buddy_handle;
 void **ptr = NULL;		/* ptrs alloc'd by _gnix_buddy_alloc */
 
 

--- a/prov/gni/test/buddy_allocator.c
+++ b/prov/gni/test/buddy_allocator.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2015 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "gnix_buddy_allocator.h"
+#include <criterion/criterion.h>
+
+#define LEN 1024 * 1024 	/* buddy_handle->len */
+#define MAX_LEN LEN / 1024	/* buddy_handle->max */
+#define MIN_LEN 16		/* buddy_handle->min */
+
+long *buf = NULL;		/* buddy_handle->base */
+handle_t buddy_handle = NULL;
+void **ptr = NULL;		/* ptrs alloc'd by _gnix_buddy_alloc */
+
+
+void buddy_allocator_setup(void)
+{
+	int ret;
+
+	ptr = calloc(LEN / MIN_LEN, sizeof(void *));
+	cr_assert(ptr, "buddy_allocator_setup");
+
+	buf = calloc(LEN, sizeof(long));
+	cr_assert(buf, "buddy_allocator_setup");
+
+	ret = _gnix_buddy_allocator_create(buf, LEN, MAX_LEN, &buddy_handle);
+	cr_assert(!ret, "_gnix_buddy_allocator_create");
+}
+
+void buddy_allocator_teardown(void)
+{
+	int ret;
+
+	ret = _gnix_buddy_allocator_destroy(buddy_handle);
+	cr_assert(!ret, "_gnix_buddy_allocator_destroy");
+
+	free(ptr);
+	free(buf);
+}
+
+/* Test invalid parameters for setup */
+void buddy_allocator_setup_error(void)
+{
+	int ret;
+
+	ret = _gnix_buddy_allocator_create(NULL, LEN, MAX_LEN, &buddy_handle);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_allocator_create(buf, 0, MAX_LEN, &buddy_handle);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_allocator_create(buf, LEN, LEN + 1, &buddy_handle);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_allocator_create(buf, LEN, 0, &buddy_handle);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_allocator_create(buf, LEN, MAX_LEN, NULL);
+	cr_assert_eq(ret, -FI_EINVAL);
+}
+
+/* Test invalid parameters for teardown */
+void buddy_allocator_teardown_error(void)
+{
+	int ret;
+
+	ret = _gnix_buddy_allocator_destroy(NULL);
+	cr_assert_eq(ret, -FI_EINVAL);
+}
+
+void do_alloc(int len)
+{
+	int i = 0, ret;
+
+	/* Allocate all the memory and write to each block */
+	for (; i < LEN / len; i++) {
+		ret = _gnix_buddy_alloc(buddy_handle, ptr + i, len);
+		cr_assert(!ret, "_gnix_buddy_alloc");
+		memset(ptr[i], 0xffffffff, len);
+	}
+
+	/* Ensure that all free lists are empty */
+	for (i = 0; i < buddy_handle->nlists; i++) {
+		ret = dlist_empty(buddy_handle->lists + i);
+		cr_assert_eq(ret, 1);
+	}
+}
+
+void do_free(int len)
+{
+	int i = 0, ret;
+
+	/* Free all allocated blocks */
+	for (; i < LEN / len; i++) {
+		ret = _gnix_buddy_free(buddy_handle, ptr[i], len);
+		cr_assert(!ret, "_gnix_buddy_free");
+	}
+
+	/* Ensure that every free list except the last is empty */
+	for (i = 0; i < buddy_handle->nlists - 1; i++) {
+		ret = dlist_empty(buddy_handle->lists + i);
+		cr_assert_eq(ret, 1);
+	}
+	ret = dlist_empty(buddy_handle->lists + i);
+	cr_assert_eq(ret, 0);
+}
+
+TestSuite(buddy_allocator, .init = buddy_allocator_setup,
+	  .fini = buddy_allocator_teardown, .disabled = false);
+
+Test(buddy_allocator, alloc_free)
+{
+	int i = MIN_LEN;
+
+	/* Sequential alloc and frees */
+	for (; i <= MIN_LEN * 2; i *= 2) {
+		do_alloc(i);
+		do_free(i);
+	}
+
+	/* TODO: Random allocs and frees */
+}
+
+Test(buddy_allocator, alloc_free_error)
+{
+	int ret;
+	void *tmp;
+
+	do_alloc(MIN_LEN);
+
+	/* Request one additional block */
+	ret = _gnix_buddy_alloc(buddy_handle, &tmp, MIN_LEN);
+	cr_assert_eq(ret, -FI_ENOMEM);
+
+	do_free(MIN_LEN);
+}
+
+/* Test invalid buddy alloc and free parameters */
+Test(buddy_allocator, parameter_error)
+{
+	int ret;
+	buddy_allocator_setup_error();
+	buddy_allocator_teardown_error();
+
+	/* BEGIN: Alloc, invalid parameters */
+	ret = _gnix_buddy_alloc(NULL, ptr, MAX_LEN);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_alloc(buddy_handle, ptr, MAX_LEN + 1);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_alloc(buddy_handle, ptr, 0);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_alloc(buddy_handle, NULL, MAX_LEN);
+	cr_assert_eq(ret, -FI_EINVAL);
+	/* END: Alloc, invalid parameters */
+
+	/* BEGIN: Free, invalid parameters */
+	ret = _gnix_buddy_free(NULL, ptr, MAX_LEN);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_free(buddy_handle, NULL, MAX_LEN);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_free(buddy_handle, buf - 1, MAX_LEN);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_free(buddy_handle, buf + LEN, MAX_LEN);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_free(buddy_handle, buf, MAX_LEN + 1);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_buddy_free(buddy_handle, buf - 1, 0);
+	cr_assert_eq(ret, -FI_EINVAL);
+	/* END: Free, invalid parameters */
+}


### PR DESCRIPTION
add a buddy allocator to gni provider.  This will be used in paths where fast allocation/release+
fast coalesce of preregistered buffers is needed.

Upstream merge of ofi-cray/libfabric-cray#594

@sungeunchoi 