### PR TITLE
prov/gni: Fix CQE data for MSG requests using PCD

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -398,17 +398,6 @@ struct gnix_fid_av {
 	struct gnix_reference ref_cnt;
 };
 
-/*
- *  enums, defines, for gni provider internal fab requests.
- */
-
-#define GNIX_FAB_RQ_M_IN_SEND_QUEUE           0x00000001
-#define GNIX_FAB_RQ_M_REPLAYABLE              0x00000002
-#define GNIX_FAB_RQ_M_UNEXPECTED              0x00000004
-#define GNIX_FAB_RQ_M_MATCHED                 0x00000008
-#define GNIX_FAB_RQ_M_COMPLETE                0x00000010
-#define GNIX_FAB_RQ_M_INJECT_DATA             0x00000020
-
 enum gnix_fab_req_type {
 	GNIX_FAB_RQ_SEND,
 	GNIX_FAB_RQ_TSEND,
@@ -481,7 +470,6 @@ struct gnix_fab_req {
 	void                      *user_context;
 	struct gnix_vc            *vc;
 	int                       (*work_fn)(void *);
-	int                       modes;
 	uint64_t                  flags;
 	void                      *txd;
 	uint32_t                  tx_failures;

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -154,7 +154,6 @@ _gnix_fr_alloc(struct gnix_fid_ep *ep)
 	}
 
 	/* reset common fields */
-	fr->modes = 0;
 	fr->tx_failures = 0;
 	_gnix_ref_get(ep);
 

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -133,16 +133,25 @@ static inline ssize_t __ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 				   uint64_t ignore)
 {
 	struct gnix_fid_ep *ep_priv;
+	uint64_t recv_addr, recv_len;
 
-	if (!ep || !msg || !msg->msg_iov || msg->iov_count != 1) {
+	if (!ep || !msg) {
 		return -FI_EINVAL;
+	}
+
+	/* msg_iov can be undefined when using FI_PEEK, etc. */
+	if (msg->msg_iov) {
+		recv_addr = (uint64_t)msg->msg_iov[0].iov_base;
+		recv_len = (uint64_t)msg->msg_iov[0].iov_len;
+	} else {
+		recv_addr = 0;
+		recv_len = 0;
 	}
 
 	ep_priv = container_of(ep, struct gnix_fid_ep, ep_fid);
 	assert((ep_priv->type == FI_EP_RDM) || (ep_priv->type == FI_EP_MSG));
 
-	return _gnix_recv(ep_priv, (uint64_t)msg->msg_iov[0].iov_base,
-			  msg->msg_iov[0].iov_len,
+	return _gnix_recv(ep_priv, recv_addr, recv_len,
 			  msg->desc ? msg->desc[0] : NULL,
 			  msg->addr, msg->context, flags, tag, ignore);
 }


### PR DESCRIPTION
-Use send length for len field in CQES for requests using FI_PEEK
-Set PEEK/CLAIM/DISCARD as needed in CQEs
-Return success when P/C/D request fails to match to match sockets prov
-Ignore receive buffer/length when FI_DISCARD is specified
-Allow selective completion when using P/C/D
-Commonize more of the P/C/D handling code
-Remove unmaintained 'modes' field from gnix_fab_req

Upstream merge of ofi-cray/libfabric-cray#601

@sungeunchoi 

Signed-off-by: Zach Tiffany <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@99da7a771bbeb17fed966a2f3a2890b7c81a8129)