### PR TITLE
Add fi_ep alias to fi_endpoint manpage.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -167,6 +167,7 @@ dummy_man_pages = \
         man/man3/fi_domain_query.3 \
         man/man3/fi_dupinfo.3 \
         man/man3/fi_enable.3 \
+        man/man3/fi_ep.3 \
         man/man3/fi_ep_bind.3 \
         man/man3/fi_eq_open.3 \
         man/man3/fi_eq_read.3 \

--- a/man/man3/fi_ep.3
+++ b/man/man3/fi_ep.3
@@ -1,0 +1,1 @@
+.so man3/fi_endpoint.3


### PR DESCRIPTION
I'm sure I'm not the only one always trying `man fi_ep` only to find that it isn't a manpage.

@shefty @jsquyres

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>