### PR TITLE
prov/gni: Added parens in the reference counting macros

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -222,14 +222,14 @@ struct gnix_reference {
  */
 #define __ref_get(ptr, var) \
 	({ \
-		struct gnix_reference *ref = &ptr->var; \
+		struct gnix_reference *ref = &(ptr)->var; \
 		int references_held = atomic_inc(&ref->references); \
 		assert(references_held > 0); \
 		references_held; })
 
 #define __ref_put(ptr, var) \
 	({ \
-		struct gnix_reference *ref = &ptr->var; \
+		struct gnix_reference *ref = &(ptr)->var; \
 		int references_held = atomic_dec(&ref->references); \
 		assert(references_held >= 0); \
 		if (references_held == 0) \


### PR DESCRIPTION
Without the appropriate parens, it is possible to have garble the
input in the macro such that it returns uncompilable code. This commit
adds the appropriate parens to prevent such behavior

upstream merge of ofi-cray/libfabric-cray#626

@sungeunchoi 

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@f411b49e8eba55568d98eb55e7cdb730adb337b7)