### PR TITLE
Udp and utility provider framework

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,16 @@ common_srcs = \
 	src/enosys.c \
 	src/rbtree.c \
 	src/fasthash.c \
-	src/indexer.c
+	src/indexer.c \
+	prov/util/src/util_attr.c   \
+	prov/util/src/util_av.c     \
+	prov/util/src/util_cq.c     \
+	prov/util/src/util_domain.c \
+	prov/util/src/util_eq.c     \
+	prov/util/src/util_fabric.c \
+	prov/util/src/util_main.c   \
+	prov/util/src/util_poll.c   \
+	prov/util/src/util_wait.c
 
 # ensure dl-built providers link back to libfabric
 linkback = $(top_builddir)/src/libfabric.la
@@ -51,10 +60,11 @@ src_libfabric_la_SOURCES = \
 	include/fi_enosys.h \
 	include/fi_indexer.h \
 	include/fi_list.h \
-	include/fi_signal.h \
 	include/fi_rbuf.h \
-	include/rbtree.h \
+	include/fi_signal.h \
+	include/fi_util.h \
 	include/fasthash.h \
+	include/rbtree.h \
 	include/prov.h \
 	src/fabric.c \
 	src/fi_tostr.c \
@@ -262,6 +272,7 @@ prov_install_man_pages=
 prov_dist_man_pages=
 
 include prov/sockets/Makefile.include
+include prov/udp/Makefile.include
 include prov/verbs/Makefile.include
 include prov/usnic/Makefile.include
 include prov/psm/Makefile.include

--- a/configure.ac
+++ b/configure.ac
@@ -218,6 +218,7 @@ dnl prov/usnic/configure.m4 for details.
 FI_PROVIDER_SETUP([usnic])
 FI_PROVIDER_SETUP([mxm])
 FI_PROVIDER_SETUP([gni])
+FI_PROVIDER_SETUP([udp])
 FI_PROVIDER_FINI
 dnl Configure the .pc file
 FI_PROVIDER_SETUP_PC

--- a/include/fi.h
+++ b/include/fi.h
@@ -149,15 +149,20 @@ void fi_param_init(void);
 void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
 
-/* flsll is defined on BSD systems, but is different. */
-static inline int fi_flsll(long long int i)
-{
-	return i ? 65 - ffsll(htonll(i)) : 0;
-}
 
 static inline uint64_t roundup_power_of_two(uint64_t n)
 {
-	return 1ULL << fi_flsll(n - 1);
+	if (!n || !(n & (n - 1)))
+		return n;
+	n--;
+	n |= n >> 1;
+	n |= n >> 2;
+	n |= n >> 4;
+	n |= n >> 8;
+	n |= n >> 16;
+	n |= n >> 32;
+	n++;
+	return n;
 }
 
 #define FI_TAG_GENERIC	0xAAAAAAAAAAAAAAAAULL

--- a/include/fi.h
+++ b/include/fi.h
@@ -143,6 +143,8 @@ void fi_create_filter(struct fi_filter *filter, const char *env_name);
 void fi_free_filter(struct fi_filter *filter);
 int fi_apply_filter(struct fi_filter *filter, const char *name);
 
+void fi_util_init(void);
+void fi_util_fini(void);
 void fi_log_init(void);
 void fi_log_fini(void);
 void fi_param_init(void);

--- a/include/fi_rbuf.h
+++ b/include/fi_rbuf.h
@@ -36,6 +36,7 @@
 
 #include "config.h"
 
+#include <stdlib.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <unistd.h>

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2015-2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <pthread.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_atomic.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_prov.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_trigger.h>
+
+#include <fi.h>
+#include <fi_list.h>
+#include <fi_signal.h>
+#include <fi_enosys.h>
+
+#ifndef _FI_UTIL_H_
+#define _FI_UTIL_H_
+
+
+#define UTIL_FLAG_ERROR	(1ULL << 60)
+
+
+/*
+ * Provider details
+ * TODO: Determine if having this structure (with expanded fields)
+ * would help support fi_getinfo.  If so, fill out and update
+ * implementation
+struct util_prov {
+	const struct fi_provider *prov;
+	const struct fi_info	*info;  -- list of provider info's
+	provider specific handlers, e.g. resolve addressing
+};
+ */
+
+
+/*
+ * Fabric
+ */
+struct util_fabric {
+	struct fid_fabric	fabric_fid;
+	struct dlist_entry	list_entry;
+	fastlock_t		lock;
+	atomic_t		ref;
+	const char		*name;
+	const struct fi_provider *prov;
+
+	struct dlist_entry	domain_list;
+};
+
+int fi_fabric_create(const struct fi_provider *prov,
+		     struct fi_fabric_attr *prov_attr,
+		     struct fi_fabric_attr *user_attr,
+		     struct fid_fabric **fabric, void *context);
+
+
+/*
+ * Domain
+ */
+struct util_domain {
+	struct fid_domain	domain_fid;
+	struct dlist_entry	list_entry;
+	struct util_fabric	*fabric;
+	fastlock_t		lock;
+	atomic_t		ref;
+	const struct fi_provider *prov;
+
+	const char		*name;
+	uint64_t		caps;
+	uint64_t		mode;
+	uint32_t		addr_format;
+	enum fi_av_type		av_type;
+};
+
+int fi_domain_create(struct fid_fabric *fabric_fid, const struct fi_info *info,
+		     struct fid_domain **domain_fid, void *context);
+
+
+/*
+ * Completion queue
+ *
+ * Utility provider derived CQs that require manual progress must
+ * progress the CQ when fi_cq_read is called with a count = 0.
+ * In such cases, fi_cq_read will return 0 if there are available
+ * entries on the CQ.  This allows poll sets to drive progress
+ * without introducing private interfaces to the CQ.
+ */
+#define FI_DEFAULT_CQ_SIZE	1024
+
+typedef void (*fi_cq_read_func)(void **dst, void *src);
+
+struct util_cq_err_entry {
+	struct fi_cq_err_entry	err_entry;
+	struct slist_entry	list_entry;
+};
+
+struct util_cq {
+	struct fid_cq		cq_fid;
+	struct util_domain	*domain;
+	struct util_wait	*wait;
+	atomic_t		ref;
+	struct dlist_entry	list;
+	fastlock_t		list_lock;
+	fastlock_t		cq_lock;
+
+	struct slist		err_list;
+	fi_cq_read_func		read_entry;
+	int			internal_wait;
+};
+
+/* util_cq must be memset to 0 */
+int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
+		fi_cq_read_func read_entry, struct util_cq *cq, void *context);
+int fi_cq_ready(struct util_cq *cq);
+int fi_cq_cleanup(struct util_cq *cq);
+
+
+/*
+ * Counter
+ */
+struct util_cntr {
+	struct fid_cntr		cntr_fid;
+	struct util_domain	*domain;
+	atomic_t		ref;
+};
+
+
+/*
+ * AV / addressing
+ */
+struct util_av_hash_entry {
+	int			index;
+	int			next;
+};
+
+struct util_av_hash {
+	struct util_av_hash_entry *table;
+	int			free_list;
+	int			slots;
+	int			total_count;
+};
+
+struct util_av {
+	struct fid_av		av_fid;
+	struct util_domain	*domain;
+	struct util_eq		*eq;
+	atomic_t		ref;
+	fastlock_t		lock;
+	const struct fi_provider *prov;
+
+	void			*context;
+	uint64_t		flags;
+	size_t			count;
+	size_t			addrlen;
+	ssize_t			free_list;
+	struct util_av_hash	hash;
+	void			*data;
+};
+
+struct util_av_attr {
+	size_t			addrlen;
+	size_t			overhead;
+	uint64_t		flags;
+};
+
+int fi_av_create(struct util_domain *domain,
+		 const struct fi_av_attr *attr, const struct util_av_attr *util_attr,
+		 struct fid_av **av, void *context);
+int ip_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
+		 struct fid_av **av, void *context);
+
+void *fi_av_get_addr(struct util_av *av, int index);
+#define ip_av_get_addr fi_av_get_addr
+int ip_av_get_index(struct util_av *av, const void *addr);
+
+int fi_get_addr(uint32_t addr_format, uint64_t flags,
+		const char *node, const char *service,
+		void **addr, size_t *addrlen);
+int fi_get_src_addr(uint32_t addr_format,
+		    const void *dest_addr, size_t dest_addrlen,
+		    void **src_addr, size_t *src_addrlen);
+
+
+/*
+ * Poll set
+ */
+struct util_poll {
+	struct fid_poll		poll_fid;
+	struct util_domain	*domain;
+	struct dlist_entry	fid_list;
+	fastlock_t		lock;
+	atomic_t		ref;
+	const struct fi_provider *prov;
+};
+
+int fi_poll_create_(const struct fi_provider *prov, struct fid_domain *domain,
+		    struct fi_poll_attr *attr, struct fid_poll **pollset);
+int fi_poll_create(struct fid_domain *domain, struct fi_poll_attr *attr,
+		   struct fid_poll **pollset);
+
+
+/*
+ * Wait set
+ */
+struct util_wait;
+typedef void (*fi_wait_signal_func)(struct util_wait *wait);
+
+struct util_wait {
+	struct fid_wait		wait_fid;
+	struct util_fabric	*fabric;
+	struct util_poll	*pollset;
+	atomic_t		ref;
+	const struct fi_provider *prov;
+
+	enum fi_wait_obj	wait_obj;
+	fi_wait_signal_func	signal;
+};
+
+int fi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
+		 struct util_wait *wait);
+int fi_wait_cleanup(struct util_wait *wait);
+
+struct util_wait_fd {
+	struct util_wait	util_wait;
+	struct fd_signal	signal;
+	fi_epoll_t		epoll_fd;
+};
+
+int fi_wait_fd_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		struct fid_wait **waitset);
+
+
+/*
+ * EQ
+ */
+struct util_eq {
+	struct fid_eq		eq_fid;
+	struct util_fabric	*fabric;
+	struct util_wait	*wait;
+	fastlock_t		lock;
+	atomic_t		ref;
+	const struct fi_provider *prov;
+
+	struct slist		list;
+	int			internal_wait;
+};
+
+struct util_event {
+	struct slist_entry	entry;
+	int			size;
+	int			event;
+	int			err;
+	uint8_t			data[0];
+};
+
+int fi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		 struct fid_eq **eq_fid, void *context);
+
+
+/*
+ * Attributes and capabilities
+ */
+#define FI_PRIMARY_CAPS	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMICS | \
+			 FI_NAMED_RX_CTX | FI_DIRECTED_RECV | \
+			 FI_READ | FI_WRITE | FI_RECV | FI_SEND | \
+			 FI_REMOTE_READ | FI_REMOTE_WRITE)
+
+#define FI_SECONDARY_CAPS (FI_MULTI_RECV | FI_SOURCE | FI_RMA_EVENT | \
+			   FI_TRIGGER | FI_FENCE)
+
+int fi_check_fabric_attr(const struct fi_provider *prov,
+			 const struct fi_fabric_attr *prov_attr,
+			 const struct fi_fabric_attr *user_attr);
+int fi_check_wait_attr(const struct fi_provider *prov,
+		       const struct fi_wait_attr *attr);
+int fi_check_domain_attr(const struct fi_provider *prov,
+			 const struct fi_domain_attr *prov_attr,
+			 const struct fi_domain_attr *user_attr);
+int fi_check_ep_attr(const struct fi_provider *prov,
+		     const struct fi_ep_attr *prov_attr,
+		     const struct fi_ep_attr *user_attr);
+int fi_check_cq_attr(const struct fi_provider *prov,
+		     const struct fi_cq_attr *attr);
+int fi_check_rx_attr(const struct fi_provider *prov,
+		     const struct fi_rx_attr *prov_attr,
+		     const struct fi_rx_attr *user_attr);
+int fi_check_tx_attr(const struct fi_provider *prov,
+		     const struct fi_tx_attr *prov_attr,
+		     const struct fi_tx_attr *user_attr);
+int fi_check_info(const struct fi_provider *prov,
+		  const struct fi_info *prov_info,
+		  const struct fi_info *user_info);
+void fi_alter_info(struct fi_info *info,
+		   const struct fi_info *hints);
+
+int util_getinfo(const struct fi_provider *prov, uint32_t version,
+		 const char *node, const char *service, uint64_t flags,
+		 const struct fi_info *prov_info, struct fi_info *hints,
+		 struct fi_info **info);
+
+
+struct fid_list_entry {
+	struct dlist_entry	entry;
+	struct fid		*fid;
+
+	uint64_t		last_cntr_val;
+};
+
+int fid_list_insert(struct dlist_entry *fid_list, fastlock_t *lock,
+		    struct fid *fid);
+void fid_list_remove(struct dlist_entry *fid_list, fastlock_t *lock,
+		     struct fid *fid);
+
+void fi_fabric_insert(struct util_fabric *fabric);
+struct util_fabric *fi_fabric_find(const char *name);
+void fi_fabric_remove(struct util_fabric *fabric);
+
+
+#endif

--- a/include/prov.h
+++ b/include/prov.h
@@ -124,4 +124,15 @@ MXM_INI ;
 #  define MXM_INIT NULL
 #endif
 
+#if (HAVE_UDP) && (HAVE_UDP_DL)
+#  define UDP_INI FI_EXT_INI
+#  define UDP_INIT NULL
+#elif (HAVE_UDP)
+#  define UDP_INI INI_SIG(fi_udp_ini)
+#  define UDP_INIT fi_udp_ini()
+UDP_INI ;
+#else
+#  define UDP_INIT NULL
+#endif
+
 #endif /* _PROV_H_ */

--- a/man/fi_udp.7.md
+++ b/man/fi_udp.7.md
@@ -1,0 +1,60 @@
+---
+layout: page
+title: fi_udp(7)
+tagline: Libfabric Programmer's Manual
+---
+{% include JB/setup %}
+
+# NAME
+
+The UDP Fabric Provider
+
+# OVERVIEW
+
+The UDP provider is a basic provider that can be used on any
+system that supports UDP sockets.  The provider is not intended to provide
+performance improvements over regular TCP sockets, but rather to allow
+application and provider developers to write, test, and debug their code.
+The UDP provider forms the foundation of a utility provider that enables
+the implementation of libfabric features over any hardware.
+
+# SUPPORTED FEATURES
+
+The UDP provider supports a minimal set of features useful for sending and
+receiving datagram messages over an unreliable endpoint.
+
+*Endpoint types*
+: The provider supports only endpoint type *FI_EP_DGRAM*.
+
+*Endpoint capabilities*
+: The following data transfer interface is supported: *fi_msg*.
+
+*Modes*
+: The provider does not require the use of any mode bits.
+
+*Progress*
+: The UDP provider supports both *FI_PROGRESS_AUTO* and *FI_PROGRESS_MANUAL*,
+  with a default set to auto.  However, receive side data buffers are not
+  modified outside of completion processing routines.
+
+# LIMITATIONS
+
+The UDP provider has hard-coded maximums for supported queue sizes and data
+transfers.  These values are reflected in the related fabric attribute
+structures
+
+EPs must be bound to both RX and TX CQs.
+
+No support for selective completions or multi-recv.
+
+No support for counters.
+
+# RUNTIME PARAMETERS
+
+No runtime parameters are currently defined.
+
+# SEE ALSO
+
+[`fabric`(7)](fabric.7.html),
+[`fi_provider`(7)](fi_provider.7.html),
+[`fi_getinfo`(3)](fi_getinfo.3.html)

--- a/man/man7/fi_udp.7
+++ b/man/man7/fi_udp.7
@@ -1,0 +1,1 @@
+.TH fi_udp 7 "2015\-09\-08" "Libfabric Programmer\[aq]s Manual" "\@VERSION\@"

--- a/prov/udp/Makefile.include
+++ b/prov/udp/Makefile.include
@@ -1,0 +1,26 @@
+if HAVE_UDP
+_udp_files = \
+	prov/udp/src/udpx_attr.c	\
+	prov/udp/src/udpx_cq.c		\
+	prov/udp/src/udpx_domain.c	\
+	prov/udp/src/udpx_ep.c		\
+	prov/udp/src/udpx_fabric.c	\
+	prov/udp/src/udpx_init.c	\
+	prov/udp/src/udpx.h
+
+if HAVE_UDP_DL
+pkglib_LTLIBRARIES += libudp-fi.la
+libudp_fi_la_SOURCES = $(_udp_files) $(common_srcs)
+libudp_fi_la_LIBADD = $(linkback) $(udp_shm_LIBS)
+libudp_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
+libudp_fi_la_DEPENDENCIES = $(linkback)
+else !HAVE_UDP_DL
+src_libfabric_la_SOURCES += $(_udp_files)
+src_libfabric_la_LIBADD += $(udp_shm_LIBS)
+endif !HAVE_UDP_DL
+
+prov_install_man_pages += man/man7/fi_udp.7
+
+endif HAVE_UDP
+
+prov_dist_man_pages += man/man7/fi_udp.7

--- a/prov/udp/configure.m4
+++ b/prov/udp/configure.m4
@@ -1,0 +1,39 @@
+dnl Configury specific to the libfabric udp provider
+
+dnl Called to configure this provider
+dnl
+dnl Arguments:
+dnl
+dnl $1: action if configured successfully
+dnl $2: action if not configured successfully
+dnl
+AC_DEFUN([FI_UDP_CONFIGURE],[
+	# Determine if we can support the udp provider
+	udp_h_happy=0
+	udp_shm_happy=0
+	AS_IF([test x"$enable_sockets" != x"no"],
+	      [AC_CHECK_HEADER([sys/socket.h], [udp_h_happy=1],
+	                       [udp_h_happy=0])
+
+
+	       # check if shm_open is already present
+	       AC_CHECK_FUNC([shm_open],
+			     [udp_shm_happy=1],
+			     [udp_shm_happy=0])
+
+	       # look for shm_open in librt if not already present
+	       AS_IF([test $udp_shm_happy -eq 0],
+		     [FI_CHECK_PACKAGE([udp_shm],
+				[sys/mman.h],
+				[rt],
+				[shm_open],
+				[],
+				[],
+				[],
+				[udp_shm_happy=1],
+				[udp_shm_happy=0])])
+	      ])
+
+	AS_IF([test $udp_h_happy -eq 1 && \
+	       test $udp_shm_happy -eq 1], [$1], [$2])
+])

--- a/prov/udp/src/fi_util.h
+++ b/prov/udp/src/fi_util.h
@@ -1,0 +1,1 @@
+../../util/src/fi_util.h

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2015-2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <netdb.h>
+#include <pthread.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_atomic.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_prov.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_trigger.h>
+
+#include <fi.h>
+#include <fi_enosys.h>
+#include <fi_indexer.h>
+#include <fi_rbuf.h>
+#include <fi_list.h>
+#include <fi_signal.h>
+#include <fi_util.h>
+
+#ifndef _UDPX_H_
+#define _UDPX_H_
+
+
+#define UDPX_MAJOR_VERSION 1
+#define UDPX_MINOR_VERSION 0
+
+
+extern struct fi_provider udpx_prov;
+extern struct fi_info udpx_info;
+
+int udpx_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
+		void *context);
+int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
+		struct fid_domain **dom, void *context);
+int udpx_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		struct fid_eq **eq, void *context);
+
+
+#define UDPX_FLAG_MULTI_RECV	1
+#define UDPX_IOV_LIMIT		4
+
+struct udpx_ep_entry {
+	void			*context;
+	struct iovec		iov[UDPX_IOV_LIMIT];
+	uint8_t			iov_count;
+	uint8_t			flags;
+	uint8_t			resv[sizeof(size_t) - 2];
+};
+
+DECLARE_CIRQUE(struct udpx_ep_entry, udpx_rx_cirq);
+
+struct udpx_ep;
+typedef void (*udpx_rx_comp_func)(struct udpx_ep *ep, void *context,
+		uint64_t flags, size_t len, void *buf, void *addr);
+typedef void (*udpx_tx_comp_func)(struct udpx_ep *ep, void *context);
+
+struct udpx_ep {
+	struct fid_ep		ep_fid;
+	struct util_domain	*domain;
+	struct util_av		*av;
+	struct udpx_cq		*rx_cq;
+	struct udpx_cq		*tx_cq;
+	udpx_rx_comp_func	rx_comp;
+	udpx_tx_comp_func	tx_comp;
+	struct udpx_rx_cirq	rxq; /* protected by rx_cq lock */
+	uint64_t		caps;
+	uint64_t		flags;
+	size_t			min_multi_recv;
+	int			sock;
+};
+
+int udpx_endpoint(struct fid_domain *domain, struct fi_info *info,
+		  struct fid_ep **ep, void *context);
+void udpx_ep_progress(struct udpx_ep *ep);
+
+
+DECLARE_CIRQUE(struct fi_cq_data_entry, udpx_comp_cirq);
+
+struct udpx_cq {
+	struct util_cq		util_cq;
+	struct udpx_comp_cirq	cirq;
+	fi_addr_t		*src;
+
+};
+
+int udpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+		 struct fid_cq **cq, void *context);
+
+
+#endif

--- a/prov/udp/src/udpx_attr.c
+++ b/prov/udp/src/udpx_attr.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2015-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "udpx.h"
+
+
+struct fi_tx_attr udpx_tx_attr = {
+	.caps = FI_MSG | FI_SEND,
+	.comp_order = FI_ORDER_STRICT,
+	.inject_size = 1472,
+	.size = 1024,
+	.iov_limit = UDPX_IOV_LIMIT
+};
+
+struct fi_rx_attr udpx_rx_attr = {
+	.caps = FI_MSG | FI_RECV | FI_SOURCE | FI_MULTI_RECV,
+	.comp_order = FI_ORDER_STRICT,
+	.total_buffered_recv = (1 << 16),
+	.size = 1024,
+	.iov_limit = UDPX_IOV_LIMIT
+};
+
+struct fi_ep_attr udpx_ep_attr = {
+	.type = FI_EP_DGRAM,
+	.protocol = FI_PROTO_UDP,
+	.protocol_version = 4,
+	.max_msg_size = 1472,
+	.tx_ctx_cnt = 1,
+	.rx_ctx_cnt = 1
+};
+
+struct fi_domain_attr udpx_domain_attr = {
+	.name = "udp",
+	.threading = FI_THREAD_SAFE,
+	.control_progress = FI_PROGRESS_AUTO,
+	.data_progress = FI_PROGRESS_AUTO,
+	.resource_mgmt = FI_RM_ENABLED,
+	.av_type = FI_AV_MAP,
+	.mr_mode = FI_MR_SCALABLE,
+	.cq_cnt = (1 << 16),
+	.ep_cnt = (1 << 15),
+	.tx_ctx_cnt = (1 << 15),
+	.rx_ctx_cnt = (1 << 15),
+	.max_ep_tx_ctx = 1,
+	.max_ep_rx_ctx = 1
+};
+
+struct fi_fabric_attr udpx_fabric_attr = {
+	.name = "UDP-IP",
+	.prov_version = FI_VERSION(UDPX_MAJOR_VERSION, UDPX_MINOR_VERSION)
+};
+
+struct fi_info udpx_info = {
+	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE, /* | FI_MULTI_RECV, */
+	.addr_format = FI_SOCKADDR,
+	.tx_attr = &udpx_tx_attr,
+	.rx_attr = &udpx_rx_attr,
+	.ep_attr = &udpx_ep_attr,
+	.domain_attr = &udpx_domain_attr,
+	.fabric_attr = &udpx_fabric_attr
+};

--- a/prov/udp/src/udpx_cq.c
+++ b/prov/udp/src/udpx_cq.c
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "udpx.h"
+
+
+static void udpx_cq_progress(struct udpx_cq *cq)
+{
+	struct udpx_ep *ep;
+	struct fid_list_entry *fid_entry;
+	struct dlist_entry *item;
+
+	fastlock_acquire(&cq->util_cq.list_lock);
+	dlist_foreach(&cq->util_cq.list, item) {
+		fid_entry = container_of(item, struct fid_list_entry, entry);
+		ep = container_of(fid_entry->fid, struct udpx_ep, ep_fid.fid);
+		udpx_ep_progress(ep);
+
+	}
+	fastlock_release(&cq->util_cq.list_lock);
+}
+
+static void udpx_cq_read_ctx(void **dst, void *src)
+{
+	*(struct fi_cq_entry *) *dst = *(struct fi_cq_entry *) src;
+	*dst += sizeof(struct fi_cq_entry);
+}
+
+static void udpx_cq_read_msg(void **dst, void *src)
+{
+	*(struct fi_cq_msg_entry *) *dst = *(struct fi_cq_msg_entry *) src;
+	*dst += sizeof(struct fi_cq_msg_entry);
+}
+
+static void udpx_cq_read_data(void **dst, void *src)
+{
+	*(struct fi_cq_data_entry *) *dst = *(struct fi_cq_data_entry *) src;
+	*dst += sizeof(struct fi_cq_data_entry);
+}
+
+static void udpx_cq_read_tagged(void **dst, void *src)
+{
+	udpx_cq_read_data(dst, src);
+	((struct fi_cq_tagged_entry *) *dst)->tag = 0;
+	*dst += sizeof(struct fi_cq_tagged_entry);
+}
+
+static ssize_t udpx_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
+{
+	struct udpx_cq *cq;
+	struct fi_cq_data_entry *entry;
+	ssize_t i;
+
+	cq = container_of(cq_fid, struct udpx_cq, util_cq.cq_fid);
+	fastlock_acquire(&cq->util_cq.cq_lock);
+	if (cirque_empty(&cq->cirq)) {
+		fastlock_release(&cq->util_cq.cq_lock);
+		udpx_cq_progress(cq);
+		fastlock_acquire(&cq->util_cq.cq_lock);
+		if (cirque_empty(&cq->cirq)) {
+			i = -FI_EAGAIN;
+			goto out;
+		}
+	}
+
+	if (count > cirque_avail(&cq->cirq))
+		count = cirque_avail(&cq->cirq);
+
+	for (i = 0; i < count; i++) {
+		entry = cirque_head(&cq->cirq);
+		if (entry->flags & UTIL_FLAG_ERROR) {
+			if (!i)
+				i = -FI_EAVAIL;
+			break;
+		}
+		cq->util_cq.read_entry(&buf, cirque_remove(&cq->cirq));
+	}
+out:
+	fastlock_release(&cq->util_cq.cq_lock);
+	return i;
+}
+
+static ssize_t udpx_cq_readfrom(struct fid_cq *cq_fid, void *buf,
+				size_t count, fi_addr_t *src_addr)
+{
+	struct udpx_cq *cq;
+	struct fi_cq_data_entry *entry;
+	ssize_t i;
+
+	cq = container_of(cq_fid, struct udpx_cq, util_cq.cq_fid);
+	if (!cq->src) {
+		i = udpx_cq_read(cq_fid, buf, count);
+		for (count = 0; count < i; count++)
+			src_addr[i] = FI_ADDR_NOTAVAIL;
+		return i;
+	}
+
+	fastlock_acquire(&cq->util_cq.cq_lock);
+	if (cirque_empty(&cq->cirq)) {
+		fastlock_release(&cq->util_cq.cq_lock);
+		udpx_cq_progress(cq);
+		fastlock_acquire(&cq->util_cq.cq_lock);
+		if (cirque_empty(&cq->cirq)) {
+			i = -FI_EAGAIN;
+			goto out;
+		}
+	}
+
+	if (count > cirque_avail(&cq->cirq))
+		count = cirque_avail(&cq->cirq);
+
+	for (i = 0; i < count; i++) {
+		entry = cirque_head(&cq->cirq);
+		if (entry->flags & UTIL_FLAG_ERROR) {
+			if (!i)
+				i = -FI_EAVAIL;
+			break;
+		}
+		src_addr[i] = cq->src[cirque_rindex(&cq->cirq)];
+		cq->util_cq.read_entry(&buf, cirque_remove(&cq->cirq));
+	}
+out:
+	fastlock_release(&cq->util_cq.cq_lock);
+	return i;
+}
+
+static ssize_t udpx_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
+			       uint64_t flags)
+{
+	struct udpx_cq *cq;
+	struct util_cq_err_entry *err;
+	struct slist_entry *entry;
+	ssize_t ret;
+
+	cq = container_of(cq_fid, struct udpx_cq, util_cq.cq_fid);
+	fastlock_acquire(&cq->util_cq.cq_lock);
+	if (!cirque_empty(&cq->cirq) &&
+	    (cirque_head(&cq->cirq)->flags & UTIL_FLAG_ERROR)) {
+		cirque_discard(&cq->cirq);
+		entry = slist_remove_head(&cq->util_cq.err_list);
+		err = container_of(entry, struct util_cq_err_entry, list_entry);
+		*buf = err->err_entry;
+		free(err);
+		ret = 0;
+	} else {
+		ret = -FI_EAGAIN;
+	}
+	fastlock_release(&cq->util_cq.cq_lock);
+	return ret;
+}
+
+static ssize_t udpx_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
+			     const void *cond, int timeout)
+{
+	struct udpx_cq *cq;
+
+	cq = container_of(cq_fid, struct udpx_cq, util_cq.cq_fid);
+	assert(cq->util_cq.wait && cq->util_cq.internal_wait);
+	fi_wait(&cq->util_cq.wait->wait_fid, timeout);
+	return udpx_cq_read(cq_fid, buf, count);
+}
+
+static ssize_t udpx_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
+				 fi_addr_t *src_addr, const void *cond,
+				 int timeout)
+{
+	struct udpx_cq *cq;
+
+	cq = container_of(cq_fid, struct udpx_cq, util_cq.cq_fid);
+	assert(cq->util_cq.wait && cq->util_cq.internal_wait);
+	fi_wait(&cq->util_cq.wait->wait_fid, timeout);
+	return udpx_cq_readfrom(cq_fid, buf, count, src_addr);
+}
+
+static int udpx_cq_signal(struct fid_cq *cq_fid)
+{
+	struct udpx_cq *cq;
+
+	cq = container_of(cq_fid, struct udpx_cq, util_cq.cq_fid);
+	assert(cq->util_cq.wait);
+	cq->util_cq.wait->signal(cq->util_cq.wait);
+	return 0;
+}
+
+static const char *udpx_cq_strerror(struct fid_cq *cq, int prov_errno,
+				    const void *err_data, char *buf, size_t len)
+{
+	return fi_strerror(prov_errno);
+}
+
+static struct fi_ops_cq udpx_cq_ops = {
+	.size = sizeof(struct fi_ops_cq),
+	.read = udpx_cq_read,
+	.readfrom = udpx_cq_readfrom,
+	.readerr = udpx_cq_readerr,
+	.sread = udpx_cq_sread,
+	.sreadfrom = udpx_cq_sreadfrom,
+	.signal = udpx_cq_signal,
+	.strerror = udpx_cq_strerror,
+};
+
+static int udpx_cq_close(struct fid *fid)
+{
+	struct udpx_cq *cq;
+	int ret;
+
+	cq = container_of(fid, struct udpx_cq, util_cq.cq_fid.fid);
+	ret = fi_cq_cleanup(&cq->util_cq);
+	if (ret)
+		return ret;
+
+	udpx_comp_cirq_free(&cq->cirq);
+	free(cq->src);
+	free(cq);
+	return 0;
+}
+
+static struct fi_ops udpx_cq_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = udpx_cq_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static int udpx_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
+			struct udpx_cq *cq, void *context)
+{
+	fi_cq_read_func read_func;
+	int ret;
+
+	switch (attr->format) {
+	case FI_CQ_FORMAT_UNSPEC:
+	case FI_CQ_FORMAT_CONTEXT:
+		read_func = udpx_cq_read_ctx;
+		break;
+	case FI_CQ_FORMAT_MSG:
+		read_func = udpx_cq_read_msg;
+		break;
+	case FI_CQ_FORMAT_DATA:
+		read_func = udpx_cq_read_data;
+		break;
+	case FI_CQ_FORMAT_TAGGED:
+		read_func = udpx_cq_read_tagged;
+		break;
+	default:
+		assert(0);
+		return -FI_EINVAL;
+	}
+
+	ret = fi_cq_init(domain, attr, read_func, &cq->util_cq, context);
+	if (ret)
+		return ret;
+
+	ret = udpx_comp_cirq_init(&cq->cirq, attr->size);
+	if (ret)
+		goto err1;
+
+	if (cq->util_cq.domain->caps & FI_SOURCE) {
+		cq->src = calloc(cq->cirq.size, sizeof *cq->src);
+		if (!cq->src) {
+			ret = -FI_ENOMEM;
+			goto err2;
+		}
+	}
+	return 0;
+
+err2:
+	udpx_comp_cirq_free(&cq->cirq);
+err1:
+	fi_cq_cleanup(&cq->util_cq);
+	return ret;
+}
+
+int udpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+		 struct fid_cq **cq_fid, void *context)
+{
+	struct udpx_cq *cq;
+	int ret;
+
+	ret = fi_check_cq_attr(&udpx_prov, attr);
+	if (ret)
+		return ret;
+
+	cq = calloc(1, sizeof(*cq));
+	if (!cq)
+		return -FI_ENOMEM;
+
+	ret = udpx_cq_init(domain, attr, cq, context);
+	if (ret) {
+		free(cq);
+		return ret;
+	}
+
+	cq->util_cq.cq_fid.fid.ops = &udpx_cq_fi_ops;
+	cq->util_cq.cq_fid.ops = &udpx_cq_ops;
+
+	ret = fi_cq_ready(&cq->util_cq);
+	if (ret) {
+		udpx_cq_close(&cq->util_cq.cq_fid.fid);
+		return ret;
+	}
+
+	*cq_fid = &cq->util_cq.cq_fid;
+	return 0;
+}

--- a/prov/udp/src/udpx_domain.c
+++ b/prov/udp/src/udpx_domain.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "udpx.h"
+
+
+static struct fi_ops_domain udpx_domain_ops = {
+	.size = sizeof(struct fi_ops_domain),
+	.av_open = ip_av_create,
+	.cq_open = udpx_cq_open,
+	.endpoint = udpx_endpoint,
+	.scalable_ep = fi_no_scalable_ep,
+	.cntr_open = fi_no_cntr_open,
+	.poll_open = fi_poll_create,
+	.stx_ctx = fi_no_stx_context,
+	.srx_ctx = fi_no_srx_context,
+};
+
+int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
+		struct fid_domain **domain, void *context)
+{
+	int ret;
+
+	ret = fi_check_info(&udpx_prov, &udpx_info, info);
+	if (ret)
+		return ret;
+
+	ret = fi_domain_create(fabric, info, domain, context);
+	if (ret)
+		return ret;
+
+	(*domain)->ops = &udpx_domain_ops;
+	return 0;
+}

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -1,0 +1,605 @@
+/*
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "udpx.h"
+
+
+int udpx_setname(fid_t fid, void *addr, size_t addrlen)
+{
+	struct udpx_ep *ep;
+	int ret;
+
+	ep = container_of(fid, struct udpx_ep, ep_fid.fid);
+	ret = bind(ep->sock, addr, addrlen);
+	return ret ? -errno : 0;
+}
+
+int udpx_getname(fid_t fid, void *addr, size_t *addrlen)
+{
+	struct udpx_ep *ep;
+	int ret;
+
+	ep = container_of(fid, struct udpx_ep, ep_fid.fid);
+	ret = getsockname(ep->sock, addr, addrlen);
+	return ret ? -errno : 0;
+}
+
+static struct fi_ops_cm udpx_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
+	.setname = udpx_setname,
+	.getname = udpx_getname,
+	.getpeer = fi_no_getpeer,
+	.connect = fi_no_connect,
+	.listen = fi_no_listen,
+	.accept = fi_no_accept,
+	.reject = fi_no_reject,
+	.shutdown = fi_no_shutdown,
+};
+
+int udpx_getopt(fid_t fid, int level, int optname,
+		void *optval, size_t *optlen)
+{
+	struct udpx_ep *ep;
+
+	ep = container_of(fid, struct udpx_ep, ep_fid.fid);
+	if (level != FI_OPT_ENDPOINT)
+		return -FI_ENOPROTOOPT;
+
+	switch (optname) {
+	case FI_OPT_MIN_MULTI_RECV:
+		*(size_t *) optval = ep->min_multi_recv;
+		*optlen = sizeof(size_t);
+		break;
+	default:
+		return -FI_ENOPROTOOPT;
+	}
+	return 0;
+}
+
+int udpx_setopt(fid_t fid, int level, int optname,
+		const void *optval, size_t optlen)
+{
+	struct udpx_ep *ep;
+
+	ep = container_of(fid, struct udpx_ep, ep_fid.fid);
+	if (level != FI_OPT_ENDPOINT)
+		return -FI_ENOPROTOOPT;
+
+	switch (optname) {
+	case FI_OPT_MIN_MULTI_RECV:
+		ep->min_multi_recv = *(size_t *) optval;
+		break;
+	default:
+		return -FI_ENOPROTOOPT;
+	}
+	return 0;
+}
+
+static struct fi_ops_ep udpx_ep_ops = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = fi_no_cancel,
+	.getopt = udpx_getopt,
+	.setopt = udpx_setopt,
+	.tx_ctx = fi_no_tx_ctx,
+	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
+};
+
+static void udpx_tx_comp(struct udpx_ep *ep, void *context)
+{
+	struct fi_cq_data_entry *comp;
+
+	comp = cirque_tail(&ep->tx_cq->cirq);
+	comp->op_context = context;
+	comp->flags = FI_SEND;
+	comp->len = 0;
+	comp->buf = NULL;
+	comp->data = 0;
+	cirque_commit(&ep->tx_cq->cirq);
+}
+
+static void udpx_tx_comp_signal(struct udpx_ep *ep, void *context)
+{
+	udpx_tx_comp(ep, context);
+	ep->tx_cq->util_cq.wait->signal(ep->tx_cq->util_cq.wait);
+}
+
+static void udpx_rx_comp(struct udpx_ep *ep, void *context, uint64_t flags,
+			 size_t len, void *buf, void *addr)
+{
+	struct fi_cq_data_entry *comp;
+
+	comp = cirque_tail(&ep->rx_cq->cirq);
+	comp->op_context = context;
+	comp->flags = FI_RECV | flags;
+	comp->len = len;
+	comp->buf = buf;
+	comp->data = 0;
+	cirque_commit(&ep->rx_cq->cirq);
+}
+
+static void udpx_rx_src_comp(struct udpx_ep *ep, void *context, uint64_t flags,
+			     size_t len, void *buf, void *addr)
+{
+	ep->rx_cq->src[cirque_windex(&ep->rx_cq->cirq)] =
+			ip_av_get_index(ep->av, addr);
+	udpx_rx_comp(ep, context, flags, len, buf, addr);
+}
+
+static void udpx_rx_comp_signal(struct udpx_ep *ep, void *context,
+			uint64_t flags, size_t len, void *buf, void *addr)
+{
+	udpx_rx_comp(ep, context, flags, len, buf, addr);
+	ep->rx_cq->util_cq.wait->signal(ep->rx_cq->util_cq.wait);
+}
+
+static void udpx_rx_src_comp_signal(struct udpx_ep *ep, void *context,
+			uint64_t flags, size_t len, void *buf, void *addr)
+{
+	udpx_rx_src_comp(ep, context, flags, len, buf, addr);
+	ep->rx_cq->util_cq.wait->signal(ep->rx_cq->util_cq.wait);
+
+}
+
+void udpx_ep_progress(struct udpx_ep *ep)
+{
+	struct udpx_ep_entry *entry;
+	struct msghdr hdr;
+	struct sockaddr_in6 addr;
+	int ret;
+
+	hdr.msg_name = &addr;
+	hdr.msg_namelen = sizeof(addr);
+	hdr.msg_control = NULL;
+	hdr.msg_controllen = 0;
+	hdr.msg_flags = 0;
+
+	fastlock_acquire(&ep->rx_cq->util_cq.cq_lock);
+	if (cirque_empty(&ep->rxq))
+		goto out;
+
+	entry = cirque_head(&ep->rxq);
+	hdr.msg_iov = entry->iov;
+	hdr.msg_iovlen = entry->iov_count;
+
+	ret = recvmsg(ep->sock, &hdr, 0);
+	if (ret >= 0) {
+		ep->rx_comp(ep, entry->context, 0, ret, NULL, &addr);
+		cirque_discard(&ep->rxq);
+	}
+out:
+	fastlock_release(&ep->rx_cq->util_cq.cq_lock);
+}
+
+ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+		uint64_t flags)
+{
+	struct udpx_ep *ep;
+	struct udpx_ep_entry entry;
+	ssize_t ret;
+
+	ep = container_of(ep_fid, struct udpx_ep, ep_fid.fid);
+	fastlock_acquire(&ep->rx_cq->util_cq.cq_lock);
+	if (cirque_full(&ep->rxq)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	entry.context = msg->context;
+	for (entry.iov_count = 0; entry.iov_count < msg->iov_count;
+	     entry.iov_count++) {
+		entry.iov[entry.iov_count] = msg->msg_iov[entry.iov_count];
+	}
+	entry.flags = 0;
+
+	cirque_insert(&ep->rxq, entry);
+	ret = 0;
+out:
+	fastlock_release(&ep->rx_cq->util_cq.cq_lock);
+	return ret;
+}
+
+ssize_t udpx_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t src_addr, void *context)
+{
+	struct fi_msg msg;
+
+	msg.msg_iov = iov;
+	msg.iov_count = count;
+	msg.context = context;
+	return udpx_recvmsg(ep_fid, &msg, 0);
+}
+
+ssize_t udpx_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
+		fi_addr_t src_addr, void *context)
+{
+	struct udpx_ep *ep;
+	struct udpx_ep_entry entry;
+	ssize_t ret;
+
+	ep = container_of(ep_fid, struct udpx_ep, ep_fid.fid);
+	fastlock_acquire(&ep->rx_cq->util_cq.cq_lock);
+	if (cirque_full(&ep->rxq)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	entry.context = context;
+	entry.iov_count = 1;
+	entry.iov[0].iov_base = buf;
+	entry.iov[0].iov_len = len;
+	entry.flags = 0;
+
+	cirque_insert(&ep->rxq, entry);
+	ret = 0;
+out:
+	fastlock_release(&ep->rx_cq->util_cq.cq_lock);
+	return ret;
+}
+
+ssize_t udpx_send(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
+		fi_addr_t dest_addr, void *context)
+{
+	struct udpx_ep *ep;
+	ssize_t ret;
+
+	ep = container_of(ep_fid, struct udpx_ep, ep_fid.fid);
+	fastlock_acquire(&ep->tx_cq->util_cq.cq_lock);
+	if (cirque_full(&ep->tx_cq->cirq)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	ret = sendto(ep->sock, buf, len, 0, ip_av_get_addr(ep->av, dest_addr),
+		     ep->av->addrlen);
+	if (ret == len) {
+		ep->tx_comp(ep, context);
+		ret = 0;
+	} else {
+		ret = -errno;
+	}
+out:
+	fastlock_release(&ep->tx_cq->util_cq.cq_lock);
+	return ret;
+}
+
+ssize_t udpx_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+		uint64_t flags)
+{
+	struct udpx_ep *ep;
+	struct msghdr hdr;
+	ssize_t ret;
+
+	ep = container_of(ep_fid, struct udpx_ep, ep_fid.fid);
+	hdr.msg_name = ip_av_get_addr(ep->av, msg->addr);
+	hdr.msg_namelen = ep->av->addrlen;
+	hdr.msg_iov = (struct iovec *) msg->msg_iov;
+	hdr.msg_iovlen = msg->iov_count;
+	hdr.msg_control = NULL;
+	hdr.msg_controllen = 0;
+	hdr.msg_flags = 0;
+
+	fastlock_acquire(&ep->tx_cq->util_cq.cq_lock);
+	if (cirque_full(&ep->tx_cq->cirq)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	ret = sendmsg(ep->sock, &hdr, 0);
+	if (ret >= 0) {
+		ep->tx_comp(ep, msg->context);
+		ret = 0;
+	} else {
+		ret = -errno;
+	}
+out:
+	fastlock_release(&ep->tx_cq->util_cq.cq_lock);
+	return ret;
+}
+
+ssize_t udpx_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t dest_addr, void *context)
+{
+	struct fi_msg msg;
+
+	msg.msg_iov = iov;
+	msg.iov_count = count;
+	msg.addr = dest_addr;
+	msg.context = context;
+
+	return udpx_sendmsg(ep_fid, &msg, 0);
+}
+
+ssize_t udpx_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
+		fi_addr_t dest_addr)
+{
+	struct udpx_ep *ep;
+	ssize_t ret;
+
+	ep = container_of(ep_fid, struct udpx_ep, ep_fid.fid);
+	ret = sendto(ep->sock, buf, len, 0, ip_av_get_addr(ep->av, dest_addr),
+		     ep->av->addrlen);
+	return ret == len ? 0 : -errno;
+}
+
+static struct fi_ops_msg udpx_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = udpx_recv,
+	.recvv = udpx_recvv,
+	.recvmsg = udpx_recvmsg,
+	.send = udpx_send,
+	.sendv = udpx_sendv,
+	.sendmsg = udpx_sendmsg,
+	.inject = udpx_inject,
+	.senddata = fi_no_msg_senddata,
+	.injectdata = fi_no_msg_injectdata,
+};
+
+static int udpx_ep_close(struct fid *fid)
+{
+	struct udpx_ep *ep;
+	struct util_wait_fd *wait;
+
+	ep = container_of(fid, struct udpx_ep, ep_fid.fid);
+
+	if (ep->av)
+		atomic_dec(&ep->av->ref);
+
+	if (ep->rx_cq) {
+		if (ep->rx_cq->util_cq.wait) {
+			wait = container_of(ep->rx_cq->util_cq.wait,
+					    struct util_wait_fd, util_wait);
+			fi_epoll_del(wait->epoll_fd, ep->sock);
+		}
+		fid_list_remove(&ep->rx_cq->util_cq.list,
+				&ep->rx_cq->util_cq.list_lock,
+				&ep->ep_fid.fid);
+		atomic_dec(&ep->rx_cq->util_cq.ref);
+	}
+
+	if (ep->tx_cq) {
+//		fid_list_remove(&ep->tx_cq->util_cq.list,
+//				&ep->tx_cq->util_cq.list_lock,
+//				&ep->ep_fid.fid);
+		atomic_dec(&ep->tx_cq->util_cq.ref);
+	}
+
+	udpx_rx_cirq_free(&ep->rxq);
+	close(ep->sock);
+	atomic_dec(&ep->domain->ref);
+	free(ep);
+	return 0;
+}
+
+static int udpx_ep_bind_cq(struct udpx_ep *ep, struct udpx_cq *cq, uint64_t flags)
+{
+	struct util_wait_fd *wait;
+	int ret;
+
+	if (flags & ~(FI_TRANSMIT | FI_RECV)) {
+		FI_WARN(&udpx_prov, FI_LOG_EP_CTRL,
+			"unsupported flags\n");
+		return -FI_EBADFLAGS;
+	}
+
+	if (((flags & FI_TRANSMIT) && ep->tx_cq) ||
+	    ((flags & FI_RECV) && ep->rx_cq)) {
+		FI_WARN(&udpx_prov, FI_LOG_EP_CTRL,
+			"duplicate CQ binding\n");
+		return -FI_EINVAL;
+	}
+
+	if (flags & FI_TRANSMIT) {
+		ep->tx_cq = cq;
+		atomic_inc(&cq->util_cq.ref);
+		ep->tx_comp = cq->util_cq.wait ?
+			      udpx_tx_comp_signal : udpx_tx_comp;
+//		ret = fid_list_insert(&cq->util_cq.list,
+//				      &cq->util_cq.list_lock,
+//				      &ep->ep_fid.fid);
+//		if (ret)
+//			return ret;
+	}
+
+	if (flags & FI_RECV) {
+		ep->rx_cq = cq;
+		atomic_inc(&cq->util_cq.ref);
+
+		if (cq->util_cq.wait) {
+			ep->rx_comp = (cq->util_cq.domain->caps & FI_SOURCE) ?
+				      udpx_rx_src_comp_signal :
+				      udpx_rx_comp_signal;
+
+			wait = container_of(cq->util_cq.wait,
+					    struct util_wait_fd, util_wait);
+			ret = fi_epoll_add(wait->epoll_fd, ep->sock,
+					   &ep->ep_fid.fid);
+			if (ret)
+				return ret;
+		} else {
+			ep->rx_comp = (cq->util_cq.domain->caps & FI_SOURCE) ?
+				      udpx_rx_src_comp : udpx_rx_comp;
+		}
+
+		ret = fid_list_insert(&cq->util_cq.list,
+				      &cq->util_cq.list_lock,
+				      &ep->ep_fid.fid);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int udpx_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
+{
+	struct udpx_ep *ep;
+	struct util_av *av;
+	int ret;
+
+	ep = container_of(ep_fid, struct udpx_ep, ep_fid.fid);
+	switch (bfid->fclass) {
+	case FI_CLASS_AV:
+		if (ep->av) {
+			FI_WARN(&udpx_prov, FI_LOG_EP_CTRL,
+				"duplicate AV binding\n");
+			return -FI_EINVAL;
+		}
+		av = container_of(bfid, struct util_av, av_fid.fid);
+		atomic_inc(&av->ref);
+		ep->av = av;
+		ret = 0;
+		break;
+	case FI_CLASS_CQ:
+		ret = udpx_ep_bind_cq(ep, container_of(bfid, struct udpx_cq,
+						util_cq.cq_fid.fid), flags);
+		break;
+	default:
+		FI_WARN(&udpx_prov, FI_LOG_EP_CTRL,
+			"invalid fid class\n");
+		ret = -FI_EINVAL;
+		break;
+	}
+	return ret;
+}
+
+static int udpx_ep_ctrl(struct fid *fid, int command, void *arg)
+{
+	struct udpx_ep *ep;
+
+	ep = container_of(fid, struct udpx_ep, ep_fid.fid);
+	switch (command) {
+	case FI_ENABLE:
+		if (!ep->rx_cq || !ep->tx_cq)
+			return -FI_ENOCQ;
+		if (!ep->av)
+			return -FI_EOPBADSTATE; /* TODO: Add FI_ENOAV */
+		break;
+	default:
+		return -FI_ENOSYS;
+	}
+	return 0;
+}
+
+static struct fi_ops udpx_ep_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = udpx_ep_close,
+	.bind = udpx_ep_bind,
+	.control = udpx_ep_ctrl,
+	.ops_open = fi_no_ops_open,
+};
+
+static int udpx_ep_init(struct udpx_ep *ep, struct fi_info *info)
+{
+	int family;
+	int ret;
+
+	ret = udpx_rx_cirq_init(&ep->rxq, info->rx_attr->size);
+	if (ret)
+		return ret;
+
+	family = info->src_addr ?
+		 ((struct sockaddr *) info->src_addr)->sa_family : AF_INET;
+	ep->sock = socket(family, SOCK_DGRAM, IPPROTO_UDP);
+	if (ep->sock < 0) {
+		ret = -errno;
+		goto err1;
+	}
+
+	if (info->src_addr) {
+		ret = bind(ep->sock, info->src_addr, info->src_addrlen);
+		if (ret) {
+			ret = -errno;
+			goto err1;
+		}
+	}
+
+	if (info->dest_addr) {
+		ret = connect(ep->sock, info->dest_addr, info->dest_addrlen);
+		if (ret) {
+			ret = -errno;
+			goto err1;
+		}
+	}
+
+	ret = fi_fd_nonblock(ep->sock);
+	if (ret)
+		goto err2;
+
+	return 0;
+err2:
+	close(ep->sock);
+err1:
+	udpx_rx_cirq_free(&ep->rxq);
+	return ret;
+}
+
+int udpx_endpoint(struct fid_domain *domain, struct fi_info *info,
+		  struct fid_ep **ep_fid, void *context)
+{
+	struct udpx_ep *ep;
+	int ret;
+
+	if (!info || !info->ep_attr || !info->rx_attr || !info->tx_attr)
+		return -FI_EINVAL;
+
+	ret = fi_check_info(&udpx_prov, &udpx_info, info);
+	if (ret)
+		return ret;
+
+	ep = calloc(1, sizeof(*ep));
+	if (!ep)
+		return -FI_ENOMEM;
+
+	ret = udpx_ep_init(ep, info);
+	if (ret) {
+		free(ep);
+		return ret;
+	}
+
+	ep->ep_fid.fid.fclass = FI_CLASS_EP;
+	ep->ep_fid.fid.context = context;
+	ep->ep_fid.fid.ops = &udpx_ep_fi_ops;
+	ep->ep_fid.ops = &udpx_ep_ops;
+	ep->ep_fid.cm = &udpx_cm_ops;
+	ep->ep_fid.msg = &udpx_msg_ops;
+
+	ep->domain = container_of(domain, struct util_domain, domain_fid);
+	atomic_inc(&ep->domain->ref);
+
+	*ep_fid = &ep->ep_fid;
+	return 0;
+}

--- a/prov/udp/src/udpx_fabric.c
+++ b/prov/udp/src/udpx_fabric.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "udpx.h"
+
+
+static struct fi_ops_fabric udpx_fabric_ops = {
+	.size = sizeof(struct fi_ops_fabric),
+	.domain = udpx_domain_open,
+	.passive_ep = fi_no_passive_ep,
+	.eq_open = fi_eq_create,
+	.wait_open = fi_wait_fd_open,
+};
+
+int udpx_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
+		void *context)
+{
+	int ret;
+
+	ret = fi_fabric_create(&udpx_prov, udpx_info.fabric_attr, attr,
+			       fabric, context);
+	if (ret)
+		return ret;
+
+	(*fabric)->ops = &udpx_fabric_ops;
+	return 0;
+}

--- a/prov/udp/src/udpx_init.c
+++ b/prov/udp/src/udpx_init.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <rdma/fi_errno.h>
+
+#include <prov.h>
+#include "udpx.h"
+
+
+static int udpx_getinfo(uint32_t version, const char *node, const char *service,
+			uint64_t flags, struct fi_info *hints, struct fi_info **info)
+{
+	return util_getinfo(&udpx_prov, version, node, service, flags,
+			    &udpx_info, hints, info);
+}
+
+static void udpx_fini(void)
+{
+	/* yawn */
+}
+
+struct fi_provider udpx_prov = {
+	.name = "UDP",
+	.version = FI_VERSION(UDPX_MAJOR_VERSION, UDPX_MINOR_VERSION),
+	.fi_version = FI_VERSION(1, 1),
+	.getinfo = udpx_getinfo,
+	.fabric = udpx_fabric,
+	.cleanup = udpx_fini
+};
+
+UDP_INI
+{
+	return &udpx_prov;
+}

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2015-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <fi_util.h>
+
+
+static int fi_valid_addr_format(uint32_t prov_format, uint32_t user_format)
+{
+	if (user_format == FI_FORMAT_UNSPEC)
+		return 1;
+
+	switch (prov_format) {
+	case FI_SOCKADDR:
+		/* Provider supports INET and INET6 */
+		return user_format <= FI_SOCKADDR_IN6;
+	case FI_SOCKADDR_IN:
+		/* Provider supports INET only */
+		return user_format <= FI_SOCKADDR_IN;
+	case FI_SOCKADDR_IN6:
+		/* Provider supports INET6 only */
+		return user_format <= FI_SOCKADDR_IN6;
+	case FI_SOCKADDR_IB:
+		/* Provider must support IB, INET, and INET6 */
+		return user_format <= FI_SOCKADDR_IB;
+	default:
+		return prov_format == user_format;
+	}
+}
+
+int fi_check_fabric_attr(const struct fi_provider *prov,
+			 const struct fi_fabric_attr *prov_attr,
+			 const struct fi_fabric_attr *user_attr)
+{
+	if (user_attr->name && strcasecmp(user_attr->name, prov_attr->name)) {
+		FI_INFO(prov, FI_LOG_CORE, "Unknown fabric name\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->prov_version > prov_attr->prov_version) {
+		FI_INFO(prov, FI_LOG_CORE, "Unsupported provider version\n");
+		return -FI_ENODATA;
+	}
+
+	return 0;
+}
+
+/*
+ * Threading models ranked by order of parallelism.
+ */
+static int fi_thread_level(enum fi_threading thread_model)
+{
+	switch (thread_model) {
+	case FI_THREAD_SAFE:
+		return 1;
+	case FI_THREAD_FID:
+		return 2;
+	case FI_THREAD_ENDPOINT:
+		return 3;
+	case FI_THREAD_COMPLETION:
+		return 4;
+	case FI_THREAD_DOMAIN:
+		return 5;
+	case FI_THREAD_UNSPEC:
+		return 6;
+	default:
+		return -1;
+	}
+}
+
+/*
+ * Progress models ranked by order of automation.
+ */
+static int fi_progress_level(enum fi_progress progress_model)
+{
+	switch (progress_model) {
+	case FI_PROGRESS_AUTO:
+		return 1;
+	case FI_PROGRESS_MANUAL:
+		return 2;
+	case FI_PROGRESS_UNSPEC:
+		return 3;
+	default:
+		return -1;
+	}
+}
+
+/*
+ * Resource management models ranked by order of enablement.
+ */
+static int fi_resource_mgmt_level(enum fi_resource_mgmt rm_model)
+{
+	switch (rm_model) {
+	case FI_RM_ENABLED:
+		return 1;
+	case FI_RM_DISABLED:
+		return 2;
+	case FI_RM_UNSPEC:
+		return 3;
+	default:
+		return -1;
+	}
+}
+
+int fi_check_domain_attr(const struct fi_provider *prov,
+			 const struct fi_domain_attr *prov_attr,
+			 const struct fi_domain_attr *user_attr)
+{
+	if (user_attr->name && strcasecmp(user_attr->name, prov_attr->name)) {
+		FI_INFO(prov, FI_LOG_CORE, "Unknown domain name\n");
+		return -FI_ENODATA;
+	}
+
+	if (fi_thread_level(user_attr->threading) <
+	    fi_thread_level(prov_attr->threading)) {
+		FI_INFO(prov, FI_LOG_CORE, "Invalid threading model\n");
+		return -FI_ENODATA;
+	}
+
+	if (fi_progress_level(user_attr->control_progress) <
+	    fi_progress_level(prov_attr->control_progress)) {
+		FI_INFO(prov, FI_LOG_CORE, "Invalid control progress model\n");
+		return -FI_ENODATA;
+	}
+
+	if (fi_progress_level(user_attr->data_progress) <
+	    fi_progress_level(prov_attr->data_progress)) {
+		FI_INFO(prov, FI_LOG_CORE, "Invalid data progress model\n");
+		return -FI_ENODATA;
+	}
+
+	if (fi_resource_mgmt_level(user_attr->resource_mgmt) <
+	    fi_resource_mgmt_level(prov_attr->resource_mgmt)) {
+		FI_INFO(prov, FI_LOG_CORE, "Invalid resource mgmt model\n");
+		return -FI_ENODATA;
+	}
+
+	if ((prov_attr->av_type != FI_AV_UNSPEC) &&
+	    (user_attr->av_type != FI_AV_UNSPEC) &&
+	    (prov_attr->av_type != user_attr->av_type)) {
+		FI_INFO(prov, FI_LOG_CORE, "Invalid AV type\n");
+	   	return -FI_ENODATA;
+	}
+
+	if (user_attr->mr_mode && (user_attr->mr_mode != prov_attr->mr_mode)) {
+		FI_INFO(prov, FI_LOG_CORE, "Invalid memory registration mode\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->cq_data_size > prov_attr->cq_data_size) {
+		FI_INFO(prov, FI_LOG_CORE, "CQ data size too large\n");
+		return -FI_ENODATA;
+	}
+
+	return 0;
+}
+
+int fi_check_ep_attr(const struct fi_provider *prov,
+		     const struct fi_ep_attr *prov_attr,
+		     const struct fi_ep_attr *user_attr)
+{
+	if (user_attr->type && (user_attr->type != prov_attr->type)) {
+		FI_INFO(prov, FI_LOG_CORE, "Unsupported endpoint type\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->protocol && (user_attr->protocol != prov_attr->protocol)) {
+		FI_INFO(prov, FI_LOG_CORE, "Unsupported protocol\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->protocol_version &&
+	    (user_attr->protocol_version > prov_attr->protocol_version)) {
+		FI_INFO(prov, FI_LOG_CORE, "Unsupported protocol version\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->max_msg_size > prov_attr->max_msg_size) {
+		FI_INFO(prov, FI_LOG_CORE, "Max message size too large\n");
+		return -FI_ENODATA;
+	}
+
+	return 0;
+}
+
+int fi_check_rx_attr(const struct fi_provider *prov,
+		     const struct fi_rx_attr *prov_attr,
+		     const struct fi_rx_attr *user_attr)
+{
+	if (user_attr->caps & ~(prov_attr->caps)) {
+		FI_INFO(prov, FI_LOG_CORE, "caps not supported\n");
+		return -FI_ENODATA;
+	}
+
+	if ((user_attr->mode & prov_attr->mode) != prov_attr->mode) {
+		FI_INFO(prov, FI_LOG_CORE, "needed mode not set\n");
+		return -FI_ENODATA;
+	}
+
+	if (prov_attr->op_flags & ~(prov_attr->op_flags)) {
+		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->msg_order & ~(prov_attr->msg_order)) {
+		FI_INFO(prov, FI_LOG_CORE, "msg_order not supported\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->comp_order & ~(prov_attr->comp_order)) {
+		FI_INFO(prov, FI_LOG_CORE, "comp_order not supported\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->total_buffered_recv > prov_attr->total_buffered_recv) {
+		FI_INFO(prov, FI_LOG_CORE, "total_buffered_recv too large\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->size > prov_attr->size) {
+		FI_INFO(prov, FI_LOG_CORE, "size is greater than supported\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->iov_limit > prov_attr->iov_limit) {
+		FI_INFO(prov, FI_LOG_CORE, "iov_limit too large\n");
+		return -FI_ENODATA;
+	}
+
+	return 0;
+}
+
+int fi_check_tx_attr(const struct fi_provider *prov,
+		     const struct fi_tx_attr *prov_attr,
+		     const struct fi_tx_attr *user_attr)
+{
+	if (user_attr->caps & ~(prov_attr->caps)) {
+		FI_INFO(prov, FI_LOG_CORE, "caps not supported\n");
+		return -FI_ENODATA;
+	}
+
+	if ((user_attr->mode & prov_attr->mode) != prov_attr->mode) {
+		FI_INFO(prov, FI_LOG_CORE, "needed mode not set\n");
+		return -FI_ENODATA;
+	}
+
+	if (prov_attr->op_flags & ~(prov_attr->op_flags)) {
+		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->msg_order & ~(prov_attr->msg_order)) {
+		FI_INFO(prov, FI_LOG_CORE, "msg_order not supported\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->comp_order & ~(prov_attr->comp_order)) {
+		FI_INFO(prov, FI_LOG_CORE, "comp_order not supported\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->inject_size > prov_attr->inject_size) {
+		FI_INFO(prov, FI_LOG_CORE, "inject_size too large\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->size > prov_attr->size) {
+		FI_INFO(prov, FI_LOG_CORE, "size is greater than supported\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->iov_limit > prov_attr->iov_limit) {
+		FI_INFO(prov, FI_LOG_CORE, "iov_limit too large\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->rma_iov_limit > prov_attr->rma_iov_limit) {
+		FI_INFO(prov, FI_LOG_CORE, "rma_iov_limit too large\n");
+		return -FI_ENODATA;
+	}
+
+	return 0;
+}
+
+int fi_check_info(const struct fi_provider *prov,
+		  const struct fi_info *prov_info,
+		  const struct fi_info *user_info)
+{
+	int ret;
+
+	if (!user_info)
+		return 0;
+
+	if (user_info->caps & ~(prov_info->caps)) {
+		FI_INFO(prov, FI_LOG_CORE, "Unsupported capabilities\n");
+		return -FI_ENODATA;
+	}
+
+	if ((user_info->mode & prov_info->mode) != prov_info->mode) {
+		FI_INFO(prov, FI_LOG_CORE, "needed mode not set\n");
+		return -FI_ENODATA;
+	}
+
+	if (!fi_valid_addr_format(prov_info->addr_format,
+				  user_info->addr_format)) {
+		FI_INFO(prov, FI_LOG_CORE, "address format not supported\n");
+		return -FI_ENODATA;
+	}
+
+	if (user_info->fabric_attr) {
+		ret = fi_check_fabric_attr(prov, prov_info->fabric_attr,
+					   user_info->fabric_attr);
+		if (ret)
+			return ret;
+	}
+
+	if (user_info->domain_attr) {
+		ret = fi_check_domain_attr(prov, prov_info->domain_attr,
+					   user_info->domain_attr);
+		if (ret)
+			return ret;
+	}
+
+	if (user_info->ep_attr) {
+		ret = fi_check_ep_attr(prov, prov_info->ep_attr,
+				       user_info->ep_attr);
+		if (ret)
+			return ret;
+	}
+
+	if (user_info->rx_attr) {
+		ret = fi_check_rx_attr(prov, prov_info->rx_attr,
+				       user_info->rx_attr);
+		if (ret)
+			return ret;
+	}
+
+	if (user_info->tx_attr) {
+		ret = fi_check_tx_attr(prov, prov_info->tx_attr,
+				       user_info->tx_attr);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static void fi_alter_ep_attr(struct fi_ep_attr *attr,
+			     const struct fi_ep_attr *hints)
+{
+	if (!hints)
+		return;
+
+	if (hints->tx_ctx_cnt)
+		attr->tx_ctx_cnt = hints->tx_ctx_cnt;
+	if (hints->rx_ctx_cnt)
+		attr->rx_ctx_cnt = hints->rx_ctx_cnt;
+}
+
+static void fi_alter_rx_attr(struct fi_rx_attr *attr,
+			     const struct fi_rx_attr *hints,
+			     uint64_t info_caps)
+{
+	if (!hints) {
+		attr->caps = (info_caps & attr->caps & FI_PRIMARY_CAPS) |
+			     (attr->caps & FI_SECONDARY_CAPS);
+		return;
+	}
+
+	attr->op_flags = hints->op_flags;
+	attr->caps = (hints->caps & FI_PRIMARY_CAPS) |
+		     (attr->caps & FI_SECONDARY_CAPS);
+	attr->total_buffered_recv = hints->total_buffered_recv;
+	if (hints->size)
+		attr->size = hints->size;
+	if (hints->iov_limit)
+		attr->iov_limit = hints->iov_limit;
+}
+
+static void fi_alter_tx_attr(struct fi_tx_attr *attr,
+			     const struct fi_tx_attr *hints,
+			     uint64_t info_caps)
+{
+	if (!hints) {
+		attr->caps = (info_caps & attr->caps & FI_PRIMARY_CAPS) |
+			     (attr->caps & FI_SECONDARY_CAPS);
+		return;
+	}
+
+	attr->op_flags = hints->op_flags;
+	attr->caps = (hints->caps & FI_PRIMARY_CAPS) |
+		     (attr->caps & FI_SECONDARY_CAPS);
+	if (hints->inject_size)
+		attr->inject_size = hints->inject_size;
+	if (hints->size)
+		attr->size = hints->size;
+	if (hints->iov_limit)
+		attr->iov_limit = hints->iov_limit;
+	if (hints->rma_iov_limit)
+		attr->rma_iov_limit = hints->rma_iov_limit;
+}
+
+/*
+ * Alter the returned fi_info based on the user hints.  We assume that
+ * the hints have been validated and the starting fi_info is properly
+ * configured by the provider.
+ */
+void fi_alter_info(struct fi_info *info,
+		   const struct fi_info *hints)
+{
+	if (!hints)
+		return;
+
+	info->caps = (hints->caps & FI_PRIMARY_CAPS) |
+		     (info->caps & FI_SECONDARY_CAPS);
+
+	fi_alter_ep_attr(info->ep_attr, hints->ep_attr);
+	fi_alter_rx_attr(info->rx_attr, hints->rx_attr, info->caps);
+	fi_alter_tx_attr(info->tx_attr, hints->tx_attr, info->caps);
+}

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1,0 +1,958 @@
+/*
+ * Copyright (c) 2015-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <arpa/inet.h>
+#include <ctype.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <netdb.h>
+#include <netinet/in.h>
+
+#include <fi_util.h>
+
+
+enum {
+	UTIL_NO_ENTRY = -1,
+	UTIL_DEFAULT_AV_SIZE = 1024,
+};
+
+
+static int fi_get_src_sockaddr(const struct sockaddr *dest_addr, size_t dest_addrlen,
+			       struct sockaddr **src_addr, size_t *src_addrlen)
+{
+	int sock, ret;
+
+	sock = socket(dest_addr->sa_family, SOCK_DGRAM, 0);
+	if (sock < 0)
+		return -errno;
+
+	ret = connect(sock, dest_addr, dest_addrlen);
+	if (ret)
+		goto out;
+
+	*src_addr = calloc(dest_addrlen, 1);
+	if (!*src_addr) {
+		ret = -FI_ENOMEM;
+		goto out;
+	}
+
+	*src_addrlen = dest_addrlen;
+	ret = getsockname(sock, *src_addr, src_addrlen);
+	if (ret) {
+		ret = -errno;
+		goto out;
+	}
+
+	switch ((*src_addr)->sa_family) {
+	case AF_INET:
+		((struct sockaddr_in *) (*src_addr))->sin_port = 0;
+		break;
+	case AF_INET6:
+		((struct sockaddr_in6 *) (*src_addr))->sin6_port = 0;
+		break;
+	default:
+		ret = -FI_ENOSYS;
+		break;
+	}
+
+out:
+	close(sock);
+	return ret;
+
+}
+
+int fi_get_src_addr(uint32_t addr_format,
+		    const void *dest_addr, size_t dest_addrlen,
+		    void **src_addr, size_t *src_addrlen)
+{
+	switch (addr_format) {
+	case FI_SOCKADDR:
+	case FI_SOCKADDR_IN:
+	case FI_SOCKADDR_IN6:
+		return fi_get_src_sockaddr(dest_addr, dest_addrlen,
+					   (struct sockaddr **) src_addr,
+					   src_addrlen);
+	default:
+		return -FI_ENOSYS;
+	}
+}
+
+static int fi_get_sockaddr(int sa_family, uint64_t flags,
+			   const char *node, const char *service,
+			   struct sockaddr **addr, size_t *addrlen)
+{
+	struct addrinfo hints, *ai;
+	int ret;
+
+	memset(&hints, 0, sizeof hints);
+	hints.ai_family = sa_family;
+	hints.ai_socktype = SOCK_STREAM;
+	if (flags & FI_SOURCE)
+		hints.ai_flags = AI_PASSIVE;
+
+	ret = getaddrinfo(node, service, &hints, &ai);
+	if (ret)
+		return -FI_ENODATA;
+
+	*addr = mem_dup(ai->ai_addr, ai->ai_addrlen);
+	if (!*addr) {
+		ret = -FI_ENOMEM;
+		goto out;
+	}
+
+	*addrlen = ai->ai_addrlen;
+out:
+	freeaddrinfo(ai);
+	return ret;
+}
+
+int fi_get_addr(uint32_t addr_format, uint64_t flags,
+		const char *node, const char *service,
+		void **addr, size_t *addrlen)
+{
+	switch (addr_format) {
+	case FI_SOCKADDR:
+		return fi_get_sockaddr(0, flags, node, service,
+				       (struct sockaddr **) addr, addrlen);
+	case FI_SOCKADDR_IN:
+		return fi_get_sockaddr(AF_INET, flags, node, service,
+				       (struct sockaddr **) addr, addrlen);
+	case FI_SOCKADDR_IN6:
+		return fi_get_sockaddr(AF_INET6, flags, node, service,
+				       (struct sockaddr **) addr, addrlen);
+	default:
+		return -FI_ENOSYS;
+	}
+}
+
+static void *util_av_get_data(struct util_av *av, int index)
+{
+	return (char *) av->data + (index * av->addrlen);
+}
+
+void *fi_av_get_addr(struct util_av *av, int index)
+{
+	return util_av_get_data(av, index);
+}
+
+static void util_av_set_data(struct util_av *av, int index,
+			     const void *data, size_t len)
+{
+	memcpy(util_av_get_data(av, index), data, len);
+}
+
+static int fi_verify_av_insert(struct util_av *av, uint64_t flags)
+{
+	if ((av->flags & FI_EVENT) && !av->eq) {
+		FI_WARN(av->prov, FI_LOG_AV, "no EQ bound to AV\n");
+		return -FI_ENOEQ;
+	}
+
+	if (flags & ~(FI_MORE)) {
+		FI_WARN(av->prov, FI_LOG_AV, "unsupported flags\n");
+		return -FI_ENOEQ;
+	}
+
+	return 0;
+}
+
+/*
+ * Must hold AV lock
+ */
+static int util_av_hash_insert(struct util_av_hash *hash, int slot, int index)
+{
+	int entry, i;
+
+	if (slot < 0 || slot >= hash->slots)
+		return -FI_EINVAL;
+
+	if (hash->table[slot].index == UTIL_NO_ENTRY) {
+		hash->table[slot].index = index;
+		return 0;
+	}
+
+	if (hash->free_list == UTIL_NO_ENTRY)
+		return -FI_ENOSPC;
+
+	entry = hash->free_list;
+	hash->free_list = hash->table[hash->free_list].next;
+
+	for (i = slot; hash->table[i].next != UTIL_NO_ENTRY; )
+		i = hash->table[i].next;
+
+	hash->table[i].next = entry;
+	hash->table[entry].index = index;
+	hash->table[entry].next = UTIL_NO_ENTRY;
+	return 0;
+}
+
+static int fi_av_insert_addr(struct util_av *av, const void *addr, int slot,
+			     int *index)
+{
+	int ret = 0;
+
+	fastlock_acquire(&av->lock);
+	if (av->free_list == UTIL_NO_ENTRY) {
+		FI_WARN(av->prov, FI_LOG_AV, "AV is full\n");
+		ret = -FI_ENOSPC;
+		goto out;
+	}
+
+	if (av->flags & FI_SOURCE) {
+		ret = util_av_hash_insert(&av->hash, slot, av->free_list);
+		if (ret) {
+			FI_WARN(av->prov, FI_LOG_AV,
+				"failed to insert addr into hash table\n");
+			goto out;
+		}
+	}
+
+	*index = av->free_list;
+	av->free_list = *(int *) util_av_get_data(av, av->free_list);
+	util_av_set_data(av, *index, addr, av->addrlen);
+out:
+	fastlock_release(&av->lock);
+	return ret;
+}
+
+/*
+ * Must hold AV lock
+ */
+static void util_av_hash_remove(struct util_av_hash *hash, int slot, int index)
+{
+	int i;
+
+	if (slot < 0 || slot >= hash->slots)
+		return;
+
+	if (slot == index) {
+		if (hash->table[slot].next == UTIL_NO_ENTRY) {
+			hash->table[slot].index = UTIL_NO_ENTRY;
+			return;
+		} else {
+			index = hash->table[slot].next;
+			hash->table[slot] = hash->table[index];
+		}
+	} else {
+		for (i = slot; hash->table[i].next != index; )
+			i = hash->table[i].next;
+
+		hash->table[i].next = hash->table[index].next;
+	}
+	hash->table[index].next = hash->free_list;
+	hash->free_list = index;
+}
+
+static int fi_av_remove_addr(struct util_av *av, int slot, int index)
+{
+	int *entry, *next, i;
+
+	if (index < 0 || index > av->count) {
+		FI_WARN(av->prov, FI_LOG_AV, "index out of range\n");
+		return -FI_EINVAL;
+	}
+
+	fastlock_acquire(&av->lock);
+	if (av->flags & FI_SOURCE)
+		util_av_hash_remove(&av->hash, slot, index);
+
+	entry = util_av_get_data(av, index);
+	if (av->free_list == UTIL_NO_ENTRY || index < av->free_list) {
+		*entry = av->free_list;
+		av->free_list = index;
+	} else {
+		i = av->free_list;
+		for (next = util_av_get_data(av, i); index > *next;) {
+			i = *next;
+			next = util_av_get_data(av, i);
+		}
+		util_av_set_data(av, index, next, sizeof index);
+		*next = index;
+	}
+
+	fastlock_release(&av->lock);
+	return 0;
+}
+
+static int fi_av_lookup_index(struct util_av *av, const void *addr, int slot)
+{
+	int i, ret = -FI_ENODATA;
+
+	if (slot < 0 || slot >= av->hash.slots) {
+		FI_WARN(av->prov, FI_LOG_AV, "invalid slot (%d)\n", slot);
+		return -FI_EINVAL;
+	}
+
+	fastlock_acquire(&av->lock);
+	if (av->hash.table[slot].index == UTIL_NO_ENTRY) {
+		FI_DBG(av->prov, FI_LOG_AV, "no entry at slot (%d)\n", slot);
+		goto out;
+	}
+
+	for (i = slot; i != UTIL_NO_ENTRY; i = av->hash.table[i].next) {
+		if (!memcmp(fi_av_get_addr(av, av->hash.table[i].index), addr,
+			    av->addrlen)) {
+			ret = av->hash.table[i].index;
+			FI_DBG(av->prov, FI_LOG_AV, "entry at index (%d)\n", ret);
+			break;
+		}
+	}
+out:
+	FI_DBG(av->prov, FI_LOG_AV, "%d\n", ret);
+	fastlock_release(&av->lock);
+	return ret;
+}
+
+static int util_av_bind(struct fid *av_fid, struct fid *eq_fid, uint64_t flags)
+{
+	struct util_av *av;
+	struct util_eq *eq;
+
+	av = container_of(av_fid, struct util_av, av_fid.fid);
+	if (eq_fid->fclass != FI_CLASS_EQ) {
+		FI_WARN(av->prov, FI_LOG_AV, "invalid fid class\n");
+		return -FI_EINVAL;
+	}
+
+	if (flags) {
+		FI_WARN(av->prov, FI_LOG_AV, "invalid flags\n");
+		return -FI_EINVAL;
+	}
+
+	eq = container_of(eq_fid, struct util_eq, eq_fid.fid);
+	av->eq = eq;
+	atomic_inc(&eq->ref);
+	return 0;
+}
+
+static int fi_av_free(struct fid *av_fid)
+{
+	struct util_av *av;
+
+	av = container_of(av_fid, struct util_av, av_fid.fid);
+	if (atomic_get(&av->ref)) {
+		FI_WARN(av->prov, FI_LOG_AV, "AV is busy\n");
+		return -FI_EBUSY;
+	}
+
+	if (av->eq)
+		atomic_dec(&av->eq->ref);
+
+	atomic_dec(&av->domain->ref);
+	fastlock_destroy(&av->lock);
+	/* TODO: unmap data? */
+	free(av->data);
+	free(av);
+	return 0;
+}
+
+static void util_av_hash_init(struct util_av_hash *hash)
+{
+	int i;
+
+	for (i = 0; i < hash->slots; i++) {
+		hash->table[i].index = UTIL_NO_ENTRY;
+		hash->table[i].next = UTIL_NO_ENTRY;
+	}
+
+	hash->free_list = hash->slots;
+	for (i = hash->slots; i < hash->total_count; i++) {
+		hash->table[i].index = UTIL_NO_ENTRY;
+		hash->table[i].next = i + 1;
+	}
+	hash->table[hash->total_count - 1].next = UTIL_NO_ENTRY;
+}
+
+static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
+			const struct util_av_attr *util_attr)
+{
+	int *entry, i, ret = 0;
+
+	atomic_initialize(&av->ref, 0);
+	fastlock_init(&av->lock);
+	av->count = attr->count ? attr->count : UTIL_DEFAULT_AV_SIZE;
+	av->count = roundup_power_of_two(av->count);
+	av->addrlen = util_attr->addrlen;
+	av->flags = util_attr->flags | attr->flags;
+
+	FI_INFO(av->prov, FI_LOG_AV, "AV size %zu\n", av->count);
+
+	/* TODO: Handle FI_READ */
+	/* TODO: Handle mmap - shared AV */
+
+	if (util_attr->flags & FI_SOURCE) {
+		av->hash.slots = av->count;
+		av->hash.total_count = av->count + util_attr->overhead;
+		FI_INFO(av->prov, FI_LOG_AV,
+		       "FI_SOURCE requested, hash size %zu\n", av->hash.total_count);
+	}
+
+	av->data = malloc((av->count * util_attr->addrlen) +
+			  (av->hash.total_count * sizeof(*av->hash.table)));
+	if (!av->data)
+		return -FI_ENOMEM;
+
+	for (i = 0; i < av->count - 1; i++) {
+		entry = util_av_get_data(av, i);
+		*entry = i + 1;
+	}
+	entry = util_av_get_data(av, av->count - 1);
+	*entry = UTIL_NO_ENTRY;
+
+	if (util_attr->flags & FI_SOURCE) {
+		av->hash.table = util_av_get_data(av, av->count);
+		util_av_hash_init(&av->hash);
+	}
+
+	return ret;
+}
+
+static int util_verify_av_attr(struct util_domain *domain,
+			       const struct fi_av_attr *attr,
+			       const struct util_av_attr *util_attr)
+{
+	switch (attr->type) {
+	case FI_AV_MAP:
+	case FI_AV_TABLE:
+		if ((domain->av_type != FI_AV_UNSPEC) &&
+		    (attr->type != domain->av_type)) {
+			FI_INFO(domain->prov, FI_LOG_AV, "Invalid AV type\n");
+		   	return -FI_EINVAL;
+		}
+		break;
+	default:
+		FI_WARN(domain->prov, FI_LOG_AV, "invalid av type\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr->flags & ~(FI_EVENT | FI_READ | FI_SYMMETRIC)) {
+		FI_WARN(domain->prov, FI_LOG_AV, "invalid flags\n");
+		return -FI_EINVAL;
+	}
+
+	if (util_attr->flags & ~(FI_SOURCE)) {
+		FI_WARN(domain->prov, FI_LOG_AV, "invalid internal flags\n");
+		return -FI_EINVAL;
+	}
+
+	if (util_attr->addrlen < sizeof(int)) {
+		FI_WARN(domain->prov, FI_LOG_AV, "unsupported address size\n");
+		return -FI_ENOSYS;
+	}
+
+	return 0;
+}
+
+int fi_av_create(struct util_domain *domain, const struct fi_av_attr *attr,
+		 const struct util_av_attr *util_attr,
+		 struct fid_av **av_fid, void *context)
+{
+	struct util_av *av;
+	int ret;
+
+	ret = util_verify_av_attr(domain, attr, util_attr);
+	if (ret)
+		return ret;
+
+	av = calloc(1, sizeof(*av));
+	if (!av)
+		return -FI_ENOMEM;
+
+	av->prov = domain->prov;
+	ret = util_av_init(av, attr, util_attr);
+	if (ret) {
+		free(av);
+		return ret;
+	}
+
+	av->av_fid.fid.fclass = FI_CLASS_AV;
+	/*
+	 * ops set by provider
+	 * av->av_fid.fid.ops = &prov_av_fi_ops;
+	 * av->av_fid.ops = &prov_av_ops;
+	 */
+	av->context = context;
+
+	av->domain = domain;
+	atomic_inc(&domain->ref);
+
+	*av_fid = &av->av_fid;
+	return 0;
+}
+
+
+/*************************************************************************
+ *
+ * AV for IP addressing
+ *
+ *************************************************************************/
+
+static int ip_av_slot(struct util_av *av, const struct sockaddr *sa)
+{
+	uint16_t host;
+	uint16_t port;
+
+	if (!sa)
+		return UTIL_NO_ENTRY;
+
+	switch (((struct sockaddr *) sa)->sa_family) {
+	case AF_INET:
+		host = (uint16_t) ntohl(((struct sockaddr_in *) sa)->
+					sin_addr.s_addr);
+		port = ntohs(((struct sockaddr_in *) sa)->sin_port);
+		break;
+	case AF_INET6:
+		host = (uint16_t) ((struct sockaddr_in6 *) sa)->
+					sin6_addr.s6_addr[15];
+		port = ntohs(((struct sockaddr_in6 *) sa)->sin6_port);
+		break;
+	default:
+		assert(0);
+		return UTIL_NO_ENTRY;
+	}
+
+	/* TODO: Find a good hash function */
+	FI_DBG(av->prov, FI_LOG_AV, "slot %d\n",
+		((host << 16) | port) % av->hash.slots);
+	return ((host << 16) | port) % av->hash.slots;
+}
+
+int ip_av_get_index(struct util_av *av, const void *addr)
+{
+	return fi_av_lookup_index(av, addr, ip_av_slot(av, addr));
+}
+
+static void ip_av_write_event(struct util_av *av, uint64_t data,
+			      int err, void *context)
+{
+	struct fi_eq_err_entry entry;
+	size_t size;
+	ssize_t ret;
+	uint64_t flags;
+
+	entry.fid = &av->av_fid.fid;
+	entry.context = context;
+	entry.data = data;
+
+	if (err) {
+		FI_INFO(av->prov, FI_LOG_AV, "writing error entry to EQ\n");
+		entry.err = err;
+		size = sizeof(struct fi_eq_err_entry);
+		flags = UTIL_FLAG_ERROR;
+	} else {
+		FI_DBG(av->prov, FI_LOG_AV, "writing entry to EQ\n");
+		size = sizeof(struct fi_eq_entry);
+		flags = 0;
+	}
+
+	ret = fi_eq_write(&av->eq->eq_fid, FI_AV_COMPLETE, &entry,
+			  size, flags);
+	if (ret != size)
+		FI_WARN(av->prov, FI_LOG_AV, "error writing to EQ\n");
+}
+
+static int ip_av_valid_addr(struct util_av *av, const void *addr)
+{
+	const struct sockaddr_in *sin = addr;
+	const struct sockaddr_in6 *sin6 = addr;
+
+	switch (sin->sin_family) {
+	case AF_INET:
+		return sin->sin_port && sin->sin_addr.s_addr;
+	case AF_INET6:
+		return sin6->sin6_port &&
+		      (sin6->sin6_addr.__in6_u.__u6_addr32[0] ||
+		       sin6->sin6_addr.__in6_u.__u6_addr32[1] ||
+		       sin6->sin6_addr.__in6_u.__u6_addr32[2] ||
+		       sin6->sin6_addr.__in6_u.__u6_addr32[3]);
+	default:
+		return 0;
+	}
+}
+
+static int ip_av_insert_addr(struct util_av *av, const void *addr,
+			     fi_addr_t *fi_addr, void *context)
+{
+	int ret, index = -1;
+
+	if (ip_av_valid_addr(av, addr)) {
+		ret = fi_av_insert_addr(av, addr, ip_av_slot(av, addr), &index);
+	} else {
+		ret = -FI_EADDRNOTAVAIL;
+		FI_WARN(av->prov, FI_LOG_AV, "invalid address\n");
+	}
+
+	if (fi_addr)
+		*fi_addr = !ret ? index : FI_ADDR_NOTAVAIL;
+	return ret;
+}
+
+static int ip_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
+			fi_addr_t *fi_addr, uint64_t flags, void *context)
+{
+	struct util_av *av;
+	int i, ret, success_cnt = 0;
+	size_t addrlen;
+
+	av = container_of(av_fid, struct util_av, av_fid);
+	ret = fi_verify_av_insert(av, flags);
+	if (ret)
+		return ret;
+
+	addrlen = ((struct sockaddr *) addr)->sa_family == AF_INET ?
+		  sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
+	FI_DBG(av->prov, FI_LOG_AV, "inserting %d addresses\n", count);
+	for (i = 0; i < count; i++) {
+		ret = ip_av_insert_addr(av, (const char *) addr + i * addrlen,
+					fi_addr ? &fi_addr[i] : NULL, context);
+		if (!ret)
+			success_cnt++;
+		else if (av->eq)
+			ip_av_write_event(av, i, -ret, context);
+	}
+
+	FI_DBG(av->prov, FI_LOG_AV, "%d addresses successful\n", success_cnt);
+	if (av->eq) {
+		ip_av_write_event(av, success_cnt, 0, context);
+		ret = 0;
+	} else {
+		ret = success_cnt;
+	}
+	return ret;
+}
+
+static int ip_av_insert_svc(struct util_av *av, const char *node,
+			    const char *service, fi_addr_t *fi_addr,
+			    void *context)
+{
+	struct addrinfo hints, *ai;
+	int ret;
+
+	FI_INFO(av->prov, FI_LOG_AV, "inserting %s-%s\n", node, service);
+
+	memset(&hints, 0, sizeof hints);
+	hints.ai_socktype = SOCK_DGRAM;
+	switch (av->domain->addr_format) {
+	case FI_SOCKADDR_IN:
+		hints.ai_family = AF_INET;
+		break;
+	case FI_SOCKADDR_IN6:
+		hints.ai_family = AF_INET6;
+		break;
+	default:
+		break;
+	}
+
+	ret = getaddrinfo(node, service, &hints, &ai);
+	if (ret)
+		return ret;
+
+	ret = ip_av_insert_addr(av, ai->ai_addr, fi_addr, context);
+	freeaddrinfo(ai);
+	return ret;
+}
+
+static int ip_av_insertsvc(struct fid_av *av, const char *node,
+			   const char *service, fi_addr_t *fi_addr,
+			   uint64_t flags, void *context)
+{
+	return fi_av_insertsym(av, node, 1, service, 1, fi_addr, flags, context);
+}
+
+static int ip_av_insert_ip4sym(struct util_av *av,
+			       struct in_addr ip, size_t ipcnt,
+			       uint16_t port, size_t portcnt,
+			       fi_addr_t *fi_addr, void *context)
+{
+	struct sockaddr_in sin;
+	int i, p, fi, ret, success_cnt = 0;
+
+	memset(&sin, 0, sizeof sin);
+	sin.sin_family = AF_INET;
+
+	for (i = 0, fi = 0; i < ipcnt; i++) {
+		/* TODO: should we skip addresses x.x.x.0 and x.x.x.255? */
+		sin.sin_addr.s_addr = htonl(ntohl(ip.s_addr) + i);
+
+		for (p = 0; p < portcnt; p++, fi++) {
+			sin.sin_port = htons(port + p);
+			ret = ip_av_insert_addr(av, &sin, fi_addr ?
+						&fi_addr[fi] : NULL, context);
+			if (!ret)
+				success_cnt++;
+			else if (av->eq)
+				ip_av_write_event(av, fi, -ret, context);
+		}
+	}
+
+	return success_cnt;
+}
+
+static int ip_av_insert_ip6sym(struct util_av *av,
+			       struct in6_addr ip, size_t ipcnt,
+			       uint16_t port, size_t portcnt,
+			       fi_addr_t *fi_addr, void *context)
+{
+	struct sockaddr_in6 sin6;
+	int i, p, o, fi, ret, success_cnt = 0;
+
+	memset(&sin6, 0, sizeof sin6);
+	sin6.sin6_family = AF_INET6;
+	sin6.sin6_addr = ip;
+
+	for (i = 0, fi = 0; i < ipcnt; i++) {
+		for (p = 0; p < portcnt; p++, fi++) {
+			sin6.sin6_port = htons(port + p);
+			ret = ip_av_insert_addr(av, &sin6, fi_addr ?
+						&fi_addr[fi] : NULL, context);
+			if (!ret)
+				success_cnt++;
+			else if (av->eq)
+				ip_av_write_event(av, fi, -ret, context);
+		}
+
+		/* TODO: should we skip addresses x::0 and x::255? */
+		for (o = 15; o >= 0; o--) {
+			if (++sin6.sin6_addr.__in6_u.__u6_addr8[o] < 255)
+				break;
+		}
+	}
+
+	return success_cnt;
+}
+
+static int ip_av_insert_nodesym(struct util_av *av,
+				const char *node, size_t nodecnt,
+				const char *service, size_t svccnt,
+				fi_addr_t *fi_addr, void *context)
+{
+	char name[FI_NAME_MAX];
+	char svc[FI_NAME_MAX];
+	size_t name_len, name_index, svc_index;
+	int fi, n, s, ret, success_cnt = 0;
+
+	for (name_len = strlen(node); isdigit(node[name_len - 1]); )
+		name_len--;
+
+	memcpy(name, node, name_len);
+	name_index = atoi(node + name_len);
+	svc_index = atoi(service);
+
+	for (n = 0, fi = 0; n < nodecnt; n++) {
+		if (nodecnt == 1) {
+			strncpy(name, node, sizeof(name));
+		} else {
+			snprintf(name + name_len, sizeof(name) - name_len - 1,
+				 "%d", name_index + n);
+		}
+
+		for (s = 0; s < svccnt; s++, fi++) {
+			if (svccnt == 1) {
+				strncpy(svc, service, sizeof(svc));
+			} else {
+				snprintf(svc, sizeof(svc) - 1,
+					 "%d", svc_index + s);
+			}
+
+			ret = ip_av_insert_svc(av, name, svc, fi_addr ?
+					       &fi_addr[fi] : NULL, context);
+			if (!ret)
+				success_cnt++;
+			else if (av->eq)
+				ip_av_write_event(av, fi, -ret, context);
+		}
+	}
+
+	return success_cnt;
+}
+
+static int ip_av_insertsym(struct fid_av *av_fid, const char *node, size_t nodecnt,
+			   const char *service, size_t svccnt, fi_addr_t *fi_addr,
+			   uint64_t flags, void *context)
+{
+	struct util_av *av;
+	struct in6_addr ip6;
+	struct in_addr ip4;
+	int ret;
+
+	av = container_of(av_fid, struct util_av, av_fid);
+	ret = fi_verify_av_insert(av, flags);
+	if (ret)
+		return ret;
+
+	if (strlen(node) >= FI_NAME_MAX || strlen(service) >= FI_NAME_MAX) {
+		FI_WARN(av->prov, FI_LOG_AV,
+			"node or service name is too long\n");
+		return -FI_ENOSYS;
+	}
+
+	ret = inet_pton(AF_INET, node, &ip4);
+	if (ret == 1) {
+		FI_INFO(av->prov, FI_LOG_AV, "insert symmetric IPv4\n");
+		ret = ip_av_insert_ip4sym(av, ip4, nodecnt,
+					  (uint16_t) strtol(service, NULL, 0),
+					  svccnt, fi_addr, context);
+		goto out;
+	}
+
+	ret = inet_pton(AF_INET6, node, &ip6);
+	if (ret == 1) {
+		FI_INFO(av->prov, FI_LOG_AV, "insert symmetric IPv6\n");
+		ret = ip_av_insert_ip6sym(av, ip6, nodecnt,
+					  (uint16_t) strtol(service, NULL, 0),
+					  svccnt, fi_addr, context);
+		goto out;
+	}
+
+	FI_INFO(av->prov, FI_LOG_AV, "insert symmetric host names\n");
+	ret = ip_av_insert_nodesym(av, node, nodecnt, service, svccnt,
+				  fi_addr, context);
+
+out:
+	if (av->eq) {
+		ip_av_write_event(av, ret, 0, context);
+		ret = 0;
+	}
+	return ret;
+}
+
+static int ip_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count,
+			uint64_t flags)
+{
+	struct util_av *av;
+	int i, slot, index, ret;
+
+	av = container_of(av_fid, struct util_av, av_fid);
+	if (flags) {
+		FI_WARN(av->prov, FI_LOG_AV, "invalid flags\n");
+		return -FI_EINVAL;
+	}
+
+	/*
+	 * It's more efficient to remove addresses from high to low index.
+	 * We assume that addresses are removed in the same order that they were
+	 * added -- i.e. fi_addr passed in here was also passed into insert.
+	 * Thus, we walk through the array backwards.
+	 */
+	for (i = count - 1; i >= 0; i--) {
+		index = (int) fi_addr[i];
+		slot = ip_av_slot(av, ip_av_get_addr(av, index));
+		ret = fi_av_remove_addr(av, slot, index);
+		if (ret) {
+			FI_WARN(av->prov, FI_LOG_AV,
+				"removal of fi_addr %d failed\n", index);
+		}
+	}
+	return 0;
+}
+
+static int ip_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr, void *addr,
+			size_t *addrlen)
+{
+	struct util_av *av;
+	int index;
+
+	av = container_of(av_fid, struct util_av, av_fid);
+	index = (int) fi_addr;
+	if (index < 0 || index > av->count) {
+		FI_WARN(av->prov, FI_LOG_AV, "unknown address\n");
+		return -FI_EINVAL;
+	}
+
+	memcpy(addr, ip_av_get_addr(av, index),
+	       MIN(*addrlen, av->addrlen));
+	*addrlen = av->addrlen;
+	return 0;
+}
+
+static const char *ip_av_straddr(struct fid_av *av, const void *addr,
+				  char *buf, size_t *len)
+{
+	char str[INET6_ADDRSTRLEN + 8];
+	size_t size;
+
+	if (!inet_ntop(((struct sockaddr *) addr)->sa_family, addr,
+			str, sizeof str))
+		return NULL;
+
+	size = strlen(str);
+	size += snprintf(&str[size], sizeof(str) - size, ":%d",
+			 ((struct sockaddr_in *) addr)->sin_port);
+	memcpy(buf, str, MIN(*len, size));
+	*len = size + 1;
+	return buf;
+}
+
+static struct fi_ops_av ip_av_ops = {
+	.size = sizeof(struct fi_ops_av),
+	.insert = ip_av_insert,
+	.insertsvc = ip_av_insertsvc,
+	.insertsym = ip_av_insertsym,
+	.remove = ip_av_remove,
+	.lookup = ip_av_lookup,
+	.straddr = ip_av_straddr,
+};
+
+static struct fi_ops ip_av_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = fi_av_free,
+	.bind = util_av_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+int ip_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
+		 struct fid_av **av, void *context)
+{
+	struct util_domain *domain;
+	struct util_av_attr util_attr;
+	int ret;
+
+	domain = container_of(domain_fid, struct util_domain, domain_fid);
+	if (domain->addr_format == FI_SOCKADDR_IN)
+		util_attr.addrlen = sizeof(struct sockaddr_in);
+	else
+		util_attr.addrlen = sizeof(struct sockaddr_in6);
+
+	util_attr.overhead = attr->count >> 2;
+	util_attr.flags = domain->caps & FI_SOURCE ? FI_SOURCE : 0;
+
+	ret = fi_av_create(domain, attr, &util_attr, av, context);
+	if (ret)
+		return ret;
+
+	(*av)->fid.ops = &ip_av_fi_ops;
+	(*av)->ops = &ip_av_ops;
+	return 0;
+}

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <fi_enosys.h>
+#include <fi_util.h>
+
+
+int fi_check_cq_attr(const struct fi_provider *prov,
+		     const struct fi_cq_attr *attr)
+{
+	switch (attr->format) {
+	case FI_CQ_FORMAT_UNSPEC:
+	case FI_CQ_FORMAT_CONTEXT:
+	case FI_CQ_FORMAT_MSG:
+	case FI_CQ_FORMAT_DATA:
+	case FI_CQ_FORMAT_TAGGED:
+		break;
+	default:
+		FI_WARN(prov, FI_LOG_CQ, "unsupported format\n");
+		return -FI_EINVAL;
+	}
+
+	switch (attr->wait_obj) {
+	case FI_WAIT_NONE:
+		break;
+	case FI_WAIT_SET:
+		if (!attr->wait_set) {
+			FI_WARN(prov, FI_LOG_CQ, "invalid wait set\n");
+			return -FI_EINVAL;
+		}
+		/* fall through */
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+		break;
+		switch (attr->wait_cond) {
+		case FI_CQ_COND_NONE:
+		case FI_CQ_COND_THRESHOLD:
+			break;
+		default:
+			FI_WARN(prov, FI_LOG_CQ, "unsupported wait cond\n");
+			return -FI_EINVAL;
+		}
+		break;
+	default:
+		FI_WARN(prov, FI_LOG_CQ, "unsupported wait object\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr->flags) {
+		FI_WARN(prov, FI_LOG_CQ, "invalid flags\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr->signaling_vector) {
+		FI_WARN(prov, FI_LOG_CQ, "signaling vectors not supported\n");
+		return -FI_ENOSYS;
+	}
+
+	return 0;
+}
+
+int fi_cq_cleanup(struct util_cq *cq)
+{
+	struct util_cq_err_entry *err;
+	struct slist_entry *entry;
+
+	if (atomic_get(&cq->ref))
+		return -FI_EBUSY;
+
+	fastlock_destroy(&cq->cq_lock);
+	fastlock_destroy(&cq->list_lock);
+
+	while (!slist_empty(&cq->err_list)) {
+		entry = slist_remove_head(&cq->err_list);
+		err = container_of(entry, struct util_cq_err_entry, list_entry);
+		free(err);
+	}
+
+	if (cq->wait) {
+		fi_poll_del(&cq->wait->pollset->poll_fid,
+			    &cq->cq_fid.fid, 0);
+		if (cq->internal_wait)
+			fi_close(&cq->wait->wait_fid.fid);
+	}
+
+	atomic_dec(&cq->domain->ref);
+	return 0;
+}
+
+int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
+		fi_cq_read_func read_entry, struct util_cq *cq, void *context)
+{
+	struct fi_wait_attr wait_attr;
+	struct fid_wait *wait;
+	int ret;
+
+	cq->domain = container_of(domain, struct util_domain, domain_fid);
+	atomic_initialize(&cq->ref, 0);
+	dlist_init(&cq->list);
+	fastlock_init(&cq->list_lock);
+	fastlock_init(&cq->cq_lock);
+	slist_init(&cq->err_list);
+	cq->read_entry = read_entry;
+
+	cq->cq_fid.fid.fclass = FI_CLASS_CQ;
+	cq->cq_fid.fid.context = context;
+
+	switch (attr->wait_obj) {
+	case FI_WAIT_NONE:
+		wait = NULL;
+		break;
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+	case FI_WAIT_MUTEX_COND:
+		memset(&wait_attr, 0, sizeof wait_attr);
+		wait_attr.wait_obj = attr->wait_obj;
+		cq->internal_wait = 1;
+		ret = fi_wait_open(&cq->domain->fabric->fabric_fid,
+				   &wait_attr, &wait);
+		if (ret)
+			return ret;
+		break;
+	case FI_WAIT_SET:
+		wait = attr->wait_set;
+		break;
+	default:
+		assert(0);
+		return -FI_EINVAL;
+	}
+
+	if (wait)
+		cq->wait = container_of(wait, struct util_wait, wait_fid);
+
+	atomic_inc(&cq->domain->ref);
+	return 0;
+}
+
+int fi_cq_ready(struct util_cq *cq)
+{
+	/* CQ must be fully operational before adding to wait set */
+	if (cq->wait) {
+		return fi_poll_add(&cq->wait->pollset->poll_fid,
+				   &cq->cq_fid.fid, 0);
+	}
+
+	return 0;
+}

--- a/prov/util/src/util_domain.c
+++ b/prov/util/src/util_domain.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <fi_enosys.h>
+#include <fi_util.h>
+
+
+static int util_domain_close(fid_t fid)
+{
+	struct util_domain *domain;
+
+	domain = container_of(fid, struct util_domain, domain_fid.fid);
+	if (atomic_get(&domain->ref))
+		return -FI_EBUSY;
+
+	fastlock_acquire(&domain->fabric->lock);
+	dlist_remove(&domain->list_entry);
+	fastlock_release(&domain->fabric->lock);
+
+	fastlock_destroy(&domain->lock);
+	free(domain);
+	return 0;
+}
+
+static struct fi_ops util_domain_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = util_domain_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static struct fi_ops_mr util_domain_mr_ops = {
+	.size = sizeof(struct fi_ops_mr),
+	.reg = fi_no_mr_reg,
+	.regv = fi_no_mr_regv,
+	.regattr = fi_no_mr_regattr,
+};
+
+static int util_domain_init(struct util_domain *domain,
+			    const struct fi_info *info)
+{
+	atomic_initialize(&domain->ref, 0);
+	fastlock_init(&domain->lock);
+	domain->caps = info->caps;
+	domain->mode = info->mode;
+	domain->addr_format = info->addr_format;
+	domain->av_type = info->domain_attr->av_type;
+	domain->name = strdup(info->domain_attr->name);
+	return domain->name ? 0 : -FI_ENOMEM;
+}
+
+int fi_domain_create(struct fid_fabric *fabric_fid, const struct fi_info *info,
+		     struct fid_domain **domain_fid, void *context)
+{
+	struct util_fabric *fabric;
+	struct util_domain *domain;
+	int ret;
+
+	fabric = container_of(fabric_fid, struct util_fabric, fabric_fid);
+
+	domain = calloc(1, sizeof(*domain));
+	if (!domain)
+		return -FI_ENOMEM;
+
+	domain->fabric = fabric;
+	domain->prov = fabric->prov;
+	ret = util_domain_init(domain, info);
+	if (ret) {
+		free(domain);
+		return ret;
+	}
+
+	domain->domain_fid.fid.fclass = FI_CLASS_DOMAIN;
+	domain->domain_fid.fid.context = context;
+	/*
+	 * domain ops set by provider
+	 */
+	domain->domain_fid.fid.ops = &util_domain_fi_ops;
+	domain->domain_fid.mr = &util_domain_mr_ops;
+
+	fastlock_acquire(&fabric->lock);
+	dlist_insert_tail(&domain->list_entry, &fabric->domain_list);
+	fastlock_release(&fabric->lock);
+
+	atomic_inc(&fabric->ref);
+	*domain_fid = &domain->domain_fid;
+	return 0;
+}

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <fi_enosys.h>
+#include <fi_util.h>
+
+
+static ssize_t util_eq_read(struct fid_eq *eq_fid, uint32_t *event,
+			    void *buf, size_t len, uint64_t flags)
+{
+	struct util_eq *eq;
+	struct util_event *entry;
+	ssize_t ret;
+
+	eq = container_of(eq_fid, struct util_eq, eq_fid);
+
+	fastlock_acquire(&eq->lock);
+	if (slist_empty(&eq->list)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	entry = container_of(eq->list.head, struct util_event, entry);
+	if (entry->err && !(flags & UTIL_FLAG_ERROR)) {
+		ret = -FI_EAVAIL;
+		goto out;
+	} else if (!entry->err && (flags & UTIL_FLAG_ERROR)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	if (event)
+		*event = entry->event;
+	if (buf) {
+		ret = MIN(len, entry->size);
+		memcpy(buf, entry->data, ret);
+	}  else {
+		ret = 0;
+	}
+
+	if (!(flags & FI_PEEK)) {
+		slist_remove_head(&eq->list);
+		free(entry);
+	}
+out:
+	fastlock_release(&eq->lock);
+	return ret;
+}
+
+static ssize_t util_eq_readerr(struct fid_eq *eq_fid, struct fi_eq_err_entry *buf,
+			       uint64_t flags)
+{
+
+	return util_eq_read(eq_fid, NULL, buf, sizeof(*buf),
+			    flags | UTIL_FLAG_ERROR);
+}
+
+static ssize_t util_eq_write(struct fid_eq *eq_fid, uint32_t event,
+			     const void *buf, size_t len, uint64_t flags)
+{
+	struct util_eq *eq;
+	struct util_event *entry;
+
+	eq = container_of(eq_fid, struct util_eq, eq_fid);
+	entry = malloc(sizeof(*entry) + len);
+	if (!entry)
+		return -FI_ENOMEM;
+
+	entry->size = (int) len;
+	entry->event = event;
+	entry->err = !!(flags & UTIL_FLAG_ERROR);
+	memcpy(entry->data, buf, len);
+
+	fastlock_acquire(&eq->lock);
+	slist_insert_tail(&entry->entry, &eq->list);
+	fastlock_release(&eq->lock);
+
+	if (eq->wait)
+		eq->wait->signal(eq->wait);
+
+	return len;
+}
+
+static ssize_t util_eq_sread(struct fid_eq *eq_fid, uint32_t *event, void *buf,
+			     size_t len, int timeout, uint64_t flags)
+{
+	struct util_eq *eq;
+
+	eq = container_of(eq_fid, struct util_eq, eq_fid);
+	if (!eq->internal_wait) {
+		FI_WARN(eq->prov, FI_LOG_EQ, "EQ not configured for sread\n");
+		return -FI_ENOSYS;
+	}
+
+	fi_wait(&eq->wait->wait_fid, timeout);
+	return fi_eq_read(eq_fid, event, buf, len, flags);
+}
+
+static const char *util_eq_strerror(struct fid_eq *eq_fid, int prov_errno,
+				    const void *err_data, char *buf, size_t len)
+{
+	return (buf && len) ? strncpy(buf, strerror(prov_errno), len) :
+			      fi_strerror(prov_errno);
+}
+
+static int util_eq_control(struct fid *fid, int command, void *arg)
+{
+	struct util_eq *eq;
+	int ret;
+
+	eq = container_of(fid, struct util_eq, eq_fid.fid);
+
+	switch (command) {
+	case FI_GETWAIT:
+		ret = fi_control(&eq->wait->wait_fid.fid, command, arg);
+		break;
+	default:
+		ret = -FI_ENOSYS;
+		break;
+	}
+
+	return ret;
+}
+
+static int util_eq_close(struct fid *fid)
+{
+	struct util_eq *eq;
+	struct slist_entry *entry;
+	struct util_event *event;
+
+	eq = container_of(fid, struct util_eq, eq_fid.fid);
+	if (atomic_get(&eq->ref))
+		return -FI_EBUSY;
+
+	while (!slist_empty(&eq->list)) {
+		entry = slist_remove_head(&eq->list);
+		event = container_of(entry, struct util_event, entry);
+		free(event);
+	}
+
+	if (eq->wait) {
+		fi_poll_del(&eq->wait->pollset->poll_fid,
+			    &eq->eq_fid.fid, 0);
+		if (eq->internal_wait)
+			fi_close(&eq->wait->wait_fid.fid);
+	}
+
+	fastlock_destroy(&eq->lock);
+	atomic_dec(&eq->fabric->ref);
+	free(eq);
+	return 0;
+}
+
+static struct fi_ops_eq util_eq_ops = {
+	.size = sizeof(struct fi_ops_eq),
+	.read = util_eq_read,
+	.readerr = util_eq_readerr,
+	.sread = util_eq_sread,
+	.write = util_eq_write,
+	.strerror = util_eq_strerror,
+};
+
+static struct fi_ops util_eq_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = util_eq_close,
+	.bind = fi_no_bind,
+	.control = util_eq_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static int util_eq_init(struct fid_fabric *fabric, struct util_eq *eq,
+			const struct fi_eq_attr *attr)
+{
+	struct fi_wait_attr wait_attr;
+	struct fid_wait *wait;
+	int ret;
+
+	atomic_initialize(&eq->ref, 0);
+	slist_init(&eq->list);
+	fastlock_init(&eq->lock);
+
+	switch (attr->wait_obj) {
+	case FI_WAIT_NONE:
+		break;
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+	case FI_WAIT_MUTEX_COND:
+		memset(&wait_attr, 0, sizeof wait_attr);
+		wait_attr.wait_obj = attr->wait_obj;
+		eq->internal_wait = 1;
+		ret = fi_wait_open(fabric, &wait_attr, &wait);
+		if (ret)
+			return ret;
+		eq->wait = container_of(wait, struct util_wait, wait_fid);
+		break;
+	case FI_WAIT_SET:
+		eq->wait = container_of(attr->wait_set, struct util_wait,
+					wait_fid);
+		break;
+	default:
+		assert(0);
+		return -FI_EINVAL;
+	}
+
+	return 0;
+}
+
+static int util_verify_eq_attr(const struct fi_provider *prov,
+			       const struct fi_eq_attr *attr)
+{
+	switch (attr->wait_obj) {
+	case FI_WAIT_NONE:
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+	case FI_WAIT_MUTEX_COND:
+		break;
+	case FI_WAIT_SET:
+		if (!attr->wait_set) {
+			FI_WARN(prov, FI_LOG_EQ, "invalid wait set\n");
+			return -FI_EINVAL;
+		}
+		break;
+	default:
+		FI_WARN(prov, FI_LOG_EQ, "invalid wait object type\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr->flags & ~(FI_WRITE)) {
+		FI_WARN(prov, FI_LOG_EQ, "invalid flags\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr->signaling_vector) {
+		FI_WARN(prov, FI_LOG_EQ, "signaling vectors not supported\n");
+		return -FI_ENOSYS;
+	}
+
+	return 0;
+}
+
+int fi_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
+		 struct fid_eq **eq_fid, void *context)
+{
+	struct util_fabric *fabric;
+	struct util_eq *eq;
+	int ret;
+
+	fabric = container_of(fabric_fid, struct util_fabric, fabric_fid);
+	ret = util_verify_eq_attr(fabric->prov, attr);
+	if (ret)
+		return ret;
+
+	eq = calloc(1, sizeof(*eq));
+	if (!eq)
+		return -FI_ENOMEM;
+
+	eq->fabric = fabric;
+	eq->prov = fabric->prov;
+	ret = util_eq_init(fabric_fid, eq, attr);
+	if (ret) {
+		free(eq);
+		return ret;
+	}
+
+	eq->eq_fid.fid.fclass = FI_CLASS_EQ;
+	eq->eq_fid.fid.context = context;
+	eq->eq_fid.fid.ops = &util_eq_fi_ops;
+	eq->eq_fid.ops = &util_eq_ops;
+
+	atomic_inc(&fabric->ref);
+
+	/* EQ must be fully operational before adding to wait set */
+	if (eq->wait) {
+		ret = fi_poll_add(&eq->wait->pollset->poll_fid,
+				  &eq->eq_fid.fid, 0);
+		if (ret) {
+			util_eq_close(&eq->eq_fid.fid);
+			return ret;
+		}
+	}
+
+	*eq_fid = &eq->eq_fid;
+	return 0;
+}
+

--- a/prov/util/src/util_fabric.c
+++ b/prov/util/src/util_fabric.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <fi_enosys.h>
+#include <fi_util.h>
+
+
+static int util_fabric_close(fid_t fid)
+{
+	struct util_fabric *fabric;
+
+	fabric = container_of(fid, struct util_fabric, fabric_fid.fid);
+	if (atomic_get(&fabric->ref))
+		return -FI_EBUSY;
+
+	fi_fabric_remove(fabric);
+	fastlock_destroy(&fabric->lock);
+	free(fabric);
+	return 0;
+}
+
+static struct fi_ops util_fabric_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = util_fabric_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static void util_fabric_init(struct util_fabric *fabric, const char *name)
+{
+	atomic_initialize(&fabric->ref, 0);
+	dlist_init(&fabric->domain_list);
+	fastlock_init(&fabric->lock);
+	fabric->name = name;
+}
+
+int fi_fabric_create(const struct fi_provider *prov,
+		     struct fi_fabric_attr *prov_attr,
+		     struct fi_fabric_attr *user_attr,
+		     struct fid_fabric **fabric_fid, void *context)
+{
+	struct util_fabric *fabric;
+	int ret;
+
+	ret = fi_check_fabric_attr(prov, prov_attr, user_attr);
+	if (ret)
+		return ret;
+
+	fabric = calloc(1, sizeof(*fabric));
+	if (!fabric)
+		return -FI_ENOMEM;
+
+	fabric->prov = prov;
+	util_fabric_init(fabric, prov_attr->name);
+
+	fabric->fabric_fid.fid.fclass = FI_CLASS_FABRIC;
+	fabric->fabric_fid.fid.context = context;
+	/*
+	 * fabric ops set by provider
+	 */
+	fabric->fabric_fid.fid.ops = &util_fabric_fi_ops;
+	fi_fabric_insert(fabric);
+
+	*fabric_fid = &fabric->fabric_fid;
+	return 0;
+}

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2014-2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include <fi_util.h>
+#include <fi.h>
+
+
+static DEFINE_LIST(fabric_list);
+static fastlock_t lock;
+
+
+void fi_util_init(void)
+{
+	fastlock_init(&lock);
+}
+
+void fi_util_fini(void)
+{
+	fastlock_destroy(&lock);
+}
+
+void fi_fabric_insert(struct util_fabric *fabric)
+{
+	fastlock_acquire(&lock);
+	dlist_insert_tail(&fabric->list_entry, &fabric_list);
+	fastlock_release(&lock);
+}
+
+static int fabric_match_name(struct dlist_entry *item, const void *arg)
+{
+	struct util_fabric *fabric;
+
+	fabric = container_of(item, struct util_fabric, list_entry);
+	return !strcmp(fabric->name, arg);
+}
+
+struct util_fabric *fi_fabric_find(const char *name)
+{
+	struct dlist_entry *item;
+
+	fastlock_acquire(&lock);
+	item = dlist_find_first_match(&fabric_list, fabric_match_name, name);
+	fastlock_release(&lock);
+
+	return item ? container_of(item, struct util_fabric, list_entry) : NULL;
+}
+
+void fi_fabric_remove(struct util_fabric *fabric)
+{
+	assert(fi_fabric_find(fabric->name));
+	fastlock_acquire(&lock);
+	dlist_remove(&fabric->list_entry);
+	fastlock_release(&lock);
+}
+
+int fid_list_insert(struct dlist_entry *fid_list, fastlock_t *lock,
+ 		    struct fid *fid)
+{
+	struct fid_list_entry *entry;
+
+	entry = calloc(1, sizeof(*entry));
+	if (!entry)
+		return -FI_ENOMEM;
+
+	fastlock_acquire(lock);
+	entry->fid = fid;
+	dlist_insert_tail(&entry->entry, fid_list);
+	fastlock_release(lock);
+	return 0;
+}
+
+static int fi_fid_match(struct dlist_entry *entry, const void *fid)
+{
+	struct fid_list_entry *item;
+	item = container_of(entry, struct fid_list_entry, entry);
+	return (item->fid == fid);
+}
+
+void fid_list_remove(struct dlist_entry *fid_list, fastlock_t *lock,
+		     struct fid *fid)
+{
+	struct fid_list_entry *item;
+	struct dlist_entry *entry;
+
+	fastlock_acquire(lock);
+	entry = dlist_remove_first_match(fid_list, fi_fid_match, fid);
+	fastlock_release(lock);
+
+	if (entry) {
+		item = container_of(entry, struct fid_list_entry, entry);
+		free(item);
+	}
+}
+
+int util_find_domain(struct dlist_entry *item, const void *arg)
+{
+	const struct util_domain *domain;
+	const struct fi_info *info = arg;
+
+	domain = container_of(item, struct util_domain, list_entry);
+
+	return !strcmp(domain->name, info->domain_attr->name) &&
+		!(info->caps & ~domain->caps) &&
+		 ((info->mode & domain->mode) == domain->mode);
+}
+
+int util_getinfo(const struct fi_provider *prov, uint32_t version,
+		 const char *node, const char *service, uint64_t flags,
+		 const struct fi_info *prov_info, struct fi_info *hints,
+		 struct fi_info **info)
+{
+	struct util_fabric *fabric;
+	struct util_domain *domain;
+	struct dlist_entry *item;
+	int ret, copy_dest;
+
+	FI_DBG(prov, FI_LOG_CORE, "checking info\n");
+
+	if ((flags & FI_SOURCE) && !node && !service) {
+		FI_INFO(prov, FI_LOG_CORE,
+			"FI_SOURCE set, but no node or service\n");
+		return -FI_EINVAL;
+	}
+
+	ret = fi_check_info(prov, prov_info, hints);
+	if (ret)
+		return ret;
+
+	*info = fi_dupinfo(prov_info);
+	if (!*info) {
+		FI_INFO(prov, FI_LOG_CORE, "cannot copy info\n");
+		return -FI_ENOMEM;
+	}
+
+	fi_alter_info(*info, hints);
+
+	fabric = fi_fabric_find((*info)->fabric_attr->name);
+	if (fabric) {
+		FI_DBG(prov, FI_LOG_CORE, "Found opened fabric\n");
+		(*info)->fabric_attr->fabric = &fabric->fabric_fid;
+
+		fastlock_acquire(&fabric->lock);
+		item = dlist_find_first_match(&fabric->domain_list,
+					      util_find_domain, *info);
+		if (item) {
+			FI_DBG(prov, FI_LOG_CORE, "Found open domain\n");
+			domain = container_of(item, struct util_domain,
+					      list_entry);
+			(*info)->domain_attr->domain = &domain->domain_fid;
+		}
+		fastlock_release(&fabric->lock);
+
+	}
+
+	if (flags & FI_SOURCE) {
+		ret = fi_get_addr((*info)->addr_format, flags,
+				  node, service, &(*info)->src_addr,
+				  &(*info)->src_addrlen);
+		if (ret) {
+			FI_INFO(prov, FI_LOG_CORE,
+				"source address not available\n");
+			goto err;
+		}
+		copy_dest = (hints && hints->dest_addr);
+	} else {
+		if (node || service) {
+			copy_dest = 0;
+			ret = fi_get_addr((*info)->addr_format, flags,
+					  node, service, &(*info)->dest_addr,
+					  &(*info)->dest_addrlen);
+			if (ret) {
+				FI_INFO(prov, FI_LOG_CORE,
+					"cannot resolve dest address\n");
+				goto err;
+			}
+		} else {
+			copy_dest = (hints && hints->dest_addr);
+		}
+
+		if (hints && hints->src_addr) {
+			(*info)->src_addr = mem_dup(hints->src_addr,
+						    hints->src_addrlen);
+			if (!(*info)->src_addr) {
+				ret = -FI_ENOMEM;
+				goto err;
+			}
+			(*info)->src_addrlen = hints->src_addrlen;
+		}
+	}
+
+	if (copy_dest) {
+		(*info)->dest_addr = mem_dup(hints->dest_addr,
+					     hints->dest_addrlen);
+		if (!(*info)->dest_addr) {
+			ret = -FI_ENOMEM;
+			goto err;
+		}
+		(*info)->dest_addrlen = hints->dest_addrlen;
+	}
+
+	if ((*info)->dest_addr && !(*info)->src_addr) {
+		ret = fi_get_src_addr((*info)->addr_format, (*info)->dest_addr,
+				      (*info)->dest_addrlen, &(*info)->src_addr,
+				      &(*info)->src_addrlen);
+		if (ret) {
+			FI_INFO(prov, FI_LOG_CORE,
+				"cannot resolve source address\n");
+		}
+	}
+	return 0;
+
+err:
+	fi_freeinfo(*info);
+	return ret;
+}

--- a/prov/util/src/util_poll.c
+++ b/prov/util/src/util_poll.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2014-2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#include <fi_enosys.h>
+#include <fi_util.h>
+
+
+static int util_poll_add(struct fid_poll *poll_fid, struct fid *event_fid,
+			 uint64_t flags)
+{
+	struct util_poll *pollset;
+
+	pollset = container_of(poll_fid, struct util_poll, poll_fid);
+	switch (event_fid->fclass) {
+	case FI_CLASS_CQ:
+	case FI_CLASS_CNTR:
+		break;
+	case FI_CLASS_EQ:
+		/* We support EQs for internal poll sets */
+		if (!pollset->domain)
+			break;
+		/* fall through */
+	default:
+		FI_WARN(pollset->prov, FI_LOG_DOMAIN,
+			"invalid fid class\n");
+		return -FI_EINVAL;
+	}
+
+	return fid_list_insert(&pollset->fid_list, &pollset->lock, event_fid);
+}
+
+static int util_poll_del(struct fid_poll *poll_fid, struct fid *event_fid,
+			 uint64_t flags)
+{
+	struct util_poll *pollset;
+
+	pollset = container_of(poll_fid, struct util_poll, poll_fid);
+	fid_list_remove(&pollset->fid_list, &pollset->lock, event_fid);
+	return 0;
+}
+
+static int util_poll_run(struct fid_poll *poll_fid, void **context, int count)
+{
+	struct util_poll *pollset;
+	struct util_eq *eq;
+	struct util_cq *cq;
+	struct util_cntr *cntr;
+	struct fid_list_entry *fid_entry;
+	struct dlist_entry *item;
+	int ret, i = 0, err = 0;
+	uint64_t val;
+
+	pollset = container_of(poll_fid, struct util_poll, poll_fid.fid);
+
+	fastlock_acquire(&pollset->lock);
+	dlist_foreach(&pollset->fid_list, item) {
+		fid_entry = container_of(item, struct fid_list_entry, entry);
+		switch (fid_entry->fid->fclass) {
+		case FI_CLASS_CQ:
+			cq = container_of(fid_entry->fid, struct util_cq,
+					  cq_fid.fid);
+			ret = fi_cq_read(&cq->cq_fid, NULL, 0);
+			if (ret == 0 || ret == -FI_EAVAIL)
+				ret = 1;
+			break;
+		case FI_CLASS_CNTR:
+			cntr = container_of(fid_entry->fid, struct util_cntr,
+					    cntr_fid.fid);
+			val = fi_cntr_read(&cntr->cntr_fid);
+			if ((ret = (val != fid_entry->last_cntr_val)))
+				fid_entry->last_cntr_val = val;
+			break;
+		case FI_CLASS_EQ:
+			eq = container_of(fid_entry->fid, struct util_eq,
+					  eq_fid.fid);
+			ret = fi_eq_read(&eq->eq_fid, NULL, NULL, 0, FI_PEEK);
+			if (ret == 0 || ret == -FI_EAVAIL)
+				ret = 1;
+			break;
+		default:
+			ret = -FI_EINVAL;
+			break;
+		}
+
+		if (ret > 0 && i < count)
+			context[i++] = fid_entry->fid->context;
+		else if (ret < 0 && ret != -FI_EAGAIN)
+			err = ret;
+	}
+	fastlock_release(&pollset->lock);
+	return i ? i : err;
+}
+
+static int util_poll_close(struct fid *fid)
+{
+	struct util_poll *pollset;
+
+	pollset = container_of(fid, struct util_poll, poll_fid.fid);
+	if (atomic_get(&pollset->ref))
+		return -FI_EBUSY;
+
+	if (pollset->domain)
+		atomic_dec(&pollset->domain->ref);
+	free(pollset);
+	return 0;
+}
+
+static struct fi_ops_poll util_poll_ops = {
+	.size = sizeof(struct fi_ops_poll),
+	.poll = util_poll_run,
+	.poll_add = util_poll_add,
+	.poll_del = util_poll_del,
+};
+
+static struct fi_ops util_poll_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = util_poll_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static int util_verify_poll_attr(const struct fi_provider *prov,
+				 struct fi_poll_attr *attr)
+{
+	if (attr->flags) {
+		FI_WARN(prov, FI_LOG_DOMAIN, "invalid flags\n");
+		return -FI_EINVAL;
+	}
+
+	return 0;
+}
+
+int fi_poll_create_(const struct fi_provider *prov, struct fid_domain *domain,
+		    struct fi_poll_attr *attr, struct fid_poll **poll_fid)
+{
+	struct util_poll *pollset;
+	int ret;
+
+	ret = util_verify_poll_attr(prov, attr);
+	if (ret)
+		return ret;
+
+	pollset = calloc(1, sizeof(*pollset));
+	if (!pollset)
+		return -FI_ENOMEM;
+
+	pollset->prov = prov;
+	atomic_initialize(&pollset->ref, 0);
+	dlist_init(&pollset->fid_list);
+	fastlock_init(&pollset->lock);
+
+	pollset->poll_fid.fid.fclass = FI_CLASS_POLL;
+	pollset->poll_fid.fid.ops = &util_poll_fi_ops;
+	pollset->poll_fid.ops = &util_poll_ops;
+
+	/* domain is NULL if pollset is used internally by a waitset */
+	if (domain) {
+		pollset->domain = container_of(domain, struct util_domain,
+					       domain_fid);
+		atomic_inc(&pollset->domain->ref);
+	}
+
+	*poll_fid = &pollset->poll_fid;
+	return 0;
+}
+
+int fi_poll_create(struct fid_domain *domain_fid, struct fi_poll_attr *attr,
+		   struct fid_poll **poll_fid)
+{
+	struct util_domain *domain;
+
+	domain = container_of(domain_fid, struct util_domain, domain_fid);
+	return fi_poll_create_(domain->prov, domain_fid, attr, poll_fid);
+}

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2014-2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/time.h>
+
+#include <fi_enosys.h>
+#include <fi_util.h>
+
+
+int fi_check_wait_attr(const struct fi_provider *prov,
+		       const struct fi_wait_attr *attr)
+{
+	switch (attr->wait_obj) {
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+	case FI_WAIT_MUTEX_COND:
+		break;
+	default:
+		FI_WARN(prov, FI_LOG_FABRIC, "invalid wait object type\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr->flags) {
+		FI_WARN(prov, FI_LOG_FABRIC, "invalid flags\n");
+		return -FI_EINVAL;
+	}
+
+	return 0;
+}
+
+int fi_wait_cleanup(struct util_wait *wait)
+{
+	int ret;
+
+	if (atomic_get(&wait->ref))
+		return -FI_EBUSY;
+
+	ret = fi_close(&wait->pollset->poll_fid.fid);
+	if (ret)
+		return ret;
+
+	atomic_dec(&wait->fabric->ref);
+	return 0;
+}
+
+int fi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
+		 struct util_wait *wait)
+{
+	struct fid_poll *poll_fid;
+	struct fi_poll_attr poll_attr;
+	int ret;
+
+	wait->prov = fabric->prov;
+	atomic_initialize(&wait->ref, 0);
+	wait->wait_fid.fid.fclass = FI_CLASS_WAIT;
+
+	switch (attr->wait_obj) {
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+		wait->wait_obj = FI_WAIT_FD;
+		break;
+	case FI_WAIT_MUTEX_COND:
+		wait->wait_obj = FI_WAIT_MUTEX_COND;
+		break;
+	default:
+		assert(0);
+		return -FI_EINVAL;
+	}
+
+	memset(&poll_attr, 0, sizeof poll_attr);
+	ret = fi_poll_create_(fabric->prov, NULL, &poll_attr, &poll_fid);
+	if (ret)
+		return ret;
+
+	wait->pollset = container_of(poll_fid, struct util_poll, poll_fid);
+	wait->fabric = fabric;
+	atomic_inc(&fabric->ref);
+	return 0;
+}
+
+static void util_wait_fd_signal(struct util_wait *util_wait)
+{
+	struct util_wait_fd *wait;
+	wait = container_of(util_wait, struct util_wait_fd, util_wait);
+	fd_signal_set(&wait->signal);
+}
+
+static int util_wait_fd_run(struct fid_wait *wait_fid, int timeout)
+{
+	struct util_wait_fd *wait;
+	uint64_t start;
+	void *context;
+	int ret;
+
+	wait = container_of(wait_fid, struct util_wait_fd, util_wait.wait_fid);
+	start = (timeout >= 0) ? fi_gettime_ms() : 0;
+
+	while (1) {
+		fd_signal_reset(&wait->signal);
+
+		ret = fi_poll(&wait->util_wait.pollset->poll_fid, &context, 1);
+		if (ret > 0)
+			return 0;
+		else if (ret < 0)
+			return ret;
+
+		if (timeout >= 0) {
+			timeout -= (int) (fi_gettime_ms() - start);
+			if (timeout <= 0)
+				return -FI_ETIMEDOUT;
+		}
+
+		context = fi_epoll_wait(wait->epoll_fd, timeout);
+	}
+}
+
+static int util_wait_fd_control(struct fid *fid, int command, void *arg)
+{
+	struct util_wait_fd *wait;
+	int ret;
+
+	wait = container_of(fid, struct util_wait_fd, util_wait.wait_fid.fid);
+	switch (command) {
+	case FI_GETWAIT:
+#if HAVE_EPOLL
+		*(int *) arg = wait->epoll_fd;
+		ret = 0;
+#else
+		ret = -FI_ENOSYS;
+#endif
+		break;
+	default:
+		FI_INFO(wait->util_wait.prov, FI_LOG_FABRIC,
+			"unsupported command\n");
+		ret = -FI_ENOSYS;
+		break;
+	}
+	return ret;
+}
+
+static int util_wait_fd_close(struct fid *fid)
+{
+	struct util_wait_fd *wait;
+	int ret;
+
+	wait = container_of(fid, struct util_wait_fd, util_wait.wait_fid.fid);
+	ret = fi_wait_cleanup(&wait->util_wait);
+	if (ret)
+		return ret;
+
+	fi_epoll_del(wait->epoll_fd, wait->signal.fd[FI_READ_FD]);
+	fd_signal_free(&wait->signal);
+	fi_epoll_close(wait->epoll_fd);
+	free(wait);
+	return 0;
+}
+
+static struct fi_ops_wait util_wait_fd_ops = {
+	.size = sizeof(struct fi_ops_wait),
+	.wait = util_wait_fd_run,
+};
+
+static struct fi_ops util_wait_fd_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = util_wait_fd_close,
+	.bind = fi_no_bind,
+	.control = util_wait_fd_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static int util_verify_wait_fd_attr(const struct fi_provider *prov,
+				    const struct fi_wait_attr *attr)
+{
+	int ret;
+
+	ret = fi_check_wait_attr(prov, attr);
+	if (ret)
+		return ret;
+
+	switch (attr->wait_obj) {
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+		break;
+	default:
+		FI_WARN(prov, FI_LOG_FABRIC, "unsupported wait object\n");
+		return -FI_EINVAL;
+	}
+
+	return 0;
+}
+
+int fi_wait_fd_open(struct fid_fabric *fabric_fid, struct fi_wait_attr *attr,
+		    struct fid_wait **waitset)
+{
+	struct util_fabric *fabric;
+	struct util_wait_fd *wait;
+	int ret;
+
+	fabric = container_of(fabric_fid, struct util_fabric, fabric_fid);
+	ret = util_verify_wait_fd_attr(fabric->prov, attr);
+	if (ret)
+		return ret;
+
+	wait = calloc(1, sizeof(*wait));
+	if (!wait)
+		return -FI_ENOMEM;
+
+	ret = fi_wait_init(fabric, attr, &wait->util_wait);
+	if (ret)
+		goto err1;
+
+	wait->util_wait.signal = util_wait_fd_signal;
+	ret = fd_signal_init(&wait->signal);
+	if (ret)
+		goto err2;
+
+	wait->epoll_fd = fi_epoll_create();
+	if (!wait->epoll_fd) {
+		ret = -FI_ENOMEM;
+		goto err3;
+	}
+
+	ret = fi_epoll_add(wait->epoll_fd, wait->signal.fd[FI_READ_FD],
+			   &wait->util_wait.wait_fid.fid);
+	if (ret)
+		goto err4;
+
+	wait->util_wait.wait_fid.fid.ops = &util_wait_fd_fi_ops;
+	wait->util_wait.wait_fid.ops = &util_wait_fd_ops;
+
+	*waitset = &wait->util_wait.wait_fid;
+	return 0;
+
+err4:
+	fi_epoll_close(wait->epoll_fd);
+err3:
+	fd_signal_free(&wait->signal);
+err2:
+	fi_wait_cleanup(&wait->util_wait);
+err1:
+	free(wait);
+	return ret;
+}

--- a/src/common.c
+++ b/src/common.c
@@ -44,11 +44,13 @@
 #include <unistd.h>
 #include <poll.h>
 #include <pthread.h>
+#include <sys/epoll.h>
 #include <sys/time.h>
 
 #include <fi_signal.h>
 #include <rdma/fi_errno.h>
 #include <fi.h>
+
 
 
 int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout)

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -352,6 +352,7 @@ void fi_ini(void)
 
 	fi_param_init();
 	fi_log_init();
+	fi_util_init();
 
 	fi_param_define(NULL, "provider", FI_PARAM_STRING,
 			"Only use specified provider (default: all available)");
@@ -394,8 +395,9 @@ libdl_done:
 	fi_register_provider(MXM_INIT, NULL);
 	fi_register_provider(VERBS_INIT, NULL);
 	fi_register_provider(GNI_INIT, NULL);
-        /* Initialize the sockets provider last.  This will result in
+        /* Initialize the socket(s) provider last.  This will result in
            it being the least preferred provider. */
+	fi_register_provider(UDP_INIT, NULL);
 	fi_register_provider(SOCKETS_INIT, NULL);
 
 	init = 1;
@@ -421,6 +423,7 @@ static void __attribute__((destructor)) fi_fini(void)
 	fi_free_filter(&prov_filter);
 	fi_log_fini();
 	fi_param_fini();
+	fi_util_fini();
 }
 
 static struct fi_prov *fi_getprov(const char *prov_name)
@@ -531,7 +534,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 			continue;
 
 		if (hints && hints->fabric_attr && hints->fabric_attr->prov_name &&
-		    strcmp(prov->provider->name, hints->fabric_attr->prov_name))
+		    strcasecmp(prov->provider->name, hints->fabric_attr->prov_name))
 			continue;
 
 		ret = prov->provider->getinfo(version, node, service, flags,


### PR DESCRIPTION
This is for review only at this point.

This series introduces a UDP sockets provider, along with a utility library.  The UDP provider is a DGRAM based provider that sends and receives UDP packets.  It should be compatible with the usnic provider, but I haven't tested that.  The UDP provider is built using basic provider building blocks -- the utility library.  The reasoning for introducing a UDP provider is that it provides the lowest level of functionality over which other features can be constructed and added to the utility library.

The utility library is intended to serve two purposes.  The first is to provide common building blocks that all providers can use.  This will allow us to focus efforts on optimizing a single implementation of various features that any provider can to use.  For example, the utility code provides basic definitions for libfabric objects in order to handle reference counting, check attributes, etc.  It also provides a software implementation of CQs, EQs, pollsets, AVs, ...  I anticipate developers iterating over the utility library code as providers are updated to use it.

The utility library is based on existing code from the sockets and psm providers.  Performance is primary focus, and it expects provider specific code segments as a result.  For example, the EP and CQ code are almost entirely provider specific.

The plan is to extend the utility library to implement additional libfabric features (such as tagged interfaces, multi-recv support, etc.), plus construct a utility provider that can automatically upgrade the feature set of an existing provider.  For many of these items, protocols will be needed.

As an example, we will implement RDM EP support over providers that only support DGRAM EPs.  The RDMoDGRAM will be part of the utility provider.  However, where it makes sense, the code will be structured such that a provider could re-use the code to create an optimized version of RDMoDGRAM for their HW.

I'm sorry that the utility and UDP provider code is one larger commit.  I originally had it broken out into about 20 patches, but I ended up iterating over the code so frequently that adjusting patches just became a huge pain.  The UDP provider passes all fabtests that it can except fi_dgram_waitset.