### PR TITLE
helper abstractions that will be used by udp and utility providers

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -149,15 +149,20 @@ void fi_param_init(void);
 void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
 
-/* flsll is defined on BSD systems, but is different. */
-static inline int fi_flsll(long long int i)
-{
-	return i ? 65 - ffsll(htonll(i)) : 0;
-}
 
 static inline uint64_t roundup_power_of_two(uint64_t n)
 {
-	return 1ULL << fi_flsll(n - 1);
+	if (!n || !(n & (n - 1)))
+		return n;
+	n--;
+	n |= n >> 1;
+	n |= n >> 2;
+	n |= n >> 4;
+	n |= n >> 8;
+	n |= n >> 16;
+	n |= n >> 32;
+	n++;
+	return n;
 }
 
 #define FI_TAG_GENERIC	0xAAAAAAAAAAAAAAAAULL

--- a/include/fi_signal.h
+++ b/include/fi_signal.h
@@ -111,5 +111,67 @@ static inline int fd_signal_poll(struct fd_signal *signal, int timeout)
 	return (ret == 0) ? -FI_ETIMEDOUT : 0;
 }
 
+#if HAVE_EPOLL
+#include <sys/epoll.h>
+
+typedef int fi_epoll_t;
+
+static inline int fi_epoll_create(void)
+{
+	int ret;
+	ret = epoll_create(4);
+	return ret < 0 ? 0 : ret;
+}
+
+static inline int fi_epoll_add(int ep, int fd, void *context)
+{
+	struct epoll_event event;
+	int ret;
+
+	event.data.ptr = context;
+	event.events = EPOLLIN;
+	ret = epoll_ctl(ep, EPOLL_CTL_ADD, fd, &event);
+	if (ret == -1 && errno != EEXIST)
+		return -errno;
+	return 0;
+}
+
+static inline int fi_epoll_del(int ep, int fd)
+{
+	return epoll_ctl(ep, EPOLL_CTL_DEL, fd, NULL) ? -errno : 0;
+}
+
+static inline void *fi_epoll_wait(int ep, int timeout)
+{
+	struct epoll_event event;
+	int ret;
+
+	ret = epoll_wait(ep, &event, 1, timeout);
+	return ret == 1 ? event.data.ptr : NULL;
+}
+
+static inline void fi_epoll_close(int ep)
+{
+	close(ep);
+}
+
+#else
+#include <poll.h>
+
+typedef struct fi_epoll {
+	int		size;
+	int		nfds;
+	struct pollfd	*fds;
+	void		**context;
+} *fi_epoll_t;
+
+struct fi_epoll *fi_epoll_create(void);
+int fi_epoll_add(struct fi_epoll *ep, int fd, void *context);
+int fi_epoll_del(struct fi_epoll *ep, int fd);
+void *fi_epoll_wait(struct fi_epoll *ep, int timeout);
+void fi_epoll_close(struct fi_epoll *ep);
+
+#endif
+
 #endif /* FI_SIGNAL_H */
 


### PR DESCRIPTION
These are patches pulled from the UDP/utility provider series which are safe to go in separately.  Although there's not a user of the circular queue template until the UDP provider is merged.