### PR TITLE
Revert "prov/sockets: Set av_type in domain attributes"

### DIFF
--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -47,7 +47,6 @@ const struct fi_domain_attr sock_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_AUTO,
 	.resource_mgmt = FI_RM_ENABLED,
-	.av_type = FI_AV_TABLE,
 	.mr_mode = FI_MR_SCALABLE,
 	.mr_key_size = sizeof(uint64_t),
 	.cq_data_size = sizeof(uint64_t),

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1284,8 +1284,6 @@ static void sock_set_domain_attr(const struct fi_domain_attr *hint_attr,
 		attr->control_progress = sock_domain_attr.control_progress;
 	if (attr->data_progress == FI_PROGRESS_UNSPEC)
 		attr->data_progress = sock_domain_attr.data_progress;
-	if (attr->av_type == FI_AV_UNSPEC)
-		attr->av_type = sock_domain_attr.av_type;
 	if (attr->mr_mode == FI_MR_UNSPEC)
 		attr->mr_mode = sock_domain_attr.mr_mode;
 


### PR DESCRIPTION
Revert "prov/sockets: Set av_type in domain attributes"
Signed-off-by: Jithin Jose <jithin.jose@intel.com>