### PR TITLE
prov/psm2: support multi-iov send in non-tagged message queue

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -269,6 +269,7 @@ struct psmx2_sendv_request {
 struct psmx2_sendv_reply {
 	struct fi_context fi_context;
 	int no_completion;
+	int multi_recv;
 	void *buf;
 	void *user_context;
 	size_t iov_done;
@@ -751,7 +752,8 @@ int	psmx2_mr_validate(struct psmx2_fid_mr *mr, uint64_t addr, size_t len, uint64
 void	psmx2_cntr_check_trigger(struct psmx2_fid_cntr *cntr);
 void	psmx2_cntr_add_trigger(struct psmx2_fid_cntr *cntr, struct psmx2_trigger *trigger);
 
-int	psmx2_handle_sendv_req(struct psmx2_fid_ep *ep, psm2_mq_status2_t *psm2_status);
+int	psmx2_handle_sendv_req(struct psmx2_fid_ep *ep, psm2_mq_status2_t *psm2_status,
+			       int multi_recv);
 
 static inline void psmx2_cntr_inc(struct psmx2_fid_cntr *cntr)
 {

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -90,14 +90,20 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_MSG_ORDER		FI_ORDER_SAS
 #define PSMX2_COMP_ORDER	FI_ORDER_NONE
 
-#define PSMX2_MSG_BIT	(0x1ULL << 31)
-#define PSMX2_RMA_BIT	(0x1ULL << 30)
+#define PSMX2_MSG_BIT	(0x80000000)
+#define PSMX2_RMA_BIT	(0x40000000)
+#define PSMX2_IOV_BIT	(0x20000000)
+#define PSMX2_SEQ_BITS	(0x0FFF0000)
 #define PSMX2_SRC_BITS	(0x0000FF00)
 #define PSMX2_DST_BITS	(0x000000FF)
 
 #define PSMX2_TAG32(base, src, dst)	((base) | ((src)<<8) | (dst))
 #define PSMX2_TAG32_GET_SRC(tag32)	(((tag32) & PSMX2_SRC_BITS) >> 8)
 #define PSMX2_TAG32_GET_DST(tag32)	((tag32) & PSMX2_DST_BITS)
+#define PSMX2_TAG32_GET_SEQ(tag32)	(((tag32) & PSMX2_SEQ_BITS) >> 16)
+#define PSMX2_TAG32_SET_SEQ(tag32,seq)	do { \
+						tag32 |= ((seq << 16) & PSMX2_SEQ_BITS); \
+					} while (0)
 
 #define PSMX2_SET_TAG(tag96,tag64,tag32) do { \
 						tag96.tag0 = (uint32_t)tag64; \
@@ -141,15 +147,19 @@ enum psmx2_context_type {
 	PSMX2_READ_CONTEXT,
 	PSMX2_REMOTE_WRITE_CONTEXT,
 	PSMX2_REMOTE_READ_CONTEXT,
+	PSMX2_SENDV_CONTEXT,
+	PSMX2_IOV_SEND_CONTEXT,
+	PSMX2_IOV_RECV_CONTEXT,
 };
 
 union psmx2_pi {
 	void	*p;
-	int	i;
+	uint32_t i[2];
 };
 
 #define PSMX2_CTXT_REQ(fi_context)	((fi_context)->internal[0])
-#define PSMX2_CTXT_TYPE(fi_context)	(((union psmx2_pi *)&(fi_context)->internal[1])->i)
+#define PSMX2_CTXT_TYPE(fi_context)	(((union psmx2_pi *)&(fi_context)->internal[1])->i[0])
+#define PSMX2_CTXT_SIZE(fi_context)	(((union psmx2_pi *)&(fi_context)->internal[1])->i[1])
 #define PSMX2_CTXT_USER(fi_context)	((fi_context)->internal[2])
 #define PSMX2_CTXT_EP(fi_context)	((fi_context)->internal[3])
 
@@ -228,6 +238,44 @@ struct psmx2_am_request {
 	int no_event;
 	int error;
 	struct slist_entry list_entry;
+};
+
+#define PSMX2_IOV_PROTO_PACK	0
+#define PSMX2_IOV_PROTO_MULTI	1
+#define PSMX2_IOV_MAX_SEQ_NUM	0x0FFF
+#define PSMX2_IOV_BUF_SIZE	PSMX2_INJECT_SIZE
+#define PSMX2_IOV_MAX_COUNT	(PSMX2_IOV_BUF_SIZE / sizeof(uint32_t) - 3)
+
+struct psmx2_iov_info {
+	uint32_t seq_num;
+	uint32_t total_len;
+	uint32_t count;
+	uint32_t len[PSMX2_IOV_MAX_COUNT];
+};
+
+struct psmx2_sendv_request {
+	struct fi_context fi_context;
+	struct fi_context fi_context_iov;
+	void *user_context;
+	int iov_protocol;
+	int no_completion;
+	uint32_t iov_done;
+	union {
+		struct psmx2_iov_info iov_info;
+		char buf[PSMX2_IOV_BUF_SIZE];
+	};
+};
+
+struct psmx2_sendv_reply {
+	struct fi_context fi_context;
+	int no_completion;
+	void *buf;
+	void *user_context;
+	size_t iov_done;
+	size_t bytes_received;
+	size_t msg_length;
+	int error_code;
+	struct psmx2_iov_info iov_info;
 };
 
 struct psmx2_req_queue {
@@ -374,6 +422,7 @@ struct psmx2_fid_eq {
 
 enum psmx2_triggered_op {
 	PSMX2_TRIGGERED_SEND,
+	PSMX2_TRIGGERED_SENDV,
 	PSMX2_TRIGGERED_RECV,
 	PSMX2_TRIGGERED_TSEND,
 	PSMX2_TRIGGERED_TRECV,
@@ -399,6 +448,16 @@ struct psmx2_trigger {
 			uint64_t	flags;
 			uint64_t	data;
 		} send;
+		struct {
+			struct fid_ep	*ep;
+			const struct iovec *iov;
+			size_t		count;
+			void		**desc;
+			fi_addr_t	dest_addr;
+			void		*context;
+			uint64_t	flags;
+			uint64_t	data;
+		} sendv;
 		struct {
 			struct fid_ep	*ep;
 			void		*buf;
@@ -552,6 +611,7 @@ struct psmx2_fid_ep {
 	struct fi_context	nocomp_send_context;
 	struct fi_context	nocomp_recv_context;
 	size_t			min_multi_recv;
+	uint32_t		iov_seq_num;
 };
 
 struct psmx2_fid_stx {
@@ -691,6 +751,8 @@ int	psmx2_mr_validate(struct psmx2_fid_mr *mr, uint64_t addr, size_t len, uint64
 void	psmx2_cntr_check_trigger(struct psmx2_fid_cntr *cntr);
 void	psmx2_cntr_add_trigger(struct psmx2_fid_cntr *cntr, struct psmx2_trigger *trigger);
 
+int	psmx2_handle_sendv_req(struct psmx2_fid_ep *ep, psm2_mq_status2_t *psm2_status);
+
 static inline void psmx2_cntr_inc(struct psmx2_fid_cntr *cntr)
 {
 	cntr->counter++;
@@ -714,6 +776,13 @@ ssize_t psmx2_send_generic(
 			struct fid_ep *ep,
 			const void *buf, size_t len,
 			void *desc, fi_addr_t dest_addr,
+			void *context, uint64_t flags,
+			uint64_t data);
+
+ssize_t psmx2_sendv_generic(
+			struct fid_ep *ep,
+			const struct iovec *iov, void *desc,
+			size_t count, fi_addr_t dest_addr,
 			void *context, uint64_t flags,
 			uint64_t data);
 

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -46,6 +46,16 @@ int psmx2_process_trigger(struct psmx2_fid_domain *domain,
 				   trigger->send.flags,
 				   trigger->send.data);
 		break;
+	case PSMX2_TRIGGERED_SENDV:
+		psmx2_sendv_generic(trigger->sendv.ep,
+				    trigger->sendv.iov,
+				    trigger->sendv.desc,
+				    trigger->sendv.count,
+				    trigger->sendv.dest_addr,
+				    trigger->sendv.context,
+				    trigger->sendv.flags,
+				    trigger->sendv.data);
+		break;
 	case PSMX2_TRIGGERED_RECV:
 		psmx2_recv_generic(trigger->recv.ep,
 				   trigger->recv.buf,

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -397,7 +397,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 
 			case PSMX2_RECV_CONTEXT:
 				if ((psm2_status.msg_tag.tag2 & PSMX2_IOV_BIT) &&
-				    !psmx2_handle_sendv_req(tmp_ep, &psm2_status))
+				    !psmx2_handle_sendv_req(tmp_ep, &psm2_status, 0))
 					continue;
 				tmp_cq = tmp_ep->recv_cq;
 				tmp_cntr = tmp_ep->recv_cntr;
@@ -409,6 +409,9 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				break;
 
 			case PSMX2_MULTI_RECV_CONTEXT:
+				if ((psm2_status.msg_tag.tag2 & PSMX2_IOV_BIT) &&
+				    !psmx2_handle_sendv_req(tmp_ep, &psm2_status, 1))
+					continue;
 				multi_recv = 1;
 				tmp_cq = tmp_ep->recv_cq;
 				tmp_cntr = tmp_ep->recv_cntr;
@@ -535,6 +538,8 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					psm2_status.nbytes = rep->bytes_received;
 					psm2_status.msg_length = rep->msg_length;
 					psm2_status.error_code = rep->error_code;
+
+					multi_recv = rep->multi_recv;
 				}
 				break;
 			}

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -160,6 +160,8 @@ psmx2_cq_create_event_from_status(struct psmx2_fid_cq *cq,
 {
 	struct psmx2_cq_event *event;
 	struct psmx2_multi_recv *req;
+	struct psmx2_sendv_request *sendv_req;
+	struct psmx2_sendv_reply *sendv_rep;
 	struct fi_context *fi_context = psm2_status->context;
 	void *op_context, *buf;
 	int is_recv = 0;
@@ -170,6 +172,20 @@ psmx2_cq_create_event_from_status(struct psmx2_fid_cq *cq,
 		op_context = fi_context;
 		buf = PSMX2_CTXT_USER(fi_context);
 		flags = FI_SEND | FI_MSG;
+		break;
+	case PSMX2_SENDV_CONTEXT:
+	case PSMX2_IOV_SEND_CONTEXT:
+		sendv_req = PSMX2_CTXT_USER(fi_context);
+		op_context = sendv_req->user_context;
+		buf = NULL;
+		flags = FI_SEND | FI_MSG;
+		break;
+	case PSMX2_IOV_RECV_CONTEXT:
+		sendv_rep = PSMX2_CTXT_USER(fi_context);
+		op_context = sendv_rep->user_context;
+		buf = sendv_rep->buf;
+		flags = FI_RECV | FI_MSG;
+		is_recv = 1;
 		break;
 	case PSMX2_RECV_CONTEXT:
 		op_context = fi_context;
@@ -380,6 +396,13 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				break;
 
 			case PSMX2_RECV_CONTEXT:
+				if ((psm2_status.msg_tag.tag2 & PSMX2_IOV_BIT) &&
+				    !psmx2_handle_sendv_req(tmp_ep, &psm2_status))
+					continue;
+				tmp_cq = tmp_ep->recv_cq;
+				tmp_cntr = tmp_ep->recv_cntr;
+				break;
+
 			case PSMX2_TRECV_CONTEXT:
 				tmp_cq = tmp_ep->recv_cq;
 				tmp_cntr = tmp_ep->recv_cntr;
@@ -461,6 +484,59 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 
 				  continue;
 				}
+
+			case PSMX2_SENDV_CONTEXT:
+				{
+					struct psmx2_sendv_request *req;
+
+					req = PSMX2_CTXT_USER(fi_context);
+					if (req->iov_protocol == PSMX2_IOV_PROTO_MULTI && 
+					    req->iov_done < req->iov_info.count)	
+						continue;
+
+					tmp_cntr = tmp_ep->send_cntr;
+					if (!req->no_completion)
+						tmp_cq = tmp_ep->send_cq;
+				}
+				break;
+
+			case PSMX2_IOV_SEND_CONTEXT:
+				{
+					struct psmx2_sendv_request *req;
+
+					req = PSMX2_CTXT_USER(fi_context);
+					req->iov_done++;
+					if (req->iov_done < req->iov_info.count)	
+						continue;
+
+					tmp_cntr = tmp_ep->send_cntr;
+					if (!req->no_completion)
+						tmp_cq = tmp_ep->send_cq;
+				}
+				break;
+
+			case PSMX2_IOV_RECV_CONTEXT:
+				{
+					struct psmx2_sendv_reply *rep;
+
+					rep = PSMX2_CTXT_USER(fi_context);
+					rep->iov_done++;
+					rep->msg_length += psm2_status.msg_length;
+					rep->bytes_received += psm2_status.nbytes;
+					if (psm2_status.error_code != PSM2_OK)
+						rep->error_code = psm2_status.error_code;
+					if (rep->iov_done < rep->iov_info.count)	
+						continue;
+
+					tmp_cntr = tmp_ep->recv_cntr;
+					if (!rep->no_completion)
+						tmp_cq = tmp_ep->recv_cq;
+
+					psm2_status.nbytes = rep->bytes_received;
+					psm2_status.msg_length = rep->msg_length;
+					psm2_status.error_code = rep->error_code;
+				}
+				break;
 			}
 
 			if (tmp_cq) {

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -381,6 +381,16 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				tmp_cntr = tmp_ep->recv_cntr;
 				break;
 
+			case PSMX2_NOCOMP_RECV_CONTEXT_ALLOC:
+				if ((psm2_status.msg_tag.tag2 & PSMX2_IOV_BIT) &&
+				    !psmx2_handle_sendv_req(tmp_ep, &psm2_status, 0)) {
+					psmx2_ep_put_op_context(tmp_ep, fi_context);
+					continue;
+				}
+				tmp_cntr = tmp_ep->recv_cntr;
+				psmx2_ep_put_op_context(tmp_ep, fi_context);
+				break;
+
 			case PSMX2_NOCOMP_WRITE_CONTEXT:
 				tmp_cntr = tmp_ep->write_cntr;
 				break;

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -89,12 +89,12 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 			vlane = PSMX2_ADDR_TO_VL(src_addr);
 		}
 		tag32 = PSMX2_TAG32(PSMX2_MSG_BIT, vlane, ep_priv->vlane);
-		tagsel32 = -1;
+		tagsel32 = ~PSMX2_IOV_BIT;
 	}
 	else {
 		psm2_epaddr = 0;
 		tag32 = PSMX2_TAG32(PSMX2_MSG_BIT, 0, ep_priv->vlane);
-		tagsel32 = ~PSMX2_SRC_BITS;
+		tagsel32 = ~(PSMX2_IOV_BIT | PSMX2_SRC_BITS);
 	}
 
 	PSMX2_SET_TAG(psm2_tag, 0ULL, tag32);
@@ -132,6 +132,7 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 			PSMX2_CTXT_USER(fi_context) = buf;
 		}
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
+		PSMX2_CTXT_SIZE(fi_context) = len;
 	}
 
 	err = psm2_mq_irecv2(ep_priv->domain->psm2_mq, psm2_epaddr,
@@ -332,6 +333,283 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 	return 0;
 }
 
+ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
+			    void *desc, size_t count, fi_addr_t dest_addr,
+			    void *context, uint64_t flags, uint64_t data)
+{
+	struct psmx2_fid_ep *ep_priv;
+	struct psmx2_fid_av *av;
+	psm2_epaddr_t psm2_epaddr;
+	uint8_t vlane;
+	psm2_mq_req_t psm2_req;
+	psm2_mq_tag_t psm2_tag;
+	uint32_t tag32, tag32_base;
+	struct fi_context * fi_context;
+	int send_flag = 0;
+	int err;
+	size_t idx;
+	int no_completion = 0;
+	struct psmx2_cq_event *event;
+	size_t real_count;
+	size_t len, total_len;
+	char *p;
+	uint32_t *q;
+	int i;
+	struct psmx2_sendv_request *req;
+
+	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
+
+	if (flags & FI_TRIGGER) {
+		struct psmx2_trigger *trigger;
+		struct fi_triggered_context *ctxt = context;
+
+		trigger = calloc(1, sizeof(*trigger));
+		if (!trigger)
+			return -FI_ENOMEM;
+
+		trigger->op = PSMX2_TRIGGERED_SENDV;
+		trigger->cntr = container_of(ctxt->trigger.threshold.cntr,
+					     struct psmx2_fid_cntr, cntr);
+		trigger->threshold = ctxt->trigger.threshold.threshold;
+		trigger->sendv.ep = ep;
+		trigger->sendv.iov = iov;
+		trigger->sendv.desc = desc;
+		trigger->sendv.count = count;
+		trigger->sendv.dest_addr = dest_addr;
+		trigger->sendv.context = context;
+		trigger->sendv.flags = flags & ~FI_TRIGGER;
+		trigger->sendv.data = data;
+
+		psmx2_cntr_add_trigger(trigger->cntr, trigger);
+		return 0;
+	}
+
+	total_len = 0;
+	real_count = 0;
+	for (i=0; i<count; i++) {
+		if (iov[i].iov_len) {
+			total_len += iov[i].iov_len;
+			real_count++;
+		}
+	}
+
+	req = malloc(sizeof(*req));
+	if (!req)
+		return -FI_ENOMEM;
+
+	if (total_len <= PSMX2_IOV_BUF_SIZE) {
+		req->iov_protocol = PSMX2_IOV_PROTO_PACK;
+		p = req->buf;
+		for (i=0; i<count; i++) {
+			if (iov[i].iov_len) {
+				memcpy(p, iov[i].iov_base, iov[i].iov_len);
+				p += iov[i].iov_len;
+			}
+		}
+
+		tag32_base = PSMX2_MSG_BIT;
+		len = total_len;
+	}
+	else {
+		req->iov_protocol = PSMX2_IOV_PROTO_MULTI;
+		req->iov_done = 0;
+		req->iov_info.seq_num = (++ep_priv->iov_seq_num) %
+					(PSMX2_IOV_MAX_SEQ_NUM + 1);
+		req->iov_info.count = (uint32_t)real_count;
+		req->iov_info.total_len = (uint32_t)total_len;
+
+		q = req->iov_info.len;
+		for (i=0; i<count; i++) {
+			if (iov[i].iov_len)
+				*q++ = (uint32_t)iov[i].iov_len;
+		}
+
+		tag32_base = PSMX2_MSG_BIT | PSMX2_IOV_BIT;
+		len = (3 + real_count) * sizeof(uint32_t);
+	}
+
+	av = ep_priv->av;
+	if (av && av->type == FI_AV_TABLE) {
+		idx = (size_t)dest_addr;
+		if (idx >= av->last) {
+			free(req);
+			return -FI_EINVAL;
+		}
+
+		psm2_epaddr = av->epaddrs[idx];
+		vlane = av->vlanes[idx];
+	}
+	else  {
+		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
+		vlane = PSMX2_ADDR_TO_VL(dest_addr);
+	}
+
+	tag32 = PSMX2_TAG32(tag32_base, ep_priv->vlane, vlane);
+	PSMX2_SET_TAG(psm2_tag, data, tag32);
+
+	if ((flags & PSMX2_NO_COMPLETION) ||
+	    (ep_priv->send_selective_completion && !(flags & FI_COMPLETION)))
+		no_completion = 1;
+
+	if (flags & FI_INJECT) {
+		if (len > PSMX2_INJECT_SIZE) {
+			free(req);
+			return -FI_EMSGSIZE;
+		}
+
+		err = psm2_mq_send2(ep_priv->domain->psm2_mq, psm2_epaddr,
+				    send_flag, &psm2_tag, req->buf, len);
+
+		free(req);
+
+		if (err != PSM2_OK)
+			return psmx2_errno(err);
+
+		if (ep_priv->send_cntr)
+			psmx2_cntr_inc(ep_priv->send_cntr);
+
+		if (ep_priv->send_cq && !no_completion) {
+			event = psmx2_cq_create_event(
+					ep_priv->send_cq,
+					context, NULL, flags, len,
+					(uint64_t) data,
+					0 /* tag */,
+					0 /* olen */,
+					0 /* err */);
+
+			if (event)
+				psmx2_cq_enqueue_event(ep_priv->send_cq, event);
+			else
+				return -FI_ENOMEM;
+		}
+
+		return 0;
+	}
+
+	req->no_completion = no_completion;
+	req->user_context = context;
+
+	fi_context = &req->fi_context;
+	PSMX2_CTXT_TYPE(fi_context) = PSMX2_SENDV_CONTEXT;
+	PSMX2_CTXT_USER(fi_context) = req;
+	PSMX2_CTXT_EP(fi_context) = ep_priv;
+
+	err = psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr,
+			     send_flag, &psm2_tag, req->buf, len,
+			     (void *)fi_context, &psm2_req);
+
+	if (err != PSM2_OK) {
+		free(req);
+		return psmx2_errno(err);
+	}
+
+	PSMX2_CTXT_REQ(fi_context) = psm2_req;
+
+	if (req->iov_protocol == PSMX2_IOV_PROTO_MULTI) {
+		fi_context = &req->fi_context_iov;
+		PSMX2_CTXT_TYPE(fi_context) = PSMX2_IOV_SEND_CONTEXT;
+		PSMX2_CTXT_USER(fi_context) = req;
+		PSMX2_CTXT_EP(fi_context) = ep_priv;
+		tag32 = PSMX2_TAG32(PSMX2_MSG_BIT, ep_priv->vlane, vlane);
+		PSMX2_TAG32_SET_SEQ(tag32, req->iov_info.seq_num);
+		PSMX2_SET_TAG(psm2_tag, data, tag32);
+		for (i=0; i<count; i++) {
+			if (iov[i].iov_len) {
+				err = psm2_mq_isend2(ep_priv->domain->psm2_mq,
+						     psm2_epaddr, send_flag, &psm2_tag,
+						     iov[i].iov_base, iov[i].iov_len,
+						     (void *)fi_context, &psm2_req);
+				if (err != PSM2_OK)
+					return psmx2_errno(err);
+			}
+		}
+	}
+
+	return 0;
+}
+
+int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
+			   psm2_mq_status2_t *psm2_status)
+{
+	psm2_mq_req_t psm2_req;
+	psm2_mq_tag_t psm2_tag, psm2_tagsel;
+	struct psmx2_sendv_reply *rep;
+	struct fi_context *fi_context;
+	struct fi_context *recv_context;
+	int i, err;
+	void *recv_buf;
+	size_t recv_len, len;
+
+	if (psm2_status->error_code != PSM2_OK)
+		return psmx2_errno(psm2_status->error_code);
+
+	rep = malloc(sizeof(*rep));
+	if (!rep) {
+		psm2_status->error_code = PSM2_NO_MEMORY;
+		return -FI_ENOMEM;
+	}
+
+	recv_context = psm2_status->context;
+	recv_buf = PSMX2_CTXT_USER(recv_context);
+	recv_len = PSMX2_CTXT_SIZE(recv_context);
+
+	/* assert(psm2_status->nbytes <= PSMX2_IOV_BUF_SIZE */
+
+	memcpy(&rep->iov_info, recv_buf, psm2_status->nbytes);
+
+	rep->user_context = psm2_status->context;
+	rep->buf = recv_buf;
+	rep->no_completion = 0;
+	rep->iov_done = 0;
+	rep->bytes_received = 0;
+	rep->msg_length = 0;
+	rep->error_code = PSM2_OK;
+
+	fi_context = &rep->fi_context;
+	PSMX2_CTXT_TYPE(fi_context) = PSMX2_IOV_RECV_CONTEXT;
+	PSMX2_CTXT_USER(fi_context) = rep;
+	PSMX2_CTXT_EP(fi_context) = ep;
+
+	/* use the same tag, with IOV bit cleared, and seq_num added */
+	psm2_tag = psm2_status->msg_tag;
+	psm2_tag.tag2 &= ~PSMX2_IOV_BIT;
+	PSMX2_TAG32_SET_SEQ(psm2_tag.tag2, rep->iov_info.seq_num);
+
+	/* match every bit of the tag */
+	PSMX2_SET_TAG(psm2_tagsel, -1UL, -1);
+
+	for (i=0; i<rep->iov_info.count; i++) {
+		if (recv_len) {
+			len = MIN(recv_len, rep->iov_info.len[i]);
+			err = psm2_mq_irecv2(ep->domain->psm2_mq,
+					     psm2_status->msg_peer,
+					     &psm2_tag, &psm2_tagsel,
+					     0/*flag*/, recv_buf, len,
+					     (void *)fi_context, &psm2_req);
+			if (err) {
+				psm2_status->error_code = err;
+				return psmx2_errno(psm2_status->error_code);
+			}
+			recv_buf += len;
+			recv_len -= len;
+		}
+		else {
+			/* recv buffer full, pust empty recvs */
+			err = psm2_mq_irecv2(ep->domain->psm2_mq,
+					     psm2_status->msg_peer,
+					     &psm2_tag, &psm2_tagsel,
+					     0/*flag*/, NULL, 0,
+					     (void *)fi_context, &psm2_req);
+			if (err) {
+				psm2_status->error_code = err;
+				return psmx2_errno(psm2_status->error_code);
+			}
+		}
+	}
+
+	return 0;
+}
+
 static ssize_t psmx2_send(struct fid_ep *ep, const void *buf, size_t len,
 			  void *desc, fi_addr_t dest_addr, void *context)
 {
@@ -353,7 +631,10 @@ static ssize_t psmx2_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		return -FI_EINVAL;
 
 	if (msg->iov_count > 1) {
-		return -FI_EINVAL;
+		return psmx2_sendv_generic(ep, msg->msg_iov, msg->desc,
+					   msg->iov_count, msg->addr,
+					   msg->context, flags,
+					   msg->data);
 	}
 	else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
@@ -380,8 +661,15 @@ static ssize_t psmx2_sendv(struct fid_ep *ep, const struct iovec *iov,
 	if (count && !iov)
 		return -FI_EINVAL;
 
-	if (count > 1) {
+	if (count > PSMX2_IOV_MAX_COUNT) {
 		return -FI_EINVAL;
+	}
+	else if (count > 1) {
+		struct psmx2_fid_ep *ep_priv;
+		ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
+
+		return psmx2_sendv_generic(ep, iov, desc, count, dest_addr,
+					   context, ep_priv->flags, 0);
 	}
 	else if (count) {
 		buf = iov[0].iov_base;

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -101,7 +101,11 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 	PSMX2_SET_TAG(psm2_tagsel, 0ULL, tagsel32);
 
 	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION)) {
-		fi_context = &ep_priv->nocomp_recv_context;
+		fi_context = psmx2_ep_get_op_context(ep_priv);
+		PSMX2_CTXT_TYPE(fi_context) = PSMX2_NOCOMP_RECV_CONTEXT_ALLOC;
+		PSMX2_CTXT_EP(fi_context) = ep_priv;
+		PSMX2_CTXT_USER(fi_context) = buf;
+		PSMX2_CTXT_SIZE(fi_context) = len;
 	}
 	else {
 		if (!context)


### PR DESCRIPTION
Allow fi_sendv and fi_sendmsg to be called with iov_count > 1. The protocol depends on the extra tag bits available in psm2, so it will remain a psm2 only feature. 