### PR TITLE
Allow libfabric to build on FreeBSD

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,10 @@ src_libfabric_la_SOURCES += src/osx/osd.c
 src_libfabric_la_SOURCES += include/osx/osd.h
 endif
 
+if FREEBSD
+src_libfabric_la_SOURCES += include/freebsd/osd.h
+endif
+
 if LINUX
 src_libfabric_la_SOURCES += include/linux/osd.h
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -13,6 +13,7 @@ AC_CANONICAL_HOST
 
 macos=0
 linux=0
+freebsd=0
 
 case $host_os in
 *darwin*)
@@ -21,13 +22,17 @@ case $host_os in
 *linux*)
 	linux=1
 	;;
+*freebsd*)
+	freebsd=1
+	;;
 *)
-	AC_MSG_ERROR([libfabric only builds on Linux & OS X])
+	AC_MSG_ERROR([libfabric only builds on Linux, OS X, and FreeBSD])
 	;;
 esac
 
 AM_CONDITIONAL([MACOS], [test "x$macos" = "x1"])
 AM_CONDITIONAL([LINUX], [test "x$linux" = "x1"])
+AM_CONDITIONAL([FREEBSD], [test "x$freebsd" = "x1"])
 
 AC_ARG_ENABLE([debug],
 	      [AS_HELP_STRING([--enable-debug],

--- a/include/fi.h
+++ b/include/fi.h
@@ -48,6 +48,8 @@
 
 #ifdef __APPLE__
 #include <osx/osd.h>
+#elif defined __FreeBSD__
+#include <freebsd/osd.h>
 #else
 #include <linux/osd.h>
 #endif

--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016 Intel Corp, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -30,54 +30,13 @@
  * SOFTWARE.
  */
 
-#ifndef _SOCK_UTIL_H_
-#define _SOCK_UTIL_H_
+#include <sys/endian.h>
+#include <pthread_np.h>
 
-#include <sys/mman.h>
-#include <rdma/fi_log.h>
-#include "sock.h"
 
-extern const char sock_fab_name[];
-extern const char sock_dom_name[];
-extern const char sock_prov_name[];
-extern struct fi_provider sock_prov;
-extern int sock_pe_waittime;
-extern int sock_conn_retry;
-extern int sock_cm_def_map_sz;
-extern int sock_av_def_sz;
-extern int sock_cq_def_sz;
-extern int sock_eq_def_sz;
-extern char *sock_pe_affinity_str;
-#if ENABLE_DEBUG
-extern int sock_dgram_drop_rate;
-#endif
+#define bswap_64 bswap64
 
-#define _SOCK_LOG_DBG(subsys, ...) FI_DBG(&sock_prov, subsys, __VA_ARGS__)
-#define _SOCK_LOG_ERROR(subsys, ...) FI_WARN(&sock_prov, subsys, __VA_ARGS__)
+#define ENODATA ENOMSG
+#define HOST_NAME_MAX  128
 
-static inline int sock_drop_packet(struct sock_ep *sock_ep)
-{
-#if ENABLE_DEBUG
-	if (sock_ep->ep_type == FI_EP_DGRAM && sock_dgram_drop_rate > 0) {
-		sock_ep->domain->fab->num_send_msg++;
-		if (!(sock_ep->domain->fab->num_send_msg % sock_dgram_drop_rate))
-			return 1;
-	}
-#endif
-	return 0;
-}
-
-static inline void *sock_mremap(void *old_address, size_t old_size,
-				size_t new_size)
-{
-#ifdef __APPLE__
-	return (void *) -1;
-#elif defined __FreeBSD__
-	return (void *) -1;
-#else
-	return mremap(old_address, old_size, new_size, 0);
-#endif
-}
-
-#endif
-
+typedef cpuset_t cpu_set_t;

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -33,6 +33,8 @@
 #ifndef _FI_EQ_H_
 #define _FI_EQ_H_
 
+#include <pthread.h>
+
 #include <rdma/fabric.h>
 
 

--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -46,6 +46,7 @@
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>
 #include <netdb.h>
+#include <netinet/in.h>
 
 #include <fi.h>
 #include <fi_enosys.h>

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -32,6 +32,7 @@
 
 #include "config.h"
 
+#include <sys/types.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
@@ -43,6 +44,7 @@
 #include <ctype.h>
 #include <sys/ipc.h>
 #include <sys/mman.h>
+#include <sys/stat.h>
 
 #include "sock.h"
 #include "sock_util.h"

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -32,6 +32,7 @@
 
 #include "config.h"
 
+#include <sys/types.h>
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/prov/sockets/src/sock_epoll.c
+++ b/prov/sockets/src/sock_epoll.c
@@ -30,6 +30,7 @@
  * SOFTWARE.
  */
 
+#include <sys/types.h>
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -34,10 +34,11 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <sys/types.h>
 #include <netdb.h>
 #include <pthread.h>
 #include <sys/socket.h>
-#include <sys/types.h>
+#include <netinet/in.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_atomic.h>


### PR DESCRIPTION
Fixes compile errors building on FreeBSD.  The UDP provider returns
proper data for fi_info, but the sockets provider does not.  Additional
fixes will be in follow on patches.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>