### PR TITLE
prov/udp: Fix compile warning reported by jenkins

### DIFF
--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -49,10 +49,13 @@ int udpx_setname(fid_t fid, void *addr, size_t addrlen)
 int udpx_getname(fid_t fid, void *addr, size_t *addrlen)
 {
 	struct udpx_ep *ep;
+	socklen_t len;
 	int ret;
 
 	ep = container_of(fid, struct udpx_ep, ep_fid.fid);
-	ret = getsockname(ep->sock, addr, addrlen);
+	len = *addrlen;
+	ret = getsockname(ep->sock, addr, &len);
+	*addrlen = len;
 	return ret ? -errno : 0;
 }
 


### PR DESCRIPTION
Error reported by Cisco:

prov/udp/src/udpx_ep.c:55:2: error: passing argument 3 of 'getsockname' from incompatible pointer type [-Werror]
  ret = getsockname(ep->sock, addr, addrlen);
  ^
In file included from /usr/include/netinet/in.h:25:0,
                 from /usr/include/netdb.h:28,
                 from prov/udp/src/udpx.h:37,
                 from prov/udp/src/udpx_ep.c:36:
/usr/include/sys/socket.h:119:12: note: expected 'socklen_t * restrict' but argument is of type 'size_t *'
 extern int getsockname (int __fd, __SOCKADDR_ARG __addr,
            ^
  CC       prov/sockets/src/sock_dom.lo

Signed-off-by: Sean Hefty <sean.hefty@intel.com>