### PR TITLE
build: fix search for fi_direct.h

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -123,8 +123,8 @@ AC_DEFUN([FI_PROVIDER_SETUP],[
 	# If this provider was requested for direct build, ensure that
 	# provider's fi_direct.h exists in tree. Error otherwise.
 	AS_IF([test x"$enable_direct" = x"$1"],
-		[AC_MSG_CHECKING(for prov/$1/include/rdma/fi_direct.h)
-		 AS_IF([test -f "prov/$1/include/rdma/fi_direct.h"],
+		[AC_MSG_CHECKING(for $srcdir/prov/$1/include/rdma/fi_direct.h)
+		 AS_IF([test -f "$srcdir/prov/$1/include/rdma/fi_direct.h"],
 			[AC_MSG_RESULT(yes)],
 			[AC_MSG_RESULT(no)
 			  AC_MSG_ERROR([$1 provider was requested as direct, but is missing fi_direct.h])]


### PR DESCRIPTION
When libfabric is configured in a different directory, the
check for fi_direct.h fails. This points configure to
look in the right place.

@jsquyres @shefty 

Looks like #1372 didn't quite fix it.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>