### PR TITLE
prov/gni: More small fixes

### DIFF
--- a/prov/gni/include/gnix_buddy_allocator.h
+++ b/prov/gni/include/gnix_buddy_allocator.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -34,11 +34,11 @@
 #ifndef _GNIX_BUDDY_ALLOCATOR_H_
 #define _GNIX_BUDDY_ALLOCATOR_H_
 
+#include <stdlib.h>
 #include "fi_list.h"
 #include "gnix_bitmap.h"
 #include "gnix_util.h"
 #include "gnix.h"
-#include <stdlib.h>
 
 #define MIN_BLOCK_SIZE 16
 

--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -279,7 +279,7 @@ static void __cntr_destruct(void *obj)
 		gnix_wait_close(&cntr->wait->fid);
 		break;
 	default:
-		GNIX_WARN(FI_LOG_CQ, "format: %d unsupported\n.",
+		GNIX_WARN(FI_LOG_CQ, "format: %d unsupported.\n",
 			  cntr->attr.wait_obj);
 		break;
 	}

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -151,7 +151,7 @@ static int verify_cq_attr(struct fi_cq_attr *attr, struct fi_ops_cq *ops,
 	case FI_CQ_FORMAT_TAGGED:
 		break;
 	default:
-		GNIX_WARN(FI_LOG_CQ, "format: %d unsupported\n.",
+		GNIX_WARN(FI_LOG_CQ, "format: %d unsupported.\n",
 			  attr->format);
 		return -FI_EINVAL;
 	}
@@ -444,7 +444,7 @@ static void __cq_destruct(void *obj)
 		gnix_wait_close(&cq->wait->fid);
 		break;
 	default:
-		GNIX_WARN(FI_LOG_CQ, "format: %d unsupported\n.",
+		GNIX_WARN(FI_LOG_CQ, "format: %d unsupported.\n",
 			  cq->attr.wait_obj);
 		break;
 	}

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -128,8 +128,8 @@ static int gnix_domain_close(fid_t fid)
 	references_held = _gnix_ref_put(domain);
 
 	if (references_held) {
-		GNIX_WARN(FI_LOG_DOMAIN, "failed to fully close domain due to "
-				"lingering references. references=%i dom=%p\n",
+		GNIX_INFO(FI_LOG_DOMAIN, "failed to fully close domain due to "
+			  "lingering references. references=%i dom=%p\n",
 			  references_held, domain);
 	}
 

--- a/prov/gni/test/rdm_rma.c
+++ b/prov/gni/test/rdm_rma.c
@@ -330,10 +330,10 @@ void rdm_rma_teardown(void)
 	cr_assert(!ret, "failure in closing dom[1] av.");
 
 	ret = fi_close(&dom[0]->fid);
-	cr_assert(!ret, "failure in closing domain.");
+	cr_assert(!ret, "failure in closing domain dom[0].");
 
 	ret = fi_close(&dom[1]->fid);
-	cr_assert(!ret, "failure in closing domain.");
+	cr_assert(!ret, "failure in closing domain dom[1].");
 
 	ret = fi_close(&fab->fid);
 	cr_assert(!ret, "failure in closing fabric.");


### PR DESCRIPTION
- Fix up some warning strings
- Be more specific with cr_assert strings
- Change GNIX_WARN to GNIX_INFO when domain not fully closed
- Move #include <stdlib.h> in gnix_buddy_allocator.h to get rid of warning

@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@ef7d8de352fea7c3156b4823d91ea99480be1444)
upstream merge of ofi-cray/libfabric-cray#628