### PR TITLE
prov/gni: Implement remove tag for multi receive

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -765,8 +765,7 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 			GNIX_INFO(FI_LOG_EP_DATA, "Freeing req: %p\n", req);
 
 			/* Dequeue and free the request. */
-			req = _gnix_match_tag(posted_queue, hdr->msg_tag, 0, 0,
-					      NULL, &vc->peer_addr);
+			_gnix_remove_tag(posted_queue, req);
 			_gnix_fr_free(ep, req);
 		}
 	} else {
@@ -940,8 +939,7 @@ static int __smsg_rndzv_start(void *data, void *msg)
 			req = dup_req;
 		} else {
 			/* Dequeue the request. */
-			req = _gnix_match_tag(posted_queue, hdr->msg_tag, 0, 0,
-					      NULL, &vc->peer_addr);
+			_gnix_remove_tag(posted_queue, req);
 		}
 
 		/* Queue request to initiate pull of source data. */

--- a/prov/gni/test/tags.c
+++ b/prov/gni/test/tags.c
@@ -267,7 +267,7 @@ static struct gnix_fr_element default_reqs[8] = {
 static struct gnix_tag_storage *test_tag_storage;
 static int call_destruct;
 static int (*match_func)(
-		struct slist_entry *entry,
+		struct dlist_entry *entry,
 		const void *arg) = _gnix_match_posted_tag;
 
 


### PR DESCRIPTION
support

- added _gnix_remove_tag which takes a request returned from a
  _gnix_match_tag FI_PEEK.
- changed gnix_tags dlist instead of slist.
- note: currently not implementing the lookup function as it is redundant with
  the match_tag functionality

@sungeunchoi 

Fixes ofi-cray/libfabric-cray#602

Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@72d78cc90f4158ccdaf80d58228e7292070163bf)
upstream merge of ofi-cray/libfabric-cray#629