### PR TITLE
pages: GH now supports Jekyl 3.0 with real Markdown

### DIFF
--- a/man/README
+++ b/man/README
@@ -52,32 +52,7 @@ tagline: Libfabric Programmer's Manual
    The whole block is needed, and it must be the first input in the
    file.
 
-2. In Github-flavored Markdown, you may be used to using "fenced
-   blocks" for multi-line code blocks, like this:
-
-```c
-void my_c_code(void) {
-  int i;
-  /* Hello, world */
-}
-```
-
-   Such fenced blocks will not work in Jekyll.  Instead, you must
-   delineate your code blocks with Jekyll delimiters:
-
-{% highlight c %}
-void my_c_code(void) {
-  int i;
-  /* Hello, world */
-}
-{% endhighlight %}
-
-   This will result in a pretty code box in the rendered HTML output,
-   and it will be syntax highlighted for the C language.  Leave the
-   "c" out of the first directive if your multi-line block is not C
-   code, and then it won't do C syntax highlighting.
-
-3. The libfabric man pages are full of 2-level lists of things.  E.g.,
+2. The libfabric man pages are full of 2-level lists of things.  E.g.,
    lists of functions, and then in some of the functions, there is a
    sub-list of flags that can be used with that function.  
 
@@ -107,7 +82,7 @@ void my_c_code(void) {
   FI_WRITE flag is not set, then the application may not invoke
   fi_cq_write of fi_cq_writeerr.
 
-4. There's a small number of places in the libfabric man pages where
+3. There's a small number of places in the libfabric man pages where
    there are unnumbered lists with deliberate line breaks.  For
    example:
 
@@ -127,7 +102,7 @@ fi_atomic / fi_atomicv__
 fi_atomicto / fi_atomicmsg
 : Initiates an atomic operation to remote memory
 
-5. The "SEE ALSO" items at the end of each man page are linked to
+4. The "SEE ALSO" items at the end of each man page are linked to
    their corresponding man pages.  Note that the links are made to
    ".html" files -- *not* ".md" files.  If you care, the reason is
    because the Github web servers statically generate .html files from

--- a/man/fabric.7.md
+++ b/man/fabric.7.md
@@ -11,9 +11,9 @@ Fabric Interface Library
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fabric.h>
-{% endhighlight %}
+```
 
 Libfabric is a high-performance fabric software library designed to
 provide low-latency interfaces to fabric hardware.

--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -25,7 +25,7 @@ fi_atomic_valid / fi_fetch_atomic_valid / fi_compare_atomic_valid
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_atomic.h>
 
 ssize_t fi_atomic(struct fid_ep *ep, const void *buf,
@@ -88,7 +88,7 @@ int fi_fetch_atomicvalid(struct fid_ep *ep, enum fi_datatype datatype,
 
 int fi_compare_atomicvalid(struct fid_ep *ep, enum fi_datatype datatype,
     enum fi_op op, size_t *count);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -218,125 +218,125 @@ operations.  A conceptual description of each operation is provided.
 
 *FI_MIN*
 : Minimum
-{% highlight c %}
+```c
 if (buf[i] < addr[i])
     addr[i] = buf[i]
-{% endhighlight %}
+```
 
 *FI_MAX*
 : Maximum
-{% highlight c %}
+```c
 if (buf[i] > addr[i])
     addr[i] = buf[i]
-{% endhighlight %}
+```
 
 *FI_SUM*
 : Sum
-{% highlight c %}
+```c
 addr[i] = addr[i] + buf[i]
-{% endhighlight %}
+```
 
 *FI_PROD*
 : Product
-{% highlight c %}
+```c
 addr[i] = addr[i] * buf[i]
-{% endhighlight %}
+```
 
 *FI_LOR*
 : Logical OR
-{% highlight c %}
+```c
 addr[i] = (addr[i] || buf[i])
-{% endhighlight %}
+```
 
 *FI_LAND*
 : Logical AND
-{% highlight c %}
+```c
 addr[i] = (addr[i] && buf[i])
-{% endhighlight %}
+```
 
 *FI_BOR*
 : Bitwise OR
-{% highlight c %}
+```c
 addr[i] = addr[i] | buf[i]
-{% endhighlight %}
+```
 
 *FI_BAND*
 : Bitwise AND
-{% highlight c %}
+```c
 addr[i] = addr[i] & buf[i]
-{% endhighlight %}
+```
 
 *FI_LXOR*
 : Logical exclusive-OR (XOR)
-{% highlight c %}
+```c
 addr[i] = ((addr[i] && !buf[i]) || (!addr[i] && buf[i]))
-{% endhighlight %}
+```
 
 *FI_BXOR*
 : Bitwise exclusive-OR (XOR)
-{% highlight c %}
+```c
 addr[i] = addr[i] ^ buf[i]
-{% endhighlight %}
+```
 
 *FI_ATOMIC_READ*
 : Read data atomically
-{% highlight c %}
+```c
 buf[i] = addr[i]
-{% endhighlight %}
+```
 
 *FI_ATOMIC_WRITE*
 : Write data atomically
-{% highlight c %}
+```c
 addr[i] = buf[i]
-{% endhighlight %}
+```
 
 *FI_CSWAP*
 : Compare values and if equal swap with data
-{% highlight c %}
+```c
 if (compare[i] == addr[i])
     addr[i] = buf[i]
-{% endhighlight %}
+```
 
 *FI_CSWAP_NE*
 : Compare values and if not equal swap with data
-{% highlight c %}
+```c
 if (compare[i] != addr[i])
     addr[i] = buf[i]
-{% endhighlight %}
+```
 
 *FI_CSWAP_LE*
 : Compare values and if less than or equal swap with data
-{% highlight c %}
+```c
 if (compare[i] <= addr[i])
     addr[i] = buf[i]
-{% endhighlight %}
+```
 
 *FI_CSWAP_LT*
 : Compare values and if less than swap with data
-{% highlight c %}
+```c
 if (compare[i] < addr[i])
     addr[i] = buf[i]
-{% endhighlight %}
+```
 
 *FI_CSWAP_GE*
 : Compare values and if greater than or equal swap with data
-{% highlight c %}
+```c
 if (compare[i] >= addr[i])
     addr[i] = buf[i]
-{% endhighlight %}
+```
 
 *FI_CSWAP_GT*
 : Compare values and if greater than swap with data
-{% highlight c %}
+```c
 if (compare[i] > addr[i])
     addr[i] = buf[i]
-{% endhighlight %}
+```
 
 *FI_MSWAP*
 : Swap masked bits with data
-{% highlight c %}
+```c
 addr[i] = (buf[i] & compare[i]) | (addr[i] & ~compare[i])
-{% endhighlight %}
+```
 
 ## Base Atomic Functions
 
@@ -375,7 +375,7 @@ and unconnected endpoints, with the ability to control the atomic
 operation per call through the use of flags.  The fi_atomicmsg
 function takes a struct fi_msg_atomic as input.
 
-{% highlight c %}
+```c
 struct fi_msg_atomic {
 	const struct fi_ioc *msg_iov; /* local scatter-gather array */
 	void                **desc;   /* local access descriptors */
@@ -394,7 +394,7 @@ struct fi_rma_ioc {
     size_t             count;        /* # target operands */
     uint64_t           key;          /* access key */
 };
-{% endhighlight %}
+```
 
 The following list of atomic operations are usable with base
 atomic operations: FI_MIN, FI_MAX, FI_SUM, FI_PROD,
@@ -515,7 +515,7 @@ the entire array.  The following pseudo-code demonstrates this operation
 for 64-bit unsigned atomic write.  ATOMIC_WRITE_U64 is a platform
 dependent macro that atomically writes 8 bytes to an aligned memory location.
 
-{% highlight c %}
+```c
 fi_atomic(ep, buf, count, NULL, dest_addr, addr, key,
 	FI_UINT64, FI_ATOMIC_WRITE, context);
 {
@@ -523,7 +523,7 @@ fi_atomic(ep, buf, count, NULL, dest_addr, addr, key,
 		ATOMIC_WRITE_U64(((uint64_t *) addr)[i],
 			((uint64_t *) buf)[i]);
 }
-{% endhighlight %}
+```
 
 The number of array elements to operate on is specified through a count
 parameter.  This must be between 1 and the maximum returned through the

--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -26,7 +26,7 @@ fi_av_straddr
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_domain.h>
 
 int fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
@@ -58,7 +58,7 @@ fi_addr_t fi_rx_addr(fi_addr_t fi_addr, int rx_index,
 
 const char * fi_av_straddr(struct fid_av *av, const void *addr,
       void *buf, size_t *len);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -111,7 +111,7 @@ must first bind an event queue to the AV before inserting addresses.
 fi_av_open allocates or opens an address vector.  The properties and
 behavior of the address vector are defined by `struct fi_av_attr`.
 
-{% highlight c %}
+```c
 struct fi_av_attr {
 	enum fi_av_type  type;        /* type of AV */
 	int              rx_ctx_bits; /* address bits to identify rx ctx */
@@ -121,7 +121,7 @@ struct fi_av_attr {
 	void             *map_addr;   /* base mmap address */
 	uint64_t         flags;       /* operation flags */
 };
-{% endhighlight %}
+```
 
 *type*
 : An AV type corresponds to a conceptual implementation of an address

--- a/man/fi_cm.3.md
+++ b/man/fi_cm.3.md
@@ -17,7 +17,7 @@ fi_setname / fi_getname / fi_getpeer
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_cm.h>
 
 int fi_connect(struct fid_ep *ep, const void *addr,
@@ -37,7 +37,7 @@ int fi_setname(fid_t fid, void *addr, size_t addrlen);
 int fi_getname(fid_t fid, void *addr, size_t *addrlen);
 
 int fi_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 

--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -29,7 +29,7 @@ fi_cntr_wait
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_domain.h>
 
 int fi_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
@@ -47,7 +47,7 @@ int fi_cntr_set(struct fid_cntr *cntr, uint64_t value);
 
 int fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold,
     int timeout);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -93,14 +93,14 @@ value.
 fi_cntr_open allocates a new fabric counter.  The properties and
 behavior of the counter are defined by `struct fi_cntr_attr`.
 
-{% highlight c %}
+```c
 struct fi_cntr_attr {
 	enum fi_cntr_events  events;    /* type of events to count */
 	enum fi_wait_obj     wait_obj;  /* requested wait object */
 	struct fid_wait     *wait_set;  /* optional wait set */
 	uint64_t             flags;     /* operation flags */
 };
-{% endhighlight %}
+```
 
 *events*
 : A counter captures different types of events.  The specific type

--- a/man/fi_control.3.md
+++ b/man/fi_control.3.md
@@ -11,11 +11,11 @@ fi_control \- Perform an operation on a fabric resource.
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fabric.h>
 
 int fi_control(struct fid *fid, int command, void *arg);
-{% endhighlight %}
+```
 
 
 # ARGUMENTS

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -27,7 +27,7 @@ fi_cq_strerror
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_domain.h>
 
 int fi_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
@@ -55,7 +55,7 @@ int fi_cq_signal(struct fid_cq *cq);
 
 const char * fi_cq_strerror(struct fid_cq *cq, int prov_errno,
       const void *err_data, char *buf, size_t len);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -125,7 +125,7 @@ offloaded entirely in provider hardware.
 The properties and behavior of a completion queue are defined by
 `struct fi_cq_attr`.
 
-{% highlight c %}
+```c
 struct fi_cq_attr {
 	size_t               size;      /* # entries for CQ */
 	uint64_t             flags;     /* operation flags */
@@ -135,7 +135,7 @@ struct fi_cq_attr {
 	enum fi_cq_wait_cond wait_cond; /* wait condition format */
 	struct fid_wait     *wait_set;  /* optional wait set */
 };
-{% endhighlight %}
+```
 
 *size*
 : Specifies the minimum size of a completion queue. A value of 0 indicates that
@@ -161,29 +161,29 @@ struct fi_cq_attr {
 : Provides only user specified context that was associated with the
   completion.
 
-{% highlight c %}
+```c
 struct fi_cq_entry {
 	void     *op_context; /* operation context */
 };
-{% endhighlight %}
+```
 
 - *FI_CQ_FORMAT_MSG*
 : Provides minimal data for processing completions, with expanded
   support for reporting information about received messages.
 
-{% highlight c %}
+```c
 struct fi_cq_msg_entry {
 	void     *op_context; /* operation context */
 	uint64_t flags;       /* completion flags */
 	size_t   len;         /* size of received data */
 };
-{% endhighlight %}
+```
 
 - *FI_CQ_FORMAT_DATA*
 : Provides data associated with a completion.  Includes support for
   received message length, remote EQ data, and multi-receive buffers.
 
-{% highlight c %}
+```c
 struct fi_cq_data_entry {
 	void     *op_context; /* operation context */
 	uint64_t flags;       /* completion flags */
@@ -191,13 +191,13 @@ struct fi_cq_data_entry {
 	void     *buf;        /* receive data buffer */
 	uint64_t data;        /* completion data */
 };
-{% endhighlight %}
+```
 
 - *FI_CQ_FORMAT_TAGGED*
 : Expands completion data to include support for the tagged message
   interfaces.
 
-{% highlight c %}
+```c
 struct fi_cq_tagged_entry {
 	void     *op_context; /* operation context */
 	uint64_t flags;       /* completion flags */
@@ -206,7 +206,7 @@ struct fi_cq_tagged_entry {
 	uint64_t data;        /* completion data */
 	uint64_t tag;         /* received tag */
 };
-{% endhighlight %}
+```
 
 *wait_obj*
 : CQ's may be associated with a specific wait object.  Wait objects
@@ -353,7 +353,7 @@ immediately whether an error completion was found or not.
 Error information is reported to the user through `struct
 fi_cq_err_entry`.  The format of this structure is defined below.
 
-{% highlight c %}
+```c
 struct fi_cq_err_entry {
 	void     *op_context; /* operation context */
 	uint64_t flags;       /* completion flags */
@@ -366,7 +366,7 @@ struct fi_cq_err_entry {
 	int      prov_errno;  /* provider error code */
 	void    *err_data;    /*  error data */
 };
-{% endhighlight %}
+```
 
 The general reason for the error is provided through the err field.
 Provider specific error information may also be available through the

--- a/man/fi_direct.7.md
+++ b/man/fi_direct.7.md
@@ -11,11 +11,11 @@ Direct fabric provider access
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 -DFABRIC_DIRECT
 
 #define FABRIC_DIRECT
-{% endhighlight %}
+```
 
 Fabric direct provides a mechanism for applications to compile against
 a specific fabric providers without going through the libfabric

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -11,7 +11,7 @@ fi_domain \- Open a fabric access domain
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fabric.h>
 
 #include <rdma/fi_domain.h>
@@ -26,7 +26,7 @@ int fi_domain_bind(struct fid_domain *domain, struct fid *eq,
 
 int fi_open_ops(struct fid *domain, const char *name, uint64_t flags,
     void **ops, void *context);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -106,7 +106,7 @@ prior to calling fi_close, otherwise the call will return -FI_EBUSY.
 The `fi_domain_attr` structure defines the set of attributes associated
 with a domain.
 
-{% highlight c %}
+```c
 struct fi_domain_attr {
 	struct fid_domain     *domain;
 	char                  *name;
@@ -127,7 +127,7 @@ struct fi_domain_attr {
 	size_t                max_ep_stx_ctx;
 	size_t                max_ep_srx_ctx;
 };
-{% endhighlight %}
+```
 
 ## domain
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -46,7 +46,7 @@ fi_rx_size_left / fi_tx_size_left
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fabric.h>
 
 #include <rdma/fi_endpoint.h>
@@ -101,7 +101,7 @@ int fi_setopt(struct fid *ep, int level, int optname,
 ssize_t fi_rx_size_left(struct fid_ep *ep);
 
 ssize_t fi_tx_size_left(struct fid_ep *ep);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -287,31 +287,31 @@ together when binding an endpoint to a completion domain CQ.
   Example: An application can selectively generate send completions by
   using the following general approach:
 
-  {% highlight c %}
+```c
   fi_tx_attr::op_flags = 0; // default - no completion
   fi_ep_bind(ep, cq, FI_SEND | FI_SELECTIVE_COMPLETION);
   fi_send(ep, ...);                   // no completion
   fi_sendv(ep, ...);                  // no completion
   fi_sendmsg(ep, ..., FI_COMPLETION); // completion!
   fi_inject(ep, ...);                 // no completion
-  {% endhighlight %}
+```
 
   Example: An application can selectively disable send completions by
   modifying the operational flags:
 
-  {% highlight c %}
+```c
   fi_tx_attr::op_flags = FI_COMPLETION; // default - completion
   fi_ep_bind(ep, cq, FI_SEND | FI_SELECTIVE_COMPLETION);
   fi_send(ep, ...);       // completion
   fi_sendv(ep, ...);      // completion
   fi_sendmsg(ep, ..., 0); // no completion!
   fi_inject(ep, ...);     // no completion!
-  {% endhighlight %}
+```
 
   Example: Omitting FI_SELECTIVE_COMPLETION when binding will generate
   completions for all non-fi_inject calls:
 
-  {% highlight c %}
+```c
   fi_tx_attr::op_flags = 0;
   fi_ep_bind(ep, cq, FI_SEND);  // default - completion
   fi_send(ep, ...);                   // completion
@@ -320,7 +320,7 @@ together when binding an endpoint to a completion domain CQ.
   fi_sendmsg(ep, ..., FI_COMPLETION); // completion
   fi_sendmsg(ep, ..., FI_INJECT|FI_COMPLETION); // completion!
   fi_inject(ep, ...);                 // no completion!
-  {% endhighlight %}
+```
 
 An endpoint may also, or instead, be bound to a fabric counter.  When
 binding an endpoint to a counter, the following flags may be specified.

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -29,7 +29,7 @@ fi_eq_strerror
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_domain.h>
 
 int fi_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
@@ -53,7 +53,7 @@ ssize_t fi_eq_sread(struct fid_eq *eq, uint32_t *event,
 
 const char * fi_eq_strerror(struct fid_eq *eq, int prov_errno,
       const void *err_data, char *buf, size_t len);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -114,7 +114,7 @@ fi_eq_open allocates a new event queue.
 The properties and behavior of an event queue are defined by `struct
 fi_eq_attr`.
 
-{% highlight c %}
+```c
 struct fi_eq_attr {
 	size_t               size;      /* # entries for EQ */
 	uint64_t             flags;     /* operation flags */
@@ -122,7 +122,7 @@ struct fi_eq_attr {
 	int                  signaling_vector; /* interrupt affinity */
 	struct fid_wait     *wait_set;  /* optional wait set */
 };
-{% endhighlight %}
+```
 
 *size*
 : Specifies the minimum size of an event queue.
@@ -209,12 +209,12 @@ commands are usable with an EQ.
   object will be written.  This should be an 'int *' for FI_WAIT_FD,
   or 'struct fi_mutex_cond' for FI_WAIT_MUTEX_COND.
   
-{% highlight c %}
+```c
 struct fi_mutex_cond {
 	pthread_mutex_t     *mutex;
 	pthread_cond_t      *cond;
 };
-{% endhighlight %}
+```
 
 ## fi_eq_read
 
@@ -240,13 +240,13 @@ information regarding the format associated with each event.
   Control requests report their completion by inserting a `struct
   fi_eq_entry` into the EQ.  The format of this structure is:
 
-{% highlight c %}
+```c
 struct fi_eq_entry {
 	fid_t            fid;        /* fid associated with request */
 	void            *context;    /* operation context */
 	uint64_t         data;       /* completion-specific data */
 };
-{% endhighlight %}
+```
 
   For the completion of basic asynchronous control operations, the
   returned event will indicate the operation that has completed, and
@@ -268,13 +268,13 @@ struct fi_eq_entry {
   FI_SHUTDOWN.  Connection notifications are reported using `struct
   fi_eq_cm_entry`:
 
-{% highlight c %}
+```c
 struct fi_eq_cm_entry {
 	fid_t            fid;        /* fid associated with request */
 	struct fi_info  *info;       /* endpoint information */
 	uint8_t         data[];     /* app connection data */
 };
-{% endhighlight %}
+```
 
   A connection request (FI_CONNREQ) event indicates that
   a remote endpoint wishes to establish a new connection to a listening,
@@ -364,7 +364,7 @@ call fi_eq_readerr.
 Error information is reported to the user through struct
 fi_eq_err_entry.  The format of this structure is defined below.
 
-{% highlight c %}
+```c
 struct fi_eq_err_entry {
 	fid_t            fid;        /* fid associated with error */
 	void            *context;    /* operation context */
@@ -374,7 +374,7 @@ struct fi_eq_err_entry {
 	void            *err_data;   /* additional error data */
 	size_t           err_data_size; /* size of err_data */
 };
-{% endhighlight %}
+```
 
 The fid will reference the fabric descriptor associated with the
 event.  For memory registration, this will be the fid_mr, address

--- a/man/fi_errno.3.md
+++ b/man/fi_errno.3.md
@@ -13,11 +13,11 @@ fi_strerror \- Convert fabric error into a printable string
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_errno.h>
 
 const char *fi_strerror(int errno);
-{% endhighlight %}
+```
 
 
 # ERRORS

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -17,7 +17,7 @@ fi_tostr
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fabric.h>
 
 int fi_fabric(struct fi_fabric_attr *attr,
@@ -26,7 +26,7 @@ int fi_fabric(struct fi_fabric_attr *attr,
 int fi_close(struct fid *fabric);
 
 char * fi_tostr(const void *data, enum fi_type datatype);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -132,14 +132,14 @@ domains, passive endpoints, and CM event queues.
 The fi_fabric_attr structure defines the set of attributes associated
 with a fabric and a fabric provider.
 
-{% highlight c %}
+```c
 struct fi_fabric_attr {
 	struct fid_fabric *fabric;
 	char              *name;
 	char              *prov_name;
 	uint32_t          prov_version;
 };
-{% endhighlight %}
+```
 
 ## fabric
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -13,7 +13,7 @@ fi_allocinfo / fi_dupinfo \- Allocate / duplicate an fi_info structure
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fabric.h>
 
 int fi_getinfo(int version, const char *node, const char *service,
@@ -24,7 +24,7 @@ void fi_freeinfo(struct fi_info *info);
 struct fi_info *fi_allocinfo(void);
 
 struct fi_info *fi_dupinfo(const struct fi_info *info);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -111,7 +111,7 @@ a single fi_info structure and all the substructures within it.
 
 # FI_INFO
 
-{% highlight c %}
+```c
 struct fi_info {
 	struct fi_info        *next;
 	uint64_t              caps;
@@ -128,7 +128,7 @@ struct fi_info {
 	struct fi_domain_attr *domain_attr;
 	struct fi_fabric_attr *fabric_attr;
 };
-{% endhighlight %}
+```
 
 *next*
 : Pointer to the next fi_info structure in the list.  Will be NULL

--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -98,12 +98,12 @@ parameter is currently ignored.  The fi_open_ops function takes a
 `struct fi_gni_ops_domain` parameter and populates it with the
 following:
 
-{% highlight c %}
+```c
 struct fi_gni_ops_domain {
 	int (*set_val)(struct fid *fid, dom_ops_val_t t, void *val);
 	int (*get_val)(struct fid *fid, dom_ops_val_t t, void *val);
 };
-{% endhighlight %}
+```
 
 The `set_val` function sets the value of a given parameter; the
 `get_val` function returns the current value.  The currently supported

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -26,7 +26,7 @@ fi_mr_bind
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_domain.h>
 
 int fi_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
@@ -47,7 +47,7 @@ void * fi_mr_desc(struct fid_mr *mr);
 uint64_t fi_mr_key(struct fid_mr *mr);
 
 int fi_mr_bind(struct fid_mr *mr, struct fid *bfid, uint64_t flags);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -243,7 +243,7 @@ The fi_mr_regattr call is a more generic, extensible registration call
 that allows the user to specify the registration request using a
 struct fi_mr_attr.
 
-{% highlight c %}
+```c
 struct fi_mr_attr {
 	const struct iovec *mr_iov;       /* scatter-gather array */
 	size_t             iov_count;     /* # elements in mr_iov */
@@ -251,7 +251,7 @@ struct fi_mr_attr {
 	uint64_t           requested_key; /* requested remote key */
 	void               *context;      /* user-defined context */
 };
-{% endhighlight %}
+```
 
 ## fi_close
 

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -18,7 +18,7 @@ fi_inject / fi_senddata
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_endpoint.h>
 
 ssize_t fi_recv(struct fid_ep *ep, void * buf, size_t len,
@@ -47,7 +47,7 @@ ssize_t fi_senddata(struct fid_ep *ep, void *buf, size_t len,
 
 ssize_t fi_injectdata(struct fid_ep *ep, void *buf, size_t len,
 	uint64_t data, fi_addr_t dest_addr);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -139,7 +139,7 @@ unconnected endpoints, with the ability to control the send operation
 per call through the use of flags.  The fi_sendmsg function takes a
 `struct fi_msg` as input.
 
-{% highlight c %}
+```c
 struct fi_msg {
 	const struct iovec *msg_iov; /* scatter-gather array */
 	void               **desc;   /* local request descriptors */
@@ -148,7 +148,7 @@ struct fi_msg {
 	void               *context; /* user-defined context */
 	uint64_t           data;     /* optional message data */
 };
-{% endhighlight %}
+```
 
 ## fi_inject
 

--- a/man/fi_poll.3.md
+++ b/man/fi_poll.3.md
@@ -30,7 +30,7 @@ fi_control
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_domain.h>
 
 int fi_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
@@ -54,7 +54,7 @@ int fi_close(struct fid *waitset);
 int fi_wait(struct fid_wait *waitset, int timeout);
 
 int fi_control(struct fid *waitset, int command, void *arg);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -100,11 +100,11 @@ multiple completion queues and counters and checking for their completions.
 
 A poll set is defined with the following attributes.
 
-{% highlight c %}
+```c
 struct fi_poll_attr {
 	uint64_t             flags;     /* operation flags */
 };
-{% endhighlight %}
+```
 
 *flags*
 : Flags that set the default operation of the poll set.  The use of
@@ -146,12 +146,12 @@ associated completion queue or counter.
 The properties and behavior of a wait set are defined by struct
 fi_wait_attr.
 
-{% highlight c %}
+```c
 struct fi_wait_attr {
 	enum fi_wait_obj     wait_obj;  /* requested wait object */
 	uint64_t             flags;     /* operation flags */
 };
-{% endhighlight %}
+```
 
 *wait_obj*
 : Wait sets are associated with specific wait object(s).  Wait objects

--- a/man/fi_provider.7.md
+++ b/man/fi_provider.7.md
@@ -125,13 +125,13 @@ Logging is performed using the FI_ERR, FI_LOG, and FI_DEBUG macros.
 
 ## DEFINITIONS
 
-{% highlight c %}
+```c
 #define FI_ERR(prov_name, subsystem, ...)
 
 #define FI_LOG(prov_name, prov, level, subsystem, ...)
 
 #define FI_DEBUG(prov_name, subsystem, ...)
-{% endhighlight %}
+```
 
 ## ARGUMENTS
 *prov_name*

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -18,7 +18,7 @@ fi_inject_write / fi_writedata
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_rma.h>
 
 ssize_t fi_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
@@ -51,7 +51,7 @@ ssize_t fi_writedata(struct fid_ep *ep, const void *buf, size_t len,
 
 ssize_t fi_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
 	uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -155,7 +155,7 @@ unconnected endpoints, with the ability to control the write operation
 per call through the use of flags.  The fi_writemsg function takes a
 struct fi_msg_rma as input.
 
-{% highlight c %}
+```c
 struct fi_msg_rma {
 	const struct iovec *msg_iov;     /* local scatter-gather array */
 	void               **desc;       /* operation descriptor */
@@ -172,7 +172,7 @@ struct fi_rma_iov {
 	size_t             len;          /* size of target buffer */
 	uint64_t           key;          /* access key */
 };
-{% endhighlight %}
+```
 
 ## fi_inject_write
 

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -17,7 +17,7 @@ fi_tsend / fi_tsendv / fi_tsendmsg / fi_tinject / fi_tsenddata
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_tagged.h>
 
 ssize_t fi_trecv(struct fid_ep *ep, void *buf, size_t len, void *desc,
@@ -49,7 +49,7 @@ ssize_t fi_tsenddata(struct fid_ep *ep, const void *buf, size_t len,
 
 ssize_t fi_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
 	uint64_t data, fi_addr_t dest_addr, uint64_t tag);
-{% endhighlight %}
+```
 
 # ARGUMENTS
 
@@ -107,9 +107,9 @@ the incoming message with a corresponding receive buffer.  Message
 tags match when the receive buffer tag is the same as the send buffer
 tag with the ignored bits masked out.  This can be stated as:
 
-{% highlight c %}
+```c
 send_tag & ~ignore == recv_tag & ~ignore
-{% endhighlight %}
+```
 
 In general, message tags are checked against receive buffers in the
 order in which messages have been posted to the endpoint.  See the
@@ -160,7 +160,7 @@ unconnected endpoints, with the ability to control the send operation
 per call through the use of flags.  The fi_tsendmsg function takes a
 struct fi_msg_tagged as input.
 
-{% highlight c %}
+```c
 struct fi_msg_tagged {
 	const struct iovec *msg_iov; /* scatter-gather array */
 	void               *desc;    /* data descriptor */
@@ -171,7 +171,7 @@ struct fi_msg_tagged {
 	void               *context; /* user-defined context */
 	uint64_t           data;     /* optional immediate data */
 };
-{% endhighlight %}
+```
 
 ## fi_tinject
 

--- a/man/fi_trigger.3.md
+++ b/man/fi_trigger.3.md
@@ -11,9 +11,9 @@ fi_trigger - Triggered operations
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fi_trigger.h>
-{% endhighlight %}
+```
 
 # DESCRIPTION
 
@@ -48,7 +48,7 @@ condition is met when the request is made, then the data transfer may
 be initiated immediately.  The format of struct fi_triggered_context
 is described below.
 
-{% highlight c %}
+```c
 struct fi_triggered_context {
 	enum fi_trigger_event   event_type;   /* trigger type */
 	union {
@@ -56,7 +56,7 @@ struct fi_triggered_context {
 		void                *internal[3]; /* reserved */
 	} trigger;
 };
-{% endhighlight %}
+```
 
 The triggered context indicates the type of event assigned to the
 trigger, along with a union of trigger details that is based on the
@@ -72,12 +72,12 @@ The following trigger events are defined.
   value.  The threshold is specified using struct
   fi_trigger_threshold:
 
-{% highlight c %}
+```c
 struct fi_trigger_threshold {
 	struct fid_cntr *cntr; /* event counter to check */
 	size_t threshold;      /* threshold value */
 };
-{% endhighlight %}
+```
 
 Threshold operations are triggered in the order of the threshold
 values.  This is true even if the counter increments by a value

--- a/man/fi_usnic.7.md
+++ b/man/fi_usnic.7.md
@@ -81,7 +81,7 @@ extension, which returns IP and SR-IOV information about a usNIC
 interface obtained from the [`fi_getinfo`(3)](fi_getinfo.3.html)
 function.
 
-{% highlight c %}
+```c
 #include <stdio.h>
 #include <rdma/fabric.h>
 
@@ -145,7 +145,7 @@ int main(int argc, char *argv[]) {
     fi_freeinfo(info_list);
     return 0;
 }
-{% endhighlight %}
+```
 
 Note that other usnic extensions are defined for other fabric objects.
 The second argument to [`fi_open_ops`(3)](fi_open_ops.3.html) is used

--- a/man/fi_version.3.md
+++ b/man/fi_version.3.md
@@ -11,7 +11,7 @@ fi_version \- Version of the library interfaces
 
 # SYNOPSIS
 
-{% highlight c %}
+```c
 #include <rdma/fabric.h>
 
 uint32_t fi_version();
@@ -19,7 +19,7 @@ uint32_t fi_version();
 FI_MAJOR(version)
 
 FI_MINOR(version)
-{% endhighlight %}
+```
 
 # DESCRIPTION
 


### PR DESCRIPTION
No need for {% highlight %} any more -- you can use regular

```c
/* My C code */
```

markdown.  Yay!

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>