### PR TITLE
prov/{psm,psm2}: a few small bug fixes

### DIFF
--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -186,7 +186,8 @@ void psmx_domain_release(struct psmx_fid_domain *domain)
 	if (domain->progress_thread_enabled)
 		psmx_domain_stop_progress(domain);
 
-	psmx_am_fini(domain);
+	if (domain->am_initialized)
+		psmx_am_fini(domain);
 
 	fastlock_destroy(&domain->poll_lock);
 	rbtDelete(domain->mr_map);

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -187,7 +187,8 @@ void psmx2_domain_release(struct psmx2_fid_domain *domain)
 	if (domain->progress_thread_enabled)
 		psmx2_domain_stop_progress(domain);
 
-	psmx2_am_fini(domain);
+	if (domain->am_initialized)
+		psmx2_am_fini(domain);
 
 	fastlock_destroy(&domain->poll_lock);
 	fastlock_destroy(&domain->vl_lock);

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -35,7 +35,7 @@
 #define BIT(i)		(1ULL << i)
 #define BITMAP_SIZE	(PSMX2_MAX_VL + 1)
 
-static void inline bitmap_set(uint64_t *map, unsigned id)
+static inline void bitmap_set(uint64_t *map, unsigned id)
 {
 	int i, j;
 
@@ -45,7 +45,7 @@ static void inline bitmap_set(uint64_t *map, unsigned id)
 	map[i] |= BIT(j);
 }
 
-static void inline bitmap_clear(uint64_t *map, unsigned id)
+static inline void bitmap_clear(uint64_t *map, unsigned id)
 {
 	int i, j;
 
@@ -55,7 +55,7 @@ static void inline bitmap_clear(uint64_t *map, unsigned id)
 	map[i] &= ~BIT(j);
 }
 
-static int inline bitmap_test(uint64_t *map, unsigned id)
+static inline int bitmap_test(uint64_t *map, unsigned id)
 {
 	int i, j;
 


### PR DESCRIPTION
(1) compiler warning about "inline" keyword position;
(2) run-time assertion failure for debug build.