### PR TITLE
Separate fi.h into multiple include files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,7 @@ util_fi_info_LDADD = $(linkback)
 
 src_libfabric_la_SOURCES = \
 	include/fi.h \
+	include/fi_abi.h \
 	include/fi_atom.h \
 	include/fi_enosys.h \
 	include/fi_indexer.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,7 @@ src_libfabric_la_SOURCES = \
 	include/fi_abi.h \
 	include/fi_atom.h \
 	include/fi_enosys.h \
+	include/fi_file.h \
 	include/fi_indexer.h \
 	include/fi_list.h \
 	include/fi_lock.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -58,6 +58,7 @@ util_fi_info_LDADD = $(linkback)
 
 src_libfabric_la_SOURCES = \
 	include/fi.h \
+	include/fi_atom.h \
 	include/fi_enosys.h \
 	include/fi_indexer.h \
 	include/fi_list.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -61,6 +61,7 @@ src_libfabric_la_SOURCES = \
 	include/fi_enosys.h \
 	include/fi_indexer.h \
 	include/fi_list.h \
+	include/fi_lock.h \
 	include/fi_mem.h \
 	include/fi_osd.h \
 	include/fi_rbuf.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -62,6 +62,7 @@ src_libfabric_la_SOURCES = \
 	include/fi_indexer.h \
 	include/fi_list.h \
 	include/fi_mem.h \
+	include/fi_osd.h \
 	include/fi_rbuf.h \
 	include/fi_signal.h \
 	include/fi_util.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -61,10 +61,10 @@ src_libfabric_la_SOURCES = \
 	include/fi_enosys.h \
 	include/fi_indexer.h \
 	include/fi_list.h \
+	include/fi_mem.h \
 	include/fi_rbuf.h \
 	include/fi_signal.h \
 	include/fi_util.h \
-	include/fi_mem.h \
 	include/fasthash.h \
 	include/rbtree.h \
 	include/prov.h \

--- a/configure.ac
+++ b/configure.ac
@@ -91,10 +91,12 @@ AC_ARG_WITH([dlopen],
 		       [dl-loadable provider support @<:@default=yes@:>@]),
 	)
 
+if test "$freebsd" == "0"; then
 AS_IF([test x"$with_dlopen" != x"no"], [
 AC_CHECK_LIB(dl, dlopen, [],
     AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.]))
 ])
+fi
 
 dnl Checks for libraries
 AC_CHECK_LIB(pthread, pthread_mutex_init, [],

--- a/include/fi.h
+++ b/include/fi.h
@@ -45,6 +45,7 @@
 #include <fi_file.h>
 #include <fi_lock.h>
 #include <fi_atom.h>
+#include <fi_mem.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_prov.h>
@@ -57,26 +58,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#ifdef INCLUDE_VALGRIND
-#   include <valgrind/memcheck.h>
-#   ifndef VALGRIND_MAKE_MEM_DEFINED
-#      warning "Valgrind requested, but VALGRIND_MAKE_MEM_DEFINED undefined"
-#   endif
-#endif
-
-#ifndef VALGRIND_MAKE_MEM_DEFINED
-#   define VALGRIND_MAKE_MEM_DEFINED(addr, len)
-#endif
-
-static inline void *mem_dup(const void *src, size_t size)
-{
-	void *dest;
-
-	if ((dest = malloc(size)))
-		memcpy(dest, src, size);
-	return dest;
-}
 
 /*
  * OS X doesn't have __BYTE_ORDER, Linux usually has BYTE_ORDER but not under

--- a/include/fi.h
+++ b/include/fi.h
@@ -42,6 +42,7 @@
 #include <sys/param.h>
 
 #include <fi_abi.h>
+#include <fi_file.h>
 #include <fi_lock.h>
 #include <fi_atom.h>
 
@@ -174,9 +175,6 @@ static inline size_t fi_get_aligned_sz(size_t size, size_t alignment)
 #define FI_TAG_GENERIC	0xAAAAAAAAAAAAAAAAULL
 
 
-int fi_read_file(const char *dir, const char *file, char *buf, size_t size);
-int fi_poll_fd(int fd, int timeout);
-
 size_t fi_datatype_size(enum fi_datatype datatype);
 uint64_t fi_tag_bits(uint64_t mem_tag_format);
 uint64_t fi_tag_format(uint64_t tag_bits);
@@ -187,10 +185,6 @@ int fi_rma_initiate_allowed(uint64_t caps);
 int fi_rma_target_allowed(uint64_t caps);
 
 uint64_t fi_gettime_ms(void);
-int fi_fd_nonblock(int fd);
-
-#define RDMA_CONF_DIR  SYSCONFDIR "/" RDMADIR
-#define FI_CONF_DIR RDMA_CONF_DIR "/fabric"
 
 
 #ifdef __cplusplus

--- a/include/fi.h
+++ b/include/fi.h
@@ -46,13 +46,7 @@
 #include <rdma/fi_atomic.h>
 #include <rdma/fi_log.h>
 
-#ifdef __APPLE__
-#include <osx/osd.h>
-#elif defined __FreeBSD__
-#include <freebsd/osd.h>
-#else
-#include <linux/osd.h>
-#endif
+#include <fi_osd.h>
 
 #ifdef HAVE_ATOMICS
 #  include <stdatomic.h>

--- a/include/fi.h
+++ b/include/fi.h
@@ -41,6 +41,8 @@
 #include <string.h>
 #include <sys/param.h>
 
+#include <fi_lock.h>
+
 #include <rdma/fabric.h>
 #include <rdma/fi_prov.h>
 #include <rdma/fi_atomic.h>
@@ -171,88 +173,6 @@ static inline size_t fi_get_aligned_sz(size_t size, size_t alignment)
 }
 
 #define FI_TAG_GENERIC	0xAAAAAAAAAAAAAAAAULL
-
-
-#if PT_LOCK_SPIN == 1
-
-#define fastlock_t_ pthread_spinlock_t
-#define fastlock_init_(lock) pthread_spin_init(lock, PTHREAD_PROCESS_PRIVATE)
-#define fastlock_destroy_(lock) pthread_spin_destroy(lock)
-#define fastlock_acquire_(lock) pthread_spin_lock(lock)
-#define fastlock_tryacquire_(lock) pthread_spin_trylock(lock)
-#define fastlock_release_(lock) pthread_spin_unlock(lock)
-
-#else
-
-#define fastlock_t_ pthread_mutex_t
-#define fastlock_init_(lock) pthread_mutex_init(lock, NULL)
-#define fastlock_destroy_(lock) pthread_mutex_destroy(lock)
-#define fastlock_acquire_(lock) pthread_mutex_lock(lock)
-#define fastlock_tryacquire_(lock) pthread_mutex_trylock(lock)
-#define fastlock_release_(lock) pthread_mutex_unlock(lock)
-
-#endif /* PT_LOCK_SPIN */
-
-#if ENABLE_DEBUG
-
-typedef struct {
-	fastlock_t_ impl;
-	int is_initialized;
-} fastlock_t;
-
-static inline int fastlock_init(fastlock_t *lock)
-{
-	int ret;
-
-	ret = fastlock_init_(&lock->impl);
-	lock->is_initialized = !ret;
-	return ret;
-}
-
-static inline void fastlock_destroy(fastlock_t *lock)
-{
-	int ret;
-
-	assert(lock->is_initialized);
-	lock->is_initialized = 0;
-	ret = fastlock_destroy_(&lock->impl);
-	assert(!ret);
-}
-
-static inline void fastlock_acquire(fastlock_t *lock)
-{
-	int ret;
-
-	assert(lock->is_initialized);
-	ret = fastlock_acquire_(&lock->impl);
-	assert(!ret);
-}
-
-static inline int fastlock_tryacquire(fastlock_t *lock)
-{
-	assert(lock->is_initialized);
-	return fastlock_tryacquire_(&lock->impl);
-}
-
-static inline void fastlock_release(fastlock_t *lock)
-{
-	int ret;
-
-	assert(lock->is_initialized);
-	ret = fastlock_release_(&lock->impl);
-	assert(!ret);
-}
-
-#else /* !ENABLE_DEBUG */
-
-#  define fastlock_t fastlock_t_
-#  define fastlock_init(lock) fastlock_init_(lock)
-#  define fastlock_destroy(lock) fastlock_destroy_(lock)
-#  define fastlock_acquire(lock) fastlock_acquire_(lock)
-#  define fastlock_tryacquire(lock) fastlock_tryacquire_(lock)
-#  define fastlock_release(lock) fastlock_release_(lock)
-
-#endif
 
 
 #if ENABLE_DEBUG
@@ -403,7 +323,6 @@ static inline int atomic_sub(atomic_t *atomic, int val)
 /* non exported symbols */
 int fi_read_file(const char *dir, const char *file, char *buf, size_t size);
 int fi_poll_fd(int fd, int timeout);
-int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout);
 
 size_t fi_datatype_size(enum fi_datatype datatype);
 uint64_t fi_tag_bits(uint64_t mem_tag_format);

--- a/include/fi.h
+++ b/include/fi.h
@@ -41,6 +41,7 @@
 #include <string.h>
 #include <sys/param.h>
 
+#include <fi_abi.h>
 #include <fi_lock.h>
 #include <fi_atom.h>
 
@@ -191,31 +192,6 @@ int fi_fd_nonblock(int fd);
 #define RDMA_CONF_DIR  SYSCONFDIR "/" RDMADIR
 #define FI_CONF_DIR RDMA_CONF_DIR "/fabric"
 
-#define DEFAULT_ABI "FABRIC_1.0"
-
-#if  HAVE_ALIAS_ATTRIBUTE == 1
-#define DEFAULT_SYMVER_PRE(a) a##_
-#else
-#define DEFAULT_SYMVER_PRE(a) a
-#endif
-
-/* symbol -> external symbol mappings */
-#if HAVE_SYMVER_SUPPORT
-
-#  define SYMVER(name, api, ver) \
-        asm(".symver " #name "," #api "@" #ver)
-#  define DEFAULT_SYMVER(name, api) \
-        asm(".symver " #name "," #api "@@" DEFAULT_ABI)
-#else
-#  define SYMVER(Name, api, ver)
-#if  HAVE_ALIAS_ATTRIBUTE == 1
-#  define DEFAULT_SYMVER(name, api) \
-        extern typeof (name) api __attribute__((alias(#name)));
-#else
-#  define DEFAULT_SYMVER(name, api)
-#endif  /* HAVE_ALIAS_ATTRIBUTE == 1*/
-
-#endif /* HAVE_SYMVER_SUPPORT */
 
 #ifdef __cplusplus
 }

--- a/include/fi_abi.h
+++ b/include/fi_abi.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_ABI_H_
+#define _FI_ABI_H_
+
+#include "config.h"
+
+#include <fi_osd.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define DEFAULT_ABI "FABRIC_1.0"
+
+#if  HAVE_ALIAS_ATTRIBUTE == 1
+#define DEFAULT_SYMVER_PRE(a) a##_
+#else
+#define DEFAULT_SYMVER_PRE(a) a
+#endif
+
+/* symbol -> external symbol mappings */
+#if HAVE_SYMVER_SUPPORT
+
+#  define SYMVER(name, api, ver) \
+        asm(".symver " #name "," #api "@" #ver)
+#  define DEFAULT_SYMVER(name, api) \
+        asm(".symver " #name "," #api "@@" DEFAULT_ABI)
+#else
+#  define SYMVER(Name, api, ver)
+#if  HAVE_ALIAS_ATTRIBUTE == 1
+#  define DEFAULT_SYMVER(name, api) \
+        extern typeof (name) api __attribute__((alias(#name)));
+#else
+#  define DEFAULT_SYMVER(name, api)
+#endif  /* HAVE_ALIAS_ATTRIBUTE == 1*/
+
+#endif /* HAVE_SYMVER_SUPPORT */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FI_ABI_H_ */

--- a/include/fi_atom.h
+++ b/include/fi_atom.h
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_ATOM_H_
+#define _FI_ATOM_H_
+
+#include "config.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+#include <fi_lock.h>
+#include <fi_osd.h>
+
+#ifdef HAVE_ATOMICS
+#  include <stdatomic.h>
+#endif
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#if ENABLE_DEBUG
+#define ATOMIC_IS_INITIALIZED(atomic) assert(atomic->is_initialized)
+#else
+#define ATOMIC_IS_INITIALIZED(atomic)
+#endif
+
+#ifdef HAVE_ATOMICS
+typedef struct {
+    atomic_int val;
+#if ENABLE_DEBUG
+    int is_initialized;
+#endif
+} atomic_t;
+
+static inline int atomic_inc(atomic_t *atomic)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	return atomic_fetch_add_explicit(&atomic->val, 1, memory_order_acq_rel) + 1;
+}
+
+static inline int atomic_dec(atomic_t *atomic)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	return atomic_fetch_sub_explicit(&atomic->val, 1, memory_order_acq_rel) - 1;
+}
+
+static inline int atomic_set(atomic_t *atomic, int value)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	atomic_store(&atomic->val, value);
+	return value;
+}
+
+static inline int atomic_get(atomic_t *atomic)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	return atomic_load(&atomic->val);
+}
+
+/* avoid using "atomic_init" so we don't conflict with symbol/macro from stdatomic.h */
+static inline void atomic_initialize(atomic_t *atomic, int value)
+{
+	atomic_init(&atomic->val, value);
+#if ENABLE_DEBUG
+	atomic->is_initialized = 1;
+#endif
+}
+
+static inline int atomic_add(atomic_t *atomic, int val)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	return atomic_fetch_add_explicit(&atomic->val,
+			val, memory_order_acq_rel) + 1;
+}
+
+static inline int atomic_sub(atomic_t *atomic, int val)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	return atomic_fetch_sub_explicit(&atomic->val,
+			val, memory_order_acq_rel) - 1;
+}
+
+#else
+
+typedef struct {
+	fastlock_t lock;
+	int val;
+#if ENABLE_DEBUG
+	int is_initialized;
+#endif
+} atomic_t;
+
+static inline int atomic_inc(atomic_t *atomic)
+{
+	int v;
+
+	ATOMIC_IS_INITIALIZED(atomic);
+	fastlock_acquire(&atomic->lock);
+	v = ++(atomic->val);
+	fastlock_release(&atomic->lock);
+	return v;
+}
+
+static inline int atomic_dec(atomic_t *atomic)
+{
+	int v;
+
+	ATOMIC_IS_INITIALIZED(atomic);
+	fastlock_acquire(&atomic->lock);
+	v = --(atomic->val);
+	fastlock_release(&atomic->lock);
+	return v;
+}
+
+static inline int atomic_set(atomic_t *atomic, int value)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	fastlock_acquire(&atomic->lock);
+	atomic->val = value;
+	fastlock_release(&atomic->lock);
+	return value;
+}
+
+/* avoid using "atomic_init" so we don't conflict with symbol/macro from stdatomic.h */
+static inline void atomic_initialize(atomic_t *atomic, int value)
+{
+	fastlock_init(&atomic->lock);
+	atomic->val = value;
+#if ENABLE_DEBUG
+	atomic->is_initialized = 1;
+#endif
+}
+
+static inline int atomic_get(atomic_t *atomic)
+{
+	ATOMIC_IS_INITIALIZED(atomic);
+	return atomic->val;
+}
+
+static inline int atomic_add(atomic_t *atomic, int val)
+{
+	int v;
+
+	ATOMIC_IS_INITIALIZED(atomic);
+	fastlock_acquire(&atomic->lock);
+	atomic->val += val;
+	v = atomic->val;
+	fastlock_release(&atomic->lock);
+	return v;
+}
+
+static inline int atomic_sub(atomic_t *atomic, int val)
+{
+	int v;
+
+	ATOMIC_IS_INITIALIZED(atomic);
+	fastlock_acquire(&atomic->lock);
+	atomic->val -= val;
+	v = atomic->val;
+	fastlock_release(&atomic->lock);
+	return v;
+}
+
+#endif // HAVE_ATOMICS
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FI_ATOM_H_ */

--- a/include/fi_file.h
+++ b/include/fi_file.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_FILE_H_
+#define _FI_FILE_H_
+
+#include "config.h"
+
+#include <assert.h>
+#include <stdlib.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+int fi_read_file(const char *dir, const char *file, char *buf, size_t size);
+int fi_poll_fd(int fd, int timeout);
+int fi_fd_nonblock(int fd);
+
+#define RDMA_CONF_DIR  SYSCONFDIR "/" RDMADIR
+#define FI_CONF_DIR RDMA_CONF_DIR "/fabric"
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FI_FILE_H_ */

--- a/include/fi_list.h
+++ b/include/fi_list.h
@@ -31,19 +31,15 @@
  *
  */
 
-#if !defined(LIST_H)
-#define LIST_H
+#ifndef _FI_LIST_H_
+#define _FI_LIST_H_
 
 #include "config.h"
 
-#include <unistd.h>
-#include <errno.h>
-#include <fcntl.h>
+#include <sys/types.h>
+#include <stdlib.h>
 
-#include <rdma/fi_errno.h>
-
-#include "fi.h"
-#include "fi_signal.h"
+#include <fi_signal.h>
 
 
 /*
@@ -276,4 +272,4 @@ static inline int dlistfd_wait_avail(struct dlistfd_head *head, int timeout)
 	return ret ? ret : !dlistfd_empty(head);
 }
 
-#endif /* LIST_H */
+#endif /* _FI_LIST_H_ */

--- a/include/fi_lock.h
+++ b/include/fi_lock.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_LOCK_H_
+#define _FI_LOCK_H_
+
+#include "config.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdlib.h>
+
+#include <fi_osd.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout);
+
+
+#if PT_LOCK_SPIN == 1
+
+#define fastlock_t_ pthread_spinlock_t
+#define fastlock_init_(lock) pthread_spin_init(lock, PTHREAD_PROCESS_PRIVATE)
+#define fastlock_destroy_(lock) pthread_spin_destroy(lock)
+#define fastlock_acquire_(lock) pthread_spin_lock(lock)
+#define fastlock_tryacquire_(lock) pthread_spin_trylock(lock)
+#define fastlock_release_(lock) pthread_spin_unlock(lock)
+
+#else
+
+#define fastlock_t_ pthread_mutex_t
+#define fastlock_init_(lock) pthread_mutex_init(lock, NULL)
+#define fastlock_destroy_(lock) pthread_mutex_destroy(lock)
+#define fastlock_acquire_(lock) pthread_mutex_lock(lock)
+#define fastlock_tryacquire_(lock) pthread_mutex_trylock(lock)
+#define fastlock_release_(lock) pthread_mutex_unlock(lock)
+
+#endif /* PT_LOCK_SPIN */
+
+#if ENABLE_DEBUG
+
+typedef struct {
+	fastlock_t_ impl;
+	int is_initialized;
+} fastlock_t;
+
+static inline int fastlock_init(fastlock_t *lock)
+{
+	int ret;
+
+	ret = fastlock_init_(&lock->impl);
+	lock->is_initialized = !ret;
+	return ret;
+}
+
+static inline void fastlock_destroy(fastlock_t *lock)
+{
+	int ret;
+
+	assert(lock->is_initialized);
+	lock->is_initialized = 0;
+	ret = fastlock_destroy_(&lock->impl);
+	assert(!ret);
+}
+
+static inline void fastlock_acquire(fastlock_t *lock)
+{
+	int ret;
+
+	assert(lock->is_initialized);
+	ret = fastlock_acquire_(&lock->impl);
+	assert(!ret);
+}
+
+static inline int fastlock_tryacquire(fastlock_t *lock)
+{
+	assert(lock->is_initialized);
+	return fastlock_tryacquire_(&lock->impl);
+}
+
+static inline void fastlock_release(fastlock_t *lock)
+{
+	int ret;
+
+	assert(lock->is_initialized);
+	ret = fastlock_release_(&lock->impl);
+	assert(!ret);
+}
+
+#else /* !ENABLE_DEBUG */
+
+#  define fastlock_t fastlock_t_
+#  define fastlock_init(lock) fastlock_init_(lock)
+#  define fastlock_destroy(lock) fastlock_destroy_(lock)
+#  define fastlock_acquire(lock) fastlock_acquire_(lock)
+#  define fastlock_tryacquire(lock) fastlock_tryacquire_(lock)
+#  define fastlock_release(lock) fastlock_release_(lock)
+
+#endif
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FI_LOCK_H_ */

--- a/include/fi_mem.h
+++ b/include/fi_mem.h
@@ -30,20 +30,41 @@
  * SOFTWARE.
  */
 
-#if HAVE_CONFIG_H
-#  include <config.h>
-#endif /* HAVE_CONFIG_H */
-
-#include <fi.h>
-#include <fi_list.h>
-
 #ifndef _FI_MEM_H_
 #define _FI_MEM_H_
+
+#include <config.h>
+
+#include <assert.h>
+#include <stdlib.h>
+#include <fi_list.h>
+
+
+#ifdef INCLUDE_VALGRIND
+#   include <valgrind/memcheck.h>
+#   ifndef VALGRIND_MAKE_MEM_DEFINED
+#      warning "Valgrind requested, but VALGRIND_MAKE_MEM_DEFINED undefined"
+#   endif
+#endif
+
+#ifndef VALGRIND_MAKE_MEM_DEFINED
+#   define VALGRIND_MAKE_MEM_DEFINED(addr, len)
+#endif
+
+/* We implement memdup to avoid external library dependency */
+static inline void *mem_dup(const void *src, size_t size)
+{
+	void *dest;
+
+	if ((dest = malloc(size)))
+		memcpy(dest, src, size);
+	return dest;
+}
+
 
 /*
  * Buffer Pool
  */
-
 struct util_buf_pool {
 	size_t entry_sz;
 	size_t max_cnt;
@@ -74,4 +95,5 @@ void util_buf_pool_destroy(struct util_buf_pool *pool);
 void *util_buf_get(struct util_buf_pool *pool);
 void util_buf_release(struct util_buf_pool *pool, void *buf);
 
-#endif
+
+#endif /* _FI_MEM_H_ */

--- a/include/fi_osd.h
+++ b/include/fi_osd.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_OSD_H_
+#define _FI_OSD_H_
+
+#ifdef __APPLE__
+#include <osx/osd.h>
+#elif defined __FreeBSD__
+#include <freebsd/osd.h>
+#else
+#include <linux/osd.h>
+#endif
+
+#endif /* _FI_OSD_H_ */

--- a/include/fi_signal.h
+++ b/include/fi_signal.h
@@ -31,8 +31,8 @@
  *
  */
 
-#if !defined(FI_SIGNAL_H)
-#define FI_SIGNAL_H
+#ifndef _FI_SIGNAL_H_
+#define _FI_SIGNAL_H_
 
 #include "config.h"
 
@@ -42,9 +42,8 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
+#include <fi_file.h>
 #include <rdma/fi_errno.h>
-
-#include "fi.h"
 
 
 enum {
@@ -173,7 +172,6 @@ int fi_epoll_del(struct fi_epoll *ep, int fd);
 void *fi_epoll_wait(struct fi_epoll *ep, int timeout);
 void fi_epoll_close(struct fi_epoll *ep);
 
-#endif
+#endif /* HAVE_EPOLL */
 
-#endif /* FI_SIGNAL_H */
-
+#endif /* _FI_SIGNAL_H_ */

--- a/include/fi_signal.h
+++ b/include/fi_signal.h
@@ -39,6 +39,8 @@
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
 #include <rdma/fi_errno.h>
 

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -35,6 +35,8 @@
 #include <unistd.h>
 #include <fi_enosys.h>
 #include <fi_mem.h>
+#include <fi.h>
+
 
 static int util_buf_region_add(struct util_buf_pool *pool)
 {

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -63,7 +63,6 @@ int fi_check_cq_attr(const struct fi_provider *prov,
 		/* fall through */
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
-		break;
 		switch (attr->wait_cond) {
 		case FI_CQ_COND_NONE:
 		case FI_CQ_COND_THRESHOLD:


### PR DESCRIPTION
This series mostly takes the contents of fi.h and splits things out into distinct header files based on content.  This just makes it easier to find functionality, specifically for people new to the project who would not know where to look to see if specific functionality is already provided by the framework.

The series also includes one bug fix to the util code to remove an early break from a switch statement.