### PR TITLE
prov/gni: tone down a warning in gnix_mr.c

### DIFF
--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -449,7 +449,7 @@ static inline void __resolve_stale_entry_collision(
 	RbtIterator iter = found;
 	int add_new_entry = 1, cmp;
 
-	GNIX_WARN(FI_LOG_MR, "resolving collisions\n");
+	GNIX_INFO(FI_LOG_MR, "resolving collisions\n");
 
 	while (iter) {
 		rbtKeyValue(cache->stale.rb_tree, iter, (void **) &c_key,


### PR DESCRIPTION
Usually we use GNIX_WARN for when something bad is happening.
Move a GNIX_WARN to GNIX_INFO so that the console doesn't get
flooed with resolving collision messages when looking for
problems by setting FI_LOG_LEVEL to warn.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@a92b125ceeee2b799efe8ad7b98d219a4e81a9c1)
upstream merge of ofi-cray/libfabric-cray#644
@sungeunchoi 