### PR TITLE
prov/gni: fix an issue with datagram exchange

### DIFF
--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 Cray Inc.  All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-16 Los Alamos National Security, LLC.
+ *                       All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -427,6 +428,9 @@ int  _gnix_dgram_poll(struct gnix_dgram_hndl *hndl,
 						   &datagram_id);
 		if ((status != GNI_RC_SUCCESS) &&
 			(status  != GNI_RC_TIMEOUT)) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				"GNI_PostdataProbeWaitById returned %s\n",
+					gni_err_str[status]);
 			ret = gnixu_to_fi_errno(status);
 			goto err;
 		}
@@ -435,6 +439,9 @@ int  _gnix_dgram_poll(struct gnix_dgram_hndl *hndl,
 						   &datagram_id);
 		if ((status != GNI_RC_SUCCESS) &&
 			(status  != GNI_RC_NO_MATCH)) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				"GNI_PostdataProbeById returned %s\n",
+					gni_err_str[status]);
 			ret = gnixu_to_fi_errno(status);
 			goto err;
 		}


### PR DESCRIPTION
Turns out there was a difficult to hit edge case where
a vc could end up sending a datagram both for connect
request and connect request response(ack), resulting in
an error in connection setup at the target.

The problem was insufficient checking in the ack
progress function.  It needs to check whether or not
the vc has either already moved to connected state or
a GNI datagram for this vc setup has already been posted.

Add some additional GNIX_WARN's for various edge cases.
The warning statements helped in debugging this problem.

Fixes ofi-cray/libfabric-cray#599

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@bb9f53fd06d1695422d27872b59b29828af6d6ed)
upstream merge of ofi-cray/libfabric-cray#647
@sungeunchoi 