### PR TITLE
prov/gni: Free buffer in memory_registration_cache

### DIFF
--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -925,6 +925,8 @@ Test(memory_registration_cache, regression_615)
 
 	ret = fi_close(&f_mr->fid);
 	cr_assert(ret == FI_SUCCESS);
+
+	free(buffer);
 }
 
 


### PR DESCRIPTION
Fixes ofi-cray/libfabric-cray#615

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@03837ddbf2f6b4f3cf78b756fd6fbc434609278c)
upstream merge of ofi-cray/libfabric-cray#651
@sungeunchoi 