### PR TITLE
prov/gni: Remove unnecessary assert in

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -500,8 +500,6 @@ static ssize_t gnix_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 	if (_gnix_queue_peek(cq_priv->errors))
 		return -FI_EAVAIL;
 
-	assert(buf);
-
 	fastlock_acquire(&cq_priv->lock);
 
 	while (_gnix_queue_peek(cq_priv->events) && count--) {


### PR DESCRIPTION
gnix_cq_readfrom

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@916b778cf5e62e0251914163c2177a3807d82b25)
upstream merge of ofi-cray/libfabric-cray#655
@sungeunchoi 