### PR TITLE
prov/{psm,psm2}: coding style tweak for "else" statement

### DIFF
--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -467,8 +467,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			target_ep = mr->domain->atomics_ep;
 			if (op == FI_ATOMIC_READ) {
 				cntr = target_ep->remote_read_cntr;
-			}
-			else {
+			} else {
 				cntr = target_ep->remote_write_cntr;
 				mr_cntr = mr->cntr;
 			}
@@ -478,8 +477,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 
 			if (mr_cntr && mr_cntr != cntr)
 				psmx_cntr_inc(mr_cntr);
-		}
-		else {
+		} else {
 			tmp_buf = NULL;
 		}
 
@@ -523,8 +521,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 
 			if (mr_cntr && mr_cntr != cntr)
 				psmx_cntr_inc(mr_cntr);
-		}
-		else {
+		} else {
 			tmp_buf = NULL;
 		}
 
@@ -651,8 +648,7 @@ static int psmx_atomic_self(int am_cmd,
 			err = psmx_atomic_do_readwrite((void *)addr, (void *)buf,
 						       (void *)result, (int)datatype,
 						       (int)op, (int)count);
-		}
-		else {
+		} else {
 			tmp_buf = malloc(len);
 			if (tmp_buf) {
 				memcpy(tmp_buf, result, len);
@@ -661,8 +657,7 @@ static int psmx_atomic_self(int am_cmd,
 							       (int)op, (int)count);
 				memcpy(result, tmp_buf, len);
 				free(tmp_buf);
-			}
-			else {
+			} else {
 				err = -FI_ENOMEM;
 			}
 		}
@@ -677,8 +672,7 @@ static int psmx_atomic_self(int am_cmd,
 			err = psmx_atomic_do_compwrite((void *)addr, (void *)buf,
 						       (void *)compare, (void *)result,
 						       (int)datatype, (int)op, (int)count);
-		}
-		else {
+		} else {
 			tmp_buf = malloc(len);
 			if (tmp_buf) {
 				memcpy(tmp_buf, result, len);
@@ -687,8 +681,7 @@ static int psmx_atomic_self(int am_cmd,
 							       (int)datatype, (int)op, (int)count);
 				memcpy(result, tmp_buf, len);
 				free(tmp_buf);
-			}
-			else {
+			} else {
 				err = -FI_ENOMEM;
 			}
 		}
@@ -699,8 +692,7 @@ static int psmx_atomic_self(int am_cmd,
 	target_ep = mr->domain->atomics_ep;
 	if (op == FI_ATOMIC_READ) {
 		cntr = target_ep->remote_read_cntr;
-	}
-	else {
+	} else {
 		cntr = target_ep->remote_write_cntr;
 		mr_cntr = mr->cntr;
 	}
@@ -810,8 +802,7 @@ ssize_t _psmx_atomic_write(struct fid_ep *ep,
 			return -FI_EINVAL;
 
 		dest_addr = (fi_addr_t) av->psm_epaddrs[idx];
-	}
-	else if (!dest_addr) {
+	} else if (!dest_addr) {
 		return -FI_EINVAL;
 	}
 
@@ -835,8 +826,7 @@ ssize_t _psmx_atomic_write(struct fid_ep *ep,
 		memset((void *)req, 0, sizeof(*req));
 		memcpy((void *)req+sizeof(*req), (void *)buf, len);
 		buf = (void *)req + sizeof(*req);
-	}
-	else {
+	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;
@@ -999,8 +989,7 @@ ssize_t _psmx_atomic_readwrite(struct fid_ep *ep,
 			return -FI_EINVAL;
 
 		dest_addr = (fi_addr_t) av->psm_epaddrs[idx];
-	}
-	else if (!dest_addr) {
+	} else if (!dest_addr) {
 		return -FI_EINVAL;
 	}
 
@@ -1024,8 +1013,7 @@ ssize_t _psmx_atomic_readwrite(struct fid_ep *ep,
 		memset((void *)req, 0, sizeof(*req));
 		memcpy((void *)req+sizeof(*req), (void *)buf, len);
 		buf = (void *)req + sizeof(*req);
-	}
-	else {
+	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;
@@ -1098,8 +1086,7 @@ static ssize_t psmx_atomic_readwritemsg(struct fid_ep *ep,
 
 		buf = NULL;
 		count = resultv[0].count;
-	}
-	else {
+	} else {
 		if (msg->iov_count != 1 || !msg->msg_iov)
 			return -FI_EINVAL;
 
@@ -1207,8 +1194,7 @@ ssize_t _psmx_atomic_compwrite(struct fid_ep *ep,
 			return -FI_EINVAL;
 
 		dest_addr = (fi_addr_t) av->psm_epaddrs[idx];
-	}
-	else if (!dest_addr) {
+	} else if (!dest_addr) {
 		return -FI_EINVAL;
 	}
 
@@ -1235,8 +1221,7 @@ ssize_t _psmx_atomic_compwrite(struct fid_ep *ep,
 		memcpy((void *)req + sizeof(*req) + len, (void *)compare, len);
 		buf = (void *)req + sizeof(*req);
 		compare = buf + len;
-	}
-	else {
+	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;

--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -166,8 +166,7 @@ static int psmx_av_insert(struct fid_av *av, const void *addr, size_t count,
 				((psm_epaddr_t *) fi_addr)[i] = epconn.addr;
 			else
 				mask[i] = 1;
-		}
-		else {
+		} else {
 			mask[i] = 1;
 		}
 	}
@@ -184,8 +183,7 @@ static int psmx_av_insert(struct fid_av *av, const void *addr, size_t count,
 			psmx_set_epaddr_context(av_priv->domain,
 						((psm_epid_t *) addr)[i],
 						((psm_epaddr_t *) fi_addr)[i]);
-		}
-		else {
+		} else {
 			psm_epconn_t epconn;
 
 			/* If duplicated addresses are passed to psm_ep_connect(), all but one will fail
@@ -295,8 +293,7 @@ static int psmx_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 			return -FI_EINVAL;
 
 		epid = av_priv->psm_epids[idx];
-	}
-	else {
+	} else {
 		context = psm_epaddr_getctxt((void *)fi_addr);
 		epid = context->epid;
 	}

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -200,8 +200,7 @@ void psmx_cntr_check_trigger(struct psmx_fid_cntr *cntr)
 			fastlock_acquire(&domain->trigger_queue.lock);
 			slist_insert_tail(&trigger->list_entry, &domain->trigger_queue.list);
 			fastlock_release(&domain->trigger_queue.lock);
-		}
-		else {
+		} else {
 			psmx_process_trigger(domain, trigger);
 		}
 
@@ -310,8 +309,7 @@ static int psmx_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout
 					     timeout - msec_passed);
 			if (ret == -FI_ETIMEDOUT)
 				break;
-		}
-		else {
+		} else {
 			psmx_progress(cntr_priv->domain);
 		}
 

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -238,8 +238,7 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 	 */
 	if (event_in && count && !psm_status->error_code) {
 		event = event_in;
-	}
-	else {
+	} else {
 		event = psmx_cq_alloc_event(cq);
 		if (!event)
 			return NULL;
@@ -326,8 +325,7 @@ out:
 					*src_addr = FI_ADDR_NOTAVAIL;
 #endif
 			}
-		}
-		else {
+		} else {
 #if (PSM_VERNO_MAJOR >= 2)
 			event->source = (uint64_t) psm_status->msg_peer;
 #else
@@ -493,8 +491,7 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 						event_buffer = count ? event_buffer + cq->entry_size : NULL;
 						if (src_addr)
 							src_addr = count ? src_addr + 1 : NULL;
-					}
-					else {
+					} else {
 						psmx_cq_enqueue_event(mr->domain->rma_ep->recv_cq, event);
 						if (mr->domain->rma_ep->recv_cq == cq)
 							read_more = 0;
@@ -538,8 +535,7 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 					event_buffer = count ? event_buffer + cq->entry_size : NULL;
 					if (src_addr)
 						src_addr = count ? src_addr + 1 : NULL;
-				}
-				else {
+				} else {
 					psmx_cq_enqueue_event(tmp_cq, event);
 					if (tmp_cq == cq)
 						read_more = 0;
@@ -565,8 +561,7 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 						return psmx_errno(err);
 
 					PSMX_CTXT_REQ(fi_context) = psm_req;
-				}
-				else {
+				} else {
 					free(req);
 				}
 			}
@@ -575,12 +570,10 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 				continue;
 
 			return read_count;
-		}
-		else if (err == PSM_MQ_NO_COMPLETIONS) {
+		} else if (err == PSM_MQ_NO_COMPLETIONS) {
 			fastlock_release(&domain->poll_lock);
 			return read_count;
-		}
-		else {
+		} else {
 			fastlock_release(&domain->poll_lock);
 			return psmx_errno(err);
 		}
@@ -629,15 +622,13 @@ static ssize_t psmx_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 				if (src_addr)
 					src_addr++;
 				continue;
-			}
-			else {
+			} else {
 				cq_priv->pending_error = event;
 				if (!read_count)
 					read_count = -FI_EAVAIL;
 				break;
 			}
-		}
-		else {
+		} else {
 			break;
 		}
 	}
@@ -687,8 +678,7 @@ static ssize_t psmx_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 	if (event_count < threshold) {
 		if (cq_priv->wait) {
 			psmx_wait_wait((struct fid_wait *)cq_priv->wait, timeout);
-		}
-		else {
+		} else {
 			clock_gettime(CLOCK_REALTIME, &ts0);
 			while (1) {
 				if (psmx_cq_poll_mq(cq_priv, cq_priv->domain, NULL, 0, NULL))

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -163,8 +163,7 @@ static void psmx_domain_stop_progress(struct psmx_fid_domain *domain)
 		if (err) {
 			FI_INFO(&psmx_prov, FI_LOG_CORE,
 				"pthread_join returns %d\n", err);
-		}
-		else {
+		} else {
 			FI_INFO(&psmx_prov, FI_LOG_CORE,
 				"progress thread exited with code %ld (%s)\n",
 				(uintptr_t)exit_code,

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -39,32 +39,28 @@ static void psmx_ep_optimize_ops(struct psmx_fid_ep *ep)
 			ep->ep.tagged = &psmx_tagged_ops;
 			FI_INFO(&psmx_prov, FI_LOG_EP_DATA,
 				"generic tagged ops.\n");
-		}
-		else if (ep->send_selective_completion && ep->recv_selective_completion) {
+		} else if (ep->send_selective_completion && ep->recv_selective_completion) {
 			if (ep->av && ep->av->type == FI_AV_TABLE)
 				ep->ep.tagged = &psmx_tagged_ops_no_event_av_table;
 			else
 				ep->ep.tagged = &psmx_tagged_ops_no_event_av_map;
 			FI_INFO(&psmx_prov, FI_LOG_EP_DATA,
 				"tagged ops optimized for op_flags=0 and event suppression\n");
-		}
-		else if (ep->send_selective_completion) {
+		} else if (ep->send_selective_completion) {
 			if (ep->av && ep->av->type == FI_AV_TABLE)
 				ep->ep.tagged = &psmx_tagged_ops_no_send_event_av_table;
 			else
 				ep->ep.tagged = &psmx_tagged_ops_no_send_event_av_map;
 			FI_INFO(&psmx_prov, FI_LOG_EP_DATA,
 				"tagged ops optimized for op_flags=0 and send event suppression\n");
-		}
-		else if (ep->recv_selective_completion) {
+		} else if (ep->recv_selective_completion) {
 			if (ep->av && ep->av->type == FI_AV_TABLE)
 				ep->ep.tagged = &psmx_tagged_ops_no_recv_event_av_table;
 			else
 				ep->ep.tagged = &psmx_tagged_ops_no_recv_event_av_map;
 			FI_INFO(&psmx_prov, FI_LOG_EP_DATA,
 				"tagged ops optimized for op_flags=0 and recv event suppression\n");
-		}
-		else {
+		} else {
 			if (ep->av && ep->av->type == FI_AV_TABLE)
 				ep->ep.tagged = &psmx_tagged_ops_no_flag_av_table;
 			else

--- a/prov/psm/src/psmx_eq.c
+++ b/prov/psm/src/psmx_eq.c
@@ -242,8 +242,7 @@ static ssize_t psmx_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
 	if (eq_priv->wait) {
 		psmx_wait_wait((struct fid_wait *)eq_priv->wait, timeout);
 		ret = psmx_eq_read(eq, event, buf, len, flags);
-	}
-	else {
+	} else {
 		clock_gettime(CLOCK_REALTIME, &ts0);
 		while (1) {
 			ret = psmx_eq_read(eq, event, buf, len, flags);

--- a/prov/psm/src/psmx_fabric.c
+++ b/prov/psm/src/psmx_fabric.c
@@ -55,8 +55,7 @@ void psmx_fabric_release(struct psmx_fid_fabric *fabric)
 		if (ret) {
 			FI_INFO(&psmx_prov, FI_LOG_CORE,
 				"pthread_join returns %d\n", ret);
-		}
-		else {
+		} else {
 			FI_INFO(&psmx_prov, FI_LOG_CORE,
 				"name server thread exited with code %ld (%s)\n",
 				(uintptr_t)exit_code,

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -74,8 +74,7 @@ static int psmx_reserve_tag_bits(int *caps, uint64_t *max_tag_value)
 	if ((ret_caps & FI_MSG) && !psmx_env.am_msg) {
 		if (*max_tag_value < PSMX_MSG_BIT) {
 			reserved_bits |= PSMX_MSG_BIT;
-		}
-		else if (ask_caps) {
+		} else if (ask_caps) {
 			FI_INFO(&psmx_prov, FI_LOG_CORE,
 				"unable to reserve tag bit for FI_MSG support.\n"
 				"ADVICE: please reduce the asked max_tag_value, "
@@ -83,8 +82,7 @@ static int psmx_reserve_tag_bits(int *caps, uint64_t *max_tag_value)
 				"or set FI_PSM_AM_MSG=1 to use an alternative (but "
 				"less optimized) message queue implementation.\n");
 			return -1;
-		}
-		else {
+		} else {
 			FI_INFO(&psmx_prov, FI_LOG_CORE,
 				"unable to reserve tag bit for FI_MSG support. "
 				"FI_MSG is removed from the capabilities.\n"
@@ -98,16 +96,14 @@ static int psmx_reserve_tag_bits(int *caps, uint64_t *max_tag_value)
 	if ((ret_caps & FI_RMA) && psmx_env.tagged_rma) {
 		if (*max_tag_value < PSMX_RMA_BIT) {
 			reserved_bits |= PSMX_RMA_BIT;
-		}
-		else if (ask_caps) {
+		} else if (ask_caps) {
 			FI_INFO(&psmx_prov, FI_LOG_CORE,
 				"unable to reserve tag bit for tagged RMA acceleration.\n"
 				"ADVICE: please reduce the asked max_tag_value, or "
 				"remove FI_RMA from the asked capabilities, or set "
 				"FI_PSM_TAGGED_RMA=0 to disable RMA acceleration.\n");
 			return -1;
-		}
-		else {
+		} else {
 			FI_INFO(&psmx_prov, FI_LOG_CORE,
 				"unable to reserve tag bit for tagged RMA acceleration. "
 				"FI_RMA is removed from the capabilities.\n"
@@ -254,8 +250,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 					hints->mode, FI_CONTEXT);
 				goto err_out;
 			}
-		}
-		else {
+		} else {
 			mode = 0;
 		}
 

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -71,8 +71,7 @@ static int psmx_mr_reserve_key(struct psmx_fid_domain *domain,
 	if (domain->mr_mode == FI_MR_SCALABLE) {
 		key = requested_key;
 		try_count = 1;
-	}
-	else {
+	} else {
 		key = domain->mr_reserved_key;
 		try_count = 10000; /* large enough */
 	}
@@ -203,8 +202,7 @@ static void psmx_mr_normalize_iov(struct iovec *iov, size_t *count)
 				if (new_len > iov[i].iov_len)
 					iov[i].iov_len = new_len;
 				iov[j].iov_len = 0;
-			}
-			else {
+			} else {
 				break;
 			}
 		}

--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -87,8 +87,7 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 		epaddr_context = psm_epaddr_getctxt((void *)src_addr);
 		psm_tag = epaddr_context->epid | PSMX_MSG_BIT;
 		psm_tagsel = -1ULL;
-	}
-	else {
+	} else {
 		psm_tag = PSMX_MSG_BIT;
 		psm_tagsel = PSMX_MSG_BIT;
 		src_addr = 0;
@@ -96,8 +95,7 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 
 	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION)) {
 		fi_context = &ep_priv->nocomp_recv_context;
-	}
-	else {
+	} else {
 		if (!context)
 			return -FI_EINVAL;
 
@@ -119,8 +117,7 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 			req->context = fi_context; 
 			PSMX_CTXT_TYPE(fi_context) = PSMX_MULTI_RECV_CONTEXT;
 			PSMX_CTXT_USER(fi_context) = req;
-		}
-		else {
+		} else {
 			PSMX_CTXT_TYPE(fi_context) = PSMX_RECV_CONTEXT;
 			PSMX_CTXT_USER(fi_context) = buf;
 		}
@@ -169,12 +166,10 @@ static ssize_t psmx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_
 
 	if (msg->iov_count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -195,12 +190,10 @@ static ssize_t psmx_recvv(struct fid_ep *ep, const struct iovec *iov, void **des
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -269,8 +262,7 @@ ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 			return -FI_EINVAL;
 
 		psm_epaddr = av->psm_epaddrs[idx];
-	}
-	else  {
+	} else {
 		psm_epaddr = (psm_epaddr_t) dest_addr;
 	}
 
@@ -325,8 +317,7 @@ ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 
 	if (no_completion && !context) {
 		fi_context = &ep_priv->nocomp_send_context;
-	}
-	else {
+	} else {
 		if (!context)
 			return -FI_EINVAL;
 
@@ -377,12 +368,10 @@ static ssize_t psmx_sendmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_
 
 	if (msg->iov_count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -409,12 +398,10 @@ static ssize_t psmx_sendv(struct fid_ep *ep, const struct iovec *iov, void **des
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -177,13 +177,11 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				copy_len = MIN(len, req->recv.len);
 				memcpy(req->recv.buf, src, len);
 				req->recv.len_received += copy_len;
-			}
-			else {
+			} else {
 				unexp = malloc(sizeof(*unexp) + len);
 				if (!unexp) {
 					op_error = -FI_ENOSPC;
-				}
-				else  {
+				} else {
 					memcpy(unexp->buf, src, len);
 					unexp->sender_addr = epaddr;
 					unexp->sender_context = args[1].u64;
@@ -209,15 +207,13 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 						rep_args, 3, NULL, 0, 0,
 						NULL, NULL );
 			}
-		}
-		else {
+		} else {
 			req = (struct psmx_am_request *)(uintptr_t)args[2].u64;
 			if (req) {
 				copy_len = MIN(req->recv.len + offset, len);
 				memcpy(req->recv.buf + offset, src, copy_len);
 				req->recv.len_received += copy_len;
-			}
-			else {
+			} else {
 				FI_WARN(&psmx_prov, FI_LOG_EP_DATA,
 					"NULL recv_req in follow-up packets.\n");
 				op_error = -FI_ENOMSG;
@@ -271,8 +267,7 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			 * put the request into a queue and process it later.
 			 */
 			psmx_am_enqueue_send(req->ep->domain, req);
-		}
-		else { /* done */
+		} else { /* done */
 			if (req->ep->send_cq && !req->no_event) {
 				event = psmx_cq_create_event(
 						req->ep->send_cq,
@@ -376,8 +371,7 @@ static ssize_t _psmx_recv2(struct fid_ep *ep, void *buf, size_t len,
 
 			src_addr = (fi_addr_t)av->psm_epaddrs[idx];
 		}
-	}
-	else {
+	} else {
 		src_addr = 0;
 	}
 
@@ -410,8 +404,7 @@ static ssize_t _psmx_recv2(struct fid_ep *ep, void *buf, size_t len,
 
 	if (unexp->done) {
 		recv_done = 1;
-	}
-	else {
+	} else {
 		args[0].u32w0 = PSMX_AM_REP_SEND;
 		args[0].u32w1 = 0;
 		args[1].u64 = unexp->sender_context;
@@ -471,12 +464,10 @@ static ssize_t psmx_recvmsg2(struct fid_ep *ep, const struct fi_msg *msg,
 
 	if (msg->iov_count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -497,12 +488,10 @@ static ssize_t psmx_recvv2(struct fid_ep *ep, const struct iovec *iov,
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -535,8 +524,7 @@ static ssize_t _psmx_send2(struct fid_ep *ep, const void *buf, size_t len,
 			return -FI_EINVAL;
 
 		dest_addr = (fi_addr_t) av->psm_epaddrs[idx];
-	}
-	else if (!dest_addr) {
+	} else if (!dest_addr) {
 		return -FI_EINVAL;
 	}
 
@@ -595,12 +583,10 @@ static ssize_t psmx_sendmsg2(struct fid_ep *ep, const struct fi_msg *msg,
 
 	if (msg->iov_count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -621,12 +607,10 @@ static ssize_t psmx_sendv2(struct fid_ep *ep, const struct iovec *iov,
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -172,8 +172,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		req = calloc(1, sizeof(*req));
 		if (!req) {
 			err = -FI_ENOMEM;
-		}
-		else {
+		} else {
 			req->op = args[0].u32w0;
 			req->write.addr = (uint64_t)rma_addr;
 			req->write.len = rma_len;
@@ -200,8 +199,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			-FI_EINVAL;
 		if (!op_error) {
 			rma_addr += mr->offset;
-		}
-		else {
+		} else {
 			rma_addr = NULL;
 			rma_len = 0;
 		}
@@ -244,8 +242,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		req = calloc(1, sizeof(*req));
 		if (!req) {
 			err = -FI_ENOMEM;
-		}
-		else {
+		} else {
 			req->op = args[0].u32w0;
 			req->read.addr = (uint64_t)rma_addr;
 			req->read.len = rma_len;
@@ -375,8 +372,7 @@ static ssize_t psmx_rma_self(int am_cmd,
 				cq = mr->domain->rma_ep->recv_cq;
 			if (mr->cntr != cntr)
 				mr_cntr = mr->cntr;
-		}
-		else {
+		} else {
 			dst = buf;
 			src = (void *)addr;
 			cntr = mr->domain->rma_ep->remote_read_cntr;
@@ -469,8 +465,7 @@ int psmx_am_process_rma(struct psmx_fid_domain *domain, struct psmx_am_request *
 		err = psm_mq_irecv(domain->psm_mq, (uint64_t)req->write.context, -1ULL,
 				0, (void *)req->write.addr, req->write.len,
 				(void *)&req->fi_context, &psm_req);
-	}
-	else {
+	} else {
 		err = psm_mq_isend(domain->psm_mq, (psm_epaddr_t)req->read.peer_addr,
 				0, (uint64_t)req->read.context,
 				(void *)req->read.addr, req->read.len,
@@ -533,8 +528,7 @@ ssize_t _psmx_read(struct fid_ep *ep, void *buf, size_t len,
 			return -FI_EINVAL;
 
 		src_addr = (fi_addr_t) av->psm_epaddrs[idx];
-	}
-	else if (!src_addr) {
+	} else if (!src_addr) {
 		return -FI_EINVAL;
 	}
 
@@ -705,8 +699,7 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 			return -FI_EINVAL;
 
 		dest_addr = (fi_addr_t) av->psm_epaddrs[idx];
-	}
-	else if (!dest_addr) {
+	} else if (!dest_addr) {
 		return -FI_EINVAL;
 	}
 
@@ -730,8 +723,7 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 		memset((void *)req, 0, sizeof(*req));
 		memcpy((void *)req + sizeof(*req), (void *)buf, len);
 		buf = (void *)req + sizeof(*req);
-	}
-	else {
+	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;
@@ -777,8 +769,7 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 		if (flags & FI_DELIVERY_COMPLETE) {
 			args[0].u32w0 |= PSMX_AM_FORCE_ACK;
 			psm_context = NULL;
-		}
-		else {
+		} else {
 			psm_context = (void *)&req->fi_context;
 		}
 

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -73,12 +73,10 @@ ssize_t _psmx_tagged_peek(struct fid_ep *ep, void *buf, size_t len,
 				return -FI_EINVAL;
 
 			psm_src_addr = av->psm_epaddrs[idx];
-		}
-		else {
+		} else {
 			psm_src_addr = (psm_epaddr_t)src_addr;
 		}
-	}
-	else {
+	} else {
 		psm_src_addr = NULL;
 	}
 
@@ -245,8 +243,7 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 
 	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION)) {
 		fi_context = &ep_priv->nocomp_recv_context;
-	}
-	else {
+	} else {
 		if (!context)
 			return -FI_EINVAL;
 
@@ -266,8 +263,7 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 
 			src_addr = (fi_addr_t)av->psm_epaddrs[idx];
 		}
-	}
-	else {
+	} else {
 		src_addr = 0;
 	}
 
@@ -377,8 +373,7 @@ ssize_t psmx_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf,
 			return -FI_EINVAL;
 
 		psm_epaddr = av->psm_epaddrs[idx];
-	}
-	else {
+	} else {
 		psm_epaddr = NULL;
 	}
 
@@ -476,8 +471,7 @@ ssize_t psmx_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf,
 			return -FI_EINVAL;
 
 		psm_epaddr = av->psm_epaddrs[idx];
-	}
-	else {
+	} else {
 		psm_epaddr = NULL;
 	}
 
@@ -520,12 +514,10 @@ static ssize_t psmx_tagged_recvmsg(struct fid_ep *ep, const struct fi_msg_tagged
 
 	if (msg->iov_count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -568,12 +560,10 @@ static ssize_t psmx_tagged_recvv(struct fid_ep *ep, const struct iovec *iov, voi
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -594,12 +584,10 @@ static ssize_t psmx_tagged_recvv_no_flag(struct fid_ep *ep, const struct iovec *
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -621,12 +609,10 @@ static ssize_t psmx_tagged_recvv_no_event(struct fid_ep *ep, const struct iovec 
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -704,8 +690,7 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 			return -FI_EINVAL;
 
 		psm_epaddr = av->psm_epaddrs[idx];
-	}
-	else  {
+	} else {
 		psm_epaddr = (psm_epaddr_t) dest_addr;
 	}
 
@@ -759,8 +744,7 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 
 	if (no_completion && !context) {
 		fi_context = &ep_priv->nocomp_send_context;
-	}
-	else {
+	} else {
 		if (!context)
 			return -FI_EINVAL;
 
@@ -1074,12 +1058,10 @@ static ssize_t psmx_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged
 
 	if (msg->iov_count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -1106,12 +1088,10 @@ static ssize_t psmx_tagged_sendv(struct fid_ep *ep, const struct iovec *iov, voi
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -1133,12 +1113,10 @@ static ssize_t psmx_tagged_sendv_no_flag_av_map(struct fid_ep *ep, const struct 
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -1161,12 +1139,10 @@ static ssize_t psmx_tagged_sendv_no_flag_av_table(struct fid_ep *ep, const struc
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -1189,12 +1165,10 @@ static ssize_t psmx_tagged_sendv_no_event_av_map(struct fid_ep *ep, const struct
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -1217,12 +1191,10 @@ static ssize_t psmx_tagged_sendv_no_event_av_table(struct fid_ep *ep, const stru
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}

--- a/prov/psm/src/psmx_wait.c
+++ b/prov/psm/src/psmx_wait.c
@@ -214,8 +214,7 @@ static int psmx_wait_close(fid_t fid)
 	if (wait->type == FI_WAIT_FD) {
 		close(wait->fd[0]);
 		close(wait->fd[1]);
-	}
-	else if (wait->type == FI_WAIT_MUTEX_COND) {
+	} else if (wait->type == FI_WAIT_MUTEX_COND) {
 		pthread_mutex_destroy(&wait->mutex);
 		pthread_cond_destroy(&wait->cond);
 	}

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -467,8 +467,7 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 
 			if (op == FI_ATOMIC_READ) {
 				cntr = target_ep->remote_read_cntr;
-			}
-			else {
+			} else {
 				cntr = target_ep->remote_write_cntr;
 				mr_cntr = mr->cntr;
 			}
@@ -478,8 +477,7 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 
 			if (mr_cntr && mr_cntr != cntr)
 				psmx2_cntr_inc(mr_cntr);
-		}
-		else {
+		} else {
 			tmp_buf = NULL;
 		}
 
@@ -524,8 +522,7 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 
 			if (mr_cntr && mr_cntr != cntr)
 				psmx2_cntr_inc(mr_cntr);
-		}
-		else {
+		} else {
 			tmp_buf = NULL;
 		}
 
@@ -654,8 +651,7 @@ static int psmx2_atomic_self(int am_cmd,
 			err = psmx2_atomic_do_readwrite((void *)addr, (void *)buf,
 							(void *)result, (int)datatype,
 							(int)op, (int)count);
-		}
-		else {
+		} else {
 			tmp_buf = malloc(len);
 			if (tmp_buf) {
 				memcpy(tmp_buf, result, len);
@@ -664,8 +660,7 @@ static int psmx2_atomic_self(int am_cmd,
 								(int)op, (int)count);
 				memcpy(result, tmp_buf, len);
 				free(tmp_buf);
-			}
-			else {
+			} else {
 				err = -FI_ENOMEM;
 			}
 			
@@ -681,8 +676,7 @@ static int psmx2_atomic_self(int am_cmd,
 			err = psmx2_atomic_do_compwrite((void *)addr, (void *)buf,
 							(void *)compare, (void *)result,
 							(int)datatype, (int)op, (int)count);
-		}
-		else {
+		} else {
 			tmp_buf = malloc(len);
 			if (tmp_buf) {
 				memcpy(tmp_buf, result, len);
@@ -691,8 +685,7 @@ static int psmx2_atomic_self(int am_cmd,
 								(int)datatype, (int)op, (int)count);
 				memcpy(result, tmp_buf, len);
 				free(tmp_buf);
-			}
-			else {
+			} else {
 				err = -FI_ENOMEM;
 			}
 		}
@@ -702,8 +695,7 @@ static int psmx2_atomic_self(int am_cmd,
 
 	if (op == FI_ATOMIC_READ) {
 		cntr = target_ep->remote_read_cntr;
-	}
-	else {
+	} else {
 		cntr = target_ep->remote_write_cntr;
 		mr_cntr = mr->cntr;
 	}
@@ -816,8 +808,7 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
-	}
-	else {
+	} else {
 		 if (!dest_addr)
 			return -FI_EINVAL;
 
@@ -845,8 +836,7 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 		memset((void *)req, 0, sizeof(*req));
 		memcpy((void *)req+sizeof(*req), (void *)buf, len);
 		buf = (void *)req + sizeof(*req);
-	}
-	else {
+	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;
@@ -1013,8 +1003,7 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
-	}
-	else {
+	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
 
@@ -1042,8 +1031,7 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 		memset((void *)req, 0, sizeof(*req));
 		memcpy((void *)req+sizeof(*req), (void *)buf, len);
 		buf = (void *)req + sizeof(*req);
-	}
-	else {
+	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;
@@ -1117,8 +1105,7 @@ static ssize_t psmx2_atomic_readwritemsg(struct fid_ep *ep,
 
 		buf = NULL;
 		count = resultv[0].count;
-	}
-	else {
+	} else {
 		if (msg->iov_count != 1 || !msg->msg_iov)
 			return -FI_EINVAL;
 
@@ -1229,8 +1216,7 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
-	}
-	else {
+	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
 
@@ -1261,8 +1247,7 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 		memcpy((void *)req + sizeof(*req) + len, (void *)compare, len);
 		buf = (void *)req + sizeof(*req);
 		compare = buf + len;
-	}
-	else {
+	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -155,8 +155,7 @@ static int psmx2_av_connet_eps(struct psmx2_fid_av *av, size_t count,
 				epaddrs[i] = epconn.addr;
 			else
 				mask[i] = 1;
-		}
-		else {
+		} else {
 			mask[i] = 1;
 		}
 	}
@@ -171,8 +170,7 @@ static int psmx2_av_connet_eps(struct psmx2_fid_av *av, size_t count,
 		if (errors[i] == PSM2_OK ||
 		    errors[i] == PSM2_EPID_ALREADY_CONNECTED) {
 			psmx2_set_epaddr_context(av->domain, epids[i], epaddrs[i]);
-		}
-		else {
+		} else {
 			/* If duplicated addrs are passed to psm2_ep_connect(),
 			 * all but one will fail with error "Endpoint could not
 			 * be reached". This should be treated the same as
@@ -324,8 +322,7 @@ static int psmx2_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 
 		name.epid = av_priv->epids[idx];
 		name.vlane = av_priv->vlanes[idx];
-	}
-	else {
+	} else {
 		context = psm2_epaddr_getctxt((void *)fi_addr);
 		name.epid = context->epid;
 		name.vlane = PSMX2_ADDR_TO_VL(fi_addr);

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -194,8 +194,7 @@ void psmx2_cntr_check_trigger(struct psmx2_fid_cntr *cntr)
 			slist_insert_tail(&trigger->list_entry,
 					  &domain->trigger_queue.list);
 			fastlock_release(&domain->trigger_queue.lock);
-		}
-		else {
+		} else {
 			psmx2_process_trigger(domain, trigger);
 		}
 
@@ -305,8 +304,7 @@ static int psmx2_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeou
 					      timeout - msec_passed);
 			if (ret == -FI_ETIMEDOUT)
 				break;
-		}
-		else {
+		} else {
 			psmx2_progress(cntr_priv->domain);
 		}
 

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -245,8 +245,7 @@ psmx2_cq_create_event_from_status(struct psmx2_fid_cq *cq,
 	 */
 	if (event_in && count && !psm2_status->error_code) {
 		event = event_in;
-	}
-	else {
+	} else {
 		event = psmx2_cq_alloc_event(cq);
 		if (!event)
 			return NULL;
@@ -318,8 +317,7 @@ out:
 		if (event == event_in) {
 			if (src_addr)
 				*src_addr = source;
-		}
-		else {
+		} else {
 			event->source = source;
 		}
 	}
@@ -466,8 +464,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 						event_buffer = count ? event_buffer + cq->entry_size : NULL;
 						if (src_addr)
 							src_addr = count ? src_addr + 1 : NULL;
-					}
-					else {
+					} else {
 						psmx2_cq_enqueue_event(req->ep->recv_cq, event);
 						if (req->ep->recv_cq == cq)
 							read_more = 0;
@@ -568,8 +565,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					event_buffer = count ? event_buffer + cq->entry_size : NULL;
 					if (src_addr)
 						src_addr = count ? src_addr + 1 : NULL;
-				}
-				else {
+				} else {
 					psmx2_cq_enqueue_event(tmp_cq, event);
 					if (tmp_cq == cq)
 						read_more = 0;
@@ -596,8 +592,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 						return psmx2_errno(err);
 
 					PSMX2_CTXT_REQ(fi_context) = psm2_req;
-				}
-				else {
+				} else {
 					free(req);
 				}
 			}
@@ -606,12 +601,10 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				continue;
 
 			return read_count;
-		}
-		else if (err == PSM2_MQ_NO_COMPLETIONS) {
+		} else if (err == PSM2_MQ_NO_COMPLETIONS) {
 			fastlock_release(&domain->poll_lock);
 			return read_count;
-		}
-		else {
+		} else {
 			fastlock_release(&domain->poll_lock);
 			return psmx2_errno(err);
 		}
@@ -660,15 +653,13 @@ static ssize_t psmx2_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 				if (src_addr)
 					src_addr++;
 				continue;
-			}
-			else {
+			} else {
 				cq_priv->pending_error = event;
 				if (!read_count)
 					read_count = -FI_EAVAIL;
 				break;
 			}
-		}
-		else {
+		} else {
 			break;
 		}
 	}
@@ -718,8 +709,7 @@ static ssize_t psmx2_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 	if (event_count < threshold) {
 		if (cq_priv->wait) {
 			psmx2_wait_wait((struct fid_wait *)cq_priv->wait, timeout);
-		}
-		else {
+		} else {
 			clock_gettime(CLOCK_REALTIME, &ts0);
 			while (1) {
 				if (psmx2_cq_poll_mq(cq_priv, cq_priv->domain, NULL, 0, NULL))

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -164,8 +164,7 @@ static void psmx2_domain_stop_progress(struct psmx2_fid_domain *domain)
 		if (err) {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
 				"pthread_join returns %d\n", err);
-		}
-		else {
+		} else {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
 				"progress thread exited with code %ld (%s)\n",
 				(uintptr_t)exit_code,

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -102,32 +102,28 @@ static void psmx2_ep_optimize_ops(struct psmx2_fid_ep *ep)
 			ep->ep.tagged = &psmx2_tagged_ops;
 			FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
 				"generic tagged ops.\n");
-		}
-		else if (ep->send_selective_completion && ep->recv_selective_completion) {
+		} else if (ep->send_selective_completion && ep->recv_selective_completion) {
 			if (ep->av && ep->av->type == FI_AV_TABLE)
 				ep->ep.tagged = &psmx2_tagged_ops_no_event_av_table;
 			else
 				ep->ep.tagged = &psmx2_tagged_ops_no_event_av_map;
 			FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
 				"tagged ops optimized for op_flags=0 and event suppression\n");
-		}
-		else if (ep->send_selective_completion) {
+		} else if (ep->send_selective_completion) {
 			if (ep->av && ep->av->type == FI_AV_TABLE)
 				ep->ep.tagged = &psmx2_tagged_ops_no_send_event_av_table;
 			else
 				ep->ep.tagged = &psmx2_tagged_ops_no_send_event_av_map;
 			FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
 				"tagged ops optimized for op_flags=0 and send event suppression\n");
-		}
-		else if (ep->recv_selective_completion) {
+		} else if (ep->recv_selective_completion) {
 			if (ep->av && ep->av->type == FI_AV_TABLE)
 				ep->ep.tagged = &psmx2_tagged_ops_no_recv_event_av_table;
 			else
 				ep->ep.tagged = &psmx2_tagged_ops_no_recv_event_av_map;
 			FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
 				"tagged ops optimized for op_flags=0 and recv event suppression\n");
-		}
-		else {
+		} else {
 			if (ep->av && ep->av->type == FI_AV_TABLE)
 				ep->ep.tagged = &psmx2_tagged_ops_no_flag_av_table;
 			else

--- a/prov/psm2/src/psmx2_eq.c
+++ b/prov/psm2/src/psmx2_eq.c
@@ -247,8 +247,7 @@ static ssize_t psmx2_eq_sread(struct fid_eq *eq, uint32_t *event,
 	if (eq_priv->wait) {
 		psmx2_wait_wait((struct fid_wait *)eq_priv->wait, timeout);
 		ret = psmx2_eq_read(eq, event, buf, len, flags);
-	}
-	else {
+	} else {
 		clock_gettime(CLOCK_REALTIME, &ts0);
 		while (1) {
 			ret = psmx2_eq_read(eq, event, buf, len, flags);

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -55,8 +55,7 @@ void psmx2_fabric_release(struct psmx2_fid_fabric *fabric)
 		if (ret) {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
 				"pthread_join returns %d\n", ret);
-		}
-		else {
+		} else {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
 				"name server thread exited with code %ld (%s)\n",
 				(uintptr_t)exit_code,

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -197,8 +197,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 					hints->mode, FI_CONTEXT);
 				goto err_out;
 			}
-		}
-		else {
+		} else {
 			mode = 0;
 		}
 

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -73,8 +73,7 @@ static int psmx2_mr_reserve_key(struct psmx2_fid_domain *domain,
 	if (domain->mr_mode == FI_MR_SCALABLE) {
 		key = requested_key;
 		try_count = 1;
-	}
-	else {
+	} else {
 		key = domain->mr_reserved_key;
 		try_count = 10000; /* large enough */
 	}
@@ -206,8 +205,7 @@ static void psmx2_mr_normalize_iov(struct iovec *iov, size_t *count)
 				if (new_len > iov[i].iov_len)
 					iov[i].iov_len = new_len;
 				iov[j].iov_len = 0;
-			}
-			else {
+			} else {
 				break;
 			}
 		}

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -83,15 +83,13 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 
 			psm2_epaddr = av->epaddrs[idx];
 			vlane = av->vlanes[idx];
-		}
-		else {
+		} else {
 			psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
 			vlane = PSMX2_ADDR_TO_VL(src_addr);
 		}
 		tag32 = PSMX2_TAG32(PSMX2_MSG_BIT, vlane, ep_priv->vlane);
 		tagsel32 = ~PSMX2_IOV_BIT;
-	}
-	else {
+	} else {
 		psm2_epaddr = 0;
 		tag32 = PSMX2_TAG32(PSMX2_MSG_BIT, 0, ep_priv->vlane);
 		tagsel32 = ~(PSMX2_IOV_BIT | PSMX2_SRC_BITS);
@@ -106,8 +104,7 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
 		PSMX2_CTXT_USER(fi_context) = buf;
 		PSMX2_CTXT_SIZE(fi_context) = len;
-	}
-	else {
+	} else {
 		if (!context)
 			return -FI_EINVAL;
 
@@ -130,8 +127,7 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 			req->context = fi_context; 
 			PSMX2_CTXT_TYPE(fi_context) = PSMX2_MULTI_RECV_CONTEXT;
 			PSMX2_CTXT_USER(fi_context) = req;
-		}
-		else {
+		} else {
 			PSMX2_CTXT_TYPE(fi_context) = PSMX2_RECV_CONTEXT;
 			PSMX2_CTXT_USER(fi_context) = buf;
 		}
@@ -173,12 +169,10 @@ static ssize_t psmx2_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 
 	if (msg->iov_count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -200,12 +194,10 @@ static ssize_t psmx2_recvv(struct fid_ep *ep, const struct iovec *iov,
 
 	if (count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -267,8 +259,7 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
-	}
-	else  {
+	} else  {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
 		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
@@ -313,8 +304,7 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 
 	if (no_completion && !context) {
 		fi_context = &ep_priv->nocomp_send_context;
-	}
-	else {
+	} else {
 		if (!context)
 			return -FI_EINVAL;
 
@@ -413,8 +403,7 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 
 		tag32_base = PSMX2_MSG_BIT;
 		len = total_len;
-	}
-	else {
+	} else {
 		req->iov_protocol = PSMX2_IOV_PROTO_MULTI;
 		req->iov_done = 0;
 		req->iov_info.seq_num = (++ep_priv->iov_seq_num) %
@@ -442,8 +431,7 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
-	}
-	else  {
+	} else  {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
 		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
@@ -561,8 +549,7 @@ int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
 		recv_buf = recv_req->buf + recv_req->offset;
 		recv_len = recv_req->len - recv_req->offset;
 		rep->multi_recv = 1;
-	}
-	else {
+	} else {
 		recv_buf = PSMX2_CTXT_USER(recv_context);
 		recv_len = PSMX2_CTXT_SIZE(recv_context);
 		rep->multi_recv = 0;
@@ -607,8 +594,7 @@ int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
 			}
 			recv_buf += len;
 			recv_len -= len;
-		}
-		else {
+		} else {
 			/* recv buffer full, pust empty recvs */
 			err = psm2_mq_irecv2(ep->domain->psm2_mq,
 					     psm2_status->msg_peer,
@@ -650,12 +636,10 @@ static ssize_t psmx2_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 					   msg->iov_count, msg->addr,
 					   msg->context, flags,
 					   msg->data);
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -678,19 +662,16 @@ static ssize_t psmx2_sendv(struct fid_ep *ep, const struct iovec *iov,
 
 	if (count > PSMX2_IOV_MAX_COUNT) {
 		return -FI_EINVAL;
-	}
-	else if (count > 1) {
+	} else if (count > 1) {
 		struct psmx2_fid_ep *ep_priv;
 		ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 		return psmx2_sendv_generic(ep, iov, desc, count, dest_addr,
 					   context, ep_priv->flags, 0);
-	}
-	else if (count) {
+	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -173,8 +173,7 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 		req = calloc(1, sizeof(*req));
 		if (!req) {
 			err = -FI_ENOMEM;
-		}
-		else {
+		} else {
 			req->ep = ep;
 			req->op = args[0].u32w0;
 			req->write.addr = (uint64_t)rma_addr;
@@ -204,8 +203,7 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 			-FI_EINVAL;
 		if (!op_error) {
 			rma_addr += mr->offset;
-		}
-		else {
+		} else {
 			rma_addr = NULL;
 			rma_len = 0;
 		}
@@ -249,8 +247,7 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 		req = calloc(1, sizeof(*req));
 		if (!req) {
 			err = -FI_ENOMEM;
-		}
-		else {
+		} else {
 			req->ep = ep;
 			req->op = args[0].u32w0;
 			req->read.addr = (uint64_t)rma_addr;
@@ -384,8 +381,7 @@ static ssize_t psmx2_rma_self(int am_cmd,
 				cq = dst_ep->recv_cq;
 			if (mr->cntr != cntr)
 				mr_cntr = mr->cntr;
-		}
-		else {
+		} else {
 			dst = buf;
 			src = (void *)addr;
 			cntr = dst_ep->remote_read_cntr;
@@ -486,8 +482,7 @@ int psmx2_am_process_rma(struct psmx2_fid_domain *domain,
 				     &psm2_tag, &psm2_tagsel, 0,
 				     (void *)req->write.addr, req->write.len,
 				     (void *)&req->fi_context, &psm2_req);
-	}
-	else {
+	} else {
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, req->read.vl, req->read.peer_vl);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req->read.context, tag32);
 		err = psm2_mq_isend2(domain->psm2_mq,
@@ -558,8 +553,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
-	}
-	else {
+	} else {
 		if (!src_addr)
 			return -FI_EINVAL;
 
@@ -744,8 +738,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
-	}
-	else {
+	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
 
@@ -774,8 +767,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 		memset((void *)req, 0, sizeof(*req));
 		memcpy((void *)req + sizeof(*req), (void *)buf, len);
 		buf = (void *)req + sizeof(*req);
-	}
-	else {
+	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;
@@ -821,8 +813,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 		if (flags & FI_DELIVERY_COMPLETE) {
 			args[0].u32w0 |= PSMX2_AM_FORCE_ACK;
 			psm2_context = NULL;
-		}
-		else {
+		} else {
 			psm2_context = (void *)&req->fi_context;
 		}
 
@@ -858,8 +849,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 		PSMX2_AM_SET_FLAG(args[0].u32w0, PSMX2_AM_DATA | PSMX2_AM_EOM);
 		args[4].u64 = data;
 		nargs++;
-	}
-	else {
+	} else {
 		PSMX2_AM_SET_FLAG(args[0].u32w0, PSMX2_AM_EOM);
 	}
 	psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args, nargs,

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -61,15 +61,13 @@ static ssize_t psmx2_tagged_peek_generic(struct fid_ep *ep,
 
 			psm2_epaddr = av->epaddrs[idx];
 			vlane = av->vlanes[idx];
-		}
-		else {
+		} else {
 			psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
 			vlane = PSMX2_ADDR_TO_VL(src_addr);
 		}
 		tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
 		tagsel32 = -1;
-	}
-	else {
+	} else {
 		psm2_epaddr = 0;
 		tag32 = PSMX2_TAG32(0, 0, ep_priv->vlane);
 		tagsel32 = ~PSMX2_SRC_BITS;
@@ -213,8 +211,7 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 
 	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION)) {
 		fi_context = &ep_priv->nocomp_recv_context;
-	}
-	else {
+	} else {
 		if (!context)
 			return -FI_EINVAL;
 
@@ -233,15 +230,13 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 
 			psm2_epaddr = av->epaddrs[idx];
 			vlane = av->vlanes[idx];
-		}
-		else {
+		} else {
 			psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
 			vlane = PSMX2_ADDR_TO_VL(src_addr);
 		}
 		tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
 		tagsel32 = -1;
-	}
-	else {
+	} else {
 		psm2_epaddr = 0;
 		tag32 = PSMX2_TAG32(0, 0, ep_priv->vlane);
 		tagsel32 = ~PSMX2_SRC_BITS;
@@ -292,8 +287,7 @@ psmx2_tagged_recv_no_flag_av_map(struct fid_ep *ep, void *buf, size_t len,
 		vlane = PSMX2_ADDR_TO_VL(src_addr);
 		tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
 		tagsel32 = -1;
-	}
-	else {
+	} else {
 		psm2_epaddr = 0;
 		tag32 = PSMX2_TAG32(0, 0, ep_priv->vlane);
 		tagsel32 = ~PSMX2_SRC_BITS;
@@ -347,8 +341,7 @@ psmx2_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf, size_t len,
 		vlane = av->vlanes[idx];
 		tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
 		tagsel32 = -1;
-	}
-	else {
+	} else {
 		psm2_epaddr = 0;
 		tag32 = PSMX2_TAG32(0, 0, ep_priv->vlane);
 		tagsel32 = ~PSMX2_SRC_BITS;
@@ -392,8 +385,7 @@ psmx2_tagged_recv_no_event_av_map(struct fid_ep *ep, void *buf, size_t len,
 		vlane = PSMX2_ADDR_TO_VL(src_addr);
 		tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
 		tagsel32 = -1;
-	}
-	else {
+	} else {
 		psm2_epaddr = 0;
 		tag32 = PSMX2_TAG32(0, 0, ep_priv->vlane);
 		tagsel32 = ~PSMX2_SRC_BITS;
@@ -441,8 +433,7 @@ psmx2_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf, size_t len,
 		vlane = av->vlanes[idx];
 		tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
 		tagsel32 = -1;
-	}
-	else {
+	} else {
 		psm2_epaddr = 0;
 		tag32 = PSMX2_TAG32(0, 0, ep_priv->vlane);
 		tagsel32 = ~PSMX2_SRC_BITS;
@@ -482,12 +473,10 @@ static ssize_t psmx2_tagged_recvmsg(struct fid_ep *ep,
 
 	if (msg->iov_count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}
@@ -584,8 +573,7 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
-	}
-	else  {
+	} else {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
 		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
@@ -629,8 +617,7 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 
 	if (no_completion && !context) {
 		fi_context = &ep_priv->nocomp_send_context;
-	}
-	else {
+	} else {
 		if (!context)
 			return -FI_EINVAL;
 
@@ -917,12 +904,10 @@ static ssize_t psmx2_tagged_sendmsg(struct fid_ep *ep,
 
 	if (msg->iov_count > 1) {
 		return -FI_EINVAL;
-	}
-	else if (msg->iov_count) {
+	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
-	}
-	else {
+	} else {
 		buf = NULL;
 		len = 0;
 	}

--- a/prov/psm2/src/psmx2_wait.c
+++ b/prov/psm2/src/psmx2_wait.c
@@ -215,8 +215,7 @@ static int psmx2_wait_close(fid_t fid)
 	if (wait->type == FI_WAIT_FD) {
 		close(wait->fd[0]);
 		close(wait->fd[1]);
-	}
-	else if (wait->type == FI_WAIT_MUTEX_COND) {
+	} else if (wait->type == FI_WAIT_MUTEX_COND) {
 		pthread_mutex_destroy(&wait->mutex);
 		pthread_cond_destroy(&wait->cond);
 	}


### PR DESCRIPTION
Move 'else' to the same line as the preceding '}'.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>