### PR TITLE
prov/psm: remove the old PSM2 related code

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -71,33 +71,19 @@ extern "C" {
 
 extern struct fi_provider psmx_prov;
 
-#if (PSM_VERNO_MAJOR == 1)
 extern int psmx_am_compat_mode;
-#endif
 
 #define PSMX_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \
 			 FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)
 
-#if (PSM_VERNO_MAJOR >= 2)
-#define PSMX_CAP_EXT	(FI_REMOTE_CQ_DATA | FI_SOURCE)
-#else
-#define PSMX_CAP_EXT	(0)
-#endif
-
 #define PSMX_CAPS	(FI_TAGGED | FI_MSG | FI_ATOMICS | \
 			 FI_RMA | FI_MULTI_RECV | \
                          FI_READ | FI_WRITE | FI_SEND | FI_RECV | \
                          FI_REMOTE_READ | FI_REMOTE_WRITE | \
-			 FI_TRIGGER | \
-			 FI_RMA_EVENT | \
-			 PSMX_CAP_EXT)
+			 FI_TRIGGER | FI_RMA_EVENT)
 
-#if (PSM_VERNO_MAJOR >= 2)
-#define PSMX_CAPS2	(PSMX_CAPS | FI_DIRECTED_RECV)
-#else
 #define PSMX_CAPS2	((PSMX_CAPS | FI_DIRECTED_RECV) & ~FI_TAGGED)
-#endif
 
 #define PSMX_SUB_CAPS	(FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE | \
 			 FI_SEND | FI_RECV)
@@ -138,14 +124,6 @@ union psmx_pi {
 #define PSMX_CTXT_TYPE(fi_context)	(((union psmx_pi *)&(fi_context)->internal[1])->i)
 #define PSMX_CTXT_USER(fi_context)	((fi_context)->internal[2])
 #define PSMX_CTXT_EP(fi_context)	((fi_context)->internal[3])
-
-#if (PSM_VERNO_MAJOR >= 2)
-#define PSMX_SET_TAG(tag96,tag64,tag32)	do { \
-						tag96.tag0 = (uint32_t)tag64; \
-						tag96.tag1 = (uint32_t)(tag64>>32); \
-						tag96.tag2 = tag32; \
-					} while (0)
-#endif
 
 #define PSMX_AM_RMA_HANDLER	0
 #define PSMX_AM_MSG_HANDLER	1
@@ -414,9 +392,6 @@ struct psmx_trigger {
 			fi_addr_t	dest_addr;
 			void		*context;
 			uint64_t	flags;
-#if (PSM_VERNO_MAJOR >= 2)
-			uint32_t	data;
-#endif
 		} send;
 		struct {
 			struct fid_ep	*ep;
@@ -436,9 +411,6 @@ struct psmx_trigger {
 			uint64_t	tag;
 			void		*context;
 			uint64_t	flags;
-#if (PSM_VERNO_MAJOR >= 2)
-			uint32_t	data;
-#endif
 		} tsend;
 		struct {
 			struct fid_ep	*ep;
@@ -699,21 +671,12 @@ int	psmx_am_process_rma(struct psmx_fid_domain *domain,
 				struct psmx_am_request *req);
 int	psmx_process_trigger(struct psmx_fid_domain *domain,
 				struct psmx_trigger *trigger);
-#if (PSM_VERNO_MAJOR >= 2)
-int	psmx_am_msg_handler(psm_am_token_t token,
-				psm_amarg_t *args, int nargs, void *src, uint32_t len);
-int	psmx_am_rma_handler(psm_am_token_t token,
-				psm_amarg_t *args, int nargs, void *src, uint32_t len);
-int	psmx_am_atomic_handler(psm_am_token_t token,
-				psm_amarg_t *args, int nargs, void *src, uint32_t len);
-#else
 int	psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
 int	psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
 int	psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				psm_amarg_t *args, int nargs, void *src, uint32_t len);
-#endif
 void	psmx_atomic_init(void);
 void	psmx_atomic_fini(void);
 
@@ -741,27 +704,15 @@ static inline void psmx_progress(struct psmx_fid_domain *domain)
 	}
 }
 
-#if (PSM_VERNO_MAJOR >= 2)
-ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
-		   void *desc, fi_addr_t dest_addr, void *context,
-		   uint64_t flags, uint32_t data);
-#else
 ssize_t _psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 		   void *desc, fi_addr_t dest_addr, void *context,
 		   uint64_t flags);
-#endif
 ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 		   void *desc, fi_addr_t src_addr, void *context,
 		   uint64_t flags);
-#if (PSM_VERNO_MAJOR >= 2)
-ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
-			  void *desc, fi_addr_t dest_addr, uint64_t tag,
-			  void *context, uint64_t flags, uint32_t data);
-#else
 ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 			  void *desc, fi_addr_t dest_addr, uint64_t tag,
 			  void *context, uint64_t flags);
-#endif
 ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 			  void *desc, fi_addr_t src_addr, uint64_t tag,
 			  uint64_t ignore, void *context, uint64_t flags);

--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -43,8 +43,6 @@ static psm_am_handler_fn_t psmx_am_handlers[3] = {
 static int psmx_am_handlers_idx[3];
 static int psmx_am_handlers_initialized = 0;
 
-#if (PSM_VERNO_MAJOR == 1)
-
 /* The AM handler signature is different between PSM1 and PSM2. The compat
  * handlers are used when compiled with PSM1 headers and run over the
  * psm2-compat library.
@@ -79,7 +77,6 @@ static int psmx_am_compat_atomic_handler(psm_am_token_t token,
 	(*psmx_am_get_source)(token, &epaddr);
 	return psmx_am_atomic_handler(token, epaddr, args, nargs, src, len);
 }
-#endif
 
 int psmx_am_progress(struct psmx_fid_domain *domain)
 {
@@ -140,7 +137,6 @@ int psmx_am_init(struct psmx_fid_domain *domain)
 		if (err)
 			return psmx_errno(err);
 
-#if (PSM_VERNO_MAJOR == 1)
 		if (psmx_am_compat_mode) {
 			void *dlsym(void*, const char *);
 			psmx_am_get_source = dlsym(NULL, "psm2_am_get_source");
@@ -154,7 +150,6 @@ int psmx_am_init(struct psmx_fid_domain *domain)
 			psmx_am_handlers[1] = (void *)psmx_am_compat_msg_handler;
 			psmx_am_handlers[2] = (void *)psmx_am_compat_atomic_handler;
 		}
-#endif
 
 		err = psm_am_register_handlers(psm_ep, psmx_am_handlers, 3,
 						psmx_am_handlers_idx);

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -371,15 +371,9 @@ static void psmx_am_atomic_completion(void *buf)
 		free(buf);
 }
 
-#if (PSM_VERNO_MAJOR >= 2)
-int psmx_am_atomic_handler(psm_am_token_t token,
-			   psm_amarg_t *args, int nargs, void *src,
-			   uint32_t len)
-#else
 int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			   psm_amarg_t *args, int nargs, void *src,
 			   uint32_t len)
-#endif
 {
 	psm_amarg_t rep_args[8];
 	int count;
@@ -395,11 +389,6 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	struct psmx_fid_cntr *cntr = NULL;
 	struct psmx_fid_cntr *mr_cntr = NULL;
 	void *tmp_buf;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_epaddr_t epaddr;
-
-	psm_am_get_source(token, &epaddr);
-#endif
 
 	switch (args[0].u32w0 & PSMX_AM_OP_MASK) {
 	case PSMX_AM_REQ_ATOMIC_WRITE:

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -36,16 +36,6 @@ int psmx_process_trigger(struct psmx_fid_domain *domain, struct psmx_trigger *tr
 {
 	switch (trigger->op) {
 	case PSMX_TRIGGERED_SEND:
-#if (PSM_VERNO_MAJOR >= 2)
-		_psmx_send(trigger->send.ep,
-			   trigger->send.buf,
-			   trigger->send.len,
-			   trigger->send.desc,
-			   trigger->send.dest_addr,
-			   trigger->send.context,
-			   trigger->send.flags,
-			   trigger->send.data);
-#else
 		_psmx_send(trigger->send.ep,
 			   trigger->send.buf,
 			   trigger->send.len,
@@ -53,7 +43,6 @@ int psmx_process_trigger(struct psmx_fid_domain *domain, struct psmx_trigger *tr
 			   trigger->send.dest_addr,
 			   trigger->send.context,
 			   trigger->send.flags);
-#endif
 		break;
 	case PSMX_TRIGGERED_RECV:
 		_psmx_recv(trigger->recv.ep,
@@ -65,17 +54,6 @@ int psmx_process_trigger(struct psmx_fid_domain *domain, struct psmx_trigger *tr
 			   trigger->recv.flags);
 		break;
 	case PSMX_TRIGGERED_TSEND:
-#if (PSM_VERNO_MAJOR >= 2)
-			_psmx_tagged_send(trigger->tsend.ep,
-					  trigger->tsend.buf,
-					  trigger->tsend.len,
-					  trigger->tsend.desc,
-					  trigger->tsend.dest_addr,
-					  trigger->tsend.tag,
-					  trigger->tsend.context,
-					  trigger->tsend.flags,
-					  trigger->tsend.data);
-#else
 		_psmx_tagged_send(trigger->tsend.ep,
 				  trigger->tsend.buf,
 				  trigger->tsend.len,
@@ -84,7 +62,6 @@ int psmx_process_trigger(struct psmx_fid_domain *domain, struct psmx_trigger *tr
 				  trigger->tsend.tag,
 				  trigger->tsend.context,
 				  trigger->tsend.flags);
-#endif
 		break;
 	case PSMX_TRIGGERED_TRECV:
 		_psmx_tagged_recv(trigger->trecv.ep,

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -149,15 +149,6 @@ out:
 	return event;
 }
 
-#if (PSM_VERNO_MAJOR >= 2)
-static struct psmx_cq_event *psmx_cq_create_event_from_status(
-				struct psmx_fid_cq *cq,
-				psm_mq_status2_t *psm_status,
-				uint64_t data,
-				struct psmx_cq_event *event_in,
-				int count,
-				fi_addr_t *src_addr)
-#else
 static struct psmx_cq_event *psmx_cq_create_event_from_status(
 				struct psmx_fid_cq *cq,
 				psm_mq_status_t *psm_status,
@@ -165,7 +156,6 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 				struct psmx_cq_event *event_in,
 				int count,
 				fi_addr_t *src_addr)
-#endif
 {
 	struct psmx_cq_event *event;
 	struct psmx_multi_recv *req;
@@ -251,11 +241,7 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 		event->cqe.err.flags = flags;
 		event->cqe.err.err = -psmx_errno(psm_status->error_code);
 		event->cqe.err.prov_errno = psm_status->error_code;
-#if (PSM_VERNO_MAJOR >= 2)
-		event->cqe.err.tag = psm_status->msg_tag.tag0 | (((uint64_t)psm_status->msg_tag.tag1) << 32);
-#else
 		event->cqe.err.tag = psm_status->msg_tag;
-#endif
 		event->cqe.err.olen = psm_status->msg_length - psm_status->nbytes;
 		if (data)
 			event->cqe.err.data = data;
@@ -278,9 +264,6 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 		event->cqe.data.buf = buf;
 		event->cqe.data.flags = flags;
 		event->cqe.data.len = psm_status->nbytes;
-#if (PSM_VERNO_MAJOR >= 2)
-		event->cqe.data.data = psm_status->msg_tag.tag2;
-#endif
 		if (data)
 			event->cqe.data.data = data;
 		break;
@@ -290,12 +273,7 @@ static struct psmx_cq_event *psmx_cq_create_event_from_status(
 		event->cqe.tagged.buf = buf;
 		event->cqe.tagged.flags = flags;
 		event->cqe.tagged.len = psm_status->nbytes;
-#if (PSM_VERNO_MAJOR >= 2)
-		event->cqe.data.data = psm_status->msg_tag.tag2;
-		event->cqe.tagged.tag = psm_status->msg_tag.tag0 | (((uint64_t)psm_status->msg_tag.tag1) << 32);
-#else
 		event->cqe.tagged.tag = psm_status->msg_tag;
-#endif
 		if (data)
 			event->cqe.tagged.data = data;
 		break;
@@ -312,9 +290,6 @@ out:
 	if (is_recv) {
 		if (event == event_in) {
 			if (src_addr) {
-#if (PSM_VERNO_MAJOR >= 2)
-				*src_addr = (fi_addr_t) psm_status->msg_peer;
-#else
 				int err = -FI_ENODATA;
 				if (cq->domain->reserved_tag_bits & PSMX_MSG_BIT & psm_status->msg_tag) {
 					err = psmx_epid_to_epaddr(cq->domain,
@@ -323,14 +298,9 @@ out:
 				}
 				if (err)
 					*src_addr = FI_ADDR_NOTAVAIL;
-#endif
 			}
 		} else {
-#if (PSM_VERNO_MAJOR >= 2)
-			event->source = (uint64_t) psm_status->msg_peer;
-#else
 			event->source = psm_status->msg_tag;
-#endif
 		}
 	}
 
@@ -341,16 +311,11 @@ static int psmx_cq_get_event_src_addr(struct psmx_fid_cq *cq,
 				      struct psmx_cq_event *event,
 				      fi_addr_t *src_addr)
 {
-#if (PSM_VERNO_MAJOR < 2)
 	int err;
-#endif
 
 	if (!src_addr)
 		return 0;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	*src_addr = (fi_addr_t) event->source;
-#else
 	if ((cq->domain->reserved_tag_bits & PSMX_MSG_BIT) &&
 		(event->source & PSMX_MSG_BIT)) {
 		err = psmx_epid_to_epaddr(cq->domain,
@@ -361,7 +326,6 @@ static int psmx_cq_get_event_src_addr(struct psmx_fid_cq *cq,
 
 		return 0;
 	}
-#endif
 
 	return -FI_ENODATA;
 }
@@ -370,11 +334,7 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 		    struct psmx_cq_event *event_in, int count, fi_addr_t *src_addr)
 {
 	psm_mq_req_t psm_req;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_status2_t psm_status;
-#else
 	psm_mq_status_t psm_status;
-#endif
 	struct fi_context *fi_context;
 	struct psmx_fid_ep *tmp_ep;
 	struct psmx_fid_cq *tmp_cq;
@@ -400,11 +360,7 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 		err = psm_mq_ipeek(domain->psm_mq, &psm_req, NULL);
 
 		if (err == PSM_OK) {
-#if (PSM_VERNO_MAJOR >= 2)
-			err = psm_mq_test2(&psm_req, &psm_status);
-#else
 			err = psm_mq_test(&psm_req, &psm_status);
-#endif
 			fastlock_release(&domain->poll_lock);
 
 			fi_context = psm_status.context;

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -74,11 +74,7 @@ static void psmx_ep_optimize_ops(struct psmx_fid_ep *ep)
 static ssize_t psmx_ep_cancel(fid_t fid, void *context)
 {
 	struct psmx_fid_ep *ep;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_status2_t status;
-#else
 	psm_mq_status_t status;
-#endif
 	struct fi_context *fi_context = context;
 	uint64_t flags;
 	struct psmx_cq_event *event;
@@ -105,11 +101,7 @@ static ssize_t psmx_ep_cancel(fid_t fid, void *context)
 
 	err = psm_mq_cancel((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context));
 	if (err == PSM_OK) {
-#if (PSM_VERNO_MAJOR >= 2)
-		err = psm_mq_test2((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context), &status);
-#else
 		err = psm_mq_test((psm_mq_req_t *)&PSMX_CTXT_REQ(fi_context), &status);
-#endif
 		if (err == PSM_OK && ep->recv_cq) {
 			event = psmx_cq_create_event(
 					ep->recv_cq,

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -605,14 +605,12 @@ PROVIDER_INI
 	FI_INFO(&psmx_prov, FI_LOG_CORE,
 		"PSM library version = (%d, %d)\n", major, minor);
 
-#if (PSM_VERNO_MAJOR == 1)
 	if (major != PSM_VERNO_MAJOR) {
 		psmx_am_compat_mode = 1;
 		FI_INFO(&psmx_prov, FI_LOG_CORE,
 			"PSM AM compat mode enabled: appliation %d.%d, library %d.%d.\n",
 			PSM_VERNO_MAJOR, PSM_VERNO_MINOR, major, minor);
 	}
-#endif
 
 	psmx_init_count++;
 	return (&psmx_prov);

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -129,13 +129,8 @@ static struct psmx_unexp *psmx_am_search_and_dequeue_unexp(
  *	args[2].u64	recv_req
  */
 
-#if (PSM_VERNO_MAJOR >= 2)
-int psmx_am_msg_handler(psm_am_token_t token,
-			psm_amarg_t *args, int nargs, void *src, uint32_t len)
-#else
 int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			psm_amarg_t *args, int nargs, void *src, uint32_t len)
-#endif
 {
         psm_amarg_t rep_args[8];
         struct psmx_am_request *req;
@@ -148,11 +143,6 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	int err = 0;
 	int op_error = 0;
 	struct psmx_unexp *unexp;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_epaddr_t epaddr;
-
-	psm_am_get_source(token, &epaddr);
-#endif
 
 	epaddr_context = psm_epaddr_getctxt(epaddr);
 	if (!epaddr_context) {

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -71,13 +71,8 @@ static inline void psmx_am_enqueue_rma(struct psmx_fid_domain *domain,
  *	args[2].u64	offset
  */
 
-#if (PSM_VERNO_MAJOR >= 2)
-int psmx_am_rma_handler(psm_am_token_t token,
-			psm_amarg_t *args, int nargs, void *src, uint32_t len)
-#else
 int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			psm_amarg_t *args, int nargs, void *src, uint32_t len)
-#endif
 {
 	psm_amarg_t rep_args[8];
 	void *rma_addr;
@@ -90,11 +85,6 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	struct psmx_cq_event *event;
 	uint64_t offset;
 	struct psmx_fid_mr *mr;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_epaddr_t epaddr;
-
-	psm_am_get_source(token, &epaddr);
-#endif
 
 	cmd = args[0].u32w0 & PSMX_AM_OP_MASK;
 	eom = args[0].u32w0 & PSMX_AM_EOM;

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -38,16 +38,7 @@ ssize_t _psmx_tagged_peek(struct fid_ep *ep, void *buf, size_t len,
 			  void *context, uint64_t flags)
 {
 	struct psmx_fid_ep *ep_priv;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_status2_t psm_status2;
-	psm_mq_tag_t psm_tag2, psm_tagsel2;
-	psm_mq_req_t req;
-	struct psmx_fid_av *av;
-	size_t idx;
-	psm_epaddr_t psm_src_addr;
-#else
 	psm_mq_status_t psm_status;
-#endif
 	uint64_t psm_tag, psm_tagsel;
 	struct psmx_cq_event *event;
 	int err;
@@ -64,57 +55,18 @@ ssize_t _psmx_tagged_peek(struct fid_ep *ep, void *buf, size_t len,
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
 	psm_tagsel = (~ignore) | ep_priv->domain->reserved_tag_bits;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	if (src_addr != FI_ADDR_UNSPEC) {
-		av = ep_priv->av;
-		if (av && av->type == FI_AV_TABLE) {
-			idx = (size_t)src_addr;
-			if (idx >= av->last)
-				return -FI_EINVAL;
-
-			psm_src_addr = av->psm_epaddrs[idx];
-		} else {
-			psm_src_addr = (psm_epaddr_t)src_addr;
-		}
-	} else {
-		psm_src_addr = NULL;
-	}
-
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
-
-	if (flags & (FI_CLAIM | FI_DISCARD))
-		err = psm_mq_improbe2(ep_priv->domain->psm_mq,
-				      psm_src_addr,
-				      &psm_tag2, &psm_tagsel2,
-				      &req, &psm_status2);
-	else
-		err = psm_mq_iprobe2(ep_priv->domain->psm_mq,
-				     psm_src_addr,
-				     &psm_tag2, &psm_tagsel2,
-				     &psm_status2);
-#else
 	if (flags & (FI_CLAIM | FI_DISCARD))
 		return -FI_EOPNOTSUPP;
 
 	err = psm_mq_iprobe(ep_priv->domain->psm_mq, psm_tag, psm_tagsel,
 			    &psm_status);
-#endif
+
 	switch (err) {
 	case PSM_OK:
 		if (ep_priv->recv_cq) {
-#if (PSM_VERNO_MAJOR >= 2)
-			if ((flags & FI_CLAIM) && context)
-				PSMX_CTXT_REQ((struct fi_context *)context) = req;
-
-			tag = psm_status2.msg_tag.tag0 | (((uint64_t)psm_status2.msg_tag.tag1) << 32);
-			len = psm_status2.msg_length;
-			src_addr = (fi_addr_t)psm_status2.msg_peer;
-#else
 			tag = psm_status.msg_tag;
 			len = psm_status.msg_length;
 			src_addr = 0;
-#endif
 			event = psmx_cq_create_event(
 					ep_priv->recv_cq,
 					context,		/* op_context */
@@ -168,11 +120,6 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2, psm_tagsel2;
-	struct psmx_fid_av *av;
-	size_t idx;
-#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -208,29 +155,6 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 		return 0;
 	}
 
-#if (PSM_VERNO_MAJOR >= 2)
-	if (flags & FI_CLAIM) {
-		if (!context)
-			return -FI_EINVAL;
-
-		/* TODO: handle FI_DISCARD */
-
-		fi_context = context;
-		psm_req = PSMX_CTXT_REQ(fi_context);
-		PSMX_CTXT_TYPE(fi_context) = PSMX_TRECV_CONTEXT;
-		PSMX_CTXT_USER(fi_context) = buf;
-		PSMX_CTXT_EP(fi_context) = ep_priv;
-
-		err = psm_mq_imrecv(ep_priv->domain->psm_mq, 0, /*flags*/
-				    buf, len, context, &psm_req);
-		if (err != PSM_OK)
-			return psmx_errno(err);
-
-		PSMX_CTXT_REQ(fi_context) = psm_req;
-		return 0;
-	}
-#endif
-
 	if (tag & ep_priv->domain->reserved_tag_bits) {
 		FI_WARN(&psmx_prov, FI_LOG_EP_DATA,
 			"using reserved tag bits."
@@ -253,32 +177,9 @@ ssize_t _psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 		PSMX_CTXT_EP(fi_context) = ep_priv;
 	}
 
-#if (PSM_VERNO_MAJOR >= 2)
-	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
-		av = ep_priv->av;
-		if (av && av->type == FI_AV_TABLE) {
-			idx = (size_t)src_addr;
-			if (idx >= av->last)
-				return -FI_EINVAL;
-
-			src_addr = (fi_addr_t)av->psm_epaddrs[idx];
-		}
-	} else {
-		src_addr = 0;
-	}
-
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
-
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
-			   (psm_epaddr_t)src_addr,
-			   &psm_tag2, &psm_tagsel2, 0, /* flags */
-			   buf, len, (void *)fi_context, &psm_req);
-#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
-#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -298,9 +199,6 @@ ssize_t psmx_tagged_recv_no_flag_av_map(struct fid_ep *ep, void *buf,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2, psm_tagsel2;
-#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -314,22 +212,9 @@ ssize_t psmx_tagged_recv_no_flag_av_map(struct fid_ep *ep, void *buf,
 	PSMX_CTXT_USER(fi_context) = buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	if (! ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC))
-		src_addr = 0;
-
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
-
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
-			   (psm_epaddr_t)src_addr,
-			   &psm_tag2, &psm_tagsel2, 0, /* flags */
-			   buf, len, (void *)fi_context, &psm_req);
-#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
-#endif
 	if (err != PSM_OK)
 		return psmx_errno(err);
 
@@ -346,12 +231,6 @@ ssize_t psmx_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2, psm_tagsel2;
-	struct psmx_fid_av *av;
-	psm_epaddr_t psm_epaddr;
-	size_t idx;
-#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -365,30 +244,9 @@ ssize_t psmx_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf,
 	PSMX_CTXT_USER(fi_context) = buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
-		av = ep_priv->av;
-		idx = (size_t)src_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
-
-		psm_epaddr = av->psm_epaddrs[idx];
-	} else {
-		psm_epaddr = NULL;
-	}
-
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
-
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
-			   psm_epaddr,
-			   &psm_tag2, &psm_tagsel2, 0, /* flags */
-			   buf, len, (void *)fi_context, &psm_req);
-#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
-#endif
 	if (err != PSM_OK)
 		return psmx_errno(err);
 
@@ -405,9 +263,6 @@ ssize_t psmx_tagged_recv_no_event_av_map(struct fid_ep *ep, void *buf,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2, psm_tagsel2;
-#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -418,22 +273,9 @@ ssize_t psmx_tagged_recv_no_event_av_map(struct fid_ep *ep, void *buf,
 
 	fi_context = &ep_priv->nocomp_recv_context;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	if (! ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC))
-		src_addr = 0;
-
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
-
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
-			   (psm_epaddr_t)src_addr,
-			   &psm_tag2, &psm_tagsel2, 0, /* flags */
-			   buf, len, (void *)fi_context, &psm_req);
-#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
-#endif
 
 	return psmx_errno(err);
 }
@@ -447,12 +289,6 @@ ssize_t psmx_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf,
 	struct psmx_fid_ep *ep_priv;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag, psm_tagsel;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2, psm_tagsel2;
-	struct psmx_fid_av *av;
-	psm_epaddr_t psm_epaddr;
-	size_t idx;
-#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -463,30 +299,9 @@ ssize_t psmx_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf,
 
 	fi_context = &ep_priv->nocomp_recv_context;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
-		av = ep_priv->av;
-		idx = (size_t)src_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
-
-		psm_epaddr = av->psm_epaddrs[idx];
-	} else {
-		psm_epaddr = NULL;
-	}
-
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-	PSMX_SET_TAG(psm_tagsel2, psm_tagsel, 0);
-
-	err = psm_mq_irecv2(ep_priv->domain->psm_mq,
-			   psm_epaddr,
-			   &psm_tag2, &psm_tagsel2, 0, /* flags */
-			   buf, len, (void *)fi_context, &psm_req);
-#else
 	err = psm_mq_irecv(ep_priv->domain->psm_mq,
 			   psm_tag, psm_tagsel, 0, /* flags */
 			   buf, len, (void *)fi_context, &psm_req);
-#endif
 
 	return psmx_errno(err);
 }
@@ -622,24 +437,15 @@ static ssize_t psmx_tagged_recvv_no_event(struct fid_ep *ep, const struct iovec 
 					tag, ignore, context);
 }
 
-#if (PSM_VERNO_MAJOR >= 2)
-ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
-			  void *desc, fi_addr_t dest_addr, uint64_t tag,
-			  void *context, uint64_t flags, uint32_t data)
-#else
 ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 			  void *desc, fi_addr_t dest_addr, uint64_t tag,
 			  void *context, uint64_t flags)
-#endif
 {
 	struct psmx_fid_ep *ep_priv;
 	struct psmx_fid_av *av;
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2;
-#endif
 	struct fi_context *fi_context;
 	int err;
 	size_t idx;
@@ -668,9 +474,6 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 		trigger->tsend.tag = tag;
 		trigger->tsend.context = context;
 		trigger->tsend.flags = flags & ~FI_TRIGGER;
-#if (PSM_VERNO_MAJOR >= 2)
-		trigger->tsend.data = data;
-#endif
 
 		psmx_cntr_add_trigger(trigger->cntr, trigger);
 		return 0;
@@ -695,9 +498,6 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 	}
 
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
-#if (PSM_VERNO_MAJOR >= 2)
-	PSMX_SET_TAG(psm_tag2, psm_tag, data);
-#endif
 
 	if ((flags & PSMX_NO_COMPLETION) ||
 	    (ep_priv->send_selective_completion && !(flags & FI_COMPLETION)))
@@ -707,13 +507,8 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 		if (len > PSMX_INJECT_SIZE)
 			return -FI_EMSGSIZE;
 
-#if (PSM_VERNO_MAJOR >= 2)
-		err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, 0,
-				   &psm_tag2, buf, len);
-#else
 		err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, 0,
 				  psm_tag, buf, len);
-#endif
 
 		if (err != PSM_OK)
 			return psmx_errno(err);
@@ -725,11 +520,7 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 			event = psmx_cq_create_event(
 					ep_priv->send_cq,
 					context, (void *)buf, flags, len,
-#if (PSM_VERNO_MAJOR >= 2)
-					(uint64_t) data, psm_tag,
-#else
 					0 /* data */, psm_tag,
-#endif
 					0 /* olen */,
 					0 /* err */);
 
@@ -754,13 +545,8 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 		PSMX_CTXT_EP(fi_context) = ep_priv;
 	}
 
-#if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
-				&psm_tag2, buf, len, (void*)fi_context, &psm_req);
-#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 				psm_tag, buf, len, (void*)fi_context, &psm_req);
-#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -780,9 +566,6 @@ ssize_t psmx_tagged_send_no_flag_av_map(struct fid_ep *ep, const void *buf,
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2;
-#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -790,22 +573,14 @@ ssize_t psmx_tagged_send_no_flag_av_map(struct fid_ep *ep, const void *buf,
 
 	psm_epaddr = (psm_epaddr_t) dest_addr;
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
-#if (PSM_VERNO_MAJOR >= 2)
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-#endif
 
 	fi_context = context;
 	PSMX_CTXT_TYPE(fi_context) = PSMX_TSEND_CONTEXT;
 	PSMX_CTXT_USER(fi_context) = (void *)buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
-			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
-#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
-#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -824,9 +599,6 @@ ssize_t psmx_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2;
-#endif
 	struct fi_context *fi_context;
 	int err;
 	size_t idx;
@@ -840,22 +612,14 @@ ssize_t psmx_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 
 	psm_epaddr = av->psm_epaddrs[idx];
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
-#if (PSM_VERNO_MAJOR >= 2)
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-#endif
 
 	fi_context = context;
 	PSMX_CTXT_TYPE(fi_context) = PSMX_TSEND_CONTEXT;
 	PSMX_CTXT_USER(fi_context) = (void *)buf;
 	PSMX_CTXT_EP(fi_context) = ep_priv;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
-			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
-#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
-#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -873,9 +637,6 @@ ssize_t psmx_tagged_send_no_event_av_map(struct fid_ep *ep, const void *buf,
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2;
-#endif
 	struct fi_context *fi_context;
 	int err;
 
@@ -883,19 +644,11 @@ ssize_t psmx_tagged_send_no_event_av_map(struct fid_ep *ep, const void *buf,
 
 	psm_epaddr = (psm_epaddr_t) dest_addr;
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
-#if (PSM_VERNO_MAJOR >= 2)
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-#endif
 
 	fi_context = &ep_priv->nocomp_send_context;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
-			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
-#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
-#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -913,9 +666,6 @@ ssize_t psmx_tagged_send_no_event_av_table(struct fid_ep *ep, const void *buf,
 	psm_epaddr_t psm_epaddr;
 	psm_mq_req_t psm_req;
 	uint64_t psm_tag;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2;
-#endif
 	struct fi_context *fi_context;
 	int err;
 	size_t idx;
@@ -929,19 +679,11 @@ ssize_t psmx_tagged_send_no_event_av_table(struct fid_ep *ep, const void *buf,
 
 	psm_epaddr = av->psm_epaddrs[idx];
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
-#if (PSM_VERNO_MAJOR >= 2)
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-#endif
 
 	fi_context = &ep_priv->nocomp_send_context;
 
-#if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_isend2(ep_priv->domain->psm_mq, psm_epaddr, 0,
-			    &psm_tag2, buf, len, (void*)fi_context, &psm_req);
-#else
 	err = psm_mq_isend(ep_priv->domain->psm_mq, psm_epaddr, 0,
 			   psm_tag, buf, len, (void*)fi_context, &psm_req);
-#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -955,9 +697,6 @@ ssize_t psmx_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf, si
 	struct psmx_fid_ep *ep_priv;
 	psm_epaddr_t psm_epaddr;
 	uint64_t psm_tag;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2;
-#endif
 	int err;
 
 	if (len > PSMX_INJECT_SIZE)
@@ -967,15 +706,8 @@ ssize_t psmx_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf, si
 
 	psm_epaddr = (psm_epaddr_t) dest_addr;
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
-#if (PSM_VERNO_MAJOR >= 2)
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-#endif
 
-#if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, 0, &psm_tag2, buf, len);
-#else
 	err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, 0, psm_tag, buf, len);
-#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -993,9 +725,6 @@ ssize_t psmx_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf, 
 	struct psmx_fid_av *av;
 	psm_epaddr_t psm_epaddr;
 	uint64_t psm_tag;
-#if (PSM_VERNO_MAJOR >= 2)
-	psm_mq_tag_t psm_tag2;
-#endif
 	int err;
 	size_t idx;
 
@@ -1011,15 +740,8 @@ ssize_t psmx_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf, 
 
 	psm_epaddr = av->psm_epaddrs[idx];
 	psm_tag = tag & (~ep_priv->domain->reserved_tag_bits);
-#if (PSM_VERNO_MAJOR >= 2)
-	PSMX_SET_TAG(psm_tag2, psm_tag, 0);
-#endif
 
-#if (PSM_VERNO_MAJOR >= 2)
-	err = psm_mq_send2(ep_priv->domain->psm_mq, psm_epaddr, 0, &psm_tag2, buf, len);
-#else
 	err = psm_mq_send(ep_priv->domain->psm_mq, psm_epaddr, 0, psm_tag, buf, len);
-#endif
 
 	if (err != PSM_OK)
 		return psmx_errno(err);
@@ -1038,13 +760,8 @@ static ssize_t psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
-#if (PSM_VERNO_MAJOR >= 2)
-	return _psmx_tagged_send(ep, buf, len, desc, dest_addr, tag, context,
-				 ep_priv->flags, 0);
-#else
 	return _psmx_tagged_send(ep, buf, len, desc, dest_addr, tag, context,
 				 ep_priv->flags);
-#endif
 }
 
 static ssize_t psmx_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
@@ -1066,15 +783,9 @@ static ssize_t psmx_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged
 		len = 0;
 	}
 
-#if (PSM_VERNO_MAJOR >= 2)
-	return _psmx_tagged_send(ep, buf, len,
-				 msg->desc ? msg->desc[0] : NULL, msg->addr,
-				 msg->tag, msg->context, flags, (uint32_t) msg->data);
-#else
 	return _psmx_tagged_send(ep, buf, len,
 				 msg->desc ? msg->desc[0] : NULL, msg->addr,
 				 msg->tag, msg->context, flags);
-#endif
 }
 
 static ssize_t psmx_tagged_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
@@ -1211,40 +922,9 @@ static ssize_t psmx_tagged_inject(struct fid_ep *ep, const void *buf, size_t len
 
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
-#if (PSM_VERNO_MAJOR >= 2)
-	return _psmx_tagged_send(ep, buf, len, NULL, dest_addr, tag, NULL,
-				 ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION, 0);
-#else
 	return _psmx_tagged_send(ep, buf, len, NULL, dest_addr, tag, NULL,
 				 ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION);
-#endif
 }
-
-#if (PSM_VERNO_MAJOR >= 2)
-static ssize_t psmx_tagged_senddata(struct fid_ep *ep, const void *buf, size_t len,
-                                    void *desc, uint64_t data, fi_addr_t dest_addr,
-                                    uint64_t tag, void *context)
-{
-	struct psmx_fid_ep *ep_priv;
-
-	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
-
-	return _psmx_tagged_send(ep, buf, len, desc, dest_addr, tag, context,
-				 ep_priv->flags,  (uint32_t)data);
-}
-
-static ssize_t psmx_tagged_injectdata(struct fid_ep *ep, const void *buf, size_t len,
-				      uint64_t data, fi_addr_t dest_addr, uint64_t tag)
-{
-	struct psmx_fid_ep *ep_priv;
-
-	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
-
-	return _psmx_tagged_send(ep, buf, len, NULL, dest_addr, tag, NULL,
-				 ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION,
-				 (uint32_t)data);
-}
-#endif
 
 /* general case */
 struct fi_ops_tagged psmx_tagged_ops = {
@@ -1256,13 +936,8 @@ struct fi_ops_tagged psmx_tagged_ops = {
 	.sendv = psmx_tagged_sendv,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject,
-#if (PSM_VERNO_MAJOR >= 2)
-	.senddata = psmx_tagged_senddata,
-	.injectdata = psmx_tagged_injectdata,
-#else
 	.senddata = fi_no_tagged_senddata,
 	.injectdata = fi_no_tagged_injectdata,
-#endif
 };
 
 /* op_flags=0, no event suppression, FI_AV_MAP */
@@ -1275,13 +950,8 @@ struct fi_ops_tagged psmx_tagged_ops_no_flag_av_map = {
 	.sendv = psmx_tagged_sendv_no_flag_av_map,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_map,
-#if (PSM_VERNO_MAJOR >= 2)
-	.senddata = psmx_tagged_senddata,
-	.injectdata = psmx_tagged_injectdata,
-#else
 	.senddata = fi_no_tagged_senddata,
 	.injectdata = fi_no_tagged_injectdata,
-#endif
 };
 
 /* op_flags=0, no event suppression, FI_AV_TABLE */
@@ -1294,13 +964,8 @@ struct fi_ops_tagged psmx_tagged_ops_no_flag_av_table = {
 	.sendv = psmx_tagged_sendv_no_flag_av_table,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_table,
-#if (PSM_VERNO_MAJOR >= 2)
-	.senddata = psmx_tagged_senddata,
-	.injectdata = psmx_tagged_injectdata,
-#else
 	.senddata = fi_no_tagged_senddata,
 	.injectdata = fi_no_tagged_injectdata,
-#endif
 };
 
 /* op_flags=0, event suppression, FI_AV_MAP */
@@ -1313,13 +978,8 @@ struct fi_ops_tagged psmx_tagged_ops_no_event_av_map = {
 	.sendv = psmx_tagged_sendv_no_event_av_map,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_map,
-#if (PSM_VERNO_MAJOR >= 2)
-	.senddata = psmx_tagged_senddata,
-	.injectdata = psmx_tagged_injectdata,
-#else
 	.senddata = fi_no_tagged_senddata,
 	.injectdata = fi_no_tagged_injectdata,
-#endif
 };
 
 /* op_flags=0, event suppression, FI_AV_TABLE */
@@ -1332,13 +992,8 @@ struct fi_ops_tagged psmx_tagged_ops_no_event_av_table = {
 	.sendv = psmx_tagged_sendv_no_event_av_table,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_table,
-#if (PSM_VERNO_MAJOR >= 2)
-	.senddata = psmx_tagged_senddata,
-	.injectdata = psmx_tagged_injectdata,
-#else
 	.senddata = fi_no_tagged_senddata,
 	.injectdata = fi_no_tagged_injectdata,
-#endif
 };
 
 /* op_flags=0, send event suppression, FI_AV_MAP */
@@ -1351,13 +1006,8 @@ struct fi_ops_tagged psmx_tagged_ops_no_send_event_av_map = {
 	.sendv = psmx_tagged_sendv_no_event_av_map,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_map,
-#if (PSM_VERNO_MAJOR >= 2)
-	.senddata = psmx_tagged_senddata,
-	.injectdata = psmx_tagged_injectdata,
-#else
 	.senddata = fi_no_tagged_senddata,
 	.injectdata = fi_no_tagged_injectdata,
-#endif
 };
 
 /* op_flags=0, send event suppression, FI_AV_TABLE */
@@ -1370,13 +1020,8 @@ struct fi_ops_tagged psmx_tagged_ops_no_send_event_av_table = {
 	.sendv = psmx_tagged_sendv_no_event_av_table,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_table,
-#if (PSM_VERNO_MAJOR >= 2)
-	.senddata = psmx_tagged_senddata,
-	.injectdata = psmx_tagged_injectdata,
-#else
 	.senddata = fi_no_tagged_senddata,
 	.injectdata = fi_no_tagged_injectdata,
-#endif
 };
 
 /* op_flags=0, recv event suppression, FI_AV_MAP */
@@ -1389,13 +1034,8 @@ struct fi_ops_tagged psmx_tagged_ops_no_recv_event_av_map = {
 	.sendv = psmx_tagged_sendv_no_flag_av_map,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_map,
-#if (PSM_VERNO_MAJOR >= 2)
-	.senddata = psmx_tagged_senddata,
-	.injectdata = psmx_tagged_injectdata,
-#else
 	.senddata = fi_no_tagged_senddata,
 	.injectdata = fi_no_tagged_injectdata,
-#endif
 };
 
 /* op_flags=0, recv event suppression, FI_AV_TABLE */
@@ -1408,11 +1048,6 @@ struct fi_ops_tagged psmx_tagged_ops_no_recv_event_av_table = {
 	.sendv = psmx_tagged_sendv_no_flag_av_table,
 	.sendmsg = psmx_tagged_sendmsg,
 	.inject = psmx_tagged_inject_no_flag_av_table,
-#if (PSM_VERNO_MAJOR >= 2)
-	.senddata = psmx_tagged_senddata,
-	.injectdata = psmx_tagged_injectdata,
-#else
 	.senddata = fi_no_tagged_senddata,
 	.injectdata = fi_no_tagged_injectdata,
-#endif
 };


### PR DESCRIPTION
PSM2 support is provided by the psm2 provider. The PSM2 related
code in the psm provider is out of date. Removing that part can
eliminate unnecessary confusion.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>