### PR TITLE
prov/sockets: Use buf-pool for progress engine overflow entries

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -81,7 +81,6 @@
 
 #define SOCK_PE_POLL_TIMEOUT (100000)
 #define SOCK_PE_MAX_ENTRIES (128)
-#define SOCK_PE_MIN_ENTRIES (1)
 #define SOCK_PE_WAITTIME (10)
 
 #define SOCK_EQ_DEF_SZ (1<<8)
@@ -150,6 +149,7 @@
 #define SOCK_NO_COMPLETION (1ULL << 60)
 #define SOCK_USE_OP_FLAGS (1ULL << 61)
 #define SOCK_PE_COMM_BUFF_SZ (1024)
+#define SOCK_PE_OVERFLOW_COMM_BUFF_SZ (128)
 
 enum {
 	SOCK_SIGNAL_RD_FD = 0,
@@ -781,7 +781,8 @@ struct sock_pe_entry {
 	uint8_t is_complete;
 	uint8_t is_error;
 	uint8_t mr_checked;
-	uint8_t reserved[4];
+	uint8_t is_pool_entry;
+	uint8_t reserved[3];
 
 	uint64_t done_len;
 	uint64_t total_len;
@@ -795,6 +796,7 @@ struct sock_pe_entry {
 	struct dlist_entry entry;
 	struct dlist_entry ctx_entry;
 	struct ringbuf comm_buf;
+	size_t cache_sz;
 };
 
 struct sock_pe {
@@ -808,6 +810,7 @@ struct sock_pe {
 	int signal_fds[2];
 	uint64_t waittime;
 
+	struct util_buf_pool *pe_rx_pool;
 	struct dlist_entry free_list;
 	struct dlist_entry busy_list;
 

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -95,7 +95,7 @@ ssize_t sock_comm_send(struct sock_pe_entry *pe_entry,
 {
 	ssize_t ret, used;
 
-	if (len > SOCK_PE_COMM_BUFF_SZ) {
+	if (len > pe_entry->cache_sz) {
 		used = rbused(&pe_entry->comm_buf);
 		if (used == sock_comm_flush(pe_entry)) {
 			return sock_comm_send_socket(pe_entry->conn, buf, len);
@@ -167,7 +167,7 @@ ssize_t sock_comm_recv(struct sock_pe_entry *pe_entry, void *buf, size_t len)
 {
 	ssize_t read_len;
 	if (rbempty(&pe_entry->comm_buf)) {
-		if (len <= SOCK_PE_COMM_BUFF_SZ) {
+		if (len <= pe_entry->cache_sz) {
 			sock_comm_recv_buffer(pe_entry);
 		} else {
 			return sock_comm_recv_socket(pe_entry->conn, buf, len);


### PR DESCRIPTION
prov/sockets: Use buf-pool for progress engine overflow entries

Signed-off-by: Jithin Jose <jithin.jose@intel.com>