### PR TITLE
[RFC - DO NOT MERGE] Abi 1 1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,6 +28,7 @@ rdmainclude_HEADERS =
 
 # internal utility functions shared by in-tree providers:
 common_srcs = \
+	src/abi_1_0.c \
 	src/common.c \
 	src/enosys.c \
 	src/rbtree.c \

--- a/libfabric.map
+++ b/libfabric.map
@@ -15,3 +15,10 @@ FABRIC_1.0 {
 		fi_freeparams;
 	local: *;
 };
+
+FABRIC_1.1 {
+	global:
+		fi_getinfo;
+		fi_freeinfo;
+		fi_dupinfo;
+} FABRIC_1.0;

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+#include <rdma/fabric.h>
+#include <fi_abi.h>
+
+
+/*
+ * TODO: Add structures that change between 1.0 and 1.1
+ */
+struct fi_info_1_0 {
+	struct fi_info		*next;
+	uint64_t		caps;
+	uint64_t		mode;
+	uint32_t		addr_format;
+	size_t			src_addrlen;
+	size_t			dest_addrlen;
+	void			*src_addr;
+	void			*dest_addr;
+	fid_t			handle;
+	struct fi_tx_attr	*tx_attr;
+	struct fi_rx_attr	*rx_attr;
+	struct fi_ep_attr	*ep_attr;
+	struct fi_domain_attr	*domain_attr;
+	struct fi_fabric_attr	*fabric_attr;
+};
+
+
+/*
+ * TODO: translate from 1.0 structures to 1.1 where needed on all calls below.
+ */
+__attribute__((visibility ("default")))
+int fi_getinfo_1_0(uint32_t version, const char *node, const char *service,
+		    uint64_t flags, struct fi_info_1_0 *hints,
+		    struct fi_info_1_0 **info)
+{
+	return fi_getinfo(version, node, service, flags,
+			  (struct fi_info *) hints,
+			  (struct fi_info **) info);
+}
+COMPAT_SYMVER(fi_getinfo_1_0, fi_getinfo, FABRIC_1.0);
+
+__attribute__((visibility ("default")))
+void fi_freeinfo_1_0(struct fi_info_1_0 *info)
+{
+	fi_freeinfo((struct fi_info *) info);
+}
+COMPAT_SYMVER(fi_freeinfo_1_0, fi_freeinfo, FABRIC_1.0);
+
+__attribute__((visibility ("default")))
+struct fi_info_1_0 *fi_dupinfo_1_0(const struct fi_info_1_0 *info)
+{
+	return (struct fi_info_1_0 *) fi_dupinfo((const struct fi_info *) info);
+}
+COMPAT_SYMVER(fi_dupinfo_1_0, fi_dupinfo, FABRIC_1.0);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -463,7 +463,7 @@ void DEFAULT_SYMVER_PRE(fi_freeinfo)(struct fi_info *info)
 		free(info);
 	}
 }
-DEFAULT_SYMVER(fi_freeinfo_, fi_freeinfo);
+CURRENT_SYMVER(fi_freeinfo_, fi_freeinfo);
 
 /* Make a dummy info object for each provider, and copy in the
  * provider name and version */
@@ -508,8 +508,9 @@ err:
 }
 
 __attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const char *service,
-	       uint64_t flags, struct fi_info *hints, struct fi_info **info)
+int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
+		const char *service, uint64_t flags,
+		struct fi_info *hints, struct fi_info **info)
 {
 	struct fi_prov *prov;
 	struct fi_info *tail, *cur;
@@ -568,7 +569,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 
 	return *info ? 0 : ret;
 }
-DEFAULT_SYMVER(fi_getinfo_, fi_getinfo);
+CURRENT_SYMVER(fi_getinfo_, fi_getinfo);
 
 static struct fi_info *fi_allocinfo_internal(void)
 {
@@ -673,10 +674,11 @@ fail:
 	fi_freeinfo(dup);
 	return NULL;
 }
-DEFAULT_SYMVER(fi_dupinfo_, fi_dupinfo);
+CURRENT_SYMVER(fi_dupinfo_, fi_dupinfo);
 
 __attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context)
+int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr,
+		struct fid_fabric **fabric, void *context)
 {
 	struct fi_prov *prov;
 
@@ -692,14 +694,14 @@ int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr, struct fid_fabric
 
 	return prov->provider->fabric(attr, fabric, context);
 }
-DEFAULT_SYMVER(fi_fabric_, fi_fabric);
+DEFAULT_SYMVER(fi_fabric_, fi_fabric, FABRIC_1.0);
 
 __attribute__((visibility ("default")))
 uint32_t DEFAULT_SYMVER_PRE(fi_version)(void)
 {
 	return FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION);
 }
-DEFAULT_SYMVER(fi_version_, fi_version);
+DEFAULT_SYMVER(fi_version_, fi_version, FABRIC_1.0);
 
 static const char *const errstr[] = {
 	[FI_EOTHER - FI_ERRNO_OFFSET] = "Unspecified error",
@@ -725,4 +727,4 @@ const char *DEFAULT_SYMVER_PRE(fi_strerror)(int errnum)
 	else
 		return errstr[FI_EOTHER - FI_ERRNO_OFFSET];
 }
-DEFAULT_SYMVER(fi_strerror_, fi_strerror);
+DEFAULT_SYMVER(fi_strerror_, fi_strerror, FABRIC_1.0);

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -693,7 +693,7 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 	}
 	return buf;
 }
-DEFAULT_SYMVER(fi_tostr_, fi_tostr);
+DEFAULT_SYMVER(fi_tostr_, fi_tostr, FABRIC_1.0);
 
 #undef CASEENUMSTR
 #undef IFFLAGSTR

--- a/src/log.c
+++ b/src/log.c
@@ -131,8 +131,9 @@ void fi_log_fini(void)
 }
 
 __attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov, enum fi_log_level level,
-		   enum fi_log_subsys subsys)
+int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov,
+		enum fi_log_level level,
+		enum fi_log_subsys subsys)
 {
 	struct fi_prov_context *ctx;
 
@@ -140,12 +141,12 @@ int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov, enum fi_l
 	return ((FI_LOG_TAG(ctx->disable_logging, level, subsys) & log_mask) ==
 		FI_LOG_TAG(ctx->disable_logging, level, subsys));
 }
-DEFAULT_SYMVER(fi_log_enabled_, fi_log_enabled);
+DEFAULT_SYMVER(fi_log_enabled_, fi_log_enabled, FABRIC_1.0);
 
 __attribute__((visibility ("default")))
 void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_level level,
-	    enum fi_log_subsys subsys, const char *func, int line,
-	    const char *fmt, ...)
+		enum fi_log_subsys subsys, const char *func, int line,
+		const char *fmt, ...)
 {
 	char buf[1024];
 	int size;
@@ -162,4 +163,4 @@ void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_leve
 
 	fprintf(stderr, "%s", buf);
 }
-DEFAULT_SYMVER(fi_log_, fi_log);
+DEFAULT_SYMVER(fi_log_, fi_log, FABRIC_1.0);

--- a/src/var.c
+++ b/src/var.c
@@ -128,7 +128,7 @@ out:
 	*params = vhead;
 	return FI_SUCCESS;
 }
-DEFAULT_SYMVER(fi_getparams_, fi_getparams);
+DEFAULT_SYMVER(fi_getparams_, fi_getparams, FABRIC_1.0);
 
 __attribute__((visibility ("default")))
 void DEFAULT_SYMVER_PRE(fi_freeparams)(struct fi_param *params)
@@ -140,7 +140,7 @@ void DEFAULT_SYMVER_PRE(fi_freeparams)(struct fi_param *params)
 	}
 	free(params);
 }
-DEFAULT_SYMVER(fi_freeparams_, fi_freeparams);
+DEFAULT_SYMVER(fi_freeparams_, fi_freeparams, FABRIC_1.0);
 
 static void fi_free_param(struct fi_param_entry *param)
 {
@@ -226,7 +226,7 @@ int DEFAULT_SYMVER_PRE(fi_param_define)(const struct fi_provider *provider,
 	FI_INFO(provider, FI_LOG_CORE, "registered var %s\n", param_name);
 	return FI_SUCCESS;
 }
-DEFAULT_SYMVER(fi_param_define_, fi_param_define);
+DEFAULT_SYMVER(fi_param_define_, fi_param_define, FABRIC_1.0);
 
 static int fi_parse_bool(const char *str_value)
 {
@@ -301,7 +301,7 @@ int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 out:
 	return ret;
 }
-DEFAULT_SYMVER(fi_param_get_, fi_param_get);
+DEFAULT_SYMVER(fi_param_get_, fi_param_get, FABRIC_1.0);
 
 
 void fi_param_init(void)


### PR DESCRIPTION
There are two quick patches to discuss.  Both are intended to target an ABI update release at the end of the year.

The first defines how to report the fabric level source address data to an app.  This change can actually go in anytime after providers have been updated to comply with the new behavior.  We need to decide if the defined behavior is what we actually want.  The concept of using the apps's requested version to select the behavior that is introduced by this change will apply to future patches.

For example, new fields will be added to fi_info.  The fi_getinfo version will indicate if the app knows how to make use of those new fields.  This change handles apps coded to an older version of libfabric, but compiled against a newer library.

The second patch does not work, but is intended to show where the ABI will change and how backwards compatibility could be supported. This change handles apps linked against an older version of libfabrc, but running with a newer version.  The problem with the change is that attempting to run code compiled against the older version of libfabric results in this error:

fi_dom_test: relocation error: fi_dom_test: symbol fi_fabric, version FABRIC_1.0 not defined in file libfabric.so.1 with link time reference

I can fix this by wrapping fi_fabric and the other 1.0 ABI calls similar to what was done for fi_getinfo.  But I'm hoping someone with more knowledge of symver can suggest an alternative that doesn't require wrapping all existing calls.

Finally, we can debate whether these changes should result in the ABI bumping to 1.1 or 2.0.