### PR TITLE
prov/sockets: bug fixes from RMA stress tests.

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -72,8 +72,6 @@
 #define SOCK_EP_MAX_IOV_LIMIT (8)
 #define SOCK_EP_TX_SZ (256)
 #define SOCK_EP_RX_SZ (256)
-#define SOCK_EP_TX_ENTRY_SZ (256)
-#define SOCK_EP_RX_ENTRY_SZ (256)
 #define SOCK_EP_MIN_MULTI_RECV (64)
 #define SOCK_EP_MAX_ATOMIC_SZ (256)
 #define SOCK_EP_MAX_CTX_BITS (16)
@@ -908,6 +906,42 @@ struct sock_conn_req_handle {
 	struct sock_conn_req *req;
 };
 
+union sock_tx_op {
+	struct sock_msg {
+		struct sock_op_send op;
+		uint64_t cq_data;
+		union {
+			char inject[SOCK_EP_MAX_INJECT_SZ];
+			union sock_iov msg[SOCK_EP_MAX_IOV_LIMIT];
+		} data;
+	} msg;
+
+	struct sock_rma_write {
+		struct sock_op_send op;
+		union {
+			char inject[SOCK_EP_MAX_INJECT_SZ];
+			union sock_iov msg[SOCK_EP_MAX_IOV_LIMIT];
+		} data;
+		union sock_iov rma[SOCK_EP_MAX_IOV_LIMIT];
+	} rma_write;
+
+	struct sock_rma_read {
+		struct sock_op_send op;
+		union sock_iov msg[SOCK_EP_MAX_IOV_LIMIT];
+		union sock_iov rma[SOCK_EP_MAX_IOV_LIMIT];
+	} rma_read;
+
+	struct sock_atomic {
+		struct sock_op_send op;
+		union {
+			char inject[SOCK_EP_MAX_INJECT_SZ];
+			union sock_iov msg[SOCK_EP_MAX_IOV_LIMIT];
+		} data;
+		union sock_iov rma[SOCK_EP_MAX_IOV_LIMIT];
+		union sock_iov res[SOCK_EP_MAX_IOV_LIMIT];
+	} atomic;
+};
+#define SOCK_EP_TX_ENTRY_SZ (sizeof(union sock_tx_op))
 
 int sock_verify_info(struct fi_info *hints);
 int sock_verify_fabric_attr(struct fi_fabric_attr *attr);
@@ -972,8 +1006,6 @@ int sock_msg_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 			struct fid_pep **pep, void *context);
 int sock_ep_enable(struct fid_ep *ep);
 int sock_ep_disable(struct fid_ep *ep);
-int sock_ep_is_send_cq_low(struct sock_comp *comp, uint64_t flags);
-int sock_ep_is_recv_cq_low(struct sock_comp *comp, uint64_t flags);
 
 int sock_stx_ctx(struct fid_domain *domain,
 		 struct fi_tx_attr *attr, struct fid_stx **stx, void *context);
@@ -986,7 +1018,6 @@ int sock_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 int sock_cq_report_error(struct sock_cq *cq, struct sock_pe_entry *entry,
 			 size_t olen, int err, int prov_errno, void *err_data);
 int sock_cq_progress(struct sock_cq *cq);
-int sock_cq_check_size_ok(struct sock_cq *cq);
 
 
 int sock_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -105,11 +105,6 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 		flags &= ~FI_INJECT;
 	}
 
-	if (sock_ep_is_send_cq_low(&tx_ctx->comp, flags)) {
-		SOCK_LOG_ERROR("CQ size low\n");
-		return -FI_EAGAIN;
-	}
-
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_atomic_op(ep, msg, comparev, compare_count,
 					resultv, result_count, flags,

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -156,7 +156,8 @@ static void sock_comm_recv_buffer(struct sock_pe_entry *pe_entry)
 		pe_entry->comm_buf.wcnt = 
 		pe_entry->comm_buf.wpos = 0;
 
-	max_read = pe_entry->total_len - pe_entry->done_len;
+	max_read = pe_entry->rem ? pe_entry->rem :
+		pe_entry->total_len - pe_entry->done_len;
 	ret = sock_comm_recv_socket(pe_entry->conn, (char *) pe_entry->comm_buf.buf,
 				    MIN(max_read, avail));
 	pe_entry->comm_buf.wpos += ret;

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -630,14 +630,3 @@ out:
 	fastlock_release(&cq->lock);
 	return ret;
 }
-
-int sock_cq_check_size_ok(struct sock_cq *cq)
-{
-	int ret = 1;
-	fastlock_acquire(&cq->lock);
-	if (rbfdavail(&cq->cq_rbfd) < sock_cq_entry_size(cq))
-		ret = 0;
-
-	fastlock_release(&cq->lock);
-	return ret;
-}

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -269,8 +269,10 @@ struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint64_t key,
 
 	fastlock_acquire(&domain->lock);
 	mr = sock_mr_get_entry(domain, key);
-	if (!mr)
+	if (!mr) {
+		fastlock_release(&domain->lock);
 		return NULL;
+	}
 
 	if (domain->attr.mr_mode == FI_MR_SCALABLE)
 		buf = (char *)buf + mr->offset;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1628,19 +1628,3 @@ int sock_ep_get_conn(struct sock_ep *ep, struct sock_tx_ctx *tx_ctx,
 	*pconn = conn;
 	return conn->address_published ? 0 : sock_conn_send_src_addr(ep, tx_ctx, conn);
 }
-
-int sock_ep_is_send_cq_low(struct sock_comp *comp, uint64_t flags)
-{
-	return (comp && comp->send_cq && !(flags & SOCK_NO_COMPLETION) &&
-	    (!comp->send_cq_event ||
-	     (comp->send_cq_event &&  (flags & FI_COMPLETION)))) &&
-		!sock_cq_check_size_ok(comp->send_cq);
-}
-
-int sock_ep_is_recv_cq_low(struct sock_comp *comp, uint64_t flags)
-{
-	return (comp && comp->recv_cq && !(flags & SOCK_NO_COMPLETION) &&
-	    (!comp->recv_cq_event ||
-	     (comp->recv_cq_event && (flags & FI_COMPLETION)))) &&
-		!sock_cq_check_size_ok(comp->recv_cq);
-}

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -90,11 +90,6 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	if (flags & SOCK_USE_OP_FLAGS)
 		flags |= rx_ctx->attr.op_flags;
 
-	if (sock_ep_is_recv_cq_low(&rx_ctx->comp, flags)) {
-		SOCK_LOG_ERROR("CQ size low\n");
-		return -FI_EAGAIN;
-	}
-
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_msg_op(ep, msg, flags, SOCK_OP_RECV);
 		if (ret != 1)
@@ -219,11 +214,6 @@ ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	SOCK_EP_SET_TX_OP_FLAGS(flags);
 	if (flags & SOCK_USE_OP_FLAGS)
 		flags |= tx_ctx->attr.op_flags;
-
-	if (sock_ep_is_send_cq_low(&tx_ctx->comp, flags)) {
-		SOCK_LOG_ERROR("CQ size low\n");
-		return -FI_EAGAIN;
-	}
 
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_msg_op(ep, msg, flags, SOCK_OP_SEND);
@@ -422,11 +412,6 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 		flags |= rx_ctx->attr.op_flags;
 	flags &= ~FI_MULTI_RECV;
 
-	if (sock_ep_is_recv_cq_low(&rx_ctx->comp, flags)) {
-		SOCK_LOG_ERROR("CQ size low\n");
-		return -FI_EAGAIN;
-	}
-
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_tmsg_op(ep, msg, flags, SOCK_OP_TRECV);
 		if (ret != 1)
@@ -557,11 +542,6 @@ ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 	SOCK_EP_SET_TX_OP_FLAGS(flags);
 	if (flags & SOCK_USE_OP_FLAGS)
 		flags |= tx_ctx->attr.op_flags;
-
-	if (sock_ep_is_send_cq_low(&tx_ctx->comp, flags)) {
-		SOCK_LOG_ERROR("CQ size low\n");
-		return -FI_EAGAIN;
-	}
 
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_tmsg_op(ep, msg, flags, SOCK_OP_TSEND);

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -101,11 +101,6 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	if (flags & SOCK_USE_OP_FLAGS)
 		flags |= tx_ctx->attr.op_flags;
 
-	if (sock_ep_is_send_cq_low(&tx_ctx->comp, flags)) {
-		SOCK_LOG_ERROR("CQ size low\n");
-		return -FI_EAGAIN;
-	}
-
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_rma_op(ep, msg, flags, SOCK_OP_READ);
 		if (ret != 1)
@@ -264,11 +259,6 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	SOCK_EP_SET_TX_OP_FLAGS(flags);
 	if (flags & SOCK_USE_OP_FLAGS)
 		flags |= tx_ctx->attr.op_flags;
-
-	if (sock_ep_is_send_cq_low(&tx_ctx->comp, flags)) {
-		SOCK_LOG_ERROR("CQ size low\n");
-		return -FI_EAGAIN;
-	}
 
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_rma_op(ep, msg, flags, SOCK_OP_WRITE);


### PR DESCRIPTION
- synchronize accesses to mr_get_key
- Remove check for cq-size availability during TX/RX operations. CQ overflows are handled internally.
- fix a bug in sock_pe_discard_field. Updated to handle the case in which the same pe-entry can be used to send the ack/error message.