### PR TITLE
prov/psm2: bug fix for multi-iov support

### DIFF
--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -407,7 +407,7 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 		req->iov_protocol = PSMX2_IOV_PROTO_MULTI;
 		req->iov_done = 0;
 		req->iov_info.seq_num = (++ep_priv->iov_seq_num) %
-					(PSMX2_IOV_MAX_SEQ_NUM + 1);
+					PSMX2_IOV_MAX_SEQ_NUM + 1;
 		req->iov_info.count = (uint32_t)real_count;
 		req->iov_info.total_len = (uint32_t)total_len;
 

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -977,7 +977,7 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 		req->iov_protocol = PSMX2_IOV_PROTO_MULTI;
 		req->iov_done = 0;
 		req->iov_info.seq_num = (++ep_priv->iov_seq_num) %
-					(PSMX2_IOV_MAX_SEQ_NUM + 1);
+					PSMX2_IOV_MAX_SEQ_NUM + 1;
 		req->iov_info.count = (uint32_t)real_count;
 		req->iov_info.total_len = (uint32_t)total_len;
 


### PR DESCRIPTION
In order to separate the messages related to the multi-iov protocol
from regular messages, the "sequence number" as part of the extended
tag cannot be 0.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>