### PR TITLE
Remove dead symlink.

### DIFF
--- a/prov/udp/src/fi_util.h
+++ b/prov/udp/src/fi_util.h
@@ -1,1 +1,0 @@
-../../util/src/fi_util.h


### PR DESCRIPTION
The referenced `fi_util.h` doesn't seem to exist.

@shefty 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>