### PR TITLE
man page updates to clarify use of wait calls

### DIFF
--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -224,6 +224,9 @@ fi_cntr_wait.
 If the call returns due to timeout, -FI_ETIMEDOUT will be returned.
 The error value associated with the counter remains unchanged.
 
+It is invalid for applications to call this function if the counter
+has been configured with a wait object of FI_WAIT_NONE or FI_WAIT_SET.
+
 # RETURN VALUES
 
 Returns 0 on success.  On error, a negative value corresponding to

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -343,6 +343,9 @@ similar to the non-blocking calls, with the exception that the calls
 will not return until either a completion has been read from the CQ or
 an error or timeout occurs.
 
+It is invalid for applications to call these functions if the CQ
+has been configured with a wait object of FI_WAIT_NONE or FI_WAIT_SET.
+
 ## fi_cq_readerr
 
 The read error function, fi_cq_readerr, retrieves information

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -345,6 +345,9 @@ exception that the calls will not return until either an event has
 been read from the EQ or an error or timeout occurs.  Specifying a
 negative timeout means an infinite timeout.
 
+It is invalid for applications to call this function if the EQ
+has been configured with a wait object of FI_WAIT_NONE or FI_WAIT_SET.
+
 ## fi_eq_readerr
 
 The read error function, fi_eq_readerr, retrieves information

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -167,7 +167,7 @@ struct fi_eq_attr {
 : Indicates that the EQ should use a file descriptor as its wait
   mechanism.  A file descriptor wait object must be usable in select,
   poll, and epoll routines.  However, a provider may signal an FD wait
-  object by marking it as readable, writable, or with an error.
+  object by marking it as readable or with an error.
 
 - *FI_WAIT_MUTEX_COND*
 : Specifies that the EQ should use a pthread mutex and cond variable


### PR DESCRIPTION
Document that fd's must be signaled using POLLIN or POLLERR, and restrict use of sread calls when wait sets are present.