### PR TITLE
configury: use configure-based libfabric.map

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ ACLOCAL_AMFLAGS = -I config
 AM_CFLAGS = -g -Wall
 
 if HAVE_LD_VERSION_SCRIPT
-    libfabric_version_script = -Wl,--version-script=$(srcdir)/libfabric.map
+    libfabric_version_script = -Wl,--version-script=$(builddir)/libfabric.map
 else !HAVE_LD_VERSION_SCRIPT
     libfabric_version_script =
 endif !HAVE_LD_VERSION_SCRIPT
@@ -95,7 +95,7 @@ endif
 src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)
 src_libfabric_la_LDFLAGS =
 src_libfabric_la_LIBADD =
-src_libfabric_la_DEPENDENCIES = $(srcdir)/libfabric.map
+src_libfabric_la_DEPENDENCIES = libfabric.map
 
 src_libfabric_la_LDFLAGS += -version-info 2:1:1 -export-dynamic \
 			   $(libfabric_version_script)
@@ -264,6 +264,9 @@ dummy_man_pages = \
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libfabric.pc
 
+libfabric.map: libfabric.map.cpp
+	@$(CPP) $(CPPFLAGS) -I$(top_builddir) -P -C $< -o $@
+
 nroff:
 	@for file in $(real_man_pages); do \
 	    source=`echo $$file | sed -e 's@/man[0-9]@@'`; \
@@ -279,6 +282,8 @@ test:
 
 rpm: dist
 	rpmbuild -ta libfabric-*.tar.bz2
+
+CLEANFILES = libfabric.map
 
 prov_install_man_pages=
 prov_dist_man_pages=
@@ -296,7 +301,7 @@ man_MANS = $(real_man_pages) $(prov_install_man_pages) $(dummy_man_pages)
 
 EXTRA_DIST = \
         NEWS.md \
-        libfabric.map \
+        libfabric.map.cpp \
         libfabric.spec.in \
         config/distscript.pl \
         $(real_man_pages) $(prov_dist_man_pages) $(dummy_man_pages)

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ AC_ARG_ENABLE([direct],
 dnl Checks for programs
 AC_PROG_CC_C99
 AM_PROG_CC_C_O
+AC_PROG_CPP
 
 dnl Checks for header files.
 AC_HEADER_STDC
@@ -233,10 +234,15 @@ FI_PROVIDER_SETUP_PC
 # If the user requested to build in direct mode, but
 # we have more than one provider, error.
 AS_IF([test x"$enable_direct" != x"no"],
-      [AS_IF([test "$PROVIDERS_COUNT" -eq "1"],
-	     [AC_SUBST(PROVIDER_DIRECT, "$enable_direct")],
-	     [AC_MSG_NOTICE([Only one provider can be chosen when using --enable-direct])
-	     AC_MSG_ERROR(Cannot continue)])])
+	[AS_IF([test "$PROVIDERS_COUNT" -eq "1"],
+		[AC_SUBST(PROVIDER_DIRECT, "$enable_direct")]
+		[AC_DEFINE_UNQUOTED([FI_DIRECT_PROVIDER_API_10],
+				    ["prov/$enable_direct/provider_FABRIC_1.0.map"],
+				    [Define location of provider symbol script])]
+		AC_DEFINE([FABRIC_DIRECT_ENABLED], 1,
+		  [Define to 1 if building for fi_direct support]),
+		[AC_MSG_NOTICE([Only one provider can be chosen when using --enable-direct])
+		AC_MSG_ERROR(Cannot continue)])])
 
 AM_CONDITIONAL([HAVE_DIRECT], [test x"$enable_direct" != x"no"])
 

--- a/libfabric.map.cpp
+++ b/libfabric.map.cpp
@@ -1,3 +1,4 @@
+#include "config.h"
 FABRIC_1.0 {
 	global:
 		fi_getinfo;
@@ -13,5 +14,8 @@ FABRIC_1.0 {
 		fi_param_get;
 		fi_getparams;
 		fi_freeparams;
+#ifdef FABRIC_DIRECT_ENABLED
+#include FI_DIRECT_PROVIDER_API_10
+#endif
 	local: *;
 };


### PR DESCRIPTION
In the course of implementing FI_DIRECT in the gni provider,
it was found that the current hardwired version-script isn't
really suitable.

A method is needed to generate the version-script depending
on how libfabric is configured.  There is no need to change
the base script if --enable-direct=<provider> is not specified
on the configure line.  However, if it is, there needs to
be a mechanism for a provider to add its provider specific
entry points to the global section of the version script.

This PR introduces such a capability.

With this PR, the libfabric.map is now generated as follows:

1) configury step where the PROVIDER_DIRECT configure variable
(the <provider> argument to --enable-direct) is substituted
in to create a libfabric.map.cpp from libfabric.map.cpp.in

2) During the make process, the C proprocessor is used to pull
in the provider specific prov/<provider>/provider.map and
thus generate the libfabric.map file, which at this point
is used as before when the file was static.

Only the libfabric.map.cpp.in file is included in the dist
tarball.  A make clean will remove the libfabric.map file.
A make distclean will also remove the libfabric.map.cpp
file.

Other additions included in this PR

- fi_provider.m4 now defines a FI_DIRECT_ENABLE macro via CFLAGS
  for fi_prov.h.  Note that an AC_DEFINE_UNQUOTED in the
  configure.ac doesn't work as this would require including
  config.h in the libfabric.map.cpp - something which the
  ld --version-script parser doesn't like.

-  fi_prov.h conditionally defines convenience macros that
   that providers can use to switch between global visibility
   and static scope  depending on whether they are being built to
   support FI_DIRECT or not.

Signed-off-by: Evan Harvey <eharvey@lanl.gov>

@shefty 
@goodell 
