### PR TITLE
[RFC] fabric: Introduce new fi_trywait call

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -249,6 +249,7 @@ dummy_man_pages = \
         man/man3/fi_trecv.3 \
         man/man3/fi_trecvmsg.3 \
         man/man3/fi_trecvv.3 \
+        man/man3/fi_trywait.3 \
         man/man3/fi_tsend.3 \
         man/man3/fi_tsenddata.3 \
         man/man3/fi_tsendmsg.3 \

--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -67,6 +67,7 @@ static struct fi_ops_fabric X = {
 	.passive_ep = fi_no_passive_ep,
 	.eq_open = fi_no_eq_open,
 	.wait_open = fi_no_wait_open,
+	.trywait = fi_no_trywait,
 };
 */
 int fi_no_domain(struct fid_fabric *fabric, struct fi_domain_attr *attr,
@@ -77,6 +78,7 @@ int fi_no_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		struct fid_eq **eq, void *context);
 int fi_no_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		struct fid_wait **waitset);
+int fi_no_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
 
 /*
 static struct fi_ops_atomic X = {

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -244,6 +244,7 @@ int fi_poll_create(struct fid_domain *domain, struct fi_poll_attr *attr,
  */
 struct util_wait;
 typedef void (*fi_wait_signal_func)(struct util_wait *wait);
+typedef int (*fi_wait_try_func)(struct util_wait *wait);
 
 struct util_wait {
 	struct fid_wait		wait_fid;
@@ -254,6 +255,7 @@ struct util_wait {
 
 	enum fi_wait_obj	wait_obj;
 	fi_wait_signal_func	signal;
+	fi_wait_try_func	try;
 };
 
 int fi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -382,6 +382,8 @@ struct fi_ops_fabric {
 			struct fid_eq **eq, void *context);
 	int	(*wait_open)(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 			struct fid_wait **waitset);
+	int	(*trywait)(struct fid_fabric *fabric, struct fid **fids,
+			int count);
 };
 
 struct fid_fabric {

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -296,6 +296,12 @@ struct fid_cntr {
 #ifndef FABRIC_DIRECT
 
 static inline int
+fi_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	return fabric->ops->trywait(fabric, fids, count);
+}
+
+static inline int
 fi_wait(struct fid_wait *waitset, int timeout)
 {
 	return waitset->ops->wait(waitset, timeout);

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -173,7 +173,7 @@ Version information for the fabric provider.
 
 # RETURN VALUE
 
-Returns 0 on success. On error, a negative value corresponding to
+Returns FI_SUCCESS on success. On error, a negative value corresponding to
 fabric errno is returned. Fabric errno values are defined in
 `rdma/fi_errno.h`.
 

--- a/man/man3/fi_trywait.3
+++ b/man/man3/fi_trywait.3
@@ -1,0 +1,1 @@
+.so man3/fi_poll.3

--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -396,7 +396,8 @@ static int gnix_cntr_control(struct fid *cntr, int command, void *arg)
 		*(uint64_t *)arg = cntr_priv->attr.flags;
 		break;
 	case FI_GETWAIT:
-		return _gnix_get_wait_obj(cntr_priv->wait, arg);
+		/* return _gnix_get_wait_obj(cntr_priv->wait, arg); */
+		return -FI_ENOSYS;
 	default:
 		return -FI_EINVAL;
 	}

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -629,7 +629,8 @@ static int gnix_cq_control(struct fid *cq, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
-		return _gnix_get_wait_obj(cq_priv->wait, arg);
+		/* return _gnix_get_wait_obj(cq_priv->wait, arg); */
+		return -FI_ENOSYS;
 	default:
 		return -FI_EINVAL;
 	}

--- a/prov/gni/src/gnix_eq.c
+++ b/prov/gni/src/gnix_eq.c
@@ -389,7 +389,8 @@ static int gnix_eq_control(struct fid *eq, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
-		return _gnix_get_wait_obj(eq_priv->wait, arg);
+		/* return _gnix_get_wait_obj(eq_priv->wait, arg); */
+		return -FI_ENOSYS;
 	default:
 		return -FI_EINVAL;
 	}

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -86,7 +86,8 @@ static struct fi_ops_fabric gnix_fab_ops = {
 	.domain = gnix_domain_open,
 	.passive_ep = fi_no_passive_ep,
 	.eq_open = gnix_eq_open,
-	.wait_open = gnix_wait_open
+	.wait_open = gnix_wait_open,
+	.trywait = fi_no_trywait
 };
 
 static void __fabric_destruct(void *obj)

--- a/prov/gni/src/gnix_wait.c
+++ b/prov/gni/src/gnix_wait.c
@@ -238,7 +238,8 @@ static int gnix_wait_control(struct fid *wait, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
-		return _gnix_get_wait_obj(wait_fid_priv, arg);
+		/* return _gnix_get_wait_obj(wait_fid_priv, arg); */
+		return -FI_ENOSYS;
 	default:
 		return -FI_EINVAL;
 	}

--- a/prov/mxm/src/mlxm_init.c
+++ b/prov/mxm/src/mlxm_init.c
@@ -235,6 +235,7 @@ static struct fi_ops_fabric mlxm_fabric_ops = {
         .passive_ep = fi_no_passive_ep            ,
         .eq_open    = fi_no_eq_open               ,
         .wait_open  = fi_no_wait_open             ,
+	.trywait = fi_no_trywait
 };
 
 static int mlxm_fabric(struct fi_fabric_attr *attr,

--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -345,9 +345,10 @@ static int psmx_cntr_control(fid_t fid, int command, void *arg)
 		break;
 
 	case FI_GETWAIT:
+		/*
 		ret = psmx_wait_get_obj(cntr->wait, arg);
 		break;
-
+		*/
 	default:
 		return -FI_ENOSYS;
 	}

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -718,9 +718,10 @@ static int psmx_cq_control(struct fid *fid, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
+		/*
 		ret = psmx_wait_get_obj(cq->wait, arg);
 		break;
-
+		*/
 	default:
 		return -FI_ENOSYS;
 	}

--- a/prov/psm/src/psmx_eq.c
+++ b/prov/psm/src/psmx_eq.c
@@ -332,9 +332,10 @@ static int psmx_eq_control(struct fid *fid, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
+		/*
 		ret = psmx_wait_get_obj(eq->wait, arg);
 		break;
-
+		*/
 	default:
 		return -FI_ENOSYS;
 	}

--- a/prov/psm/src/psmx_fabric.c
+++ b/prov/psm/src/psmx_fabric.c
@@ -95,6 +95,7 @@ static struct fi_ops_fabric psmx_fabric_ops = {
 	.passive_ep = fi_no_passive_ep,
 	.eq_open = psmx_eq_open,
 	.wait_open = psmx_wait_open,
+	.trywait = fi_no_trywait
 };
 
 int psmx_fabric(struct fi_fabric_attr *attr,

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -387,9 +387,10 @@ static int psmx2_cntr_control(fid_t fid, int command, void *arg)
 		break;
 
 	case FI_GETWAIT:
+		/*
 		ret = psmx2_wait_get_obj(cntr->wait, arg);
 		break;
-
+		*/
 	default:
 		return -FI_ENOSYS;
 	}

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -782,6 +782,7 @@ static int psmx2_cq_close(fid_t fid)
 
 static int psmx2_cq_control(struct fid *fid, int command, void *arg)
 {
+	/*
 	struct psmx2_fid_cq *cq;
 	int ret = 0;
 
@@ -797,6 +798,8 @@ static int psmx2_cq_control(struct fid *fid, int command, void *arg)
 	}
 
 	return ret;
+	*/
+	return -FI_ENOSYS;
 }
 
 static struct fi_ops psmx2_fi_ops = {

--- a/prov/psm2/src/psmx2_eq.c
+++ b/prov/psm2/src/psmx2_eq.c
@@ -335,6 +335,7 @@ static int psmx2_eq_close(fid_t fid)
 
 static int psmx2_eq_control(struct fid *fid, int command, void *arg)
 {
+	/*
 	struct psmx2_fid_eq *eq;
 	int ret = 0;
 
@@ -350,6 +351,8 @@ static int psmx2_eq_control(struct fid *fid, int command, void *arg)
 	}
 
 	return ret;
+	*/
+	return -FI_ENOSYS;
 }
 
 static struct fi_ops psmx2_fi_ops = {

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -95,6 +95,7 @@ static struct fi_ops_fabric psmx2_fabric_ops = {
 	.passive_ep = fi_no_passive_ep,
 	.eq_open = psmx2_eq_open,
 	.wait_open = psmx2_wait_open,
+	.trywait = fi_no_trywait
 };
 
 int psmx2_fabric(struct fi_fabric_attr *attr,

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -281,6 +281,7 @@ static int sock_cntr_control(struct fid *fid, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
+		/*
 		switch (cntr->attr.wait_obj) {
 		case FI_WAIT_NONE:
 		case FI_WAIT_UNSPEC:
@@ -300,6 +301,8 @@ static int sock_cntr_control(struct fid *fid, int command, void *arg)
 			break;
 		}
 		break;
+		*/
+		return -FI_ENOSYS;
 
 	case FI_GETOPSFLAG:
 		memcpy(arg, &cntr->attr.flags, sizeof(uint64_t));

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -401,6 +401,7 @@ static struct fi_ops_cq sock_cq_ops = {
 
 static int sock_cq_control(struct fid *fid, int command, void *arg)
 {
+	/*
 	struct sock_cq *cq;
 	int ret = 0;
 
@@ -431,6 +432,8 @@ static int sock_cq_control(struct fid *fid, int command, void *arg)
 	}
 
 	return ret;
+	*/
+	return -FI_ENOSYS;
 }
 
 static struct fi_ops sock_cq_fi_ops = {

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -284,6 +284,7 @@ static int sock_eq_fi_close(struct fid *fid)
 
 static int sock_eq_control(struct fid *fid, int command, void *arg)
 {
+	/*
 	int ret = 0;
 	struct sock_eq *eq;
 
@@ -310,6 +311,8 @@ static int sock_eq_control(struct fid *fid, int command, void *arg)
 		break;
 	}
 	return ret;
+	*/
+	return -FI_ENOSYS;
 }
 
 static struct fi_ops sock_eq_fi_ops = {

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -283,6 +283,7 @@ static struct fi_ops_fabric sock_fab_ops = {
 	.passive_ep = sock_msg_passive_ep,
 	.eq_open = sock_eq_open,
 	.wait_open = sock_wait_open,
+	.trywait = fi_no_trywait
 };
 
 static int sock_fabric_close(fid_t fid)

--- a/prov/sockets/src/sock_wait.c
+++ b/prov/sockets/src/sock_wait.c
@@ -211,6 +211,7 @@ static struct fi_ops_wait sock_wait_ops = {
 
 static int sock_wait_control(struct fid *fid, int command, void *arg)
 {
+	/*
 	struct sock_wait *wait;
 	int ret = 0;
 
@@ -224,6 +225,8 @@ static int sock_wait_control(struct fid *fid, int command, void *arg)
 		break;
 	}
 	return ret;
+	*/
+	return -FI_ENOSYS;
 }
 
 int sock_wait_close(fid_t fid)

--- a/prov/udp/src/udpx_fabric.c
+++ b/prov/udp/src/udpx_fabric.c
@@ -42,6 +42,7 @@ static struct fi_ops_fabric udpx_fabric_ops = {
 	.passive_ep = fi_no_passive_ep,
 	.eq_open = fi_eq_create,
 	.wait_open = fi_wait_fd_open,
+	.trywait = fi_no_trywait
 };
 
 static int udpx_fabric_close(fid_t fid)

--- a/prov/udp/src/udpx_fabric.c
+++ b/prov/udp/src/udpx_fabric.c
@@ -36,13 +36,46 @@
 #include "udpx.h"
 
 
+static int udpx_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	struct util_cq *cq;
+	struct util_eq *eq;
+	struct util_wait *wait;
+	int i, ret;
+
+	for (i = 0; i < count; i++) {
+		switch (fids[i]->fclass) {
+		case FI_CLASS_CQ:
+			cq = container_of(fids[i], struct util_cq, cq_fid.fid);
+			wait = cq->wait;
+			break;
+		case FI_CLASS_EQ:
+			eq = container_of(fids[i], struct util_eq, eq_fid.fid);
+			wait = eq->wait;
+			break;
+		case FI_CLASS_CNTR:
+			return -FI_ENOSYS;
+		case FI_CLASS_WAIT:
+			wait = container_of(fids[i], struct util_wait, wait_fid.fid);
+			break;
+		default:
+			return -FI_EINVAL;
+		}
+
+		ret = wait->try(wait);
+		if (ret)
+			return ret;
+	}
+	return 0;
+}
+
 static struct fi_ops_fabric udpx_fabric_ops = {
 	.size = sizeof(struct fi_ops_fabric),
 	.domain = udpx_domain_open,
 	.passive_ep = fi_no_passive_ep,
 	.eq_open = fi_eq_create,
 	.wait_open = fi_wait_fd_open,
-	.trywait = fi_no_trywait
+	.trywait = udpx_trywait
 };
 
 static int udpx_fabric_close(fid_t fid)

--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -447,6 +447,7 @@ usdf_eq_strerror(struct fid_eq *feq, int prov_errno, const void *err_data,
 static int
 usdf_eq_control(fid_t fid, int command, void *arg)
 {
+	/*
 	struct usdf_eq *eq;
 
 	USDF_TRACE_SYS(EQ, "\n");
@@ -466,6 +467,8 @@ usdf_eq_control(fid_t fid, int command, void *arg)
 	}
 
 	return 0;
+	*/
+	return -FI_ENOSYS;
 }
 
 static int

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -802,6 +802,7 @@ static struct fi_ops_fabric usdf_ops_fabric = {
 	.passive_ep = usdf_pep_open,
 	.eq_open = usdf_eq_open,
 	.wait_open = fi_no_wait_open,
+	.trywait = fi_no_trywait
 };
 
 static int

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -154,8 +154,11 @@ static int util_wait_fd_control(struct fid *fid, int command, void *arg)
 	switch (command) {
 	case FI_GETWAIT:
 #ifdef HAVE_EPOLL
+		/*
 		*(int *) arg = wait->epoll_fd;
 		ret = 0;
+		*/
+		ret = -FI_ENOSYS;
 #else
 		ret = -FI_ENOSYS;
 #endif

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -116,23 +116,30 @@ static void util_wait_fd_signal(struct util_wait *util_wait)
 	fd_signal_set(&wait->signal);
 }
 
+static int util_wait_fd_try(struct util_wait *wait)
+{
+	struct util_wait_fd *wait_fd;
+	void *context;
+	int ret;
+
+	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
+	fd_signal_reset(&wait_fd->signal);
+	ret = fi_poll(&wait->pollset->poll_fid, &context, 1);
+	return (ret > 0) ? -FI_EAGAIN : ret;
+}
+
 static int util_wait_fd_run(struct fid_wait *wait_fid, int timeout)
 {
 	struct util_wait_fd *wait;
 	uint64_t start;
-	void *context;
 	int ret;
 
 	wait = container_of(wait_fid, struct util_wait_fd, util_wait.wait_fid);
 	start = (timeout >= 0) ? fi_gettime_ms() : 0;
 
 	while (1) {
-		fd_signal_reset(&wait->signal);
-
-		ret = fi_poll(&wait->util_wait.pollset->poll_fid, &context, 1);
-		if (ret > 0)
-			return 0;
-		else if (ret < 0)
+		ret = wait->util_wait.try(&wait->util_wait);
+		if (ret)
 			return ret;
 
 		if (timeout >= 0) {
@@ -141,7 +148,7 @@ static int util_wait_fd_run(struct fid_wait *wait_fid, int timeout)
 				return -FI_ETIMEDOUT;
 		}
 
-		context = fi_epoll_wait(wait->epoll_fd, timeout);
+		fi_epoll_wait(wait->epoll_fd, timeout);
 	}
 }
 
@@ -154,11 +161,8 @@ static int util_wait_fd_control(struct fid *fid, int command, void *arg)
 	switch (command) {
 	case FI_GETWAIT:
 #ifdef HAVE_EPOLL
-		/*
 		*(int *) arg = wait->epoll_fd;
 		ret = 0;
-		*/
-		ret = -FI_ENOSYS;
 #else
 		ret = -FI_ENOSYS;
 #endif
@@ -244,6 +248,7 @@ int fi_wait_fd_open(struct fid_fabric *fabric_fid, struct fi_wait_attr *attr,
 		goto err1;
 
 	wait->util_wait.signal = util_wait_fd_signal;
+	wait->util_wait.try = util_wait_fd_try;
 	ret = fd_signal_init(&wait->signal);
 	if (ret)
 		goto err2;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -336,6 +336,7 @@ static struct fi_ops_cq fi_ibv_cq_data_ops = {
 
 static int fi_ibv_cq_control(fid_t fid, int command, void *arg)
 {
+	/*
 	struct fi_ibv_cq *cq;
 	int ret = 0;
 
@@ -354,6 +355,8 @@ static int fi_ibv_cq_control(fid_t fid, int command, void *arg)
 	}
 
 	return ret;
+	*/
+	return -FI_ENOSYS;
 }
 
 static int fi_ibv_cq_close(fid_t fid)

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -268,6 +268,7 @@ static struct fi_ops_fabric fi_ibv_ops_fabric = {
 	.passive_ep = fi_ibv_passive_ep,
 	.eq_open = fi_ibv_eq_open,
 	.wait_open = fi_no_wait_open,
+	.trywait = fi_no_trywait
 };
 
 int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -306,6 +306,7 @@ static struct fi_ops_eq fi_ibv_eq_ops = {
 
 static int fi_ibv_eq_control(fid_t fid, int command, void *arg)
 {
+	/*
 	struct fi_ibv_eq *eq;
 	int ret = 0;
 
@@ -324,6 +325,8 @@ static int fi_ibv_eq_control(fid_t fid, int command, void *arg)
 	}
 
 	return ret;
+	*/
+	return -FI_ENOSYS;
 }
 
 static int fi_ibv_eq_close(fid_t fid)

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -74,6 +74,10 @@ int fi_no_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 {
 	return -FI_ENOSYS;
 }
+int fi_no_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	return -FI_ENOSYS;
+}
 
 /*
  * struct fi_ops_atomic


### PR DESCRIPTION
Add a new call that applications must use when waiting on the
native wait object associated with an EQ or CQ.  The expected
behavior is for apps to do something like this:

    while (1) {
        if (fi_trywait(cq, ...) == 0)
            poll(cq_fd, ...);
 
       do {
            ret = fi_cq_read(cq, ...);
        } while (ret > 0);
    }

The trywait call is responsible for performing any steps needed
to safely block on the underlying fd using standard OS calls.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>