### PR TITLE
prov/gni: Fix the assertion check on the CQ event

### DIFF
--- a/prov/gni/test/rdm_rx_overrun.c
+++ b/prov/gni/test/rdm_rx_overrun.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -234,9 +234,11 @@ Test(rdm_rx_overrun, all_to_one)
 		for (i = 1; i < NUM_EPS; i++) {
 			for (j = 0; j < num_msgs; j++) {
 				if (fi_cq_read(msg_cq[i], &s_cqe, 1) == 1) {
-					cr_assert_eq((uint64_t)
-						     s_cqe.op_context,
-						     (uint64_t) (ctx+i));
+					cr_assert(((uint64_t) s_cqe.op_context
+						   >= (uint64_t) ctx) &&
+						  ((uint64_t) s_cqe.op_context
+						   <=
+						   (uint64_t) (ctx+NUM_EPS-1)));
 					source_done += 1;
 				}
 			}
@@ -255,9 +257,11 @@ Test(rdm_rx_overrun, all_to_one)
 		for (i = 1; i < NUM_EPS; i++) {
 			for (j = 0; j < num_msgs; j++) {
 				if (fi_cq_read(msg_cq[0], &d_cqe, 1) == 1) {
-					cr_assert_eq((uint64_t)
-						     d_cqe.op_context,
-						     (uint64_t)(ctx+i));
+					cr_assert(((uint64_t) d_cqe.op_context
+						   >= (uint64_t) ctx) &&
+						  ((uint64_t) d_cqe.op_context
+						   <=
+						   (uint64_t) (ctx+NUM_EPS-1)));
 					dest_done += 1;
 				}
 			}


### PR DESCRIPTION
op_context

Just make sure the op_context is in the correct range.  The original
code assumed that the completion events would be returned in order.  I
can't believe this worked for so long.

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@9c97d85a7929c34674c2d49fc23e3a74ef9a2c91)
upstream merge of ofi-cray/libfabric-cray#673
@sungeunchoi 