### PR TITLE
prov/gni: fix type impacting FI_PROGRESS_ ...

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -309,7 +309,7 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 			if (hints->domain_attr->data_progress !=
 				FI_PROGRESS_UNSPEC)
 				data_progress =
-					hints->domain_attr->control_progress;
+					hints->domain_attr->data_progress;
 
 			switch (hints->domain_attr->mr_mode) {
 			case FI_MR_UNSPEC:


### PR DESCRIPTION
fix typo in toggling options for data_progress
on a domain.

relates to ofi-cray/libfabric-cray#668
relates to ofi-cray/libfabric-cray#676

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@5e25011fdd0b7d6a832e09c9f21a9d4de392017e)
upstream merge of ofi-cray/libfabric-cray#677
@sungeunchoi 