### PR TITLE
prov/gni: Modify progress functions to exit after

### DIFF
--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -272,7 +272,7 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req);
  * There are three facets of VC progress: RX, deferred work and TX.  The NIC
  * maintains one queue of VCs for each type of progress.  When a VC requires
  * progress, the associated _gnix_vc_<prog_type>_schedule() function is used to
- * schedule processing within _gnix_nic_vc_progress().  The queues are
+ * schedule processing within _gnix_vc_nic_progress().  The queues are
  * independent to prevent a stall in TX processing from delaying RX processing,
  * and so forth.
  *
@@ -295,7 +295,7 @@ int _gnix_vc_queue_tx_req(struct gnix_fab_req *req);
  *
  * @param[in] nic The GNIX NIC to progress.
  */
-int _gnix_nic_vc_progress(struct gnix_nic *nic);
+int _gnix_vc_nic_progress(struct gnix_nic *nic);
 
 /**
  * @brief  return vc associated with a given ep/dest address, or the ep in the

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015-16 Los Alamos National Security, LLC.
  *                       All rights reserved.
  *
@@ -285,9 +285,12 @@ int _gnix_dgram_free(struct gnix_datagram *d)
 
 	if (d->type == GNIX_DGRAM_BND) {
 		status = GNI_EpUnbind(d->gni_ep);
-		if (status != GNI_RC_SUCCESS)
-			assert(0);
+		if (status != GNI_RC_SUCCESS) {
 			/* TODO: have to handle this */
+			GNIX_FATAL(FI_LOG_EP_CTRL,
+				   "GNI_EpUnbind returned %s (ep=%p)\n",
+				   gni_err_str[status], d->gni_ep);
+		}
 	}
 
 	fastlock_acquire(&d->d_hndl->lock);

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -544,7 +544,7 @@ int _gnix_nic_progress(struct gnix_nic *nic)
 	if (unlikely(ret != FI_SUCCESS))
 		return ret;
 
-	ret = _gnix_nic_vc_progress(nic);
+	ret = _gnix_vc_nic_progress(nic);
 	if (unlikely(ret != FI_SUCCESS))
 		return ret;
 


### PR DESCRIPTION
any VC reschedules

The only way to really guarantee we break out of the progress loop is
to return when any VC is rescheduled.  Just checking that we don't see
the first VC again is not enough, as it could be another VC that is
repeatedly rescheduled.  If we don't break out of the progress loop,
we run into a potential deadlock situation when 2 or more endpoints
are trying to connect at the same time.

While in there I renamed __gnix_nic_vc_* functions to __gnix_vc_nic_*
to be consistent with our naming convention and changed a few
assert(0) calls to call GNIX_FATAL so that we could get better info
when we hit them.

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@1f4b6633f3cb253ee6d95d185c60a4bb31f94b4c)
upstream merge of ofi-cray/libfabric-cray#672
@sungeunchoi 