### PR TITLE
verbs: Don't throw error when user specifies only one of send or recv CQ

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -137,6 +137,7 @@ ssize_t fi_ibv_send(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr, size_t len
 	struct ibv_send_wr *bad_wr;
 	int ret;
 
+	assert(ep->scq);
 	wr->num_sge = count;
 	wr->wr_id = (uintptr_t) context;
 

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -45,6 +45,8 @@ fi_ibv_msg_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flag
 	size_t i;
 
 	_ep = container_of(ep, struct fi_ibv_msg_ep, ep_fid);
+	assert(_ep->rcq);
+
 	wr.wr_id = (uintptr_t) msg->context;
 	wr.next = NULL;
 	if (msg->iov_count) {


### PR DESCRIPTION
When user specifies only one of send or recv CQ, use it for both send and
recv CQs while creating the verbs QP.

Assert if we have corresponding CQ open in a send or recv operation.

Signed-off-by: Arun C Ilango <arun.ilango@intel.com>