### PR TITLE
usnic: Fix issues with IOV handling in EP_RDM and EP_MSG.

### DIFF
--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -639,8 +639,8 @@ usdf_msg_send_segment(struct usdf_tx *tx, struct usdf_ep *ep)
 		ptr = (uint8_t *)(hdr + 1);
 		while (resid > 0) {
 			memcpy(ptr, cur_ptr, cur_resid);
-			ptr += msg->ms_iov_resid;
-			resid -= msg->ms_iov_resid;
+			ptr += cur_resid;
+			resid -= cur_resid;
 			++cur_iov;
 			cur_ptr = msg->ms_iov[cur_iov].iov_base;
 			cur_resid = msg->ms_iov[cur_iov].iov_len;
@@ -692,7 +692,7 @@ usdf_msg_send_segment(struct usdf_tx *tx, struct usdf_ep *ep)
 				cur_ptr += sge_len;
 			} else {
 				sge_len = cur_resid;
-				if (num_sge == USDF_MSG_MAX_SGE - 1 ||
+				if (num_sge == USDF_MSG_MAX_SGE ||
 				    cur_resid == resid) {
 					eop = 1;
 				}

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -861,8 +861,8 @@ usdf_rdm_send_segment(struct usdf_tx *tx, struct usdf_rdm_connection *rdc)
 		sent = resid;
 		while (resid > 0) {
 			memcpy(ptr, cur_ptr, cur_resid);
-			ptr += wqe->rd_iov_resid;
-			resid -= wqe->rd_iov_resid;
+			ptr += cur_resid;
+			resid -= cur_resid;
 			++cur_iov;
 			cur_ptr = wqe->rd_iov[cur_iov].iov_base;
 			cur_resid = wqe->rd_iov[cur_iov].iov_len;
@@ -915,7 +915,7 @@ usdf_rdm_send_segment(struct usdf_tx *tx, struct usdf_rdm_connection *rdc)
 				cur_ptr += sge_len;
 			} else {
 				sge_len = cur_resid;
-				if (num_sge == USDF_RDM_MAX_SGE - 1 ||
+				if (num_sge == USDF_RDM_MAX_SGE ||
 				    cur_resid == resid) {
 					eop = 1;
 				}


### PR DESCRIPTION
- Counting of the IOV is in the range [1..USDF_MSG_MAX_SGE] not
  [0..USDF_MSG_MAX_SGE - 1]. The previous version was invalidly marking
  both the second to the last and the last packet with the eop flag.

  The context returned in the send completion is retrieved from the
  wp_context field of the post info. The usNIC provider only fills in
  this field once it has deemed a message as being RUDP_OP_LAST meaning
  the last message.

  Due to this bug, the second to the last message was had eop set and
  did not have a valid transmit context in the context field given by
  the send completion.

- Fix bug where the current pointer and remaining transmit data were
  always being shifted by the information associated with the first IOV
  entry when the amount being sent was below the copy limit. This caused
  a similar segmentation fault.

This is a partial solution to #1747.

When combined with #1594, the usNIC provider can pass the `fi_ubertest` for `EP_RDM`.
There is still a problem with the `EP_MSG` IOV handling that I am tracking down.

@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>