### PR TITLE
prov/gni: fixes for auto progress

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -266,8 +266,16 @@ struct gnix_smsg_rma_data_hdr {
  *
  * @var list             list element
  * @var gni_desc         embedded GNI post descriptor
- * @var gnix_smsg_desc   embedded gnix SMSG descriptor
+ * @var gnix_ct_descs    embedded GNI post descriptors for concatenated gets
+ *                       used for unaligned gets
+ * @var gnix_smsg_eager_hdr embedded header for SMSG eager protocol
+ * @var gnix_smsg_rndzv_start_hdr embedded header for rendezvous protocol
+ * @var gnix_smsg_rndzv_fin_hdr embedded header for rendezvous protocol
+ * @var gnix_smsg_rndzv_rma_data_hdr embedded header for remote notification for
+ *                       rma operations
  * @var req              pointer to fab request associated with this descriptor
+ * @var completer_fn     call back to invoke when associated GNI CQE's are
+ *                       returned.
  * @var id               the id of this descriptor - the value returned
  *                       from GNI_CQ_MSG_ID
  * @var err_list         Error TXD list entry

--- a/prov/gni/src/gnix_freelist.c
+++ b/prov/gni/src/gnix_freelist.c
@@ -202,7 +202,8 @@ void _gnix_sfe_free(struct slist_entry *e, struct gnix_s_freelist *fl)
 	assert(e);
 	assert(fl);
 
-	/* */
+	e->next = NULL;  /* keep slist implementation happy */
+
 	if (fl->ts)
 		fastlock_acquire(&fl->lock);
 	slist_insert_tail(e, &fl->freelist);


### PR DESCRIPTION
Turns out the return value of __nic_get_completed_txd
wasn't being checked, resulting in possible processing
of CQE's that had previously been processed.

Reworked __nic_get_completed_txd to always store a
value into txd (possibly NULL).

Updates ofi-cray/libfabric-cray#676
Updates ofi-cray/libfabric-cray#668

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@9ac10a3f7af7bf75b8bd7968c0e7283072c34710)
upstream merge of ofi-cray/libfabric-cray#679
@sungeunchoi 