### PR TITLE
usnic: Fix dereference before null check.

### DIFF
--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -799,7 +799,8 @@ usdf_ep_dgram_open(struct fid_domain *domain, struct fi_info *info,
 			rx_size = info->rx_attr->size;
 	}
 
-	ep->max_msg_size = info->ep_attr->max_msg_size;
+	if (info->ep_attr)
+		ep->max_msg_size = info->ep_attr->max_msg_size;
 
 	if (ep->ep_mode & FI_MSG_PREFIX) {
 		ep->ep_wqe = tx_size * ep->e.dg.tx_iov_limit;


### PR DESCRIPTION
@jsquyres @goodell 

Are we going to ever have a situation where the info struct being used isn't acquired through `fi_getinfo`? I think as long as `fi_getinfo` is used, then we'll always have `info->ep_attr` set and can eliminate these `NULL` checks.

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>