### PR TITLE
[RFC only] Shared memory support definitions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,7 @@ src_libfabric_la_SOURCES = \
 	include/fi_lock.h \
 	include/fi_mem.h \
 	include/fi_osd.h \
+	include/fi_proto.h \
 	include/fi_rbuf.h \
 	include/fi_signal.h \
 	include/fi_util.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -69,6 +69,7 @@ src_libfabric_la_SOURCES = \
 	include/fi_osd.h \
 	include/fi_proto.h \
 	include/fi_rbuf.h \
+	include/fi_shm.h \
 	include/fi_signal.h \
 	include/fi_util.h \
 	include/fasthash.h \

--- a/include/fi_proto.h
+++ b/include/fi_proto.h
@@ -51,7 +51,8 @@ enum {
 	ofi_op_tagged,
 	ofi_op_rma,
 	ofi_op_atomic,
-	ofi_op_ctrl
+	ofi_op_ctrl,
+	ofi_op_sar
 };
 
 enum {
@@ -59,6 +60,14 @@ enum {
 	ofi_ctrl_inject,
 	ofi_ctrl_iov,
 	ofi_ctrl_ack
+};
+
+/* Segmentation and reassembly */
+struct ofi_sar_hdr {
+	uint8_t			version;
+	uint8_t			op_ctrl;
+	uint16_t		seg_size;
+	uint32_t		seg_no;
 };
 
 /* Keep data items and size aligned */

--- a/include/fi_proto.h
+++ b/include/fi_proto.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_PROTO_H_
+#define _FI_PROTO_H_
+
+#include "config.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <rdma/fi_rma.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+enum {
+	ofi_op_msg,
+	ofi_op_tagged,
+	ofi_op_rma,
+	ofi_op_atomic,
+	ofi_op_ctrl
+};
+
+enum {
+	ofi_ctrl_inline,
+	ofi_ctrl_inject,
+	ofi_ctrl_iov,
+	ofi_ctrl_ack
+};
+
+/* Keep data items and size aligned */
+struct ofi_cmd_hdr {
+	uint8_t			version_rxid;
+	uint8_t			op_ctrl;
+	uint16_t		req_id;
+	uint32_t		flags;
+
+	uint64_t		size;
+	uint64_t		data;
+	union {
+		uint64_t	tag;
+		uint8_t		iov_len;
+		struct {
+			uint8_t	datatype;
+			uint8_t	op;
+			uint8_t ioc_len;
+		} atomic;
+		uint64_t	resv;
+	};
+};
+
+struct ofi_iov {
+	uint64_t		addr;
+	uint64_t		len;
+};
+
+struct ofi_rma_iov {
+	uint64_t		addr;
+	uint64_t		len;
+	uint64_t		key;
+};
+
+struct ofi_rma_ioc {
+	uint64_t		addr;
+	uint64_t		count;
+	uint64_t		key;
+};
+
+#define OFI_CMD_SIZE		64
+#define OFI_CMD_DATA_LEN	(OFI_CMD_SIZE - sizeof(struct ofi_cmd_hdr))
+
+struct ofi_cmd {
+	struct ofi_cmd_hdr	hdr;
+	union {
+		uint8_t		data[OFI_CMD_DATA_LEN];
+		uint64_t	buf;
+		struct iovec	iov[OFI_CMD_DATA_LEN / sizeof(struct iovec)];
+	};
+};
+
+/* Align with sizeof struct ofi_cmd */
+union ofi_cmd_data {
+	uint8_t			msg[OFI_CMD_SIZE];
+	struct iovec		iov[OFI_CMD_SIZE / sizeof(struct iovec)];
+	struct ofi_rma_iov	rma_iov[OFI_CMD_SIZE / sizeof(struct ofi_rma_iov)];
+	struct ofi_rma_ioc	rma_ioc[OFI_CMD_SIZE / sizeof(struct ofi_rma_ioc)];
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FI_PROTO_H_ */

--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_SHM_H_
+#define _FI_SHM_H_
+
+#include "config.h"
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include <fi_atom.h>
+#include <fi_mem.h>
+#include <fi_rbuf.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#define SMR_VERSION	1
+
+#ifdef HAVE_ATOMICS
+#define SMR_FLAG_ATOMIC	(1 << 0)
+#else
+#define SMR_FLAG_ATOMIC	(0 << 0)
+#endif
+
+#define SMR_FLAG_DEBUG	(1 << 1)
+
+
+struct shm_region {
+	uint8_t		version;
+	uint8_t		resv;
+	uint16_t	flags;
+	int		pid;
+	atomic_t	lock;
+	int		peer_size;
+
+	size_t		total_size;
+	size_t		rx_cmd_offset;
+	size_t		rx_ctrl_offset;
+	size_t		inject_buf_offset;
+
+	struct shm_region *peer[];
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _FI_SHM_H_ */

--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -39,6 +39,7 @@
 #include <stddef.h>
 
 #include <fi_atom.h>
+#include <fi_proto.h>
 #include <fi_mem.h>
 #include <fi_rbuf.h>
 
@@ -58,6 +59,9 @@ extern "C" {
 
 #define SMR_FLAG_DEBUG	(1 << 1)
 
+enum {
+	SMR_INJECT_SIZE = 4096
+};
 
 struct shm_region {
 	uint8_t		version;
@@ -74,6 +78,26 @@ struct shm_region {
 
 	struct shm_region *peer[];
 };
+
+struct smr_req {
+	void		*context;
+	void		*buffer;
+	uint64_t	flags;
+};
+
+struct smr_resp {
+	uint32_t	req_id;
+	uint32_t	status;
+};
+
+struct smr_inject_buf {
+	uint8_t		data[SMX_INJECT_SIZE];
+};
+
+DECLARE_CIRQUE(struct smr_cmd, smr_rx_cmdq);
+DECLARE_CIRQUE(struct smr_resp, smr_rx_ctrlq);
+DECLARE_FREESTACK(struct smr_req, smr_tx_ctx);
+DECLARE_FREESTACK(struct smr_inject_buf, smr_buf_pool);
 
 
 #ifdef __cplusplus

--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -99,6 +99,23 @@ DECLARE_CIRQUE(struct smr_resp, smr_rx_ctrlq);
 DECLARE_FREESTACK(struct smr_req, smr_tx_ctx);
 DECLARE_FREESTACK(struct smr_inject_buf, smr_buf_pool);
 
+struct smr_attr {
+	char		*name;
+	size_t		cmd_size;
+	size_t		cmd_count;
+	size_t		ctrl_size;
+	size_t		ctrl_count;
+	size_t		tx_size;
+	size_t		tx_count;
+	size_t		inject_size;
+	size_t		inject_count;
+	size_t		peer_count;
+};
+
+int smr_create(const struct smr_attr *attr, struct shm_region **smr);
+int smr_connect(struct shm_region *smr, const char *name, int *id);
+void smr_free(struct shm_region *smr);
+
 
 #ifdef __cplusplus
 }

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -107,7 +107,7 @@ struct udpx_ep {
 	struct udpx_cq		*tx_cq;
 	udpx_rx_comp_func	rx_comp;
 	udpx_tx_comp_func	tx_comp;
-	struct udpx_rx_cirq	rxq; /* protected by rx_cq lock */
+	struct udpx_rx_cirq	*rxq; /* protected by rx_cq lock */
 	uint64_t		caps;
 	uint64_t		flags;
 	size_t			min_multi_recv;
@@ -123,7 +123,7 @@ DECLARE_CIRQUE(struct fi_cq_data_entry, udpx_comp_cirq);
 
 struct udpx_cq {
 	struct util_cq		util_cq;
-	struct udpx_comp_cirq	cirq;
+	struct udpx_comp_cirq	*cirq;
 	fi_addr_t		*src;
 
 };


### PR DESCRIPTION
This series defines a set of data structures and helper routines that will be used to implement a set of shared memory primitives and provider.

1. Modify the cirque template to allow the user to allocate the memory region, rather than the template allocating the data buffers.
2. Introduce a new template that provides a fixed sized buffer pool, which also allows users to allocate the memory that is used.
3. Define the shm data structures that will be exposed between different processes.
4. Define the protocol structures for implementing libfabric features over shared memory.

Ideally, the shared memory protocol will have some overlap with the protocol used by the utility provider(s).