### PR TITLE
Remove aliased pages from 'SEE ALSO' sections.

### DIFF
--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -511,6 +511,5 @@ vectors.
 [`fi_getinfo`(3)](fi_getinfo.3.html),
 [`fi_endpoint`(3)](fi_endpoint.3.html),
 [`fi_av`(3)](fi_av.3.html),
-[`fi_ep`(3)](fi_ep.3.html),
 [`fi_eq`(3)](fi_eq.3.html),
 [`fi_mr`(3)](fi_mr.3.html)

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -571,6 +571,5 @@ Multiple threads may call
 
 # SEE ALSO
 
-[`fi_open`(3)](fi_open.3.html),
 [`fi_endpoint`(3)](fi_endpoint.3.html),
 [`fi_domain`(3)](fi_domain.3.html)

--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -168,7 +168,6 @@ values are:
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),
-[`fi_open_ops`(3)](fi_open_ops.3.html),
 [`fi_provider`(7)](fi_provider.7.html),
 [`fi_getinfo`(3)](fi_getinfo.3.html)
 

--- a/man/fi_trigger.3.md
+++ b/man/fi_trigger.3.md
@@ -89,5 +89,4 @@ the endpoint.
 
 [`fi_getinfo`(3)](fi_getinfo.3.html),
 [`fi_endpoint`(3)](fi_endpoint.3.html),
-[`fi_alias`(3)](fi_alias.3.html),
 [`fi_cntr`(3)](fi_cntr.3.html)

--- a/man/fi_usnic.7.md
+++ b/man/fi_usnic.7.md
@@ -158,5 +158,4 @@ See fi_ext_usnic.h for more details.
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),
-[`fi_open_ops`(3)](fi_open_ops.3.html),
 [`fi_provider`(7)](fi_provider.7.html),


### PR DESCRIPTION
They do not render on the web version since they are not generated.

@shefty @jithinjosepkl 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>