### PR TITLE
prov/gni: fix damage in gniprovider from efb285e

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -623,9 +623,11 @@ static int gnix_cq_signal(struct fid_cq *cq)
 
 static int gnix_cq_control(struct fid *cq, int command, void *arg)
 {
+	/* disabled until new trywait interface is implemented
 	struct gnix_fid_cq *cq_priv;
 
 	cq_priv = container_of(cq, struct gnix_fid_cq, cq_fid);
+	*/
 
 	switch (command) {
 	case FI_GETWAIT:

--- a/prov/gni/src/gnix_eq.c
+++ b/prov/gni/src/gnix_eq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -383,9 +383,11 @@ err:
 
 static int gnix_eq_control(struct fid *eq, int command, void *arg)
 {
+	/* disabled until new trywait interface is implemented
 	struct gnix_fid_eq *eq_priv;
 
 	eq_priv = container_of(eq, struct gnix_fid_eq, eq_fid);
+	*/
 
 	switch (command) {
 	case FI_GETWAIT:

--- a/prov/gni/src/gnix_wait.c
+++ b/prov/gni/src/gnix_wait.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -230,11 +230,13 @@ err:
  ******************************************************************************/
 static int gnix_wait_control(struct fid *wait, int command, void *arg)
 {
+	/* disabled until new trywait interface is implemented
 	struct fid_wait *wait_fid_priv;
 
 	GNIX_TRACE(WAIT_SUB, "\n");
 
 	wait_fid_priv = container_of(wait, struct fid_wait, fid);
+	*/
 
 	switch (command) {
 	case FI_GETWAIT:

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -522,7 +522,7 @@ Test(cq_msg, multi_sread, .init = cq_wait_unspec_setup)
 }
 
 TestSuite(cq_wait_obj, .fini = cq_teardown);
-TestSuite(cq_wait_control, .fini = cq_teardown);
+TestSuite(cq_wait_control, .fini = cq_teardown, .disabled = true);
 TestSuite(cq_wait_ops, .fini = cq_teardown);
 
 Test(cq_wait_obj, none, .init = cq_wait_none_setup)
@@ -625,7 +625,7 @@ Test(cq_wait_ops, fd, .init = cq_wait_fd_setup)
 		      "control implementation not available.");
 }
 
-Test(cq_wait_set, fd, .init = setup)
+Test(cq_wait_set, fd, .init = setup, .disabled = true)
 {
 	int ret;
 	int fd;

--- a/prov/gni/test/eq.c
+++ b/prov/gni/test/eq.c
@@ -160,7 +160,7 @@ Test(eq_wait_obj, mutex_cond, .init = eq_wait_mutex_cond_setup)
 	cr_expect_eq(wait_priv->cond_type, FI_CQ_COND_NONE);
 }
 
-TestSuite(eq_wait_control, .fini = eq_teardown);
+TestSuite(eq_wait_control, .fini = eq_teardown, .disabled = true);
 
 /*
 Test(eq_wait_control, none, .init = eq_wait_none_setup)
@@ -212,7 +212,7 @@ Test(eq_wait_control, mutex_cond, .init = eq_wait_mutex_cond_setup)
 	cr_expect_eq(0, ret, "cond compare failed.");
 }
 
-Test(eq_wait_set, fd, .init = _setup, .fini = _teardown)
+Test(eq_wait_set, fd, .init = _setup, .fini = _teardown, .disabled = true)
 {
 	int ret;
 	int fd;

--- a/prov/gni/test/wait.c
+++ b/prov/gni/test/wait.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -129,7 +129,8 @@ Test(wait_creation, mutex_cond, .init = mutex_cond_setup, .fini = wait_teardown)
 	cr_expect_eq(wait_priv->cond_type, FI_CQ_COND_NONE);
 }
 
-Test(wait_control, unspec, .init = unspec_setup, .fini = wait_teardown)
+Test(wait_control, unspec, .init = unspec_setup, .fini = wait_teardown,
+     .disabled = true)
 {
 	int fd;
 	int ret;
@@ -140,7 +141,8 @@ Test(wait_control, unspec, .init = unspec_setup, .fini = wait_teardown)
 	cr_expect_eq(wait_priv->fd[WAIT_READ], fd);
 }
 
-Test(wait_control, fd, .init = fd_setup, .fini = wait_teardown)
+Test(wait_control, fd, .init = fd_setup, .fini = wait_teardown,
+     .disabled = true)
 {
 	int fd;
 	int ret;
@@ -151,7 +153,8 @@ Test(wait_control, fd, .init = fd_setup, .fini = wait_teardown)
 	cr_expect_eq(wait_priv->fd[WAIT_READ], fd);
 }
 
-Test(wait_control, mutex_cond, .init = mutex_cond_setup, .fini = wait_teardown)
+Test(wait_control, mutex_cond, .init = mutex_cond_setup, .fini = wait_teardown,
+     .disabled = true)
 {
 	int ret;
 	struct fi_mutex_cond mutex_cond;


### PR DESCRIPTION
Upstream commit for the new trywait included disabling current
implementations of wait.

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@1d560f2166bfe1c07febf1a8f8e7f49a5d5329e3)
upsteam merge ofi-cray/libfabric-cray#685
@sungeunchoi 