### PR TITLE
usnic: Fix handling of info parameter passed to fi_passive_ep.

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -173,6 +173,7 @@ struct usdf_pep {
 	struct sockaddr_in pep_src_addr;
 	enum usdf_pep_state pep_state;
 	struct usdf_poll_item pep_pollitem;
+	struct fi_info *pep_info;
 
 	pthread_spinlock_t pep_cr_lock;
 	size_t pep_cr_max_data;


### PR DESCRIPTION
- Info parameter to fi_passive_ep can't be NULL.
- Connections opened using passive endpoints should inherit the
  properties of the fi_info struct used to open the passive endpoint.
  Store the info struct in the passive endpoint and grab the source
  address up front so it doesn't have to be retrieved each time.
- pep->pep_src_addr is set to the fabric address, even if 0 is passed as
  the src addrlen.

Closes #1801.

@goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>