### PR TITLE
usnic: usdf_msg.c: Clear receive state when a message has completed.

### DIFF
--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -1231,6 +1231,8 @@ usdf_msg_handle_recv(struct usdf_domain *udp, struct usd_completion *comp)
 		} else {
 			usdf_msg_recv_complete(ep, rqe);
 		}
+
+		ep->e.msg.ep_cur_recv = NULL;
 		break;
 	default:
 		break;


### PR DESCRIPTION
- The ep_cur_recv field is meant to track the current receive, once a
  receive has completed and the completion has been posted this should
  be sent to NULL so it is not acquired on the next call to handle_recv.
- This makes ubertest pass! (Only the quick test mode passes, still have issue otherwise)

This fixes #1747.

@goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>