### PR TITLE
prov/gni: function renaming

### DIFF
--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -311,7 +311,7 @@ int _gnix_vc_nic_progress(struct gnix_nic *nic);
  *                      memory to allocate vc, -FI_EINVAL if an invalid
  *                      argument was supplied
  */
-int _gnix_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
+int _gnix_vc_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 		    struct gnix_vc **vc_ptr);
 
 /**

--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -436,10 +436,10 @@ ssize_t _gnix_atomic(struct gnix_fid_ep *ep,
 	}
 
 	/* find VC for target */
-	rc = _gnix_ep_get_vc(ep, msg->addr, &vc);
+	rc = _gnix_vc_ep_get_vc(ep, msg->addr, &vc);
 	if (rc) {
 		GNIX_INFO(FI_LOG_EP_DATA,
-			  "_gnix_ep_get_vc() failed, addr: %lx, rc:\n",
+			  "_gnix_vc_ep_get_vc() failed, addr: %lx, rc:\n",
 			  msg->addr, rc);
 		goto err_get_vc;
 	}

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1281,10 +1281,10 @@ retry_match:
 				  req);
 
 			/* TODO: prevent re-lookup of src_addr */
-			ret = _gnix_ep_get_vc(ep, src_addr, &req->vc);
+			ret = _gnix_vc_ep_get_vc(ep, src_addr, &req->vc);
 			if (ret) {
 				GNIX_INFO(FI_LOG_EP_DATA,
-					  "_gnix_ep_get_vc failed: %dn",
+					  "_gnix_vc_ep_get_vc failed: %dn",
 					  ret);
 				return ret;
 			}
@@ -1585,7 +1585,7 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 		GNIX_INFO(FI_LOG_EP_DATA, "auto-reg MR: %p\n", auto_mr);
 	}
 
-	ret = _gnix_ep_get_vc(ep, dest_addr, &vc);
+	ret = _gnix_vc_ep_get_vc(ep, dest_addr, &vc);
 	if (ret) {
 		goto err_get_vc;
 	}

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -826,10 +826,10 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 	}
 
 	/* find VC for target */
-	rc = _gnix_ep_get_vc(ep, dest_addr, &vc);
+	rc = _gnix_vc_ep_get_vc(ep, dest_addr, &vc);
 	if (rc) {
 		GNIX_INFO(FI_LOG_EP_DATA,
-			  "_gnix_ep_get_vc() failed, addr: %lx, rc:\n",
+			  "_gnix_vc_ep_get_vc() failed, addr: %lx, rc:\n",
 			  dest_addr, rc);
 		return rc;
 	}

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -876,7 +876,7 @@ err:
 /*
  * callback function to process incoming messages
  */
-int __gnix_vc_recv_fn(struct gnix_cm_nic *cm_nic,
+static int __gnix_vc_recv_fn(struct gnix_cm_nic *cm_nic,
 		      char *msg_buffer,
 		      struct gnix_address src_cm_nic_addr)
 {
@@ -2011,7 +2011,7 @@ int _gnix_vc_schedule(struct gnix_vc *vc)
 	return FI_SUCCESS;
 }
 
-static int __gnix_ep_rdm_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
+static int __gnix_vc_ep_rdm_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 			    struct gnix_vc **vc_ptr)
 {
 	int ret = FI_SUCCESS;
@@ -2092,7 +2092,7 @@ err:
 	return ret;
 }
 
-int _gnix_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
+int _gnix_vc_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 			struct gnix_vc **vc_ptr)
 {
 	int ret;
@@ -2100,10 +2100,10 @@ int _gnix_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	if (ep->type == FI_EP_RDM) {
-		ret = __gnix_ep_rdm_get_vc(ep, dest_addr, vc_ptr);
+		ret = __gnix_vc_ep_rdm_get_vc(ep, dest_addr, vc_ptr);
 		if (unlikely(ret != FI_SUCCESS)) {
 			GNIX_WARN(FI_LOG_EP_DATA,
-				  "__gnix_ep_get_vc returned %s\n",
+				  "__gnix_vc_ep_get_vc returned %s\n",
 				   fi_strerror(-ret));
 			return ret;
 		}


### PR DESCRIPTION
rename some functions to comport more closely
with the gni provider's naming convention.

Change scope of a function to static that should
have been in the first place.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@99dc332f1d1df4cbf63202a1ee6ef80a7eeb009a)
upstream merge of ofi-cray/libfabric-cray#688
@sungeunchoi 