### PR TITLE
util: Define protocol headers for layered protocols

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -67,6 +67,7 @@ src_libfabric_la_SOURCES = \
 	include/fi_lock.h \
 	include/fi_mem.h \
 	include/fi_osd.h \
+	include/fi_proto.h \
 	include/fi_rbuf.h \
 	include/fi_signal.h \
 	include/fi_util.h \


### PR DESCRIPTION
Shared memory needs to define protocol headers for data
transfers between peers.  Similarly, there will need to
be protocol headers for implementing RDM over MSG, RDM
over DGRAM, MSG over DGRAM, etc.  Provide what can become
a common set of headers for libfabric <-> libfabric
communication.

This will be used by the shared memory provider.  It
should be usable by the sockets provider as well.  Other
layered implementations should examine if it meets their
needs, or if an alternate protocol is required.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>