### PR TITLE
verbs/RDM: buffered RMA operations works thru dedicated buffers

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -559,7 +559,7 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 		FI_IBV_RDM_ADDR_STR(_ep->my_rdm_addr));
 
 	_ep->n_buffs = FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM;
-	_ep->buff_len = FI_IBV_RDM_TAGGED_DFLT_BUFFER_SIZE;
+	_ep->buff_len = FI_IBV_RDM_DFLT_BUFFER_SIZE;
 	_ep->rndv_threshold = FI_IBV_RDM_DFLT_BUFFERED_SSIZE;
 
 	_ep->rq_wr_depth = FI_IBV_RDM_TAGGED_DFLT_RQ_SIZE;

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -69,15 +69,15 @@ struct fi_ibv_msg_ep;
 
 #define FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM (8)
 
-#define FI_IBV_RDM_TAGGED_DFLT_BUFFER_SIZE                              \
-	((8 * 1024 + FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE) +        \
-	 (8 * 1024 + FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE) %        \
+#define FI_IBV_RDM_DFLT_BUFFER_SIZE					\
+	((8 * 1024 + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE) +		\
+	 (8 * 1024 + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE) %		\
 	  FI_IBV_RDM_BUF_ALIGNMENT)
 
 #define FI_IBV_RDM_DFLT_BUFFERED_SSIZE					\
-	(FI_IBV_RDM_TAGGED_DFLT_BUFFER_SIZE -				\
-	 FI_IBV_RDM_TAGGED_BUFF_SERVICE_DATA_SIZE -			\
-	 sizeof(struct fi_ibv_rdm_tagged_header))
+	(FI_IBV_RDM_DFLT_BUFFER_SIZE -					\
+	 FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE -				\
+	 sizeof(struct fi_ibv_rdm_header))
 
 #define FI_IBV_RDM_TAGGED_DFLT_RQ_SIZE  (1000)
 


### PR DESCRIPTION
 - This change fixes hang of RMA ops mixed with TAGGED messaging due to buffers releasing moderation
 - Refactoring: somewhere prefix "tagged" is removed because the code is reused in RMA

@a-ilango 