### PR TITLE
libfabric.map: use AC_CONFIG_FILES to generate libfabric.map

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -265,9 +265,6 @@ dummy_man_pages = \
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libfabric.pc
 
-libfabric.map: libfabric.map.cpp
-	@$(CPP) $(CPPFLAGS) -I$(top_builddir) -P -C $< -o $@
-
 nroff:
 	@for file in $(real_man_pages); do \
 	    source=`echo $$file | sed -e 's@/man[0-9]@@'`; \
@@ -283,8 +280,6 @@ test:
 
 rpm: dist
 	rpmbuild -ta libfabric-*.tar.bz2
-
-CLEANFILES = libfabric.map
 
 prov_install_man_pages=
 prov_dist_man_pages=
@@ -302,7 +297,6 @@ man_MANS = $(real_man_pages) $(prov_install_man_pages) $(dummy_man_pages)
 
 EXTRA_DIST = \
         NEWS.md \
-        libfabric.map.cpp \
         libfabric.spec.in \
         config/distscript.pl \
         $(real_man_pages) $(prov_dist_man_pages) $(dummy_man_pages)

--- a/configure.ac
+++ b/configure.ac
@@ -233,20 +233,24 @@ FI_PROVIDER_SETUP_PC
 
 # If the user requested to build in direct mode, but
 # we have more than one provider, error.
+PROVIDER_DIRECT=no
+FI_DIRECT_PROVIDER_API_10=/dev/null
 AS_IF([test x"$enable_direct" != x"no"],
-	[AS_IF([test "$PROVIDERS_COUNT" -eq "1"],
-		[AC_SUBST(PROVIDER_DIRECT, "$enable_direct")]
-		[AC_DEFINE_UNQUOTED([FI_DIRECT_PROVIDER_API_10],
-				    ["prov/$enable_direct/provider_FABRIC_1.0.map"],
-				    [Define location of provider symbol script])]
-		AC_DEFINE([FABRIC_DIRECT_ENABLED], 1,
-		  [Define to 1 if building for fi_direct support]),
-		[AC_MSG_NOTICE([Only one provider can be chosen when using --enable-direct])
-		AC_MSG_ERROR(Cannot continue)])])
+      [AS_IF([test "$PROVIDERS_COUNT" -gt 1],
+	     [AC_MSG_WARN([Only one provider can be chosen when using --enable-direct])
+	      AC_MSG_ERROR(Cannot continue)])
 
+       PROVIDER_DIRECT=$enable_direct
+       FI_DIRECT_PROVIDER_API_10="prov/$enable_direct/provider_FABRIC_1.0.map"
+       AS_IF([test ! -r "$FI_DIRECT_PROVIDER_API_10"],
+	     [AC_MSG_WARN([--enable-direct=$enable_direct specified, but $FI_DIRECT_PROVIDER_API_10 does not exist])
+	      AC_MSG_ERROR([Cannot continue])])])
+
+AC_SUBST(PROVIDER_DIRECT)
+AC_SUBST_FILE(FI_DIRECT_PROVIDER_API_10)
 AM_CONDITIONAL([HAVE_DIRECT], [test x"$enable_direct" != x"no"])
 
-AC_CONFIG_FILES([Makefile libfabric.spec])
+AC_CONFIG_FILES([Makefile libfabric.spec libfabric.map])
 AC_OUTPUT
 
 dnl helpful output

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -1,4 +1,3 @@
-#include "config.h"
 FABRIC_1.0 {
 	global:
 		fi_getinfo;
@@ -14,8 +13,6 @@ FABRIC_1.0 {
 		fi_param_get;
 		fi_getparams;
 		fi_freeparams;
-#ifdef FABRIC_DIRECT_ENABLED
-#include FI_DIRECT_PROVIDER_API_10
-#endif
+		@FI_DIRECT_PROVIDER_API_10@
 	local: *;
 };


### PR DESCRIPTION
Also make the logic for checking for $enable_direct sligthly more straightforward, and also check for the existence of the provider's .map file during configure.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

This PR uses m4 to generate the libfabric.map (not the C preprocessor), and could replace #1828.

@bturrubiates @shefty @sayantansur @hppritcha Please review.  I do not have any direct providers with which to test this functionality.