### PR TITLE
usnic: ensure to really fail if we can't find libnl-route-3

### DIFF
--- a/prov/usnic/configure.m4
+++ b/prov/usnic/configure.m4
@@ -1,5 +1,5 @@
 dnl
-dnl Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+dnl Copyright (c) 2015-2016, Cisco Systems, Inc. All rights reserved.
 dnl
 dnl This software is available to you under a choice of one of two
 dnl licenses.  You may choose to be licensed under the terms of the GNU
@@ -294,7 +294,10 @@ AC_DEFUN([USNIC_CHECK_LIBNL3],[
 	# If we found everything
 	AS_IF([test $usnic_libnl3_happy -eq 1],
 	      [$2_LIBS="-lnl-3 -lnl-route-3"
-	       HAVE_LIBNL3=1])
+	       HAVE_LIBNL3=1],
+	      [$2_CPPFLAGS=
+	       $2_LDFLAGS=
+	       $2_LIBS=])
 ])
 
 dnl


### PR DESCRIPTION
Clear out the relevant flags so that the caller doesn't think we actually passed the libnl v3 check.

This could happen if configury finds libnl-3 just fine, but then fails to find libnl-route-3.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@bturrubiates Please review.