### PR TITLE
prov/gni: swat compiler warning

### DIFF
--- a/prov/gni/src/gnix_mr_cache.c
+++ b/prov/gni/src/gnix_mr_cache.c
@@ -405,7 +405,7 @@ static inline void __resolve_stale_entry_collision(
 		RbtIterator found,
 		gnix_mr_cache_entry_t *entry)
 {
-	RbtStatus rc;
+	RbtStatus __attribute__((unused)) rc;
 	gnix_mr_cache_entry_t *c_entry, *tmp;
 	gnix_mr_cache_key_t *c_key;
 	int ret;


### PR DESCRIPTION
Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@3f5125c9ba2bcc707ed3df120da38cb2f86465fa)
upstream merge of ofi-cray/libfabric-cray#687
@sungeunchoi 