### PR TITLE
usnic: Implement waitsets

### DIFF
--- a/prov/usnic/Makefile.include
+++ b/prov/usnic/Makefile.include
@@ -1,3 +1,39 @@
+#
+# Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# BSD license below:
+#
+#     Redistribution and use in source and binary forms, with or
+#     without modification, are permitted provided that the following
+#     conditions are met:
+#
+#      - Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      - Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials
+#        provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+
 if HAVE_USNIC
 libusnic_direct_sources = \
 	prov/usnic/src/usnic_direct/cq_desc.h \
@@ -95,7 +131,9 @@ _usnic_files = \
 	prov/usnic/src/usdf_timer.h \
 	prov/usnic/src/usdf_poll.c \
 	prov/usnic/src/usdf_poll.h \
-	prov/usnic/src/usdf_ext.c
+	prov/usnic/src/usdf_ext.c \
+	prov/usnic/src/usdf_wait.h \
+	prov/usnic/src/usdf_wait.c
 
 if HAVE_VERBS
 _usnic_files += prov/usnic/src/usdf_fake_ibv.c

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -376,6 +376,11 @@ struct usdf_cq {
 	struct fi_cq_attr cq_attr;
 
 	union {
+		int fd;
+		struct fi_mutex_cond mutex_cond;
+	} object;
+
+	union {
 		struct {
 			struct usd_cq *cq_cq;
 		} hard;

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -107,6 +107,7 @@ struct usdf_fabric {
 	struct usd_device_attrs *fab_dev_attrs;
 	int fab_arp_sockfd;
 	atomic_t fab_refcnt;
+	atomic_t num_blocked_waiting;
 	LIST_HEAD(,usdf_domain) fab_domain_list;
 
 	/* progression */

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -431,7 +431,7 @@ struct usdf_eq {
 	atomic_t eq_num_events;
 
 	/* various ways to wait */
-	enum fi_wait_obj eq_wait_obj;
+	struct fi_eq_attr eq_attr;
 	union {
 		int eq_fd;
 	};

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -374,6 +374,7 @@ struct usdf_cq {
 	atomic_t cq_refcnt;
 	struct usdf_domain *cq_domain;
 	struct fi_cq_attr cq_attr;
+	uint8_t is_soft;
 
 	union {
 		int fd;
@@ -395,6 +396,7 @@ struct usdf_cq {
 		} soft;
 	} c;
 	struct usd_completion cq_comp;
+	struct fi_ops_cq cq_ops;
 };
 
 enum {

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -746,6 +746,8 @@ usdf_cq_close(fid_t fid)
 				return -FI_EBUSY;
 			}
 			TAILQ_REMOVE(&cq->c.soft.cq_list, hcq, cqh_link);
+			TAILQ_REMOVE(&cq->cq_domain->dom_hcq_list, hcq,
+					cqh_dom_link);
 			if (hcq->cqh_ucq != NULL) {
 				ret = usd_destroy_cq(hcq->cqh_ucq);
 				if (ret != 0) {

--- a/prov/usnic/src/usdf_cq.h
+++ b/prov/usnic/src/usdf_cq.h
@@ -45,6 +45,7 @@ int usdf_cq_make_soft(struct usdf_cq *cq);
 int usdf_cq_create_cq(struct usdf_cq *cq);
 int usdf_check_empty_hard_cq(struct usdf_cq *cq);
 int usdf_check_empty_soft_cq(struct usdf_cq *cq);
+int usdf_cq_trywait(struct fid *fcq);
 
 void usdf_progress_hard_cq(struct usdf_cq_hard *hcq);
 

--- a/prov/usnic/src/usdf_cq.h
+++ b/prov/usnic/src/usdf_cq.h
@@ -42,7 +42,7 @@
 #define SREAD_MAX_SLEEP_TIME_US 5000
 
 int usdf_cq_make_soft(struct usdf_cq *cq);
-int usdf_cq_create_cq(struct usdf_cq *cq);
+int usdf_cq_create_cq(struct usdf_cq *cq, struct usd_cq **ucq, int create_fd);
 int usdf_check_empty_hard_cq(struct usdf_cq *cq);
 int usdf_check_empty_soft_cq(struct usdf_cq *cq);
 int usdf_cq_trywait(struct fid *fcq);

--- a/prov/usnic/src/usdf_cq.h
+++ b/prov/usnic/src/usdf_cq.h
@@ -41,7 +41,6 @@
 #define SREAD_INIT_SLEEP_TIME_US 1
 #define SREAD_MAX_SLEEP_TIME_US 5000
 
-int usdf_cq_is_soft(struct usdf_cq *cq);
 int usdf_cq_make_soft(struct usdf_cq *cq);
 int usdf_cq_create_cq(struct usdf_cq *cq);
 int usdf_check_empty_hard_cq(struct usdf_cq *cq);

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -109,7 +109,7 @@ usdf_dom_rdc_free_data(struct usdf_domain *udp)
 		pthread_spin_unlock(&udp->dom_progress_lock);
 
 		/* XXX probably want a timeout here... */
-		while (atomic_get(&udp->dom_rdc_free_cnt) < 
+		while (atomic_get(&udp->dom_rdc_free_cnt) <
 		       (int)udp->dom_rdc_total) {
 			pthread_yield();
 		}

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -177,7 +177,7 @@ usdf_ep_dgram_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		/* actually, could look through CQ list for a hard
 		 * CQ with function usd_poll_cq() and use that... XXX
 		 */
-		if (usdf_cq_is_soft(cq)) {
+		if (cq->is_soft) {
 			return -FI_EINVAL;
 		}
 		if (cq->c.hard.cq_cq == NULL) {
@@ -248,7 +248,7 @@ usdf_ep_dgram_deref_cq(struct usdf_cq *cq)
 
 	rtn = usdf_progress_hard_cq;
 
-	if (usdf_cq_is_soft(cq)) {
+	if (cq->is_soft) {
 		TAILQ_FOREACH(hcq, &cq->c.soft.cq_list, cqh_link) {
 			if (hcq->cqh_progress == rtn) {
 				atomic_dec(&hcq->cqh_refcnt);

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -45,6 +45,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
@@ -181,7 +182,7 @@ usdf_ep_dgram_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			return -FI_EINVAL;
 		}
 		if (cq->c.hard.cq_cq == NULL) {
-			ret = usdf_cq_create_cq(cq);
+			ret = usdf_cq_create_cq(cq, &cq->c.hard.cq_cq, true);
 			if (ret != 0) {
 				return ret;
 			}

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -45,6 +45,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
+#include <sys/eventfd.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
@@ -637,23 +639,31 @@ usdf_ep_rdm_bind_cq(struct usdf_ep *ep, struct usdf_cq *cq, uint64_t flags)
 		return ret;
 	}
 
+	if ((cq->cq_attr.wait_obj == FI_WAIT_FD) ||
+			(cq->cq_attr.wait_obj == FI_WAIT_SET)) {
+		cq->object.fd = eventfd(0, EFD_NONBLOCK | EFD_SEMAPHORE);
+		if (cq->object.fd == -1) {
+			USDF_DBG_SYS(CQ, "creating eventfd failed: %s\n",
+					strerror(errno));
+			return -errno;
+		}
+
+		USDF_DBG_SYS(CQ, "successfully created eventfd: %d\n",
+				cq->object.fd);
+	}
+
 	/* Use existing rdm CQ if present */
 	hcq = usdf_ep_rdm_find_cqh(cq);
 	if (hcq == NULL) {
-		struct usd_cq_init_attr attr;
 		hcq = malloc(sizeof(*hcq));
 		if (hcq == NULL) {
 			return -errno;
 		}
 
-		memset(&attr, 0, sizeof(attr));
-		attr.num_entries = 8195, /* XXX */
-		attr.comp_fd = -1;
-		ret = usd_create_cq(cq->cq_domain->dom_dev, &attr,
-					&hcq->cqh_ucq);
-		if (ret != 0) {
+		ret = usdf_cq_create_cq(cq, &hcq->cqh_ucq, false);
+		if (ret)
 			goto fail;
-		}
+
 		hcq->cqh_cq = cq;
 		atomic_initialize(&hcq->cqh_refcnt, 0);
 		hcq->cqh_progress = usdf_rdm_hcq_progress;

--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -324,10 +324,25 @@ usdf_eq_strerror(struct fid_eq *feq, int prov_errno, const void *err_data,
 	return NULL;
 }
 
+static int usdf_eq_get_wait(struct usdf_eq *eq, void *arg)
+{
+	USDF_TRACE_SYS(EQ, "\n");
+
+	switch (eq->eq_wait_obj) {
+	case FI_WAIT_FD:
+		*(int *) arg = eq->eq_fd;
+		break;
+	default:
+		USDF_WARN_SYS(EQ, "unsupported wait type\n");
+		return -FI_EINVAL;
+	}
+
+	return FI_SUCCESS;
+}
+
 static int
 usdf_eq_control(fid_t fid, int command, void *arg)
 {
-	/*
 	struct usdf_eq *eq;
 
 	USDF_TRACE_SYS(EQ, "\n");
@@ -336,19 +351,12 @@ usdf_eq_control(fid_t fid, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
-		if (eq->eq_wait_obj == FI_WAIT_FD) {
-			*(int *)arg = eq->eq_fd;
-		} else {
-			return -FI_ENODATA;
-		}
 		break;
 	default:
 		return -FI_EINVAL;
 	}
 
-	return 0;
-	*/
-	return -FI_ENOSYS;
+	return usdf_eq_get_wait(eq, arg);
 }
 
 static int

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -844,14 +844,6 @@ usdf_fabric_open(struct fi_fabric_attr *fattrp, struct fid_fabric **fabric,
 		goto fail;
 	}
 
-	ret = pthread_create(&fp->fab_thread, NULL,
-			usdf_fabric_progression_thread, fp);
-	if (ret != 0) {
-		ret = -ret;
-		USDF_INFO("unable to create progress thread\n");
-		goto fail;
-	}
-
 	/* create and bind socket for ARP resolution */
 	memset(&sin, 0, sizeof(sin));
 	sin.sin_family = AF_INET;
@@ -868,6 +860,16 @@ usdf_fabric_open(struct fi_fabric_attr *fattrp, struct fid_fabric **fabric,
 	}
 
 	atomic_initialize(&fp->fab_refcnt, 0);
+	atomic_initialize(&fp->num_blocked_waiting, 0);
+
+	ret = pthread_create(&fp->fab_thread, NULL,
+			usdf_fabric_progression_thread, fp);
+	if (ret != 0) {
+		ret = -ret;
+		USDF_INFO("unable to create progress thread\n");
+		goto fail;
+	}
+
 	fattrp->fabric = fab_utof(fp);
 	fattrp->prov_version = USDF_PROV_VERSION;
 	*fabric = fab_utof(fp);

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -66,6 +66,7 @@
 #include "libnl_utils.h"
 
 #include "usdf.h"
+#include "usdf_wait.h"
 #include "fi_ext_usnic.h"
 #include "usdf_progress.h"
 #include "usdf_timer.h"
@@ -752,7 +753,7 @@ static struct fi_ops_fabric usdf_ops_fabric = {
 	.domain = usdf_domain_open,
 	.passive_ep = usdf_pep_open,
 	.eq_open = usdf_eq_open,
-	.wait_open = fi_no_wait_open,
+	.wait_open = usdf_wait_open,
 	.trywait = fi_no_trywait
 };
 

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -754,7 +754,7 @@ static struct fi_ops_fabric usdf_ops_fabric = {
 	.passive_ep = usdf_pep_open,
 	.eq_open = usdf_eq_open,
 	.wait_open = usdf_wait_open,
-	.trywait = fi_no_trywait
+	.trywait = usdf_trywait
 };
 
 static int

--- a/prov/usnic/src/usdf_poll.c
+++ b/prov/usnic/src/usdf_poll.c
@@ -67,7 +67,7 @@ static int usdf_poll_poll(struct fid_poll *fps, void **context, int count)
 
 		cq = cq_fidtou(entry->fid);
 
-		if (usdf_cq_is_soft(cq)) {
+		if (cq->is_soft) {
 			if (!progressed) {
 				usdf_domain_progress(ps->poll_domain);
 				progressed = 1;

--- a/prov/usnic/src/usdf_progress.c
+++ b/prov/usnic/src/usdf_progress.c
@@ -92,6 +92,7 @@ usdf_fabric_progression_thread(void *v)
 	struct epoll_event ev;
 	struct usdf_poll_item *pip;
 	struct usdf_domain *dom;
+	int num_blocked_waiting;
 	int sleep_time;
 	int epfd;
 	int ret;
@@ -101,9 +102,11 @@ usdf_fabric_progression_thread(void *v)
 	epfd = fp->fab_epollfd;
 
 	while (1) {
+		num_blocked_waiting = atomic_get(&fp->num_blocked_waiting);
 
 		/* sleep inifinitely if nothing to do */
-		if (fp->fab_active_timer_count > 0) {
+		if ((fp->fab_active_timer_count > 0) ||
+				(num_blocked_waiting > 0)) {
 			sleep_time = 1;
 		} else {
 			sleep_time = -1;

--- a/prov/usnic/src/usdf_progress.c
+++ b/prov/usnic/src/usdf_progress.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -91,6 +91,7 @@ usdf_fabric_progression_thread(void *v)
 	struct usdf_fabric *fp;
 	struct epoll_event ev;
 	struct usdf_poll_item *pip;
+	struct usdf_domain *dom;
 	int sleep_time;
 	int epfd;
 	int ret;
@@ -124,6 +125,10 @@ usdf_fabric_progression_thread(void *v)
 
 		/* call timer progress each wakeup */
 		usdf_timer_progress(fp);
+
+		LIST_FOREACH(dom, &fp->fab_domain_list, dom_link) {
+			usdf_domain_progress(dom);
+		}
 	}
 }
 

--- a/prov/usnic/src/usdf_wait.c
+++ b/prov/usnic/src/usdf_wait.c
@@ -236,70 +236,33 @@ static int usdf_wait_close(struct fid *waitset)
 
 static int usdf_wait_wait(struct fid_wait *fwait, int timeout)
 {
-	struct usdf_cq *cq;
-	struct usdf_wait *wait_priv;
-	struct epoll_event *events;
-	const int max_events = 64;
-	uint64_t ev;
-	ssize_t ret;
-	int nrevents;
-	int i;
+	struct usdf_wait *wait;
+	struct epoll_event event;
+	struct fid *fids[1];
+	int ret = FI_SUCCESS;
+	int nevents;
 
 	USDF_TRACE_SYS(FABRIC, "\n");
-	wait_priv = wait_ftou(fwait);
+	wait = wait_ftou(fwait);
 
-	switch (wait_priv->wait_obj) {
-	case FI_WAIT_FD:
-	case FI_WAIT_UNSPEC:
-		break;
-	default:
-		USDF_WARN_SYS(FABRIC,
-				"unsupported wait object\n");
-		return -FI_EINVAL;
+	fids[0] = &fwait->fid;
+
+	ret = usdf_trywait(&wait->wait_fabric->fab_fid, fids, 1);
+	if (ret) {
+		if (ret == -FI_EAGAIN)
+			return FI_SUCCESS;
+
+		return ret;
 	}
 
-	/* TODO: Change this to something real instead of maximum of 64 events.
-	 * This is just for testing purposes. Could also possibly statically
-	 * allocate this...
-	 */
-	events = calloc(max_events, sizeof(*events));
-	if (!events) {
-		USDF_DBG_SYS(FABRIC, "calloc for events failed\n");
-		return -FI_ENOMEM;
-	}
-
-	nrevents = epoll_wait(wait_priv->object.epfd, events, max_events,
-			timeout);
-	if (nrevents == 0) {
+	nevents = epoll_wait(wait->object.epfd, &event, 1, timeout);
+	if (nevents == 0) {
 		ret = -FI_ETIMEDOUT;
-		goto out;
-	} else if (nrevents < 0) {
+	} else if (nevents < 0) {
 		USDF_DBG_SYS(FABRIC, "epoll wait failed\n");
 		ret = -errno;
-		goto out;
 	}
 
-	for (i = 0; i < nrevents; i++) {
-		cq = events[i].data.ptr;
-		for (;;) {
-			ret = read(cq->object.fd, &ev, sizeof(ev));
-			if (ret < 0 && errno != EAGAIN) {
-				USDF_WARN_SYS(FABRIC,
-						"failed with errno: %d\n",
-						errno);
-				ret = -errno;
-				goto out;
-			} else if (errno == EAGAIN) {
-				break;
-			}
-		}
-		usd_poll_req_notify(cq->c.hard.cq_cq);
-	}
-
-	ret = FI_SUCCESS;
-
-out:
-	free(events);
 	return ret;
 }
 

--- a/prov/usnic/src/usdf_wait.c
+++ b/prov/usnic/src/usdf_wait.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/* This needs to be included for usdf.h */
+#include "fi.h"
+#include "fi_enosys.h"
+
+#include "usdf.h"
+#include "usdf_wait.h"
+
+
+/* Necessary to support top-of-file struct declarations. */
+static int usdf_wait_close(struct fid *waitset);
+
+static struct fi_ops_wait usdf_wait_ops = {
+	.size = sizeof(struct fi_ops_wait),
+};
+
+static struct fi_ops usdf_wait_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = usdf_wait_close,
+	.bind = fi_no_bind,
+	.ops_open = fi_no_ops_open
+};
+
+/* Since a domain hasn't been opened at the time of wait object creation, open a
+ * device temporarily to check for the group interrupt capability.
+ */
+static int usdf_wait_check_support(struct usdf_fabric *fabric_priv)
+{
+	struct usd_open_params params = {
+		.flags = UOPF_SKIP_PD_ALLOC,
+		.cmd_fd = -1,
+		.context = NULL
+	};
+	struct usd_device *dev;
+	int ret;
+
+	ret = usd_open_with_params(fabric_priv->fab_dev_attrs->uda_devname,
+			&params, &dev);
+	if (ret) {
+		USDF_DBG_SYS(FABRIC,
+				"opening device to check fd support failed.\n");
+		return ret;
+	}
+
+	if (!usd_get_cap(dev, USD_CAP_GRP_INTR)) {
+		USDF_WARN_SYS(FABRIC, "FD request invalid.\n");
+		USDF_WARN_SYS(FABRIC, "group interrupts not supported.\n");
+		ret = usd_close(dev);
+		if (ret)
+			USDF_WARN_SYS(FABRIC, "closing usd device failed: %s\n",
+					strerror(ret));
+
+		return -FI_EOPNOTSUPP;
+	}
+
+	return usd_close(dev);
+}
+
+/* Non-static because this is exported due to being returned as a callback for
+ * fabric ops.
+ *
+ * Supporting wait objects in the usNIC provider is done using an epoll
+ * context. When fi_wait_open is called an epoll context is created using
+ * epoll_create1. This simplifies multi-CQ support and also allows us to get
+ * around a limitation of the usNIC provider. IB completion channels are opened
+ * on the domain because we have a context associated with the domain. At
+ * fi_wait_open time, we only have access to the fabric. It isn't guaranteed
+ * that a domain has been opened yet. The epoll context approach allows us to
+ * defer creating the completion channel for the CQ until CQ open time.
+ */
+int usdf_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		struct fid_wait **waitset)
+{
+	struct usdf_wait *wait_priv;
+	struct usdf_fabric *fabric_priv;
+	int epfd;
+	int ret;
+
+	USDF_TRACE_SYS(FABRIC, "\n");
+
+	switch (attr->wait_obj) {
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+		break;
+	default:
+		USDF_WARN_SYS(FABRIC, "unsupported wait object type\n");
+		ret = -FI_EINVAL;
+		goto error;
+	}
+
+	fabric_priv = fab_fidtou(fabric);
+	ret = usdf_wait_check_support(fabric_priv);
+	if (ret)
+		goto error;
+
+	epfd = epoll_create1(0);
+	if (epfd < 0) {
+		USDF_WARN_SYS(FABRIC, "failed to create epoll fd[%d]\n", errno);
+		ret = -errno;
+		goto error;
+	}
+
+	USDF_DBG_SYS(FABRIC, "successfully created epoll fd: %d\n", epfd);
+
+	wait_priv = calloc(1, sizeof(*wait_priv));
+	if (!wait_priv) {
+		USDF_WARN_SYS(FABRIC,
+				"unable to allocate memory for usdf_wait obj");
+		ret = -FI_ENOMEM;
+		goto calloc_fail;
+	}
+
+	wait_priv->wait_fid.fid.fclass = FI_CLASS_WAIT;
+	wait_priv->wait_fid.fid.ops = &usdf_wait_fi_ops;
+	wait_priv->wait_fid.ops = &usdf_wait_ops;
+	wait_priv->wait_fid.fid.context = 0;
+	wait_priv->wait_fabric = fabric_priv;
+	wait_priv->wait_obj = attr->wait_obj;
+	wait_priv->object.epfd = epfd;
+
+	atomic_initialize(&wait_priv->wait_refcnt, 0);
+	fastlock_init(&wait_priv->lock);
+	dlist_init(&wait_priv->list);
+
+	atomic_inc(&wait_priv->wait_fabric->fab_refcnt);
+
+	*waitset = &wait_priv->wait_fid;
+
+	return FI_SUCCESS;
+
+calloc_fail:
+	close(epfd);
+error:
+	*waitset = NULL;
+	return ret;
+}
+
+/* Close a wait object. Make sure all resources associated with the wait object
+ * have been closed.
+ */
+static int usdf_wait_close(struct fid *waitset)
+{
+	struct usdf_wait *wait_priv;
+
+	USDF_TRACE_SYS(FABRIC, "\n");
+	if (!waitset) {
+		USDF_WARN_SYS(FABRIC, "invalid input.\n");
+		return -FI_EINVAL;
+	}
+
+	wait_priv = wait_ftou(waitset);
+
+	if (atomic_get(&wait_priv->wait_refcnt) > 0) {
+		USDF_DBG_SYS(FABRIC,
+				"failed to close waitset with non-zero refcnt");
+		return -FI_EBUSY;
+	}
+
+	switch (wait_priv->wait_obj) {
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_FD:
+		close(wait_priv->object.epfd);
+		break;
+	default:
+		USDF_WARN_SYS(FABRIC,
+				"unsupported wait object type\n");
+		return -FI_EINVAL;
+	}
+
+	atomic_dec(&wait_priv->wait_fabric->fab_refcnt);
+	free(wait_priv);
+
+	return FI_SUCCESS;
+}
+

--- a/prov/usnic/src/usdf_wait.h
+++ b/prov/usnic/src/usdf_wait.h
@@ -60,5 +60,6 @@ struct usdf_wait {
 
 int usdf_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		struct fid_wait **waitset);
+int usdf_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
 
 #endif

--- a/prov/usnic/src/usdf_wait.h
+++ b/prov/usnic/src/usdf_wait.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _USDF_WAIT_H_
+#define _USDF_WAIT_H_
+
+#include "fi_list.h"
+
+struct usdf_wait {
+	struct fid_wait		wait_fid;
+	struct usdf_fabric	*wait_fabric;
+
+	enum fi_wait_obj	wait_obj;
+	union {
+		int epfd;
+		struct fi_mutex_cond mutex_cond;
+	} object;
+
+	atomic_t		wait_refcnt;
+
+	fastlock_t		lock;
+	struct dlist_entry	list;
+};
+
+#define wait_ftou(FWT) container_of(FWT, struct usdf_wait, wait_fid)
+#define wait_fidtou(FWT) container_of(FWT, struct usdf_wait, wait_fid.fid)
+
+int usdf_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		struct fid_wait **waitset);
+
+#endif


### PR DESCRIPTION
At the moment this only implements waitsets for `FI_EP_DGRAM`. Still working on the emulated endpoint support. 

This has been tested with `fi_dgram_waitset` and a modified `fi_ud_pingpong`. 

- [x] Support EQ for waitset
- [x] Support waitset for emulated endpoints
- [x] Support CQ for waitsets
- [x] Support waitset for hardware based endpoints (`FI_EP_DGRAM`)
- [x] Implement FD based `fi_cq_sread`
- [x] Implement `fi_trywait`

@goodell @jsquyres 