### PR TITLE
prov/gni: handle fi_endpoint_enable better

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -382,7 +382,8 @@ struct gnix_fid_ep {
 	int (*progress_fn)(struct gnix_fid_ep *, enum gnix_progress_type);
 	/* RX specific progress fn */
 	int (*rx_progress_fn)(struct gnix_fid_ep *, gni_return_t *rc);
-	int enabled;
+	bool tx_enabled;
+	bool rx_enabled;
 	int send_selective_completion;
 	int recv_selective_completion;
 	int min_multi_recv;


### PR DESCRIPTION
correctly set tx/rx enable when an app calls
fi_ep_enable.  Return -FI_ENOCQ if the ep
hasn't been binded to a CQ.

Enahnce a criterion test to check for the
-FI_ENOCQ error return when an attempting
to enable a ep which has not been bound to
a CQ.

Fixes ofi-cray/libfabric-cray#704

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@8aff71a3c53149c916b896582dfa398b04d8a642)
upstream merge of ofi-cray/libfabric-cray#705
@sungeunchoi 