### PR TITLE
verbs: Define AF_IB, RAI_FAMILY if they are not defined already.

### DIFF
--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -278,7 +278,7 @@ if ($rebuilt_libfabric) {
 # Run the coverity script if requested
 if (defined($libfabric_coverity_token_arg) && $rebuilt_libfabric) {
     submit_to_coverity("ofiwg%2Flibfabric", $libfabric_version,
-            "--enable-sockets --enable-udp --enable-usnic",
+            "--enable-sockets --enable-udp --enable-verbs --enable-usnic",
             $libfabric_coverity_token_arg);
 }
 if (defined($fabtests_coverity_token_arg) && $rebuilt_fabtests) {

--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -25,7 +25,7 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 	       FI_CHECK_PACKAGE([verbs_rdmacm],
 				[rdma/rsocket.h],
 				[rdmacm],
-				[riowrite],
+				[rdma_create_qp],
 				[],
 				[$verbs_PREFIX],
 				[$verbs_LIBDIR],

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -69,6 +69,13 @@
 #include "fi_list.h"
 #include "fi_signal.h"
 
+#ifndef AF_IB
+#define AF_IB 27
+#endif
+
+#ifndef RAI_FAMILY
+#define RAI_FAMILY              0x00000008
+#endif
 
 #define VERBS_PROV_NAME "verbs"
 #define VERBS_PROV_VERS FI_VERSION(1,0)


### PR DESCRIPTION
Older version of librdmacm (versions < v1.0.16) didn't have these
defined.
Re-enable verbs provider for OFI build server.
This should fix #1799 