### PR TITLE
prov/gni: Add custom EP ops and tag matching opts

### DIFF
--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -60,10 +60,21 @@ typedef enum dom_ops_val { GNI_MSG_RENDEZVOUS_THRESHOLD,
 			   GNI_NUM_DOM_OPS
 } dom_ops_val_t;
 
+#define FI_GNI_EP_OPS_1 "ep ops 1"
+typedef enum ep_ops_val {
+	GNI_HASH_TAG_IMPL = 0,
+	GNI_NUM_EP_OPS,
+} ep_ops_val_t;
+
 /* per domain gni provider specific ops */
 struct fi_gni_ops_domain {
 	int (*set_val)(struct fid *fid, dom_ops_val_t t, void *val);
 	int (*get_val)(struct fid *fid, dom_ops_val_t t, void *val);
+};
+
+struct fi_gni_ops_ep {
+	int (*set_val)(struct fid *fid, ep_ops_val_t t, void *val);
+	int (*get_val)(struct fid *fid, ep_ops_val_t t, void *val);
 };
 
 /* per domain parameters */

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -346,6 +346,7 @@ struct gnix_fid_ep {
 	struct gnix_fid_domain *domain;
 	uint64_t op_flags;
 	uint64_t caps;
+	uint32_t use_tag_hlist;
 	struct gnix_fid_cq *send_cq;
 	struct gnix_fid_cq *recv_cq;
 	struct gnix_fid_cntr *send_cntr;


### PR DESCRIPTION
GNIX EPs can be manipulated by retrieving the opt functions
via fi_open_ops. GNI_HLIST_TAG_IMPL has been added as a way
of telling the EP to use the hash list implementation
instead of the default list implementation.

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@2bb5c94a502a9a1efbf7d6bab360440542e8bff0)
upstream merge of ofi-cray/libfabric-cray#711
@sungeunchoi 