### PR TITLE
prov/sockets: Assign port correctly for source address 0.0.0.0

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -324,6 +324,7 @@ static int sock_pep_create_listener(struct sock_pep *pep)
 		if (getsockname(pep->cm.sock, (struct sockaddr *)&addr, &addr_size))
 			return -FI_EINVAL;
 		pep->src_addr.sin_port = addr.sin_port;
+		sprintf(sa_port, "%d", ntohs(pep->src_addr.sin_port));
 	}
 
 	if (pep->src_addr.sin_addr.s_addr == 0) {


### PR DESCRIPTION
- Assign port number correctly when 0.0.0.0 is specified as source address.
@jithinjosepkl @shefty 

Fixes #1857

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>