### PR TITLE
build: fix search for provider_FABRIC_1.0.map

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -241,7 +241,7 @@ AS_IF([test x"$enable_direct" != x"no"],
 	      AC_MSG_ERROR(Cannot continue)])
 
        PROVIDER_DIRECT=$enable_direct
-       FI_DIRECT_PROVIDER_API_10="prov/$enable_direct/provider_FABRIC_1.0.map"
+       FI_DIRECT_PROVIDER_API_10="$srcdir/prov/$enable_direct/provider_FABRIC_1.0.map"
        AS_IF([test ! -r "$FI_DIRECT_PROVIDER_API_10"],
 	     [AC_MSG_WARN([--enable-direct=$enable_direct specified, but $FI_DIRECT_PROVIDER_API_10 does not exist])
 	      AC_MSG_ERROR([Cannot continue])])])


### PR DESCRIPTION
When libfabric is configured in a different directory, the check for
provider_FABRIC_1.0.map fails. This points configure to look in the
right place.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>

@jsquyres 

@shantonu @jithinjosepkl It'd be great if the sockets provider supported at least building with fabric direct. It would also help if there was a build check somewhere that checks for builds outside the source tree to catch issues like this. This particular type of build breakage has happened before, and we should be able to catch this.