### PR TITLE
prov/sockets: Code cleanup based on Klocwork scan

### DIFF
--- a/prov/sockets/src/sock.h
+++ b/prov/sockets/src/sock.h
@@ -1034,8 +1034,8 @@ int sock_eq_openwait(struct sock_eq *eq, const char *service);
 
 int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		   struct fid_cntr **cntr, void *context);
-int sock_cntr_inc(struct sock_cntr *cntr);
-int sock_cntr_err_inc(struct sock_cntr *cntr);
+void sock_cntr_inc(struct sock_cntr *cntr);
+void sock_cntr_err_inc(struct sock_cntr *cntr);
 int sock_cntr_progress(struct sock_cntr *cntr);
 
 

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -495,11 +495,11 @@ int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (!attr || sock_verify_av_attr(attr))
 		return -FI_EINVAL;
 
-	if (attr && attr->type == FI_AV_UNSPEC)
+	if (attr->type == FI_AV_UNSPEC)
 		attr->type = FI_AV_TABLE;
 
 	dom = container_of(domain, struct sock_domain, dom_fid);
-	if (dom->attr.av_type != FI_AV_UNSPEC && attr &&
+	if (dom->attr.av_type != FI_AV_UNSPEC &&
 	    dom->attr.av_type != attr->type)
 		return -FI_EINVAL;
 

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -57,7 +57,8 @@ static ssize_t sock_comm_send_socket(struct sock_conn *conn,
 			SOCK_LOG_DBG("write %s\n", strerror(errno));
 		}
 	}
-	SOCK_LOG_DBG("wrote to network: %lu\n", ret);
+	if (ret > 0)
+		SOCK_LOG_DBG("wrote to network: %lu\n", ret);
 	return ret;
 }
 

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -572,6 +572,10 @@ int sock_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		sock_cq->signal = 1;
 		wait = container_of(attr->wait_set, struct sock_wait, wait_fid);
 		list_entry = calloc(1, sizeof(*list_entry));
+		if (!list_entry) {
+                        ret = -FI_ENOMEM;
+                        goto err4;
+                }
 		dlist_init(&list_entry->entry);
 		list_entry->fid = &sock_cq->cq_fid.fid;
 		dlist_insert_after(&list_entry->entry, &wait->fid_list);

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -519,7 +519,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 	sock_domain->dom_fid.ops = &sock_dom_ops;
 	sock_domain->dom_fid.mr = &sock_dom_mr_ops;
 
-	if (!info || !info->domain_attr ||
+	if (!info->domain_attr ||
 	    info->domain_attr->data_progress == FI_PROGRESS_UNSPEC)
 		sock_domain->progress_mode = FI_PROGRESS_AUTO;
 	else

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -1111,6 +1111,8 @@ static void *sock_pep_listener_thread(void *data)
 
 			cm_entry->fid = &pep->pep.fid;
 			cm_entry->info = sock_ep_msg_process_info(conn_req);
+			if (!cm_entry->info)
+				goto out;
 			cm_entry->info->handle = &handle->handle;
 
 			memcpy(&cm_entry->data, &conn_req->user_data,

--- a/prov/sockets/src/sock_epoll.c
+++ b/prov/sockets/src/sock_epoll.c
@@ -61,10 +61,16 @@
 #ifdef HAVE_EPOLL
 int sock_epoll_create(struct sock_epoll_set *set, int size)
 {
+	int ret;
 	set->size = size;
 	set->used = 0;
 	set->events = calloc(size, sizeof(struct epoll_event));
-	return set->fd = epoll_create(size);
+	if (!set->events)
+		return -FI_ENOMEM;
+	ret = set->fd = epoll_create(size);
+	if (ret < 0)
+		free(set->events);
+	return ret;
 }
 
 int sock_epoll_add(struct sock_epoll_set *set, int fd)

--- a/prov/sockets/src/sock_rx_entry.c
+++ b/prov/sockets/src/sock_rx_entry.c
@@ -56,6 +56,9 @@ struct sock_rx_entry *sock_rx_new_entry(struct sock_rx_ctx *rx_ctx)
 	if (rx_ctx->rx_entry_pool == NULL) {
 		rx_ctx->rx_entry_pool = calloc(rx_ctx->attr.size,
 						sizeof(*rx_entry));
+		if (!rx_ctx->rx_entry_pool)
+			return NULL;
+
 		slist_init(&rx_ctx->pool_list);
 
 		for (i = 0; i < rx_ctx->attr.size; i++) {


### PR DESCRIPTION
- Made the functions void which was always returning 0.
- Removed unnecessary NULL check
- Added NULL check and error path where needed
- Used snprintf instead of sprintf where needed
- Released memory where needed
- Fixed a bug in reporting tx_completion

Verified with fabtests and mpich test bucket.
@jithinjosepkl @shefty  
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>