### PR TITLE
Removing the map file check so that other providers can build with FABRIC_DIRECT

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -241,10 +241,7 @@ AS_IF([test x"$enable_direct" != x"no"],
 	      AC_MSG_ERROR(Cannot continue)])
 
        PROVIDER_DIRECT=$enable_direct
-       FI_DIRECT_PROVIDER_API_10="$srcdir/prov/$enable_direct/provider_FABRIC_1.0.map"
-       AS_IF([test ! -r "$FI_DIRECT_PROVIDER_API_10"],
-	     [AC_MSG_WARN([--enable-direct=$enable_direct specified, but $FI_DIRECT_PROVIDER_API_10 does not exist])
-	      AC_MSG_ERROR([Cannot continue])])])
+       FI_DIRECT_PROVIDER_API_10="$srcdir/prov/$enable_direct/provider_FABRIC_1.0.map"])
 
 AC_SUBST(PROVIDER_DIRECT)
 AC_SUBST_FILE(FI_DIRECT_PROVIDER_API_10)


### PR DESCRIPTION
Opened this PR for discussion. As suggested in #1870, I started to work on a PR that allows all the providers to build with FABRIC_DIRECT enabled. But because of this check in <code>configure.ac</code>, it'll fail since those providers won't have <code>provider_FABRIC_1.0.map</code> file.

Please let me know if you have any comments/suggestions. @shefty @hppritcha 

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>