### PR TITLE
verbs/RDM. Fabtests enable

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -44,7 +44,6 @@ int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
                                 struct fi_ibv_rdm_tagged_conn *conn)
 {
 	struct rdma_cm_id *id;
-	struct sockaddr_in sock_addr;
 
 	if (conn->state != FI_VERBS_CONN_ALLOCATED)
 		return 0;
@@ -52,17 +51,11 @@ int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 	if (ep->is_closing) {
 		VERBS_INFO(FI_LOG_AV, "Attempt to start connection with addr "
 		FI_IBV_RDM_ADDR_STR_FORMAT" when ep is closing\n",
-		FI_IBV_RDM_ADDR_STR(conn->addr));
+		FI_IBV_RDM_ADDR_STR(&conn->addr));
 		return -1;
 	}
 
 	conn->state = FI_VERBS_CONN_STARTED;
-	memcpy(&sock_addr.sin_addr.s_addr, conn->addr,
-		sizeof(sock_addr.sin_addr.s_addr));
-	memcpy(&sock_addr.sin_port, (char *) conn->addr +
-		sizeof(sock_addr.sin_addr.s_addr), sizeof(sock_addr.sin_port));
-	sock_addr.sin_port = htons(sock_addr.sin_port);
-	sock_addr.sin_family = AF_INET;
 
 	if (rdma_create_id(ep->cm_listener_ec, &id, conn, RDMA_PS_TCP))
 		return -1;
@@ -73,7 +66,7 @@ int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 		conn->id[0] = id;
 	}
 
-	return rdma_resolve_addr(id, NULL, (struct sockaddr *)&sock_addr, 30000);
+	return rdma_resolve_addr(id, NULL, (struct sockaddr *)&conn->addr, 30000);
 }
 
 int fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_ep *ep,
@@ -128,7 +121,7 @@ static int fi_ibv_rdm_av_insert(struct fid_av *av, const void *addr,
 			memset(conn, 0, sizeof *conn);
 			dlist_init(&conn->postponed_requests_head);
 			conn->state = FI_VERBS_CONN_ALLOCATED;
-			memcpy(conn->addr, addr_i, FI_IBV_RDM_DFLT_ADDRLEN);
+			memcpy(&conn->addr, addr_i, FI_IBV_RDM_DFLT_ADDRLEN);
 			HASH_ADD(hh, fi_ibv_rdm_tagged_conn_hash, addr,
 			FI_IBV_RDM_DFLT_ADDRLEN, conn);
 		}
@@ -138,7 +131,7 @@ static int fi_ibv_rdm_av_insert(struct fid_av *av, const void *addr,
 		fi_addr[i] = (uintptr_t) (void *) conn;
 		FI_INFO(&fi_ibv_prov, FI_LOG_AV, "fi_av_insert: addr "
 			FI_IBV_RDM_ADDR_STR_FORMAT " conn %p %d\n",
-			FI_IBV_RDM_ADDR_STR(conn->addr), conn, conn->cm_role);
+			FI_IBV_RDM_ADDR_STR(&conn->addr), conn, conn->cm_role);
 
 		ret++;
 	}
@@ -158,7 +151,7 @@ static int fi_ibv_rdm_av_remove(struct fid_av *av, fi_addr_t * fi_addr,
 		conn = (struct fi_ibv_rdm_tagged_conn *) fi_addr[i];
 		FI_INFO(&fi_ibv_prov, FI_LOG_AV,
 			"av_remove conn %p, addr " FI_IBV_RDM_ADDR_STR_FORMAT "\n",
-			conn, FI_IBV_RDM_ADDR_STR(conn->addr));
+			conn, FI_IBV_RDM_ADDR_STR(&conn->addr));
 		rdma_disconnect(conn->id[0]);
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -49,9 +49,9 @@ int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 		return 0;
 
 	if (ep->is_closing) {
-		VERBS_INFO(FI_LOG_AV, "Attempt to start connection with addr "
-		FI_IBV_RDM_ADDR_STR_FORMAT" when ep is closing\n",
-		FI_IBV_RDM_ADDR_STR(&conn->addr));
+		VERBS_INFO(FI_LOG_AV, "Attempt to start connection with addr %s:%u when ep is closing\n",
+			inet_ntoa(conn->addr.sin_addr),
+			ntohs(conn->addr.sin_port));
 		return -1;
 	}
 
@@ -129,9 +129,9 @@ static int fi_ibv_rdm_av_insert(struct fid_av *av, const void *addr,
 		fi_ibv_rdm_conn_init_cm_role(conn, ep);
 
 		fi_addr[i] = (uintptr_t) (void *) conn;
-		FI_INFO(&fi_ibv_prov, FI_LOG_AV, "fi_av_insert: addr "
-			FI_IBV_RDM_ADDR_STR_FORMAT " conn %p %d\n",
-			FI_IBV_RDM_ADDR_STR(&conn->addr), conn, conn->cm_role);
+		FI_INFO(&fi_ibv_prov, FI_LOG_AV, "fi_av_insert: addr %s:%u conn %p %d\n",
+			inet_ntoa(conn->addr.sin_addr),
+			ntohs(conn->addr.sin_port), conn, conn->cm_role);
 
 		ret++;
 	}
@@ -149,9 +149,9 @@ static int fi_ibv_rdm_av_remove(struct fid_av *av, fi_addr_t * fi_addr,
 
 	for (i = 0; i < count; i++) {
 		conn = (struct fi_ibv_rdm_tagged_conn *) fi_addr[i];
-		FI_INFO(&fi_ibv_prov, FI_LOG_AV,
-			"av_remove conn %p, addr " FI_IBV_RDM_ADDR_STR_FORMAT "\n",
-			conn, FI_IBV_RDM_ADDR_STR(&conn->addr));
+		FI_INFO(&fi_ibv_prov, FI_LOG_AV, "av_remove conn %p, addr %s:%u\n",
+			conn, inet_ntoa(conn->addr.sin_addr),
+			ntohs(conn->addr.sin_port));
 		rdma_disconnect(conn->id[0]);
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -547,16 +547,15 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->cm_listener_port = ntohs(rdma_get_src_port(_ep->cm_listener));
 	VERBS_INFO(FI_LOG_EP_CTRL, "listener port: %d\n", _ep->cm_listener_port);
 
-	size_t s1 = sizeof(_ep->my_ipoib_addr.sin_addr.s_addr);
-	size_t s2 = sizeof(_ep->cm_listener_port);
-	assert(FI_IBV_RDM_DFLT_ADDRLEN == s1 + s2);
-
-	memcpy(_ep->my_rdm_addr, &_ep->my_ipoib_addr.sin_addr.s_addr, s1);
-	memcpy(_ep->my_rdm_addr + s1, &_ep->cm_listener_port, s2);
+	memset(&_ep->my_rdm_addr, 0, sizeof (_ep->my_rdm_addr));
+	_ep->my_rdm_addr.sin_family = AF_INET;
+	_ep->my_rdm_addr.sin_port = htons(_ep->cm_listener_port);
+	_ep->my_rdm_addr.sin_addr.s_addr = _ep->my_ipoib_addr.sin_addr.s_addr;
 
 	VERBS_INFO(FI_LOG_EP_CTRL,
-		"My ep_addr: " FI_IBV_RDM_ADDR_STR_FORMAT "\n",
-		FI_IBV_RDM_ADDR_STR(_ep->my_rdm_addr));
+		"My ep_addr: " FI_IBV_RDM_ADDR_STR_FORMAT ", port: %d\n",
+		FI_IBV_RDM_ADDR_STR(&_ep->my_rdm_addr),
+		ntohs(_ep->my_rdm_addr.sin_port));
 
 	_ep->n_buffs = FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM;
 	_ep->buff_len = FI_IBV_RDM_DFLT_BUFFER_SIZE;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -40,16 +40,6 @@
 #include "verbs_utils.h"
 #include "verbs_tagged_ep_rdm_states.h"
 
-#define FI_IBV_RDM_ADDR_STR_FORMAT "[%02x:%02x:%02x:%02x:%02x:%02x]"
-
-#define FI_IBV_RDM_ADDR_STR(addr)				\
-        *((unsigned char*) addr + sizeof(sa_family_t) + 0),	\
-	*((unsigned char*) addr + sizeof(sa_family_t) + 1),	\
-	*((unsigned char*) addr + sizeof(sa_family_t) + 2),	\
-	*((unsigned char*) addr + sizeof(sa_family_t) + 3),	\
-	*((unsigned char*) addr + sizeof(sa_family_t) + 4),	\
-	*((unsigned char*) addr + sizeof(sa_family_t) + 5)
-
 #define FI_IBV_RDM_ST_PKTTYPE_MASK  ((uint32_t) 0xFF)
 #define FI_IBV_RDM_EAGER_PKT		0
 #define FI_IBV_RDM_RNDV_RTS_PKT		1

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -38,15 +38,15 @@
 #include "../uthash.h"
 #include "verbs_tagged_ep_rdm_states.h"
 
-
-#define FI_IBV_RDM_CONN_SELF ((struct fi_ibv_rdm_tagged_conn *) 0x1)
-
 #define FI_IBV_RDM_ADDR_STR_FORMAT "[%02x:%02x:%02x:%02x:%02x:%02x]"
 
-#define FI_IBV_RDM_ADDR_STR(addr)				   \
-        *((unsigned char*) addr), *((unsigned char*) addr + 1),	   \
-        *((unsigned char*) addr + 2),*((unsigned char*) addr + 3), \
-        *((unsigned char*) addr + 4),*((unsigned char*) addr + 5)
+#define FI_IBV_RDM_ADDR_STR(addr)				\
+        *((unsigned char*) addr + sizeof(sa_family_t) + 0),	\
+	*((unsigned char*) addr + sizeof(sa_family_t) + 1),	\
+	*((unsigned char*) addr + sizeof(sa_family_t) + 2),	\
+	*((unsigned char*) addr + sizeof(sa_family_t) + 3),	\
+	*((unsigned char*) addr + sizeof(sa_family_t) + 4),	\
+	*((unsigned char*) addr + sizeof(sa_family_t) + 5)
 
 #define FI_IBV_RDM_ST_PKTTYPE_MASK  ((uint32_t) 0xFF)
 #define FI_IBV_RDM_EAGER_PKT		0
@@ -220,7 +220,7 @@ struct fi_ibv_rdm_ep {
 	uint16_t cm_listener_port;
 	struct fi_ibv_av *av;
 	int fi_ibv_rdm_addrlen;
-	char my_rdm_addr[FI_IBV_RDM_DFLT_ADDRLEN];
+	struct sockaddr_in my_rdm_addr;
 
 	int buff_len;
 	int n_buffs;
@@ -266,7 +266,7 @@ struct fi_ibv_rdm_tagged_conn {
 	 */
 	struct ibv_qp *qp[2];
 	struct rdma_cm_id *id[2];
-	char addr[FI_IBV_RDM_DFLT_ADDRLEN];
+	struct sockaddr_in addr;
 	enum fi_rdm_cm_role cm_role;
 	int state;
 

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -33,9 +33,11 @@
 #ifndef _VERBS_RDM_H
 #define _VERBS_RDM_H
 
+#include <rdma/rdma_cma.h>
+#include "../uthash.h"
+
 #include "../fi_verbs.h"
 #include "verbs_utils.h"
-#include "../uthash.h"
 #include "verbs_tagged_ep_rdm_states.h"
 
 #define FI_IBV_RDM_ADDR_STR_FORMAT "[%02x:%02x:%02x:%02x:%02x:%02x]"
@@ -207,20 +209,23 @@ struct fi_ibv_rdm_buf {
 	char payload[sizeof(void *)];
 };
 
+struct fi_ibv_rdm_cm {
+	struct rdma_cm_id *listener;
+	struct rdma_event_channel *ec;
+	struct sockaddr_in my_addr;
+	struct rdma_addrinfo *rai;
+};
+
 struct fi_ibv_rdm_ep {
 	struct fid_ep ep_fid;
 	struct fi_ibv_domain *domain;
 	struct fi_ibv_cq *fi_scq;
 	struct fi_ibv_cq *fi_rcq;
 
-	struct sockaddr_in my_ipoib_addr;
-	char my_ipoib_addr_str[INET6_ADDRSTRLEN];
-	struct rdma_cm_id *cm_listener;
-	struct rdma_event_channel *cm_listener_ec;
-	uint16_t cm_listener_port;
+	struct fi_ibv_rdm_cm cm;
+	size_t addrlen;
+
 	struct fi_ibv_av *av;
-	int fi_ibv_rdm_addrlen;
-	struct sockaddr_in my_rdm_addr;
 
 	int buff_len;
 	int n_buffs;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -191,7 +191,7 @@ fi_ibv_rdm_pack_cm_params(struct rdma_conn_param *cm_params,
 	cm_params->private_data = malloc(cm_params->private_data_len);
 
 	char *p = (char *) cm_params->private_data;
-	memcpy(p, &ep->my_rdm_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+	memcpy(p, &ep->cm.my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
 	p += FI_IBV_RDM_DFLT_ADDRLEN;
 
 	if ((conn->cm_role != FI_VERBS_CM_SELF) && (conn->r_mr && conn->s_mr)) {
@@ -217,7 +217,7 @@ fi_ibv_rdm_unpack_cm_params(struct rdma_conn_param *cm_param,
 
 	if (conn->cm_role == FI_VERBS_CM_SELF) {
 		if (conn->r_mr && conn->s_mr) {
-			memcpy(&conn->addr, &ep->my_rdm_addr,
+			memcpy(&conn->addr, &ep->cm.my_addr,
 				FI_IBV_RDM_DFLT_ADDRLEN);
 			conn->remote_rbuf_rkey = conn->r_mr->rkey;
 			conn->remote_rbuf_mem_reg = conn->r_mr->addr;
@@ -587,7 +587,7 @@ int fi_ibv_rdm_tagged_cm_progress(struct fi_ibv_rdm_ep *ep)
 	struct rdma_cm_event *event = NULL;
 	int ret = 0;
 
-	rdma_get_cm_event(ep->cm_listener_ec, &event);
+	rdma_get_cm_event(ep->cm.ec, &event);
 
 	while (event) {
 		pthread_mutex_lock(&ep->cm_lock);
@@ -608,7 +608,7 @@ int fi_ibv_rdm_tagged_cm_progress(struct fi_ibv_rdm_ep *ep)
 		free(data);
 		event = NULL;
 		pthread_mutex_unlock(&ep->cm_lock);
-		rdma_get_cm_event(ep->cm_listener_ec, &event);
+		rdma_get_cm_event(ep->cm.ec, &event);
 	}
 	return ret;
 }

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -106,8 +106,8 @@ static int fi_ibv_rdm_tagged_getname(fid_t fid, void *addr, size_t * addrlen)
 		return -FI_ETOOSMALL;
 	}
 	memset(addr, 0, *addrlen);
-	memcpy(addr, &ep->my_rdm_addr, FI_IBV_RDM_DFLT_ADDRLEN);
-	ep->fi_ibv_rdm_addrlen = *addrlen;
+	memcpy(addr, &ep->cm.my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+	ep->addrlen = *addrlen;
 
 	return 0;
 }

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -106,7 +106,7 @@ static int fi_ibv_rdm_tagged_getname(fid_t fid, void *addr, size_t * addrlen)
 		return -FI_ETOOSMALL;
 	}
 	memset(addr, 0, *addrlen);
-	memcpy(addr, ep->my_rdm_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+	memcpy(addr, &ep->my_rdm_addr, FI_IBV_RDM_DFLT_ADDRLEN);
 	ep->fi_ibv_rdm_addrlen = *addrlen;
 
 	return 0;

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -123,7 +123,6 @@ void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_tagged_conn *conn,
  * If the name is the desired one then we're done.
  */
 int fi_ibv_rdm_tagged_find_ipoib_addr(const struct sockaddr_in *addr,
-				      struct ibv_context *ctx,
 				      struct fi_ibv_rdm_cm* cm)
 {
 	struct ifaddrs *addrs, *tmp;

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -30,6 +30,7 @@
  * SOFTWARE.
  */
 
+#include <ifaddrs.h>
 #include <rdma/fi_errno.h>
 #include "../fi_verbs.h"
 #include "verbs_utils.h"
@@ -103,7 +104,7 @@ int fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *postponed_item,
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_tagged_conn *conn,
 				  struct fi_ibv_rdm_ep *ep)
 {
-	const int addr_cmp = memcmp(&conn->addr, &ep->my_rdm_addr,
+	const int addr_cmp = memcmp(&conn->addr, &ep->cm.my_addr,
 				    FI_IBV_RDM_DFLT_ADDRLEN);
 
 	if (addr_cmp < 0) {
@@ -113,4 +114,61 @@ void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_tagged_conn *conn,
 	} else {
 		conn->cm_role = FI_VERBS_CM_SELF;
 	}
+}
+
+/* find the IPoIB address of the device opened in the fi_domain call. The name
+ * of this device is _domain->verbs->device->name. The logic of the function is:
+ * iterate through all the available network interfaces, find those having "ib"
+ * in the name, then try to test the IB device that correspond to each address.
+ * If the name is the desired one then we're done.
+ */
+int fi_ibv_rdm_tagged_find_ipoib_addr(const struct sockaddr_in *addr,
+				      struct ibv_context *ctx,
+				      struct fi_ibv_rdm_cm* cm)
+{
+	struct ifaddrs *addrs, *tmp;
+	struct sockaddr_in lh;
+	int found = 0;
+
+	inet_pton(AF_INET, "127.0.0.1", &lh.sin_addr);
+
+	getifaddrs(&addrs);
+	tmp = addrs;
+	while (tmp) {
+		if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_INET) {
+			struct sockaddr_in *paddr =
+			    (struct sockaddr_in *) tmp->ifa_addr;
+			if (!strncmp(tmp->ifa_name, "ib", 2)) {
+				int ret;
+
+				if (addr && addr->sin_addr.s_addr) {
+					ret = !memcmp(&addr->sin_addr,
+						      &paddr->sin_addr,
+						      sizeof(addr->sin_addr)) ||
+					      !memcmp(&addr->sin_addr,
+						      &lh.sin_addr,
+						      sizeof(addr->sin_addr))
+					      ? 1 : 0;
+				}
+
+				if (ret == 1) {
+					memcpy(&(cm->my_addr), paddr,
+					       sizeof(cm->my_addr));
+					found = 1;
+					break;
+				} else if (ret < 0) {
+					return -1;
+				}
+			}
+		}
+
+		tmp = tmp->ifa_next;
+	}
+
+	freeifaddrs(addrs);
+
+	if (found) {
+		assert(cm->my_addr.sin_family == AF_INET);
+	}
+	return !found;
 }

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -103,7 +103,7 @@ int fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *postponed_item,
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_tagged_conn *conn,
 				  struct fi_ibv_rdm_ep *ep)
 {
-	const int addr_cmp = memcmp(conn->addr, ep->my_rdm_addr,
+	const int addr_cmp = memcmp(&conn->addr, &ep->my_rdm_addr,
 				    FI_IBV_RDM_DFLT_ADDRLEN);
 
 	if (addr_cmp < 0) {

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -142,7 +142,9 @@ struct fi_verbs_rdm_tagged_request_minfo {
 	struct fi_ibv_rdm_tagged_conn	*conn;
 	uint64_t			tag;
 	uint64_t			tagmask;
-} ;
+};
+
+struct fi_ibv_rdm_cm;
 
 int fi_ibv_rdm_tagged_req_match(struct dlist_entry *item, const void *other);
 int fi_ibv_rdm_tagged_req_match_by_info(struct dlist_entry *item,
@@ -153,5 +155,8 @@ int fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *item,
                                               const void *arg);
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_tagged_conn *conn,
 				  struct fi_ibv_rdm_ep *ep);
+int fi_ibv_rdm_tagged_find_ipoib_addr(const struct sockaddr_in *addr,
+				      struct ibv_context *ctx,
+				      struct fi_ibv_rdm_cm* cm);
 
 #endif /* _VERBS_UTILS_H */

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -156,7 +156,6 @@ int fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *item,
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_tagged_conn *conn,
 				  struct fi_ibv_rdm_ep *ep);
 int fi_ibv_rdm_tagged_find_ipoib_addr(const struct sockaddr_in *addr,
-				      struct ibv_context *ctx,
 				      struct fi_ibv_rdm_cm* cm);
 
 #endif /* _VERBS_UTILS_H */

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -60,9 +60,7 @@
 
 struct fi_ibv_msg_ep;
 
-#define FI_IBV_RDM_DFLT_ADDRLEN                                         \
-    (/*ep->my_ipoib_addr.sin_addr.s_addr)*/ sizeof(in_addr_t) +         \
-     /*ep->cm_listener_port */              sizeof(uint16_t))
+#define FI_IBV_RDM_DFLT_ADDRLEN	(sizeof (struct sockaddr_in))
 
 #define FI_IBV_RDM_CM_THREAD_TIMEOUT (100)
 #define FI_IBV_RDM_MEM_ALIGNMENT (64)

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -118,10 +118,8 @@ static int fi_ibv_rdm_cm_init(struct fi_ibv_rdm_cm* cm,
 	}
 	assert(cm->my_addr.sin_family == AF_INET);
 
-	VERBS_INFO(FI_LOG_EP_CTRL,
-		"My ep_addr: " FI_IBV_RDM_ADDR_STR_FORMAT ", port: %d\n",
-		FI_IBV_RDM_ADDR_STR(&cm->my_addr),
-		ntohs(cm->my_addr.sin_port));
+	VERBS_INFO(FI_LOG_EP_CTRL, "My ep_addr: %s:%u\n",
+		inet_ntoa(cm->my_addr.sin_addr), ntohs(cm->my_addr.sin_port));
 
 	return FI_SUCCESS;
 }

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -239,6 +239,9 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 int fi_ibv_create_ep(const char *node, const char *service,
 		     uint64_t flags, const struct fi_info *hints,
 		     struct rdma_addrinfo **rai, struct rdma_cm_id **id);
+void fi_ibv_destroy_ep(enum fi_ep_type ep_type,
+		       struct rdma_addrinfo *rai,
+		       struct rdma_cm_id **id);
 
 struct fi_ops_atomic *fi_ibv_msg_ep_ops_atomic(struct fi_ibv_msg_ep *ep);
 struct fi_ops_cm *fi_ibv_msg_ep_ops_cm(struct fi_ibv_msg_ep *ep);


### PR DESCRIPTION
tested with fi_rdm_tagged_pingpong:
1) modification of the test: hints->mode = FI_LOCAL_MR | FI_CONTEXT;
2) server/host argument (-s) should have valid IP address of ib device

@a-ilango @shefty 