### PR TITLE
prov/gni: Implemented gnix vector:

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -38,6 +38,7 @@ _gni_files = \
 	prov/gni/src/gnix_tags.c \
 	prov/gni/src/gnix_util.c \
 	prov/gni/src/gnix_vc.c \
+	prov/gni/src/gnix_vector.c \
 	prov/gni/src/gnix_wait.c
 
 _gni_headers = \
@@ -68,6 +69,7 @@ _gni_headers = \
 	prov/gni/include/gnix_tags.h \
 	prov/gni/include/gnix_util.h \
 	prov/gni/include/gnix_vc.h \
+	prov/gni/include/gnix_vector.h \
 	prov/gni/include/gnix_wait.h
 
 if HAVE_CRITERION
@@ -102,6 +104,7 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/api.c \
 	prov/gni/test/utils.c \
 	prov/gni/test/vc.c \
+	prov/gni/test/vector.c \
 	prov/gni/test/wait.c \
 	prov/gni/test/common.c
 

--- a/prov/gni/include/gnix_vector.h
+++ b/prov/gni/include/gnix_vector.h
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef GNIX_VECTOR_H_
+#define GNIX_VECTOR_H_
+
+#include "gnix.h"
+#include "gnix_util.h"
+
+#include "stdlib.h"
+#include "string.h"
+
+/*******************************************************************************
+ * DATASTRUCTS
+ ******************************************************************************/
+typedef enum gnix_vec_state {
+	GNIX_VEC_STATE_READY = 0xdeadbeef,
+	GNIX_VEC_STATE_DEAD,
+} gnix_vec_state_e;
+
+typedef enum gnix_vec_increase {
+	GNIX_VEC_INCREASE_ADD,
+	GNIX_VEC_INCREASE_MULT,
+} gnix_vec_increase_e;
+
+typedef enum gnix_vec_lock {
+	GNIX_VEC_UNLOCKED,
+	GNIX_VEC_LOCKED,
+} gnix_vec_lock_e;
+
+typedef uint64_t gnix_vec_index_t;
+typedef void * gnix_vec_entry_t;
+
+/**
+ * Set of attributes that MUST be initialized and passed to _gnix_vec_init.
+ *
+ * @var vec_initial_size	Initial size of the vector
+ * @var vec_maximum_size	Maximum size of the vector
+ * @var vec_increase_step	Type of step to increase vector by, ADD or MULT
+ * @var vec_internal_locking	GNIX_VEC_UNLOCKED for unlocked, otherwise locked
+ * @var creator			fn required to properly alloc the vector element
+ */
+typedef struct gnix_vec_attr {
+	uint64_t vec_initial_size;
+	uint64_t cur_size;
+	uint64_t vec_maximum_size;
+
+	uint64_t vec_increase_step;
+
+	gnix_vec_increase_e vec_increase_type;
+
+	gnix_vec_lock_e vec_internal_locking;
+} gnix_vec_attr_t;
+
+struct gnix_vector;
+
+/**
+ * Vector operations
+ *
+ * @var insert_first	Insert an entry into first index of the vector.
+ * @var insert_last	Insert an entry into the last index of the vector.
+ * @var insert_at	Insert an entry into the vector at the given index.
+ *
+ * @var remove_first	Removes the first element from the vector.
+ * @var remove_last	Removes the last element from the vector.
+ * @var remove_at	Removes the element at index from the vector.
+ *
+ * @var first		Return the first element of the vector.
+ * @var last		Return the last element of the vector.
+ * @var at		Return the element at the specified index.
+ */
+typedef struct gnix_vector_ops {
+	int (*insert_first)(struct gnix_vector *, gnix_vec_entry_t *);
+	int (*insert_last)(struct gnix_vector *, gnix_vec_entry_t *);
+	int (*insert_at)(struct gnix_vector *, gnix_vec_entry_t *,
+			 gnix_vec_index_t);
+
+	int (*remove_first)(struct gnix_vector *);
+	int (*remove_last)(struct gnix_vector *);
+	int (*remove_at)(struct gnix_vector *, gnix_vec_index_t);
+
+	int (*first)(struct gnix_vector *, void **);
+	int (*last)(struct gnix_vector *, void **);
+	int (*at)(struct gnix_vector *, void **, gnix_vec_index_t);
+	/* TODO: void *(*iter_next)(struct gnix_vector_iter *); */
+} gnix_vector_ops_t;
+
+/**
+ * Vector handle
+ *
+ * @var state	The current state of the vector instance.
+ * @var attr	The attributes of this vector.
+ * @var ops	The supported operations on this vector.
+ * @var vector	The begging address of the vector.
+ * @var size	The current size of the vector.
+ * @var lock	A read/write lock for the vector.
+ */
+typedef struct gnix_vector {
+	gnix_vec_state_e state;
+	gnix_vec_attr_t attr;
+	gnix_vector_ops_t *ops;
+	gnix_vec_entry_t *vector;
+	rwlock_t lock;
+} gnix_vector_t;
+
+
+/*******************************************************************************
+ * API Prototypes
+ ******************************************************************************/
+/**
+ * Create the initial vector.  The user is responsible for initializing the
+ * "attr" parameter prior to calling this function.
+ *
+ * @param[in] vec	the vector to initialize
+ * @param[in] attr	the vector attributes
+ *
+ * @return FI_SUCCESS	Upon successfully creating the vector
+ * @return -FI_EINVAL	Upon receiving an invalid parameter
+ * @return -FI_ENOMEM	Upon insufficient memory to create the vector
+ */
+int _gnix_vec_init(struct gnix_vector *vec, gnix_vec_attr_t *attr);
+
+/**
+ * Close the vector elements and then the vector.
+ *
+ * @param[in] vec       the vector to close
+ *
+ * @return FI_SUCCESS	Upon successfully closing the vector
+ * @return -FI_EINVAL	Upon a uninitialized or dead vector
+ */
+int _gnix_vec_close(gnix_vector_t *vec);
+
+/**
+ * Resize the vector to size.
+ *
+ * @param[in] vec	the vector to resize
+ * @param[in] size	the new size of the vector
+ *
+ * @return FI_SUCCESS	Upon successfully resizing the vector
+ * @return -FI_EINVAL	Upon passing a uninitialized or dead vector, a size
+ * 			less than the minimum vector size, or a size greater
+ *			than the maximum vector size
+ * @return -FI_ENOMEM	Upon running out of memory
+ */
+int _gnix_vec_resize(gnix_vector_t *vec, uint64_t size);
+
+
+/*******************************************************************************
+ * INLINE OPS FNS
+ ******************************************************************************/
+/**
+ * Get the element at index in the vector.
+ *
+ * @param[in]	  vec 	  The vector to return an element from
+ * @param[in/out] element The element at the specified index in the vector
+ * @param[in]	  index   The index of the desired element
+ *
+ * @return FI_SUCCESS	Upon successfully returning the element
+ * @return -FI_EINVAL	Upon passing a NULL or dead vector
+ * @return -FI_ECANCLED Upon attempting to get an empty element
+ */
+int _gnix_vec_at(gnix_vector_t *vec, void **element, gnix_vec_index_t index);
+
+/**
+ * Get the first element in the vector.
+ *
+ * @param[in]	  vec The vector to return an element from
+ * @param[in/out] element the first element in the vector
+ *
+ * @return FI_SUCCESS	Upon successfully returning the element
+ * @return -FI_EINVAL	Upon passing a NULL or dead vector
+ * @return -FI_ECANCLED Upon attempting to get an empty element
+ */
+int _gnix_vec_last(gnix_vector_t *vec, void **element);
+
+/**
+ * Get the first element in the vector.
+ *
+ * @param[in]	  vec The vector to return an element from
+ * @param[in/out] element the first element in the vector
+ *
+ * @return FI_SUCCESS	Upon successfully returning the element
+ * @return -FI_EINVAL	Upon passing a NULL or dead vector
+ * @return -FI_ECANCLED Upon attempting to get an empty element
+ */
+int _gnix_vec_first(gnix_vector_t *vec, void **element);
+
+/**
+ * Removes the element at index from the vector.  Note that
+ * the user is responsible for properly disconnecting and/or destroying
+ * this vector element.
+ *
+ * @param[in] vec	the vector to remove an entry from
+ * @param[in] index	the index of the entry to remove
+ *
+ * @return FI_SUCCESS	 Upon successfully removing the entry
+ * @return -FI_EINVAL	 Upon passing a dead vector
+ * @return -FI_ECANCELED Upon attempting to remove an empty entry
+ */
+int _gnix_vec_remove_at(gnix_vector_t *vec, gnix_vec_index_t index);
+
+/**
+ * Removes the last element from the vector.  Note that
+ * the user is responsible for properly disconnecting and/or destroying
+ * this vector element.
+ *
+ * @param[in] vec	the vector to remove an entry from
+ *
+ * @return FI_SUCCESS	 Upon successfully removing and destroying the entry
+ * @return -FI_EINVAL	 Upon passing a dead entry
+ * @return -FI_ECANCELED Upon attempting to remove an empty entry
+ */
+int _gnix_vec_remove_last(gnix_vector_t *vec);
+
+/**
+ * Removes the first element from the vector.  Note that
+ * the user is responsible for properly disconnecting and/or destroying
+ * this vector element.
+ *
+ * @param[in] vec	the vector to remove an entry from
+ *
+ * @return FI_SUCCESS	 Upon successfully removing and destroying the entry
+ * @return -FI_EINVAL	 Upon passing a dead entry
+ * @return -FI_ECANCELED Upon attempting to remove an empty entry
+ */
+int _gnix_vec_remove_first(gnix_vector_t *vec);
+
+/**
+ * Inserts an entry into the vector at the given index. If the current size
+ * of the vector is not large enough to satisfy the insertion then the vector
+ * will be grown up to the maximum size. If the entry at index is not empty
+ * the insertion will be canceled.
+ *
+ * @param[in] vec	the vector to insert entry into
+ * @param[in] entry	the item to insert into the vector
+ * @param[in] index	the index to insert the item at
+ *
+ * @return FI_SUCCESS	 Upon successfully inserting the entry into the vector
+ * @return -FI_ENOMEM	 Upon exceeding the available memory
+ * @return -FI_EINVAL	 Upon passing a dead or null vector, or an index passed
+ *			 the maximum size.
+ * @return -FI_ECANCELED Upon an existing non-empty entry being found at index
+ * 			 or reaching the maximum vector size.
+ */
+int _gnix_vec_insert_at(gnix_vector_t *vec, gnix_vec_entry_t *entry,
+				      gnix_vec_index_t index);
+
+/**
+ * Inserts an entry into the last index of the vector. If the entry at the
+ * last index is not empty the insertion will be canceled.
+ *
+ * @param[in] vec	the vector to insert entry into
+ * @param[in] entry	the item to insert into the vector
+ *
+ * @return FI_SUCCESS	 Upon successfully inserting the entry into the vector
+ * @return -FI_EINVAL	 Upon passing a dead vector, or a null
+ * 			 entry
+ * @return -FI_ECANCELED Upon an existing non-empty entry being found at the
+ *			 last index
+ */
+int _gnix_vec_insert_last(gnix_vector_t *vec, gnix_vec_entry_t *entry);
+
+/**
+ * Inserts an entry into the first index of the vector. If the entry at the
+ * first index is not empty the insertion will be canceled.
+ *
+ * @param[in] vec	the vector to insert entry into
+ * @param[in] entry	the item to insert into the vector
+ *
+ * @return FI_SUCCESS	 Upon successfully inserting the entry into the vector
+ * @return -FI_EINVAL	 Upon passing a dead vector, or a null
+ * 			 entry
+ * @return -FI_ECANCELED Upon an existing non-empty entry being found at index 0
+ */
+int _gnix_vec_insert_first(gnix_vector_t *vec, gnix_vec_entry_t *entry);
+
+#endif /* GNIX_VECTOR_H_ */

--- a/prov/gni/src/gnix_vector.c
+++ b/prov/gni/src/gnix_vector.c
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "gnix_vector.h"
+
+static gnix_vector_ops_t __gnix_vec_lockless_ops;
+static gnix_vector_ops_t __gnix_vec_locked_ops;
+
+
+/*******************************************************************************
+ * INTERNAL HELPER FNS
+ ******************************************************************************/
+static inline uint64_t __gnix_vec_get_new_size(gnix_vector_t *vec, uint64_t index)
+{
+	uint64_t new_size = vec->attr.cur_size;
+
+	if (vec->attr.vec_increase_type == GNIX_VEC_INCREASE_ADD) {
+		do {
+			new_size += vec->attr.vec_increase_step;
+		} while (index >= new_size);
+	} else {
+		if (new_size)
+			new_size *= vec->attr.vec_increase_step;
+		else
+			new_size = (new_size + 1) * vec->attr.vec_increase_step;
+
+		while (index >= new_size)
+			new_size *= vec->attr.vec_increase_step;
+
+	}
+
+	if (new_size > vec->attr.vec_maximum_size) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Maximum vector size of %lu "
+			  "reached in __gnix_vec_new_size\n", vec->attr.vec_maximum_size);
+		new_size = vec->attr.vec_maximum_size;
+	}
+
+	return new_size;
+}
+
+static inline int __gnix_vec_resize(gnix_vector_t *vec, uint64_t new_size)
+{
+	void *tmp = realloc(vec->vector, new_size * sizeof(gnix_vec_entry_t));
+
+	if (!tmp) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Insufficient memory in "
+			  "__gnix_vec_resize\n");
+		return -FI_ENOMEM;
+	}
+
+	vec->vector = tmp;
+
+	if (new_size > vec->attr.cur_size) {
+		memset(vec->vector + vec->attr.cur_size, 0,
+		       (sizeof(gnix_vec_entry_t) * (new_size - vec->attr.cur_size)));
+	}
+
+	vec->attr.cur_size = new_size;
+
+	return FI_SUCCESS;
+}
+
+static inline int __gnix_vec_create(gnix_vector_t *vec, gnix_vec_attr_t *attr)
+{
+	vec->vector = calloc(attr->vec_initial_size, sizeof(gnix_vec_entry_t));
+
+	if (unlikely(!vec->vector)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Insufficient memory in "
+			  "_gnix_vec_init.\n");
+		return -FI_ENOMEM;
+	} else {
+		attr->cur_size = attr->vec_initial_size;
+	}
+
+	memcpy(&vec->attr, attr, sizeof(gnix_vec_attr_t));
+
+	return FI_SUCCESS;
+}
+
+static inline void __gnix_vec_close_entries(gnix_vector_t *vec)
+{
+	memset(vec->vector, 0, (sizeof(gnix_vec_entry_t) * vec->attr.cur_size));
+}
+
+static inline void __gnix_vec_close(gnix_vector_t *vec)
+{
+	free(vec->vector);
+	vec->ops = NULL;
+	vec->attr.cur_size = 0;
+	vec->state = GNIX_VEC_STATE_DEAD;
+}
+
+/*******************************************************************************
+ * INLINE OPS FNS
+ ******************************************************************************/
+inline int _gnix_vec_insert_first(gnix_vector_t *vec, gnix_vec_entry_t *entry)
+{
+	return _gnix_vec_insert_at(vec, entry, 0);
+}
+
+inline int _gnix_vec_insert_last(gnix_vector_t *vec, gnix_vec_entry_t *entry)
+{
+	return _gnix_vec_insert_at(vec, entry, vec->attr.cur_size-1);
+}
+
+inline int _gnix_vec_insert_at(gnix_vector_t *vec, gnix_vec_entry_t *entry,
+				      gnix_vec_index_t index)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (unlikely(!vec || !entry ||
+		    index >= vec->attr.vec_maximum_size)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to "
+			  "__gnix_vec_insert_at\n");
+		return -FI_EINVAL;
+	}
+
+	if (unlikely(vec->state == GNIX_VEC_STATE_DEAD)) {
+		GNIX_FATAL(FI_LOG_EP_CTRL, "gnix_vector_t is in state "
+			   "GNIX_VEC_STATE_DEAD in _gnix_vec_insert_at.\n");
+	}
+
+	if (index >= vec->attr.cur_size) {
+		uint64_t new_size = __gnix_vec_get_new_size(vec, index);
+		int ret = __gnix_vec_resize(vec, new_size);
+
+		if (unlikely(ret))
+			return ret;
+	}
+
+	if (vec->vector[index]) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Existing element found in "
+			  "__gnix_vec_insert_last\n");
+		return -FI_ECANCELED;
+	} else {
+		vec->vector[index] = entry;
+		return FI_SUCCESS;
+	}
+}
+
+inline int _gnix_vec_remove_first(gnix_vector_t *vec)
+{
+	return _gnix_vec_remove_at(vec, 0);
+}
+
+inline int _gnix_vec_remove_last(gnix_vector_t *vec)
+{
+	return _gnix_vec_remove_at(vec, vec->attr.cur_size-1);
+}
+
+inline int _gnix_vec_remove_at(gnix_vector_t *vec, gnix_vec_index_t index)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (unlikely(!vec || index >= vec->attr.cur_size)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to "
+			  "__gnix_vec_remove_at\n");
+		return -FI_EINVAL;
+	} else if (unlikely(vec->state == GNIX_VEC_STATE_DEAD)) {
+		GNIX_FATAL(FI_LOG_EP_CTRL, "gnix_vector_t is in state "
+			   "GNIX_VEC_STATE_DEAD in _gnix_vec_remove_at.\n");
+	} else {
+		if (!vec->vector[index]) {
+			GNIX_WARN(FI_LOG_EP_CTRL, "No entry exists in "
+				  "__gnix_vec_remove_at\n");
+			return -FI_ECANCELED;
+		} else {
+			vec->vector[index] = NULL;
+		}
+	}
+	return FI_SUCCESS;
+}
+
+inline int _gnix_vec_first(gnix_vector_t *vec, void **element)
+{
+	return _gnix_vec_at(vec, element, 0);
+}
+
+inline int _gnix_vec_last(gnix_vector_t *vec, void **element)
+{
+	return _gnix_vec_at(vec, element, vec->attr.cur_size-1);
+}
+
+inline int _gnix_vec_at(gnix_vector_t *vec, void **element, gnix_vec_index_t index)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (unlikely(!vec || index > vec->attr.cur_size || !element)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to "
+			  "_gnix_vec_at\n");
+		return -FI_EINVAL;
+	} else if (unlikely(vec->state == GNIX_VEC_STATE_DEAD)) {
+		GNIX_FATAL(FI_LOG_EP_CTRL, "gnix_vector_t is in state "
+			   "GNIX_VEC_STATE_DEAD in _gnix_vec_at.\n");
+	} else {
+		if (likely((uint64_t) vec->vector[index])) {
+			*element = vec->vector[index];
+		} else {
+			GNIX_WARN(FI_LOG_EP_CTRL, "There is no element at index "
+				  "%lu in _gnix_vec_at\n", index);
+			return -FI_ECANCELED;
+		}
+
+	}
+	return FI_SUCCESS;
+}
+
+/*******************************************************************************
+ * LOCKLESS FNS
+ ******************************************************************************/
+static int __gnix_vec_lf_init(gnix_vector_t *vec, gnix_vec_attr_t *attr)
+{
+	int ret;
+
+	ret = __gnix_vec_create(vec, attr);
+	vec->ops = &__gnix_vec_lockless_ops;
+	vec->state = GNIX_VEC_STATE_READY;
+
+	return ret;
+}
+
+static int __gnix_vec_lf_close(gnix_vector_t *vec)
+{
+	__gnix_vec_close_entries(vec);
+	__gnix_vec_close(vec);
+
+	return FI_SUCCESS;
+}
+
+static int __gnix_vec_lf_resize(gnix_vector_t *vec, uint64_t size)
+{
+	return __gnix_vec_resize(vec, size);
+}
+
+static int __gnix_vec_lf_insert_first(gnix_vector_t *vec,
+				      gnix_vec_entry_t *entry)
+{
+	return _gnix_vec_insert_first(vec, entry);
+}
+
+static int __gnix_vec_lf_insert_last(gnix_vector_t *vec,
+			      gnix_vec_entry_t *entry)
+{
+	return _gnix_vec_insert_last(vec, entry);
+}
+
+static int __gnix_vec_lf_insert_at(gnix_vector_t *vec,
+				   gnix_vec_entry_t *entry,
+				   gnix_vec_index_t index)
+{
+	return _gnix_vec_insert_at(vec, entry, index);
+}
+
+static int __gnix_vec_lf_remove_first(gnix_vector_t *vec)
+{
+	return _gnix_vec_remove_first(vec);
+}
+
+static int __gnix_vec_lf_remove_last(gnix_vector_t *vec)
+{
+	return _gnix_vec_remove_last(vec);
+}
+
+static int __gnix_vec_lf_remove_at(gnix_vector_t *vec,
+				   gnix_vec_index_t index)
+{
+	return _gnix_vec_remove_at(vec, index);
+}
+
+static int __gnix_vec_lf_first(gnix_vector_t *vec, void **element)
+{
+	return _gnix_vec_first(vec, element);
+}
+
+static int __gnix_vec_lf_last(gnix_vector_t *vec, void **element)
+{
+	return _gnix_vec_last(vec, element);
+}
+
+static int __gnix_vec_lf_at(gnix_vector_t *vec, void **element, gnix_vec_index_t index)
+{
+	return _gnix_vec_at(vec, element, index);
+}
+
+/*******************************************************************************
+ * LOCKED FNS
+ ******************************************************************************/
+static int __gnix_vec_lk_init(gnix_vector_t *vec, gnix_vec_attr_t *attr)
+{
+	int ret;
+
+	rwlock_init(&vec->lock);
+	ret = __gnix_vec_create(vec, attr);
+	vec->ops = &__gnix_vec_locked_ops;
+	vec->state = GNIX_VEC_STATE_READY;
+
+	return ret;
+}
+
+static int __gnix_vec_lk_close(gnix_vector_t *vec)
+{
+	rwlock_wrlock(&vec->lock);
+
+	__gnix_vec_close_entries(vec);
+	__gnix_vec_close(vec);
+
+	rwlock_unlock(&vec->lock);
+
+	rwlock_destroy(&vec->lock);
+
+	return FI_SUCCESS;
+}
+
+static int __gnix_vec_lk_resize(gnix_vector_t *vec, uint64_t size)
+{
+	int ret;
+
+	rwlock_wrlock(&vec->lock);
+
+	ret = __gnix_vec_resize(vec, size);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+static int __gnix_vec_lk_insert_first(gnix_vector_t *vec,
+				      gnix_vec_entry_t *entry)
+{
+	int ret;
+
+	rwlock_wrlock(&vec->lock);
+
+	ret = _gnix_vec_insert_first(vec, entry);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+static int __gnix_vec_lk_insert_last(gnix_vector_t *vec,
+			      gnix_vec_entry_t *entry)
+{
+	int ret;
+
+	rwlock_wrlock(&vec->lock);
+
+	ret = _gnix_vec_insert_last(vec, entry);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+static int __gnix_vec_lk_insert_at(gnix_vector_t *vec,
+				   gnix_vec_entry_t *entry,
+				   gnix_vec_index_t index)
+{
+	int ret;
+
+	rwlock_wrlock(&vec->lock);
+
+	ret = _gnix_vec_insert_at(vec, entry, index);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+static int __gnix_vec_lk_remove_first(gnix_vector_t *vec)
+{
+	int ret;
+
+	rwlock_wrlock(&vec->lock);
+
+	ret = _gnix_vec_remove_first(vec);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+static int __gnix_vec_lk_remove_last(gnix_vector_t *vec)
+{
+	int ret;
+
+	rwlock_wrlock(&vec->lock);
+
+	ret = _gnix_vec_remove_last(vec);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+static int __gnix_vec_lk_remove_at(gnix_vector_t *vec,
+				   gnix_vec_index_t index)
+{
+	int ret;
+
+	rwlock_wrlock(&vec->lock);
+
+	ret = _gnix_vec_remove_at(vec, index);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+static int __gnix_vec_lk_first(gnix_vector_t *vec, void **element)
+{
+	int ret;
+
+	rwlock_rdlock(&vec->lock);
+
+	ret = _gnix_vec_first(vec, element);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+static int __gnix_vec_lk_last(gnix_vector_t *vec, void **element)
+{
+	int ret;
+
+	rwlock_rdlock(&vec->lock);
+
+	ret = _gnix_vec_last(vec, element);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+static int __gnix_vec_lk_at(gnix_vector_t *vec, void **element, gnix_vec_index_t index)
+{
+	int ret;
+
+	rwlock_rdlock(&vec->lock);
+
+	ret = _gnix_vec_at(vec, element, index);
+
+	rwlock_unlock(&vec->lock);
+
+	return ret;
+}
+
+/**
+ * Create the initial vector.  The user is responsible for initializing the
+ * "attr" parameter prior to calling this function.
+ *
+ * @param[in] vec	the vector to initialize
+ * @param[in] attr	the vector attributes
+ *
+ * @return FI_SUCCESS	Upon successfully creating the vector
+ * @return -FI_EINVAL	Upon receiving an invalid parameter
+ * @return -FI_ENOMEM	Upon insufficient memory to create the vector
+ */
+int _gnix_vec_init(struct gnix_vector *vec, gnix_vec_attr_t *attr)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (unlikely(!vec || !attr ||
+		     attr->vec_initial_size > attr->vec_maximum_size)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to _gnix_vec_init."
+			  "\n");
+		return -FI_EINVAL;
+	} else if (unlikely(vec->state == GNIX_VEC_STATE_READY)) {
+		GNIX_FATAL(FI_LOG_EP_CTRL, "gnix_vector_t is in state "
+			   "GNIX_VEC_STATE_READY in _gnix_vec_init.\n");
+	}
+
+	if (attr->vec_internal_locking == GNIX_VEC_LOCKED) {
+		return __gnix_vec_lk_init(vec, attr);
+	} else {
+		return __gnix_vec_lf_init(vec, attr);
+	}
+}
+
+/**
+ * Close the vector elements and then the vector.
+ *
+ * @param[in] vec       the vector to close
+ *
+ * @return FI_SUCCESS	Upon successfully closing the vector
+ * @return -FI_EINVAL	Upon a uninitialized or dead vector
+ */
+int _gnix_vec_close(gnix_vector_t *vec)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (unlikely(!vec)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to _gnix_vec_close."
+			  "\n");
+		return -FI_EINVAL;
+	} else if (unlikely(vec->state == GNIX_VEC_STATE_DEAD)) {
+		GNIX_FATAL(FI_LOG_EP_CTRL, "gnix_vector_t is in state "
+			   "GNIX_VEC_STATE_DEAD in _gnix_vec_close.\n");
+	} else {
+		if (vec->attr.vec_internal_locking == GNIX_VEC_LOCKED) {
+			return __gnix_vec_lk_close(vec);
+		} else {
+			return __gnix_vec_lf_close(vec);
+		}
+	}
+}
+
+int _gnix_vec_resize(gnix_vector_t *vec, uint64_t size)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (unlikely(!vec || !size)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to _gnix_vec_resize."
+			  "\n");
+		return -FI_EINVAL;
+	} else {
+		if (vec->attr.vec_internal_locking == GNIX_VEC_LOCKED) {
+			return __gnix_vec_lk_resize(vec, size);
+		} else {
+			return __gnix_vec_lf_resize(vec, size);
+		}
+	}
+}
+
+static gnix_vector_ops_t __gnix_vec_lockless_ops = {
+	.insert_first = __gnix_vec_lf_insert_first,
+	.insert_last = __gnix_vec_lf_insert_last,
+	.insert_at = __gnix_vec_lf_insert_at,
+
+	.remove_first = __gnix_vec_lf_remove_first,
+	.remove_last = __gnix_vec_lf_remove_last,
+	.remove_at = __gnix_vec_lf_remove_at,
+
+	.first = __gnix_vec_lf_first,
+	.last = __gnix_vec_lf_last,
+	.at = __gnix_vec_lf_at,
+};
+
+static gnix_vector_ops_t __gnix_vec_locked_ops = {
+	.insert_first = __gnix_vec_lk_insert_first,
+	.insert_last = __gnix_vec_lk_insert_last,
+	.insert_at = __gnix_vec_lk_insert_at,
+
+	.remove_first = __gnix_vec_lk_remove_first,
+	.remove_last = __gnix_vec_lk_remove_last,
+	.remove_at = __gnix_vec_lk_remove_at,
+
+	.first = __gnix_vec_lk_first,
+	.last = __gnix_vec_lk_last,
+	.at = __gnix_vec_lk_at,
+};

--- a/prov/gni/test/vector.c
+++ b/prov/gni/test/vector.c
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All
+ * rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "gnix_vector.h"
+#include <unistd.h>
+#include <criterion/criterion.h>
+#include <stdlib.h>
+
+gnix_vector_t vec;
+gnix_vec_attr_t attr;
+
+#define VEC_MAX  (1024)
+#define VEC_INIT 128
+
+void vector_setup_lockless(void)
+{
+	int ret;
+
+	attr.vec_increase_step = 2;
+	attr.vec_increase_type = GNIX_VEC_INCREASE_MULT;
+	attr.vec_initial_size = VEC_INIT;
+	attr.vec_internal_locking = GNIX_VEC_UNLOCKED;
+	attr.vec_maximum_size = VEC_MAX;
+
+	ret = _gnix_vec_init(&vec, &attr);
+	cr_assert(!ret, "_gnix_vec_init");
+}
+
+void vector_setup_locked()
+{
+	int ret;
+
+	attr.vec_increase_step = 2;
+	attr.vec_increase_type = GNIX_VEC_INCREASE_ADD;
+	attr.vec_initial_size = VEC_INIT;
+	attr.vec_internal_locking = GNIX_VEC_LOCKED;
+	attr.vec_maximum_size = VEC_MAX;
+
+	ret = _gnix_vec_init(&vec, &attr);
+	cr_assert(!ret, "_gnix_vec_init");
+}
+
+void do_invalid_ops_params()
+{
+	int ret;
+	void *tmp;
+
+	/* ret = _gnix_vec_insert_first(&vec, NULL); */
+	/* cr_assert_eq(ret, -FI_EINVAL); */
+
+	/* ret = _gnix_vec_remove_first(&vec); */
+	/* cr_assert_eq(ret, -FI_EINVAL); */
+
+	/* ret = _gnix_vec_first(&vec, &tmp); */
+	/* cr_assert_eq(ret, -FI_EINVAL); */
+
+	ret = _gnix_vec_insert_first(NULL, NULL);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_vec_remove_first(NULL);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_vec_first(NULL, &tmp);
+	cr_assert_eq(ret, -FI_EINVAL);
+}
+
+void vector_teardown(void)
+{
+	int ret;
+
+	ret = _gnix_vec_close(&vec);
+	cr_assert(!ret, "_gnix_vec_close");
+
+	do_invalid_ops_params();
+
+	/* ret = _gnix_vec_close(&vec); */
+	/* cr_assert_eq(ret, -FI_EINVAL); */
+
+	ret = _gnix_vec_close(NULL);
+	cr_assert_eq(ret, -FI_EINVAL);
+}
+
+/* Test invalid parameters for setup */
+void vector_setup_error(void)
+{
+	int ret;
+
+	attr.vec_increase_step = 2;
+	attr.vec_increase_type = GNIX_VEC_INCREASE_MULT;
+	attr.vec_initial_size = VEC_INIT;
+	attr.vec_internal_locking = GNIX_VEC_UNLOCKED;
+	attr.vec_maximum_size = VEC_MAX;
+
+	ret = _gnix_vec_init(NULL, NULL);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_vec_init(NULL, &attr);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	ret = _gnix_vec_init(&vec, NULL);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	attr.vec_initial_size = 256;
+	attr.vec_maximum_size = 128;
+
+	ret = _gnix_vec_init(&vec, &attr);
+	cr_assert_eq(ret, -FI_EINVAL);
+
+	/* attr.vec_initial_size = 64; */
+	/* attr.vec_maximum_size = 128; */
+	/* vec.state = GNIX_VEC_STATE_READY; */
+	/* ret = _gnix_vec_init(&vec, &attr); */
+
+	vector_setup_lockless();
+}
+
+void do_insert_first()
+{
+	int ret;
+	void *tmp = malloc(sizeof(gnix_vec_entry_t));
+	cr_assert(tmp, "do_insert_first");
+
+	ret = vec.ops->insert_first(&vec, tmp);
+	cr_assert(!ret, "_gnix_vec_insert_first");
+
+	ret = vec.ops->insert_first(&vec, tmp);
+	cr_assert_eq(ret, -FI_ECANCELED);
+}
+
+void do_insert_last()
+{
+	int ret;
+	void *tmp = malloc(sizeof(gnix_vec_entry_t));
+	cr_assert(tmp, "do_insert_last");
+
+	ret = vec.ops->insert_last(&vec, tmp);
+	cr_assert(!ret, "_gnix_vec_insert_last");
+
+	ret = vec.ops->insert_last(&vec, tmp);
+	cr_assert_eq(ret, -FI_ECANCELED);
+}
+
+void do_fill_insert_at()
+{
+	int i, ret;
+	void *tmp;
+
+	for (i = 0; i < vec.attr.cur_size; i++) {
+		tmp = malloc(sizeof(gnix_vec_entry_t));
+		cr_assert(tmp, "do_insert_at");
+
+		ret = vec.ops->insert_at(&vec, tmp, i);
+		cr_assert(!ret, "_gnix_vec_insert_at");
+	}
+
+	/* Test grow. */
+	tmp = malloc(sizeof(gnix_vec_entry_t));
+	cr_assert(tmp, "do_insert_at");
+
+	ret = vec.ops->insert_at(&vec, tmp, VEC_MAX-1);
+	cr_assert(!ret, "_gnix_vec_insert_at");
+	cr_assert_eq(vec.attr.cur_size, VEC_MAX);
+
+	ret = vec.ops->insert_at(&vec, tmp, VEC_MAX-1);
+	cr_assert_eq(ret, -FI_ECANCELED);
+
+	for (; i < vec.attr.cur_size - 1; i++) {
+		tmp = malloc(sizeof(gnix_vec_entry_t));
+		cr_assert(tmp, "do_insert_at");
+
+		ret = vec.ops->insert_at(&vec, tmp, i);
+		cr_assert(!ret, "_gnix_vec_insert_at");
+	}
+
+	ret = vec.ops->insert_at(&vec, tmp, VEC_MAX);
+	cr_assert_eq(ret, -FI_EINVAL);
+}
+
+void do_remove_first()
+{
+	int ret;
+
+	ret = vec.ops->remove_first(&vec);
+	cr_assert(!ret, "_gnix_vec_remove_first");
+
+	ret = vec.ops->remove_first(&vec);
+	cr_assert_eq(ret, -FI_ECANCELED);
+}
+
+void do_remove_last()
+{
+	int ret;
+
+	ret = vec.ops->remove_last(&vec);
+	cr_assert(!ret, "_gnix_vec_remove_last");
+
+	ret = vec.ops->remove_last(&vec);
+	cr_assert_eq(ret, -FI_ECANCELED);
+}
+
+void do_unfill_remove_at()
+{
+	int i, ret;
+
+	for (i = 0; i < vec.attr.cur_size; i++) {
+		ret = vec.ops->remove_at(&vec, i);
+		cr_assert(!ret, "_gnix_vec_remove_at");
+	}
+
+	ret = vec.ops->remove_at(&vec, vec.attr.cur_size / 2);
+	cr_assert_eq(ret, -FI_ECANCELED);
+}
+
+void do_first()
+{
+	int ret;
+	void *tmp;
+
+	ret = vec.ops->first(&vec, &tmp);
+	cr_assert(tmp, "_gnix_vec_first");
+	cr_assert(!ret, "_gnix_vec_first");
+
+	tmp = NULL;
+
+	do_remove_first();
+
+	ret = vec.ops->first(&vec, &tmp);
+	cr_assert_eq(tmp, NULL);
+	cr_assert_eq(ret, -FI_ECANCELED);
+}
+
+void do_last()
+{
+	int ret;
+	void *tmp;
+
+	ret = vec.ops->last(&vec, &tmp);
+	cr_assert(tmp, "_gnix_vec_last");
+	cr_assert(!ret, "_gnix_vec_last");
+
+	tmp = NULL;
+
+	do_remove_last();
+
+	ret = vec.ops->last(&vec, &tmp);
+	cr_assert_eq(tmp, NULL);
+	cr_assert_eq(ret, -FI_ECANCELED);
+}
+
+void do_at()
+{
+	int i ,ret;
+	void *tmp;
+
+	for (i = 0; i < vec.attr.cur_size; i++) {
+		ret = vec.ops->at(&vec, &tmp, i);
+		cr_assert(!ret, "_gnix_vec_at");
+
+		cr_assert(!!tmp, "_gnix_vec_at");
+		tmp = NULL;
+	}
+}
+
+void do_tests()
+{
+	do_insert_first();
+	do_first();
+
+	do_insert_last();
+	do_last();
+
+	do_fill_insert_at();
+	do_at();
+	do_unfill_remove_at();
+}
+
+TestSuite(vector_lockless, .init = vector_setup_lockless,
+	  .fini = vector_teardown, .disabled = false);
+
+Test(vector_lockless, do_first)
+{
+	do_insert_first();
+	do_first();
+}
+
+Test(vector_lockless, do_last)
+{
+	do_insert_last();
+	do_last();
+}
+
+Test(vector_lockless, do_at)
+{
+	do_fill_insert_at();
+	do_at();
+	do_unfill_remove_at();
+}
+
+TestSuite(vector_locked, .init = vector_setup_locked,
+	  .fini = vector_teardown, .disabled = false);
+
+Test(vector_locked, do_first)
+{
+	do_insert_first();
+	do_first();
+}
+
+Test(vector_locked, do_last)
+{
+	do_insert_last();
+	do_last();
+}
+
+Test(vector_locked, do_at)
+{
+	do_fill_insert_at();
+	do_at();
+	do_unfill_remove_at();
+}
+
+TestSuite(vector_error_lockless, .init = vector_setup_error,
+	  .fini = vector_teardown, .disabled = false);
+
+Test(vector_error_lockless, setup_teardown_error)
+{
+
+}


### PR DESCRIPTION
	  *Added lockless and locked fns in the ops tables.
	  *Added lockless inline functions of all ops in header.
	  *Added criterion unit tests.
	  *Updated Makefile.include.

	  Implemented ofi-cray/libfabric-cray#696 feedback:
	  *The vector aborts upon attempting to operate on a "DEAD" object.
	  *Replaced bzero with memset.
	  *Fixed minor spelling errors.

@sungeunchoi 

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@6e689ae4b0942a9163a43f4555f4ca1dc1105f9e)
upstream merge of ofi-cray/libfabric-cray#696