### PR TITLE
prov/gni: change gnix_cm_nic to point to fabric

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -47,7 +47,7 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
  *
  * @var nic            pointer to gnix_nic associated with this cm nic
  * @var dgram_hndl     handle to dgram allocator associated with this nic
- * @var domain         GNI provider domain associated with this nic
+ * @var fabric         GNI provider fabric associated with this nic
  * @var addr_to_ep_ht  Hash table for looking up ep bound to this
  *                     cm nic, key is ep's gnix_address
  * @var wq_lock        spin lock for cm nic's work queue
@@ -63,7 +63,7 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
 struct gnix_cm_nic {
 	struct gnix_nic *nic;
 	struct gnix_dgram_hndl *dgram_hndl;
-	struct gnix_fid_domain *domain;
+	struct gnix_fid_fabric *fabric;
 	struct gnix_hashtable *addr_to_ep_ht;
 	fastlock_t wq_lock;
 	struct dlist_entry cm_nic_wq;

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -402,7 +402,7 @@ int _gnix_cm_nic_reg_recv_fn(struct gnix_cm_nic *cm_nic,
 int _gnix_cm_nic_enable(struct gnix_cm_nic *cm_nic)
 {
 	int i, ret = FI_SUCCESS;
-	struct gnix_fid_domain *domain;
+	struct gnix_fid_fabric *fabric;
 	struct gnix_datagram *dg_ptr;
 	uint8_t tag = GNIX_CM_NIC_WC_TAG;
 
@@ -411,12 +411,12 @@ int _gnix_cm_nic_enable(struct gnix_cm_nic *cm_nic)
 	if (cm_nic == NULL)
 		return -FI_EINVAL;
 
-	domain = cm_nic->domain;
-	assert(domain != NULL);
+	fabric = cm_nic->fabric;
+	assert(fabric != NULL);
 
 	assert(cm_nic->dgram_hndl != NULL);
 
-	for (i = 0; i < domain->fabric->n_wc_dgrams; i++) {
+	for (i = 0; i < fabric->n_wc_dgrams; i++) {
 		ret = _gnix_dgram_alloc(cm_nic->dgram_hndl, GNIX_DGRAM_WC,
 					&dg_ptr);
 
@@ -548,7 +548,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	cm_nic->my_name.cookie = domain->cookie;
 	cm_nic->my_name.gnix_addr.device_addr =
 	cm_nic->nic->device_addr;
-	cm_nic->domain = domain;
+	cm_nic->fabric = domain->fabric;
 	cm_nic->ctrl_progress = domain->control_progress;
 	cm_nic->my_name.name_type = name_type;
 	fastlock_init(&cm_nic->wq_lock);


### PR DESCRIPTION
turns out it makes more sense to have a gnix_cm_nic
to point to the fabric struct its associated with
rather than the domain.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@cf0ee9204bc51c6a7d452f5fda98b4012e76b76d)
upstream merge of ofi-cray/libfabric-cray#712
@sungeunchoi 
