### PR TITLE
prov/gni: Set default mr_mode

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -247,6 +247,7 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	/* only one aries per node */
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);
+	gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
 
 	gnix_info->next = NULL;
 	gnix_info->addr_format = FI_ADDR_GNI;
@@ -368,6 +369,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 			switch (hints->domain_attr->mr_mode) {
 			case FI_MR_UNSPEC:
 			case FI_MR_BASIC:
+				gnix_info->domain_attr->mr_mode =
+					hints->domain_attr->mr_mode;
 				break;
 			case FI_MR_SCALABLE:
 				goto err;

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -214,6 +214,7 @@ void rdm_api_setup(void)
 		hints[i]->domain_attr->cq_data_size = NUMEPS * 2;
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
 		hints[i]->mode = ~0;
+		hints[i]->domain_attr->mr_mode = FI_MR_BASIC;
 		hints[i]->fabric_attr->name = strdup("gni");
 	}
 }


### PR DESCRIPTION
Set mr_mode in api tests to verify correct behavior.

Fixes ofi-cray/libfabric-cray#732.

Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@f4195162f6ad8f29c3b96aa2052916b5b3d089f6)
upstream merge or ofi-cray/libfabric-cray#733
@sungeunchoi 