### PR TITLE
prov/gni: Fix valgrind warnings

### DIFF
--- a/prov/gni/test/api_cq.c
+++ b/prov/gni/test/api_cq.c
@@ -323,6 +323,9 @@ void api_cq_send_recv(int len)
 	struct fi_msg_rma rma_msg;
 	struct fi_rma_iov rma_iov;
 
+	iov.iov_base = NULL;
+	iov.iov_len = 0;
+
 	api_cq_init_data(source, len, 0xab);
 	api_cq_init_data(target, len, 0);
 


### PR DESCRIPTION
conditional jump depending on unitialized values.
struct iovec iov was not intialized in the fn api_cq_send_recv.

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@1356c5cc5fcfd407498b446b8f49aff80538e453)
upstream merge of ofi-cray/libfabric-cray#738
@sungeunchoi 