### PR TITLE
prov/gni: specify resource mgmt support

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -248,6 +248,7 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);
 	gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
+	gnix_info->domain_attr->resource_mgmt = FI_RM_ENABLED;
 
 	gnix_info->next = NULL;
 	gnix_info->addr_format = FI_ADDR_GNI;


### PR DESCRIPTION
GNI provider was not specifying resource management
support level.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@081d106fcc55491b20980335f46863ada48ad989)
upstream merge of ofi-cray/libfabric-cray#740
@sungeunchoi 