### PR TITLE
prov/gni: Update gnix_av_straddr() to include

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -256,6 +256,21 @@ struct gnix_ep_name {
 	uint64_t reserved[4];
 };
 
+/* AV address string revision. */
+#define GNIX_AV_STR_ADDR_VERSION  1
+
+/*
+ * 49 is the number of characters printed out in gnix_av_straddr.
+ *  1 is for the null terminator
+ */
+#define GNIX_AV_MAX_STR_ADDR_LEN  (49 + 1)
+
+/*
+ * 15 is the number of characters for the device addr.
+ *  1 is for the null terminator
+ */
+#define GNIX_AV_MIN_STR_ADDR_LEN  (15 + 1)
+
 /*
  * enum for blocking/non-blocking progress
  */

--- a/prov/gni/include/gnix_av.h
+++ b/prov/gni/include/gnix_av.h
@@ -93,4 +93,28 @@ int _gnix_av_reverse_lookup(struct gnix_fid_av *gnix_av,
 			    struct gnix_address gnix_addr,
 			    fi_addr_t *fi_addr);
 
+/**
+ * @brief Return the string representation of the FI address.
+ *
+ * @param[in]   buf         The buffer that contains the address string.
+ * @param(out)  gnix_ep     The gnix_ep_name structure that contains the
+ * @return      FI_SUCCESS on success or -FI_EINVAL on error.
+ */
+int gnix_av_straddr_to_ep_name(char *buf,
+			       struct gnix_ep_name *gnix_ep);
+
+/**
+ * @brief Return the string representation of the FI address.
+ *
+ * @param[in]      av      The AV to use.
+ * @param[in]      addr    The GNIX address to translate.
+ * @param[in/out]  buf     The buffer that contains the address string.
+ * @param[in/out]  len     The length of the address string.
+ * @return         char    The buffer that contains the address string.
+ */
+const char *gnix_av_straddr(struct fid_av *av,
+			    const void *addr,
+			    char *buf,
+			    size_t *len);
+
 #endif /* _GNIX_AV_H_ */

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -34,7 +34,8 @@
 #include "gnix.h"
 #include "gnix_util.h"
 #include "gnix_nic.h"
-#include "gnix_cm_nic.h"
+#include "gnix_nic.h"
+#include "gnix_av.h"
 
 /*******************************************************************************
  * API function implementations.
@@ -56,33 +57,32 @@ DIRECT_FN STATIC int gnix_getname(fid_t fid, void *addr, size_t *addrlen)
 	struct gnix_ep_name name = {{0}};
 	struct gnix_fid_ep *ep = NULL;
 	int ret = FI_SUCCESS;
-	size_t copy_size;
+	size_t copy_size = GNIX_AV_MAX_STR_ADDR_LEN;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
-	copy_size = sizeof(struct gnix_ep_name);
-
-	/*
-	 * If addrlen is less than the size necessary then continue copying with
-	 * truncation and return error value -FI_ETOOSMALL.
-	 */
-	if (*addrlen < copy_size) {
-		copy_size = *addrlen;
-		ret = -FI_ETOOSMALL;
+	if (!addrlen) {
+		ret = -FI_EINVAL;
+		goto err;
 	}
 
-	/* copy the address length */
-	*addrlen = sizeof(struct gnix_ep_name);
+	if (*addrlen < GNIX_AV_MIN_STR_ADDR_LEN) {
+		/* return the maximum length of the string. */
+		*addrlen = GNIX_AV_MAX_STR_ADDR_LEN;
+		ret = -FI_ETOOSMALL;
+		goto err;
+	}
 
 	if (!addr) {
-		if (copy_size >= *addrlen) {
-			ret = -FI_EINVAL;
-		}
-
+		/* return the maximum length of the string. */
+		*addrlen = GNIX_AV_MAX_STR_ADDR_LEN;
+		ret = -FI_EINVAL;
 		goto err;
 	}
 
 	if (!fid) {
+		/* return the maximum length of the string. */
+		*addrlen = GNIX_AV_MAX_STR_ADDR_LEN;
 		ret = -FI_EINVAL;
 		goto err;
 	}
@@ -103,7 +103,31 @@ DIRECT_FN STATIC int gnix_getname(fid_t fid, void *addr, size_t *addrlen)
 		return -FI_ENOSYS;  /*TODO: need to implement FI_EP_MSG */
 	}
 
-	memcpy(addr, &name, copy_size);
+	/*
+	 * If addrlen is less than the size necessary then continue copying
+	 * with the size of the receiving buffer.
+	 */
+	if (*addrlen < copy_size) {
+		copy_size = *addrlen;
+	}
+
+	/*
+	 * Retrieve the cdm_id, device_addr and other information
+	 * from the gnix_ep_name structure.
+	 */
+
+	gnix_av_straddr(NULL, (void *) &name, addr, &copy_size);
+
+	/*
+	 * If the copy size is less then the string addr length,
+	 * truncation has occurred so return the error value -FI_ETOOSMALL.
+	 */
+	if (copy_size < GNIX_AV_MAX_STR_ADDR_LEN) {
+		ret = -FI_ETOOSMALL;
+	}
+
+	/* return the copied length of the string. */
+	*addrlen = copy_size;
 
 err:
 	return ret;

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -43,6 +43,7 @@
 #include "gnix_cm_nic.h"
 #include "gnix_nic.h"
 #include "gnix_hashtable.h"
+#include "gnix_av.h"
 
 
 #define GNIX_CM_NIC_BND_TAG (100)
@@ -478,7 +479,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	struct gnix_cm_nic *cm_nic = NULL;
 	uint32_t cdm_id, seed;
 	gnix_hashtable_attr_t gnix_ht_attr = {0};
-	struct gnix_ep_name *name;
+	struct gnix_ep_name name;
 	uint32_t name_type = GNIX_EPN_TYPE_UNBOUND;
 	struct gnix_nic_attr nic_attr = {0};
 
@@ -495,12 +496,12 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	 */
 
 	if (info->src_addr &&
-	    info->src_addrlen == sizeof(struct gnix_ep_name)) {
-		name = (struct gnix_ep_name *)info->src_addr;
-		if (name->name_type == GNIX_EPN_TYPE_BOUND) {
+	    info->src_addrlen == GNIX_AV_MAX_STR_ADDR_LEN) {
+		gnix_av_straddr_to_ep_name(info->src_addr, &name);
+		if (name.name_type == GNIX_EPN_TYPE_BOUND) {
 			/* EP name includes user specified service/port */
-			cdm_id = name->gnix_addr.cdm_id;
-			name_type = name->name_type;
+			cdm_id = name.gnix_addr.cdm_id;
+			name_type = name.name_type;
 		}
 	}
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -59,6 +59,7 @@
 #include "gnix_util.h"
 #include "gnix_nameserver.h"
 #include "gnix_wait.h"
+#include "gnix_av.h"
 
 const char gnix_fab_name[] = "gni";
 const char gnix_dom_name[] = "/sys/class/gni/kgni0";
@@ -178,6 +179,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	struct gnix_ep_name *dest_addr = NULL;
 	struct gnix_ep_name *src_addr = NULL;
 	struct gnix_ep_name *addr = NULL;
+	char *str_src_addr = NULL;
+	char *str_dest_addr = NULL;
 
 	/*
 	 * the code below for resolving a node/service to what
@@ -251,10 +254,30 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 
 	gnix_info->next = NULL;
 	gnix_info->addr_format = FI_ADDR_GNI;
-	gnix_info->src_addrlen = sizeof(struct gnix_ep_name);
-	gnix_info->dest_addrlen = sizeof(struct gnix_ep_name);
-	gnix_info->src_addr = src_addr;
-	gnix_info->dest_addr = dest_addr;
+	gnix_info->src_addrlen = 0;
+	gnix_info->dest_addrlen = 0;
+	gnix_info->src_addr = NULL;
+	gnix_info->dest_addr = NULL;
+	if (src_addr) {
+		str_src_addr = malloc(GNIX_AV_MAX_STR_ADDR_LEN);
+		if (!str_src_addr) {
+			goto err;
+		}
+		gnix_info->src_addrlen = GNIX_AV_MAX_STR_ADDR_LEN;
+		gnix_av_straddr(NULL, (void *) src_addr, (char *) str_src_addr,
+			 &gnix_info->src_addrlen);
+		gnix_info->src_addr = str_src_addr;
+	}
+	if (dest_addr) {
+		str_dest_addr = malloc(GNIX_AV_MAX_STR_ADDR_LEN);
+		if (!str_dest_addr) {
+			goto err;
+		}
+		gnix_info->dest_addrlen = GNIX_AV_MAX_STR_ADDR_LEN;
+		gnix_av_straddr(NULL, (void *) addr, (char *) str_dest_addr,
+			 &gnix_info->dest_addrlen);
+		gnix_info->dest_addr = str_dest_addr;
+	}
 	/* prov_name gets filled in by fi_getinfo from the gnix_prov struct */
 	/* let's consider gni copyrighted :) */
 
@@ -419,6 +442,18 @@ err:
 		if (gnix_info->domain_attr) free(gnix_info->domain_attr);
 		if (gnix_info->fabric_attr) free(gnix_info->fabric_attr);
 		free(gnix_info);
+	}
+
+	if (addr) {
+		free(addr);
+	}
+
+	if (str_src_addr) {
+		free(str_src_addr);
+	}
+
+	if (str_dest_addr) {
+		free(str_dest_addr);
 	}
 
 	/*


### PR DESCRIPTION
additional information.

Modified gnix_av_straddr() to include the information from the
gnix_ep_name structure that was missing.  Also, added a version
number to the string generated.

Created gnix_av_straddr_to_ep_name() to parse the string created
by gnix_av_straddr().

Modified gnix_av table_insert() and map_insert() to parse
and use the information in the ep address string.

Modified gnix_av_lookup() to return the ep address string.

Modified _gnix_cm_nic_alloc() to parse the ep address strin
and to use its information when allocating the cm_nic structure.

Modified gnix_getinfo() to return the ep address strings for
the src_addr and dest_addr fields.

Modified gnix_getname() to return the ep address string.

Modified the gni av test to use the ep address string
when inserting av addresses.

Fixes: ofi-cray/libfabric-cray#665
Signed-off-by: Tony Zinger <ajz@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@51f1f43bc0f362e6037a495c97c839d4d80fb355)
upstream commit of ofi-cray/libfabric-cray#735
@sungeunchoi 