### PR TITLE
prov/gni: fixes for use of fi_inject

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -83,7 +83,6 @@ const struct fi_fabric_attr gnix_fabric_attr = {
 	.prov_version = FI_VERSION(GNI_MAJOR_VERSION, GNI_MINOR_VERSION),
 };
 
-
 DIRECT_FN int gnix_fabric_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
 {
 	return -FI_ENOSYS;

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1629,6 +1629,7 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	if (flags & FI_INJECT) {
 		memcpy(req->inject_buf, (void *)loc_addr, len);
 		req->msg.send_addr = (uint64_t)req->inject_buf;
+		req->flags |= FI_INJECT;
 	} else {
 		req->msg.send_addr = loc_addr;
 	}


### PR DESCRIPTION
fi_inject could fail for certain edge cases
in Open MPI since at finalize, the MPI processes
fall in to an out-of-band barrier that prevents
completion of inject requests.  This commit fixes
the issue.

add criterion test
Fixes ofi-cray/libfabric-cray#559

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@af2d6ccb9431c21f5fcf550fda30fb0f9ee41509)
upstream merge of ofi-cray/libfabric-cray#730

@sungeunchoi 