### PR TITLE
verbs/RDM improvements

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -98,7 +98,7 @@ static ssize_t fi_ibv_rdm_tagged_cq_read(struct fid_cq *cq, void *buf,
 	return fi_ibv_rdm_tagged_cq_readfrom(cq, buf, MIN(_count, count), addr);
 }
 
-ssize_t	fi_ibv_rdm_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
+ssize_t fi_ibv_rdm_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 				fi_addr_t *src_addr, const void *cond,
 				int timeout)
 {
@@ -126,7 +126,7 @@ ssize_t	fi_ibv_rdm_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 	return (counter != 0) ? counter : -FI_EAGAIN;
 }
 
-ssize_t	fi_ibv_rdm_cq_sread(struct fid_cq *cq, void *buf, size_t count,
+ssize_t fi_ibv_rdm_cq_sread(struct fid_cq *cq, void *buf, size_t count,
 			    const void *cond, int timeout)
 {
 	struct fi_ibv_cq *_cq	= container_of(cq, struct fi_ibv_cq, cq_fid);

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -159,6 +159,7 @@ struct fi_ibv_rdm_tagged_request {
 		void *unexp_rbuf;
 		void *sbuf;
 		void *rmabuf;
+		struct iovec *rmaiovec_arr;
 	};
 
 	/*

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -721,6 +721,8 @@ static int fi_ibv_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 
 	if (ep_dom->type == FI_EP_RDM) {
 		fi->tx_attr->inject_size = FI_IBV_RDM_DFLT_BUFFERED_SSIZE;
+		fi->tx_attr->iov_limit = 1;
+		fi->tx_attr->rma_iov_limit = 1;
 	}
 
 	switch (ctx->device->transport_type) {

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -275,8 +275,11 @@ fi_ibv_rdm_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
 		if (again) {
 			goto out_again;
 		}
-	} else if (RMA_RESOURCES_IS_BUSY(conn, ep)) {
-		/* TODO: to implement postponed queue flow for RMA */
+	} else if (!fi_ibv_rdm_check_connection(conn, ep) ||
+		   RMA_RESOURCES_IS_BUSY(conn, ep)) {
+		/*
+		 * TODO: Should be postponed queue flow for RMA be implemented?
+		 */
 		goto out_again;
 	}
 
@@ -322,6 +325,55 @@ out_errinput:
 }
 
 static ssize_t
+fi_ibv_rdm_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+		uint64_t flags)
+{
+	if(msg->iov_count == 1 && msg->rma_iov_count == 1) {
+		return fi_ibv_rdm_ep_rma_read(ep,
+					      msg->msg_iov[0].iov_base,
+					      msg->msg_iov[0].iov_len,
+					      msg->desc[0],
+					      msg->addr,
+					      msg->rma_iov[0].addr,
+					      msg->rma_iov[0].key,
+					      msg->context);
+	}
+
+	assert(0);
+	return -FI_EMSGSIZE;
+}
+
+static ssize_t
+fi_ibv_rdm_ep_rma_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
+		void *context)
+{
+	struct fi_rma_iov rma_iov = {
+		.addr = src_addr,
+		.len = 0,
+		.key = key
+	};
+
+	size_t i;
+	for (i = 0; i < count; i++) {
+		rma_iov.len += iov[i].iov_len;
+	}
+
+	struct fi_msg_rma msg = {
+		.msg_iov = iov,
+		.desc = desc,
+		.iov_count = count,
+		.addr = addr,
+		.rma_iov = &rma_iov,
+		.rma_iov_count = 1,
+		.context = context,
+		.data = 0
+	};
+
+	return fi_ibv_rdm_ep_rma_readmsg(ep, &msg, 0);
+}
+
+static ssize_t
 fi_ibv_rdm_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 		     void *desc, fi_addr_t dest_addr,
 		     uint64_t addr, uint64_t key, void *context)
@@ -354,8 +406,11 @@ fi_ibv_rdm_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 		if (again) {
 			goto out_again;
 		}
-	} else if (SEND_RESOURCES_IS_BUSY(conn, ep)) {
-		/* TODO: to implement postponed queue flow for RMA */
+	} else if (!fi_ibv_rdm_check_connection(conn, ep) ||
+		   SEND_RESOURCES_IS_BUSY(conn, ep)) {
+		/*
+		 * TODO: Should be postponed queue flow for RMA be implemented?
+		 */
 		goto out_again;
 	}
 
@@ -398,6 +453,55 @@ out_again:
 out_errinput:
 	ret = -FI_EINVAL;
 	goto out;
+}
+
+static ssize_t
+fi_ibv_rdm_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+		uint64_t flags)
+{
+	if(msg->iov_count == 1 && msg->rma_iov_count == 1) {
+		return fi_ibv_rdm_ep_rma_write(ep,
+					       msg->msg_iov[0].iov_base,
+					       msg->msg_iov[0].iov_len,
+					       msg->desc[0],
+					       msg->addr,
+					       msg->rma_iov[0].addr,
+					       msg->rma_iov[0].key,
+					       msg->context);
+	}
+
+	assert(0);
+	return -FI_EMSGSIZE;
+}
+
+static ssize_t
+fi_ibv_rdm_ep_rma_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		void *context)
+{
+	struct fi_rma_iov rma_iov = {
+		.addr = dest_addr,
+		.len = 0,
+		.key = key
+	};
+
+	size_t i;
+	for (i = 0; i < count; i++) {
+		rma_iov.len += iov[i].iov_len;
+	}
+
+	struct fi_msg_rma msg = {
+		.msg_iov = iov,
+		.desc = desc,
+		.iov_count = count,
+		.addr = addr,
+		.rma_iov = &rma_iov,
+		.rma_iov_count = 1,
+		.context = context,
+		.data = 0
+	};
+
+	return fi_ibv_rdm_ep_rma_writemsg(ep, &msg, 0);
 }
 
 static ssize_t fi_ibv_rdm_ep_rma_inject_write(struct fid_ep *ep,
@@ -468,11 +572,11 @@ static ssize_t fi_ibv_rdm_ep_rma_inject_write(struct fid_ep *ep,
 static struct fi_ops_rma fi_ibv_rdm_ep_rma_ops = {
 	.size		= sizeof(struct fi_ops_rma),
 	.read		= fi_ibv_rdm_ep_rma_read,
-	.readv		= fi_no_rma_readv,
-	.readmsg	= fi_no_rma_readmsg,
+	.readv		= fi_ibv_rdm_ep_rma_readv,
+	.readmsg	= fi_ibv_rdm_ep_rma_readmsg,
 	.write		= fi_ibv_rdm_ep_rma_write,
-	.writev		= fi_no_rma_writev,
-	.writemsg	= fi_no_rma_writemsg,
+	.writev		= fi_ibv_rdm_ep_rma_writev,
+	.writemsg	= fi_ibv_rdm_ep_rma_writemsg,
 	.inject		= fi_ibv_rdm_ep_rma_inject_write,
 	.writedata	= fi_no_rma_writedata,
 	.injectdata	= fi_no_rma_injectdata,


### PR DESCRIPTION
- iov counts reduced to 1 due to unreadiness for large messages
- implemented RMA readv/readmsg, writev/writemsg for 1 iov
- implemented cq_sread/cq_sreadfrom
- update: added check for connection and resources availability in fi_ibv_rdm_ep_rma_inject_write

@a-ilango 