### PR TITLE
usnic: Use EFD_SEMAPHORE for EQ and fabric control FDs.

### DIFF
--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -532,7 +532,7 @@ usdf_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		eq->eq_ops_data.sread = usdf_eq_sread_fd;
 		/* FALLTHROUGH. Don't set sread for wait set. */
 	case FI_WAIT_SET:
-		eq->eq_fd = eventfd(0, EFD_NONBLOCK);
+		eq->eq_fd = eventfd(0, EFD_NONBLOCK | EFD_SEMAPHORE);
 		if (eq->eq_fd == -1) {
 			ret = -errno;
 			goto fail;

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -820,7 +820,7 @@ usdf_fabric_open(struct fi_fabric_attr *fattrp, struct fid_fabric **fabric,
 		goto fail;
 	}
 
-	fp->fab_eventfd = eventfd(0, EFD_NONBLOCK);
+	fp->fab_eventfd = eventfd(0, EFD_NONBLOCK | EFD_SEMAPHORE);
 	if (fp->fab_eventfd == -1) {
 		ret = -errno;
 		USDF_INFO("unable to allocate event fd\n");


### PR DESCRIPTION
Commit 8c533eb removed the EFD_SEMAPHORE flag from all control
descriptors. This is alright for the CQ operations since the provider
has to handle the FD used for the hardware CQs that does not support
counting. This means that the FD is cleared upon every invocation of
trywait. For the EQs, the FD should not be cleared. The EQ operations
rely on the counting behavior of an FD opened with EFD_SEMAPHORE. This
commit adds back the EFD_SEMAPHORE to the fabric and EQ control FDs.
This fixes #1896.

@jsquyres @goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>