### PR TITLE
prov/gni: Added missing prototype for gnix_fabric_trywait.

### DIFF
--- a/prov/gni/include/rdma/fi_direct_eq.h
+++ b/prov/gni/include/rdma/fi_direct_eq.h
@@ -40,6 +40,9 @@
 /*******************************************************************************
  * GNI API Functions
  ******************************************************************************/
+extern int gnix_fabric_trywait(struct fid_fabric *fabric, struct fid **fids,
+                               int count);
+
 extern int gnix_wait_wait(struct fid_wait *wait, int timeout);
 
 extern int gnix_poll_poll(struct fid_poll *pollset, void **context, int count);


### PR DESCRIPTION
(cherry picked from commit ofi-cray/libfabric-cray@69274922f86053abaed89b4b4bd9dd1f107e619e)
upstream merge of ofi-cray/libfabric-cray#751
@sungeunchoi 