### PR TITLE
verbs/RDM fixes

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -298,11 +298,9 @@ static int fi_ibv_rdm_tagged_ep_close(fid_t fid)
 		HASH_DEL(fi_ibv_rdm_tagged_conn_hash, conn);
 		switch (conn->state) {
 		case FI_VERBS_CONN_ALLOCATED:
-			free(conn);
-			break;
 		case FI_VERBS_CONN_REMOTE_DISCONNECT:
-			fi_ibv_rdm_start_disconnection(ep, conn);
-			fi_ibv_rdm_tagged_conn_cleanup(ep, conn);
+		case FI_VERBS_CONN_ESTABLISHED:
+			fi_ibv_rdm_start_disconnection(conn);
 			break;
 		case FI_VERBS_CONN_STARTED:
 			while (conn->state != FI_VERBS_CONN_ESTABLISHED &&
@@ -314,9 +312,6 @@ static int fi_ibv_rdm_tagged_ep_close(fid_t fid)
 					return ret;
 				}
 			}
-			break;
-		case FI_VERBS_CONN_ESTABLISHED:
-			fi_ibv_rdm_start_disconnection(ep, conn);
 			break;
 		default:
 			break;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -451,10 +451,8 @@ fi_ibv_rdm_tagged_buffer_lists_init(struct fi_ibv_rdm_tagged_conn *conn,
 
 int fi_ibv_rdm_tagged_poll(struct fi_ibv_rdm_ep *ep);
 int fi_ibv_rdm_tagged_cm_progress(struct fi_ibv_rdm_ep *ep);
-int fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_ep *ep,
-                                   struct fi_ibv_rdm_tagged_conn *conn);
-int fi_ibv_rdm_tagged_conn_cleanup(struct fi_ibv_rdm_ep *ep,
-                                   struct fi_ibv_rdm_tagged_conn *conn);
+int fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_tagged_conn *conn);
+int fi_ibv_rdm_tagged_conn_cleanup(struct fi_ibv_rdm_tagged_conn *conn);
 int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
                                 struct fi_ibv_rdm_tagged_conn *conn);
 int fi_ibv_rdm_tagged_repost_receives(struct fi_ibv_rdm_tagged_conn *conn,

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -40,6 +40,9 @@
 #include "verbs_utils.h"
 #include "verbs_tagged_ep_rdm_states.h"
 
+#define FI_IBV_EP_TYPE_IS_RDM(_info)	\
+	(_info && _info->ep_attr && (_info->ep_attr->type == FI_EP_RDM))
+
 #define FI_IBV_RDM_ST_PKTTYPE_MASK  ((uint32_t) 0xFF)
 #define FI_IBV_RDM_EAGER_PKT		0
 #define FI_IBV_RDM_RNDV_RTS_PKT		1

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -237,7 +237,7 @@ static inline ssize_t fi_ibv_rdm_tagged_inject(struct fid_ep *fid,
 
 	const size_t size = len + sizeof(struct fi_ibv_rdm_header);
 
-	if (size > ep->rndv_threshold) {
+	if (len > ep->rndv_threshold) {
 		return -FI_EMSGSIZE;
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -582,6 +582,7 @@ fi_ibv_rdm_tagged_eager_recv_got_pkt(struct fi_ibv_rdm_tagged_request *request,
 
 	switch (p->pkt_type) {
 	case FI_IBV_RDM_EAGER_PKT:
+		assert(p->arrived_len - sizeof(rbuf->header) <= request->len);
 		request->tag = rbuf->header.tag;
 		request->conn = p->conn;
 		request->len = p->arrived_len - sizeof(rbuf->header);
@@ -589,7 +590,6 @@ fi_ibv_rdm_tagged_eager_recv_got_pkt(struct fi_ibv_rdm_tagged_request *request,
 		request->imm = p->imm_data;
 
 		assert(request->len <= p->ep->rndv_threshold);
-		assert(request->len <= request->len);
 
 		if (request->dest_buf) {
 			assert(request->exp_rbuf);

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -517,12 +517,14 @@ fi_ibv_rdm_tagged_init_unexp_recv_request(
 	switch (p->pkt_type) {
 	case FI_IBV_RDM_EAGER_PKT:
 		FI_IBV_RDM_TAGGED_HANDLER_LOG();
-		assert(p->arrived_len <= p->ep->rndv_threshold);
 
 		request->tag = rbuf->header.tag;
 		request->conn = p->conn;
 		request->len = 
 			p->arrived_len - sizeof(struct fi_ibv_rdm_header);
+		
+		assert(request->len <= p->ep->rndv_threshold);
+
 		if (request->len > 0) {
 			request->unexp_rbuf = util_buf_alloc(
 				fi_ibv_rdm_tagged_extra_buffers_pool);
@@ -580,15 +582,14 @@ fi_ibv_rdm_tagged_eager_recv_got_pkt(struct fi_ibv_rdm_tagged_request *request,
 
 	switch (p->pkt_type) {
 	case FI_IBV_RDM_EAGER_PKT:
-		assert(p->pkt_type == FI_IBV_RDM_EAGER_PKT);
-		assert(p->arrived_len <= p->ep->rndv_threshold);
-		assert(p->arrived_len - sizeof(rbuf->header) <= request->len);
-
 		request->tag = rbuf->header.tag;
 		request->conn = p->conn;
 		request->len = p->arrived_len - sizeof(rbuf->header);
 		request->exp_rbuf = rbuf->payload;
 		request->imm = p->imm_data;
+
+		assert(request->len <= p->ep->rndv_threshold);
+		assert(request->len <= request->len);
 
 		if (request->dest_buf) {
 			assert(request->exp_rbuf);

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -138,7 +138,7 @@ int fi_ibv_rdm_tagged_find_ipoib_addr(const struct sockaddr_in *addr,
 			struct sockaddr_in *paddr =
 			    (struct sockaddr_in *) tmp->ifa_addr;
 			if (!strncmp(tmp->ifa_name, "ib", 2)) {
-				int ret;
+				int ret = 0;
 
 				if (addr && addr->sin_addr.s_addr) {
 					ret = !memcmp(&addr->sin_addr,

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -138,7 +138,7 @@ int fi_ibv_create_ep(const char *node, const char *service,
 
 	if (!node && !rai_hints.ai_dst_addr) {
 		if ((!rai_hints.ai_src_addr && !service) ||
-		    (!rai_hints.ai_src_addr &&
+		    (!rai_hints.ai_src_addr && hints &&
 		     (hints->ep_attr->type == FI_EP_RDM)))
 		{
 			node = local_node;
@@ -172,7 +172,7 @@ int fi_ibv_create_ep(const char *node, const char *service,
 		}
 	}
 
-	if (hints->ep_attr->type == FI_EP_RDM) {
+	if (hints && (hints->ep_attr->type == FI_EP_RDM)) {
 		struct fi_ibv_rdm_cm* cm = 
 			container_of(id, struct fi_ibv_rdm_cm, listener);
 		fi_ibv_rdm_cm_init(cm, _rai);

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -138,8 +138,7 @@ int fi_ibv_create_ep(const char *node, const char *service,
 
 	if (!node && !rai_hints.ai_dst_addr) {
 		if ((!rai_hints.ai_src_addr && !service) ||
-		    (!rai_hints.ai_src_addr && hints &&
-		     (hints->ep_attr->type == FI_EP_RDM)))
+		    (!rai_hints.ai_src_addr && FI_IBV_EP_TYPE_IS_RDM(hints)))
 		{
 			node = local_node;
 		}
@@ -172,7 +171,7 @@ int fi_ibv_create_ep(const char *node, const char *service,
 		}
 	}
 
-	if (hints && (hints->ep_attr->type == FI_EP_RDM)) {
+	if (FI_IBV_EP_TYPE_IS_RDM(hints)) {
 		struct fi_ibv_rdm_cm* cm = 
 			container_of(id, struct fi_ibv_rdm_cm, listener);
 		fi_ibv_rdm_cm_init(cm, _rai);

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -33,7 +33,7 @@
 #include "config.h"
 
 #include "fi_verbs.h"
-
+#include "ep_rdm/verbs_rdm.h"
 
 static int fi_ibv_mr_close(fid_t fid)
 {
@@ -228,7 +228,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (!_domain->info)
 		goto err1;
 
-	_domain->rdm = (info->ep_attr->type == FI_EP_RDM);
+	_domain->rdm = FI_IBV_EP_TYPE_IS_RDM(info);
 	ret = fi_ibv_open_device_by_name(_domain, info->domain_attr->name);
 	if (ret)
 		goto err2;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -319,7 +319,7 @@ int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
 
 	compare_mode = attr->mode ? attr->mode : hints->mode;
 	
-	check_mode = (info->ep_attr->type == FI_EP_RDM) ? VERBS_RDM_MODE :
+	check_mode = FI_IBV_EP_TYPE_IS_RDM(info) ? VERBS_RDM_MODE :
 		(hints->caps & FI_RMA) ? info->rx_attr->mode : VERBS_MODE;
 
 	if ((compare_mode & check_mode) != check_mode) {
@@ -942,7 +942,7 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 	if (ret)
 		goto out;
 
-	if (hints->ep_attr->type == FI_EP_RDM) {
+	if (FI_IBV_EP_TYPE_IS_RDM(hints)) {
 		memset(&rdm_cm, 0, sizeof(struct fi_ibv_rdm_cm));
 		ret = fi_ibv_create_ep(node, service, flags, hints, &rai,
 				       &(rdm_cm.listener));
@@ -962,7 +962,7 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 	}
 
 	fi_ibv_destroy_ep(hints->ep_attr->type, rai, 
-		hints->ep_attr->type == FI_EP_RDM ? &(rdm_cm.listener) : &id);
+		FI_IBV_EP_TYPE_IS_RDM(hints) ? &(rdm_cm.listener) : &id);
 
 out:
 	if (!ret || ret == -FI_ENOMEM)


### PR DESCRIPTION
Fixed hang of RMA stress tests (initialization checks before RMA operations)
Fixed check for message size in tinject (rndv_threshold is alredy calculated with the header size)
Fixed coverity issues

@a-ilango 