### PR TITLE
usnic: Limit FI_GETWAIT to bound CQs.

### DIFF
--- a/man/fi_usnic.7.md
+++ b/man/fi_usnic.7.md
@@ -64,6 +64,9 @@ low latency and other offload capabilities on Ethernet networks.
         * The tag matching interface is not supported.
         * *FI_MSG_PREFIX* is only supported on *FI_EP_DGRAM* and usage
           is limited to releases 1.1 and beyond.
+        * fi_control with FI_GETWAIT may only be used on CQs that have been
+          bound to an endpoint. If fi_control is used on an unbound CQ, it will
+          return -FI_EOPBADSTATE.
     - The usnic libfabric provider supports extensions that provide
       information and functionality beyond the standard libfabric
       interface.  See the "USNIC EXTENSIONS" section, below.

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -810,6 +810,12 @@ static int usdf_cq_get_wait(struct usdf_cq *cq, void *arg)
 
 	switch (cq->cq_attr.wait_obj) {
 	case FI_WAIT_FD:
+		if (cq->object.fd == -1) {
+			USDF_WARN_SYS(CQ,
+					"CQ must be bound before FD can be retrieved\n");
+			return -FI_EOPBADSTATE;
+		}
+
 		*(int *) arg = cq->object.fd;
 		break;
 	default:
@@ -1270,6 +1276,7 @@ usdf_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		atomic_inc(&wait_priv->wait_refcnt);
 	}
 
+	cq->object.fd = -1;
 	cq->cq_domain = udp;
 	cq->cq_fid.fid.fclass = FI_CLASS_CQ;
 	cq->cq_fid.fid.context = context;


### PR DESCRIPTION
Since FD creation is done during CQ creation, a CQ will not have a valid
FD before a bind operation. If fi_control is used before the FD has been
created, then return -FI_EOPBADSTATE. Also initialize the FD to -1.

@jsquyres @goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>