### PR TITLE
usnic: Keep progress thread alive for CQs.

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -376,6 +376,7 @@ struct usdf_cq {
 	struct usdf_domain *cq_domain;
 	struct fi_cq_attr cq_attr;
 	uint8_t is_soft;
+	uint8_t cq_waiting;
 
 	union {
 		int fd;

--- a/prov/usnic/src/usdf_wait.c
+++ b/prov/usnic/src/usdf_wait.c
@@ -274,7 +274,6 @@ static int usdf_wait_close(struct fid *waitset)
 
 static int usdf_wait_wait(struct fid_wait *fwait, int timeout)
 {
-	struct usdf_fabric *fabric;
 	struct usdf_wait *wait;
 	struct epoll_event event;
 	int ret = FI_SUCCESS;
@@ -282,7 +281,6 @@ static int usdf_wait_wait(struct fid_wait *fwait, int timeout)
 
 	USDF_TRACE_SYS(FABRIC, "\n");
 	wait = wait_ftou(fwait);
-	fabric = wait->wait_fabric;
 
 	ret = usdf_wait_trywait(&fwait->fid);
 	if (ret) {
@@ -290,13 +288,6 @@ static int usdf_wait_wait(struct fid_wait *fwait, int timeout)
 			return FI_SUCCESS;
 
 		return ret;
-	}
-
-	atomic_inc(&fabric->num_blocked_waiting);
-	ret = usdf_fabric_wake_thread(fabric);
-	if (ret) {
-		USDF_DBG_SYS(FABRIC, "error while waking progress thread\n");
-		goto out;
 	}
 
 	nevents = epoll_wait(wait->object.epfd, &event, 1, timeout);
@@ -307,8 +298,6 @@ static int usdf_wait_wait(struct fid_wait *fwait, int timeout)
 		ret = -errno;
 	}
 
-out:
-	atomic_dec(&fabric->num_blocked_waiting);
 	return ret;
 }
 


### PR DESCRIPTION
A common usage pattern for external FD use is to acquire the FD, call
trywait, and call fi_cq_read. The progress threads needs to stay alive
during the duration of the wait in order to progress receives. Keep
track of CQs that are waiting and increment the fabric wait var to keep
the thread alive. Decrement once again upon the first fi_cq_read for
each CQ.

@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>