### PR TITLE
usnic: Rename CQ member is_soft -> cq_is_soft.

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -375,7 +375,7 @@ struct usdf_cq {
 	atomic_t cq_refcnt;
 	struct usdf_domain *cq_domain;
 	struct fi_cq_attr cq_attr;
-	uint8_t is_soft;
+	uint8_t cq_is_soft;
 	uint8_t cq_waiting;
 
 	union {

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -374,7 +374,7 @@ usdf_cq_readfrom_context(struct fid_cq *fcq, void *buf, size_t count,
 			}
 			++src_addr;
 		}
-			
+
 
 		entry->op_context = cq->cq_comp.uc_context;
 
@@ -784,7 +784,7 @@ usdf_cq_close(fid_t fid)
 			return ret;
 	}
 
-	if (cq->is_soft) {
+	if (cq->cq_is_soft) {
 		while (!TAILQ_EMPTY(&cq->c.soft.cq_list)) {
 			hcq = TAILQ_FIRST(&cq->c.soft.cq_list);
 			if (atomic_get(&hcq->cqh_refcnt) > 0) {
@@ -958,7 +958,7 @@ usdf_cq_make_soft(struct usdf_cq *cq)
 		return 0;
         }
 
-	if (!cq->is_soft) {
+	if (!cq->cq_is_soft) {
 
 		/* save the CQ before we trash the union */
 		ucq = cq->c.hard.cq_cq;
@@ -992,7 +992,7 @@ usdf_cq_make_soft(struct usdf_cq *cq)
 			TAILQ_INSERT_HEAD(&cq->c.soft.cq_list, hcq, cqh_link);
 		}
 
-		cq->is_soft = 1;
+		cq->cq_is_soft = 1;
 		cq->cq_ops = *soft_ops;
         }
 	return 0;
@@ -1146,7 +1146,7 @@ int usdf_cq_trywait(struct fid *fcq)
 		atomic_dec(&fab->num_blocked_waiting);
 	}
 
-	if (cq->is_soft) {
+	if (cq->cq_is_soft) {
 		empty = usdf_check_empty_soft_cq(cq);
 	} else {
 		usd_poll_req_notify(cq->c.hard.cq_cq);

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -178,7 +178,7 @@ usdf_ep_dgram_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		/* actually, could look through CQ list for a hard
 		 * CQ with function usd_poll_cq() and use that... XXX
 		 */
-		if (cq->is_soft) {
+		if (cq->cq_is_soft) {
 			return -FI_EINVAL;
 		}
 		if (cq->c.hard.cq_cq == NULL) {
@@ -249,7 +249,7 @@ usdf_ep_dgram_deref_cq(struct usdf_cq *cq)
 
 	rtn = usdf_progress_hard_cq;
 
-	if (cq->is_soft) {
+	if (cq->cq_is_soft) {
 		TAILQ_FOREACH(hcq, &cq->c.soft.cq_list, cqh_link) {
 			if (hcq->cqh_progress == rtn) {
 				atomic_dec(&hcq->cqh_refcnt);

--- a/prov/usnic/src/usdf_poll.c
+++ b/prov/usnic/src/usdf_poll.c
@@ -67,7 +67,7 @@ static int usdf_poll_poll(struct fid_poll *fps, void **context, int count)
 
 		cq = cq_fidtou(entry->fid);
 
-		if (cq->is_soft) {
+		if (cq->cq_is_soft) {
 			if (!progressed) {
 				usdf_domain_progress(ps->poll_domain);
 				progressed = 1;


### PR DESCRIPTION
@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>