### PR TITLE
prov/gni: match getinfo man page better

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -150,11 +150,15 @@ extern "C" {
 /*
  * See capabilities section in fi_getinfo.3.
  */
-#define GNIX_EP_RDM_CAPS                                                       \
+#define GNIX_EP_RDM_PRIMARY_CAPS                                               \
 	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMICS |                            \
-	 FI_DIRECTED_RECV | FI_INJECT | FI_SOURCE | FI_READ |                  \
-	 FI_WRITE | FI_SEND | FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE |     \
-	 FI_TRANSMIT_COMPLETE | FI_FENCE)
+	 FI_DIRECTED_RECV | FI_READ |                                          \
+	 FI_WRITE | FI_SEND | FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE)
+
+#define GNIX_EP_RDM_SEC_CAPS                                             \
+	(FI_MULTI_RECV | FI_SOURCE | FI_TRIGGER | FI_FENCE)
+
+#define GNIX_EP_RDM_CAPS (GNIX_EP_RDM_PRIMARY_CAPS | GNIX_EP_RDM_SEC_CAPS)
 
 /*
  * see Operations flags in fi_endpoint.3
@@ -201,6 +205,7 @@ extern "C" {
  * if this has to be changed, check gnix_getinfo, etc.
  */
 #define GNIX_EP_MSG_CAPS GNIX_EP_RDM_CAPS
+#define GNIX_EP_MSG_SEC_CAPS GNIX_EP_RDM_SEC_CAPS
 
 #define GNIX_MAX_MSG_SIZE ((0x1ULL << 32) - 1)
 #define GNIX_CACHELINE_SIZE (64)

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -424,7 +424,21 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	/*
 	 * Set the values based on hints
 	 */
-	gnix_info->caps = caps;
+
+	switch (gnix_info->ep_attr->type) {
+	case FI_EP_RDM:
+	case FI_EP_DGRAM:
+		gnix_info->caps = caps | GNIX_EP_RDM_SEC_CAPS;
+		break;
+	case FI_EP_MSG:
+		gnix_info->caps = caps | GNIX_EP_MSG_SEC_CAPS;
+		break;
+	default:
+		GNIX_ERR(FI_LOG_FABRIC, "unknown ep type %d",
+			 gnix_info->ep_attr->type);
+		break;
+	}
+
 	gnix_info->mode = mode;
 	gnix_info->fabric_attr->name = strdup(gnix_fab_name);
 	gnix_info->tx_attr->caps = gnix_info->caps;


### PR DESCRIPTION
The GNI provider wasn't appending the secondary capabilities
in the returned caps field in the fi_getinfo call.  This was
leading to some confusion on the part of MPICH users/developers
as to the capabilities that the GNI provider supported.

Follow the pattern used by the sockets provider and have
separate macros for primary and secondary caps, and or in the
secondary caps in the returned fi_info struct.

Fixes #1899
Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@0b1fbb3a289a90925e4be8995570fddb61bbd351)
upstream merge of ofi-cray/libfabric-cray#758
@sungeunchoi 