### PR TITLE
prov/gni: fix problem when using FI_ADDR_UNSPEC

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1284,13 +1284,12 @@ retry_match:
 			GNIX_INFO(FI_LOG_EP_DATA, "matched RNDZV, req: %p\n",
 				  req);
 
-			/* TODO: prevent re-lookup of src_addr */
-			ret = _gnix_vc_ep_get_vc(ep, src_addr, &req->vc);
-			if (ret) {
-				GNIX_INFO(FI_LOG_EP_DATA,
-					  "_gnix_vc_ep_get_vc failed: %dn",
-					  ret);
-				return ret;
+			/*
+			 * this shouldn't happen
+			 */
+			if (unlikely(req->vc == NULL)) {
+				GNIX_ERR(FI_LOG_EP_DATA,
+					 "fab req vc field NULL");
 			}
 
 			/* Check if second GET for unaligned data is needed. */

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -2073,8 +2073,8 @@ static int __gnix_vc_ep_rdm_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
 	ret = _gnix_av_lookup(av, dest_addr, &av_entry);
 	if (ret != FI_SUCCESS) {
 		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_av_lookup returned %s\n",
-			  fi_strerror(-ret));
+			  "_gnix_av_lookup for addr 0x%llx returned %s \n",
+			  dest_addr, fi_strerror(-ret));
 		goto err;
 	}
 


### PR DESCRIPTION
some IMB tests weren't passing.  This commit
fixes that problem.

Fixes ofi-cray/libfabric-cray#760

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@4285cf15393628f1100fd5491437702c755858fa)
upstream merge of ofi-cray/libfabric-cray#761
@sungeunchoi 