### PR TITLE
prov/verbs: fix a problem with fi_info

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -172,7 +172,7 @@ int fi_ibv_create_ep(const char *node, const char *service,
 		}
 	}
 
-	if (hints->ep_attr->type == FI_EP_RDM) {
+	if (hints && hints->ep_attr && (hints->ep_attr->type == FI_EP_RDM)) {
 		struct fi_ibv_rdm_cm* cm = 
 			container_of(id, struct fi_ibv_rdm_cm, listener);
 		fi_ibv_rdm_cm_init(cm, _rai);

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -942,7 +942,8 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 	if (ret)
 		goto out;
 
-	if (hints->ep_attr->type == FI_EP_RDM) {
+	if (hints && hints->ep_attr &&
+		(hints->ep_attr->type == FI_EP_RDM)) {
 		memset(&rdm_cm, 0, sizeof(struct fi_ibv_rdm_cm));
 		ret = fi_ibv_create_ep(node, service, flags, hints, &rai,
 				       &(rdm_cm.listener));
@@ -961,8 +962,9 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 		ret = fi_ibv_get_matching_info(NULL, hints, rai, info);
 	}
 
-	fi_ibv_destroy_ep(hints->ep_attr->type, rai, 
-		hints->ep_attr->type == FI_EP_RDM ? &(rdm_cm.listener) : &id);
+	if (hints && hints->ep_attr)
+		fi_ibv_destroy_ep(hints->ep_attr->type, rai,
+			hints->ep_attr->type == FI_EP_RDM ? &(rdm_cm.listener) : &id);
 
 out:
 	if (!ret || ret == -FI_ENOMEM)


### PR DESCRIPTION
fi_info fails with SIGSEGV without this fix
if verbs provider is built.

@evgeny-leksikov 
@shefty 

May not get in to 1.3.0 but I'd like for fi_info to work. 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>