### PR TITLE
prov/verbs: fix a problem with max_inline_data

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -76,8 +77,13 @@ fi_ibv_rdm_tagged_find_max_inline_size(struct ibv_pd *pd,
 			ibv_destroy_qp(qp);
 		qp_attr.cap.max_inline_data = max_inline;
 		qp = ibv_create_qp(pd, &qp_attr);
-		if (qp)
+		if (qp) {
+			/* 
+			 * truescale returns max_inline_data 0
+			 */
+			if (0 == qp_attr.cap.max_inline_data) break;
 			rst = max_inline;
+		}
 	} while (qp && (max_inline *= 2));
 
 	if (rst != 0) {


### PR DESCRIPTION
On truescale HCAs
InfiniBand: QLogic Corp. IBA7322 QDR InfiniBand HCA (rev 02)
the max_inline_data attr returned from ibv_create_qp returns
0.  This messes up the existing calculation of max inline
size.

@jsquyres 
@evgeny-leksikov 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>