### PR TITLE
usnic: Reset old max_msg_size for pre-1.3 releases.

### DIFF
--- a/prov/usnic/src/usdf_dgram.h
+++ b/prov/usnic/src/usdf_dgram.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -58,8 +58,8 @@ int usdf_dgram_fill_rx_attr(struct fi_info *hints,
 int usdf_dgram_fill_tx_attr(struct fi_info *hints, struct fi_info *fi,
 		struct usd_device_attrs *dap);
 int usdf_dgram_fill_dom_attr(struct fi_info *hints, struct fi_info *fi);
-int usdf_dgram_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
-		struct usd_device_attrs *dap);
+int usdf_dgram_fill_ep_attr(uint32_t version, struct fi_info *hints,
+		struct fi_info *fi, struct usd_device_attrs *dap);
 
 /* fi_ops_msg for DGRAM */
 ssize_t usdf_dgram_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -256,7 +256,7 @@ usdf_fill_info_dgram(
 			fi->mode &= ~FI_MSG_PREFIX;
 	}
 
-	ret = usdf_dgram_fill_ep_attr(hints, fi, dap);
+	ret = usdf_dgram_fill_ep_attr(version, hints, fi, dap);
 	if (ret)
 		goto fail;
 


### PR DESCRIPTION
If an application is requesting a pre-1.3 version of Libfabric, then it
is expecting that the max_msg_size not include the prefix size and not
include the size of the ethernet header.

@jsquyres @goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>