### PR TITLE
configure.ac: use "ustar" tar format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,7 @@ AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)
-AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects parallel-tests])
+AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects parallel-tests tar-ustar])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_CANONICAL_HOST


### PR DESCRIPTION
Some of the filenames get very long in Ubuntu builds, especially when
adding vendor-specific version numbers -- so long, in fact, that the
default format for tar will not include some files in the resulting
tarball.  So instead, use the "ustar" format in tar, that allows for
longer filenames.

This Automake option (to use the "ustar" format) has been in use by
the Open MPI project (literally) for years; it is quite safe and
portable.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>