### PR TITLE
verbs/RDM fixes (issue #1943)

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -292,7 +292,7 @@ static int fi_ibv_rdm_tagged_ep_close(fid_t fid)
 	pthread_mutex_destroy(&ep->cm_lock);
 
 	/* All posted sends are waiting local completions */
-	while (ep->posted_sends > 0) {
+	while (ep->posted_sends > 0 && ep->num_active_conns > 0) {
 		fi_ibv_rdm_tagged_poll(ep);
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -570,6 +570,9 @@ static int fi_ibv_rdm_tagged_process_event(struct rdma_cm_event *event,
 	case RDMA_CM_EVENT_REJECTED:
 		ret = fi_ibv_rdm_tagged_process_event_rejected(ep, event);
 		break;
+	case RDMA_CM_EVENT_TIMEWAIT_EXIT:
+		ret = FI_SUCCESS;
+		break;
 	case RDMA_CM_EVENT_ADDR_ERROR:
 	case RDMA_CM_EVENT_ROUTE_ERROR:
 	case RDMA_CM_EVENT_CONNECT_ERROR:

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -641,6 +641,14 @@ wc_error:
 	VERBS_INFO(FI_LOG_EP_DATA, "ibv_poll_cq returned %d\n", ret);
 
 	if (wc[i].status != IBV_WC_SUCCESS) {
+		struct fi_ibv_rdm_tagged_conn *conn =
+		    (struct fi_ibv_rdm_tagged_conn *)(uintptr_t)wc[i].wr_id;
+		if (wc[i].status == IBV_WC_WR_FLUSH_ERR &&
+			conn && conn->state !=  FI_VERBS_CONN_ESTABLISHED)
+		{
+			return FI_SUCCESS;
+		}
+
 		VERBS_INFO(FI_LOG_EP_DATA, "got ibv_wc.status = %d:%s\n",
 			wc[i].status, ibv_wc_status_str(wc[i].status));
 		assert(0);

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -155,8 +155,6 @@ int fi_ibv_rdm_tagged_find_ipoib_addr(const struct sockaddr_in *addr,
 					       sizeof(cm->my_addr));
 					found = 1;
 					break;
-				} else if (ret < 0) {
-					return -1;
 				}
 			}
 		}

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -515,11 +515,9 @@ static ssize_t fi_ibv_rdm_ep_rma_inject_write(struct fid_ep *ep,
 		break;
 	}
 
-	if (request) {
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
-					      FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
-	}
+	FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
+				      FI_LOG_DEBUG);
+	util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 
 	fi_ibv_rdm_tagged_poll(ep_rdm);
 


### PR DESCRIPTION
	- fix coverity issues
	- fix finalization with Open MPI: all preposted recvs are flushed
	during polling after start of disconnecting. This case is handled
	like a normal scenario now
	- add handling of RDMA_CM_EVENT_TIMEWAIT_EXIT. This makes more stable
	finalization of Open MPI for some configurations.

@hppritcha this patch also contains fix for Open MPI finalization. Please check it on your system.
@a-ilango 