### PR TITLE
Add information about release download page and add release badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [<img alt="libfabric master branch Travis CI status" src="https://travis-ci.org/ofiwg/libfabric.svg?branch=master"/>](https://travis-ci.org/ofiwg/libfabric)
 [<img alt="libfabric Coverity scan suild status" src="https://scan.coverity.com/projects/4274/badge.svg"/>](https://scan.coverity.com/projects/4274)
+[![libfabric release version](https://img.shields.io/github/release/ofiwg/libfabric.svg)](https://github.com/ofiwg/libfabric/releases/latest)
 
 # libfabric
 
@@ -25,12 +26,14 @@ distributions.
 
 ## Building and installing Libfabric from source
 
+Distribution tarballs are available from the Github
+[releases](https://github.com/ofiwg/libfabric/releases) tab.
+
 If you are building Libfabric from a developer Git clone, you must first run
 the `autogen.sh` script. This will invoke the GNU Autotools to bootstrap
 Libfabric's configuration and build mechanisms. If you are building Libfabric
-from an official distribution tarball from libfabric.org, there is no need to
-run `autogen.sh`; Libfabric distribution tarballs are already bootstrapped for
-you.
+from an official distribution tarball, there is no need to run `autogen.sh`;
+Libfabric distribution tarballs are already bootstrapped for you.
 
 Libfabric currently supports GNU/Linux, Free BSD, and OS X.
 


### PR DESCRIPTION
During the face-to-face we discussed using the releases tab to distribute tarballs. I've since edited the last few releases to include a description and attach the release tarballs. This commit amends the `README.md` file to include the download location and adds a badge that always reflects the latest stable release.

@shefty @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>