### PR TITLE
Changed the include guard format.

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FABRIC_H_
-#define _FABRIC_H_
+#ifndef FABRIC_H
+#define FABRIC_H
 
 #include <stdint.h>
 #include <stddef.h>

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_ATOMIC_H_
-#define _FI_ATOMIC_H_
+#ifndef FI_ATOMIC_H
+#define FI_ATOMIC_H
 
 #include <rdma/fabric.h>
 #include <rdma/fi_endpoint.h>

--- a/include/rdma/fi_cm.h
+++ b/include/rdma/fi_cm.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_CM_H_
-#define _FI_CM_H_
+#ifndef FI_CM_H
+#define FI_CM_H
 
 #include <rdma/fi_endpoint.h>
 

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_DOMAIN_H_
-#define _FI_DOMAIN_H_
+#ifndef FI_DOMAIN_H
+#define FI_DOMAIN_H
 
 #include <rdma/fabric.h>
 #include <rdma/fi_eq.h>

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_ENDPOINT_H_
-#define _FI_ENDPOINT_H_
+#ifndef FI_ENDPOINT_H
+#define FI_ENDPOINT_H
 
 #include <sys/socket.h>
 #include <rdma/fabric.h>

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_EQ_H_
-#define _FI_EQ_H_
+#ifndef FI_EQ_H
+#define FI_EQ_H
 
 #include <pthread.h>
 

--- a/include/rdma/fi_errno.h
+++ b/include/rdma/fi_errno.h
@@ -31,8 +31,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_ERRNO_H_
-#define _FI_ERRNO_H_
+#ifndef FI_ERRNO_H
+#define FI_ERRNO_H
 
 #include <errno.h>
 

--- a/include/rdma/fi_log.h
+++ b/include/rdma/fi_log.h
@@ -32,8 +32,8 @@
  *
  */
 
-#ifndef _FI_LOG_H_
-#define _FI_LOG_H_
+#ifndef FI_LOG_H
+#define FI_LOG_H
 
 #include "config.h"
 

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -33,8 +33,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_PROV_H_
-#define _FI_PROV_H_
+#ifndef FI_PROV_H
+#define FI_PROV_H
 
 #include <rdma/fabric.h>
 

--- a/include/rdma/fi_rma.h
+++ b/include/rdma/fi_rma.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_RMA_H_
-#define _FI_RMA_H_
+#ifndef FI_RMA_H
+#define FI_RMA_H
 
 #include <rdma/fabric.h>
 #include <rdma/fi_endpoint.h>

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_TAGGED_H_
-#define _FI_TAGGED_H_
+#ifndef FI_TAGGED_H
+#define FI_TAGGED_H
 
 #include <rdma/fabric.h>
 #include <rdma/fi_endpoint.h>

--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_TRIGGER_H_
-#define _FI_TRIGGER_H_
+#ifndef FI_TRIGGER_H
+#define FI_TRIGGER_H
 
 #include <stdint.h>
 #include <stddef.h>


### PR DESCRIPTION
Changed in the main header files to eliminate the warnings given
when compiling with clang. Before, clang produced warnings as
macros beginning with an underscore are in the domain
of the compiler.

New format example from fabric.h:

        #ifndef FABRIC_H
        #define FABRIC_H

Signed-off-by: Thomas Smith <thomasm2@cisco.com>