### PR TITLE
Tidied up include guards to match earlier change.

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -495,4 +495,4 @@ struct fi_context {
 }
 #endif
 
-#endif /* _FABRIC_H_ */
+#endif /* FABRIC_H */

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -310,4 +310,4 @@ fi_compare_atomicvalid(struct fid_ep *ep,
 }
 #endif
 
-#endif /* _FI_ATOMIC_H_ */
+#endif /* FI_ATOMIC_H */

--- a/include/rdma/fi_cm.h
+++ b/include/rdma/fi_cm.h
@@ -113,4 +113,4 @@ static inline int fi_shutdown(struct fid_ep *ep, uint64_t flags)
 }
 #endif
 
-#endif /* _FI_CM_H_ */
+#endif /* FI_CM_H */

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -290,4 +290,4 @@ fi_rx_addr(fi_addr_t fi_addr, int rx_index, int rx_ctx_bits)
 }
 #endif
 
-#endif /* _FI_DOMAIN_H_ */
+#endif /* FI_DOMAIN_H */

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -312,4 +312,4 @@ fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 }
 #endif
 
-#endif /* _FI_ENDPOINT_H_ */
+#endif /* FI_ENDPOINT_H */

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -445,4 +445,4 @@ fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout)
 }
 #endif
 
-#endif /* _FI_EQ_H_ */
+#endif /* FI_EQ_H */

--- a/include/rdma/fi_errno.h
+++ b/include/rdma/fi_errno.h
@@ -200,4 +200,4 @@ const char *fi_strerror(int errnum);
 }
 #endif
 
-#endif /* _FI_ERRNO_H_ */
+#endif /* FI_ERRNO_H */

--- a/include/rdma/fi_log.h
+++ b/include/rdma/fi_log.h
@@ -99,4 +99,4 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 }
 #endif
 
-#endif /*_FI_LOG_H_ */
+#endif /* FI_LOG_H */

--- a/include/rdma/fi_prov.h
+++ b/include/rdma/fi_prov.h
@@ -133,4 +133,4 @@ fi_param_get_bool(struct fi_provider *provider, const char *param_name, int *val
 }
 #endif
 
-#endif /* _FI_PROV_H_ */
+#endif /* FI_PROV_H */

--- a/include/rdma/fi_rma.h
+++ b/include/rdma/fi_rma.h
@@ -166,4 +166,4 @@ fi_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
 }
 #endif
 
-#endif /* _FI_RMA_H_ */
+#endif /* FI_RMA_H */

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -156,4 +156,4 @@ fi_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
 }
 #endif
 
-#endif /* _FI_TAGGED_H_ */
+#endif /* FI_TAGGED_H */

--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -71,4 +71,4 @@ struct fi_triggered_context {
 }
 #endif
 
-#endif /* _FI_TRIGGER_H_ */
+#endif /* FI_TRIGGER_H */


### PR DESCRIPTION
I changed the include guards earlier so that they
may keep clang happy however I did not update the
                   #endif
this has now been done.

Signed-off-by: Thomas Smith <thomasm2@cisco.com>