### PR TITLE
prov/util: Updates to fi_proto, av, cq

### DIFF
--- a/include/fi_mem.h
+++ b/include/fi_mem.h
@@ -104,7 +104,7 @@ static inline struct name * name ## _create(size_t size)	\
 {								\
 	struct name *fs;					\
 	fs = calloc(1, sizeof(*fs) + sizeof(entrytype) *	\
-			(roundup_power_of_two(size) - 1));	\
+		    (roundup_power_of_two(size)));		\
 	if (fs)							\
 		name ##_init(fs, roundup_power_of_two(size));	\
 	return fs;						\

--- a/include/fi_proto.h
+++ b/include/fi_proto.h
@@ -50,11 +50,12 @@ extern "C" {
 
 /* ofi_ctrl_hdr::type */
 enum {
-	ofi_ctrl_connect,
+	ofi_ctrl_connreq,
+	ofi_ctrl_connresp,
 	ofi_ctrl_start_data,
 	ofi_ctrl_data,
 	ofi_ctrl_large_data,
-	ofi_ctrl_ack
+	ofi_ctrl_ack,
 };
 
 /*
@@ -90,10 +91,8 @@ struct ofi_ctrl_hdr {
 	uint8_t			type;
 	uint16_t		seg_size;
 	uint32_t		seg_no;
-	union {
-		uint64_t	conn_id;
-		uint64_t	msg_id;
-	};
+	uint64_t		conn_id;
+	uint64_t		msg_id;
 	union {
 		uint64_t	conn_data;
 		uint64_t	rx_key;

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -157,8 +157,9 @@ struct util_cq_err_entry {
 	struct slist_entry	list_entry;
 };
 
-DECLARE_CIRQUE(struct fi_cq_data_entry, util_comp_cirq);
+DECLARE_CIRQUE(struct fi_cq_tagged_entry, util_comp_cirq);
 
+typedef void (*fi_cq_progress_func)(struct util_cq *cq);
 struct util_cq {
 	struct fid_cq		cq_fid;
 	struct util_domain	*domain;
@@ -174,12 +175,14 @@ struct util_cq {
 	struct slist		err_list;
 	fi_cq_read_func		read_entry;
 	int			internal_wait;
+	fi_cq_progress_func	progress;
 };
 
-int util_cq_open(const struct fi_provider *prov,
-		 struct fid_domain *domain, struct fi_cq_attr *attr,
-		 struct fid_cq **cq_fid, void *context);
-
+int util_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
+		 struct fi_cq_attr *attr, struct util_cq *cq,
+		 fi_cq_progress_func progress, void *context);
+void ofi_cq_progress(struct util_cq *cq);
+int ofi_cq_cleanup(struct util_cq *cq);
 
 /*
  * Counter

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -232,22 +232,28 @@ struct util_av_attr {
 	uint64_t		flags;
 };
 
-int fi_av_create(struct util_domain *domain,
-		 const struct fi_av_attr *attr, const struct util_av_attr *util_attr,
-		 struct fid_av **av, void *context);
+int ofi_av_init(struct util_domain *domain,
+	       const struct fi_av_attr *attr, const struct util_av_attr *util_attr,
+	       struct util_av *av, void *context);
+int ofi_av_close(struct util_av *av);
+
+int ofi_av_insert_addr(struct util_av *av, const void *addr, int slot, int *index);
+int ofi_av_lookup_index(struct util_av *av, const void *addr, int slot);
+int ofi_av_bind(struct fid *av_fid, struct fid *eq_fid, uint64_t flags);
+
 int ip_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		 struct fid_av **av, void *context);
 
-void *fi_av_get_addr(struct util_av *av, int index);
-#define ip_av_get_addr fi_av_get_addr
+void *ofi_av_get_addr(struct util_av *av, int index);
+#define ip_av_get_addr ofi_av_get_addr
 int ip_av_get_index(struct util_av *av, const void *addr);
 
-int fi_get_addr(uint32_t addr_format, uint64_t flags,
-		const char *node, const char *service,
-		void **addr, size_t *addrlen);
-int fi_get_src_addr(uint32_t addr_format,
-		    const void *dest_addr, size_t dest_addrlen,
-		    void **src_addr, size_t *src_addrlen);
+int ofi_get_addr(uint32_t addr_format, uint64_t flags,
+		 const char *node, const char *service,
+		 void **addr, size_t *addrlen);
+int ofi_get_src_addr(uint32_t addr_format,
+		     const void *dest_addr, size_t dest_addrlen,
+		     void **src_addr, size_t *src_addrlen);
 
 
 /*

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -93,12 +93,12 @@ struct util_fabric {
 	struct dlist_entry	domain_list;
 };
 
-int fi_fabric_init(const struct fi_provider *prov,
+int ofi_fabric_init(const struct fi_provider *prov,
 		   struct fi_fabric_attr *prov_attr,
 		   struct fi_fabric_attr *user_attr,
 		   struct util_fabric *fabric, void *context,
 		   enum fi_match_type type);
-int util_fabric_close(struct util_fabric *fabric);
+int ofi_fabric_close(struct util_fabric *fabric);
 int util_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
 
 /*
@@ -119,9 +119,9 @@ struct util_domain {
 	enum fi_av_type		av_type;
 };
 
-int fi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
+int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
 		     struct util_domain *domain, void *context);
-int util_domain_close(struct util_domain *domain);
+int ofi_domain_close(struct util_domain *domain);
 
 
 struct util_ep;
@@ -178,7 +178,7 @@ struct util_cq {
 	fi_cq_progress_func	progress;
 };
 
-int util_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
+int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 		 struct fi_cq_attr *attr, struct util_cq *cq,
 		 fi_cq_progress_func progress, void *context);
 void ofi_cq_progress(struct util_cq *cq);

--- a/prov/udp/src/udpx_cq.c
+++ b/prov/udp/src/udpx_cq.c
@@ -35,9 +35,23 @@
 
 #include "udpx.h"
 
-
 int udpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq_fid, void *context)
 {
-	return util_cq_open(&udpx_prov, domain, attr, cq_fid, context);
+	int ret;
+	struct util_cq *cq;
+
+	cq = calloc(1, sizeof(*cq));
+	if (!cq)
+		return -FI_ENOMEM;
+
+	ret = ofi_cq_init(&udpx_prov, domain, attr, cq,
+			   &ofi_cq_progress, context);
+	if (ret) {
+		free(cq);
+		return ret;
+	}
+
+	*cq_fid = &cq->cq_fid;
+	return 0;
 }

--- a/prov/udp/src/udpx_domain.c
+++ b/prov/udp/src/udpx_domain.c
@@ -53,7 +53,7 @@ static int udpx_domain_close(fid_t fid)
 	int ret;
 	struct util_domain *domain;
 	domain = container_of(fid, struct util_domain, domain_fid.fid);
-	ret = util_domain_close(domain);
+	ret = ofi_domain_close(domain);
 	if (ret)
 		return ret;
 	free(domain);
@@ -82,7 +82,7 @@ int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!util_domain)
 		return -FI_ENOMEM;
 
-	ret = fi_domain_init(fabric, info, util_domain, context);
+	ret = ofi_domain_init(fabric, info, util_domain, context);
 	if (ret)
 		return ret;
 

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -96,7 +96,7 @@ static struct fi_ops_ep udpx_ep_ops = {
 
 static void udpx_tx_comp(struct udpx_ep *ep, void *context)
 {
-	struct fi_cq_data_entry *comp;
+	struct fi_cq_tagged_entry *comp;
 
 	comp = cirque_tail(ep->util_ep.tx_cq->cirq);
 	comp->op_context = context;
@@ -116,7 +116,7 @@ static void udpx_tx_comp_signal(struct udpx_ep *ep, void *context)
 static void udpx_rx_comp(struct udpx_ep *ep, void *context, uint64_t flags,
 			 size_t len, void *buf, void *addr)
 {
-	struct fi_cq_data_entry *comp;
+	struct fi_cq_tagged_entry *comp;
 
 	comp = cirque_tail(ep->util_ep.rx_cq->cirq);
 	comp->op_context = context;

--- a/prov/udp/src/udpx_fabric.c
+++ b/prov/udp/src/udpx_fabric.c
@@ -50,7 +50,7 @@ static int udpx_fabric_close(fid_t fid)
 	int ret;
 	struct util_fabric *fabric;
 	fabric = container_of(fid, struct util_fabric, fabric_fid.fid);
-	ret = util_fabric_close(fabric);
+	ret = ofi_fabric_close(fabric);
 	if (ret)
 		return ret;
 	free(fabric);
@@ -75,7 +75,7 @@ int udpx_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 	if (!util_fabric)
 		return -FI_ENOMEM;
 
-	ret = fi_fabric_init(&udpx_prov, udpx_info.fabric_attr, attr,
+	ret = ofi_fabric_init(&udpx_prov, udpx_info.fabric_attr, attr,
 			     util_fabric, context, FI_MATCH_EXACT);
 	if (ret)
 		return ret;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -90,22 +90,6 @@ int fi_check_cq_attr(const struct fi_provider *prov,
 	return 0;
 }
 
-static void util_cq_progress(struct util_cq *cq)
-{
-	struct util_ep *ep;
-	struct fid_list_entry *fid_entry;
-	struct dlist_entry *item;
-
-	fastlock_acquire(&cq->list_lock);
-	dlist_foreach(&cq->list, item) {
-		fid_entry = container_of(item, struct fid_list_entry, entry);
-		ep = container_of(fid_entry->fid, struct util_ep, ep_fid.fid);
-		ep->progress(ep);
-
-	}
-	fastlock_release(&cq->list_lock);
-}
-
 static void util_cq_read_ctx(void **dst, void *src)
 {
 	*(struct fi_cq_entry *) *dst = *(struct fi_cq_entry *) src;
@@ -134,14 +118,14 @@ static void util_cq_read_tagged(void **dst, void *src)
 static ssize_t util_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 {
 	struct util_cq *cq;
-	struct fi_cq_data_entry *entry;
+	struct fi_cq_tagged_entry *entry;
 	ssize_t i;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 	fastlock_acquire(&cq->cq_lock);
 	if (cirque_isempty(cq->cirq)) {
 		fastlock_release(&cq->cq_lock);
-		util_cq_progress(cq);
+		cq->progress(cq);
 		fastlock_acquire(&cq->cq_lock);
 		if (cirque_isempty(cq->cirq)) {
 			i = -FI_EAGAIN;
@@ -171,7 +155,7 @@ static ssize_t util_cq_readfrom(struct fid_cq *cq_fid, void *buf,
 				size_t count, fi_addr_t *src_addr)
 {
 	struct util_cq *cq;
-	struct fi_cq_data_entry *entry;
+	struct fi_cq_tagged_entry *entry;
 	ssize_t i;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
@@ -187,7 +171,7 @@ static ssize_t util_cq_readfrom(struct fid_cq *cq_fid, void *buf,
 	fastlock_acquire(&cq->cq_lock);
 	if (cirque_isempty(cq->cirq)) {
 		fastlock_release(&cq->cq_lock);
-		util_cq_progress(cq);
+		cq->progress(cq);
 		fastlock_acquire(&cq->cq_lock);
 		if (cirque_isempty(cq->cirq)) {
 			i = -FI_EAGAIN;
@@ -289,7 +273,7 @@ static struct fi_ops_cq util_cq_ops = {
 	.strerror = util_cq_strerror,
 };
 
-static int fi_cq_cleanup(struct util_cq *cq)
+int util_cq_cleanup(struct util_cq *cq)
 {
 	struct util_cq_err_entry *err;
 	struct slist_entry *entry;
@@ -314,6 +298,8 @@ static int fi_cq_cleanup(struct util_cq *cq)
 	}
 
 	atomic_dec(&cq->domain->ref);
+	util_comp_cirq_free(cq->cirq);
+	free(cq->src);
 	return 0;
 }
 
@@ -323,13 +309,9 @@ static int util_cq_close(struct fid *fid)
 	int ret;
 
 	cq = container_of(fid, struct util_cq, cq_fid.fid);
-	ret = fi_cq_cleanup(cq);
+	ret = util_cq_cleanup(cq);
 	if (ret)
 		return ret;
-
-	util_comp_cirq_free(cq->cirq);
-	free(cq->src);
-	free(cq);
 	return 0;
 }
 
@@ -390,11 +372,37 @@ static int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 	return 0;
 }
 
-static int util_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
-			struct util_cq *cq, void *context)
+void ofi_cq_progress(struct util_cq *cq)
+{
+	struct util_ep *ep;
+	struct fid_list_entry *fid_entry;
+	struct dlist_entry *item;
+
+	fastlock_acquire(&cq->list_lock);
+	dlist_foreach(&cq->list, item) {
+		fid_entry = container_of(item, struct fid_list_entry, entry);
+		ep = container_of(fid_entry->fid, struct util_ep, ep_fid.fid);
+		ep->progress(ep);
+
+	}
+	fastlock_release(&cq->list_lock);
+}
+
+int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
+		 struct fi_cq_attr *attr, struct util_cq *cq,
+		 fi_cq_progress_func progress, void *context)
 {
 	fi_cq_read_func read_func;
 	int ret;
+
+	assert(progress);
+	ret = fi_check_cq_attr(prov, attr);
+	if (ret)
+		return ret;
+
+	cq->cq_fid.fid.ops = &util_cq_fi_ops;
+	cq->cq_fid.ops = &util_cq_ops;
+	cq->progress = progress;
 
 	switch (attr->format) {
 	case FI_CQ_FORMAT_UNSPEC:
@@ -419,6 +427,16 @@ static int util_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (ret)
 		return ret;
 
+	/* CQ must be fully operational before adding to wait set */
+	if (cq->wait) {
+		ret = fi_poll_add(&cq->wait->pollset->poll_fid,
+				  &cq->cq_fid.fid, 0);
+		if (ret) {
+			util_cq_cleanup(cq);
+			return ret;
+		}
+	}
+
 	cq->cirq = util_comp_cirq_create(attr->size);
 	if (!cq->cirq) {
 		ret = -FI_ENOMEM;
@@ -437,44 +455,6 @@ static int util_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 err2:
 	util_comp_cirq_free(cq->cirq);
 err1:
-	fi_cq_cleanup(cq);
+	util_cq_cleanup(cq);
 	return ret;
-}
-
-int util_cq_open(const struct fi_provider *prov,
-		 struct fid_domain *domain, struct fi_cq_attr *attr,
-		 struct fid_cq **cq_fid, void *context)
-{
-	struct util_cq *cq;
-	int ret;
-
-	ret = fi_check_cq_attr(prov, attr);
-	if (ret)
-		return ret;
-
-	cq = calloc(1, sizeof(*cq));
-	if (!cq)
-		return -FI_ENOMEM;
-
-	ret = util_cq_init(domain, attr, cq, context);
-	if (ret) {
-		free(cq);
-		return ret;
-	}
-
-	cq->cq_fid.fid.ops = &util_cq_fi_ops;
-	cq->cq_fid.ops = &util_cq_ops;
-
-	/* CQ must be fully operational before adding to wait set */
-	if (cq->wait) {
-		ret = fi_poll_add(&cq->wait->pollset->poll_fid,
-				  &cq->cq_fid.fid, 0);
-		if (ret) {
-			util_cq_close(&cq->cq_fid.fid);
-			return ret;
-		}
-	}
-
-	*cq_fid = &cq->cq_fid;
-	return 0;
 }

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -273,7 +273,7 @@ static struct fi_ops_cq util_cq_ops = {
 	.strerror = util_cq_strerror,
 };
 
-int util_cq_cleanup(struct util_cq *cq)
+int ofi_cq_cleanup(struct util_cq *cq)
 {
 	struct util_cq_err_entry *err;
 	struct slist_entry *entry;
@@ -309,7 +309,7 @@ static int util_cq_close(struct fid *fid)
 	int ret;
 
 	cq = container_of(fid, struct util_cq, cq_fid.fid);
-	ret = util_cq_cleanup(cq);
+	ret = ofi_cq_cleanup(cq);
 	if (ret)
 		return ret;
 	return 0;
@@ -432,7 +432,7 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 		ret = fi_poll_add(&cq->wait->pollset->poll_fid,
 				  &cq->cq_fid.fid, 0);
 		if (ret) {
-			util_cq_cleanup(cq);
+			ofi_cq_cleanup(cq);
 			return ret;
 		}
 	}
@@ -455,6 +455,6 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 err2:
 	util_comp_cirq_free(cq->cirq);
 err1:
-	util_cq_cleanup(cq);
+	ofi_cq_cleanup(cq);
 	return ret;
 }

--- a/prov/util/src/util_domain.c
+++ b/prov/util/src/util_domain.c
@@ -37,7 +37,7 @@
 #include <fi_util.h>
 
 
-int util_domain_close(struct util_domain *domain)
+int ofi_domain_close(struct util_domain *domain)
 {
 	if (atomic_get(&domain->ref))
 		return -FI_EBUSY;
@@ -71,7 +71,7 @@ static int util_domain_init(struct util_domain *domain,
 	return domain->name ? 0 : -FI_ENOMEM;
 }
 
-int fi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
+int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
 		   struct util_domain *domain, void *context)
 {
 	struct util_fabric *fabric;

--- a/prov/util/src/util_fabric.c
+++ b/prov/util/src/util_fabric.c
@@ -36,7 +36,7 @@
 #include <fi_enosys.h>
 #include <fi_util.h>
 
-int util_fabric_close(struct util_fabric *fabric)
+int ofi_fabric_close(struct util_fabric *fabric)
 {
 	if (atomic_get(&fabric->ref))
 		return -FI_EBUSY;
@@ -54,7 +54,7 @@ static void util_fabric_init(struct util_fabric *fabric, const char *name)
 	fabric->name = name;
 }
 
-int fi_fabric_init(const struct fi_provider *prov,
+int ofi_fabric_init(const struct fi_provider *prov,
 		   struct fi_fabric_attr *prov_attr,
 		   struct fi_fabric_attr *user_attr,
 		   struct util_fabric *fabric, void *context,

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -186,7 +186,7 @@ int util_getinfo(const struct fi_provider *prov, uint32_t version,
 	}
 
 	if (flags & FI_SOURCE) {
-		ret = fi_get_addr((*info)->addr_format, flags,
+		ret = ofi_get_addr((*info)->addr_format, flags,
 				  node, service, &(*info)->src_addr,
 				  &(*info)->src_addrlen);
 		if (ret) {
@@ -198,7 +198,7 @@ int util_getinfo(const struct fi_provider *prov, uint32_t version,
 	} else {
 		if (node || service) {
 			copy_dest = 0;
-			ret = fi_get_addr((*info)->addr_format, flags,
+			ret = ofi_get_addr((*info)->addr_format, flags,
 					  node, service, &(*info)->dest_addr,
 					  &(*info)->dest_addrlen);
 			if (ret) {
@@ -232,7 +232,7 @@ int util_getinfo(const struct fi_provider *prov, uint32_t version,
 	}
 
 	if ((*info)->dest_addr && !(*info)->src_addr) {
-		ret = fi_get_src_addr((*info)->addr_format, (*info)->dest_addr,
+		ret = ofi_get_src_addr((*info)->addr_format, (*info)->dest_addr,
 				      (*info)->dest_addrlen, &(*info)->src_addr,
 				      &(*info)->src_addrlen);
 		if (ret) {


### PR DESCRIPTION
- Update fi_protocol
    - All packets should carry connection-id
    - Add new ctrl type for connect-ack
- Refactor util-cq
- Refactor util-av
- Add ofi_ prefix for fabric, domain, cq, av, util functions that can be used by any provider