### PR TITLE
prov/sockets: Include socket directories in CFLGS if enabled

### DIFF
--- a/prov/sockets/Makefile.include
+++ b/prov/sockets/Makefile.include
@@ -1,6 +1,9 @@
-AM_CFLAGS += -I$(top_srcdir)/prov/sockets/include -I$(top_srcdir)/prov/sockets
+# Makefile.include for sockets provider
 
 if HAVE_SOCKETS
+
+AM_CFLAGS += -I$(top_srcdir)/prov/sockets/include -I$(top_srcdir)/prov/sockets
+
 _sockets_files = \
 	prov/sockets/src/sock_av.c \
 	prov/sockets/src/sock_dom.c \


### PR DESCRIPTION
Fixed Makefile.include to set the CFLAGS to sockets directories only if sockets provider is enabled.

@jithinjosepkl 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>