### PR TITLE
prov/sockets: Restructured struct sock_ep to support alias ep

### DIFF
--- a/prov/sockets/include/sock_util.h
+++ b/prov/sockets/include/sock_util.h
@@ -55,12 +55,12 @@ extern int sock_dgram_drop_rate;
 #define _SOCK_LOG_DBG(subsys, ...) FI_DBG(&sock_prov, subsys, __VA_ARGS__)
 #define _SOCK_LOG_ERROR(subsys, ...) FI_WARN(&sock_prov, subsys, __VA_ARGS__)
 
-static inline int sock_drop_packet(struct sock_ep *sock_ep)
+static inline int sock_drop_packet(struct sock_ep_attr *ep_attr)
 {
 #if ENABLE_DEBUG
-	if (sock_ep->ep_type == FI_EP_DGRAM && sock_dgram_drop_rate > 0) {
-		sock_ep->domain->fab->num_send_msg++;
-		if (!(sock_ep->domain->fab->num_send_msg % sock_dgram_drop_rate))
+	if (ep_attr->ep_type == FI_EP_DGRAM && sock_dgram_drop_rate > 0) {
+		ep_attr->domain->fab->num_send_msg++;
+		if (!(ep_attr->domain->fab->num_send_msg % sock_dgram_drop_rate))
 			return 1;
 	}
 #endif

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -176,7 +176,7 @@ void sock_tx_ctx_abort(struct sock_tx_ctx *tx_ctx)
 
 void sock_tx_ctx_write_op_send(struct sock_tx_ctx *tx_ctx,
 		struct sock_op *op, uint64_t flags, uint64_t context,
-		uint64_t dest_addr, uint64_t buf, struct sock_ep *ep,
+		uint64_t dest_addr, uint64_t buf, struct sock_ep_attr *ep_attr,
 		struct sock_conn *conn)
 {
 	sock_tx_ctx_write(tx_ctx, op, sizeof(*op));
@@ -184,23 +184,23 @@ void sock_tx_ctx_write_op_send(struct sock_tx_ctx *tx_ctx,
 	sock_tx_ctx_write(tx_ctx, &context, sizeof(context));
 	sock_tx_ctx_write(tx_ctx, &dest_addr, sizeof(dest_addr));
 	sock_tx_ctx_write(tx_ctx, &buf, sizeof(buf));
-	sock_tx_ctx_write(tx_ctx, &ep, sizeof(ep));
+	sock_tx_ctx_write(tx_ctx, &ep_attr, sizeof(ep_attr));
 	sock_tx_ctx_write(tx_ctx, &conn, sizeof(conn));
 }
 
 void sock_tx_ctx_write_op_tsend(struct sock_tx_ctx *tx_ctx,
 		struct sock_op *op, uint64_t flags, uint64_t context,
-		uint64_t dest_addr, uint64_t buf, struct sock_ep *ep,
+		uint64_t dest_addr, uint64_t buf, struct sock_ep_attr *ep_attr,
 		struct sock_conn *conn, uint64_t tag)
 {
 	sock_tx_ctx_write_op_send(tx_ctx, op, flags, context, dest_addr,
-			buf, ep, conn);
+			buf, ep_attr, conn);
 	sock_tx_ctx_write(tx_ctx, &tag, sizeof(tag));
 }
 
 void sock_tx_ctx_read_op_send(struct sock_tx_ctx *tx_ctx,
 		struct sock_op *op, uint64_t *flags, uint64_t *context,
-		uint64_t *dest_addr, uint64_t *buf, struct sock_ep **ep,
+		uint64_t *dest_addr, uint64_t *buf, struct sock_ep_attr **ep_attr,
 		struct sock_conn **conn)
 {
 	rbread(&tx_ctx->rb, op, sizeof(*op));
@@ -208,6 +208,6 @@ void sock_tx_ctx_read_op_send(struct sock_tx_ctx *tx_ctx,
 	rbread(&tx_ctx->rb, context, sizeof(*context));
 	rbread(&tx_ctx->rb, dest_addr, sizeof(*dest_addr));
 	rbread(&tx_ctx->rb, buf, sizeof(*buf));
-	rbread(&tx_ctx->rb, ep, sizeof(*ep));
+	rbread(&tx_ctx->rb, ep_attr, sizeof(*ep_attr));
 	rbread(&tx_ctx->rb, conn, sizeof(*conn));
 }

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -271,7 +271,7 @@ static int sock_dgram_endpoint(struct fid_domain *domain, struct fi_info *info,
 		return ret;
 
 	if (!info || !info->ep_attr)
-		(*ep)->ep_attr = sock_dgram_ep_attr;
+		(*ep)->attr->ep_attr = sock_dgram_ep_attr;
 
 	if (!info || !info->tx_attr)
 		(*ep)->tx_attr = sock_dgram_tx_attr;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -251,7 +251,7 @@ static int sock_ep_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 	case FI_CLASS_EP:
 	case FI_CLASS_SEP:
 		sock_ep = container_of(fid, struct sock_ep, ep.fid);
-		memcpy(addr, sock_ep->src_addr, len);
+		memcpy(addr, sock_ep->attr->src_addr, len);
 		break;
 	case FI_CLASS_PEP:
 		sock_pep = container_of(fid, struct sock_pep, pep.fid);
@@ -350,10 +350,10 @@ static int sock_ep_cm_setname(fid_t fid, void *addr, size_t addrlen)
 	case FI_CLASS_EP:
 	case FI_CLASS_SEP:
 		sock_ep = container_of(fid, struct sock_ep, ep.fid);
-		if (sock_ep->listener.listener_thread)
+		if (sock_ep->attr->listener.listener_thread)
 			return -FI_EINVAL;
-		memcpy(sock_ep->src_addr, addr, addrlen);
-		return sock_conn_listen(sock_ep);
+		memcpy(sock_ep->attr->src_addr, addr, addrlen);
+		return sock_conn_listen(sock_ep->attr);
 	case FI_CLASS_PEP:
 		sock_pep = container_of(fid, struct sock_pep, pep.fid);
 		if (sock_pep->cm.listener_thread)
@@ -374,7 +374,7 @@ static int sock_ep_cm_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
 
 	sock_ep = container_of(ep, struct sock_ep, ep);
 	len = MIN(*addrlen, sizeof(struct sockaddr_in));
-	memcpy(addr, sock_ep->dest_addr, len);
+	memcpy(addr, sock_ep->attr->dest_addr, len);
 	*addrlen = sizeof(struct sockaddr_in);
 	return (len == sizeof(struct sockaddr_in)) ? 0 : -FI_ETOOSMALL;
 }
@@ -457,7 +457,7 @@ static void sock_ep_cm_release_entry(struct sock_cm_msg_list_entry *msg_entry)
 		if (sock_eq_report_event(msg_entry->eq, FI_SHUTDOWN, &cm_entry,
 					 sizeof(cm_entry), 0))
 			SOCK_LOG_ERROR("Error in writing to EQ\n");
-		sock_ep->cm.shutdown_received = 1;
+		sock_ep->attr->cm.shutdown_received = 1;
 		sock_ep_disable(&sock_ep->ep);
 	} else {
 		if (sock_eq_report_error(msg_entry->eq, msg_entry->fid, NULL,
@@ -519,18 +519,16 @@ static int sock_ep_cm_send_ack(struct sock_cm_entry *cm,
 	return (ret == sizeof(conn_response)) ? 0 : -1;
 }
 
-static void sock_ep_cm_handle_ack(struct sock_cm_entry *cm,
+static void sock_ep_cm_handle_ack(struct sock_ep *sock_ep,
 				  struct sock_conn_hdr *hdr)
 {
 	struct sock_conn_hdr *msg_hdr;
 	struct dlist_entry *entry;
 	struct sock_cm_msg_list_entry *msg_entry;
 	struct fi_eq_cm_entry cm_entry;
-	struct sock_ep *sock_ep;
 
-	sock_ep = container_of(cm, struct sock_ep, cm);
-	fastlock_acquire(&cm->lock);
-	for (entry = cm->msg_list.next; entry != &cm->msg_list;) {
+	fastlock_acquire(&sock_ep->attr->cm.lock);
+	for (entry = sock_ep->attr->cm.msg_list.next; entry != &sock_ep->attr->cm.msg_list;) {
 
 		msg_entry = container_of(entry, struct sock_cm_msg_list_entry,
 					 entry);
@@ -542,10 +540,10 @@ static void sock_ep_cm_handle_ack(struct sock_cm_entry *cm,
 				SOCK_LOG_DBG("Got ack for SOCK_CONN_SHUTDOWN\n");
 				memset(&cm_entry, 0, sizeof(cm_entry));
 				cm_entry.fid = &sock_ep->ep.fid;
-				if (sock_ep->cm.shutdown_received)
+				if (sock_ep->attr->cm.shutdown_received)
 					break;
 
-				if (sock_eq_report_event(sock_ep->eq, FI_SHUTDOWN,
+				if (sock_eq_report_event(sock_ep->attr->eq, FI_SHUTDOWN,
 							 &cm_entry,
 							 sizeof(cm_entry), 0))
 					SOCK_LOG_ERROR("Error in writing to EQ\n");
@@ -557,7 +555,7 @@ static void sock_ep_cm_handle_ack(struct sock_cm_entry *cm,
 				cm_entry.fid = &sock_ep->ep.fid;
 				sock_ep_enable(&sock_ep->ep);
 
-				if (sock_eq_report_event(sock_ep->eq,
+				if (sock_eq_report_event(sock_ep->attr->eq,
 					FI_CONNECTED, &cm_entry,
 					sizeof(cm_entry), 0))
 					SOCK_LOG_ERROR("Error in writing to EQ\n");
@@ -572,7 +570,7 @@ static void sock_ep_cm_handle_ack(struct sock_cm_entry *cm,
 		}
 		entry = entry->next;
 	}
-	fastlock_release(&cm->lock);
+	fastlock_release(&sock_ep->attr->cm.lock);
 }
 
 
@@ -588,8 +586,8 @@ static void *sock_msg_ep_listener_thread(void *data)
 	int ret, user_data_sz, entry_sz, timeout;
 	char tmp = 0;
 
-	ep->cm.sock = sock_ep_cm_create_socket();
-	if (!ep->cm.sock) {
+	ep->attr->cm.sock = sock_ep_cm_create_socket();
+	if (!ep->attr->cm.sock) {
 		SOCK_LOG_ERROR("Cannot open socket\n");
 		return NULL;
 	}
@@ -608,27 +606,27 @@ static void *sock_msg_ep_listener_thread(void *data)
 		return NULL;
 	}
 
-	poll_fds[0].fd = ep->cm.sock;
-	poll_fds[1].fd = ep->cm.signal_fds[1];
+	poll_fds[0].fd = ep->attr->cm.sock;
+	poll_fds[1].fd = ep->attr->cm.signal_fds[1];
 	poll_fds[0].events = poll_fds[1].events = POLLIN;
 
-	while (*((volatile int*) &ep->cm.do_listen)) {
-		timeout = dlist_empty(&ep->cm.msg_list) ? -1 :
+	while (*((volatile int*) &ep->attr->cm.do_listen)) {
+		timeout = dlist_empty(&ep->attr->cm.msg_list) ? -1 :
 					SOCK_CM_COMM_TIMEOUT;
 		ret = poll(poll_fds, 2, timeout);
 		if (ret > 0) {
 			if (poll_fds[1].revents & POLLIN) {
-				ret = read(ep->cm.signal_fds[1], &tmp, 1);
+				ret = read(ep->attr->cm.signal_fds[1], &tmp, 1);
 				if (ret != 1) {
 					SOCK_LOG_DBG("Invalid signal\n");
 					break;
 				}
-				sock_ep_cm_flush_msg(&ep->cm);
+				sock_ep_cm_flush_msg(&ep->attr->cm);
 				continue;
 			}
 		} else {
 			if (ret == 0) {
-				sock_ep_cm_flush_msg(&ep->cm);
+				sock_ep_cm_flush_msg(&ep->attr->cm);
 				continue;
 			} else {
 				break;
@@ -636,7 +634,7 @@ static void *sock_msg_ep_listener_thread(void *data)
 		}
 
 		addr_len = sizeof(from_addr);
-		ret = recvfrom(ep->cm.sock, (char *) conn_response,
+		ret = recvfrom(ep->attr->cm.sock, (char *) conn_response,
 			       sizeof(*conn_response) + SOCK_EP_MAX_CM_DATA_SZ,
 			       0, (struct sockaddr *) &from_addr, &addr_len);
 		if (ret <= 0)
@@ -648,7 +646,7 @@ static void *sock_msg_ep_listener_thread(void *data)
 			continue;
 
 		if (conn_response->hdr.type != SOCK_CONN_ACK)
-			sock_ep_cm_send_ack(&ep->cm, &from_addr,
+			sock_ep_cm_send_ack(&ep->attr->cm, &from_addr,
 						conn_response->hdr.msg_id);
 
 		user_data_sz = ret - sizeof(*conn_response);
@@ -656,7 +654,7 @@ static void *sock_msg_ep_listener_thread(void *data)
 
 		case SOCK_CONN_ACK:
 			SOCK_LOG_DBG("Received SOCK_CONN_ACK\n");
-			sock_ep_cm_handle_ack(&ep->cm, &conn_response->hdr);
+			sock_ep_cm_handle_ack(ep, &conn_response->hdr);
 			break;
 
 		case SOCK_CONN_ACCEPT:
@@ -666,28 +664,28 @@ static void *sock_msg_ep_listener_thread(void *data)
 			memset(cm_entry, 0, sizeof(*cm_entry));
 			cm_entry->fid = &ep->ep.fid;
 
-			memcpy(&ep->cm_addr, &from_addr, sizeof(from_addr));
+			memcpy(&ep->attr->cm_addr, &from_addr, sizeof(from_addr));
 			memcpy(&cm_entry->data, &conn_response->user_data,
 			       user_data_sz);
 
-			if (ep->is_disabled || ep->cm.shutdown_received)
+			if (ep->attr->is_disabled || ep->attr->cm.shutdown_received)
 				break;
 
-			((struct sockaddr_in *) ep->dest_addr)->sin_port =
+			((struct sockaddr_in *) ep->attr->dest_addr)->sin_port =
 				conn_response->hdr.s_port;
 
 			sock_ep_enable(&ep->ep);
-			if (sock_eq_report_event(ep->eq, FI_CONNECTED, cm_entry,
+			if (sock_eq_report_event(ep->attr->eq, FI_CONNECTED, cm_entry,
 						 entry_sz, 0))
 				SOCK_LOG_ERROR("Error in writing to EQ\n");
 			break;
 		case SOCK_CONN_REJECT:
 			SOCK_LOG_DBG("Received SOCK_CONN_REJECT\n");
 
-			if (ep->is_disabled || ep->cm.shutdown_received)
+			if (ep->attr->is_disabled || ep->attr->cm.shutdown_received)
 				break;
 
-			if (sock_eq_report_error(ep->eq, &ep->ep.fid, NULL, 0,
+			if (sock_eq_report_error(ep->attr->eq, &ep->ep.fid, NULL, 0,
 						FI_ECONNREFUSED,
 						-FI_ECONNREFUSED,
 						&conn_response->user_data,
@@ -702,12 +700,12 @@ static void *sock_msg_ep_listener_thread(void *data)
 			memset(cm_entry, 0, sizeof(*cm_entry));
 			cm_entry->fid = &ep->ep.fid;
 
-			if (ep->cm.shutdown_received)
+			if (ep->attr->cm.shutdown_received)
 				break;
 
 			sock_ep_disable(&ep->ep);
-			ep->cm.shutdown_received = 1;
-			if (sock_eq_report_event(ep->eq, FI_SHUTDOWN, cm_entry,
+			ep->attr->cm.shutdown_received = 1;
+			if (sock_eq_report_event(ep->attr->eq, FI_SHUTDOWN, cm_entry,
 						 entry_sz, 0))
 				SOCK_LOG_ERROR("Error in writing to EQ\n");
 			goto out;
@@ -721,8 +719,8 @@ static void *sock_msg_ep_listener_thread(void *data)
 out:
 	free(conn_response);
 	free(cm_entry);
-	close(ep->cm.sock);
-	ep->cm.listener_thread = 0L;
+	close(ep->attr->cm.sock);
+	ep->attr->cm.listener_thread = 0L;
 	return NULL;
 }
 
@@ -735,11 +733,11 @@ static int sock_ep_cm_connect(struct fid_ep *ep, const void *addr,
 	int ret = 0;
 
 	_ep = container_of(ep, struct sock_ep, ep);
-	_eq = _ep->eq;
+	_eq = _ep->attr->eq;
 	if (!_eq || paramlen > SOCK_EP_MAX_CM_DATA_SZ)
 		return -FI_EINVAL;
 
-	if (!_ep->listener.listener_thread && sock_conn_listen(_ep))
+	if (!_ep->attr->listener.listener_thread && sock_conn_listen(_ep->attr))
 		return -FI_EINVAL;
 
 	req = calloc(1, sizeof(*req) + paramlen);
@@ -749,23 +747,23 @@ static int sock_ep_cm_connect(struct fid_ep *ep, const void *addr,
 	((struct sockaddr *) addr)->sa_family = AF_INET;
 
 	req->hdr.type = SOCK_CONN_REQ;
-	req->hdr.msg_id = _ep->cm.next_msg_id++;
-	req->info = _ep->info;
-	memcpy(&req->src_addr, _ep->src_addr, sizeof(req->src_addr));
-	memcpy(&req->dest_addr, _ep->info.dest_addr, sizeof(req->dest_addr));
-	req->tx_attr = *_ep->info.tx_attr;
-	req->rx_attr = *_ep->info.rx_attr;
-	req->ep_attr = *_ep->info.ep_attr;
-	req->domain_attr = *_ep->info.domain_attr;
-	req->fabric_attr = *_ep->info.fabric_attr;
+	req->hdr.msg_id = _ep->attr->cm.next_msg_id++;
+	req->info = _ep->attr->info;
+	memcpy(&req->src_addr, _ep->attr->src_addr, sizeof(req->src_addr));
+	memcpy(&req->dest_addr, _ep->attr->info.dest_addr, sizeof(req->dest_addr));
+	req->tx_attr = *_ep->attr->info.tx_attr;
+	req->rx_attr = *_ep->attr->info.rx_attr;
+	req->ep_attr = *_ep->attr->info.ep_attr;
+	req->domain_attr = *_ep->attr->info.domain_attr;
+	req->fabric_attr = *_ep->attr->info.fabric_attr;
 	req->fabric_attr.fabric = NULL;
 	req->domain_attr.domain = NULL;
 
 	if (param && paramlen)
 		memcpy(&req->user_data, param, paramlen);
 
-	memcpy(&_ep->cm_addr, addr, sizeof(struct sockaddr_in));
-	if (sock_ep_cm_enqueue_msg(&_ep->cm, addr, req,
+	memcpy(&_ep->attr->cm_addr, addr, sizeof(struct sockaddr_in));
+	if (sock_ep_cm_enqueue_msg(&_ep->attr->cm, addr, req,
 				   sizeof(*req) + paramlen,
 				   &_ep->ep.fid, _eq)) {
 		ret = -FI_EIO;
@@ -791,20 +789,20 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param,
 	int ret = 0;
 
 	_ep = container_of(ep, struct sock_ep, ep);
-	if (!_ep->eq || paramlen > SOCK_EP_MAX_CM_DATA_SZ)
+	if (!_ep->attr->eq || paramlen > SOCK_EP_MAX_CM_DATA_SZ)
 		return -FI_EINVAL;
 
-	if (_ep->is_disabled || _ep->cm.shutdown_received)
+	if (_ep->attr->is_disabled || _ep->attr->cm.shutdown_received)
 		return -FI_EINVAL;
 
-	if (!_ep->listener.listener_thread && sock_conn_listen(_ep))
+	if (!_ep->attr->listener.listener_thread && sock_conn_listen(_ep->attr))
 		return -FI_EINVAL;
 
 	response = calloc(1, sizeof(*response) + paramlen);
 	if (!response)
 		return -FI_ENOMEM;
 
-	handle = container_of(_ep->info.handle, struct sock_conn_req_handle,
+	handle = container_of(_ep->attr->info.handle, struct sock_conn_req_handle,
 				handle);
 	if (!handle || handle->handle.fclass != FI_CLASS_CONNREQ) {
 		SOCK_LOG_ERROR("invalid handle for cm_accept\n");
@@ -818,15 +816,15 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param,
 		memcpy(&response->user_data, param, paramlen);
 
 	addr = &req->from_addr;
-	memcpy(&_ep->cm_addr, addr, sizeof(*addr));
+	memcpy(&_ep->attr->cm_addr, addr, sizeof(*addr));
 
 	response->hdr.type = SOCK_CONN_ACCEPT;
-	req->hdr.msg_id = _ep->cm.next_msg_id++;
-	response->hdr.s_port = htons(atoi(_ep->listener.service));
+	req->hdr.msg_id = _ep->attr->cm.next_msg_id++;
+	response->hdr.s_port = htons(atoi(_ep->attr->listener.service));
 
-	if (sock_ep_cm_enqueue_msg(&_ep->cm, addr, response,
+	if (sock_ep_cm_enqueue_msg(&_ep->attr->cm, addr, response,
 				   sizeof(*response) + paramlen,
-				   &_ep->ep.fid, _ep->eq)) {
+				   &_ep->ep.fid, _ep->attr->eq)) {
 		ret = -FI_EIO;
 		goto out;
 	}
@@ -835,7 +833,7 @@ out:
 	free(handle);
 	free(req);
 	free(response);
-	_ep->info.handle = NULL;
+	_ep->attr->info.handle = NULL;
 	return ret;
 }
 
@@ -848,10 +846,10 @@ static int sock_ep_cm_shutdown(struct fid_ep *ep, uint64_t flags)
 	memset(&response, 0, sizeof(response));
 
 	response.hdr.type = SOCK_CONN_SHUTDOWN;
-	response.hdr.msg_id = _ep->cm.next_msg_id++;
+	response.hdr.msg_id = _ep->attr->cm.next_msg_id++;
 
-	if (sock_ep_cm_enqueue_msg(&_ep->cm, &_ep->cm_addr, &response,
-				   sizeof(response), &_ep->ep.fid, _ep->eq)) {
+	if (sock_ep_cm_enqueue_msg(&_ep->attr->cm, &_ep->attr->cm_addr, &response,
+				   sizeof(response), &_ep->ep.fid, _ep->attr->eq)) {
 		return -FI_EIO;
 	}
 
@@ -905,11 +903,11 @@ static int sock_msg_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	if (info && info->handle && info->handle->fclass == FI_CLASS_PEP) {
 		pep = container_of(info->handle, struct sock_pep, pep.fid);
-		memcpy((*ep)->src_addr, &pep->src_addr, sizeof *(*ep)->src_addr);
+		memcpy((*ep)->attr->src_addr, &pep->src_addr, sizeof *(*ep)->attr->src_addr);
 	}
 
 	if (!info || !info->ep_attr)
-		(*ep)->ep_attr = sock_msg_ep_attr;
+		(*ep)->attr->ep_attr = sock_msg_ep_attr;
 
 	if (!info || !info->tx_attr)
 		(*ep)->tx_attr = sock_msg_tx_attr;
@@ -930,8 +928,8 @@ int sock_msg_ep(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		return ret;
 
-	endpoint->cm.do_listen = 1;
-	if (pthread_create(&endpoint->cm.listener_thread, NULL,
+	endpoint->attr->cm.do_listen = 1;
+	if (pthread_create(&endpoint->attr->cm.listener_thread, NULL,
 			   sock_msg_ep_listener_thread, endpoint)) {
 		SOCK_LOG_ERROR("Couldn't create listener thread\n");
 		return -FI_EINVAL;
@@ -1093,11 +1091,6 @@ static void *sock_pep_listener_thread(void *data)
 						conn_req->hdr.msg_id);
 
 		switch (conn_req->hdr.type) {
-		case SOCK_CONN_ACK:
-			SOCK_LOG_DBG("Received SOCK_CONN_ACK\n");
-			sock_ep_cm_handle_ack(&pep->cm, &conn_req->hdr);
-			break;
-
 		case SOCK_CONN_REQ:
 			SOCK_LOG_DBG("Received SOCK_CONN_REQ\n");
 

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -315,7 +315,7 @@ static int sock_rdm_endpoint(struct fid_domain *domain, struct fi_info *info,
 		return ret;
 
 	if (!info || !info->ep_attr)
-		(*ep)->ep_attr = sock_rdm_ep_attr;
+		(*ep)->attr->ep_attr = sock_rdm_ep_attr;
 
 	if (!info || !info->tx_attr)
 		(*ep)->tx_attr = sock_rdm_tx_attr;

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -65,18 +65,22 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	union sock_iov tx_iov;
 	struct sock_conn *conn;
 	struct sock_tx_ctx *tx_ctx;
-	uint64_t total_len, src_len, dst_len;
+	uint64_t total_len, src_len, dst_len, op_flags;
 	struct sock_ep *sock_ep;
+	struct sock_ep_attr *ep_attr;
 
 	switch (ep->fid.fclass) {
 	case FI_CLASS_EP:
 		sock_ep = container_of(ep, struct sock_ep, ep);
-		tx_ctx = sock_ep->tx_ctx;
+		tx_ctx = sock_ep->attr->tx_ctx;
+		ep_attr = sock_ep->attr;
+		op_flags = sock_ep->tx_attr.op_flags;
 		break;
 
 	case FI_CLASS_TX_CTX:
 		tx_ctx = container_of(ep, struct sock_tx_ctx, fid.ctx);
-		sock_ep = tx_ctx->ep;
+		ep_attr = tx_ctx->ep_attr;
+		op_flags = tx_ctx->attr.op_flags;
 		break;
 
 	default:
@@ -93,13 +97,13 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
 
-	ret = sock_ep_get_conn(sock_ep, tx_ctx, msg->addr, &conn);
+	ret = sock_ep_get_conn(ep_attr, tx_ctx, msg->addr, &conn);
 	if (ret)
 		return ret;
 
 	SOCK_EP_SET_TX_OP_FLAGS(flags);
 	if (flags & SOCK_USE_OP_FLAGS)
-		flags |= tx_ctx->attr.op_flags;
+		flags |= op_flags;
 
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_rma_op(ep, msg, flags, SOCK_OP_READ);
@@ -125,7 +129,7 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	sock_tx_ctx_write_op_send(tx_ctx, &tx_op, flags,
 			(uintptr_t) msg->context, msg->addr,
 			(uintptr_t) msg->msg_iov[0].iov_base,
-			sock_ep, conn);
+			ep_attr, conn);
 
 	src_len = 0;
 	for (i = 0; i < msg->rma_iov_count; i++) {
@@ -224,18 +228,22 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	union sock_iov tx_iov;
 	struct sock_conn *conn;
 	struct sock_tx_ctx *tx_ctx;
-	uint64_t total_len, src_len, dst_len;
+	uint64_t total_len, src_len, dst_len, op_flags;
 	struct sock_ep *sock_ep;
+	struct sock_ep_attr *ep_attr;
 
 	switch (ep->fid.fclass) {
 	case FI_CLASS_EP:
 		sock_ep = container_of(ep, struct sock_ep, ep);
-		tx_ctx = sock_ep->tx_ctx;
+		tx_ctx = sock_ep->attr->tx_ctx;
+		ep_attr = sock_ep->attr;
+		op_flags = sock_ep->tx_attr.op_flags;
 		break;
 
 	case FI_CLASS_TX_CTX:
 		tx_ctx = container_of(ep, struct sock_tx_ctx, fid.ctx);
-		sock_ep = tx_ctx->ep;
+		ep_attr = tx_ctx->ep_attr;
+		op_flags = tx_ctx->attr.op_flags;
 		break;
 
 	default:
@@ -252,13 +260,13 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
 
-	ret = sock_ep_get_conn(sock_ep, tx_ctx, msg->addr, &conn);
+	ret = sock_ep_get_conn(ep_attr, tx_ctx, msg->addr, &conn);
 	if (ret)
 		return ret;
 
 	SOCK_EP_SET_TX_OP_FLAGS(flags);
 	if (flags & SOCK_USE_OP_FLAGS)
-		flags |= tx_ctx->attr.op_flags;
+		flags |= op_flags;
 
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_rma_op(ep, msg, flags, SOCK_OP_WRITE);
@@ -295,7 +303,7 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 
 	sock_tx_ctx_write_op_send(tx_ctx, &tx_op, flags,
 			(uintptr_t) msg->context, msg->addr,
-			(uintptr_t) msg->msg_iov[0].iov_base, sock_ep, conn);
+			(uintptr_t) msg->msg_iov[0].iov_base, ep_attr, conn);
 
 	if (flags & FI_REMOTE_CQ_DATA)
 		sock_tx_ctx_write(tx_ctx, &msg->data, sizeof(msg->data));


### PR DESCRIPTION
Restructured sock_ep structure to support alias ep and share the resources allocated by the base ep.
- Created a new struct <code>sock_ep_attr</code> that to hold ep resources and modified struct <code>sock_ep</code> to include a pointer to <code>sock_ep_attr</code>
- Added flag <code>is_alias</code> in <code>sock_ep</code> to differentiate alias ep
- Added reference counting for alias ep
- Removed a unused case in <code>sock_pep_listener_thread</code>
- Use correct op_flags
- Verified the patch with fabtests and osu/pt2pt

Modified fabtests/simple/rdm_rma_trigger.c with fi_alias_ep (https://github.com/shantonu/fabtests/tree/pr/alias-test) works with this patch. Will be submitted after this patch is merged.
@jithinjosepkl @shefty 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>