### PR TITLE
prov/verbs: add support of FI_PEEK & FI_CLAIM flags to FI_EP_RDM

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -60,14 +60,14 @@ static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
 		FI_DBG(&fi_ibv_prov, FI_LOG_CQ,
 		       "\t\t-> found match in ready: op_ctx %p, len %d, tag 0x%llx\n",
 		       completed_req->context, completed_req->len,
-		       (long long unsigned int) completed_req->tag);
+		       completed_req->minfo.tag);
 
-		src_addr[i] = (fi_addr_t) (uintptr_t) completed_req->conn;
+		src_addr[i] = (fi_addr_t) (uintptr_t) completed_req->minfo.conn;
 		entry[i].op_context = completed_req->context;
 		entry[i].flags = 0;
 		entry[i].len = completed_req->len;
 		entry[i].data = completed_req->imm;
-		entry[i].tag = completed_req->tag;
+		entry[i].tag = completed_req->minfo.tag;
 
 		if (completed_req->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
 			FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", completed_req,

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -177,8 +177,7 @@ static ssize_t fi_ibv_rdm_tagged_ep_cancel(fid_t fid, void *ctx)
 
 	VERBS_DBG(FI_LOG_EP_DATA,
 		  "ep_cancel, match %p, tag 0x%llx, len %d, ctx %p\n",
-		  request, (long long unsigned)request->tag,
-		  request->len, request->context);
+		  request, request->minfo.tag, request->len, request->context);
 
 	struct dlist_entry *found =
 	    dlist_find_first_match(&fi_ibv_rdm_tagged_recv_posted_queue,

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -115,9 +115,9 @@ fi_ibv_rdm_tagged_move_to_postponed_queue(
 {
 	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_postponed_queue: ", request,
 				      FI_LOG_DEBUG);
-	assert(request && request->conn);
+	assert(request && request->minfo.conn);
 
-	struct fi_ibv_rdm_tagged_conn *conn = request->conn;
+	struct fi_ibv_rdm_tagged_conn *conn = request->minfo.conn;
 
 	if (dlist_empty(&conn->postponed_requests_head)) {
 		struct fi_ibv_rdm_tagged_postponed_entry *entry =
@@ -140,7 +140,7 @@ fi_ibv_rdm_tagged_remove_from_postponed_queue(
 	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_postponed_queue: ", request,
 				      FI_LOG_DEBUG);
 
-	struct fi_ibv_rdm_tagged_conn *conn = request->conn;
+	struct fi_ibv_rdm_tagged_conn *conn = request->minfo.conn;
 	assert(conn);
 	assert(!dlist_empty(&conn->postponed_requests_head));
 
@@ -149,7 +149,6 @@ fi_ibv_rdm_tagged_remove_from_postponed_queue(
 	 * then if conn->postponed_requests_head is empty
 	 * clean fi_ibv_rdm_tagged_send_postponed_queue
 	 */
-
 
 	dlist_remove(&request->queue_entry);
 	request->queue_entry.next = request->queue_entry.prev = NULL;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -136,10 +136,7 @@ struct fi_ibv_rdm_tagged_request {
 		enum fi_ibv_rdm_tagged_request_rndv_state rndv;
 	} state;
 
-	struct fi_ibv_rdm_tagged_conn *conn;
-
-	uint64_t tag;
-	uint64_t tagmask;
+	struct fi_verbs_rdm_tagged_minfo minfo;
 
 	/* User data: buffers, lens, imm, context */
 

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -614,7 +614,8 @@ fi_ibv_rdm_tagged_process_recv(struct fi_ibv_rdm_ep *ep,
 					found_request->minfo.conn,
 					found_request->minfo.tag,
 					found_request->minfo.tagmask);
-				assert(0); /* TODO: return correct err code */
+				assert(0);
+				return -FI_ETRUNC;
 			}
 
 			fi_ibv_rdm_tagged_remove_from_posted_queue

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -615,7 +615,7 @@ fi_ibv_rdm_tagged_process_recv(struct fi_ibv_rdm_ep *ep,
 					found_request->minfo.tag,
 					found_request->minfo.tagmask);
 				assert(0);
-				return -FI_ETRUNC;
+				/* TODO: return -FI_ETRUNC; */
 			}
 
 			fi_ibv_rdm_tagged_remove_from_posted_queue

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
@@ -37,6 +37,7 @@
 #include <stdint.h>
 
 struct fi_ibv_rdm_tagged_request;
+struct fi_verbs_rdm_tagged_request_minfo;
 
 enum fi_ibv_rdm_tagged_request_eager_state {
 	FI_IBV_STATE_EAGER_BEGIN = 0,      // must be 0
@@ -48,6 +49,7 @@ enum fi_ibv_rdm_tagged_request_eager_state {
 	FI_IBV_STATE_EAGER_RECV_BEGIN,
 	FI_IBV_STATE_EAGER_RECV_WAIT4PKT,
 	FI_IBV_STATE_EAGER_RECV_WAIT4RECV,
+	FI_IBV_STATE_EAGER_RECV_CLAIMED,
 	FI_IBV_STATE_EAGER_RECV_END,
 
 	FI_IBV_STATE_EAGER_RMA_INJECT,
@@ -98,6 +100,9 @@ enum fi_ibv_rdm_tagged_request_event {
 	FI_IBV_EVENT_RECV_GOT_PKT_PREPROCESS,
 	FI_IBV_EVENT_RECV_GOT_PKT_PROCESS,
 	FI_IBV_EVENT_RECV_GOT_ACK,
+	FI_IBV_EVENT_RECV_PEEK,
+	FI_IBV_EVENT_RECV_CLAIM,
+	FI_IBV_EVENT_RECV_DISCARD,
 
 	FI_IBV_EVENT_RMA_START,
 
@@ -143,12 +148,10 @@ struct fi_ibv_rdm_tagged_send_completed_data {
 // Recv service data types
 
 struct fi_ibv_rdm_tagged_recv_start_data {
-	size_t tag;
-	size_t tagmask;
+	struct fi_ibv_rdm_tagged_peek_data peek_data;
 	struct fi_context *context;
-	void *dest_addr;
-	struct fi_ibv_rdm_tagged_conn *conn;
 	struct fi_ibv_rdm_ep *ep;
+	void *dest_addr;
 	size_t data_len;
 };
 

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
@@ -186,24 +186,12 @@ struct fi_ibv_rma_post_ready_data {
 	struct fi_ibv_rdm_ep *ep_rdm;
 };
 
-// Return codes
-/* TODO: to replace with native OFI codes */
-
-enum fi_rdm_tagged_req_hndl_ret {
-    FI_EP_RDM_HNDL_SUCCESS = 0,
-    FI_EP_RDM_HNDL_DELETED_REQUEST = 1,
-    FI_EP_RDM_HNDL_ERROR = 2,
-    FI_EP_RDM_HNDL_AGAIN = 3,
-    FI_EP_RDM_HNDL_NOT_INIT = (int)-1
-};
-
 // Interfaces
 
-enum fi_rdm_tagged_req_hndl_ret fi_ibv_rdm_tagged_req_hndls_init();
-enum fi_rdm_tagged_req_hndl_ret fi_ibv_rdm_tagged_req_hndls_clean();
-enum fi_rdm_tagged_req_hndl_ret
-fi_ibv_rdm_tagged_req_hndl(struct fi_ibv_rdm_tagged_request *request,
-			   enum fi_ibv_rdm_tagged_request_event event,
-			   void *data);
+ssize_t fi_ibv_rdm_tagged_req_hndls_init();
+ssize_t fi_ibv_rdm_tagged_req_hndls_clean();
+ssize_t fi_ibv_rdm_tagged_req_hndl(struct fi_ibv_rdm_tagged_request *request,
+				   enum fi_ibv_rdm_tagged_request_event event,
+				   void *data);
 
 #endif /* _VERBS_TAGGED_EP_RDM_STATES_H */

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -72,6 +72,22 @@ int fi_ibv_rdm_tagged_req_match_by_info2(struct dlist_entry *item,
 		 (minfo->tag   & minfo->tagmask)));
 }
 
+/*
+ * The same as fi_ibv_rdm_tagged_req_match_by_info2 but context field is added  
+ * to compare
+ */
+int fi_ibv_rdm_tagged_req_match_by_info3(struct dlist_entry *item,
+					 const void *info)
+{
+	struct fi_ibv_rdm_tagged_request *request =
+	    container_of(item, struct fi_ibv_rdm_tagged_request, queue_entry);
+
+	const struct fi_ibv_rdm_tagged_peek_data *peek_data = info;
+
+	return ((request->context == peek_data->context) && 
+		fi_ibv_rdm_tagged_req_match_by_info2(item, &peek_data->minfo));
+}
+
 int fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *postponed_item,
 					     const void *arg)
 {

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -48,11 +48,12 @@ int fi_ibv_rdm_tagged_req_match_by_info(struct dlist_entry *item,
 	struct fi_ibv_rdm_tagged_request *request =
 	    container_of(item, struct fi_ibv_rdm_tagged_request, queue_entry);
 
-	const struct fi_verbs_rdm_tagged_request_minfo *minfo = info;
+	const struct fi_verbs_rdm_tagged_minfo *minfo = info;
 
-	return (((request->conn == NULL) || (request->conn == minfo->conn)) &&
-		((request->tag & request->tagmask) ==
-		 (minfo->tag   & request->tagmask)));
+	return (((request->minfo.conn == NULL) ||
+		 (request->minfo.conn == minfo->conn)) &&
+		((request->minfo.tag & request->minfo.tagmask) ==
+		 (minfo->tag         & request->minfo.tagmask)));
 }
 
 /*
@@ -65,11 +66,11 @@ int fi_ibv_rdm_tagged_req_match_by_info2(struct dlist_entry *item,
 	struct fi_ibv_rdm_tagged_request *request =
 	    container_of(item, struct fi_ibv_rdm_tagged_request, queue_entry);
 
-	const struct fi_verbs_rdm_tagged_request_minfo *minfo = info;
+	const struct fi_verbs_rdm_tagged_minfo *minfo = info;
 
-	return (((minfo->conn == NULL) || (request->conn == minfo->conn)) &&
-		((request->tag & minfo->tagmask) ==
-		 (minfo->tag   & minfo->tagmask)));
+	return (((minfo->conn == NULL) || (request->minfo.conn == minfo->conn)) &&
+		((request->minfo.tag & minfo->tagmask) ==
+		 (minfo->tag         & minfo->tagmask)));
 }
 
 /*

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -84,8 +84,10 @@ int fi_ibv_rdm_tagged_req_match_by_info3(struct dlist_entry *item,
 	    container_of(item, struct fi_ibv_rdm_tagged_request, queue_entry);
 
 	const struct fi_ibv_rdm_tagged_peek_data *peek_data = info;
+	const void *context = (peek_data->flags & FI_CLAIM) ?
+		peek_data->context : NULL;
 
-	return ((request->context == peek_data->context) && 
+	return ((request->context == context) && 
 		fi_ibv_rdm_tagged_req_match_by_info2(item, &peek_data->minfo));
 }
 

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -144,6 +144,12 @@ struct fi_verbs_rdm_tagged_request_minfo {
 	uint64_t			tagmask;
 };
 
+struct fi_ibv_rdm_tagged_peek_data {
+	struct fi_verbs_rdm_tagged_request_minfo minfo;
+	void *context;
+	uint64_t flags;
+};
+
 struct fi_ibv_rdm_cm;
 
 int fi_ibv_rdm_tagged_req_match(struct dlist_entry *item, const void *other);
@@ -151,6 +157,8 @@ int fi_ibv_rdm_tagged_req_match_by_info(struct dlist_entry *item,
                                         const void *info);
 int fi_ibv_rdm_tagged_req_match_by_info2(struct dlist_entry *item,
                                          const void *info);
+int fi_ibv_rdm_tagged_req_match_by_info3(struct dlist_entry *item,
+					 const void *info);
 int fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *item,
                                               const void *arg);
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_tagged_conn *conn,

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -113,10 +113,10 @@ do {                                                                        \
             request,                                                        \
             fi_ibv_rdm_tagged_req_eager_state_to_str(request->state.eager), \
             fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.rndv),   \
-            request->tag,                                                   \
+            request->minfo.tag,                                                   \
             request->len,                                                   \
             request->context,                                               \
-            request->conn);                                                 \
+            request->minfo.conn);                                                 \
                                                                             \
     switch (level)                                                          \
     {                                                                       \
@@ -138,14 +138,14 @@ do {                                                                        \
 
 #endif                          // ENABLE_DEBUG
 
-struct fi_verbs_rdm_tagged_request_minfo {
+struct fi_verbs_rdm_tagged_minfo {
 	struct fi_ibv_rdm_tagged_conn	*conn;
 	uint64_t			tag;
 	uint64_t			tagmask;
 };
 
 struct fi_ibv_rdm_tagged_peek_data {
-	struct fi_verbs_rdm_tagged_request_minfo minfo;
+	struct fi_verbs_rdm_tagged_minfo minfo;
 	void *context;
 	uint64_t flags;
 };

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -96,6 +96,12 @@ const struct fi_rx_attr verbs_rx_attr = {
 	.total_buffered_recv	= 0,
 };
 
+const struct fi_rx_attr verbs_rdm_rx_attr = {
+	.mode			= VERBS_RX_MODE,
+	.msg_order		= VERBS_MSG_ORDER,
+	.total_buffered_recv	= FI_IBV_RDM_DFLT_BUFFERED_SSIZE /* TODO: */
+};
+
 const struct fi_tx_attr verbs_tx_attr = {
 	.mode			= VERBS_TX_MODE,
 	.op_flags		= VERBS_TX_OP_FLAGS,
@@ -722,6 +728,7 @@ static int fi_ibv_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 		fi->tx_attr->inject_size = FI_IBV_RDM_DFLT_BUFFERED_SSIZE;
 		fi->tx_attr->iov_limit = 1;
 		fi->tx_attr->rma_iov_limit = 1;
+		*(fi->rx_attr) = verbs_rdm_rx_attr;
 	}
 
 	switch (ctx->device->transport_type) {

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -316,9 +316,8 @@ fi_ibv_rdm_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
 
 	struct fi_ibv_rma_post_ready_data post_ready_data = { .ep_rdm = ep };
 
-	ret = fi_ibv_rdm_tagged_req_hndl(request, FI_IBV_EVENT_SEND_READY,
+	return fi_ibv_rdm_tagged_req_hndl(request, FI_IBV_EVENT_SEND_READY,
 					 &post_ready_data);
-	return (ret == FI_EP_RDM_HNDL_SUCCESS) ? FI_SUCCESS : -FI_EOTHER;
 }
 
 static ssize_t
@@ -411,9 +410,8 @@ fi_ibv_rdm_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	struct fi_ibv_rma_post_ready_data post_ready_data = { .ep_rdm = ep };
 
-	ret = fi_ibv_rdm_tagged_req_hndl(request, FI_IBV_EVENT_SEND_READY,
+	return fi_ibv_rdm_tagged_req_hndl(request, FI_IBV_EVENT_SEND_READY,
 					 &post_ready_data);
-	return (ret == FI_EP_RDM_HNDL_SUCCESS) ? FI_SUCCESS : -FI_EOTHER;
 }
 
 static ssize_t
@@ -505,10 +503,9 @@ static ssize_t fi_ibv_rdm_ep_rma_inject_write(struct fid_ep *ep,
 
 	switch (ret)
 	{
-	case FI_EP_RDM_HNDL_SUCCESS:
+	case FI_SUCCESS:
 		return ret;
-	case FI_EP_RDM_HNDL_AGAIN:
-		ret = -FI_EAGAIN;
+	case -FI_EAGAIN:
 		break;
 	default:
 		ret = -errno;


### PR DESCRIPTION
1. Add support of FI_PEEK & FI_CLAIM flags
2. Partially related refactoring:

    - conn, tag and tagmask fields of request structure are joined into fi_verbs_rdm_tagged_minfo structure
    - return code type of state machine handlers

Related PR to fabtests repo https://github.com/ofiwg/fabtests/pull/513

@a-ilango 