### PR TITLE
Fix manpage inconsistencies

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -28,7 +28,7 @@ fi_enable
 fi_cancel
 :   Cancel a pending asynchronous data transfer
 
-fi_alias
+fi_ep_alias
 :   Create an alias to the endpoint
 
 fi_control
@@ -88,7 +88,7 @@ int fi_enable(struct fid_ep *ep);
 
 int fi_cancel(struct fid_ep *ep, void *context);
 
-int fi_alias(struct fid_ep *ep, fid_t *alias_ep, uint64_t flags);
+int fi_ep_alias(struct fid_ep *ep, struct fid_ep **alias_ep, uint64_t flags);
 
 int fi_control(struct fid *ep, int command, void *arg);
 
@@ -400,13 +400,13 @@ parameter, only one will be canceled.  In this case, the operation
 which is canceled is provider specific.  The cancel operation is
 asynchronous, but will complete within a bounded period of time.
 
-## fi_alias
+## fi_ep_alias
 
 This call creates an alias to the specified endpoint.  Conceptually,
 an endpoint alias provides an alternate software path from the
 application to the underlying provider hardware.  Applications
 configure an alias endpoint with data transfer flags, specified
-through the fi_alias call.  Typically, the data transfer flags will be
+through the fi_ep_alias call.  Typically, the data transfer flags will be
 different than those assigned to the actual endpoint.  The alias
 mechanism allows a single endpoint to have multiple optimized software
 interfaces.  All allocated aliases must be closed for the underlying

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -406,11 +406,13 @@ This call creates an alias to the specified endpoint.  Conceptually,
 an endpoint alias provides an alternate software path from the
 application to the underlying provider hardware.  Applications
 configure an alias endpoint with data transfer flags, specified
-through the fi_ep_alias call.  Typically, the data transfer flags will be
-different than those assigned to the actual endpoint.  The alias
-mechanism allows a single endpoint to have multiple optimized software
-interfaces.  All allocated aliases must be closed for the underlying
-endpoint to be released.
+through the fi_ep_alias call. The flags must include FI_TRANSMIT or FI_RECV
+(not both) with other flags OR'ed to indicate the type of data transfer the
+flags should apply to. This will override the transmit and recieve attributes
+of the alias endpoint. Typically the attributes of the alias endpoint are
+different than those assigned to the actual endpoint. The alias mechanism
+allows a single endpoint to have multiple optimized software interfaces.
+All allocated aliases must be closed for the underlying endpoint to be released.
 
 ## fi_control
 
@@ -425,15 +427,19 @@ struct fi_info.  The following control commands and arguments may be
 assigned to an endpoint.
 
 **FI_GETOPSFLAG -- uint64_t *flags**
-: Used to retrieve the current value of flags associated with data
-  transfer operations initiated on the endpoint.  See below for a list
-  of control flags.
+: Used to retrieve the current value of flags associated with the data
+  transfer operations initiated on the endpoint. The control argument must
+  include FI_TRANSMIT or FI_RECV (not both) flags to indicate the type of
+  data transfer flags to be returned.
+  See below for a list of control flags.
 
 **FI_SETOPSFLAG -- uint64_t *flags**
 : Used to change the data transfer operation flags associated with an
-  endpoint.  The FI_READ, FI_WRITE, FI_SEND, FI_RECV flags indicate
-  the type of data transfer that the flags should apply to, with other
-  flags OR'ed in.  Valid control flags are defined below.
+  endpoint. The control argument must include FI_TRANSMIT or FI_RECV (not both)
+  to indicate the type of data transfer that the flags should apply to, with other
+  flags OR'ed in. The given flags will override the previous transmit and receive
+  attributes that were set when the endpoint was created.
+  Valid control flags are defined below.
 
 **FI_BACKLOG - int *value**
 : This option only applies to passive endpoints.  It is used to set the
@@ -1104,7 +1110,7 @@ Operation flags are obtained by OR-ing the following flags together.
 Operation flags define the default flags applied to an endpoint's data
 transfer operations, where a flags parameter is not available.  Data
 transfer operations that take flags as input override the op_flags
-value of an endpoint.
+value of transmit or receive context attributes of an endpoint.
 
 *FI_INJECT*
 : Indicates that all outbound data buffers should be returned to the

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1091,8 +1091,8 @@ DIRECT_FN STATIC int gnix_ep_control(fid_t fid, int command, void *arg)
 		}
 		break;
 
-	case FI_GETFIDFLAG:
-	case FI_SETFIDFLAG:
+	case FI_GETOPSFLAG:
+	case FI_SETOPSFLAG:
 	case FI_ALIAS:
 	default:
 		return -FI_ENOSYS;

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -284,12 +284,12 @@ static int psmx_ep_control(fid_t fid, int command, void *arg)
 		*alias->fid = &new_ep->ep.fid;
 		break;
 
-	case FI_SETFIDFLAG:
+	case FI_SETOPSFLAG:
 		ep->flags = *(uint64_t *)arg;
 		psmx_ep_optimize_ops(ep);
 		break;
 
-	case FI_GETFIDFLAG:
+	case FI_GETOPSFLAG:
 		if (!arg)
 			return -FI_EINVAL;
 		*(uint64_t *)arg = ep->flags;

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -357,12 +357,12 @@ static int psmx2_ep_control(fid_t fid, int command, void *arg)
 		*alias->fid = &new_ep->ep.fid;
 		break;
 
-	case FI_SETFIDFLAG:
+	case FI_SETOPSFLAG:
 		ep->flags = *(uint64_t *)arg;
 		psmx2_ep_optimize_ops(ep);
 		break;
 
-	case FI_GETFIDFLAG:
+	case FI_GETOPSFLAG:
 		if (!arg)
 			return -FI_EINVAL;
 		*(uint64_t *)arg = ep->flags;


### PR DESCRIPTION
Based on the discussion of #1981 
- Replaced inconsistent definition of FI_GETFIDFLAG/FI_SETFIDFLAG with FI_GETOPSFLAG/FI_SETOPSFLAG and updated psm, psm2 and gni provider
- Modified fi_control and fi_ep_alias definition
- Added fi_alias_ep to man/fi_endpoint.3.md based on #1968

Can you please take a look? @jithinjosepkl @j-xiong @shefty 