### PR TITLE
prov/sockets: Set rx/tx op_flags to be consistent with manpage

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -498,7 +498,6 @@ struct sock_conn_listener {
 struct sock_ep {
 	struct fid_ep ep;
 	size_t fclass;
-	uint64_t op_flags;
 
 	int tx_shared;
 	int rx_shared;


### PR DESCRIPTION
- Removed op_flags from <code>struct sock_ep</code>
- Fixed <code>FI_SETOPSFLAG/FI_GETOPSFLAG</code> command implementation
- Fixed <code>fi_alias_ep</code> implementation

to be consistent with manpage as discussed in #1981 and #1982 

@jithinjosepkl @shefty @j-xiong 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>