### PR TITLE
prov/psm, psm2: use separate op flags for tx and rx

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -538,7 +538,8 @@ struct psmx_fid_ep {
 	struct psmx_fid_cntr	*remote_read_cntr;
 	unsigned		send_selective_completion:1;
 	unsigned		recv_selective_completion:1;
-	uint64_t		flags;
+	uint64_t		tx_flags;
+	uint64_t		rx_flags;
 	uint64_t		caps;
 	struct fi_context	nocomp_send_context;
 	struct fi_context	nocomp_recv_context;

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -860,7 +860,7 @@ static ssize_t psmx_atomic_write(struct fid_ep *ep,
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 	return _psmx_atomic_write(ep, buf, count, desc,
 				  dest_addr, addr, key,
-				  datatype, op, context, ep_priv->flags);
+				  datatype, op, context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx_atomic_writemsg(struct fid_ep *ep,
@@ -908,7 +908,7 @@ static ssize_t psmx_atomic_inject(struct fid_ep *ep,
 	return _psmx_atomic_write(ep, buf, count, NULL/*desc*/,
 				  dest_addr, addr, key,
 				  datatype, op, NULL,
-				  ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION);
+				  ep_priv->tx_flags | FI_INJECT | PSMX_NO_COMPLETION);
 }
 
 ssize_t _psmx_atomic_readwrite(struct fid_ep *ep,
@@ -1053,7 +1053,7 @@ static ssize_t psmx_atomic_readwrite(struct fid_ep *ep,
 	return _psmx_atomic_readwrite(ep, buf, count, desc,
 					result, result_desc, dest_addr,
 					addr, key, datatype, op,
-					context, ep_priv->flags);
+					context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx_atomic_readwritemsg(struct fid_ep *ep,
@@ -1273,7 +1273,7 @@ static ssize_t psmx_atomic_compwrite(struct fid_ep *ep,
 					compare, compare_desc,
 					result, result_desc,
 					dest_addr, addr, key,
-				        datatype, op, context, ep_priv->flags);
+				        datatype, op, context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx_atomic_compwritemsg(struct fid_ep *ep,

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -35,7 +35,7 @@
 static void psmx_ep_optimize_ops(struct psmx_fid_ep *ep)
 {
 	if (ep->ep.tagged) {
-		if (ep->flags) {
+		if (ep->tx_flags | ep->rx_flags) {
 			ep->ep.tagged = &psmx_tagged_ops;
 			FI_INFO(&psmx_prov, FI_LOG_EP_DATA,
 				"generic tagged ops.\n");
@@ -266,10 +266,44 @@ static int psmx_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	return 0;
 }
 
+static inline int psmx_ep_set_flags(struct psmx_fid_ep *ep, uint64_t flags)
+{
+	uint64_t real_flags = flags & ~(FI_TRANSMIT | FI_RECV);
+
+	if ((flags & FI_TRANSMIT) && (flags & FI_RECV))
+		return -EINVAL;
+	else if (flags & FI_TRANSMIT)
+		ep->tx_flags = real_flags;
+	else if (flags & FI_RECV)
+		ep->rx_flags = real_flags;
+	else
+		; /* ok to leave the flags intact */
+
+	return 0;
+}
+
+static inline int psmx_ep_get_flags(struct psmx_fid_ep *ep, uint64_t *flags)
+{
+	uint64_t flags_in = *flags;
+
+	if ((flags_in & FI_TRANSMIT) && (flags_in & FI_RECV))
+		return -EINVAL;
+	else if (flags_in & FI_TRANSMIT)
+		*flags = ep->tx_flags;
+	else if (flags_in & FI_RECV)
+		*flags = ep->rx_flags;
+	else
+		return -EINVAL;
+
+	return 0;
+}
+
 static int psmx_ep_control(fid_t fid, int command, void *arg)
 {
 	struct fi_alias *alias;
 	struct psmx_fid_ep *ep, *new_ep;
+	int err;
+
 	ep = container_of(fid, struct psmx_fid_ep, ep.fid);
 
 	switch (command) {
@@ -279,20 +313,28 @@ static int psmx_ep_control(fid_t fid, int command, void *arg)
 			return -FI_ENOMEM;
 		alias = arg;
 		*new_ep = *ep;
-		new_ep->flags = alias->flags;
+		err = psmx_ep_set_flags(new_ep, alias->flags);
+		if (err) {
+			free(new_ep);
+			return err;
+		}
 		psmx_ep_optimize_ops(new_ep);
 		*alias->fid = &new_ep->ep.fid;
 		break;
 
 	case FI_SETOPSFLAG:
-		ep->flags = *(uint64_t *)arg;
+		err = psmx_ep_set_flags(ep, *(uint64_t *)arg);
+		if (err)
+			return err;
 		psmx_ep_optimize_ops(ep);
 		break;
 
 	case FI_GETOPSFLAG:
 		if (!arg)
 			return -FI_EINVAL;
-		*(uint64_t *)arg = ep->flags;
+		err = psmx_ep_get_flags(ep, arg);
+		if (err)
+			return err;
 		break;
 
 	case FI_ENABLE:
@@ -394,9 +436,9 @@ int psmx_ep_open(struct fid_domain *domain, struct fi_info *info,
 
 	if (info) {
 		if (info->tx_attr)
-			ep_priv->flags = info->tx_attr->op_flags;
+			ep_priv->tx_flags = info->tx_attr->op_flags;
 		if (info->rx_attr)
-			ep_priv->flags |= info->rx_attr->op_flags;
+			ep_priv->rx_flags = info->rx_attr->op_flags;
 	}
 
 	psmx_ep_optimize_ops(ep_priv);

--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -140,7 +140,7 @@ static ssize_t psmx_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
 
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
-	return _psmx_recv(ep, buf, len, desc, src_addr, context, ep_priv->flags);
+	return _psmx_recv(ep, buf, len, desc, src_addr, context, ep_priv->rx_flags);
 }
 
 static ssize_t psmx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags)
@@ -308,7 +308,7 @@ static ssize_t psmx_send(struct fid_ep *ep, const void *buf, size_t len,
 
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
-	return _psmx_send(ep, buf, len, desc, dest_addr, context, ep_priv->flags);
+	return _psmx_send(ep, buf, len, desc, dest_addr, context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx_sendmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags)
@@ -364,7 +364,7 @@ static ssize_t psmx_inject(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_send(ep, buf, len, NULL, dest_addr, NULL,
-			  ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION);
+			  ep_priv->tx_flags | FI_INJECT | PSMX_NO_COMPLETION);
 }
 
 struct fi_ops_msg psmx_msg_ops = {

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -440,7 +440,7 @@ static ssize_t psmx_recv2(struct fid_ep *ep, void *buf, size_t len,
 	struct psmx_fid_ep *ep_priv;
 
         ep_priv = container_of(ep, struct psmx_fid_ep, ep);
-	return _psmx_recv2(ep, buf, len, desc, src_addr, context, ep_priv->flags);
+	return _psmx_recv2(ep, buf, len, desc, src_addr, context, ep_priv->rx_flags);
 }
 
 static ssize_t psmx_recvmsg2(struct fid_ep *ep, const struct fi_msg *msg,
@@ -559,7 +559,7 @@ static ssize_t psmx_send2(struct fid_ep *ep, const void *buf,
 	struct psmx_fid_ep *ep_priv;
 
         ep_priv = container_of(ep, struct psmx_fid_ep, ep);
-	return _psmx_send2(ep, buf, len, desc, dest_addr, context, ep_priv->flags);
+	return _psmx_send2(ep, buf, len, desc, dest_addr, context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx_sendmsg2(struct fid_ep *ep, const struct fi_msg *msg,
@@ -617,7 +617,7 @@ static ssize_t psmx_inject2(struct fid_ep *ep, const void *buf, size_t len,
 
 	/* TODO: optimize it & guarantee buffered */
 	return _psmx_send2(ep, buf, len, NULL, dest_addr, NULL,
-			   ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION);
+			   ep_priv->tx_flags | FI_INJECT | PSMX_NO_COMPLETION);
 }
 
 struct fi_ops_msg psmx_msg2_ops = {

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -604,7 +604,7 @@ static ssize_t psmx_read(struct fid_ep *ep, void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_read(ep, buf, len, desc, src_addr, addr,
-			  key, context, ep_priv->flags);
+			  key, context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
@@ -821,7 +821,7 @@ static ssize_t psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_write(ep, buf, len, desc, dest_addr, addr, key, context,
-			   ep_priv->flags, 0);
+			   ep_priv->tx_flags, 0);
 }
 
 static ssize_t psmx_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
@@ -856,7 +856,7 @@ static ssize_t psmx_inject(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_write(ep, buf, len, NULL, dest_addr, addr, key,
-			   NULL, ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION, 0);
+			   NULL, ep_priv->tx_flags | FI_INJECT | PSMX_NO_COMPLETION, 0);
 }
 
 static ssize_t psmx_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
@@ -868,7 +868,7 @@ static ssize_t psmx_writedata(struct fid_ep *ep, const void *buf, size_t len, vo
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_write(ep, buf, len, desc, dest_addr, addr, key, context,
-			   ep_priv->flags | FI_REMOTE_CQ_DATA, data);
+			   ep_priv->tx_flags | FI_REMOTE_CQ_DATA, data);
 }
 
 static ssize_t psmx_injectdata(struct fid_ep *ep, const void *buf, size_t len,
@@ -880,7 +880,7 @@ static ssize_t psmx_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_write(ep, buf, len, NULL, dest_addr, addr, key,
-			   NULL, ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION,
+			   NULL, ep_priv->tx_flags | FI_INJECT | PSMX_NO_COMPLETION,
 			   data);
 }
 

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -315,7 +315,7 @@ static ssize_t psmx_tagged_recv(struct fid_ep *ep, void *buf, size_t len, void *
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_tagged_recv(ep, buf, len, desc, src_addr, tag, ignore,
-				 context, ep_priv->flags);
+				 context, ep_priv->rx_flags);
 }
 
 static ssize_t psmx_tagged_recvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
@@ -761,7 +761,7 @@ static ssize_t psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_tagged_send(ep, buf, len, desc, dest_addr, tag, context,
-				 ep_priv->flags);
+				 ep_priv->tx_flags);
 }
 
 static ssize_t psmx_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
@@ -923,7 +923,7 @@ static ssize_t psmx_tagged_inject(struct fid_ep *ep, const void *buf, size_t len
 	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
 	return _psmx_tagged_send(ep, buf, len, NULL, dest_addr, tag, NULL,
-				 ep_priv->flags | FI_INJECT | PSMX_NO_COMPLETION);
+				 ep_priv->tx_flags | FI_INJECT | PSMX_NO_COMPLETION);
 }
 
 /* general case */

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -596,7 +596,8 @@ struct psmx2_fid_ep {
 	uint8_t			vlane;
 	unsigned		send_selective_completion:1;
 	unsigned		recv_selective_completion:1;
-	uint64_t		flags;
+	uint64_t		tx_flags;
+	uint64_t		rx_flags;
 	uint64_t		caps;
 	struct fi_context	nocomp_send_context;
 	struct fi_context	nocomp_recv_context;

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -882,7 +882,7 @@ static ssize_t psmx2_atomic_write(struct fid_ep *ep,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 	return psmx2_atomic_write_generic(ep, buf, count, desc, dest_addr,
 					  addr, key, datatype, op, context,
-					  ep_priv->flags);
+					  ep_priv->tx_flags);
 }
 
 static ssize_t psmx2_atomic_writemsg(struct fid_ep *ep,
@@ -930,7 +930,7 @@ static ssize_t psmx2_atomic_inject(struct fid_ep *ep,
 	return psmx2_atomic_write_generic(ep, buf, count, NULL/*desc*/,
 					  dest_addr, addr, key,
 					  datatype, op, NULL,
-					  ep_priv->flags | FI_INJECT | PSMX2_NO_COMPLETION);
+					  ep_priv->tx_flags | FI_INJECT | PSMX2_NO_COMPLETION);
 }
 
 ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
@@ -1083,7 +1083,7 @@ static ssize_t psmx2_atomic_readwrite(struct fid_ep *ep,
 	return psmx2_atomic_readwrite_generic(ep, buf, count, desc,
 					      result, result_desc, dest_addr,
 					      addr, key, datatype, op,
-					      context, ep_priv->flags);
+					      context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx2_atomic_readwritemsg(struct fid_ep *ep,
@@ -1311,7 +1311,7 @@ static ssize_t psmx2_atomic_compwrite(struct fid_ep *ep,
 					      compare, compare_desc,
 					      result, result_desc,
 					      dest_addr, addr, key,
-			        	      datatype, op, context, ep_priv->flags);
+			        	      datatype, op, context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx2_atomic_compwritemsg(struct fid_ep *ep,

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -155,7 +155,7 @@ static ssize_t psmx2_recv(struct fid_ep *ep, void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_recv_generic(ep, buf, len, desc, src_addr, context,
-				  ep_priv->flags);
+				  ep_priv->rx_flags);
 }
 
 static ssize_t psmx2_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
@@ -622,7 +622,7 @@ static ssize_t psmx2_send(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_send_generic(ep, buf, len, desc, dest_addr, context,
-				  ep_priv->flags, 0);
+				  ep_priv->tx_flags, 0);
 }
 
 static ssize_t psmx2_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
@@ -670,7 +670,7 @@ static ssize_t psmx2_sendv(struct fid_ep *ep, const struct iovec *iov,
 		ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 		return psmx2_sendv_generic(ep, iov, desc, count, dest_addr,
-					   context, ep_priv->flags, 0);
+					   context, ep_priv->tx_flags, 0);
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -691,7 +691,7 @@ static ssize_t psmx2_inject(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_send_generic(ep, buf, len, NULL, dest_addr, NULL,
-				  ep_priv->flags | FI_INJECT | PSMX2_NO_COMPLETION, 
+				  ep_priv->tx_flags | FI_INJECT | PSMX2_NO_COMPLETION, 
 				  0);
 }
 
@@ -704,7 +704,7 @@ static ssize_t psmx2_senddata(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_send_generic(ep, buf, len, desc, dest_addr, context,
-				  ep_priv->flags, data);
+				  ep_priv->tx_flags, data);
 }
 
 static ssize_t psmx2_injectdata(struct fid_ep *ep, const void *buf, size_t len,
@@ -715,7 +715,7 @@ static ssize_t psmx2_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_send_generic(ep, buf, len, NULL, dest_addr, NULL,
-				  ep_priv->flags | FI_INJECT | PSMX2_NO_COMPLETION,
+				  ep_priv->tx_flags | FI_INJECT | PSMX2_NO_COMPLETION,
 				  data);
 }
 

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -671,7 +671,7 @@ static ssize_t psmx2_read(struct fid_ep *ep, void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_read_generic(ep, buf, len, desc, src_addr, addr,
-				  key, context, ep_priv->flags);
+				  key, context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx2_readmsg(struct fid_ep *ep,
@@ -1137,7 +1137,7 @@ static ssize_t psmx2_write(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_write_generic(ep, buf, len, desc, dest_addr, addr,
-				   key, context, ep_priv->flags, 0);
+				   key, context, ep_priv->tx_flags, 0);
 }
 
 static ssize_t psmx2_writemsg(struct fid_ep *ep,
@@ -1175,11 +1175,11 @@ static ssize_t psmx2_writev(struct fid_ep *ep, const struct iovec *iov,
 
 	if (count > 1)
 		return psmx2_writev_generic(ep, iov, desc, count, dest_addr,
-					    addr, key, context, ep_priv->flags, 0);
+					    addr, key, context, ep_priv->tx_flags, 0);
 
 	return psmx2_write_generic(ep, iov->iov_base, iov->iov_len,
 				   desc ? desc[0] : NULL, dest_addr, addr, key,
-				   context, ep_priv->flags, 0);
+				   context, ep_priv->tx_flags, 0);
 }
 
 static ssize_t psmx2_inject(struct fid_ep *ep, const void *buf, size_t len,
@@ -1190,7 +1190,7 @@ static ssize_t psmx2_inject(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_write_generic(ep, buf, len, NULL, dest_addr, addr, key, NULL,
-				   ep_priv->flags | FI_INJECT | PSMX2_NO_COMPLETION,
+				   ep_priv->tx_flags | FI_INJECT | PSMX2_NO_COMPLETION,
 				   0);
 }
 
@@ -1203,7 +1203,7 @@ static ssize_t psmx2_writedata(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_write_generic(ep, buf, len, desc, dest_addr, addr, key,
-				   context, ep_priv->flags | FI_REMOTE_CQ_DATA,
+				   context, ep_priv->tx_flags | FI_REMOTE_CQ_DATA,
 				   data);
 }
 
@@ -1216,7 +1216,7 @@ static ssize_t psmx2_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_write_generic(ep, buf, len, NULL, dest_addr, addr, key, NULL,
-				   ep_priv->flags | FI_INJECT | PSMX2_NO_COMPLETION,
+				   ep_priv->tx_flags | FI_INJECT | PSMX2_NO_COMPLETION,
 				   data);
 }
 

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -473,7 +473,7 @@ static ssize_t psmx2_tagged_recv(struct fid_ep *ep, void *buf, size_t len,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_tagged_recv_generic(ep, buf, len, desc, src_addr, tag,
-					 ignore, context, ep_priv->flags);
+					 ignore, context, ep_priv->rx_flags);
 }
 
 static ssize_t psmx2_tagged_recvmsg(struct fid_ep *ep,
@@ -1101,7 +1101,7 @@ static ssize_t psmx2_tagged_send(struct fid_ep *ep,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	return psmx2_tagged_send_generic(ep, buf, len, desc, dest_addr,
-					 tag, context, ep_priv->flags, 0);
+					 tag, context, ep_priv->tx_flags, 0);
 }
 
 static ssize_t psmx2_tagged_sendmsg(struct fid_ep *ep,
@@ -1153,7 +1153,7 @@ psmx2_tagged_sendv##suffix(struct fid_ep *ep, const struct iovec *iov,	\
 		return psmx2_tagged_sendv_generic(ep, iov, desc, count, \
 						  dest_addr, tag,	\
 						  context,		\
-						  ep_priv->flags, 0);	\
+						  ep_priv->tx_flags, 0);\
 	} else if (count) {						\
 		buf = iov[0].iov_base;					\
 		len = iov[0].iov_len;					\
@@ -1182,7 +1182,7 @@ static ssize_t psmx2_tagged_inject(struct fid_ep *ep,
 
 	return psmx2_tagged_send_generic(ep, buf, len, NULL, dest_addr,
 					 tag, NULL,
-				  	 ep_priv->flags | FI_INJECT | PSMX2_NO_COMPLETION,
+				  	 ep_priv->tx_flags | FI_INJECT | PSMX2_NO_COMPLETION,
 					 0);
 }
 


### PR DESCRIPTION
According to the latest man pages, the op flags for tx and rx
need to be able to be set and retrieved independently.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>