### PR TITLE
verbs: Return fi_info that matches hints

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -370,7 +370,7 @@ int fi_check_info(const struct fi_provider *prov,
 		  const struct fi_info *prov_info,
 		  const struct fi_info *user_info,
 		  enum fi_match_type type);
-void fi_alter_info(struct fi_info *info,
+void ofi_alter_info(struct fi_info *info,
 		   const struct fi_info *hints);
 
 int util_getinfo(const struct fi_provider *prov, uint32_t version,

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -557,16 +557,18 @@ static void fi_alter_tx_attr(struct fi_tx_attr *attr,
  * the hints have been validated and the starting fi_info is properly
  * configured by the provider.
  */
-void fi_alter_info(struct fi_info *info,
+void ofi_alter_info(struct fi_info *info,
 		   const struct fi_info *hints)
 {
 	if (!hints)
 		return;
 
-	info->caps = (hints->caps & FI_PRIMARY_CAPS) |
-		     (info->caps & FI_SECONDARY_CAPS);
+	for (; info; info = info->next) {
+		info->caps = (hints->caps & FI_PRIMARY_CAPS) |
+			     (info->caps & FI_SECONDARY_CAPS);
 
-	fi_alter_ep_attr(info->ep_attr, hints->ep_attr);
-	fi_alter_rx_attr(info->rx_attr, hints->rx_attr, info->caps);
-	fi_alter_tx_attr(info->tx_attr, hints->tx_attr, info->caps);
+		fi_alter_ep_attr(info->ep_attr, hints->ep_attr);
+		fi_alter_rx_attr(info->rx_attr, hints->rx_attr, info->caps);
+		fi_alter_tx_attr(info->tx_attr, hints->tx_attr, info->caps);
+	}
 }

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -165,7 +165,7 @@ int util_getinfo(const struct fi_provider *prov, uint32_t version,
 		return -FI_ENOMEM;
 	}
 
-	fi_alter_info(*info, hints);
+	ofi_alter_info(*info, hints);
 
 	fabric = fi_fabric_find((*info)->fabric_attr->name);
 	if (fabric) {

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -30,6 +30,8 @@
  * SOFTWARE.
  */
 
+#include <fi_util.h>
+
 #include "fi_verbs.h"
 #include "ep_rdm/verbs_rdm.h"
 
@@ -164,7 +166,7 @@ int fi_ibv_check_domain_attr(const struct fi_domain_attr *attr,
 	case FI_THREAD_FID:
 	case FI_THREAD_DOMAIN:
 	case FI_THREAD_COMPLETION:
-    case FI_THREAD_ENDPOINT:
+	case FI_THREAD_ENDPOINT:
 		break;
 	default:
 		FI_INFO(&fi_ibv_prov, FI_LOG_CORE,
@@ -967,6 +969,8 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 	} else {
 		ret = fi_ibv_get_matching_info(NULL, hints, rai, info);
 	}
+
+	ofi_alter_info(*info, hints);
 
 	if (hints && hints->ep_attr)
 		fi_ibv_destroy_ep(hints->ep_attr->type, rai,


### PR DESCRIPTION
- Use util provider's ofi_alter_info function to return fi_info
  structure that matches what was requested in the hints.
- Update ofi_alter_info to handle a list of fi_info structures.