### PR TITLE
usnic: Fix log statement when calling EQ read with an undersized buffer.

### DIFF
--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -94,7 +94,7 @@ static inline ssize_t usdf_eq_read_event(struct usdf_eq *eq, uint32_t *event,
 	copylen = MIN(ev->ue_len, len);
 
 	if (copylen < ev->ue_len) {
-		USDF_DBG_SYS(EP_CTRL,
+		USDF_WARN_SYS(EQ,
 				"buffer too small, got: %zu needed %zu\n",
 				copylen, ev->ue_len);
 		return -FI_ETOOSMALL;


### PR DESCRIPTION
Enable on warn level instead of debug level, log to EQ subsystem.

@goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>