### PR TITLE
man: Clarify use of fi_cntr_wait wrt errors

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -162,10 +162,10 @@ size_t fi_datatype_size(enum fi_datatype datatype);
 uint64_t fi_tag_bits(uint64_t mem_tag_format);
 uint64_t fi_tag_format(uint64_t tag_bits);
 
-int fi_send_allowed(uint64_t caps);
-int fi_recv_allowed(uint64_t caps);
-int fi_rma_initiate_allowed(uint64_t caps);
-int fi_rma_target_allowed(uint64_t caps);
+int ofi_send_allowed(uint64_t caps);
+int ofi_recv_allowed(uint64_t caps);
+int ofi_rma_initiate_allowed(uint64_t caps);
+int ofi_rma_target_allowed(uint64_t caps);
 
 uint64_t fi_gettime_ms(void);
 

--- a/include/fi.h
+++ b/include/fi.h
@@ -166,6 +166,7 @@ int ofi_send_allowed(uint64_t caps);
 int ofi_recv_allowed(uint64_t caps);
 int ofi_rma_initiate_allowed(uint64_t caps);
 int ofi_rma_target_allowed(uint64_t caps);
+int ofi_ep_bind_valid(struct fi_provider *prov, struct fid *bfid, uint64_t flags);
 
 uint64_t fi_gettime_ms(void);
 

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -240,6 +240,7 @@ enum {
 #define FI_ASYNC_IOV		(1ULL << 57)
 #define FI_RX_CQ_DATA		(1ULL << 56)
 #define FI_LOCAL_MR		(1ULL << 55)
+#define FI_NOTIFY_FLAGS_ONLY	(1ULL << 54)
 
 struct fi_tx_attr {
 	uint64_t		caps;

--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -201,6 +201,13 @@ provider implementation constraints.
 
 *FI_LONG_DOUBLE*
 : A double-extended precision floating point value (IEEE 754).
+  Note that the size of a long double and number of bits used for
+  precision is compiler, platform, and/or provider specific.
+  Developers that use long double should ensure that libfabric is
+  built using a long double format that is compatible with their
+  application, and that format is supported by the provider.  The
+  mechanism used for this validation is currently beyond the scope of
+  the libfabric API.
 
 *FI_LONG_DOUBLE_COMPLEX*
 : An ordered pair of double-extended precision floating point values

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -525,6 +525,12 @@ operation.  The following completion flags are defined.
   If other flag bits are zero, the provider is reporting that the multi-recv
   buffer has been freed, and the completion entry is not associated
   with a received message.
+
+Completion flags may be suppressed if the FI_NOTIFY_FLAGS_ONLY mode bit
+has been set.  When enabled, only the following flags are guaranteed to
+be set in completion data when they are valid: FI_REMOTE_READ and
+FI_REMOTE_WRITE (when FI_RMA_EVENT capability bit has been set),
+FI_REMOTE_CQ_DATA, and FI_MULTI_RECV.
  
 # RETURN VALUES
 

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -250,8 +250,11 @@ struct fi_cq_tagged_entry {
   as a wait object.
 
 *signaling_vector*
-: Indicates which processor core interrupts associated with the EQ should
-  target.
+: Indicates which processor core (1..max cpu) that interrupts associated
+  with the CQ should target.  A value of 0 indicates that the provider
+  should select the vector.  This field should be treated as a hint
+  to the provider and may be ignored if the provider does not support
+  interrupt affinity.
 
 *wait_cond*
 : By default, when a completion is inserted into an CQ that supports

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -174,8 +174,11 @@ struct fi_eq_attr {
   as a wait object.
 
 *signaling_vector*
-: Indicates which processor core interrupts associated with the EQ
-  should target.
+: Indicates which processor core (1..max cpu) that interrupts associated
+  with the EQ should target.  A value of 0 indicates that the provider
+  should select the vector.  This field should be treated as a hint
+  to the provider and may be ignored if the provider does not support
+  interrupt affinity.
 
 *wait_set*
 : If wait_obj is FI_WAIT_SET, this field references a wait object to

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -455,6 +455,15 @@ supported set of modes will be returned in the info structure(s).
   receive buffer at the target.  This is true even for operations that would
   normally not consume posted receive buffers, such as RMA write operations.
 
+*FI_NOTIFY_FLAGS_ONLY*
+: This bit indicates that general completion flags may not be set by
+  the provider, and are not needed by the application.  If specified,
+  completion flags which simply report the type of operation that
+  completed (e.g. send or receive) may not be set.  However,
+  completion flags that are used for remote notifications will still
+  be set when applicable.  See `fi_cq`(3) for details on which completion
+  flags are valid when this mode bit is enabled.
+
 # ADDRESSING FORMATS
 
 Multiple fabric interfaces take as input either a source or

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1428,7 +1428,7 @@ static int gnix_ep_close(fid_t fid)
 
 DIRECT_FN STATIC int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 {
-	int ret = FI_SUCCESS;
+	int ret;
 	struct gnix_fid_ep  *ep;
 	struct gnix_fid_av  *av;
 	struct gnix_fid_cq  *cq;
@@ -1438,9 +1438,9 @@ DIRECT_FN STATIC int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
-
-	if (!bfid)
-		return -FI_EINVAL;
+	ret = ofi_ep_bind_valid(&gnix_prov, bfid, flags);
+	if (ret)
+		return ret;
 
 	switch (bfid->fclass) {
 	case FI_CLASS_EQ:

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1631,16 +1631,16 @@ static int __gnix_ep_bound_prep(struct gnix_fid_domain *domain,
 
 static void gnix_ep_caps(struct gnix_fid_ep *ep_priv, uint64_t caps)
 {
-	if (fi_recv_allowed(caps & ~FI_TAGGED))
+	if (ofi_recv_allowed(caps & ~FI_TAGGED))
 		ep_priv->ep_ops.msg_recv_allowed = 1;
 
-	if (fi_send_allowed(caps & ~FI_TAGGED))
+	if (ofi_send_allowed(caps & ~FI_TAGGED))
 		ep_priv->ep_ops.msg_send_allowed = 1;
 
-	if (fi_recv_allowed(caps & ~FI_MSG))
+	if (ofi_recv_allowed(caps & ~FI_MSG))
 		ep_priv->ep_ops.tagged_recv_allowed = 1;
 
-	if (fi_send_allowed(caps & ~FI_MSG))
+	if (ofi_send_allowed(caps & ~FI_MSG))
 		ep_priv->ep_ops.tagged_send_allowed = 1;
 
 }

--- a/prov/mxm/src/mlxm_ep.c
+++ b/prov/mxm/src/mlxm_ep.c
@@ -81,8 +81,12 @@ static int mlxm_ep_close(fid_t fid)
 static int mlxm_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
         struct mlxm_fid_ep *fid_ep;
-        int           err = 0;
+        int ret;
         fid_ep = container_of(fid, struct mlxm_fid_ep, ep.fid);
+
+	ret = ofi_ep_bind_valid(&mlxm_prov, bfid, flags);
+	if (ret)
+		return ret;
 
         switch (bfid->fclass) {
         case FI_CLASS_CQ:
@@ -97,7 +101,7 @@ static int mlxm_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
         default:
                 return -ENOSYS;
         }
-        return err;
+        return 0;
 }
 
 

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -420,19 +420,19 @@ int psmx_domain_check_features(struct psmx_fid_domain *domain, int ep_cap)
 	}
 
 	if ((ep_cap & FI_TAGGED) && domain->tagged_ep &&
-	    fi_recv_allowed(ep_cap))
+	    ofi_recv_allowed(ep_cap))
 		return -FI_EBUSY;
 
 	if ((ep_cap & FI_MSG) && domain->msg_ep &&
-	    fi_recv_allowed(ep_cap))
+	    ofi_recv_allowed(ep_cap))
 		return -FI_EBUSY;
 
 	if ((ep_cap & FI_RMA) && domain->rma_ep &&
-	    fi_rma_target_allowed(ep_cap))
+	    ofi_rma_target_allowed(ep_cap))
 		return -FI_EBUSY;
 
 	if ((ep_cap & FI_ATOMICS) && domain->atomics_ep &&
-	    fi_rma_target_allowed(ep_cap))
+	    ofi_rma_target_allowed(ep_cap))
 		return -FI_EBUSY;
 
 	return 0;
@@ -470,16 +470,16 @@ int psmx_domain_enable_ep(struct psmx_fid_domain *domain, struct psmx_fid_ep *ep
 		domain->am_initialized = 1;
 	}
 
-	if ((ep_cap & FI_RMA) && fi_rma_target_allowed(ep_cap))
+	if ((ep_cap & FI_RMA) && ofi_rma_target_allowed(ep_cap))
 		domain->rma_ep = ep;
 
-	if ((ep_cap & FI_ATOMICS) && fi_rma_target_allowed(ep_cap))
+	if ((ep_cap & FI_ATOMICS) && ofi_rma_target_allowed(ep_cap))
 		domain->atomics_ep = ep;
 
-	if ((ep_cap & FI_TAGGED) && fi_recv_allowed(ep_cap))
+	if ((ep_cap & FI_TAGGED) && ofi_recv_allowed(ep_cap))
 		domain->tagged_ep = ep;
 
-	if ((ep_cap & FI_MSG) && fi_recv_allowed(ep_cap))
+	if ((ep_cap & FI_MSG) && ofi_recv_allowed(ep_cap))
 		domain->msg_ep = ep;
 
 	return 0;

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -201,9 +201,10 @@ static int psmx_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	int err;
 
 	ep = container_of(fid, struct psmx_fid_ep, ep.fid);
+	err = ofi_ep_bind_valid(&psmx_prov, bfid, flags);
+	if (err)
+		return err;
 
-	if (!bfid)
-		return -FI_EINVAL;
 	switch (bfid->fclass) {
 	case FI_CLASS_EQ:
 		return -FI_ENOSYS;

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -274,9 +274,10 @@ static int psmx2_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	int err;
 
 	ep = container_of(fid, struct psmx2_fid_ep, ep.fid);
+	err = ofi_ep_bind_valid(&psmx2_prov, bfid, flags);
+	if (err)
+		return err;
 
-	if (!bfid)
-		return -FI_EINVAL;
 	switch (bfid->fclass) {
 	case FI_CLASS_EQ:
 		return -FI_ENOSYS;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -709,6 +709,10 @@ static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	struct sock_tx_ctx *tx_ctx;
 	struct sock_rx_ctx *rx_ctx;
 
+	ret = ofi_ep_bind_valid(&sock_prov, bfid, flags);
+	if (ret)
+		return ret;
+
 	switch (fid->fclass) {
 	case FI_CLASS_EP:
 		ep = container_of(fid, struct sock_ep, ep.fid);

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -439,7 +439,11 @@ static int udpx_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 {
 	struct udpx_ep *ep;
 	struct util_av *av;
-	int ret = 0;
+	int ret;
+
+	ret = ofi_ep_bind_valid(&udpx_prov, bfid, flags);
+	if (ret)
+		return ret;
 
 	ep = container_of(ep_fid, struct udpx_ep, util_ep.ep_fid.fid);
 	switch (bfid->fclass) {

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -83,8 +83,7 @@ int fi_check_cq_attr(const struct fi_provider *prov,
 	}
 
 	if (attr->signaling_vector) {
-		FI_WARN(prov, FI_LOG_CQ, "signaling vectors not supported\n");
-		return -FI_ENOSYS;
+		FI_WARN(prov, FI_LOG_CQ, "signaling vector ignored\n");
 	}
 
 	return 0;

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -263,8 +263,7 @@ static int util_verify_eq_attr(const struct fi_provider *prov,
 	}
 
 	if (attr->signaling_vector) {
-		FI_WARN(prov, FI_LOG_EQ, "signaling vectors not supported\n");
-		return -FI_ENOSYS;
+		FI_WARN(prov, FI_LOG_EQ, "signaling vector ignored\n");
 	}
 
 	return 0;

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -132,8 +132,12 @@ static int fi_ibv_rdm_tagged_ep_bind(struct fid *fid, struct fid *bfid,
 	struct fi_ibv_rdm_ep *ep;
 	struct fi_ibv_rdm_cq *cq;
 	struct fi_ibv_av *av;
+	int ret;
 
 	ep = container_of(fid, struct fi_ibv_rdm_ep, ep_fid.fid);
+	ret = ofi_ep_bind_valid(&fi_ibv_prov, bfid, flags);
+	if (ret)
+		return ret;
 
 	switch (bfid->fclass) {
 	case FI_CLASS_CQ:

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -127,6 +127,9 @@ static int fi_ibv_msg_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	int ret;
 
 	ep = container_of(fid, struct fi_ibv_msg_ep, ep_fid.fid);
+	ret = ofi_ep_bind_valid(&fi_ibv_prov, bfid, flags);
+	if (ret)
+		return ret;
 
 	switch (bfid->fclass) {
 	case FI_CLASS_CQ:

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -185,15 +185,15 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 		return -FI_ENOCQ;
 	}
 
-	if (!_ep->scq && (fi_send_allowed(_ep->info->caps) ||
-				fi_rma_initiate_allowed(_ep->info->caps))) {
+	if (!_ep->scq && (ofi_send_allowed(_ep->info->caps) ||
+				ofi_rma_initiate_allowed(_ep->info->caps))) {
 		FI_WARN(&fi_ibv_prov, FI_LOG_EP_CTRL, "Endpoint is not bound to "
 				"a send completion queue when it has transmit "
 				"capabilities enabled (FI_SEND | FI_RMA).\n");
 		return -FI_ENOCQ;
 	}
 
-	if (!_ep->rcq && fi_recv_allowed(_ep->info->caps)) {
+	if (!_ep->rcq && ofi_recv_allowed(_ep->info->caps)) {
 		FI_WARN(&fi_ibv_prov, FI_LOG_EP_CTRL, "Endpoint is not bound to "
 				"a receive completion queue when it has receive "
 				"capabilities enabled. (FI_RECV)\n");

--- a/src/common.c
+++ b/src/common.c
@@ -188,6 +188,37 @@ int ofi_rma_target_allowed(uint64_t caps)
 	return 0;
 }
 
+int ofi_ep_bind_valid(struct fi_provider *prov, struct fid *bfid, uint64_t flags)
+{
+	if (!bfid) {
+		FI_WARN(prov, FI_LOG_EP_CTRL, "NULL bind fid\n");
+		return -FI_EINVAL;
+	}
+
+	switch (bfid->fclass) {
+	case FI_CLASS_CQ:
+		if (flags & ~(FI_TRANSMIT | FI_RECV | FI_SELECTIVE_COMPLETION)) {
+			FI_WARN(prov, FI_LOG_EP_CTRL, "invalid CQ flags\n");
+			return -FI_EBADFLAGS;
+		}
+		break;
+	case FI_CLASS_CNTR:
+		if (flags & ~(FI_SEND | FI_RECV | FI_READ | FI_WRITE |
+			      FI_REMOTE_READ | FI_REMOTE_WRITE)) {
+			FI_WARN(prov, FI_LOG_EP_CTRL, "invalid cntr flags\n");
+			return -FI_EBADFLAGS;
+		}
+		break;
+	default:
+		if (flags) {
+			FI_WARN(prov, FI_LOG_EP_CTRL, "invalid bind flags\n");
+			return -FI_EBADFLAGS;
+		}
+		break;
+	}
+	return FI_SUCCESS;
+}
+
 uint64_t fi_gettime_ms(void)
 {
 	struct timeval now;

--- a/src/common.c
+++ b/src/common.c
@@ -128,7 +128,7 @@ size_t fi_datatype_size(enum fi_datatype datatype)
 	return fi_datatype_size_table[datatype];
 }
 
-int fi_send_allowed(uint64_t caps)
+int ofi_send_allowed(uint64_t caps)
 {
 	if (caps & FI_MSG ||
 		caps & FI_TAGGED) {
@@ -142,7 +142,7 @@ int fi_send_allowed(uint64_t caps)
 	return 0;
 }
 
-int fi_recv_allowed(uint64_t caps)
+int ofi_recv_allowed(uint64_t caps)
 {
 	if (caps & FI_MSG ||
 		caps & FI_TAGGED) {
@@ -156,7 +156,7 @@ int fi_recv_allowed(uint64_t caps)
 	return 0;
 }
 
-int fi_rma_initiate_allowed(uint64_t caps)
+int ofi_rma_initiate_allowed(uint64_t caps)
 {
 	if (caps & FI_RMA ||
 		caps & FI_ATOMICS) {
@@ -172,7 +172,7 @@ int fi_rma_initiate_allowed(uint64_t caps)
 	return 0;
 }
 
-int fi_rma_target_allowed(uint64_t caps)
+int ofi_rma_target_allowed(uint64_t caps)
 {
 	if (caps & FI_RMA ||
 		caps & FI_ATOMICS) {


### PR DESCRIPTION
There is a race condition that exists between an application
reading an error counter and waiting on the counter to
update.  The man page states that a wait is satisfied if
any error occurs; however, an error could occur between the
time the application last read the counter and when wait is
called.

Fix this race by clarifying that wait will be satisfied if
the error counter has changed since the last time the
application read it.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>