### PR TITLE
index.md: use non-embed links to SlideShare

### DIFF
--- a/index.md
+++ b/index.md
@@ -52,9 +52,9 @@ A set of man pages have been carefully written to specify the libfabric API.
 
 Additionally, developers may find the documents listed below useful in understanding the libfabric architecture and objectives in more detail.
 
-* [A Short Introduction to the libfabric Architecture](https://www.slideshare.net/slideshow/embed_code/key/arAPmHHuShNbde) - recommended for anyone new to libfabric.
-* [Developer Tutorial](https://www.slideshare.net/slideshow/embed_code/key/p0nI8BbOoDdSzj) - walks through low-level interface details, followed by examples of application and middleware (MPI, SHMEM) using the APIs.
-* [Starting Guide for Writing to libfabric](https://www.slideshare.net/slideshow/embed_code/key/tRnMHhyoS9HWy1)
+* [A Short Introduction to the libfabric Architecture](https://www.slideshare.net/seanhefty/ofi-overview) - recommended for anyone new to libfabric.
+* [Developer Tutorial](https://www.slideshare.net/dgoodell/ofi-libfabric-tutorial) - walks through low-level interface details, followed by examples of application and middleware (MPI, SHMEM) using the APIs.
+* [Starting Guide for Writing to libfabric](https://www.slideshare.net/JianxinXiong/getting-started-with-libfabric)
 
 
 Open Collaboration


### PR DESCRIPTION
The embed links render very poorly as external links.

Fixes #1995.

Signed-off-by: Dave Goodell <dgoodell@cisco.com>