### PR TITLE
prov/{psm,psm2}: properly handle the closing of ep alias

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -526,6 +526,7 @@ struct psmx_fid_av {
 
 struct psmx_fid_ep {
 	struct fid_ep		ep;
+	struct psmx_fid_ep	*base_ep;
 	struct psmx_fid_domain	*domain;
 	struct psmx_fid_av	*av;
 	struct psmx_fid_cq	*send_cq;
@@ -541,6 +542,7 @@ struct psmx_fid_ep {
 	uint64_t		tx_flags;
 	uint64_t		rx_flags;
 	uint64_t		caps;
+	atomic_t		ref;
 	struct fi_context	nocomp_send_context;
 	struct fi_context	nocomp_recv_context;
 	size_t			min_multi_recv;

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -583,6 +583,7 @@ struct psmx2_fid_av {
 
 struct psmx2_fid_ep {
 	struct fid_ep		ep;
+	struct psmx2_fid_ep	*base_ep;
 	struct psmx2_fid_domain	*domain;
 	struct psmx2_fid_av	*av;
 	struct psmx2_fid_cq	*send_cq;
@@ -599,6 +600,7 @@ struct psmx2_fid_ep {
 	uint64_t		tx_flags;
 	uint64_t		rx_flags;
 	uint64_t		caps;
+	atomic_t		ref;
 	struct fi_context	nocomp_send_context;
 	struct fi_context	nocomp_recv_context;
 	struct slist		free_context_list;


### PR DESCRIPTION
Closing of an EP alias only decreases the reference to the base EP. Resource should not be released until the base EP is closed.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

