### PR TITLE
prov/gni: Doubled the max timeout for the rdm_fi_pcd unit

### DIFF
--- a/prov/gni/test/rdm_fi_pcd_trecv_msg.c
+++ b/prov/gni/test/rdm_fi_pcd_trecv_msg.c
@@ -268,7 +268,7 @@ static char *target;
 static char *source;
 static struct fid_mr *rem_mr, *loc_mr;
 static uint64_t mr_key;
-static const int max_test_time = 5;
+static const int max_test_time = 10;
 
 /* test variables */
 static int elapsed;


### PR DESCRIPTION
tests.  Since __gnix_rndzv_req_send_fin sometimes hangs for
more than 5 seconds while waiting for CQ events the criterion
test was timeingout causeing an assertion failure.

@sungeunchoi 
upstream merge of ofi-cray/libfabric-cray#762

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@e02bfb8ddfbe767fb9f76c3d6e8fe67c7a34acb0)