### PR TITLE
prov/gni: fix race condition in non-aligned send

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -357,8 +357,7 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 		 * complete. */
 		req->msg.status |= tx_status;
 
-		atomic_dec(&req->msg.outstanding_txds);
-		if (atomic_get(&req->msg.outstanding_txds)) {
+		if (atomic_dec(&req->msg.outstanding_txds) == 1) {
 			_gnix_nic_tx_free(req->gnix_ep->nic, txd);
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "Received first RDMA chain TXD, req: %p\n",


### PR DESCRIPTION
There was a race condition in the non-aligned get
part of the send/recv path that caused hangs for
certain criterion tests.

Fixes ofi-cray/libfabric-cray#795

upstream merge of ofi-cray/libfabric-cray#796

@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@90d2f3ab2cb13edbd91604b2eb8ad28bf2b1ab33)