### PR TITLE
prov/gni: DGRAM ep should not retry MSG type

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -247,6 +247,7 @@ struct gnix_smsg_rndzv_start_hdr {
  */
 struct gnix_smsg_rndzv_fin_hdr {
 	uint64_t req_addr;
+	int status;
 };
 
 /**


### PR DESCRIPTION
Close loop and send response back to sender that the transaction failed.

Fixes: ofi-cray/libfabric-cray#766

upstream merge of ofi-cray/libfabric-cray#775

@sungeunchoi 

Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@ddb958d097a3ec6d98ec09b0e1e5049df7d6bd18)