### PR TITLE
prov/gni: Remove Criterion assertion for checking

### DIFF
--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -108,7 +108,6 @@ Test(endpoint_info, info)
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");
 	cr_assert_eq(fi->ep_attr->type, FI_EP_RDM);
-	cr_assert_eq(fi->next, NULL);
 
 	fi_freeinfo(fi);
 
@@ -116,7 +115,6 @@ Test(endpoint_info, info)
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");
 	cr_assert_eq(fi->ep_attr->type, FI_EP_DGRAM);
-	cr_assert_eq(fi->next, NULL);
 
 	fi_freeinfo(fi);
 	fi_freeinfo(hints);


### PR DESCRIPTION
that RDM and DGRAM info struct is the last in the list.

upstream merge of ofi-cray/libfabric-cray#792
@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@44081fbbebd0bf086af7926477575e9be695ed1c)