### PR TITLE
prov/gni: some fixes for vec accelerator

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -381,12 +381,10 @@ struct gnix_fid_ep {
 	struct gnix_ep_name my_name;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *nic;
-	fastlock_t vc_ht_lock;
-	union {
-		struct gnix_hashtable *vc_ht;
-		struct gnix_vc **vc_table;      /* used for FI_AV_TABLE */
-		struct gnix_vc *vc;
-	};
+	fastlock_t vc_lock;
+	struct gnix_hashtable *vc_ht;
+	struct gnix_vector *vc_table;   /* used for FI_AV_TABLE */
+	struct gnix_vc *vc;		/* used for FI_EP_MSG */
 	/* lock for unexp and posted recv queue */
 	fastlock_t recv_queue_lock;
 	/* used for unexpected receives */

--- a/prov/gni/include/gnix_av.h
+++ b/prov/gni/include/gnix_av.h
@@ -93,6 +93,69 @@ int _gnix_av_reverse_lookup(struct gnix_fid_av *gnix_av,
 			    struct gnix_address gnix_addr,
 			    fi_addr_t *fi_addr);
 
+/*******************************************************************************
+ * If the caller already knows the av type they can call the lookups directly
+ * using the following functions.
+ ******************************************************************************/
+
+/**
+ * @brief (FI_AV_TABLE) Return the gnix address using its corresponding
+ * fi_addr.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] fi_addr		The corresponding fi_addr_t.
+ * @param[in/out] entry_ptr	The pointer to an address in the entry table.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_table_lookup(struct gnix_fid_av *int_av,
+		       fi_addr_t fi_addr,
+		       struct gnix_av_addr_entry **entry_ptr);
+
+/**
+ * @brief (FI_AV_MAP) Return the gnix address using its corresponding
+ * fi_addr.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] fi_addr		The corresponding fi_addr_t.
+ * @param[in/out] entry_ptr	The pointer to an address in the entry table.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_map_lookup(struct gnix_fid_av *int_av,
+		     fi_addr_t fi_addr,
+		     struct gnix_av_addr_entry **entry_ptr);
+
+/**
+ * @brief (FI_AV_TABLE) Return fi_addr using its corresponding gnix address.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] gnix_addr		The gnix address
+ * @param[in/out] fi_addr	The pointer to the corresponding fi_addr.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_table_reverse_lookup(struct gnix_fid_av *int_av,
+			       struct gnix_address gnix_addr,
+			       fi_addr_t *fi_addr);
+
+/**
+ * @brief (FI_AV_MAP) Return fi_addr using its corresponding gnix address.
+ *
+ * @param[in] int_av		The AV to use for the lookup.
+ * @param[in] gnix_addr		The gnix address
+ * @param[in/out] fi_addr	The pointer to the corresponding fi_addr.
+ *
+ * @return FI_SUCCESS on successfully looking up the entry in the entry table.
+ * @return -FI_EINVAL upon passing an invalid parameter.
+ */
+int _gnix_map_reverse_lookup(struct gnix_fid_av *int_av,
+			     struct gnix_address gnix_addr,
+			     fi_addr_t *fi_addr);
+
 /**
  * @brief Return the string representation of the FI address.
  *

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -54,6 +54,7 @@ extern "C" {
 #define GNIX_VC_MODE_DG_POSTED		(1U << 2)
 #define GNIX_VC_MODE_PENDING_MSGS	(1U << 3)
 #define GNIX_VC_MODE_PEER_CONNECTED	(1U << 4)
+#define GNIX_VC_MODE_IN_TABLE		(1U << 5)
 
 /* VC flags */
 #define GNIX_VC_FLAG_RX_SCHEDULED	0

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -539,6 +539,33 @@ static int map_reverse_lookup(struct gnix_fid_av *int_av,
 /*******************************************************************************
  * FI_AV API implementations.
  ******************************************************************************/
+int _gnix_table_lookup(struct gnix_fid_av *int_av,
+		       fi_addr_t fi_addr,
+		       struct gnix_av_addr_entry **entry_ptr)
+{
+	return table_lookup(int_av, fi_addr, entry_ptr);
+}
+
+int _gnix_table_reverse_lookup(struct gnix_fid_av *int_av,
+			       struct gnix_address gnix_addr,
+			       fi_addr_t *fi_addr)
+{
+	return table_reverse_lookup(int_av, gnix_addr, fi_addr);
+}
+
+int _gnix_map_lookup(struct gnix_fid_av *int_av,
+		     fi_addr_t fi_addr,
+		     struct gnix_av_addr_entry **entry_ptr)
+{
+	return map_lookup(int_av, fi_addr, entry_ptr);
+}
+
+int _gnix_map_reverse_lookup(struct gnix_fid_av *int_av,
+			     struct gnix_address gnix_addr,
+			     fi_addr_t *fi_addr)
+{
+	return map_reverse_lookup(int_av, gnix_addr, fi_addr);
+}
 
 int _gnix_av_lookup(struct gnix_fid_av *gnix_av, fi_addr_t fi_addr,
 		    struct gnix_av_addr_entry **entry_ptr)

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -51,6 +51,7 @@
 #include "gnix_hashtable.h"
 #include "gnix_av.h"
 #include "gnix_trigger.h"
+#include "gnix_vector.h"
 
 /*
  * forward declarations and local struct defs.
@@ -71,6 +72,171 @@ static int __gnix_vc_push_tx_reqs(struct gnix_vc *vc);
 /*******************************************************************************
  * Helper functions
  ******************************************************************************/
+
+/**
+ * Set key to the given gnix_addr.
+ *
+ * NOTE: If struct gnix_address is ever bit packed or packed by
+ * the compiler this assignment may not set key to the correct
+ * bytes.
+ */
+static inline void __gnix_vc_set_ht_key(void *gnix_addr,
+					gnix_ht_key_t *key)
+{
+	*key = *((gnix_ht_key_t *)gnix_addr);
+}
+
+/**
+ * Look up the vc by fi_addr_t, if it's found just return it,
+ * otherwise allocate a new vc, insert it into the hashtable,
+ * and vector for FI_AV_TABLE AV type, and start connection setup.
+ *
+ * assumptions: ep is non-null;
+ * dest_addr is valid;
+ * vc_ptr is non-null.
+ */
+static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
+			    struct gnix_vc **vc_ptr)
+{
+	struct gnix_fid_av *av;
+	enum fi_av_type av_type;
+	int ret = FI_SUCCESS;
+	struct gnix_av_addr_entry *av_entry;
+	gnix_ht_key_t key;
+	struct gnix_vc *vc = NULL, *vc_tmp = NULL;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+        GNIX_DEBUG(FI_LOG_EP_CTRL,
+                   "ep->vc_table = %p, ep->vc_table->vector = %p\n",
+                   ep->vc_table, ep->vc_table->vector);
+
+	av = ep->av;
+	if (unlikely(av == NULL)) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "av field NULL for ep %p\n", ep);
+		return -FI_EINVAL;
+	}
+
+	av_type = av->type;
+
+	/*
+	 * if AV for this ep is type FI_AV_TABLE
+	 * do quick lookup, don't bother with taking lock
+	 * as we're only reading.
+	 */
+
+	if (likely(av_type == FI_AV_TABLE)) {
+		ret = _gnix_vec_at(ep->vc_table, (void **)&vc, dest_addr);
+		if ((ret == FI_SUCCESS) && vc) {
+			*vc_ptr = vc;
+			return FI_SUCCESS;
+		}
+	}
+
+	/*
+	 * use the slow path, have to take the lock
+	 */
+
+	/* Lookup the av_entry to find dest_addr's corresponding gnix_addr */
+	ret = _gnix_av_lookup(av, dest_addr, &av_entry);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_DATA,
+			  "_gnix_av_lookup for addr 0x%llx returned %s \n",
+			  dest_addr, fi_strerror(-ret));
+		goto err;
+	}
+
+	__gnix_vc_set_ht_key(&av_entry->gnix_addr, &key);
+
+	fastlock_acquire(&ep->vc_lock);
+
+	vc = (struct gnix_vc *)_gnix_ht_lookup(ep->vc_ht, key);
+
+	if (vc == NULL) {
+		ret = _gnix_vc_alloc(ep,
+				     av_entry,
+				     &vc_tmp);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_vc_alloc returned %s\n",
+				  fi_strerror(-ret));
+			goto err_w_lock;
+		}
+
+		ret = _gnix_ht_insert(ep->vc_ht, key,
+				      vc_tmp);
+		if (likely(ret == FI_SUCCESS)) {
+			vc = vc_tmp;
+			vc->modes |= GNIX_VC_MODE_IN_HT;
+			/*
+			 * if FI_AV_TABLE is being used, also insert
+			 * in to vector lookup table
+			 */
+			if (av_type == FI_AV_TABLE) {
+				ret = _gnix_vec_insert_at(ep->vc_table, (void *)vc_tmp,
+							  dest_addr);
+				if (ret != FI_SUCCESS) {
+					GNIX_WARN(FI_LOG_EP_DATA,
+						  "_gnix_vec_insert_at returned %s\n",
+						  fi_strerror(-ret));
+				} else {
+					vc_tmp->modes |= GNIX_VC_MODE_IN_TABLE;
+				}
+			}
+			fastlock_release(&ep->vc_lock);
+			ret = _gnix_vc_connect(vc);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_DATA,
+					  "_gnix_vc_connect returned %s\n",
+					  fi_strerror(-ret));
+				goto err;
+			}
+		} else if (ret == -FI_ENOSPC) {
+			_gnix_vc_destroy(vc_tmp);
+			vc = _gnix_ht_lookup(ep->vc_ht, key);
+			fastlock_release(&ep->vc_lock);
+			assert(vc != NULL);
+			assert(vc->modes & GNIX_VC_MODE_IN_HT);
+			ret = FI_SUCCESS;
+		} else {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_ht_insert returned %s\n",
+				  fi_strerror(-ret));
+			goto err_w_lock;
+		}
+	} else  {
+
+		/*
+		 * check here if the vc should be in the table accelerated
+		 * lookup but hasn't yet been inserted
+		 */
+
+		if ((av_type == FI_AV_TABLE) &&
+			!(vc->modes & GNIX_VC_MODE_IN_TABLE)) {
+			ret = _gnix_vec_insert_at(ep->vc_table, (void *)vc,
+						  dest_addr);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_DATA,
+					  "_gnix_vec_insert_at returned %s\n",
+					  fi_strerror(-ret));
+			} else {
+				vc->modes |= GNIX_VC_MODE_IN_TABLE;
+			}
+		}
+
+		fastlock_release(&ep->vc_lock);
+	}
+
+	*vc_ptr = vc;
+	return ret;
+
+err_w_lock:
+	fastlock_release(&ep->vc_lock);
+err:
+	if (vc != NULL)
+		_gnix_vc_destroy(vc);
+	return ret;
+}
 
 /*******************************************************************************
  * connection request /response message pack/unpack functions
@@ -370,7 +536,7 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 	struct gnix_vc *vc_peer;
 	gni_smsg_attr_t smsg_mbox_attr;
 	gni_smsg_attr_t smsg_mbox_attr_peer;
-	gnix_ht_key_t *key_ptr;
+	gnix_ht_key_t key;
 	struct gnix_av_addr_entry entry;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
@@ -391,15 +557,15 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 		goto exit;
 	}
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	fastlock_acquire(&ep->vc_lock);
 	if ((vc->conn_state == GNIX_VC_CONNECTING) ||
 	    (vc->conn_state == GNIX_VC_CONNECTED)) {
-		fastlock_release(&ep->vc_ht_lock);
+		fastlock_release(&ep->vc_lock);
 		return FI_SUCCESS;
 	} else
 		vc->conn_state = GNIX_VC_CONNECTING;
 
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connecting\n", vc);
 
@@ -425,9 +591,9 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 	smsg_mbox_attr.mbox_maxcredit = dom->params.mbox_maxcredit;
 	smsg_mbox_attr.msg_maxsize = dom->params.mbox_msg_maxsize;
 
-	key_ptr = (gnix_ht_key_t *)&vc->peer_addr;
+	__gnix_vc_set_ht_key(&vc->peer_addr, &key);
 	ep_peer = (struct gnix_fid_ep *)_gnix_ht_lookup(cm_nic->addr_to_ep_ht,
-						   *key_ptr);
+							key);
 	if (ep_peer == NULL) {
 		GNIX_WARN(FI_LOG_EP_DATA,
 			  "_gnix_ht_lookup addr_to_ep failed\n");
@@ -435,11 +601,11 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 		goto exit;
 	}
 
-	key_ptr = (gnix_ht_key_t *)&ep->my_name.gnix_addr;
+	__gnix_vc_set_ht_key(&ep->my_name.gnix_addr, &key);
 
-	fastlock_acquire(&ep_peer->vc_ht_lock);
+	fastlock_acquire(&ep_peer->vc_lock);
 	vc_peer = (struct gnix_vc *)_gnix_ht_lookup(ep_peer->vc_ht,
-						   *key_ptr);
+						    key);
 
 	/*
 	 * handle the special case of connecting to self
@@ -489,7 +655,7 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 		}
 
 		ret = _gnix_ht_insert(ep_peer->vc_ht,
-				      *key_ptr,
+				      key,
 				      vc_peer);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
@@ -560,7 +726,7 @@ static int __gnix_vc_connect_to_same_cm_nic(struct gnix_vc *vc)
 		   vc_peer);
 
 exit_w_lock:
-	fastlock_release(&ep_peer->vc_ht_lock);
+	fastlock_release(&ep_peer->vc_lock);
 exit:
 	return ret;
 }
@@ -606,7 +772,7 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 	ep = vc->ep;
 	assert(ep != NULL);
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	fastlock_acquire(&ep->vc_lock);
 
 	/*
 	 * at this point vc should be in connecting state
@@ -644,7 +810,7 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 		   " moving vc %p to state connected\n",vc);
 
 	vc->peer_caps = peer_caps;
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 
 	ret = _gnix_vc_schedule(vc);
 	if (ret != FI_SUCCESS)
@@ -655,7 +821,7 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 	return ret;
 err:
 	vc->conn_state = GNIX_VC_CONN_ERROR;
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 	return ret;
 }
 
@@ -666,7 +832,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	int ret = FI_SUCCESS;
 	gni_return_t __attribute__((unused)) status;
 	struct gnix_fid_ep *ep = NULL;
-	gnix_ht_key_t *key_ptr;
+	gnix_ht_key_t key;
 	struct gnix_av_addr_entry entry;
 	struct gnix_address src_addr, target_addr;
 	struct gnix_vc *vc = NULL;
@@ -710,10 +876,10 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	 * in the datagram
 	 */
 
-	key_ptr = (gnix_ht_key_t *)&target_addr;
+	__gnix_vc_set_ht_key(&target_addr, &key);
 
 	ep = (struct gnix_fid_ep *)_gnix_ht_lookup(cm_nic->addr_to_ep_ht,
-						   *key_ptr);
+						   key);
 	if (ep == NULL) {
 		GNIX_WARN(FI_LOG_EP_DATA,
 			  "_gnix_ht_lookup addr_to_ep failed\n");
@@ -726,18 +892,17 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	 * address of the connecting EP.
 	 */
 
-	key_ptr = (gnix_ht_key_t *)&src_addr;
+	__gnix_vc_set_ht_key(&src_addr, &key);
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	fastlock_acquire(&ep->vc_lock);
 	vc = (struct gnix_vc *)_gnix_ht_lookup(ep->vc_ht,
-					       *key_ptr);
+					       key);
 
 	/*
- 	 * if there is no corresponding vc in the hash,
- 	 * or there is an entry and its not in connecting state
- 	 * go down the conn req ack route.
- 	 */
-
+	 * if there is no corresponding vc in the hash,
+	 * or there is an entry and it's not in connecting state
+	 * go down the conn req ack route.
+	 */
 	if ((vc == NULL)  ||
 	    (vc->conn_state == GNIX_VC_CONN_NONE)) {
 		if (vc == NULL) {
@@ -755,8 +920,9 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 
 			vc_try->conn_state = GNIX_VC_CONNECTING;
 			ret = _gnix_ht_insert(ep->vc_ht,
-					      *key_ptr,
+					      key,
 					      vc_try);
+
 			if (likely(ret == FI_SUCCESS)) {
 				vc = vc_try;
 				vc->modes |= GNIX_VC_MODE_IN_HT;
@@ -764,7 +930,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 				if (ret == -FI_ENOSPC)
 					_gnix_vc_destroy(vc_try);
 				GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_ht_insert returned %s\n",
+				  "__gnix_ht_insert returned %s\n",
 				   fi_strerror(-ret));
 				goto err;
 			}
@@ -805,12 +971,11 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 		 * cm_nic's work queue, progress the cm_nic.
 		 */
 
-
 		fastlock_acquire(&cm_nic->wq_lock);
 		dlist_insert_before(&work_req->list, &cm_nic->cm_nic_wq);
 		fastlock_release(&cm_nic->wq_lock);
 
-		fastlock_release(&ep->vc_ht_lock);
+		fastlock_release(&ep->vc_lock);
 
 		ret = _gnix_vc_schedule(vc);
 		if (ret != FI_SUCCESS)
@@ -855,7 +1020,7 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 		GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n",
 			vc);
 
-		fastlock_release(&ep->vc_ht_lock);
+		fastlock_release(&ep->vc_lock);
 
 		ret = _gnix_vc_schedule(vc);
 		if (ret != FI_SUCCESS)
@@ -949,7 +1114,7 @@ static int __gnix_vc_conn_ack_prog_fn(void *data, int *complete_ptr)
 	if (cm_nic == NULL)
 		return -FI_EINVAL;
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	fastlock_acquire(&ep->vc_lock);
 
 	/*
 	 * we may have already been moved to connected or
@@ -1049,7 +1214,7 @@ static int __gnix_vc_conn_ack_prog_fn(void *data, int *complete_ptr)
 	}
 
 exit:
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 
 	*complete_ptr = complete;
 	return ret;
@@ -1081,7 +1246,7 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 	if (cm_nic == NULL)
 		return -FI_EINVAL;
 
-	fastlock_acquire(&ep->vc_ht_lock);
+	fastlock_acquire(&ep->vc_lock);
 
 	if ((vc->conn_state == GNIX_VC_CONNECTING) ||
 		(vc->conn_state == GNIX_VC_CONNECTED)) {
@@ -1177,7 +1342,7 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 			  fi_strerror(-ret));
 
 err:
-	fastlock_release(&ep->vc_ht_lock);
+	fastlock_release(&ep->vc_lock);
 	*complete_ptr = complete;
 	return ret;
 }
@@ -1205,7 +1370,6 @@ static int __gnix_vc_conn_req_comp_fn(void *data)
 /*******************************************************************************
  * Internal API functions
  ******************************************************************************/
-
 int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 		   struct gnix_av_addr_entry *entry, struct gnix_vc **vc)
 
@@ -2053,6 +2217,8 @@ int _gnix_vc_nic_progress(struct gnix_nic *nic)
  */
 int _gnix_vc_schedule(struct gnix_vc *vc)
 {
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
 	_gnix_vc_rx_schedule(vc);
 	__gnix_vc_work_schedule(vc);
 	_gnix_vc_tx_schedule(vc);
@@ -2060,99 +2226,18 @@ int _gnix_vc_schedule(struct gnix_vc *vc)
 	return FI_SUCCESS;
 }
 
-static int __gnix_vc_ep_rdm_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
-			    struct gnix_vc **vc_ptr)
-{
-	int ret = FI_SUCCESS;
-	struct gnix_vc *vc = NULL, *vc_tmp;
-	struct gnix_fid_av *av;
-	struct gnix_av_addr_entry *av_entry;
-	gnix_ht_key_t key;
-
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	av = ep->av;
-	assert(av != NULL);
-
-	ret = _gnix_av_lookup(av, dest_addr, &av_entry);
-	if (ret != FI_SUCCESS) {
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_av_lookup for addr 0x%llx returned %s \n",
-			  dest_addr, fi_strerror(-ret));
-		goto err;
-	}
-
-	GNIX_INFO(FI_LOG_EP_CTRL, "fi_addr_t: 0x%llx gnix_addr: 0x%llx\n",
-		  dest_addr, av_entry->gnix_addr);
-
-	memcpy(&key, &av_entry->gnix_addr, sizeof(gnix_ht_key_t));
-
-	fastlock_acquire(&ep->vc_ht_lock);
-	vc = (struct gnix_vc *)_gnix_ht_lookup(ep->vc_ht,
-						key);
-	if (vc == NULL) {
-		ret = _gnix_vc_alloc(ep,
-				     av_entry,
-				     &vc_tmp);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_vc_alloc returned %s\n",
-				  fi_strerror(-ret));
-			goto err_w_lock;
-		}
-		ret = _gnix_ht_insert(ep->vc_ht, key,
-					vc_tmp);
-		if (likely(ret == FI_SUCCESS)) {
-			vc = vc_tmp;
-			vc->modes |= GNIX_VC_MODE_IN_HT;
-			fastlock_release(&ep->vc_ht_lock);
-			ret = _gnix_vc_connect(vc);
-			if (ret != FI_SUCCESS) {
-				GNIX_WARN(FI_LOG_EP_DATA,
-					"_gnix_vc_connect returned %s\n",
-					   fi_strerror(-ret));
-				goto err;
-			}
-		} else if (ret == -FI_ENOSPC) {
-			_gnix_vc_destroy(vc_tmp);
-			vc = _gnix_ht_lookup(ep->vc_ht, key);
-			fastlock_release(&ep->vc_ht_lock);
-			assert(vc != NULL);
-			assert(vc->modes & GNIX_VC_MODE_IN_HT);
-			ret = FI_SUCCESS;
-		} else {
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_ht_insert returned %s\n",
-				   fi_strerror(-ret));
-			goto err_w_lock;
-		}
-	} else  {
-		fastlock_release(&ep->vc_ht_lock);
-	}
-
-	*vc_ptr = vc;
-	return ret;
-
-err_w_lock:
-	fastlock_release(&ep->vc_ht_lock);
-err:
-	if (vc != NULL)
-		_gnix_vc_destroy(vc);
-	return ret;
-}
-
 int _gnix_vc_ep_get_vc(struct gnix_fid_ep *ep, fi_addr_t dest_addr,
-			struct gnix_vc **vc_ptr)
+		       struct gnix_vc **vc_ptr)
 {
 	int ret;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	if (GNIX_EP_RDM_DGM(ep->type)) {
-		ret = __gnix_vc_ep_rdm_get_vc(ep, dest_addr, vc_ptr);
+		ret = __gnix_vc_get_vc_by_fi_addr(ep, dest_addr, vc_ptr);
 		if (unlikely(ret != FI_SUCCESS)) {
 			GNIX_WARN(FI_LOG_EP_DATA,
-				  "__gnix_vc_ep_get_vc returned %s\n",
+				  "__gnix_vc_get_vc_by_fi_addr returned %s\n",
 				   fi_strerror(-ret));
 			return ret;
 		}
@@ -2213,4 +2298,3 @@ int _gnix_vc_cm_init(struct gnix_cm_nic *cm_nic)
 
 	return ret;
 }
-


### PR DESCRIPTION
simplify things by retaining the vc hash table
for use with connection setup, irrespective of
whether the EP is bound to an FI_AV_TABLE or
FI_AV_MAP flavor of AV.

@sungeunchoi 

upstream merge of ofi-cray/libfabric-cray#786

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@0d755d28357f0c599e48e3040fded5c9452ae5dd)