### PR TITLE
prov/gni: honor request for FI_THREAD_COMPLETION

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -408,6 +408,15 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 
+			switch (hints->domain_attr->threading) {
+			case FI_THREAD_COMPLETION:
+				gnix_info->domain_attr->threading =
+					hints->domain_attr->threading;
+				break;
+			default:
+				break;
+			}
+
 			ret = fi_check_domain_attr(&gnix_prov,
 						   gnix_info->domain_attr,
 						   hints->domain_attr,


### PR DESCRIPTION
If an app asks for FI_THREAD_COMPLETION, honor it.
Default is to get FI_THREAD_SAFE.

upstream merge of ofi-cray/libfabric-cray#805
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@e9230ced3234bc80df7263045c011f62f9d76a49)