### PR TITLE
prov/gni: Change GNIX_WARN to GNIX_INFO in gnix_vec_at upon

### DIFF
--- a/prov/gni/src/gnix_vector.c
+++ b/prov/gni/src/gnix_vector.c
@@ -226,7 +226,7 @@ inline int _gnix_vec_at(gnix_vector_t *vec, void **element, gnix_vec_index_t ind
 		if (likely((uint64_t) vec->vector[index])) {
 			*element = vec->vector[index];
 		} else {
-			GNIX_WARN(FI_LOG_EP_CTRL, "There is no element at index "
+			GNIX_INFO(FI_LOG_EP_CTRL, "There is no element at index "
 				  "%lu in _gnix_vec_at\n", index);
 			return -FI_ECANCELED;
 		}


### PR DESCRIPTION
finding a empty vector element.

upstream merge of ofi-cray/libfabric-cray#789
@sungeunchoi 

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@798c0b324f6f8ccc2c8a2fd12e8683573d503efd)