### PR TITLE
prov/gni: perf improvements

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -58,6 +59,8 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
  * @var rcv_cb_fn      pointer to callback function used to process
  *                     incoming messages received by this cm nic
  * @var ptag           ptag of this nic.
+ * @var poll_cnt       non-atomic counter to reduce datagram polling cnt
+ *                     when using FI_PROGRESS_MANUAL for control progress.
  * @var device_id      local Aries device id associated with this nic.
  */
 struct gnix_cm_nic {
@@ -72,6 +75,7 @@ struct gnix_cm_nic {
 	struct gnix_ep_name my_name;
 	gnix_cm_nic_rcv_cb_func *rcv_cb_fn;
 	uint8_t ptag;
+	uint32_t poll_cnt;
 	uint32_t device_id;
 };
 

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -41,6 +42,7 @@
 #include "gnix.h"
 #include "gnix_cq.h"
 #include "gnix_nic.h"
+#include "gnix_cm_nic.h"
 
 /*******************************************************************************
  * Function pointer for filling specific entry format type.
@@ -248,8 +250,6 @@ cleanup:
 err:
 	return NULL;
 }
-
-extern int _gnix_cm_nic_progress(struct gnix_cm_nic *cm_nic);
 
 static int __gnix_cq_progress(struct gnix_fid_cq *cq)
 {

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
- * Copyright (c) 2015-16 Los Alamos National Security, LLC.
- *                       All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/gni/src/gnix_freelist.c
+++ b/prov/gni/src/gnix_freelist.c
@@ -209,7 +209,7 @@ void _gnix_fl_free(struct dlist_entry *e, struct gnix_freelist *fl)
 	if (fl->ts)
 		fastlock_acquire(&fl->lock);
 	dlist_init(e);
-	dlist_insert_tail(e, &fl->freelist);
+	dlist_insert_head(e, &fl->freelist);
 	if (fl->ts)
 		fastlock_release(&fl->lock);
 }

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1457,7 +1457,7 @@ static int _gnix_send_req(void *arg)
 	}
 	assert(rc == FI_SUCCESS);
 
-	if (rendezvous) {
+	if (unlikely(rendezvous)) {
 		assert(req->msg.send_md);
 
 		tag = GNIX_SMSG_T_RNDZV_START;
@@ -1514,7 +1514,7 @@ static int _gnix_send_req(void *arg)
 
 	COND_ACQUIRE(nic->requires_lock, &nic->lock);
 
-	if (inject_err) {
+	if (unlikely(inject_err)) {
 		_gnix_nic_txd_err_inject(nic, tdesc);
 		status = GNI_RC_SUCCESS;
 	} else {

--- a/prov/gni/src/gnix_queue.c
+++ b/prov/gni/src/gnix_queue.c
@@ -129,5 +129,5 @@ void _gnix_queue_enqueue(struct gnix_queue *queue, struct slist_entry *item)
 void _gnix_queue_enqueue_free(struct gnix_queue *queue,
 			      struct slist_entry *item)
 {
-	gnix_slist_insert_tail(item, &queue->free_list);
+	slist_insert_head(item, &queue->free_list);
 }


### PR DESCRIPTION
Try to recycle elements off free lists more frequently
to reduce cache misses.

Reduce poll rate for cm nic unless there are elements
on the cm nic work queue.

This shaves about 100 nsecs off of the osu_latency results
@sungeunchoi 

upstream merge of ofi-cray/libfabric-cray#803

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@2a1832e4143722b9422d989445b091d76076ef94)