### PR TITLE
prov/{psm,psm2}: Use atomic type for counters

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -455,10 +455,8 @@ struct psmx_fid_cntr {
 	struct psmx_fid_domain	*domain;
 	int			events;
 	uint64_t		flags;
-	volatile uint64_t	counter;
-	volatile uint64_t	error_counter;
-	uint64_t		counter_last_read;
-	uint64_t		error_counter_last_read;
+	atomic_t		counter;
+	atomic_t		error_counter;
 	struct util_wait	*wait;
 	int			wait_is_local;
 	struct psmx_trigger	*trigger;
@@ -640,7 +638,7 @@ void	psmx_cntr_add_trigger(struct psmx_fid_cntr *cntr, struct psmx_trigger *trig
 
 static inline void psmx_cntr_inc(struct psmx_fid_cntr *cntr)
 {
-	cntr->counter++;
+	atomic_inc(&cntr->counter);
 	psmx_cntr_check_trigger(cntr);
 	if (cntr->wait)
 		cntr->wait->signal(cntr->wait);

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -557,10 +557,8 @@ struct psmx2_fid_cntr {
 	struct psmx2_fid_domain	*domain;
 	int			events;
 	uint64_t		flags;
-	volatile uint64_t	counter;
-	volatile uint64_t	error_counter;
-	uint64_t		counter_last_read;
-	uint64_t		error_counter_last_read;
+	atomic_t		counter;
+	atomic_t		error_counter;
 	struct util_wait	*wait;
 	int			wait_is_local;
 	struct psmx2_trigger	*trigger;
@@ -747,7 +745,7 @@ int	psmx2_handle_sendv_req(struct psmx2_fid_ep *ep, psm2_mq_status2_t *psm2_stat
 
 static inline void psmx2_cntr_inc(struct psmx2_fid_cntr *cntr)
 {
-	cntr->counter++;
+	atomic_inc(&cntr->counter);
 	psmx2_cntr_check_trigger(cntr);
 	if (cntr->wait)
 		cntr->wait->signal(cntr->wait);

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -208,7 +208,7 @@ void psmx2_cntr_check_trigger(struct psmx2_fid_cntr *cntr)
 
 	trigger = cntr->trigger;
 	while (trigger) {
-		if (cntr->counter < trigger->threshold)
+		if (atomic_get(&cntr->counter) < trigger->threshold)
 			break;
 
 		cntr->trigger = trigger->next;
@@ -265,9 +265,7 @@ static uint64_t psmx2_cntr_read(struct fid_cntr *cntr)
 		poll_cnt = 0;
 	}
 
-	cntr_priv->counter_last_read = cntr_priv->counter;
-
-	return cntr_priv->counter_last_read;
+	return atomic_get(&cntr_priv->counter);
 }
 
 static uint64_t psmx2_cntr_readerr(struct fid_cntr *cntr)
@@ -276,9 +274,7 @@ static uint64_t psmx2_cntr_readerr(struct fid_cntr *cntr)
 
 	cntr_priv = container_of(cntr, struct psmx2_fid_cntr, cntr);
 
-	cntr_priv->error_counter_last_read = cntr_priv->error_counter;
-
-	return cntr_priv->error_counter_last_read;
+	return atomic_get(&cntr_priv->error_counter);
 }
 
 static int psmx2_cntr_add(struct fid_cntr *cntr, uint64_t value)
@@ -286,7 +282,7 @@ static int psmx2_cntr_add(struct fid_cntr *cntr, uint64_t value)
 	struct psmx2_fid_cntr *cntr_priv;
 
 	cntr_priv = container_of(cntr, struct psmx2_fid_cntr, cntr);
-	cntr_priv->counter += value;
+	atomic_add(&cntr_priv->counter, value);
 
 	psmx2_cntr_check_trigger(cntr_priv);
 
@@ -301,7 +297,7 @@ static int psmx2_cntr_set(struct fid_cntr *cntr, uint64_t value)
 	struct psmx2_fid_cntr *cntr_priv;
 
 	cntr_priv = container_of(cntr, struct psmx2_fid_cntr, cntr);
-	cntr_priv->counter = value;
+	atomic_set(&cntr_priv->counter, value);
 
 	psmx2_cntr_check_trigger(cntr_priv);
 
@@ -322,7 +318,7 @@ static int psmx2_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeou
 
 	clock_gettime(CLOCK_REALTIME, &ts0);
 
-	while (cntr_priv->counter < threshold) {
+	while (atomic_get(&cntr_priv->counter) < threshold) {
 		if (cntr_priv->wait) {
 			ret = fi_wait((struct fid_wait *)cntr_priv->wait,
 				      timeout - msec_passed);
@@ -332,7 +328,7 @@ static int psmx2_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeou
 			psmx2_progress(cntr_priv->domain);
 		}
 
-		if (cntr_priv->counter >= threshold)
+		if (atomic_get(&cntr_priv->counter) >= threshold)
 			break;
 
 		if (timeout < 0)
@@ -493,6 +489,8 @@ int psmx2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	cntr_priv->cntr.fid.context = context;
 	cntr_priv->cntr.fid.ops = &psmx2_fi_ops;
 	cntr_priv->cntr.ops = &psmx2_cntr_ops;
+	atomic_initialize(&cntr_priv->counter, 0);
+	atomic_initialize(&cntr_priv->error_counter, 0);
 
 	pthread_mutex_init(&cntr_priv->trigger_lock, NULL);
 


### PR DESCRIPTION
The counter values need to be accessed atomically to avoid race
condition between the readers and the writers.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>