### PR TITLE
prov/{psm,psm2}: Eliminate compiler warnings of debug build

### DIFF
--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -284,8 +284,8 @@ static inline int psmx_ep_set_flags(struct psmx_fid_ep *ep, uint64_t flags)
 		ep->tx_flags = real_flags;
 	else if (flags & FI_RECV)
 		ep->rx_flags = real_flags;
-	else
-		; /* ok to leave the flags intact */
+
+	/* otherwise ok to leave the flags intact */
 
 	return 0;
 }

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -357,8 +357,8 @@ static inline int psmx2_ep_set_flags(struct psmx2_fid_ep *ep, uint64_t flags)
 		ep->tx_flags = real_flags;
 	else if (flags & FI_RECV)
 		ep->rx_flags = real_flags;
-	else
-		; /* ok to leave the flags intact */
+
+	/* otherwise ok to leave the flags intact */
 
 	return 0;
 }


### PR DESCRIPTION
The extra warning options used for debug build caused the compiler
to compalain about empty statement in the "else" clause. Just keep
the comment and remove the "else".

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>