### PR TITLE
usnic: Fix invalid completion lengths.

### DIFF
--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -278,7 +278,7 @@ usdf_msg_recvv(struct fid_ep *fep, const struct iovec *iov, void **desc,
 	rqe->ms_cur_ptr = iov[0].iov_base;
 	rqe->ms_iov_resid = iov[0].iov_len;
 	rqe->ms_resid = tot_len;
-	rqe->ms_length = tot_len;
+	rqe->ms_length = 0;
 
 	op_flags = ep->ep_rx->rx_attr.op_flags;
 	rqe->ms_signal_comp = ep->ep_rx_dflt_signal_comp ||
@@ -576,7 +576,7 @@ usdf_msg_recvmsg(struct fid_ep *fep, const struct fi_msg *msg, uint64_t flags)
 
 	rqe->ms_cur_iov = 0;
 	rqe->ms_resid = tot_len;
-	rqe->ms_length = tot_len;
+	rqe->ms_length = 0;
 	rqe->ms_cur_ptr = iov[0].iov_base;
 	rqe->ms_iov_resid = iov[0].iov_len;
 

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -534,7 +534,7 @@ static inline ssize_t _usdf_rdm_recv_vector(struct fid_ep *fep,
 	rqe->rd_last_iov = count - 1;
 	rqe->rd_cur_ptr = iov[0].iov_base;
 	rqe->rd_resid = tot_len;
-	rqe->rd_length = tot_len;
+	rqe->rd_length = 0;
 
 	rqe->rd_signal_comp = ep->ep_rx_dflt_signal_comp ||
 		(flags & FI_COMPLETION) ? 1 : 0;


### PR DESCRIPTION
The FI_EP_RDM and FI_EP_MSG implementations in the usNIC provider use
fields in the work requests (rd_length and ms_length) to keep track of
how many bytes have been received. Some of the receive functions were
incorrectly initializing these lengths to the full length of the
receive. This resulted in a completion length that counted the length
twice. Initialize them to 0 instead.

Fixes #1832.

@goodell @jsquyres 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>