### PR TITLE
prov/sockets: Fix a race condition in enqueing triggered operation

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -1164,6 +1164,7 @@ ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 			   uint64_t flags, uint8_t op_type);
 ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
 			  uint64_t flags, uint8_t op_type);
+void sock_cntr_check_trigger_list(struct sock_cntr *cntr);
 
 int sock_epoll_create(struct sock_epoll_set *set, int size);
 int sock_epoll_add(struct sock_epoll_set *set, int fd);

--- a/prov/sockets/src/sock_trigger.c
+++ b/prov/sockets/src/sock_trigger.c
@@ -82,6 +82,7 @@ ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	fastlock_acquire(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
 	fastlock_release(&cntr->trigger_lock);
+	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
 
@@ -121,6 +122,7 @@ ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
 	fastlock_acquire(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
 	fastlock_release(&cntr->trigger_lock);
+	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
 
@@ -160,6 +162,7 @@ ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 	fastlock_acquire(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
 	fastlock_release(&cntr->trigger_lock);
+	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
 
@@ -214,5 +217,6 @@ ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 	fastlock_acquire(&cntr->trigger_lock);
 	dlist_insert_tail(&trigger->entry, &cntr->trigger_list);
 	fastlock_release(&cntr->trigger_lock);
+	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }


### PR DESCRIPTION
- Fix a race condition in enqueing triggered operation and incrementing counter.
