### PR TITLE
Clarify the use of FI_OPT_CM_DATA_SIZE.

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -468,9 +468,12 @@ The following option levels and option names and parameters are defined.
 
 - *FI_OPT_CM_DATA_SIZE - size_t*
 : Defines the size of available space in CM messages for user-defined
-  data.  This value limits the amount of data that applications can
-  exchange between peer endpoints using the fi_connect, fi_accept,
-  and fi_reject operations.  This option is read only.
+  data.  This value limits the amount of data that applications can exchange
+  between peer endpoints using the fi_connect, fi_accept, and fi_reject
+  operations.  The size returned is dependent upon the properties of the
+  endpoint, except in the case of passive endpoints, in which the size reflects
+  the maximum size of the data that may be present as part of a connection
+  request event. This option is read only.
 
 ## fi_rx_size_left
 


### PR DESCRIPTION
When used with a passive endpoint, return the maximum possible size
across all domains. This is useful when receiving connection data in
a FI_CONNREQ event.

@shefty @goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>