### PR TITLE
usnic: Enhance getopt support.

### DIFF
--- a/prov/usnic/src/usdf_endpoint.c
+++ b/prov/usnic/src/usdf_endpoint.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -58,6 +58,7 @@
 
 #include "usdf.h"
 #include "usdf_endpoint.h"
+#include "usdf_cm.h"
 
 int
 usdf_endpoint_open(struct fid_domain *domain, struct fi_info *info,
@@ -75,4 +76,53 @@ usdf_endpoint_open(struct fid_domain *domain, struct fi_info *info,
 	default:
 		return -FI_ENODEV;
 	}
+}
+
+int usdf_ep_getopt_connected(fid_t fid, int level, int optname, void *optval,
+		size_t *optlen)
+{
+	size_t *cm_size;
+	size_t dest_size;
+
+	USDF_TRACE_SYS(EP_CTRL, "\n");
+
+	if (!optval || !optlen)
+		return -FI_EINVAL;
+
+	if (level != FI_OPT_ENDPOINT)
+		return -FI_ENOPROTOOPT;
+
+	switch (optname) {
+	case FI_OPT_CM_DATA_SIZE:
+		dest_size = *optlen;
+		*optlen = sizeof(*cm_size);
+
+		if (dest_size < sizeof(*cm_size))
+			return -FI_ETOOSMALL;
+
+		cm_size = optval;
+		*cm_size = USDF_MAX_CONN_DATA;
+		break;
+	default:
+		return -FI_ENOPROTOOPT;
+	}
+
+	return FI_SUCCESS;
+}
+
+int usdf_ep_getopt_unconnected(fid_t fid, int level, int optname, void *optval,
+		size_t *optlen)
+{
+	USDF_TRACE_SYS(EP_CTRL, "\n");
+
+	return -FI_ENOPROTOOPT;
+}
+
+
+int usdf_ep_setopt(fid_t fid, int level, int optname, const void *optval,
+		size_t optlen)
+{
+	USDF_TRACE_SYS(EP_CTRL, "\n");
+
+	return -FI_ENOPROTOOPT;
 }

--- a/prov/usnic/src/usdf_endpoint.h
+++ b/prov/usnic/src/usdf_endpoint.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -46,6 +46,13 @@ int usdf_ep_rdm_open(struct fid_domain *domain, struct fi_info *info,
 int usdf_ep_msg_get_queues(struct usdf_ep *ep);
 void usdf_ep_msg_release_queues(struct usdf_ep *ep);
 int usdf_msg_upd_lcl_addr(struct usdf_ep *ep);
+
+int usdf_ep_getopt_connected(fid_t fid, int level, int optname, void *optval,
+		size_t *optlen);
+int usdf_ep_getopt_unconnected(fid_t fid, int level, int optname, void *optval,
+		size_t *optlen);
+int usdf_ep_setopt(fid_t fid, int level, int optname, const void *optval,
+		size_t optlen);
 
 extern struct fi_ops usdf_ep_ops;
 

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -552,43 +552,6 @@ usdf_ep_msg_enable(struct fid_ep *fep)
 	return usdf_ep_msg_get_queues(ep_ftou(fep));
 }
 
-static int
-usdf_ep_msg_getopt(fid_t fid, int level, int optname,
-		  void *optval, size_t *optlen)
-{
-	USDF_TRACE_SYS(EP_CTRL, "\n");
-
-	if (level != FI_OPT_ENDPOINT)
-		return -FI_ENOPROTOOPT;
-
-	switch (optname) {
-	case FI_OPT_CM_DATA_SIZE:
-		if (*optlen < sizeof(size_t))
-			return -FI_ETOOSMALL;
-		*((size_t *) optval) = USDF_MAX_CONN_DATA;
-		*optlen = sizeof(size_t);
-		break;
-	case FI_OPT_ENDPOINT:
-		return -FI_ENOPROTOOPT;
-	default:
-		return -FI_ENOPROTOOPT;
-	}
-
-	return FI_SUCCESS;
-}
-
-static int
-usdf_ep_msg_setopt(fid_t fid, int level, int optname,
-		  const void *optval, size_t optlen)
-{
-	USDF_TRACE_SYS(EP_CTRL, "\n");
-
-	switch (optname) {
-	default:
-		return -FI_ENOPROTOOPT;
-	}
-}
-
 static ssize_t
 usdf_ep_msg_cancel(fid_t fid, void *context)
 {
@@ -829,7 +792,7 @@ usdf_ep_msg_close(fid_t fid)
 		atomic_dec(&ep->ep_eq->eq_refcnt);
 	}
 	usdf_timer_free(ep->ep_domain->dom_fabric, ep->e.msg.ep_ack_timer);
-	
+
 	free(ep);
 	return 0;
 }
@@ -837,8 +800,8 @@ usdf_ep_msg_close(fid_t fid)
 static struct fi_ops_ep usdf_base_msg_ops = {
 	.size = sizeof(struct fi_ops_ep),
 	.cancel = usdf_ep_msg_cancel,
-	.getopt = usdf_ep_msg_getopt,
-	.setopt = usdf_ep_msg_setopt,
+	.getopt = usdf_ep_getopt_connected,
+	.setopt = usdf_ep_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = usdf_msg_rx_size_left,

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -543,46 +543,6 @@ usdf_ep_rdm_enable(struct fid_ep *fep)
 	return usdf_ep_rdm_get_queues(ep_ftou(fep));
 }
 
-static int
-usdf_ep_rdm_getopt(fid_t fid, int level, int optname,
-		  void *optval, size_t *optlen)
-{
-	struct usdf_ep *ep;
-
-	USDF_TRACE_SYS(EP_CTRL, "\n");
-
-	ep = ep_fidtou(fid);
-	(void)ep;
-
-	switch (level) {
-	case FI_OPT_ENDPOINT:
-		return -FI_ENOPROTOOPT;
-	default:
-		return -FI_ENOPROTOOPT;
-	}
-	return 0;
-}
-
-static int
-usdf_ep_rdm_setopt(fid_t fid, int level, int optname,
-		  const void *optval, size_t optlen)
-{
-	struct usdf_ep *ep;
-
-	USDF_TRACE_SYS(EP_CTRL, "\n");
-
-	ep = ep_fidtou(fid);
-	(void)ep;
-
-	switch (level) {
-	case FI_OPT_ENDPOINT:
-		return -FI_ENOPROTOOPT;
-	default:
-		return -FI_ENOPROTOOPT;
-	}
-	return 0;
-}
-
 static ssize_t
 usdf_ep_rdm_cancel(fid_t fid, void *context)
 {
@@ -835,7 +795,7 @@ usdf_rx_rdm_port_bind(struct usdf_rx *rx, struct fi_info *info)
 		sin->sin_addr.s_addr =
 			rx->rx_domain->dom_fabric->fab_dev_attrs->uda_ipaddr_be;
 	}
-		
+
 	rx->r.rdm.rx_sock = socket(AF_INET, SOCK_DGRAM, 0);
 	if (rx->r.rdm.rx_sock == -1) {
 		return -errno;
@@ -885,7 +845,7 @@ usdf_ep_rdm_close(fid_t fid)
 	if (ep->ep_eq != NULL) {
 		atomic_dec(&ep->ep_eq->eq_refcnt);
 	}
-	
+
 	free(ep);
 	return 0;
 }
@@ -893,8 +853,8 @@ usdf_ep_rdm_close(fid_t fid)
 static struct fi_ops_ep usdf_base_rdm_ops = {
 	.size = sizeof(struct fi_ops_ep),
 	.cancel = usdf_ep_rdm_cancel,
-	.getopt = usdf_ep_rdm_getopt,
-	.setopt = usdf_ep_rdm_setopt,
+	.getopt = usdf_ep_getopt_unconnected,
+	.setopt = usdf_ep_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = usdf_rdm_rx_size_left,

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -63,6 +63,7 @@
 #include "usnic_direct.h"
 #include "usd.h"
 #include "usdf.h"
+#include "usdf_endpoint.h"
 #include "usdf_cm.h"
 #include "usdf_msg.h"
 
@@ -496,8 +497,8 @@ struct fi_ops usdf_pep_ops = {
 static struct fi_ops_ep usdf_pep_base_ops = {
 	.size = sizeof(struct fi_ops_ep),
 	.cancel = fi_no_cancel,
-	.getopt = fi_no_getopt,
-	.setopt = fi_no_setopt,
+	.getopt = usdf_ep_getopt_connected,
+	.setopt = usdf_ep_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = fi_no_rx_size_left,


### PR DESCRIPTION
- Unify into connected vs. unconnected as it is likely that the only
  differing call is to get the CM size.
- Support getopt in passive endpoints to retrieve the CM size. Since the
  only CM data we support is on MSG, the implementations should not
  differ.
- Set the length of the field before returning in error cases.
- Unify the setopt and getopt implementations that return ENOPROTOOPT
  into common code.

@goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>