### PR TITLE
prov/gni: Revert getname/av_insert straddr changes

### DIFF
--- a/prov/gni/include/gnix_av.h
+++ b/prov/gni/include/gnix_av.h
@@ -159,16 +159,6 @@ int _gnix_map_reverse_lookup(struct gnix_fid_av *int_av,
 /**
  * @brief Return the string representation of the FI address.
  *
- * @param[in]   buf         The buffer that contains the address string.
- * @param(out)  gnix_ep     The gnix_ep_name structure that contains the
- * @return      FI_SUCCESS on success or -FI_EINVAL on error.
- */
-int gnix_av_straddr_to_ep_name(char *buf,
-			       struct gnix_ep_name *gnix_ep);
-
-/**
- * @brief Return the string representation of the FI address.
- *
  * @param[in]      av      The AV to use.
  * @param[in]      addr    The GNIX address to translate.
  * @param[in/out]  buf     The buffer that contains the address string.

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -85,133 +85,6 @@ static int gnix_verify_av_attr(struct fi_av_attr *attr)
 }
 
 /*
- * Given a string that contains the string representation of gnix_ep_name.
- * Parse this string and return the values in a gnix_ep_name structure.
- */
-int gnix_av_straddr_to_ep_name(char *buf,
-			       struct gnix_ep_name *gnix_ep)
-{
-	uint32_t cdm_id;
-	uint32_t cm_nic_cdm_id;
-	uint32_t cookie;
-	uint32_t device_addr;
-	char *int_buf;
-	uint32_t name_type;
-	int ret = FI_SUCCESS;
-	char *save_ptr = NULL;
-	char temp_buf[GNIX_AV_MAX_STR_ADDR_LEN];
-	uint32_t version;
-
-	if ((buf == NULL) || (gnix_ep == NULL)) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	memset(temp_buf, 0, GNIX_AV_MAX_STR_ADDR_LEN);
-	strncpy(temp_buf, buf, (GNIX_AV_MAX_STR_ADDR_LEN - 1));
-
-	errno = 0;
-	gnix_ep->gnix_addr.device_addr = 0;
-	gnix_ep->gnix_addr.cdm_id = 0;
-	gnix_ep->name_type = 0;
-	gnix_ep->cm_nic_cdm_id = 0;
-	gnix_ep->cookie = 0;
-
-	/* extract the version component */
-	int_buf = strtok_r(temp_buf, ":", &save_ptr);
-	if (int_buf == NULL) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	version = (uint32_t) strtol(int_buf, NULL, 10);
-	if (errno != 0) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	if ((version == 0) || (version > GNIX_AV_STR_ADDR_VERSION)) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	/* extract the device_addr component */
-	int_buf = strtok_r(NULL, ":", &save_ptr);
-	if (int_buf == NULL) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	device_addr = (uint32_t) strtol(int_buf, NULL, 16);
-	if (errno != 0) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	/* extract the cdm_id component */
-	int_buf = strtok_r(NULL, ":", &save_ptr);
-	if (int_buf == NULL) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	cdm_id = (uint32_t) strtol(int_buf, NULL, 16);
-	if (errno != 0) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	/* extract the name_type component */
-	int_buf = strtok_r(NULL, ":", &save_ptr);
-	if (int_buf == NULL) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	name_type = (uint32_t) strtol(int_buf, NULL, 10);
-	if (errno != 0) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	/* extract the cm_nic_cdm_id component */
-	int_buf = strtok_r(NULL, ":", &save_ptr);
-	if (int_buf == NULL) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	cm_nic_cdm_id = (uint32_t) strtol(int_buf, NULL, 16);
-	if (errno != 0) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	/* extract the cookie component */
-	int_buf = strtok_r(NULL, ":", &save_ptr);
-	if (int_buf == NULL) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	cookie = (uint32_t) strtol(int_buf, NULL, 16);
-	if (errno != 0) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
-
-	/* check to see if additional component are specified */
-	gnix_ep->gnix_addr.device_addr = device_addr;
-	gnix_ep->gnix_addr.cdm_id = cdm_id;
-	gnix_ep->name_type = name_type;
-	gnix_ep->cm_nic_cdm_id = cm_nic_cdm_id;
-	gnix_ep->cookie = cookie;
-
-err:
-	return ret;
-}
-
-/*
  * Check the capacity of the internal table used to represent FI_AV_TABLE type
  * address vectors. Initially the table starts with a capacity and count of 0
  * and the capacity increases by roughly double each time a resize is necessary.
@@ -275,10 +148,8 @@ static int table_insert(struct gnix_fid_av *int_av, const void *addr,
 			size_t count, fi_addr_t *fi_addr, uint64_t flags,
 			void *context)
 {
-	struct gnix_ep_name temp;
-	char *temp_addr = (char *) addr;
+	struct gnix_ep_name *temp = NULL;
 	int ret = count;
-	int rc;
 	size_t index;
 	size_t i;
 
@@ -289,30 +160,15 @@ static int table_insert(struct gnix_fid_av *int_av, const void *addr,
 
 	assert(int_av->table);
 	for (index = int_av->count, i = 0; i < count; index++, i++) {
-		temp.gnix_addr.device_addr = 0;
-		temp.gnix_addr.cdm_id = 0;
-		temp.name_type = 0;
-		temp.cm_nic_cdm_id = 0;
-		temp.cookie = 0;
-
-		rc = gnix_av_straddr_to_ep_name(temp_addr, &temp);
-		if (rc != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_AV,
-				  "table_insert: gnix_av_straddr_to_ep_name failed %d\n",
-				  ret);
-			return ret;
-		}
-
-		int_av->table[index].gnix_addr = temp.gnix_addr;
+		temp = &((struct gnix_ep_name *)addr)[i];
+		int_av->table[index].gnix_addr = temp->gnix_addr;
 		int_av->valid_entry_vec[index] = 1;
-		int_av->table[index].name_type = temp.name_type;
-		int_av->table[index].cookie = temp.cookie;
+		int_av->table[index].name_type = temp->name_type;
+		int_av->table[index].cookie = temp->cookie;
 		int_av->table[index].cm_nic_cdm_id =
-				temp.cm_nic_cdm_id;
+				temp->cm_nic_cdm_id;
 		if (fi_addr)
 			fi_addr[i] = index;
-
-		temp_addr += GNIX_AV_MAX_STR_ADDR_LEN;
 	}
 
 	int_av->count += count;
@@ -405,8 +261,7 @@ static int map_insert(struct gnix_fid_av *int_av, const void *addr,
 		      void *context)
 {
 	int ret;
-	struct gnix_ep_name temp;
-	char *temp_addr = (char *) addr;
+	struct gnix_ep_name *temp = NULL;
 	struct gnix_av_addr_entry *the_entry;
 	gnix_ht_key_t key;
 	size_t i;
@@ -430,28 +285,15 @@ static int map_insert(struct gnix_fid_av *int_av, const void *addr,
 	slist_insert_tail(&blk->slist, &int_av->block_list);
 
 	for (i = 0; i < count; i++) {
-		temp.gnix_addr.device_addr = 0;
-		temp.gnix_addr.cdm_id = 0;
-		temp.name_type = 0;
-		temp.cm_nic_cdm_id = 0;
-		temp.cookie = 0;
-
-		ret = gnix_av_straddr_to_ep_name(temp_addr, &temp);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_AV,
-				  "map_insert: gnix_av_straddr_to_ep_name failed %d\n",
-				  ret);
-			return ret;
-		}
-
-		((struct gnix_address *)fi_addr)[i] = temp.gnix_addr;
+		temp = &((struct gnix_ep_name *)addr)[i];
+		((struct gnix_address *)fi_addr)[i] = temp->gnix_addr;
 		the_entry =  &blk->base[i];
-		memcpy(&the_entry->gnix_addr, &temp.gnix_addr,
+		memcpy(&the_entry->gnix_addr, &temp->gnix_addr,
 		       sizeof(struct gnix_address));
-		the_entry->name_type = temp.name_type;
-		the_entry->cm_nic_cdm_id = temp.cm_nic_cdm_id;
-		the_entry->cookie = temp.cookie;
-		memcpy(&key, &temp.gnix_addr, sizeof(gnix_ht_key_t));
+		the_entry->name_type = temp->name_type;
+		the_entry->cm_nic_cdm_id = temp->cm_nic_cdm_id;
+		the_entry->cookie = temp->cookie;
+		memcpy(&key, &temp->gnix_addr, sizeof(gnix_ht_key_t));
 		ret = _gnix_ht_insert(int_av->map_ht,
 				      key,
 				      the_entry);
@@ -461,12 +303,11 @@ static int map_insert(struct gnix_fid_av *int_av, const void *addr,
 		 */
 		if ((ret != FI_SUCCESS) && (ret != -FI_ENOSPC)) {
 			GNIX_WARN(FI_LOG_AV,
-				  "map_insert: _gnix_ht_insert failed %d\n",
+				  "_gnix_ht_insert failed %d\n",
 				  ret);
 			return ret;
 		}
 
-		temp_addr += GNIX_AV_MAX_STR_ADDR_LEN;
 	}
 
 	return count;
@@ -642,8 +483,8 @@ DIRECT_FN STATIC int gnix_av_lookup(struct fid_av *av, fi_addr_t fi_addr,
 	if (!av || !addrlen)
 		return -FI_EINVAL;
 
-	if (*addrlen < GNIX_AV_MAX_STR_ADDR_LEN) {
-		*addrlen = GNIX_AV_MAX_STR_ADDR_LEN;
+	if (*addrlen < sizeof(ep_name)) {
+		*addrlen = sizeof(ep_name);
 		return -FI_ETOOSMALL;
 	}
 
@@ -669,7 +510,8 @@ DIRECT_FN STATIC int gnix_av_lookup(struct fid_av *av, fi_addr_t fi_addr,
 	ep_name.cm_nic_cdm_id = entry->cm_nic_cdm_id;
 	ep_name.cookie = entry->cookie;
 
-	gnix_av_straddr(NULL, (void *) &ep_name, (char *) addr, addrlen);
+	memcpy(addr, (void *)&ep_name, MIN(*addrlen, sizeof(ep_name)));
+	*addrlen = sizeof(ep_name);
 
 	return FI_SUCCESS;
 }
@@ -770,12 +612,11 @@ err:
  * hexadecimal. And name_type is represented as an integer.
  */
 DIRECT_FN const char *gnix_av_straddr(struct fid_av *av,
-				      const void *addr, char *buf,
-				      size_t *len)
+		const void *addr, char *buf,
+		size_t *len)
 {
 	char int_buf[GNIX_AV_MAX_STR_ADDR_LEN];
 	int size;
-
 	const struct gnix_ep_name *gnix_ep = addr;
 
 	/*
@@ -784,15 +625,14 @@ DIRECT_FN const char *gnix_av_straddr(struct fid_av *av,
 	 *   GNIX_AV_STR_ADDR_VERSION, increment this value
 	 *   GNIX_AV_MAX_STR_ADDR_LEN, to be the number of characters printed
 	 */
-	size =
-	    snprintf(int_buf, sizeof(int_buf), "%04i:0x%08" PRIx32 ":0x%08"
-		     PRIx32 ":%02i:0x%06" PRIx32 ":0x%08" PRIx32,
-		     GNIX_AV_STR_ADDR_VERSION,
-		     gnix_ep->gnix_addr.device_addr,
-		     gnix_ep->gnix_addr.cdm_id,
-		     gnix_ep->name_type,
-		     gnix_ep->cm_nic_cdm_id,
-		     gnix_ep->cookie);
+	size = snprintf(int_buf, sizeof(int_buf), "%04i:0x%08" PRIx32 ":0x%08"
+			PRIx32 ":%02i:0x%06" PRIx32 ":0x%08" PRIx32,
+			GNIX_AV_STR_ADDR_VERSION,
+			gnix_ep->gnix_addr.device_addr,
+			gnix_ep->gnix_addr.cdm_id,
+			gnix_ep->name_type,
+			gnix_ep->cm_nic_cdm_id,
+			gnix_ep->cookie);
 
 	/*
 	 * snprintf returns the number of character written

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -44,7 +44,6 @@
 #include "gnix_cm_nic.h"
 #include "gnix_nic.h"
 #include "gnix_hashtable.h"
-#include "gnix_av.h"
 
 
 #define GNIX_CM_NIC_BND_TAG (100)
@@ -484,7 +483,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	struct gnix_cm_nic *cm_nic = NULL;
 	uint32_t cdm_id, seed;
 	gnix_hashtable_attr_t gnix_ht_attr = {0};
-	struct gnix_ep_name name;
+	struct gnix_ep_name *name;
 	uint32_t name_type = GNIX_EPN_TYPE_UNBOUND;
 	struct gnix_nic_attr nic_attr = {0};
 
@@ -501,12 +500,12 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	 */
 
 	if (info->src_addr &&
-	    info->src_addrlen == GNIX_AV_MAX_STR_ADDR_LEN) {
-		gnix_av_straddr_to_ep_name(info->src_addr, &name);
-		if (name.name_type == GNIX_EPN_TYPE_BOUND) {
+	    info->src_addrlen == sizeof(struct gnix_ep_name)) {
+		name = (struct gnix_ep_name *)info->src_addr;
+		if (name->name_type == GNIX_EPN_TYPE_BOUND) {
 			/* EP name includes user specified service/port */
-			cdm_id = name.gnix_addr.cdm_id;
-			name_type = name.name_type;
+			cdm_id = name->gnix_addr.cdm_id;
+			name_type = name->name_type;
 		}
 	}
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -59,7 +59,6 @@
 #include "gnix_util.h"
 #include "gnix_nameserver.h"
 #include "gnix_wait.h"
-#include "gnix_av.h"
 
 const char gnix_fab_name[] = "gni";
 const char gnix_dom_name[] = "/sys/class/gni/kgni0";
@@ -179,8 +178,6 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	struct gnix_ep_name *dest_addr = NULL;
 	struct gnix_ep_name *src_addr = NULL;
 	struct gnix_ep_name *addr = NULL;
-	char *str_src_addr = NULL;
-	char *str_dest_addr = NULL;
 
 	/*
 	 * the code below for resolving a node/service to what
@@ -255,30 +252,10 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 
 	gnix_info->next = NULL;
 	gnix_info->addr_format = FI_ADDR_GNI;
-	gnix_info->src_addrlen = 0;
-	gnix_info->dest_addrlen = 0;
-	gnix_info->src_addr = NULL;
-	gnix_info->dest_addr = NULL;
-	if (src_addr) {
-		str_src_addr = malloc(GNIX_AV_MAX_STR_ADDR_LEN);
-		if (!str_src_addr) {
-			goto err;
-		}
-		gnix_info->src_addrlen = GNIX_AV_MAX_STR_ADDR_LEN;
-		gnix_av_straddr(NULL, (void *) src_addr, (char *) str_src_addr,
-			 &gnix_info->src_addrlen);
-		gnix_info->src_addr = str_src_addr;
-	}
-	if (dest_addr) {
-		str_dest_addr = malloc(GNIX_AV_MAX_STR_ADDR_LEN);
-		if (!str_dest_addr) {
-			goto err;
-		}
-		gnix_info->dest_addrlen = GNIX_AV_MAX_STR_ADDR_LEN;
-		gnix_av_straddr(NULL, (void *) addr, (char *) str_dest_addr,
-			 &gnix_info->dest_addrlen);
-		gnix_info->dest_addr = str_dest_addr;
-	}
+	gnix_info->src_addrlen = sizeof(struct gnix_ep_name);
+	gnix_info->dest_addrlen = sizeof(struct gnix_ep_name);
+	gnix_info->src_addr = src_addr;
+	gnix_info->dest_addr = dest_addr;
 	/* prov_name gets filled in by fi_getinfo from the gnix_prov struct */
 	/* let's consider gni copyrighted :) */
 
@@ -474,18 +451,6 @@ err:
 		if (gnix_info->domain_attr) free(gnix_info->domain_attr);
 		if (gnix_info->fabric_attr) free(gnix_info->fabric_attr);
 		free(gnix_info);
-	}
-
-	if (addr) {
-		free(addr);
-	}
-
-	if (str_src_addr) {
-		free(str_src_addr);
-	}
-
-	if (str_dest_addr) {
-		free(str_dest_addr);
 	}
 
 	/*


### PR DESCRIPTION
Revert getname/av_insert straddr changes.  Re-add fi_straddr() implementation.

This reverts commit ofi-cray/libfabric-cray@51f1f43bc0f362e6037a495c97c839d4d80fb355.
upstream merge of ofi-cray/libfabric-cray#814

@ztiffany please double check

Signed-off-by: Zach Tiffany <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@9c8f30debd0b0aedf9099047fc8696528345475d)