### PR TITLE
added unix-specific API abstraction

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -85,15 +85,21 @@ src_libfabric_la_SOURCES = \
 
 if MACOS
 src_libfabric_la_SOURCES += src/osx/osd.c
+src_libfabric_la_SOURCES += src/unix/osd.c
 src_libfabric_la_SOURCES += include/osx/osd.h
+src_libfabric_la_SOURCES += include/unix/osd.h
 endif
 
 if FREEBSD
+src_libfabric_la_SOURCES += src/unix/osd.c
 src_libfabric_la_SOURCES += include/freebsd/osd.h
+src_libfabric_la_SOURCES += include/unix/osd.h
 endif
 
 if LINUX
+src_libfabric_la_SOURCES += src/unix/osd.c
 src_libfabric_la_SOURCES += include/linux/osd.h
+src_libfabric_la_SOURCES += include/unix/osd.h
 endif
 
 src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)

--- a/include/fi_mem.h
+++ b/include/fi_mem.h
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <fi_list.h>
+#include <fi_osd.h>
 
 
 #ifdef INCLUDE_VALGRIND

--- a/include/fi_signal.h
+++ b/include/fi_signal.h
@@ -43,6 +43,7 @@
 #include <sys/socket.h>
 
 #include <fi_file.h>
+#include <fi_osd.h>
 #include <rdma/fi_errno.h>
 
 
@@ -65,29 +66,29 @@ static inline int fd_signal_init(struct fd_signal *signal)
 	if (ret < 0)
 		return -errno;
 
-	ret = fcntl(signal->fd[FI_READ_FD], F_SETFL, O_NONBLOCK);
-	if (ret < 0)
+	ret = fi_fd_nonblock(signal->fd[FI_READ_FD]);
+	if (ret)
 		goto err;
 
 	return 0;
 
 err:
-	close(signal->fd[0]);
-	close(signal->fd[1]);
+	ofi_close_socket(signal->fd[0]);
+	ofi_close_socket(signal->fd[1]);
 	return -errno;
 }
 
 static inline void fd_signal_free(struct fd_signal *signal)
 {
-	close(signal->fd[0]);
-	close(signal->fd[1]);
+	ofi_close_socket(signal->fd[0]);
+	ofi_close_socket(signal->fd[1]);
 }
 
 static inline void fd_signal_set(struct fd_signal *signal)
 {
 	char c = 0;
 	if (signal->wcnt == signal->rcnt) {
-		if (write(signal->fd[FI_WRITE_FD], &c, sizeof c) == sizeof c)
+		if (ofi_write_socket(signal->fd[FI_WRITE_FD], &c, sizeof c) == sizeof c)
 			signal->wcnt++;
 	}
 }
@@ -96,7 +97,7 @@ static inline void fd_signal_reset(struct fd_signal *signal)
 {
 	char c;
 	if (signal->rcnt != signal->wcnt) {
-		if (read(signal->fd[FI_READ_FD], &c, sizeof c) == sizeof c)
+		if (ofi_read_socket(signal->fd[FI_READ_FD], &c, sizeof c) == sizeof c)
 			signal->rcnt++;
 	}
 }

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -35,6 +35,7 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <pthread.h>
+#include <stdio.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_atomic.h>

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -35,7 +35,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <sys/socket.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -33,10 +33,8 @@
 #ifndef FI_ENDPOINT_H
 #define FI_ENDPOINT_H
 
-#include <sys/socket.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
-#include <stddef.h>
 
 
 #ifdef __cplusplus

--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -33,8 +33,6 @@
 #ifndef FI_TRIGGER_H
 #define FI_TRIGGER_H
 
-#include <stdint.h>
-#include <stddef.h>
 #include <rdma/fabric.h>
 
 #ifdef __cplusplus

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -30,18 +30,36 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_OSD_H_
-#define _FI_OSD_H_
+#ifndef _FI_UNIX_OSD_H_
+#define _FI_UNIX_OSD_H_
 
-#ifdef __APPLE__
-#include <osx/osd.h>
-#include <unix/osd.h>
-#elif defined __FreeBSD__
-#include <freebsd/osd.h>
-#include <unix/osd.h>
-#else
-#include <linux/osd.h>
-#include <unix/osd.h>
-#endif
+#include <stdlib.h>
+#include <unistd.h>
 
-#endif /* _FI_OSD_H_ */
+static inline int ofi_memalign(void **memptr, size_t alignment, size_t size)
+{
+	return posix_memalign(memptr, alignment, size);
+}
+
+static inline void ofi_freealign(void *memptr)
+{
+	free(memptr);
+}
+
+static inline ssize_t ofi_read_socket(int fd, void *buf, size_t count)
+{
+	return read(fd, buf, count);
+}
+
+static inline ssize_t ofi_write_socket(int fd, const void *buf, size_t count)
+{
+	return write(fd, buf, count);
+}
+
+static inline int ofi_close_socket(int socket)
+{
+	return close(socket);
+}
+
+#endif /* _FI_UNIX_OSD_H_ */
+

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -63,6 +63,7 @@ extern "C" {
 #include <fi_indexer.h>
 #include <fi_rbuf.h>
 #include <fi_list.h>
+#include <fi_file.h>
 #include "gni_pub.h"
 #include "gnix_util.h"
 #include "gnix_freelist.h"

--- a/prov/gni/include/gnix_trigger.h
+++ b/prov/gni/include/gnix_trigger.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -34,13 +35,19 @@
  * Triggered operations handling.
  */
 
-#ifndef _GNIX_TRIGGER_H_
-#define _GNIX_TRIGGER_H_
+#ifndef GNIX_TRIGGER_H_
+#define GNIX_TRIGGER_H_
 
 #include "gnix.h"
 #include "gnix_cntr.h"
+#include "gnix_vc.h"
 
 int _gnix_trigger_queue_req(struct gnix_fab_req *req);
 void _gnix_trigger_check_cntr(struct gnix_fid_cntr *cntr);
 
-#endif
+static inline int _gnix_trigger_pending(struct gnix_fid_cntr *cntr)
+{
+	return dlist_empty(&cntr->trigger_list) ? 0 : 1;
+}
+
+#endif /* GNIX_TRIGGER_H */

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -455,7 +456,7 @@ static void __nic_get_completed_txd(struct gnix_nic *nic,
 	assert(status == GNI_RC_SUCCESS ||
 	       status == GNI_RC_TRANSACTION_ERROR);
 
-	if (status == GNI_RC_TRANSACTION_ERROR) {
+	if (unlikely(status == GNI_RC_TRANSACTION_ERROR)) {
 		status = GNI_CqErrorRecoverable(cqe, &recov);
 		if (status != GNI_RC_SUCCESS || !recov) {
 			char ebuf[512];
@@ -535,11 +536,11 @@ int _gnix_nic_progress(struct gnix_nic *nic)
 	}
 
 	ret = __nic_rx_progress(nic);
-	if (unlikely(ret != FI_SUCCESS))
+	if (ret != FI_SUCCESS)
 		return ret;
 
 	ret = _gnix_vc_nic_progress(nic);
-	if (unlikely(ret != FI_SUCCESS))
+	if (ret != FI_SUCCESS)
 		return ret;
 
 	return ret;

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -935,7 +936,7 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 		req->flags |= GNIX_RMA_RDMA;
 	}
 
-	GNIX_INFO(FI_LOG_EP_DATA, "Queuing (%p %p %d)\n",
+	GNIX_DEBUG(FI_LOG_EP_DATA, "Queuing (%p %p %d)\n",
 		  (void *)loc_addr, (void *)rem_addr, len);
 
 	return _gnix_vc_queue_tx_req(req);

--- a/prov/gni/src/gnix_trigger.c
+++ b/prov/gni/src/gnix_trigger.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
+ *
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -96,11 +98,13 @@ void _gnix_trigger_check_cntr(struct gnix_fid_cntr *cntr)
 	struct fi_triggered_context *trigger_context;
 	struct fi_trigger_threshold *threshold;
 	struct gnix_fab_req *req, *req2;
-	size_t count = atomic_get(&cntr->cnt);
+	size_t count;
 
-	if (dlist_empty(&cntr->trigger_list)) {
+	if (likely(dlist_empty(&cntr->trigger_list))) {
 		return;
 	}
+
+	 count = atomic_get(&cntr->cnt);
 
 	fastlock_acquire(&cntr->trigger_lock);
 	dlist_for_each_safe(&cntr->trigger_list, req, req2, dlist) {
@@ -122,4 +126,3 @@ void _gnix_trigger_check_cntr(struct gnix_fid_cntr *cntr)
 	}
 	fastlock_release(&cntr->trigger_lock);
 }
-

--- a/prov/gni/src/gnix_wait.c
+++ b/prov/gni/src/gnix_wait.c
@@ -190,8 +190,6 @@ static int gnix_verify_wait_attr(struct fi_wait_attr *attr)
 
 static int gnix_init_wait_obj(struct gnix_fid_wait *wait, enum fi_wait_obj type)
 {
-	long flags = 0;
-
 	GNIX_TRACE(WAIT_SUB, "\n");
 
 	wait->type = type;
@@ -201,8 +199,7 @@ static int gnix_init_wait_obj(struct gnix_fid_wait *wait, enum fi_wait_obj type)
 		if (socketpair(AF_LOCAL, SOCK_STREAM, 0, wait->fd))
 			goto err;
 
-		fcntl(wait->fd[WAIT_READ], F_GETFL, &flags);
-		if (fcntl(wait->fd[WAIT_READ], F_SETFL, flags | O_NONBLOCK))
+		if (fi_fd_nonblock(wait->fd[WAIT_READ]))
 			goto cleanup;
 		break;
 	case FI_WAIT_MUTEX_COND:

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -67,6 +67,7 @@ extern "C" {
 #include "fi_enosys.h"
 #include "fi_list.h"
 #include "fi_util.h"
+#include "fi_file.h"
 #include "rbtree.h"
 #include "version.h"
 

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -53,6 +53,7 @@
 #include <fi_indexer.h>
 #include <fi_rbuf.h>
 #include <fi_list.h>
+#include <fi_file.h>
 #include <rbtree.h>
 
 #ifndef _SOCK_H_

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -49,7 +49,7 @@ static ssize_t sock_comm_send_socket(struct sock_conn *conn,
 {
 	ssize_t ret;
 
-	ret = write(conn->sock_fd, buf, len);
+	ret = ofi_write_socket(conn->sock_fd, buf, len);
 	if (ret < 0) {
 		if (errno == EAGAIN || errno == EWOULDBLOCK) {
 			ret = 0;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -305,7 +305,7 @@ static int sock_pep_create_listener(struct sock_pep *pep)
 
 			if (!bind(pep->cm.sock, s_res->ai_addr, s_res->ai_addrlen))
 				break;
-			close(pep->cm.sock);
+			ofi_close_socket(pep->cm.sock);
 			pep->cm.sock = -1;
 		}
 	}
@@ -416,7 +416,7 @@ static int sock_ep_cm_enqueue_msg(struct sock_cm_entry *cm,
 	dlist_insert_tail(&list_entry->entry, &cm->msg_list);
 	fastlock_release(&cm->lock);
 
-	ret = write(cm->signal_fds[0], &c, 1);
+	ret = ofi_write_socket(cm->signal_fds[0], &c, 1);
 	if (ret != 1) {
 		SOCK_LOG_DBG("failed to signal\n");
 		ret = -FI_EIO;
@@ -616,7 +616,7 @@ static void *sock_msg_ep_listener_thread(void *data)
 		ret = poll(poll_fds, 2, timeout);
 		if (ret > 0) {
 			if (poll_fds[1].revents & POLLIN) {
-				ret = read(ep->attr->cm.signal_fds[1], &tmp, 1);
+				ret = ofi_read_socket(ep->attr->cm.signal_fds[1], &tmp, 1);
 				if (ret != 1) {
 					SOCK_LOG_DBG("Invalid signal\n");
 					break;
@@ -719,7 +719,7 @@ static void *sock_msg_ep_listener_thread(void *data)
 out:
 	free(conn_response);
 	free(cm_entry);
-	close(ep->attr->cm.sock);
+	ofi_close_socket(ep->attr->cm.sock);
 	return NULL;
 }
 
@@ -965,7 +965,7 @@ static int sock_pep_fi_close(fid_t fid)
 
 	pep = container_of(fid, struct sock_pep, pep.fid);
 	pep->cm.do_listen = 0;
-	ret = write(pep->cm.signal_fds[0], &c, 1);
+	ret = ofi_write_socket(pep->cm.signal_fds[0], &c, 1);
 	if (ret != 1)
 		SOCK_LOG_DBG("Failed to signal\n");
 
@@ -974,8 +974,8 @@ static int sock_pep_fi_close(fid_t fid)
 		SOCK_LOG_DBG("pthread join failed\n");
 	}
 
-	close(pep->cm.signal_fds[0]);
-	close(pep->cm.signal_fds[1]);
+	ofi_close_socket(pep->cm.signal_fds[0]);
+	ofi_close_socket(pep->cm.signal_fds[1]);
 	fastlock_destroy(&pep->cm.lock);
 
 	free(pep);
@@ -1040,7 +1040,7 @@ static void *sock_pep_listener_thread(void *data)
 					SOCK_CM_COMM_TIMEOUT;
 		if (poll(poll_fds, 2, timeout) > 0) {
 			if (poll_fds[1].revents & POLLIN) {
-				ret = read(pep->cm.signal_fds[1], &tmp, 1);
+				ret = ofi_read_socket(pep->cm.signal_fds[1], &tmp, 1);
 				if (ret != 1)
 					SOCK_LOG_DBG("Invalid signal\n");
 				sock_ep_cm_flush_msg(&pep->cm);
@@ -1129,7 +1129,7 @@ out:
 	if (handle)
 		free(handle);
 	free(cm_entry);
-	close(pep->cm.sock);
+	ofi_close_socket(pep->cm.sock);
 	return NULL;
 }
 

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -407,7 +407,7 @@ int sock_get_src_addr(struct sockaddr_in *dest_addr,
 		ret = -errno;
 	}
 out:
-	close(sock);
+	ofi_close_socket(sock);
 	return ret;
 }
 

--- a/prov/usnic/src/usdf_cm.c
+++ b/prov/usnic/src/usdf_cm.c
@@ -55,6 +55,7 @@
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>
 #include "fi.h"
+#include "fi_file.h"
 
 #include "usnic_direct.h"
 #include "usdf.h"
@@ -414,13 +415,8 @@ usdf_cm_msg_connect(struct fid_ep *fep, const void *addr,
 		ep->e.msg.ep_cm_sock = -1;
 	}
 
-	ret = fcntl(crp->cr_sockfd, F_GETFL, 0);
-	if (ret == -1) {
-		ret = -errno;
-		goto fail;
-	}
-	ret = fcntl(crp->cr_sockfd, F_SETFL, ret | O_NONBLOCK);
-	if (ret == -1) {
+	ret = fi_fd_nonblock(crp->cr_sockfd);
+	if (ret) {
 		ret = -errno;
 		goto fail;
 	}

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -58,6 +58,7 @@
 #include <rdma/fi_errno.h>
 #include "fi.h"
 #include "fi_enosys.h"
+#include "fi_file.h"
 
 #include "fi_ext_usnic.h"
 #include "usnic_direct.h"
@@ -581,16 +582,11 @@ usdf_pep_open(struct fid_fabric *fabric, struct fi_info *info,
 		ret = -errno;
 		goto fail;
 	}
-        ret = fcntl(pep->pep_sock, F_GETFL, 0);
-        if (ret == -1) {
-                ret = -errno;
-                goto fail;
-        }
-        ret = fcntl(pep->pep_sock, F_SETFL, ret | O_NONBLOCK);
-        if (ret == -1) {
-                ret = -errno;
-                goto fail;
-        }
+	ret = fi_fd_nonblock(pep->pep_sock);
+	if (ret) {
+		ret = -errno;
+		goto fail;
+	}
 
 	/* set SO_REUSEADDR to prevent annoying "Address already in use" errors
 	 * on successive runs of programs listening on a well known port */

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -36,6 +36,7 @@
 #include <fi_enosys.h>
 #include <fi_mem.h>
 #include <fi.h>
+#include <fi_osd.h>
 
 #if ENABLE_DEBUG
 static inline int util_buf_use_ftr(struct util_buf_pool *pool)
@@ -75,7 +76,7 @@ int util_buf_grow(struct util_buf_pool *pool)
 	if (!buf_region)
 		return -1;
 
-	ret = posix_memalign((void **)&buf_region->mem_region, pool->alignment,
+	ret = ofi_memalign((void **)&buf_region->mem_region, pool->alignment,
 			     pool->chunk_cnt * pool->entry_sz);
 	if (ret)
 		goto err;
@@ -174,7 +175,7 @@ void util_buf_pool_destroy(struct util_buf_pool *pool)
 #endif
 		if (pool->free_hndlr)
 			pool->free_hndlr(pool->ctx, buf_region->context);
-		free(buf_region->mem_region);
+		ofi_freealign(buf_region->mem_region);
 		free(buf_region);
 	}
 	free(pool);

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -36,6 +36,7 @@
 #include <rdma/rdma_cma.h>
 
 #include <fi_list.h>
+#include <fi_file.h>
 #include <fi_enosys.h>
 #include "../fi_verbs.h"
 #include "verbs_queuing.h"

--- a/prov/verbs/src/verbs_av.c
+++ b/prov/verbs/src/verbs_av.c
@@ -30,6 +30,9 @@
  * SOFTWARE.
  */
 
+#include <pthread.h>
+#include <stdio.h>
+
 #include <fi_enosys.h>
 #include "fi_verbs.h"
 

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -466,10 +466,10 @@ static int fi_ibv_cq_close(fid_t fid)
 	}
 
 	if (cq->signal_fd[0]) {
-		close(cq->signal_fd[0]);
+		ofi_close_socket(cq->signal_fd[0]);
 	}
 	if (cq->signal_fd[1]) {
-		close(cq->signal_fd[1]);
+		ofi_close_socket(cq->signal_fd[1]);
 	}
 
 	if (cq->channel)
@@ -596,8 +596,8 @@ int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 err4:
 	ibv_destroy_cq(_cq->cq);
 err3:
-	close(_cq->signal_fd[0]);
-	close(_cq->signal_fd[1]);
+	ofi_close_socket(_cq->signal_fd[0]);
+	ofi_close_socket(_cq->signal_fd[1]);
 err2:
 	if (_cq->channel)
 		ibv_destroy_comp_channel(_cq->channel);

--- a/src/common.c
+++ b/src/common.c
@@ -203,21 +203,6 @@ uint64_t fi_gettime_ms(void)
 	return now.tv_sec * 1000 + now.tv_usec / 1000;
 }
 
-int fi_fd_nonblock(int fd)
-{
-	long flags = 0;
-
-	flags = fcntl(fd, F_GETFL);
-	if (flags < 0) {
-		return -errno;
-	}
-
-	if(fcntl(fd, F_SETFL, flags | O_NONBLOCK))
-		return -errno;
-
-	return 0;
-}
-
 #ifndef HAVE_EPOLL
 
 int fi_epoll_create(struct fi_epoll **ep)

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -30,6 +30,9 @@
  * SOFTWARE.
  */
 
+#include <pthread.h>
+#include <stdio.h>
+#include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include "fi_enosys.h"
 

--- a/src/fasthash.c
+++ b/src/fasthash.c
@@ -27,10 +27,13 @@
 
 // Compression function for Merkle-Damgard construction.
 // This function is generated using the framework provided.
-#define mix(h) ({					\
-			(h) ^= (h) >> 23;		\
-			(h) *= 0x2127599bf4325c37ULL;	\
-			(h) ^= (h) >> 47; })
+static inline uint64_t mix(uint64_t h)
+{
+	h ^= h >> 23;
+	h *= 0x2127599bf4325c37ULL;
+	h ^= h >> 47;
+	return h;
+}
 
 uint64_t fasthash64(const void *buf, size_t len, uint64_t seed)
 {
@@ -70,6 +73,6 @@ uint32_t fasthash32(const void *buf, size_t len, uint32_t seed)
 	// the following trick converts the 64-bit hashcode to Fermat
 	// residue, which shall retain information from both the higher
 	// and lower parts of hashcode.
-        uint64_t h = fasthash64(buf, len, seed);
+	uint64_t h = fasthash64(buf, len, seed);
 	return h - (h >> 32);
 }

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -30,18 +30,26 @@
  * SOFTWARE.
  */
 
-#ifndef _FI_OSD_H_
-#define _FI_OSD_H_
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
 
-#ifdef __APPLE__
-#include <osx/osd.h>
-#include <unix/osd.h>
-#elif defined __FreeBSD__
-#include <freebsd/osd.h>
-#include <unix/osd.h>
-#else
-#include <linux/osd.h>
-#include <unix/osd.h>
-#endif
+#include "fi_osd.h"
+#include "fi_file.h"
 
-#endif /* _FI_OSD_H_ */
+int fi_fd_nonblock(int fd)
+{
+	long flags = 0;
+
+	flags = fcntl(fd, F_GETFL);
+	if (flags < 0) {
+		return -errno;
+	}
+
+	if(fcntl(fd, F_SETFL, flags | O_NONBLOCK))
+		return -errno;
+
+	return 0;
+}
+
+


### PR DESCRIPTION
as part of porting OFI into windows platform minor code refactoring
presented:
- removed all system-specific includes from public headers
- added unix specific sources (header & source), common for
  Linux/OSX/FreeBSD
- socket specific (and some other) calls are wrapped into
  abstraction layer & shifted into unix specific sources
- 'mix' macro is replaced by inline function (due to non-standard
  extention used in macro)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>