### PR TITLE
prov/gni: Add kdreg notifier to memory reg cache

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -29,6 +29,7 @@ _gni_files = \
 	prov/gni/src/gnix_mbox_allocator.c \
 	prov/gni/src/gnix_mr.c \
 	prov/gni/src/gnix_mr_cache.c \
+	prov/gni/src/gnix_mr_notifier.c \
 	prov/gni/src/gnix_msg.c \
 	prov/gni/src/gnix_nameserver.c \
 	prov/gni/src/gnix_nic.c \
@@ -60,6 +61,7 @@ _gni_headers = \
 	prov/gni/include/gnix_mbox_allocator.h \
 	prov/gni/include/gnix_mr.h \
 	prov/gni/include/gnix_mr_cache.h \
+	prov/gni/include/gnix_mr_notifier.h \
 	prov/gni/include/gnix_msg.h \
 	prov/gni/include/gnix_nameserver.h \
 	prov/gni/include/gnix_nic.h \
@@ -93,6 +95,7 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/freelist.c \
 	prov/gni/test/hashtable.c \
 	prov/gni/test/mr.c \
+	prov/gni/test/mr_notifier.c \
 	prov/gni/test/nic.c \
 	prov/gni/test/pmi_utils.c \
 	prov/gni/test/queue.c \

--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -102,6 +102,14 @@ dnl looks like we need to get rid of some white space
 
         ])
 
+	AC_ARG_WITH([kdreg], [AS_HELP_STRING([--with-kdreg],
+                                             [Install directory for kdreg headers])])
+
+        if test "$with_kdreg" != "" && test "$with_kdreg" != "no"; then
+		    gni_CPPFLAGS="-I$with_kdreg/include -DHAVE_KDREG $gni_CPPFLAGS"
+        fi
+
+
         AM_CONDITIONAL([HAVE_CRITERION], [test "x$have_criterion" = "xtrue"])
 
         AC_SUBST(gni_CPPFLAGS)

--- a/prov/gni/contrib/gnitest.supp
+++ b/prov/gni/contrib/gnitest.supp
@@ -142,6 +142,18 @@
 }
 
 #
+# This is from reading kernel initialized memory
+#
+{
+   gnix_notifier_get_event
+   Memcheck:Addr8
+   fun:_gnix_notifier_get_event
+   fun:__clear_notifier_events.part.5
+   fun:__clear_notifier_events
+   ...
+}
+
+#
 # These are due to writing fewer than 4 bytes of data, but the
 # compiler reading a whole word in the generated code.
 #

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -71,6 +71,7 @@ extern "C" {
 #include "fi_ext_gni.h"
 #include "gnix_tags.h"
 #include "gnix_mr_cache.h"
+#include "gnix_mr_notifier.h"
 
 #define GNI_MAJOR_VERSION 1
 #define GNI_MINOR_VERSION 0
@@ -304,6 +305,7 @@ struct gnix_fid_fabric {
 	 * GNI_PostdataProbeWaitById in gni_pub.h */
 	uint64_t datagram_timeout;
 	struct gnix_reference ref_cnt;
+	struct gnix_mr_notifier mr_notifier;
 };
 
 extern struct fi_ops_cm gnix_cm_ops;

--- a/prov/gni/include/gnix_mr_cache.h
+++ b/prov/gni/include/gnix_mr_cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -148,6 +148,7 @@ typedef struct gnix_mr_cache_attr {
 	void *reg_context;
 	void *dereg_context;
 	void *destruct_context;
+	struct gnix_mr_notifier *notifier;
 	void *(*reg_callback)(void *handle, void *address, size_t length,
 			struct _gnix_fi_reg_context *fi_reg_context,
 			void *context);
@@ -220,7 +221,13 @@ int _gnix_mr_cache_destroy(gnix_mr_cache_t *cache);
 int _gnix_mr_cache_flush(gnix_mr_cache_t *cache);
 
 /**
- * TODO
+ * @brief Initializes the MR cache state
+ *
+ * @param[in,out] cache   a gnix memory registration cache
+ * @param[in] attr        cache attributes, @see gnix_mr_cache_attr_t
+ *
+ * @return           FI_SUCCESS on success
+ *                   -FI_ENOMEM otherwise
  */
 int _gnix_mr_cache_init(
 		gnix_mr_cache_t      **cache,

--- a/prov/gni/include/gnix_mr_notifier.h
+++ b/prov/gni/include/gnix_mr_notifier.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2016 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNIX_MR_NOTIFIER_H_
+#define _GNIX_MR_NOTIFIER_H_
+
+#include <stdint.h>
+#include <stddef.h>
+#include "rdma/fi_errno.h"
+
+#ifdef HAVE_KDREG
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <kdreg_pub.h>
+
+#include "rdma/fi_log.h"
+#include "gnix_util.h"
+
+#define KDREG_DEV "/dev/kdreg"
+
+typedef volatile uint64_t kdreg_user_delta_t;
+
+/**
+ * @brief memory registration notifier
+ *
+ * @var   fd        File descriptor for KDREG_DEV
+ * @var   cntr      Kernel managed counter for monitored events
+ * @var   lock      Only used for set up and tear down (no guarantees
+ *                  if reading or writing while setting up or tearing down)
+ */
+struct gnix_mr_notifier {
+	int fd;
+	kdreg_user_delta_t *cntr;
+	fastlock_t lock;
+};
+
+/**
+ * @brief initialize the gnix_mr_notifier struct
+ *
+ * @param[out] k        Empty (zeroed) gnix_mr_notifier struct
+ * @return              FI_SUCESSS on success
+ *                      -FI_EINVAL if k == NULL
+ */
+int _gnix_notifier_init(struct gnix_mr_notifier *mrn);
+
+/**
+ * @brief open the kdreg device and prepare for notifications
+ *
+ * @param[in,out] k     Empty and initialized gnix_mr_notifier struct
+ * @return              FI_SUCESSS on success
+ *                      -FI_EBUSY if device already open
+ *                      -FI_ENODATA if user delta unavailable
+ *                      -fi_errno or -errno on other failures
+ */
+int _gnix_notifier_open(struct gnix_mr_notifier *mrn);
+
+/**
+ * @brief close the kdreg device and zero the notifier
+ *
+ * @param[in] k         gnix_mr_notifier struct
+ * @return              FI_SUCESSS on success
+ *                      -fi_errno or -errno on other failures
+ */
+int _gnix_notifier_close(struct gnix_mr_notifier *mrn);
+
+/**
+ * @brief monitor a memory region
+ *
+ * @param[in] k         gnix_mr_notifier struct
+ * @param[in] addr      address of memory region to monitor
+ * @param[in] len       length of memory region
+ * @param[in] cookie    user identifier associated with the region
+ * @return              FI_SUCESSS on success
+ *                      -fi_errno or -errno on failure
+ */
+int _gnix_notifier_monitor(struct gnix_mr_notifier *mrn, void *addr,
+			   uint64_t len, uint64_t cookie);
+
+/**
+ * @brief stop monitoring a memory region
+ *
+ * @param[in]  k        gnix_mr_notifier struct
+ * @param[out] cookie   user identifier for notification event
+ * @return              FI_SUCESSS on success
+ *                      -fi_errno or -errno on failure
+ */
+int _gnix_notifier_unmonitor(struct gnix_mr_notifier *mrn, uint64_t cookie);
+
+/**
+ * @brief get a monitoring event
+ *
+ * @param[in]  k        gnix_mr_notifier struct
+ * @param[out] buf      buffer to write event data
+ * @param[in]  len      length of buffer
+ * @return              Number of bytes read on success
+ *                      -FI_EINVAL if invalid arguments
+ *                      -FI_EAGAIN if nothing to read
+ *                      -fi_errno or -errno on failure
+ */
+int _gnix_notifier_get_event(struct gnix_mr_notifier *mrn,
+			     void* buf, size_t len);
+
+#else
+
+struct gnix_mr_notifier {
+	int dummy[0];
+};
+
+static inline int
+_gnix_notifier_init(struct gnix_mr_notifier *mrn)
+{
+	return FI_SUCCESS;
+}
+
+static inline int
+_gnix_notifier_open(struct gnix_mr_notifier *mrn)
+{
+	return FI_SUCCESS;
+}
+
+static inline int
+_gnix_notifier_close(struct gnix_mr_notifier *mrn)
+{
+	return FI_SUCCESS;
+}
+
+static inline int
+_gnix_notifier_monitor(struct gnix_mr_notifier *mrn, void *addr,
+		       uint64_t len, uint64_t cookie)
+{
+	return FI_SUCCESS;
+}
+
+static inline int
+_gnix_notifier_unmonitor(struct gnix_mr_notifier *mrn, uint64_t cookie)
+{
+	return FI_SUCCESS;
+}
+
+static inline int
+_gnix_notifier_get_event(struct gnix_mr_notifier *mrn, void* buf, size_t len)
+{
+	return -FI_EAGAIN;
+}
+
+#endif /* HAVE_KDREG */
+
+#endif /* _GNIX_MR_NOTIFIER_H_ */

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -486,6 +486,7 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->mr_cache_attr.reg_context = (void *) domain;
 	domain->mr_cache_attr.dereg_context = NULL;
 	domain->mr_cache_attr.destruct_context = NULL;
+	domain->mr_cache_attr.notifier = &fabric_priv->mr_notifier;
 	domain->mr_cache = NULL;
 	fastlock_init(&domain->mr_cache_lock);
 

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  *
@@ -281,7 +281,7 @@ static int fi_gnix_mr_close(fid_t fid)
 
 	/* call cache deregister op */
 	fastlock_acquire(&domain->mr_cache_lock);
-	ret = _gnix_mr_cache_deregister(mr->domain->mr_cache, mr);
+	ret = _gnix_mr_cache_deregister(domain->mr_cache, mr);
 	fastlock_release(&domain->mr_cache_lock);
 
 	/* check retcode */

--- a/prov/gni/src/gnix_mr_notifier.c
+++ b/prov/gni/src/gnix_mr_notifier.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2016 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifdef HAVE_KDREG
+
+#include "gnix_mr_notifier.h"
+
+static inline int
+notifier_verify_stuff(struct gnix_mr_notifier *mrn) {
+	/* Can someone confirm that these values are POSIX so we can
+	 * be less pedantic? */
+	if (mrn->fd == STDIN_FILENO ||
+	    mrn->fd == STDOUT_FILENO ||
+	    mrn->fd == STDERR_FILENO ||
+	    mrn->fd < 0) {
+		// Be quiet here
+		return -FI_EBADF;
+	}
+
+	if (mrn->cntr == NULL) {
+		// Be quiet here
+		return -FI_ENODATA;
+	}
+
+	return FI_SUCCESS;
+}
+
+int
+_gnix_notifier_init(struct gnix_mr_notifier *mrn)
+{
+	if (mrn == NULL) {
+		GNIX_WARN(FI_LOG_MR, "mr notifier NULL\n");
+		return -FI_EINVAL;
+	}
+
+	mrn->fd = 0;
+	mrn->cntr = NULL;
+	fastlock_init(&mrn->lock);
+
+	return FI_SUCCESS;
+}
+
+int
+_gnix_notifier_open(struct gnix_mr_notifier *mrn)
+{
+	int ret = FI_SUCCESS;
+	int kdreg_fd, ret_errno;
+        kdreg_get_user_delta_args_t get_user_delta_args;
+
+	if ((mrn->fd != 0) || (mrn->cntr != NULL)) {
+		GNIX_WARN(FI_LOG_MR, "mr notifier already open\n");
+		return -FI_EBUSY;
+	}
+
+	fastlock_acquire(&mrn->lock);
+
+	kdreg_fd = open(KDREG_DEV, O_RDWR | O_NONBLOCK);
+	if (kdreg_fd < 0) {
+		ret_errno = errno;
+		GNIX_WARN(FI_LOG_MR, "kdreg device open failed: %s\n",
+			  strerror(ret_errno));
+		// Not all of these map to fi_errno values
+		ret = -ret_errno;
+		goto err_exit;
+	}
+
+	(void) memset(&get_user_delta_args,0,sizeof(get_user_delta_args));
+	if (ioctl(kdreg_fd, KDREG_IOC_GET_USER_DELTA,
+		  &get_user_delta_args) < 0) {
+		ret_errno = errno;
+		GNIX_WARN(FI_LOG_MR, "kdreg get_user_delta failed: %s\n",
+			  strerror(ret_errno));
+		close(kdreg_fd);
+		// Not all of these map to fi_errno values
+		ret = -ret_errno;
+		goto err_exit;
+	}
+
+	if (get_user_delta_args.user_delta == NULL) {
+		GNIX_WARN(FI_LOG_MR, "kdreg get_user_delta is NULL\n");
+		ret = -FI_ENODATA;
+		goto err_exit;
+	}
+
+	mrn->fd = kdreg_fd;
+	mrn->cntr = (kdreg_user_delta_t *) get_user_delta_args.user_delta;
+
+err_exit:
+	fastlock_release(&mrn->lock);
+
+	return ret;
+}
+
+int
+_gnix_notifier_close(struct gnix_mr_notifier *mrn)
+{
+	int ret = FI_SUCCESS;
+	int ret_errno;
+
+	ret = notifier_verify_stuff(mrn);
+
+	if (ret == 0) {
+		fastlock_acquire(&mrn->lock);
+
+		if (close(mrn->fd) != 0) {
+			ret_errno = errno;
+			GNIX_WARN(FI_LOG_MR, "error closing kdreg device: %s\n",
+				  strerror(ret_errno));
+			// Not all of these map to fi_errno values
+			ret = -ret_errno;
+			goto err_exit;
+		}
+
+		mrn->cntr = NULL;
+	err_exit:
+		fastlock_release(&mrn->lock);
+	}
+
+	return ret;
+}
+
+static inline int
+kdreg_write(struct gnix_mr_notifier *mrn, void *buf, size_t len) {
+	int ret;
+
+	ret = write(mrn->fd, buf, len);
+	if ((ret < 0) || (ret != len)) {
+		// Not all of these map to fi_errno values
+		ret = -errno;
+		GNIX_WARN(FI_LOG_MR, "kdreg_write failed: %s\n",
+			  strerror(errno));
+		return ret;
+	}
+
+	return FI_SUCCESS;
+}
+
+int
+_gnix_notifier_monitor(struct gnix_mr_notifier *mrn,
+		    void *addr, uint64_t len, uint64_t cookie)
+{
+	int ret;
+	struct registration_monitor rm;
+
+	ret = notifier_verify_stuff(mrn);
+
+	if (ret == 0) {
+		GNIX_INFO(FI_LOG_MR, "monitoring %p (len=%lu) cookie=%lu\n",
+			  addr, len, cookie);
+
+		memset(&rm, 0, sizeof(rm));
+		rm.type = REGISTRATION_MONITOR;
+		rm.u.mon.addr = (uint64_t) addr;
+		rm.u.mon.len = len;
+		rm.u.mon.user_cookie = cookie;
+
+		ret = kdreg_write(mrn, &rm, sizeof(rm));
+	}
+
+	return ret;
+}
+
+int
+_gnix_notifier_unmonitor(struct gnix_mr_notifier *mrn, uint64_t cookie)
+{
+	int ret;
+	struct registration_monitor rm;
+
+	ret = notifier_verify_stuff(mrn);
+	if (ret == 0) {
+		GNIX_INFO(FI_LOG_MR, "unmonitoring cookie=%lu\n", cookie);
+
+		memset(&rm, 0, sizeof(rm));
+
+		rm.type = REGISTRATION_UNMONITOR;
+		rm.u.unmon.user_cookie = cookie;
+
+		ret = kdreg_write(mrn, &rm, sizeof(rm));
+	}
+
+	return ret;
+}
+
+int
+_gnix_notifier_get_event(struct gnix_mr_notifier *mrn, void* buf, size_t len)
+{
+	int ret, ret_errno;
+
+	if ((mrn == NULL) || (buf == NULL) || (len <= 0)) {
+		GNIX_WARN(FI_LOG_MR,
+			  "Invalid argument to _gnix_notifier_get_event\n");
+		return -FI_EINVAL;
+	}
+
+	if (*(mrn->cntr) > 0) {
+		GNIX_INFO(FI_LOG_MR, "reading kdreg event\n");
+		ret = read(mrn->fd, buf, len);
+		if (ret >= 0) {
+			return ret;
+		} else {
+			ret_errno = errno;
+			if (ret_errno != EAGAIN) {
+				GNIX_WARN(FI_LOG_MR,
+					  "kdreg event read failed: %s\n",
+					  strerror(ret_errno));
+			}
+			// Not all of these map to fi_errno values
+			return -ret_errno;
+		}
+	} else {
+		GNIX_INFO(FI_LOG_MR, "nothing to read from kdreg :(\n");
+		return -FI_EAGAIN;
+	}
+}
+
+#endif /* HAVE_KDREG */

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -216,11 +216,6 @@ static void rdm_api_teardown_common(bool unreg)
 {
 	int ret = 0, i = 0;
 
-	free(uc_source);
-	free(uc_target);
-	free(target);
-	free(source);
-
 	for (; i < NUMEPS; i++) {
 		fi_close(&recv_cntr[i]->fid);
 		fi_close(&send_cntr[i]->fid);
@@ -246,6 +241,11 @@ static void rdm_api_teardown_common(bool unreg)
 		free(ep_name[i]);
 		fi_freeinfo(hints[i]);
 	}
+
+	free(uc_source);
+	free(uc_target);
+	free(target);
+	free(source);
 
 	ret = fi_close(&fab->fid);
 	cr_assert(!ret, "failure in closing fabric.");

--- a/prov/gni/test/api_cq.c
+++ b/prov/gni/test/api_cq.c
@@ -216,11 +216,6 @@ static void api_cq_teardown_common(bool unreg)
 {
 	int ret = 0, i = 0;
 
-	free(uc_source);
-	free(uc_target);
-	free(target);
-	free(source);
-
 	for (; i < NUMEPS; i++) {
 		fi_close(&recv_cntr[i]->fid);
 		fi_close(&send_cntr[i]->fid);
@@ -246,6 +241,11 @@ static void api_cq_teardown_common(bool unreg)
 		free(ep_name[i]);
 		fi_freeinfo(hints[i]);
 	}
+
+	free(uc_source);
+	free(uc_target);
+	free(target);
+	free(source);
 
 	ret = fi_close(&fab->fid);
 	cr_assert(!ret, "failure in closing fabric.");

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -48,7 +48,6 @@
 #include <stdlib.h>
 #include <inttypes.h>
 
-#include "gnix_cq.h"
 #include "gnix.h"
 #include "common.h"
 
@@ -57,11 +56,9 @@
 
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
-static struct fid_ep *ep;
 static struct fid_mr *mr;
 static struct fi_info *hints;
 static struct fi_info *fi;
-static struct fi_cq_attr cq_attr;
 
 #define __BUF_LEN 4096
 static unsigned char *buf;
@@ -70,12 +67,12 @@ static struct gnix_fid_domain *domain;
 static gnix_mr_cache_t *cache;
 static int regions;
 
-uint64_t default_access = (FI_REMOTE_READ | FI_REMOTE_WRITE
-		| FI_READ | FI_WRITE);
+static uint64_t default_access = (FI_REMOTE_READ | FI_REMOTE_WRITE
+				  | FI_READ | FI_WRITE);
 
-uint64_t default_flags = 0;
-uint64_t default_req_key = 0;
-uint64_t default_offset = 0;
+static uint64_t default_flags;
+static uint64_t default_req_key;
+static uint64_t default_offset;
 
 struct timeval s1, s2;
 
@@ -85,9 +82,6 @@ static void mr_setup(void)
 
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
-
-	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
 
 	hints->fabric_attr->name = strdup("gni");
 
@@ -100,11 +94,6 @@ static void mr_setup(void)
 	ret = fi_domain(fab, fi, &dom, NULL);
 	cr_assert(!ret, "fi_domain");
 
-	ret = fi_endpoint(dom, fi, &ep, NULL);
-	cr_assert(!ret, "fi_endpoint");
-
-	cq_attr.wait_obj = FI_WAIT_NONE;
-
 	buf = calloc(__BUF_LEN, sizeof(unsigned char));
 	cr_assert(buf, "buffer allocation");
 
@@ -116,8 +105,6 @@ static void mr_teardown(void)
 {
 	int ret = 0;
 
-	ret = fi_close(&ep->fid);
-	cr_assert(!ret, "failure in closing ep.");
 	ret = fi_close(&dom->fid);
 	cr_assert(!ret, "failure in closing domain.");
 	ret = fi_close(&fab->fid);

--- a/prov/gni/test/mr_notifier.c
+++ b/prov/gni/test/mr_notifier.c
@@ -1,0 +1,493 @@
+/*
+ * Copyright (c) 2016 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <sys/mman.h>
+#include "gnix_mr_notifier.h"
+
+#include <criterion/criterion.h>
+
+static struct gnix_mr_notifier mr_notifier;
+static void mr_notifier_setup(void)
+{
+	int ret;
+
+	ret = _gnix_notifier_init(&mr_notifier);
+	cr_assert(ret == 0, "_gnix_notifier_init failed");
+
+	ret = _gnix_notifier_open(&mr_notifier);
+	cr_assert(ret == 0, "_gnix_notifier_open failed");
+}
+
+static void mr_notifier_teardown(void)
+{
+	int ret;
+
+	ret = _gnix_notifier_close(&mr_notifier);
+	cr_assert(ret == 0, "_gnix_notifier_open failed");
+}
+
+TestSuite(mr_notifier,
+	  .init = mr_notifier_setup,
+	  .fini = mr_notifier_teardown);
+
+static void
+monitor_single(size_t len) {
+	int ret;
+	uint64_t cookie;
+	char *mem = mmap(NULL, len, PROT_READ | PROT_WRITE,
+			 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	cr_assert_neq(mem, MAP_FAILED, "Could not allocate %ld bytes\n", len);
+
+	ret = _gnix_notifier_monitor(&mr_notifier, mem, len, (uint64_t) mem);
+	cr_assert(ret == 0, "_gnix_notifier_monitor failed");
+
+	munmap(mem, len);
+
+	ret = _gnix_notifier_get_event(&mr_notifier, &cookie, sizeof(cookie));
+	if (ret >= 0) {
+		cr_assert(cookie == (uint64_t) mem,
+			  "Unexpected cookie (got %lu, expected %lu)",
+			  cookie, (uint64_t) mem);
+		cr_assert(ret == sizeof(cookie),
+			  "Unexpected number of bytes (got %d, expected %lu)",
+			  ret, sizeof(cookie));
+	} else if (ret == -FI_EAGAIN) {
+		/* Nothing to read, ok */
+		ret = _gnix_notifier_unmonitor(&mr_notifier, (uint64_t) mem);
+		cr_assert(ret == 0, "_gnix_notifier_unmonitor failed");
+	} else {
+		cr_assert(0, "Unexpected error");
+	}
+}
+
+Test(mr_notifier, single)
+{
+	monitor_single(131);
+	monitor_single(4099);
+	monitor_single((1<<22) + 1);
+	monitor_single((1<<26) - 1);
+}
+
+static void
+monitor_multiple(size_t *lens, size_t num_lens)
+{
+	int i, ret;
+	uint64_t cookie;
+	char *mems[num_lens];
+	bool unmapped[num_lens];
+
+	for (i = 0; i < num_lens; i++) {
+		mems[i] = mmap(NULL, lens[i], PROT_READ | PROT_WRITE,
+			       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+		cr_assert_neq(mems[i], MAP_FAILED,
+			      "Could not allocate %ld bytes\n", lens[i]);
+
+		ret = _gnix_notifier_monitor(&mr_notifier, mems[i], lens[i],
+					     (uint64_t) &mems[i]);
+		cr_assert(ret == 0, "_gnix_notifier_monitor failed");
+		unmapped[i] = false;
+	}
+
+	for (i = 0; i < num_lens; i++) {
+		munmap(mems[i], lens[i]);
+	}
+
+	for (ret = _gnix_notifier_get_event(&mr_notifier,
+					    &cookie, sizeof(cookie));
+	     ret > 0;
+	     ret = _gnix_notifier_get_event(&mr_notifier,
+					    &cookie, sizeof(cookie))) {
+		i = (int) (cookie - (uint64_t) mems)/8;
+		cr_assert(cookie == (uint64_t) &mems[i],
+			  "Unexpected cookie (got %lu, expected %lu)",
+			  cookie, (uint64_t) &mems[i]);
+		cr_assert(ret == sizeof(cookie),
+			  "Unexpected number of bytes (got %d, expected %lu)",
+			  ret, sizeof(cookie));
+		unmapped[i] = true;
+	}
+
+	for (i = 0; i < num_lens; i++) {
+		if (unmapped[i] == false) {
+			ret = _gnix_notifier_unmonitor(&mr_notifier,
+						       (uint64_t) &mems[i]);
+			cr_assert(ret == 0, "_gnix_notifier_unmonitor failed");
+		}
+	}
+}
+
+Test(mr_notifier, multiple)
+{
+	const int num_lens = 11;
+	size_t lens[num_lens];
+
+	lens[0] = 131;
+	lens[1] = 4099;
+	lens[2] = 8096;
+	lens[3] = (1<<15)-1;
+	lens[4] = 777;
+	lens[5] = (1<<19)+1;
+	lens[6] = 1<<20;
+	lens[7] = 1<<20;
+	lens[8] = 42;
+	lens[9] = (1<<14)-1;
+	lens[10] = (1<<21)+1;
+	lens[11] = (1<<21)-1;
+
+	monitor_multiple(lens+5, 2);
+	monitor_multiple(lens, num_lens);
+
+}
+
+#include <pthread.h>
+#include "gnix_rdma_headers.h"
+static struct fi_info *fi;
+static struct fid_fabric *fab;
+static struct fid_domain *dom;
+static uint64_t default_access = (FI_REMOTE_READ | FI_REMOTE_WRITE |
+			   FI_READ | FI_WRITE);
+static uint64_t default_flags;
+static uint64_t default_req_key;
+static uint64_t default_offset;
+
+static pthread_t freer;
+
+/* simple bounded buffer for 2 threads */
+#include "fi_atom.h"
+#define buflen 23
+static void *to_free_buf[buflen];
+static atomic_t head, tail;
+
+static inline int next_head(void)
+{
+	int val = atomic_inc(&head);
+
+	while (atomic_get(&tail)-buflen >= val) {
+		pthread_yield();
+	}
+	return val%buflen;
+}
+
+static inline int next_tail(void)
+{
+	int val = atomic_inc(&tail);
+
+	while (atomic_get(&head) <= val) {
+		pthread_yield();
+	}
+	return val%buflen;
+}
+
+static void *do_free(void *data)
+{
+	int loc = next_tail();
+	void *addr = to_free_buf[loc];
+
+	while (addr != MAP_FAILED) {
+		if (addr) {
+			free(addr);
+		}
+
+		pthread_yield();
+
+		loc = next_tail();
+		addr = to_free_buf[loc];
+	}
+	return NULL;
+}
+
+static void mr_stressor_setup_common(void)
+{
+	int ret = 0;
+	struct fi_info *hints;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->cq_data_size = 4;
+	hints->mode = ~0;
+
+	hints->fabric_attr->name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	cr_assert(!ret, "fi_getinfo");
+
+	fi_freeinfo(hints);
+
+	ret = fi_fabric(fi->fabric_attr, &fab, NULL);
+	cr_assert(!ret, "fi_fabric");
+
+	ret = fi_domain(fab, fi, &dom, NULL);
+	cr_assert(!ret, "fi_domain");
+
+}
+
+static void mr_notifier_stressor_setup(void)
+{
+	int ret = 0;
+
+	mr_stressor_setup_common();
+
+	atomic_initialize(&head, 0);
+	atomic_initialize(&tail, -1);
+
+	ret = pthread_create(&freer, NULL, do_free, NULL);
+	cr_assert_eq(ret, 0, "Could not create pthread");
+
+	srand(0); /* want repeatable sequence, I think */
+}
+
+static void mr_stressor_teardown_common(void)
+{
+	int ret = 0;
+
+	ret = fi_close(&dom->fid);
+	cr_assert_eq(ret, 0, "Could not close domain");
+
+	ret = fi_close(&fab->fid);
+	cr_assert_eq(ret, 0, "Could not close fabric");
+
+	fi_freeinfo(fi);
+}
+
+static void mr_notifier_stressor_teardown(void)
+{
+	int ret = 0;
+
+	ret = pthread_join(freer, NULL);
+	cr_assert_eq(ret, 0, "Could not join pthread");
+
+	mr_stressor_teardown_common();
+}
+
+TestSuite(mr_notifier_stressor,
+	  .init = mr_notifier_stressor_setup,
+	  .fini = mr_notifier_stressor_teardown);
+
+/* good 'nuff */
+static int get_len(int min_len, int max_len)
+{
+	int r;
+	int m = max_len - min_len;
+
+	cr_assert(m > 0);
+	r = rand()%m;
+
+	return min_len+r;
+
+}
+
+static void do_notifier_stressor(int num_allocs, int min_len, int max_len,
+				 bool free_imm, bool close_imm)
+{
+	int i, len, ret;
+	char **r = calloc(num_allocs, sizeof(char *));
+	struct fid_mr **mr = calloc(num_allocs, sizeof(struct fid_mr));
+	int loc = atomic_get(&head);
+
+	for (i = 0; i < num_allocs; i++) {
+		len = get_len(min_len, max_len);
+		r[i] = calloc(len, sizeof(char));
+		cr_assert_neq(r[i], NULL,
+			      "Could not allocate %d bytes\n", len);
+
+		ret = fi_mr_reg(dom, (void *) r[i], len, default_access,
+				default_offset, default_req_key,
+				default_flags, &mr[i], NULL);
+		cr_assert_eq(ret, FI_SUCCESS);
+
+		to_free_buf[loc] = free_imm ? r[i] : 0x0;
+
+		loc = next_head();
+		pthread_yield();
+
+		if (close_imm) {
+			fi_close(&mr[i]->fid);
+		}
+	}
+
+	to_free_buf[loc] = MAP_FAILED;
+	loc = next_head();
+
+	for (i = 0; i < num_allocs; i++) {
+		if (!free_imm) {
+			free(r[i]);
+		}
+		if (!close_imm) {
+			fi_close(&mr[i]->fid);
+		}
+	}
+
+	free(r);
+	free(mr);
+}
+
+Test(mr_notifier_stressor, free_and_close)
+{
+	do_notifier_stressor(300, 1<<10, 1<<25, true, true);
+}
+
+Test(mr_notifier_stressor, close_only)
+{
+	do_notifier_stressor(300, 1<<10, 1<<25, false, true);
+}
+
+Test(mr_notifier_stressor, free_only)
+{
+	do_notifier_stressor(300, 1<<10, 1<<25, true, false);
+}
+
+Test(mr_notifier_stressor, no_free_no_close)
+{
+	do_notifier_stressor(300, 1<<10, 1<<25, false, false);
+}
+
+Test(mr_notifier_stressor, small_free_and_close)
+{
+	do_notifier_stressor(3000, 1<<4, 1<<14, true, true);
+}
+
+Test(mr_notifier_stressor, small_close_only)
+{
+	do_notifier_stressor(3000, 1<<4, 1<<14, false, true);
+}
+
+Test(mr_notifier_stressor, small_free_only)
+{
+	do_notifier_stressor(3000, 1<<4, 1<<14, true, false);
+}
+
+Test(mr_notifier_stressor, small_no_free_no_close)
+{
+	do_notifier_stressor(3000, 1<<4, 1<<14, false, false);
+}
+
+
+static void mr_reuse_stressor_setup(void)
+{
+	mr_stressor_setup_common();
+}
+
+static void mr_reuse_stressor_teardown(void)
+{
+	mr_stressor_teardown_common();
+}
+
+TestSuite(mr_reuse_stressor,
+	  .init = mr_reuse_stressor_setup,
+	  .fini = mr_reuse_stressor_teardown);
+
+static void do_reuse(int num_allocs, int num_reuse,
+		     int min_len, int max_len)
+{
+	int i, a, len, ret;
+
+	cr_assert(num_allocs > 2*num_reuse);
+
+	char **r = calloc(num_reuse, sizeof(char *));
+
+	cr_assert_neq(r, NULL);
+
+	int *r_len = calloc(num_reuse, sizeof(int));
+
+	cr_assert_neq(r_len, NULL);
+
+	for (i = 0; i < num_reuse; i++) {
+		len = get_len(min_len, max_len);
+		r[i] = calloc(len, sizeof(char));
+		cr_assert_neq(r[i], NULL,
+			      "Could not allocate %d bytes\n", len);
+		r_len[i] = len;
+	}
+
+	int nr = 0;
+
+	for (a = 0; a < num_allocs; a++) {
+		char *buf;
+		struct fid_mr *buf_mr;
+		bool free_me;
+
+		if ((nr < num_reuse) && (a % 2)) {
+			buf = r[nr];
+			len = r_len[nr];
+			nr++;
+			free_me = false;
+		} else {
+			len = get_len(min_len, max_len);
+			buf = calloc(len, sizeof(char));
+			cr_assert_neq(buf, NULL,
+				      "Could not allocate %d bytes\n", len);
+			free_me = true;
+		}
+		ret = fi_mr_reg(dom, (void *) buf, len, default_access,
+				default_offset, default_req_key,
+				default_flags, &buf_mr, NULL);
+		cr_assert_eq(ret, FI_SUCCESS);
+
+		fi_close(&buf_mr->fid);
+
+		if (free_me) {
+			free(buf);
+		}
+	}
+
+	for (i = 0; i < num_reuse; i++) {
+		free(r[i]);
+	}
+
+	free(r);
+	free(r_len);
+}
+
+Test(mr_reuse_stressor, few_small)
+{
+	do_reuse(2347, 11, 1<<8, 1<<12);
+}
+
+Test(mr_reuse_stressor, few_large)
+{
+	do_reuse(2347, 11, 1<<18, 1<<24);
+}
+
+Test(mr_reuse_stressor, lots_small)
+{
+	do_reuse(2347, 491, 1<<8, 1<<12);
+}
+
+Test(mr_reuse_stressor, lots_large)
+{
+	do_reuse(2347, 491, 1<<18, 1<<24);
+}
+

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -297,11 +297,6 @@ static void rdm_sr_teardown_common(bool unreg)
 {
 	int ret = 0, i = 0;
 
-	free(uc_source);
-	free(uc_target);
-	free(target);
-	free(source);
-
 	for (; i < NUMEPS; i++) {
 		fi_close(&recv_cntr[i]->fid);
 		fi_close(&send_cntr[i]->fid);
@@ -327,6 +322,11 @@ static void rdm_sr_teardown_common(bool unreg)
 
 		free(ep_name[i]);
 	}
+
+	free(uc_source);
+	free(uc_target);
+	free(target);
+	free(source);
 
 	ret = fi_close(&fab->fid);
 	cr_assert(!ret, "failure in closing fabric.");


### PR DESCRIPTION
Add the option to use the kdreg IOMMU notifier to manage memory
registrations that have been unmapped by the OS.  Every memory region
is monitored upon successful registration (fi_mr_reg) and unmonitored
upon deregistration (fi_close).  The notifier is checked for events
that identify monitored memory regions that have had 1 or more pages
unmapped.  Unmapped regions are marked as such and removed from use
(retired) or deleted from the cache.  Retired memory registrations are
entries that have not been closed (i.e., deregistered) and may be due
to a user freeing memory before closing the memory registration.  A
warning is emitted in this case.

Some minor restructuring and clean up was also done with this commit.

- Added notifier functionality to the cache, to be used with or
  without kdreg.  TODO: further generalize to plug in any notifier.

- Added __mr_cache_lru_remove() and replaced all dlist function on the
  lru list with the appropriate __mr_cache_lru_* functions (for
  clarity's sake).

- Other minor stuff:
  - Removed legacy check for entry match in __mr_cache_flush
  - Improved error checking
  - Replaced asserts with calls to GNIX_FATAL
  - Added/updated GNIX_INFO output
  - Updated comments and doxygen annotations

- gnitest changes:
  - Added new notifier tests
  - Changed rdm_sr, api, and api_cq tests to close memory regions
    before freeing them
  - Cleaned up mr tests a bit (got rid of unused stuff and made stuff
    file static)
  - Added valgrind suppression for reading kernel managed counter

KNOWN BUGS:

- Stale entry that becomes unmapped during __mr_cache_search_inuse,
  can result in double free
- Entry in to_destroy list can be freed by notifier call

upstream merge of ofi-cray/libfabric-cray#809
@ztiffany please sanity check

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@b3431d31db21ca0713e6f743d66c7dbffab29331)