### PR TITLE
Makefile.am: do not install fi_log.h or fi_prov.h

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -77,8 +77,8 @@ src_libfabric_la_SOURCES = \
 	include/fasthash.h \
 	include/rbtree.h \
 	include/prov.h \
-	include/rdma/fi_log.h \
-	include/rdma/fi_prov.h \
+	include/rdma/providers/fi_log.h \
+	include/rdma/providers/fi_prov.h \
 	src/fabric.c \
 	src/fi_tostr.c \
 	src/log.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,6 +77,8 @@ src_libfabric_la_SOURCES = \
 	include/fasthash.h \
 	include/rbtree.h \
 	include/prov.h \
+	include/rdma/fi_log.h \
+	include/rdma/fi_prov.h \
 	src/fabric.c \
 	src/fi_tostr.c \
 	src/log.c \
@@ -115,8 +117,6 @@ rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fi_cm.h \
 	$(top_srcdir)/include/rdma/fi_domain.h \
 	$(top_srcdir)/include/rdma/fi_eq.h \
-	$(top_srcdir)/include/rdma/fi_log.h \
-	$(top_srcdir)/include/rdma/fi_prov.h \
 	$(top_srcdir)/include/rdma/fi_rma.h \
 	$(top_srcdir)/include/rdma/fi_endpoint.h \
 	$(top_srcdir)/include/rdma/fi_errno.h \

--- a/include/fi.h
+++ b/include/fi.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -46,11 +47,11 @@
 #include <fi_lock.h>
 #include <fi_atom.h>
 #include <fi_mem.h>
+#include <rdma/providers/fi_prov.h>
+#include <rdma/providers/fi_log.h>
 
 #include <rdma/fabric.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_atomic.h>
-#include <rdma/fi_log.h>
 
 #include <fi_osd.h>
 

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -44,7 +45,6 @@
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_eq.h>
 #include <rdma/fi_errno.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>

--- a/include/prov.h
+++ b/include/prov.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -35,7 +36,7 @@
 
 #include "config.h"
 
-#include <rdma/fi_prov.h>
+#include <rdma/providers/fi_prov.h>
 
 /* Provider initialization function signature that built-in providers
  * must specify. */

--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2015-2016, Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2015, Intel Corp., Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -38,7 +38,7 @@
 #include "config.h"
 
 #include <rdma/fabric.h>
-#include <rdma/fi_prov.h>
+#include <rdma/providers/fi_prov.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/rdma/providers/fi_prov.h
+++ b/include/rdma/providers/fi_prov.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2004, 2005 Topspin Communications.  All rights reserved.
- * Copyright (c) 2005, 2006 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2005, 2006, 2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2005 PathScale, Inc.  All rights reserved.
  * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
  *

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -53,7 +54,7 @@ extern "C" {
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_eq.h>
 #include <rdma/fi_errno.h>
-#include <rdma/fi_prov.h>
+#include <rdma/providers/fi_prov.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>

--- a/prov/gni/include/gnix_mr_notifier.h
+++ b/prov/gni/include/gnix_mr_notifier.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -47,7 +48,7 @@
 #include <string.h>
 #include <kdreg_pub.h>
 
-#include "rdma/fi_log.h"
+#include "rdma/providers/fi_log.h"
 #include "gnix_util.h"
 
 #define KDREG_DEV "/dev/kdreg"

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -40,7 +41,6 @@
 
 #include <stdio.h>
 #include <fi.h>
-#include "rdma/fi_log.h"
 
 extern struct fi_provider gnix_prov;
 

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,10 +50,11 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>
+
+#include <rdma/providers/fi_prov.h>
 
 #include "gnix.h"
 #include "gnix_datagram.h"

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -37,7 +38,6 @@
 
 #include "fi.h"
 #include "rdma/fi_domain.h"
-#include "rdma/fi_prov.h"
 
 #include "gnix.h"
 

--- a/prov/gni/test/gnix_rdma_headers.h
+++ b/prov/gni/test/gnix_rdma_headers.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -45,8 +46,6 @@
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_eq.h>
 #include <rdma/fi_errno.h>
-#include <rdma/fi_log.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>

--- a/prov/mxm/src/mlxm.h
+++ b/prov/mxm/src/mlxm.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Intel Corporation. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -44,14 +45,14 @@ extern "C" {
 #include <string.h>
 #include <unistd.h>
 #include <rdma/fabric.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_errno.h>
-#include <rdma/fi_log.h>
+#include <rdma/providers/fi_log.h>
+#include <rdma/providers/fi_prov.h>
 #include "fi_enosys.h"
 #include <mxm/api/mxm_api.h>
 #include "mpool.h"

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -53,7 +54,6 @@ extern "C" {
 #include <netdb.h>
 #include <complex.h>
 #include <rdma/fabric.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_tagged.h>
@@ -62,7 +62,6 @@ extern "C" {
 #include <rdma/fi_trigger.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_errno.h>
-#include <rdma/fi_log.h>
 #include "fi.h"
 #include "fi_enosys.h"
 #include "fi_list.h"

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -53,7 +54,6 @@ extern "C" {
 #include <netdb.h>
 #include <complex.h>
 #include <rdma/fabric.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_tagged.h>
@@ -62,7 +62,6 @@ extern "C" {
 #include <rdma/fi_trigger.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_errno.h>
-#include <rdma/fi_log.h>
 #include "fi.h"
 #include "fi_enosys.h"
 #include "fi_list.h"

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -39,7 +40,6 @@
 
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
-#include <rdma/fi_prov.h>
 
 #include <fi.h>
 #include <fi_enosys.h>

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -41,7 +42,6 @@
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_eq.h>
 #include <rdma/fi_errno.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>

--- a/prov/sockets/include/sock_util.h
+++ b/prov/sockets/include/sock_util.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -34,7 +35,7 @@
 #define _SOCK_UTIL_H_
 
 #include <sys/mman.h>
-#include <rdma/fi_log.h>
+#include <rdma/providers/fi_log.h>
 #include "sock.h"
 
 extern const char sock_fab_name[];

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -47,7 +48,6 @@
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_eq.h>
 #include <rdma/fi_errno.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_trigger.h>

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -39,7 +39,7 @@
 #include <sys/queue.h>
 #include <pthread.h>
 
-#include <rdma/fi_log.h>
+#include <rdma/providers/fi_log.h>
 
 #include "usdf_progress.h"
 #include "usd.h"

--- a/prov/usnic/src/usdf_cm.c
+++ b/prov/usnic/src/usdf_cm.c
@@ -50,7 +50,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -51,7 +51,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_dgram.c
+++ b/prov/usnic/src/usdf_dgram.c
@@ -49,7 +49,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -46,7 +46,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_endpoint.c
+++ b/prov/usnic/src/usdf_endpoint.c
@@ -49,7 +49,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -50,7 +50,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -50,7 +50,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -51,7 +51,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -52,7 +52,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -54,7 +54,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_mem.c
+++ b/prov/usnic/src/usdf_mem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014,2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,7 +49,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -50,7 +50,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -52,7 +52,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_progress.c
+++ b/prov/usnic/src/usdf_progress.c
@@ -45,7 +45,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -50,7 +50,6 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -42,7 +43,6 @@
 
 #include <infiniband/verbs.h>
 
-#include <rdma/fi_log.h>
 #include "../fi_verbs.h"
 
 #if (defined(__ICC) || defined(__INTEL_COMPILER) ||	\

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -57,14 +58,12 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
-#include <rdma/fi_prov.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_errno.h>
 
 #include "fi.h"
 #include "fi_enosys.h"
-#include <rdma/fi_log.h>
 #include "prov.h"
 #include "fi_list.h"
 #include "fi_signal.h"

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2004, 2005 Topspin Communications.  All rights reserved.
- * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013 Intel Corp., Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -43,7 +43,6 @@
 #include <rdma/fi_errno.h>
 #include "fi.h"
 #include "prov.h"
-#include <rdma/fi_log.h>
 
 #ifdef HAVE_LIBDL
 #include <dlfcn.h>

--- a/src/log.c
+++ b/src/log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2015-2016, Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2015, Intel Corp., Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -37,7 +37,6 @@
 #include <stdlib.h>
 
 #include <rdma/fi_errno.h>
-#include <rdma/fi_log.h>
 
 #include "fi.h"
 

--- a/src/var.c
+++ b/src/var.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2015-2016, Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2015, Intel Corp., Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -38,8 +38,6 @@
 #include <ctype.h>
 
 #include <rdma/fi_errno.h>
-#include <rdma/fi_prov.h>
-#include <rdma/fi_log.h>
 
 #include "fi.h"
 #include "fi_list.h"


### PR DESCRIPTION
Per discussion on https://github.com/ofiwg/libfabric/pull/2041, these two header files are not intended for libfabric applications -- they are only to be used inside libfabric and its providers.  So do not install them.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@bturrubiates @shefty Please review.