### PR TITLE
prov/sockets: Set fabric/domain name correctly

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -89,6 +89,7 @@
 
 #define SOCK_CQ_DATA_SIZE (sizeof(uint64_t))
 #define SOCK_TAG_SIZE (sizeof(uint64_t))
+#define SOCK_MAX_NETWORK_ADDR_SZ (35)
 
 #define SOCK_PEP_LISTENER_TIMEOUT (10000)
 #define SOCK_CM_COMM_TIMEOUT (2000)
@@ -911,6 +912,11 @@ enum {
 struct sock_conn_req_handle {
 	struct fid handle;
 	struct sock_conn_req *req;
+};
+
+struct sock_host_list_entry {
+	char hostname[HOST_NAME_MAX];
+	struct slist_entry entry;
 };
 
 union sock_tx_op {

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -65,11 +65,6 @@ int sock_verify_domain_attr(struct fi_domain_attr *attr)
 	if (!attr)
 		return 0;
 
-	if (attr->name) {
-		if (strcmp(attr->name, sock_dom_name))
-			return -FI_ENODATA;
-	}
-
 	switch (attr->threading) {
 	case FI_THREAD_UNSPEC:
 	case FI_THREAD_SAFE:


### PR DESCRIPTION
- Set network address as fabric name in the format of <code>a.b.c.d/e</code> based on discussion in #1974.
- Set domain name as network interface.
- Return all available network interfaces as <code>fi_getinfo</code> results.

Output: <code>fi_info -f sockets</code>
```
    provider: sockets
    fabric: 192.168.33.0/24
    domain: eth1
    version: 1.0
    type: FI_EP_MSG
    protocol: FI_PROTO_SOCK_TCP
```
@jithinjosepkl @shefty 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>