### PR TITLE
include/fi_log: Remove config.h include

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -168,6 +168,30 @@ int fi_rma_target_allowed(uint64_t caps);
 uint64_t fi_gettime_ms(void);
 
 
+#define FI_LOG(prov, level, subsystem, ...)				\
+	do {								\
+		if (fi_log_enabled(prov, level, subsystem))		\
+			fi_log(prov, level, subsystem,			\
+				__func__, __LINE__, __VA_ARGS__);	\
+	} while (0)
+
+#define FI_WARN(prov, subsystem, ...)					\
+	FI_LOG(prov, FI_LOG_WARN, subsystem, __VA_ARGS__)
+
+#define FI_TRACE(prov, subsystem, ...)					\
+	FI_LOG(prov, FI_LOG_TRACE, subsystem, __VA_ARGS__)
+
+#define FI_INFO(prov, subsystem, ...)					\
+	FI_LOG(prov, FI_LOG_INFO, subsystem, __VA_ARGS__)
+
+#if defined(ENABLE_DEBUG) && ENABLE_DEBUG > 0
+#define FI_DBG(prov, subsystem, ...)					\
+	FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
+#else
+#define FI_DBG(prov_name, subsystem, ...)				\
+	do {} while (0)
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rdma/fi_log.h
+++ b/include/rdma/fi_log.h
@@ -35,8 +35,6 @@
 #ifndef FI_LOG_H
 #define FI_LOG_H
 
-#include "config.h"
-
 #include <rdma/fabric.h>
 #include <rdma/fi_prov.h>
 
@@ -70,30 +68,6 @@ int fi_log_enabled(const struct fi_provider *prov, enum fi_log_level level,
 void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 	    enum fi_log_subsys subsys, const char *func, int line,
 	    const char *fmt, ...);
-
-#define FI_LOG(prov, level, subsystem, ...)				\
-	do {								\
-		if (fi_log_enabled(prov, level, subsystem))		\
-			fi_log(prov, level, subsystem,			\
-				__func__, __LINE__, __VA_ARGS__);	\
-	} while (0)
-
-#define FI_WARN(prov, subsystem, ...)					\
-	FI_LOG(prov, FI_LOG_WARN, subsystem, __VA_ARGS__)
-
-#define FI_TRACE(prov, subsystem, ...)					\
-	FI_LOG(prov, FI_LOG_TRACE, subsystem, __VA_ARGS__)
-
-#define FI_INFO(prov, subsystem, ...)					\
-	FI_LOG(prov, FI_LOG_INFO, subsystem, __VA_ARGS__)
-
-#if ENABLE_DEBUG
-#define FI_DBG(prov, subsystem, ...)					\
-	FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
-#else
-#define FI_DBG(prov_name, subsystem, ...)				\
-	do {} while (0)
-#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
config.h was incorrectly added to address an undefined
ENABLE_DEBUG check.  Instead, replace the ENABLE_DEBUG
check with one that works when ENABLE_DEBUG is not
defined.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

This should address issue #2050, which stems from PR #2041, which spawned PR #2046.  We use ENABLE_DEBUG checks throughout the source base, but would NDEBUG be a better option?  At least that's somewhat standard.