### PR TITLE
prov/sockets: Initialize cntr threshold to INT_MAX

### DIFF
--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -509,7 +509,7 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	atomic_initialize(&_cntr->err_cnt, 0);
 
 	atomic_initialize(&_cntr->value, 0);
-	atomic_initialize(&_cntr->threshold, ~0);
+	atomic_initialize(&_cntr->threshold, INT_MAX);
 
 	dlist_init(&_cntr->tx_list);
 	dlist_init(&_cntr->rx_list);


### PR DESCRIPTION
Initialize cntr threshold to INT_MAX