### PR TITLE
.gitignore: add file in newer versions of Automake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ config/libtool.m4
 config/ltmain.sh
 config/lt*.m4
 config/missing
+config/test-driver
 
 util/fi_info


### PR DESCRIPTION
config/test-driver will be created by newer versions of Automake; it
is safe to ignore.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>