### PR TITLE
prov/verbs: add iwarp HW support

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -460,9 +460,9 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	fi_ibv_rdm_tagged_extra_buffers_pool = util_buf_pool_create(
 		_ep->buff_len, FI_IBV_RDM_MEM_ALIGNMENT, 0, 100);
 
-	_ep->max_inline_rc =
-	    fi_ibv_rdm_tagged_find_max_inline_size(_ep->domain->pd,
-						   _ep->domain->verbs);
+	_ep->max_inline_rc = 0;
+//	    fi_ibv_rdm_tagged_find_max_inline_size(_ep->domain->pd,
+//						   _ep->domain->verbs);
 	_ep->scq_depth = FI_IBV_RDM_TAGGED_DFLT_SCQ_SIZE;
 	_ep->rcq_depth = FI_IBV_RDM_TAGGED_DFLT_RCQ_SIZE;
 

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -435,7 +435,7 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->buff_len = FI_IBV_RDM_DFLT_BUFFER_SIZE;
 	_ep->rndv_threshold = FI_IBV_RDM_DFLT_BUFFERED_SSIZE;
 
-	_ep->rq_wr_depth = FI_IBV_RDM_TAGGED_DFLT_RQ_SIZE;
+	_ep->rq_wr_depth = info->domain_attr->rx_ctx_cnt;
 
 	/*
 	 * max number of WRs in SQ is n_buffer for send and

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -313,7 +313,6 @@ struct fi_ibv_rdm_tagged_conn {
 
 	int sends_outgoing;
 	int recv_preposted;
-	int last_recv_preposted;
 	/* counter for eager buffer releasing */
 	uint16_t recv_completions;
 	/* counter to control OOO behaviour, works in pair with recv_completions */
@@ -456,9 +455,9 @@ int fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_tagged_conn *conn);
 int fi_ibv_rdm_tagged_conn_cleanup(struct fi_ibv_rdm_tagged_conn *conn);
 int fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
                                 struct fi_ibv_rdm_tagged_conn *conn);
-int fi_ibv_rdm_tagged_repost_receives(struct fi_ibv_rdm_tagged_conn *conn,
-                                      struct fi_ibv_rdm_ep *ep,
-                                      int num_to_post);
+ssize_t fi_ibv_rdm_repost_receives(struct fi_ibv_rdm_tagged_conn *conn,
+				   struct fi_ibv_rdm_ep *ep,
+				   int num_to_post);
 int fi_ibv_rdm_tagged_open_ep(struct fid_domain *domain, struct fi_info *info,
                               struct fid_ep **ep, void *context);
 int fi_ibv_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -308,6 +308,7 @@ struct fi_ibv_rdm_tagged_conn {
 
 	int sends_outgoing;
 	int recv_preposted;
+	int last_recv_preposted;
 	/* counter for eager buffer releasing */
 	uint16_t recv_completions;
 	/* counter to control OOO behaviour, works in pair with recv_completions */

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -233,6 +233,11 @@ struct fi_ibv_rdm_ep {
 
 	struct fi_ibv_av *av;
 
+	/*
+	 * ibv_post_send opcode for tagged messaging.
+	 * It must generate work completion in receive CQ
+	 */
+	enum ibv_wr_opcode topcode;
 	int buff_len;
 	int n_buffs;
 	int rq_wr_depth;    // RQ depth

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -132,8 +132,8 @@ ssize_t fi_ibv_rdm_repost_receives(struct fi_ibv_rdm_tagged_conn *conn,
 
 		count += ret;
 		rest -= ret;
-		
-		assert(ret != batch);
+
+		assert(ret == batch);
 	}
 
 	return count;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -322,7 +322,7 @@ fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len,
 			wr.send_flags = (size < ep->max_inline_rc)
 				? IBV_SEND_INLINE : 0;
 			wr.imm_data = 0;
-			wr.opcode = IBV_WR_SEND; IBV_WR_RDMA_WRITE_WITH_IMM;
+			wr.opcode = ep->topcode;
 
 			sge.addr = (uintptr_t)(void*)sbuf;
 			sge.length = size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -603,9 +603,10 @@ void check_and_repost_receives(struct fi_ibv_rdm_ep *ep,
 	VERBS_DBG(FI_LOG_EP_DATA, "conn %p remain prepost recvs %d\n", conn, conn->recv_preposted);
 	if (conn->recv_preposted < ep->recv_preposted_threshold) {
 		int to_post = ep->rq_wr_depth - conn->recv_preposted;
-		int res = fi_ibv_rdm_tagged_repost_receives(conn, ep, to_post);
-		if (res == 0) {
+		ssize_t res = fi_ibv_rdm_repost_receives(conn, ep, to_post);
+		if (res < 0) {
 			VERBS_INFO(FI_LOG_EP_DATA, "repost recv failed %d\n", res);
+			/* TODO: err code propagation */
 			abort();
 		}
 		VERBS_DBG(FI_LOG_EP_DATA,

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -627,16 +627,8 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 
 	FI_IBV_DBG_OPCODE(wc->opcode, "RECV");
 
-	assert(wc->opcode != IBV_WC_RDMA_READ);
-
-	if (wc->status != IBV_WC_SUCCESS
-#if ENABLE_DEBUG
-	    ||
-	    (wc->opcode != IBV_WC_RECV_RDMA_WITH_IMM &&
-	     (wc->opcode != IBV_WC_RECV))
-#endif /* ENABLE_DEBUG */
-	   )
-	{
+	if (!FI_IBV_RDM_CHECK_RECV_WC(wc)) {
+		assert(0 && "Error recv wc\n");
 		return 1;
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -629,8 +629,13 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 
 	assert(wc->opcode != IBV_WC_RDMA_READ);
 
-	if (wc->status != IBV_WC_SUCCESS ||
-	    (wc->opcode != IBV_WC_RECV_RDMA_WITH_IMM && (wc->opcode != IBV_WC_RECV)))
+	if (wc->status != IBV_WC_SUCCESS
+#if ENABLE_DEBUG
+	    ||
+	    (wc->opcode != IBV_WC_RECV_RDMA_WITH_IMM &&
+	     (wc->opcode != IBV_WC_RECV))
+#endif /* ENABLE_DEBUG */
+	   )
 	{
 		return 1;
 	}

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -844,10 +844,14 @@ fi_ibv_rdm_tagged_rndv_recv_post_read(struct fi_ibv_rdm_tagged_request *request,
 	wr.wr.rdma.remote_addr = (uintptr_t) request->rndv.remote_addr;
 	wr.wr.rdma.rkey = request->rndv.rkey;
 
-	request->rndv.mr = ibv_reg_mr(p->ep->domain->pd,
-				      request->dest_buf,
-				      request->len, IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
-	assert(request->rndv.mr);
+	request->rndv.mr =
+		ibv_reg_mr(p->ep->domain->pd, request->dest_buf, request->len,
+			   IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE);
+	if (!request->rndv.mr) {
+		VERBS_INFO_ERRNO(FI_LOG_EP_DATA, "failed ibv_reg_mr", errno);
+		assert(0);
+		return -FI_ENOMEM;
+	}
 
 	sge.addr = (uintptr_t) request->dest_buf;
 	sge.length = request->len;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -162,7 +162,7 @@ fi_ibv_rdm_tagged_eager_send_ready(struct fi_ibv_rdm_tagged_request *request,
 	sge.lkey = conn->s_mr->lkey;
 
 	wr.imm_data = 0;
-	wr.opcode = IBV_WR_SEND; IBV_WR_RDMA_WRITE_WITH_IMM;
+	wr.opcode = p->ep->topcode;
 	struct fi_ibv_rdm_buf *sbuf = (struct fi_ibv_rdm_buf *)request->sbuf;
 	char *payload = &(sbuf->payload[0]);
 
@@ -270,7 +270,7 @@ fi_ibv_rdm_tagged_rndv_rts_send_ready(struct fi_ibv_rdm_tagged_request *request,
 		fi_ibv_rdm_get_remote_addr(conn, request->sbuf);
 	wr.wr.rdma.rkey = conn->remote_rbuf_rkey;
 	wr.send_flags = 0;
-	wr.opcode = IBV_WR_SEND; IBV_WR_RDMA_WRITE_WITH_IMM;
+	wr.opcode = p->ep->topcode;
 	wr.imm_data = 0;
 
 	sge.addr = (uintptr_t)request->sbuf;
@@ -904,7 +904,7 @@ fi_ibv_rdm_tagged_rndv_recv_read_lc(struct fi_ibv_rdm_tagged_request *request,
 	wr.wr_id = ((uint64_t) (uintptr_t) (void *) request);
 	assert(FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wr.wr_id) == 0);
 
-	wr.opcode = IBV_WR_SEND; IBV_WR_RDMA_WRITE_WITH_IMM;
+	wr.opcode = p->ep->topcode;
 	wr.sg_list = &sge;
 	wr.num_sge = 1;
 	wr.wr.rdma.remote_addr = 

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -161,7 +161,11 @@ int fi_ibv_rdm_tagged_find_ipoib_addr(const struct sockaddr_in *addr,
 		if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_INET) {
 			struct sockaddr_in *paddr =
 			    (struct sockaddr_in *) tmp->ifa_addr;
-			if (!strncmp(tmp->ifa_name, "ib", 2)) {
+			/* TODO: initialize from outside */
+			if (!strncmp(tmp->ifa_name, "ib",   2) ||
+			    !strncmp(tmp->ifa_name, "enp",  3) ||
+			    !strncmp(tmp->ifa_name, "eth2", 4))
+			{
 				int ret = 0;
 
 				if (addr && addr->sin_addr.s_addr) {

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -69,14 +69,12 @@ struct fi_ibv_msg_ep;
 #define FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM (8)
 
 #define FI_IBV_RDM_DFLT_BUFFER_SIZE					\
-	(1 * FI_IBV_RDM_BUF_ALIGNMENT)
+	(3 * FI_IBV_RDM_BUF_ALIGNMENT)
 
 #define FI_IBV_RDM_DFLT_BUFFERED_SSIZE					\
 	(FI_IBV_RDM_DFLT_BUFFER_SIZE -					\
 	 FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE -				\
 	 sizeof(struct fi_ibv_rdm_header))
-
-#define FI_IBV_RDM_TAGGED_DFLT_RQ_SIZE  (500)
 
 /* TODO: CQs depths increased from 100 to 1000 to prevent
  *      "Work Request Flushed Error" in stress tests like alltoall.

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -167,7 +167,7 @@ int fi_ibv_rdm_tagged_send_postponed_process(struct dlist_entry *item,
                                               const void *arg);
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_tagged_conn *conn,
 				  struct fi_ibv_rdm_ep *ep);
-int fi_ibv_rdm_tagged_find_ipoib_addr(const struct sockaddr_in *addr,
-				      struct fi_ibv_rdm_cm* cm);
+int fi_ibv_rdm_find_ipoib_addr(const struct sockaddr_in *addr,
+			       struct fi_ibv_rdm_cm* cm);
 
 #endif /* _VERBS_UTILS_H */

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -84,6 +84,14 @@ struct fi_ibv_msg_ep;
 
 #define FI_IBV_RDM_CM_RESOLVEADDR_TIMEOUT (30000)
 
+#if ENABLE_DEBUG
+#define FI_IBV_RDM_CHECK_RECV_WC(wc)						\
+	((wc->status == IBV_WC_SUCCESS) &&					\
+	(wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM || wc->opcode == IBV_WC_RECV))
+#else
+#define FI_IBV_RDM_CHECK_RECV_WC(wc) (wc->status == IBV_WC_SUCCESS)
+#endif /* ENABLE_DEBUG */
+
 /* TODO: Holy macro batman, use verbs calls */
 #define FI_IBV_DBG_OPCODE(wc_opcode, str)                                      \
         VERBS_DBG(FI_LOG_CQ, "CQ COMPL: "str" -> %s\n",                        \

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -69,14 +69,14 @@ struct fi_ibv_msg_ep;
 #define FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM (8)
 
 #define FI_IBV_RDM_DFLT_BUFFER_SIZE					\
-	(3 * FI_IBV_RDM_BUF_ALIGNMENT)
+	(1 * FI_IBV_RDM_BUF_ALIGNMENT)
 
 #define FI_IBV_RDM_DFLT_BUFFERED_SSIZE					\
 	(FI_IBV_RDM_DFLT_BUFFER_SIZE -					\
 	 FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE -				\
 	 sizeof(struct fi_ibv_rdm_header))
 
-#define FI_IBV_RDM_TAGGED_DFLT_RQ_SIZE  (1000)
+#define FI_IBV_RDM_TAGGED_DFLT_RQ_SIZE  (500)
 
 /* TODO: CQs depths increased from 100 to 1000 to prevent
  *      "Work Request Flushed Error" in stress tests like alltoall.

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -91,7 +91,7 @@ static int fi_ibv_rdm_cm_init(struct fi_ibv_rdm_cm* cm,
 		return -FI_EOTHER;
 	}
 
-	if (fi_ibv_rdm_tagged_find_ipoib_addr(src_addr, cm)) {
+	if (fi_ibv_rdm_find_ipoib_addr(src_addr, cm)) {
 		VERBS_INFO(FI_LOG_EP_CTRL, 
 			   "Failed to find correct IPoIB address\n");
 		return -FI_ENODEV;

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -174,7 +174,7 @@ int fi_ibv_create_ep(const char *node, const char *service,
 	if (FI_IBV_EP_TYPE_IS_RDM(hints)) {
 		struct fi_ibv_rdm_cm* cm = 
 			container_of(id, struct fi_ibv_rdm_cm, listener);
-		fi_ibv_rdm_cm_init(cm, _rai);
+		ret = fi_ibv_rdm_cm_init(cm, _rai);
 	} else {
 		ret = rdma_create_ep(id, _rai, NULL, NULL);
 		if (ret) {
@@ -366,5 +366,9 @@ static void fi_ibv_fini(void)
 
 VERBS_INI
 {
+	fi_param_define(&fi_ibv_prov, "iface", FI_PARAM_STRING,
+			"prefix or full name of network interface associated "
+			"with IB device (default: ib)");
+
 	return &fi_ibv_prov;
 }

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -641,8 +641,8 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx, struct fi_info *info
 
 	info->domain_attr->cq_cnt 		= device_attr.max_cq;
 	info->domain_attr->ep_cnt 		= device_attr.max_qp;
-	info->domain_attr->tx_ctx_cnt 		= MIN(info->domain_attr->tx_ctx_cnt, device_attr.max_qp);
-	info->domain_attr->rx_ctx_cnt 		= MIN(info->domain_attr->rx_ctx_cnt, device_attr.max_qp);
+	info->domain_attr->tx_ctx_cnt 		= MIN(info->domain_attr->tx_ctx_cnt, device_attr.max_qp_wr);
+	info->domain_attr->rx_ctx_cnt 		= MIN(info->domain_attr->rx_ctx_cnt, device_attr.max_qp_wr);
 	info->domain_attr->max_ep_tx_ctx 	= device_attr.max_qp;
 	info->domain_attr->max_ep_rx_ctx 	= device_attr.max_qp;
 

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -617,6 +617,10 @@ static inline int fi_ibv_get_qp_cap(struct ibv_context *ctx,
 	info->tx_attr->size	 	= init_attr.cap.max_send_wr;
 
 	info->rx_attr->iov_limit 	= init_attr.cap.max_recv_sge;
+	/*
+	 * On some HW ibv_create_qp can increase max_recv_wr value more than
+	 * it really supports. So, alignment with device capability is needed.
+	 */
 	info->rx_attr->size	 	= MIN(init_attr.cap.max_recv_wr,
 						device_attr->max_qp_wr);
 

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -51,6 +51,7 @@
 
 #define VERBS_TX_OP_FLAGS (FI_INJECT | FI_COMPLETION | FI_TRANSMIT_COMPLETE)
 #define VERBS_TX_OP_FLAGS_IWARP (FI_INJECT | FI_COMPLETION)
+#define VERBS_TX_OP_FLAGS_IWARP_RDM (VERBS_TX_OP_FLAGS)
 
 #define VERBS_TX_MODE VERBS_MODE
 #define VERBS_TX_RDM_MODE VERBS_RDM_MODE
@@ -761,10 +762,12 @@ static int fi_ibv_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 			goto err;
 		}
 
-		fi->ep_attr->protocol = (ep_dom == &verbs_msg_domain) ?
-					FI_PROTO_IWARP : FI_PROTO_IWARP_RDM;
 		if (ep_dom == &verbs_msg_domain) {
+			fi->ep_attr->protocol = FI_PROTO_IWARP;
 			fi->tx_attr->op_flags = VERBS_TX_OP_FLAGS_IWARP;
+		} else {
+			fi->ep_attr->protocol = FI_PROTO_IWARP_RDM;
+			fi->tx_attr->op_flags = VERBS_TX_OP_FLAGS_IWARP_RDM;
 		}
 		break;
 	default:

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -763,7 +763,9 @@ static int fi_ibv_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 
 		fi->ep_attr->protocol = (ep_dom == &verbs_msg_domain) ?
 					FI_PROTO_IWARP : FI_PROTO_IWARP_RDM;
-		fi->tx_attr->op_flags = VERBS_TX_OP_FLAGS_IWARP;
+		if (ep_dom == &verbs_msg_domain) {
+			fi->tx_attr->op_flags = VERBS_TX_OP_FLAGS_IWARP;
+		}
 		break;
 	default:
 		FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "Unknown transport type\n");


### PR DESCRIPTION
First patch add iWarp HW support.
All following patches add parameters by recognition and cleanup related code.

There is a new possibility to define full name or prefix of interface associated with IB device via FI_VERBS_IFACE env variable (iface parameter), default value is "ib" as before.

@a-ilango please, take a look in verbs_info.c changes especially. domain_attr->tx[rx]_ctx_cnt values changed for ep_msg too. Let me know if it's wrong. Also, probably you can reuse iface parameter for msg_ep if that's make sense.