### PR TITLE
prov/gni: swat bug in vector code

### DIFF
--- a/prov/gni/src/gnix_vector.c
+++ b/prov/gni/src/gnix_vector.c
@@ -215,7 +215,7 @@ inline int _gnix_vec_at(gnix_vector_t *vec, void **element, gnix_vec_index_t ind
 {
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
-	if (unlikely(!vec || index > vec->attr.cur_size || !element)) {
+	if (unlikely(!vec || index >= vec->attr.cur_size || !element)) {
 		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid parameter to "
 			  "_gnix_vec_at\n");
 		return -FI_EINVAL;


### PR DESCRIPTION
check for index limit wasn't quite right for vector
lookup.

verified with sandia shmem tests at high PE counts
@sungeunchoi 

upstream merge of ofi-cray/libfabric-cray#833

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@33214e7fd9d01152d4be30f742ab36f31cb9c60a)