### PR TITLE
Document err_data lifetime for EQ.

### DIFF
--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -396,9 +396,10 @@ through the prov_errno and err_data fields.  Users may call fi_eq_strerror to
 convert provider specific error information into a printable string
 for debugging purposes.
 
-If err_data_size is > 0, then the buffer referenced by err_data is
-directly user-accessible.  Applications which read the err_data buffer
-must ensure that they do not read past the end of the referenced buffer.
+If err_data_size is > 0, then the buffer referenced by err_data is directly
+user-accessible.  The contents of the buffer will remain valid until a
+subsequent read call against the EQ.  Applications which read the err_data
+buffer must ensure that they do not read past the end of the referenced buffer.
 
 # RETURN VALUES
 


### PR DESCRIPTION
The data referenced by the err_data buffer of the fi_eq_err_entry struct
is only valid until the next call to fi_eq_(s)read.

Closes #2063.

@shefty 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>