### PR TITLE
Add SRQ support to verbs MSG

### DIFF
--- a/prov/verbs/Makefile.include
+++ b/prov/verbs/Makefile.include
@@ -7,6 +7,7 @@ _verbs_files = \
 	prov/verbs/src/verbs_av.c \
 	prov/verbs/src/verbs_cm.c \
 	prov/verbs/src/verbs_cq.c \
+	prov/verbs/src/verbs_srq.c \
 	prov/verbs/src/verbs_domain.c \
 	prov/verbs/src/verbs_eq.c \
 	prov/verbs/src/verbs_info.c \

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -222,12 +222,16 @@ struct fi_ibv_srq_ep {
 	struct ibv_srq		*srq;
 };
 
+int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
+		struct fid_ep **rx_ep, void *context);
+
 struct fi_ibv_msg_ep {
 	struct fid_ep		ep_fid;
 	struct rdma_cm_id	*id;
 	struct fi_ibv_eq	*eq;
 	struct fi_ibv_cq	*rcq;
 	struct fi_ibv_cq	*scq;
+	struct fi_ibv_srq_ep	*srq_ep;
 	uint64_t		ep_flags;
 	struct fi_info		*info;
 	atomic_t		unsignaled_send_cnt;
@@ -259,6 +263,8 @@ struct fi_ops_msg *fi_ibv_msg_ep_ops_msg(struct fi_ibv_msg_ep *ep);
 struct fi_ops_rma *fi_ibv_msg_ep_ops_rma(struct fi_ibv_msg_ep *ep);
 
 struct fi_ops_rma *fi_ibv_rdm_ep_ops_rma(struct fi_ibv_rdm_ep *ep);
+
+struct fi_ops_msg *fi_ibv_msg_srq_ep_ops_msg(struct fi_ibv_msg_ep *ep);
 
 struct fi_ibv_connreq {
 	struct fid		handle;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -217,6 +217,11 @@ struct fi_ibv_mem_desc {
 	struct fi_ibv_domain	*domain;
 };
 
+struct fi_ibv_srq_ep {
+	struct fid_ep		ep_fid;
+	struct ibv_srq		*srq;
+};
+
 struct fi_ibv_msg_ep {
 	struct fid_ep		ep_fid;
 	struct rdma_cm_id	*id;

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -141,6 +141,9 @@ fi_ibv_msg_ep_connect(struct fid_ep *ep, const void *addr,
 	conn_param.retry_count = 15;
 	conn_param.rnr_retry_count = 7;
 
+	if (_ep->srq_ep)
+		conn_param.srq = 1;
+
 	src_addr = rdma_get_local_addr(_ep->id);
 	if (src_addr) {
 		FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "src_addr: %s:%d\n",
@@ -180,6 +183,9 @@ fi_ibv_msg_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	conn_param.initiator_depth = RDMA_MAX_INIT_DEPTH;
 	conn_param.flow_control = 1;
 	conn_param.rnr_retry_count = 7;
+
+	if (_ep->srq_ep)
+		conn_param.srq = 1;
 
 	ret = rdma_accept(_ep->id, &conn_param);
 	if (ret)

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -189,7 +189,7 @@ static struct fi_ops_domain fi_ibv_domain_ops = {
 	.cntr_open = fi_no_cntr_open,
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = fi_no_stx_context,
-	.srx_ctx = fi_no_srx_context,
+	.srx_ctx = fi_ibv_srq_context,
 };
 
 static struct fi_ops_domain fi_ibv_rdm_domain_ops = {

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -62,6 +62,7 @@ fi_ibv_msg_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flag
 	wr.num_sge = msg->iov_count;
 
 	ret = ibv_post_recv(_ep->id->qp, &wr, &bad);
+
 	switch (ret) {
 	case ENOMEM:
 		return -FI_EAGAIN;
@@ -220,5 +221,23 @@ static struct fi_ops_msg fi_ibv_msg_ep_msg_ops = {
 struct fi_ops_msg *fi_ibv_msg_ep_ops_msg(struct fi_ibv_msg_ep *ep)
 {
 	return &fi_ibv_msg_ep_msg_ops;
+}
+
+static struct fi_ops_msg fi_ibv_msg_srq_ep_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = fi_no_msg_recv,
+	.recvv = fi_no_msg_recvv,
+	.recvmsg = fi_no_msg_recvmsg,
+	.send = fi_ibv_msg_ep_send,
+	.sendv = fi_ibv_msg_ep_sendv,
+	.sendmsg = fi_ibv_msg_ep_sendmsg,
+	.inject = fi_ibv_msg_ep_inject,
+	.senddata = fi_ibv_msg_ep_senddata,
+	.injectdata = fi_ibv_msg_ep_injectdata,
+};
+
+struct fi_ops_msg *fi_ibv_msg_srq_ep_ops_msg(struct fi_ibv_msg_ep *ep)
+{
+	return &fi_ibv_msg_srq_ep_msg_ops;
 }
 

--- a/prov/verbs/src/verbs_srq.c
+++ b/prov/verbs/src/verbs_srq.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+
+#include "fi_verbs.h"
+
+static struct fi_ops_ep fi_ibv_srq_ep_base_ops = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = fi_no_cancel,
+	.getopt = fi_no_getopt,
+	.setopt = fi_no_setopt,
+	.tx_ctx = fi_no_tx_ctx,
+	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
+};
+
+static struct fi_ops_cm fi_ibv_srq_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
+	.getname = fi_no_getname,
+	.getpeer = fi_no_getpeer,
+	.connect = fi_no_connect,
+	.listen = fi_no_listen,
+	.accept = fi_no_accept,
+	.reject = fi_no_reject,
+	.shutdown = fi_no_shutdown,
+};
+
+static struct fi_ops_rma fi_ibv_srq_rma_ops = {
+	.size = sizeof(struct fi_ops_rma),
+	.read = fi_no_rma_read,
+	.readv = fi_no_rma_readv,
+	.readmsg = fi_no_rma_readmsg,
+	.write = fi_no_rma_write,
+	.writev = fi_no_rma_writev,
+	.writemsg = fi_no_rma_writemsg,
+	.inject = fi_no_rma_inject,
+	.writedata = fi_no_rma_writedata,
+	.injectdata = fi_no_rma_injectdata,
+};
+
+static struct fi_ops_atomic fi_ibv_srq_atomic_ops = {
+	.size = sizeof(struct fi_ops_atomic),
+	.write = fi_no_atomic_write,
+	.writev = fi_no_atomic_writev,
+	.writemsg = fi_no_atomic_writemsg,
+	.inject = fi_no_atomic_inject,
+	.readwrite = fi_no_atomic_readwrite,
+	.readwritev = fi_no_atomic_readwritev,
+	.readwritemsg = fi_no_atomic_readwritemsg,
+	.compwrite = fi_no_atomic_compwrite,
+	.compwritev = fi_no_atomic_compwritev,
+	.compwritemsg = fi_no_atomic_compwritemsg,
+	.writevalid = fi_no_atomic_writevalid,
+	.readwritevalid = fi_no_atomic_readwritevalid,
+	.compwritevalid = fi_no_atomic_compwritevalid,
+};
+
+static ssize_t
+fi_ibv_srq_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags)
+{
+	struct fi_ibv_srq_ep *_ep;
+	struct ibv_recv_wr wr, *bad;
+	struct ibv_sge *sge = NULL;
+	ssize_t ret;
+	size_t i;
+
+	_ep = container_of(ep, struct fi_ibv_srq_ep, ep_fid);
+	assert(_ep->srq);
+
+	wr.wr_id = (uintptr_t) msg->context;
+	wr.next = NULL;
+	if (msg->iov_count) {
+		sge = alloca(sizeof(*sge) * msg->iov_count);
+		for (i = 0; i < msg->iov_count; i++) {
+			sge[i].addr = (uintptr_t) msg->msg_iov[i].iov_base;
+			sge[i].length = (uint32_t) msg->msg_iov[i].iov_len;
+			sge[i].lkey = (uint32_t) (uintptr_t) (msg->desc[i]);
+		}
+
+	}
+	wr.sg_list = sge;
+	wr.num_sge = msg->iov_count;
+
+	ret = ibv_post_srq_recv(_ep->srq, &wr, &bad);
+
+	switch (ret) {
+	case ENOMEM:
+		return -FI_EAGAIN;
+	case -1:
+		/* Deal with non-compliant libibverbs drivers which set errno
+		 * instead of directly returning the error value */
+		return (errno == ENOMEM) ? -FI_EAGAIN : -errno;
+	default:
+		return -ret;
+	}
+}
+
+static ssize_t
+fi_ibv_srq_ep_recv(struct fid_ep *ep, void *buf, size_t len,
+		void *desc, fi_addr_t src_addr, void *context)
+{
+	struct iovec iov;
+	struct fi_msg msg;
+
+	iov.iov_base = buf;
+	iov.iov_len = len;
+
+	msg.msg_iov = &iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = src_addr;
+	msg.context = context;
+
+	return fi_ibv_srq_ep_recvmsg(ep, &msg, 0);
+}
+
+static ssize_t
+fi_ibv_srq_ep_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+                 size_t count, fi_addr_t src_addr, void *context)
+{
+	struct fi_msg msg;
+
+	msg.msg_iov = iov;
+	msg.desc = desc;
+	msg.iov_count = count;
+	msg.addr = src_addr;
+	msg.context = context;
+
+	return fi_ibv_srq_ep_recvmsg(ep, &msg, 0);
+}
+
+static struct fi_ops_msg fi_ibv_srq_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = fi_ibv_srq_ep_recv,
+	.recvv = fi_ibv_srq_ep_recvv,
+	.recvmsg = fi_ibv_srq_ep_recvmsg,
+	.send = fi_no_msg_send,
+	.sendv = fi_no_msg_sendv,
+	.sendmsg = fi_no_msg_sendmsg,
+	.inject = fi_no_msg_inject,
+	.senddata = fi_no_msg_senddata,
+	.injectdata = fi_no_msg_injectdata,
+};
+
+int fi_ibv_srq_close(fid_t fid)
+{
+	struct fi_ibv_srq_ep *ep;
+	int rc;
+
+	ep = container_of(fid, struct fi_ibv_srq_ep, ep_fid.fid);
+
+	rc = ibv_destroy_srq(ep->srq);
+	if (rc)
+		FI_WARN(&fi_ibv_prov, FI_LOG_EP_CTRL, "Cannot destroy SRQ rc=%d\n", rc);
+
+	free(ep);
+
+	return 0;
+}
+
+static struct fi_ops fi_ibv_srq_ep_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = fi_ibv_srq_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+
+int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
+		struct fid_ep **rx_ep, void *context)
+{
+	struct ibv_srq_init_attr srq_init_attr = {};
+	struct fi_ibv_domain *dom;
+	struct fi_ibv_srq_ep *_rx_ep;
+
+	if (!domain)
+		return -FI_EINVAL;
+
+	_rx_ep = calloc(1, sizeof *_rx_ep);
+	if (!_rx_ep)
+		return -FI_ENOMEM;
+
+	dom = container_of(domain, struct fi_ibv_domain, domain_fid);
+
+	_rx_ep->ep_fid.fid.fclass = FI_CLASS_SRX_CTX;
+	_rx_ep->ep_fid.fid.context = context;
+	_rx_ep->ep_fid.fid.ops = &fi_ibv_srq_ep_ops;
+	_rx_ep->ep_fid.ops = &fi_ibv_srq_ep_base_ops;
+	_rx_ep->ep_fid.msg = &fi_ibv_srq_msg_ops;
+	_rx_ep->ep_fid.cm = &fi_ibv_srq_cm_ops;
+	_rx_ep->ep_fid.rma = &fi_ibv_srq_rma_ops;
+	_rx_ep->ep_fid.atomic = &fi_ibv_srq_atomic_ops;
+
+	srq_init_attr.attr.max_wr = attr->size;
+	srq_init_attr.attr.max_sge = attr->iov_limit;
+
+	_rx_ep->srq = ibv_create_srq(dom->pd, &srq_init_attr);
+	if (!_rx_ep->srq) {
+		free(_rx_ep);
+		return -errno;
+	}
+
+	*rx_ep = &_rx_ep->ep_fid;
+
+	return 0;
+}
+


### PR DESCRIPTION
Hi,

These two patches aim at adding the support for Shared Receive Queues to the Verbs provider.
Only FI_MSG  is supported at this moment but I can write another patch to support FI_RMA as well. 

For your information, I based my patches on the discussion available here:
https://github.com/ofiwg/libfabric/issues/39

Thank you for your feedback and for your effort in developing this great network library.
(I've been using it for 1 week but I already love it!)

Sylvain