### PR TITLE
Fix page loading issues.

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -16,7 +16,11 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
+      {% if layout.theme.name %}
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
+      {% else %}
       {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
+      {% endif %}
     {% endif %}  
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
This is analogous to commit #311 in the jekyll-bootstrap repository.
In Jekyll v3.0, documents use `layout` for metadata instead of `page`. Try to
handle both cases. This solves the issue of Jekyll generating pages
without the theme name in the asset path.

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>