### PR TITLE
prov/sockets: Fixed resource leaks and null pointer deference found by Coverity Scan

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1394,6 +1394,8 @@ struct fi_info *sock_fi_info(enum fi_ep_type ep_type, struct fi_info *hints,
 	if (src_addr) {
 		memcpy(info->src_addr, src_addr, sizeof(struct sockaddr_in));
 		info->src_addrlen = sizeof(struct sockaddr_in);
+	} else {
+		sock_get_src_addr_from_hostname(info->src_addr, NULL);
 	}
 
 	if (dest_addr) {
@@ -1420,11 +1422,11 @@ struct fi_info *sock_fi_info(enum fi_ep_type ep_type, struct fi_info *hints,
 		if (hints->handle)
 			info->handle = hints->handle;
 
-		sock_set_domain_attr(src_addr, hints->domain_attr, info->domain_attr);
-		sock_set_fabric_attr(src_addr, hints->fabric_attr, info->fabric_attr);
+		sock_set_domain_attr(info->src_addr, hints->domain_attr, info->domain_attr);
+		sock_set_fabric_attr(info->src_addr, hints->fabric_attr, info->fabric_attr);
 	} else {
-		sock_set_domain_attr(src_addr, NULL, info->domain_attr);
-		sock_set_fabric_attr(src_addr, NULL, info->fabric_attr);
+		sock_set_domain_attr(info->src_addr, NULL, info->domain_attr);
+		sock_set_fabric_attr(info->src_addr, NULL, info->fabric_attr);
 	}
 
 	info->ep_attr->type = ep_type;

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -545,8 +545,11 @@ struct slist sock_get_list_of_addr(void)
 			ret = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in),
 					  addr_entry->hostname, sizeof(addr_entry->hostname),
 					  NULL, 0, NI_NUMERICHOST);
-			if (ret)
+			if (ret) {
+				SOCK_LOG_DBG("getnameinfo failed: %d\n", ret);
+				free(addr_entry);
 				continue;
+			}
 			slist_insert_tail(&addr_entry->entry, &addr_list);
 		}
 		freeifaddrs(ifaddrs);
@@ -667,7 +670,7 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 		while (!slist_empty(&addr_list)) {
 			entry = slist_remove_head(&addr_list);
 			host_entry = container_of(entry, struct sock_host_list_entry, entry);
-			node = strdup(host_entry->hostname);
+			node = host_entry->hostname;
 			ret = sock_node_getinfo(node, service, flags, hints, info, &tail);
 			free(host_entry);
 			if (ret) {


### PR DESCRIPTION
- Fixed a resource leak in the error path while getting the list of addresses
- Fixed unnecessary resource allocation while iterating list of addresses returned by getifaddrs
- Added code to get src_addr before setting fabric/domain attributes when src_addr is NULL
 
Can you please review @jithinjosepkl?

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>