### PR TITLE
prov/gni: Add udreg option for memory registration

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -48,6 +48,13 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                                   gni_LDFLAGS="$CRAY_ALPS_UTIL_LIBS $gni_LDFLAGS"
                                  ],
                                  [alps_util_happy=0])
+               FI_PKG_CHECK_MODULES([CRAY_UDREG], [cray-udreg],
+                                 [udreg_lib_happy=1
+                                  gni_CPPFLAGS="-DHAVE_UDREG $CRAY_UDREG_INCLUDE_OPTS $gni_CPPFLAGS"
+                                  gni_LDFLAGS="$CRAY_UDREG_POST_LINK_OPTS $gni_LDFLAGS"
+                                  gni_LIBS="-ludreg $gni_LIBS"
+                                 ],
+                                 [udreg_lib_happy=0])
                gni_path_to_gni_pub=${CRAY_GNI_HEADERS_CFLAGS:2}
 dnl looks like we need to get rid of some white space
                gni_path_to_gni_pub=${gni_path_to_gni_pub%?}/gni_pub.h
@@ -72,8 +79,8 @@ dnl looks like we need to get rid of some white space
                            [AC_MSG_CHECKING([criterion path])
                             if test -d "$with_criterion"; then
                                 AC_MSG_RESULT([yes])
-                                gnitest_CPPFLAGS="-I$with_criterion/include $gnitest_CPPFLAGS"
-				gnitest_LIBS="-lcriterion $gnitest_LIBS"
+                                gnitest_CPPFLAGS="-I$with_criterion/include -DHAVE_UDREG $CRAY_UDREG_INCLUDE_OPTS $gnitest_CPPFLAGS"
+                                gnitest_LIBS="-lcriterion -ludreg  $gnitest_LIBS"
 
                                 if test -d "$with_criterion/lib"; then
                                         gnitest_LDFLAGS="$CRAY_ALPS_LLI_STATIC_LIBS -L$with_criterion/lib -Wl,-rpath=$with_criterion/lib $gnitest_LDFLAGS"
@@ -84,6 +91,8 @@ dnl looks like we need to get rid of some white space
                                 else
                                         have_criterion=false
                                 fi
+
+                                gnitest_LDFLAGS="$CRAY_UDREG_POST_LINK_OPTS $gnitest_LDFLAGS"
                                 FI_PKG_CHECK_MODULES([CRAY_PMI], [cray-pmi],
                                                      [],
                                                      [have_criterion=false])
@@ -120,5 +129,6 @@ dnl looks like we need to get rid of some white space
         AC_SUBST(gnitest_LIBS)
 
         AS_IF([test $gni_header_happy -eq 1 -a $ugni_lib_happy -eq 1 \
-               -a $alps_lli_happy -eq 1 -a $alps_util_happy -eq 1], [$1], [$2])
+               -a $alps_lli_happy -eq 1 -a $alps_util_happy -eq 1 \
+               -a $udreg_lib_happy -eq 1], [$1], [$2])
 ])

--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -57,6 +57,8 @@ typedef enum dom_ops_val { GNI_MSG_RENDEZVOUS_THRESHOLD,
 			   GNI_MAX_RETRANSMITS,
 			   GNI_ERR_INJECT_COUNT,
 			   GNI_MR_CACHE_LAZY_DEREG,
+			   GNI_MR_CACHE_UDREG,
+			   GNI_MR_UDREG_REG_LIMIT,
 			   GNI_NUM_DOM_OPS
 } dom_ops_val_t;
 

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -65,6 +65,11 @@ extern "C" {
 #include <fi_rbuf.h>
 #include <fi_list.h>
 #include <fi_file.h>
+
+#ifdef HAVE_UDREG
+#include <udreg_pub.h>
+#endif
+
 #include "gni_pub.h"
 #include "gnix_util.h"
 #include "gnix_freelist.h"
@@ -346,6 +351,12 @@ struct gnix_fid_domain {
 	gnix_mr_cache_attr_t mr_cache_attr;
 	gnix_mr_cache_t *mr_cache;
 	fastlock_t mr_cache_lock;
+	struct gnix_mr_ops *mr_ops;
+	int mr_cache_type;
+	int udreg_reg_limit;
+#ifdef HAVE_UDREG
+	udreg_cache_handle_t udreg_cache;
+#endif
 };
 
 #define GNIX_CQS_PER_EP		8


### PR DESCRIPTION
Add udreg as a domain option selection for use
with memory registration

upstream merge of ofi-cray/libfabric-cray#826
@sungeunchoi 

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@827b3a67dba8c5b2816be6e213f2d2ef0a4dd9ab)