### PR TITLE
prov/gni: Fix domain test to accept non-zero value

### DIFF
--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -136,7 +136,11 @@ Test(domain, open_ops)
 		for (op = 0; op < GNI_NUM_DOM_OPS; op++) {
 			ret = gni_domain_ops->get_val(&doms[i]->fid, op, &val);
 			cr_assert(ret == FI_SUCCESS, "get_val");
-			cr_assert(val == i*op+op, "Incorrect op value");
+
+			if (op == GNI_MR_CACHE_UDREG)
+				cr_assert(val != 0, "Incorrect op value");
+			else 
+				cr_assert(val == i*op+op, "Incorrect op value");
 		}
 		ret = fi_close(&doms[i]->fid);
 		cr_assert(ret == FI_SUCCESS, "fi_close domain");


### PR DESCRIPTION
Fixed domain test to accept non-zero value for
boolean opts

upstream merge of ofi-cray/libfabric-cray#834
@sungeunchoi 

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@5933f311dbc8967e49ea4f20c6c20013e8dfbf01)