### PR TITLE
added util shm layer

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -55,6 +55,7 @@
 #include <fi_rbuf.h>
 #include <fi_signal.h>
 #include <fi_enosys.h>
+#include <fi_osd.h>
 
 #ifndef _FI_UTIL_H_
 #define _FI_UTIL_H_
@@ -410,4 +411,9 @@ int ofix_getinfo(uint32_t version, const char *node, const char *service,
 			int get_base_info, struct fi_info **info);
 char *ofi_strdup_less_prefix(char *name, char *prefix);
 char *ofi_strdup_add_prefix(char *name, char *prefix);
+
+int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
+		int readonly, void **mapped);
+int ofi_shm_unmap(struct util_shm *shm);
+
 #endif

--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -30,6 +30,9 @@
  * SOFTWARE.
  */
 
+#ifndef _FREEBSD_OSD_H_
+#define _FREEBSD_OSD_H_
+
 #include <sys/endian.h>
 #include <pthread_np.h>
 
@@ -40,3 +43,12 @@
 #define HOST_NAME_MAX  128
 
 typedef cpuset_t cpu_set_t;
+
+static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
+{
+	return -1;
+}
+
+#endif /* _FREEBSD_OSD_H_ */
+
+

--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -30,5 +30,26 @@
  * SOFTWARE.
  */
 
+#ifndef _LINUX_OSD_H_
+#define _LINUX_OSD_H_
+
+/*#define _GNU_SOURCE*/
+
 #include <byteswap.h>
 #include <endian.h>
+#include <sys/mman.h>
+
+#include "unix/osd.h"
+#include "rdma/fi_errno.h"
+
+static inline int ofi_shm_remap(struct util_shm *shm,
+				size_t newsize, void **mapped)
+{
+	shm->ptr = mremap(shm->ptr, shm->size, newsize, 0);
+	shm->size = newsize;
+	*mapped = shm->ptr;
+	return shm->ptr == MAP_FAILED ? -FI_EINVAL : FI_SUCCESS;
+}
+
+#endif /* _LINUX_OSD_H_ */
+

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -64,6 +64,11 @@ extern "C" {
 
 int clock_gettime(clockid_t clk_id, struct timespec *tp);
 
+static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
+{
+	return -1;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -37,6 +37,14 @@
 #include <unistd.h>
 #include <errno.h>
 
+struct util_shm
+{
+	int		shared_fd;
+	void		*ptr;
+	const char	*name;
+	size_t		size;
+};
+
 static inline int ofi_memalign(void **memptr, size_t alignment, size_t size)
 {
 	return posix_memalign(memptr, alignment, size);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include "pthread.h"
 
+#include <rdma/fi_errno.h>
 #include <rdma/fabric.h>
 
 #ifdef __cplusplus
@@ -33,6 +34,15 @@ extern "C" {
 #define LITTLE_ENDIAN 5678
 #define BIG_ENDIAN 8765
 #define BYTE_ORDER LITTLE_ENDIAN
+
+struct util_shm
+{ /* this is dummy structure to provide compilation on Windows platform. */
+  /* will be updated on real Windows implementation */
+	int		shared_fd;
+	void		*ptr;
+	const char	*name;
+	size_t		size;
+};
 
 static inline void ofi_osd_init()
 {
@@ -113,7 +123,7 @@ static inline int ffsll(long long val)
 	return 0;
 }
 
-static inline int asprintf(char** ptr, const char* format, ...)
+static inline int asprintf(char **ptr, const char *format, ...)
 {
 	va_list args;
 	va_start(args, format);
@@ -127,7 +137,7 @@ static inline int asprintf(char** ptr, const char* format, ...)
 	return len;
 }
 
-static inline char* strsep(char** stringp, const char* delim)
+static inline char* strsep(char **stringp, const char *delim)
 {
 	char* ptr = *stringp;
 	char* p;
@@ -200,6 +210,34 @@ static inline int fi_fd_nonblock(int fd)
 static inline int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout)
 {
 	return !SleepConditionVariableCS(cond, mut, (DWORD)timeout);
+}
+
+static inline int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
+				int readonly, void **mapped)
+{
+	OFI_UNUSED(shm);
+	OFI_UNUSED(name);
+	OFI_UNUSED(size);
+	OFI_UNUSED(readonly);
+	OFI_UNUSED(mapped);
+
+	return -FI_ENOENT;
+}
+
+static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
+{
+	OFI_UNUSED(shm);
+	OFI_UNUSED(newsize);
+	OFI_UNUSED(mapped);
+
+	return -FI_ENOENT;
+}
+
+static inline int ofi_shm_unmap(struct util_shm *shm)
+{
+	OFI_UNUSED(shm);
+
+	return -FI_ENOENT;
 }
 
 #ifdef __cplusplus

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -54,6 +54,7 @@
 #include <fi_rbuf.h>
 #include <fi_list.h>
 #include <fi_file.h>
+#include <fi_osd.h>
 #include <rbtree.h>
 
 #ifndef _SOCK_H_
@@ -327,8 +328,8 @@ struct sock_av {
 	struct sock_av_table_hdr *table_hdr;
 	struct sock_av_addr *table;
 	uint64_t *idx_arr;
-	char *name;
-	int shared_fd;
+	struct util_shm shm;
+	int    shared;
 };
 
 struct sock_fid_list {


### PR DESCRIPTION
the next step to windows port: move shared memory functios into separate layer.

added Unix/Linux basic shared memory API:
- create shared memory segment (based on name + size)
- re-allocate segment
- unmap segment

additionally added structure datatype to handle shared memory segment

AV for socket provider is implemented using new API

next step will be add SHM support for windows

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>