### PR TITLE
verbs: Strengthen configure check to workaround libtool behavior

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,7 @@ dnl Check for compiler features
 AC_C_TYPEOF
 
 LT_INIT
+LT_OUTPUT
 
 dnl dlopen support is optional
 AC_ARG_WITH([dlopen],

--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -19,7 +19,25 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 				[],
 				[$verbs_PREFIX],
 				[$verbs_LIBDIR],
-				[verbs_ibverbs_happy=1],
+				[
+				AC_MSG_CHECKING(if libibverbs is linkable by libtool)
+				file=conftemp.$$.c
+				rm -f $file conftemp
+				cat > $file <<-EOF
+					char ibv_open_device ();
+					int main ()
+					{ return ibv_open_device (); }
+				EOF
+				./libtool --mode=link --tag=CC $CC $CPPFLAGS \
+				$CFLAGS $file -o conftemp $LDFLAGS -libverbs \
+				2>&1 > /dev/null
+				status=$?
+				AS_IF([test $status -eq 0 && test -x conftemp],
+					[AC_MSG_RESULT(yes)
+					verbs_ibverbs_happy=1],
+					[AC_MSG_RESULT(no)
+					verbs_ibverbs_happy=0])
+				rm -f $file conftemp],
 				[verbs_ibverbs_happy=0])
 
 	       FI_CHECK_PACKAGE([verbs_rdmacm],


### PR DESCRIPTION
This is a configure time link test to see if libtool can
successfully link against ibverbs. libtool by default adds
library dependencies of libibverbs when building libfabric.
When those libraries are not found, the build fails. This
patch adds a check that prevents build failure and disables
verbs provider instead.

Refer github libfabric issue #2070 for more info.