### PR TITLE
prov/sockets: Fixes for connection management operations

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -964,6 +964,7 @@ int sock_ep_enable(struct fid_ep *ep)
 	if (sock_ep->attr->ep_type != FI_EP_MSG &&
 	    !sock_ep->attr->listener.listener_thread && sock_conn_listen(sock_ep->attr))
 		SOCK_LOG_ERROR("cannot start connection thread\n");
+	sock_ep->attr->is_disabled = 0;
 	return 0;
 }
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1013,8 +1013,10 @@ static int sock_ep_getopt(fid_t fid, int level, int optname,
 		break;
 
 	case FI_OPT_CM_DATA_SIZE:
-		if (*optlen < sizeof(size_t))
+		if (*optlen < sizeof(size_t)) {
+			*optlen = sizeof(size_t);
 			return -FI_ETOOSMALL;
+		}
 		*((size_t *) optval) = SOCK_EP_MAX_CM_DATA_SZ;
 		*optlen = sizeof(size_t);
 		break;

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -155,6 +155,7 @@ static ssize_t sock_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
 		}
 
 		dlistfd_remove(list, &sock_eq->err_list);
+		dlistfd_reset(&sock_eq->list);
 		free(entry);
 	}
 


### PR DESCRIPTION
This PR includes patches from @jithinjosepkl  and runs newly added test <code>fabtests/simple/fi_cm_data</code>.
- Added <code>fi_getopt</code> for <code>FI_OPT_CM_DATA_SIZE</code>
- Handled ACK for <code>fi_reject</code> cm op and fixed a bug in msg enqueuing
- Fixed <code>fi_shutdown</code> management when client is in connecting/disconnecting state
- Added missing reset signal in <code>fi_eq_readerr</code>
- Fixed minor cm issues
- Added <code>#if ENABLE_DEBUG</code> where needed

@jithinjosepkl, can you please take a look?