### PR TITLE
Updates to verbs configury

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -28,9 +28,9 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 					int main ()
 					{ return ibv_open_device (); }
 				EOF
-				./libtool --mode=link --tag=CC $CC $CPPFLAGS \
-				$CFLAGS $file -o conftemp $LDFLAGS -libverbs \
-				2>&1 > /dev/null
+				cmd="./libtool --mode=link --tag=CC $CC $CPPFLAGS $CFLAGS $file -o conftemp $LDFLAGS -libverbs"
+				echo "configure:$LINENO: $cmd" >> config.log 2>&1
+				eval $cmd >> config.log 2>&1
 				status=$?
 				AS_IF([test $status -eq 0 && test -x conftemp],
 					[AC_MSG_RESULT(yes)


### PR DESCRIPTION
@jswaro @a-ilango Please verify.

1. 1st commit fixes the stdout/stderr issue (and outputs into config.log)
1. 2nd commit moves the new test into its own .m4 macro and also adds a little more to the config.log output.  Also adds a giant comment explaining why this is necessary.