### PR TITLE
prov/gni: Clean up gni internal datagram states

### DIFF
--- a/prov/gni/include/gnix_datagram.h
+++ b/prov/gni/include/gnix_datagram.h
@@ -106,9 +106,7 @@ enum gnix_dgram_type {
 
 enum gnix_dgram_state {
 	GNIX_DGRAM_STATE_FREE,
-	GNIX_DGRAM_STATE_CONNECTING,
-	GNIX_DGRAM_STATE_LISTENING,
-	GNIX_DGRAM_STATE_CONNECTED
+	GNIX_DGRAM_STATE_ACTIVE
 };
 
 enum gnix_dgram_buf {

--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -324,7 +324,7 @@ int _gnix_dgram_wc_post(struct gnix_datagram *d)
 		/*
 		 * datagram is active now, listening
 		 */
-		d->state = GNIX_DGRAM_STATE_LISTENING;
+		d->state = GNIX_DGRAM_STATE_ACTIVE;
 	}
 	COND_RELEASE(nic->requires_lock, &nic->lock);
 
@@ -403,7 +403,7 @@ int _gnix_dgram_bnd_post(struct gnix_datagram *d)
 			/*
 			 * datagram is active now, connecting
 			 */
-			d->state = GNIX_DGRAM_STATE_CONNECTING;
+			d->state = GNIX_DGRAM_STATE_ACTIVE;
 		} else {
 			ret = -FI_EBUSY;
 		}
@@ -463,9 +463,7 @@ int  _gnix_dgram_poll(struct gnix_dgram_hndl *hndl,
 
 		dg_ptr = (struct gnix_datagram *)datagram_id;
 		assert(dg_ptr != NULL);
-
-		assert((dg_ptr->state == GNIX_DGRAM_STATE_CONNECTING) ||
-			(dg_ptr->state = GNIX_DGRAM_STATE_LISTENING));
+		assert(dg_ptr->state == GNIX_DGRAM_STATE_ACTIVE);
 
 		/*
 		 * do need to take lock here


### PR DESCRIPTION
upstream merge of ofi-cray/libfabric-cray#843
@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@918c90f95979f0cc5238bdc74197f1b969d03cd9)