### PR TITLE
osx/osd.h: fix compiler warning

### DIFF
--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -42,6 +43,8 @@
 #include <libkern/OSByteOrder.h>
 
 #include <pthread.h>
+
+#include "unix/osd.h"
 
 #define CLOCK_REALTIME CALENDAR_CLOCK
 #define CLOCK_MONOTONIC SYSTEM_CLOCK


### PR DESCRIPTION
Be sure to include "unix/osd.h" so that we have a declaration for struct util_shm.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@bturrubiates please review