### PR TITLE
windows implementation of SHM layer

### DIFF
--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -38,7 +38,7 @@ extern "C" {
 struct util_shm
 { /* this is dummy structure to provide compilation on Windows platform. */
   /* will be updated on real Windows implementation */
-	int		shared_fd;
+	HANDLE		shared_fd;
 	void		*ptr;
 	const char	*name;
 	size_t		size;
@@ -212,17 +212,8 @@ static inline int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int t
 	return !SleepConditionVariableCS(cond, mut, (DWORD)timeout);
 }
 
-static inline int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
-				int readonly, void **mapped)
-{
-	OFI_UNUSED(shm);
-	OFI_UNUSED(name);
-	OFI_UNUSED(size);
-	OFI_UNUSED(readonly);
-	OFI_UNUSED(mapped);
-
-	return -FI_ENOENT;
-}
+int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
+				int readonly, void **mapped);
 
 static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
 {
@@ -233,12 +224,7 @@ static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **map
 	return -FI_ENOENT;
 }
 
-static inline int ofi_shm_unmap(struct util_shm *shm)
-{
-	OFI_UNUSED(shm);
-
-	return -FI_ENOENT;
-}
+int ofi_shm_unmap(struct util_shm *shm);
 
 #ifdef __cplusplus
 }

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -34,11 +34,16 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include "fi.h"
 #include "fi_osd.h"
 #include "fi_file.h"
 
+#include "rdma/providers/fi_log.h"
+
 extern pthread_mutex_t ini_lock;
 static INIT_ONCE ofi_init_once = INIT_ONCE_STATIC_INIT;
+
+static char ofi_shm_prefix[] = "Local\\";
 
 int socketpair(int af, int type, int protocol, int socks[2])
 {
@@ -127,4 +132,80 @@ BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved)
 
 	return TRUE;
 }
+
+int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
+	int readonly, void **mapped)
+{
+	int ret = FI_SUCCESS;
+	char *fname = 0;
+	size_t len = lstrlenA(name) + sizeof(ofi_shm_prefix);
+	LARGE_INTEGER large = {.QuadPart = size};
+	DWORD access = FILE_MAP_READ | (readonly ? 0 : FILE_MAP_WRITE);
+
+	ZeroMemory(shm, sizeof(*shm));
+
+	fname = malloc(len);
+	if (!fname)
+	{
+		ret = -FI_ENOMEM;
+		goto fn_fail;
+	}
+	shm->name = fname;
+
+	lstrcpyA(fname, ofi_shm_prefix);
+	lstrcatA(fname, name);
+
+	if (!readonly) {
+		shm->shared_fd = CreateFileMappingA(INVALID_HANDLE_VALUE, 0,
+			PAGE_READWRITE, large.HighPart, large.LowPart,
+			shm->name);
+		if (!shm->shared_fd) {
+			FI_WARN(&core_prov, FI_LOG_CORE, "CreateFileMapping failed\n");
+			ret = -FI_EINVAL;
+			goto fn_fail;
+		}
+	} else { /* readonly */
+		shm->shared_fd = OpenFileMappingA(access, FALSE, shm->name);
+		if (!shm->shared_fd) {
+			FI_WARN(&core_prov, FI_LOG_CORE, "OpenFileMapping failed\n");
+			ret = -FI_EINVAL;
+			goto fn_fail;
+		}
+	}
+
+	shm->ptr = MapViewOfFile(shm->shared_fd, access, 0, 0, size);
+	if (!shm->ptr) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "MapViewOfFile failed\n");
+		ret = -FI_EINVAL;
+		goto fn_fail;
+	}
+
+	*mapped = shm->ptr;
+
+	return FI_SUCCESS;
+
+fn_fail:
+	if (shm->shared_fd)
+		CloseHandle(shm->shared_fd);
+	if (fname)
+		free((void*)fname);
+	ZeroMemory(shm, sizeof(*shm));
+	return ret;
+}
+
+int ofi_shm_unmap(struct util_shm *shm)
+{
+	if (shm->name)
+		free((void*)shm->name);
+	if (shm->ptr)
+		UnmapViewOfFile(shm->ptr);
+	if (shm->shared_fd)
+		CloseHandle(shm->shared_fd);
+
+	ZeroMemory(shm, sizeof(*shm));
+
+	return FI_SUCCESS;
+}
+
+
 


### PR DESCRIPTION
added windows implementation of shared memory layer.
for now implemented map/unmap API only (remap is not implemeted
due to WIN API limitations)

also updated external header - fi_eq.h to provide compilation on windows: added include windows.h and added native datatypes to fi_mutex_cond structure. no ideas how to do same things another way

additionally switched default Intel compiler version to sync with default compiler for MPICH on windows

Signed-off-by: Sergey Oblomov <sergey.oblomov@intel.com>