### PR TITLE
prov/psm2: Add multi-iov support for RMA read

### DIFF
--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -136,6 +136,18 @@ int psmx2_process_trigger(struct psmx2_fid_domain *domain,
 				   trigger->read.flags);
 		break;
 
+	case PSMX2_TRIGGERED_READV:
+		psmx2_readv_generic(trigger->readv.ep,
+				    trigger->readv.iov,
+				    trigger->readv.desc,
+				    trigger->readv.count,
+				    trigger->readv.src_addr,
+				    trigger->readv.addr,
+				    trigger->readv.key,
+				    trigger->readv.context,
+				    trigger->readv.flags);
+		break;
+
 	case PSMX2_TRIGGERED_ATOMIC_WRITE:
 		psmx2_atomic_write_generic(
 				trigger->atomic_write.ep,


### PR DESCRIPTION
Removed the iov_count limitation from fi_readv and fi_readmsg.
For fi_readmsg remote_iov_count is still limited to 1 only.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>