### PR TITLE
fix for dl build

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -119,6 +119,7 @@ struct fi_filter {
 };
 
 extern struct fi_filter prov_log_filter;
+extern struct fi_provider core_prov;
 
 void fi_create_filter(struct fi_filter *filter, const char *env_name);
 void fi_free_filter(struct fi_filter *filter);

--- a/src/common.c
+++ b/src/common.c
@@ -47,9 +47,15 @@
 #include <sys/time.h>
 
 #include <fi_signal.h>
+#include <rdma/providers/fi_prov.h>
 #include <rdma/fi_errno.h>
 #include <fi.h>
 
+struct fi_provider core_prov = {
+	.name = "core",
+	.version = 1,
+	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION)
+};
 
 int fi_read_file(const char *dir, const char *file, char *buf, size_t size)
 {

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -62,13 +62,6 @@ pthread_mutex_t ini_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static struct fi_filter prov_filter;
 
-struct fi_provider core_prov = {
-	.name = "core",
-	.version = 1,
-	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION)
-};
-
-
 static int fi_find_name(char **names, const char *name)
 {
 	int i;

--- a/src/log.c
+++ b/src/log.c
@@ -61,8 +61,6 @@ static const char * const log_levels[] = {
 	[FI_LOG_MAX] = NULL
 };
 
-extern struct fi_provider core_prov;
-
 enum {
 	FI_LOG_SUBSYS_OFFSET	= FI_LOG_MAX,
 	FI_LOG_PROV_OFFSET	= FI_LOG_SUBSYS_OFFSET + FI_LOG_SUBSYS_MAX,

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -38,13 +38,12 @@
 #include <sys/mman.h>
 #include <sys/stat.h>
 
+#include "fi.h"
 #include "fi_osd.h"
 #include "fi_file.h"
 
 #include "rdma/fi_errno.h"
 #include "rdma/providers/fi_log.h"
-
-extern struct fi_provider core_prov;
 
 int fi_fd_nonblock(int fd)
 {

--- a/src/var.c
+++ b/src/var.c
@@ -43,9 +43,6 @@
 #include "fi_list.h"
 
 
-/* When given a NULL provider pointer, use core for logging and settings. */
-extern struct fi_provider core_prov;
-
 extern int init;
 extern void fi_ini();
 


### PR DESCRIPTION
fix for https://github.com/ofiwg/libfabric/issues/2107:
reason for issue is incorrect location of core_prov structure.
fix is move core_prov declaration into common source file,
where it is available from any build configuration

Signed-off-by: Sergey Oblomov <sergey.oblomov@intel.com>