### PR TITLE
prov/gni: Updated indentation of if clause in

### DIFF
--- a/prov/gni/src/gnix_nameserver.c
+++ b/prov/gni/src/gnix_nameserver.c
@@ -229,11 +229,13 @@ int gnix_resolve_name(IN const char *node, IN const char *service,
 	ret =  __gnix_ipaddr_from_iface("ipogif0", &sin);
 	if (ret != FI_SUCCESS)
 		ret =  __gnix_ipaddr_from_iface("br0", &sin);
-		if (ret != FI_SUCCESS) {
-			GNIX_WARN(FI_LOG_FABRIC,
-				  "Unable to obtain local iface addr\n");
-			goto err;
-		}
+
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_FABRIC,
+			  "Unable to obtain local iface addr\n");
+		goto err;
+	}
+
 
 	ret = getaddrinfo(node, service, &hints, &result);
 	if (ret != 0) {


### PR DESCRIPTION
gnix_nameserver for GCC 6.1.0.

upstream merge of ofi-cray/libfabric-cray#860
@sungeunchoi 

Signed-off-by: Evan Harvey <eharvey@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@e24be6e82a39c4180b4bff07cb55ebc9239cf6f2)