### PR TITLE
prov/gni: Fix addr arg to fi_av_lookup in av tests

### DIFF
--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -244,7 +244,7 @@ Test(av_full_table, remove_addr)
 static void lookup_invalid_test(void)
 {
 	int ret;
-	fi_addr_t addresses[SIMPLE_ADDR_COUNT];
+	struct gnix_ep_name addr;
 	size_t addrlen = sizeof(struct gnix_ep_name);
 
 	/* test null addrlen */
@@ -257,14 +257,14 @@ static void lookup_invalid_test(void)
 
 	/* test invalid lookup */
 	if (gnix_av->type == FI_AV_TABLE) {
-		ret = fi_av_lookup(av, 2000, &addresses[0], &addrlen);
+		ret = fi_av_lookup(av, 2000, &addr, &addrlen);
 		cr_assert_eq(ret, -FI_EINVAL);
 
 		/* test within range, but not inserted case */
-		ret = fi_av_lookup(av, 1, &addresses[1], &addrlen);
+		ret = fi_av_lookup(av, 1, &addr, &addrlen);
 		cr_assert_eq(ret, -FI_EINVAL);
 	} else {
-		ret = fi_av_lookup(av, 0xdeadbeef, &addresses[0], &addrlen);
+		ret = fi_av_lookup(av, 0xdeadbeef, &addr, &addrlen);
 		cr_assert_eq(ret, -FI_ENOENT);
 	}
 }
@@ -285,7 +285,7 @@ static void lookup_test(void)
 	int i;
 	fi_addr_t addresses[SIMPLE_ADDR_COUNT];
 	fi_addr_t *compare;
-	fi_addr_t found;
+	struct gnix_ep_name found;
 	size_t addrlen = sizeof(struct gnix_ep_name);
 
 	/* insert addresses */
@@ -303,8 +303,10 @@ static void lookup_test(void)
 		}
 	}
 
-	ret = fi_av_lookup(av, addresses[1], &found, &addrlen);
-	cr_assert_eq(ret, FI_SUCCESS);
+	for (i = 0; i < SIMPLE_ADDR_COUNT; i++) {
+		ret = fi_av_lookup(av, addresses[i], &found, &addrlen);
+		cr_assert_eq(ret, FI_SUCCESS);
+	}
 }
 
 Test(av_full_map, lookup)


### PR DESCRIPTION
Calls to fi_av_lookup were passing in a pointer to fi_addr_t for the
addr argument, but stating that it was sizeof(struct gnix_ep_name).
This was leading to stack corruption that didn't really matter, until
I copied the tests to create multithreaded versions.

upstream merge of ofi-cray/libfabric-cray#862

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@8f97f6247cd65c078d0516b4b4c0191ac371ccea)