### PR TITLE
prov/verbs: ep_rdm bugfix

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -105,7 +105,7 @@ fi_ibv_rdm_take_first_from_errcq()
 		struct fi_ibv_rdm_tagged_request *entry =
 			container_of(fi_ibv_rdm_comp_queue.request_errcq.next,
 				struct fi_ibv_rdm_tagged_request, queue_entry);
-		fi_ibv_rdm_remove_from_cq(entry);
+		fi_ibv_rdm_remove_from_errcq(entry);
 		return entry;
 	}
 	return NULL;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -1089,7 +1089,7 @@ fi_ibv_rdm_rma_inject_request(struct fi_ibv_rdm_tagged_request *request,
 		sge.lkey = request->minfo.conn->rma_mr->lkey;
 	} else {
 		FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
-		return FI_SUCCESS;
+		return -FI_EAGAIN;
 	}
 
 	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep_rdm,

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -411,7 +411,9 @@ fi_ibv_rdm_copy_unexp_request(struct fi_ibv_rdm_tagged_request *request,
 			unexp->len, request->len,
 			request->minfo.conn, request->minfo.tag,
 			request->minfo.tagmask);
-		assert(0);
+
+		util_buf_release(fi_ibv_rdm_tagged_extra_buffers_pool,
+				 unexp->unexp_rbuf);
 		ret = -FI_ETRUNC;
 		return ret;
 	}
@@ -480,7 +482,8 @@ fi_ibv_rdm_tagged_init_recv_request(struct fi_ibv_rdm_tagged_request *request,
 
 		ret = fi_ibv_rdm_copy_unexp_request(request, found_request);
 
-		assert(((p->peek_data.flags & FI_CLAIM) &&
+		assert((ret != FI_SUCCESS) ||
+			((p->peek_data.flags & FI_CLAIM) &&
 				(request->state.eager == 
 					FI_IBV_STATE_EAGER_RECV_CLAIMED) &&
 				(request->context == found_request->context)) ||
@@ -520,6 +523,7 @@ fi_ibv_rdm_tagged_init_recv_request(struct fi_ibv_rdm_tagged_request *request,
 	
 	if (ret != FI_SUCCESS) {
 		fi_ibv_rdm_move_to_errcq(request, ret);
+		ret = FI_SUCCESS;
 	}
 
 	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -149,7 +149,9 @@ int fi_ibv_create_ep(const char *node, const char *service,
 				&rai_hints, &_rai);
 	if (ret) {
 		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "rdma_getaddrinfo", errno);
-		ret = -errno;
+		if (errno) {
+			ret = -errno;
+		}
 		goto out;
 	}
 


### PR DESCRIPTION
1. segfault if wrong node address was passed. The bug was reproduced with fi_rdm and fi_msg fabtests: fi_rdm -f verbs aaa
2. err code in case of truncated recv + memory leak
3. rma_inject_write, the message was lost if resources are busy, -FI_EAGAIN err should be returned.

@a-ilango 