### PR TITLE
fix `void *` pointer arithmetic and warn about it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,11 +37,13 @@ AM_CONDITIONAL([MACOS], [test "x$macos" = "x1"])
 AM_CONDITIONAL([LINUX], [test "x$linux" = "x1"])
 AM_CONDITIONAL([FREEBSD], [test "x$freebsd" = "x1"])
 
+base_c_warn_flags="-Wall -Wundef -Wpointer-arith"
+
 AC_ARG_ENABLE([debug],
 	      [AS_HELP_STRING([--enable-debug],
 			      [Enable debugging @<:@default=no@:>@])
 	      ],
-	      [CFLAGS="-g -O0 -Wall -Wextra -Wundef -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers $CFLAGS"
+	      [CFLAGS="-g -O0 ${base_c_warn_flags} -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers $CFLAGS"
 	       dbg=1],
 	      [enable_debug=no
                dbg=0])
@@ -51,7 +53,7 @@ AC_DEFINE_UNQUOTED([ENABLE_DEBUG],[$dbg],
 
 # Fix autoconf's habit of setting CFLAGS="-g -O2" by default while still
 # allowing the user to explicitly set CFLAGS=""
-: ${CFLAGS="-fvisibility=hidden -O2 -DNDEBUG -Wall -Wundef"}
+: ${CFLAGS="-fvisibility=hidden -O2 -DNDEBUG ${base_c_warn_flags}"}
 
 # AM PROG_AR did not exist pre AM 1.11.x (where x is somewhere >0 and
 # <3), but it is necessary in AM 1.12.x.

--- a/prov/usnic/src/usdf_dgram.c
+++ b/prov/usnic/src/usdf_dgram.c
@@ -158,7 +158,7 @@ usdf_dgram_recvv(struct fid_ep *fep, const struct iovec *iov, void **desc,
 	qp = to_qpi(ep->e.dg.ep_qp);
 
 	rxd.urd_context = context;
-	rxd.urd_iov[0].iov_base = ep->e.dg.ep_hdr_buf +
+	rxd.urd_iov[0].iov_base = ((uint8_t *)ep->e.dg.ep_hdr_buf) +
 		qp->uq_rq.urq_post_index * USDF_HDR_BUF_ENTRY;
 	rxd.urd_iov[0].iov_len = sizeof(struct usd_udp_hdr);
 	memcpy(&rxd.urd_iov[1], iov, sizeof(*iov) * count);
@@ -196,7 +196,8 @@ usdf_dgram_recvmsg(struct fid_ep *fep, const struct fi_msg *msg, uint64_t flags)
 
 	iovp = msg->msg_iov;
 	rq->urq_context[index] = msg->context;
-	hdr_ptr = ep->e.dg.ep_hdr_buf + (index * USDF_HDR_BUF_ENTRY);
+	hdr_ptr = ((uint8_t *)ep->e.dg.ep_hdr_buf) +
+			(index * USDF_HDR_BUF_ENTRY);
 	rq_enet_desc_enc(desc, (dma_addr_t) hdr_ptr,
 			RQ_ENET_TYPE_ONLY_SOP, sizeof(struct usd_udp_hdr));
 	ep->e.dg.ep_hdr_ptr[index] = (struct usd_udp_hdr *) hdr_ptr;
@@ -426,7 +427,7 @@ usdf_dgram_inject(struct fid_ep *fep, const void *buf, size_t len,
 ssize_t usdf_dgram_prefix_inject(struct fid_ep *fep, const void *buf,
 		size_t len, fi_addr_t dest_addr)
 {
-	return usdf_dgram_inject(fep, buf + USDF_HDR_BUF_ENTRY,
+	return usdf_dgram_inject(fep, ((uint8_t *)buf) + USDF_HDR_BUF_ENTRY,
 			len - USDF_HDR_BUF_ENTRY, dest_addr);
 }
 
@@ -549,7 +550,7 @@ usdf_dgram_prefix_recvmsg(struct fid_ep *fep, const struct fi_msg *msg, uint64_t
 
 	iovp = msg->msg_iov;
 	rq->urq_context[index] = msg->context;
-	hdr_ptr = iovp[0].iov_base +
+	hdr_ptr = ((uint8_t *)iovp[0].iov_base) +
 		(USDF_HDR_BUF_ENTRY - sizeof(struct usd_udp_hdr));
 	rq_enet_desc_enc(desc, (dma_addr_t) hdr_ptr,
 			 RQ_ENET_TYPE_ONLY_SOP,
@@ -613,7 +614,7 @@ usdf_dgram_prefix_send(struct fid_ep *fep, const void *buf, size_t len,
 		}
 
 		return usd_post_send_one_copy(ep->e.dg.ep_qp, &dest->ds_dest,
-				buf + USDF_HDR_BUF_ENTRY, len -
+				((uint8_t *)buf) + USDF_HDR_BUF_ENTRY, len -
 				USDF_HDR_BUF_ENTRY, flags,
 				context);
 	}

--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -154,7 +154,7 @@ usdf_msg_rewind_qe(struct usdf_msg_qe *qe, size_t rewind, size_t mtu)
 	}
 
 	qe->ms_cur_iov = cur_iov;
-	qe->ms_cur_ptr = qe->ms_iov[cur_iov].iov_base +
+	qe->ms_cur_ptr = ((uint8_t *)qe->ms_iov[cur_iov].iov_base) +
 		qe->ms_iov[cur_iov].iov_len - cur_resid;
 	qe->ms_iov_resid = cur_resid;
 }

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -403,7 +403,7 @@ usdf_rdm_rewind_qe(struct usdf_rdm_qe *qe, size_t rewind, size_t mtu)
 	}
 
 	qe->rd_cur_iov = cur_iov;
-	qe->rd_cur_ptr = qe->rd_iov[cur_iov].iov_base +
+	qe->rd_cur_ptr = ((uint8_t *)qe->rd_iov[cur_iov].iov_base) +
 		qe->rd_iov[cur_iov].iov_len - cur_resid;
 	qe->rd_iov_resid = cur_resid;
 }

--- a/prov/usnic/src/usnic_direct/vnic_dev.c
+++ b/prov/usnic/src/usnic_direct/vnic_dev.c
@@ -251,7 +251,11 @@ void vnic_dev_upd_res_vaddr(struct vnic_dev *vdev,
 			continue;
 		if (vdev->res[i].bus_addr >= map->bus_addr &&
 			vdev->res[i].bus_addr < map->bus_addr + map->len)
-			vdev->res[i].vaddr = map->vaddr +
+			/*
+			 * ptr cast is a libfabric-local modification, port to
+			 * Cisco-internal repository is in progress
+			 */
+			vdev->res[i].vaddr = ((uint8_t *)map->vaddr) +
 					(vdev->res[i].bus_addr - map->bus_addr);
 	}
 }

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -123,7 +123,9 @@ fi_ibv_cq_sread(struct fid_cq *cq, void *buf, size_t count, const void *cond,
 	ssize_t ret = 0, cur;
 	ssize_t  threshold;
 	struct fi_ibv_cq *_cq;
+	uint8_t *p;
 
+	p = buf;
 	_cq = container_of(cq, struct fi_ibv_cq, cq_fid);
 
 	if (!_cq->channel)
@@ -139,9 +141,9 @@ fi_ibv_cq_sread(struct fid_cq *cq, void *buf, size_t count, const void *cond,
 				break;
 		}
 
-		ret = _cq->cq_fid.ops->read(&_cq->cq_fid, buf, count - cur);
+		ret = _cq->cq_fid.ops->read(&_cq->cq_fid, p, count - cur);
 		if (ret > 0) {
-			buf += ret * _cq->entry_size;
+			p += ret * _cq->entry_size;
 			cur += ret;
 			if (cur >= threshold)
 				break;


### PR DESCRIPTION
@hoopoepg [points out](https://github.com/ofiwg/libfabric/pull/2119/files/adbed0b28338abbc2508ec68f3f259800fbe06ef#r67461488) that `void *` arithmetic is not supported on Windows.  This PR addresses existing `void *` arithmetic in the verbs and usnic providers, and adds `-Wpointer-arith` to `CFLAGS` so that we catch these cases more easily in the future.

@jsquyres please review