### PR TITLE
windows changes for ext-headers update

### DIFF
--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -201,11 +201,6 @@ static inline int ofi_sockerr(void)
 	}
 }
 
-static inline int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout)
-{
-	return !SleepConditionVariableCS(cond, mut, (DWORD)timeout);
-}
-
 int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
 				int readonly, void **mapped);
 

--- a/include/windows/sys/socket.h
+++ b/include/windows/sys/socket.h
@@ -1,3 +1,14 @@
 
-#pragma once
+#ifndef _LIBFABRIC_OSD_SYS_SOCKET_H_
+#define _LIBFABRIC_OSD_SYS_SOCKET_H_
+
+/* on Windows we have to follow strong sequence of includes:
+   winsock2.h & ws2tcpip.h should be included prior to
+   windows.h */
+
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+
+#endif /* _LIBFABRIC_OSD_SYS_SOCKET_H_ */
 

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -328,6 +328,7 @@ static int sock_cntr_control(struct fid *fid, int command, void *arg)
 		case FI_WAIT_NONE:
 		case FI_WAIT_UNSPEC:
 		case FI_WAIT_MUTEX_COND:
+		case FI_WAIT_CRITSEC_COND:
 			memcpy(arg, &cntr->mut, sizeof(cntr->mut));
 			memcpy((char *)arg + sizeof(cntr->mut), &cntr->cond,
 			       sizeof(cntr->cond));
@@ -420,7 +421,11 @@ static int sock_cntr_verify_attr(struct fi_cntr_attr *attr)
 	switch (attr->wait_obj) {
 	case FI_WAIT_NONE:
 	case FI_WAIT_UNSPEC:
+#ifndef _WIN32
 	case FI_WAIT_MUTEX_COND:
+#else /* _WIN32 */
+	case FI_WAIT_CRITSEC_COND:
+#endif /* _WIN32 */
 	case FI_WAIT_SET:
 	case FI_WAIT_FD:
 		break;
@@ -464,6 +469,7 @@ int sock_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	case FI_WAIT_NONE:
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_MUTEX_COND:
+	case FI_WAIT_CRITSEC_COND:
 		_cntr->signal = 0;
 		break;
 

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -348,6 +348,7 @@ static int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
 	case FI_WAIT_MUTEX_COND:
+	case FI_WAIT_CRITSEC_COND:
 		memset(&wait_attr, 0, sizeof wait_attr);
 		wait_attr.wait_obj = attr->wait_obj;
 		cq->internal_wait = 1;

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -217,6 +217,7 @@ static int util_eq_init(struct fid_fabric *fabric, struct util_eq *eq,
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
 	case FI_WAIT_MUTEX_COND:
+	case FI_WAIT_CRITSEC_COND:
 		memset(&wait_attr, 0, sizeof wait_attr);
 		wait_attr.wait_obj = attr->wait_obj;
 		eq->internal_wait = 1;
@@ -244,7 +245,11 @@ static int util_verify_eq_attr(const struct fi_provider *prov,
 	case FI_WAIT_NONE:
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
+#ifndef _WIN32
 	case FI_WAIT_MUTEX_COND:
+#else /* _WIN32 */
+	case FI_WAIT_CRITSEC_COND:
+#endif /* _WIN32 */
 		break;
 	case FI_WAIT_SET:
 		if (!attr->wait_set) {

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -77,7 +77,11 @@ int fi_check_wait_attr(const struct fi_provider *prov,
 	switch (attr->wait_obj) {
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
+#ifndef _WIN32
 	case FI_WAIT_MUTEX_COND:
+#else /* _WIN32 */
+	case FI_WAIT_CRITSEC_COND:
+#endif /* _WIN32 */
 		break;
 	default:
 		FI_WARN(prov, FI_LOG_FABRIC, "invalid wait object type\n");
@@ -124,7 +128,8 @@ int fi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
 		wait->wait_obj = FI_WAIT_FD;
 		break;
 	case FI_WAIT_MUTEX_COND:
-		wait->wait_obj = FI_WAIT_MUTEX_COND;
+	case FI_WAIT_CRITSEC_COND:
+		wait->wait_obj = attr->wait_obj;
 		break;
 	default:
 		assert(0);

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -258,5 +258,10 @@ int fi_fd_nonblock(int fd)
 	return ioctlsocket(fd, FIONBIO, &argp) ? -WSAGetLastError() : 0;
 }
 
+int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout)
+{
+	return !SleepConditionVariableCS(cond, mut, (DWORD)timeout);
+}
+
 
 


### PR DESCRIPTION
this is additional PR to https://github.com/ofiwg/libfabric/pull/2117

updated access to fi_mutex_cond datatype: used macro
to acceess structure changes to avoid #ifdef's

additionally supppressed warning on windows systems on
double declaration of fi_fd_nonblock function (on unix
systems it is declared in unix-specific osd.h file)