### PR TITLE
Updates to address several open issues

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -162,10 +162,10 @@ size_t fi_datatype_size(enum fi_datatype datatype);
 uint64_t fi_tag_bits(uint64_t mem_tag_format);
 uint64_t fi_tag_format(uint64_t tag_bits);
 
-int fi_send_allowed(uint64_t caps);
-int fi_recv_allowed(uint64_t caps);
-int fi_rma_initiate_allowed(uint64_t caps);
-int fi_rma_target_allowed(uint64_t caps);
+int ofi_send_allowed(uint64_t caps);
+int ofi_recv_allowed(uint64_t caps);
+int ofi_rma_initiate_allowed(uint64_t caps);
+int ofi_rma_target_allowed(uint64_t caps);
 
 uint64_t fi_gettime_ms(void);
 

--- a/include/fi.h
+++ b/include/fi.h
@@ -166,6 +166,7 @@ int ofi_send_allowed(uint64_t caps);
 int ofi_recv_allowed(uint64_t caps);
 int ofi_rma_initiate_allowed(uint64_t caps);
 int ofi_rma_target_allowed(uint64_t caps);
+int ofi_ep_bind_valid(struct fi_provider *prov, struct fid *bfid, uint64_t flags);
 
 uint64_t fi_gettime_ms(void);
 

--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -8,7 +8,7 @@ Summary: User-space RDMA Fabric Interfaces
 Group: System Environment/Libraries
 License: GPLv2 or BSD
 Url: http://www.github.com/ofiwg/libfabric
-Source: http://www.openfabrics.org/downloads/ofi/%{name}-%{version}.tar.bz2
+Source: http://www.github.org/ofiwg/%{name}/releases/download/v{%version}/%{name}-%{version}.tar.bz2
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 %description

--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -201,6 +201,13 @@ provider implementation constraints.
 
 *FI_LONG_DOUBLE*
 : A double-extended precision floating point value (IEEE 754).
+  Note that the size of a long double and number of bits used for
+  precision is compiler, platform, and/or provider specific.
+  Developers that use long double should ensure that libfabric is
+  built using a long double format that is compatible with their
+  application, and that format is supported by the provider.  The
+  mechanism used for this validation is currently beyond the scope of
+  the libfabric API.
 
 *FI_LONG_DOUBLE_COMPLEX*
 : An ordered pair of double-extended precision floating point values

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1428,7 +1428,7 @@ static int gnix_ep_close(fid_t fid)
 
 DIRECT_FN STATIC int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 {
-	int ret = FI_SUCCESS;
+	int ret;
 	struct gnix_fid_ep  *ep;
 	struct gnix_fid_av  *av;
 	struct gnix_fid_cq  *cq;
@@ -1438,9 +1438,9 @@ DIRECT_FN STATIC int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
-
-	if (!bfid)
-		return -FI_EINVAL;
+	ret = ofi_ep_bind_valid(&gnix_prov, bfid, flags);
+	if (ret)
+		return ret;
 
 	switch (bfid->fclass) {
 	case FI_CLASS_EQ:

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1631,16 +1631,16 @@ static int __gnix_ep_bound_prep(struct gnix_fid_domain *domain,
 
 static void gnix_ep_caps(struct gnix_fid_ep *ep_priv, uint64_t caps)
 {
-	if (fi_recv_allowed(caps & ~FI_TAGGED))
+	if (ofi_recv_allowed(caps & ~FI_TAGGED))
 		ep_priv->ep_ops.msg_recv_allowed = 1;
 
-	if (fi_send_allowed(caps & ~FI_TAGGED))
+	if (ofi_send_allowed(caps & ~FI_TAGGED))
 		ep_priv->ep_ops.msg_send_allowed = 1;
 
-	if (fi_recv_allowed(caps & ~FI_MSG))
+	if (ofi_recv_allowed(caps & ~FI_MSG))
 		ep_priv->ep_ops.tagged_recv_allowed = 1;
 
-	if (fi_send_allowed(caps & ~FI_MSG))
+	if (ofi_send_allowed(caps & ~FI_MSG))
 		ep_priv->ep_ops.tagged_send_allowed = 1;
 
 }

--- a/prov/mxm/src/mlxm_ep.c
+++ b/prov/mxm/src/mlxm_ep.c
@@ -81,8 +81,12 @@ static int mlxm_ep_close(fid_t fid)
 static int mlxm_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
         struct mlxm_fid_ep *fid_ep;
-        int           err = 0;
+        int ret;
         fid_ep = container_of(fid, struct mlxm_fid_ep, ep.fid);
+
+	ret = ofi_ep_bind_valid(&mlxm_prov, bfid, flags);
+	if (ret)
+		return ret;
 
         switch (bfid->fclass) {
         case FI_CLASS_CQ:
@@ -97,7 +101,7 @@ static int mlxm_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
         default:
                 return -ENOSYS;
         }
-        return err;
+        return 0;
 }
 
 

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -420,19 +420,19 @@ int psmx_domain_check_features(struct psmx_fid_domain *domain, int ep_cap)
 	}
 
 	if ((ep_cap & FI_TAGGED) && domain->tagged_ep &&
-	    fi_recv_allowed(ep_cap))
+	    ofi_recv_allowed(ep_cap))
 		return -FI_EBUSY;
 
 	if ((ep_cap & FI_MSG) && domain->msg_ep &&
-	    fi_recv_allowed(ep_cap))
+	    ofi_recv_allowed(ep_cap))
 		return -FI_EBUSY;
 
 	if ((ep_cap & FI_RMA) && domain->rma_ep &&
-	    fi_rma_target_allowed(ep_cap))
+	    ofi_rma_target_allowed(ep_cap))
 		return -FI_EBUSY;
 
 	if ((ep_cap & FI_ATOMICS) && domain->atomics_ep &&
-	    fi_rma_target_allowed(ep_cap))
+	    ofi_rma_target_allowed(ep_cap))
 		return -FI_EBUSY;
 
 	return 0;
@@ -470,16 +470,16 @@ int psmx_domain_enable_ep(struct psmx_fid_domain *domain, struct psmx_fid_ep *ep
 		domain->am_initialized = 1;
 	}
 
-	if ((ep_cap & FI_RMA) && fi_rma_target_allowed(ep_cap))
+	if ((ep_cap & FI_RMA) && ofi_rma_target_allowed(ep_cap))
 		domain->rma_ep = ep;
 
-	if ((ep_cap & FI_ATOMICS) && fi_rma_target_allowed(ep_cap))
+	if ((ep_cap & FI_ATOMICS) && ofi_rma_target_allowed(ep_cap))
 		domain->atomics_ep = ep;
 
-	if ((ep_cap & FI_TAGGED) && fi_recv_allowed(ep_cap))
+	if ((ep_cap & FI_TAGGED) && ofi_recv_allowed(ep_cap))
 		domain->tagged_ep = ep;
 
-	if ((ep_cap & FI_MSG) && fi_recv_allowed(ep_cap))
+	if ((ep_cap & FI_MSG) && ofi_recv_allowed(ep_cap))
 		domain->msg_ep = ep;
 
 	return 0;

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -201,9 +201,10 @@ static int psmx_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	int err;
 
 	ep = container_of(fid, struct psmx_fid_ep, ep.fid);
+	err = ofi_ep_bind_valid(&psmx_prov, bfid, flags);
+	if (err)
+		return err;
 
-	if (!bfid)
-		return -FI_EINVAL;
 	switch (bfid->fclass) {
 	case FI_CLASS_EQ:
 		return -FI_ENOSYS;

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -274,9 +274,10 @@ static int psmx2_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	int err;
 
 	ep = container_of(fid, struct psmx2_fid_ep, ep.fid);
+	err = ofi_ep_bind_valid(&psmx2_prov, bfid, flags);
+	if (err)
+		return err;
 
-	if (!bfid)
-		return -FI_EINVAL;
 	switch (bfid->fclass) {
 	case FI_CLASS_EQ:
 		return -FI_ENOSYS;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -709,6 +709,10 @@ static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	struct sock_tx_ctx *tx_ctx;
 	struct sock_rx_ctx *rx_ctx;
 
+	ret = ofi_ep_bind_valid(&sock_prov, bfid, flags);
+	if (ret)
+		return ret;
+
 	switch (fid->fclass) {
 	case FI_CLASS_EP:
 		ep = container_of(fid, struct sock_ep, ep.fid);

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -439,7 +439,11 @@ static int udpx_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 {
 	struct udpx_ep *ep;
 	struct util_av *av;
-	int ret = 0;
+	int ret;
+
+	ret = ofi_ep_bind_valid(&udpx_prov, bfid, flags);
+	if (ret)
+		return ret;
 
 	ep = container_of(ep_fid, struct udpx_ep, util_ep.ep_fid.fid);
 	switch (bfid->fclass) {

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -132,8 +132,12 @@ static int fi_ibv_rdm_tagged_ep_bind(struct fid *fid, struct fid *bfid,
 	struct fi_ibv_rdm_ep *ep;
 	struct fi_ibv_rdm_cq *cq;
 	struct fi_ibv_av *av;
+	int ret;
 
 	ep = container_of(fid, struct fi_ibv_rdm_ep, ep_fid.fid);
+	ret = ofi_ep_bind_valid(&fi_ibv_prov, bfid, flags);
+	if (ret)
+		return ret;
 
 	switch (bfid->fclass) {
 	case FI_CLASS_CQ:

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -127,6 +127,9 @@ static int fi_ibv_msg_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	int ret;
 
 	ep = container_of(fid, struct fi_ibv_msg_ep, ep_fid.fid);
+	ret = ofi_ep_bind_valid(&fi_ibv_prov, bfid, flags);
+	if (ret)
+		return ret;
 
 	switch (bfid->fclass) {
 	case FI_CLASS_CQ:

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -185,15 +185,15 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 		return -FI_ENOCQ;
 	}
 
-	if (!_ep->scq && (fi_send_allowed(_ep->info->caps) ||
-				fi_rma_initiate_allowed(_ep->info->caps))) {
+	if (!_ep->scq && (ofi_send_allowed(_ep->info->caps) ||
+				ofi_rma_initiate_allowed(_ep->info->caps))) {
 		FI_WARN(&fi_ibv_prov, FI_LOG_EP_CTRL, "Endpoint is not bound to "
 				"a send completion queue when it has transmit "
 				"capabilities enabled (FI_SEND | FI_RMA).\n");
 		return -FI_ENOCQ;
 	}
 
-	if (!_ep->rcq && fi_recv_allowed(_ep->info->caps)) {
+	if (!_ep->rcq && ofi_recv_allowed(_ep->info->caps)) {
 		FI_WARN(&fi_ibv_prov, FI_LOG_EP_CTRL, "Endpoint is not bound to "
 				"a receive completion queue when it has receive "
 				"capabilities enabled. (FI_RECV)\n");

--- a/src/common.c
+++ b/src/common.c
@@ -188,6 +188,37 @@ int ofi_rma_target_allowed(uint64_t caps)
 	return 0;
 }
 
+int ofi_ep_bind_valid(struct fi_provider *prov, struct fid *bfid, uint64_t flags)
+{
+	if (!bfid) {
+		FI_WARN(prov, FI_LOG_EP_CTRL, "NULL bind fid\n");
+		return -FI_EINVAL;
+	}
+
+	switch (bfid->fclass) {
+	case FI_CLASS_CQ:
+		if (flags & ~(FI_TRANSMIT | FI_RECV | FI_SELECTIVE_COMPLETION)) {
+			FI_WARN(prov, FI_LOG_EP_CTRL, "invalid CQ flags\n");
+			return -FI_EBADFLAGS;
+		}
+		break;
+	case FI_CLASS_CNTR:
+		if (flags & ~(FI_SEND | FI_RECV | FI_READ | FI_WRITE |
+			      FI_REMOTE_READ | FI_REMOTE_WRITE)) {
+			FI_WARN(prov, FI_LOG_EP_CTRL, "invalid cntr flags\n");
+			return -FI_EBADFLAGS;
+		}
+		break;
+	default:
+		if (flags) {
+			FI_WARN(prov, FI_LOG_EP_CTRL, "invalid bind flags\n");
+			return -FI_EBADFLAGS;
+		}
+		break;
+	}
+	return FI_SUCCESS;
+}
+
 uint64_t fi_gettime_ms(void)
 {
 	struct timeval now;

--- a/src/common.c
+++ b/src/common.c
@@ -128,7 +128,7 @@ size_t fi_datatype_size(enum fi_datatype datatype)
 	return fi_datatype_size_table[datatype];
 }
 
-int fi_send_allowed(uint64_t caps)
+int ofi_send_allowed(uint64_t caps)
 {
 	if (caps & FI_MSG ||
 		caps & FI_TAGGED) {
@@ -142,7 +142,7 @@ int fi_send_allowed(uint64_t caps)
 	return 0;
 }
 
-int fi_recv_allowed(uint64_t caps)
+int ofi_recv_allowed(uint64_t caps)
 {
 	if (caps & FI_MSG ||
 		caps & FI_TAGGED) {
@@ -156,7 +156,7 @@ int fi_recv_allowed(uint64_t caps)
 	return 0;
 }
 
-int fi_rma_initiate_allowed(uint64_t caps)
+int ofi_rma_initiate_allowed(uint64_t caps)
 {
 	if (caps & FI_RMA ||
 		caps & FI_ATOMICS) {
@@ -172,7 +172,7 @@ int fi_rma_initiate_allowed(uint64_t caps)
 	return 0;
 }
 
-int fi_rma_target_allowed(uint64_t caps)
+int ofi_rma_target_allowed(uint64_t caps)
 {
 	if (caps & FI_RMA ||
 		caps & FI_ATOMICS) {


### PR DESCRIPTION
Fixes #778.  Fixes #1142.  Fixes #1550.  (Fix is probably too strong of a word for these.)

Document range for signaling vector value.
Add mode bit to relax completion flag reporting.  *API UPDATE*
Document that long double is undocumented.  :)
Add checks to validate EP bind flags.

Please see individual commits for details.  This series includes changes to most providers, which have not been tested.  I wanted to get feedback on the proposed changes.  @goodell @j-xiong @a-ilango @hppritcha @sungeunchoi @jsquyres 