### PR TITLE
prov/psm,psm2: fix the "void *" arithmetic warnings

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -162,7 +162,7 @@ struct psmx_am_request {
 	int op;
 	union {
 		struct {
-			void	*buf;
+			uint8_t	*buf;
 			size_t	len;
 			uint64_t addr;
 			uint64_t key;
@@ -172,7 +172,7 @@ struct psmx_am_request {
 			uint64_t data;
 		} write;
 		struct {
-			void	*buf;
+			uint8_t	*buf;
 			size_t	len;
 			uint64_t addr;
 			uint64_t key;
@@ -181,7 +181,7 @@ struct psmx_am_request {
 			size_t	len_read;
 		} read;
 		struct {
-			void	*buf;
+			uint8_t	*buf;
 			size_t	len;
 			void	*context;
 			void	*peer_context;
@@ -190,19 +190,19 @@ struct psmx_am_request {
 			size_t	len_sent;
 		} send;
 		struct {
-			void	*buf;
+			uint8_t	*buf;
 			size_t	len;
 			void	*context;
 			void	*src_addr;
 			size_t  len_received;
 		} recv;
 		struct {
-			void	*buf;
+			uint8_t	*buf;
 			size_t	len;
 			uint64_t addr;
 			uint64_t key;
 			void	*context;
-			void 	*result;
+			uint8_t	*result;
 		} atomic;
 	};
 	uint64_t cq_flags;
@@ -230,7 +230,7 @@ struct psmx_req_queue {
 struct psmx_multi_recv {
 	uint64_t	tag;
 	uint64_t	tagsel;
-	void		*buf;
+	uint8_t		*buf;
 	size_t		len;
 	size_t		offset;
 	int		min_buf_size;

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -377,7 +377,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 {
 	psm_amarg_t rep_args[8];
 	int count;
-	void *addr;
+	uint8_t *addr;
 	uint64_t key;
 	int datatype, op;
 	int err = 0;
@@ -393,7 +393,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	switch (args[0].u32w0 & PSMX_AM_OP_MASK) {
 	case PSMX_AM_REQ_ATOMIC_WRITE:
 		count = args[0].u32w1;
-		addr = (void *)(uintptr_t)args[2].u64;
+		addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		datatype = args[4].u32w0;
 		op = args[4].u32w1;
@@ -429,7 +429,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 
 	case PSMX_AM_REQ_ATOMIC_READWRITE:
 		count = args[0].u32w1;
-		addr = (void *)(uintptr_t)args[2].u64;
+		addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		datatype = args[4].u32w0;
 		op = args[4].u32w1;
@@ -480,7 +480,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 
 	case PSMX_AM_REQ_ATOMIC_COMPWRITE:
 		count = args[0].u32w1;
-		addr = (void *)(uintptr_t)args[2].u64;
+		addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		datatype = args[4].u32w0;
 		op = args[4].u32w1;
@@ -496,7 +496,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			addr += mr->offset;
 			tmp_buf = malloc(len);
 			if (tmp_buf)
-				psmx_atomic_do_compwrite(addr, src, src + len,
+				psmx_atomic_do_compwrite(addr, src, (uint8_t *)src + len,
 							 tmp_buf, datatype, op, count);
 			else
 				op_error = -FI_ENOMEM;
@@ -812,9 +812,9 @@ ssize_t _psmx_atomic_write(struct fid_ep *ep,
 		req = malloc(sizeof(*req) + len);
 		if (!req)
 			return -FI_ENOMEM;
-		memset((void *)req, 0, sizeof(*req));
-		memcpy((void *)req+sizeof(*req), (void *)buf, len);
-		buf = (void *)req + sizeof(*req);
+		memset(req, 0, sizeof(*req));
+		memcpy((uint8_t *)req+sizeof(*req), (void *)buf, len);
+		buf = (uint8_t *)req + sizeof(*req);
 	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
@@ -999,9 +999,9 @@ ssize_t _psmx_atomic_readwrite(struct fid_ep *ep,
 		req = malloc(sizeof(*req) + len);
 		if (!req)
 			return -FI_ENOMEM;
-		memset((void *)req, 0, sizeof(*req));
-		memcpy((void *)req+sizeof(*req), (void *)buf, len);
-		buf = (void *)req + sizeof(*req);
+		memset(req, 0, sizeof(*req));
+		memcpy((uint8_t *)req+sizeof(*req), (void *)buf, len);
+		buf = (uint8_t *)req + sizeof(*req);
 	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
@@ -1205,17 +1205,17 @@ ssize_t _psmx_atomic_compwrite(struct fid_ep *ep,
 		req = malloc(sizeof(*req) + len + len);
 		if (!req)
 			return -FI_ENOMEM;
-		memset((void *)req, 0, sizeof(*req));
-		memcpy((void *)req + sizeof(*req), (void *)buf, len);
-		memcpy((void *)req + sizeof(*req) + len, (void *)compare, len);
-		buf = (void *)req + sizeof(*req);
-		compare = buf + len;
+		memset(req, 0, sizeof(*req));
+		memcpy((uint8_t *)req + sizeof(*req), (void *)buf, len);
+		memcpy((uint8_t *)req + sizeof(*req) + len, (void *)compare, len);
+		buf = (uint8_t *)req + sizeof(*req);
+		compare = (uint8_t *)buf + len;
 	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;
 
-		if (compare != buf + len) {
+		if ((uintptr_t)compare != (uintptr_t)buf + len) {
 			tmp_buf = malloc(len * 2);
 			if (!tmp_buf) {
 				free(req);
@@ -1223,7 +1223,7 @@ ssize_t _psmx_atomic_compwrite(struct fid_ep *ep,
 			}
 
 			memcpy(tmp_buf, buf, len);
-			memcpy(tmp_buf + len, compare, len);
+			memcpy((uint8_t *)tmp_buf + len, compare, len);
 		}
 	}
 

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -433,7 +433,9 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 					if (event == event_buffer) {
 						read_count++;
 						read_more = --count;
-						event_buffer = count ? event_buffer + cq->entry_size : NULL;
+						event_buffer = count ?
+							(uint8_t *)event_buffer + cq->entry_size :
+							NULL;
 						if (src_addr)
 							src_addr = count ? src_addr + 1 : NULL;
 					} else {
@@ -477,7 +479,9 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 				if (event == event_buffer) {
 					read_count++;
 					read_more = --count;
-					event_buffer = count ? event_buffer + cq->entry_size : NULL;
+					event_buffer = count ?
+						(uint8_t *)event_buffer + cq->entry_size :
+						NULL;
 					if (src_addr)
 						src_addr = count ? src_addr + 1 : NULL;
 				} else {
@@ -563,7 +567,7 @@ static ssize_t psmx_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 				psmx_cq_free_event(cq_priv, event);
 
 				read_count++;
-				buf += cq_priv->entry_size;
+				buf = (uint8_t *)buf + cq_priv->entry_size;
 				if (src_addr)
 					src_addr++;
 				continue;

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -171,6 +171,7 @@ static void psmx_mr_normalize_iov(struct iovec *iov, size_t *count)
 {
 	struct iovec tmp_iov;
 	int i, j, n, new_len;
+	uintptr_t iov_end_i, iov_end_j;
 
 	n = *count;
 
@@ -197,8 +198,10 @@ static void psmx_mr_normalize_iov(struct iovec *iov, size_t *count)
 			if (iov[j].iov_len == 0)
 				continue;
 
-			if (iov[i].iov_base + iov[i].iov_len >= iov[j].iov_base) {
-				new_len = iov[j].iov_base + iov[j].iov_len - iov[i].iov_base;
+			iov_end_i = (uintptr_t)iov[i].iov_base + iov[i].iov_len;
+			iov_end_j = (uintptr_t)iov[j].iov_base + iov[j].iov_len;
+			if (iov_end_i >= (uintptr_t)iov[j].iov_base) {
+				new_len = iov_end_j - (uintptr_t)iov[i].iov_base;
 				if (new_len > iov[i].iov_len)
 					iov[i].iov_len = new_len;
 				iov[j].iov_len = 0;

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -330,7 +330,7 @@ int psmx_am_process_send(struct psmx_fid_domain *domain, struct psmx_am_request 
 	req->send.len_sent = offset + len;
 	err = psm_am_request_short((psm_epaddr_t) req->send.dest_addr,
 				PSMX_AM_MSG_HANDLER, args, 4,
-				(void *)req->send.buf+offset, len,
+				req->send.buf+offset, len,
 				am_flags, NULL, NULL);
 
 	return psmx_errno(err);

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -75,7 +75,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			psm_amarg_t *args, int nargs, void *src, uint32_t len)
 {
 	psm_amarg_t rep_args[8];
-	void *rma_addr;
+	uint8_t *rma_addr;
 	ssize_t rma_len;
 	uint64_t key;
 	int err = 0;
@@ -93,7 +93,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	switch (cmd) {
 	case PSMX_AM_REQ_WRITE:
 		rma_len = args[0].u32w1;
-		rma_addr = (void *)(uintptr_t)args[2].u64;
+		rma_addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		mr = psmx_mr_get(psmx_active_fabric->active_domain, key);
 		op_error = mr ?
@@ -141,7 +141,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 
 	case PSMX_AM_REQ_WRITE_LONG:
 		rma_len = args[0].u32w1;
-		rma_addr = (void *)(uintptr_t)args[2].u64;
+		rma_addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		mr = psmx_mr_get(psmx_active_fabric->active_domain, key);
 		op_error = mr ?
@@ -180,7 +180,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 
 	case PSMX_AM_REQ_READ:
 		rma_len = args[0].u32w1;
-		rma_addr = (void *)(uintptr_t)args[2].u64;
+		rma_addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		offset = args[4].u64;
 		mr = psmx_mr_get(psmx_active_fabric->active_domain, key);
@@ -210,7 +210,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 
 	case PSMX_AM_REQ_READ_LONG:
 		rma_len = args[0].u32w1;
-		rma_addr = (void *)(uintptr_t)args[2].u64;
+		rma_addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		mr = psmx_mr_get(psmx_active_fabric->active_domain, key);
 		op_error = mr ?
@@ -710,9 +710,9 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 		if (!req)
 			return -FI_ENOMEM;
 
-		memset((void *)req, 0, sizeof(*req));
-		memcpy((void *)req + sizeof(*req), (void *)buf, len);
-		buf = (void *)req + sizeof(*req);
+		memset(req, 0, sizeof(*req));
+		memcpy((uint8_t *)req + sizeof(*req), (void *)buf, len);
+		buf = (uint8_t *)req + sizeof(*req);
 	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
@@ -790,7 +790,7 @@ ssize_t _psmx_write(struct fid_ep *ep, const void *buf, size_t len,
 					PSMX_AM_RMA_HANDLER, args, nargs,
 					(void *)buf, chunk_size,
 					am_flags, NULL, NULL);
-		buf += chunk_size;
+		buf = (const uint8_t *)buf + chunk_size;
 		addr += chunk_size;
 		len -= chunk_size;
 	}

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -213,7 +213,7 @@ struct psmx2_am_request {
 	int op;
 	union {
 		struct {
-			void	*buf;
+			uint8_t	*buf;
 			size_t	len;
 			uint64_t addr;
 			uint64_t key;
@@ -225,7 +225,7 @@ struct psmx2_am_request {
 		} write;
 		struct {
 			union {
-				void	*buf;	   /* for read */
+				uint8_t	*buf;	   /* for read */
 				size_t	iov_count; /* for readv */
 			};
 			size_t	len;
@@ -238,12 +238,12 @@ struct psmx2_am_request {
 			size_t	len_read;
 		} read;
 		struct {
-			void	*buf;
+			uint8_t	*buf;
 			size_t	len;
 			uint64_t addr;
 			uint64_t key;
 			void	*context;
-			void 	*result;
+			uint8_t *result;
 		} atomic;
 	};
 	uint64_t cq_flags;
@@ -286,7 +286,7 @@ struct psmx2_sendv_reply {
 	struct fi_context fi_context;
 	int no_completion;
 	int multi_recv;
-	void *buf;
+	uint8_t *buf;
 	void *user_context;
 	size_t iov_done;
 	size_t bytes_received;
@@ -305,7 +305,7 @@ struct psmx2_multi_recv {
 	psm2_epaddr_t	src_addr;
 	psm2_mq_tag_t	tag;
 	psm2_mq_tag_t	tagsel;
-	void		*buf;
+	uint8_t		*buf;
 	size_t		len;
 	size_t		offset;
 	int		min_buf_size;

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -377,7 +377,7 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 {
 	psm2_amarg_t rep_args[8];
 	int count;
-	void *addr;
+	uint8_t *addr;
 	uint64_t key;
 	int datatype, op;
 	int err = 0;
@@ -405,7 +405,7 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 	switch (cmd) {
 	case PSMX2_AM_REQ_ATOMIC_WRITE:
 		count = args[0].u32w1;
-		addr = (void *)(uintptr_t)args[2].u64;
+		addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		datatype = args[4].u32w0;
 		op = args[4].u32w1;
@@ -440,7 +440,7 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 
 	case PSMX2_AM_REQ_ATOMIC_READWRITE:
 		count = args[0].u32w1;
-		addr = (void *)(uintptr_t)args[2].u64;
+		addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		datatype = args[4].u32w0;
 		op = args[4].u32w1;
@@ -491,7 +491,7 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 
 	case PSMX2_AM_REQ_ATOMIC_COMPWRITE:
 		count = args[0].u32w1;
-		addr = (void *)(uintptr_t)args[2].u64;
+		addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
 		datatype = args[4].u32w0;
 		op = args[4].u32w1;
@@ -508,7 +508,7 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 			addr += mr->offset;
 			tmp_buf = malloc(len);
 			if (tmp_buf)
-				psmx2_atomic_do_compwrite(addr, src, src + len,
+				psmx2_atomic_do_compwrite(addr, src, (uint8_t *)src + len,
 							  tmp_buf, datatype,
 							  op, count);
 			else
@@ -833,9 +833,9 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 		req = malloc(sizeof(*req) + len);
 		if (!req)
 			return -FI_ENOMEM;
-		memset((void *)req, 0, sizeof(*req));
-		memcpy((void *)req+sizeof(*req), (void *)buf, len);
-		buf = (void *)req + sizeof(*req);
+		memset(req, 0, sizeof(*req));
+		memcpy((uint8_t *)req+sizeof(*req), (void *)buf, len);
+		buf = (uint8_t *)req + sizeof(*req);
 	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
@@ -1028,9 +1028,9 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 		req = malloc(sizeof(*req) + len);
 		if (!req)
 			return -FI_ENOMEM;
-		memset((void *)req, 0, sizeof(*req));
-		memcpy((void *)req+sizeof(*req), (void *)buf, len);
-		buf = (void *)req + sizeof(*req);
+		memset(req, 0, sizeof(*req));
+		memcpy((uint8_t *)req+sizeof(*req), (void *)buf, len);
+		buf = (uint8_t *)req + sizeof(*req);
 	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
@@ -1242,17 +1242,17 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 		req = malloc(sizeof(*req) + len + len);
 		if (!req)
 			return -FI_ENOMEM;
-		memset((void *)req, 0, sizeof(*req));
-		memcpy((void *)req + sizeof(*req), (void *)buf, len);
-		memcpy((void *)req + sizeof(*req) + len, (void *)compare, len);
-		buf = (void *)req + sizeof(*req);
-		compare = buf + len;
+		memset(req, 0, sizeof(*req));
+		memcpy((uint8_t *)req + sizeof(*req), (void *)buf, len);
+		memcpy((uint8_t *)req + sizeof(*req) + len, (void *)compare, len);
+		buf = (uint8_t *)req + sizeof(*req);
+		compare = (uint8_t *)buf + len;
 	} else {
 		req = calloc(1, sizeof(*req));
 		if (!req)
 			return -FI_ENOMEM;
 
-		if (compare != buf + len) {
+		if ((uintptr_t)compare != (uintptr_t)buf + len) {
 			tmp_buf = malloc(len * 2);
 			if (!tmp_buf) {
 				free(req);
@@ -1260,7 +1260,7 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 			}
 
 			memcpy(tmp_buf, buf, len);
-			memcpy(tmp_buf + len, compare, len);
+			memcpy((uint8_t *)tmp_buf + len, compare, len);
 		}
 	}
 

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -461,7 +461,9 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					if (event == event_buffer) {
 						read_count++;
 						read_more = --count;
-						event_buffer = count ? event_buffer + cq->entry_size : NULL;
+						event_buffer = count ?
+							(uint8_t *)event_buffer + cq->entry_size :
+							NULL;
 						if (src_addr)
 							src_addr = count ? src_addr + 1 : NULL;
 					} else {
@@ -562,7 +564,9 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				if (event == event_buffer) {
 					read_count++;
 					read_more = --count;
-					event_buffer = count ? event_buffer + cq->entry_size : NULL;
+					event_buffer = count ?
+						(uint8_t *)event_buffer + cq->entry_size :
+						NULL;
 					if (src_addr)
 						src_addr = count ? src_addr + 1 : NULL;
 				} else {
@@ -649,7 +653,7 @@ static ssize_t psmx2_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 				psmx2_cq_free_event(cq_priv, event);
 
 				read_count++;
-				buf += cq_priv->entry_size;
+				buf = (uint8_t *)buf + cq_priv->entry_size;
 				if (src_addr)
 					src_addr++;
 				continue;

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -174,6 +174,7 @@ static void psmx2_mr_normalize_iov(struct iovec *iov, size_t *count)
 {
 	struct iovec tmp_iov;
 	int i, j, n, new_len;
+	uintptr_t iov_end_i, iov_end_j;
 
 	n = *count;
 
@@ -200,8 +201,10 @@ static void psmx2_mr_normalize_iov(struct iovec *iov, size_t *count)
 			if (iov[j].iov_len == 0)
 				continue;
 
-			if (iov[i].iov_base + iov[i].iov_len >= iov[j].iov_base) {
-				new_len = iov[j].iov_base + iov[j].iov_len - iov[i].iov_base;
+			iov_end_i = (uintptr_t)iov[i].iov_base + iov[i].iov_len;
+			iov_end_j = (uintptr_t)iov[j].iov_base + iov[j].iov_len;
+			if (iov_end_i >= (uintptr_t)iov[j].iov_base) {
+				new_len = iov_end_j - (uintptr_t)iov[i].iov_base;
 				if (new_len > iov[i].iov_len)
 					iov[i].iov_len = new_len;
 				iov[j].iov_len = 0;

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -532,7 +532,7 @@ int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
 	struct fi_context *fi_context;
 	struct fi_context *recv_context;
 	int i, err;
-	void *recv_buf;
+	uint8_t *recv_buf;
 	size_t recv_len, len;
 
 	if (psm2_status->error_code != PSM2_OK)


### PR DESCRIPTION
Use a combination of the following methods:
(1) Define the pointer as type "uint8_t *" whenever possible;
(2) Type cast to "uint8_t *" before arithmetic operations if the
    result is intended to be used as a pointer;
(3) Type cast to "uintptr_t" before arithmetic operations if the
    result is intended to be used as a value.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>