### PR TITLE
usnic: fi_listen() needs to get the actual sin_port

### DIFF
--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -283,6 +283,7 @@ usdf_pep_listen(struct fid_pep *fpep)
 	struct usdf_pep *pep;
 	struct epoll_event ev;
 	struct usdf_fabric *fp;
+	socklen_t socklen;
 	int ret;
 
 	USDF_TRACE_SYS(EP_CTRL, "\n");
@@ -315,6 +316,15 @@ usdf_pep_listen(struct fid_pep *fpep)
 		if (ret == -1) {
 			return -errno;
 		}
+
+		/* Get the actual port (since we may have requested
+		 * port 0)
+		 */
+		socklen = sizeof(pep->pep_src_addr);
+		ret = getsockname(pep->pep_sock, &pep->pep_src_addr,
+				&socklen);
+		if (ret == -1)
+			return -errno;
 		pep->pep_state = USDF_PEP_BOUND;
 	}
 


### PR DESCRIPTION
We may have requested sin_port==0, in which case we need to query to find out what the actual port number is that we got.  This enables fi_getname() to return the right sin_port value, later.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

@bturrubiates Please review.