### PR TITLE
prov/verbs: fix return err code in fi_ibv_rdm_find_ipoib_addr function

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -458,6 +458,9 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	}
 
 	ret = fi_ibv_create_ep(NULL, NULL, 0, info, &_ep->cm.rai, &_ep->cm.listener);
+	if (ret) {
+		goto err;
+	}
 
 	if (rdma_listen(_ep->cm.listener, 1024)) {
 		VERBS_INFO(FI_LOG_EP_CTRL, "rdma_listen failed: %s\n",

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -182,7 +182,7 @@ int fi_ibv_rdm_find_ipoib_addr(const struct sockaddr_in *addr,
 	size_t iface_len = 2;
 
 	if (!addr || !addr->sin_addr.s_addr) {
-		return 0;
+		return 1;
 	}
 
 	if (fi_param_get_str(&fi_ibv_prov, "iface", &iface_tmp) == FI_SUCCESS) {
@@ -191,7 +191,7 @@ int fi_ibv_rdm_find_ipoib_addr(const struct sockaddr_in *addr,
 			VERBS_INFO(FI_LOG_EP_CTRL,
 				   "Too long iface name: %s, max: %d\n",
 				   iface_tmp, IFNAMSIZ);
-			return 0;
+			return 1;
 		}
 	}
 

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -987,7 +987,7 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 			FI_IBV_EP_TYPE_IS_RDM(hints) ? &(rdm_cm.listener) : &id);
 
 out:
-	if (!ret || ret == -FI_ENOMEM)
+	if (!ret || ret == -FI_ENOMEM || ret == -FI_ENODEV)
 		return ret;
 	else
 		return -FI_ENODATA;


### PR DESCRIPTION
This caused a segfault when wrong IP address was passed:
fi_rdm -f verbs 2.2.2.2

@a-ilango 