### PR TITLE
fabric/windows: Add critical section wait object

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -39,6 +39,7 @@
 
 #if defined(_WIN32)
 #include <BaseTsd.h>
+#include <windows.h>
 typedef SSIZE_T ssize_t;
 #endif
 

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -58,6 +58,7 @@ enum fi_wait_obj {
 	FI_WAIT_SET,
 	FI_WAIT_FD,
 	FI_WAIT_MUTEX_COND,	/* pthread mutex & cond */
+	FI_WAIT_CRITSEC_COND	/* critical section & cond */
 };
 
 struct fi_wait_attr {
@@ -75,10 +76,18 @@ struct fid_wait {
 	struct fi_ops_wait	*ops;
 };
 
+#ifndef _WIN32
 struct fi_mutex_cond {
 	pthread_mutex_t		*mutex;
 	pthread_cond_t		*cond;
 };
+#else /* _WIN32 */
+struct fi_critsec_cond {
+	LPCRITICAL_SECTION	critsec;
+	PCONDITION_VARIABLE	cond;
+};
+#endif /* _WIN32 */
+
 
 /*
  * Poll Set

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -249,6 +249,10 @@ struct fi_cq_tagged_entry {
 : Specifies that the CQ should use a pthread mutex and cond variable
   as a wait object.
 
+- *FI_WAIT_CRITSEC_COND*
+: Windows specific.  Specifies that the EQ should use a critical
+  section and condition variable as a wait object.
+
 *signaling_vector*
 : Indicates which processor core interrupts associated with the EQ should
   target.

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -173,6 +173,10 @@ struct fi_eq_attr {
 : Specifies that the EQ should use a pthread mutex and cond variable
   as a wait object.
 
+- *FI_WAIT_CRITSEC_COND*
+: Windows specific.  Specifies that the EQ should use a critical
+  section and condition variable as a wait object.
+
 *signaling_vector*
 : Indicates which processor core interrupts associated with the EQ
   should target.

--- a/man/fi_poll.3.md
+++ b/man/fi_poll.3.md
@@ -190,6 +190,10 @@ struct fi_wait_attr {
 : Specifies that the wait set should use a pthread mutex and cond
   variable as a wait object.
 
+- *FI_WAIT_CRITSEC_COND*
+: Windows specific.  Specifies that the EQ should use a critical
+  section and condition variable as a wait object.
+
 *flags*
 : Flags that set the default operation of the wait set.  The use of
   this field is reserved and must be set to 0 by the caller.


### PR DESCRIPTION
Add new wait object type for windows: critical section +
condition variable.

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>
Signed-off-by: Sean Hefty <sean.hefty@intel.com>

This replaces PR #2117