### PR TITLE
fabric/cq: Add mode bit to relax completion flag reporting

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -240,6 +240,7 @@ enum {
 #define FI_ASYNC_IOV		(1ULL << 57)
 #define FI_RX_CQ_DATA		(1ULL << 56)
 #define FI_LOCAL_MR		(1ULL << 55)
+#define FI_NOTIFY_FLAGS_ONLY	(1ULL << 54)
 
 struct fi_tx_attr {
 	uint64_t		caps;

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -522,6 +522,12 @@ operation.  The following completion flags are defined.
   If other flag bits are zero, the provider is reporting that the multi-recv
   buffer has been freed, and the completion entry is not associated
   with a received message.
+
+Completion flags may be suppressed if the FI_NOTIFY_FLAGS_ONLY mode bit
+has been set.  When enabled, only the following flags are guaranteed to
+be set in completion data when they are valid: FI_REMOTE_READ and
+FI_REMOTE_WRITE (when FI_RMA_EVENT capability bit has been set),
+FI_REMOTE_CQ_DATA, and FI_MULTI_RECV.
  
 # RETURN VALUES
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -455,6 +455,15 @@ supported set of modes will be returned in the info structure(s).
   receive buffer at the target.  This is true even for operations that would
   normally not consume posted receive buffers, such as RMA write operations.
 
+*FI_NOTIFY_FLAGS_ONLY*
+: This bit indicates that general completion flags may not be set by
+  the provider, and are not needed by the application.  If specified,
+  completion flags which simply report the type of operation that
+  completed (e.g. send or receive) may not be set.  However,
+  completion flags that are used for remote notifications will still
+  be set when applicable.  See `fi_cq`(3) for details on which completion
+  flags are valid when this mode bit is enabled.
+
 # ADDRESSING FORMATS
 
 Multiple fabric interfaces take as input either a source or


### PR DESCRIPTION
Some providers cannot report the full set of completion flags
without tracking requests internally.  For example, verbs cannot
report any flags if a request completes in error.

Define a new mode bit that allows a provider to leave most
of the completion flags unset.  

Define FI_NOTIFY_FLAGS_ONLY mode bit
When set on an EP, only the following flags are returned in completions:

    FI_REMOTE_READ | FI_RMA (if FI_RMA_EVENT cap set)
    FI_REMOTE_WRITE | FI_RMA (if FI_RMA_EVENT cap set)
    FI_REMOTE_CQ_DATA
    FI_MULTI_RECV

Fixes #1142

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

Separating from PR #2135 for further discussion and analysis based on application needs.