### PR TITLE
man/cq: Document range for signaling vector

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -127,6 +127,7 @@ typedef struct fid *fid_t;
 #define FI_INJECT_COMPLETE	(1ULL << 26)
 #define FI_TRANSMIT_COMPLETE	(1ULL << 27)
 #define FI_DELIVERY_COMPLETE	(1ULL << 28)
+#define FI_AFFINITY		(1ULL << 29)
 
 /* fi_getinfo()-specific flags/caps */
 #define FI_PROV_ATTR_ONLY	(1ULL << 54)

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -145,7 +145,10 @@ struct fi_cq_attr {
   the provider may choose a default value.
 
 *flags*
-: Flags that control the configuration of the CQ.  This field must be 0.
+: Flags that control the configuration of the CQ.
+
+- *FI_AFFINITY*
+: Indicates that the signaling_vector field (see below) is valid.
 
 *format*
 : Completion queues allow the application to select the amount of
@@ -250,8 +253,10 @@ struct fi_cq_tagged_entry {
   as a wait object.
 
 *signaling_vector*
-: Indicates which processor core interrupts associated with the EQ should
-  target.
+: If the FI_AFFINITY flag is set, this indicates the logical cpu number
+  (0..max cpu - 1) that interrupts associated with the EQ should target.
+  This field should be treated as a hint to the provider and may be
+  ignored if the provider does not support interrupt affinity.
 
 *wait_cond*
 : By default, when a completion is inserted into an CQ that supports

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -136,6 +136,9 @@ struct fi_eq_attr {
   operation must be supported by the provider.  If the FI_WRITE flag
   is not set, then the application may not invoke fi_eq_write.
 
+- *FI_AFFINITY*
+: Indicates that the signaling_vector field (see below) is valid.
+
 *wait_obj*
 : EQ's may be associated with a specific wait object.  Wait objects
   allow applications to block until the wait object is signaled,
@@ -174,8 +177,10 @@ struct fi_eq_attr {
   as a wait object.
 
 *signaling_vector*
-: Indicates which processor core interrupts associated with the EQ
-  should target.
+: If the FI_AFFINITY flag is set, this indicates the logical cpu number
+  (0..max cpu - 1) that interrupts associated with the EQ should target.
+  This field should be treated as a hint to the provider and may be
+  ignored if the provider does not support interrupt affinity.
 
 *wait_set*
 : If wait_obj is FI_WAIT_SET, this field references a wait object to

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -77,14 +77,13 @@ int fi_check_cq_attr(const struct fi_provider *prov,
 		return -FI_EINVAL;
 	}
 
-	if (attr->flags) {
+	if (attr->flags & ~(FI_AFFINITY)) {
 		FI_WARN(prov, FI_LOG_CQ, "invalid flags\n");
 		return -FI_EINVAL;
 	}
 
-	if (attr->signaling_vector) {
-		FI_WARN(prov, FI_LOG_CQ, "signaling vectors not supported\n");
-		return -FI_ENOSYS;
+	if (attr->flags & FI_AFFINITY) {
+		FI_WARN(prov, FI_LOG_CQ, "signaling vector ignored\n");
 	}
 
 	return 0;

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -262,9 +262,13 @@ static int util_verify_eq_attr(const struct fi_provider *prov,
 		return -FI_EINVAL;
 	}
 
-	if (attr->signaling_vector) {
-		FI_WARN(prov, FI_LOG_EQ, "signaling vectors not supported\n");
-		return -FI_ENOSYS;
+	if (attr->flags & ~(FI_AFFINITY | FI_WRITE)) {
+		FI_WARN(prov, FI_LOG_EQ, "invalid flags\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr->flags & FI_AFFINITY) {
+		FI_WARN(prov, FI_LOG_EQ, "signaling vector ignored\n");
 	}
 
 	return 0;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -535,7 +535,7 @@ int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	}
 
 	_cq->cq = ibv_create_cq(_cq->domain->verbs, attr->size, _cq,
-	_cq->channel, attr->signaling_vector);
+				_cq->channel, attr->signaling_vector);
 
 	if (!_cq->cq) {
 		ret = -errno;


### PR DESCRIPTION
Identify the range for signaling vectors and indicate
that the value may be ignored by the provider.  Update
the utility code to accept any value, but still print
a warning if it is non-zero.

Fixes #778.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>