### PR TITLE
Pr/sockets: Fix address matching login in setting fabric/domain name

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -41,6 +41,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/param.h>
+#include <netinet/in.h>
 
 #include <fi_abi.h>
 #include <fi_file.h>
@@ -133,7 +134,6 @@ void fi_param_init(void);
 void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
 
-
 static inline uint64_t roundup_power_of_two(uint64_t n)
 {
 	if (!n || !(n & (n - 1)))
@@ -169,6 +169,18 @@ int fi_rma_target_allowed(uint64_t caps);
 
 uint64_t fi_gettime_ms(void);
 
+static inline int ofi_equals_ipaddr(struct sockaddr_in *addr1,
+                             struct sockaddr_in *addr2)
+{
+        return (addr1->sin_addr.s_addr == addr2->sin_addr.s_addr);
+}
+
+static inline int ofi_equals_sockaddr(struct sockaddr_in *addr1,
+                             struct sockaddr_in *addr2)
+{
+        return (ofi_equals_ipaddr(addr1, addr2) &&
+                (addr1->sin_port == addr2->sin_port));
+}
 
 #ifdef __cplusplus
 }

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -1100,7 +1100,6 @@ int sock_wait_close(fid_t fid);
 int sock_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		 struct fid_av **av, void *context);
 int sock_av_compare_addr(struct sock_av *av, fi_addr_t addr1, fi_addr_t addr2);
-int sock_compare_addr(struct sockaddr_in *addr1, struct sockaddr_in *addr2);
 int sock_av_get_addr_index(struct sock_av *av, struct sockaddr_in *addr);
 
 struct sock_conn *sock_ep_lookup_conn(struct sock_ep_attr *attr, fi_addr_t index,

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -60,13 +60,6 @@
 				count * sizeof(struct sock_av_addr))
 #define SOCK_IS_SHARED_AV(av_name) ((av_name) ? 1 : 0)
 
-int sock_compare_addr(struct sockaddr_in *addr1,
-			     struct sockaddr_in *addr2)
-{
-	return ((addr1->sin_addr.s_addr == addr2->sin_addr.s_addr) &&
-		(addr1->sin_port == addr2->sin_port));
-}
-
 int sock_av_get_addr_index(struct sock_av *av, struct sockaddr_in *addr)
 {
 	int i;
@@ -74,7 +67,7 @@ int sock_av_get_addr_index(struct sock_av *av, struct sockaddr_in *addr)
 
 	for (i = 0; i < av->table_hdr->stored; i++) {
 		av_addr = &av->table[i];
-		if (sock_compare_addr(addr, (struct sockaddr_in *)&av_addr->addr))
+		if (ofi_equals_sockaddr(addr, (struct sockaddr_in *)&av_addr->addr))
 			return i;
 	}
 	SOCK_LOG_DBG("failed to get index in AV\n");

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1262,7 +1262,7 @@ char *sock_get_fabric_name(struct sockaddr_in *src_addr)
 		if (ifa->ifa_addr == NULL || !(ifa->ifa_flags & IFF_UP) ||
 		     (ifa->ifa_addr->sa_family != AF_INET))
 			continue;
-		if (sock_compare_addr((struct sockaddr_in *)ifa->ifa_addr, src_addr)) {
+		if (ofi_equals_ipaddr((struct sockaddr_in *)ifa->ifa_addr, src_addr)) {
 			host_addr = (struct sockaddr_in *)ifa->ifa_addr;
 			net_addr = (struct sockaddr_in *)ifa->ifa_netmask;
 			// set fabric name to the network_adress in the format of a.b.c.d/e
@@ -1296,7 +1296,7 @@ char *sock_get_domain_name(struct sockaddr_in *src_addr)
 		if (ifa->ifa_addr == NULL || !(ifa->ifa_flags & IFF_UP) ||
 		     (ifa->ifa_addr->sa_family != AF_INET))
 			continue;
-		if (sock_compare_addr((struct sockaddr_in *)ifa->ifa_addr, src_addr)) {
+		if (ofi_equals_ipaddr((struct sockaddr_in *)ifa->ifa_addr, src_addr)) {
 			domain_name = strdup(ifa->ifa_name);
 			return domain_name;
 		}
@@ -1408,12 +1408,11 @@ struct fi_info *sock_fi_info(enum fi_ep_type ep_type, struct fi_info *hints,
 	info->mode = SOCK_MODE;
 	info->addr_format = FI_SOCKADDR_IN;
 
-	if (src_addr) {
+	if (src_addr)
 		memcpy(info->src_addr, src_addr, sizeof(struct sockaddr_in));
-		info->src_addrlen = sizeof(struct sockaddr_in);
-	} else {
+	else
 		sock_get_src_addr_from_hostname(info->src_addr, NULL);
-	}
+	info->src_addrlen = sizeof(struct sockaddr_in);
 
 	if (dest_addr) {
 		info->dest_addr = calloc(1, sizeof(struct sockaddr_in));
@@ -1709,12 +1708,12 @@ struct sock_conn *sock_ep_lookup_conn(struct sock_ep_attr *attr, fi_addr_t index
 	idx = (attr->ep_type == FI_EP_MSG) ? index : index & attr->av->mask;
 	conn = idm_lookup(&attr->av_idm, idx);
 	if (conn && conn != SOCK_CM_CONN_IN_PROGRESS) {
-		assert(sock_compare_addr(&conn->addr, addr));
+		assert(ofi_equals_sockaddr(&conn->addr, addr));
 		return conn;
 	}
 
 	for (i = 0; i < attr->cmap.used; i++) {
-		if (sock_compare_addr(&attr->cmap.table[i].addr, addr))
+		if (ofi_equals_sockaddr(&attr->cmap.table[i].addr, addr))
 			return &attr->cmap.table[i];
 	}
 	return conn;


### PR DESCRIPTION
- Moved <code>sock_comapre_addr()</code> call (and renamed to <code>ofi_equals_sockaddr()</code>) from <code>sock_av.c</code> to <code>fi.h</code> so that other providers can use it. The refactored functions are -

 <code>ofi_equals_ipaddr()</code>
 <code>ofi_equals_sockaddr()</code>
- Fixed the logic in setting fabric/domain to only compares IP address as fabric/domain address should not depend on the port.
- Assign <code>info->src_addrlen</code> correctly when <code>src_addr</code> is not given.
- Fixed formatting issues.

Fixes #2105. 

@shefty @jithinjosepkl @bturrubiates 