### PR TITLE
prov/psm,psm2: Fix segfault when retrieving wait object

### DIFF
--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -343,7 +343,10 @@ static int psmx_cntr_control(fid_t fid, int command, void *arg)
 		break;
 
 	case FI_GETWAIT:
-		ret = fi_control(&cntr->wait->wait_fid.fid, FI_GETWAIT, arg);
+		if (cntr->wait)
+			ret = fi_control(&cntr->wait->wait_fid.fid, FI_GETWAIT, arg);
+		else
+			return -FI_EINVAL;
 		break;
 
 	default:

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -717,7 +717,10 @@ static int psmx_cq_control(struct fid *fid, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
-		ret = fi_control(&cq->wait->wait_fid.fid, FI_GETWAIT, arg);
+		if (cq->wait)
+			ret = fi_control(&cq->wait->wait_fid.fid, FI_GETWAIT, arg);
+		else
+			return -FI_EINVAL;
 		break;
 
 	default:

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -397,7 +397,10 @@ static int psmx2_cntr_control(fid_t fid, int command, void *arg)
 		break;
 
 	case FI_GETWAIT:
-		ret = fi_control(&cntr->wait->wait_fid.fid, FI_GETWAIT, arg);
+		if (cntr->wait)
+			ret = fi_control(&cntr->wait->wait_fid.fid, FI_GETWAIT, arg);
+		else
+			return -FI_EINVAL;
 		break;
 	default:
 		return -FI_ENOSYS;

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -802,7 +802,10 @@ static int psmx2_cq_control(struct fid *fid, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
-		ret = fi_control(&cq->wait->wait_fid.fid, FI_GETWAIT, arg);
+		if (cq->wait)
+			ret = fi_control(&cq->wait->wait_fid.fid, FI_GETWAIT, arg);
+		else
+			return -FI_EINVAL;
 		break;
 
 	default:


### PR DESCRIPTION
If a CQ or counter is created with FI_WAIT_NONE, fi_control with
FI_GETWAIT command would fail with segfault trying to dereference
the empty wait object. Add checking to prevent this from happening.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>