### PR TITLE
prov/sockets: Fix return code when fi_getinfo fails

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -590,7 +590,7 @@ int sock_node_getinfo(const char *node, const char *service, uint64_t flags,
 						hints->ep_attr->type, &cur);
 			if (ret) {
 				if (ret == -FI_ENODATA)
-					return 0;
+					return ret;
 				goto err;
 			}
 


### PR DESCRIPTION
When invalid hostname is passed, <code>sock_node_getinfo</code> returns <code>-FI_ENODATA</code> but passes 0 to the caller which causes a segfault. Fixed the return error code.

Fixes #2149 

@shefty @jithinjosepkl 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>