### PR TITLE
windows: fi_fd_nonblock moved to osd.c

### DIFF
--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -201,12 +201,6 @@ static inline int ofi_sockerr(void)
 	}
 }
 
-static inline int fi_fd_nonblock(int fd)
-{
-	u_long argp = 1;
-	return ioctlsocket(fd, FIONBIO, &argp) ? -WSAGetLastError() : 0;
-}
-
 static inline int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout)
 {
 	return !SleepConditionVariableCS(cond, mut, (DWORD)timeout);

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -252,5 +252,11 @@ int ofi_shm_unmap(struct util_shm *shm)
 	return FI_SUCCESS;
 }
 
+int fi_fd_nonblock(int fd)
+{
+	u_long argp = 1;
+	return ioctlsocket(fd, FIONBIO, &argp) ? -WSAGetLastError() : 0;
+}
+
 
 


### PR DESCRIPTION
to avoid compilation warning (double declaration)
function fi_fd_nonblock is moved to osd.c file

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>