### PR TITLE
prov/psm,psm2: prevent segfault in fi_av_insert due to invalid input

### DIFF
--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -149,6 +149,12 @@ static int psmx_av_insert(struct fid_av *av, const void *addr, size_t count,
 	fi_addr_t *result = NULL;
 	struct psmx_epaddr_context *epaddr_context;
 
+	if (count && (!addr || !fi_addr)) {
+		FI_INFO(&psmx_prov, FI_LOG_AV,
+			"NULL address array: addr=%p fi_addr=%p.\n", addr, fi_addr);
+		return -FI_EINVAL;
+	}
+
 	av_priv = container_of(av, struct psmx_fid_av, av);
 
 	if ((av_priv->flags & FI_EVENT) && !av_priv->eq)

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -241,6 +241,12 @@ static int psmx2_av_insert(struct fid_av *av, const void *addr,
 	int error_count;
 	int i;
 
+	if (count && (!addr || !fi_addr)) {
+		FI_INFO(&psmx2_prov, FI_LOG_AV,
+			"NULL address array: addr=%p fi_addr=%p.\n", addr, fi_addr);
+		return -FI_EINVAL;
+	}
+
 	av_priv = container_of(av, struct psmx2_fid_av, av);
 
 	if ((av_priv->flags & FI_EVENT) && !av_priv->eq)


### PR DESCRIPTION
It is possible that applications call fi_av_insert with NULL as
the address array(s). One example is to use "fi->dest_addr" as the
input without verifying it's value. This would lead to a segfault.
Add parameter checking to return error in such case.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>