### PR TITLE
prov/psm,psm2: Report error when fi_getinfo can't resolve "node"

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -149,8 +149,18 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 
 	psmx_init_env();
 
-	if (node && !(flags & FI_SOURCE))
+	if (node && !(flags & FI_SOURCE)) {
 		dest_addr = psmx_resolve_name(node, 0);
+		if (dest_addr) {
+			FI_INFO(&psmx_prov, FI_LOG_CORE,
+				"node '%s' resolved to <epid=0x%llx>\n", node,
+				*(psm_epid_t *)dest_addr);
+		} else {
+			FI_INFO(&psmx_prov, FI_LOG_CORE,
+				"failed to resolve node '%s'.\n", node);
+			return -FI_ENODATA;
+		}
+	}
 
 	if (hints) {
 		switch (hints->addr_format) {

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -91,14 +91,16 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 
 	if (node && !(flags & FI_SOURCE)) {
 		dest_addr = psmx2_resolve_name(node, 0);
-		if (dest_addr)
+		if (dest_addr) {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
 				"node '%s' resolved to <epid=0x%llx, vl=%d>\n", node,
 				((struct psmx2_ep_name *)dest_addr)->epid,
 				((struct psmx2_ep_name *)dest_addr)->vlane);
-		else
+		} else {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
 				"failed to resolve node '%s'.\n", node);
+			return -FI_ENODATA;
+		}
 	}
 
 	if (hints) {


### PR DESCRIPTION
The resolution from "node" to destination address (FI_SOURCE flag
not set) was handled as "optional" and on failure fi_getinfo
could return success with the "dest_addr" field set to NULL. This
may break applications that assume successful return always means
successful address resolution. Change the behavior to return
-FI_ENODATA when such address resolution fails.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>