### PR TITLE
fabric/getinfo: Return -FI_NODATA on failure

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -508,7 +508,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 {
 	struct fi_prov *prov;
 	struct fi_info *tail, *cur;
-	int ret = -FI_ENODATA;
+	int ret;
 
 	if (!init)
 		fi_ini();
@@ -561,7 +561,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 		tail->fabric_attr->prov_version = prov->provider->version;
 	}
 
-	return *info ? 0 : ret;
+	return *info ? 0 : -FI_ENODATA;
 }
 DEFAULT_SYMVER(fi_getinfo_, fi_getinfo);
 


### PR DESCRIPTION
fi_getinfo returns the error code from the last provider
if no fi_info structures are available.  Instead return
FI_ENODATA for more consistency.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>