### PR TITLE
prov/gni: Ignore getifaddrs leak in the sockets

### DIFF
--- a/prov/gni/contrib/gnitest.supp
+++ b/prov/gni/contrib/gnitest.supp
@@ -32,6 +32,19 @@
 }
 
 #
+# These are leaks from getifaddrs in the sockets provider.
+#
+{
+    getifaddrs_criterion_run_all_tests
+    Memcheck:Leak
+    match-leak-kinds: definite
+    fun:calloc
+    fun:getifaddrs_internal
+    fun:getifaddrs
+}
+
+
+#
 # This is an actual memory leak in uGNI.  A bug has been submitted
 #
 {


### PR DESCRIPTION
provider.

upstream merge of ofi-cray/libfabric-cray#880
@sungeunchoi 

Signed-off-by: Evan Harvey <eharvey@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@a2d7a3f014209713b0e930b7d43b3a57727f34fa)