### PR TITLE
fabric: Document that FI_ASYNC_IOV is not needed if iov_cnt = 1

### DIFF
--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -445,7 +445,7 @@ supported set of modes will be returned in the info structure(s).
   IOV buffering may have a negative impact on performance and memory
   consumption.  The FI_ASYNC_IOV mode indicates that the application
   must provide the buffering needed for the IO vectors.  When set,
-  an application must not modify an IO vector, including any
+  an application must not modify an IO vector of length > 1, including any
   related memory descriptor array, until the associated
   operation has completed.
 


### PR DESCRIPTION
This relates to issue #1393.  If the user specifies a single
iov, clarify that async iov support is not needed, and the
FI_ASYNC_IOV mode bit is ignored.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

This at least partially addresses #1393, and depending on the outcome from that issue, may be a possible solution.  Note that nothing in tree requires FI_ASYNC_IOV (I think B/G may), so this is addressing a theoretic issue.