### PR TITLE
PSM2: fix memory corruption in fi_trywait() for FI_CLASS_CQ

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -123,7 +123,7 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_SIGN_MASK  		(0x0080000000000000UL)
 #define PSMX2_SIGN_EXT			(0xFF00000000000000UL)
 #define PSMX2_VL_MASK			(0xFF00000000000000UL)
- 
+
 #define PSMX2_EP_TO_ADDR(ep,vl)		((((uint64_t)vl) << 56) | \
 						((uint64_t)ep & PSMX2_EP_MASK))
 #define PSMX2_ADDR_TO_VL(addr)		((uint8_t)((addr & PSMX2_VL_MASK) >> 56))
@@ -338,7 +338,7 @@ struct psmx2_fid_domain {
 	uint64_t		vl_map[(PSMX2_MAX_VL+1)/sizeof(uint64_t)];
 	int			vl_alloc;
 	struct psmx2_fid_ep	*eps[PSMX2_MAX_VL+1];
-	
+
 	int			am_initialized;
 
 	/* incoming req queue for AM based RMA request. */
@@ -689,6 +689,7 @@ int	psmx2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		       struct fid_cntr **cntr, void *context);
 int	psmx2_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 			struct fid_wait **waitset);
+int psmx2_wait_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
 
 static inline void psmx2_fabric_acquire(struct psmx2_fid_fabric *fabric)
 {

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -91,7 +91,7 @@ static struct fi_ops_fabric psmx2_fabric_ops = {
 	.passive_ep = fi_no_passive_ep,
 	.eq_open = ofi_eq_create,
 	.wait_open = psmx2_wait_open,
-	.trywait = ofi_trywait
+	.trywait = psmx2_wait_trywait
 };
 
 static struct fi_fabric_attr psmx2_fabric_attr = {

--- a/prov/psm2/src/psmx2_wait.c
+++ b/prov/psm2/src/psmx2_wait.c
@@ -150,3 +150,36 @@ int psmx2_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 	return 0;
 }
 
+int psmx2_wait_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	struct psmx2_fid_cq *cq_priv;
+	struct util_eq *eq;
+	struct util_wait *wait;
+	int i, ret;
+
+	for (i = 0; i < count; i++) {
+		switch (fids[i]->fclass) {
+			case FI_CLASS_CQ:
+				cq_priv = container_of(fids[i], struct psmx2_fid_cq, cq);
+				wait = cq_priv->wait;
+				break;
+			case FI_CLASS_EQ:
+				eq = container_of(fids[i], struct util_eq, eq_fid.fid)
+				wait = eq->wait;
+				break;
+			case FI_CLASS_CNTR:
+				return -FI_ENOSYS;
+			case FI_CLASS_WAIT:
+				wait = container_of(fids[i], struct util_wait, wait_fid.fid);
+				break;
+			default:
+				return -FI_EINVAL;
+		}
+
+		ret = wait->try(wait);
+		if (ret)
+			return ret;
+	}
+	return 0;
+}
+


### PR DESCRIPTION
Hi, 

I've discovered a memory corruption with the PSM2 provider and the function fi_trywait().
Thank you for reviewing the patch and for your feedback.

Regards,

--

With the current master, PSM2 makes use of the generic function
ofi_trywait(). This is wrong since PSM2 uses it's own representation
of the CQ (struct psmx2_fid_cq), which is different than the generic
one defined in util_wait.c (struct util_cq).
This aims at causing a memory corruption in fi_trywait() for any FID
belonging to the class FI_CLASS_CQ.

This patch also disables the support for FI_CLASS_EQ in fi_trywait()
since EQ are not supported in PSM2 (-FI_ENOSYS is returned in this
case).