### PR TITLE
prov/verbs: ep_rdm bugfix

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -73,8 +73,8 @@ static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
 		entry[ret].tag = cq_entry->minfo.tag;
 
 		if (cq_entry->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
-			FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", cq_entry,
-						      FI_LOG_DEBUG);
+			FI_IBV_RDM_DBG_REQUEST("to_pool: ", cq_entry, 
+						FI_LOG_DEBUG);
 			util_buf_release(fi_ibv_rdm_tagged_request_pool, cq_entry);
 		} else {
 			cq_entry->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
@@ -197,8 +197,8 @@ fi_ibv_rdm_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *entry,
 		entry->err_data = NULL;
 
 		if (err_request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
-			FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", err_request,
-				FI_LOG_DEBUG);
+			FI_IBV_RDM_DBG_REQUEST("to_pool: ", err_request,
+						FI_LOG_DEBUG);
 			util_buf_release(fi_ibv_rdm_tagged_request_pool,
 				err_request);
 		} else {

--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -196,9 +196,15 @@ fi_ibv_rdm_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *entry,
 		entry->prov_errno = -err_request->state.err;
 		entry->err_data = NULL;
 
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", err_request,
-			FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_tagged_request_pool, err_request);
+		if (err_request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
+			FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", err_request,
+				FI_LOG_DEBUG);
+			util_buf_release(fi_ibv_rdm_tagged_request_pool,
+				err_request);
+		} else {
+			err_request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
+		}
+
 		ret++;
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -82,9 +82,9 @@ fi_ibv_rdm_take_first_from_cq()
 static inline void
 fi_ibv_rdm_move_to_errcq(struct fi_ibv_rdm_tagged_request *request, ssize_t err)
 {
+	request->state.err = llabs(err);
 	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_errcq: ",
 				      request, FI_LOG_DEBUG);
-	request->state.err = llabs(err);
 	assert(request->context);
 	dlist_insert_tail(&request->queue_entry,
 			  &fi_ibv_rdm_comp_queue.request_errcq);

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -52,8 +52,7 @@ extern struct util_buf_pool* fi_ibv_rdm_postponed_pool;
 static inline void
 fi_ibv_rdm_move_to_cq(struct fi_ibv_rdm_tagged_request *request)
 {
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_cq: ",
-				      request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("move_to_cq: ", request, FI_LOG_DEBUG);
 	dlist_insert_tail(&request->queue_entry,
 			  &fi_ibv_rdm_comp_queue.request_cq);
 }
@@ -61,8 +60,7 @@ fi_ibv_rdm_move_to_cq(struct fi_ibv_rdm_tagged_request *request)
 static inline void
 fi_ibv_rdm_remove_from_cq(struct fi_ibv_rdm_tagged_request *request)
 {
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_cq: ",
-				      request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("remove_from_cq: ", request, FI_LOG_DEBUG);
 	dlist_remove(&request->queue_entry);
 }
 
@@ -83,8 +81,7 @@ static inline void
 fi_ibv_rdm_move_to_errcq(struct fi_ibv_rdm_tagged_request *request, ssize_t err)
 {
 	request->state.err = llabs(err);
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_errcq: ",
-				      request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("move_to_errcq: ", request, FI_LOG_DEBUG);
 	assert(request->context);
 	dlist_insert_tail(&request->queue_entry,
 			  &fi_ibv_rdm_comp_queue.request_errcq);
@@ -93,8 +90,7 @@ fi_ibv_rdm_move_to_errcq(struct fi_ibv_rdm_tagged_request *request, ssize_t err)
 static inline void
 fi_ibv_rdm_remove_from_errcq(struct fi_ibv_rdm_tagged_request *request)
 {
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_errcq: ",
-				      request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("remove_from_errcq: ", request, FI_LOG_DEBUG);
 	dlist_remove(&request->queue_entry);
 }
 
@@ -115,8 +111,8 @@ static inline void
 fi_ibv_rdm_tagged_move_to_unexpected_queue(
 		struct fi_ibv_rdm_tagged_request *request)
 {
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_unexpected_queue: ",
-				      request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("move_to_unexpected_queue: ", request,
+				FI_LOG_DEBUG);
 	dlist_insert_tail(&request->queue_entry,
 			  &fi_ibv_rdm_tagged_recv_unexp_queue);
 }
@@ -125,8 +121,8 @@ static inline void
 fi_ibv_rdm_tagged_remove_from_unexp_queue(
 		struct fi_ibv_rdm_tagged_request *request)
 {
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_unexpected_queue: ", request,
-				      FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("remove_from_unexpected_queue: ", request,
+				FI_LOG_DEBUG);
 	dlist_remove(&request->queue_entry);
 }
 
@@ -148,8 +144,7 @@ fi_ibv_rdm_tagged_move_to_posted_queue(
 		struct fi_ibv_rdm_tagged_request *request,
 		struct fi_ibv_rdm_ep *ep)
 {
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_posted_queue: ", request,
-				      FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("move_to_posted_queue: ", request, FI_LOG_DEBUG);
 	dlist_insert_tail(&request->queue_entry,
 			  &fi_ibv_rdm_tagged_recv_posted_queue);
 	ep->posted_recvs++;
@@ -160,8 +155,8 @@ fi_ibv_rdm_tagged_remove_from_posted_queue(
 		struct fi_ibv_rdm_tagged_request *request,
 		struct fi_ibv_rdm_ep *ep)
 {
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_posted_queue: ", request,
-				      FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("remove_from_posted_queue: ", request, 
+				FI_LOG_DEBUG);
 	dlist_remove(&request->queue_entry);
 	ep->posted_recvs--;
 }
@@ -182,8 +177,8 @@ fi_ibv_rdm_take_first_from_posted_queue()
 static inline void
 fi_ibv_rdm_move_to_postponed_queue(struct fi_ibv_rdm_tagged_request *request)
 {
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("move_to_postponed_queue: ", request,
-				      FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("move_to_postponed_queue: ", request, 
+				FI_LOG_DEBUG);
 	assert(request && request->minfo.conn);
 
 	struct fi_ibv_rdm_tagged_conn *conn = request->minfo.conn;
@@ -205,8 +200,8 @@ fi_ibv_rdm_move_to_postponed_queue(struct fi_ibv_rdm_tagged_request *request)
 static inline void
 fi_ibv_rdm_remove_from_postponed_queue(struct fi_ibv_rdm_tagged_request *request)
 {
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("remove_from_postponed_queue: ", request,
-				      FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("remove_from_postponed_queue: ", request,
+				FI_LOG_DEBUG);
 
 	struct fi_ibv_rdm_tagged_conn *conn = request->minfo.conn;
 	assert(conn);

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -207,7 +207,7 @@ void fi_ibv_rdm_tagged_print_request(char *buf,
 struct fi_ibv_rdm_buf_service_data {
 	volatile uint16_t status;
 	uint16_t seq_num;
-	int pkt_len;
+	int32_t pkt_len;
 };
 
 #define FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE	\
@@ -216,7 +216,7 @@ struct fi_ibv_rdm_buf_service_data {
 struct fi_ibv_rdm_buf {
 	struct fi_ibv_rdm_buf_service_data service_data;
 	struct fi_ibv_rdm_header header;
-	char payload[sizeof(void *)];
+	uint8_t payload;
 };
 
 struct fi_ibv_rdm_cm {

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -334,7 +334,7 @@ fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len,
 			FI_IBV_RDM_SET_PKTTYPE(sbuf->header.service_tag,
 					       FI_IBV_RDM_EAGER_PKT);
 			if ((len > 0) && (buf)) {
-				memcpy(sbuf->payload, buf, len);
+				memcpy(&sbuf->payload, buf, len);
 			}
 
 			FI_IBV_RDM_INC_SIG_POST_COUNTERS(conn, ep,
@@ -539,7 +539,7 @@ fi_ibv_rdm_process_recv(struct fi_ibv_rdm_ep *ep,
 	int pkt_type = FI_IBV_RDM_GET_PKTTYPE(rbuf->header.service_tag);
 
 	if (pkt_type == FI_IBV_RDM_RNDV_ACK_PKT) {
-		memcpy(&request, rbuf->payload, sizeof(request));
+		memcpy(&request, &rbuf->payload, sizeof(request));
 		assert(request);
 		VERBS_DBG(FI_LOG_EP_DATA,
 			"GOT RNDV ACK from conn %p, id %p\n", conn, request);

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -60,14 +60,14 @@ int fi_ibv_rdm_tagged_prepare_send_request(
 	int res =
 		FI_IBV_RDM_TAGGED_SENDS_OUTGOING_ARE_LIMITED(request->minfo.conn, ep);
 	if (res) {
-		FI_IBV_RDM_TAGGED_DBG_REQUEST
+		FI_IBV_RDM_DBG_REQUEST
 			("failed because SENDS_OUTGOING_ARE_LIMITED", request,
 			FI_LOG_DEBUG);
 		return !res;
 	}
 	res = PEND_SEND_IS_LIMITED(ep);
 	if (res) {
-		FI_IBV_RDM_TAGGED_DBG_REQUEST
+		FI_IBV_RDM_DBG_REQUEST
 			("failed because PEND_SEND_IS_LIMITED", request,
 			FI_LOG_DEBUG);
 		return !res;
@@ -111,7 +111,7 @@ static ssize_t fi_ibv_rdm_tagged_recvfrom(struct fid_ep *ep_fid, void *buf,
 	struct fi_ibv_rdm_tagged_request *request =
 		util_buf_alloc(fi_ibv_rdm_tagged_request_pool);
 	fi_ibv_rdm_tagged_zero_request(request);
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 	struct fi_ibv_rdm_tagged_conn *conn = (src_addr == FI_ADDR_UNSPEC)
 		? NULL : (struct fi_ibv_rdm_tagged_conn *) src_addr;
@@ -219,8 +219,7 @@ static ssize_t fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid,
 		struct fi_ibv_rdm_tagged_request *request =
 			util_buf_alloc(fi_ibv_rdm_tagged_request_pool);
 		fi_ibv_rdm_tagged_zero_request(request);
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ", request,
-			FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 		struct fi_ibv_rdm_tagged_peek_data peek_data = {
 			.minfo = {
@@ -241,8 +240,7 @@ static ssize_t fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid,
 		struct fi_ibv_rdm_tagged_request *request =
 			util_buf_alloc(fi_ibv_rdm_tagged_request_pool);
 		fi_ibv_rdm_tagged_zero_request(request);
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ", request,
-			FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 		assert(msg->iov_count == 1);
 
@@ -365,7 +363,7 @@ fi_ibv_rdm_tagged_send_common(struct fi_ibv_rdm_tagged_send_start_data* sdata)
 {
 	struct fi_ibv_rdm_tagged_request *request =
 		util_buf_alloc(fi_ibv_rdm_tagged_request_pool);
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 	/* Initial state */
 	request->state.eager = FI_IBV_STATE_EAGER_BEGIN;
@@ -573,8 +571,8 @@ fi_ibv_rdm_process_recv(struct fi_ibv_rdm_ep *ep,
 			request = util_buf_alloc(fi_ibv_rdm_tagged_request_pool);
 			fi_ibv_rdm_tagged_zero_request(request);
 
-			FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ",
-				request, FI_LOG_DEBUG);
+			FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request,
+						FI_LOG_DEBUG);
 		}
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -143,8 +143,8 @@ static ssize_t fi_ibv_rdm_tagged_recvfrom(struct fid_ep *ep_fid, void *buf,
 			conn, tag, (int)len, buf, context,
 			ep->posted_recvs);
 
-		if (ret || request->state.eager ==
-		    FI_IBV_STATE_EAGER_RECV_WAIT4PKT) {
+		if (ret || request->state.err ||
+		    request->state.eager == FI_IBV_STATE_EAGER_RECV_WAIT4PKT) {
 			goto out;
 		}
 	}

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -58,22 +58,22 @@ enum fi_ibv_rdm_tagged_hndl_req_log_state {
 	hndl_req_log_state_out = 10000
 };
 
-#define FI_IBV_RDM_TAGGED_HANDLER_LOG_IN()                                  \
-enum fi_ibv_rdm_tagged_hndl_req_log_state state = hndl_req_log_state_in;    \
-do {                                                                        \
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("\t> IN\t< ", request, FI_LOG_DEBUG); \
+#define FI_IBV_RDM_TAGGED_HANDLER_LOG_IN()					\
+enum fi_ibv_rdm_tagged_hndl_req_log_state state = hndl_req_log_state_in;	\
+do {										\
+	FI_IBV_RDM_DBG_REQUEST("\t> IN\t< ", request, FI_LOG_DEBUG);		\
 } while(0)
 
-#define FI_IBV_RDM_TAGGED_HANDLER_LOG() do {                            \
-	state++;                                                        \
-	char prefix[128];                                               \
-	snprintf(prefix, 128, "\t> %d\t< ", state);                     \
-	FI_IBV_RDM_TAGGED_DBG_REQUEST(prefix, request, FI_LOG_DEBUG);   \
+#define FI_IBV_RDM_TAGGED_HANDLER_LOG() do {					\
+	state++;								\
+	char prefix[128];							\
+	snprintf(prefix, 128, "\t> %d\t< ", state);				\
+	FI_IBV_RDM_DBG_REQUEST(prefix, request, FI_LOG_DEBUG);			\
 } while(0)
 
-#define FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT() do {                              \
-	assert(state < hndl_req_log_state_out);                               \
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("\t> OUT\t< ", request, FI_LOG_DEBUG);  \
+#define FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT() do {				\
+	assert(state < hndl_req_log_state_out);					\
+	FI_IBV_RDM_DBG_REQUEST("\t> OUT\t< ", request, FI_LOG_DEBUG);		\
 } while(0)
 
 #else // ENABLE_DEBUG
@@ -227,8 +227,7 @@ fi_ibv_rdm_tagged_eager_send_lc(struct fi_ibv_rdm_tagged_request *request,
 	}
 
 	if (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
-					      FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 	} else {
 		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
@@ -351,8 +350,7 @@ fi_ibv_rdm_tagged_rndv_rts_lc(struct fi_ibv_rdm_tagged_request *request,
 	if (request->state.eager == FI_IBV_STATE_EAGER_SEND_WAIT4LC) {
 		request->state.eager = FI_IBV_STATE_EAGER_SEND_END;
 	} else { /* (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) */
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
-					      FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 	}
 
@@ -431,8 +429,8 @@ fi_ibv_rdm_copy_unexp_request(struct fi_ibv_rdm_tagged_request *request,
 
 	VERBS_DBG(FI_LOG_EP_DATA, "found req: len = %d, eager_state = %s, rndv_state = %s \n",
 		unexp->len,
-		fi_ibv_rdm_tagged_req_eager_state_to_str(unexp->state.eager),
-		fi_ibv_rdm_tagged_req_rndv_state_to_str(unexp->state.rndv));
+		fi_ibv_rdm_req_eager_state_to_str(unexp->state.eager),
+		fi_ibv_rdm_req_rndv_state_to_str(unexp->state.rndv));
 
 	if (request->state.rndv != FI_IBV_STATE_RNDV_NOT_USED) {
 		assert(request->state.rndv == FI_IBV_STATE_RNDV_RECV_WAIT4RES);
@@ -493,8 +491,7 @@ fi_ibv_rdm_tagged_init_recv_request(struct fi_ibv_rdm_tagged_request *request,
 
 		FI_IBV_RDM_TAGGED_HANDLER_LOG();
 
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", found_request,
-					      FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", found_request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, found_request);
 
 		if (ret == FI_SUCCESS &&
@@ -656,8 +653,8 @@ fi_ibv_rdm_tagged_init_unexp_recv_request(
 		request->state.rndv = FI_IBV_STATE_RNDV_RECV_WAIT4RES;
 		break;
 	case FI_IBV_RDM_RNDV_ACK_PKT:
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("Unexpected RNDV ack!!!",
-					      request, FI_LOG_INFO);
+		FI_IBV_RDM_DBG_REQUEST("Unexpected RNDV ack!!!", request,
+					FI_LOG_INFO);
 	default:
 		VERBS_INFO(FI_LOG_EP_DATA,
 			"Got unknown unexpected pkt: %" PRIu64 "\n",
@@ -827,7 +824,7 @@ fi_ibv_rdm_tagged_eager_recv_discard(struct fi_ibv_rdm_tagged_request *request,
 		request->unexp_rbuf = NULL;
 	}
 
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 	util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 
 	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
@@ -1015,8 +1012,7 @@ fi_ibv_rdm_tagged_rndv_recv_ack_lc(struct fi_ibv_rdm_tagged_request *request,
 	FI_IBV_RDM_TAGGED_DEC_SEND_COUNTERS(request->minfo.conn, p->ep);
 
 	if (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
-					      FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 	} else {
 		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
@@ -1205,8 +1201,7 @@ fi_ibv_rdm_rma_inject_lc(struct fi_ibv_rdm_tagged_request *request, void *data)
 
 	FI_IBV_RDM_TAGGED_HANDLER_LOG();
 
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
-				      FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 	util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 
 	FI_IBV_RDM_TAGGED_HANDLER_LOG_OUT();
@@ -1238,8 +1233,7 @@ fi_ibv_rdm_rma_buffered_lc(struct fi_ibv_rdm_tagged_request *request,
 		fi_ibv_rdm_move_to_cq(request);
 		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
 	} else { /* FI_IBV_STATE_EAGER_READY_TO_FREE */
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
-					      FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 	}
 
@@ -1281,8 +1275,8 @@ fi_ibv_rdm_tagged_err_hndl(struct fi_ibv_rdm_tagged_request *request,
 {
 	VERBS_INFO(FI_LOG_EP_DATA,
 		"\t> IN\t< eager_state = %s, rndv_state = %s, len = %lu\n",
-		fi_ibv_rdm_tagged_req_eager_state_to_str(request->state.eager),
-		fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.rndv),
+		fi_ibv_rdm_req_eager_state_to_str(request->state.eager),
+		fi_ibv_rdm_req_rndv_state_to_str(request->state.rndv),
 		request->len);
 
 	assert(0);
@@ -1444,12 +1438,10 @@ fi_ibv_rdm_tagged_req_hndl(struct fi_ibv_rdm_tagged_request * request,
 			   enum fi_ibv_rdm_tagged_request_event event, void *data)
 {
 	VERBS_DBG(FI_LOG_EP_DATA, "\t%p, eager_state = %s, rndv_state = %s, event = %s\n",
-		     request,
-		     fi_ibv_rdm_tagged_req_eager_state_to_str
-		     (request->state.eager),
-		     fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.
-							     rndv),
-		     fi_ibv_rdm_tagged_req_event_to_str(event));
+		  request,
+		  fi_ibv_rdm_req_eager_state_to_str(request->state.eager),
+		  fi_ibv_rdm_req_rndv_state_to_str(request->state.rndv),
+		  fi_ibv_rdm_event_to_str(event));
 	assert(fi_ibv_rdm_tagged_hndl_arr[request->state.eager]
 	       [request->state.rndv]
 	       [event]);
@@ -1459,7 +1451,7 @@ fi_ibv_rdm_tagged_req_hndl(struct fi_ibv_rdm_tagged_request * request,
 	    [event] (request, data);
 }
 
-char *fi_ibv_rdm_tagged_req_eager_state_to_str(
+char *fi_ibv_rdm_req_eager_state_to_str(
 		enum fi_ibv_rdm_tagged_request_eager_state state)
 {
 	switch (state) {
@@ -1507,7 +1499,7 @@ char *fi_ibv_rdm_tagged_req_eager_state_to_str(
 	}
 }
 
-char *fi_ibv_rdm_tagged_req_rndv_state_to_str(
+char *fi_ibv_rdm_req_rndv_state_to_str(
 		enum fi_ibv_rdm_tagged_request_rndv_state state)
 {
 	switch (state) {
@@ -1545,7 +1537,7 @@ char *fi_ibv_rdm_tagged_req_rndv_state_to_str(
 	}
 }
 
-char *fi_ibv_rdm_tagged_req_event_to_str(
+char *fi_ibv_rdm_event_to_str(
 		enum fi_ibv_rdm_tagged_request_event event)
 {
 	switch (event) {

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
@@ -64,7 +64,7 @@ enum fi_ibv_rdm_tagged_request_eager_state {
 	FI_IBV_STATE_EAGER_COUNT           // must be last
 };
 
-char *fi_ibv_rdm_tagged_req_eager_state_to_str(
+char *fi_ibv_rdm_req_eager_state_to_str(
 		enum fi_ibv_rdm_tagged_request_eager_state state);
 
 enum fi_ibv_rdm_tagged_request_rndv_state {
@@ -87,7 +87,7 @@ enum fi_ibv_rdm_tagged_request_rndv_state {
 	FI_IBV_STATE_RNDV_COUNT            // must be last
 };
 
-char *fi_ibv_rdm_tagged_req_rndv_state_to_str(
+char *fi_ibv_rdm_req_rndv_state_to_str(
 		enum fi_ibv_rdm_tagged_request_rndv_state state);
 
 enum fi_ibv_rdm_tagged_request_event {
@@ -108,8 +108,7 @@ enum fi_ibv_rdm_tagged_request_event {
 	FI_IBV_EVENT_COUNT                 // must be last
 };
 
-char *fi_ibv_rdm_tagged_req_event_to_str(
-		enum fi_ibv_rdm_tagged_request_event event);
+char *fi_ibv_rdm_event_to_str(enum fi_ibv_rdm_tagged_request_event event);
 
 // Send service data types
 

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -226,7 +226,7 @@ void fi_ibv_rdm_clean_queues()
 			util_buf_release(fi_ibv_rdm_tagged_extra_buffers_pool,
 				request->unexp_rbuf);
 		}
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 	}
 
@@ -235,7 +235,7 @@ void fi_ibv_rdm_clean_queues()
 			util_buf_release(fi_ibv_rdm_tagged_extra_buffers_pool,
 				request->unexp_rbuf);
 		}
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 	}
 
@@ -244,7 +244,7 @@ void fi_ibv_rdm_clean_queues()
 			util_buf_release(fi_ibv_rdm_tagged_extra_buffers_pool,
 				request->unexp_rbuf);
 		}
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 	}
 
@@ -253,12 +253,12 @@ void fi_ibv_rdm_clean_queues()
 			util_buf_release(fi_ibv_rdm_tagged_extra_buffers_pool,
 				request->unexp_rbuf);
 		}
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 	}
 
 	while ((request = fi_ibv_rdm_take_first_from_errcq())) {
-		FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
+		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 	}
 }

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -115,14 +115,15 @@ do {                                                                        \
     const size_t max_str_len = 1024;                                        \
     char str[max_str_len];                                                  \
     snprintf(str, max_str_len,                                              \
-            "%s request: %p, eager_state: %s, rndv_state: %s, tag: 0x%lx, len: %lu, rest: %lu, context: %p, connection: %p\n", \
+            "%s request: %p, eager_state: %s, rndv_state: %s, err_state: %ld, tag: 0x%lx, len: %lu, rest: %lu, context: %p, connection: %p\n", \
             prefix,                                                         \
             request,                                                        \
             fi_ibv_rdm_tagged_req_eager_state_to_str(request->state.eager), \
             fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.rndv),   \
+	    request->state.err,						    \
             request->minfo.tag,						    \
             request->len,                                                   \
-	    request->rest_len,					    \
+	    request->rest_len,						    \
             request->context,                                               \
             request->minfo.conn);					    \
                                                                             \

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -110,40 +110,42 @@ struct fi_ibv_msg_ep;
 
 #if ENABLE_DEBUG
 
-#define FI_IBV_RDM_TAGGED_DBG_REQUEST(prefix, request, level)               \
-do {                                                                        \
-    const size_t max_str_len = 1024;                                        \
-    char str[max_str_len];                                                  \
-    snprintf(str, max_str_len,                                              \
-            "%s request: %p, eager_state: %s, rndv_state: %s, err_state: %ld, tag: 0x%lx, len: %lu, rest: %lu, context: %p, connection: %p\n", \
-            prefix,                                                         \
-            request,                                                        \
-            fi_ibv_rdm_tagged_req_eager_state_to_str(request->state.eager), \
-            fi_ibv_rdm_tagged_req_rndv_state_to_str(request->state.rndv),   \
-	    request->state.err,						    \
-            request->minfo.tag,						    \
-            request->len,                                                   \
-	    request->rest_len,						    \
-            request->context,                                               \
-            request->minfo.conn);					    \
-                                                                            \
-    switch (level)                                                          \
-    {                                                                       \
-        case FI_LOG_WARN:                                                   \
-        case FI_LOG_TRACE:                                                  \
-        case FI_LOG_INFO:                                                   \
-            VERBS_INFO(FI_LOG_EP_DATA, "%s", str);                          \
-            break;                                                          \
-        case FI_LOG_DEBUG:                                                  \
-        default:                                                            \
-            VERBS_DBG(FI_LOG_EP_DATA, "%s", str);                           \
-            break;                                                          \
-    }                                                                       \
+#define FI_IBV_RDM_DBG_REQUEST(prefix, request, level)				\
+do {										\
+	const size_t max_str_len = 1024;					\
+	char str[max_str_len];							\
+	snprintf(str, max_str_len,						\
+		"%s request: %p, eager_state: %s, rndv_state: %s,"		\
+		" err_state: %ld, tag: 0x%lx, len: %lu, rest: %lu,"		\
+		"context: %p, connection: %p\n",				\
+		prefix,								\
+		request,							\
+		fi_ibv_rdm_req_eager_state_to_str(request->state.eager),	\
+		fi_ibv_rdm_req_rndv_state_to_str(request->state.rndv),		\
+		request->state.err,						\
+		request->minfo.tag,						\
+		request->len,							\
+		request->rest_len,						\
+		request->context,						\
+		request->minfo.conn);						\
+										\
+	switch (level)								\
+	{									\
+	case FI_LOG_WARN:							\
+	case FI_LOG_TRACE:							\
+	case FI_LOG_INFO:							\
+		VERBS_INFO(FI_LOG_EP_DATA, "%s", str);				\
+		break;								\
+	case FI_LOG_DEBUG:							\
+	default:								\
+		VERBS_DBG(FI_LOG_EP_DATA, "%s", str);				\
+		break;								\
+	}									\
 } while (0);
 
 #else                           // ENABLE_DEBUG
 
-#define FI_IBV_RDM_TAGGED_DBG_REQUEST(prefix, request, level)
+#define FI_IBV_RDM_DBG_REQUEST(prefix, request, level)
 
 #endif                          // ENABLE_DEBUG
 

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -293,7 +293,7 @@ fi_ibv_rdm_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
 
 	struct fi_ibv_rdm_tagged_request *request = 
 		util_buf_alloc(fi_ibv_rdm_tagged_request_pool);
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 	/* Initial state */
 	request->state.eager = FI_IBV_STATE_EAGER_BEGIN;
@@ -389,7 +389,7 @@ fi_ibv_rdm_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	struct fi_ibv_rdm_tagged_request *request = 
 		util_buf_alloc(fi_ibv_rdm_tagged_request_pool);
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 	/* Initial state */
 	request->state.eager = FI_IBV_STATE_EAGER_BEGIN;
@@ -485,7 +485,7 @@ static ssize_t fi_ibv_rdm_ep_rma_inject_write(struct fid_ep *ep,
 
 	request = util_buf_alloc(fi_ibv_rdm_tagged_request_pool);
 
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 	/* Initial state */
 	request->state.eager = FI_IBV_STATE_EAGER_RMA_INJECT;
@@ -517,8 +517,7 @@ static ssize_t fi_ibv_rdm_ep_rma_inject_write(struct fid_ep *ep,
 		break;
 	}
 
-	FI_IBV_RDM_TAGGED_DBG_REQUEST("to_pool: ", request,
-				      FI_LOG_DEBUG);
+	FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 	util_buf_release(fi_ibv_rdm_tagged_request_pool, request);
 
 	fi_ibv_rdm_tagged_poll(ep_rdm);


### PR DESCRIPTION
 - Fix truncated error handling in rndv protocol (tagged send/recv)
 - Fix inconsistent max_inline check in tagged inject
 - Remove types with variable size from fi_ibv_rdm_buf and fi_ibv_rdm_buf_service_data structures
 - Other minor refactoring

@a-ilango @shefty 