### PR TITLE
prov/psm,psm2: complete the memory corruption fix for fi_trywait()

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -558,6 +558,8 @@ int	psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			 struct fid_domain **domain, void *context);
 int	psmx_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		       struct fid_wait **waitset);
+int	psmx_wait_trywait(struct fid_fabric *fabric, struct fid **fids,
+			  int count);
 int	psmx_ep_open(struct fid_domain *domain, struct fi_info *info,
 		     struct fid_ep **ep, void *context);
 int	psmx_stx_ctx(struct fid_domain *domain, struct fi_tx_attr *attr,

--- a/prov/psm/src/psmx_fabric.c
+++ b/prov/psm/src/psmx_fabric.c
@@ -91,7 +91,7 @@ static struct fi_ops_fabric psmx_fabric_ops = {
 	.passive_ep = fi_no_passive_ep,
 	.eq_open = ofi_eq_create,
 	.wait_open = psmx_wait_open,
-	.trywait = ofi_trywait
+	.trywait = psmx_wait_trywait,
 };
 
 static struct fi_fabric_attr psmx_fabric_attr = {

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -689,7 +689,8 @@ int	psmx2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		       struct fid_cntr **cntr, void *context);
 int	psmx2_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 			struct fid_wait **waitset);
-int psmx2_wait_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
+int	psmx2_wait_trywait(struct fid_fabric *fabric, struct fid **fids,
+			   int count);
 
 static inline void psmx2_fabric_acquire(struct psmx2_fid_fabric *fabric)
 {

--- a/prov/psm2/src/psmx2_wait.c
+++ b/prov/psm2/src/psmx2_wait.c
@@ -164,7 +164,7 @@ int psmx2_wait_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
 				wait = cq_priv->wait;
 				break;
 			case FI_CLASS_EQ:
-				eq = container_of(fids[i], struct util_eq, eq_fid.fid)
+				eq = container_of(fids[i], struct util_eq, eq_fid.fid);
 				wait = eq->wait;
 				break;
 			case FI_CLASS_CNTR:


### PR DESCRIPTION
Fix a compilation error in commit e74a6950 "PSM2: fix memory corruption
in fi_trywait() for FI_CLASS_CQ". Apply simiar changes to the psm
provider.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>