### PR TITLE
prov/sockets: Remove fd from pollsets when disconnected

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -1107,6 +1107,7 @@ void sock_pe_add_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *ctx);
 void sock_pe_add_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *ctx);
 void sock_pe_signal(struct sock_pe *pe);
 void sock_pe_poll_add(struct sock_pe *pe, int fd);
+void sock_pe_poll_del(struct sock_pe *pe, int fd);
 int sock_pe_progress_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx);
 int sock_pe_progress_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx);
 void sock_pe_remove_tx_ctx(struct sock_tx_ctx *tx_ctx);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -682,6 +682,9 @@ static int sock_ep_close(struct fid *fid)
 		sock_rx_ctx_free(sock_ep->attr->rx_array[0]);
 	}
 
+	idm_reset(&sock_ep->attr->conn_idm);
+	idm_reset(&sock_ep->attr->av_idm);
+
 	free(sock_ep->attr->tx_array);
 	free(sock_ep->attr->rx_array);
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1269,7 +1269,7 @@ char *sock_get_fabric_name(struct sockaddr_in *src_addr)
 		if (ofi_equals_ipaddr((struct sockaddr_in *)ifa->ifa_addr, src_addr)) {
 			host_addr = (struct sockaddr_in *)ifa->ifa_addr;
 			net_addr = (struct sockaddr_in *)ifa->ifa_netmask;
-			// set fabric name to the network_adress in the format of a.b.c.d/e
+			/* set fabric name to the network_adress in the format of a.b.c.d/e */
 			net_in_addr.s_addr = (uint32_t)((uint32_t) host_addr->sin_addr.s_addr &
 						(uint32_t) net_addr->sin_addr.s_addr);
 			inet_ntop(host_addr->sin_family, (void *)&(net_in_addr), netbuf,
@@ -1278,11 +1278,11 @@ char *sock_get_fabric_name(struct sockaddr_in *src_addr)
 			snprintf(netbuf + strlen(netbuf), sizeof(netbuf) - strlen(netbuf),
 				  "%s%d", "/", prefix_len);
 			fabric_name = strdup(netbuf);
-			return fabric_name;
+			goto out;
 		}
 	}
+out:
 	freeifaddrs(ifaddrs);
-
 	return fabric_name;
 }
 
@@ -1302,11 +1302,11 @@ char *sock_get_domain_name(struct sockaddr_in *src_addr)
 			continue;
 		if (ofi_equals_ipaddr((struct sockaddr_in *)ifa->ifa_addr, src_addr)) {
 			domain_name = strdup(ifa->ifa_name);
-			return domain_name;
+			goto out;
 		}
 	}
+out:
 	freeifaddrs(ifaddrs);
-
 	return domain_name;
 }
 #else


### PR DESCRIPTION
- If the TCP connection is disconnected, the associated fd is removed
  from the epoll set of progress engine and EP connection map. If the
  disconnect was identified in between a data transfer, it is reported
  to the app as an I/O error
- Fix mem leaks from getifaddrs

Signed-off-by: Jithin Jose <jithin.jose@intel.com>