### PR TITLE
prov/psm2: Fix race condition in psmx2_mr_get()

### DIFF
--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -36,13 +36,16 @@ struct psmx2_fid_mr *psmx2_mr_get(struct psmx2_fid_domain *domain,
 				  uint64_t key)
 {
 	RbtIterator it;
-	struct psmx2_fid_mr *mr;
+	struct psmx2_fid_mr *mr = NULL;
 
+	fastlock_acquire(&domain->mr_lock);
 	it = rbtFind(domain->mr_map, (void *)key);
 	if (!it)
-		return NULL;
+		goto exit;
 
 	rbtKeyValue(domain->mr_map, it, (void **)&key, (void **)&mr);
+exit:
+	fastlock_release(&domain->mr_lock);
 	return mr;
 }
 


### PR DESCRIPTION
psmx2_mr_get() must hold the lock while iterating over the RB tree.

I've just hit a bug where new MR entries were added to the RB tree
while another thread was concurrently iterating over the tree.
This race condition leads to the failure of some completion events
(error -FI_EINVAL).

Signed-off-by: Sean Hefty sean.hefty@intel.com