### PR TITLE
prov/psm,psm2: Fix a bug introduced by commit 74e9037

### DIFF
--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -149,9 +149,9 @@ static int psmx_av_insert(struct fid_av *av, const void *addr, size_t count,
 	fi_addr_t *result = NULL;
 	struct psmx_epaddr_context *epaddr_context;
 
-	if (count && (!addr || !fi_addr)) {
+	if (count && !addr) {
 		FI_INFO(&psmx_prov, FI_LOG_AV,
-			"NULL address array: addr=%p fi_addr=%p.\n", addr, fi_addr);
+			"the input address array is NULL.\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -241,9 +241,9 @@ static int psmx2_av_insert(struct fid_av *av, const void *addr,
 	int error_count;
 	int i;
 
-	if (count && (!addr || !fi_addr)) {
+	if (count && !addr) {
 		FI_INFO(&psmx2_prov, FI_LOG_AV,
-			"NULL address array: addr=%p fi_addr=%p.\n", addr, fi_addr);
+			"the input address array is NULL.\n");
 		return -FI_EINVAL;
 	}
 


### PR DESCRIPTION
The commit "prov/psm,psm2: prevent segfault in fi_av_insert due to
invalid input" incorrectly returns error when the output address
array is NULL, which should be allowed.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>