### PR TITLE
prov/gni: Test EQ interface, implement fi_eq_sread

### DIFF
--- a/prov/gni/include/gnix_eq.h
+++ b/prov/gni/include/gnix_eq.h
@@ -46,6 +46,11 @@ extern "C" {
 
 #define GNIX_EQ_DEFAULT_SIZE 256
 
+ssize_t _gnix_eq_write_error(struct fid_eq *eq, fid_t fid,
+			     void *context, uint64_t index, int err,
+			     int prov_errno, void *err_data,
+			     size_t err_size);
+
 /*
  * Stores events inside of the event queue.
  *


### PR DESCRIPTION
-Add basic tests for add/removal of EQ events
-Add a couple fixes for EQ API found in testing.
-Do simple fastpoll fi_eq_sread implementation.

Fixes ofi-cray/libfabric-cray#784.

upstream merge of ofi-cray/libfabric-cray#874
@sungeunchoi 

Signed-off-by: Zach Tiffany <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@164fe5e5a9bb01e04250065d7dfd160812ef5483)