### PR TITLE
prov/sockets: Add error-checks in fi_getname

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -533,7 +533,7 @@ struct sock_ep_attr {
 
 	uint64_t peer_fid;
 	uint16_t key;
-	int is_disabled;
+	int is_enabled;
 	struct sock_cm_entry cm;
 	struct sock_conn_listener listener;
 	struct dlist_entry conn_list;
@@ -560,6 +560,7 @@ struct sock_pep {
 	struct sockaddr_in src_addr;
 	struct fi_info info;
 	struct sock_eq *eq;
+	int name_set;
 };
 
 struct sock_rx_entry {

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -971,7 +971,7 @@ int sock_ep_enable(struct fid_ep *ep)
 	if (sock_ep->attr->ep_type != FI_EP_MSG &&
 	    !sock_ep->attr->listener.listener_thread && sock_conn_listen(sock_ep->attr))
 		SOCK_LOG_ERROR("cannot start connection thread\n");
-	sock_ep->attr->is_disabled = 0;
+	sock_ep->attr->is_enabled = 1;
 	return 0;
 }
 
@@ -1001,7 +1001,7 @@ int sock_ep_disable(struct fid_ep *ep)
 		if (sock_ep->attr->rx_array[i])
 			sock_ep->attr->rx_array[i]->enabled = 0;
 	}
-	sock_ep->attr->is_disabled = 1;
+	sock_ep->attr->is_enabled = 0;
 	return 0;
 }
 

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -251,10 +251,14 @@ static int sock_ep_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 	case FI_CLASS_EP:
 	case FI_CLASS_SEP:
 		sock_ep = container_of(fid, struct sock_ep, ep.fid);
+		if (sock_ep->attr->is_enabled == 0)
+			return -FI_EOPBADSTATE;
 		memcpy(addr, sock_ep->attr->src_addr, len);
 		break;
 	case FI_CLASS_PEP:
 		sock_pep = container_of(fid, struct sock_pep, pep.fid);
+		if (!sock_pep->name_set)
+			return -FI_EOPBADSTATE;
 		memcpy(addr, &sock_pep->src_addr, len);
 		break;
 	default:
@@ -332,6 +336,7 @@ static int sock_pep_create_listener(struct sock_pep *pep)
 		return -errno;
 	}
 
+	pep->name_set = 1;
 	SOCK_LOG_DBG("Listener thread bound to %s:%d\n",
 		     sa_ip, ntohs(pep->src_addr.sin_port));
 	return 0;


### PR DESCRIPTION
- Added checks in fi_getname to see if the endpoint is
  enabled (fi_enable/fi_listen or fi_setname).
  (Please see #2188)

Couple of tests in fabtests were failing because of missing fi_enable. Fabtests PR 540 fixes these.

@j-xiong @hppritcha @goodell @a-ilango 