### PR TITLE
prov/gni: Add a few more valgrind suppressions

### DIFF
--- a/prov/gni/contrib/gnitest.supp
+++ b/prov/gni/contrib/gnitest.supp
@@ -155,14 +155,23 @@
 }
 
 #
+# This is from the av multithreaded tests that pass void * args via pthread-create
+#
+{
+   atomic_cas_weak_continuous_remove
+   Memcheck:Cond
+   fun:atomic_cas_weak
+   fun:continuous_remove
+   fun:start_thread
+}
+
+#
 # This is from reading kernel initialized memory
 #
 {
    gnix_notifier_get_event
    Memcheck:Addr8
    fun:_gnix_notifier_get_event
-   fun:__clear_notifier_events.part.5
-   fun:__clear_notifier_events
    ...
 }
 


### PR DESCRIPTION
- Make clear_notifier_event valgrind suppression more generic
- Add suppression for atomic_cas_weak call

upstream merge of ofi-cray/libfabric-cray#879
@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@2e9602564aa3ac90a275c9a51176c03ddf2cd5f5)