### PR TITLE
[RFC] Add communication scope to domain attribute.

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -209,6 +209,12 @@ enum fi_resource_mgmt {
 #define FI_ORDER_STRICT		0x1FF
 #define FI_ORDER_DATA		(1 << 16)
 
+/*
+ * Allow for growing communication scope as needed.
+ */
+#define FI_COMM_LOCAL		(1 << 0)
+#define FI_COMM_REMOTE		(1 << 1)
+
 enum fi_ep_type {
 	FI_EP_UNSPEC,
 	FI_EP_MSG,
@@ -300,6 +306,7 @@ struct fi_domain_attr {
 	size_t			max_ep_rx_ctx;
 	size_t			max_ep_stx_ctx;
 	size_t			max_ep_srx_ctx;
+	uint64_t		comm_scope;
 };
 
 struct fi_fabric_attr {

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -126,6 +126,7 @@ struct fi_domain_attr {
 	size_t                max_ep_rx_ctx;
 	size_t                max_ep_stx_ctx;
 	size_t                max_ep_srx_ctx;
+	uint64_t              comm_scope;
 };
 ```
 
@@ -490,6 +491,22 @@ shared transmit context.
 
 The maximum number of endpoints that may be associated with a
 shared receive context.
+
+## Communication Scope (comm_scope)
+
+Specifies the scope of the communication that will be used with this domain.
+Communication scope is determined using a set of bits. Each set bit indicates
+that a specific form of communication is required.
+
+*FI_COMM_LOCAL*
+: Indicates that local communication is required.
+
+*FI_COMM_REMOTE*
+: Indicates that remote communication is required.
+
+If no scope is provided in the attribute or no attribute is given, then the
+provider may choose to support whichever scope results in minimal
+performance impact.
 
 # RETURN VALUE
 


### PR DESCRIPTION
Allow the application to provide the type of communication it requires
as a hint. This implementation does not use extra bits that may
otherwise be used by the capabilities or modes. By providing flags
specific to the domain attribute, this allows more flexibility if it is
determined that FI_COMM_LOCAL and FI_COMM_REMOTE do not offer the
granularity required.

This will affect both the API and the ABI.

This is a possible solution for issue #1975.

Signed-off-by: Ben Turrubiates bturrubi@cisco.com
