### PR TITLE
prov/gni: add XPMEM on-node transfer method

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -41,6 +41,7 @@ _gni_files = \
 	prov/gni/src/gnix_util.c \
 	prov/gni/src/gnix_vc.c \
 	prov/gni/src/gnix_vector.c \
+	prov/gni/src/gnix_xpmem.c \
 	prov/gni/src/gnix_wait.c
 
 _gni_headers = \
@@ -74,6 +75,7 @@ _gni_headers = \
 	prov/gni/include/gnix_util.h \
 	prov/gni/include/gnix_vc.h \
 	prov/gni/include/gnix_vector.h \
+	prov/gni/include/gnix_xpmem.h \
 	prov/gni/include/gnix_wait.h
 
 if HAVE_CRITERION
@@ -116,7 +118,7 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/common.c
 
 prov_gni_test_gnitest_LDFLAGS = $(CRAY_PMI_LIBS) $(gnitest_LDFLAGS) -static
-prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(CRAY_PMI_CFLAGS) $(gnitest_CPPFLAGS)
+prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(CRAY_PMI_CFLAGS) $(CRAY_XPMEM_CFLAGS) $(gnitest_CPPFLAGS)
 prov_gni_test_gnitest_LDADD =  $(gnitest_LIBS) $(linkback)
 endif HAVE_CRITERION
 

--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -20,6 +20,12 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
 	gnitest_LDFLAGS=
         gnitest_LIBS=
 
+
+        AC_ARG_ENABLE([xpmem],
+                      [AS_HELP_STRING([--enable-xpmem],
+                                      [Enable xpmem (gni provider) @<:@default=yes@:>@])],
+                      )
+
         AS_IF([test x"$enable_gni" != x"no"],
                [FI_PKG_CHECK_MODULES([CRAY_GNI_HEADERS], [cray-gni-headers],
                                  [gni_header_happy=1
@@ -54,6 +60,20 @@ AC_DEFUN([FI_GNI_CONFIGURE],[
                                   gni_LDFLAGS="$CRAY_UDREG_LIBS $gni_LDFLAGS"
                                  ],
                                  [udreg_lib_happy=0])
+               AS_IF([test x"$enable_xpmem" != x"no"],
+                     [FI_PKG_CHECK_MODULES([CRAY_XPMEM], [cray-xpmem],
+                                 [AC_DEFINE_UNQUOTED([HAVE_XPMEM], [1], [Define to 1 if xpmem available])
+                                  gni_CPPFLAGS="$CRAY_XPMEM_CFLAGS $gni_CPPFLAGS"
+                                  gni_LDFLAGS="$CRAY_XPMEM_LIBS $gni_LDFLAGS"
+                                 ],
+                                 [])
+                      ],
+                      [AC_DEFINE_UNQUOTED([HAVE_XPMEM], [0], [Define to 1 if xpmem available])
+                      ])
+
+               gni_path_to_gni_pub=${CRAY_GNI_HEADERS_CFLAGS:2}
+dnl looks like we need to get rid of some white space
+               gni_path_to_gni_pub=${gni_path_to_gni_pub%?}/gni_pub.h
                gni_path_to_gni_pub=${CRAY_GNI_HEADERS_CFLAGS:2}
 dnl looks like we need to get rid of some white space
                gni_path_to_gni_pub=${gni_path_to_gni_pub%?}/gni_pub.h

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -435,6 +435,7 @@ struct gnix_fid_ep {
 	int (*progress_fn)(struct gnix_fid_ep *, enum gnix_progress_type);
 	/* RX specific progress fn */
 	int (*rx_progress_fn)(struct gnix_fid_ep *, gni_return_t *rc);
+	struct gnix_xpmem_handle *xpmem_hndl;
 	bool tx_enabled;
 	bool rx_enabled;
 	bool requires_lock;

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -45,6 +45,7 @@ extern "C" {
 #include "gnix.h"
 #include "gnix_bitmap.h"
 #include "gnix_av.h"
+#include "gnix_xpmem.h"
 
 /*
  * mode bits
@@ -55,6 +56,7 @@ extern "C" {
 #define GNIX_VC_MODE_PENDING_MSGS	(1U << 3)
 #define GNIX_VC_MODE_PEER_CONNECTED	(1U << 4)
 #define GNIX_VC_MODE_IN_TABLE		(1U << 5)
+#define GNIX_VC_MODE_XPMEM		(1U << 6)
 
 /* VC flags */
 #define GNIX_VC_FLAG_RX_SCHEDULED	0
@@ -144,6 +146,7 @@ struct gnix_vc {
 	int modes;
 	gnix_bitmap_t flags; /* We're missing regular bit ops */
 	gni_mem_handle_t peer_irq_mem_hndl;
+	xpmem_apid_t peer_apid;
 	uint64_t peer_caps;
 };
 

--- a/prov/gni/include/gnix_xpmem.h
+++ b/prov/gni/include/gnix_xpmem.h
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2016      Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef GNIX_XPMEM_H_
+#define GNIX_XPMEM_H_
+
+#include "gnix.h"
+#if HAVE_XPMEM
+#include <xpmem.h>
+#else
+typedef int64_t xpmem_apid_t;
+typedef int64_t xpmem_segid_t;
+#endif
+
+struct gnix_xpmem_handle {
+	struct gnix_reference ref_cnt;
+	struct gnix_hashtable *apid_ht;
+	fastlock_t lock;
+};
+
+struct gnix_xpmem_access_handle {
+	struct gnix_xpmem_handle *xp_hndl;
+	struct gnix_xpmem_ht_entry *entry;
+	void *attach_addr;
+	void *remote_base_addr;
+	size_t access_len;
+};
+
+extern bool gnix_xpmem_disabled;
+
+/*******************************************************************************
+ * API Prototypes
+ ******************************************************************************/
+
+/**
+ * @brief create an xpmem handle to use for subsequent
+ *        xpmem operations
+ *
+ * @param [in] dom      pointer to a previously allocated
+ *                      gnix_fid_domain struct
+ * @param [out] handle  pointer to a memory location where
+ *                      a pointer to an xpmem_handle will be
+ *                      returned
+ *
+ * @return FI_SUCCESS   xpmem handle successfully allocated
+ * @return -FI_EINVAL   Upon receiving an invalid parameter
+ */
+int _gnix_xpmem_handle_create(struct gnix_fid_domain *dom,
+			      struct gnix_xpmem_handle **handle);
+
+/**
+ * @brief destroy an xpmem handle
+ *
+ * @param [in] handle   pointer to a previously allocated
+ *                      xpmem_handle
+ * @return FI_SUCCESS   xpmem handle successfully destroyed
+ * @return -FI_EINVAL   Upon receiving an invalid parameter
+ */
+int _gnix_xpmem_handle_destroy(struct gnix_xpmem_handle *hndl);
+
+/**
+ * @brief get an access handle to a address range a peer's
+ *        address space
+ *
+ * @param[in] xp_handle         pointer to previously created
+ *                              xpmem handle
+ * @param[in] peer_apid         xpmem apid for peer
+ * @param[in] remote_vaddr      virtual address in process associated
+ *                              with the target EP
+ * @param[in] len               length in bytes of the region to
+ *                              to be accessed in the target process
+ * @param[out] access_hndl      access handle to be used to copy data
+ *                              from the peer process in to the local
+ *                              address space
+ *
+ * @return FI_SUCCESS   Upon xpmem successfully initialized
+ * @return -FI_EINVAL   Upon receiving an invalid parameter
+ * @return -FI_ENOSYS   Target EP can't be attached to local process
+ *                      address space
+ */
+int _gnix_xpmem_access_hndl_get(struct gnix_xpmem_handle *xp_hndl,
+			     xpmem_apid_t peer_apid,
+			     uint64_t remote_vaddr,
+			     size_t len,
+			     struct gnix_xpmem_access_handle **access_hndl);
+
+
+/**
+ * @brief release an access handle
+ *
+ * @param[in] access_handle     pointer to previously created
+ *                              access handle
+ *
+ * @return FI_SUCCESS   Upon xpmem successfully initialized
+ * @return -FI_EINVAL   Upon receiving an invalid parameter
+ */
+int _gnix_xpmem_access_hndl_put(struct gnix_xpmem_access_handle *access_hndl);
+
+/**
+ * @brief memcpy from previously accessed memory in peer's
+ *        virtual address space
+ *
+ * @param[in] access_hndl       pointer to previously created
+ *                              xpmem access handle
+ * @param[in] dst_addr          starting virtual address in the calling
+ *                              process address space where data
+ *                              will be copied
+ * @param[in] remote_start_addr   starting virtual address in the target
+ *                              address space from which data will be copied
+ * @param[in] len		copy length in bytes
+ *
+ * @return FI_SUCCESS	Upon successful copy
+ * @return -FI_EINVAL	Invalid argument
+ */
+int _gnix_xpmem_copy(struct gnix_xpmem_access_handle *access_hndl,
+		     void *dst_addr,
+		     void *remote_start_addr,
+		     size_t len);
+
+/**
+ * @brief get the xpmem segid associated with an xpmem_handle
+ *
+ * @param[in] xp_handle         pointer to previously created
+ *                              will be copied
+ * @param[out] seg_id           pointer to memory location where
+ *                              the segid value will be returned
+ *
+ * @return FI_SUCCESS	Upon success
+ * @return -FI_EINVAL	Invalid argument
+ */
+int _gnix_xpmem_get_my_segid(struct gnix_xpmem_handle *xp_hndl,
+				xpmem_segid_t *seg_id);
+
+/**
+ * @brief get the xpmem apid associated with an xpmem_handle
+ *        and input segid
+ *
+ * @param[in] xp_handle         pointer to previously created
+ *                              will be copied
+ * @param[in] seg_id            seg_id obtained from process
+ *                              whose memory is to be accessed
+ *                              via xpmem.
+ * @param[out] peer_apid        pointer to memory location where
+ *                              the apid value to use for accessing
+ *                              the address space of the peer
+ *                              process.
+ *
+ * @return FI_SUCCESS	Upon success
+ * @return -FI_EINVAL	Invalid argument
+ */
+int _gnix_xpmem_get_apid(struct gnix_xpmem_handle *xp_hndl,
+				xpmem_segid_t segid,
+				xpmem_apid_t *peer_apid);
+
+/**
+ * @brief determine if a process at a given gnix_address can
+ *        be accessed using xpmem
+ *
+ * @param[in] ep                pointer to a previously allocated
+ *                              gnix_fid_ep structure
+ * @param[in] addr              address used by an endpoint of the
+ *                              peer process
+ * @param[out] accessible       set to true if endpoint with
+ *                              gnix_address addr can be accessed
+ *                              using xpmem, otherwise false
+ *
+ * @return FI_SUCCESS	Upon success
+ * @return -FI_EINVAL	Invalid argument
+ */
+int _gnix_xpmem_accessible(struct gnix_fid_ep *ep,
+			   struct gnix_address addr,
+			   bool *accessible);
+
+
+
+
+#endif /* GNIX_XPMEM_H_ */

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -42,6 +42,7 @@
 #include "gnix.h"
 #include "gnix_nic.h"
 #include "gnix_util.h"
+#include "gnix_xpmem.h"
 
 gni_cq_mode_t gnix_def_gni_cq_modes = GNI_CQ_PHYS_PAGES;
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -59,6 +59,7 @@
 #include "gnix_util.h"
 #include "gnix_nameserver.h"
 #include "gnix_wait.h"
+#include "gnix_xpmem.h"
 
 const char gnix_fab_name[] = "gni";
 const char gnix_dom_name[] = "/sys/class/gni/kgni0";
@@ -520,6 +521,9 @@ GNI_INI
 
 	if (getenv("GNIX_MAX_NICS") != NULL)
 		gnix_max_nics_per_ptag = atoi(getenv("GNIX_MAX_NICS"));
+
+	if (getenv("GNIX_DISABLE_XPMEM") != NULL)
+		gnix_xpmem_disabled = true;
 
 	/*
 	 * if for some reason we can't even allocate a single nic, bail.

--- a/prov/gni/src/gnix_mr_cache.c
+++ b/prov/gni/src/gnix_mr_cache.c
@@ -583,18 +583,22 @@ static int
 __notifier_monitor(gnix_mr_cache_t *cache,
 		   gnix_mr_cache_entry_t *entry)
 {
+
 	if (!cache->attr.lazy_deregistration) {
+		return FI_SUCCESS;
+	}
+
+	if (cache->attr.notifier == NULL) {
 		return FI_SUCCESS;
 	}
 
 	GNIX_DEBUG(FI_LOG_MR, "monitoring entry=%p %llx:%llx\n", entry,
 		   entry->key.address, entry->key.length);
 
-	return _gnix_notifier_monitor(cache->attr.notifier,
-				      (void *) entry->key.address,
-				      entry->key.length,
-				      (uint64_t) entry);
-
+	return  _gnix_notifier_monitor(cache->attr.notifier,
+					      (void *) entry->key.address,
+					      entry->key.length,
+					      (uint64_t) entry);
 }
 
 /**
@@ -612,6 +616,10 @@ __notifier_unmonitor(gnix_mr_cache_t *cache,
 	int rc;
 
 	if (!cache->attr.lazy_deregistration) {
+		return;
+	}
+
+	if (cache->attr.notifier == NULL) {
 		return;
 	}
 

--- a/prov/gni/src/gnix_xpmem.c
+++ b/prov/gni/src/gnix_xpmem.c
@@ -1,0 +1,603 @@
+/*
+ * Copyright (c) 2016 Los Alamos National Security, LLC.
+ *                    All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        opyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include "gnix.h"
+#include "gnix_mr.h"
+#include "gnix_hashtable.h"
+#include "gnix_xpmem.h"
+
+
+#if HAVE_XPMEM
+
+bool gnix_xpmem_disabled = false;
+
+#define XPMEM_PAGE_SIZE 4096
+
+static  pthread_mutex_t gnix_xpmem_lock = PTHREAD_MUTEX_INITIALIZER;
+static xpmem_segid_t gnix_my_segid;
+static int gnix_xpmem_ref_cnt;
+
+static void *__gnix_xpmem_attach_seg(void *handle,
+				     void *address,
+				     size_t length,
+				     struct _gnix_fi_reg_context *,
+				     void *context);
+
+static int __gnix_xpmem_detach_seg(void *handle,
+				   void *context);
+
+static int __gnix_xpmem_destroy_mr_cache(void *context);
+
+struct gnix_xpmem_ht_entry {
+	struct gnix_mr_cache *mr_cache;
+	struct gnix_xpmem_handle *xp_hndl;
+	xpmem_apid_t apid;
+};
+
+/*
+ * TODO: should be adjustable from domain params
+ */
+static gnix_mr_cache_attr_t _gnix_xpmem_default_mr_cache_attr = {
+		.soft_reg_limit      = 128,
+		.hard_reg_limit      = 16384,
+		.hard_stale_limit    = 128,
+		.lazy_deregistration = 1,
+		.reg_callback        = __gnix_xpmem_attach_seg,
+		.dereg_callback      = __gnix_xpmem_detach_seg,
+		.destruct_callback   = __gnix_xpmem_destroy_mr_cache,
+		.elem_size           = sizeof(struct gnix_xpmem_access_handle),
+};
+
+/*******************************************************************************
+ * INTERNAL HELPER FNS
+ ******************************************************************************/
+
+static void __xpmem_hndl_destruct(void *obj)
+{
+	int __attribute__((unused)) ret;
+	struct gnix_xpmem_handle *hndl = (struct gnix_xpmem_handle *) obj;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	ret = _gnix_ht_destroy(hndl->apid_ht);
+	if (ret == FI_SUCCESS) {
+		free(hndl->apid_ht);
+		hndl->apid_ht = NULL;
+	} else {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			"_gnix_ht_destroy returned %s\n",
+			  fi_strerror(-ret));
+	}
+
+	pthread_mutex_lock(&gnix_xpmem_lock);
+
+	gnix_xpmem_ref_cnt--;
+	/*
+	 * if refcnt drops to zero for entire xpmem use, remove
+	 * this process' segment from xpmem.
+	 */
+	if (gnix_xpmem_ref_cnt == 0) {
+		ret = xpmem_remove(gnix_my_segid);
+		if (ret)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				 "xpmem_remove returned error %s\n",
+				 strerror(errno));
+	}
+
+	pthread_mutex_unlock(&gnix_xpmem_lock);
+
+	free(hndl);
+}
+
+static void __gnix_xpmem_destroy_ht_entry(void *val)
+{
+	int __attribute__((unused)) ret;
+	struct gnix_xpmem_ht_entry *entry = (struct gnix_xpmem_ht_entry *)val;
+
+	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
+
+	ret = _gnix_mr_cache_destroy(entry->mr_cache);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			 "_gnix_mr_cache_destroy returned error %s\n",
+			 fi_strerror(-ret));
+
+	xpmem_release(entry->apid);
+	free(entry);
+}
+
+static void *__gnix_xpmem_attach_seg(void *handle,
+				     void *address,
+				     size_t length,
+				     struct _gnix_fi_reg_context *reg_context,
+				     void *context)
+{
+	struct gnix_xpmem_access_handle *access_hndl =
+		(struct gnix_xpmem_access_handle *)handle;
+	struct gnix_xpmem_ht_entry *entry = context;
+	struct xpmem_addr xpmem_addr;
+	size_t top, attach_len;
+
+	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
+
+	xpmem_addr.apid   = entry->apid;
+
+	/*
+	 * xpmem requires page aligned addresses for attach operation
+	 */
+	xpmem_addr.offset = (off_t) FLOOR((uint64_t)address, XPMEM_PAGE_SIZE);
+	top = CEILING(((uint64_t)address + length), XPMEM_PAGE_SIZE);
+	attach_len = top - FLOOR((uint64_t)address, XPMEM_PAGE_SIZE);
+
+	access_hndl->attach_addr =  xpmem_attach(xpmem_addr,
+					    attach_len,
+					    NULL);
+	if (access_hndl->attach_addr != (void *)-1L) {
+		access_hndl->xp_hndl = entry->xp_hndl;
+		_gnix_ref_get(entry->xp_hndl);
+		access_hndl->remote_base_addr = (void *)xpmem_addr.offset;
+		access_hndl->access_len = attach_len;
+		access_hndl->entry = entry;
+		return handle;
+	} else {
+		GNIX_WARN(FI_LOG_EP_DATA,
+			  "xpmem_attach returned %s xpmem_addr %ld:0x%016lx len %d\n",
+			   strerror(errno), xpmem_addr.apid, xpmem_addr.offset,
+			   attach_len);
+		/* TODO: dump /proc/self/maps ? */
+		exit(-1);
+		return NULL;
+	}
+}
+
+static int __gnix_xpmem_detach_seg(void *handle, void *context)
+{
+	int ret;
+	struct gnix_xpmem_access_handle *access_hndl;
+
+	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
+
+	access_hndl = (struct gnix_xpmem_access_handle *)handle;
+	assert(access_hndl);
+
+	ret = xpmem_detach(access_hndl->attach_addr);
+	if (ret)
+		GNIX_WARN(FI_LOG_EP_DATA, "xpmem_detach returned %s\n",
+			  strerror(errno));
+	_gnix_ref_put(access_hndl->xp_hndl);
+	return ret;
+}
+
+/*
+ * TODO: do we need a destructor callback for mr cache?
+ */
+static int __gnix_xpmem_destroy_mr_cache(void *context)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	/*
+	 * use iterator over mr cache entries and invoke
+	 * xpmem_detach on each
+	 */
+	return FI_SUCCESS;
+}
+
+/*******************************************************************************
+ * the stuff
+ ******************************************************************************/
+
+int _gnix_xpmem_handle_create(struct gnix_fid_domain *dom,
+			      struct gnix_xpmem_handle **handle)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_xpmem_handle *hndl = NULL;
+	struct gnix_hashtable_attr ht_attr = {0};
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	hndl = calloc(1, sizeof *hndl);
+	if (!hndl)
+		return -FI_ENOMEM;
+
+	pthread_mutex_lock(&gnix_xpmem_lock);
+
+	if (gnix_xpmem_ref_cnt == 0) {
+		gnix_my_segid = xpmem_make(0, XPMEM_MAXADDR_SIZE,
+					   XPMEM_PERMIT_MODE,
+					   (void *)0666);
+		if (gnix_my_segid == -1L) {
+			GNIX_WARN(FI_LOG_DOMAIN, "xpmem make failed - %s\n",
+				  strerror(errno));
+			ret = -errno;
+			pthread_mutex_unlock(&gnix_xpmem_lock);
+			goto exit;
+		}
+
+		gnix_xpmem_ref_cnt++;
+	}
+
+	pthread_mutex_unlock(&gnix_xpmem_lock);
+
+	_gnix_ref_init(&hndl->ref_cnt, 1,
+			__xpmem_hndl_destruct);
+	fastlock_init(&hndl->lock);
+
+	/*
+	 * initialize xpmem_apid_t key'd hash table for
+	 * retrieving r/b tree for that apid
+	 */
+
+	hndl->apid_ht = calloc(1, sizeof(struct gnix_hashtable));
+	if (hndl->apid_ht == NULL)
+		goto exit;
+
+	/*
+	 * TODO: use domain parameters to adjust these
+	 */
+
+	ht_attr.ht_initial_size = 1024; /* will we ever have more than
+					   this many local processes? */
+	ht_attr.ht_maximum_size = 1024 * 1024;
+	ht_attr.ht_increase_step = 1024;
+	ht_attr.ht_increase_type = GNIX_HT_INCREASE_MULT;
+	ht_attr.ht_collision_thresh = 500;
+	ht_attr.ht_hash_seed = 0xdeadbeefbeefdead;
+	ht_attr.ht_internal_locking = 0;
+	ht_attr.destructor = __gnix_xpmem_destroy_ht_entry;
+
+	ret = _gnix_ht_init(hndl->apid_ht,
+			    &ht_attr);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "_gnix_ht_init returned %s\n",
+			  fi_strerror(-ret));
+		goto exit;
+	}
+
+	*handle = hndl;
+	return ret;
+
+exit:
+	if (hndl != NULL) {
+		if (hndl->apid_ht != NULL)
+			free(hndl->apid_ht);
+		free(hndl);
+	}
+
+	return ret;
+}
+
+int _gnix_xpmem_handle_destroy(struct gnix_xpmem_handle *hndl)
+{
+	int ret = FI_SUCCESS;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	_gnix_ref_put(hndl);
+
+	return ret;
+}
+
+
+int _gnix_xpmem_access_hndl_get(struct gnix_xpmem_handle *xp_hndl,
+			     xpmem_apid_t peer_apid,
+			     uint64_t remote_vaddr,
+			     size_t len,
+			     struct gnix_xpmem_access_handle  **access_hndl)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_xpmem_ht_entry *entry;
+        gnix_mr_cache_attr_t mr_cache_attr = {0};
+
+	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
+
+	/*
+	 * use peer_apid to look up the reg cache
+	 *  - if not in the hash, create and insert
+	 */
+
+	fastlock_acquire(&xp_hndl->lock);
+
+	entry = _gnix_ht_lookup(xp_hndl->apid_ht,
+			      (gnix_ht_key_t)peer_apid);
+
+	/*
+	 * okay need to create an mr_cache for this apid
+	 */
+	if (unlikely(entry == NULL)) {
+
+		entry = calloc(1, sizeof *entry);
+		if (entry == NULL) {
+			ret = -FI_ENOMEM;
+			goto exit_w_lock;
+		}
+
+		entry->apid = peer_apid;
+		entry->xp_hndl = xp_hndl;
+
+		memcpy(&mr_cache_attr, &_gnix_xpmem_default_mr_cache_attr,
+			sizeof(gnix_mr_cache_attr_t));
+		mr_cache_attr.reg_context = entry;
+		mr_cache_attr.dereg_context = entry;
+		mr_cache_attr.destruct_context = entry;
+		ret = _gnix_mr_cache_init(&entry->mr_cache,
+					  &mr_cache_attr);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				 "_gnix_mr_cache_init returned %s\n",
+				fi_strerror(-ret));
+			goto exit_w_lock;
+		}
+		ret = _gnix_ht_insert(xp_hndl->apid_ht,
+				      (gnix_ht_key_t)peer_apid,
+				      entry);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_DATA,
+				 "_gnix_ht_insert returned %s\n",
+				fi_strerror(-ret));
+			goto exit_w_lock;
+		}
+	}
+
+	ret = _gnix_mr_cache_register(entry->mr_cache,
+				      remote_vaddr,
+				      len,
+				      NULL,
+				      (void **)access_hndl);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_DATA,
+			  "_gnix_mr_cache_register returned %s\n",
+			   fi_strerror(-ret));
+		goto exit_w_lock;
+	}
+
+exit_w_lock:
+	fastlock_release(&xp_hndl->lock);
+	return ret;
+
+}
+
+int _gnix_xpmem_access_hndl_put(struct gnix_xpmem_access_handle *access_hndl)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_xpmem_ht_entry *entry;
+	struct gnix_xpmem_handle *xp_hndl;
+
+	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
+
+	entry = access_hndl->entry;
+	if (!entry) {
+		GNIX_WARN(FI_LOG_EP_DATA, "entry is null\n");
+		return -FI_EINVAL;
+	}
+
+	xp_hndl = entry->xp_hndl;
+	if (!xp_hndl) {
+		GNIX_WARN(FI_LOG_EP_DATA, "entry->xp_hndl is null\n");
+		return -FI_EINVAL;
+	}
+
+	fastlock_acquire(&xp_hndl->lock);
+
+	ret = _gnix_mr_cache_deregister(entry->mr_cache,
+					access_hndl);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_DATA, "_gnix_mr_cache_deregister returned %s\n",
+			  fi_strerror(-ret));
+
+	fastlock_release(&xp_hndl->lock);
+
+	return ret;
+}
+
+int _gnix_xpmem_accessible(struct gnix_fid_ep *ep,
+			   struct gnix_address addr,
+			   bool *accessible)
+{
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (!ep || *accessible)
+		return -FI_EINVAL;
+
+	if (gnix_xpmem_disabled == true) {
+		*accessible = false;
+		return FI_SUCCESS;
+	}
+
+	/*
+	 * if the endpoint's device_addr is the same as tht
+	 * of the supplied address, return true, else false
+	 */
+
+	*accessible = (ep->my_name.gnix_addr.device_addr ==
+			addr.device_addr) ? true : false;
+
+	return FI_SUCCESS;
+}
+
+int _gnix_xpmem_copy(struct gnix_xpmem_access_handle *access_hndl,
+		     void *dst_addr,
+		     void *remote_start_addr,
+		     size_t len)
+{
+	void *local_start_addr, *remote_base_addr;
+	uint64_t attach_addr, reg_len;
+
+	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
+
+	if (!access_hndl)
+		return -FI_EINVAL;
+
+	attach_addr = (uint64_t)access_hndl->attach_addr;
+	remote_base_addr = access_hndl->remote_base_addr;
+	reg_len = access_hndl->access_len;
+
+	/*
+	 * check that the access handle limits and the
+	 * copy request are consistent
+	 */
+
+	if (((uint64_t)remote_start_addr < (uint64_t)remote_base_addr) ||
+		((uint64_t)remote_start_addr >=
+			((uint64_t)remote_base_addr + reg_len)))
+		return -FI_EINVAL;
+
+	if (((uint64_t)remote_start_addr + len) >
+			((uint64_t)remote_base_addr + reg_len))
+		return -FI_EINVAL;
+
+	local_start_addr = (void *)((uint8_t *)attach_addr +
+				    ((uint8_t *)remote_start_addr -
+				     (uint8_t *)remote_base_addr));
+	GNIX_DEBUG(FI_LOG_EP_DATA,
+		  "xpmem copy dst addr 0x%016lx start addr 0x%016lx, len %ld\n",
+		    (uint64_t)dst_addr, (uint64_t)local_start_addr, len);
+	memcpy(dst_addr, local_start_addr, len);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_xpmem_get_my_segid(struct gnix_xpmem_handle *xp_hndl,
+			     xpmem_segid_t *seg_id)
+{
+	int ret = FI_SUCCESS;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	*seg_id = gnix_my_segid;
+	return ret;
+
+}
+
+int _gnix_xpmem_get_apid(struct gnix_xpmem_handle *xp_hndl,
+			 xpmem_segid_t segid,
+			 xpmem_apid_t *peer_apid)
+{
+	int ret = FI_SUCCESS;
+	xpmem_apid_t apid;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	apid = xpmem_get(segid, XPMEM_RDWR, XPMEM_PERMIT_MODE,
+			 (void *)0666);
+	if (apid == -1L) {
+		GNIX_WARN(FI_LOG_DOMAIN, "xpmem_get returned %s\n",
+			  strerror(errno));
+		ret = -errno;
+	} else {
+		*peer_apid = apid;
+	}
+
+	return ret;
+}
+
+#else
+
+bool gnix_xpmem_disabled = true;
+
+/*******************************************************************************
+ * almost stub functions when xpmem configuration is disabled
+ ******************************************************************************/
+
+int _gnix_xpmem_handle_create(struct gnix_fid_domain *dom,
+			      struct gnix_xpmem_handle **handle)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	return FI_SUCCESS;
+}
+
+int _gnix_xpmem_handle_destroy(struct gnix_xpmem_handle *hndl)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	return FI_SUCCESS;
+}
+
+
+int _gnix_xpmem_access_hndl_get(struct gnix_xpmem_handle *xp_hndl,
+			     xpmem_apid_t peer_apid,
+			     uint64_t remote_vaddr,
+			     size_t len,
+			     struct gnix_xpmem_access_handle  **access_hndl)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	return FI_SUCCESS;
+}
+
+int _gnix_xpmem_access_hndl_put(struct gnix_xpmem_access_handle *access_hndl)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	return FI_SUCCESS;
+}
+
+int _gnix_xpmem_accessible(struct gnix_fid_ep *ep,
+			   struct gnix_address addr,
+			   bool *accessible)
+{
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if (accessible == NULL)
+		return -FI_EINVAL;
+
+	*accessible = false;
+
+	return FI_SUCCESS;
+}
+
+int _gnix_xpmem_copy(struct gnix_xpmem_access_handle *access_hndl,
+		     void *dst_addr,
+		     void *remote_start_addr,
+		     size_t len)
+{
+	return -FI_ENOSYS;
+}
+
+int _gnix_xpmem_get_my_segid(struct gnix_xpmem_handle *xp_hndl,
+			     xpmem_segid_t *seg_id)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	return FI_SUCCESS;
+}
+
+int _gnix_xpmem_get_apid(struct gnix_xpmem_handle *xp_hndl,
+			 xpmem_segid_t segid,
+			 xpmem_apid_t *peer_apid)
+{
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+	return FI_SUCCESS;
+}
+
+#endif /* HAVE_XPMEM */

--- a/prov/gni/test/run_gnitest
+++ b/prov/gni/test/run_gnitest
@@ -32,6 +32,11 @@
 #
 
 #
+# disable use of xpmem bypass for criterion tests
+#
+
+export GNIX_DISABLE_XPMEM=1
+#
 # Check for srun or aprun
 #
 srun=`command -v srun`


### PR DESCRIPTION
This commit adds support for use of XPMEM for
on-node transfers for GNI provider's send/recv
rendezvous protocol

The feature by default will be automatically
enabled when building on a Cray XC system running
CLE 5.2up04 or higher and using a C11 compliant C
compiler.

The feature can be disabled at configure time with
the

--disable-xpmem

configure option.

If the provider is configured with XPMEM support
(the default) the feature can be partially disabled
by setting the

GNIX_DISABLE_XPMEM

environment variable.  This will disable use of XPMEM
for inter process memcpy, but will not disable the
initial setup and teardown of XPMEM related setup
steps.

disable xpmem bypass for criterion test

upstream merge of ofi-cray/libfabric-cray#881
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@d4ff3f56a0402cc82fae410d70e246ceb1095361)