### PR TITLE
prov/verbs: EP RDM generates CQ entries regarding to flags

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -67,7 +67,7 @@ static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
 
 		src_addr[ret] = (fi_addr_t) (uintptr_t) cq_entry->minfo.conn;
 		entry[ret].op_context = cq_entry->context;
-		entry[ret].flags = cq_entry->comp_flags;
+		entry[ret].flags = (cq_entry->comp_flags & ~FI_COMPLETION);
 		entry[ret].len = cq_entry->len;
 		entry[ret].data = cq_entry->imm;
 		entry[ret].tag = cq_entry->minfo.tag;
@@ -186,7 +186,7 @@ fi_ibv_rdm_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *entry,
 
 	if (err_request) {
 		entry->op_context = err_request->context;
-		entry->flags = err_request->comp_flags;
+		entry->flags = (err_request->comp_flags & ~FI_COMPLETION);
 		entry->len = err_request->len;
 		entry->buf = err_request->unexp_rbuf;
 		entry->data = err_request->imm;

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -126,8 +126,7 @@ fi_ibv_rdm_find_max_inline(struct ibv_pd *pd, struct ibv_context *context)
 	return rst;
 }
 
-static int fi_ibv_rdm_tagged_ep_bind(struct fid *fid, struct fid *bfid,
-				     uint64_t flags)
+static int fi_ibv_rdm_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
 	struct fi_ibv_rdm_ep *ep;
 	struct fi_ibv_rdm_cq *cq;
@@ -153,6 +152,8 @@ static int fi_ibv_rdm_tagged_ep_bind(struct fid *fid, struct fid *bfid,
 				return -EINVAL;
 			ep->fi_scq = cq;
 		}
+
+		ep->ep_flags |= flags;
 
 		/* TODO: this is wrong. CQ to EP is 1:n */
 		cq->ep = ep;
@@ -370,7 +371,7 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 	util_buf_pool_destroy(fi_ibv_rdm_tagged_request_pool);
 	util_buf_pool_destroy(fi_ibv_rdm_tagged_extra_buffers_pool);
 	util_buf_pool_destroy(fi_ibv_rdm_postponed_pool);
-
+	
 	free(ep);
 
 	return ret;
@@ -411,7 +412,7 @@ static int fi_ibv_ep_sync(fid_t fid, uint64_t flags, void *context)
 struct fi_ops fi_ibv_rdm_tagged_ep_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = fi_ibv_rdm_ep_close,
-	.bind = fi_ibv_rdm_tagged_ep_bind,
+	.bind = fi_ibv_rdm_ep_bind,
 	.control = fi_ibv_rdm_tagged_control,
 	.ops_open = fi_no_ops_open,
 };
@@ -446,6 +447,7 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->ep_fid.tagged = &fi_ibv_rdm_tagged_ops;
 	_ep->ep_fid.rma = fi_ibv_rdm_ep_ops_rma(_ep);
 	_ep->ep_fid.cm = &fi_ibv_rdm_tagged_ep_cm_ops;
+	_ep->ep_flags = 0;
 
 	switch (info->ep_attr->protocol) {
 	case FI_PROTO_IB_RDM:

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -146,19 +146,16 @@ static int fi_ibv_rdm_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			if (ep->fi_rcq)
 				return -EINVAL;
 			ep->fi_rcq = cq;
-			ep->ep_info->rx_attr->op_flags |= FI_COMPLETION; /* default */
+			ep->rx_selective_completion = 
+				(flags & FI_SELECTIVE_COMPLETION) ? 1 : 0;
 		}
 
 		if (flags & FI_SEND) {
 			if (ep->fi_scq)
 				return -EINVAL;
 			ep->fi_scq = cq;
-
-			if (flags & FI_SELECTIVE_COMPLETION) {
-				ep->ep_flags |= FI_SELECTIVE_COMPLETION;
-			} else {
-				ep->ep_info->tx_attr->op_flags |= FI_COMPLETION; /* default */
-			}
+			ep->tx_selective_completion = 
+				(flags & FI_SELECTIVE_COMPLETION) ? 1 : 0;
 		}
 
 		/* TODO: this is wrong. CQ to EP is 1:n */
@@ -378,7 +375,6 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 	util_buf_pool_destroy(fi_ibv_rdm_tagged_extra_buffers_pool);
 	util_buf_pool_destroy(fi_ibv_rdm_postponed_pool);
 
-	fi_freeinfo(ep->ep_info);
 	free(ep);
 
 	return ret;
@@ -454,11 +450,8 @@ int fi_ibv_open_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->ep_fid.tagged = &fi_ibv_rdm_tagged_ops;
 	_ep->ep_fid.rma = fi_ibv_rdm_ep_ops_rma(_ep);
 	_ep->ep_fid.cm = &fi_ibv_rdm_tagged_ep_cm_ops;
-	_ep->ep_flags = 0;
-	_ep->ep_info = fi_dupinfo(info);
-	if (!_ep->ep_info) {
-		return -FI_ENOMEM;
-	}
+	_ep->tx_selective_completion = 0;
+	_ep->rx_selective_completion = 0;
 
 	switch (info->ep_attr->protocol) {
 	case FI_PROTO_IB_RDM:

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -236,8 +236,8 @@ struct fi_ibv_rdm_ep {
 	size_t addrlen;
 
 	struct fi_ibv_av *av;
-	uint64_t ep_flags;
-	struct fi_info *ep_info;
+	int tx_selective_completion;
+	int rx_selective_completion;
 
 	/*
 	 * ibv_post_send opcode for tagged messaging.

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -236,6 +236,7 @@ struct fi_ibv_rdm_ep {
 	size_t addrlen;
 
 	struct fi_ibv_av *av;
+	uint64_t ep_flags;
 
 	/*
 	 * ibv_post_send opcode for tagged messaging.

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -237,6 +237,7 @@ struct fi_ibv_rdm_ep {
 
 	struct fi_ibv_av *av;
 	uint64_t ep_flags;
+	struct fi_info *ep_info;
 
 	/*
 	 * ibv_post_send opcode for tagged messaging.

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -357,7 +357,7 @@ fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len,
 }
 
 static ssize_t
-fi_ibv_rdm_tagged_send_common(struct fi_ibv_rdm_tagged_send_start_data* sdata)
+fi_ibv_rdm_tagged_send_common(struct fi_ibv_rdm_tsend_start_data* sdata)
 {
 	struct fi_ibv_rdm_tagged_request *request =
 		util_buf_alloc(fi_ibv_rdm_tagged_request_pool);
@@ -389,11 +389,12 @@ static ssize_t fi_ibv_rdm_tagged_senddatato(struct fid_ep *fid, const void *buf,
 					    uint64_t data, fi_addr_t dest_addr,
 					    uint64_t tag, void *context)
 {
-	struct fi_ibv_rdm_tagged_send_start_data sdata = {
+	struct fi_ibv_rdm_tsend_start_data sdata = {
 		.ep_rdm = container_of(fid, struct fi_ibv_rdm_ep, ep_fid),
 		.conn = (struct fi_ibv_rdm_tagged_conn *) dest_addr,
 		.data_len = len,
 		.context = context,
+		.flags = 0,
 		.tag = tag,
 		.buf.src_addr = (void*)buf,
 		.iov_count = 0,
@@ -416,11 +417,12 @@ static ssize_t fi_ibv_rdm_tagged_sendto(struct fid_ep *fid, const void *buf,
 static ssize_t fi_ibv_rdm_tagged_sendmsg(struct fid_ep *ep,
 	const struct fi_msg_tagged *msg, uint64_t flags)
 {
-	struct fi_ibv_rdm_tagged_send_start_data sdata = {
+	struct fi_ibv_rdm_tsend_start_data sdata = {
 		.ep_rdm = container_of(ep, struct fi_ibv_rdm_ep, ep_fid),
 		.conn = (struct fi_ibv_rdm_tagged_conn *) msg->addr,
 		.data_len = 0,
 		.context = msg->context,
+		.flags = flags,
 		.tag = msg->tag,
 		.buf.src_addr = NULL,
 		.iov_count = 0,

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -397,8 +397,8 @@ static ssize_t fi_ibv_rdm_tagged_senddatato(struct fid_ep *fid, const void *buf,
 		.conn = (struct fi_ibv_rdm_tagged_conn *) dest_addr,
 		.data_len = len,
 		.context = context,
-		.flags = FI_TAGGED | (ep_rdm->ep_flags & FI_SEND) |
-			(ep_rdm->ep_info->tx_attr->op_flags & FI_COMPLETION),
+		.flags = FI_TAGGED | FI_SEND |
+			(ep_rdm->tx_selective_completion ? 0ULL : FI_COMPLETION),
 		.tag = tag,
 		.buf.src_addr = (void*)buf,
 		.iov_count = 0,
@@ -429,9 +429,8 @@ static ssize_t fi_ibv_rdm_tagged_sendmsg(struct fid_ep *ep,
 		.conn = (struct fi_ibv_rdm_tagged_conn *) msg->addr,
 		.data_len = 0,
 		.context = msg->context,
-		.flags = FI_TAGGED | (ep_rdm->ep_flags & FI_SEND) |
-			((ep_rdm->ep_flags & FI_SELECTIVE_COMPLETION) ?
-				(flags & FI_COMPLETION) : FI_COMPLETION),
+		.flags = FI_TAGGED | FI_SEND | (ep_rdm->tx_selective_completion ?
+			(flags & FI_COMPLETION) : FI_COMPLETION),
 		.tag = msg->tag,
 		.buf.src_addr = NULL,
 		.iov_count = 0,
@@ -496,8 +495,7 @@ static ssize_t fi_ibv_rdm_tagged_sendv(struct fid_ep *ep,
 	};
 
 	return fi_ibv_rdm_tagged_sendmsg(ep, &msg,
-		FI_TAGGED | (ep_rdm->ep_flags & (FI_SEND)) |
-		(ep_rdm->ep_info->tx_attr->op_flags & FI_COMPLETION));
+		(ep_rdm->tx_selective_completion ? 0ULL : FI_COMPLETION));
 }
 
 struct fi_ops_tagged fi_ibv_rdm_tagged_ops = {

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -177,6 +177,7 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 	if (flags & FI_PEEK) {
+		recv_data.peek_data.flags |= FI_COMPLETION;
 		ret = fi_ibv_rdm_tagged_req_hndl(request,
 						FI_IBV_EVENT_RECV_PEEK,
 						&recv_data.peek_data);
@@ -184,6 +185,7 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 			fi_ibv_rdm_tagged_poll(ep_rdm);
 		}
 	} else if (flags & FI_CLAIM) {
+		recv_data.peek_data.flags |= FI_COMPLETION;
 		ret = fi_ibv_rdm_tagged_req_hndl(request,
 						 FI_IBV_EVENT_RECV_START,
 						 &recv_data);
@@ -196,7 +198,7 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 						 &recv_data);
 
 		VERBS_DBG(FI_LOG_EP_DATA,
-			"fi_recvfrom: conn %p, tag 0x%llx, len %ull, rbuf %p, fi_ctx %p, posted_recv %d\n",
+			"fi_recvfrom: conn %p, tag 0x%llx, len %llu, rbuf %p, fi_ctx %p, posted_recv %d\n",
 			conn, msg->tag, recv_data.data_len, recv_data.dest_addr,
 			msg->context, ep_rdm->posted_recvs);
 

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -1082,7 +1082,6 @@ fi_ibv_rdm_rma_init_request(struct fi_ibv_rdm_tagged_request *request,
 	} else {
 		assert(p->op_code == IBV_WR_RDMA_WRITE);
 		request->src_addr = (void*)p->lbuf;
-		request->comp_flags = FI_RMA | FI_WRITE;
 	}
 
 	if (request->rmabuf && request->len >= p->ep_rdm->max_inline_rc) {

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -88,7 +88,7 @@ fi_ibv_rdm_tagged_init_send_request(struct fi_ibv_rdm_tagged_request *request,
 {
 	FI_IBV_RDM_TAGGED_HANDLER_LOG_IN();
 
-	struct fi_ibv_rdm_tagged_send_start_data *p = data;
+	struct fi_ibv_rdm_tsend_start_data *p = data;
 	request->minfo.conn = p->conn;
 	request->minfo.tag = p->tag;
 	request->iov_count = p->iov_count;
@@ -102,7 +102,7 @@ fi_ibv_rdm_tagged_init_send_request(struct fi_ibv_rdm_tagged_request *request,
 
 	request->sbuf = NULL;
 	request->len = p->data_len;
-	request->comp_flags = FI_TAGGED | FI_SEND;
+	request->comp_flags = /* TODO: p->flags */ FI_TAGGED | FI_SEND;
 	request->imm = p->imm;
 	request->context = p->context;
 	request->state.eager = FI_IBV_STATE_EAGER_BEGIN;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -102,7 +102,7 @@ fi_ibv_rdm_tagged_init_send_request(struct fi_ibv_rdm_tagged_request *request,
 
 	request->sbuf = NULL;
 	request->len = p->data_len;
-	request->comp_flags = /* TODO: p->flags */ FI_TAGGED | FI_SEND;
+	request->comp_flags = p->flags;
 	request->imm = p->imm;
 	request->context = p->context;
 	request->state.eager = FI_IBV_STATE_EAGER_BEGIN;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
@@ -120,10 +120,11 @@ enum ibv_rdm_send_type
 	IBV_RDM_SEND_TYPE_VEC
 };
 
-struct fi_ibv_rdm_tagged_send_start_data {
+struct fi_ibv_rdm_tsend_start_data {
 	struct fi_ibv_rdm_ep *ep_rdm;
 	struct fi_ibv_rdm_tagged_conn *conn;
 	void *context;
+	uint64_t flags;
 	size_t tag;
 	size_t data_len;
 	union {

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.h
@@ -173,6 +173,7 @@ struct fi_ibv_rdm_rma_start_data {
 	struct fi_ibv_rdm_ep *ep_rdm;
 	struct fi_ibv_rdm_tagged_conn *conn;
 	void *context;
+	uint64_t flags;
 	uint64_t data_len;
 	uint64_t rbuf;
 	uintptr_t lbuf;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -57,6 +57,9 @@
 #define VERBS_TX_RDM_MODE VERBS_RDM_MODE
 
 #define VERBS_RX_MODE (FI_LOCAL_MR | FI_RX_CQ_DATA)
+
+#define VERBS_RX_RDM_OP_FLAGS (FI_COMPLETION)
+
 #define VERBS_MSG_ORDER (FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_RAS | \
 		FI_ORDER_WAW | FI_ORDER_WAS | FI_ORDER_SAW | FI_ORDER_SAS )
 
@@ -101,6 +104,7 @@ const struct fi_rx_attr verbs_rx_attr = {
 
 const struct fi_rx_attr verbs_rdm_rx_attr = {
 	.mode			= VERBS_RX_MODE,
+	.op_flags		= VERBS_RX_RDM_OP_FLAGS,
 	.msg_order		= VERBS_MSG_ORDER,
 	.total_buffered_recv	= FI_IBV_RDM_DFLT_BUFFERED_SSIZE /* TODO: */
 };

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -462,7 +462,7 @@ fi_ibv_rdm_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **
 		container_of(ep_fid, struct fi_ibv_rdm_ep, ep_fid);
 
 	return fi_ibv_rdm_ep_rma_writemsg(ep_fid, &msg,
-		FI_RMA | (ep_rdm->ep_flags & (FI_WRITE)) |
+		FI_RMA | (ep_rdm->ep_flags & (FI_TRANSMIT)) |
 		(ep_rdm->ep_info->tx_attr->op_flags & FI_COMPLETION));
 }
 

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -313,9 +313,8 @@ fi_ibv_rdm_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		.ep_rdm = container_of(ep_fid, struct fi_ibv_rdm_ep, ep_fid),
 		.conn = conn,
 		.context = msg->context,
-		.flags = FI_RMA | FI_READ | (ep->ep_flags & FI_TRANSMIT) |
-			((ep->ep_flags & FI_SELECTIVE_COMPLETION) ?
-				(flags & FI_COMPLETION) : FI_COMPLETION),
+		.flags = FI_RMA | FI_READ | (ep->tx_selective_completion ?
+			(flags & FI_COMPLETION) : FI_COMPLETION),
  		.data_len = (uint64_t)msg->msg_iov[0].iov_len,
 		.rbuf = msg->rma_iov[0].addr,
 		.lbuf = (uintptr_t)msg->msg_iov[0].iov_base,
@@ -363,8 +362,7 @@ fi_ibv_rdm_ep_rma_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 	};
 
 	return fi_ibv_rdm_ep_rma_readmsg(ep, &msg,
-		FI_RMA | (ep_rdm->ep_flags & (FI_TRANSMIT)) |
-		(ep_rdm->ep_info->tx_attr->op_flags & FI_COMPLETION));
+		(ep_rdm->tx_selective_completion ? 0ULL : FI_COMPLETION));
 }
 
 static ssize_t
@@ -418,9 +416,8 @@ fi_ibv_rdm_ep_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		.conn = conn,
 		.ep_rdm = ep,
 		.context = msg->context,
-		.flags = FI_RMA | FI_WRITE | (ep->ep_flags & FI_TRANSMIT) |
-			((ep->ep_flags & FI_SELECTIVE_COMPLETION) ?
-				(flags & FI_COMPLETION) : FI_COMPLETION),
+		.flags = FI_RMA | FI_WRITE | (ep->tx_selective_completion ?
+			(flags & FI_COMPLETION) : FI_COMPLETION),
 		.data_len = (uint64_t)msg->msg_iov[0].iov_len,
 		.rbuf = msg->rma_iov[0].addr,
 		.lbuf = (uintptr_t)msg->msg_iov[0].iov_base,
@@ -468,8 +465,7 @@ fi_ibv_rdm_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **
 		container_of(ep_fid, struct fi_ibv_rdm_ep, ep_fid);
 
 	return fi_ibv_rdm_ep_rma_writemsg(ep_fid, &msg,
-		FI_RMA | (ep_rdm->ep_flags & (FI_TRANSMIT)) |
-		(ep_rdm->ep_info->tx_attr->op_flags & FI_COMPLETION));
+		(ep_rdm->tx_selective_completion ? 0ULL : FI_COMPLETION));
 }
 
 static ssize_t

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -508,7 +508,7 @@ static ssize_t fi_ibv_rdm_ep_rma_inject_write(struct fid_ep *ep,
 	struct fi_ibv_rdm_rma_start_data start_data = {
 		.conn = conn,
 		.ep_rdm = ep_rdm,
-		.data_len = (uint32_t)len,
+		.data_len = (uint64_t)len,
 		.rbuf = addr,
 		.lbuf = (uintptr_t)buf,
 		.rkey = (uint32_t)key,


### PR DESCRIPTION
This series includes implementation of selective completion model and refactoring of tsend/trecv/rma nesting calls, i.e. now all simple functions call more complex ones. For example: tsend->tsendv->tsendmsg

@a-ilango , please review

Every commit passes build and fabtests