### PR TITLE
prov/udp: Bind to source address during fi_enable

### DIFF
--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -106,6 +106,7 @@ struct udpx_ep {
 	udpx_tx_comp_func	tx_comp;
 	struct udpx_rx_cirq	*rxq;    /* protected by rx_cq lock */
 	int			sock;
+	int			is_bound;
 };
 
 int udpx_endpoint(struct fid_domain *domain, struct fi_info *info,


### PR DESCRIPTION
- UDP endpoint was not binding to source address even after
  fi_enable(). This can result in invalid address for fi_getname()
  calls. This patch fixes it.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>