### PR TITLE
prov/sockets: Added code to release connection map entry when disconnected

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -195,7 +195,7 @@ struct sock_fabric {
 
 struct sock_conn {
         int sock_fd;
-        int disconnected;
+        int connected;
 	int address_published;
         struct sockaddr_in addr;
         struct sock_pe_entry *rx_pe_entry;
@@ -536,7 +536,6 @@ struct sock_ep_attr {
 	int is_enabled;
 	struct sock_cm_entry cm;
 	struct sock_conn_listener listener;
-	struct dlist_entry conn_list;
 	fastlock_t lock;
 
 	struct index_map conn_idm;
@@ -1095,7 +1094,8 @@ struct sock_conn *sock_ep_connect(struct sock_ep_attr *attr, fi_addr_t index);
 ssize_t sock_conn_send_src_addr(struct sock_ep_attr *ep_attr, struct sock_tx_ctx *tx_ctx,
 				struct sock_conn *conn);
 int sock_conn_listen(struct sock_ep_attr *ep_attr);
-void sock_conn_map_destroy(struct sock_conn_map *cmap);
+void sock_conn_map_destroy(struct sock_ep_attr *ep_attr);
+void sock_conn_reset_entry(struct sock_conn *conn);
 void sock_set_sockopts(int sock);
 int fd_set_nonblock(int fd);
 void sock_set_sockopt_reuseaddr(int sock);

--- a/prov/sockets/src/sock_epoll.c
+++ b/prov/sockets/src/sock_epoll.c
@@ -110,6 +110,7 @@ void sock_epoll_close(struct sock_epoll_set *set)
 {
 	free(set->events);
 	close(set->fd);
+	set->used = 0;
 }
 
 #else
@@ -179,6 +180,7 @@ int sock_epoll_get_fd_at_index(struct sock_epoll_set *set, int index)
 void sock_epoll_close(struct sock_epoll_set *set)
 {
 	free(set->pollfds);
+	set->used = 0;
 }
 
 #endif


### PR DESCRIPTION
- Added code to reset connection map entry when the connection is disconnected. It avoids connection map size overflow during high load
- Removed unused list <code>conn_list from</code> <code>sock_ep_attr</code>
- Added check for <code>idm_set</code> failures
- Fixed minor formatting issues

@jithinjosepkl, can you please review?

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>