### PR TITLE
util: new util_mr

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -51,7 +51,8 @@ common_srcs = \
 	prov/util/src/util_main.c   \
 	prov/util/src/util_poll.c   \
 	prov/util/src/util_wait.c   \
-	prov/util/src/util_buf.c
+	prov/util/src/util_buf.c    \
+	prov/util/src/util_mr.c
 
 if MACOS
 common_srcs += src/osx/osd.c

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -339,6 +339,39 @@ struct util_event {
 int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		 struct fid_eq **eq_fid, void *context);
 
+/*
+ * MR
+ */
+
+
+/*hide addr related info & store prov_mr ptr */
+struct ofi_util_mr {
+    void *map_handle;
+    uint64_t b_key; /* track available key (BASIC usage) */
+    enum fi_mr_mode mr_type;
+    const struct fi_provider *prov;
+};
+
+/*create instance of data structure and return handle to user */
+int ofi_mr_init(const struct fi_provider *in_prov, enum fi_mr_mode mode,
+                                struct ofi_util_mr ** out_new_mr);
+/*insert user mr struct in data structure*/
+int ofi_mr_insert(struct ofi_util_mr * in_mr_h,
+                                const struct fi_mr_attr *in_attr,
+                                uint64_t * out_key, void * in_prov_mr);
+/*return on user mr struct */
+void * ofi_mr_retrieve(struct ofi_util_mr * in_mr_h,  uint64_t in_key);
+/*need address offsetted, verified, and user mr struct returned*/
+/* io_addr is address of buff (&buf) */
+int ofi_mr_retrieve_and_verify(struct ofi_util_mr * in_mr_h, ssize_t in_len,
+                                uintptr_t *io_addr, uint64_t in_key,
+                                uint64_t in_access, void **out_prov_mr);
+/*erase a specific item in the data structure */
+int ofi_mr_erase(struct ofi_util_mr * in_mr_h, uint64_t in_key);
+/*close data structure instance */
+void ofi_mr_close(struct ofi_util_mr *in_mr_h);
+
+
 
 /*
  * Attributes and capabilities

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -55,7 +55,7 @@
 #include <fi_list.h>
 #include <fi_file.h>
 #include <fi_osd.h>
-#include <rbtree.h>
+#include "fi_util.h"
 
 #ifndef _SOCK_H_
 #define _SOCK_H_
@@ -224,7 +224,7 @@ struct sock_domain {
 	struct sock_eq *mr_eq;
 
 	enum fi_progress progress_mode;
-	RbtHandle mr_heap;
+	struct ofi_util_mr *mr_heap;
 	struct sock_pe *pe;
 	struct dlist_entry dom_list_entry;
 	struct fi_domain_attr attr;
@@ -295,14 +295,10 @@ struct sock_cntr {
 struct sock_mr {
 	struct fid_mr mr_fid;
 	struct sock_domain *domain;
-	uint64_t access;
-	uint64_t offset;
 	uint64_t key;
 	uint64_t flags;
-	size_t iov_count;
 	struct sock_cntr *cntr;
 	struct sock_cq *cq;
-	struct iovec mr_iov[1];
 };
 
 struct sock_av_addr {
@@ -1042,11 +1038,9 @@ void sock_cntr_remove_rx_ctx(struct sock_cntr *cntr, struct sock_rx_ctx *rx_ctx)
 
 
 struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint64_t key,
-				   void *buf, size_t len, uint64_t access);
+				   uintptr_t *buf, size_t len, uint64_t access);
 struct sock_mr *sock_mr_verify_desc(struct sock_domain *domain, void *desc,
 				    void *buf, size_t len, uint64_t access);
-struct sock_mr * sock_mr_get_entry(struct sock_domain *domain, uint64_t key);
-
 
 struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr,
 				      void *context, int use_shared);

--- a/prov/util/src/util_mr.c
+++ b/prov/util/src/util_mr.c
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <config.h>
+#include <stdlib.h>
+#include <fi_enosys.h>
+#include <fi_util.h>
+#include <assert.h>
+#include <rbtree.h>
+
+/* deep copy: make seperate copy of mr_attr and use context for prov_mr */
+static struct fi_mr_attr * create_mr_attr_copy(
+                        const struct fi_mr_attr *in_attr, void * prov_mr)
+{
+    struct fi_mr_attr * item;
+    struct iovec *mr_iov;
+    int i = 0;
+
+    if (!prov_mr || !in_attr)
+        return NULL;
+
+    item = malloc(sizeof(struct fi_mr_attr));
+    if (!item)
+        return NULL;
+
+    *item = *in_attr;
+    item->context = prov_mr;
+    mr_iov = malloc(sizeof(struct iovec) * in_attr->iov_count);
+    if (!mr_iov)
+        return NULL;
+
+    for(i = 0; i < in_attr->iov_count; i++)
+        mr_iov[i] = in_attr->mr_iov[i];
+
+    item->mr_iov = mr_iov;
+
+    return item;
+}
+
+static uint64_t get_mr_key(struct ofi_util_mr *mr_h)
+{
+    assert(mr_h->b_key != UINT64_MAX);
+    return mr_h->b_key++;
+}
+
+static int verify_addr(struct ofi_util_mr * in_mr, struct fi_mr_attr * item, uint64_t in_access,
+                                 uint64_t in_addr, ssize_t in_len)
+{
+    int i = 0;
+    uint64_t start = (uint64_t)item->mr_iov[i].iov_base;
+    uint64_t end = start + item->mr_iov[i].iov_len;
+
+    if (!in_addr) {
+        FI_DBG(in_mr->prov, FI_LOG_MR, "verify_addr: input address to is zero\n");
+        return -FI_EINVAL;
+    }
+
+    if ((in_access & item->access) != in_access) {
+        FI_DBG(in_mr->prov, FI_LOG_MR, "verify_addr: requested access is not valid\n");
+        return -FI_EACCES;
+    }
+
+      for (i = 0; i < item->iov_count; i++) {
+        if (start <= in_addr && end >= (in_addr + in_len))
+            return 0;
+    }
+
+    return -FI_EACCES;
+}
+
+int ofi_mr_insert(struct ofi_util_mr * in_mr_h, const struct fi_mr_attr *in_attr,
+                                uint64_t * out_key, void * in_prov_mr)
+{
+    struct fi_mr_attr * item;
+
+    if (!in_attr || in_attr->iov_count <= 0 || !in_prov_mr) {
+        return -FI_EINVAL;
+    }
+
+    item = create_mr_attr_copy(in_attr, in_prov_mr);
+    if (!item)
+        return -FI_ENOMEM;
+
+    /* Scalable MR handling: use requested key and offset */
+    if (in_mr_h->mr_type == FI_MR_SCALABLE) {
+        item->offset = (uintptr_t) in_attr->mr_iov[0].iov_base + in_attr->offset;
+        /* verify key doesn't already exist */
+        if (rbtFind(in_mr_h->map_handle, &item->requested_key))
+                return -FI_EINVAL;
+    } else {
+        item->requested_key = get_mr_key(in_mr_h);
+        item->offset = (uintptr_t) in_attr->mr_iov[0].iov_base;
+    }
+
+    rbtInsert(in_mr_h->map_handle, &item->requested_key, item);
+    *out_key = item->requested_key;
+
+    return 0;
+}
+
+void * ofi_mr_retrieve(struct ofi_util_mr * in_mr_h,  uint64_t in_key)
+{
+    void * itr;
+    struct fi_mr_attr * item;
+    void * key = &in_key;
+
+    itr = rbtFind(in_mr_h->map_handle, key);
+
+    if (!itr)
+        return NULL;
+
+    rbtKeyValue(in_mr_h->map_handle, itr, (void **)&key,
+                                (void **) &item);
+    return item->context;
+}
+
+
+/* io_addr is address of buff (&buf) */
+int ofi_mr_retrieve_and_verify(struct ofi_util_mr * in_mr_h, ssize_t in_len,
+                                uintptr_t *io_addr, uint64_t in_key,
+                                uint64_t in_access, void **out_prov_mr)
+{
+    int ret = 0;
+    void * itr;
+    struct fi_mr_attr * item;
+    void * key = &in_key;
+
+    itr = rbtFind(in_mr_h->map_handle, key);
+
+    if (!itr)
+        return -FI_EINVAL;
+
+    rbtKeyValue(in_mr_h->map_handle, itr, &key, (void **) &item);
+
+    /*return providers MR struct */
+    if (!item || !io_addr)
+        return -FI_EINVAL;
+
+    if (out_prov_mr)
+        (*out_prov_mr) = item->context;
+
+    /*offset for scalable */
+    if (in_mr_h->mr_type == FI_MR_SCALABLE)
+        *io_addr = (*io_addr) + item->offset;
+
+    ret = verify_addr(in_mr_h, item, in_access, *io_addr, in_len);
+
+    return ret;
+}
+
+int ofi_mr_erase(struct ofi_util_mr * in_mr_h, uint64_t in_key)
+{
+    void * itr;
+    struct fi_mr_attr * item;
+
+    if (!in_mr_h)
+        return -FI_EINVAL;
+
+    itr = rbtFind(in_mr_h->map_handle, &in_key);
+
+    if (!itr)
+        return -FI_ENOKEY;
+
+    /*release memory */
+    rbtKeyValue(in_mr_h->map_handle, itr, (void **)&in_key,
+                                (void **) &item);
+
+    assert(item);
+
+    free((void *)item->mr_iov);
+    free(item);
+
+    rbtErase(in_mr_h->map_handle, itr);
+
+    return 0;
+}
+
+/*assumes uint64_t keys */
+static int compare_mr_keys(void *key1, void *key2)
+{
+    uint64_t k1 = *((uint64_t *) key1);
+    uint64_t k2 = *((uint64_t *) key2);
+    return (k1 < k2) ?  -1 : (k1 > k2);
+}
+
+
+int ofi_mr_init(const struct fi_provider *in_prov, enum fi_mr_mode mode,
+                struct ofi_util_mr ** out_new_mr)
+{
+    struct ofi_util_mr * new_mr = malloc(sizeof(struct ofi_util_mr));
+    if (!new_mr)
+        return -FI_ENOMEM;
+
+    assert((mode == FI_MR_SCALABLE) || (mode == FI_MR_BASIC));
+
+    new_mr->mr_type = mode;
+
+    new_mr->map_handle = rbtNew(compare_mr_keys);
+    if (!new_mr->map_handle)
+        return -FI_ENOMEM;
+
+    new_mr->b_key = 0;
+
+    new_mr->prov = in_prov;
+
+    (*out_new_mr) = new_mr;
+
+    return 0;
+}
+
+
+void ofi_mr_close(struct ofi_util_mr *in_mr_h)
+{
+    if (!in_mr_h) {
+        FI_WARN(in_mr_h->prov, FI_LOG_MR, "util mr_close: received NULL input\n");
+        return;
+    }
+
+    rbtDelete(in_mr_h->map_handle);
+    free(in_mr_h);
+}


### PR DESCRIPTION
+enables the MR data structure choice to be opaque to provider

usage notes:
+key must also be tracked by prov, only way to find mr for closing
+fi_mr_attr->context will not be stored by util MR (store in provider)

-validated on MPI/SHMEM/fabtests

-only implemented in sockets provider

Signed-off-by: kseager <kayla.seager@intel.com>

@jithinjosepkl  @j-xiong : please review