### PR TITLE
Fix minor formatting error in manpage

### DIFF
--- a/man/man7/fi_rxd.7
+++ b/man/man7/fi_rxd.7
@@ -8,7 +8,7 @@ The RxD provider is a utility provider that supports RDM endpoints
 emulated over a base DGRAM provider.
 .SH SUPPORTED FEATURES
 .PP
-The RxD provider currently supports \f[I]FI_MSG\f and \f[I]FI_TAGGED\f
+The RxD provider currently supports \f[I]FI_MSG\f[] and \f[I]FI_TAGGED\f[]
 capabilities. It requires the base DGRAM provider to support FI_MSG
 capabilities.
 .PP


### PR DESCRIPTION
Fixes these error messages:
```
fi_rxd.7:11: a space character is not allowed in an escape name
fi_rxd.7:11: a newline character is not allowed in an escape name
```