### PR TITLE
prov/rxd: Add AV, CQ, and EP components

### DIFF
--- a/prov/rxd/Makefile.include
+++ b/prov/rxd/Makefile.include
@@ -1,9 +1,10 @@
 if HAVE_RXD
 _rxd_files = \
-	prov/rxd/src/rxd_attr.c	\
-	prov/rxd/src/rxd_init.c	\
+	prov/rxd/src/rxd_attr.c		\
+	prov/rxd/src/rxd_init.c		\
 	prov/rxd/src/rxd_fabric.c	\
 	prov/rxd/src/rxd_domain.c	\
+	prov/rxd/src/rxd_av.c		\
 	prov/rxd/src/rxd.h
 
 if HAVE_RXD_DL

--- a/prov/rxd/Makefile.include
+++ b/prov/rxd/Makefile.include
@@ -5,6 +5,8 @@ _rxd_files = \
 	prov/rxd/src/rxd_fabric.c	\
 	prov/rxd/src/rxd_domain.c	\
 	prov/rxd/src/rxd_av.c		\
+	prov/rxd/src/rxd_cq.c		\
+	prov/rxd/src/rxd_ep.c		\
 	prov/rxd/src/rxd.h
 
 if HAVE_RXD_DL

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -73,10 +73,59 @@
 #define RXD_TX_IDX_BITS		((1ULL << RXD_MAX_TX_BITS) - 1)
 #define RXD_RX_IDX_BITS		((1ULL << RXD_MAX_RX_BITS) - 1)
 
+#define RXD_BUF_POOL_ALIGNMENT	(16)
+#define RXD_TX_POOL_CHUNK_CNT	(1024)
+#define RXD_RX_POOL_CHUNK_CNT	(1024)
+
+#define RXD_MAX_RX_WIN		(16)
+#define RXD_MAX_OUT_TX_MSG	(8)
+#define RXD_MAX_UNACKED		(128)
+
+#define RXD_EP_MAX_UNEXP_PKT	(512)
+#define RXD_EP_MAX_UNEXP_MSG	(128)
+
+#define RXD_USE_OP_FLAGS	(1ULL << 61)
+#define RXD_NO_COMPLETION	(1ULL << 62)
+#define RXD_UNEXP_ENTRY		(1ULL << 63)
+
+
+#define RXD_RETRY_TIMEOUT	(900)
+#define RXD_WAIT_TIMEOUT	(2000)
+#define RXD_MAX_PKT_RETRY	(50)
+
+#define RXD_PKT_LOCAL_ACK	(1)
+#define RXD_PKT_REMOTE_ACK	(1 << 1)
+#define RXD_PKT_DONE (RXD_PKT_LOCAL_ACK | RXD_PKT_REMOTE_ACK)
+
+#define RXD_PKT_MARK_LOCAL_ACK(_pkt)	((_pkt)->ref |= RXD_PKT_LOCAL_ACK)
+#define RXD_PKT_MARK_REMOTE_ACK(_pkt)	((_pkt)->ref |= RXD_PKT_REMOTE_ACK)
+#define RXD_PKT_IS_COMPLETE(_pkt)	((_pkt)->ref == RXD_PKT_DONE)
+
+#define RXD_COPY_IOV_TO_BUF	(1)
+#define RXD_COPY_BUF_TO_IOV	(2)
+
 extern struct fi_provider rxd_prov;
 extern struct fi_info rxd_info;
 extern struct fi_fabric_attr rxd_fabric_attr;
 extern struct util_prov rxd_util_prov;
+
+enum {
+	RXD_PKT_ORDR_OK = 0,
+	RXD_PKT_ORDR_UNEXP,
+	RXD_PKT_ORDR_DUP,
+};
+
+enum {
+	RXD_TX_CONN = 0,
+	RXD_TX_MSG,
+	RXD_TX_TAG,
+};
+
+enum {
+	RXD_PKT_STRT = 0,
+	RXD_PKT_DATA,
+	RXD_PKT_LAST,
+};
 
 struct rxd_fabric {
 	struct util_fabric util_fabric;
@@ -108,13 +157,200 @@ struct rxd_av {
 	size_t size;
 };
 
+struct rxd_cq;
+typedef int (*rxd_cq_write_fn)(struct rxd_cq *cq,
+			       struct fi_cq_tagged_entry *cq_entry);
 struct rxd_cq {
 	struct util_cq util_cq;
+	struct fid_cq *dg_cq;
+	struct rxd_domain *domain;
+	rxd_cq_write_fn write_fn;
 	struct dlist_entry dom_entry;
+	struct util_buf_pool *unexp_pool;
+	struct dlist_entry unexp_list;
+	fastlock_t lock;
+};
+
+struct rxd_peer {
+	uint64_t nxt_msg_id;
+	uint64_t exp_msg_id;
+	uint64_t conn_data;
+
+	uint8_t addr_published;
+	uint8_t conn_initiated;
+	uint16_t num_msg_out;
+	uint8_t pad[4];
 };
 
 struct rxd_ep {
+	struct fid_ep ep;
+	struct fid_ep *dg_ep;
+
+	struct rxd_domain *domain;
+	struct rxd_cq *rx_cq;
+	struct rxd_cq *tx_cq;
+	struct rxd_av *av;
+
+	struct rxd_peer *peer_info;
+	size_t max_peers;
+
+	void *name;
+	size_t addrlen;
+	int conn_data_set;
+	uint64_t conn_data;
+
+	size_t rx_size;
+	size_t credits;
+	uint64_t num_out;
+
+	int do_local_mr;
+	uint64_t caps;
+
 	struct dlist_entry dom_entry;
+	struct dlist_entry wait_rx_list;
+
+	struct dlist_entry unexp_tag_list;
+	struct dlist_entry unexp_msg_list;
+	uint16_t num_unexp_pkt;
+	uint16_t num_unexp_msg;
+
+	struct util_buf_pool *tx_pkt_pool;
+	struct util_buf_pool *rx_pkt_pool;
+	struct slist rx_pkt_list;
+
+	struct rxd_tx_entry_fs *tx_entry_fs;
+	struct dlist_entry tx_entry_list;
+
+	struct rxd_rx_entry_fs *rx_entry_fs;
+	struct dlist_entry rx_entry_list;
+
+	struct rxd_recv_fs *recv_fs;
+	struct dlist_entry recv_list;
+
+	struct rxd_trecv_fs *trecv_fs;
+	struct dlist_entry trecv_list;
+	fastlock_t lock;
+};
+
+struct rxd_unexp_cq_entry {
+	struct dlist_entry entry;
+	struct fi_cq_msg_entry cq_entry;
+};
+
+struct rxd_rx_buf {
+	struct fi_context context;
+	struct slist_entry entry;
+	struct rxd_ep *ep;
+	struct fid_mr *mr;
+	char buf[];
+};
+
+struct rxd_rx_entry {
+	struct ofi_op_hdr op_hdr;
+	uint32_t exp_seg_no;
+	uint64_t msg_id;
+	uint64_t key;
+	uint64_t done;
+	uint64_t peer;
+	uint16_t window;
+	uint32_t last_win_seg;
+	fi_addr_t source;
+	struct rxd_peer *peer_info;
+	struct rxd_rx_buf *unexp_buf;
+	uint64_t nack_stamp;
+	struct dlist_entry entry;
+
+	union {
+		struct rxd_recv_entry *recv;
+		struct rxd_trecv_entry *trecv;
+	};
+
+	union {
+		struct dlist_entry wait_entry;
+		struct dlist_entry unexp_entry;
+	};
+};
+DECLARE_FREESTACK(struct rxd_rx_entry, rxd_rx_entry_fs);
+
+struct rxd_tx_entry {
+	fi_addr_t peer;
+	uint64_t msg_id;
+	uint64_t flags;
+	uint64_t done;
+	uint64_t rx_key;
+	uint32_t nxt_seg_no;
+	uint32_t win_sz;
+	int num_unacked;
+	int is_waiting;
+	uint64_t retry_stamp;
+
+	struct dlist_entry entry;
+	struct dlist_entry pkt_list;
+
+	uint8_t op_type;
+	struct ofi_op_hdr op_hdr;
+
+	union {
+		struct {
+			struct fi_msg msg;
+			struct iovec msg_iov[RXD_IOV_LIMIT];
+		} msg;
+
+		struct {
+			struct fi_msg_tagged tmsg;
+			struct iovec msg_iov[RXD_IOV_LIMIT];
+		} tmsg;
+	};
+};
+DECLARE_FREESTACK(struct rxd_tx_entry, rxd_tx_entry_fs);
+
+struct rxd_recv_entry {
+	struct dlist_entry entry;
+	struct fi_msg msg;
+	uint64_t flags;
+	struct iovec iov[RXD_IOV_LIMIT];
+	void *desc[RXD_IOV_LIMIT];
+};
+DECLARE_FREESTACK(struct rxd_recv_entry, rxd_recv_fs);
+
+struct rxd_trecv_entry {
+	struct dlist_entry entry;
+	struct fi_msg_tagged msg;
+	uint64_t flags;
+	struct rxd_rx_entry *rx_entry;
+	struct iovec iov[RXD_IOV_LIMIT];
+	void *desc[RXD_IOV_LIMIT];
+};
+DECLARE_FREESTACK(struct rxd_trecv_entry, rxd_trecv_fs);
+
+struct rxd_pkt_data_start {
+	struct ofi_ctrl_hdr ctrl;
+	struct ofi_op_hdr op;
+	char data[];
+};
+#define RXD_START_DATA_PKT_SZ (sizeof(struct rxd_pkt_data_start))
+#define RXD_MAX_STRT_DATA_PKT_SZ(ep) (ep->domain->max_mtu_sz - RXD_START_DATA_PKT_SZ)
+
+struct rxd_pkt_data {
+	struct ofi_ctrl_hdr ctrl;
+	char data[];
+};
+#define RXD_DATA_PKT_SZ (sizeof(struct rxd_pkt_data))
+#define RXD_MAX_DATA_PKT_SZ(ep)	(ep->domain->max_mtu_sz - RXD_DATA_PKT_SZ)
+
+struct rxd_pkt_meta {
+	struct fi_context context;
+	struct dlist_entry entry;
+	struct rxd_tx_entry *tx_entry;
+	struct rxd_ep *ep;
+	struct fid_mr *mr;
+	uint64_t us_stamp;
+	uint8_t ref;
+	uint8_t type;
+	uint8_t retries;
+	uint8_t pad[5];
+
+	char pkt_data[]; /* rxd_pkt, followed by data */
 };
 
 int rxd_alter_layer_info(struct fi_info *layer_info, struct fi_info *base_info);
@@ -126,4 +362,66 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		    struct fid_domain **dom, void *context);
 int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		  struct fid_av **av, void *context);
+int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
+		 struct fid_ep **ep, void *context);
+int rxd_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+		struct fid_cq **cq_fid, void *context);
+
+
+/* AV sub-functions */
+fi_addr_t rxd_av_get_dg_addr(struct rxd_av *av, fi_addr_t fi_addr);
+int rxd_av_insert_dg_av(struct rxd_av *av, const void *addr);
+fi_addr_t rxd_av_get_fi_addr(struct rxd_av *av, fi_addr_t dg_addr);
+int rxd_av_dg_reverse_lookup(struct rxd_av *av, uint64_t start_idx,
+			     const void *addr, size_t addrlen, uint64_t *idx);
+
+/* EP sub-functions */
+void rxd_ep_lock_if_required(struct rxd_ep *rxd_ep);
+void rxd_ep_unlock_if_required(struct rxd_ep *rxd_ep);
+int rxd_ep_repost_buff(struct rxd_rx_buf *rx_buf);
+void rxd_ep_progress(struct rxd_ep *ep);
+int rxd_ep_reply_ack(struct rxd_ep *ep, struct ofi_ctrl_hdr *in_ctrl,
+		     uint8_t type, uint16_t seg_size, uint64_t rx_key,
+		     uint64_t source, fi_addr_t dest);
+int rxd_ep_reply_nack(struct rxd_ep *ep, struct ofi_ctrl_hdr *in_ctrl,
+		      uint32_t seg_no, uint64_t rx_key,
+		      uint64_t source, fi_addr_t dest);
+int rxd_ep_reply_discard(struct rxd_ep *ep, struct ofi_ctrl_hdr *in_ctrl,
+			 uint32_t seg_no, uint64_t rx_key,
+			 uint64_t source, fi_addr_t dest);
+struct rxd_peer *rxd_ep_getpeer_info(struct rxd_ep *rxd_ep, fi_addr_t addr);
+
+void rxd_ep_check_unexp_msg_list(struct rxd_ep *ep, struct rxd_recv_entry *recv_entry);
+void rxd_ep_check_unexp_tag_list(struct rxd_ep *ep, struct rxd_trecv_entry *trecv_entry);
+void rxd_ep_handle_data_msg(struct rxd_ep *ep, struct rxd_peer *peer,
+			    struct rxd_rx_entry *rx_entry,
+			    struct iovec *iov, size_t iov_count,
+			    struct ofi_ctrl_hdr *ctrl, void *data,
+			    struct rxd_rx_buf *rx_buf);
+void rxd_ep_free_acked_pkts(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
+			    uint32_t seg_no);
+uint64_t rxd_ep_copy_iov_buf(const struct iovec *iov, size_t iov_count,
+			     void *buf, uint64_t data_sz, uint64_t skip, int dir);
+int rxd_ep_retry_pkt(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
+		     struct rxd_pkt_meta *pkt);
+
+/* Tx/Rx entry sub-functions */
+struct rxd_tx_entry *rxd_tx_entry_acquire(struct rxd_ep *ep, struct rxd_peer *peer);
+int rxd_tx_entry_progress(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
+			  struct ofi_ctrl_hdr *ack);
+void rxd_tx_entry_discard(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry);
+void rxd_tx_entry_release(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry);
+void rxd_tx_entry_done(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry);
+
+struct rxd_pkt_meta *rxd_tx_pkt_acquire(struct rxd_ep *ep);
+void rxd_tx_pkt_release(struct rxd_pkt_meta *pkt_meta);
+void rxd_rx_entry_release(struct rxd_ep *ep, struct rxd_rx_entry *rx_entry);
+
+
+/* CQ sub-functions */
+void rxd_cq_progress(struct util_cq *util_cq);
+void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry);
+void rxd_cq_report_tx_comp(struct rxd_cq *cq, struct rxd_tx_entry *tx_entry);
+void rxd_cq_report_rx_comp(struct rxd_cq *cq, struct rxd_rx_entry *rx_entry);
+
 #endif

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -98,6 +98,16 @@ struct rxd_domain {
 	struct dlist_entry cq_list;
 };
 
+struct rxd_av {
+	struct fid_av *dg_av;
+	fastlock_t lock;
+
+	struct util_av util_av;
+	int dg_av_used;
+	size_t addrlen;
+	size_t size;
+};
+
 struct rxd_cq {
 	struct util_cq util_cq;
 	struct dlist_entry dom_entry;
@@ -114,5 +124,6 @@ int rxd_fabric(struct fi_fabric_attr *attr,
 	       struct fid_fabric **fabric, void *context);
 int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		    struct fid_domain **dom, void *context);
-
+int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
+		  struct fid_av **av, void *context);
 #endif

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -58,7 +58,7 @@ out:
 	return ret;
 }
 
-int rxd_dg_av_reverse_lookup(struct rxd_av *av, uint64_t start_idx,
+int rxd_av_dg_reverse_lookup(struct rxd_av *av, uint64_t start_idx,
 			      const void *addr, size_t addrlen, uint64_t *idx)
 {
 	int ret;
@@ -96,7 +96,7 @@ size_t rxd_av_insert_check(struct rxd_av *av, const void *addr, size_t count,
 
 	for (i = 0; i < count; i++) {
 		curr_addr = (char *) addr + av->addrlen * i;
-		ret = rxd_dg_av_reverse_lookup(av, i, curr_addr, av->addrlen, &dg_av_idx);
+		ret = rxd_av_dg_reverse_lookup(av, i, curr_addr, av->addrlen, &dg_av_idx);
 		if (ret == -FI_ENODATA) {
 			ret = fi_av_insert(av->dg_av, curr_addr, 1, &dg_av_idx,
 					   flags, context);

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2015-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "rxd.h"
+
+fi_addr_t rxd_av_get_dg_addr(struct rxd_av *av, fi_addr_t fi_addr)
+{
+	uint64_t *dg_idx;
+	dg_idx = ofi_av_get_addr(&av->util_av, (int) fi_addr);
+	return *dg_idx;
+}
+
+fi_addr_t rxd_av_get_fi_addr(struct rxd_av *av, fi_addr_t dg_addr)
+{
+	return (fi_addr_t) ofi_av_lookup_index(&av->util_av,
+					      &dg_addr, (int) dg_addr);
+}
+
+int rxd_av_insert_dg_av(struct rxd_av *av, const void *addr)
+{
+	int ret;
+	fastlock_acquire(&av->lock);
+	ret = fi_av_insert(av->dg_av, addr, 1, NULL, 0, NULL);
+	if (ret != 1)
+		goto out;
+	av->dg_av_used++;
+out:
+	fastlock_release(&av->lock);
+	return ret;
+}
+
+int rxd_dg_av_reverse_lookup(struct rxd_av *av, uint64_t start_idx,
+			      const void *addr, size_t addrlen, uint64_t *idx)
+{
+	int ret;
+	size_t i, len;
+	void *curr_addr;
+
+	len = addrlen;
+	curr_addr = calloc(1, av->addrlen);
+	if (!curr_addr)
+		return -FI_ENOMEM;
+
+	for (i = 0; i < av->dg_av_used; i++) {
+		ret = fi_av_lookup(av->dg_av, (i + start_idx) % av->dg_av_used,
+				   curr_addr, &len);
+		if (ret)
+			continue;
+		if (len == addrlen && memcmp(curr_addr, addr, len) == 0) {
+			*idx = (i + start_idx) % av->dg_av_used;
+			goto out;
+		}
+	}
+	ret = -FI_ENODATA;
+out:
+	free(curr_addr);
+	return ret;
+}
+
+size_t rxd_av_insert_check(struct rxd_av *av, const void *addr, size_t count,
+			    fi_addr_t *fi_addr, uint64_t flags, void *context)
+{
+	size_t i, success_cnt = 0;
+	int ret, index;
+	void *curr_addr;
+	uint64_t dg_av_idx;
+
+	for (i = 0; i < count; i++) {
+		curr_addr = (char *) addr + av->addrlen * i;
+		ret = rxd_dg_av_reverse_lookup(av, i, curr_addr, av->addrlen, &dg_av_idx);
+		if (ret == -FI_ENODATA) {
+			ret = fi_av_insert(av->dg_av, curr_addr, 1, &dg_av_idx,
+					   flags, context);
+			if (ret <= 0) {
+				if (av->util_av.eq)
+					ofi_av_write_event(&av->util_av, i,
+							   (ret == 0) ? FI_EINVAL : -ret,
+							   context);
+				if (fi_addr)
+					fi_addr[i] = FI_ADDR_NOTAVAIL;
+				continue;
+			}
+		}
+
+		ret = ofi_av_insert_addr(&av->util_av, &dg_av_idx, dg_av_idx, &index);
+		if (ret) {
+			if (av->util_av.eq)
+				ofi_av_write_event(&av->util_av, i, -ret, context);
+		} else {
+			success_cnt++;
+		}
+		
+		if (fi_addr)
+			fi_addr[i] = (ret == 0) ? index : FI_ADDR_NOTAVAIL;
+	}
+	av->dg_av_used += success_cnt;
+	if (av->util_av.eq) {
+		ofi_av_write_event(&av->util_av, success_cnt, 0, context);
+		ret = 0;
+	} else {
+		ret = success_cnt;
+	}
+	return ret;
+}
+
+size_t rxd_av_insert_fast(struct rxd_av *av, const void *addr, size_t count,
+			   fi_addr_t *fi_addr, uint64_t flags, void *context)
+{
+	size_t i, num, ret, success_cnt = 0;
+	int index;
+	fi_addr_t *fi_addrs;
+
+	fi_addrs = calloc(count, sizeof(fi_addr_t));
+	if (!fi_addrs)
+		return -FI_ENOMEM;
+
+	num = fi_av_insert(av->dg_av, addr, count, fi_addrs, flags, context);
+	if (num != count) {
+		free(fi_addrs);
+		return rxd_av_insert_check(av, addr, count, fi_addr,
+					    flags, context);
+	}
+
+	for (i = 0; i < num; i++) {
+		ret = ofi_av_insert_addr(&av->util_av, &fi_addrs[i],
+					 fi_addrs[i], &index);
+		if (ret) {
+			if (av->util_av.eq)
+				ofi_av_write_event(&av->util_av, i, -ret, context);
+		} else {
+			success_cnt++;
+		}
+
+		if (fi_addr)
+			fi_addr[i] = (ret == 0) ? index : FI_ADDR_NOTAVAIL;
+	}
+
+	free(fi_addrs);
+	av->dg_av_used += success_cnt;
+
+	if (av->util_av.eq) {
+		ofi_av_write_event(&av->util_av, success_cnt, 0, context);
+		ret = 0;
+	} else {
+		ret = success_cnt;
+	}
+
+	return ret;
+}
+
+static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
+			fi_addr_t *fi_addr, uint64_t flags, void *context)
+{
+	struct rxd_av *av;
+	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
+	return av->dg_av_used ?
+		rxd_av_insert_check(av, addr, count, fi_addr, flags, context) :
+		rxd_av_insert_fast(av, addr, count, fi_addr, flags, context);
+}
+
+static int rxd_av_insertsvc(struct fid_av *av, const char *node,
+			   const char *service, fi_addr_t *fi_addr,
+			   uint64_t flags, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static int rxd_av_insertsym(struct fid_av *av_fid, const char *node, size_t nodecnt,
+			   const char *service, size_t svccnt, fi_addr_t *fi_addr,
+			   uint64_t flags, void *context)
+{
+	return -FI_ENOSYS;
+}
+
+static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count,
+			uint64_t flags)
+{
+	int ret = 0;
+	size_t i;
+	fi_addr_t dg_idx;
+	struct rxd_av *av;
+
+	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
+	for (i = 0; i < count; i++) {
+		dg_idx = rxd_av_get_dg_addr(av, fi_addr[i]);
+		ret = fi_av_remove(av->dg_av, &dg_idx, 1, flags);
+		if (ret)
+			break;
+		av->dg_av_used--;
+	}
+	return ret;
+}
+
+static const char * rxd_av_straddr(struct fid_av *av, const void *addr, char *buf, size_t *len)
+{
+	struct rxd_av *rxd_av;
+	rxd_av = container_of(av, struct rxd_av, util_av.av_fid);
+	return rxd_av->dg_av->ops->straddr(rxd_av->dg_av, addr, buf, len);
+}
+
+int rxd_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr, size_t *addrlen)
+{
+	struct rxd_av *rxd_av;
+	fi_addr_t dg_addr;
+	rxd_av = container_of(av, struct rxd_av, util_av.av_fid);
+	dg_addr = rxd_av_get_dg_addr(rxd_av, fi_addr);
+	return fi_av_lookup(rxd_av->dg_av, dg_addr, addr, addrlen);
+}
+
+static struct fi_ops_av rxd_av_ops = {
+	.size = sizeof(struct fi_ops_av),
+	.insert = rxd_av_insert,
+	.insertsvc = rxd_av_insertsvc,
+	.insertsym = rxd_av_insertsym,
+	.remove = rxd_av_remove,
+	.lookup = rxd_av_lookup,
+	.straddr = rxd_av_straddr,
+};
+
+int rxd_av_close(struct fid *fid)
+{
+	int ret;
+	struct rxd_av *av;
+	av = container_of(fid, struct rxd_av, util_av.av_fid);
+	ret = fi_close(&av->dg_av->fid);
+	if (ret)
+		return ret;
+
+	ret = ofi_av_close(&av->util_av);
+	if (ret)
+		return ret;
+
+	fastlock_destroy(&av->lock);
+	free(av);
+	return 0;
+}
+
+int rxd_av_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+{
+	return ofi_av_bind(fid, bfid, flags);
+}
+
+static struct fi_ops rxd_av_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = rxd_av_close,
+	.bind = rxd_av_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
+		   struct fid_av **av_fid, void *context)
+{
+	int ret;
+	struct rxd_av *av;
+	struct rxd_domain *domain;
+	struct util_av_attr util_attr;
+
+	if (attr && attr->name)
+		return -FI_ENOSYS;
+
+	domain = container_of(domain_fid, struct rxd_domain, util_domain.domain_fid);
+	av = calloc(1, sizeof(*av));
+	if (!av)
+		return -FI_ENOMEM;
+
+	util_attr.addrlen = sizeof(fi_addr_t);
+	util_attr.overhead = attr->count;
+	util_attr.flags = FI_SOURCE;
+	av->size = attr->count;
+	ret = ofi_av_init(&domain->util_domain, attr, &util_attr,
+			 &av->util_av, context);
+	if (ret)
+		goto err1;
+
+	av->size = av->util_av.count;
+	attr->type = FI_AV_TABLE;
+	attr->count = 0;
+	attr->flags = 0;
+	ret = fi_av_open(domain->dg_domain, attr, &av->dg_av, context);
+	if (ret)
+		goto err2;
+
+	fastlock_init(&av->lock);
+	av->addrlen = domain->addrlen;
+
+	*av_fid = &av->util_av.av_fid;
+	(*av_fid)->fid.fclass = FI_CLASS_AV;
+	(*av_fid)->fid.ops = &rxd_av_fi_ops;
+	(*av_fid)->ops = &rxd_av_ops;
+	return 0;
+
+err2:
+	ofi_av_close(&av->util_av);
+err1:
+	free(av);
+	return ret;
+}

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -1,0 +1,1215 @@
+/*
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include "rxd.h"
+
+static int rxd_cq_write_ctx(struct rxd_cq *cq,
+			     struct fi_cq_tagged_entry *cq_entry)
+{
+	struct fi_cq_tagged_entry *comp;
+	if (cirque_isfull(cq->util_cq.cirq))
+		return -FI_ENOSPC;
+
+	comp = cirque_tail(cq->util_cq.cirq);
+	comp->op_context = cq_entry->op_context;
+	cirque_commit(cq->util_cq.cirq);
+	return 0;
+}
+
+static int rxd_cq_write_ctx_signal(struct rxd_cq *cq,
+				    struct fi_cq_tagged_entry *cq_entry)
+{
+	int ret = rxd_cq_write_ctx(cq, cq_entry);
+	cq->util_cq.wait->signal(cq->util_cq.wait);
+	return ret;
+}
+
+static int rxd_cq_write_msg(struct rxd_cq *cq,
+			     struct fi_cq_tagged_entry *cq_entry)
+{
+	struct fi_cq_tagged_entry *comp;
+	if (cirque_isfull(cq->util_cq.cirq))
+		return -FI_ENOSPC;
+
+	comp = cirque_tail(cq->util_cq.cirq);
+	comp->op_context = cq_entry->op_context;
+	comp->flags = cq_entry->flags;
+	comp->len = cq_entry->len;
+	cirque_commit(cq->util_cq.cirq);
+	return 0;
+}
+
+static int rxd_cq_write_msg_signal(struct rxd_cq *cq,
+				    struct fi_cq_tagged_entry *cq_entry)
+{
+	int ret = rxd_cq_write_msg(cq, cq_entry);
+	cq->util_cq.wait->signal(cq->util_cq.wait);
+	return ret;
+}
+
+static int rxd_cq_write_data(struct rxd_cq *cq,
+			      struct fi_cq_tagged_entry *cq_entry)
+{
+	struct fi_cq_tagged_entry *comp;
+	if (cirque_isfull(cq->util_cq.cirq))
+		return -FI_ENOSPC;
+
+	comp = cirque_tail(cq->util_cq.cirq);
+	comp->op_context = cq_entry->op_context;
+	comp->flags = cq_entry->flags;
+	comp->len = cq_entry->len;
+	comp->buf = cq_entry->buf;
+	comp->data = cq_entry->data;
+	cirque_commit(cq->util_cq.cirq);
+	return 0;
+}
+
+static int rxd_cq_write_data_signal(struct rxd_cq *cq,
+				     struct fi_cq_tagged_entry *cq_entry)
+{
+	int ret = rxd_cq_write_data(cq, cq_entry);
+	cq->util_cq.wait->signal(cq->util_cq.wait);
+	return ret;
+}
+
+static int rxd_cq_write_tagged(struct rxd_cq *cq,
+				struct fi_cq_tagged_entry *cq_entry)
+{
+	struct fi_cq_tagged_entry *comp;
+	if (cirque_isfull(cq->util_cq.cirq))
+		return -FI_ENOSPC;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
+		"report completion: %p\n", cq_entry->tag);
+
+	comp = cirque_tail(cq->util_cq.cirq);
+	*comp = *cq_entry;
+	cirque_commit(cq->util_cq.cirq);
+	return 0;
+}
+
+static int rxd_cq_write_tagged_signal(struct rxd_cq *cq,
+				       struct fi_cq_tagged_entry *cq_entry)
+{
+	int ret = rxd_cq_write_tagged(cq, cq_entry);
+	cq->util_cq.wait->signal(cq->util_cq.wait);
+	return ret;
+}
+
+static int rxd_check_start_pkt_order(struct rxd_ep *ep, struct rxd_peer *peer,
+				      struct ofi_ctrl_hdr *ctrl,
+				      struct fi_cq_msg_entry *comp)
+{
+	uint64_t msg_id;
+	msg_id = ctrl->msg_id >> RXD_MAX_TX_BITS;
+	if (peer->exp_msg_id == msg_id)
+		return RXD_PKT_ORDR_OK;
+
+	return (peer->exp_msg_id > msg_id) ? RXD_PKT_ORDR_DUP : RXD_PKT_ORDR_UNEXP;
+}
+
+static int rxd_rx_entry_match(struct dlist_entry *item, const void *arg)
+{
+	const struct ofi_ctrl_hdr *ctrl = arg;
+	struct rxd_rx_entry *rx_entry;
+
+	rx_entry = container_of(item, struct rxd_rx_entry, entry);
+	return (rx_entry->msg_id == ctrl->msg_id && rx_entry->peer == ctrl->conn_id);
+}
+
+static void rxd_handle_dup_datastart(struct rxd_ep *ep, struct ofi_ctrl_hdr *ctrl,
+				      struct rxd_rx_buf *rx_buf)
+{
+	struct dlist_entry *item;
+	struct rxd_rx_entry *rx_entry;
+	struct rxd_peer *peer;
+
+	item = dlist_find_first_match(&ep->rx_entry_list,
+				      rxd_rx_entry_match, ctrl);
+	if (!item)
+		return;
+
+	FI_INFO(&rxd_prov, FI_LOG_EP_CTRL,
+		"duplicate start-data: msg_id: %" PRIu64 ", seg_no: %d\n",
+		ctrl->msg_id, ctrl->seg_no);
+
+	rx_entry = container_of(item, struct rxd_rx_entry, entry);
+	peer = rxd_ep_getpeer_info(ep, ctrl->conn_id);
+	rxd_ep_reply_ack(ep, ctrl, ofi_ctrl_ack, rx_entry->window, rx_entry->key,
+		       peer->conn_data, ctrl->conn_id);
+	return;
+}
+
+int rxd_handle_conn_req(struct rxd_ep *ep, struct ofi_ctrl_hdr *ctrl,
+			 struct fi_cq_msg_entry *comp,
+			 struct rxd_rx_buf *rx_buf)
+{
+	int ret;
+	void *addr;
+	size_t addrlen;
+	uint64_t peer;
+	struct rxd_pkt_data *pkt_data;
+	struct rxd_peer *peer_info;
+
+	rxd_ep_lock_if_required(ep);
+
+	pkt_data = (struct rxd_pkt_data *) ctrl;
+	addr = pkt_data->data;
+	addrlen = ctrl->seg_size;
+
+	ret = rxd_av_dg_reverse_lookup(ep->av, ctrl->rx_key, addr, addrlen, &peer);
+	if (ret == -FI_ENODATA) {
+		ret = rxd_av_insert_dg_av(ep->av, addr);
+		assert(ret == 1);
+
+		ret = rxd_av_dg_reverse_lookup(ep->av, ctrl->rx_key, addr, addrlen, &peer);
+		assert(ret == 0);
+	}
+
+	peer_info = rxd_ep_getpeer_info(ep, peer);
+	if (!peer_info->addr_published) {
+		peer_info->addr_published = 1;
+		peer_info->conn_initiated = 1;
+		peer_info->conn_data = ctrl->conn_id;
+		peer_info->exp_msg_id++;
+	}
+
+	rxd_ep_reply_ack(ep, ctrl, ofi_ctrl_connresp, 0, ctrl->conn_id, peer, peer);
+	rxd_ep_repost_buff(rx_buf);
+	rxd_ep_unlock_if_required(ep);
+	return ret;
+}
+
+int rxd_tx_pkt_match(struct dlist_entry *item, const void *arg)
+{
+	const struct ofi_ctrl_hdr *pkt_ctrl, *ack_ctrl = arg;
+	struct rxd_pkt_meta *tx_pkt;
+
+	tx_pkt = container_of(item, struct rxd_pkt_meta, entry);
+	pkt_ctrl = (struct ofi_ctrl_hdr *) tx_pkt->pkt_data;
+	return (ack_ctrl->seg_no == pkt_ctrl->seg_no) ? 1 : 0;
+}
+
+int rxd_handle_ack(struct rxd_ep *ep, struct ofi_ctrl_hdr *ctrl,
+		    struct rxd_rx_buf *rx_buf)
+{
+	int ret = 0;
+	uint64_t idx;
+	struct rxd_tx_entry *tx_entry;
+	struct dlist_entry *item;
+	struct rxd_pkt_meta *pkt;
+
+	rxd_ep_lock_if_required(ep);
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "got ack: msg: %p - %d\n",
+		ctrl->msg_id, ctrl->seg_no);
+
+	idx = ctrl->msg_id & RXD_TX_IDX_BITS;
+	tx_entry = &ep->tx_entry_fs->buf[idx];
+	if (tx_entry->msg_id != ctrl->msg_id)
+		goto out;
+
+	item = dlist_find_first_match(&tx_entry->pkt_list, rxd_tx_pkt_match, ctrl);
+	if (!item)
+		goto out;
+
+	pkt = container_of(item, struct rxd_pkt_meta, entry);
+	switch (pkt->type) {
+
+	case RXD_PKT_STRT:
+	case RXD_PKT_DATA:
+		ret = rxd_tx_entry_progress(ep, tx_entry, ctrl);
+		break;
+
+	case RXD_PKT_LAST:
+		rxd_ep_free_acked_pkts(ep, tx_entry, ctrl->seg_no);
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "reporting TX completion : %p\n", tx_entry);
+		rxd_cq_report_tx_comp(ep->tx_cq, tx_entry);
+		rxd_tx_entry_done(ep, tx_entry);
+		break;
+	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid pkt type\n");
+		break;
+	}
+out:
+	rxd_ep_repost_buff(rx_buf);
+	rxd_ep_unlock_if_required(ep);
+	return ret;
+}
+
+int rxd_handle_nack(struct rxd_ep *ep, struct ofi_ctrl_hdr *ctrl,
+		     struct rxd_rx_buf *rx_buf)
+{
+	int ret = 0;
+	uint64_t idx;
+	struct rxd_tx_entry *tx_entry;
+
+	rxd_ep_lock_if_required(ep);
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "got NACK: msg: %p - %d\n",
+		ctrl->msg_id, ctrl->seg_no);
+
+	idx = ctrl->msg_id & RXD_TX_IDX_BITS;
+	tx_entry = &ep->tx_entry_fs->buf[idx];
+	if (tx_entry->msg_id != ctrl->msg_id)
+		goto out;
+
+	ret = rxd_tx_entry_progress(ep, tx_entry, ctrl);
+out:
+	rxd_ep_repost_buff(rx_buf);
+	rxd_ep_unlock_if_required(ep);
+	return ret;
+}
+
+void rxd_handle_discard(struct rxd_ep *ep, struct ofi_ctrl_hdr *ctrl,
+			struct rxd_rx_buf *rx_buf)
+{
+	uint64_t idx;
+	struct rxd_tx_entry *tx_entry;
+
+	rxd_ep_lock_if_required(ep);
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "got Reject: msg: %p - %d\n",
+		ctrl->msg_id, ctrl->seg_no);
+
+	idx = ctrl->msg_id & RXD_TX_IDX_BITS;
+	tx_entry = &ep->tx_entry_fs->buf[idx];
+	if (tx_entry->msg_id != ctrl->msg_id)
+		goto out;
+
+	rxd_tx_entry_discard(ep, tx_entry);
+out:
+	rxd_ep_repost_buff(rx_buf);
+	rxd_ep_unlock_if_required(ep);
+}
+
+void rxd_tx_pkt_release(struct rxd_pkt_meta *pkt_meta)
+{
+	if (RXD_PKT_IS_COMPLETE(pkt_meta)) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Releasing buf: %p, num_out: %d\n",
+		       pkt_meta, pkt_meta->ep->num_out);
+		pkt_meta->ep->num_out--;
+		util_buf_release(pkt_meta->ep->tx_pkt_pool, pkt_meta);
+	}
+}
+
+void rxd_tx_entry_done(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
+{
+	struct rxd_pkt_meta *pkt_meta;
+	struct dlist_entry *item;
+
+	while (!dlist_empty(&tx_entry->pkt_list)) {
+		item = tx_entry->pkt_list.next;
+		pkt_meta = container_of(item, struct rxd_pkt_meta, entry);
+		dlist_remove(&pkt_meta->entry);
+		RXD_PKT_MARK_REMOTE_ACK(pkt_meta);
+		rxd_tx_pkt_release(pkt_meta);
+	}
+	rxd_tx_entry_release(ep, tx_entry);
+}
+
+static int rxd_conn_msg_match(struct dlist_entry *item, const void *arg)
+{
+	struct rxd_tx_entry *tx_entry;
+	struct ofi_ctrl_hdr *ctrl = (struct ofi_ctrl_hdr *) arg;
+	tx_entry = container_of(item, struct rxd_tx_entry, entry);
+	return (tx_entry->op_type == RXD_TX_CONN &&
+		tx_entry->peer == ctrl->rx_key);
+}
+
+void rxd_handle_connect_ack(struct rxd_ep *ep, struct ofi_ctrl_hdr *ctrl,
+			     struct rxd_rx_buf *rx_buf)
+{
+	struct rxd_peer *peer;
+	struct dlist_entry *match;
+	struct rxd_tx_entry *tx_entry;
+
+	rxd_ep_lock_if_required(ep);
+	match = dlist_find_first_match(&ep->tx_entry_list, rxd_conn_msg_match, ctrl);
+	if (!match)
+		goto out;
+
+	tx_entry = container_of(match, struct rxd_tx_entry, entry);
+	peer = rxd_ep_getpeer_info(ep, tx_entry->peer);
+	peer->addr_published = 1;
+	peer->conn_data = ctrl->conn_id;
+
+	dlist_remove(match);
+	rxd_tx_entry_done(ep, tx_entry);
+out:
+	rxd_ep_repost_buff(rx_buf);
+	rxd_ep_unlock_if_required(ep);
+}
+
+static inline uint16_t rxd_get_window_sz(struct rxd_ep *ep, uint64_t rem)
+{
+	uint16_t num_pkts, avail;
+
+	num_pkts = (rem +  RXD_MAX_DATA_PKT_SZ(ep) - 1) / RXD_MAX_DATA_PKT_SZ(ep);
+	avail = MIN(ep->credits, num_pkts);
+	return MIN(avail, RXD_MAX_RX_WIN);
+}
+
+struct rxd_rx_entry *rxd_get_rx_entry(struct rxd_ep *ep)
+{
+	struct rxd_rx_entry *rx_entry;
+	if (freestack_isempty(ep->rx_entry_fs))
+		return NULL;
+
+	rx_entry = freestack_pop(ep->rx_entry_fs);
+	rx_entry->key = rx_entry - &ep->rx_entry_fs->buf[0];
+	dlist_init(&rx_entry->entry);
+	dlist_init(&rx_entry->wait_entry);
+	dlist_insert_tail(&rx_entry->entry, &ep->rx_entry_list);
+	return rx_entry;
+}
+
+static void rxd_progress_wait_rx(struct rxd_ep *ep, struct rxd_rx_entry *rx_entry)
+{
+	struct ofi_ctrl_hdr ctrl;
+
+	rx_entry->window = rxd_get_window_sz(ep, rx_entry->op_hdr.size - rx_entry->done);
+
+	if (!rx_entry->window)
+		return;
+
+	rx_entry->last_win_seg += rx_entry->window;
+	dlist_remove(&rx_entry->wait_entry);
+
+	ep->credits -= rx_entry->window;
+
+	ctrl.msg_id = rx_entry->msg_id;
+	ctrl.seg_no = rx_entry->exp_seg_no - 1;
+	ctrl.conn_id = rx_entry->peer;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "rx-entry wait over [%p], window: %d\n",
+		rx_entry->msg_id, rx_entry->window);
+	rxd_ep_reply_ack(ep, &ctrl, ofi_ctrl_ack, rx_entry->window,
+		       rx_entry->key, rx_entry->peer_info->conn_data,
+		       ctrl.conn_id);
+}
+
+static void rxd_check_waiting_rx(struct rxd_ep *ep)
+{
+	struct dlist_entry *entry;
+	struct rxd_rx_entry *rx_entry;
+
+	if (!ep->credits)
+		return;
+
+	while(!dlist_empty(&ep->wait_rx_list) && ep->credits) {
+		entry = ep->wait_rx_list.next;
+		rx_entry = container_of(entry, struct rxd_rx_entry, wait_entry);
+		rxd_progress_wait_rx(ep, rx_entry);
+	}
+}
+
+void rxd_rx_entry_release(struct rxd_ep *ep, struct rxd_rx_entry *rx_entry)
+{
+	rx_entry->key = -1;
+	dlist_remove(&rx_entry->entry);
+	freestack_push(ep->rx_entry_fs, rx_entry);
+
+	if (ep->credits && !dlist_empty(&ep->wait_rx_list))
+		rxd_check_waiting_rx(ep);
+}
+
+static int rxd_match_recv_entry(struct dlist_entry *item, const void *arg)
+{
+	fi_addr_t addr = (fi_addr_t) arg;
+	struct rxd_recv_entry *recv_entry;
+	recv_entry = container_of(item, struct rxd_recv_entry, entry);
+	return (recv_entry->msg.addr == FI_ADDR_UNSPEC ||
+		addr == FI_ADDR_UNSPEC || recv_entry->msg.addr == addr);
+}
+
+struct rxd_recv_entry *rxd_get_recv_entry(struct rxd_ep *ep, fi_addr_t addr)
+{
+	struct dlist_entry *match;
+	struct rxd_recv_entry *recv_entry;
+
+	match = dlist_find_first_match(&ep->recv_list, &rxd_match_recv_entry,
+				       (void *)addr);
+	if (!match) {
+		/*todo: queue the pkt */
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "no matching recv entry\n");
+		return NULL;
+	}
+
+	dlist_remove(match);
+	recv_entry = container_of(match, struct rxd_recv_entry, entry);
+	return recv_entry;
+}
+
+static int rxd_match_trecv_entry(struct dlist_entry *item, const void *arg)
+{
+	struct rxd_rx_entry *rx_entry = (struct rxd_rx_entry *) arg;
+	struct rxd_trecv_entry *trecv_entry;
+
+	trecv_entry = container_of(item, struct rxd_trecv_entry, entry);
+	return ((trecv_entry->msg.tag | trecv_entry->msg.ignore) ==
+		(rx_entry->op_hdr.tag | trecv_entry->msg.ignore) &&
+                ((trecv_entry->msg.addr == FI_ADDR_UNSPEC) ||
+		 (rx_entry->source == FI_ADDR_UNSPEC) ||
+                 (trecv_entry->msg.addr == rx_entry->source)));
+	return 0;
+}
+
+struct rxd_trecv_entry *rxd_get_trecv_entry(struct rxd_ep *ep,
+					      struct rxd_rx_entry *rx_entry)
+{
+	struct dlist_entry *match;
+	struct rxd_trecv_entry *trecv_entry;
+
+	match = dlist_find_first_match(&ep->trecv_list, &rxd_match_trecv_entry,
+				       (void *)rx_entry);
+	if (!match) {
+		/*todo: queue the pkt */
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "no matching trecv entry, tag: %p\n",
+			rx_entry->op_hdr.tag);
+		return NULL;
+	}
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "matched - tag: %p\n", rx_entry->op_hdr.tag);
+
+	dlist_remove(match);
+	trecv_entry = container_of(match, struct rxd_trecv_entry, entry);
+	trecv_entry->rx_entry = rx_entry;
+	return trecv_entry;
+}
+
+void rxd_report_rx_comp(struct rxd_cq *cq, struct rxd_rx_entry *rx_entry)
+{
+	struct fi_cq_tagged_entry cq_entry = {0};
+
+	/* todo: handle FI_COMPLETION */
+	if (rx_entry->op_hdr.flags & OFI_REMOTE_CQ_DATA)
+		cq_entry.flags |= FI_REMOTE_CQ_DATA;
+
+	switch(rx_entry->op_hdr.op) {
+	case ofi_op_msg:
+		cq_entry.flags |= FI_RECV;
+		cq_entry.op_context = rx_entry->recv->msg.context;
+		cq_entry.len = rx_entry->done;
+		cq_entry.buf = rx_entry->recv->iov[0].iov_base;
+		cq_entry.data = rx_entry->op_hdr.data;
+		break;
+
+	case ofi_op_tagged:
+		cq_entry.flags |= (FI_RECV | FI_TAGGED);
+		cq_entry.op_context = rx_entry->trecv->msg.context;
+		cq_entry.len = rx_entry->done;
+		cq_entry.buf = rx_entry->trecv->iov[0].iov_base;
+		cq_entry.data = rx_entry->op_hdr.data;
+		cq_entry.tag = rx_entry->trecv->msg.tag;
+		break;
+
+	case ofi_op_read:
+		cq_entry.flags |= (FI_RMA | FI_REMOTE_READ);
+		break;
+
+	case ofi_op_write:
+		cq_entry.flags |= (FI_RMA | FI_REMOTE_WRITE);
+		break;
+
+	case ofi_op_atomic:
+		cq_entry.flags |= FI_ATOMIC;
+		break;
+
+	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op type\n");
+		break;
+	}
+
+	cq->write_fn(cq, &cq_entry);
+}
+
+void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry)
+{
+	struct fi_cq_tagged_entry cq_entry = {0};
+	struct util_cq_err_entry *entry = calloc(1, sizeof(*entry));
+	if (!entry) {
+		FI_WARN(&rxd_prov, FI_LOG_CQ,
+			"out of memory, cannot report CQ error\n");
+		return;
+	}
+
+	entry->err_entry = *err_entry;
+	slist_insert_tail(&entry->list_entry, &cq->util_cq.err_list);
+	cq_entry.flags = UTIL_FLAG_ERROR;
+	cq->write_fn(cq, &cq_entry);
+}
+
+void rxd_cq_report_tx_comp(struct rxd_cq *cq, struct rxd_tx_entry *tx_entry)
+{
+	struct fi_cq_tagged_entry cq_entry = {0};
+
+	/* todo: handle FI_COMPLETION */
+	switch(tx_entry->op_type) {
+	case RXD_TX_MSG:
+		cq_entry.flags = (FI_TRANSMIT | FI_MSG);
+		cq_entry.op_context = tx_entry->msg.msg.context;
+		cq_entry.len = tx_entry->op_hdr.size;
+		cq_entry.buf = tx_entry->msg.msg_iov[0].iov_base;
+		cq_entry.data = tx_entry->op_hdr.data;
+		break;
+
+	case RXD_TX_TAG:
+		cq_entry.flags = (FI_TRANSMIT | FI_TAGGED);
+		cq_entry.op_context = tx_entry->tmsg.tmsg.context;
+		cq_entry.len = tx_entry->op_hdr.size;
+		cq_entry.buf = tx_entry->tmsg.msg_iov[0].iov_base;
+		cq_entry.data = tx_entry->op_hdr.data;
+		cq_entry.tag = tx_entry->tmsg.tmsg.tag;
+		break;
+
+	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op type\n");
+		return;
+	}
+
+	cq->write_fn(cq, &cq_entry);
+}
+
+void rxd_ep_handle_data_msg(struct rxd_ep *ep, struct rxd_peer *peer,
+			   struct rxd_rx_entry *rx_entry,
+			   struct iovec *iov, size_t iov_count,
+			   struct ofi_ctrl_hdr *ctrl, void *data,
+			   struct rxd_rx_buf *rx_buf)
+{
+
+	uint64_t done;
+
+	ep->credits++;
+	done = rxd_ep_copy_iov_buf(iov, iov_count, data, ctrl->seg_size,
+				   rx_entry->done, RXD_COPY_BUF_TO_IOV);
+	rx_entry->done += done;
+	rx_entry->window--;
+	rx_entry->exp_seg_no++;
+
+	if (done != ctrl->seg_size) {
+		/* todo: generate truncation error */
+		/* inform peer */
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "TODO: message truncated\n");
+	}
+
+	if (rx_entry->window == 0) {
+		rx_entry->window = rxd_get_window_sz(ep, rx_entry->op_hdr.size - rx_entry->done);
+
+		rx_entry->last_win_seg += rx_entry->window;
+		ep->credits -= rx_entry->window;
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "replying ack [%p] - %d\n",
+			ctrl->msg_id, ctrl->seg_no);
+
+		rxd_ep_reply_ack(ep, ctrl, ofi_ctrl_ack, rx_entry->window,
+			       rx_entry->key, peer->conn_data, ctrl->conn_id);
+	}
+
+	if (rx_entry->op_hdr.size != rx_entry->done) {
+		if (rx_entry->window == 0) {
+			dlist_init(&rx_entry->wait_entry);
+			dlist_insert_tail(&rx_entry->wait_entry, &ep->wait_rx_list);
+			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "rx-entry %p - %d enqueued\n",
+				ctrl->msg_id, ctrl->seg_no);
+		} else {
+			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
+				"rx_entry->op_hdr.size: %d, rx_entry->done: %d\n",
+				rx_entry->op_hdr.size, rx_entry->done);
+		}
+		return;
+	}
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "reporting RX completion event\n");
+	rxd_report_rx_comp(ep->rx_cq, rx_entry);
+	if (rx_entry->op_hdr.op == ofi_op_msg) {
+		freestack_push(ep->recv_fs, rx_entry->recv);
+	} else {
+		freestack_push(ep->trecv_fs, rx_entry->trecv);
+	}
+	rxd_rx_entry_release(ep, rx_entry);
+}
+
+static int rxd_check_data_pkt_order(struct rxd_ep *ep,
+				     struct rxd_peer *peer,
+				     struct ofi_ctrl_hdr *ctrl,
+				     struct rxd_rx_entry *rx_entry)
+{
+	if (rx_entry->msg_id != ctrl->msg_id)
+		return RXD_PKT_ORDR_DUP;
+
+	if (rx_entry->exp_seg_no == ctrl->seg_no)
+		return RXD_PKT_ORDR_OK;
+
+	return (rx_entry->exp_seg_no > ctrl->seg_no) ?
+		RXD_PKT_ORDR_DUP : RXD_PKT_ORDR_UNEXP;
+}
+
+static inline void rxd_ep_enqueue_pkt(struct rxd_ep *ep, struct ofi_ctrl_hdr *ctrl,
+				       struct fi_cq_msg_entry *comp)
+{
+	struct rxd_unexp_cq_entry *unexp;
+	if (comp->flags & RXD_UNEXP_ENTRY ||
+	    ep->num_unexp_pkt > RXD_EP_MAX_UNEXP_PKT)
+		return;
+
+	unexp = util_buf_alloc(ep->rx_cq->unexp_pool);
+	assert(unexp);
+	unexp->cq_entry = *comp;
+	unexp->cq_entry.flags |= RXD_UNEXP_ENTRY;
+
+	dlist_init(&unexp->entry);
+	dlist_insert_tail(&ep->rx_cq->unexp_list, &unexp->entry);
+	FI_INFO(&rxd_prov, FI_LOG_EP_CTRL,
+		"enqueuing unordered pkt: %p, seg_no: %d\n",
+		ctrl->msg_id, ctrl->seg_no);
+	ep->num_unexp_pkt++;
+}
+
+static inline void rxd_release_unexp_entry(struct rxd_cq *cq,
+					    struct fi_cq_msg_entry *comp)
+{
+	struct rxd_unexp_cq_entry *unexp;
+	unexp = container_of(comp, struct rxd_unexp_cq_entry, cq_entry);
+	dlist_remove(&unexp->entry);
+	util_buf_release(cq->unexp_pool, unexp);
+}
+
+
+static int rxd_match_unexp_msg(struct dlist_entry *item, const void *arg)
+{
+	const struct rxd_recv_entry *recv_entry = arg;
+	struct rxd_rx_entry *rx_entry;
+
+	rx_entry = container_of(item, struct rxd_rx_entry, unexp_entry);
+	return (recv_entry->msg.addr == FI_ADDR_UNSPEC ||
+		rx_entry->source == FI_ADDR_UNSPEC ||
+		rx_entry->source == recv_entry->msg.addr);
+}
+
+void rxd_ep_check_unexp_msg_list(struct rxd_ep *ep, struct rxd_recv_entry *recv_entry)
+{
+	struct dlist_entry *match;
+	struct rxd_rx_entry *rx_entry;
+	struct rxd_pkt_data_start *pkt_start;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "ep->num_unexp_msg: %d\n", ep->num_unexp_msg);
+	match = dlist_remove_first_match(&ep->unexp_msg_list, &rxd_match_unexp_msg,
+					 (void *) recv_entry);
+	if (match) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "progressing unexp msg entry\n");
+		dlist_remove(&recv_entry->entry);
+		ep->num_unexp_msg--;
+
+		rx_entry = container_of(match, struct rxd_rx_entry, unexp_entry);
+		rx_entry->recv = recv_entry;
+
+		pkt_start = (struct rxd_pkt_data_start *) rx_entry->unexp_buf->buf;
+		rxd_ep_handle_data_msg(ep, rx_entry->peer_info, rx_entry, rx_entry->recv->iov,
+				     rx_entry->recv->msg.iov_count, &pkt_start->ctrl,
+				     pkt_start->data, rx_entry->unexp_buf);
+		rxd_ep_repost_buff(rx_entry->unexp_buf);
+	}
+}
+
+static int rxd_match_unexp_tag(struct dlist_entry *item, const void *arg)
+{
+	const struct rxd_trecv_entry *trecv_entry = arg;
+	struct rxd_rx_entry *rx_entry;
+
+	rx_entry = container_of(item, struct rxd_rx_entry, unexp_entry);
+	return ((trecv_entry->msg.tag | trecv_entry->msg.ignore) ==
+		(rx_entry->op_hdr.tag | trecv_entry->msg.ignore) &&
+		((trecv_entry->msg.addr == FI_ADDR_UNSPEC) ||
+		 (rx_entry->source == FI_ADDR_UNSPEC) ||
+		 (trecv_entry->msg.addr == rx_entry->source)));
+}
+
+void rxd_ep_check_unexp_tag_list(struct rxd_ep *ep, struct rxd_trecv_entry *trecv_entry)
+{
+	struct dlist_entry *match;
+	struct rxd_rx_entry *rx_entry;
+	struct rxd_pkt_data_start *pkt_start;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "ep->num_unexp_msg: %d\n", ep->num_unexp_msg);
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "ep->num_unexp_pkt: %d\n", ep->num_unexp_pkt);
+	match = dlist_find_first_match(&ep->unexp_tag_list, &rxd_match_unexp_tag,
+				       (void *) trecv_entry);
+	if (match) {
+		dlist_remove(match);
+		dlist_remove(&trecv_entry->entry);
+		ep->num_unexp_msg--;
+
+		rx_entry = container_of(match, struct rxd_rx_entry, unexp_entry);
+		rx_entry->trecv = trecv_entry;
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "progressing unexp tagged recv [%p]\n",
+			rx_entry->msg_id);
+
+		pkt_start = (struct rxd_pkt_data_start *) rx_entry->unexp_buf->buf;
+		rxd_ep_handle_data_msg(ep, rx_entry->peer_info, rx_entry, rx_entry->trecv->iov,
+				     rx_entry->trecv->msg.iov_count, &pkt_start->ctrl,
+				     pkt_start->data, rx_entry->unexp_buf);
+		rxd_ep_repost_buff(rx_entry->unexp_buf);
+	}
+}
+
+void rxd_handle_data(struct rxd_ep *ep, struct rxd_peer *peer,
+		      struct ofi_ctrl_hdr *ctrl, struct fi_cq_msg_entry *comp,
+		      struct rxd_rx_buf *rx_buf)
+{
+	int ret;
+	struct rxd_rx_entry *rx_entry;
+	struct rxd_pkt_data *pkt_data = (struct rxd_pkt_data *) ctrl;
+	uint16_t win_sz;
+	uint64_t curr_stamp;
+
+	rxd_ep_lock_if_required(ep);
+	rx_entry = &ep->rx_entry_fs->buf[ctrl->rx_key];
+
+	ret = rxd_check_data_pkt_order(ep, peer, ctrl, rx_entry);
+	if (ret == RXD_PKT_ORDR_DUP) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
+			"duplicate pkt: %d expected:%d, rx-key:%d, ctrl_msg_id: %p\n",
+			ctrl->seg_no, rx_entry->exp_seg_no, ctrl->rx_key, ctrl->msg_id);
+
+		win_sz = (rx_entry->msg_id == ctrl->msg_id &&
+			  rx_entry->last_win_seg == ctrl->seg_no) ? rx_entry->window : 0;
+		rxd_ep_reply_ack(ep, ctrl, ofi_ctrl_ack, win_sz,
+			       ctrl->rx_key, peer->conn_data, ctrl->conn_id);
+
+		goto repost;
+	} else if (ret == RXD_PKT_ORDR_UNEXP) {
+		if (!(comp->flags & RXD_UNEXP_ENTRY)) {
+			curr_stamp = fi_gettime_us();
+			if (rx_entry->nack_stamp == 0 ||
+			    (curr_stamp > rx_entry->nack_stamp &&
+			     curr_stamp - rx_entry->nack_stamp > RXD_RETRY_TIMEOUT)) {
+
+				FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
+				       "unexpected pkt, sending NACK: %d\n", ctrl->seg_no);
+
+				rx_entry->nack_stamp = curr_stamp;
+				rxd_ep_reply_nack(ep, ctrl, rx_entry->exp_seg_no,
+						ctrl->rx_key, peer->conn_data,
+						ctrl->conn_id);
+			}
+			rxd_ep_enqueue_pkt(ep, ctrl, comp);
+		}
+		goto out;
+	}
+
+	rx_entry->nack_stamp = 0;
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "expected pkt: %d\n", ctrl->seg_no);
+	switch (rx_entry->op_hdr.op) {
+	case ofi_op_msg:
+		rxd_ep_handle_data_msg(ep, peer, rx_entry, rx_entry->recv->iov,
+				     rx_entry->recv->msg.iov_count, ctrl,
+				     pkt_data->data, rx_buf);
+		break;
+
+	case ofi_op_tagged:
+		rxd_ep_handle_data_msg(ep, peer, rx_entry, rx_entry->trecv->iov,
+				     rx_entry->trecv->msg.iov_count, ctrl,
+				     pkt_data->data, rx_buf);
+		break;
+
+	case ofi_op_read:
+	case ofi_op_write:
+	case ofi_op_atomic:
+	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op type\n");
+	}
+
+repost:
+	if (comp->flags & RXD_UNEXP_ENTRY) {
+		rxd_release_unexp_entry(ep->rx_cq, comp);
+		ep->num_unexp_pkt--;
+	}
+
+	rxd_ep_repost_buff(rx_buf);
+out:
+	rxd_ep_unlock_if_required(ep);
+}
+
+int rxd_process_start_data(struct rxd_ep *ep, struct rxd_rx_entry *rx_entry,
+			    struct rxd_peer *peer, struct ofi_ctrl_hdr *ctrl,
+			    struct fi_cq_msg_entry *comp,
+			    struct rxd_rx_buf *rx_buf)
+{
+	struct rxd_pkt_data_start *pkt_start;
+	pkt_start = (struct rxd_pkt_data_start *) ctrl;
+
+	switch (rx_entry->op_hdr.op) {
+	case ofi_op_msg:
+		rx_entry->recv = rxd_get_recv_entry(ep, rx_entry->source);
+		if (!rx_entry->recv) {
+			if (ep->num_unexp_msg < RXD_EP_MAX_UNEXP_MSG) {
+				dlist_insert_tail(&rx_entry->unexp_entry, &ep->unexp_msg_list);
+				rx_entry->unexp_buf = rx_buf;
+				ep->num_unexp_msg++;
+				return -FI_ENOENT;
+			} else {
+				FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "dropping msg\n");
+				return -FI_ENOMEM;
+			}
+		}
+
+		rxd_ep_handle_data_msg(ep, peer, rx_entry, rx_entry->recv->iov,
+				     rx_entry->recv->msg.iov_count, ctrl,
+				     pkt_start->data, rx_buf);
+		break;
+
+	case ofi_op_tagged:
+		rx_entry->trecv = rxd_get_trecv_entry(ep, rx_entry);
+		if (!rx_entry->trecv) {
+			if (ep->num_unexp_msg < RXD_EP_MAX_UNEXP_MSG) {
+				dlist_insert_tail(&rx_entry->unexp_entry, &ep->unexp_tag_list);
+				rx_entry->unexp_buf = rx_buf;
+				ep->num_unexp_msg++;
+				return -FI_ENOENT;
+			} else {
+				FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "dropping msg\n");
+				return -FI_ENOMEM;
+			}
+		}
+
+		rxd_ep_handle_data_msg(ep, peer, rx_entry, rx_entry->trecv->iov,
+				     rx_entry->trecv->msg.iov_count, ctrl,
+				     pkt_start->data, rx_buf);
+		break;
+
+	case ofi_op_read:
+	case ofi_op_write:
+	case ofi_op_atomic:
+	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "invalid op type\n");
+		return -FI_EINVAL;
+	}
+	return 0;
+}
+
+void rxd_handle_start_data(struct rxd_ep *ep, struct rxd_peer *peer,
+			    struct ofi_ctrl_hdr *ctrl,
+			    struct fi_cq_msg_entry *comp,
+			    struct rxd_rx_buf *rx_buf)
+{
+	int ret;
+	struct rxd_rx_entry *rx_entry;
+	struct rxd_pkt_data_start *pkt_start;
+	pkt_start = (struct rxd_pkt_data_start *) ctrl;
+
+	rxd_ep_lock_if_required(ep);
+	if (pkt_start->op.version != OFI_OP_VERSION) {
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "op version mismatch\n");
+		goto repost;
+	}
+
+	ret = rxd_check_start_pkt_order(ep, peer, ctrl, comp);
+	if (ret == RXD_PKT_ORDR_DUP) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "duplicate pkt: %d\n", ctrl->seg_no);
+		rxd_handle_dup_datastart(ep, ctrl, rx_buf);
+		goto repost;
+	} else if (ret == RXD_PKT_ORDR_UNEXP) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "unexpected pkt: %d\n", ctrl->seg_no);
+		rxd_ep_enqueue_pkt(ep, ctrl, comp);
+		goto out;
+	}
+
+	rx_entry = rxd_get_rx_entry(ep);
+	if (!rx_entry)
+		goto repost;
+
+	rx_entry->peer_info = peer;
+	rx_entry->op_hdr = pkt_start->op;
+	rx_entry->exp_seg_no = 0;
+	rx_entry->msg_id = ctrl->msg_id;
+	rx_entry->done = 0;
+	rx_entry->peer = ctrl->conn_id;
+	rx_entry->source = (ep->caps & FI_DIRECTED_RECV) ?
+		rxd_av_get_fi_addr(ep->av, ctrl->conn_id) : FI_ADDR_UNSPEC;
+	rx_entry->window = 1;
+	rx_entry->last_win_seg = 1;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Assign rx_entry :%d for  %p\n",
+	       rx_entry->key, rx_entry->msg_id);
+
+	ep->credits--;
+	ret = rxd_process_start_data(ep, rx_entry, peer, ctrl, comp, rx_buf);
+	if (ret == -FI_ENOMEM)
+		rxd_rx_entry_release(ep, rx_entry);
+	else if (ret == -FI_ENOENT) {
+		peer->exp_msg_id++;
+
+		/* reply ack, with win_sz = 0 */
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Sending wait-ACK [%p] - %d\n",
+			ctrl->msg_id, ctrl->seg_no);
+		goto out;
+	} else {
+		peer->exp_msg_id++;
+	}
+
+repost:
+	if (comp->flags & RXD_UNEXP_ENTRY) {
+		rxd_release_unexp_entry(ep->rx_cq, comp);
+		ep->num_unexp_pkt--;
+	}
+	rxd_ep_repost_buff(rx_buf);
+out:
+	rxd_ep_unlock_if_required(ep);
+	return;
+}
+
+void rxd_handle_recv_comp(struct rxd_cq *cq, struct fi_cq_msg_entry *comp,
+			   int is_unexpected)
+{
+	struct rxd_ep *ep;
+	struct ofi_ctrl_hdr *ctrl;
+	struct rxd_rx_buf *rx_buf;
+	struct rxd_peer *peer;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "got recv completion\n");
+
+	rx_buf = container_of(comp->op_context, struct rxd_rx_buf, context);
+	ctrl = (struct ofi_ctrl_hdr *) rx_buf->buf;
+	ep = rx_buf->ep;
+	peer = rxd_ep_getpeer_info(ep, ctrl->conn_id);
+
+	if (ctrl->type != ofi_ctrl_ack && ctrl->type != ofi_ctrl_nack) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
+		       "got data pkt - msg_id:[%p - %d], type: %d on buf %p [unexp: %d]\n",
+		       ctrl->msg_id, ctrl->seg_no, ctrl->type, rx_buf, is_unexpected);
+	} else {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
+		       "got ack pkt - msg_id:[%p - %d], type: %d on buf %p  [unexp: %d]\n",
+		       ctrl->msg_id, ctrl->seg_no, ctrl->type, rx_buf, is_unexpected);
+	}
+	if (ctrl->version != OFI_CTRL_VERSION) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "ctrl version mismatch\n");
+		return;
+	}
+
+	switch(ctrl->type) {
+	case ofi_ctrl_connreq:
+		rxd_handle_conn_req(ep, ctrl, comp, rx_buf);
+		break;
+
+	case ofi_ctrl_ack:
+		rxd_handle_ack(ep, ctrl, rx_buf);
+		break;
+
+	case ofi_ctrl_nack:
+		rxd_handle_nack(ep, ctrl, rx_buf);
+		break;
+
+	case ofi_ctrl_discard:
+		rxd_handle_discard(ep, ctrl, rx_buf);
+		break;
+
+	case ofi_ctrl_connresp:
+		rxd_handle_connect_ack(ep, ctrl, rx_buf);
+		break;
+
+	case ofi_ctrl_start_data:
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
+		       "start data msg for tx: %p\n", ctrl->msg_id);
+		rxd_handle_start_data(ep, peer, ctrl, comp, rx_buf);
+		break;
+
+	case ofi_ctrl_data:
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
+			"data msg for tx: %p, %d \n", ctrl->msg_id, ctrl->seg_no);
+		rxd_handle_data(ep, peer, ctrl, comp, rx_buf);
+		break;
+
+	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
+			"invalid ctrl type \n", ctrl->type);
+	}
+
+	rxd_ep_lock_if_required(ep);
+	rxd_check_waiting_rx(ep);
+	rxd_ep_unlock_if_required(ep);
+	return;
+}
+
+static inline void rxd_handle_send_comp(struct fi_cq_msg_entry *comp)
+{
+	struct rxd_pkt_meta *pkt_meta;
+	pkt_meta = container_of(comp->op_context, struct rxd_pkt_meta, context);
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Send completion for: %p\n", pkt_meta);
+	rxd_ep_lock_if_required(pkt_meta->ep);
+	RXD_PKT_MARK_LOCAL_ACK(pkt_meta);
+	rxd_tx_pkt_release(pkt_meta);
+	rxd_ep_unlock_if_required(pkt_meta->ep);
+}
+
+void rxd_cq_progress(struct util_cq *util_cq)
+{
+	ssize_t ret = 0;
+	struct rxd_cq *cq;
+	struct fi_cq_msg_entry cq_entry;
+	struct dlist_entry *item, *next;
+	struct rxd_unexp_cq_entry *unexp;
+
+	cq = container_of(util_cq, struct rxd_cq, util_cq);
+	fastlock_acquire(&cq->lock);
+
+	do {
+		ret = fi_cq_read(cq->dg_cq, &cq_entry, 1);
+		if (ret == -FI_EAGAIN)
+			break;
+
+		if (cq_entry.flags & FI_SEND) {
+			rxd_handle_send_comp(&cq_entry);
+		} else if (cq_entry.flags & FI_RECV) {
+			rxd_handle_recv_comp(cq, &cq_entry, 0);
+		} else
+			assert (0);
+	} while (ret > 0);
+
+	for (item = cq->unexp_list.next; item != &cq->unexp_list;) {
+		unexp = container_of(item, struct rxd_unexp_cq_entry, entry);
+		next = item->next;
+		rxd_handle_recv_comp(cq, &unexp->cq_entry, 1);
+		item = next;
+	}
+
+	fastlock_release(&cq->lock);
+}
+
+static int rxd_cq_close(struct fid *fid)
+{
+	int ret;
+	struct rxd_cq *cq;
+
+	cq = container_of(fid, struct rxd_cq, util_cq.cq_fid.fid);
+
+	fastlock_acquire(&cq->domain->lock);
+	dlist_remove(&cq->dom_entry);
+	fastlock_release(&cq->domain->lock);
+	fastlock_destroy(&cq->lock);
+
+	ret = fi_close(&cq->dg_cq->fid);
+	if (ret)
+		return ret;
+
+	ret = ofi_cq_cleanup(&cq->util_cq);
+	if (ret)
+		return ret;
+
+	free(cq);
+	return 0;
+}
+
+static struct fi_ops rxd_cq_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = rxd_cq_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+int rxd_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+		 struct fid_cq **cq_fid, void *context)
+{
+	int ret;
+	struct rxd_cq *cq;
+	struct rxd_domain *rxd_domain;
+
+	cq = calloc(1, sizeof(*cq));
+	if (!cq)
+		return -FI_ENOMEM;
+
+	ret = ofi_cq_init(&rxd_prov, domain, attr, &cq->util_cq,
+			  &rxd_cq_progress, context);
+	if (ret)
+		goto err1;
+
+	switch (attr->format) {
+	case FI_CQ_FORMAT_UNSPEC:
+	case FI_CQ_FORMAT_CONTEXT:
+		cq->write_fn = cq->util_cq.wait ?
+			rxd_cq_write_ctx_signal : rxd_cq_write_ctx;
+		break;
+	case FI_CQ_FORMAT_MSG:
+		cq->write_fn = cq->util_cq.wait ?
+			rxd_cq_write_msg_signal : rxd_cq_write_msg;
+		break;
+	case FI_CQ_FORMAT_DATA:
+		cq->write_fn = cq->util_cq.wait ?
+			rxd_cq_write_data_signal : rxd_cq_write_data;
+		break;
+	case FI_CQ_FORMAT_TAGGED:
+		cq->write_fn = cq->util_cq.wait ?
+			rxd_cq_write_tagged_signal : rxd_cq_write_tagged;
+		break;
+	default:
+		ret = -FI_EINVAL;
+		goto err2;
+	}
+
+	rxd_domain = container_of(domain, struct rxd_domain, util_domain.domain_fid);
+	attr->format = FI_CQ_FORMAT_MSG;
+	ret = fi_cq_open(rxd_domain->dg_domain, attr, &cq->dg_cq, context);
+	if (ret)
+		goto err2;
+
+	cq->unexp_pool = util_buf_pool_create(
+		RXD_EP_MAX_UNEXP_PKT * sizeof (struct rxd_unexp_cq_entry),
+		RXD_BUF_POOL_ALIGNMENT, 0, RXD_EP_MAX_UNEXP_PKT);
+	if (!cq->unexp_pool) {
+		ret = -FI_ENOMEM;
+		goto err3;
+	}
+
+	dlist_init(&cq->dom_entry);
+	dlist_init(&cq->unexp_list);
+	fastlock_init(&cq->lock);
+
+	fastlock_acquire(&rxd_domain->lock);
+	dlist_insert_tail(&cq->dom_entry, &rxd_domain->cq_list);
+	fastlock_release(&rxd_domain->lock);
+
+	*cq_fid = &cq->util_cq.cq_fid;
+	(*cq_fid)->fid.ops = &rxd_cq_fi_ops;
+	*cq_fid = &cq->util_cq.cq_fid;
+	cq->domain = rxd_domain;
+	return 0;
+
+err3:
+	ofi_cq_cleanup(&cq->util_cq);
+err2:
+	fi_close(&cq->dg_cq->fid);
+err1:
+	free(cq);
+	return ret;
+}

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -40,8 +40,8 @@
 static struct fi_ops_domain rxd_domain_ops = {
 	.size = sizeof(struct fi_ops_domain),
 	.av_open = rxd_av_create,
-	.cq_open = fi_no_cq_open,
-	.endpoint = fi_no_endpoint,
+	.cq_open = rxd_cq_open,
+	.endpoint = rxd_endpoint,
 	.scalable_ep = fi_no_scalable_ep,
 	.cntr_open = fi_no_cntr_open,
 	.poll_open = fi_poll_create,
@@ -78,18 +78,6 @@ static struct fi_ops rxd_domain_fi_ops = {
 	.control = fi_no_control,
 	.ops_open = fi_no_ops_open,
 };
-
-void rxd_cq_progress(struct util_cq *util_cq)
-{
-	/* place-holder */
-	return;
-}
-
-void rxd_ep_progress(struct rxd_ep *ep)
-{
-	/* place-holder */
-	return;
-}
 
 void *rxd_progress(void *arg)
 {

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -39,7 +39,7 @@
 
 static struct fi_ops_domain rxd_domain_ops = {
 	.size = sizeof(struct fi_ops_domain),
-	.av_open = fi_no_av_open,
+	.av_open = rxd_av_create,
 	.cq_open = fi_no_cq_open,
 	.endpoint = fi_no_endpoint,
 	.scalable_ep = fi_no_scalable_ep,

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1,0 +1,1772 @@
+/*
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <fi_mem.h>
+#include "rxd.h"
+
+static ssize_t	rxd_ep_cancel(fid_t fid, void *context)
+{
+	struct rxd_ep *ep;
+	struct dlist_entry *entry, *next;
+	struct rxd_recv_entry *recv_entry;
+	struct rxd_trecv_entry *trecv_entry;
+	struct fi_cq_err_entry err_entry = {0};
+
+	ep = container_of(fid, struct rxd_ep, ep.fid);
+	rxd_ep_lock_if_required(ep);
+	for (entry = ep->recv_list.next; entry != &ep->recv_list; entry = next) {
+		next = entry->next;
+		recv_entry = container_of(entry, struct rxd_recv_entry, entry);
+		if (recv_entry->msg.context != context)
+			continue;
+
+		dlist_remove(entry);
+		err_entry.op_context = recv_entry->msg.context;
+		err_entry.flags = (FI_MSG | FI_RECV);
+		err_entry.err = FI_ECANCELED;
+		err_entry.prov_errno = -FI_ECANCELED;
+		rxd_cq_report_error(ep->rx_cq, &err_entry);
+		goto out;
+	}
+
+	for (entry = ep->trecv_list.next; entry != &ep->trecv_list; entry = next) {
+		next = entry->next;
+		trecv_entry = container_of(entry, struct rxd_trecv_entry, entry);
+		if (trecv_entry->msg.context != context)
+			continue;
+
+		dlist_remove(entry);
+		err_entry.op_context = trecv_entry->msg.context;
+		err_entry.flags = (FI_MSG | FI_RECV | FI_TAGGED);
+		err_entry.tag = trecv_entry->msg.tag;
+		err_entry.err = FI_ECANCELED;
+		err_entry.prov_errno = -FI_ECANCELED;
+		rxd_cq_report_error(ep->rx_cq, &err_entry);
+		goto out;
+	}
+
+out:
+	rxd_ep_unlock_if_required(ep);
+	return 0;
+}
+
+static int rxd_ep_getopt(fid_t fid, int level, int optname,
+		   void *optval, size_t *optlen)
+{
+	return -FI_ENOSYS;
+}
+
+static int rxd_ep_setopt(fid_t fid, int level, int optname,
+		   const void *optval, size_t optlen)
+{
+	return -FI_ENOSYS;
+}
+
+struct fi_ops_ep rxd_ops_ep = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = rxd_ep_cancel,
+	.getopt = rxd_ep_getopt,
+	.setopt = rxd_ep_setopt,
+	.tx_ctx = fi_no_tx_ctx,
+	.rx_ctx = fi_no_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
+};
+
+static ssize_t rxd_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
+			       uint64_t flags)
+{
+	ssize_t ret = 0, i;
+	struct rxd_ep *rxd_ep;
+	struct rxd_recv_entry *recv_entry;
+
+	rxd_ep = container_of(ep, struct rxd_ep, ep);
+
+	rxd_ep_lock_if_required(rxd_ep);
+	if (freestack_isempty(rxd_ep->recv_fs)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	recv_entry = freestack_pop(rxd_ep->recv_fs);
+	recv_entry->msg = *msg;
+	recv_entry->flags = flags;
+	recv_entry->msg.addr = (rxd_ep->caps & FI_DIRECTED_RECV) ?
+		recv_entry->msg.addr : FI_ADDR_UNSPEC;
+	for (i = 0; i < msg->iov_count; i++) {
+		recv_entry->iov[i].iov_base = msg->msg_iov[i].iov_base;
+		recv_entry->iov[i].iov_len = msg->msg_iov[i].iov_len;
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "post recv: %u\n",
+			msg->msg_iov[i].iov_len);
+	}
+
+	dlist_init(&recv_entry->entry);
+	dlist_insert_tail(&recv_entry->entry, &rxd_ep->recv_list);
+
+	if (!dlist_empty(&rxd_ep->unexp_msg_list)) {
+		rxd_ep_check_unexp_msg_list(rxd_ep, recv_entry);
+	}
+out:
+	rxd_ep_unlock_if_required(rxd_ep);
+	return ret;
+}
+
+static ssize_t rxd_ep_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+			    fi_addr_t src_addr, void *context)
+{
+	struct fi_msg msg;
+	struct iovec msg_iov;
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = buf;
+	msg_iov.iov_len = len;
+
+	msg.msg_iov = &msg_iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = src_addr;
+	msg.context = context;
+	msg.data = 0;
+	return rxd_ep_recvmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+static ssize_t rxd_ep_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+			     size_t count, fi_addr_t src_addr, void *context)
+{
+	struct fi_msg msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = iov;
+	msg.desc = desc;
+	msg.iov_count = count;
+	msg.addr = src_addr;
+	msg.context = context;
+	msg.data = 0;
+	return rxd_ep_recvmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+static inline void *rxd_mr_desc(struct fid_mr *mr, struct rxd_ep *ep)
+{
+	return (ep->do_local_mr) ? fi_mr_desc(mr) : NULL;
+}
+
+int rxd_ep_repost_buff(struct rxd_rx_buf *buf)
+{
+	int ret;
+	ret = fi_recv(buf->ep->dg_ep, buf->buf, buf->ep->domain->max_mtu_sz,
+		      rxd_mr_desc(buf->mr, buf->ep),
+		      FI_ADDR_UNSPEC, &buf->context);
+	if (ret)
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "failed to repost\n");
+	return ret;
+}
+
+static int rxd_ep_set_conn_id(struct rxd_ep *ep)
+{
+	int ret;
+	ep->name = calloc(1, ep->addrlen);
+	if (!ep->name)
+		return -FI_ENOMEM;
+
+	ret = fi_getname(&ep->dg_ep->fid, ep->name, &ep->addrlen);
+	if (ret)
+		return -FI_EINVAL;
+
+	ret = rxd_av_dg_reverse_lookup(ep->av, 0, ep->name, ep->addrlen,
+					&ep->conn_data);
+	if (!ret)
+		ep->conn_data_set = 1;
+	return 0;
+}
+
+int rxd_ep_enable(struct rxd_ep *ep)
+{
+	ssize_t i, ret;
+	struct fid_mr *mr = NULL;
+	struct rxd_rx_buf *rx_buf;
+
+	ret = fi_enable(ep->dg_ep);
+	if (ret)
+		return ret;
+
+	rxd_ep_lock_if_required(ep);
+	ret = rxd_ep_set_conn_id(ep);
+	if (ret)
+		goto out;
+
+	ep->credits = ep->rx_size;
+	for (i = 0; i < ep->rx_size; i++) {
+		rx_buf = ep->do_local_mr ?
+			util_buf_get_ex(ep->rx_pkt_pool, (void **)&mr) :
+			util_buf_get(ep->rx_pkt_pool);
+
+		if (!rx_buf) {
+			ret = -FI_ENOMEM;
+			goto out;
+		}
+
+		rx_buf->mr = mr;
+		rx_buf->ep = ep;
+		ret = rxd_ep_repost_buff(rx_buf);
+		if (ret)
+			goto out;
+		slist_insert_tail(&rx_buf->entry, &ep->rx_pkt_list);
+	}
+
+	fastlock_acquire(&ep->domain->lock);
+	dlist_insert_tail(&ep->dom_entry, &ep->domain->ep_list);
+	fastlock_release(&ep->domain->lock);
+	ret = 0;
+out:
+	rxd_ep_unlock_if_required(ep);
+	return ret;
+}
+
+struct rxd_peer *rxd_ep_getpeer_info(struct rxd_ep *ep, fi_addr_t addr)
+{
+	return &ep->peer_info[addr];
+}
+
+void rxd_ep_lock_if_required(struct rxd_ep *ep)
+{
+	/* todo: do locking based on threading model */
+	fastlock_acquire(&ep->lock);
+}
+
+void rxd_ep_unlock_if_required(struct rxd_ep *ep)
+{
+	/* todo: do unlocking based on threading model */
+	fastlock_release(&ep->lock);
+}
+
+size_t rxd_get_msg_len(const struct iovec *iov, size_t iov_count)
+{
+	size_t i, ret = 0;
+	for (i = 0; i < iov_count; i++)
+		ret += iov[i].iov_len;
+	return ret;
+}
+
+static void rxd_init_ctrl_hdr(struct ofi_ctrl_hdr *ctrl,
+			      uint8_t type, uint16_t seg_size,
+			      uint32_t seg_no, uint64_t msg_id,
+			      uint64_t rx_key, uint64_t source)
+{
+	ctrl->version = OFI_CTRL_VERSION;
+	ctrl->type = type;
+	ctrl->seg_size = seg_size;
+	ctrl->seg_no = seg_no;
+	ctrl->msg_id = msg_id;
+	ctrl->rx_key = rx_key;
+	ctrl->conn_id = source;
+}
+
+static void rxd_init_op_hdr(struct ofi_op_hdr *op, uint64_t data,
+			    uint64_t msg_sz, uint8_t rx_index,
+			    uint8_t op_type, uint64_t tag, uint32_t flags)
+{
+	op->version = OFI_OP_VERSION;
+	op->rx_index = rx_index;
+	op->op = op_type;
+	op->op_data = 0; /* unused */
+	op->flags = flags;
+	op->size = msg_sz;
+	op->data = data;
+	op->tag = tag;
+}
+
+static uint32_t rxd_prepare_tx_flags(uint64_t flags)
+{
+	uint32_t tx_flags = 0;
+	if (flags & FI_REMOTE_CQ_DATA)
+		tx_flags = OFI_REMOTE_CQ_DATA;
+	if (flags & FI_TRANSMIT_COMPLETE)
+		tx_flags |= OFI_TRANSMIT_COMPLETE;
+	if (flags & FI_DELIVERY_COMPLETE)
+		tx_flags |= OFI_DELIVERY_COMPLETE;
+	return tx_flags;
+}
+
+uint64_t rxd_ep_copy_iov_buf(const struct iovec *iov, size_t iov_count,
+			     void *buf, uint64_t data_sz, uint64_t skip, int dir)
+{
+	int i;
+	uint64_t rem, offset, len, iov_offset;
+	offset = 0, rem = data_sz, iov_offset = 0;
+
+	for (i = 0; i < iov_count; i++) {
+		len = iov[i].iov_len;
+		iov_offset = 0;
+
+		if (skip) {
+			iov_offset = MIN(skip, len);
+			skip -= iov_offset;
+			len -= iov_offset;
+		}
+
+		len = MIN(rem, len);
+		if (dir == RXD_COPY_BUF_TO_IOV)
+			memcpy((char *) iov[i].iov_base + iov_offset,
+			       (char *) buf + offset, len);
+		else if (dir == RXD_COPY_IOV_TO_BUF)
+			memcpy((char *) buf + offset,
+			       (char *) iov[i].iov_base + iov_offset, len);
+		rem -= len, offset += len;
+	}
+	return offset;
+}
+
+struct rxd_pkt_meta *rxd_tx_pkt_acquire(struct rxd_ep *ep)
+{
+	struct rxd_pkt_meta *pkt_meta;
+	struct fid_mr *mr = NULL;
+
+	pkt_meta = ep->do_local_mr ?
+		util_buf_alloc_ex(ep->tx_pkt_pool, (void **)&mr) :
+		util_buf_alloc(ep->tx_pkt_pool);
+
+	if (!pkt_meta) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "No free tx pkt\n");
+		return NULL;
+	}
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Acquired tx pkt: %p\n", pkt_meta);
+	pkt_meta->ep = ep;
+	pkt_meta->retries = 0;
+	pkt_meta->mr = mr;
+	pkt_meta->ref = 0;
+	return pkt_meta;
+}
+
+ssize_t rxd_ep_post_data_msg(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
+{
+	int ret;
+	uint64_t data_sz;
+	size_t done;
+	struct rxd_pkt_meta *pkt_meta;
+	struct rxd_pkt_data *pkt;
+	struct rxd_peer *peer;
+
+	peer = rxd_ep_getpeer_info(ep, tx_entry->peer);
+	pkt_meta = rxd_tx_pkt_acquire(ep);
+	if (!pkt_meta)
+		return -FI_ENOMEM;
+
+	pkt = (struct rxd_pkt_data *)pkt_meta->pkt_data;
+	data_sz = MIN(RXD_MAX_DATA_PKT_SZ(ep), tx_entry->op_hdr.size - tx_entry->done);
+
+	rxd_init_ctrl_hdr(&pkt->ctrl, ofi_ctrl_data, data_sz, tx_entry->nxt_seg_no,
+			   tx_entry->msg_id, tx_entry->rx_key, peer->conn_data);
+
+	if (tx_entry->op_hdr.op == ofi_op_msg)
+		done = rxd_ep_copy_iov_buf(tx_entry->msg.msg_iov,
+					   tx_entry->msg.msg.iov_count,
+					   pkt->data, data_sz, tx_entry->done,
+					   RXD_COPY_IOV_TO_BUF);
+	else
+		done = rxd_ep_copy_iov_buf(tx_entry->tmsg.msg_iov,
+					   tx_entry->tmsg.tmsg.iov_count,
+					   pkt->data, data_sz, tx_entry->done,
+					   RXD_COPY_IOV_TO_BUF);
+
+	pkt_meta->tx_entry = tx_entry;
+	pkt_meta->type = (tx_entry->op_hdr.size == tx_entry->done + done) ?
+		RXD_PKT_LAST : RXD_PKT_DATA;
+	pkt_meta->us_stamp = fi_gettime_us();
+
+	ret = fi_send(ep->dg_ep, pkt, data_sz + RXD_DATA_PKT_SZ,
+		      rxd_mr_desc(pkt_meta->mr, ep), tx_entry->peer, &pkt_meta->context);
+	if (ret) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "send %d failed\n", pkt->ctrl.seg_no);
+		util_buf_release(ep->tx_pkt_pool, pkt_meta);
+		return ret;
+	}
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "sent data %p, %d [on buf: %p]\n",
+		pkt->ctrl.msg_id, pkt->ctrl.seg_no, pkt_meta);
+	tx_entry->done += done;
+	tx_entry->win_sz--;
+	tx_entry->nxt_seg_no++;
+	tx_entry->num_unacked++;
+
+	dlist_insert_tail(&pkt_meta->entry, &tx_entry->pkt_list);
+	ep->num_out++;
+	return 0;
+}
+
+void rxd_ep_free_acked_pkts(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
+			  uint32_t seg_no)
+{
+	struct dlist_entry *next, *curr;
+	struct rxd_pkt_meta *pkt;
+	struct ofi_ctrl_hdr *ctrl;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "freeing all [%p] pkts <= %d\n",
+		tx_entry->msg_id, seg_no);
+	for (curr = tx_entry->pkt_list.next; curr != &tx_entry->pkt_list;) {
+		next = curr->next;
+		pkt = container_of(curr, struct rxd_pkt_meta, entry);
+		ctrl = (struct ofi_ctrl_hdr *) pkt->pkt_data;
+		if (ctrl->seg_no <= seg_no) {
+			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "freeing [%p] pkt:%d\n",
+				tx_entry->msg_id, ctrl->seg_no);
+			dlist_remove(curr);
+			RXD_PKT_MARK_REMOTE_ACK(pkt);
+			rxd_tx_pkt_release(pkt);
+			tx_entry->num_unacked--;
+		} else {
+			break;
+		}
+		curr = next;
+	}
+}
+
+void rxd_tx_entry_update_ts(struct rxd_tx_entry *tx_entry, uint32_t seg_no)
+{
+	struct dlist_entry *curr;
+	struct rxd_pkt_meta *pkt;
+	struct ofi_ctrl_hdr *ctrl;
+
+	for (curr = tx_entry->pkt_list.next; curr != &tx_entry->pkt_list;
+	     curr = curr->next) {
+		pkt = container_of(curr, struct rxd_pkt_meta, entry);
+		ctrl = (struct ofi_ctrl_hdr *) pkt->pkt_data;
+		if (ctrl->seg_no == seg_no) {
+			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "updating TS of [%p] pkt:%d\n",
+				tx_entry->msg_id, seg_no);
+			pkt->us_stamp += RXD_WAIT_TIMEOUT;
+			break;
+		}
+	}
+}
+
+int rxd_progress_tx(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
+{
+	int ret = 0;
+
+	switch (tx_entry->op_hdr.op) {
+	case ofi_op_msg:
+	case ofi_op_tagged:
+		ret = rxd_ep_post_data_msg(ep, tx_entry);
+		break;
+	default:
+		break;
+	}
+	return ret;
+}
+
+void rxd_tx_entry_discard(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
+{
+	rxd_cq_report_tx_comp(ep->tx_cq, tx_entry);
+	rxd_tx_entry_done(ep, tx_entry);
+}
+
+void rxd_resend_pkt(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
+		     uint32_t seg_no)
+{
+	struct dlist_entry *pkt_item;
+	struct rxd_pkt_meta *pkt;
+	struct ofi_ctrl_hdr *ctrl;
+	uint64_t curr_stamp = fi_gettime_us();
+
+	dlist_foreach(&tx_entry->pkt_list, pkt_item) {
+		pkt = container_of(pkt_item, struct rxd_pkt_meta, entry);
+		ctrl = (struct ofi_ctrl_hdr *)pkt->pkt_data;
+
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "check pkt %d, %p\n",
+			ctrl->seg_no, ctrl->msg_id);
+
+		if (ctrl->seg_no == seg_no) {
+
+			if (curr_stamp < pkt->us_stamp ||
+			    (curr_stamp - pkt->us_stamp) <
+			    (1 << (pkt->retries + 1)) * RXD_RETRY_TIMEOUT) {
+				break;
+			}
+
+			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "resending pkt %d, %p\n",
+				ctrl->seg_no, ctrl->msg_id);
+
+			pkt->us_stamp = fi_gettime_us();
+			rxd_ep_retry_pkt(ep, tx_entry, pkt);
+			break;
+		}
+	}
+}
+
+int rxd_tx_entry_progress(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
+			   struct ofi_ctrl_hdr *ack)
+{
+	if (ack) {
+		tx_entry->rx_key = ack->rx_key;
+		tx_entry->win_sz += ack->seg_size;
+
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "tx: %p [%p] - avail_win: %d\n",
+			tx_entry, ack->msg_id, ack->seg_size);
+
+		if (ack->type == ofi_ctrl_nack) {
+			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "got NACK for %d, %p\n",
+				ack->seg_no, ack->msg_id);
+			if (ack->seg_no > 0)
+				rxd_ep_free_acked_pkts(ep, tx_entry, ack->seg_no - 1);
+			rxd_resend_pkt(ep, tx_entry, ack->seg_no);
+		} else {
+			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "got ACK for %d, %p\n",
+			       ack->seg_no, ack->msg_id);
+
+			rxd_ep_free_acked_pkts(ep, tx_entry, ack->seg_no);
+			if (ack->seg_size == 0 &&
+			    tx_entry->done != tx_entry->op_hdr.size) {
+				tx_entry->is_waiting = 1;
+				tx_entry->retry_stamp = fi_gettime_us();
+				FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
+					"Marking [%p] as waiting\n", tx_entry->msg_id);
+			}
+		}
+	}
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "tx: %p [%p] - num_unacked: %d\n",
+		tx_entry, tx_entry->msg_id, tx_entry->num_unacked);
+
+	while (tx_entry->win_sz && tx_entry->num_unacked < RXD_MAX_UNACKED &&
+	       tx_entry->done != tx_entry->op_hdr.size) {
+		if (rxd_progress_tx(ep, tx_entry))
+			break;
+	}
+	return 0;
+}
+
+int rxd_ep_reply_ack(struct rxd_ep *ep, struct ofi_ctrl_hdr *in_ctrl,
+		   uint8_t type, uint16_t seg_size, uint64_t rx_key,
+		   uint64_t source, fi_addr_t dest)
+{
+	ssize_t ret;
+	struct rxd_pkt_meta *pkt_meta;
+	struct rxd_pkt_data *pkt;
+
+	pkt_meta = rxd_tx_pkt_acquire(ep);
+	if (!pkt_meta)
+		return -FI_ENOMEM;
+
+	pkt = (struct rxd_pkt_data *)pkt_meta->pkt_data;
+	rxd_init_ctrl_hdr(&pkt->ctrl, type, seg_size, in_ctrl->seg_no,
+			   in_ctrl->msg_id, rx_key, source);
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "sending ack [%p] - %d, %d\n",
+		in_ctrl->msg_id, in_ctrl->seg_no, seg_size);
+
+	RXD_PKT_MARK_REMOTE_ACK(pkt_meta);
+	pkt_meta->us_stamp = fi_gettime_us();
+	ret = fi_send(ep->dg_ep, pkt, RXD_DATA_PKT_SZ,
+		      rxd_mr_desc(pkt_meta->mr, ep),
+		      dest, &pkt_meta->context);
+	if (ret)
+		goto err;
+	ep->num_out++;
+	return 0;
+err:
+	util_buf_release(ep->tx_pkt_pool, pkt_meta);
+	return ret;
+}
+
+int rxd_ep_reply_nack(struct rxd_ep *ep, struct ofi_ctrl_hdr *in_ctrl,
+		    uint32_t seg_no, uint64_t rx_key,
+		    uint64_t source, fi_addr_t dest)
+{
+	ssize_t ret;
+	struct rxd_pkt_meta *pkt_meta;
+	struct rxd_pkt_data *pkt;
+
+	pkt_meta = rxd_tx_pkt_acquire(ep);
+	if (!pkt_meta)
+		return -FI_ENOMEM;
+
+	pkt = (struct rxd_pkt_data *)pkt_meta->pkt_data;
+	rxd_init_ctrl_hdr(&pkt->ctrl, ofi_ctrl_nack, 0, seg_no,
+			   in_ctrl->msg_id, rx_key, source);
+
+	RXD_PKT_MARK_REMOTE_ACK(pkt_meta);
+	pkt_meta->us_stamp = fi_gettime_us();
+	ret = fi_send(ep->dg_ep, pkt, RXD_DATA_PKT_SZ,
+		      rxd_mr_desc(pkt_meta->mr, ep),
+		      dest, &pkt_meta->context);
+	if (ret)
+		goto err;
+	ep->num_out++;
+	return 0;
+err:
+	util_buf_release(ep->tx_pkt_pool, pkt_meta);
+	return ret;
+}
+
+int rxd_ep_reply_discard(struct rxd_ep *ep, struct ofi_ctrl_hdr *in_ctrl,
+		       uint32_t seg_no, uint64_t rx_key,
+		       uint64_t source, fi_addr_t dest)
+{
+	ssize_t ret;
+	struct rxd_pkt_meta *pkt_meta;
+	struct rxd_pkt_data *pkt;
+
+	pkt_meta = rxd_tx_pkt_acquire(ep);
+	if (!pkt_meta)
+		return -FI_ENOMEM;
+
+	pkt = (struct rxd_pkt_data *)pkt_meta->pkt_data;
+	rxd_init_ctrl_hdr(&pkt->ctrl, ofi_ctrl_discard, 0, seg_no,
+			   in_ctrl->msg_id, rx_key, source);
+
+	RXD_PKT_MARK_REMOTE_ACK(pkt_meta);
+	pkt_meta->us_stamp = fi_gettime_us();
+	ret = fi_send(ep->dg_ep, pkt, RXD_DATA_PKT_SZ,
+		      rxd_mr_desc(pkt_meta->mr, ep),
+		      dest, &pkt_meta->context);
+	if (ret)
+		goto err;
+	ep->num_out++;
+	return 0;
+err:
+	util_buf_release(ep->tx_pkt_pool, pkt_meta);
+	return ret;
+}
+
+#define RXD_TX_ENTRY_ID(ep, tx_entry) (tx_entry - &ep->tx_entry_fs->buf[0])
+
+ssize_t rxd_ep_post_start_msg(struct rxd_ep *ep, struct rxd_peer *peer,
+			       uint8_t op, struct rxd_tx_entry *tx_entry)
+{
+	ssize_t ret;
+	uint32_t flags;
+	uint64_t msg_sz;
+	uint64_t data_sz;
+	struct rxd_pkt_meta *pkt_meta;
+	struct rxd_pkt_data_start *pkt;
+
+	pkt_meta = rxd_tx_pkt_acquire(ep);
+	if (!pkt_meta)
+		return -FI_ENOMEM;
+
+	pkt = (struct rxd_pkt_data_start *)pkt_meta->pkt_data;
+	flags = rxd_prepare_tx_flags(tx_entry->flags);
+	tx_entry->msg_id = RXD_TX_ID(peer->nxt_msg_id, RXD_TX_ENTRY_ID(ep, tx_entry));
+
+	if (op == ofi_op_msg) {
+		msg_sz = rxd_get_msg_len(tx_entry->msg.msg_iov, tx_entry->msg.msg.iov_count);
+		data_sz = MIN(RXD_MAX_STRT_DATA_PKT_SZ(ep), msg_sz);
+		rxd_init_op_hdr(&pkt->op, tx_entry->msg.msg.data, msg_sz, 0, op, 0, flags);
+		tx_entry->done = rxd_ep_copy_iov_buf(tx_entry->msg.msg_iov,
+						     tx_entry->msg.msg.iov_count,
+						     pkt->data, data_sz, 0, RXD_COPY_IOV_TO_BUF);
+	} else {
+		msg_sz = rxd_get_msg_len(tx_entry->tmsg.msg_iov, tx_entry->tmsg.tmsg.iov_count);
+		data_sz = MIN(RXD_MAX_STRT_DATA_PKT_SZ(ep), msg_sz);
+		rxd_init_op_hdr(&pkt->op, tx_entry->tmsg.tmsg.data, msg_sz, 0, op,
+				 tx_entry->tmsg.tmsg.tag,flags);
+		tx_entry->done = rxd_ep_copy_iov_buf(tx_entry->tmsg.msg_iov,
+						     tx_entry->tmsg.tmsg.iov_count,
+						     pkt->data, data_sz, 0, RXD_COPY_IOV_TO_BUF);
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "sent start %p, tag: %p, len: %d\n",
+		       pkt->ctrl.msg_id, tx_entry->tmsg.tmsg.tag, msg_sz);
+	}
+
+	rxd_init_ctrl_hdr(&pkt->ctrl, ofi_ctrl_start_data, data_sz, 0,
+			   tx_entry->msg_id, peer->conn_data, peer->conn_data);
+	tx_entry->nxt_seg_no = 1;
+	tx_entry->op_hdr = pkt->op;
+	tx_entry->win_sz = 0;
+
+	pkt_meta->tx_entry = tx_entry;
+	pkt_meta->type = (tx_entry->op_hdr.size == tx_entry->done) ?
+		RXD_PKT_LAST : RXD_PKT_DATA;
+
+	pkt_meta->us_stamp = fi_gettime_us();
+	ret = fi_send(ep->dg_ep, pkt, data_sz + RXD_START_DATA_PKT_SZ,
+		      rxd_mr_desc(pkt_meta->mr, ep),
+		      tx_entry->peer, &pkt_meta->context);
+	if (ret)
+		goto err;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "sent start %p, %d\n",
+		pkt->ctrl.msg_id, pkt->ctrl.seg_no);
+	dlist_insert_tail(&pkt_meta->entry, &tx_entry->pkt_list);
+	peer->nxt_msg_id++;
+	ep->num_out++;
+	tx_entry->num_unacked++;
+	return 0;
+err:
+	util_buf_release(ep->tx_pkt_pool, pkt_meta);
+	return ret;
+}
+
+uint64_t rxd_find_av_index(struct rxd_av *av, uint64_t start_idx,
+			    const void *addr, size_t addrlen, int *p_found)
+{
+	void *tmp_addr;
+	uint64_t idx = 0, count;
+	size_t tmp_addrlen;
+
+	if (p_found)
+		*p_found = 0;
+
+	tmp_addr = calloc(1, addrlen);
+	if (!tmp_addr)
+		return 0;
+
+	for (idx = start_idx, count = 0; count < av->dg_av_used;
+	     count++, idx = (idx+1) % av->dg_av_used) {
+		tmp_addrlen = addrlen;
+		if (fi_av_lookup(av->dg_av, idx, tmp_addr, &tmp_addrlen)) {
+			idx = 0;
+			goto out;
+		}
+
+		if (addrlen == tmp_addrlen &&
+		    memcmp(tmp_addr, addr, addrlen) == 0) {
+			if (p_found)
+				*p_found = 1;
+			goto out;
+		}
+	}
+out:
+	free(tmp_addr);
+	return idx;
+}
+
+ssize_t rxd_ep_post_conn_msg(struct rxd_ep *ep, struct rxd_peer *peer,
+			      fi_addr_t addr)
+{
+	ssize_t ret;
+	size_t addrlen;
+	uint16_t data_sz;
+	struct rxd_pkt_data *pkt;
+	struct rxd_pkt_meta *pkt_meta;
+	struct rxd_tx_entry *tx_entry;
+
+	if (peer->conn_initiated)
+		return 0;
+
+	tx_entry = rxd_tx_entry_acquire(ep, peer);
+	if (!tx_entry)
+		return -FI_EAGAIN;
+
+	dlist_init(&tx_entry->pkt_list);
+	tx_entry->op_type = RXD_TX_CONN;
+	tx_entry->peer = addr;
+	tx_entry->win_sz = 0;
+
+	pkt_meta = rxd_tx_pkt_acquire(ep);
+	if (!pkt_meta) {
+		rxd_tx_entry_release(ep, tx_entry);
+		return -FI_ENOMEM;
+	}
+
+	pkt = (struct rxd_pkt_data *)pkt_meta->pkt_data;
+	addrlen = RXD_MAX_DATA_PKT_SZ(ep);
+	ret = fi_getname(&ep->dg_ep->fid, pkt->data, &addrlen);
+	assert(ret == 0);
+	data_sz = (uint16_t) addrlen;
+	tx_entry->msg_id = RXD_TX_ID(peer->nxt_msg_id, RXD_TX_ENTRY_ID(ep, tx_entry));
+
+	rxd_init_ctrl_hdr(&pkt->ctrl, ofi_ctrl_connreq, data_sz, 0,
+			   tx_entry->msg_id, ep->conn_data, addr);
+
+	pkt_meta->us_stamp = fi_gettime_us();
+	ret = fi_send(ep->dg_ep, pkt, data_sz + RXD_DATA_PKT_SZ,
+		      rxd_mr_desc(pkt_meta->mr, ep),
+		      addr, &pkt_meta->context);
+	if (ret)
+		goto err;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "sent conn %p\n", pkt->ctrl.msg_id);
+	dlist_insert_tail(&pkt_meta->entry, &tx_entry->pkt_list);
+	dlist_insert_tail(&tx_entry->entry, &ep->tx_entry_list);
+	peer->nxt_msg_id++;
+	ep->num_out++;
+	peer->conn_initiated = 1;
+	return 0;
+err:
+	rxd_tx_entry_release(ep, tx_entry);
+	util_buf_release(ep->tx_pkt_pool, pkt_meta);
+	return ret;
+}
+
+struct rxd_tx_entry *rxd_tx_entry_acquire(struct rxd_ep *ep, struct rxd_peer *peer)
+{
+	struct rxd_tx_entry *tx_entry;
+	if (freestack_isempty(ep->tx_entry_fs) ||
+	    peer->num_msg_out == RXD_MAX_OUT_TX_MSG)
+		return NULL;
+
+	peer->num_msg_out++;
+	tx_entry = freestack_pop(ep->tx_entry_fs);
+	tx_entry->num_unacked = 0;
+	tx_entry->is_waiting = 0;
+	dlist_init(&tx_entry->entry);
+	return tx_entry;
+}
+
+void rxd_tx_entry_release(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry)
+{
+	struct rxd_peer *peer;
+
+	peer = rxd_ep_getpeer_info(ep, tx_entry->peer);
+	peer->num_msg_out--;
+	dlist_remove(&tx_entry->entry);
+	freestack_push(ep->tx_entry_fs, tx_entry);
+}
+
+static inline void rxd_copy_iov(const struct iovec *src_iov,
+				 struct iovec *dst_iov, size_t iov_count)
+{
+	size_t i;
+	for (i = 0; i < iov_count; i++)
+		dst_iov[i] = src_iov[i];
+}
+
+static ssize_t rxd_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
+			       uint64_t flags)
+{
+	ssize_t ret;
+	uint64_t peer_addr;
+	struct rxd_ep *rxd_ep;
+	struct rxd_peer *peer;
+	struct rxd_tx_entry *tx_entry;
+	rxd_ep = container_of(ep, struct rxd_ep, ep);
+
+	peer_addr = rxd_av_get_dg_addr(rxd_ep->av, msg->addr);
+	peer = rxd_ep_getpeer_info(rxd_ep, peer_addr);
+
+	rxd_ep_lock_if_required(rxd_ep);
+	if (!peer->addr_published) {
+		ret = rxd_ep_post_conn_msg(rxd_ep, peer, peer_addr);
+		ret = (ret) ? ret : -FI_EAGAIN;
+		goto out;
+	}
+
+	tx_entry = rxd_tx_entry_acquire(rxd_ep, peer);
+	if (!tx_entry) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	dlist_init(&tx_entry->pkt_list);
+	tx_entry->op_type = RXD_TX_MSG;
+	tx_entry->msg.msg = *msg;
+	tx_entry->flags = flags;
+	tx_entry->peer = peer_addr;
+	rxd_copy_iov(msg->msg_iov, &tx_entry->msg.msg_iov[0], msg->iov_count);
+
+	ret = rxd_ep_post_start_msg(rxd_ep, peer, ofi_op_msg, tx_entry);
+	if (ret)
+		goto err;
+
+	dlist_insert_tail(&tx_entry->entry, &rxd_ep->tx_entry_list);
+out:
+	rxd_ep_unlock_if_required(rxd_ep);
+	return ret;
+err:
+	rxd_tx_entry_release(rxd_ep, tx_entry);
+	goto out;
+}
+
+static ssize_t rxd_ep_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+			    fi_addr_t dest_addr, void *context)
+{
+	struct fi_msg msg;
+	struct iovec msg_iov;
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	msg.context = context;
+
+	return rxd_ep_sendmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+static ssize_t rxd_ep_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+			     size_t count, fi_addr_t dest_addr, void *context)
+{
+	struct fi_msg msg;
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = iov;
+	msg.desc = desc;
+	msg.iov_count = count;
+	msg.addr = dest_addr;
+	msg.context = context;
+	return rxd_ep_sendmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+static ssize_t	rxd_ep_inject(struct fid_ep *ep, const void *buf, size_t len,
+			       fi_addr_t dest_addr)
+{
+	struct fi_msg msg;
+	struct iovec msg_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+
+	return rxd_ep_sendmsg(ep, &msg, FI_INJECT |
+			       RXD_NO_COMPLETION | RXD_USE_OP_FLAGS);
+}
+
+static ssize_t rxd_ep_senddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+				uint64_t data, fi_addr_t dest_addr, void *context)
+{
+	struct fi_msg msg;
+	struct iovec msg_iov;
+
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+
+	msg.msg_iov = &msg_iov;
+	msg.desc = desc;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	msg.context = context;
+	msg.data = data;
+
+	return rxd_ep_sendmsg(ep, &msg, FI_REMOTE_CQ_DATA | RXD_USE_OP_FLAGS);
+}
+
+static ssize_t	rxd_ep_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+				   uint64_t data, fi_addr_t dest_addr)
+{
+	struct fi_msg msg;
+	struct iovec msg_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	msg.data = data;
+
+	return rxd_ep_sendmsg(ep, &msg, FI_REMOTE_CQ_DATA | FI_INJECT |
+			       RXD_NO_COMPLETION | RXD_USE_OP_FLAGS);
+}
+
+static struct fi_ops_msg rxd_ops_msg = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = rxd_ep_recv,
+	.recvv = rxd_ep_recvv,
+	.recvmsg = rxd_ep_recvmsg,
+	.send = rxd_ep_send,
+	.sendv = rxd_ep_sendv,
+	.sendmsg = rxd_ep_sendmsg,
+	.inject = rxd_ep_inject,
+	.senddata = rxd_ep_senddata,
+	.injectdata = rxd_ep_injectdata,
+};
+
+static int rxd_peek_trecv(struct dlist_entry *item, const void *arg)
+{
+	const struct fi_msg_tagged *msg = (const struct fi_msg_tagged *) arg;
+	struct rxd_rx_entry *rx_entry;
+
+	rx_entry = container_of(item, struct rxd_rx_entry, unexp_entry);
+	return ((rx_entry->op_hdr.tag | msg->ignore) ==
+		(msg->tag | msg->ignore) &&
+                ((rx_entry->source == FI_ADDR_UNSPEC) ||
+		 (msg->addr == FI_ADDR_UNSPEC) ||
+                 (rx_entry->source == msg->addr)));
+}
+
+static void rxd_trx_discard_recv(struct rxd_ep *ep,
+				  struct rxd_rx_entry *rx_entry)
+{
+	struct rxd_rx_buf *rx_buf;
+	struct ofi_ctrl_hdr *ctrl;
+	struct rxd_peer *peer;
+
+	rx_buf = rx_entry->unexp_buf;
+	ctrl = (struct ofi_ctrl_hdr *) rx_buf->buf;
+	peer = rxd_ep_getpeer_info(ep, ctrl->conn_id);
+
+	dlist_remove(&rx_entry->unexp_entry);
+	ep->num_unexp_msg--;
+
+	rxd_ep_reply_discard(ep, ctrl, 0, ctrl->rx_key, peer->conn_data, ctrl->conn_id);
+	rxd_rx_entry_release(ep, rx_entry);
+	rxd_ep_repost_buff(rx_buf);
+}
+
+static ssize_t rxd_trx_peek_recv(struct rxd_ep *ep,
+				  const struct fi_msg_tagged *msg, uint64_t flags)
+{
+	struct dlist_entry *match;
+	struct rxd_rx_entry *rx_entry;
+	struct fi_cq_err_entry err_entry = {0};
+	struct fi_cq_tagged_entry cq_entry = {0};
+	struct fi_context *context;
+
+	match = dlist_find_first_match(&ep->unexp_tag_list,
+				       &rxd_peek_trecv, msg);
+	if (!match) {
+		err_entry.op_context = msg->context;
+		err_entry.flags = (FI_MSG | FI_RECV | FI_TAGGED);
+		err_entry.tag = msg->tag;
+		err_entry.err = FI_ENOMSG;
+		err_entry.prov_errno = -FI_ENOMSG;
+		rxd_cq_report_error(ep->rx_cq, &err_entry);
+		return 0;
+	}
+
+	rx_entry = container_of(match, struct rxd_rx_entry, unexp_entry);
+	cq_entry.flags = (FI_MSG | FI_RECV | FI_TAGGED);
+	cq_entry.op_context = msg->context;
+	cq_entry.len = rx_entry->op_hdr.size;
+	cq_entry.buf = NULL;
+	cq_entry.data = rx_entry->op_hdr.data;
+	cq_entry.tag = rx_entry->op_hdr.tag;
+
+	if (flags & FI_CLAIM) {
+		context = (struct fi_context *)msg->context;
+		context->internal[0] = rx_entry;
+		dlist_remove(match);
+	} else if (flags & FI_DISCARD) {
+		rxd_trx_discard_recv(ep, rx_entry);
+	}
+
+	ep->rx_cq->write_fn(ep->rx_cq, &cq_entry);
+	return 0;
+}
+
+ssize_t rxd_trx_claim_recv(struct rxd_ep *ep, const struct fi_msg_tagged *msg,
+			    uint64_t flags)
+{
+	int ret = 0, i;
+	struct fi_context *context;
+	struct rxd_rx_entry *rx_entry;
+	struct rxd_trecv_entry *trecv_entry;
+	struct rxd_peer *peer;
+	struct rxd_rx_buf *rx_buf;
+	struct ofi_ctrl_hdr *ctrl;
+	struct rxd_pkt_data_start *pkt_start;
+
+	rxd_ep_lock_if_required(ep);
+	if (freestack_isempty(ep->trecv_fs)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	trecv_entry = freestack_pop(ep->trecv_fs);
+	trecv_entry->msg = *msg;
+	trecv_entry->msg.addr = (ep->caps & FI_DIRECTED_RECV) ?
+		msg->addr : FI_ADDR_UNSPEC;
+	trecv_entry->flags = flags;
+	for (i = 0; i < msg->iov_count; i++) {
+		trecv_entry->iov[i].iov_base = msg->msg_iov[i].iov_base;
+		trecv_entry->iov[i].iov_len = msg->msg_iov[i].iov_len;
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "post claim trecv: %u, tag: %p\n",
+		       msg->msg_iov[i].iov_len, msg->tag);
+	}
+
+	context = (struct fi_context *) msg->context;
+	rx_entry = context->internal[0];
+	rx_entry->trecv = trecv_entry;
+
+	rx_buf = rx_entry->unexp_buf;
+	peer = rx_entry->peer_info;
+	ctrl = (struct ofi_ctrl_hdr *) rx_buf->buf;
+	pkt_start = (struct rxd_pkt_data_start *) ctrl;
+
+	rxd_ep_handle_data_msg(ep, peer, rx_entry, rx_entry->trecv->iov,
+			     rx_entry->trecv->msg.iov_count, ctrl,
+			     pkt_start->data, rx_buf);
+out:
+	rxd_ep_unlock_if_required(ep);
+	return ret;
+}
+
+ssize_t rxd_ep_trecvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+			 uint64_t flags)
+{
+	ssize_t ret = 0, i;
+	struct rxd_ep *rxd_ep;
+	struct rxd_trecv_entry *trecv_entry;
+
+	rxd_ep = container_of(ep, struct rxd_ep, ep);
+	rxd_ep_lock_if_required(rxd_ep);
+
+	if (flags & FI_PEEK) {
+		ret = rxd_trx_peek_recv(rxd_ep, msg, flags);
+		goto out;
+	} else if (flags & FI_CLAIM) {
+		ret = rxd_trx_claim_recv(rxd_ep, msg, flags);
+		goto out;
+	}
+
+	if (freestack_isempty(rxd_ep->trecv_fs)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	trecv_entry = freestack_pop(rxd_ep->trecv_fs);
+	trecv_entry->msg = *msg;
+	trecv_entry->msg.addr = (rxd_ep->caps & FI_DIRECTED_RECV) ?
+		msg->addr : FI_ADDR_UNSPEC;
+	trecv_entry->flags = flags;
+	for (i = 0; i < msg->iov_count; i++) {
+		trecv_entry->iov[i].iov_base = msg->msg_iov[i].iov_base;
+		trecv_entry->iov[i].iov_len = msg->msg_iov[i].iov_len;
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "post trecv: %u, tag: %p\n",
+			msg->msg_iov[i].iov_len, msg->tag);
+	}
+	dlist_init(&trecv_entry->entry);
+	dlist_insert_tail(&trecv_entry->entry, &rxd_ep->trecv_list);
+
+	if (!dlist_empty(&rxd_ep->unexp_tag_list)) {
+		rxd_ep_check_unexp_tag_list(rxd_ep, trecv_entry);
+	}
+out:
+	rxd_ep_unlock_if_required(rxd_ep);
+	return ret;
+}
+
+static ssize_t rxd_ep_trecv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+			    fi_addr_t src_addr,
+			    uint64_t tag, uint64_t ignore, void *context)
+{
+	struct fi_msg_tagged msg;
+	struct iovec msg_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = buf;
+	msg_iov.iov_len = len;
+
+	msg.msg_iov = &msg_iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = src_addr;
+	msg.context = context;
+	msg.tag = tag;
+	msg.ignore = ignore;
+	msg.data = 0;
+	return rxd_ep_trecvmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+ssize_t rxd_ep_trecvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t src_addr,
+		       uint64_t tag, uint64_t ignore, void *context)
+{
+	struct fi_msg_tagged msg;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = iov;
+	msg.desc = desc;
+	msg.iov_count = count;
+	msg.addr = src_addr;
+	msg.context = context;
+	msg.tag = tag;
+	msg.ignore = ignore;
+	msg.data = 0;
+	return rxd_ep_trecvmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+ssize_t rxd_ep_tsendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+			 uint64_t flags)
+{
+	ssize_t ret;
+	uint64_t peer_addr;
+	struct rxd_ep *rxd_ep;
+	struct rxd_peer *peer;
+	struct rxd_tx_entry *tx_entry;
+	rxd_ep = container_of(ep, struct rxd_ep, ep);
+
+	peer_addr = rxd_av_get_dg_addr(rxd_ep->av, msg->addr);
+	peer = rxd_ep_getpeer_info(rxd_ep, peer_addr);
+
+	rxd_ep_lock_if_required(rxd_ep);
+	if (!peer->addr_published) {
+		ret = rxd_ep_post_conn_msg(rxd_ep, peer, peer_addr);
+		ret = (ret) ? ret : -FI_EAGAIN;
+		goto out;
+	}
+
+	tx_entry = rxd_tx_entry_acquire(rxd_ep, peer);
+	if (!tx_entry) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	dlist_init(&tx_entry->pkt_list);
+	tx_entry->op_type = RXD_TX_TAG;
+	tx_entry->tmsg.tmsg = *msg;
+	tx_entry->flags = flags;
+	tx_entry->peer = peer_addr;
+	rxd_copy_iov(msg->msg_iov, &tx_entry->tmsg.msg_iov[0], msg->iov_count);
+
+	ret = rxd_ep_post_start_msg(rxd_ep, peer, ofi_op_tagged, tx_entry);
+	if (ret)
+		goto err;
+
+	dlist_insert_tail(&tx_entry->entry, &rxd_ep->tx_entry_list);
+out:
+	rxd_ep_unlock_if_required(rxd_ep);
+	return ret;
+err:
+	rxd_tx_entry_release(rxd_ep, tx_entry);
+	goto out;
+}
+
+ssize_t rxd_ep_tsend(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		      fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	struct fi_msg_tagged msg;
+	struct iovec msg_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	msg.context = context;
+	msg.tag = tag;
+
+	return rxd_ep_tsendmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+ssize_t rxd_ep_tsendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	struct fi_msg_tagged msg;
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = iov;
+	msg.desc = desc;
+	msg.iov_count = count;
+	msg.addr = dest_addr;
+	msg.context = context;
+	msg.tag = tag;
+	return rxd_ep_tsendmsg(ep, &msg, RXD_USE_OP_FLAGS);
+}
+
+ssize_t	rxd_ep_tinject(struct fid_ep *ep, const void *buf, size_t len,
+			fi_addr_t dest_addr, uint64_t tag)
+{
+	struct fi_msg_tagged msg;
+	struct iovec msg_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	msg.tag = tag;
+	return rxd_ep_tsendmsg(ep, &msg, FI_INJECT |
+				RXD_NO_COMPLETION | RXD_USE_OP_FLAGS);
+}
+
+ssize_t rxd_ep_tsenddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+			  uint64_t data, fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	struct fi_msg_tagged msg;
+	struct iovec msg_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+	msg.desc = desc;
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	msg.context = context;
+	msg.data = data;
+	msg.tag = tag;
+
+	return rxd_ep_tsendmsg(ep, &msg, FI_REMOTE_CQ_DATA | RXD_USE_OP_FLAGS);
+}
+
+ssize_t	rxd_ep_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
+			    uint64_t data, fi_addr_t dest_addr, uint64_t tag)
+{
+	struct fi_msg_tagged msg;
+	struct iovec msg_iov;
+
+	memset(&msg, 0, sizeof(msg));
+	msg_iov.iov_base = (void *) buf;
+	msg_iov.iov_len = len;
+	msg.msg_iov = &msg_iov;
+
+	msg.iov_count = 1;
+	msg.addr = dest_addr;
+	msg.data = data;
+	msg.tag = tag;
+
+	return rxd_ep_tsendmsg(ep, &msg, FI_REMOTE_CQ_DATA | FI_INJECT |
+				RXD_NO_COMPLETION | RXD_USE_OP_FLAGS);
+}
+
+struct fi_ops_tagged rxd_ops_tagged = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = rxd_ep_trecv,
+	.recvv = rxd_ep_trecvv,
+	.recvmsg = rxd_ep_trecvmsg,
+	.send = rxd_ep_tsend,
+	.sendv = rxd_ep_tsendv,
+	.sendmsg = rxd_ep_tsendmsg,
+	.inject = rxd_ep_tinject,
+	.senddata = rxd_ep_tsenddata,
+	.injectdata = rxd_ep_tinjectdata,
+};
+
+static void rxd_ep_free_buf_pools(struct rxd_ep *ep)
+{
+	util_buf_pool_destroy(ep->tx_pkt_pool);
+	util_buf_pool_destroy(ep->rx_pkt_pool);
+
+	if (ep->tx_entry_fs)
+		rxd_tx_entry_fs_free(ep->tx_entry_fs);
+
+	if (ep->rx_entry_fs)
+		rxd_rx_entry_fs_free(ep->rx_entry_fs);
+
+	if (ep->recv_fs)
+		rxd_recv_fs_free(ep->recv_fs);
+
+	if (ep->trecv_fs)
+		rxd_trecv_fs_free(ep->trecv_fs);
+}
+
+static int rxd_ep_close(struct fid *fid)
+{
+	int ret;
+	struct rxd_ep *ep;
+	struct slist_entry *entry;
+	struct rxd_rx_buf *buf;
+
+	ep = container_of(fid, struct rxd_ep, ep.fid);
+	while (ep->num_out) {
+		rxd_cq_progress(&ep->tx_cq->util_cq);
+	}
+
+	ret = fi_close(&ep->dg_ep->fid);
+	if (ret)
+		return ret;
+
+	fastlock_acquire(&ep->domain->lock);
+	dlist_remove(&ep->dom_entry);
+	fastlock_release(&ep->domain->lock);
+
+	while(!slist_empty(&ep->rx_pkt_list)) {
+		entry = slist_remove_head(&ep->rx_pkt_list);
+		buf = container_of(entry, struct rxd_rx_buf, entry);
+		util_buf_release(ep->rx_pkt_pool, buf);
+	}
+
+	if (ep->tx_cq)
+		atomic_dec(&ep->tx_cq->util_cq.ref);
+
+	if (ep->rx_cq)
+		atomic_dec(&ep->rx_cq->util_cq.ref);
+
+	atomic_dec(&ep->domain->util_domain.ref);
+	fastlock_destroy(&ep->lock);
+	rxd_ep_free_buf_pools(ep);
+	free(ep);
+	return 0;
+}
+
+static int rxd_ep_bind_cq(struct rxd_ep *ep, struct rxd_cq *cq, uint64_t flags)
+{
+	int ret;
+
+	if (flags & ~(FI_TRANSMIT | FI_RECV)) {
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "unsupported flags\n");
+		return -FI_EBADFLAGS;
+	}
+
+	if (((flags & FI_TRANSMIT) && ep->tx_cq) ||
+	    ((flags & FI_RECV) && ep->rx_cq)) {
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "duplicate CQ binding\n");
+		return -FI_EINVAL;
+	}
+
+	if (flags & FI_TRANSMIT) {
+		if (!ep->tx_cq && !ep->rx_cq) {
+			ret = fi_ep_bind(ep->dg_ep, &cq->dg_cq->fid, FI_TRANSMIT | FI_RECV);
+		if (ret)
+			return ret;
+		}
+
+		ep->tx_cq = cq;
+		atomic_inc(&cq->util_cq.ref);
+	}
+
+	if (flags & FI_RECV) {
+		if (!ep->tx_cq && !ep->rx_cq) {
+			ret = fi_ep_bind(ep->dg_ep, &cq->dg_cq->fid, FI_TRANSMIT | FI_RECV);
+			if (ret)
+				return ret;
+		}
+
+		ep->rx_cq = cq;
+		atomic_inc(&cq->util_cq.ref);
+	}
+	return 0;
+}
+
+static int rxd_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
+{
+	struct rxd_ep *ep;
+	struct rxd_av *av;
+	int ret = 0;
+
+	ep = container_of(ep_fid, struct rxd_ep, ep.fid);
+	switch (bfid->fclass) {
+	case FI_CLASS_AV:
+		if (ep->av) {
+			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
+				"duplicate AV binding\n");
+			return -FI_EINVAL;
+		}
+		av = container_of(bfid, struct rxd_av, util_av.av_fid.fid);
+		ret = fi_ep_bind(ep->dg_ep, &av->dg_av->fid, flags);
+		if (ret)
+			return ret;
+
+		/* todo: handle case where AV is updated after binding */
+		ep->peer_info = calloc(av->size, sizeof(struct rxd_peer));
+		ep->max_peers = av->size;
+		if (!ep->peer_info) {
+			return -FI_ENOMEM;
+		}
+
+		ep->av = av;
+		break;
+	case FI_CLASS_CQ:
+		ret = rxd_ep_bind_cq(ep, container_of(bfid, struct rxd_cq,
+						       util_cq.cq_fid.fid), flags);
+		break;
+	case FI_CLASS_EQ:
+		break;
+	default:
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
+			"invalid fid class\n");
+		ret = -FI_EINVAL;
+		break;
+	}
+	return ret;
+}
+
+static int rxd_ep_control(struct fid *fid, int command, void *arg)
+{
+	int ret;
+	struct rxd_ep *ep;
+
+	switch (command) {
+	case FI_ENABLE:
+		ep = container_of(fid, struct rxd_ep, ep.fid);
+		ret = rxd_ep_enable(ep);
+		break;
+	default:
+		ret = -FI_ENOSYS;
+		break;
+	}
+	return ret;
+}
+
+static struct fi_ops rxd_ep_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = rxd_ep_close,
+	.bind = rxd_ep_bind,
+	.control = rxd_ep_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static int rxd_ep_cm_setname(fid_t fid, void *addr, size_t addrlen)
+{
+	struct rxd_ep *ep;
+	ep = container_of(fid, struct rxd_ep, ep.fid);
+	return fi_setname(&ep->dg_ep->fid, addr, addrlen);
+}
+
+static int rxd_ep_cm_getname(fid_t fid, void *addr, size_t *addrlen)
+{
+	struct rxd_ep *ep;
+	ep = container_of(fid, struct rxd_ep, ep.fid);
+	return fi_getname(&ep->dg_ep->fid, addr, addrlen);
+}
+
+struct fi_ops_cm rxd_ep_cm = {
+	.size = sizeof(struct fi_ops_cm),
+	.setname = rxd_ep_cm_setname,
+	.getname = rxd_ep_cm_getname,
+	.getpeer = fi_no_getpeer,
+	.connect = fi_no_connect,
+	.listen = fi_no_listen,
+	.accept = fi_no_accept,
+	.reject = fi_no_reject,
+	.shutdown = fi_no_shutdown,
+};
+
+static int rxd_buf_region_alloc_hndlr(void *pool_ctx, void *addr, size_t len,
+				void **context)
+{
+	int ret;
+	struct fid_mr *mr;
+	struct rxd_domain *domain = (struct rxd_domain *)pool_ctx;
+
+	ret = fi_mr_reg(domain->dg_domain, addr, len,
+			FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL);
+	*context = mr;
+	return ret;
+}
+
+static void rxd_buf_region_free_hndlr(void *pool_ctx, void *context)
+{
+	fi_close((struct fid *) context);
+}
+
+int rxd_ep_create_buf_pools(struct rxd_ep *ep, struct fi_info *fi_info)
+{
+	ep->tx_pkt_pool = util_buf_pool_create_ex(
+		ep->domain->max_mtu_sz + sizeof(struct rxd_pkt_meta),
+		RXD_BUF_POOL_ALIGNMENT, 0, RXD_TX_POOL_CHUNK_CNT,
+	        (fi_info->mode & FI_LOCAL_MR) ? rxd_buf_region_alloc_hndlr : NULL,
+		(fi_info->mode & FI_LOCAL_MR) ? rxd_buf_region_free_hndlr : NULL,
+		ep->domain);
+	if (!ep->tx_pkt_pool)
+		return -FI_ENOMEM;
+
+	ep->rx_pkt_pool = util_buf_pool_create_ex(
+		ep->domain->max_mtu_sz + sizeof (struct rxd_rx_buf),
+		RXD_BUF_POOL_ALIGNMENT, 0, RXD_RX_POOL_CHUNK_CNT,
+	        (fi_info->mode & FI_LOCAL_MR) ? rxd_buf_region_alloc_hndlr : NULL,
+		(fi_info->mode & FI_LOCAL_MR) ? rxd_buf_region_free_hndlr : NULL,
+		ep->domain);
+	if (!ep->rx_pkt_pool)
+		goto err;
+
+	ep->tx_entry_fs = rxd_tx_entry_fs_create(1ULL << RXD_MAX_TX_BITS);
+	if (!ep->tx_entry_fs)
+		goto err;
+
+	ep->rx_entry_fs = rxd_rx_entry_fs_create(1ULL << RXD_MAX_RX_BITS);
+	if (!ep->rx_entry_fs)
+		goto err;
+
+	if (ep->caps & FI_MSG) {
+		ep->recv_fs = rxd_recv_fs_create(ep->rx_size);
+		dlist_init(&ep->recv_list);
+		if (!ep->recv_fs)
+			goto err;
+	}
+
+	if (ep->caps & FI_TAGGED) {
+		ep->trecv_fs = rxd_trecv_fs_create(ep->rx_size);
+		dlist_init(&ep->trecv_list);
+		if (!ep->trecv_fs)
+			goto err;
+	}
+
+	return 0;
+err:
+	if (ep->tx_pkt_pool)
+		util_buf_pool_destroy(ep->tx_pkt_pool);
+
+	if (ep->rx_pkt_pool)
+		util_buf_pool_destroy(ep->rx_pkt_pool);
+
+	if (ep->tx_entry_fs)
+		rxd_tx_entry_fs_free(ep->tx_entry_fs);
+
+	if (ep->rx_entry_fs)
+		rxd_rx_entry_fs_free(ep->rx_entry_fs);
+
+	if (ep->recv_fs)
+		rxd_recv_fs_free(ep->recv_fs);
+
+	if (ep->trecv_fs)
+		rxd_trecv_fs_free(ep->trecv_fs);
+
+	return -FI_ENOMEM;
+}
+
+int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
+		  struct fid_ep **ep, void *context)
+{
+	int ret;
+	struct fi_info *dg_info;
+	struct rxd_ep *rxd_ep;
+	struct rxd_domain *rxd_domain;
+
+	ret = fi_check_info(&rxd_util_prov, info, FI_MATCH_PREFIX);
+	if (ret)
+		return ret;
+
+	ret = ofix_getinfo(rxd_prov.version, NULL, NULL, 0, &rxd_util_prov,
+			   info, rxd_alter_layer_info,
+			   rxd_alter_base_info, 1, &dg_info);
+	if (ret)
+		return ret;
+
+	rxd_domain = container_of(domain, struct rxd_domain, util_domain.domain_fid);
+	rxd_ep = calloc(1, sizeof(*rxd_ep));
+	if (!rxd_ep) {
+		ret = -FI_ENOMEM;
+		goto err1;
+	}
+
+	rxd_ep->addrlen = (info->src_addr) ? info->src_addrlen : info->dest_addrlen;
+	rxd_ep->do_local_mr = (rxd_domain->dg_mode & FI_LOCAL_MR) ? 1 : 0;
+	ret = fi_endpoint(rxd_domain->dg_domain, dg_info, ep, context);
+	if (ret)
+		goto err2;
+
+	rxd_ep->caps = info->caps;
+	rxd_ep->domain = rxd_domain;
+	rxd_ep->rx_size = info->rx_attr->size;
+	ret = rxd_ep_create_buf_pools(rxd_ep, info);
+	if (ret)
+		goto err3;
+
+	rxd_ep->dg_ep = *ep;
+	rxd_ep->ep.fid.ops = &rxd_ep_fi_ops;
+	rxd_ep->ep.cm = &rxd_ep_cm;
+	rxd_ep->ep.ops = &rxd_ops_ep;
+	rxd_ep->ep.msg = &rxd_ops_msg;
+	rxd_ep->ep.tagged = &rxd_ops_tagged;
+
+	dlist_init(&rxd_ep->tx_entry_list);
+	dlist_init(&rxd_ep->rx_entry_list);
+	dlist_init(&rxd_ep->wait_rx_list);
+	dlist_init(&rxd_ep->unexp_msg_list);
+	dlist_init(&rxd_ep->unexp_tag_list);
+	slist_init(&rxd_ep->rx_pkt_list);
+	fastlock_init(&rxd_ep->lock);
+
+	dlist_init(&rxd_ep->dom_entry);
+	atomic_inc(&rxd_ep->domain->util_domain.ref);
+
+	*ep = &rxd_ep->ep;
+	fi_freeinfo(dg_info);
+	return 0;
+
+err3:
+	fi_close(&(*ep)->fid);
+err2:
+	free(rxd_ep);
+err1:
+	fi_freeinfo(dg_info);
+	return ret;
+}
+
+int rxd_ep_retry_pkt(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
+		   struct rxd_pkt_meta *pkt)
+{
+	int ret;
+	struct ofi_ctrl_hdr *ctrl;
+
+	ctrl = (struct ofi_ctrl_hdr *)pkt->pkt_data;
+	if (pkt->retries > RXD_MAX_PKT_RETRY) {
+		/* todo: report error */
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "Pkt delivery failed\n", ctrl->seg_no);
+		return -FI_EIO;
+	}
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "retry packet : %2d, size: %d, tx_id :%p\n",
+		ctrl->seg_no, ctrl->type == ofi_ctrl_start_data ?
+		ctrl->seg_size + RXD_START_DATA_PKT_SZ :
+		ctrl->seg_size + RXD_DATA_PKT_SZ,
+		ctrl->msg_id);
+
+	ret = fi_send(ep->dg_ep, ctrl,
+		      ctrl->type == ofi_ctrl_start_data ?
+		      ctrl->seg_size + RXD_START_DATA_PKT_SZ :
+		      ctrl->seg_size + RXD_DATA_PKT_SZ,
+		      rxd_mr_desc(pkt->mr, ep),
+		      tx_entry->peer, &pkt->context);
+
+	if (ret != -FI_EAGAIN)
+		pkt->retries++;
+
+	if (ret && ret != -FI_EAGAIN) {
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "Pkt sent failed seg: %d, ret: %d\n",
+			ctrl->seg_no, ret);
+	}
+
+	return ret;
+}
+
+void rxd_ep_progress(struct rxd_ep *ep)
+{
+	struct dlist_entry *tx_item, *pkt_item;
+	struct rxd_tx_entry *tx_entry;
+	struct rxd_pkt_meta *pkt;
+	uint64_t curr_stamp;
+
+	rxd_ep_lock_if_required(ep);
+	curr_stamp = fi_gettime_us();
+	dlist_foreach(&ep->tx_entry_list, tx_item) {
+
+		tx_entry = container_of(tx_item, struct rxd_tx_entry, entry);
+
+		if (tx_entry->win_sz)
+			rxd_tx_entry_progress(ep, tx_entry, NULL);
+
+		else if (tx_entry->is_waiting &&
+			 (curr_stamp - tx_entry->retry_stamp > RXD_WAIT_TIMEOUT) &&
+			 dlist_empty(&tx_entry->pkt_list)) {
+			tx_entry->win_sz = 1;
+			tx_entry->is_waiting = 0;
+
+			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "Progressing waiting entry [%p]\n",
+				tx_entry->msg_id);
+
+			rxd_tx_entry_progress(ep, tx_entry, NULL);
+			tx_entry->retry_stamp = fi_gettime_us();
+		}
+
+		dlist_foreach(&tx_entry->pkt_list, pkt_item) {
+			pkt = container_of(pkt_item, struct rxd_pkt_meta, entry);
+			if (curr_stamp > pkt->us_stamp &&
+			    curr_stamp - pkt->us_stamp >
+			    (1 << (pkt->retries + 1)) * RXD_RETRY_TIMEOUT) {
+				pkt->us_stamp = curr_stamp;
+				rxd_ep_retry_pkt(ep, tx_entry, pkt);
+			}
+		}
+	}
+	rxd_ep_unlock_if_required(ep);
+}


### PR DESCRIPTION
-> Add RxD address vector

  This commit adds address-vector (AV) for RxD provider. RxD AV uses
  util-AV internally, and keeps a pointer to the underlying DGRAM
  provider AV (opened in AV-table mode).

  To insert an address, the address is first inserted to the DGRAM AV,
  and the returned index is stored in the util-AV. There is no
  one-to-one relationship between util-AV entries and DGRAM-AV entries
  as the addresses can be inserted to DGRAM-AV only (eg. a receive-only
  EP, but ACK messages need to be sent out to peer).


-> prov/rxd - Add EP and CQ for RxD provider

  This commit adds EP and CQ components for the RxD provider. This patch
  enables fi_msg and fi_tagged capabilities for RxD provider.

  The overall message transfer protocol is as follows:
  - Sender sends the header packet (msg_id, msg_sz, msg_type) along with
  payload data to the receiver.
  - Receiver finds the matching receive and copies the payload. It sends
  an ack back along with the allowes window size (number for packets
  that it is ready to receive).
  - Sender gets the ack, and sends the data packets till the allowed
  window size. Packets are resent when NACKs/Timeouts are detected.
  - Please refer to fi_proto.h for the protocol defenitions.

  RxD uses util-CQ for reporting CQ entries. It also keeps a handle to
  the underlying DGRAM provider CQ for pulling out completions.


(This is a work-in-progress. There are still some corner case issues, which need to be handled)
