### PR TITLE
configury: add shm_open check in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -115,7 +115,7 @@ AC_CHECK_FUNC([pthread_spin_init],
 
 dnl shm_open not used in the common code on os-x
 
-if test "$macos" -eq "0"; then
+if test "$macos" -eq 0; then
 AC_CHECK_FUNC([shm_open],
 	[],
 	[AC_SEARCH_LIBS([shm_open],[rt],[],

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,15 @@ AC_CHECK_FUNC([pthread_spin_init],
 	[have_spinlock=1],
 	[have_spinlock=0])
 
+dnl shm_open not used in the common code on os-x
+
+if test "$macos" -eq "0"; then
+AC_CHECK_FUNC([shm_open],
+	[],
+	[AC_SEARCH_LIBS([shm_open],[rt],[],
+	 [AC_MSG_ERROR([shm_open() not found.  libfabric requires shm_open.])])])
+fi
+
 AC_DEFINE_UNQUOTED([PT_LOCK_SPIN], [$have_spinlock],
 	[Define to 1 if pthread_spin_init is available.])
 


### PR DESCRIPTION
shm_open is now used in common code.  Since
this was only by chance being checked in certain
providers, the enable-direct build with GNI provider
was failing.

@sungeunchoi 
@goodell 

Fixes ofi-cray/libfabric-cray#911

Signed-off-by: Howard Pritchard <howardp@lanl.gov>