### PR TITLE
prov/sockets: Allow multiple threads to wait on one counter

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -271,7 +271,6 @@ struct sock_cntr {
 	struct fid_cntr cntr_fid;
 	struct sock_domain *domain;
 	atomic_t value;
-	atomic_t threshold;
 	atomic_t ref;
 	atomic_t err_cnt;
 	atomic_t last_read_val;
@@ -288,7 +287,7 @@ struct sock_cntr {
 
 	struct fid_wait *waitset;
 	int signal;
-	int is_waiting;
+	atomic_t num_waiting;
 	int err_flag;
 };
 


### PR DESCRIPTION
fi_cntr_wait cannot be called on a single counter from multiple threads, even with the FI_WAIT_MUTEX_COND wait object (it returns -FI_EBUSY). This patch allows that use case.