### PR TITLE
Allow OFI to be embedded into another library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,11 +10,17 @@ AM_CPPFLAGS = \
 	-DRDMADIR=\"@rdmadir@\" \
 	-DPROVDLDIR=\"$(pkglibdir)\"
 
-lib_LTLIBRARIES = src/libfabric.la
+noinst_LTLIBRARIES =
+lib_LTLIBRARIES =
+
+if EMBEDDED
+noinst_LTLIBRARIES += src/libfabric.la
+else
+lib_LTLIBRARIES += src/libfabric.la
+endif
 
 pkglib_LTLIBRARIES = $(DL_PROVIDERS)
 
-noinst_LTLIBRARIES =
 
 ACLOCAL_AMFLAGS = -I config
 AM_CFLAGS = -g -Wall

--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,15 @@ AC_CACHE_CHECK(whether ld accepts --version-script, ac_cv_version_script,
         ac_cv_version_script=no
     fi])
 
+AC_ARG_ENABLE([embedded],
+	      [AS_HELP_STRING([--enable-embedded],
+			      [Enable embedded support (turns off symbol versioning) @<:@default=no@:>@])
+	      ],
+	      [ac_asm_symver_support=0
+               icc_symver_hack=1],
+	      [enable_embedded=no])
+AM_CONDITIONAL([EMBEDDED], [test x"$enable_embedded" = x"yes"])
+
 AM_CONDITIONAL(HAVE_LD_VERSION_SCRIPT, test "$ac_cv_version_script" = "yes")
 
 dnl Disable symbol versioning when -ipo is in CFLAGS or ipo is disabled by icc.


### PR DESCRIPTION
Add a new `--enable-embedded` configure flag to change the makefiles to
make the library embeddable rather than built independently.

Signed-off-by: Wesley Bland <wesley.bland@intel.com>