### PR TITLE
prov/verbs: ep rdm bugfixes

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -89,7 +89,6 @@ ssize_t fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_tagged_conn *conn)
 		if (rdma_disconnect(conn->id[0])) {
 			VERBS_INFO_ERRNO(FI_LOG_AV, "rdma_disconnect\n", errno);
 			ret = -errno;
-			assert(ret == 0);
 		}
 	}
 
@@ -109,7 +108,6 @@ ssize_t fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_tagged_conn *conn)
 		ret = -FI_EOTHER;
 	}
 
-	assert(ret == FI_SUCCESS);
 	return ret;
 }
 

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -96,7 +96,7 @@ do {                                                                	\
 } while (0)
 
 #define FI_IBV_RDM_TAGGED_SENDS_OUTGOING_ARE_LIMITED(_connection, _ep)  \
-	((_connection)->sends_outgoing > 0.5*(_ep)->sq_wr_depth)
+	((_connection)->sends_outgoing >= (_ep)->sq_wr_depth - 1)
 
 #define PEND_SEND_IS_LIMITED(_ep)                                       \
 	((_ep)->posted_sends > 0.5 * (_ep)->scq_depth)

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -174,7 +174,8 @@ void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_tagged_conn *conn,
 int fi_ibv_rdm_find_ipoib_addr(const struct sockaddr_in *addr,
 			       struct fi_ibv_rdm_cm* cm)
 {
-	struct ifaddrs *addrs, *tmp;
+	struct ifaddrs *addrs = NULL;
+	struct ifaddrs *tmp = NULL;
 	int found = 0;
 
 	char iface[IFNAMSIZ];
@@ -197,7 +198,10 @@ int fi_ibv_rdm_find_ipoib_addr(const struct sockaddr_in *addr,
 
 	strncpy(iface, iface_tmp, iface_len);
 
-	getifaddrs(&addrs);
+	if (getifaddrs(&addrs)) {
+		return 1;
+	}
+
 	tmp = addrs;
 	while (tmp) {
 		if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_INET) {


### PR DESCRIPTION
 - fix hang of bidirectional RNDV tests on iWarp - workarounded with posting only 1 signaled ibv_post_send at time
 - fix processing of rejected event in connection management logic when user's data is not received (iWarp specific), workarounded with checking role and event status
 - add checking getifaddrs return code (Coverity issue #127875)

@a-ilango , please review
