### PR TITLE
prov/sockets: Synchronize releasing of connection map resources

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -1096,7 +1096,7 @@ ssize_t sock_conn_send_src_addr(struct sock_ep_attr *ep_attr, struct sock_tx_ctx
 				struct sock_conn *conn);
 int sock_conn_listen(struct sock_ep_attr *ep_attr);
 void sock_conn_map_destroy(struct sock_ep_attr *ep_attr);
-void sock_conn_reset_entry(struct sock_conn *conn);
+void sock_conn_release_entry(struct sock_conn_map *map, struct sock_conn *conn);
 void sock_set_sockopts(int sock);
 int fd_set_nonblock(int fd);
 void sock_set_sockopt_reuseaddr(int sock);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -686,9 +686,6 @@ static int sock_ep_close(struct fid *fid)
 		sock_rx_ctx_free(sock_ep->attr->rx_array[0]);
 	}
 
-	idm_reset(&sock_ep->attr->conn_idm);
-	idm_reset(&sock_ep->attr->av_idm);
-
 	free(sock_ep->attr->tx_array);
 	free(sock_ep->attr->rx_array);
 
@@ -697,7 +694,12 @@ static int sock_ep_close(struct fid *fid)
 	if (sock_ep->attr->dest_addr)
 		free(sock_ep->attr->dest_addr);
 
+	fastlock_acquire(&sock_ep->attr->domain->pe->lock);
+	idm_reset(&sock_ep->attr->conn_idm);
+	idm_reset(&sock_ep->attr->av_idm);
 	sock_conn_map_destroy(sock_ep->attr);
+	fastlock_release(&sock_ep->attr->domain->pe->lock);
+
 	atomic_dec(&sock_ep->attr->domain->ref);
 	fastlock_destroy(&sock_ep->attr->lock);
 	free(sock_ep->attr);

--- a/prov/sockets/src/sock_epoll.c
+++ b/prov/sockets/src/sock_epoll.c
@@ -76,7 +76,9 @@ int sock_epoll_create(struct sock_epoll_set *set, int size)
 
 int sock_epoll_add(struct sock_epoll_set *set, int fd)
 {
+	int ret;
 	struct epoll_event event;
+
 	memset(&event, 0, sizeof(event));
 	event.data.fd = fd;
 	event.events = EPOLLIN;
@@ -84,14 +86,25 @@ int sock_epoll_add(struct sock_epoll_set *set, int fd)
 	if (set->used == set->size)
 		return -1;
 
-	set->used++;
-	return epoll_ctl(set->fd, EPOLL_CTL_ADD, fd, &event);
+	ret = epoll_ctl(set->fd, EPOLL_CTL_ADD, fd, &event);
+	if (!ret)
+		set->used++;
+
+	return ret;
 }
 
 int sock_epoll_del(struct sock_epoll_set *set, int fd)
 {
-	set->used--;
-	return epoll_ctl(set->fd, EPOLL_CTL_DEL, fd, NULL);
+	int ret;
+
+	if (!set->used)
+		return -1;
+
+	ret = epoll_ctl(set->fd, EPOLL_CTL_DEL, fd, NULL);
+	if (!ret)
+		set->used--;
+
+	return ret;
 }
 
 int sock_epoll_wait(struct sock_epoll_set *set, int timeout)


### PR DESCRIPTION
- Fixed indexing issue in sock_epoll add/delete
- Added a flag to track if a connection fd is already released
- Added progress thread lock in ep_close while destroying connection map
- Fixed the handling of <code>used</code> parameter during connection map insert and destroy

Verified with fabtests and SandiaOpenSHMEM tests. @jithinjosepkl