### PR TITLE
usnic: Convert port to host order.

### DIFF
--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -504,7 +504,7 @@ usdf_av_straddr(struct fid_av *av, const void *addr,
 
 	sin = addr;
 	size = snprintf(straddr, sizeof straddr, "%s:%d",
-			inet_ntoa(sin->sin_addr), sin->sin_port);
+			inet_ntoa(sin->sin_addr), ntohs(sin->sin_port));
 	snprintf(buf, *len, "%s", straddr);
 	*len = size + 1;
 	return buf;


### PR DESCRIPTION
When converting an address to a string, make sure the port is in host
order.

@goodell 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>