### PR TITLE
man: Wrong interface for fi_av_straddr

### DIFF
--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -57,7 +57,7 @@ fi_addr_t fi_rx_addr(fi_addr_t fi_addr, int rx_index,
 	  int rx_ctx_bits);
 
 const char * fi_av_straddr(struct fid_av *av, const void *addr,
-      void *buf, size_t *len);
+      char *buf, size_t *len);
 ```
 
 # ARGUMENTS


### PR DESCRIPTION
The man page (fi_av:3) has inconsistent interface of the function fi_av_straddr.

The buf argument (3rd) is actually a char* type,
however the man page shows it as void* type.

Checked that the header file in include/rdma/fi_domain.h has char* type
and compiles properly with char* type.

Signed-off-by: Chang Hyun Park <heartinpiece@gmail.com>