### PR TITLE
sockets: Convert port to host format in straddr.

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -385,7 +386,7 @@ static const char *sock_av_straddr(struct fid_av *av, const void *addr,
 
 	sin = addr;
 	size = snprintf(straddr, sizeof(straddr), "%s:%d",
-			inet_ntoa(sin->sin_addr), sin->sin_port);
+			inet_ntoa(sin->sin_addr), ntohs(sin->sin_port));
 	snprintf(buf, *len, "%s", straddr);
 	*len = size + 1;
 	return buf;


### PR DESCRIPTION
Recently fixed this in the usNIC provider, noticed the sockets provider also had the same issue.

Signed-off-by: Ben Turrubiates \<bturrubi@cisco.com\>