### PR TITLE
prov/sockets: Update fi_poll semantics

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -274,6 +274,7 @@ struct sock_cntr {
 	atomic_t threshold;
 	atomic_t ref;
 	atomic_t err_cnt;
+	atomic_t last_read_val;
 	pthread_cond_t 	cond;
 	pthread_mutex_t mut;
 	struct fi_cntr_attr attr;

--- a/prov/sockets/src/sock_poll.c
+++ b/prov/sockets/src/sock_poll.c
@@ -142,8 +142,10 @@ static int sock_poll_poll(struct fid_poll *pollset, void **context, int count)
 						cntr_fid);
 			sock_cntr_progress(cntr);
 			pthread_mutex_lock(&cntr->mut);
-			if (atomic_get(&cntr->value) >=
-				atomic_get(&cntr->threshold)) {
+			if (atomic_get(&cntr->value) !=
+			    atomic_get(&cntr->last_read_val)) {
+				atomic_set(&cntr->last_read_val,
+					   atomic_get(&cntr->value));
 				*context++ = cntr->cntr_fid.fid.context;
 				ret_count++;
 			}


### PR DESCRIPTION
- Update fi_poll semanctis for counters. fi_poll() returns success if
  the counter value is different from the last-read-value.

Fixes #2240

Signed-off-by: Jithin Jose <jithin.jose@intel.com>