### PR TITLE
man: Provider manpages added to `make nroff`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -288,7 +288,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libfabric.pc
 
 nroff:
-	@for file in $(real_man_pages); do \
+	@for file in $(real_man_pages) $(prov_install_man_pages); do \
 	    source=`echo $$file | sed -e 's@/man[0-9]@@'`; \
 	    config/md2nroff.pl --source=$$source.md; \
 	done


### PR DESCRIPTION
Previously manpages of providers were not compiled on

```
`make nroff`
```

This was because the manpages for the providers were not included in the
list of manpages to compile `real_man_pages`.
Provider manpages were included in `prov_install_man_pages`.
In the `Makefile.am` the `prov_install_man_pages` is an empty list.
However after configuring, the list is populated in the Makefile.

Signed-off-by: Chang Hyun Park <heartinpiece@gmail.com>