### PR TITLE
prov/gni: Free xpmem_hndl field in gnix_fid_ep if

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1914,6 +1914,15 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	return ret;
 
 err:
+	if (ep_priv->xpmem_hndl) {
+		if (_gnix_xpmem_handle_destroy(ep_priv->xpmem_hndl) !=
+		    FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_xpmem_handle_destroy returned %s\n",
+				  fi_strerror(-ret));
+		}
+	}
+
 	__destruct_tag_storages(ep_priv);
 
 	if (free_list_inited == true)


### PR DESCRIPTION
endpoint initialization fails

upstream merge of ofi-cray/libfabric-cray#915
@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@f56a687be01cba1a25c6aa94ab79ca92590192c8)