### PR TITLE
prov/gni: return -FI_EOPBADSTATE for fi_enable

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -1261,6 +1261,14 @@ DIRECT_FN STATIC int gnix_ep_control(fid_t fid, int command, void *arg)
 	 */
 	case FI_ENABLE:
 		if (GNIX_EP_RDM_DGM(ep->type)) {
+			if ((ep->send_cq && ep->tx_enabled)) {
+				ret = -FI_EOPBADSTATE;
+				goto err;
+			}
+			if ((ep->recv_cq && ep->rx_enabled)) {
+				ret = -FI_EOPBADSTATE;
+				goto err;
+			}
 			ret = _gnix_vc_cm_init(ep->cm_nic);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -170,6 +170,9 @@ void rdm_api_setup_ep(void)
 		ret = fi_enable(ep[i]);
 		cr_assert(!ret, "fi_ep_enable");
 
+		ret = fi_enable(ep[i]);
+		cr_assert_eq(ret, -FI_EOPBADSTATE);
+
 		ret = fi_cntr_open(dom[i], &cntr_attr, send_cntr + i, 0);
 		cr_assert(!ret, "fi_cntr_open");
 


### PR DESCRIPTION
called on an ep which has already been enabled.

Fixes ofi-cray/libfabric-cray#903

upstream merge of ofi-cray/libfabric-cray#920
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@c808615bea271350292f118df6e8c7eef415a6a6)