### PR TITLE
prov/gni: fix up kdreg related warnings

### DIFF
--- a/prov/gni/src/gnix_mr_cache.c
+++ b/prov/gni/src/gnix_mr_cache.c
@@ -556,7 +556,7 @@ __clear_notifier_events(gnix_mr_cache_t *cache)
 		} else {
 			/* Should we do something else here? */
 			GNIX_FATAL(FI_LOG_MR,
-				   "_gnix_notifier_get_event returned incomplete event");
+				   "_gnix_notifier_get_event returned incomplete event\n");
 		}
 		ret = _gnix_notifier_get_event(cache->attr.notifier,
 					       &cookie, sizeof(cookie));
@@ -564,7 +564,7 @@ __clear_notifier_events(gnix_mr_cache_t *cache)
 	if (ret != -FI_EAGAIN) {
 		/* Should we do something else here? */
 		GNIX_WARN(FI_LOG_MR,
-			  "_gnix_notifier_get_event returned error: %s",
+			  "_gnix_notifier_get_event returned error: %s\n",
 			  fi_strerror(-ret));
 	}
 

--- a/prov/gni/src/gnix_mr_notifier.c
+++ b/prov/gni/src/gnix_mr_notifier.c
@@ -231,7 +231,7 @@ _gnix_notifier_get_event(struct gnix_mr_notifier *mrn, void* buf, size_t len)
 		} else {
 			ret_errno = errno;
 			if (ret_errno != EAGAIN) {
-				GNIX_INFO(FI_LOG_MR,
+				GNIX_WARN(FI_LOG_MR,
 					  "kdreg event read failed: %s\n",
 					  strerror(ret_errno));
 			}


### PR DESCRIPTION
Relates to ofi-cray/libfabric-cray#918

upstream merge of ofi-cray/libfabric-cray#921
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@519eb58b92fe5082c25afec9ce371b5181b6099d)