### PR TITLE
fixed windows build

### DIFF
--- a/include/windows/netinet/in.h
+++ b/include/windows/netinet/in.h
@@ -1,4 +1,9 @@
 
-#pragma once
+#ifndef _FI_WIN_NETINET_IN_H_
+#define _FI_WIN_NETINET_IN_H_
 
+#include <WinSock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
 
+#endif /* _FI_WIN_NETINET_IN_H_ */

--- a/prov/sockets/src/sock_wait.c
+++ b/prov/sockets/src/sock_wait.c
@@ -50,7 +50,9 @@ enum {
 
 int sock_wait_get_obj(struct fid_wait *fid, void *arg)
 {
+#ifndef _WIN32 /* there is no support of wait objects on windows */
 	struct fi_mutex_cond mut_cond;
+#endif /* _WIN32 */
 	struct sock_wait *wait;
 
 	wait = container_of(fid, struct sock_wait, wait_fid.fid);
@@ -58,6 +60,7 @@ int sock_wait_get_obj(struct fid_wait *fid, void *arg)
 		return -FI_ENOSYS;
 
 	switch (wait->type) {
+#ifndef _WIN32
 	case FI_WAIT_FD:
 		memcpy(arg, &wait->wobj.fd[WAIT_READ_FD], sizeof(int));
 		break;
@@ -67,7 +70,7 @@ int sock_wait_get_obj(struct fid_wait *fid, void *arg)
 		mut_cond.cond  = &wait->wobj.mutex_cond.cond;
 		memcpy(arg, &mut_cond, sizeof(mut_cond));
 		break;
-
+#endif /* _WIN32 */
 	default:
 		SOCK_LOG_ERROR("Invalid wait obj type\n");
 		return -FI_EINVAL;


### PR DESCRIPTION
fixed build on windows platform
- disabled processing of object in sock_wait_get_obj for
  windows platform
- updated Linux specific header replacer to provide compilation

Signed-off-by: Oblomov, Sergery <sergey.oblomov@intel.com>