### PR TITLE
usnic: Fix EP enabled check in size left.

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -263,6 +263,10 @@ struct usdf_rx {
 #define rx_utof(RX) (&(RX)->rx_fid)
 #define rx_utofid(RX) (&(RX)->rx_fid.fid)
 
+enum {
+	USDF_EP_ENABLED = (1 << 0)
+};
+
 struct usdf_ep {
 	struct fid_ep ep_fid;
 	struct usdf_domain *ep_domain;
@@ -275,6 +279,8 @@ struct usdf_ep {
 
 	uint8_t ep_tx_completion;
 	uint8_t ep_rx_completion;
+
+	uint32_t flags;
 
 	uint32_t ep_wqe;	/* requested queue sizes */
 	uint32_t ep_rqe;

--- a/prov/usnic/src/usdf_dgram.c
+++ b/prov/usnic/src/usdf_dgram.c
@@ -442,8 +442,8 @@ ssize_t usdf_dgram_rx_size_left(struct fid_ep *fep)
 
 	ep = ep_ftou(fep);
 
-	if (ep->e.dg.ep_qp == NULL)
-		return -FI_EOPBADSTATE; /* EP not enabled */
+	if (!(ep->flags & USDF_EP_ENABLED))
+		return -FI_EOPBADSTATE;
 
 	return usd_get_recv_credits(ep->e.dg.ep_qp) /
 		(ep->e.dg.rx_iov_limit + 1);
@@ -460,8 +460,8 @@ ssize_t usdf_dgram_tx_size_left(struct fid_ep *fep)
 
 	ep = ep_ftou(fep);
 
-	if (ep->e.dg.ep_qp == NULL)
-		return -FI_EOPBADSTATE; /* EP not enabled */
+	if (!(ep->flags & USDF_EP_ENABLED))
+		return -FI_EOPBADSTATE;
 
 	return usd_get_send_credits(ep->e.dg.ep_qp) /
 		(ep->e.dg.tx_iov_limit + 1);
@@ -777,8 +777,8 @@ ssize_t usdf_dgram_prefix_rx_size_left(struct fid_ep *fep)
 
 	ep = ep_ftou(fep);
 
-	if (ep->e.dg.ep_qp == NULL)
-		return -FI_EOPBADSTATE; /* EP not enabled */
+	if (!(ep->flags & USDF_EP_ENABLED))
+		return -FI_EOPBADSTATE;
 
 	/* prefix_recvv can post up to iov_limit descriptors
 	 */
@@ -796,8 +796,8 @@ ssize_t usdf_dgram_prefix_tx_size_left(struct fid_ep *fep)
 
 	ep = ep_ftou(fep);
 
-	if (ep->e.dg.ep_qp == NULL)
-		return -FI_EOPBADSTATE; /* EP not enabled */
+	if (!(ep->flags & USDF_EP_ENABLED))
+		return -FI_EOPBADSTATE;
 
 	/* prefix_sendvcan post up to iov_limit descriptors
 	 */

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -138,6 +138,8 @@ usdf_ep_dgram_enable(struct fid_ep *fep)
 		goto fail;
 	}
 
+	ep->flags |= USDF_EP_ENABLED;
+
 	return 0;
 
 fail:

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -548,7 +548,16 @@ fail:
 static int
 usdf_ep_msg_enable(struct fid_ep *fep)
 {
-	return usdf_ep_msg_get_queues(ep_ftou(fep));
+	struct usdf_ep *ep;
+	int ret;
+
+	ep = ep_ftou(fep);
+
+	ret = usdf_ep_msg_get_queues(ep);
+	if (ret == FI_SUCCESS)
+		ep->flags |= USDF_EP_ENABLED;
+
+	return ret;
 }
 
 static ssize_t

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -539,7 +539,16 @@ fail:
 static int
 usdf_ep_rdm_enable(struct fid_ep *fep)
 {
-	return usdf_ep_rdm_get_queues(ep_ftou(fep));
+	struct usdf_ep *ep;
+	int ret;
+
+	ep = ep_ftou(fep);
+
+	ret = usdf_ep_rdm_get_queues(ep);
+	if (ret == FI_SUCCESS)
+		ep->flags |= USDF_EP_ENABLED;
+
+	return ret;
 }
 
 static ssize_t

--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -1229,8 +1229,9 @@ ssize_t usdf_msg_rx_size_left(struct fid_ep *fep)
 
 	ep = ep_ftou(fep);
 	rx = ep->ep_rx;
-	if (rx == NULL)
-		return -FI_EOPBADSTATE; /* EP not enabled */
+
+	if (!(ep->flags & USDF_EP_ENABLED))
+		return -FI_EOPBADSTATE;
 
 	return rx->r.msg.rx_num_free_rqe;
 }
@@ -1244,8 +1245,9 @@ ssize_t usdf_msg_tx_size_left(struct fid_ep *fep)
 
 	ep = ep_ftou(fep);
 	tx = ep->ep_tx;
-	if (tx == NULL)
-		return -FI_EOPBADSTATE; /* EP not enabled */
+
+	if (!(ep->flags & USDF_EP_ENABLED))
+		return -FI_EOPBADSTATE;
 
 	return tx->t.msg.tx_num_free_wqe;
 }

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -1612,8 +1612,9 @@ ssize_t usdf_rdm_rx_size_left(struct fid_ep *fep)
 
 	ep = ep_ftou(fep);
 	rx = ep->ep_rx;
-	if (rx == NULL)
-		return -FI_EOPBADSTATE; /* EP not enabled */
+
+	if (!(ep->flags & USDF_EP_ENABLED))
+		return -FI_EOPBADSTATE;
 
 	return rx->r.rdm.rx_num_free_rqe;
 }
@@ -1627,8 +1628,9 @@ ssize_t usdf_rdm_tx_size_left(struct fid_ep *fep)
 
 	ep = ep_ftou(fep);
 	tx = ep->ep_tx;
-	if (tx == NULL)
-		return -FI_EOPBADSTATE; /* EP not enabled */
+
+	if (!(ep->flags & USDF_EP_ENABLED))
+		return -FI_EOPBADSTATE;
 
 	return tx->t.rdm.tx_num_free_wqe;
 }


### PR DESCRIPTION
Add a flags field to the EP and define a flag that represents whether an
endpoint has been enabled or not. Use this flag to check for an invalid
state in the size left functions.

Fixes #2265.

@jsquyres @goodell @piroux 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>