### PR TITLE
prov/gni: Adds four byte alignment for sendv/recvv

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -50,6 +50,7 @@ extern "C" {
 #include "gnix_util.h"
 
 #define GNIX_DEF_MAX_NICS_PER_PTAG	4
+#define GNIX_MAX_IOV_LIMIT 8	/* this should have been pulled in from gnix.h.. */
 
 extern uint32_t gnix_max_nics_per_ptag;
 
@@ -267,7 +268,7 @@ struct gnix_smsg_rndzv_iov_start_hdr {
 	uint64_t imm;
 	uint64_t msg_tag;
 	uint64_t req_addr;
-	size_t iov_cnt;
+	size_t   iov_cnt;
 	uint64_t send_len;
 };
 


### PR DESCRIPTION
	  - Each send vector is checked for alignment on the
	  client. If unaligned buffers are found, the
	  unaligned head and tail sections are sent to the
	  remote peer in the control message.

	  - When the iov txd's are being built, the recv iov
	  is checked for alignment. If unaligned recv addrs
	  are found, a chained transaction is created to
	  GET the head and tail sections.
	  	  - A head tail data buffer pool was added
		  to each endpoint for GETting the head and
		  tail sections on the remote peer.

	  - The heads and tails are finally copied to the
	  posted recv buffer just before sending the rndzv
	  fin message back to the sender.

prov/gni: Ensure FI_PEEK CQE is correct.

	  - Updated send/recv code to use the minimum
	  of the send length/recv length for generating
	  CQEs.

	  - Updated the peek_event_present_small_buff_provid
	  gnitest to use the recv buffer length for
	  validating the CQE contents.

	  - Updated __gnix_peek_request to support iovectors.

	  - Enabled and tested xpmem with sendv/recvv.

upstream merge of ofi-cray/libfabric-cray#922

@sungeunchoi 

Signed-off-by: Evan Harvey <eharvey@cray.com>

(cherry picked from commit ofi-cray/libfabric-cray@8a9234cc5cc4dfa2b71e5907dc627adc28bcc4a2)
(cherry picked from commit ofi-cray/libfabric-cray@42bd4f183709d84fb177dc24bf8fc9d5657311e4)
(cherry picked from commit ofi-cray/libfabric-cray@59e05e18b2597ea8ff67ec9b25d900a764d2b804)