### PR TITLE
prov/gni: fix a possible race condition with dgrams

### DIFF
--- a/prov/gni/include/gnix_datagram.h
+++ b/prov/gni/include/gnix_datagram.h
@@ -135,14 +135,6 @@ enum gnix_dgram_poll_type {
  * @var type                 datagram type (bound or wildcard)
  * @var d_hndl               pointer to datagram handle this datagram is
  *                           associated
- * @var pre_test_clbk_fn     Call back function to be called prior to
- *                           a call to GNI_EpPostDataTestById to retrieve
- *                           the datagram from GNI.  This callback is invoked
- *                           while the lock is held on the cm nic.
- * @var post_test_clbk_fn    Call back function to be called following a
- *                           call to GNI_EpPostDataTestById to retrieve
- *                           the datagram from GNI.  This callback is invoked
- *                           while the lock is held on the cm nic.
  * @var pre_post_clbk_fn     Call back function to be called prior to
  *                           to the call to GNI_EpPostDataWId. This callback
  *                           is invoked while the lock is held on the cm nic.
@@ -184,10 +176,6 @@ struct gnix_datagram {
 	enum gnix_dgram_state   state;
 	enum gnix_dgram_type    type;
 	struct gnix_dgram_hndl  *d_hndl;
-	int  (*pre_test_clbk_fn)(struct gnix_datagram *);
-	int  (*post_test_clbk_fn)(struct gnix_datagram *,
-				      struct gnix_address,
-				      gni_post_state_t);
 	int  (*pre_post_clbk_fn)(struct gnix_datagram *,
 				 int *);
 	int  (*post_post_clbk_fn)(struct gnix_datagram *,


### PR DESCRIPTION
When an app is using manual progress for control, but
has data progress set to auto, its possible for multiple
threads to be progressing datagrams.  This can result in
occasions where multiple threads may detect the presence
of a complete datagram transaction via GNI_PostDataProbeById,
but only one of the threads will actually dequeue the datagram
in the subsequent call to GNI_EpPostDataTestById, the others
will get an GNI_RC_NO_MATCH error return.

This was not being properly handled.

@sungeunchoi 

upstream merge of ofi-cray/libfabric-cray#928

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@7ffb3c06bd3387998d05399e7f211ef24c80c132)