### PR TITLE
-I flags go in CPPFLAGS, not CFLAGS

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -7,7 +7,7 @@ if HAVE_GNI
 # source code, so just add prov/gni to the include path
 # rather than prov/gni/ccan
 #
-AM_CFLAGS += -I$(top_srcdir)/prov/gni/include -I$(top_srcdir)/prov/gni
+AM_CPPFLAGS += -I$(top_srcdir)/prov/gni/include -I$(top_srcdir)/prov/gni
 
 _gni_files = \
 	prov/gni/src/gnix_atomic.c \

--- a/prov/sockets/Makefile.include
+++ b/prov/sockets/Makefile.include
@@ -2,7 +2,7 @@
 
 if HAVE_SOCKETS
 
-AM_CFLAGS += -I$(top_srcdir)/prov/sockets/include -I$(top_srcdir)/prov/sockets
+AM_CPPFLAGS += -I$(top_srcdir)/prov/sockets/include -I$(top_srcdir)/prov/sockets
 
 _sockets_files = \
 	prov/sockets/src/sock_av.c \


### PR DESCRIPTION
Update the sockets and gni providers to set `-I` flags in `AM_CPPFLAGS` instead of `AM_CFLAGS`.

@jithinjosepkl @shantonu @hppritcha @sungeunchoi 