### PR TITLE
Pr/sockets size left

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -942,6 +942,7 @@ int sock_verify_info(struct fi_info *hints);
 int sock_verify_fabric_attr(struct fi_fabric_attr *attr);
 int sock_verify_domain_attr(struct fi_domain_attr *attr);
 
+size_t sock_get_tx_size(size_t size);
 int sock_rdm_verify_ep_attr(struct fi_ep_attr *ep_attr, struct fi_tx_attr *tx_attr,
 			    struct fi_rx_attr *rx_attr);
 int sock_dgram_verify_ep_attr(struct fi_ep_attr *ep_attr, struct fi_tx_attr *tx_attr,

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -61,7 +61,7 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr,
 
 	rx_ctx->ctx.fid.fclass = FI_CLASS_RX_CTX;
 	rx_ctx->ctx.fid.context = context;
-	rx_ctx->num_left = attr->size;
+	rx_ctx->num_left = sock_get_tx_size(attr->size);
 	rx_ctx->attr = *attr;
 	rx_ctx->use_shared = use_shared;
 	return rx_ctx;

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -109,7 +109,8 @@ static int sock_dgram_verify_rx_attr(const struct fi_rx_attr *attr)
 	if (attr->total_buffered_recv > sock_dgram_rx_attr.total_buffered_recv)
 		return -FI_ENODATA;
 
-	if (attr->size > sock_dgram_rx_attr.size)
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_dgram_rx_attr.size))
 		return -FI_ENODATA;
 
 	if (attr->iov_limit > sock_dgram_rx_attr.iov_limit)
@@ -132,7 +133,8 @@ static int sock_dgram_verify_tx_attr(const struct fi_tx_attr *attr)
 	if (attr->inject_size > sock_dgram_tx_attr.inject_size)
 		return -FI_ENODATA;
 
-	if (attr->size > sock_dgram_tx_attr.size)
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_dgram_tx_attr.size))
 		return -FI_ENODATA;
 
 	if (attr->iov_limit > sock_dgram_tx_attr.iov_limit)
@@ -203,7 +205,9 @@ int sock_dgram_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 		return -FI_ENOMEM;
 
 	*(*info)->tx_attr = sock_dgram_tx_attr;
+	(*info)->tx_attr->size = sock_get_tx_size(sock_dgram_tx_attr.size);
 	*(*info)->rx_attr = sock_dgram_rx_attr;
+	(*info)->rx_attr->size = sock_get_tx_size(sock_dgram_rx_attr.size);
 	*(*info)->ep_attr = sock_dgram_ep_attr;
 
 	if (hints && hints->ep_attr) {

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -111,7 +111,8 @@ static int sock_msg_verify_rx_attr(const struct fi_rx_attr *attr)
 	if (attr->total_buffered_recv > sock_msg_rx_attr.total_buffered_recv)
 		return -FI_ENODATA;
 
-	if (attr->size > sock_msg_rx_attr.size)
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_msg_rx_attr.size))
 		return -FI_ENODATA;
 
 	if (attr->iov_limit > sock_msg_rx_attr.iov_limit)
@@ -134,7 +135,8 @@ static int sock_msg_verify_tx_attr(const struct fi_tx_attr *attr)
 	if (attr->inject_size > sock_msg_tx_attr.inject_size)
 		return -FI_ENODATA;
 
-	if (attr->size > sock_msg_tx_attr.size)
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_msg_tx_attr.size))
 		return -FI_ENODATA;
 
 	if (attr->iov_limit > sock_msg_tx_attr.iov_limit)
@@ -204,7 +206,9 @@ int sock_msg_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 		return -FI_ENOMEM;
 
 	*(*info)->tx_attr = sock_msg_tx_attr;
+	(*info)->tx_attr->size = sock_get_tx_size(sock_msg_tx_attr.size);
 	*(*info)->rx_attr = sock_msg_rx_attr;
+	(*info)->rx_attr->size = sock_get_tx_size(sock_msg_rx_attr.size);
 	*(*info)->ep_attr = sock_msg_ep_attr;
 
 	if (hints && hints->ep_attr) {

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -118,7 +118,8 @@ static int sock_rdm_verify_rx_attr(const struct fi_rx_attr *attr)
 		return -FI_ENODATA;
 	}
 
-	if (attr->size > sock_rdm_rx_attr.size) {
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_rdm_rx_attr.size)) {
 		SOCK_LOG_DBG("Rx size too large\n");
 		return -FI_ENODATA;
 	}
@@ -151,7 +152,8 @@ static int sock_rdm_verify_tx_attr(const struct fi_tx_attr *attr)
 		return -FI_ENODATA;
 	}
 
-	if (attr->size > sock_rdm_tx_attr.size) {
+	if (sock_get_tx_size(attr->size) >
+	     sock_get_tx_size(sock_rdm_tx_attr.size)) {
 		SOCK_LOG_DBG("Tx size too large\n");
 		return -FI_ENODATA;
 	}
@@ -247,7 +249,9 @@ int sock_rdm_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
 		return -FI_ENOMEM;
 
 	*(*info)->tx_attr = sock_rdm_tx_attr;
+	(*info)->tx_attr->size = sock_get_tx_size(sock_rdm_tx_attr.size);
 	*(*info)->rx_attr = sock_rdm_rx_attr;
+	(*info)->rx_attr->size = sock_get_tx_size(sock_rdm_rx_attr.size);
 	*(*info)->ep_attr = sock_rdm_ep_attr;
 
 	if (hints && hints->ep_attr) {


### PR DESCRIPTION
- Fixed a bug in storing the size of <code>fi_tx_attr</code> from ep attr.
- Modified tx/rx attr verification code to handle rounding up tx/rx attr size (rounding up to the power of two is done when allocating buffer size for tx_attr)
- Fixed the code to return the actual size of tx/rx attr after rounding up to the power of two.

Fixes #2271. @bturrubiates , @a-ilango @j-xiong , could you please review? 