### PR TITLE
prov/verbs: add FI_AV_TABLE support

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -117,12 +117,12 @@ static inline int fi_ibv_rdm_av_is_valid_address(struct sockaddr_in *addr)
 }
 
 
-static int fi_ibv_rdm_av_insert(struct fid_av *av, const void *addr,
+static int fi_ibv_rdm_av_insert(struct fid_av *av_fid, const void *addr,
                                 size_t count, fi_addr_t * fi_addr,
                                 uint64_t flags, void *context)
 {
-	struct fi_ibv_av *fid_av = container_of(av, struct fi_ibv_av, av);
-	struct fi_ibv_rdm_ep *ep = fid_av->ep;
+	struct fi_ibv_av *av = container_of(av_fid, struct fi_ibv_av, av_fid);
+	struct fi_ibv_rdm_ep *ep = av->ep;
 	int i,  ret = 0;
 
 	if (ep) {

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -50,9 +50,6 @@ extern struct util_buf_pool* fi_ibv_rdm_request_pool;
 extern struct util_buf_pool* fi_ibv_rdm_extra_buffers_pool;
 extern struct fi_provider fi_ibv_prov;
 
-struct fi_ibv_rdm_conn *fi_ibv_rdm_conn_hash = NULL;
-
-
 static int
 fi_ibv_rdm_find_max_inline(struct ibv_pd *pd, struct ibv_context *context)
 {
@@ -320,8 +317,8 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 
 	struct fi_ibv_rdm_conn *conn = NULL, *tmp = NULL;
 
-	HASH_ITER(hh, fi_ibv_rdm_conn_hash, conn, tmp) {
-		HASH_DEL(fi_ibv_rdm_conn_hash, conn);
+	HASH_ITER(hh, ep->domain->rdm_cm->conn_hash, conn, tmp) {
+		HASH_DEL(ep->domain->rdm_cm->conn_hash, conn);
 		switch (conn->state) {
 		case FI_VERBS_CONN_ALLOCATED:
 		case FI_VERBS_CONN_REMOTE_DISCONNECT:
@@ -351,8 +348,8 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 		}
 	}
 
-	assert(0 == HASH_COUNT(fi_ibv_rdm_conn_hash) &&
-		NULL == fi_ibv_rdm_conn_hash);
+	assert(HASH_COUNT(ep->domain->rdm_cm->conn_hash) == 0 &&
+	       ep->domain->rdm_cm->conn_hash == NULL);
 
 	VERBS_INFO(FI_LOG_AV, "DISCONNECT complete\n");
 	assert(ep->scq && ep->rcq);
@@ -362,7 +359,8 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 	}
 
 	errno = 0;
-	fi_ibv_destroy_ep(FI_EP_RDM, ep->cm.rai, &(ep->cm.listener));
+	fi_ibv_destroy_ep(FI_EP_RDM, ep->domain->rdm_cm->rai,
+			  &(ep->domain->rdm_cm->listener));
 	if (errno) {
 		VERBS_INFO_ERRNO(FI_LOG_AV, "ibv_destroy_ep failed\n", errno);
 		ret = (ret == FI_SUCCESS) ? -errno : ret;
@@ -480,12 +478,13 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 		goto err;
 	}
 
-	ret = fi_ibv_create_ep(NULL, NULL, 0, info, &_ep->cm.rai, &_ep->cm.listener);
+	ret = fi_ibv_create_ep(NULL, NULL, 0, info, &_domain->rdm_cm->rai,
+			       &_domain->rdm_cm->listener);
 	if (ret) {
 		goto err;
 	}
 
-	if (rdma_listen(_ep->cm.listener, 1024)) {
+	if (rdma_listen(_domain->rdm_cm->listener, 1024)) {
 		VERBS_INFO(FI_LOG_EP_CTRL, "rdma_listen failed: %s\n",
 			strerror(errno));
 		ret = -FI_EOTHER;

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -162,7 +162,7 @@ static int fi_ibv_rdm_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		cq->ep = ep;
 		break;
 	case FI_CLASS_AV:
-		av = container_of(bfid, struct fi_ibv_av, av.fid);
+		av = container_of(bfid, struct fi_ibv_av, av_fid.fid);
 		ep->av = av;
 
 		/* TODO: this is wrong, AV to EP is 1:n */

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -350,6 +350,7 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 
 	assert(HASH_COUNT(ep->domain->rdm_cm->conn_hash) == 0 &&
 	       ep->domain->rdm_cm->conn_hash == NULL);
+	free(ep->domain->rdm_cm->conn_table);
 
 	VERBS_INFO(FI_LOG_AV, "DISCONNECT complete\n");
 	assert(ep->scq && ep->rcq);

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -220,6 +220,7 @@ struct fi_ibv_rdm_cm {
 	struct rdma_cm_id *listener;
 	struct rdma_event_channel *ec;
 	struct sockaddr_in my_addr;
+	struct fi_ibv_rdm_conn *conn_hash;
 	struct rdma_addrinfo *rai;
 };
 
@@ -229,7 +230,6 @@ struct fi_ibv_rdm_ep {
 	struct fi_ibv_rdm_cq *fi_scq;
 	struct fi_ibv_rdm_cq *fi_rcq;
 
-	struct fi_ibv_rdm_cm cm;
 	size_t addrlen;
 
 	struct fi_ibv_av *av;
@@ -254,6 +254,7 @@ struct fi_ibv_rdm_ep {
 	struct ibv_cq *rcq;
 	int scq_depth;
 	int rcq_depth;
+	/* TODO: move all CM things to domain */
 	pthread_t cm_progress_thread;
 	pthread_mutex_t cm_lock;
 	int is_closing;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -219,8 +219,6 @@ struct fi_ibv_rdm_buf {
 struct fi_ibv_rdm_cm {
 	struct rdma_cm_id *listener;
 	struct rdma_event_channel *ec;
-	struct sockaddr_in my_addr;
-	struct rdma_addrinfo *rai;
 
 	/* conn_hash has a sockaddr_in -> conn associative */
 	struct fi_ibv_rdm_conn *conn_hash;
@@ -235,6 +233,8 @@ struct fi_ibv_rdm_ep {
 	struct fi_ibv_rdm_cq *fi_rcq;
 
 	size_t addrlen;
+	struct rdma_addrinfo *rai;
+	struct sockaddr_in my_addr;
 
 	struct fi_ibv_av *av;
 	int tx_selective_completion;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -220,8 +220,12 @@ struct fi_ibv_rdm_cm {
 	struct rdma_cm_id *listener;
 	struct rdma_event_channel *ec;
 	struct sockaddr_in my_addr;
-	struct fi_ibv_rdm_conn *conn_hash;
 	struct rdma_addrinfo *rai;
+
+	/* conn_hash has a sockaddr_in -> conn associative */
+	struct fi_ibv_rdm_conn *conn_hash;
+	/* Used only for FI_AV_TABLE */
+	struct fi_ibv_rdm_conn **conn_table;
 };
 
 struct fi_ibv_rdm_ep {

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -40,8 +40,6 @@
 
 
 extern struct fi_provider fi_ibv_prov;
-extern struct fi_ibv_rdm_conn *fi_ibv_rdm_conn_hash;
-
 
 static struct ibv_mr *
 fi_ibv_rdm_alloc_and_reg(struct fi_ibv_rdm_ep *ep, void **buf, size_t size)
@@ -236,7 +234,7 @@ fi_ibv_rdm_pack_cm_params(struct rdma_conn_param *cm_params,
 	cm_params->private_data = malloc(cm_params->private_data_len);
 
 	char *p = (char *) cm_params->private_data;
-	memcpy(p, &ep->cm.my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+	memcpy(p, &ep->domain->rdm_cm->my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
 	p += FI_IBV_RDM_DFLT_ADDRLEN;
 
 	if ((conn->cm_role != FI_VERBS_CM_SELF) && (conn->r_mr && conn->s_mr)) {
@@ -262,7 +260,7 @@ fi_ibv_rdm_unpack_cm_params(struct rdma_conn_param *cm_param,
 
 	if (conn->cm_role == FI_VERBS_CM_SELF) {
 		if (conn->r_mr && conn->s_mr) {
-			memcpy(&conn->addr, &ep->cm.my_addr,
+			memcpy(&conn->addr, &ep->domain->rdm_cm->my_addr,
 				FI_IBV_RDM_DFLT_ADDRLEN);
 			conn->remote_rbuf_rkey = conn->r_mr->rkey;
 			conn->remote_rbuf_mem_reg = conn->r_mr->addr;
@@ -379,7 +377,8 @@ fi_ibv_rdm_process_connect_request(struct rdma_cm_event *event,
 		return ret;
 	}
 
-	HASH_FIND(hh, fi_ibv_rdm_conn_hash, p, FI_IBV_RDM_DFLT_ADDRLEN, conn);
+	HASH_FIND(hh, ep->domain->rdm_cm->conn_hash, p, FI_IBV_RDM_DFLT_ADDRLEN,
+		  conn);
 
 	if (!conn) {
 		conn = memalign(FI_IBV_RDM_MEM_ALIGNMENT, sizeof(*conn));
@@ -398,8 +397,8 @@ fi_ibv_rdm_process_connect_request(struct rdma_cm_event *event,
 			conn, conn->cm_role, inet_ntoa(conn->addr.sin_addr),
 			ntohs(conn->addr.sin_port));
 
-		HASH_ADD(hh, fi_ibv_rdm_conn_hash, addr,
-			FI_IBV_RDM_DFLT_ADDRLEN, conn);
+		HASH_ADD(hh, ep->domain->rdm_cm->conn_hash, addr,
+			 FI_IBV_RDM_DFLT_ADDRLEN, conn);
 	} else {
 		if (conn->cm_role != FI_VERBS_CM_ACTIVE) {
 			/*
@@ -742,7 +741,7 @@ ssize_t fi_ibv_rdm_cm_progress(struct fi_ibv_rdm_ep *ep)
 	void *data = NULL;
 	ssize_t ret = FI_SUCCESS;
 
-	if (rdma_get_cm_event(ep->cm.ec, &event)) {
+	if (rdma_get_cm_event(ep->domain->rdm_cm->ec, &event)) {
 		if(errno == EAGAIN) {
 			errno = 0;
 			usleep(FI_IBV_RDM_CM_THREAD_TIMEOUT);
@@ -793,7 +792,7 @@ ssize_t fi_ibv_rdm_cm_progress(struct fi_ibv_rdm_ep *ep)
 			break;
 		}
 
-		if(rdma_get_cm_event(ep->cm.ec, &event)) {
+		if(rdma_get_cm_event(ep->domain->rdm_cm->ec, &event)) {
 			if(errno == EAGAIN) {
 				errno = 0;
 				usleep(FI_IBV_RDM_CM_THREAD_TIMEOUT);

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -234,7 +234,7 @@ fi_ibv_rdm_pack_cm_params(struct rdma_conn_param *cm_params,
 	cm_params->private_data = malloc(cm_params->private_data_len);
 
 	char *p = (char *) cm_params->private_data;
-	memcpy(p, &ep->domain->rdm_cm->my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+	memcpy(p, &ep->my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
 	p += FI_IBV_RDM_DFLT_ADDRLEN;
 
 	if ((conn->cm_role != FI_VERBS_CM_SELF) && (conn->r_mr && conn->s_mr)) {
@@ -260,7 +260,7 @@ fi_ibv_rdm_unpack_cm_params(struct rdma_conn_param *cm_param,
 
 	if (conn->cm_role == FI_VERBS_CM_SELF) {
 		if (conn->r_mr && conn->s_mr) {
-			memcpy(&conn->addr, &ep->domain->rdm_cm->my_addr,
+			memcpy(&conn->addr, &ep->my_addr,
 				FI_IBV_RDM_DFLT_ADDRLEN);
 			conn->remote_rbuf_rkey = conn->r_mr->rkey;
 			conn->remote_rbuf_mem_reg = conn->r_mr->addr;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -96,7 +96,7 @@ static int fi_ibv_rdm_tagged_getname(fid_t fid, void *addr, size_t * addrlen)
 		return -FI_ETOOSMALL;
 	}
 	memset(addr, 0, *addrlen);
-	memcpy(addr, &ep->cm.my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+	memcpy(addr, &ep->domain->rdm_cm->my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
 	ep->addrlen = *addrlen;
 
 	return 0;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -96,7 +96,7 @@ static int fi_ibv_rdm_tagged_getname(fid_t fid, void *addr, size_t * addrlen)
 		return -FI_ETOOSMALL;
 	}
 	memset(addr, 0, *addrlen);
-	memcpy(addr, &ep->domain->rdm_cm->my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
+	memcpy(addr, &ep->my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
 	ep->addrlen = *addrlen;
 
 	return 0;

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -148,7 +148,7 @@ int fi_ibv_rdm_postponed_process(struct dlist_entry *postponed_item,
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_conn *conn,
 				  struct fi_ibv_rdm_ep *ep)
 {
-	const int addr_cmp = memcmp(&conn->addr, &ep->domain->rdm_cm->my_addr,
+	const int addr_cmp = memcmp(&conn->addr, &ep->my_addr,
 				    FI_IBV_RDM_DFLT_ADDRLEN);
 
 	if (addr_cmp < 0) {
@@ -168,7 +168,7 @@ void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_conn *conn,
  * propagation of error code.
  */
 int fi_ibv_rdm_find_ipoib_addr(const struct sockaddr_in *addr,
-			       struct fi_ibv_rdm_cm* cm)
+			       struct sockaddr_in *ipoib_addr)
 {
 	struct ifaddrs *addrs = NULL;
 	struct ifaddrs *tmp = NULL;
@@ -203,8 +203,9 @@ int fi_ibv_rdm_find_ipoib_addr(const struct sockaddr_in *addr,
 		if (tmp->ifa_addr && tmp->ifa_addr->sa_family == AF_INET) {
 			found = !strncmp(tmp->ifa_name, iface, iface_len);
 			if (found) {
-				memcpy(&cm->my_addr, tmp->ifa_addr,
-					sizeof(cm->my_addr));
+				memcpy(ipoib_addr, tmp->ifa_addr,
+					sizeof(ipoib_addr));
+				ipoib_addr->sin_port = addr->sin_port;
 				break;
 			}
 		}

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -148,7 +148,7 @@ int fi_ibv_rdm_postponed_process(struct dlist_entry *postponed_item,
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_conn *conn,
 				  struct fi_ibv_rdm_ep *ep)
 {
-	const int addr_cmp = memcmp(&conn->addr, &ep->cm.my_addr,
+	const int addr_cmp = memcmp(&conn->addr, &ep->domain->rdm_cm->my_addr,
 				    FI_IBV_RDM_DFLT_ADDRLEN);
 
 	if (addr_cmp < 0) {

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -171,6 +171,6 @@ int fi_ibv_rdm_postponed_process(struct dlist_entry *item, const void *arg);
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_conn *conn,
 				  struct fi_ibv_rdm_ep *ep);
 int fi_ibv_rdm_find_ipoib_addr(const struct sockaddr_in *addr,
-			       struct fi_ibv_rdm_cm* cm);
+			       struct sockaddr_in *ipoib_addr);
 
 #endif /* _VERBS_UTILS_H */

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -67,80 +67,59 @@ int fi_ibv_sockaddr_len(struct sockaddr *addr)
 	}
 }
 
-static int fi_ibv_rdm_cm_bind_addr(struct fi_ibv_rdm_cm* cm,
-				   const struct rdma_addrinfo* rai)
+int fi_ibv_rdm_cm_bind_ep(struct fi_ibv_rdm_cm *cm, struct fi_ibv_rdm_ep *ep)
 {
-	struct sockaddr_in* src_addr = (struct sockaddr_in*)rai->ai_src_addr;
-	if (cm->ec) {
-		VERBS_INFO(FI_LOG_EP_CTRL,
-			   "Failed to initialize more then 1 endpoint per domain, "
-			   "currently it's not supported\n", strerror(errno));
-		return -FI_ENOSYS;
-	}
+	char my_ipoib_addr_str[INET6_ADDRSTRLEN];
+	struct sockaddr_in* src_addr = (struct sockaddr_in*)ep->rai->ai_src_addr;
 
-	cm->ec = rdma_create_event_channel();
+	assert(cm->ec && cm->listener);
 
-	if (!cm->ec) {
-		VERBS_INFO(FI_LOG_EP_CTRL,
-			"Failed to create listener event channel: %s\n",
-			strerror(errno));
-		return -FI_EOTHER;
-	}
-
-	if (fi_fd_nonblock(cm->ec->fd) != 0) {
-		VERBS_INFO_ERRNO(FI_LOG_EP_CTRL, "fcntl", errno);
-		return -FI_EOTHER;
-	}
-
-	if (rdma_create_id(cm->ec, &cm->listener, NULL, RDMA_PS_TCP)) {
-		VERBS_INFO(FI_LOG_EP_CTRL, "Failed to create cm listener: %s\n",
-			     strerror(errno));
-		return -FI_EOTHER;
-	}
-
-	if (fi_ibv_rdm_find_ipoib_addr(src_addr, cm)) {
+	if (fi_ibv_rdm_find_ipoib_addr(src_addr, &ep->my_addr)) {
 		VERBS_INFO(FI_LOG_EP_CTRL, 
 			   "Failed to find correct IPoIB address\n");
 		return -FI_ENODEV;
 	}
 
-	cm->my_addr.sin_port = src_addr->sin_port;
-
-	char my_ipoib_addr_str[INET6_ADDRSTRLEN];
-	inet_ntop(cm->my_addr.sin_family,
-		  &cm->my_addr.sin_addr.s_addr,
+	inet_ntop(ep->my_addr.sin_family,
+		  &ep->my_addr.sin_addr.s_addr,
 		  my_ipoib_addr_str, INET_ADDRSTRLEN);
 
 	VERBS_INFO(FI_LOG_EP_CTRL, "My IPoIB: %s\n", my_ipoib_addr_str);
 
-	if (rdma_bind_addr(cm->listener, (struct sockaddr *)&cm->my_addr)) {
+	if (rdma_bind_addr(cm->listener, (struct sockaddr *)&ep->my_addr)) {
 		VERBS_INFO(FI_LOG_EP_CTRL,
 			"Failed to bind cm listener to my IPoIB addr %s: %s\n",
 			my_ipoib_addr_str, strerror(errno));
 		return -FI_EOTHER;
 	}
 
-	if (!cm->my_addr.sin_port) {
-		cm->my_addr.sin_port = rdma_get_src_port(cm->listener);
+	if (!ep->my_addr.sin_port) {
+		ep->my_addr.sin_port = rdma_get_src_port(cm->listener);
 	}
-	assert(cm->my_addr.sin_family == AF_INET);
+	assert(ep->my_addr.sin_family == AF_INET);
+
+	/* TODO:
+	 * check - should rdma_listen be called after binding every endpoint?
+	 */
+	if (rdma_listen(cm->listener, 1024)) {
+		VERBS_INFO(FI_LOG_EP_CTRL, "rdma_listen failed: %s\n",
+			strerror(errno));
+		return -FI_EOTHER;
+	}
 
 	VERBS_INFO(FI_LOG_EP_CTRL, "My ep_addr: %s:%u\n",
-		inet_ntoa(cm->my_addr.sin_addr), ntohs(cm->my_addr.sin_port));
+		inet_ntoa(ep->my_addr.sin_addr), ntohs(ep->my_addr.sin_port));
 
 	return FI_SUCCESS;
 }
 
-int fi_ibv_create_ep(const char *node, const char *service,
-		     uint64_t flags, const struct fi_info *hints,
-		     struct rdma_addrinfo **rai, struct rdma_cm_id **id)
+int fi_ibv_get_rdma_rai(const char *node, const char *service, uint64_t flags,
+		   const struct fi_info *hints, struct rdma_addrinfo **rai)
 {
 	struct rdma_addrinfo rai_hints, *_rai;
 	struct rdma_addrinfo **rai_current;
-	struct sockaddr *local_addr;
-	int ret;
+	int ret = fi_ibv_fi_to_rai(hints, flags, &rai_hints);
 
-	ret = fi_ibv_fi_to_rai(hints, flags, &rai_hints);
 	if (ret)
 		goto out;
 
@@ -181,39 +160,8 @@ int fi_ibv_create_ep(const char *node, const char *service,
 		}
 	}
 
-	if (FI_IBV_EP_TYPE_IS_RDM(hints)) {
-		struct fi_ibv_rdm_cm* cm = 
-			container_of(id, struct fi_ibv_rdm_cm, listener);
-		ret = fi_ibv_rdm_cm_bind_addr(cm, _rai);
-	} else {
-		ret = rdma_create_ep(id, _rai, NULL, NULL);
-		if (ret) {
-			VERBS_INFO_ERRNO(FI_LOG_FABRIC, "rdma_create_ep", errno);
-			ret = -errno;
-			goto err1;
-		}
-		if (rai && !_rai->ai_src_addr) {
-			local_addr = rdma_get_local_addr(*id);
-			_rai->ai_src_len = fi_ibv_sockaddr_len(local_addr);
-			if (!(_rai->ai_src_addr = malloc(_rai->ai_src_len))) {
-				ret = -FI_ENOMEM;
-				goto err2;
-			}
-			memcpy(_rai->ai_src_addr, local_addr, _rai->ai_src_len);
-		}
-	}
+	*rai = _rai;
 
-	if (rai) {
-		*rai = _rai;
-	} else {
-		rdma_freeaddrinfo(_rai);
-	}
-
-	goto out;
-err2:
-	rdma_destroy_ep(*id);
-err1:
-	rdma_freeaddrinfo(_rai);
 out:
 	if (rai_hints.ai_src_addr)
 		free(rai_hints.ai_src_addr);
@@ -222,19 +170,54 @@ out:
 	return ret;
 }
 
-void fi_ibv_destroy_ep(enum fi_ep_type ep_type,
-		       struct rdma_addrinfo *rai,
-		       struct rdma_cm_id **id)
+int fi_ibv_create_ep(const char *node, const char *service,
+		     uint64_t flags, const struct fi_info *hints,
+		     struct rdma_addrinfo **rai, struct rdma_cm_id **id)
+{
+	struct rdma_addrinfo *_rai;
+	struct sockaddr *local_addr;
+	int ret;
+
+	ret = fi_ibv_get_rdma_rai(node, service, flags, hints, &_rai);
+	if (ret) {
+		return ret;
+	}
+
+	ret = rdma_create_ep(id, _rai, NULL, NULL);
+	if (ret) {
+		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "rdma_create_ep", errno);
+		ret = -errno;
+		goto err1;
+	}
+	if (rai && !_rai->ai_src_addr) {
+		local_addr = rdma_get_local_addr(*id);
+		_rai->ai_src_len = fi_ibv_sockaddr_len(local_addr);
+		if (!(_rai->ai_src_addr = malloc(_rai->ai_src_len))) {
+			ret = -FI_ENOMEM;
+			goto err2;
+		}
+		memcpy(_rai->ai_src_addr, local_addr, _rai->ai_src_len);
+	}
+
+	if (rai) {
+		*rai = _rai;
+	} else {
+		rdma_freeaddrinfo(_rai);
+	}
+
+	return ret;
+err2:
+	rdma_destroy_ep(*id);
+err1:
+	rdma_freeaddrinfo(_rai);
+
+	return ret;
+}
+
+void fi_ibv_destroy_ep(struct rdma_addrinfo *rai, struct rdma_cm_id **id)
 {
 	rdma_freeaddrinfo(rai);
-	if (ep_type == FI_EP_RDM) {
-		struct fi_ibv_rdm_cm* cm = 
-			container_of(id, struct fi_ibv_rdm_cm, listener);
-		rdma_destroy_id(cm->listener);
-		rdma_destroy_event_channel(cm->ec);
-	} else {
-		rdma_destroy_ep(*id);
-	}
+	rdma_destroy_ep(*id);
 }
 
 #define VERBS_SIGNAL_SEND(ep) \

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -71,6 +71,10 @@ static int fi_ibv_rdm_cm_init(struct fi_ibv_rdm_cm* cm,
 			      const struct rdma_addrinfo* rai)
 {
 	struct sockaddr_in* src_addr = (struct sockaddr_in*)rai->ai_src_addr;
+	if (cm->ec) {
+		/* cm is already initialized (by other ep) */
+		return FI_SUCCESS;
+	}
 	cm->ec = rdma_create_event_channel();
 
 	if (!cm->ec) {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -260,9 +260,7 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 int fi_ibv_create_ep(const char *node, const char *service,
 		     uint64_t flags, const struct fi_info *hints,
 		     struct rdma_addrinfo **rai, struct rdma_cm_id **id);
-void fi_ibv_destroy_ep(enum fi_ep_type ep_type,
-		       struct rdma_addrinfo *rai,
-		       struct rdma_cm_id **id);
+void fi_ibv_destroy_ep(struct rdma_addrinfo *rai, struct rdma_cm_id **id);
 
 struct fi_ops_atomic *fi_ibv_msg_ep_ops_atomic(struct fi_ibv_msg_ep *ep);
 struct fi_ops_cm *fi_ibv_msg_ep_ops_cm(struct fi_ibv_msg_ep *ep);
@@ -289,6 +287,9 @@ struct fi_info *fi_ibv_get_verbs_info(const char *domain_name);
 void fi_ibv_update_info(const struct fi_info *hints, struct fi_info *info);
 int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags,
 		     struct rdma_addrinfo *rai);
+int fi_ibv_get_rdma_rai(const char *node, const char *service, uint64_t flags,
+			const struct fi_info *hints, struct rdma_addrinfo **rai);
+int fi_ibv_rdm_cm_bind_ep(struct fi_ibv_rdm_cm *cm, struct fi_ibv_rdm_ep *ep);
 
 struct verbs_ep_domain {
 	char			*suffix;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -157,12 +157,19 @@ struct fi_ibv_pep {
 };
 
 struct fi_ops_cm *fi_ibv_pep_ops_cm(struct fi_ibv_pep *pep);
+struct fi_ibv_rdm_cm;
 
 struct fi_ibv_domain {
 	struct fid_domain	domain_fid;
 	struct ibv_context	*verbs;
 	struct ibv_pd		*pd;
+	/*
+	 * TODO: Currently, only 1 rdm EP can be created per rdm domain!
+	 *	 CM logic should be separated from EP,
+	 *	 excluding naming/addressing
+	 */
 	int			rdm;
+	struct fi_ibv_rdm_cm	*rdm_cm;
 	struct fi_info		*info;
 	struct fi_ibv_fabric	*fab;
 };

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -137,11 +137,10 @@ int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		   struct fid_eq **eq, void *context);
 
 struct fi_ibv_av {
-	struct fid_av		av;	/* TODO: rename to av_fid */
+	struct fid_av		av_fid;
 	struct fi_ibv_domain	*domain;
-	struct fi_ibv_rdm_ep	*ep;	/* TODO: check usage */
-	int			type;	/* TODO: AV enum? */
-	size_t			count;
+	struct fi_ibv_rdm_ep	*ep;
+	enum fi_av_type		type;
 };
 
 int fi_ibv_av_open(struct fid_domain *domain, struct fi_av_attr *attr,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -140,6 +140,7 @@ struct fi_ibv_av {
 	struct fid_av		av_fid;
 	struct fi_ibv_domain	*domain;
 	struct fi_ibv_rdm_ep	*ep;
+	size_t			count;
 	enum fi_av_type		type;
 };
 

--- a/prov/verbs/src/verbs_av.c
+++ b/prov/verbs/src/verbs_av.c
@@ -56,7 +56,6 @@ int fi_ibv_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 {
 	struct fi_ibv_domain *fid_domain;
 	struct fi_ibv_av *av;
-	int type = FI_AV_MAP;
 	size_t count = 64;
 
 	fid_domain = container_of(domain, struct fi_ibv_domain, domain_fid);
@@ -64,15 +63,12 @@ int fi_ibv_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (!attr)
 		return -FI_EINVAL;
 
-	if (attr->type == FI_AV_UNSPEC)
-		attr->type = FI_AV_MAP;
-
 	switch (attr->type) {
+	case FI_AV_UNSPEC:
+		attr->type = FI_AV_MAP;
 	case FI_AV_MAP:
-		type = attr->type;
-		break;
 	case FI_AV_TABLE:
-		return -FI_ENOSYS;
+		break;
 	default:
 		return -EINVAL;
 	}
@@ -86,7 +82,7 @@ int fi_ibv_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 
 	assert(fid_domain->rdm);
 	av->domain = fid_domain;
-	av->type = type;
+	av->type = attr->type;
 
 	av->av_fid.fid.fclass = FI_CLASS_AV;
 	av->av_fid.fid.context = context;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -974,22 +974,13 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 {
 	struct rdma_cm_id *id = NULL;
 	struct rdma_addrinfo *rai;
-	struct fi_ibv_rdm_cm rdm_cm;
 	int ret;
 
 	ret = fi_ibv_init_info();
 	if (ret)
 		goto out;
 
-	if (FI_IBV_EP_TYPE_IS_RDM(hints)) {
-		memset(&rdm_cm, 0, sizeof(struct fi_ibv_rdm_cm));
-		ret = fi_ibv_create_ep(node, service, flags, hints, &rai,
-				       &(rdm_cm.listener));
-		id = rdm_cm.listener;
-	} else {
-		ret = fi_ibv_create_ep(node, service, flags, hints, &rai, &id);
-	}
-
+	ret = fi_ibv_create_ep(node, service, flags, hints, &rai, &id);
 	if (ret)
 		goto out;
 
@@ -1002,9 +993,7 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 
 	ofi_alter_info(*info, hints);
 
-	if (hints && hints->ep_attr)
-		fi_ibv_destroy_ep(hints->ep_attr->type, rai,
-			FI_IBV_EP_TYPE_IS_RDM(hints) ? &(rdm_cm.listener) : &id);
+	fi_ibv_destroy_ep(rai, &id);
 
 out:
 	if (!ret || ret == -FI_ENOMEM || ret == -FI_ENODEV)


### PR DESCRIPTION
This series includes:
- add FI_AV_TABLE support
- refactoring of address vector and connection management. CM structure was moved to domain level to preserve not bound AV working

@a-ilango , please review. domain level is affected a bit
