### PR TITLE
Pr/sockets: Add garbage collection and cleanup code in AV

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -310,7 +310,6 @@ struct sock_av_addr {
 struct sock_av_table_hdr {
 	uint64_t size;
 	uint64_t stored;
-	uint64_t req_sz;
 };
 
 struct sock_av {

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -66,9 +66,12 @@ int sock_av_get_addr_index(struct sock_av *av, struct sockaddr_in *addr)
 	int i;
 	struct sock_av_addr *av_addr;
 
-	for (i = 0; i < av->table_hdr->stored; i++) {
+	for (i = 0; i < av->table_hdr->size; i++) {
 		av_addr = &av->table[i];
-		if (ofi_equals_sockaddr(addr, (struct sockaddr_in *)&av_addr->addr))
+		if (!av_addr->valid)
+			continue;
+
+		 if (ofi_equals_sockaddr(addr, (struct sockaddr_in *)&av_addr->addr))
 			return i;
 	}
 	SOCK_LOG_DBG("failed to get index in AV\n");
@@ -84,8 +87,8 @@ int sock_av_compare_addr(struct sock_av *av,
 	index1 = ((uint64_t)addr1 & av->mask);
 	index2 = ((uint64_t)addr2 & av->mask);
 
-	if (index1 >= av->table_hdr->stored || index1 < 0 ||
-	    index2 >= av->table_hdr->stored || index2 < 0) {
+	if (index1 >= av->table_hdr->size || index1 < 0 ||
+	    index2 >= av->table_hdr->size || index2 < 0) {
 		SOCK_LOG_ERROR("requested rank is larger than av table\n");
 		return -1;
 	}
@@ -135,23 +138,63 @@ static void sock_update_av_table(struct sock_av *_av, size_t count)
 		sizeof(struct sock_av_table_hdr));
 }
 
+static int sock_resize_av_table(struct sock_av *av)
+{
+	void *new_addr;
+	size_t new_count, table_sz, old_sz;
+
+	new_count = av->table_hdr->size * 2;
+	table_sz = SOCK_AV_TABLE_SZ(new_count, av->attr.name);
+	old_sz = SOCK_AV_TABLE_SZ(av->table_hdr->size, av->attr.name);
+
+	if (av->attr.name) {
+		new_addr = sock_mremap(av->table_hdr, old_sz, table_sz);
+		if (new_addr == MAP_FAILED)
+			return -1;
+
+		av->idx_arr[av->table_hdr->stored] = av->table_hdr->stored;
+	} else {
+		new_addr = realloc(av->table_hdr, table_sz);
+		if (!new_addr)
+			return -1;
+	}
+
+	av->table_hdr = new_addr;
+	av->table_hdr->size = new_count;
+	sock_update_av_table(av, new_count);
+
+	return 0;
+}
+
+static int sock_av_get_next_index(struct sock_av *av)
+{
+	int i;
+
+	for (i = 0; i < av->table_hdr->size; i++) {
+		if (!av->table[i].valid)
+			return i;
+	}
+
+	return -1;
+}
+
 static int sock_check_table_in(struct sock_av *_av, struct sockaddr_in *addr,
 			       fi_addr_t *fi_addr, int count, uint64_t flags,
 			       void *context)
 {
-	void *new_addr;
 	int i, j, ret = 0;
 	char sa_ip[INET_ADDRSTRLEN];
 	struct sock_av_addr *av_addr;
-	size_t new_count, table_sz, old_sz;
+	int index;
 
 	if ((_av->attr.flags & FI_EVENT) && !_av->eq)
 		return -FI_ENOEQ;
 
 	if (_av->attr.flags & FI_READ) {
 		for (i = 0; i < count; i++) {
-			for (j = 0; j < _av->table_hdr->stored; j++) {
-				if (!sock_av_is_valid_address(&addr[i])) {
+			for (j = 0; j < _av->table_hdr->size; j++) {
+				if (_av->table[j].valid &&
+				     !sock_av_is_valid_address(&addr[i])) {
 					if (fi_addr)
 						fi_addr[i] = FI_ADDR_NOTAVAIL;
 					sock_av_report_error(_av, context, i,
@@ -174,43 +217,28 @@ static int sock_check_table_in(struct sock_av *_av, struct sockaddr_in *addr,
 	}
 
 	for (i = 0, ret = 0; i < count; i++) {
-		if (_av->table_hdr->stored == _av->table_hdr->size) {
-			new_count = _av->table_hdr->size * 2;
-			table_sz = SOCK_AV_TABLE_SZ(new_count, _av->attr.name);
-			old_sz = SOCK_AV_TABLE_SZ(_av->table_hdr->size, _av->attr.name);
-
-			if (_av->attr.name) {
-				new_addr = sock_mremap(_av->table_hdr,
-							old_sz, table_sz);
-				if (new_addr == MAP_FAILED) {
-					if (fi_addr)
-						fi_addr[i] = FI_ADDR_NOTAVAIL;
-					sock_av_report_error(_av, context, i, FI_ENOMEM);
-					continue;
-				}
-				_av->idx_arr[_av->table_hdr->stored] = _av->table_hdr->stored;
-			} else {
-				new_addr = realloc(_av->table_hdr, table_sz);
-				if (!new_addr) {
-					if (fi_addr)
-						fi_addr[i] = FI_ADDR_NOTAVAIL;
-					sock_av_report_error(_av, context, i, FI_ENOMEM);
-					continue;
-				}
-			}
-			_av->table_hdr = new_addr;
-			_av->table_hdr->size = new_count;
-			sock_update_av_table(_av, new_count);
-		}
-
 		if (!sock_av_is_valid_address(&addr[i])) {
 			if (fi_addr)
 				fi_addr[i] = FI_ADDR_NOTAVAIL;
 			sock_av_report_error(_av, context, i, FI_EINVAL);
 			continue;
 		}
+		if (_av->table_hdr->stored == _av->table_hdr->size) {
+			index = sock_av_get_next_index(_av);
+			if (index < 0) {
+				if (sock_resize_av_table(_av)) {
+					if (fi_addr)
+						fi_addr[i] = FI_ADDR_NOTAVAIL;
+					sock_av_report_error(_av, context, i, FI_ENOMEM);
+					continue;
+				}
+				index = _av->table_hdr->stored++;
+			}
+		} else {
+			index = _av->table_hdr->stored++;
+		}
 
-		av_addr = &_av->table[_av->table_hdr->stored];
+		av_addr = &_av->table[index];
 		memcpy(sa_ip, inet_ntoa((&addr[i])->sin_addr), INET_ADDRSTRLEN);
 		SOCK_LOG_DBG("AV-INSERT:dst_addr: family: %d, IP is %s, port: %d\n",
 			      ((struct sockaddr_in *)&addr[i])->sin_family,
@@ -218,10 +246,9 @@ static int sock_check_table_in(struct sock_av *_av, struct sockaddr_in *addr,
 
 		memcpy(&av_addr->addr, &addr[i], sizeof(struct sockaddr_in));
 		if (fi_addr)
-			fi_addr[i] = (fi_addr_t)_av->table_hdr->stored;
+			fi_addr[i] = (fi_addr_t)index;
 
 		av_addr->valid = 1;
-		_av->table_hdr->stored++;
 		ret++;
 	}
 	sock_av_report_success(_av, context, ret, flags);
@@ -246,7 +273,7 @@ static int sock_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 
 	_av = container_of(av, struct sock_av, av_fid);
 	index = ((uint64_t)fi_addr & _av->mask);
-	if (index >= _av->table_hdr->stored || index < 0) {
+	if (index >= _av->table_hdr->size || index < 0) {
 		SOCK_LOG_ERROR("requested address not inserted\n");
 		return -EINVAL;
 	}

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -137,7 +137,7 @@ static void sock_update_av_table(struct sock_av *_av, size_t count)
 
 static int sock_check_table_in(struct sock_av *_av, struct sockaddr_in *addr,
 			       fi_addr_t *fi_addr, int count, uint64_t flags,
-			       void *context, int index)
+			       void *context)
 {
 	void *new_addr;
 	int i, j, ret = 0;
@@ -234,7 +234,7 @@ static int sock_av_insert(struct fid_av *av, const void *addr, size_t count,
 	struct sock_av *_av;
 	_av = container_of(av, struct sock_av, av_fid);
 	return sock_check_table_in(_av, (struct sockaddr_in *)addr,
-				   fi_addr, count, flags, context, 0);
+				   fi_addr, count, flags, context);
 }
 
 static int sock_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
@@ -259,7 +259,7 @@ static int sock_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 
 static int _sock_av_insertsvc(struct fid_av *av, const char *node,
 			      const char *service, fi_addr_t *fi_addr,
-			      uint64_t flags, void *context, int index)
+			      uint64_t flags, void *context)
 {
 	int ret;
 	struct addrinfo sock_hints;
@@ -281,7 +281,7 @@ static int _sock_av_insertsvc(struct fid_av *av, const char *node,
 	}
 
 	ret = sock_check_table_in(_av, (struct sockaddr_in *)result->ai_addr,
-				  fi_addr, 1, flags, context, index);
+				  fi_addr, 1, flags, context);
 	freeaddrinfo(result);
 	return ret;
 }
@@ -295,7 +295,7 @@ static int sock_av_insertsvc(struct fid_av *av, const char *node,
 		return -FI_EINVAL;
 	}
 
-	return _sock_av_insertsvc(av, node, service, fi_addr, flags, context, 0);
+	return _sock_av_insertsvc(av, node, service, fi_addr, flags, context);
 }
 
 static int sock_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
@@ -335,7 +335,7 @@ static int sock_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt
 			len2 = snprintf(tmp_port, FI_NAME_MAX,  "%d",
 					var_port + j);
 			if (len1 > 0 && len1 < FI_NAME_MAX && len2 > 0 && len2 < FI_NAME_MAX) {
-				ret = _sock_av_insertsvc(av, tmp_host, tmp_port, fi_addr, flags, context, i * nodecnt + j);
+				ret = _sock_av_insertsvc(av, tmp_host, tmp_port, fi_addr, flags, context);
 				if (ret == 1)
 					success++;
 				else


### PR DESCRIPTION
- Don't report error when number of inserted addresses exceeds the hint parameter <code>count</code> in <code>fi_av_attr</code>. Fixes #2226 
- Removed unused index parameter in av insert.
- Added reuse of indices of deleted addresses as discussed in #2261.

Verified with fabtests and OpenSHMEM test suites.

Could you please review @j-xiong @a-ilango?