### PR TITLE
prov/psm2: Zero out paddings in endpoint address

### DIFF
--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -319,6 +319,7 @@ static int psmx2_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 
 	av_priv = container_of(av, struct psmx2_fid_av, av);
 
+	memset(&name, 0, sizeof(name));
 	if (av_priv->type == FI_AV_TABLE) {
 		idx = (int)(int64_t)fi_addr;
 		if (idx >= av_priv->last)

--- a/prov/psm2/src/psmx2_cm.c
+++ b/prov/psm2/src/psmx2_cm.c
@@ -46,6 +46,7 @@ static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 		return -FI_ETOOSMALL;
 	}
 
+	memset(epname, 0, sizeof(*epname));
 	epname->epid = ep->domain->psm2_epid;
 	epname->vlane = ep->vlane;
 	*addrlen = sizeof(struct psmx2_ep_name);


### PR DESCRIPTION
The endpoint address (struct psmx2_ep_name) contains some padding area,
which may contain random bytes and prevent applications from using byte
comparison to determine if two addresses are the same.

Zero out the padding area so that the address representation is unique.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>