### PR TITLE
Update API and usnic provider to v1.4

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([libfabric], [1.3.1a1], [ofiwg@lists.openfabrics.org])
+AC_INIT([libfabric], [1.4a1], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -53,8 +53,11 @@ extern "C" {
 	((type *) ((char *)ptr - offsetof(type, field)))
 #endif
 
+/* API version (which is not necessarily the same as the
+ * tarball/libfabric package version number).
+ */
 #define FI_MAJOR_VERSION 1
-#define FI_MINOR_VERSION 3
+#define FI_MINOR_VERSION 4
 
 enum {
 	FI_PATH_MAX		= 256,

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -711,7 +712,7 @@ static void fi_sockets_fini(void)
 struct fi_provider sock_prov = {
 	.name = sock_prov_name,
 	.version = FI_VERSION(SOCK_MAJOR_VERSION, SOCK_MINOR_VERSION),
-	.fi_version = FI_VERSION(1, 3),
+	.fi_version = FI_VERSION(1, 4),
 	.getinfo = sock_getinfo,
 	.fabric = sock_fabric,
 	.cleanup = fi_sockets_fini

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -893,7 +893,7 @@ static void usdf_fini(void)
 struct fi_provider usdf_ops = {
 	.name = USDF_PROV_NAME,
 	.version = USDF_PROV_VERSION,
-	.fi_version = FI_VERSION(1, 3),
+	.fi_version = FI_VERSION(1, 4),
 	.getinfo = usdf_getinfo,
 	.fabric = usdf_fabric_open,
 	.cleanup =  usdf_fini

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -114,8 +114,11 @@ static int fi_register_provider(struct fi_provider *provider, void *dlhandle)
 	       "registering provider: %s (%d.%d)\n", provider->name,
 	       FI_MAJOR(provider->version), FI_MINOR(provider->version));
 
-	if (FI_MAJOR(provider->fi_version) != FI_MAJOR_VERSION ||
-	    FI_MINOR(provider->fi_version) != FI_MINOR_VERSION) {
+	/* The current core implementation is not backward compatible
+	 * with providers that support a release earlier than v1.3.
+	 * See commit 0f4b6651.
+	 */
+	if (provider->fi_version < FI_VERSION(1, 3)) {
 		FI_INFO(&core_prov, FI_LOG_CORE,
 		       "provider has unsupported FI version (provider %d.%d != libfabric %d.%d); ignoring\n",
 		       FI_MAJOR(provider->fi_version),


### PR DESCRIPTION
It's time to update `fabric.h` to indicate that we're libfabric v1.4.

Per #2052, the usNIC provider will need to be able to tell the difference between `<v1.4` and `>=v1.4`.

Other providers can update their API version if they need/want to.

@bturrubiates @goodell @piroux 