### PR TITLE
prov/psm,psm2: Allow multi-recv to post buffer larger than limit

### DIFF
--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -114,6 +114,8 @@ ssize_t _psmx_recv(struct fid_ep *ep, void *buf, size_t len,
 			req->context = fi_context; 
 			PSMX_CTXT_TYPE(fi_context) = PSMX_MULTI_RECV_CONTEXT;
 			PSMX_CTXT_USER(fi_context) = req;
+			if (len > PSMX_MAX_MSG_SIZE)
+				len = PSMX_MAX_MSG_SIZE;
 		} else {
 			PSMX_CTXT_TYPE(fi_context) = PSMX_RECV_CONTEXT;
 			PSMX_CTXT_USER(fi_context) = buf;

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -127,6 +127,8 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 			req->context = fi_context; 
 			PSMX2_CTXT_TYPE(fi_context) = PSMX2_MULTI_RECV_CONTEXT;
 			PSMX2_CTXT_USER(fi_context) = req;
+			if (len > PSMX2_MAX_MSG_SIZE)
+				len = PSMX2_MAX_MSG_SIZE;
 		} else {
 			PSMX2_CTXT_TYPE(fi_context) = PSMX2_RECV_CONTEXT;
 			PSMX2_CTXT_USER(fi_context) = buf;


### PR DESCRIPTION
Previously multi-recv buffer had the same size limit as inidividual
messages. This would effectively halve the size of the messages that
can be received into multi-recv buffer without being truncated. By
removing the limit, the multi-recv buffer can have ebough space to
accomandate multiple incoming messages with the maximum allowed size.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>