### PR TITLE
man: Clarify the completion ordering of multi-recv operation

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -1136,7 +1136,8 @@ value of transmit or receive context attributes of an endpoint.
   restrictions.  The buffer will be returned to the application's
   control, and an *FI_MULTI_RECV* completion will be generated, when a
   message is received that cannot fit into the remaining free buffer
-  space.
+  space. The completions for this single posted receive operation should 
+  be generated in order.
 
 *FI_COMPLETION*
 : Indicates that a completion entry should be generated for data


### PR DESCRIPTION
A single posted recv with FI_MULTI_RECV flag set can generate
multiple completion events. The ordering of these completions was
not clearly defined. Application may need to take extra effort to
determine the ordering of received data, an overhead that can be
avoided if the ordering is enforced.

Add the text to clarify that strict ordering is guaranteed for
completions generated from a single multi-recv operation.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>