### PR TITLE
minor refactoring of freestack macro

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -184,9 +184,11 @@
     <ClCompile Include="prov\util\src\util_buf.c" />
     <ClCompile Include="prov\util\src\util_cq.c" />
     <ClCompile Include="prov\util\src\util_domain.c" />
+    <ClCompile Include="prov\util\src\util_ep.c" />
     <ClCompile Include="prov\util\src\util_eq.c" />
     <ClCompile Include="prov\util\src\util_fabric.c" />
     <ClCompile Include="prov\util\src\util_main.c" />
+    <ClCompile Include="prov\util\src\util_mr.c" />
     <ClCompile Include="prov\util\src\util_poll.c" />
     <ClCompile Include="prov\util\src\util_wait.c" />
     <ClCompile Include="src\common.c" />
@@ -228,11 +230,11 @@
     <ClInclude Include="include\rdma\fi_endpoint.h" />
     <ClInclude Include="include\rdma\fi_eq.h" />
     <ClInclude Include="include\rdma\fi_errno.h" />
-    <ClInclude Include="include\rdma\fi_log.h" />
-    <ClInclude Include="include\rdma\fi_prov.h" />
     <ClInclude Include="include\rdma\fi_rma.h" />
     <ClInclude Include="include\rdma\fi_tagged.h" />
     <ClInclude Include="include\rdma\fi_trigger.h" />
+    <ClInclude Include="include\rdma\providers\fi_log.h" />
+    <ClInclude Include="include\rdma\providers\fi_prov.h" />
     <ClInclude Include="include\windows\arpa\inet.h" />
     <ClInclude Include="include\windows\config.h" />
     <ClInclude Include="include\windows\netinet\in.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -180,6 +180,12 @@
     <ClCompile Include="prov\sockets\src\sock_wait.c">
       <Filter>Source Files\prov\sockets\src</Filter>
     </ClCompile>
+    <ClCompile Include="prov\util\src\util_ep.c">
+      <Filter>Source Files\prov\util</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\util\src\util_mr.c">
+      <Filter>Source Files\prov\util</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\fasthash.h">
@@ -228,12 +234,6 @@
       <Filter>Header Files\rdma</Filter>
     </ClInclude>
     <ClInclude Include="include\rdma\fi_errno.h">
-      <Filter>Header Files\rdma</Filter>
-    </ClInclude>
-    <ClInclude Include="include\rdma\fi_log.h">
-      <Filter>Header Files\rdma</Filter>
-    </ClInclude>
-    <ClInclude Include="include\rdma\fi_prov.h">
       <Filter>Header Files\rdma</Filter>
     </ClInclude>
     <ClInclude Include="include\rdma\fi_rma.h">
@@ -322,6 +322,12 @@
     </ClInclude>
     <ClInclude Include="prov\sockets\include\sock_util.h">
       <Filter>Source Files\prov\sockets\include</Filter>
+    </ClInclude>
+    <ClInclude Include="include\rdma\providers\fi_log.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\rdma\providers\fi_prov.h">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
due to windows compiler limitations macro like ({...})
could not be compiled. to workaround this issue freestack
macro were re-implemented using inline function

additionally added missing source files into VS project

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>