### PR TITLE
rxd: Fix issue reported by coverity

### DIFF
--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -297,7 +297,7 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	util_attr.addrlen = sizeof(fi_addr_t);
 	util_attr.overhead = attr ? attr->count : 0;
 	util_attr.flags = FI_SOURCE;
-	av->size = attr->count;
+	av->size = attr ? attr->count : RXD_AV_DEF_COUNT;
 	ret = ofi_av_init(&domain->util_domain, attr, &util_attr,
 			 &av->util_av, context);
 	if (ret)


### PR DESCRIPTION
Fix "CID 135359 Dereference before null check"