### PR TITLE
prov/verbs: parameterize performance sensitive knobs for ep rdm

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -100,7 +100,7 @@ static ssize_t fi_ibv_rdm_tagged_cq_read(struct fid_cq *cq, void *buf,
 {
 	struct fi_ibv_rdm_cq *_cq =
 		container_of(cq, struct fi_ibv_rdm_cq, cq_fid);
-	const size_t _count = _cq->ep->n_buffs;
+	const size_t _count = _cq->read_bunch_size;
 	fi_addr_t addr[_count];
 
 	return fi_ibv_rdm_tagged_cq_readfrom(cq, buf, MIN(_count, count), addr);
@@ -147,7 +147,7 @@ ssize_t fi_ibv_rdm_cq_sread(struct fid_cq *cq, void *buf, size_t count,
 {
 	struct fi_ibv_rdm_cq *_cq =
 		container_of(cq, struct fi_ibv_rdm_cq, cq_fid);
-	size_t chunk		= MIN(_cq->ep->n_buffs, count);
+	size_t chunk		= MIN(_cq->read_bunch_size, count);
 	uint64_t time_limit	= fi_gettime_ms() + timeout;
 	size_t rest		= count;
 	fi_addr_t addr[chunk];
@@ -251,6 +251,7 @@ int fi_ibv_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 {
 	struct fi_ibv_rdm_cq *_cq;
 	int ret;
+	int param;
 
 	_cq = calloc(1, sizeof *_cq);
 	if (!_cq)
@@ -295,6 +296,18 @@ int fi_ibv_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	dlist_init(&fi_ibv_rdm_comp_queue.request_cq);
 	dlist_init(&fi_ibv_rdm_comp_queue.request_errcq);
+
+	_cq->read_bunch_size = FI_IBV_RDM_DFLT_CQREAD_BUNCH_SIZE;
+	if (!fi_param_get_int(&fi_ibv_prov, "rdm_cqread_bunch_size", &param)) {
+		if (param > 0) {
+			_cq->read_bunch_size = param;
+		} else {
+			FI_INFO(&fi_ibv_prov, FI_LOG_CORE,
+				"invalid value of rdm_cqread_bunch_size\n");
+			ret = -FI_EINVAL;
+			goto err;
+		}
+	}
 
 	*cq = &_cq->cq_fid;
 	return 0;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -254,13 +254,17 @@ struct fi_ibv_rdm_ep {
 	int num_active_conns;
 	int max_inline_rc;
 	int rndv_threshold;
+	int rndv_seg_size;
 	struct ibv_cq *scq;
 	struct ibv_cq *rcq;
 	int scq_depth;
 	int rcq_depth;
+	int cqread_bunch_size;
+
 	/* TODO: move all CM things to domain */
 	pthread_t cm_progress_thread;
 	pthread_mutex_t cm_lock;
+	int cm_progress_timeout;
 	int is_closing;
 	int recv_preposted_threshold;
 };
@@ -574,7 +578,6 @@ fi_ibv_rdm_check_connection(struct fi_ibv_rdm_conn *conn,
 			fi_ibv_rdm_start_connection(ep, conn);
 		}
 		pthread_mutex_unlock(&ep->cm_lock);
-		usleep(1000);
 	}
 
 	return status;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -744,7 +744,7 @@ ssize_t fi_ibv_rdm_cm_progress(struct fi_ibv_rdm_ep *ep)
 	if (rdma_get_cm_event(ep->domain->rdm_cm->ec, &event)) {
 		if(errno == EAGAIN) {
 			errno = 0;
-			usleep(FI_IBV_RDM_CM_THREAD_TIMEOUT);
+			usleep(ep->cm_progress_timeout);
 			return FI_SUCCESS;
 		} else {
 			VERBS_INFO_ERRNO(FI_LOG_AV,
@@ -795,7 +795,7 @@ ssize_t fi_ibv_rdm_cm_progress(struct fi_ibv_rdm_ep *ep)
 		if(rdma_get_cm_event(ep->domain->rdm_cm->ec, &event)) {
 			if(errno == EAGAIN) {
 				errno = 0;
-				usleep(FI_IBV_RDM_CM_THREAD_TIMEOUT);
+				usleep(ep->cm_progress_timeout);
 				break;
 			} else {
 				VERBS_INFO_ERRNO(FI_LOG_AV,

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -673,7 +673,7 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 
 static inline int fi_ibv_rdm_tagged_poll_recv(struct fi_ibv_rdm_ep *ep)
 {
-	const int wc_count = ep->n_buffs; /* TODO: to set from upper level */
+	const int wc_count = ep->fi_rcq->read_bunch_size;
 	struct ibv_wc wc[wc_count];
 	int ret = 0;
 	int err = 0;
@@ -750,7 +750,7 @@ fi_ibv_rdm_process_send_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 
 static inline int fi_ibv_rdm_tagged_poll_send(struct fi_ibv_rdm_ep *ep)
 {
-	const int wc_count = ep->n_buffs;
+	const int wc_count = ep->fi_scq->read_bunch_size;
 	struct ibv_wc wc[wc_count];
 	int ret = 0;
 	int err = 0;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -871,7 +871,7 @@ fi_ibv_rdm_tagged_rndv_recv_post_read(struct fi_ibv_rdm_request *request,
 	struct fi_ibv_rdm_tagged_send_ready_data *p = data;
 	const size_t offset = request->len - request->rest_len;
 	const size_t seg_cursize =
-		MIN(FI_IBV_RDM_SEG_MAXSIZE, request->rest_len);
+		MIN(p->ep->rndv_seg_size, request->rest_len);
 
 	struct ibv_send_wr wr = { 0 };
 	struct ibv_send_wr *bad_wr = NULL;
@@ -1159,7 +1159,7 @@ fi_ibv_rdm_rma_post_ready(struct fi_ibv_rdm_request *request, void *data)
 	
 	const size_t offset = request->len - request->rest_len;
 	const size_t seg_cursize =
-		MIN(FI_IBV_RDM_SEG_MAXSIZE, request->rest_len);
+		MIN(p->ep_rdm->rndv_seg_size, request->rest_len);
 
 	struct ibv_sge sge = { 0 };
 	struct ibv_send_wr wr = { 0 };

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -44,6 +44,14 @@ extern struct util_buf_pool *fi_ibv_rdm_request_pool;
 extern struct util_buf_pool *fi_ibv_rdm_extra_buffers_pool;
 extern struct util_buf_pool *fi_ibv_rdm_postponed_pool;
 
+size_t rdm_buffer_size(size_t buf_send_size)
+{
+	size_t size = buf_send_size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE +
+		sizeof(struct fi_ibv_rdm_header) + FI_IBV_RDM_BUF_ALIGNMENT;
+	size -= (size % FI_IBV_RDM_BUF_ALIGNMENT);
+	return size;
+}
+
 int fi_ibv_rdm_req_match(struct dlist_entry *item, const void *other)
 {
 	const struct fi_ibv_rdm_request *req = other;

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -64,9 +64,10 @@ struct fi_ibv_msg_ep;
 
 #define FI_IBV_RDM_CM_THREAD_TIMEOUT (100)
 #define FI_IBV_RDM_MEM_ALIGNMENT (64)
-#define FI_IBV_RDM_BUF_ALIGNMENT (4096) /* TODO: Page size */
+#define FI_IBV_RDM_BUF_ALIGNMENT (4096) /* TODO: Page or MTU size */
 
 #define FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM (8)
+#define FI_IBV_RDM_DFLT_CQREAD_BUNCH_SIZE (FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM)
 
 #define FI_IBV_RDM_DFLT_BUFFER_SIZE					\
 	(3 * FI_IBV_RDM_BUF_ALIGNMENT)
@@ -75,6 +76,12 @@ struct fi_ibv_msg_ep;
 	(FI_IBV_RDM_DFLT_BUFFER_SIZE -					\
 	 FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE -				\
 	 sizeof(struct fi_ibv_rdm_header))
+
+/*
+ * calculates internal buffer size from user defined buffered send size in
+ * consideration of wired protocols, alignment, etc
+ */
+size_t rdm_buffer_size(size_t buf_send_size);
 
 /* 1GB is RC_QP limitation */
 #define FI_IBV_RDM_SEG_MAXSIZE (1024*1024*1024)

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -374,8 +374,24 @@ static void fi_ibv_fini(void)
 VERBS_INI
 {
 	fi_param_define(&fi_ibv_prov, "iface", FI_PARAM_STRING,
-			"prefix or full name of network interface associated "
-			"with IB device (default: ib)");
+			"the prefix or the full name of the network interface "
+			"associated with the IB device (default: ib)");
+	fi_param_define(&fi_ibv_prov, "rdm_buffer_num", FI_PARAM_INT,
+			"the number of pre-registered buffers for buffered "
+			"operations between the endpoints, must be a power of 2 "
+			"(default: 8)");
+	fi_param_define(&fi_ibv_prov, "rdm_buffer_size", FI_PARAM_INT,
+			"the maximum size of a buffered operation (bytes) "
+			"(default: platform specific)");
+	fi_param_define(&fi_ibv_prov, "rdm_rndv_seg_size", FI_PARAM_INT,
+			"the segment size for zero copy protocols (bytes)"
+			"(default: 1073741824)");
+	fi_param_define(&fi_ibv_prov, "rdm_cqread_bunch_size", FI_PARAM_INT,
+			"the number of entries to be read from the verbs "
+			"completion queue at a time (default: 8)");
+	fi_param_define(&fi_ibv_prov, "rdm_thread_timeout", FI_PARAM_INT,
+			"the wake up timeout of the helper thread (usec) "
+			"(default: 100)");
 
 	return &fi_ibv_prov;
 }

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -212,6 +212,7 @@ struct fi_ibv_rdm_cq {
 	struct dlist_entry	request_errcq;
 	uint64_t		flags;
 	size_t			entry_size;
+	int			read_bunch_size;
 	enum fi_cq_wait_cond	wait_cond;
 };
 


### PR DESCRIPTION
 - rdm_buffer_num - number of pre-registered eager buffers per connection
 - rdm_buffer_size - size of pre-registered eager buffer
 - rdm_rndv_seg_size - segment size of zero-copy protocols
 - rdm_cqread_bunch_size - count of completions to read from cq,
   aligned with corresponding ibv_poll_cq arg
 - rdm_thread_timeout - timeout to wakeup helper thread (currently )

Update: resolved conflicts

@a-ilango , please review