### PR TITLE
prov/gni: Documented new mr ops in fi_gni

### DIFF
--- a/man/man7/fi_gni.7
+++ b/man/man7/fi_gni.7
@@ -178,6 +178,22 @@ The value is of type uint32_t.
 of memory.
 The value is of type int32_t.
 .PP
+\f[I]GNI_MR_CACHE\f[] : Select the type of cache that the domain will use. Valid choices are given below.
+.PP
+\'internal\' - GNI provider internal registration cache.
+.PP
+\'udreg\' - user level dreg library based cache.
+.PP
+\'none\' - no caching, device direct registration
+.PP
+\f[I]IGNI_MR_HARD_REG_LIMIT\f[] : Maximum number of registrations. Applies only to the GNI provider cache. The value is of type int32_t (-1 for no limit).
+.PP
+\f[I]GNI_MR_SOFT_REG_LIMIT\f[] : Soft cap on the registration limit. Applies only to the GNI provider cache. The value is of type int32_t (-1 for no limit).
+.PP
+\f[I]GNI_MR_HARD_STALE_REG_LIMIT\f[] : Maximum number of stale registrations to be held in cache. This applies to  the GNI provider cache and the udreg cache. The value is of type int32_t (-1 for no limit for the GNI provider cache and udreg cache values must be greater than 0).
+.PP
+\f[I]GNI_MR_UDREG_LIMIT\f[] : Maximum number of registrations. Applies only to the udreg cache. The value is of type int32_t. The value must be greater than 0.
+.PP
 For \f[I]FI_GNI_EP_OPS_1\f[], the currently supported values are:
 \f[I]GNI_HASH_TAG_IMPL\f[] : Use a hashlist for the tag list
 implementation.


### PR DESCRIPTION
Added documentation for GNI_MR_CACHE, GNI_MR_HARD_REG_LIMIT,
GNI_SOFT_REG_LIMIT, GNI_MR_HARD_STALE_REG_LIMIT, GNI_MR_UDREG_LIMIT,
and GNI_MR_UDREG_LIMIT

upstream merge of ofi-cray/libfabric-cray#933

closes ofi-cray/libfabric-cray#850

@sungeunchoi 

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@9286b04b77c493109f7a91e799ac7754c5307ac8)