### PR TITLE
usnic: Verify domain name hint.

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -479,8 +479,12 @@ int usdf_endpoint_open(struct fid_domain *domain, struct fi_info *info,
 		struct fid_ep **ep, void *context);
 int usdf_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		 struct fid_av **av_o, void *context);
+
+/* Domain name functionality */
 int usdf_domain_getname(uint32_t version, struct usd_device_attrs *dap,
 			char **name);
+bool usdf_domain_checkname(uint32_t version, struct usd_device_attrs *dap,
+			char *hint);
 
 /* fi_ops_mr */
 int usdf_reg_mr(struct fid *fid, const void *buf, size_t len,

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -146,6 +146,7 @@ static int usdf_validate_hints(uint32_t version, struct fi_info *hints,
 			       struct usd_device_attrs *dap)
 {
 	struct fi_fabric_attr *fattrp;
+	struct fi_domain_attr *dattrp;
 	size_t size;
 
 	switch (hints->addr_format) {
@@ -188,6 +189,12 @@ static int usdf_validate_hints(uint32_t version, struct fi_info *hints,
 		    !usdf_fabric_checkname(version, dap, fattrp->name)) {
 			return -FI_ENODATA;
 		}
+	}
+
+	dattrp = hints->domain_attr;
+	if (dattrp) {
+		if (!usdf_domain_checkname(version, dap, dattrp->name))
+			return -FI_ENODATA;
 	}
 
 	return FI_SUCCESS;


### PR DESCRIPTION
Previously it seems that the usNIC provider was not checking the domain
name hint. This needs to be validated in both getinfo and in fi_fabric.

Since the domain name was NULL in pre-1.4 releases of libfabric, the
comparison logic is somewhat complicated:

1. If version is greater than or equal to 1.4 and a non-NULL name hint
   is provided, then compare the hint and reference domain name.
2. If the version is greater than or equal to 1.4 and the provider hint
   is NULL, then treat this as valid. This could be an application
   requesting a 1.4 domain and not explicitly providing a name hint.
3. If the version is less than 1.4 and a name hint is provided, then
   this is always going to be invalid as the name should always be NULL
   in pre-1.4.
4. If the version is less than 1.4 and the name hint is NULL, then this
   will always be valid as all domains have NULL as their name in
   pre-1.4.

If there is no version provided, and a name hint is provided then
version 1.4 is assumed. This is the case when used from fi_fabric.

I noticed that it seems we forgot to implement domain name checking
this morning. This is a follow-up to #2287. 

@goodell @jsquyres 
Please review. 

Signed-off-by: Ben Turrubiates \<bturrubi@cisco.com\>