### PR TITLE
prov/psm,psm2: Check EP state in fi_tx/rx_size_left()

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -491,6 +491,7 @@ struct psmx_fid_ep {
 	struct psmx_fid_cntr	*remote_read_cntr;
 	unsigned		send_selective_completion:1;
 	unsigned		recv_selective_completion:1;
+	unsigned		enabled:1;
 	uint64_t		tx_flags;
 	uint64_t		rx_flags;
 	uint64_t		caps;

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -349,6 +349,7 @@ static int psmx_ep_control(fid_t fid, int command, void *arg)
 		break;
 
 	case FI_ENABLE:
+		ep->enabled = 1;
 		return 0;
 
 	default:
@@ -360,12 +361,24 @@ static int psmx_ep_control(fid_t fid, int command, void *arg)
 
 static ssize_t psmx_rx_size_left(struct fid_ep *ep)
 {
-	return 0x7fffffff; /* a random choice */
+	struct psmx_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
+	if (ep_priv->enabled)
+		return 0x7fffffff;
+	else
+		return -FI_EOPBADSTATE;
 }
 
 static ssize_t psmx_tx_size_left(struct fid_ep *ep)
 {
-	return 0x7fffffff; /* a random choice */
+	struct psmx_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
+	if (ep_priv->enabled)
+		return 0x7fffffff;
+	else
+		return -FI_EOPBADSTATE;
 }
 
 static struct fi_ops psmx_fi_ops = {

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -669,6 +669,7 @@ struct psmx2_fid_ep {
 	uint8_t			vlane;
 	unsigned		send_selective_completion:1;
 	unsigned		recv_selective_completion:1;
+	unsigned		enabled:1;
 	uint64_t		tx_flags;
 	uint64_t		rx_flags;
 	uint64_t		caps;

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -422,6 +422,7 @@ static int psmx2_ep_control(fid_t fid, int command, void *arg)
 		break;
 
 	case FI_ENABLE:
+		ep->enabled = 1;
 		return 0;
 
 	default:
@@ -433,12 +434,24 @@ static int psmx2_ep_control(fid_t fid, int command, void *arg)
 
 static ssize_t psmx2_rx_size_left(struct fid_ep *ep)
 {
-	return 0x7fffffff; /* a random choice */
+	struct psmx2_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
+	if (ep_priv->enabled)
+		return 0x7fffffff;
+	else
+		return -FI_EOPBADSTATE;
 }
 
 static ssize_t psmx2_tx_size_left(struct fid_ep *ep)
 {
-	return 0x7fffffff; /* a random choice */
+	struct psmx2_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
+	if (ep_priv->enabled)
+		return 0x7fffffff;
+	else
+		return -FI_EOPBADSTATE;
 }
 
 static struct fi_ops psmx2_fi_ops = {


### PR DESCRIPTION
Return error code if the EP has not been enabled yet. This fixes
the negative test failure of fabtests/fi_size_left_test.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>