### PR TITLE
util/info.c: Add domain and fabric name hints.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,9 +5,12 @@ This file contains the main features as well as overviews of specific
 bug fixes (and other actions) for each version of Libfabric since
 version 1.0.
 
-v1.3.1, TBD
+v1.4.0, TBD
 ===========
 
+- Add new options, `-f` and `-d`, to fi_info that can be used to specify hints
+  about the fabric and domain name. Change port to `-P` and provider to `-p` to
+  be more in line with fi_pingpong.
 
 v1.3.0, Mon Apr 11, 2016
 ========================

--- a/man/fi_info.1.md
+++ b/man/fi_info.1.md
@@ -33,7 +33,7 @@ for all providers and endpoint types will be returned.
 : Node name or address used to filter interfaces. Only interfaces which can
 reach the given node or address will respond.
 
-*-p, --port=\<PORT\>*
+*-P, --port=\<PORT\>*
 : Port number used to filter interfaces.
 
 *-c, --caps=\<CAP1|CAP2\>..*
@@ -57,9 +57,15 @@ specifying FI_SOCKADDR_IN would return only interfaces which use sockaddr_in
 structures for addressing. For more information on address formats, see
 fi_getinfo(3).
 
-*-f, --provider=\<PROV\>*
+*-p, --provider=\<PROV\>*
 : Filter fabric interfaces by the provider implementation. For a list of
 providers, see the `--list` option.
+
+*-d, --domain=\<DOMAIN\>*
+: Filter interfaces to only those with the given domain name.
+
+*-f, --fabric=\<FABRIC\>*
+: Filter interfaces to only those with the given fabric name.
 
 ## Discovery
 
@@ -82,7 +88,7 @@ the fi_info structure, see fi_getinfo(3).
 # USAGE EXAMPLES
 
 ```
-$ fi_info -n 30.0.11.1 -f usnic -t FI_EP_DGRAM
+$ fi_info -n 30.0.11.1 -p usnic -t FI_EP_DGRAM
 ```
 
 This will respond with all fabric interfaces that can reach address 30.0.11.1
@@ -93,7 +99,7 @@ using endpoint type FI_EP_DGRAM with the usNIC provider.
 By default fi_info will output a summary of the fabric interfaces discovered:
 
 ```
-$ ./fi_info -n 30.0.11.1 -f usnic -t FI_EP_DGRAM
+$ ./fi_info -n 30.0.11.1 -p usnic -t FI_EP_DGRAM
 provider: usnic
     fabric: 30.0.11.0/24
     domain: usnic_2

--- a/util/info.c
+++ b/util/info.c
@@ -48,12 +48,14 @@ static int verbose = 0, env = 0;
 static const struct option longopts[] = {
 	{"help", no_argument, NULL, 'h'},
 	{"node", required_argument, NULL, 'n'},
-	{"port", required_argument, NULL, 'p'},
+	{"port", required_argument, NULL, 'P'},
 	{"caps", required_argument, NULL, 'c'},
 	{"mode", required_argument, NULL, 'm'},
 	{"ep_type", required_argument, NULL, 't'},
+	{"domain", required_argument, NULL, 'd'},
+	{"fabric", required_argument, NULL, 'f'},
 	{"addr_format", required_argument, NULL, 'a'},
-	{"provider", required_argument, NULL, 'f'},
+	{"provider", required_argument, NULL, 'p'},
 	{"env", no_argument, NULL, 'e'},
 	{"list", no_argument, NULL, 'l'},
 	{"verbose", no_argument, NULL, 'v'},
@@ -68,6 +70,8 @@ static const char *help_strings[][2] = {
 	{"CAP1|CAP2..", "\tone or more capabilities: FI_MSG|FI_RMA..."},
 	{"MOD1|MOD2..", "\tone or more modes, default all modes"},
 	{"EPTYPE", "\t\tspecify single endpoint type: FI_EP_MSG, FI_EP_DGRAM..."},
+	{"DOMAIN", "\t\tspecify the domain name"},
+	{"FABRIC", "\t\tspecify the fabric name"},
 	{"FMT", "\t\tspecify accepted address format: FI_FORMAT_UNSPEC, FI_SOCKADDR..."},
 	{"PROV", "\t\tspecify provider explicitly"},
 	{"", "\t\tprint libfabric environment variables"},
@@ -290,7 +294,8 @@ int main(int argc, char **argv)
 
 	hints->mode = ~0;
 
-	while ((op = getopt_long(argc, argv, "n:p:c:m:t:a:f:elhv", longopts, &option_index)) != -1) {
+	while ((op = getopt_long(argc, argv, "n:P:c:m:t:a:p:d:f:elhv", longopts,
+				 &option_index)) != -1) {
 		switch (op) {
 		case 0:
 			/* If --verbose set a flag, do nothing. */
@@ -299,7 +304,7 @@ int main(int argc, char **argv)
 		case 'n':
 			node = optarg;
 			break;
-		case 'p':
+		case 'P':
 			port = optarg;
 			break;
 		case 'c':
@@ -318,9 +323,17 @@ int main(int argc, char **argv)
 			hints->addr_format = str2addr_format(optarg);
 			use_hints = 1;
 			break;
-		case 'f':
+		case 'p':
 			free(hints->fabric_attr->prov_name);
 			hints->fabric_attr->prov_name = strdup(optarg);
+			use_hints = 1;
+			break;
+		case 'd':
+			hints->domain_attr->name = strdup(optarg);
+			use_hints = 1;
+			break;
+		case 'f':
+			hints->fabric_attr->name = strdup(optarg);
 			use_hints = 1;
 			break;
 		case 'e':


### PR DESCRIPTION
Add new options `-d` and `-f` for providing domain and fabric name
hints. Change port to `-P` and provider to `-p` to be more inline with
fi_pingpong.

@jsquyres @goodell @shantonu @j-xiong 

Signed-off-by: Ben Turrubiates \<bturrubi@cisco.com\>