### PR TITLE
Pr/sockets: Add fabric/domain name based filtering in fi_getinfo

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -404,6 +404,19 @@ out:
 	return ret;
 }
 
+static int sock_fi_checkinfo(struct fi_info *info, struct fi_info *hints)
+{
+	if (hints && hints->domain_attr && hints->domain_attr->name &&
+             strcmp(info->domain_attr->name, hints->domain_attr->name))
+		return -FI_ENODATA;
+
+	if (hints && hints->fabric_attr && hints->fabric_attr->name &&
+             strcmp(info->fabric_attr->name, hints->fabric_attr->name))
+		return -FI_ENODATA;
+
+	return 0;
+}
+
 static int sock_ep_getinfo(const char *node, const char *service, uint64_t flags,
 			   struct fi_info *hints, enum fi_ep_type ep_type,
 			   struct fi_info **info)
@@ -473,6 +486,10 @@ static int sock_ep_getinfo(const char *node, const char *service, uint64_t flags
 
 	if (rai)
 		freeaddrinfo(rai);
+
+	if (ret == 0)
+		return sock_fi_checkinfo(*info, hints);
+
 	return ret;
 }
 

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -718,7 +718,8 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 			return ret;
 		}
 	}
-	return 0;
+
+	return ret;
 }
 
 static void fi_sockets_fini(void)


### PR DESCRIPTION
- After setting the fabric/domain name from the local interfaces, check if if matches with the hint provided by the user.
- Fix the return value of fi_getinfo when there is no fi_info to return.

Fixes #2248 and #2302. Verified with #2300 that adds fabric and domain parameter in ```fi_info```.

Could you please review @j-xiong @bturrubiates @a-ilango?