### PR TITLE
prov/gni: add support for unassigned cpus

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -235,6 +235,7 @@ int _gnix_job_cq_limit(uint32_t dev_id, uint8_t ptag, uint32_t *limit);
 int _gnix_pes_on_node(uint32_t *num_pes);
 int _gnix_nics_per_rank(uint32_t *nics_per_rank);
 void _gnix_dump_gni_res(uint8_t ptag);
+int _gnix_get_num_corespec_cpus(uint32_t *num_core_spec_cpus);
 
 struct gnix_reference {
 	atomic_t references;

--- a/prov/gni/test/utils.c
+++ b/prov/gni/test/utils.c
@@ -64,12 +64,11 @@ Test(utils, proc)
 	rc = _gnix_task_is_not_app();
 	cr_expect(rc == 0);
 
-	/* *_unassigned_cpus flags don't work on tiger */
 	rc = _gnix_job_enable_unassigned_cpus();
-	cr_expect(rc != 0);
+	cr_expect(rc == 0);
 
 	rc = _gnix_job_disable_unassigned_cpus();
-	cr_expect(rc != 0);
+	cr_expect(rc == 0);
 
 	rc = _gnix_job_enable_affinity_apply();
 	cr_expect(rc == 0);


### PR DESCRIPTION
add option to place progress threads on unused
cpus (aka hyperthreads) if user is not using corespec
feature.  This helps modestly with progress thread
interference with application threads.

fix some errors in telling job container about
use of unassigned cpus. fix criterion test.

@sungeunchoi 
upstream merge of ofi-cray/libfabric-cray#931

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@aadfe44316cc290d922befad768a1dba0a55e971)