### PR TITLE
prov/psm,psm2: Allow FI_AV_UNSPEC type in fi_av_open()

### DIFF
--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -392,6 +392,9 @@ int psmx_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 
 	if (attr) {
 		switch (attr->type) {
+		case FI_AV_UNSPEC:
+			break;
+
 		case FI_AV_MAP:
 		case FI_AV_TABLE:
 			type = attr->type;
@@ -432,6 +435,9 @@ int psmx_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	av_priv->av.ops = &psmx_av_ops;
 
 	*av = &av_priv->av;
+	if (attr)
+		attr->type = type;
+
 	return 0;
 }
 

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -424,6 +424,9 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 
 	if (attr) {
 		switch (attr->type) {
+		case FI_AV_UNSPEC:
+			break;
+
 		case FI_AV_MAP:
 		case FI_AV_TABLE:
 			type = attr->type;
@@ -464,6 +467,9 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	av_priv->av.ops = &psmx2_av_ops;
 
 	*av = &av_priv->av;
+	if (attr)
+		attr->type = type;
+
 	return 0;
 }
 


### PR DESCRIPTION
Fix a bug in the code that causes fi_av_open to return error when
the input av type is FI_AV_UNSPEC.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>