### PR TITLE
util/pingpong.c: Fix coverity CIDs.

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -475,8 +475,13 @@ static int pp_ctrl_init_server(struct ct_pingpong *ct)
 	return ret;
 
 fail_close_socket:
-	close(ct->ctrl_connfd);
-	ct->ctrl_connfd = -1;
+	if (ct->ctrl_connfd != -1) {
+		close(ct->ctrl_connfd);
+		ct->ctrl_connfd = -1;
+	}
+
+	if (listenfd != -1)
+		close(listenfd);
 
 	return ret;
 }


### PR DESCRIPTION
- Fix coverity CID 135561 by checking if the FD is -1 before passing it
  to close.
- Fix coverity CID 135562 by closing the listenfd in the error path.

@jsquyres Please review. 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>