### PR TITLE
Pr/sockets: Fix fi_getinfo return value

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -719,7 +719,7 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 		}
 	}
 
-	return ret;
+	return (!*info) ? ret : 0;
 }
 
 static void fi_sockets_fini(void)

--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -321,8 +321,12 @@ void pp_banner_options(struct ct_pingpong *ct)
 	PP_DEBUG("  - %-20s: [%" PRIu16 "]\n", "dst_port", opts.dst_port);
 	PP_DEBUG("  - %-20s: %s\n", "sizes_enabled", size_msg);
 	PP_DEBUG("  - %-20s: %s\n", "iterations", iter_msg);
-	PP_DEBUG("  - %-20s: %s\n", "provider",
-		 ct->hints->fabric_attr->prov_name);
+	if (ct->hints->fabric_attr->prov_name)
+		PP_DEBUG("  - %-20s: %s\n", "provider",
+			  ct->hints->fabric_attr->prov_name);
+	if (ct->hints->domain_attr->name)
+		PP_DEBUG("  - %-20s: %s\n", "domain",
+			  ct->hints->domain_attr->name);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
- Print domain name in verbose mode in util/fi_fingpong if specified
- Noticed a sockets provider issue while testing ```fi_pingpong``` as part of  #2307. Sockets provider was returning the last return value of ```sock_node_getinfo()``` suppressing all the previous return values. This could be an issue when the last call returns ```-FI_ENODATA``` but previous call was successful. Fixed the issue by checking the returned ```fi_info``` structure. 

@j-xiong @bturrubiates @a-ilango  