### PR TITLE
windows: added missing API to list of exports

### DIFF
--- a/libfabric.def
+++ b/libfabric.def
@@ -1,8 +1,10 @@
 
 EXPORTS
-    fi_dupinfo  = fi_dupinfo
-    fi_getinfo  = fi_getinfo
-    fi_freeinfo = fi_freeinfo
-    fi_fabric   = fi_fabric
-    fi_strerror = fi_strerror
-    fi_tostr    = fi_tostr
+    fi_dupinfo    = fi_dupinfo
+    fi_getinfo    = fi_getinfo
+    fi_freeinfo   = fi_freeinfo
+    fi_fabric     = fi_fabric
+    fi_strerror   = fi_strerror
+    fi_tostr      = fi_tostr
+    fi_getparams  = fi_getparams
+    fi_freeparams = fi_freeparams


### PR DESCRIPTION
added fi_getparams and fi_freeparams calls to
export symbols of libfabric.dll

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>