### PR TITLE
windows: added macro for pthread_cond_broadcast

### DIFF
--- a/include/windows/pthread.h
+++ b/include/windows/pthread.h
@@ -21,6 +21,7 @@
 #define PTHREAD_MUTEX_INITIALIZER {0}
 
 #define pthread_cond_signal WakeConditionVariable
+#define pthread_cond_broadcast WakeAllConditionVariable
 #define pthread_mutex_init(mutex, attr) InitializeCriticalSection(mutex)
 #define pthread_mutex_destroy DeleteCriticalSection
 #define pthread_cond_init(cond, attr) (InitializeConditionVariable(cond), 0)


### PR DESCRIPTION
windows platform has no pthread implementation, but
most of pthread calls may be re-implemented using
windows native calls.

added macro wrapper for pthread_cond_broadcast call

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>