### PR TITLE
prov/gni: cm_nic alloc changes to facilitate SEP

### DIFF
--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -136,6 +136,7 @@ int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic);
  */
 int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 		       struct fi_info *info,
+		       uint32_t cdm_id,
 		       struct gnix_cm_nic **cm_nic);
 
 /**


### PR DESCRIPTION
Pass cdm_id to _gnix_cm_nic_alloc().
Change how cdm_id's are formed to allow a range of values that will not
collide with multiple processes on one node.

Fixes ofi-cray/libfabric-cray#939

@sungeunchoi 

Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@922d9b81f5173641764e9b89a31f79b8cf0ee6f0)