### PR TITLE
verbs: fi_cq_open bug fixes

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -100,6 +100,8 @@
 #define VERBS_WCE_CNT 1024
 #define VERBS_EPE_CNT 1024
 
+#define VERBS_DEF_CQ_SIZE 1024
+
 extern struct fi_provider fi_ibv_prov;
 
 


### PR DESCRIPTION
- Choose a default size when opening CQ if user provides size of 0
- Allow FI_CQ_FORMAT_UNSPEC
- Add some logging

This should fix #2322