### PR TITLE
prov/sockets: Set default CQ format

### DIFF
--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -518,6 +518,9 @@ static int sock_cq_verify_attr(struct fi_cq_attr *attr)
 	case FI_CQ_FORMAT_DATA:
 	case FI_CQ_FORMAT_TAGGED:
 		break;
+	case FI_CQ_FORMAT_UNSPEC:
+		attr->format = FI_CQ_FORMAT_CONTEXT;
+		break;
 	default:
 		return -FI_ENOSYS;
 	}


### PR DESCRIPTION
 - Set default CQ format to FI_CQ_FORMAT_CONTEXT when user specifies FI_CQ_FORMAT_UNSPEC

Fixes newly added fabtests unit/fi_cq_test
@a-ilango, @j-xiong 

Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>