### PR TITLE
fi_fini destructor attribute refactoring

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -37,6 +37,8 @@
 #include <unistd.h>
 #include <errno.h>
 
+#define FI_DESTRUCTOR(func) static __attribute__((destructor)) void func
+
 struct util_shm
 {
 	int		shared_fd;

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -31,6 +31,8 @@
 extern "C" {
 #endif
 
+#define FI_DESTRUCTOR(func) void func
+
 #define LITTLE_ENDIAN 5678
 #define BIG_ENDIAN 8765
 #define BYTE_ORDER LITTLE_ENDIAN

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -409,7 +409,7 @@ unlock:
 	pthread_mutex_unlock(&ini_lock);
 }
 
-static void __attribute__((destructor)) fi_fini(void)
+FI_DESTRUCTOR(fi_fini(void))
 {
 	struct fi_prov *prov;
 

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -45,6 +45,8 @@ static INIT_ONCE ofi_init_once = INIT_ONCE_STATIC_INIT;
 
 static char ofi_shm_prefix[] = "Local\\";
 
+void fi_fini(void);
+
 int socketpair(int af, int type, int protocol, int socks[2])
 {
 	protocol; /* suppress warning */
@@ -163,14 +165,17 @@ BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved)
 	OFI_UNUSED(instance);
 	OFI_UNUSED(reserved);
 
-	switch(reason)
-	{
+	switch (reason) {
 	case DLL_PROCESS_ATTACH:
 		InitOnceExecuteOnce(&ofi_init_once, ofi_init_once_cb, &ini_lock, 0);
 		break;
 	case DLL_THREAD_ATTACH:
+		break;
 	case DLL_PROCESS_DETACH:
+		fi_fini();
+		break;
 	case DLL_THREAD_DETACH:
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
on Unix-like systems there is way to register callback
on module unload/process termination. for windows platforms
there is no way to do this for "C" module. to workaround
this issue such "destructors" are called from DllMain
function when module is unloaded.

so, change is: wrap fi_fini function to FI_DESTRUCTOR macro
which expanded as __attribute__((destructor)) on Unix
systems and "void fi_fini" on windows systems to be called
from DllMain function

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>