### PR TITLE
prov/gni: Optimized AV lookups for frequent usage patterns

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -119,7 +119,7 @@ extern "C" {
 #endif
 
 #define GNIX_MAX_IOV_LIMIT 8
-
+#define GNIX_ADDR_CACHE_SIZE 5
 /*
  * GNI GET alignment
  */
@@ -417,6 +417,11 @@ struct gnix_htd_pool {
 	void *sl_ptr;
 };
 
+struct gnix_addr_cache_entry {
+	fi_addr_t addr;
+	struct gnix_vc *vc;
+};
+
 /*
  *   gnix endpoint structure
  *
@@ -470,6 +475,8 @@ struct gnix_fid_ep {
 	bool tx_enabled;
 	bool rx_enabled;
 	bool requires_lock;
+	int last_cached;
+	struct gnix_addr_cache_entry addr_cache[GNIX_ADDR_CACHE_SIZE];
 	int send_selective_completion;
 	int recv_selective_completion;
 	int min_multi_recv;

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -297,5 +297,13 @@ static inline void _gnix_ref_init(
 	__COND_FUNC((cond), (lock), fastlock_release)
 #define COND_RW_RELEASE(cond, lock) \
 	__COND_FUNC((cond), (lock), rwlock_unlock)
+#ifdef __GNUC__
+#define __PREFETCH(addr, rw, locality) __builtin_prefetch(addr, rw, locality)
+#else 
+#define __PREFETCH(addr, rw, locality) ((void *) 0)
+#endif
+
+#define READ_PREFETCH(addr) __PREFETCH(addr, 0, 3)
+#define WRITE_PREFETCH(addr) __PREFETCH(addr, 1, 3)
 
 #endif


### PR DESCRIPTION
Added prefetch macros to assign the hardware with fetching
data that will be used soon, if not already prefetched by the
hardware prefetcher.

Modified the hashtable to code to remove unnecessary branching conditions

Added small AV-address mapping for fast search without requiring search
in the hash table.

Upstream merge of ofi-cray/libfabric-cray#944

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@7f790d8a28acb330aefc133984eecff32a3f4edc)

@hppritcha 