### PR TITLE
prov/gni: refactor a bit av lookup functions

### DIFF
--- a/prov/gni/include/gnix_av.h
+++ b/prov/gni/include/gnix_av.h
@@ -79,7 +79,7 @@ struct gnix_av_addr_entry {
  * @return  FI_SUCCESS on success, -FI_EINVAL on error
  */
 int _gnix_av_lookup(struct gnix_fid_av *gnix_av, fi_addr_t fi_addr,
-		    struct gnix_av_addr_entry **addr);
+		    struct gnix_av_addr_entry *addr);
 
 /**
  * @brief Return the FI address mapped to a given GNIX address.
@@ -104,14 +104,14 @@ int _gnix_av_reverse_lookup(struct gnix_fid_av *gnix_av,
  *
  * @param[in] int_av		The AV to use for the lookup.
  * @param[in] fi_addr		The corresponding fi_addr_t.
- * @param[in/out] entry_ptr	The pointer to an address in the entry table.
+ * @param[in/out] entry_ptr	pointer to an av entry struct
  *
  * @return FI_SUCCESS on successfully looking up the entry in the entry table.
  * @return -FI_EINVAL upon passing an invalid parameter.
  */
 int _gnix_table_lookup(struct gnix_fid_av *int_av,
 		       fi_addr_t fi_addr,
-		       struct gnix_av_addr_entry **entry_ptr);
+		       struct gnix_av_addr_entry *entry_ptr);
 
 /**
  * @brief (FI_AV_MAP) Return the gnix address using its corresponding
@@ -119,14 +119,14 @@ int _gnix_table_lookup(struct gnix_fid_av *int_av,
  *
  * @param[in] int_av		The AV to use for the lookup.
  * @param[in] fi_addr		The corresponding fi_addr_t.
- * @param[in/out] entry_ptr	The pointer to an address in the entry table.
+ * @param[in/out] entry_ptr	pointer to an av entry struct
  *
  * @return FI_SUCCESS on successfully looking up the entry in the entry table.
  * @return -FI_EINVAL upon passing an invalid parameter.
  */
 int _gnix_map_lookup(struct gnix_fid_av *int_av,
 		     fi_addr_t fi_addr,
-		     struct gnix_av_addr_entry **entry_ptr);
+		     struct gnix_av_addr_entry *entry_ptr);
 
 /**
  * @brief (FI_AV_TABLE) Return fi_addr using its corresponding gnix address.

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -211,7 +211,7 @@ static int table_remove(struct gnix_fid_av *av_priv, fi_addr_t *fi_addr,
  * table_lookup(): Translate fi_addr_t to struct gnix_address.
  */
 static int table_lookup(struct gnix_fid_av *av_priv, fi_addr_t fi_addr,
-			struct gnix_av_addr_entry **entry_ptr)
+			struct gnix_av_addr_entry *entry_ptr)
 {
 	size_t index;
 	struct gnix_av_addr_entry *entry = NULL;
@@ -229,7 +229,7 @@ static int table_lookup(struct gnix_fid_av *av_priv, fi_addr_t fi_addr,
 	if (av_priv->valid_entry_vec[index] == 0)
 		return -FI_EINVAL;
 
-	*entry_ptr = entry;
+	memcpy(entry_ptr, entry, sizeof(*entry));
 
 	return FI_SUCCESS;
 }
@@ -346,7 +346,7 @@ static int map_remove(struct gnix_fid_av *av_priv, fi_addr_t *fi_addr,
 }
 
 static int map_lookup(struct gnix_fid_av *av_priv, fi_addr_t fi_addr,
-		      struct gnix_av_addr_entry **entry_ptr)
+		      struct gnix_av_addr_entry *entry_ptr)
 {
 	gnix_ht_key_t *key = (gnix_ht_key_t *)&fi_addr;
 	struct gnix_av_addr_entry *entry;
@@ -355,7 +355,7 @@ static int map_lookup(struct gnix_fid_av *av_priv, fi_addr_t fi_addr,
 	if (entry == NULL)
 		return -FI_ENOENT;
 
-	*entry_ptr = entry;
+	memcpy(entry_ptr, entry, sizeof(*entry));
 
 	return FI_SUCCESS;
 }
@@ -383,7 +383,7 @@ static int map_reverse_lookup(struct gnix_fid_av *av_priv,
  ******************************************************************************/
 int _gnix_table_lookup(struct gnix_fid_av *av_priv,
 		       fi_addr_t fi_addr,
-		       struct gnix_av_addr_entry **entry_ptr)
+		       struct gnix_av_addr_entry *entry_ptr)
 {
 	return table_lookup(av_priv, fi_addr, entry_ptr);
 }
@@ -397,7 +397,7 @@ int _gnix_table_reverse_lookup(struct gnix_fid_av *av_priv,
 
 int _gnix_map_lookup(struct gnix_fid_av *av_priv,
 		     fi_addr_t fi_addr,
-		     struct gnix_av_addr_entry **entry_ptr)
+		     struct gnix_av_addr_entry *entry_ptr)
 {
 	return map_lookup(av_priv, fi_addr, entry_ptr);
 }
@@ -410,7 +410,7 @@ int _gnix_map_reverse_lookup(struct gnix_fid_av *av_priv,
 }
 
 int _gnix_av_lookup(struct gnix_fid_av *gnix_av, fi_addr_t fi_addr,
-		    struct gnix_av_addr_entry **entry_ptr)
+		    struct gnix_av_addr_entry *entry_ptr)
 {
 	int ret = FI_SUCCESS;
 
@@ -477,7 +477,7 @@ DIRECT_FN STATIC int gnix_av_lookup(struct fid_av *av, fi_addr_t fi_addr,
 {
 	struct gnix_fid_av *gnix_av;
 	struct gnix_ep_name ep_name = { {0} };
-	struct gnix_av_addr_entry *entry = NULL;
+	struct gnix_av_addr_entry entry;
 	int rc;
 
 	GNIX_TRACE(FI_LOG_AV, "\n");
@@ -506,11 +506,10 @@ DIRECT_FN STATIC int gnix_av_lookup(struct fid_av *av, fi_addr_t fi_addr,
 		return rc;
 	}
 
-	memcpy(&ep_name.gnix_addr, &entry->gnix_addr,
-	       sizeof(struct gnix_address));
-	ep_name.name_type = entry->name_type;
-	ep_name.cm_nic_cdm_id = entry->cm_nic_cdm_id;
-	ep_name.cookie = entry->cookie;
+	ep_name.gnix_addr = entry.gnix_addr;
+	ep_name.name_type = entry.name_type;
+	ep_name.cm_nic_cdm_id = entry.cm_nic_cdm_id;
+	ep_name.cookie = entry.cookie;
 
 	memcpy(addr, (void *)&ep_name, MIN(*addrlen, sizeof(ep_name)));
 	*addrlen = sizeof(ep_name);

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -2308,7 +2308,7 @@ static int __gnix_msg_addr_lookup(struct gnix_fid_ep *ep, uint64_t src_addr,
 {
 	int ret;
 	struct gnix_fid_av *av;
-	struct gnix_av_addr_entry *av_entry;
+	struct gnix_av_addr_entry av_entry;
 
 	/* Translate source address. */
 	if (GNIX_EP_RDM_DGM(ep->type)) {
@@ -2323,7 +2323,7 @@ static int __gnix_msg_addr_lookup(struct gnix_fid_ep *ep, uint64_t src_addr,
 					  ret);
 				return ret;
 			}
-			*gnix_addr = av_entry->gnix_addr;
+			*gnix_addr = av_entry.gnix_addr;
 		} else {
 			*(uint64_t *)gnix_addr = FI_ADDR_UNSPEC;
 		}

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -149,7 +149,7 @@ static int __gnix_vc_gnix_addr_equal(struct dlist_entry *item, const void *arg)
 static struct gnix_vc *__gnix_vc_lookup_unmapped(struct gnix_fid_ep *ep,
 						 fi_addr_t dest_addr)
 {
-	struct gnix_av_addr_entry *av_entry;
+	struct gnix_av_addr_entry av_entry;
 	struct dlist_entry *entry;
 	struct gnix_vc *vc;
 	int ret;
@@ -167,7 +167,7 @@ static struct gnix_vc *__gnix_vc_lookup_unmapped(struct gnix_fid_ep *ep,
 	 * mapped by dest_addr. */
 	entry = dlist_remove_first_match(&ep->unmapped_vcs,
 					 __gnix_vc_gnix_addr_equal,
-					 (void *)&av_entry->gnix_addr);
+					 (void *)&av_entry.gnix_addr);
 	if (entry) {
 		/* Found a matching, unmapped VC.  Map dest_addr to the VC in
 		 * the EP's VC look up table. */
@@ -205,7 +205,7 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 {
 	struct gnix_fid_av *av;
 	int ret = FI_SUCCESS;
-	struct gnix_av_addr_entry *av_entry;
+	struct gnix_av_addr_entry av_entry;
 	struct gnix_vc *vc;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
@@ -247,7 +247,7 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 		}
 
 		/* Initiate a connection to the endpoint. */
-		ret = _gnix_vc_alloc(ep, av_entry, &vc);
+		ret = _gnix_vc_alloc(ep, &av_entry, &vc);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_vc_alloc returned %s\n",

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -64,7 +64,7 @@ static struct fid_cq *cq;
 static struct fi_cq_attr cq_attr;
 void *ep_name[2];
 fi_addr_t gni_addr[2];
-struct gnix_av_addr_entry * gnix_addr[2];
+struct gnix_av_addr_entry gnix_addr[2];
 size_t gnix_addrlen[2];
 
 static void vc_setup_common(void);
@@ -227,10 +227,10 @@ Test(vc_management_auto, vc_alloc_simple)
 
 	ep_priv = container_of(ep[0], struct gnix_fid_ep, ep_fid);
 
-	ret = _gnix_vc_alloc(ep_priv, gnix_addr[0], &vc[0]);
+	ret = _gnix_vc_alloc(ep_priv, &gnix_addr[0], &vc[0]);
 	cr_assert_eq(ret, FI_SUCCESS);
 
-	ret = _gnix_vc_alloc(ep_priv, gnix_addr[1], &vc[1]);
+	ret = _gnix_vc_alloc(ep_priv, &gnix_addr[1], &vc[1]);
 	cr_assert_eq(ret, FI_SUCCESS);
 
 	/*
@@ -254,10 +254,10 @@ Test(vc_management_auto, vc_lookup_by_id)
 
 	ep_priv = container_of(ep[0], struct gnix_fid_ep, ep_fid);
 
-	ret = _gnix_vc_alloc(ep_priv, gnix_addr[0], &vc[0]);
+	ret = _gnix_vc_alloc(ep_priv, &gnix_addr[0], &vc[0]);
 	cr_assert_eq(ret, FI_SUCCESS);
 
-	ret = _gnix_vc_alloc(ep_priv, gnix_addr[1], &vc[1]);
+	ret = _gnix_vc_alloc(ep_priv, &gnix_addr[1], &vc[1]);
 	cr_assert_eq(ret, FI_SUCCESS);
 
 	vc_chk = __gnix_nic_elem_by_rem_id(ep_priv->nic, vc[0]->vc_id);
@@ -286,7 +286,7 @@ Test(vc_management_auto, vc_connect)
 
 	ep_priv[1] = container_of(ep[1], struct gnix_fid_ep, ep_fid);
 
-	ret = _gnix_vc_alloc(ep_priv[0], gnix_addr[1], &vc_conn);
+	ret = _gnix_vc_alloc(ep_priv[0], &gnix_addr[1], &vc_conn);
 	cr_assert_eq(ret, FI_SUCCESS);
 
 	memcpy(&key, &gni_addr[1],
@@ -328,7 +328,7 @@ Test(vc_management_auto, vc_connect2)
 	ep_priv[0] = container_of(ep[0], struct gnix_fid_ep, ep_fid);
 	ep_priv[1] = container_of(ep[1], struct gnix_fid_ep, ep_fid);
 
-	ret = _gnix_vc_alloc(ep_priv[0], gnix_addr[1], &vc_conn0);
+	ret = _gnix_vc_alloc(ep_priv[0], &gnix_addr[1], &vc_conn0);
 	cr_assert_eq(ret, FI_SUCCESS);
 
 	memcpy(&key, &gni_addr[1],
@@ -339,7 +339,7 @@ Test(vc_management_auto, vc_connect2)
 
 	vc_conn0->modes |= GNIX_VC_MODE_IN_HT;
 
-	ret = _gnix_vc_alloc(ep_priv[1], gnix_addr[0], &vc_conn1);
+	ret = _gnix_vc_alloc(ep_priv[1], &gnix_addr[0], &vc_conn1);
 	cr_assert_eq(ret, FI_SUCCESS);
 
 	memcpy(&key, &gni_addr[0],


### PR DESCRIPTION
In order to handle the more general AV entries required
for SEP, change some of the internal av lookup methods
to return the content of an AV entry rather than just a pointer
to the entry in the hash or vector.

Upstream merge of ofi-cray/libfabric-cray#948

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@6f9603ee7dd1d2e2ec4e9053252aedf3a4682b9b)

@chuckfossen 