### PR TITLE
man: clarifications on injection thresholds

### DIFF
--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -394,7 +394,8 @@ available for reuse immediately on returning from from
 fi_inject_atomic, and no completion event will be generated for this
 atomic.  The completion event will be suppressed even if the endpoint
 has not been configured with FI_SELECTIVE_COMPLETION.  See the flags
-discussion below for more details.
+discussion below for more details. The requested message size that
+can be used with fi_inject_atomic is limited by inject_size.
 
 The fi_atomicmsg call supports atomic functions over both connected
 and unconnected endpoints, with the ability to control the atomic
@@ -515,7 +516,8 @@ with atomic message calls.
   returns, even if the operation is handled asynchronously.  This may
   require that the underlying provider implementation copy the data
   into a local buffer and transfer out of that buffer.  The use of
-  output result buffers are not affected by this flag.
+  output result buffers are not affected by this flag. This flag can only
+  be used with messages smaller than inject_size.
 
 *FI_FENCE*
 : Indicates that the requested operation, also

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -1122,8 +1122,10 @@ value of transmit or receive context attributes of an endpoint.
   user's control immediately after a data transfer call returns, even
   if the operation is handled asynchronously.  This may require that
   the provider copy the data into a local buffer and transfer out of
-  that buffer.  A provider may limit the total amount of send data
-  that may be buffered and/or the size of a single send.
+  that buffer.  A provider can limit the total amount of send data
+  that may be buffered and/or the size of a single send that can use
+  this flag. This limit is indicated using inject_size (see inject_size
+  above).
 
 *FI_MULTI_RECV*
 : Applies to posted receive operations.  This flag allows the user to
@@ -1151,7 +1153,8 @@ value of transmit or receive context attributes of an endpoint.
 
   Note: This flag is used to control when a completion entry is inserted
   into a completion queue.  It does not apply to operations that do not
-  generate a completion queue entry, such as the fi_inject operation.
+  generate a completion queue entry, such as the fi_inject operation, and
+  is not subject to the inject_size message limit restriction.
 
 *FI_TRANSMIT_COMPLETE*
 : Indicates that a completion should be generated when the transmit

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -159,7 +159,9 @@ available for reuse immediately on returning from from fi_inject, and
 no completion event will be generated for this send.  The completion
 event will be suppressed even if the CQ was bound without
 FI_SELECTIVE_COMPLETION or the endpoint's op_flags contain
-FI_COMPLETION.  See the flags discussion below for more details.
+FI_COMPLETION.  See the flags discussion below for more details. The
+requested message size that can be used with fi_inject is limited
+by inject_size.
 
 ## fi_senddata
 
@@ -229,7 +231,8 @@ fi_sendmsg.
   should be returned to user immediately after the send call returns,
   even if the operation is handled asynchronously.  This may require
   that the underlying provider implementation copy the data into a
-  local buffer and transfer out of that buffer.
+  local buffer and transfer out of that buffer. This flag can only
+  be used with messages smaller than inject_size.
 
 *FI_MULTI_RECV*
 : Applies to posted receive operations.  This flag allows the user to

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -183,7 +183,8 @@ available for reuse immediately on returning from from
 fi_inject_write, and no completion event will be generated for this
 write.  The completion event will be suppressed even if the endpoint
 has not been configured with FI_SELECTIVE_COMPLETION.  See the flags
-discussion below for more details.
+discussion below for more details. The requested message size that
+can be used with fi_inject_write is limited by inject_size.
 
 ## fi_writedata
 
@@ -249,7 +250,8 @@ fi_writemsg.
    should be returned to user immediately after the write call
    returns, even if the operation is handled asynchronously.  This may
    require that the underlying provider implementation copy the data
-   into a local buffer and transfer out of that buffer.
+   into a local buffer and transfer out of that buffer. This flag can only
+   be used with messages smaller than inject_size.
 
 *FI_INJECT_COMPLETE*
 : Applies to fi_writemsg.  Indicates that a completion should be

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -182,7 +182,8 @@ available for reuse immediately on returning from from fi_tinject, and
 no completion event will be generated for this send.  The completion
 event will be suppressed even if the endpoint has not been configured
 with FI_SELECTIVE_COMPLETION.  See the flags discussion below for more
-details.
+details. The requested message size that can be used with fi_tinject is
+limited by inject_size.
 
 ## fi_tsenddata
 
@@ -249,7 +250,8 @@ and/or fi_tsendmsg.
   should be returned to user immediately after the send call returns,
   even if the operation is handled asynchronously.  This may require
   that the underlying provider implementation copy the data into a
-  local buffer and transfer out of that buffer.
+  local buffer and transfer out of that buffer. This flag can only
+  be used with messages smaller than inject_size.
 
 *FI_INJECT_COMPLETE*
 : Applies to fi_tsendmsg.  Indicates that a completion should be


### PR DESCRIPTION
Inject is an term that means different things, so further clarifications help understand the subtleties and how apps can use the calls.

tx_attr::inject_size indicates the threshold below which an app can use fi_inject() or call with FI_INJECT op flag. The reasoning for this limit is that fi_inject() and FI_INJECT imply buffer reuse on call return, therefore can imply a memory copy.

FI_INJECT_COMPLETE on the other hand is a completion level that applies to asynchronous completions indicating that the buffer may be reused (no other guarantees are made).

===

- clarify that inject_size threshold applies to
  all the inject calls and FI_INJECT flags

- clarify that inject_size threshold does NOT
  apply to the usage of FI_INJECT_COMPLETE completion
  level

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>