### PR TITLE
prov/psm2: Avoid a long PSM2 delay when the device is absent

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -50,6 +50,7 @@ extern "C" {
 #include <fcntl.h>
 #include <pthread.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/socket.h>
 #include <netdb.h>
 #include <complex.h>

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -76,12 +76,18 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	uint64_t caps = PSMX2_CAPS;
 	uint64_t max_tag_value = -1ULL;
 	int err = -FI_ENODATA;
+	struct stat st;
 
 	FI_INFO(&psmx2_prov, FI_LOG_CORE,"\n");
 
 	*info = NULL;
 
-	if (psm2_ep_num_devunits(&cnt) || !cnt) {
+	/*
+	 * psm2_ep_num_devunits() may wait for 15 seconds before return
+	 * when /dev/hfi1_0 is not present. Check the existence of this
+	 * device first to avoid this delay.
+	 */
+	if (stat("/dev/hfi1_0", &st) || psm2_ep_num_devunits(&cnt) || !cnt) {
 		FI_INFO(&psmx2_prov, FI_LOG_CORE,
 			"no PSM device is found.\n");
 		return -FI_ENODATA;


### PR DESCRIPTION
The PSM2 function that is used to check the number of available device
units for PSM2 may wait up to 15 seconds for the device to come up.
This introduces unnecessary delay for setups that have the PSM2 library
installed w/o the actual hardware. This patch provides a workaround.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>