### PR TITLE
prov/udp: Further reduction to default EP, CQ counts

### DIFF
--- a/prov/udp/src/udpx_attr.c
+++ b/prov/udp/src/udpx_attr.c
@@ -66,10 +66,10 @@ struct fi_domain_attr udpx_domain_attr = {
 	.resource_mgmt = FI_RM_ENABLED,
 	.av_type = FI_AV_UNSPEC,
 	.mr_mode = FI_MR_SCALABLE,
-	.cq_cnt = 1024,
-	.ep_cnt = 1024,
-	.tx_ctx_cnt = 1024,
-	.rx_ctx_cnt = 1024,
+	.cq_cnt = 256,
+	.ep_cnt = 256,
+	.tx_ctx_cnt = 256,
+	.rx_ctx_cnt = 256,
 	.max_ep_tx_ctx = 1,
 	.max_ep_rx_ctx = 1
 };


### PR DESCRIPTION
The CQ allocates up to 3 fd's per CQ.  With many Linux systems using
a default of 1024 opened fd's, we need to reduce the default cq_cnt
from 1024 to around 300.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>