### PR TITLE
prov/psm: Remove an extra right brace

### DIFF
--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -596,7 +596,6 @@ static ssize_t psmx_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 
 	return read_count;
 }
-}
 
 static ssize_t psmx_cq_read(struct fid_cq *cq, void *buf, size_t count)
 {


### PR DESCRIPTION
This was an error in a previous commit that was caught during
compilation but left out accidentally when commiting the changes.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>