### PR TITLE
prov/sockets: Cleanup conn map during fi_av_remove

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -325,6 +325,8 @@ struct sock_av {
 	uint64_t *idx_arr;
 	struct util_shm shm;
 	int    shared;
+	struct dlist_entry ep_list;
+	fastlock_t list_lock;
 };
 
 struct sock_fid_list {
@@ -1084,6 +1086,7 @@ struct sock_conn *sock_ep_lookup_conn(struct sock_ep_attr *attr, fi_addr_t index
                                       struct sockaddr_in *addr);
 int sock_ep_get_conn(struct sock_ep_attr *ep_attr, struct sock_tx_ctx *tx_ctx,
 		     fi_addr_t index, struct sock_conn **pconn);
+void sock_ep_remove_conn(struct sock_ep_attr *ep_attr, struct sock_conn *conn);
 struct sock_conn *sock_ep_connect(struct sock_ep_attr *attr, fi_addr_t index);
 ssize_t sock_conn_send_src_addr(struct sock_ep_attr *ep_attr, struct sock_tx_ctx *tx_ctx,
 				struct sock_conn *conn);

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2152,9 +2152,7 @@ static int sock_pe_progress_rx_pe_entry(struct sock_pe *pe,
 		SOCK_LOG_DBG("conn disconnected: removing fd from pollset\n");
 		if (pe_entry->conn->sock_fd != -1) {
 			fastlock_acquire(&pe_entry->ep_attr->cmap.lock);
-			sock_pe_poll_del(pe, pe_entry->conn->sock_fd);
-			idm_clear(&pe_entry->ep_attr->conn_idm, pe_entry->conn->sock_fd);
-			sock_conn_release_entry(&pe_entry->ep_attr->cmap, pe_entry->conn);
+			sock_ep_remove_conn(pe_entry->ep_attr, pe_entry->conn);
 			fastlock_release(&pe_entry->ep_attr->cmap.lock);
 		}
 


### PR DESCRIPTION
- Added a list of EP in ```sock_av```
- Added code to insert/remove EP in ```fi_ep_bind/fi_ep_close```
- Closed fd and cleaned up connection map for all the EPs bound to the AV when ```fi_av_remove``` is called
- Added minor refactoring

Fixes #2291

@jithinjosepkl  @a-ilango 
 
Signed-off-by: Shantonu Hossain <shantonu.hossain@intel.com>