### PR TITLE
log: add a debug trace macro

### DIFF
--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -90,8 +90,12 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 #if ENABLE_DEBUG
 #define FI_DBG(prov, subsystem, ...)					\
 	FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
+#define FI_DBG_TRACE(prov, subsystem, ...)				\
+	FI_LOG(prov, FI_LOG_TRACE, subsystem, __VA_ARGS__)
 #else
 #define FI_DBG(prov_name, subsystem, ...)				\
+	do {} while (0)
+#define FI_DBG_TRACE(prov, subsystem, ...)				\
 	do {} while (0)
 #endif
 


### PR DESCRIPTION
This allows for tracing to be turned off in optimized builds,
and also to runtime turn on/off of tracing in debug builds.

Fixes #2372.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>