### PR TITLE
fi_proto: Rename peer_id to remote_idx and document it

### DIFF
--- a/include/fi_proto.h
+++ b/include/fi_proto.h
@@ -136,6 +136,7 @@ enum {
  * tag: Message tag, used for tagged operations only
  * iov_count: Count of destination iov, used for RMA operations
  * atomic: Control fields for atomic operations
+ * remote_idx: Tx request identifier of remote side
  * resv: Reserved, used for msg operations
  */
 struct ofi_op_hdr {
@@ -155,7 +156,7 @@ struct ofi_op_hdr {
 			uint8_t	op;
 			uint8_t ioc_count;
 		} atomic;
-		uint64_t	peer_id;
+		uint64_t	remote_idx;
 		uint64_t	resv;
 	};
 };

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -1037,9 +1037,9 @@ int rxd_process_start_data(struct rxd_ep *ep, struct rxd_rx_entry *rx_entry,
 		break;
 
 	case ofi_op_read_rsp:
-		idx = rx_entry->op_hdr.peer_id & RXD_TX_IDX_BITS;
+		idx = rx_entry->op_hdr.remote_idx & RXD_TX_IDX_BITS;
 		tx_entry = &ep->tx_entry_fs->buf[idx];
-		if (tx_entry->msg_id != rx_entry->op_hdr.peer_id)
+		if (tx_entry->msg_id != rx_entry->op_hdr.remote_idx)
 			return -FI_ENOMEM;
 
 		rx_entry->read_rsp.tx_entry = tx_entry;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -774,7 +774,7 @@ void rxd_ep_init_start_hdr(struct rxd_ep *ep, struct rxd_peer *peer,
 		*data_sz = MIN(RXD_MAX_STRT_DATA_PKT_SZ(ep), *msg_sz);
 
 		rxd_init_op_hdr(&pkt->op, 0, *msg_sz, 0, op, 0, flags);
-		pkt->op.peer_id = tx_entry->read_rsp.peer_msg_id;
+		pkt->op.remote_idx = tx_entry->read_rsp.peer_msg_id;
 
 		tx_entry->done = rxd_ep_copy_iov_buf(tx_entry->read_rsp.src_iov,
 						     tx_entry->read_rsp.iov_count,


### PR DESCRIPTION
Rename peer_id in op_hdr to remote_idx and document it
