### PR TITLE
prov/util: Disable utility providers

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -396,12 +396,16 @@ libdl_done:
 	fi_register_provider(MXM_INIT, NULL);
 	fi_register_provider(VERBS_INIT, NULL);
 	fi_register_provider(GNI_INIT, NULL);
+	/* fi_register_provider(RXM_INIT, NULL); */
+	/* fi_register_provider(RXD_INIT, NULL); */
+
         /* Initialize the socket(s) provider last.  This will result in
            it being the least preferred provider. */
 	fi_register_provider(UDP_INIT, NULL);
 	fi_register_provider(SOCKETS_INIT, NULL);
-	fi_register_provider(RXM_INIT, NULL);
-	fi_register_provider(RXD_INIT, NULL);
+	/* Before you add ANYTHING here, read the comment above!!! */
+
+	/* Seriously, read it! */
 
 	init = 1;
 


### PR DESCRIPTION
Don't register the utility providers with the framework until they
are really ready for use by applications.

This is in preparation for the 1.4 release.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

Fixes #2373