### PR TITLE
prov/gni: don't abort on non-recoverable CQE

### DIFF
--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -196,15 +196,14 @@ static int __gnix_rma_post_err_no_retrans(struct gnix_fab_req *req, int error)
 
 static int __gnix_rma_post_err(struct gnix_fab_req *req, int error)
 {
-	req->tx_failures++;
 	if (GNIX_EP_RDM(req->gnix_ep->type) &&
-	    req->tx_failures < req->gnix_ep->domain->params.max_retransmits) {
+		GNIX_REQ_REPLAYABLE(req)) {
 		GNIX_INFO(FI_LOG_EP_DATA,
 			  "Requeueing failed request: %p\n", req);
 		return _gnix_vc_queue_work_req(req);
 	}
 
-	GNIX_INFO(FI_LOG_EP_DATA, "Failed %d transmits: %p error: %d\n",
+	GNIX_WARN(FI_LOG_EP_DATA, "Failed %u transmits: %p error: %d\n",
 		  req->tx_failures, req, error);
 
 	__gnix_rma_post_err_no_retrans(req, error);


### PR DESCRIPTION
Don't abort when a GNI transaction is non-recoverable,
let app figure out how to do that.  Turn off retry
by setting retry count(tx_failures) to UINT_MAX.

introduce a new macro to simplify replay
encapsulate logic for deciding whether a request
can be replayed based on tx_failures field

Fixes ofi-cray/libfabric-cray#891

Upstream merge of ofi-cray/libfabric-cray#953

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@a523924508b171fbded756eae51047ed376996d6)

@chuckfossen 