### PR TITLE
prov/sockets: Add error checking in cm-reject

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -886,6 +886,7 @@ struct sock_conn_req_handle {
 	struct fid handle;
 	struct sock_conn_req *req;
 	int sock_fd;
+	int is_connected;
 	struct sock_pep *pep;
 	struct sock_ep *ep;
 	size_t paramlen;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -654,6 +654,7 @@ static void *sock_cm_accept_handler(void *data)
 	ep_attr->cm.is_connected = 1;
 	ep_attr->cm.do_listen = 1;
 	ep_attr->cm.sock = hreq->sock_fd;
+	hreq->is_connected = 1;
 	sock_ep_wait_shutdown(hreq->ep);
 
 	if (pthread_join(hreq->req_handler, NULL))
@@ -1079,7 +1080,7 @@ static int sock_pep_reject(struct fid_pep *pep, fid_t handle,
 	_pep = container_of(pep, struct sock_pep, pep);
 	hreq = container_of(handle, struct sock_conn_req_handle, handle);
 	req = hreq->req;
-	if (!req || hreq->handle.fclass != FI_CLASS_CONNREQ)
+	if (!req || hreq->handle.fclass != FI_CLASS_CONNREQ || hreq->is_connected)
 		return -FI_EINVAL;
 
 	hreq->paramlen = 0;


### PR DESCRIPTION
Add error checking in cm-reject call to check if the endpoint is already
connected.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>