### PR TITLE
added processing of raw memory key

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -247,6 +247,7 @@ enum {
 #define FI_ASYNC_IOV		(1ULL << 57)
 #define FI_RX_CQ_DATA		(1ULL << 56)
 #define FI_LOCAL_MR		(1ULL << 55)
+#define FI_RAW_MR		(1ULL << 54)
 
 struct fi_tx_attr {
 	uint64_t		caps;
@@ -418,6 +419,17 @@ struct fi_alias {
 	uint64_t		flags;
 };
 
+struct fi_mr_raw_key {
+	uint8_t		*raw;
+	size_t		*size;
+};
+
+struct fi_mr_map_raw_key {
+	uint8_t		*raw;
+	size_t		size;
+	uint64_t	*key;
+};
+
 /* control commands */
 enum {
 	FI_GETFIDFLAG,		/* uint64_t flags */
@@ -428,6 +440,7 @@ enum {
 	FI_GETWAIT,		/* void * wait object */
 	FI_ENABLE,		/* NULL */
 	FI_BACKLOG,		/* integer * */
+	FI_RAW_KEY		/* fi_mr_raw_key or fi_mr_map_raw_key */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -237,6 +237,22 @@ static inline uint64_t fi_mr_key(struct fid_mr *mr)
 	return mr->key;
 }
 
+static inline int
+fi_mr_raw_key(struct fid_mr *mr, uint8_t *raw, size_t *size)
+{
+	struct fi_mr_raw_key lakey = {.size = size, .raw = raw};
+	return mr->fid.ops->control(&mr->fid, FI_RAW_KEY, &lakey);
+}
+
+static inline int
+fi_mr_map_key(struct fid_domain *domain,
+	      uint8_t *raw, size_t size, uint64_t* key)
+{
+	struct fi_mr_map_raw_key lakey =
+		{.raw = raw, .size = size, .key = key};
+	return domain->fid.ops->control(&domain->fid, FI_RAW_KEY, &lakey);
+}
+
 static inline int fi_mr_bind(struct fid_mr *mr, struct fid *bfid, uint64_t flags)
 {
 	return mr->fid.ops->bind(&mr->fid, bfid, flags);


### PR DESCRIPTION
added pair of calls: fi_mr_raw_key & fi_mr_map_key to
operate by large memory keys. calls are declared as
static inline - should not break ABI.

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>