### PR TITLE
prov/psm,psm2: Fix incorrect max_ep_tx_ctx value in domain attribute

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -477,7 +477,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	psmx_info->domain_attr->ep_cnt = 65535;
 	psmx_info->domain_attr->tx_ctx_cnt = 1;
 	psmx_info->domain_attr->rx_ctx_cnt = 1;
-	psmx_info->domain_attr->max_ep_tx_ctx = 65535;
+	psmx_info->domain_attr->max_ep_tx_ctx = 1;
 	psmx_info->domain_attr->max_ep_rx_ctx = 1;
 	psmx_info->domain_attr->max_ep_stx_ctx = 65535;
 	psmx_info->domain_attr->max_ep_srx_ctx = 0;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -421,7 +421,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->domain_attr->ep_cnt = 65535;
 	psmx2_info->domain_attr->tx_ctx_cnt = 1;
 	psmx2_info->domain_attr->rx_ctx_cnt = 1;
-	psmx2_info->domain_attr->max_ep_tx_ctx = 65535;
+	psmx2_info->domain_attr->max_ep_tx_ctx = 1;
 	psmx2_info->domain_attr->max_ep_rx_ctx = 1;
 	psmx2_info->domain_attr->max_ep_stx_ctx = 65535;
 	psmx2_info->domain_attr->max_ep_srx_ctx = 0;


### PR DESCRIPTION
The providers don't support scalable endpoints and this field should
be set to 1.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>