### PR TITLE
Pr/rxd: Minor updates

### DIFF
--- a/man/fi_rxd.7.md
+++ b/man/fi_rxd.7.md
@@ -16,15 +16,15 @@ emulated over a base DGRAM provider.
 
 # SUPPORTED FEATURES
 
-The RxD provider currently supports *FI_MSG* and *FI_TAGGED*
+The RxD provider currently supports *FI_MSG*, *FI_TAGGED* and *FI_RMA*
 capabilities. It requires the base DGRAM provider to support *FI_MSG*
 capabilities.
 
 *Endpoint types*
 : The provider supports only endpoint type *FI_EP_RDM*.
 
-*Endpoint capabilities*
-: The following data transfer interface is supported: *fi_msg*, *fi_tagged*.
+*Endpoint capabilities* : The following data transfer interface is
+supported: *fi_msg*, *fi_tagged* and *fi_rma*.
 
 *Modes*
 : The provider does not require the use of any mode bits.
@@ -43,6 +43,9 @@ base DGRAM provider.
 No support for multi-recv.
 
 No support for counters.
+
+The RxD provider is still under development and is not extensively
+tested.
 
 # RUNTIME PARAMETERS
 

--- a/prov/rxd/Makefile.include
+++ b/prov/rxd/Makefile.include
@@ -21,8 +21,8 @@ src_libfabric_la_SOURCES += $(_rxd_files)
 src_libfabric_la_LIBADD += $(rxd_shm_LIBS)
 endif !HAVE_RXD_DL
 
-prov_install_man_pages += man/man7/fi_rxd.7
+#prov_install_man_pages += man/man7/fi_rxd.7
 
 endif HAVE_RXD
 
-prov_dist_man_pages += man/man7/fi_rxd.7
+#prov_dist_man_pages += man/man7/fi_rxd.7

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -301,6 +301,9 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	util_attr.overhead = attr->count;
 	util_attr.flags = FI_SOURCE;
 	av->size = attr->count ? attr->count : RXD_AV_DEF_COUNT;
+	if (attr->type == FI_AV_UNSPEC)
+		attr->type = FI_AV_TABLE;
+
 	ret = ofi_av_init(&domain->util_domain, attr, &util_attr,
 			 &av->util_av, context);
 	if (ret)


### PR DESCRIPTION
- Set default AV type as AV table
- Disable man page installation
- Update rxd man page about capabilities