### PR TITLE
man/ep: Clarify when unconnected EPs must be bound to an AV

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -79,6 +79,10 @@ v1.4.0, TBD
   and cleanup conn map during fi_av_remove
 - Use correct fi_tx_attr/fi_rx_attr for scalable ep
 
+## MXM provider
+
+- The mxm provider has been deprecated and will be replaced in a future release.
+
 v1.3.0, Mon Apr 11, 2016
 ========================
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -184,7 +184,8 @@ In order to transition an endpoint into an enabled state, it must be
 bound to one or more fabric resources.  An endpoint that will generate
 asynchronous completions, either through data transfer operations or
 communication establishment events, must be bound to the appropriate
-completion queues or event queues before being enabled.
+completion queues or event queues, respectively, before being enabled.
+Unconnected endpoints must be bound to an address vector.
 
 Once an endpoint has been activated, it may be associated with an address
 vector.  Receive buffers may be posted to it and
@@ -379,7 +380,9 @@ contexts created using the scalable endpoint.
 This call transitions the endpoint into an enabled state.  An endpoint
 must be enabled before it may be used to perform data transfers.
 Enabling an endpoint typically results in hardware resources being
-assigned to it.
+assigned to it.  Endpoints making use of completion queues, counters,
+event queues, and/or address vectors must be bound to them before being
+enabled.
 
 Calling connect or accept on an endpoint will implicitly enable an
 endpoint if it has not already been enabled.

--- a/man/fi_mxm.7.md
+++ b/man/fi_mxm.7.md
@@ -11,6 +11,9 @@ The MXM Fabric Provider
 
 # OVERVIEW
 
+The mxm provider is deprecated and will be replaced in a future release
+of libfabric.
+
 The *mxm* provider runs over the MXM (Mellanox messaging) interface
 that is currently supported by the Mellanox infiniband fabrics.
 The *mxm* provider makes use of MXM tag matching API in order to


### PR DESCRIPTION
EPs must be bound before becoming active.  Fixes #2398

Signed-off-by: Sean Hefty <sean.hefty@intel.com>