### PR TITLE
prov/verbs: ep rdm bugfixes and improvements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,7 +40,8 @@ v1.4.0, TBD
   - Add fi_cntr support
   - Add environment variables for the provider tuning: FI_VERBS_RDM_BUFFER_NUM,
     FI_VERBS_RDM_BUFFER_SIZE, FI_VERBS_RDM_RNDV_SEG_SIZE,
-    FI_VERBS_RDM_CQREAD_BUNCH_SIZE, FI_VERBS_RDM_THREAD_TIMEOUT
+    FI_VERBS_RDM_CQREAD_BUNCH_SIZE, FI_VERBS_RDM_THREAD_TIMEOUT,
+    FI_VERBS_RDM_EAGER_SEND_OPCODE
   - Add iWarp support
 
 ## Sockets provider notes

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -527,8 +527,15 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 		goto err;
 	}
 
-	_ep->buff_len = _ep->rndv_threshold =
-		rdm_buffer_size(info->tx_attr->inject_size);
+	FI_INFO(&fi_ibv_prov, FI_LOG_EP_CTRL, "inject_size: %d\n",
+		info->tx_attr->inject_size);
+
+	_ep->rndv_threshold = info->tx_attr->inject_size;
+	FI_INFO(&fi_ibv_prov, FI_LOG_EP_CTRL, "rndv_threshold: %d\n",
+		_ep->rndv_threshold);
+
+	_ep->buff_len = rdm_buffer_size(info->tx_attr->inject_size);
+	FI_INFO(&fi_ibv_prov, FI_LOG_EP_CTRL, "buff_len: %d\n", _ep->buff_len);
 
 	_ep->rndv_seg_size = FI_IBV_RDM_SEG_MAXSIZE;
 	if (!fi_param_get_int(&fi_ibv_prov, "rdm_rndv_seg_size", &param)) {

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -563,19 +563,15 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 
 	switch (info->ep_attr->protocol) {
 	case FI_PROTO_IB_RDM:
-		_ep->topcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+		/* _ep->topcode = IBV_WR_RDMA_WRITE_WITH_IMM; */
+		_ep->topcode = IBV_WR_SEND;
 		_ep->rq_wr_depth = info->rx_attr->size;
 		_ep->sq_wr_depth = _ep->n_buffs + 1;
 		break;
 	case FI_PROTO_IWARP_RDM:
 		_ep->topcode = IBV_WR_SEND;
 		_ep->rq_wr_depth = info->rx_attr->size;
-		/*
-		 * TODO: More then 1 outgoing send causes hang of bidirectional
-		 * RNDV tests on iWarp devices +1 for eager buffers releasing.
-		 * Ideally it should be the same as for FI_PROTO_IB_RDM case
-		 */
-		_ep->sq_wr_depth = 2;
+		_ep->sq_wr_depth = _ep->n_buffs + 1;
 		break;
 	default:
 		FI_INFO(&fi_ibv_prov, FI_LOG_CORE,

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -491,6 +491,7 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 		container_of(domain, struct fi_ibv_domain, domain_fid);
 	int ret = 0;
 	int param = 0;
+	char *str_param = NULL;
 
 	if (!info || !info->ep_attr || !info->domain_attr ||
 	    strncmp(_domain->verbs->device->name, info->domain_attr->name,
@@ -561,21 +562,46 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 		}
 	}
 
+	_ep->rq_wr_depth = info->rx_attr->size;
+	/* one more outstanding slot for releasing eager buffers */
+	_ep->sq_wr_depth = _ep->n_buffs + 1;
+	if (!fi_param_get_str(&fi_ibv_prov, "rdm_eager_send_opcode", &str_param)) {
+		if (!strncmp(str_param, "IBV_WR_RDMA_WRITE_WITH_IMM",
+			     strlen("IBV_WR_RDMA_WRITE_WITH_IMM"))) {
+			_ep->eopcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+		} else if (!strncmp(str_param, "IBV_WR_SEND",
+				    strlen("IBV_WR_SEND"))) {
+			_ep->eopcode = IBV_WR_SEND;
+		} else {
+			FI_INFO(&fi_ibv_prov, FI_LOG_CORE,
+				"invalid value of rdm_eager_send_opcode\n");
+			ret = -FI_EINVAL;
+			goto err;
+		}
+	} else {
+		_ep->eopcode = IBV_WR_SEND;
+	}
+
 	switch (info->ep_attr->protocol) {
 	case FI_PROTO_IB_RDM:
-		/* _ep->topcode = IBV_WR_RDMA_WRITE_WITH_IMM; */
-		_ep->topcode = IBV_WR_SEND;
-		_ep->rq_wr_depth = info->rx_attr->size;
-		_ep->sq_wr_depth = _ep->n_buffs + 1;
+		if (_ep->eopcode != IBV_WR_RDMA_WRITE_WITH_IMM &&
+		    _ep->eopcode != IBV_WR_SEND) {
+			FI_INFO(&fi_ibv_prov, FI_LOG_CORE,
+			"Unsupported eager operation code\n");
+			ret = -FI_ENODATA;
+			goto err;
+		}
 		break;
 	case FI_PROTO_IWARP_RDM:
-		_ep->topcode = IBV_WR_SEND;
-		_ep->rq_wr_depth = info->rx_attr->size;
-		_ep->sq_wr_depth = _ep->n_buffs + 1;
+		if (_ep->eopcode != IBV_WR_SEND) {
+			FI_INFO(&fi_ibv_prov, FI_LOG_CORE,
+			"Unsupported eager operation code\n");
+			ret = -FI_ENODATA;
+			goto err;
+		}
 		break;
 	default:
-		FI_INFO(&fi_ibv_prov, FI_LOG_CORE,
-			"Unsupported protocol\n");
+		FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "Unsupported protocol\n");
 		ret = -FI_ENODATA;
 		goto err;
 	}

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -257,10 +257,10 @@ struct fi_ibv_rdm_ep {
 	int rx_selective_completion;
 
 	/*
-	 * ibv_post_send opcode for tagged messaging.
+	 * ibv_post_send opcode for eager messaging.
 	 * It must generate work completion in receive CQ
 	 */
-	enum ibv_wr_opcode topcode;
+	enum ibv_wr_opcode eopcode;
 	int buff_len;
 	int n_buffs;
 	int rq_wr_depth;    // RQ depth

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -84,10 +84,10 @@ fi_ibv_rdm_batch_repost_receives(struct fi_ibv_rdm_conn *conn,
 	/* IBV_WR_SEND opcode specific */
 	assert((num_to_post % ep->n_buffs) == 0);
 
-	assert(ep->topcode == IBV_WR_SEND ||
-	       ep->topcode == IBV_WR_RDMA_WRITE_WITH_IMM);
+	assert(ep->eopcode == IBV_WR_SEND ||
+	       ep->eopcode == IBV_WR_RDMA_WRITE_WITH_IMM);
 
-	if (ep->topcode == IBV_WR_SEND) {
+	if (ep->eopcode == IBV_WR_SEND) {
 		for (i = 0; i < num_to_post; i++) {
 			sge[i].addr = (uint64_t)(void *)
 			fi_ibv_rdm_get_rbuf(conn, ep, i % ep->n_buffs);

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -248,7 +248,7 @@ static ssize_t fi_ibv_rdm_inject(struct fid_ep *ep_fid, const void *buf,
 			wr.send_flags = (sge.length < ep->max_inline_rc)
 				? IBV_SEND_INLINE : 0;
 			wr.imm_data = 0;
-			wr.opcode = ep->topcode;
+			wr.opcode = ep->eopcode;
 
 			sbuf->service_data.pkt_len = size;
 			sbuf->header.tag = 0;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -581,8 +581,18 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 
 	check_and_repost_receives(ep, conn);
 
-	if (rbuf->service_data.status == BUF_STATUS_RECVED &&
-	    fi_ibv_rdm_buffer_check_seq_num(rbuf, conn->recv_processed))
+	if ((rbuf->service_data.status == BUF_STATUS_RECVED) &&
+	    /* NOTE: the ibverbs bug?
+	     * In case of out of order arriving we may check seq_num only if
+	     * send was posted with IBV_WR_RDMA_WRITE_WITH_IMM opcode because
+	     * the sender controls this.
+	     * Otherwise, the sender with IBV_WR_SEND opcode consumes pre-posted
+	     * buffers in the same order as they were pre-posted by recv.
+	     * So, we should handle it as is. Potentially, this way may cause
+	     * broken ordering of completions in fi_cq.
+	     */
+	    (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM ?
+	    fi_ibv_rdm_buffer_check_seq_num(rbuf, conn->recv_processed) : 1))
 	{
 		do {
 			assert(rbuf->service_data.pkt_len > 0);

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -249,7 +249,7 @@ fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len,
 			wr.send_flags = (sge.length < ep->max_inline_rc)
 				? IBV_SEND_INLINE : 0;
 			wr.imm_data = 0;
-			wr.opcode = ep->topcode;
+			wr.opcode = ep->eopcode;
 
 			sbuf->service_data.pkt_len = size;
 			sbuf->header.tag = tag;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -163,7 +163,7 @@ fi_ibv_rdm_eager_send_ready(struct fi_ibv_rdm_request *request, void *data)
 	sge.lkey = conn->s_mr->lkey;
 
 	wr.imm_data = 0;
-	wr.opcode = p->ep->topcode;
+	wr.opcode = p->ep->eopcode;
 	struct fi_ibv_rdm_buf *sbuf = (struct fi_ibv_rdm_buf *)request->sbuf;
 	uint8_t *payload = &sbuf->payload;
 
@@ -278,7 +278,7 @@ fi_ibv_rdm_rndv_rts_send_ready(struct fi_ibv_rdm_request *request, void *data)
 		fi_ibv_rdm_get_remote_addr(conn, request->sbuf);
 	wr.wr.rdma.rkey = conn->remote_rbuf_rkey;
 	wr.send_flags = 0;
-	wr.opcode = p->ep->topcode;
+	wr.opcode = p->ep->eopcode;
 	wr.imm_data = 0;
 
 	sge.addr = (uintptr_t)request->sbuf;
@@ -1021,7 +1021,7 @@ fi_ibv_rdm_rndv_recv_read_lc(struct fi_ibv_rdm_request *request, void *data)
 	wr.wr_id = ((uint64_t) (uintptr_t) (void *) request);
 	assert(FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wr.wr_id) == 0);
 
-	wr.opcode = p->ep->topcode;
+	wr.opcode = p->ep->eopcode;
 	wr.sg_list = &sge;
 	wr.num_sge = 1;
 	wr.wr.rdma.remote_addr = 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -393,6 +393,11 @@ VERBS_INI
 	fi_param_define(&fi_ibv_prov, "rdm_thread_timeout", FI_PARAM_INT,
 			"the wake up timeout of the helper thread (usec) "
 			"(default: 100)");
+	fi_param_define(&fi_ibv_prov, "rdm_eager_send_opcode", FI_PARAM_STRING,
+			"the operation code that will be used for eager messaging. "
+			"Only IBV_WR_SEND and IBV_WR_RDMA_WRITE_WITH_IMM are supported. "
+			"The last one is not applicable for iWarp. "
+			"(default: IBV_WR_SEND)");
 
 	return &fi_ibv_prov;
 }


### PR DESCRIPTION
Bugfixes:

- Fix initialization of rndv-threshold
- Fix bidirectional hangs on iWarp devices over rndv protocol in case of out of order arriving on recv side. (The issue was reproduced on MLX with IBV_WR_SEND opcode as well. It's fixed now)

Improvements:

- IBV_WR_SEND shows better latency vs IBV_WR_RDMA_WRITE_WITH_IMM on MLX HW. So, as all known issues are resolved, this is a default opcode now.
- Add parameter rdm_eager_send_opcode to be able to define this from environment
- Add the parameter into release notes

@a-ilango @shefty please review