### PR TITLE
prov/verbs: Fix RDM EP tagged cq return value

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -92,7 +92,7 @@ static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
 		}
 	}
 
-	return ret;
+	return !ret ? -FI_EAGAIN : ret;
 }
 
 static ssize_t fi_ibv_rdm_tagged_cq_read(struct fid_cq *cq, void *buf,


### PR DESCRIPTION
According to the manpages, fi_cq_read() should return -FI_EAGAIN
if no completions are available, not zero.

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>