### PR TITLE
Makefile.am: bump .so version to 3:1:2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -127,7 +127,7 @@ src_libfabric_la_LDFLAGS =
 src_libfabric_la_LIBADD =
 src_libfabric_la_DEPENDENCIES = libfabric.map
 
-src_libfabric_la_LDFLAGS += -version-info 3:0:2 -export-dynamic \
+src_libfabric_la_LDFLAGS += -version-info 3:1:2 -export-dynamic \
 			   $(libfabric_version_script)
 rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fabric.h \


### PR DESCRIPTION
Here's what changed in the core since v1.3.0:

1. We added a few enum constants, such as FI_NOAV
   * I *think* that this should have no effect on the c and a values, because these are not linker symbols, but constants.

2. We added some new static inline functions in fabric.h, such as fi_mr_regv(), fi_mr_regattr(), and fi_ep_alias().
   * These affect the user's application, not the libfabric.so library.

So we just bump "r" from 0 to 1, indicating that code has changed in libfabric.so, but no public-facing symbols in libfabric.so have changed in terms of ABI.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>