### PR TITLE
prov/psm,psm2: Return error when trying to open shared AV

### DIFF
--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -415,6 +415,13 @@ int psmx_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 				attr->flags, FI_EVENT);
 			return -FI_EINVAL;
 		}
+
+		if (attr->name) {
+			FI_INFO(&psmx_prov, FI_LOG_AV,
+				"attr->name=%s, named AV is not supported\n",
+				attr->name);
+			return -FI_EINVAL;
+		}
 	}
 
 	av_priv = (struct psmx_fid_av *) calloc(1, sizeof *av_priv);

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -447,6 +447,13 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 				attr->flags, FI_EVENT);
 			return -FI_EINVAL;
 		}
+
+		if (attr->name) {
+			FI_INFO(&psmx2_prov, FI_LOG_AV,
+				"attr->name=%s, named AV is not supported\n",
+				attr->name);
+			return -FI_EINVAL;
+		}
 	}
 
 	av_priv = (struct psmx2_fid_av *) calloc(1, sizeof *av_priv);


### PR DESCRIPTION
Shared address vector is not supported because the transport address
information is process specific. Check the "name" attribute when
opening address vectors and return error when it is not NULL. This
allows fabtests/fi_rdm_shared_av to bail out early instead of failing
after a long delay.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>