### PR TITLE
prov/verbs: fix FI_AV_TABLE

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -65,7 +65,8 @@ static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
 			cq_entry, cq_entry->context, cq_entry->len,
 			cq_entry->minfo.tag);
 
-		src_addr[ret] = (fi_addr_t) (uintptr_t) cq_entry->minfo.conn;
+		src_addr[ret] =
+			_cq->ep->av->conn_to_addr(_cq->ep, cq_entry->minfo.conn);
 		entry[ret].op_context = cq_entry->context;
 		entry[ret].flags = (cq_entry->comp_flags & ~FI_COMPLETION);
 		entry[ret].len = cq_entry->len;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -115,9 +115,7 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 		return -FI_EMSGSIZE;
 	}
 
-	struct fi_ibv_rdm_conn *conn =
-		(msg->addr == FI_ADDR_UNSPEC) ? NULL :
-		(struct fi_ibv_rdm_conn *) msg->addr;
+	struct fi_ibv_rdm_conn *conn = ep_rdm->av->addr_to_conn(ep_rdm, msg->addr);
 
 	struct fi_ibv_rdm_tagged_recv_start_data recv_data = {
 		.peek_data = {
@@ -216,9 +214,9 @@ static inline ssize_t
 fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len, 
 			 fi_addr_t dest_addr, uint64_t tag)
 {
-	struct fi_ibv_rdm_conn *conn = (struct fi_ibv_rdm_conn *)dest_addr;
 	struct fi_ibv_rdm_ep *ep =
 		container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
+	struct fi_ibv_rdm_conn *conn = ep->av->addr_to_conn(ep, dest_addr);
 
 	const size_t size = len + sizeof(struct fi_ibv_rdm_header);
 
@@ -290,7 +288,7 @@ static ssize_t fi_ibv_rdm_tagged_senddatato(struct fid_ep *fid, const void *buf,
 
 	struct fi_ibv_rdm_send_start_data sdata = {
 		.ep_rdm = container_of(fid, struct fi_ibv_rdm_ep, ep_fid),
-		.conn = (struct fi_ibv_rdm_conn *) dest_addr,
+		.conn = ep_rdm->av->addr_to_conn(ep_rdm, dest_addr),
 		.data_len = len,
 		.context = context,
 		.flags = FI_TAGGED | FI_SEND |
@@ -323,7 +321,7 @@ static ssize_t fi_ibv_rdm_tagged_sendmsg(struct fid_ep *ep,
 
 	struct fi_ibv_rdm_send_start_data sdata = {
 		.ep_rdm = container_of(ep, struct fi_ibv_rdm_ep, ep_fid),
-		.conn = (struct fi_ibv_rdm_conn *) msg->addr,
+		.conn = ep_rdm->av->addr_to_conn(ep_rdm, msg->addr),
 		.data_len = 0,
 		.context = msg->context,
 		.flags = FI_TAGGED | FI_SEND | (ep_rdm->tx_selective_completion ?

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -138,12 +138,25 @@ struct fi_ibv_eq {
 int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		   struct fid_eq **eq, void *context);
 
+struct fi_ibv_rdm_ep;
+
+typedef struct fi_ibv_rdm_conn *
+	(*fi_ibv_rdm_addr_to_conn_func)
+	(struct fi_ibv_rdm_ep *ep, fi_addr_t addr);
+
+typedef fi_addr_t
+	(*fi_ibv_rdm_conn_to_addr_func)
+	(struct fi_ibv_rdm_ep *ep, struct fi_ibv_rdm_conn *conn);
+
 struct fi_ibv_av {
 	struct fid_av		av_fid;
 	struct fi_ibv_domain	*domain;
 	struct fi_ibv_rdm_ep	*ep;
 	size_t			count;
+	size_t			used;
 	enum fi_av_type		type;
+	fi_ibv_rdm_addr_to_conn_func addr_to_conn;
+	fi_ibv_rdm_conn_to_addr_func conn_to_addr;
 };
 
 int fi_ibv_av_open(struct fid_domain *domain, struct fi_av_attr *attr,

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -282,7 +282,7 @@ fi_ibv_rdm_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	struct fi_ibv_rdm_ep *ep =
 		container_of(ep_fid, struct fi_ibv_rdm_ep, ep_fid);
 
-	struct fi_ibv_rdm_conn *conn = (struct fi_ibv_rdm_conn *)msg->addr;
+	struct fi_ibv_rdm_conn *conn = ep->av->addr_to_conn(ep, msg->addr);
 
 	struct fi_ibv_rdm_rma_start_data start_data = {
 		.ep_rdm = ep,
@@ -387,7 +387,7 @@ fi_ibv_rdm_ep_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 {
 	struct fi_ibv_rdm_ep *ep = container_of(ep_fid, struct fi_ibv_rdm_ep,
 						ep_fid);
-	struct fi_ibv_rdm_conn *conn = (struct fi_ibv_rdm_conn *) msg->addr;
+	struct fi_ibv_rdm_conn *conn = ep->av->addr_to_conn(ep, msg->addr);
 	struct fi_ibv_rdm_request *request = NULL;
 	void *raw_buf = NULL;
 	ssize_t ret = FI_SUCCESS;
@@ -492,7 +492,7 @@ static ssize_t fi_ibv_rdm_ep_rma_inject_write(struct fid_ep *ep,
 {
 	struct fi_ibv_rdm_ep *ep_rdm = container_of(ep, struct fi_ibv_rdm_ep,
 						    ep_fid);
-	struct fi_ibv_rdm_conn *conn = (struct fi_ibv_rdm_conn *) dest_addr;
+	struct fi_ibv_rdm_conn *conn = ep_rdm->av->addr_to_conn(ep_rdm, dest_addr);
 	struct fi_ibv_rdm_request *request = NULL;
 
 	struct fi_ibv_rdm_rma_start_data start_data = {


### PR DESCRIPTION
Lack of "connection to address" and "address to connection" conversions caused a segfault.

@a-ilango please review
@epaulson10 could you check this patch with your case?
