### PR TITLE
fabric: Re-order provider initialization

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -390,11 +390,11 @@ void fi_ini(void)
 libdl_done:
 #endif
 
-	fi_register_provider(PSM_INIT, NULL);
 	fi_register_provider(PSM2_INIT, NULL);
+	fi_register_provider(PSM_INIT, NULL);
 	fi_register_provider(USNIC_INIT, NULL);
-	fi_register_provider(MXM_INIT, NULL);
 	fi_register_provider(VERBS_INIT, NULL);
+	fi_register_provider(MXM_INIT, NULL);
 	fi_register_provider(GNI_INIT, NULL);
 	/* fi_register_provider(RXM_INIT, NULL); */
 	/* fi_register_provider(RXD_INIT, NULL); */


### PR DESCRIPTION
Some hardware may be supported by more than one provider.  Re-order
the initialization to set a priority order.

A second level of prioritization may be needed in the future, but
this is an easy change for now.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>