### PR TITLE
util/counter: Store cached value

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -228,6 +228,8 @@ struct util_cntr {
 	struct fid_cntr		cntr_fid;
 	struct util_domain	*domain;
 	atomic_t		ref;
+	uint64_t		checkpoint_cnt;
+	uint64_t		checkpoint_err;
 };
 
 
@@ -510,8 +512,6 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 struct fid_list_entry {
 	struct dlist_entry	entry;
 	struct fid		*fid;
-
-	uint64_t		last_cntr_val;
 };
 
 int fid_list_insert(struct dlist_entry *fid_list, fastlock_t *lock,

--- a/man/fi_poll.3.md
+++ b/man/fi_poll.3.md
@@ -136,13 +136,20 @@ Removes an completion queue or counter from a poll set.
 ## fi_poll
 
 Progresses all completion queues and counters associated with a poll set
-and checks for events.  If events have occurred, contexts associated
+and checks for events.  If events might have occurred, contexts associated
 with the completion queues and/or counters are returned.  Completion
 queues will return their context if they are not empty.  The context
 associated with a counter will be returned if the counter's success
-value or error value have changed since the last time fi_poll was
-called.  The number of contexts is limited to the size of the context
-array, indicated by the count parameter.
+value or error value have changed since the last time fi_poll, fi_cntr_set,
+or fi_cntr_add were called.  The number of contexts is limited to the
+size of the context array, indicated by the count parameter.
+
+Note that fi_poll only indicates that events might be available.  In some
+cases, providers may consume such events internally, to drive progress, for
+example.  This can result in fi_poll returning false positives.  Applications
+should drive their progress based on the results of reading events from a
+completion queue or reading counter values.  The fi_poll function will always
+return all completion queues and counters that do have new events.
 
 ## fi_wait_open
 

--- a/prov/util/src/util_poll.c
+++ b/prov/util/src/util_poll.c
@@ -99,8 +99,13 @@ static int util_poll_run(struct fid_poll *poll_fid, void **context, int count)
 			cntr = container_of(fid_entry->fid, struct util_cntr,
 					    cntr_fid.fid);
 			val = fi_cntr_read(&cntr->cntr_fid);
-			if ((ret = (val != fid_entry->last_cntr_val)))
-				fid_entry->last_cntr_val = val;
+			if ((ret = (val != cntr->checkpoint_cnt))) {
+				cntr->checkpoint_cnt = val;
+			} else {
+				val = fi_cntr_readerr(&cntr->cntr_fid);
+				if ((ret = (val != cntr->checkpoint_err)))
+					cntr->checkpoint_err = val;
+			}
 			break;
 		case FI_CLASS_EQ:
 			eq = container_of(fid_entry->fid, struct util_eq,


### PR DESCRIPTION
Fixes #2260.

There is a race using fi_poll, where counter updates may
be lost in cases where the app manually modifies the counter
(using set/add)  Restructure the utility implementation to
store a cached value with the util_cntr structure.

This value is updated by fi_poll, fi_cntr_set, and fi_cntr_add
routines.  The man page is updated to reflect the new behavior.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>