### PR TITLE
prov/sockets: Avoid caching cntr value in cntr-read

### DIFF
--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -200,13 +200,10 @@ void sock_cntr_check_trigger_list(struct sock_cntr *cntr)
 
 static uint64_t sock_cntr_read(struct fid_cntr *cntr)
 {
-	uint64_t curr_val;
 	struct sock_cntr *_cntr;
 	_cntr = container_of(cntr, struct sock_cntr, cntr_fid);
 	sock_cntr_progress(_cntr);
-	curr_val = atomic_get(&_cntr->value);
-	atomic_set(&_cntr->last_read_val, curr_val);
-	return curr_val;
+	return atomic_get(&_cntr->value);
 }
 
 void sock_cntr_inc(struct sock_cntr *cntr)


### PR DESCRIPTION
- This change is as per the counter semantics described in #2415.
  Caching counter values in cntr-read would be a performance hit.

Signed-off-by: Jithin Jose <jithin.jose@intel.com>