### PR TITLE
verbs: Fix CQ size reporting.

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -87,6 +87,9 @@
 	OFI_Q_READERR(prov, log, eq, "eq", fi_eq_readerr, 	\
 			fi_eq_strerror, ret, err_entry)
 
+#define ofi_sin_addr(addr) (((struct sockaddr_in *)(addr))->sin_addr)
+#define ofi_sin6_addr(addr) (((struct sockaddr_in6 *)(addr))->sin6_addr)
+
 enum fi_match_type {
 	FI_MATCH_EXACT,
 	FI_MATCH_PREFIX,

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -538,8 +538,7 @@ int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		goto err3;
 	}
 
-	size = attr->size ? attr->size :
-		MIN(VERBS_DEF_CQ_SIZE, _cq->domain->info->domain_attr->cq_cnt);
+	size = attr->size ? attr->size : VERBS_DEF_CQ_SIZE;
 
 	_cq->cq = ibv_create_cq(_cq->domain->verbs, size, _cq, _cq->channel,
 			attr->signaling_vector);


### PR DESCRIPTION
Also add macros for accessing address fields in sockaddr_in, sockaddr_in6 structs.