### PR TITLE
fabric: Introduce socket endpoints

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -217,8 +217,8 @@ enum fi_ep_type {
 	FI_EP_MSG,
 	FI_EP_DGRAM,
 	FI_EP_RDM,
-	/* FI_EP_RAW, */
-	/* FI_EP_PACKET, */
+	FI_EP_SOCK_STREAM,
+	FI_EP_SOCK_DGRAM,
 };
 
 /* Endpoint protocol

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -447,6 +447,14 @@ assigned to an endpoint.
 : This option only applies to passive endpoints.  It is used to set the
   connection request backlog for listening endpoints.
 
+*FI_GETWAIT (void \*\*)*
+: This command allows the user to retrieve the file descriptor associated
+  with a socket endpoint.  The fi_control arg parameter should be an address
+  where a pointer to the returned file descriptor will be written.  See fi_eq.3
+  for addition details using fi_control with FI_GETWAIT.  The file descriptor
+  may be used for notification that the endpoint is ready to send or receive
+  data.
+
 ## fi_getopt / fi_setopt
 
 Endpoint protocol operations may be retrieved using fi_getopt or set
@@ -539,6 +547,20 @@ desired.  Supported types are:
 : Reliable datagram message.  Provides a reliable, unconnected data
   transfer service with flow control that maintains message
   boundaries.
+
+*FI_EP_SOCK_STREAM*
+: Data streaming endpoint with TCP socket-like semantics.  Provides
+  a reliable, connection-oriented data transfer service that does
+  not maintain message boundaries.  FI_EP_SOCK_STREAM is most useful for
+  applications designed around using TCP sockets.  See the SOCKET
+  ENDPOINT section for additional details and restrictions that apply
+  to stream endpoints.
+
+*FI_EP_SOCK_DGRAM*
+: A connectionless, unreliable datagram endpoint with UDP socket-like
+  semantics.  FI_EP_SOCK_DGRAM is most useful for applications designed
+  around using UDP sockets.  See the SOCKET ENDPOINT section for additional
+  details and restrictions that apply to datagram socket endpoints.
 
 ## Protocol
 
@@ -1110,6 +1132,40 @@ under SCALABLE ENDPOINTS section for details on the receive context
 attributes.  The exception is that endpoints attached to a shared
 receive context must use a subset of the receive context attributes.
 This is opposite of the requirement for scalable endpoints.
+
+# SOCKET ENDPOINTS
+
+This section applies to endpoints of type FI_EP_SOCK_STREAM and
+FI_EP_SOCK_DGRAM, commonly referred to as socket endpoints.
+
+Socket endpoints are defined with semantics that allow them to more
+easily be adopted by developers familiar with the UNIX socket API, or
+by middleware that exposes the socket API, while still taking advantage
+of high-performance hardware features.
+
+The key difference between socket endpoints and other active endpoints
+are socket endpoints use synchronous data transfers.  Buffers passed
+into send and receive operations revert to the control of the application
+upon returning from the function call.  As a result, no data transfer
+completions are reported to the application, and socket endpoints are not
+associated with completion queues or counters.
+
+Socket endpoints support a subset of message operations: fi_send,
+fi_sendv, fi_sendmsg, fi_recv, fi_recvv, fi_recvmsg, and fi_inject.
+Because data transfers are synchronous, the return value from send and receive
+operations indicate the number of bytes transferred on success, or a negative
+value on error, including -FI_EAGAIN if the endpoint cannot send or
+receive any data because of full or empty queues, respectively.
+
+Socket endpoints are associated with event queues and address vectors, and
+process connection management events asynchronously, similar to other endpoints.
+Unlike UNIX sockets, socket endpoint must still be declared as either active
+or passive.
+
+Socket endpoints behave like non-blocking sockets.  In order to support
+select and poll semantics, active socket endpoints are associated with a
+file descriptor that is signaled whenever the endpoint is ready to send
+and/or receive data.  The file descriptor may be retrieved using fi_control.
 
 # OPERATION FLAGS
 


### PR DESCRIPTION
Define new endpoint types, FI_EP_SOCK_STREAM and FI_EP_SOCK_DGRAM.
These provide data transfer semantics similar to unix TCP and UDP
sockets.

The intent is to support middleware that exports a socket-like API
to applications (e.g. rsockets), while allowing providers to optimize
the data transfer protocol around their hardware.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

This is the first cut at a proposal to better support the socket API over libfabric.  I took a hybrid approach, where mostly the data transfer component is pushed down to the provider, and the rest is left to the upper layer library.  We would need to implement this to see if it would be usable in practice, but if so, then the API is basically unchanged.  The new socket endpoint types just use slightly different semantics for send and receive operations.  (Though, send behaves the same as the existing calls with the FI_INJECT flag specified.  Receive is new.)