### PR TITLE
prov/verbs: Fix segfault in verbs getinfo() function

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1100,8 +1100,8 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 					       hints, rai, info);
 	} else {
 		ret = fi_ibv_get_matching_info(NULL, hints, rai, info);
-		if (!ret && !(flags & FI_SOURCE) && !node && !hints->src_addr &&
-				!hints->dest_addr) {
+		if (!ret && !(flags & FI_SOURCE) && !node 
+                && (!hints || (!hints->src_addr && !hints->dest_addr))) {
 			ret = fi_ibv_getifaddrs(service, flags, *info);
 			if (ret) {
 				fi_freeinfo(*info);


### PR DESCRIPTION
Handle the case where the hints argument is NULL, such as in
calling the fi_info utility with no arguments.

@a-ilango Please review.