### PR TITLE
usnic: Post completion flags on MSG/RDM

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -362,7 +362,7 @@ struct usdf_cq_hard {
 	atomic_t cqh_refcnt;
 	void (*cqh_progress)(struct usdf_cq_hard *hcq);
 	void (*cqh_post)(struct usdf_cq_hard *hcq, void *context, size_t len,
-			int prov_errno);
+			int prov_errno, uint64_t flags);
 	TAILQ_ENTRY(usdf_cq_hard) cqh_link;
 	TAILQ_ENTRY(usdf_cq_hard) cqh_dom_link;
 };

--- a/prov/usnic/src/usdf_cq.c
+++ b/prov/usnic/src/usdf_cq.c
@@ -437,7 +437,7 @@ usdf_progress_hard_cq(struct usdf_cq_hard *hcq)
 
 void
 usdf_cq_post_soft(struct usdf_cq_hard *hcq, void *context, size_t len,
-		int prov_errno)
+		int prov_errno, uint64_t flags)
 {
 	int ret;
 	struct usdf_cq_soft_entry *entry;
@@ -460,6 +460,7 @@ usdf_cq_post_soft(struct usdf_cq_hard *hcq, void *context, size_t len,
 	entry->cse_context = context;
 	entry->cse_len = len;
 	entry->cse_prov_errno = prov_errno;
+	entry->cse_flags = flags;
 
 	/* update with wrap */
 	entry++;

--- a/prov/usnic/src/usdf_cq.h
+++ b/prov/usnic/src/usdf_cq.h
@@ -50,6 +50,6 @@ int usdf_cq_trywait(struct fid *fcq);
 void usdf_progress_hard_cq(struct usdf_cq_hard *hcq);
 
 void usdf_cq_post_soft(struct usdf_cq_hard *hcq, void *context,
-		size_t len, int prov_errno);
+		size_t len, int prov_errno, uint64_t flags);
 
 #endif /* _USDF_CQ_H_ */

--- a/prov/usnic/src/usdf_msg.c
+++ b/prov/usnic/src/usdf_msg.c
@@ -896,7 +896,8 @@ usdf_msg_recv_complete(struct usdf_ep *ep, struct usdf_msg_qe *rqe, int status)
 	rx = ep->ep_rx;
 	hcq = rx->r.msg.rx_hcq;
 
-	hcq->cqh_post(hcq, rqe->ms_context, rqe->ms_length, status);
+	hcq->cqh_post(hcq, rqe->ms_context, rqe->ms_length, status,
+		      FI_MSG | FI_RECV);
 	usdf_msg_put_rx_rqe(rx, rqe);
 }
 
@@ -967,7 +968,8 @@ usdf_msg_process_ack(struct usdf_ep *ep, uint16_t seq)
 			USDF_DBG_SYS(EP_DATA, "send complete, signal_comp=%u\n", wqe->ms_signal_comp);
 			if (wqe->ms_signal_comp)
 				hcq->cqh_post(hcq, wqe->ms_context,
-						wqe->ms_length, FI_SUCCESS);
+					      wqe->ms_length, FI_SUCCESS,
+					      FI_MSG | FI_SEND);
 
 			usdf_msg_put_tx_wqe(tx, wqe);
 		} else {

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -1144,7 +1144,8 @@ static inline void usdf_rdm_recv_complete(struct usdf_rx *rx,
 	USDF_DBG_SYS(EP_DATA, "RECV complete ID=%u len=%lu with status %d\n",
 		     rdc->dc_rx_msg_id, rqe->rd_length, status);
 	hcq = rx->r.rdm.rx_hcq;
-	hcq->cqh_post(hcq, rqe->rd_context, rqe->rd_length, status);
+	hcq->cqh_post(hcq, rqe->rd_context, rqe->rd_length, status,
+		      FI_MSG | FI_RECV);
 
 	usdf_rdm_put_rx_rqe(rx, rqe);
 
@@ -1318,7 +1319,9 @@ usdf_rdm_process_ack(struct usdf_rdm_connection *rdc,
 				USDF_DBG_SYS(EP_DATA, "send ID=%u complete\n", msg_id);
 				if (wqe->rd_signal_comp)
 					hcq->cqh_post(hcq, wqe->rd_context,
-							wqe->rd_length, FI_SUCCESS);
+						      wqe->rd_length,
+						      FI_SUCCESS,
+						      FI_MSG | FI_SEND);
 
 				usdf_rdm_put_tx_wqe(tx, wqe);
 


### PR DESCRIPTION
Set the flags field of the completion for RDM and MSG.

Closes #2431 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>