### PR TITLE
prov/psm,psm2: Return -FI_ENOSYS for unsupported parameters

### DIFF
--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -413,14 +413,14 @@ int psmx_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 			FI_INFO(&psmx_prov, FI_LOG_AV,
 				"attr->flags=%x, supported=%x\n",
 				attr->flags, FI_EVENT);
-			return -FI_EINVAL;
+			return -FI_ENOSYS;
 		}
 
 		if (attr->name) {
 			FI_INFO(&psmx_prov, FI_LOG_AV,
 				"attr->name=%s, named AV is not supported\n",
 				attr->name);
-			return -FI_EINVAL;
+			return -FI_ENOSYS;
 		}
 	}
 

--- a/prov/psm/src/psmx_msg.c
+++ b/prov/psm/src/psmx_msg.c
@@ -154,7 +154,7 @@ static ssize_t psmx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_
 		return -FI_EINVAL;
 
 	if (msg->iov_count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
@@ -178,7 +178,7 @@ static ssize_t psmx_recvv(struct fid_ep *ep, const struct iovec *iov, void **des
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -322,7 +322,7 @@ static ssize_t psmx_sendmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_
 		return -FI_EINVAL;
 
 	if (msg->iov_count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
@@ -346,7 +346,7 @@ static ssize_t psmx_sendv(struct fid_ep *ep, const struct iovec *iov, void **des
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -453,7 +453,7 @@ static ssize_t psmx_recvmsg2(struct fid_ep *ep, const struct fi_msg *msg,
 		return -FI_EINVAL;
 
 	if (msg->iov_count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
@@ -477,7 +477,7 @@ static ssize_t psmx_recvv2(struct fid_ep *ep, const struct iovec *iov,
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -572,7 +572,7 @@ static ssize_t psmx_sendmsg2(struct fid_ep *ep, const struct fi_msg *msg,
 		return -FI_EINVAL;
 
 	if (msg->iov_count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
@@ -596,7 +596,7 @@ static ssize_t psmx_sendv2(struct fid_ep *ep, const struct iovec *iov,
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -328,7 +328,7 @@ static ssize_t psmx_tagged_recvmsg(struct fid_ep *ep, const struct fi_msg_tagged
 		return -FI_EINVAL;
 
 	if (msg->iov_count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
@@ -374,7 +374,7 @@ static ssize_t psmx_tagged_recvv(struct fid_ep *ep, const struct iovec *iov, voi
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -398,7 +398,7 @@ static ssize_t psmx_tagged_recvv_no_flag(struct fid_ep *ep, const struct iovec *
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -423,7 +423,7 @@ static ssize_t psmx_tagged_recvv_no_event(struct fid_ep *ep, const struct iovec 
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -774,7 +774,7 @@ static ssize_t psmx_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged
 		return -FI_EINVAL;
 
 	if (msg->iov_count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
@@ -798,7 +798,7 @@ static ssize_t psmx_tagged_sendv(struct fid_ep *ep, const struct iovec *iov, voi
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -823,7 +823,7 @@ static ssize_t psmx_tagged_sendv_no_flag_av_map(struct fid_ep *ep, const struct 
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -849,7 +849,7 @@ static ssize_t psmx_tagged_sendv_no_flag_av_table(struct fid_ep *ep, const struc
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -875,7 +875,7 @@ static ssize_t psmx_tagged_sendv_no_event_av_map(struct fid_ep *ep, const struct
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;
@@ -901,7 +901,7 @@ static ssize_t psmx_tagged_sendv_no_event_av_table(struct fid_ep *ep, const stru
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -445,14 +445,14 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 			FI_INFO(&psmx2_prov, FI_LOG_AV,
 				"attr->flags=%x, supported=%x\n",
 				attr->flags, FI_EVENT);
-			return -FI_EINVAL;
+			return -FI_ENOSYS;
 		}
 
 		if (attr->name) {
 			FI_INFO(&psmx2_prov, FI_LOG_AV,
 				"attr->name=%s, named AV is not supported\n",
 				attr->name);
-			return -FI_EINVAL;
+			return -FI_ENOSYS;
 		}
 	}
 

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -170,7 +170,7 @@ static ssize_t psmx2_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		return -FI_EINVAL;
 
 	if (msg->iov_count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
@@ -195,7 +195,7 @@ static ssize_t psmx2_recvv(struct fid_ep *ep, const struct iovec *iov,
 		return -FI_EINVAL;
 
 	if (count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (count) {
 		buf = iov[0].iov_base;
 		len = iov[0].iov_len;

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -487,7 +487,7 @@ static ssize_t psmx2_tagged_recvmsg(struct fid_ep *ep,
 		return -FI_EINVAL;
 
 	if (msg->iov_count > 1) {
-		return -FI_EINVAL;
+		return -FI_ENOSYS;
 	} else if (msg->iov_count) {
 		buf = msg->msg_iov[0].iov_base;
 		len = msg->msg_iov[0].iov_len;
@@ -511,8 +511,10 @@ psmx2_tagged_recvv##suffix(struct fid_ep *ep, const struct iovec *iov,	\
 {									\
 	void *buf;							\
 	size_t len;							\
-	if ((count && !iov) || (count > 1))				\
+	if (count && !iov)						\
 		return -FI_EINVAL;					\
+	if (count > 1)							\
+		return -FI_ENOSYS;					\
 	if (count) {							\
 		buf = iov[0].iov_base;					\
 		len = iov[0].iov_len;					\


### PR DESCRIPTION
Some parameter values are valid per libfabric definitions but are
not supported by the provider(s). Return -FI_ENOSYS instead of
-FI_EINVAL for such cases.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

This is related to #2424 