### PR TITLE
prov/psm,psm2: Fix fi_poll failure on counters

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -451,7 +451,10 @@ struct psmx_trigger {
 };
 
 struct psmx_fid_cntr {
-	struct fid_cntr		cntr;
+	union {
+		struct fid_cntr		cntr;
+		struct util_cntr	util_cntr; /* for util_poll_run */
+	};
 	struct psmx_fid_domain	*domain;
 	int			events;
 	uint64_t		flags;

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -628,7 +628,10 @@ struct psmx2_trigger {
 };
 
 struct psmx2_fid_cntr {
-	struct fid_cntr		cntr;
+	union {
+		struct fid_cntr		cntr;
+		struct util_cntr	util_cntr; /* for util_poll_run */
+	};
 	struct psmx2_fid_domain	*domain;
 	int			events;
 	uint64_t		flags;


### PR DESCRIPTION
Commit 010204f1c3d8(util/counter: Store cached value) introduces
some new fields to util_cntr that are used in util_poll_run. That
has caused fi_poll to fail on psm/psm2 counters because those fields
are missing. Add util_cntr to the provider counter definition to
allow it to work with the new util_poll_run function.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>