### PR TITLE
ABI-1.1 staging for early review

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -122,6 +122,7 @@ src_libfabric_la_SOURCES = \
 	src/fi_tostr.c \
 	src/log.c \
 	src/var.c \
+	src/abi_1_0.c \
 	$(common_srcs)
 
 src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)

--- a/docs/providers
+++ b/docs/providers
@@ -67,7 +67,7 @@ that handles progress or timeout/retries.
 
 // include/fi_rbuf.h
 
-This provides inline implemenations of ring buffers.
+This provides inline implementations of ring buffers.
 
 ringbuf:
 This defines a fixed-sized ring buffer that supports variable-sized
@@ -108,4 +108,3 @@ fi_datatype_size() - return size of an atomic datatype
 fi_[capability]_allowed() - routines to check caps bits
 fi_gettime_ms() - return current time in milliseconds
 fi_fd_nonblock() - set fd to nonblocking
-

--- a/include/fi_abi.h
+++ b/include/fi_abi.h
@@ -43,7 +43,75 @@ extern "C" {
 #endif
 
 
-#define DEFAULT_ABI "FABRIC_1.0"
+/*
+ * ABI version support definitions.
+ *
+ * CURRENT_ABI:
+ * This defines the current ABI version.  The ABI version is separate from
+ * the packaging or interface versions.  Whenever a change is
+ * added to the interfaces that breaks the ABI, this definition should be
+ * updated.  If you don't know if a change breaks the ABI, then you shouldn't
+ * be modifying the header files under include/rdma!  :P
+ *
+ * DEFAULT_SYMVER_PRE:
+ * This macro appends an underscore to a function name.  It should be used
+ * around any function that is exported from the library as the default call
+ * that applications invoke.
+ *
+ * CURRENT_SYMVER:
+ * This macro is placed after a function definition.  It should be used with
+ * any function that is exported by the library and was added as part of the
+ * current ABI (identified by CURRENT_ABI) version.  It results in the function
+ * being exported at the current ABI version.  This is the macro to use when
+ * exporting new functions.
+ *
+ * DEFAULT_SYMVER:
+ * This macro is similar to CURRENT_SYMVER, but is used to specify that a
+ * function, while the default interface that applications call, was added
+ * in a previous version of the ABI.  Any function that was not impacted by
+ * an ABI change should use this macro.  This often means converting functions
+ * marked as CURRENT_SYMVER to DEFAULT_SYMVER as part of the ABI update.
+ *
+ * COMPAT_SYMVER:
+ * The compatibility symbols are used to mark interfaces which were exported
+ * in previous ABI versions, but are no longer the default.  These functions
+ * are provided purely for backwards compatibility with existing (already
+ * compiled) applications.
+ *
+ * Example:
+ * ABI version 1.0 introduced functions foo() and bar().
+ * ABI version 1.1 modified the behavior for funtion foo().
+ * This scenario would result in the following definitions.
+ *
+ * CURRENT_ABI "MYLIB_1.1"
+ *
+ * This function is the main entry point for function bar.
+ * int DEFAULT_SYMVER_PRE(bar)(void)
+ * {
+ *    ...
+ * }
+ * DEFAULT_SYMVER(bar_, bar, "MYLIB_1.0");
+ *
+ * This function is the main entry point for function foo.
+ * int DEFAULT_SYMVER_PRE(foo)(void)
+ * {
+ *    ...
+ * }
+ * CURRENT_SYMVER(foo_, foo);
+ *
+ * This function is the old entry point for function foo, provided for
+ * backwards compatibility.
+ * int foo_1_0(void)
+ * {
+ *    ...
+ * }
+ * COMPAT_SYMVER(foo_1_0, foo, "MYLIB_1.0");
+ *
+ * By convention, the name of compatibility functions is the exported function
+ * name appended with the ABI version that it is compatible with.
+ */
+
+#define CURRENT_ABI "FABRIC_1.1"
 
 #if  HAVE_ALIAS_ATTRIBUTE == 1
 #define DEFAULT_SYMVER_PRE(a) a##_
@@ -54,17 +122,25 @@ extern "C" {
 /* symbol -> external symbol mappings */
 #if HAVE_SYMVER_SUPPORT
 
-#  define SYMVER(name, api, ver) \
-        asm(".symver " #name "," #api "@" #ver)
-#  define DEFAULT_SYMVER(name, api) \
-        asm(".symver " #name "," #api "@@" DEFAULT_ABI)
+#define COMPAT_SYMVER(name, api, ver) \
+	asm(".symver " #name "," #api "@" #ver)
+#define DEFAULT_SYMVER(name, api, ver) \
+	asm(".symver " #name "," #api "@@" #ver)
+#define CURRENT_SYMVER(name, api) \
+	asm(".symver " #name "," #api "@@" CURRENT_ABI)
+
 #else
-#  define SYMVER(Name, api, ver)
-#if  HAVE_ALIAS_ATTRIBUTE == 1
-#  define DEFAULT_SYMVER(name, api) \
-        extern typeof (name) api __attribute__((alias(#name)));
+
+#define COMPAT_SYMVER(name, api, ver)
+
+#if HAVE_ALIAS_ATTRIBUTE == 1
+#define DEFAULT_SYMVER(name, api, ver) \
+	extern typeof (name) api __attribute__((alias(#name)));
+#define CURRENT_SYMVER(name, api) \
+	extern typeof (name) api __attribute__((alias(#name)));
 #else
-#  define DEFAULT_SYMVER(name, api)
+#define DEFAULT_SYMVER(name, api, ver)
+#define CURRENT_SYMVER(name, api)
 #endif  /* HAVE_ALIAS_ATTRIBUTE == 1*/
 
 #endif /* HAVE_SYMVER_SUPPORT */

--- a/include/fi_abi.h
+++ b/include/fi_abi.h
@@ -80,7 +80,7 @@ extern "C" {
  *
  * Example:
  * ABI version 1.0 introduced functions foo() and bar().
- * ABI version 1.1 modified the behavior for funtion foo().
+ * ABI version 1.1 modified the behavior for function foo().
  * This scenario would result in the following definitions.
  *
  * CURRENT_ABI "MYLIB_1.1"

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -531,6 +531,7 @@ int fi_check_info(const struct util_prov *util_prov,
 void ofi_alter_info(struct fi_info *info,
 		   const struct fi_info *hints);
 
+struct fi_info *ofi_allocinfo_internal(void);
 int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		 const char *node, const char *service, uint64_t flags,
 		 struct fi_info *hints, struct fi_info **info);

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -307,6 +307,8 @@ struct fi_ep_attr {
 	uint64_t		mem_tag_format;
 	size_t			tx_ctx_cnt;
 	size_t			rx_ctx_cnt;
+	size_t			auth_keylen;
+	uint8_t			*auth_key;
 };
 
 struct fi_domain_attr {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -146,6 +146,7 @@ typedef struct fid *fid_t;
 #define FI_AFFINITY		(1ULL << 29)
 
 /* fi_getinfo()-specific flags/caps */
+#define FI_SHARED_AV		(1ULL << 53)
 #define FI_PROV_ATTR_ONLY	(1ULL << 54)
 #define FI_NUMERICHOST		(1ULL << 55)
 #define FI_RMA_EVENT		(1ULL << 56)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -325,6 +325,8 @@ struct fi_domain_attr {
 	size_t			max_ep_srx_ctx;
 	size_t			cntr_cnt;
 	size_t			mr_iov_limit;
+	uint64_t		caps;
+	uint64_t		mode;
 };
 
 struct fi_fabric_attr {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -38,6 +38,17 @@
 #include <stddef.h>
 #include <sys/types.h>
 
+#ifdef __GNUC__
+#define FI_DEPRECATED_FUNC __attribute__((deprecated))
+#define FI_DEPRECATED_FIELD __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define FI_DEPRECATED_FUNC __declspec(deprecated)
+#define FI_DEPRECATED_FIELD
+#else
+#define FI_DEPRECATED_FUNC
+#define FI_DEPRECATED_FIELD
+#endif
+
 #if defined(_WIN32)
 #include <BaseTsd.h>
 #include <windows.h>

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -267,6 +267,7 @@ enum {
 #define FI_RX_CQ_DATA		(1ULL << 56)
 #define FI_LOCAL_MR		(1ULL << 55)
 #define FI_NOTIFY_FLAGS_ONLY	(1ULL << 54)
+#define FI_RESTRICTED_COMP	(1ULL << 53)
 
 struct fi_tx_attr {
 	uint64_t		caps;

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -253,6 +253,7 @@ enum {
 #define FI_ASYNC_IOV		(1ULL << 57)
 #define FI_RX_CQ_DATA		(1ULL << 56)
 #define FI_LOCAL_MR		(1ULL << 55)
+#define FI_NOTIFY_FLAGS_ONLY	(1ULL << 54)
 
 struct fi_tx_attr {
 	uint64_t		caps;

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -146,6 +146,8 @@ typedef struct fid *fid_t;
 #define FI_AFFINITY		(1ULL << 29)
 
 /* fi_getinfo()-specific flags/caps */
+#define FI_LOCAL_COMM		(1ULL << 51)
+#define FI_REMOTE_COMM		(1ULL << 52)
 #define FI_SHARED_AV		(1ULL << 53)
 #define FI_PROV_ATTR_ONLY	(1ULL << 54)
 #define FI_NUMERICHOST		(1ULL << 55)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -310,6 +310,7 @@ struct fi_domain_attr {
 	size_t			max_ep_rx_ctx;
 	size_t			max_ep_stx_ctx;
 	size_t			max_ep_srx_ctx;
+	size_t			cntr_cnt;
 };
 
 struct fi_fabric_attr {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -219,8 +219,8 @@ enum fi_ep_type {
 	FI_EP_MSG,
 	FI_EP_DGRAM,
 	FI_EP_RDM,
-	/* FI_EP_RAW, */
-	/* FI_EP_PACKET, */
+	FI_EP_SOCK_STREAM,
+	FI_EP_SOCK_DGRAM,
 };
 
 /* Endpoint protocol

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -340,6 +340,7 @@ struct fi_fabric_attr {
 	char			*prov_name;
 	uint32_t		prov_version;
 	uint32_t		api_version;
+	char			*comp_list;
 };
 
 struct fi_info {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -171,7 +171,8 @@ enum {
 	FI_ADDR_PSMX,		/* uint64_t */
 	FI_ADDR_GNI,
 	FI_ADDR_BGQ,
-	FI_ADDR_MLX
+	FI_ADDR_MLX,
+	FI_ADDR_STR,		/* formatted char * */
 };
 
 #define FI_ADDR_UNSPEC		((uint64_t) -1)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -121,6 +121,7 @@ typedef struct fid *fid_t;
 #define FI_TAGGED		(1ULL << 3)
 #define FI_ATOMIC		(1ULL << 4)
 #define FI_ATOMICS		FI_ATOMIC
+#define FI_MULTICAST		(1ULL << 5)
 
 #define FI_READ			(1ULL << 8)
 #define FI_WRITE		(1ULL << 9)
@@ -377,7 +378,8 @@ enum {
 	FI_CLASS_CNTR,
 	FI_CLASS_WAIT,
 	FI_CLASS_POLL,
-	FI_CLASS_CONNREQ
+	FI_CLASS_CONNREQ,
+	FI_CLASS_MC,
 };
 
 struct fi_eq_attr;

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -317,6 +317,7 @@ struct fi_fabric_attr {
 	char			*name;
 	char			*prov_name;
 	uint32_t		prov_version;
+	uint32_t		api_version;
 };
 
 struct fi_info {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -324,6 +324,7 @@ struct fi_domain_attr {
 	size_t			max_ep_stx_ctx;
 	size_t			max_ep_srx_ctx;
 	size_t			cntr_cnt;
+	size_t			mr_iov_limit;
 };
 
 struct fi_fabric_attr {

--- a/include/rdma/fi_cm.h
+++ b/include/rdma/fi_cm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -41,6 +41,11 @@ extern "C" {
 #endif
 
 
+struct fid_mc {
+	struct fid		fid;
+	fi_addr_t		fi_addr;
+};
+
 struct fi_ops_cm {
 	size_t	size;
 	int	(*setname)(fid_t fid, void *addr, size_t addrlen);
@@ -53,6 +58,8 @@ struct fi_ops_cm {
 	int	(*reject)(struct fid_pep *pep, fid_t handle,
 			const void *param, size_t paramlen);
 	int	(*shutdown)(struct fid_ep *ep, uint64_t flags);
+	int	(*join)(struct fid_ep *ep, const void *addr, uint64_t flags,
+			struct fid_mc **mc, void *context);
 };
 
 
@@ -107,6 +114,18 @@ fi_reject(struct fid_pep *pep, fid_t handle,
 static inline int fi_shutdown(struct fid_ep *ep, uint64_t flags)
 {
 	return ep->cm->shutdown(ep, flags);
+}
+
+static inline int fi_join(struct fid_ep *ep, const void *addr, uint64_t flags,
+			  struct fid_mc **mc, void *context)
+{
+	return FI_CHECK_OP(ep->cm, struct fi_ops_cm, join) ?
+		ep->cm->join(ep, addr, flags, mc, context) : -FI_ENOSYS;
+}
+
+static inline fi_addr_t fi_mc_addr(struct fid_mc *mc)
+{
+	return mc->fi_addr;
 }
 
 #endif

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -48,6 +48,8 @@ extern "C" {
  */
 
 #define FI_SYMMETRIC		(1ULL << 59)
+#define FI_SYNC_ERR		(1ULL << 58)
+
 
 struct fi_av_attr {
 	enum fi_av_type		type;

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -231,13 +231,13 @@ fi_rx_context(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 	return ep->ops->rx_ctx(ep, index, attr, rx_ep, context);
 }
 
-static inline ssize_t
+static inline FI_DEPRECATED_FUNC ssize_t
 fi_rx_size_left(struct fid_ep *ep)
 {
 	return ep->ops->rx_size_left(ep);
 }
 
-static inline ssize_t
+static inline FI_DEPRECATED_FUNC ssize_t
 fi_tx_size_left(struct fid_ep *ep)
 {
 	return ep->ops->tx_size_left(ep);

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -128,6 +128,7 @@ enum {
 	FI_SHUTDOWN,
 	FI_MR_COMPLETE,
 	FI_AV_COMPLETE,
+	FI_JOIN_COMPLETE,
 };
 
 struct fi_eq_entry {

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -38,6 +38,7 @@
 #endif /* _WIN32 */
 
 #include <rdma/fabric.h>
+#include <rdma/fi_errno.h>
 
 
 #ifdef __cplusplus
@@ -289,6 +290,8 @@ struct fi_ops_cntr {
 	int	(*add)(struct fid_cntr *cntr, uint64_t value);
 	int	(*set)(struct fid_cntr *cntr, uint64_t value);
 	int	(*wait)(struct fid_cntr *cntr, uint64_t threshold, int timeout);
+	int	(*adderr)(struct fid_cntr *cntr, uint64_t value);
+	int	(*seterr)(struct fid_cntr *cntr, uint64_t value);
 };
 
 struct fid_cntr {
@@ -433,9 +436,21 @@ static inline int fi_cntr_add(struct fid_cntr *cntr, uint64_t value)
 	return cntr->ops->add(cntr, value);
 }
 
+static inline int fi_cntr_adderr(struct fid_cntr *cntr, uint64_t value)
+{
+	return FI_CHECK_OP(cntr->ops, struct fi_ops_cntr, adderr) ?
+		cntr->ops->adderr(cntr, value) : -FI_ENOSYS;
+}
+
 static inline int fi_cntr_set(struct fid_cntr *cntr, uint64_t value)
 {
 	return cntr->ops->set(cntr, value);
+}
+
+static inline int fi_cntr_seterr(struct fid_cntr *cntr, uint64_t value)
+{
+	return FI_CHECK_OP(cntr->ops, struct fi_ops_cntr, seterr) ?
+		cntr->ops->seterr(cntr, value) : -FI_ENOSYS;
 }
 
 static inline int

--- a/include/rdma/fi_errno.h
+++ b/include/rdma/fi_errno.h
@@ -192,6 +192,7 @@ enum {
 	FI_ETRUNC        = 265, /* Truncation error */
 	FI_ENOKEY        = 266, /* Required key not available */
 	FI_ENOAV	 = 267, /* Missing or unavailable address vector */
+	FI_EOVERRUN	 = 268, /* Queue has been overrun */
 	FI_ERRNO_MAX
 };
 

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -16,3 +16,10 @@ FABRIC_1.0 {
 		@FI_DIRECT_PROVIDER_API_10@
 	local: *;
 };
+
+FABRIC_1.1 {
+	global:
+		fi_getinfo;
+		fi_freeinfo;
+		fi_dupinfo;
+} FABRIC_1.0;

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -22,4 +22,5 @@ FABRIC_1.1 {
 		fi_getinfo;
 		fi_freeinfo;
 		fi_dupinfo;
+		fi_fabric;
 } FABRIC_1.0;

--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -43,7 +43,11 @@ uint64_t fi_cntr_readerr(struct fid_cntr *cntr);
 
 int fi_cntr_add(struct fid_cntr *cntr, uint64_t value);
 
+int fi_cntr_adderr(struct fid_cntr *cntr, uint64_t value);
+
 int fi_cntr_set(struct fid_cntr *cntr, uint64_t value);
+
+int fi_cntr_seterr(struct fid_cntr *cntr, uint64_t value);
 
 int fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold,
     int timeout);
@@ -86,7 +90,8 @@ request.
 
 Counters typically only count successful completions.  However, if an
 operation completes in error, it may increment an associated error
-value.
+value.  That is, a counter actually stores two distinct values, with
+error completions updating an error specific value.
 
 ## fi_cntr_open
 
@@ -170,7 +175,6 @@ receive contexts or memory regions associated with the counter.  If resources
 are still associated with the counter when attempting to close, the call will
 return -FI_EBUSY.
 
-
 ## fi_cntr_control
 
 The fi_cntr_control call is used to access provider or implementation
@@ -205,9 +209,17 @@ error and were unable to update the counter.
 
 This adds the user-specified value to the counter.
 
+## fi_cntr_adderr
+
+This adds the user-specified value to the error value of the counter.
+
 ## fi_cntr_set
 
 This sets the counter to the specified value.
+
+## fi_cntr_seterr
+
+This sets the error value of the counter to the specified value.
 
 ## fi_cntr_wait
 

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -567,6 +567,12 @@ operation.  The following completion flags are defined.
 A completion queue must be bound to at least one enabled endpoint before any
 operation such as fi_cq_read, fi_cq_readfrom, fi_cq_sread, fi_cq_sreadfrom etc.
 can be called on it.
+
+Completion flags may be suppressed if the FI_NOTIFY_FLAGS_ONLY mode bit
+has been set.  When enabled, only the following flags are guaranteed to
+be set in completion data when they are valid: FI_REMOTE_READ and
+FI_REMOTE_WRITE (when FI_RMA_EVENT capability bit has been set),
+FI_REMOTE_CQ_DATA, and FI_MULTI_RECV.
  
 # RETURN VALUES
 

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -320,17 +320,30 @@ commands are usable with a CQ.
   object will be written.  See fi_eq.3 for addition details using
   fi_control with FI_GETWAIT.
 
-## fi_cq_read / fi_cq_readfrom
+## fi_cq_read
 
-The fi_cq_read and fi_cq_readfrom operations perform a non-blocking
+The fi_cq_read operation performs a non-blocking
 read of completion data from the CQ.  The format of the completion
 event is determined using the fi_cq_format option that was specified
 when the CQ was opened.  Multiple completions may be retrieved from a
 CQ in a single call.  The maximum number of entries to return is
 limited to the specified count parameter, with the number of entries
-successfully read from the CQ returned by the call.
+successfully read from the CQ returned by the call.  (See return
+values section below.)
 
-The fi_cq_readfrom call allows the CQ to return source address
+CQs are optimized to report operations which have completed
+successfully.  Operations which fail are reported 'out of band'.  Such
+operations are retrieved using the fi_cq_readerr function.  When an
+operation that has completed with an unexpected error is encountered,
+it is placed into a temporary error queue.  Attempting to read
+from a CQ while an item is in the error queue results in fi_cq_read
+failing with a return code of -FI_EAVAIL.  Applications may use this
+return code to determine when to call fi_cq_readerr.
+
+## fi_cq_readfrom
+
+The fi_cq_readfrom call behaves identical to fi_cq_read, with the
+exception that it allows the CQ to return source address
 information to the user for any received data.  Source address data is
 only available for those endpoints configured with FI_SOURCE
 capability.  If fi_cq_readfrom is called on an endpoint for which
@@ -338,14 +351,16 @@ source addressing data is not available, the source address will be
 set to FI_ADDR_NOTAVAIL.  The number of input src_addr entries must
 the the same as the count parameter.
 
-CQs are optimized to report operations which have completed
-successfully.  Operations which fail are reported 'out of band'.  Such
-operations are retrieved using the fi_cq_readerr function.  When an
-operation that completes with an unexpected error is inserted into a
-CQ, it is placed into a temporary error queue.  Attempting to read
-from a CQ while an item is in the error queue results in a failure
-with a return code of -FI_EAVAIL.  Applications may use this return 
-code to determine when to call fi_cq_readerr.
+Returned source addressing data is converted from the native address
+used by the underlying fabric into an fi_addr_t, which may be used in
+transmit operations.  Returning fi_addr_t requires that the source
+address be inserted into the address vector associated with the
+receiving endpoint.  For applications using API version 1.5 and later
+(specified through the fi_getinfo call), if the source address has not
+been inserted into the address vector, fi_cq_readfrom will return
+-FI_EAVAIL.  The completion will then be reported through
+fi_cq_readerr with error code -FI_EADDRNOTAVAIL.  See fi_cq_readerr
+for details.
 
 ## fi_cq_sread / fi_cq_sreadfrom
 
@@ -390,6 +405,20 @@ reference an internal buffer owned by the provider.  The contents of
 the buffer will remain valid until a subsequent read call against the
 CQ.  Users may call fi_cq_strerror to convert provider specific error
 information into a printable string for debugging purposes.
+
+Notable completion error codes are given below.
+
+*FI_EADDRNOTAVAIL*
+: This error code is used by CQs configured with FI_SOURCE to report
+  completions for which a matching fi_addr_t source address could not
+  be found.  An error code of FI_EADDRNOTAVAIL indicates that the data
+  transfer was successfully received and processed, with the
+  fi_cq_err_entry fields containing information about the completion.
+  The err_data field will be set to the source address data.  The
+  source address will be in the same format as specified through
+  the fi_info addr_format field for the opened domain. This may be
+  pass directly into an fi_av_insert call to add the source address
+  to the address vector.
 
 ## fi_cq_signal
 

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -574,6 +574,15 @@ be set in completion data when they are valid: FI_REMOTE_READ and
 FI_REMOTE_WRITE (when FI_RMA_EVENT capability bit has been set),
 FI_REMOTE_CQ_DATA, and FI_MULTI_RECV.
  
+# NOTES
+
+If a completion queue has been overrun, it will be placed into an 'overrun'
+state.  Read operations will continue to return any valid, non-corrupted
+completions, if available.  After all valid completions have been retrieved,
+any attempt to read the CQ will result in it returning an FI_EOVERRUN error
+event.  Overrun completion queues are considered fatal and may not be used
+to report additional completions once the overrun occurs.
+
 # RETURN VALUES
 
 fi_cq_open / fi_cq_signal

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -523,6 +523,10 @@ operation.  The following completion flags are defined.
 : Indicates that a tagged message operation completed.  This flag may be
   combined with an FI_SEND or FI_RECV flag.
 
+*FI_MULTICAST*
+: Indicates that a multicast operation completed.  This flag may be combined
+  with FI_MSG and relevant flags.
+
 *FI_READ*
 : Indicates that a locally initiated RMA or atomic read operation has
   completed.  This flag may be combined with an FI_RMA or FI_ATOMIC flag.

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -512,6 +512,21 @@ that a single memory registration operation may reference.
 Domain level capabilities.  Domain capabilities indicate domain
 level features that are supported by the provider.
 
+*FI_LOCAL_COMM*
+: At a conceptual level, this field indicates that the underlying device
+  supports loopback communication.  More specifically, this field
+  indicates that an endpoint may communicate with other endpoints that
+  are allocated from the same underlying named domain.  If this field
+  is not set, an application may need to use an alternate domain or
+  mechanism (e.g. shared memory) to communicate with peers that execute
+  on the same node.
+
+*FI_REMOTE_COMM*
+: This field indicates that the underlying provider supports communication
+  with nodes that are reachable over the network.  If this field is not set,
+  then the provider only supports communication between processes that
+  execute on the same node -- a shared memory provider, for example.
+
 *FI_SHARED_AV*
 : Indicates that the domain supports the ability to share address
   vectors among multiple processes using the named address vector

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -127,6 +127,7 @@ struct fi_domain_attr {
 	size_t                max_ep_stx_ctx;
 	size_t                max_ep_srx_ctx;
 	size_t                cntr_cnt;
+	size_t                mr_iov_limit;
 };
 ```
 
@@ -498,6 +499,11 @@ The optimal number of completion counters supported by the domain.
 The cq_cnt value may be a fixed value of the maximum number of counters
 supported by the underlying hardware, or may be a dynamic value, based on
 the default attributes of the domain.
+
+## MR IOV Limit (mr_iov_limit)
+
+This is the maximum number of IO vectors (scatter-gather elements)
+that a single memory registration operation may reference.
 
 # RETURN VALUE
 

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -521,6 +521,11 @@ level features that are supported by the provider.
 
 The operational mode bit related to using the domain.
 
+*FI_RESTRICTED_COMP*
+: This bit indicates that the domain limits completion queues and counters
+  to only be used with endpoints, transmit contexts, and receive contexts that
+  have the same set of capability flags.
+
 # RETURN VALUE
 
 Returns 0 on success. On error, a negative value corresponding to fabric

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -126,6 +126,7 @@ struct fi_domain_attr {
 	size_t                max_ep_rx_ctx;
 	size_t                max_ep_stx_ctx;
 	size_t                max_ep_srx_ctx;
+	size_t                cntr_cnt;
 };
 ```
 
@@ -490,6 +491,13 @@ shared transmit context.
 
 The maximum number of endpoints that may be associated with a
 shared receive context.
+
+## Counter Count (cntr_cnt)
+
+The optimal number of completion counters supported by the domain.
+The cq_cnt value may be a fixed value of the maximum number of counters
+supported by the underlying hardware, or may be a dynamic value, based on
+the default attributes of the domain.
 
 # RETURN VALUE
 

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -128,6 +128,8 @@ struct fi_domain_attr {
 	size_t                max_ep_srx_ctx;
 	size_t                cntr_cnt;
 	size_t                mr_iov_limit;
+	uint64_t              caps;
+	uint64_t              mode;
 };
 ```
 
@@ -504,6 +506,15 @@ the default attributes of the domain.
 
 This is the maximum number of IO vectors (scatter-gather elements)
 that a single memory registration operation may reference.
+
+## Capabilities (caps)
+
+Domain level capabilities.  Domain capabilities indicate domain
+level features that are supported by the provider.
+
+## mode
+
+The operational mode bit related to using the domain.
 
 # RETURN VALUE
 

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -512,6 +512,11 @@ that a single memory registration operation may reference.
 Domain level capabilities.  Domain capabilities indicate domain
 level features that are supported by the provider.
 
+*FI_SHARED_AV*
+: Indicates that the domain supports the ability to share address
+  vectors among multiple processes using the named address vector
+  feature.
+
 ## mode
 
 The operational mode bit related to using the domain.

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -544,6 +544,8 @@ struct fi_ep_attr {
 	uint64_t        mem_tag_format;
 	size_t          tx_ctx_cnt;
 	size_t          rx_ctx_cnt;
+	size_t          auth_keylen;
+	uint8_t         *auth_key;
 };
 {% endhighlight %}
 
@@ -760,6 +762,21 @@ fail the request.
 
 See the scalable endpoint and shared contexts sections for additional
 details.
+
+## auth_keylen - Authorization Key Length
+
+The length of the authorization key.  This field will be 0 if
+authorization keys are not available or used.
+
+## auth_key - Authorization Key
+
+If supported by the fabric, an authorization key (a.k.a. job
+key) to associate with the endpoint.  An authorization key is used
+to limit communication between endpoints.  Only peer endpoints that are
+programmed to use the same authorization key may communicate.
+Authorization keys are often used to implement job keys, to ensure
+that processes running in different jobs do not accidentally
+cross traffic.
 
 # TRANSMIT CONTEXT ATTRIBUTES
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -40,9 +40,10 @@ fi_getopt / fi_setopt
 fi_rx_context / fi_tx_context / fi_srx_context  / fi_stx_context
 :   Open a transmit or receive context.
 
-fi_rx_size_left / fi_tx_size_left
+fi_rx_size_left / fi_tx_size_left (DEPRECATED)
 :   Query the lower bound on how many RX/TX operations may be posted without
-    an operation returning -FI_EAGAIN.
+    an operation returning -FI_EAGAIN.  This functions have been deprecated
+    and will be removed in a future version of the library.
 
 # SYNOPSIS
 
@@ -98,9 +99,9 @@ int fi_getopt(struct fid *ep, int level, int optname,
 int fi_setopt(struct fid *ep, int level, int optname,
     const void *optval, size_t optlen);
 
-ssize_t fi_rx_size_left(struct fid_ep *ep);
+DEPRECATED ssize_t fi_rx_size_left(struct fid_ep *ep);
 
-ssize_t fi_tx_size_left(struct fid_ep *ep);
+DEPRECATED ssize_t fi_tx_size_left(struct fid_ep *ep);
 ```
 
 # ARGUMENTS
@@ -489,7 +490,10 @@ The following option levels and option names and parameters are defined.
   the maximum size of the data that may be present as part of a connection
   request event. This option is read only.
 
-## fi_rx_size_left
+## fi_rx_size_left (DEPRECATED)
+
+This function has been deprecated and will be removed in a future version
+of the library.  It may not be supported by all providers.
 
 The fi_rx_size_left call returns a lower bound on the number of receive
 operations that may be posted to the given endpoint without that operation
@@ -498,7 +502,10 @@ posted receive operations (e.g., number of iov entries, which receive function
 is called, etc.), it may be possible to post more receive operations than
 originally indicated by fi_rx_size_left.
 
-## fi_tx_size_left
+## fi_tx_size_left (DEPRECATED)
+
+This function has been deprecated and will be removed in a future version
+of the library.  It may not be supported by all providers.
 
 The fi_tx_size_left call returns a lower bound on the number of transmit
 operations that may be posted to the given endpoint without that operation

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -1014,13 +1014,21 @@ the _Transmit Context Attribute_ section.
 
 ## total_buffered_recv
 
-Defines the total available space allocated by the provider to buffer messages
-that are received for which there is no matching receive operation.  That is,
-this defines the minimal amount of receive side buffering available.  If
-receive side buffering is disabled (total_buffered_recv = 0) and a message is
-received by an endpoint, then the behavior is dependent on whether resource
-management has been enabled (FI_RM_ENABLED has be set or not).  See
-the Resource Management section of fi_domain.3 for further clarification.
+This field is supported for backwards compatibility purposes.
+It is a hint to the provider of the total available space
+that may be needed to buffer messages that are received for which there
+is no matching receive operation.  The provider may adjust or ignore
+this value.  The allocation of internal network buffering among received
+message is provider specific.  For instance, a provider may limit the size
+of messages which can be buffered or the amount of buffering allocated to
+a single message.
+
+If receive side buffering is disabled (total_buffered_recv = 0)
+and a message is received by an endpoint, then the behavior is dependent on
+whether resource management has been enabled (FI_RM_ENABLED has be set or not).
+See the Resource Management section of fi_domain.3 for further clarification.
+It is recommended that applications enable resource management if they
+anticipate receiving unexpected messages, rather than modifying this value.
 
 ## size
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -1276,6 +1276,11 @@ value of transmit or receive context attributes of an endpoint.
   the source endpoint is also considered a destination endpoint.  This is the
   default completion mode for such operations.
 
+*FI_MULTICAST*
+: Indicates that data transfers will target multicast addresses by default.
+  Any fi_addr_t passed into a data transfer operation will be treated as a
+  multicast address.
+
 # NOTES
 
 Users should call fi_close to release all resources allocated to the

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -361,6 +361,11 @@ binding an endpoint to a counter, the following flags may be specified.
   the given endpoint.  Use of this flag requires that the
   endpoint be created using FI_RMA_EVENT.
 
+An endpoint may only be bound to a single CQ or counter for a given
+type of operation.  For example, a EP may not bind to two counters
+both using FI_WRITE.  Furthermore, providers may limit CQ and counter
+bindings to endpoints of the same endpoint type (DGRAM, MSG, RDM, etc.).
+
 Connectionless endpoints must be bound to a single address vector.
 If an endpoint is using a shared transmit and/or receive context, the
 shared contexts must be bound to the endpoint.  CQs, counters, AV, and

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -412,15 +412,21 @@ period of time.
 
 This call creates an alias to the specified endpoint.  Conceptually,
 an endpoint alias provides an alternate software path from the
-application to the underlying provider hardware.  Applications
-configure an alias endpoint with data transfer flags, specified
-through the fi_ep_alias call. The flags must include FI_TRANSMIT or FI_RECV
-(not both) with other flags OR'ed to indicate the type of data transfer the
-flags should apply to. This will override the transmit and receive attributes
-of the alias endpoint. Typically the attributes of the alias endpoint are
-different than those assigned to the actual endpoint. The alias mechanism
-allows a single endpoint to have multiple optimized software interfaces.
-All allocated aliases must be closed for the underlying endpoint to be released.
+application to the underlying provider hardware.  An alias EP differs
+from its parent endpoint only by its default data transfer flags.  For
+example, an alias EP may be configured to use a different completion
+mode.  By default, an alias EP inherits the same data transfer flags
+as the parent endpoint.  An application can use fi_control to modify
+the alias EP operational flags.
+
+When allocating an alias, an application may configure either the transmit
+or receive operational flags.  This avoids needing a separate call to
+fi_control to set those flags.  The flags passed to fi_ep_alias must
+include FI_TRANSMIT or FI_RECV (not both) with other operational flags OR'ed
+in.  This will override the transmit or receive flags,
+respectively, for operations posted through the alias endpoint.
+All allocated aliases must be closed for the underlying endpoint to be
+released.
 
 ## fi_control
 

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -410,6 +410,16 @@ user-accessible.  The contents of the buffer will remain valid until a
 subsequent read call against the EQ.  Applications which read the err_data
 buffer must ensure that they do not read past the end of the referenced buffer.
 
+# NOTES
+
+If an event queue has been overrun, it will be placed into an 'overrun'
+state.  Write operations against an overrun EQ will fail with -FI_EOVERRUN.
+Read operations will continue to return any valid, non-corrupted events, if
+available.  After all valid events have been retrieved, any attempt to read
+the EQ will result in it returning an FI_EOVERRUN error event.  Overrun
+event queues are considered fatal and may not be used to report additional
+events once the overrun occurs.
+
 # RETURN VALUES
 
 fi_eq_open

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -243,8 +243,8 @@ information regarding the format associated with each event.
 *Asynchronous Control Operations*
 : Asynchronous control operations are basic requests that simply need
   to generate an event to indicate that they have completed.  These
-  include the following types of events: memory registration and address
-  vector resolution.
+  include the following types of events: memory registration, address
+  vector resolution, and multicast joins.
 
   Control requests report their completion by inserting a `struct
   fi_eq_entry` into the EQ.  The format of this structure is:
@@ -261,8 +261,9 @@ struct fi_eq_entry {
   returned event will indicate the operation that has completed, and
   the fid will reference the fabric descriptor associated with
   the event.  For memory registration, this will be an FI_MR_COMPLETE
-  event and the fid_mr; address resolution will reference an
-  FI_AV_COMPLETE event and fid_av.  The context field will be set
+  event and the fid_mr.  Address resolution will reference an
+  FI_AV_COMPLETE event and fid_av.  Multicast joins will report an
+  FI_JOIN_COMPLETE and fid_mc.  The context field will be set
   to the context specified as part of the operation, if available,
   otherwise the context will be associated with the fabric descriptor.
   The data field will be set as described in the man page for the

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -139,6 +139,7 @@ struct fi_fabric_attr {
 	char              *prov_name;
 	uint32_t          prov_version;
 	uint32_t          api_version;
+	char              *comp_list;
 };
 ```
 
@@ -154,7 +155,7 @@ instance.  If no instance has been opened, this field will be NULL.
 
 A fabric identifier.
 
-## prov_name
+## prov_name - Provider Name
 
 The name of the underlying fabric provider.
 
@@ -168,7 +169,7 @@ Applications which need a specific set of providers should implement
 their own filtering of fi_getinfo's results rather than relying on these
 environment variables in a production setting.
 
-## prov_version
+## prov_version - Provider Version
 
 Version information for the fabric provider.
 
@@ -176,6 +177,19 @@ Version information for the fabric provider.
 
 The interface version requested by the application.  This value corresponds to
 the version parameter passed into `fi_getinfo(3)`.
+
+## comp_list - Component List
+
+This string lists details of the selected software implementation.  Its use
+is primarily for debugging purposes to indicate which software components
+are in use by a provider.  Direct application use of this field is currently
+reserved and undefined.
+
+The component list is a comma separated set of string identifiers, each
+corresponding to a specific core or utility provider or feature.  On input
+to fi_getinfo, if an identifier is preceded by a '^', then the corresponding
+component will be excluded from any output.  Otherwise, all selected
+components will be included as part of the output.
 
 # RETURN VALUE
 

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -138,6 +138,7 @@ struct fi_fabric_attr {
 	char              *name;
 	char              *prov_name;
 	uint32_t          prov_version;
+	uint32_t          api_version;
 };
 ```
 
@@ -170,6 +171,11 @@ environment variables in a production setting.
 ## prov_version
 
 Version information for the fabric provider.
+
+## api_version
+
+The interface version requested by the application.  This value corresponds to
+the version parameter passed into `fi_getinfo(3)`.
 
 # RETURN VALUE
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -362,6 +362,23 @@ additional optimizations.
   used to enforce ordering between operations that are not otherwise
   guaranteed by the underlying provider or protocol.
 
+*FI_LOCAL_COMM*
+: Indicates that the endpoint support host local communication.  This
+  flag may be used in conjunction with FI_REMOTE_COMM to indicate that
+  local and remote communication are required.  If neither FI_LOCAL_COMM
+  or FI_REMOTE_COMM are specified, then the provider will indicate
+  support for the configuration that minimally affects performance.
+  Providers that set FI_LOCAL_COMM but not FI_REMOTE_COMM, for example
+  a shared memory provider, may only be used to communication between
+  processes on the same system.
+
+*FI_REMOTE_COMM*
+: Indicates that the endpoint support communication with endpoints
+  located at remote nodes (across the fabric).  See FI_LOCAL_COMM for
+  additional details.  Providers that set FI_REMOTE_COMM but not
+  FI_LOCAL_COMM, for example NICs that lack loopback support, cannot
+  be used to communicate with processes on the same system.
+
 Capabilities may be grouped into two general categories: primary and
 secondary.  Primary capabilities must explicitly be requested by an
 application, and a provider must enable support for only those primary
@@ -376,7 +393,7 @@ FI_DIRECTED_RECV, FI_READ, FI_WRITE, FI_RECV, FI_SEND, FI_REMOTE_READ,
 and FI_REMOTE_WRITE.
 
 Secondary capabilities: FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_SHARED_AV,
-FI_TRIGGER, FI_FENCE.
+FI_TRIGGER, FI_FENCE, FI_LOCAL_COMM, FI_REMOTE_COMM.
 
 # MODE
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -168,13 +168,19 @@ struct fi_info {
 *src_addr - source address*
 : If specified, indicates the source address.  This field will be
   ignored in hints if FI_SOURCE flag is set.  On output a provider shall
-  return an address that corresponds to the indicated fabric or domain,
-  with the format indicated by the returned *addr_format* field.
+  return an address that corresponds to the indicated fabric, domain,
+  node, and/or service fields.  The format of the address is indicated
+  by the returned *addr_format* field.  Note that any returned address
+  is only used when opening a local endpoint.  The address is not
+  guaranteed to be usable by a peer process.
 
 *dest_addr - destination address*
 : If specified, indicates the destination address.  This field will be
   ignored in hints unless the node and service parameters are NULL or
-  FI_SOURCE flag is set.
+  FI_SOURCE flag is set.  If FI_SOURCE is not specified, on output a
+  provider shall return an address the corresponds to the indicated
+  node and/or service fields, relative to the fabric and domain.  Note
+  that any returned address is only usable locally.
 
 *handle - provider context handle*
 : References a provider specific handle.  The use of this field

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -89,7 +89,13 @@ Node, service, or hints may be provided, with any combination
 being supported.  If node is provided, fi_getinfo will attempt to
 resolve the fabric address to the given node.  If node is not given,
 fi_getinfo will attempt to resolve the fabric addressing information
-based on the provided hints.
+based on the provided hints.  Node is commonly used to provide a network
+address (such as an IP address) or hostname.  Service is usually
+associated with a transport address (such as a TCP port number).  Node
+and service parameters may be mapped by providers to native fabric
+addresses.  Applications may also pass in an FI_ADDR_STR formatted
+address (see format details below) as the node parameter.  In such cases,
+the service parameter must be NULL.
 
 The hints parameter, if provided, may be used to limit the resulting
 output as indicated below.  As a general rule, specifying a non-zero
@@ -508,6 +514,14 @@ fabric.  See `fi_av`(3).
 *FI_ADDR_GNI*
 : Address is a Cray proprietary format that is used with their GNI
   protocol.
+
+*FI_ADDR_STR*
+: Address is a formatted character string.  The length and content of
+  the string is address and/or provider specific, but follows this model:
+
+  address_family[;[node][;[service][;[field3]...]]]
+
+  Examples: AF_INET;10.31.6.12;7471, AF_INET;;7471
 
 # FLAGS
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -481,6 +481,11 @@ supported set of modes will be returned in the info structure(s).
   be set when applicable.  See `fi_cq`(3) for details on which completion
   flags are valid when this mode bit is enabled.
 
+*FI_RESTRICTED_COMP*
+: This bit indicates that the application will only share completion queues
+  and counters among endpoints, transmit contexts, and receive contexts that
+  have the same set of capability flags.
+
 # ADDRESSING FORMATS
 
 Multiple fabric interfaces take as input either a source or

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -455,6 +455,15 @@ supported set of modes will be returned in the info structure(s).
   receive buffer at the target.  This is true even for operations that would
   normally not consume posted receive buffers, such as RMA write operations.
 
+*FI_NOTIFY_FLAGS_ONLY*
+: This bit indicates that general completion flags may not be set by
+  the provider, and are not needed by the application.  If specified,
+  completion flags which simply report the type of operation that
+  completed (e.g. send or receive) may not be set.  However,
+  completion flags that are used for remote notifications will still
+  be set when applicable.  See `fi_cq`(3) for details on which completion
+  flags are valid when this mode bit is enabled.
+
 # ADDRESSING FORMATS
 
 Multiple fabric interfaces take as input either a source or

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -286,6 +286,11 @@ additional optimizations.
   FI_WRITE, FI_REMOTE_READ, and FI_REMOTE_WRITE flags to restrict the
   types of atomic operations supported by an endpoint.
 
+*FI_MULTICAST*
+: Indicates that the endpoint support multicast data transfers.  This
+  capability must be paired with at least one other data transfer capability,
+  (e.g. FI_MSG, FI_SEND, FI_RECV, ...).
+
 *FI_NAMED_RX_CTX*
 : Requests that endpoints which support multiple receive contexts
   allow an initiator to target (or name) a specific receive context as

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -345,6 +345,10 @@ additional optimizations.
   flag requires that FI_REMOTE_READ and/or FI_REMOTE_WRITE be enabled on
   the endpoint.
 
+*FI_SHARED_AV*
+: Requests or indicates support for address vectors which may be shared
+  among multiple processes.
+
 *FI_TRIGGER*
 : Indicates that the endpoint should support triggered operations.
   Endpoints support this capability must meet the usage model as
@@ -371,7 +375,8 @@ Primary capabilities: FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_NAMED_RX_CTX,
 FI_DIRECTED_RECV, FI_READ, FI_WRITE, FI_RECV, FI_SEND, FI_REMOTE_READ,
 and FI_REMOTE_WRITE.
 
-Secondary capabilities: FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_TRIGGER, FI_FENCE.
+Secondary capabilities: FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_SHARED_AV,
+FI_TRIGGER, FI_FENCE.
 
 # MODE
 

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -109,6 +109,12 @@ Similar to the send operations, receive operations operate
 asynchronously.  Users should not touch the posted data buffer(s)
 until the receive operation has completed.
 
+An endpoint must be enabled before an application can post send
+or receive operations to it.  For connected endpoints, receive
+buffers may be posted prior to connect or accept being called on
+the endpoint.  This ensures that buffers are available to receive
+incoming data immediately after the connection has been established.
+
 Completed message operations are reported to the user through one or
 more event collectors associated with the endpoint.  Users provide
 context which are associated with each operation, and is returned to

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -270,6 +270,12 @@ fi_sendmsg.
   known as the fenced operation, be deferred until all previous operations
   targeting the same target endpoint have completed.
 
+*FI_MULTICAST*
+: Applies to transmits.  This flag indicates that the address specified
+  as the data transfer destination is a multicast address.  This flag must
+  be used in all multicast transfers, in conjunction with a multicast
+  fi_addr_t.
+
 # NOTES
 
 If an endpoint has been configured with FI_MSG_PREFIX, the application

--- a/man/fi_provider.7.md
+++ b/man/fi_provider.7.md
@@ -56,6 +56,28 @@ This distribution of libfabric contains the following providers
 *Blue Gene/Q*
 : See [`fi_bgq`(7)](fi_bgq.7.html) for more information.
 
+# CORE VERSUS UTILITY PROVIDERS
+
+The providers listed above are referred to as core providers.  Core
+providers implement the libfabric interfaces directly over low-level
+hardware and software interfaces.  They are designed to support a
+specific class of hardware, and may be limited to supporting a single
+NIC.  Core providers often only support libfabric features and interfaces
+that map efficiently to their underlying hardware.
+
+Utility providers are distinct from core providers in that they are not
+associated with specific classes of devices.  They instead work with
+core providers to expand their features, and interact with core providers
+through libfabric interfaces internally.  Utility providers are often used
+to support a specific endpoint type over a simpler endpoint type.  For
+example, the RXD provider implements reliability over unreliable datagram
+endpoints.
+
+Utility providers show up as a component in the core provider's component
+list.  See [`fi_fabric`(3)`](fi_fabric.7.html).  Utility providers are
+enabled automatically for core providers that do not support the feature
+set requested by an application.
+
 # PROVIDER REQUIREMENTS
 
 Libfabric provides a general framework for supporting multiple types

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -130,6 +130,12 @@ until the receive operation has completed.  Posted receive buffers are
 matched with inbound send messages based on the tags associated with
 the send and receive buffers.
 
+An endpoint must be enabled before an application can post send
+or receive operations to it.  For connected endpoints, receive
+buffers may be posted prior to connect or accept being called on
+the endpoint.  This ensures that buffers are available to receive
+incoming data immediately after the connection has been established.
+
 Completed message operations are reported to the user through one or
 more event collectors associated with the endpoint.  Users provide
 context which are associated with each operation, and is returned to

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -68,7 +68,7 @@ static void rxd_fini(void)
 }
 
 struct fi_provider rxd_prov = {
-	.name = "rxd",
+	.name = "ofi-rxd",
 	.version = FI_VERSION(RXD_MAJOR_VERSION, RXD_MINOR_VERSION),
 	.fi_version = RXD_FI_VERSION,
 	.getinfo = rxd_getinfo,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -81,7 +81,7 @@ static void rxm_fini(void)
 }
 
 struct fi_provider rxm_prov = {
-	.name = "rxm",
+	.name = "ofi-rxm",
 	.version = FI_VERSION(RXM_MAJOR_VERSION, RXM_MINOR_VERSION),
 	.fi_version = FI_VERSION(1, 3),
 	.getinfo = rxm_getinfo,

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -176,3 +176,18 @@ int fi_getinfo_1_0(uint32_t version, const char *node, const char *service,
 			  (struct fi_info **) info);
 }
 COMPAT_SYMVER(fi_getinfo_1_0, fi_getinfo, FABRIC_1.0);
+
+__attribute__((visibility ("default")))
+int fi_fabric_1_0(struct fi_fabric_attr_1_0 *attr_1_0,
+		  struct fid_fabric **fabric, void *context)
+{
+	struct fi_fabric_attr attr;
+
+	if (!attr_1_0)
+		return -FI_EINVAL;
+
+	memcpy(&attr, attr_1_0, sizeof(*attr_1_0));
+	attr.api_version = FI_VERSION(1, 0);
+	return fi_fabric(&attr, fabric, context);
+}
+COMPAT_SYMVER(fi_fabric_1_0, fi_fabric, FABRIC_1.0);

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2016 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+#include <rdma/fabric.h>
+#include <fi_abi.h>
+
+
+/*
+ * TODO: Add structures that change between 1.0 and 1.1
+ */
+struct fi_info_1_0 {
+	struct fi_info		*next;
+	uint64_t		caps;
+	uint64_t		mode;
+	uint32_t		addr_format;
+	size_t			src_addrlen;
+	size_t			dest_addrlen;
+	void			*src_addr;
+	void			*dest_addr;
+	fid_t			handle;
+	struct fi_tx_attr	*tx_attr;
+	struct fi_rx_attr	*rx_attr;
+	struct fi_ep_attr	*ep_attr;
+	struct fi_domain_attr	*domain_attr;
+	struct fi_fabric_attr	*fabric_attr;
+};
+
+
+/*
+ * TODO: translate from 1.0 structures to 1.1 where needed on all calls below.
+ */
+__attribute__((visibility ("default")))
+int fi_getinfo_1_0(uint32_t version, const char *node, const char *service,
+		    uint64_t flags, struct fi_info_1_0 *hints,
+		    struct fi_info_1_0 **info)
+{
+	return fi_getinfo(version, node, service, flags,
+			  (struct fi_info *) hints,
+			  (struct fi_info **) info);
+}
+COMPAT_SYMVER(fi_getinfo_1_0, fi_getinfo, FABRIC_1.0);
+
+__attribute__((visibility ("default")))
+void fi_freeinfo_1_0(struct fi_info_1_0 *info)
+{
+	fi_freeinfo((struct fi_info *) info);
+}
+COMPAT_SYMVER(fi_freeinfo_1_0, fi_freeinfo, FABRIC_1.0);
+
+__attribute__((visibility ("default")))
+struct fi_info_1_0 *fi_dupinfo_1_0(const struct fi_info_1_0 *info)
+{
+	return (struct fi_info_1_0 *) fi_dupinfo((const struct fi_info *) info);
+}
+COMPAT_SYMVER(fi_dupinfo_1_0, fi_dupinfo, FABRIC_1.0);

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -43,6 +43,13 @@
 /*
  * TODO: Add structures that change between 1.0 and 1.1
  */
+struct fi_fabric_attr_1_0 {
+	struct fid_fabric	*fabric;
+	char			*name;
+	char			*prov_name;
+	uint32_t		prov_version;
+};
+
 struct fi_info_1_0 {
 	struct fi_info		*next;
 	uint64_t		caps;

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -52,6 +52,27 @@ struct fi_fabric_attr_1_0 {
 	uint32_t			prov_version;
 };
 
+struct fi_domain_attr_1_0 {
+	struct fid_domain		*domain;
+	char				*name;
+	enum fi_threading		threading;
+	enum fi_progress		control_progress;
+	enum fi_progress		data_progress;
+	enum fi_resource_mgmt		resource_mgmt;
+	enum fi_av_type			av_type;
+	enum fi_mr_mode			mr_mode;
+	size_t				mr_key_size;
+	size_t				cq_data_size;
+	size_t				cq_cnt;
+	size_t				ep_cnt;
+	size_t				tx_ctx_cnt;
+	size_t				rx_ctx_cnt;
+	size_t				max_ep_tx_ctx;
+	size_t				max_ep_rx_ctx;
+	size_t				max_ep_stx_ctx;
+	size_t				max_ep_srx_ctx;
+};
+
 struct fi_info_1_0 {
 	struct fi_info			*next;
 	uint64_t			caps;
@@ -65,7 +86,7 @@ struct fi_info_1_0 {
 	struct fi_tx_attr		*tx_attr;
 	struct fi_rx_attr		*rx_attr;
 	struct fi_ep_attr		*ep_attr;
-	struct fi_domain_attr		*domain_attr;
+	struct fi_domain_attr_1_0	*domain_attr;
 	struct fi_fabric_attr_1_0	*fabric_attr;
 };
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -574,6 +574,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 					tail->fabric_attr->prov_name);
 			tail->fabric_attr->prov_name = strdup(prov->provider->name);
 			tail->fabric_attr->prov_version = prov->provider->version;
+			tail->fabric_attr->api_version = version;
 		}
 		if (tail->fabric_attr->prov_name != NULL)
 			FI_WARN(&core_prov, FI_LOG_CORE,
@@ -581,6 +582,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 				tail->fabric_attr->prov_name);
 		tail->fabric_attr->prov_name = strdup(prov->provider->name);
 		tail->fabric_attr->prov_version = prov->provider->version;
+		tail->fabric_attr->api_version = version;
 	}
 
 	return *info ? 0 : -FI_ENODATA;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -712,7 +712,7 @@ int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr,
 
 	return prov->provider->fabric(attr, fabric, context);
 }
-DEFAULT_SYMVER(fi_fabric_, fi_fabric, FABRIC_1.0);
+CURRENT_SYMVER(fi_fabric_, fi_fabric);
 
 __attribute__((visibility ("default")))
 uint32_t DEFAULT_SYMVER_PRE(fi_version)(void)

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -472,7 +472,7 @@ void DEFAULT_SYMVER_PRE(fi_freeinfo)(struct fi_info *info)
 		free(info);
 	}
 }
-DEFAULT_SYMVER(fi_freeinfo_, fi_freeinfo);
+CURRENT_SYMVER(fi_freeinfo_, fi_freeinfo);
 
 /* Make a dummy info object for each provider, and copy in the
  * provider name and version */
@@ -517,8 +517,9 @@ err:
 }
 
 __attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const char *service,
-	       uint64_t flags, struct fi_info *hints, struct fi_info **info)
+int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
+		const char *service, uint64_t flags,
+		struct fi_info *hints, struct fi_info **info)
 {
 	struct fi_prov *prov;
 	struct fi_info *tail, *cur;
@@ -584,7 +585,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 
 	return *info ? 0 : -FI_ENODATA;
 }
-DEFAULT_SYMVER(fi_getinfo_, fi_getinfo);
+CURRENT_SYMVER(fi_getinfo_, fi_getinfo);
 
 static struct fi_info *fi_allocinfo_internal(void)
 {
@@ -689,10 +690,11 @@ fail:
 	fi_freeinfo(dup);
 	return NULL;
 }
-DEFAULT_SYMVER(fi_dupinfo_, fi_dupinfo);
+CURRENT_SYMVER(fi_dupinfo_, fi_dupinfo);
 
 __attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr, struct fid_fabric **fabric, void *context)
+int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr,
+		struct fid_fabric **fabric, void *context)
 {
 	struct fi_prov *prov;
 
@@ -708,14 +710,14 @@ int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr, struct fid_fabric
 
 	return prov->provider->fabric(attr, fabric, context);
 }
-DEFAULT_SYMVER(fi_fabric_, fi_fabric);
+DEFAULT_SYMVER(fi_fabric_, fi_fabric, FABRIC_1.0);
 
 __attribute__((visibility ("default")))
 uint32_t DEFAULT_SYMVER_PRE(fi_version)(void)
 {
 	return FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION);
 }
-DEFAULT_SYMVER(fi_version_, fi_version);
+DEFAULT_SYMVER(fi_version_, fi_version, FABRIC_1.0);
 
 static const char *const errstr[] = {
 	[FI_EOTHER - FI_ERRNO_OFFSET] = "Unspecified error",
@@ -742,4 +744,4 @@ const char *DEFAULT_SYMVER_PRE(fi_strerror)(int errnum)
 	else
 		return errstr[FI_EOTHER - FI_ERRNO_OFFSET];
 }
-DEFAULT_SYMVER(fi_strerror_, fi_strerror);
+DEFAULT_SYMVER(fi_strerror_, fi_strerror, FABRIC_1.0);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -734,6 +734,7 @@ static const char *const errstr[] = {
 	[FI_ETRUNC - FI_ERRNO_OFFSET] = "Truncation error",
 	[FI_ENOKEY - FI_ERRNO_OFFSET] = "Required key not available",
 	[FI_ENOAV - FI_ERRNO_OFFSET] = "Missing or unavailable address vector",
+	[FI_EOVERRUN - FI_ERRNO_OFFSET] = "Queue has been overrun",
 };
 
 __attribute__((visibility ("default")))

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -589,7 +589,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 }
 CURRENT_SYMVER(fi_getinfo_, fi_getinfo);
 
-static struct fi_info *fi_allocinfo_internal(void)
+struct fi_info *ofi_allocinfo_internal(void)
 {
 	struct fi_info *info;
 
@@ -619,7 +619,7 @@ struct fi_info *DEFAULT_SYMVER_PRE(fi_dupinfo)(const struct fi_info *info)
 	struct fi_info *dup;
 
 	if (!info)
-		return fi_allocinfo_internal();
+		return ofi_allocinfo_internal();
 
 	dup = mem_dup(info, sizeof(*dup));
 	if (dup == NULL) {

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -484,6 +484,8 @@ static void fi_tostr_fabric_attr(char *buf, const struct fi_fabric_attr *attr,
 	strcatf(buf, "%s%sprov_name: %s\n", prefix, TAB, attr->prov_name);
 	strcatf(buf, "%s%sprov_version: %d.%d\n", prefix, TAB,
 		FI_MAJOR(attr->prov_version), FI_MINOR(attr->prov_version));
+	strcatf(buf, "%s%sapi_version: %d.%d\n", prefix, TAB,
+		FI_MAJOR(attr->api_version), FI_MINOR(attr->api_version));
 }
 
 static void fi_tostr_info(char *buf, const struct fi_info *info)

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -469,6 +469,7 @@ static void fi_tostr_domain_attr(char *buf, const struct fi_domain_attr *attr,
 	strcatf(buf, "%s%smax_ep_rx_ctx: %zd\n", prefix, TAB, attr->max_ep_rx_ctx);
 	strcatf(buf, "%s%smax_ep_stx_ctx: %zd\n", prefix, TAB, attr->max_ep_stx_ctx);
 	strcatf(buf, "%s%smax_ep_srx_ctx: %zd\n", prefix, TAB, attr->max_ep_srx_ctx);
+	strcatf(buf, "%s%scntr_cnt: %zd\n", prefix, TAB, attr->cntr_cnt);
 }
 
 static void fi_tostr_fabric_attr(char *buf, const struct fi_fabric_attr *attr,

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -248,6 +248,7 @@ static void fi_tostr_mode(char *buf, uint64_t mode)
 	IFFLAGSTR(mode, FI_ASYNC_IOV);
 	IFFLAGSTR(mode, FI_RX_CQ_DATA);
 	IFFLAGSTR(mode, FI_LOCAL_MR);
+	IFFLAGSTR(mode, FI_NOTIFY_FLAGS_ONLY);
 
 	fi_remove_comma(buf);
 }

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -696,7 +696,7 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 	}
 	return buf;
 }
-DEFAULT_SYMVER(fi_tostr_, fi_tostr);
+DEFAULT_SYMVER(fi_tostr_, fi_tostr, FABRIC_1.0);
 
 #undef CASEENUMSTR
 #undef IFFLAGSTR

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -208,6 +208,8 @@ static void fi_tostr_ep_type(char *buf, enum fi_ep_type ep_type)
 	CASEENUMSTR(FI_EP_MSG);
 	CASEENUMSTR(FI_EP_DGRAM);
 	CASEENUMSTR(FI_EP_RDM);
+	CASEENUMSTR(FI_EP_SOCK_STREAM);
+	CASEENUMSTR(FI_EP_SOCK_DGRAM);
 	default:
 		strcatf(buf, "Unknown");
 		break;

--- a/src/log.c
+++ b/src/log.c
@@ -128,8 +128,9 @@ void fi_log_fini(void)
 }
 
 __attribute__((visibility ("default")))
-int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov, enum fi_log_level level,
-		   enum fi_log_subsys subsys)
+int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov,
+		enum fi_log_level level,
+		enum fi_log_subsys subsys)
 {
 	struct fi_prov_context *ctx;
 
@@ -137,12 +138,12 @@ int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov, enum fi_l
 	return ((FI_LOG_TAG(ctx->disable_logging, level, subsys) & log_mask) ==
 		FI_LOG_TAG(ctx->disable_logging, level, subsys));
 }
-DEFAULT_SYMVER(fi_log_enabled_, fi_log_enabled);
+DEFAULT_SYMVER(fi_log_enabled_, fi_log_enabled, FABRIC_1.0);
 
 __attribute__((visibility ("default")))
 void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_level level,
-	    enum fi_log_subsys subsys, const char *func, int line,
-	    const char *fmt, ...)
+		enum fi_log_subsys subsys, const char *func, int line,
+		const char *fmt, ...)
 {
 	char buf[1024];
 	int size;
@@ -159,4 +160,4 @@ void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_leve
 
 	fprintf(stderr, "%s", buf);
 }
-DEFAULT_SYMVER(fi_log_, fi_log);
+DEFAULT_SYMVER(fi_log_, fi_log, FABRIC_1.0);

--- a/src/var.c
+++ b/src/var.c
@@ -123,7 +123,7 @@ out:
 	*params = vhead;
 	return FI_SUCCESS;
 }
-DEFAULT_SYMVER(fi_getparams_, fi_getparams);
+DEFAULT_SYMVER(fi_getparams_, fi_getparams, FABRIC_1.0);
 
 __attribute__((visibility ("default")))
 void DEFAULT_SYMVER_PRE(fi_freeparams)(struct fi_param *params)
@@ -135,7 +135,7 @@ void DEFAULT_SYMVER_PRE(fi_freeparams)(struct fi_param *params)
 	}
 	free(params);
 }
-DEFAULT_SYMVER(fi_freeparams_, fi_freeparams);
+DEFAULT_SYMVER(fi_freeparams_, fi_freeparams, FABRIC_1.0);
 
 static void fi_free_param(struct fi_param_entry *param)
 {
@@ -221,7 +221,7 @@ int DEFAULT_SYMVER_PRE(fi_param_define)(const struct fi_provider *provider,
 	FI_INFO(provider, FI_LOG_CORE, "registered var %s\n", param_name);
 	return FI_SUCCESS;
 }
-DEFAULT_SYMVER(fi_param_define_, fi_param_define);
+DEFAULT_SYMVER(fi_param_define_, fi_param_define, FABRIC_1.0);
 
 static int fi_parse_bool(const char *str_value)
 {
@@ -296,7 +296,7 @@ int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 out:
 	return ret;
 }
-DEFAULT_SYMVER(fi_param_get_, fi_param_get);
+DEFAULT_SYMVER(fi_param_get_, fi_param_get, FABRIC_1.0);
 
 
 void fi_param_init(void)


### PR DESCRIPTION
This is a series of patches for what will be an ABI bump from 1.0 to 1.1 (likely release 1.5).  These will mostly be updates to man pages and header files that introduce the new semantics.  If accepted, between the merging of the patches and an actual release, providers will need to be updated to support the new behavior, where needed.

Note that not all of these changes actually require bumping the ABI.
