### PR TITLE
fixed potential build issue in udpx init

### DIFF
--- a/prov/udp/src/udpx_init.c
+++ b/prov/udp/src/udpx_init.c
@@ -89,7 +89,7 @@ static void udpx_getinfo_ifs(struct fi_info **info)
 	}
 }
 #else
-#define udpx_get_interfaces(info)
+#define udpx_getinfo_ifs(info) do{}while(0)
 #endif
 
 int udpx_check_info(struct fi_info *info)


### PR DESCRIPTION
there was typo in macro declaration which may break
compilation of udp provider

this PR is safe to be included into 1.4 (in case if it happen :) )

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>