### PR TITLE
fixed windows build of info tool

### DIFF
--- a/util/windows/getopt/getopt.h
+++ b/util/windows/getopt/getopt.h
@@ -21,6 +21,10 @@ extern "C" {
 extern char* optarg;
 extern int   optind, opterr, optopt;
 
+#ifndef strcasecmp
+#  define strcasecmp lstrcmpiA
+#endif /* strcasecmp */
+
 #ifndef no_argument
 #    define no_argument        0
 #endif /* no_argument */


### PR DESCRIPTION
there is no strcasecmp call in windows, but there is
call lstrcmpiA/W calls with same semantics. Added
macro to wrap strcasecmp

this PR is safe to be included into 1.4 (in case if it happen)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>