### PR TITLE
prov/verbs: improved close protocol for EP_RDM

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -47,8 +47,8 @@
 #define FI_IBV_RDM_EAGER_PKT		0
 #define FI_IBV_RDM_RNDV_RTS_PKT		1
 #define FI_IBV_RDM_RNDV_ACK_PKT		2
-#define FI_IBV_RDM_RMA_PKT		3
-#define FI_IBV_RDM_MSG_PKT		4
+#define FI_IBV_RDM_MSG_PKT		3
+#define FI_IBV_RDM_DISCONNECT_PKT	100
 #define FI_IBV_RDM_SET_PKTTYPE(dest, type) (dest |= type)
 #define FI_IBV_RDM_GET_PKTTYPE(value) (value & FI_IBV_RDM_ST_PKTTYPE_MASK)
 
@@ -290,8 +290,8 @@ enum {
 	FI_VERBS_CONN_STARTED,
 	FI_VERBS_CONN_REJECTED,
 	FI_VERBS_CONN_ESTABLISHED,
-	FI_VERBS_CONN_LOCAL_DISCONNECT,
-	FI_VERBS_CONN_REMOTE_DISCONNECT,
+	FI_VERBS_CONN_DISCONNECT_REQUESTED,
+	FI_VERBS_CONN_DISCONNECT_STARTED,
 	FI_VERBS_CONN_CLOSED
 };
 
@@ -493,7 +493,8 @@ static inline void fi_ibv_rdm_cntr_inc_err(struct fi_ibv_rdm_cntr *cntr)
 
 int fi_ibv_rdm_tagged_poll(struct fi_ibv_rdm_ep *ep);
 ssize_t fi_ibv_rdm_cm_progress(struct fi_ibv_rdm_ep *ep);
-ssize_t fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_conn *conn);
+ssize_t fi_ibv_rdm_start_disconnect(struct fi_ibv_rdm_ep *ep,
+				    struct fi_ibv_rdm_conn *conn);
 ssize_t fi_ibv_rdm_conn_cleanup(struct fi_ibv_rdm_conn *conn);
 ssize_t fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
                                 struct fi_ibv_rdm_conn *conn);

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -563,6 +563,7 @@ ssize_t fi_ibv_rdm_conn_cleanup(struct fi_ibv_rdm_conn *conn)
 			if (ret == FI_SUCCESS)
 				ret = -errno;
 		}
+		conn->id[0] = NULL;
 	}
 
 	if (conn->id[1]) {
@@ -578,6 +579,7 @@ ssize_t fi_ibv_rdm_conn_cleanup(struct fi_ibv_rdm_conn *conn)
 			if (ret == FI_SUCCESS)
 				ret = -errno;
 		}
+		conn->id[1] = NULL;
 	}
 
 	if (conn->s_mr) {
@@ -599,6 +601,7 @@ ssize_t fi_ibv_rdm_conn_cleanup(struct fi_ibv_rdm_conn *conn)
 			if (ret == FI_SUCCESS)
 				ret = -errno;
 		}
+		conn->ack_mr = NULL;
 	}
 
 	if (conn->rma_mr) {
@@ -618,24 +621,22 @@ fi_ibv_rdm_process_event_disconnected(struct fi_ibv_rdm_ep *ep,
 				      struct rdma_cm_event *event)
 {
 	struct fi_ibv_rdm_conn *conn = event->id->context;
+	struct fi_ibv_rdm_conn *tmp = NULL;
 
 	ep->num_active_conns--;
 	
-	if (conn->state == FI_VERBS_CONN_ESTABLISHED) {
-		conn->state = FI_VERBS_CONN_REMOTE_DISCONNECT;
-	} else {
-		assert(conn->state == FI_VERBS_CONN_LOCAL_DISCONNECT);
-		conn->state = FI_VERBS_CONN_CLOSED;
-	}
+	conn->state = FI_VERBS_CONN_CLOSED;
 	VERBS_INFO(FI_LOG_AV,
 		   "Disconnected from conn %p, addr %s:%u\n",
 		   conn, inet_ntoa(conn->addr.sin_addr),
 		   ntohs(conn->addr.sin_port));
-	if (conn->state == FI_VERBS_CONN_CLOSED) {
-		return fi_ibv_rdm_conn_cleanup(conn);
-	}
 
-	return FI_SUCCESS;
+	HASH_FIND(hh, ep->domain->rdm_cm->conn_hash, &conn->addr,
+		  FI_IBV_RDM_DFLT_ADDRLEN, tmp);
+	if (tmp == conn) {
+		HASH_DEL(ep->domain->rdm_cm->conn_hash, conn);
+	}
+	return fi_ibv_rdm_conn_cleanup(conn);
 }
 
 static ssize_t
@@ -685,7 +686,6 @@ fi_ibv_rdm_process_event_rejected(struct fi_ibv_rdm_ep *ep,
 			*(int *)event->param.conn.private_data : 0,
 			event->status, errno);
 		conn->state = FI_VERBS_CONN_REJECTED;
-
 	}
 	return ret;
 }

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -453,15 +453,25 @@ fi_ibv_rdm_process_recv(struct fi_ibv_rdm_ep *ep, struct fi_ibv_rdm_conn *conn,
 			int arrived_len, struct fi_ibv_rdm_buf *rbuf)
 {
 	struct fi_ibv_rdm_request *request = NULL;
-
-	int pkt_type = FI_IBV_RDM_GET_PKTTYPE(rbuf->header.service_tag);
+	uint32_t pkt_type = FI_IBV_RDM_GET_PKTTYPE(rbuf->header.service_tag);
+	struct fi_ibv_recv_got_pkt_preprocess_data p = {
+		.conn = conn,
+		.ep = ep,
+		.rbuf = rbuf,
+		.arrived_len = arrived_len,
+		.pkt_type = pkt_type,
+		.imm_data = 0 // TODO:
+	};
 
 	if (pkt_type == FI_IBV_RDM_RNDV_ACK_PKT) {
 		memcpy(&request, &rbuf->payload, sizeof(request));
 		assert(request);
 		VERBS_DBG(FI_LOG_EP_DATA,
 			"GOT RNDV ACK from conn %p, id %p\n", conn, request);
-	} else if (pkt_type != FI_IBV_RDM_RMA_PKT) {
+	} else if (pkt_type == FI_IBV_RDM_DISCONNECT_PKT) {
+		fi_ibv_rdm_start_disconnect(ep, conn);
+		return;
+	} else {
 		struct fi_ibv_rdm_minfo minfo = {
 			.conn = conn,
 			.tag = rbuf->header.tag,
@@ -497,21 +507,7 @@ fi_ibv_rdm_process_recv(struct fi_ibv_rdm_ep *ep, struct fi_ibv_rdm_conn *conn,
 		}
 	}
 
-	/* RMA packets are not handled yet (without IMM) */
-	if (pkt_type != FI_IBV_RDM_RMA_PKT) {
-
-		struct fi_ibv_recv_got_pkt_preprocess_data p = {
-			.conn = conn,
-			.ep = ep,
-			.rbuf = rbuf,
-			.arrived_len = arrived_len,
-			.pkt_type = pkt_type,
-			.imm_data = 0 // TODO:
-		};
-
-		fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_RECV_GOT_PKT_PROCESS,
-				    &p);
-	}
+	fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_RECV_GOT_PKT_PROCESS, &p);
 }
 
 static inline
@@ -534,7 +530,7 @@ void check_and_repost_receives(struct fi_ibv_rdm_ep *ep,
 	}
 }
 
-static inline int 
+static inline void
 fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 {
 	struct fi_ibv_rdm_conn *conn = (void *) wc->wr_id;
@@ -547,31 +543,10 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 	FI_IBV_DBG_OPCODE(wc->opcode, "RECV");
 
 	if (!FI_IBV_RDM_CHECK_RECV_WC(wc)) {
-
-		VERBS_INFO(FI_LOG_EP_DATA, "conn %p state %d, wc status %d\n",
-			conn, conn->state, wc->status);
-		if (wc->status == IBV_WC_WR_FLUSH_ERR &&
-		    conn->state == FI_VERBS_CONN_ESTABLISHED)
-		{
-			/*
-			 * It means that remote side initiated disconnection
-			 * and QP is flushed earlier then disconnect event was
-			 * handled or arrived. Just initiate disconnect to
-			 * opposite direction.
-			 */
-			fi_ibv_rdm_start_disconnection(conn);
-		} else {
-			assert("Error recv wc\n" &&
-			       (!ep->is_closing ||
-				conn->state != FI_VERBS_CONN_ESTABLISHED));
-		}
-
-		return 1;
-	}
-
-	conn->recv_completions++;
-	if (conn->recv_completions & ep->n_buffs) {
-		conn->recv_completions = 0;
+		VERBS_INFO(FI_LOG_EP_DATA, "conn %p state %d, wc status %d:s\n",
+			conn, conn->state, wc->status,
+			ibv_wc_status_str(wc->status));
+		return;
 	}
 
 	VERBS_DBG(FI_LOG_EP_DATA, "conn %p recv_completions %d\n",
@@ -593,7 +568,7 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 	    fi_ibv_rdm_buffer_check_seq_num(rbuf, conn->recv_processed) : 1))
 	{
 		do {
-			assert(rbuf->service_data.pkt_len > 0);
+			assert(rbuf->service_data.pkt_len >= 0);
 
 			fi_ibv_rdm_process_recv(ep, conn, 
 				rbuf->service_data.pkt_len, rbuf);
@@ -622,8 +597,6 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 		VERBS_DBG(FI_LOG_EP_DATA, "not processed: conn %p, status: %d\n",
 			conn, rbuf->service_data.status);
 	}
-
-	return 0;
 }
 
 static inline int fi_ibv_rdm_tagged_poll_recv(struct fi_ibv_rdm_ep *ep)
@@ -631,75 +604,47 @@ static inline int fi_ibv_rdm_tagged_poll_recv(struct fi_ibv_rdm_ep *ep)
 	const int wc_count = ep->fi_rcq->read_bunch_size;
 	struct ibv_wc wc[wc_count];
 	int ret = 0;
-	int err = 0;
 	int i = 0;
 
 	do {
 		ret = ibv_poll_cq(ep->rcq, wc_count, wc);
-		for (i = 0; i < ret && !err; ++i) {
-			err = fi_ibv_rdm_process_recv_wc(ep, &wc[i]);
+		for (i = 0; i < ret; ++i) {
+			fi_ibv_rdm_process_recv_wc(ep, &wc[i]);
 		}
-	} while (!err && ret == wc_count);
+	} while (ret == wc_count);
 
-	if (!err && ret >= 0) {
-		return FI_SUCCESS;
-	}
-
-	/* error handling */
-
-	VERBS_INFO(FI_LOG_EP_DATA, "ibv_poll_cq returned %d\n", ret);
-
-	for(i = 0; i < wc_count; i++) {
-
-		if (wc[i].status != IBV_WC_SUCCESS) {
-			struct fi_ibv_rdm_conn *conn = (void *)wc[i].wr_id;
-
-			if (wc[i].status == IBV_WC_WR_FLUSH_ERR && conn &&
-				conn->state != FI_VERBS_CONN_ESTABLISHED)
-			{
-				return FI_SUCCESS;
-			}
-
-			VERBS_INFO(FI_LOG_EP_DATA, "got ibv_wc[%d].status = %d:%s\n",
-				i, wc[i].status, ibv_wc_status_str(wc[i].status));
-			return -FI_EOTHER;
-		}
-
-		if (wc[i].opcode != IBV_WC_RECV_RDMA_WITH_IMM &&
-		    wc[i].opcode != IBV_WC_RECV)
-		{
-			VERBS_INFO(FI_LOG_EP_DATA, "got ibv_wc[%d].opcode = %d\n",
-				i, wc[i].opcode);
-		}
-	}
-
-	return -FI_EOTHER;
+	return ret >= 0 ? FI_SUCCESS : -FI_EOTHER;
 }
 
-static inline int
+static inline void
 fi_ibv_rdm_process_send_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 {
-	if (wc->status != IBV_WC_SUCCESS) {
-		return 1;
-	}
+	struct fi_ibv_rdm_conn *conn = NULL;
+	struct fi_ibv_rdm_request *req = NULL;
+	struct fi_ibv_rdm_tagged_send_completed_data data = { .ep = ep };
 
-	if (FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wc->wr_id)) {
+	if (wc->status != IBV_WC_SUCCESS) {
+		if (FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wc->wr_id)) {
+			conn = FI_IBV_RDM_UNPACK_SERVICE_WR(wc->wr_id);
+		} else {
+			req = (void *)wc->wr_id;
+			conn = req->minfo.conn;
+		}
+
+		VERBS_INFO(FI_LOG_EP_DATA,
+			"got ibv_wc.status = %d:%s, pend_send: %d, connection: %p\n",
+			wc->status,
+			ibv_wc_status_str(wc->status),
+			ep->posted_sends, conn);
+	} else if (FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wc->wr_id)) {
 		VERBS_DBG(FI_LOG_EP_DATA, "CQ COMPL: SEND -> 0x1\n");
-		struct fi_ibv_rdm_conn *conn =
-			(struct fi_ibv_rdm_conn *)
+		conn = (struct fi_ibv_rdm_conn *)
 			FI_IBV_RDM_UNPACK_SERVICE_WR(wc->wr_id);
 		FI_IBV_RDM_DEC_SIG_POST_COUNTERS(conn, ep);
-
-		return 0;
 	} else {
 		FI_IBV_DBG_OPCODE(wc->opcode, "SEND");
-		struct fi_ibv_rdm_request *request =
-			(void *)FI_IBV_RDM_UNPACK_WR(wc->wr_id);
-
-		struct fi_ibv_rdm_tagged_send_completed_data data = 
-			{ .ep = ep };
-
-		return fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_POST_LC, &data);
+		req = (void *)FI_IBV_RDM_UNPACK_WR(wc->wr_id);
+		fi_ibv_rdm_req_hndl(req, FI_IBV_EVENT_POST_LC, &data);
 	}
 }
 
@@ -708,20 +653,20 @@ static inline int fi_ibv_rdm_tagged_poll_send(struct fi_ibv_rdm_ep *ep)
 	const int wc_count = ep->fi_scq->read_bunch_size;
 	struct ibv_wc wc[wc_count];
 	int ret = 0;
-	int err = 0;
 	int i = 0;
 
 	if (ep->posted_sends > 0) {
 		do {
 			ret = ibv_poll_cq(ep->scq, wc_count, wc);
-			for (i = 0; i < ret && !err; ++i) {
-				err = fi_ibv_rdm_process_send_wc(ep, &wc[i]);
+			for (i = 0; i < ret; ++i) {
+				fi_ibv_rdm_process_send_wc(ep, &wc[i]);
 			}
-		} while (!err && ret == wc_count);
+		} while (ret == wc_count);
 	}
 
-	if (err || ret < 0) {
-		goto wc_error;
+	if (ret < 0) {
+		VERBS_INFO(FI_LOG_EP_DATA, "ibv_poll_cq returned %d\n", ret);
+		return -FI_EOTHER;
 	}
 
 	struct fi_ibv_rdm_tagged_send_ready_data data = { .ep = ep };
@@ -736,41 +681,12 @@ static inline int fi_ibv_rdm_tagged_poll_send(struct fi_ibv_rdm_ep *ep)
 	}
 
 	return FI_SUCCESS;
-
-wc_error:
-	if (ret < 0) {
-		VERBS_INFO(FI_LOG_EP_DATA, "ibv_poll_cq returned %d\n", ret);
-		assert(0);
-	}
-
-	for (i = 0; i < wc_count; i++) {
-		if (wc[i].status != IBV_WC_SUCCESS) {
-			struct fi_ibv_rdm_conn *conn;
-			if (FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wc[i].wr_id)) {
-				conn = FI_IBV_RDM_UNPACK_SERVICE_WR(wc[i].wr_id);
-			} else {
-				struct fi_ibv_rdm_request *req =
-					(void *)wc[i].wr_id;
-				conn = req->minfo.conn;
-			}
-
-			VERBS_INFO(FI_LOG_EP_DATA,
-				"got ibv_wc.status = %d:%s, pend_send: %d, connection: %p\n",
-				wc[i].status,
-				ibv_wc_status_str(wc[i].status),
-				ep->posted_sends, conn);
-			assert(0);
-		}
-	}
-
-	return -FI_EOTHER;
 }
 
 int fi_ibv_rdm_tagged_poll(struct fi_ibv_rdm_ep *ep)
 {
 	int ret = fi_ibv_rdm_tagged_poll_send(ep);
-	/* Only already posted sends should be processed during EP closing */
-	if (ret || ep->is_closing) {
+	if (ret) {
 		return ret;
 	}
 


### PR DESCRIPTION
Before both sides might initiate disconnection
without assurance that everything were read from
ibv recv queue.

The improvement is in the following:
1) the first process which want to close connection
   requests remote side to start disconnection by
   PKT with special type via the same QP as eager sends
   use.
2) the second process read this pkt and initiate real
   disconnection, the first one is waiting disconnect
   event in CM
3) in case of bidirectional requesting, the first side
   which processes this pkt, initiate real disconnection
   and everything after, for this connection (QP), will
   be ignored, these may be only completions of completion
   requests (PKTs)

@a-ilango @shefty 
