### PR TITLE
prov/gni: Added flush_cache documentation

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -113,6 +113,7 @@ the following:
 struct fi_gni_ops_domain {
 	int (*set_val)(struct fid *fid, dom_ops_val_t t, void *val);
 	int (*get_val)(struct fid *fid, dom_ops_val_t t, void *val);
+	int (*flush_cache)(struct fid *fid);
 };
 
 struct fi_gni_ops_ep {
@@ -206,6 +207,18 @@ The `set_val` function sets the value of a given parameter; the
 
 *GNI_XPMEM_ENABLE*
 : Enable or disable use of XPMEM for on node messages using the GNI provider internal rendezvous protocol.  The value is of type bool.
+
+The `flush_cache` function allows the user to flush any stale registration
+cache entries from the cache. This has the effect of removing registrations
+from the cache that have been deregistered with the provider, but still
+exist in case that they may be reused in the near future. Flushing the stale
+registrations forces hardware-level deregistration of the stale memory
+registrations and frees any memory related to those stale registrations. Only
+the provider-level registration struct is freed, not the user buffer
+associated with the registration.
+The parameter for `flush_cache` is a struct fid pointer to a fi_domain. The
+memory registration cache is tied to the domain, so issuing a `flush_cache` to
+the domain will flush the registration cache of the domain.
 
 For *FI_GNI_EP_OPS_1*, the currently supported values are:
 *GNI_HASH_TAG_IMPL*


### PR DESCRIPTION
Added flush_cache documentation to fi_gni

@sungeunchoi 
upstream merge of ofi-cray/libfabric-cray#995

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@aa7b9ef41720a88c95801f9370f673a1a3e3944c)