### PR TITLE
usnic (v1.1.x): Pad the getinfo extension structures.

### DIFF
--- a/man/fi_usnic.7.md
+++ b/man/fi_usnic.7.md
@@ -79,6 +79,13 @@ extension, which returns IP and SR-IOV information about a usNIC
 interface obtained from the [`fi_getinfo`(3)](fi_getinfo.3.html)
 function.
 
+## Compatibility issues
+
+The 1.3.0 release of Libfabric introduced a version 2 of the getinfo extension
+that caused an alignment issue that could lead to invalid data in the v1
+portion of the structure. This issue was fixed on the v1.1.x branch after the
+v1.1.1 release.
+
 {% highlight c %}
 #include <stdio.h>
 #include <rdma/fabric.h>

--- a/prov/usnic/src/fi_ext_usnic.h
+++ b/prov/usnic/src/fi_ext_usnic.h
@@ -57,14 +57,27 @@ struct fi_usnic_info_v1 {
 	uint32_t ui_num_vf;
 	uint32_t ui_qp_per_vf;
 	uint32_t ui_cq_per_vf;
-};
+} __attribute__((packed));
 
+/* In API version 1.2 and below, the v1 structure did not contain any 64-bit
+ * data types and therefore had a 4-byte alignment. Once v2 of the extension API
+ * was introduced in version 1.3, the extra pointers mandated an 8-byte
+ * alignment thus changing the offset of the v1 structure. This means that the
+ * alignment difference manifests when an application using v1 of the extension
+ * is compiled with Libfabric v1.1.x or v1.2.x, but then runs with libfabric.so
+ * that is v1.3.x or higher (and vice versa). Make the alignment explicit and
+ * consistent by adding an extra 32-bit padding (4 uint8_t). The padding and
+ * packed attribute fix the compatibility issues with 1.3 and above.
+ *
+ * Fixed on the 1.1.x branch after the 1.1.1 release (backported from 1.4rc1).
+ */
 struct fi_usnic_info {
 	uint32_t ui_version;
+	uint8_t ui_pad0[4];
 	union {
 		struct fi_usnic_info_v1 v1;
 	} ui;
-};
+} __attribute__((packed));
 
 /*
  * usNIC-specific fabric ops


### PR DESCRIPTION
The introduction of version 2 of the fi_usnic_info extension in the 1.3
release caused a compatibility issue with older versions of the
extension. This commit adds padding to the structure to explicitly
maintain the alignment requirements for the extension in the 1.3
release. Add explicit padding to all structures used in the getinfo
extension and add the packed attribute.

Relevant documents have been updated to document the issue and recommend
possible solutions.

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>