### PR TITLE
prov/gni: fix problem with FI_MULTI_RECV

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -153,7 +153,7 @@
 
 #define GNIX_MSG_RENDEZVOUS		(1ULL << 61)	/* MSG only flag */
 #define GNIX_MSG_GET_TAIL		(1ULL << 62)	/* MSG only flag */
-#define LAST_FLAG			(1ULL << 63)	/* MSG only flag */
+#define GNIX_MSG_MULTI_RECV_SUP		(1ULL << 63)	/* MSG only flag */
 
 /*
  * Cray gni provider supported flags for fi_getinfo argument for now, needs


### PR DESCRIPTION
GNI provider wasn't properly handling FI_MULTI_RECV
in CQ events.

Fixes ofi-cray/libfabric-cray#965
also closes ofi-cray/libfabric-cray#876

Note this doesn't resolve all issues with GNI provider
FI_MULTI_RECV.  See ofi-cray/libfabric-cray#1003.

Upstream merge of ofi-cray/libfabric-cray/#999

@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@939382053b9dc66ef03cf2a6bf34b342e8b85b1c)