### PR TITLE
build/test: Remove testing of verbs provider build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,17 +25,13 @@ env:
         - LD_LIBRARY_PATH=$HOME/lib
         - LIBFABRIC_CONFIGURE_ARGS="--prefix=$HOME --enable-sockets"
 
-# install dependencies for the verbs and usnic providers
+# install dependencies for the usnic providers
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git clone https://git.kernel.org/pub/scm/libs/infiniband/libibverbs.git ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd libibverbs && ./autogen.sh && ./configure --prefix=$HOME && make && make install && cd .. ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git clone https://github.com/ofiwg/librdmacm.git ; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cd librdmacm && ./autogen.sh && ./configure --prefix=$HOME CC=gcc && make && make install && cd .. ; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew upgrade automake || true; brew upgrade libtool || true; fi
 
 install:
     - ./autogen.sh
-    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "gcc" ]]; then ./configure $LIBFABRIC_CONFIGURE_ARGS --enable-debug --enable-verbs && make -j2; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" && "$CC" == "gcc" ]]; then ./configure $LIBFABRIC_CONFIGURE_ARGS --enable-debug && make -j2; fi
     - ./configure --prefix=$HOME --enable-direct=sockets --enable-udp=no --enable-psm=no --enable-mxm=no --enable-gni=no --enable-psm2=no --enable-verbs=no --enable-usnic=no --enable-rxm=no --enable-rxd=no && make -j2
     - ./configure --enable-sockets=dl --disable-udp --disable-rxm --disable-rxd --disable-verbs --disable-usnic --prefix=$HOME && make -j2  && make install && make test
     - ./configure $LIBFABRIC_CONFIGURE_ARGS


### PR DESCRIPTION
libibverbs and friends were merged into a mega-package with brand new
build tool requirements.  Update.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

yay - build testing via trial and error