### PR TITLE
prov/psm,psm2: Handle FI_SOURCE in fi_getinfo()

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -293,6 +293,16 @@ struct psmx_fid_domain {
 	pthread_t		progress_thread;
 };
 
+#define PSMX_DEFAULT_UNIT	(-1)
+#define PSMX_DEFAULT_PORT	0
+#define PSMX_DEFAULT_SERVICE	0
+
+struct psmx_src_name {
+	int	unit;		/* start from 0. -1 means any */
+	int	port;		/* start from 1. 0 means any */
+	int	service;	/* 0 means any */
+};
+
 struct psmx_cq_event {
 	union {
 		struct fi_cq_entry		context;

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -252,7 +252,8 @@ static int psmx_key_compare(void *key1, void *key2)
 	return (key1 < key2) ? -1 : (key1 > key2);
 }
 
-static int psmx_domain_init(struct psmx_fid_domain *domain)
+static int psmx_domain_init(struct psmx_fid_domain *domain,
+			    struct psmx_src_name *src_addr)
 {
 	struct psmx_fid_fabric *fabric = domain->fabric;
 	struct psm_ep_open_opts opts;
@@ -262,6 +263,13 @@ static int psmx_domain_init(struct psmx_fid_domain *domain)
 
 	FI_INFO(&psmx_prov, FI_LOG_CORE,
 		"uuid: %s\n", psmx_uuid_to_string(fabric->uuid));
+
+	if (src_addr) {
+		opts.unit = src_addr->unit;
+		opts.port = src_addr->port;
+		FI_INFO(&psmx_prov, FI_LOG_CORE,
+			"ep_open_opts: unit=%d port=%u\n", opts.unit, opts.port);
+	}
 
 	err = psm_ep_open(fabric->uuid, &opts,
 			  &domain->psm_ep, &domain->psm_epid);
@@ -390,7 +398,7 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain_priv->progress_thread_enabled =
 		(info->domain_attr->data_progress == FI_PROGRESS_AUTO && psmx_env.prog_thread);
 
-	err = psmx_domain_init(domain_priv);
+	err = psmx_domain_init(domain_priv, info->src_addr);
 	if (err)
 		goto err_out_close_domain;
 

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -369,6 +369,16 @@ struct psmx2_ep_name {
 	uint8_t			vlane;
 };
 
+#define PSMX2_DEFAULT_UNIT	(-1)
+#define PSMX2_DEFAULT_PORT	0
+#define PSMX2_DEFAULT_SERVICE	0
+
+struct psmx2_src_name {
+	int	unit;		/* start from 0. -1 means any */
+	int	port;		/* start from 1. 0 means any */
+	int	service;	/* 0 means any */
+};
+
 struct psmx2_cq_event {
 	union {
 		struct fi_cq_entry		context;

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -254,7 +254,8 @@ static int psmx2_key_compare(void *key1, void *key2)
 	return (key1 < key2) ?  -1 : (key1 > key2);
 }
 
-static int psmx2_domain_init(struct psmx2_fid_domain *domain)
+static int psmx2_domain_init(struct psmx2_fid_domain *domain,
+			     struct psmx2_src_name *src_addr)
 {
 	struct psmx2_fid_fabric *fabric = domain->fabric;
 	struct psm2_ep_open_opts opts;
@@ -264,6 +265,13 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain)
 
 	FI_INFO(&psmx2_prov, FI_LOG_CORE,
 		"uuid: %s\n", psmx2_uuid_to_string(fabric->uuid));
+
+	if (src_addr) {
+		opts.unit = src_addr->unit;
+		opts.port = src_addr->port;
+		FI_INFO(&psmx2_prov, FI_LOG_CORE,
+			"ep_open_opts: unit=%d port=%u\n", opts.unit, opts.port);
+	}
 
 	err = psm2_ep_open(fabric->uuid, &opts,
 			   &domain->psm2_ep, &domain->psm2_epid);
@@ -404,7 +412,7 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain_priv->progress_thread_enabled =
 		(info->domain_attr->data_progress == FI_PROGRESS_AUTO);
 
-	err = psmx2_domain_init(domain_priv);
+	err = psmx2_domain_init(domain_priv, info->src_addr);
 	if (err)
 		goto err_out_close_domain;
 

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -65,7 +65,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 {
 	struct fi_info *psmx2_info;
 	uint32_t cnt = 0;
-	void *dest_addr = NULL;
+	struct psmx2_ep_name *dest_addr = NULL;
+	struct psmx2_src_name *src_addr;
 	int ep_type = FI_EP_RDM;
 	int av_type = FI_AV_UNSPEC;
 	uint64_t mode = FI_CONTEXT;
@@ -95,17 +96,36 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 
 	psmx2_init_env();
 
-	if (node && !(flags & FI_SOURCE)) {
-		dest_addr = psmx2_resolve_name(node, 0);
-		if (dest_addr) {
+	src_addr = calloc(1, sizeof(*src_addr));
+	if (!src_addr) {
+		FI_INFO(&psmx2_prov, FI_LOG_CORE,
+			"failed to allocate src addr.\n");
+		return -FI_ENODATA;
+	}
+	src_addr->unit = PSMX2_DEFAULT_UNIT;
+	src_addr->port = PSMX2_DEFAULT_PORT;
+	src_addr->service = PSMX2_DEFAULT_SERVICE;
+
+	if (node) {
+		if (flags & FI_SOURCE) {
+			sscanf(node, "%*[^:]:%d:%d", &src_addr->unit, &src_addr->port);
+			if (service)
+				sscanf(service, "%d", &src_addr->service);
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"node '%s' resolved to <epid=0x%llx, vl=%d>\n", node,
-				((struct psmx2_ep_name *)dest_addr)->epid,
-				((struct psmx2_ep_name *)dest_addr)->vlane);
+				"node '%s' service '%s' converted to <unit=%d, port=%d, service=%d>\n",
+				node, service, src_addr->unit, src_addr->port, src_addr->service);
 		} else {
-			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"failed to resolve node '%s'.\n", node);
-			return -FI_ENODATA;
+			dest_addr = psmx2_resolve_name(node, 0);
+			if (dest_addr) {
+				FI_INFO(&psmx2_prov, FI_LOG_CORE,
+					"node '%s' resolved to <epid=0x%llx, vl=%d>\n", node,
+					dest_addr->epid, dest_addr->vlane);
+			} else {
+				FI_INFO(&psmx2_prov, FI_LOG_CORE,
+					"failed to resolve node '%s'.\n", node);
+				err = -FI_ENODATA;
+				goto err_out;
+			}
 		}
 	}
 
@@ -430,10 +450,10 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->caps = caps;
 	psmx2_info->mode = mode;
 	psmx2_info->addr_format = FI_ADDR_PSMX;
-	psmx2_info->src_addrlen = 0;
-	psmx2_info->dest_addrlen = sizeof(struct psmx2_ep_name);
-	psmx2_info->src_addr = NULL;
+	psmx2_info->src_addr = src_addr;
+	psmx2_info->src_addrlen = sizeof(*src_addr);
 	psmx2_info->dest_addr = dest_addr;
+	psmx2_info->dest_addrlen = sizeof(*dest_addr);
 	psmx2_info->fabric_attr->name = strdup(PSMX2_FABRIC_NAME);
 	psmx2_info->fabric_attr->prov_name = NULL;
 	psmx2_info->fabric_attr->prov_version = PSMX2_VERSION;
@@ -463,8 +483,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	return 0;
 
 err_out:
-	if (dest_addr)
-		free(dest_addr);
+	free(dest_addr);
+	free(src_addr);
 
 	return err;
 }


### PR DESCRIPTION
When FI_SOURCE is set, allows HCA unit and port selection be passed
via the "node" argument and be saved to the "src_addr" field of fi_info
for later use in local operations. The address should not be used as the
input of fi_av_insert().

The format of "node" is expected to be `"<name>[:<unit>[:<port>]]".` A
simple `"<name>"` implies automatic selection of unit and port.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>