### PR TITLE
Updates to util cmap and rxm provider

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -161,6 +161,7 @@ static inline size_t fi_get_aligned_sz(size_t size, size_t alignment)
 size_t fi_datatype_size(enum fi_datatype datatype);
 uint64_t fi_tag_bits(uint64_t mem_tag_format);
 uint64_t fi_tag_format(uint64_t tag_bits);
+int fi_size_bits(uint64_t num);
 
 int ofi_send_allowed(uint64_t caps);
 int ofi_recv_allowed(uint64_t caps);

--- a/include/fi.h
+++ b/include/fi.h
@@ -185,6 +185,40 @@ static inline int ofi_equals_sockaddr(struct sockaddr_in *addr1,
                 (addr1->sin_port == addr2->sin_port));
 }
 
+/*
+ * Key Index
+ */
+
+/*
+ * The key_idx object and related functions can be used to generate unique keys
+ * from an index. The key and index would refer to an object defined by the user.
+ * A local endpoint can exchange this key with a remote endpoint in the first message.
+ * The remote endpoint would then use this key in subsequent messages to reference
+ * the correct object at the local endpoint.
+ */
+struct ofi_key_idx {
+	uint64_t seq_no;
+	/* The uniqueness of the generated key would depend on how many bits are
+	 * used for the index */
+	uint8_t idx_bits;
+};
+
+static inline void ofi_key_idx_init(struct ofi_key_idx *key_idx, uint8_t idx_bits)
+{
+	key_idx->seq_no = 0;
+	key_idx->idx_bits = idx_bits;
+}
+
+static inline uint64_t ofi_idx2key(struct ofi_key_idx *key_idx, uint64_t idx)
+{
+	return ((++(key_idx->seq_no)) << key_idx->idx_bits) | idx;
+}
+
+static inline uint64_t ofi_key2idx(struct ofi_key_idx *key_idx, uint64_t key)
+{
+	return key & ((1ULL << key_idx->idx_bits) - 1);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -56,6 +56,7 @@
 #include <fi_signal.h>
 #include <fi_enosys.h>
 #include <fi_osd.h>
+#include <fi_indexer.h>
 
 #ifndef _FI_UTIL_H_
 #define _FI_UTIL_H_
@@ -307,6 +308,8 @@ int ofi_av_get_index(struct util_av *av, const void *addr);
  * Connection Map
  */
 
+#define UTIL_CMAP_IDX_BITS 48
+
 enum util_cmap_state {
 	CMAP_UNSPEC,
 	CMAP_CONNECTING,
@@ -316,16 +319,15 @@ enum util_cmap_state {
 struct util_cmap_handle {
 	struct util_cmap *cmap;
 	enum util_cmap_state state;
-	struct util_cmap_key *key;
-	size_t key_index;
+	/* Unique identifier for a connection. Can be exchanged with a peer
+	 * during connection setup and can later be used in a messsage header
+	 * to identify the source of the message (Used for FI_SOURCE, RNDV
+	 * protocol, etc.) */
+	uint64_t key;
+	uint64_t remote_key;
 	fi_addr_t fi_addr;
 	struct util_cmap_peer *peer;
 };
-
-struct util_cmap_key {
-	struct util_cmap_handle *handle;
-};
-DECLARE_FREESTACK(struct util_cmap_key, util_cmap_keypool);
 
 struct util_cmap_peer {
 	struct util_cmap_handle *handle;
@@ -338,13 +340,22 @@ typedef void (*ofi_cmap_free_handle_func)(void *arg);
 
 struct util_cmap {
 	struct util_av *av;
-	struct util_cmap_handle **handles;
-	struct util_cmap_keypool *keypool;
+
+	/* cmap handles that correspond to addresses in AV */
+	struct util_cmap_handle **handles_av;
+
+	/* Store all cmap handles (inclusive of handles_av) in an indexer.
+	 * This allows reverse lookup of the handle using the index. */
+	struct indexer handles_idx;
+
+	struct ofi_key_idx key_idx;
+
 	struct dlist_entry peer_list;
 	ofi_cmap_free_handle_func free_handle;
 	fastlock_t lock;
 };
 
+struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t key);
 void ofi_cmap_update_state(struct util_cmap_handle *handle,
 		enum util_cmap_state state);
 /*

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -358,14 +358,10 @@ struct util_cmap {
 struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t key);
 void ofi_cmap_update_state(struct util_cmap_handle *handle,
 		enum util_cmap_state state);
-/*
- * Caller must hold cmap->lock. Either fi_addr or
- * addr and addrlen args should be present.
- */
+/* Either fi_addr or addr and addrlen args must be given. */
 int ofi_cmap_add_handle(struct util_cmap *cmap, struct util_cmap_handle *handle,
 		enum util_cmap_state state, fi_addr_t fi_addr, void *addr,
 		size_t addrlen);
-/* Caller must hold cmap->lock */
 struct util_cmap_handle *ofi_cmap_get_handle(struct util_cmap *cmap, fi_addr_t fi_addr);
 void ofi_cmap_del_handle(struct util_cmap_handle *handle);
 void ofi_cmap_free(struct util_cmap *cmap);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -56,6 +56,8 @@ static int rxm_msg_cq_read(struct util_cq *util_cq, struct fid_cq *cq,
 		}
 		slist_insert_tail(&entry->list_entry, &util_cq->err_list);
 		comp->flags = UTIL_FLAG_ERROR;
+		cirque_commit(util_cq->cirq);
+		return -FI_EAVAIL;
 	}
 
 	return ret;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -129,16 +129,12 @@ ssize_t rxm_send(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
 	ssize_t ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	fastlock_acquire(&rxm_ep->cmap->lock);
 	ret = rxm_get_msg_ep(rxm_ep, dest_addr, &msg_ep);
 	if (ret)
-		goto unlock;
+		return ret;
 
 	// TODO handle the case when send fails due to connection shutdown
-	ret = fi_send(msg_ep, buf, len, desc, 0, context);
-unlock:
-	fastlock_release(&rxm_ep->cmap->lock);
-	return ret;
+	return fi_send(msg_ep, buf, len, desc, 0, context);
 }
 
 ssize_t rxm_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
@@ -149,15 +145,11 @@ ssize_t rxm_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ssize_t ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	fastlock_acquire(&rxm_ep->cmap->lock);
 	ret = rxm_get_msg_ep(rxm_ep, msg->addr, &msg_ep);
 	if (ret)
-		goto unlock;
+		return ret;
 
-	ret = fi_sendmsg(msg_ep, msg, flags);
-unlock:
-	fastlock_release(&rxm_ep->cmap->lock);
-	return ret;
+	return fi_sendmsg(msg_ep, msg, flags);
 }
 
 ssize_t rxm_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -168,15 +160,11 @@ ssize_t rxm_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	ssize_t ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	fastlock_acquire(&rxm_ep->cmap->lock);
 	ret = rxm_get_msg_ep(rxm_ep, dest_addr, &msg_ep);
 	if (ret)
-		goto unlock;
+		return ret;
 
-	ret = fi_sendv(msg_ep, iov, desc, count, 0, context);
-unlock:
-	fastlock_release(&rxm_ep->cmap->lock);
-	return ret;
+	return fi_sendv(msg_ep, iov, desc, count, 0, context);
 }
 
 ssize_t rxm_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -187,15 +175,11 @@ ssize_t rxm_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	ssize_t ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	fastlock_acquire(&rxm_ep->cmap->lock);
 	ret = rxm_get_msg_ep(rxm_ep, dest_addr, &msg_ep);
 	if (ret)
-		goto unlock;
+		return ret;
 
-	ret = fi_inject(msg_ep, buf, len, 0);
-unlock:
-	fastlock_release(&rxm_ep->cmap->lock);
-	return ret;
+	return fi_inject(msg_ep, buf, len, 0);
 }
 
 static struct fi_ops_msg rxm_msg_ops = {

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1015,6 +1015,42 @@ int ip_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 /*
  * Connection Map
  */
+
+/* Note: Callers should serialize access */
+static void util_cmap_set_key(struct util_cmap_handle *handle)
+{
+	handle->key = ofi_idx2key(&handle->cmap->key_idx,
+		idx_insert(&handle->cmap->handles_idx, handle));
+}
+
+static void util_cmap_clear_key(struct util_cmap_handle *handle)
+{
+	int index = ofi_key2idx(&handle->cmap->key_idx, handle->key);
+	if (index > handle->cmap->handles_idx.size) {
+		FI_WARN(handle->cmap->av->prov, FI_LOG_AV, "Invalid key\n");
+		return;
+	}
+	idx_remove(&handle->cmap->handles_idx, index);
+}
+
+struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t key)
+{
+	struct util_cmap_handle *handle;
+
+	int index = ofi_key2idx(&cmap->key_idx, key);
+	if (index > cmap->handles_idx.size) {
+		FI_WARN(cmap->av->prov, FI_LOG_AV, "Invalid key\n");
+		return NULL;
+	}
+	handle = idx_at(&cmap->handles_idx, index);
+	if (handle->key != key) {
+		FI_WARN(cmap->av->prov, FI_LOG_AV,
+				"handle->key not matching given key\n");
+		return NULL;
+	}
+	return handle;
+}
+
 static void ofi_cmap_init_handle(struct util_cmap_handle *handle,
 		struct util_cmap *cmap,
 		enum util_cmap_state state,
@@ -1023,9 +1059,7 @@ static void ofi_cmap_init_handle(struct util_cmap_handle *handle,
 {
 	handle->cmap = cmap;
 	handle->state = state;
-	handle->key = freestack_pop(cmap->keypool);
-	handle->key->handle = handle;
-	handle->key_index = util_cmap_keypool_index(cmap->keypool, handle->key);
+	util_cmap_set_key(handle);
 	handle->fi_addr = fi_addr;
 	handle->peer = peer;
 }
@@ -1092,12 +1126,12 @@ int ofi_cmap_add_handle(struct util_cmap *cmap, struct util_cmap_handle *handle,
 		fi_addr = index;
 	}
 
-	if (cmap->handles[fi_addr]) {
+	if (cmap->handles_av[fi_addr]) {
 		FI_WARN(cmap->av->prov, FI_LOG_EP_CTRL,
 				"Handle already present\n");
 	} else {
 		ofi_cmap_init_handle(handle, cmap, state, fi_addr, NULL);
-		cmap->handles[fi_addr] = handle;
+		cmap->handles_av[fi_addr] = handle;
 	}
 	return 0;
 }
@@ -1108,9 +1142,10 @@ struct util_cmap_handle *ofi_cmap_get_handle(struct util_cmap *cmap, fi_addr_t f
 	struct util_cmap_peer *peer;
 	struct dlist_entry *entry;
 
-	if (cmap->handles[fi_addr])
-		return cmap->handles[fi_addr];
+	if (cmap->handles_av[fi_addr])
+		return cmap->handles_av[fi_addr];
 
+	// TODO Move this to av_insert
 	/* Search in peer list */
 	entry = dlist_remove_first_match(&cmap->peer_list, ofi_cmap_match_peer,
 			ip_av_get_addr(cmap->av, fi_addr));
@@ -1122,9 +1157,9 @@ struct util_cmap_handle *ofi_cmap_get_handle(struct util_cmap *cmap, fi_addr_t f
 	peer->handle->peer = NULL;
 	peer->handle->fi_addr = fi_addr;
 
-	cmap->handles[fi_addr] = peer->handle;
+	cmap->handles_av[fi_addr] = peer->handle;
 	free(peer);
-	return cmap->handles[fi_addr];
+	return cmap->handles_av[fi_addr];
 }
 
 void ofi_cmap_del_handle(struct util_cmap_handle *handle)
@@ -1136,10 +1171,9 @@ void ofi_cmap_del_handle(struct util_cmap_handle *handle)
 		dlist_remove(&handle->peer->entry);
 		free(handle->peer);
 	} else {
-		cmap->handles[handle->fi_addr] = 0;
+		cmap->handles_av[handle->fi_addr] = 0;
 	}
-	handle->key->handle = NULL;
-	freestack_push(cmap->keypool, handle->key);
+	util_cmap_clear_key(handle);
 	cmap->free_handle(handle);
 	fastlock_release(&cmap->lock);
 }
@@ -1151,8 +1185,8 @@ void ofi_cmap_del_handles(struct util_cmap *cmap)
 	int i;
 
 	for (i = 0; i < cmap->av->count; i++) {
-		if (cmap->handles[i])
-			ofi_cmap_del_handle(cmap->handles[i]);
+		if (cmap->handles_av[i])
+			ofi_cmap_del_handle(cmap->handles_av[i]);
 	}
 	dlist_foreach(&cmap->peer_list, entry) {
 		peer = container_of(entry, struct util_cmap_peer, entry);
@@ -1164,8 +1198,7 @@ void ofi_cmap_free(struct util_cmap *cmap)
 {
 	ofi_cmap_del_handles(cmap);
 	fastlock_acquire(&cmap->lock);
-	util_cmap_keypool_free(cmap->keypool);
-	free(cmap->handles);
+	free(cmap->handles_av);
 	fastlock_release(&cmap->lock);
 	free(cmap);
 }
@@ -1181,21 +1214,18 @@ struct util_cmap *ofi_cmap_alloc(struct util_av *av,
 
 	cmap->av = av;
 
-	cmap->handles = calloc(cmap->av->count, sizeof(*cmap->handles));
-	if (!cmap->handles)
+	cmap->handles_av = calloc(cmap->av->count, sizeof(*cmap->handles_av));
+	if (!cmap->handles_av)
 		goto err1;
 
-	cmap->keypool = util_cmap_keypool_create(cmap->av->count);
-	if (!cmap->keypool)
-		goto err2;
+	memset(&cmap->handles_idx, 0, sizeof(cmap->handles_idx));
+	ofi_key_idx_init(&cmap->key_idx, UTIL_CMAP_IDX_BITS);
 
 	dlist_init(&cmap->peer_list);
 	cmap->free_handle = free_handle;
 	fastlock_init(&cmap->lock);
 
 	return cmap;
-err2:
-	free(cmap->handles);
 err1:
 	free(cmap);
 	return NULL;

--- a/src/common.c
+++ b/src/common.c
@@ -78,6 +78,13 @@ uint64_t fi_tag_format(uint64_t tag_bits)
 	return FI_TAG_GENERIC >> (ffsll(htonll(tag_bits)) - 1);
 }
 
+int fi_size_bits(uint64_t num)
+{
+	int size_bits = 0;
+	while (num >> ++size_bits);
+	return size_bits;
+}
+
 static const size_t fi_datatype_size_table[] = {
 	[FI_INT8]   = sizeof(int8_t),
 	[FI_UINT8]  = sizeof(uint8_t),


### PR DESCRIPTION
Use indexer for assigning cmap handle's key. Remove cmap locking requirements and update rxm provider w.r.t cmap locks.
