### PR TITLE
prov/verbs: fix inititialization on several devices

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -180,8 +180,6 @@ int fi_ibv_rdm_req_match_by_info3(struct dlist_entry *item, const void *info);
 int fi_ibv_rdm_postponed_process(struct dlist_entry *item, const void *arg);
 void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_conn *conn,
 				  struct fi_ibv_rdm_ep *ep);
-int fi_ibv_rdm_find_ipoib_addr(const struct sockaddr_in *addr,
-			       struct sockaddr_in *ipoib_addr);
 
 ssize_t fi_ibv_rdm_send_common(struct fi_ibv_rdm_send_start_data* sdata);
 ssize_t rdm_trecv_second_event(struct fi_ibv_rdm_request *request,

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -70,15 +70,10 @@ int fi_ibv_sockaddr_len(struct sockaddr *addr)
 int fi_ibv_rdm_cm_bind_ep(struct fi_ibv_rdm_cm *cm, struct fi_ibv_rdm_ep *ep)
 {
 	char my_ipoib_addr_str[INET6_ADDRSTRLEN];
-	struct sockaddr_in* src_addr = (struct sockaddr_in*)ep->rai->ai_src_addr;
 
 	assert(cm->ec && cm->listener);
 
-	if (fi_ibv_rdm_find_ipoib_addr(src_addr, &ep->my_addr)) {
-		VERBS_INFO(FI_LOG_EP_CTRL, 
-			   "Failed to find correct IPoIB address\n");
-		return -FI_ENODEV;
-	}
+	memcpy(&ep->my_addr, ep->domain->info->src_addr, sizeof(ep->my_addr));
 
 	inet_ntop(ep->my_addr.sin_family,
 		  &ep->my_addr.sin_addr.s_addr,


### PR DESCRIPTION
The patch fixes the case then there are several devices in the system
and IPoIB is not configured for all ones. If user tried to initialize
fi_info from other device, it's failing on connection establishment
phase because of verbs context mismatch.

The fix adds cleanup of all rdm-domains which aren't binded to some
interface or explicite defined interface (via env variable)

@a-ilango , please review