### PR TITLE
Disable clock_gettime workaround for OSX version 10.12.

### DIFF
--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -46,18 +46,15 @@
 
 #include "unix/osd.h"
 
+#include <AvailabilityMacros.h>
+#ifndef MAC_OS_X_VERSION_10_12
+#define MAC_OS_X_VERSION_10_12 101200
+#endif
+
+#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12
+
 #define CLOCK_REALTIME CALENDAR_CLOCK
 #define CLOCK_MONOTONIC SYSTEM_CLOCK
-
-#define pthread_yield pthread_yield_np
-
-#define bswap_64 OSSwapInt64
-
-#ifdef _POSIX_HOST_NAME_MAX
-#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
-#else
-#define HOST_NAME_MAX 255
-#endif
 
 typedef int clockid_t;
 
@@ -66,6 +63,26 @@ extern "C" {
 #endif
 
 int clock_gettime(clockid_t clk_id, struct timespec *tp);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+#ifdef _POSIX_HOST_NAME_MAX
+#define HOST_NAME_MAX _POSIX_HOST_NAME_MAX
+#else
+#define HOST_NAME_MAX 255
+#endif
+
+#define pthread_yield pthread_yield_np
+
+#define bswap_64 OSSwapInt64
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
 {

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -46,12 +46,9 @@
 
 #include "unix/osd.h"
 
-#include <AvailabilityMacros.h>
-#ifndef MAC_OS_X_VERSION_10_12
-#define MAC_OS_X_VERSION_10_12 101200
-#endif
+#include "config.h"
 
-#if MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_X_VERSION_10_12
+#if HAVE_CLOCK_GETTIME == 0
 
 #define CLOCK_REALTIME CALENDAR_CLOCK
 #define CLOCK_MONOTONIC SYSTEM_CLOCK

--- a/src/osx/osd.c
+++ b/src/osx/osd.c
@@ -32,6 +32,8 @@
 
 #include "osx/osd.h"
 
+#if HAVE_CLOCK_GETTIME == 0
+
 int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 	int retval;
 
@@ -47,3 +49,5 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 
 	return retval;
 }
+
+#endif


### PR DESCRIPTION
OSX has clock_gettime() starting from version 10.12. The workaround
breaks the build on OSX 10.12. The patch checks the version of current
OSX and disables the workaround if the version is greater or equal to
10.12.

Signed-off-by: Yanfei Guo yguo@anl.gov
