### PR TITLE
prov/psm2: Bug fix for fi_av_straddr()

### DIFF
--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -346,11 +346,12 @@ static const char *psmx2_av_straddr(struct fid_av *av, const void *addr,
 				    char *buf, size_t *len)
 {
 	int n;
+	const struct psmx2_ep_name *name = addr;
 
 	if (!buf || !len)
 		return NULL;
 
-	n = snprintf(buf, *len, "%lx", (uint64_t)(uintptr_t)addr);
+	n = snprintf(buf, *len, "%lx-%x", name->epid, name->vlane);
 	if (n < 0)
 		return NULL;
 


### PR DESCRIPTION
The stringfied address lacked the "vlane" part of the endpoint
address.

Signed-off-by: Jianxin Xiong jianxin.xiong@intel.com
