### PR TITLE
Fix build on macOS Sierra.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -56,7 +56,10 @@ common_srcs = \
 	prov/util/src/util_mr.c
 
 if MACOS
+if !HAVE_CLOCK_GETTIME
 common_srcs += src/osx/osd.c
+endif
+
 common_srcs += src/unix/osd.c
 common_srcs += include/osx/osd.h
 common_srcs += include/unix/osd.h

--- a/configure.ac
+++ b/configure.ac
@@ -141,6 +141,7 @@ AC_SEARCH_LIBS([clock_gettime],[rt],
 
 AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
 		   [Define to 1 if clock_gettime is available.])
+AM_CONDITIONAL(HAVE_CLOCK_GETTIME, [test $have_clock_gettime -eq 1])
 
 dnl Check for gcc atomic intrinsics
 AC_MSG_CHECKING(compiler support for c11 atomics)

--- a/configure.ac
+++ b/configure.ac
@@ -126,7 +126,6 @@ AC_DEFINE_UNQUOTED([PT_LOCK_SPIN], [$have_spinlock],
 	[Define to 1 if pthread_spin_init is available.])
 
 have_clock_gettime=0
-have_host_get_clock_service=0
 
 AC_CHECK_FUNCS([epoll_create])
 if test "$ac_cv_func_epoll_create" = yes; then
@@ -136,14 +135,12 @@ fi
 AC_SEARCH_LIBS([clock_gettime],[rt],
 		[have_clock_gettime=1],
 		[AC_CHECK_FUNCS([host_get_clock_service],
-			[have_host_get_clock_service=1],
+			[],
 			[AC_MSG_ERROR([clock_gettime or host_get_clock_service
 			 not found.])])])
 
 AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
 		   [Define to 1 if clock_gettime is available.])
-AC_DEFINE_UNQUOTED(HAVE_HOST_GET_CLOCK_SERVICE, [$have_host_get_clock_service],
-		   [Define to 1 if host_clock_get_service is available.])
 
 dnl Check for gcc atomic intrinsics
 AC_MSG_CHECKING(compiler support for c11 atomics)

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -31,8 +31,8 @@
  * SOFTWARE.
  */
 
-#ifndef _MACH_CLOCK_GETTIME_H_
-#define _MACH_CLOCK_GETTIME_H_
+#ifndef OSX_OSD_H
+#define OSX_OSD_H
 
 #include <sys/time.h>
 #include <time.h>

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -46,8 +46,7 @@
 
 #include "unix/osd.h"
 
-#define CLOCK_REALTIME CALENDAR_CLOCK
-#define CLOCK_MONOTONIC SYSTEM_CLOCK
+#include "config.h"
 
 #define pthread_yield pthread_yield_np
 
@@ -59,13 +58,22 @@
 #define HOST_NAME_MAX 255
 #endif
 
-typedef int clockid_t;
-
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/* macOS Sierra added clock_gettime to libc. This implementation should only
+ * take effect if it is not available.
+ */
+#if !HAVE_CLOCK_GETTIME
+
+#define CLOCK_REALTIME CALENDAR_CLOCK
+#define CLOCK_MONOTONIC SYSTEM_CLOCK
+
+typedef int clockid_t;
 int clock_gettime(clockid_t clk_id, struct timespec *tp);
+
+#endif
 
 static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
 {

--- a/src/osx/osd.c
+++ b/src/osx/osd.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -31,7 +32,12 @@
  */
 
 #include "osx/osd.h"
+#include "config.h"
 
+/* Define clock_gettime if it is not already defined. As of macOS Sierra, it is
+ * available in libc.
+ */
+#if !HAVE_CLOCK_GETTIME
 int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 	int retval;
 
@@ -47,3 +53,4 @@ int clock_gettime(clockid_t clk_id, struct timespec *tp) {
 
 	return retval;
 }
+#endif

--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -205,8 +205,7 @@ static const int integ_alphabet_length =
 /*******************************************************************************
  *                                  Compatibility methods
  ******************************************************************************/
-
-#ifdef __APPLE__
+#if defined(__APPLE__) && !HAVE_CLOCK_GETTIME
 int clock_gettime(clockid_t clk_id, struct timespec *tp)
 {
 	int retval;


### PR DESCRIPTION
The workaround for `clock_gettime` is only necessary when the function is
not already available. macOS Sierra includes an implementation of
`clock_gettime` in libc.
- Only define the implementation if `HAVE_CLOCK_GETTIME` is 0. 
- Get rid of unused `AC_DEFINE` `HAVE_HOST_GET_CLOCK_SERVICE`.

Found-by: Yanfei Guo \<yguo@anl.gov\>
Signed-off-by: Ben Turrubiates \<bturrubi@cisco.com\>
