### PR TITLE
prov/verbs: add on demand paging support for ep_rdm

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -11,6 +11,7 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 	# Determine if we can support the verbs provider
 	verbs_ibverbs_happy=0
 	verbs_rdmacm_happy=0
+	verbs_ibverbs_exp_happy=0
 	AS_IF([test x"$enable_verbs" != x"no"],
 	      [FI_CHECK_PACKAGE([verbs_ibverbs],
 				[infiniband/verbs.h],
@@ -21,6 +22,16 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 				[$verbs_LIBDIR],
 				[FI_VERBS_DOUBLE_CHECK_LIBIBVERBS],
 				[verbs_ibverbs_happy=0])
+
+	      FI_CHECK_PACKAGE([verbs_ibverbs],
+				[infiniband/verbs_exp.h],
+				[ibverbs],
+				[ibv_open_device],
+				[],
+				[$verbs_PREFIX],
+				[$verbs_LIBDIR],
+				[verbs_ibverbs_exp_happy=1],
+				[verbs_ibverbs_exp_happy=0])
 
 	       FI_CHECK_PACKAGE([verbs_rdmacm],
 				[rdma/rsocket.h],
@@ -35,6 +46,13 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 
 	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
 	       test $verbs_rdmacm_happy -eq 1], [$1], [$2])
+
+	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
+	       test $verbs_rdmacm_happy -eq 1 && \
+	       test $verbs_ibverbs_exp_happy -eq 1],
+		[AC_DEFINE([HAVE_VERBS_EXP_H], [1],
+			   [Experimental verbs features support])],
+		[])
 
 	# Technically, verbs_ibverbs_CPPFLAGS and
 	# verbs_rdmacm_CPPFLAGS could be different, but it is highly

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -271,6 +271,7 @@ struct fi_ibv_rdm_ep {
 	int max_inline_rc;
 	int rndv_threshold;
 	int rndv_seg_size;
+	int use_odp;
 	struct ibv_cq *scq;
 	struct ibv_cq *rcq;
 	int scq_depth;

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -83,8 +83,13 @@ struct fi_ibv_msg_ep;
  */
 size_t rdm_buffer_size(size_t buf_send_size);
 
+#ifdef HAVE_VERBS_EXP_H
+/* 128MB is ODP MR limitation */
+#define FI_IBV_RDM_SEG_MAXSIZE (128*1024*1024)
+#else /* HAVE_VERBS_EXP_H */
 /* 1GB is RC_QP limitation */
 #define FI_IBV_RDM_SEG_MAXSIZE (1024*1024*1024)
+#endif /* HAVE_VERBS_EXP_H */
 
 /* TODO: CQs depths increased from 100 to 1000 to prevent
  *      "Work Request Flushed Error" in stress tests like alltoall.

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -379,9 +379,12 @@ VERBS_INI
 	fi_param_define(&fi_ibv_prov, "rdm_buffer_size", FI_PARAM_INT,
 			"the maximum size of a buffered operation (bytes) "
 			"(default: platform specific)");
+	fi_param_define(&fi_ibv_prov, "rdm_use_odp", FI_PARAM_BOOL,
+			"enable on-demand paging experimental feature"
+			"(default: platform specific)");
 	fi_param_define(&fi_ibv_prov, "rdm_rndv_seg_size", FI_PARAM_INT,
 			"the segment size for zero copy protocols (bytes)"
-			"(default: 1073741824)");
+			"(default: platform specific");
 	fi_param_define(&fi_ibv_prov, "rdm_cqread_bunch_size", FI_PARAM_INT,
 			"the number of entries to be read from the verbs "
 			"completion queue at a time (default: 8)");


### PR DESCRIPTION
rdm_ep uses ODP memory registration for RNDV protocol if new parameter
FI_VERBS_RDM_USE_ODP is enabled. Default value is platform specific.
If ODP is used then FI_VERBS_RDM_RNDV_SEG_SIZE is reduced to 128MB.
The change improves bandwidth.

@a-ilango @shefty , please review. This change is not targeted for 1.4
