### PR TITLE
prov/gni: Implement scalable endpoints

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -36,6 +36,7 @@ _gni_files = \
 	prov/gni/src/gnix_poll.c \
 	prov/gni/src/gnix_queue.c \
 	prov/gni/src/gnix_rma.c \
+	prov/gni/src/gnix_sep.c \
 	prov/gni/src/gnix_tags.c \
 	prov/gni/src/gnix_trigger.c \
 	prov/gni/src/gnix_util.c \
@@ -111,6 +112,7 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/api.c \
 	prov/gni/test/api_cq.c \
 	prov/gni/test/api_cntr.c \
+	prov/gni/test/sep.c \
 	prov/gni/test/utils.c \
 	prov/gni/test/vc.c \
 	prov/gni/test/vc_lookup.c \

--- a/prov/gni/include/gnix_av.h
+++ b/prov/gni/include/gnix_av.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -55,6 +55,7 @@
  *                           is associated
  * @var cookie               RDMA cookie credential for the endpoint
  *                           this entry corresponds to
+ * @var rx_ctx_cnt           number of contexts associated with this AV
  */
 struct gnix_av_addr_entry {
 	struct gnix_address gnix_addr;
@@ -62,6 +63,10 @@ struct gnix_av_addr_entry {
 		uint32_t name_type : 8;
 		uint32_t cm_nic_cdm_id : 24;
 		uint32_t cookie;
+	};
+	struct {
+		uint32_t rx_ctx_cnt : 8;
+		uint32_t unused1 : 24;
 	};
 };
 

--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
@@ -66,7 +66,7 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
 struct gnix_cm_nic {
 	struct gnix_nic *nic;
 	struct gnix_dgram_hndl *dgram_hndl;
-	struct gnix_fid_fabric *fabric;
+	struct gnix_fid_domain *domain;
 	struct gnix_hashtable *addr_to_ep_ht;
 	fastlock_t wq_lock;
 	struct dlist_entry cm_nic_wq;
@@ -128,6 +128,7 @@ int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic);
  * @param[in]  domain   pointer to a previously allocated gnix_fid_domain struct
  * @param[in]  info     pointer to fi_info struct returned from fi_getinfo (may
  *                      be NULL)
+ * @param[in]  cdm_id   cdm id to be used for this cm nic
  * @param[out] cm_nic   pointer to address where address of the allocated
  *                      cm nic structure should be returned
  * @return              FI_SUCCESS on success, -EINVAL on invalid argument,

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -85,7 +85,7 @@ extern atomic_t gnix_debug_next_tid;
 				gnix_debug_pid = getpid();		\
 			}						\
 			snprintf(new_fmt, fmt_len, "[%%d:%%d] %s", fmt);	\
-			FI_LOG_FN(&gnix_prov, subsystem, new_fmt,		\
+			FI_LOG_FN(&gnix_prov, subsystem, new_fmt,	\
 				  gnix_debug_pid, gnix_debug_tid, ##__VA_ARGS__); \
 		} \
 	} while (0)

--- a/prov/gni/include/rdma/fi_direct_endpoint.h
+++ b/prov/gni/include/rdma/fi_direct_endpoint.h
@@ -46,15 +46,15 @@ extern int gnix_passive_ep_open(struct fid_fabric *fabric, struct fi_info *info,
 extern int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 			struct fid_ep **ep, void *context);
 
-extern int gnix_scalable_ep_open(struct fid_domain *domain,
-				 struct fi_info *info, struct fid_ep **ep,
-				 void *context);
+extern int gnix_sep_open(struct fid_domain *domain,
+			 struct fi_info *info, struct fid_ep **ep,
+			 void *context);
 
 extern int gnix_ep_bind(fid_t fid, fid_t bfid, uint64_t flags);
 
 extern int gnix_pep_bind(fid_t pep, fid_t bfid, uint64_t flags);
 
-extern int gnix_scalable_ep_bind(fid_t sep, fid_t bfid, uint64_t flags);
+extern int gnix_sep_bind(fid_t sep, fid_t bfid, uint64_t flags);
 
 extern int gnix_ep_control(fid_t fid, int command, void *arg);
 
@@ -134,7 +134,7 @@ static inline int fi_scalable_ep(struct fid_domain *domain,
 				 struct fi_info *info, struct fid_ep **sep,
 				 void *context)
 {
-	return gnix_scalable_ep_open(domain, info, sep, context);
+	return gnix_sep_open(domain, info, sep, context);
 }
 
 static inline int fi_ep_bind(struct fid_ep *ep, fid_t bfid, uint64_t flags)
@@ -150,7 +150,7 @@ static inline int fi_pep_bind(struct fid_pep *pep, fid_t bfid, uint64_t flags)
 static inline int fi_scalable_ep_bind(struct fid_ep *sep, fid_t bfid,
 				      uint64_t flags)
 {
-	return gnix_scalable_ep_bind(&sep->fid, bfid, flags);
+	return gnix_sep_bind(&sep->fid, bfid, flags);
 }
 
 static inline int fi_enable(struct fid_ep *ep)

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -648,18 +648,6 @@ DIRECT_FN int gnix_srx_context(struct fid_domain *domain,
 	return -FI_ENOSYS;
 }
 
-DIRECT_FN int gnix_scalable_ep_open(struct fid_domain *domain,
-				    struct fi_info *info,
-				    struct fid_ep **sep, void *context)
-{
-	return -FI_ENOSYS;
-}
-
-DIRECT_FN int gnix_scalable_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
-{
-	return -FI_ENOSYS;
-}
-
 /*******************************************************************************
  * FI_OPS_* data structures.
  ******************************************************************************/
@@ -691,7 +679,7 @@ static struct fi_ops_domain gnix_domain_ops = {
 	.av_open = gnix_av_open,
 	.cq_open = gnix_cq_open,
 	.endpoint = gnix_ep_open,
-	.scalable_ep = fi_no_scalable_ep,
+	.scalable_ep = gnix_sep_open,
 	.cntr_open = gnix_cntr_open,
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = gnix_stx_open,

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -180,10 +180,9 @@ struct fi_ops_atomic gnix_ep_atomic_ops;
 /*******************************************************************************
  * EP common messaging wrappers.
  ******************************************************************************/
-
-static inline ssize_t __ep_recv(struct fid_ep *ep, void *buf, size_t len,
-				void *desc, fi_addr_t src_addr, void *context,
-				uint64_t flags, uint64_t tag, uint64_t ignore)
+ssize_t _ep_recv(struct fid_ep *ep, void *buf, size_t len,
+		 void *desc, fi_addr_t src_addr, void *context,
+		 uint64_t flags, uint64_t tag, uint64_t ignore)
 {
 	struct gnix_fid_ep *ep_priv;
 
@@ -198,10 +197,10 @@ static inline ssize_t __ep_recv(struct fid_ep *ep, void *buf, size_t len,
 			  ep_priv->op_flags | flags, tag, ignore);
 }
 
-static inline ssize_t __ep_recvv(struct fid_ep *ep, const struct iovec *iov,
-				 void **desc, size_t count, fi_addr_t src_addr,
-				 void *context, uint64_t flags, uint64_t tag,
-				 uint64_t ignore)
+ssize_t _ep_recvv(struct fid_ep *ep, const struct iovec *iov,
+		  void **desc, size_t count, fi_addr_t src_addr,
+		  void *context, uint64_t flags, uint64_t tag,
+		  uint64_t ignore)
 {
 	struct gnix_fid_ep *ep_priv;
 
@@ -223,9 +222,9 @@ static inline ssize_t __ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 			   context, ep_priv->op_flags | flags, ignore, tag);
 }
 
-static inline ssize_t __ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
-				   uint64_t flags, uint64_t tag,
-				   uint64_t ignore)
+ssize_t _ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
+		    uint64_t flags, uint64_t tag,
+		    uint64_t ignore)
 {
 	struct iovec iov;
 
@@ -237,14 +236,14 @@ static inline ssize_t __ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 
 	/* msg_iov can be undefined when using FI_PEEK, etc. */
-	return __ep_recvv(ep, msg->msg_iov ? msg->msg_iov : &iov, msg->desc,
-			  msg->iov_count, msg->addr, msg->context, flags, tag,
-			  ignore);
+	return _ep_recvv(ep, msg->msg_iov ? msg->msg_iov : &iov, msg->desc,
+			 msg->iov_count, msg->addr, msg->context, flags, tag,
+			 ignore);
 }
 
-static inline ssize_t __ep_send(struct fid_ep *ep, const void *buf, size_t len,
-				void *desc, fi_addr_t dest_addr, void *context,
-				uint64_t flags, uint64_t tag)
+ssize_t _ep_send(struct fid_ep *ep, const void *buf, size_t len,
+		 void *desc, fi_addr_t dest_addr, void *context,
+		 uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -259,9 +258,9 @@ static inline ssize_t __ep_send(struct fid_ep *ep, const void *buf, size_t len,
 			  gnix_ep->op_flags | flags, 0, tag);
 }
 
-static inline ssize_t __ep_sendv(struct fid_ep *ep, const struct iovec *iov,
-				 void **desc, size_t count, fi_addr_t dest_addr,
-				 void *context, uint64_t flags, uint64_t tag)
+ssize_t _ep_sendv(struct fid_ep *ep, const struct iovec *iov,
+		  void **desc, size_t count, fi_addr_t dest_addr,
+		  void *context, uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -283,8 +282,8 @@ static inline ssize_t __ep_sendv(struct fid_ep *ep, const struct iovec *iov,
 			   gnix_ep->op_flags | flags, tag);
 }
 
-static inline ssize_t __ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
-				   uint64_t flags, uint64_t tag)
+ssize_t _ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
+		     uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 
@@ -294,8 +293,8 @@ static inline ssize_t __ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 
 	/* Must check the iov count here, can't send msg->data to sendv */
 	if (msg->iov_count > 1) {
-		return __ep_sendv(ep, msg->msg_iov, msg->desc, msg->iov_count,
-				  msg->addr, msg->context, flags, tag);
+		return _ep_sendv(ep, msg->msg_iov, msg->desc, msg->iov_count,
+				 msg->addr, msg->context, flags, tag);
 	}
 
 	gnix_ep = container_of(ep, struct gnix_fid_ep, ep_fid);
@@ -307,9 +306,9 @@ static inline ssize_t __ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 			  msg->context, flags, msg->data, tag);
 }
 
-static inline ssize_t __ep_inject(struct fid_ep *ep, const void *buf,
-				  size_t len, uint64_t data, fi_addr_t dest_addr,
-				  uint64_t flags, uint64_t tag)
+ssize_t _ep_inject(struct fid_ep *ep, const void *buf,
+		   size_t len, uint64_t data, fi_addr_t dest_addr,
+		   uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 	uint64_t inject_flags;
@@ -328,10 +327,10 @@ static inline ssize_t __ep_inject(struct fid_ep *ep, const void *buf,
 			  NULL, inject_flags, data, tag);
 }
 
-static inline ssize_t __ep_senddata(struct fid_ep *ep, const void *buf,
-				    size_t len, void *desc, uint64_t data,
-				    fi_addr_t dest_addr, void *context,
-				    uint64_t flags, uint64_t tag)
+ssize_t _ep_senddata(struct fid_ep *ep, const void *buf,
+		     size_t len, void *desc, uint64_t data,
+		     fi_addr_t dest_addr, void *context,
+		     uint64_t flags, uint64_t tag)
 {
 	struct gnix_fid_ep *gnix_ep;
 	uint64_t sd_flags;
@@ -360,16 +359,13 @@ static void __gnix_vc_destroy_ht_entry(void *val)
  * EP vc initialization helper
  ******************************************************************************/
 
-static inline int __gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
+int _gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
 {
 	int ret;
-	enum fi_av_type type;
 	gnix_hashtable_attr_t gnix_ht_attr;
 	gnix_vec_attr_t gnix_vec_attr;
 
-	type = ep_priv->av->type;
-
-	if (type == FI_AV_TABLE) {
+	if (ep_priv->av->type == FI_AV_TABLE) {
 		/* Use array to store EP VCs when using FI_AV_TABLE. */
 		ep_priv->vc_table = calloc(1, sizeof(struct gnix_vector));
 		if(ep_priv->vc_table == NULL)
@@ -424,7 +420,7 @@ static inline int __gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
 	return FI_SUCCESS;
 
 err:
-	if (type == FI_AV_TABLE) {
+	if (ep_priv->av->type == FI_AV_TABLE) {
 		free(ep_priv->vc_table);
 		ep_priv->vc_table = NULL;
 	} else {
@@ -494,7 +490,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_recv(struct fid_ep *ep, void *buf, size_t len,
 				      void *desc, fi_addr_t src_addr,
 				      void *context)
 {
-	return __ep_recv(ep, buf, len, desc, src_addr, context, 0, 0, 0);
+	return _ep_recv(ep, buf, len, desc, src_addr, context, 0, 0, 0);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_recvv(struct fid_ep *ep,
@@ -503,21 +499,21 @@ DIRECT_FN STATIC ssize_t gnix_ep_recvv(struct fid_ep *ep,
 				       fi_addr_t src_addr,
 				       void *context)
 {
-	return __ep_recvv(ep, iov, desc, count, src_addr, context, 0, 0, 0);
+	return _ep_recvv(ep, iov, desc, count, src_addr, context, 0, 0, 0);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_recvmsg(struct fid_ep *ep,
 					 const struct fi_msg *msg,
 					 uint64_t flags)
 {
-	return __ep_recvmsg(ep, msg, flags & GNIX_RECVMSG_FLAGS, 0, 0);
+	return _ep_recvmsg(ep, msg, flags & GNIX_RECVMSG_FLAGS, 0, 0);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_send(struct fid_ep *ep, const void *buf,
 				      size_t len, void *desc,
 				      fi_addr_t dest_addr, void *context)
 {
-	return __ep_send(ep, buf, len, desc, dest_addr, context, 0, 0);
+	return _ep_send(ep, buf, len, desc, dest_addr, context, 0, 0);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_sendv(struct fid_ep *ep,
@@ -526,28 +522,27 @@ DIRECT_FN STATIC ssize_t gnix_ep_sendv(struct fid_ep *ep,
 				       fi_addr_t dest_addr,
 				       void *context)
 {
-	return __ep_sendv(ep, iov, desc, count, dest_addr, context, 0, 0);
+	return _ep_sendv(ep, iov, desc, count, dest_addr, context, 0, 0);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_sendmsg(struct fid_ep *ep,
 					 const struct fi_msg *msg,
 					 uint64_t flags)
 {
-	return __ep_sendmsg(ep, msg, flags & GNIX_SENDMSG_FLAGS, 0);
+	return _ep_sendmsg(ep, msg, flags & GNIX_SENDMSG_FLAGS, 0);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_msg_inject(struct fid_ep *ep, const void *buf,
 					    size_t len, fi_addr_t dest_addr)
 {
-	return __ep_inject(ep, buf, len, 0, dest_addr, 0, 0);
+	return _ep_inject(ep, buf, len, 0, dest_addr, 0, 0);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_senddata(struct fid_ep *ep, const void *buf,
 					  size_t len, void *desc, uint64_t data,
 					  fi_addr_t dest_addr, void *context)
 {
-	return __ep_senddata(ep, buf, len, desc, data, dest_addr,
-			     context, 0, 0);
+	return _ep_senddata(ep, buf, len, desc, data, dest_addr, context, 0, 0);
 }
 
 DIRECT_FN STATIC ssize_t
@@ -794,7 +789,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_trecv(struct fid_ep *ep, void *buf, size_t len,
 				       uint64_t tag, uint64_t ignore,
 				       void *context)
 {
-	return __ep_recv(ep, buf, len, desc, src_addr, context,
+	return _ep_recv(ep, buf, len, desc, src_addr, context,
 			FI_TAGGED, tag, ignore);
 }
 
@@ -805,7 +800,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_trecvv(struct fid_ep *ep,
 					uint64_t tag, uint64_t ignore,
 					void *context)
 {
-	return __ep_recvv(ep, iov, desc, count, src_addr, context,
+	return _ep_recvv(ep, iov, desc, count, src_addr, context,
 			  FI_TAGGED, tag, ignore);
 }
 
@@ -847,7 +842,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_trecvmsg(struct fid_ep *ep,
 	if ((flags & FI_DISCARD) && !(flags & (FI_PEEK | FI_CLAIM)))
 		return -FI_EINVAL;
 
-	return __ep_recvmsg(ep, &_msg, clean_flags, msg->tag,
+	return _ep_recvmsg(ep, &_msg, clean_flags, msg->tag,
 			msg->ignore);
 }
 
@@ -856,7 +851,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_tsend(struct fid_ep *ep, const void *buf,
 				       fi_addr_t dest_addr, uint64_t tag,
 				       void *context)
 {
-	return __ep_send(ep, buf, len, desc, dest_addr, context,
+	return _ep_send(ep, buf, len, desc, dest_addr, context,
 			FI_TAGGED, tag);
 }
 
@@ -866,8 +861,8 @@ DIRECT_FN STATIC ssize_t gnix_ep_tsendv(struct fid_ep *ep,
 					fi_addr_t dest_addr,
 					uint64_t tag, void *context)
 {
-	return __ep_sendv(ep, iov, desc, count, dest_addr, context,
-			  FI_TAGGED, tag);
+	return _ep_sendv(ep, iov, desc, count, dest_addr, context,
+			 FI_TAGGED, tag);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_tsendmsg(struct fid_ep *ep,
@@ -887,14 +882,14 @@ DIRECT_FN STATIC ssize_t gnix_ep_tsendmsg(struct fid_ep *ep,
 
 	clean_flags = (flags & GNIX_SENDMSG_FLAGS) | FI_TAGGED;
 
-	return __ep_sendmsg(ep, &_msg, clean_flags, msg->tag);
+	return _ep_sendmsg(ep, &_msg, clean_flags, msg->tag);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_tinject(struct fid_ep *ep, const void *buf,
 					 size_t len, fi_addr_t dest_addr,
 					 uint64_t tag)
 {
-	return __ep_inject(ep, buf, len, 0, dest_addr, FI_TAGGED, tag);
+	return _ep_inject(ep, buf, len, 0, dest_addr, FI_TAGGED, tag);
 }
 
 DIRECT_FN STATIC ssize_t gnix_ep_tsenddata(struct fid_ep *ep, const void *buf,
@@ -902,7 +897,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_tsenddata(struct fid_ep *ep, const void *buf,
 					   uint64_t data, fi_addr_t dest_addr,
 					   uint64_t tag, void *context)
 {
-	return __ep_senddata(ep, buf, len, desc, data, dest_addr, context,
+	return _ep_senddata(ep, buf, len, desc, data, dest_addr, context,
 			FI_TAGGED, tag);
 }
 
@@ -924,7 +919,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_tinjectdata(struct fid_ep *ep, const void *buf,
 					     size_t len, uint64_t data,
 					     fi_addr_t dest_addr, uint64_t tag)
 {
-	return __ep_inject(ep, buf, len, data, dest_addr,
+	return _ep_inject(ep, buf, len, data, dest_addr,
 			  FI_TAGGED | FI_REMOTE_CQ_DATA, tag);
 }
 
@@ -1539,7 +1534,7 @@ static void __ep_destruct(void *obj)
 	free(ep);
 }
 
-static int gnix_ep_close(fid_t fid)
+int gnix_ep_close(fid_t fid)
 {
 	int ret = FI_SUCCESS;
 	struct gnix_fid_ep *ep;
@@ -1558,7 +1553,7 @@ static int gnix_ep_close(fid_t fid)
 	return ret;
 }
 
-DIRECT_FN STATIC int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
+DIRECT_FN int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 {
 	int ret;
 	struct gnix_fid_ep  *ep;
@@ -1566,10 +1561,20 @@ DIRECT_FN STATIC int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	struct gnix_fid_cq  *cq;
 	struct gnix_fid_stx *stx;
 	struct gnix_fid_cntr *cntr;
+	struct gnix_fid_trx *trx_priv;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
-	ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
+	switch (fid->fclass) {
+	case FI_CLASS_TX_CTX:
+	case FI_CLASS_RX_CTX:
+		trx_priv = container_of(fid, struct gnix_fid_trx, ep_fid);
+		ep = trx_priv->ep;
+		break;
+	default:
+		ep = container_of(fid, struct gnix_fid_ep, ep_fid.fid);
+	}
+
 	ret = ofi_ep_bind_valid(&gnix_prov, bfid, flags);
 	if (ret)
 		return ret;
@@ -1623,7 +1628,7 @@ DIRECT_FN STATIC int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 			break;
 		}
 		ep->av = av;
-		__gnix_ep_init_vc(ep);
+		_gnix_ep_init_vc(ep);
 		_gnix_ref_get(ep->av);
 		break;
 	case FI_CLASS_CNTR:
@@ -1755,14 +1760,15 @@ static int __gnix_ep_cm_nic_prep(struct gnix_fid_domain *domain,
 	if (info->src_addr &&
 	    info->src_addrlen == sizeof(struct gnix_ep_name)) {
 		name = (struct gnix_ep_name *)info->src_addr;
-		if (name->name_type == GNIX_EPN_TYPE_BOUND) {
-			/* EP name includes user specified service/port */
+		if (name->name_type & GNIX_EPN_TYPE_BOUND) {
+			/* the EP name cdm_id contains the user specified
+			 * port for bound endpoints */
 			*cdm_id = name->gnix_addr.cdm_id;
 			name_type = name->name_type;
 		}
 	}
 
-	if (name_type == GNIX_EPN_TYPE_UNBOUND) {
+	if (name_type & GNIX_EPN_TYPE_UNBOUND) {
 		ret = _gnix_cm_nic_create_cdm_id(domain, cdm_id);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
@@ -1873,8 +1879,7 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 			   struct fid_ep **ep, void *context)
 {
 	int ret = FI_SUCCESS;
-	int err_ret;
-	uint32_t cdm_id;
+	uint32_t cdm_id = GNIX_CREATE_CDM_ID;
 	struct gnix_fid_domain *domain_priv;
 	struct gnix_fid_ep *ep_priv;
 	struct gnix_ep_name *name;
@@ -2051,10 +2056,238 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		ret = gnix_nic_alloc(domain_priv, NULL, &ep_priv->nic);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
-				    "_gnix_nic_alloc call returned %d\n",
-				     ret);
+				    "gnix_nic_alloc call returned %d\n", ret);
 			goto err;
 		}
+	}
+
+	/*
+	 * if smsg callbacks not present hook them up now
+	 */
+
+	if (ep_priv->nic->smsg_callbacks == NULL)
+		ep_priv->nic->smsg_callbacks = gnix_ep_smsg_callbacks;
+
+	_gnix_ref_get(ep_priv->domain);
+	*ep = &ep_priv->ep_fid;
+	return ret;
+
+err:
+	if (ep_priv->xpmem_hndl) {
+		if (_gnix_xpmem_handle_destroy(ep_priv->xpmem_hndl) !=
+		    FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "_gnix_xpmem_handle_destroy returned %s\n",
+				  fi_strerror(-ret));
+		}
+	}
+
+	__destruct_tag_storages(ep_priv);
+
+	if (free_list_inited == true)
+		__fr_freelist_destroy(ep_priv);
+
+	if (ep_priv->cm_nic != NULL)
+		ret = _gnix_cm_nic_free(ep_priv->cm_nic);
+
+	if (ep_priv->nic != NULL)
+		ret = _gnix_nic_free(ep_priv->nic);
+
+	free(ep_priv);
+	return ret;
+
+}
+
+int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
+			   struct gnix_ep_attr *attr,
+			   struct fid_ep **ep, void *context)
+{
+	int ret = FI_SUCCESS;
+	int err_ret;
+	struct gnix_fid_domain *domain_priv;
+	struct gnix_fid_ep *ep_priv;
+	gnix_ht_key_t *key_ptr;
+	uint32_t cdm_id;
+	bool free_list_inited = false;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if ((domain == NULL) || (info == NULL) || (ep == NULL) ||
+	    (info->ep_attr == NULL))
+		return -FI_EINVAL;
+
+	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
+
+	ep_priv = calloc(1, sizeof(*ep_priv));
+	if (!ep_priv)
+		return -FI_ENOMEM;
+
+	ep_priv->requires_lock = (domain_priv->thread_model !=
+				FI_THREAD_COMPLETION);
+
+	ep_priv->ep_fid.fid.fclass = FI_CLASS_EP;
+	ep_priv->ep_fid.fid.context = context;
+
+	ep_priv->ep_fid.fid.ops = &gnix_ep_fi_ops;
+	ep_priv->ep_fid.ops = &gnix_ep_ops;
+	ep_priv->domain = domain_priv;
+	ep_priv->type = info->ep_attr->type;
+
+	_gnix_ref_init(&ep_priv->ref_cnt, 1, __ep_destruct);
+
+	fastlock_init(&ep_priv->recv_queue_lock);
+	fastlock_init(&ep_priv->tagged_queue_lock);
+
+	ep_priv->caps = info->caps & GNIX_EP_RDM_CAPS_FULL;
+
+	if (info->tx_attr)
+		ep_priv->op_flags = info->tx_attr->op_flags;
+	if (info->rx_attr)
+		ep_priv->op_flags |= info->rx_attr->op_flags;
+	ep_priv->op_flags &= GNIX_EP_OP_FLAGS;
+
+	ep_priv->min_multi_recv = GNIX_OPT_MIN_MULTI_RECV_DEFAULT;
+
+	if (attr && attr->msg_ops)
+		ep_priv->ep_fid.msg = attr->msg_ops;
+	else
+		ep_priv->ep_fid.msg = &gnix_ep_msg_ops;
+
+	if (attr && attr->rma_ops)
+		ep_priv->ep_fid.rma = attr->rma_ops;
+	else
+		ep_priv->ep_fid.rma = &gnix_ep_rma_ops;
+
+	if (attr && attr->tagged_ops)
+		ep_priv->ep_fid.tagged = attr->tagged_ops;
+	else
+		ep_priv->ep_fid.tagged = &gnix_ep_tagged_ops;
+
+	if (attr && attr->atomic_ops)
+		ep_priv->ep_fid.atomic = attr->atomic_ops;
+	else
+		ep_priv->ep_fid.atomic = &gnix_ep_atomic_ops;
+
+	if (attr && attr->cm_ops)
+		ep_priv->ep_fid.cm = attr->cm_ops;
+	else
+		ep_priv->ep_fid.cm = &gnix_cm_ops;
+
+	gnix_ep_caps(ep_priv, ep_priv->caps);
+
+	ret = __init_tag_storages(ep_priv, GNIX_TAG_LIST);
+	if (ret) {
+		goto err;
+	}
+
+	ret = __fr_freelist_init(ep_priv);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			 "Error allocating gnix_fab_req freelist (%s)",
+			 fi_strerror(-ret));
+		goto err;
+	} else
+		free_list_inited = true;
+
+	/*
+	 * try out XPMEM
+	 */
+
+	ret = _gnix_xpmem_handle_create(domain_priv,
+					&ep_priv->xpmem_hndl);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "xpmem_handl_create returned %s\n",
+			  fi_strerror(-ret));
+	}
+
+	if (attr && attr->cm_nic) {
+		ep_priv->cm_nic = attr->cm_nic;
+		_gnix_ref_get(ep_priv->cm_nic);
+	} else {
+
+		/*
+		 * if a cm_nic has not yet been allocated for this
+		 * domain, do it now.  Reuse the embedded gnix_nic
+		 * in the cm_nic as the nic for this endpoint
+		 * to reduce demand on Aries hw resources.
+		 */
+
+		fastlock_acquire(&domain_priv->cm_nic_lock);
+		if (domain_priv->cm_nic == NULL) {
+			ret = _gnix_cm_nic_alloc(domain_priv, info,
+						 cdm_id,
+						 &domain_priv->cm_nic);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					"_gnix_cm_nic_alloc returned %s\n",
+					fi_strerror(-ret));
+				fastlock_release(
+					 &domain_priv->cm_nic_lock);
+				goto err;
+			}
+			ep_priv->cm_nic = domain_priv->cm_nic;
+			ep_priv->nic = ep_priv->cm_nic->nic;
+			_gnix_ref_get(ep_priv->nic);
+		} else {
+			ep_priv->cm_nic = domain_priv->cm_nic;
+			_gnix_ref_get(ep_priv->cm_nic);
+		}
+
+		fastlock_release(&domain_priv->cm_nic_lock);
+
+	}
+
+	ep_priv->my_name.gnix_addr.device_addr =
+		ep_priv->cm_nic->my_name.gnix_addr.device_addr;
+	ep_priv->my_name.cm_nic_cdm_id =
+		ep_priv->cm_nic->my_name.gnix_addr.cdm_id;
+
+	if (attr && attr->use_cdm_id) {
+		cdm_id = attr->cdm_id;
+	} else {
+		ret = _gnix_cm_nic_create_cdm_id(domain_priv, &cdm_id);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				    "gnix_cm_nic_create_cdm_id returned %s\n",
+				     fi_strerror(-ret));
+			goto err;
+		}
+	}
+	ep_priv->my_name.gnix_addr.cdm_id = cdm_id;
+
+	key_ptr = (gnix_ht_key_t *)&ep_priv->my_name.gnix_addr;
+	ret = _gnix_ht_insert(ep_priv->cm_nic->addr_to_ep_ht,
+			      *key_ptr,
+			      ep_priv);
+	if ((ret != FI_SUCCESS) && (ret != -FI_ENOSPC)) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "__gnix_ht_insert returned %d\n",
+			  ret);
+		goto err;
+	}
+
+	fastlock_init(&ep_priv->vc_lock);
+
+	ep_priv->progress_fn = NULL;
+	ep_priv->rx_progress_fn = NULL;
+	ep_priv->tx_enabled = false;
+	ep_priv->rx_enabled = false;
+
+	if (attr && attr->nic) {
+		ep_priv->nic = attr->nic;
+	} else {
+		assert(ep_priv->nic == NULL);
+
+		ret = gnix_nic_alloc(domain_priv, NULL, &ep_priv->nic);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				    "gnix_nic_alloc call returned %d\n", ret);
+			goto err;
+		}
+		if (!(attr && attr->cm_nic)) {
+			ep_priv->cm_nic = domain_priv->cm_nic;
+		}
+		_gnix_ref_get(ep_priv->nic);
 	}
 
 	/*

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -308,12 +308,15 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->domain_attr->data_progress = FI_PROGRESS_AUTO;
 	gnix_info->domain_attr->av_type = FI_AV_UNSPEC;
 	gnix_info->domain_attr->tx_ctx_cnt = gnix_max_nics_per_ptag;
+	gnix_info->domain_attr->rx_ctx_cnt = gnix_max_nics_per_ptag;
 	/* only one aries per node */
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);
 	gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
 	gnix_info->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	gnix_info->domain_attr->mr_key_size = sizeof(uint64_t),
+	gnix_info->domain_attr->max_ep_tx_ctx = GNIX_SEP_MAX_CNT;
+	gnix_info->domain_attr->max_ep_rx_ctx = GNIX_SEP_MAX_CNT;
 
 	gnix_info->next = NULL;
 	gnix_info->addr_format = FI_ADDR_GNI;
@@ -363,13 +366,18 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 
-			if (hints->ep_attr->tx_ctx_cnt > 1) {
+			if (hints->ep_attr->tx_ctx_cnt > GNIX_SEP_MAX_CNT) {
 				goto err;
 			}
 
-			if (hints->ep_attr->rx_ctx_cnt > 1) {
+			if (hints->ep_attr->rx_ctx_cnt > GNIX_SEP_MAX_CNT) {
 				goto err;
 			}
+
+			gnix_info->ep_attr->tx_ctx_cnt =
+				hints->ep_attr->tx_ctx_cnt;
+			gnix_info->ep_attr->rx_ctx_cnt =
+				hints->ep_attr->rx_ctx_cnt;
 
 			if (hints->ep_attr->max_msg_size > GNIX_MAX_MSG_SIZE) {
 				goto err;

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -940,7 +940,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 	struct gnix_nic *nic = NULL;
 	uint32_t device_addr;
 	gni_return_t status;
-	uint32_t fake_cdm_id;
+	uint32_t fake_cdm_id = GNIX_CREATE_CDM_ID;
 	gni_smsg_attr_t smsg_mbox_attr;
 	struct gnix_nic_attr *nic_attr = &default_attr;
 	uint32_t num_corespec_cpus = 0;

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -1,0 +1,877 @@
+/*
+ * Copyright (c) 2016 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Endpoint common code
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "gnix.h"
+#include "gnix_cm_nic.h"
+#include "gnix_ep.h"
+#include "gnix_vc.h"
+#include "gnix_util.h"
+#include "gnix_msg.h"
+
+/******************************************************************************
+ * Forward declaration for ops structures.
+ ******************************************************************************/
+
+static struct fi_ops gnix_sep_fi_ops;
+static struct fi_ops_ep gnix_sep_ops;
+/*
+static struct fi_ops gnix_tx_fi_ops;
+static struct fi_ops_ep gnix_tx_ops;
+*/
+static struct fi_ops_cm gnix_sep_rxtx_cm_ops;
+static struct fi_ops_msg gnix_sep_msg_ops;
+static struct fi_ops_rma gnix_sep_rma_ops;
+static struct fi_ops_tagged gnix_sep_tagged_ops;
+static struct fi_ops_atomic gnix_sep_atomic_ops;
+
+/*******************************************************************************
+ * SEP(EP) OPS API function implementations.
+ ******************************************************************************/
+/* TODO:
+	initialize capabilities for tx_priv?
+	initialize attr?
+*/
+
+static void __trx_destruct(void *obj)
+{
+	int __attribute__((unused)) ret;
+	struct gnix_fid_trx *trx = (struct gnix_fid_trx *) obj;
+	struct gnix_fid_ep *ep_priv;
+	struct gnix_fid_sep *sep_priv;
+	struct fid_domain *domain;
+	int refs_held;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	ep_priv = trx->ep;
+	assert(ep_priv != NULL);
+	sep_priv = trx->sep;
+	assert(sep_priv != NULL);
+	domain = sep_priv->domain;
+	assert(domain != NULL);
+
+	refs_held = _gnix_ref_put(ep_priv);
+	if (refs_held == 0)
+		_gnix_ref_put(sep_priv->cm_nic);
+	_gnix_ref_put(sep_priv);
+
+	free(trx);
+}
+
+static int gnix_sep_tx_ctx(struct fid_ep *sep, int index,
+			   struct fi_tx_attr *attr,
+			   struct fid_ep **tx_ep, void *context)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_fid_sep *sep_priv;
+	struct gnix_fid_ep *ep_priv = NULL;
+	struct gnix_fid_trx *tx_priv = NULL;
+	struct fid_ep *ep_ptr;
+	struct gnix_ep_attr ep_attr = {0};
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	sep_priv = container_of(sep, struct gnix_fid_sep, ep_fid);
+
+	if (!sep_priv) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "endpoint is not initialized\n");
+		return -FI_EINVAL;
+	}
+
+	if ((sep_priv->ep_fid.fid.fclass != FI_CLASS_SEP) ||
+		(index >= sep_priv->info->ep_attr->tx_ctx_cnt))
+		return -FI_EINVAL;
+
+	/*
+	 * check to see if the tx context was already
+	 * allocated
+	 */
+
+	fastlock_acquire(&sep_priv->sep_lock);
+
+	if (sep_priv->tx_ep_table[index] != NULL) {
+		ret = -FI_EBUSY;
+		goto err;
+	}
+
+	tx_priv = calloc(1, sizeof(struct gnix_fid_trx));
+	if (!tx_priv) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	tx_priv->ep_fid.fid.fclass = FI_CLASS_TX_CTX;
+	tx_priv->ep_fid.fid.context = context;
+	tx_priv->ep_fid.fid.ops = &gnix_sep_fi_ops;
+	tx_priv->ep_fid.ops = &gnix_sep_ops;
+	tx_priv->ep_fid.msg = &gnix_sep_msg_ops;
+	tx_priv->ep_fid.rma = &gnix_sep_rma_ops;
+	tx_priv->ep_fid.tagged = &gnix_sep_tagged_ops;
+	tx_priv->ep_fid.atomic = &gnix_sep_atomic_ops;
+	tx_priv->ep_fid.cm = &gnix_sep_rxtx_cm_ops;
+
+	/* if an EP already allocated for this index, use it */
+	if (sep_priv->ep_table[index] != NULL) {
+		ep_priv = container_of(sep_priv->ep_table[index],
+				       struct gnix_fid_ep, ep_fid);
+		sep_priv->tx_ep_table[index] = sep_priv->ep_table[index];
+		_gnix_ref_get(ep_priv);
+	} else {
+
+		/*
+		 * allocate the underlying gnix_fid_ep struct
+		 */
+
+		ep_attr.use_cdm_id = true;
+		ep_attr.cdm_id = sep_priv->cdm_id_base + index;
+		ep_attr.cm_nic = sep_priv->cm_nic;
+		ep_attr.cm_ops = &gnix_sep_rxtx_cm_ops;
+		/* TODO: clean up this cm_nic */
+		_gnix_ref_get(sep_priv->cm_nic);
+		ret = _gnix_ep_alloc(sep_priv->domain,
+				     sep_priv->info,
+				     &ep_attr,
+				     &ep_ptr, context);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "gnix_ep_alloc returned %s\n",
+				  fi_strerror(-ret));
+			goto err;
+		}
+
+		sep_priv->ep_table[index] = ep_ptr;
+		sep_priv->tx_ep_table[index] = ep_ptr;
+		ep_priv = container_of(ep_ptr, struct gnix_fid_ep, ep_fid);
+	}
+
+	_gnix_ref_init(&tx_priv->ref_cnt, 1, __trx_destruct);
+	tx_priv->ep = ep_priv;
+	tx_priv->sep = sep_priv;
+	_gnix_ref_get(sep_priv);
+	tx_priv->caps = ep_priv->caps;
+	*tx_ep = &tx_priv->ep_fid;
+err:
+	fastlock_release(&sep_priv->sep_lock);
+
+	return ret;
+}
+
+static int gnix_sep_rx_ctx(struct fid_ep *sep, int index,
+			   struct fi_rx_attr *attr,
+			   struct fid_ep **rx_ep, void *context)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_fid_sep *sep_priv;
+	struct gnix_fid_ep *ep_priv = NULL;
+	struct gnix_fid_trx *rx_priv = NULL;
+	struct fid_ep *ep_ptr;
+	struct gnix_ep_attr ep_attr = {0};
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	sep_priv = container_of(sep, struct gnix_fid_sep, ep_fid);
+
+	if (!sep_priv) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "endpoint is not initialized\n");
+		return -FI_EINVAL;
+	}
+
+	if ((sep_priv->ep_fid.fid.fclass != FI_CLASS_SEP) ||
+		(index >= sep_priv->info->ep_attr->rx_ctx_cnt))
+		return -FI_EINVAL;
+
+	/*
+	 * check to see if the rx context was already
+	 * allocated
+	 */
+
+	fastlock_acquire(&sep_priv->sep_lock);
+
+	if (sep_priv->rx_ep_table[index] != NULL) {
+		ret = -FI_EBUSY;
+		goto err;
+	}
+
+	rx_priv = calloc(1, sizeof(struct gnix_fid_trx));
+	if (!rx_priv) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	rx_priv->ep_fid.fid.fclass = FI_CLASS_RX_CTX;
+	rx_priv->ep_fid.fid.context = context;
+	rx_priv->ep_fid.fid.ops = &gnix_sep_fi_ops;
+	rx_priv->ep_fid.ops = &gnix_sep_ops;
+	rx_priv->ep_fid.msg = &gnix_sep_msg_ops;
+	rx_priv->ep_fid.rma = &gnix_sep_rma_ops;
+	rx_priv->ep_fid.tagged = &gnix_sep_tagged_ops;
+	rx_priv->ep_fid.atomic = &gnix_sep_atomic_ops;
+	rx_priv->ep_fid.cm = &gnix_sep_rxtx_cm_ops;
+
+	/* if an EP already allocated for this index, use it */
+	if (sep_priv->ep_table[index] != NULL) {
+		ep_priv = container_of(sep_priv->ep_table[index],
+				       struct gnix_fid_ep, ep_fid);
+		sep_priv->rx_ep_table[index] = sep_priv->ep_table[index];
+		_gnix_ref_get(ep_priv);
+	} else {
+
+		/*
+		 * compute cdm_id and allocate an EP.
+		 */
+
+		ep_attr.use_cdm_id = true;
+		ep_attr.cdm_id = sep_priv->cdm_id_base + index;
+		ep_attr.cm_nic = sep_priv->cm_nic;
+		ep_attr.cm_ops = &gnix_sep_rxtx_cm_ops;
+		_gnix_ref_get(sep_priv->cm_nic);
+		ret = _gnix_ep_alloc(sep_priv->domain,
+				     sep_priv->info,
+				     &ep_attr,
+				     &ep_ptr, context);
+		if (ret != FI_SUCCESS) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "gnix_ep_alloc returned %s\n",
+				  fi_strerror(-ret));
+			goto err;
+		}
+
+		sep_priv->ep_table[index] = ep_ptr;
+		sep_priv->rx_ep_table[index] = ep_ptr;
+		ep_priv = container_of(ep_ptr, struct gnix_fid_ep, ep_fid);
+	}
+
+	_gnix_ref_init(&rx_priv->ref_cnt, 1, __trx_destruct);
+	rx_priv->ep = ep_priv;
+	rx_priv->sep = sep_priv;
+	_gnix_ref_get(sep_priv);
+	rx_priv->caps = ep_priv->caps;
+	*rx_ep = &rx_priv->ep_fid;
+err:
+	fastlock_release(&sep_priv->sep_lock);
+
+	return ret;
+}
+
+static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
+{
+	int i, ret;
+	struct gnix_fid_ep  *ep;
+	struct gnix_fid_av  *av;
+	struct gnix_fid_sep *sep;
+	struct gnix_fid_trx *trx_priv;
+	struct gnix_fid_domain *domain_priv;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	switch (fid->fclass) {
+	case FI_CLASS_SEP:
+		break;
+	case FI_CLASS_TX_CTX:
+	case FI_CLASS_RX_CTX:
+		trx_priv = container_of(fid, struct gnix_fid_trx, ep_fid);
+		return gnix_ep_bind(&trx_priv->ep->ep_fid.fid, bfid, flags);
+	default:
+		return -FI_ENOSYS;
+	}
+
+	sep = container_of(fid, struct gnix_fid_sep, ep_fid);
+	domain_priv = container_of(sep->domain, struct gnix_fid_domain,
+				   domain_fid);
+
+	ret = ofi_ep_bind_valid(&gnix_prov, bfid, flags);
+	if (ret)
+		return ret;
+
+	switch (bfid->fclass) {
+	case FI_CLASS_AV:
+		av = container_of(bfid, struct gnix_fid_av, av_fid.fid);
+		if (domain_priv != av->domain) {
+			return -FI_EINVAL;
+		}
+
+		/* We currently only support FI_AV_MAP */
+		if (av->type != FI_AV_MAP) {
+			return -FI_EINVAL;
+		}
+
+		for (i = 0; i < sep->info->ep_attr->tx_ctx_cnt; i++) {
+			ep = container_of(sep->tx_ep_table[i],
+					  struct gnix_fid_ep, ep_fid);
+			if (ep == NULL) {
+				return -FI_EINVAL;
+			}
+			ep->av = av;
+			_gnix_ep_init_vc(ep);
+			_gnix_ref_get(ep->av);
+		}
+
+		for (i = 0; i < sep->info->ep_attr->rx_ctx_cnt; i++) {
+			ep = container_of(sep->rx_ep_table[i],
+					  struct gnix_fid_ep, ep_fid);
+			if (ep == NULL) {
+				return -FI_EINVAL;
+			}
+			ep->av = av;
+			_gnix_ep_init_vc(ep);
+			_gnix_ref_get(ep->av);
+		}
+
+		break;
+	default:
+		ret = -FI_ENOSYS;
+		break;
+	}
+
+	return ret;
+}
+
+/*******************************************************************************
+ * Base SEP API function implementations.
+ ******************************************************************************/
+static int gnix_sep_control(fid_t fid, int command, void *arg)
+{
+	int ret = FI_SUCCESS;
+	struct gnix_fid_ep *ep;
+	struct gnix_fid_trx *trx_priv;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	switch (fid->fclass) {
+	case FI_CLASS_SEP:
+		/* nothing to do for scalable endpoints */
+		return FI_SUCCESS;
+	case FI_CLASS_TX_CTX:
+	case FI_CLASS_RX_CTX:
+		trx_priv = container_of(fid, struct gnix_fid_trx, ep_fid);
+		ep = trx_priv->ep;
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+
+	if (!ep) {
+		return -FI_EINVAL;
+	}
+
+	switch (command) {
+	case FI_ENABLE:
+		if (GNIX_EP_RDM_DGM(ep->type)) {
+			if (ep->cm_nic == NULL) {
+				ret = -FI_EOPBADSTATE;
+				goto err;
+			}
+			ret = _gnix_vc_cm_init(ep->cm_nic);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+				     "_gnix_vc_cm_nic_init call returned %d\n",
+					ret);
+				goto err;
+			}
+			ret = _gnix_cm_nic_enable(ep->cm_nic);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+				     "_gnix_cm_nic_enable call returned %d\n",
+					ret);
+				goto err;
+			}
+			if (ep->send_cq)
+				ep->tx_enabled = true;
+			if (ep->recv_cq)
+				ep->rx_enabled = true;
+		}
+
+		break;
+	case FI_GETFIDFLAG:
+	case FI_SETFIDFLAG:
+	case FI_ALIAS:
+	default:
+		return -FI_ENOSYS;
+	}
+err:
+	return ret;
+}
+
+static void __sep_destruct(void *obj)
+{
+	int i;
+	struct fid_domain *domain;
+	struct gnix_fid_ep *ep;
+	struct gnix_fid_domain *domain_priv;
+	struct gnix_fid_sep *sep = (struct gnix_fid_sep *) obj;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	domain = sep->domain;
+	assert(domain != NULL);
+	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
+
+	_gnix_ref_put(domain_priv);
+
+	if (sep->ep_table) {
+		for (i = 0; i < sep->info->ep_attr->tx_ctx_cnt; i++) {
+			ep = container_of(sep->ep_table[i],
+					  struct gnix_fid_ep, ep_fid);
+			if (ep == NULL) {
+				continue;
+			}
+
+			if (ep->av) {
+				_gnix_ref_put(ep->av);
+			}
+		}
+
+		free(sep->ep_table);
+	}
+
+	if (sep->tx_ep_table)
+		free(sep->tx_ep_table);
+	if (sep->rx_ep_table)
+		free(sep->rx_ep_table);
+	fi_freeinfo(sep->info);
+	free(sep);
+}
+
+static int gnix_sep_close(fid_t fid)
+{
+	int ret = FI_SUCCESS;
+	int refs_held;
+	struct gnix_fid_sep *sep;
+	struct gnix_fid_trx *trx_priv;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	switch (fid->fclass) {
+	case FI_CLASS_SEP:
+		sep = container_of(fid, struct gnix_fid_sep, ep_fid.fid);
+		refs_held = _gnix_ref_put(sep);
+		if (refs_held) {
+			GNIX_INFO(FI_LOG_CQ, "failed to fully close sep due to"
+				  " lingering references. refs=%i sep=%p\n",
+				  refs_held, sep);
+		}
+		break;
+	case FI_CLASS_TX_CTX:
+	case FI_CLASS_RX_CTX:
+		trx_priv = container_of(fid, struct gnix_fid_trx, ep_fid);
+		_gnix_ref_put(trx_priv);
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+
+	return ret;
+}
+
+int gnix_sep_open(struct fid_domain *domain, struct fi_info *info,
+		 struct fid_ep **sep, void *context)
+{
+	struct gnix_fid_sep *sep_priv = NULL;
+	struct gnix_fid_domain *domain_priv = NULL;
+	int ret = FI_SUCCESS;
+	int n_ids = GNIX_SEP_MAX_CNT;
+	uint32_t cdm_id, cdm_id_base;
+	struct gnix_ep_name *name;
+	uint32_t name_type = GNIX_EPN_TYPE_UNBOUND;
+
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
+
+	if ((domain == NULL) || (info == NULL) || (sep == NULL) ||
+	    (info->ep_attr == NULL))
+		return -FI_EINVAL;
+
+	if (!GNIX_EP_RDM_DGM(info->ep_attr->type))
+		return -FI_ENOSYS;
+
+	/*
+	 * check limits for rx and tx ctx's
+	 */
+
+	if ((info->ep_attr->tx_ctx_cnt > n_ids) ||
+	    (info->ep_attr->rx_ctx_cnt > n_ids))
+		return -FI_EINVAL;
+
+	n_ids = MAX(info->ep_attr->tx_ctx_cnt, info->ep_attr->rx_ctx_cnt);
+
+	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
+
+	sep_priv = calloc(1, sizeof(*sep_priv));
+	if (!sep_priv)
+		return -FI_ENOMEM;
+
+	sep_priv->type = info->ep_attr->type;
+	sep_priv->ep_fid.fid.fclass = FI_CLASS_SEP;
+	sep_priv->ep_fid.fid.context = context;
+
+	sep_priv->ep_fid.fid.ops = &gnix_sep_fi_ops;
+	sep_priv->ep_fid.ops = &gnix_sep_ops;
+	sep_priv->ep_fid.cm = &gnix_cm_ops;
+	sep_priv->domain = domain;
+
+	sep_priv->info = fi_dupinfo(info);
+	if (!sep_priv->info) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			    "fi_dupinfo NULL\n");
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	_gnix_ref_init(&sep_priv->ref_cnt, 1, __sep_destruct);
+
+	sep_priv->caps = info->caps & GNIX_EP_RDM_PRIMARY_CAPS;
+
+	sep_priv->op_flags = info->tx_attr->op_flags;
+	sep_priv->op_flags |= info->rx_attr->op_flags;
+	sep_priv->op_flags &= GNIX_EP_OP_FLAGS;
+
+	sep_priv->ep_table = calloc(n_ids, sizeof(struct gnix_fid_ep *));
+	if (sep_priv->ep_table == NULL) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			    "call returned NULL\n");
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	sep_priv->tx_ep_table = calloc(n_ids, sizeof(struct gnix_fid_ep *));
+	if (sep_priv->tx_ep_table == NULL) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			    "call returned NULL\n");
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	sep_priv->rx_ep_table = calloc(n_ids, sizeof(struct gnix_fid_ep *));
+	if (sep_priv->rx_ep_table == NULL) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			    "call returned NULL\n");
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	/*
+	 * allocate a block of cm nic ids for both tx/rx ctx - first
+	 * checking to see if the application has specified a base
+	 * via a node/service option to fi_getinfo
+	 */
+
+	if ((info->src_addr != NULL) &&
+		info->src_addrlen == sizeof(struct gnix_ep_name)) {
+		name = (struct gnix_ep_name *)info->src_addr;
+
+		if (name->name_type & GNIX_EPN_TYPE_BOUND) {
+			cdm_id_base = name->gnix_addr.cdm_id;
+			name_type = name->name_type;
+		}
+	}
+
+	name_type |= GNIX_EPN_TYPE_SEP;
+
+	cdm_id = (name_type & GNIX_EPN_TYPE_UNBOUND) ? -1 : cdm_id_base;
+
+	ret = _gnix_get_new_cdm_id_set(domain_priv, n_ids, &cdm_id);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			  "_gnix_get_new_cdm_id_set call returned %s\n",
+			  fi_strerror(-ret));
+		goto err;
+	}
+
+	sep_priv->cdm_id_base = cdm_id;
+
+	/*
+	 * allocate cm_nic for this SEP
+	 */
+	ret = _gnix_cm_nic_alloc(domain_priv,
+				 info,
+				 cdm_id,
+				 &sep_priv->cm_nic);
+	if (ret != FI_SUCCESS) {
+		GNIX_WARN(FI_LOG_EP_CTRL,
+			    "gnix_cm_nic_alloc call returned %s\n",
+			     fi_strerror(-ret));
+		goto err;
+	}
+
+	/*
+	 * ep name of SEP is the same as the cm_nic
+	 * since there's a one-to-one relationship
+	 * between a given SEP and its cm_nic.
+	 */
+	sep_priv->my_name = sep_priv->cm_nic->my_name;
+	sep_priv->my_name.cm_nic_cdm_id =
+				sep_priv->cm_nic->my_name.gnix_addr.cdm_id;
+	sep_priv->my_name.rx_ctx_cnt = info->ep_attr->rx_ctx_cnt;
+	sep_priv->my_name.name_type = name_type;
+
+	fastlock_init(&sep_priv->sep_lock);
+	_gnix_ref_get(domain_priv);
+
+	*sep = &sep_priv->ep_fid;
+	return ret;
+
+err:
+	if (sep_priv->ep_table)
+		free(sep_priv->ep_table);
+	if (sep_priv->tx_ep_table)
+		free(sep_priv->tx_ep_table);
+	if (sep_priv->rx_ep_table)
+		free(sep_priv->rx_ep_table);
+	if (sep_priv)
+		free(sep_priv);
+	return ret;
+
+}
+
+/*******************************************************************************
+ssize_t (*recv)(struct fid_ep *ep, void *buf, size_t len, void *desc,
+		fi_addr_t src_addr, void *context);
+ssize_t (*send)(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		fi_addr_t dest_addr, void *context);
+ ******************************************************************************/
+
+/*
+ * TODO: need to define the other msg/rma/amo methods for tx/rx contexts
+ */
+
+DIRECT_FN STATIC ssize_t gnix_sep_recv(struct fid_ep *ep, void *buf,
+				       size_t len, void *desc,
+				       fi_addr_t src_addr, void *context)
+{
+	struct gnix_fid_trx *rx_ep = container_of(ep, struct gnix_fid_trx,
+						  ep_fid);
+
+	return _ep_recv(&rx_ep->ep->ep_fid, buf, len, desc, src_addr,
+			context, 0, 0, 0);
+}
+
+DIRECT_FN STATIC ssize_t gnix_sep_recvv(struct fid_ep *ep,
+					const struct iovec *iov,
+					void **desc, size_t count,
+					fi_addr_t src_addr,
+					void *context)
+{
+	struct gnix_fid_trx *rx_ep = container_of(ep, struct gnix_fid_trx,
+						  ep_fid);
+
+	return _ep_recvv(&rx_ep->ep->ep_fid, iov, desc, count, src_addr,
+			 context, 0, 0, 0);
+}
+
+DIRECT_FN STATIC ssize_t gnix_sep_recvmsg(struct fid_ep *ep,
+					 const struct fi_msg *msg,
+					 uint64_t flags)
+{
+	struct gnix_fid_trx *rx_ep = container_of(ep, struct gnix_fid_trx,
+						  ep_fid);
+
+	return _ep_recvmsg(&rx_ep->ep->ep_fid, msg, flags & GNIX_RECVMSG_FLAGS,
+			   0, 0);
+}
+
+DIRECT_FN STATIC ssize_t gnix_sep_send(struct fid_ep *ep, const void *buf,
+				       size_t len, void *desc,
+				       fi_addr_t dest_addr, void *context)
+{
+	struct gnix_fid_trx *tx_ep = container_of(ep, struct gnix_fid_trx,
+						  ep_fid);
+
+	return _ep_send(&tx_ep->ep->ep_fid, buf, len, desc, dest_addr,
+			context, 0, 0);
+}
+
+DIRECT_FN ssize_t gnix_sep_sendv(struct fid_ep *ep,
+				 const struct iovec *iov,
+				 void **desc, size_t count,
+				 fi_addr_t dest_addr,
+				 void *context)
+{
+	struct gnix_fid_trx *tx_ep = container_of(ep, struct gnix_fid_trx,
+						  ep_fid);
+
+	return _ep_sendv(&tx_ep->ep->ep_fid, iov, desc, count, dest_addr,
+			 context, 0, 0);
+}
+
+DIRECT_FN ssize_t gnix_sep_sendmsg(struct fid_ep *ep,
+				  const struct fi_msg *msg,
+				  uint64_t flags)
+{
+	struct gnix_fid_trx *tx_ep = container_of(ep, struct gnix_fid_trx,
+						  ep_fid);
+
+	return _ep_sendmsg(&tx_ep->ep->ep_fid, msg,
+			   flags & GNIX_SENDMSG_FLAGS, 0);
+}
+
+DIRECT_FN ssize_t gnix_sep_msg_inject(struct fid_ep *ep, const void *buf,
+				      size_t len, fi_addr_t dest_addr)
+{
+	struct gnix_fid_trx *tx_ep = container_of(ep, struct gnix_fid_trx,
+						  ep_fid);
+
+	return _ep_inject(&tx_ep->ep->ep_fid, buf, len, 0, dest_addr, 0, 0);
+}
+
+DIRECT_FN ssize_t gnix_sep_senddata(struct fid_ep *ep, const void *buf,
+				    size_t len, void *desc, uint64_t data,
+				    fi_addr_t dest_addr, void *context)
+{
+	struct gnix_fid_trx *tx_ep = container_of(ep, struct gnix_fid_trx,
+						  ep_fid);
+
+	return _ep_senddata(&tx_ep->ep->ep_fid, buf, len, desc, data,
+			    dest_addr, context, 0, 0);
+}
+
+DIRECT_FN ssize_t
+gnix_sep_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+			uint64_t data, fi_addr_t dest_addr)
+{
+	uint64_t flags;
+	struct gnix_fid_trx *tx_ep;
+
+	if (!ep) {
+		return -FI_EINVAL;
+	}
+
+	tx_ep = container_of(ep, struct gnix_fid_trx, ep_fid);
+	assert(GNIX_EP_RDM_DGM_MSG(tx_ep->ep->type));
+
+	flags = tx_ep->ep->op_flags | FI_INJECT | FI_REMOTE_CQ_DATA |
+		GNIX_SUPPRESS_COMPLETION;
+
+	return _gnix_send(tx_ep->ep, (uint64_t)buf, len, NULL, dest_addr,
+			  NULL, flags, data, 0);
+}
+
+/*******************************************************************************
+ * FI_OPS_* data structures.
+ ******************************************************************************/
+
+static struct fi_ops gnix_sep_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = gnix_sep_close,
+	.bind = gnix_sep_bind,
+	.control = gnix_sep_control,
+	.ops_open = fi_no_ops_open
+};
+
+static struct fi_ops_ep gnix_sep_ops = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = fi_no_cancel,
+	.getopt = fi_no_getopt,
+	.setopt = fi_no_setopt,
+	.tx_ctx = gnix_sep_tx_ctx,
+	.rx_ctx = gnix_sep_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
+};
+
+static struct fi_ops_msg gnix_sep_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = gnix_sep_recv,
+	.recvv = gnix_sep_recvv,
+	.recvmsg = gnix_sep_recvmsg,
+	.send = gnix_sep_send,
+	.sendv = gnix_sep_sendv,
+	.sendmsg = gnix_sep_sendmsg,
+	.inject = gnix_sep_msg_inject,
+	.senddata = gnix_sep_senddata,
+	.injectdata = gnix_sep_msg_injectdata,
+};
+
+static struct fi_ops_rma gnix_sep_rma_ops = {
+	.size = sizeof(struct fi_ops_rma),
+	.read = NULL,
+	.readv = NULL,
+	.readmsg = NULL,
+	.write = NULL,
+	.writev = NULL,
+	.writemsg = NULL,
+	.inject = NULL,
+	.writedata = NULL,
+	.injectdata = NULL,
+};
+
+static struct fi_ops_tagged gnix_sep_tagged_ops = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = NULL,
+	.recvv = NULL,
+	.recvmsg = NULL,
+	.send = NULL,
+	.sendv = NULL,
+	.sendmsg = NULL,
+	.inject = NULL,
+	.senddata = NULL,
+	.injectdata = NULL,
+};
+
+static struct fi_ops_atomic gnix_sep_atomic_ops = {
+	.size = sizeof(struct fi_ops_atomic),
+	.write = NULL,
+	.writev = NULL,
+	.writemsg = NULL,
+	.inject = NULL,
+	.readwrite = NULL,
+	.readwritev = NULL,
+	.readwritemsg = NULL,
+	.compwrite = NULL,
+	.compwritev = NULL,
+	.compwritemsg = NULL,
+	.writevalid = NULL,
+	.readwritevalid = NULL,
+	.compwritevalid = NULL,
+};
+
+/*
+ * rx/tx contexts don't do any connection management,
+ * nor does the underlying gnix_fid_ep struct
+ */
+static struct fi_ops_cm gnix_sep_rxtx_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
+	.getname = fi_no_getname,
+	.getpeer = fi_no_getpeer,
+	.connect = fi_no_connect,
+	.listen = fi_no_listen,
+	.accept = fi_no_accept,
+	.reject = fi_no_reject,
+	.shutdown = fi_no_shutdown,
+};

--- a/prov/gni/test/sep.c
+++ b/prov/gni/test/sep.c
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <limits.h>
+#include <assert.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <inttypes.h>
+
+#include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+#include "fi_ext_gni.h"
+#include "gnix.h"
+
+#if 1
+#define dbg_printf(...)
+#else
+#define dbg_printf(...)				\
+	do {					\
+		printf(__VA_ARGS__);		\
+		fflush(stdout);			\
+	} while (0)
+#endif
+
+#define NUMEPS 2
+
+static struct fid_fabric *fab;
+static struct fid_domain *dom[NUMEPS];
+static struct fid_ep *sep[NUMEPS];
+static struct fid_av *av[NUMEPS];
+static struct fid_av *t_av;
+static void *ep_name[NUMEPS];
+fi_addr_t gni_addr[NUMEPS];
+static struct fi_cq_attr cq_attr;
+struct fi_info *hints;
+static struct fi_info *fi[NUMEPS];
+static struct fid_ep *sep[NUMEPS];
+
+#define BUF_SZ (1<<20)
+char *target;
+char *source;
+struct fid_mr *rem_mr[NUMEPS], *loc_mr[NUMEPS];
+uint64_t mr_key[NUMEPS];
+
+/* from scalable_ep.c */
+static int ctx_cnt = 4;
+static int rx_ctx_bits;
+static struct fid_ep **tx_ep[NUMEPS], **rx_ep[NUMEPS];
+static struct fid_cq **txcq_array[NUMEPS];
+static struct fid_cq **rxcq_array[NUMEPS];
+static fi_addr_t *rx_addr;
+
+void sep_setup(void)
+{
+	int ret, i, j;
+	struct fi_av_attr av_attr = {0};
+	size_t addrlen = 0;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->caps = FI_MSG | FI_NAMED_RX_CTX;
+	hints->mode = FI_LOCAL_MR;
+	hints->domain_attr->cq_data_size = NUMEPS * 2;
+	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
+	hints->domain_attr->mr_mode = FI_MR_BASIC;
+	hints->fabric_attr->prov_name = strdup("gni");
+	hints->ep_attr->tx_ctx_cnt = ctx_cnt;
+	hints->ep_attr->rx_ctx_cnt = ctx_cnt;
+
+	for (i = 0; i < NUMEPS; i++) {
+		ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi[i]);
+		cr_assert(!ret, "fi_getinfo");
+
+		txcq_array[i] = calloc(ctx_cnt, sizeof(*txcq_array));
+		rxcq_array[i] = calloc(ctx_cnt, sizeof(*rxcq_array));
+		tx_ep[i] = calloc(ctx_cnt, sizeof(*tx_ep));
+		rx_ep[i] = calloc(ctx_cnt, sizeof(*rx_ep));
+		if (!txcq_array[i] || !txcq_array[i] ||
+		    !tx_ep[i] || !rx_ep[i]) {
+			cr_assert(0, "calloc");
+		}
+	}
+
+	ctx_cnt = MIN(ctx_cnt, fi[0]->domain_attr->rx_ctx_cnt);
+	ctx_cnt = MIN(ctx_cnt, fi[0]->domain_attr->tx_ctx_cnt);
+	cr_assert(ctx_cnt, "ctx_cnt is 0");
+
+	ret = fi_fabric(fi[0]->fabric_attr, &fab, NULL);
+	cr_assert(!ret, "fi_fabric");
+
+	while (ctx_cnt >> ++rx_ctx_bits);
+	av_attr.rx_ctx_bits = rx_ctx_bits;
+	av_attr.type = FI_AV_MAP;
+	av_attr.count = NUMEPS;
+
+	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cq_attr.size = 1024;
+	cq_attr.wait_obj = FI_WAIT_NONE;
+
+	rx_addr = calloc(ctx_cnt, sizeof(*rx_addr));
+	target = calloc(BUF_SZ, 1);
+	source = calloc(BUF_SZ, 1);
+
+	if (!rx_addr || !target || !source) {
+		cr_assert(0, "calloc");
+	}
+
+	for (i = 0; i < NUMEPS; i++) {
+		fi[i]->ep_attr->tx_ctx_cnt = ctx_cnt;
+		fi[i]->ep_attr->rx_ctx_cnt = ctx_cnt;
+
+		ret = fi_domain(fab, fi[i], &dom[i], NULL);
+		cr_assert(!ret, "fi_domain");
+
+		ret = fi_scalable_ep(dom[i], fi[i], &sep[i], NULL);
+		cr_assert(!ret, "fi_scalable_ep");
+
+		ret = fi_av_open(dom[i], &av_attr, &av[i], NULL);
+		cr_assert(!ret, "fi_av_open");
+
+		for (j = 0; j < ctx_cnt; j++) {
+			ret = fi_tx_context(sep[i], j, NULL, &tx_ep[i][j],
+					    NULL);
+			cr_assert(!ret, "fi_tx_context");
+
+			ret = fi_cq_open(dom[i], &cq_attr, &txcq_array[i][j],
+					 NULL);
+			cr_assert(!ret, "fi_cq_open");
+
+			ret = fi_rx_context(sep[i], j, NULL, &rx_ep[i][j],
+					    NULL);
+			cr_assert(!ret, "fi_rx_context");
+
+			ret = fi_cq_open(dom[i], &cq_attr, &rxcq_array[i][j],
+					 NULL);
+			cr_assert(!ret, "fi_cq_open");
+		}
+
+		ret = fi_scalable_ep_bind(sep[i], &av[i]->fid, 0);
+		cr_assert(!ret, "fi_scalable_ep_bind");
+
+		for (j = 0; j < ctx_cnt; j++) {
+			ret = fi_ep_bind(tx_ep[i][j], &txcq_array[i][j]->fid,
+					 FI_SEND);
+			cr_assert(!ret, "fi_ep_bind");
+
+			ret = fi_enable(tx_ep[i][j]);
+			cr_assert(!ret, "fi_enable");
+
+			ret = fi_ep_bind(tx_ep[i][j], &rxcq_array[i][j]->fid,
+					 FI_RECV);
+			cr_assert(!ret, "fi_ep_bind");
+
+			ret = fi_enable(rx_ep[i][j]);
+			cr_assert(!ret, "fi_enable");
+		}
+	}
+
+	for (i = 0; i < NUMEPS; i++) {
+		ret = fi_enable(sep[i]);
+		cr_assert(!ret, "fi_enable");
+
+		ret = fi_getname(&sep[i]->fid, NULL, &addrlen);
+		cr_assert(addrlen > 0);
+
+		ep_name[i] = malloc(addrlen);
+		cr_assert(ep_name[i] != NULL);
+
+		ret = fi_getname(&sep[i]->fid, ep_name[i], &addrlen);
+		cr_assert(ret == FI_SUCCESS);
+
+		ret = fi_mr_reg(dom[i], target, BUF_SZ, FI_REMOTE_WRITE,
+				0, 0, 0, &rem_mr[i], &target);
+		cr_assert_eq(ret, 0);
+
+		ret = fi_mr_reg(dom[i], source, BUF_SZ, FI_REMOTE_WRITE,
+				0, 0, 0, &loc_mr[i], &source);
+		cr_assert_eq(ret, 0);
+
+		mr_key[i] = fi_mr_key(rem_mr[i]);
+	}
+
+	for (i = 0; i < NUMEPS; i++) {
+		for (j = 0; j < NUMEPS; j++) {
+			ret = fi_av_insert(av[i], ep_name[j], 1, &gni_addr[j],
+					   0, NULL);
+			cr_assert(ret == 1);
+		}
+	}
+
+	for (i = 0; i < ctx_cnt; i++) {
+		rx_addr[i] = fi_rx_addr(gni_addr[1], i, rx_ctx_bits);
+		dbg_printf("fi_rx_addr[%d] %016lx\n", i, rx_addr[i]);
+	}
+
+	/* test for inserting an ep_name that doesn't fit in the AV */
+	av_attr.rx_ctx_bits = 1;
+	ret = fi_av_open(dom[0], &av_attr, &t_av, NULL);
+	cr_assert(!ret, "fi_av_open");
+	ret = fi_av_insert(t_av, ep_name[0], 1, &gni_addr[0], 0, NULL);
+	cr_assert(ret == -FI_EINVAL);
+	ret = fi_close(&t_av->fid);
+	cr_assert(!ret, "failure in closing av.");
+}
+
+static void sep_teardown(void)
+{
+	int ret, i, j;
+
+	for (i = 0; i < NUMEPS; i++) {
+		for (j = 0; j < ctx_cnt; j++) {
+			ret = fi_close(&tx_ep[i][j]->fid);
+			cr_assert(!ret, "failure closing tx_ep.");
+
+			ret = fi_close(&rx_ep[i][j]->fid);
+			cr_assert(!ret, "failure closing rx_ep.");
+
+			ret = fi_close(&txcq_array[i][j]->fid);
+			cr_assert(!ret, "failure closing tx cq.");
+
+			ret = fi_close(&rxcq_array[i][j]->fid);
+			cr_assert(!ret, "failure closing rx cq.");
+		}
+
+		ret = fi_close(&sep[i]->fid);
+		cr_assert(!ret, "failure in closing ep.");
+
+		ret = fi_close(&av[i]->fid);
+		cr_assert(!ret, "failure in closing av.");
+
+		fi_close(&loc_mr[i]->fid);
+		fi_close(&rem_mr[i]->fid);
+
+		ret = fi_close(&dom[i]->fid);
+		cr_assert(!ret, "failure in closing domain.");
+
+		free(tx_ep[i]);
+		free(rx_ep[i]);
+		free(ep_name[i]);
+		fi_freeinfo(fi[i]);
+	}
+
+	fi_freeinfo(hints);
+	free(target);
+	free(source);
+
+	ret = fi_close(&fab->fid);
+	cr_assert(!ret, "failure in closing fabric.");
+}
+
+void sep_init_data(char *buf, int len, char seed)
+{
+	int i;
+
+	for (i = 0; i < len; i++)
+		buf[i] = seed++;
+}
+
+int sep_check_data(char *buf1, char *buf2, int len)
+{
+	int i;
+
+	for (i = 0; i < len; i++) {
+		if (buf1[i] != buf2[i]) {
+			printf("data mismatch, elem: %d, exp: %hhx, act: %hhx\n"
+			       , i, buf1[i], buf2[i]);
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+static void wait_for_cqs(struct fid_cq *scq, struct fid_cq *dcq)
+{
+	struct fi_cq_tagged_entry cqe;
+	int ret;
+	int s_done = 0, d_done = 0;
+
+	do {
+		ret = fi_cq_read(scq, &cqe, 1);
+		if (ret == 1) {
+			s_done = 1;
+		}
+
+		ret = fi_cq_read(dcq, &cqe, 1);
+		if (ret == 1) {
+			d_done = 1;
+		}
+	} while (!(s_done && d_done));
+}
+
+static void
+xfer_each_size(void (*xfer)(int index, int len), int index, int slen, int elen)
+{
+	int i;
+
+	for (i = slen; i <= elen; i *= 2) {
+		xfer(index, i);
+	}
+}
+
+/*******************************************************************************
+ * Test MSG functions
+ ******************************************************************************/
+
+TestSuite(scalable, .init = sep_setup, .fini = sep_teardown,
+	  .disabled = false);
+
+/*
+ * ssize_t fi_send(struct fid_ep *ep, void *buf, size_t len,
+ *		void *desc, fi_addr_t dest_addr, void *context);
+ *
+ * ssize_t fi_recv(struct fid_ep *ep, void * buf, size_t len,
+ *		void *desc, fi_addr_t src_addr, void *context);
+ */
+void sep_send_recv(int index, int len)
+{
+	ssize_t ret;
+
+	sep_init_data(source, len, 0xab);
+	sep_init_data(target, len, 0);
+
+	ret = fi_send(tx_ep[0][index], source, len, loc_mr[0],
+		      rx_addr[index], target);
+	cr_assert(ret == 0, "fi_send failed err:%ld", ret);
+
+	ret = fi_recv(rx_ep[1][index], target, len, rem_mr[0],
+		      FI_ADDR_UNSPEC, source);
+	cr_assert(ret == 0, "fi_recv failed err:%ld", ret);
+
+	wait_for_cqs(txcq_array[0][index], rxcq_array[1][index]);
+
+	ret = sep_check_data(source, target, 8);
+	cr_assert(ret == 1, "Data check failed");
+}
+
+Test(scalable, sr)
+{
+	int i;
+
+	for (i = 0; i < ctx_cnt; i++) {
+		xfer_each_size(sep_send_recv, i, 1, BUF_SZ);
+	}
+
+	dbg_printf("scalable done\n");
+}


### PR DESCRIPTION
The gnix scalable endpoint is comprised of:
ep_table - a list of endpoint pointers associated with a list of:
tx_ep_table - tx contexts
rx_ep_table - rx contexts
cdm_id_base - base value for the list of tx/rx context cdm_id for each
gnix endpoint associated with this scalable endpoint.
gnix_cm_nic - cm nic associated with this scalable endpoint
av - address vector bound to this scalable endpoint
The endpoint pointers ep_table[i] correspond to tx/rx_ep_table[i]. The
gnix endpoint for each rx/tx context pair has a cdm_id of cdm_id_base +
index of the context.

The scalable endpoint (sep) keeps a list of pointers of the tx/rx
context endpoints. The tx/rx contexts are based on a single endpoint
base address. A range of cdm_id's are reserved for the scalable endpoint
and these are assigned to the endpoints associated with each tx/rx
context pair.
We currently only support FI_AV_MAP.
The rx_ctx_cnt is stored in the struct gnix_ep_name. This value is saved
in the gnix_av_addr_entry.rx_ctx_cnt field in map_insert().
The rx_ctx_bits and a mask value is stored in the gnix_av structure.
During map_reverse_lookup() rx_ctx_cnt is used to calculate fi_addr that
is returned.

The cm_nic struct now holds a pointer to the domain instead of the
fabric. This is facilitate cm_nic cleanup.

This initial commit supports message endpoint ops.
Future work:
Add tests for the implemented message endpoint ops.
recvv, recvmsg, sendv, sendmsg, inject, senddata, injectdata
Implement rma, tagged and atomic scalable endpoint ops and test.

@sungeunchoi 
upstream merge of ofi-cray/libfabric-cray#1011
Fixes ofi-cray/libfabric-cray#710

Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit 701daaabf96a5a087000554f8b9107825768d6ca)