### PR TITLE
build: Move -g option to avoid always building debug code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ pkglib_LTLIBRARIES = $(DL_PROVIDERS)
 
 
 ACLOCAL_AMFLAGS = -I config
-AM_CFLAGS = -g -Wall
+AM_CFLAGS = -Wall
 
 if HAVE_LD_VERSION_SCRIPT
     libfabric_version_script = -Wl,--version-script=$(builddir)/libfabric.map


### PR DESCRIPTION
Move the -g option inside an ENABLE_DEBUG conditional.

Fixes #2491

Signed-off-by: Sean Hefty <sean.hefty@intel.com>