### PR TITLE
Updates for utility providers.

### DIFF
--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -36,6 +36,13 @@
 #include <inttypes.h>
 #include "rxd.h"
 
+static const char *rxd_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
+		const void *err_data, char *buf, size_t len)
+{
+	struct rxd_cq *rxd_cq = container_of(cq_fid, struct rxd_cq, util_cq.cq_fid);
+	return fi_cq_strerror(rxd_cq->dg_cq, prov_errno, err_data, buf, len);
+}
+
 static int rxd_cq_write_ctx(struct rxd_cq *cq,
 			     struct fi_cq_tagged_entry *cq_entry)
 {
@@ -1290,7 +1297,7 @@ int rxd_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		return -FI_ENOMEM;
 
 	ret = ofi_cq_init(&rxd_prov, domain, attr, &cq->util_cq,
-			  &rxd_cq_progress, context);
+			  &rxd_cq_progress, &rxd_cq_strerror, context);
 	if (ret)
 		goto err1;
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -83,17 +83,11 @@ struct rxm_mr {
 	struct fid_mr *msg_mr;
 };
 
-struct rxm_cq {
-	struct util_cq util_cq;
-	struct fid_cq *msg_cq;
-};
-
 struct rxm_ep {
 	struct util_ep util_ep;
 	struct fi_info *msg_info;
 	struct fid_pep *msg_pep;
-	struct rxm_cq *tx_cq;
-	struct rxm_cq *rx_cq;
+	struct fid_cq *msg_cq;
 	struct fid_ep *srx_ctx;
 	struct util_cmap *cmap;
 };
@@ -111,6 +105,10 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			     struct fid_domain **dom, void *context);
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 			 struct fid_cq **cq_fid, void *context);
+int rxm_cq_comp(struct util_cq *util_cq, void *context, uint64_t flags, size_t len,
+		void *buf, uint64_t data, uint64_t tag);
+int rxm_cq_report_error(struct util_cq *util_cq, struct fi_cq_err_entry *err_entry);
+
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  struct fid_ep **ep, void *context);
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -41,7 +41,6 @@ int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 {
 	struct rxm_domain *rxm_domain;
 	struct rxm_fabric *rxm_fabric;
-	struct rxm_cq *rxm_cq;
 	struct fid_ep *msg_ep;
 	int ret;
 
@@ -68,24 +67,11 @@ int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 	}
 
 	// TODO add other completion flags
-	if (rxm_ep->util_ep.tx_cq) {
-		rxm_cq = container_of(rxm_ep->util_ep.tx_cq, struct rxm_cq, util_cq);
-		ret = fi_ep_bind(msg_ep, &rxm_cq->msg_cq->fid, FI_TRANSMIT);
-		if (ret) {
-			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-					"Unable to bind msg_ep to tx_cq\n");
-			goto err;
-		}
-	}
-
-	if (rxm_ep->util_ep.rx_cq) {
-		rxm_cq = container_of(rxm_ep->util_ep.rx_cq, struct rxm_cq, util_cq);
-		ret = fi_ep_bind(msg_ep, &rxm_cq->msg_cq->fid, FI_RECV);
-		if (ret) {
-			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-					"Unable to bind msg_ep to rx_cq\n");
-			goto err;
-		}
+	ret = fi_ep_bind(msg_ep, &rxm_ep->msg_cq->fid, FI_TRANSMIT | FI_RECV);
+	if (ret) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+				"Unable to bind msg_ep to msg_cq\n");
+		goto err;
 	}
 
 	ret = fi_enable(msg_ep);

--- a/prov/udp/src/udpx_cq.c
+++ b/prov/udp/src/udpx_cq.c
@@ -67,7 +67,7 @@ int udpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		return -FI_ENOMEM;
 
 	ret = ofi_cq_init(&udpx_prov, domain, attr, cq,
-			   &ofi_cq_progress, context);
+			   &ofi_cq_progress, NULL, context);
 	if (ret) {
 		free(cq);
 		return ret;

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -152,7 +152,7 @@ static void udpx_rx_src_comp_signal(struct udpx_ep *ep, void *context,
 	ep->util_ep.rx_cq->wait->signal(ep->util_ep.rx_cq->wait);
 }
 
-void udpx_ep_progress(struct util_ep *util_ep)
+void udpx_ep_progress(struct util_ep *util_ep, struct util_cq *util_cq)
 {
 	struct udpx_ep *ep;
 	struct udpx_ep_entry *entry;
@@ -368,8 +368,8 @@ static int udpx_ep_close(struct fid *fid)
 					    struct util_wait_fd, util_wait);
 			fi_epoll_del(wait->epoll_fd, ep->sock);
 		}
-		fid_list_remove(&ep->util_ep.rx_cq->list,
-				&ep->util_ep.rx_cq->list_lock,
+		fid_list_remove(&ep->util_ep.rx_cq->ep_list,
+				&ep->util_ep.rx_cq->ep_list_lock,
 				&ep->util_ep.ep_fid.fid);
 		atomic_dec(&ep->util_ep.rx_cq->ref);
 	}
@@ -428,8 +428,8 @@ static int udpx_ep_bind_cq(struct udpx_ep *ep, struct util_cq *cq, uint64_t flag
 				      udpx_rx_src_comp : udpx_rx_comp;
 		}
 
-		ret = fid_list_insert(&cq->list,
-				      &cq->list_lock,
+		ret = fid_list_insert(&cq->ep_list,
+				      &cq->ep_list_lock,
 				      &ep->util_ep.ep_fid.fid);
 		if (ret)
 			return ret;

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -38,7 +38,7 @@
 
 int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_prov,
 		struct fi_info *info, struct util_ep *ep, void *context,
-		enum fi_match_type type)
+		ofi_ep_progress_func progress, enum fi_match_type type)
 {
 	struct util_domain *util_domain;
 	int ret;
@@ -55,6 +55,7 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	ep->ep_fid.fid.fclass = FI_CLASS_EP;
 	ep->ep_fid.fid.context = context;
 	ep->domain = util_domain;
+	ep->progress = progress;
 	atomic_inc(&util_domain->ref);
 	return 0;
 }


### PR DESCRIPTION
- rxm: use single msg CQ. When CQ is progressed progress each EP bound to it.
- util: Add provider defined strerror function for util CQ.
- util: Pass util_cq for EP progress function to easily identify the CQ to write completion.
- rxd: define a cq_strerror function.