### PR TITLE
prov/gni: Adjust hints:caps in transmit crit tests

### DIFF
--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -112,8 +112,9 @@ void common_atomic_setup(void)
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
-	hints->fabric_attr->name = strdup("gni");
-	hints->caps |= GNIX_EP_RDM_PRIMARY_CAPS;
+	hints->fabric_attr->prov_name = strdup("gni");
+	hints->caps |= FI_ATOMIC | FI_READ | FI_REMOTE_READ |
+		       FI_WRITE | FI_REMOTE_WRITE;
 
 	target = malloc(BUF_SZ);
 	assert(target);

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -107,7 +107,8 @@ void common_setup(void)
 
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
-	hints->caps |= GNIX_EP_RDM_PRIMARY_CAPS;
+	hints->caps |= FI_RMA | FI_READ | FI_REMOTE_READ |
+		       FI_WRITE | FI_REMOTE_WRITE;
 
 	hints->fabric_attr->name = strdup("gni");
 

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -319,7 +319,8 @@ void rdm_sr_bnd_ep_setup(void)
 
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->mode = ~0;
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
+	hints->caps = FI_SOURCE | FI_MSG;
 
 	ret = gethostname(my_hostname, sizeof(my_hostname));
 	cr_assert(!ret, "gethostname");


### PR DESCRIPTION
Specify the minimal set of capabilities necessary in RMA, atomic and send/recv
criterion tests.

@sungeunchoi 
Updates ofi-cray/libfabric-cray#866.
upstream merge of ofi-cray/libfabric-cray#1024

Signed-off-by: Zach <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@db68cf01fe0d97a9d8cc0d9657c9bf0d54144f05)

Conflicts:
	prov/gni/test/rdm_atomic.c
	prov/gni/test/rdm_sr.c