### PR TITLE
prov/gni: use a free list for VC's

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -173,6 +173,8 @@ struct gnix_nic {
 	struct dlist_entry work_vcs;
 	fastlock_t tx_vc_lock;
 	struct dlist_entry tx_vcs;
+	/* note this free list will be initialized for thread safe */
+	struct gnix_freelist vc_freelist;
 	uint8_t ptag;
 	uint32_t cookie;
 	uint32_t device_id;

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -89,6 +90,8 @@ enum gnix_vc_conn_req_type {
  * @var tx_queue             TX request queue
  * @var tx_queue_lock        TX request queue lock
  * @var tx_list              NIC TX VC list
+ * @var list                 used for unmapped vc list
+ * @var fr_list              used for vc free list
  * @var entry                used internally for managing linked lists
  *                           of vc structs that require O(1) insertion/removal
  * @var peer_fi_addr         FI address of peer with which this VC is connected
@@ -127,6 +130,7 @@ struct gnix_vc {
 	struct dlist_entry tx_list;	/* TX VC list entry */
 
 	struct dlist_entry list;	/* General purpose list */
+	struct dlist_entry fr_list;	/* fr list */
 	fi_addr_t peer_fi_addr;
 	struct gnix_address peer_addr;
 	struct gnix_address peer_cm_nic_addr;

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -353,8 +353,10 @@ static void  __cm_nic_destruct(void *obj)
 		cm_nic->addr_to_ep_ht = NULL;
 	}
 
-	if (cm_nic->nic != NULL)
+	if (cm_nic->nic != NULL) {
 		_gnix_ref_put(cm_nic->nic);
+		cm_nic->nic = NULL;
+	}
 
 	cm_nic->domain->cm_nic = NULL;
 	free(cm_nic);


### PR DESCRIPTION
Turns out some of the criterion tests which intentionally
do things to check for errors, etc. have a tendency to
bring out some issues in the destruction of objects within
the GNI provider when EPs, domains, etc. are closed and
there are outstanding transactions/GNI RX CQEs etc. still
outstanding.  As a partial step to addressing this implement
a nic-based free list of VC's that aren't completely destructed
till the nic is destructed.

Also be more careful when processing GNI RX CQEs.

upstream merge of ofi-cray/libfabric-cray#1029
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@60893468f302108ed93d7685b2e44840f602949d)