### PR TITLE
prov/gni: pacify gnu compiler

### DIFF
--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -400,7 +400,8 @@ static int map_reverse_lookup(struct gnix_fid_av *av_priv,
 
 			if ((index >= 0) && (index < entry->rx_ctx_cnt)) {
 				/* we have a match */
-				rx_addr = *(fi_addr_t *)&entry->gnix_addr;
+				memcpy(&rx_addr, &entry->gnix_addr,
+					sizeof(fi_addr_t));
 				*fi_addr = fi_rx_addr(rx_addr,
 						      index,
 						      av_priv->rx_ctx_bits);

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -75,7 +75,6 @@ static void __trx_destruct(void *obj)
 	struct gnix_fid_trx *trx = (struct gnix_fid_trx *) obj;
 	struct gnix_fid_ep *ep_priv;
 	struct gnix_fid_sep *sep_priv;
-	struct fid_domain *domain;
 	int refs_held;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
@@ -84,8 +83,6 @@ static void __trx_destruct(void *obj)
 	assert(ep_priv != NULL);
 	sep_priv = trx->sep;
 	assert(sep_priv != NULL);
-	domain = sep_priv->domain;
-	assert(domain != NULL);
 
 	refs_held = _gnix_ref_put(ep_priv);
 	if (refs_held == 0)


### PR DESCRIPTION
fix some warnings being emitted by gcc
upstream merge of ofi-cray/libfabric-cray#1039
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@b3d9a4226128fe23dde3eb1904675a65bb97a93c)