### PR TITLE
prov/gni: fix argument checking for GNI atomics

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -724,7 +724,6 @@ struct gnix_fab_req_amo {
 	enum fi_op               op;
 	uint64_t                 first_operand;
 	uint64_t                 second_operand;
-	void                     *read_buf;
 };
 
 /*

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -3055,17 +3055,15 @@ void do_fetch_atomic_read(int len)
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe = { (void *) -1, UINT_MAX, UINT_MAX,
 					  (void *) -1, UINT_MAX, UINT_MAX };
-	uint64_t operand;
 	float operand_fp;
 	double operand_dp;
 	uint64_t w[NUMEPS] = {0}, r[NUMEPS] = {0}, w_e[NUMEPS] = {0};
 	uint64_t r_e[NUMEPS] = {0};
 
 	/* u64 */
-	operand = SOURCE_DATA;
 	*((uint64_t *)source) = FETCH_SOURCE_DATA;
 	*((uint64_t *)target) = TARGET_DATA;
-	sz = fi_fetch_atomic(ep[0], &operand, 1, NULL,
+	sz = fi_fetch_atomic(ep[0], NULL, 1, NULL,
 			     source, loc_mr[0], gni_addr[1], (uint64_t)target,
 			     mr_key[1], FI_UINT64, FI_ATOMIC_READ, target);
 	cr_assert_eq(sz, 0);
@@ -3086,14 +3084,11 @@ void do_fetch_atomic_read(int len)
 	cr_assert(ret, "Data mismatch");
 	ret = *((uint64_t *)source) == (uint64_t)TARGET_DATA;
 	cr_assert(ret, "Fetch data mismatch");
-	ret = *((uint64_t *)&operand) == TARGET_DATA;
-	cr_assert(ret, "Read data mismatch");
 
 	/* U32 */
-	operand = SOURCE_DATA;
 	*((uint64_t *)source) = FETCH_SOURCE_DATA;
 	*((uint64_t *)target) = TARGET_DATA;
-	sz = fi_fetch_atomic(ep[0], &operand, 1, NULL,
+	sz = fi_fetch_atomic(ep[0], NULL, 1, NULL,
 			     source, loc_mr[0], gni_addr[1], (uint64_t)target,
 			     mr_key[1], FI_UINT32, FI_ATOMIC_READ, target);
 	cr_assert_eq(sz, 0);
@@ -3117,16 +3112,11 @@ void do_fetch_atomic_read(int len)
 		(uint64_t)((TARGET_DATA & U32_MASK) |
 			   (FETCH_SOURCE_DATA & (U32_MASK << 32)));
 	cr_assert(ret, "Fetch data mismatch");
-	ret = *((uint64_t *)&operand) ==
-		(uint64_t)((TARGET_DATA & U32_MASK) |
-			   (SOURCE_DATA & (U32_MASK << 32)));
-	cr_assert(ret, "Read data mismatch");
 
 	/* i64 */
-	operand = SOURCE_DATA;
 	*((uint64_t *)source) = FETCH_SOURCE_DATA;
 	*((uint64_t *)target) = TARGET_DATA;
-	sz = fi_fetch_atomic(ep[0], &operand, 1, NULL,
+	sz = fi_fetch_atomic(ep[0], NULL, 1, NULL,
 			     source, loc_mr[0], gni_addr[1], (uint64_t)target,
 			     mr_key[1], FI_INT64, FI_ATOMIC_READ, target);
 	cr_assert_eq(sz, 0);
@@ -3148,14 +3138,11 @@ void do_fetch_atomic_read(int len)
 	cr_assert(ret, "Data mismatch");
 	ret = *((uint64_t *)source) == TARGET_DATA;
 	cr_assert(ret, "Fetch data mismatch");
-	ret = *((uint64_t *)&operand) == TARGET_DATA;
-	cr_assert(ret, "Read data mismatch");
 
 	/* i32 */
-	operand = SOURCE_DATA;
 	*((uint64_t *)source) = FETCH_SOURCE_DATA;
 	*((uint64_t *)target) = TARGET_DATA;
-	sz = fi_fetch_atomic(ep[0], &operand, 1, NULL,
+	sz = fi_fetch_atomic(ep[0], NULL, 1, NULL,
 			     source, loc_mr[0], gni_addr[1], (uint64_t)target,
 			     mr_key[1], FI_INT32, FI_ATOMIC_READ, target);
 	cr_assert_eq(sz, 0);
@@ -3179,16 +3166,12 @@ void do_fetch_atomic_read(int len)
 		(uint64_t)((TARGET_DATA & U32_MASK) |
 			   (FETCH_SOURCE_DATA & (U32_MASK << 32)));
 	cr_assert(ret, "Fetch data mismatch");
-	ret = *((uint64_t *)&operand) ==
-		(uint64_t)((TARGET_DATA & U32_MASK) |
-			   (SOURCE_DATA & (U32_MASK << 32)));
-	cr_assert(ret, "Read data mismatch");
 
 	/* float */
 	*((float *)&operand_fp) = SOURCE_DATA_FP;
 	*((float *)source) = FETCH_SOURCE_DATA;
 	*((float *)target) = TARGET_DATA_FP;
-	sz = fi_fetch_atomic(ep[0], &operand_fp, 1, NULL,
+	sz = fi_fetch_atomic(ep[0], NULL, 1, NULL,
 			     source, loc_mr[0], gni_addr[1], (uint64_t)target,
 			     mr_key[1], FI_FLOAT, FI_ATOMIC_READ, target);
 	cr_assert_eq(sz, 0);
@@ -3210,14 +3193,12 @@ void do_fetch_atomic_read(int len)
 	cr_assert(ret, "Data mismatch");
 	ret = *((float *)source) == (float)TARGET_DATA_FP;
 	cr_assert(ret, "Fetch data mismatch");
-	ret = *((float *)&operand_fp) == (float)TARGET_DATA_FP;
-	cr_assert(ret, "Read data mismatch");
 
 	/* double */
 	*(double *)&operand_dp = SOURCE_DATA_FP;
 	*((double *)source) = FETCH_SOURCE_DATA;
 	*((double *)target) = TARGET_DATA_FP;
-	sz = fi_fetch_atomic(ep[0], &operand_dp, 1, NULL,
+	sz = fi_fetch_atomic(ep[0], NULL, 1, NULL,
 			     source, loc_mr[0], gni_addr[1], (uint64_t)target,
 			     mr_key[1], FI_DOUBLE, FI_ATOMIC_READ, target);
 	cr_assert_eq(sz, 0);
@@ -3239,8 +3220,6 @@ void do_fetch_atomic_read(int len)
 	cr_assert(ret, "Data mismatch");
 	ret = *((double *)source) == (double)TARGET_DATA_FP;
 	cr_assert(ret, "Fetch data mismatch");
-	ret = *((double *)&operand_dp) == (double)TARGET_DATA_FP;
-	cr_assert(ret, "Read data mismatch");
 }
 
 Test(rdm_atomic, fetch_atomic_read)


### PR DESCRIPTION
The GNI provider wasn't handling the special case
of FI_ATOMIC_READ properly both with argument checking
and where the return value would be stored.

There seemed to have been general confusion here about
the FI_ATOMIC_READ operation.

With these fixes, three previously failing SOS unit
tests now pass.

Fix related criterion test.
@sungeunchoi 

Fixes ofi-cray/libfabric-cray#1021

upstream merge of ofi-cray/libfabric-cray#1035

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@cb31f634549e6956334b9907df1754774737183d)