### PR TITLE
util: Use provider specific strerror function + refactoring

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -227,6 +227,16 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 		 ofi_cq_progress_func progress, void *context);
 void ofi_cq_progress(struct util_cq *cq);
 int ofi_cq_cleanup(struct util_cq *cq);
+ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count);
+ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
+		fi_addr_t *src_addr);
+ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
+		uint64_t flags);
+ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
+		const void *cond, int timeout);
+ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
+		fi_addr_t *src_addr, const void *cond, int timeout);
+int ofi_cq_signal(struct fid_cq *cq_fid);
 
 /*
  * Counter

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -178,7 +178,7 @@ struct util_ep {
 
 int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_prov,
 		struct fi_info *info, struct util_ep *ep, void *context,
-		enum fi_match_type type);
+		ofi_ep_progress_func progress, enum fi_match_type type);
 
 int ofi_endpoint_close(struct util_ep *util_ep);
 

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -163,7 +163,7 @@ int ofi_domain_close(struct util_domain *domain);
  */
 
 struct util_ep;
-typedef void (*fi_ep_progress_func)(struct util_ep *util_ep);
+typedef void (*ofi_ep_progress_func)(struct util_ep *util_ep);
 
 struct util_ep {
 	struct fid_ep		ep_fid;
@@ -173,7 +173,7 @@ struct util_ep {
 	struct util_cq		*tx_cq;
 	uint64_t		caps;
 	uint64_t		flags;
-	fi_ep_progress_func	progress;
+	ofi_ep_progress_func	progress;
 };
 
 int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_prov,
@@ -202,14 +202,15 @@ struct util_cq_err_entry {
 
 DECLARE_CIRQUE(struct fi_cq_tagged_entry, util_comp_cirq);
 
-typedef void (*fi_cq_progress_func)(struct util_cq *cq);
+typedef void (*ofi_cq_progress_func)(struct util_cq *cq);
+
 struct util_cq {
 	struct fid_cq		cq_fid;
 	struct util_domain	*domain;
 	struct util_wait	*wait;
 	atomic_t		ref;
-	struct dlist_entry	list;
-	fastlock_t		list_lock;
+	struct dlist_entry	ep_list;
+	fastlock_t		ep_list_lock;
 	fastlock_t		cq_lock;
 
 	struct util_comp_cirq	*cirq;
@@ -218,12 +219,12 @@ struct util_cq {
 	struct slist		err_list;
 	fi_cq_read_func		read_entry;
 	int			internal_wait;
-	fi_cq_progress_func	progress;
+	ofi_cq_progress_func	progress;
 };
 
 int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 		 struct fi_cq_attr *attr, struct util_cq *cq,
-		 fi_cq_progress_func progress, void *context);
+		 ofi_cq_progress_func progress, void *context);
 void ofi_cq_progress(struct util_cq *cq);
 int ofi_cq_cleanup(struct util_cq *cq);
 

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -36,6 +36,13 @@
 #include <inttypes.h>
 #include "rxd.h"
 
+static const char *rxd_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
+		const void *err_data, char *buf, size_t len)
+{
+	struct rxd_cq *rxd_cq = container_of(cq_fid, struct rxd_cq, util_cq.cq_fid);
+	return fi_cq_strerror(rxd_cq->dg_cq, prov_errno, err_data, buf, len);
+}
+
 static int rxd_cq_write_ctx(struct rxd_cq *cq,
 			     struct fi_cq_tagged_entry *cq_entry)
 {
@@ -1278,6 +1285,17 @@ static struct fi_ops rxd_cq_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
+static struct fi_ops_cq rxd_cq_ops = {
+	.size = sizeof(struct fi_ops_cq),
+	.read = ofi_cq_read,
+	.readfrom = ofi_cq_readfrom,
+	.readerr = ofi_cq_readerr,
+	.sread = ofi_cq_sread,
+	.sreadfrom = ofi_cq_sreadfrom,
+	.signal = ofi_cq_signal,
+	.strerror = rxd_cq_strerror,
+};
+
 int rxd_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq_fid, void *context)
 {
@@ -1341,7 +1359,7 @@ int rxd_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	*cq_fid = &cq->util_cq.cq_fid;
 	(*cq_fid)->fid.ops = &rxd_cq_fi_ops;
-	*cq_fid = &cq->util_cq.cq_fid;
+	(*cq_fid)->ops = &rxd_cq_ops;
 	cq->domain = rxd_domain;
 	return 0;
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -227,7 +227,7 @@ static int rxm_ep_close(struct fid *fid)
 	if (rxm_ep->util_ep.tx_cq)
 		atomic_dec(&rxm_ep->util_ep.tx_cq->ref);
 
-	atomic_dec(&rxm_ep->util_ep.domain->ref);
+	ofi_endpoint_close(&rxm_ep->util_ep);
 	free(rxm_ep);
 	return retv;
 }
@@ -407,7 +407,7 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 		return -FI_ENOMEM;
 
 	ret = ofi_endpoint_init(domain, &rxm_util_prov, info, &rxm_ep->util_ep,
-			context, FI_MATCH_PREFIX);
+			context, NULL, FI_MATCH_PREFIX);
 	if (ret)
 		goto err;
 

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -379,7 +379,7 @@ static int udpx_ep_close(struct fid *fid)
 
 	udpx_rx_cirq_free(ep->rxq);
 	close(ep->sock);
-	atomic_dec(&ep->util_ep.domain->ref);
+	ofi_endpoint_close(&ep->util_ep);
 	free(ep);
 	return 0;
 }
@@ -574,16 +574,14 @@ int udpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct udpx_ep *ep;
 	int ret;
 
-	if (!info || !info->ep_attr || !info->rx_attr || !info->tx_attr)
-		return -FI_EINVAL;
-
-	ret = udpx_check_info(info);
-	if (ret)
-		return ret;
-
 	ep = calloc(1, sizeof(*ep));
 	if (!ep)
 		return -FI_ENOMEM;
+
+	ret = ofi_endpoint_init(domain, &udpx_util_prov, info, &ep->util_ep,
+			context, udpx_ep_progress, FI_MATCH_EXACT);
+	if (ret)
+		goto err;
 
 	ret = udpx_ep_init(ep, info);
 	if (ret) {
@@ -591,17 +589,14 @@ int udpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 		return ret;
 	}
 
-	ep->util_ep.ep_fid.fid.fclass = FI_CLASS_EP;
-	ep->util_ep.ep_fid.fid.context = context;
-	ep->util_ep.ep_fid.fid.ops = &udpx_ep_fi_ops;
-	ep->util_ep.ep_fid.ops = &udpx_ep_ops;
-	ep->util_ep.ep_fid.cm = &udpx_cm_ops;
-	ep->util_ep.ep_fid.msg = &udpx_msg_ops;
-	ep->util_ep.progress = udpx_ep_progress;
-
-	ep->util_ep.domain = container_of(domain, struct util_domain, domain_fid);
-	atomic_inc(&ep->util_ep.domain->ref);
-
 	*ep_fid = &ep->util_ep.ep_fid;
+	(*ep_fid)->fid.ops = &udpx_ep_fi_ops;
+	(*ep_fid)->ops = &udpx_ep_ops;
+	(*ep_fid)->cm = &udpx_cm_ops;
+	(*ep_fid)->msg = &udpx_msg_ops;
+
 	return 0;
+err:
+	free(ep);
+	return ret;
 }

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -368,8 +368,8 @@ static int udpx_ep_close(struct fid *fid)
 					    struct util_wait_fd, util_wait);
 			fi_epoll_del(wait->epoll_fd, ep->sock);
 		}
-		fid_list_remove(&ep->util_ep.rx_cq->list,
-				&ep->util_ep.rx_cq->list_lock,
+		fid_list_remove(&ep->util_ep.rx_cq->ep_list,
+				&ep->util_ep.rx_cq->ep_list_lock,
 				&ep->util_ep.ep_fid.fid);
 		atomic_dec(&ep->util_ep.rx_cq->ref);
 	}
@@ -428,8 +428,8 @@ static int udpx_ep_bind_cq(struct udpx_ep *ep, struct util_cq *cq, uint64_t flag
 				      udpx_rx_src_comp : udpx_rx_comp;
 		}
 
-		ret = fid_list_insert(&cq->list,
-				      &cq->list_lock,
+		ret = fid_list_insert(&cq->ep_list,
+				      &cq->ep_list_lock,
 				      &ep->util_ep.ep_fid.fid);
 		if (ret)
 			return ret;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -114,7 +114,7 @@ static void util_cq_read_tagged(void **dst, void *src)
 	*(char **)dst += sizeof(struct fi_cq_tagged_entry);
 }
 
-static ssize_t util_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
+ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 {
 	struct util_cq *cq;
 	struct fi_cq_tagged_entry *entry;
@@ -150,8 +150,8 @@ out:
 	return i;
 }
 
-static ssize_t util_cq_readfrom(struct fid_cq *cq_fid, void *buf,
-				size_t count, fi_addr_t *src_addr)
+ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
+		fi_addr_t *src_addr)
 {
 	struct util_cq *cq;
 	struct fi_cq_tagged_entry *entry;
@@ -159,7 +159,7 @@ static ssize_t util_cq_readfrom(struct fid_cq *cq_fid, void *buf,
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 	if (!cq->src) {
-		i = util_cq_read(cq_fid, buf, count);
+		i = ofi_cq_read(cq_fid, buf, count);
 		if (i > 0) {
 			for (count = 0; count < i; count++)
 				src_addr[i] = FI_ADDR_NOTAVAIL;
@@ -197,8 +197,8 @@ out:
 	return i;
 }
 
-static ssize_t util_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
-			       uint64_t flags)
+ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
+		uint64_t flags)
 {
 	struct util_cq *cq;
 	struct util_cq_err_entry *err;
@@ -222,30 +222,29 @@ static ssize_t util_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *bu
 	return ret;
 }
 
-static ssize_t util_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
-			     const void *cond, int timeout)
+ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
+		const void *cond, int timeout)
 {
 	struct util_cq *cq;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 	assert(cq->wait && cq->internal_wait);
 	fi_wait(&cq->wait->wait_fid, timeout);
-	return util_cq_read(cq_fid, buf, count);
+	return ofi_cq_read(cq_fid, buf, count);
 }
 
-static ssize_t util_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
-				 fi_addr_t *src_addr, const void *cond,
-				 int timeout)
+ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
+		fi_addr_t *src_addr, const void *cond, int timeout)
 {
 	struct util_cq *cq;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 	assert(cq->wait && cq->internal_wait);
 	fi_wait(&cq->wait->wait_fid, timeout);
-	return util_cq_readfrom(cq_fid, buf, count, src_addr);
+	return ofi_cq_readfrom(cq_fid, buf, count, src_addr);
 }
 
-static int util_cq_signal(struct fid_cq *cq_fid)
+int ofi_cq_signal(struct fid_cq *cq_fid)
 {
 	struct util_cq *cq;
 
@@ -263,12 +262,12 @@ static const char *util_cq_strerror(struct fid_cq *cq, int prov_errno,
 
 static struct fi_ops_cq util_cq_ops = {
 	.size = sizeof(struct fi_ops_cq),
-	.read = util_cq_read,
-	.readfrom = util_cq_readfrom,
-	.readerr = util_cq_readerr,
-	.sread = util_cq_sread,
-	.sreadfrom = util_cq_sreadfrom,
-	.signal = util_cq_signal,
+	.read = ofi_cq_read,
+	.readfrom = ofi_cq_readfrom,
+	.readerr = ofi_cq_readerr,
+	.sread = ofi_cq_sread,
+	.sreadfrom = ofi_cq_sreadfrom,
+	.signal = ofi_cq_signal,
 	.strerror = util_cq_strerror,
 };
 

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -38,7 +38,7 @@
 
 int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_prov,
 		struct fi_info *info, struct util_ep *ep, void *context,
-		enum fi_match_type type)
+		ofi_ep_progress_func progress, enum fi_match_type type)
 {
 	struct util_domain *util_domain;
 	int ret;
@@ -55,6 +55,7 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	ep->ep_fid.fid.fclass = FI_CLASS_EP;
 	ep->ep_fid.fid.context = context;
 	ep->domain = util_domain;
+	ep->progress = progress;
 	atomic_inc(&util_domain->ref);
 	return 0;
 }


### PR DESCRIPTION
- The prov_errno might not correspond to typical errno. We need
  to use provider specific strerror function to get a meaningful
  error string.
- Use common endpoint init function in UDP provider.