### PR TITLE
rxm: Add support for FI_TAGGED + misc updates

### DIFF
--- a/prov/rxm/Makefile.include
+++ b/prov/rxm/Makefile.include
@@ -7,6 +7,7 @@ _rxm_files = \
        prov/rxm/src/rxm_conn.c		\
        prov/rxm/src/rxm_ep.c		\
        prov/rxm/src/rxm_cq.c		\
+       prov/rxm/src/rxm.c		\
        prov/rxm/src/rxm.h
 
 if HAVE_RXM_DL

--- a/prov/rxm/src/rxm.c
+++ b/prov/rxm/src/rxm.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "rxm.h"
+
+char *rxm_lmt_state_str[] = {
+	RXM_LMT_STATES(STR)
+};

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
- * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -35,8 +34,10 @@
 #  include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#include <pthread.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
@@ -49,6 +50,7 @@
 #include <fi_enosys.h>
 #include <fi_util.h>
 #include <fi_list.h>
+#include <fi_proto.h>
 
 #ifndef _RXM_H_
 #define _RXM_H_
@@ -57,6 +59,28 @@
 
 #define RXM_MAJOR_VERSION 1
 #define RXM_MINOR_VERSION 0
+
+#define RXM_IOV_LIMIT 4
+
+/*
+ * Macros to generate enums and associated string values
+ * e.g.
+ * #define RXM_STATES(FUNC)	\
+ * 	FUNC(STATE1),		\
+ * 	FUNC(STATE2),		\
+ * 	...			\
+ * 	FUNC(STATEn)
+ *
+ * enum rxm_state {
+ * 	RXM_STATES(ENUM_VAL)
+ * };
+ *
+ * char *rxm_state_str[] = {
+ * 	RXM_STATES(STR)
+ * };
+ */
+#define ENUM(X) X
+#define STR(X) #X
 
 extern struct fi_provider rxm_prov;
 extern struct util_prov rxm_util_prov;
@@ -83,25 +107,158 @@ struct rxm_mr {
 	struct fid_mr *msg_mr;
 };
 
-struct rxm_cq {
-	struct util_cq util_cq;
-	struct fid_cq *msg_cq;
+struct rxm_cm_data {
+	struct sockaddr name;
+	uint64_t conn_id;
+};
+
+struct rxm_rma_iov {
+	uint32_t count;
+	struct ofi_rma_iov iov[];
+};
+
+/* States for large message transfer */
+#define RXM_LMT_STATES(FUNC)	\
+	FUNC(RXM_LMT_NONE),	\
+	FUNC(RXM_LMT_START),	\
+	FUNC(RXM_LMT_ACK),	\
+	FUNC(RXM_LMT_FINISH),
+
+enum rxm_lmt_state {
+	RXM_LMT_STATES(ENUM)
+};
+
+extern char *rxm_lmt_state_str[];
+
+struct rxm_pkt {
+	struct ofi_ctrl_hdr ctrl_hdr;
+	struct ofi_op_hdr hdr;
+	char data[];
+};
+
+struct rxm_recv_match_attr {
+	fi_addr_t addr;
+	uint64_t tag;
+	uint64_t ignore;
+};
+
+enum rxm_ctx_type {
+	RXM_TX_ENTRY,
+	RXM_RX_BUF,
+};
+
+struct rxm_unexp_msg {
+	struct dlist_entry entry;
+	fi_addr_t addr;
+	uint64_t tag;
+};
+
+struct rxm_match_iov {
+	struct iovec *iov;
+	void **desc;
+	size_t count;
+	size_t index;
+	size_t offset;
+};
+
+struct rxm_iovx_entry {
+	struct iovec iov[RXM_IOV_LIMIT];
+	void *desc[RXM_IOV_LIMIT];
+	uint8_t count;
+};
+
+struct rxm_rx_buf {
+	enum rxm_ctx_type ctx_type;
+	struct slist_entry entry;
+	struct rxm_ep *ep;
+	struct rxm_conn *conn;
+	struct rxm_recv_fs *recv_fs;
+	struct rxm_recv_entry *recv_entry;
+	struct rxm_unexp_msg unexp_msg;
+
+	/* Used for large messages */
+	enum rxm_lmt_state state;
+	struct rxm_match_iov match_iov;
+	struct rxm_rma_iov *rma_iov;
+	size_t index;
+
+	struct rxm_pkt pkt;
+};
+
+#define RXM_BUF_SIZE 4096
+#define RXM_TX_DATA_SIZE (RXM_BUF_SIZE - sizeof(struct rxm_pkt))
+
+struct rxm_tx_entry {
+	enum rxm_ctx_type ctx_type;
+	struct rxm_ep *ep;
+	void *context;
+	// TODO use a tx_buf instead. Add posted tx_buf to list for clean up
+	// on endpont close: similar to rx_buf
+	struct rxm_pkt *pkt;
+
+	/* Used for large messages */
+	enum rxm_lmt_state state;
+	uint64_t msg_id;
+};
+DECLARE_FREESTACK(struct rxm_tx_entry, rxm_txe_fs);
+
+struct rxm_recv_entry {
+	struct dlist_entry entry;
+	struct iovec iov[RXM_IOV_LIMIT];
+	void *desc[RXM_IOV_LIMIT];
+	uint8_t count;
+	fi_addr_t addr;
+	void *context;
+	uint64_t flags;
+	uint64_t tag;
+	uint64_t ignore;
+};
+DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
+
+struct rxm_recv_queue {
+	struct rxm_recv_fs *recv_fs;
+	struct dlist_entry recv_list;
+	struct dlist_entry unexp_msg_list;
 };
 
 struct rxm_ep {
 	struct util_ep util_ep;
+	struct fi_info *rxm_info;
 	struct fi_info *msg_info;
 	struct fid_pep *msg_pep;
-	struct rxm_cq *tx_cq;
-	struct rxm_cq *rx_cq;
+	struct fid_cq *msg_cq;
 	struct fid_ep *srx_ctx;
 	struct util_cmap *cmap;
+
+	struct util_buf_pool *tx_pool;
+	struct slist tx_buf_list;
+
+	struct util_buf_pool *rx_pool;
+	struct slist rx_buf_list;
+
+	struct rxm_txe_fs *txe_fs;
+	struct ofi_key_idx tx_key_idx;
+
+	struct rxm_recv_queue recv_queue;
+	struct rxm_recv_queue trecv_queue;
 };
 
 extern struct fi_provider rxm_prov;
 extern struct fi_info rxm_info;
 extern struct fi_fabric_attr rxm_fabric_attr;
 extern struct fi_domain_attr rxm_domain_attr;
+
+// TODO move to common code?
+static inline int rxm_match_addr(fi_addr_t addr, fi_addr_t match_addr)
+{
+	return (addr == FI_ADDR_UNSPEC) || (match_addr == FI_ADDR_UNSPEC) ||
+		(addr == match_addr);
+}
+
+static inline int rxm_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_tag)
+{
+	return ((tag | ignore) == (match_tag | ignore));
+}
 
 int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 			void *context);
@@ -111,6 +268,12 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			     struct fid_domain **dom, void *context);
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 			 struct fid_cq **cq_fid, void *context);
+void rxm_cq_progress(struct fid_cq *msg_cq);
+int rxm_cq_comp(struct util_cq *util_cq, void *context, uint64_t flags, size_t len,
+		void *buf, uint64_t data, uint64_t tag);
+int rxm_cq_report_error(struct util_cq *util_cq, struct fi_cq_err_entry *err_entry);
+int rxm_cq_handle_data(struct rxm_rx_buf *rx_buf);
+
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  struct fid_ep **ep, void *context);
 
@@ -118,7 +281,12 @@ void *rxm_msg_listener(void *arg);
 int rxm_msg_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
 		struct fi_info *msg_info);
 int rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
-		void *data, ssize_t datalen);
-int rxm_get_msg_ep(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
-		struct fid_ep **msg_ep);
+		void *data);
 void rxm_conn_close(void *arg);
+int rxm_get_conn(struct rxm_ep *rxm_ep, fi_addr_t fi_addr, struct rxm_conn **rxm_conn);
+
+int rxm_ep_repost_buf(struct rxm_rx_buf *buf);
+int rxm_write_recv_comp(struct rxm_rx_buf *rx_buf);
+int ofi_match_addr(fi_addr_t addr, fi_addr_t match_addr);
+int ofi_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_tag);
+void rxm_pkt_init(struct rxm_pkt *pkt);

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -33,16 +33,19 @@
 #include "rxm.h"
 
 struct fi_tx_attr rxm_tx_attr = {
-	.caps = FI_MSG | FI_SEND,
+	.caps = FI_MSG | FI_TAGGED | FI_SEND,
 	.comp_order = FI_ORDER_STRICT,
+	// TODO set correct inject size and support inject
 	.inject_size = 0,
 	.size = 1024,
+	.iov_limit = RXM_IOV_LIMIT,
 };
 
 struct fi_rx_attr rxm_rx_attr = {
-	.caps = FI_MSG | FI_RECV,
+	.caps = FI_MSG | FI_TAGGED | FI_RECV,
 	.comp_order = FI_ORDER_STRICT,
 	.size = 1024,
+	.iov_limit= RXM_IOV_LIMIT,
 };
 
 struct fi_ep_attr rxm_ep_attr = {
@@ -77,8 +80,8 @@ struct fi_fabric_attr rxm_fabric_attr = {
 };
 
 struct fi_info rxm_info = {
-	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE,
-	.mode = FI_LOCAL_MR,
+	.caps = FI_MSG | FI_TAGGED | FI_SEND | FI_RECV | FI_SOURCE | FI_DIRECTED_RECV,
+	.mode = FI_LOCAL_MR, // TODO remove this requirement
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxm_tx_attr,
 	.rx_attr = &rxm_rx_attr,

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -32,84 +32,475 @@
 
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
+
+#include "fi.h"
+#include <fi_iov.h>
 
 #include "rxm.h"
 
-static const char *rxm_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
-	       const void *err_data, char *buf, size_t len)
+static int rxm_match_recv_entry(struct dlist_entry *item, const void *arg)
 {
-	struct rxm_cq *rxm_cq = container_of(cq_fid, struct rxm_cq, util_cq.cq_fid);
-	return fi_cq_strerror(rxm_cq->msg_cq, prov_errno, err_data, buf, len);
+	struct rxm_recv_match_attr *attr = (struct rxm_recv_match_attr *) arg;
+	struct rxm_recv_entry *recv_entry;
+
+	recv_entry = container_of(item, struct rxm_recv_entry, entry);
+	return rxm_match_addr(recv_entry->addr, attr->addr);
 }
 
-static int rxm_msg_cq_read(struct util_cq *util_cq, struct fid_cq *cq,
-		struct fi_cq_tagged_entry *comp)
+static int rxm_match_recv_entry_tagged(struct dlist_entry *item, const void *arg)
+{
+	struct rxm_recv_match_attr *attr = (struct rxm_recv_match_attr *)arg;
+	struct rxm_recv_entry *recv_entry;
+
+	recv_entry = container_of(item, struct rxm_recv_entry, entry);
+	return rxm_match_addr(recv_entry->addr, attr->addr) &&
+		rxm_match_tag(recv_entry->tag, recv_entry->ignore, attr->tag);
+}
+
+static struct rxm_conn *rxm_key2conn(struct rxm_ep *rxm_ep, uint64_t key)
+{
+	struct util_cmap_handle *handle;
+	handle = ofi_cmap_key2handle(rxm_ep->cmap, key);
+	if (!handle) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Can't find handle!\n");
+		return NULL;
+	}
+	if (handle->key != key) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+				"handle->key not matching with given key!\n");
+		return NULL;
+	}
+
+	return container_of(handle, struct rxm_conn, handle);
+}
+
+static const char *rxm_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
+		const void *err_data, char *buf, size_t len)
+{
+	struct util_cq *cq;
+	struct rxm_ep *rxm_ep;
+	struct fid_list_entry *fid_entry;
+
+	cq = container_of(cq_fid, struct util_cq, cq_fid);
+	fid_entry = container_of(cq->ep_list.next, struct fid_list_entry, entry);
+	rxm_ep = container_of(fid_entry->fid, struct rxm_ep, util_ep.ep_fid);
+
+	return fi_cq_strerror(rxm_ep->msg_cq, prov_errno, err_data, buf, len);
+}
+
+int rxm_cq_report_error(struct util_cq *util_cq, struct fi_cq_err_entry *err_entry)
 {
 	struct util_cq_err_entry *entry;
+	struct fi_cq_tagged_entry *comp;
+
+	entry = calloc(1, sizeof(*entry));
+	if (!entry) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+				"Unable to allocate util_cq_err_entry\n");
+		return -FI_ENOMEM;
+	}
+
+	entry->err_entry = *err_entry;
+	fastlock_acquire(&util_cq->cq_lock);
+	slist_insert_tail(&entry->list_entry, &util_cq->err_list);
+
+	comp = cirque_tail(util_cq->cirq);
+	comp->flags = UTIL_FLAG_ERROR;
+	cirque_commit(util_cq->cirq);
+	fastlock_release(&util_cq->cq_lock);
+
+	return 0;
+}
+
+int rxm_cq_comp(struct util_cq *util_cq, void *context, uint64_t flags, size_t len,
+		void *buf, uint64_t data, uint64_t tag)
+{
+	struct fi_cq_tagged_entry *comp;
+	int ret = 0;
+
+	fastlock_acquire(&util_cq->cq_lock);
+	if (cirque_isfull(util_cq->cirq)) {
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "util_cq cirq is full!\n");
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	comp = cirque_tail(util_cq->cirq);
+	comp->op_context = context;
+	comp->flags = flags;
+	comp->len = len;
+	comp->buf = buf;
+	comp->data = data;
+	cirque_commit(util_cq->cirq);
+out:
+	fastlock_release(&util_cq->cq_lock);
+	return ret;
+}
+
+int rxm_write_recv_comp(struct rxm_rx_buf *rx_buf)
+{
 	int ret;
 
-	ret = fi_cq_read(cq, comp, 1);
-	if (ret == -FI_EAVAIL) {
-		entry = calloc(1, sizeof(*entry));
-		if (!entry) {
+	// TODO deal with other flags, specify recv buf
+	ret = rxm_cq_comp(rx_buf->ep->util_ep.rx_cq, rx_buf->recv_entry->context,
+			FI_RECV, rx_buf->pkt.hdr.size, NULL, rx_buf->pkt.hdr.data,
+			rx_buf->pkt.hdr.tag);
+	if (ret) {
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "Unable to write recv completion\n");
+		return ret;
+	}
+
+	freestack_push(rx_buf->recv_fs, rx_buf->recv_entry);
+
+	return rxm_ep_repost_buf(rx_buf);
+}
+
+int rxm_write_send_comp(struct rxm_tx_entry *tx_entry)
+{
+	int ret;
+
+	util_buf_release(tx_entry->ep->tx_pool, tx_entry->pkt);
+	ret = rxm_cq_comp(tx_entry->ep->util_ep.tx_cq, tx_entry->context,
+			FI_SEND, 0, NULL, 0, 0);
+	if (ret) {
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "Unable to write send comletion\n");
+		return ret;
+	}
+
+	freestack_push(tx_entry->ep->txe_fs, tx_entry);
+	return 0;
+}
+
+/* Get an iov whose size matches given length */
+static void rxm_match_iov(struct rxm_match_iov *match_iov, size_t len,
+		struct rxm_iovx_entry *iovx)
+{
+	int i, j;
+
+	for (i = match_iov->index, j = 0; i < match_iov->count; i++) {
+		iovx->iov[j].iov_base = (char *)match_iov->iov[i].iov_base + match_iov->offset;
+		iovx->iov[j].iov_len = MIN(match_iov->iov[i].iov_len - match_iov->offset, len);
+		iovx->desc[j] = match_iov->desc[i];
+
+		len -= match_iov->iov[j].iov_len;
+		j++;
+		if (!len)
+			break;
+		match_iov->offset = 0;
+	}
+
+	iovx->count = j;
+	match_iov->index = i;
+	match_iov->offset += iovx->iov[j - 1].iov_len;
+}
+
+static int rxm_lmt_rma_read(struct rxm_rx_buf *rx_buf)
+{
+	struct rxm_iovx_entry iovx;
+	int i, ret;
+
+	memset(&iovx, 0, sizeof(iovx));
+
+	rxm_match_iov(&rx_buf->match_iov, rx_buf->rma_iov->iov[rx_buf->index].len, &iovx);
+
+	for (i = 0; i < iovx.count; i++)
+		iovx.desc[i] = fi_mr_desc(iovx.desc[i]);
+
+	ret = fi_readv(rx_buf->conn->msg_ep, iovx.iov, iovx.desc, iovx.count, 0,
+			rx_buf->rma_iov->iov[0].addr, rx_buf->rma_iov->iov[0].key, rx_buf);
+	// TODO do any cleanup?
+	if (ret)
+		return ret;
+	rx_buf->index++;
+	return 0;
+}
+
+int rxm_cq_handle_ack(struct rxm_rx_buf *rx_buf)
+{
+	struct rxm_tx_entry *tx_entry;
+	int ret, index;
+
+	FI_DBG(&rxm_prov, FI_LOG_CQ, "Got ACK for msg_id: 0x" PRIx64 "\n",
+			rx_buf->pkt.ctrl_hdr.msg_id);
+
+	index = ofi_key2idx(&rx_buf->ep->tx_key_idx, rx_buf->pkt.ctrl_hdr.msg_id);
+	tx_entry = &rx_buf->ep->txe_fs->buf[index];
+
+	assert(tx_entry->msg_id == rx_buf->pkt.ctrl_hdr.msg_id);
+	assert(tx_entry->state == RXM_LMT_ACK);
+
+	FI_DBG(&rxm_prov, FI_LOG_CQ, "tx_entry->state -> RXM_LMT_FINISH\n");
+	tx_entry->state = RXM_LMT_FINISH;
+
+	ret = rxm_write_send_comp(tx_entry);
+	if (ret)
+		return ret;
+
+	return rxm_ep_repost_buf(rx_buf);
+}
+
+int rxm_cq_handle_data(struct rxm_rx_buf *rx_buf)
+{
+	if (rx_buf->pkt.ctrl_hdr.type == ofi_ctrl_large_data) {
+		if (!rx_buf->conn) {
+			rx_buf->conn = rxm_key2conn(rx_buf->ep, rx_buf->pkt.ctrl_hdr.conn_id);
+			if (!rx_buf->conn)
+				return -FI_EOTHER;
+		}
+
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "rx_buf->state -> RXM_LMT_START\n");
+		rx_buf->state = RXM_LMT_START;
+
+		memset(&rx_buf->match_iov, 0, sizeof(rx_buf->match_iov));
+		rx_buf->match_iov.iov = rx_buf->recv_entry->iov;
+		rx_buf->match_iov.desc = rx_buf->recv_entry->desc;
+		rx_buf->match_iov.count = rx_buf->recv_entry->count;
+
+		rx_buf->rma_iov = (struct rxm_rma_iov *)rx_buf->pkt.data;
+		rx_buf->index = 0;
+
+		return rxm_lmt_rma_read(rx_buf);
+	} else {
+		ofi_copy_iov_buf(rx_buf->recv_entry->iov, rx_buf->recv_entry->count, rx_buf->pkt.data,
+			rx_buf->pkt.hdr.size, 0, OFI_COPY_BUF_TO_IOV);
+		return rxm_write_recv_comp(rx_buf);
+	}
+}
+
+int rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
+{
+	struct rxm_recv_match_attr match_attr = {0};
+	struct dlist_entry *entry;
+	struct rxm_recv_queue *recv_queue;
+	struct util_cq *util_cq;
+	dlist_func_t *match;
+
+	if (rx_buf->pkt.ctrl_hdr.type == ofi_ctrl_ack)
+		return rxm_cq_handle_ack(rx_buf);
+
+	util_cq = rx_buf->ep->util_ep.rx_cq;
+
+	if ((rx_buf->ep->rxm_info->caps & FI_SOURCE) ||
+			(rx_buf->ep->rxm_info->caps & FI_DIRECTED_RECV)) {
+		if (!rx_buf->conn) {
+			rx_buf->conn = rxm_key2conn(rx_buf->ep, rx_buf->pkt.ctrl_hdr.conn_id);
+			if (!rx_buf->conn)
+				return -FI_EOTHER;
+		}
+	}
+
+	if (rx_buf->ep->rxm_info->caps & FI_DIRECTED_RECV)
+		match_attr.addr = rx_buf->conn->handle.fi_addr;
+	else
+		match_attr.addr = FI_ADDR_UNSPEC;
+
+	if (rx_buf->ep->rxm_info->caps & FI_SOURCE)
+		util_cq->src[cirque_windex(util_cq->cirq)] = rx_buf->conn->handle.fi_addr;
+
+	switch(rx_buf->pkt.hdr.op) {
+	case ofi_op_msg:
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "Got MSG op\n");
+		recv_queue = &rx_buf->ep->recv_queue;
+		match = rxm_match_recv_entry;
+		break;
+	case ofi_op_tagged:
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "Got TAGGED op\n");
+		match_attr.tag = rx_buf->pkt.hdr.tag;
+		recv_queue = &rx_buf->ep->trecv_queue;
+		match = rxm_match_recv_entry_tagged;
+		break;
+	default:
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unknown op!\n");
+		assert(0);
+		return -FI_EINVAL;
+	}
+
+	rx_buf->recv_fs = recv_queue->recv_fs;
+
+	entry = dlist_remove_first_match(&recv_queue->recv_list, match, &match_attr);
+	if (!entry) {
+		FI_DBG(&rxm_prov, FI_LOG_CQ,
+				"No matching recv found. Enqueueing msg to unexpected queue\n");
+		rx_buf->unexp_msg.addr = match_attr.addr;
+		rx_buf->unexp_msg.tag = match_attr.tag;
+		dlist_insert_tail(&rx_buf->unexp_msg.entry, &recv_queue->unexp_msg_list);
+		return 0;
+	}
+
+	rx_buf->recv_entry = container_of(entry, struct rxm_recv_entry, entry);
+	return rxm_cq_handle_data(rx_buf);
+}
+
+int rxm_handle_send_comp(void *op_context)
+{
+	struct rxm_tx_entry *tx_entry;
+	struct rxm_rx_buf *rx_buf;
+	int ret = 0;
+
+	switch (*(enum rxm_ctx_type *)op_context) {
+	case RXM_TX_ENTRY:
+		tx_entry = (struct rxm_tx_entry *)op_context;
+		if (tx_entry->pkt->ctrl_hdr.type == ofi_ctrl_large_data) {
+			assert(tx_entry->state == RXM_LMT_START);
+			FI_DBG(&rxm_prov, FI_LOG_CQ, "tx_entry->state -> RXM_LMT_ACK\n");
+			tx_entry->state = RXM_LMT_ACK;
+			return 0;
+		}
+		ret = rxm_write_send_comp(tx_entry);
+		break;
+	case RXM_RX_BUF:
+		rx_buf = (struct rxm_rx_buf *)op_context;
+		if (rx_buf->state != RXM_LMT_ACK) {
 			FI_WARN(&rxm_prov, FI_LOG_CQ,
-					"Unable to allocate util_cq_err_entry\n");
-			return -FI_ENOMEM;
+					"invalid state. expected: %s, found: %s\n",
+					rxm_lmt_state_str[RXM_LMT_START],
+					rxm_lmt_state_str[rx_buf->state]);
+			return -FI_EOPBADSTATE;
 		}
-		OFI_CQ_READERR(&rxm_prov, FI_LOG_CQ, cq, ret, entry->err_entry);
-		if (ret < 0) {
-			free(entry);
-			return ret;
-		}
-		slist_insert_tail(&entry->list_entry, &util_cq->err_list);
-		comp->flags = UTIL_FLAG_ERROR;
-		cirque_commit(util_cq->cirq);
-		return -FI_EAVAIL;
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "rx_buf->state -> RXM_LMT_FINISH\n");
+		rx_buf->state = RXM_LMT_FINISH;
+		ret = rxm_write_recv_comp(rx_buf);
+		break;
+	default:
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unknown entry type!\n");
+		assert(0);
+		return -FI_EOTHER;
 	}
 
 	return ret;
 }
 
-void rxm_cq_progress(struct util_cq *util_cq)
+static int rxm_handle_read_comp(struct rxm_rx_buf *rx_buf)
 {
+	struct iovec iov;
+	struct fi_msg msg;
+	struct rxm_pkt pkt;
+	int ret;
+
+	if (rx_buf->pkt.ctrl_hdr.type == ofi_ctrl_large_data) {
+		if (rx_buf->state != RXM_LMT_START) {
+			FI_WARN(&rxm_prov, FI_LOG_CQ,
+					"invalid state. expected: %s, found: %s\n",
+					rxm_lmt_state_str[RXM_LMT_START],
+					rxm_lmt_state_str[rx_buf->state]);
+			return -FI_EOPBADSTATE;
+		}
+		assert(rx_buf->conn);
+
+		if (rx_buf->index < rx_buf->rma_iov->count)
+			return rxm_lmt_rma_read(rx_buf);
+
+		rxm_pkt_init(&pkt);
+		pkt.ctrl_hdr.type = ofi_ctrl_ack;
+		pkt.ctrl_hdr.conn_id = rx_buf->conn->handle.remote_key;
+		pkt.ctrl_hdr.msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
+		pkt.hdr.op = rx_buf->pkt.hdr.op;
+
+		iov.iov_base = &pkt;
+		iov.iov_len = sizeof(pkt);
+
+		memset(&msg, 0, sizeof(msg));
+		msg.msg_iov = &iov;
+		msg.iov_count = 1;
+		msg.context = rx_buf;
+
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "rx_buf->state -> RXM_LMT_ACK\n");
+		rx_buf->state = RXM_LMT_ACK;
+
+		ret = fi_sendmsg(rx_buf->conn->msg_ep, &msg, FI_INJECT);
+		if (ret) {
+			FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to send ACK\n");
+			rx_buf->state = RXM_LMT_NONE;
+			return ret;
+		}
+	}
+	// TODO process app RMA read
+	return 0;
+}
+
+static ssize_t rxm_cq_read(struct fid_cq *msg_cq, struct fi_cq_msg_entry *comp)
+{
+	struct rxm_tx_entry *tx_entry;
+	struct rxm_rx_buf *rx_buf;
+	struct fi_cq_err_entry err_entry;
+	ssize_t ret;
+
+	ret = fi_cq_read(msg_cq, comp, 1);
+	if (ret == -FI_EAVAIL) {
+		OFI_CQ_READERR(&rxm_prov, FI_LOG_CQ, msg_cq,
+				ret, err_entry);
+		if (ret < 0) {
+			FI_WARN(&rxm_prov, FI_LOG_CQ,
+					"Unable to fi_cq_readerr on msg cq\n");
+			return ret;
+		}
+		switch (*(enum rxm_ctx_type *)comp->op_context) {
+		case RXM_TX_ENTRY:
+			tx_entry = (struct rxm_tx_entry *)comp->op_context;
+			return rxm_cq_report_error(tx_entry->ep->util_ep.tx_cq, &err_entry);
+		case RXM_RX_BUF:
+			rx_buf = (struct rxm_rx_buf *)comp->op_context;
+			return rxm_cq_report_error(rx_buf->ep->util_ep.rx_cq, &err_entry);
+		default:
+			FI_WARN(&rxm_prov, FI_LOG_CQ, "Unknown ctx type!\n");
+			assert(0);
+			return -FI_EOTHER;
+		}
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+				"msg cq readerr:  %s\n",
+				fi_cq_strerror(msg_cq, err_entry.prov_errno,
+					err_entry.err_data, NULL, 0));
+		return err_entry.err;
+	}
+	return ret;
+}
+
+void rxm_cq_progress(struct fid_cq *msg_cq)
+{
+	struct fi_cq_msg_entry comp;
 	ssize_t ret = 0;
-	struct rxm_cq *rxm_cq;
-	struct fi_cq_tagged_entry *comp;
 
-	rxm_cq = container_of(util_cq, struct rxm_cq, util_cq);
-
-	fastlock_acquire(&util_cq->cq_lock);
 	do {
-		if (cirque_isfull(util_cq->cirq))
-			goto out;
-
-		comp = cirque_tail(util_cq->cirq);
-		ret = rxm_msg_cq_read(util_cq, rxm_cq->msg_cq, comp);
+		ret = rxm_cq_read(msg_cq, &comp);
 		if (ret < 0)
-			goto out;
-		cirque_commit(util_cq->cirq);
+			goto err;
+
+		if (comp.flags & FI_RECV) {
+			ret = rxm_handle_recv_comp(comp.op_context);
+			if (ret)
+				goto err;
+		} else if (comp.flags & FI_SEND) {
+			ret = rxm_handle_send_comp(comp.op_context);
+			if (ret)
+				goto err;
+		} else if (comp.flags & FI_READ) {
+			ret = rxm_handle_read_comp(comp.op_context);
+			if (ret)
+				goto err;
+		} else {
+			FI_WARN(&rxm_prov, FI_LOG_CQ, "Unknown completion!\n");
+			goto err;
+		}
 	} while (ret > 0);
-out:
-	fastlock_release(&util_cq->cq_lock);
+	return;
+err:
+	// TODO report error on RXM EP/domain since EP/CQ is broken.
+	return;
 }
 
 static int rxm_cq_close(struct fid *fid)
 {
-	struct rxm_cq *rxm_cq;
+	struct util_cq *util_cq;
 	int ret, retv = 0;
 
-	rxm_cq = container_of(fid, struct rxm_cq, util_cq.cq_fid.fid);
+	util_cq = container_of(fid, struct util_cq, cq_fid.fid);
 
-	ret = ofi_cq_cleanup(&rxm_cq->util_cq);
+	ret = ofi_cq_cleanup(util_cq);
 	if (ret)
 		retv = ret;
 
-	ret = fi_close(&rxm_cq->msg_cq->fid);
-	if (ret) {
-		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to close MSG CQ\n");
-		retv = ret;
-	}
-	free(rxm_cq);
+	free(util_cq);
 	return retv;
 }
 
@@ -135,35 +526,24 @@ static struct fi_ops_cq rxm_cq_ops = {
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq_fid, void *context)
 {
-	struct rxm_domain *rxm_domain;
-	struct rxm_cq *rxm_cq;
+	struct util_cq *util_cq;
 	int ret;
 
-	rxm_cq = calloc(1, sizeof(*rxm_cq));
-	if (!rxm_cq)
+	util_cq = calloc(1, sizeof(*util_cq));
+	if (!util_cq)
 		return -FI_ENOMEM;
 
-	rxm_domain = container_of(domain, struct rxm_domain, util_domain.domain_fid);
-
-	ret = fi_cq_open(rxm_domain->msg_domain, attr, &rxm_cq->msg_cq, context);
-	if (ret) {
-		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to open MSG CQ\n");
-		goto err1;
-	}
-
-	ret = ofi_cq_init(&rxm_prov, domain, attr, &rxm_cq->util_cq,
-			&rxm_cq_progress, context);
+	ret = ofi_cq_init(&rxm_prov, domain, attr, util_cq, &ofi_cq_progress,
+			context);
 	if (ret)
-		goto err2;
+		goto err1;
 
-	*cq_fid = &rxm_cq->util_cq.cq_fid;
+	*cq_fid = &util_cq->cq_fid;
 	/* Override util_cq_fi_ops */
 	(*cq_fid)->fid.ops = &rxm_cq_fi_ops;
 	(*cq_fid)->ops = &rxm_cq_ops;
 	return 0;
-err2:
-	fi_close(&rxm_cq->msg_cq->fid);
 err1:
-	free(rxm_cq);
+	free(util_cq);
 	return ret;
 }

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -111,6 +111,9 @@ static int rxm_mr_reg(struct fid *domain_fid, const void *buf, size_t len,
 	if (!(rxm_mr = calloc(1, sizeof(*rxm_mr))))
 		return -FI_ENOMEM;
 
+	/* Additional flags to use RMA read for large message transfers */
+	access |= FI_READ | FI_REMOTE_READ;
+
 	ret = fi_mr_reg(rxm_domain->msg_domain, buf, len, access, offset, requested_key,
 			flags, &rxm_mr->msg_mr, context);
 	if (ret) {
@@ -121,7 +124,10 @@ static int rxm_mr_reg(struct fid *domain_fid, const void *buf, size_t len,
 	rxm_mr->mr_fid.fid.fclass = FI_CLASS_MR;
 	rxm_mr->mr_fid.fid.context = context;
 	rxm_mr->mr_fid.fid.ops = &rxm_mr_ops;
-	rxm_mr->mr_fid.mem_desc = fi_mr_desc(rxm_mr->msg_mr);
+	/* Store msg_mr as rxm_mr descriptor so that we can get its key when
+	 * the app passes msg_mr as the descriptor in fi_send and friends.
+	 * The key would be used in large message transfer protocol. */
+	rxm_mr->mr_fid.mem_desc = rxm_mr->msg_mr;
 	rxm_mr->mr_fid.key = fi_mr_key(rxm_mr->msg_mr);
 	*mr = &rxm_mr->mr_fid;
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -30,11 +30,177 @@
  * SOFTWARE.
  */
 
-#include <stdlib.h>
-#include <string.h>
+#include <inttypes.h>
+
+#include "fi.h"
+#include <fi_iov.h>
+#include <fi_util.h>
 
 #include "rxm.h"
 
+static void rxm_mr_buf_close(void *pool_ctx, void *context)
+{
+	/* We would get a (fid_mr *) in context but it is safe to cast it into (fid *) */
+	fi_close((struct fid *)context);
+}
+
+static int rxm_mr_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
+{
+	int ret;
+	struct fid_mr *mr;
+	struct fid_domain *msg_domain = (struct fid_domain *)pool_ctx;
+
+	ret = fi_mr_reg(msg_domain, addr, len, FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL);
+	*context = mr;
+	return ret;
+}
+
+static int rxm_buf_pool_create(int local_mr, size_t count, size_t size,
+		struct util_buf_pool **pool, void *pool_ctx)
+{
+	*pool = local_mr ? util_buf_pool_create_ex(RXM_BUF_SIZE + size, 16, 0, count,
+				rxm_mr_buf_reg, rxm_mr_buf_close, pool_ctx) :
+		util_buf_pool_create(RXM_BUF_SIZE, 16, 0, count);
+	if (!(*pool)) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_DATA, "Unable to create buf pool\n");
+		return -FI_ENOMEM;
+	}
+	return 0;
+}
+
+static int rxm_recv_queue_init(struct rxm_recv_queue *recv_queue, size_t size)
+{
+	recv_queue->recv_fs = rxm_recv_fs_create(size);
+	if (!recv_queue->recv_fs)
+		return -FI_ENOMEM;
+	dlist_init(&recv_queue->recv_list);
+	dlist_init(&recv_queue->unexp_msg_list);
+	return 0;
+}
+
+static void rxm_recv_queue_close(struct rxm_recv_queue *recv_queue)
+{
+	if (recv_queue->recv_fs)
+		rxm_recv_fs_free(recv_queue->recv_fs);
+	// TODO cleanup recv_list and unexp msg list
+}
+
+static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep)
+{
+	struct rxm_domain *rxm_domain;
+	uint8_t local_mr;
+	int ret;
+
+	rxm_domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain, util_domain);
+	local_mr = rxm_ep->msg_info->mode & FI_LOCAL_MR ? 1 : 0;
+
+	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "MSG provider mode & FI_LOCAL_MR: %d\n",
+			local_mr);
+
+	ret = rxm_buf_pool_create(local_mr, rxm_ep->msg_info->tx_attr->size,
+			sizeof(struct rxm_pkt), &rxm_ep->tx_pool, rxm_domain->msg_domain);
+	if (ret)
+	        return ret;
+
+	ret = rxm_buf_pool_create(local_mr, rxm_ep->msg_info->rx_attr->size,
+			sizeof(struct rxm_rx_buf), &rxm_ep->rx_pool, rxm_domain->msg_domain);
+	if (ret)
+		goto err1;
+
+	rxm_ep->txe_fs = rxm_txe_fs_create(rxm_ep->rxm_info->tx_attr->size);
+	if (!rxm_ep->txe_fs) {
+		ret = -FI_ENOMEM;
+		goto err2;
+	}
+
+	ofi_key_idx_init(&rxm_ep->tx_key_idx, fi_size_bits(rxm_ep->rxm_info->tx_attr->size));
+
+	ret = rxm_recv_queue_init(&rxm_ep->recv_queue, rxm_ep->rxm_info->rx_attr->size);
+	if (ret)
+		goto err3;
+
+	ret = rxm_recv_queue_init(&rxm_ep->trecv_queue, rxm_ep->rxm_info->rx_attr->size);
+	if (ret)
+		goto err4;
+
+	return 0;
+err4:
+	rxm_recv_queue_close(&rxm_ep->recv_queue);
+err3:
+	rxm_txe_fs_free(rxm_ep->txe_fs);
+err2:
+	util_buf_pool_destroy(rxm_ep->tx_pool);
+err1:
+	util_buf_pool_destroy(rxm_ep->rx_pool);
+	return ret;
+}
+
+static void rxm_ep_txrx_res_close(struct rxm_ep *rxm_ep)
+{
+	struct slist_entry *entry;
+	struct rxm_rx_buf *rx_buf;
+
+	rxm_recv_queue_close(&rxm_ep->trecv_queue);
+	rxm_recv_queue_close(&rxm_ep->recv_queue);
+
+	if (rxm_ep->txe_fs)
+		rxm_txe_fs_free(rxm_ep->txe_fs);
+
+	while(!slist_empty(&rxm_ep->rx_buf_list)) {
+		entry = slist_remove_head(&rxm_ep->rx_buf_list);
+		rx_buf = container_of(entry, struct rxm_rx_buf, entry);
+		util_buf_release(rxm_ep->rx_pool, rx_buf);
+	}
+
+	util_buf_pool_destroy(rxm_ep->rx_pool);
+	util_buf_pool_destroy(rxm_ep->tx_pool);
+}
+
+int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
+{
+	struct fid_mr *mr;
+	void *desc = NULL;
+	int ret;
+
+	rx_buf->conn = NULL;
+	rx_buf->recv_fs = NULL;
+	rx_buf->recv_entry = NULL;
+	memset(&rx_buf->unexp_msg, 0, sizeof(rx_buf->unexp_msg));
+	rx_buf->state = RXM_LMT_NONE;
+	rx_buf->rma_iov = NULL;
+
+	if (rx_buf->ep->msg_info->mode & FI_LOCAL_MR) {
+		mr = util_buf_get_ctx(rx_buf->ep->rx_pool, rx_buf);
+		desc = fi_mr_desc(mr);
+	}
+
+	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "Re-posting rx buf\n");
+	ret = fi_recv(rx_buf->ep->srx_ctx, &rx_buf->pkt, RXM_BUF_SIZE, desc,
+			FI_ADDR_UNSPEC,	rx_buf);
+	if (ret)
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to repost buf\n");
+	return ret;
+}
+
+int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep)
+{
+	struct rxm_rx_buf *rx_buf;
+	int ret, i;
+
+	for (i = 0; i < rxm_ep->rx_pool->chunk_cnt; i++) {
+		rx_buf = util_buf_get(rxm_ep->rx_pool);
+		rx_buf->ctx_type = RXM_RX_BUF;
+		rx_buf->ep = rxm_ep;
+
+		ret = rxm_ep_repost_buf(rx_buf);
+		if (ret) {
+			util_buf_release(rxm_ep->rx_pool, rx_buf);
+			return ret;
+		}
+		slist_insert_tail(&rx_buf->entry, &rxm_ep->rx_buf_list);
+	}
+	return 0;
+}
 
 int rxm_setname(fid_t fid, void *addr, size_t addrlen)
 {
@@ -52,7 +218,7 @@ int rxm_getname(fid_t fid, void *addr, size_t *addrlen)
 	return fi_getname(&rxm_ep->msg_pep->fid, addr, addrlen);
 }
 
-static struct fi_ops_cm rxm_cm_ops = {
+static struct fi_ops_cm rxm_ops_cm = {
 	.size = sizeof(struct fi_ops_cm),
 	.setname = rxm_setname,
 	.getname = rxm_getname,
@@ -76,7 +242,7 @@ int rxm_setopt(fid_t fid, int level, int optname,
 	return -FI_ENOPROTOOPT;
 }
 
-static struct fi_ops_ep rxm_ep_ops = {
+static struct fi_ops_ep rxm_ops_ep = {
 	.size = sizeof(struct fi_ops_ep),
 	.cancel = fi_no_cancel,
 	.getopt = rxm_getopt,
@@ -87,124 +253,444 @@ static struct fi_ops_ep rxm_ep_ops = {
 	.tx_size_left = fi_no_tx_size_left,
 };
 
-ssize_t rxm_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
-		uint64_t flags)
+static int ofi_match_unexp_msg(struct dlist_entry *item, const void *arg)
 {
-	struct rxm_ep *rxm_ep;
+	struct rxm_recv_match_attr *attr = (struct rxm_recv_match_attr *)arg;
+	struct rxm_unexp_msg *unexp_msg;
 
-	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	return fi_recvmsg(rxm_ep->srx_ctx, msg, flags);
+	unexp_msg = container_of(item, struct rxm_unexp_msg, entry);
+	return rxm_match_addr(unexp_msg->addr, attr->addr);
 }
 
-ssize_t rxm_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t src_addr, void *context)
+static int ofi_match_unexp_msg_tagged(struct dlist_entry *item, const void *arg)
 {
-	struct rxm_ep *rxm_ep;
+	struct rxm_recv_match_attr *attr = (struct rxm_recv_match_attr *)arg;
+	struct rxm_unexp_msg *unexp_msg;
 
-	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	return fi_recvv(rxm_ep->srx_ctx, iov, desc, count, 0, context);
+	unexp_msg = container_of(item, struct rxm_unexp_msg, entry);
+	return rxm_match_addr(attr->tag, unexp_msg->addr) &&
+		rxm_match_tag(attr->tag, attr->ignore, unexp_msg->tag);
 }
 
-ssize_t rxm_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
-		fi_addr_t src_addr, void *context)
+static int rxm_check_unexp_msg_list(struct util_cq *util_cq, struct rxm_recv_queue *recv_queue,
+		struct rxm_recv_entry *recv_entry, dlist_func_t *match)
 {
-	struct rxm_ep *rxm_ep;
+	struct dlist_entry *entry;
+	struct rxm_unexp_msg *unexp_msg;
+	struct rxm_recv_match_attr match_attr;
+	struct rxm_rx_buf *rx_buf;
+	int ret = 0;
 
-	/* TODO Handle recv from particular src */
-	if (src_addr) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-				"Unable to post recv for a particular source\n");
+	fastlock_acquire(&util_cq->cq_lock);
+	if (cirque_isfull(util_cq->cirq)) {
+		ret = -FI_EAGAIN;
+		goto out;
+	}
+
+	match_attr.addr = recv_entry->addr;
+	match_attr.tag = recv_entry->tag;
+	match_attr.ignore = recv_entry->ignore;
+
+	entry = dlist_remove_first_match(&recv_queue->unexp_msg_list, match, &match_attr);
+	if (!entry)
+		goto out;
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Match for posted recv found in unexp msg list\n");
+
+	unexp_msg = container_of(entry, struct rxm_unexp_msg, entry);
+	rx_buf = container_of(unexp_msg, struct rxm_rx_buf, unexp_msg);
+	rx_buf->recv_entry = recv_entry;
+
+	ret = rxm_cq_handle_data(rx_buf);
+	free(unexp_msg);
+out:
+	fastlock_release(&util_cq->cq_lock);
+	return ret;
+}
+
+int rxm_ep_recv_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
+		void *context, uint64_t flags, int op)
+{
+	struct rxm_recv_entry *recv_entry;
+	struct rxm_ep *rxm_ep;
+	struct rxm_recv_queue *recv_queue;
+	dlist_func_t *match;
+	int ret, i;
+
+	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
+
+	// TODO pass recv_queue as arg
+	if (op == ofi_op_msg) {
+		recv_queue = &rxm_ep->recv_queue;
+		match = ofi_match_unexp_msg;
+	} else if (op == ofi_op_tagged) {
+		recv_queue = &rxm_ep->trecv_queue;
+		match = ofi_match_unexp_msg_tagged;
+	} else {
+		FI_WARN(&rxm_prov, FI_LOG_EP_DATA, "Unknown op!\n");
 		return -FI_EINVAL;
 	}
 
-	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	return fi_recv(rxm_ep->srx_ctx, buf, len, desc, 0, context);
+	if (freestack_isempty(recv_queue->recv_fs)) {
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "Exhaused recv_entry freestack\n");
+		return -FI_EAGAIN;
+	}
+
+	recv_entry = freestack_pop(recv_queue->recv_fs);
+
+	for (i = 0; i < count; i++) {
+		recv_entry->iov[i].iov_base = iov[i].iov_base;
+		recv_entry->iov[i].iov_len = iov[i].iov_len;
+		recv_entry->desc[i] = desc[i];
+		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "post recv: %u\n",
+			iov[i].iov_len);
+	}
+	recv_entry->count = count;
+	recv_entry->addr = (rxm_ep->rxm_info->caps & FI_DIRECTED_RECV) ?
+		src_addr : FI_ADDR_UNSPEC;
+	recv_entry->flags = flags;
+	if (op == ofi_op_tagged) {
+		recv_entry->tag = tag;
+		recv_entry->ignore = ignore;
+	}
+
+	if (!dlist_empty(&recv_queue->unexp_msg_list)) {
+		ret = rxm_check_unexp_msg_list(rxm_ep->util_ep.rx_cq, recv_queue,
+				recv_entry, match);
+		if (ret) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+					"Unable to check unexp msg list\n");
+			return ret;
+		}
+	}
+
+	dlist_insert_tail(&recv_entry->entry, &recv_queue->recv_list);
+	return 0;
 }
 
-ssize_t rxm_send(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
-		fi_addr_t dest_addr, void *context)
+static ssize_t rxm_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+			       uint64_t flags)
+{
+	return rxm_ep_recv_common(ep_fid, msg->msg_iov, msg->desc, msg->iov_count,
+			msg->addr, 0, 0, msg->context, flags, ofi_op_msg);
+}
+
+static ssize_t rxm_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
+			    fi_addr_t src_addr, void *context)
+{
+	struct iovec iov;
+	memset(&iov, 0, sizeof(iov));
+	iov.iov_base = buf;
+	iov.iov_len = len;
+
+	return rxm_ep_recv_common(ep_fid, &iov, &desc, 1, src_addr, 0, 0,
+			context, 0, ofi_op_msg);
+}
+
+static ssize_t rxm_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov,
+		void **desc, size_t count, fi_addr_t src_addr, void *context)
+{
+	return rxm_ep_recv_common(ep_fid, iov, desc, count, src_addr, 0, 0,
+			context, 0, ofi_op_msg);
+}
+
+static void rxm_op_hdr_process_flags(struct ofi_op_hdr *hdr, uint64_t flags,
+		uint64_t data)
+{
+	if (flags & FI_REMOTE_CQ_DATA) {
+		hdr->flags = OFI_REMOTE_CQ_DATA;
+		hdr->data = data;
+	}
+	if (flags & FI_TRANSMIT_COMPLETE)
+		hdr->flags |= OFI_TRANSMIT_COMPLETE;
+	if (flags & FI_DELIVERY_COMPLETE)
+		hdr->flags |= OFI_DELIVERY_COMPLETE;
+}
+
+void rxm_pkt_init(struct rxm_pkt *pkt)
+{
+	memset(pkt, 0, sizeof(*pkt));
+	pkt->ctrl_hdr.version = OFI_CTRL_VERSION;
+	pkt->hdr.version = OFI_OP_VERSION;
+}
+
+// TODO handle all flags
+static ssize_t rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov,
+		void **desc, size_t count, fi_addr_t dest_addr, void *context,
+		uint64_t data, uint64_t tag, uint64_t flags, int op)
 {
 	struct rxm_ep *rxm_ep;
-	struct fid_ep *msg_ep;
-	ssize_t ret;
+	struct rxm_conn *rxm_conn;
+	struct rxm_tx_entry *tx_entry;
+	struct rxm_pkt *pkt;
+	struct fid_mr *mr;
+	void *desc_tx_buf;
+	struct rxm_rma_iov *rma_iov;
+	int pkt_size = 0;
+	int i, ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	ret = rxm_get_msg_ep(rxm_ep, dest_addr, &msg_ep);
+
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		return ret;
 
-	// TODO handle the case when send fails due to connection shutdown
-	return fi_send(msg_ep, buf, len, desc, 0, context);
+	if (freestack_isempty(rxm_ep->txe_fs)) {
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "Exhaused tx_entry freestack\n");
+		return -FI_ENOMEM;
+	}
+
+	tx_entry = freestack_pop(rxm_ep->txe_fs);
+
+	tx_entry->ctx_type = RXM_TX_ENTRY;
+	tx_entry->ep = rxm_ep;
+	tx_entry->context = context;
+
+	if (rxm_ep->msg_info->mode & FI_LOCAL_MR) {
+		pkt = util_buf_get_ex(rxm_ep->tx_pool, (void **)&mr);
+		desc_tx_buf = fi_mr_desc(mr);
+	} else {
+		pkt = util_buf_get(rxm_ep->tx_pool);
+	}
+	assert(pkt);
+
+	tx_entry->pkt = pkt;
+
+	rxm_pkt_init(pkt);
+	pkt->ctrl_hdr.conn_id = rxm_conn->handle.remote_key;
+	pkt->hdr.op = op;
+	pkt->hdr.size = ofi_get_iov_len(iov, count);
+	rxm_op_hdr_process_flags(&pkt->hdr, flags, data);
+
+	if (op == ofi_op_tagged)
+		pkt->hdr.tag = tag;
+
+
+	if (pkt->hdr.size > RXM_TX_DATA_SIZE) {
+		tx_entry->msg_id = ofi_idx2key(&rxm_ep->tx_key_idx,
+				rxm_txe_fs_index(rxm_ep->txe_fs, tx_entry));
+		pkt->ctrl_hdr.msg_id = tx_entry->msg_id;
+		pkt->ctrl_hdr.type = ofi_ctrl_large_data;
+		rma_iov = (struct rxm_rma_iov *)pkt->data;
+		rma_iov->count = count;
+		for (i = 0; i < count; i++) {
+			rma_iov->iov[i].addr = rxm_ep->msg_info->domain_attr->mr_mode == FI_MR_SCALABLE ?
+				0 : (uintptr_t)iov->iov_base;
+			rma_iov->iov[i].len = (uint64_t)iov->iov_len;
+			rma_iov->iov[i].key = fi_mr_key(desc[i]);
+		}
+		pkt_size = sizeof(*pkt) + sizeof(*rma_iov) + sizeof(*rma_iov->iov) * count;
+		FI_DBG(&rxm_prov, FI_LOG_CQ,
+				"Sending large msg. msg_id: 0x%" PRIx64 "\n",
+				tx_entry->msg_id);
+		FI_DBG(&rxm_prov, FI_LOG_CQ, "tx_entry->state -> RXM_LMT_START\n");
+		tx_entry->state = RXM_LMT_START;
+	} else {
+		pkt->ctrl_hdr.type = ofi_ctrl_data;
+		ofi_copy_iov_buf(iov, count, pkt->data, pkt->hdr.size, 0,
+				OFI_COPY_IOV_TO_BUF);
+		pkt_size = sizeof(*pkt) + pkt->hdr.size;
+	}
+
+	ret = fi_send(rxm_conn->msg_ep, pkt, pkt_size, desc_tx_buf, 0, tx_entry);
+	if (ret) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_DATA, "fi_send for MSG provider failed\n");
+		util_buf_release(rxm_ep->tx_pool, pkt);
+		freestack_push(rxm_ep->txe_fs, tx_entry);
+	}
+	return ret;
 }
 
-ssize_t rxm_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
-		uint64_t flags)
+static ssize_t rxm_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+			       uint64_t flags)
 {
-	struct rxm_ep *rxm_ep;
-	struct fid_ep *msg_ep;
-	ssize_t ret;
 
-	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	ret = rxm_get_msg_ep(rxm_ep, msg->addr, &msg_ep);
-	if (ret)
-		return ret;
-
-	return fi_sendmsg(msg_ep, msg, flags);
+	return rxm_ep_send_common(ep_fid, msg->msg_iov, msg->desc, msg->iov_count,
+			msg->addr, msg->context, msg->data, 0, flags, ofi_op_msg);
 }
 
-ssize_t rxm_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t dest_addr, void *context)
+static ssize_t rxm_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
+		void *desc, fi_addr_t dest_addr, void *context)
 {
-	struct rxm_ep *rxm_ep;
-	struct fid_ep *msg_ep;
-	ssize_t ret;
+	struct iovec iov;
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
 
-	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	ret = rxm_get_msg_ep(rxm_ep, dest_addr, &msg_ep);
-	if (ret)
-		return ret;
-
-	return fi_sendv(msg_ep, iov, desc, count, 0, context);
+	return rxm_ep_send_common(ep_fid, &iov, &desc, 1, dest_addr, context, 0,
+			0, 0, ofi_op_msg);
 }
 
-ssize_t rxm_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
-		fi_addr_t dest_addr)
+static ssize_t rxm_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
+		void **desc, size_t count, fi_addr_t dest_addr, void *context)
 {
-	struct rxm_ep *rxm_ep;
-	struct fid_ep *msg_ep;
-	ssize_t ret;
-
-	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	ret = rxm_get_msg_ep(rxm_ep, dest_addr, &msg_ep);
-	if (ret)
-		return ret;
-
-	return fi_inject(msg_ep, buf, len, 0);
+	return rxm_ep_send_common(ep_fid, iov, desc, count, dest_addr, context,
+			0, 0, 0, ofi_op_msg);
 }
 
-static struct fi_ops_msg rxm_msg_ops = {
+static ssize_t	rxm_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
+			       fi_addr_t dest_addr)
+{
+	struct iovec iov;
+
+	memset(&iov, 0, sizeof(iov));
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
+
+	return rxm_ep_send_common(ep_fid, &iov, NULL, 1, dest_addr, NULL, 0, 0,
+			FI_INJECT, ofi_op_msg);
+}
+
+static ssize_t rxm_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
+				uint64_t data, fi_addr_t dest_addr, void *context)
+{
+	struct iovec iov;
+
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
+
+	return rxm_ep_send_common(ep_fid, &iov, desc, 1, dest_addr, context, data,
+			0, 0, ofi_op_msg);
+}
+
+static ssize_t	rxm_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
+				   uint64_t data, fi_addr_t dest_addr)
+{
+	struct iovec iov;
+
+	memset(&iov, 0, sizeof(iov));
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
+
+	return rxm_ep_send_common(ep_fid, &iov, NULL, 1, dest_addr, NULL, data, 0,
+			FI_INJECT, ofi_op_msg);
+}
+
+static struct fi_ops_msg rxm_ops_msg = {
 	.size = sizeof(struct fi_ops_msg),
-	.recv = rxm_recv,
-	.recvv = rxm_recvv,
-	.recvmsg = rxm_recvmsg,
-	.send = rxm_send,
-	.sendv = rxm_sendv,
-	.sendmsg = rxm_sendmsg,
-	.inject = rxm_inject,
-	.senddata = fi_no_msg_senddata,
-	.injectdata = fi_no_msg_injectdata,
+	.recv = rxm_ep_recv,
+	.recvv = rxm_ep_recvv,
+	.recvmsg = rxm_ep_recvmsg,
+	.send = rxm_ep_send,
+	.sendv = rxm_ep_sendv,
+	.sendmsg = rxm_ep_sendmsg,
+	.inject = rxm_ep_inject,
+	.senddata = rxm_ep_senddata,
+	.injectdata = rxm_ep_injectdata,
 };
 
-static int rxm_ep_close(struct fid *fid)
+ssize_t rxm_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
+			 uint64_t flags)
 {
-	struct rxm_ep *rxm_ep;
+	return rxm_ep_recv_common(ep_fid, msg->msg_iov, msg->desc, msg->iov_count,
+			msg->addr, msg->tag, msg->ignore, msg->context, flags,
+			ofi_op_tagged);
+}
+
+static ssize_t rxm_ep_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
+		fi_addr_t src_addr, uint64_t tag, uint64_t ignore, void *context)
+{
+	struct iovec iov;
+	memset(&iov, 0, sizeof(iov));
+	iov.iov_base = buf;
+	iov.iov_len = len;
+
+	return rxm_ep_recv_common(ep_fid, &iov, &desc, 1, src_addr, tag, ignore,
+			context, 0, ofi_op_tagged);
+}
+
+ssize_t rxm_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
+		void *context)
+{
+	return rxm_ep_recv_common(ep_fid, iov, desc, count, src_addr, tag, ignore,
+			context, 0, ofi_op_tagged);
+}
+
+ssize_t rxm_ep_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
+			 uint64_t flags)
+{
+	return rxm_ep_send_common(ep_fid, msg->msg_iov, msg->desc, msg->iov_count,
+			msg->addr, msg->context, msg->data, msg->tag, flags,
+			ofi_op_tagged);
+}
+
+ssize_t rxm_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
+		      fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	struct iovec iov;
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
+
+	return rxm_ep_send_common(ep_fid, &iov, &desc, 1, dest_addr, context, 0,
+			tag, 0, ofi_op_tagged);
+}
+
+ssize_t rxm_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+		       size_t count, fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	return rxm_ep_send_common(ep_fid, iov, desc, count, dest_addr, context,
+			0, tag, 0, ofi_op_tagged);
+}
+
+ssize_t	rxm_ep_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
+			fi_addr_t dest_addr, uint64_t tag)
+{
+	struct iovec iov;
+
+	memset(&iov, 0, sizeof(iov));
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
+
+	return rxm_ep_send_common(ep_fid, &iov, NULL, 1, dest_addr, NULL, 0, tag,
+			FI_INJECT, ofi_op_tagged);
+}
+
+ssize_t rxm_ep_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
+			  uint64_t data, fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	struct iovec iov;
+
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
+
+	return rxm_ep_send_common(ep_fid, &iov, desc, 1, dest_addr, context, data,
+			tag, 0, ofi_op_tagged);
+}
+
+ssize_t	rxm_ep_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
+			    uint64_t data, fi_addr_t dest_addr, uint64_t tag)
+{
+	struct iovec iov;
+
+	memset(&iov, 0, sizeof(iov));
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
+
+	return rxm_ep_send_common(ep_fid, &iov, NULL, 1, dest_addr, NULL, data,
+			tag, FI_INJECT, ofi_op_tagged);
+}
+
+struct fi_ops_tagged rxm_ops_tagged = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = rxm_ep_trecv,
+	.recvv = rxm_ep_trecvv,
+	.recvmsg = rxm_ep_trecvmsg,
+	.send = rxm_ep_tsend,
+	.sendv = rxm_ep_tsendv,
+	.sendmsg = rxm_ep_tsendmsg,
+	.inject = rxm_ep_tinject,
+	.senddata = rxm_ep_tsenddata,
+	.injectdata = rxm_ep_tinjectdata,
+};
+
+static int rxm_ep_msg_res_close(struct rxm_ep *rxm_ep)
+{
 	int ret, retv = 0;
 
-	rxm_ep = container_of(fid, struct rxm_ep, util_ep.ep_fid.fid);
-
-	if (rxm_ep->util_ep.av) {
-		ofi_cmap_free(rxm_ep->cmap);
-		atomic_dec(&rxm_ep->util_ep.av->ref);
+	ret = fi_close(&rxm_ep->msg_cq->fid);
+	if (ret) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to close msg CQ\n");
+		retv = ret;
 	}
 
 	ret = fi_close(&rxm_ep->srx_ctx->fid);
@@ -220,43 +706,73 @@ static int rxm_ep_close(struct fid *fid)
 	}
 
 	fi_freeinfo(rxm_ep->msg_info);
+	return retv;
+}
 
-	if (rxm_ep->util_ep.rx_cq)
-		atomic_dec(&rxm_ep->util_ep.rx_cq->ref);
+static int rxm_ep_close(struct fid *fid)
+{
+	struct rxm_ep *rxm_ep;
+	int ret;
 
-	if (rxm_ep->util_ep.tx_cq)
+	rxm_ep = container_of(fid, struct rxm_ep, util_ep.ep_fid.fid);
+
+	if (rxm_ep->util_ep.av) {
+		ofi_cmap_free(rxm_ep->cmap);
+		atomic_dec(&rxm_ep->util_ep.av->ref);
+	}
+
+	rxm_ep_txrx_res_close(rxm_ep);
+	ret = rxm_ep_msg_res_close(rxm_ep);
+
+	if (rxm_ep->util_ep.tx_cq) {
+		fid_list_remove(&rxm_ep->util_ep.tx_cq->ep_list,
+				&rxm_ep->util_ep.tx_cq->ep_list_lock,
+				&rxm_ep->util_ep.ep_fid.fid);
 		atomic_dec(&rxm_ep->util_ep.tx_cq->ref);
+	}
+
+	if (rxm_ep->util_ep.rx_cq) {
+		fid_list_remove(&rxm_ep->util_ep.rx_cq->ep_list,
+				&rxm_ep->util_ep.rx_cq->ep_list_lock,
+				&rxm_ep->util_ep.ep_fid.fid);
+		atomic_dec(&rxm_ep->util_ep.rx_cq->ref);
+	}
 
 	ofi_endpoint_close(&rxm_ep->util_ep);
 	free(rxm_ep);
-	return retv;
+	return ret;
 }
 
 static int rxm_ep_bind_cq(struct rxm_ep *rxm_ep, struct util_cq *util_cq, uint64_t flags)
 {
-	struct rxm_cq *rxm_cq;
-
-	rxm_cq = container_of(util_cq, struct rxm_cq, util_cq);
+	int ret;
 
 	if (flags & ~(FI_TRANSMIT | FI_RECV)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "unsupported flags\n");
 		return -FI_EBADFLAGS;
 	}
 
-	if (((flags & FI_TRANSMIT) && rxm_ep->tx_cq) ||
-	    ((flags & FI_RECV) && rxm_ep->rx_cq)) {
+	if (((flags & FI_TRANSMIT) && rxm_ep->util_ep.tx_cq) ||
+	    ((flags & FI_RECV) && rxm_ep->util_ep.rx_cq)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "duplicate CQ binding\n");
 		return -FI_EINVAL;
 	}
 
 	if (flags & FI_TRANSMIT) {
-		rxm_ep->util_ep.tx_cq = &rxm_cq->util_cq;
-		atomic_inc(&rxm_cq->util_cq.ref);
+		rxm_ep->util_ep.tx_cq = util_cq;
+		atomic_inc(&util_cq->ref);
 	}
 
 	if (flags & FI_RECV) {
-		rxm_ep->util_ep.rx_cq = &rxm_cq->util_cq;
-		atomic_inc(&rxm_cq->util_cq.ref);
+		rxm_ep->util_ep.rx_cq = util_cq;
+		atomic_inc(&util_cq->ref);
+	}
+	if (flags & (FI_TRANSMIT | FI_RECV)) {
+		ret = fid_list_insert(&util_cq->ep_list,
+				      &util_cq->ep_list_lock,
+				      &rxm_ep->util_ep.ep_fid.fid);
+		if (ret)
+			return ret;
 	}
 	return 0;
 }
@@ -317,7 +833,14 @@ static int rxm_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (!rxm_ep->util_ep.rx_cq || !rxm_ep->util_ep.tx_cq)
 			return -FI_ENOCQ;
 		if (!rxm_ep->util_ep.av)
-			return -FI_EOPBADSTATE; /* TODO: Add FI_ENOAV */
+			return -FI_EOPBADSTATE;
+
+		ret = rxm_ep_prepost_buf(rxm_ep);
+		if (ret) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+					"Unable to prepost recv bufs\n");
+			return ret;
+		}
 		ret = fi_pep_bind(rxm_ep->msg_pep, &rxm_fabric->msg_eq->fid, 0);
 		if (ret) {
 			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
@@ -350,6 +873,7 @@ static int rxm_ep_msg_res_open(struct fi_info *rxm_info,
 {
 	struct rxm_fabric *rxm_fabric;
 	struct rxm_domain *rxm_domain;
+	struct fi_cq_attr cq_attr;
 	int ret;
 
 	ret = ofix_getinfo(rxm_prov.version, NULL, NULL, 0, &rxm_util_prov,
@@ -364,6 +888,16 @@ static int rxm_ep_msg_res_open(struct fi_info *rxm_info,
 	ret = fi_passive_ep(rxm_fabric->msg_fabric, rxm_ep->msg_info, &rxm_ep->msg_pep, rxm_ep);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_FABRIC, "Unable to open msg PEP\n");
+		goto err1;
+	}
+
+	memset(&cq_attr, 0, sizeof(cq_attr));
+	cq_attr.size = rxm_info->tx_attr->size + rxm_info->rx_attr->size;
+	cq_attr.format = FI_CQ_FORMAT_MSG;
+
+	ret = fi_cq_open(rxm_domain->msg_domain, &cq_attr, &rxm_ep->msg_cq, NULL);
+	if (ret) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to open MSG CQ\n");
 		goto err1;
 	}
 
@@ -383,7 +917,6 @@ static int rxm_ep_msg_res_open(struct fi_info *rxm_info,
 
 	/* Zero out the port as we would be creating multiple MSG EPs for a single
 	 * RXM EP and we don't want address conflicts. */
-	// TODO handle other address types?
 	if (rxm_ep->msg_info->src_addr)
 		((struct sockaddr_in *)(rxm_ep->msg_info->src_addr))->sin_port = 0;
 
@@ -393,6 +926,14 @@ err2:
 err1:
 	fi_freeinfo(rxm_ep->msg_info);
 	return ret;
+}
+
+void rxm_ep_progress(struct util_ep *util_ep)
+{
+	struct rxm_ep *rxm_ep;
+
+	rxm_ep = container_of(util_ep, struct rxm_ep, util_ep);
+	rxm_cq_progress(rxm_ep->msg_cq);
 }
 
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
@@ -406,25 +947,41 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (!rxm_ep)
 		return -FI_ENOMEM;
 
+	if (!(rxm_ep->rxm_info = fi_dupinfo(info))) {
+		ret = -FI_ENOMEM;
+		goto err1;
+	}
+
 	ret = ofi_endpoint_init(domain, &rxm_util_prov, info, &rxm_ep->util_ep,
-			context, NULL, FI_MATCH_PREFIX);
+			context, &rxm_ep_progress, FI_MATCH_PREFIX);
 	if (ret)
-		goto err;
+		goto err1;
 
 	util_domain = container_of(domain, struct util_domain, domain_fid);
 
 	ret = rxm_ep_msg_res_open(info, util_domain, rxm_ep);
 	if (ret)
-		goto err;
+		goto err2;
+
+	ret = rxm_ep_txrx_res_open(rxm_ep);
+	if (ret)
+		goto err3;
 
 	*ep_fid = &rxm_ep->util_ep.ep_fid;
 	(*ep_fid)->fid.ops = &rxm_ep_fi_ops;
-	(*ep_fid)->ops = &rxm_ep_ops;
-	(*ep_fid)->cm = &rxm_cm_ops;
-	(*ep_fid)->msg = &rxm_msg_ops;
+	(*ep_fid)->ops = &rxm_ops_ep;
+	(*ep_fid)->cm = &rxm_ops_cm;
+	(*ep_fid)->msg = &rxm_ops_msg;
+	(*ep_fid)->tagged = &rxm_ops_tagged;
 
 	return 0;
-err:
+err3:
+	rxm_ep_msg_res_close(rxm_ep);
+err2:
+	ofi_endpoint_close(&rxm_ep->util_ep);
+err1:
+	if (rxm_ep->rxm_info)
+		fi_freeinfo(rxm_ep->rxm_info);
 	free(rxm_ep);
 	return ret;
 }

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -53,7 +53,14 @@ int rxm_alter_base_info(struct fi_info *base_info, struct fi_info *layer_info)
 	layer_info->mode = rxm_info.mode;
 
 	*layer_info->tx_attr = *rxm_info.tx_attr;
+	layer_info->tx_attr->iov_limit = MIN(MIN(layer_info->tx_attr->iov_limit,
+			base_info->tx_attr->iov_limit),
+			base_info->tx_attr->rma_iov_limit);
+
 	*layer_info->rx_attr = *rxm_info.rx_attr;
+	layer_info->rx_attr->iov_limit = MIN(layer_info->rx_attr->iov_limit,
+			base_info->rx_attr->iov_limit);
+
 	*layer_info->ep_attr = *rxm_info.ep_attr;
 	layer_info->ep_attr->max_msg_size = base_info->ep_attr->max_msg_size;
 	*layer_info->domain_attr = *rxm_info.domain_attr;


### PR DESCRIPTION
This is the initial commit for the following features and they are not guaranteed
to be stable yet.

- Add support for FI_TAGGED
  - Copy data for small messages ( < ~4096 bytes).
  - Use msg provider RMA read for large messages.
- Add support for FI_SOURCE, FI_DIRECTED_RECV
- Use single CQ for msg provider. When RXM CQ is progressed, progress each EP bound to it.
- Exchange conn_id (used to identify source of a message) during connection establishment.
- Add FI_LOCAL_MR mode bit requirement (this would be removed in the future)