### PR TITLE
prov/psm2: Fix initialization for dll provider

### DIFF
--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -523,6 +523,9 @@ PROVIDER_INI
 	int major, minor;
 	int err;
 
+#ifdef HAVE_PSM2_DL
+	fi_util_init();
+#endif
 	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
 
 	fi_param_define(&psmx2_prov, "name_server", FI_PARAM_BOOL,


### PR DESCRIPTION
Initialize the utility code when built as a dll provider.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>