### PR TITLE
prov/gni: Fix mr_mode field in fi_getinfo

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -459,8 +459,7 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 			switch (hints->domain_attr->mr_mode) {
 			case FI_MR_UNSPEC:
 			case FI_MR_BASIC:
-				gnix_info->domain_attr->mr_mode =
-					hints->domain_attr->mr_mode;
+				gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
 				break;
 			case FI_MR_SCALABLE:
 				goto err;


### PR DESCRIPTION
@sungeunchoi and @hppritcha, let me know if you approve. This is such a small change that I figured I should target it for the upstream. Let me know if you want me to target Cray's fork instead.

The GNI provider currently is copying whatever the user specified
in the hints into the output for this field. So if the hints had
FI_MR_UNSPEC, the resulting info object will also have FI_MR_UNSPEC.
This patch fills the field with the mr_mode that will actually be
used, FI_MR_BASIC.

Fixes ofi-cray/libfabric-cray#1062

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>