### PR TITLE
usnic: Properly handle invalid service argument.

### DIFF
--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -666,11 +666,11 @@ usdf_getinfo(uint32_t version, const char *node, const char *service,
 	if (node != NULL || service != NULL) {
 		ret = getaddrinfo(node, service, NULL, &ai);
 		if (ret != 0) {
-			USDF_DBG("getaddrinfo failed, likely bad node/service specified (%s:%s)\n",
-				node, service);
-			ret = -errno;
+			USDF_DBG("getaddrinfo failed: %d: <%s>\n", ret,
+				 gai_strerror(ret));
 			goto fail;
 		}
+
 		if (flags & FI_SOURCE) {
 			src = (struct sockaddr_in *)ai->ai_addr;
 		} else {

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -555,6 +555,13 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node, const cha
 			continue;
 		}
 
+		if (!cur) {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+				"fi_getinfo: provider %s output empty list\n",
+				prov->provider->name);
+			continue;
+		}
+
 		if (!*info)
 			*info = cur;
 		else


### PR DESCRIPTION
Bug in the usNIC providers `getinfo` implementation would cause a return value of `FI_SUCCESS`, but an empty list of `fi_info` structures. Log a warning to the core and avoid crashing.