### PR TITLE
prov/gni: Disable fma shared to get the criterion

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -66,7 +66,7 @@ const char gnix_dom_name[] = "/sys/class/gni/kgni0";
 const char gnix_prov_name[] = "gni";
 
 uint32_t gnix_cdm_modes =
-	(GNI_CDM_MODE_FAST_DATAGRAM_POLL | GNI_CDM_MODE_FMA_SHARED |
+	(GNI_CDM_MODE_FAST_DATAGRAM_POLL | /* GNI_CDM_MODE_FMA_SHARED | */
 	GNI_CDM_MODE_FMA_SMALL_WINDOW | GNI_CDM_MODE_FORK_PARTCOPY |
 	GNI_CDM_MODE_ERR_NO_KILL);
 


### PR DESCRIPTION
 tests passing

upstream merge of ofi-cray/libfabric-cray#1060
@sungeunchoi 

Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@79eb83192cf097e239b783cd17470617104bad88)