### PR TITLE
prov/gni: initial FI_EP_MSG endpoint type implementation

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -118,7 +118,8 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/vc_lookup.c \
 	prov/gni/test/vector.c \
 	prov/gni/test/wait.c \
-	prov/gni/test/common.c
+	prov/gni/test/common.c \
+	prov/gni/test/cm.c
 
 prov_gni_test_gnitest_LDFLAGS = $(CRAY_PMI_LIBS) $(gnitest_LDFLAGS) -static
 prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(CRAY_PMI_CFLAGS) $(CRAY_XPMEM_CFLAGS) $(gnitest_CPPFLAGS)

--- a/prov/gni/include/gnix_cm.h
+++ b/prov/gni/include/gnix_cm.h
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,28 +30,52 @@
  * SOFTWARE.
  */
 
-#ifndef _GNIX_NAMESERVER_H_
-#define _GNIX_NAMESERVER_H_
+#ifndef _GNIX_CM_H_
+#define _GNIX_CM_H_
 
 #include "gnix.h"
 
-/*
- * defines, data structs, and prototypes for gnix nameserver
- */
+struct gnix_pep_sock_connreq {
+	int type;
+	int msg_id;
+	struct fi_info info;
+	struct gnix_ep_name src_addr;
+	struct gnix_ep_name dest_addr;
+	struct fi_tx_attr tx_attr;
+	struct fi_rx_attr rx_attr;
+	struct fi_ep_attr ep_attr;
+	struct fi_domain_attr domain_attr;
+	struct fi_fabric_attr fabric_attr;
+	int vc_id;
+	gni_smsg_attr_t vc_mbox_attr;
+	gni_mem_handle_t cq_irq_mdh;
+	uint64_t peer_caps;
+};
 
-/*
- * prototypes
- */
+enum gnix_pep_sock_resp_cmd {
+	GNIX_PEP_SOCK_RESP_ACCEPT,
+	GNIX_PEP_SOCK_RESP_REJECT
+};
 
-int _gnix_local_ipaddr(struct sockaddr_in *sin);
+struct gnix_pep_sock_connresp {
+	enum gnix_pep_sock_resp_cmd cmd;
+	int vc_id;
+	gni_smsg_attr_t vc_mbox_attr;
+	gni_mem_handle_t cq_irq_mdh;
+	uint64_t peer_caps;
+};
 
-int _gnix_pe_to_ip(const struct gnix_ep_name *ep_name,
-		   struct sockaddr_in *saddr);
+struct gnix_pep_sock_conn {
+	struct fid fid;
+	struct dlist_entry list;
+	int sock_fd;
+	struct gnix_pep_sock_connreq req;
+	int bytes_read;
+	struct fi_info *info;
+};
 
-int _gnix_resolve_name(IN const char *node, IN const char *service,
-		       IN uint64_t flags, INOUT struct gnix_ep_name
-		       *resolved_addr);
+int _gnix_pep_progress(struct gnix_fid_pep *pep);
+int _gnix_ep_progress(struct gnix_fid_ep *ep);
 
-int _gnix_src_addr(struct gnix_ep_name *resolved_addr);
+#endif
 
-#endif /* _GNIX_NAMESERVER_H_ */

--- a/prov/gni/include/gnix_eq.h
+++ b/prov/gni/include/gnix_eq.h
@@ -35,6 +35,7 @@
 #define _GNIX_EQ_H_
 
 #include <rdma/fi_eq.h>
+#include <stdbool.h>
 
 #include "gnix_queue.h"
 #include "gnix_wait.h"
@@ -65,12 +66,19 @@ struct gnix_eq_entry {
 	struct slist_entry item;
 };
 
+struct gnix_eq_poll_obj {
+	struct dlist_entry list;
+	struct fid *obj_fid;
+};
+
 /*
  * EQ structure. Contains error and event queue.
  */
 struct gnix_fid_eq {
 	struct fid_eq eq_fid;
 	struct gnix_fid_fabric *fabric;
+
+	bool requires_lock;
 
 	struct gnix_queue *events;
 	struct gnix_queue *errors;
@@ -81,6 +89,12 @@ struct gnix_fid_eq {
 
 	fastlock_t lock;
 	struct gnix_reference ref_cnt;
+
+	rwlock_t poll_obj_lock;
+	struct dlist_entry poll_objs;
 };
+
+int _gnix_eq_poll_obj_add(struct gnix_fid_eq *eq, struct fid *obj_fid);
+int _gnix_eq_poll_obj_rem(struct gnix_fid_eq *eq, struct fid *obj_fid);
 
 #endif /* _GNIX_EQ_H_ */

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -65,6 +65,8 @@ extern uint32_t gnix_max_nics_per_ptag;
  */
 typedef int (*smsg_callback_fn_t)(void  *ptr, void *msg);
 
+extern smsg_callback_fn_t gnix_ep_smsg_callbacks[];
+
 /*
  * typedef for completer functions invoked
  * at initiator when local CQE (tx) is processed

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -178,21 +178,6 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
  */
 int _gnix_vc_connect(struct gnix_vc *vc);
 
-
-/**
- * @brief Sets up an accepting vc - one accepting vc can accept a
- *        single incoming connection request
- *
- * @param[in]  vc   pointer to previously allocated vc struct with
- *                  FI_ADDR_UNSPEC value supplied for the fi_addr_t
- *                  argument
- *
- * @return FI_SUCCESS on success, -FI_EINVAL if an invalid field in the vc
- *         struct is encountered, -ENOMEM if insufficient memory to initiate
- *         accept request.
- */
-int _gnix_vc_accept(struct gnix_vc *vc);
-
 /**
  * @brief Initiates a non-blocking disconnect of a vc from its peer
  *
@@ -203,7 +188,6 @@ int _gnix_vc_accept(struct gnix_vc *vc);
  *         connection request.
  */
 int _gnix_vc_disconnect(struct gnix_vc *vc);
-
 
 /**
  * @brief Destroys a previously allocated vc and cleans up resources
@@ -329,6 +313,10 @@ fi_addr_t _gnix_vc_peer_fi_addr(struct gnix_vc *vc);
 
 int _gnix_vc_cm_init(struct gnix_cm_nic *cm_nic);
 int _gnix_vc_schedule(struct gnix_vc *vc);
+int _gnix_vc_smsg_init(struct gnix_vc *vc,
+		       int peer_id,
+		       gni_smsg_attr_t *peer_smsg_attr,
+		       gni_mem_handle_t *peer_irq_mem_hndl);
 
 /*
  * inline functions

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -534,12 +534,6 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	GNIX_TRACE(FI_LOG_DOMAIN, "\n");
 
 	fabric_priv = container_of(fabric, struct gnix_fid_fabric, fab_fid);
-	if (!info->domain_attr->name ||
-	    strncmp(info->domain_attr->name, gnix_dom_name,
-		    strlen(gnix_dom_name))) {
-		ret = -FI_EINVAL;
-		goto err;
-	}
 
 	/*
 	 * check cookie/ptag credentials - for FI_EP_MSG we may be creating a

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -91,7 +91,7 @@ DIRECT_FN int gnix_fabric_trywait(struct fid_fabric *fabric, struct fid **fids, 
 static struct fi_ops_fabric gnix_fab_ops = {
 	.size = sizeof(struct fi_ops_fabric),
 	.domain = gnix_domain_open,
-	.passive_ep = fi_no_passive_ep,
+	.passive_ep = gnix_passive_ep_open,
 	.eq_open = gnix_eq_open,
 	.wait_open = gnix_wait_open,
 	.trywait = gnix_fabric_trywait
@@ -184,115 +184,15 @@ static int gnix_fabric_open(struct fi_fabric_attr *attr,
 	return FI_SUCCESS;
 }
 
-static int gnix_getinfo(uint32_t version, const char *node, const char *service,
-			uint64_t flags, struct fi_info *hints,
-			struct fi_info **info)
+static struct fi_info *_gnix_allocinfo()
 {
-	int ret = 0;
-	uint32_t pe = -1;
-	uint32_t cpu_id = -1;
-	int ep_type_unspec = 1;
-	uint64_t mode = GNIX_FAB_MODES;
-	struct fi_info *gnix_info = NULL;
-	struct gnix_ep_name *dest_addr = NULL;
-	struct gnix_ep_name *src_addr = NULL;
-	struct gnix_ep_name *addr = NULL;
-	gni_return_t status;
+	struct fi_info *gnix_info;
 
-	/*
-	 * do an early check of hints if an app is trying to use
-	 * an addressing format we don't handle
-	 */
-
-	if (hints) {
-		switch (hints->addr_format) {
-		case FI_FORMAT_UNSPEC:
-		case FI_ADDR_GNI:
-			break;
-		default:
-			GNIX_INFO(FI_LOG_FABRIC,
-				"hints->addr_format=%d, supported=%d,%d.\n",
-				hints->addr_format, FI_FORMAT_UNSPEC, FI_ADDR_GNI);
-			ret = -FI_EADDRNOTAVAIL;
-			goto err;
-		}
-	}
-
-	addr = malloc(sizeof(*addr));
-	if (!addr) {
-		goto err;
-	}
-
-	/*
-	 * the code below for resolving a node/service to what
-	 * will be a gnix_ep_name address is not fully implemented,
-	 * but put a place holder in place
-	 */
-	if (node) {
-
-		/* resolve node/service to gnix_ep_name */
-		ret = gnix_resolve_name(node, service, flags, addr);
-		if (ret) {
-			goto err;
-		}
-
-		if (flags & FI_SOURCE) {
-			/* resolved address is the local address */
-			src_addr = addr;
-			if (hints && hints->dest_addr)
-				dest_addr = hints->dest_addr;
-		} else {
-			/* resolved address is a peer */
-			dest_addr = addr;
-			if (hints && hints->src_addr)
-				src_addr = hints->src_addr;
-		}
-	} else {
-		/*
-		 * okay per the man page, just fill in the src_addr
-		 */
-		src_addr = addr;
-
-		status = GNI_CdmGetNicAddress(0, &pe, &cpu_id);
-		if(status != GNI_RC_SUCCESS) {
-			GNIX_WARN(FI_LOG_FABRIC,
-				  "Unable to get NIC address.");
-				  ret = gnixu_to_fi_errno(status);
-			goto err;
-		}
-
-		if (pe == -1) {
-			GNIX_WARN(FI_LOG_FABRIC,
-				"Unable to acquire valid address for local Aries\n");
-			ret = -FI_EADDRNOTAVAIL;
-			goto err;
-		}
-
-		src_addr->gnix_addr.device_addr = pe;
-		src_addr->gnix_addr.cdm_id = 0;  /* just set this to zero */
-		src_addr->name_type = GNIX_EPN_TYPE_UNBOUND;
-	}
-
-	if (src_addr)
-		GNIX_INFO(FI_LOG_FABRIC, "src_pe: 0x%x src_port: 0x%lx\n",
-			  src_addr->gnix_addr.device_addr,
-			  src_addr->gnix_addr.cdm_id);
-	if (dest_addr)
-		GNIX_INFO(FI_LOG_FABRIC, "dest_pe: 0x%x dest_port: 0x%lx\n",
-			  dest_addr->gnix_addr.device_addr,
-			  dest_addr->gnix_addr.cdm_id);
-
-	/*
-	 * fill in the gnix_info struct
-	 */
 	gnix_info = fi_allocinfo();
 	if (gnix_info == NULL) {
-		goto err;
+		return NULL;
 	}
 
-	/*
-	 * Set the default values
-	 */
 	gnix_info->tx_attr->op_flags = 0;
 	gnix_info->rx_attr->op_flags = 0;
 	gnix_info->ep_attr->type = FI_EP_RDM;
@@ -309,7 +209,7 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->domain_attr->av_type = FI_AV_UNSPEC;
 	gnix_info->domain_attr->tx_ctx_cnt = gnix_max_nics_per_ptag;
 	gnix_info->domain_attr->rx_ctx_cnt = gnix_max_nics_per_ptag;
-	/* only one aries per node */
+
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);
 	gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
@@ -322,10 +222,8 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->addr_format = FI_ADDR_GNI;
 	gnix_info->src_addrlen = sizeof(struct gnix_ep_name);
 	gnix_info->dest_addrlen = sizeof(struct gnix_ep_name);
-	gnix_info->src_addr = src_addr;
-	gnix_info->dest_addr = dest_addr;
-	/* prov_name gets filled in by fi_getinfo from the gnix_prov struct */
-	/* let's consider gni copyrighted :) */
+	gnix_info->src_addr = NULL;
+	gnix_info->dest_addr = NULL;
 
 	gnix_info->tx_attr->msg_order = FI_ORDER_SAS;
 	gnix_info->tx_attr->comp_order = FI_ORDER_NONE;
@@ -338,26 +236,144 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->rx_attr->size = GNIX_RX_SIZE_DEFAULT;
 	gnix_info->rx_attr->iov_limit = GNIX_MAX_MSG_IOV_LIMIT;
 
-	if (hints) {
-		if (hints->ep_attr) {
-			/*
-			 * support FI_EP_RDM, FI_EP_DGRAM endpoint types
-			 */
-			switch (hints->ep_attr->type) {
-			case FI_EP_UNSPEC:
-				break;
-			case FI_EP_RDM:
-			case FI_EP_DGRAM:
-				gnix_info->ep_attr->type = hints->ep_attr->type;
-				ep_type_unspec = 0;
-				break;
-			default:
+	return gnix_info;
+}
+
+static int __gnix_getinfo_resolve_node(const char *node, const char *service,
+				       uint64_t flags, struct fi_info *hints,
+				       struct fi_info *info)
+{
+	int ret;
+	struct gnix_ep_name *dest_addr = NULL;
+	struct gnix_ep_name *src_addr = NULL;
+	struct gnix_ep_name *addr = NULL;
+
+	if (flags & FI_SOURCE) {
+		/* -resolve node/port to make info->src_addr
+		 * -ignore hints->src_addr
+		 * -copy hints->dest_addr to output info */
+		src_addr = malloc(sizeof(*addr));
+		if (!src_addr) {
+			ret = -FI_ENOMEM;
+			goto err;
+		}
+
+		ret = _gnix_resolve_name(node, service, flags, src_addr);
+		if (ret != FI_SUCCESS) {
+			ret = -FI_ENODATA;
+			goto err;
+		}
+
+		if (hints && hints->dest_addr) {
+			dest_addr = malloc(sizeof(*dest_addr));
+			if (!dest_addr) {
+				ret = -FI_ENOMEM;
 				goto err;
 			}
 
-			/*
-			 * only support FI_PROTO_GNI protocol
-			 */
+			memcpy(dest_addr, hints->dest_addr,
+			       hints->dest_addrlen);
+		}
+	} else {
+		/* -try to resolve node/port to make info->dest_addr
+		 * -fallback to copying hints->dest_addr to output info
+		 * -try to copy hints->src_addr to output info
+		 * -falback to finding src_addr for output info */
+		if (node || service) {
+			dest_addr = malloc(sizeof(*dest_addr));
+			if (!dest_addr) {
+				ret = -FI_ENOMEM;
+				goto err;
+			}
+
+			ret = _gnix_resolve_name(node, service, flags,
+						 dest_addr);
+			if (ret != FI_SUCCESS) {
+				ret = -FI_ENODATA;
+				goto err;
+			}
+		} else {
+			if (hints && hints->dest_addr) {
+				dest_addr = malloc(sizeof(*dest_addr));
+				if (!dest_addr) {
+					ret = -FI_ENOMEM;
+					goto err;
+				}
+
+				memcpy(dest_addr, hints->dest_addr,
+				       hints->dest_addrlen);
+			}
+		}
+
+		if (hints && hints->src_addr) {
+			src_addr = malloc(sizeof(*src_addr));
+			if (!src_addr) {
+				ret = -FI_ENOMEM;
+				goto err;
+			}
+
+			memcpy(src_addr, hints->src_addr, hints->src_addrlen);
+		} else {
+			src_addr = malloc(sizeof(*src_addr));
+			if (!src_addr) {
+				ret = -FI_ENOMEM;
+				goto err;
+			}
+
+			ret = _gnix_src_addr(src_addr);
+			if (ret != FI_SUCCESS)
+				goto err;
+		}
+	}
+
+	GNIX_INFO(FI_LOG_FABRIC, "%snode: %s service: %s\n",
+		  flags & FI_SOURCE ? "(FI_SOURCE) " : "", node, service);
+
+	if (src_addr)
+		GNIX_INFO(FI_LOG_FABRIC, "src_pe: 0x%x src_port: 0x%lx\n",
+			  src_addr->gnix_addr.device_addr,
+			  src_addr->gnix_addr.cdm_id);
+	if (dest_addr)
+		GNIX_INFO(FI_LOG_FABRIC, "dest_pe: 0x%x dest_port: 0x%lx\n",
+			  dest_addr->gnix_addr.device_addr,
+			  dest_addr->gnix_addr.cdm_id);
+
+	info->src_addr = src_addr;
+	info->dest_addr = dest_addr;
+
+	return FI_SUCCESS;
+
+err:
+	free(src_addr);
+	free(dest_addr);
+
+	return ret;
+}
+
+static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
+			    const char *node, const char *service,
+			    uint64_t flags, struct fi_info *hints,
+			    struct fi_info **info)
+{
+	uint64_t mode = GNIX_FAB_MODES;
+	struct fi_info *gnix_info = NULL;
+	int ret;
+
+	if ((hints && hints->ep_attr) &&
+	    (hints->ep_attr->type != FI_EP_UNSPEC &&
+	     hints->ep_attr->type != ep_type)) {
+		return -FI_ENODATA;
+	}
+
+	gnix_info = _gnix_allocinfo(info);
+	if (!gnix_info)
+		return -FI_ENOMEM;
+
+	gnix_info->ep_attr->type = ep_type;
+
+	if (hints) {
+		if (hints->ep_attr) {
+			/* Only support FI_PROTO_GNI protocol. */
 			switch (hints->ep_attr->protocol) {
 			case FI_PROTO_UNSPEC:
 			case FI_PROTO_GNI:
@@ -366,22 +382,19 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 				goto err;
 			}
 
-			if (hints->ep_attr->tx_ctx_cnt > GNIX_SEP_MAX_CNT) {
+			if (hints->ep_attr->tx_ctx_cnt > GNIX_SEP_MAX_CNT)
 				goto err;
-			}
 
-			if (hints->ep_attr->rx_ctx_cnt > GNIX_SEP_MAX_CNT) {
+			if (hints->ep_attr->rx_ctx_cnt > GNIX_SEP_MAX_CNT)
 				goto err;
-			}
 
 			gnix_info->ep_attr->tx_ctx_cnt =
 				hints->ep_attr->tx_ctx_cnt;
 			gnix_info->ep_attr->rx_ctx_cnt =
 				hints->ep_attr->rx_ctx_cnt;
 
-			if (hints->ep_attr->max_msg_size > GNIX_MAX_MSG_SIZE) {
+			if (hints->ep_attr->max_msg_size > GNIX_MAX_MSG_SIZE)
 				goto err;
-			}
 		}
 
 		/*
@@ -395,19 +408,17 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 		}
 
 		if (!hints->caps) {
-			/* Return all supported capabilities. */
-			gnix_info->caps = GNIX_EP_RDM_CAPS_FULL;
+			/* If no caps are requested, return all supported. */
+			gnix_info->caps = GNIX_EP_CAPS_FULL;
 		} else {
 			/* The provider must support all requested
 			 * capabilities. */
-			if ((hints->caps & GNIX_EP_RDM_CAPS_FULL) !=
-			    hints->caps) {
+			if ((hints->caps & GNIX_EP_CAPS_FULL) != hints->caps)
 				goto err;
-			}
 
 			/* The provider may silently enable secondary
 			 * capabilities that do not introduce any overhead. */
-			gnix_info->caps = hints->caps | GNIX_EP_RDM_SEC_CAPS;
+			gnix_info->caps = hints->caps | GNIX_EP_SEC_CAPS;
 		}
 
 		if (hints->tx_attr) {
@@ -483,6 +494,11 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 		}
 	}
 
+	ret = __gnix_getinfo_resolve_node(node, service, flags, hints,
+					  gnix_info);
+	if (ret != FI_SUCCESS)
+		goto  err;
+
 	gnix_info->mode = mode;
 	gnix_info->fabric_attr->name = strdup(gnix_fab_name);
 	gnix_info->tx_attr->caps = gnix_info->caps;
@@ -490,37 +506,50 @@ static int gnix_getinfo(uint32_t version, const char *node, const char *service,
 	gnix_info->rx_attr->caps = gnix_info->caps;
 	gnix_info->rx_attr->mode = gnix_info->mode;
 
-	if (ep_type_unspec) {
-		struct fi_info *dg_info = fi_dupinfo(gnix_info);
-
-		if (!dg_info) {
-			GNIX_WARN(FI_LOG_FABRIC, "cannot copy info\n");
-			goto err;
-		}
-
-		dg_info->ep_attr->type = FI_EP_DGRAM;
-		gnix_info->next = dg_info;
-	}
-
 	*info = gnix_info;
 
-	return 0;
+	GNIX_DEBUG(FI_LOG_FABRIC, "Returning EP type: %s\n",
+		   fi_tostr(&ep_type, FI_TYPE_EP_TYPE));
+	return FI_SUCCESS;
 err:
-	if (gnix_info) {
-		if (gnix_info->tx_attr) free(gnix_info->tx_attr);
-		if (gnix_info->rx_attr) free(gnix_info->rx_attr);
-		if (gnix_info->ep_attr) free(gnix_info->ep_attr);
-		if (gnix_info->domain_attr) free(gnix_info->domain_attr);
-		if (gnix_info->fabric_attr) free(gnix_info->fabric_attr);
-		free(gnix_info);
+	fi_freeinfo(gnix_info);
+	return -FI_ENODATA;
+}
+
+static int gnix_getinfo(uint32_t version, const char *node, const char *service,
+			uint64_t flags, struct fi_info *hints,
+			struct fi_info **info)
+{
+	int ret = 0;
+	struct fi_info *info_ptr;
+
+	/* Note that info entries are added to the head of 'info', that is,
+	 * they are preferred in the reverse order shown here. */
+
+	*info = NULL;
+
+	ret = _gnix_ep_getinfo(FI_EP_MSG, version, node, service, flags,
+			       hints, &info_ptr);
+	if (ret == FI_SUCCESS) {
+		info_ptr->next = *info;
+		*info = info_ptr;
 	}
 
-	/*
-	 *  for the getinfo method, we need to return -FI_ENODATA  otherwise
-	 *  the fi_getinfo call will make an early exit without querying
-	 *  other providers which may be avaialble.
-	 */
-	return -FI_ENODATA;
+	ret = _gnix_ep_getinfo(FI_EP_DGRAM, version, node, service, flags,
+			       hints, &info_ptr);
+	if (ret == FI_SUCCESS) {
+		info_ptr->next = *info;
+		*info = info_ptr;
+	}
+
+	ret = _gnix_ep_getinfo(FI_EP_RDM, version, node, service, flags,
+			       hints, &info_ptr);
+	if (ret == FI_SUCCESS) {
+		info_ptr->next = *info;
+		*info = info_ptr;
+	}
+
+	return *info ? FI_SUCCESS : -FI_ENODATA;
 }
 
 static void gnix_fini(void)

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -52,6 +52,8 @@
 
 #define GNIX_TAGGED_PCD_COMPLETION_FLAGS	(FI_MSG | FI_RECV | FI_TAGGED)
 
+smsg_completer_fn_t gnix_ep_smsg_completers[];
+
 /*******************************************************************************
  * helper functions
  ******************************************************************************/
@@ -2366,10 +2368,8 @@ static int __gnix_msg_addr_lookup(struct gnix_fid_ep *ep, uint64_t src_addr,
 		} else {
 			*(uint64_t *)gnix_addr = FI_ADDR_UNSPEC;
 		}
-	} else {
-		assert(ep->vc != NULL);
-		*gnix_addr = ep->vc->peer_addr;
 	}
+	/* NOP for MSG EPs. */
 
 	return FI_SUCCESS;
 }

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -1345,6 +1345,8 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		dlist_insert_tail(&nic->gnix_nic_list, &gnix_nic_list);
 		dlist_insert_tail(&nic->dom_nic_list, &domain->nic_list);
 
+		nic->smsg_callbacks = gnix_ep_smsg_callbacks;
+
 		++gnix_nics_per_ptag[domain->ptag];
 
 		GNIX_INFO(FI_LOG_EP_CTRL, "Allocated NIC:%p\n", nic);

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -645,7 +645,7 @@ int gnix_sep_open(struct fid_domain *domain, struct fi_info *info,
 
 	sep_priv->ep_fid.fid.ops = &gnix_sep_fi_ops;
 	sep_priv->ep_fid.ops = &gnix_sep_ops;
-	sep_priv->ep_fid.cm = &gnix_cm_ops;
+	sep_priv->ep_fid.cm = &gnix_ep_ops_cm;
 	sep_priv->domain = domain;
 
 	sep_priv->info = fi_dupinfo(info);
@@ -658,7 +658,7 @@ int gnix_sep_open(struct fid_domain *domain, struct fi_info *info,
 
 	_gnix_ref_init(&sep_priv->ref_cnt, 1, __sep_destruct);
 
-	sep_priv->caps = info->caps & GNIX_EP_RDM_PRIMARY_CAPS;
+	sep_priv->caps = info->caps & GNIX_EP_PRIMARY_CAPS;
 
 	sep_priv->op_flags = info->tx_attr->op_flags;
 	sep_priv->op_flags |= info->rx_attr->op_flags;

--- a/prov/gni/src/gnix_xpmem.c
+++ b/prov/gni/src/gnix_xpmem.c
@@ -450,7 +450,7 @@ int _gnix_xpmem_accessible(struct gnix_fid_ep *ep,
 	 * of the supplied address, return true, else false
 	 */
 
-	*accessible = (ep->my_name.gnix_addr.device_addr ==
+	*accessible = (ep->src_addr.gnix_addr.device_addr ==
 			addr.device_addr) ? true : false;
 
 	return FI_SUCCESS;

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -266,7 +266,7 @@ Test(gnix_cancel, cancel_ep_send)
 	ret = _gnix_vc_alloc(gnix_ep, NULL, &vc);
 	cr_assert(ret == FI_SUCCESS, "_gnix_vc_alloc failed");
 
-	key = (gnix_ht_key_t *)&gnix_ep->my_name.gnix_addr;
+	key = (gnix_ht_key_t *)&gnix_ep->src_addr.gnix_addr;
 	ret = _gnix_ht_insert(gnix_ep->vc_ht, *key, vc);
 	cr_assert(!ret);
 

--- a/prov/gni/test/cm.c
+++ b/prov/gni/test/cm.c
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) 2016 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+#include <inttypes.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <ifaddrs.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/ip.h> /* superset of previous */
+#include <arpa/inet.h>
+
+#include "gnix_vc.h"
+#include "gnix_cm_nic.h"
+#include "gnix_hashtable.h"
+#include "gnix_atomic.h"
+
+#include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+
+#if 1
+#define dbg_printf(...)
+#else
+#define dbg_printf(...)				\
+	do {					\
+		printf(__VA_ARGS__);		\
+		fflush(stdout);			\
+	} while (0)
+#endif
+
+#define NUMEPS 2
+
+#define DEF_PORT "1973"
+
+static struct fid_fabric *cli_fab;
+static struct fid_domain *cli_dom;
+static struct fid_ep *cli_ep;
+static struct fi_info *cli_hints;
+static struct fi_info *cli_fi;
+static struct fid_eq *cli_eq;
+static struct fid_cq *cli_cq;
+
+static struct fid_fabric *srv_fab;
+static struct fid_domain *srv_dom;
+static struct fid_pep *srv_pep;
+static struct fid_ep *srv_ep;
+static struct fi_info *srv_hints;
+static struct fi_info *srv_fi;
+static struct fid_eq *srv_eq;
+static struct fid_cq *srv_cq;
+
+struct fi_eq_attr eq_attr = {
+	.wait_obj = FI_WAIT_UNSPEC
+};
+
+struct fi_cq_attr cq_attr = {
+	.wait_obj = FI_WAIT_NONE
+};
+
+int cm_local_ip(struct sockaddr_in *sa)
+{
+	struct ifaddrs *ifap;
+	struct ifaddrs *ifa;
+	int ret = -1;
+
+	getifaddrs(&ifap);
+
+	ifa = ifap;
+	while (ifa) {
+		fprintf(stderr, "IF: %s, IP ADDR: %s\n",
+			ifa->ifa_name,
+			inet_ntoa(((struct sockaddr_in *)
+					(ifa->ifa_addr))->sin_addr));
+		/* Return first non loopback interface. */
+		if (ifa->ifa_addr &&
+		    ifa->ifa_addr->sa_family == AF_INET &&
+		    ((struct sockaddr_in *)(ifa->ifa_addr))->sin_addr.s_addr !=
+		     inet_addr("127.0.0.1")) {
+			ret = 0;
+			break;
+		}
+		ifa = ifa->ifa_next;
+	}
+
+	if (!ret) {
+		memcpy((void *)sa, (void *)ifa->ifa_addr,
+		       sizeof(struct sockaddr));
+	}
+
+	freeifaddrs(ifap);
+
+	return ret;
+}
+
+int cm_server_start(void)
+{
+	int ret;
+	struct sockaddr_in loc_sa;
+
+	cm_local_ip(&loc_sa);
+
+	srv_hints = fi_allocinfo();
+	srv_hints->fabric_attr->name = strdup("gni");
+	srv_hints->ep_attr->type = FI_EP_MSG;
+
+	ret = fi_getinfo(FI_VERSION(1, 0), inet_ntoa(loc_sa.sin_addr),
+			 DEF_PORT, FI_SOURCE, srv_hints, &srv_fi);
+	cr_assert(!ret);
+
+	ret = fi_fabric(srv_fi->fabric_attr, &srv_fab, NULL);
+	cr_assert(!ret);
+
+	ret = fi_eq_open(srv_fab, &eq_attr, &srv_eq, NULL);
+	cr_assert(!ret);
+
+	ret = fi_passive_ep(srv_fab, srv_fi, &srv_pep, NULL);
+	cr_assert(!ret);
+
+	ret = fi_pep_bind(srv_pep, &srv_eq->fid, 0);
+	cr_assert(!ret);
+
+	ret = fi_listen(srv_pep);
+	cr_assert(!ret);
+
+	dbg_printf("Server start complete.\n");
+
+	return 0;
+}
+
+void cm_stop_server(void)
+{
+	fi_close(&srv_cq->fid);
+	fi_close(&srv_ep->fid);
+	fi_close(&srv_dom->fid);
+	fi_close(&srv_pep->fid);
+	fi_close(&srv_eq->fid);
+	fi_close(&srv_fab->fid);
+	fi_freeinfo(srv_fi);
+}
+
+int cm_server_accept(void)
+{
+	uint32_t event;
+	struct fi_eq_cm_entry entry;
+	ssize_t rd;
+	int ret;
+
+	rd = fi_eq_sread(srv_eq, &event, &entry, sizeof(entry), -1, 0);
+	cr_assert(rd == sizeof(entry));
+
+	cr_assert(event == FI_CONNREQ);
+
+	ret = fi_domain(srv_fab, entry.info, &srv_dom, NULL);
+	cr_assert(!ret);
+
+	ret = fi_endpoint(srv_dom, entry.info, &srv_ep, NULL);
+	cr_assert(!ret, "fi_endpoint");
+
+	fi_freeinfo(entry.info);
+
+	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cq_attr.size = 1024;
+	cq_attr.wait_obj = 0;
+
+	ret = fi_cq_open(srv_dom, &cq_attr, &srv_cq, &srv_cq);
+	cr_assert(!ret);
+
+	ret = fi_ep_bind(srv_ep, &srv_eq->fid, 0);
+	cr_assert(!ret);
+
+	ret = fi_ep_bind(srv_ep, &srv_cq->fid, FI_SEND | FI_RECV);
+	cr_assert(!ret);
+
+	ret = fi_enable(srv_ep);
+	cr_assert(!ret);
+
+	ret = fi_accept(srv_ep, NULL, 0);
+	cr_assert(!ret);
+
+	dbg_printf("Server accept complete.\n");
+
+	return 0;
+}
+
+int cm_server_finish_connect(void)
+{
+	uint32_t event;
+	struct fi_eq_cm_entry entry;
+	ssize_t rd;
+
+	rd = fi_eq_read(srv_eq, &event, &entry, sizeof(entry), 0);
+	if (rd > 0) {
+		dbg_printf("got event: %d\n", event);
+		cr_assert(rd == sizeof(entry));
+		cr_assert(event == FI_CONNECTED && entry.fid == &srv_ep->fid);
+		return 1;
+	}
+
+	return 0;
+}
+
+int cm_client_start_connect(void)
+{
+	int ret;
+	struct sockaddr_in loc_sa;
+
+	cm_local_ip(&loc_sa);
+
+	cli_hints = fi_allocinfo();
+	cli_hints->fabric_attr->name = strdup("gni");
+	cli_hints->caps = GNIX_EP_PRIMARY_CAPS;
+	cli_hints->ep_attr->type = FI_EP_MSG;
+
+	ret = fi_getinfo(FI_VERSION(1, 0), inet_ntoa(loc_sa.sin_addr),
+			 DEF_PORT, 0, cli_hints, &cli_fi);
+	cr_assert(!ret);
+
+	ret = fi_fabric(cli_fi->fabric_attr, &cli_fab, NULL);
+	cr_assert(!ret);
+
+	ret = fi_eq_open(cli_fab, &eq_attr, &cli_eq, NULL);
+	cr_assert(!ret);
+
+	ret = fi_domain(cli_fab, cli_fi, &cli_dom, NULL);
+	cr_assert(!ret);
+
+	ret = fi_endpoint(cli_dom, cli_fi, &cli_ep, NULL);
+	cr_assert(!ret, "fi_endpoint");
+
+	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cq_attr.size = 1024;
+	cq_attr.wait_obj = 0;
+
+	ret = fi_cq_open(cli_dom, &cq_attr, &cli_cq, &cli_cq);
+	cr_assert(!ret);
+
+	ret = fi_ep_bind(cli_ep, &cli_eq->fid, 0);
+	cr_assert(!ret);
+
+	ret = fi_ep_bind(cli_ep, &cli_cq->fid, FI_SEND | FI_RECV);
+	cr_assert(!ret);
+
+	ret = fi_enable(cli_ep);
+	cr_assert(!ret);
+
+	ret = fi_connect(cli_ep, cli_fi->dest_addr, NULL, 0);
+	cr_assert(!ret);
+
+	dbg_printf("Client connect complete.\n");
+
+	return 0;
+}
+
+int cm_client_finish_connect(void)
+{
+	uint32_t event;
+	struct fi_eq_cm_entry entry;
+	ssize_t rd;
+
+	rd = fi_eq_read(cli_eq, &event, &entry, sizeof(entry), 0);
+	if (rd > 0) {
+		dbg_printf("got event: %d\n", event);
+		cr_assert(rd == sizeof(entry));
+		cr_assert(event == FI_CONNECTED && entry.fid == &cli_ep->fid);
+		return 1;
+	}
+
+	return 0;
+}
+
+void cm_stop_client(void)
+{
+	fi_close(&cli_cq->fid);
+	fi_close(&cli_ep->fid);
+	fi_close(&cli_dom->fid);
+	fi_close(&cli_eq->fid);
+	fi_close(&cli_fab->fid);
+	fi_freeinfo(cli_fi);
+}
+
+void cm_basic_send(void)
+{
+	int ret;
+	int source_done = 0, dest_done = 0;
+	struct fi_cq_tagged_entry cqe;
+	ssize_t sz;
+	uint64_t source = 0xa4321234a4321234,
+		 target = 0xb5678901b5678901;
+
+	sz = fi_send(cli_ep, &source, 8, 0, 0, &target);
+	cr_assert_eq(sz, 0);
+
+	sz = fi_recv(srv_ep, &target, 8, 0, 0, &source);
+	cr_assert_eq(sz, 0);
+
+	/* need to progress both CQs simultaneously for rendezvous */
+	do {
+		ret = fi_cq_read(cli_cq, &cqe, 1);
+		if (ret == 1) {
+			cr_assert_eq(cqe.op_context, &target);
+			source_done = 1;
+		}
+
+		ret = fi_cq_read(srv_cq, &cqe, 1);
+		if (ret == 1) {
+			cr_assert_eq(cqe.op_context, &source);
+			dest_done = 1;
+		}
+	} while (!source_done || !dest_done);
+
+	cr_assert_eq(source, target);
+	dbg_printf("Basic send/recv complete! (0x%lx, 0x%lx)\n",
+		   source, target);
+}
+
+Test(cm_basic, srv_setup)
+{
+	int cli_connected = 0, srv_connected = 0;
+	int i;
+
+	/* Start listening PEP. */
+	cm_server_start();
+	/* Create EP and fi_connect() to server. */
+	cm_client_start_connect();
+	/* Wait for EQE and fi_accept() new EP. */
+	cm_server_accept();
+
+	/* Wait for FI_CONNECTED EQES on client and server EQ. */
+	do {
+		if (!srv_connected) {
+			srv_connected += cm_server_finish_connect();
+			if (srv_connected)
+				dbg_printf("Server connect complete!\n");
+		}
+
+		if (!cli_connected) {
+			cli_connected += cm_client_finish_connect();
+			if (cli_connected)
+				dbg_printf("Client connect complete!\n");
+		}
+	} while (!srv_connected || !cli_connected);
+
+	for (i = 0; i < 1000; i++) {
+		/* Perform basic send/recv. */
+		cm_basic_send();
+	}
+
+	cm_stop_server();
+	cm_stop_client();
+}
+

--- a/prov/gni/test/cntr.c
+++ b/prov/gni/test/cntr.c
@@ -101,7 +101,7 @@ static inline void cntr_setup_eps(void)
 
 	/* This test hangs with the FI_RMA_EVENT capability enabled because the
 	 * receiver does not progress libfabric. */
-	hints->caps = GNIX_EP_RDM_PRIMARY_CAPS;
+	hints->caps = GNIX_EP_PRIMARY_CAPS;
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -98,6 +98,7 @@ Test(endpoint_info, info)
 	cr_assert(!ret, "fi_getinfo");
 	cr_assert_eq(fi->ep_attr->type, FI_EP_RDM);
 	cr_assert_eq(fi->next->ep_attr->type, FI_EP_DGRAM);
+	cr_assert_eq(fi->next->next->ep_attr->type, FI_EP_MSG);
 
 	fi_freeinfo(fi);
 


### PR DESCRIPTION
This commit includes the initial FI_EP_MSG implementation.

Remaining work includes:
-overall resiliency
-CM data support
-reject, shutdown APIs
-more FI_EP_MSG criterion tests.
  -testing resiliency
  -testing cleanup

@sungeunchoi 
upstream merge of ofi-cray/libfabric-cray#1051
Signed-off-by: Zach <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@585579b)