### PR TITLE
added base EQ support for verbs

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -250,6 +250,8 @@ fi_ibv_rdm_send_common(struct fi_ibv_rdm_send_start_data* sdata)
 	request->state.rndv  = FI_IBV_STATE_RNDV_NOT_USED;
 	request->state.err   = FI_SUCCESS;
 
+	/* postponed_entry means that there are elements postponed to
+	 * send & current request must be queued */
 	const int in_order = (sdata->conn->postponed_entry) ? 0 : 1;
 	int ret = fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_SEND_START, sdata);
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -153,8 +153,10 @@ struct fi_ibv_av {
 	struct fid_av		av_fid;
 	struct fi_ibv_domain	*domain;
 	struct fi_ibv_rdm_ep	*ep;
+	struct fi_ibv_eq	*eq;
 	size_t			count;
 	size_t			used;
+	uint64_t		flags;
 	enum fi_av_type		type;
 	fi_ibv_rdm_addr_to_conn_func addr_to_conn;
 	fi_ibv_rdm_conn_to_addr_func conn_to_addr;
@@ -189,6 +191,8 @@ struct fi_ibv_domain {
 	struct fi_ibv_rdm_cm	*rdm_cm;
 	struct fi_info		*info;
 	struct fi_ibv_fabric	*fab;
+	struct fi_ibv_eq	*eq;
+	uint64_t		eq_flags;
 };
 
 struct fi_ibv_cq;
@@ -343,6 +347,9 @@ ssize_t fi_ibv_send_iov_flags(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 			      void *context, uint64_t flags);
 ssize_t fi_ibv_poll_cq(struct fi_ibv_cq *cq, struct ibv_wc *wc);
 int fi_ibv_cq_signal(struct fid_cq *cq);
+
+ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
+		const void *buf, size_t len);
 
 #define fi_ibv_set_sge(sge, buf, len, desc)				\
 	do {								\

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -163,7 +163,7 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 	return sizeof(*entry) + datalen;
 }
 
-static ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
+ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
 		const void *buf, size_t len)
 {
 	struct fi_ibv_eq_entry *entry;


### PR DESCRIPTION
added minimal EQ support to verbs RDM provider:
- added support EQ_EVENT to AV bind
- added support of FI_REG_MR to fi_ep_bind

actually all AV & MR API's are blocking, and support of
such flags is just push 'success' record into EQ

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>