### PR TITLE
prov/gni: Disable FMA sharing for gni unit tests

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -66,7 +66,7 @@ const char gnix_dom_name[] = "/sys/class/gni/kgni0";
 const char gnix_prov_name[] = "gni";
 
 uint32_t gnix_cdm_modes =
-	(GNI_CDM_MODE_FAST_DATAGRAM_POLL | /* GNI_CDM_MODE_FMA_SHARED | */
+	(GNI_CDM_MODE_FAST_DATAGRAM_POLL | GNI_CDM_MODE_FMA_SHARED |
 	GNI_CDM_MODE_FMA_SMALL_WINDOW | GNI_CDM_MODE_FORK_PARTCOPY |
 	GNI_CDM_MODE_ERR_NO_KILL);
 

--- a/prov/gni/test/run_gnitest
+++ b/prov/gni/test/run_gnitest
@@ -34,8 +34,13 @@
 #
 # disable use of xpmem bypass for criterion tests
 #
-
 export GNIX_DISABLE_XPMEM=1
+
+#
+# disable fma sharing for criterion tests
+#
+export UGNI_FMA_SHARED=0
+
 #
 # Check for srun or aprun
 #


### PR DESCRIPTION
upstream merge of ofi-cray/libfabric-cray#1067

@sungeunchoi 
Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@24625ce91f46a2cec771ed97c754f8b3558b084a)