### PR TITLE
prov/gni: Use prov_name fabric attribute in gnitests

### DIFF
--- a/prov/gni/test/allocator.c
+++ b/prov/gni/test/allocator.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -58,7 +58,7 @@ void allocator_setup(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert_eq(ret, FI_SUCCESS, "fi_getinfo");

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -214,7 +214,7 @@ void rdm_api_setup(void)
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
 		hints[i]->mode = ~0;
 		hints[i]->domain_attr->mr_mode = FI_MR_BASIC;
-		hints[i]->fabric_attr->name = strdup("gni");
+		hints[i]->fabric_attr->prov_name = strdup("gni");
 	}
 }
 

--- a/prov/gni/test/api_cntr.c
+++ b/prov/gni/test/api_cntr.c
@@ -139,7 +139,7 @@ void api_cntr_setup(void)
 
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
 		hints[i]->mode = ~0;
-		hints[i]->fabric_attr->name = strdup("gni");
+		hints[i]->fabric_attr->prov_name = strdup("gni");
 	}
 
 	/* Get info about fabric services with the provided hints */

--- a/prov/gni/test/api_cq.c
+++ b/prov/gni/test/api_cq.c
@@ -110,7 +110,7 @@ void api_cq_setup(void)
 		hints[i]->domain_attr->cq_data_size = NUMEPS * 2;
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
 		hints[i]->mode = ~0;
-		hints[i]->fabric_attr->name = strdup("gni");
+		hints[i]->fabric_attr->prov_name = strdup("gni");
 	}
 
 	/* Get info about fabric services with the provided hints */

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -138,7 +138,7 @@ static void av_setup(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert_eq(ret, FI_SUCCESS, "fi_getinfo");

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -83,7 +83,7 @@ void cancel_setup(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/cntr.c
+++ b/prov/gni/test/cntr.c
@@ -97,7 +97,7 @@ static inline void cntr_setup_eps(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	/* This test hangs with the FI_RMA_EVENT capability enabled because the
 	 * receiver does not progress libfabric. */

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -72,7 +72,7 @@ void setup(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/datagram.c
+++ b/prov/gni/test/datagram.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -72,7 +72,7 @@ void dg_setup(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = gethostname(my_hostname, sizeof(my_hostname));
 	cr_assert(!ret, "gethostname");
@@ -102,7 +102,7 @@ void dg_setup_prog_manual(void)
 	hints->domain_attr->control_progress = FI_PROGRESS_MANUAL;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -55,7 +55,7 @@ static void setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(ret == FI_SUCCESS, "fi_getinfo");

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -57,7 +57,7 @@ static void setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");
@@ -92,7 +92,7 @@ Test(endpoint_info, info)
 
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/eq.c
+++ b/prov/gni/test/eq.c
@@ -59,7 +59,7 @@ void _setup(void)
 	cr_assert(hints, "fi_allocinfo failed.");
 
 	hints->mode = ~0;
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert_eq(ret, FI_SUCCESS, "fi_getinfo failed.");

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -143,7 +143,7 @@ static void _mr_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/mr_notifier.c
+++ b/prov/gni/test/mr_notifier.c
@@ -239,7 +239,7 @@ static void mr_stressor_setup_common(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/nic.c
+++ b/prov/gni/test/nic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -57,7 +57,7 @@ static void setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -114,7 +114,7 @@ void common_atomic_setup(void)
 	hints->mode = ~0;
 	hints->fabric_attr->prov_name = strdup("gni");
 	hints->caps |= FI_ATOMIC | FI_READ | FI_REMOTE_READ |
-		       FI_WRITE | FI_REMOTE_WRITE;
+			FI_WRITE | FI_REMOTE_WRITE;
 
 	target = malloc(BUF_SZ);
 	assert(target);

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -110,7 +110,7 @@ void common_setup(void)
 	hints->caps |= FI_RMA | FI_READ | FI_REMOTE_READ |
 		       FI_WRITE | FI_REMOTE_WRITE;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/rdm_fi_pcd_trecv_msg.c
+++ b/prov/gni/test/rdm_fi_pcd_trecv_msg.c
@@ -340,7 +340,7 @@ static void rdm_fi_pdc_setup(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/rdm_rx_overrun.c
+++ b/prov/gni/test/rdm_rx_overrun.c
@@ -99,7 +99,7 @@ static void setup(void)
 
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -254,7 +254,7 @@ void rdm_sr_setup(bool is_noreg, enum fi_progress pm)
 	hints->domain_attr->data_progress = pm;
 	hints->mode = ~0;
 	hints->caps = is_noreg ? hints->caps : FI_SOURCE | FI_MSG;
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	/* Get info about fabric services with the provided hints */
 	for (; i < NUMEPS; i++) {
@@ -282,7 +282,7 @@ void dgram_sr_setup(bool is_noreg, enum fi_progress pm)
 	hints->domain_attr->data_progress = pm;
 	hints->mode = ~0;
 	hints->caps = is_noreg ? hints->caps : FI_SOURCE | FI_MSG;
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 	hints->ep_attr->type = FI_EP_DGRAM;
 
 	/* Get info about fabric services with the provided hints */

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -96,7 +96,7 @@ static void setup_dom(enum fi_progress pm)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/tags.c
+++ b/prov/gni/test/tags.c
@@ -348,7 +348,7 @@ static void __gnix_tags_bare_test_setup(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert_eq(ret, FI_SUCCESS, "fi_getinfo");

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -114,7 +114,7 @@ static void vc_setup_common(void)
 	size_t addrlen = 0;
 	struct gnix_fid_av *gnix_av;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");

--- a/prov/gni/test/vc_lookup.c
+++ b/prov/gni/test/vc_lookup.c
@@ -64,7 +64,7 @@ void vc_lookup_setup(int av_type, int av_size)
 	hints = fi_allocinfo();
 
 	hints->mode = ~0;
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	/* Create endpoint */
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);

--- a/prov/gni/test/wait.c
+++ b/prov/gni/test/wait.c
@@ -55,7 +55,7 @@ void wait_setup(void)
 
 	hints->mode = ~0;
 
-	hints->fabric_attr->name = strdup("gni");
+	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
 	cr_assert(!ret, "fi_getinfo");


### PR DESCRIPTION
upstream merge of ofi-cray/libfabric-cray#993

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@0ffb9defa8fcdd2cf4bfbca30bc1fcd95a11d25e)

Conflicts:
	prov/gni/test/rdm_atomic.c
	prov/gni/test/rdm_sr.c