### PR TITLE
prov/gni: avoid initialization via constructor

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -1132,6 +1132,11 @@ int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags);
 
 int gnix_ep_close(fid_t fid);
 
+/*
+ * prototype for static data initialization method
+ */
+void _gnix_init(void);
+
 /* Prepend DIRECT_FN to provider specific API functions for global visibility
  * when using fabric direct.  If the API function is static use the STATIC
  * macro to bind symbols globally when compiling with fabric direct.

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -581,6 +581,11 @@ GNI_INI
 		return NULL;
 	}
 
+	/*
+	 * ensure all globals are properly initialized
+	 */
+	_gnix_init();
+
 	/* sanity check that the 1 aries/node holds */
 	assert(num_devices == 1);
 

--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -55,8 +55,51 @@ __thread uint32_t gnix_debug_tid = ~(uint32_t) 0;
 atomic_t gnix_debug_next_tid;
 #endif
 
-uint8_t precomputed_crc_results[256];
+/**
+ * Helper for static computation of GNI CRC updating an intermediate crc
+ * value based on the status of one bit in the data value.
+ *
+ * @param[in]  data  value to compute crc for
+ * @param[in]  lcrc  intermediate crc to update
+ * @param[in]  bit   which bit (in range [0-7]) of 'data' to test
+ * @param[in]  xor   value to 'xor' into 'lcrc' iff bit 'bit' of 'data' is set
+ *
+ * @return updated intermediate crc
+ */
+#define CRC_HELPER(data, lcrc, bit, xor) (((((data)>>(bit))&1)*(xor))^(lcrc))
 
+/* Parameterized helpers for each bit in GNI CRC */
+#define CRC_80(data, lcrc)              CRC_HELPER(data, lcrc, 7, 0x8c)
+#define CRC_40(data, lcrc) CRC_80(data, CRC_HELPER(data, lcrc, 6, 0x46))
+#define CRC_20(data, lcrc) CRC_40(data, CRC_HELPER(data, lcrc, 5, 0x23))
+#define CRC_10(data, lcrc) CRC_20(data, CRC_HELPER(data, lcrc, 4, 0x9d))
+#define CRC_08(data, lcrc) CRC_10(data, CRC_HELPER(data, lcrc, 3, 0xc2))
+#define CRC_04(data, lcrc) CRC_08(data, CRC_HELPER(data, lcrc, 2, 0x61))
+#define CRC_02(data, lcrc) CRC_04(data, CRC_HELPER(data, lcrc, 1, 0xbc))
+#define CRC_01(data, lcrc) CRC_02(data, CRC_HELPER(data, lcrc, 0, 0x5e))
+
+/* Static computation of 8-bit GNI CRC of one 8-bit value */
+#define CRC(data) ((uint8_t)CRC_01(data, 0))
+
+/* Helpers for declaring large array of precomputed CRCs */
+/* 4 elements starting at x */
+#define CRCS_4(x)   CRC((x)), CRC((x)+1), CRC((x)+2), CRC((x)+3)
+
+/* 16 elements starting at x: ie, CRC(x),...,CRC(x+15) */
+#define CRCS_16(x)  CRCS_4((x)), CRCS_4((x)+4), \
+		    CRCS_4((x)+8), CRCS_4((x)+12)
+
+/* 64 elements starting at x: ie, CRC(x),...,CRC(x+63) */
+#define CRCS_64(x)  CRCS_16((x)), CRCS_16((x)+16), \
+		    CRCS_16((x)+32), CRCS_16((x)+48)
+
+/* 256 elements starting at x: ie, CRC(x),...,CRC(x+255) */
+#define CRCS_256(x) CRCS_64((x)), CRCS_64((x)+64), \
+		    CRCS_64((x)+128), CRCS_64((x)+192)
+
+uint8_t precomputed_crc_results[256] = { CRCS_256(0) };
+
+#ifndef NDEBUG
 static inline uint8_t __gni_crc_bits(uint8_t data)
 {
   uint8_t lcrc = 0;
@@ -81,26 +124,39 @@ static inline uint8_t __gni_crc_bits(uint8_t data)
   return lcrc;
 }
 
-void __setup_precomputed_crcs(void)
+static void __validate_precomputed_crcs(void)
 {
 	int i;
+	uint8_t crc_i;
 
-	for (i = 0; i < 256; i++)
-	{
-		precomputed_crc_results[i] = __gni_crc_bits(i);
+	for (i = 0; i < 256; i++) {
+		crc_i = __gni_crc_bits(i);
+		if (precomputed_crc_results[i] != crc_i) {
+			GNIX_WARN(FI_LOG_FABRIC, "precomputed_crc_results[%d]"
+				" initialized to 0x%x, expected 0x%x\n",
+				i, (int)precomputed_crc_results[i], (int)crc_i);
+			precomputed_crc_results[i] = crc_i;
+		}
 	}
 }
+#endif /* NDEBUG */
 
 /**
  * Initialization function for performing global setup
  */
 __attribute__((constructor))
-void gnix_init(void)
+void _gnix_init(void)
 {
-	__setup_precomputed_crcs();
-	atomic_initialize(&gnix_id_counter, 0);
-	atomic_initialize(&file_id_counter, 0);
+	static int called=0;
+
+	if (called==0) {
+
+		atomic_initialize(&gnix_id_counter, 0);
+		atomic_initialize(&file_id_counter, 0);
 #ifndef NDEBUG
-	atomic_initialize(&gnix_debug_next_tid, 0);
+		__validate_precomputed_crcs();
+		atomic_initialize(&gnix_debug_next_tid, 0);
 #endif
+		called = 1;
+	}
 }


### PR DESCRIPTION
Try to avoid run-time initialization of data structures in src/gnix_init.c
to avoid issues with the (undefined) order in which library constructors
get called during process startup.  Initialize global atomics in gnix_init()
when GNI_INI is invoked to determine if it is an available provider in
addition to in the gnix_init() constructor in case it gets called before the
constructor runs.

@sungeunchoi 
upstream merge of ofi-cray/libfabric-cray#964

Signed-off-by: Steven Vormwald <sdvormwa@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@50ff82e87a66d760aea0374e5dff0a3940e6715f)