### PR TITLE
util: ep and av updates

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -176,6 +176,7 @@ struct util_ep {
 	ofi_ep_progress_func	progress;
 };
 
+int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av);
 int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_prov,
 		struct fi_info *info, struct util_ep *ep, void *context,
 		ofi_ep_progress_func progress, enum fi_match_type type);

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -169,11 +169,13 @@ struct util_ep {
 	struct fid_ep		ep_fid;
 	struct util_domain	*domain;
 	struct util_av		*av;
+	struct dlist_entry	av_entry;
 	struct util_cq		*rx_cq;
 	struct util_cq		*tx_cq;
 	uint64_t		caps;
 	uint64_t		flags;
 	ofi_ep_progress_func	progress;
+	struct util_cmap	*cmap;
 };
 
 int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av);
@@ -281,6 +283,7 @@ struct util_av {
 	ssize_t			free_list;
 	struct util_av_hash	hash;
 	void			*data;
+	struct dlist_entry	ep_list;
 };
 
 struct util_av_attr {

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -229,7 +229,6 @@ struct rxm_ep {
 	struct fid_pep *msg_pep;
 	struct fid_cq *msg_cq;
 	struct fid_ep *srx_ctx;
-	struct util_cmap *cmap;
 
 	struct util_buf_pool *tx_pool;
 	struct slist tx_buf_list;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -123,7 +123,7 @@ int rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 		goto err1;
 	}
 
-	ret = ofi_cmap_add_handle(rxm_ep->cmap, &rxm_conn->handle, CMAP_CONNECTING,
+	ret = ofi_cmap_add_handle(rxm_ep->util_ep.cmap, &rxm_conn->handle, CMAP_CONNECTING,
 			FI_ADDR_UNSPEC, &remote_cm_data->name,
 			sizeof(remote_cm_data->name));
 	if (ret) {
@@ -288,7 +288,7 @@ int rxm_msg_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
 		goto err1;
 	}
 
-	ret = ofi_cmap_add_handle(rxm_ep->cmap, &rxm_conn->handle,
+	ret = ofi_cmap_add_handle(rxm_ep->util_ep.cmap, &rxm_conn->handle,
 			CMAP_CONNECTING, fi_addr, NULL, 0);
 	if (ret)
 		goto err2;
@@ -328,7 +328,7 @@ int rxm_get_conn(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
 		return -FI_EINVAL;
 	}
 
-	handle = ofi_cmap_get_handle(rxm_ep->cmap, fi_addr);
+	handle = ofi_cmap_get_handle(rxm_ep->util_ep.cmap, fi_addr);
 	if (!handle)
 		goto connect;
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -61,7 +61,7 @@ static int rxm_match_recv_entry_tagged(struct dlist_entry *item, const void *arg
 static struct rxm_conn *rxm_key2conn(struct rxm_ep *rxm_ep, uint64_t key)
 {
 	struct util_cmap_handle *handle;
-	handle = ofi_cmap_key2handle(rxm_ep->cmap, key);
+	handle = ofi_cmap_key2handle(rxm_ep->util_ep.cmap, key);
 	if (!handle) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Can't find handle!\n");
 		return NULL;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -741,8 +741,8 @@ static int rxm_ep_close(struct fid *fid)
 
 	rxm_ep = container_of(fid, struct rxm_ep, util_ep.ep_fid.fid);
 
-	if (rxm_ep->cmap)
-		ofi_cmap_free(rxm_ep->cmap);
+	if (rxm_ep->util_ep.cmap)
+		ofi_cmap_free(rxm_ep->util_ep.cmap);
 
 	rxm_ep_txrx_res_close(rxm_ep);
 	ret = rxm_ep_msg_res_close(rxm_ep);
@@ -821,8 +821,8 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		ret = ofi_ep_bind_av(&rxm_ep->util_ep, util_av);
 		if (ret)
 			return ret;
-		rxm_ep->cmap = ofi_cmap_alloc(util_av, rxm_conn_close);
-		if (!rxm_ep->cmap)
+		rxm_ep->util_ep.cmap = ofi_cmap_alloc(util_av, rxm_conn_close);
+		if (!rxm_ep->util_ep.cmap)
 			return -FI_ENOMEM;
 		break;
 	case FI_CLASS_CQ:

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -46,6 +46,10 @@ int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av)
 	util_ep->av = av;
 	atomic_inc(&av->ref);
 
+	fastlock_acquire(&av->lock);
+	dlist_insert_tail(&util_ep->av_entry, &av->ep_list);
+	fastlock_release(&av->lock);
+
 	return 0;
 }
 
@@ -75,8 +79,13 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 
 int ofi_endpoint_close(struct util_ep *util_ep)
 {
-	if (util_ep->av)
+	if (util_ep->av) {
+		fastlock_acquire(&util_ep->av->lock);
+		dlist_remove(&util_ep->av_entry);
+		fastlock_release(&util_ep->av->lock);
+
 		atomic_dec(&util_ep->av->ref);
+	}
 
 	atomic_dec(&util_ep->domain->ref);
 	return 0;


### PR DESCRIPTION
- Add an util_ep_av_bind function
- Maintain a list of endpoints in util_av. Use this to do any cmap processing on fi_av_remove
- Update rxm and udp providers to work with these changes