### PR TITLE
prov/gni:  fi_more support for writes in gnix_rma

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -557,6 +557,10 @@ struct gnix_fid_ep {
 		struct gnix_vector *vc_table;	/* FI_AV_TABLE */
 	};
 	struct dlist_entry unmapped_vcs;
+
+	/* FI_MORE specific. */
+	struct slist more_read;
+	struct slist more_write;
 };
 
 #define GNIX_EP_RDM(type)         (type == FI_EP_RDM)
@@ -715,6 +719,7 @@ struct gnix_fab_req_rma {
 	uint64_t                 imm;
 	atomic_t                 outstanding_txds;
 	gni_return_t             status;
+	struct slist_entry       sle;
 };
 
 struct gnix_fab_req_msg {

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -313,6 +313,8 @@ struct gnix_smsg_amo_cntr_hdr {
  * @var gni_desc         embedded GNI post descriptor
  * @var gnix_ct_descs    embedded GNI post descriptors for concatenated gets
  *                       used for unaligned gets
+ * @var gni_more_ct_descs embedded GNI post descriptors for concatenated puts
+			  or gets for FI_MORE.
  * @var gnix_smsg_eager_hdr embedded header for SMSG eager protocol
  * @var gnix_smsg_rndzv_start_hdr embedded header for rendezvous protocol
  * @var gnix_smsg_rndzv_iov_start_hdr embedded header for iovec rndzv protocol
@@ -335,6 +337,7 @@ struct gnix_tx_descriptor {
 		struct {
 			gni_post_descriptor_t        gni_desc;
 			gni_ct_get_post_descriptor_t gni_ct_descs[2];
+			void			     *gni_more_ct_descs;
 		};
 		struct gnix_smsg_eager_hdr           eager_hdr;
 		struct gnix_smsg_rndzv_start_hdr     rndzv_start_hdr;


### PR DESCRIPTION
fab_reqs with the fi_more hint will not be immediately
queued but will instead be added to a corresponding list
for writes and reads on the EP. When a message is for the
target EP is received without fi_more, the first fab_req is
queued and the txd is populated with multiple subdescriptors.
This creates one gni transaction and thereby avoids
unnecessary overhead. A completion event will be generated
for each fab_req.

Created simple test in rdm_dgram_rma using write_msg. One
message is sent with FI_MORE and one is sent without it.
Check the CQ for 2 completion events.

upstream merge of ofi-cray/libfabric-cray#1050

Signed-off-by: Amith Abraham <aabraham@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@e59ce379defdaf9d264e9ebc7bef6866d1ec7c1f)

Conflicts:
	prov/gni/test/rdm_dgram_rma.c