### PR TITLE
man: clarify counter and CQ use with FI_RMA_EVENT

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -349,14 +349,14 @@ binding an endpoint to a counter, the following flags may be specified.
   initiated from the endpoint has completed successfully or in error.
 
 *FI_REMOTE_READ*
-: Increments the specified counter whenever an RMA read or
-  atomic fetch operation is initiated from a remote endpoint that
+: Increments the specified counter or generates a completion event whenever
+  an RMA read or atomic fetch operation is initiated from a remote endpoint that
   targets the given endpoint.  Use of this flag requires that the
   endpoint be created using FI_RMA_EVENT.
 
 *FI_REMOTE_WRITE*
-: Increments the specified counter whenever an RMA write or
-  atomic operation is initiated from a remote endpoint that targets
+: Increments the specified counter or generates a completion event whenever
+  an RMA write or atomic operation is initiated from a remote endpoint that targets
   the given endpoint.  Use of this flag requires that the
   endpoint be created using FI_RMA_EVENT.
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -329,8 +329,8 @@ additional optimizations.
 
 *FI_RMA_EVENT*
 : Requests that an endpoint support the generation of completion events
-  when it is the target of an RMA and/or atomic operation.  This
-  flag requires that FI_REMOTE_READ and/or FI_REMOTE_WRITE be enabled on
+  or counter updates when it is the target of an RMA and/or atomic operation.
+  This flag requires that FI_REMOTE_READ and/or FI_REMOTE_WRITE be enabled on
   the endpoint.
 
 *FI_TRIGGER*


### PR DESCRIPTION
The getinfo man page says that completion events are generated
with FI_RMA_EVENT, but the endpoint man page only mentions
counters. Modify them to say that both completion queue events
are generated and counters updated on this capability bit.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>