### PR TITLE
Fix more typos in the man pages

### DIFF
--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -420,7 +420,7 @@ resources from removed entries.
 Insertion calls for an AV opened for synchronous operation will return
 the number of addresses that were successfully inserted.  In the case of
 failure, the return value will be less than the number of addresses that
-were specified.
+was specified.
 
 Insertion calls for an AV opened for asynchronous operation (with FI_EVENT
 flag specified) will return 0 if the operation was successfully initiated.

--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -110,7 +110,7 @@ struct fi_cntr_attr {
 : The counter increments for every successful completion that occurs
   on an associated bound endpoint.  The type of completions -- sends
   and/or receives -- which are counted may be restricted using control
-  flags when binding the counter an the endpoint.  Counters increment
+  flags when binding the counter and the endpoint.  Counters increment
   on all successful completions, separately from whether the operation
   generates an entry in an event queue.
 

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -218,9 +218,9 @@ struct fi_cq_tagged_entry {
 : CQ's may be associated with a specific wait object.  Wait objects
   allow applications to block until the wait object is signaled,
   indicating that a completion is available to be read.  Users may use
-  fi_control to retrieve the underlying wait object associated with an
+  fi_control to retrieve the underlying wait object associated with a
   CQ, in order to use it in other system calls.  The following values
-  may be used to specify the type of wait object associated with an
+  may be used to specify the type of wait object associated with a
   CQ: FI_WAIT_NONE, FI_WAIT_UNSPEC, FI_WAIT_SET, FI_WAIT_FD, and
   FI_WAIT_MUTEX_COND.
 
@@ -263,7 +263,7 @@ struct fi_cq_tagged_entry {
   ignored if the provider does not support interrupt affinity.
 
 *wait_cond*
-: By default, when a completion is inserted into an CQ that supports
+: By default, when a completion is inserted into a CQ that supports
   blocking reads (fi_cq_sread/fi_cq_sreadfrom), the corresponding wait
   object is signaled.  Users may specify a condition that must first
   be met before the wait is satisfied.  This field indicates how the
@@ -310,7 +310,7 @@ The fi_control call is used to access provider or implementation
 specific details of the completion queue.  Access to the CQ should be
 serialized across all calls when fi_control is invoked, as it may
 redirect the implementation of CQ operations.  The following control
-commands are usable with an CQ.
+commands are usable with a CQ.
 
 *FI_GETWAIT (void \*\*)*
 : This command allows the user to retrieve the low-level wait object
@@ -341,9 +341,9 @@ the the same as the count parameter.
 CQs are optimized to report operations which have completed
 successfully.  Operations which fail are reported 'out of band'.  Such
 operations are retrieved using the fi_cq_readerr function.  When an
-operation that completes with an unexpected error is inserted into an
+operation that completes with an unexpected error is inserted into a
 CQ, it is placed into a temporary error queue.  Attempting to read
-from an CQ while an item is in the error queue results in an FI_EAVAIL
+from a CQ while an item is in the error queue results in an FI_EAVAIL
 failure.  Applications may use this return code to determine when to
 call fi_cq_readerr.
 

--- a/man/fi_poll.3.md
+++ b/man/fi_poll.3.md
@@ -131,7 +131,7 @@ Associates a completion queue or counter with a poll set.
 
 ## fi_poll_del
 
-Removes an completion queue or counter from a poll set.
+Removes a completion queue or counter from a poll set.
 
 ## fi_poll
 

--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -11,7 +11,7 @@ The RxM (RDM over MSG) Utility Provider
 
 # OVERVIEW
 
-The RxM provider is an utility provider that supports RDM endpoints
+The RxM provider is a utility provider that supports RDM endpoints
 emulated over a base MSG provider.
 
 # REQUIREMENTS


### PR DESCRIPTION
Typos fixed:
* "a" vs "an"
* "an" -> "and"
* One instance of "were" with a singular, third-person noun

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>