### PR TITLE
prov/gni: Do not create CM NIC on MSG EP

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -476,6 +476,7 @@ struct gnix_addr_cache_entry {
 
 enum gnix_conn_state {
 	GNIX_EP_UNCONNECTED,
+	GNIX_EP_CONNECTING,
 	GNIX_EP_CONNECTED,
 	GNIX_EP_SHUTDOWN
 };

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1419,7 +1419,6 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 	int ret = FI_SUCCESS;
 	int remote_id;
 	struct gnix_vc *vc_ptr = NULL;
-	struct gnix_cm_nic *cm_nic = NULL;
 	struct gnix_nic *nic = NULL;
 	struct dlist_entry *de;
 
@@ -1427,10 +1426,6 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 
 	nic = ep_priv->nic;
 	if (nic == NULL)
-		return -FI_EINVAL;
-
-	cm_nic = ep_priv->cm_nic;
-	if (cm_nic == NULL)
 		return -FI_EINVAL;
 
 	/*


### PR DESCRIPTION
Do not create CM NIC on MSG EPs.  MSG EPs do not use datagram connection setup.
This fix allows the following test to complete:
	"./fi_shared_ctx -p gni -e msg --no-rx-shared-ctx"

Do not progress MSG EPs unless in process of connecting.   "Bad file
descriptor" errors could be seen from _gnix_ep_progress() without this fix.

Fixes ofi-cray/libfabric-cray#1071.
upstream merge of ofi-cray/libfabric-cray#1073

@sungeunchoi 
Signed-off-by: Zach <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@5896b97a11c30e731449febb9af865354a76ad01)