### PR TITLE
Prefix idx_* and idm_* symbols with "ofi_"

### DIFF
--- a/include/fi_indexer.h
+++ b/include/fi_indexer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2011 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc .  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -44,35 +45,35 @@
  * indexer by setting free_list and size to 0.
  */
 
-union idx_entry {
+union ofi_idx_entry {
 	void *item;
 	int   next;
 };
 
-#define IDX_INDEX_BITS 16
-#define IDX_ENTRY_BITS 10
-#define IDX_ENTRY_SIZE (1 << IDX_ENTRY_BITS)
-#define IDX_ARRAY_SIZE (1 << (IDX_INDEX_BITS - IDX_ENTRY_BITS))
-#define IDX_MAX_INDEX  ((1 << IDX_INDEX_BITS) - 1)
+#define OFI_IDX_INDEX_BITS 16
+#define OFI_IDX_ENTRY_BITS 10
+#define OFI_IDX_ENTRY_SIZE (1 << OFI_IDX_ENTRY_BITS)
+#define OFI_IDX_ARRAY_SIZE (1 << (OFI_IDX_INDEX_BITS - OFI_IDX_ENTRY_BITS))
+#define OFI_IDX_MAX_INDEX  ((1 << OFI_IDX_INDEX_BITS) - 1)
 
 struct indexer
 {
-	union idx_entry *array[IDX_ARRAY_SIZE];
+	union ofi_idx_entry *array[OFI_IDX_ARRAY_SIZE];
 	int		 free_list;
 	int		 size;
 };
 
-#define idx_array_index(index) (index >> IDX_ENTRY_BITS)
-#define idx_entry_index(index) (index & (IDX_ENTRY_SIZE - 1))
+#define ofi_idx_array_index(index) (index >> OFI_IDX_ENTRY_BITS)
+#define ofi_idx_entry_index(index) (index & (OFI_IDX_ENTRY_SIZE - 1))
 
-int idx_insert(struct indexer *idx, void *item);
-void *idx_remove(struct indexer *idx, int index);
-void idx_replace(struct indexer *idx, int index, void *item);
-void idx_reset(struct indexer *idx);
+int ofi_idx_insert(struct indexer *idx, void *item);
+void *ofi_idx_remove(struct indexer *idx, int index);
+void ofi_idx_replace(struct indexer *idx, int index, void *item);
+void ofi_idx_reset(struct indexer *idx);
 
-static inline void *idx_at(struct indexer *idx, int index)
+static inline void *ofi_idx_at(struct indexer *idx, int index)
 {
-	return (idx->array[idx_array_index(index)] + idx_entry_index(index))->item;
+	return (idx->array[ofi_idx_array_index(index)] + ofi_idx_entry_index(index))->item;
 }
 
 /*
@@ -83,25 +84,25 @@ static inline void *idx_at(struct indexer *idx, int index)
 
 struct index_map
 {
-	void **array[IDX_ARRAY_SIZE];
-	int count[IDX_ARRAY_SIZE];
+	void **array[OFI_IDX_ARRAY_SIZE];
+	int count[OFI_IDX_ARRAY_SIZE];
 };
 
-int idm_set(struct index_map *idm, int index, void *item);
-void *idm_clear(struct index_map *idm, int index);
-void idm_reset(struct index_map *idm);
+int ofi_idm_set(struct index_map *idm, int index, void *item);
+void *ofi_idm_clear(struct index_map *idm, int index);
+void ofi_idm_reset(struct index_map *idm);
 
-static inline void *idm_at(struct index_map *idm, int index)
+static inline void *ofi_idm_at(struct index_map *idm, int index)
 {
 	void **entry;
-	entry = idm->array[idx_array_index(index)];
-	return entry[idx_entry_index(index)];
+	entry = idm->array[ofi_idx_array_index(index)];
+	return entry[ofi_idx_entry_index(index)];
 }
 
-static inline void *idm_lookup(struct index_map *idm, int index)
+static inline void *ofi_idm_lookup(struct index_map *idm, int index)
 {
-	return ((index <= IDX_MAX_INDEX) && idm->array[idx_array_index(index)]) ?
-		idm_at(idm, index) : NULL;
+	return ((index <= OFI_IDX_MAX_INDEX) && idm->array[ofi_idx_array_index(index)]) ?
+		ofi_idm_at(idm, index) : NULL;
 }
 
 #endif /* INDEXER_H */

--- a/include/fi_rbuf.h
+++ b/include/fi_rbuf.h
@@ -327,7 +327,7 @@ static inline size_t rbfdsread(struct ringbuffd *rbfd, void *buf, size_t len,
 		rbfdread(rbfd, buf, len);
 		return len;
 	}
-	
+
 	ret = fi_poll_fd(rbfd->fd[RB_READ_FD], timeout);
 	if (ret == 1) {
 		len = MIN(len, rbfdused(rbfd));

--- a/include/fi_rbuf.h
+++ b/include/fi_rbuf.h
@@ -51,7 +51,7 @@
 /*
  * Circular queue/array template
  */
-#define DECLARE_CIRQUE(entrytype, name)				\
+#define OFI_DECLARE_CIRQUE(entrytype, name)                     \
 struct name {							\
 	size_t		size;					\
 	size_t		size_mask;				\
@@ -84,25 +84,25 @@ static inline void name ## _free(struct name *cq)		\
 	free(cq);						\
 }
 
-#define cirque_isempty(cq)	((cq)->wcnt == (cq)->rcnt)
-#define cirque_usedcnt(cq)	((cq)->wcnt - (cq)->rcnt)
-#define cirque_freecnt(cq)	((cq)->size - cirque_usedcnt(cq))
-#define cirque_isfull(cq)	(cirque_freecnt(cq) <= 0)
+#define ofi_cirque_isempty(cq)		((cq)->wcnt == (cq)->rcnt)
+#define ofi_cirque_usedcnt(cq)		((cq)->wcnt - (cq)->rcnt)
+#define ofi_cirque_freecnt(cq)		((cq)->size - ofi_cirque_usedcnt(cq))
+#define ofi_cirque_isfull(cq)		(ofi_cirque_freecnt(cq) <= 0)
 
-#define cirque_rindex(cq)	((cq)->rcnt & (cq)->size_mask)
-#define cirque_windex(cq)	((cq)->wcnt & (cq)->size_mask)
-#define cirque_head(cq)		(&(cq)->buf[cirque_rindex(cq)])
-#define cirque_tail(cq)		(&(cq)->buf[cirque_windex(cq)])
-#define cirque_insert(cq, x)	(cq)->buf[(cq)->wcnt++ & (cq)->size_mask] = x
-#define cirque_remove(cq)	(&(cq)->buf[(cq)->rcnt++ & (cq)->size_mask])
-#define cirque_discard(cq)	((cq)->rcnt++)
-#define cirque_commit(cq)	((cq)->wcnt++)
+#define ofi_cirque_rindex(cq)		((cq)->rcnt & (cq)->size_mask)
+#define ofi_cirque_windex(cq)		((cq)->wcnt & (cq)->size_mask)
+#define ofi_cirque_head(cq)		(&(cq)->buf[ofi_cirque_rindex(cq)])
+#define ofi_cirque_tail(cq)		(&(cq)->buf[ofi_cirque_windex(cq)])
+#define ofi_cirque_insert(cq, x)	(cq)->buf[(cq)->wcnt++ & (cq)->size_mask] = x
+#define ofi_cirque_remove(cq)		(&(cq)->buf[(cq)->rcnt++ & (cq)->size_mask])
+#define ofi_cirque_discard(cq)		((cq)->rcnt++)
+#define ofi_cirque_commit(cq)		((cq)->wcnt++)
 
 
 /*
  * Simple ring buffer
  */
-struct ringbuf {
+struct ofi_ringbuf {
 	size_t		size;
 	size_t		size_mask;
 	size_t		rcnt;
@@ -111,7 +111,7 @@ struct ringbuf {
 	void		*buf;
 };
 
-static inline int rbinit(struct ringbuf *rb, size_t size)
+static inline int ofi_rbinit(struct ofi_ringbuf *rb, size_t size)
 {
 	rb->size = roundup_power_of_two(size);
 	rb->size_mask = rb->size - 1;
@@ -124,32 +124,32 @@ static inline int rbinit(struct ringbuf *rb, size_t size)
 	return 0;
 }
 
-static inline void rbfree(struct ringbuf *rb)
+static inline void ofi_rbfree(struct ofi_ringbuf *rb)
 {
 	free(rb->buf);
 }
 
-static inline int rbfull(struct ringbuf *rb)
+static inline int ofi_rbfull(struct ofi_ringbuf *rb)
 {
 	return rb->wcnt - rb->rcnt >= rb->size;
 }
 
-static inline int rbempty(struct ringbuf *rb)
+static inline int ofi_rbempty(struct ofi_ringbuf *rb)
 {
 	return rb->wcnt == rb->rcnt;
 }
 
-static inline size_t rbused(struct ringbuf *rb)
+static inline size_t ofi_rbused(struct ofi_ringbuf *rb)
 {
 	return rb->wcnt - rb->rcnt;
 }
 
-static inline size_t rbavail(struct ringbuf *rb)
+static inline size_t ofi_rbavail(struct ofi_ringbuf *rb)
 {
-	return rb->size - rbused(rb);
+	return rb->size - ofi_rbused(rb);
 }
 
-static inline void rbwrite(struct ringbuf *rb, const void *buf, size_t len)
+static inline void ofi_rbwrite(struct ofi_ringbuf *rb, const void *buf, size_t len)
 {
 	size_t endlen;
 
@@ -163,17 +163,17 @@ static inline void rbwrite(struct ringbuf *rb, const void *buf, size_t len)
 	rb->wpos += len;
 }
 
-static inline void rbcommit(struct ringbuf *rb)
+static inline void ofi_rbcommit(struct ofi_ringbuf *rb)
 {
 	rb->wcnt = rb->wpos;
 }
 
-static inline void rbabort(struct ringbuf *rb)
+static inline void ofi_rbabort(struct ofi_ringbuf *rb)
 {
 	rb->wpos = rb->wcnt;
 }
 
-static inline void rbpeek(struct ringbuf *rb, void *buf, size_t len)
+static inline void ofi_rbpeek(struct ofi_ringbuf *rb, void *buf, size_t len)
 {
 	size_t endlen;
 
@@ -186,15 +186,15 @@ static inline void rbpeek(struct ringbuf *rb, void *buf, size_t len)
 	}
 }
 
-static inline void rbread(struct ringbuf *rb, void *buf, size_t len)
+static inline void ofi_rbread(struct ofi_ringbuf *rb, void *buf, size_t len)
 {
-	rbpeek(rb, buf, len);
+	ofi_rbpeek(rb, buf, len);
 	rb->rcnt += len;
 }
 
-static inline size_t rbdiscard(struct ringbuf *rb, size_t len)
+static inline size_t ofi_rbdiscard(struct ofi_ringbuf *rb, size_t len)
 {
-	size_t used_len = MIN(rbused(rb), len);
+	size_t used_len = MIN(ofi_rbused(rb), len);
 	rb->rcnt += used_len;
 	return used_len;
 }
@@ -203,24 +203,24 @@ static inline size_t rbdiscard(struct ringbuf *rb, size_t len)
  * Ring buffer with blocking read support using an fd
  */
 enum {
-	RB_READ_FD,
-	RB_WRITE_FD
+	OFI_RB_READ_FD,
+	OFI_RB_WRITE_FD
 };
 
-struct ringbuffd {
-	struct ringbuf	rb;
-	int		fdrcnt;
-	int		fdwcnt;
-	int		fd[2];
+struct ofi_ringbuffd {
+	struct ofi_ringbuf	rb;
+	int			fdrcnt;
+	int			fdwcnt;
+	int			fd[2];
 };
 
-static inline int rbfdinit(struct ringbuffd *rbfd, size_t size)
+static inline int ofi_rbfdinit(struct ofi_ringbuffd *rbfd, size_t size)
 {
 	int ret;
 
 	rbfd->fdrcnt = 0;
 	rbfd->fdwcnt = 0;
-	ret = rbinit(&rbfd->rb, size);
+	ret = ofi_rbinit(&rbfd->rb, size);
 	if (ret)
 		return ret;
 
@@ -228,7 +228,7 @@ static inline int rbfdinit(struct ringbuffd *rbfd, size_t size)
 	if (ret < 0)
 		goto err1;
 
-	ret = fi_fd_nonblock(rbfd->fd[RB_READ_FD]);
+	ret = fi_fd_nonblock(rbfd->fd[OFI_RB_READ_FD]);
 	if (ret)
 		goto err2;
 
@@ -238,108 +238,108 @@ err2:
 	ofi_close_socket(rbfd->fd[0]);
 	ofi_close_socket(rbfd->fd[1]);
 err1:
-	rbfree(&rbfd->rb);
+	ofi_rbfree(&rbfd->rb);
 	return -errno;
 }
 
-static inline void rbfdfree(struct ringbuffd *rbfd)
+static inline void ofi_rbfdfree(struct ofi_ringbuffd *rbfd)
 {
-	rbfree(&rbfd->rb);
+	ofi_rbfree(&rbfd->rb);
 	ofi_close_socket(rbfd->fd[0]);
 	ofi_close_socket(rbfd->fd[1]);
 }
 
-static inline int rbfdfull(struct ringbuffd *rbfd)
+static inline int ofi_rbfdfull(struct ofi_ringbuffd *rbfd)
 {
-	return rbfull(&rbfd->rb);
+	return ofi_rbfull(&rbfd->rb);
 }
 
-static inline int rbfdempty(struct ringbuffd *rbfd)
+static inline int ofi_rbfdempty(struct ofi_ringbuffd *rbfd)
 {
-	return rbempty(&rbfd->rb);
+	return ofi_rbempty(&rbfd->rb);
 }
 
-static inline size_t rbfdused(struct ringbuffd *rbfd)
+static inline size_t ofi_rbfdused(struct ofi_ringbuffd *rbfd)
 {
-	return rbused(&rbfd->rb);
+	return ofi_rbused(&rbfd->rb);
 }
 
-static inline size_t rbfdavail(struct ringbuffd *rbfd)
+static inline size_t ofi_rbfdavail(struct ofi_ringbuffd *rbfd)
 {
-	return rbavail(&rbfd->rb);
+	return ofi_rbavail(&rbfd->rb);
 }
 
-static inline void rbfdsignal(struct ringbuffd *rbfd)
+static inline void ofi_rbfdsignal(struct ofi_ringbuffd *rbfd)
 {
 	char c = 0;
 	if (rbfd->fdwcnt == rbfd->fdrcnt) {
-		if (ofi_write_socket(rbfd->fd[RB_WRITE_FD], &c, sizeof c) == sizeof c)
+		if (ofi_write_socket(rbfd->fd[OFI_RB_WRITE_FD], &c, sizeof c) == sizeof c)
 			rbfd->fdwcnt++;
 	}
 }
 
-static inline void rbfdreset(struct ringbuffd *rbfd)
+static inline void ofi_rbfdreset(struct ofi_ringbuffd *rbfd)
 {
 	char c;
 
-	if (rbfdempty(rbfd) && (rbfd->fdrcnt != rbfd->fdwcnt)) {
-		if (ofi_read_socket(rbfd->fd[RB_READ_FD], &c, sizeof c) == sizeof c)
+	if (ofi_rbfdempty(rbfd) && (rbfd->fdrcnt != rbfd->fdwcnt)) {
+		if (ofi_read_socket(rbfd->fd[OFI_RB_READ_FD], &c, sizeof c) == sizeof c)
 			rbfd->fdrcnt++;
 	}
 }
 
-static inline void rbfdwrite(struct ringbuffd *rbfd, const void *buf, size_t len)
+static inline void ofi_rbfdwrite(struct ofi_ringbuffd *rbfd, const void *buf, size_t len)
 {
-	rbwrite(&rbfd->rb, buf, len);
+	ofi_rbwrite(&rbfd->rb, buf, len);
 }
 
-static inline void rbfdcommit(struct ringbuffd *rbfd)
+static inline void ofi_rbfdcommit(struct ofi_ringbuffd *rbfd)
 {
-	rbcommit(&rbfd->rb);
-	rbfdsignal(rbfd);
+	ofi_rbcommit(&rbfd->rb);
+	ofi_rbfdsignal(rbfd);
 }
 
-static inline void rbfdabort(struct ringbuffd *rbfd)
+static inline void ofi_rbfdabort(struct ofi_ringbuffd *rbfd)
 {
-	rbabort(&rbfd->rb);
+	ofi_rbabort(&rbfd->rb);
 }
 
-static inline void rbfdpeek(struct ringbuffd *rbfd, void *buf, size_t len)
+static inline void ofi_rbfdpeek(struct ofi_ringbuffd *rbfd, void *buf, size_t len)
 {
-	rbpeek(&rbfd->rb, buf, len);
+	ofi_rbpeek(&rbfd->rb, buf, len);
 }
 
-static inline void rbfdread(struct ringbuffd *rbfd, void *buf, size_t len)
+static inline void ofi_rbfdread(struct ofi_ringbuffd *rbfd, void *buf, size_t len)
 {
-	rbread(&rbfd->rb, buf, len);
-	rbfdreset(rbfd);
+	ofi_rbread(&rbfd->rb, buf, len);
+	ofi_rbfdreset(rbfd);
 }
 
-static inline size_t rbfdsread(struct ringbuffd *rbfd, void *buf, size_t len,
+static inline size_t ofi_rbfdsread(struct ofi_ringbuffd *rbfd, void *buf, size_t len,
 				int timeout)
 {
 	int ret;
 	size_t avail;
 
-	avail = rbfdused(rbfd);
+	avail = ofi_rbfdused(rbfd);
 	if (avail) {
 		len = MIN(len, avail);
-		rbfdread(rbfd, buf, len);
+		ofi_rbfdread(rbfd, buf, len);
 		return len;
 	}
 
-	ret = fi_poll_fd(rbfd->fd[RB_READ_FD], timeout);
+	ret = fi_poll_fd(rbfd->fd[OFI_RB_READ_FD], timeout);
 	if (ret == 1) {
-		len = MIN(len, rbfdused(rbfd));
-		rbfdread(rbfd, buf, len);
+		len = MIN(len, ofi_rbfdused(rbfd));
+		ofi_rbfdread(rbfd, buf, len);
 		return len;
 	}
 	return ret;
 }
 
-static inline size_t rbfdwait(struct ringbuffd *rbfd, int timeout)
+static inline size_t ofi_rbfdwait(struct ofi_ringbuffd *rbfd, int timeout)
 {
-	return  fi_poll_fd(rbfd->fd[RB_READ_FD], timeout);
+	return  fi_poll_fd(rbfd->fd[OFI_RB_READ_FD], timeout);
 }
 
 

--- a/include/fi_rbuf.h
+++ b/include/fi_rbuf.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,8 +32,8 @@
  *
  */
 
-#if !defined(RBUF_H)
-#define RBUF_H
+#if !defined(FI_RBUF_H)
+#define FI_RBUF_H
 
 #include "config.h"
 
@@ -342,4 +343,4 @@ static inline size_t rbfdwait(struct ringbuffd *rbfd, int timeout)
 }
 
 
-#endif /* RBUF_H */
+#endif /* FI_RBUF_H */

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -203,7 +203,7 @@ struct util_cq_err_entry {
 	struct slist_entry	list_entry;
 };
 
-DECLARE_CIRQUE(struct fi_cq_tagged_entry, util_comp_cirq);
+OFI_DECLARE_CIRQUE(struct fi_cq_tagged_entry, util_comp_cirq);
 
 typedef void (*ofi_cq_progress_func)(struct util_cq *cq);
 

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -57,7 +57,6 @@
 
 #include <fi.h>
 #include <fi_enosys.h>
-#include <fi_indexer.h>
 #include <fi_rbuf.h>
 #include <fi_list.h>
 #include <fi_file.h>

--- a/prov/mlx/src/mlx.h
+++ b/prov/mlx/src/mlx.h
@@ -136,7 +136,7 @@ struct mlx_request {
 	struct mlx_ep* ep;
 };
 
-DECLARE_CIRQUE(struct fi_cq_tagged_entry, mlx_comp_cirq);
+OFI_DECLARE_CIRQUE(struct fi_cq_tagged_entry, mlx_comp_cirq);
 
 extern int mlx_errcode_translation_table[];
 #define MLX_TRANSLATE_ERRCODE(X) mlx_errcode_translation_table[(-X)+1]

--- a/prov/mlx/src/mlx_callbacks.c
+++ b/prov/mlx/src/mlx_callbacks.c
@@ -56,9 +56,9 @@ void mlx_send_callback( void *request,
 
 	fastlock_acquire(&cq->cq_lock);
 
-	t_entry = cirque_tail(cq->cirq);
+	t_entry = ofi_cirque_tail(cq->cirq);
 	*t_entry = (mlx_req->completion.tagged);
-	cirque_commit(cq->cirq);
+	ofi_cirque_commit(cq->cirq);
 
 	if (status != UCS_OK){
 		t_entry->flags |= UTIL_FLAG_ERROR;
@@ -120,7 +120,7 @@ void mlx_recv_callback (
 		}
 
 		struct fi_cq_tagged_entry *t_entry;
-		t_entry = cirque_tail(cq->cirq);
+		t_entry = ofi_cirque_tail(cq->cirq);
 		*t_entry = (mlx_req->completion.tagged);
 
 		if (status != UCS_OK) {
@@ -139,7 +139,7 @@ void mlx_recv_callback (
 		}
 
 		if (cq->src){
-			cq->src[cirque_windex((struct mlx_comp_cirq*)(cq->cirq))] =
+			cq->src[ofi_cirque_windex((struct mlx_comp_cirq*)(cq->cirq))] =
 					FI_ADDR_NOTAVAIL;
 		}
 
@@ -148,7 +148,7 @@ void mlx_recv_callback (
 		}
 
 		mlx_req->type = MLX_FI_REQ_UNINITIALIZED;
-		cirque_commit(cq->cirq);
+		ofi_cirque_commit(cq->cirq);
 		ucp_request_release(request);
 	}
 	fastlock_release(&cq->cq_lock);

--- a/prov/mlx/src/mlx_tagged.c
+++ b/prov/mlx/src/mlx_tagged.c
@@ -92,7 +92,7 @@ static ssize_t mlx_tagged_recvmsg(
 	/*Unexpected path*/
 	struct fi_cq_tagged_entry *t_entry;
 	fastlock_acquire(&cq->cq_lock);
-	t_entry = cirque_tail(cq->cirq);
+	t_entry = ofi_cirque_tail(cq->cirq);
 	*t_entry = (req->completion.tagged);
 
 	if(req->type == MLX_FI_REQ_UNEXPECTED_ERR) {
@@ -111,7 +111,7 @@ static ssize_t mlx_tagged_recvmsg(
 	}
 
 	//ucp_request_release(req);
-	cirque_commit(cq->cirq);
+	ofi_cirque_commit(cq->cirq);
 	fastlock_release(&cq->cq_lock);
 
 fence:
@@ -212,14 +212,14 @@ static ssize_t mlx_tagged_sendmsg(
 	} else {
 		struct fi_cq_tagged_entry *t_entry;
 		fastlock_acquire(&cq->cq_lock);
-		t_entry = cirque_tail(cq->cirq);
+		t_entry = ofi_cirque_tail(cq->cirq);
 		t_entry->op_context = msg->context;
 		t_entry->flags = FI_SEND;
 		t_entry->len = msg->msg_iov[0].iov_len;
 		t_entry->buf = msg->msg_iov[0].iov_base;
 		t_entry->data = 0;
 		t_entry->tag = msg->tag;
-		cirque_commit(cq->cirq);
+		ofi_cirque_commit(cq->cirq);
 		fastlock_release(&cq->cq_lock);
 	}
 

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -48,12 +48,12 @@ static int rxd_cq_write_ctx(struct rxd_cq *cq,
 			     struct fi_cq_tagged_entry *cq_entry)
 {
 	struct fi_cq_tagged_entry *comp;
-	if (cirque_isfull(cq->util_cq.cirq))
+	if (ofi_cirque_isfull(cq->util_cq.cirq))
 		return -FI_ENOSPC;
 
-	comp = cirque_tail(cq->util_cq.cirq);
+	comp = ofi_cirque_tail(cq->util_cq.cirq);
 	comp->op_context = cq_entry->op_context;
-	cirque_commit(cq->util_cq.cirq);
+	ofi_cirque_commit(cq->util_cq.cirq);
 	return 0;
 }
 
@@ -69,14 +69,14 @@ static int rxd_cq_write_msg(struct rxd_cq *cq,
 			     struct fi_cq_tagged_entry *cq_entry)
 {
 	struct fi_cq_tagged_entry *comp;
-	if (cirque_isfull(cq->util_cq.cirq))
+	if (ofi_cirque_isfull(cq->util_cq.cirq))
 		return -FI_ENOSPC;
 
-	comp = cirque_tail(cq->util_cq.cirq);
+	comp = ofi_cirque_tail(cq->util_cq.cirq);
 	comp->op_context = cq_entry->op_context;
 	comp->flags = cq_entry->flags;
 	comp->len = cq_entry->len;
-	cirque_commit(cq->util_cq.cirq);
+	ofi_cirque_commit(cq->util_cq.cirq);
 	return 0;
 }
 
@@ -92,16 +92,16 @@ static int rxd_cq_write_data(struct rxd_cq *cq,
 			      struct fi_cq_tagged_entry *cq_entry)
 {
 	struct fi_cq_tagged_entry *comp;
-	if (cirque_isfull(cq->util_cq.cirq))
+	if (ofi_cirque_isfull(cq->util_cq.cirq))
 		return -FI_ENOSPC;
 
-	comp = cirque_tail(cq->util_cq.cirq);
+	comp = ofi_cirque_tail(cq->util_cq.cirq);
 	comp->op_context = cq_entry->op_context;
 	comp->flags = cq_entry->flags;
 	comp->len = cq_entry->len;
 	comp->buf = cq_entry->buf;
 	comp->data = cq_entry->data;
-	cirque_commit(cq->util_cq.cirq);
+	ofi_cirque_commit(cq->util_cq.cirq);
 	return 0;
 }
 
@@ -117,15 +117,15 @@ static int rxd_cq_write_tagged(struct rxd_cq *cq,
 				struct fi_cq_tagged_entry *cq_entry)
 {
 	struct fi_cq_tagged_entry *comp;
-	if (cirque_isfull(cq->util_cq.cirq))
+	if (ofi_cirque_isfull(cq->util_cq.cirq))
 		return -FI_ENOSPC;
 
 	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
 		"report completion: %p\n", cq_entry->tag);
 
-	comp = cirque_tail(cq->util_cq.cirq);
+	comp = ofi_cirque_tail(cq->util_cq.cirq);
 	*comp = *cq_entry;
-	cirque_commit(cq->util_cq.cirq);
+	ofi_cirque_commit(cq->util_cq.cirq);
 	return 0;
 }
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -292,7 +292,7 @@ static int rxm_check_unexp_msg_list(struct util_cq *util_cq, struct rxm_recv_que
 	int ret = 0;
 
 	fastlock_acquire(&util_cq->cq_lock);
-	if (cirque_isfull(util_cq->cirq)) {
+	if (ofi_cirque_isfull(util_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -629,7 +629,7 @@ struct sock_tx_ctx {
 	} fid;
 	size_t fclass;
 
-	struct ringbuf rb;
+	struct ofi_ringbuf rb;
 	fastlock_t wlock;
 	fastlock_t rlock;
 
@@ -798,7 +798,7 @@ struct sock_pe_entry {
 
 	struct dlist_entry entry;
 	struct dlist_entry ctx_entry;
-	struct ringbuf comm_buf;
+	struct ofi_ringbuf comm_buf;
 	size_t cache_sz;
 };
 
@@ -845,9 +845,9 @@ struct sock_cq {
 	atomic_t ref;
 	struct fi_cq_attr attr;
 
-	struct ringbuf addr_rb;
-	struct ringbuffd cq_rbfd;
-	struct ringbuf cqerr_rb;
+	struct ofi_ringbuf addr_rb;
+	struct ofi_ringbuffd cq_rbfd;
+	struct ofi_ringbuf cqerr_rb;
 	struct dlist_entry overflow_list;
 	fastlock_t lock;
 	fastlock_t list_lock;

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -139,7 +139,7 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 		      (result_count * sizeof(union sock_iov)));
 
 	sock_tx_ctx_start(tx_ctx);
-	if (rbavail(&tx_ctx->rb) < total_len) {
+	if (ofi_rbavail(&tx_ctx->rb) < total_len) {
 		ret = -FI_EAGAIN;
 		goto err;
 	}

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -397,10 +397,10 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 		fastlock_acquire(&sock_ep->attr->cmap.lock);
 		for (i = 0; i < count; i++) {
         		idx = fi_addr[i] & sock_ep->attr->av->mask;
-			conn = idm_lookup(&sock_ep->attr->av_idm, idx);
+			conn = ofi_idm_lookup(&sock_ep->attr->av_idm, idx);
 			if (conn && conn->sock_fd != -1) {
 				sock_ep_remove_conn(sock_ep->attr, conn);
-				idm_clear(&sock_ep->attr->av_idm, idx);
+				ofi_idm_clear(&sock_ep->attr->av_idm, idx);
 			}
 		}
 		fastlock_release(&sock_ep->attr->cmap.lock);

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -71,7 +71,7 @@ ssize_t sock_comm_flush(struct sock_pe_entry *pe_entry)
 	ssize_t ret1, ret2 = 0;
 	size_t endlen, len, xfer_len;
 
-	len = rbused(&pe_entry->comm_buf);
+	len = ofi_rbused(&pe_entry->comm_buf);
 	endlen = pe_entry->comm_buf.size -
 		(pe_entry->comm_buf.rcnt & pe_entry->comm_buf.size_mask);
 
@@ -101,7 +101,7 @@ ssize_t sock_comm_send(struct sock_pe_entry *pe_entry,
 	ssize_t ret, used;
 
 	if (len > pe_entry->cache_sz) {
-		used = rbused(&pe_entry->comm_buf);
+		used = ofi_rbused(&pe_entry->comm_buf);
 		if (used == sock_comm_flush(pe_entry)) {
 			return sock_comm_send_socket(pe_entry->conn, buf, len);
 		} else {
@@ -109,22 +109,22 @@ ssize_t sock_comm_send(struct sock_pe_entry *pe_entry,
 		}
 	}
 
-	if (rbavail(&pe_entry->comm_buf) < len) {
+	if (ofi_rbavail(&pe_entry->comm_buf) < len) {
 		ret = sock_comm_flush(pe_entry);
 		if (ret <= 0)
 			return 0;
 	}
 
-	ret = MIN(rbavail(&pe_entry->comm_buf), len);
-	rbwrite(&pe_entry->comm_buf, buf, ret);
-	rbcommit(&pe_entry->comm_buf);
+	ret = MIN(ofi_rbavail(&pe_entry->comm_buf), len);
+	ofi_rbwrite(&pe_entry->comm_buf, buf, ret);
+	ofi_rbcommit(&pe_entry->comm_buf);
 	SOCK_LOG_DBG("buffered %lu\n", ret);
 	return ret;
 }
 
 int sock_comm_tx_done(struct sock_pe_entry *pe_entry)
 {
-	return rbempty(&pe_entry->comm_buf);
+	return ofi_rbempty(&pe_entry->comm_buf);
 }
 
 static ssize_t sock_comm_recv_socket(struct sock_conn *conn,
@@ -154,7 +154,7 @@ static void sock_comm_recv_buffer(struct sock_pe_entry *pe_entry)
 	int ret;
 	size_t max_read, avail;
 
-	avail = rbavail(&pe_entry->comm_buf);
+	avail = ofi_rbavail(&pe_entry->comm_buf);
 	assert(avail == pe_entry->comm_buf.size);
 	pe_entry->comm_buf.rcnt =
 		pe_entry->comm_buf.wcnt =
@@ -165,13 +165,13 @@ static void sock_comm_recv_buffer(struct sock_pe_entry *pe_entry)
 	ret = sock_comm_recv_socket(pe_entry->conn, (char *) pe_entry->comm_buf.buf,
 				    MIN(max_read, avail));
 	pe_entry->comm_buf.wpos += ret;
-	rbcommit(&pe_entry->comm_buf);
+	ofi_rbcommit(&pe_entry->comm_buf);
 }
 
 ssize_t sock_comm_recv(struct sock_pe_entry *pe_entry, void *buf, size_t len)
 {
 	ssize_t read_len;
-	if (rbempty(&pe_entry->comm_buf)) {
+	if (ofi_rbempty(&pe_entry->comm_buf)) {
 		if (len <= pe_entry->cache_sz) {
 			sock_comm_recv_buffer(pe_entry);
 		} else {
@@ -179,8 +179,8 @@ ssize_t sock_comm_recv(struct sock_pe_entry *pe_entry, void *buf, size_t len)
 		}
 	}
 
-	read_len = MIN(len, rbused(&pe_entry->comm_buf));
-	rbread(&pe_entry->comm_buf, buf, read_len);
+	read_len = MIN(len, ofi_rbused(&pe_entry->comm_buf));
+	ofi_rbread(&pe_entry->comm_buf, buf, read_len);
 	SOCK_LOG_DBG("read from buffer: %lu\n", read_len);
 	return read_len;
 }
@@ -221,5 +221,5 @@ ssize_t sock_comm_discard(struct sock_pe_entry *pe_entry, size_t len)
 
 int sock_comm_is_disconnected(struct sock_pe_entry *pe_entry)
 {
-	return (rbempty(&pe_entry->comm_buf) && !pe_entry->conn->connected);
+	return (ofi_rbempty(&pe_entry->comm_buf) && !pe_entry->conn->connected);
 }

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -73,7 +73,7 @@ ssize_t sock_conn_send_src_addr(struct sock_ep_attr *ep_attr, struct sock_tx_ctx
 	total_len = tx_op.src_iov_len + sizeof(struct sock_op_send);
 
 	sock_tx_ctx_start(tx_ctx);
-	if (rbavail(&tx_ctx->rb) < total_len) {
+	if (ofi_rbavail(&tx_ctx->rb) < total_len) {
 		ret = -FI_EAGAIN;
 		goto err;
 	}

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -189,8 +189,8 @@ static struct sock_conn *sock_conn_map_insert(struct sock_ep_attr *ep_attr,
 	sock_set_sockopts(conn_fd);
 
 
-	if (idm_set(&ep_attr->conn_idm, conn_fd, &map->table[index]) < 0)
-		SOCK_LOG_ERROR("idm_set failed\n");
+	if (ofi_idm_set(&ep_attr->conn_idm, conn_fd, &map->table[index]) < 0)
+		SOCK_LOG_ERROR("ofi_idm_set failed\n");
 
 	if (sock_epoll_add(&map->epoll_set, conn_fd))
 		SOCK_LOG_ERROR("failed to add to epoll set: %d\n", conn_fd);
@@ -511,10 +511,10 @@ out:
 		goto err;
 	}
 	new_conn->av_index = (ep_attr->ep_type == FI_EP_MSG) ? FI_ADDR_NOTAVAIL : index;
-	conn = idm_lookup(&ep_attr->av_idm, index);
+	conn = ofi_idm_lookup(&ep_attr->av_idm, index);
 	if (conn == SOCK_CM_CONN_IN_PROGRESS) {
-		if (idm_set(&ep_attr->av_idm, index, new_conn) < 0)
-			SOCK_LOG_ERROR("idm_set failed\n");
+		if (ofi_idm_set(&ep_attr->av_idm, index, new_conn) < 0)
+			SOCK_LOG_ERROR("ofi_idm_set failed\n");
 		conn = new_conn;
 	}
 	fastlock_release(&ep_attr->cmap.lock);

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -85,7 +85,7 @@ static struct sock_tx_ctx *sock_tx_context_alloc(const struct fi_tx_attr *attr,
 	if (!tx_ctx)
 		return NULL;
 
-	if (!use_shared && rbinit(&tx_ctx->rb,
+	if (!use_shared && ofi_rbinit(&tx_ctx->rb,
 				 (attr->size) ? attr->size * SOCK_EP_TX_ENTRY_SZ :
 				 SOCK_EP_TX_SZ * SOCK_EP_TX_ENTRY_SZ))
 		goto err;
@@ -151,7 +151,7 @@ void sock_tx_ctx_free(struct sock_tx_ctx *tx_ctx)
 	fastlock_destroy(&tx_ctx->lock);
 
 	if (!tx_ctx->use_shared) {
-		rbfree(&tx_ctx->rb);
+		ofi_rbfree(&tx_ctx->rb);
 		sock_rx_ctx_free(tx_ctx->rx_ctrl_ctx);
 	}
 	free(tx_ctx);
@@ -164,19 +164,19 @@ void sock_tx_ctx_start(struct sock_tx_ctx *tx_ctx)
 
 void sock_tx_ctx_write(struct sock_tx_ctx *tx_ctx, const void *buf, size_t len)
 {
-	rbwrite(&tx_ctx->rb, buf, len);
+	ofi_rbwrite(&tx_ctx->rb, buf, len);
 }
 
 void sock_tx_ctx_commit(struct sock_tx_ctx *tx_ctx)
 {
-	rbcommit(&tx_ctx->rb);
+	ofi_rbcommit(&tx_ctx->rb);
 	sock_pe_signal(tx_ctx->domain->pe);
 	fastlock_release(&tx_ctx->wlock);
 }
 
 void sock_tx_ctx_abort(struct sock_tx_ctx *tx_ctx)
 {
-	rbabort(&tx_ctx->rb);
+	ofi_rbabort(&tx_ctx->rb);
 	fastlock_release(&tx_ctx->wlock);
 }
 
@@ -209,11 +209,11 @@ void sock_tx_ctx_read_op_send(struct sock_tx_ctx *tx_ctx,
 		uint64_t *dest_addr, uint64_t *buf, struct sock_ep_attr **ep_attr,
 		struct sock_conn **conn)
 {
-	rbread(&tx_ctx->rb, op, sizeof(*op));
-	rbread(&tx_ctx->rb, flags, sizeof(*flags));
-	rbread(&tx_ctx->rb, context, sizeof(*context));
-	rbread(&tx_ctx->rb, dest_addr, sizeof(*dest_addr));
-	rbread(&tx_ctx->rb, buf, sizeof(*buf));
-	rbread(&tx_ctx->rb, ep_attr, sizeof(*ep_attr));
-	rbread(&tx_ctx->rb, conn, sizeof(*conn));
+	ofi_rbread(&tx_ctx->rb, op, sizeof(*op));
+	ofi_rbread(&tx_ctx->rb, flags, sizeof(*flags));
+	ofi_rbread(&tx_ctx->rb, context, sizeof(*context));
+	ofi_rbread(&tx_ctx->rb, dest_addr, sizeof(*dest_addr));
+	ofi_rbread(&tx_ctx->rb, buf, sizeof(*buf));
+	ofi_rbread(&tx_ctx->rb, ep_attr, sizeof(*ep_attr));
+	ofi_rbread(&tx_ctx->rb, conn, sizeof(*conn));
 }

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -706,8 +706,8 @@ static int sock_ep_close(struct fid *fid)
 		free(sock_ep->attr->dest_addr);
 
 	fastlock_acquire(&sock_ep->attr->domain->pe->lock);
-	idm_reset(&sock_ep->attr->conn_idm);
-	idm_reset(&sock_ep->attr->av_idm);
+	ofi_idm_reset(&sock_ep->attr->conn_idm);
+	ofi_idm_reset(&sock_ep->attr->av_idm);
 	sock_conn_map_destroy(sock_ep->attr);
 	fastlock_release(&sock_ep->attr->domain->pe->lock);
 
@@ -1742,7 +1742,7 @@ err1:
 void sock_ep_remove_conn(struct sock_ep_attr *attr, struct sock_conn *conn)
 {
 	sock_pe_poll_del(attr->domain->pe, conn->sock_fd);
-	idm_clear(&attr->conn_idm, conn->sock_fd);
+	ofi_idm_clear(&attr->conn_idm, conn->sock_fd);
 	sock_conn_release_entry(&attr->cmap, conn);
 }
 
@@ -1755,7 +1755,7 @@ struct sock_conn *sock_ep_lookup_conn(struct sock_ep_attr *attr, fi_addr_t index
 
 	idx = (attr->ep_type == FI_EP_MSG) ? index : index & attr->av->mask;
 
-	conn = idm_lookup(&attr->av_idm, idx);
+	conn = ofi_idm_lookup(&attr->av_idm, idx);
 	if (conn && conn != SOCK_CM_CONN_IN_PROGRESS)
 		return conn;
 
@@ -1785,8 +1785,8 @@ int sock_ep_get_conn(struct sock_ep_attr *attr, struct sock_tx_ctx *tx_ctx,
 	conn = sock_ep_lookup_conn(attr, av_index, addr);
 	if (!conn) {
 		conn = SOCK_CM_CONN_IN_PROGRESS;
-		if (idm_set(&attr->av_idm, av_index, conn) < 0)
-			SOCK_LOG_ERROR("idm_set failed\n");
+		if (ofi_idm_set(&attr->av_idm, av_index, conn) < 0)
+			SOCK_LOG_ERROR("ofi_idm_set failed\n");
 	}
 	fastlock_release(&attr->cmap.lock);
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -588,7 +588,7 @@ static ssize_t sock_tx_size_left(struct fid_ep *ep)
 		return -FI_EOPBADSTATE;
 
 	fastlock_acquire(&tx_ctx->wlock);
-	num_left = rbavail(&tx_ctx->rb)/SOCK_EP_TX_ENTRY_SZ;
+	num_left = ofi_rbavail(&tx_ctx->rb)/SOCK_EP_TX_ENTRY_SZ;
 	fastlock_release(&tx_ctx->wlock);
 	return num_left;
 }

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -253,7 +253,7 @@ ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		total_len += sizeof(uint64_t);
 
 	sock_tx_ctx_start(tx_ctx);
-	if (rbavail(&tx_ctx->rb) < total_len) {
+	if (ofi_rbavail(&tx_ctx->rb) < total_len) {
 		ret = -FI_EAGAIN;
 		goto err;
 	}
@@ -588,7 +588,7 @@ ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 		total_len += sizeof(uint64_t);
 
 	sock_tx_ctx_start(tx_ctx);
-	if (rbavail(&tx_ctx->rb) < total_len) {
+	if (ofi_rbavail(&tx_ctx->rb) < total_len) {
 		ret = -FI_EAGAIN;
 		goto err;
 	}

--- a/prov/sockets/src/sock_poll.c
+++ b/prov/sockets/src/sock_poll.c
@@ -130,7 +130,7 @@ static int sock_poll_poll(struct fid_poll *pollset, void **context, int count)
 						cq_fid);
 			sock_cq_progress(cq);
 			fastlock_acquire(&cq->lock);
-			if (rbfdused(&cq->cq_rbfd) || rbused(&cq->cqerr_rb)) {
+			if (ofi_rbfdused(&cq->cq_rbfd) || ofi_rbused(&cq->cqerr_rb)) {
 				*context++ = cq->cq_fid.fid.context;
 				ret_count++;
 			}

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1659,8 +1659,8 @@ static int sock_pe_process_rx_conn_msg(struct sock_pe *pe,
 		fastlock_acquire(&map->lock);
 		conn = sock_ep_lookup_conn(ep_attr, index, addr);
 		if (conn == NULL || conn == SOCK_CM_CONN_IN_PROGRESS) {
-			if (idm_set(&ep_attr->av_idm, index, pe_entry->conn) < 0)
-				SOCK_LOG_ERROR("idm_set failed\n");
+			if (ofi_idm_set(&ep_attr->av_idm, index, pe_entry->conn) < 0)
+				SOCK_LOG_ERROR("ofi_idm_set failed\n");
 		}
 		fastlock_release(&map->lock);
 	}
@@ -2540,9 +2540,9 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe, struct sock_ep_attr *ep_at
 		if (fd == -1) /* failed to lookup fd due to connection failures */
 			continue;
 
-		conn = idm_lookup(&ep_attr->conn_idm, fd);
+		conn = ofi_idm_lookup(&ep_attr->conn_idm, fd);
 		if (!conn)
-			SOCK_LOG_ERROR("idm_lookup failed\n");
+			SOCK_LOG_ERROR("ofi_idm_lookup failed\n");
 
 		if (!conn || conn->rx_pe_entry)
 			continue;

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -117,7 +117,7 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		(msg->rma_iov_count * sizeof(union sock_iov));
 
 	sock_tx_ctx_start(tx_ctx);
-	if (rbavail(&tx_ctx->rb) < total_len) {
+	if (ofi_rbavail(&tx_ctx->rb) < total_len) {
 		ret = -FI_EAGAIN;
 		goto err;
 	}
@@ -298,7 +298,7 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		      (msg->rma_iov_count * sizeof(union sock_iov)));
 
 	sock_tx_ctx_start(tx_ctx);
-	if (rbavail(&tx_ctx->rb) < total_len) {
+	if (ofi_rbavail(&tx_ctx->rb) < total_len) {
 		ret = -FI_EAGAIN;
 		goto err;
 	}

--- a/prov/sockets/src/sock_wait.c
+++ b/prov/sockets/src/sock_wait.c
@@ -137,7 +137,7 @@ static int sock_wait_wait(struct fid_wait *wait_fid, int timeout)
 			cq = container_of(list_item->fid,
 					  struct sock_cq, cq_fid);
 			sock_cq_progress(cq);
-			if (rbused(&cq->cqerr_rb))
+			if (ofi_rbused(&cq->cqerr_rb))
 				return 1;
 			break;
 

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -54,7 +54,6 @@
 
 #include <fi.h>
 #include <fi_enosys.h>
-#include <fi_indexer.h>
 #include <fi_rbuf.h>
 #include <fi_list.h>
 #include <fi_signal.h>

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -92,7 +92,7 @@ struct udpx_ep_entry {
 	uint8_t			resv[sizeof(size_t) - 2];
 };
 
-DECLARE_CIRQUE(struct udpx_ep_entry, udpx_rx_cirq);
+OFI_DECLARE_CIRQUE(struct udpx_ep_entry, udpx_rx_cirq);
 
 struct udpx_ep;
 typedef void (*udpx_rx_comp_func)(struct udpx_ep *ep, void *context,

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1033,7 +1033,7 @@ int ip_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 static void util_cmap_set_key(struct util_cmap_handle *handle)
 {
 	handle->key = ofi_idx2key(&handle->cmap->key_idx,
-		idx_insert(&handle->cmap->handles_idx, handle));
+		ofi_idx_insert(&handle->cmap->handles_idx, handle));
 }
 
 static void util_cmap_clear_key(struct util_cmap_handle *handle)
@@ -1043,7 +1043,7 @@ static void util_cmap_clear_key(struct util_cmap_handle *handle)
 		FI_WARN(handle->cmap->av->prov, FI_LOG_AV, "Invalid key\n");
 		return;
 	}
-	idx_remove(&handle->cmap->handles_idx, index);
+	ofi_idx_remove(&handle->cmap->handles_idx, index);
 }
 
 struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t key)
@@ -1055,7 +1055,7 @@ struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t ke
 		FI_WARN(cmap->av->prov, FI_LOG_AV, "Invalid key\n");
 		return NULL;
 	}
-	handle = idx_at(&cmap->handles_idx, index);
+	handle = ofi_idx_at(&cmap->handles_idx, index);
 	if (handle->key != key) {
 		FI_WARN(cmap->av->prov, FI_LOG_AV,
 				"handle->key not matching given key\n");

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -52,23 +52,23 @@
  * list without taking a lock during data lookups.
  */
 
-static int idx_grow(struct indexer *idx)
+static int ofi_idx_grow(struct indexer *idx)
 {
-	union idx_entry *entry;
+	union ofi_idx_entry *entry;
 	int i, start_index;
 
-	if (idx->size >= IDX_ARRAY_SIZE)
+	if (idx->size >= OFI_IDX_ARRAY_SIZE)
 		goto nomem;
 
-	idx->array[idx->size] = calloc(IDX_ENTRY_SIZE, sizeof(union idx_entry));
+	idx->array[idx->size] = calloc(OFI_IDX_ENTRY_SIZE, sizeof(union ofi_idx_entry));
 	if (!idx->array[idx->size])
 		goto nomem;
 
 	entry = idx->array[idx->size];
-	start_index = idx->size << IDX_ENTRY_BITS;
-	entry[IDX_ENTRY_SIZE - 1].next = idx->free_list;
+	start_index = idx->size << OFI_IDX_ENTRY_BITS;
+	entry[OFI_IDX_ENTRY_SIZE - 1].next = idx->free_list;
 
-	for (i = IDX_ENTRY_SIZE - 2; i >= 0; i--)
+	for (i = OFI_IDX_ENTRY_SIZE - 2; i >= 0; i--)
 		entry[i].next = start_index + i + 1;
 
 	/* Index 0 is reserved */
@@ -83,43 +83,43 @@ nomem:
 	return -1;
 }
 
-int idx_insert(struct indexer *idx, void *item)
+int ofi_idx_insert(struct indexer *idx, void *item)
 {
-	union idx_entry *entry;
+	union ofi_idx_entry *entry;
 	int index;
 
 	if ((index = idx->free_list) == 0) {
-		if ((index = idx_grow(idx)) <= 0)
+		if ((index = ofi_idx_grow(idx)) <= 0)
 			return index;
 	}
 
-	entry = idx->array[idx_array_index(index)];
-	idx->free_list = entry[idx_entry_index(index)].next;
-	entry[idx_entry_index(index)].item = item;
+	entry = idx->array[ofi_idx_array_index(index)];
+	idx->free_list = entry[ofi_idx_entry_index(index)].next;
+	entry[ofi_idx_entry_index(index)].item = item;
 	return index;
 }
 
-void *idx_remove(struct indexer *idx, int index)
+void *ofi_idx_remove(struct indexer *idx, int index)
 {
-	union idx_entry *entry;
+	union ofi_idx_entry *entry;
 	void *item;
 
-	entry = idx->array[idx_array_index(index)];
-	item = entry[idx_entry_index(index)].item;
-	entry[idx_entry_index(index)].next = idx->free_list;
+	entry = idx->array[ofi_idx_array_index(index)];
+	item = entry[ofi_idx_entry_index(index)].item;
+	entry[ofi_idx_entry_index(index)].next = idx->free_list;
 	idx->free_list = index;
 	return item;
 }
 
-void idx_replace(struct indexer *idx, int index, void *item)
+void ofi_idx_replace(struct indexer *idx, int index, void *item)
 {
-	union idx_entry *entry;
+	union ofi_idx_entry *entry;
 
-	entry = idx->array[idx_array_index(index)];
-	entry[idx_entry_index(index)].item = item;
+	entry = idx->array[ofi_idx_array_index(index)];
+	entry[ofi_idx_entry_index(index)].item = item;
 }
 
-void idx_reset(struct indexer *idx)
+void ofi_idx_reset(struct indexer *idx)
 {
 	while (idx->size) {
 		free(idx->array[idx->size - 1]);
@@ -129,10 +129,10 @@ void idx_reset(struct indexer *idx)
 	idx->free_list = 0;
 }
 
-static int idm_grow(struct index_map *idm, int index)
+static int ofi_idm_grow(struct index_map *idm, int index)
 {
-	idm->array[idx_array_index(index)] = calloc(IDX_ENTRY_SIZE, sizeof(void *));
-	if (!idm->array[idx_array_index(index)])
+	idm->array[ofi_idx_array_index(index)] = calloc(OFI_IDX_ENTRY_SIZE, sizeof(void *));
+	if (!idm->array[ofi_idx_array_index(index)])
 		goto nomem;
 
 	return index;
@@ -142,46 +142,46 @@ nomem:
 	return -1;
 }
 
-int idm_set(struct index_map *idm, int index, void *item)
+int ofi_idm_set(struct index_map *idm, int index, void *item)
 {
 	void **entry;
 
-	if (index > IDX_MAX_INDEX) {
+	if (index > OFI_IDX_MAX_INDEX) {
 		errno = ENOMEM;
 		return -1;
 	}
 
-	if (!idm->array[idx_array_index(index)]) {
-		if (idm_grow(idm, index) < 0)
+	if (!idm->array[ofi_idx_array_index(index)]) {
+		if (ofi_idm_grow(idm, index) < 0)
 			return -1;
 	}
 
-	entry = idm->array[idx_array_index(index)];
-	entry[idx_entry_index(index)] = item;
-	idm->count[idx_array_index(index)]++;
+	entry = idm->array[ofi_idx_array_index(index)];
+	entry[ofi_idx_entry_index(index)] = item;
+	idm->count[ofi_idx_array_index(index)]++;
 	return index;
 }
 
-void *idm_clear(struct index_map *idm, int index)
+void *ofi_idm_clear(struct index_map *idm, int index)
 {
 	void **entry;
 	void *item;
 
-	entry = idm->array[idx_array_index(index)];
-	item = entry[idx_entry_index(index)];
-	entry[idx_entry_index(index)] = NULL;
-	if (--idm->count[idx_array_index(index)] == 0) {
-		free(idm->array[idx_array_index(index)]);
-		idm->array[idx_array_index(index)] = NULL;
+	entry = idm->array[ofi_idx_array_index(index)];
+	item = entry[ofi_idx_entry_index(index)];
+	entry[ofi_idx_entry_index(index)] = NULL;
+	if (--idm->count[ofi_idx_array_index(index)] == 0) {
+		free(idm->array[ofi_idx_array_index(index)]);
+		idm->array[ofi_idx_array_index(index)] = NULL;
 	}
 	return item;
 }
 
-void idm_reset(struct index_map *idm)
+void ofi_idm_reset(struct index_map *idm)
 {
 	int i;
 
-	for (i=0; i<IDX_ARRAY_SIZE; i++) {
+	for (i=0; i<OFI_IDX_ARRAY_SIZE; i++) {
 		if (idm->array[i]) {
 			free(idm->array[i]);
 			idm->array[i] = NULL;


### PR DESCRIPTION
Per conventions that we agreed to after writing this code, prefix private symbols with `ofi_` so that it's obvious that these are defined by libfabric, and meant to be private functions inside the library.

Also remove `<fi_indexer.h>` from two providers that were not using it.