### PR TITLE
sockets: remove 2 now-unused variables

### DIFF
--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -48,7 +48,6 @@ static ssize_t sock_comm_send_socket(struct sock_conn *conn,
 				     const void *buf, size_t len)
 {
 	ssize_t ret;
-	int flags = 0;
 
 	ret = ofi_send_socket(conn->sock_fd, buf, len, MSG_NOSIGNAL);
 	if (ret < 0) {

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -390,7 +390,6 @@ static int sock_ep_cm_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
 static int sock_cm_send(int fd, const void *buf, int len)
 {
 	int ret, done = 0;
-	int flags = 0;
 
 	while (done != len) {
 		ret = ofi_send_socket(fd, (const char*) buf + done, len - done, MSG_NOSIGNAL);


### PR DESCRIPTION
As a result of #2544.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>