### PR TITLE
prov/gni: add gnix_cm.h to Makefile

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -51,6 +51,7 @@ _gni_headers = \
 	prov/gni/include/gnix_av.h \
 	prov/gni/include/gnix_bitmap.h \
 	prov/gni/include/gnix_buddy_allocator.h \
+	prov/gni/include/gnix_cm.h \
 	prov/gni/include/gnix_cm_nic.h \
 	prov/gni/include/gnix_cntr.h \
 	prov/gni/include/gnix_cq.h \


### PR DESCRIPTION
Fixes ofi-cray/libfabric-cray#1088.

upstream merge of ofi-cray/libfabric-cray#1089
@sungeunchoi 

Signed-off-by: Zach <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@9ba24548591d4df0066cc03028f7849e50d04663)