### PR TITLE
prov/gni: Implement reject, shutdown, EQ fixes

### DIFF
--- a/prov/gni/include/gnix_cm.h
+++ b/prov/gni/include/gnix_cm.h
@@ -40,8 +40,6 @@
 				 GNIX_CM_DATA_MAX_SIZE)
 
 struct gnix_pep_sock_connreq {
-	int type;
-	int msg_id;
 	struct fi_info info;
 	struct gnix_ep_name src_addr;
 	struct gnix_ep_name dest_addr;

--- a/prov/gni/include/gnix_eq.h
+++ b/prov/gni/include/gnix_eq.h
@@ -69,6 +69,12 @@ struct gnix_eq_poll_obj {
 	struct fid *obj_fid;
 };
 
+struct gnix_eq_err_buf {
+	struct dlist_entry dlist;
+	int do_free;
+	char buf[];
+};
+
 /*
  * EQ structure. Contains error and event queue.
  */
@@ -91,9 +97,11 @@ struct gnix_fid_eq {
 	rwlock_t poll_obj_lock;
 	struct dlist_entry poll_objs;
 	struct dlist_entry gnix_fid_eq_list;
+
+	struct dlist_entry err_bufs;
 };
 
-ssize_t _gnix_eq_write_error(struct fid_eq *eq, fid_t fid,
+ssize_t _gnix_eq_write_error(struct gnix_fid_eq *eq, fid_t fid,
 			     void *context, uint64_t index, int err,
 			     int prov_errno, void *err_data,
 			     size_t err_size);

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -47,9 +47,15 @@
 
 #define GNIX_DEF_MAX_NICS_PER_PTAG	4
 
+/*
+ * globals
+ */
+
 extern uint32_t gnix_max_nics_per_ptag;
+extern struct dlist_entry gnix_nic_list_ptag[];
 extern struct dlist_entry gnix_nic_list;
 extern pthread_mutex_t gnix_nic_list_lock;
+
 /*
  * allocation flags for cleaning up GNI resources
  * when closing a gnix_nic - needed since these
@@ -99,8 +105,8 @@ struct gnix_nic_attr {
  * GNIX nic struct
  *
  * @var gnix_nic_list        list element used for global NIC list
- * @var dom_nic_list         list element used for nic linked list associated
- *                           with a given gnix_fid_domain
+ * @var ptag_nic_list        list element used for NIC linked list associated
+ *                           with a given PTAG.
  * @var lock                 lock used for serializing access to
  *                           gni_nic_hndl, rx_cq, and tx_cq
  * @var gni_cdm_hndl         handle for the GNI communication domain (CDM)
@@ -156,7 +162,7 @@ struct gnix_nic_attr {
  */
 struct gnix_nic {
 	struct dlist_entry gnix_nic_list; /* global NIC list */
-	struct dlist_entry dom_nic_list;  /* domain NIC list */
+	struct dlist_entry ptag_nic_list; /* global PTAG NIC list */
 	fastlock_t lock;
 	uint32_t allocd_gni_res;
 	gni_cdm_handle_t gni_cdm_hndl;
@@ -354,12 +360,6 @@ struct gnix_tx_descriptor {
 };
 
 /*
- * globals
- */
-
-extern uint32_t gnix_def_max_nics_per_ptag;
-
-/*
  * prototypes
  */
 
@@ -469,5 +469,10 @@ static inline void *__gnix_nic_elem_by_rem_id(struct gnix_nic *nic, int rem_id)
 
 void _gnix_nic_txd_err_inject(struct gnix_nic *nic,
 			      struct gnix_tx_descriptor *txd);
+
+/**
+ * @brief Initialize global NIC data.
+ */
+void _gnix_nic_init(void);
 
 #endif /* _GNIX_NIC_H_ */

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -563,7 +563,6 @@ GNI_INI
 	gni_return_t status;
 	gni_version_info_t lib_version;
 	int num_devices;
-	int rc;
 
 	/*
 	 * if no GNI devices available, don't register as provider
@@ -592,33 +591,14 @@ GNI_INI
 		provider = &gnix_prov;
 	}
 
-	rc = _gnix_nics_per_rank(&gnix_max_nics_per_ptag);
-	if (rc == FI_SUCCESS) {
-		GNIX_INFO(FI_LOG_FABRIC, "gnix_max_nics_per_ptag: %u\n",
-			  gnix_max_nics_per_ptag);
-	} else {
-		GNIX_WARN(FI_LOG_FABRIC, "_gnix_nics_per_rank failed: %d\n",
-			  rc);
-	}
+	/* Initialize global MR notifier. */
+	_gnix_notifier_init();
 
-	if (getenv("GNIX_MAX_NICS") != NULL)
-		gnix_max_nics_per_ptag = atoi(getenv("GNIX_MAX_NICS"));
+	/* Initialize global NIC data. */
+	_gnix_nic_init();
 
 	if (getenv("GNIX_DISABLE_XPMEM") != NULL)
 		gnix_xpmem_disabled = true;
-
-	/*
-	 * well if we didn't get 1 nic, that means we must really be doing
-	 * FMA sharing.
-	 */
-
-	if (gnix_max_nics_per_ptag == 0) {
-		gnix_max_nics_per_ptag = 1;
-		GNIX_WARN(FI_LOG_FABRIC, "Using inter-procss FMA sharing\n");
-	}
-
-	/* Initialize global MR notifier. */
-	_gnix_notifier_init();
 
 	return (provider);
 }

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -198,7 +198,7 @@ DIRECT_FN int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 	domain = container_of(fid, struct gnix_fid_domain, domain_fid.fid);
 
 	/* If the nic list is empty, create a nic */
-	if (unlikely(dlist_empty(&domain->nic_list))) {
+	if (unlikely((dlist_empty(&gnix_nic_list_ptag[domain->ptag])))) {
 		rc = gnix_nic_alloc(domain, NULL, &nic);
 		if (rc) {
 			GNIX_INFO(FI_LOG_MR,
@@ -312,7 +312,7 @@ static inline void *__gnix_generic_register(
 	struct gnix_nic *nic;
 	gni_return_t grc = GNI_RC_SUCCESS;
 
-	dlist_for_each(&domain->nic_list, nic, dom_nic_list)
+	dlist_for_each(&gnix_nic_list_ptag[domain->ptag], nic, ptag_nic_list)
 	{
 		COND_ACQUIRE(nic->requires_lock, &nic->lock);
 		grc = GNI_MemRegister(nic->gni_nic_hndl, (uint64_t) address,


### PR DESCRIPTION
-Implement fi_reject
-Stub for fi_shutdown (no quiesce of EP is done before EQE is generated)
-Fixes for EQE error event error buffers
-Dissasociate NIC from domain to allow MSG EPs to share GNIX NICs despite using
 different domains
-Implement PEP getopt

@sungeunchoi 
upstream merge of ofi-cray/libfabric-cray#1085

Signed-off-by: Zach <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@20f61eecfc351ff8b4b4e7ed2e591a84a1d14ba7)