### PR TITLE
prov/gni: Move htd_buf from fab_req.msg to fab_req

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -134,7 +134,7 @@
  *
  * Note: "* 2" for head and tail
  */
-#define GNIX_HTD_BUF_SZ (GNIX_MAX_MSG_IOV_LIMIT * GNI_READ_ALIGN * 2)
+#define GNIX_INT_TX_BUF_SZ (GNIX_MAX_MSG_IOV_LIMIT * GNI_READ_ALIGN * 2)
 
 /*
  * Flags
@@ -452,14 +452,14 @@ struct gnix_fid_ep_ops_en {
 	uint32_t atomic_write_allowed: 1;
 };
 
-#define GNIX_HTD_POOL_SIZE 128
+#define GNIX_INT_TX_POOL_SIZE 128
 
-struct gnix_htd_buf {
+struct gnix_int_tx_buf {
 	struct slist_entry e;
 	uint8_t *buf;
 };
 
-struct gnix_htd_pool {
+struct gnix_int_tx_pool {
 	bool enabled;
 	fastlock_t lock;
 	struct gnix_fid_mem_desc *md;
@@ -536,7 +536,7 @@ struct gnix_fid_ep {
 	int min_multi_recv;
 	/* note this free list will be initialized for thread safe */
 	struct gnix_freelist fr_freelist;
-	struct gnix_htd_pool htd_pool;
+	struct gnix_int_tx_pool int_tx_pool;
 	struct gnix_reference ref_cnt;
 	struct gnix_fid_ep_ops_en ep_ops;
 
@@ -751,11 +751,6 @@ struct gnix_fab_req_msg {
 	size_t			     recv_iov_cnt;
 	uint64_t                     recv_flags; /* protocol, API info */
 	size_t			     cum_recv_len;
-
-	/* @var htd_buf->buf "head(H) tail(T) data buf" layout: '[T|T|...|H|H]' */
-	struct slist_entry	     *htd_buf_e;
-	uint8_t			     *htd_buf;
-	gni_mem_handle_t	     htd_mdh;
 
 	uint64_t                     tag;
 	uint64_t                     ignore;
@@ -1002,6 +997,10 @@ struct gnix_fab_req {
 	struct gnix_vc            *vc;
 	int                       (*work_fn)(void *);
 	uint64_t                  flags;
+
+	struct slist_entry           *int_tx_buf_e;
+	uint8_t                      *int_tx_buf;
+	gni_mem_handle_t             int_tx_mdh;
 
 	/* TODO: change the size of this for unaligned data? */
 	struct gnix_tx_descriptor *iov_txds[GNIX_MAX_MSG_IOV_LIMIT];

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -203,8 +203,6 @@ struct gnix_nic {
 	struct gnix_reference ref_cnt;
 	smsg_callback_fn_t const *smsg_callbacks;
 	struct slist err_txds;
-	void *int_bufs;
-	gni_mem_handle_t int_bufs_mdh;
 	gni_mem_handle_t irq_mem_hndl;
 	void *irq_mmap_addr;
 	size_t irq_mmap_len;
@@ -334,7 +332,6 @@ struct gnix_smsg_amo_cntr_hdr {
  * @var id               the id of this descriptor - the value returned
  *                       from GNI_CQ_MSG_ID
  * @var err_list         Error TXD list entry
- * @var int_buf          Intermediate buffer for landing unaligned data, etc.
  * @var tx_failures	 Number of times this transmission descriptor failed.
  */
 struct gnix_tx_descriptor {
@@ -356,7 +353,6 @@ struct gnix_tx_descriptor {
 	int  (*completer_fn)(void *, gni_return_t);
 	int id;
 	struct slist_entry err_list;
-	void *int_buf;
 };
 
 /*

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -698,8 +698,6 @@ static int __gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs)
 {
 	int i, ret = FI_SUCCESS;
 	struct gnix_tx_descriptor *desc_base, *desc_ptr;
-	void *int_bufs;
-	gni_return_t status;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -713,29 +711,11 @@ static int __gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs)
 		goto err;
 	}
 
-	int_bufs = calloc(n_descs, GNIX_CACHELINE_SIZE);
-	if (int_bufs == NULL) {
-		ret = -FI_ENOMEM;
-		goto err_buf_alloc;
-	}
-
-	/* We don't have a domain here to use for caching the registration. */
-	status = GNI_MemRegister(nic->gni_nic_hndl, (uint64_t)int_bufs,
-				 n_descs * GNIX_CACHELINE_SIZE, NULL,
-				 GNI_MEM_READWRITE, 0, &nic->int_bufs_mdh);
-	if (status != GNI_RC_SUCCESS) {
-		ret = gnixu_to_fi_errno(status);
-		goto err_buf_reg;
-	}
-	nic->int_bufs = int_bufs;
-
 	dlist_init(&nic->tx_desc_free_list);
 	dlist_init(&nic->tx_desc_active_list);
 
 	for (i = 0, desc_ptr = desc_base; i < n_descs; i++, desc_ptr++) {
 		desc_ptr->id = i;
-		desc_ptr->int_buf = (void *) ((uint8_t *) int_bufs +
-					      (i * GNIX_CACHELINE_SIZE));
 		dlist_insert_tail(&desc_ptr->list,
 				  &nic->tx_desc_free_list);
 	}
@@ -747,10 +727,6 @@ static int __gnix_nic_tx_freelist_init(struct gnix_nic *nic, int n_descs)
 
 	return ret;
 
-err_buf_reg:
-	free(int_bufs);
-err_buf_alloc:
-	free(desc_base);
 err:
 	return ret;
 
@@ -761,15 +737,7 @@ err:
  */
 static void __gnix_nic_tx_freelist_destroy(struct gnix_nic *nic)
 {
-	gni_return_t status;
-
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
-	status = GNI_MemDeregister(nic->gni_nic_hndl, &nic->int_bufs_mdh);
-	if (status != GNI_RC_SUCCESS)
-		GNIX_WARN(FI_LOG_DOMAIN, "GNI_MemDeregister() failed: %s\n",
-			  gni_err_str[status]);
-	free(nic->int_bufs);
 
 	free(nic->tx_desc_base);
 	fastlock_destroy(&nic->tx_desc_lock);

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -131,7 +131,7 @@ static void __gnix_rma_copy_indirect_get_data(struct gnix_tx_descriptor *txd)
 	int head_off = req->rma.rem_addr & GNI_READ_ALIGN_MASK;
 
 	memcpy((void *)req->rma.loc_addr,
-	       (void *) ((uint8_t *) txd->int_buf + head_off),
+	       (void *) ((uint8_t *) req->int_tx_buf + head_off),
 	       req->rma.len);
 }
 
@@ -149,7 +149,7 @@ static void __gnix_rma_copy_chained_get_data(struct gnix_tx_descriptor *txd)
 		GNIX_INFO(FI_LOG_EP_DATA, "writing %d bytes to %p\n",
 			  head_len, req->rma.loc_addr);
 		memcpy((void *)req->rma.loc_addr,
-		       (void *) ((uint8_t *) txd->int_buf + head_off),
+		       (void *) ((uint8_t *) req->int_tx_buf + head_off),
 		       head_len);
 	}
 
@@ -161,7 +161,7 @@ static void __gnix_rma_copy_chained_get_data(struct gnix_tx_descriptor *txd)
 		GNIX_INFO(FI_LOG_EP_DATA, "writing %d bytes to %p\n",
 			  tail_len, addr);
 		memcpy((void *)addr,
-		       (void *) ((uint8_t *) txd->int_buf + GNI_READ_ALIGN),
+		       (void *) ((uint8_t *) req->int_tx_buf + GNI_READ_ALIGN),
 		       tail_len);
 	}
 }
@@ -511,6 +511,17 @@ static void __gnix_rma_fill_pd_chained_get(struct gnix_fab_req *req,
 {
 	int head_off, head_len, tail_len, desc_idx = 0;
 	struct gnix_fid_mem_desc *loc_md;
+	struct gnix_fid_ep *ep = req->gnix_ep;
+
+	if (req->int_tx_buf_e == NULL) {
+		req->int_tx_buf_e = _gnix_ep_get_int_tx_buf(ep);
+		if (req->int_tx_buf_e == NULL)
+			GNIX_FATAL(FI_LOG_EP_DATA, "RAN OUT OF INT_TX_BUFS");
+			/* TODO Create growable list of buffers */
+	}
+
+	req->int_tx_buf = ((struct gnix_int_tx_buf *) req->int_tx_buf_e)->buf;
+	req->int_tx_mdh = _gnix_ep_get_int_tx_mdh(ep);
 
 	/* Copy head and tail through intermediate buffer.  Copy
 	 * aligned data directly to user buffer. */
@@ -533,10 +544,8 @@ static void __gnix_rma_fill_pd_chained_get(struct gnix_fab_req *req,
 		txd->gni_ct_descs[0].remote_addr =
 				req->rma.rem_addr & ~GNI_READ_ALIGN_MASK;
 		txd->gni_ct_descs[0].remote_mem_hndl = *rem_mdh;
-		txd->gni_ct_descs[0].local_addr =
-				(uint64_t)txd->int_buf;
-		txd->gni_ct_descs[0].local_mem_hndl =
-				req->vc->ep->nic->int_bufs_mdh;
+		txd->gni_ct_descs[0].local_addr = (uint64_t)req->int_tx_buf;
+		txd->gni_ct_descs[0].local_mem_hndl = req->int_tx_mdh;
 
 		if (tail_len)
 			txd->gni_ct_descs[0].next_descr =
@@ -555,9 +564,8 @@ static void __gnix_rma_fill_pd_chained_get(struct gnix_fab_req *req,
 				 req->rma.len) & ~GNI_READ_ALIGN_MASK;
 		txd->gni_ct_descs[desc_idx].remote_mem_hndl = *rem_mdh;
 		txd->gni_ct_descs[desc_idx].local_addr =
-				(uint64_t)txd->int_buf + GNI_READ_ALIGN;
-		txd->gni_ct_descs[desc_idx].local_mem_hndl =
-				req->vc->ep->nic->int_bufs_mdh;
+				(uint64_t)req->int_tx_buf + GNI_READ_ALIGN;
+		txd->gni_ct_descs[desc_idx].local_mem_hndl = req->int_tx_mdh;
 		txd->gni_ct_descs[desc_idx].next_descr = NULL;
 	}
 
@@ -573,10 +581,21 @@ static void __gnix_rma_fill_pd_indirect_get(struct gnix_fab_req *req,
 					    struct gnix_tx_descriptor *txd)
 {
 	int head_off = req->rma.rem_addr & GNI_READ_ALIGN_MASK;
+	struct gnix_fid_ep *ep = req->gnix_ep;
+
+	if (req->int_tx_buf_e == NULL) {
+		req->int_tx_buf_e = _gnix_ep_get_int_tx_buf(ep);
+		if (req->int_tx_buf_e == NULL)
+			GNIX_FATAL(FI_LOG_EP_DATA, "RAN OUT OF INT_TX_BUFS");
+			/* TODO Create growable list of buffers */
+	}
+
+	req->int_tx_buf = ((struct gnix_int_tx_buf *) req->int_tx_buf_e)->buf;
+	req->int_tx_mdh = _gnix_ep_get_int_tx_mdh(ep);
 
 	/* Copy all data through an intermediate buffer. */
-	txd->gni_desc.local_addr = (uint64_t)txd->int_buf;
-	txd->gni_desc.local_mem_hndl = req->vc->ep->nic->int_bufs_mdh;
+	txd->gni_desc.local_addr = (uint64_t)req->int_tx_buf;
+	txd->gni_desc.local_mem_hndl = req->int_tx_mdh;
 	txd->gni_desc.length = CEILING(req->rma.len + head_off, GNI_READ_ALIGN);
 	txd->gni_desc.remote_addr =
 			(uint64_t)req->rma.rem_addr & ~GNI_READ_ALIGN_MASK;
@@ -642,6 +661,17 @@ int _gnix_rma_post_rdma_chain_req(void *data)
 	int head_off, head_len, tail_len;
 	int fma_chain = 0;
 
+	if (req->int_tx_buf_e == NULL) {
+		req->int_tx_buf_e = _gnix_ep_get_int_tx_buf(ep);
+		if (req->int_tx_buf_e == NULL)
+			GNIX_FATAL(FI_LOG_EP_DATA, "RAN OUT OF INT_TX_BUFS");
+			return -FI_ENOSPC;
+			/* TODO Create growable list of buffers */
+	}
+
+	req->int_tx_buf = ((struct gnix_int_tx_buf *) req->int_tx_buf_e)->buf;
+	req->int_tx_mdh = _gnix_ep_get_int_tx_mdh(ep);
+
 	if (!gnix_ops_allowed(ep, req->vc->peer_caps, req->flags)) {
 		rc = __gnix_rma_post_err_no_retrans(req, FI_EOPNOTSUPP);
 		if (rc != FI_SUCCESS)
@@ -704,13 +734,13 @@ int _gnix_rma_post_rdma_chain_req(void *data)
 	ct_txd->gni_desc.remote_mem_hndl = mdh;
 	ct_txd->gni_desc.rdma_mode = 0; /* check flags */
 	ct_txd->gni_desc.src_cq_hndl = nic->tx_cq; /* check flags */
-	ct_txd->gni_desc.local_mem_hndl = nic->int_bufs_mdh;
+	ct_txd->gni_desc.local_mem_hndl = req->int_tx_mdh;
 	ct_txd->gni_desc.length = GNI_READ_ALIGN;
 
 	if (head_off) {
 		ct_txd->gni_desc.remote_addr =
 				req->rma.rem_addr & ~GNI_READ_ALIGN_MASK;
-		ct_txd->gni_desc.local_addr = (uint64_t)ct_txd->int_buf;
+		ct_txd->gni_desc.local_addr = (uint64_t)req->int_tx_buf;
 
 		if (tail_len) {
 			ct_txd->gni_desc.next_descr = &ct_txd->gni_ct_descs[0];
@@ -721,10 +751,10 @@ int _gnix_rma_post_rdma_chain_req(void *data)
 					 req->rma.len) & ~GNI_READ_ALIGN_MASK;
 			ct_txd->gni_ct_descs[0].remote_mem_hndl = mdh;
 			ct_txd->gni_ct_descs[0].local_addr =
-					(uint64_t)ct_txd->int_buf +
+					(uint64_t)req->int_tx_buf +
 					GNI_READ_ALIGN;
 			ct_txd->gni_ct_descs[0].local_mem_hndl =
-					nic->int_bufs_mdh;
+					req->int_tx_mdh;
 			ct_txd->gni_ct_descs[0].next_descr = NULL;
 			fma_chain = 1;
 		}
@@ -733,7 +763,7 @@ int _gnix_rma_post_rdma_chain_req(void *data)
 				(req->rma.rem_addr +
 				 req->rma.len) & ~GNI_READ_ALIGN_MASK;
 		ct_txd->gni_desc.local_addr =
-				(uint64_t)ct_txd->int_buf + GNI_READ_ALIGN;
+				(uint64_t)req->int_tx_buf + GNI_READ_ALIGN;
 	}
 
 	GNIX_LOG_DUMP_TXD(ct_txd);


### PR DESCRIPTION
Now that htd_bufs are available on the top level fab_req
utilize that as the intermediate buffer for chained gets
and remove the int_buf.


Fixes ofi-cray/libfabric-cray#1087
Fixes ofi-cray/libfabric-cray#1077
Fixes ofi-cray/libfabric-cray#1091

upstream merge of ofi-cray/libfabric-cray#1090

@sungeunchoi 
Signed-off-by: Amith Abraham <aabraham@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@7a0fa249f19aeb5e5c985a3e996ed57e609a9cb7)
(cherry picked from commit ofi-cray/libfabric-cray@8f11bd30e6d004cf44024c903ccb6bd697c17615)
(cherry picked from commit ofi-cray/libfabric-cray@06f34aa87822c54cfb8a9f861a3b47ccee318f85)