### PR TITLE
prov/gni: return statement on incorrect level

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -966,9 +966,10 @@ static int __gnix_rndzv_req(void *arg)
 
 		if (req->int_tx_buf_e == NULL) {
 			req->int_tx_buf_e = _gnix_ep_get_int_tx_buf(ep);
-			if (req->int_tx_buf_e == NULL)
+			if (req->int_tx_buf_e == NULL) {
 				GNIX_WARN(FI_LOG_EP_DATA,
 					  "RAN OUT OF INT_TX_BUFS");
+			}
 		}
 
 		req->int_tx_buf = ((struct gnix_int_tx_buf *)

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -515,9 +515,10 @@ static void __gnix_rma_fill_pd_chained_get(struct gnix_fab_req *req,
 
 	if (req->int_tx_buf_e == NULL) {
 		req->int_tx_buf_e = _gnix_ep_get_int_tx_buf(ep);
-		if (req->int_tx_buf_e == NULL)
+		if (req->int_tx_buf_e == NULL) {
 			GNIX_FATAL(FI_LOG_EP_DATA, "RAN OUT OF INT_TX_BUFS");
 			/* TODO Create growable list of buffers */
+		}
 	}
 
 	req->int_tx_buf = ((struct gnix_int_tx_buf *) req->int_tx_buf_e)->buf;
@@ -585,9 +586,10 @@ static void __gnix_rma_fill_pd_indirect_get(struct gnix_fab_req *req,
 
 	if (req->int_tx_buf_e == NULL) {
 		req->int_tx_buf_e = _gnix_ep_get_int_tx_buf(ep);
-		if (req->int_tx_buf_e == NULL)
+		if (req->int_tx_buf_e == NULL) {
 			GNIX_FATAL(FI_LOG_EP_DATA, "RAN OUT OF INT_TX_BUFS");
 			/* TODO Create growable list of buffers */
+		}
 	}
 
 	req->int_tx_buf = ((struct gnix_int_tx_buf *) req->int_tx_buf_e)->buf;
@@ -663,10 +665,11 @@ int _gnix_rma_post_rdma_chain_req(void *data)
 
 	if (req->int_tx_buf_e == NULL) {
 		req->int_tx_buf_e = _gnix_ep_get_int_tx_buf(ep);
-		if (req->int_tx_buf_e == NULL)
+		if (req->int_tx_buf_e == NULL) {
 			GNIX_FATAL(FI_LOG_EP_DATA, "RAN OUT OF INT_TX_BUFS");
 			return -FI_ENOSPC;
 			/* TODO Create growable list of buffers */
+		}
 	}
 
 	req->int_tx_buf = ((struct gnix_int_tx_buf *) req->int_tx_buf_e)->buf;


### PR DESCRIPTION
returning -FI_ENOSPC is not contained in the correct
if statement. Adding curly braces to correct issue
and to avoid the issue in the future in other areas.

Fixes ofi-cray/libfabric-cray#1093

upstream merge of ofi-cray/libfabric-cray#1094
@sungeunchoi 

Signed-off-by: Amith Abraham <aabraham@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@8fad7a55c031c46ca8babb8b0dba27cc40d23bc0)