### PR TITLE
prov/gni: some opts for KNL

### DIFF
--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -205,11 +205,11 @@ static inline void _gnix_ep_release_int_tx_buf(struct gnix_fid_ep *ep,
 static inline struct gnix_fab_req *
 _gnix_fr_alloc(struct gnix_fid_ep *ep)
 {
-	struct dlist_entry *de;
+	struct dlist_entry *de = NULL;
 	struct gnix_fab_req *fr = NULL;
 	int ret = _gnix_fl_alloc(&de, &ep->fr_freelist);
 
-	while (ret == -FI_EAGAIN)
+	while (unlikely(ret == -FI_EAGAIN))
 		ret = _gnix_fl_alloc(&de, &ep->fr_freelist);
 
 	if (ret == FI_SUCCESS) {

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -651,46 +651,6 @@ err:
 }
 
 /*
- * allocate a tx desc for this nic
- */
-
-int _gnix_nic_tx_alloc(struct gnix_nic *nic,
-		       struct gnix_tx_descriptor **desc)
-{
-	struct dlist_entry *entry;
-
-	COND_ACQUIRE(nic->requires_lock, &nic->tx_desc_lock);
-	if (dlist_empty(&nic->tx_desc_free_list)) {
-		COND_RELEASE(nic->requires_lock, &nic->tx_desc_lock);
-		return -FI_ENOSPC;
-	}
-
-	entry = nic->tx_desc_free_list.next;
-	dlist_remove_init(entry);
-	dlist_insert_head(entry, &nic->tx_desc_active_list);
-	*desc = dlist_entry(entry, struct gnix_tx_descriptor, list);
-	COND_RELEASE(nic->requires_lock, &nic->tx_desc_lock);
-
-	return FI_SUCCESS;
-}
-
-/*
- * free a tx desc for this nic - the nic is not embedded in the
- * descriptor to help keep it small
- */
-
-int _gnix_nic_tx_free(struct gnix_nic *nic,
-		      struct gnix_tx_descriptor *desc)
-{
-	COND_ACQUIRE(nic->requires_lock, &nic->tx_desc_lock);
-	dlist_remove_init(&desc->list);
-	dlist_insert_head(&desc->list, &nic->tx_desc_free_list);
-	COND_RELEASE(nic->requires_lock, &nic->tx_desc_lock);
-
-	return FI_SUCCESS;
-}
-
-/*
  * allocate a free list of tx descs for a gnix_nic struct.
  */
 

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1420,7 +1420,7 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 	int remote_id;
 	struct gnix_vc *vc_ptr = NULL;
 	struct gnix_nic *nic = NULL;
-	struct dlist_entry *de;
+	struct dlist_entry *de = NULL;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -1729,27 +1729,6 @@ int _gnix_vc_disconnect(struct gnix_vc *vc)
 	vc->conn_state = GNIX_VC_CONN_TERMINATED;
 	return FI_SUCCESS;
 }
-
-/* Return 0 if VC is connected.  Progress VC CM if not. */
-static int __gnix_vc_connected(struct gnix_vc *vc)
-{
-	struct gnix_cm_nic *cm_nic;
-	int ret;
-
-	if (unlikely(vc->conn_state < GNIX_VC_CONNECTED)) {
-		cm_nic = vc->ep->cm_nic;
-		ret = _gnix_cm_nic_progress(cm_nic);
-		if ((ret != FI_SUCCESS) && (ret != -FI_EAGAIN))
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				"_gnix_cm_nic_progress() failed: %s\n",
-			fi_strerror(-ret));
-		/* waiting to connect, check back later */
-		return -FI_EAGAIN;
-	}
-
-	return 0;
-}
-
 
 /******************************************************************************
  *


### PR DESCRIPTION
move some functions to header files to allow for inlining.
This tends to help with KNL processor.

inline attribute in the wrong place was causing gcc
to complain.

upstream merge of ofi-cray/libfabric-cray#1096
upstream merge of ofi-cray/libfabric-cray#1100

@sungeunchoi 

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>
(cherry picked from commit ofi-cray/libfabric-cray@9bfbd81633afe8ef89d0a350dc874d78f29975c9)
(cherry picked from commit ofi-cray/libfabric-cray@a76d6b24540d1d07e06e5178b9d946ea9d86fa64)