### PR TITLE
prov/psm2: Set FI_REMOTE_CQ_DATA flag properly in recv completions

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -96,6 +96,7 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_MSG_BIT	(0x80000000)
 #define PSMX2_RMA_BIT	(0x40000000)
 #define PSMX2_IOV_BIT	(0x20000000)
+#define PSMX2_IMM_BIT	(0x10000000)
 #define PSMX2_SEQ_BITS	(0x0FFF0000)
 #define PSMX2_SRC_BITS	(0x0000FF00)
 #define PSMX2_DST_BITS	(0x000000FF)

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -191,6 +191,8 @@ psmx2_cq_create_event_from_status(struct psmx2_fid_cq *cq,
 		op_context = fi_context;
 		buf = PSMX2_CTXT_USER(fi_context);
 		flags = FI_RECV | FI_MSG;
+		if (psm2_status->msg_tag.tag2 & PSMX2_IMM_BIT)
+			flags |= FI_REMOTE_CQ_DATA;
 		is_recv = 1;
 		break;
 	case PSMX2_MULTI_RECV_CONTEXT:
@@ -198,6 +200,8 @@ psmx2_cq_create_event_from_status(struct psmx2_fid_cq *cq,
 		req = PSMX2_CTXT_USER(fi_context);
 		buf = req->buf + req->offset;
 		flags = FI_RECV | FI_MSG;
+		if (psm2_status->msg_tag.tag2 & PSMX2_IMM_BIT)
+			flags |= FI_REMOTE_CQ_DATA;
 		if (req->offset + psm2_status->nbytes + req->min_buf_size > req->len)
 			flags |= FI_MULTI_RECV;	/* buffer used up */
 		is_recv = 1;


### PR DESCRIPTION
Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>