### PR TITLE
prov/gnix: Migrate away from NDEBUG in print macro

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -48,7 +48,7 @@ extern struct fi_provider gnix_prov;
  * For debug logging (#undef NDEBUG)
  * Q: should this just always be available?
  */
-#ifdef NDEBUG
+#ifdef ENABLE_DEBUG
 
 #define GNIX_LOG_INTERNAL(FI_LOG_FN, LEVEL, subsystem, fmt, ...)	\
 	FI_LOG_FN(&gnix_prov, subsystem, fmt, ##__VA_ARGS__)


### PR DESCRIPTION
In the gnix provider, we used NDEBUG to determine whether we added additional debug information. To make this more consistent with configure provided options, it will change from NDEBUG to ENABLE_DEBUG.

To enable debug information with the GNIX provider, add --enable-debug to configure time options.
upstream merge of ofi-cray/libfabric-cray#1101
@sungeunchoi 

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@cb870ab97a198da9251915d1460fd79a99b2edc8)