### PR TITLE
Clarify fi_cq.3.md on available errors

### DIFF
--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -343,9 +343,9 @@ successfully.  Operations which fail are reported 'out of band'.  Such
 operations are retrieved using the fi_cq_readerr function.  When an
 operation that completes with an unexpected error is inserted into a
 CQ, it is placed into a temporary error queue.  Attempting to read
-from a CQ while an item is in the error queue results in an FI_EAVAIL
-failure.  Applications may use this return code to determine when to
-call fi_cq_readerr.
+from a CQ while an item is in the error queue results in a failure
+with a return code of -FI_EAVAIL.  Applications may use this return 
+code to determine when to call fi_cq_readerr.
 
 ## fi_cq_sread / fi_cq_sreadfrom
 


### PR DESCRIPTION
I found it personally confusing that FI_EAVAIL was written without
a negative sign in the fi_cq man page. This updates it to exactly
specify what the value of the error code will be in the case of an
error being present in the error queue.

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>