### PR TITLE
prov/udp: Fix setting address format incorrectly

### DIFF
--- a/prov/udp/src/udpx_attr.c
+++ b/prov/udp/src/udpx_attr.c
@@ -81,7 +81,7 @@ struct fi_fabric_attr udpx_fabric_attr = {
 
 struct fi_info udpx_info = {
 	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE, /* | FI_MULTI_RECV, */
-	.addr_format = FI_SOCKADDR_IN,
+	.addr_format = FI_SOCKADDR,
 	.tx_attr = &udpx_tx_attr,
 	.rx_attr = &udpx_rx_attr,
 	.ep_attr = &udpx_ep_attr,

--- a/prov/udp/src/udpx_init.c
+++ b/prov/udp/src/udpx_init.c
@@ -46,6 +46,7 @@ static void udpx_getinfo_ifs(struct fi_info **info)
 	struct ifaddrs *ifaddrs, *ifa;
 	struct fi_info *head, *tail, *cur;
 	size_t addrlen;
+	uint32_t addr_format;
 	int ret;
 
 	ret = getifaddrs(&ifaddrs);
@@ -60,9 +61,11 @@ static void udpx_getinfo_ifs(struct fi_info **info)
 		switch (ifa->ifa_addr->sa_family) {
 		case AF_INET:
 			addrlen = sizeof(struct sockaddr_in);
+			addr_format = FI_SOCKADDR_IN;
 			break;
 		case AF_INET6:
 			addrlen = sizeof(struct sockaddr_in6);
+			addr_format = FI_SOCKADDR_IN6;
 			break;
 		default:
 			continue;
@@ -78,8 +81,10 @@ static void udpx_getinfo_ifs(struct fi_info **info)
 			tail->next = cur;
 		tail = cur;
 
-		if ((cur->src_addr = mem_dup(ifa->ifa_addr, addrlen)))
+		if ((cur->src_addr = mem_dup(ifa->ifa_addr, addrlen))) {
 			cur->src_addrlen = addrlen;
+			cur->addr_format = addr_format;
+		}
 	}
 	freeifaddrs(ifaddrs);
 


### PR DESCRIPTION
The UDP provider incorrectly uses the previous fi_info structure
to set the address format when reporting available source addresses.
We should instead set the address format based on the address family
of the source address.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>