### PR TITLE
prov/verbs: fixed issues in verbs shutdown

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -296,6 +296,7 @@ struct fi_ibv_rdm_ep {
 	int cm_progress_timeout;
 	int is_closing;
 	int recv_preposted_threshold;
+	struct slist av_removed_conn_head;
 };
 
 enum {
@@ -363,6 +364,7 @@ struct fi_ibv_rdm_conn {
 	size_t unexp_counter;
 	size_t exp_counter;
 #endif
+	struct slist_entry removed_next;
 };
 
 struct fi_ibv_rdm_postponed_entry {
@@ -505,6 +507,7 @@ static inline void fi_ibv_rdm_cntr_inc_err(struct fi_ibv_rdm_cntr *cntr)
 }
 
 int fi_ibv_rdm_tagged_poll(struct fi_ibv_rdm_ep *ep);
+int fi_ibv_rdm_tagged_poll_recv(struct fi_ibv_rdm_ep *ep);
 ssize_t fi_ibv_rdm_cm_progress(struct fi_ibv_rdm_ep *ep);
 ssize_t fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_conn *conn);
 ssize_t fi_ibv_rdm_conn_cleanup(struct fi_ibv_rdm_conn *conn);

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -38,7 +38,6 @@
 #include "verbs_utils.h"
 #include "verbs_rdm.h"
 
-
 extern struct fi_provider fi_ibv_prov;
 
 static struct ibv_mr *
@@ -563,6 +562,7 @@ ssize_t fi_ibv_rdm_conn_cleanup(struct fi_ibv_rdm_conn *conn)
 			if (ret == FI_SUCCESS)
 				ret = -errno;
 		}
+		conn->id[0] = NULL;
 	}
 
 	if (conn->id[1]) {
@@ -578,6 +578,7 @@ ssize_t fi_ibv_rdm_conn_cleanup(struct fi_ibv_rdm_conn *conn)
 			if (ret == FI_SUCCESS)
 				ret = -errno;
 		}
+		conn->id[1] = NULL;
 	}
 
 	if (conn->s_mr) {
@@ -599,6 +600,7 @@ ssize_t fi_ibv_rdm_conn_cleanup(struct fi_ibv_rdm_conn *conn)
 			if (ret == FI_SUCCESS)
 				ret = -errno;
 		}
+		conn->ack_mr = NULL;
 	}
 
 	if (conn->rma_mr) {
@@ -621,19 +623,12 @@ fi_ibv_rdm_process_event_disconnected(struct fi_ibv_rdm_ep *ep,
 
 	ep->num_active_conns--;
 	
-	if (conn->state == FI_VERBS_CONN_ESTABLISHED) {
-		conn->state = FI_VERBS_CONN_REMOTE_DISCONNECT;
-	} else {
-		assert(conn->state == FI_VERBS_CONN_LOCAL_DISCONNECT);
-		conn->state = FI_VERBS_CONN_CLOSED;
-	}
+	conn->state = FI_VERBS_CONN_CLOSED;
+
 	VERBS_INFO(FI_LOG_AV,
 		   "Disconnected from conn %p, addr %s:%u\n",
 		   conn, inet_ntoa(conn->addr.sin_addr),
 		   ntohs(conn->addr.sin_port));
-	if (conn->state == FI_VERBS_CONN_CLOSED) {
-		return fi_ibv_rdm_conn_cleanup(conn);
-	}
 
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
in some cases verbs EP hangs on close: close state was based
on message from RDMA transport which may be lost for unknown
reason.

for now disconnection is detected by flush error, after this
preposted entried are cleaned and QP set to 'closed' state
(free to destroy)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>