### PR TITLE
prov/gni: Fix use of ENABLE_DEBUG for print macros

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -45,10 +45,10 @@
 extern struct fi_provider gnix_prov;
 
 /*
- * For debug logging (#undef NDEBUG)
+ * For debug logging (ENABLE_DEBUG)
  * Q: should this just always be available?
  */
-#ifdef ENABLE_DEBUG
+#ifndef ENABLE_DEBUG
 
 #define GNIX_LOG_INTERNAL(FI_LOG_FN, LEVEL, subsystem, fmt, ...)	\
 	FI_LOG_FN(&gnix_prov, subsystem, fmt, ##__VA_ARGS__)


### PR DESCRIPTION
upstream merge of ofi-cray/libfabric-cray#1115

@sungeunchoi 
Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@ad6fd0dc4d2c1a9efbd3b653a823365d767c8dda)