### PR TITLE
prov/gni: Change use of NDEBUG to ENABLE_DEBUG to

### DIFF
--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -48,7 +48,7 @@
 
 atomic_t gnix_id_counter;
 atomic_t file_id_counter;
-#ifndef NDEBUG
+#ifdef ENABLE_DEBUG
 /* don't think this needs to be in tls */
 __thread pid_t gnix_debug_pid = ~(uint32_t) 0;
 __thread uint32_t gnix_debug_tid = ~(uint32_t) 0;


### PR DESCRIPTION
match logging macros
upstream merge of ofi-cray/libfabric-cray#1117
@sungeunchoi 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@fae15063a178330f3484dd63655a7fbe8acb4f8d)