### PR TITLE
man: clarify FI_MULTI_RECV documentation

### DIFF
--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -521,7 +521,7 @@ operation.  The following completion flags are defined.
   consumed and was released by the provider.  Providers may set
   this flag on the last message that is received into the multi-
   recv buffer, or may generate a separate completion that indicates
-  that the buffer has been freed.
+  that the buffer has been released.
   
   Applications can distinguish between these two cases by examining
   the completion entry flags field.  If additional flags, such as
@@ -530,7 +530,7 @@ operation.  The following completion flags are defined.
   message was placed into the multi-recv buffer.  Other fields in the
   completion entry will be determined based on the received message.
   If other flag bits are zero, the provider is reporting that the multi-recv
-  buffer has been freed, and the completion entry is not associated
+  buffer has been released, and the completion entry is not associated
   with a received message.
 
 # NOTES

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -466,7 +466,7 @@ The following option levels and option names and parameters are defined.
 
 - *FI_OPT_MIN_MULTI_RECV - size_t*
 : Defines the minimum receive buffer space available when the receive
-  buffer is automatically freed (see FI_MULTI_RECV).  Modifying this
+  buffer is released by the provider (see FI_MULTI_RECV).  Modifying this
   value is only guaranteed to set the minimum buffer space needed on
   receives posted after the value has been changed.  It is recommended
   that applications that want to override the default MIN_MULTI_RECV
@@ -1144,10 +1144,9 @@ value of transmit or receive context attributes of an endpoint.
   posted receive operation to generate multiple completions as
   messages are placed into the buffer.  The placement of received data
   into the buffer may be subjected to provider specific alignment
-  restrictions.  The buffer will be returned to the application's
-  control, and an *FI_MULTI_RECV* completion will be generated, when a
-  message is received that cannot fit into the remaining free buffer
-  space.
+  restrictions.  The buffer will be released by the provider when the
+  available buffer space falls below the specified minimum (see
+  FI_OPT_MIN_MULTI_RECV).
 
 *FI_COMPLETION*
 : Indicates that a completion entry should be generated for data

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -242,8 +242,8 @@ fi_sendmsg.
   posted receive operation to generate multiple events as messages are
   placed into the buffer.  The placement of received data into the
   buffer may be subjected to provider specific alignment restrictions.
-  The buffer will be freed from the endpoint when the available buffer
-  space falls below the network's MTU size (see
+  The buffer will be released by the provider when the available buffer
+  space falls below the specified minimum (see
   FI_OPT_MIN_MULTI_RECV).
 
 *FI_INJECT_COMPLETE*


### PR DESCRIPTION
- Get rid of all references to "freeing" the buffer
- Make the fi_msg and fi_endpoint documentation match

Closes #2616 

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>