### PR TITLE
Enhanced triggered support and tagged atomics

### DIFF
--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -186,6 +186,7 @@ static struct fi_ops_domain X = {
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
+	.query_atomic = fi_no_query_atomic,
 };
 */
 int fi_no_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
@@ -204,6 +205,9 @@ int fi_no_stx_context(struct fid_domain *domain, struct fi_tx_attr *attr,
 		struct fid_stx **stx, void *context);
 int fi_no_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		struct fid_ep **rx_ep, void *context);
+int fi_no_query_atomic(struct fid_ep *ep, enum fi_datatype datatype,
+		enum fi_op op, struct fi_atomic_attr *attr, uint64_t flags);
+
 
 /*
 static struct fi_ops_mr X = {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -487,6 +487,9 @@ enum {
 	FI_GET_RAW_MR,		/* fi_mr_raw_attr */
 	FI_MAP_RAW_MR,		/* fi_mr_map_raw */
 	FI_UNMAP_KEY,		/* uint64_t key */
+	FI_QUEUE_WORK,		/* struct fi_deferred_work */
+	FI_CANCEL_WORK,		/* struct fi_deferred_work */
+	FI_FLUSH_WORK,		/* NULL */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -65,6 +65,18 @@ struct fi_msg_atomic {
 	uint64_t		data;
 };
 
+struct fi_msg_fetch {
+	struct fi_ioc		*msg_iov;
+	void			**desc;
+	size_t			iov_count;
+};
+
+struct fi_msg_compare {
+	const struct fi_ioc	*msg_iov;
+	void			**desc;
+	size_t			iov_count;
+};
+
 struct fi_ops_atomic {
 	size_t	size;
 	ssize_t	(*write)(struct fid_ep *ep,

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -42,54 +42,15 @@
 extern "C" {
 #endif
 
-#ifdef FABRIC_DIRECT
-#include <rdma/fi_direct_atomic_def.h>
-#endif /* FABRIC_DIRECT */
 
-#ifndef FABRIC_DIRECT_ATOMIC_DEF
+/* Atomic flags */
+#define FI_FETCH_ATOMIC		(1ULL << 58)
+#define FI_COMPARE_ATOMIC	(1ULL << 59)
 
-enum fi_datatype {
-	FI_INT8,
-	FI_UINT8,
-	FI_INT16,
-	FI_UINT16,
-	FI_INT32,
-	FI_UINT32,
-	FI_INT64,
-	FI_UINT64,
-	FI_FLOAT,
-	FI_DOUBLE,
-	FI_FLOAT_COMPLEX,
-	FI_DOUBLE_COMPLEX,
-	FI_LONG_DOUBLE,
-	FI_LONG_DOUBLE_COMPLEX,
-	FI_DATATYPE_LAST
+struct fi_atomic_attr {
+	size_t			count;
+	size_t			size;
 };
-
-enum fi_op {
-	FI_MIN,
-	FI_MAX,
-	FI_SUM,
-	FI_PROD,
-	FI_LOR,
-	FI_LAND,
-	FI_BOR,
-	FI_BAND,
-	FI_LXOR,
-	FI_BXOR,
-	FI_ATOMIC_READ,
-	FI_ATOMIC_WRITE,
-	FI_CSWAP,
-	FI_CSWAP_NE,
-	FI_CSWAP_LE,
-	FI_CSWAP_LT,
-	FI_CSWAP_GE,
-	FI_CSWAP_GT,
-	FI_MSWAP,
-	FI_ATOMIC_OP_LAST
-};
-
-#endif
 
 struct fi_msg_atomic {
 	const struct fi_ioc	*msg_iov;
@@ -306,6 +267,16 @@ fi_compare_atomicvalid(struct fid_ep *ep,
 		       enum fi_datatype datatype, enum fi_op op, size_t *count)
 {
 	return ep->atomic->compwritevalid(ep, datatype, op, count);
+}
+
+static inline int
+fi_query_atomic(struct fid_domain *domain,
+		enum fi_datatype datatype, enum fi_op op,
+		struct fi_atomic_attr *attr, uint64_t flags)
+{
+	return FI_CHECK_OP(domain->ops, struct fi_ops_domain, query_atomic) ?
+		domain->ops->query_atomic(domain, datatype, op, attr, flags) :
+		-FI_ENOSYS;
 }
 
 #endif

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -108,9 +108,59 @@ struct fi_mr_attr {
 };
 
 
+#ifdef FABRIC_DIRECT
+#include <rdma/fi_direct_atomic_def.h>
+#endif /* FABRIC_DIRECT */
+
+#ifndef FABRIC_DIRECT_ATOMIC_DEF
+
+enum fi_datatype {
+	FI_INT8,
+	FI_UINT8,
+	FI_INT16,
+	FI_UINT16,
+	FI_INT32,
+	FI_UINT32,
+	FI_INT64,
+	FI_UINT64,
+	FI_FLOAT,
+	FI_DOUBLE,
+	FI_FLOAT_COMPLEX,
+	FI_DOUBLE_COMPLEX,
+	FI_LONG_DOUBLE,
+	FI_LONG_DOUBLE_COMPLEX,
+	FI_DATATYPE_LAST
+};
+
+enum fi_op {
+	FI_MIN,
+	FI_MAX,
+	FI_SUM,
+	FI_PROD,
+	FI_LOR,
+	FI_LAND,
+	FI_BOR,
+	FI_BAND,
+	FI_LXOR,
+	FI_BXOR,
+	FI_ATOMIC_READ,
+	FI_ATOMIC_WRITE,
+	FI_CSWAP,
+	FI_CSWAP_NE,
+	FI_CSWAP_LE,
+	FI_CSWAP_LT,
+	FI_CSWAP_GE,
+	FI_CSWAP_GT,
+	FI_MSWAP,
+	FI_ATOMIC_OP_LAST
+};
+
+#endif
+
+
+struct fi_atomic_attr;
 struct fi_cq_attr;
 struct fi_cntr_attr;
-
 
 struct fi_ops_domain {
 	size_t	size;
@@ -132,6 +182,9 @@ struct fi_ops_domain {
 	int	(*srx_ctx)(struct fid_domain *domain,
 			struct fi_rx_attr *attr, struct fid_ep **rx_ep,
 			void *context);
+	int	(*query_atomic)(struct fid_domain *domain,
+			enum fi_datatype datatype, enum fi_op op,
+			struct fi_atomic_attr *attr, uint64_t flags);
 };
 
 

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -105,7 +105,6 @@ struct fi_ops_cm;
 struct fi_ops_rma;
 struct fi_ops_tagged;
 struct fi_ops_atomic;
-/* struct fi_ops_collectives; */
 
 /*
  * Calls which modify the properties of a endpoint (control, setopt, bind, ...)

--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -34,6 +34,10 @@
 #define FI_TRIGGER_H
 
 #include <rdma/fabric.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_atomic.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,9 +47,67 @@ enum fi_trigger_event {
 	FI_TRIGGER_THRESHOLD,
 };
 
+enum fi_trigger_op {
+	FI_OP_RECV,
+	FI_OP_SEND,
+	FI_OP_TRECV,
+	FI_OP_TSEND,
+	FI_OP_READ,
+	FI_OP_WRITE,
+	FI_OP_ATOMIC,
+	FI_OP_FETCH_ATOMIC,
+	FI_OP_COMPARE_ATOMIC,
+	FI_OP_CNTR_SET,
+	FI_OP_CNTR_ADD
+};
+
 struct fi_trigger_threshold {
 	struct fid_cntr		*cntr;
 	size_t			threshold;
+};
+
+struct fi_op_msg {
+	struct fid_ep		*ep;
+	struct fi_msg		msg;
+	uint64_t		flags;
+};
+
+struct fi_op_tagged {
+	struct fid_ep		*ep;
+	struct fi_msg_tagged	msg;
+	uint64_t		flags;
+};
+
+struct fi_op_rma {
+	struct fid_ep		*ep;
+	struct fi_msg_rma	msg;
+	uint64_t		flags;
+};
+
+struct fi_op_atomic {
+	struct fid_ep		*ep;
+	struct fi_msg_atomic	msg;
+	uint64_t		flags;
+};
+
+struct fi_op_fetch_atomic {
+	struct fid_ep		*ep;
+	struct fi_msg_atomic	msg;
+	struct fi_msg_fetch	fetch;
+	uint64_t		flags;
+};
+
+struct fi_op_compare_atomic {
+	struct fid_ep		*ep;
+	struct fi_msg_atomic	msg;
+	struct fi_msg_fetch	fetch;
+	struct fi_msg_compare	compare;
+	uint64_t		flags;
+};
+
+struct fi_op_cntr {
+	struct fid_cntr		*cntr;
+	uint64_t		value;
 };
 
 #ifdef FABRIC_DIRECT
@@ -56,11 +118,32 @@ struct fi_trigger_threshold {
 
 /* Size must match struct fi_context */
 struct fi_triggered_context {
-	enum fi_trigger_event	event_type;
+	enum fi_trigger_event			event_type;
 	union {
 		struct fi_trigger_threshold	threshold;
 		void				*internal[3];
 	} trigger;
+};
+
+struct fi_deferred_work {
+	struct fi_context			context;
+
+	enum fi_trigger_event			event_type;
+	enum fi_trigger_op			op_type;
+
+	union {
+		struct fi_trigger_threshold	*threshold;
+	} event;
+
+	union {
+		struct fi_op_msg		*msg;
+		struct fi_op_tagged		*tagged;
+		struct fi_op_rma		*rma;
+		struct fi_op_atomic		*atomic;
+		struct fi_op_fetch_atomic	*fetch_atomic;
+		struct fi_op_compare_atomic	*compare_atomic;
+		struct fi_op_cntr		*cntr;
+	} op;
 };
 
 #endif

--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -45,6 +45,7 @@ extern "C" {
 
 enum fi_trigger_event {
 	FI_TRIGGER_THRESHOLD,
+	FI_TRIGGER_COMPLETION
 };
 
 enum fi_trigger_op {
@@ -64,6 +65,10 @@ enum fi_trigger_op {
 struct fi_trigger_threshold {
 	struct fid_cntr		*cntr;
 	size_t			threshold;
+};
+
+struct fi_trigger_completion {
+	struct fi_context	*context;
 };
 
 struct fi_op_msg {
@@ -133,6 +138,7 @@ struct fi_deferred_work {
 
 	union {
 		struct fi_trigger_threshold	*threshold;
+		struct fi_trigger_completion	*completion;
 	} event;
 
 	union {

--- a/man/fi_trigger.3.md
+++ b/man/fi_trigger.3.md
@@ -72,18 +72,18 @@ The following trigger events are defined.
   value.  The threshold is specified using struct
   fi_trigger_threshold:
 
-```c
-struct fi_trigger_threshold {
+  ```c
+  struct fi_trigger_threshold {
 	struct fid_cntr *cntr; /* event counter to check */
 	size_t threshold;      /* threshold value */
-};
-```
+  };
+  ```
 
-Threshold operations are triggered in the order of the threshold
-values.  This is true even if the counter increments by a value
-greater than 1.  If two triggered operations have the same threshold,
-they will be triggered in the order in which they were submitted to
-the endpoint.
+  Threshold operations are triggered in the order of the threshold
+  values.  This is true even if the counter increments by a value
+  greater than 1.  If two triggered operations have the same threshold,
+  they will be triggered in the order in which they were submitted to
+  the endpoint.
 
 # EXPERIMENTAL TRIGGERED OPERATIONS
 
@@ -114,6 +114,7 @@ struct fi_deferred_work {
 
 	union {
 		struct fi_trigger_threshold *threshold;
+		struct fi_trigger_completion *completion;
 	} event;
 
 	union {
@@ -156,6 +157,26 @@ not read or otherwise accessed.  But the provider may validate fabric
 objects, such as endpoints and counters, and that input parameters fall
 within supported ranges.  If a specific request is not supported by the
 provider, it will fail the operation with -FI_ENOSYS.
+
+## EXPERIMENTAL TRIGGER EVENTS
+
+The following trigger events are defined.
+
+*FI_TRIGGER_THRESHOLD*
+: See the above definition.
+
+*FI_TRIGGER_COMPLETION*
+: This indicates that the data transfer operation will be deferred
+  until the specified operation has completed.  The operation is specified
+  using struct fi_trigger_completion:
+
+  ```c
+  struct fi_trigger_completion {
+	struct fi_context *context;
+  };
+  ```
+
+  The context must refer to the fi_context of the posted operation.
 
 # SEE ALSO
 

--- a/man/fi_trigger.3.md
+++ b/man/fi_trigger.3.md
@@ -85,6 +85,78 @@ greater than 1.  If two triggered operations have the same threshold,
 they will be triggered in the order in which they were submitted to
 the endpoint.
 
+# EXPERIMENTAL TRIGGERED OPERATIONS
+
+The following feature and description are enhancements to triggered
+operation support, but should be considered experimental.  Until the
+experimental tag is removed, the interfaces and data structures defined
+below may change between library versions.
+
+Experimental triggered operations allow an application to queue operations
+to a deferred work queue that is associated with the domain.  Note that
+the deferred work queue is a conceptual construct, rather than an
+implementation requirement.  Deferred work requests consist of two
+components: an event or condition that must first be met, along with an
+operation to perform.
+
+Because deferred work requests are posted directly to the domain, they
+can support a broader set of conditions and operations.  Deferred
+work requests are submitted using struct fi_deferred_work.  That structure,
+along with any event and operation structures used to describe the work
+must remain valid until the operation completes or is canceled.
+
+```c
+struct fi_deferred_work {
+	struct fi_context     context;
+
+	enum fi_trigger_event event_type;
+	enum fi_trigger_op    op_type;
+
+	union {
+		struct fi_trigger_threshold *threshold;
+	} event;
+
+	union {
+		struct fi_op_msg            *msg;
+		struct fi_op_tagged         *tagged;
+		struct fi_op_rma            *rma;
+		struct fi_op_atomic         *atomic;
+		struct fi_op_fetch_atomic   *fetch_atomic;
+		struct fi_op_compare_atomic *compare_atomic;
+		struct fi_op_cntr           *cntr;
+	} op;
+};
+
+```
+
+Once a work request has been posted to the deferred work queue, it will
+remain on the queue until its condition has been met.  It is the
+responsibility of the application to detect and handle situations that
+occur which could result in the condition not being met.  For example,
+if a work request is dependent upon the successful completion of a data
+transfer operation, which fails, then the application must cancel the
+work request.  A work request with its condition met at the time of posting
+will automatically have its operation initiated.
+
+If the work request will generate a completion, the completion event
+will return the context field of struct fi_deferred_work as the context
+for the operation.
+
+To submit a deferred work request, applications should use the domain's
+fi_control function with command FI_QUEUE_WORK and struct fi_deferred_work
+as the fi_control arg parameter.  To cancel a deferred work request, use
+fi_control with command FI_CANCEL_WORK and the corresponding struct
+fi_deferred_work to cancel.  The fi_control command FI_FLUSH_WORK will
+cancel all queued work requests.
+
+Deferred work requests are not acted upon by the provider until the
+associated event has occurred; although, certain validation checks
+may still occur when a request is submitted.  Referenced data buffers are
+not read or otherwise accessed.  But the provider may validate fabric
+objects, such as endpoints and counters, and that input parameters fall
+within supported ranges.  If a specific request is not supported by the
+provider, it will fail the operation with -FI_ENOSYS.
+
 # SEE ALSO
 
 [`fi_getinfo`(3)](fi_getinfo.3.html),

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -260,6 +260,11 @@ int fi_no_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 {
 	return -FI_ENOSYS;
 }
+int fi_no_query_atomic(struct fid_ep *ep, enum fi_datatype datatype,
+		enum fi_op op, struct fi_atomic_attr *attr, uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
 
 /*
  * struct fi_ops_mr


### PR DESCRIPTION
Trying to finish up a couple of ABI/API related requests.  These two patches were part of the collective support discussion that were presented during my sabbatical.  There are still a couple more outstanding ABI/API related issues to address.

Note that I didn't go overboard on updating the man pages with all the details (e.g. listing all enum values), as I want to get feedback on the proposals first.  But the man pages were updated enough that I think someone could figure out how to use the new features.

Tagging Sayantan, even though is out until the end of January.