### PR TITLE
Refactor verbs initialization

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -172,6 +172,14 @@ int ofi_ep_bind_valid(struct fi_provider *prov, struct fid *bfid, uint64_t flags
 uint64_t fi_gettime_ms(void);
 uint64_t fi_gettime_us(void);
 
+/*
+ * Address utility functions
+ */
+
+#ifndef AF_IB
+#define AF_IB 27
+#endif
+
 static inline int ofi_equals_ipaddr(struct sockaddr_in *addr1,
                              struct sockaddr_in *addr2)
 {
@@ -183,6 +191,20 @@ static inline int ofi_equals_sockaddr(struct sockaddr_in *addr1,
 {
         return (ofi_equals_ipaddr(addr1, addr2) &&
                 (addr1->sin_port == addr2->sin_port));
+}
+
+static inline int ofi_translate_addr_format(int family)
+{
+	switch (family) {
+	case AF_INET:
+		return FI_SOCKADDR_IN;
+	case AF_INET6:
+		return FI_SOCKADDR_IN6;
+	case AF_IB:
+		return FI_SOCKADDR_IB;
+	default:
+		return FI_FORMAT_UNSPEC;
+	}
 }
 
 /*

--- a/include/fi_list.h
+++ b/include/fi_list.h
@@ -89,8 +89,20 @@ static inline void dlist_remove(struct dlist_entry *item)
 	item->next->prev = item->prev;
 }
 
+#define dlist_pop_front_container(head, container, member) 			\
+	do {									\
+		container = container_of((head)->next, typeof(*container),	\
+				member);					\
+		dlist_remove((head)->next);					\
+	} while (0)
+
 #define dlist_foreach(head, item) \
 	for ((item) = (head)->next; (item) != (head); (item) = (item)->next)
+
+#define dlist_foreach_container(head, container, member) \
+	for (container = container_of((head)->next, typeof(*container), member); \
+		&(container->member) != (head); \
+		container = container_of(container->member.next, typeof(*container), member))
 
 typedef int dlist_func_t(struct dlist_entry *item, const void *arg);
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -171,7 +171,6 @@ int fi_ibv_create_ep(const char *node, const char *service,
 		     struct rdma_addrinfo **rai, struct rdma_cm_id **id)
 {
 	struct rdma_addrinfo *_rai;
-	struct sockaddr *local_addr;
 	int ret;
 
 	ret = fi_ibv_get_rdma_rai(node, service, flags, hints, &_rai);
@@ -185,15 +184,6 @@ int fi_ibv_create_ep(const char *node, const char *service,
 		ret = -errno;
 		goto err1;
 	}
-	if (rai && !_rai->ai_src_addr) {
-		local_addr = rdma_get_local_addr(*id);
-		_rai->ai_src_len = fi_ibv_sockaddr_len(local_addr);
-		if (!(_rai->ai_src_addr = malloc(_rai->ai_src_len))) {
-			ret = -FI_ENOMEM;
-			goto err2;
-		}
-		memcpy(_rai->ai_src_addr, local_addr, _rai->ai_src_len);
-	}
 
 	if (rai) {
 		*rai = _rai;
@@ -202,8 +192,6 @@ int fi_ibv_create_ep(const char *node, const char *service,
 	}
 
 	return ret;
-err2:
-	rdma_destroy_ep(*id);
 err1:
 	rdma_freeaddrinfo(_rai);
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -105,6 +105,16 @@
 
 extern struct fi_provider fi_ibv_prov;
 
+struct verbs_addr {
+	struct dlist_entry entry;
+	struct rdma_addrinfo *rai;
+};
+
+struct verbs_dev_info {
+	struct dlist_entry entry;
+	char *name;
+	struct dlist_entry addrs;
+};
 
 struct fi_ibv_fabric {
 	struct fid_fabric	fabric_fid;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -551,27 +551,21 @@ int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags,
 
 static int fi_ibv_rai_to_fi(struct rdma_addrinfo *rai, struct fi_info *fi)
 {
-	switch(rai->ai_family) {
-	case AF_INET:
-		fi->addr_format = FI_SOCKADDR_IN;
-		break;
-	case AF_INET6:
-		fi->addr_format = FI_SOCKADDR_IN6;
-		break;
-	case AF_IB:
-		fi->addr_format = FI_SOCKADDR_IB;
-		break;
-	default:
-		FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "Unknown rai->ai_family\n");
+	fi->addr_format = ofi_translate_addr_format(rai->ai_family);
+	if (fi->addr_format == FI_FORMAT_UNSPEC) {
+		FI_WARN(&fi_ibv_prov, FI_LOG_FABRIC, "Unknown address format\n");
+		return -FI_EINVAL;
 	}
 
 	if (rai->ai_src_len) {
+		free(fi->src_addr);
  		if (!(fi->src_addr = malloc(rai->ai_src_len)))
  			return -FI_ENOMEM;
  		memcpy(fi->src_addr, rai->ai_src_addr, rai->ai_src_len);
  		fi->src_addrlen = rai->ai_src_len;
  	}
  	if (rai->ai_dst_len) {
+		free(fi->dest_addr);
 		if (!(fi->dest_addr = malloc(rai->ai_dst_len)))
 			return -FI_ENOMEM;
  		memcpy(fi->dest_addr, rai->ai_dst_addr, rai->ai_dst_len);
@@ -834,52 +828,67 @@ err:
 	return ret;
 }
 
-static int fi_ibv_copy_ifaddr(const char *name, const char *service, uint64_t flags,
-		struct fi_info *info)
+static void fi_ibv_verbs_devs_free(struct dlist_entry *verbs_devs)
 {
-	struct rdma_addrinfo *rai;
-	struct fi_info *fi;
-	struct rdma_cm_id *id;
-	int ret;
+	struct verbs_dev_info *dev;
+	struct verbs_addr *addr;
 
-	ret = fi_ibv_get_rdma_rai(name, service, flags, NULL, &rai);
-	if (ret) {
-		FI_WARN(&fi_ibv_prov, FI_LOG_FABRIC,
-				"rdma_getaddrinfo failed for name:%s\n", name);
-		return ret;
-	}
-	ret = rdma_create_ep(&id, rai, NULL, NULL);
-	if (!ret) {
-		for (fi = info; fi; fi = fi->next)
-			if (!strncmp(id->verbs->device->name, fi->domain_attr->name,
-						strlen(id->verbs->device->name)))
-				break;
-		if (!fi) {
-			FI_WARN(&fi_ibv_prov, FI_LOG_FABRIC,
-					"No matching fi_info for device: "
-					"%s with address: %s\n",
-					id->verbs->device->name, name);
-		} else {
-			if (fi->src_addr) {
-				free(fi->src_addr);
-				fi->src_addr = NULL;
-			}
-			fi_ibv_rai_to_fi(rai, fi);
+	while (!dlist_empty(verbs_devs)) {
+		dlist_pop_front_container(verbs_devs, dev, entry);
+		while (!dlist_empty(&dev->addrs)) {
+			dlist_pop_front_container(&dev->addrs, addr, entry);
+			rdma_freeaddrinfo(addr->rai);
+			free(addr);
 		}
-		rdma_destroy_ep(id);
+		free(dev->name);
+		free(dev);
 	}
-	rdma_freeaddrinfo(rai);
-	return 0;
 }
 
-static int fi_ibv_getifaddrs(const char *service, uint64_t flags, struct fi_info *info)
+static int fi_ibv_add_rai(struct dlist_entry *verbs_devs, struct rdma_cm_id *id,
+		struct rdma_addrinfo *rai)
+{
+	struct verbs_dev_info *dev;
+	struct verbs_addr *addr;
+	const char *dev_name;
+
+	if (!(addr = malloc(sizeof(*addr))))
+		return -FI_ENOMEM;
+
+	addr->rai = rai;
+
+	dev_name = ibv_get_device_name(id->verbs->device);
+	dlist_foreach_container(verbs_devs, dev, entry)
+		if (!strcmp(dev_name, dev->name))
+			goto add_rai;
+
+	if (!(dev = malloc(sizeof(*dev))))
+		goto err1;
+
+	if (!(dev->name = strdup(dev_name)))
+		goto err2;
+
+	dlist_init(&dev->addrs);
+	dlist_insert_tail(&dev->entry, verbs_devs);
+add_rai:
+	dlist_insert_tail(&addr->entry, &dev->addrs);
+	return 0;
+err2:
+	free(dev);
+err1:
+	free(addr);
+	return -FI_ENOMEM;
+}
+
+/* Builds a list of interfaces that correspond to active verbs devices */
+static int fi_ibv_getifaddrs(struct dlist_entry *verbs_devs)
 {
 	struct ifaddrs *ifaddr, *ifa;
 	char name[INET6_ADDRSTRLEN];
+	struct rdma_addrinfo *rai;
+	struct rdma_cm_id *id;
 	const char *ret_ptr;
 	int ret, num_verbs_ifs = 0;
-
-	flags |= FI_NUMERICHOST | FI_SOURCE;
 
 	ret = getifaddrs(&ifaddr);
 	if (ret) {
@@ -892,6 +901,7 @@ static int fi_ibv_getifaddrs(const char *service, uint64_t flags, struct fi_info
 		if (!ifa->ifa_addr || !(ifa->ifa_flags & IFF_UP) ||
 				!strcmp(ifa->ifa_name, "lo"))
 			continue;
+		// TODO call a function here that filters ifa based on interface name
 		switch (ifa->ifa_addr->sa_family) {
 		case AF_INET:
 			ret_ptr = inet_ntop(AF_INET, &ofi_sin_addr(ifa->ifa_addr),
@@ -908,18 +918,142 @@ static int fi_ibv_getifaddrs(const char *service, uint64_t flags, struct fi_info
 			FI_WARN(&fi_ibv_prov, FI_LOG_FABRIC,
 					"inet_ntop failed: %s(%d)\n",
 					strerror(errno), errno);
-			goto err;
+			goto err1;
 		}
-		ret = fi_ibv_copy_ifaddr(name, service, flags, info);
+
+		ret = fi_ibv_create_ep(name, NULL, FI_NUMERICHOST | FI_SOURCE,
+				NULL, &rai, &id);
 		if (ret)
-			goto err;
+			continue;
+
+		ret = fi_ibv_add_rai(verbs_devs, id, rai);
+		if (ret)
+			goto err2;
+
+		FI_DBG(&fi_ibv_prov, FI_LOG_FABRIC,
+			"Found active interface for verbs device: %s with address: %s\n",
+			ibv_get_device_name(id->verbs->device), name);
+
+		rdma_destroy_ep(id);
+
 		num_verbs_ifs++;
 	}
 	freeifaddrs(ifaddr);
 	return num_verbs_ifs ? 0 : -FI_ENODATA;
-err:
+err2:
+	rdma_destroy_ep(id);
+err1:
+	fi_ibv_verbs_devs_free(verbs_devs);
 	freeifaddrs(ifaddr);
 	return ret;
+}
+
+int fi_ibv_get_srcaddr_devs(struct fi_info *info)
+{
+	struct fi_info *fi, *add_info;
+	struct verbs_dev_info *dev;
+	struct verbs_addr *addr;
+	int ret = 0;
+
+	DEFINE_LIST(verbs_devs);
+
+	ret = fi_ibv_getifaddrs(&verbs_devs);
+	if (ret)
+		return ret;
+
+	if (dlist_empty(&verbs_devs)) {
+		FI_WARN(&fi_ibv_prov, FI_LOG_CORE, "No interface address found\n");
+		return 0;
+	}
+
+	for (fi = info; fi; fi = fi->next) {
+		dlist_foreach_container(&verbs_devs, dev, entry)
+			if (!strncmp(fi->domain_attr->name, dev->name, strlen(dev->name)))
+				break;
+
+		dlist_foreach_container(&dev->addrs, addr, entry) {
+			/* When a device has multiple interfaces/addresses configured
+			 * duplicate fi_info and add the address info. fi->src_addr
+			 * would have been set in the previous iteration */
+			if (fi->src_addr) {
+				if (!(add_info = fi_dupinfo(fi))) {
+					ret = -FI_ENOMEM;
+					goto out;
+				}
+
+				add_info->next = fi->next;
+				fi->next = add_info;
+				fi = add_info;
+			}
+
+			ret = fi_ibv_rai_to_fi(addr->rai, fi);
+			if (ret)
+				goto out;
+		}
+	}
+out:
+	fi_ibv_verbs_devs_free(&verbs_devs);
+	return ret;
+
+}
+
+static void fi_ibv_sockaddr_set_port(struct sockaddr *sa, uint16_t port)
+{
+	switch(sa->sa_family) {
+	case AF_INET:
+		((struct sockaddr_in *)sa)->sin_port = port;
+		break;
+	case AF_INET6:
+		((struct sockaddr_in6 *)sa)->sin6_port = port;
+		break;
+	}
+}
+
+static int fi_ibv_fill_addr(uint64_t flags, struct rdma_addrinfo *rai,
+		struct fi_info *info, struct rdma_cm_id *id)
+{
+	struct fi_info *fi;
+	struct sockaddr *local_addr;
+	int ret;
+
+	if (id->verbs) {
+		assert(!info->next);
+		/* Handle the case when rdma_cm doesn't fill src address even
+		 * though it fills the destination address (presence of id->verbs
+		 * corresponds to a valid dest addr) */
+		if (!rai->ai_src_addr) {
+			local_addr = rdma_get_local_addr(id);
+			if (!local_addr) {
+				FI_WARN(&fi_ibv_prov, FI_LOG_CORE,
+						"Unable to get local address\n");
+				return -FI_ENODATA;
+			}
+
+			rai->ai_src_len = fi_ibv_sockaddr_len(local_addr);
+			if (!(rai->ai_src_addr = malloc(rai->ai_src_len)))
+				return -FI_ENOMEM;
+
+			memcpy(rai->ai_src_addr, local_addr, rai->ai_src_len);
+			/* User didn't specify a port. Zero out the random port
+			 * assigned by rdmamcm so that this rai/fi_info can be
+			 * used multiple times to create rdma endpoints.*/
+			fi_ibv_sockaddr_set_port(rai->ai_src_addr, 0);
+		}
+
+		return fi_ibv_rai_to_fi(rai, info);
+	}
+
+	/* This would correspond to a wildcard address */
+	if (flags & FI_SOURCE) {
+		for (fi = info; fi; fi = fi->next) {
+			ret = fi_ibv_rai_to_fi(rai, fi);
+			if (ret)
+				return ret;
+		}
+		return 0;
+	}
+
+	return fi_ibv_get_srcaddr_devs(info);
 }
 
 int fi_ibv_init_info(void)
@@ -1037,9 +1171,7 @@ struct fi_info *fi_ibv_get_verbs_info(const char *domain_name)
 	return NULL;
 }
 
-static int fi_ibv_get_matching_info(const char *domain_name,
-		struct fi_info *hints, struct rdma_addrinfo *rai,
-		struct fi_info **info)
+static int fi_ibv_get_matching_info(struct fi_info *hints, struct fi_info **info)
 {
 	struct fi_info *check_info;
 	struct fi_info *fi, *tail;
@@ -1048,10 +1180,6 @@ static int fi_ibv_get_matching_info(const char *domain_name,
 	*info = tail = NULL;
 
 	for (check_info = verbs_info; check_info; check_info = check_info->next) {
-		if (domain_name && strncmp(check_info->domain_attr->name,
-					   domain_name, strlen(domain_name)))
-			continue;
-
 		if (hints) {
 			ret = fi_ibv_check_hints(hints, check_info);
 			if (ret)
@@ -1062,10 +1190,6 @@ static int fi_ibv_get_matching_info(const char *domain_name,
 			ret = -FI_ENOMEM;
 			goto err1;
 		}
-
-		ret = fi_ibv_rai_to_fi(rai, fi);
-		if (ret)
-			goto err2;
 
 		fi_ibv_update_info(hints, fi);
 
@@ -1080,8 +1204,6 @@ static int fi_ibv_get_matching_info(const char *domain_name,
 		return -FI_ENODATA;
 
 	return 0;
-err2:
-	fi_freeinfo(fi);
 err1:
 	fi_freeinfo(*info);
 	return ret;
@@ -1239,29 +1361,31 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 		goto out;
 
 	if (id->verbs) {
-		ret = fi_ibv_get_matching_info(ibv_get_device_name(id->verbs->device),
-					       hints, rai, info);
-	} else {
-		ret = fi_ibv_get_matching_info(NULL, hints, rai, info);
-		if (!ret && !(flags & FI_SOURCE) && !node 
-		&& (!hints || (!hints->src_addr && !hints->dest_addr))) {
-			ret = fi_ibv_getifaddrs(service, flags, *info);
-			if (ret) {
-				fi_freeinfo(*info);
-				fi_ibv_destroy_ep(rai, &id);
-				goto out;
-			}
-		}
+		hints->domain_attr->name = strdup(ibv_get_device_name(id->verbs->device));
+		if (!hints->domain_attr->name)
+			goto err;
 	}
 
-	if (!ret) {
-		ret = fi_ibv_rdm_remove_nonaddr_info(info);
+	ret = fi_ibv_get_matching_info(hints, info);
+	if (ret)
+		goto err;
+
+	ret = fi_ibv_fill_addr(flags, rai, *info, id);
+	if (ret) {
+		fi_freeinfo(*info);
+		goto err;
+	}
+
+	// TODO remove this and add a filtering function within fi_ibv_getifaddrs
+	ret = fi_ibv_rdm_remove_nonaddr_info(info);
+	if (ret) {
+		fi_freeinfo(*info);
+		goto err;
 	}
 
 	ofi_alter_info(*info, hints);
-
+err:
 	fi_ibv_destroy_ep(rai, &id);
-
 out:
 	if (!ret || ret == -FI_ENOMEM || ret == -FI_ENODEV)
 		return ret;


### PR DESCRIPTION
Refactor verbs intialization and add some helper functions for lists and sockaddr utility functions.

The refactoring patch would:
Find the list of network interfaces on the system that correspond to verbs
devices and store their addresses in a list indexed by the verbs device name.
When filling out fi_info src_addr, walk through this list and pick the correct
address by matching the device/domain name. Duplicate fi_info in case there are
mulitple interfaces/addresses.

@hoopoepg I tested this patch with multiple network interfaces.  fi_ibv_rdm_remove_nonaddr_info -> fi_ibv_retain_info removes fi_info corresponding to additional network addresses. Running fi_info -p verbs -v would show it. Ultimately it would be better to remove that function and filter the interfaces when we iterate through the list returned by getifaddrs. I have added a TODO for that. Please take a look.

This PR includes the intended fix in #2570, so that PR can be closed.

This PR should also fix #2596.