### PR TITLE
prov/util: Rework util_mr.c

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -463,35 +463,26 @@ int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 /*
  * MR
  */
-
-
-/*hide addr related info & store prov_mr ptr */
-struct ofi_util_mr {
-    void *map_handle;
-    uint64_t b_key; /* track available key (BASIC usage) */
-    enum fi_mr_mode mr_type;
-    const struct fi_provider *prov;
+struct ofi_mr_map {
+	const struct fi_provider *prov;
+	void			*rbtree;
+	uint64_t		key;
+	enum fi_mr_mode		mode;
 };
 
-/*create instance of data structure and return handle to user */
-int ofi_mr_init(const struct fi_provider *in_prov, enum fi_mr_mode mode,
-                                struct ofi_util_mr ** out_new_mr);
-/*insert user mr struct in data structure*/
-int ofi_mr_insert(struct ofi_util_mr * in_mr_h,
-                                const struct fi_mr_attr *in_attr,
-                                uint64_t * out_key, void * in_prov_mr);
-/*return on user mr struct */
-void * ofi_mr_retrieve(struct ofi_util_mr * in_mr_h,  uint64_t in_key);
-/*need address offsetted, verified, and user mr struct returned*/
-/* io_addr is address of buff (&buf) */
-int ofi_mr_retrieve_and_verify(struct ofi_util_mr * in_mr_h, ssize_t in_len,
-                                uintptr_t *io_addr, uint64_t in_key,
-                                uint64_t in_access, void **out_prov_mr);
-/*erase a specific item in the data structure */
-int ofi_mr_erase(struct ofi_util_mr * in_mr_h, uint64_t in_key);
-/*close data structure instance */
-void ofi_mr_close(struct ofi_util_mr *in_mr_h);
+int ofi_mr_map_init(const struct fi_provider *in_prov, enum fi_mr_mode mode,
+		    struct ofi_mr_map *map);
+void ofi_mr_map_close(struct ofi_mr_map *map);
 
+int ofi_mr_insert(struct ofi_mr_map *map,
+		  const struct fi_mr_attr *attr,
+		  uint64_t *key, void *context);
+int ofi_mr_remove(struct ofi_mr_map *map, uint64_t key);
+void *ofi_mr_get(struct ofi_mr_map *map,  uint64_t key);
+
+int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
+		  size_t len, uint64_t key, uint64_t access,
+		  void **context);
 
 
 /*

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -146,7 +146,7 @@ struct rxd_domain {
 
 	struct dlist_entry ep_list;
 	struct dlist_entry cq_list;
-	struct ofi_util_mr *mr_heap;
+	struct ofi_mr_map mr_map;
 	fastlock_t mr_lock;
 };
 

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -224,7 +224,7 @@ struct sock_domain {
 	struct sock_eq *mr_eq;
 
 	enum fi_progress progress_mode;
-	struct ofi_util_mr *mr_heap;
+	struct ofi_mr_map mr_map;
 	struct sock_pe *pe;
 	struct dlist_entry dom_list_entry;
 	struct fi_domain_attr attr;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -285,7 +285,7 @@ static void sock_pe_report_mr_completion(struct sock_domain *domain,
 
 	for (i = 0; i < pe_entry->msg_hdr.dest_iov_len; i++) {
 		fastlock_acquire(&domain->lock);
-		mr = ofi_mr_retrieve(domain->mr_heap, pe_entry->pe.rx.rx_iov[i].iov.key);
+		mr = ofi_mr_get(&domain->mr_map, pe_entry->pe.rx.rx_iov[i].iov.key);
 		fastlock_release(&domain->lock);
 		if (!mr || (!mr->cq && !mr->cntr))
 			continue;

--- a/prov/util/src/util_mr.c
+++ b/prov/util/src/util_mr.c
@@ -36,221 +36,138 @@
 #include <assert.h>
 #include <rbtree.h>
 
-/* deep copy: make seperate copy of mr_attr and use context for prov_mr */
-static struct fi_mr_attr * create_mr_attr_copy(
-                        const struct fi_mr_attr *in_attr, void * prov_mr)
+
+static struct fi_mr_attr *
+dup_mr_attr(const struct fi_mr_attr *attr)
 {
-    struct fi_mr_attr * item;
-    struct iovec *mr_iov;
-    int i = 0;
+	struct fi_mr_attr *dup_attr;
 
-    if (!prov_mr || !in_attr)
-        return NULL;
+	assert(attr->iov_count == 1);
+	dup_attr = calloc(1, sizeof(*attr) +
+			     sizeof(*attr->mr_iov) * attr->iov_count);
+	if (!dup_attr)
+		return NULL;
 
-    item = malloc(sizeof(struct fi_mr_attr));
-    if (!item)
-        return NULL;
+	*dup_attr = *attr;
+	dup_attr->mr_iov = (struct iovec *) (dup_attr + 1);
+	memcpy((void *) dup_attr->mr_iov, attr->mr_iov,
+		sizeof(*attr->mr_iov) * attr->iov_count);
 
-    *item = *in_attr;
-    item->context = prov_mr;
-    mr_iov = malloc(sizeof(struct iovec) * in_attr->iov_count);
-    if (!mr_iov) {
-        free(item);
-        return NULL;
-    }
-
-    for(i = 0; i < in_attr->iov_count; i++)
-        mr_iov[i] = in_attr->mr_iov[i];
-
-    item->mr_iov = mr_iov;
-
-    return item;
+	return dup_attr;
 }
 
-static uint64_t get_mr_key(struct ofi_util_mr *mr_h)
+int ofi_mr_insert(struct ofi_mr_map *map, const struct fi_mr_attr *attr,
+		  uint64_t *key, void *context)
 {
-    assert(mr_h->b_key != UINT64_MAX);
-    return mr_h->b_key++;
+	struct fi_mr_attr *item;
+
+	item = dup_mr_attr(attr);
+	if (!item)
+		return -FI_ENOMEM;
+
+	if (map->mode == FI_MR_SCALABLE) {
+		item->offset = (uintptr_t) attr->mr_iov[0].iov_base;
+		if (rbtFind(map->rbtree, &item->requested_key)) {
+			free(item);
+			return -FI_ENOKEY;
+		}
+	} else {
+		item->requested_key = map->key++;
+	}
+
+	rbtInsert(map->rbtree, &item->requested_key, item);
+	*key = item->requested_key;
+	item->context = context;
+
+	return 0;
 }
 
-static int verify_addr(struct ofi_util_mr * in_mr, struct fi_mr_attr * item, uint64_t in_access,
-                                 uint64_t in_addr, ssize_t in_len)
+void *ofi_mr_get(struct ofi_mr_map *map, uint64_t key)
 {
-    int i = 0;
-    uint64_t start = (uintptr_t) item->mr_iov[i].iov_base;
-    uint64_t end = start + item->mr_iov[i].iov_len;
+	struct fi_mr_attr *attr;
+	void *itr, *key_ptr;
 
-    if (!in_addr) {
-        FI_DBG(in_mr->prov, FI_LOG_MR, "verify_addr: input address to is zero\n");
-        return -FI_EINVAL;
-    }
+	itr = rbtFind(map->rbtree, &key);
+	if (!itr)
+		return NULL;
 
-    if ((in_access & item->access) != in_access) {
-        FI_DBG(in_mr->prov, FI_LOG_MR, "verify_addr: requested access is not valid\n");
-        return -FI_EACCES;
-    }
-
-      for (i = 0; i < item->iov_count; i++) {
-        if (start <= in_addr && end >= (in_addr + in_len))
-            return 0;
-    }
-
-    return -FI_EACCES;
+	rbtKeyValue(map->rbtree, itr, &key_ptr, (void **) &attr);
+	return attr->context;
 }
 
-int ofi_mr_insert(struct ofi_util_mr * in_mr_h, const struct fi_mr_attr *in_attr,
-                                uint64_t * out_key, void * in_prov_mr)
+int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
+		  size_t len, uint64_t key, uint64_t access,
+		  void **context)
 {
-    struct fi_mr_attr * item;
+	struct fi_mr_attr *attr;
+	void *itr, *key_ptr, *addr;
 
-    if (!in_attr || in_attr->iov_count <= 0 || !in_prov_mr) {
-        return -FI_EINVAL;
-    }
+	itr = rbtFind(map->rbtree, &key);
+	if (!itr)
+		return -FI_EINVAL;
 
-    item = create_mr_attr_copy(in_attr, in_prov_mr);
-    if (!item)
-        return -FI_ENOMEM;
+	rbtKeyValue(map->rbtree, itr, &key_ptr, (void **) &attr);
+	assert(attr);
 
-    /* Scalable MR handling: use requested key and offset */
-    if (in_mr_h->mr_type == FI_MR_SCALABLE) {
-        item->offset = (uintptr_t) in_attr->mr_iov[0].iov_base + in_attr->offset;
-        /* verify key doesn't already exist */
-        if (rbtFind(in_mr_h->map_handle, &item->requested_key)) {
-                free((void *)item->mr_iov);
-                free(item);
-                return -FI_ENOKEY;
-        }
-    } else {
-        item->requested_key = get_mr_key(in_mr_h);
-        item->offset = (uintptr_t) in_attr->mr_iov[0].iov_base;
-    }
+	if ((access & attr->access) != access) {
+		FI_DBG(map->prov, FI_LOG_MR, "verify_addr: invalid access\n");
+		return -FI_EACCES;
+	}
 
-    rbtInsert(in_mr_h->map_handle, &item->requested_key, item);
-    *out_key = item->requested_key;
+	addr = (void *) (*io_addr + (uintptr_t) attr->offset);
 
-    return 0;
+	if ((addr < attr->mr_iov[0].iov_base) ||
+	    (((char *) addr + len) > ((char *) attr->mr_iov[0].iov_base +
+			    	      attr->mr_iov[0].iov_len))) {
+		return -FI_EACCES;
+	}
+
+	if (context)
+		*context = attr->context;
+	*io_addr = (uintptr_t) addr;
+	return 0;
 }
 
-void * ofi_mr_retrieve(struct ofi_util_mr * in_mr_h,  uint64_t in_key)
+int ofi_mr_remove(struct ofi_mr_map *map, uint64_t key)
 {
-    void * itr;
-    struct fi_mr_attr * item;
-    void * key = &in_key;
+	struct fi_mr_attr *attr;
+	void *itr, *key_ptr;
 
-    itr = rbtFind(in_mr_h->map_handle, key);
+	itr = rbtFind(map->rbtree, &key);
+	if (!itr)
+		return -FI_ENOKEY;
 
-    if (!itr)
-        return NULL;
+	rbtKeyValue(map->rbtree, itr, &key_ptr, (void **) &attr);
+	rbtErase(map->rbtree, itr);
+	free(attr);
 
-    rbtKeyValue(in_mr_h->map_handle, itr, (void **)&key,
-                                (void **) &item);
-    return item->context;
+	return 0;
 }
 
-
-/* io_addr is address of buff (&buf) */
-int ofi_mr_retrieve_and_verify(struct ofi_util_mr * in_mr_h, ssize_t in_len,
-                                uintptr_t *io_addr, uint64_t in_key,
-                                uint64_t in_access, void **out_prov_mr)
-{
-    int ret = 0;
-    void * itr;
-    struct fi_mr_attr * item;
-    void * key = &in_key;
-
-    itr = rbtFind(in_mr_h->map_handle, key);
-
-    if (!itr)
-        return -FI_EINVAL;
-
-    rbtKeyValue(in_mr_h->map_handle, itr, &key, (void **) &item);
-
-    /*return providers MR struct */
-    if (!item || !io_addr)
-        return -FI_EINVAL;
-
-    if (out_prov_mr)
-        (*out_prov_mr) = item->context;
-
-    /*offset for scalable */
-    if (in_mr_h->mr_type == FI_MR_SCALABLE)
-        *io_addr = (*io_addr) + item->offset;
-
-    ret = verify_addr(in_mr_h, item, in_access, *io_addr, in_len);
-
-    return ret;
-}
-
-int ofi_mr_erase(struct ofi_util_mr * in_mr_h, uint64_t in_key)
-{
-    void * itr;
-    struct fi_mr_attr * item;
-
-    if (!in_mr_h)
-        return -FI_EINVAL;
-
-    itr = rbtFind(in_mr_h->map_handle, &in_key);
-
-    if (!itr)
-        return -FI_ENOKEY;
-
-    /*release memory */
-    rbtKeyValue(in_mr_h->map_handle, itr, (void **)&in_key,
-                                (void **) &item);
-
-    assert(item);
-
-    free((void *)item->mr_iov);
-    free(item);
-
-    rbtErase(in_mr_h->map_handle, itr);
-
-    return 0;
-}
-
-/*assumes uint64_t keys */
+/* assumes uint64_t keys */
 static int compare_mr_keys(void *key1, void *key2)
 {
-    uint64_t k1 = *((uint64_t *) key1);
-    uint64_t k2 = *((uint64_t *) key2);
-    return (k1 < k2) ?  -1 : (k1 > k2);
+	uint64_t k1 = *((uint64_t *) key1);
+	uint64_t k2 = *((uint64_t *) key2);
+	return (k1 < k2) ? -1 : (k1 > k2);
 }
 
 
-int ofi_mr_init(const struct fi_provider *in_prov, enum fi_mr_mode mode,
-                struct ofi_util_mr ** out_new_mr)
+int ofi_mr_map_init(const struct fi_provider *prov, enum fi_mr_mode mode,
+		    struct ofi_mr_map *map)
 {
-    struct ofi_util_mr * new_mr = malloc(sizeof(struct ofi_util_mr));
-    if (!new_mr)
-        return -FI_ENOMEM;
+	map->rbtree = rbtNew(compare_mr_keys);
+	if (!map->rbtree)
+		return -FI_ENOMEM;
 
-    assert((mode == FI_MR_SCALABLE) || (mode == FI_MR_BASIC));
+	map->mode = mode;
+	map->prov = prov;
+	map->key = 1;
 
-    new_mr->mr_type = mode;
-
-    new_mr->map_handle = rbtNew(compare_mr_keys);
-    if (!new_mr->map_handle) {
-        free(new_mr);
-        return -FI_ENOMEM;
-    }
-
-    new_mr->b_key = 0;
-
-    new_mr->prov = in_prov;
-
-    (*out_new_mr) = new_mr;
-
-    return 0;
+	return 0;
 }
 
-
-void ofi_mr_close(struct ofi_util_mr *in_mr_h)
+void ofi_mr_map_close(struct ofi_mr_map *map)
 {
-    if (!in_mr_h) {
-        FI_WARN(&core_prov, FI_LOG_MR, "util mr_close: received NULL input\n");
-        return;
-    }
-
-    rbtDelete(in_mr_h->map_handle);
-    free(in_mr_h);
+	rbtDelete(map->rbtree);
 }


### PR DESCRIPTION
Re-write the util_mr.c code.  Update the code to adhere to the
coding guidelines and preferred variable naming.

Rename ofi_util_mr to ofi_mr_map to better reflect the intent
of the structure as a mapping not a MR.  Simplify the code and
remove unnecessary checks (which should be handled earlier in
the code paths).  Limit the code to handling a single SGE, since
the algorithms assume this.  Add a couple of small optimizations
around structure allocation and initialization.

Fixes #2637

Signed-off-by: Sean Hefty <sean.hefty@intel.com>