### PR TITLE
prov/gni: Fix boundary condition

### DIFF
--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
@@ -1328,7 +1328,7 @@ void _gnix_nic_init(void)
 {
 	int i, rc;
 
-	for (i = 0; i <= GNI_PTAG_MAX; i++) {
+	for (i = 0; i < GNI_PTAG_MAX; i++) {
 		dlist_init(&gnix_nic_list_ptag[i]);
 	}
 


### PR DESCRIPTION
on gnix_nic_list_ptag initialization loop.
upstream merge of ofi-cray/libfabric-cray#1127

@sungeunchoi 
Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@37651cef41838564edc322847eafefcaa38ee3dd)