### PR TITLE
man/mr: Indicate the the EP must support FI_RMA_EVENT

### DIFF
--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -279,7 +279,9 @@ memory region is based on the bitwise OR of the following flags.
 
 *FI_REMOTE_WRITE*
 : Generates an event whenever a remote RMA write or atomic operation
-  modify the memory region.
+  modifies the memory region.  Use of this flag requires that the endpoint
+  through which the MR is accessed be created with the FI_RMA_EVENT
+  capability.
 
 # FLAGS
 


### PR DESCRIPTION
Clarify that binding a MR to a counter requires FI_RMA_EVENT
support from the EP.  This matches the documentation for
binding an EP to a counter for RMA events.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>