### PR TITLE
fabric/mr: Convert domain mr_mode to mode bits

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -181,6 +181,7 @@ enum {
 
 #define FI_ADDR_UNSPEC		((uint64_t) -1)
 #define FI_ADDR_NOTAVAIL	((uint64_t) -1)
+#define FI_KEY_NOTAVAIL		((uint64_t) -1)
 #define FI_SHARED_CONTEXT	(-(size_t)1)
 typedef uint64_t		fi_addr_t;
 
@@ -190,11 +191,18 @@ enum fi_av_type {
 	FI_AV_TABLE
 };
 
+/* Named enum for backwards compatibility */
 enum fi_mr_mode {
 	FI_MR_UNSPEC,
-	FI_MR_BASIC,
-	FI_MR_SCALABLE
+	FI_MR_BASIC,	     /* (1 << 0) */
+	FI_MR_SCALABLE,	     /* (1 << 1) */
 };
+#define FI_MR_LOCAL		(1 << 2)
+#define FI_MR_RAW		(1 << 3)
+#define FI_MR_VIRT_ADDR		(1 << 4)
+#define FI_MR_ALLOCATED		(1 << 5)
+#define FI_MR_PROV_KEY		(1 << 6)
+#define FI_MR_MMU_NOTIFY	(1 << 7)
 
 enum fi_progress {
 	FI_PROGRESS_UNSPEC,
@@ -319,7 +327,7 @@ struct fi_domain_attr {
 	enum fi_progress	data_progress;
 	enum fi_resource_mgmt	resource_mgmt;
 	enum fi_av_type		av_type;
-	enum fi_mr_mode		mr_mode;
+	int			mr_mode;
 	size_t			mr_key_size;
 	size_t			cq_data_size;
 	size_t			cq_cnt;
@@ -451,6 +459,21 @@ struct fi_alias {
 	uint64_t		flags;
 };
 
+struct fi_mr_raw_attr {
+	uint64_t	flags;
+	uint64_t	*base_addr;
+	uint8_t		*raw_key;
+	size_t		*key_size;
+};
+
+struct fi_mr_map_raw {
+	uint64_t	flags;
+	uint64_t	base_addr;
+	uint8_t		*raw_key;
+	size_t		key_size;
+	uint64_t	*key;
+};
+
 /* control commands */
 enum {
 	FI_GETFIDFLAG,		/* uint64_t flags */
@@ -461,6 +484,9 @@ enum {
 	FI_GETWAIT,		/* void * wait object */
 	FI_ENABLE,		/* NULL */
 	FI_BACKLOG,		/* integer * */
+	FI_GET_RAW_MR,		/* fi_mr_raw_attr */
+	FI_MAP_RAW_MR,		/* fi_mr_map_raw */
+	FI_UNMAP_KEY,		/* uint64_t key */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -239,6 +239,39 @@ static inline void *fi_mr_desc(struct fid_mr *mr)
 static inline uint64_t fi_mr_key(struct fid_mr *mr)
 {
 	return mr->key;
+}
+
+static inline int
+fi_mr_raw_attr(struct fid_mr *mr, uint64_t *base_addr,
+	       uint8_t *raw_key, size_t *key_size, uint64_t flags)
+{
+	struct fi_mr_raw_attr attr = {
+		.flags = flags,
+		.base_addr = base_addr,
+		.raw_key = raw_key,
+		.key_size = key_size
+	};
+	return mr->fid.ops->control(&mr->fid, FI_GET_RAW_MR, &attr);
+}
+
+static inline int
+fi_mr_map_raw(struct fid_domain *domain, uint64_t base_addr,
+	      uint8_t *raw_key, size_t key_size, uint64_t *key, uint64_t flags)
+{
+	struct fi_mr_map_raw map = {
+		.flags = flags,
+		.base_addr = base_addr,
+		.raw_key = raw_key,
+		.key_size = key_size,
+		.key = key
+	};
+	return domain->fid.ops->control(&domain->fid, FI_MAP_RAW_MR, &map);
+}
+
+static inline int
+fi_mr_unmap_key(struct fid_domain *domain, uint64_t key)
+{
+	return domain->fid.ops->control(&domain->fid, FI_UNMAP_KEY, &key);
 }
 
 static inline int fi_mr_bind(struct fid_mr *mr, struct fid *bfid, uint64_t flags)

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -438,7 +438,10 @@ supported set of modes will be returned in the info structure(s).
   for locally accessed data buffers.  Data buffers used in send and
   receive operations and as the source buffer for RMA and atomic
   operations must be registered by the application for access domains
-  opened with this capability.
+  opened with this capability.  This flag is defined for compatibility
+  and is ignored if the FI_MR_LOCAL domain mr_mode bit is set.
+  See the domain attribute mr_mode [`fi_domain`(3)](fi_domain.3.html)
+  and [`fi_mr`(3)](fi_mr.3.html).
 
 *FI_MSG_PREFIX*
 : Message prefix mode indicates that an application will provide

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -21,6 +21,16 @@ fi_mr_desc
 fi_mr_key
 : Return the remote key needed to access a registered memory region
 
+fi_mr_raw_attr
+: Return raw memory region attributes.
+
+fi_mr_map_raw
+: Converts a raw memory region key into a key that is usable for data
+  transfer operations.
+
+fi_mr_unmap_key
+: Releases a previously mapped raw memory region key.
+
 fi_mr_bind
 : Associate a registered memory region with a completion counter.
 
@@ -45,6 +55,14 @@ int fi_close(struct fid *mr);
 void * fi_mr_desc(struct fid_mr *mr);
 
 uint64_t fi_mr_key(struct fid_mr *mr);
+
+int fi_mr_raw_attr(struct fid_mr *mr, uint64_t *base_addr,
+    uint8_t *raw_key, size_t *key_size, uint64_t flags);
+
+int fi_mr_map_raw(struct fid_domain *domain, uint64_t base_addr,
+    uint8_t *raw_key, size_t key_size, uint64_t *key, uint64_t flags);
+
+int fi_mr_unmap_key(struct fid_domain *domain, uint64_t key);
 
 int fi_mr_bind(struct fid_mr *mr, struct fid *bfid, uint64_t flags);
 ```
@@ -98,62 +116,109 @@ granted for access by fabric resources.  A memory buffer must be
 registered with a resource domain before it can be used as the target
 of a remote RMA or atomic data transfer.  Additionally, a fabric
 provider may require that data buffers be registered before being used
-in local transfers.
+in local transfers.  Memory registration restrictions are controlled
+using a separate set of mode bits, specified through the domain
+attributes (mr_mode field).
 
-A provider may hide local registration requirements from applications
-by making use of an internal registration cache or similar mechanisms.
-Such mechanisms, however, may negatively impact performance for some
-applications, notably those which manage their own network buffers.
-In order to support as broad range of applications as possible,
-without unduly affecting their performance, applications that wish to
-manage their own local memory registrations may do so by using the
-memory registration calls.  Applications may use the FI_LOCAL_MR
-domain mode bit as a guide.
+The following apply to memory registration.
 
-When the FI_LOCAL_MR mode bit is set, applications must register all
-data buffers that will be accessed by the local hardware and provide
-a valid mem_desc parameter into applicable data transfer operations.
-When FI_LOCAL_MR is zero, applications are not required to register
-data buffers before using them for local operations (e.g. send and
-receive data buffers), and the mem_desc parameter into data transfer
-operations is ignored.
+*Scalable Memory Registration*
+: By default, memory registration is considered scalable.  (For library versions
+  1.4 and earlier, this is indicated by setting mr_mode to FI_MR_SCALABLE,
+  with the fi_info mode bit FI_LOCAL_MR set to 0).  For versions 1.5 and later,
+  scalable is implied by the lack of any mr_mode bits being set.  The setting
+  of mr_mode bits therefore adjusts application behavior as described below.
+  Default, scalable registration has several properties.
 
-Further behavior of memory registration operations is
-controlled based on the mr_mode field in the domain attribute.
-
-*Basic Memory Registration Mode*
-: If the mr_mode field is set to FI_MR_BASIC, then memory registration
-  operations are set to basic mode.  In basic mode, registration occurs
-  on allocated data buffers, and the MR attributes are selected by
-  the provider.
-
-  Basic mode uses provider assigned attributes for the registered buffers.
-  The local memory descriptor and remote memory key are selected by
-  the provider.  The address used to access a buffer as the target of an
-  RMA or atomic operation is the same as the virtual address of the buffer.
-
-  Applications that support the basic registration mode will need to
-  exchange MR parameters with remote peers for RMA and atomic
-  operations.  The exchanged data should include both the address of
-  the memory region as well as the MR key.
-
-*Scalable Memory Registration Mode*
-: If the mr_mode field is set to FI_MR_SCALABLE, then memory registration
-  operations are set to scalable mode.  In scalable mode, registration
-  occurs on memory address ranges, and the MR attributes are selected by
-  the user.
-
-  Memory regions registered as the target of RMA and atomic operations are
-  associated with a MR key selected by the application.  If local
-  registrations are required (see FI_LOCAL_MR mode), the local descriptor
-  will be the same as the remote key.  The resulting memory
-  region will be accessible by remote peers starting at a base address of 0.
-  Because scalable registration mode refers to memory regions, versus data
-  buffers, the address ranges given for a registration request do not need
-  to map to data buffers allocated by the application at the time the
-  registration call is made.  That is, an application can register any
+  In scalable mode, registration occurs on memory address ranges.
+  Because registration refers to memory regions, versus data buffers, the
+  address ranges given for a registration request do not need to map to
+  data buffers allocated by the application at the time the registration
+  call is made.  That is, an application can register any
   range of addresses in their virtual address space, whether or not those
   addresses are backed by physical pages or have been allocated.
+
+  The resulting memory regions are accessible by peers starting at a base
+  address of 0.  That is, the target address that is specified is a byte
+  offset into the registered region.
+
+  The application also selects the access key associated with the MR.  The
+  key size is restricted to a maximum of 8 bytes.
+
+  With scalable registration, locally accessed data buffers are not registered.
+  This includes source buffers for all transmit operations -- sends,
+  tagged sends, RMA, and atomics -- as well as buffers posted for receive
+  and tagged receive operations.
+
+*FI_MR_LOCAL*
+: When the FI_MR_LOCAL mode bit is set, applications must register all
+  data buffers that will be accessed by the local hardware and provide
+  a valid mem_desc parameter into applicable data transfer operations.
+  When FI_MR_LOCAL is zero, applications are not required to register
+  data buffers before using them for local operations (e.g. send and
+  receive data buffers), and the mem_desc parameter into data transfer
+  operations is ignored.
+
+  A provider may hide local registration requirements from applications
+  by making use of an internal registration cache or similar mechanisms.
+  Such mechanisms, however, may negatively impact performance for some
+  applications, notably those which manage their own network buffers.
+  In order to support as broad range of applications as possible,
+  without unduly affecting their performance, applications that wish to
+  manage their own local memory registrations may do so by using the
+  memory registration calls.
+
+  Note: the FI_MR_LOCAL mr_mode bit replaces the FI_LOCAL_MR fi_info mode bit.
+  When FI_MR_LOCAL is set, FI_LOCAL_MR is ignored.
+
+*FI_MR_RAW*
+: Raw memory regions are used to support providers with keys larger than
+  64-bits or require setup at the peer.  When the FI_MR_RAW bit is set,
+  applications must use fi_mr_raw_attr() locally and fi_mr_map_raw()
+  at the peer before targeting a memory region as part of any data transfer
+  request.
+
+*FI_MR_VIRT_ADDR*
+: The FI_MR_VIRT_ADDR bit indicates that the provider references memory
+  regions by virtual address, rather than a 0-based offset.  Peers that
+  target memory regions registered with FI_MR_VIRT_ADDR specify the
+  destination memory buffer using the target's virtual address, with any
+  offset into the region specified as virtual address + offset.  Support
+  of this bit typically implies that peers must exchange addressing data
+  prior to initiating any RMA or atomic operation.
+
+*FI_MR_ALLOCATED*
+: When set, all registered memory regions must be backed by physical
+  memory pages at the time the registration call is made.
+
+*FI_MR_PROV_KEY*
+: This memory region mode indicates that the provider does not support
+  application requested MR keys.  MR keys are returned by the provider.
+  Applications that support FI_MR_PROV_KEY can obtain the provider key
+  using fi_mr_key(), unless FI_MR_RAW is also set. The returned key should
+  then be exchanged with peers prior to initiating an RMA or atomic
+  operation.
+
+*FI_MR_MMU_NOTIFY*
+: FI_MR_MMU_NOTIFY is typically set by providers that support memory
+  registration against memory regions that are not necessarily backed by
+  allocated physical pages at the time the memory registration occurs.
+  (That is, FI_MR_ALLOCATED is typically 0).  However, such providers
+  require that applications notify the provider prior to the MR being
+  accessed as part of a data transfer operation.  This notification
+  informs the provider that all necessary physical pages now back the
+  region.  The notification is necessary for providers that cannot
+  hook directly into the operating system page tables or memory management
+  unit.  TODO: Define notification mechanism and data.
+
+*Basic Memory Registration*
+: Basic memory registration is indicated by the FI_MR_BASIC mr_mode bit
+  in library versions 1.4 and earlier.  Basic registration is equivalent
+  to setting the following mr_mode bits to one: FI_MR_VIRT_ADDR,
+  FI_MR_ALLOCATED, and FI_MR_PROV_KEY.  Additionally, providers that
+  supported basic registation usually required FI_MR_LOCAL.  FI_MR_BASIC
+  is provided for backwards compatibility.  Applications coding to
+  libfabric version 1.5 or later should set the independent mr_mode bits.
 
 The registrations functions -- fi_mr_reg, fi_mr_regv, and
 fi_mr_regattr -- are used to register one or more memory regions with
@@ -229,12 +294,49 @@ When closing the MR, there must be no opened endpoints or counters associated
 with the MR.  If resources are still associated with the MR when attempting to
 close, the call will return -FI_EBUSY.
 
-## fi_mr_desc / fi_mr_key
+## fi_mr_desc
 
-The local memory descriptor and remote protection key associated with
-a MR may be obtained by calling fi_mr_desc and fi_mr_key,
-respectively.  The memory registration must have completed
-successfully before invoking these calls.
+Obtains the local memory descriptor associated with a MR.
+The memory registration must have completed successfully before invoking
+this call.
+
+## fi_mr_key
+
+Returns the remote protection key associated with a MR.  The memory
+registration must have completed successfully before invoking this.  The
+returned key may be used in data transfer operations at a peer.  If the
+FI_RAW_MR mode bit has been set for the domain, then the memory key must
+be obtained using the fi_mr_raw_key function instead.  A return value of
+FI_KEY_NOTAVAIL will be returned if the registration has not completed
+or a raw memory key is required.
+
+## fi_mr_raw_attr
+
+Returns the raw, remote protection key and base address associated with a MR.
+The memory registration must have completed successfully before invoking
+this routine.  Use of this call is required if the FI_RAW_MR mode bit has
+been set by the provider; however, it is safe to use this call with any
+memory region.
+
+A raw key must be mapped by a peer before it can be used in data transfer
+operations.  See fi_mr_map_key below.
+
+## fi_mr_map_raw
+
+Raw protection keys must be mapped to a usable key value before they
+can be used for data transfer operations.  The mapping is done by the
+peer that initiates the RMA or atomic operation.  The mapping function
+takes as input the raw key and its size, and returns the mapped key.
+Use of the fi_mr_map_raw function is required if the peer has the
+FI_RAW_MR mode bit set, but this routine may be called on any valid
+key.  All mapped keys must be freed by calling fi_mr_unmap_key when
+access to the peer memory region is no longer necessary.
+
+## fi_mr_unmap_key
+
+This call releases any resources that may have been allocated as part of
+mapping a raw memory key.  All mapped keys must be freed before the
+corresponding domain is closed.
 
 ## fi_mr_bind
 
@@ -339,6 +441,29 @@ keys are used to limit communication between endpoints.  Only peer endpoints
 that are programmed to use the same authorization key may access the memory
 region.  This field is ignored unless the fabric is opened with API version 1.5
 or greater.
+
+# NOTES
+
+Direct access to an application's memory by a remote peer requires that
+the application register the targeted memory buffer(s).  This is typically
+done by calling one of the fi_mr_reg* routines.  For FI_MR_PROV_KEY, the
+provider will return a key that must be used by the peer when accessing
+the memory region.  The application is responsible for transferring this
+key to the peer.  If FI_MR_RAW mode has been set, the key must be retrieved
+using the fi_mr_raw_attr function.
+
+FI_RAW_MR allows support for providers that require more than 8-bytes for
+their protection keys or need additional setup before a key can
+be used for transfers.  After a raw key has been retrieved, it must be
+exchanged with the remote peer.  The peer must use fi_mr_map_raw to convert
+the raw key into a usable 64-bit key.  The mapping must be done even if
+the raw key is 64-bits or smaller.
+
+The raw key support functions are usable with all registered memory
+regions, even if FI_MR_RAW has not been set.  It is recommended that
+portable applications target using those interfaces; however, their use
+does carry extra message and memory footprint overhead, making it less
+desirable for highly scalable apps.
 
 # FLAGS
 

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -415,16 +415,18 @@ static void fi_tostr_av_type(char *buf, enum fi_av_type type)
 	}
 }
 
-static void fi_tostr_mr_mode(char *buf, enum fi_mr_mode type)
+static void fi_tostr_mr_mode(char *buf, int mr_mode)
 {
-	switch (type) {
-	CASEENUMSTR(FI_MR_UNSPEC);
-	CASEENUMSTR(FI_MR_BASIC);
-	CASEENUMSTR(FI_MR_SCALABLE);
-	default:
-		strcatf(buf, "Unknown");
-		break;
-	}
+	IFFLAGSTR(mr_mode, FI_MR_BASIC);
+	IFFLAGSTR(mr_mode, FI_MR_SCALABLE);
+	IFFLAGSTR(mr_mode, FI_MR_LOCAL);
+	IFFLAGSTR(mr_mode, FI_MR_RAW);
+	IFFLAGSTR(mr_mode, FI_MR_VIRT_ADDR);
+	IFFLAGSTR(mr_mode, FI_MR_ALLOCATED);
+	IFFLAGSTR(mr_mode, FI_MR_PROV_KEY);
+	IFFLAGSTR(mr_mode, FI_MR_MMU_NOTIFY);
+
+	fi_remove_comma(buf);
 }
 
 static void fi_tostr_domain_attr(char *buf, const struct fi_domain_attr *attr,
@@ -456,9 +458,9 @@ static void fi_tostr_domain_attr(char *buf, const struct fi_domain_attr *attr,
 	strcatf(buf, "%s%sav_type: ", prefix, TAB);
 	fi_tostr_av_type(buf, attr->av_type);
 	strcatf(buf, "\n");
-	strcatf(buf, "%s%smr_mode: ", prefix, TAB);
+	strcatf(buf, "%s%smr_mode: [ ", prefix, TAB);
 	fi_tostr_mr_mode(buf, attr->mr_mode);
-	strcatf(buf, "\n");
+	strcatf(buf, " ]\n");
 
 	strcatf(buf, "%s%smr_key_size: %zd\n", prefix, TAB, attr->mr_key_size);
 	strcatf(buf, "%s%scq_data_size: %zd\n", prefix, TAB, attr->cq_data_size);


### PR DESCRIPTION
In order to support a broader array of hardware types, we need
to expand the memory registration mode types.  The current MR
modes: scalable and basic, each define several different MR
attributes.  We break these attributes into their own MR mode
bits.  To do so, we convert the domain attribute mr_mode from
an enum to an int.  This provides backwards compatibility, but
allows us to define flags.

A total of 6 MR mode bit flags are defined.  The new default for
registered memory is now scalable.  Applications can then set
mode bits for the options that they support.  Each option
corresponds to specific actions that an application must take
in order to suport that option.

Most of the options are attributes implied by the FI_MR_BASIC
MR mode.  A new option is defined to support MR keys larger than
64-bits (FI_MR_RAW).  Another option is defined to support GNI
hardware restrictions (FI_MR_MMU_NOTIFY).  Finally, in order to
group all MR mode bits together, we move the FI_LOCAL_MR mode
bit from fi_info to fi_domain_attr (and rename, since we can't
fit the actual assigned bit value into 32-bits).


Derived from work by: Oblomov, Sergey <sergey.oblomov@intel.com>

Signed-off-by: Sean Hefty <sean.hefty@intel.com>