### PR TITLE
poll: mask user and real-time signals

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -64,7 +64,21 @@ int fi_poll_fd(int fd, int timeout)
 
 	fds.fd = fd;
 	fds.events = POLLIN;
-	ret = poll(&fds, 1, timeout);
+
+	// set the timeout value
+	struct timespec tmo = {0, timeout*1000000 /* milisec -> nanosec */};
+
+	// to set the signal mask
+        sigset_t set;
+
+         /* Block SIGUSR1, SIGUSR2, and all realtime signals from SIGRTMIN to SIGRTMAX */
+        sigemptyset(&set);
+        sigaddset(&set, SIGUSR1);
+        sigaddset(&set, SIGUSR2);
+	for (int i = SIGRTMIN; i <= SIGRTMAX; i++)
+	        sigaddset(&set, i);
+
+	ret = ppoll(&fds, 1, &tmo, &set);
 	return ret == -1 ? -errno : ret;
 }
 


### PR DESCRIPTION
SIGUSR1, SIGUSR2, and SIGRT signals should not cause the process to abort; they can be legitimately used in user apps safely. These signals, however, cause poll() to abort as it is not interrupt safe. This patch permits polling safely with ppoll() while masking those signal temporarily during the call.