### PR TITLE
poll: mask user and real-time signals

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -64,7 +64,20 @@ int fi_poll_fd(int fd, int timeout)
 
 	fds.fd = fd;
 	fds.events = POLLIN;
-	ret = poll(&fds, 1, timeout);
+
+	// to set the signal mask
+        sigset_t orgmask, sigmask;
+
+         /* Block SIGUSR1, SIGUSR2, and all realtime signals from SIGRTMIN to SIGRTMAX */
+        sigemptyset(&sigmask);
+        sigaddset(&sigmask, SIGUSR1);
+        sigaddset(&sigmask, SIGUSR2);
+	for (int i = SIGRTMIN; i <= SIGRTMAX; i++)
+	        sigaddset(&sigmask, i);
+        pthread_sigmask(SIG_SETMASK, &sigmask, &orgmask);
+        ret = poll(&fds, 1, timeout);
+        pthread_sigmask(SIG_SETMASK, &orgmask, NULL);
+
 	return ret == -1 ? -errno : ret;
 }
 


### PR DESCRIPTION
SIGUSR1, SIGUSR2, and SIGRT signals should not cause the process to abort; they can be legitimately used in user apps safely. These signals, however, cause poll() to abort as it is not interrupt safe. This patch permits polling safely with ppoll() while masking those signal temporarily during the call.

Signed-off-by: Halim Amer <aamer@anl.gov>