### PR TITLE
prov/sockets: Add/release CQ reference count from EP

### DIFF
--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -60,12 +60,15 @@ void sock_cntr_add_tx_ctx(struct sock_cntr *cntr, struct sock_tx_ctx *tx_ctx)
 	ret = fid_list_insert(&cntr->tx_list, &cntr->list_lock, fid);
 	if (ret)
 		SOCK_LOG_ERROR("Error in adding ctx to progress list\n");
+	else
+		atomic_inc(&cntr->ref);
 }
 
 void sock_cntr_remove_tx_ctx(struct sock_cntr *cntr, struct sock_tx_ctx *tx_ctx)
 {
 	struct fid *fid = &tx_ctx->fid.ctx.fid;
 	fid_list_remove(&cntr->tx_list, &cntr->list_lock, fid);
+	atomic_dec(&cntr->ref);
 }
 
 void sock_cntr_add_rx_ctx(struct sock_cntr *cntr, struct sock_rx_ctx *rx_ctx)
@@ -75,12 +78,15 @@ void sock_cntr_add_rx_ctx(struct sock_cntr *cntr, struct sock_rx_ctx *rx_ctx)
 	ret = fid_list_insert(&cntr->rx_list, &cntr->list_lock, fid);
 	if (ret)
 		SOCK_LOG_ERROR("Error in adding ctx to progress list\n");
+	else
+		atomic_inc(&cntr->ref);
 }
 
 void sock_cntr_remove_rx_ctx(struct sock_cntr *cntr, struct sock_rx_ctx *rx_ctx)
 {
 	struct fid *fid = &rx_ctx->ctx.fid;
 	fid_list_remove(&cntr->rx_list, &cntr->list_lock, fid);
+	atomic_dec(&cntr->ref);
 }
 
 int sock_cntr_progress(struct sock_cntr *cntr)

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -62,15 +62,17 @@ void sock_cq_add_tx_ctx(struct sock_cq *cq, struct sock_tx_ctx *tx_ctx)
 			goto out;
 	}
 	dlist_insert_tail(&tx_ctx->cq_entry, &cq->tx_list);
+	atomic_inc(&cq->ref);
 out:
 	fastlock_release(&cq->list_lock);
 }
 
 void sock_cq_remove_tx_ctx(struct sock_cq *cq, struct sock_tx_ctx *tx_ctx)
 {
-		fastlock_acquire(&cq->list_lock);
-		dlist_remove(&tx_ctx->cq_entry);
-		fastlock_release(&cq->list_lock);
+	fastlock_acquire(&cq->list_lock);
+	dlist_remove(&tx_ctx->cq_entry);
+	atomic_dec(&cq->ref);
+	fastlock_release(&cq->list_lock);
 }
 
 void sock_cq_add_rx_ctx(struct sock_cq *cq, struct sock_rx_ctx *rx_ctx)
@@ -86,15 +88,17 @@ void sock_cq_add_rx_ctx(struct sock_cq *cq, struct sock_rx_ctx *rx_ctx)
 			goto out;
 	}
 	dlist_insert_tail(&rx_ctx->cq_entry, &cq->rx_list);
+	atomic_inc(&cq->ref);
 out:
 	fastlock_release(&cq->list_lock);
 }
 
 void sock_cq_remove_rx_ctx(struct sock_cq *cq, struct sock_rx_ctx *rx_ctx)
 {
-		fastlock_acquire(&cq->list_lock);
-		dlist_remove(&rx_ctx->cq_entry);
-		fastlock_release(&cq->list_lock);
+	fastlock_acquire(&cq->list_lock);
+	dlist_remove(&rx_ctx->cq_entry);
+	atomic_dec(&cq->ref);
+	fastlock_release(&cq->list_lock);
 }
 
 int sock_cq_progress(struct sock_cq *cq)


### PR DESCRIPTION
When binding a CQ to an EP or Rx/Tx context, increment the CQ
reference count.  Release the reference when removing the binding.
This will fail attempts to close the CQ while it is in use.

Fixes #2662

Signed-off-by: Sean Hefty <sean.hefty@intel.com>