### PR TITLE
Updates to common util code and verbs provider.

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -494,7 +494,8 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 			 FI_REMOTE_READ | FI_REMOTE_WRITE)
 
 #define FI_SECONDARY_CAPS (FI_MULTI_RECV | FI_SOURCE | FI_RMA_EVENT | \
-			   FI_TRIGGER | FI_FENCE)
+			   FI_SHARED_AV | FI_TRIGGER | FI_FENCE | \
+			   FI_LOCAL_COMM | FI_REMOTE_COMM)
 
 int ofi_check_fabric_attr(const struct fi_provider *prov,
 			 const struct fi_fabric_attr *prov_attr,

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -496,27 +496,27 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 #define FI_SECONDARY_CAPS (FI_MULTI_RECV | FI_SOURCE | FI_RMA_EVENT | \
 			   FI_TRIGGER | FI_FENCE)
 
-int fi_check_fabric_attr(const struct fi_provider *prov,
+int ofi_check_fabric_attr(const struct fi_provider *prov,
 			 const struct fi_fabric_attr *prov_attr,
 			 const struct fi_fabric_attr *user_attr,
 			 enum fi_match_type type);
 int fi_check_wait_attr(const struct fi_provider *prov,
 		       const struct fi_wait_attr *attr);
-int fi_check_domain_attr(const struct fi_provider *prov,
+int ofi_check_domain_attr(const struct fi_provider *prov,
 			 const struct fi_domain_attr *prov_attr,
 			 const struct fi_domain_attr *user_attr,
 			 enum fi_match_type type);
-int fi_check_ep_attr(const struct util_prov *util_prov,
+int ofi_check_ep_attr(const struct util_prov *util_prov,
 		     const struct fi_ep_attr *user_attr);
 int fi_check_cq_attr(const struct fi_provider *prov,
 		     const struct fi_cq_attr *attr);
-int fi_check_rx_attr(const struct fi_provider *prov,
+int ofi_check_rx_attr(const struct fi_provider *prov,
 		     const struct fi_rx_attr *prov_attr,
 		     const struct fi_rx_attr *user_attr);
-int fi_check_tx_attr(const struct fi_provider *prov,
+int ofi_check_tx_attr(const struct fi_provider *prov,
 		     const struct fi_tx_attr *prov_attr,
 		     const struct fi_tx_attr *user_attr);
-int fi_check_info(const struct util_prov *util_prov,
+int ofi_check_info(const struct util_prov *util_prov,
 		  const struct fi_info *user_info,
 		  enum fi_match_type type);
 void ofi_alter_info(struct fi_info *info,

--- a/prov/mlx/src/mlx_domain.c
+++ b/prov/mlx/src/mlx_domain.c
@@ -83,7 +83,7 @@ int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_EINVAL;
 	}
 
-	ofi_status = fi_check_info(&mlx_util_prov, info, FI_MATCH_EXACT);
+	ofi_status = ofi_check_info(&mlx_util_prov, info, FI_MATCH_EXACT);
 	if (ofi_status) {
 		return ofi_status;
 	}

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -237,7 +237,7 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct rxd_domain *rxd_domain;
 	struct rxd_fabric *rxd_fabric;
 
-	ret = fi_check_info(&rxd_util_prov, info, FI_MATCH_PREFIX);
+	ret = ofi_check_info(&rxd_util_prov, info, FI_MATCH_PREFIX);
 	if (ret)
 		return ret;
 

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1722,7 +1722,7 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct rxd_ep *rxd_ep;
 	struct rxd_domain *rxd_domain;
 
-	ret = fi_check_info(&rxd_util_prov, info, FI_MATCH_PREFIX);
+	ret = ofi_check_info(&rxd_util_prov, info, FI_MATCH_PREFIX);
 	if (ret)
 		return ret;
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1108,7 +1108,7 @@ static int sock_ep_tx_ctx(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
 		return -FI_EINVAL;
 
 	if (attr) {
-		if (fi_check_tx_attr(&sock_prov, &sock_ep->tx_attr, attr))
+		if (ofi_check_tx_attr(&sock_prov, &sock_ep->tx_attr, attr))
 			return -FI_ENODATA;
 		tx_ctx = sock_tx_ctx_alloc(attr, context, 0);
 	} else {
@@ -1149,7 +1149,7 @@ static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 		return -FI_EINVAL;
 
 	if (attr) {
-		if (fi_check_rx_attr(&sock_prov, &sock_ep->rx_attr, attr))
+		if (ofi_check_rx_attr(&sock_prov, &sock_ep->rx_attr, attr))
 			return -FI_ENODATA;
 		rx_ctx = sock_rx_ctx_alloc(attr, context, 0);
 	} else {

--- a/prov/udp/src/udpx_init.c
+++ b/prov/udp/src/udpx_init.c
@@ -99,7 +99,7 @@ static void udpx_getinfo_ifs(struct fi_info **info)
 
 int udpx_check_info(struct fi_info *info)
 {
-	return fi_check_info(&udpx_util_prov, info, FI_MATCH_EXACT);
+	return ofi_check_info(&udpx_util_prov, info, FI_MATCH_EXACT);
 }
 
 static int udpx_getinfo(uint32_t version, const char *node, const char *service,

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -199,7 +199,7 @@ int ofix_getinfo(uint32_t version, const char *node, const char *service,
 	struct fi_info *temp = NULL, *fi, *tail = NULL;
 	int ret;
 
-	ret = fi_check_info(util_prov, hints, FI_MATCH_PREFIX);
+	ret = ofi_check_info(util_prov, hints, FI_MATCH_PREFIX);
 	if (ret)
 		goto err1;
 
@@ -246,7 +246,7 @@ static int fi_check_name(char *user_name, char *prov_name, enum fi_match_type ty
 		strcasecmp(prov_name, user_name);
 }
 
-int fi_check_fabric_attr(const struct fi_provider *prov,
+int ofi_check_fabric_attr(const struct fi_provider *prov,
 			 const struct fi_fabric_attr *prov_attr,
 			 const struct fi_fabric_attr *user_attr,
 			 enum fi_match_type type)
@@ -321,7 +321,7 @@ static int fi_resource_mgmt_level(enum fi_resource_mgmt rm_model)
 	}
 }
 
-int fi_check_domain_attr(const struct fi_provider *prov,
+int ofi_check_domain_attr(const struct fi_provider *prov,
 			 const struct fi_domain_attr *prov_attr,
 			 const struct fi_domain_attr *user_attr,
 			 enum fi_match_type type)
@@ -375,7 +375,7 @@ int fi_check_domain_attr(const struct fi_provider *prov,
 	return 0;
 }
 
-int fi_check_ep_attr(const struct util_prov *util_prov,
+int ofi_check_ep_attr(const struct util_prov *util_prov,
 		     const struct fi_ep_attr *user_attr)
 {
 	const struct fi_provider *prov = util_prov->prov;
@@ -438,7 +438,7 @@ int fi_check_ep_attr(const struct util_prov *util_prov,
 	return 0;
 }
 
-int fi_check_rx_attr(const struct fi_provider *prov,
+int ofi_check_rx_attr(const struct fi_provider *prov,
 		     const struct fi_rx_attr *prov_attr,
 		     const struct fi_rx_attr *user_attr)
 {
@@ -490,7 +490,7 @@ int fi_check_rx_attr(const struct fi_provider *prov,
 	return 0;
 }
 
-int fi_check_tx_attr(const struct fi_provider *prov,
+int ofi_check_tx_attr(const struct fi_provider *prov,
 		     const struct fi_tx_attr *prov_attr,
 		     const struct fi_tx_attr *user_attr)
 {
@@ -547,7 +547,7 @@ int fi_check_tx_attr(const struct fi_provider *prov,
 	return 0;
 }
 
-int fi_check_info(const struct util_prov *util_prov,
+int ofi_check_info(const struct util_prov *util_prov,
 		  const struct fi_info *user_info,
 		  enum fi_match_type type)
 {
@@ -577,7 +577,7 @@ int fi_check_info(const struct util_prov *util_prov,
 	}
 
 	if (user_info->fabric_attr) {
-		ret = fi_check_fabric_attr(prov, prov_info->fabric_attr,
+		ret = ofi_check_fabric_attr(prov, prov_info->fabric_attr,
 					   user_info->fabric_attr,
 					   type);
 		if (ret)
@@ -585,7 +585,7 @@ int fi_check_info(const struct util_prov *util_prov,
 	}
 
 	if (user_info->domain_attr) {
-		ret = fi_check_domain_attr(prov, prov_info->domain_attr,
+		ret = ofi_check_domain_attr(prov, prov_info->domain_attr,
 				user_info->domain_attr,
 				type);
 		if (ret)
@@ -593,20 +593,20 @@ int fi_check_info(const struct util_prov *util_prov,
 	}
 
 	if (user_info->ep_attr) {
-		ret = fi_check_ep_attr(util_prov, user_info->ep_attr);
+		ret = ofi_check_ep_attr(util_prov, user_info->ep_attr);
 		if (ret)
 			return ret;
 	}
 
 	if (user_info->rx_attr) {
-		ret = fi_check_rx_attr(prov, prov_info->rx_attr,
+		ret = ofi_check_rx_attr(prov, prov_info->rx_attr,
 				user_info->rx_attr);
 		if (ret)
 			return ret;
 	}
 
 	if (user_info->tx_attr) {
-		ret = fi_check_tx_attr(prov, prov_info->tx_attr,
+		ret = ofi_check_tx_attr(prov, prov_info->tx_attr,
 				user_info->tx_attr);
 		if (ret)
 			return ret;

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -65,7 +65,7 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	if (!info || !info->ep_attr || !info->rx_attr || !info->tx_attr)
 		return -FI_EINVAL;
 
-	ret = fi_check_info(util_prov, info, type);
+	ret = ofi_check_info(util_prov, info, type);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_fabric.c
+++ b/prov/util/src/util_fabric.c
@@ -62,7 +62,7 @@ int ofi_fabric_init(const struct fi_provider *prov,
 {
 	int ret;
 
-	ret = fi_check_fabric_attr(prov, prov_attr, user_attr, type);
+	ret = ofi_check_fabric_attr(prov, prov_attr, user_attr, type);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -165,7 +165,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		return -FI_EINVAL;
 	}
 
-	ret = fi_check_info(util_prov, hints, FI_MATCH_EXACT);
+	ret = ofi_check_info(util_prov, hints, FI_MATCH_EXACT);
 	if (ret)
 		return ret;
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -320,7 +320,6 @@ void fi_ibv_free_info();
 int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, struct fi_info *hints, struct fi_info **info);
 struct fi_info *fi_ibv_get_verbs_info(const char *domain_name);
-void fi_ibv_update_info(const struct fi_info *hints, struct fi_info *info);
 int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags,
 		     struct rdma_addrinfo *rai);
 int fi_ibv_get_rdma_rai(const char *node, const char *service, uint64_t flags,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -183,6 +183,7 @@ struct fi_ibv_pep {
 	int			backlog;
 	int			bound;
 	size_t			src_addrlen;
+	struct fi_info		*info;
 };
 
 struct fi_ops_cm *fi_ibv_pep_ops_cm(struct fi_ibv_pep *pep);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -335,10 +335,6 @@ struct verbs_ep_domain {
 
 extern const struct verbs_ep_domain verbs_rdm_domain;
 
-int fi_ibv_check_fabric_attr(const struct fi_fabric_attr *attr,
-			     const struct fi_info *info);
-int fi_ibv_check_domain_attr(const struct fi_domain_attr *attr,
-			     const struct fi_info *info);
 int fi_ibv_check_ep_attr(const struct fi_ep_attr *attr,
 			 const struct fi_info *info);
 int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -32,6 +32,7 @@
 
 #include "config.h"
 
+#include <fi_util.h>
 #include "fi_verbs.h"
 #include "ep_rdm/verbs_rdm.h"
 
@@ -277,7 +278,8 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (!fi)
 		return -FI_EINVAL;
 
-	ret = fi_ibv_check_domain_attr(info->domain_attr, fi);
+	ret = ofi_check_domain_attr(&fi_ibv_prov, fi->domain_attr,
+			info->domain_attr, FI_MATCH_EXACT);
 	if (ret)
 		return ret;
 

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -32,6 +32,7 @@
 
 #include "config.h"
 
+#include <fi_util.h>
 #include "fi_verbs.h"
 
 
@@ -70,7 +71,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event,
 	if (!(info->fabric_attr->prov_name = strdup(VERBS_PROV_NAME)))
 		goto err;
 
-	fi_ibv_update_info(pep_info, info);
+	ofi_alter_info(info, pep_info);
 
 	info->src_addrlen = fi_ibv_sockaddr_len(rdma_get_local_addr(event->id));
 	if (!(info->src_addr = malloc(info->src_addrlen)))

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -51,9 +51,9 @@ fi_ibv_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 	return sizeof(*entry);
 }
 
-/* TODO: This should copy the listening fi_info as the base */
 static struct fi_info *
-fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
+fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event,
+		struct fi_info *pep_info)
 {
 	struct fi_info *info, *fi;
 	struct fi_ibv_connreq *connreq;
@@ -70,7 +70,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event)
 	if (!(info->fabric_attr->prov_name = strdup(VERBS_PROV_NAME)))
 		goto err;
 
-	fi_ibv_update_info(NULL, info);
+	fi_ibv_update_info(pep_info, info);
 
 	info->src_addrlen = fi_ibv_sockaddr_len(rdma_get_local_addr(event->id));
 	if (!(info->src_addr = malloc(info->src_addrlen)))
@@ -107,10 +107,12 @@ static ssize_t
 fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event,
 	uint32_t *event, struct fi_eq_cm_entry *entry, size_t len)
 {
+	struct fi_ibv_pep *pep;
 	fid_t fid;
 	size_t datalen;
 
 	fid = cma_event->id->context;
+	pep = container_of(fid, struct fi_ibv_pep, pep_fid);
 	switch (cma_event->event) {
 //	case RDMA_CM_EVENT_ADDR_RESOLVED:
 //		return 0;
@@ -118,7 +120,7 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 //		return 0;
 	case RDMA_CM_EVENT_CONNECT_REQUEST:
 		*event = FI_CONNREQ;
-		entry->info = fi_ibv_eq_cm_getinfo(eq->fab, cma_event);
+		entry->info = fi_ibv_eq_cm_getinfo(eq->fab, cma_event, pep->info);
 		if (!entry->info) {
 			rdma_destroy_id(cma_event->id);
 			return 0;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1037,30 +1037,6 @@ unlock:
 	return ret;
 }
 
-void fi_ibv_update_info(const struct fi_info *hints, struct fi_info *info)
-{
-	if (hints) {
-		if (hints->ep_attr) {
-			if (hints->ep_attr->tx_ctx_cnt)
-				info->ep_attr->tx_ctx_cnt = hints->ep_attr->tx_ctx_cnt;
-			if (hints->ep_attr->rx_ctx_cnt)
-				info->ep_attr->rx_ctx_cnt = hints->ep_attr->rx_ctx_cnt;
-		}
-
-		if (hints->tx_attr)
-			info->tx_attr->op_flags = hints->tx_attr->op_flags;
-
-		if (hints->rx_attr)
-			info->rx_attr->op_flags = hints->rx_attr->op_flags;
-
-		if (hints->handle)
-			info->handle = hints->handle;
-	} else {
-		info->tx_attr->op_flags = 0;
-		info->rx_attr->op_flags = 0;
-	}
-}
-
 int fi_ibv_find_fabric(const struct fi_fabric_attr *attr)
 {
 	struct fi_info *fi;
@@ -1111,8 +1087,6 @@ static int fi_ibv_get_matching_info(const char *dev_name, struct fi_info *hints,
 			ret = -FI_ENOMEM;
 			goto err1;
 		}
-
-		fi_ibv_update_info(hints, fi);
 
 		if (!*info)
 			*info = fi;


### PR DESCRIPTION
- verbs: Use pep info as hints when creating new fi_info on incoming connection request.
- util: rename fi_check functions related to fi_getinfo to ofi_check
- util: Add additional checks to check_info functions
- verbs: Update check hints function to use common code
- verbs: Remove update_info function and use ofi_alter_info

