### PR TITLE
Fix unbalanced tx/rx counter refs in sockets prov

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -219,29 +219,38 @@ static int sock_ctx_bind_cntr(struct fid *fid, struct fid *bfid, uint64_t flags)
 	switch (fid->fclass) {
 	case FI_CLASS_TX_CTX:
 		tx_ctx = container_of(fid, struct sock_tx_ctx, fid.ctx.fid);
-		if (flags & FI_SEND)
+		if (flags & FI_SEND) {
 			tx_ctx->comp.send_cntr = cntr;
+			sock_cntr_add_tx_ctx(cntr, tx_ctx);
+		}
 
-		if (flags & FI_READ)
+		if (flags & FI_READ) {
 			tx_ctx->comp.read_cntr = cntr;
+			sock_cntr_add_tx_ctx(cntr, tx_ctx);
+		}
 
-		if (flags & FI_WRITE)
+		if (flags & FI_WRITE) {
 			tx_ctx->comp.write_cntr = cntr;
-
-		sock_cntr_add_tx_ctx(cntr, tx_ctx);
+			sock_cntr_add_tx_ctx(cntr, tx_ctx);
+		}
 		break;
 
 	case FI_CLASS_RX_CTX:
 		rx_ctx = container_of(fid, struct sock_rx_ctx, ctx.fid);
-		if (flags & FI_RECV)
+		if (flags & FI_RECV) {
 			rx_ctx->comp.recv_cntr = cntr;
+			sock_cntr_add_rx_ctx(cntr, rx_ctx);
+		}
 
-		if (flags & FI_REMOTE_READ)
+		if (flags & FI_REMOTE_READ) {
 			rx_ctx->comp.rem_read_cntr = cntr;
+			sock_cntr_add_rx_ctx(cntr, rx_ctx);
+		}
 
-		if (flags & FI_REMOTE_WRITE)
+		if (flags & FI_REMOTE_WRITE) {
 			rx_ctx->comp.rem_write_cntr = cntr;
-		sock_cntr_add_rx_ctx(cntr, rx_ctx);
+			sock_cntr_add_rx_ctx(cntr, rx_ctx);
+		}
 		break;
 
 	default:


### PR DESCRIPTION
The sockets provider was adding each counter once per ctx, in spite of
actually referencing it once per event class on the ctx.  As a result,
when closing the ctx, if the same cntr was handling multiple event
classes, it would be removed from the ctx more times than it was added,
causing the ref count on the cntr to become negative (and by extension,
causing an error when the application tried to close the cntr).

This fix adds the cntr on the ctx once per event class for parity with
the operations performed when closing the ctx.

Signed-off-by: James Dinan <james.dinan@intel.com>