### PR TITLE
usnic: fix compilation issue with new libibverbs

### DIFF
--- a/prov/usnic/Makefile.include
+++ b/prov/usnic/Makefile.include
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
+# Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU
@@ -135,7 +135,7 @@ _usnic_files = \
 	prov/usnic/src/usdf_wait.h \
 	prov/usnic/src/usdf_wait.c
 
-if HAVE_VERBS
+if USNIC_BUILD_FAKE_VERBS_DRIVER
 _usnic_files += prov/usnic/src/usdf_fake_ibv.c
 endif
 

--- a/prov/usnic/configure.m4
+++ b/prov/usnic/configure.m4
@@ -1,5 +1,5 @@
 dnl
-dnl Copyright (c) 2015-2016, Cisco Systems, Inc. All rights reserved.
+dnl Copyright (c) 2015-2017, Cisco Systems, Inc. All rights reserved.
 dnl
 dnl This software is available to you under a choice of one of two
 dnl licenses.  You may choose to be licensed under the terms of the GNU
@@ -104,7 +104,8 @@ AC_DEFUN([FI_USNIC_CONFIGURE],[
     AS_IF([test "x$enable_usnic" != "xno"],
 	  [AC_CHECK_HEADER([infiniband/verbs.h], [usnic_happy=1])
 	   AS_IF([test $usnic_happy -eq 1],
-	       [USNIC_CHECK_LIBNL_SADNESS])
+	       [USNIC_CHECK_IF_NEED_FAKE_USNIC
+	        USNIC_CHECK_LIBNL_SADNESS])
 	  ])
 ])
 
@@ -135,6 +136,42 @@ AC_DEFUN([USNIC_PARSE_WITH],[
 		usnic_$1_location="$2"
 		;;
 	esac
+])
+
+dnl
+dnl Check for ibv_register_driver
+dnl
+dnl If libibverbs is available and is old enough, we need to install a
+dnl "fake" usnic verbs driver to keep it from complaining to stderr
+dnl that there is no usnic verbs provider.  Newer versions of
+dnl libibverbs won't complain.  If we can detect a new-enough
+dnl libibverbs, don't bother to compile the fake usnic verbs driver.
+dnl
+dnl Per
+dnl https://github.com/ofiwg/libfabric/pull/2684#issuecomment-276462368,
+dnl the logic boils down to:
+dnl
+dnl Compile the fake usnic verbs provider if <infiniband/driver.h>
+dnl exists and do not contain a prototype for verbs_register_driver().
+dnl
+AC_DEFUN([USNIC_CHECK_IF_NEED_FAKE_USNIC],[
+	usnic_build_fake_driver=0
+	AC_CHECK_HEADER([infiniband/driver.h],
+		[AC_CHECK_DECL([verbs_register_driver],
+			[],
+			[usnic_build_fake_driver=1],
+			[#include <infiniband/driver.h>
+			])])
+
+	AC_MSG_CHECKING([if building usnic fake verbs driver])
+	AS_IF([test $usnic_build_fake_driver -eq 1],
+		[AC_MSG_RESULT([yes])],
+		[AC_MSG_RESULT([no])])
+	AC_DEFINE_UNQUOTED([USNIC_BUILD_FAKE_VERBS_DRIVER],
+		[$usnic_build_fake_driver],
+		[Whether to build the fake usNIC verbs provider or not])
+	AM_CONDITIONAL([USNIC_BUILD_FAKE_VERBS_DRIVER],
+		[test $usnic_build_fake_driver -eq 1])
 ])
 
 dnl

--- a/prov/usnic/configure.m4
+++ b/prov/usnic/configure.m4
@@ -228,8 +228,12 @@ AC_DEFUN([USNIC_CHECK_LIBNL_SADNESS],[
 	# handled in Makefile.am via an AM_CONDITIONAL.  However, to
 	# properly support pkg-config, we have to make this decision
 	# here/now and AC SUBST the final result into usnic_LIBS.
-	AS_IF([test "$verbs_dl" = "1" || test "$usnic_dl" = "1"],
-	      [usnic_LIBS="$usnic_LIBS -libverbs"])
+	usnic_verbs_lib=
+	AS_IF([test "$verbs_dl" = "1"],
+	      [usnic_verbs_lib="-libverbs"])
+	AS_IF([test "$usnic_dl" = "1" -a $usnic_build_fake_driver -eq 1],
+	      [usnic_verbs_lib="-libverbs"])
+	usnic_LIBS="$usnic_LIBS $usnic_verbs_lib"
 
 	AC_SUBST([usnic_CPPFLAGS])
 	AC_SUBST([usnic_LDFLAGS])

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -975,7 +975,7 @@ struct fi_provider usdf_ops = {
 
 USNIC_INI
 {
-#if HAVE_VERBS
+#if USNIC_BUILD_FAKE_VERBS_DRIVER
 	usdf_setup_fake_ibv_provider();
 #endif
 	return (&usdf_ops);

--- a/prov/usnic/src/usnic_direct/usd_event.c
+++ b/prov/usnic/src/usnic_direct/usd_event.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
  *
  * LICENSE_BEGIN
  *
@@ -44,8 +44,9 @@
 #include <unistd.h>
 #include <errno.h>
 
-#include <infiniband/kern-abi.h>
 #include <infiniband/verbs.h>
+
+#include <rdma/ib_user_verbs.h>
 
 #include "usnic_direct.h"
 #include "usd.h"
@@ -57,7 +58,7 @@ int
 usd_get_device_event(struct usd_device *dev,
                      struct usd_device_event *devent)
 {
-    struct ibv_kern_async_event ib_event;
+    struct ib_uverbs_async_event_desc ib_event;
     int n;
 
     n = read(dev->ud_attrs.uda_event_fd, &ib_event, sizeof(ib_event));

--- a/prov/usnic/src/usnic_direct/usd_ib_cmd.c
+++ b/prov/usnic/src/usnic_direct/usd_ib_cmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
  *
  * LICENSE_BEGIN
  *
@@ -66,8 +66,9 @@ usd_ib_cmd_get_context(struct usd_context *uctx)
 {
     struct usnic_get_context cmd;
     struct usnic_get_context_resp resp;
-    struct ibv_get_context *icp;
-    struct ibv_get_context_resp *irp;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_get_context *icp;
+    struct ib_uverbs_get_context_resp *irp;
     struct usnic_ib_get_context_cmd *ucp;
     struct usnic_ib_get_context_resp *urp;
     int n;
@@ -77,10 +78,12 @@ usd_ib_cmd_get_context(struct usd_context *uctx)
     memset(&resp, 0, sizeof(resp));
 
     /* fill in the command struct */
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_GET_CONTEXT;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(resp) / 4;
+
     icp = &cmd.ibv_cmd;
-    icp->command = IB_USER_VERBS_CMD_GET_CONTEXT;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(resp) / 4;
     icp->response = (uintptr_t) & resp;
 
     ucp = &cmd.usnic_cmd;
@@ -150,7 +153,8 @@ usd_ib_cmd_devcmd(
 {
     struct usnic_get_context cmd;
     struct usnic_get_context_resp resp;
-    struct ibv_get_context *icp;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_get_context *icp;
     struct usnic_ib_get_context_cmd *ucp;
     struct usnic_ib_get_context_resp *urp;
     struct usnic_udevcmd_cmd udevcmd;
@@ -167,10 +171,12 @@ usd_ib_cmd_devcmd(
     memset(&udevcmd_resp, 0, sizeof(udevcmd_resp));
 
     /* fill in the command struct */
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_GET_CONTEXT;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(resp) / 4;
+
     icp = &cmd.ibv_cmd;
-    icp->command = IB_USER_VERBS_CMD_GET_CONTEXT;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(resp) / 4;
     icp->response = (uintptr_t) & resp;
 
     /* fill in usnic devcmd struct */
@@ -229,16 +235,19 @@ _usd_ib_cmd_dealloc_pd(
     uint32_t pd_handle)
 {
     struct usnic_dealloc_pd cmd;
-    struct ibv_dealloc_pd *icp;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_dealloc_pd *icp;
     int n;
 
     memset(&cmd, 0, sizeof(cmd));
 
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_DEALLOC_PD;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = 0;
+
     icp = &cmd.ibv_cmd;
-    icp->command = IB_USER_VERBS_CMD_DEALLOC_PD;
     icp->pd_handle = pd_handle;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = 0;
 
     n = write(dev->ud_ctx->ucx_ib_dev_fd, &cmd, sizeof(cmd));
     if (n != sizeof(cmd)) {
@@ -260,9 +269,10 @@ _usd_ib_cmd_alloc_pd(
 {
     struct usnic_alloc_pd cmd;
     struct usnic_alloc_pd_resp resp;
-    struct ibv_alloc_pd *icp;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_alloc_pd *icp;
     struct usnic_ib_alloc_pd_cmd *ucp;
-    struct ibv_alloc_pd_resp *irp;
+    struct ib_uverbs_alloc_pd_resp *irp;
     struct usnic_ib_alloc_pd_resp *urp;
     int n;
 
@@ -270,10 +280,12 @@ _usd_ib_cmd_alloc_pd(
     memset(&resp, 0, sizeof(resp));
 
     /* fill in command */
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_ALLOC_PD;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(resp) / 4;
+
     icp = &cmd.ibv_cmd;
-    icp->command = IB_USER_VERBS_CMD_ALLOC_PD;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(resp) / 4;
     icp->response = (uintptr_t) & resp;
 
     /*
@@ -357,19 +369,21 @@ usd_ib_cmd_reg_mr(
 {
     struct usnic_reg_mr cmd;
     struct usnic_reg_mr_resp resp;
-    struct ibv_reg_mr *icp;
-    struct ibv_reg_mr_resp *irp;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_reg_mr *icp;
+    struct ib_uverbs_reg_mr_resp *irp;
     int n;
 
     memset(&cmd, 0, sizeof(cmd));
     memset(&resp, 0, sizeof(resp));
 
-    icp = &cmd.ibv_cmd;
-    icp->command = IB_USER_VERBS_CMD_REG_MR;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(resp) / 4;
-    icp->response = (uintptr_t) & resp;
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_REG_MR;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(resp) / 4;
 
+    icp = &cmd.ibv_cmd;
+    icp->response = (uintptr_t) & resp;
     icp->start = (uintptr_t) vaddr;
     icp->length = length;
     icp->hca_va = (uintptr_t) vaddr;
@@ -396,17 +410,19 @@ usd_ib_cmd_dereg_mr(
     struct usd_device *dev,
     struct usd_mr *mr)
 {
-    struct ibv_dereg_mr cmd;
-    struct ibv_dereg_mr *icp;
+    struct usnic_dereg_mr cmd;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_dereg_mr *icp;
     int n;
 
     memset(&cmd, 0, sizeof(cmd));
 
-    icp = &cmd;
-    icp->command = IB_USER_VERBS_CMD_DEREG_MR;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = 0;
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_DEREG_MR;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = 0;
 
+    icp = &cmd.ibv_cmd;
     icp->mr_handle = mr->umr_handle;
 
     /* Issue command to IB driver */
@@ -431,8 +447,9 @@ usd_ib_cmd_create_cq(
 {
     struct usnic_create_cq cmd;
     struct usnic_create_cq_resp resp;
-    struct ibv_create_cq *icp;
-    struct ibv_create_cq_resp *irp;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_create_cq *icp;
+    struct ib_uverbs_create_cq_resp *irp;
     cpu_set_t *affinity_mask = NULL;
     int flags = 0;
     int n;
@@ -440,10 +457,12 @@ usd_ib_cmd_create_cq(
     memset(&cmd, 0, sizeof(cmd));
     memset(&resp, 0, sizeof(resp));
 
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_CREATE_CQ;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(resp) / 4;
+
     icp = &cmd.ibv_cmd;
-    icp->command = IB_USER_VERBS_CMD_CREATE_CQ;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(resp) / 4;
     icp->response = (uintptr_t) & resp;
 
     if (ibv_cq == NULL) {
@@ -510,17 +529,19 @@ usd_ib_cmd_destroy_cq(
     struct usd_device *dev,
     struct usd_cq_impl *cq)
 {
-    struct ibv_destroy_cq cmd;
-    struct ibv_destroy_cq *icp;
+    struct usnic_destroy_cq cmd;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_destroy_cq *icp;
     int n;
 
     memset(&cmd, 0, sizeof(cmd));
 
-    icp = &cmd;
-    icp->command = IB_USER_VERBS_CMD_DESTROY_CQ;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = 0;
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_DESTROY_CQ;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = 0;
 
+    icp = &cmd.ibv_cmd;
     icp->cq_handle = cq->ucq_handle;
 
     /* Issue command to IB driver */
@@ -543,8 +564,9 @@ usd_ib_cmd_create_qp(
 {
     struct usnic_create_qp cmd;
     struct usnic_create_qp_resp *resp;
-    struct ibv_create_qp *icp;
-    struct ibv_create_qp_resp *irp = NULL;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_create_qp *icp;
+    struct ib_uverbs_create_qp_resp *irp = NULL;
     struct usnic_ib_create_qp_cmd *ucp;
     struct usnic_ib_create_qp_resp *urp;
     struct usd_qp_filter *qfilt;
@@ -564,12 +586,13 @@ usd_ib_cmd_create_qp(
         return -ENOMEM;
     }
 
-    icp = &cmd.ibv_cmd;
-    icp->command = IB_USER_VERBS_CMD_CREATE_QP;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(*resp) / 4;
-    icp->response = (uintptr_t) resp;
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_CREATE_QP;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(*resp) / 4;
 
+    icp = &cmd.ibv_cmd;
+    icp->response = (uintptr_t) resp;
     icp->user_handle = (uintptr_t) qp;
     icp->pd_handle = dev->ud_pd_handle;
     icp->send_cq_handle = qp->uq_wq.uwq_cq->ucq_handle;
@@ -725,17 +748,19 @@ usd_ib_cmd_modify_qp(
     struct usd_qp_impl *qp,
     int state)
 {
-    struct ibv_modify_qp cmd;
-    struct ibv_modify_qp *icp;
+    struct usnic_modify_qp cmd;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_modify_qp *icp;
     int n;
 
     memset(&cmd, 0, sizeof(cmd));
 
-    icp = &cmd;
-    icp->command = IB_USER_VERBS_CMD_MODIFY_QP;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = 0;
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_MODIFY_QP;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = 0;
 
+    icp = &cmd.ibv_cmd;
     icp->qp_handle = qp->uq_qp_handle;
     icp->attr_mask = IBV_QP_STATE;
     icp->qp_state = state;
@@ -754,19 +779,21 @@ usd_ib_cmd_destroy_qp(
     struct usd_device *dev,
     struct usd_qp_impl *qp)
 {
-    struct ibv_destroy_qp cmd;
-    struct ibv_destroy_qp_resp resp;
-    struct ibv_destroy_qp *icp;
+    struct usnic_destroy_qp cmd;
+    struct ib_uverbs_destroy_qp_resp resp;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_destroy_qp *icp;
     int n;
 
     memset(&cmd, 0, sizeof(cmd));
 
-    icp = &cmd;
-    icp->command = IB_USER_VERBS_CMD_DESTROY_QP;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(resp) / 4;
-    icp->response = (uintptr_t) & resp;
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_DESTROY_QP;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(resp) / 4;
 
+    icp = &cmd.ibv_cmd;
+    icp->response = (uintptr_t) & resp;
     icp->qp_handle = qp->uq_qp_handle;
 
     /* Issue command to IB driver */
@@ -781,18 +808,21 @@ usd_ib_cmd_destroy_qp(
 static int
 usd_ib_cmd_query_device(
     struct usd_device *dev,
-    struct ibv_query_device_resp *irp)
+    struct ib_uverbs_query_device_resp *irp)
 {
-    struct ibv_query_device cmd;
-    struct ibv_query_device *icp;
+    struct usnic_query_device cmd;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_query_device *icp;
     int n;
 
     memset(&cmd, 0, sizeof(cmd));
 
-    icp = &cmd;
-    icp->command = IB_USER_VERBS_CMD_QUERY_DEVICE;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(*irp) / 4;
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_QUERY_DEVICE;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(*irp) / 4;
+
+    icp = &cmd.ibv_cmd;
     icp->response = (uintptr_t) irp;
 
     /* keep Valgrind happy */
@@ -810,20 +840,22 @@ usd_ib_cmd_query_device(
 static int
 usd_ib_cmd_query_port(
     struct usd_device *dev,
-    struct ibv_query_port_resp *irp)
+    struct ib_uverbs_query_port_resp *irp)
 {
-    struct ibv_query_port cmd;
-    struct ibv_query_port *icp;
+    struct usnic_query_port cmd;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_query_port *icp;
     int n;
 
     memset(&cmd, 0, sizeof(cmd));
 
-    icp = &cmd;
-    icp->command = IB_USER_VERBS_CMD_QUERY_PORT;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(*irp) / 4;
-    icp->response = (uintptr_t) irp;
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_QUERY_PORT;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(*irp) / 4;
 
+    icp = &cmd.ibv_cmd;
+    icp->response = (uintptr_t) irp;
     icp->port_num = 1;
 
     /* keep Valgrind happy */
@@ -845,8 +877,8 @@ int
 usd_ib_query_dev(
     struct usd_device *dev)
 {
-    struct ibv_query_device_resp dresp;
-    struct ibv_query_port_resp presp;
+    struct ib_uverbs_query_device_resp dresp;
+    struct ib_uverbs_query_port_resp presp;
     struct usd_device_attrs *dap;
     unsigned speed;
     int ret;
@@ -925,17 +957,20 @@ usd_ib_cmd_create_comp_channel(
     int *comp_fd_o)
 {
     int n;
-    struct ibv_create_comp_channel cmd;
-    struct ibv_create_comp_channel_resp resp;
-    struct ibv_create_comp_channel *icp;
-    struct ibv_create_comp_channel_resp *irp;
+    struct usnic_create_comp_channel cmd;
+    struct ib_uverbs_create_comp_channel_resp resp;
+    struct ib_uverbs_cmd_hdr *ich;
+    struct ib_uverbs_create_comp_channel *icp;
+    struct ib_uverbs_create_comp_channel_resp *irp;
 
     memset(&cmd, 0, sizeof(cmd));
 
-    icp = &cmd;
-    icp->command = IB_USER_VERBS_CMD_CREATE_COMP_CHANNEL;
-    icp->in_words = sizeof(cmd) / 4;
-    icp->out_words = sizeof(resp) / 4;
+    ich = &cmd.ibv_cmd_hdr;
+    ich->command = IB_USER_VERBS_CMD_CREATE_COMP_CHANNEL;
+    ich->in_words = sizeof(cmd) / 4;
+    ich->out_words = sizeof(resp) / 4;
+
+    icp = &cmd.ibv_cmd;
     icp->response = (uintptr_t) & resp;
 
     /* Issue command to IB driver */

--- a/prov/usnic/src/usnic_direct/usnic_ib_abi.h
+++ b/prov/usnic/src/usnic_direct/usnic_ib_abi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2013-2017, Cisco Systems, Inc. All rights reserved.
  *
  * LICENSE_BEGIN
  *
@@ -44,68 +44,110 @@
 #ifndef USNIC_IB_ABI_H
 #define USNIC_IB_ABI_H
 
-#include <infiniband/kern-abi.h>
+#include "kcompat.h"
+#include <rdma/ib_user_verbs.h>
 
 /*
  * Pick up common file with driver
  */
 #include "usnic_abi.h"
 
-struct usnic_create_qp_resp {
-	struct ibv_create_qp_resp   ibv_resp;
-	struct usnic_ib_create_qp_resp usnic_resp;
+struct usnic_query_device {
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_query_device	ibv_cmd;
+};
+
+struct usnic_query_port {
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_query_port	ibv_cmd;
 };
 
 struct usnic_get_context {
-	struct ibv_get_context		ibv_cmd;
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_get_context	ibv_cmd;
 	struct usnic_ib_get_context_cmd usnic_cmd;
 	__u64				reserved;
 };
 
 struct usnic_get_context_resp {
-	struct ibv_get_context_resp	ibv_resp;
+	struct ib_uverbs_get_context_resp ibv_resp;
 	struct usnic_ib_get_context_resp usnic_resp;
 	__u64				reserved;
 };
 
 struct usnic_alloc_pd {
-	struct ibv_alloc_pd		ibv_cmd;
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_alloc_pd	ibv_cmd;
 	struct usnic_ib_alloc_pd_cmd	usnic_cmd;
 };
 
 struct usnic_alloc_pd_resp {
-	struct ibv_alloc_pd_resp	ibv_resp;
+	struct ib_uverbs_alloc_pd_resp	ibv_resp;
 	struct usnic_ib_alloc_pd_resp	usnic_resp;
 };
 
 struct usnic_dealloc_pd {
-	struct ibv_dealloc_pd		ibv_cmd;
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_dealloc_pd	ibv_cmd;
+};
+
+struct usnic_create_comp_channel {
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_create_comp_channel	ibv_cmd;
 };
 
 struct usnic_reg_mr {
-	struct ibv_reg_mr		ibv_cmd;
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_reg_mr		ibv_cmd;
 	__u64				reserved;
 };
 
 struct usnic_reg_mr_resp {
-	struct ibv_reg_mr_resp		ibv_resp;
+	struct ib_uverbs_reg_mr_resp	ibv_resp;
 	__u64				reserved;
 };
 
+struct usnic_dereg_mr {
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_dereg_mr	ibv_cmd;
+};
+
+struct usnic_create_qp {
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_create_qp	ibv_cmd;
+	struct usnic_ib_create_qp_cmd	usnic_cmd;
+	__u64				reserved[8];
+};
+
+struct usnic_create_qp_resp {
+	struct ib_uverbs_create_qp_resp	ibv_resp;
+	struct usnic_ib_create_qp_resp	usnic_resp;
+};
+
+struct usnic_modify_qp {
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_modify_qp	ibv_cmd;
+};
+
+struct usnic_destroy_qp {
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_destroy_qp	ibv_cmd;
+};
+
 struct usnic_create_cq {
-	struct ibv_create_cq		ibv_cmd;
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_create_cq	ibv_cmd;
 	struct usnic_ib_create_cq	usnic_cmd;
 };
 
 struct usnic_create_cq_resp {
-	struct ibv_create_cq_resp	ibv_resp;
+	struct ib_uverbs_create_cq_resp	ibv_resp;
 	struct usnic_ib_create_cq_resp	usnic_resp;
 };
 
-struct usnic_create_qp {
-	struct ibv_create_qp		ibv_cmd;
-	struct usnic_ib_create_qp_cmd	usnic_cmd;
-	__u64				reserved[8];
+struct usnic_destroy_cq {
+	struct ib_uverbs_cmd_hdr	ibv_cmd_hdr;
+	struct ib_uverbs_destroy_cq	ibv_cmd;
 };
 
 #endif /* USNIC_IB_ABI_H */


### PR DESCRIPTION
libibverbs recently modified the internals of struct ibv_modify_qp in
kern-abi.h.  This commit adds the relevant configury to the usnic
provider to handle both old and new <infiniband/kern-abi.h>.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Fixes #2682 