### PR TITLE
Remove unnecessary includes of infiniband/driver.h

### DIFF
--- a/prov/usnic/src/usnic_direct/usd_device.c
+++ b/prov/usnic/src/usnic_direct/usd_device.c
@@ -51,8 +51,6 @@
 #include <sys/stat.h>
 #include <sys/mman.h>
 
-#include <infiniband/driver.h>
-
 #include "usnic_direct.h"
 #include "usd.h"
 #include "usd_ib_sysfs.h"

--- a/prov/usnic/src/usnic_direct/usd_ib_cmd.c
+++ b/prov/usnic/src/usnic_direct/usd_ib_cmd.c
@@ -52,7 +52,7 @@
 #include <sys/mman.h>
 #include <sched.h>
 
-#include <infiniband/driver.h>
+#include <infiniband/verbs.h>
 
 #include "kcompat.h"
 #include "usnic_ib_abi.h"

--- a/prov/usnic/src/usnic_direct/usd_ib_sysfs.c
+++ b/prov/usnic/src/usnic_direct/usd_ib_sysfs.c
@@ -50,8 +50,6 @@
 #include <errno.h>
 #include <sys/stat.h>
 
-#include <infiniband/driver.h>
-
 #include "usd.h"
 #include "usd_ib_sysfs.h"
 #include "usd_util.h"

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -52,7 +52,6 @@
 
 #include <infiniband/ib.h>
 #include <infiniband/verbs.h>
-#include <infiniband/driver.h>
 #include <rdma/rdma_cma.h>
 
 #include <rdma/fabric.h>


### PR DESCRIPTION
None of the declarations from that file are being used and rdma-core
is going to stop exporting the header.

Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>