### PR TITLE
prov/gni: Updated gnix signatures to match direct

### DIFF
--- a/prov/gni/include/rdma/fi_direct_atomic.h
+++ b/prov/gni/include/rdma/fi_direct_atomic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All
  * rights reserved.
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
@@ -115,17 +115,17 @@ gnix_ep_atomic_compwritemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 			    void **result_desc, size_t result_count,
 			    uint64_t flags);
 
-extern ssize_t gnix_ep_atomic_valid(struct fid_ep *ep,
-				    enum fi_datatype datatype, enum fi_op op,
-				    size_t *);
+extern int gnix_ep_atomic_valid(struct fid_ep *ep,
+				enum fi_datatype datatype, enum fi_op op,
+				size_t *count);
 
 extern int gnix_ep_fetch_atomic_valid(struct fid_ep *ep,
 				      enum fi_datatype datatype, enum fi_op op,
 				      size_t *count);
 
-extern ssize_t gnix_ep_cmp_atomic_valid(struct fid_ep *ep,
-					enum fi_datatype datatype,
-					enum fi_op op, size_t *count);
+extern int gnix_ep_cmp_atomic_valid(struct fid_ep *ep,
+				    enum fi_datatype datatype,
+				    enum fi_op op, size_t *count);
 
 /*******************************************************************************
  * Libfabric API Functions

--- a/prov/gni/include/rdma/fi_direct_endpoint.h
+++ b/prov/gni/include/rdma/fi_direct_endpoint.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All
  * rights reserved.
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  *
@@ -52,7 +52,7 @@ extern int gnix_sep_open(struct fid_domain *domain,
 
 extern int gnix_ep_bind(fid_t fid, fid_t bfid, uint64_t flags);
 
-extern int gnix_pep_bind(fid_t pep, fid_t bfid, uint64_t flags);
+extern int gnix_pep_bind(fid_t pep, struct fid *bfid, uint64_t flags);
 
 extern int gnix_sep_bind(fid_t sep, fid_t bfid, uint64_t flags);
 

--- a/prov/gni/include/rdma/fi_direct_eq.h
+++ b/prov/gni/include/rdma/fi_direct_eq.h
@@ -56,13 +56,13 @@ extern int gnix_poll_del(struct fid_poll *pollset, struct fid *event_fid,
 extern int gnix_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 			struct fid_eq **eq, void *context);
 
-extern int gnix_eq_read(struct fid_eq *eq, uint32_t *event, void *buf,
+extern ssize_t gnix_eq_read(struct fid_eq *eq, uint32_t *event, void *buf,
 			size_t len, uint64_t flags);
 
-extern int gnix_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
+extern ssize_t gnix_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
 			   uint64_t flags);
 
-extern int gnix_eq_write(struct fid_eq *eq, uint32_t event, const void *buf,
+extern ssize_t gnix_eq_write(struct fid_eq *eq, uint32_t event, const void *buf,
 			 size_t len, uint64_t flags);
 
 extern ssize_t gnix_eq_sread(struct fid_eq *eq, uint32_t *event, void *buf,
@@ -72,18 +72,18 @@ extern const char *gnix_eq_strerror(struct fid_eq *eq, int prov_errno,
 				    const void *err_data, char *buf,
 				    size_t len);
 
-extern int gnix_cq_read(struct fid_cq *cq, void *buf, size_t count);
+extern ssize_t gnix_cq_read(struct fid_cq *cq, void *buf, size_t count);
 
-extern int gnix_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
+extern ssize_t gnix_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 			    fi_addr_t *src_addr);
 
 extern ssize_t gnix_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 			       uint64_t flags);
 
-extern int gnix_cq_sread(struct fid_cq *cq, void *buf, size_t count,
+extern ssize_t gnix_cq_sread(struct fid_cq *cq, void *buf, size_t count,
 			 const void *cond, int timeout);
 
-extern int gnix_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
+extern ssize_t gnix_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 			     fi_addr_t *src_addr, const void *cond,
 			     int timeout);
 
@@ -93,9 +93,9 @@ extern const char *gnix_cq_strerror(struct fid_cq *cq, int prov_errno,
 				    const void *err_data, char *buf,
 				    size_t len);
 
-extern int gnix_cntr_read(struct fid_cntr *cntr);
+extern uint64_t gnix_cntr_read(struct fid_cntr *cntr);
 
-extern int gnix_cntr_readerr(struct fid_cntr *cntr);
+extern uint64_t gnix_cntr_readerr(struct fid_cntr *cntr);
 
 extern int gnix_cntr_add(struct fid_cntr *cntr, uint64_t value);
 

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -887,6 +887,12 @@ err_unlock:
 	return ret;
 }
 
+__attribute__((unused))
+DIRECT_FN STATIC int gnix_listen(struct fid_pep *pep)
+{
+        return -FI_ENOSYS;
+}
+
 DIRECT_FN STATIC int gnix_reject(struct fid_pep *pep, fid_t handle,
 				 const void *param, size_t paramlen)
 {

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -2882,7 +2882,7 @@ DIRECT_FN STATIC int gnix_tx_context(struct fid_ep *ep, int index,
 
 __attribute__((unused))
 DIRECT_FN STATIC int gnix_rx_context(struct fid_ep *ep, int index,
-				     struct fi_tx_attr *attr,
+				     struct fi_rx_attr *attr,
 				     struct fid_ep **rx_ep, void *context)
 {
 	return -FI_ENOSYS;

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -338,7 +338,7 @@ err:
 	return ret;
 }
 
-static int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
+DIRECT_FN STATIC int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 {
 	int i, ret;
 	struct gnix_fid_ep  *ep;


### PR DESCRIPTION
signatures

- Updated eq, cq, ep, atomic, cntr signatures.
- Add dummy gnix_connect for cm.
- _gnix_ep_getinfo now uses ofi_check_domain_attr fn.
- gnix_sep_bind is now a "direct function".

upstream merge of ofi-cray/libfabric-cray#1174
@sungeunchoi 

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@48b6209afd543203efe2f23a58884e3ee2727de8)