### PR TITLE
prov/gni: Implement fi_mr_regv and fi_mr_regvattr

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -408,6 +408,7 @@ struct gnix_fid_domain {
 	 * be changed at this point.
 	 */
 	int mr_is_init;
+	int mr_iov_limit;
 	int udreg_reg_limit;
 #ifdef HAVE_UDREG
 	udreg_cache_handle_t udreg_cache;
@@ -1130,6 +1131,14 @@ int gnix_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 int gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 		uint64_t access, uint64_t offset, uint64_t requested_key,
 		uint64_t flags, struct fid_mr **mr_o, void *context);
+
+int gnix_mr_regv(struct fid *fid, const struct iovec *iov,
+                 size_t count, uint64_t access,
+                 uint64_t offset, uint64_t requested_key,
+                 uint64_t flags, struct fid_mr **mr, void *context);
+
+int gnix_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
+                    uint64_t flags, struct fid_mr **mr);
 
 int gnix_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		 struct fid_cntr **cntr, void *context);

--- a/prov/gni/provider_FABRIC_1.0.map
+++ b/prov/gni/provider_FABRIC_1.0.map
@@ -40,6 +40,8 @@
 		gnix_listen;
 		gnix_mr_bind;
 		gnix_mr_reg;
+		gnix_mr_regv;
+		gnix_mr_regattr;
 		gnix_passive_ep_open;
 		gnix_pep_bind;
 		gnix_poll_add;

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -629,6 +629,7 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->data_progress = info->domain_attr->data_progress;
 	domain->thread_model = info->domain_attr->threading;
 	domain->mr_is_init = 0;
+	domain->mr_iov_limit = info->domain_attr->mr_iov_limit;
 
 	fastlock_init(&domain->cm_nic_lock);
 
@@ -673,8 +674,8 @@ static struct fi_ops gnix_domain_fi_ops = {
 static struct fi_ops_mr gnix_domain_mr_ops = {
 	.size = sizeof(struct fi_ops_mr),
 	.reg = gnix_mr_reg,
-	.regv = fi_no_mr_regv,
-	.regattr = fi_no_mr_regattr
+	.regv = gnix_mr_regv,
+	.regattr = gnix_mr_regattr, 
 };
 
 static struct fi_ops_domain gnix_domain_ops = {


### PR DESCRIPTION
Implement the regv and regattr functions using existing
functionality and limits. Reject regv/regattr requests
for iov_count > 1 until regv is fully implemented.

upstream merge of ofi-cray/libfabric-cray#1158

@sungeunchoi 
Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/lifabric-cray@56f71f28ee552b20e8d541585d6ca0dc5115e5fe)