### PR TITLE
v1.4.1 version number updates

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -3,8 +3,8 @@ licenses.  You may choose to be licensed under the terms of the the
 BSD license or the GNU General Public License (GPL) Version
 2, both included below.
 
-Copyright (c) 2015-2016 Intel Corporation.  All rights reserved.
-Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
+Copyright (c) 2015-2017 Intel Corporation.  All rights reserved.
+Copyright (c) 2015-2017 Cisco Systems, Inc.  All rights reserved.
 
 ==================================================================
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2016-2017 Cisco Systems, Inc.  All rights reserved.
 #
 # Makefile.am for libfabric
 
@@ -130,7 +130,7 @@ src_libfabric_la_LDFLAGS =
 src_libfabric_la_LIBADD =
 src_libfabric_la_DEPENDENCIES = libfabric.map
 
-src_libfabric_la_LDFLAGS += -version-info 3:1:2 -export-dynamic \
+src_libfabric_la_LDFLAGS += -version-info 3:2:2 -export-dynamic \
 			   $(libfabric_version_script)
 rdmainclude_HEADERS += \
 	$(top_srcdir)/include/rdma/fabric.h \

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,21 @@ This file contains the main features as well as overviews of specific
 bug fixes (and other actions) for each version of Libfabric since
 version 1.0.
 
+v1.4.1, Fri Feb  3, 2017
+========================
+
+## PSM provider notes
+
+- INTEL TO FILL IN HERE
+
+## PSM2 provider notes
+
+- INTEL TO FILL IN HERE
+
+## usNIC provider notes
+
+- Fixed compilation issues with newer versions of libibverbs.
+
 v1.4.0, Fri Oct 28, 2016
 ========================
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,10 +1,10 @@
 dnl
-dnl Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2016-2017 Cisco Systems, Inc.  All rights reserved.
 dnl
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([libfabric], [1.4.0], [ofiwg@lists.openfabrics.org])
+AC_INIT([libfabric], [1.4.1], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)


### PR DESCRIPTION
Version number and other miscellaneous updates for the v1.4.1 release (per #2688).

@shefty You will need to update PSM/PSM2 sections in NEWS.md after this is merged.