### PR TITLE
prov/psm,psm2: Bug fixes for the name server

### DIFF
--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -490,7 +490,8 @@ int psmx_ep_open(struct fid_domain *domain, struct fi_info *info,
 		ep_priv->service = ((struct psmx_src_name *)info->src_addr)->service;
 
 	if (ep_priv->service == PSMX_ANY_SERVICE)
-		ep_priv->service = (getpid() << 16) + ((uintptr_t)ep_priv & 0xFFFF);
+		ep_priv->service = ((getpid() & 0x7FFF) << 16) +
+				   ((uintptr_t)ep_priv & 0xFFFF);
 
        psmx_ns_add_local_name(ep_priv->service, domain_priv->psm_epid);
 

--- a/prov/psm/src/psmx_ns.c
+++ b/prov/psm/src/psmx_ns.c
@@ -105,12 +105,12 @@ static int psmx_ns_map_add(int service, psm_epid_t name)
 static void psmx_ns_map_del(int service, psm_epid_t name_in)
 {
 	RbtIterator it;
-	int key;
+	void *key;
 	psm_epid_t name;
 
         it = rbtFind(psmx_ns_map, (void *)(uintptr_t)service);
         if (it) {
-		rbtKeyValue(psmx_ns_map, it, (void **)&key, (void **)&name);
+		rbtKeyValue(psmx_ns_map, it, &key, (void **)&name);
 		if (name != name_in) {
 			FI_WARN(&psmx_prov, FI_LOG_CORE,
 				"failed to delete address for service %u: "
@@ -125,15 +125,15 @@ static void psmx_ns_map_del(int service, psm_epid_t name_in)
 static int psmx_ns_map_lookup(int *service, psm_epid_t *name_out)
 {
 	RbtIterator it;
-	int key;
+	void *key;
 
         it = rbtFind(psmx_ns_map, (void *)(uintptr_t)(*service));
 	if (!it)
 		return -FI_ENOENT;
 
-	rbtKeyValue(psmx_ns_map, it, (void **)&key, (void **)name_out);
+	rbtKeyValue(psmx_ns_map, it, &key, (void **)name_out);
 	if (*service == PSMX_ANY_SERVICE)
-		*service = key;
+		*service = (uintptr_t)key;
 
 	return 0;
 }

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -590,7 +590,8 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 		ep_priv->service = ((struct psmx2_src_name *)info->src_addr)->service;
 
 	if (ep_priv->service == PSMX2_ANY_SERVICE)
-		ep_priv->service = (getpid() << 16) + ((uintptr_t)ep_priv & 0xFFFF);
+		ep_priv->service = ((getpid() & 0x7FFF) << 16) +
+				   ((uintptr_t)ep_priv & 0xFFFF);
 
 	ep_name.epid = domain_priv->psm2_epid;
 	ep_name.vlane = ep_priv->vlane;

--- a/prov/psm2/src/psmx2_ns.c
+++ b/prov/psm2/src/psmx2_ns.c
@@ -116,12 +116,12 @@ static int psmx2_ns_map_add(int service, struct psmx2_ep_name *name_in)
 static void psmx2_ns_map_del(int service, struct psmx2_ep_name *name_in)
 {
 	RbtIterator it;
-	int key;
+	void *key;
 	struct psmx2_ep_name *name;
 
         it = rbtFind(psmx2_ns_map, (void *)(uintptr_t)service);
         if (it) {
-		rbtKeyValue(psmx2_ns_map, it, (void **)&key, (void **)&name);
+		rbtKeyValue(psmx2_ns_map, it, &key, (void **)&name);
 		if (name->epid != name_in->epid ||
 		    name->vlane != name_in->vlane) {
 			FI_WARN(&psmx2_prov, FI_LOG_CORE,
@@ -139,17 +139,17 @@ static void psmx2_ns_map_del(int service, struct psmx2_ep_name *name_in)
 static int psmx2_ns_map_lookup(int *service, struct psmx2_ep_name *name_out)
 {
 	RbtIterator it;
-	int key;
+	void *key;
 	struct psmx2_ep_name *name;
 
         it = rbtFind(psmx2_ns_map, (void *)(uintptr_t)(*service));
 	if (!it)
 		return -FI_ENOENT;
 
-	rbtKeyValue(psmx2_ns_map, it, (void **)&key, (void **)&name);
+	rbtKeyValue(psmx2_ns_map, it, &key, (void **)&name);
 	*name_out = *name;
 	if (*service == PSMX2_ANY_SERVICE)
-		*service = key;
+		*service = (uintptr_t)key;
 
 	return 0;
 }


### PR DESCRIPTION
(1) Fix a memory corruption bug
(2) Limit the range of generated service id

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>