### PR TITLE
prov/gni: Allow gnix_freelist to be non-growable.

### DIFF
--- a/prov/gni/src/gnix_freelist.c
+++ b/prov/gni/src/gnix_freelist.c
@@ -103,9 +103,7 @@ int _gnix_fl_init(int elem_size, int offset, int init_size,
 
 	int fill_size = init_size != 0 ? init_size : GNIX_FL_INIT_SIZE;
 
-	fl->refill_size = (refill_size != 0 ?
-			   refill_size :
-			   GNIX_FL_INIT_REFILL_SIZE);
+	fl->refill_size = refill_size;
 	fl->growth_factor = (growth_factor != 0 ?
 			     growth_factor :
 			     GNIX_FL_GROWTH_FACTOR);

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -48,6 +48,7 @@
  * TODO: make this a domain parameter
  */
 #define GNIX_VC_FL_MIN_SIZE 128
+#define GNIX_VC_FL_INIT_REFILL_SIZE 10
 
 static int gnix_nics_per_ptag[GNI_PTAG_MAX];
 struct dlist_entry gnix_nic_list_ptag[GNI_PTAG_MAX];
@@ -1127,7 +1128,7 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		ret = _gnix_fl_init_ts(sizeof(struct gnix_vc),
 				       offsetof(struct gnix_vc, fr_list),
 				       GNIX_VC_FL_MIN_SIZE,
-				       0,
+				       GNIX_VC_FL_INIT_REFILL_SIZE,
 				       0,
 				       0,
 				       &nic->vc_freelist);

--- a/prov/gni/test/freelist.c
+++ b/prov/gni/test/freelist.c
@@ -40,6 +40,12 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
+#if 0
+#define dbg_printf(...)
+#else
+#define dbg_printf(...) fprintf(stderr, __VA_ARGS__); fflush(stderr)
+#endif
+
 static void setup(void)
 {
 	srand(time(NULL));
@@ -124,50 +130,86 @@ Test(gnix_freelist, freelist_refill_test)
 	_gnix_fl_destroy(&fl);
 }
 
+Test(gnix_freelist, freelist_zero_refill_test)
+{
+	struct gnix_freelist fl;
+	int i, ret;
+	const int num_elems = 71;
+	struct dlist_entry *elems[num_elems + 1];
+	const int refill_size = 0;
+
+	/* non-optimized code may not zero structures */
+	memset(&fl, 0x0, sizeof(struct gnix_freelist));
+
+	ret = _gnix_fl_init(sizeof(struct dlist_entry), 0,
+			    num_elems, refill_size, 0, 0, &fl);
+	cr_assert_eq(ret, FI_SUCCESS, "Failed to initialize freelist");
+
+	for (i = 0; i < num_elems; i++) {
+		ret = _gnix_fl_alloc(&elems[i], &fl);
+		cr_assert_eq(ret, FI_SUCCESS, "Failed to obtain dlist_entry");
+	}
+
+	cr_assert(_gnix_fl_empty(&fl), "Freelist not empty");
+
+	ret = _gnix_fl_alloc(&elems[num_elems], &fl);
+	cr_assert_eq(ret, -FI_ECANCELED, "Unexpected return code from "
+                 "_gnix_fl_alloc");
+
+	for (i = num_elems-1; i >= 0 ; i--)
+		_gnix_fl_free(elems[i], &fl);
+
+	_gnix_fl_destroy(&fl);
+}
+
 struct list_ts {
 	char dummy[7];
 	struct dlist_entry e;
 	int n;
 };
 
-Test(gnix_freelist, freelist_random_alloc_free)
-{
+Test(gnix_freelist, freelist_random_alloc_free) {
+
 	struct gnix_freelist fl;
-	int i, ret;
+	int i, ret, refill_size = 0;
 	const int n = 719;
 	int perm[n];
 	struct dlist_entry *de;
 	struct list_ts *ts[n];
 
-	for (i = 0; i < n; i++)
-		perm[i] = i;
+	while (++refill_size <= 23) {
+		for (i = 0; i < n; i++)
+			perm[i] = i;
 
-	generate_perm(perm, n);
+		generate_perm(perm, n);
 
-	/* non-optimized code may not zero structures */
-	memset(&fl, 0x0, sizeof(struct gnix_freelist));
+		/* non-optimized code may not zero structures */
+		memset(&fl, 0x0, sizeof(struct gnix_freelist));
 
-	ret = _gnix_fl_init(sizeof(struct list_ts),
-			     offsetof(struct list_ts, e),
-			     0, 0, 0, 0, &fl);
-	cr_assert_eq(ret, FI_SUCCESS, "Failed to initialize freelist");
+		ret = _gnix_fl_init(sizeof(struct list_ts),
+				    offsetof(struct list_ts, e), 0,
+				    refill_size, 0, 0, &fl);
+		cr_assert_eq(ret, FI_SUCCESS, "Failed to initialize "
+			     "freelist");
 
-	for (i = 0; i < n; i++) {
-		ret = _gnix_fl_alloc(&de, &fl);
-		cr_assert_eq(ret, FI_SUCCESS,
-			     "Failed to obtain valid dlist_entry");
-		ts[i] = container_of(de, struct list_ts, e);
-		ts[i]->n = perm[i];
+		for (i = 0; i < n; i++) {
+			ret = _gnix_fl_alloc(&de, &fl);
+			cr_assert_eq(ret, FI_SUCCESS,
+				     "Failed to obtain valid "
+				     "dlist_entry");
+			ts[i] = container_of(de, struct list_ts, e);
+			ts[i]->n = perm[i];
+		}
+
+		for (i = 0; i < n; i++) {
+			int j = perm[i];
+
+			cr_assert(ts[j]->n == perm[j], "Incorrect value");
+			_gnix_fl_free(&ts[j]->e, &fl);
+			ts[j] = NULL;
+		}
+
+		_gnix_fl_destroy(&fl);
 	}
-
-	for (i = 0; i < n; i++) {
-		int j = perm[i];
-
-		cr_assert(ts[j]->n == perm[j], "Incorrect value");
-		_gnix_fl_free(&ts[j]->e, &fl);
-		ts[j] = NULL;
-	}
-
-	_gnix_fl_destroy(&fl);
 }
 


### PR DESCRIPTION
- If the refill size is zero, do not allow the freelist to grow.

- Revert "Revert "prov/gni: If refill size is zero don't grow the list.""

- This reverts commit ofi-cray/libfabric-cray@eafd4366d388ceabd856d20c05176f1e4ee5e0fb.

- Revert "Revert "prov/gni: Implemented PR1149 feedback.""

- This reverts commit ofi-cray/libfabric-cray@3a569a5fb81e5dc7d21f956b6feb36ff33543a16.

upstream merge ofi-cray/libfabric-cray#1162
@sungeunchoi 

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@eda4fc44fcae1c6d3d8f7d388199c56e59a8f143)