### PR TITLE
prov/gni: default context count should be one if not specified

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -383,10 +383,12 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 			if (hints->ep_attr->rx_ctx_cnt > GNIX_SEP_MAX_CNT)
 				goto err;
 
-			gnix_info->ep_attr->tx_ctx_cnt =
-				hints->ep_attr->tx_ctx_cnt;
-			gnix_info->ep_attr->rx_ctx_cnt =
-				hints->ep_attr->rx_ctx_cnt;
+			if (hints->ep_attr->tx_ctx_cnt)
+				gnix_info->ep_attr->tx_ctx_cnt =
+					hints->ep_attr->tx_ctx_cnt;
+			if (hints->ep_attr->rx_ctx_cnt)
+				gnix_info->ep_attr->rx_ctx_cnt =
+					hints->ep_attr->rx_ctx_cnt;
 
 			if (hints->ep_attr->max_msg_size > GNIX_MAX_MSG_SIZE)
 				goto err;

--- a/prov/gni/test/sep.c
+++ b/prov/gni/test/sep.c
@@ -364,6 +364,15 @@ void sep_setup_context(void)
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
 	hints->domain_attr->mr_mode = FI_MR_BASIC;
 	hints->fabric_attr->prov_name = strdup("gni");
+
+	hints->ep_attr->tx_ctx_cnt = 0;
+	hints->ep_attr->rx_ctx_cnt = 0;
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi[0]);
+	cr_assert(!ret, "fi_getinfo");
+	cr_assert_eq(fi[0]->ep_attr->tx_ctx_cnt, 1, "incorrect tx_ctx_cnt");
+	cr_assert_eq(fi[0]->ep_attr->rx_ctx_cnt, 1, "incorrect rx_ctx_cnt");
+
 	hints->ep_attr->tx_ctx_cnt = ctx_cnt;
 	hints->ep_attr->rx_ctx_cnt = ctx_cnt;
 


### PR DESCRIPTION
fixes ofi-cray/libfabric-cray#1165

upstream merge of ofi-cray/libfabric-cray#1167
@sungeunchoi 

Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@479afdca037e805ab64692238df0c42ee7bad352)