### PR TITLE
prov/gni: Implemented gnix_cntr{add,set}err.

### DIFF
--- a/prov/gni/include/rdma/fi_direct_eq.h
+++ b/prov/gni/include/rdma/fi_direct_eq.h
@@ -104,6 +104,10 @@ extern int gnix_cntr_set(struct fid_cntr *cntr, uint64_t value);
 extern int gnix_cntr_wait(struct fid_cntr *cntr, uint64_t threshold,
 			  int timeout);
 
+extern int gnix_cntr_adderr(struct fid_cntr *cntr, uint64_t value);
+
+extern int gnix_cntr_seterr(struct fid_cntr *cntr, uint64_t value);
+
 /*******************************************************************************
  * Libfabric API Functions
  ******************************************************************************/
@@ -238,6 +242,16 @@ static inline int fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold,
 			       int timeout)
 {
 	return gnix_cntr_wait(cntr, threshold, timeout);
+}
+
+static inline int fi_cntr_adderr(struct fid_cntr *cntr, uint64_t value)
+{
+	return gnix_cntr_adderr(cntr, value);
+}
+
+static inline int fi_cntr_seterr(struct fid_cntr *cntr, uint64_t value)
+{
+	return gnix_cntr_seterr(cntr, value);
 }
 
 #endif /* _FI_DIRECT_EQ_H_ */


### PR DESCRIPTION
- Updated fabric direct build for adderr/seterr.
- Added fi_cntr_{set,add,read}(err) unit tests.
- Added multi- and single- threaded tests to assert
that counter values are maintained properly.
- Added fi_cntr_wait unit tests.
  - Ensure that fi_cntr_wait:
    - Unblocks upon fi_cntr_adderr.
    - Returns a non-zero value after fi_cntr_adderr.

upstream merge of PR ofi-cray/libfabric-cray#1175
@sungeunchoi 

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@763b34e415d9566235583b636c615e483f655307)