### PR TITLE
prov/gni: squash a compiler warning

### DIFF
--- a/prov/gni/test/freelist.c
+++ b/prov/gni/test/freelist.c
@@ -1,5 +1,7 @@
 /*
  * Copyright (c) 2015 Cray Inc. All rights reserved.
+ * Copyright (c) 2017 Los Alamos National Security, LLC.
+ *                    All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -136,7 +138,7 @@ Test(gnix_freelist, freelist_random_alloc_free)
 	int i, ret;
 	const int n = 719;
 	int perm[n];
-	struct dlist_entry *de;
+	struct dlist_entry *de = NULL;
 	struct list_ts *ts[n];
 
 	for (i = 0; i < n; i++)


### PR DESCRIPTION
gcc 6.2 with --enable-debug complains about uninitialized
variable

upstream merge of ofi-cray/libfabric-cray#1177
@sungeunchoi 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@684c80a0e60fa602a154e73a061a6ec18f247e40)