### PR TITLE
prov/gni: kdreg configury improvements

### DIFF
--- a/prov/gni/include/gnix_mr_notifier.h
+++ b/prov/gni/include/gnix_mr_notifier.h
@@ -37,8 +37,9 @@
 #include <stdint.h>
 #include <stddef.h>
 #include "rdma/fi_errno.h"
+#include "config.h"
 
-#ifdef HAVE_KDREG
+#if HAVE_KDREG
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/prov/gni/src/gnix_mr_notifier.c
+++ b/prov/gni/src/gnix_mr_notifier.c
@@ -30,9 +30,10 @@
  * SOFTWARE.
  */
 
-#ifdef HAVE_KDREG
 
 #include "gnix_mr_notifier.h"
+
+#if HAVE_KDREG
 
 struct gnix_mr_notifier global_mr_not;
 


### PR DESCRIPTION
Simplify finding kdreg component on Cray XC systems running
CLE 6.x.  Retain the --with-kdreg option for those building
GNI provider on Cray XC systems running CLE 5.x.

Switch to using an unquoted define for HAVE_KDREG.  Adjust
some files to take use of this change.

Also add a copyright statement to the configury.  Should
have added this a long ago.

upstream merge of ofi-cray/libfabric-cray#1176

Also add an action if xpmem is not found by configury.
Otherwise PKG_CONFIG macro errors out rather than just
not enabling xpmem usage.

Fixes ofi-cray/libfabric-cray#892

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@22f20cfeb2b178db6e3647d3a692f842fa11bb54)