### PR TITLE
Add capability to set default auth key for domain

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -342,6 +342,8 @@ struct fi_domain_attr {
 	size_t			mr_iov_limit;
 	uint64_t		caps;
 	uint64_t		mode;
+	uint8_t			*auth_key;
+	size_t 			auth_keylen;
 };
 
 struct fi_fabric_attr {

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -130,6 +130,8 @@ struct fi_domain_attr {
 	size_t                mr_iov_limit;
 	uint64_t              caps;
 	uint64_t              mode;
+	uint8_t               *auth_key;
+	size_t                auth_keylen;
 };
 ```
 
@@ -585,6 +587,21 @@ The operational mode bit related to using the domain.
 : This bit indicates that the domain limits completion queues and counters
   to only be used with endpoints, transmit contexts, and receive contexts that
   have the same set of capability flags.
+
+
+## Default authorization key (auth_key)
+
+The default authorization key to associate with endpoint and memory
+registrations created within the domain. This field is ignored unless the 
+fabric is opened with API version 1.5 or greater.
+
+## Default authorization key length (auth_keylen)
+
+The length of the default authorization key for the domain. If set to 0, then
+no authorization key will be associated with endpoints and memory
+registrations created within the domain unless specified in the endpoint or 
+memory registration attributes. This field is ignored unless the fabric is 
+opened with API version 1.5 or greater.
 
 # RETURN VALUE
 

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -766,7 +766,8 @@ details.
 ## auth_keylen - Authorization Key Length
 
 The length of the authorization key.  This field will be 0 if
-authorization keys are not available or used.
+authorization keys are not available or used.  This field is ignored 
+unless the fabric is opened with API version 1.5 or greater.
 
 ## auth_key - Authorization Key
 
@@ -776,7 +777,9 @@ to limit communication between endpoints.  Only peer endpoints that are
 programmed to use the same authorization key may communicate.
 Authorization keys are often used to implement job keys, to ensure
 that processes running in different jobs do not accidentally
-cross traffic.
+cross traffic.  The domain authorization key will be used if auth_keylen 
+is set to 0.  This field is ignored unless the fabric is opened with API
+version 1.5 or greater. 
 
 # TRANSMIT CONTEXT ATTRIBUTES
 

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -439,8 +439,9 @@ version 1.5 or greater.
 Indicates the key to associate with this memory registration.  Authorization
 keys are used to limit communication between endpoints.  Only peer endpoints
 that are programmed to use the same authorization key may access the memory
-region.  This field is ignored unless the fabric is opened with API version 1.5
-or greater.
+region.  The domain authorization key will be used if the auth_keylen 
+provided is 0.  This field is ignored unless the fabric is opened with API 
+version 1.5 or greater.
 
 # NOTES
 


### PR DESCRIPTION
This commit adds the ability to set the default authorization key
to associate with endpoints and memory registrations created within
a given domain.

If default_auth_keylen is set to 0, then providers will use their
own internal authorization key (if any) as the default authorization
key to associate with endpoints and memory registrations.

Signed-off-by: James Swaro <jswaro@cray.com>

closes ofiwg/libfabric#2707

@shefty @hppritcha @sungeunchoi 