### PR TITLE
Pre-cursor patches related to re-working rxd provider

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -134,6 +134,8 @@ void fi_param_init(void);
 void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
 
+const char *ofi_hex_str(const uint8_t *data, size_t len);
+
 static inline uint64_t roundup_power_of_two(uint64_t n)
 {
 	if (!n || !(n & (n - 1)))

--- a/include/fi_iov.h
+++ b/include/fi_iov.h
@@ -40,10 +40,8 @@
 #include <sys/uio.h>
 #include <inttypes.h>
 
-#define OFI_COPY_IOV_TO_BUF 0
-#define OFI_COPY_BUF_TO_IOV 1
 
-static inline size_t ofi_get_iov_len(const struct iovec *iov, size_t iov_count)
+static inline size_t ofi_total_iov_len(const struct iovec *iov, size_t iov_count)
 {
 	size_t i, len = 0;
 	for (i = 0; i < iov_count; i++)
@@ -51,8 +49,30 @@ static inline size_t ofi_get_iov_len(const struct iovec *iov, size_t iov_count)
 	return len;
 }
 
+
+#define OFI_COPY_IOV_TO_BUF 0
+#define OFI_COPY_BUF_TO_IOV 1
+
 uint64_t ofi_copy_iov_buf(const struct iovec *iov, size_t iov_count,
-		void *buf, uint64_t rem, uint64_t skip, int dir);
+			uint64_t iov_offset, void *buf, uint64_t bufsize,
+			int dir);
+
+static inline uint64_t
+ofi_copy_to_iov(const struct iovec *iov, size_t iov_count,
+		uint64_t iov_offset, void *buf, uint64_t bufsize)
+{
+	return ofi_copy_iov_buf(iov, iov_count, iov_offset, buf, bufsize,
+				OFI_COPY_BUF_TO_IOV);
+}
+
+static inline uint64_t
+ofi_copy_from_iov(void *buf, uint64_t bufsize,
+		  const struct iovec *iov, size_t iov_count, uint64_t iov_offset)
+{
+	return ofi_copy_iov_buf(iov, iov_count, iov_offset, buf, bufsize,
+				OFI_COPY_IOV_TO_BUF);
+}
+
 
 #endif /* IOV_H */
 

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -648,8 +648,7 @@ void rxd_ep_handle_data_msg(struct rxd_ep *ep, struct rxd_peer *peer,
 	uint64_t done;
 
 	ep->credits++;
-	done = ofi_copy_iov_buf(iov, iov_count, data, ctrl->seg_size,
-				   rx_entry->done, OFI_COPY_BUF_TO_IOV);
+	done = ofi_copy_to_iov(iov, iov_count, rx_entry->done, data, ctrl->seg_size);
 	rx_entry->done += done;
 	rx_entry->window--;
 	rx_entry->exp_seg_no++;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -276,8 +276,8 @@ int rxm_cq_handle_data(struct rxm_rx_buf *rx_buf)
 
 		return rxm_lmt_rma_read(rx_buf);
 	} else {
-		ofi_copy_iov_buf(rx_buf->recv_entry->iov, rx_buf->recv_entry->count, rx_buf->pkt.data,
-			rx_buf->pkt.hdr.size, 0, OFI_COPY_BUF_TO_IOV);
+		ofi_copy_to_iov(rx_buf->recv_entry->iov, rx_buf->recv_entry->count, 0,
+				rx_buf->pkt.data, rx_buf->pkt.hdr.size);
 		return rxm_finish_recv(rx_buf);
 	}
 }

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -472,7 +472,7 @@ static ssize_t rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov
 	rxm_pkt_init(pkt);
 	pkt->ctrl_hdr.conn_id = rxm_conn->handle.remote_key;
 	pkt->hdr.op = op;
-	pkt->hdr.size = ofi_get_iov_len(iov, count);
+	pkt->hdr.size = ofi_total_iov_len(iov, count);
 	rxm_op_hdr_process_flags(&pkt->hdr, flags, data);
 
 	if (op == ofi_op_tagged)
@@ -507,8 +507,7 @@ static ssize_t rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov
 		tx_entry->state = RXM_LMT_START;
 	} else {
 		pkt->ctrl_hdr.type = ofi_ctrl_data;
-		ofi_copy_iov_buf(iov, count, pkt->data, pkt->hdr.size, 0,
-				OFI_COPY_IOV_TO_BUF);
+		ofi_copy_to_iov(iov, count, 0, pkt->data, pkt->hdr.size);
 		pkt_size = sizeof(*pkt) + pkt->hdr.size;
 	}
 

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -43,8 +43,11 @@ int udpx_setname(fid_t fid, void *addr, size_t addrlen)
 
 	ep = container_of(fid, struct udpx_ep, util_ep.ep_fid.fid);
 	ret = bind(ep->sock, addr, addrlen);
-	if (ret)
+	if (ret) {
+		FI_WARN(&udpx_prov, FI_LOG_EP_CTRL, "bind %d (%s)\n",
+			errno, strerror(errno));
 		return -errno;
+	}
 	ep->is_bound = 1;
 	return 0;
 }
@@ -540,11 +543,10 @@ static int udpx_ep_init(struct udpx_ep *ep, struct fi_info *info)
 	}
 
 	if (info->src_addr) {
-		ret = bind(ep->sock, info->src_addr, info->src_addrlen);
-		if (ret) {
-			ret = -errno;
+		ret = udpx_setname(&ep->util_ep.ep_fid.fid, info->src_addr,
+				   info->src_addrlen);
+		if (ret)
 			goto err1;
-		}
 	}
 
 	ret = fi_fd_nonblock(ep->sock);

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -42,6 +42,7 @@ int udpx_setname(fid_t fid, void *addr, size_t addrlen)
 	int ret;
 
 	ep = container_of(fid, struct udpx_ep, util_ep.ep_fid.fid);
+	FI_DBG(&udpx_prov, FI_LOG_EP_CTRL, "%s\n", ofi_hex_str(addr, addrlen));
 	ret = bind(ep->sock, addr, addrlen);
 	if (ret) {
 		FI_WARN(&udpx_prov, FI_LOG_EP_CTRL, "bind %d (%s)\n",

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -211,12 +211,16 @@ static void *util_av_get_data(struct util_av *av, int index)
 
 void *ofi_av_get_addr(struct util_av *av, int index)
 {
+	FI_DBG(av->prov, FI_LOG_AV, "get[%d]:%s\n", index,
+		ofi_hex_str(util_av_get_data(av, index), av->addrlen));
 	return util_av_get_data(av, index);
 }
 
 static void util_av_set_data(struct util_av *av, int index,
 			     const void *data, size_t len)
 {
+	FI_DBG(av->prov, FI_LOG_AV, "set[%d]:%s\n", index,
+		ofi_hex_str(data, len));
 	memcpy(util_av_get_data(av, index), data, len);
 }
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -397,7 +397,6 @@ libdl_done:
 	fi_register_provider(VERBS_INIT, NULL);
 	fi_register_provider(GNI_INIT, NULL);
 	fi_register_provider(RXM_INIT, NULL);
-	fi_register_provider(RXD_INIT, NULL);
 	fi_register_provider(BGQ_INIT, NULL);
 
         /* Initialize the socket(s) provider last.  This will result in

--- a/src/log.c
+++ b/src/log.c
@@ -40,6 +40,7 @@
 
 #include "fi.h"
 
+
 static const char * const log_subsys[] = {
 	[FI_LOG_CORE] = "core",
 	[FI_LOG_FABRIC] = "fabric",
@@ -78,6 +79,28 @@ enum {
 
 uint64_t log_mask;
 struct fi_filter prov_log_filter;
+
+
+const char *ofi_hex_str(const uint8_t *data, size_t len)
+{
+	static char str[64];
+	const char hex[] = "0123456789abcdef";
+	int i, p;
+
+	if (len >= (sizeof(str) >> 1))
+		len = (sizeof(str) >> 1) - 1;
+
+	for (p = 0, i = 0; i < len; i++) {
+		str[p++] = hex[data[i] >> 4];
+		str[p++] = hex[data[i] & 0xF];
+	}
+
+	if (len == (sizeof(str) >> 1) - 1)
+		str[p++] = '~';
+
+	str[p] = '\0';
+	return str;
+}
 
 static int fi_convert_log_str(const char *value)
 {


### PR DESCRIPTION
The rxd provider does not work on a virtual system due to starvation issues.  That provider is being significantly re-worked to make use of the utility code and use its progress engine.  Several inefficiencies and bugs are also being fixed.  This series includes a small number of updates to code added as part of the rxd re-write, along with disabling the rxd provider.

The rxd provider will be put on hold until the work needed for the 1.5 release is done.