### PR TITLE
prov/verbs: Move wce, epe pools to CQ

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -214,7 +214,7 @@ static int fi_ibv_signal_send(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr)
 
 	fastlock_acquire(&ep->scq->lock);
 	if (VERBS_SIGNAL_SEND(ep)) {
-		epe = util_buf_alloc(ep->scq->domain->fab->epe_pool);
+		epe = util_buf_alloc(ep->scq->epe_pool);
 		if (!epe) {
 			fastlock_release(&ep->scq->lock);
 			return -FI_ENOMEM;
@@ -239,7 +239,7 @@ static int fi_ibv_reap_comp(struct fi_ibv_msg_ep *ep)
 	fastlock_acquire(&ep->scq->lock);
 	while (atomic_get(&ep->comp_pending) > 0) {
 		if (!wce) {
-			wce = util_buf_alloc(ep->scq->domain->fab->wce_pool);
+			wce = util_buf_alloc(ep->scq->wce_pool);
 			if (!wce) {
 				fastlock_release(&ep->scq->lock);
 				return -FI_ENOMEM;
@@ -250,7 +250,7 @@ static int fi_ibv_reap_comp(struct fi_ibv_msg_ep *ep)
 		if (ret < 0) {
 			FI_WARN(&fi_ibv_prov, FI_LOG_EP_DATA,
 				"Failed to read completion for signaled send\n");
-			util_buf_release(ep->scq->domain->fab->wce_pool, wce);
+			util_buf_release(ep->scq->wce_pool, wce);
 			fastlock_release(&ep->scq->lock);
 			return ret;
 		} else if (ret > 0) {
@@ -260,7 +260,7 @@ static int fi_ibv_reap_comp(struct fi_ibv_msg_ep *ep)
 		}
 	}
 	if (wce)
-		util_buf_release(ep->scq->domain->fab->wce_pool, wce);
+		util_buf_release(ep->scq->wce_pool, wce);
 
 	if (got_wc && ep->scq->channel)
 		ret = fi_ibv_cq_signal(&ep->scq->cq_fid);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -117,8 +117,6 @@ struct verbs_dev_info {
 
 struct fi_ibv_fabric {
 	struct fid_fabric	fabric_fid;
-	struct util_buf_pool	*wce_pool;
-	struct util_buf_pool	*epe_pool;
 };
 
 int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
@@ -232,6 +230,8 @@ struct fi_ibv_cq {
 	uint64_t		wr_id_mask;
 	fi_ibv_trywait_func	trywait;
 	atomic_t		nevents;
+	struct util_buf_pool	*epe_pool;
+	struct util_buf_pool	*wce_pool;
 };
 
 struct fi_ibv_rdm_cq {

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -390,11 +390,6 @@ static int fi_ibv_trywait(struct fid_fabric *fabric, struct fid **fids, int coun
 
 static int fi_ibv_fabric_close(fid_t fid)
 {
-	struct fi_ibv_fabric *fab;
-
-	fab = container_of(fid, struct fi_ibv_fabric, fabric_fid.fid);
-	util_buf_pool_destroy(fab->wce_pool);
-	util_buf_pool_destroy(fab->epe_pool);
 	free(fid);
 	return 0;
 }
@@ -439,25 +434,6 @@ int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 	fab->fabric_fid.fid.ops = &fi_ibv_fi_ops;
 	fab->fabric_fid.ops = &fi_ibv_ops_fabric;
 
-	fab->wce_pool = util_buf_pool_create(sizeof(struct fi_ibv_wce), 16, 0, VERBS_WCE_CNT);
-	if (!fab->wce_pool) {
-		FI_WARN(&fi_ibv_prov, FI_LOG_FABRIC, "Failed to create wce_pool\n");
-		ret = -FI_ENOMEM;
-		goto err1;
-	}
-
-	fab->epe_pool = util_buf_pool_create(sizeof(struct fi_ibv_msg_epe), 16, 0, VERBS_EPE_CNT);
-	if (!fab->epe_pool) {
-		FI_WARN(&fi_ibv_prov, FI_LOG_FABRIC, "Failed to create epe_pool\n");
-		ret = -FI_ENOMEM;
-		goto err2;
-	}
-
 	*fabric = &fab->fabric_fid;
 	return 0;
-err2:
-	util_buf_pool_destroy(fab->wce_pool);
-err1:
-	free(fab);
-	return ret;
 }


### PR DESCRIPTION
When multiple CQs are opened, accessing the wce, epe buf pools
would require serialization as the pools are part of the fabric
object. Move them to CQ to avoid locking.