### PR TITLE
cm/join: Add fi_no_join call

### DIFF
--- a/include/fi_enosys.h
+++ b/include/fi_enosys.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c); 2014 Intel Corporation. All rights reserved.
+ * Copyright (c) 2014-2017 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -162,6 +162,7 @@ static struct fi_ops_cm X = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 */
 int fi_no_setname(fid_t fid, void *addr, size_t addrlen);
@@ -174,6 +175,8 @@ int fi_no_accept(struct fid_ep *ep, const void *param, size_t paramlen);
 int fi_no_reject(struct fid_pep *pep, fid_t handle,
 		const void *param, size_t paramlen);
 int fi_no_shutdown(struct fid_ep *ep, uint64_t flags);
+int fi_no_join(struct fid_ep *ep, const void *addr, uint64_t flags,
+		struct fid_mc **mc, void *context);
 
 /*
 static struct fi_ops_domain X = {

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -159,7 +159,8 @@ struct fi_ops_cm gnix_ep_ops_cm = {
 	.listen = fi_no_listen,
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
-	.shutdown = fi_no_shutdown
+	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 /******************************************************************************
@@ -609,6 +610,7 @@ struct fi_ops_cm gnix_ep_msg_ops_cm = {
 	.accept = gnix_accept,
 	.reject = fi_no_reject,
 	.shutdown = gnix_shutdown,
+	.join = fi_no_join,
 };
 
 /******************************************************************************
@@ -1014,5 +1016,6 @@ struct fi_ops_cm gnix_pep_ops_cm = {
 	.accept = fi_no_accept,
 	.reject = gnix_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -1674,4 +1674,5 @@ static struct fi_ops_cm gnix_sep_rxtx_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };

--- a/prov/psm/src/psmx_cm.c
+++ b/prov/psm/src/psmx_cm.c
@@ -53,6 +53,7 @@ static int psmx_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 
 struct fi_ops_cm psmx_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = psmx_cm_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,
@@ -60,5 +61,6 @@ struct fi_ops_cm psmx_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 

--- a/prov/psm2/src/psmx2_cm.c
+++ b/prov/psm2/src/psmx2_cm.c
@@ -56,6 +56,7 @@ static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 
 struct fi_ops_cm psmx2_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
+	.setname = fi_no_setname,
 	.getname = psmx2_cm_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,
@@ -63,5 +64,6 @@ struct fi_ops_cm psmx2_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1625,6 +1625,7 @@ struct fi_ops_cm rxd_ep_cm = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 static int rxd_buf_region_alloc_hndlr(void *pool_ctx, void *addr, size_t len,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -228,6 +228,7 @@ static struct fi_ops_cm rxm_ops_cm = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 int rxm_getopt(fid_t fid, int level, int optname,

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -742,6 +742,7 @@ struct fi_ops_cm sock_ep_cm_ops = {
 	.accept = sock_ep_cm_accept,
 	.reject = fi_no_reject,
 	.shutdown = sock_ep_cm_shutdown,
+	.join = fi_no_join,
 };
 
 static int sock_msg_endpoint(struct fid_domain *domain, struct fi_info *info,
@@ -1109,7 +1110,9 @@ static struct fi_ops_cm sock_pep_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = sock_pep_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
+
 
 int sock_pep_getopt(fid_t fid, int level, int optname,
 		      void *optval, size_t *optlen)

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -76,6 +76,7 @@ static struct fi_ops_cm udpx_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 int udpx_getopt(fid_t fid, int level, int optname,

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -359,6 +359,7 @@ static struct fi_ops_cm usdf_cm_dgram_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 /*******************************************************************************

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -830,6 +830,7 @@ static struct fi_ops_cm usdf_cm_msg_ops = {
 	.accept = usdf_cm_msg_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 static struct fi_ops_msg usdf_msg_ops = {

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -890,6 +890,7 @@ static struct fi_ops_cm usdf_cm_rdm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 static struct fi_ops_msg usdf_rdm_ops = {

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -621,6 +621,7 @@ static struct fi_ops_cm usdf_pep_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = usdf_pep_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 int

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -227,6 +227,7 @@ static struct fi_ops_cm fi_ibv_msg_ep_cm_ops = {
 	.accept = fi_ibv_msg_ep_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_ibv_msg_ep_shutdown,
+	.join = fi_no_join,
 };
 
 struct fi_ops_cm *fi_ibv_msg_ep_ops_cm(struct fi_ibv_msg_ep *ep)
@@ -308,6 +309,7 @@ static struct fi_ops_cm fi_ibv_pep_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_ibv_msg_ep_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 struct fi_ops_cm *fi_ibv_pep_ops_cm(struct fi_ibv_pep *pep)

--- a/prov/verbs/src/verbs_srq.c
+++ b/prov/verbs/src/verbs_srq.c
@@ -55,6 +55,7 @@ static struct fi_ops_cm fi_ibv_srq_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 static struct fi_ops_rma fi_ibv_srq_rma_ops = {

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -212,6 +212,11 @@ int fi_no_shutdown(struct fid_ep *ep, uint64_t flags)
 {
 	return -FI_ENOSYS;
 }
+int fi_no_join(struct fid_ep *ep, const void *addr, uint64_t flags,
+			  struct fid_mc **mc, void *context)
+{
+	return -FI_ENOSYS;
+}
 
 /*
  * struct fi_ops_av


### PR DESCRIPTION
Add ENOSYS version for multicast join.  Update all providers to
set their join call.

Fixes #2706.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>