### PR TITLE
prov/gni: Ensure the CQE flags are set properly for ABI-1.1

### DIFF
--- a/prov/gni/include/gnix_cq.h
+++ b/prov/gni/include/gnix_cq.h
@@ -45,6 +45,9 @@
 #define GNIX_CQ_DEFAULT_FORMAT struct fi_cq_entry
 #define GNIX_CQ_DEFAULT_SIZE   256
 
+/* forward declaration */
+struct gnix_fid_ep;
+
 struct gnix_cq_entry {
 	void *the_entry;
 	fi_addr_t src_addr;
@@ -79,9 +82,10 @@ struct gnix_fid_cq {
 };
 
 
-ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, void *op_context,
-			  uint64_t flags, size_t len, void *buf,
-			  uint64_t data, uint64_t tag, fi_addr_t src_addr);
+ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
+			   void *op_context, uint64_t flags, size_t len,
+			   void *buf, uint64_t data, uint64_t tag,
+			   fi_addr_t src_addr);
 
 ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 			  uint64_t flags, size_t len, void *buf,

--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -91,7 +91,7 @@ static int __gnix_amo_send_completion(struct gnix_fid_ep *ep,
 	uint64_t flags = req->flags & GNIX_AMO_COMPLETION_FLAGS;
 
 	if ((req->flags & FI_COMPLETION) && ep->send_cq) {
-		rc = _gnix_cq_add_event(ep->send_cq, req->user_context,
+		rc = _gnix_cq_add_event(ep->send_cq, ep, req->user_context,
 					flags, 0, 0, 0, 0, FI_ADDR_NOTAVAIL);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -335,7 +335,7 @@ static int __recv_completion(
 	int rc;
 
 	if ((req->msg.recv_flags & FI_COMPLETION) && ep->recv_cq) {
-		rc = _gnix_cq_add_event(ep->recv_cq, context, flags, len,
+		rc = _gnix_cq_add_event(ep->recv_cq, ep, context, flags, len,
 					addr, data, tag, src_addr);
 		if (rc != FI_SUCCESS)  {
 			GNIX_WARN(FI_LOG_EP_DATA,
@@ -419,9 +419,8 @@ static int __gnix_msg_send_completion(struct gnix_fid_ep *ep,
 	GNIX_DEBUG(FI_LOG_EP_DATA, "send_cq = %p\n", ep->send_cq);
 
 	if ((req->msg.send_flags & FI_COMPLETION) && ep->send_cq) {
-		rc = _gnix_cq_add_event(ep->send_cq,
-				req->user_context,
-				flags, 0, 0, 0, 0, FI_ADDR_NOTAVAIL);
+		rc = _gnix_cq_add_event(ep->send_cq, ep, req->user_context,
+					flags, 0, 0, 0, 0, FI_ADDR_NOTAVAIL);
 		if (rc != FI_SUCCESS)  {
 			GNIX_WARN(FI_LOG_EP_DATA,
 					"_gnix_cq_add_event returned %d\n",

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -97,7 +97,7 @@ static int __gnix_rma_send_completion(struct gnix_fid_ep *ep,
 	uint64_t flags = req->flags & GNIX_RMA_COMPLETION_FLAGS;
 
 	if ((req->flags & FI_COMPLETION) && ep->send_cq) {
-		rc = _gnix_cq_add_event(ep->send_cq, req->user_context,
+		rc = _gnix_cq_add_event(ep->send_cq, ep, req->user_context,
 					flags, 0, 0, 0, 0, FI_ADDR_NOTAVAIL);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,
@@ -251,8 +251,8 @@ int __smsg_rma_data(void *data, void *msg)
 	gni_return_t status;
 
 	if (hdr->flags & FI_REMOTE_CQ_DATA && ep->recv_cq) {
-		ret = _gnix_cq_add_event(ep->recv_cq, NULL, hdr->user_flags, 0,
-					 0, hdr->user_data, 0,
+		ret = _gnix_cq_add_event(ep->recv_cq, ep, NULL, hdr->user_flags,
+					 0, 0, hdr->user_data, 0,
 					 FI_ADDR_NOTAVAIL);
 		if (ret != FI_SUCCESS)  {
 			GNIX_WARN(FI_LOG_EP_DATA,


### PR DESCRIPTION
- If EP op_flags have FI_NOTIFY_FLAGS_ONLY set, mask off the
CQE flags.

upstream mreg of ofi-cray/libfabric-cray#1183
Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@f9d0df0e09bb2c57a8c41f9a1c767fc1c9d5da59)
(cherry picked from commit ofi-cray/libfabric-cray@59f28f726379da4bc54769c63b1f255f940985ff)