### PR TITLE
prov/gni: report number of counters

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -38,7 +38,6 @@ libfabric API:
 : The provider implements the *FI_MR_BASIC* memory registration mode.
 
 *Data transfer operations*
-
 : The following data transfer interfaces are supported for all
   endpoint types: *FI_ATOMIC*, *FI_MSG*, *FI_RMA*, *FI_TAGGED*.  See
   DATA TRANSFER OPERATIONS below for more details.
@@ -52,7 +51,6 @@ libfabric API:
 : The GNI provider does not require any operation modes.
 
 *Progress*
-
 : For both control and data progress, the GNI provider supports both
   *FI_PROGRESS_AUTO* and *FI_PROGRESS_MANUAL*, with a default set to
   *FI_PROGRESS_AUTO*.
@@ -63,9 +61,8 @@ libfabric API:
 : The GNI provider specifically supports wait object types *FI_WAIT_UNSPEC*,
   and *FI_WAIT_SET*. A wait object must be used when calling fi_cntr_wait,
   fi_cq_sread/from, fi_eq_sread/from, fi_wait.
-  The GNI provider spawns an internal wait progress thread that is woken up 
+  The GNI provider spawns an internal wait progress thread that is woken up
   when clients utilize the wait system (e.g., calling fi_wait).
- 
 
 *Additional Features*
 : The GNI provider also supports the following capabilities and features:
@@ -244,6 +241,10 @@ but adds the following parameter:
  (AND and XOR), and GNIX_FAB_RQ_NAMO_AX_S (AND and XOR 32 bit),
 GNIX_FAB_RQ_NAMO_FAX (Fetch AND and XOR) and GNIX_FAB_RQ_NAMO_FAX_S
  (Fetch AND and XOR 32 bit).
+
+#NOTES
+
+The GNI provider sets the domain attribute *cntr_cnt* to the the CQ limit divided by 2.
 
 # SEE ALSO
 

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -220,6 +220,7 @@ static inline void dlist_splice_tail(
 /*
  * prototypes
  */
+int _gnix_get_cq_limit(void);
 int gnixu_get_rdma_credentials(void *addr, uint8_t *ptag, uint32_t *cookie);
 int gnixu_to_fi_errno(int err);
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -198,6 +198,7 @@ static struct fi_info *_gnix_allocinfo()
 	gnix_info->domain_attr->av_type = FI_AV_UNSPEC;
 	gnix_info->domain_attr->tx_ctx_cnt = gnix_max_nics_per_ptag;
 	gnix_info->domain_attr->rx_ctx_cnt = gnix_max_nics_per_ptag;
+	gnix_info->domain_attr->cntr_cnt = _gnix_get_cq_limit() / 2;
 
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);

--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -83,6 +83,7 @@ typedef struct ccm_alps_info {
 static uint64_t gnix_apid;
 static alpsAppLayout_t gnix_appLayout;
 static uint32_t gnix_device_id;
+static int gnix_cq_limit;
 /* These are not used currently and could be static to gnix_alps_init */
 static int alps_init;
 static int *gnix_app_placementList;
@@ -95,6 +96,11 @@ static int *gnix_app_totalPes;
 static int *gnix_app_nodePes;
 static int *gnix_app_peCpus;
 
+
+int _gnix_get_cq_limit(void)
+{
+	return gnix_cq_limit;
+}
 
 static inline void __gnix_ccm_cleanup(void)
 {
@@ -617,6 +623,8 @@ int _gnix_nics_per_rank(uint32_t *nics_per_rank)
 	if (rc) {
 		return rc;
 	}
+
+	gnix_cq_limit = cqs;
 	cqs /= GNIX_CQS_PER_EP;
 
 	rc = _gnix_pes_on_node(&npes);

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -99,6 +99,7 @@ Test(endpoint_info, info)
 	cr_assert_eq(fi->ep_attr->type, FI_EP_RDM);
 	cr_assert_eq(fi->next->ep_attr->type, FI_EP_DGRAM);
 	cr_assert_eq(fi->next->next->ep_attr->type, FI_EP_MSG);
+	cr_assert_neq(fi->domain_attr->cntr_cnt, 0);
 
 	fi_freeinfo(fi);
 


### PR DESCRIPTION
Use half of the available cqs as the value returned in cntr_cnt

fixes ofi-cray/libfabric-cray#1169
upstream merge of ofi-cray/libfabric-cray#1185
Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@592ade26618977f6411f90d48b198b7fcdc2e597)