### PR TITLE
prov/sockets: Fix iovec handling in atomic operations

### DIFF
--- a/include/fi_iov.h
+++ b/include/fi_iov.h
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <sys/uio.h>
 #include <inttypes.h>
+#include <rdma/fabric.h>
 
 
 static inline size_t ofi_total_iov_len(const struct iovec *iov, size_t iov_count)
@@ -49,6 +50,13 @@ static inline size_t ofi_total_iov_len(const struct iovec *iov, size_t iov_count
 	return len;
 }
 
+static inline size_t ofi_total_ioc_cnt(const struct fi_ioc *ioc, size_t ioc_count)
+{
+	size_t i, cnt = 0;
+	for (i = 0; i < ioc_count; i++)
+		cnt += ioc[i].count;
+	return cnt;
+}
 
 #define OFI_COPY_IOV_TO_BUF 0
 #define OFI_COPY_BUF_TO_IOV 1

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -53,6 +53,7 @@
 
 #include "sock.h"
 #include "sock_util.h"
+#include <fi_iov.h>
 
 #define SOCK_LOG_DBG(...) _SOCK_LOG_DBG(FI_LOG_EP_DATA, __VA_ARGS__)
 #define SOCK_LOG_ERROR(...) _SOCK_LOG_ERROR(FI_LOG_EP_DATA, __VA_ARGS__)
@@ -416,7 +417,7 @@ static ssize_t sock_ep_atomic_readwrite(struct fid_ep *ep,
 	msg.addr = dest_addr;
 
 	rma_iov.addr = addr;
-	rma_iov.count = 1;
+	rma_iov.count = count;
 	rma_iov.key = key;
 	msg.rma_iov = &rma_iov;
 	msg.rma_iov_count = 1;
@@ -425,7 +426,7 @@ static ssize_t sock_ep_atomic_readwrite(struct fid_ep *ep,
 	msg.context = context;
 
 	resultv.addr = result;
-	resultv.count = 1;
+	resultv.count = count;
 
 	return sock_ep_atomic_readwritemsg(ep, &msg, &resultv, &result_desc, 1,
 						SOCK_USE_OP_FLAGS);
@@ -447,7 +448,7 @@ static ssize_t sock_ep_atomic_readwritev(struct fid_ep *ep,
 	msg.addr = dest_addr;
 
 	rma_iov.addr = addr;
-	rma_iov.count = 1;
+	rma_iov.count = ofi_total_ioc_cnt(iov, count);
 	rma_iov.key = key;
 	msg.rma_iov = &rma_iov;
 	msg.rma_iov_count = 1;
@@ -507,7 +508,7 @@ static ssize_t sock_ep_atomic_compwrite(struct fid_ep *ep,
 	msg.addr = dest_addr;
 
 	rma_iov.addr = addr;
-	rma_iov.count = 1;
+	rma_iov.count = count;
 	rma_iov.key = key;
 	msg.rma_iov = &rma_iov;
 	msg.rma_iov_count = 1;
@@ -516,9 +517,9 @@ static ssize_t sock_ep_atomic_compwrite(struct fid_ep *ep,
 	msg.context = context;
 
 	resultv.addr = result;
-	resultv.count = 1;
+	resultv.count = count;
 	comparev.addr = (void *)compare;
-	comparev.count = 1;
+	comparev.count = count;
 
 	return sock_ep_atomic_compwritemsg(ep, &msg, &comparev, &compare_desc,
 			1, &resultv, &result_desc, 1, SOCK_USE_OP_FLAGS);
@@ -541,7 +542,7 @@ static ssize_t sock_ep_atomic_compwritev(struct fid_ep *ep,
 	msg.addr = dest_addr;
 
 	rma_iov.addr = addr;
-	rma_iov.count = 1;
+	rma_iov.count = ofi_total_ioc_cnt(iov, count);
 	rma_iov.key = key;
 	msg.rma_iov = &rma_iov;
 	msg.rma_iov_count = 1;
@@ -549,8 +550,9 @@ static ssize_t sock_ep_atomic_compwritev(struct fid_ep *ep,
 	msg.op = op;
 	msg.context = context;
 
-	return sock_ep_atomic_compwritemsg(ep, &msg, comparev, compare_desc, 1,
-					   resultv, result_desc, 1,
+	return sock_ep_atomic_compwritemsg(ep, &msg,
+					   comparev, compare_desc, compare_count,
+					   resultv, result_desc, result_count,
 					   SOCK_USE_OP_FLAGS);
 }
 


### PR DESCRIPTION
Fixes #2740.  As reported:

When sending a multiple source iov on the fi_fetch_atomicv
API, an invalid parameter error is returned from the function
sock_ep_tx_atomic() in sock_atomic.c at line 219, when it
is comparing the source buffer length against the destination
buffer length.

The log error message, that is displayed, with logging set to warn is:
libfabric:sockets:ep_data:sock_ep_tx_atomic():219 Buffer length mismatch

In the sock_ep_atomic_readwritev() function it sets up the
fi_rma_ioc structure with a rma_iov.count value of 1. This
rma_iov.count value should be initialized properly.

A code inspection shows several places where iovec support does
not set the number of atomic elements properly.  Fix all areas.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>