### PR TITLE
prov/gni: fix mixedmore test

### DIFF
--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -1119,7 +1119,6 @@ void do_mixed_more(int len)
 		pthread_yield();
 	}
 	cr_assert_eq(ret, 1);
-	rdm_rma_check_tcqe(&cqe, target, FI_RMA | FI_WRITE, 0);
 
 	while ((ret = fi_cq_read(recv_cq[1], &cqe, 1)) == -FI_EAGAIN) {
 		pthread_yield();


### PR DESCRIPTION
It should not be assumed that fi_rma cq event is
generated before the fi_send event.
upstream merge of ofi-cray/libfabric-cray#1192
Signed-off-by: Amith Abraham <aabraham@cray.com>
(cherry picked from commit ofi-cray/libfabri-cray@dc3f80c343853314b9e19abc9fa421597aec7534)