### PR TITLE
prov/gni: Break mr_cache into read only and read/write caches

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -400,7 +400,8 @@ struct gnix_fid_domain {
 	enum fi_threading thread_model;
 	struct gnix_reference ref_cnt;
 	gnix_mr_cache_attr_t mr_cache_attr;
-	gnix_mr_cache_t *mr_cache;
+	gnix_mr_cache_t *mr_cache_rw;
+	gnix_mr_cache_t *mr_cache_ro;
 	fastlock_t mr_cache_lock;
 	struct gnix_mr_ops *mr_ops;
 	int mr_cache_type;


### PR DESCRIPTION
The mr_cache was coalescing read only and read/write memory regions.
Separate them into two caches to avoid this condition.
Update the mr test to handle two caches. Most of the testing is on
the RW cache as that is the default access mode.

fixes ofi-cray/libfabric-cray#1197
upstream merge of ofi-cray/libfabric-cray#1206

Signed-off-by: Chuck Fossen <chuckf@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@acf7566abf96ed539dd6e198a89718e943a99399)