### PR TITLE
prov/verbs: Support FI_FENCE.

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -347,6 +347,9 @@ ssize_t fi_ibv_send_iov_flags(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 
 	wr->send_flags = VERBS_INJECT_FLAGS(ep, len, flags) | VERBS_COMP_FLAGS(ep, flags);
 
+	if (flags & FI_FENCE)
+		wr->send_flags = IBV_SEND_FENCE;
+
 	return fi_ibv_send(ep, wr, len, count, context);
 }
 


### PR DESCRIPTION
FI_FENCE is needed only in case the ordering is not supported.
fi_info->tx/rx_attr->msg_order would list the supported ordering.