### PR TITLE
util/mr: Remove unnecessary assertion from dup_mr_attr

### DIFF
--- a/prov/util/src/util_mr.c
+++ b/prov/util/src/util_mr.c
@@ -42,7 +42,6 @@ dup_mr_attr(const struct fi_mr_attr *attr)
 {
 	struct fi_mr_attr *dup_attr;
 
-	assert(attr->iov_count == 1);
 	dup_attr = calloc(1, sizeof(*attr) +
 			     sizeof(*attr->mr_iov) * attr->iov_count);
 	if (!dup_attr)


### PR DESCRIPTION
The code handles an iov_count > 1, so the assertion is not
needed.  The author must have been confused.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>