### PR TITLE
v1.4.x: configure.ac: bump to version 1.4.2a1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([libfabric], [1.4.1], [ofiwg@lists.openfabrics.org])
+AC_INIT([libfabric], [1.4.2a1], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)


### PR DESCRIPTION
1.4.1 has been released, so bump our version up to 1.4.2a1.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>