### PR TITLE
prov/util: Store API version with fabric

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -123,15 +123,16 @@ struct util_fabric {
 	atomic_t		ref;
 	const char		*name;
 	const struct fi_provider *prov;
+	uint32_t		api_version;
 
 	struct dlist_entry	domain_list;
 };
 
 int ofi_fabric_init(const struct fi_provider *prov,
-		   struct fi_fabric_attr *prov_attr,
-		   struct fi_fabric_attr *user_attr,
-		   struct util_fabric *fabric, void *context,
-		   enum fi_match_type type);
+		    const struct fi_fabric_attr *prov_attr,
+		    const struct fi_fabric_attr *user_attr,
+		    struct util_fabric *fabric, void *context,
+		    enum fi_match_type type);
 int ofi_fabric_close(struct util_fabric *fabric);
 int ofi_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
 

--- a/prov/util/src/util_fabric.c
+++ b/prov/util/src/util_fabric.c
@@ -46,19 +46,11 @@ int ofi_fabric_close(struct util_fabric *fabric)
 	return 0;
 }
 
-static void util_fabric_init(struct util_fabric *fabric, const char *name)
-{
-	atomic_initialize(&fabric->ref, 0);
-	dlist_init(&fabric->domain_list);
-	fastlock_init(&fabric->lock);
-	fabric->name = name;
-}
-
 int ofi_fabric_init(const struct fi_provider *prov,
-		   struct fi_fabric_attr *prov_attr,
-		   struct fi_fabric_attr *user_attr,
-		   struct util_fabric *fabric, void *context,
-		   enum fi_match_type type)
+		    const struct fi_fabric_attr *prov_attr,
+		    const struct fi_fabric_attr *user_attr,
+		    struct util_fabric *fabric, void *context,
+		    enum fi_match_type type)
 {
 	int ret;
 
@@ -67,7 +59,11 @@ int ofi_fabric_init(const struct fi_provider *prov,
 		return ret;
 
 	fabric->prov = prov;
-	util_fabric_init(fabric, prov_attr->name);
+	atomic_initialize(&fabric->ref, 0);
+	dlist_init(&fabric->domain_list);
+	fastlock_init(&fabric->lock);
+	fabric->name = prov_attr->name;
+	fabric->api_version = user_attr->api_version;
 
 	fabric->fabric_fid.fid.fclass = FI_CLASS_FABRIC;
 	fabric->fabric_fid.fid.context = context;


### PR DESCRIPTION
Future changes to the providers will need to know the API
version that the application is using.  Store it with the
fabric structure.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>