### PR TITLE
OFI Provider Supporting MPICH3 CH4 on BGQ Release 0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ See the `fi_verbs(7)` man page for more details.
 ***
 
 The `bgq` provider is a native provider that directly utilizes the hardware
-interfaces of the Blue Gene/Q system to implement all aspects of the libfabric
-interface.
+interfaces of the Blue Gene/Q system to implement aspects of the libfabric
+interface to fully support MPICH3 CH4.
 
 See the `fi_bgq(7)` man page for more details
 
@@ -273,7 +273,14 @@ See the `fi_bgq(7)` man page for more details
 #### Configure options
 
 ```
---with-bgq-progress=(auto|manual|runtime)
+--with-bgq-progress=(auto|manual)
 ```
 
-If specified, set the progress mode enabled in FABRIC_DIRECT.
+If specified, set the progress mode enabled in FABRIC_DIRECT (default is FI_PROGRESS_MANUAL).
+
+```
+--with-bgq-mr=(basic|scalable)
+```
+
+If specified, set the memory registration mode (default is FI_MR_BASIC).
+

--- a/man/fi_bgq.7.md
+++ b/man/fi_bgq.7.md
@@ -16,13 +16,14 @@ that makes direct use of the unique hardware features such as the
 Messaging Unit (MU), Base Address Table (BAT), and L2 Atomics.
 
 The purpose of this provider is to demonstrate the scalability and
-performance of libfabric, and to provide an "extreme scale"
+performance of libfabric, providing an "extreme scale"
 development environment for applications and middleware using the
-libfabric API.
+libfabric API, and to support a functional and performant version of
+MPI3 on Blue Gene/Q via MPICH CH4.
 
 # SUPPORTED FEATURES
 
-The bgq provider supports most features defined for the libfabric API. 
+The bgq provider supports most features defined for the libfabric API.
 Key features include:
 
 *Endpoint types*
@@ -47,10 +48,15 @@ standard minimum.
 : The bgq provider requires *FI_CONTEXT* and *FI_ASYNC_IOV*
 
 *Memory registration modes*
-: Only *FI_MR_SCALABLE* is supported, however hardware acceleration of
-  rdma transfers is not enabled. The FI_ATOMIC, FI_READ, FI_WRITE,
-  FI_REMOTE_READ, and FI_REMOTE_WRITE capabilities are emulated in
-  software.
+: Both FI_MR_SCALABLE and FI_MR_BASIC are supported, specified at configuration
+  time with the "--with-bgq-mr" configure option.  The base address table
+  utilized by FI_MR_SCALABLE for rdma transfers is completely software emulated,
+  supporting FI_ATOMIC, FI_READ, FI_WRITE, FI_REMOTE_READ, and FI_REMOTE_WRITE
+  capabilities.  With FI_MR_BASIC the FI_WRITE is completely hardware
+  accelerated, the other rdma transfers are still software emulated but the
+  use of a base address table is no longer required as the offset is now the
+  virtual address of the memory from the application and the key is the delta
+  from which the physical address can be computed if necessary.
 
 *Additional features*
 : Supported additional features include *FABRIC_DIRECT*, *scalable endpoints*,
@@ -72,9 +78,6 @@ standard minimum.
 *Capabilities*
 : The bgq provider does not support the *FI_RMA_EVENT*, and
   *FI_TRIGGER* capabilities.
-
-*Memory registration modes*
-: The bgq provider does not support the *FI_MR_BASIC* memory region mode.
 
 *Address vector*
 : The bgq provider does not support the *FI_AV_TABLE* address vector format.
@@ -98,7 +101,7 @@ pre-processor flag is not specified).
 The progress thread used for *FI_PROGRESS_AUTO* effectively limits the maximum
 number of ranks-per-node to 32.  However for FI_PROGRESS_MANUAL the maximum is 64.
 
-The memory region key size (mr_key_size) is 2 *bytes*; Valid key values are
+For FI_MR_SCALABLE mr mode the memory region key size (mr_key_size) is 2 *bytes*; Valid key values are
 0..2^16-1.
 
 It is invalid to register memory at the base virtual address "0" with a

--- a/man/fi_bgq.7.md
+++ b/man/fi_bgq.7.md
@@ -29,13 +29,19 @@ Key features include:
 : The Blue Gene/Q hardware is connectionless and reliable. Therefore, the
   bgq provider only supports the *FI_EP_RDM* endpoint type.
 
-*Primary capabilities*
-: Supported primary capabilities include *FI_MSG*, *FI_RMA*, *FI_TAGGED*,
+*Capabilities*
+: Supported capabilities include *FI_MSG*, *FI_RMA*, *FI_TAGGED*,
   *FI_ATOMIC*, *FI_NAMED_RX_CTX*, *FI_READ*, *FI_WRITE*, *FI_SEND*, *FI_RECV*,
-  *FI_REMOTE_READ*, and *FI_REMOTE_WRITE*.
+  *FI_REMOTE_READ*,  *FI_REMOTE_WRITE*, *FI_MULTI_RECV*, *FI_DIRECTED_RECV*,
+  *FI_SOURCE* and *FI_FENCE*.
 
-*Secondary capabilities*
-: Supported secondary capabilities include *FI_MULTI_RECV* and *FI_FENCE*.
+Notes on FI_DIRECTED_RECV capability:
+The immediate data which is sent within the *senddata* call to support
+FI_DIRECTED_RECV for BGQ must be exactly 4 bytes, which BGQ uses to
+completely identify the source address to an exascale-level number of ranks
+for tag matching on the recv and can be managed within the MU packet.
+Therefore the domain attribute cq_data_size is set to 4 which is the OFI
+standard minimum.
 
 *Modes*
 : The bgq provider requires *FI_CONTEXT* and *FI_ASYNC_IOV*
@@ -63,11 +69,8 @@ Key features include:
 *Endpoint types*
 : Unsupported endpoint types include *FI_EP_DGRAM* and *FI_EP_MSG*
 
-*Primary capabilities*
-: The bgq provider does not support the *FI_DIRECTED_RECV *capability.
-
-*Secondary capabilities*
-: The bgq provider does not support the *FI_SOURCE*, *FI_RMA_EVENT*, and
+*Capabilities*
+: The bgq provider does not support the *FI_RMA_EVENT*, and
   *FI_TRIGGER* capabilities.
 
 *Memory registration modes*
@@ -93,7 +96,7 @@ bgq provider will assert on the alignment for "debug" builds (i.e., the '-DNDEBU
 pre-processor flag is not specified).
 
 The progress thread used for *FI_PROGRESS_AUTO* effectively limits the maximum
-number of ranks-per-node to 32.
+number of ranks-per-node to 32.  However for FI_PROGRESS_MANUAL the maximum is 64.
 
 The memory region key size (mr_key_size) is 2 *bytes*; Valid key values are
 0..2^16-1.

--- a/prov/bgq/configure.m4
+++ b/prov/bgq/configure.m4
@@ -105,8 +105,16 @@ AC_DEFUN([FI_BGQ_CONFIGURE],[
 			BGQ_FABRIC_DIRECT_AV=FI_AV_MAP
 			AC_SUBST(bgq_fabric_direct_av, [$BGQ_FABRIC_DIRECT_AV])
 
-			dnl Only FI_MR_SCALABLE is supported by the bgq provider
-			BGQ_FABRIC_DIRECT_MR=FI_MR_SCALABLE
+			AC_ARG_WITH([bgq-mr],
+				[AS_HELP_STRING([--with-bgq-mr(=scalable|basic)],
+					[Specify the bgq FABRIC_DIRECT mr mode  @<:@default=scalable@:>@])
+				])
+
+			AS_CASE([$with_bgq_mr],
+				[scalable], [BGQ_FABRIC_DIRECT_MR=FI_MR_SCALABLE],
+				[basic], [BGQ_FABRIC_DIRECT_MR=FI_MR_BASIC],
+				[BGQ_FABRIC_DIRECT_MR=FI_MR_SCALABLE])
+
 			AC_SUBST(bgq_fabric_direct_mr, [$BGQ_FABRIC_DIRECT_MR])
 
 			dnl Only FI_THREAD_ENDPOINT is supported by the bgq provider

--- a/prov/bgq/include/rdma/bgq/fi_bgq.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq.h
@@ -64,6 +64,7 @@
 
 #define FI_BGQ_PFX "bgq"
 
+// #define FI_BGQ_TRACE 1
 
 /* --- Will be exposed by fabric.h */
 #define FI_BGQ_PROTOCOL		0x0008

--- a/prov/bgq/include/rdma/bgq/fi_bgq.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq.h
@@ -76,12 +76,6 @@
 #define FI_BGQ_DEVICE_MAX_PATH_NAME	(32)
 #define FI_BGQ_FABRIC_NAME	"BGQ"
 
-#define FI_BGQ_DOMAIN_RMA_AVTABLE_STR "bgq-rma-avtable"
-#define FI_BGQ_DOMAIN_RMA_AVMAP_STR   "bgq-rma-avmap"
-#define FI_BGQ_DOMAIN_AVTABLE_STR     "bgq-avtable"
-#define FI_BGQ_DOMAIN_AVMAP_STR       "bgq-avmap"
-#define FI_BGQ_DOMAIN_UNSPEC_STR "bgq"
-
 #define FI_BGQ_CACHE_LINE_SIZE	(L2_CACHE_LINE_SIZE)
 
 #define FI_BGQ_MAX_STRLEN	(64)

--- a/prov/bgq/include/rdma/bgq/fi_bgq.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq.h
@@ -110,7 +110,7 @@ static inline void always_assert(bool val, char *msg)
 static inline void fi_bgq_ref_init(struct fi_bgq_node *node,
 		struct l2atomic_counter *ref, char *name)
 {
-	int ret = -1;
+	int ret __attribute__ ((unused));
 	ret = fi_bgq_node_counter_allocate(node, ref);
 	assert(ret == 0);
 

--- a/prov/bgq/include/rdma/bgq/fi_bgq_l2atomic.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_l2atomic.h
@@ -58,7 +58,7 @@ struct l2atomic_lock_data {
 static inline
 void l2atomic_lock_initialize (struct l2atomic_lock * lock, struct l2atomic_lock_data * data) {
 
-	uint32_t cnk_rc = 0;
+	uint32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = Kernel_L2AtomicsAllocate((void*)data, sizeof(struct l2atomic_lock_data));
 	assert(0==cnk_rc);
 
@@ -274,7 +274,7 @@ void l2atomic_fifo_initialize (struct l2atomic_fifo_consumer * consumer,
 #endif
 #endif
 
-	uint32_t cnk_rc = 0;
+	uint32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = Kernel_L2AtomicsAllocate((void*)data, sizeof(struct l2atomic_fifo_data) + sizeof(uint64_t) * npackets);
 	assert(0==cnk_rc);
 
@@ -607,7 +607,7 @@ void l2atomic_counter_initialize (struct l2atomic_counter * counter,
 	assert(data);
 	assert(((uintptr_t)data & 0x07) == 0);	/* 8 byte aligned */
 
-	uint32_t cnk_rc = 0;
+	uint32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = Kernel_L2AtomicsAllocate((void*)data, sizeof(struct l2atomic_counter_data));
 	assert(0==cnk_rc);
 
@@ -666,7 +666,7 @@ void l2atomic_boundedcounter_initialize (struct l2atomic_boundedcounter * counte
 	assert(data);
 	assert(((uintptr_t)data & 0x01F) == 0);	/* 32 byte aligned */
 
-	uint32_t cnk_rc = 0;
+	uint32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = Kernel_L2AtomicsAllocate((void*)data, sizeof(struct l2atomic_boundedcounter_data));
 	assert(0==cnk_rc);
 
@@ -714,7 +714,7 @@ void l2atomic_barrier_initialize (struct l2atomic_barrier * barrier,
 	assert(data);
 	assert(((uintptr_t)data & (L1D_CACHE_LINE_SIZE-1)) == 0);
 
-	uint32_t cnk_rc = 0;
+	uint32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = Kernel_L2AtomicsAllocate((void*)data, sizeof(struct l2atomic_barrier_data));
 	assert(0==cnk_rc);
 

--- a/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
@@ -303,7 +303,7 @@ union fi_bgq_mu_packet_hdr {
 		union {
 			struct {
 				uint64_t		reserved_2	: 10;
-				uint64_t		is_local	:  1;	/* used to specify fifo map */
+				uint64_t		is_local	:  1;	/* used to specify fifo map; only needed for FI_BGQ_REMOTE_COMPLETION */
 				uint64_t		unused_0	:  3;
 				uint64_t		message_length	: 10;	/* 0..512 bytes of payload data */
 				uint64_t		reserved_3	:  8;	/* a.k.a. common::packet_type */

--- a/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
@@ -242,7 +242,7 @@ fi_addr_t fi_bgq_addr_create (const MUHWI_Destination_t destination,
 
 
 #define FI_BGQ_MU_PACKET_TYPE_TAG			(0x01ul<<1)
-#define FI_BGQ_MU_PACKET_TYPE_INJECT			(0x01ul<<2)
+#define FI_BGQ_MU_PACKET_TYPE_UNUSED			(0x01ul<<2)
 #define FI_BGQ_MU_PACKET_TYPE_EAGER			(0x01ul<<3)
 #define FI_BGQ_MU_PACKET_TYPE_RENDEZVOUS		(0x01ul<<4)
 #define FI_BGQ_MU_PACKET_TYPE_RMA			(0x01ul<<5)
@@ -301,14 +301,6 @@ union fi_bgq_mu_packet_hdr {
 		uint32_t		reserved_1;
 
 		union {
-			struct {
-				uint16_t		reserved_2	: 10;
-				uint16_t		unused_0	:  5;
-				uint16_t		message_length	:  1;	/* 0..1 bytes of immediate data */
-				uint8_t			data;
-				uint8_t			reserved_3;		/* a.k.a. common::packet_type */
-			} __attribute__((__packed__)) inject;
-
 			struct {
 				uint64_t		reserved_2	: 10;
 				uint64_t		is_local	:  1;	/* used to specify fifo map */

--- a/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
@@ -169,8 +169,7 @@ union fi_bgq_mu_packet_hdr {
 		uint64_t		message_length	: 10;	/* 0..512 bytes of payload data */
 		uint64_t		reserved_3	:  8;	/* a.k.a. common::packet_type */
 
-		MUHWI_Destination_t	origin;
-		uint32_t		cntr_paddr_rsh3b;	/* 34b paddr, 8 byte aligned; See: NOTE_MU_PADDR */
+		uint32_t		unused[2];
 		uint64_t		ofi_tag;
 	} __attribute__((__packed__)) send;
 
@@ -179,7 +178,7 @@ union fi_bgq_mu_packet_hdr {
 		uint32_t		reserved_1;
 		uint16_t		reserved_2	: 10;
 		uint16_t		is_local	:  1;	/* used to specify fifo map */
-		uint16_t		niov_minus_1	:  5;	/* 1..32 mu iov elements in payload data */
+		uint16_t		niov_minus_1	:  5;	/* 1..31 mu iov elements in payload data */
 		uint8_t			rget_inj_fifo_id;	/* 0..255 */
 		uint8_t			reserved_3;		/* a.k.a. common::packet_type */
 
@@ -294,7 +293,10 @@ struct fi_bgq_mu_fetch_metadata {
 
 union fi_bgq_mu_packet_payload {
 	uint8_t				byte[512];
-	struct fi_bgq_mu_iov		mu_iov[32];
+	struct {
+		uint32_t		unused[4];
+		struct fi_bgq_mu_iov	mu_iov[31];
+	} rendezvous;
 	struct {
 		struct fi_bgq_mu_fetch_metadata	metadata;
 		uint8_t				data[512-sizeof(struct fi_bgq_mu_fetch_metadata)];

--- a/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
@@ -302,11 +302,11 @@ union fi_bgq_mu_packet_hdr {
 
 		union {
 			struct {
-				uint64_t		reserved_2	: 10;
-				uint64_t		is_local	:  1;	/* used to specify fifo map; only needed for FI_BGQ_REMOTE_COMPLETION */
-				uint64_t		unused_0	:  3;
-				uint64_t		message_length	: 10;	/* 0..512 bytes of payload data */
-				uint64_t		reserved_3	:  8;	/* a.k.a. common::packet_type */
+				uint32_t		reserved_2	: 10;
+				uint32_t		is_local	:  1;	/* used to specify fifo map; only needed for FI_BGQ_REMOTE_COMPLETION */
+				uint32_t		unused_0	:  3;
+				uint32_t		message_length	: 10;	/* 0..512 bytes of payload data */
+				uint32_t		reserved_3	:  8;	/* a.k.a. common::packet_type */
 			} __attribute__((__packed__)) send;
 
 			struct {

--- a/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
@@ -152,6 +152,18 @@ union fi_bgq_mu_packet_hdr {
 		uint64_t		reserved_0;
 		uint64_t		reserved_1	: 32;
 		uint64_t		reserved_2	: 10;
+		uint64_t		unused_0	: 14;
+		uint64_t		reserved_3	:  8;	/* a.k.a. common::packet_type */
+
+		MUHWI_Destination_t	origin;
+		uint32_t		cntr_paddr_rsh3b;	/* 34b paddr, 8 byte aligned; See: NOTE_MU_PADDR */
+		uint64_t		is_local;		/* only 1 bit is needed */
+	} __attribute__((__packed__)) completion;
+
+	struct {
+		uint64_t		reserved_0;
+		uint64_t		reserved_1	: 32;
+		uint64_t		reserved_2	: 10;
 		uint64_t		is_local	:  1;	/* used to specify fifo map */
 		uint64_t		unused_0	:  3;
 		uint64_t		message_length	: 10;	/* 0..512 bytes of payload data */

--- a/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
@@ -214,10 +214,12 @@ union fi_bgq_mu_packet_hdr {
 		uint64_t		reserved_0;
 		uint32_t		reserved_1;
 		uint16_t		reserved_2	: 10;
-		uint16_t		unused_0	:  6;
-		uint8_t			message_length;		/* 0..8 bytes of immediate data; only 4 bits are actually needed */
+		uint16_t		unused_0	:  5;
+		uint16_t		message_length	:  1;	/* 0..1 bytes of immediate data */
+		uint8_t			data;
 		uint8_t			reserved_3;		/* a.k.a. common::packet_type */
-		uint64_t		data;
+		uint32_t		unused_1;
+		uint32_t		unused_2;
 		uint64_t		ofi_tag;
 	} __attribute__((__packed__)) inject;
 

--- a/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
@@ -169,7 +169,8 @@ union fi_bgq_mu_packet_hdr {
 		uint64_t		message_length	: 10;	/* 0..512 bytes of payload data */
 		uint64_t		reserved_3	:  8;	/* a.k.a. common::packet_type */
 
-		uint32_t		unused[2];
+		uint32_t		unused_1;
+		uint32_t		immediate_data;
 		uint64_t		ofi_tag;
 	} __attribute__((__packed__)) send;
 
@@ -219,7 +220,7 @@ union fi_bgq_mu_packet_hdr {
 		uint8_t			data;
 		uint8_t			reserved_3;		/* a.k.a. common::packet_type */
 		uint32_t		unused_1;
-		uint32_t		unused_2;
+		uint32_t		immediate_data;
 		uint64_t		ofi_tag;
 	} __attribute__((__packed__)) inject;
 
@@ -296,7 +297,8 @@ struct fi_bgq_mu_fetch_metadata {
 union fi_bgq_mu_packet_payload {
 	uint8_t				byte[512];
 	struct {
-		uint32_t		unused[4];
+		uint32_t		immediate_data;
+		uint32_t		unused[3];
 		struct fi_bgq_mu_iov	mu_iov[31];
 	} rendezvous;
 	struct {

--- a/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_mu.h
@@ -346,8 +346,8 @@ union fi_bgq_mu_packet_hdr {
 		uint8_t			reserved_3;		/* a.k.a. common::packet_type (FI_BGQ_MU_PACKET_TYPE_RMA) */
 		uint64_t		nbytes		: 16;	/* 0..512 bytes */
 		uint64_t		unused_2	: 11;
-		uint64_t		offset		: 37;	/* really only need 34 bits to reference all of physical memory (no mu atomics) TODO - FI_MR_SCALABLE uses virtual address as the offset? */
-		uint64_t		key;			/* only 16 bits needed for FI_MR_SCALABLE */
+		uint64_t		offset		: 37;	/* FI_MR_BASIC uses virtual address as the offset */
+		uint64_t		key;			/* only 16 bits needed for FI_MR_SCALABLE but need up to 34 for FI_MR_BASIC vaddr-paddr delta */
 	} __attribute__((__packed__)) rma;
 
 	struct {
@@ -376,8 +376,8 @@ union fi_bgq_mu_packet_hdr {
 			} __attribute__((__packed__));
 		};
 		uint16_t		nbytes_minus_1;			/* only 9 bits needed */
-		uint16_t		key;				/* only 16 bits needed for FI_MR_SCALABLE; TODO 34 bits to hold paddr for FI_MR_BASIC */
-		uint64_t		offset;				/* TODO FI_MR_BASIC* only needs 34 bits */
+		uint16_t		key;				/* only 16 bits needed for FI_MR_SCALABLE and not used for FI_MR_BASIC */
+		uint64_t		offset;				/* FI_MR_BASIC needs 34 bits */
 	} __attribute__((__packed__)) atomic;
 
 } __attribute__((__aligned__(32)));

--- a/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
@@ -417,10 +417,10 @@ void complete_receive_operation (struct fi_bgq_ep * bgq_ep,
 
 		uint64_t niov = pkt->hdr.rendezvous.niov_minus_1 + 1;
 		assert(niov <= (7-is_multi_receive));
-		uint64_t xfer_len = pkt->payload.mu_iov[0].message_length;
+		uint64_t xfer_len = pkt->payload.rendezvous.mu_iov[0].message_length;
 		{
 			uint64_t i;
-			for (i=1; i<niov; ++i) xfer_len += pkt->payload.mu_iov[i].message_length;
+			for (i=1; i<niov; ++i) xfer_len += pkt->payload.rendezvous.mu_iov[i].message_length;
 		}
 
 		uint64_t byte_counter_vaddr = 0;
@@ -559,8 +559,8 @@ void complete_receive_operation (struct fi_bgq_ep * bgq_ep,
 
 			qpx_memcpy64((void*)xfer_desc, (const void*)&bgq_ep->rx.poll.rzv.dput_model[is_local]);
 
-			xfer_desc->Pa_Payload = pkt->payload.mu_iov[i].src_paddr;
-			const uint64_t message_length = pkt->payload.mu_iov[i].message_length;
+			xfer_desc->Pa_Payload = pkt->payload.rendezvous.mu_iov[i].src_paddr;
+			const uint64_t message_length = pkt->payload.rendezvous.mu_iov[i].message_length;
 			xfer_desc->Message_Length = message_length;
 			MUSPI_SetRecPayloadBaseAddressInfo(xfer_desc, FI_BGQ_MU_BAT_ID_GLOBAL, dst_paddr);
 			dst_paddr += message_length;
@@ -706,9 +706,9 @@ void process_rfifo_packet_optimized (struct fi_bgq_ep * bgq_ep, struct fi_bgq_mu
 					send_len = pkt->hdr.send.message_length;
 				} else /* FI_BGQ_MU_PACKET_TYPE_RENDEZVOUS */ {
 					const uint64_t niov = pkt->hdr.rendezvous.niov_minus_1 + 1;
-					send_len = pkt->payload.mu_iov[0].message_length;
+					send_len = pkt->payload.rendezvous.mu_iov[0].message_length;
 					uint64_t i;
-					for (i=1; i<niov; ++i) send_len += pkt->payload.mu_iov[i].message_length;
+					for (i=1; i<niov; ++i) send_len += pkt->payload.rendezvous.mu_iov[i].message_length;
 				}
 
 				if (send_len > recv_len) {
@@ -1069,7 +1069,7 @@ int process_mfifo_context (struct fi_bgq_ep * bgq_ep, const unsigned poll_msg,
 					const uint64_t niov = uepkt->hdr.rendezvous.niov_minus_1 + 1;
 					uint64_t len = 0;
 					unsigned i;
-					for (i=0; i<niov; ++i) len += uepkt->payload.mu_iov[i].message_length;
+					for (i=0; i<niov; ++i) len += uepkt->payload.rendezvous.mu_iov[i].message_length;
 					context->len = len;
 				} else {	/* "eager" or "eager with completion" packet type */
 					context->len = uepkt->hdr.send.message_length;
@@ -1191,9 +1191,9 @@ int process_mfifo_context (struct fi_bgq_ep * bgq_ep, const unsigned poll_msg,
 					send_len = uepkt->hdr.send.message_length;
 				} else if (packet_type & FI_BGQ_MU_PACKET_TYPE_RENDEZVOUS) {
 					const uint64_t niov = uepkt->hdr.rendezvous.niov_minus_1 + 1;
-					send_len = uepkt->payload.mu_iov[0].message_length;
+					send_len = uepkt->payload.rendezvous.mu_iov[0].message_length;
 					uint64_t i;
-					for (i=1; i<niov; ++i) send_len += uepkt->payload.mu_iov[i].message_length;
+					for (i=1; i<niov; ++i) send_len += uepkt->payload.rendezvous.mu_iov[i].message_length;
 				}
 
 				if (send_len > recv_len) {

--- a/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
@@ -33,6 +33,7 @@
 #define _FI_PROV_BGQ_RX_H_
 
 #define FI_BGQ_UEPKT_BLOCKSIZE (1024)
+#define PROCESS_RFIFO_MAX 64
 
 /* forward declaration - see: prov/bgq/src/fi_bgq_atomic.c */
 void fi_bgq_rx_atomic_dispatch (void * buf, void * addr, size_t nbytes,
@@ -814,8 +815,10 @@ int poll_rfifo (struct fi_bgq_ep * bgq_ep, const unsigned is_manual_progress) {
 		_bgq_msync();
 
 		const uintptr_t stop = va_head + offset_tail - offset_head;
-		while ((uintptr_t)hdr < stop) {
+		int process_rfifo_iter = 0;
+		while (((uintptr_t)hdr < stop) && (process_rfifo_iter < PROCESS_RFIFO_MAX)) {
 
+			process_rfifo_iter++;
 			struct fi_bgq_mu_packet *pkt = (struct fi_bgq_mu_packet *) hdr;
 			const uint64_t packet_type = fi_bgq_mu_packet_type_get(pkt);
 
@@ -844,8 +847,10 @@ int poll_rfifo (struct fi_bgq_ep * bgq_ep, const unsigned is_manual_progress) {
 			_bgq_msync();
 
 			const uintptr_t stop = va_end - 544;
-			while ((uintptr_t)hdr < stop) {
+			int process_rfifo_iter = 0;
+			while  (((uintptr_t)hdr < stop) && (process_rfifo_iter < PROCESS_RFIFO_MAX)) {
 
+				process_rfifo_iter++;
 				struct fi_bgq_mu_packet *pkt = (struct fi_bgq_mu_packet *) hdr;
 				const uint64_t packet_type = fi_bgq_mu_packet_type_get(pkt);
 

--- a/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
@@ -625,7 +625,7 @@ void complete_receive_operation (struct fi_bgq_ep * bgq_ep,
 static inline
 unsigned is_match(struct fi_bgq_mu_packet *pkt, union fi_bgq_context * context, const unsigned poll_msg)
 {
-	if (poll_msg) return 1;		/* branch should compile out */
+	if (poll_msg && context->src_addr == FI_ADDR_UNSPEC) return 1;
 
 	const uint64_t origin_tag = pkt->hdr.inject.ofi_tag;
 	const uint64_t ignore = context->ignore;

--- a/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
@@ -756,7 +756,7 @@ void process_rfifo_packet_optimized (struct fi_bgq_ep * bgq_ep, struct fi_bgq_mu
 
 	if (bgq_ep->rx.poll.rfifo[poll_msg].ue.free == NULL) { /* unlikely */
 		struct fi_bgq_mu_packet * block = NULL;
-		int rc = 0;
+		int rc __attribute__ ((unused));
 		rc = posix_memalign((void **)&block,
 			32, sizeof(struct fi_bgq_mu_packet)*FI_BGQ_UEPKT_BLOCKSIZE);
 		assert(rc==0);

--- a/prov/bgq/include/rdma/bgq/fi_bgq_spi.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_spi.h
@@ -172,4 +172,23 @@ void * fi_bgq_spi_injfifo_immediate_payload (struct fi_bgq_spi_injfifo *f,
 	return (void*)(f->immediate_payload_base_vaddr + offset);
 }
 
+
+static inline
+MUHWI_Destination_t fi_bgq_spi_coordinates_to_destination (BG_CoordinateMapping_t coords) {
+
+	union foo {
+		BG_CoordinateMapping_t	coords;
+		uint32_t		raw;
+	};
+
+	const union foo tmp = {.coords=coords};
+
+	const uint32_t tmp2 = (tmp.raw & 0x3FFFFFC0ul) | (tmp.raw >> 31);
+	const MUHWI_Destination_t * const out = (const MUHWI_Destination_t * const)&tmp2;
+
+	return *out;
+}
+
+
+
 #endif /* _FI_PROV_BGQ_SPI_H_ */

--- a/prov/bgq/include/rdma/fi_direct.h.in
+++ b/prov/bgq/include/rdma/fi_direct.h.in
@@ -78,12 +78,6 @@ static const uint64_t FI_BGQ_DEFAULT_CAPS = (FI_MSG | FI_RMA | FI_TAGGED | FI_AT
 						FI_NAMED_RX_CTX | FI_DIRECTED_RECV |
 						FI_MULTI_RECV | FI_SOURCE);
 
-enum fi_bgq_domain_type {
-	FI_BGQ_DOMAIN_AVTABLE,
-	FI_BGQ_DOMAIN_AVMAP,
-	FI_BGQ_DOMAIN_UNSPEC,
-};
-
 #define FI_BGQ_FABRIC_DIRECT_PROGRESS	@bgq_fabric_direct_progress@
 #define FI_BGQ_FABRIC_DIRECT_AV		@bgq_fabric_direct_av@
 #define FI_BGQ_FABRIC_DIRECT_MR		@bgq_fabric_direct_mr@

--- a/prov/bgq/include/rdma/fi_direct.h.in
+++ b/prov/bgq/include/rdma/fi_direct.h.in
@@ -53,6 +53,7 @@ static const size_t FI_BGQ_TOTAL_BUFFERED_RECV	= (512ULL);
 static const uint64_t FI_BGQ_TX_SIZE		= (16*1024);
 static const uint64_t FI_BGQ_RX_SIZE		= (16*1024);
 static const uint64_t FI_BGQ_MR_KEY_SIZE	= (2);
+static const size_t   FI_BGQ_REMOTE_CQ_DATA_SIZE= 4;
 /* TODO: revisit these values, these are just placeholders now */
 /*
 static const uint64_t FI_BGQ_CMD_SLOT_AVAIL_POLL= (1ULL<<10);
@@ -61,8 +62,6 @@ static const uint64_t FI_BGQ_UNEXPECTED_COUNT	= (1ULL<<8);
 static const uint64_t FI_BGQ_TRIG_OP_COUNT	= (0);
 static const uint64_t FI_BGQ_MAX_NUM_EP		= (1ULL<<10); // TODO: is it needed?
 static const size_t   FI_BGQ_CACHE_LINE_SIZE	= 128;
-static const size_t   FI_BGQ_RMA_CQ_DATA_SIZE	= 8;
-static const size_t   FI_BGQ_TAGGED_CQ_DATA_SIZE= 4;
 static const size_t   FI_BGQ_DEFAULT_CQ_DEPTH   = 32768;
 */
 static const uint64_t FI_BGQ_MEM_TAG_FORMAT	= (0xFFFFFFFFFFFFFFFFULL);

--- a/prov/bgq/include/rdma/fi_direct_atomic.h
+++ b/prov/bgq/include/rdma/fi_direct_atomic.h
@@ -284,7 +284,7 @@ static inline void fi_bgq_atomic_fence (struct fi_bgq_ep * bgq_ep,
 			bgq_context->tag = 0;
 
 			uint64_t byte_counter_paddr = 0;
-			uint32_t cnk_rc = 0;
+			uint32_t cnk_rc __attribute__ ((unused));
 			cnk_rc = fi_bgq_cnk_vaddr2paddr((void*)&bgq_context->byte_counter,
 					sizeof(uint64_t), &byte_counter_paddr);
 			assert(cnk_rc == 0);
@@ -466,7 +466,7 @@ static inline ssize_t fi_bgq_atomic_generic(struct fid_ep *ep,
 	ret = fi_bgq_lock_if_required(&bgq_ep->lock, lock_required);
 	if (ret) return ret;
 
-	size_t xfer = 0;
+	size_t xfer __attribute__ ((unused));
 	xfer = fi_bgq_atomic_internal(bgq_ep, buf, count,
 		(union fi_bgq_addr *)&dst_addr,	addr, key, datatype, op,
 		context, 0, NULL, 0, NULL,

--- a/prov/bgq/include/rdma/fi_direct_atomic.h
+++ b/prov/bgq/include/rdma/fi_direct_atomic.h
@@ -229,12 +229,6 @@ static inline void fi_bgq_atomic_fence (struct fi_bgq_ep * bgq_ep,
 
 	assert(do_cq || do_cntr);
 
-	if (FI_BGQ_FABRIC_DIRECT_MR == FI_MR_BASIC) {
-
-		assert(0);	/* TODO */
-
-	} else {	/* FI_BGQ_FABRIC_DIRECT_MR == FI_MR_SCALABLE */
-
 		MUHWI_Descriptor_t * model = &bgq_ep->tx.atomic.emulation.fence.mfifo_model;
 
 		MUHWI_Descriptor_t * desc =
@@ -331,7 +325,6 @@ static inline void fi_bgq_atomic_fence (struct fi_bgq_ep * bgq_ep,
 		}
 
 		MUSPI_InjFifoAdvanceDesc(bgq_ep->tx.injfifo.muspi_injfifo);
-	}
 }
 
 static inline size_t fi_bgq_atomic_internal(struct fi_bgq_ep *bgq_ep,

--- a/prov/bgq/include/rdma/fi_direct_domain.h
+++ b/prov/bgq/include/rdma/fi_direct_domain.h
@@ -343,8 +343,6 @@ fi_rx_addr(fi_addr_t fi_addr, int rx_index, int rx_ctx_bits)
 
 	assert(rx_ctx_bits <= 4);
 
-	assert(0);	/* TODO - double check that this actually works! */
-
 	return fi_addr + ((uint64_t)rx_index << 33);
 }
 

--- a/prov/bgq/include/rdma/fi_direct_domain.h
+++ b/prov/bgq/include/rdma/fi_direct_domain.h
@@ -60,7 +60,6 @@ struct fi_bgq_domain {
 	struct fid_domain	domain_fid;
 	struct fi_bgq_fabric	*fabric;
 
-	enum fi_bgq_domain_type type;
 	enum fi_threading	threading;
 	enum fi_resource_mgmt	resource_mgmt;
 	enum fi_mr_mode		mr_mode;

--- a/prov/bgq/include/rdma/fi_direct_domain.h
+++ b/prov/bgq/include/rdma/fi_direct_domain.h
@@ -176,7 +176,7 @@ fi_bgq_domain_bat_write(struct fi_bgq_domain *bgq_domain, uint64_t requested_key
 		bgq_domain->bat[requested_key].paddr = 0;
 	} else {
 		Kernel_MemoryRegion_t cnk_mr;
-		uint32_t cnk_rc;
+		uint32_t cnk_rc __attribute__ ((unused));
 		cnk_rc = Kernel_CreateMemoryRegion(&cnk_mr, (void *)buf, len);
 		assert(cnk_rc == 0);
 

--- a/prov/bgq/include/rdma/fi_direct_domain.h
+++ b/prov/bgq/include/rdma/fi_direct_domain.h
@@ -333,14 +333,20 @@ static inline fi_addr_t
 fi_rx_addr(fi_addr_t fi_addr, int rx_index, int rx_ctx_bits)
 {
 	/*
-	 * The least significant bits of a 'base' fi_addr_t (stored in the
-	 * address vector object) are initially zero, and the 'rx' field is
-	 * the last field in the address structure which means that
-	 * a 'base' address stored in the address vector object can be
-	 * converted into a 'scalable' address by simply adding the rx index
+	 * The 'rx_lsb' field in the uid, located in the upper 4 bytes of the
+	 * fi_addr_t, is 5 bits wide and, for scalable endpoints, represents
+	 * the 'base mu reception fifo id'. To specialize the rx field the
+	 * 'rx index' must be added to the 'rx base'.
+	 *
+	 * This can be done by shifting the 'rx index' 33 bits and adding it
 	 * to the fi_addr_t (which is typedef'd to uint64_t).
 	 */
-	return fi_addr + rx_index;
+
+	assert(rx_ctx_bits <= 4);
+
+	assert(0);	/* TODO - double check that this actually works! */
+
+	return fi_addr + ((uint64_t)rx_index << 33);
 }
 
 static inline int fi_wait_open(struct fid_fabric *fabric,

--- a/prov/bgq/include/rdma/fi_direct_endpoint.h
+++ b/prov/bgq/include/rdma/fi_direct_endpoint.h
@@ -36,6 +36,7 @@
 
 #include <stdint.h>
 #include <pthread.h>
+#include <sys/uio.h>
 
 #include "rdma/bgq/fi_bgq_compiler.h"
 #include "rdma/bgq/fi_bgq_hwi.h"

--- a/prov/bgq/include/rdma/fi_direct_endpoint.h
+++ b/prov/bgq/include/rdma/fi_direct_endpoint.h
@@ -454,9 +454,6 @@ ssize_t fi_bgq_inject_generic(struct fid_ep *ep,
 		int lock_required,
 		const unsigned is_msg)
 {
-#ifdef FI_BGQ_TRACE
-	fprintf(stderr,"fi_bgq_inject_generic\n");
-#endif
 	assert(is_msg == 0 || is_msg == 1);
 
 	struct fi_bgq_ep *bgq_ep = container_of(ep, struct fi_bgq_ep, ep_fid);
@@ -508,6 +505,7 @@ ssize_t fi_bgq_inject_generic(struct fid_ep *ep,
 	hdr->pt2pt.immediate_data = data;
 
 #ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_inject_generic dest addr is:\n");
 	FI_BGQ_ADDR_DUMP((fi_addr_t *)&dest_addr);
 #endif
 	MUSPI_InjFifoAdvanceDesc(bgq_ep->tx.injfifo.muspi_injfifo);
@@ -527,6 +525,9 @@ ssize_t fi_bgq_send_generic_flags(struct fid_ep *ep,
 		const unsigned is_msg, const unsigned is_contiguous,
 		const unsigned override_flags, uint64_t tx_op_flags)
 {
+#ifdef FI_BGQ_TRACE
+        fprintf(stderr,"fi_bgq_send_generic_flags starting\n");
+#endif
 	assert(is_msg == 0 || is_msg == 1);
 	assert(is_contiguous == 0 || is_contiguous == 1);
 
@@ -599,6 +600,7 @@ ssize_t fi_bgq_send_generic_flags(struct fid_ep *ep,
 		hdr->pt2pt.immediate_data = data;
 
 #ifdef FI_BGQ_TRACE
+		fprintf(stderr,"eager sending to dest:\n");
 		FI_BGQ_ADDR_DUMP(&dest_addr);
 #endif
 		if (is_msg) {
@@ -661,6 +663,10 @@ ssize_t fi_bgq_send_generic_flags(struct fid_ep *ep,
 
 			if (tx_op_flags & (FI_INJECT_COMPLETE | FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)) {
 
+#ifdef FI_BGQ_TRACE
+                fprintf(stderr,"eager injecting local completion dput\n");
+#endif
+
 				/* inject the 'local completion' direct put descriptor */
 				send_desc = fi_bgq_spi_injfifo_tail_wait(&bgq_ep->tx.injfifo);
 
@@ -692,6 +698,11 @@ ssize_t fi_bgq_send_generic_flags(struct fid_ep *ep,
 
 	} else {
 		/* rendezvous */
+
+#ifdef FI_BGQ_TRACE
+                fprintf(stderr,"rendezvous sending to dest:\n");
+                FI_BGQ_ADDR_DUMP(&dest_addr);
+#endif
 
 		assert((tx_op_flags & FI_INJECT) == 0);
 
@@ -810,6 +821,7 @@ ssize_t fi_bgq_recv_generic(struct fid_ep *ep,
 	bgq_context->src_addr = src_addr;
 
 #ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_recv_generic from source addr:\n");
 	FI_BGQ_ADDR_DUMP(&bgq_context->src_addr);
 #endif
 
@@ -822,6 +834,9 @@ ssize_t fi_bgq_recv_generic(struct fid_ep *ep,
 		int ret;
 		ret = fi_bgq_lock_if_required(&bgq_ep->lock, lock_required);
 		if (ret) return ret;
+#ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_recv_generic calling fi_bgq_ep_progress_manual_recv_fast:\n");
+#endif
 
 		fi_bgq_ep_progress_manual_recv_fast(bgq_ep, is_msg, context);
 

--- a/prov/bgq/include/rdma/fi_direct_endpoint.h
+++ b/prov/bgq/include/rdma/fi_direct_endpoint.h
@@ -499,7 +499,7 @@ ssize_t fi_bgq_inject_generic(struct fid_ep *ep,
 	send_desc->Pa_Payload = payload_paddr;
 
 	send_desc->Message_Length = len;
-	memcpy(payload_vaddr, buf, len);	/* TODO use a qpx-optimized memcpy instead */
+	if (len) memcpy(payload_vaddr, buf, len);	/* TODO use a qpx-optimized memcpy instead */
 
 	hdr->pt2pt.send.message_length = len;
 	hdr->pt2pt.ofi_tag = tag;
@@ -584,7 +584,7 @@ ssize_t fi_bgq_send_generic_flags(struct fid_ep *ep,
 			send_desc->Pa_Payload = payload_paddr;
 
 			if (is_contiguous) {
-				memcpy((void*)payload_vaddr, buf, len);
+				if (len) memcpy((void*)payload_vaddr, buf, len);
 			} else {
 				unsigned i;
 				const struct iovec * iov = (const struct iovec *)buf;

--- a/prov/bgq/include/rdma/fi_direct_endpoint.h
+++ b/prov/bgq/include/rdma/fi_direct_endpoint.h
@@ -753,17 +753,18 @@ ssize_t fi_bgq_send_generic_flags(struct fid_ep *ep,
 
 		if (is_contiguous) {
 			/* only send one mu iov */
-			fi_bgq_cnk_vaddr2paddr(buf, len, &payload->mu_iov[0].src_paddr);
-			payload->mu_iov[0].message_length = len;
+			fi_bgq_cnk_vaddr2paddr(buf, len, &payload->rendezvous.mu_iov[0].src_paddr);
+			payload->rendezvous.mu_iov[0].message_length = len;
 			hdr->rendezvous.niov_minus_1 = 0;
 		} else {
-			assert(len <= 32);
+			assert(len <= 31);
 			size_t i;
 			const struct iovec * iov = (const struct iovec *)buf;
-			send_desc->Message_Length = len * sizeof(struct fi_bgq_mu_iov);
+			send_desc->Message_Length = len * sizeof(struct fi_bgq_mu_iov)
+				+ sizeof(uint32_t)*4;	/* "unused" payload space */
 			for (i=0; i<len; ++i) {
-				fi_bgq_cnk_vaddr2paddr(iov[i].iov_base, iov[i].iov_len, &payload->mu_iov[i].src_paddr);
-				payload->mu_iov[i].message_length = iov[i].iov_len;
+				fi_bgq_cnk_vaddr2paddr(iov[i].iov_base, iov[i].iov_len, &payload->rendezvous.mu_iov[i].src_paddr);
+				payload->rendezvous.mu_iov[i].message_length = iov[i].iov_len;
 			}
 			hdr->rendezvous.niov_minus_1 = len - 1;
 		}

--- a/prov/bgq/include/rdma/fi_direct_endpoint.h
+++ b/prov/bgq/include/rdma/fi_direct_endpoint.h
@@ -840,9 +840,10 @@ ssize_t fi_bgq_recv_generic(struct fid_ep *ep,
 	bgq_context->flags = rx_op_flags;
 	bgq_context->len = len;
 	bgq_context->buf = buf;
-	bgq_context->byte_counter = (uint64_t)-1;
+	bgq_context->src_addr = src_addr;
 	bgq_context->tag = tag;
 	bgq_context->ignore = ignore;
+	bgq_context->byte_counter = (uint64_t)-1;
 
 	if (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) {	/* constant expression will compile out */
 
@@ -916,6 +917,7 @@ ssize_t fi_bgq_recvmsg_generic(struct fid_ep *ep,
 		bgq_context->flags = FI_MULTI_RECV;
 		bgq_context->len = len - sizeof(union fi_bgq_context);
 		bgq_context->buf = (void *)((uintptr_t)base + sizeof(union fi_bgq_context));
+		bgq_context->src_addr = msg->addr;
 		bgq_context->byte_counter = 0;
 		bgq_context->multi_recv_next = (union fi_bgq_context *)base;
 		bgq_context->ignore = (uint64_t)-1;
@@ -933,9 +935,10 @@ ssize_t fi_bgq_recvmsg_generic(struct fid_ep *ep,
 		bgq_context->flags = flags;
 		bgq_context->len = 0;
 		bgq_context->buf = NULL;
-		bgq_context->byte_counter = (uint64_t)-1;
+		bgq_context->src_addr = msg->addr;
 		bgq_context->tag = 0;
 		bgq_context->ignore = (uint64_t)-1;
+		bgq_context->byte_counter = (uint64_t)-1;
 
 		context_rsh3b = (uint64_t)bgq_context >> 3;
 		rx_op_flags = flags;
@@ -949,9 +952,10 @@ ssize_t fi_bgq_recvmsg_generic(struct fid_ep *ep,
 		bgq_context->flags = flags;
 		bgq_context->len = msg->msg_iov[0].iov_len;
 		bgq_context->buf = msg->msg_iov[0].iov_base;
-		bgq_context->byte_counter = (uint64_t)-1;
+		bgq_context->src_addr = msg->addr;
 		bgq_context->tag = 0;
 		bgq_context->ignore = (uint64_t)-1;
+		bgq_context->byte_counter = (uint64_t)-1;
 
 		context_rsh3b = (uint64_t)bgq_context >> 3;
 		rx_op_flags = flags;
@@ -962,6 +966,7 @@ ssize_t fi_bgq_recvmsg_generic(struct fid_ep *ep,
 
 		ext->bgq_context.flags = flags | FI_BGQ_CQ_CONTEXT_EXT;
 		ext->bgq_context.byte_counter = (uint64_t)-1;
+		ext->bgq_context.src_addr = msg->addr;
 		ext->bgq_context.tag = 0;
 		ext->bgq_context.ignore = (uint64_t)-1;
 		ext->msg.op_context = (struct fi_context *)msg->context;

--- a/prov/bgq/include/rdma/fi_direct_eq.h
+++ b/prov/bgq/include/rdma/fi_direct_eq.h
@@ -264,6 +264,11 @@ static size_t fi_bgq_cq_fill(uintptr_t output,
 		const enum fi_cq_format format)
 {
 	assert((context->flags & FI_BGQ_CQ_CONTEXT_EXT)==0);
+#ifndef FABRIC_DIRECT
+	fprintf(stderr,"BGQ provider must be run in fabric-direct mode only\n");
+	assert(0);
+#endif
+	assert(sizeof(struct fi_context) == sizeof(union fi_bgq_context));
 
 	struct fi_cq_tagged_entry * entry = (struct fi_cq_tagged_entry *) output;
 	switch (format) {

--- a/prov/bgq/include/rdma/fi_direct_eq.h
+++ b/prov/bgq/include/rdma/fi_direct_eq.h
@@ -185,8 +185,6 @@ int fi_bgq_cq_enqueue_pending (struct fi_bgq_cq * bgq_cq,
 		union fi_bgq_context * context,
 		const int lock_required)
 {
-	assert(0 != context->byte_counter);
-
 	if (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) {
 
 		int ret;

--- a/prov/bgq/include/rdma/fi_direct_rma.h
+++ b/prov/bgq/include/rdma/fi_direct_rma.h
@@ -87,7 +87,7 @@ static inline void fi_bgq_readv_internal (struct fi_bgq_ep * bgq_ep,
 			&bgq_ep->tx.read.direct.rget_model :
 			&bgq_ep->tx.read.emulation.mfifo_model;
 
-	const uint64_t fifo_map = (uint64_t) bgq_target_addr->fifo_map;
+	const uint64_t fifo_map = fi_bgq_addr_get_fifo_map(bgq_target_addr->fi);
 
 	/* busy-wait until a fifo slot is available .. */
 	MUHWI_Descriptor_t * desc =
@@ -97,7 +97,7 @@ static inline void fi_bgq_readv_internal (struct fi_bgq_ep * bgq_ep,
 	qpx_memcpy64((void*)desc, (const void *)model);
 
 	/* set the target torus address and fifo map */
-	desc->PacketHeader.NetworkHeader.pt2pt.Destination = bgq_target_addr->Destination;
+	desc->PacketHeader.NetworkHeader.pt2pt.Destination = fi_bgq_uid_get_destination(bgq_target_addr->uid.fi);
 	desc->Torus_FIFO_Map = fifo_map;
 
 	/* locate the payload lookaside slot */
@@ -342,8 +342,8 @@ static inline ssize_t fi_bgq_inject_write_generic(struct fid_ep *ep,
 
 	/* set the destination torus address and fifo map */
 	union fi_bgq_addr * bgq_dst_addr = (union fi_bgq_addr *)&dst_addr;
-	desc->PacketHeader.NetworkHeader.pt2pt.Destination = bgq_dst_addr->Destination;
-	desc->Torus_FIFO_Map = (uint64_t) bgq_dst_addr->fifo_map;
+	desc->PacketHeader.NetworkHeader.pt2pt.Destination = fi_bgq_uid_get_destination(bgq_dst_addr->uid.fi);
+	desc->Torus_FIFO_Map = fi_bgq_addr_get_fifo_map(bgq_dst_addr->fi);
 	desc->Message_Length = len;
 
 	/* locate the payload lookaside slot */
@@ -432,8 +432,8 @@ static inline void fi_bgq_write_internal (struct fi_bgq_ep * bgq_ep,
 	qpx_memcpy64((void*)desc, (const void *)model);
 
 	/* set the destination torus address and fifo map */
-	desc->PacketHeader.NetworkHeader.pt2pt.Destination = bgq_dst_addr->Destination;
-	desc->Torus_FIFO_Map = (uint64_t) bgq_dst_addr->fifo_map;
+	desc->PacketHeader.NetworkHeader.pt2pt.Destination = fi_bgq_uid_get_destination(bgq_dst_addr->uid.fi);
+	desc->Torus_FIFO_Map = fi_bgq_addr_get_fifo_map(bgq_dst_addr->fi);
 
 	if (tx_op_flags & FI_INJECT) {	/* unlikely */
 

--- a/prov/bgq/include/rdma/fi_direct_rma.h
+++ b/prov/bgq/include/rdma/fi_direct_rma.h
@@ -132,7 +132,7 @@ static inline void fi_bgq_readv_internal (struct fi_bgq_ep * bgq_ep,
 
 			/* determine the physical address of the destination data location */
 			uint64_t iov_base_paddr = 0;
-			uint32_t cnk_rc = 0;
+			uint32_t cnk_rc __attribute__ ((unused));
 			cnk_rc = fi_bgq_cnk_vaddr2paddr(iov[i].iov_base, iov[i].iov_len, &iov_base_paddr);
 			assert(cnk_rc==0);
 			MUSPI_SetRecPayloadBaseAddressInfo(&dput_desc[i], FI_BGQ_MU_BAT_ID_GLOBAL, iov_base_paddr);
@@ -181,7 +181,7 @@ static inline void fi_bgq_readv_internal (struct fi_bgq_ep * bgq_ep,
 			bgq_context->tag = 0;
 
 			uint64_t byte_counter_paddr = 0;
-			uint32_t cnk_rc = 0;
+			uint32_t cnk_rc __attribute__ ((unused));
 			cnk_rc = fi_bgq_cnk_vaddr2paddr((void*)&bgq_context->byte_counter,
 						sizeof(uint64_t), &byte_counter_paddr);
 			assert(cnk_rc == 0);
@@ -256,7 +256,7 @@ static inline void fi_bgq_readv_internal (struct fi_bgq_ep * bgq_ep,
 		bgq_context->tag = 0;
 
 		uint64_t byte_counter_paddr = 0;
-		uint32_t cnk_rc = 0;
+		uint32_t cnk_rc __attribute__ ((unused));
 		cnk_rc = fi_bgq_cnk_vaddr2paddr((void*)&bgq_context->byte_counter,
 				sizeof(uint64_t), &byte_counter_paddr);
 		assert(cnk_rc == 0);
@@ -516,7 +516,7 @@ static inline void fi_bgq_write_internal (struct fi_bgq_ep * bgq_ep,
 
 		/* determine the physical address of the source data */
 		uint64_t src_paddr = 0;
-		uint32_t cnk_rc = 0;
+		uint32_t cnk_rc __attribute__ ((unused));
 		cnk_rc = fi_bgq_cnk_vaddr2paddr(buf, len, &src_paddr);
 		assert(cnk_rc==0);
 

--- a/prov/bgq/include/rdma/fi_direct_tagged.h
+++ b/prov/bgq/include/rdma/fi_direct_tagged.h
@@ -54,7 +54,7 @@ ssize_t fi_bgq_tinject(struct fid_ep *ep,
 		uint64_t tag,
 		int lock_required)
 {
-	return fi_bgq_inject_generic(ep, buf, len, dest_addr, tag,
+	return fi_bgq_inject_generic(ep, buf, len, dest_addr, tag, 0,
 			lock_required, 0);
 }
 

--- a/prov/bgq/src/fi_bgq_av.c
+++ b/prov/bgq/src/fi_bgq_av.c
@@ -41,7 +41,7 @@ void fi_bgq_addr_initialize (union fi_bgq_addr * output,
 		uint32_t domain_id, uint32_t domains_per_process,
 		uint32_t endpoint_id, uint32_t endpoints_per_domain)
 {
-	const uint32_t rx_per_node = ((BGQ_MU_NUM_REC_FIFO_GROUPS-1) * BGQ_MU_NUM_REC_FIFOS_PER_GROUP) / 2;	/* each rx uses two mu reception fifos */
+	const uint32_t rx_per_node = ((BGQ_MU_NUM_REC_FIFO_GROUPS-1) * BGQ_MU_NUM_REC_FIFOS_PER_GROUP) ;
 	const uint32_t rx_per_process = rx_per_node / ppn;
 	const uint32_t rx_per_domain = rx_per_process / domains_per_process;
 	const uint32_t rx_per_endpoint = rx_per_domain / endpoints_per_domain;
@@ -53,7 +53,7 @@ void fi_bgq_addr_initialize (union fi_bgq_addr * output,
 	output->d		= d;
 	output->e		= e;
 
-	output->is_local	=
+	output->is_local        =
 		(my_coords->a == a) &&
 		(my_coords->b == b) &&
 		(my_coords->c == c) &&
@@ -70,9 +70,14 @@ void fi_bgq_addr_initialize (union fi_bgq_addr * output,
 	 * converted into a 'scalable' address by simply adding the rx index
 	 * to the fi_addr_t.
 	 */
+
 	output->rx		= (rx_per_process * t) +
 				(rx_per_domain * domain_id) +
 				(rx_per_endpoint * endpoint_id);
+#ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_addr_initialize acbde rx is %u %u %u %u %u %u\n",a,b,c,d,e,output->rx );
+#endif
+
 }
 
 static int fi_bgq_close_av(fid_t fid)

--- a/prov/bgq/src/fi_bgq_cntr.c
+++ b/prov/bgq/src/fi_bgq_cntr.c
@@ -71,7 +71,7 @@ static uint64_t fi_bgq_cntr_read(struct fid_cntr *cntr)
 
 	const uint64_t value = L2_AtomicLoad(bgq_cntr->std.l2_vaddr);
 
-	if (bgq_cntr->domain->data_progress == FI_PROGRESS_MANUAL) {
+	if (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) {
 		const uint64_t count = bgq_cntr->progress.ep_count;
 		uint64_t i;
 		for (i=0; i<count; ++i) {
@@ -124,7 +124,7 @@ fi_bgq_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout)
 	do {
 		current_value = L2_AtomicLoad(bgq_cntr->std.l2_vaddr);
 
-		if (bgq_cntr->domain->data_progress == FI_PROGRESS_MANUAL) {
+		if (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) {
 			const uint64_t count = bgq_cntr->progress.ep_count;
 			uint64_t i;
 			for (i=0; i<count; ++i) {

--- a/prov/bgq/src/fi_bgq_cntr.c
+++ b/prov/bgq/src/fi_bgq_cntr.c
@@ -223,7 +223,7 @@ int fi_bgq_cntr_open(struct fid_domain *domain,
 
 	/* ---- allocate and initialize the "std" and "err" mu/l2 counters ---- */
 	{
-		uint32_t cnk_rc = 0;
+		uint32_t cnk_rc __attribute__ ((unused));
 		struct l2atomic_lock * lock = &bgq_cntr->domain->mu.lock;
 		struct fi_bgq_node * node = &bgq_cntr->domain->fabric->node;
 

--- a/prov/bgq/src/fi_bgq_cq.c
+++ b/prov/bgq/src/fi_bgq_cq.c
@@ -151,7 +151,7 @@ fi_bgq_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags
 {
 	struct fi_bgq_cq *bgq_cq = container_of(cq, struct fi_bgq_cq, cq_fid);
 
-	if (bgq_cq->domain->data_progress == FI_PROGRESS_MANUAL) {
+	if (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) {
 
 		struct fi_bgq_context_ext * ext = bgq_cq->err_head;
 		if (NULL == ext) {
@@ -319,7 +319,7 @@ int fi_bgq_cq_enqueue_err (struct fi_bgq_cq * bgq_cq,
 		struct fi_bgq_context_ext * ext,
 		const int lock_required)
 {
-	if (bgq_cq->domain->data_progress == FI_PROGRESS_MANUAL) {
+	if (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) {
 
 		int lock_required = 0;
 		switch (bgq_cq->domain->threading) {

--- a/prov/bgq/src/fi_bgq_domain.c
+++ b/prov/bgq/src/fi_bgq_domain.c
@@ -145,7 +145,7 @@ static int fi_bgq_mu_init(struct fi_bgq_domain *bgq_domain,
 		bgq_domain->rx.rfifo[n] = NULL;
 	}
 
-	const uint32_t subgroups_to_allocate_per_process = ppn == 64 ? 1 : 2;
+	const uint32_t subgroups_to_allocate_per_process = ppn == 64 ? 1 : ppn == 32 ? 2 : 4;
 	for (n = 0; n < subgroups_to_allocate_per_process; ++n) {
 
 		const uint32_t requested_subgroup = subgroup_offset + n;

--- a/prov/bgq/src/fi_bgq_domain.c
+++ b/prov/bgq/src/fi_bgq_domain.c
@@ -415,13 +415,6 @@ err:
 
 int fi_bgq_check_domain_attr(struct fi_domain_attr *attr)
 {
-	enum fi_bgq_domain_type type = FI_BGQ_DOMAIN_UNSPEC;
-
-	if (attr->name) {
-		if (fi_bgq_domain_str_to_type(attr->name, &type) < 0) {
-			goto err;
-		}
-	}
 	switch(attr->threading) {
 	case FI_THREAD_UNSPEC:
 	case FI_THREAD_SAFE:
@@ -440,38 +433,6 @@ int fi_bgq_check_domain_attr(struct fi_domain_attr *attr)
 		FI_LOG(fi_bgq_global.prov, FI_LOG_WARN, FI_LOG_DOMAIN,
 				"control auto progress is not fully implemented\n");
 	}
-	switch (attr->av_type) {
-	case FI_AV_UNSPEC:
-		break;
-	case FI_AV_MAP:
-		switch (type) {
-		//case FI_BGQ_DOMAIN_RMA_AVTABLE:
-		case FI_BGQ_DOMAIN_AVTABLE:
-			FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
-					"mismatch between domain and av type\n");
-			errno = FI_EINVAL;
-			goto err;
-		default:
-			break;
-		}
-		break;
-	case FI_AV_TABLE:
-		switch (type) {
-		//case FI_BGQ_DOMAIN_RMA_AVMAP:
-		case FI_BGQ_DOMAIN_AVMAP:
-			FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
-					"mismatch between domain and av type\n");
-			errno = FI_EINVAL;
-			goto err;
-		default:
-			break;
-		}
-		break;
-	default:
-		FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
-				"incorrect av type\n");
-		goto err;
-	}
 	switch (attr->mr_mode) {
 	case FI_MR_UNSPEC:
 	case FI_MR_SCALABLE:
@@ -483,37 +444,18 @@ int fi_bgq_check_domain_attr(struct fi_domain_attr *attr)
 			goto err;
 	}
 	if (attr->mr_key_size) {
-		switch(type) {
-		case FI_BGQ_DOMAIN_AVTABLE:
-		case FI_BGQ_DOMAIN_AVMAP:
-			if (attr->mr_key_size > FI_BGQ_MR_KEY_SIZE) {
-				FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
-						"memory key size too large\n");
-				goto err;
-			}
-			break;
-		default:
+		if (attr->mr_key_size > FI_BGQ_MR_KEY_SIZE) {
 			FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
-					"Unknown error\n");
+					"memory key size too large\n");
 			goto err;
 		}
 	}
 	if (attr->cq_data_size) {
-		switch(type) {
-		case FI_BGQ_DOMAIN_AVTABLE:
-		case FI_BGQ_DOMAIN_AVMAP:
-			if (attr->cq_data_size > FI_BGQ_REMOTE_CQ_DATA_SIZE) {
-				FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
-						"max cq data supported is %d\n",
-						FI_BGQ_REMOTE_CQ_DATA_SIZE);
-				goto err;
-			}
-			break;
-		default:
+		if (attr->cq_data_size > FI_BGQ_REMOTE_CQ_DATA_SIZE) {
 			FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
-					"Unknown error\n");
-			errno = FI_EINVAL;
-			return -errno;
+					"max cq data supported is %d\n",
+					FI_BGQ_REMOTE_CQ_DATA_SIZE);
+			goto err;
 		}
 	}
 

--- a/prov/bgq/src/fi_bgq_domain.c
+++ b/prov/bgq/src/fi_bgq_domain.c
@@ -263,7 +263,7 @@ int fi_bgq_alloc_default_domain_attr(struct fi_domain_attr **domain_attr)
 	attr->av_type		= FI_AV_MAP;
 	attr->mr_mode		= FI_MR_SCALABLE;
 	attr->mr_key_size 	= 2;			/* 2^16 keys */
-	attr->cq_data_size 	= 0;
+	attr->cq_data_size 	= FI_BGQ_REMOTE_CQ_DATA_SIZE;
 	attr->cq_cnt		= 128 / ppn;
 	attr->ep_cnt		= 1;			/* TODO - what about endpoints that only use a shared receive context and a shared transmit context? */
 	attr->tx_ctx_cnt	= tx_ctx_cnt;
@@ -366,7 +366,7 @@ int fi_bgq_choose_domain(uint64_t caps, struct fi_domain_attr *domain_attr, stru
 	switch(type) {
 	case FI_BGQ_DOMAIN_AVMAP:
 	case FI_BGQ_DOMAIN_AVTABLE:
-		domain_attr->cq_data_size = 0;//FI_BGQ_TAGGED_CQ_DATA_SIZE;
+		domain_attr->cq_data_size = FI_BGQ_REMOTE_CQ_DATA_SIZE;
 		break;
 	default:
 		FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
@@ -484,11 +484,6 @@ int fi_bgq_check_domain_attr(struct fi_domain_attr *attr)
 	}
 	if (attr->mr_key_size) {
 		switch(type) {
-		//case FI_BGQ_DOMAIN_RMA_AVTABLE:
-		//case FI_BGQ_DOMAIN_RMA_AVMAP:
-		//	FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
-		//			"memory keys not supported with this domain\n");
-		//	goto err;
 		case FI_BGQ_DOMAIN_AVTABLE:
 		case FI_BGQ_DOMAIN_AVMAP:
 			if (attr->mr_key_size > FI_BGQ_MR_KEY_SIZE) {
@@ -505,27 +500,14 @@ int fi_bgq_check_domain_attr(struct fi_domain_attr *attr)
 	}
 	if (attr->cq_data_size) {
 		switch(type) {
-		//case FI_BGQ_DOMAIN_RMA_AVTABLE:
-		//case FI_BGQ_DOMAIN_RMA_AVMAP:
-#ifdef TODO
-			if (attr->cq_data_size > FI_BGQ_RMA_CQ_DATA_SIZE) {
-				FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
-						"max cq data supported is %d\n",
-						FI_BGQ_RMA_CQ_DATA_SIZE);
-				goto err;
-			}
-#endif
-			break;
 		case FI_BGQ_DOMAIN_AVTABLE:
 		case FI_BGQ_DOMAIN_AVMAP:
-#ifdef TODO
-			if (attr->cq_data_size > FI_BGQ_TAGGED_CQ_DATA_SIZE) {
+			if (attr->cq_data_size > FI_BGQ_REMOTE_CQ_DATA_SIZE) {
 				FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,
 						"max cq data supported is %d\n",
-						FI_BGQ_TAGGED_CQ_DATA_SIZE);
+						FI_BGQ_REMOTE_CQ_DATA_SIZE);
 				goto err;
 			}
-#endif
 			break;
 		default:
 			FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_DOMAIN,

--- a/prov/bgq/src/fi_bgq_domain.c
+++ b/prov/bgq/src/fi_bgq_domain.c
@@ -439,9 +439,34 @@ int fi_bgq_check_domain_attr(struct fi_domain_attr *attr)
 		goto err;
 	}
 	if (attr->control_progress &&
-			attr->control_progress == FI_PROGRESS_AUTO) {
-		FI_LOG(fi_bgq_global.prov, FI_LOG_WARN, FI_LOG_DOMAIN,
-				"control auto progress is not fully implemented\n");
+			attr->control_progress != FI_PROGRESS_MANUAL) {
+		fprintf(stderr,"BGQ Provider only supports control_progress of FI_PROGRESS_MANUAL\n");
+		assert(0);
+		exit(1);
+	}
+	if (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_AUTO) {
+		if (attr->data_progress &&
+				attr->data_progress == FI_PROGRESS_MANUAL) {
+			fprintf(stderr,"BGQ Provider configured with data progress mode of FI_PROGRESS_AUTO but application specified FI_PROGRESS_MANUAL\n");
+			fflush(stderr);
+			assert(0);
+			exit(1);
+		}
+	}
+	else if (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) {
+		if (attr->data_progress &&
+				attr->data_progress == FI_PROGRESS_AUTO) {
+			fprintf(stderr,"BGQ Provider configured with data progress mode of FI_PROGRESS_MANUAL but application specified FI_PROGRESS_AUTO\n");
+			fflush(stderr);
+			assert(0);
+			exit(1);
+		}
+	}
+	else {
+		fprintf(stderr,"BGQ Provider progress mode not properly configured.\n");
+		fflush(stderr);
+		assert(0);
+		exit(1);
 	}
 
 	if (FI_BGQ_FABRIC_DIRECT_MR == FI_MR_SCALABLE) {

--- a/prov/bgq/src/fi_bgq_ep.c
+++ b/prov/bgq/src/fi_bgq_ep.c
@@ -509,8 +509,8 @@ static int fi_bgq_ep_tx_init (struct fi_bgq_ep *bgq_ep,
 
 		hdr = (union fi_bgq_mu_packet_hdr *) &desc->PacketHeader;
 		fi_bgq_mu_packet_type_set(hdr, FI_BGQ_MU_PACKET_TYPE_TAG|FI_BGQ_MU_PACKET_TYPE_EAGER);
-
-		hdr->send.origin = self.Destination;
+		hdr->send.unused[0] = 0;
+		hdr->send.unused[1] = 0;
 	}
 
 	/*
@@ -528,7 +528,8 @@ static int fi_bgq_ep_tx_init (struct fi_bgq_ep *bgq_ep,
 			MUHWI_DESCRIPTOR_PRE_FETCH_ONLY_NO;
 		desc->Half_Word1.Interrupt =
 			MUHWI_DESCRIPTOR_DO_NOT_INTERRUPT_ON_PACKET_ARRIVAL;
-		desc->Message_Length = sizeof(struct fi_bgq_mu_iov);
+		desc->Message_Length = sizeof(struct fi_bgq_mu_iov)
+			+ sizeof(uint32_t)*4; 	/* "unused" payload space */
 		desc->PacketHeader.NetworkHeader.pt2pt.Data_Packet_Type =
 			MUHWI_PT2PT_DATA_PACKET_TYPE;
 		desc->PacketHeader.NetworkHeader.pt2pt.Byte3.Byte3 =

--- a/prov/bgq/src/fi_bgq_ep.c
+++ b/prov/bgq/src/fi_bgq_ep.c
@@ -503,7 +503,7 @@ static int fi_bgq_ep_tx_init (struct fi_bgq_ep *bgq_ep,
 		union fi_bgq_mu_packet_hdr * hdr = (union fi_bgq_mu_packet_hdr *) &desc->PacketHeader;
 		fi_bgq_mu_packet_type_set(hdr, FI_BGQ_MU_PACKET_TYPE_TAG|FI_BGQ_MU_PACKET_TYPE_INJECT);
 		hdr->inject.unused_1 = 0;
-		hdr->inject.unused_2 = 0;
+		hdr->inject.immediate_data = 0;
 
 		/* send model - copy from inject model and update */
 		desc = &bgq_ep->tx.inject.send_model;
@@ -511,8 +511,8 @@ static int fi_bgq_ep_tx_init (struct fi_bgq_ep *bgq_ep,
 
 		hdr = (union fi_bgq_mu_packet_hdr *) &desc->PacketHeader;
 		fi_bgq_mu_packet_type_set(hdr, FI_BGQ_MU_PACKET_TYPE_TAG|FI_BGQ_MU_PACKET_TYPE_EAGER);
-		hdr->send.unused[0] = 0;
-		hdr->send.unused[1] = 0;
+		hdr->send.unused_1 = 0;
+		hdr->send.immediate_data = 0;
 	}
 
 	/*
@@ -530,8 +530,7 @@ static int fi_bgq_ep_tx_init (struct fi_bgq_ep *bgq_ep,
 			MUHWI_DESCRIPTOR_PRE_FETCH_ONLY_NO;
 		desc->Half_Word1.Interrupt =
 			MUHWI_DESCRIPTOR_DO_NOT_INTERRUPT_ON_PACKET_ARRIVAL;
-		desc->Message_Length = sizeof(struct fi_bgq_mu_iov)
-			+ sizeof(uint32_t)*4; 	/* "unused" payload space */
+		desc->Message_Length = sizeof(struct fi_bgq_mu_iov) + offsetof(union fi_bgq_mu_packet_payload, rendezvous.mu_iov);
 		desc->PacketHeader.NetworkHeader.pt2pt.Data_Packet_Type =
 			MUHWI_PT2PT_DATA_PACKET_TYPE;
 		desc->PacketHeader.NetworkHeader.pt2pt.Byte3.Byte3 =

--- a/prov/bgq/src/fi_bgq_ep.c
+++ b/prov/bgq/src/fi_bgq_ep.c
@@ -502,6 +502,8 @@ static int fi_bgq_ep_tx_init (struct fi_bgq_ep *bgq_ep,
 
 		union fi_bgq_mu_packet_hdr * hdr = (union fi_bgq_mu_packet_hdr *) &desc->PacketHeader;
 		fi_bgq_mu_packet_type_set(hdr, FI_BGQ_MU_PACKET_TYPE_TAG|FI_BGQ_MU_PACKET_TYPE_INJECT);
+		hdr->inject.unused_1 = 0;
+		hdr->inject.unused_2 = 0;
 
 		/* send model - copy from inject model and update */
 		desc = &bgq_ep->tx.inject.send_model;

--- a/prov/bgq/src/fi_bgq_ep.c
+++ b/prov/bgq/src/fi_bgq_ep.c
@@ -557,6 +557,18 @@ static int fi_bgq_ep_tx_init (struct fi_bgq_ep *bgq_ep,
 		desc = &bgq_ep->tx.send.rzv_model[1];
 		hdr = (union fi_bgq_mu_packet_hdr *) &desc->PacketHeader;
 		hdr->rendezvous.is_local = 1;
+
+		/* remote completion model - used for FI_DELIVERY_COMPLETE */
+		desc = &bgq_ep->tx.send.remote_completion_model;
+		*desc = bgq_ep->tx.inject.send_model;
+
+		hdr = (union fi_bgq_mu_packet_hdr *) &desc->PacketHeader;
+		fi_bgq_mu_packet_type_set(hdr, FI_BGQ_MU_PACKET_TYPE_EAGER|FI_BGQ_MU_PACKET_TYPE_ACK);
+		hdr->completion.origin = self.Destination;
+
+		/* specified at injection time */
+		hdr->completion.is_local = 0;
+		hdr->completion.cntr_paddr_rsh3b = 0;
 	}
 
 	/*

--- a/prov/bgq/src/fi_bgq_info.c
+++ b/prov/bgq/src/fi_bgq_info.c
@@ -100,7 +100,7 @@ int fi_bgq_set_default_info()
 		.name		= NULL, /* TODO: runtime query for name? */
 		.threading	= FI_THREAD_FID,
 		.control_progress = FI_PROGRESS_MANUAL,
-		.data_progress	= FI_PROGRESS_AUTO, // + FI_PROGRESS_MANUAL ?
+		.data_progress	= FI_BGQ_FABRIC_DIRECT_PROGRESS,
 		.resource_mgmt	= FI_RM_DISABLED,
 		.av_type	= FI_AV_MAP,
 		.mr_mode	= FI_MR_SCALABLE,

--- a/prov/bgq/src/fi_bgq_info.c
+++ b/prov/bgq/src/fi_bgq_info.c
@@ -105,7 +105,7 @@ int fi_bgq_set_default_info()
 		.av_type	= FI_AV_MAP,
 		.mr_mode	= FI_MR_SCALABLE,
 		.mr_key_size	= 2,
-		.cq_data_size	= 0,
+		.cq_data_size	= FI_BGQ_REMOTE_CQ_DATA_SIZE,
 		.cq_cnt		= 128 / ppn,
 		.ep_cnt		= SIZE_MAX,
 		.tx_ctx_cnt	= tx_ctx_cnt,

--- a/prov/bgq/src/fi_bgq_info.c
+++ b/prov/bgq/src/fi_bgq_info.c
@@ -103,7 +103,7 @@ int fi_bgq_set_default_info()
 		.data_progress	= FI_BGQ_FABRIC_DIRECT_PROGRESS,
 		.resource_mgmt	= FI_RM_DISABLED,
 		.av_type	= FI_AV_MAP,
-		.mr_mode	= FI_MR_SCALABLE,
+		.mr_mode	= FI_BGQ_FABRIC_DIRECT_MR,
 		.mr_key_size	= 2,
 		.cq_data_size	= FI_BGQ_REMOTE_CQ_DATA_SIZE,
 		.cq_cnt		= 128 / ppn,

--- a/prov/bgq/src/fi_bgq_info.c
+++ b/prov/bgq/src/fi_bgq_info.c
@@ -33,7 +33,7 @@
 
 int fi_bgq_set_default_info()
 {
-	struct fi_info *fi, *prev_fi;
+	struct fi_info *fi;
 	uint32_t ppn = Kernel_ProcessCount();
 
 	/*
@@ -124,16 +124,17 @@ int fi_bgq_set_default_info()
 		.prov_version	= FI_BGQ_PROVIDER_VERSION
 	};
 
-	fi->caps		= FI_RMA | FI_ATOMIC |
-					FI_NAMED_RX_CTX | FI_TRANSMIT_COMPLETE;
+	fi->caps		= FI_BGQ_DEFAULT_CAPS;
 	fi->mode		= FI_ASYNC_IOV;
+	fi->mode		|= (FI_CONTEXT);
+	fi->mode		&= (~FI_LOCAL_MR);
+	fi->mode		&= (~FI_MSG_PREFIX);
+
 	fi->addr_format		= FI_ADDR_BGQ;
 	fi->src_addrlen		= 24; // includes null
 	fi->dest_addrlen	= 24; // includes null
-
-	prev_fi = fi;
-	fi = fi_dupinfo(prev_fi);
-	prev_fi->next = fi;
+	fi->dest_addr = NULL;
+	fi->next = NULL;
 
 	return 0;
 }

--- a/prov/bgq/src/fi_bgq_init.c
+++ b/prov/bgq/src/fi_bgq_init.c
@@ -275,6 +275,14 @@ static int fi_bgq_getinfo(uint32_t version, const char *node,
 		const char *service, uint64_t flags,
 		struct fi_info *hints, struct fi_info **info)
 {
+
+#ifndef FABRIC_DIRECT
+        always_assert(1,
+                "BGQ provider must be run in fabric-direct mode only\n");
+
+#endif
+	assert(sizeof(struct fi_context) == sizeof(union fi_bgq_context));
+
 	int ret;
 	struct fi_info *fi, *prev_fi, *curr;
 
@@ -301,19 +309,10 @@ static int fi_bgq_getinfo(uint32_t version, const char *node,
 			errno = FI_ENODATA;
 			return -errno;
 		} else {
-			curr = fi_bgq_global.info;
-			*info = curr;
-			prev_fi = NULL;
-			do {
-				if (!(fi = fi_dupinfo(curr))) {
-					return -FI_ENOMEM;
-				}
-				if (prev_fi) {
-					prev_fi->next = fi;
-				}
-				prev_fi = fi;
-				curr    = curr->next;
-			} while(curr);
+			if (!(fi = fi_dupinfo(fi_bgq_global.info))) {
+				return -FI_ENOMEM;
+			}
+			*info = fi;
 		}
 	}
 

--- a/prov/bgq/src/fi_bgq_init.c
+++ b/prov/bgq/src/fi_bgq_init.c
@@ -276,13 +276,6 @@ static int fi_bgq_getinfo(uint32_t version, const char *node,
 		struct fi_info *hints, struct fi_info **info)
 {
 
-#ifndef FABRIC_DIRECT
-	fprintf(stderr,"BGQ provider must be run in fabric-direct mode only\n");
-	assert(0);
-
-#endif
-	assert(sizeof(struct fi_context) == sizeof(union fi_bgq_context));
-
 	if (!((FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) || (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_AUTO))){
 		fprintf(stderr,"BGQ Provider must be configured with either auto or manual progresss mode specified\n");
 		assert(0);

--- a/prov/bgq/src/fi_bgq_init.c
+++ b/prov/bgq/src/fi_bgq_init.c
@@ -277,11 +277,16 @@ static int fi_bgq_getinfo(uint32_t version, const char *node,
 {
 
 #ifndef FABRIC_DIRECT
-        always_assert(1,
-                "BGQ provider must be run in fabric-direct mode only\n");
+	fprintf(stderr,"BGQ provider must be run in fabric-direct mode only\n");
+	assert(0);
 
 #endif
 	assert(sizeof(struct fi_context) == sizeof(union fi_bgq_context));
+
+	if (!((FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) || (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_AUTO))){
+		fprintf(stderr,"BGQ Provider must be configured with either auto or manual progresss mode specified\n");
+		assert(0);
+	}
 
 	int ret;
 	struct fi_info *fi, *prev_fi, *curr;

--- a/prov/bgq/src/fi_bgq_mr.c
+++ b/prov/bgq/src/fi_bgq_mr.c
@@ -34,17 +34,18 @@
 
 static int fi_bgq_close_mr(fid_t fid)
 {
-	int ret;
 	struct fi_bgq_domain *bgq_domain;
 	struct fi_bgq_mr *bgq_mr = (struct fi_bgq_mr *) fid;
 
 	bgq_domain = bgq_mr->domain;
 
+	if (FI_BGQ_FABRIC_DIRECT_MR == FI_MR_SCALABLE) {
+	int ret;
 	fi_bgq_domain_bat_clear(bgq_domain, bgq_mr->mr_fid.key);
 
 	ret = fi_bgq_ref_dec(&bgq_domain->ref_cnt, "domain");
 	if (ret) return ret;
-
+	}
 	free(bgq_mr);
 	return 0;
 }
@@ -71,7 +72,6 @@ static int fi_bgq_bind_mr(struct fid *fid,
 		errno = FI_ENOSYS;
 		return -errno;
 	}
-
 	return 0;
 }
 
@@ -89,6 +89,7 @@ static int fi_bgq_mr_reg(struct fid *fid, const void *buf,
 		struct fid_mr **mr, void *context)
 {
 	int ret;
+
 	struct fi_bgq_mr *bgq_mr;
 	struct fi_bgq_domain *bgq_domain;
 
@@ -109,12 +110,13 @@ static int fi_bgq_mr_reg(struct fid *fid, const void *buf,
 
 	bgq_domain = (struct fi_bgq_domain *) container_of(fid, struct fid_domain, fid);
 
-	if (requested_key >= bgq_domain->num_mr_keys) {
-		/* requested key is too large */
-		errno = FI_EKEYREJECTED;
-		return -errno;
+	if (FI_BGQ_FABRIC_DIRECT_MR == FI_MR_SCALABLE) {
+		if (requested_key >= bgq_domain->num_mr_keys) {
+			/* requested key is too large */
+			errno = FI_EKEYREJECTED;
+			return -errno;
+		}
 	}
-
 	bgq_mr = calloc(1, sizeof(*bgq_mr));
 	if (!bgq_mr) {
 		errno = FI_ENOMEM;
@@ -124,8 +126,22 @@ static int fi_bgq_mr_reg(struct fid *fid, const void *buf,
 	bgq_mr->mr_fid.fid.fclass	= FI_CLASS_MR;
 	bgq_mr->mr_fid.fid.context	= context;
 	bgq_mr->mr_fid.fid.ops		= &fi_bgq_fi_ops;
-	bgq_mr->mr_fid.key		= requested_key;
+	if (FI_BGQ_FABRIC_DIRECT_MR == FI_MR_SCALABLE) {
+		bgq_mr->mr_fid.key		= requested_key;
+	}
+	else if (FI_BGQ_FABRIC_DIRECT_MR == FI_MR_BASIC) {
 
+		uint64_t paddr = 0;
+
+		fi_bgq_cnk_vaddr2paddr(buf,1,&paddr);
+		bgq_mr->mr_fid.key		= ((uint64_t)buf - paddr);
+#ifdef FI_BGQ_TRACE
+        fprintf(stderr,"fi_bgq_mr_reg - FI_MR_BASIC virtual addr is 0x%016lx physical addr is 0x%016lx key is %lu  \n",(uint64_t)buf,paddr,(uint64_t)((uint64_t)buf - paddr));
+fflush(stderr);
+
+#endif
+
+	}
 	bgq_mr->buf 	= buf;
 	bgq_mr->len	= len;
 	bgq_mr->offset	= offset;
@@ -133,9 +149,11 @@ static int fi_bgq_mr_reg(struct fid *fid, const void *buf,
 	bgq_mr->flags	= flags;
 	bgq_mr->domain  = bgq_domain;
 
-	fi_bgq_domain_bat_write(bgq_domain, requested_key, buf, len);
+	if (FI_BGQ_FABRIC_DIRECT_MR == FI_MR_SCALABLE) {
+		fi_bgq_domain_bat_write(bgq_domain, requested_key, buf, len);
 
-	fi_bgq_ref_inc(&bgq_domain->ref_cnt, "domain");
+		fi_bgq_ref_inc(&bgq_domain->ref_cnt, "domain");
+	}
 
 	*mr = &bgq_mr->mr_fid;
 
@@ -167,9 +185,11 @@ int fi_bgq_init_mr_ops(struct fi_bgq_domain *bgq_domain, struct fi_info *info)
 
 	bgq_domain->mr_mode = info->domain_attr->mr_mode;
 
+	if (FI_BGQ_FABRIC_DIRECT_MR == FI_MR_SCALABLE) {
 	bgq_domain->num_mr_keys = (1<<(8*info->domain_attr->mr_key_size));
 	bgq_domain->bat = (struct fi_bgq_bat_entry *) calloc(bgq_domain->num_mr_keys, sizeof(struct fi_bgq_bat_entry));
 
+	}
 	return 0;
 err:
 	errno = FI_EINVAL;
@@ -178,9 +198,10 @@ err:
 
 int fi_bgq_finalize_mr_ops(struct fi_bgq_domain *bgq_domain)
 {
+	if (FI_BGQ_FABRIC_DIRECT_MR == FI_MR_SCALABLE) {
 	free((void*)bgq_domain->bat);
 	bgq_domain->bat = (void*)NULL;
 	bgq_domain->num_mr_keys = 0;
-
+	}
 	return 0;
 }

--- a/prov/bgq/src/fi_bgq_msg.c
+++ b/prov/bgq/src/fi_bgq_msg.c
@@ -38,8 +38,11 @@ ssize_t fi_bgq_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	struct fi_bgq_ep * bgq_ep = container_of(ep, struct fi_bgq_ep, ep_fid);
 	const enum fi_threading threading = bgq_ep->threading;
 
+	/* assert that the most significant bits are zero in the immediate data */
+	assert(0 == (~((0x01ull << (FI_BGQ_REMOTE_CQ_DATA_SIZE * sizeof(uint8_t))) - 1) & msg->data));
+
 	return fi_bgq_send_generic_flags(ep, msg->msg_iov, msg->iov_count,
-		msg->desc, msg->addr, 0, msg->context,
+		msg->desc, msg->addr, 0, msg->context, msg->data,
 		(threading != FI_THREAD_ENDPOINT && threading != FI_THREAD_DOMAIN),	/* "lock required"? */
 		1 /* is_msg */,
 		0 /* is_contiguous */,
@@ -55,7 +58,7 @@ ssize_t fi_bgq_sendv(struct fid_ep *ep, const struct iovec *iov,
 	const enum fi_threading threading = bgq_ep->threading;
 
 	return fi_bgq_send_generic_flags(ep, iov, count,
-		desc, dest_addr, 0, context,
+		desc, dest_addr, 0, context, 0,
 		(threading != FI_THREAD_ENDPOINT && threading != FI_THREAD_DOMAIN),	/* "lock required"? */
 		1 /* is_msg */,
 		0 /* is_contiguous */,

--- a/prov/bgq/src/fi_bgq_msg.c
+++ b/prov/bgq/src/fi_bgq_msg.c
@@ -38,9 +38,6 @@ ssize_t fi_bgq_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	struct fi_bgq_ep * bgq_ep = container_of(ep, struct fi_bgq_ep, ep_fid);
 	const enum fi_threading threading = bgq_ep->threading;
 
-	/* assert that the most significant bits are zero in the immediate data */
-	assert(0 == (~((0x01ull << (FI_BGQ_REMOTE_CQ_DATA_SIZE * sizeof(uint8_t))) - 1) & msg->data));
-
 	return fi_bgq_send_generic_flags(ep, msg->msg_iov, msg->iov_count,
 		msg->desc, msg->addr, 0, msg->context, msg->data,
 		(threading != FI_THREAD_ENDPOINT && threading != FI_THREAD_DOMAIN),	/* "lock required"? */

--- a/prov/bgq/src/fi_bgq_msg.c
+++ b/prov/bgq/src/fi_bgq_msg.c
@@ -77,26 +77,28 @@ ssize_t fi_bgq_senddata(struct fid_ep *ep, const void *buf, size_t len, void *de
 /* "FI_BGQ_MSG_SPECIALIZED_FUNC(0)" is already declared via FABRIC_DIRECT */
 FI_BGQ_MSG_SPECIALIZED_FUNC(1)
 
-#define FI_BGQ_MSG_OPS_STRUCT_NAME(LOCK)			\
+#define FI_BGQ_MSG_OPS_STRUCT_NAME(LOCK)				\
 	fi_bgq_ops_msg_ ## LOCK
 
-#define FI_BGQ_MSG_OPS_STRUCT(LOCK)				\
-static struct fi_ops_msg					\
-	FI_BGQ_MSG_OPS_STRUCT_NAME(LOCK) = {			\
-	.size		= sizeof(struct fi_ops_msg),		\
-	.recv		=					\
-		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(recv, LOCK),	\
-	.recvv		= fi_no_msg_recvv,			\
-	.recvmsg	=					\
-		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(recvmsg, LOCK),\
-	.send		=					\
-		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(send, LOCK),	\
-	.sendv		= fi_bgq_sendv,				\
-	.sendmsg	= fi_bgq_sendmsg,			\
-	.inject	=						\
-		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(inject, LOCK),	\
-	.senddata	= fi_no_msg_senddata,			\
-	.injectdata	= fi_no_msg_injectdata			\
+#define FI_BGQ_MSG_OPS_STRUCT(LOCK)					\
+static struct fi_ops_msg						\
+	FI_BGQ_MSG_OPS_STRUCT_NAME(LOCK) = {				\
+	.size		= sizeof(struct fi_ops_msg),			\
+	.recv		=						\
+		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(recv, LOCK),		\
+	.recvv		= fi_no_msg_recvv,				\
+	.recvmsg	=						\
+		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(recvmsg, LOCK),	\
+	.send		=						\
+		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(send, LOCK),		\
+	.sendv		= fi_bgq_sendv,					\
+	.sendmsg	= fi_bgq_sendmsg,				\
+	.inject		=						\
+		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(inject, LOCK),		\
+	.senddata	=						\
+		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(senddata, LOCK),	\
+	.injectdata	=						\
+		FI_BGQ_MSG_SPECIALIZED_FUNC_NAME(injectdata, LOCK),	\
 }
 
 FI_BGQ_MSG_OPS_STRUCT(0);

--- a/prov/bgq/src/fi_bgq_node.c
+++ b/prov/bgq/src/fi_bgq_node.c
@@ -83,7 +83,7 @@ struct fi_bgq_node_shared {
 
 void calculate_local_process_count (uint64_t * local_process_count, uint32_t * leader_tcoord) {
 
-	int cnk_rc;
+	int cnk_rc __attribute__ ((unused));
 
 	Personality_t personality;
 	cnk_rc = Kernel_GetPersonality(&personality, sizeof(Personality_t));
@@ -165,7 +165,7 @@ int fi_bgq_node_init (struct fi_bgq_node * node) {
 
 	struct fi_bgq_node_shared * shared = (struct fi_bgq_node_shared *) node->shm_ptr;
 
-	uint32_t cnk_rc = 0;
+	uint32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = Kernel_L2AtomicsAllocate((void *)shared, FI_BGQ_NODE_SHM_FILESIZE);
 	assert(cnk_rc==0);
 
@@ -231,7 +231,7 @@ int fi_bgq_node_init (struct fi_bgq_node * node) {
 		 * variable which is used as a 'garbage' location to write
 		 * data that is to be ignored.
 		 */
-		uint64_t rc = 0;
+		uint64_t rc __attribute__ ((unused));
 
 		rc = fi_bgq_node_bat_allocate_id(node, NULL, FI_BGQ_MU_BAT_ID_GLOBAL);
 		assert(rc == 0);
@@ -369,7 +369,7 @@ void fi_bgq_node_bat_write (struct fi_bgq_node * node, struct l2atomic_lock * lo
 
 	if (lock) l2atomic_lock_acquire(lock);
 
-	int32_t cnk_rc = 0;
+	int32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = MUSPI_SetBaseAddress(&node->bat.subgroup[index], requested_bat_id, offset);
 	assert(cnk_rc == 0);
 
@@ -400,7 +400,7 @@ uint64_t fi_bgq_node_bat_allocate (struct fi_bgq_node * node, struct l2atomic_lo
 
 		uint32_t nbatids;
 		uint32_t batids[BGQ_MU_NUM_DATA_COUNTERS_PER_SUBGROUP];
-		int32_t cnk_rc = 0;
+		int32_t cnk_rc __attribute__ ((unused));
 		cnk_rc = Kernel_QueryBaseAddressTable(subgroup_id, &nbatids, batids);
 		assert(cnk_rc == 0);
 
@@ -412,7 +412,7 @@ uint64_t fi_bgq_node_bat_allocate (struct fi_bgq_node * node, struct l2atomic_lo
 				&node->bat.subgroup[index], 1, &batids[0], 0);
 			assert(cnk_rc == 0);
 
-			uint64_t bat_offset = 0;
+			uint64_t bat_offset __attribute__ ((unused));
 			bat_offset = fi_bgq_node_bat_read(node, index);
 			assert(bat_offset == 0xFFFFFFFFFFFFFFFFull);
 
@@ -438,7 +438,7 @@ uint64_t fi_bgq_node_bat_allocate_id (struct fi_bgq_node * node, struct l2atomic
 
 	uint32_t nbatids;
 	uint32_t batids[BGQ_MU_NUM_DATA_COUNTERS_PER_SUBGROUP];
-	int32_t cnk_rc = 0;
+	int32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = Kernel_QueryBaseAddressTable(requested_subgroup_id, &nbatids, batids);
 	assert(cnk_rc == 0);
 	assert(nbatids > 0);
@@ -453,7 +453,7 @@ uint64_t fi_bgq_node_bat_allocate_id (struct fi_bgq_node * node, struct l2atomic
 				&node->bat.subgroup[index], 1, &batids[i], 0);
 			assert(cnk_rc == 0);
 
-			uint64_t bat_offset = 0;
+			uint64_t bat_offset __attribute__ ((unused));
 			bat_offset = fi_bgq_node_bat_read(node, index);
 			assert(bat_offset == 0xFFFFFFFFFFFFFFFFull);
 
@@ -478,7 +478,7 @@ void fi_bgq_node_bat_free (struct fi_bgq_node * node, struct l2atomic_lock * loc
 
 	uint32_t batid = index & 0x07;
 
-	int32_t cnk_rc = 0;
+	int32_t cnk_rc  __attribute__ ((unused));
 	cnk_rc = Kernel_DeallocateBaseAddressTable(&node->bat.subgroup[index], 1, &batid);
 	assert(cnk_rc == 0);
 

--- a/prov/bgq/src/fi_bgq_pmi.c
+++ b/prov/bgq/src/fi_bgq_pmi.c
@@ -67,7 +67,7 @@ convert_virtual_address_to_global_virtual_address (void * vaddr, size_t len)
 {
 	uint64_t paddr = 0;
 	void * global_vaddr = NULL;
-	uint32_t cnk_rc = 0;
+	uint32_t cnk_rc __attribute__ ((unused));
 
 	Kernel_MemoryRegion_t cnk_mr;
 	cnk_rc = Kernel_CreateMemoryRegion(&cnk_mr, (void *)vaddr, len);

--- a/prov/bgq/src/fi_bgq_progress.c
+++ b/prov/bgq/src/fi_bgq_progress.c
@@ -312,7 +312,7 @@ int fi_bgq_progress_disable (struct fi_bgq_domain *bgq_domain, const unsigned id
 		fi_bgq_msync(FI_BGQ_MSYNC_TYPE_RO);
 	}
 
-	int rc = 1;
+	int rc __attribute__ ((unused));
 	void *retval = NULL;
 	rc = pthread_join(bgq_domain->progress.thread[id].pthread, &retval);
 	assert(0 == rc);

--- a/prov/bgq/src/fi_bgq_sep.c
+++ b/prov/bgq/src/fi_bgq_sep.c
@@ -77,7 +77,7 @@ static int fi_bgq_close_sep(fid_t fid)
 
 static int fi_bgq_control_sep(fid_t fid, int command, void *arg)
 {
-	struct fid_ep *ep;
+	struct fid_ep *ep __attribute__ ((unused));
 	ep = container_of(fid, struct fid_ep, fid);
 	return 0;
 }

--- a/prov/bgq/src/fi_bgq_tagged.c
+++ b/prov/bgq/src/fi_bgq_tagged.c
@@ -67,9 +67,6 @@ ssize_t fi_bgq_tsendmsg(struct fid_ep *ep,
 		struct fi_bgq_ep * bgq_ep = container_of(ep, struct fi_bgq_ep, ep_fid);
 		const enum fi_threading threading = bgq_ep->threading;
 
-		/* assert that the most significant bits are zero in the immediate data */
-		assert(0 == (~((0x01ull << (FI_BGQ_REMOTE_CQ_DATA_SIZE * sizeof(uint8_t))) - 1) & msg->data));
-
 		return fi_bgq_send_generic_flags(ep, msg->msg_iov, niov,
 			msg->desc, msg->addr, msg->tag, msg->context, msg->data,
 			(threading != FI_THREAD_ENDPOINT && threading != FI_THREAD_DOMAIN),

--- a/prov/bgq/src/fi_bgq_tagged.c
+++ b/prov/bgq/src/fi_bgq_tagged.c
@@ -67,8 +67,11 @@ ssize_t fi_bgq_tsendmsg(struct fid_ep *ep,
 		struct fi_bgq_ep * bgq_ep = container_of(ep, struct fi_bgq_ep, ep_fid);
 		const enum fi_threading threading = bgq_ep->threading;
 
+		/* assert that the most significant bits are zero in the immediate data */
+		assert(0 == (~((0x01ull << (FI_BGQ_REMOTE_CQ_DATA_SIZE * sizeof(uint8_t))) - 1) & msg->data));
+
 		return fi_bgq_send_generic_flags(ep, msg->msg_iov, niov,
-			msg->desc, msg->addr, msg->tag, msg->context,
+			msg->desc, msg->addr, msg->tag, msg->context, msg->data,
 			(threading != FI_THREAD_ENDPOINT && threading != FI_THREAD_DOMAIN),
 			0 /* is_msg */,
 			0 /* is_contiguous */,

--- a/prov/bgq/src/fi_bgq_tagged.c
+++ b/prov/bgq/src/fi_bgq_tagged.c
@@ -107,10 +107,12 @@ static struct fi_ops_tagged						\
 		FI_BGQ_TAGGED_SPECIALIZED_FUNC_NAME(tsend, LOCK),	\
 	.sendv		= fi_no_tagged_sendv,				\
 	.sendmsg	= fi_bgq_tsendmsg,				\
-	.inject =							\
+	.inject 	=						\
 		FI_BGQ_TAGGED_SPECIALIZED_FUNC_NAME(tinject, LOCK),	\
-	.senddata	= fi_no_tagged_senddata,			\
-	.injectdata	= fi_no_tagged_injectdata			\
+	.senddata	=						\
+		FI_BGQ_TAGGED_SPECIALIZED_FUNC_NAME(tsenddata, LOCK),	\
+	.injectdata	=						\
+		FI_BGQ_TAGGED_SPECIALIZED_FUNC_NAME(tinjectdata, LOCK),	\
 }
 
 FI_BGQ_TAGGED_OPS_STRUCT(0);

--- a/prov/bgq/src/test/spi_pingpong.c
+++ b/prov/bgq/src/test/spi_pingpong.c
@@ -48,7 +48,7 @@ static inline void bat_allocate (MUSPI_BaseAddressTableSubGroup_t * bat_subgroup
 {
 	uint32_t nbatids;
 	uint32_t batids[BGQ_MU_NUM_DATA_COUNTERS_PER_SUBGROUP];
-	int32_t cnk_rc = 0;
+	int32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = Kernel_QueryBaseAddressTable(0, &nbatids, batids);
 	assert(cnk_rc == 0);
 	assert(nbatids > 0);
@@ -60,7 +60,7 @@ static inline void bat_allocate (MUSPI_BaseAddressTableSubGroup_t * bat_subgroup
 static inline void bat_write (MUSPI_BaseAddressTableSubGroup_t * bat_subgroup, uint64_t index, uint64_t offset)
 {
 
-	int32_t cnk_rc = 0;
+	int32_t cnk_rc __attribute__ ((unused));
 	cnk_rc = MUSPI_SetBaseAddress(bat_subgroup, index, offset);
 	assert(cnk_rc == 0);
 
@@ -103,7 +103,7 @@ static inline void do_gi_barrier_no_timeout (MUSPI_GIBarrier_t * GIBarrier)
 static inline MUSPI_RecFifo_t * allocate_reception_fifo (MUSPI_RecFifoSubGroup_t * rfifo_subgroup)
 {
 
-	int rc;
+	int rc __attribute__ ((unused));
 	uint8_t * memptr;
 
 	size_t nbytes = 8 * 1024 * 1024;


### PR DESCRIPTION
This is a pull request that includes all the updates for scalability, performance and capabilities to support MPICH3 CH4 on BGQ that I am calling Release 0.2 (I was at Release 0.1 a couple weeks ago but then added more performance improvements and functionality since then and am calling this 0.2.  It is a 0.x release because of the fact MPICH CH4 is still under development.)  I know this is a massive amount of code changes, so my apologies, but there were several significant coding endeavors that took place with tight schedules, overlap and bug fixing / chasing and dealing with changes in CH4 that didn't lend itself to proceeding atomically with small changes.  I think I'm at a point now where that will no longer be the case going forward and I will work closely off ofiwg libfabric master and do relatively small and precise pull requests.
Highlights for this work include support of both memory registration modes FI_MR_SCALABLE and FI_MR_BASIC -- the main reason for FI_MR_BASIC support was to hardware accelerate the rdma transfers for MPICH MPI_Put  via the fi_*write* calls.  The FI_DIRECTED_RECV  is now supported, the main reason for that was for scalability to allow for tagged receives to go beyond 16M ranks within MPICH CH4.  There are several optimizations to reduce branching and speed tag matching.  There are enhancements and bug fixes for capability and domain attribute specifications and error handling within interactions with  MPICH.  Both FI_PROGRESS_MANUAL AND FI_PROGRESS_AUTO are both supported and fully functional (FI_PROGRESS_AUTO was there but needed to be resurrected after being unused for months in preference to FI_PROGRESS_MANUAL). 