### PR TITLE
Fix some issues in RXM, provider's utils and coverity warnings in verbs and RXD

### DIFF
--- a/include/windows/pthread.h
+++ b/include/windows/pthread.h
@@ -22,8 +22,8 @@
 
 #define pthread_cond_signal WakeConditionVariable
 #define pthread_cond_broadcast WakeAllConditionVariable
-#define pthread_mutex_init(mutex, attr) InitializeCriticalSection(mutex)
-#define pthread_mutex_destroy DeleteCriticalSection
+#define pthread_mutex_init(mutex, attr) (InitializeCriticalSection(mutex), 0)
+#define pthread_mutex_destroy(mutex) (DeleteCriticalSection(mutex), 0)
 #define pthread_cond_init(cond, attr) (InitializeConditionVariable(cond), 0)
 #define pthread_cond_destroy(x)	/* nothing to do */
 

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -121,10 +121,10 @@ static int rxd_mr_close(struct fid *fid)
 
 	fastlock_acquire(&dom->lock);
 	err = ofi_mr_remove(&dom->mr_map, mr->key);
+	fastlock_release(&dom->lock);
 	if (err)
 		return err;
 
-	fastlock_release(&dom->lock);
 	atomic_dec(&dom->util_domain.ref);
 	free(mr);
 	return 0;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -182,7 +182,7 @@ int rxm_finish_send(struct rxm_tx_entry *tx_entry)
 static int rxm_match_iov(struct rxm_match_iov *match_iov, size_t len,
 		struct rxm_iovx_entry *iovx)
 {
-	int i, j;
+	size_t i, j;
 
 	for (i = match_iov->index, j = 0; i < match_iov->count; i++, j++) {
 		iovx->iov[j].iov_base = (char *)match_iov->iov[i].iov_base + match_iov->offset;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -669,7 +669,8 @@ static int ip_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
 	struct util_av *av;
-	int i, ret, success_cnt = 0;
+	int ret, success_cnt = 0;
+	size_t i;
 	size_t addrlen;
 
 	av = container_of(av_fid, struct util_av, av_fid);
@@ -743,7 +744,8 @@ static int ip_av_insert_ip4sym(struct util_av *av,
 			       fi_addr_t *fi_addr, void *context)
 {
 	struct sockaddr_in sin;
-	int i, p, fi, ret, success_cnt = 0;
+	int fi, ret, success_cnt = 0;
+	size_t i, p;
 
 	memset(&sin, 0, sizeof sin);
 	sin.sin_family = AF_INET;
@@ -772,7 +774,8 @@ static int ip_av_insert_ip6sym(struct util_av *av,
 			       fi_addr_t *fi_addr, void *context)
 {
 	struct sockaddr_in6 sin6;
-	int i, j, p, fi, ret, success_cnt = 0;
+	int j, fi, ret, success_cnt = 0;
+	size_t i, p;
 
 	memset(&sin6, 0, sizeof sin6);
 	sin6.sin6_family = AF_INET6;
@@ -806,8 +809,8 @@ static int ip_av_insert_nodesym(struct util_av *av,
 {
 	char name[FI_NAME_MAX];
 	char svc[FI_NAME_MAX];
-	size_t name_len;
-	int fi, n, s, ret, name_index, svc_index, success_cnt = 0;
+	size_t name_len, n, s;
+	int fi, ret, name_index, svc_index, success_cnt = 0;
 
 	for (name_len = strlen(node); isdigit(node[name_len - 1]); )
 		name_len--;
@@ -930,7 +933,7 @@ static int ip_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr, void *addr,
 			size_t *addrlen)
 {
 	struct util_av *av;
-	int index;
+	size_t index;
 
 	av = container_of(av_fid, struct util_av, av_fid);
 	index = (int) fi_addr;
@@ -1221,7 +1224,7 @@ void ofi_cmap_del_handles(struct util_cmap *cmap)
 {
 	struct util_cmap_peer *peer;
 	struct dlist_entry *entry;
-	int i;
+	size_t i;
 
 	fastlock_acquire(&cmap->lock);
 	for (i = 0; i < cmap->av->count; i++) {

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -825,7 +825,7 @@ static int ip_av_insert_nodesym(struct util_av *av,
 			name[FI_NAME_MAX - 1] = '\0';
 		} else {
 			snprintf(name + name_len, sizeof(name) - name_len - 1,
-				 "%d", name_index + n);
+				 "%zu", name_index + n);
 		}
 
 		for (s = 0; s < svccnt; s++, fi++) {
@@ -834,7 +834,7 @@ static int ip_av_insert_nodesym(struct util_av *av,
 				svc[FI_NAME_MAX - 1] = '\0';
 			} else {
 				snprintf(svc, sizeof(svc) - 1,
-					 "%d", svc_index + s);
+					 "%zu", svc_index + s);
 			}
 
 			ret = ip_av_insert_svc(av, name, svc, fi_addr ?
@@ -933,7 +933,7 @@ static int ip_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr, void *addr,
 			size_t *addrlen)
 {
 	struct util_av *av;
-	size_t index;
+	int index;
 
 	av = container_of(av_fid, struct util_av, av_fid);
 	index = (int) fi_addr;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -87,16 +87,25 @@ fi_ibv_rdm_prepare_rma_request(struct fi_ibv_rdm_request *request,
 
 static int fi_ibv_rdm_tagged_getname(fid_t fid, void *addr, size_t * addrlen)
 {
-	struct fi_ibv_rdm_ep *ep =
-		container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
+	struct fi_ibv_rdm_ep *ep;
+
+	if (fid->fclass == FI_CLASS_EP) {
+ 		ep = container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
+	} else {
+		VERBS_INFO(FI_LOG_EP_CTRL, "Invalid fid class: %d\n",
+			  fid->fclass);
+		return -FI_EINVAL;
+	}
 
 	if (FI_IBV_RDM_DFLT_ADDRLEN > *addrlen) {
 		*addrlen = FI_IBV_RDM_DFLT_ADDRLEN;
 		return -FI_ETOOSMALL;
 	}
+
 	memset(addr, 0, *addrlen);
 	memcpy(addr, &ep->my_addr, FI_IBV_RDM_DFLT_ADDRLEN);
-	ep->addrlen = *addrlen;
+	*addrlen = FI_IBV_RDM_DFLT_ADDRLEN;
+	ep->addrlen = FI_IBV_RDM_DFLT_ADDRLEN;
 
 	return 0;
 }


### PR DESCRIPTION
Fix incorrect filling of msg_iov structure in rxm fi_(send | sendmsg | fi_sendv)
Some minor fixes to avoid comparison between signed and unsigned values
Corrected zeroing of the port for AF_INET6 family in rxm
Fix build issue with ENABLE_DEBUG under Windows OS

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>