### PR TITLE
prov/util: Add api version to ofi_check_info

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -498,26 +498,28 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 			   FI_SHARED_AV | FI_TRIGGER | FI_FENCE | \
 			   FI_LOCAL_COMM | FI_REMOTE_COMM)
 
+#define OFI_TODO_API_VERSION 0 /* remove when no longer used by providers */
+
 int ofi_check_fabric_attr(const struct fi_provider *prov,
-			 const struct fi_fabric_attr *prov_attr,
-			 const struct fi_fabric_attr *user_attr,
-			 enum fi_match_type type);
+			  const struct fi_fabric_attr *prov_attr,
+			  const struct fi_fabric_attr *user_attr,
+			  enum fi_match_type type);
 int ofi_check_wait_attr(const struct fi_provider *prov,
 		        const struct fi_wait_attr *attr);
-int ofi_check_domain_attr(const struct fi_provider *prov,
-			 const struct fi_domain_attr *prov_attr,
-			 const struct fi_domain_attr *user_attr,
-			 enum fi_match_type type);
+int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
+			  const struct fi_domain_attr *prov_attr,
+			  const struct fi_domain_attr *user_attr,
+			  enum fi_match_type type);
 int ofi_check_ep_attr(const struct util_prov *util_prov,
 		      const struct fi_ep_attr *user_attr);
 int ofi_check_cq_attr(const struct fi_provider *prov,
-		     const struct fi_cq_attr *attr);
+		      const struct fi_cq_attr *attr);
 int ofi_check_rx_attr(const struct fi_provider *prov,
-		     const struct fi_rx_attr *prov_attr,
-		     const struct fi_rx_attr *user_attr);
+		      const struct fi_rx_attr *prov_attr,
+		      const struct fi_rx_attr *user_attr);
 int ofi_check_tx_attr(const struct fi_provider *prov,
-		     const struct fi_tx_attr *prov_attr,
-		     const struct fi_tx_attr *user_attr);
+		      const struct fi_tx_attr *prov_attr,
+		      const struct fi_tx_attr *user_attr);
 int ofi_check_info(const struct util_prov *util_prov, uint32_t api_version,
 		   const struct fi_info *user_info, enum fi_match_type type);
 void ofi_alter_info(struct fi_info *info,

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -518,11 +518,10 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 int ofi_check_tx_attr(const struct fi_provider *prov,
 		     const struct fi_tx_attr *prov_attr,
 		     const struct fi_tx_attr *user_attr);
-int ofi_check_info(const struct util_prov *util_prov,
-		  const struct fi_info *user_info,
-		  enum fi_match_type type);
+int ofi_check_info(const struct util_prov *util_prov, uint32_t api_version,
+		   const struct fi_info *user_info, enum fi_match_type type);
 void ofi_alter_info(struct fi_info *info,
-		   const struct fi_info *hints);
+		    const struct fi_info *hints);
 
 struct fi_info *ofi_allocinfo_internal(void);
 int util_getinfo(const struct util_prov *util_prov, uint32_t version,

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -502,15 +502,15 @@ int ofi_check_fabric_attr(const struct fi_provider *prov,
 			 const struct fi_fabric_attr *prov_attr,
 			 const struct fi_fabric_attr *user_attr,
 			 enum fi_match_type type);
-int fi_check_wait_attr(const struct fi_provider *prov,
-		       const struct fi_wait_attr *attr);
+int ofi_check_wait_attr(const struct fi_provider *prov,
+		        const struct fi_wait_attr *attr);
 int ofi_check_domain_attr(const struct fi_provider *prov,
 			 const struct fi_domain_attr *prov_attr,
 			 const struct fi_domain_attr *user_attr,
 			 enum fi_match_type type);
 int ofi_check_ep_attr(const struct util_prov *util_prov,
-		     const struct fi_ep_attr *user_attr);
-int fi_check_cq_attr(const struct fi_provider *prov,
+		      const struct fi_ep_attr *user_attr);
+int ofi_check_cq_attr(const struct fi_provider *prov,
 		     const struct fi_cq_attr *attr);
 int ofi_check_rx_attr(const struct fi_provider *prov,
 		     const struct fi_rx_attr *prov_attr,

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -494,7 +494,7 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 					hints->domain_attr->caps;
 			}
 
-			ret = ofi_check_domain_attr(&gnix_prov,
+			ret = ofi_check_domain_attr(&gnix_prov, version,
 						    gnix_info->domain_attr,
 						    hints->domain_attr,
 						    FI_MATCH_EXACT);

--- a/prov/mlx/src/mlx_domain.c
+++ b/prov/mlx/src/mlx_domain.c
@@ -37,7 +37,7 @@ static int mlx_domain_close(fid_t fid)
 	int status;
 
 	domain = container_of( fid,
-				struct mlx_domain, 
+				struct mlx_domain,
 				u_domain.domain_fid.fid);
 
 	ucp_cleanup(domain->context);
@@ -71,19 +71,22 @@ struct fi_ops_mr mlx_mr_ops = {
 };
 
 int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
-                     struct fid_domain **fid, void *context){
-
+                     struct fid_domain **fid, void *context)
+{
+	struct mlx_fabric *fab;
 	ucs_status_t status = UCS_OK;
 	int ofi_status;
 	struct mlx_domain* domain;
 	ucp_params_t params;
 
-	if (!info->domain_attr->name 
-		|| strcmp(info->domain_attr->name, FI_MLX_FABRIC_NAME)) {
+	if (!info->domain_attr->name ||
+	    strcmp(info->domain_attr->name, FI_MLX_FABRIC_NAME)) {
 		return -FI_EINVAL;
 	}
 
-	ofi_status = ofi_check_info(&mlx_util_prov, info, FI_MATCH_EXACT);
+	fab = container_of(fabric, struct mlx_fabric, u_fabric.fabric_fid);
+	ofi_status = ofi_check_info(&mlx_util_prov, fab->u_fabric.api_version,
+				    info, FI_MATCH_EXACT);
 	if (ofi_status) {
 		return ofi_status;
 	}

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -237,7 +237,9 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct rxd_domain *rxd_domain;
 	struct rxd_fabric *rxd_fabric;
 
-	ret = ofi_check_info(&rxd_util_prov, info, FI_MATCH_PREFIX);
+	rxd_fabric = container_of(fabric, struct rxd_fabric, util_fabric.fabric_fid);
+	ret = ofi_check_info(&rxd_util_prov, rxd_fabric->util_fabric.api_version,
+			     info, FI_MATCH_PREFIX);
 	if (ret)
 		return ret;
 
@@ -245,14 +247,13 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!rxd_domain)
 		return -FI_ENOMEM;
 
-	ret = ofix_getinfo(rxd_prov.version, NULL, NULL, 0, &rxd_util_prov,
-			info, rxd_alter_layer_info,
-			rxd_alter_base_info, 1, &dg_info);
+	ret = ofix_getinfo(rxd_fabric->util_fabric.api_version, NULL, NULL, 0,
+			   &rxd_util_prov, info, rxd_alter_layer_info,
+			   rxd_alter_base_info, 1, &dg_info);
 	if (ret)
 		goto err1;
 
 
-	rxd_fabric = container_of(fabric, struct rxd_fabric, util_fabric.fabric_fid);
 	ret = fi_domain(rxd_fabric->dg_fabric, dg_info, &rxd_domain->dg_domain, context);
 	if (ret)
 		goto err2;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1719,17 +1719,19 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct rxd_ep *rxd_ep;
 	struct rxd_domain *rxd_domain;
 
-	ret = ofi_check_info(&rxd_util_prov, info, FI_MATCH_PREFIX);
+	rxd_domain = container_of(domain, struct rxd_domain, util_domain.domain_fid);
+	ret = ofi_check_info(&rxd_util_prov,
+			     rxd_domain->util_domain.fabric->api_version,
+			     info, FI_MATCH_PREFIX);
 	if (ret)
 		return ret;
 
-	ret = ofix_getinfo(rxd_prov.version, NULL, NULL, 0, &rxd_util_prov,
-			   info, rxd_alter_layer_info,
+	ret = ofix_getinfo(rxd_domain->util_domain.fabric->api_version, NULL, NULL,
+			   0, &rxd_util_prov, info, rxd_alter_layer_info,
 			   rxd_alter_base_info, 1, &dg_info);
 	if (ret)
 		return ret;
 
-	rxd_domain = container_of(domain, struct rxd_domain, util_domain.domain_fid);
 	rxd_ep = calloc(1, sizeof(*rxd_ep));
 	if (!rxd_ep) {
 		ret = -FI_ENOMEM;

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -72,7 +72,6 @@ extern struct util_prov udpx_util_prov;
 extern struct fi_info udpx_info;
 
 
-int udpx_check_info(struct fi_info *info);
 int udpx_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		void *context);
 int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/udp/src/udpx_domain.c
+++ b/prov/udp/src/udpx_domain.c
@@ -72,10 +72,13 @@ static struct fi_ops udpx_domain_fi_ops = {
 int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		struct fid_domain **domain, void *context)
 {
-	int ret;
+	struct util_fabric *util_fabric;
 	struct util_domain *util_domain;
+	int ret;
 
-	ret = udpx_check_info(info);
+	util_fabric = container_of(fabric, struct util_fabric, fabric_fid);
+	ret = ofi_check_info(&udpx_util_prov, util_fabric->api_version, info,
+			     FI_MATCH_EXACT);
 	if (ret)
 		return ret;
 

--- a/prov/udp/src/udpx_init.c
+++ b/prov/udp/src/udpx_init.c
@@ -97,11 +97,6 @@ static void udpx_getinfo_ifs(struct fi_info **info)
 #define udpx_getinfo_ifs(info) do{}while(0)
 #endif
 
-int udpx_check_info(struct fi_info *info)
-{
-	return ofi_check_info(&udpx_util_prov, info, FI_MATCH_EXACT);
-}
-
 static int udpx_getinfo(uint32_t version, const char *node, const char *service,
 			uint64_t flags, struct fi_info *hints, struct fi_info **info)
 {

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -199,7 +199,7 @@ int ofix_getinfo(uint32_t version, const char *node, const char *service,
 	struct fi_info *temp = NULL, *fi, *tail = NULL;
 	int ret;
 
-	ret = ofi_check_info(util_prov, hints, FI_MATCH_PREFIX);
+	ret = ofi_check_info(util_prov, version, hints, FI_MATCH_PREFIX);
 	if (ret)
 		goto err1;
 
@@ -559,9 +559,8 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 	return 0;
 }
 
-int ofi_check_info(const struct util_prov *util_prov,
-		  const struct fi_info *user_info,
-		  enum fi_match_type type)
+int ofi_check_info(const struct util_prov *util_prov, uint32_t api_version,
+		   const struct fi_info *user_info, enum fi_match_type type)
 {
 	const struct fi_info *prov_info = util_prov->info;
 	const struct fi_provider *prov = util_prov->prov;

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -321,10 +321,10 @@ static int fi_resource_mgmt_level(enum fi_resource_mgmt rm_model)
 	}
 }
 
-int ofi_check_domain_attr(const struct fi_provider *prov,
-			 const struct fi_domain_attr *prov_attr,
-			 const struct fi_domain_attr *user_attr,
-			 enum fi_match_type type)
+int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
+			  const struct fi_domain_attr *prov_attr,
+			  const struct fi_domain_attr *user_attr,
+			  enum fi_match_type type)
 {
 	if (user_attr->name && fi_check_name(user_attr->name, prov_attr->name, type)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unknown domain name\n");
@@ -596,9 +596,9 @@ int ofi_check_info(const struct util_prov *util_prov, uint32_t api_version,
 	}
 
 	if (user_info->domain_attr) {
-		ret = ofi_check_domain_attr(prov, prov_info->domain_attr,
-				user_info->domain_attr,
-				type);
+		ret = ofi_check_domain_attr(prov, api_version,
+					    prov_info->domain_attr,
+					    user_info->domain_attr, type);
 		if (ret)
 			return ret;
 	}

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -38,8 +38,8 @@
 
 #define UTIL_DEF_CQ_SIZE (1024)
 
-int fi_check_cq_attr(const struct fi_provider *prov,
-		     const struct fi_cq_attr *attr)
+int ofi_check_cq_attr(const struct fi_provider *prov,
+		      const struct fi_cq_attr *attr)
 {
 	switch (attr->format) {
 	case FI_CQ_FORMAT_UNSPEC:
@@ -394,7 +394,7 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 	int ret;
 
 	assert(progress);
-	ret = fi_check_cq_attr(prov, attr);
+	ret = ofi_check_cq_attr(prov, attr);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -65,7 +65,8 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	if (!info || !info->ep_attr || !info->rx_attr || !info->tx_attr)
 		return -FI_EINVAL;
 
-	ret = ofi_check_info(util_prov, info, type);
+	ret = ofi_check_info(util_prov, util_domain->fabric->api_version,
+			     info, type);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -165,7 +165,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		return -FI_EINVAL;
 	}
 
-	ret = ofi_check_info(util_prov, hints, FI_MATCH_EXACT);
+	ret = ofi_check_info(util_prov, version, hints, FI_MATCH_EXACT);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -71,8 +71,8 @@ int ofi_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
 	return 0;
 }
 
-int fi_check_wait_attr(const struct fi_provider *prov,
-		       const struct fi_wait_attr *attr)
+int ofi_check_wait_attr(const struct fi_provider *prov,
+		        const struct fi_wait_attr *attr)
 {
 	switch (attr->wait_obj) {
 	case FI_WAIT_UNSPEC:
@@ -244,7 +244,7 @@ static int util_verify_wait_fd_attr(const struct fi_provider *prov,
 {
 	int ret;
 
-	ret = fi_check_wait_attr(prov, attr);
+	ret = ofi_check_wait_attr(prov, attr);
 	if (ret)
 		return ret;
 

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -278,8 +278,9 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (!fi)
 		return -FI_EINVAL;
 
-	ret = ofi_check_domain_attr(&fi_ibv_prov, fi->domain_attr,
-			info->domain_attr, FI_MATCH_EXACT);
+	ret = ofi_check_domain_attr(&fi_ibv_prov, OFI_TODO_API_VERSION,
+				    fi->domain_attr, info->domain_attr,
+				    FI_MATCH_EXACT);
 	if (ret)
 		return ret;
 

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -234,7 +234,7 @@ int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
 	}
 
 	compare_mode = attr->mode ? attr->mode : hints->mode;
-	
+
 	check_mode = FI_IBV_EP_TYPE_IS_RDM(info) ? VERBS_RDM_MODE :
 		(hints->caps & FI_RMA) ? info->rx_attr->mode : VERBS_MODE;
 
@@ -357,8 +357,9 @@ static int fi_ibv_check_hints(const struct fi_info *hints,
 	}
 
 	if (hints->domain_attr) {
-		ret = ofi_check_domain_attr(&fi_ibv_prov, info->domain_attr,
-				hints->domain_attr, FI_MATCH_EXACT);
+		ret = ofi_check_domain_attr(&fi_ibv_prov, OFI_TODO_API_VERSION,
+					    info->domain_attr,
+					    hints->domain_attr, FI_MATCH_EXACT);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
In order to validate attributes correctly, we need to know
what version of the api the application is attempting to use.

Start by updating ofi_check_info to take the api_version that
was specified by the application.  Update providers that make
use of this call, and fix-up the version being used.  Follow
on patches will push the api_version through to other calls.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>