### PR TITLE
prov/bgq: Hardcode provider version to 1.5

### DIFF
--- a/prov/bgq/src/fi_bgq_init.c
+++ b/prov/bgq/src/fi_bgq_init.c
@@ -327,7 +327,7 @@ static void fi_bgq_fini()
 static struct fi_provider fi_bgq_provider = {
 	.name 		= FI_BGQ_PROVIDER_NAME,
 	.version 	= FI_VERSION(0, 1),
-	.fi_version 	= FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+	.fi_version 	= FI_VERSION(1,5),
 	.getinfo	= fi_bgq_getinfo,
 	.fabric		= fi_bgq_fabric,
 	.cleanup	= fi_bgq_fini


### PR DESCRIPTION
Instead of setting .fi_version from the defines in the header file
hardcode it to 1.5 since that is the version the bgq provider
supports.