### PR TITLE
Sockets: init av_index field of a newly created sock_conn

### DIFF
--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -182,6 +182,7 @@ static struct sock_conn *sock_conn_map_insert(struct sock_ep_attr *ep_attr,
 		map->used++;
 	}
 
+	map->table[index].av_index = FI_ADDR_NOTAVAIL;
 	map->table[index].connected = 1;
 	map->table[index].addr = *addr;
 	map->table[index].sock_fd = conn_fd;


### PR DESCRIPTION
Needed to init av_index to FI_ADDR_NOAVAIL, because it prevents mpi from race if scalable ep are enabled. Since connections are established dynamically, there would be 2 messages at once on a socket first time - conn_msg and regular one. When we have multiple contexts and cqs, these messages could be handled not in order, in this case we'd have sock_conn's av_index=0 (actually, not initialized) for regular message, which could be falsely treated as a real av_index.