### PR TITLE
prov/verbs: Fixed the issue when CQ entry isn't provided

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -566,6 +566,7 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->buff_len = rdm_buffer_size(info->tx_attr->inject_size);
 	FI_INFO(&fi_ibv_prov, FI_LOG_EP_CTRL, "buff_len: %d\n", _ep->buff_len);
 
+	_ep->tx_op_flags = info->tx_attr->op_flags;
 	_ep->rx_op_flags = info->rx_attr->op_flags;
 	_ep->min_multi_recv_size = (_ep->rx_op_flags & FI_MULTI_RECV) ?
 				   info->tx_attr->inject_size : 0;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -108,6 +108,16 @@ do {									\
 #define RMA_RESOURCES_IS_BUSY(_connection, _ep)				\
 	(OUTGOING_POST_LIMIT(_connection, _ep) || PEND_POST_LIMIT(_ep))
 
+#define GET_TX_COMP(ep_rdm)						\
+	(!ep_rdm->rx_selective_completion ||		\
+	(ep_rdm->rx_op_flags & FI_COMPLETION) ?		\
+	FI_COMPLETION : 0ULL)
+
+#define GET_TX_COMP_FLAG(ep_rdm, flag)			\
+	(!ep_rdm->rx_selective_completion ||		\
+	(ep_rdm->rx_op_flags & FI_COMPLETION) ?		\
+	FI_COMPLETION : (flags & FI_COMPLETION))
+
 struct fi_ibv_rdm_header {
 /*	uint64_t imm_data; TODO: not implemented */
 	uint64_t tag;
@@ -266,6 +276,7 @@ struct fi_ibv_rdm_ep {
 	int tx_selective_completion;
 	int rx_selective_completion;
 	size_t min_multi_recv_size;
+	uint64_t tx_op_flags;
 	uint64_t rx_op_flags;
 
 	/*

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -130,8 +130,7 @@ static ssize_t fi_ibv_rdm_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		.conn = ep_rdm->av->addr_to_conn(ep_rdm, msg->addr),
 		.data_len = 0,
 		.context = msg->context,
-		.flags = FI_MSG | FI_SEND | (ep_rdm->tx_selective_completion ?
-			(flags & FI_COMPLETION) : FI_COMPLETION),
+		.flags = FI_MSG | FI_SEND | GET_TX_COMP_FLAG(ep_rdm, flags),
 		.tag = 0,
 		.is_tagged = 0,
 		.buf.src_addr = NULL,
@@ -193,8 +192,7 @@ static ssize_t fi_ibv_rdm_sendv(struct fid_ep *ep, const struct iovec *iov,
 		.data = 0
 	};
 
-	return fi_ibv_rdm_sendmsg(ep, &msg,
-		(ep_rdm->tx_selective_completion ? 0ULL : FI_COMPLETION));
+	return fi_ibv_rdm_sendmsg(ep, &msg, GET_TX_COMP(ep_rdm));
 }
 
 static ssize_t fi_ibv_rdm_send(struct fid_ep *ep, const void *buf, size_t len,

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -280,14 +280,12 @@ static ssize_t fi_ibv_rdm_tagged_senddatato(struct fid_ep *fid, const void *buf,
 {
 	struct fi_ibv_rdm_ep *ep_rdm = 
 		container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
-
 	struct fi_ibv_rdm_send_start_data sdata = {
 		.ep_rdm = container_of(fid, struct fi_ibv_rdm_ep, ep_fid),
 		.conn = ep_rdm->av->addr_to_conn(ep_rdm, dest_addr),
 		.data_len = len,
 		.context = context,
-		.flags = FI_TAGGED | FI_SEND |
-			(ep_rdm->tx_selective_completion ? 0ULL : FI_COMPLETION),
+		.flags = FI_TAGGED | FI_SEND | GET_TX_COMP(ep_rdm),
 		.tag = tag,
 		.is_tagged = 1,
 		.buf.src_addr = (void*)buf,
@@ -319,8 +317,7 @@ static ssize_t fi_ibv_rdm_tagged_sendmsg(struct fid_ep *ep,
 		.conn = ep_rdm->av->addr_to_conn(ep_rdm, msg->addr),
 		.data_len = 0,
 		.context = msg->context,
-		.flags = FI_TAGGED | FI_SEND | (ep_rdm->tx_selective_completion ?
-			(flags & FI_COMPLETION) : FI_COMPLETION),
+		.flags = FI_TAGGED | FI_SEND | GET_TX_COMP_FLAG(ep_rdm, flags),
 		.tag = msg->tag,
 		.is_tagged = 1,
 		.buf.src_addr = NULL,
@@ -385,8 +382,7 @@ static ssize_t fi_ibv_rdm_tagged_sendv(struct fid_ep *ep,
 		.data = 0
 	};
 
-	return fi_ibv_rdm_tagged_sendmsg(ep, &msg,
-		(ep_rdm->tx_selective_completion ? 0ULL : FI_COMPLETION));
+	return fi_ibv_rdm_tagged_sendmsg(ep, &msg, GET_TX_COMP(ep_rdm));
 }
 
 struct fi_ops_tagged fi_ibv_rdm_tagged_ops = {

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -281,8 +281,7 @@ fi_ibv_rdm_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		.ep_rdm = ep,
 		.conn = conn,
 		.context = msg->context,
-		.flags = FI_RMA | FI_READ | (ep->tx_selective_completion ?
-			(flags & FI_COMPLETION) : FI_COMPLETION),
+		.flags = FI_RMA | FI_READ | GET_TX_COMP_FLAG(ep, flags),
 		.data_len = (uint64_t)msg->msg_iov[0].iov_len,
 		.rbuf = (uintptr_t)msg->rma_iov[0].addr,
 		.lbuf = (uintptr_t)msg->msg_iov[0].iov_base,
@@ -356,8 +355,7 @@ fi_ibv_rdm_ep_rma_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 		rma_iov.len += iov[i].iov_len;
 	}
 
-	return fi_ibv_rdm_ep_rma_readmsg(ep, &msg,
-		(ep_rdm->tx_selective_completion ? 0ULL : FI_COMPLETION));
+	return fi_ibv_rdm_ep_rma_readmsg(ep, &msg, GET_TX_COMP(ep_rdm));
 }
 
 static ssize_t
@@ -460,8 +458,7 @@ fi_ibv_rdm_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **
 	struct fi_ibv_rdm_ep *ep_rdm =
 		container_of(ep_fid, struct fi_ibv_rdm_ep, ep_fid);
 
-	return fi_ibv_rdm_ep_rma_writemsg(ep_fid, &msg,
-		(ep_rdm->tx_selective_completion ? 0ULL : FI_COMPLETION));
+	return fi_ibv_rdm_ep_rma_writemsg(ep_fid, &msg, GET_TX_COMP(ep_rdm));
 }
 
 static ssize_t


### PR DESCRIPTION
prov/verbs: Fixed the issue when CQ entry isn't provided FI_SELECTIVE_COMPLETION is set and fi_tx_attr::op_flags = FI_COMPLETION

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>