### PR TITLE
prov/rxm: The allocated entries from pool of contexts are never released

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -59,7 +59,7 @@ base MSG provider.
 
 RxM provider does not support the following features:
 
-  * op_flags: FI_INJECT, FI_COMPLETION, FI_CLAIM, FI_PEEK, FI_FENCE.
+  * op_flags: FI_INJECT, FI_CLAIM, FI_PEEK, FI_FENCE.
 
   * FI_ATOMIC
 


### PR DESCRIPTION
prov/rxm: The allocated entries from pool of contexts are 
never released if only fi_[t]inject is used and fi_cq_[s]read
isn't called after inject operation.
Add usage of fi_inject in case of FI_INJECT.
Add cancellation of pre-posted operations during EP closure if any.

Change-Id: I4242483a371a6598a52b3e9065bb806e9df3bf82
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>