### PR TITLE
fabric: remove fi_log* and fi_param_* from map

### DIFF
--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -7,10 +7,6 @@ FABRIC_1.0 {
 		fi_version;
 		fi_strerror;
 		fi_tostr;
-		fi_log_enabled;
-		fi_log;
-		fi_param_define;
-		fi_param_get;
 		fi_getparams;
 		fi_freeparams;
 		@FI_DIRECT_PROVIDER_API_10@


### PR DESCRIPTION
Remove API functions which are no longer present in headers.

Ref: ofiwg/libfabric#2046

Signed-off-by: Jan M Michalski <jan.m.michalski@intel.com>