### PR TITLE
prov/sockets: Fix crash in fi_atomicvalid

### DIFF
--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -596,13 +596,11 @@ int sock_query_atomic(struct fid_domain *domain,
 static int sock_ep_atomic_valid(struct fid_ep *ep, enum fi_datatype datatype,
 				enum fi_op op, size_t *count)
 {
-	struct sock_ep *sock_ep;
 	struct fi_atomic_attr attr;
 	int ret;
 
-	sock_ep = container_of(ep, struct sock_ep, ep);
-	ret = sock_query_atomic(&sock_ep->attr->domain->dom_fid, datatype,
-				op, &attr, 0);
+	/* domain parameter is ignored - okay to pass in NULL */
+	ret = sock_query_atomic(NULL, datatype, op, &attr, 0);
 	if (!ret)
 		*count = attr.count;
 	return ret;

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -75,9 +75,9 @@ int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
 	if (timeout_ms < 0)
 		return pthread_cond_wait(cond, mut);
 
-	t = fi_gettime_us();
-	ts.tv_sec = t / 1000000;
-	ts.tv_nsec = t % 1000000;
+	t = fi_gettime_ms() + timeout_ms;
+	ts.tv_sec = t / 1000;
+	ts.tv_nsec = (t % 1000) * 1000000;
 	return pthread_cond_timedwait(cond, mut, &ts);
 }
 


### PR DESCRIPTION
Commit 6b7fb392 causes a crash when using scalable Tx
contexts.  The sock_ep->attr field is NULL.  We don't
actually use the domain, so just pass in NULL and
report the results.

Fixes #2784