### PR TITLE
man/cq: Document that FI_WAIT_NONE is the default wait object

### DIFF
--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -127,7 +127,8 @@ struct fi_cntr_attr {
   object associated with a counter, in order to use it in other system
   calls.  The following values may be used to specify the type of wait
   object associated with a counter: FI_WAIT_NONE, FI_WAIT_UNSPEC,
-  FI_WAIT_SET, FI_WAIT_FD, and FI_WAIT_MUTEX_COND.
+  FI_WAIT_SET, FI_WAIT_FD, and FI_WAIT_MUTEX_COND.  The default is
+  FI_WAIT_NONE.
 
 - *FI_WAIT_NONE*
 : Used to indicate that the user will not block (wait) for events on

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -222,7 +222,7 @@ struct fi_cq_tagged_entry {
   CQ, in order to use it in other system calls.  The following values
   may be used to specify the type of wait object associated with a
   CQ: FI_WAIT_NONE, FI_WAIT_UNSPEC, FI_WAIT_SET, FI_WAIT_FD, and
-  FI_WAIT_MUTEX_COND.
+  FI_WAIT_MUTEX_COND.  The default is FI_WAIT_NONE.
 
 - *FI_WAIT_NONE*
 : Used to indicate that the user will not block (wait) for completions

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -151,7 +151,7 @@ struct fi_eq_attr {
 - *FI_WAIT_NONE*
 : Used to indicate that the user will not block (wait) for events on
   the EQ.  When FI_WAIT_NONE is specified, the application may not
-  call fi_eq_sread.
+  call fi_eq_sread.  This is the default is no wait object is specified.
 
 - *FI_WAIT_UNSPEC*
 : Specifies that the user will only wait on the EQ using fabric


### PR DESCRIPTION
CQs, EQs, and counters default to using wait none.  This needs
to be called out in the man pages, as it may be surprising.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>