### PR TITLE
prov/verbs: Handle application's err_data in fi_cq/eq_readerr

### DIFF
--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -466,7 +466,7 @@ described below.
 : On input, err_data_size indicates the size of the err_data buffer in bytes.
   On output, err_data_size will be set to the number of bytes copied to the
   err_data buffer.  The err_data information is typically used with
-  fi_cq_strerror to provide details about the type of error that occurred.
+  fi_eq_strerror to provide details about the type of error that occurred.
 
   For compatibility purposes, if err_data_size is 0 on input, or the fabric
   was opened with release < 1.5, err_data will be set to a data buffer

--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -186,6 +186,7 @@ fi_ibv_rdm_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
                              uint64_t flags)
 {
 	ssize_t ret = 0;
+	uint32_t api_version;
 	struct fi_ibv_rdm_cq *cq =
 		container_of(cq_fid, struct fi_ibv_rdm_cq, cq_fid.fid);
 
@@ -202,7 +203,13 @@ fi_ibv_rdm_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 		entry->olen = -1; /* TODO: */
 		entry->err = err_request->state.err;
 		entry->prov_errno = -err_request->state.err;
-		entry->err_data = NULL;
+
+		api_version = cq->domain->fab->util_fabric.fabric_fid.api_version;
+
+		if (!entry->err_data_size)
+			entry->err_data = NULL;
+		else if (FI_VERSION_GE(api_version, FI_VERSION(1, 5)))
+			entry->err_data_size = 0;
 
 		if (err_request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
 			FI_IBV_RDM_DBG_REQUEST("to_pool: ", err_request,

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -91,6 +91,8 @@ const struct fi_domain_attr verbs_domain_attr = {
 	.max_ep_tx_ctx		= 1,
 	.max_ep_rx_ctx		= 1,
 	.mr_iov_limit		= 1,
+	/* max_err_data is size of ibv_wc::vendor_err for CQ, 0 - for EQ */
+	.max_err_data		= sizeof_field(struct ibv_wc, vendor_err),
 };
 
 const struct fi_ep_attr verbs_ep_attr = {


### PR DESCRIPTION
Added support of application's error buffer (err_data) for CQ/EQ entries in fi_cq/eq_readerr.
Application's err_data is used in case of FI_VERSION >= 1.5 and passed err_data != NULL and err_data_size > 0

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>