### PR TITLE
prov/socket: Handle application's err_data in fi_cq/eq_readerr

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -153,6 +153,10 @@
 #define SOCK_PE_COMM_BUFF_SZ (1024)
 #define SOCK_PE_OVERFLOW_COMM_BUFF_SZ (128)
 
+/* it must be adjusted if error data size in CQ/EQ 
+ * will be larger than SOCK_EP_MAX_CM_DATA_SZ */
+#define SOCK_MAX_ERR_CQ_EQ_DATA_SZ SOCK_EP_MAX_CM_DATA_SZ
+
 enum {
 	SOCK_SIGNAL_RD_FD = 0,
 	SOCK_SIGNAL_WR_FD
@@ -195,22 +199,22 @@ struct sock_fabric {
 };
 
 struct sock_conn {
-        int sock_fd;
-        int connected;
+	int sock_fd;
+	int connected;
 	int address_published;
-        struct sockaddr_in addr;
-        struct sock_pe_entry *rx_pe_entry;
-        struct sock_pe_entry *tx_pe_entry;
+	struct sockaddr_in addr;
+	struct sock_pe_entry *rx_pe_entry;
+	struct sock_pe_entry *tx_pe_entry;
 	struct sock_ep_attr *ep_attr;
 	fi_addr_t av_index;
 	struct dlist_entry ep_entry;
 };
 
 struct sock_conn_map {
-        struct sock_conn *table;
+	struct sock_conn *table;
 	struct sock_epoll_set epoll_set;
-        int used;
-        int size;
+	int used;
+	int size;
 	fastlock_t lock;
 };
 
@@ -1015,7 +1019,8 @@ int sock_srx_ctx(struct fid_domain *domain,
 int sock_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq, void *context);
 int sock_cq_report_error(struct sock_cq *cq, struct sock_pe_entry *entry,
-			 size_t olen, int err, int prov_errno, void *err_data);
+			 size_t olen, int err, int prov_errno, void *err_data,
+			 size_t err_data_size);
 int sock_cq_progress(struct sock_cq *cq);
 void sock_cq_add_tx_ctx(struct sock_cq *cq, struct sock_tx_ctx *tx_ctx);
 void sock_cq_remove_tx_ctx(struct sock_cq *cq, struct sock_tx_ctx *tx_ctx);

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -60,6 +60,7 @@ const struct fi_domain_attr sock_domain_attr = {
 	.max_ep_srx_ctx = SOCK_EP_MAX_EP_CNT,
 	.cntr_cnt = SOCK_EP_MAX_CNTR_CNT,
 	.mr_iov_limit = SOCK_EP_MAX_IOV_LIMIT,
+	.max_err_data = SOCK_MAX_ERR_CQ_EQ_DATA_SZ,
 };
 
 int sock_verify_domain_attr(struct fi_domain_attr *attr)
@@ -156,6 +157,9 @@ int sock_verify_domain_attr(struct fi_domain_attr *attr)
 		return -FI_ENODATA;
 
 	if (attr->mr_iov_limit > sock_domain_attr.mr_iov_limit)
+		return -FI_ENODATA;
+
+	if (attr->max_err_data > sock_domain_attr.max_err_data)
 		return -FI_ENODATA;
 
 	return 0;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -495,8 +495,8 @@ static ssize_t sock_rx_ctx_cancel(struct sock_rx_ctx *rx_ctx, void *context)
 					pe_entry.flags |= FI_TAGGED;
 
 				if (sock_cq_report_error(pe_entry.comp->recv_cq,
-							  &pe_entry, 0, FI_ECANCELED,
-							  -FI_ECANCELED, NULL)) {
+							 &pe_entry, 0, FI_ECANCELED,
+							 -FI_ECANCELED, NULL, 0)) {
 					SOCK_LOG_ERROR("failed to report error\n");
 				}
 			}

--- a/prov/sockets/src/sock_eq.c
+++ b/prov/sockets/src/sock_eq.c
@@ -131,6 +131,9 @@ static ssize_t sock_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
 	struct sock_eq_entry *entry;
 	struct fi_eq_err_entry *err_entry;
 	struct sock_eq_err_data_entry *err_data_entry;
+	void *err_data = NULL;
+	size_t err_data_size = 0;
+	uint32_t api_version;
 
 	sock_eq = container_of(eq, struct sock_eq, eq);
 	fastlock_acquire(&sock_eq->lock);
@@ -139,14 +142,29 @@ static ssize_t sock_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
 		goto out;
 	}
 
+	api_version = sock_eq->sock_fab->fab_fid.api_version;
+
 	list = sock_eq->err_list.list.next;
 	entry = container_of(list, struct sock_eq_entry, entry);
+	err_entry = (struct fi_eq_err_entry *) entry->event;
 
 	ret = entry->len;
-	memcpy(buf, entry->event, entry->len);
+
+	if ((FI_VERSION_GE(api_version, FI_VERSION(1, 5)))
+		&& buf->err_data && buf->err_data_size) {
+		err_data = buf->err_data;
+		err_data_size = buf->err_data_size;
+ 		*buf = *err_entry;
+		buf->err_data = err_data;
+
+		/* Fill provided user's buffer */
+ 		buf->err_data_size = MIN(err_entry->err_data_size, err_data_size);
+ 		memcpy(buf->err_data, err_entry->err_data, buf->err_data_size);
+	} else {
+	    	*buf = *err_entry;
+	}
 
 	if (!(flags & FI_PEEK)) {
-		err_entry = (struct fi_eq_err_entry *) entry->event;
 		if (err_entry->err_data) {
 			err_data_entry = container_of(
 				err_entry->err_data,

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -354,7 +354,7 @@ static void sock_pe_report_rx_error(struct sock_pe_entry *pe_entry, int rem, int
 		fi_cntr_adderr(&pe_entry->comp->recv_cntr->cntr_fid, 1);
 	if (pe_entry->comp->recv_cq)
 		sock_cq_report_error(pe_entry->comp->recv_cq, pe_entry, rem,
-				     err, -err, NULL);
+				     err, -err, NULL, 0);
 }
 
 static void sock_pe_report_tx_error(struct sock_pe_entry *pe_entry, int rem, int err)
@@ -363,7 +363,7 @@ static void sock_pe_report_tx_error(struct sock_pe_entry *pe_entry, int rem, int
 		fi_cntr_adderr(&pe_entry->comp->send_cntr->cntr_fid, 1);
 	if (pe_entry->comp->send_cq)
 		sock_cq_report_error(pe_entry->comp->send_cq, pe_entry, rem,
-				     err, -err, NULL);
+				     err, -err, NULL, 0);
 }
 
 static void sock_pe_report_tx_rma_read_err(struct sock_pe_entry *pe_entry,
@@ -373,7 +373,7 @@ static void sock_pe_report_tx_rma_read_err(struct sock_pe_entry *pe_entry,
 		fi_cntr_adderr(&pe_entry->comp->read_cntr->cntr_fid, 1);
 	if (pe_entry->comp->send_cq)
 		sock_cq_report_error(pe_entry->comp->send_cq, pe_entry, 0,
-				     err, -err, NULL);
+				     err, -err, NULL, 0);
 }
 
 static void sock_pe_report_tx_rma_write_err(struct sock_pe_entry *pe_entry,
@@ -383,7 +383,7 @@ static void sock_pe_report_tx_rma_write_err(struct sock_pe_entry *pe_entry,
 		fi_cntr_adderr(&pe_entry->comp->write_cntr->cntr_fid, 1);
 	if (pe_entry->comp->send_cq)
 		sock_cq_report_error(pe_entry->comp->send_cq, pe_entry, 0,
-				     err, -err, NULL);
+			 	     err, -err, NULL, 0);
 }
 
 static void sock_pe_progress_pending_ack(struct sock_pe *pe,
@@ -1303,7 +1303,7 @@ ssize_t sock_rx_peek_recv(struct sock_rx_ctx *rx_ctx, fi_addr_t addr,
 		sock_pe_report_recv_completion(&pe_entry);
 	} else {
 		sock_cq_report_error(rx_ctx->comp.recv_cq, &pe_entry, 0,
-				     FI_ENOMSG, -FI_ENOMSG, NULL);
+				     FI_ENOMSG, -FI_ENOMSG, NULL, 0);
 	}
 	fastlock_release(&rx_ctx->lock);
 	return 0;


### PR DESCRIPTION
Added support of application's error buffer (err_data) for
CQ/EQ entries in fi_cq/eq_readerr. Application's err_data is used
in case of FI_VERSION >= 1.5 and passed err_data != NULL
and err_data_size > 0

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>