### PR TITLE
prov/verbs: Added support of FI_SYNC_ERR for AV insertion

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -499,8 +499,6 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 			   FI_SHARED_AV | FI_TRIGGER | FI_FENCE | \
 			   FI_LOCAL_COMM | FI_REMOTE_COMM)
 
-#define OFI_TODO_API_VERSION 0 /* remove when no longer used by providers */
-
 int ofi_check_fabric_attr(const struct fi_provider *prov,
 			  const struct fi_fabric_attr *prov_attr,
 			  const struct fi_fabric_attr *user_attr,

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -71,7 +71,7 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event,
 	if (!(info->fabric_attr->prov_name = strdup(VERBS_PROV_NAME)))
 		goto err;
 
-	ofi_alter_info(info, pep_info, OFI_TODO_API_VERSION);
+	ofi_alter_info(info, pep_info, fab->util_fabric.fabric_fid.api_version);
 
 	info->src_addrlen = fi_ibv_sockaddr_len(rdma_get_local_addr(event->id));
 	if (!(info->src_addr = malloc(info->src_addrlen)))


### PR DESCRIPTION
prov/verbs: Added support of FI_SYNC_ERR for AV insertion
If family of passed address isn't a AF_INET (ipv4 addr family), -FI_ADDRNOTAVAIL is set to an appropriate index of passed context

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>