### PR TITLE
Sockets: prevent from dropping out on incomplete header read attempt

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1774,7 +1774,7 @@ static int sock_pe_read_hdr(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 
 	msg_hdr = &pe_entry->msg_hdr;
 	if (sock_pe_peek_hdr(pe, pe_entry))
-		return 0;
+		return -1;
 
 	if (rx_ctx->is_ctrl_ctx && sock_pe_is_data_msg(msg_hdr->op_type))
 		return -1;


### PR DESCRIPTION
In rare occasions there's no full 24-byte header on a socket to peek, in that case sock_pe_peek_hdr() returns (-1), but sock_pe_read_hdr() recognized it as a completion returning 0 in turn, which leads to releasing pe_entry. It must return (-1) meaning the header reading is failed and we need to re-read it again.

Signed-off-by: Michael Chuvelev <michael.chuvelev@intel.com>