### PR TITLE
fabric: Add support for 'shadow' utility provider

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -61,6 +61,8 @@
 extern "C" {
 #endif
 
+#define OFI_CORE_PROV_ONLY	(1ULL << 59)
+
 /*
  * OS X doesn't have __BYTE_ORDER, Linux usually has BYTE_ORDER but not under
  * all features.h flags
@@ -112,6 +114,7 @@ static inline uint64_t ntohll(uint64_t x) { return x; }
 /* Restrict to size of struct fi_context */
 struct fi_prov_context {
 	int disable_logging;
+	int is_util_prov;
 };
 
 struct fi_filter {
@@ -122,6 +125,7 @@ struct fi_filter {
 extern struct fi_filter prov_log_filter;
 extern struct fi_provider core_prov;
 
+int ofi_is_util_prov(struct fi_provider *provider);
 void ofi_create_filter(struct fi_filter *filter, const char *env_name);
 void ofi_free_filter(struct fi_filter *filter);
 int ofi_apply_filter(struct fi_filter *filter, const char *name);

--- a/include/fi.h
+++ b/include/fi.h
@@ -122,9 +122,9 @@ struct fi_filter {
 extern struct fi_filter prov_log_filter;
 extern struct fi_provider core_prov;
 
-void fi_create_filter(struct fi_filter *filter, const char *env_name);
-void fi_free_filter(struct fi_filter *filter);
-int fi_apply_filter(struct fi_filter *filter, const char *name);
+void ofi_create_filter(struct fi_filter *filter, const char *env_name);
+void ofi_free_filter(struct fi_filter *filter);
+int ofi_apply_filter(struct fi_filter *filter, const char *name);
 
 void fi_util_init(void);
 void fi_util_fini(void);

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -93,11 +93,6 @@
 #define ofi_sin_addr(addr) (((struct sockaddr_in *)(addr))->sin_addr)
 #define ofi_sin6_addr(addr) (((struct sockaddr_in6 *)(addr))->sin6_addr)
 
-enum fi_match_type {
-	FI_MATCH_EXACT,
-	FI_MATCH_PREFIX,
-};
-
 enum {
 	UTIL_TX_SHARED_CTX = 1 << 0,
 	UTIL_RX_SHARED_CTX = 1 << 1,
@@ -130,8 +125,7 @@ struct util_fabric {
 int ofi_fabric_init(const struct fi_provider *prov,
 		    const struct fi_fabric_attr *prov_attr,
 		    const struct fi_fabric_attr *user_attr,
-		    struct util_fabric *fabric, void *context,
-		    enum fi_match_type type);
+		    struct util_fabric *fabric, void *context);
 int ofi_fabric_close(struct util_fabric *fabric);
 int ofi_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
 
@@ -180,8 +174,8 @@ struct util_ep {
 
 int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av);
 int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_prov,
-		struct fi_info *info, struct util_ep *ep, void *context,
-		ofi_ep_progress_func progress, enum fi_match_type type);
+		      struct fi_info *info, struct util_ep *ep, void *context,
+		      ofi_ep_progress_func progress);
 
 int ofi_endpoint_close(struct util_ep *util_ep);
 
@@ -503,14 +497,12 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 
 int ofi_check_fabric_attr(const struct fi_provider *prov,
 			  const struct fi_fabric_attr *prov_attr,
-			  const struct fi_fabric_attr *user_attr,
-			  enum fi_match_type type);
+			  const struct fi_fabric_attr *user_attr);
 int ofi_check_wait_attr(const struct fi_provider *prov,
 		        const struct fi_wait_attr *attr);
 int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 			  const struct fi_domain_attr *prov_attr,
-			  const struct fi_domain_attr *user_attr,
-			  enum fi_match_type type);
+			  const struct fi_domain_attr *user_attr);
 int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		      const struct fi_ep_attr *user_attr);
 int ofi_check_cq_attr(const struct fi_provider *prov,
@@ -522,7 +514,7 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 		      const struct fi_tx_attr *prov_attr,
 		      const struct fi_tx_attr *user_attr, uint64_t info_mode);
 int ofi_check_info(const struct util_prov *util_prov, uint32_t api_version,
-		   const struct fi_info *user_info, enum fi_match_type type);
+		   const struct fi_info *user_info);
 void ofi_alter_info(struct fi_info *info, const struct fi_info *hints,
 		    uint32_t api_version);
 
@@ -547,19 +539,31 @@ struct util_fabric *fi_fabric_find(const char *name);
 void fi_fabric_remove(struct util_fabric *fabric);
 
 /*
- * Layered Providers
+ * Utility Providers
  */
 
-typedef int (*ofi_alter_info_t)(struct fi_info *src_info, struct fi_info *dest_info);
+typedef int (*ofi_alter_info_t)(struct fi_info *src_info,
+				struct fi_info *dest_info);
 
+int ofi_get_core_info(uint32_t version, const char *node, const char *service,
+		      uint64_t flags, const struct util_prov *util_prov,
+		      struct fi_info *util_hints, ofi_alter_info_t info_to_core,
+		      struct fi_info **core_info);
 int ofix_getinfo(uint32_t version, const char *node, const char *service,
-			uint64_t flags, const struct util_prov *util_prov,
-			struct fi_info *hints,
-			ofi_alter_info_t alter_layer_info,
-			ofi_alter_info_t alter_base_info,
-			int get_base_info, struct fi_info **info);
-char *ofi_strdup_less_prefix(char *name, char *prefix);
-char *ofi_strdup_add_prefix(char *name, char *prefix);
+		 uint64_t flags, const struct util_prov *util_prov,
+		 struct fi_info *hints, ofi_alter_info_t info_to_core,
+		 ofi_alter_info_t info_to_util, struct fi_info **info);
+
+
+#define OFI_NAME_DELIM	';'
+#define OFI_UTIL_PREFIX "ofi-"
+
+char *ofi_strdup_append(const char *head, const char *tail);
+// char *ofi_strdup_head(const char *str);
+// char *ofi_strdup_tail(const char *str);
+const char *ofi_util_name(const char *prov_name, size_t *len);
+const char *ofi_core_name(const char *prov_name, size_t *len);
+
 
 int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,
 		int readonly, void **mapped);

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -354,7 +354,6 @@ struct fi_fabric_attr {
 	char			*prov_name;
 	uint32_t		prov_version;
 	uint32_t		api_version;
-	char			*comp_list;
 };
 
 struct fi_info {

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -139,7 +139,6 @@ struct fi_fabric_attr {
 	char              *prov_name;
 	uint32_t          prov_version;
 	uint32_t          api_version;
-	char              *comp_list;
 };
 ```
 
@@ -177,19 +176,6 @@ Version information for the fabric provider.
 
 The interface version requested by the application.  This value corresponds to
 the version parameter passed into `fi_getinfo(3)`.
-
-## comp_list - Component List
-
-This string lists details of the selected software implementation.  Its use
-is primarily for debugging purposes to indicate which software components
-are in use by a provider.  Direct application use of this field is currently
-reserved and undefined.
-
-The component list is a comma separated set of string identifiers, each
-corresponding to a specific core or utility provider or feature.  On input
-to fi_getinfo, if an identifier is preceded by a '^', then the corresponding
-component will be excluded from any output.  Otherwise, all selected
-components will be included as part of the output.
 
 # RETURN VALUE
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -496,8 +496,7 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 
 			ret = ofi_check_domain_attr(&gnix_prov, version,
 						    gnix_info->domain_attr,
-						    hints->domain_attr,
-						    FI_MATCH_EXACT);
+						    hints->domain_attr);
 			if (ret)
 				goto err;
 		}

--- a/prov/mlx/src/mlx_domain.c
+++ b/prov/mlx/src/mlx_domain.c
@@ -83,8 +83,7 @@ int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_EINVAL;
 	}
 
-	ofi_status = ofi_check_info(&mlx_util_prov, fabric->api_version,
-				    info, FI_MATCH_EXACT);
+	ofi_status = ofi_check_info(&mlx_util_prov, fabric->api_version, info);
 	if (ofi_status) {
 		return ofi_status;
 	}

--- a/prov/mlx/src/mlx_ep.c
+++ b/prov/mlx/src/mlx_ep.c
@@ -198,10 +198,8 @@ int mlx_ep_open( struct fid_domain *domain, struct fi_info *info,
 		return -ENOMEM;
 	}
 
-	ofi_status = ofi_endpoint_init(
-				domain, &mlx_util_prov, info,
-				&ep->ep, context,
-				mlx_ep_progress, FI_MATCH_EXACT);
+	ofi_status = ofi_endpoint_init(domain, &mlx_util_prov, info,
+				       &ep->ep, context, mlx_ep_progress);
 	if (ofi_status) {
 		goto free_ep;
 	}
@@ -219,7 +217,7 @@ int mlx_ep_open( struct fid_domain *domain, struct fi_info *info,
 	ep->ep.ep_fid.ops = &mlx_ep_ops;
 	ep->ep.ep_fid.cm = &mlx_cm_ops;
 	ep->ep.ep_fid.tagged = &mlx_tagged_ops;
-	ep->ep.flags = info->mode; 
+	ep->ep.flags = info->mode;
 	ep->ep.caps = u_domain->u_domain.caps;
 
 	*fid = &(ep->ep.ep_fid);

--- a/prov/mlx/src/mlx_fabric.c
+++ b/prov/mlx/src/mlx_fabric.c
@@ -59,7 +59,7 @@ static struct fi_ops_fabric mlx_fabric_ops = {
 
 int mlx_fabric_open(
 		struct fi_fabric_attr *attr,
-		struct fid_fabric **fabric, 
+		struct fid_fabric **fabric,
 		void *context)
 {
 	struct mlx_fabric *fabric_priv;
@@ -76,11 +76,8 @@ int mlx_fabric_open(
 		return -FI_ENOMEM;
 	}
 
-	status = ofi_fabric_init(
-			&mlx_prov,
-			&mlx_fabric_attrs, attr,
-			&(fabric_priv->u_fabric), context,
-			FI_MATCH_EXACT );
+	status = ofi_fabric_init(&mlx_prov, &mlx_fabric_attrs, attr,
+				 &(fabric_priv->u_fabric), context);
 	if (status) {
 		FI_INFO( &mlx_prov, FI_LOG_CORE,
 			"Error in ofi_fabric_init: %d\n", status);

--- a/prov/psm/src/psmx_fabric.c
+++ b/prov/psm/src/psmx_fabric.c
@@ -104,8 +104,7 @@ int psmx_fabric(struct fi_fabric_attr *attr,
 		return -FI_ENOMEM;
 
 	ret = ofi_fabric_init(&psmx_prov, &psmx_fabric_attr, attr,
-			     &fabric_priv->util_fabric, context,
-			     FI_MATCH_EXACT);
+			      &fabric_priv->util_fabric, context);
 	if (ret) {
 		FI_INFO(&psmx_prov, FI_LOG_CORE, "ofi_fabric_init returns %d\n", ret);
 		free(fabric_priv);

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -104,8 +104,7 @@ int psmx2_fabric(struct fi_fabric_attr *attr,
 		return -FI_ENOMEM;
 
 	ret = ofi_fabric_init(&psmx2_prov, &psmx2_fabric_attr, attr,
-			     &fabric_priv->util_fabric, context,
-			     FI_MATCH_EXACT);
+			     &fabric_priv->util_fabric, context);
 	if (ret) {
 		FI_INFO(&psmx2_prov, FI_LOG_CORE, "ofi_fabric_init returns %d\n", ret);
 		free(fabric_priv);

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -382,8 +382,8 @@ struct rxd_pkt_meta {
 	char pkt_data[]; /* rxd_pkt, followed by data */
 };
 
-int rxd_alter_layer_info(struct fi_info *layer_info, struct fi_info *base_info);
-int rxd_alter_base_info(struct fi_info *base_info, struct fi_info *layer_info);
+int rxd_info_to_core(struct fi_info *rxd_info, struct fi_info *core_info);
+int rxd_info_to_rxd(struct fi_info *core_info, struct fi_info *info);
 
 int rxd_fabric(struct fi_fabric_attr *attr,
 	       struct fid_fabric **fabric, void *context);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1720,15 +1720,14 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct rxd_domain *rxd_domain;
 
 	rxd_domain = container_of(domain, struct rxd_domain, util_domain.domain_fid);
-	ret = ofi_check_info(&rxd_util_prov,
-			     rxd_domain->util_domain.fabric->fabric_fid.api_version,
-			     info, FI_MATCH_PREFIX);
+	ret = ofi_check_info(&rxd_util_prov, rxd_domain->util_domain.fabric->
+			     fabric_fid.api_version, info);
 	if (ret)
 		return ret;
 
-	ret = ofix_getinfo(rxd_domain->util_domain.fabric->fabric_fid.api_version,
-			   NULL, NULL, 0, &rxd_util_prov, info,
-			   rxd_alter_layer_info, rxd_alter_base_info, 1, &dg_info);
+	ret = ofi_get_core_info(rxd_domain->util_domain.fabric->fabric_fid.api_version,
+				NULL, NULL, 0, &rxd_util_prov, info,
+				rxd_info_to_core, &dg_info);
 	if (ret)
 		return ret;
 

--- a/prov/rxd/src/rxd_fabric.c
+++ b/prov/rxd/src/rxd_fabric.c
@@ -82,7 +82,7 @@ int rxd_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		return -FI_ENOMEM;
 
 	ret = ofi_fabric_init(&rxd_prov, &rxd_fabric_attr, attr,
-			     &rxd_fabric->util_fabric, context, FI_MATCH_PREFIX);
+			      &rxd_fabric->util_fabric, context);
 	if (ret)
 		goto err1;
 
@@ -93,9 +93,8 @@ int rxd_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 	}
 	hints.fabric_attr->name = attr->name;
 
-	ret = ofix_getinfo(rxd_prov.version, NULL, NULL, 0, &rxd_util_prov,
-			&hints, rxd_alter_layer_info,
-			rxd_alter_base_info, 1, &dg_info);
+	ret = ofi_get_core_info(rxd_prov.version, NULL, NULL, 0, &rxd_util_prov,
+				&hints, rxd_info_to_core, &dg_info);
 	if (ret) {
 		ret = -FI_EINVAL;
 		goto err3;

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -35,23 +35,23 @@
 #include <prov.h>
 #include "rxd.h"
 
-int rxd_alter_layer_info(struct fi_info *layer_info, struct fi_info *base_info)
+int rxd_info_to_core(struct fi_info *rxd_info, struct fi_info *core_info)
 {
-	base_info->caps = FI_MSG;
-	base_info->mode = FI_LOCAL_MR;
-	base_info->ep_attr->type = FI_EP_DGRAM;
+	core_info->caps = FI_MSG;
+	core_info->mode = FI_LOCAL_MR;
+	core_info->ep_attr->type = FI_EP_DGRAM;
 	return 0;
 }
 
-int rxd_alter_base_info(struct fi_info *base_info, struct fi_info *layer_info)
+int rxd_info_to_rxd(struct fi_info *core_info, struct fi_info *info)
 {
-	layer_info->caps = rxd_info.caps;
-	layer_info->mode = rxd_info.mode;
+	info->caps = rxd_info.caps;
+	info->mode = rxd_info.mode;
 
-	*layer_info->tx_attr = *rxd_info.tx_attr;
-	*layer_info->rx_attr = *rxd_info.rx_attr;
-	*layer_info->ep_attr = *rxd_info.ep_attr;
-	*layer_info->domain_attr = *rxd_info.domain_attr;
+	*info->tx_attr = *rxd_info.tx_attr;
+	*info->rx_attr = *rxd_info.rx_attr;
+	*info->ep_attr = *rxd_info.ep_attr;
+	*info->domain_attr = *rxd_info.domain_attr;
 	return 0;
 }
 
@@ -59,7 +59,7 @@ static int rxd_getinfo(uint32_t version, const char *node, const char *service,
 			uint64_t flags, struct fi_info *hints, struct fi_info **info)
 {
 	return ofix_getinfo(version, node, service, flags, &rxd_util_prov,
-			    hints, rxd_alter_layer_info, rxd_alter_base_info, 0, info);
+			    hints, rxd_info_to_core, rxd_info_to_rxd, info);
 }
 
 static void rxd_fini(void)

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -264,8 +264,8 @@ static inline int rxm_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_ta
 
 int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 			void *context);
-int rxm_alter_layer_info(struct fi_info *layer_info, struct fi_info *base_info);
-int rxm_alter_base_info(struct fi_info *base_info, struct fi_info *layer_info);
+int rxm_info_to_core(struct fi_info *rxm_info, struct fi_info *core_info);
+int rxm_info_to_rxm(struct fi_info *core_info, struct fi_info *info);
 int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			     struct fid_domain **dom, void *context);
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -158,9 +158,8 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	rxm_fabric = container_of(fabric, struct rxm_fabric, util_fabric.fabric_fid);
 
-	ret = ofix_getinfo(rxm_prov.version, NULL, NULL, 0, &rxm_util_prov,
-			info, rxm_alter_layer_info, rxm_alter_base_info,
-			1, &msg_info);
+	ret = ofi_get_core_info(rxm_prov.version, NULL, NULL, 0, &rxm_util_prov,
+				info, rxm_info_to_core, &msg_info);
 	if (ret)
 		goto err1;
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -916,9 +916,8 @@ static int rxm_ep_msg_res_open(struct fi_info *rxm_fi_info,
 	struct fi_cq_attr cq_attr;
 	int ret;
 
-	ret = ofix_getinfo(rxm_prov.version, NULL, NULL, 0, &rxm_util_prov,
-			rxm_fi_info, rxm_alter_layer_info, rxm_alter_base_info,
-			1, &rxm_ep->msg_info);
+	ret = ofi_get_core_info(rxm_prov.version, NULL, NULL, 0, &rxm_util_prov,
+				rxm_fi_info, rxm_info_to_core, &rxm_ep->msg_info);
 	if (ret)
 		return ret;
 
@@ -958,9 +957,9 @@ static int rxm_ep_msg_res_open(struct fi_info *rxm_fi_info,
 	/* Zero out the port as we would be creating multiple MSG EPs for a single
 	 * RXM EP and we don't want address conflicts. */
 	if (rxm_ep->msg_info->src_addr) {
-		if (((struct sockaddr *)rxm_ep->msg_info->src_addr)->sa_family == AF_INET) 
+		if (((struct sockaddr *)rxm_ep->msg_info->src_addr)->sa_family == AF_INET)
 			((struct sockaddr_in *)(rxm_ep->msg_info->src_addr))->sin_port = 0;
-		else 
+		else
 			((struct sockaddr_in6 *)(rxm_ep->msg_info->src_addr))->sin6_port = 0;
 	}
 
@@ -997,7 +996,7 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 	}
 
 	ret = ofi_endpoint_init(domain, &rxm_util_prov, info, &rxm_ep->util_ep,
-			context, &rxm_ep_progress, FI_MATCH_PREFIX);
+				context, &rxm_ep_progress);
 	if (ret)
 		goto err1;
 

--- a/prov/rxm/src/rxm_fabric.c
+++ b/prov/rxm/src/rxm_fabric.c
@@ -100,7 +100,7 @@ int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		return -FI_ENOMEM;
 
 	ret = ofi_fabric_init(&rxm_prov, &rxm_fabric_attr, attr,
-			     &rxm_fabric->util_fabric, context, FI_MATCH_PREFIX);
+			      &rxm_fabric->util_fabric, context);
 	if (ret)
 		goto err1;
 
@@ -112,9 +112,8 @@ int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 	hints.fabric_attr->name = attr->name;
 	hints.mode = rxm_info.mode;
 
-	ret = ofix_getinfo(rxm_prov.version, NULL, NULL, 0, &rxm_util_prov,
-			&hints, rxm_alter_layer_info,
-			rxm_alter_base_info, 1, &msg_info);
+	ret = ofi_get_core_info(rxm_prov.version, NULL, NULL, 0, &rxm_util_prov,
+				&hints, rxm_info_to_core, &msg_info);
 	if (ret) {
 		ret = -FI_EINVAL;
 		goto err3;

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -35,35 +35,35 @@
 #include <prov.h>
 #include "rxm.h"
 
-int rxm_alter_layer_info(struct fi_info *layer_info, struct fi_info *base_info)
+int rxm_info_to_core(struct fi_info *rxm_info, struct fi_info *core_info)
 {
-	/* TODO choose base_info attr based on layer_info attr */
-	base_info->caps = FI_MSG;
-	base_info->mode = FI_LOCAL_MR;
-	base_info->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;
-	base_info->ep_attr->type = FI_EP_MSG;
+	/* TODO choose core_info attr based on rxm_info attr */
+	core_info->caps = FI_MSG;
+	core_info->mode = FI_LOCAL_MR;
+	core_info->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;
+	core_info->ep_attr->type = FI_EP_MSG;
 
 	return 0;
 }
 
-int rxm_alter_base_info(struct fi_info *base_info, struct fi_info *layer_info)
+int rxm_info_to_rxm(struct fi_info *core_info, struct fi_info *info)
 {
-	// TODO choose caps based on base_info caps
-	layer_info->caps = rxm_info.caps;
-	layer_info->mode = rxm_info.mode;
+	// TODO choose caps based on core_info caps
+	info->caps = rxm_info.caps;
+	info->mode = rxm_info.mode;
 
-	*layer_info->tx_attr = *rxm_info.tx_attr;
-	layer_info->tx_attr->iov_limit = MIN(MIN(layer_info->tx_attr->iov_limit,
-			base_info->tx_attr->iov_limit),
-			base_info->tx_attr->rma_iov_limit);
+	*info->tx_attr = *rxm_info.tx_attr;
+	info->tx_attr->iov_limit = MIN(MIN(info->tx_attr->iov_limit,
+			core_info->tx_attr->iov_limit),
+			core_info->tx_attr->rma_iov_limit);
 
-	*layer_info->rx_attr = *rxm_info.rx_attr;
-	layer_info->rx_attr->iov_limit = MIN(layer_info->rx_attr->iov_limit,
-			base_info->rx_attr->iov_limit);
+	*info->rx_attr = *rxm_info.rx_attr;
+	info->rx_attr->iov_limit = MIN(info->rx_attr->iov_limit,
+			core_info->rx_attr->iov_limit);
 
-	*layer_info->ep_attr = *rxm_info.ep_attr;
-	layer_info->ep_attr->max_msg_size = base_info->ep_attr->max_msg_size;
-	*layer_info->domain_attr = *rxm_info.domain_attr;
+	*info->ep_attr = *rxm_info.ep_attr;
+	info->ep_attr->max_msg_size = core_info->ep_attr->max_msg_size;
+	*info->domain_attr = *rxm_info.domain_attr;
 
 	return 0;
 }
@@ -72,7 +72,7 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 			uint64_t flags, struct fi_info *hints, struct fi_info **info)
 {
 	return ofix_getinfo(version, node, service, flags, &rxm_util_prov,
-			hints, rxm_alter_layer_info, rxm_alter_base_info, 0, info);
+			    hints, rxm_info_to_core, rxm_info_to_rxm, info);
 }
 
 static void rxm_fini(void)

--- a/prov/udp/src/udpx_domain.c
+++ b/prov/udp/src/udpx_domain.c
@@ -75,8 +75,7 @@ int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct util_domain *util_domain;
 	int ret;
 
-	ret = ofi_check_info(&udpx_util_prov, fabric->api_version, info,
-			     FI_MATCH_EXACT);
+	ret = ofi_check_info(&udpx_util_prov, fabric->api_version, info);
 	if (ret)
 		return ret;
 

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -574,7 +574,7 @@ int udpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 		return -FI_ENOMEM;
 
 	ret = ofi_endpoint_init(domain, &udpx_util_prov, info, &ep->util_ep,
-			context, udpx_ep_progress, FI_MATCH_EXACT);
+				context, udpx_ep_progress);
 	if (ret)
 		goto err;
 

--- a/prov/udp/src/udpx_fabric.c
+++ b/prov/udp/src/udpx_fabric.c
@@ -76,7 +76,7 @@ int udpx_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		return -FI_ENOMEM;
 
 	ret = ofi_fabric_init(&udpx_prov, udpx_info.fabric_attr, attr,
-			     util_fabric, context, FI_MATCH_EXACT);
+			      util_fabric, context);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -54,8 +54,8 @@ int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av)
 }
 
 int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_prov,
-		struct fi_info *info, struct util_ep *ep, void *context,
-		ofi_ep_progress_func progress, enum fi_match_type type)
+		      struct fi_info *info, struct util_ep *ep, void *context,
+		      ofi_ep_progress_func progress)
 {
 	struct util_domain *util_domain;
 	int ret;
@@ -65,8 +65,8 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	if (!info || !info->ep_attr || !info->rx_attr || !info->tx_attr)
 		return -FI_EINVAL;
 
-	ret = ofi_check_info(util_prov, util_domain->fabric->fabric_fid.api_version,
-			     info, type);
+	ret = ofi_check_info(util_prov,
+			     util_domain->fabric->fabric_fid.api_version, info);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_fabric.c
+++ b/prov/util/src/util_fabric.c
@@ -49,12 +49,11 @@ int ofi_fabric_close(struct util_fabric *fabric)
 int ofi_fabric_init(const struct fi_provider *prov,
 		    const struct fi_fabric_attr *prov_attr,
 		    const struct fi_fabric_attr *user_attr,
-		    struct util_fabric *fabric, void *context,
-		    enum fi_match_type type)
+		    struct util_fabric *fabric, void *context)
 {
 	int ret;
 
-	ret = ofi_check_fabric_attr(prov, prov_attr, user_attr, type);
+	ret = ofi_check_fabric_attr(prov, prov_attr, user_attr);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -165,7 +165,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		return -FI_EINVAL;
 	}
 
-	ret = ofi_check_info(util_prov, version, hints, FI_MATCH_EXACT);
+	ret = ofi_check_info(util_prov, version, hints);
 	if (ret)
 		return ret;
 

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -283,7 +283,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 
 	fab = container_of(fabric, struct fi_ibv_fabric, util_fabric.fabric_fid);
 	ret = ofi_check_domain_attr(&fi_ibv_prov, fabric->api_version,
-			fi->domain_attr, info->domain_attr, FI_MATCH_EXACT);
+				    fi->domain_attr, info->domain_attr);
 	if (ret)
 		return ret;
 
@@ -440,7 +440,7 @@ int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 
 	for (info = verbs_info; info; info = info->next) {
 		ret = ofi_fabric_init(&fi_ibv_prov, info->fabric_attr, attr,
-				&fab->util_fabric, context, FI_MATCH_EXACT);
+				      &fab->util_fabric, context);
 		if (ret != -FI_ENODATA)
 			break;
 	}

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -354,14 +354,14 @@ static int fi_ibv_check_hints(uint32_t version, const struct fi_info *hints,
 
 	if (hints->fabric_attr) {
 		ret = ofi_check_fabric_attr(&fi_ibv_prov, info->fabric_attr,
-				hints->fabric_attr, FI_MATCH_EXACT);
+					    hints->fabric_attr);
 		if (ret)
 			return ret;
 	}
 
 	if (hints->domain_attr) {
 		ret = ofi_check_domain_attr(&fi_ibv_prov, version, info->domain_attr,
-					    hints->domain_attr, FI_MATCH_EXACT);
+					    hints->domain_attr);
 		if (ret)
 			return ret;
 	}

--- a/src/log.c
+++ b/src/log.c
@@ -132,22 +132,22 @@ void fi_log_init(void)
 	fi_param_define(NULL, "log_prov", FI_PARAM_STRING,
 			"Specify specific provider to log (default: all)");
 	fi_param_get_str(NULL, "log_prov", &provstr);
-	fi_create_filter(&prov_log_filter, provstr);
+	ofi_create_filter(&prov_log_filter, provstr);
 
 	fi_param_define(NULL, "log_subsys", FI_PARAM_STRING,
 			"Specify specific subsystem to log (default: all)");
 	fi_param_get_str(NULL, "log_subsys", &subsysstr);
-	fi_create_filter(&subsys_filter, subsysstr);
+	ofi_create_filter(&subsys_filter, subsysstr);
 	for (i = 0; i < FI_LOG_SUBSYS_MAX; i++) {
-		if (!fi_apply_filter(&subsys_filter, log_subsys[i]))
+		if (!ofi_apply_filter(&subsys_filter, log_subsys[i]))
 			log_mask |= (1 << (i + FI_LOG_SUBSYS_OFFSET));
 	}
-	fi_free_filter(&subsys_filter);
+	ofi_free_filter(&subsys_filter);
 }
 
 void fi_log_fini(void)
 {
-	fi_free_filter(&prov_log_filter);
+	ofi_free_filter(&prov_log_filter);
 }
 
 __attribute__((visibility ("default")))


### PR DESCRIPTION
Utility providers layer over core providers and have the
following features:

- Uility fabric names match that of the core
- Utility domain names match that of the core
- The provider name is a list of core[;utility]
- Apps that specify a utility provider name to fi_getinfo
  will have their requests directed to that utility provider.
- If a core provider name is also specified, the utility
  will use the specified core provider.
- Apps that specify only a core provider name will have
  their request directed to all utility providers that
  are capable of layering over that core provider.
- The provider version reported by fi_getinfo is the
  topmost provider that is used.
- Utility providers can only layer over core providers.
- Utility providers have a provider name starting with 'ofi-'
- The fi_getinfo prov_attr_only reports utility providers
  directly with no layering.
- Utility providers are not affected by provider filtering.
  I.e. FI_PROVIDER environment variable
- Utility providers always have their logging enabled.

From the viewpoint of an application, the above means that the
fabric attribute prov_name is treated as a substring, rather than
a matching string.  The man pages do not specify how the prov_name
is used when passed as hints.

As part of this change, several utility helper functions were
renamed, with parameters renamed as well.  This should make it
easier to understand what the functions are doing and how they
should be used.