### PR TITLE
prov/gni: Fix FI_NOTIFY_FLAGS_ONLY bug.

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -289,16 +289,14 @@ ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
 {
 	struct gnix_cq_entry *event;
 	struct slist_entry *item;
-	uint64_t op_flags, mask;
+	uint64_t mask;
 
-	/* TODO: Move below conditional to gnix_cq.h and make static/inline */
+	/* TODO: handle scalable eps - note info is NULL for scalable eps */
 	if (ep) {
-		op_flags = ep->op_flags;
-
-		if (op_flags & FI_NOTIFY_FLAGS_ONLY) {
+		if (ep->info && ep->info->mode & FI_NOTIFY_FLAGS_ONLY) {
 			mask = (FI_REMOTE_CQ_DATA | FI_MULTI_RECV);
 
-			if (op_flags & FI_RMA_EVENT) {
+			if (flags & FI_RMA_EVENT) {
 				mask |= (FI_REMOTE_READ | FI_REMOTE_WRITE |
 					 FI_RMA);
 			}

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -2260,6 +2260,7 @@ int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->ep_fid.ops = &gnix_ep_ops;
 	ep_priv->domain = domain_priv;
 	ep_priv->type = info->ep_attr->type;
+	ep_priv->info = fi_dupinfo(info);
 
 	_gnix_ref_init(&ep_priv->ref_cnt, 1, __ep_destruct);
 

--- a/prov/gni/test/allocator.c
+++ b/prov/gni/test/allocator.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc.  All rights reserved
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -40,6 +40,8 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep;
@@ -56,7 +58,7 @@ void allocator_setup(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -63,6 +63,8 @@
 
 #define NUMEPS 2
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom[NUMEPS];
 struct fi_gni_ops_domain *gni_domain_ops[NUMEPS];
@@ -212,7 +214,7 @@ void rdm_api_setup(void)
 
 		hints[i]->domain_attr->cq_data_size = NUMEPS * 2;
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
-		hints[i]->mode = ~0;
+		hints[i]->mode = mode_bits;
 		hints[i]->domain_attr->mr_mode = FI_MR_BASIC;
 		hints[i]->fabric_attr->prov_name = strdup("gni");
 	}
@@ -436,7 +438,7 @@ Test(api, dom_caps)
 	hints[0] = fi_allocinfo();
 	cr_assert(hints[0], "fi_allocinfo");
 
-	hints[0]->mode = ~0;
+	hints[0]->mode = mode_bits;
 	hints[0]->fabric_attr->prov_name = strdup("gni");
 
 	/* we only support REMOTE_COMM */

--- a/prov/gni/test/api_cntr.c
+++ b/prov/gni/test/api_cntr.c
@@ -62,6 +62,8 @@
 
 #define NUMEPS 2
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom[NUMEPS];
 struct fi_gni_ops_domain *gni_domain_ops[NUMEPS];
@@ -138,7 +140,7 @@ void api_cntr_setup(void)
 		cr_assert(hints[i], "fi_allocinfo");
 
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
-		hints[i]->mode = ~0;
+		hints[i]->mode = mode_bits;
 		hints[i]->fabric_attr->prov_name = strdup("gni");
 	}
 

--- a/prov/gni/test/api_cq.c
+++ b/prov/gni/test/api_cq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -63,6 +63,8 @@
 
 #define NUMEPS 2
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom[NUMEPS];
 struct fi_gni_ops_domain *gni_domain_ops[NUMEPS];
@@ -109,7 +111,7 @@ void api_cq_setup(void)
 
 		hints[i]->domain_attr->cq_data_size = NUMEPS * 2;
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
-		hints[i]->mode = ~0;
+		hints[i]->mode = mode_bits;
 		hints[i]->fabric_attr->prov_name = strdup("gni");
 	}
 

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -46,6 +46,8 @@
 #include "gnix_rdma_headers.h"
 #include "common.h"
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fi_info *hints;
@@ -138,7 +140,7 @@ static void av_setup(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -54,6 +54,8 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep[2];
@@ -81,7 +83,7 @@ void cancel_setup(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/cntr.c
+++ b/prov/gni/test/cntr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -65,6 +65,8 @@ do {				\
 
 #define NUM_EPS 5
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep[NUM_EPS];
@@ -96,7 +98,7 @@ static inline void cntr_setup_eps(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/datagram.c
+++ b/prov/gni/test/datagram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -53,6 +53,8 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep;
@@ -70,7 +72,7 @@ void dg_setup(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 
@@ -100,7 +102,7 @@ void dg_setup_prog_manual(void)
 
 	hints->domain_attr->cq_data_size = 4;
 	hints->domain_attr->control_progress = FI_PROGRESS_MANUAL;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/eq.c
+++ b/prov/gni/test/eq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -39,6 +39,8 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fi_info *hints;
 static struct fi_info *fi;
@@ -58,7 +60,7 @@ void _setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo failed.");
 
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);

--- a/prov/gni/test/fi_addr_str.c
+++ b/prov/gni/test/fi_addr_str.c
@@ -65,6 +65,8 @@
 #define NUMEPS 2
 #define NUMCONTEXTS (NUMEPS * 2)
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom[NUMEPS];
 static struct fi_gni_ops_domain *gni_domain_ops[NUMEPS];
@@ -291,7 +293,7 @@ static void fas_setup_common(uint32_t version)
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->fabric_attr->prov_name = strdup("gni");
 	hints->addr_format = use_str_fmt ? FI_ADDR_STR : FI_ADDR_GNI;
 	if (ep_type == SEP) {

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -328,7 +328,7 @@ Test(mr_internal_bare, basic_init_regv)
 {
 	int ret;
 	const struct iovec iov = {
-		.iov_base = buf, 
+		.iov_base = buf,
 		.iov_len = buf_len,
 	};
 
@@ -347,14 +347,14 @@ Test(mr_internal_bare, basic_init_regattr)
 {
 	int ret;
 	const struct iovec iov = {
-		.iov_base = buf, 
-		.iov_len = buf_len, 
+		.iov_base = buf,
+		.iov_len = buf_len,
 	};
 	struct fi_mr_attr attr = {
-		.mr_iov = &iov, 
-		.iov_count = 1, 
+		.mr_iov = &iov,
+		.iov_count = 1,
 		.access = default_access,
-		.offset = default_offset, 
+		.offset = default_offset,
 		.requested_key = default_req_key,
 		.context = NULL,
 	};
@@ -386,7 +386,7 @@ Test(mr_internal_bare, bug_1086)
 
 	g_nic = g_mr->nic;
 	cr_assert(atomic_get(&g_nic->ref_cnt.references) > 0);
-	
+
 	ret = fi_close(&mr->fid);
 	cr_assert(ret == FI_SUCCESS);
 	cr_assert(atomic_get(&g_nic->ref_cnt.references) == 0);
@@ -452,7 +452,7 @@ Test(mr_internal_bare, invalid_attr)
 {
 	int ret;
 
-	ret = fi_mr_regattr(dom, NULL, default_flags, &mr); 
+	ret = fi_mr_regattr(dom, NULL, default_flags, &mr);
 	cr_assert(ret == -FI_EINVAL);
 }
 
@@ -462,7 +462,7 @@ Test(mr_internal_bare, invalid_iov_count)
 	int ret;
 	const struct iovec iov = {
 		.iov_base = buf,
-		.iov_len = buf_len, 
+		.iov_len = buf_len,
 	};
 
 	ret = fi_mr_regv(dom, &iov, 0, default_access,
@@ -487,8 +487,8 @@ Test(mr_internal_bare, unsupported_iov_count)
 	const struct iovec iov[2] = {
 		{
 			.iov_base = buf,
-			.iov_len = buf_len >> 2, 
-		}, 
+			.iov_len = buf_len >> 2,
+		},
 		{
 			.iov_base = buf + (buf_len >> 1),
 			.iov_len = buf_len >> 2,

--- a/prov/gni/test/mr_notifier.c
+++ b/prov/gni/test/mr_notifier.c
@@ -174,6 +174,8 @@ Test(mr_notifier, multiple)
 #include <pthread.h>
 #include "gnix_rdma_headers.h"
 static struct fi_info *fi;
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static uint64_t default_access = (FI_REMOTE_READ | FI_REMOTE_WRITE |
@@ -237,7 +239,7 @@ static void mr_stressor_setup_common(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -65,6 +65,8 @@
 
 #define NUMEPS 2
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom[NUMEPS];
 struct fi_gni_ops_domain *gni_domain_ops[NUMEPS];
@@ -111,7 +113,7 @@ void common_atomic_setup(void)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->fabric_attr->prov_name = strdup("gni");
 	hints->caps |= FI_ATOMIC | FI_READ | FI_REMOTE_READ |
 			FI_WRITE | FI_REMOTE_WRITE;

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -64,6 +64,8 @@
 	} while (0)
 #endif
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom[2];
 struct fi_gni_ops_domain *gni_domain_ops[2];
@@ -107,7 +109,7 @@ void common_setup(void)
 	dgm_fail = 0;
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->caps |= FI_RMA | FI_READ | FI_REMOTE_READ |
 		       FI_WRITE | FI_REMOTE_WRITE | FI_MSG | FI_SEND | FI_RECV;
 
@@ -321,7 +323,7 @@ void common_setup_1dom(void)
 	dgm_fail = 0;
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->caps |= FI_RMA | FI_READ | FI_REMOTE_READ |
 		       FI_WRITE | FI_REMOTE_WRITE;
 

--- a/prov/gni/test/rdm_dgram_stx.c
+++ b/prov/gni/test/rdm_dgram_stx.c
@@ -64,6 +64,8 @@
 	} while (0)
 #endif
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom[2];
 struct fi_gni_ops_domain *gni_domain_ops[2];
@@ -108,7 +110,7 @@ static void common_setup_stx(void)
 
 	hints->domain_attr->cq_data_size = 4;
 	hints->ep_attr->tx_ctx_cnt = FI_SHARED_CONTEXT;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->caps |= FI_RMA | FI_READ | FI_REMOTE_READ |
 		       FI_WRITE | FI_REMOTE_WRITE;
 
@@ -335,7 +337,7 @@ static void common_setup_stx_1dom(void)
 
 	hints->domain_attr->cq_data_size = 4;
 	hints->ep_attr->tx_ctx_cnt = FI_SHARED_CONTEXT;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->caps |= FI_RMA | FI_READ | FI_REMOTE_READ |
 		       FI_WRITE | FI_REMOTE_WRITE;
 

--- a/prov/gni/test/rdm_fi_pcd_trecv_msg.c
+++ b/prov/gni/test/rdm_fi_pcd_trecv_msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -247,6 +247,8 @@ static char *recv_state_strings[R_STATE_INVALID + 1] = {
 struct timeval begin, end;
 struct timeval loop_start, loop_end;
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep[2];
@@ -338,7 +340,7 @@ static void rdm_fi_pdc_setup(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/rdm_rx_overrun.c
+++ b/prov/gni/test/rdm_rx_overrun.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -64,6 +64,8 @@ const int num_msgs = 10;
  */
 const int min_rx_cq_size = 1;
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom[NUM_EPS];
 static struct fid_ep *ep[NUM_EPS];
@@ -97,7 +99,7 @@ static void setup(void)
 	hints->domain_attr->cq_data_size = 4;
 	hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
 
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -64,6 +64,8 @@
 #define NUMEPS 2
 #define NUM_MULTIRECVS 5
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom[NUMEPS];
 struct fi_gni_ops_domain *gni_domain_ops[NUMEPS];
@@ -253,7 +255,7 @@ void rdm_sr_setup(bool is_noreg, enum fi_progress pm)
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->control_progress = pm;
 	hints->domain_attr->data_progress = pm;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->caps = is_noreg ? hints->caps : FI_SOURCE | FI_MSG;
 	hints->fabric_attr->prov_name = strdup("gni");
 
@@ -281,7 +283,7 @@ void dgram_sr_setup(bool is_noreg, enum fi_progress pm)
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->control_progress = pm;
 	hints->domain_attr->data_progress = pm;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->caps = is_noreg ? hints->caps : FI_SOURCE | FI_MSG;
 	hints->fabric_attr->prov_name = strdup("gni");
 	hints->ep_attr->type = FI_EP_DGRAM;
@@ -320,7 +322,7 @@ void rdm_sr_bnd_ep_setup(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->fabric_attr->prov_name = strdup("gni");
 	hints->caps = FI_SOURCE | FI_MSG;
 

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -63,6 +63,8 @@
 	} while(0)
 #endif
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep[2];
@@ -94,7 +96,7 @@ static void setup_dom(enum fi_progress pm)
 	hints->domain_attr->data_progress = pm;
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/tags.c
+++ b/prov/gni/test/tags.c
@@ -48,6 +48,8 @@
 #include "gnix_rdma_headers.h"
 #include <criterion/parameterized.h>
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fi_info *hints;
 static struct fi_info *fi;
 
@@ -346,7 +348,7 @@ static void __gnix_tags_bare_test_setup(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->domain_attr->cq_data_size = 4;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -1,6 +1,7 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
+ *
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -54,6 +55,8 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep[2];
@@ -90,7 +93,7 @@ static void vc_setup_auto(void)
 
 	hints->domain_attr->cq_data_size = 4;
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	vc_setup_common();
 }
@@ -103,7 +106,7 @@ static void vc_setup_manual(void)
 
 	hints->domain_attr->cq_data_size = 4;
 	hints->domain_attr->control_progress = FI_PROGRESS_MANUAL;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	vc_setup_common();
 }
 
@@ -379,7 +382,7 @@ static void vc_conn_ping_setup_auto(void)
 
 	hints->domain_attr->cq_data_size = 4;
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	vc_conn_ping_setup();
 }
@@ -392,7 +395,7 @@ static void vc_conn_ping_setup_manual(void)
 
 	hints->domain_attr->cq_data_size = 4;
 	hints->domain_attr->control_progress = FI_PROGRESS_MANUAL;
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	vc_conn_ping_setup();
 }
 

--- a/prov/gni/test/vc_lookup.c
+++ b/prov/gni/test/vc_lookup.c
@@ -46,6 +46,8 @@
 
 static struct fi_info *hints;
 static struct fi_info *fi;
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fid_domain *dom;
 static struct fid_ep *ep;
@@ -63,7 +65,7 @@ void vc_lookup_setup(int av_type, int av_size)
 
 	hints = fi_allocinfo();
 
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	/* Create endpoint */

--- a/prov/gni/test/wait.c
+++ b/prov/gni/test/wait.c
@@ -39,6 +39,8 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 
+/* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
+static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
 static struct fid_fabric *fab;
 static struct fi_info *hints;
 static struct fi_info *fi;
@@ -53,7 +55,7 @@ void wait_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
-	hints->mode = ~0;
+	hints->mode = mode_bits;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 


### PR DESCRIPTION
 - _gnix_cq_add_event now checks the ep's mode bit and
 masks off the flags if the FI_NOTIFY_FLAGS_ONLY bit is set.

 - Update the unit tests to reflect these changes.
  - Corrected and simplified switch to if/else.

 - Set mode_bits to ~FI_NOTIFY_CQ_FLAGS as default for
 gnitest.

upstream merge of ofi-cray/libfabric-cray#1231
Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@dc4825224a8727f88c170002365be0186c9a160c)
(cherry picked from commit ofi-cray/libfabric-cray@436a7ea1ab6cc0f8ae2f94fa9c13f44cfe41aba8)

Conflicts:
	prov/gni/src/gnix_cq.c
	prov/gni/test/allocator.c
	prov/gni/test/api_cq.c
	prov/gni/test/cancel.c
	prov/gni/test/cntr.c
	prov/gni/test/cq.c
	prov/gni/test/datagram.c
	prov/gni/test/eq.c
	prov/gni/test/fi_addr_str.c
	prov/gni/test/rdm_fi_pcd_trecv_msg.c
	prov/gni/test/rdm_rx_overrun.c
	prov/gni/test/rdm_sr.c
	prov/gni/test/rdm_tagged_sr.c
	prov/gni/test/vc.c