### PR TITLE
prov/gni: Add return value checks to calls to fi_close()

### DIFF
--- a/prov/gni/test/cm.c
+++ b/prov/gni/test/cm.c
@@ -171,12 +171,26 @@ int cm_server_start(void)
 
 void cm_stop_server(void)
 {
-	fi_close(&srv_cq->fid);
-	fi_close(&srv_ep->fid);
-	fi_close(&srv_dom->fid);
-	fi_close(&srv_pep->fid);
-	fi_close(&srv_eq->fid);
-	fi_close(&srv_fab->fid);
+	int ret;
+
+	ret = fi_close(&srv_cq->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_close(&srv_ep->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_close(&srv_dom->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_close(&srv_pep->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_close(&srv_eq->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_close(&srv_fab->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
 	fi_freeinfo(srv_fi);
 }
 
@@ -328,11 +342,23 @@ int cm_client_finish_connect(void)
 
 void cm_stop_client(void)
 {
-	fi_close(&cli_cq->fid);
-	fi_close(&cli_ep->fid);
-	fi_close(&cli_dom->fid);
-	fi_close(&cli_eq->fid);
-	fi_close(&cli_fab->fid);
+	int ret;
+
+	ret = fi_close(&cli_cq->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_close(&cli_ep->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_close(&cli_dom->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_close(&cli_eq->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_close(&cli_fab->fid);
+	cr_assert_eq(ret, FI_SUCCESS);
+
 	fi_freeinfo(cli_fi);
 }
 


### PR DESCRIPTION
upstream merge of ofi-cray/libfabric-cray#1254

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@e26b26edbd07061838d9c5103f4b1817d84997f4)