### PR TITLE
prov/gni: Refactor EP locking.

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -34,6 +34,7 @@ _gni_files = \
 	prov/gni/src/gnix_nameserver.c \
 	prov/gni/src/gnix_nic.c \
 	prov/gni/src/gnix_poll.c \
+	prov/gni/src/gnix_progress.c \
 	prov/gni/src/gnix_queue.c \
 	prov/gni/src/gnix_rma.c \
 	prov/gni/src/gnix_sep.c \
@@ -69,6 +70,7 @@ _gni_headers = \
 	prov/gni/include/gnix_nameserver.h \
 	prov/gni/include/gnix_nic.h \
 	prov/gni/include/gnix_poll.h \
+	prov/gni/include/gnix_progress.h \
 	prov/gni/include/gnix_priv.h \
 	prov/gni/include/gnix_queue.h \
 	prov/gni/include/gnix_rma.h \

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -522,14 +522,11 @@ struct gnix_fid_ep {
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_nic *nic;
 	fastlock_t vc_lock;
-	/* lock for unexp and posted recv queue */
-	fastlock_t recv_queue_lock;
 	/* used for unexpected receives */
 	struct gnix_tag_storage unexp_recv_queue;
 	/* used for posted receives */
 	struct gnix_tag_storage posted_recv_queue;
 
-	fastlock_t tagged_queue_lock;
 	struct gnix_tag_storage tagged_unexp_recv_queue;
 	struct gnix_tag_storage tagged_posted_recv_queue;
 

--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
@@ -39,6 +39,9 @@
 
 #define GNIX_CM_NIC_MAX_MSG_SIZE (GNI_DATAGRAM_MAXSIZE - sizeof(uint8_t))
 
+extern struct dlist_entry gnix_cm_nic_list;
+extern pthread_mutex_t gnix_cm_nic_list_lock;
+
 typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
 				    char *rbuf,
 				    struct gnix_address addr);
@@ -46,6 +49,7 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
 /**
  * @brief GNI provider connection management (cm) nic structure
  *
+ * @var cm_nic_list    global CM NIC list element
  * @var nic            pointer to gnix_nic associated with this cm nic
  * @var dgram_hndl     handle to dgram allocator associated with this nic
  * @var fabric         GNI provider fabric associated with this nic
@@ -64,6 +68,7 @@ typedef int gnix_cm_nic_rcv_cb_func(struct gnix_cm_nic *cm_nic,
  * @var device_id      local Aries device id associated with this nic.
  */
 struct gnix_cm_nic {
+	struct dlist_entry cm_nic_list;
 	struct gnix_nic *nic;
 	struct gnix_dgram_hndl *dgram_hndl;
 	struct gnix_fid_domain *domain;
@@ -151,13 +156,13 @@ int _gnix_cm_nic_enable(struct gnix_cm_nic *cm_nic);
 /**
  * @brief poke the cm nic's progress engine
  *
- * @param[in] cm_nic   pointer to previously allocated gnix_cm_nic struct
- * @return              FI_SUCCESS on success, -EINVAL on invalid argument.
+ * @param[in] arg      pointer to previously allocated gnix_cm_nic struct
+ * @return             FI_SUCCESS on success, -EINVAL on invalid argument.
  *                     Other error codes may be returned depending on the
  *                     error codes returned from callback function
  *                     that had been added to the nic's work queue.
  */
-int _gnix_cm_nic_progress(struct gnix_cm_nic *cm_nic);
+int _gnix_cm_nic_progress(void *arg);
 
 /**
  * @brief generate a cdm_id to be used in call to  GNI_CdmCreate based on a seed

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -124,6 +124,8 @@ struct gnix_nic_attr {
  *                           with this nic
  * @var tx_desc_base         base address for the block of memory from which
  *                           tx descriptors were allocated
+ * @var prog_vcs_lock        lock for prog_vcs
+ * @var prog_vcs             list of VCs needing progress
  * @var wq_lock              lock for serializing access to the nic's work queue
  * @var nic_wq               head of linked list of work queue elements
  *                           associated with this nic
@@ -177,12 +179,8 @@ struct gnix_nic {
 	struct dlist_entry tx_desc_active_list;
 	struct dlist_entry tx_desc_free_list;
 	struct gnix_tx_descriptor *tx_desc_base;
-	fastlock_t rx_vc_lock;
-	struct dlist_entry rx_vcs;
-	fastlock_t work_vc_lock;
-	struct dlist_entry work_vcs;
-	fastlock_t tx_vc_lock;
-	struct dlist_entry tx_vcs;
+	fastlock_t prog_vcs_lock;
+	struct dlist_entry prog_vcs;
 	/* note this free list will be initialized for thread safe */
 	struct gnix_freelist vc_freelist;
 	uint8_t ptag;
@@ -440,12 +438,12 @@ int _gnix_nic_free(struct gnix_nic *nic);
 /**
  * @brief progresses control/data operations associated with the nic
  *
- * @param[in] nic      pointer to previously allocated gnix_nic struct
+ * @param[in] arg      pointer to previously allocated gnix_nic struct
  * @return             FI_SUCCESS on success, -FI_EINVAL if an invalid
  *                     nic struct was supplied. TODO: a lot more error
  *                     values can be returned.
  */
-int _gnix_nic_progress(struct gnix_nic *nic);
+int _gnix_nic_progress(void *arg);
 
 /**
  * @brief allocate a remote id for an object, used for looking up an object

--- a/prov/gni/include/gnix_progress.h
+++ b/prov/gni/include/gnix_progress.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _GNIX_PROGRESS_H_
+#define _GNIX_PROGRESS_H_
+
+#include "gnix_util.h"
+
+/*
+ * Progress common code
+ */
+
+struct gnix_prog_set {
+	struct dlist_entry prog_objs;
+	rwlock_t lock;
+	int requires_lock;
+};
+
+int _gnix_prog_progress(struct gnix_prog_set *set);
+int _gnix_prog_obj_add(struct gnix_prog_set *set, void *obj,
+		       int (*prog_fn)(void *data));
+int _gnix_prog_obj_rem(struct gnix_prog_set *set, void *obj,
+		       int (*prog_fn)(void *data));
+int _gnix_prog_init(struct gnix_prog_set *set);
+int _gnix_prog_fini(struct gnix_prog_set *set);
+
+#endif /* _GNIX_PROGRESS_H_ */
+

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -178,35 +178,71 @@ int _gnix_ep_enable(struct gnix_fid_ep *ep)
 	 */
 
 	if (ep->send_cq) {
-		_gnix_cq_poll_nic_add(ep->send_cq, ep->nic);
+		_gnix_cq_poll_obj_add(ep->send_cq, ep->nic,
+				      _gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cq_poll_obj_add(ep->send_cq, ep->cm_nic,
+					      _gnix_cm_nic_progress);
 		ep->tx_enabled = true;
 	}
 
 	if (ep->recv_cq) {
-		_gnix_cq_poll_nic_add(ep->recv_cq, ep->nic);
+		_gnix_cq_poll_obj_add(ep->recv_cq, ep->nic,
+				      _gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cq_poll_obj_add(ep->recv_cq, ep->cm_nic,
+					      _gnix_cm_nic_progress);
 		ep->rx_enabled = true;
 	}
 
-	if (ep->send_cntr)
-		_gnix_cntr_poll_nic_add(ep->send_cntr, ep->nic);
+	if (ep->send_cntr) {
+		_gnix_cntr_poll_obj_add(ep->send_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->send_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->recv_cntr)
-		_gnix_cntr_poll_nic_add(ep->recv_cntr, ep->nic);
+	if (ep->recv_cntr) {
+		_gnix_cntr_poll_obj_add(ep->recv_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->recv_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->write_cntr)
-		_gnix_cntr_poll_nic_add(ep->write_cntr,
-					ep->nic);
+	if (ep->write_cntr) {
+		_gnix_cntr_poll_obj_add(ep->write_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->write_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->read_cntr)
-		_gnix_cntr_poll_nic_add(ep->read_cntr, ep->nic);
+	if (ep->read_cntr) {
+		_gnix_cntr_poll_obj_add(ep->read_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->read_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->rwrite_cntr)
-		_gnix_cntr_poll_nic_add(ep->rwrite_cntr,
-					ep->nic);
+	if (ep->rwrite_cntr) {
+		_gnix_cntr_poll_obj_add(ep->rwrite_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->rwrite_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
 
-	if (ep->rread_cntr)
-		_gnix_cntr_poll_nic_add(ep->rread_cntr,
-					ep->nic);
+	if (ep->rread_cntr) {
+		_gnix_cntr_poll_obj_add(ep->rread_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_add(ep->rread_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
+	}
+
 	return FI_SUCCESS;
 }
 
@@ -1502,42 +1538,74 @@ static void __ep_destruct(void *obj)
 	}
 
 	if (ep->send_cq) {
-		_gnix_cq_poll_nic_rem(ep->send_cq, ep->nic);
+		_gnix_cq_poll_obj_rem(ep->send_cq, ep->nic,
+				      _gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cq_poll_obj_rem(ep->send_cq, ep->cm_nic,
+					      _gnix_cm_nic_progress);
 		_gnix_ref_put(ep->send_cq);
 	}
 
 	if (ep->recv_cq) {
-		_gnix_cq_poll_nic_rem(ep->recv_cq, ep->nic);
+		_gnix_cq_poll_obj_rem(ep->recv_cq, ep->nic,
+				       _gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cq_poll_obj_rem(ep->recv_cq, ep->cm_nic,
+					      _gnix_cm_nic_progress);
 		_gnix_ref_put(ep->recv_cq);
 	}
 
 	if (ep->send_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->send_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->send_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->send_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->send_cntr);
 	}
 
 	if (ep->recv_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->recv_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->recv_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->recv_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->recv_cntr);
 	}
 
 	if (ep->write_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->write_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->write_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->write_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->write_cntr);
 	}
 
 	if (ep->read_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->read_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->read_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->read_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->read_cntr);
 	}
 
 	if (ep->rwrite_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->rwrite_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->rwrite_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->rwrite_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->rwrite_cntr);
 	}
 
 	if (ep->rread_cntr) {
-		_gnix_cntr_poll_nic_rem(ep->rread_cntr, ep->nic);
+		_gnix_cntr_poll_obj_rem(ep->rread_cntr, ep->nic,
+					_gnix_nic_progress);
+		if (ep->cm_nic) /* No CM NIC for MSG EPs */
+			_gnix_cntr_poll_obj_rem(ep->rread_cntr, ep->cm_nic,
+						_gnix_cm_nic_progress);
 		_gnix_ref_put(ep->rread_cntr);
 	}
 
@@ -2099,8 +2167,6 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->type = info->ep_attr->type;
 	ep_priv->domain = domain_priv;
 	_gnix_ref_init(&ep_priv->ref_cnt, 1, __ep_destruct);
-	fastlock_init(&ep_priv->recv_queue_lock);
-	fastlock_init(&ep_priv->tagged_queue_lock);
 	ep_priv->min_multi_recv = GNIX_OPT_MIN_MULTI_RECV_DEFAULT;
 	fastlock_init(&ep_priv->vc_lock);
 	ep_priv->progress_fn = NULL;
@@ -2262,9 +2328,6 @@ int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->type = info->ep_attr->type;
 
 	_gnix_ref_init(&ep_priv->ref_cnt, 1, __ep_destruct);
-
-	fastlock_init(&ep_priv->recv_queue_lock);
-	fastlock_init(&ep_priv->tagged_queue_lock);
 
 	ep_priv->caps = info->caps & GNIX_EP_CAPS_FULL;
 
@@ -2498,13 +2561,9 @@ static inline struct gnix_fab_req *__find_tx_req(
 
 		while ((vc = (struct gnix_vc *)
 				_gnix_vec_iterator_next(&iter))) {
-			COND_ACQUIRE(vc->ep->requires_lock,
-				     &vc->tx_queue_lock);
 			entry = dlist_remove_first_match(&vc->tx_queue,
 							 __match_context,
 							 context);
-			COND_RELEASE(vc->ep->requires_lock,
-				     &vc->tx_queue_lock);
 
 			if (entry) {
 				req = container_of(entry,
@@ -2517,13 +2576,9 @@ static inline struct gnix_fab_req *__find_tx_req(
 		GNIX_HASHTABLE_ITERATOR(ep->vc_ht, iter);
 
 		while ((vc = _gnix_ht_iterator_next(&iter))) {
-			COND_ACQUIRE(vc->ep->requires_lock,
-				     &vc->tx_queue_lock);
 			entry = dlist_remove_first_match(&vc->tx_queue,
 							 __match_context,
 							 context);
-			COND_RELEASE(vc->ep->requires_lock,
-				     &vc->tx_queue_lock);
 
 			if (entry) {
 				req = container_of(entry,
@@ -2545,17 +2600,16 @@ static inline struct gnix_fab_req *__find_rx_req(
 {
 	struct gnix_fab_req *req = NULL;
 
-	COND_ACQUIRE(ep->requires_lock, &ep->recv_queue_lock);
+	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
 	req = _gnix_remove_req_by_context(&ep->posted_recv_queue, context);
-	COND_RELEASE(ep->requires_lock, &ep->recv_queue_lock);
-
-	if (req)
+	if (req) {
+		COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 		return req;
+	}
 
-	COND_ACQUIRE(ep->requires_lock, &ep->tagged_queue_lock);
 	req = _gnix_remove_req_by_context(&ep->tagged_posted_recv_queue,
 			context);
-	COND_RELEASE(ep->requires_lock, &ep->tagged_queue_lock);
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 
 	return req;
 }

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -250,16 +250,13 @@ static struct gnix_fab_req *__gnix_msg_dup_req(struct gnix_fab_req *req)
 
 static void __gnix_msg_queues(struct gnix_fid_ep *ep,
 			      int tagged,
-			      fastlock_t **queue_lock,
 			      struct gnix_tag_storage **posted_queue,
 			      struct gnix_tag_storage **unexp_queue)
 {
 	if (tagged) {
-		*queue_lock = &ep->tagged_queue_lock;
 		*posted_queue = &ep->tagged_posted_recv_queue;
 		*unexp_queue = &ep->tagged_unexp_recv_queue;
 	} else {
-		*queue_lock = &ep->recv_queue_lock;
 		*posted_queue = &ep->posted_recv_queue;
 		*unexp_queue = &ep->unexp_recv_queue;
 	}
@@ -277,7 +274,6 @@ static void __gnix_msg_send_fr_complete(struct gnix_fab_req *req,
 
 	/* Schedule VC TX queue in case the VC is 'fenced'. */
 	_gnix_vc_tx_schedule(vc);
-
 }
 
 static int __recv_err(struct gnix_fid_ep *ep, void *context, uint64_t flags,
@@ -671,7 +667,7 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 			req->tx_failures++;
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "Requeueing failed request: %p\n", req);
-			return _gnix_vc_queue_work_req(req);
+			return _gnix_vc_requeue_work_req(req);
 		}
 
 		if (!GNIX_EP_DGM(req->gnix_ep->type)) {
@@ -689,7 +685,7 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 
 		req->msg.status = tx_status;
 		req->work_fn = __gnix_rndzv_req_send_fin;
-		return _gnix_vc_queue_work_req(req);
+		return _gnix_vc_requeue_work_req(req);
 	}
 
 	__gnix_msg_copy_unaligned_get_data(req);
@@ -703,9 +699,7 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 	}
 
 	req->work_fn = __gnix_rndzv_req_send_fin;
-	ret = _gnix_vc_queue_work_req(req);
-
-	return ret;
+	return _gnix_vc_requeue_work_req(req);
 }
 
 /*
@@ -750,7 +744,7 @@ static int __gnix_rndzv_iov_req_complete(void *arg, gni_return_t tx_status)
 				/* Build and re-tx the entire iov request if the
 				 * ep type is "reliable datagram" */
 				req->work_fn = __gnix_rndzv_iov_req_build;
-				return _gnix_vc_queue_work_req(req);
+				return _gnix_vc_requeue_work_req(req);
 			}
 
 			if (!GNIX_EP_DGM(req->gnix_ep->type)) {
@@ -778,7 +772,7 @@ static int __gnix_rndzv_iov_req_complete(void *arg, gni_return_t tx_status)
 
 		/* Generate remote CQE and send fin msg back to sender */
 		req->work_fn = __gnix_rndzv_req_send_fin;
-		return _gnix_vc_queue_work_req(req);
+		return _gnix_vc_requeue_work_req(req);
 	}
 
 	/*
@@ -1743,7 +1737,6 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 	void *data_ptr;
 	struct gnix_tag_storage *unexp_queue;
 	struct gnix_tag_storage *posted_queue;
-	fastlock_t *queue_lock;
 	int tagged;
 
 	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
@@ -1754,9 +1747,7 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 	data_ptr = (void *)((char *)msg + sizeof(*hdr));
 
 	tagged = !!(hdr->flags & FI_TAGGED);
-	__gnix_msg_queues(ep, tagged, &queue_lock, &posted_queue, &unexp_queue);
-
-	COND_ACQUIRE(ep->requires_lock, queue_lock);
+	__gnix_msg_queues(ep, tagged, &posted_queue, &unexp_queue);
 
 	/* Lookup a matching posted request. */
 	req = _gnix_match_tag(posted_queue, hdr->msg_tag, 0, FI_PEEK, NULL,
@@ -1807,14 +1798,12 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 		/* Add new unexpected receive request. */
 		req = _gnix_fr_alloc(ep);
 		if (req == NULL) {
-			COND_RELEASE(ep->requires_lock, queue_lock);
 			return -FI_ENOMEM;
 		}
 
 		/* TODO: Buddy alloc */
 		req->msg.send_info[0].send_addr = (uint64_t)malloc(hdr->len);
 		if (unlikely(req->msg.send_info[0].send_addr == 0ULL)) {
-			COND_RELEASE(ep->requires_lock, queue_lock);
 			_gnix_fr_free(ep, req);
 			return -FI_ENOMEM;
 		}
@@ -1839,8 +1828,6 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 		GNIX_DEBUG(FI_LOG_EP_DATA, "New req: %p (%u)\n",
 			  req, req->msg.cum_send_len);
 	}
-
-	COND_RELEASE(ep->requires_lock, queue_lock);
 
 	status = GNI_SmsgRelease(vc->gni_ep);
 	if (unlikely(status != GNI_RC_SUCCESS)) {
@@ -1918,7 +1905,6 @@ static int __smsg_rndzv_start(void *data, void *msg)
 	struct gnix_fab_req *req = NULL, *dup_req;
 	struct gnix_tag_storage *unexp_queue;
 	struct gnix_tag_storage *posted_queue;
-	fastlock_t *queue_lock;
 	int tagged;
 
 	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
@@ -1927,9 +1913,7 @@ static int __smsg_rndzv_start(void *data, void *msg)
 	assert(ep);
 
 	tagged = !!(hdr->flags & FI_TAGGED);
-	__gnix_msg_queues(ep, tagged, &queue_lock, &posted_queue, &unexp_queue);
-
-	COND_ACQUIRE(ep->requires_lock, queue_lock);
+	__gnix_msg_queues(ep, tagged, &posted_queue, &unexp_queue);
 
 	req = _gnix_match_tag(posted_queue, hdr->msg_tag, 0, FI_PEEK, NULL,
 			      &vc->peer_addr);
@@ -1989,7 +1973,6 @@ static int __smsg_rndzv_start(void *data, void *msg)
 			/* Allocate new request for this transfer. */
 			dup_req = __gnix_msg_dup_req(req);
 			if (!dup_req) {
-				COND_RELEASE(ep->requires_lock, queue_lock);
 				return -FI_ENOMEM;
 			}
 
@@ -2020,7 +2003,6 @@ static int __smsg_rndzv_start(void *data, void *msg)
 		/* Add new unexpected receive request. */
 		req = _gnix_fr_alloc(ep);
 		if (req == NULL) {
-			COND_RELEASE(ep->requires_lock, queue_lock);
 			return -FI_ENOMEM;
 		}
 
@@ -2049,8 +2031,6 @@ static int __smsg_rndzv_start(void *data, void *msg)
 			  req, req->msg.send_info[0].send_len);
 	}
 
-	COND_RELEASE(ep->requires_lock, queue_lock);
-
 	status = GNI_SmsgRelease(vc->gni_ep);
 	if (unlikely(status != GNI_RC_SUCCESS)) {
 		GNIX_WARN(FI_LOG_EP_DATA,
@@ -2073,7 +2053,6 @@ static int __smsg_rndzv_iov_start(void *data, void *msg)
 	struct gnix_fab_req *req = NULL;
 	struct gnix_tag_storage *unexp_queue;
 	struct gnix_tag_storage *posted_queue;
-	fastlock_t *queue_lock;
 	char is_req_posted = 0;
 
 	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
@@ -2090,10 +2069,8 @@ static int __smsg_rndzv_iov_start(void *data, void *msg)
 	ep = vc->ep;
 	assert(ep != NULL);
 
-	__gnix_msg_queues(ep, hdr->flags & FI_TAGGED, &queue_lock,
+	__gnix_msg_queues(ep, hdr->flags & FI_TAGGED,
 			  &posted_queue, &unexp_queue);
-
-	COND_ACQUIRE(ep->requires_lock, queue_lock);
 
 	req = _gnix_match_tag(posted_queue, hdr->msg_tag, 0, FI_PEEK, NULL,
 			      &vc->peer_addr);
@@ -2109,7 +2086,6 @@ static int __smsg_rndzv_iov_start(void *data, void *msg)
 	} else {		/* Unexpected receive, enqueue it */
 		req = _gnix_fr_alloc(ep);
 		if (req == NULL) {
-			COND_RELEASE(ep->requires_lock, queue_lock);
 			return -FI_ENOMEM;
 		}
 
@@ -2138,9 +2114,6 @@ static int __smsg_rndzv_iov_start(void *data, void *msg)
 		ret = _gnix_vc_queue_work_req(req);
 	else
 		_gnix_insert_tag(unexp_queue, req->msg.tag, req, ~0);
-
-
-	COND_RELEASE(ep->requires_lock, queue_lock);
 
 	/*
 	 * Release the message buffer on the nic, need to copy the data
@@ -2400,7 +2373,6 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 	int ret;
 	struct gnix_fab_req *req = NULL;
 	struct gnix_address gnix_addr;
-	fastlock_t *queue_lock = NULL;
 	struct gnix_tag_storage *posted_queue = NULL;
 	struct gnix_tag_storage *unexp_queue = NULL;
 	uint64_t match_flags;
@@ -2426,7 +2398,7 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 	if (ret != FI_SUCCESS)
 		return ret;
 
-	__gnix_msg_queues(ep, tagged, &queue_lock, &posted_queue, &unexp_queue);
+	__gnix_msg_queues(ep, tagged, &posted_queue, &unexp_queue);
 
 	GNIX_DEBUG(FI_LOG_EP_DATA, "posted_queue = %p\n", posted_queue);
 
@@ -2435,7 +2407,7 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 		ignore = ~0;
 	}
 
-	COND_ACQUIRE(ep->requires_lock, queue_lock);
+	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
 
 retry_match:
 	try_again = false;
@@ -2638,7 +2610,7 @@ retry_match:
 
 pdc_exit:
 err:
-	COND_RELEASE(ep->requires_lock, queue_lock);
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 
 	return ret;
 }
@@ -2882,20 +2854,13 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 		GNIX_DEBUG(FI_LOG_EP_DATA, "auto-reg MR: %p\n", auto_mr);
 	}
 
-	ret = _gnix_vc_ep_get_vc(ep, dest_addr, &vc);
-	if (ret) {
-		goto err_get_vc;
-	}
-
 	req = _gnix_fr_alloc(ep);
 	if (req == NULL) {
-		ret = -FI_ENOSPC;
-		goto err_fr_alloc;
+		return -FI_ENOSPC;
 	}
 
 	req->type = GNIX_FAB_RQ_SEND;
 	req->gnix_ep = ep;
-	req->vc = vc;
 	req->user_context = context;
 	req->work_fn = _gnix_send_req;
 
@@ -2947,13 +2912,26 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	GNIX_DEBUG(FI_LOG_EP_DATA, "Queuing (%p %d)\n",
 		  (void *)loc_addr, len);
 
-	return _gnix_vc_queue_tx_req(req);
+	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
 
-err_fr_alloc:
-err_get_vc:
-	if (auto_mr) {
-		fi_close(&auto_mr->fid);
+	ret = _gnix_vc_ep_get_vc(ep, dest_addr, &vc);
+	if (ret) {
+		goto err_get_vc;
 	}
+
+	req->vc = vc;
+
+	ret = _gnix_vc_queue_tx_req(req);
+
+	COND_RELEASE(vc->ep->requires_lock, &vc->ep->vc_lock);
+
+	return ret;
+
+err_get_vc:
+	COND_RELEASE(vc->ep->requires_lock, &vc->ep->vc_lock);
+	_gnix_fr_free(ep, req);
+	if (flags & FI_LOCAL_MR)
+		fi_close(&auto_mr->fid);
 	return ret;
 }
 
@@ -2965,7 +2943,6 @@ ssize_t _gnix_recvv(struct gnix_fid_ep *ep, const struct iovec *iov,
 	size_t cum_len = 0;
 	struct gnix_fab_req *req = NULL;
 	struct gnix_address gnix_addr;
-	fastlock_t *queue_lock = NULL;
 	struct gnix_tag_storage *posted_queue = NULL;
 	struct gnix_tag_storage *unexp_queue = NULL;
 	uint64_t match_flags;
@@ -3024,9 +3001,9 @@ ssize_t _gnix_recvv(struct gnix_fid_ep *ep, const struct iovec *iov,
 	 * in the posted queue (i.e. no fi_recvs have been called (or posted)
 	 * on the remote endpoint).
 	 */
-	__gnix_msg_queues(ep, tagged, &queue_lock, &posted_queue, &unexp_queue);
+	__gnix_msg_queues(ep, tagged, &posted_queue, &unexp_queue);
 
-	COND_ACQUIRE(ep->requires_lock, queue_lock);
+	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
 
 	/*
 	 * Posting a recv, look for an existing request in the
@@ -3098,7 +3075,7 @@ ssize_t _gnix_recvv(struct gnix_fid_ep *ep, const struct iovec *iov,
 							fi_close(&req->msg.recv_md[i]->mr_fid.fid);
 						}
 
-						return ret;
+						goto err;
 					}
 
 					req->msg.recv_md[i] = container_of(
@@ -3125,7 +3102,8 @@ ssize_t _gnix_recvv(struct gnix_fid_ep *ep, const struct iovec *iov,
 							  "invalid memory reg"
 							  "istration (%p).\n",
 							  desc[i]);
-						return -FI_EINVAL;
+						ret = -FI_EINVAL;
+						goto err;
 					}
 
 					req->msg.recv_md[i] =
@@ -3233,7 +3211,7 @@ ssize_t _gnix_recvv(struct gnix_fid_ep *ep, const struct iovec *iov,
 
 pdc_exit:
 err:
-	COND_RELEASE(ep->requires_lock, queue_lock);
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 
 	return ret;
 }
@@ -3261,11 +3239,6 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 	} else {
 		if (!ep->ep_ops.tagged_send_allowed)
 			return -FI_EOPNOTSUPP;
-	}
-
-	ret = _gnix_vc_ep_get_vc(ep, dest_addr, &vc);
-	if (ret != FI_SUCCESS) {
-		return ret;
 	}
 
 	req = _gnix_fr_alloc(ep);
@@ -3296,7 +3269,6 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 
 	req->gnix_ep = ep;
 	req->user_context = context;
-	req->vc = vc;
 	req->work_fn = _gnix_send_req;
 	req->flags = 0; /* Flags that apply to all message types? */
 	req->msg.send_flags = flags;
@@ -3332,7 +3304,7 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 						fi_close(&req->msg.send_md[i]->mr_fid.fid);
 					}
 
-					return ret;
+					goto err_mr_reg;
 				}
 
 				req->msg.send_md[i] = container_of(
@@ -3369,7 +3341,7 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 						  "invalid memory reg"
 						  "istration (%p).\n",
 						  mdesc[i]);
-					return -FI_EINVAL;
+					goto err_mr_reg;
 				}
 
 				req->msg.send_md[i] =
@@ -3411,5 +3383,30 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 
 	req->msg.cum_send_len = (size_t) cum_len;
 
-	return _gnix_vc_queue_tx_req(req);
+	COND_ACQUIRE(ep->requires_lock, &ep->vc_lock);
+
+	ret = _gnix_vc_ep_get_vc(ep, dest_addr, &vc);
+	if (ret != FI_SUCCESS) {
+		goto err_get_vc;
+	}
+
+	req->vc = vc;
+
+	ret = _gnix_vc_queue_tx_req(req);
+
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
+
+	return ret;
+
+err_get_vc:
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
+	if (req->msg.send_flags & FI_LOCAL_MR) {
+		for (i = 0; i < count; i++) {
+			fi_close(&req->msg.send_md[i]->mr_fid.fid);
+		}
+	}
+err_mr_reg:
+	_gnix_fr_free(ep, req);
+
+	return ret;
 }

--- a/prov/gni/src/gnix_progress.c
+++ b/prov/gni/src/gnix_progress.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Progress common code
+ */
+
+#include <stdlib.h>
+
+#include "gnix_progress.h"
+
+struct gnix_prog_obj {
+	struct dlist_entry list;
+	int ref_cnt;
+	void *obj;
+	int (*prog_fn)(void *data);
+};
+
+
+int _gnix_prog_progress(struct gnix_prog_set *set)
+{
+	struct gnix_prog_obj *pobj, *tmp;
+	int rc;
+
+	COND_READ_ACQUIRE(set->requires_lock, &set->lock);
+
+	dlist_for_each_safe(&set->prog_objs, pobj, tmp, list) {
+		rc = pobj->prog_fn(pobj->obj);
+		if (rc) {
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				  "Obj(%p) prog function failed: %d\n",
+				  pobj, rc);
+		}
+	}
+
+	COND_RW_RELEASE(set->requires_lock, &set->lock);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_prog_obj_add(struct gnix_prog_set *set, void *obj,
+		       int (*prog_fn)(void *data))
+{
+	struct gnix_prog_obj *pobj, *tmp;
+
+	COND_WRITE_ACQUIRE(set->requires_lock, &set->lock);
+
+	dlist_for_each_safe(&set->prog_objs, pobj, tmp, list) {
+		if (obj == pobj->obj && prog_fn == pobj->prog_fn) {
+			pobj->ref_cnt++;
+			COND_RW_RELEASE(set->requires_lock, &set->lock);
+			return FI_SUCCESS;
+		}
+	}
+
+	pobj = malloc(sizeof(struct gnix_prog_obj));
+	if (!pobj) {
+		GNIX_WARN(FI_LOG_EP_CTRL, "Failed to add OBJ to prog set.\n");
+		COND_RW_RELEASE(set->requires_lock, &set->lock);
+		return -FI_ENOMEM;
+	}
+
+	pobj->obj = obj;
+	pobj->prog_fn = prog_fn;
+	pobj->ref_cnt = 1;
+	dlist_init(&pobj->list);
+	dlist_insert_tail(&pobj->list, &set->prog_objs);
+
+	COND_RW_RELEASE(set->requires_lock, &set->lock);
+
+	GNIX_INFO(FI_LOG_EP_CTRL, "Added obj(%p) to set(%p)\n",
+		  obj, set);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_prog_obj_rem(struct gnix_prog_set *set, void *obj,
+		       int (*prog_fn)(void *data))
+{
+	struct gnix_prog_obj *pobj, *tmp;
+
+	COND_WRITE_ACQUIRE(set->requires_lock, &set->lock);
+
+	dlist_for_each_safe(&set->prog_objs, pobj, tmp, list) {
+		if (obj == pobj->obj && prog_fn == pobj->prog_fn) {
+			if (!--pobj->ref_cnt) {
+				dlist_remove(&pobj->list);
+				free(pobj);
+				GNIX_INFO(FI_LOG_EP_CTRL,
+					  "Removed obj(%p) from set(%p)\n",
+					  obj, set);
+			}
+			COND_RW_RELEASE(set->requires_lock, &set->lock);
+			return FI_SUCCESS;
+		}
+	}
+
+	COND_RW_RELEASE(set->requires_lock, &set->lock);
+
+	GNIX_WARN(FI_LOG_EP_CTRL, "Object not found on prog set.\n");
+	return -FI_EINVAL;
+}
+
+int _gnix_prog_init(struct gnix_prog_set *set)
+{
+	dlist_init(&set->prog_objs);
+	rwlock_init(&set->lock);
+	set->requires_lock = 1;
+
+	return FI_SUCCESS;
+}
+
+int _gnix_prog_fini(struct gnix_prog_set *set)
+{
+	struct gnix_prog_obj *pobj, *tmp;
+
+	COND_WRITE_ACQUIRE(set->requires_lock, &set->lock);
+
+	dlist_for_each_safe(&set->prog_objs, pobj, tmp, list) {
+		dlist_remove(&pobj->list);
+		free(pobj);
+	}
+
+	COND_RW_RELEASE(set->requires_lock, &set->lock);
+
+	rwlock_destroy(&set->lock);
+
+	return FI_SUCCESS;
+}
+

--- a/prov/gni/src/gnix_sep.c
+++ b/prov/gni/src/gnix_sep.c
@@ -445,7 +445,10 @@ DIRECT_FN STATIC int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->send_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 
@@ -458,7 +461,10 @@ DIRECT_FN STATIC int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->write_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 
@@ -471,7 +477,10 @@ DIRECT_FN STATIC int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->rwrite_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 		}
@@ -493,7 +502,10 @@ DIRECT_FN STATIC int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->recv_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 
@@ -506,7 +518,10 @@ DIRECT_FN STATIC int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->read_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 
@@ -519,13 +534,15 @@ DIRECT_FN STATIC int gnix_sep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 					break;
 				}
 				ep->rread_cntr = cntr;
-				_gnix_cntr_poll_nic_add(cntr, ep->nic);
+				_gnix_cntr_poll_obj_add(cntr, ep->nic,
+							_gnix_nic_progress);
+				_gnix_cntr_poll_obj_add(cntr, ep->cm_nic,
+							_gnix_cm_nic_progress);
 				_gnix_ref_get(cntr);
 			}
 		}
 
 		break;
-			break;
 	default:
 		ret = -FI_ENOSYS;
 		break;

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -271,9 +271,7 @@ Test(gnix_cancel, cancel_ep_send)
 	cr_assert(!ret);
 
 	/* make a dummy request */
-	fastlock_acquire(&vc->tx_queue_lock);
 	dlist_insert_head(&req->dlist, &vc->tx_queue);
-	fastlock_release(&vc->tx_queue_lock);
 
 	/* cancel simulated request */
 	ret = fi_cancel(&ep[0]->fid, foobar_ptr);

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -521,6 +521,7 @@ void do_tinject(int len)
 	cr_assert_eq(sz, 0);
 
 	while ((ret = fi_cq_read(msg_cq[1], &cqe, 1)) == -FI_EAGAIN) {
+		ret = fi_cq_read(msg_cq[0], &cqe, 1);
 		pthread_yield();
 	}
 

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -554,9 +554,6 @@ Test(vc_management_auto, vc_connect)
 		state = _gnix_vc_state(vc_conn);
 	}
 
-	ret = _gnix_vc_disconnect(vc_conn);
-	cr_assert_eq(ret, FI_SUCCESS);
-
 	/* VC is destroyed by the EP */
 }
 
@@ -624,12 +621,6 @@ Test(vc_management_auto, vc_connect2)
 		pthread_yield();
 		state = _gnix_vc_state(vc_conn1);
 	}
-
-	ret = _gnix_vc_disconnect(vc_conn0);
-	cr_assert_eq(ret, FI_SUCCESS);
-
-	ret = _gnix_vc_disconnect(vc_conn1);
-	cr_assert_eq(ret, FI_SUCCESS);
 
 	/* VC is destroyed by the EP */
 }


### PR DESCRIPTION
Refactor EP locking to acommodate VC teardown.

-Protect EP connections/request queues/posted messages with the vc_lock field
  -Remove many extra, more fine grained locks
  -Pro: Less locks taken overall in transaction code paths
  -Pro: Adds the synch needed to safely remove VCs from an EP (future work)
  -Con: Concurrent, multi-threaded use of separate VCs on an EP is now
	serialized. (Concurrent use of a single EP was not a primary use case)
-Make CQ/CNTR progress code common
-Remove CM progress checks from gnix_vc.c for simplification, lock sanity
-Add CM progress checks to CQ/CNTR progress code paths

prov/gni: Fix progress thread teardown deadlock

upstream merge of ofi-cray/libfabric-cray#1261

Signed-off-by: Zach <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@a8ccd9faf406fc5b459b1483a3e3220cb6054e6a)
(cherry picked from commit ofi-cray/libfabric-cray@e7506d966b02e71f97b9cdf237a2ac62b778a33a)

Conflicts:
	prov/gni/include/gnix_vc.h