### PR TITLE
fabric: Fix uninitialized variable usage

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -563,7 +563,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 {
 	struct ofi_prov *prov;
 	struct fi_info *tail, *cur;
-	const char *util_name, *core_name;
+	const char *util_name = NULL, *core_name = NULL;
 	size_t util_len = 0, core_len = 0;
 	int ret;
 
@@ -597,10 +597,10 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 		    (flags & OFI_CORE_PROV_ONLY))
 			continue;
 
-		if (util_len) {
+		if (util_len && util_name) {
 			if (strncasecmp(util_name, prov->provider->name, util_len))
 				continue;
-		} else if (core_len) {
+		} else if (core_len && core_name) {
 			if (!ofi_is_util_prov(prov->provider) &&
 			    strncasecmp(core_name, prov->provider->name, core_len))
 				continue;


### PR DESCRIPTION
From Cisco build bot:

 CC       prov/util/src/src_libfabric_la-util_attr.lo
src/fabric.c: In function 'fi_getinfo_':
src/fabric.c:605:19: error: 'core_name' may be used uninitialized in this function [-Werror=maybe-uninitialized]
        strncasecmp(core_name, prov->provider->name, core_len))
                   ^
src/fabric.c:601:19: error: 'util_name' may be used uninitialized in this function [-Werror=maybe-uninitialized]
    if (strncasecmp(util_name, prov->provider->name, util_len))
                   ^
cc1: all warnings being treated as errors

Note that these are false warnings.  The core_len and util_len variables
trap against uninitialized access.  But to make this error go away, go
ahead and initialize all variables and include them in a check.  This isn't
a speed path area anyway.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>