### PR TITLE
prov/gni: Remove #define of cr_log_info needed for v2.2.2

### DIFF
--- a/prov/gni/test/common.h
+++ b/prov/gni/test/common.h
@@ -42,7 +42,6 @@
 
 #define BLUE "\x1b[34m"
 #define COLOR_RESET "\x1b[0m"
-#define cr_log_info criterion_info
 
 /* defined in rdm_atomic.c */
 extern int supported_compare_atomic_ops[FI_ATOMIC_OP_LAST][FI_DATATYPE_LAST];


### PR DESCRIPTION
After this commit, you will need to use Criterion v2.3.0 or later.

upstream merge of ofi-cray/libfabric-cray#1276

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@4e458153821f7fc7627d79ea4eeea3990d35d5a6)