### PR TITLE
prov/gni: Added support for reporting source addresses.

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -253,6 +253,14 @@ gni;node;service;GNIX_AV_STR_ADDR_VERSION;device_addr;cdm_id;name_type;cm_nic_cd
 
 The GNI provider sets the domain attribute *cntr_cnt* to the the CQ limit divided by 2.
 
+Completion queue events may report unknown source address information when
+using *FI_SOURCE*. The source address information will be reported in the
+err_data member of the struct fi_cq_err_entry populated by fi_cq_readerr. The
+err_data member will contain the source address information in the FI_ADDR_GNI
+address format. In order to populate the remote peer's address vector
+with this mechanism, the application must call fi_cq_readerr to get the
+source address followed by fi_av_insert on the populated err_data member.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -1011,7 +1011,6 @@ struct gnix_fab_req {
 	uint8_t                      *int_tx_buf;
 	gni_mem_handle_t             int_tx_mdh;
 
-	/* TODO: change the size of this for unaligned data? */
 	struct gnix_tx_descriptor *iov_txds[GNIX_MAX_MSG_IOV_LIMIT];
 	/*
 	 * special value of UINT_MAX is used to indicate

--- a/prov/gni/include/gnix_cq.h
+++ b/prov/gni/include/gnix_cq.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -45,6 +46,7 @@
 
 #define GNIX_CQ_DEFAULT_FORMAT struct fi_cq_entry
 #define GNIX_CQ_DEFAULT_SIZE   256
+#define GNIX_CQ_MAX_ERR_DATA_SIZE 64
 
 /* forward declaration */
 struct gnix_fid_ep;
@@ -73,8 +75,8 @@ struct gnix_fid_cq {
 	struct gnix_prog_set pset;
 
 	bool requires_lock;
+	char err_data[GNIX_CQ_MAX_ERR_DATA_SIZE];
 };
-
 
 ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
 			   void *op_context, uint64_t flags, size_t len,
@@ -84,7 +86,8 @@ ssize_t _gnix_cq_add_event(struct gnix_fid_cq *cq, struct gnix_fid_ep *ep,
 ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 			  uint64_t flags, size_t len, void *buf,
 			  uint64_t data, uint64_t tag, size_t olen,
-			  int err, int prov_errno, void *err_data);
+			  int err, int prov_errno, void *err_data,
+			  size_t err_data_size);
 
 int _gnix_cq_poll_obj_add(struct gnix_fid_cq *cq, void *obj,
 			  int (*prog_fn)(void *data));

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -83,7 +83,7 @@ enum gnix_vc_conn_req_type {
 #define REMOTE_MBOX_RCVD (1UL << 1)
 
 /**
- * Virual Connection (VC) struct
+ * Virtual Connection (VC) struct
  *
  * @var prog_list            NIC VC progress list
  * @var work_queue           Deferred work request queue
@@ -101,7 +101,6 @@ enum gnix_vc_conn_req_type {
  *                           associated
  * @var smsg_mbox            pointer to GNI SMSG mailbox used by this VC
  *                           to exchange SMSG messages with its peer
- * @var dgram                pointer to dgram - used in connection setup
  * @var gni_ep               GNI endpoint for this VC
  * @var outstanding_fab_reqs Count of outstanding libfabric level requests
  *                           associated with this endpoint.
@@ -129,7 +128,7 @@ struct gnix_vc {
 	struct gnix_address peer_cm_nic_addr;
 	struct gnix_fid_ep *ep;
 	void *smsg_mbox;
-	struct gnix_datagram *dgram;
+	void *gnix_ep_name;
 	gni_ep_handle_t gni_ep;
 	atomic_t outstanding_tx_reqs;
 	enum gnix_vc_conn_state conn_state;

--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -53,7 +54,7 @@ static int __gnix_amo_send_err(struct gnix_fid_ep *ep,
 	if (ep->send_cq) {
 		rc = _gnix_cq_add_error(ep->send_cq, req->user_context,
 					flags, 0, 0, 0, 0, 0, error,
-					GNI_RC_TRANSACTION_ERROR, NULL);
+					GNI_RC_TRANSACTION_ERROR, NULL, 0);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_cq_add_error() failed: %d\n", rc);

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -2676,7 +2676,7 @@ DIRECT_FN STATIC ssize_t gnix_ep_cancel(fid_t fid, void *context)
 		flags = req->flags;
 
 		_gnix_cq_add_error(err_cq, context, flags, len, addr, 0 /* data */,
-				tag, len, FI_ECANCELED, FI_ECANCELED, 0);
+				tag, len, FI_ECANCELED, FI_ECANCELED, 0, 0);
 
 	}
 

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -64,7 +64,7 @@ static int __gnix_rma_send_err(struct gnix_fid_ep *ep,
 	if (ep->send_cq) {
 		rc = _gnix_cq_add_error(ep->send_cq, req->user_context,
 					flags, 0, 0, 0, 0, 0, error,
-					GNI_RC_TRANSACTION_ERROR, NULL);
+					GNI_RC_TRANSACTION_ERROR, NULL, 0);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_cq_add_error() failed: %d\n", rc);
@@ -93,7 +93,7 @@ static int __gnix_rma_send_completion(struct gnix_fid_ep *ep,
 				      struct gnix_fab_req *req)
 {
 	struct gnix_fid_cntr *cntr = NULL;
-	int rc = FI_SUCCESS;
+	int rc;
 	uint64_t flags = req->flags & GNIX_RMA_COMPLETION_FLAGS;
 
 	if ((req->flags & FI_COMPLETION) && ep->send_cq) {

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -317,7 +317,9 @@ static void __gnix_vc_pack_conn_req(char *sbuf,
 				    gni_smsg_attr_t *src_smsg_attr,
 				    gni_mem_handle_t *src_irq_cq_mhdl,
 				    uint64_t caps,
-				    xpmem_segid_t my_segid)
+				    xpmem_segid_t my_segid,
+				    uint8_t name_type,
+				    uint8_t rx_ctx_cnt)
 {
 	size_t __attribute__((unused)) len;
 	char *cptr = sbuf;
@@ -335,7 +337,10 @@ static void __gnix_vc_pack_conn_req(char *sbuf,
 	      sizeof(uint64_t) * 2 +
 	      sizeof(gni_smsg_attr_t) +
 	      sizeof(gni_mem_handle_t) +
-	      sizeof(xpmem_segid_t);
+	      sizeof(xpmem_segid_t) +
+	      sizeof(name_type) +
+	      sizeof(rx_ctx_cnt);
+
 	assert(len <= GNIX_CM_NIC_MAX_MSG_SIZE);
 
 	memcpy(cptr, &rtype, sizeof(rtype));
@@ -355,6 +360,10 @@ static void __gnix_vc_pack_conn_req(char *sbuf,
 	memcpy(cptr, &caps, sizeof(uint64_t));
 	cptr += sizeof(xpmem_segid_t);
 	memcpy(cptr, &my_segid, sizeof(xpmem_segid_t));
+	cptr += sizeof(name_type);
+	memcpy(cptr, &name_type, sizeof(name_type));
+	cptr += sizeof(rx_ctx_cnt);
+	memcpy(cptr, &rx_ctx_cnt, sizeof(rx_ctx_cnt));
 }
 
 /*
@@ -368,7 +377,9 @@ static void __gnix_vc_unpack_conn_req(char *rbuf,
 				      gni_smsg_attr_t *src_smsg_attr,
 				      gni_mem_handle_t *src_irq_cq_mhndl,
 				      uint64_t *caps,
-				      xpmem_segid_t *peer_segid)
+				      xpmem_segid_t *peer_segid,
+				      uint8_t *name_type,
+				      uint8_t *rx_ctx_cnt)
 {
 	size_t __attribute__((unused)) len;
 	char *cptr = rbuf;
@@ -395,6 +406,11 @@ static void __gnix_vc_unpack_conn_req(char *rbuf,
 	memcpy(caps, cptr, sizeof(uint64_t));
 	cptr += sizeof(uint64_t);
 	memcpy(peer_segid, cptr, sizeof(xpmem_segid_t));
+	cptr += sizeof(uint8_t);
+	memcpy(name_type, cptr, sizeof(*name_type));
+	cptr += sizeof(uint8_t);
+	memcpy(rx_ctx_cnt, cptr, sizeof(*rx_ctx_cnt));
+
 }
 
 /*
@@ -818,8 +834,10 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 	fi_addr_t fi_addr;
 	xpmem_segid_t peer_segid;
 	xpmem_apid_t peer_apid;
+	uint8_t name_type, rx_ctx_cnt;
 	bool accessible;
 	ssize_t __attribute__((unused)) len;
+	struct gnix_ep_name *error_data;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -835,7 +853,9 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 				  &src_smsg_attr,
 				  &tmp_mem_hndl,
 				  &peer_caps,
-				  &peer_segid);
+				  &peer_segid,
+				  &name_type,
+				  &rx_ctx_cnt);
 
 
 	GNIX_DEBUG(FI_LOG_EP_CTRL,
@@ -921,9 +941,30 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 					  vc, src_addr);
 
 				dlist_insert_tail(&vc->list, &ep->unmapped_vcs);
+
+				if (vc->ep->caps & FI_SOURCE) {
+					error_data =
+						calloc(1, sizeof(*error_data));
+					if (error_data == NULL) {
+						ret = -FI_ENOMEM;
+						goto err;
+					}
+					vc->gnix_ep_name = (void *) error_data;
+
+					error_data->gnix_addr = src_addr;
+					error_data->name_type = name_type;
+
+					error_data->cm_nic_cdm_id =
+						cm_nic->my_name.cm_nic_cdm_id;
+					error_data->cookie =
+						cm_nic->my_name.cookie;
+
+					error_data->rx_ctx_cnt = rx_ctx_cnt;
+				}
 			}
-		} else
+		} else {
 			vc->conn_state = GNIX_VC_CONNECTING;
+		}
 
 		/*
 		 * prepare a work request to
@@ -1315,7 +1356,9 @@ static int __gnix_vc_conn_req_prog_fn(void *data, int *complete_ptr)
 				&smsg_mbox_attr,
 				&ep->nic->irq_mem_hndl,
 				ep->caps,
-				my_segid);
+				my_segid,
+				ep->src_addr.name_type,
+				ep->src_addr.rx_ctx_cnt);
 
 	/*
 	 * try to send the message, if -FI_EAGAIN is returned, okay,
@@ -1555,15 +1598,6 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 			      "_gnix_mbox_free returned %s\n",
 			      fi_strerror(-ret));
 		vc->smsg_mbox = NULL;
-	}
-
-	if (vc->dgram != NULL) {
-		ret = _gnix_dgram_free(vc->dgram);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-			      "_gnix_dgram_free returned %s\n",
-			      fi_strerror(-ret));
-		vc->dgram = NULL;
 	}
 
 	ret = _gnix_nic_free_rem_id(nic, vc->vc_id);
@@ -2114,9 +2148,7 @@ fi_addr_t _gnix_vc_peer_fi_addr(struct gnix_vc *vc)
 
 	/* If FI_SOURCE capability was requested, do a reverse lookup of a VC's
 	 * FI address once.  Skip translation on connected EPs (no AV). */
-	if (vc->ep->caps & FI_SOURCE &&
-	    vc->ep->av &&
-	    vc->peer_fi_addr == FI_ADDR_NOTAVAIL) {
+	if (vc->ep->av && vc->peer_fi_addr == FI_ADDR_NOTAVAIL) {
 		rc = _gnix_av_reverse_lookup(vc->ep->av,
 					     vc->peer_addr,
 					     &vc->peer_fi_addr);

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -355,7 +355,7 @@ Test(reading, error)
 	cr_assert(!cq_priv->errors->free_list.head);
 
 	_gnix_cq_add_error(cq_priv, &input_ctx, flags, len, buf, data, tag,
-			   olen, err, prov_errno, 0);
+			   olen, err, prov_errno, 0, 0);
 
 	cr_assert(cq_priv->errors->item_list.head);
 
@@ -387,7 +387,7 @@ Test(reading, error)
 	cr_assert_eq(err_entry.olen, olen);
 	cr_assert_eq(err_entry.err, err);
 	cr_assert_eq(err_entry.prov_errno, prov_errno);
-	cr_assert_eq(err_entry.err_data, 0);
+	cr_assert(err_entry.err_data == NULL);
 }
 
 #define ENTRY_CNT 5
@@ -534,7 +534,7 @@ static void cq_fill_test(enum fi_cq_format format)
 	 */
 
 	_gnix_cq_add_error(cq_priv, &input_ctx, flags, len, 0, 0, 0, 0, 0, 0,
-			   0);
+			   0, 0);
 	cr_assert(cq_priv->errors->item_list.head);
 
 	ret = fi_cq_read(rcq, &entry, 1);

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
@@ -2006,6 +2006,8 @@ void do_write_error(int len)
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
 	struct fi_cq_err_entry err_cqe;
+
+	err_cqe.err_data_size = 0;
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
 
 	init_data(source, len, 0xab);

--- a/prov/gni/test/rdm_dgram_stx.c
+++ b/prov/gni/test/rdm_dgram_stx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
@@ -1690,6 +1690,8 @@ static void do_write_error(int len)
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
 	struct fi_cq_err_entry err_cqe;
+
+	err_cqe.err_data_size = 0;
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
 
 	init_data(source, len, 0xab);
@@ -1763,6 +1765,8 @@ static void do_read_error(int len)
 	ssize_t sz;
 	struct fi_cq_tagged_entry cqe;
 	struct fi_cq_err_entry err_cqe;
+
+	err_cqe.err_data_size = 0;
 	uint64_t w[2] = {0}, r[2] = {0}, w_e[2] = {0}, r_e[2] = {0};
 
 	init_data(source, len, 0);


### PR DESCRIPTION
 - Updated _gnix_cq_addr_error to check API version and copy
 out the error data properly.
 - Replaced dgram member of VC struct with gnix_ep_name
 pointer.
 - Updated VC connection request routines to include
 required source address fields.
  - If FI_SOURCE is used and the remote peer's AV doesn't
   contain the source address the unknown source address
   is added to the VC.
 - Updated FI_EP_{RDM,DGM} receive completions to report
 source addresses via error CQEs.
 - Updated fi_gni man page and gnitest unit tests to reflect
 these changes.
 - Updated goto labels in gnix_cq_open for readability.

usptream merge of ofi-cray/libfabric-cray#1179

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@59b56468dbc1e43f4f7bf99da69e1c4b928198d0)

Conflicts:
	prov/gni/test/rdm_sr.c