### PR TITLE
Updates to common code and utility providers.

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -111,6 +111,11 @@ struct util_prov {
 /*
  * Fabric
  */
+struct util_fabric_info {
+	const char 			*name;
+	const struct fi_provider 	*prov;
+};
+
 struct util_fabric {
 	struct fid_fabric	fabric_fid;
 	struct dlist_entry	list_entry;
@@ -534,7 +539,7 @@ void fid_list_remove(struct dlist_entry *fid_list, fastlock_t *lock,
 		     struct fid *fid);
 
 void fi_fabric_insert(struct util_fabric *fabric);
-struct util_fabric *fi_fabric_find(const char *name);
+struct util_fabric *ofi_fabric_find(struct util_fabric_info *fabric_info);
 void fi_fabric_remove(struct util_fabric *fabric);
 
 /*

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -93,6 +93,20 @@
 #define ofi_sin_addr(addr) (((struct sockaddr_in *)(addr))->sin_addr)
 #define ofi_sin6_addr(addr) (((struct sockaddr_in6 *)(addr))->sin6_addr)
 
+#define FI_INFO_FIELD(provider, prov, user, prov_str, user_str, field, type)	\
+	do {									\
+		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",		\
+				fi_tostr(&prov->field, type));			\
+		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n",		\
+				fi_tostr(&user->field, type));			\
+	} while (0)
+
+#define FI_INFO_CHECK(provider, prov, user, field, type) \
+	FI_INFO_FIELD(provider, prov, user, "Supported", "Requested", field, type)
+
+#define FI_INFO_MODE(provider, prov, user) \
+	FI_INFO_FIELD(provider, prov, user, "Expected", "Given", mode, FI_TYPE_MODE)
+
 enum {
 	UTIL_TX_SHARED_CTX = 1 << 0,
 	UTIL_RX_SHARED_CTX = 1 << 1,

--- a/prov/rxd/src/rxd_attr.c
+++ b/prov/rxd/src/rxd_attr.c
@@ -63,7 +63,6 @@ struct fi_ep_attr rxd_ep_attr = {
 };
 
 struct fi_domain_attr rxd_domain_attr = {
-	.name = "rxd",
 	.threading = FI_THREAD_SAFE,
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_AUTO,
@@ -81,9 +80,7 @@ struct fi_domain_attr rxd_domain_attr = {
 };
 
 struct fi_fabric_attr rxd_fabric_attr = {
-	.name = "",
 	.prov_version = FI_VERSION(RXD_MAJOR_VERSION, RXD_MINOR_VERSION),
-	.prov_name = "rxd",
 };
 
 struct fi_info rxd_info = {

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -57,7 +57,6 @@ struct fi_ep_attr rxm_ep_attr = {
 };
 
 struct fi_domain_attr rxm_domain_attr = {
-	.name = "rxm",
 	.threading = FI_THREAD_SAFE,
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_AUTO,
@@ -74,9 +73,7 @@ struct fi_domain_attr rxm_domain_attr = {
 };
 
 struct fi_fabric_attr rxm_fabric_attr = {
-	.name = "",
 	.prov_version = FI_VERSION(RXM_MAJOR_VERSION, RXM_MINOR_VERSION),
-	.prov_name = "rxm",
 };
 
 struct fi_info rxm_info = {

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -430,7 +430,8 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 			  const struct fi_domain_attr *prov_attr,
 			  const struct fi_domain_attr *user_attr)
 {
-	if (user_attr->name && strcasecmp(user_attr->name, prov_attr->name)) {
+	if (prov_attr->name && user_attr->name &&
+	    strcasecmp(user_attr->name, prov_attr->name)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unknown domain name\n");
 		return -FI_ENODATA;
 	}

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -34,20 +34,6 @@
 
 #include <fi_util.h>
 
-#define FI_INFO_FIELD(provider, prov, user, prov_str, user_str, field, type)	\
-	do {									\
-		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",		\
-				fi_tostr(&prov->field, type));			\
-		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n",		\
-				fi_tostr(&user->field, type));			\
-	} while (0)
-
-#define FI_INFO_CAPS(provider, prov, user, field, type) \
-	FI_INFO_FIELD(provider, prov, user, "Supported", "Requested", field, type)
-
-#define FI_INFO_MODE(provider, prov, user) \
-	FI_INFO_FIELD(provider, prov, user, "Expected", "Given", mode, FI_TYPE_MODE)
-
 static int fi_valid_addr_format(uint32_t prov_format, uint32_t user_format)
 {
 	if (user_format == FI_FORMAT_UNSPEC)
@@ -433,6 +419,8 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 	if (prov_attr->name && user_attr->name &&
 	    strcasecmp(user_attr->name, prov_attr->name)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unknown domain name\n");
+		FI_INFO_CHECK(prov, prov_attr, user_attr, name,
+			      FI_TYPE_DOMAIN_ATTR);
 		return -FI_ENODATA;
 	}
 
@@ -494,7 +482,7 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->caps & ~(prov_attr->caps)) {
 		FI_INFO(prov, FI_LOG_CORE, "Requested domain caps not supported\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
+		FI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
@@ -515,13 +503,13 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 
 	if (user_attr->type && (user_attr->type != prov_attr->type)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported endpoint type\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, type, FI_TYPE_EP_TYPE);
+		FI_INFO_CHECK(prov, prov_attr, user_attr, type, FI_TYPE_EP_TYPE);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->protocol && (user_attr->protocol != prov_attr->protocol)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported protocol\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, protocol, FI_TYPE_PROTOCOL);
+		FI_INFO_CHECK(prov, prov_attr, user_attr, protocol, FI_TYPE_PROTOCOL);
 		return -FI_ENODATA;
 	}
 
@@ -576,7 +564,7 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 {
 	if (user_attr->caps & ~(prov_attr->caps)) {
 		FI_INFO(prov, FI_LOG_CORE, "caps not supported\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
+		FI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
@@ -589,21 +577,21 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 
 	if (prov_attr->op_flags & ~(prov_attr->op_flags)) {
 		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, op_flags,
+		FI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
 			     FI_TYPE_OP_FLAGS);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->msg_order & ~(prov_attr->msg_order)) {
 		FI_INFO(prov, FI_LOG_CORE, "msg_order not supported\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, msg_order,
+		FI_INFO_CHECK(prov, prov_attr, user_attr, msg_order,
 			     FI_TYPE_MSG_ORDER);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->comp_order & ~(prov_attr->comp_order)) {
 		FI_INFO(prov, FI_LOG_CORE, "comp_order not supported\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, comp_order,
+		FI_INFO_CHECK(prov, prov_attr, user_attr, comp_order,
 			     FI_TYPE_MSG_ORDER);
 		return -FI_ENODATA;
 	}
@@ -632,7 +620,7 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 {
 	if (user_attr->caps & ~(prov_attr->caps)) {
 		FI_INFO(prov, FI_LOG_CORE, "caps not supported\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
+		FI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
@@ -645,21 +633,21 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 
 	if (prov_attr->op_flags & ~(prov_attr->op_flags)) {
 		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, op_flags,
+		FI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
 			     FI_TYPE_OP_FLAGS);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->msg_order & ~(prov_attr->msg_order)) {
 		FI_INFO(prov, FI_LOG_CORE, "msg_order not supported\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, msg_order,
+		FI_INFO_CHECK(prov, prov_attr, user_attr, msg_order,
 			     FI_TYPE_MSG_ORDER);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->comp_order & ~(prov_attr->comp_order)) {
 		FI_INFO(prov, FI_LOG_CORE, "comp_order not supported\n");
-		FI_INFO_CAPS(prov, prov_attr, user_attr, comp_order,
+		FI_INFO_CHECK(prov, prov_attr, user_attr, comp_order,
 			     FI_TYPE_MSG_ORDER);
 		return -FI_ENODATA;
 	}
@@ -699,7 +687,7 @@ int ofi_check_info(const struct util_prov *util_prov, uint32_t api_version,
 
 	if (user_info->caps & ~(prov_info->caps)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported capabilities\n");
-		FI_INFO_CAPS(prov, prov_info, user_info, caps, FI_TYPE_CAPS);
+		FI_INFO_CHECK(prov, prov_info, user_info, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 

--- a/prov/util/src/util_fabric.c
+++ b/prov/util/src/util_fabric.c
@@ -42,6 +42,7 @@ int ofi_fabric_close(struct util_fabric *fabric)
 		return -FI_EBUSY;
 
 	fi_fabric_remove(fabric);
+	free((char *)fabric->name);
 	fastlock_destroy(&fabric->lock);
 	return 0;
 }
@@ -61,7 +62,8 @@ int ofi_fabric_init(const struct fi_provider *prov,
 	atomic_initialize(&fabric->ref, 0);
 	dlist_init(&fabric->domain_list);
 	fastlock_init(&fabric->lock);
-	fabric->name = prov_attr->name;
+	if (!(fabric->name = strdup(user_attr->name)))
+	    return -FI_ENOMEM;
 
 	fabric->fabric_fid.fid.fclass = FI_CLASS_FABRIC;
 	fabric->fabric_fid.fid.context = context;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -340,15 +340,14 @@ static int fi_ibv_check_hints(uint32_t version, const struct fi_info *hints,
 	int ret;
 
 	if (hints->caps & ~(info->caps)) {
-		FI_INFO(&fi_ibv_prov, FI_LOG_CORE,
-			"Unsupported capabilities\n");
+		FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "Unsupported capabilities\n");
+		FI_INFO_CHECK(&fi_ibv_prov, hints, info, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
 	if ((hints->mode & info->mode) != info->mode) {
-		FI_INFO(&fi_ibv_prov, FI_LOG_CORE,
-			"Required hints mode bits not set. Expected:0x%llx"
-			" Given:0x%llx\n", info->mode, hints->mode);
+		FI_INFO(&fi_ibv_prov, FI_LOG_CORE, "needed mode not set\n");
+		FI_INFO_MODE(&fi_ibv_prov, hints, info);
 		return -FI_ENODATA;
 	}
 


### PR DESCRIPTION
- util: Use both fabric name and provider to search fabric
- prov/rxm and rxd: Don't set domain, prov, fabric names.
- util: Rename logging macros for check info functions.