### PR TITLE
prov/gni: Fix hang after EP lock refactor (#1261)

### DIFF
--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -796,13 +796,13 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 	GNIX_DEBUG(FI_LOG_EP_CTRL,
 		   " moving vc %p to state connected\n",vc);
 
-	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
-
 	ret = _gnix_vc_sched_new_conn(vc);
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_DATA,
 			  "_gnix_vc_sched_new_conn returned %s\n",
 			  fi_strerror(-ret));
+
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 
 	return ret;
 err:


### PR DESCRIPTION
This is fix to a regression introduced in ofi-cray/libfabric-cray#1261.
upstream merge of ofi-cray/libfabric-cray#1299

Signed-off-by: Zach <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@534a4c1683404b2f32c85361f5d5fff2c86adfd4)