### PR TITLE
prov/gni: Fix problems with GNI cm nic progress

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -215,6 +215,9 @@ The `set_val` function sets the value of a given parameter; the
 *GNI_XPMEM_ENABLE*
 : Enable or disable use of XPMEM for on node messages using the GNI provider internal rendezvous protocol.  The value is of type bool.
 
+*GNI_DGRAM_PROGRESS_TIMEOUT*
+: Controls timeout value in milliseconds for the control progress thread.  The value is of type uint32_t.
+
 The `flush_cache` function allows the user to flush any stale registration
 cache entries from the cache. This has the effect of removing registrations
 from the cache that have been deregistered with the provider, but still

--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -65,6 +65,7 @@ typedef enum dom_ops_val { GNI_MSG_RENDEZVOUS_THRESHOLD,
 			   GNI_MR_HARD_REG_LIMIT,
 			   GNI_MR_HARD_STALE_REG_LIMIT,
 			   GNI_XPMEM_ENABLE,
+			   GNI_DGRAM_PROGRESS_TIMEOUT,
 			   GNI_NUM_DOM_OPS
 } dom_ops_val_t;
 
@@ -123,6 +124,7 @@ struct gnix_ops_domain {
 	uint32_t max_retransmits;
 	int32_t err_inject_count;
 	bool xpmem_enabled;
+	uint32_t dgram_progress_timeout;
 };
 
 struct fi_gni_ops_fab {

--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -184,5 +184,30 @@ int _gnix_cm_nic_create_cdm_id(struct gnix_fid_domain *domain, uint32_t *id);
  */
 int _gnix_get_new_cdm_id_set(struct gnix_fid_domain *domain, int nids,
 				uint32_t *id);
+
+/**
+ * @brief helper function to quickly check whether progress is required on
+ *        a cm_nic
+ *
+ * @param cm_nic  pointer to previously allocated gnix_cm_nic struct
+ * @return true if progress is needed, otherwise false
+ */
+static inline bool _gnix_cm_nic_need_progress(struct gnix_cm_nic *cm_nic)
+{
+	bool ret;
+
+	/*
+	 * if control progress is manual, always need to progress
+	 */
+	if (cm_nic->domain->control_progress == FI_PROGRESS_MANUAL)
+		return true;
+
+	/*
+	 * otherwise we only need to see if the wq has stuff to
+	 * progress
+	 */
+	ret = (dlist_empty(&cm_nic->cm_nic_wq)) ? false : true;
+	return ret;
+}
 
 #endif /* _GNIX_CM_NIC_H_ */

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -284,6 +284,7 @@ static const uint32_t default_rx_cq_size = 16384;
 static const uint32_t default_tx_cq_size = 2048;
 static const uint32_t default_max_retransmits = 5;
 static const int32_t default_err_inject_count; /* static var is zeroed */
+static const uint32_t default_dgram_progress_timeout = 100;
 
 static int __gnix_string_to_mr_type(const char *name)
 {
@@ -395,6 +396,9 @@ __gnix_dom_ops_get_val(struct fid *fid, dom_ops_val_t t, void *val)
 			  "GNI provider XPMEM support not configured\n");
 #endif
 		break;
+	case GNI_DGRAM_PROGRESS_TIMEOUT:
+		*(uint32_t *)val = domain->params.dgram_progress_timeout;
+		break;
 	default:
 		GNIX_WARN(FI_LOG_DOMAIN, ("Invalid dom_ops_val\n"));
 		return -FI_EINVAL;
@@ -503,6 +507,9 @@ __gnix_dom_ops_set_val(struct fid *fid, dom_ops_val_t t, void *val)
 		GNIX_WARN(FI_LOG_DOMAIN,
 			  "GNI provider XPMEM support not configured\n");
 #endif
+		break;
+	case GNI_DGRAM_PROGRESS_TIMEOUT:
+		domain->params.dgram_progress_timeout = *(uint32_t *)val;
 		break;
 	default:
 		GNIX_WARN(FI_LOG_DOMAIN, ("Invalid dom_ops_val\n"));
@@ -627,6 +634,7 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 #else
 	domain->params.xpmem_enabled = false;
 #endif
+	domain->params.dgram_progress_timeout = default_dgram_progress_timeout;
 
 	domain->gni_tx_cq_size = default_tx_cq_size;
 	domain->gni_rx_cq_size = default_rx_cq_size;

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -688,6 +688,12 @@ static int __gnix_vc_connect_to_self(struct gnix_vc *vc)
 			  "_gnix_vc_sched_new_conn returned %s\n",
 			  fi_strerror(-ret));
 
+	ret = __gnix_vc_push_tx_reqs(vc);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_DATA,
+			  "_gnix_vc_push_tx_reqs returned %s\n",
+			  fi_strerror(-ret));
+
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n", vc);
 	return ret;
 
@@ -802,6 +808,11 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_DATA,
 			  "_gnix_vc_sched_new_conn returned %s\n",
+			  fi_strerror(-ret));
+	ret = __gnix_vc_push_tx_reqs(vc);
+	if (ret != FI_SUCCESS)
+		GNIX_WARN(FI_LOG_EP_DATA,
+			  "_gnix_vc_push_tx_reqs returned %s\n",
 			  fi_strerror(-ret));
 
 	return ret;
@@ -1053,6 +1064,18 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_vc_sched_new_conn returned %s\n",
 				  fi_strerror(-ret));
+
+		ret = _gnix_cm_nic_progress(cm_nic);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_CTRL,
+				"_gnix_cm_nic_progress returned %s\n",
+				fi_strerror(-ret));
+
+		ret = __gnix_vc_push_tx_reqs(vc);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_vc_push_tx_reqs returned %s\n",
+				  fi_strerror(-ret));
 	}
 
 err:
@@ -1249,6 +1272,11 @@ static int __gnix_vc_conn_ack_prog_fn(void *data, int *complete_ptr)
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_vc_sched_new_conn returned %s\n",
+				  fi_strerror(-ret));
+		ret = __gnix_vc_push_tx_reqs(vc);
+		if (ret != FI_SUCCESS)
+			GNIX_WARN(FI_LOG_EP_DATA,
+				  "_gnix_vc_push_tx_reqs returned %s\n",
 				  fi_strerror(-ret));
 
 	} else if (ret == -FI_EAGAIN) {


### PR DESCRIPTION
It turns out there are certain kGNI datagram exchange
patterns that result in the current GNI provider
CM NIC mechanism not making forward progress when
FI_PROGRESS_AUTO is requested for control progress.

This situation can arise when multiple datagrams
using the same Aries NIC/cookie/cdm_id are being processed
by the progress thread.  The underlying problem is that the
kGNI datagram mechanism only allows one outstanding datagram
for a given target nic/cookie/cdm_id to be posted to the
state engine at a time, and the fact that there is no notification
to the application when a previously posted, bound datagram
transaction completes.  As a consequence, there can be cases where
a process posts a series of connection requests to a target process
with same cookie/cdm_id, that results in the target responding
to the first, then getting GNI_RC_RESOURCE_ERROR for the second because
the first has not completed.

The first response completes, but the progress thread is not woken
up, i.e. does not break out of GNI_PostdataProbeWaitById to progress
the backlog of connection management responses.

We do not see this problem with MPI tests nor simple OpenSHMEM tests
because each process is only using a single endpoint, and thus its
not possible to get this multiple connection requests with same
target aries/cookie/cdm_id.

However we can see this with both shared TXs and with scalable EPs
since in both cases we can have multiple EP's using the same gnix_cm_nic.
Shared TX's are being used in a new version of SOS OpenSHMEM, and
that's where this problem was observed.

To fix this problem, a timeout may be optionally supplied to
GNI_PostdataProbeWaitById and a mechanism for the progress thread to progress
backlogged connection management requests is added.  When progress is not
needed, the progress thread defaults to waiting with infinite timeout.
This approach insures true auto progress for control data.

In addressing this issue,  another problem was found with the progression
mechanism.  Namely, we do need to progress the GNI provider state when an
application executes a fi_cq_readerr on a GNI provider CQ.  See the sockets
provider for the correct way to do this.

upstream merge of ofi-cray/libfabric-cray#1238

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@c9f962e7187d64833f3c9a2095e43b5b1b99a919)