### PR TITLE
prov/gni: Fixed FI_REMOTE_CQ_DATA.

### DIFF
--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
@@ -272,6 +273,15 @@ struct gnix_reference {
 #define _gnix_ref_get(ptr) __ref_get(ptr, ref_cnt)
 #define _gnix_ref_put(ptr) __ref_put(ptr, ref_cnt)
 
+/**
+ * Only allow FI_REMOTE_CQ_DATA when the EP cap, FI_RMA_EVENT, is also set.
+ *
+ * @return zero if FI_REMOTE_CQ_DATA is not permitted; otherwise one.
+ */
+#define GNIX_ALLOW_FI_REMOTE_CQ_DATA(_flags, _ep_caps) \
+					(((_flags) & FI_REMOTE_CQ_DATA) && \
+					 ((_ep_caps) & FI_RMA_EVENT))
+
 static inline void _gnix_ref_init(
 		struct gnix_reference *ref,
 		int initial_value,
@@ -306,7 +316,7 @@ static inline void _gnix_ref_init(
 	__COND_FUNC((cond), (lock), rwlock_unlock)
 #ifdef __GNUC__
 #define __PREFETCH(addr, rw, locality) __builtin_prefetch(addr, rw, locality)
-#else 
+#else
 #define __PREFETCH(addr, rw, locality) ((void *) 0)
 #endif
 

--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -114,7 +114,7 @@ enum gnix_vc_conn_req_type {
  * @var flags                Bitmap used to hold vc schedule state
  * @var peer_irq_mem_hndl    peer GNI memhndl used for delivering
  *                           GNI_PostCqWrite requests to remote peer
- *
+ * @var peer_caps            peer capability flags
  */
 struct gnix_vc {
 	struct dlist_entry prog_list;	/* NIC VC progress list entry */

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -250,7 +250,7 @@ int __smsg_rma_data(void *data, void *msg)
 	struct gnix_fid_ep *ep = vc->ep;
 	gni_return_t status;
 
-	if (hdr->flags & FI_REMOTE_CQ_DATA && ep->recv_cq) {
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(hdr->flags, ep->caps) && ep->recv_cq) {
 		ret = _gnix_cq_add_event(ep->recv_cq, ep, NULL, hdr->user_flags,
 					 0, 0, hdr->user_data, 0,
 					 FI_ADDR_NOTAVAIL);
@@ -335,7 +335,7 @@ static int __gnix_rma_send_data_req(void *arg)
 	txd->completer_fn = __gnix_rma_txd_data_complete;
 	txd->rma_data_hdr.flags = 0;
 
-	if (req->flags & FI_REMOTE_CQ_DATA) {
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(req->flags, ep->caps)) {
 		txd->rma_data_hdr.flags |= FI_REMOTE_CQ_DATA;
 		txd->rma_data_hdr.user_flags = FI_RMA | FI_REMOTE_CQ_DATA;
 		if (req->type == GNIX_FAB_RQ_RDMA_WRITE) {
@@ -488,7 +488,7 @@ static int __gnix_rma_txd_complete(void *arg, gni_return_t tx_status)
 
 	_gnix_nic_tx_free(req->gnix_ep->nic, txd);
 
-	if (req->flags & FI_REMOTE_CQ_DATA ||
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(req->flags, req->gnix_ep->caps) ||
 	    req->vc->peer_caps & FI_RMA_EVENT) {
 		/* control message needed for imm. data or a counter event. */
 		req->tx_failures = 0;

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -50,6 +51,8 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 #include "fi_ext_gni.h"
+#include "gnix_util.h"
+#include "common.h"
 
 #if 1
 #define dbg_printf(...)
@@ -289,8 +292,10 @@ int rdm_api_check_data(char *buf1, char *buf2, int len)
 
 void rdm_api_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 		      uint64_t flags, void *addr, size_t len,
-		      uint64_t data)
+		      uint64_t data, struct fid_ep *fid_ep)
 {
+	struct gnix_fid_ep *gnix_ep = get_gnix_ep(fid_ep);
+
 	cr_assert(cqe->op_context == ctx, "CQE Context mismatch");
 	cr_assert(cqe->flags == flags, "CQE flags mismatch");
 
@@ -298,7 +303,8 @@ void rdm_api_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 		cr_assert(cqe->len == len, "CQE length mismatch");
 		cr_assert(cqe->buf == addr, "CQE address mismatch");
 
-		if (flags & FI_REMOTE_CQ_DATA)
+	/* TODO: Remove GNIX_ALLOW_FI_REMOTE_CQ_DATA and only check flags for FI_RMA_EVENT */
+	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
 			cr_assert(cqe->data == data, "CQE data mismatch");
 	} else {
 		cr_assert(cqe->len == 0, "Invalid CQE length");

--- a/prov/gni/test/common.h
+++ b/prov/gni/test/common.h
@@ -39,6 +39,7 @@
 #include <criterion/criterion.h>
 #include <criterion/logging.h>
 #include "gnix_rdma_headers.h"
+#include "gnix.h"
 
 #define BLUE "\x1b[34m"
 #define COLOR_RESET "\x1b[0m"
@@ -49,5 +50,10 @@ extern int supported_fetch_atomic_ops[FI_ATOMIC_OP_LAST][FI_DATATYPE_LAST];
 
 void calculate_time_difference(struct timeval *start, struct timeval *end,
 		int *secs_out, int *usec_out);
+
+static inline struct gnix_fid_ep *get_gnix_ep(struct fid_ep *fid_ep)
+{
+	return container_of(fid_ep, struct gnix_fid_ep, ep_fid);
+}
 
 #endif /* PROV_GNI_TEST_COMMON_H_ */


### PR DESCRIPTION
 - FI_REMOTE_CQ_DATA is only allowed when FI_RMA_EVENT is
 set on an EPs caps.

 - Added a macro to check the above condition.

 - Updated source and unit tests accordingly.

upstream merge of ofi-cray/libfabric-cray#1240

Signed-off-by: Evan Harvey <eharvey@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@90577bd0b8291bbdb3b80eb2828004de48ff5bd5)
(cherry picked from commit ofi-cray/libfabric-cray@85d64b6d570723812e2f2912d171ec28a9c37946)