### PR TITLE
prov/psm2: Add FI_SOURCE_ERR to the supported caps

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -82,8 +82,8 @@ extern struct fi_provider psmx2_prov;
 			 FI_RMA | FI_MULTI_RECV | \
                          FI_READ | FI_WRITE | FI_SEND | FI_RECV | \
                          FI_REMOTE_READ | FI_REMOTE_WRITE | \
-			 FI_TRIGGER | FI_RMA_EVENT | \
-			 FI_REMOTE_CQ_DATA | FI_SOURCE | FI_DIRECTED_RECV)
+			 FI_TRIGGER | FI_RMA_EVENT | FI_REMOTE_CQ_DATA | \
+			 FI_SOURCE | FI_SOURCE_ERR | FI_DIRECTED_RECV)
 
 #define PSMX2_SUB_CAPS	(FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE | \
 			 FI_SEND | FI_RECV)

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -676,7 +676,8 @@ static ssize_t psmx2_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 					if (source == FI_ADDR_NOTAVAIL) {
 						psmx2_get_source_name(event->source, (void *)&cq_priv->error_data);
 						event->cqe.err.err_data = &cq_priv->error_data;
-						event->error = -FI_EADDRNOTAVAIL;
+						event->cqe.err.err = FI_EADDRNOTAVAIL;
+						event->error = !!event->cqe.err.err;
 						cq_priv->pending_error = event;
 						if (!read_count)
 							read_count = -FI_EAVAIL;


### PR DESCRIPTION
Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>