### PR TITLE
prov/gni: Set PMI environment variable to insure PMI_Init does not ge…

### DIFF
--- a/prov/gni/test/run_gnitest
+++ b/prov/gni/test/run_gnitest
@@ -69,5 +69,11 @@ else
     args="-n1 -N1 -j0 -cc none -t1200"
 fi
 
+# As of Criterion 2.3, it seems that the PRE_ALL hook is being run
+# more than once.  These two environment variables insure we never
+# fork and never initialize more than once.
+export PMI_NO_PREINITIALIZE=1
+export PMI_NO_FORK=1
+
 # pass all command line args to gnitest
 $launcher $args $gnitest_bin -j1 "$@"


### PR DESCRIPTION
…t called more than once

For some reason, the new (2.3) Criterion PRE_ALL report hook
infrastructure is causing gnitest to call PMI_Init() twice on
ALPS-based systems.  It seems like it's always twice, since it's still
two times even if I pass it -j2.

usptream merge of ofi-cray/libfabric-cray#1298

[ci skip]

Signed-off-by: Sung-Eun Choi <sungeunchoi@users.noreply.github.com>
(cherry picked from commit ofi-cray/libfabric-cray@297c0bb68ffe00583905805a706b245967787fda)