### PR TITLE
util: Fix util_mr code check for FI_MR_SCALABLE

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -486,7 +486,7 @@ struct ofi_mr_map {
 	enum fi_mr_mode		mode;
 };
 
-int ofi_mr_map_init(const struct fi_provider *in_prov, enum fi_mr_mode mode,
+int ofi_mr_map_init(const struct fi_provider *in_prov, int mode,
 		    struct ofi_mr_map *map);
 void ofi_mr_map_close(struct ofi_mr_map *map);
 

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -513,6 +513,8 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 			   FI_SHARED_AV | FI_TRIGGER | FI_FENCE | \
 			   FI_LOCAL_COMM | FI_REMOTE_COMM)
 
+int ofi_check_mr_mode(uint32_t api_version, uint32_t prov_mode,
+			     uint32_t user_mode);
 int ofi_check_fabric_attr(const struct fi_provider *prov,
 			  const struct fi_fabric_attr *prov_attr,
 			  const struct fi_fabric_attr *user_attr);

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -942,9 +942,9 @@ union sock_tx_op {
 };
 #define SOCK_EP_TX_ENTRY_SZ (sizeof(union sock_tx_op))
 
-int sock_verify_info(struct fi_info *hints);
+int sock_verify_info(uint32_t version, struct fi_info *hints);
 int sock_verify_fabric_attr(struct fi_fabric_attr *attr);
-int sock_verify_domain_attr(struct fi_domain_attr *attr);
+int sock_verify_domain_attr(uint32_t version, struct fi_domain_attr *attr);
 
 size_t sock_get_tx_size(size_t size);
 int sock_rdm_verify_ep_attr(struct fi_ep_attr *ep_attr, struct fi_tx_attr *tx_attr,
@@ -957,14 +957,15 @@ int sock_get_src_addr(struct sockaddr_in *dest_addr,
 		      struct sockaddr_in *src_addr);
 int sock_get_src_addr_from_hostname(struct sockaddr_in *src_addr, const char *service);
 
-struct fi_info *sock_fi_info(enum fi_ep_type ep_type,
-			     struct fi_info *hints, void *src_addr, void *dest_addr);
-int sock_msg_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
-		     struct fi_info **info);
-int sock_dgram_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
-			struct fi_info **info);
-int sock_rdm_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
-		     struct fi_info **info);
+struct fi_info *sock_fi_info(uint32_t version, enum fi_ep_type ep_type,
+			     struct fi_info *hints, void *src_addr,
+			     void *dest_addr);
+int sock_msg_fi_info(uint32_t version, void *src_addr, void *dest_addr,
+		     struct fi_info *hints, struct fi_info **info);
+int sock_dgram_fi_info(uint32_t version, void *src_addr, void *dest_addr,
+		       struct fi_info *hints, struct fi_info **info);
+int sock_rdm_fi_info(uint32_t version, void *src_addr, void *dest_addr,
+		     struct fi_info *hints, struct fi_info **info);
 void free_fi_info(struct fi_info *info);
 
 int sock_msg_getinfo(uint32_t version, const char *node, const char *service,

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1390,7 +1390,8 @@ static void sock_set_fabric_attr(void *src_addr, const struct fi_fabric_attr *hi
 	attr->prov_name = NULL;
 }
 
-static void sock_set_domain_attr(void *src_addr, const struct fi_domain_attr *hint_attr,
+static void sock_set_domain_attr(uint32_t api_version, void *src_addr,
+				 const struct fi_domain_attr *hint_attr,
 				 struct fi_domain_attr *attr)
 {
 	struct sock_domain *domain;
@@ -1399,6 +1400,9 @@ static void sock_set_domain_attr(void *src_addr, const struct fi_domain_attr *hi
 	attr->domain = domain ? &domain->dom_fid : NULL;
 	if (!hint_attr) {
 		*attr = sock_domain_attr;
+
+		if (FI_VERSION_LT(api_version, FI_VERSION(1, 5)))
+			attr->mr_mode = FI_MR_SCALABLE;
 		goto out;
 	}
 
@@ -1417,8 +1421,12 @@ static void sock_set_domain_attr(void *src_addr, const struct fi_domain_attr *hi
 		attr->control_progress = sock_domain_attr.control_progress;
 	if (attr->data_progress == FI_PROGRESS_UNSPEC)
 		attr->data_progress = sock_domain_attr.data_progress;
-	if (attr->mr_mode == FI_MR_UNSPEC)
+	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5))) {
+		if (attr->mr_mode == FI_MR_UNSPEC)
+			attr->mr_mode = FI_MR_SCALABLE;
+	} else {
 		attr->mr_mode = sock_domain_attr.mr_mode;
+	}
 
 	if (attr->cq_cnt == 0)
 		attr->cq_cnt = sock_domain_attr.cq_cnt;
@@ -1448,8 +1456,9 @@ out:
 }
 
 
-struct fi_info *sock_fi_info(enum fi_ep_type ep_type, struct fi_info *hints,
-			     void *src_addr, void *dest_addr)
+struct fi_info *sock_fi_info(uint32_t version, enum fi_ep_type ep_type,
+			     struct fi_info *hints, void *src_addr,
+			     void *dest_addr)
 {
 	struct fi_info *info;
 
@@ -1494,10 +1503,12 @@ struct fi_info *sock_fi_info(enum fi_ep_type ep_type, struct fi_info *hints,
 		if (hints->handle)
 			info->handle = hints->handle;
 
-		sock_set_domain_attr(info->src_addr, hints->domain_attr, info->domain_attr);
+		sock_set_domain_attr(version, info->src_addr, hints->domain_attr,
+				     info->domain_attr);
 		sock_set_fabric_attr(info->src_addr, hints->fabric_attr, info->fabric_attr);
 	} else {
-		sock_set_domain_attr(info->src_addr, NULL, info->domain_attr);
+		sock_set_domain_attr(version, info->src_addr, NULL,
+				     info->domain_attr);
 		sock_set_fabric_attr(info->src_addr, NULL, info->fabric_attr);
 	}
 
@@ -1554,15 +1565,15 @@ int sock_alloc_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct sock_rx_ctx *rx_ctx;
 	struct sock_domain *sock_dom;
 
+	sock_dom = container_of(domain, struct sock_domain, dom_fid);
 	if (info) {
-		ret = sock_verify_info(info);
+		ret = sock_verify_info(sock_dom->fab->fab_fid.api_version, info);
 		if (ret) {
 			SOCK_LOG_DBG("Cannot support requested options!\n");
 			return -FI_EINVAL;
 		}
 	}
 
-	sock_dom = container_of(domain, struct sock_domain, dom_fid);
 	sock_ep = (struct sock_ep *) calloc(1, sizeof(*sock_ep));
 	if (!sock_ep)
 		return -FI_ENOMEM;

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -197,10 +197,10 @@ int sock_dgram_verify_ep_attr(struct fi_ep_attr *ep_attr,
 	return 0;
 }
 
-int sock_dgram_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
-			struct fi_info **info)
+int sock_dgram_fi_info(uint32_t version, void *src_addr, void *dest_addr,
+		       struct fi_info *hints, struct fi_info **info)
 {
-	*info = sock_fi_info(FI_EP_DGRAM, hints, src_addr, dest_addr);
+	*info = sock_fi_info(version, FI_EP_DGRAM, hints, src_addr, dest_addr);
 	if (!*info)
 		return -FI_ENOMEM;
 

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -198,10 +198,10 @@ int sock_msg_verify_ep_attr(struct fi_ep_attr *ep_attr,
 	return 0;
 }
 
-int sock_msg_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
-		     struct fi_info **info)
+int sock_msg_fi_info(uint32_t version, void *src_addr, void *dest_addr,
+		     struct fi_info *hints, struct fi_info **info)
 {
-	*info = sock_fi_info(FI_EP_MSG, hints, src_addr, dest_addr);
+	*info = sock_fi_info(version, FI_EP_MSG, hints, src_addr, dest_addr);
 	if (!*info)
 		return -FI_ENOMEM;
 
@@ -875,8 +875,8 @@ static struct fi_info *sock_ep_msg_get_info(struct sock_pep *pep,
 
 	hints = pep->info;
 	hints.caps = req->caps;
-	return sock_fi_info(FI_EP_MSG, &hints,
-			    &pep->src_addr, &req->src_addr);
+	return sock_fi_info(pep->sock_fab->fab_fid.api_version, FI_EP_MSG,
+			    &hints, &pep->src_addr, &req->src_addr);
 }
 
 static void *sock_pep_req_handler(void *data)
@@ -1161,7 +1161,7 @@ int sock_msg_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	struct addrinfo hints, *result;
 
 	if (info) {
-		ret = sock_verify_info(info);
+		ret = sock_verify_info(fabric->api_version, info);
 		if (ret) {
 			SOCK_LOG_DBG("Cannot support requested options!\n");
 			return ret;

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -241,10 +241,10 @@ int sock_rdm_verify_ep_attr(struct fi_ep_attr *ep_attr,
 	return 0;
 }
 
-int sock_rdm_fi_info(void *src_addr, void *dest_addr, struct fi_info *hints,
-		     struct fi_info **info)
+int sock_rdm_fi_info(uint32_t version, void *src_addr, void *dest_addr,
+		     struct fi_info *hints, struct fi_info **info)
 {
-	*info = sock_fi_info(FI_EP_RDM, hints, src_addr, dest_addr);
+	*info = sock_fi_info(version, FI_EP_RDM, hints, src_addr, dest_addr);
 	if (!*info)
 		return -FI_ENOMEM;
 

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -390,7 +390,7 @@ static int fi_resource_mgmt_level(enum fi_resource_mgmt rm_model)
 	}
 }
 
-static int ofi_check_mr_mode(uint32_t api_version, uint32_t prov_mode,
+int ofi_check_mr_mode(uint32_t api_version, uint32_t prov_mode,
 			     uint32_t user_mode)
 {
 	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5))) {


### PR DESCRIPTION
- libfabric version 1.5 replaced FI_MR_SCALABLE with new mr_mode bits. Update the
util_mr code to handle it correctly.
- Update sockets provider to correctly set mr_mode based on api version