### PR TITLE
prov/verbs: forced processing of IB interfaces

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -968,6 +968,13 @@ static void fi_ibv_sockaddr_set_port(struct sockaddr *sa, uint16_t port)
 	}
 }
 
+static inline int fi_ibv_is_loopback(struct sockaddr *addr)
+{
+	assert(addr);
+	return addr->sa_family == AF_INET &&
+	       ((struct sockaddr_in *)addr)->sin_addr.s_addr == ntohl(INADDR_LOOPBACK);
+}
+
 static int fi_ibv_fill_addr(struct rdma_addrinfo *rai, struct fi_info **info,
 		struct rdma_cm_id *id)
 {
@@ -975,7 +982,7 @@ static int fi_ibv_fill_addr(struct rdma_addrinfo *rai, struct fi_info **info,
 	struct sockaddr *local_addr;
 	int ret;
 
-	if (rai->ai_src_addr)
+	if (rai->ai_src_addr && !fi_ibv_is_loopback(rai->ai_src_addr))
 		goto rai_to_fi;
 
 	if (!id->verbs)


### PR DESCRIPTION
- in some configurations default source address for IB is
  localhost (127.0.0.1), for such address when EP is
  initialized RAI points to loopback address & failed to
  connect/accept connection to/from another host.
  Fix: force processing of preferrable interfaces for
  cases when default RAI is initialized by loopback
  interface

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>