### PR TITLE
prov/verbs: fixed crash on verbs fi_write

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -1307,7 +1307,8 @@ fi_ibv_rdm_rma_inject_request(struct fi_ibv_rdm_request *request, void *data)
 	sge.addr = p->lbuf;
 
 	if ((request->len < p->ep_rdm->max_inline_rc) && 
-	    (!RMA_RESOURCES_IS_BUSY(request->minfo.conn, p->ep_rdm)))
+	    (!RMA_RESOURCES_IS_BUSY(request->minfo.conn, p->ep_rdm)) &&
+	    fi_ibv_rdm_check_connection(request->minfo.conn, p->ep_rdm))
 	{
 		wr.send_flags |= IBV_SEND_INLINE;
 	} else if (fi_ibv_rdm_prepare_rma_request(request, p->ep_rdm)) {


### PR DESCRIPTION
- there is connection optimization in verbs provider:
  real connection is established on first interaction
  with peer. But this optimization is too aggressive:
  in case if first interaction is RMA write, and data
  size is low (less than inline threshold) connection
  is not established & application crashed due to
  null pointer to QP.
  Fix: force "reqular" way of data transmit if
  connection is not established yet

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>