### PR TITLE
windows: fixed build on windows systems

### DIFF
--- a/include/windows/inttypes.h
+++ b/include/windows/inttypes.h
@@ -1,4 +1,0 @@
-
-#pragma once
-
-

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -96,12 +96,8 @@ do						\
 #define getpid (int)GetCurrentProcessId
 #define sleep(x) Sleep(x * 1000)
 
-#define PRIx8         "hhx"
-#define PRIx16        "hx"
-#define PRIx32        "lx"
-#define PRIx64        "llx"
 #define __PRI64_PREFIX "ll"
-# define PRIu64 __PRI64_PREFIX "u"
+
 #define HOST_NAME_MAX 256
 
 #define MIN min
@@ -226,6 +222,18 @@ static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **map
 	OFI_UNUSED(mapped);
 
 	return -FI_ENOENT;
+}
+
+static inline char * strndup(char const *src, size_t n)
+{
+	size_t len = strnlen(src, n);
+	char *dst = malloc(len + 1);
+
+	if (dst) {
+		memcpy(dst, src, len);
+		dst[len] = 0;
+	}
+	return dst;
 }
 
 int ofi_shm_unmap(struct util_shm *shm);

--- a/include/windows/pthread.h
+++ b/include/windows/pthread.h
@@ -17,6 +17,7 @@
 #include <ws2tcpip.h>
 #include <windows.h>
 #include <stdint.h>
+#include <stdlib.h>
 
 #define PTHREAD_MUTEX_INITIALIZER {0}
 

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -53,7 +53,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;_DEBUG;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;_DEBUG;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)include;$(ProjectDir)include\windows</AdditionalIncludeDirectories>
       <CompileAs>CompileAsC</CompileAs>
@@ -75,7 +75,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;WIN32_LEAN_AND_MEAN;_CRT_SECURE_NO_WARNINGS;NDEBUG;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)include;$(ProjectDir)include\windows</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4127</DisableSpecificWarnings>
@@ -100,8 +100,10 @@
     <ClCompile Include="prov\rxd\src\rxd_ep.c" />
     <ClCompile Include="prov\rxd\src\rxd_fabric.c" />
     <ClCompile Include="prov\rxd\src\rxd_init.c">
-      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">fi_osd.h</ForcedIncludeFiles>
-      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|x64'">fi_osd.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="prov\rxd\src\rxd_rma.c" />
     <ClCompile Include="prov\rxm\src\rxm.c" />
@@ -112,8 +114,10 @@
     <ClCompile Include="prov\rxm\src\rxm_ep.c" />
     <ClCompile Include="prov\rxm\src\rxm_fabric.c" />
     <ClCompile Include="prov\rxm\src\rxm_init.c">
-      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">fi_osd.h</ForcedIncludeFiles>
-      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|x64'">fi_osd.h</ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+      </ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+      </ForcedIncludeFiles>
     </ClCompile>
     <ClCompile Include="prov\sockets\src\sock_atomic.c">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir)prov\sockets\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
- updated VS project configuration
- removed stub for inttypes.h (now used SDK version of this file)
- added strndup implementation (missing in win SDK)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>