### PR TITLE
Compile warning suppress

### DIFF
--- a/include/windows/sys/mman.h
+++ b/include/windows/sys/mman.h
@@ -34,31 +34,54 @@ typedef uint32_t mode_t;
 /* stubs for Linux only functions */
 static inline void *mremap(void *old_address, size_t old_size, size_t new_size, int flags)
 {
+	OFI_UNUSED(old_address);
+	OFI_UNUSED(old_size);
+	OFI_UNUSED(new_size);
+	OFI_UNUSED(flags);
+
 	return MAP_FAILED;
 }
 
 static inline int shm_open(const char *name, int oflag, mode_t mode)
 {
+	OFI_UNUSED(name);
+	OFI_UNUSED(oflag);
+	OFI_UNUSED(mode);
+
 	return -1;
 }
 
 static inline int shm_unlink(const char *name)
 {
+	OFI_UNUSED(name);
 	return -1;
 }
 
 static inline void *mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset)
 {
+	OFI_UNUSED(addr);
+	OFI_UNUSED(length);
+	OFI_UNUSED(prot);
+	OFI_UNUSED(flags);
+	OFI_UNUSED(fd);
+	OFI_UNUSED(offset);
+
 	return MAP_FAILED;
 }
 
 static inline int munmap(void *addr, size_t length)
 {
+	OFI_UNUSED(addr);
+	OFI_UNUSED(length);
+
 	return -1;
 }
 
 static inline int ftruncate(int fd, off_t length)
 {
+	OFI_UNUSED(fd);
+	OFI_UNUSED(length);
+
 	return -1;
 }
 

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -71,7 +71,7 @@ int rxd_av_dg_reverse_lookup(struct rxd_av *av, uint64_t start_idx,
 	if (!curr_addr)
 		return -FI_ENOMEM;
 
-	for (i = 0; i < av->dg_av_used; i++) {
+	for (i = 0; i < (size_t)av->dg_av_used; i++) {
 		ret = fi_av_lookup(av->dg_av, (i + start_idx) % av->dg_av_used,
 				   curr_addr, &len);
 		if (ret)
@@ -90,7 +90,8 @@ out:
 int rxd_av_insert_check(struct rxd_av *av, const void *addr, size_t count,
 			fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
-	int i, success_cnt = 0;
+	int success_cnt = 0;
+	size_t i;
 	int ret, index;
 	void *curr_addr;
 	uint64_t dg_av_idx;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -108,7 +108,8 @@ struct fi_ops_ep rxd_ops_ep = {
 static ssize_t rxd_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 			       uint64_t flags)
 {
-	ssize_t ret = 0, i;
+	ssize_t ret = 0;
+	size_t i;
 	struct rxd_ep *rxd_ep;
 	struct rxd_recv_entry *recv_entry;
 
@@ -211,7 +212,8 @@ static int rxd_ep_set_conn_id(struct rxd_ep *ep)
 
 int rxd_ep_enable(struct rxd_ep *ep)
 {
-	ssize_t i, ret;
+	size_t i;
+	ssize_t ret;
 	void *mr = NULL;
 	struct rxd_rx_buf *rx_buf;
 
@@ -800,7 +802,8 @@ uint64_t rxd_find_av_index(struct rxd_av *av, uint64_t start_idx,
 			    const void *addr, size_t addrlen, int *p_found)
 {
 	void *tmp_addr;
-	uint64_t idx = 0, count;
+	uint64_t idx = 0;
+	int count;
 	size_t tmp_addrlen;
 
 	if (p_found)
@@ -1156,7 +1159,8 @@ static ssize_t rxd_trx_peek_recv(struct rxd_ep *ep,
 ssize_t rxd_trx_claim_recv(struct rxd_ep *ep, const struct fi_msg_tagged *msg,
 			    uint64_t flags)
 {
-	int ret = 0, i;
+	int ret = 0;
+	size_t i;
 	struct fi_context *context;
 	struct rxd_rx_entry *rx_entry;
 	struct rxd_trecv_entry *trecv_entry;
@@ -1203,7 +1207,8 @@ out:
 ssize_t rxd_ep_trecvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 			 uint64_t flags)
 {
-	ssize_t ret = 0, i;
+	ssize_t ret = 0;
+	size_t i;
 	struct rxd_ep *rxd_ep;
 	struct rxd_trecv_entry *trecv_entry;
 

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -236,7 +236,7 @@ static ssize_t rxd_ep_writev(struct fid_ep *ep, const struct iovec *iov,
 			     void **desc, size_t count, fi_addr_t dest_addr,
 			     uint64_t addr, uint64_t key, void *context)
 {
-	int i;
+	size_t i;
 	size_t len;
 	struct fi_msg_rma msg;
 	struct fi_rma_iov rma_iov;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -443,7 +443,8 @@ static ssize_t rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov
 	struct fid_mr *mr;
 	void *desc_tx_buf = NULL;
 	struct rxm_rma_iov *rma_iov;
-	int ret, pkt_size = 0;
+	int ret;
+	size_t pkt_size = 0;
 	size_t i;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
@@ -526,7 +527,7 @@ static ssize_t rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov
 		} else {
 			FI_WARN(&rxm_prov, FI_LOG_EP_DATA, "passed data (size = %d) is too "
 				"big for MSG provider (max inject size = %d) \n",
-				pkt_size, rxm_ep->msg_info->tx_attr->inject_size);
+				(int)pkt_size, rxm_ep->msg_info->tx_attr->inject_size);
 		}
 	}
 

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -64,7 +64,8 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 			  size_t compare_count, struct fi_ioc *resultv,
 			  void **result_desc, size_t result_count, uint64_t flags)
 {
-	int i, ret;
+	ssize_t ret;
+	size_t i;
 	size_t datatype_sz;
 	struct sock_op tx_op;
 	union sock_iov tx_iov;

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -138,7 +138,7 @@ void sock_cntr_check_trigger_list(struct sock_cntr *cntr)
 		trigger = container_of(entry, struct sock_trigger, entry);
 		entry = entry->next;
 
-		if (atomic_get(&cntr->value) < trigger->threshold)
+		if (atomic_get(&cntr->value) < (int)trigger->threshold)
 			continue;
 
 		switch (trigger->op_type) {
@@ -302,7 +302,7 @@ static int sock_cntr_wait(struct fid_cntr *fid_cntr, uint64_t threshold,
 		goto out;
 	}
 
-	if (atomic_get(&cntr->value) >= threshold) {
+	if (atomic_get(&cntr->value) >= (int)threshold) {
 		ret = 0;
 		goto out;
 	}
@@ -317,7 +317,7 @@ static int sock_cntr_wait(struct fid_cntr *fid_cntr, uint64_t threshold,
 	last_read = atomic_get(&cntr->value);
 	remaining_ms = timeout;
 
-	while (!ret && last_read < threshold) {
+	while (!ret && last_read < (int)threshold) {
 		if (cntr->domain->progress_mode == FI_PROGRESS_MANUAL) {
 			pthread_mutex_unlock(&cntr->mut);
 			ret = sock_cntr_progress(cntr);

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -285,7 +285,7 @@ static void sock_cq_set_report_fn(struct sock_cq *sock_cq)
 
 static inline void sock_cq_copy_overflow_list(struct sock_cq *cq, size_t count)
 {
-	ssize_t i;
+	size_t i;
 	struct sock_cq_overflow_entry_t *overflow_entry;
 
 	for (i = 0; i < count && !dlist_empty(&cq->overflow_list); i++) {
@@ -310,7 +310,7 @@ static inline ssize_t sock_cq_rbuf_read(struct sock_cq *cq, void *buf,
 					size_t count, fi_addr_t *src_addr,
 					size_t cq_entry_len)
 {
-	ssize_t i;
+	size_t i;
 	fi_addr_t addr;
 
 	ofi_rbfdread(&cq->cq_rbfd, buf, cq_entry_len * count);
@@ -354,7 +354,7 @@ static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 			avail = ofi_rbfdused(&sock_cq->cq_rbfd);
 			if (avail)
 				ret = sock_cq_rbuf_read(sock_cq, buf,
-					MIN(threshold, avail / cq_entry_len),
+					MIN(threshold, (size_t)(avail / cq_entry_len)),
 					src_addr, cq_entry_len);
 			fastlock_release(&sock_cq->lock);
 			if (ret == 0 && timeout >= 0) {
@@ -370,7 +370,7 @@ static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 			avail = ofi_rbfdused(&sock_cq->cq_rbfd);
 			if (avail)
 				ret = sock_cq_rbuf_read(sock_cq, buf,
-					MIN(threshold, avail / cq_entry_len),
+					MIN(threshold, (size_t)(avail / cq_entry_len)),
 					src_addr, cq_entry_len);
 			else /* No CQ entry available, read the fd */
 				ofi_rbfdreset(&sock_cq->cq_rbfd);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -729,7 +729,8 @@ static int sock_ep_close(struct fid *fid)
 
 static int sock_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
-	int ret, i;
+	int ret;
+	size_t i;
 	struct sock_ep *ep;
 	struct sock_eq *eq;
 	struct sock_cq *cq;
@@ -965,7 +966,7 @@ struct fi_ops sock_ep_fi_ops = {
 
 int sock_ep_enable(struct fid_ep *ep)
 {
-	int i;
+	size_t i;
 	struct sock_ep *sock_ep;
 	struct sock_tx_ctx *tx_ctx;
 	struct sock_rx_ctx *rx_ctx;
@@ -1010,7 +1011,7 @@ int sock_ep_enable(struct fid_ep *ep)
 
 int sock_ep_disable(struct fid_ep *ep)
 {
-	int i;
+	size_t i;
 	struct sock_ep *sock_ep;
 
 	sock_ep = container_of(ep, struct sock_ep, ep);
@@ -1071,7 +1072,7 @@ static int sock_ep_getopt(fid_t fid, int level, int optname,
 static int sock_ep_setopt(fid_t fid, int level, int optname,
 		       const void *optval, size_t optlen)
 {
-	int i;
+	size_t i;
 	struct sock_ep *sock_ep;
 	sock_ep = container_of(fid, struct sock_ep, ep.fid);
 
@@ -1104,7 +1105,7 @@ static int sock_ep_tx_ctx(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
 
 	sock_ep = container_of(ep, struct sock_ep, ep);
 	if (sock_ep->attr->fclass != FI_CLASS_SEP ||
-		index >= sock_ep->attr->ep_attr.tx_ctx_cnt)
+		index >= (int)sock_ep->attr->ep_attr.tx_ctx_cnt)
 		return -FI_EINVAL;
 
 	if (attr) {
@@ -1145,7 +1146,7 @@ static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 
 	sock_ep = container_of(ep, struct sock_ep, ep);
 	if (sock_ep->attr->fclass != FI_CLASS_SEP ||
-		index >= sock_ep->attr->ep_attr.rx_ctx_cnt)
+		index >= (int)sock_ep->attr->ep_attr.rx_ctx_cnt)
 		return -FI_EINVAL;
 
 	if (attr) {

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -60,7 +60,8 @@
 ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 			uint64_t flags)
 {
-	int i, ret;
+	int ret;
+	size_t i;
 	struct sock_rx_ctx *rx_ctx;
 	struct sock_rx_entry *rx_entry;
 	struct sock_ep *sock_ep;
@@ -174,7 +175,8 @@ static ssize_t sock_ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 			uint64_t flags)
 {
-	int ret, i;
+	int ret;
+	size_t i;
 	uint64_t total_len, op_flags;
 	struct sock_op tx_op;
 	union sock_iov tx_iov;
@@ -389,7 +391,8 @@ struct fi_ops_msg sock_ep_msg_ops = {
 ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 			 const struct fi_msg_tagged *msg, uint64_t flags)
 {
-	int i, ret;
+	int ret;
+	size_t i;
 	struct sock_rx_ctx *rx_ctx;
 	struct sock_rx_entry *rx_entry;
 	struct sock_ep *sock_ep;
@@ -513,7 +516,8 @@ static ssize_t sock_ep_trecvv(struct fid_ep *ep, const struct iovec *iov,
 ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 			 const struct fi_msg_tagged *msg, uint64_t flags)
 {
-	int ret, i;
+	int ret;
+	size_t i;
 	uint64_t total_len, op_flags;
 	struct sock_op tx_op;
 	union sock_iov tx_iov;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1158,7 +1158,8 @@ static int sock_pe_process_rx_atomic(struct sock_pe *pe,
 				struct sock_rx_ctx *rx_ctx,
 				struct sock_pe_entry *pe_entry)
 {
-	int i, j, ret = 0;
+	int i, ret = 0;
+	size_t j;
 	size_t datatype_sz;
 	struct sock_mr *mr;
 	uint64_t offset, len, entry_len;
@@ -2668,7 +2669,7 @@ static int sock_pe_wait_ok(struct sock_pe *pe)
 	struct sock_tx_ctx *tx_ctx;
 	struct sock_rx_ctx *rx_ctx;
 
-	if (pe->waittime && ((fi_gettime_ms() - pe->waittime) < sock_pe_waittime))
+	if (pe->waittime && ((fi_gettime_ms() - pe->waittime) < (uint64_t)sock_pe_waittime))
 		return 0;
 
 	if (dlist_empty(&pe->tx_list) && dlist_empty(&pe->rx_list))

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -60,7 +60,8 @@
 ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 			    uint64_t flags)
 {
-	int ret, i;
+	int ret;
+	size_t i;
 	struct sock_op tx_op;
 	union sock_iov tx_iov;
 	struct sock_conn *conn;
@@ -224,7 +225,8 @@ static ssize_t sock_ep_rma_readv(struct fid_ep *ep, const struct iovec *iov,
 ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 			     uint64_t flags)
 {
-	int ret, i;
+	int ret;
+	size_t i;
 	struct sock_op tx_op;
 	union sock_iov tx_iov;
 	struct sock_conn *conn;
@@ -384,7 +386,7 @@ static ssize_t sock_ep_rma_writev(struct fid_ep *ep, const struct iovec *iov,
 				void **desc, size_t count, fi_addr_t dest_addr,
 				uint64_t addr, uint64_t key, void *context)
 {
-	int i;
+	size_t i;
 	size_t len;
 	struct fi_msg_rma msg;
 	struct fi_rma_iov rma_iov;

--- a/prov/sockets/src/sock_rx_entry.c
+++ b/prov/sockets/src/sock_rx_entry.c
@@ -51,7 +51,7 @@ struct sock_rx_entry *sock_rx_new_entry(struct sock_rx_ctx *rx_ctx)
 {
 	struct sock_rx_entry *rx_entry;
 	struct slist_entry *entry;
-	int i;
+	size_t i;
 
 	if (rx_ctx->rx_entry_pool == NULL) {
 		rx_ctx->rx_entry_pool = calloc(rx_ctx->attr.size,

--- a/prov/sockets/src/sock_trigger.c
+++ b/prov/sockets/src/sock_trigger.c
@@ -58,7 +58,7 @@ ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
 
 	threshold = &trigger_context->trigger.threshold;
 	cntr = container_of(threshold->cntr, struct sock_cntr, cntr_fid);
-	if (atomic_get(&cntr->value) >= threshold->threshold)
+	if (atomic_get(&cntr->value) >= (int)threshold->threshold)
 		return 1;
 
 	trigger = calloc(1, sizeof(*trigger));
@@ -101,7 +101,7 @@ ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
 
 	threshold = &trigger_context->trigger.threshold;
 	cntr = container_of(threshold->cntr, struct sock_cntr, cntr_fid);
-	if (atomic_get(&cntr->value) >= threshold->threshold)
+	if (atomic_get(&cntr->value) >= (int)threshold->threshold)
 		return 1;
 
 	trigger = calloc(1, sizeof(*trigger));
@@ -141,7 +141,7 @@ ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 
 	threshold = &trigger_context->trigger.threshold;
 	cntr = container_of(threshold->cntr, struct sock_cntr, cntr_fid);
-	if (atomic_get(&cntr->value) >= threshold->threshold)
+	if (atomic_get(&cntr->value) >= (int)threshold->threshold)
 		return 1;
 
 	trigger = calloc(1, sizeof(*trigger));
@@ -183,7 +183,7 @@ ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 
 	threshold = &trigger_context->trigger.threshold;
 	cntr = container_of(threshold->cntr, struct sock_cntr, cntr_fid);
-	if (atomic_get(&cntr->value) >= threshold->threshold)
+	if (atomic_get(&cntr->value) >= (int)threshold->threshold)
 		return 1;
 
 	trigger = calloc(1, sizeof(*trigger));

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -333,7 +333,7 @@ static int fi_av_remove_addr(struct util_av *av, int slot, int index)
 	struct dlist_entry *av_entry;
 	int *entry, *next, i;
 
-	if (index < 0 || index > av->count) {
+	if (index < 0 || (size_t)index > av->count) {
 		FI_WARN(av->prov, FI_LOG_AV, "index out of range\n");
 		return -FI_EINVAL;
 	}
@@ -484,7 +484,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 	if (!av->data)
 		return -FI_ENOMEM;
 
-	for (i = 0; i < av->count - 1; i++) {
+	for (i = 0; i < (int)av->count - 1; i++) {
 		entry = util_av_get_data(av, i);
 		*entry = i + 1;
 	}
@@ -939,7 +939,7 @@ static int ip_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr, void *addr,
 
 	av = container_of(av_fid, struct util_av, av_fid);
 	index = (int) fi_addr;
-	if (index < 0 || index > av->count) {
+	if (index < 0 || (size_t)index > av->count) {
 		FI_WARN(av->prov, FI_LOG_AV, "unknown address\n");
 		return -FI_EINVAL;
 	}

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -118,7 +118,7 @@ ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 {
 	struct util_cq *cq;
 	struct fi_cq_tagged_entry *entry;
-	ssize_t i;
+	size_t i;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 	fastlock_acquire(&cq->cq_lock);
@@ -161,7 +161,7 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 	if (!cq->src) {
 		i = ofi_cq_read(cq_fid, buf, count);
 		if (i > 0) {
-			for (count = 0; count < i; count++)
+			for (count = 0; count < (size_t)i; count++)
 				src_addr[i] = FI_ADDR_NOTAVAIL;
 		}
 		return i;
@@ -181,7 +181,7 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 	if (count > ofi_cirque_usedcnt(cq->cirq))
 		count = ofi_cirque_usedcnt(cq->cirq);
 
-	for (i = 0; i < count; i++) {
+	for (i = 0; i < (ssize_t)count; i++) {
 		entry = ofi_cirque_head(cq->cirq);
 		if (entry->flags & UTIL_FLAG_ERROR) {
 			if (!i)

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -64,7 +64,7 @@ static ssize_t util_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 	if (event)
 		*event = entry->event;
 	if (buf) {
-		ret = MIN(len, entry->size);
+		ret = MIN(len, (size_t)entry->size);
 		memcpy(buf, entry->data, ret);
 	}  else {
 		ret = 0;

--- a/src/iov.c
+++ b/src/iov.c
@@ -43,7 +43,7 @@ uint64_t ofi_copy_iov_buf(const struct iovec *iov, size_t iov_count,
 {
 	uint64_t done = 0, len;
 	char *iov_buf;
-	int i;
+	size_t i;
 
 	for (i = 0; i < iov_count && bufsize; i++) {
 		len = iov[i].iov_len;

--- a/src/log.c
+++ b/src/log.c
@@ -85,7 +85,8 @@ const char *ofi_hex_str(const uint8_t *data, size_t len)
 {
 	static char str[64];
 	const char hex[] = "0123456789abcdef";
-	int i, p;
+	int p;
+	size_t i;
 
 	if (len >= (sizeof(str) >> 1))
 		len = (sizeof(str) >> 1) - 1;


### PR DESCRIPTION
- suppressed compilation warnings on comparison
  signed/unsigned data types (generally in
  socks/utils/rxm/rxd providers)
- there were a lot of warnings for unused variables in mman.h
  stub. All such wariables are marked as unused