### PR TITLE
build: suppress warning on size of an array

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -468,7 +468,7 @@ struct util_event {
 	int			size;
 	int			event;
 	int			err;
-	uint8_t			data[0];
+	uint8_t			data[];
 };
 
 int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -434,7 +434,7 @@ struct sock_eq_entry {
 	size_t len;
 	uint64_t flags;
 	struct dlist_entry entry;
-	char event[0];
+	char event[];
 };
 
 struct sock_eq_err_data_entry {
@@ -837,7 +837,7 @@ struct sock_cq_overflow_entry_t {
 	size_t len;
 	fi_addr_t addr;
 	struct dlist_entry entry;
-	char cq_entry[0];
+	char cq_entry[];
 };
 
 struct sock_cq {
@@ -869,14 +869,14 @@ struct sock_conn_hdr {
 	uint8_t reserved[3];
 	uint16_t port;
 	uint16_t cm_data_sz;
-	char cm_data[0];
+	char cm_data[];
 };
 
 struct sock_conn_req {
 	struct sock_conn_hdr hdr;
 	struct sockaddr_in src_addr;
 	uint64_t caps;
-	char cm_data[0];
+	char cm_data[];
 };
 
 enum {


### PR DESCRIPTION
- suppressed warning #94: the size of an array must be greater than
  zero: zero-size arrays is not standard for C (it is suported by
  all known compilers, but most of them are generates warning).
  warning appeared by default on windows system where compiler has
  much more paranoic settings

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>