### PR TITLE
prov/bgq: Do not set fabric prov_name in the provider

### DIFF
--- a/prov/bgq/src/fi_bgq_init.c
+++ b/prov/bgq/src/fi_bgq_init.c
@@ -169,12 +169,6 @@ static int fi_bgq_fillinfo(struct fi_info *fi, const char *node,
 				"memory allocation failed");
 		goto err;
 	}
-	fi->fabric_attr->prov_name = strdup(FI_BGQ_PROVIDER_NAME);
-	if (!fi->fabric_attr->prov_name) {
-		FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_FABRIC,
-				"memory allocation failed");
-		goto err;
-	}
 	fi->fabric_attr->prov_version = FI_BGQ_PROVIDER_VERSION;
 
 	memcpy(fi->tx_attr, fi_bgq_global.default_tx_attr, sizeof(*fi->tx_attr));


### PR DESCRIPTION
The fi_fabric_attr->prov_name should only be set by the framework NOT the
provider.  This was causing an assertion check to fail in ofi_set_prov_attr
on the ofi_is_util_prov call.

Signed-off-by: Paul Coffman <pcoffman@anl.gov>