### PR TITLE
prov/gni: Fix problems with GNI cm nic progress

### DIFF
--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -121,30 +121,7 @@ static int gnix_cntr_set_wait(struct gnix_fid_cntr *cntr)
 
 static int __gnix_cntr_progress(struct gnix_fid_cntr *cntr)
 {
-	int ret;
-	struct gnix_cm_nic *cm_nic = cntr->domain->cm_nic;
-
-	ret = _gnix_prog_progress(&cntr->pset);
-
-	/*
-	 * check to see if we need to poke the cm nic to progress
-	 * backlogged datagram requests.  This is needed even if
-	 * control_progress is set to FI_PROGRESS_AUTO since we
-	 * don't get notification back from kGNI when a previously
-	 * posted bound datagram has actually completed, allowing
-	 * subsequent pending bound datagrams to be posted to kGNI.
-	 */
-
-	if (cm_nic != NULL &&
-		_gnix_cm_nic_need_progress(cm_nic)) {
-			ret = _gnix_cm_nic_progress(cm_nic);
-			if (ret)
-				GNIX_WARN(FI_LOG_CQ,
-				  "_gnix_cm_nic_progress returned: %d\n",
-				  ret);
-	}
-
-	return ret;
+	return _gnix_prog_progress(&cntr->pset);
 }
 
 /*******************************************************************************

--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -251,29 +251,7 @@ err:
 
 static int __gnix_cq_progress(struct gnix_fid_cq *cq)
 {
-        int ret;
-	struct gnix_cm_nic *cm_nic = cq->domain->cm_nic;
-
-	/*
-	 * check to see if we need to poke the cm nic to progress
-	 * backlogged datagram requests.  This is needed even if
-	 * control_progress is set to FI_PROGRESS_AUTO since we
-	 * don't get notification back from kGNI when a previously
-	 * posted bound datagram has actually completed, allowing
-	 * subsequent pending bound datagrams to be posted to kGNI.
-	 */
-
-	if (cm_nic != NULL &&
-		_gnix_cm_nic_need_progress(cm_nic)) {
-			ret = _gnix_cm_nic_progress(cm_nic);
-			if (ret)
-				GNIX_WARN(FI_LOG_CQ,
-				  "_gnix_cm_nic_progress returned: %d\n",
-				  ret);
-	}
-
 	return _gnix_prog_progress(&cq->pset);
-
 }
 
 /*******************************************************************************
@@ -558,9 +536,8 @@ DIRECT_FN STATIC ssize_t gnix_cq_readerr(struct fid_cq *cq,
 	 * we need to progress cq.  some apps may be only using
 	 * cq to check for errors.
 	 */
-	__gnix_cq_progress(cq_priv);
 
-	COND_ACQUIRE(cq_priv->requires_lock, &cq_priv->lock);
+	_gnix_prog_progress(&cq_priv->pset);
 
 	entry = _gnix_queue_dequeue(cq_priv->errors);
 	if (!entry) {

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -688,12 +688,6 @@ static int __gnix_vc_connect_to_self(struct gnix_vc *vc)
 			  "_gnix_vc_sched_new_conn returned %s\n",
 			  fi_strerror(-ret));
 
-	ret = __gnix_vc_push_tx_reqs(vc);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_vc_push_tx_reqs returned %s\n",
-			  fi_strerror(-ret));
-
 	GNIX_DEBUG(FI_LOG_EP_CTRL, "moving vc %p state to connected\n", vc);
 	return ret;
 
@@ -806,11 +800,6 @@ static int __gnix_vc_hndl_conn_resp(struct gnix_cm_nic *cm_nic,
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_EP_DATA,
 			  "_gnix_vc_sched_new_conn returned %s\n",
-			  fi_strerror(-ret));
-	ret = __gnix_vc_push_tx_reqs(vc);
-	if (ret != FI_SUCCESS)
-		GNIX_WARN(FI_LOG_EP_DATA,
-			  "_gnix_vc_push_tx_reqs returned %s\n",
 			  fi_strerror(-ret));
 
 	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
@@ -1064,18 +1053,6 @@ static int __gnix_vc_hndl_conn_req(struct gnix_cm_nic *cm_nic,
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_vc_sched_new_conn returned %s\n",
 				  fi_strerror(-ret));
-
-		ret = _gnix_cm_nic_progress(cm_nic);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_CTRL,
-				"_gnix_cm_nic_progress returned %s\n",
-				fi_strerror(-ret));
-
-		ret = __gnix_vc_push_tx_reqs(vc);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_vc_push_tx_reqs returned %s\n",
-				  fi_strerror(-ret));
 	}
 
 err:
@@ -1272,11 +1249,6 @@ static int __gnix_vc_conn_ack_prog_fn(void *data, int *complete_ptr)
 		if (ret != FI_SUCCESS)
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_vc_sched_new_conn returned %s\n",
-				  fi_strerror(-ret));
-		ret = __gnix_vc_push_tx_reqs(vc);
-		if (ret != FI_SUCCESS)
-			GNIX_WARN(FI_LOG_EP_DATA,
-				  "_gnix_vc_push_tx_reqs returned %s\n",
 				  fi_strerror(-ret));
 
 	} else if (ret == -FI_EAGAIN) {


### PR DESCRIPTION
Fixes to GNI cm nic progress.  Turns out the VC/EP
refactor (ofi-cray/libfabric-cray#1261) changed lock holding, etc. The initial
rebase of PR ofi-cray/libfabric-cray#1238 on top of that PR had some errors.
This PR fixes those problems.  Miniapps script now
passes again.

upstream merge of ofi-cray/libfabric-cray#1305

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@e32205f8a3b688d17a08922c65e325d7fb27ee98)