### PR TITLE
prov/sockets: fix sockets cq_sreadfrom error

### DIFF
--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -342,12 +342,12 @@ static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 	else
 		threshold = count;
 
-	if (sock_cq->domain->progress_mode == FI_PROGRESS_MANUAL) {
-		if (timeout >= 0) {
-			start_ms = fi_gettime_ms();
-			end_ms = start_ms + timeout;
-		}
+	if (timeout >= 0) {
+		start_ms = fi_gettime_ms();
+		end_ms = start_ms + timeout;
+	}
 
+	if (sock_cq->domain->progress_mode == FI_PROGRESS_MANUAL) {
 		do {
 			sock_cq_progress(sock_cq);
 			fastlock_acquire(&sock_cq->lock);
@@ -363,8 +363,11 @@ static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 			}
 		} while (ret == 0);
 	} else {
-		ret = ofi_rbfdwait(&sock_cq->cq_rbfd, timeout);
-		if (ret > 0) {
+		do {
+			ret = ofi_rbfdwait(&sock_cq->cq_rbfd, timeout);
+			if (ret <= 0)
+				break;
+
 			fastlock_acquire(&sock_cq->lock);
 			ret = 0;
 			avail = ofi_rbfdused(&sock_cq->cq_rbfd);
@@ -375,7 +378,13 @@ static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 			else /* No CQ entry available, read the fd */
 				ofi_rbfdreset(&sock_cq->cq_rbfd);
 			fastlock_release(&sock_cq->lock);
-		}
+
+			if ((ret == -FI_EAGAIN || ret == 0) && timeout >= 0) {
+				timeout = end_ms - fi_gettime_ms();
+				if (timeout <= 0)
+					break;
+			}
+		} while (ret == 0 || ret == -FI_EAGAIN);
 	}
 	return (ret == 0 || ret == -FI_ETIMEDOUT) ? -FI_EAGAIN : ret;
 }


### PR DESCRIPTION
Fixes a bug in the sockets provider where EAGAIN might be returned when timeout = -1

Signed-off-by: aingerson <alexia.ingerson@intel.com>