### PR TITLE
fabric: Add new FI_CONTEXT2 mode bit

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -280,6 +280,7 @@ enum {
 #define FI_LOCAL_MR		(1ULL << 55)
 #define FI_NOTIFY_FLAGS_ONLY	(1ULL << 54)
 #define FI_RESTRICTED_COMP	(1ULL << 53)
+#define FI_CONTEXT2		(1ULL << 52)
 
 struct fi_tx_attr {
 	uint64_t		caps;
@@ -567,6 +568,10 @@ void fi_freeparams(struct fi_param *params);
 #ifndef FABRIC_DIRECT_
 struct fi_context {
 	void			*internal[4];
+};
+
+struct fi_context2 {
+	void			*internal[8];
 };
 #endif
 

--- a/man/fi_direct.7.md
+++ b/man/fi_direct.7.md
@@ -61,8 +61,9 @@ values may be used by an application to test for provider support of
 supported features.
 
 *FI_DIRECT_CONTEXT*
-: The provider sets FI_CONTEXT for fi_info:mode.  See fi_getinfo
-  for additional details.
+: The provider sets FI_CONTEXT or FI_CONTEXT2 for fi_info:mode.  See fi_getinfo
+  for additional details.  When FI_DIRECT_CONTEXT is defined, applications
+  should use struct fi_context in their definitions, even if FI_CONTEXT2 is set.
 
 *FI_DIRECT_LOCAL_MR*
 : The provider sets FI_LOCAL_MR for fi_info:mode.  See fi_getinfo

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -443,6 +443,16 @@ supported set of modes will be returned in the info structure(s).
   or reuse it until the original operation has completed.  The
   structure is specified in rdma/fabric.h.
 
+*FI_CONTEXT2*
+: This bit is similar to FI_CONTEXT, but doubles the provider's
+  requirement on the size of the per context structure.  When set,
+  this specifies that the provider requires that applications use
+  struct fi_context2 as their per operation context parameter.
+  Or, optionally, an application can provide an array of two
+  fi_context structures (e.g. struct fi_context[2]) instead.
+  The requirements for using struct fi_context2 are identical as
+  defined for FI_CONTEXT above.
+
 *FI_LOCAL_MR*
 : The provider is optimized around having applications register memory
   for locally accessed data buffers.  Data buffers used in send and


### PR DESCRIPTION
The current fi_context structure is too small for some providers
(e.g. BGQ).  Introduce a new mode bit that doubles the size of
the fi_context structure.

In order to ensure backwards compatibility, the current fi_context
structure is left unchanged.  This avoids the possibility that an
app may have embedded fi_context into a structure optimized to fit
into a specific amount of memory, such as a single cache line.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>