### PR TITLE
usnic: Provider updates for 1.5

### DIFF
--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -51,6 +51,7 @@
 #include <rdma/fi_errno.h>
 #include "fi.h"
 #include "fi_enosys.h"
+#include "fi_util.h"
 
 #include "usnic_direct.h"
 #include "usdf.h"
@@ -247,14 +248,12 @@ usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			return -FI_ENODATA;
 		}
 
-		switch (info->domain_attr->mr_mode) {
-		case FI_MR_UNSPEC:
-		case FI_MR_BASIC:
-			break;
-		default:
+		if (ofi_check_mr_mode(fabric->api_version,
+				      OFI_MR_BASIC_MAP | FI_MR_LOCAL,
+				      info->domain_attr->mr_mode)) {
 			/* the caller ignored our fi_getinfo results */
 			USDF_WARN_SYS(DOMAIN, "MR mode (%d) not supported\n",
-				info->domain_attr->mr_mode);
+				      info->domain_attr->mr_mode);
 			return -FI_ENODATA;
 		}
 	}

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -55,6 +55,7 @@
 #include <rdma/fi_errno.h>
 #include "fi.h"
 #include "fi_enosys.h"
+#include "fi_util.h"
 
 #include "usnic_direct.h"
 #include "usd.h"
@@ -403,7 +404,7 @@ static const struct fi_domain_attr dgram_dflt_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_DISABLED,
-	.mr_mode = FI_MR_BASIC
+	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL
 };
 
 /*******************************************************************************
@@ -520,13 +521,9 @@ int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	switch (hints->domain_attr->mr_mode) {
-	case FI_MR_UNSPEC:
-	case FI_MR_BASIC:
-		break;
-	default:
+	if (ofi_check_mr_mode(version, defaults.mr_mode,
+			      hints->domain_attr->mr_mode))
 		return -FI_ENODATA;
-	}
 
 out:
 	*fi->domain_attr = defaults;

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -525,6 +525,8 @@ int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
 			      hints->domain_attr->mr_mode))
 		return -FI_ENODATA;
 
+	defaults.mr_mode = hints->domain_attr->mr_mode;
+
 out:
 	*fi->domain_attr = defaults;
 

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -214,13 +214,9 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	switch (hints->domain_attr->mr_mode) {
-	case FI_MR_UNSPEC:
-	case FI_MR_BASIC:
-		break;
-	default:
+	if (ofi_check_mr_mode(version, defaults.mr_mode,
+			      hints->domain_attr->mr_mode))
 		return -FI_ENODATA;
-	}
 
 out:
 	*fi->domain_attr = defaults;

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -218,6 +218,8 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 			      hints->domain_attr->mr_mode))
 		return -FI_ENODATA;
 
+	defaults.mr_mode = hints->domain_attr->mr_mode;
+
 out:
 	*fi->domain_attr = defaults;
 

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -56,6 +56,7 @@
 #include <rdma/fi_errno.h>
 #include "fi.h"
 #include "fi_enosys.h"
+#include "fi_util.h"
 
 #include "usd.h"
 #include "usdf.h"
@@ -118,7 +119,7 @@ static const struct fi_domain_attr rdm_dflt_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_DISABLED,
-	.mr_mode = FI_MR_BASIC
+	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL
 };
 
 /*******************************************************************************
@@ -217,13 +218,9 @@ int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	switch (hints->domain_attr->mr_mode) {
-	case FI_MR_UNSPEC:
-	case FI_MR_BASIC:
-		break;
-	default:
+	if (ofi_check_mr_mode(version, defaults.mr_mode,
+			      hints->domain_attr->mr_mode))
 		return -FI_ENODATA;
-	}
 
 out:
 	*fi->domain_attr = defaults;

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -222,6 +222,8 @@ int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
 			      hints->domain_attr->mr_mode))
 		return -FI_ENODATA;
 
+	defaults.mr_mode = hints->domain_attr->mr_mode;
+
 out:
 	*fi->domain_attr = defaults;
 

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -1016,7 +1016,7 @@ static void usdf_fini(void)
 struct fi_provider usdf_ops = {
 	.name = USDF_PROV_NAME,
 	.version = USDF_PROV_VERSION,
-	.fi_version = FI_VERSION(1, 4),
+	.fi_version = FI_VERSION(1, 5),
 	.getinfo = usdf_getinfo,
 	.fabric = usdf_fabric_open,
 	.cleanup =  usdf_fini


### PR DESCRIPTION
There will be more updates to come, these fixes allow us to respond to `fi_info -p` after the changes made to the core. 

Update the usNIC provider to 1.5, and fix the MR mode checking logic to correctly handle pre-1.5 mode bits.