### PR TITLE
prov/Sockets: Deferred work queue support

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -233,7 +233,7 @@ struct sock_domain {
 };
 
 struct sock_trigger {
-	uint8_t op_type;
+	enum fi_trigger_op op_type;
 	size_t threshold;
 	struct dlist_entry entry;
 
@@ -1165,15 +1165,15 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 
 
 ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
-			  uint64_t flags, uint8_t op_type);
+			  uint64_t flags, enum fi_trigger_op op_type);
 ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 			     const struct fi_ioc *comparev, size_t compare_count,
 			     struct fi_ioc *resultv, size_t result_count,
-			     uint64_t flags, uint8_t op_type);
+			     uint64_t flags, enum fi_trigger_op op_type);
 ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
-			   uint64_t flags, uint8_t op_type);
+			   uint64_t flags, enum fi_trigger_op op_type);
 ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
-			  uint64_t flags, uint8_t op_type);
+			  uint64_t flags, enum fi_trigger_op op_type);
 void sock_cntr_check_trigger_list(struct sock_cntr *cntr);
 
 int sock_epoll_create(struct sock_epoll_set *set, int size);

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -237,7 +237,8 @@ struct sock_trigger {
 	size_t threshold;
 	struct dlist_entry entry;
 
-	struct fid_ep	*ep;
+	struct fi_deferred_work *work;
+	struct fid_ep *ep;
 	uint64_t flags;
 
 	union {
@@ -1174,6 +1175,7 @@ ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 			   uint64_t flags, enum fi_trigger_op op_type);
 ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
 			  uint64_t flags, enum fi_trigger_op op_type);
+ssize_t sock_queue_cntr_op(struct fi_deferred_work *work, uint64_t flags);
 void sock_cntr_check_trigger_list(struct sock_cntr *cntr);
 
 int sock_epoll_create(struct sock_epoll_set *set, int size);

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -1164,7 +1164,7 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 			  size_t compare_count, struct fi_ioc *resultv,
 			  void **result_desc, size_t result_count, uint64_t flags);
 
-
+int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work);
 ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
 			  uint64_t flags, enum fi_trigger_op op_type);
 ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -114,8 +114,8 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 
 	if (flags & FI_TRIGGER) {
 		ret = sock_queue_atomic_op(ep, msg, comparev, compare_count,
-					resultv, result_count, flags,
-					SOCK_OP_ATOMIC);
+					   resultv, result_count, flags,
+					   FI_OP_ATOMIC);
 		if (ret != 1)
 			return ret;
 	}

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -142,52 +142,45 @@ void sock_cntr_check_trigger_list(struct sock_cntr *cntr)
 			continue;
 
 		switch (trigger->op_type) {
-		case SOCK_OP_SEND:
+		case FI_OP_SEND:
 			ret = sock_ep_sendmsg(trigger->ep, &trigger->op.msg.msg,
-					trigger->flags & ~FI_TRIGGER);
+					      trigger->flags & ~FI_TRIGGER);
 			break;
-
-		case SOCK_OP_RECV:
+		case FI_OP_RECV:
 			ret = sock_ep_recvmsg(trigger->ep, &trigger->op.msg.msg,
-					trigger->flags & ~FI_TRIGGER);
+					      trigger->flags & ~FI_TRIGGER);
 			break;
-
-		case SOCK_OP_TSEND:
-			ret = sock_ep_tsendmsg(trigger->ep,
-					&trigger->op.tmsg.msg,
-					trigger->flags & ~FI_TRIGGER);
+		case FI_OP_TSEND:
+			ret = sock_ep_tsendmsg(trigger->ep, &trigger->op.tmsg.msg,
+					       trigger->flags & ~FI_TRIGGER);
 			break;
-
-		case SOCK_OP_TRECV:
-			ret = sock_ep_trecvmsg(trigger->ep,
-					&trigger->op.tmsg.msg,
-					trigger->flags & ~FI_TRIGGER);
+		case FI_OP_TRECV:
+			ret = sock_ep_trecvmsg(trigger->ep, &trigger->op.tmsg.msg,
+					       trigger->flags & ~FI_TRIGGER);
 			break;
-
-		case SOCK_OP_WRITE:
+		case FI_OP_WRITE:
 			ret = sock_ep_rma_writemsg(trigger->ep,
-					&trigger->op.rma.msg,
-					trigger->flags & ~FI_TRIGGER);
+						   &trigger->op.rma.msg,
+						   trigger->flags & ~FI_TRIGGER);
 			break;
-
-		case SOCK_OP_READ:
+		case FI_OP_READ:
 			ret = sock_ep_rma_readmsg(trigger->ep,
-					&trigger->op.rma.msg,
-					trigger->flags & ~FI_TRIGGER);
+						  &trigger->op.rma.msg,
+						  trigger->flags & ~FI_TRIGGER);
 			break;
-
-		case SOCK_OP_ATOMIC:
+		case FI_OP_ATOMIC:
+		case FI_OP_FETCH_ATOMIC:
+		case FI_OP_COMPARE_ATOMIC:
 			ret = sock_ep_tx_atomic(trigger->ep,
-					&trigger->op.atomic.msg,
-					trigger->op.atomic.comparev,
-					NULL,
-					trigger->op.atomic.compare_count,
-					trigger->op.atomic.resultv,
-					NULL,
-					trigger->op.atomic.result_count,
-					trigger->flags & ~FI_TRIGGER);
+						&trigger->op.atomic.msg,
+						trigger->op.atomic.comparev,
+						NULL,
+						trigger->op.atomic.compare_count,
+						trigger->op.atomic.resultv,
+						NULL,
+						trigger->op.atomic.result_count,
+						trigger->flags & ~FI_TRIGGER);
 			break;
-
 		default:
 			SOCK_LOG_ERROR("unsupported op\n");
 			ret = 0;

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -138,7 +138,7 @@ void sock_cntr_check_trigger_list(struct sock_cntr *cntr)
 		trigger = container_of(entry, struct sock_trigger, entry);
 		entry = entry->next;
 
-		if (atomic_get(&cntr->value) < (int)trigger->threshold)
+		if (atomic_get(&cntr->value) < (int) trigger->threshold)
 			continue;
 
 		switch (trigger->op_type) {
@@ -180,6 +180,18 @@ void sock_cntr_check_trigger_list(struct sock_cntr *cntr)
 						NULL,
 						trigger->op.atomic.result_count,
 						trigger->flags & ~FI_TRIGGER);
+			break;
+		case FI_OP_CNTR_SET:
+			assert(trigger->work);
+			fi_cntr_set(trigger->work->op.cntr->cntr,
+				    trigger->work->op.cntr->value);
+			ret = 0;
+			break;
+		case FI_OP_CNTR_ADD:
+			assert(trigger->work);
+			fi_cntr_add(trigger->work->op.cntr->cntr,
+				    trigger->work->op.cntr->value);
+			ret = 0;
 			break;
 		default:
 			SOCK_LOG_ERROR("unsupported op\n");

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -366,6 +366,19 @@ static int sock_dom_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	return 0;
 }
 
+static int sock_dom_ctrl(struct fid *fid, int command, void *arg)
+{
+	struct sock_domain *dom;
+
+	dom = container_of(fid, struct sock_domain, dom_fid.fid);
+	switch (command) {
+	case FI_QUEUE_WORK:
+		return sock_queue_work(dom, arg);
+	default:
+		return -FI_ENOSYS;
+	}
+}
+
 static int sock_endpoint(struct fid_domain *domain, struct fi_info *info,
 			 struct fid_ep **ep, void *context)
 {
@@ -400,7 +413,7 @@ static struct fi_ops sock_dom_fi_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = sock_dom_close,
 	.bind = sock_dom_bind,
-	.control = fi_no_control,
+	.control = sock_dom_ctrl,
 	.ops_open = fi_no_ops_open,
 };
 

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -95,7 +95,7 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		flags |= op_flags;
 
 	if (flags & FI_TRIGGER) {
-		ret = sock_queue_msg_op(ep, msg, flags, SOCK_OP_RECV);
+		ret = sock_queue_msg_op(ep, msg, flags, FI_OP_RECV);
 		if (ret != 1)
 			return ret;
 	}
@@ -226,7 +226,7 @@ ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		flags |= op_flags;
 
 	if (flags & FI_TRIGGER) {
-		ret = sock_queue_msg_op(ep, msg, flags, SOCK_OP_SEND);
+		ret = sock_queue_msg_op(ep, msg, flags, FI_OP_SEND);
 		if (ret != 1)
 			return ret;
 	}
@@ -427,7 +427,7 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 	flags &= ~FI_MULTI_RECV;
 
 	if (flags & FI_TRIGGER) {
-		ret = sock_queue_tmsg_op(ep, msg, flags, SOCK_OP_TRECV);
+		ret = sock_queue_tmsg_op(ep, msg, flags, FI_OP_TRECV);
 		if (ret != 1)
 			return ret;
 	}
@@ -564,7 +564,7 @@ ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 		flags |= op_flags;
 
 	if (flags & FI_TRIGGER) {
-		ret = sock_queue_tmsg_op(ep, msg, flags, SOCK_OP_TSEND);
+		ret = sock_queue_tmsg_op(ep, msg, flags, FI_OP_TSEND);
 		if (ret != 1)
 			return ret;
 	}

--- a/prov/sockets/src/sock_rma.c
+++ b/prov/sockets/src/sock_rma.c
@@ -108,7 +108,7 @@ ssize_t sock_ep_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		flags |= op_flags;
 
 	if (flags & FI_TRIGGER) {
-		ret = sock_queue_rma_op(ep, msg, flags, SOCK_OP_READ);
+		ret = sock_queue_rma_op(ep, msg, flags, FI_OP_READ);
 		if (ret != 1)
 			return ret;
 	}
@@ -273,7 +273,7 @@ ssize_t sock_ep_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		flags |= op_flags;
 
 	if (flags & FI_TRIGGER) {
-		ret = sock_queue_rma_op(ep, msg, flags, SOCK_OP_WRITE);
+		ret = sock_queue_rma_op(ep, msg, flags, FI_OP_WRITE);
 		if (ret != 1)
 			return ret;
 	}

--- a/prov/sockets/src/sock_trigger.c
+++ b/prov/sockets/src/sock_trigger.c
@@ -255,3 +255,73 @@ ssize_t sock_queue_cntr_op(struct fi_deferred_work *work, uint64_t flags)
 	sock_cntr_check_trigger_list(cntr);
 	return 0;
 }
+
+int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work)
+{
+	struct fi_triggered_context *ctx;
+
+	if (work->event_type != FI_TRIGGER_THRESHOLD)
+		return -FI_ENOSYS;
+
+	/* We require the operation's context to point back to the fi_context
+	 * embedded within the deferred work item.  This is an implementation
+	 * limitation, which we may turn into a requirement.  The app must
+	 * keep the fi_deferred_work structure around for the duration of the
+	 * processing anyway.
+	 */
+	ctx = (struct fi_triggered_context *) &work->context;
+	ctx->event_type = work->event_type;
+	ctx->trigger.threshold = *work->event.threshold;
+
+	switch (work->op_type) {
+	case FI_OP_RECV:
+	case FI_OP_SEND:
+		if (work->op.msg->msg.context != &work->context)
+			return -FI_EINVAL;
+		return sock_queue_msg_op(work->op.msg->ep, &work->op.msg->msg,
+					 work->op.msg->flags, work->op_type);
+	case FI_OP_TRECV:
+	case FI_OP_TSEND:
+		if (work->op.tagged->msg.context != &work->context)
+			return -FI_EINVAL;
+		return sock_queue_tmsg_op(work->op.tagged->ep, &work->op.tagged->msg,
+					  work->op.tagged->flags, work->op_type);
+	case FI_OP_READ:
+	case FI_OP_WRITE:
+		if (work->op.rma->msg.context != &work->context)
+			return -FI_EINVAL;
+		return sock_queue_rma_op(work->op.rma->ep, &work->op.rma->msg,
+					 work->op.rma->flags, work->op_type);
+	case FI_OP_ATOMIC:
+		if (work->op.atomic->msg.context != &work->context)
+			return -FI_EINVAL;
+		return sock_queue_atomic_op(work->op.atomic->ep,
+					    &work->op.atomic->msg,
+					    NULL, 0, NULL, 0,
+					    work->op.atomic->flags, work->op_type);
+	case FI_OP_FETCH_ATOMIC:
+		if (work->op.fetch_atomic->msg.context != &work->context)
+			return -FI_EINVAL;
+		return sock_queue_atomic_op(work->op.fetch_atomic->ep,
+					    &work->op.fetch_atomic->msg,
+					    NULL, 0,
+					    work->op.fetch_atomic->fetch.msg_iov,
+					    work->op.fetch_atomic->fetch.iov_count,
+					    work->op.fetch_atomic->flags, work->op_type);
+	case FI_OP_COMPARE_ATOMIC:
+		if (work->op.compare_atomic->msg.context != &work->context)
+			return -FI_EINVAL;
+		return sock_queue_atomic_op(work->op.compare_atomic->ep,
+					    &work->op.compare_atomic->msg,
+					    work->op.compare_atomic->compare.msg_iov,
+					    work->op.compare_atomic->compare.iov_count,
+					    work->op.compare_atomic->fetch.msg_iov,
+					    work->op.compare_atomic->fetch.iov_count,
+					    work->op.compare_atomic->flags, work->op_type);
+	case FI_OP_CNTR_SET:
+	case FI_OP_CNTR_ADD:
+		return sock_queue_cntr_op(work, 0);
+	default:
+		return -FI_ENOSYS;
+	}
+}

--- a/prov/sockets/src/sock_trigger.c
+++ b/prov/sockets/src/sock_trigger.c
@@ -44,7 +44,7 @@
 #define SOCK_LOG_ERROR(...) _SOCK_LOG_ERROR(FI_LOG_EP_DATA, __VA_ARGS__)
 
 ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
-			  uint64_t flags, uint8_t op_type)
+			  uint64_t flags, enum fi_trigger_op op_type)
 {
 	struct sock_cntr *cntr;
 	struct sock_trigger *trigger;
@@ -87,7 +87,7 @@ ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
 }
 
 ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
-			  uint64_t flags, uint8_t op_type)
+			  uint64_t flags, enum fi_trigger_op op_type)
 {
 	struct sock_cntr *cntr;
 	struct sock_trigger *trigger;
@@ -127,7 +127,7 @@ ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
 }
 
 ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
-			   uint64_t flags, uint8_t op_type)
+			   uint64_t flags, enum fi_trigger_op op_type)
 {
 	struct sock_cntr *cntr;
 	struct sock_trigger *trigger;
@@ -169,7 +169,7 @@ ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 			     const struct fi_ioc *comparev, size_t compare_count,
 			     struct fi_ioc *resultv, size_t result_count,
-			     uint64_t flags, uint8_t op_type)
+			     uint64_t flags, enum fi_trigger_op op_type)
 {
 	struct sock_cntr *cntr;
 	struct sock_trigger *trigger;


### PR DESCRIPTION
There are no triggered tests, so these are compiled tested only at this point.  But they do build on the existing socket implementation.  Additional enhancements to deferred work queue support will come in follow on patches.