### PR TITLE
rxm: remove FI_MR_LOCAL requirement from app

### DIFF
--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -65,7 +65,7 @@ struct fi_domain_attr rxm_domain_attr = {
 	/* Advertise support for FI_MR_BASIC so that ofi_check_info call
 	 * doesn't fail at RxM level. If an app requires FI_MR_BASIC, it
 	 * would be passed down to core provider. */
-	.mr_mode = FI_MR_LOCAL | FI_MR_BASIC,
+	.mr_mode = FI_MR_BASIC,
 	.cq_cnt = (1 << 16),
 	.ep_cnt = (1 << 15),
 	.tx_ctx_cnt = 1,

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -163,6 +163,12 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (ret)
 		goto err1;
 
+	/* Force core provider to supply MR key */
+	if (FI_VERSION_LT(fabric->api_version, FI_VERSION(1, 5)))
+		msg_info->domain_attr->mr_mode = FI_MR_BASIC;
+	else
+		msg_info->domain_attr->mr_mode |= FI_MR_PROV_KEY;
+
 	ret = fi_domain(rxm_fabric->msg_fabric, msg_info,
 			&rxm_domain->msg_domain, context);
 	if (ret)


### PR DESCRIPTION
This patch removes the FI_MR_LOCAL mr_mode requirement from the app.
In case the app supports FI_MR_LOCAL, the provider would prioritize that over
handling memory registrations by itself to provide a better performance.

Also increase large message size form 4k to 16k.