### PR TITLE
prov/sockets: removed unused sock_conn_hdr.cm_data

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -870,7 +870,7 @@ struct sock_conn_hdr {
 	uint8_t reserved[3];
 	uint16_t port;
 	uint16_t cm_data_sz;
-	char cm_data[0];
+	/* cm data follows cm_data_sz */
 };
 
 struct sock_conn_req {


### PR DESCRIPTION
- we are working over building of libfabric by MS compilers,
  and found issue: there are more limitations to zero-based
  arrays than in Linux/Unix compilers.
- the value sock_conn_hdr.cm_data[0] prevents compilation
  of sockets (this not single issue, but other will be fixed
  later) by MS compiler. this value is not used in code and
  may be removed (at least for now)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>