### PR TITLE
header: fixed FI_SHARED_CONTEXT datatype

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -182,7 +182,7 @@ enum {
 #define FI_ADDR_UNSPEC		((uint64_t) -1)
 #define FI_ADDR_NOTAVAIL	((uint64_t) -1)
 #define FI_KEY_NOTAVAIL		((uint64_t) -1)
-#define FI_SHARED_CONTEXT	(-(size_t)1)
+#define FI_SHARED_CONTEXT	SIZE_MAX
 typedef uint64_t		fi_addr_t;
 
 enum fi_av_type {


### PR DESCRIPTION
- FI_SHARED_CONTEXT datatype is forced to size_t
  datatype (to suppress compilation warnings in
  compiler paranoic mode)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>