### PR TITLE
prov/sockets: re-implement complex atomics

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
+#include <complex.h>
 #include <sys/socket.h>
 
 /* MSG_NOSIGNAL doesn't exist on OS X */
@@ -102,5 +103,40 @@ static inline void ofi_osd_init(void)
 static inline void ofi_osd_fini(void)
 {
 }
+
+/* complex operations implementation */
+#define OFI_COMPLEX(name) ofi_##name##_complex
+#define OFI_COMPLEX_OP(name, op) ofi_complex_##name##_##op
+#define OFI_COMPLEX_TYPE_DECL(name, type) typedef type complex OFI_COMPLEX(name);
+
+OFI_COMPLEX_TYPE_DECL(float, float)
+OFI_COMPLEX_TYPE_DECL(double, double)
+OFI_COMPLEX_TYPE_DECL(long_double, long double)
+
+#define OFI_COMPLEX_OPS(name)									      \
+static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, sum)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2) \
+{												      \
+	return v1 + v2;										      \
+}												      \
+static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, mul)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2) \
+{												      \
+	return v1 * v2;										      \
+}												      \
+static inline int OFI_COMPLEX_OP(name, equ)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2)		      \
+{												      \
+	return v1 == v2;                                                                	      \
+}												      \
+static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, land)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2)\
+{												      \
+	return v1 && v2;      									      \
+}												      \
+static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, lor)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2) \
+{												      \
+	return v1 || v2;									      \
+}
+
+OFI_COMPLEX_OPS(float)
+OFI_COMPLEX_OPS(double)
+OFI_COMPLEX_OPS(long_double)
 
 #endif /* _FI_UNIX_OSD_H_ */

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <malloc.h>
 #include <errno.h>
+#include <complex.h>
 #include "pthread.h"
 
 #include <sys/uio.h>
@@ -237,6 +238,64 @@ static inline char * strndup(char const *src, size_t n)
 }
 
 int ofi_shm_unmap(struct util_shm *shm);
+
+/* complex operations implementation */
+#define OFI_COMPLEX(name) ofi_##name##_complex
+#define OFI_COMPLEX_BASE(name) OFI_COMPLEX(name)##_base
+#define OFI_COMPLEX_OP(name, op) ofi_complex_##name##_##op
+#define OFI_COMPLEX_TYPE_DECL(name, type)	\
+typedef type OFI_COMPLEX_BASE(name);		\
+typedef struct {				\
+	OFI_COMPLEX_BASE(name) re;		\
+	OFI_COMPLEX_BASE(name) im;		\
+} OFI_COMPLEX(name);
+
+OFI_COMPLEX_TYPE_DECL(float, float)
+OFI_COMPLEX_TYPE_DECL(double, double)
+OFI_COMPLEX_TYPE_DECL(long_double, long double)
+
+#define OFI_COMPLEX_OPS(name)								\
+static inline OFI_COMPLEX_BASE(name) OFI_COMPLEX_OP(name, real)(OFI_COMPLEX(name) v)	\
+{											\
+	return v.re;									\
+} 											\
+static inline OFI_COMPLEX_BASE(name) OFI_COMPLEX_OP(name, imag)(OFI_COMPLEX(name) v)	\
+{											\
+	return v.im;									\
+}											\
+static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, sum)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2) \
+{											\
+	OFI_COMPLEX(name) ret = {.re = v1.re + v2.re, .im = v1.im + v2.im};		\
+	return ret;									\
+}											\
+static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, mul)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2) \
+{											\
+	OFI_COMPLEX(name) ret = {.re = (v1.re * v2.re) - (v1.im * v2.im),		\
+			      .im = (v1.re * v2.im) + (v1.im * v2.re)};			\
+	return ret;									\
+}											\
+static inline int OFI_COMPLEX_OP(name, equ)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2)	\
+{											\
+	return v1.re == v2.re && v1.im == v2.im;					\
+}											\
+static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, land)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2) \
+{											\
+	OFI_COMPLEX(name) zero = {.re = 0, .im = 0};					\
+	int equ = !OFI_COMPLEX_OP(name, equ)(v1, zero) && !OFI_COMPLEX_OP(name, equ)(v2, zero); \
+	OFI_COMPLEX(name) ret = {.re = equ ? 1.f : 0, .im = 0};				\
+	return ret;									\
+}											\
+static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, lor)(OFI_COMPLEX(name) v1, OFI_COMPLEX(name) v2) \
+{											\
+	OFI_COMPLEX(name) zero = {.re = 0, .im = 0};					\
+	int equ = !OFI_COMPLEX_OP(name, equ)(v1, zero) || !OFI_COMPLEX_OP(name, equ)(v2, zero); \
+	OFI_COMPLEX(name) ret = {.re = equ ? 1.f : 0, .im = 0};				\
+	return ret;									\
+}
+
+OFI_COMPLEX_OPS(float)
+OFI_COMPLEX_OPS(double)
+OFI_COMPLEX_OPS(long_double)
 
 #ifdef __cplusplus
 }

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -978,26 +978,26 @@ out:
 	}								\
 } while (0)
 
-#define SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst) do {		\
+#define SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst, _name) do {	\
 	switch (op) {							\
 	case FI_SUM:							\
 		*_cmp = *_dst;						\
-		*_dst = *_dst + *_src;					\
+		*_dst = OFI_COMPLEX_OP(_name, sum)(*_dst, *_src);		\
 		break;							\
 									\
 	case FI_PROD:							\
 		*_cmp = *_dst;						\
-		*_dst = *_dst * *_src;					\
+		*_dst = OFI_COMPLEX_OP(_name, mul)(*_dst, *_src);		\
 		break;							\
 									\
 	case FI_LOR:							\
 		*_cmp = *_dst;						\
-		*_dst = *_dst || *_src;					\
+		*_dst = OFI_COMPLEX_OP(_name, lor)(*_dst, *_src);		\
 		break;							\
 									\
 	case FI_LAND:							\
 		*_cmp = *_dst;						\
-		*_dst = *_dst && *_src;					\
+		*_dst = OFI_COMPLEX_OP(_name, land)(*_dst, *_src);		\
 		break;							\
 									\
 	case FI_ATOMIC_READ:						\
@@ -1010,7 +1010,7 @@ out:
 		break;							\
 									\
 	case FI_CSWAP:							\
-		if (*_cmp == *_dst)					\
+		if (OFI_COMPLEX_OP(_name, equ)(*_dst, *_src))		\
 			*_dst = *_src;					\
 		else							\
 			*_cmp = *_dst;					\
@@ -1018,7 +1018,7 @@ out:
 									\
 	case FI_CSWAP_NE:						\
 		_tmp = *_dst;						\
-		if (*_cmp != *_dst)					\
+		if (!OFI_COMPLEX_OP(_name, equ)(*_dst, *_src))		\
 			*_dst = *_src;					\
 		*_cmp = _tmp;						\
 		break;							\
@@ -1124,25 +1124,25 @@ static int sock_pe_update_atomic(void *cmp, void *dst, void *src,
 
 	case FI_DOUBLE_COMPLEX:
 	{
-		double complex *_cmp, *_dst, *_src, _tmp;
+		OFI_COMPLEX(double) *_cmp, *_dst, *_src, _tmp;
 		_cmp = cmp, _src = src, _dst = dst;
-		SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst);
+		SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst, double);
 		break;
 	}
 
 	case FI_FLOAT_COMPLEX:
 	{
-		float complex *_cmp, *_dst, *_src, _tmp;
+		OFI_COMPLEX(float) *_cmp, *_dst, *_src, _tmp;
 		_cmp = cmp, _src = src, _dst = dst;
-		SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst);
+		SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst, float);
 		break;
 	}
 
 	case FI_LONG_DOUBLE_COMPLEX:
 	{
-		long double complex *_cmp, *_dst, *_src, _tmp;
+		OFI_COMPLEX(long_double) *_cmp, *_dst, *_src, _tmp;
 		_cmp = cmp, _src = src, _dst = dst;
-		SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst);
+		SOCK_ATOMIC_UPDATE_COMPLEX(_cmp, _src, _dst, long_double);
 		break;
 	}
 

--- a/src/common.c
+++ b/src/common.c
@@ -96,10 +96,10 @@ static const size_t fi_datatype_size_table[] = {
 	[FI_UINT64] = sizeof(uint64_t),
 	[FI_FLOAT]  = sizeof(float),
 	[FI_DOUBLE] = sizeof(double),
-	[FI_FLOAT_COMPLEX]  = sizeof(float complex),
-	[FI_DOUBLE_COMPLEX] = sizeof(double complex),
+	[FI_FLOAT_COMPLEX]  = sizeof(OFI_COMPLEX(float)),
+	[FI_DOUBLE_COMPLEX] = sizeof(OFI_COMPLEX(double)),
 	[FI_LONG_DOUBLE]    = sizeof(long double),
-	[FI_LONG_DOUBLE_COMPLEX] = sizeof(long double complex),
+	[FI_LONG_DOUBLE_COMPLEX] = sizeof(OFI_COMPLEX(long_double)),
 };
 
 size_t fi_datatype_size(enum fi_datatype datatype)


### PR DESCRIPTION
- MS Visual Studio compiler has no complex datatype
  support. to workaround this issue added minimal
  layer to wrap processing of complex datatypes by
  inline functions

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>