### PR TITLE
fabric: Rename auth_keylen to auth_key_size

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -317,7 +317,7 @@ struct fi_ep_attr {
 	uint64_t		mem_tag_format;
 	size_t			tx_ctx_cnt;
 	size_t			rx_ctx_cnt;
-	size_t			auth_keylen;
+	size_t			auth_key_size;
 	uint8_t			*auth_key;
 };
 
@@ -345,7 +345,7 @@ struct fi_domain_attr {
 	uint64_t		caps;
 	uint64_t		mode;
 	uint8_t			*auth_key;
-	size_t 			auth_keylen;
+	size_t 			auth_key_size;
 	size_t			max_err_data;
 };
 

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -103,7 +103,7 @@ struct fi_mr_attr {
 	uint64_t		offset;
 	uint64_t		requested_key;
 	void			*context;
-	size_t			auth_keylen;
+	size_t			auth_key_size;
 	uint8_t			*auth_key;
 };
 

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -131,7 +131,7 @@ struct fi_domain_attr {
 	uint64_t              caps;
 	uint64_t              mode;
 	uint8_t               *auth_key;
-	size_t                auth_keylen;
+	size_t                auth_key_size;
 	size_t                max_err_data;
 };
 ```
@@ -624,10 +624,10 @@ The default authorization key to associate with endpoint and memory
 registrations created within the domain. This field is ignored unless the
 fabric is opened with API version 1.5 or greater.
 
-## Default authorization key length (auth_keylen)
+## Default authorization key length (auth_key_size)
 
-The length of the default authorization key for the domain. If set to 0, then
-no authorization key will be associated with endpoints and memory
+The length in bytes of the default authorization key for the domain. If set to 0,
+then no authorization key will be associated with endpoints and memory
 registrations created within the domain unless specified in the endpoint or
 memory registration attributes. This field is ignored unless the fabric is
 opened with API version 1.5 or greater.

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -544,7 +544,7 @@ struct fi_ep_attr {
 	uint64_t        mem_tag_format;
 	size_t          tx_ctx_cnt;
 	size_t          rx_ctx_cnt;
-	size_t          auth_keylen;
+	size_t          auth_key_size;
 	uint8_t         *auth_key;
 };
 {% endhighlight %}
@@ -763,9 +763,9 @@ fail the request.
 See the scalable endpoint and shared contexts sections for additional
 details.
 
-## auth_keylen - Authorization Key Length
+## auth_key_size - Authorization Key Length
 
-The length of the authorization key.  This field will be 0 if
+The length of the authorization key in bytes.  This field will be 0 if
 authorization keys are not available or used.  This field is ignored 
 unless the fabric is opened with API version 1.5 or greater.
 
@@ -777,7 +777,7 @@ to limit communication between endpoints.  Only peer endpoints that are
 programmed to use the same authorization key may communicate.
 Authorization keys are often used to implement job keys, to ensure
 that processes running in different jobs do not accidentally
-cross traffic.  The domain authorization key will be used if auth_keylen 
+cross traffic.  The domain authorization key will be used if auth_key_size 
 is set to 0.  This field is ignored unless the fabric is opened with API
 version 1.5 or greater. 
 

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -424,7 +424,7 @@ struct fi_mr_attr {
 	uint64_t           access;
 	uint64_t           requested_key;
 	void               *context;
-	size_t             auth_keylen;
+	size_t             auth_key_size;
 	uint8_t            *auth_key;
 };
 ```
@@ -487,9 +487,9 @@ operations.  This value is returned as part of any asynchronous event
 associated with the registration.  This field is ignored for synchronous
 registration calls.
 
-## auth_keylen
+## auth_key_size
 
-The size of key referenced by the auth_key field, or 0 if no authorization
+The size of key referenced by the auth_key field in bytes, or 0 if no authorization
 key is given.  This field is ignored unless the fabric is opened with API
 version 1.5 or greater.
 
@@ -498,7 +498,7 @@ version 1.5 or greater.
 Indicates the key to associate with this memory registration.  Authorization
 keys are used to limit communication between endpoints.  Only peer endpoints
 that are programmed to use the same authorization key may access the memory
-region.  The domain authorization key will be used if the auth_keylen 
+region.  The domain authorization key will be used if the auth_key_size 
 provided is 0.  This field is ignored unless the fabric is opened with API 
 version 1.5 or greater.
 

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -418,10 +418,10 @@ int psmx_ep_open(struct fid_domain *domain, struct fi_info *info,
 		return -FI_EINVAL;
 
 	if (info && info->ep_attr && info->ep_attr->auth_key) {
-		if (info->ep_attr->auth_keylen != sizeof(psm_uuid_t)) {
+		if (info->ep_attr->auth_key_size != sizeof(psm_uuid_t)) {
 			FI_WARN(&psmx_prov, FI_LOG_EP_CTRL,
 				"Invalid auth_key_len %d, should be %d.\n",
-				info->ep_attr->auth_keylen,
+				info->ep_attr->auth_key_size,
 				sizeof(psm_uuid_t));
 			return -FI_EINVAL;
 		}

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -501,10 +501,10 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 		goto errout;
 
 	if (info && info->ep_attr && info->ep_attr->auth_key) {
-		if (info->ep_attr->auth_keylen != sizeof(psm2_uuid_t)) {
+		if (info->ep_attr->auth_key_size != sizeof(psm2_uuid_t)) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"Invalid auth_key_len %d, should be %d.\n",
-				info->ep_attr->auth_keylen,
+				info->ep_attr->auth_key_size,
 				sizeof(psm2_uuid_t));
 			return -FI_EINVAL;
 		}


### PR DESCRIPTION
The new name aligns better with the rest of the API.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>