### PR TITLE
Update FI_COMPLETION description

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -1256,7 +1256,10 @@ value of transmit or receive context attributes of an endpoint.
 
 *FI_COMPLETION*
 : Indicates that a completion entry should be generated for data
-  transfer operations.
+  transfer operations. This flag only applies to operations issued on
+  endpoints that were bound to a CQ or counter with the 
+  FI_SELECTIVE_COMPLETION flag. See the fi_ep_bind section above for more
+  detail.
 
 *FI_INJECT_COMPLETE*
 : Indicates that a completion should be generated when the


### PR DESCRIPTION
Clarify that FI_COMPLETION is only needed in cases where an endpoint was
bound to a CQ or counter with the FI_SELECTIVE_COMPLETION flag.

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>