### PR TITLE
prov/gni: Upstream merge pr1292

### DIFF
--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -66,6 +66,7 @@ typedef enum dom_ops_val { GNI_MSG_RENDEZVOUS_THRESHOLD,
 			   GNI_MR_HARD_STALE_REG_LIMIT,
 			   GNI_XPMEM_ENABLE,
 			   GNI_DGRAM_PROGRESS_TIMEOUT,
+			   GNI_EAGER_AUTO_PROGRESS,
 			   GNI_NUM_DOM_OPS
 } dom_ops_val_t;
 
@@ -125,6 +126,7 @@ struct gnix_ops_domain {
 	int32_t err_inject_count;
 	bool xpmem_enabled;
 	uint32_t dgram_progress_timeout;
+	uint32_t eager_auto_progress;
 };
 
 struct fi_gni_ops_fab {

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -396,10 +396,6 @@ struct gnix_fid_domain {
 	uint32_t addr_format;
 	/* user tunable parameters accessed via open_ops functions */
 	struct gnix_ops_domain params;
-	/* size of gni tx cqs for this domain */
-	uint32_t gni_tx_cq_size;
-	/* size of gni rx cqs for this domain */
-	uint32_t gni_rx_cq_size;
 	/* additional gni cq modes to use for this domain */
 	gni_cq_mode_t gni_cq_modes;
 	/* additional gni cq modes to use for this domain */

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -285,6 +285,7 @@ static const uint32_t default_tx_cq_size = 2048;
 static const uint32_t default_max_retransmits = 5;
 static const int32_t default_err_inject_count; /* static var is zeroed */
 static const uint32_t default_dgram_progress_timeout = 100;
+static const uint32_t default_eager_auto_progress = 0;
 
 static int __gnix_string_to_mr_type(const char *name)
 {
@@ -399,6 +400,9 @@ __gnix_dom_ops_get_val(struct fid *fid, dom_ops_val_t t, void *val)
 	case GNI_DGRAM_PROGRESS_TIMEOUT:
 		*(uint32_t *)val = domain->params.dgram_progress_timeout;
 		break;
+	case GNI_EAGER_AUTO_PROGRESS:
+		*(uint32_t *)val = domain->params.eager_auto_progress;
+		break;
 	default:
 		GNIX_WARN(FI_LOG_DOMAIN, ("Invalid dom_ops_val\n"));
 		return -FI_EINVAL;
@@ -510,6 +514,9 @@ __gnix_dom_ops_set_val(struct fid *fid, dom_ops_val_t t, void *val)
 		break;
 	case GNI_DGRAM_PROGRESS_TIMEOUT:
 		domain->params.dgram_progress_timeout = *(uint32_t *)val;
+		break;
+	case GNI_EAGER_AUTO_PROGRESS:
+		domain->params.eager_auto_progress = *(uint32_t *)val;
 		break;
 	default:
 		GNIX_WARN(FI_LOG_DOMAIN, ("Invalid dom_ops_val\n"));
@@ -635,6 +642,7 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->params.xpmem_enabled = false;
 #endif
 	domain->params.dgram_progress_timeout = default_dgram_progress_timeout;
+	domain->params.eager_auto_progress = default_eager_auto_progress;
 
 	domain->gni_tx_cq_size = default_tx_cq_size;
 	domain->gni_rx_cq_size = default_rx_cq_size;

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -634,6 +634,8 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->params.mbox_num_per_slab = default_mbox_num_per_slab;
 	domain->params.mbox_maxcredit = default_mbox_maxcredit;
 	domain->params.mbox_msg_maxsize = default_mbox_msg_maxsize;
+	domain->params.rx_cq_size = default_rx_cq_size;
+	domain->params.tx_cq_size = default_tx_cq_size;
 	domain->params.max_retransmits = default_max_retransmits;
 	domain->params.err_inject_count = default_err_inject_count;
 #if HAVE_XPMEM
@@ -644,8 +646,6 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->params.dgram_progress_timeout = default_dgram_progress_timeout;
 	domain->params.eager_auto_progress = default_eager_auto_progress;
 
-	domain->gni_tx_cq_size = default_tx_cq_size;
-	domain->gni_rx_cq_size = default_rx_cq_size;
 	domain->gni_cq_modes = gnix_def_gni_cq_modes;
 	_gnix_ref_init(&domain->ref_cnt, 1, __domain_destruct);
 

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -3015,12 +3015,11 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	req->msg.send_info[0].send_len = len;
 	req->msg.cum_send_len = len;
 	req->msg.imm = data;
-	req->flags = 0;
+	req->flags = flags;
 
 	if (flags & FI_INJECT) {
 		memcpy(req->inject_buf, (void *)loc_addr, len);
 		req->msg.send_info[0].send_addr = (uint64_t)req->inject_buf;
-		req->flags |= FI_INJECT;
 	} else {
 		req->msg.send_info[0].send_addr = loc_addr;
 	}
@@ -3387,7 +3386,7 @@ ssize_t _gnix_sendv(struct gnix_fid_ep *ep, const struct iovec *iov,
 	req->gnix_ep = ep;
 	req->user_context = context;
 	req->work_fn = _gnix_send_req;
-	req->flags = 0; /* Flags that apply to all message types? */
+	req->flags = flags;
 	req->msg.send_flags = flags;
 	req->msg.imm = 0;
 

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -1009,17 +1009,17 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 
 		status = GNI_CqCreate(nic->gni_nic_hndl,
 					domain->params.tx_cq_size,
-					0,
-					GNI_CQ_BLOCKING |
-						domain->gni_cq_modes,
-					NULL,
-					NULL,
-					&nic->tx_cq_blk);
+					0,                  /* no delay count */
+					GNI_CQ_NOBLOCK |
+					domain->gni_cq_modes,
+					NULL,              /* useless handler */
+					NULL,               /* useless handler
+								context */
+					&nic->tx_cq);
 		if (status != GNI_RC_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "GNI_CqCreate returned %s\n",
 				  gni_err_str[status]);
-			_gnix_dump_gni_res(domain->ptag);
 			ret = gnixu_to_fi_errno(status);
 			goto err1;
 		}
@@ -1054,16 +1054,15 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 		status = GNI_CqCreate(nic->gni_nic_hndl,
 					domain->params.rx_cq_size,
 					0,
-					GNI_CQ_BLOCKING |
-					domain->gni_cq_modes,
+					GNI_CQ_NOBLOCK |
+						domain->gni_cq_modes,
 					NULL,
 					NULL,
-					&nic->rx_cq_blk);
+					&nic->rx_cq);
 		if (status != GNI_RC_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "GNI_CqCreate returned %s\n",
 				  gni_err_str[status]);
-			_gnix_dump_gni_res(domain->ptag);
 			ret = gnixu_to_fi_errno(status);
 			goto err1;
 		}
@@ -1147,7 +1146,8 @@ int gnix_nic_alloc(struct gnix_fid_domain *domain,
 
 		fastlock_init(&nic->lock);
 
-		ret = __gnix_nic_tx_freelist_init(nic, domain->gni_tx_cq_size);
+		ret = __gnix_nic_tx_freelist_init(nic,
+						  domain->params.tx_cq_size);
 		if (ret != FI_SUCCESS)
 			goto err1;
 


### PR DESCRIPTION
prov/gni: Add domain op to enable trans. CQ IRQs
Enabling CQ IRQs in GNI allows the data auto progress thread to complete all
transaction asynchronously.

This commit also fixes a bug where an fi_send was not handling FI_FENCE
correctly.

Fixes ofi-cray/libfabric-cray#1036
upstream merge of ofi-cray/libfabric-cray#1292

Signed-off-by: Zach <ztiffany@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@dc45400)

Conflicts:
	prov/gni/src/gnix_nic.c