### PR TITLE
utils/atomics: added support of GCC atomics intrinsics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,20 @@ AC_TRY_LINK([#include <stdatomic.h>],
     ],
     [AC_MSG_RESULT(no)])
 
+dnl Check for gcc built-in atomics
+AC_MSG_CHECKING(compiler support for built-in atomics)
+AC_TRY_LINK([#include <stdint.h>],
+    [int32_t a;
+     __sync_add_and_fetch(&a, 0);
+     __sync_sub_and_fetch(&a, 0);
+       return 0;
+    ],
+    [
+	AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_BUILTIN_ATOMICS, 1, [Set to 1 to use built-in intrincics atomics])
+    ],
+    [AC_MSG_RESULT(no)])
+
 if test "$with_valgrind" != "" && test "$with_valgrind" != "no"; then
 AC_CHECK_HEADER(valgrind/memcheck.h, [],
     AC_MSG_ERROR([valgrind requested but <valgrind/memcheck.h> not found.]))

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -33,6 +33,8 @@
 #ifndef _FI_UNIX_OSD_H_
 #define _FI_UNIX_OSD_H_
 
+#include "config.h"
+
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
@@ -138,5 +140,11 @@ static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, lor)(OFI_COMPLEX(name) v1, 
 OFI_COMPLEX_OPS(float)
 OFI_COMPLEX_OPS(double)
 OFI_COMPLEX_OPS(long_double)
+
+/* atomics primitives */
+#ifdef HAVE_BUILTIN_ATOMICS
+#define ofi_atomic_add_and_fetch(radix, ptr, val) __sync_add_and_fetch((ptr), (val))
+#define ofi_atomic_sub_and_fetch(radix, ptr, val) __sync_sub_and_fetch((ptr), (val))
+#endif /* HAVE_BUILTIN_ATOMICS */
 
 #endif /* _FI_UNIX_OSD_H_ */

--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -11,6 +11,9 @@
 /* Set to 1 to use c11 atomic functions */
 /* #undef HAVE_ATOMICS */   /* TODO: add atomics support for windows */
 
+/* Set to 1 to use built-in intrincics atomics */
+#define HAVE_BUILTIN_ATOMICS 1
+
 /* Define to 1 if clock_gettime is available. */
 /* #undef HAVE_CLOCK_GETTIME */
 

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -15,6 +15,8 @@
 #ifndef _FI_WIN_OSD_H_
 #define _FI_WIN_OSD_H_
 
+#include "config.h"
+
 #include <WinSock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>
@@ -296,6 +298,16 @@ static inline OFI_COMPLEX(name) OFI_COMPLEX_OP(name, lor)(OFI_COMPLEX(name) v1, 
 OFI_COMPLEX_OPS(float)
 OFI_COMPLEX_OPS(double)
 OFI_COMPLEX_OPS(long_double)
+
+/* atomics primitives */
+#ifdef HAVE_BUILTIN_ATOMICS
+#define InterlockedAdd32 InterlockedAdd
+typedef LONG ofi_atomic_int_32_t;
+typedef LONGLONG ofi_atomic_int_64_t;
+
+#define ofi_atomic_add_and_fetch(radix, ptr, val) InterlockedAdd##radix((ofi_atomic_int_##radix##_t *)(ptr), (ofi_atomic_int_##radix##_t)(val))
+#define ofi_atomic_sub_and_fetch(radix, ptr, val) InterlockedAdd##radix((ofi_atomic_int_##radix##_t *)(ptr), -(ofi_atomic_int_##radix##_t)(val))
+#endif /* HAVE_BUILTIN_ATOMICS */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
utils/atomics: added support of GCC atomics intrinsics
- GCC version 4+ has built-in intrinsics which may be used
  for atomics ofi atomics implementation. Also added
  configuration script for such intrinsics detection

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>