### PR TITLE
build/linux: fixed build by GCC 4.9.2+ compilers

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@
 
 AM_CPPFLAGS = \
 	-I$(srcdir)/include \
-	-D_GNU_SOURCE \
+	-D_GNU_SOURCE -D__USE_XOPEN2K8 \
 	-DSYSCONFDIR=\"$(sysconfdir)\" \
 	-DRDMADIR=\"@rdmadir@\" \
 	-DPROVDLDIR=\"$(pkglibdir)\"


### PR DESCRIPTION
- gcc compiler 4.9.2+ require __USE_XOPEN2K8 (additionally
  to _GNU_SOURCE) macro to compile string.h header

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>