### PR TITLE
prov/udp+utils: close call is replaced by ofi_close_socket

### DIFF
--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -380,7 +380,7 @@ static int udpx_ep_close(struct fid *fid)
 		ofi_atomic_dec32(&ep->util_ep.tx_cq->ref);
 
 	udpx_rx_cirq_free(ep->rxq);
-	close(ep->sock);
+	ofi_close_socket(ep->sock);
 	ofi_endpoint_close(&ep->util_ep);
 	free(ep);
 	return 0;
@@ -557,7 +557,7 @@ static int udpx_ep_init(struct udpx_ep *ep, struct fi_info *info)
 
 	return 0;
 err2:
-	close(ep->sock);
+	ofi_close_socket(ep->sock);
 err1:
 	udpx_rx_cirq_free(ep->rxq);
 	return ret;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -98,7 +98,7 @@ static int fi_get_src_sockaddr(const struct sockaddr *dest_addr, size_t dest_add
 	}
 
 out:
-	close(sock);
+	ofi_close_socket(sock);
 	return ret;
 
 }


### PR DESCRIPTION
- in udp & util providers calls 'close' were replaced by
  ofi_close_socket wrapper to better fit windows builds

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>