### PR TITLE
win/build: suppressed MS VC C11 specific warnings

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -53,11 +53,11 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;ENABLE_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect</AdditionalIncludeDirectories>
       <CompileAs>CompileAsC</CompileAs>
-      <DisableSpecificWarnings>4127;4200;94</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4127;4200;94;4204;4221</DisableSpecificWarnings>
       <C99Support>true</C99Support>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
@@ -80,7 +80,7 @@
       <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4127;4200;94</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4127;4200;94;4204;4221</DisableSpecificWarnings>
       <C99Support>true</C99Support>
       <ShowIncludes>false</ShowIncludes>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
@@ -141,7 +141,7 @@
     <ClCompile Include="prov\netdir\netdir_fabric.c" />
     <ClCompile Include="prov\netdir\netdir_fs.c" />
     <ClCompile Include="prov\netdir\netdir_init.c" />
-    <ClCompile Include="prov\netdir\netdir_ndinit.c"/>
+    <ClCompile Include="prov\netdir\netdir_ndinit.c" />
     <ClCompile Include="prov\netdir\netdir_pep.c" />
     <ClCompile Include="prov\sockets\src\sock_atomic.c">
       <AdditionalIncludeDirectories Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir)prov\sockets\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>


### PR DESCRIPTION
- due to lack in support of C11 standard by MS VC2015
  compiler it generates a lot of warnings specific to
  structures initialization, like:
  struct type a = {.ptr = &val, .v = b};
  added command line switch to suppress such warnings

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>