### PR TITLE
list: add another entry point to remove an item

### DIFF
--- a/include/fi_list.h
+++ b/include/fi_list.h
@@ -211,6 +211,18 @@ slist_find_first_match(const struct slist *list, slist_func_t *match,
 	return NULL;
 }
 
+static inline void slist_remove(struct slist *list,
+		struct slist_entry *item, struct slist_entry *prev)
+{
+	if (prev)
+		prev->next = item->next;
+	else
+		list->head = item->next;
+
+	if (!item->next)
+		list->tail = prev;
+}
+
 static inline struct slist_entry *
 slist_remove_first_match(struct slist *list, slist_func_t *match, const void *arg)
 {
@@ -218,14 +230,7 @@ slist_remove_first_match(struct slist *list, slist_func_t *match, const void *ar
 
 	slist_foreach(list, item, prev) {
 		if (match(item, arg)) {
-			if (prev)
-				prev->next = item->next;
-			else
-				list->head = item->next;
-
-			if (!item->next)
-				list->tail = prev;
-
+			slist_remove(list, item, prev);
 			return item;
 		}
 	}


### PR DESCRIPTION
A generic remove entry point can be useful to list users,
and just reuses the code from within slist_remove_match

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>