### PR TITLE
prov/netdir: Fix VS C++ compiler warnings

### DIFF
--- a/prov/netdir/netdir_cq.c
+++ b/prov/netdir/netdir_cq.c
@@ -201,11 +201,15 @@ int ofi_nd_cq_open(struct fid_domain *pdomain, struct fi_cq_attr *attr,
 	ND2_ADAPTER_INFO *info = &domain->ainfo;
 
 	cq->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
-	if (!cq->iocp || cq->iocp == INVALID_HANDLE_VALUE)
+	if (!cq->iocp || cq->iocp == INVALID_HANDLE_VALUE) {
+		hr = -FI_EINVAL;
 		goto hr_fail;
+	}
 	cq->err = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
-	if (!cq->err || cq->err == INVALID_HANDLE_VALUE)
+	if (!cq->err || cq->err == INVALID_HANDLE_VALUE) {
+		hr = -FI_EINVAL;
 		goto hr_fail;
+	}
 
 	*pcq_fid = &cq->fid;
 

--- a/prov/netdir/netdir_ep.c
+++ b/prov/netdir/netdir_ep.c
@@ -451,6 +451,7 @@ static void ofi_nd_ep_accepted(nd_event_base *base, DWORD bytes)
 		if (FAILED(hr)) {
 			ND_LOG_WARN(FI_LOG_EP_CTRL,
 				   "failed to complete connection\n");
+			ND_BUF_FREE(nd_ep_completed, compl);
 			goto fn_fail_compl;
 		}
 	}
@@ -462,6 +463,7 @@ static void ofi_nd_ep_accepted(nd_event_base *base, DWORD bytes)
 	if (FAILED(hr)) {
 		ND_LOG_WARN(FI_LOG_EP_CTRL,
 			   "failed to notify disconnect\n");
+		ND_BUF_FREE(nd_ep_completed, compl);
 		goto fn_fail_compl;
 	}
 
@@ -477,7 +479,6 @@ fn_fail_compl:
 		free(ev->data);
 		ev->len = 0;
 	}
-	ND_BUF_FREE(nd_ep_completed, compl);
 	connect->connector->lpVtbl->Release(connect->connector);
 
 fn_fail_data:

--- a/prov/netdir/netdir_init.c
+++ b/prov/netdir/netdir_init.c
@@ -138,7 +138,11 @@ NETDIR_INI
 	fi_param_define(&ofi_nd_prov, "inlinethr", FI_PARAM_INT,
 		"Inline threshold: size of buffer to be send using pre-allocated buffer");
 	fi_param_define(&ofi_nd_prov, "prepostcnt", FI_PARAM_INT,
-		"Prepost Count: number of buffers to be preposted per EP");
+		"Prepost Buffer Count: number of buffers to be preposted per EP and "
+		"not required internal ACK");
+	fi_param_define(&ofi_nd_prov, "prepostbuftcnt", FI_PARAM_INT,
+		"Count of Entries in Array of Preposted Buffers: number of set of buffer "
+		"in each entry array of buffers to be preposted per EP");
 
 	//fi_param_define(&ofi_nd_prov, "presize", FI_PARAM_INT,
 	//	"Pre-post vector size, number of elements in pre-post vector");

--- a/prov/netdir/netdir_ndinit.c
+++ b/prov/netdir/netdir_ndinit.c
@@ -294,7 +294,7 @@ static inline struct module_t *ofi_nd_create_module(const wchar_t* path)
 	HMODULE hmodule = LoadLibraryW(path);
 	if (!hmodule) {
 		ND_LOG_WARN(FI_LOG_CORE,
-			   "ofi_nd_create_module: provider : %S, failed to load: %s",
+			   "ofi_nd_create_module: provider : %S, failed to load: %s\n",
 			   path, ofi_nd_strerror(GetLastError(), 0));
 		return NULL;
 	}
@@ -303,7 +303,7 @@ static inline struct module_t *ofi_nd_create_module(const wchar_t* path)
 	get_class_object_t getclass = (get_class_object_t)GetProcAddress(hmodule, "DllGetClassObject");
 	if (!unload || !getclass) {
 		ND_LOG_WARN(FI_LOG_CORE,
-			   "ofi_nd_create_module: provider: %S, failed to import interface",
+			   "ofi_nd_create_module: provider: %S, failed to import interface\n",
 			   path);
 		goto fn_noiface;
 	}
@@ -332,7 +332,7 @@ static inline HRESULT ofi_nd_create_factory(const WSAPROTOCOL_INFOW* proto)
 	wchar_t *path = ofi_nd_get_provider_path(proto);
 	if (path)
 		ND_LOG_INFO(FI_LOG_CORE,
-			   "ofi_nd_create_factory: provider " FI_ND_GUID_FORMAT " path: %S",
+			   "ofi_nd_create_factory: provider " FI_ND_GUID_FORMAT " path: %S \n",
 			   FI_ND_GUID_ARG(proto->ProviderId), path);
 	else /* can't get provider path. just return */
 		return S_OK;
@@ -594,7 +594,7 @@ HRESULT ofi_nd_startup(ofi_nd_adapter_cb_t cb)
 	if (ofi_nd_startup_done)
 		return S_OK;
 
-	ND_LOG_INFO(FI_LOG_CORE, "ofi_nd_startup: starting initialization");
+	ND_LOG_INFO(FI_LOG_CORE, "ofi_nd_startup: starting initialization\n");
 
 	WSADATA data;
 
@@ -602,7 +602,7 @@ HRESULT ofi_nd_startup(ofi_nd_adapter_cb_t cb)
 	if (ret)
 		return HRESULT_FROM_WIN32(ret);
 
-	ND_LOG_DEBUG(FI_LOG_CORE, "ofi_nd_startup: WSAStartup complete");
+	ND_LOG_DEBUG(FI_LOG_CORE, "ofi_nd_startup: WSAStartup complete\n");
 
 	HRESULT hr = ofi_nd_init(cb);
 

--- a/prov/netdir/netdir_unexp.c
+++ b/prov/netdir/netdir_unexp.c
@@ -234,10 +234,10 @@ void ofi_nd_unexp_match(struct nd_ep *ep)
 
 	int done = 0;
 	do {
-		nd_cq_entry *entry;
+		nd_cq_entry *entry = NULL;
 		nd_cq_entry *ep_entry = NULL;
 		nd_cq_entry *srx_entry = NULL;
-		nd_unexpected_entry *unexp;
+		nd_unexpected_entry *unexp = NULL;
 
 		if (ep->srx)
 			EnterCriticalSection(&ep->srx->prepost_lock);
@@ -307,8 +307,8 @@ void ofi_nd_srx_match(struct nd_srx *srx)
 
 	int done = 0;
 	do {
-		nd_cq_entry *entry;
-		nd_unexpected_entry *unexp;
+		nd_cq_entry *entry = NULL;
+		nd_unexpected_entry *unexp = NULL;
 
 		EnterCriticalSection(&srx->prepost_lock);
 


### PR DESCRIPTION
Update INFO macro in ND provider to be new-line-terminated
Add missed defenition of FI_NETDIR_PREPOSTBUFCNT env variable

Change-Id: I41483fc50ab04617950e50493996cca552bb550e
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>