### PR TITLE
prov/psm,psm2: Keep the provider version up to date

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -74,7 +74,7 @@ extern struct fi_provider psmx_prov;
 
 extern int psmx_am_compat_mode;
 
-#define PSMX_VERSION	(FI_VERSION(1,3))
+#define PSMX_VERSION	(FI_VERSION(1,4))
 
 #define PSMX_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -634,8 +634,8 @@ static void psmx_fini(void)
 
 struct fi_provider psmx_prov = {
 	.name = PSMX_PROV_NAME,
-	.version = FI_VERSION(0, 9),
-	.fi_version = FI_VERSION(1, 3),
+	.version = PSMX_VERSION,
+	.fi_version = PSMX_VERSION,
 	.getinfo = psmx_getinfo,
 	.fabric = psmx_fabric,
 	.cleanup = psmx_fini

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -72,7 +72,7 @@ extern "C" {
 
 extern struct fi_provider psmx2_prov;
 
-#define PSMX2_VERSION	(FI_VERSION(1,3))
+#define PSMX2_VERSION	(FI_VERSION(1,4))
 
 #define PSMX2_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -582,8 +582,8 @@ static void psmx2_fini(void)
 
 struct fi_provider psmx2_prov = {
 	.name = PSMX2_PROV_NAME,
-	.version = FI_VERSION(0, 9),
-	.fi_version = FI_VERSION(1, 3),
+	.version = PSMX2_VERSION,
+	.fi_version = PSMX2_VERSION,
 	.getinfo = psmx2_getinfo,
 	.fabric = psmx2_fabric,
 	.cleanup = psmx2_fini


### PR DESCRIPTION
In addition, use a single version number to avoid confusion and
ease future update.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>