### PR TITLE
Fix a performance issue for large messages when app doesn't support FI_LOCAL_MR

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -164,15 +164,7 @@ struct rxm_unexp_msg {
 	uint64_t tag;
 };
 
-struct rxm_match_iov {
-	struct iovec *iov;
-	void **desc;
-	uint8_t count;
-	size_t index;
-	size_t offset;
-};
-
-struct rxm_iovx_entry {
+struct rxm_iov {
 	struct iovec iov[RXM_IOV_LIMIT];
 	void *desc[RXM_IOV_LIMIT];
 	uint8_t count;
@@ -199,6 +191,7 @@ struct rxm_rx_buf {
 
 	/* Used for large messages */
 	enum rxm_lmt_state state;
+	struct rxm_iov match_iov[RXM_IOV_LIMIT];
 	struct rxm_rma_iov *rma_iov;
 	size_t index;
 	struct fid_mr *mr[RXM_IOV_LIMIT];

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -196,15 +196,14 @@ static void rxm_ep_txrx_res_close(struct rxm_ep *rxm_ep)
 
 int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 {
+	struct rxm_buf hdr = rx_buf->hdr;
+	struct rxm_ep *rxm_ep = rx_buf->ep;
 	void *desc = NULL;
 	int ret;
 
-	rx_buf->conn = NULL;
-	rx_buf->recv_fs = NULL;
-	rx_buf->recv_entry = NULL;
-	memset(&rx_buf->unexp_msg, 0, sizeof(rx_buf->unexp_msg));
-	rx_buf->state = RXM_LMT_NONE;
-	rx_buf->rma_iov = NULL;
+	memset(rx_buf, 0, sizeof(*rx_buf));
+	rx_buf->hdr = hdr;
+	rx_buf->ep = rxm_ep;
 
 	desc = rxm_buf_get_desc(&rx_buf->ep->rx_pool, rx_buf);
 
@@ -227,7 +226,6 @@ int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep)
 		rx_buf->hdr.ctx_type = RXM_RX_BUF;
 		rx_buf->hdr.msg_ep = rxm_ep->srx_ctx;
 		rx_buf->ep = rxm_ep;
-
 		ret = rxm_ep_repost_buf(rx_buf);
 		if (ret) {
 			rxm_buf_release(&rxm_ep->rx_pool, (struct rxm_buf *)rx_buf);


### PR DESCRIPTION
Previously, the entire recv buffer posted was registered. This caused
performance issue when the app wasn't supporting FI_LOCAL_MR and posted a
receive buffer >> received data. Fix the code so that memory registration is
done only for the portion of recv buffer that matches incoming data length.

Other updates: Refactoring of rx_buf reset and rxm_match_iov logic.