### PR TITLE
prov/sockets: fixed init on Windows systems

### DIFF
--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -161,6 +161,9 @@
 /* Define to 1 if pthread_spin_init is available. */
 /* #undef PT_LOCK_SPIN */
 
+/* Define to 1 if adapter info API is defined. */
+#define HAVE_MIB_IPADDRTABLE 1
+
 /* The size of `void *', as computed by sizeof. */
 #ifdef _WIN64
 #define SIZEOF_VOID_P 8

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -115,6 +115,7 @@ do						\
 int fd_set_nonblock(int fd);
 
 int socketpair(int af, int type, int protocol, int socks[2]);
+void sock_get_ip_addr_table(struct slist *addr_list);
 
 static inline int ffsl(long val)
 {

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -66,7 +66,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Synchronization.lib;Ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Synchronization.lib;Ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;iphlpapi.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>libfabric.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>
@@ -91,7 +91,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>Synchronization.lib;Ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Synchronization.lib;Ws2_32.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;iphlpapi.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>libfabric.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -47,6 +47,7 @@
 #endif
 
 #include "prov.h"
+#include "fi_osd.h"
 
 #include "sock.h"
 #include "sock_util.h"
@@ -532,6 +533,12 @@ void sock_get_list_of_addr(struct slist *addr_list)
 		freeifaddrs(ifaddrs);
 	}
 	// Always add loopback address at the end
+	sock_insert_loopback_addr(addr_list);
+}
+#elif defined HAVE_MIB_IPADDRTABLE
+void sock_get_list_of_addr(struct slist *addr_list)
+{
+	sock_get_ip_addr_table(addr_list);
 	sock_insert_loopback_addr(addr_list);
 }
 #else

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -34,9 +34,15 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include <winsock2.h>
+#include <iphlpapi.h>
+
 #include "fi.h"
 #include "fi_osd.h"
 #include "fi_file.h"
+#include "fi_list.h"
+
+#include "prov/sockets/include/sock.h"
 
 #include "rdma/providers/fi_log.h"
 
@@ -349,3 +355,46 @@ fn_nomem:
 	sent = -1;
 	goto fn_complete;
 }
+
+/* enumerate existing addresses */
+/* in case if GetIpAddrTable is not enough, try to use
+   GetAdaptersInfo or GetAdaptersAddresses */
+void sock_get_ip_addr_table(struct slist *addr_list)
+{
+	DWORD i;
+	MIB_IPADDRTABLE _iptbl;
+	MIB_IPADDRTABLE *iptbl = &_iptbl;
+	ULONG ips = 1;
+	ULONG res = GetIpAddrTable(iptbl, &ips, 0);
+	if (res == ERROR_INSUFFICIENT_BUFFER) {
+		iptbl = malloc(ips);
+		if (!iptbl)
+			goto failed_no_mem;
+		res = GetIpAddrTable(iptbl, &ips, 0);
+		if (res != NO_ERROR)
+			goto failed_get_addr;
+	}
+	else if (res != NO_ERROR) {
+		goto failed;
+	}
+
+	for (i = 0; i < iptbl->dwNumEntries; i++) {
+		if (iptbl->table[i].dwAddr && iptbl->table[i].dwAddr != ntohl(INADDR_LOOPBACK)) {
+			struct sock_host_list_entry *addr_entry;
+			addr_entry = calloc(1, sizeof(struct sock_host_list_entry));
+			inet_ntop(AF_INET, &iptbl->table[i].dwAddr, addr_entry->hostname, sizeof(addr_entry->hostname));
+			slist_insert_tail(&addr_entry->entry, addr_list);
+		}
+	}
+
+	if (iptbl != &_iptbl)
+		free(iptbl);
+	return;
+
+failed_get_addr:
+	free(iptbl);
+failed_no_mem:
+failed:
+	return;
+}
+


### PR DESCRIPTION
- due to missing call 'getifaddrs' on Windows systems
  socket provider initialized loopback interface only
  which break inter-node communications
  fix: added enumeration of existing IP interfaces
  using Windows IP helper API to provide same functionality
  as in getifaddrs

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>