### PR TITLE
build/warnings: suppressed tons of warnings

### DIFF
--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -188,7 +188,7 @@ static inline ssize_t ofi_write_socket(int fd, const void *buf, size_t count)
 static inline ssize_t ofi_send_socket(int fd, const void *buf, size_t count,
         int flags)
 {
-	return send(fd, (const char*)buf, count, flags);
+	return send(fd, (const char*)buf, (int)count, flags);
 }
 
 static inline int ofi_close_socket(int socket)

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -57,7 +57,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect</AdditionalIncludeDirectories>
       <CompileAs>CompileAsC</CompileAs>
-      <DisableSpecificWarnings>4127;4200;94;4204;4221</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4127;4200;94;4204;4221;869</DisableSpecificWarnings>
       <C99Support>true</C99Support>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <ExceptionHandling>false</ExceptionHandling>
@@ -80,7 +80,7 @@
       <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect</AdditionalIncludeDirectories>
-      <DisableSpecificWarnings>4127;4200;94;4204;4221</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4127;4200;94;4204;4221;869</DisableSpecificWarnings>
       <C99Support>true</C99Support>
       <ShowIncludes>false</ShowIncludes>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -464,7 +464,8 @@ void rxm_pkt_init(struct rxm_pkt *pkt)
 
 void rxm_ep_msg_mr_closev(struct fid_mr **mr, size_t count)
 {
-	int i, ret;
+	int ret;
+	size_t i;
 
 	for (i = 0; i < count; i++) {
 		if (mr[i]) {

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -312,7 +312,7 @@ static ssize_t sock_ep_atomic_writev(struct fid_ep *ep,
 			uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op, void *context)
 {
-	int i;
+	size_t i;
 	struct fi_msg_atomic msg;
 	struct fi_rma_ioc rma_iov;
 

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -372,7 +372,6 @@ static int sock_ep_cm_setname(fid_t fid, void *addr, size_t addrlen)
 		SOCK_LOG_ERROR("Invalid argument\n");
 		return -FI_EINVAL;
 	}
-	return 0;
 }
 
 static int sock_ep_cm_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)


### PR DESCRIPTION
- suppressed a lot of annoying compilation warnings which
  hides really important warning messages, in general
  suppressed warnings about unused variables,
  signed/unsigned mismatch, type mismatching. No real
  functionality changed

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>