### PR TITLE
prov/verbs: Fix fi_cq_sread and incorrect handling of disconnection event from peer

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -470,38 +470,6 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 	return ret;
 }
 
-#if 0
-static int fi_ibv_ep_sync(fid_t fid, uint64_t flags, void *context)
-{
-	struct fi_ibv_rdm_ep *ep;
-
-	ep = container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
-
-	if (ep->type == FI_EP_MSG) {
-		return 0;
-	} else if (ep->type == FI_EP_RDM) {
-		if (!flags || (flags & FI_SEND)) {
-			while (ep->pend_send) {
-				fi_ibv_rdm_tagged_poll(ep);
-			}
-		}
-
-		if (!flags || (flags & FI_RECV)) {
-			while (ep->pend_recv) {
-				fi_ibv_rdm_tagged_poll(ep);
-			}
-		}
-
-		if (!flags || (flags & FI_READ)) {
-		}
-
-		if (!flags || (flags & FI_WRITE) || (flags & FI_WRITE)) {
-		}
-	}
-	return 0;
-}
-#endif /* 0 */
-
 struct fi_ops fi_ibv_rdm_ep_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = fi_ibv_rdm_ep_close,


### PR DESCRIPTION
1) Add handling of infinite timeout in fi_cq_sread
   - The problem was reproduced in rdm_tagged_peek tests
2) Update handling of disconnection event to cleanup prepost send
queue
   - When there are some send requestes in postponed queue and
   remote side closes the connection between enpoints, this was a
   cause of requests' leak and triggers ASSERT in debug mode
   (during destroying of pool since some resources are busy)
3) Remove unused function

Change-Id: I8ca3c46d7fb5a57094e3c61a6ebf33df211f8112
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>