### PR TITLE
prov/psm2: Add scalable endpoint support

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -338,6 +338,9 @@ struct psmx2_trx_ctxt {
 	int			am_initialized;
 	struct psm2_am_parameters psm2_am_param;
 
+	/* ep bound to this tx/rx context, NULL if multiplexed */
+	struct psmx2_fid_ep	*ep;
+
 	/* incoming req queue for AM based RMA request. */
 	struct psmx2_req_queue	rma_queue;
 
@@ -836,6 +839,8 @@ struct	psmx2_cq_event *psmx2_cq_create_event(struct psmx2_fid_cq *cq,
 int	psmx2_cq_poll_mq(struct psmx2_fid_cq *cq, struct psmx2_fid_domain *domain,
 			struct psmx2_cq_event *event, int count, fi_addr_t *src_addr);
 
+void	psmx2_am_global_init(void);
+void	psmx2_am_global_fini(void);
 int	psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt);
 void	psmx2_am_fini(struct psmx2_trx_ctxt *trx_ctxt);
 int	psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt);
@@ -845,12 +850,14 @@ int	psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 				struct psmx2_am_request *req);
 int	psmx2_process_trigger(struct psmx2_trx_ctxt *trx_ctxt,
 				struct psmx2_trigger *trigger);
-int	psmx2_am_rma_handler(psm2_am_token_t token,
-				psm2_amarg_t *args, int nargs, void *src, uint32_t len);
-int	psmx2_am_atomic_handler(psm2_am_token_t token,
-				psm2_amarg_t *args, int nargs, void *src, uint32_t len);
-void	psmx2_atomic_init(void);
-void	psmx2_atomic_fini(void);
+int	psmx2_am_rma_handler_ext(psm2_am_token_t token,
+				 psm2_amarg_t *args, int nargs, void *src, uint32_t len,
+				 struct psmx2_trx_ctxt *trx_ctxt);
+int	psmx2_am_atomic_handler_ext(psm2_am_token_t token,
+				    psm2_amarg_t *args, int nargs, void *src, uint32_t len,
+				    struct psmx2_trx_ctxt *trx_ctxt);
+void	psmx2_atomic_global_init(void);
+void	psmx2_atomic_global_fini(void);
 
 void	psmx2_am_ack_rma(struct psmx2_am_request *req);
 

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -83,7 +83,8 @@ extern struct fi_provider psmx2_prov;
                          FI_READ | FI_WRITE | FI_SEND | FI_RECV | \
                          FI_REMOTE_READ | FI_REMOTE_WRITE | \
 			 FI_TRIGGER | FI_RMA_EVENT | FI_REMOTE_CQ_DATA | \
-			 FI_SOURCE | FI_SOURCE_ERR | FI_DIRECTED_RECV)
+			 FI_SOURCE | FI_SOURCE_ERR | FI_DIRECTED_RECV | \
+			 FI_NAMED_RX_CTX)
 
 #define PSMX2_SUB_CAPS	(FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE | \
 			 FI_SEND | FI_RECV)
@@ -820,6 +821,8 @@ struct psmx2_env {
 	int timeout;
 	int prog_interval;
 	char *prog_affinity;
+	int sep;
+	int max_trx_ctxt;
 };
 
 extern struct fi_ops_mr		psmx2_mr_ops;
@@ -846,6 +849,8 @@ int	psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			 struct fid_domain **domain, void *context);
 int	psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 		     struct fid_ep **ep, void *context);
+int	psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
+		       struct fid_ep **sep, void *context);
 int	psmx2_stx_ctx(struct fid_domain *domain, struct fi_tx_attr *attr,
 		     struct fid_stx **stx, void *context);
 int	psmx2_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -827,6 +827,7 @@ struct psmx2_env {
 	char *prog_affinity;
 	int sep;
 	int max_trx_ctxt;
+	int num_devunits;
 };
 
 extern struct fi_ops_mr		psmx2_mr_ops;
@@ -941,7 +942,8 @@ int	psmx2_domain_enable_ep(struct psmx2_fid_domain *domain, struct psmx2_fid_ep 
 
 void	psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt);
 struct	psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
-					     struct psmx2_src_name *src_addr);
+					     struct psmx2_src_name *src_addr,
+					     int sep_ctxt_idx);
 
 void	psmx2_ns_start_server(struct psmx2_fid_fabric *fabric);
 void	psmx2_ns_stop_server(struct psmx2_fid_fabric *fabric);

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -808,7 +808,7 @@ struct psmx2_fid_mr {
 };
 
 struct psmx2_epaddr_context {
-	struct psmx2_fid_domain	*domain;
+	struct psmx2_trx_ctxt	*trx_ctxt;
 	psm2_epid_t		epid;
 };
 
@@ -896,8 +896,6 @@ void	psmx2_get_uuid(psm2_uuid_t uuid);
 int	psmx2_uuid_to_port(psm2_uuid_t uuid);
 char	*psmx2_uuid_to_string(psm2_uuid_t uuid);
 int	psmx2_errno(int err);
-int	psmx2_epid_to_epaddr(struct psmx2_fid_domain *domain,
-			    psm2_epid_t epid, psm2_epaddr_t *epaddr);
 void	psmx2_query_mpi(void);
 
 struct	fi_context *psmx2_ep_get_op_context(struct psmx2_fid_ep *ep);
@@ -910,6 +908,9 @@ struct	psmx2_cq_event *psmx2_cq_create_event(struct psmx2_fid_cq *cq,
 					size_t olen, int err);
 int	psmx2_cq_poll_mq(struct psmx2_fid_cq *cq, struct psmx2_fid_domain *domain,
 			struct psmx2_cq_event *event, int count, fi_addr_t *src_addr);
+
+psm2_epaddr_t psmx2_av_translate_sep(struct psmx2_fid_av *av,
+				     struct psmx2_trx_ctxt *trx_ctxt, fi_addr_t addr);
 
 void	psmx2_am_global_init(void);
 void	psmx2_am_global_fini(void);

--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -32,63 +32,56 @@
 
 #include "psmx2.h"
 
-struct psm2_am_parameters psmx2_am_param;
-
-static psm2_am_handler_fn_t psmx2_am_handlers[2] = {
-	psmx2_am_rma_handler,
-	psmx2_am_atomic_handler,
-};
-
-static int psmx2_am_handlers_idx[2];
-static int psmx2_am_handlers_initialized = 0;
-
-int psmx2_am_progress(struct psmx2_fid_domain *domain)
+int psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt)
 {
 	struct slist_entry *item;
 	struct psmx2_am_request *req;
 	struct psmx2_trigger *trigger;
 
 	if (psmx2_env.tagged_rma) {
-		fastlock_acquire(&domain->rma_queue.lock);
-		while (!slist_empty(&domain->rma_queue.list)) {
-			item = slist_remove_head(&domain->rma_queue.list);
+		fastlock_acquire(&trx_ctxt->rma_queue.lock);
+		while (!slist_empty(&trx_ctxt->rma_queue.list)) {
+			item = slist_remove_head(&trx_ctxt->rma_queue.list);
 			req = container_of(item, struct psmx2_am_request, list_entry);
-			fastlock_release(&domain->rma_queue.lock);
-			psmx2_am_process_rma(domain, req);
-			fastlock_acquire(&domain->rma_queue.lock);
+			fastlock_release(&trx_ctxt->rma_queue.lock);
+			psmx2_am_process_rma(trx_ctxt, req);
+			fastlock_acquire(&trx_ctxt->rma_queue.lock);
 		}
-		fastlock_release(&domain->rma_queue.lock);
+		fastlock_release(&trx_ctxt->rma_queue.lock);
 	}
 
-	fastlock_acquire(&domain->trigger_queue.lock);
-	while (!slist_empty(&domain->trigger_queue.list)) {
-		item = slist_remove_head(&domain->trigger_queue.list);
+	fastlock_acquire(&trx_ctxt->trigger_queue.lock);
+	while (!slist_empty(&trx_ctxt->trigger_queue.list)) {
+		item = slist_remove_head(&trx_ctxt->trigger_queue.list);
 		trigger = container_of(item, struct psmx2_trigger, list_entry);
-		fastlock_release(&domain->trigger_queue.lock);
-		psmx2_process_trigger(domain, trigger);
-		fastlock_acquire(&domain->trigger_queue.lock);
+		fastlock_release(&trx_ctxt->trigger_queue.lock);
+		psmx2_process_trigger(trx_ctxt, trigger);
+		fastlock_acquire(&trx_ctxt->trigger_queue.lock);
 	}
-	fastlock_release(&domain->trigger_queue.lock);
+	fastlock_release(&trx_ctxt->trigger_queue.lock);
 
 	return 0;
 }
 
-int psmx2_am_init(struct psmx2_fid_domain *domain)
+int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 {
-	psm2_ep_t psm2_ep = domain->psm2_ep;
+	psm2_am_handler_fn_t psmx2_am_handlers[2];
+	int psmx2_am_handlers_idx[2];
+	psm2_ep_t psm2_ep = trx_ctxt->psm2_ep;
 	size_t size;
 	int err = 0;
 
 	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
 
-	psmx2_atomic_init();
-
-	if (!psmx2_am_handlers_initialized) {
-		err = psm2_am_get_parameters(psm2_ep, &psmx2_am_param,
-					     sizeof(psmx2_am_param), &size);
+	if (!trx_ctxt->am_initialized) {
+		err = psm2_am_get_parameters(psm2_ep, &trx_ctxt->psm2_am_param,
+					     sizeof(struct psm2_am_parameters),
+					     &size);
 		if (err)
 			return psmx2_errno(err);
 
+		psmx2_am_handlers[0] = psmx2_am_rma_handler;
+		psmx2_am_handlers[1] = psmx2_am_atomic_handler;
 		err = psm2_am_register_handlers(psm2_ep, psmx2_am_handlers, 2,
 						psmx2_am_handlers_idx);
 		if (err)
@@ -103,24 +96,14 @@ int psmx2_am_init(struct psmx2_fid_domain *domain)
 			return -FI_EBUSY;
 		}
 
-		psmx2_am_handlers_initialized = 1;
+		trx_ctxt->am_initialized = 1;
 	}
-
-	slist_init(&domain->rma_queue.list);
-	slist_init(&domain->trigger_queue.list);
-	fastlock_init(&domain->rma_queue.lock);
-	fastlock_init(&domain->trigger_queue.lock);
 
 	return err;
 }
 
-int psmx2_am_fini(struct psmx2_fid_domain *domain)
+void psmx2_am_fini(struct psmx2_trx_ctxt *trx_ctxt)
 {
-	fastlock_destroy(&domain->rma_queue.lock);
-	fastlock_destroy(&domain->trigger_queue.lock);
-
-	psmx2_atomic_fini();
-
-	return 0;
+	trx_ctxt->am_initialized = 0;
 }
 

--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -269,8 +269,9 @@ int psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt)
 
 int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 {
-	psm2_am_handler_fn_t psmx2_am_handlers[2];
-	int psmx2_am_handlers_idx[2];
+	psm2_am_handler_fn_t psmx2_am_handlers[3];
+	int psmx2_am_handlers_idx[3];
+	int num_handlers = 3;
 	psm2_ep_t psm2_ep = trx_ctxt->psm2_ep;
 	size_t size;
 	int err = 0;
@@ -297,20 +298,22 @@ int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 		idx = psmx2_am_global.cnt++;
 		psmx2_am_handlers[0] = psmx2_am_global.rma_handlers[idx];
 		psmx2_am_handlers[1] = psmx2_am_global.atomic_handlers[idx];
+		psmx2_am_handlers[2] = psmx2_am_sep_handler;
 		psmx2_am_global.trx_ctxts[idx] = trx_ctxt;
 		fastlock_release(&psmx2_am_global.lock);
 
-		err = psm2_am_register_handlers(psm2_ep, psmx2_am_handlers, 2,
-						psmx2_am_handlers_idx);
+		err = psm2_am_register_handlers(psm2_ep, psmx2_am_handlers,
+						num_handlers, psmx2_am_handlers_idx);
 		if (err)
 			return psmx2_errno(err);
 
 		if ((psmx2_am_handlers_idx[0] != PSMX2_AM_RMA_HANDLER) ||
-		    (psmx2_am_handlers_idx[1] != PSMX2_AM_ATOMIC_HANDLER)) {
+		    (psmx2_am_handlers_idx[1] != PSMX2_AM_ATOMIC_HANDLER) ||
+		    (psmx2_am_handlers_idx[2] != PSMX2_AM_SEP_HANDLER)) {
 			FI_WARN(&psmx2_prov, FI_LOG_CORE,
 				"failed to register one or more AM handlers "
-				"at indecies %d, %d\n", PSMX2_AM_RMA_HANDLER,
-				PSMX2_AM_ATOMIC_HANDLER);
+				"at indecies %d, %d, %d\n", PSMX2_AM_RMA_HANDLER,
+				PSMX2_AM_ATOMIC_HANDLER, PSMX2_AM_SEP_HANDLER);
 			return -FI_EBUSY;
 		}
 

--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -32,6 +32,210 @@
 
 #include "psmx2.h"
 
+#define PSMX2_AM_MAX_TRX_CTXT 80
+static struct {
+	struct psmx2_trx_ctxt *trx_ctxts[PSMX2_AM_MAX_TRX_CTXT];
+	psm2_am_handler_fn_t rma_handlers[PSMX2_AM_MAX_TRX_CTXT];
+	psm2_am_handler_fn_t atomic_handlers[PSMX2_AM_MAX_TRX_CTXT];
+	fastlock_t lock;
+	int cnt;
+} psmx2_am_global;
+
+#define DEFINE_AM_HANDLERS(INDEX) \
+	static int psmx2_am_rma_handler_##INDEX( \
+			psm2_am_token_t token, psm2_amarg_t *args, \
+			int nargs, void *src, uint32_t len) \
+	{ \
+		return psmx2_am_rma_handler_ext( \
+				token, args, nargs, src, len, \
+				psmx2_am_global.trx_ctxts[INDEX]); \
+	} \
+	\
+	static int psmx2_am_atomic_handler_##INDEX( \
+			psm2_am_token_t token, psm2_amarg_t *args, \
+			int nargs, void *src, uint32_t len) \
+	{ \
+		return psmx2_am_atomic_handler_ext( \
+				token, args, nargs, src, len, \
+				psmx2_am_global.trx_ctxts[INDEX]); \
+	}
+
+DEFINE_AM_HANDLERS(0)
+DEFINE_AM_HANDLERS(1)
+DEFINE_AM_HANDLERS(2)
+DEFINE_AM_HANDLERS(3)
+DEFINE_AM_HANDLERS(4)
+DEFINE_AM_HANDLERS(5)
+DEFINE_AM_HANDLERS(6)
+DEFINE_AM_HANDLERS(7)
+DEFINE_AM_HANDLERS(8)
+DEFINE_AM_HANDLERS(9)
+DEFINE_AM_HANDLERS(10)
+DEFINE_AM_HANDLERS(11)
+DEFINE_AM_HANDLERS(12)
+DEFINE_AM_HANDLERS(13)
+DEFINE_AM_HANDLERS(14)
+DEFINE_AM_HANDLERS(15)
+DEFINE_AM_HANDLERS(16)
+DEFINE_AM_HANDLERS(17)
+DEFINE_AM_HANDLERS(18)
+DEFINE_AM_HANDLERS(19)
+DEFINE_AM_HANDLERS(20)
+DEFINE_AM_HANDLERS(21)
+DEFINE_AM_HANDLERS(22)
+DEFINE_AM_HANDLERS(23)
+DEFINE_AM_HANDLERS(24)
+DEFINE_AM_HANDLERS(25)
+DEFINE_AM_HANDLERS(26)
+DEFINE_AM_HANDLERS(27)
+DEFINE_AM_HANDLERS(28)
+DEFINE_AM_HANDLERS(29)
+DEFINE_AM_HANDLERS(30)
+DEFINE_AM_HANDLERS(31)
+DEFINE_AM_HANDLERS(32)
+DEFINE_AM_HANDLERS(33)
+DEFINE_AM_HANDLERS(34)
+DEFINE_AM_HANDLERS(35)
+DEFINE_AM_HANDLERS(36)
+DEFINE_AM_HANDLERS(37)
+DEFINE_AM_HANDLERS(38)
+DEFINE_AM_HANDLERS(39)
+DEFINE_AM_HANDLERS(40)
+DEFINE_AM_HANDLERS(41)
+DEFINE_AM_HANDLERS(42)
+DEFINE_AM_HANDLERS(43)
+DEFINE_AM_HANDLERS(44)
+DEFINE_AM_HANDLERS(45)
+DEFINE_AM_HANDLERS(46)
+DEFINE_AM_HANDLERS(47)
+DEFINE_AM_HANDLERS(48)
+DEFINE_AM_HANDLERS(49)
+DEFINE_AM_HANDLERS(50)
+DEFINE_AM_HANDLERS(51)
+DEFINE_AM_HANDLERS(52)
+DEFINE_AM_HANDLERS(53)
+DEFINE_AM_HANDLERS(54)
+DEFINE_AM_HANDLERS(55)
+DEFINE_AM_HANDLERS(56)
+DEFINE_AM_HANDLERS(57)
+DEFINE_AM_HANDLERS(58)
+DEFINE_AM_HANDLERS(59)
+DEFINE_AM_HANDLERS(60)
+DEFINE_AM_HANDLERS(61)
+DEFINE_AM_HANDLERS(62)
+DEFINE_AM_HANDLERS(63)
+DEFINE_AM_HANDLERS(64)
+DEFINE_AM_HANDLERS(65)
+DEFINE_AM_HANDLERS(66)
+DEFINE_AM_HANDLERS(67)
+DEFINE_AM_HANDLERS(68)
+DEFINE_AM_HANDLERS(69)
+DEFINE_AM_HANDLERS(70)
+DEFINE_AM_HANDLERS(71)
+DEFINE_AM_HANDLERS(72)
+DEFINE_AM_HANDLERS(73)
+DEFINE_AM_HANDLERS(74)
+DEFINE_AM_HANDLERS(75)
+DEFINE_AM_HANDLERS(76)
+DEFINE_AM_HANDLERS(77)
+DEFINE_AM_HANDLERS(78)
+DEFINE_AM_HANDLERS(79)
+
+#define ASSIGN_AM_HANDLERS(INDEX) \
+	psmx2_am_global.rma_handlers[INDEX] =  psmx2_am_rma_handler_##INDEX; \
+	psmx2_am_global.atomic_handlers[INDEX] =  psmx2_am_atomic_handler_##INDEX;
+
+void psmx2_am_global_init(void)
+{
+	fastlock_init(&psmx2_am_global.lock);
+
+	ASSIGN_AM_HANDLERS(0)
+	ASSIGN_AM_HANDLERS(1)
+	ASSIGN_AM_HANDLERS(2)
+	ASSIGN_AM_HANDLERS(3)
+	ASSIGN_AM_HANDLERS(4)
+	ASSIGN_AM_HANDLERS(5)
+	ASSIGN_AM_HANDLERS(6)
+	ASSIGN_AM_HANDLERS(7)
+	ASSIGN_AM_HANDLERS(8)
+	ASSIGN_AM_HANDLERS(9)
+	ASSIGN_AM_HANDLERS(10)
+	ASSIGN_AM_HANDLERS(11)
+	ASSIGN_AM_HANDLERS(12)
+	ASSIGN_AM_HANDLERS(13)
+	ASSIGN_AM_HANDLERS(14)
+	ASSIGN_AM_HANDLERS(15)
+	ASSIGN_AM_HANDLERS(16)
+	ASSIGN_AM_HANDLERS(17)
+	ASSIGN_AM_HANDLERS(18)
+	ASSIGN_AM_HANDLERS(19)
+	ASSIGN_AM_HANDLERS(20)
+	ASSIGN_AM_HANDLERS(21)
+	ASSIGN_AM_HANDLERS(22)
+	ASSIGN_AM_HANDLERS(23)
+	ASSIGN_AM_HANDLERS(24)
+	ASSIGN_AM_HANDLERS(25)
+	ASSIGN_AM_HANDLERS(26)
+	ASSIGN_AM_HANDLERS(27)
+	ASSIGN_AM_HANDLERS(28)
+	ASSIGN_AM_HANDLERS(29)
+	ASSIGN_AM_HANDLERS(30)
+	ASSIGN_AM_HANDLERS(31)
+	ASSIGN_AM_HANDLERS(32)
+	ASSIGN_AM_HANDLERS(33)
+	ASSIGN_AM_HANDLERS(34)
+	ASSIGN_AM_HANDLERS(35)
+	ASSIGN_AM_HANDLERS(36)
+	ASSIGN_AM_HANDLERS(37)
+	ASSIGN_AM_HANDLERS(38)
+	ASSIGN_AM_HANDLERS(39)
+	ASSIGN_AM_HANDLERS(40)
+	ASSIGN_AM_HANDLERS(41)
+	ASSIGN_AM_HANDLERS(42)
+	ASSIGN_AM_HANDLERS(43)
+	ASSIGN_AM_HANDLERS(44)
+	ASSIGN_AM_HANDLERS(45)
+	ASSIGN_AM_HANDLERS(46)
+	ASSIGN_AM_HANDLERS(47)
+	ASSIGN_AM_HANDLERS(48)
+	ASSIGN_AM_HANDLERS(49)
+	ASSIGN_AM_HANDLERS(50)
+	ASSIGN_AM_HANDLERS(51)
+	ASSIGN_AM_HANDLERS(52)
+	ASSIGN_AM_HANDLERS(53)
+	ASSIGN_AM_HANDLERS(54)
+	ASSIGN_AM_HANDLERS(55)
+	ASSIGN_AM_HANDLERS(56)
+	ASSIGN_AM_HANDLERS(57)
+	ASSIGN_AM_HANDLERS(58)
+	ASSIGN_AM_HANDLERS(59)
+	ASSIGN_AM_HANDLERS(60)
+	ASSIGN_AM_HANDLERS(61)
+	ASSIGN_AM_HANDLERS(62)
+	ASSIGN_AM_HANDLERS(63)
+	ASSIGN_AM_HANDLERS(64)
+	ASSIGN_AM_HANDLERS(65)
+	ASSIGN_AM_HANDLERS(66)
+	ASSIGN_AM_HANDLERS(67)
+	ASSIGN_AM_HANDLERS(68)
+	ASSIGN_AM_HANDLERS(69)
+	ASSIGN_AM_HANDLERS(70)
+	ASSIGN_AM_HANDLERS(71)
+	ASSIGN_AM_HANDLERS(72)
+	ASSIGN_AM_HANDLERS(73)
+	ASSIGN_AM_HANDLERS(74)
+	ASSIGN_AM_HANDLERS(75)
+	ASSIGN_AM_HANDLERS(76)
+	ASSIGN_AM_HANDLERS(77)
+	ASSIGN_AM_HANDLERS(78)
+	ASSIGN_AM_HANDLERS(79)
+}
+
+void psmx2_am_global_fini(void)
+{
+	fastlock_destroy(&psmx2_am_global.lock);
+}
+
 int psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt)
 {
 	struct slist_entry *item;
@@ -70,6 +274,7 @@ int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 	psm2_ep_t psm2_ep = trx_ctxt->psm2_ep;
 	size_t size;
 	int err = 0;
+	int idx;
 
 	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
 
@@ -80,8 +285,21 @@ int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 		if (err)
 			return psmx2_errno(err);
 
-		psmx2_am_handlers[0] = psmx2_am_rma_handler;
-		psmx2_am_handlers[1] = psmx2_am_atomic_handler;
+		fastlock_acquire(&psmx2_am_global.lock);
+		if (psmx2_am_global.cnt >= PSMX2_AM_MAX_TRX_CTXT) {
+			fastlock_release(&psmx2_am_global.lock);
+			FI_WARN(&psmx2_prov, FI_LOG_CORE,
+				"number of PSM2 endpoints exceed limit %d.\n"
+				"at indecies %d, %d\n", PSMX2_AM_MAX_TRX_CTXT);
+			return -FI_EBUSY;
+		}
+
+		idx = psmx2_am_global.cnt++;
+		psmx2_am_handlers[0] = psmx2_am_global.rma_handlers[idx];
+		psmx2_am_handlers[1] = psmx2_am_global.atomic_handlers[idx];
+		psmx2_am_global.trx_ctxts[idx] = trx_ctxt;
+		fastlock_release(&psmx2_am_global.lock);
+
 		err = psm2_am_register_handlers(psm2_ep, psmx2_am_handlers, 2,
 						psmx2_am_handlers_idx);
 		if (err)
@@ -104,6 +322,6 @@ int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 
 void psmx2_am_fini(struct psmx2_trx_ctxt *trx_ctxt)
 {
-	trx_ctxt->am_initialized = 0;
+	/* there is no way to unregister AM handlers */
 }
 

--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -32,7 +32,7 @@
 
 #include "psmx2.h"
 
-#define PSMX2_AM_MAX_TRX_CTXT 80
+#define PSMX2_AM_MAX_TRX_CTXT PSMX2_MAX_TRX_CTXT
 static struct {
 	struct psmx2_trx_ctxt *trx_ctxts[PSMX2_AM_MAX_TRX_CTXT];
 	psm2_am_handler_fn_t rma_handlers[PSMX2_AM_MAX_TRX_CTXT];

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -855,7 +855,10 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 		return -FI_EINVAL;
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;
@@ -990,7 +993,10 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 		return -FI_EINVAL;
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;
@@ -1219,7 +1225,10 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 		return -FI_EINVAL;
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;
@@ -1384,7 +1393,10 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 		return -FI_EINVAL;
 	
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;
@@ -1671,7 +1683,10 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 		return -FI_EINVAL;
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;
@@ -1850,7 +1865,10 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 		return -FI_EINVAL;
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -32,6 +32,142 @@
 
 #include "psmx2.h"
 
+static void psmx2_av_post_completion(struct psmx2_fid_av *av, void *context,
+				     uint64_t data, int prov_errno);
+
+/*
+ * SEP address query protocol:
+ *
+ * SEQ Query REQ:
+ *	args[0].u32w0	cmd
+ *	args[0].u32w1	id
+ *	args[1].u64	req
+ *	args[2].u64	av_idx
+ *
+ * SEP Query REP:
+ *	args[0].u32w0	cmd
+ *	args[0].u32w1	error
+ *	args[1].u64	req
+ *	args[2].u64	av_idx
+ *	args[3].u64	n
+ *	data		epaddrs
+ */
+
+struct psmx2_sep_query {
+	struct psmx2_fid_av	*av;
+	void 			*context;
+	psm2_error_t		*errors;
+	ofi_atomic32_t		error_count;
+	ofi_atomic32_t		pending;
+};
+
+static int psmx2_am_sep_match(struct dlist_entry *entry, const void *arg)
+{
+	struct psmx2_fid_sep *sep;
+
+	sep = container_of(entry, struct psmx2_fid_sep, entry);
+	return ((uintptr_t)sep->id == (uintptr_t)arg);
+}
+
+static void psmx2_am_sep_completion(void *buf)
+{
+	free(buf);
+}
+
+int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
+			 int nargs, void *src, uint32_t len)
+{
+	struct psmx2_fid_domain *domain;
+	psm2_amarg_t rep_args[8];
+	int op_error = 0;
+	int err = 0;
+	int cmd;
+	int n, i, j;
+	uint8_t sep_id;
+	struct psmx2_fid_sep *sep;
+	struct psmx2_sep_addr *p;
+	struct psmx2_sep_query *req;
+	struct psmx2_fid_av *av;
+	psm2_epid_t *buf = NULL;
+	int buflen;
+	struct dlist_entry *entry;
+
+	cmd = PSMX2_AM_GET_OP(args[0].u32w0);
+	domain = psmx2_active_fabric->active_domain;
+
+	switch (cmd) {
+	case PSMX2_AM_REQ_SEP_QUERY:
+		sep_id = args[0].u32w1;
+		fastlock_acquire(&domain->sep_lock);
+		entry = dlist_find_first_match(&domain->sep_list, psmx2_am_sep_match,
+					       (void *)(uintptr_t)sep_id);
+		if (!entry) {
+			op_error = PSM2_EPID_UNKNOWN;
+			n = 0;
+			buflen = 0;
+		} else {
+			sep = container_of(entry, struct psmx2_fid_sep, entry);
+			n = sep->ctxt_cnt;
+			buflen = n * sizeof(psm2_epid_t);
+			if (n) {
+				buf = malloc(buflen);
+				if (!buf) {
+					op_error = -FI_ENOMEM;
+					buflen = 0;
+					n = 0;
+				}
+				for (i=0; i< n; i++)
+					buf[i] = sep->ctxts[i].trx_ctxt->psm2_epid;
+			}
+		}
+		fastlock_release(&domain->sep_lock);
+
+		rep_args[0].u32w0 = PSMX2_AM_REP_SEP_QUERY;
+		rep_args[0].u32w1 = op_error;
+		rep_args[1].u64 = args[1].u64;
+		rep_args[2].u64 = args[2].u64;
+		rep_args[3].u64 = n;
+		err = psm2_am_reply_short(token, PSMX2_AM_SEP_HANDLER,
+					  rep_args, 4, buf, buflen, 0,
+					  psmx2_am_sep_completion, buf);
+		break;
+
+	case PSMX2_AM_REP_SEP_QUERY:
+		op_error = args[0].u32w1;
+		req = (void *)(uintptr_t)args[1].u64;
+		av = req->av;
+		i = args[2].u64;
+		if (op_error) {
+			ofi_atomic_inc32(&req->error_count);
+			if (av->flags & FI_EVENT)
+				psmx2_av_post_completion(av, req->context, i, op_error);
+		} else {
+			n = args[3].u64;
+			p  = calloc(1, sizeof (struct psmx2_sep_addr) +
+				       n * sizeof(struct psmx2_ctxt_addr));
+			if (!p) {
+				ofi_atomic_inc32(&req->error_count);
+				req->errors[i] = PSM2_NO_MEMORY;
+			} else {
+				p->ctxt_cnt = n;
+				for (j=0; j<n; j++) {
+					p->ctxt_addrs[j].epid = ((psm2_epid_t *)src)[j];
+					p->ctxt_addrs[j].epaddr = (psm2_epaddr_t)FI_ADDR_NOTAVAIL;
+				}
+				av->sepaddrs[i] = p;
+			}
+		}
+		ofi_atomic_dec32(&req->pending);
+		break;
+
+	default:
+		err = -FI_EINVAL;
+		break;
+	}
+
+	return err;
+}
+
 #define PSMX2_MIN_CONN_TIMEOUT	5
 #define PSMX2_MAX_CONN_TIMEOUT	30
 
@@ -102,12 +238,38 @@ int psmx2_epid_to_epaddr(struct psmx2_fid_domain *domain,
         return 0;
 }
 
+fi_addr_t psmx2_av_translate_sep(struct psmx2_fid_av *av, fi_addr_t addr)
+{
+	int idx = PSMX2_SEP_ADDR_IDX(addr);
+	int ctxt = PSMX2_SEP_ADDR_CTXT(addr, av->rx_ctx_bits);
+	psm2_epaddr_t epaddr;
+	int err;
+
+	if (!av->sepaddrs[idx])
+		return FI_ADDR_NOTAVAIL;
+
+	if (ctxt >= av->sepaddrs[idx]->ctxt_cnt)
+		return FI_ADDR_NOTAVAIL;
+
+	if ((fi_addr_t)av->sepaddrs[idx]->ctxt_addrs[ctxt].epaddr == FI_ADDR_NOTAVAIL) {
+		err = psmx2_epid_to_epaddr(av->domain,
+					   av->sepaddrs[idx]->ctxt_addrs[ctxt].epid,
+					   &epaddr);
+		if (!err)
+			av->sepaddrs[idx]->ctxt_addrs[ctxt].epaddr = epaddr;
+	}
+
+	return (fi_addr_t)av->sepaddrs[idx]->ctxt_addrs[ctxt].epaddr;
+}
+
 static int psmx2_av_check_table_size(struct psmx2_fid_av *av, size_t count)
 {
 	size_t new_count;
 	psm2_epid_t *new_epids;
 	psm2_epaddr_t *new_epaddrs;
 	uint8_t *new_vlanes;
+	uint8_t *new_types;
+	struct psmx2_sep_addr **new_sepaddrs;
 
 	new_count = av->count;
 	while (new_count < av->last + count)
@@ -131,6 +293,18 @@ static int psmx2_av_check_table_size(struct psmx2_fid_av *av, size_t count)
 		return -FI_ENOMEM;
 
 	av->vlanes = new_vlanes;
+	new_types = realloc(av->types, new_count * sizeof(*new_types));
+	if (!new_types)
+		return -FI_ENOMEM;
+
+	av->types = new_types;
+
+	new_sepaddrs = realloc(av->sepaddrs, new_count * sizeof(*new_sepaddrs));
+	if (!new_sepaddrs)
+		return -FI_ENOMEM;
+
+	av->sepaddrs = new_sepaddrs;
+
 	av->count = new_count;
 	return 0;
 }
@@ -231,6 +405,66 @@ static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
 	return error_count;
 }
 
+static int psmx2_av_query_seps(struct psmx2_fid_av *av, size_t count, psm2_epid_t *epids,
+			       uint8_t *sep_ids, uint8_t *types, psm2_error_t *errors,
+			       psm2_epaddr_t *epaddrs, void *context)
+{
+	struct psmx2_sep_query *req;
+	psm2_amarg_t args[8];
+	int error_count = 0;
+	int i;
+
+	req = malloc(sizeof *req);
+
+	if (req) {
+		req->av = av;
+		req->context = context;
+		req->errors = errors;
+		ofi_atomic_initialize32(&req->error_count, 0);
+		ofi_atomic_initialize32(&req->pending, 0);
+	}
+
+	for (i=0; i<count; i++) {
+		if (types[i] != PSMX2_EP_SCALABLE)
+			continue;
+
+		if (errors[i] != PSM2_OK)
+			continue;
+
+		if (av->sepaddrs[i])
+			continue;
+
+		if (!req) {
+			errors[i] = PSM2_NO_MEMORY;
+			error_count++;
+			continue;
+		}
+
+		ofi_atomic_inc32(&req->pending);
+		args[0].u32w0 = PSMX2_AM_REQ_SEP_QUERY;
+		args[0].u32w1 = sep_ids[i];
+		args[1].u64 = (uint64_t)(uintptr_t)req;
+		args[2].u64 = i;
+		psm2_am_request_short(epaddrs[i], PSMX2_AM_SEP_HANDLER,
+				      args, 3, NULL, 0, 0, NULL, NULL);
+	}
+
+	/*
+	 * make it synchronous for now to:
+	 * (1) ensure array "req->errors" is valid;
+	 * (2) to simplify the logic of generating the final completion event.
+	 */
+	while (ofi_atomic_get32(&req->pending))
+		psmx2_progress(av->domain);
+
+	if (req) {
+		error_count = ofi_atomic_get32(&req->error_count);
+		free(req);
+	}
+
+	return error_count;
+}
+
 static int psmx2_av_insert(struct fid_av *av, const void *addr,
 			   size_t count, fi_addr_t *fi_addr,
 			   uint64_t flags, void *context)
@@ -238,6 +472,8 @@ static int psmx2_av_insert(struct fid_av *av, const void *addr,
 	struct psmx2_fid_av *av_priv;
 	psm2_epid_t *epids;
 	uint8_t *vlanes;
+	uint8_t *types;
+	struct psmx2_sep_addr **sepaddrs;
 	psm2_epaddr_t *epaddrs;
 	psm2_error_t *errors;
 	int *mask;
@@ -262,10 +498,14 @@ static int psmx2_av_insert(struct fid_av *av, const void *addr,
 	epids = av_priv->epids + av_priv->last;
 	epaddrs = av_priv->epaddrs + av_priv->last;
 	vlanes = av_priv->vlanes + av_priv->last;
+	types = av_priv->types + av_priv->last;
+	sepaddrs = av_priv->sepaddrs + av_priv->last;
 
 	for (i=0; i<count; i++) {
 		epids[i] = names[i].epid;
 		vlanes[i] = names[i].vlane;
+		types[i] = names[i].type;
+		sepaddrs[i] = NULL;
 	}
 
 	errors = (psm2_error_t *) calloc(count, sizeof *errors);
@@ -279,10 +519,15 @@ static int psmx2_av_insert(struct fid_av *av, const void *addr,
 	error_count = psmx2_av_connect_eps(av_priv, count, epids, mask,
 					   errors, epaddrs, context);
 
+	error_count += psmx2_av_query_seps(av_priv, count, epids, vlanes, types,
+					   errors, epaddrs, context);
+
 	if (fi_addr) {
 		for (i=0; i<count; i++) {
 			if (epaddrs[i] == (void *)FI_ADDR_NOTAVAIL)
 				fi_addr[i] = FI_ADDR_NOTAVAIL;
+			else if (types[i] == PSMX2_EP_SCALABLE)
+				fi_addr[i] = (av_priv->last + i) | PSMX2_SEP_ADDR_FLAG;
 			else if (av_priv->type == FI_AV_TABLE)
 				fi_addr[i] = av_priv->last + i;
 			else
@@ -397,12 +642,17 @@ static const char *psmx2_av_straddr(struct fid_av *av, const void *addr,
 static int psmx2_av_close(fid_t fid)
 {
 	struct psmx2_fid_av *av;
+	int i;
 
 	av = container_of(fid, struct psmx2_fid_av, av.fid);
 	psmx2_domain_release(av->domain);
 	free(av->epids);
 	free(av->epaddrs);
 	free(av->vlanes);
+	free(av->types);
+	for (i=0; i<av->last; i++)
+		free(av->sepaddrs[i]);
+	free(av->sepaddrs);
 	free(av);
 	return 0;
 }
@@ -454,6 +704,7 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	int type = FI_AV_MAP;
 	size_t count = 64;
 	uint64_t flags = 0;
+	int rx_ctx_bits = PSMX2_MAX_RX_CTX_BITS;
 
 	domain_priv = container_of(domain, struct psmx2_fid_domain,
 				   util_domain.domain_fid);
@@ -490,6 +741,15 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 				attr->name);
 			return -FI_ENOSYS;
 		}
+
+		if (attr->rx_ctx_bits > PSMX2_MAX_RX_CTX_BITS) {
+			FI_INFO(&psmx2_prov, FI_LOG_AV,
+				"attr->rx_ctx_bits=%d, maximum allowed is %d\n",
+				attr->rx_ctx_bits, PSMX2_MAX_RX_CTX_BITS);
+			return -FI_ENOSYS;
+		}
+
+		rx_ctx_bits = attr->rx_ctx_bits;
 	}
 
 	av_priv = (struct psmx2_fid_av *) calloc(1, sizeof *av_priv);
@@ -503,6 +763,7 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	av_priv->addrlen = sizeof(psm2_epaddr_t);
 	av_priv->count = count;
 	av_priv->flags = flags;
+	av_priv->rx_ctx_bits = rx_ctx_bits;
 
 	av_priv->av.fid.fclass = FI_CLASS_AV;
 	av_priv->av.fid.context = context;

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -467,7 +467,7 @@ static int psmx2_av_query_seps(struct psmx2_fid_av *av, size_t count, psm2_epid_
 	 * (2) to simplify the logic of generating the final completion event.
 	 */
 	while (ofi_atomic_get32(&req->pending))
-		psmx2_progress(av->domain);
+		psmx2_progress_all(av->domain);
 
 	if (req) {
 		error_count = ofi_atomic_get32(&req->error_count);

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -92,7 +92,7 @@ int psmx2_epid_to_epaddr(struct psmx2_fid_domain *domain,
 		}
 	}
 
-        err = psm2_ep_connect(domain->psm2_ep, 1, &epid, NULL, &errors,
+        err = psm2_ep_connect(domain->base_trx_ctxt->psm2_ep, 1, &epid, NULL, &errors,
 			      epaddr, psmx2_conn_timeout(1));
         if (err != PSM2_OK)
                 return psmx2_errno(err);
@@ -182,7 +182,7 @@ static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
 		}
 	}
 
-	psm2_ep_connect(av->domain->psm2_ep, count, epids, mask, errors,
+	psm2_ep_connect(av->domain->base_trx_ctxt->psm2_ep, count, epids, mask, errors,
 			epaddrs, psmx2_conn_timeout(count));
 
 	for (i=0; i<count; i++){

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -219,7 +219,7 @@ int psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,
 	psm2_epconn_t epconn;
 	struct psmx2_epaddr_context *context;
 
-	err = psm2_ep_epid_lookup(epid, &epconn);
+	err = psmx2_ep_epid_lookup(trx_ctxt->psm2_ep, epid, &epconn);
 	if (err == PSM2_OK) {
 		context = psm2_epaddr_getctxt(epconn.addr);
 		if (context && context->epid  == epid) {
@@ -354,10 +354,11 @@ static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
 	psm2_epconn_t epconn;
 	struct psmx2_epaddr_context *epaddr_context;
 	int error_count = 0;
+	psm2_ep_t ep = av->domain->base_trx_ctxt->psm2_ep;
 
 	/* set up mask to prevent connecting to an already connected ep */
 	for (i=0; i<count; i++) {
-		if (psm2_ep_epid_lookup(epids[i], &epconn) == PSM2_OK) {
+		if (psmx2_ep_epid_lookup(ep, epids[i], &epconn) == PSM2_OK) {
 			epaddr_context = psm2_epaddr_getctxt(epconn.addr);
 			if (epaddr_context && epaddr_context->epid == epids[i])
 				epaddrs[i] = epconn.addr;
@@ -368,8 +369,7 @@ static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
 		}
 	}
 
-	psm2_ep_connect(av->domain->base_trx_ctxt->psm2_ep, count, epids, mask, errors,
-			epaddrs, psmx2_conn_timeout(count));
+	psm2_ep_connect(ep, count, epids, mask, errors, epaddrs, psmx2_conn_timeout(count));
 
 	for (i=0; i<count; i++){
 		if (!mask[i]) {
@@ -387,7 +387,7 @@ static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
 			 * be reached". This should be treated the same as
 			 * "Endpoint already connected".
 			 */
-			if (psm2_ep_epid_lookup(epids[i], &epconn) == PSM2_OK) {
+			if (psmx2_ep_epid_lookup(ep, epids[i], &epconn) == PSM2_OK) {
 				epaddr_context = psm2_epaddr_getctxt(epconn.addr);
 				if (epaddr_context &&
 				    epaddr_context->epid == epids[i]) {

--- a/prov/psm2/src/psmx2_cm.c
+++ b/prov/psm2/src/psmx2_cm.c
@@ -35,6 +35,7 @@
 static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 {
 	struct psmx2_fid_ep *ep;
+	struct psmx2_fid_sep *sep;
 	struct psmx2_ep_name *epname = addr;
 
 	ep = container_of(fid, struct psmx2_fid_ep, ep.fid);
@@ -47,8 +48,17 @@ static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 	}
 
 	memset(epname, 0, sizeof(*epname));
-	epname->epid = ep->trx_ctxt->psm2_epid;
-	epname->vlane = ep->vlane;
+
+	if (ep->type == PSMX2_EP_REGULAR) {
+		epname->epid = ep->trx_ctxt->psm2_epid;
+		epname->vlane = ep->vlane;
+		epname->type = ep->type;
+	} else {
+		sep = (struct psmx2_fid_sep *)ep;
+		epname->epid = sep->domain->base_trx_ctxt->psm2_epid;
+		epname->sep_id = sep->id;
+		epname->type = sep->type;
+	}
 	*addrlen = sizeof(struct psmx2_ep_name);
 
 	return 0;

--- a/prov/psm2/src/psmx2_cm.c
+++ b/prov/psm2/src/psmx2_cm.c
@@ -47,7 +47,7 @@ static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 	}
 
 	memset(epname, 0, sizeof(*epname));
-	epname->epid = ep->domain->psm2_epid;
+	epname->epid = ep->trx_ctxt->psm2_epid;
 	epname->vlane = ep->vlane;
 	*addrlen = sizeof(struct psmx2_ep_name);
 

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -273,7 +273,10 @@ static uint64_t psmx2_cntr_read(struct fid_cntr *cntr)
 	cntr_priv = container_of(cntr, struct psmx2_fid_cntr, cntr);
 
 	if (poll_cnt++ == PSMX2_CNTR_POLL_THRESHOLD) {
-		psmx2_progress(cntr_priv->domain);
+		if (cntr_priv->trx_ctxt == PSMX2_ALL_TRX_CTXT)
+			psmx2_progress_all(cntr_priv->domain);
+		else
+			psmx2_progress(cntr_priv->trx_ctxt);
 		poll_cnt = 0;
 	}
 
@@ -367,7 +370,10 @@ static int psmx2_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeou
 			if (ret == -FI_ETIMEDOUT)
 				break;
 		} else {
-			psmx2_progress(cntr_priv->domain);
+			if (cntr_priv->trx_ctxt == PSMX2_ALL_TRX_CTXT)
+				psmx2_progress_all(cntr_priv->domain);
+			else
+				psmx2_progress(cntr_priv->trx_ctxt);
 		}
 
 		if (ofi_atomic_get64(&cntr_priv->counter) >= threshold)

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -32,7 +32,7 @@
 
 #include "psmx2.h"
 
-int psmx2_process_trigger(struct psmx2_fid_domain *domain,
+int psmx2_process_trigger(struct psmx2_trx_ctxt *trx_ctxt,
 			  struct psmx2_trigger *trigger)
 {
 	switch (trigger->op) {
@@ -225,13 +225,13 @@ void psmx2_cntr_check_trigger(struct psmx2_fid_cntr *cntr)
 
 		cntr->trigger = trigger->next;
 
-		if (domain->am_initialized) {
-			fastlock_acquire(&domain->trigger_queue.lock);
+		if (domain->base_trx_ctxt->am_initialized) {
+			fastlock_acquire(&domain->base_trx_ctxt->trigger_queue.lock);
 			slist_insert_tail(&trigger->list_entry,
-					  &domain->trigger_queue.list);
-			fastlock_release(&domain->trigger_queue.lock);
+					  &domain->base_trx_ctxt->trigger_queue.list);
+			fastlock_release(&domain->base_trx_ctxt->trigger_queue.lock);
 		} else {
-			psmx2_process_trigger(domain, trigger);
+			psmx2_process_trigger(domain->base_trx_ctxt, trigger);
 		}
 
 		trigger = cntr->trigger;

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -272,7 +272,7 @@ static uint64_t psmx2_cntr_read(struct fid_cntr *cntr)
 
 	cntr_priv = container_of(cntr, struct psmx2_fid_cntr, cntr);
 
-	if (poll_cnt++ == PSMX2_CNTR_POLL_THRESHOLD) {
+	if (poll_cnt++ >= PSMX2_CNTR_POLL_THRESHOLD) {
 		if (cntr_priv->trx_ctxt == PSMX2_ALL_TRX_CTXT)
 			psmx2_progress_all(cntr_priv->domain);
 		else

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -345,7 +345,7 @@ out:
 }
 
 int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
-		     struct psmx2_fid_domain *domain,
+		     struct psmx2_trx_ctxt *trx_ctxt,
 		     struct psmx2_cq_event *event_in,
 		     int count, fi_addr_t *src_addr)
 {
@@ -371,14 +371,14 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 		 * freed because the two psm2_mq_ipeek calls may return the
 		 * same request. Use a lock to ensure that won't happen.
 		 */
-		if (fastlock_tryacquire(&domain->base_trx_ctxt->poll_lock))
+		if (fastlock_tryacquire(&trx_ctxt->poll_lock))
 			return read_count;
 
-		err = psm2_mq_ipeek(domain->base_trx_ctxt->psm2_mq, &psm2_req, NULL);
+		err = psm2_mq_ipeek(trx_ctxt->psm2_mq, &psm2_req, NULL);
 
 		if (err == PSM2_OK) {
 			err = psm2_mq_test2(&psm2_req, &psm2_status);
-			fastlock_release(&domain->base_trx_ctxt->poll_lock);
+			fastlock_release(&trx_ctxt->poll_lock);
 
 			fi_context = psm2_status.context;
 
@@ -629,10 +629,10 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 
 			return read_count;
 		} else if (err == PSM2_MQ_NO_COMPLETIONS) {
-			fastlock_release(&domain->base_trx_ctxt->poll_lock);
+			fastlock_release(&trx_ctxt->poll_lock);
 			return read_count;
 		} else {
-			fastlock_release(&domain->base_trx_ctxt->poll_lock);
+			fastlock_release(&trx_ctxt->poll_lock);
 			return psmx2_errno(err);
 		}
 	}
@@ -651,13 +651,13 @@ static ssize_t psmx2_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 	cq_priv = container_of(cq, struct psmx2_fid_cq, cq);
 
 	if (slist_empty(&cq_priv->event_queue) || !buf) {
-		ret = psmx2_cq_poll_mq(cq_priv, cq_priv->domain,
+		ret = psmx2_cq_poll_mq(cq_priv, cq_priv->trx_ctxt,
 				       (struct psmx2_cq_event *)buf, count, src_addr);
 		if (ret > 0)
 			return ret;
 
-		if (cq_priv->domain->base_trx_ctxt->am_initialized)
-			psmx2_am_progress(cq_priv->domain->base_trx_ctxt);
+		if (cq_priv->trx_ctxt->am_initialized)
+			psmx2_am_progress(cq_priv->trx_ctxt);
 	}
 
 	if (cq_priv->pending_error)
@@ -762,7 +762,7 @@ static ssize_t psmx2_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 		} else {
 			clock_gettime(CLOCK_REALTIME, &ts0);
 			while (1) {
-				if (psmx2_cq_poll_mq(cq_priv, cq_priv->domain, NULL, 0, NULL))
+				if (psmx2_cq_poll_mq(cq_priv, cq_priv->trx_ctxt, NULL, 0, NULL))
 					break;
 
 				/* CQ may be updated asynchronously by the AM handlers */

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -387,6 +387,7 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 	if (domain->progress_thread_enabled)
 		psmx2_domain_start_progress(domain);
 
+	psmx2_am_init(domain->base_trx_ctxt);
 	return 0;
 
 err_out_reset_active_domain:

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -297,7 +297,8 @@ static int psmx2_domain_close(fid_t fid)
 	domain->fabric->active_domain = NULL;
 	free(domain);
 
-	psmx2_atomic_fini();
+	psmx2_atomic_global_fini();
+	psmx2_am_global_fini();
 	return 0;
 }
 
@@ -331,7 +332,8 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 {
 	int err;
 
-	psmx2_atomic_init();
+	psmx2_am_global_init();
+	psmx2_atomic_global_init();
 
 	domain->base_trx_ctxt = psmx2_trx_ctxt_alloc(domain, src_addr);
 	if (!domain->base_trx_ctxt)

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -227,7 +227,7 @@ static void *psmx2_progress_func(void *args)
 	ts.tv_nsec = (sleep_usec % 1000000) * 1000;
 
 	while (1) {
-		psmx2_progress(domain);
+		psmx2_progress_all(domain);
 		nanosleep(&ts, NULL);
 	}
 
@@ -372,6 +372,9 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 	ofi_atomic_initialize32(&domain->sep_cnt, 0);
 	fastlock_init(&domain->sep_lock);
 	dlist_init(&domain->sep_list);
+	dlist_init(&domain->trx_ctxt_list);
+	fastlock_init(&domain->trx_ctxt_lock);
+	dlist_insert_before(&domain->base_trx_ctxt->entry, &domain->trx_ctxt_list);
 
 	/* Set active domain before psmx2_domain_enable_ep() installs the
 	 * AM handlers to ensure that psmx2_active_fabric->active_domain

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -320,7 +320,7 @@ static struct fi_ops_domain psmx2_domain_ops = {
 	.av_open = psmx2_av_open,
 	.cq_open = psmx2_cq_open,
 	.endpoint = psmx2_ep_open,
-	.scalable_ep = fi_no_scalable_ep,
+	.scalable_ep = psmx2_sep_open,
 	.cntr_open = psmx2_cntr_open,
 	.poll_open = fi_poll_create,
 	.stx_ctx = psmx2_stx_ctx,
@@ -413,6 +413,9 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	int err;
 
 	FI_INFO(&psmx2_prov, FI_LOG_DOMAIN, "\n");
+
+	if (!psmx2_env.sep)
+		psmx2_domain_ops.scalable_ep = fi_no_scalable_ep;
 
 	fabric_priv = container_of(fabric, struct psmx2_fid_fabric,
 				   util_fabric.fabric_fid);

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -32,6 +32,103 @@
 
 #include "psmx2.h"
 
+void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt)
+{
+	int err;
+
+	if (trx_ctxt->am_initialized)
+		psmx2_am_fini(trx_ctxt);
+
+#if 0
+	/* AM messages could arrive after MQ is finalized, causing segfault
+	 * when trying to dereference the MQ pointer. There is no mechanism
+	 * to properly shutdown AM. The workaround is to keep MQ valid.
+	 */
+	psm2_mq_finalize(trx_ctxt->psm2_mq);
+#endif
+
+	/* workaround for:
+	 * Assertion failure at psm2_ep.c:1059: ep->mctxt_master == ep
+	 */
+	sleep(psmx2_env.delay);
+
+	if (psmx2_env.timeout)
+		err = psm2_ep_close(trx_ctxt->psm2_ep, PSM2_EP_CLOSE_GRACEFUL,
+				    (int64_t) psmx2_env.timeout * 1000000000LL);
+	else
+		err = PSM2_EP_CLOSE_TIMEOUT;
+
+	if (err != PSM2_OK)
+		psm2_ep_close(trx_ctxt->psm2_ep, PSM2_EP_CLOSE_FORCE, 0);
+
+	fastlock_destroy(&trx_ctxt->poll_lock);
+	free(trx_ctxt);
+}
+
+struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
+					    struct psmx2_src_name *src_addr)
+{
+	struct psmx2_trx_ctxt *trx_ctxt;
+	struct psm2_ep_open_opts opts;
+	int err;
+
+	trx_ctxt = calloc(1, sizeof(*trx_ctxt));
+	if (!trx_ctxt) {
+		FI_WARN(&psmx2_prov, FI_LOG_CORE,
+			"failed to allocate trx_ctxt.\n");
+		return NULL;
+	}
+
+	psm2_ep_open_opts_get_defaults(&opts);
+	FI_INFO(&psmx2_prov, FI_LOG_CORE,
+		"uuid: %s\n", psmx2_uuid_to_string(domain->fabric->uuid));
+
+	if (src_addr) {
+		opts.unit = src_addr->unit;
+		opts.port = src_addr->port;
+		FI_INFO(&psmx2_prov, FI_LOG_CORE,
+			"ep_open_opts: unit=%d port=%u\n", opts.unit, opts.port);
+	}
+
+	err = psm2_ep_open(domain->fabric->uuid, &opts,
+			   &trx_ctxt->psm2_ep, &trx_ctxt->psm2_epid);
+	if (err != PSM2_OK) {
+		FI_WARN(&psmx2_prov, FI_LOG_CORE,
+			"psm2_ep_open returns %d, errno=%d\n", err, errno);
+		err = psmx2_errno(err);
+		goto err_out;
+	}
+
+	FI_INFO(&psmx2_prov, FI_LOG_CORE,
+		"epid: 0x%016lx\n", trx_ctxt->psm2_epid);
+
+	err = psm2_mq_init(trx_ctxt->psm2_ep, PSM2_MQ_ORDERMASK_ALL,
+			   NULL, 0, &trx_ctxt->psm2_mq);
+	if (err != PSM2_OK) {
+		FI_WARN(&psmx2_prov, FI_LOG_CORE,
+			"psm2_mq_init returns %d, errno=%d\n", err, errno);
+		err = psmx2_errno(err);
+		goto err_out_close_ep;
+	}
+
+	fastlock_init(&trx_ctxt->poll_lock);
+	fastlock_init(&trx_ctxt->rma_queue.lock);
+	fastlock_init(&trx_ctxt->trigger_queue.lock);
+	slist_init(&trx_ctxt->rma_queue.list);
+	slist_init(&trx_ctxt->trigger_queue.list);
+
+	return trx_ctxt;
+
+err_out_close_ep:
+	if (psm2_ep_close(trx_ctxt->psm2_ep, PSM2_EP_CLOSE_GRACEFUL,
+			  (int64_t) psmx2_env.timeout * 1000000000LL) != PSM2_OK)
+		psm2_ep_close(trx_ctxt->psm2_ep, PSM2_EP_CLOSE_FORCE, 0);
+
+err_out:
+	free(trx_ctxt);
+	return NULL;
+}
+
 static inline int normalize_core_id(int core_id, int num_cores)
 {
 	if (core_id < 0)
@@ -177,7 +274,6 @@ static void psmx2_domain_stop_progress(struct psmx2_fid_domain *domain)
 static int psmx2_domain_close(fid_t fid)
 {
 	struct psmx2_fid_domain *domain;
-	int err;
 
 	domain = container_of(fid, struct psmx2_fid_domain,
 			      util_domain.domain_fid.fid);
@@ -193,39 +289,15 @@ static int psmx2_domain_close(fid_t fid)
 	if (domain->progress_thread_enabled)
 		psmx2_domain_stop_progress(domain);
 
-	if (domain->am_initialized)
-		psmx2_am_fini(domain);
-
-	fastlock_destroy(&domain->poll_lock);
 	fastlock_destroy(&domain->vl_lock);
 	rbtDelete(domain->mr_map);
 	fastlock_destroy(&domain->mr_lock);
 
-#if 0
-	/* AM messages could arrive after MQ is finalized, causing segfault
-	 * when trying to dereference the MQ pointer. There is no mechanism
-	 * to properly shutdown AM. The workaround is to keep MQ valid.
-	 */
-	psm2_mq_finalize(domain->psm2_mq);
-#endif
-
-	/* workaround for:
-	 * Assertion failure at psm2_ep.c:1059: ep->mctxt_master == ep
-	 */
-	sleep(psmx2_env.delay);
-
-	if (psmx2_env.timeout)
-		err = psm2_ep_close(domain->psm2_ep, PSM2_EP_CLOSE_GRACEFUL,
-				    (int64_t) psmx2_env.timeout * 1000000000LL);
-	else
-		err = PSM2_EP_CLOSE_TIMEOUT;
-
-	if (err != PSM2_OK)
-		psm2_ep_close(domain->psm2_ep, PSM2_EP_CLOSE_FORCE, 0);
-
+	psmx2_trx_ctxt_free(domain->base_trx_ctxt);
 	domain->fabric->active_domain = NULL;
-
 	free(domain);
+
+	psmx2_atomic_fini();
 	return 0;
 }
 
@@ -257,48 +329,19 @@ static int psmx2_key_compare(void *key1, void *key2)
 static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 			     struct psmx2_src_name *src_addr)
 {
-	struct psmx2_fid_fabric *fabric = domain->fabric;
-	struct psm2_ep_open_opts opts;
 	int err;
 
-	psm2_ep_open_opts_get_defaults(&opts);
+	psmx2_atomic_init();
 
-	FI_INFO(&psmx2_prov, FI_LOG_CORE,
-		"uuid: %s\n", psmx2_uuid_to_string(fabric->uuid));
-
-	if (src_addr) {
-		opts.unit = src_addr->unit;
-		opts.port = src_addr->port;
-		FI_INFO(&psmx2_prov, FI_LOG_CORE,
-			"ep_open_opts: unit=%d port=%u\n", opts.unit, opts.port);
-	}
-
-	err = psm2_ep_open(fabric->uuid, &opts,
-			   &domain->psm2_ep, &domain->psm2_epid);
-	if (err != PSM2_OK) {
-		FI_WARN(&psmx2_prov, FI_LOG_CORE,
-			"psm2_ep_open returns %d, errno=%d\n", err, errno);
-		err = psmx2_errno(err);
-		goto err_out;
-	}
-
-	FI_INFO(&psmx2_prov, FI_LOG_CORE,
-		"epid: 0x%016lx\n", domain->psm2_epid);
-
-	err = psm2_mq_init(domain->psm2_ep, PSM2_MQ_ORDERMASK_ALL,
-			   NULL, 0, &domain->psm2_mq);
-	if (err != PSM2_OK) {
-		FI_WARN(&psmx2_prov, FI_LOG_CORE,
-			"psm2_mq_init returns %d, errno=%d\n", err, errno);
-		err = psmx2_errno(err);
-		goto err_out_close_ep;
-	}
+	domain->base_trx_ctxt = psmx2_trx_ctxt_alloc(domain, src_addr);
+	if (!domain->base_trx_ctxt)
+		return -FI_ENODEV;
 
 	err = fastlock_init(&domain->mr_lock);
 	if (err) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"fastlock_init(mr_lock) returns %d\n", err);
-		goto err_out_finalize_mq;
+		goto err_out_free_trx_ctxt;
 	}
 
 	domain->mr_map = rbtNew(&psmx2_key_compare);
@@ -319,20 +362,13 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 	memset(domain->vl_map, 0, sizeof(domain->vl_map));
 	domain->vl_alloc = 0;
 
-	err = fastlock_init(&domain->poll_lock);
-	if (err) {
-		FI_WARN(&psmx2_prov, FI_LOG_CORE,
-			"fastlock_init(poll_lock) returns %d\n", err);
-		goto err_out_destroy_vl_lock;
-	}
-
 	/* Set active domain before psmx2_domain_enable_ep() installs the
 	 * AM handlers to ensure that psmx2_active_fabric->active_domain
 	 * is always non-NULL inside the handlers. Notice that the vlaue
 	 * active_domain becomes NULL again only when the domain is closed.
 	 * At that time the AM handlers are gone with the PSM endpoint.
 	 */
-	fabric->active_domain = domain;
+	domain->fabric->active_domain = domain;
 
 	if (psmx2_domain_enable_ep(domain, NULL) < 0)
 		goto err_out_reset_active_domain;
@@ -343,10 +379,7 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 	return 0;
 
 err_out_reset_active_domain:
-	fabric->active_domain = NULL;
-	fastlock_destroy(&domain->poll_lock);
-
-err_out_destroy_vl_lock:
+	domain->fabric->active_domain = NULL;
 	fastlock_destroy(&domain->vl_lock);
 
 err_out_delete_mr_map:
@@ -355,15 +388,8 @@ err_out_delete_mr_map:
 err_out_destroy_mr_lock:
 	fastlock_destroy(&domain->mr_lock);
 
-err_out_finalize_mq:
-	psm2_mq_finalize(domain->psm2_mq);
-
-err_out_close_ep:
-	if (psm2_ep_close(domain->psm2_ep, PSM2_EP_CLOSE_GRACEFUL,
-			  (int64_t) psmx2_env.timeout * 1000000000LL) != PSM2_OK)
-		psm2_ep_close(domain->psm2_ep, PSM2_EP_CLOSE_FORCE, 0);
-
-err_out:
+err_out_free_trx_ctxt:
+	psmx2_trx_ctxt_free(domain->base_trx_ctxt);
 	return err;
 }
 
@@ -463,14 +489,8 @@ int psmx2_domain_enable_ep(struct psmx2_fid_domain *domain,
 		return -FI_EOPNOTSUPP;
 	}
 
-	if (((ep_cap & FI_RMA) || (ep_cap & FI_ATOMICS)) &&
-	    !domain->am_initialized) {
-		int err = psmx2_am_init(domain);
-		if (err)
-			return err;
-
-		domain->am_initialized = 1;
-	}
+	if ((ep_cap & FI_RMA) || (ep_cap & FI_ATOMICS))
+		return psmx2_am_init(ep->trx_ctxt);
 
 	return 0;
 }

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -248,7 +248,7 @@ static int psmx2_ep_close(fid_t fid)
 	if (ofi_atomic_get32(&ep->ref))
 		return -FI_EBUSY;
 
-	ep_name.epid = ep->domain->psm2_epid;
+	ep_name.epid = ep->trx_ctxt->psm2_epid;
 	ep_name.vlane = ep->vlane;
 	psmx2_ns_del_local_name(ep->service, &ep_name);
 
@@ -537,6 +537,7 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->ep.ops = &psmx2_ep_ops;
 	ep_priv->ep.cm = &psmx2_cm_ops;
 	ep_priv->domain = domain_priv;
+	ep_priv->trx_ctxt = domain_priv->base_trx_ctxt;
 	ep_priv->vlane = vlane;
 	ofi_atomic_initialize32(&ep_priv->ref, 0);
 
@@ -593,7 +594,7 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 		ep_priv->service = ((getpid() & 0x7FFF) << 16) +
 				   ((uintptr_t)ep_priv & 0xFFFF);
 
-	ep_name.epid = domain_priv->psm2_epid;
+	ep_name.epid = domain_priv->base_trx_ctxt->psm2_epid;
 	ep_name.vlane = ep_priv->vlane;
 	psmx2_ns_add_local_name(ep_priv->service, &ep_name);
 

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -944,7 +944,7 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 
 	for (i = 0; i < ctxt_cnt; i++) {
 		trx_ctxt = psmx2_trx_ctxt_alloc(domain_priv,
-					        info ? info->src_addr : NULL);
+					        info ? info->src_addr : NULL, i);
 		if (!trx_ctxt)
 			goto errout_free_ctxt;
 

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -854,18 +854,18 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 		goto errout;
 
 	if (info && info->ep_attr) {
-		if (info->ep_attr->tx_ctx_cnt > PSMX2_MAX_TRX_CTXT) {
+		if (info->ep_attr->tx_ctx_cnt > psmx2_env.max_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"tx_ctx_cnt %d exceed limit %d.\n",
 				info->ep_attr->tx_ctx_cnt,
-				PSMX2_MAX_TRX_CTXT);
+				psmx2_env.max_trx_ctxt);
 			goto errout;
 		}
-		if (info->ep_attr->rx_ctx_cnt > PSMX2_MAX_TRX_CTXT) {
+		if (info->ep_attr->rx_ctx_cnt > psmx2_env.max_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"rx_ctx_cnt %d exceed limit %d.\n",
 				info->ep_attr->rx_ctx_cnt,
-				PSMX2_MAX_TRX_CTXT);
+				psmx2_env.max_trx_ctxt);
 			goto errout;
 		}
 		ctxt_cnt = info->ep_attr->tx_ctx_cnt;

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -41,7 +41,7 @@ static inline void bitmap_set(uint64_t *map, unsigned id)
 
 	i = id / sizeof(uint64_t);
 	j = id % sizeof(uint64_t);
-	
+
 	map[i] |= BIT(j);
 }
 
@@ -51,7 +51,7 @@ static inline void bitmap_clear(uint64_t *map, unsigned id)
 
 	i = id / sizeof(uint64_t);
 	j = id % sizeof(uint64_t);
-	
+
 	map[i] &= ~BIT(j);
 }
 
@@ -61,7 +61,7 @@ static inline int bitmap_test(uint64_t *map, unsigned id)
 
 	i = id / sizeof(uint64_t);
 	j = id % sizeof(uint64_t);
-	
+
 	return !!(map[i] & BIT(j));
 }
 
@@ -78,7 +78,7 @@ static int psmx2_alloc_vlane(struct psmx2_fid_domain *domain, uint8_t *vl)
 	int id;
 
 	fastlock_acquire(&domain->vl_lock);
-	for (i=0; i<BITMAP_SIZE; i++) {
+	for (i = 0; i < BITMAP_SIZE; i++) {
 		id = (domain->vl_alloc + i) % BITMAP_SIZE;
 		if (bitmap_test(domain->vl_map, id) == 0) {
 			bitmap_set(domain->vl_map, id);
@@ -478,14 +478,13 @@ static struct fi_ops_ep psmx2_ep_ops = {
 	.tx_size_left = psmx2_tx_size_left,
 };
 
-int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
-		  struct fid_ep **ep, void *context)
+int psmx2_ep_open_internal(struct psmx2_fid_domain *domain_priv,
+			   struct fi_info *info,
+			   struct psmx2_fid_ep **ep_out, void *context,
+			   struct psmx2_trx_ctxt *trx_ctxt, int vlane)
 {
-	struct psmx2_fid_domain *domain_priv;
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_context *item;
-	struct psmx2_ep_name ep_name;
-	uint8_t vlane;
 	uint64_t ep_cap;
 	int err = -FI_EINVAL;
 	int i;
@@ -495,25 +494,20 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 	else
 		ep_cap = FI_TAGGED;
 
-	domain_priv = container_of(domain, struct psmx2_fid_domain,	
-				   util_domain.domain_fid.fid);
-	if (!domain_priv)
-		goto errout;
-
 	if (info && info->ep_attr && info->ep_attr->auth_key) {
 		if (info->ep_attr->auth_key_size != sizeof(psm2_uuid_t)) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"Invalid auth_key_len %d, should be %d.\n",
 				info->ep_attr->auth_key_size,
 				sizeof(psm2_uuid_t));
-			return -FI_EINVAL;
+			goto errout;
 		}
 		if (memcmp(domain_priv->fabric->uuid, info->ep_attr->auth_key,
 			   sizeof(psm2_uuid_t))) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"Invalid auth_key: %s\n",
 				psmx2_uuid_to_string((void *)info->ep_attr->auth_key));
-			return -FI_EINVAL;
+			goto errout;
 		}
 	}
 
@@ -521,14 +515,10 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 	if (err)
 		goto errout;
 
-	err = psmx2_alloc_vlane(domain_priv, &vlane);
-	if (err)
-		goto errout;
-
 	ep_priv = (struct psmx2_fid_ep *) calloc(1, sizeof *ep_priv);
 	if (!ep_priv) {
 		err = -FI_ENOMEM;
-		goto errout_free_vlane;
+		goto errout;
 	}
 
 	ep_priv->ep.fid.fclass = FI_CLASS_EP;
@@ -537,7 +527,7 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->ep.ops = &psmx2_ep_ops;
 	ep_priv->ep.cm = &psmx2_cm_ops;
 	ep_priv->domain = domain_priv;
-	ep_priv->trx_ctxt = domain_priv->base_trx_ctxt;
+	ep_priv->trx_ctxt = trx_ctxt;
 	ep_priv->vlane = vlane;
 	ofi_atomic_initialize32(&ep_priv->ref, 0);
 
@@ -562,7 +552,6 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 		goto errout_free_ep;
 
 	psmx2_domain_acquire(domain_priv);
-	domain_priv->eps[ep_priv->vlane] = ep_priv;
 
 	if (info) {
 		if (info->tx_attr)
@@ -577,7 +566,7 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 	fastlock_init(&ep_priv->context_lock);
 
 #define PSMX2_FREE_CONTEXT_LIST_SIZE	64
-	for (i=0; i<PSMX2_FREE_CONTEXT_LIST_SIZE; i++) {
+	for (i = 0; i < PSMX2_FREE_CONTEXT_LIST_SIZE; i++) {
 		item = calloc(1, sizeof(*item));
 		if (!item) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL, "out of memory.\n");
@@ -586,6 +575,45 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 		slist_insert_tail(&item->list_entry, &ep_priv->free_context_list);
 	}
 
+
+	*ep_out = ep_priv;
+	return 0;
+
+errout_free_ep:
+	free(ep_priv);
+
+errout:
+	return err;
+}
+
+int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
+		  struct fid_ep **ep, void *context)
+{
+	struct psmx2_fid_domain *domain_priv;
+	struct psmx2_fid_ep *ep_priv;
+	struct psmx2_ep_name ep_name;
+	uint8_t vlane;
+	int err = -FI_EINVAL;
+
+	domain_priv = container_of(domain, struct psmx2_fid_domain,
+				   util_domain.domain_fid.fid);
+	if (!domain_priv)
+		goto errout;
+
+	err = psmx2_alloc_vlane(domain_priv, &vlane);
+	if (err)
+		goto errout;
+
+	err = psmx2_ep_open_internal(domain_priv, info, &ep_priv, context,
+				     domain_priv->base_trx_ctxt, vlane);
+	if (err) {
+		psmx2_free_vlane(domain_priv, vlane);
+		goto errout;
+	}
+
+	domain_priv->eps[ep_priv->vlane] = ep_priv;
+
+	ep_priv->type = PSMX2_EP_REGULAR;
 	ep_priv->service = PSMX2_ANY_SERVICE;
 	if (info && info->src_addr)
 		ep_priv->service = ((struct psmx2_src_name *)info->src_addr)->service;
@@ -596,16 +624,11 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 
 	ep_name.epid = domain_priv->base_trx_ctxt->psm2_epid;
 	ep_name.vlane = ep_priv->vlane;
+	ep_name.type = ep_priv->type;
 	psmx2_ns_add_local_name(ep_priv->service, &ep_name);
 
 	*ep = &ep_priv->ep;
 	return 0;
-
-errout_free_ep:
-	free(ep_priv);
-
-errout_free_vlane:
-	psmx2_free_vlane(domain_priv, vlane);
 
 errout:
 	return err;
@@ -696,3 +719,235 @@ void psmx2_ep_put_op_context(struct psmx2_fid_ep *ep,
 	fastlock_release(&ep->context_lock);
 }
 
+/*
+ * Scalable endpoint
+ */
+
+static int psmx2_sep_close(fid_t fid)
+{
+	struct psmx2_fid_sep *sep;
+	struct psmx2_ep_name ep_name;
+	int i;
+
+	sep = container_of(fid, struct psmx2_fid_sep, ep.fid);
+
+	if (ofi_atomic_get32(&sep->ref))
+		return -FI_EBUSY;
+
+	for (i = 0; i < sep->ctxt_cnt; i++) {
+		if (sep->ctxts[i].ep)
+			fi_close(&sep->ctxts[i].ep->ep.fid);
+		psmx2_trx_ctxt_free(sep->ctxts[i].trx_ctxt);
+	}
+
+	ep_name.epid = sep->domain->base_trx_ctxt->psm2_epid;
+	ep_name.sep_id = sep->id;
+	ep_name.type = sep->type;
+	psmx2_ns_del_local_name(sep->service, &ep_name);
+
+	fastlock_acquire(&sep->domain->sep_lock);
+	dlist_remove(&sep->entry);
+	fastlock_release(&sep->domain->sep_lock);
+
+	psmx2_domain_release(sep->domain);
+	free(sep);
+	return 0;
+}
+
+static int psmx2_sep_control(fid_t fid, int command, void *arg)
+{
+	struct psmx2_fid_sep *sep;
+
+	sep = container_of(fid, struct psmx2_fid_sep, ep.fid);
+
+	switch (command) {
+	case FI_ENABLE:
+		sep->enabled = 1;
+		return 0;
+
+	default:
+		return -FI_ENOSYS;
+	}
+
+	return 0;
+}
+
+static int psmx2_sep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+{
+	struct psmx2_fid_sep *sep;
+	int i, err = 0;
+
+	sep = container_of(fid, struct psmx2_fid_sep, ep.fid);
+
+	for (i = 0; i < sep->ctxt_cnt; i++) {
+		err = psmx2_ep_bind(&sep->ctxts[i].ep->ep.fid, bfid, flags);
+		if (err)
+			break;
+	}
+
+	return err;
+}
+
+static int psmx2_tx_context(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
+			    struct fid_ep **tx_ep, void *context)
+{
+	struct psmx2_fid_sep *sep;
+
+	sep = container_of(ep, struct psmx2_fid_sep, ep);
+
+	if (index < 0 || index > sep->ctxt_cnt)
+		return -FI_EINVAL;
+
+	*tx_ep = &sep->ctxts[index].ep->ep;
+	return 0;
+}
+
+static int psmx2_rx_context(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
+			    struct fid_ep **rx_ep, void *context)
+{
+	struct psmx2_fid_sep *sep;
+
+	sep = container_of(ep, struct psmx2_fid_sep, ep);
+
+	if (index < 0 || index > sep->ctxt_cnt)
+		return -FI_EINVAL;
+
+	*rx_ep = &sep->ctxts[index].ep->ep;
+	return 0;
+}
+
+static struct fi_ops psmx2_fi_ops_sep = {
+	.size = sizeof(struct fi_ops),
+	.close = psmx2_sep_close,
+	.bind = psmx2_sep_bind,
+	.control = psmx2_sep_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static struct fi_ops_ep psmx2_sep_ops = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = fi_no_cancel,
+	.getopt = fi_no_getopt,
+	.setopt = fi_no_setopt,
+	.tx_ctx = psmx2_tx_context,
+	.rx_ctx = psmx2_rx_context,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
+};
+
+int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
+		   struct fid_ep **sep, void *context)
+{
+	struct psmx2_fid_domain *domain_priv;
+	struct psmx2_fid_ep *ep_priv;
+	struct psmx2_fid_sep *sep_priv;
+	struct psmx2_ep_name ep_name;
+	struct psmx2_trx_ctxt *trx_ctxt;
+	size_t ctxt_cnt = 1;
+	size_t ctxt_size;
+	int err = -FI_EINVAL;
+	int i;
+
+	domain_priv = container_of(domain, struct psmx2_fid_domain,
+				   util_domain.domain_fid.fid);
+	if (!domain_priv)
+		goto errout;
+
+	if (info && info->ep_attr) {
+		if (info->ep_attr->tx_ctx_cnt > PSMX2_MAX_TRX_CTXT) {
+			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
+				"tx_ctx_cnt %d exceed limit %d.\n",
+				info->ep_attr->tx_ctx_cnt,
+				PSMX2_MAX_TRX_CTXT);
+			goto errout;
+		}
+		if (info->ep_attr->rx_ctx_cnt > PSMX2_MAX_TRX_CTXT) {
+			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
+				"rx_ctx_cnt %d exceed limit %d.\n",
+				info->ep_attr->rx_ctx_cnt,
+				PSMX2_MAX_TRX_CTXT);
+			goto errout;
+		}
+		ctxt_cnt = info->ep_attr->tx_ctx_cnt;
+		if (ctxt_cnt < info->ep_attr->rx_ctx_cnt)
+			ctxt_cnt = info->ep_attr->rx_ctx_cnt;
+		if (ctxt_cnt == 0) {
+			FI_INFO(&psmx2_prov, FI_LOG_EP_CTRL,
+				"tx_ctx_cnt and rx_ctx_cnt are 0, use 1.\n");
+			ctxt_cnt = 1;
+		}
+	}
+
+	ctxt_size = ctxt_cnt * sizeof(struct psmx2_sep_ctxt);
+	sep_priv = (struct psmx2_fid_sep *) calloc(1, sizeof(*sep_priv) + ctxt_size);
+	if (!sep_priv) {
+		err = -FI_ENOMEM;
+		goto errout;
+	}
+
+	sep_priv->ep.fid.fclass = FI_CLASS_SEP;
+	sep_priv->ep.fid.context = context;
+	sep_priv->ep.fid.ops = &psmx2_fi_ops_sep;
+	sep_priv->ep.ops = &psmx2_sep_ops;
+	sep_priv->ep.cm = &psmx2_cm_ops;
+	sep_priv->domain = domain_priv;
+	sep_priv->ctxt_cnt = ctxt_cnt;
+	ofi_atomic_initialize32(&sep_priv->ref, 0);
+
+	for (i = 0; i < ctxt_cnt; i++) {
+		trx_ctxt = psmx2_trx_ctxt_alloc(domain_priv,
+					        info ? info->src_addr : NULL);
+		if (!trx_ctxt)
+			goto errout_free_ctxt;
+
+		sep_priv->ctxts[i].trx_ctxt = trx_ctxt;
+
+		err = psmx2_ep_open_internal(domain_priv, info, &ep_priv, context,
+					     trx_ctxt, 0);
+		if (err)
+			goto errout_free_ctxt;
+
+		/* modify the fi_ops: especially close op */
+
+		sep_priv->ctxts[i].ep = ep_priv;
+	}
+
+	sep_priv->type = PSMX2_EP_SCALABLE;
+	sep_priv->service = PSMX2_ANY_SERVICE;
+	if (info && info->src_addr)
+		sep_priv->service = ((struct psmx2_src_name *)info->src_addr)->service;
+
+	if (sep_priv->service == PSMX2_ANY_SERVICE)
+		sep_priv->service = ((getpid() & 0x7FFF) << 16) +
+				   ((uintptr_t)sep_priv & 0xFFFF);
+
+	sep_priv->id = ofi_atomic_inc32(&domain_priv->sep_cnt);
+
+	fastlock_acquire(&domain_priv->sep_lock);
+	dlist_insert_before(&sep_priv->entry, &domain_priv->sep_list);
+	fastlock_release(&domain_priv->sep_lock);
+
+	ep_name.epid = domain_priv->base_trx_ctxt->psm2_epid;
+	ep_name.sep_id = sep_priv->id;
+	ep_name.type = sep_priv->type;
+	psmx2_ns_add_local_name(sep_priv->service, &ep_name);
+
+	*sep = &sep_priv->ep;
+	return 0;
+
+errout_free_ctxt:
+	while (i) {
+		if (sep_priv->ctxts[i].ep)
+			fi_close(&sep_priv->ctxts[i].ep->ep.fid);
+
+		if (sep_priv->ctxts[i].trx_ctxt)
+			psmx2_trx_ctxt_free(sep_priv->ctxts[i].trx_ctxt);
+
+		i--;
+	}
+
+	free(sep_priv);
+
+errout:
+	return err;
+}

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -67,14 +67,7 @@ static void psmx2_init_env(void)
 
 static int psmx2_check_sep_cap(void)
 {
-	uint64_t (*func)(uint64_t);
-	int mask = 1; /* PSM2_MULTI_EP_CAP */
-
-	func = dlsym(NULL, "psm2_get_capability_mask");
-	if (!func)
-		return 0;
-
-	if ((*func)(mask) != mask)
+	if (!psmx2_sep_ok())
 		return 0;
 
 	psmx2_env.sep = 1;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -49,6 +49,7 @@ struct psmx2_env psmx2_env = {
 	.prog_affinity	= NULL,
 	.sep		= 0,
 	.max_trx_ctxt	= 1,
+	.num_devunits	= 1,
 };
 
 static void psmx2_init_env(void)
@@ -174,6 +175,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		return -FI_ENODATA;
 	}
 
+	psmx2_env.num_devunits = cnt;
 	psmx2_init_env();
 
 	src_addr = calloc(1, sizeof(*src_addr));

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -156,6 +156,7 @@ static int psmx2_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		if (mr->domain != cntr->domain)
 			return -FI_EINVAL;
 		mr->cntr = cntr;
+		cntr->trx_ctxt = PSMX2_ALL_TRX_CTXT;
 		break;
 
 	default:

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -137,7 +137,7 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 		PSMX2_CTXT_SIZE(fi_context) = len;
 	}
 
-	err = psm2_mq_irecv2(ep_priv->domain->psm2_mq, psm2_epaddr,
+	err = psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     &psm2_tag, &psm2_tagsel, recv_flag, buf, len,
 			     (void *)fi_context, &psm2_req);
 	if (err != PSM2_OK)
@@ -279,7 +279,7 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 		if (len > PSMX2_INJECT_SIZE)
 			return -FI_EMSGSIZE;
 
-		err = psm2_mq_send2(ep_priv->domain->psm2_mq, psm2_epaddr,
+		err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 				    send_flag, &psm2_tag, buf, len);
 
 		if (err != PSM2_OK)
@@ -318,7 +318,7 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
 	}
 
-	err = psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr,
+	err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     send_flag, &psm2_tag, buf, len,
 			     (void *)fi_context, &psm2_req);
 
@@ -455,7 +455,7 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 			return -FI_EMSGSIZE;
 		}
 
-		err = psm2_mq_send2(ep_priv->domain->psm2_mq, psm2_epaddr,
+		err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 				    send_flag, &psm2_tag, req->buf, len);
 
 		free(req);
@@ -493,7 +493,7 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 	PSMX2_CTXT_USER(fi_context) = req;
 	PSMX2_CTXT_EP(fi_context) = ep_priv;
 
-	err = psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr,
+	err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     send_flag, &psm2_tag, req->buf, len,
 			     (void *)fi_context, &psm2_req);
 
@@ -514,7 +514,7 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 		PSMX2_SET_TAG(psm2_tag, data, tag32);
 		for (i=0; i<count; i++) {
 			if (iov[i].iov_len) {
-				err = psm2_mq_isend2(ep_priv->domain->psm2_mq,
+				err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq,
 						     psm2_epaddr, send_flag, &psm2_tag,
 						     iov[i].iov_base, iov[i].iov_len,
 						     (void *)fi_context, &psm2_req);
@@ -594,7 +594,7 @@ int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
 	for (i=0; i<rep->iov_info.count; i++) {
 		if (recv_len) {
 			len = MIN(recv_len, rep->iov_info.len[i]);
-			err = psm2_mq_irecv2(ep->domain->psm2_mq,
+			err = psm2_mq_irecv2(ep->trx_ctxt->psm2_mq,
 					     psm2_status->msg_peer,
 					     &psm2_tag, &psm2_tagsel,
 					     0/*flag*/, recv_buf, len,
@@ -607,7 +607,7 @@ int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
 			recv_len -= len;
 		} else {
 			/* recv buffer full, pust empty recvs */
-			err = psm2_mq_irecv2(ep->domain->psm2_mq,
+			err = psm2_mq_irecv2(ep->trx_ctxt->psm2_mq,
 					     psm2_status->msg_peer,
 					     &psm2_tag, &psm2_tagsel,
 					     0/*flag*/, NULL, 0,

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -76,7 +76,10 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 
 	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
 		av = ep_priv->av;
-		if (av && av->type == FI_AV_TABLE) {
+		if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
+			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
+			vlane = 0;
+		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
 			if (idx >= av->last)
 				return -FI_EINVAL;
@@ -254,7 +257,10 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 	}
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;
@@ -426,7 +432,10 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 	}
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
 		if (idx >= av->last) {
 			free(req);

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -32,12 +32,12 @@
 
 #include "psmx2.h"
 
-static inline void psmx2_am_enqueue_rma(struct psmx2_fid_domain *domain,
+static inline void psmx2_am_enqueue_rma(struct psmx2_trx_ctxt *trx_ctxt,
 				        struct psmx2_am_request *req)
 {
-	fastlock_acquire(&domain->rma_queue.lock);
-	slist_insert_tail(&req->list_entry, &domain->rma_queue.list);
-	fastlock_release(&domain->rma_queue.lock);
+	fastlock_acquire(&trx_ctxt->rma_queue.lock);
+	slist_insert_tail(&req->list_entry, &trx_ctxt->rma_queue.list);
+	fastlock_release(&trx_ctxt->rma_queue.lock);
 }
 
 static inline void psmx2_iov_copy(struct iovec *iov, size_t count,
@@ -216,7 +216,7 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 					(has_data ? FI_REMOTE_CQ_DATA : 0),
 			PSMX2_CTXT_TYPE(&req->fi_context) = PSMX2_REMOTE_WRITE_CONTEXT;
 			PSMX2_CTXT_USER(&req->fi_context) = mr;
-			psmx2_am_enqueue_rma(mr->domain, req);
+			psmx2_am_enqueue_rma(mr->domain->base_trx_ctxt, req);
 		}
 		break;
 
@@ -287,7 +287,7 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 			req->read.peer_vl = src_vl;
 			PSMX2_CTXT_TYPE(&req->fi_context) = PSMX2_REMOTE_READ_CONTEXT;
 			PSMX2_CTXT_USER(&req->fi_context) = mr;
-			psmx2_am_enqueue_rma(mr->domain, req);
+			psmx2_am_enqueue_rma(mr->domain->base_trx_ctxt, req);
 		}
 		break;
 
@@ -542,7 +542,7 @@ void psmx2_am_ack_rma(struct psmx2_am_request *req)
 			      PSM2_AM_FLAG_NOREPLY, NULL, NULL);
 }
 
-int psmx2_am_process_rma(struct psmx2_fid_domain *domain,
+int psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 			 struct psmx2_am_request *req)
 {
 	int err;
@@ -554,7 +554,7 @@ int psmx2_am_process_rma(struct psmx2_fid_domain *domain,
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, req->write.peer_vl, req->write.vl);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req->write.context, tag32);
 		PSMX2_SET_TAG(psm2_tagsel, -1ULL, -1);
-		err = psm2_mq_irecv2(domain->psm2_mq,
+		err = psm2_mq_irecv2(trx_ctxt->psm2_mq,
 				     (psm2_epaddr_t)req->write.peer_addr,
 				     &psm2_tag, &psm2_tagsel, 0,
 				     (void *)req->write.addr, req->write.len,
@@ -562,7 +562,7 @@ int psmx2_am_process_rma(struct psmx2_fid_domain *domain,
 	} else {
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, req->read.vl, req->read.peer_vl);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req->read.context, tag32);
-		err = psm2_mq_isend2(domain->psm2_mq,
+		err = psm2_mq_isend2(trx_ctxt->psm2_mq,
 				     (psm2_epaddr_t)req->read.peer_addr,
 				     0, &psm2_tag,
 				     (void *)req->read.addr, req->read.len,
@@ -639,7 +639,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
-	if (epaddr_context->epid == ep_priv->domain->psm2_epid)
+	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_rma_self(PSMX2_AM_REQ_READ, ep_priv,
 				      ep_priv->domain->eps[vlane],
 				      buf, len, desc, addr, key,
@@ -666,7 +666,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 		req->no_event = 1;
 	}
 
-	chunk_size = psmx2_am_param.max_reply_short;
+	chunk_size = ep_priv->trx_ctxt->psm2_am_param.max_reply_short;
 
 	args[0].u32w0 = 0;
 	PSMX2_AM_SET_SRC(args[0].u32w0, ep_priv->vlane);
@@ -676,7 +676,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, vlane, ep_priv->vlane);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 		PSMX2_SET_TAG(psm2_tagsel, -1ULL, -1);
-		psm2_mq_irecv2(ep_priv->domain->psm2_mq, psm2_epaddr,
+		psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			       &psm2_tag, &psm2_tagsel, 0, buf, len,
 			       (void *)&req->fi_context, &psm2_req);
 
@@ -782,7 +782,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
-	if (epaddr_context->epid == ep_priv->domain->psm2_epid)
+	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_rma_self(PSMX2_AM_REQ_READV, ep_priv,
 				      ep_priv->domain->eps[vlane],
 				      (void *)iov, count, desc, addr,
@@ -815,7 +815,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 		req->no_event = 1;
 	}
 
-	chunk_size = psmx2_am_param.max_reply_short;
+	chunk_size = ep_priv->trx_ctxt->psm2_am_param.max_reply_short;
 
 	long_len = 0;
 	if (psmx2_env.tagged_rma) {
@@ -863,7 +863,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, vlane, ep_priv->vlane);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 		PSMX2_SET_TAG(psm2_tagsel, -1ULL, -1);
-		psm2_mq_irecv2(ep_priv->domain->psm2_mq, psm2_epaddr,
+		psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			       &psm2_tag, &psm2_tagsel, 0,
 			       long_buf, long_len,
 			       (void *)&req->fi_context, &psm2_req);
@@ -1007,7 +1007,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
-	if (epaddr_context->epid == ep_priv->domain->psm2_epid)
+	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_rma_self(PSMX2_AM_REQ_WRITE, ep_priv,
 				      ep_priv->domain->eps[vlane],
 				      (void *)buf, len, desc, addr,
@@ -1049,7 +1049,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	PSMX2_CTXT_USER(&req->fi_context) = context;
 	PSMX2_CTXT_EP(&req->fi_context) = ep_priv;
 
-	chunk_size = psmx2_am_param.max_request_short;
+	chunk_size = ep_priv->trx_ctxt->psm2_am_param.max_request_short;
 
 	args[0].u32w0 = 0;
 	PSMX2_AM_SET_SRC(args[0].u32w0, ep_priv->vlane);
@@ -1080,7 +1080,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 		psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args,
 				      nargs, NULL, 0, am_flags, NULL, NULL);
 
-		psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr, 0,
+		psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			       &psm2_tag, buf, len, psm2_context, &psm2_req);
 
 		return 0;
@@ -1189,7 +1189,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
-	if (epaddr_context->epid == ep_priv->domain->psm2_epid)
+	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_rma_self(PSMX2_AM_REQ_WRITEV, ep_priv,
 				      ep_priv->domain->eps[vlane],
 				      (void *)iov, count, desc, addr,
@@ -1202,7 +1202,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	for (i=0; i<count; i++)
 		total_len += iov[i].iov_len;
 
-	chunk_size = psmx2_am_param.max_request_short;
+	chunk_size = ep_priv->trx_ctxt->psm2_am_param.max_request_short;
 
 	/* Case 1: fit into a AM message, then pack and send */
 	if (total_len <= chunk_size) {
@@ -1315,7 +1315,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 			psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args,
 					      nargs, NULL, 0, am_flags, NULL, NULL);
 
-			psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr, 0,
+			psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 				       &psm2_tag, iov[i].iov_base, iov[i].iov_len,
 				       psm2_context, &psm2_req);
 

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -629,7 +629,10 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 		return -FI_EINVAL;
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;
@@ -772,7 +775,10 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	}
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;
@@ -997,7 +1003,10 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 		return -FI_EINVAL;
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;
@@ -1179,7 +1188,10 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	}
 
 	av = ep_priv->av;
-	if (av && av->type == FI_AV_TABLE) {
+	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
+		vlane = 0;
+	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if (idx >= av->last)
 			return -FI_EINVAL;

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -222,7 +222,7 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 					(has_data ? FI_REMOTE_CQ_DATA : 0),
 			PSMX2_CTXT_TYPE(&req->fi_context) = PSMX2_REMOTE_WRITE_CONTEXT;
 			PSMX2_CTXT_USER(&req->fi_context) = mr;
-			psmx2_am_enqueue_rma(mr->domain->base_trx_ctxt, req);
+			psmx2_am_enqueue_rma(trx_ctxt, req);
 		}
 		break;
 
@@ -293,7 +293,7 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 			req->read.peer_vl = src_vl;
 			PSMX2_CTXT_TYPE(&req->fi_context) = PSMX2_REMOTE_READ_CONTEXT;
 			PSMX2_CTXT_USER(&req->fi_context) = mr;
-			psmx2_am_enqueue_rma(mr->domain->base_trx_ctxt, req);
+			psmx2_am_enqueue_rma(trx_ctxt, req);
 		}
 		break;
 

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -98,8 +98,9 @@ static inline void psmx2_iov_copy(struct iovec *iov, size_t count,
  *	args[2].u64	offset
  */
 
-int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
-			 int nargs, void *src, uint32_t len)
+int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
+			     int nargs, void *src, uint32_t len,
+			     struct psmx2_trx_ctxt *trx_ctxt)
 {
 	psm2_amarg_t rep_args[8];
 	uint8_t *rma_addr;
@@ -120,10 +121,15 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 	psm2_am_get_source(token, &epaddr);
 
 	cmd = PSMX2_AM_GET_OP(args[0].u32w0);
-	dst_vl = PSMX2_AM_GET_DST(args[0].u32w0);
-
 	domain = psmx2_active_fabric->active_domain;
-	ep = domain->eps[dst_vl];
+
+	if (trx_ctxt->ep) {
+		dst_vl = 0;
+		ep = trx_ctxt->ep;
+	} else {
+		dst_vl = PSMX2_AM_GET_DST(args[0].u32w0);
+		ep = domain->eps[dst_vl];
+	}
 
 	eom = args[0].u32w0 & PSMX2_AM_EOM;
 	has_data = args[0].u32w0 & PSMX2_AM_DATA;

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -77,11 +77,11 @@ static ssize_t psmx2_tagged_peek_generic(struct fid_ep *ep,
 	PSMX2_SET_TAG(psm2_tagsel, ~ignore, tagsel32);
 
 	if (flags & (FI_CLAIM | FI_DISCARD))
-		err = psm2_mq_improbe2(ep_priv->domain->psm2_mq,
+		err = psm2_mq_improbe2(ep_priv->trx_ctxt->psm2_mq,
 				       psm2_epaddr, &psm2_tag,
 				       &psm2_tagsel, &req, &psm2_status);
 	else
-		err = psm2_mq_iprobe2(ep_priv->domain->psm2_mq,
+		err = psm2_mq_iprobe2(ep_priv->trx_ctxt->psm2_mq,
 				      psm2_epaddr, &psm2_tag, &psm2_tagsel,
 				      &psm2_status);
 	switch (err) {
@@ -202,7 +202,7 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 		PSMX2_CTXT_USER(fi_context) = buf;
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
 
-		err = psm2_mq_imrecv(ep_priv->domain->psm2_mq, 0,
+		err = psm2_mq_imrecv(ep_priv->trx_ctxt->psm2_mq, 0,
 				     buf, len, context, &psm2_req);
 		if (err != PSM2_OK)
 			return psmx2_errno(err);
@@ -252,7 +252,7 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 	PSMX2_SET_TAG(psm2_tag, tag, tag32);
 	PSMX2_SET_TAG(psm2_tagsel, ~ignore, tagsel32);
 
-	err = psm2_mq_irecv2(ep_priv->domain->psm2_mq, psm2_epaddr,
+	err = psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     &psm2_tag, &psm2_tagsel, 0, buf, len,
 			     (void *)fi_context, &psm2_req);
 
@@ -304,7 +304,7 @@ psmx2_tagged_recv_no_flag_av_map(struct fid_ep *ep, void *buf, size_t len,
 	PSMX2_SET_TAG(psm2_tag, tag, tag32);
 	PSMX2_SET_TAG(psm2_tagsel, ~ignore, tagsel32);
 
-	err = psm2_mq_irecv2(ep_priv->domain->psm2_mq, psm2_epaddr,
+	err = psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     &psm2_tag, &psm2_tagsel, 0, buf, len,
 			     (void *)fi_context, &psm2_req);
 	if (err != PSM2_OK)
@@ -359,7 +359,7 @@ psmx2_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf, size_t len,
 	PSMX2_SET_TAG(psm2_tag, tag, tag32);
 	PSMX2_SET_TAG(psm2_tagsel, ~ignore, tagsel32);
 
-	err = psm2_mq_irecv2(ep_priv->domain->psm2_mq, psm2_epaddr,
+	err = psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     &psm2_tag, &psm2_tagsel, 0, buf, len,
 			     (void *)fi_context, &psm2_req);
 	if (err != PSM2_OK)
@@ -407,7 +407,7 @@ psmx2_tagged_recv_no_event_av_map(struct fid_ep *ep, void *buf, size_t len,
 	PSMX2_SET_TAG(psm2_tag, tag, tag32);
 	PSMX2_SET_TAG(psm2_tagsel, ~ignore, tagsel32);
 
-	err = psm2_mq_irecv2(ep_priv->domain->psm2_mq, psm2_epaddr,
+	err = psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     &psm2_tag, &psm2_tagsel, 0, buf, len,
 			     (void *)fi_context, &psm2_req);
 
@@ -459,7 +459,7 @@ psmx2_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf, size_t len,
 	PSMX2_SET_TAG(psm2_tag, tag, tag32);
 	PSMX2_SET_TAG(psm2_tagsel, ~ignore, tagsel32);
 
-	err = psm2_mq_irecv2(ep_priv->domain->psm2_mq, psm2_epaddr,
+	err = psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     &psm2_tag, &psm2_tagsel, 0, buf, len,
 			     (void *)fi_context, &psm2_req);
 
@@ -608,7 +608,7 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 		if (len > PSMX2_INJECT_SIZE)
 			return -FI_EMSGSIZE;
 
-		err = psm2_mq_send2(ep_priv->domain->psm2_mq, psm2_epaddr,
+		err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 				    0, &psm2_tag, buf, len);
 
 		if (err != PSM2_OK)
@@ -646,7 +646,7 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
 	}
 
-	err = psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr, 0,
+	err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			     &psm2_tag, buf, len, (void*)fi_context,
 			     &psm2_req);
 
@@ -687,7 +687,7 @@ psmx2_tagged_send_no_flag_av_map(struct fid_ep *ep, const void *buf,
 	PSMX2_CTXT_USER(fi_context) = (void *)buf;
 	PSMX2_CTXT_EP(fi_context) = ep_priv;
 
-	err = psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr, 0,
+	err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			     &psm2_tag, buf, len, (void*)fi_context,
 			     &psm2_req);
 
@@ -733,7 +733,7 @@ psmx2_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	PSMX2_CTXT_USER(fi_context) = (void *)buf;
 	PSMX2_CTXT_EP(fi_context) = ep_priv;
 
-	err = psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr, 0,
+	err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			     &psm2_tag, buf, len, (void*)fi_context,
 			     &psm2_req);
 
@@ -769,7 +769,7 @@ psmx2_tagged_send_no_event_av_map(struct fid_ep *ep, const void *buf,
 
 	fi_context = &ep_priv->nocomp_send_context;
 
-	err = psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr, 0,
+	err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			     &psm2_tag, buf, len, (void*)fi_context,
 			     &psm2_req);
 
@@ -811,7 +811,7 @@ psmx2_tagged_send_no_event_av_table(struct fid_ep *ep, const void *buf,
 
 	fi_context = &ep_priv->nocomp_send_context;
 
-	err = psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr, 0,
+	err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			     &psm2_tag, buf, len, (void*)fi_context,
 			     &psm2_req);
 
@@ -844,7 +844,7 @@ psmx2_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf,
 	tag32 = PSMX2_TAG32(0, ep_priv->vlane, vlane);
 	PSMX2_SET_TAG(psm2_tag, tag, tag32);
 
-	err = psm2_mq_send2(ep_priv->domain->psm2_mq, psm2_epaddr, 0,
+	err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			    &psm2_tag, buf, len);
 
 	if (err != PSM2_OK)
@@ -886,7 +886,7 @@ psmx2_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	tag32 = PSMX2_TAG32(0, ep_priv->vlane, vlane);
 	PSMX2_SET_TAG(psm2_tag, tag, tag32);
 
-	err = psm2_mq_send2(ep_priv->domain->psm2_mq, psm2_epaddr, 0,
+	err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			    &psm2_tag, buf, len);
 
 	if (err != PSM2_OK)
@@ -1023,7 +1023,7 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 			return -FI_EMSGSIZE;
 		}
 
-		err = psm2_mq_send2(ep_priv->domain->psm2_mq, psm2_epaddr,
+		err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 				    send_flag, &psm2_tag, req->buf, len);
 
 		free(req);
@@ -1061,7 +1061,7 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 	PSMX2_CTXT_USER(fi_context) = req;
 	PSMX2_CTXT_EP(fi_context) = ep_priv;
 
-	err = psm2_mq_isend2(ep_priv->domain->psm2_mq, psm2_epaddr,
+	err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     send_flag, &psm2_tag, req->buf, len,
 			     (void *)fi_context, &psm2_req);
 
@@ -1082,7 +1082,7 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 		PSMX2_SET_TAG(psm2_tag, tag, tag32);
 		for (i=0; i<count; i++) {
 			if (iov[i].iov_len) {
-				err = psm2_mq_isend2(ep_priv->domain->psm2_mq,
+				err = psm2_mq_isend2(ep_priv->trx_ctxt->psm2_mq,
 						     psm2_epaddr, send_flag, &psm2_tag,
 						     iov[i].iov_base, iov[i].iov_len,
 						     (void *)fi_context, &psm2_req);

--- a/prov/psm2/src/psmx2_wait.c
+++ b/prov/psm2/src/psmx2_wait.c
@@ -62,7 +62,7 @@ static void *psmx2_wait_progress(void *args)
 
 		psmx2_wait_thread_busy = 1;
 		while (psmx2_wait_thread_enabled)
-			psmx2_progress(domain);
+			psmx2_progress_all(domain);
 
 		psmx2_wait_thread_busy = 0;
 


### PR DESCRIPTION
This set of commits implement scalable endpoints in the psm2 provider. It allows applications to utilize multiple hardware Tx/Rx contexts to achieve higher bandwidth over a single endpoint.