### PR TITLE
prov/sockets: Add support for tagged atomics

### DIFF
--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -565,8 +565,12 @@ int sock_query_atomic(struct fid_domain *domain,
 		      enum fi_datatype datatype, enum fi_op op,
 		      struct fi_atomic_attr *attr, uint64_t flags)
 {
-	if (flags)
-		return -FI_ENOSYS;
+	if (flags & FI_TAGGED) {
+		if (flags & (FI_FETCH_ATOMIC | FI_COMPARE_ATOMIC))
+			return -FI_ENOSYS;
+	} else if (flags & ~(FI_FETCH_ATOMIC | FI_COMPARE_ATOMIC)) {
+		 return -FI_EBADFLAGS;
+	}
 
 	switch (datatype) {
 	case FI_FLOAT:

--- a/prov/sockets/src/sock_rx_entry.c
+++ b/prov/sockets/src/sock_rx_entry.c
@@ -125,8 +125,6 @@ struct sock_rx_entry *sock_rx_new_buffered_entry(struct sock_rx_ctx *rx_ctx,
 
 	rx_ctx->buffered_len += len;
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_buffered_list);
-	rx_entry->is_busy = 1;
-	rx_entry->is_tagged = 0;
 
 	return rx_entry;
 }


### PR DESCRIPTION
Initial implementation of performing atomic operations to
tagged data buffers.  This patch is untested -- need to
create a tagged atomic test.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>