### PR TITLE
prov/socket: inet_ntoa is replaced by inet_ntop

### DIFF
--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -53,7 +53,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;ENABLE_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;ENABLE_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect</AdditionalIncludeDirectories>
       <CompileAs>CompileAsC</CompileAs>
@@ -77,7 +77,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;_CRT_SECURE_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_WINSOCKAPI_;_CRT_SECURE_NO_WARNINGS;_WINSOCK_DEPRECATED_NO_WARNINGS;_WINDOWS;_USRDLL;LIBFABRIC_EXPORTS;HAVE_CONFIG_H;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)include;$(ProjectDir)include\windows;$(ProjectDir)prov\netdir\NetDirect</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4127;4200;94;4204;4221</DisableSpecificWarnings>

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -240,7 +240,7 @@ static int sock_check_table_in(struct sock_av *_av, struct sockaddr_in *addr,
 		}
 
 		av_addr = &_av->table[index];
-		memcpy(sa_ip, inet_ntoa((&addr[i])->sin_addr), INET_ADDRSTRLEN);
+		inet_ntop(addr[i].sin_family, &addr[i].sin_addr, sa_ip, INET_ADDRSTRLEN);
 		SOCK_LOG_DBG("AV-INSERT: dst_addr family: %d, IP %s, port: %d\n",
 			      ((struct sockaddr_in *)&addr[i])->sin_family,
 				sa_ip, ntohs(((struct sockaddr_in *)&addr[i])->sin_port));
@@ -418,15 +418,17 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 }
 
 static const char *sock_av_straddr(struct fid_av *av, const void *addr,
-				    char *buf, size_t *len)
+				   char *buf, size_t *len)
 {
 	const struct sockaddr_in *sin;
 	char straddr[24];
+	char ipaddr[24];
 	int size;
 
 	sin = addr;
+	inet_ntop(sin->sin_family, (void*)&sin->sin_addr, ipaddr, sizeof(ipaddr));
 	size = snprintf(straddr, sizeof(straddr), "%s:%d",
-			inet_ntoa(sin->sin_addr), ntohs(sin->sin_port));
+			ipaddr, ntohs(sin->sin_port));
 	snprintf(buf, *len, "%s", straddr);
 	*len = size + 1;
 	return buf;

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -307,6 +307,7 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 	struct sock_conn_listener *listener = &ep_attr->listener;
 	char service[NI_MAXSERV] = {0};
 	char *port;
+	char ipaddr[24];
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_INET;
@@ -328,7 +329,8 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 	} else
 		port = listener->service;
 
-	ret = getaddrinfo(inet_ntoa(addr.sin_addr), port, &hints, &s_res);
+	inet_ntop(addr.sin_family, &addr.sin_addr, ipaddr, sizeof(ipaddr));
+	ret = getaddrinfo(ipaddr, port, &hints, &s_res);
 	if (ret) {
 		SOCK_LOG_ERROR("no available AF_INET address, service %s, %s\n",
 			       listener->service, gai_strerror(ret));

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -967,7 +967,7 @@ static const char *ip_av_straddr(struct fid_av *av, const void *addr, char *buf,
 	switch (sock_addr->sa_family) {
 	case AF_INET:
 		sin = addr;
-		if (!inet_ntop(sin->sin_family, &sin->sin_addr.s_addr, str,
+		if (!inet_ntop(sin->sin_family, (void*)&sin->sin_addr.s_addr, str,
 			       sizeof(str)))
 			return NULL;
 


### PR DESCRIPTION
- inet_ntoa is deprecated call, it is not thread safe due
  to usage of static buffers. these calls are replaced by
  inet_ntop calls in release mode (SOCK_DBG_***) macro were
  not changed)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>