### PR TITLE
prov/psm,psm2: Cherry-pick two performance related bug fixes from master

### DIFF
--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -404,6 +404,7 @@ int psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 
 	switch (attr->wait_obj) {
 	case FI_WAIT_NONE:
+	case FI_WAIT_UNSPEC:
 		break;
 
 	case FI_WAIT_SET:
@@ -415,7 +416,6 @@ int psmx_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		wait = attr->wait_set;
 		break;
 
-	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
 	case FI_WAIT_MUTEX_COND:
 		wait_attr.wait_obj = attr->wait_obj;

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -457,6 +457,7 @@ int psmx2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 
 	switch (attr->wait_obj) {
 	case FI_WAIT_NONE:
+	case FI_WAIT_UNSPEC:
 		break;
 
 	case FI_WAIT_SET:
@@ -468,7 +469,6 @@ int psmx2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		wait = attr->wait_set;
 		break;
 
-	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
 	case FI_WAIT_MUTEX_COND:
 		wait_attr.wait_obj = attr->wait_obj;

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -272,7 +272,7 @@ static uint64_t psmx2_cntr_read(struct fid_cntr *cntr)
 
 	cntr_priv = container_of(cntr, struct psmx2_fid_cntr, cntr);
 
-	if (poll_cnt++ == PSMX2_CNTR_POLL_THRESHOLD) {
+	if (poll_cnt++ >= PSMX2_CNTR_POLL_THRESHOLD) {
 		psmx2_progress(cntr_priv->domain);
 		poll_cnt = 0;
 	}


### PR DESCRIPTION
(1) Update the default wait method for counters
(2) Fix an RMA progress bug in multi-threaded runs