### PR TITLE
prov/bgq: Incorrect posting of errors in manual progress mode

### DIFF
--- a/prov/bgq/include/rdma/fi_direct_tagged.h
+++ b/prov/bgq/include/rdma/fi_direct_tagged.h
@@ -141,6 +141,9 @@ ssize_t fi_bgq_trecvmsg_generic (struct fid_ep *ep,
 			ret = fi_bgq_lock_if_required(&bgq_ep->lock, lock_required);
 			if (ret) return ret;
 
+#ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_trecvmsg_generic calling fi_bgq_ep_progress_manual_recv:\n");
+#endif
 			fi_bgq_ep_progress_manual_recv(bgq_ep,
 				0, /* is_msg */
 				(union fi_bgq_context *)(context_rsh3b << 3),
@@ -160,6 +163,9 @@ ssize_t fi_bgq_trecvmsg_generic (struct fid_ep *ep,
 		ret = fi_bgq_lock_if_required(&bgq_ep->lock, lock_required);
 		if (ret) return ret;
 
+#ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_trecvmsg_generic calling fi_bgq_ep_progress_manual_recv:\n");
+#endif
 		fi_bgq_ep_progress_manual_recv(bgq_ep,
 			0, /* is_msg */
 			(union fi_bgq_context *)(context_rsh3b << 3),

--- a/prov/bgq/src/fi_bgq_cq.c
+++ b/prov/bgq/src/fi_bgq_cq.c
@@ -327,7 +327,7 @@ int fi_bgq_cq_enqueue_err (struct fi_bgq_cq * bgq_cq,
 		case FI_THREAD_DOMAIN:
 			lock_required = 0;
 		default:
-			lock_required = 1;
+			lock_required = 0;
 		}
 
 		int ret;


### PR DESCRIPTION
The function fi_bgq_cq_enqueue_err was written to properly handle queuing of errors
appropriately as a linked list for manual mode or atomic fifo for auto mode.  However
there were places in the code where error events took place and instead of calling
fi_bgq_cq_enqueue_err posted the error on atomic fifo instead, which then was only
correct for auto mode.  In manual mode this resulted in hangs in some error situations,
one of which was for MPI_Probe when the context probed for had not yet arrived.  The
fix is to utilize the fi_bgq_cq_enqueue_err function in all these situations, and also
there was a but in fi_bgq_cq_enqueue_err regarding locks which was resolved.

Signed-off-by: Paul Coffman <pcoffman@anl.gov>