### PR TITLE
core: Fix crash while printing fi_domain_atrr::name

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -93,25 +93,35 @@
 #define ofi_sin_addr(addr) (((struct sockaddr_in *)(addr))->sin_addr)
 #define ofi_sin6_addr(addr) (((struct sockaddr_in6 *)(addr))->sin6_addr)
 
-#define FI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str,type)	\
-	do {									\
-		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",		\
-				fi_tostr(&prov_attr, type));			\
-		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n",		\
-				fi_tostr(&user_attr, type));			\
+#define FI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type)	\
+	do {										\
+		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",			\
+				fi_tostr(&prov_attr, type));				\
+		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n",			\
+				fi_tostr(&user_attr, type));				\
 	} while (0)
 
-#define FI_INFO_CHECK(provider, prov, user, field, type) \
-	FI_INFO_FIELD(provider, prov->field, user->field, "Supported",\
+#define FI_INFO_STRING(provider, prov_attr, user_attr, prov_str, user_str)	\
+	do {									\
+		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n", prov_attr);	\
+		FI_INFO(provider, FI_LOG_CORE, user_str ": %s\n", user_attr);	\
+	} while (0)
+
+#define FI_INFO_CHECK(provider, prov, user, field, type)		\
+	FI_INFO_FIELD(provider, prov->field, user->field, "Supported",	\
 		      "Requested", type)
 
-#define FI_INFO_MODE(provider, prov_mode, user_mode) \
-	FI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",\
+#define FI_INFO_MODE(provider, prov_mode, user_mode)				\
+	FI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",	\
 		      FI_TYPE_MODE)
 
-#define FI_INFO_MR_MODE(provider, prov_mode, user_mode) \
-	FI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",\
+#define FI_INFO_MR_MODE(provider, prov_mode, user_mode)			\
+	FI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",	\
 		      FI_TYPE_MR_MODE)
+
+#define FI_INFO_NAME(provider, prov, user)				\
+	FI_INFO_STRING(provider, prov->name, user->name, "Supported",	\
+		       "Requested")
 
 enum {
 	UTIL_TX_SHARED_CTX = 1 << 0,

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -394,7 +394,7 @@ static int fi_resource_mgmt_level(enum fi_resource_mgmt rm_model)
  * mode bit in prov_mode. Support for FI_MR_SCALABLE is indicated by not setting
  * any of OFI_MR_BASIC_MAP bits. */
 int ofi_check_mr_mode(uint32_t api_version, uint32_t prov_mode,
-			     uint32_t user_mode)
+		      uint32_t user_mode)
 {
 	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5))) {
 		prov_mode &= ~FI_MR_LOCAL; /* ignore local bit */
@@ -433,8 +433,7 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 	if (prov_attr->name && user_attr->name &&
 	    strcasecmp(user_attr->name, prov_attr->name)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unknown domain name\n");
-		FI_INFO_CHECK(prov, prov_attr, user_attr, name,
-			      FI_TYPE_DOMAIN_ATTR);
+		FI_INFO_NAME(prov, prov_attr, user_attr);
 		return -FI_ENODATA;
 	}
 


### PR DESCRIPTION
The problem is incompatible datatype (FI_TYPE_DOMAIN_ATTR) and fi_domain_atrr->field (char *name) were passed to helper macro that uses fi_tostr
Proposed solution:
Add new datatype FI_TYPE_NAME for fi_tostr that can be used to printout fi_domain_atrr/fi_fabric_attr::name.