### PR TITLE
win/ci: added Windows CI support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,23 @@
+image: Visual Studio 2015
+
+build:
+  project: libfabric.sln
+
+configuration:
+- Debug
+- Release
+
+before_build:
+  - ps: Invoke-WebRequest -Uri "https://download.microsoft.com/download/5/A/E/5AEA3C34-32A1-4A70-9622-F9734E92981F/NetworkDirect_DDK.zip" -OutFile "NetworkDirect_DDK.zip"
+  - ps: '$wd=$PWD.Path; & { Add-Type -A "System.IO.Compression.FileSystem"; [IO.Compression.ZipFile]::ExtractToDirectory("$wd\NetworkDirect_DDK.zip", "$wd"); }'
+  - ps: mkdir prov\netdir\NetDirect
+  - ps: move "NetDirect\include\*" "prov\netdir\NetDirect"
+  - ps: >
+          $tool="v140";
+          $namespaces=@{ vs="http://schemas.microsoft.com/developer/msbuild/2003" };
+          Get-ChildItem "." -Filter "*.vcxproj" |
+          foreach {
+              $toolsets = Select-Xml -Path $_.FullName -XPath '/vs:Project/vs:PropertyGroup[@Label="Configuration"]/vs:PlatformToolset' -Namespace $namespaces;
+              foreach ($_ in $toolsets) {$_.Node.InnerText=$tool};
+              $toolsets[0].Node.OwnerDocument.Save($toolsets[0].Path);
+          }


### PR DESCRIPTION
Added `.appveyor.yml` to support [AppVeyor CI](https://www.appveyor.com) for Windows build

#### Steps for repository administrator to enable AppVeyor:
1. Sign in on https://ci.appveyor.com
2. click **NEW PROJECT** -> hover on **libfabric** -> click **ADD**
3. libfabric -> click **SETTINGS** -> **General**:
  a) set **'Build version format'** to: `{build}`
  b) set **'Custom configuration .yml file name'** to: `.appveyor.yml`
  c) check **'Skip branches without appveyor.yml'**: `on`
