### PR TITLE
prov/netdir: added Network Direct DDK readme

### DIFF
--- a/prov/netdir/NetDirect/README.NetworkDirect
+++ b/prov/netdir/NetDirect/README.NetworkDirect
@@ -1,0 +1,6 @@
+Network Direct SDK/DDK may be downloaded from:
+https://www.microsoft.com/en-us/download/details.aspx?id=36043
+on page press Download button and select NetworkDirect_DDK.zip.
+Extract header files from downloaded
+NetworkDirect_DDK.zip:\NetDirect\include\ file into this directory,
+or add path to NetDirect headers into VS include paths


### PR DESCRIPTION
- added readme file with instructions how to downoad
  and extract Network Direct headers (required to build
  netdir provider)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>