### PR TITLE
utils/mem: suppressed type-mismatch warnings

### DIFF
--- a/include/fi_mem.h
+++ b/include/fi_mem.h
@@ -99,7 +99,7 @@ struct name {							\
 								\
 static inline void name ## _init(struct name *fs, size_t size)	\
 {								\
-	int i;							\
+	ssize_t i;						\
 	assert(size == roundup_power_of_two(size));		\
 	assert(sizeof(fs->buf[0]) >= sizeof(void *));		\
 	fs->size = size;					\
@@ -121,7 +121,7 @@ static inline struct name * name ## _create(size_t size)	\
 static inline int name ## _index(struct name *fs,		\
 		entrytype *entry)				\
 {								\
-	return entry - fs->buf;					\
+	return (int)(entry - fs->buf);				\
 }								\
 								\
 static inline void name ## _free(struct name *fs)		\

--- a/prov/netdir/netdir_buf.h
+++ b/prov/netdir/netdir_buf.h
@@ -186,7 +186,7 @@ extern "C" {
 			} while (ICEP((volatile PVOID*)&footer->item_free,			\
 				      (void*)&data->item[1], (void*)next_free) != next_free);	\
 												\
-			InterlockedAdd(&footer->count, count);					\
+			InterlockedAdd(&footer->count, (LONG)count);				\
 												\
 			/* add new chunk into footer */						\
 			do {									\


### PR DESCRIPTION
- there was size_t->int type conversion which caused compilation
  warning. Added type-operator to suppress warning

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>