### PR TITLE
fabric: Update proposed deferred work queue definition

### DIFF
--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -45,10 +45,9 @@ extern "C" {
 
 enum fi_trigger_event {
 	FI_TRIGGER_THRESHOLD,
-	FI_TRIGGER_COMPLETION
 };
 
-enum fi_trigger_op {
+enum fi_op_type {
 	FI_OP_RECV,
 	FI_OP_SEND,
 	FI_OP_TRECV,
@@ -65,10 +64,6 @@ enum fi_trigger_op {
 struct fi_trigger_threshold {
 	struct fid_cntr		*cntr;
 	size_t			threshold;
-};
-
-struct fi_trigger_completion {
-	struct fi_context	*context;
 };
 
 struct fi_op_msg {
@@ -133,13 +128,11 @@ struct fi_triggered_context {
 struct fi_deferred_work {
 	struct fi_context			context;
 
-	enum fi_trigger_event			event_type;
-	enum fi_trigger_op			op_type;
+	uint64_t				threshold;
+	struct fid_cntr				*triggering_cntr;
+	struct fid_cntr				*completion_cntr;
 
-	union {
-		struct fi_trigger_threshold	*threshold;
-		struct fi_trigger_completion	*completion;
-	} event;
+	enum fi_op_type				op_type;
 
 	union {
 		struct fi_op_msg		*msg;

--- a/man/fi_trigger.3.md
+++ b/man/fi_trigger.3.md
@@ -85,37 +85,40 @@ The following trigger events are defined.
   they will be triggered in the order in which they were submitted to
   the endpoint.
 
-# EXPERIMENTAL TRIGGERED OPERATIONS
+# EXPERIMENTAL DEFERRED WORK QUEUES
 
 The following feature and description are enhancements to triggered
 operation support, but should be considered experimental.  Until the
-experimental tag is removed, the interfaces and data structures defined
-below may change between library versions.
+experimental tag is removed, the interfaces, semantics, and data
+structures defined below may change between library versions.
 
-Experimental triggered operations allow an application to queue operations
-to a deferred work queue that is associated with the domain.  Note that
-the deferred work queue is a conceptual construct, rather than an
-implementation requirement.  Deferred work requests consist of two
-components: an event or condition that must first be met, along with an
-operation to perform.
+The deferred work queue interface is designed as primitive constructs
+that can be used to implement application-level collective operations.
+They are a more advanced form of triggered operation.  They
+allow an application to queue operations to a deferred work queue
+that is associated with the domain.  Note that the deferred work queue
+is a conceptual construct, rather than an implementation requirement.
+Deferred work requests consist of three main components: an event or
+condition that must first be met, an operation to perform, and a
+completion notification.
 
 Because deferred work requests are posted directly to the domain, they
 can support a broader set of conditions and operations.  Deferred
 work requests are submitted using struct fi_deferred_work.  That structure,
-along with any event and operation structures used to describe the work
-must remain valid until the operation completes or is canceled.
+along with the corresponding operation structures (referenced through
+the op union) used to describe the work must remain valid until the
+operation completes or is canceled.  The format of the deferred work
+request is as follows:
 
 ```c
 struct fi_deferred_work {
 	struct fi_context     context;
 
-	enum fi_trigger_event event_type;
-	enum fi_trigger_op    op_type;
+	uint64_t              threshold;
+	struct fid_cntr       *triggering_cntr;
+	struct fid_cntr       *completion_cntr;
 
-	union {
-		struct fi_trigger_threshold *threshold;
-		struct fi_trigger_completion *completion;
-	} event;
+	enum fi_trigger_op    op_type;
 
 	union {
 		struct fi_op_msg            *msg;
@@ -131,24 +134,39 @@ struct fi_deferred_work {
 ```
 
 Once a work request has been posted to the deferred work queue, it will
-remain on the queue until its condition has been met.  It is the
-responsibility of the application to detect and handle situations that
-occur which could result in the condition not being met.  For example,
-if a work request is dependent upon the successful completion of a data
-transfer operation, which fails, then the application must cancel the
-work request.  A work request with its condition met at the time of posting
-will automatically have its operation initiated.
+remain on the queue until the triggering counter (success plus error
+counter values) has reached the indicated threshold.  If the triggering
+condition has already been met at the time the work request is queued,
+the operation will be initiated immediately.
 
-If the work request will generate a completion, the completion event
-will return the context field of struct fi_deferred_work as the context
-for the operation.
+On the completion of a deferred data transfer, the specified completion
+counter will be incremented by one.  Note that deferred counter operations do
+not update the completion counter; only the counter specified through the
+fi_op_cntr is modified.  The completion_cntr field must be NULL for counter
+operations.
+
+Because deferred work targets support of collective communication operations,
+posted work requests do not generate any completions at the endpoint by
+default.  For example, completed operations are not written to the EP's
+completion queue or update the EP counter (unless the EP counter is
+explicitly referenced as the completion_cntr).  An application may request
+EP completions by specifying the FI_COMPLETION flag as part of the
+operation.
+
+It is the responsibility of the application to detect and handle situations
+that occur which could result in a deferred work request's condition not
+being met.  For example, if a work request is dependent upon the successful
+completion of a data transfer operation, which fails, then the application
+must cancel the work request.
 
 To submit a deferred work request, applications should use the domain's
 fi_control function with command FI_QUEUE_WORK and struct fi_deferred_work
 as the fi_control arg parameter.  To cancel a deferred work request, use
 fi_control with command FI_CANCEL_WORK and the corresponding struct
 fi_deferred_work to cancel.  The fi_control command FI_FLUSH_WORK will
-cancel all queued work requests.
+cancel all queued work requests.  FI_FLUSH_WORK may be used to flush all
+work queued to the domain, or may be used to cancel all requests waiting
+on a specific triggering_cntr.
 
 Deferred work requests are not acted upon by the provider until the
 associated event has occurred; although, certain validation checks
@@ -157,26 +175,6 @@ not read or otherwise accessed.  But the provider may validate fabric
 objects, such as endpoints and counters, and that input parameters fall
 within supported ranges.  If a specific request is not supported by the
 provider, it will fail the operation with -FI_ENOSYS.
-
-## EXPERIMENTAL TRIGGER EVENTS
-
-The following trigger events are defined.
-
-*FI_TRIGGER_THRESHOLD*
-: See the above definition.
-
-*FI_TRIGGER_COMPLETION*
-: This indicates that the data transfer operation will be deferred
-  until the specified operation has completed.  The operation is specified
-  using struct fi_trigger_completion:
-
-  ```c
-  struct fi_trigger_completion {
-	struct fi_context *context;
-  };
-  ```
-
-  The context must refer to the fi_context of the posted operation.
 
 # SEE ALSO
 

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -233,7 +233,7 @@ struct sock_domain {
 };
 
 struct sock_trigger {
-	enum fi_trigger_op op_type;
+	enum fi_op_type op_type;
 	size_t threshold;
 	struct dlist_entry entry;
 
@@ -1166,15 +1166,15 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 
 int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work);
 ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
-			  uint64_t flags, enum fi_trigger_op op_type);
+			  uint64_t flags, enum fi_op_type op_type);
 ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 			     const struct fi_ioc *comparev, size_t compare_count,
 			     struct fi_ioc *resultv, size_t result_count,
-			     uint64_t flags, enum fi_trigger_op op_type);
+			     uint64_t flags, enum fi_op_type op_type);
 ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
-			   uint64_t flags, enum fi_trigger_op op_type);
+			   uint64_t flags, enum fi_op_type op_type);
 ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
-			  uint64_t flags, enum fi_trigger_op op_type);
+			  uint64_t flags, enum fi_op_type op_type);
 ssize_t sock_queue_cntr_op(struct fi_deferred_work *work, uint64_t flags);
 void sock_cntr_check_trigger_list(struct sock_cntr *cntr);
 

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -127,6 +127,7 @@ int sock_cntr_progress(struct sock_cntr *cntr)
 
 void sock_cntr_check_trigger_list(struct sock_cntr *cntr)
 {
+	struct fi_deferred_work *work;
 	struct sock_trigger *trigger;
 	struct dlist_entry *entry;
 	int ret = 0;
@@ -182,15 +183,15 @@ void sock_cntr_check_trigger_list(struct sock_cntr *cntr)
 						trigger->flags & ~FI_TRIGGER);
 			break;
 		case FI_OP_CNTR_SET:
-			assert(trigger->work);
-			fi_cntr_set(trigger->work->op.cntr->cntr,
-				    trigger->work->op.cntr->value);
+			work = container_of(trigger->context,
+					    struct fi_deferred_work, context);
+			fi_cntr_set(work->op.cntr->cntr, work->op.cntr->value);
 			ret = 0;
 			break;
 		case FI_OP_CNTR_ADD:
-			assert(trigger->work);
-			fi_cntr_add(trigger->work->op.cntr->cntr,
-				    trigger->work->op.cntr->value);
+			work = container_of(trigger->context,
+					    struct fi_deferred_work, context);
+			fi_cntr_add(work->op.cntr->cntr, work->op.cntr->value);
 			ret = 0;
 			break;
 		default:

--- a/prov/sockets/src/sock_trigger.c
+++ b/prov/sockets/src/sock_trigger.c
@@ -48,24 +48,27 @@ ssize_t sock_queue_rma_op(struct fid_ep *ep, const struct fi_msg_rma *msg,
 {
 	struct sock_cntr *cntr;
 	struct sock_trigger *trigger;
-	struct fi_triggered_context *trigger_context;
-	struct fi_trigger_threshold *threshold;
+	struct sock_triggered_context *trigger_context;
+	struct sock_trigger_work *work;
 
-	trigger_context = (struct fi_triggered_context *) msg->context;
+	trigger_context = (struct sock_triggered_context *) msg->context;
 	if ((flags & FI_INJECT) || !trigger_context ||
-	     (trigger_context->event_type != FI_TRIGGER_THRESHOLD))
+	    ((trigger_context->event_type != FI_TRIGGER_THRESHOLD) &&
+	     (trigger_context->event_type != SOCK_DEFERRED_WORK)))
 		return -FI_EINVAL;
 
-	threshold = &trigger_context->trigger.threshold;
-	cntr = container_of(threshold->cntr, struct sock_cntr, cntr_fid);
-	if (ofi_atomic_get32(&cntr->value) >= (int)threshold->threshold)
+	work = &trigger_context->trigger.work;
+	cntr = container_of(work->triggering_cntr, struct sock_cntr, cntr_fid);
+	if (ofi_atomic_get32(&cntr->value) >= (int) work->threshold)
 		return 1;
 
 	trigger = calloc(1, sizeof(*trigger));
 	if (!trigger)
 		return -FI_ENOMEM;
 
-	trigger->threshold = threshold->threshold;
+	trigger->context = trigger_context;
+	trigger->threshold = work->threshold;
+
 	memcpy(&trigger->op.rma.msg, msg, sizeof(*msg));
 	trigger->op.rma.msg.msg_iov = &trigger->op.rma.msg_iov[0];
 	trigger->op.rma.msg.rma_iov = &trigger->op.rma.rma_iov[0];
@@ -91,24 +94,26 @@ ssize_t sock_queue_msg_op(struct fid_ep *ep, const struct fi_msg *msg,
 {
 	struct sock_cntr *cntr;
 	struct sock_trigger *trigger;
-	struct fi_triggered_context *trigger_context;
-	struct fi_trigger_threshold *threshold;
+	struct sock_triggered_context *trigger_context;
+	struct sock_trigger_work *work;
 
-	trigger_context = (struct fi_triggered_context *) msg->context;
+	trigger_context = (struct sock_triggered_context *) msg->context;
 	if ((flags & FI_INJECT) || !trigger_context ||
-	     (trigger_context->event_type != FI_TRIGGER_THRESHOLD))
+	    ((trigger_context->event_type != FI_TRIGGER_THRESHOLD) &&
+	     (trigger_context->event_type != SOCK_DEFERRED_WORK)))
 		return -FI_EINVAL;
 
-	threshold = &trigger_context->trigger.threshold;
-	cntr = container_of(threshold->cntr, struct sock_cntr, cntr_fid);
-	if (ofi_atomic_get32(&cntr->value) >= (int)threshold->threshold)
+	work = &trigger_context->trigger.work;
+	cntr = container_of(work->triggering_cntr, struct sock_cntr, cntr_fid);
+	if (ofi_atomic_get32(&cntr->value) >= (int) work->threshold)
 		return 1;
 
 	trigger = calloc(1, sizeof(*trigger));
 	if (!trigger)
 		return -FI_ENOMEM;
 
-	trigger->threshold = threshold->threshold;
+	trigger->context = trigger_context;
+	trigger->threshold = work->threshold;
 
 	memcpy(&trigger->op.msg.msg, msg, sizeof(*msg));
 	trigger->op.msg.msg.msg_iov = &trigger->op.msg.msg_iov[0];
@@ -131,24 +136,26 @@ ssize_t sock_queue_tmsg_op(struct fid_ep *ep, const struct fi_msg_tagged *msg,
 {
 	struct sock_cntr *cntr;
 	struct sock_trigger *trigger;
-	struct fi_triggered_context *trigger_context;
-	struct fi_trigger_threshold *threshold;
+	struct sock_triggered_context *trigger_context;
+	struct sock_trigger_work *work;
 
-	trigger_context = (struct fi_triggered_context *) msg->context;
+	trigger_context = (struct sock_triggered_context *) msg->context;
 	if ((flags & FI_INJECT) || !trigger_context ||
-	     (trigger_context->event_type != FI_TRIGGER_THRESHOLD))
+	    ((trigger_context->event_type != FI_TRIGGER_THRESHOLD) &&
+	     (trigger_context->event_type != SOCK_DEFERRED_WORK)))
 		return -FI_EINVAL;
 
-	threshold = &trigger_context->trigger.threshold;
-	cntr = container_of(threshold->cntr, struct sock_cntr, cntr_fid);
-	if (ofi_atomic_get32(&cntr->value) >= (int)threshold->threshold)
+	work = &trigger_context->trigger.work;
+	cntr = container_of(work->triggering_cntr, struct sock_cntr, cntr_fid);
+	if (ofi_atomic_get32(&cntr->value) >= (int) work->threshold)
 		return 1;
 
 	trigger = calloc(1, sizeof(*trigger));
 	if (!trigger)
 		return -FI_ENOMEM;
 
-	trigger->threshold = threshold->threshold;
+	trigger->context = trigger_context;
+	trigger->threshold = work->threshold;
 
 	memcpy(&trigger->op.tmsg.msg, msg, sizeof(*msg));
 	trigger->op.tmsg.msg.msg_iov = &trigger->op.tmsg.msg_iov[0];
@@ -173,24 +180,27 @@ ssize_t sock_queue_atomic_op(struct fid_ep *ep, const struct fi_msg_atomic *msg,
 {
 	struct sock_cntr *cntr;
 	struct sock_trigger *trigger;
-	struct fi_triggered_context *trigger_context;
-	struct fi_trigger_threshold *threshold;
+	struct sock_triggered_context *trigger_context;
+	struct sock_trigger_work *work;
 
-	trigger_context = (struct fi_triggered_context *) msg->context;
+	trigger_context = (struct sock_triggered_context *) msg->context;
 	if ((flags & FI_INJECT) || !trigger_context ||
-	     (trigger_context->event_type != FI_TRIGGER_THRESHOLD))
+	    ((trigger_context->event_type != FI_TRIGGER_THRESHOLD) &&
+	     (trigger_context->event_type != SOCK_DEFERRED_WORK)))
 		return -FI_EINVAL;
 
-	threshold = &trigger_context->trigger.threshold;
-	cntr = container_of(threshold->cntr, struct sock_cntr, cntr_fid);
-	if (ofi_atomic_get32(&cntr->value) >= (int)threshold->threshold)
+	work = &trigger_context->trigger.work;
+	cntr = container_of(work->triggering_cntr, struct sock_cntr, cntr_fid);
+	if (ofi_atomic_get32(&cntr->value) >= (int) work->threshold)
 		return 1;
 
 	trigger = calloc(1, sizeof(*trigger));
 	if (!trigger)
 		return -FI_ENOMEM;
 
-	trigger->threshold = threshold->threshold;
+	trigger->context = trigger_context;
+	trigger->threshold = work->threshold;
+
 	memcpy(&trigger->op.atomic.msg, msg, sizeof(*msg));
 	trigger->op.atomic.msg.msg_iov = &trigger->op.atomic.msg_iov[0];
 	trigger->op.atomic.msg.rma_iov = &trigger->op.atomic.rma_iov[0];
@@ -239,7 +249,7 @@ ssize_t sock_queue_cntr_op(struct fi_deferred_work *work, uint64_t flags)
 	if (!trigger)
 		return -FI_ENOMEM;
 
-	trigger->work = work;
+	trigger->context = (struct sock_triggered_context *) &work->context;
 	trigger->op_type = work->op_type;
 	trigger->threshold = work->threshold;
 	trigger->flags = flags;
@@ -253,7 +263,8 @@ ssize_t sock_queue_cntr_op(struct fi_deferred_work *work, uint64_t flags)
 
 int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work)
 {
-	struct fi_triggered_context *ctx;
+	struct sock_triggered_context *ctx;
+	uint64_t flags = SOCK_NO_COMPLETION | SOCK_TRIGGERED_OP | FI_TRIGGER;
 
 	/* We require the operation's context to point back to the fi_context
 	 * embedded within the deferred work item.  This is an implementation
@@ -261,48 +272,49 @@ int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work)
 	 * keep the fi_deferred_work structure around for the duration of the
 	 * processing anyway.
 	 */
-	ctx = (struct fi_triggered_context *) &work->context;
-	ctx->event_type = FI_TRIGGER_THRESHOLD;
-	ctx->trigger.threshold.cntr = work->triggering_cntr;
-	ctx->trigger.threshold.threshold = work->threshold;
+	ctx = (struct sock_triggered_context *) &work->context;
+	ctx->event_type = SOCK_DEFERRED_WORK;
+	ctx->trigger.work.triggering_cntr = work->triggering_cntr;
+	ctx->trigger.work.threshold = work->threshold;
+	ctx->trigger.work.completion_cntr = work->completion_cntr;
 
 	switch (work->op_type) {
 	case FI_OP_RECV:
 		if (work->op.msg->msg.context != &work->context)
 			return -FI_EINVAL;
 		return sock_ep_recvmsg(work->op.msg->ep, &work->op.msg->msg,
-				       work->op.msg->flags | FI_TRIGGER);
+				       work->op.msg->flags | flags);
 	case FI_OP_SEND:
 		if (work->op.msg->msg.context != &work->context)
 			return -FI_EINVAL;
 		return sock_ep_sendmsg(work->op.msg->ep, &work->op.msg->msg,
-				       work->op.msg->flags | FI_TRIGGER);
+				       work->op.msg->flags | flags);
 	case FI_OP_TRECV:
 		if (work->op.tagged->msg.context != &work->context)
 			return -FI_EINVAL;
 		return sock_ep_trecvmsg(work->op.tagged->ep, &work->op.tagged->msg,
-					  work->op.tagged->flags | FI_TRIGGER);
+					  work->op.tagged->flags | flags);
 	case FI_OP_TSEND:
 		if (work->op.tagged->msg.context != &work->context)
 			return -FI_EINVAL;
 		return sock_ep_tsendmsg(work->op.tagged->ep, &work->op.tagged->msg,
-					  work->op.tagged->flags | FI_TRIGGER);
+					  work->op.tagged->flags | flags);
 	case FI_OP_READ:
 		if (work->op.rma->msg.context != &work->context)
 			return -FI_EINVAL;
 		return sock_ep_rma_readmsg(work->op.rma->ep, &work->op.rma->msg,
-					   work->op.rma->flags | FI_TRIGGER);
+					   work->op.rma->flags | flags);
 	case FI_OP_WRITE:
 		if (work->op.rma->msg.context != &work->context)
 			return -FI_EINVAL;
 		return sock_ep_rma_writemsg(work->op.rma->ep, &work->op.rma->msg,
-					    work->op.rma->flags | FI_TRIGGER);
+					    work->op.rma->flags | flags);
 	case FI_OP_ATOMIC:
 		if (work->op.atomic->msg.context != &work->context)
 			return -FI_EINVAL;
 		return sock_ep_tx_atomic(work->op.atomic->ep, &work->op.atomic->msg,
 					 NULL, NULL, 0, NULL, NULL, 0,
-					 work->op.atomic->flags | FI_TRIGGER);
+					 work->op.atomic->flags | flags);
 	case FI_OP_FETCH_ATOMIC:
 		if (work->op.fetch_atomic->msg.context != &work->context)
 			return -FI_EINVAL;
@@ -312,7 +324,7 @@ int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work)
 					 work->op.fetch_atomic->fetch.msg_iov,
 					 work->op.fetch_atomic->fetch.desc,
 					 work->op.fetch_atomic->fetch.iov_count,
-					 work->op.fetch_atomic->flags | FI_TRIGGER);
+					 work->op.fetch_atomic->flags | flags);
 	case FI_OP_COMPARE_ATOMIC:
 		if (work->op.compare_atomic->msg.context != &work->context)
 			return -FI_EINVAL;
@@ -324,7 +336,7 @@ int sock_queue_work(struct sock_domain *dom, struct fi_deferred_work *work)
 					 work->op.compare_atomic->fetch.msg_iov,
 					 work->op.compare_atomic->fetch.desc,
 					 work->op.compare_atomic->fetch.iov_count,
-					 work->op.compare_atomic->flags | FI_TRIGGER);
+					 work->op.compare_atomic->flags | flags);
 	case FI_OP_CNTR_SET:
 	case FI_OP_CNTR_ADD:
 		return sock_queue_cntr_op(work, 0);


### PR DESCRIPTION
The proposed updates included a new triggering event type,
FI_TRIGGER_COMPLETION.  This allows linking two work
requests together.  However, there's a race condition
with this definition, where the first work request can
complete prior to the app being able to post the second
operation.  Also, the API allows posting the work requests
in any order.  There's no simple fix for this.

After more discussion, adjust the deferred work queue
definition in preparation for moving to a more generic
directed-acyclic graph.

We define a set of primitives that can be used to create
a schedule of queued work requests.  Each work item is
an operation that is deferred until a specified triggering
counter meets a pre-determined threshold.  After the operation
completes, a completion counter is incremented by one.  The
completion counter can then become a triggering counter for
another set of operations.

```
fi_deferred_work {
    struct fi_context context;
    struct fid_cntr *triggering_cntr;
    struct fid_cntr *completion_cntr;
    size_t           threshold;

    enum fi_tigger_op op_type;
    union {
    	struct fi_op_xxx ...
    } op;
};
```
Note that with this change, operations are only triggered based
on counter thresholds.  FI_TRIGGER_COMPLETION goes away.  To
isolate the work schedule from normal operations, only the
specified counters are updated.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>