### PR TITLE
CI: Update travis to use 1.4.0 fabtest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ install:
 script:
     - git clone https://github.com/ofiwg/fabtests.git
     - cd fabtests
+    - git checkout -b v1.4.x origin/v1.4.x
     - ./autogen.sh
     - ./configure --prefix=$HOME --with-libfabric=$HOME
     - make -j2


### PR DESCRIPTION
The upstream fabtest requires 1.5+

Signed-off-by: Sean Hefty <sean.hefty@intel.com>