### PR TITLE
prov/rxm: Fix reporting CQ errors, completion flags and progress model.

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -306,7 +306,6 @@ int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 void rxm_cq_progress(struct fid_cq *msg_cq);
 int rxm_cq_comp(struct util_cq *util_cq, void *context, uint64_t flags, size_t len,
 		void *buf, uint64_t data, uint64_t tag);
-int rxm_cq_report_error(struct util_cq *util_cq, struct fi_cq_err_entry *err_entry);
 int rxm_cq_handle_data(struct rxm_rx_buf *rx_buf);
 
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -190,6 +190,7 @@ struct rxm_rx_buf {
 	struct rxm_recv_fs *recv_fs;
 	struct rxm_recv_entry *recv_entry;
 	struct rxm_unexp_msg unexp_msg;
+	uint64_t comp_flags;
 
 	/* Used for large messages */
 	struct rxm_iov match_iov[RXM_IOV_LIMIT];
@@ -218,6 +219,7 @@ struct rxm_tx_entry {
 	uint8_t count;
 	void *context;
 	uint64_t flags;
+	uint64_t comp_flags;
 	struct rxm_tx_buf *tx_buf;
 
 	/* Used for large messages */

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -59,7 +59,7 @@ struct fi_ep_attr rxm_ep_attr = {
 struct fi_domain_attr rxm_domain_attr = {
 	.threading = FI_THREAD_SAFE,
 	.control_progress = FI_PROGRESS_AUTO,
-	.data_progress = FI_PROGRESS_AUTO,
+	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_ENABLED,
 	.av_type = FI_AV_UNSPEC,
 	/* Advertise support for FI_MR_BASIC so that ofi_check_info call

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -70,7 +70,7 @@ static const char *rxm_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 	return fi_cq_strerror(rxm_ep->msg_cq, prov_errno, err_data, buf, len);
 }
 
-int rxm_cq_report_error(struct util_cq *util_cq, struct fi_cq_err_entry *err_entry)
+static int rxm_cq_report_error(struct util_cq *util_cq, struct fi_cq_err_entry *err_entry)
 {
 	struct util_cq_err_entry *entry;
 	struct fi_cq_tagged_entry *comp;
@@ -464,39 +464,49 @@ static ssize_t rxm_cq_read(struct fid_cq *msg_cq, struct fi_cq_msg_entry *comp)
 	struct rxm_tx_entry *tx_entry;
 	struct rxm_rx_buf *rx_buf;
 	struct fi_cq_err_entry err_entry;
+	struct util_cq *util_cq;
+	void *op_context;
 	ssize_t ret;
 
 	ret = fi_cq_read(msg_cq, comp, 1);
+	if (ret >= 0 || ret == -FI_EAGAIN)
+		return ret;
+
+	op_context = comp->op_context;
+	memset(&err_entry, 0, sizeof(err_entry));
+
 	if (ret == -FI_EAVAIL) {
 		OFI_CQ_READERR(&rxm_prov, FI_LOG_CQ, msg_cq,
 				ret, err_entry);
-		if (ret < 0) {
+		if (ret < 0)
 			FI_WARN(&rxm_prov, FI_LOG_CQ,
 					"Unable to fi_cq_readerr on msg cq\n");
-			return ret;
-		}
-		switch (*(enum rxm_proto_state *)comp->op_context) {
-		case RXM_TX:
-		case RXM_LMT_TX:
-			tx_entry = (struct rxm_tx_entry *)comp->op_context;
-			return rxm_cq_report_error(tx_entry->ep->util_ep.tx_cq, &err_entry);
-		case RXM_LMT_ACK_SENT:
-			tx_entry = (struct rxm_tx_entry *)comp->op_context;
-			return rxm_cq_report_error(tx_entry->ep->util_ep.rx_cq, &err_entry);
-		case RXM_RX:
-		case RXM_LMT_READ:
-			rx_buf = (struct rxm_rx_buf *)comp->op_context;
-			return rxm_cq_report_error(rx_buf->ep->util_ep.rx_cq, &err_entry);
-		default:
-			FI_WARN(&rxm_prov, FI_LOG_CQ, "Unknown ctx type!\n");
-			FI_WARN(&rxm_prov, FI_LOG_CQ, "msg cq readerr: %s\n",
-					fi_cq_strerror(msg_cq, err_entry.prov_errno,
-						err_entry.err_data, NULL, 0));
-			assert(0);
-			return err_entry.err;
-		}
+		op_context = err_entry.op_context;
 	}
-	return ret;
+	switch (*(enum rxm_proto_state *)op_context) {
+	case RXM_TX:
+	case RXM_LMT_TX:
+		tx_entry = (struct rxm_tx_entry *)op_context;
+		util_cq = tx_entry->ep->util_ep.tx_cq;
+		break;
+	case RXM_LMT_ACK_SENT:
+		tx_entry = (struct rxm_tx_entry *)op_context;
+		util_cq = tx_entry->ep->util_ep.rx_cq;
+		break;
+	case RXM_RX:
+	case RXM_LMT_READ:
+		rx_buf = (struct rxm_rx_buf *)op_context;
+		util_cq = rx_buf->ep->util_ep.rx_cq;
+		break;
+	default:
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Invalid state!\n");
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "msg cq readerr: %s\n",
+				fi_cq_strerror(msg_cq, err_entry.prov_errno,
+					err_entry.err_data, NULL, 0));
+		assert(0);
+		return err_entry.err;
+	}
+	return rxm_cq_report_error(util_cq, &err_entry);
 }
 
 void rxm_cq_progress(struct fid_cq *msg_cq)

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -126,9 +126,10 @@ int rxm_finish_recv(struct rxm_rx_buf *rx_buf)
 	if (rx_buf->recv_entry->flags & FI_COMPLETION) {
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "writing recv completion\n");
 		ret = rxm_cq_comp(rx_buf->ep->util_ep.rx_cq,
-				rx_buf->recv_entry->context,
-				FI_RECV, rx_buf->pkt.hdr.size, NULL,
-				rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
+				  rx_buf->recv_entry->context,
+				  rx_buf->comp_flags | FI_RECV,
+				  rx_buf->pkt.hdr.size, NULL,
+				  rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
 		if (ret) {
 			FI_WARN(&rxm_prov, FI_LOG_CQ,
 					"Unable to write recv completion\n");
@@ -147,7 +148,7 @@ int rxm_finish_send(struct rxm_tx_entry *tx_entry)
 	if (tx_entry->flags & FI_COMPLETION) {
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "writing send completion\n");
 		ret = rxm_cq_comp(tx_entry->ep->util_ep.tx_cq, tx_entry->context,
-				FI_SEND, 0, NULL, 0, 0);
+				tx_entry->comp_flags | FI_SEND, 0, NULL, 0, 0);
 		if (ret) {
 			FI_WARN(&rxm_prov, FI_LOG_CQ,
 					"Unable to write send completion\n");
@@ -358,9 +359,11 @@ int rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 	case ofi_op_msg:
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "Got MSG op\n");
 		recv_queue = &rx_buf->ep->recv_queue;
+		rx_buf->comp_flags = FI_MSG;
 		break;
 	case ofi_op_tagged:
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "Got TAGGED op\n");
+		rx_buf->comp_flags = FI_TAGGED;
 		match_attr.tag = rx_buf->pkt.hdr.tag;
 		recv_queue = &rx_buf->ep->trecv_queue;
 		break;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -599,8 +599,12 @@ static ssize_t rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov
 	pkt->hdr.size = ofi_total_iov_len(iov, count);
 	rxm_op_hdr_process_flags(&pkt->hdr, flags, data);
 
-	if (op == ofi_op_tagged)
+	if (op == ofi_op_tagged) {
 		pkt->hdr.tag = tag;
+		tx_entry->comp_flags = FI_TAGGED;
+	} else {
+		tx_entry->comp_flags = FI_MSG;
+	}
 
 	if (pkt->hdr.size > RXM_TX_DATA_SIZE) {
 		if (flags & FI_INJECT) {


### PR DESCRIPTION
- Write CQ errors to RXM CQ in error path of underlying provider's CQ readerr
- Return correct completion flags.
- Expose correct data progress model.