### PR TITLE
prov/verbs: Add clarification of limitation in provider's man page

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -84,7 +84,8 @@ Generic fi_mr_regattr is not supported. No support for binding memory regions to
 a counter.
 
 ### Wait objects
-Only FI_WAIT_FD wait object is supported. Wait sets are not supported.
+Only FI_WAIT_FD wait object is supported only for FI_EP_MSG endpoint type.
+Wait sets are not supported.
 
 ### Resource Management
 Application has to make sure CQs are not overrun as this cannot be detected


### PR DESCRIPTION
The man pages is updated to say more regarding FI_WAIT_FD object in verbs' man page.

It doesn't say which EP type support/doesn't support FI_WAIT_FD/_SET.
FI_WAIT_FD are supported only by verbs with FI_EP_MSG endpoint type.

There are some information about wait objects' support in the limitations of verbs/RDM section.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>