### PR TITLE
prov/verbs: Fix mismatching of addr:port in case of multiple EPs per one domain

### DIFF
--- a/include/fi_list.h
+++ b/include/fi_list.h
@@ -96,13 +96,15 @@ static inline void dlist_remove(struct dlist_entry *item)
 		dlist_remove((head)->next);					\
 	} while (0)
 
-#define dlist_foreach(head, item) \
+#define dlist_foreach(head, item) 						\
 	for ((item) = (head)->next; (item) != (head); (item) = (item)->next)
 
-#define dlist_foreach_container(head, container, member) \
-	for (container = container_of((head)->next, typeof(*container), member); \
-		&(container->member) != (head); \
-		container = container_of(container->member.next, typeof(*container), member))
+#define dlist_foreach_container(head, container, member)		\
+	for (container = container_of((head)->next,			\
+				      typeof(*container), member);	\
+		&(container->member) != (head);				\
+		container = container_of(container->member.next,	\
+					 typeof(*container), member))
 
 typedef int dlist_func_t(struct dlist_entry *item, const void *arg);
 
@@ -192,9 +194,10 @@ static inline struct slist_entry *slist_remove_head(struct slist *list)
 	return item;
 }
 
-#define slist_foreach(list, item, prev)\
-	for ((prev) = NULL, (item) = (list)->head; (item); \
+#define slist_foreach(list, item, prev)				\
+	for ((prev) = NULL, (item) = (list)->head; (item); 	\
 			(prev) = (item), (item) = (item)->next)
+
 
 typedef int slist_func_t(struct slist_entry *item, const void *arg);
 

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -213,7 +213,7 @@ static ssize_t fi_ibv_rdm_cancel(fid_t fid, void *ctx)
 	struct fi_context *context = (struct fi_context *)ctx;
 	struct fi_ibv_rdm_ep *ep_rdm = 
 		container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
-	int err = 1;
+	int err = -FI_ENOENT;
 
 	if (!ep_rdm->domain)
 		return -EBADF;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -268,6 +268,8 @@ struct fi_ibv_rdm_ep {
 	struct fi_ibv_rdm_cntr *read_cntr;
 	struct fi_ibv_rdm_cntr *write_cntr;
 
+	struct fi_info *info;
+
 	size_t addrlen;
 	struct rdma_addrinfo *rai;
 	struct sockaddr_in my_addr;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -238,14 +238,20 @@ struct fi_ibv_rdm_buf {
 };
 
 struct fi_ibv_rdm_cm {
-	struct rdma_event_channel *ec;
-	struct rdma_cm_id *listener;
-	int is_bound;
+	struct rdma_event_channel*	ec;
+	struct rdma_cm_id*		listener;
+	int				is_bound;
 
 	/* conn_hash has a sockaddr_in -> conn associative */
-	struct fi_ibv_rdm_conn *conn_hash;
+	struct fi_ibv_rdm_conn*		conn_hash;
 	/* Used only for FI_AV_TABLE */
-	struct fi_ibv_rdm_conn **conn_table;
+	struct fi_ibv_rdm_conn**	conn_table;
+
+	struct slist			av_removed_conn_head;
+	pthread_mutex_t			cm_lock;
+	pthread_t			cm_progress_thread;
+	int				cm_progress_timeout;
+	int				fi_ibv_rdm_tagged_cm_progress_running;
 };
 
 struct fi_ibv_rdm_cntr {
@@ -259,57 +265,54 @@ struct fi_ibv_rdm_cntr {
 
 struct fi_ibv_rdm_ep {
 	struct fid_ep ep_fid;
-	struct fi_ibv_domain *domain;
-	struct fi_ibv_rdm_cq *fi_scq;
-	struct fi_ibv_rdm_cq *fi_rcq;
+	struct fi_ibv_domain*	domain;
+	struct slist_entry	list_entry;
+	struct fi_ibv_rdm_cq*	fi_scq;
+	struct fi_ibv_rdm_cq*	fi_rcq;
 
-	struct fi_ibv_rdm_cntr *send_cntr;
-	struct fi_ibv_rdm_cntr *recv_cntr;
-	struct fi_ibv_rdm_cntr *read_cntr;
-	struct fi_ibv_rdm_cntr *write_cntr;
+	struct fi_ibv_rdm_cntr*	send_cntr;
+	struct fi_ibv_rdm_cntr*	recv_cntr;
+	struct fi_ibv_rdm_cntr*	read_cntr;
+	struct fi_ibv_rdm_cntr*	write_cntr;
 
-	struct fi_info *info;
+	struct fi_info*	info;
 
-	size_t addrlen;
-	struct rdma_addrinfo *rai;
-	struct sockaddr_in my_addr;
+	size_t			addrlen;
+	struct rdma_addrinfo*	rai;
+	struct sockaddr_in	my_addr;
 
-	struct fi_ibv_av *av;
-	int tx_selective_completion;
-	int rx_selective_completion;
-	size_t min_multi_recv_size;
-	uint64_t tx_op_flags;
-	uint64_t rx_op_flags;
+	struct fi_ibv_av*	av;
+	int		tx_selective_completion;
+	int 		rx_selective_completion;
+	size_t 		min_multi_recv_size;
+	uint64_t 	tx_op_flags;
+	uint64_t 	rx_op_flags;
 
 	/*
 	 * ibv_post_send opcode for eager messaging.
 	 * It must generate work completion in receive CQ
 	 */
-	enum ibv_wr_opcode eopcode;
-	int buff_len;
-	int n_buffs;
-	int rq_wr_depth;    // RQ depth
-	int sq_wr_depth;    // SQ depth
-	int posted_sends;
-	int posted_recvs;
-	int num_active_conns;
-	int max_inline_rc;
-	int rndv_threshold;
-	int rndv_seg_size;
-	int use_odp;
-	struct ibv_cq *scq;
-	struct ibv_cq *rcq;
-	int scq_depth;
-	int rcq_depth;
-	int cqread_bunch_size;
+	enum ibv_wr_opcode	eopcode;
+	struct ibv_cq*		scq;
+	struct ibv_cq*		rcq;
 
-	/* TODO: move all CM things to domain */
-	pthread_t cm_progress_thread;
-	pthread_mutex_t cm_lock;
-	int cm_progress_timeout;
-	int is_closing;
-	int recv_preposted_threshold;
-	struct slist av_removed_conn_head;
+	int	buff_len;
+	int	n_buffs;
+	int	rq_wr_depth;    // RQ depth
+	int	sq_wr_depth;    // SQ depth
+	int	posted_sends;
+	int	posted_recvs;
+	int	num_active_conns;
+	int	max_inline_rc;
+	int	rndv_threshold;
+	int	rndv_seg_size;
+	int	use_odp;
+	int	scq_depth;
+	int	rcq_depth;
+	int	cqread_bunch_size;
+
+	int	is_closing;
+	int	recv_preposted_threshold;
 };
 
 enum {
@@ -323,6 +326,7 @@ enum {
 };
 
 enum fi_rdm_cm_role {
+	FI_VERBS_CM_UNDEFINED,
 	FI_VERBS_CM_ACTIVE,
 	FI_VERBS_CM_PASSIVE,
 	FI_VERBS_CM_SELF,
@@ -634,11 +638,11 @@ fi_ibv_rdm_check_connection(struct fi_ibv_rdm_conn *conn,
 {
 	const int status = (conn->state == FI_VERBS_CONN_ESTABLISHED);
 	if (!status) {
-		pthread_mutex_lock(&ep->cm_lock);
+		pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
 		if (conn->state == FI_VERBS_CONN_ALLOCATED) {
 			fi_ibv_rdm_start_connection(ep, conn);
 		}
-		pthread_mutex_unlock(&ep->cm_lock);
+		pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
 	}
 
 	return status;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -54,7 +54,7 @@ static inline int fi_ibv_rdm_tagged_poll_send(struct fi_ibv_rdm_ep *ep);
 
 int
 fi_ibv_rdm_tagged_prepare_send_request(struct fi_ibv_rdm_request *request,
-					struct fi_ibv_rdm_ep *ep)
+				       struct fi_ibv_rdm_ep *ep)
 {
 #if ENABLE_DEBUG
 	int res = OUTGOING_POST_LIMIT(request->minfo.conn, ep);

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -258,7 +258,7 @@ fi_ibv_rdm_send_common(struct fi_ibv_rdm_send_start_data* sdata)
 	int ret = fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_SEND_START, sdata);
 
 	if (!ret && in_order &&
-		fi_ibv_rdm_tagged_prepare_send_request(request, sdata->ep_rdm))
+	    fi_ibv_rdm_tagged_prepare_send_request(request, sdata->ep_rdm))
 	{
 		struct fi_ibv_rdm_tagged_send_ready_data req_data = 
 			{ .ep = sdata->ep_rdm };

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -258,8 +258,7 @@ fi_ibv_rdm_send_common(struct fi_ibv_rdm_send_start_data* sdata)
 	int ret = fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_SEND_START, sdata);
 
 	if (!ret && in_order &&
-	    fi_ibv_rdm_tagged_prepare_send_request(request, sdata->ep_rdm))
-	{
+	    fi_ibv_rdm_tagged_prepare_send_request(request, sdata->ep_rdm)) {
 		struct fi_ibv_rdm_tagged_send_ready_data req_data = 
 			{ .ep = sdata->ep_rdm };
 		ret = fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_POST_READY,

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -73,8 +73,8 @@ int fi_ibv_rdm_cm_bind_ep(struct fi_ibv_rdm_cm *cm, struct fi_ibv_rdm_ep *ep)
 
 	assert(cm->ec && cm->listener);
 
-	if (ep->domain->info->src_addr) {
-		memcpy(&ep->my_addr, ep->domain->info->src_addr, sizeof(ep->my_addr));
+	if (ep->info->src_addr) {
+		memcpy(&ep->my_addr, ep->info->src_addr, sizeof(ep->my_addr));
 
 		inet_ntop(ep->my_addr.sin_family,
 			  &ep->my_addr.sin_addr.s_addr,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -159,6 +159,14 @@ typedef fi_addr_t
 	(*fi_ibv_rdm_conn_to_addr_func)
 	(struct fi_ibv_rdm_ep *ep, struct fi_ibv_rdm_conn *conn);
 
+typedef struct fi_ibv_rdm_av_entry *
+	(*fi_ibv_rdm_addr_to_av_entry_func)
+	(struct fi_ibv_rdm_ep *ep, fi_addr_t addr);
+
+typedef fi_addr_t
+	(*fi_ibv_rdm_av_entry_to_addr_func)
+	(struct fi_ibv_rdm_ep *ep, struct fi_ibv_rdm_av_entry *av_entry);
+
 struct fi_ibv_av {
 	struct fid_av		av_fid;
 	struct fi_ibv_domain	*domain;
@@ -170,6 +178,8 @@ struct fi_ibv_av {
 	enum fi_av_type		type;
 	fi_ibv_rdm_addr_to_conn_func addr_to_conn;
 	fi_ibv_rdm_conn_to_addr_func conn_to_addr;
+	fi_ibv_rdm_addr_to_av_entry_func addr_to_av_entry;
+	fi_ibv_rdm_av_entry_to_addr_func av_entry_to_addr;
 };
 
 int fi_ibv_av_open(struct fid_domain *domain, struct fi_av_attr *attr,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -200,6 +200,7 @@ struct fi_ibv_domain {
 	 */
 	int			rdm;
 	struct fi_ibv_rdm_cm	*rdm_cm;
+	struct slist		ep_list;
 	struct fi_info		*info;
 	struct fi_ibv_fabric	*fab;
 	struct fi_ibv_eq	*eq;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -87,7 +87,8 @@ fi_ibv_mr_reg(struct fid *fid, const void *buf, size_t len,
 	/* Enable local write access by default for FI_EP_RDM which hides local
 	 * registration requirements. This allows to avoid buffering or double
 	 * registration */
-	if (!(md->domain->info->caps & FI_LOCAL_MR))
+	if (!(md->domain->info->caps & FI_LOCAL_MR) ||
+	    (md->domain->info->domain_attr->mr_mode & FI_MR_LOCAL))
 		fi_ibv_access |= IBV_ACCESS_LOCAL_WRITE;
 
 	/* Local read access to an MR is enabled by default in verbs */

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -178,12 +178,51 @@ static int fi_ibv_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	return 0;
 }
 
+static void *fi_ibv_rdm_cm_progress_thread(void *dom)
+{
+	struct fi_ibv_domain *domain =
+		(struct fi_ibv_domain *)dom;
+	struct slist_entry *item, *prev;
+	while (domain->rdm_cm->fi_ibv_rdm_tagged_cm_progress_running) {
+		struct fi_ibv_rdm_ep *ep = NULL;
+		slist_foreach(&domain->ep_list, item, prev) {
+			(void) prev;
+			ep = container_of(item, struct fi_ibv_rdm_ep,
+					  list_entry);
+			if (fi_ibv_rdm_cm_progress(ep)) {
+				VERBS_INFO (FI_LOG_EP_DATA,
+				            "fi_ibv_rdm_cm_progress error\n");
+				abort();
+			}
+		}
+		usleep(domain->rdm_cm->cm_progress_timeout);
+	}
+	return NULL;
+}
+
 static int fi_ibv_domain_close(fid_t fid)
 {
 	struct fi_ibv_domain *domain;
+	struct fi_ibv_rdm_conn *conn = NULL;
+	struct slist_entry *item;
+	void *status = NULL;
 	int ret;
 
 	domain = container_of(fid, struct fi_ibv_domain, domain_fid.fid);
+
+	domain->rdm_cm->fi_ibv_rdm_tagged_cm_progress_running = 0;
+	pthread_join(domain->rdm_cm->cm_progress_thread, &status);
+	pthread_mutex_destroy(&domain->rdm_cm->cm_lock);
+
+	for (item = slist_remove_head(
+			&domain->rdm_cm->av_removed_conn_head);
+	     item;
+	     item = slist_remove_head(
+			&domain->rdm_cm->av_removed_conn_head)) {
+		conn = container_of(item, struct fi_ibv_rdm_conn, 
+				    removed_next);
+		fi_ibv_rdm_conn_cleanup(conn);
+	}
 
 	if (domain->rdm) {
 		rdma_destroy_ep(domain->rdm_cm->listener);
@@ -276,13 +315,14 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 	struct fi_ibv_domain *_domain;
 	struct fi_ibv_fabric *fab;
 	struct fi_info *fi;
-	int ret;
+	int param = 0, ret;
 
 	fi = fi_ibv_get_verbs_info(info->domain_attr->name);
 	if (!fi)
 		return -FI_EINVAL;
 
-	fab = container_of(fabric, struct fi_ibv_fabric, util_fabric.fabric_fid);
+	fab = container_of(fabric, struct fi_ibv_fabric,
+			   util_fabric.fabric_fid);
 	ret = ofi_check_domain_attr(&fi_ibv_prov, fabric->api_version,
 				    fi->domain_attr, info->domain_attr);
 	if (ret)
@@ -301,6 +341,35 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		_domain->rdm_cm = calloc(1, sizeof(*_domain->rdm_cm));
 		if (!_domain->rdm_cm) {
 			ret = -FI_ENOMEM;
+			goto err2;
+		}
+		_domain->rdm_cm->cm_progress_timeout =
+			FI_IBV_RDM_CM_THREAD_TIMEOUT;
+		if (!fi_param_get_int(&fi_ibv_prov,
+				      "rdm_thread_timeout",
+				      &param)) {
+			if (param < 0) {
+				VERBS_INFO(FI_LOG_CORE,
+				   	   "invalid value of "
+					   "rdm_thread_timeout\n");
+				ret = -FI_EINVAL;
+				goto err2;
+			} else {
+				_domain->rdm_cm->cm_progress_timeout = param;
+			}
+		}
+		slist_init(&_domain->rdm_cm->av_removed_conn_head);
+
+		pthread_mutex_init(&_domain->rdm_cm->cm_lock, NULL);
+		_domain->rdm_cm->fi_ibv_rdm_tagged_cm_progress_running = 1;
+		ret = pthread_create(&_domain->rdm_cm->cm_progress_thread,
+				     NULL, &fi_ibv_rdm_cm_progress_thread,
+				     (void *)_domain);
+		if (ret) {
+			VERBS_INFO(FI_LOG_EP_CTRL,
+				   "Failed to launch CM progress thread, "
+				   "err :%d\n", ret);
+			ret = -FI_EOTHER;
 			goto err2;
 		}
 	}


### PR DESCRIPTION
**1st commit** - Add check for FI_MR_LOCAL bit together with FI_LOCAL_MR in MR registration

**2nd commit** - Fix mismatching of addr:port in case of multiple EPs per one domain
The description of the problem:
verbs/RDM uses fi_info::src_addr from domain structure.
In case of multiple EPs over different addr:port pairs per one domain, there is the following situation:
```
fi_getinfo(..., &info1);
fi_fabric(...);
fi_domain(...info1);
for (i = 0; i < num_of_eps; i++) {
     fi_info(...addr[i], port[i],...,&info[i]);
     fi_endpoint(...,info[i],...);
}
```
The created EPs don't use `addr[i]`:`port[i]`.

The solution is to keep info provided during ep's registration and use information from this info during EP life-cycle (in particular, use the fi_info::src_addr in `rdma_bind_addr`).

**3rd commit** - Add support of fi_av_straddr/_insertsvc/_insertsym/_lookup

**4th commit** - Make more clear handling of connection establishment procedure. 
Avoid usage of while-loop just for break operation. Add utilization of "go to label" procedure instead.

**5th commit** - Add proper handling of erroneous case in fi_cancel. If there is no matched entry to be canceled, the verbs/RDM provider have to return '-FI_ENOENT' instead '1'.

**6th commit** - Allow multiple EPs per one Domain.

**7th commit** - Allow multiple EPs per one AV.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>