### PR TITLE
Provide common helper routine to convert an address into FI_ADDR_STR

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -220,6 +220,9 @@ static inline int ofi_translate_addr_format(int family)
 	}
 }
 
+const char *ofi_straddr(char *buf, size_t *len,
+			uint32_t addr_format, const void *addr);
+
 /*
  * Key Index
  */

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -1192,6 +1192,11 @@ for scalable endpoints.
 
 # SOCKET ENDPOINTS
 
+The following feature and description should be considered experimental.
+Until the experimental tag is removed, the interfaces, semantics, and data
+structures associated with socket endpoints may change between library
+versions.
+
 This section applies to endpoints of type FI_EP_SOCK_STREAM and
 FI_EP_SOCK_DGRAM, commonly referred to as socket endpoints.
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -578,11 +578,13 @@ fabric.  See `fi_av`(3).
 
 *FI_ADDR_STR*
 : Address is a formatted character string.  The length and content of
-  the string is address and/or provider specific, but follows this model:
+  the string is address and/or provider specific, but in general follows
+  a URI model:
 
-  address_family[;[node][;[service][;[field3]...]]]
+  address_format[://[node][:[service][/[field3]...]]]
 
-  Examples: AF_INET;10.31.6.12;7471, AF_INET;;7471
+  Examples: inet://10.31.6.12:7471, inet6://[fe80::6:12]:7471,
+  name://hostname:7471
 
 # FLAGS
 

--- a/prov/udp/src/udpx_init.c
+++ b/prov/udp/src/udpx_init.c
@@ -121,7 +121,7 @@ static void udpx_fini(void)
 struct fi_provider udpx_prov = {
 	.name = "UDP",
 	.version = FI_VERSION(UDPX_MAJOR_VERSION, UDPX_MINOR_VERSION),
-	.fi_version = FI_VERSION(1, 3),
+	.fi_version = FI_VERSION(1, 5),
 	.getinfo = udpx_getinfo,
 	.fabric = udpx_fabric,
 	.cleanup = udpx_fini

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -953,51 +953,7 @@ static int ip_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr, void *addr,
 static const char *ip_av_straddr(struct fid_av *av, const void *addr, char *buf,
 				 size_t *len)
 {
-	const struct sockaddr *sock_addr;
-	const struct sockaddr_in6 *sin6;
-	const struct sockaddr_in *sin;
-	char str[INET6_ADDRSTRLEN + 8];
-	uint16_t port;
-	int size;
-
-	if (!addr || !len)
-		return NULL;
-
-	sock_addr = addr;
-	switch (sock_addr->sa_family) {
-	case AF_INET:
-		sin = addr;
-		if (!inet_ntop(sin->sin_family, (void*)&sin->sin_addr.s_addr, str,
-			       sizeof(str)))
-			return NULL;
-
-		port = sin->sin_port;
-		break;
-	case AF_INET6:
-		sin6 = addr;
-		if (!inet_ntop(sin6->sin6_family, &sin6->sin6_addr.s6_addr, str,
-			       sizeof(str)))
-			return NULL;
-
-		port = sin6->sin6_port;
-		break;
-	default:
-		return NULL;
-	}
-
-	size = snprintf(buf, MIN(*len, sizeof(str)), "%s:%" PRIu16, str,
-			ntohs(port));
-
-	/* Make sure that possibly truncated messages have a NULL terminator. */
-	if (buf && *len)
-		buf[*len - 1] = '\0';
-
-	/* Output length includes NULL terminator, which snprintf does not
-	 * include in it's length calculation.
-	 */
-	*len = size + 1;
-
-	return buf;
+	return ofi_straddr(buf, len, FI_SOCKADDR, addr);
 }
 
 static struct fi_ops_av ip_av_ops = {
@@ -1065,6 +1021,7 @@ int ip_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	(*av)->ops = &ip_av_ops;
 	return 0;
 }
+
 
 /*
  * Connection Map

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -255,10 +255,11 @@ static void fi_tostr_mode(char *buf, uint64_t mode)
 	fi_remove_comma(buf);
 }
 
-static void fi_tostr_addr(char *buf, uint32_t addr_format,
-		void *addr)
+static void fi_tostr_addr(char *buf, uint32_t addr_format, void *addr)
 {
 	char *p;
+	size_t len;
+
 	p = buf + strlen(buf);
 
 	if (addr == NULL) {
@@ -266,36 +267,8 @@ static void fi_tostr_addr(char *buf, uint32_t addr_format,
 		return;
 	}
 
-	switch (addr_format) {
-	case FI_SOCKADDR:
-		/* translate and recurse... */
-		switch (((struct sockaddr *)addr)->sa_family) {
-		case AF_INET:
-			fi_tostr_addr(p, FI_SOCKADDR_IN, addr);
-			break;
-		case AF_INET6:
-			fi_tostr_addr(p, FI_SOCKADDR_IN6, addr);
-			break;
-		default:
-			fi_tostr_addr(p, FI_FORMAT_UNSPEC, addr);
-			break;
-		}
-		break;
-	case FI_SOCKADDR_IN:
-		inet_ntop(AF_INET, &((struct sockaddr_in *)addr)->sin_addr,
-			p, 64);
-		break;
-	case FI_SOCKADDR_IN6:
-		inet_ntop(AF_INET6, &((struct sockaddr_in6 *)addr)->sin6_addr,
-			p, 64);
-		break;
-	case FI_ADDR_GNI:  /*TODO: eventually something better */
-		sprintf(p, "0x%" PRIx64,*(uint64_t *)addr);
-		break;
-	default:
-		sprintf(p, "%p", addr);
-		break;
-	}
+	len = 64;
+	ofi_straddr(p, &len, addr_format, addr);
 }
 
 static void fi_tostr_tx_attr(char *buf, const struct fi_tx_attr *attr,


### PR DESCRIPTION
NOTE: This changes the string format of existing address strings reported by fi_tostr and fi_av_addrstr.  We need to determine if this will be a problem.