### PR TITLE
util + prov/rxm: Serialize recv list access and read multiple completions when progressing.

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -206,6 +206,7 @@ struct util_ep {
 	uint64_t		flags;
 	ofi_ep_progress_func	progress;
 	struct util_cmap	*cmap;
+	fastlock_t		lock;
 };
 
 int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -267,6 +267,7 @@ struct rxm_ep {
 	struct fid_pep *msg_pep;
 	struct fid_cq *msg_cq;
 	struct fid_ep *srx_ctx;
+	size_t comp_per_progress;
 
 	struct rxm_buf_pool tx_pool;
 	struct rxm_buf_pool rx_pool;
@@ -305,7 +306,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			     struct fid_domain **dom, void *context);
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 			 struct fid_cq **cq_fid, void *context);
-void rxm_cq_progress(struct fid_cq *msg_cq);
+void rxm_cq_progress(struct rxm_ep *rxm_ep);
 int rxm_cq_comp(struct util_cq *util_cq, void *context, uint64_t flags, size_t len,
 		void *buf, uint64_t data, uint64_t tag);
 int rxm_cq_handle_data(struct rxm_rx_buf *rx_buf);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -429,10 +429,10 @@ static int rxm_lmt_send_ack(struct rxm_rx_buf *rx_buf)
 	return 0;
 }
 
-static int rxm_cq_handle_comp(struct fi_cq_msg_entry *comp) {
+static int rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
+			      struct fi_cq_tagged_entry *comp) {
 	enum rxm_proto_state *state = comp->op_context;
 	struct rxm_rx_buf *rx_buf = comp->op_context;
-	int ret;
 
 	switch (*state) {
 	case RXM_TX:
@@ -462,10 +462,9 @@ static int rxm_cq_handle_comp(struct fi_cq_msg_entry *comp) {
 		assert(0);
 		return -FI_EOPBADSTATE;
 	}
-	return ret;
 }
 
-static ssize_t rxm_cq_read(struct fid_cq *msg_cq, struct fi_cq_msg_entry *comp)
+static ssize_t rxm_cq_read(struct fid_cq *msg_cq, struct fi_cq_tagged_entry *comp)
 {
 	struct rxm_tx_entry *tx_entry;
 	struct rxm_rx_buf *rx_buf;
@@ -515,20 +514,26 @@ static ssize_t rxm_cq_read(struct fid_cq *msg_cq, struct fi_cq_msg_entry *comp)
 	return rxm_cq_report_error(util_cq, &err_entry);
 }
 
-void rxm_cq_progress(struct fid_cq *msg_cq)
+void rxm_cq_progress(struct rxm_ep *rxm_ep)
 {
-	struct fi_cq_msg_entry comp;
-	ssize_t ret = 0;
+	struct fi_cq_tagged_entry comp;
+	ssize_t ret, comp_read = 0;
 
 	do {
-		ret = rxm_cq_read(msg_cq, &comp);
+		ret = rxm_cq_read(rxm_ep->msg_cq, &comp);
+		if (ret == -FI_EAGAIN)
+			break;
+
 		if (ret < 0)
 			goto err;
 
-		ret = rxm_cq_handle_comp(&comp);
-		if (ret)
-			goto err;
-	} while (ret > 0);
+		if (ret) {
+			comp_read += ret;
+			ret = rxm_cq_handle_comp(rxm_ep, &comp);
+			if (ret)
+				goto err;
+		}
+	} while (comp_read < rxm_ep->comp_per_progress);
 	return;
 err:
 	// TODO report error on RXM EP/domain since EP/CQ is broken.

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -375,6 +375,7 @@ int rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 
 	rx_buf->recv_fs = recv_queue->fs;
 
+	fastlock_acquire(&rx_buf->ep->util_ep.lock);
 	entry = dlist_remove_first_match(&recv_queue->recv_list,
 					 recv_queue->match_recv, &match_attr);
 	if (!entry) {
@@ -383,8 +384,10 @@ int rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 		rx_buf->unexp_msg.addr = match_attr.addr;
 		rx_buf->unexp_msg.tag = match_attr.tag;
 		dlist_insert_tail(&rx_buf->unexp_msg.entry, &recv_queue->unexp_msg_list);
+		fastlock_release(&rx_buf->ep->util_ep.lock);
 		return 0;
 	}
+	fastlock_release(&rx_buf->ep->util_ep.lock);
 
 	rx_buf->recv_entry = container_of(entry, struct rxm_recv_entry, entry);
 	return rxm_cq_handle_data(rx_buf);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -357,38 +357,39 @@ static inline uint64_t rxm_ep_rx_flags(struct fid_ep *ep_fid) {
 	return rxm_ep->rxm_info->rx_attr->op_flags;
 }
 
-static int rxm_check_unexp_msg_list(struct util_cq *util_cq, struct rxm_recv_queue *recv_queue,
-		struct rxm_recv_entry *recv_entry, dlist_func_t *match)
+static int rxm_check_unexp_msg_list(struct rxm_ep *rxm_ep,
+				    struct rxm_recv_queue *recv_queue,
+				    struct rxm_recv_entry *recv_entry)
 {
 	struct dlist_entry *entry;
 	struct rxm_unexp_msg *unexp_msg;
 	struct rxm_recv_match_attr match_attr;
 	struct rxm_rx_buf *rx_buf;
-	int ret = 0;
 
-	fastlock_acquire(&util_cq->cq_lock);
-	if (ofi_cirque_isfull(util_cq->cirq)) {
-		ret = -FI_EAGAIN;
-		goto out;
+	fastlock_acquire(&rxm_ep->util_ep.lock);
+
+	if (dlist_empty(&recv_queue->unexp_msg_list)) {
+		fastlock_release(&rxm_ep->util_ep.lock);
+		return -FI_EAGAIN;
 	}
 
 	match_attr.addr = recv_entry->addr;
 	match_attr.tag = recv_entry->tag;
 	match_attr.ignore = recv_entry->ignore;
 
-	entry = dlist_remove_first_match(&recv_queue->unexp_msg_list, match, &match_attr);
+	entry = dlist_remove_first_match(&recv_queue->unexp_msg_list,
+					 recv_queue->match_unexp, &match_attr);
+	fastlock_release(&rxm_ep->util_ep.lock);
 	if (!entry)
-		goto out;
+		return -FI_EAGAIN;
+
 	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Match for posted recv found in unexp msg list\n");
 
 	unexp_msg = container_of(entry, struct rxm_unexp_msg, entry);
 	rx_buf = container_of(unexp_msg, struct rxm_rx_buf, unexp_msg);
 	rx_buf->recv_entry = recv_entry;
 
-	ret = rxm_cq_handle_data(rx_buf);
-out:
-	fastlock_release(&util_cq->cq_lock);
-	return ret;
+	return rxm_cq_handle_data(rx_buf);
 }
 
 static int rxm_ep_recv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
@@ -421,17 +422,17 @@ static int rxm_ep_recv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
 	recv_entry->tag = tag;
 	recv_entry->ignore = ignore;
 
-	if (!dlist_empty(&recv_queue->unexp_msg_list)) {
-		ret = rxm_check_unexp_msg_list(rxm_ep->util_ep.rx_cq, recv_queue,
-				recv_entry, recv_queue->match_unexp);
-		if (ret) {
-			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-					"Unable to check unexp msg list\n");
-			return ret;
-		}
+	ret = rxm_check_unexp_msg_list(rxm_ep, recv_queue, recv_entry);
+	if (ret == -FI_EAGAIN) {
+		fastlock_acquire(&rxm_ep->util_ep.lock);
+		dlist_insert_tail(&recv_entry->entry,
+				  &recv_queue->recv_list);
+		fastlock_release(&rxm_ep->util_ep.lock);
+	} else if (ret) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+				"Unable to check unexp msg list\n");
+		return ret;
 	}
-
-	dlist_insert_tail(&recv_entry->entry, &recv_queue->recv_list);
 	return 0;
 }
 
@@ -655,7 +656,8 @@ static ssize_t rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov
 		if (pkt_size <= rxm_ep->msg_info->tx_attr->inject_size) {
 			ret = fi_inject(rxm_conn->msg_ep, pkt, pkt_size, 0);
 			if (ret)
-				FI_WARN(&rxm_prov, FI_LOG_EP_DATA, "fi_inject for MSG provider failed\n");
+				FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
+				       "fi_inject for MSG provider failed\n");
 			/* release allocated buffer for further reuse */
 			goto done;
 		} else {

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1070,6 +1070,9 @@ static int rxm_ep_msg_res_open(struct fi_info *rxm_fi_info,
 	if (ret)
 		return ret;
 
+	rxm_ep->comp_per_progress = MIN(rxm_ep->msg_info->tx_attr->size,
+					rxm_ep->msg_info->rx_attr->size) / 2;
+
 	rxm_domain = container_of(util_domain, struct rxm_domain, util_domain);
 	rxm_fabric = container_of(util_domain->fabric, struct rxm_fabric, util_fabric);
 
@@ -1081,7 +1084,7 @@ static int rxm_ep_msg_res_open(struct fi_info *rxm_fi_info,
 
 	memset(&cq_attr, 0, sizeof(cq_attr));
 	cq_attr.size = rxm_fi_info->tx_attr->size + rxm_fi_info->rx_attr->size;
-	cq_attr.format = FI_CQ_FORMAT_MSG;
+	cq_attr.format = FI_CQ_FORMAT_DATA;
 
 	ret = fi_cq_open(rxm_domain->msg_domain, &cq_attr, &rxm_ep->msg_cq, NULL);
 	if (ret) {
@@ -1125,7 +1128,7 @@ void rxm_ep_progress(struct util_ep *util_ep)
 	struct rxm_ep *rxm_ep;
 
 	rxm_ep = container_of(util_ep, struct rxm_ep, util_ep);
-	rxm_cq_progress(rxm_ep->msg_cq);
+	rxm_cq_progress(rxm_ep);
 }
 
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -75,11 +75,13 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	ep->domain = util_domain;
 	ep->progress = progress;
 	ofi_atomic_inc32(&util_domain->ref);
+	fastlock_init(&ep->lock);
 	return 0;
 }
 
 int ofi_endpoint_close(struct util_ep *util_ep)
 {
+	fastlock_destroy(&util_ep->lock);
 	if (util_ep->av) {
 		fastlock_acquire(&util_ep->av->lock);
 		dlist_remove(&util_ep->av_entry);


### PR DESCRIPTION
-	util: Add a lock to util_ep
-	prov/rxm: Serialize access to recv_list and unexp_msg_list
-	prov/rxm: Read multiple completions per progress