### PR TITLE
prov/gni: address issue 1311

### DIFF
--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -335,7 +335,6 @@ DIRECT_FN STATIC uint64_t gnix_cntr_read(struct fid_cntr *cntr)
 		return -FI_EINVAL;
 
 	cntr_priv = container_of(cntr, struct gnix_fid_cntr, cntr_fid);
-	v = ofi_atomic_get32(&cntr_priv->cnt);
 
 	if (cntr_priv->wait)
 		gnix_wait_wait((struct fid_wait *)cntr_priv->wait, 0);
@@ -344,6 +343,8 @@ DIRECT_FN STATIC uint64_t gnix_cntr_read(struct fid_cntr *cntr)
 	if (ret != FI_SUCCESS)
 		GNIX_WARN(FI_LOG_CQ, " __gnix_cntr_progress returned %d.\n",
 			  ret);
+
+	v = ofi_atomic_get32(&cntr_priv->cnt);
 
 	return (uint64_t)v;
 }

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -535,7 +535,7 @@ void do_tinject(int len)
 	cr_assert(rdm_tagged_sr_check_data(source, target, len), "Data mismatch");
 }
 
-Test(rdm_tagged_sr, tinject)
+Test(rdm_tagged_sr, tinject, .disabled = false)
 {
 	rdm_tagged_sr_xfer_for_each_size(do_tinject, 1, INJECT_SIZE);
 }


### PR DESCRIPTION
It turns out that some of the GNI provider criterion tests
don't currently test TX counters correctly when using the
fi_inject and related paths.  The method taken to progress
the TX side when using inject isn't sufficient, and depending
on timing, the TX counter values read aren't the "expected" ones.

The check cntrs code was modified to allow for an optional
"spin" mode to wait for the counters to reach expected values.
Consequently, some of the tests involving fi_inject and friends
in rdm_sr.c and sep.c may hang if a bug is introduced that causes
counters not to be properly updated.

Also move the read of the counter to after the associated gnix_nic
has been progressed.

Fixes ofi-cray/libfabric-cray#1311
Fixes ofi-cray/libfabric-cray#1095
Fixes ofi-cray/libfabric-cray#1330

upstream merge of ofi-cray/libfabric-cray#1331

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@7bc84bd5e3bbb190e4052e5a3f1aceaaa2a3f33d)

Conflicts:
	prov/gni/src/gnix_cntr.c