### PR TITLE
prov/gni: be more accurate about nic allocation

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -418,6 +418,7 @@ struct gnix_fid_domain {
 #ifdef HAVE_UDREG
 	udreg_cache_handle_t udreg_cache;
 #endif
+	uint32_t num_allocd_stxs;
 };
 
 /**

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -152,7 +152,8 @@ DIRECT_FN STATIC int gnix_stx_open(struct fid_domain *dom,
 	 * a TX context (aka gnix nic) that can be shared
 	 * explicitly amongst endpoints
 	 */
-	nic_attr.must_alloc = true;
+	nic_attr.must_alloc = (domain->num_allocd_stxs <
+					gnix_max_nics_per_ptag) ? true : false;
 	ret = gnix_nic_alloc(domain, &nic_attr, &nic);
 	if (ret != FI_SUCCESS) {
 		GNIX_WARN(FI_LOG_EP_CTRL,
@@ -170,6 +171,7 @@ DIRECT_FN STATIC int gnix_stx_open(struct fid_domain *dom,
 	stx_priv->stx_fid.fid.context = context;
 	stx_priv->stx_fid.fid.ops = &gnix_stx_ops;
 	stx_priv->stx_fid.ops = NULL;
+	domain->num_allocd_stxs++;
 
 	*stx = &stx_priv->stx_fid;
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -199,7 +199,12 @@ static struct fi_info *_gnix_allocinfo(void)
 	gnix_info->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	gnix_info->domain_attr->data_progress = FI_PROGRESS_AUTO;
 	gnix_info->domain_attr->av_type = FI_AV_UNSPEC;
-	gnix_info->domain_attr->tx_ctx_cnt = gnix_max_nics_per_ptag;
+	/*
+	 * the cm_nic currently sucks up one of the gnix_nic's so
+	 * we have to subtract one from the gnix_max_nics_per_ptag.
+	 */
+	gnix_info->domain_attr->tx_ctx_cnt = (gnix_max_nics_per_ptag == 1) ?
+						1 : gnix_max_nics_per_ptag - 1;
 	gnix_info->domain_attr->rx_ctx_cnt = gnix_max_nics_per_ptag;
 	gnix_info->domain_attr->cntr_cnt = _gnix_get_cq_limit() / 2;
 


### PR DESCRIPTION
when using shared TX contexts.

Also, improve the cleanup code in the error path
when we fail to allocate a gnix_nic due to underlying
resource constraints.

Also, since they chew up IOMMU space and aren't being
used currently, if def out code to allocate send/receive
buffers when allocating a gnix_nic.

Adjust allocator test to take account of the fact
that we're no longer allocating slabs when a nic is
allocated.

upstream merge of ofi-cray/libfabric-cray#1332

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@870ad0fe7ff04b9cd465ab5e6e50046519349f48)