### PR TITLE
prov/usnic: add flags validation before binding object to an endpoint.

### DIFF
--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -668,10 +668,16 @@ fail:
 static int
 usdf_ep_msg_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
+	int ret;
 	struct usdf_ep *ep;
 	struct usdf_cq *cq;
 
 	USDF_TRACE_SYS(EP_CTRL, "\n");
+
+	/* Validate the flags. */
+	ret = ofi_ep_bind_valid(&usdf_ops, bfid, flags);
+	if (ret)
+		return ret;
 
 	ep = ep_fidtou(fid);
 

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -662,11 +662,17 @@ fail:
 static int
 usdf_ep_rdm_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
+	int ret;
 	struct usdf_ep *ep;
 	struct usdf_cq *cq;
 	struct usdf_av *av;
 
 	USDF_TRACE_SYS(EP_CTRL, "\n");
+
+	/* Check if the binding flags are valid. */
+	ret = ofi_ep_bind_valid(&usdf_ops, bfid, flags);
+	if (ret)
+		return ret;
 
 	ep = ep_fidtou(fid);
 


### PR DESCRIPTION
usnic provider has not been validating the flags for binding objects to
the endpoint as it should be. This patch fixed the issue and provide
backward compatibility to Open MPI (which always bind av with FI_RECV
mistakenly) by manually removing the flag if the requested FI version is
below 1.5.

Signed-off-by: Thananon Patinyasakdikul <apatinya@cisco.com>