### PR TITLE
code cleanup - squash some compiler warnings

### DIFF
--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -756,7 +756,7 @@ ssize_t rxd_ep_post_start_msg(struct rxd_ep *ep, struct rxd_peer *peer,
 	ssize_t ret;
 	uint32_t flags;
 	uint64_t msg_sz;
-	uint64_t data_sz;
+	uint64_t data_sz = 0UL;
 	struct rxd_pkt_meta *pkt_meta;
 	struct rxd_pkt_data_start *pkt;
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -174,7 +174,7 @@ int fi_ibv_create_ep(const char *node, const char *service,
 		     uint64_t flags, const struct fi_info *hints,
 		     struct rdma_addrinfo **rai, struct rdma_cm_id **id)
 {
-	struct rdma_addrinfo *_rai;
+	struct rdma_addrinfo *_rai = NULL;
 	int ret;
 
 	ret = fi_ibv_get_rdma_rai(node, service, flags, hints, &_rai);


### PR DESCRIPTION
gcc 6.3.0 was complaining about use of variables
without initialization.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>