### PR TITLE
prov/psm,psm2: Update provider version and mr_mode checking

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -74,7 +74,7 @@ extern struct fi_provider psmx_prov;
 
 extern int psmx_am_compat_mode;
 
-#define PSMX_VERSION	(FI_VERSION(1,4))
+#define PSMX_VERSION	(FI_VERSION(1,5))
 
 #define PSMX_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -369,20 +369,8 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 				goto err_out;
 			}
 
-			switch (hints->domain_attr->mr_mode) {
-			case FI_MR_UNSPEC:
-				break;
-			case FI_MR_BASIC:
-			case FI_MR_SCALABLE:
-				mr_mode = hints->domain_attr->mr_mode;
-				break;
-			default:
-				FI_INFO(&psmx_prov, FI_LOG_CORE,
-					"hints->domain_attr->mr_mode=%d, supported=%d %d %d\n",
-					hints->domain_attr->mr_mode, FI_MR_UNSPEC, FI_MR_BASIC,
-					FI_MR_SCALABLE);
-				goto err_out;
-			}
+			if (hints->domain_attr->mr_mode & FI_MR_BASIC)
+				mr_mode = FI_MR_BASIC;
 
 			switch (hints->domain_attr->threading) {
 			case FI_THREAD_UNSPEC:

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -72,7 +72,7 @@ extern "C" {
 
 extern struct fi_provider psmx2_prov;
 
-#define PSMX2_VERSION	(FI_VERSION(1,4))
+#define PSMX2_VERSION	(FI_VERSION(1,5))
 
 #define PSMX2_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -388,20 +388,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 				goto err_out;
 			}
 
-			switch (hints->domain_attr->mr_mode) {
-			case FI_MR_UNSPEC:
-				break;
-			case FI_MR_BASIC:
-			case FI_MR_SCALABLE:
-				mr_mode = hints->domain_attr->mr_mode;
-				break;
-			default:
-				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->domain_attr->mr_mode=%d, supported=%d %d %d\n",
-					hints->domain_attr->mr_mode, FI_MR_UNSPEC, FI_MR_BASIC,
-					FI_MR_SCALABLE);
-				goto err_out;
-			}
+			if (hints->domain_attr->mr_mode & FI_MR_BASIC)
+				mr_mode = FI_MR_BASIC;
 
 			switch (hints->domain_attr->threading) {
 			case FI_THREAD_UNSPEC:


### PR DESCRIPTION
Update the way mr_mode is checked to be consistent with the new
API. Update the provider version to 1.5.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>