### PR TITLE
Proposal: specfile for a single DL provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,6 @@ util/fi_info
 util/fi_strerror
 util/fi_pingpong
 
+prov/*/*.spec
+
 .vs

--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -105,6 +105,11 @@ dnl
 				 AC_MSG_WARN([but libfabric is being built as static-only])
 				 AC_MSG_ERROR([This is an impossible situation. Cannot continue.])])
 			 AC_MSG_NOTICE([$1 provider: build as plugin])
+
+			 # See if this provider has a specfile that
+			 # needs to be generated
+			 m4_ifnblank(m4_esyscmd(ls prov/$1/libfabric-$1.spec.in 2> /dev/null),
+			       [AC_CONFIG_FILES([prov/$1/libfabric-$1.spec])])
 			],
 			[PROVIDERS_STATIC="prov/$1/lib$1.la $PROVIDERS_STATIC"
 			 AC_MSG_NOTICE([$1 provider: include in libfabric])])

--- a/prov/usnic/libfabric-usnic.spec.in
+++ b/prov/usnic/libfabric-usnic.spec.in
@@ -1,0 +1,52 @@
+%{!?configopts: %global configopts LDFLAGS=-Wl,--build-id}
+%{!?provider: %define provider usnic}
+%{!?provider_formal: %define provider_formal usNIC}
+
+Name: libfabric-%{provider}
+Version: @VERSION@
+Release: 1%{?dist}
+Summary: Dynamic %{provider_formal} provider for user-space RDMA Fabric Interfaces
+Group: System Environment/Libraries
+License: GPLv2 or BSD
+Url: http://www.github.com/ofiwg/libfabric
+Source: http://www.github.org/ofiwg/%{name}/releases/download/v{%version}/libfabric-%{version}.tar.bz2
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+Requires: libfabric
+BuildRequires: libfabric
+
+%description
+libfabric provides a user-space API to access high-performance fabric
+services, such as RDMA.
+
+This RPM provides the %{provider_formal} provider as a "plugin" to an existing
+Libfabric installation.  This plugin will override any existing %{provider_formal}
+provider functionality in the existing Libfabric installation.
+
+%prep
+%setup -q -n libfabric-%{version}
+
+%build
+%configure %{configopts} --enable-%{provider}=dl
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+%makeinstall installdirs
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%{_libdir}/libfabric/*.so
+
+%exclude %{_libdir}/libfabric.*
+%exclude %{_libdir}/libfabric/*.la
+%exclude %{_libdir}/pkgconfig
+%exclude %{_bindir}
+%exclude %{_mandir}
+%exclude %{_includedir}
+
+%changelog
+* Wed May 24 2017 Open Fabrics Interfaces Working Group <ofiwg@lists.openfabrics.org>
+- First release of specfile for packaging a single dl provider.


### PR DESCRIPTION
This PR does two things:

1. Adds a tiny little bit into the m4 code that will add `prov/PROVIDER/libfabric-PROVIDER.spec` to AC_CONFIG_FILES (i.e., it'll generate it) if the corresponding `.in` file is found at `configure` time.
1. Adds a proposed specfile that is mostly suitable for customization to any provider.

Comments welcome.