### PR TITLE
prov/verbs: Fix an incorrect usage of hash; use ofi_memalign wrapper instead memalign

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -371,7 +371,7 @@ static int fi_ibv_rdm_av_insertsym(struct fid_av *av, const char *node,
 					    var_port + (int)j);
 
 			check_host = (len_host > 0 && len_host < FI_NAME_MAX);
-			check_host = (len_port > 0 && len_port < FI_NAME_MAX);
+			check_port = (len_port > 0 && len_port < FI_NAME_MAX);
 
 			if (check_port && check_host) {
 				ret = fi_ibv_rdm_av_insertsvc(av, tmp_host,
@@ -393,7 +393,7 @@ static int fi_ibv_rdm_av_insertsym(struct fid_av *av, const char *node,
 			}
 		}
 	}
-	return success > 0 ? success : err_code;
+	return ((success > 0) ? success : err_code);
 }
 
 static int fi_ibv_rdm_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr,

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -228,9 +228,6 @@ static int fi_ibv_rdm_av_insert(struct fid_av *av_fid, const void *addr,
 			if (ret)
 				goto out;
 			memset(av_entry, 0, sizeof *av_entry);
-			/*dlist_init(&conn->postponed_requests_head);
-			conn->state = FI_VERBS_CONN_ALLOCATED;
-			conn->cm_role = FI_VERBS_CM_UNDEFINED;*/
 			memcpy(&av_entry->addr, addr_i, FI_IBV_RDM_DFLT_ADDRLEN);
 			HASH_ADD(hh, av->domain->rdm_cm->av_hash, addr,
 				 FI_IBV_RDM_DFLT_ADDRLEN, av_entry);

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -219,15 +219,14 @@ static int fi_ibv_rdm_av_insert(struct fid_av *av_fid, const void *addr,
 
 		if (!av_entry) {
 			/* If addr_i is not found in HASH then we malloc it.
-			 * It could be found if the connection was initiated by the remote
-			 * side.
+			 * It could be found if the connection was initiated
+			 * by the remote side.
 			 */
-			av_entry = memalign(FI_IBV_RDM_MEM_ALIGNMENT, sizeof *av_entry);
-			if (!av_entry) {
-				ret = -FI_ENOMEM;
+			ret = -ofi_memalign((void**)&av_entry,
+					    FI_IBV_RDM_MEM_ALIGNMENT,
+					    sizeof *av_entry);
+			if (ret)
 				goto out;
-			}
-
 			memset(av_entry, 0, sizeof *av_entry);
 			/*dlist_init(&conn->postponed_requests_head);
 			conn->state = FI_VERBS_CONN_ALLOCATED;
@@ -252,7 +251,8 @@ static int fi_ibv_rdm_av_insert(struct fid_av *av_fid, const void *addr,
 			break;
 		}
 
-		VERBS_INFO(FI_LOG_AV, "fi_av_insert: addr %s:%u; av_entry - %p\n",
+		VERBS_INFO(FI_LOG_AV,
+			   "fi_av_insert: addr %s:%u; av_entry - %p\n",
 			   inet_ntoa(av_entry->addr.sin_addr),
 			   ntohs(av_entry->addr.sin_port), av_entry);
 
@@ -561,9 +561,9 @@ fi_ibv_rdm_av_map_addr_to_conn_add_new_conn(struct fi_ibv_rdm_ep *ep,
 		HASH_FIND(hh, av_entry->conn_hash,
 			  &ep, sizeof(struct fi_ibv_rdm_ep *), conn);
 		if (!conn) {
-			conn = memalign(FI_IBV_RDM_MEM_ALIGNMENT,
-					sizeof(*conn));
-			if (!conn)
+			if (ofi_memalign((void**)&conn,
+					 FI_IBV_RDM_MEM_ALIGNMENT,
+					 sizeof(*conn)))
 				return NULL;
 			memset(conn, 0, sizeof(*conn));
 		    	memcpy(&conn->addr, &av_entry->addr,
@@ -591,9 +591,9 @@ fi_ibv_rdm_av_tbl_idx_to_conn_add_new_conn(struct fi_ibv_rdm_ep *ep,
 		HASH_FIND(hh, av_entry->conn_hash,
 			  &ep, sizeof(struct fi_ibv_rdm_ep *), conn);
 		if (!conn) {
-			conn = memalign(FI_IBV_RDM_MEM_ALIGNMENT,
-					sizeof(*conn));
-			if (!conn)
+			if (ofi_memalign((void**)&conn,
+					 FI_IBV_RDM_MEM_ALIGNMENT,
+					 sizeof(*conn)))
 				return NULL;
 			memset(conn, 0, sizeof(*conn));
 		    	memcpy(&conn->addr, &av_entry->addr,

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -398,13 +398,13 @@ fi_ibv_rdm_process_connect_request(struct rdma_cm_event *event,
 		}
 		memset(conn, 0, sizeof(*conn));
 		conn->av_entry = av_entry;
-		HASH_ADD(hh, av_entry->conn_hash, ep,
-			 sizeof(struct fi_ibv_rdm_ep *), conn);
 		conn->ep = ep;
 		conn->state = FI_VERBS_CONN_ALLOCATED;
 		dlist_init(&conn->postponed_requests_head);
 		fi_ibv_rdm_unpack_cm_params(&event->param.conn, conn, ep);
 		fi_ibv_rdm_conn_init_cm_role(conn, ep);
+		HASH_ADD(hh, av_entry->conn_hash, ep,
+			 sizeof(struct fi_ibv_rdm_ep *), conn);
 
 		VERBS_INFO(FI_LOG_AV, "CONN REQUEST, NOT found in hash, "
 			   "new conn %p %d, addr %s:%u, HASH ADD\n",

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -224,6 +224,7 @@ static int fi_ibv_domain_close(fid_t fid)
 						struct fi_ibv_rdm_av_entry,
 						removed_next);
 			fi_ibv_rdm_overall_conn_cleanup(av_entry);
+			ofi_freealign(av_entry);
 		}
 		rdma_destroy_ep(domain->rdm_cm->listener);
 		free(domain->rdm_cm);


### PR DESCRIPTION
The PR contains the changes related to:
**1st commit** get rid of usage of memalign. It was replaced by ofi_memalign wrapper
**2nd commit** fix reported Coverity issue. One of them wasn't fixed, because I guess it should be suppressed (Coverity considers that I should free memory when I get failure during allocation for another one. This is not really so what I want, because the `av_entry` object - for AV entries, and the `conn` is just a its reflection of `av_entry` for EP utilizing)
**3nd commit** Fix an incorrect adding of key to hash. A memory address of  EP object is a key in hash. Hence, we should fill `conn` structure by EP address value before the adding to hash.
