### PR TITLE
prov/gni: Authorization key support

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -11,6 +11,7 @@ AM_CPPFLAGS += -I$(top_srcdir)/prov/gni/include -I$(top_srcdir)/prov/gni
 
 _gni_files = \
 	prov/gni/src/gnix_atomic.c \
+	prov/gni/src/gnix_auth_key.c \
 	prov/gni/src/gnix_av.c \
 	prov/gni/src/gnix_bitmap.c \
 	prov/gni/src/gnix_buddy_allocator.c \
@@ -99,6 +100,7 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/dom.c \
 	prov/gni/test/ep.c \
 	prov/gni/test/eq.c \
+	prov/gni/test/fabric.c \
 	prov/gni/test/fi_addr_str.c \
 	prov/gni/test/freelist.c \
 	prov/gni/test/hashtable.c \

--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -79,6 +79,8 @@ typedef enum ep_ops_val {
 #define FI_GNI_FAB_OPS_1 "fab ops 1"
 typedef enum fab_ops_val {
 	GNI_WAIT_THREAD_SLEEP = 0,
+	GNI_DEFAULT_USER_REGISTRATION_LIMIT,
+	GNI_DEFAULT_PROV_REGISTRATION_LIMIT,
 	GNI_NUM_FAB_OPS,
 } fab_ops_val_t;
 
@@ -132,6 +134,51 @@ struct gnix_ops_domain {
 struct fi_gni_ops_fab {
 	int (*set_val)(struct fid *fid, fab_ops_val_t t, void *val);
 	int (*get_val)(struct fid *fid, fab_ops_val_t t, void *val);
+};
+
+typedef enum gnix_auth_key_opt {
+	GNIX_USER_KEY_LIMIT = 0,
+	GNIX_PROV_KEY_LIMIT,
+	GNIX_TOTAL_KEYS_NEEDED,
+	GNIX_MAX_AUTH_KEY_OPTS,
+} gnix_auth_key_opt_t;
+
+struct gnix_auth_key_attr {
+	int user_key_limit;
+	int prov_key_limit;
+};
+
+enum {
+	GNIX_AKT_RAW = 0,
+	GNIX_MAX_AKT_TYPES,
+};
+
+struct fi_gni_raw_auth_key {
+	uint32_t protection_key;
+};
+
+struct fi_gni_auth_key {
+	uint32_t type;
+	union {
+		struct fi_gni_raw_auth_key raw;
+	};
+};
+
+#define GNIX_PROV_DEFAULT_AUTH_KEY NULL
+#define GNIX_PROV_DEFAULT_AUTH_KEYLEN 0
+
+#define FI_GNI_FAB_OPS_2 "fab ops 2"
+struct fi_gni_auth_key_ops_fab {
+	int (*set_val)(
+			uint8_t *auth_key,
+			size_t auth_key_size,
+			gnix_auth_key_opt_t opt,
+			void *val);
+	int (*get_val)(
+			uint8_t *auth_key,
+			size_t auth_key_size,
+			gnix_auth_key_opt_t opt,
+			void *val);
 };
 
 #ifdef __cplusplus

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -76,6 +76,7 @@
 #include "gnix_mr_cache.h"
 #include "gnix_mr_notifier.h"
 #include "gnix_nic.h"
+#include "gnix_auth_key.h"
 
 #define GNI_MAJOR_VERSION 1
 #define GNI_MINOR_VERSION 0
@@ -375,6 +376,9 @@ struct gnix_fid_fabric {
 extern struct fi_ops_cm gnix_ep_msg_ops_cm;
 extern struct fi_ops_cm gnix_ep_ops_cm;
 
+#define GNIX_GET_MR_CACHE_INFO(domain, auth_key) \
+	({ &(domain)->mr_cache_info[(auth_key)->ptag]; })
+
 /*
  * a gnix_fid_domain is associated with one or more gnix_nic's.
  * the gni_nics are in turn associated with ep's opened off of the
@@ -390,8 +394,6 @@ struct gnix_fid_domain {
 	struct gnix_fid_fabric *fabric;
 	struct gnix_cm_nic *cm_nic;
 	fastlock_t cm_nic_lock;
-	uint8_t ptag;
-	uint32_t cookie;
 	uint32_t cdm_id_seed;
 	uint32_t addr_format;
 	/* user tunable parameters accessed via open_ops functions */
@@ -404,10 +406,9 @@ struct gnix_fid_domain {
 	enum fi_threading thread_model;
 	struct gnix_reference ref_cnt;
 	gnix_mr_cache_attr_t mr_cache_attr;
-	gnix_mr_cache_t *mr_cache_rw;
-	gnix_mr_cache_t *mr_cache_ro;
-	fastlock_t mr_cache_lock;
+	struct gnix_mr_cache_info *mr_cache_info;
 	struct gnix_mr_ops *mr_ops;
+	fastlock_t mr_cache_lock;
 	int mr_cache_type;
 	/* flag to indicate that memory registration is initialized and should not
 	 * be changed at this point.
@@ -415,6 +416,7 @@ struct gnix_fid_domain {
 	int mr_is_init;
 	int mr_iov_limit;
 	int udreg_reg_limit;
+	struct gnix_auth_key *auth_key;
 #ifdef HAVE_UDREG
 	udreg_cache_handle_t udreg_cache;
 #endif
@@ -544,6 +546,7 @@ struct gnix_fid_ep {
 	bool rx_enabled;
 	bool shared_tx;
 	bool requires_lock;
+	struct gnix_auth_key *auth_key;
 	int last_cached;
 	struct gnix_addr_cache_entry addr_cache[GNIX_ADDR_CACHE_SIZE];
 	int send_selective_completion;
@@ -613,6 +616,7 @@ struct gnix_fid_ep {
  * @var my_name         ep name for this endpoint
  * @var sep_lock        lock protecting this sep object
  * @var ref_cnt         ref cnt on this object
+ * @var auth_key		GNIX authorization key
  */
 struct gnix_fid_sep {
 	struct fid_ep ep_fid;
@@ -629,6 +633,7 @@ struct gnix_fid_sep {
 	struct gnix_ep_name my_name;
 	fastlock_t sep_lock;
 	struct gnix_reference ref_cnt;
+	struct gnix_auth_key *auth_key;
 };
 
 /**
@@ -663,6 +668,7 @@ struct gnix_fid_stx {
 	struct fid_stx stx_fid;
 	struct gnix_fid_domain *domain;
 	struct gnix_nic *nic;
+	struct gnix_auth_key *auth_key;
 	struct gnix_reference ref_cnt;
 };
 
@@ -1077,6 +1083,15 @@ static inline int _gnix_req_inject_smsg_err(struct gnix_fab_req *req)
 		return 0;
 	}
 }
+
+extern int gnix_default_user_registration_limit;
+extern int gnix_default_prov_registration_limit;
+extern int gnix_dealloc_aki_on_fabric_close;
+
+/* This is a per-node limitation of the GNI provider. Each process
+   should request only as many registrations as it intends to use
+   and no more than that. */
+#define GNIX_MAX_SCALABLE_REGISTRATIONS 4096
 
 /*
  * work queue struct, used for handling delay ops, etc. in a generic wat

--- a/prov/gni/include/gnix_auth_key.h
+++ b/prov/gni/include/gnix_auth_key.h
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PROV_GNI_INCLUDE_GNIX_AUTH_KEY_H_
+#define PROV_GNI_INCLUDE_GNIX_AUTH_KEY_H_
+
+#include <fi_lock.h>
+
+#include "fi_ext_gni.h"
+#include "gnix_bitmap.h"
+
+/*
+ * GNIX Authorization keys are directly associated with a specific GNI network
+ * key. There are some limitations to GNI network keys that should be noted.
+ *
+ * GNI network keys are directly associated with memory registrations, and
+ * can only support a single type of memory mode at a time. This means that
+ * the memory mode must be tracked with the authorization key, and must exist
+ * as globally known information. Since references to objects may still exist
+ * after the fabric is closed, this information must persist unless the
+ * application has promised not to open any more GNI fabric instances.
+ * See fi_gni man page for guidance on GNI_DEALLOC_AKI_ON_FABRIC_CLOSE.
+ */
+
+/**
+ * GNIX authorization key construct
+ *
+ * @var lock      lock for data structure
+ * @var attr      authorization key attributes
+ * @var enabled   Is this authorization key live? If so, refuse changes to limits
+ * @var mr_mode   mr_mode bits associated with the authorization key
+ * @var prov      bitmap for detecting provider key usage
+ * @var user      bitmap for detecting user key usage
+ */
+struct gnix_auth_key {
+	fastlock_t lock;
+	struct gnix_auth_key_attr attr;
+	int enabled;
+	uint8_t ptag;
+	uint32_t cookie;
+	int mr_mode;
+	gnix_bitmap_t prov;
+	gnix_bitmap_t user;
+};
+
+/**
+ * Allocates an authorization key structure, if possible
+ *
+ * @return  non-NULL pointer to initialized memory on success
+ *          NULL on failure
+ */
+struct gnix_auth_key *_gnix_auth_key_alloc();
+
+/**
+ * Frees an authorization key structure
+ *
+ * @param key    A GNI authorization key structure to free
+ * @return       0 on success
+ *               -FI_EINVAL, if invalid parameter passed as key
+ */
+int _gnix_auth_key_free(struct gnix_auth_key *key);
+
+/**
+ * Lookup an authorization key in global data storage
+ *
+ * @param auth_key     authorization key
+ * @param auth_key_size  length of authorization key in bytes
+ * @return             non-NULL pointer on success
+ *                     NULL pointer if not found
+ */
+struct gnix_auth_key *_gnix_auth_key_lookup(
+		uint8_t *auth_key,
+		size_t auth_key_size);
+
+/**
+ * Enables and prevents further limit modifications for an authorization key
+ *
+ * @param key  GNI authorization key
+ * @return     FI_SUCCESS on success
+ *             -FI_EINVAL, if bad parameters were passed
+ *             -FI_EBUSY, if already enabled
+ */
+
+int _gnix_auth_key_enable(struct gnix_auth_key *key);
+
+/**
+ * Retrieves the next available provider-reserved key for a given
+ * authorization key
+ *
+ * @param info  A GNI authorization key
+ * @return      FI_SUCCESS on success
+ *              -FI_EINVAL, if bad parameters were passed
+ *              -FI_EAGAIN, if no available key could be foundi
+ */
+int _gnix_get_next_reserved_key(struct gnix_auth_key *info);
+
+/**
+ * Releases a reserved key back to the bitset to be reused
+ *
+ * @param info          A GNI authorization key
+ * @param reserved_key  index of the reserved key
+ * @return              FI_SUCCESS on success
+ *                      -FI_EINVAL, if invalid parameters were passed
+ *                      -FI_EBUSY, if reserved key was already released
+ */
+int _gnix_release_reserved_key(struct gnix_auth_key *info, int reserved_key);
+
+/**
+ * Creates an authorization key from default configuration
+ *
+ * @param auth_key     authorization key
+ * @param auth_key_size  length of authorization key in bytes
+ * @return             non-NULL pointer on success
+ *                     NULL pointer on failure
+ */
+struct gnix_auth_key *_gnix_auth_key_create(
+		uint8_t *auth_key,
+		size_t auth_key_size);
+
+/**
+ * Inserts an authorization key into global data storage
+ *
+ * @param auth_key     authorization key
+ * @param auth_key_size  length of authorization key in bytes
+ * @param to_insert    GNI authorization key structure to insert
+ * @return             FI_SUCCESS on success
+ *                     -FI_EINVAL, if to_insert is NULL or global data
+ *                                 storage is destroyed
+ *                     -FI_ENOSPC, if auth key exists in global data
+ *                                 storage
+ */
+int _gnix_auth_key_insert(
+		uint8_t *auth_key,
+		size_t auth_key_size,
+		struct gnix_auth_key *to_insert);
+
+#define GNIX_GET_AUTH_KEY(auth_key, auth_key_size) \
+	({ \
+		struct gnix_auth_key *_tmp; \
+		_tmp  = _gnix_auth_key_lookup((auth_key), (auth_key_size)); \
+		int _tmp_ret; \
+		if (!_tmp) { \
+			GNIX_INFO(FI_LOG_FABRIC, \
+				"failed to find authorization " \
+				"key, creating new authorization key\n"); \
+			_tmp = _gnix_auth_key_create( \
+				(auth_key), (auth_key_size)); \
+			if (!_tmp) { \
+				GNIX_WARN(FI_LOG_FABRIC, \
+					"failed to create new " \
+					"authorization key\n"); \
+			} \
+			_tmp_ret = _gnix_auth_key_enable(_tmp); \
+			if (_tmp_ret) { \
+				GNIX_WARN(FI_LOG_FABRIC, \
+					"failed to enable new " \
+					"authorization key\n"); \
+			} \
+		} \
+		_tmp; \
+	})
+
+/* provider subsystem initialization and teardown functions */
+int _gnix_auth_key_subsys_init(void);
+int _gnix_auth_key_subsys_fini(void);
+
+#endif /* PROV_GNI_INCLUDE_GNIX_AUTH_KEY_H_ */

--- a/prov/gni/include/gnix_cm_nic.h
+++ b/prov/gni/include/gnix_cm_nic.h
@@ -143,6 +143,7 @@ int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic);
 int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 		       struct fi_info *info,
 		       uint32_t cdm_id,
+			   struct gnix_auth_key *auth_key,
 		       struct gnix_cm_nic **cm_nic);
 
 /**

--- a/prov/gni/include/gnix_mr_cache.h
+++ b/prov/gni/include/gnix_mr_cache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -118,6 +118,7 @@ struct _gnix_fi_reg_context {
 	uint64_t requested_key;
 	uint64_t flags;
 	void *context;
+	struct gnix_auth_key *auth_key;
 };
 
 /**

--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -99,6 +99,7 @@ struct gnix_nic_attr {
 	bool use_cdm_id;
 	uint32_t cdm_id;
 	bool must_alloc;
+	struct gnix_auth_key *auth_key;
 };
 
 /**

--- a/prov/gni/src/gnix_auth_key.c
+++ b/prov/gni/src/gnix_auth_key.c
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "rdma/fabric.h"
+#include "rdma/fi_errno.h"
+#include "fi_ext_gni.h"
+
+#include "gnix_auth_key.h"
+#include "gnix_hashtable.h"
+#include "gnix.h"
+
+#define GNIX_AUTH_KEY_HASHSEED 0xdeadbeef
+
+/* Global data storage for authorization key information */
+gnix_hashtable_t __gnix_auth_key_ht;
+
+int _gnix_get_next_reserved_key(struct gnix_auth_key *info)
+{
+	int reserved_key;
+	int offset = info->attr.user_key_limit;
+	int retry_limit = 10; /* randomly picked */
+	int ret;
+
+	if (!info) {
+		GNIX_WARN(FI_LOG_MR, "bad authorization key, key=%p\n",
+			info);
+		return -FI_EINVAL;
+	}
+
+	do {
+		reserved_key = _gnix_find_first_zero_bit(&info->prov);
+		if (reserved_key >= 0) {
+			ret = _gnix_test_and_set_bit(&info->prov, reserved_key);
+			if (ret)
+				reserved_key = -FI_EAGAIN;
+		}
+		retry_limit--;
+	} while (reserved_key < 0 && retry_limit > 0);
+
+	ret = (reserved_key < 0) ? reserved_key : (offset + reserved_key);
+
+	GNIX_INFO(FI_LOG_DOMAIN, "returning key=%d offset=%d\n", ret, offset);
+
+	return ret;
+}
+
+int _gnix_release_reserved_key(struct gnix_auth_key *info, int reserved_key)
+{
+	int offset = info->attr.user_key_limit;
+	int ret;
+
+	if (!info || reserved_key < 0) {
+		GNIX_WARN(FI_LOG_MR, "bad authorization key or reserved key,"
+			" auth_key=%p requested_key=%d\n",
+			info, reserved_key);
+		return -FI_EINVAL;
+	}
+
+	ret = _gnix_test_and_clear_bit(&info->prov, reserved_key - offset);
+	assert(ret == 1);
+
+	return (ret == 1) ? FI_SUCCESS : -FI_EBUSY;
+}
+
+int _gnix_auth_key_enable(struct gnix_auth_key *info)
+{
+	int ret = -FI_EBUSY;
+
+	if (!info) {
+		GNIX_WARN(FI_LOG_MR, "bad authorization key, key=%p\n",
+			info);
+		return -FI_EINVAL;
+	}
+
+	fastlock_acquire(&info->lock);
+	if (!info->enabled) {
+		info->enabled = 1;
+
+		ret = _gnix_alloc_bitmap(&info->prov,
+			info->attr.prov_key_limit);
+		assert(ret == FI_SUCCESS);
+
+		ret = _gnix_alloc_bitmap(&info->user,
+			info->attr.user_key_limit);
+		assert(ret == FI_SUCCESS);
+
+		GNIX_INFO(FI_LOG_DOMAIN,
+				"set resource limits: pkey=%08x ptag=%d "
+				"reserved=%d registration_limit=%d "
+				"reserved_keys=%d-%d\n",
+				info->cookie,
+				info->ptag,
+				info->attr.prov_key_limit,
+				info->attr.user_key_limit,
+				info->attr.user_key_limit,
+				(info->attr.prov_key_limit +
+				info->attr.user_key_limit - 1));
+		ret = FI_SUCCESS;
+	}
+	fastlock_release(&info->lock);
+
+	if (ret == -FI_EBUSY) {
+		GNIX_DEBUG(FI_LOG_MR, "authorization key already enabled, "
+			"auth_key=%p\n", info);
+	}
+
+	return ret;
+}
+
+struct gnix_auth_key *_gnix_auth_key_alloc()
+{
+	struct gnix_auth_key *auth_key = NULL;
+
+	auth_key = calloc(1, sizeof(*auth_key));
+	if (auth_key) {
+		fastlock_init(&auth_key->lock);
+	} else {
+		GNIX_WARN(FI_LOG_MR, "failed to allocate memory for "
+			"authorization key\n");
+	}
+
+	return auth_key;
+}
+
+int _gnix_auth_key_insert(
+		uint8_t *auth_key,
+		size_t auth_key_size,
+		struct gnix_auth_key *to_insert)
+{
+	int ret;
+	gnix_ht_key_t key;
+	struct fi_gni_auth_key *gni_auth_key =
+		(struct fi_gni_auth_key *) auth_key;
+
+	if (!to_insert) {
+		GNIX_WARN(FI_LOG_MR, "bad parameters, to_insert=%p\n",
+			to_insert);
+		return -FI_EINVAL;
+	}
+
+	if (auth_key_size == GNIX_PROV_DEFAULT_AUTH_KEYLEN)
+		key = 0;
+	else {
+		if (!auth_key) {
+			GNIX_INFO(FI_LOG_FABRIC, "auth key is null\n");
+			return -FI_EINVAL;
+		}
+
+		switch (gni_auth_key->type) {
+		case GNIX_AKT_RAW:
+			key = (gnix_ht_key_t) gni_auth_key->raw.protection_key;
+			break;
+		default:
+			GNIX_INFO(FI_LOG_FABRIC, "unrecognized auth key "
+				"type, type=%d\n",
+				gni_auth_key->type);
+			return -FI_EINVAL;
+		}
+	}
+
+	ret = _gnix_ht_insert(&__gnix_auth_key_ht, key, to_insert);
+	if (ret) {
+		GNIX_WARN(FI_LOG_MR, "failed to insert entry, ret=%d\n",
+			ret);
+	}
+
+	return ret;
+}
+
+int _gnix_auth_key_free(struct gnix_auth_key *key)
+{
+	int ret;
+
+	if (!key) {
+		GNIX_WARN(FI_LOG_MR, "bad parameters, key=%p\n", key);
+		return -FI_EINVAL;
+	}
+
+	fastlock_destroy(&key->lock);
+
+	key->enabled = 0;
+
+	ret = _gnix_free_bitmap(&key->user);
+	assert(ret == FI_SUCCESS);
+	if (ret) {
+		GNIX_ERR(FI_LOG_MR, "failed to free bitmap, bitmap=%p\n",
+			&key->user);
+	}
+
+	ret = _gnix_free_bitmap(&key->prov);
+	assert(ret == FI_SUCCESS);
+	if (ret) {
+		GNIX_ERR(FI_LOG_MR, "failed to free bitmap, bitmap=%p\n",
+			&key->prov);
+	}
+
+	free(key);
+
+	return FI_SUCCESS;
+}
+
+struct gnix_auth_key *
+_gnix_auth_key_lookup(uint8_t *auth_key, size_t auth_key_size)
+{
+	gnix_ht_key_t key;
+	struct gnix_auth_key *ptr = NULL;
+	struct fi_gni_auth_key *gni_auth_key;
+
+	if (auth_key_size == GNIX_PROV_DEFAULT_AUTH_KEYLEN) {
+		key = 0;
+	} else {
+		if (!auth_key) {
+			GNIX_INFO(FI_LOG_FABRIC,
+				"null auth key provided, cannot find entry\n");
+			return NULL;
+		}
+
+		gni_auth_key = (struct fi_gni_auth_key *) auth_key;
+		switch (gni_auth_key->type) {
+		case GNIX_AKT_RAW:
+			key = (gnix_ht_key_t) gni_auth_key->raw.protection_key;
+			break;
+		default:
+			GNIX_INFO(FI_LOG_FABRIC, "unrecognized auth key type, "
+				"type=%d\n", gni_auth_key->type);
+			return NULL;
+		}
+
+	}
+
+	ptr = (struct gnix_auth_key *) _gnix_ht_lookup(
+		&__gnix_auth_key_ht, key);
+
+	return ptr;
+}
+
+int _gnix_auth_key_subsys_init(void)
+{
+	int ret;
+
+	gnix_hashtable_attr_t attr = {
+			.ht_initial_size     = 8,
+			.ht_maximum_size     = 256,
+			.ht_increase_step    = 2,
+			.ht_increase_type    = GNIX_HT_INCREASE_MULT,
+			.ht_collision_thresh = 400,
+			.ht_hash_seed        = 0xcafed00d,
+			.ht_internal_locking = 1,
+			.destructor          = NULL
+	};
+
+	ret = _gnix_ht_init(&__gnix_auth_key_ht, &attr);
+	assert(ret == FI_SUCCESS);
+
+	return FI_SUCCESS;
+}
+
+int _gnix_auth_key_subsys_fini(void)
+{
+	return FI_SUCCESS;
+}
+
+struct gnix_auth_key *_gnix_auth_key_create(
+		uint8_t *auth_key,
+		size_t auth_key_size)
+{
+	struct gnix_auth_key *to_insert;
+	struct fi_gni_auth_key *gni_auth_key;
+	int ret;
+	gni_return_t grc;
+	uint8_t ptag;
+	uint32_t cookie;
+
+	if (auth_key_size == GNIX_PROV_DEFAULT_AUTH_KEYLEN) {
+		gnixu_get_rdma_credentials(NULL, &ptag, &cookie);
+	} else {
+		gni_auth_key = (struct fi_gni_auth_key *) auth_key;
+		switch (gni_auth_key->type) {
+		case GNIX_AKT_RAW:
+			cookie = gni_auth_key->raw.protection_key;
+			break;
+		default:
+			GNIX_WARN(FI_LOG_FABRIC,
+				"unrecognized auth key type, type=%d\n",
+				gni_auth_key->type);
+			return NULL;
+		}
+
+		grc = GNI_GetPtag(0, cookie, &ptag);
+		if (grc) {
+			GNIX_WARN(FI_LOG_FABRIC,
+				"could not retrieve ptag, "
+				"cookie=%d ret=%d\n", cookie, grc);
+			return NULL;
+		}
+	}
+
+	to_insert = _gnix_auth_key_alloc();
+	if (!to_insert) {
+		GNIX_WARN(FI_LOG_MR, "failed to allocate memory for "
+			"auth key\n");
+		return NULL;
+	}
+
+	to_insert->attr.prov_key_limit = gnix_default_prov_registration_limit;
+	to_insert->attr.user_key_limit = gnix_default_user_registration_limit;
+	to_insert->ptag = ptag;
+	to_insert->cookie = cookie;
+
+	ret = _gnix_auth_key_insert(auth_key, auth_key_size, to_insert);
+	if (ret) {
+		GNIX_INFO(FI_LOG_MR, "failed to insert authorization key, "
+			"key=%p len=%d to_insert=%p ret=%d\n",
+			auth_key, auth_key_size, to_insert, ret);
+		_gnix_auth_key_free(to_insert);
+		to_insert = NULL;
+	}
+
+	return to_insert;
+}

--- a/prov/gni/src/gnix_cm_nic.c
+++ b/prov/gni/src/gnix_cm_nic.c
@@ -594,6 +594,7 @@ int _gnix_cm_nic_free(struct gnix_cm_nic *cm_nic)
 int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 		       struct fi_info *info,
 		       uint32_t cdm_id,
+			   struct gnix_auth_key *auth_key,
 		       struct gnix_cm_nic **cm_nic_ptr)
 {
 	int ret = FI_SUCCESS;
@@ -624,7 +625,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	}
 
 	GNIX_INFO(FI_LOG_EP_CTRL, "creating cm_nic for %u/0x%x/%u\n",
-		      domain->ptag, domain->cookie, cdm_id);
+			auth_key->ptag, auth_key->cookie, cdm_id);
 
 	cm_nic = (struct gnix_cm_nic *)calloc(1, sizeof(*cm_nic));
 	if (cm_nic == NULL) {
@@ -639,6 +640,7 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	nic_attr.must_alloc = true;
 	nic_attr.use_cdm_id = true;
 	nic_attr.cdm_id = cdm_id;
+	nic_attr.auth_key = auth_key;
 
 	ret = gnix_nic_alloc(domain, &nic_attr, &cm_nic->nic);
 	if (ret != FI_SUCCESS) {
@@ -649,8 +651,8 @@ int _gnix_cm_nic_alloc(struct gnix_fid_domain *domain,
 	}
 
 	cm_nic->my_name.gnix_addr.cdm_id = cdm_id;
-	cm_nic->ptag = domain->ptag;
-	cm_nic->my_name.cookie = domain->cookie;
+	cm_nic->ptag = auth_key->ptag;
+	cm_nic->my_name.cookie = auth_key->cookie;
 	cm_nic->my_name.gnix_addr.device_addr = cm_nic->nic->device_addr;
 	cm_nic->domain = domain;
 	cm_nic->ctrl_progress = domain->control_progress;

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -54,7 +54,7 @@
 #include "gnix_xpmem.h"
 #include "gnix_eq.h"
 #include "gnix_cm.h"
-
+#include "gnix_auth_key.h"
 
 /*******************************************************************************
  * gnix_fab_req freelist functions
@@ -1749,6 +1749,7 @@ DIRECT_FN int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	struct gnix_fid_stx *stx;
 	struct gnix_fid_cntr *cntr;
 	struct gnix_fid_trx *trx_priv;
+	struct gnix_nic_attr nic_attr = {0};
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -1943,7 +1944,6 @@ DIRECT_FN int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		break;
 
 	case FI_CLASS_STX_CTX:
-
 		stx = container_of(bfid, struct gnix_fid_stx, stx_fid.fid);
 		if (ep->domain != stx->domain) {
 			ret = -FI_EINVAL;
@@ -1959,6 +1959,31 @@ DIRECT_FN int gnix_ep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 		if (ep->shared_tx == false || ep->nic) {
 			ret =  -FI_EOPBADSTATE;
 			break;
+		}
+
+		/*
+		 * we force allocation of a nic to make semantics
+		 * match the intent fi_endpoint man page, provide
+		 * a TX context (aka gnix nic) that can be shared
+		 * explicitly amongst endpoints
+		 */
+		if (stx->auth_key && ep->auth_key != stx->auth_key) {
+			ret = -FI_EINVAL;
+			break;
+		}
+
+		if (!stx->nic) {
+			nic_attr.must_alloc = true;
+			nic_attr.auth_key = ep->auth_key;
+			ret = gnix_nic_alloc(ep->domain, &nic_attr,
+				&stx->nic);
+			if (ret != FI_SUCCESS) {
+				GNIX_WARN(FI_LOG_EP_CTRL,
+					 "_gnix_nic_alloc call returned %d\n",
+					ret);
+					break;
+			}
+			stx->auth_key = nic_attr.auth_key;
 		}
 
 		ep->stx_ctx = stx;
@@ -2041,10 +2066,14 @@ static int _gnix_ep_nic_init(struct gnix_fid_domain *domain,
 	int ret = FI_SUCCESS;
 	uint32_t cdm_id = GNIX_CREATE_CDM_ID;
 	struct gnix_ep_name *name;
+	struct gnix_nic_attr nic_attr = {0};
 
 	if (ep->type == FI_EP_MSG) {
 		if (ep->shared_tx == false) {
-			ret = gnix_nic_alloc(domain, NULL, &ep->nic);
+			nic_attr.auth_key = ep->auth_key;
+
+			ret = gnix_nic_alloc(domain, &nic_attr,
+				&ep->nic);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,
 					  "_gnix_nic_alloc call returned %d\n",
@@ -2059,7 +2088,7 @@ static int _gnix_ep_nic_init(struct gnix_fid_domain *domain,
 		/* Endpoint was bound to a specific source address.  Create a
 		 * new CM NIC to listen on this address. */
 		ret = _gnix_cm_nic_alloc(domain, info, name->gnix_addr.cdm_id,
-					 &ep->cm_nic);
+				ep->auth_key, &ep->cm_nic);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				  "_gnix_cm_nic_alloc returned %s\n",
@@ -2097,7 +2126,7 @@ static int _gnix_ep_nic_init(struct gnix_fid_domain *domain,
 			}
 
 			ret = _gnix_cm_nic_alloc(domain, info, cdm_id,
-						 &domain->cm_nic);
+					ep->auth_key, &domain->cm_nic);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,
 					  "_gnix_cm_nic_alloc returned %s\n",
@@ -2123,11 +2152,12 @@ static int _gnix_ep_nic_init(struct gnix_fid_domain *domain,
 			_gnix_ref_get(ep->cm_nic);
 
 			if (ep->shared_tx == false) {
+				nic_attr.auth_key = ep->auth_key;
 
 				/* Allocate a new NIC for data
 				   movement on this EP. */
 				ret = gnix_nic_alloc(domain,
-						     NULL, &ep->nic);
+					&nic_attr, &ep->nic);
 				if (ret != FI_SUCCESS) {
 					GNIX_WARN(FI_LOG_EP_CTRL,
 					    "_gnix_nic_alloc call returned %d\n",
@@ -2205,6 +2235,7 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	int err_ret;
 	struct gnix_fid_domain *domain_priv;
 	struct gnix_fid_ep *ep_priv;
+	struct gnix_auth_key *auth_key;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -2213,6 +2244,23 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 		return -FI_EINVAL;
 
 	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
+
+#if 0 /* TODO: Enable after 1.5 version update */
+	if (FI_VERSION_LT(domain_priv->fabric->fab_fid.api_version,
+		FI_VERSION(1, 5)) &&
+		(info->ep_attr->auth_key || info->ep_attr->auth_key_size))
+		return -FI_EINVAL;
+#endif
+
+	if (info->ep_attr->auth_key_size) {
+		auth_key = GNIX_GET_AUTH_KEY(info->ep_attr->auth_key,
+				info->ep_attr->auth_key_size);
+		if (!auth_key)
+			return -FI_EINVAL;
+	} else {
+		auth_key = domain_priv->auth_key;
+		assert(auth_key);
+	}
 
 	ep_priv = calloc(1, sizeof *ep_priv);
 	if (!ep_priv)
@@ -2229,6 +2277,7 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->ep_fid.atomic = &gnix_ep_atomic_ops;
 
 	/* Init GNIX data. */
+	ep_priv->auth_key = auth_key;
 	ep_priv->type = info->ep_attr->type;
 	ep_priv->domain = domain_priv;
 	_gnix_ref_init(&ep_priv->ref_cnt, 1, __ep_destruct);
@@ -2366,8 +2415,10 @@ int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
 	struct gnix_fid_domain *domain_priv;
 	struct gnix_fid_ep *ep_priv;
 	gnix_ht_key_t *key_ptr;
+	struct gnix_auth_key *auth_key;
 	uint32_t cdm_id;
 	bool free_list_inited = false;
+	struct gnix_nic_attr nic_attr = {0};
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -2377,9 +2428,21 @@ int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
 
 	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
 
+	if (info->ep_attr->auth_key_size) {
+		auth_key = GNIX_GET_AUTH_KEY(info->ep_attr->auth_key,
+				info->ep_attr->auth_key_size);
+		if (!auth_key)
+			return -FI_EINVAL;
+	} else {
+		auth_key = domain_priv->auth_key;
+		assert(auth_key);
+	}
+
 	ep_priv = calloc(1, sizeof(*ep_priv));
 	if (!ep_priv)
 		return -FI_ENOMEM;
+
+	ep_priv->auth_key = auth_key;
 
 	ep_priv->requires_lock = (domain_priv->thread_model !=
 				FI_THREAD_COMPLETION);
@@ -2473,6 +2536,7 @@ int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
 		if (domain_priv->cm_nic == NULL) {
 			ret = _gnix_cm_nic_alloc(domain_priv, info,
 						 cdm_id,
+						 ep_priv->auth_key,
 						 &domain_priv->cm_nic);
 			if (ret != FI_SUCCESS) {
 				GNIX_WARN(FI_LOG_EP_CTRL,
@@ -2534,8 +2598,10 @@ int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
 		ep_priv->nic = attr->nic;
 	} else {
 		assert(ep_priv->nic == NULL);
+		nic_attr.auth_key = ep_priv->auth_key;
 
-		ret = gnix_nic_alloc(domain_priv, NULL, &ep_priv->nic);
+		ret = gnix_nic_alloc(domain_priv, &nic_attr,
+			&ep_priv->nic);
 		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL,
 				    "gnix_nic_alloc call returned %d\n", ret);

--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2015-2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <gni_pub.h>
 #include "gnix.h"
+#include "gnix_auth_key.h"
 #include "gnix_util.h"
 #include "fi.h"
 #include "prov.h"
@@ -150,6 +151,16 @@ void _gnix_init(void)
 	static int called=0;
 
 	if (called==0) {
+		if (sizeof(struct gnix_mr_key) != sizeof(uint64_t)) {
+			GNIX_FATAL(FI_LOG_FABRIC,
+				"gnix_mr_key size is invalid, "
+				"size=%d expected=%d\n",
+				sizeof(struct gnix_mr_key),
+				sizeof(uint64_t));
+			assert(0);
+		}
+
+		_gnix_auth_key_subsys_init();
 
 		ofi_atomic_initialize32(&gnix_id_counter, 0);
 		ofi_atomic_initialize32(&file_id_counter, 0);

--- a/prov/gni/test/common.h
+++ b/prov/gni/test/common.h
@@ -45,6 +45,14 @@
 #define BLUE "\x1b[34m"
 #define COLOR_RESET "\x1b[0m"
 
+#define CACHE_RO 0
+#define CACHE_RW 1
+
+#define GET_DOMAIN_RO_CACHE(domain) \
+    ({ domain->mr_cache_info[domain->auth_key->ptag].mr_cache_ro; })
+#define GET_DOMAIN_RW_CACHE(domain) \
+    ({ domain->mr_cache_info[domain->auth_key->ptag].mr_cache_rw; })
+
 /* defined in rdm_atomic.c */
 extern int supported_compare_atomic_ops[FI_ATOMIC_OP_LAST][FI_DATATYPE_LAST];
 extern int supported_fetch_atomic_ops[FI_ATOMIC_OP_LAST][FI_DATATYPE_LAST];

--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -167,6 +167,7 @@ Test(domain, open_ops)
 			case GNI_XPMEM_ENABLE:
 				cr_assert(xpmem_toggle == xpmem_check,
 					  "Incorrect op value");
+				break;
 			default:
 				cr_assert(val == i*op+op, "Incorrect op value");
 				break;

--- a/prov/gni/test/fabric.c
+++ b/prov/gni/test/fabric.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+
+
+#include "gnix.h"
+
+#include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+#include "fi_ext_gni.h"
+
+static struct fid_fabric *fabric;
+static struct fi_info *fi;
+
+static void setup(void)
+{
+	int ret;
+	struct fi_info *hints;
+
+	hints = fi_allocinfo();
+	cr_assert(hints, "fi_allocinfo");
+
+	hints->fabric_attr->prov_name = strdup("gni");
+
+	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
+	cr_assert(ret == FI_SUCCESS, "fi_getinfo");
+
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
+	cr_assert(ret == FI_SUCCESS, "fi_fabric");
+
+	fi_freeinfo(hints);
+}
+
+static void teardown(void)
+{
+	int ret;
+
+	ret = fi_close(&fabric->fid);
+	cr_assert(ret == FI_SUCCESS, "fi_close fabric");
+
+	fi_freeinfo(fi);
+}
+
+TestSuite(fabric, .init = setup, .fini = teardown);
+
+
+
+
+Test(fabric, simple)
+{
+	cr_assert(fabric != NULL);
+}
+
+Test(fabric, open_ops_1)
+{
+	int ret;
+	struct fi_gni_ops_fab *ops;
+
+	ret = fi_open_ops(&fabric->fid,
+		FI_GNI_FAB_OPS_1, 0, (void **) &ops, NULL);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	cr_assert(ops);
+}
+
+Test(fabric, open_ops_2)
+{
+	int ret;
+	struct fi_gni_auth_key_ops_fab *auth_ops;
+
+	ret = fi_open_ops(&fabric->fid,
+		FI_GNI_FAB_OPS_2, 0, (void **) &auth_ops, NULL);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	cr_assert(auth_ops);
+}
+
+Test(fabric, set_limits)
+{
+	int ret;
+	int in;
+	int total;
+
+	struct gnix_auth_key_attr default_attr = { 0 };
+	struct gnix_auth_key_attr expected_attr = { 0 };
+	struct gnix_auth_key_attr actual_attr = { 0 };
+
+	struct fi_gni_ops_fab *ops;
+	struct fi_gni_auth_key_ops_fab *auth_ops;
+
+	ret = fi_open_ops(&fabric->fid,
+		FI_GNI_FAB_OPS_1, 0, (void **) &ops, NULL);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = fi_open_ops(&fabric->fid,
+		FI_GNI_FAB_OPS_2, 0, (void **) &auth_ops, NULL);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	cr_assert(ops);
+	cr_assert(auth_ops);
+
+	ret = ops->get_val(&fabric->fid,
+		GNI_DEFAULT_USER_REGISTRATION_LIMIT,
+		&default_attr.user_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	in = (default_attr.user_key_limit == 1) ?
+		2 : default_attr.user_key_limit - 1;
+	cr_assert(in > 0);
+	expected_attr.user_key_limit = in;
+
+	ret = ops->get_val(&fabric->fid,
+		GNI_DEFAULT_PROV_REGISTRATION_LIMIT,
+		&default_attr.prov_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	in = (default_attr.prov_key_limit == 1) ?
+		2 : default_attr.prov_key_limit - 1;
+	cr_assert(in > 0);
+	expected_attr.prov_key_limit = in;
+
+	/* set defaults */
+	ret = ops->set_val(&fabric->fid,
+		GNI_DEFAULT_USER_REGISTRATION_LIMIT,
+		&expected_attr.user_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = ops->set_val(&fabric->fid,
+		GNI_DEFAULT_PROV_REGISTRATION_LIMIT,
+		&expected_attr.prov_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	/* get defaults */
+	ret = ops->get_val(&fabric->fid,
+		GNI_DEFAULT_USER_REGISTRATION_LIMIT,
+		&actual_attr.user_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+	cr_assert_eq(actual_attr.user_key_limit, expected_attr.user_key_limit);
+
+	ret = ops->get_val(&fabric->fid,
+		GNI_DEFAULT_PROV_REGISTRATION_LIMIT,
+		&actual_attr.prov_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+	cr_assert_eq(actual_attr.prov_key_limit, expected_attr.prov_key_limit);
+
+	/* clear result buffer */
+	memset(&actual_attr, 0x0, sizeof(actual_attr));
+
+	/* ensure defaults were propogated to default key */
+	ret = auth_ops->get_val(GNIX_PROV_DEFAULT_AUTH_KEY,
+		GNIX_PROV_DEFAULT_AUTH_KEYLEN,
+		GNIX_USER_KEY_LIMIT,
+		&actual_attr.user_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+	cr_assert_eq(actual_attr.user_key_limit, expected_attr.user_key_limit);
+
+	ret = auth_ops->get_val(GNIX_PROV_DEFAULT_AUTH_KEY,
+		GNIX_PROV_DEFAULT_AUTH_KEYLEN,
+		GNIX_PROV_KEY_LIMIT,
+		&actual_attr.prov_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+	cr_assert_eq(actual_attr.prov_key_limit, expected_attr.prov_key_limit);
+
+	ret = auth_ops->get_val(GNIX_PROV_DEFAULT_AUTH_KEY,
+		GNIX_PROV_DEFAULT_AUTH_KEYLEN,
+		GNIX_TOTAL_KEYS_NEEDED,
+		&total);
+	cr_assert_eq(ret, FI_SUCCESS);
+	cr_assert_eq(total,
+		expected_attr.prov_key_limit + expected_attr.user_key_limit);
+
+	/* set default auth key limits to something else */
+	expected_attr.user_key_limit >>= 1;
+	expected_attr.prov_key_limit >>= 1;
+
+	ret = auth_ops->set_val(GNIX_PROV_DEFAULT_AUTH_KEY,
+		GNIX_PROV_DEFAULT_AUTH_KEYLEN,
+		GNIX_USER_KEY_LIMIT,
+		&expected_attr.user_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = auth_ops->set_val(GNIX_PROV_DEFAULT_AUTH_KEY,
+		GNIX_PROV_DEFAULT_AUTH_KEYLEN,
+		GNIX_PROV_KEY_LIMIT,
+		&expected_attr.prov_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	ret = auth_ops->get_val(GNIX_PROV_DEFAULT_AUTH_KEY,
+		GNIX_PROV_DEFAULT_AUTH_KEYLEN,
+		GNIX_USER_KEY_LIMIT,
+		&actual_attr.user_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+	cr_assert_eq(actual_attr.user_key_limit, expected_attr.user_key_limit);
+
+	ret = auth_ops->get_val(GNIX_PROV_DEFAULT_AUTH_KEY,
+		GNIX_PROV_DEFAULT_AUTH_KEYLEN,
+		GNIX_PROV_KEY_LIMIT,
+		&actual_attr.prov_key_limit);
+	cr_assert_eq(ret, FI_SUCCESS);
+	cr_assert_eq(actual_attr.prov_key_limit, expected_attr.prov_key_limit);
+}

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -52,9 +52,6 @@
 #include "gnix.h"
 #include "gnix_mr.h"
 
-#define CACHE_RO 0
-#define CACHE_RW 1
-
 #define CHECK_HOOK(name, args...) \
 	({ \
 		int __hook_return_val = 0; \
@@ -89,6 +86,7 @@ static struct fi_info *fi;
 static unsigned char *buf;
 static int buf_len = __BUF_LEN * sizeof(unsigned char);
 static struct gnix_fid_domain *domain;
+static uint8_t ptag;
 static gnix_mr_cache_t *cache;
 static int regions;
 
@@ -162,6 +160,8 @@ static void _mr_setup(void)
 	cr_assert(buf, "buffer allocation");
 
 	domain = container_of(dom, struct gnix_fid_domain, domain_fid.fid);
+	ptag = domain->auth_key->ptag;
+
 	regions = 1024;
 }
 
@@ -265,8 +265,8 @@ TestSuite(perf_mr_no_cache, .init = no_cache_setup, .fini = mr_teardown,
 
 static int __simple_init_hook(const char *func, int line)
 {
-	cr_assert(domain->mr_cache_ro->state == GNIX_MRC_STATE_READY);
-	cr_assert(domain->mr_cache_rw->state == GNIX_MRC_STATE_READY);
+	cr_assert(GET_DOMAIN_RO_CACHE(domain)->state == GNIX_MRC_STATE_READY);
+	cr_assert(GET_DOMAIN_RW_CACHE(domain)->state == GNIX_MRC_STATE_READY);
 
 	return 0;
 }
@@ -276,9 +276,9 @@ static int __simple_post_reg_hook(const char *func, int line, int cache_type,
 		int expected_stale)
 {
 	if (cache_type == CACHE_RO)
-		cache = domain->mr_cache_ro;
+		cache = GET_DOMAIN_RO_CACHE(domain);
 	else
-		cache = domain->mr_cache_rw;
+		cache = GET_DOMAIN_RW_CACHE(domain);
 
 	cr_assert(ofi_atomic_get32(&cache->inuse.elements) == expected_inuse,
 		"%s:%d failed expected inuse condition, actual=%d expected=%d\n",
@@ -294,7 +294,7 @@ static int __simple_post_dereg_hook(const char *func, int line,
 		int expected_inuse,
 		int expected_stale)
 {
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 	cr_assert(ofi_atomic_get32(&cache->inuse.elements) == expected_inuse);
 	cr_assert(ofi_atomic_get32(&cache->stale.elements) == expected_stale);
 
@@ -612,7 +612,7 @@ Test(mr_internal_cache, change_hard_soft_limits)
 			default_flags, &mr, NULL);
 	cr_assert(ret == FI_SUCCESS);
 
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 	cr_assert(cache->state == GNIX_MRC_STATE_READY);
 	cr_assert(cache->attr.hard_reg_limit == 8192);
 	cr_assert(cache->attr.soft_reg_limit == 4096);
@@ -667,7 +667,7 @@ static int __post_dereg_greater_or_equal(const char *func, int line,
 		int expected_inuse,
 		int expected_stale)
 {
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 
 	cr_assert(ofi_atomic_get32(&cache->inuse.elements) == expected_inuse,
 		"failed expected inuse test, actual=%d expected=%d\n",
@@ -740,7 +740,7 @@ static int __post_dereg_greater_than(const char *func, int line,
 		int expected_inuse,
 		int expected_stale)
 {
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 	cr_assert(ofi_atomic_get32(&cache->inuse.elements) == expected_inuse);
 	cr_assert(ofi_atomic_get32(&cache->stale.elements) > expected_stale);
 
@@ -815,7 +815,7 @@ static void __simple_register_1024_non_unique_regions_test(HOOK_DECL)
 
 static int __get_lazy_dereg_limit(const char *func, int line)
 {
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 
 	return cache->attr.hard_stale_limit;
 }
@@ -913,9 +913,9 @@ static int __test_stale_lt_or_equal(const char *func, int line,
 		int expected_stale)
 {
 	if (cache_type == CACHE_RO)
-		cache = domain->mr_cache_ro;
+		cache = GET_DOMAIN_RO_CACHE(domain);
 	else
-		cache = domain->mr_cache_rw;
+		cache = GET_DOMAIN_RW_CACHE(domain);
 
 	cr_assert(ofi_atomic_get32(&cache->inuse.elements) == expected_inuse);
 	cr_assert(ofi_atomic_get32(&cache->stale.elements) <= expected_stale);
@@ -1073,7 +1073,7 @@ Test(mr_internal_cache, lru_evict_first_entry)
 	}
 
 	/* all registrations should now be 'in-use' */
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 	cr_assert(ofi_atomic_get32(&cache->inuse.elements) == regions);
 	cr_assert(ofi_atomic_get32(&cache->stale.elements) == 0);
 
@@ -1149,7 +1149,7 @@ Test(mr_internal_cache, lru_evict_middle_entry)
 	}
 
 	/* all registrations should now be 'in-use' */
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 	limit = cache->attr.hard_stale_limit;
 	cr_assert(limit < regions);
 
@@ -1222,7 +1222,7 @@ static inline void _repeated_registration(const char *label)
 					default_offset, default_req_key,
 					default_flags, &mr, NULL);
 
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 
 	gettimeofday(&s1, 0);
 	for (i = 0; i < registrations; i++) {
@@ -1280,7 +1280,7 @@ static inline void _single_large_registration(const char *label)
 					default_offset, default_req_key,
 					default_flags, &mr, NULL);
 
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 
 	gettimeofday(&s1, 0);
 	for (i = 0; i < registrations; i++) {
@@ -1431,7 +1431,7 @@ Test(mr_internal_cache, regression_615)
 			default_flags, &f_mr, NULL);
 	cr_assert(ret == FI_SUCCESS);
 
-	cache = domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(domain);
 
 	cr_assert(ofi_atomic_get32(&cache->inuse.elements) == 1);
 	cr_assert(ofi_atomic_get32(&cache->stale.elements) == 0);

--- a/prov/gni/test/nic.c
+++ b/prov/gni/test/nic.c
@@ -91,11 +91,18 @@ Test(nic, alloc_free)
 	int i, ret;
 	const int num_nics = 79;
 	struct gnix_nic *nics[num_nics];
+	struct gnix_fid_domain *domain = container_of(
+		dom, struct gnix_fid_domain, domain_fid);
+	struct gnix_auth_key *auth_key = domain->auth_key;
+	struct gnix_nic_attr nic_attr = {0};
+
+
+	nic_attr.auth_key = auth_key;
 
 	for (i = 0; i < num_nics; i++) {
 		ret = gnix_nic_alloc(container_of(dom, struct gnix_fid_domain,
 						  domain_fid),
-						  NULL,
+						  &nic_attr,
 						  &nics[i]);
 		cr_assert_eq(ret, FI_SUCCESS, "Could not allocate nic");
 	}

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -1979,7 +1979,7 @@ Test(rdm_atomic, atomicinject)
 	*((int64_t *)target) = TARGET_DATA;
 
 	ep_priv = container_of(ep[0], struct gnix_fid_ep, ep_fid);
-	cache = ep_priv->domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(ep_priv->domain);
 	cr_assert(cache != NULL);
 	already_registered = ofi_atomic_get32(&cache->inuse.elements);
 

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -1294,7 +1294,7 @@ void do_inject_write(int len)
 	init_data(target, len, 0);
 
 	ep_priv = container_of(ep[0], struct gnix_fid_ep, ep_fid);
-	cache = ep_priv->domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(ep_priv->domain);
 	cr_assert(cache != NULL);
 
 	already_registered = ofi_atomic_get32(&cache->inuse.elements);

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -1108,7 +1108,7 @@ void do_inject(int len)
 	rdm_sr_init_data(target, len, 0);
 
 	ep_priv = container_of(ep[0], struct gnix_fid_ep, ep_fid);
-	cache = ep_priv->domain->mr_cache_rw;
+	cache = GET_DOMAIN_RW_CACHE(ep_priv->domain);
 	cr_assert(cache != NULL);
 	already_registered = ofi_atomic_get32(&cache->inuse.elements);
 


### PR DESCRIPTION
Added necessary code to support authorization keys for the GNI provider

upstream merge of ofi-cray/libfabric-cray#1302

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@501260bf82e8b45a7d92a12f88b5953c3af79c66)

Conflicts:
	prov/gni/src/gnix_nic.c
(cherry picked from commit 5928ba1a49b029c2bb774eff28541196eb7f6299)