### PR TITLE
prov/gni: report ep_cnt, cq_cnt

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -259,6 +259,10 @@ gni;node;service;GNIX_AV_STR_ADDR_VERSION;device_addr;cdm_id;name_type;cm_nic_cd
 
 The GNI provider sets the domain attribute *cntr_cnt* to the the CQ limit divided by 2.
 
+The GNI provider sets the domain attribute *cq_cnt* to the CQ limit divided by 2.
+
+The GNI provider sets the domain attribute *ep_cnt* to SIZE_MAX.
+
 Completion queue events may report unknown source address information when
 using *FI_SOURCE*. The source address information will be reported in the
 err_data member of the struct fi_cq_err_entry populated by fi_cq_readerr. The

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -207,6 +207,8 @@ static struct fi_info *_gnix_allocinfo(void)
 						1 : gnix_max_nics_per_ptag - 1;
 	gnix_info->domain_attr->rx_ctx_cnt = gnix_max_nics_per_ptag;
 	gnix_info->domain_attr->cntr_cnt = _gnix_get_cq_limit() / 2;
+	gnix_info->domain_attr->cq_cnt = _gnix_get_cq_limit() / 2;
+	gnix_info->domain_attr->ep_cnt = SIZE_MAX;
 
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -100,6 +100,8 @@ Test(endpoint_info, info)
 	cr_assert_eq(fi->next->ep_attr->type, FI_EP_DGRAM);
 	cr_assert_eq(fi->next->next->ep_attr->type, FI_EP_MSG);
 	cr_assert_neq(fi->domain_attr->cntr_cnt, 0);
+	cr_assert_neq(fi->domain_attr->cq_cnt, 0);
+	cr_assert_eq(fi->domain_attr->ep_cnt, SIZE_MAX);
 
 	fi_freeinfo(fi);
 


### PR DESCRIPTION
Use SIZE_MAX for ep_cnt. Use half available cq's for cq_cnt
similar to what was done for cntr_cnt.

fixes ofi-cray/libfabric-cray#1343
fixes ofi-cray/libfabric-cray#1128

upstream merge of ofi-cray/libfabric-cray#1344

Signed-off-by: James Shimek <jshimek@cray.com>
(cherry picked from commit 4e5866ad19f485e208df01509de0c4e4f1505359)