### PR TITLE
prov/gni: runtime version check cntr_err methods

### DIFF
--- a/prov/gni/src/gnix_cntr.c
+++ b/prov/gni/src/gnix_cntr.c
@@ -237,6 +237,9 @@ DIRECT_FN STATIC int gnix_cntr_adderr(struct fid_cntr *cntr, uint64_t value)
 	struct gnix_fid_cntr *cntr_priv;
 
 	cntr_priv = container_of(cntr, struct gnix_fid_cntr, cntr_fid);
+	if (FI_VERSION_LT(cntr_priv->domain->fabric->fab_fid.api_version, FI_VERSION(1, 5)))
+		return -FI_EOPNOTSUPP;
+
 	ofi_atomic_add32(&cntr_priv->cnt_err, (int)value);
 
 	if (cntr_priv->wait)
@@ -250,6 +253,10 @@ DIRECT_FN STATIC int gnix_cntr_seterr(struct fid_cntr *cntr, uint64_t value)
 	struct gnix_fid_cntr *cntr_priv;
 
 	cntr_priv = container_of(cntr, struct gnix_fid_cntr, cntr_fid);
+
+	if (FI_VERSION_LT(cntr_priv->domain->fabric->fab_fid.api_version, FI_VERSION(1, 5)))
+		return -FI_EOPNOTSUPP;
+
 	ofi_atomic_set32(&cntr_priv->cnt_err, (int)value);
 
 	if (cntr_priv->wait)


### PR DESCRIPTION
Return -FI_EOPNOTSUPP when requested api_version is
below version 1.5.

fixes ofi-cray/libfabric-cray#1229
upstream merge of ofi-cray/libfabric-cray#1345

Signed-off-by: James Shimek <jshimek@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@c5e085a4cb0605c7650f6705a3194e0e43045f27)