### PR TITLE
prov/psm,psm2: Add a synchronization point for local name servers

### DIFF
--- a/prov/psm/src/psmx_ns.c
+++ b/prov/psm/src/psmx_ns.c
@@ -196,7 +196,9 @@ static void *psmx_name_server_func(void *args)
 
 	if (listenfd < 0) {
 		FI_INFO(&psmx_prov, FI_LOG_CORE,
-			"couldn't listen to port %d. try set FI_PSM2_UUID to a different value?\n",
+			"couldn't bind to port %d. It is fine if another process from the "
+			"same job has started the name server.\nHowever, if that's not the "
+			"case, try set FI_PSM_UUID to a different value.\n",
 			port);
 		return NULL;
 	}
@@ -256,9 +258,13 @@ static void *psmx_name_server_func(void *args)
  * Name server API: server side
  */
 
+static int psmx_ns_connect_server(const char *server);
+
 void psmx_ns_start_server(struct psmx_fid_fabric *fabric)
 {
 	int ret;
+	int sockfd;
+	int sleep_usec = 1000;
 
 	ret = pthread_create(&fabric->name_server_thread, NULL,
 			     psmx_name_server_func, (void *)fabric);
@@ -267,6 +273,23 @@ void psmx_ns_start_server(struct psmx_fid_fabric *fabric)
 		/* use the main thread's ID as invalid value for the new thread */
 		fabric->name_server_thread = pthread_self();
 	}
+
+	/*
+	 * Wait for the local name server to come up. It could be the thread
+	 * created above, or the thread created by another process on the same
+	 * node. The total wait time is about (1+2+4+...+8192)ms = 16 seconds.
+	 */
+	FI_INFO(&psmx_prov, FI_LOG_CORE, "connecting to local name server\n");
+	while (sleep_usec < 10000) {
+		sockfd = psmx_ns_connect_server("localhost");
+		if (sockfd >= 0) {
+			close(sockfd);
+			return;
+		}
+		usleep(sleep_usec);
+		sleep_usec *= 2;
+	}
+	FI_WARN(&psmx_prov, FI_LOG_CORE, "can't connect to local name server.\n", ret);
 }
 
 void psmx_ns_stop_server(struct psmx_fid_fabric *fabric)


### PR DESCRIPTION
Name server runs as a separate thread. Sometimes it could start a
little bit slow so that when a local endpoint tries to register its
address the name server has not entered the ready state. This would
lead to future name resolution failure when a remote process tries
to get the address of that endpoint.

A synchronization point is added when the name server thread is
started. Within a limited period of time multiple attempts are made
to connect to the local name server. The synchronization point is
inside the name server start routine and thus does not affect the
execution if the name server is turned off.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>