### PR TITLE
prov/bgq: Store msg data in context for fi_trecvmsg implementation

### DIFF
--- a/prov/bgq/include/rdma/fi_direct_tagged.h
+++ b/prov/bgq/include/rdma/fi_direct_tagged.h
@@ -98,6 +98,7 @@ ssize_t fi_bgq_trecvmsg_generic (struct fid_ep *ep,
 			bgq_context->tag = msg->tag;
 			bgq_context->ignore = msg->ignore;
 			bgq_context->src_addr = (fi_addr_t ) (msg->addr);
+			bgq_context->data = msg->data;
 		}
 
 		context_rsh3b = (uint64_t)bgq_context >> 3;
@@ -117,6 +118,7 @@ ssize_t fi_bgq_trecvmsg_generic (struct fid_ep *ep,
 			bgq_context->tag = msg->tag;
 			bgq_context->ignore = msg->ignore;
 			bgq_context->src_addr = (fi_addr_t ) (msg->addr);
+			bgq_context->data = msg->data;
 		}
 
 		context_rsh3b = (uint64_t)bgq_context >> 3;
@@ -132,6 +134,7 @@ ssize_t fi_bgq_trecvmsg_generic (struct fid_ep *ep,
 		ext->bgq_context.byte_counter = (uint64_t)-1;
 		ext->bgq_context.tag = msg->tag;
 		ext->bgq_context.src_addr = (fi_addr_t ) (msg->addr);
+		ext->bgq_context.data = msg->data;
 		ext->bgq_context.ignore = msg->ignore;
 		ext->msg.op_context = msg->context;
 		ext->msg.iov_count = msg->iov_count;


### PR DESCRIPTION
The immediate data was not making it into the completion queue entry
for the fi_trecvmsg implementation because the msg data was not being
copied into the fi_bgq_context, in the case of MPI_Mprobe this resulted
in the MPI_Status object not correctly having the MPI_SOURCE field set
as the source rank is sent as the immediate data.  This fix copies that
data into the context and the MPI_Mprobe now works correctly.

Signed-off-by: Paul Coffman <pcoffman@anl.gov>