### PR TITLE
prov/gni: Fix free for failure to insert for gnix auth keys

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -90,6 +90,7 @@ bin_SCRIPTS += prov/gni/test/run_gnitest
 nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/allocator.c \
 	prov/gni/test/av.c \
+	prov/gni/test/auth_key.c \
 	prov/gni/test/bitmap.c \
 	prov/gni/test/buddy_allocator.c \
 	prov/gni/test/cancel.c \

--- a/prov/gni/src/gnix_auth_key.c
+++ b/prov/gni/src/gnix_auth_key.c
@@ -207,21 +207,22 @@ int _gnix_auth_key_free(struct gnix_auth_key *key)
 
 	fastlock_destroy(&key->lock);
 
+	if (key->enabled) {
+		ret = _gnix_free_bitmap(&key->user);
+		assert(ret == FI_SUCCESS);
+		if (ret) {
+			GNIX_ERR(FI_LOG_MR, "failed to free bitmap, bitmap=%p\n",
+				&key->user);
+		}
+
+		ret = _gnix_free_bitmap(&key->prov);
+		assert(ret == FI_SUCCESS);
+		if (ret) {
+			GNIX_ERR(FI_LOG_MR, "failed to free bitmap, bitmap=%p\n",
+				&key->prov);
+		}
+	}
 	key->enabled = 0;
-
-	ret = _gnix_free_bitmap(&key->user);
-	assert(ret == FI_SUCCESS);
-	if (ret) {
-		GNIX_ERR(FI_LOG_MR, "failed to free bitmap, bitmap=%p\n",
-			&key->user);
-	}
-
-	ret = _gnix_free_bitmap(&key->prov);
-	assert(ret == FI_SUCCESS);
-	if (ret) {
-		GNIX_ERR(FI_LOG_MR, "failed to free bitmap, bitmap=%p\n",
-			&key->prov);
-	}
 
 	free(key);
 

--- a/prov/gni/test/auth_key.c
+++ b/prov/gni/test/auth_key.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <getopt.h>
+#include <poll.h>
+#include <time.h>
+#include <string.h>
+
+
+#include "gnix.h"
+
+#include <criterion/criterion.h>
+#include "gnix_rdma_headers.h"
+#include "fi_ext_gni.h"
+
+#include "gnix_auth_key.h"
+
+static void setup(void)
+{
+}
+
+static void teardown(void)
+{
+}
+
+TestSuite(auth_key, .init = setup, .fini = teardown);
+
+
+Test(auth_key, create)
+{
+	struct gnix_auth_key *ret;
+
+	ret = _gnix_auth_key_create(NULL, 0);
+	cr_assert(ret != NULL, "failed to create auth key");
+}
+
+Test(auth_key, failed_insert)
+{
+	struct gnix_auth_key *ret;
+
+	ret = _gnix_auth_key_create(NULL, 0);
+	cr_assert(ret != NULL, "failed to create auth_key");
+
+	ret = _gnix_auth_key_create(NULL, 0);
+	cr_assert(ret == NULL, "unexpectedly created auth_key");
+}


### PR DESCRIPTION
If the insertion in the global structure fails due to keep collision and races,
it will free a key that hasn't been enabled yet. This causes an error because
it expects the bitmap to have been initialized.

upstream merge of ofi-cray/libfabric-cray#1346

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@fdd1280d8d1b84fe97765e3bbc43ffdb2e7b1727)