### PR TITLE
prov/gni: add gnix_auth_key.h to makefile

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -50,6 +50,7 @@ _gni_files = \
 _gni_headers = \
 	prov/gni/include/fi_ext_gni.h \
 	prov/gni/include/gnix_atomic.h \
+	prov/gni/include/gnix_auth_key.h \
 	prov/gni/include/gnix_av.h \
 	prov/gni/include/gnix_bitmap.h \
 	prov/gni/include/gnix_buddy_allocator.h \


### PR DESCRIPTION
upstream merge of ofi-cray/libfabric-cray#1355

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@ed4e78545bf1858f672eefbb4765ee878856d49b)