### PR TITLE
prov/bgq: Copy immediate_data into context on match for FI_PEEK

### DIFF
--- a/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq_rx.h
@@ -1148,6 +1148,8 @@ int process_mfifo_context (struct fi_bgq_ep * bgq_ep, const unsigned poll_msg,
 						prev->next = uepkt->next;
 					}
 				}
+				/* tranfer immediate data from pkt to context for matching FI_PEEK */
+				context->data = uepkt->hdr.pt2pt.immediate_data;
 
 				/* post a completion event for the receive */
 				fi_bgq_cq_enqueue_completed(bgq_ep->recv_cq, context, 0);	/* TODO - IS lock required? */


### PR DESCRIPTION
The immediate data was missed as part of the meta-data that needs to be
copied into the context when matching on an FI_PEEK into the context queue.

Signed-off-by: Paul Coffman <pcoffman@anl.gov>