### PR TITLE
Add script to convert libfabric manpages into a PDF

### DIFF
--- a/contrib/man2pdf/man2pdf.sh
+++ b/contrib/man2pdf/man2pdf.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Copyright (c) 2017 Intel Corp.  All rights reserved.
+#
+# This software is available to you under a choice of one of two
+# licenses.  You may choose to be licensed under the terms of the GNU
+# General Public License (GPL) Version 2, available from the file
+# COPYING in the main directory of this source tree, or the
+# BSD license below:
+#
+#     Redistribution and use in source and binary forms, with or
+#     without modification, are permitted provided that the following
+#     conditions are met:
+#
+#      - Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      - Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials
+#        provided with the distribution.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+#
+# MAN 2 PDF -- Simple script to convert the libfabric manpages into a PDF
+#
+# Requires libfabric manpages to be installed and available in MANPATH.
+# Uses man and ps2pdf to convert each manpage, followed by Mac join.py or
+# pdfjoin to generate final PDF
+#
+
+# Generate list of manpages, but exclude manpages that are symlinks to other manpages
+#MANPAGES=( `echo fabric && man -a -w fi_* | xargs basename | sort | uniq | cut -d . -f 1` )
+
+# List of manpages, sorted in suggested reading order
+MANPAGES=(  fabric
+            fi_getinfo
+            fi_fabric
+            fi_domain
+            fi_endpoint
+            fi_av
+            fi_cm
+            fi_eq
+            fi_cq
+            fi_cntr
+            fi_poll
+            fi_mr
+            fi_msg
+            fi_tagged
+            fi_rma
+            fi_atomic
+            fi_trigger
+            fi_errno
+            fi_direct
+            fi_provider
+            fi_strerror
+            fi_control
+            fi_udp
+            fi_sockets
+            fi_info
+            fi_version
+            fi_pingpong
+        )
+
+PDFMANPAGES=( "${MANPAGES[@]/%/.pdf}" )
+WORKDIR=`mktemp -d /tmp/libfabric-manpages.XXXXXX || exit 1`
+OUTFILE="libfabric-manpages-`date \"+%Y-%m-%d\"`.pdf"
+EXITDIR="$PWD"
+
+if [ -e $OUTFILE ]; then
+    echo "Error: $OUTFILE already exists"
+    exit 1
+fi
+
+echo Entering work directory: $WORKDIR
+cd $WORKDIR || exit 1
+
+for manpage in "${MANPAGES[@]}"; do
+    echo "  - Converting $manpage"
+    man -t $manpage | ps2pdf - $WORKDIR/${manpage}.pdf || exit 1
+done
+
+echo "  + Merging manpages"
+
+if [ -x /System/Library/Automator/Combine\ PDF\ Pages.action/Contents/Resources/join.py ]; then
+    /System/Library/Automator/Combine\ PDF\ Pages.action/Contents/Resources/join.py -o $OUTFILE "${PDFMANPAGES[@]}" || exit 1
+elif hash pdfjoin 2>/dev/null; then
+    pdfjoin --quiet -o $OUTFILE "${PDFMANPAGES[@]}" || exit 1
+else
+    echo "Error: could not join PDFs (check installation of pdfjoin)"
+fi
+
+echo "  + Cleaning up"
+
+rm -f "${PDFMANPAGES[@]}"
+cd $EXITDIR
+if [ -e $WORKDIR/$OUTFILE ]; then
+    mv $WORKDIR/$OUTFILE .
+    echo "Done: $OUTFILE"
+else
+    echo "PDF generation failed"
+fi
+
+rmdir $WORKDIR
+

--- a/contrib/man2pdf/man2pdf.sh
+++ b/contrib/man2pdf/man2pdf.sh
@@ -39,37 +39,7 @@
 #
 
 # Generate list of manpages, but exclude manpages that are symlinks to other manpages
-#MANPAGES=( `echo fabric && man -a -w fi_* | xargs basename | sort | uniq | cut -d . -f 1` )
-
-# List of manpages, sorted in suggested reading order
-MANPAGES=(  fabric
-            fi_getinfo
-            fi_fabric
-            fi_domain
-            fi_endpoint
-            fi_av
-            fi_cm
-            fi_eq
-            fi_cq
-            fi_cntr
-            fi_poll
-            fi_mr
-            fi_msg
-            fi_tagged
-            fi_rma
-            fi_atomic
-            fi_trigger
-            fi_errno
-            fi_direct
-            fi_provider
-            fi_strerror
-            fi_control
-            fi_udp
-            fi_sockets
-            fi_info
-            fi_version
-            fi_pingpong
-        )
+MANPAGES=( `echo fabric && man -a -w fi_* | xargs basename | sort | uniq | cut -d . -f 1` )
 
 PDFMANPAGES=( "${MANPAGES[@]/%/.pdf}" )
 WORKDIR=`mktemp -d /tmp/libfabric-manpages.XXXXXX || exit 1`


### PR DESCRIPTION
This is a little script that converts the libfabric manpages into a single PDF file.  I've found this to be a pretty handy way to read and search through the manpages.