### PR TITLE
fabric: Update triggered op definitions in response to FI_CONTEXT2

### DIFF
--- a/include/rdma/fi_trigger.h
+++ b/include/rdma/fi_trigger.h
@@ -125,8 +125,17 @@ struct fi_triggered_context {
 	} trigger;
 };
 
+/* Size must match struct fi_context2 */
+struct fi_triggered_context2 {
+	enum fi_trigger_event			event_type;
+	union {
+		struct fi_trigger_threshold	threshold;
+		void				*internal[7];
+	} trigger;
+};
+
 struct fi_deferred_work {
-	struct fi_context			context;
+	struct fi_context2			context;
 
 	uint64_t				threshold;
 	struct fid_cntr				*triggering_cntr;

--- a/man/fi_trigger.3.md
+++ b/man/fi_trigger.3.md
@@ -33,27 +33,36 @@ only those interfaces supported by the provider which are trigger-able
 are available.
 
 Triggered operations require that applications use struct
-fi_triggered_context as their per operation context parameter.  The
-use of struct fi_triggered_context replaces struct fi_context, if
-required by the provider.  Although struct fi_triggered_context is not
+fi_triggered_context as their per operation context parameter, or if
+the provider requires the FI_CONTEXT2 mode, struct fi_trigger_context2.  The
+use of struct fi_triggered_context[2] replaces struct fi_context[2], if
+required by the provider.  Although struct fi_triggered_context[2] is not
 opaque to the application, the contents of the structure may be
-modified by the provider.  This structure has similar requirements as
-struct fi_context.  It must be allocated by the application and remain
-valid until the corresponding operation completes or is successfully
-canceled.
+modified by the provider once it has been submitted as an operation.
+This structure has similar requirements as struct fi_context[2].  It
+must be allocated by the application and remain valid until the
+corresponding operation completes or is successfully canceled.
 
-Struct fi_triggered_context is used to specify the condition that must
+Struct fi_triggered_context[2] is used to specify the condition that must
 be met before the triggered data transfer is initiated.  If the
 condition is met when the request is made, then the data transfer may
-be initiated immediately.  The format of struct fi_triggered_context
+be initiated immediately.  The format of struct fi_triggered_context[2]
 is described below.
 
 ```c
 struct fi_triggered_context {
-	enum fi_trigger_event   event_type;   /* trigger type */
+	enum fi_trigger_event               event_type;   /* trigger type */
 	union {
-		struct fi_trigger_threshold	threshold;
-		void                *internal[3]; /* reserved */
+		struct fi_trigger_threshold threshold;
+		void                        *internal[3]; /* reserved */
+	} trigger;
+};
+
+struct fi_triggered_context2 {
+	enum fi_trigger_event               event_type;   /* trigger type */
+	union {
+		struct fi_trigger_threshold threshold;
+		void                        *internal[7]; /* reserved */
 	} trigger;
 };
 ```
@@ -112,7 +121,7 @@ request is as follows:
 
 ```c
 struct fi_deferred_work {
-	struct fi_context     context;
+	struct fi_context2    context;
 
 	uint64_t              threshold;
 	struct fid_cntr       *triggering_cntr;


### PR DESCRIPTION
There should be an equivalent fi_triggered_context2, similar to
fi_context.  Also adjust fi_deferred_work to have fi_context2.
Otherwise, providers that do require FI_CONTEXT2 will need to
deal with smaller contexts for triggered operations.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>