### PR TITLE
prov/usnic: fixed bug when user give no mr_mode flag for 1.5+

### DIFF
--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -490,7 +490,7 @@ int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	if (ret < 0)
 		return -FI_ENODATA;
 
-	if (!hints || !hints->domain_attr) {
+	if (!hints || !hints->domain_attr || !hints->domain_attr->mr_mode) {
 		/* mr_mode behavior changed in version 1.5 from a single flag to mode bits.
 		* Hence, if a version less than v1.5 was requested, return the prior default:
 		* FI_MR_BASIC. */

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -175,7 +175,7 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	if (ret < 0)
 		return -FI_ENODATA;
 
-	if (!hints || !hints->domain_attr) {
+	if (!hints || !hints->domain_attr || !hints->domain_attr->mr_mode) {
 		/* mr_mode behavior changed in version 1.5 from a single flag to mode bits.
 		* Hence, if a version less than v1.5 was requested, return the prior default:
 		* FI_MR_BASIC. */

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -179,7 +179,7 @@ int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	if (ret < 0)
 		return -FI_ENODATA;
 
-	if (!hints || !hints->domain_attr) {
+	if (!hints || !hints->domain_attr || !hints->domain_attr->mr_mode) {
 		/* mr_mode behavior changed in version 1.5 from a single flag to mode bits.
 		* Hence, if a version less than v1.5 was requested, return the prior default:
 		* FI_MR_BASIC. */


### PR DESCRIPTION
This is a patch for 45465f4. We missed a condition and might resulted in
returning FI_ENODATA when user give no mr_mode flag.

Signed-off-by: Thananon Patinyasakdikul <apatinya@cisco.com>

@jsquyres @bturrubiates I found this bug when I'm writing the test code. please review.
