### PR TITLE
Update fi_info for new 1.5 mode bits

### DIFF
--- a/util/info.c
+++ b/util/info.c
@@ -148,10 +148,12 @@ static int str2cap(char *inputstr, uint64_t *value)
 static int str2mode(char *inputstr, uint64_t *value)
 {
 	ORCASE(FI_CONTEXT);
+	ORCASE(FI_CONTEXT2);
 	ORCASE(FI_LOCAL_MR);
 	ORCASE(FI_MSG_PREFIX);
 	ORCASE(FI_ASYNC_IOV);
 	ORCASE(FI_RX_CQ_DATA);
+	ORCASE(FI_RESTRICTED_COMP);
 
 	fprintf(stderr, "error: Unrecognized mode: %s\n", inputstr);
 


### PR DESCRIPTION
Adds FI_RESTRICTED_COMP and FI_CONTEXT2 to the fi_info tool.

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>