### PR TITLE
win/ci: testing via fabtests

### DIFF
--- a/.appveyor.ps1
+++ b/.appveyor.ps1
@@ -1,0 +1,16 @@
+[cmdletbinding()] Param()
+
+$ErrorActionPreference="Stop"
+
+
+Write-Verbose "downloading NetworkDirect DDK.."
+Invoke-WebRequest -Uri "https://download.microsoft.com/download/5/A/E/5AEA3C34-32A1-4A70-9622-F9734E92981F/NetworkDirect_DDK.zip" -OutFile "NetworkDirect_DDK.zip"
+Write-Verbose "done"
+
+Write-Verbose "extracting NetworkDirect DDK.."
+$wd=$PWD.Path; & { Add-Type -A "System.IO.Compression.FileSystem"; [IO.Compression.ZipFile]::ExtractToDirectory("$wd\NetworkDirect_DDK.zip", "$wd"); }
+Write-Verbose "done"
+
+Write-Verbose "moving NetworkDirect headers.."
+move NetDirect\include\* prov\netdir\NetDirect
+Write-Verbose "done"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,3 +9,16 @@ configuration:
 
 before_build:
   - ps: .appveyor.ps1 -Verbose
+
+after_build:
+  - set PATH=%CD%\x64\%CONFIGURATION%;%PATH%
+  - cd ..
+
+before_test:
+  - git clone https://github.com/ofiwg/fabtests
+  - cd fabtests
+  - msbuild fabtests.sln
+
+test_script:
+  - set PATH=%CD%\x64\%CONFIGURATION%;%PATH%
+  - scripts\runfabtests.cmd

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,20 +4,8 @@ build:
   project: libfabric.sln
 
 configuration:
-- Debug
-- Release
+  - Debug
+  - Release
 
 before_build:
-  - ps: Invoke-WebRequest -Uri "https://download.microsoft.com/download/5/A/E/5AEA3C34-32A1-4A70-9622-F9734E92981F/NetworkDirect_DDK.zip" -OutFile "NetworkDirect_DDK.zip"
-  - ps: '$wd=$PWD.Path; & { Add-Type -A "System.IO.Compression.FileSystem"; [IO.Compression.ZipFile]::ExtractToDirectory("$wd\NetworkDirect_DDK.zip", "$wd"); }'
-  - ps: mkdir -f prov\netdir\NetDirect
-  - ps: move "NetDirect\include\*" "prov\netdir\NetDirect"
-  - ps: >
-          $tool="v140";
-          $namespaces=@{ vs="http://schemas.microsoft.com/developer/msbuild/2003" };
-          Get-ChildItem "." -Filter "*.vcxproj" |
-          foreach {
-              $toolsets = Select-Xml -Path $_.FullName -XPath '/vs:Project/vs:PropertyGroup[@Label="Configuration"]/vs:PlatformToolset' -Namespace $namespaces;
-              foreach ($_ in $toolsets) {$_.Node.InnerText=$tool};
-              $toolsets[0].Node.OwnerDocument.Save($toolsets[0].Path);
-          }
+  - ps: .appveyor.ps1 -Verbose


### PR DESCRIPTION
### Enable testing for Windows via AppVeyor CI.
- This PR enables testing only for [this](https://github.com/ofiwg/libfabric) repository.
- Further similar PR will be prepared for [fabtests](https://github.com/ofiwg/fabtests) repo too.