### PR TITLE
Make Travis CI treat warnings as errors and fix compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,25 +25,36 @@ env:
     global:
         - PREFIX=$HOME/install
         - PATH=$PREFIX/bin:$PATH
-        - CPPFLAGS=-I$PREFIX/include
+        - CPPFLAGS="-Werror -I$PREFIX/include"
         - LDFLAGS=-L$PREFIX/lib
         - LD_LIBRARY_PATH=$PREFIX/lib
         - LIBFABRIC_CONFIGURE_ARGS="--prefix=$PREFIX --enable-sockets"
 
 # Brew update GNU Autotools so that autogen can succeed
 before_install:
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew upgrade automake || true; brew upgrade libtool || true; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update;
+        brew upgrade automake || true; brew upgrade libtool || true;
+      fi
 
 install:
     - ./autogen.sh
     # Build verbs only in linux as OS X doesn't have verbs support
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then LIBRARY_CONFIGURE_ARGS="$LIBFABRIC_CONFIGURE_ARGS --enable-usnic --enable-verbs"; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" && "`basename $CC`" == "clang" ]]; then ./configure CFLAGS="-Werror $CFLAGS" $LIBFABRIC_CONFIGURE_ARGS --enable-debug && make -j2; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        LIBRARY_CONFIGURE_ARGS="$LIBFABRIC_CONFIGURE_ARGS --enable-usnic
+        --enable-verbs";
+      fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" && "`basename $CC`" == "clang" ]]; then
+        ./configure CFLAGS="-Werror $CFLAGS" $LIBFABRIC_CONFIGURE_ARGS
+        --enable-debug && make -j2;
+      fi
     # Test fabric direct
-    - ./configure --prefix=$PREFIX --enable-direct=sockets --enable-udp=no --enable-psm=no --enable-gni=no --enable-psm2=no --enable-verbs=no --enable-usnic=no --enable-rxm=no --enable-rxd=no
+    - ./configure --prefix=$PREFIX --enable-direct=sockets --enable-udp=no
+      --enable-psm=no --enable-gni=no --enable-psm2=no --enable-verbs=no
+      --enable-usnic=no --enable-rxm=no --enable-rxd=no
     - make -j2
     # Test loadable library option
-    - ./configure --enable-sockets=dl --disable-udp --disable-rxm --disable-rxd --disable-verbs --disable-usnic --prefix=$PREFIX
+    - ./configure --enable-sockets=dl --disable-udp --disable-rxm --disable-rxd
+      --disable-verbs --disable-usnic --prefix=$PREFIX
     - make -j2
     - make install
     - make test

--- a/prov/verbs/src/verbs_atomic.c
+++ b/prov/verbs/src/verbs_atomic.c
@@ -96,6 +96,8 @@ int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype
 			if (op != FI_CSWAP)
 				return -FI_ENOSYS;
 			log_str = log_str_comp;
+		} else {
+			return  -FI_EBADFLAGS;
 		}
 		if (domain->info->tx_attr->op_flags & FI_INJECT) {
 			VERBS_INFO(FI_LOG_EP_DATA,

--- a/src/var.c
+++ b/src/var.c
@@ -128,7 +128,8 @@ DEFAULT_SYMVER(fi_getparams_, fi_getparams, FABRIC_1.0);
 __attribute__((visibility ("default")))
 void DEFAULT_SYMVER_PRE(fi_freeparams)(struct fi_param *params)
 {
-	for (int i = 0; params[i].name; ++i) {
+	int i;
+	for (i = 0; params[i].name; ++i) {
 		free((void*) params[i].name);
 		free((void*) params[i].help_string);
 		free((void*) params[i].value);

--- a/util/info.c
+++ b/util/info.c
@@ -221,7 +221,7 @@ static const char *param_type(enum fi_param_type type)
 
 static int print_vars(void)
 {
-	int ret, count;
+	int ret, count, i;
 	struct fi_param *params;
 	char delim;
 
@@ -229,7 +229,7 @@ static int print_vars(void)
 	if (ret)
 		return ret;
 
-	for (int i = 0; i < count; ++i) {
+	for (i = 0; i < count; ++i) {
 		printf("# %s: %s\n", params[i].name, param_type(params[i].type));
 		printf("# %s\n", params[i].help_string);
 
@@ -248,7 +248,8 @@ static int print_vars(void)
 
 static int print_providers(struct fi_info *info)
 {
-	for (struct fi_info *cur = info; cur; cur = cur->next) {
+	struct fi_info *cur;
+	for (cur = info; cur; cur = cur->next) {
 		printf("%s:\n", cur->fabric_attr->prov_name);
 		printf("    version: %d.%d\n",
 			FI_MAJOR(cur->fabric_attr->prov_version),
@@ -259,7 +260,8 @@ static int print_providers(struct fi_info *info)
 
 static int print_short_info(struct fi_info *info)
 {
-	for (struct fi_info *cur = info; cur; cur = cur->next) {
+	struct fi_info *cur;
+	for (cur = info; cur; cur = cur->next) {
 		printf("provider: %s\n", cur->fabric_attr->prov_name);
 		printf("    fabric: %s\n", cur->fabric_attr->name),
 		printf("    domain: %s\n", cur->domain_attr->name),
@@ -275,7 +277,8 @@ static int print_short_info(struct fi_info *info)
 
 static int print_long_info(struct fi_info *info)
 {
-	for (struct fi_info *cur = info; cur; cur = cur->next) {
+	struct fi_info *cur;
+	for (cur = info; cur; cur = cur->next) {
 		printf("---\n");
 		printf("%s", fi_tostr(cur, FI_TYPE_INFO));
 	}


### PR DESCRIPTION
- travis CI: Treat warnings as errors. Also break long lines.

- Fix following gcc warnings:

  - ‘for’ loop initial declarations are only allowed in C99 mode
  src/var.c:131:2: note: use option -std=c99 or -std=gnu99 to compile your code

  - prov/verbs: Fix uninitialized variable issue introduced by commit 6ae1b56