### PR TITLE
prov/udp: Add multicast support

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -186,24 +186,24 @@ uint64_t fi_gettime_us(void);
 #define AF_IB 27
 #endif
 
-static inline size_t ofi_sizeofaddr(struct sockaddr *address)
+static inline size_t ofi_sizeofaddr(const struct sockaddr *address)
 {
 	return (address->sa_family == AF_INET ?
 		sizeof(struct sockaddr_in) :
 		sizeof(struct sockaddr_in6));
 }
 
-static inline int ofi_equals_ipaddr(struct sockaddr_in *addr1,
-                             struct sockaddr_in *addr2)
+static inline int ofi_equals_ipaddr(const struct sockaddr_in *addr1,
+				    const struct sockaddr_in *addr2)
 {
         return (addr1->sin_addr.s_addr == addr2->sin_addr.s_addr);
 }
 
-static inline int ofi_equals_sockaddr(struct sockaddr_in *addr1,
-                             struct sockaddr_in *addr2)
+static inline int ofi_equals_sockaddr(const struct sockaddr_in *addr1,
+				      const struct sockaddr_in *addr2)
 {
         return (ofi_equals_ipaddr(addr1, addr2) &&
-                (addr1->sin_port == addr2->sin_port));
+        	(addr1->sin_port == addr2->sin_port));
 }
 
 static inline int ofi_translate_addr_format(int family)

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -532,7 +532,7 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 /*
  * Attributes and capabilities
  */
-#define FI_PRIMARY_CAPS	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMICS | \
+#define FI_PRIMARY_CAPS	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMICS | FI_MULTICAST | \
 			 FI_NAMED_RX_CTX | FI_DIRECTED_RECV | \
 			 FI_READ | FI_WRITE | FI_RECV | FI_SEND | \
 			 FI_REMOTE_READ | FI_REMOTE_WRITE)

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -171,6 +171,7 @@ struct util_domain {
 	struct fid_domain	domain_fid;
 	struct dlist_entry	list_entry;
 	struct util_fabric	*fabric;
+	struct util_eq		*eq;
 	fastlock_t		lock;
 	ofi_atomic32_t		ref;
 	const struct fi_provider *prov;
@@ -185,6 +186,7 @@ struct util_domain {
 
 int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
 		     struct util_domain *domain, void *context);
+int ofi_domain_bind_eq(struct util_domain *domain, struct util_eq *eq);
 int ofi_domain_close(struct util_domain *domain);
 
 
@@ -198,10 +200,13 @@ typedef void (*ofi_ep_progress_func)(struct util_ep *util_ep);
 struct util_ep {
 	struct fid_ep		ep_fid;
 	struct util_domain	*domain;
+
 	struct util_av		*av;
 	struct dlist_entry	av_entry;
 	struct util_cq		*rx_cq;
 	struct util_cq		*tx_cq;
+	struct util_eq		*eq;
+
 	uint64_t		caps;
 	uint64_t		flags;
 	ofi_ep_progress_func	progress;
@@ -210,6 +215,7 @@ struct util_ep {
 };
 
 int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av);
+int ofi_ep_bind_eq(struct util_ep *ep, struct util_eq *eq);
 int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_prov,
 		      struct fi_info *info, struct util_ep *ep, void *context,
 		      ofi_ep_progress_func progress);

--- a/man/fi_cm.3.md
+++ b/man/fi_cm.3.md
@@ -15,6 +15,9 @@ fi_connect / fi_listen / fi_accept / fi_reject / fi_shutdown
 fi_setname / fi_getname / fi_getpeer
 : Set local, or return local or peer endpoint address.
 
+fi_join / fi_close / fi_mc_addr
+: Join, leave, or retrieve a multicast address.
+
 # SYNOPSIS
 
 ```c

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -546,7 +546,8 @@ operation.  The following completion flags are defined.
 
 *FI_MULTICAST*
 : Indicates that a multicast operation completed.  This flag may be combined
-  with FI_MSG and relevant flags.
+  with FI_MSG and relevant flags.  This flag is only guaranteed to be valid
+  for received messages if the endpoint has been configured with FI_SOURCE.
 
 *FI_READ*
 : Indicates that a locally initiated RMA or atomic read operation has

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -403,9 +403,9 @@ the capability or fail the fi_getinfo request (FI_ENODATA).  A provider
 may optionally report non-selected secondary capabilities if doing so
 would not compromise performance or security.
 
-Primary capabilities: FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_NAMED_RX_CTX,
-FI_DIRECTED_RECV, FI_READ, FI_WRITE, FI_RECV, FI_SEND, FI_REMOTE_READ,
-and FI_REMOTE_WRITE.
+Primary capabilities: FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_MULTICAST,
+FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_READ, FI_WRITE, FI_RECV, FI_SEND,
+FI_REMOTE_READ, and FI_REMOTE_WRITE.
 
 Secondary capabilities: FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_SHARED_AV,
 FI_TRIGGER, FI_FENCE, FI_LOCAL_COMM, FI_REMOTE_COMM, FI_SOURCE_ERR.

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -65,7 +65,7 @@
 
 
 #define UDPX_MAJOR_VERSION 1
-#define UDPX_MINOR_VERSION 0
+#define UDPX_MINOR_VERSION 1
 
 
 extern struct fi_provider udpx_prov;

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -40,6 +40,7 @@
 #include <pthread.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <netinet/ip.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_atomic.h>
@@ -105,6 +106,7 @@ struct udpx_ep {
 	struct udpx_rx_cirq	*rxq;    /* protected by rx_cq lock */
 	int			sock;
 	int			is_bound;
+	ofi_atomic32_t		ref;
 };
 
 int udpx_endpoint(struct fid_domain *domain, struct fi_info *info,
@@ -113,6 +115,15 @@ int udpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 int udpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq, void *context);
+
+
+struct udpx_mc {
+	struct fid_mc		mc_fid;
+	union {
+		struct sockaddr_in	sin;
+	} addr;
+	struct udpx_ep		*ep;
+};
 
 
 #endif

--- a/prov/udp/src/udpx_attr.c
+++ b/prov/udp/src/udpx_attr.c
@@ -80,7 +80,7 @@ struct fi_fabric_attr udpx_fabric_attr = {
 };
 
 struct fi_info udpx_info = {
-	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE, /* | FI_MULTI_RECV, */
+	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE | FI_MULTICAST,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &udpx_tx_attr,
 	.rx_attr = &udpx_rx_attr,

--- a/prov/udp/src/udpx_attr.c
+++ b/prov/udp/src/udpx_attr.c
@@ -34,7 +34,7 @@
 
 
 struct fi_tx_attr udpx_tx_attr = {
-	.caps = FI_MSG | FI_SEND,
+	.caps = FI_MSG | FI_SEND | FI_MULTICAST,
 	.comp_order = FI_ORDER_STRICT,
 	.inject_size = 1472,
 	.size = 1024,
@@ -42,7 +42,7 @@ struct fi_tx_attr udpx_tx_attr = {
 };
 
 struct fi_rx_attr udpx_rx_attr = {
-	.caps = FI_MSG | FI_RECV | FI_SOURCE,
+	.caps = FI_MSG | FI_RECV | FI_SOURCE | FI_MULTICAST,
 	.comp_order = FI_ORDER_STRICT,
 	.total_buffered_recv = (1 << 16),
 	.size = 1024,

--- a/prov/util/src/util_domain.c
+++ b/prov/util/src/util_domain.c
@@ -37,6 +37,19 @@
 #include <fi_util.h>
 
 
+int ofi_domain_bind_eq(struct util_domain *domain, struct util_eq *eq)
+{
+	if (domain->eq) {
+		FI_WARN(domain->prov, FI_LOG_DOMAIN,
+			"duplicate EQ binding\n");
+		return -FI_EINVAL;
+	}
+
+	domain->eq = eq;
+	ofi_atomic_inc32(&eq->ref);
+	return 0;
+}
+
 int ofi_domain_close(struct util_domain *domain)
 {
 	if (ofi_atomic_get32(&domain->ref))

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -83,6 +83,7 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 
 	ep->ep_fid.fid.fclass = FI_CLASS_EP;
 	ep->ep_fid.fid.context = context;
+	ep->caps = info->caps;
 	ep->domain = util_domain;
 	ep->progress = progress;
 	ep->caps = info->caps;

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -85,6 +85,7 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	ep->ep_fid.fid.context = context;
 	ep->domain = util_domain;
 	ep->progress = progress;
+	ep->caps = info->caps;
 	ofi_atomic_inc32(&util_domain->ref);
 	if (util_domain->eq)
 		ofi_ep_bind_eq(ep, util_domain->eq);

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -36,6 +36,17 @@
 #include <fi_enosys.h>
 #include <fi_util.h>
 
+
+int ofi_ep_bind_eq(struct util_ep *ep, struct util_eq *eq)
+{
+	if (ep->eq)
+		ofi_atomic_dec32(&ep->eq->ref);
+
+	ep->eq = eq;
+	ofi_atomic_inc32(&eq->ref);
+	return 0;
+}
+
 int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av)
 {
 	if (util_ep->av) {
@@ -75,6 +86,8 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	ep->domain = util_domain;
 	ep->progress = progress;
 	ofi_atomic_inc32(&util_domain->ref);
+	if (util_domain->eq)
+		ofi_ep_bind_eq(ep, util_domain->eq);
 	fastlock_init(&ep->lock);
 	return 0;
 }
@@ -90,6 +103,8 @@ int ofi_endpoint_close(struct util_ep *util_ep)
 		ofi_atomic_dec32(&util_ep->av->ref);
 	}
 
+	if (util_ep->eq)
+		ofi_atomic_dec32(&util_ep->eq->ref);
 	ofi_atomic_dec32(&util_ep->domain->ref);
 	return 0;
 }

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -102,6 +102,7 @@ static void fi_tostr_flags(char *buf, uint64_t flags)
 	IFFLAGSTR(flags, FI_RMA);
 	IFFLAGSTR(flags, FI_TAGGED);
 	IFFLAGSTR(flags, FI_ATOMIC);
+	IFFLAGSTR(flags, FI_MULTICAST);
 
 	IFFLAGSTR(flags, FI_READ);
 	IFFLAGSTR(flags, FI_WRITE);
@@ -122,6 +123,7 @@ static void fi_tostr_flags(char *buf, uint64_t flags)
 	IFFLAGSTR(flags, FI_INJECT_COMPLETE);
 	IFFLAGSTR(flags, FI_TRANSMIT_COMPLETE);
 	IFFLAGSTR(flags, FI_DELIVERY_COMPLETE);
+	IFFLAGSTR(flags, FI_AFFINITY);
 
 	fi_remove_comma(buf);
 }
@@ -136,6 +138,9 @@ static void fi_tostr_addr_format(char *buf, uint32_t addr_format)
 	CASEENUMSTR(FI_SOCKADDR_IB);
 	CASEENUMSTR(FI_ADDR_PSMX);
 	CASEENUMSTR(FI_ADDR_GNI);
+	CASEENUMSTR(FI_ADDR_BGQ);
+	CASEENUMSTR(FI_ADDR_MLX);
+	CASEENUMSTR(FI_ADDR_STR);
 	default:
 		if (addr_format & FI_PROV_SPECIFIC)
 			strcatf(buf, "Provider specific");
@@ -192,6 +197,10 @@ static void fi_tostr_order(char *buf, uint64_t flags)
 
 static void fi_tostr_caps(char *buf, uint64_t caps)
 {
+	IFFLAGSTR(caps, FI_SOURCE_ERR);
+	IFFLAGSTR(caps, FI_LOCAL_COMM);
+	IFFLAGSTR(caps, FI_REMOTE_COMM);
+	IFFLAGSTR(caps, FI_SHARED_AV);
 	IFFLAGSTR(caps, FI_NUMERICHOST);
 	IFFLAGSTR(caps, FI_RMA_EVENT);
 	IFFLAGSTR(caps, FI_SOURCE);


### PR DESCRIPTION
Initial implementation to validate multicast interfaces.  This supports joining and sending multicast messages.  It gives all appearances of working correctly, except that sent messages are not routed back to the listener (at least when run on the same system).  I'm not sure if this is a problem in the code or my system setup.  tcpdump does show that the sender will send packets to the specified multicast address.

This series expands the util code to support binding and EP to an EQ, plus adds some missing output to fi_tostr.