### PR TITLE
prov/psm,psm2: Adjust default mr_mode based on API version

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -190,6 +190,9 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 
 	*info = NULL;
 
+	if (FI_VERSION_GE(version, FI_VERSION(1,5)))
+		mr_mode = 0;
+
 	if (psmx_init_lib())
 		return -FI_ENODATA;
 

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -71,18 +71,18 @@ static int psmx_mr_reserve_key(struct psmx_fid_domain *domain,
 
 	fastlock_acquire(&domain->mr_lock);
 
-	if (domain->mr_mode == FI_MR_SCALABLE) {
-		key = requested_key;
-		try_count = 1;
-	} else {
+	if (domain->mr_mode == FI_MR_BASIC) {
 		key = domain->mr_reserved_key;
 		try_count = 10000; /* large enough */
+	} else {
+		key = requested_key;
+		try_count = 1;
 	}
 
 	for (i=0; i<try_count; i++, key++) {
 		if (!rbtFind(domain->mr_map, (void *)key)) {
 			if (!rbtInsert(domain->mr_map, (void *)key, mr)) {
-				if (domain->mr_mode != FI_MR_SCALABLE)
+				if (domain->mr_mode == FI_MR_BASIC)
 					domain->mr_reserved_key = key + 1;
 				*assigned_key = key;
 				err = 0;
@@ -272,9 +272,8 @@ static int psmx_mr_reg(struct fid *fid, const void *buf, size_t len,
 	mr_priv->iov_count = 1;
 	mr_priv->iov[0].iov_base = (void *)buf;
 	mr_priv->iov[0].iov_len = len;
-	mr_priv->offset = (domain_priv->mr_mode == FI_MR_SCALABLE) ?
-				((uint64_t)mr_priv->iov[0].iov_base - offset) :
-				0;
+	mr_priv->offset = (domain_priv->mr_mode == FI_MR_BASIC) ? 0 :
+				((uint64_t)mr_priv->iov[0].iov_base - offset);
 
 	*mr = &mr_priv->mr;
 	return 0;
@@ -327,9 +326,8 @@ static int psmx_mr_regv(struct fid *fid,
 	for (i=0; i<count; i++)
 		mr_priv->iov[i] = iov[i];
 	psmx_mr_normalize_iov(mr_priv->iov, &mr_priv->iov_count);
-	mr_priv->offset = (domain_priv->mr_mode == FI_MR_SCALABLE) ?
-				((uint64_t)mr_priv->iov[0].iov_base - offset) :
-				0;
+	mr_priv->offset = (domain_priv->mr_mode == FI_MR_BASIC) ? 0 :
+				((uint64_t)mr_priv->iov[0].iov_base - offset);
 
 	*mr = &mr_priv->mr;
 	return 0;
@@ -383,9 +381,8 @@ static int psmx_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	for (i=0; i<attr->iov_count; i++)
 		mr_priv->iov[i] = attr->mr_iov[i];
 	psmx_mr_normalize_iov(mr_priv->iov, &mr_priv->iov_count);
-	mr_priv->offset = (domain_priv->mr_mode == FI_MR_SCALABLE) ?
-				((uint64_t)mr_priv->iov[0].iov_base - attr->offset) :
-				0;
+	mr_priv->offset = (domain_priv->mr_mode == FI_MR_SCALABLE) ? 0 :
+				((uint64_t)mr_priv->iov[0].iov_base - attr->offset);
 
 	*mr = &mr_priv->mr;
 	return 0;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -189,6 +189,9 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 
 	*info = NULL;
 
+	if (FI_VERSION_GE(version, FI_VERSION(1,5)))
+		mr_mode = 0;
+
 	/*
 	 * Try to turn on PSM2 multi-EP support if the application asks for
 	 * more than one tx context per endpoint. This only works for the

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -73,18 +73,18 @@ static int psmx2_mr_reserve_key(struct psmx2_fid_domain *domain,
 
 	fastlock_acquire(&domain->mr_lock);
 
-	if (domain->mr_mode == FI_MR_SCALABLE) {
-		key = requested_key;
-		try_count = 1;
-	} else {
+	if (domain->mr_mode == FI_MR_BASIC) {
 		key = domain->mr_reserved_key;
 		try_count = 10000; /* large enough */
+	} else {
+		key = requested_key;
+		try_count = 1;
 	}
 
 	for (i=0; i<try_count; i++, key++) {
 		if (!rbtFind(domain->mr_map, (void *)key)) {
 			if (!rbtInsert(domain->mr_map, (void *)key, mr)) {
-				if (domain->mr_mode != FI_MR_SCALABLE)
+				if (domain->mr_mode == FI_MR_BASIC)
 					domain->mr_reserved_key = key + 1;
 				*assigned_key = key;
 				err = 0;
@@ -276,9 +276,8 @@ static int psmx2_mr_reg(struct fid *fid, const void *buf, size_t len,
 	mr_priv->iov_count = 1;
 	mr_priv->iov[0].iov_base = (void *)buf;
 	mr_priv->iov[0].iov_len = len;
-	mr_priv->offset = (domain_priv->mr_mode == FI_MR_SCALABLE) ?
-				((uint64_t)mr_priv->iov[0].iov_base - offset) :
-				0;
+	mr_priv->offset = (domain_priv->mr_mode == FI_MR_BASIC) ? 0 :
+				((uint64_t)mr_priv->iov[0].iov_base - offset);
 
 	*mr = &mr_priv->mr;
 	return 0;
@@ -332,9 +331,8 @@ static int psmx2_mr_regv(struct fid *fid,
 	for (i=0; i<count; i++)
 		mr_priv->iov[i] = iov[i];
 	psmx2_mr_normalize_iov(mr_priv->iov, &mr_priv->iov_count);
-	mr_priv->offset = (domain_priv->mr_mode == FI_MR_SCALABLE) ?
-				((uint64_t)mr_priv->iov[0].iov_base - offset) :
-				0;
+	mr_priv->offset = (domain_priv->mr_mode == FI_MR_BASIC) ? 0 :
+				((uint64_t)mr_priv->iov[0].iov_base - offset);
 
 	*mr = &mr_priv->mr;
 	return 0;
@@ -388,9 +386,8 @@ static int psmx2_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	for (i=0; i<attr->iov_count; i++)
 		mr_priv->iov[i] = attr->mr_iov[i];
 	psmx2_mr_normalize_iov(mr_priv->iov, &mr_priv->iov_count);
-	mr_priv->offset = (domain_priv->mr_mode == FI_MR_SCALABLE) ?
-				((uint64_t)mr_priv->iov[0].iov_base - attr->offset) :
-				0;
+	mr_priv->offset = (domain_priv->mr_mode == FI_MR_BASIC) ? 0 :
+				((uint64_t)mr_priv->iov[0].iov_base - attr->offset);
 
 	*mr = &mr_priv->mr;
 	return 0;


### PR DESCRIPTION
By default MR works in scalable mode. In earlier versions This is
indicated by setting mr_mode to FI_MR_SCALABLE. But for version
1.5 mr_mode should be set to 0 for the same purpose.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>