### PR TITLE
util: Move MR mode check to a common function

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -514,6 +514,24 @@ struct ofi_mr_map {
 	enum fi_mr_mode		mode;
 };
 
+/* If the app sets FI_MR_LOCAL, we ignore FI_LOCAL_MR.  So, if the
+ * app doesn't set FI_MR_LOCAL, we need to check for FI_LOCAL_MR.
+ * The provider is assumed only to set FI_MR_LOCAL correctly.
+ */
+static inline uint64_t ofi_mr_get_prov_mode(uint32_t version,
+					    const struct fi_info *user_info,
+					    const struct fi_info *prov_info)
+{
+	if (FI_VERSION_LT(version, FI_VERSION(1, 5)) ||
+	    (user_info->domain_attr &&
+	     !(user_info->domain_attr->mr_mode & FI_MR_LOCAL))) {
+		return (prov_info->domain_attr->mr_mode & FI_MR_LOCAL) ?
+			prov_info->mode | FI_LOCAL_MR : prov_info->mode;
+	} else {
+		return prov_info->mode;
+	}
+}
+
 int ofi_mr_map_init(const struct fi_provider *in_prov, int mode,
 		    struct ofi_mr_map *map);
 void ofi_mr_map_close(struct ofi_mr_map *map);

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -738,18 +738,7 @@ int ofi_check_info(const struct util_prov *util_prov, uint32_t api_version,
 		return -FI_ENODATA;
 	}
 
-	/* If the app sets FI_MR_LOCAL, we ignore FI_LOCAL_MR.  So, if the
-	 * app doesn't set FI_MR_LOCAL, we need to check for FI_LOCAL_MR.
-	 * The provider is assumed only to set FI_MR_LOCAL correctly.
-	 */
-	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5)) ||
-	    (user_info->domain_attr &&
-	     !(user_info->domain_attr->mr_mode & FI_MR_LOCAL))) {
-		prov_mode = (prov_info->domain_attr->mr_mode & FI_MR_LOCAL) ?
-			prov_info->mode | FI_LOCAL_MR : prov_info->mode;
-	} else {
-		prov_mode = prov_info->mode;
-	}
+	prov_mode = ofi_mr_get_prov_mode(api_version, user_info, prov_info);
 
 	if ((user_info->mode & prov_mode) != prov_mode) {
 		FI_INFO(prov, FI_LOG_CORE, "needed mode not set\n");

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -349,16 +349,7 @@ static int fi_ibv_check_hints(uint32_t version, const struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	/* If the app sets FI_MR_LOCAL, we ignore FI_LOCAL_MR.  So, if the
-	 * app doesn't set FI_MR_LOCAL, we need to check for FI_LOCAL_MR.
-	 * The provider is assumed only to set FI_MR_LOCAL correctly.
-	 */
-	prov_mode = info->mode;
-	if ((FI_VERSION_LT(version, FI_VERSION(1, 5)) ||
-	     !(hints->domain_attr->mr_mode & FI_MR_LOCAL)) &&
-	    (info->domain_attr->mr_mode & FI_MR_LOCAL)) {
-		prov_mode |= FI_LOCAL_MR;
-	}
+	prov_mode = ofi_mr_get_prov_mode(version, hints, info);
 
 	if ((hints->mode & prov_mode) != prov_mode) {
 		VERBS_INFO(FI_LOG_CORE, "needed mode not set\n");


### PR DESCRIPTION
This also fixes a null pointer dereference issue in verbs provider.