### PR TITLE
prov/psm,psm2: Make src_addr format consistent with other addresses

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -48,6 +48,7 @@ extern "C" {
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <pthread.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -300,9 +301,10 @@ struct psmx_fid_domain {
 #define PSMX_ANY_SERVICE	0
 
 struct psmx_src_name {
-	int	unit;		/* start from 0. -1 means any */
-	int	port;		/* start from 1. 0 means any */
-	int	service;	/* 0 means any */
+	uint16_t	signature;	/* 0xFFFF, different from any valid epid */
+	int8_t		unit;		/* start from 0. -1 means any */
+	uint8_t		port;		/* start from 1. 0 means any */
+	uint32_t	service;	/* 0 means any */
 };
 
 struct psmx_cq_event {

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -210,15 +210,16 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 			"failed to allocate src addr.\n");
 		return -FI_ENODATA;
 	}
+	src_addr->signature = 0xFFFF;
 	src_addr->unit = PSMX_DEFAULT_UNIT;
 	src_addr->port = PSMX_DEFAULT_PORT;
 	src_addr->service = PSMX_ANY_SERVICE;
 
 	if (flags & FI_SOURCE) {
 		if (node)
-			sscanf(node, "%*[^:]:%d:%d", &src_addr->unit, &src_addr->port);
+			sscanf(node, "%*[^:]:%" SCNi8 ":%" SCNu8, &src_addr->unit, &src_addr->port);
 		if (service)
-			sscanf(service, "%d", &src_addr->service);
+			sscanf(service, "%" SCNu32, &src_addr->service);
 		FI_INFO(&psmx_prov, FI_LOG_CORE,
 			"node '%s' service '%s' converted to <unit=%d, port=%d, service=%d>\n",
 			node, service, src_addr->unit, src_addr->port, src_addr->service);

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -48,6 +48,7 @@ extern "C" {
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <pthread.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -430,9 +431,11 @@ struct psmx2_ep_name {
 #define PSMX2_ANY_SERVICE	0
 
 struct psmx2_src_name {
-	int	unit;		/* start from 0. -1 means any */
-	int	port;		/* start from 1. 0 means any */
-	int	service;	/* 0 means any */
+	uint16_t		signature;	/* 0xFFFF, different from any valid epid */
+	int8_t			unit;		/* start from 0. -1 means any */
+	uint8_t			port;		/* start from 1. 0 means any */
+	uint32_t		service;	/* 0 means any */
+	uint64_t		padding;	/* make it the same size as psmx2_ep_name */
 };
 
 struct psmx2_cq_event {

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -239,15 +239,16 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 			"failed to allocate src addr.\n");
 		return -FI_ENODATA;
 	}
+	src_addr->signature = 0xFFFF;
 	src_addr->unit = PSMX2_DEFAULT_UNIT;
 	src_addr->port = PSMX2_DEFAULT_PORT;
 	src_addr->service = PSMX2_ANY_SERVICE;
 
 	if (flags & FI_SOURCE) {
 		if (node)
-			sscanf(node, "%*[^:]:%d:%d", &src_addr->unit, &src_addr->port);
+			sscanf(node, "%*[^:]:%" SCNi8 ":%" SCNu8, &src_addr->unit, &src_addr->port);
 		if (service)
-			sscanf(service, "%u", &src_addr->service);
+			sscanf(service, "%" SCNu32, &src_addr->service);
 		FI_INFO(&psmx2_prov, FI_LOG_CORE,
 			"node '%s' service '%s' converted to <unit=%d, port=%d, service=%d>\n",
 			node, service, src_addr->unit, src_addr->port, src_addr->service);


### PR DESCRIPTION
The information stored in the "src_addr" field of fi_info is different
from a regular endpoint address. While this address still cannot be
used as input to fi_av_insert, it is helpful to make all the addresses
the same size and be distighuishable from each other. It also makes
it easier to stringfy the "src_addr" for debugging purpose.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>