### PR TITLE
util: add check to verify that the job key sizes are at least the same

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -111,6 +111,12 @@
 	FI_INFO_FIELD(provider, prov->field, user->field, "Supported",	\
 		      "Requested", type)
 
+#define FI_INFO_CHECK_VAL(provider, prov, user, field)					\
+	do {										\
+		FI_INFO(provider, FI_LOG_CORE, "Supported: %zd\n", prov->field);	\
+		FI_INFO(provider, FI_LOG_CORE, "Requested: %zd\n", user->field);	\
+	} while (0)
+
 #define FI_INFO_MODE(provider, prov_mode, user_mode)				\
 	FI_INFO_FIELD(provider, prov_mode, user_mode, "Expected", "Given",	\
 		      FI_TYPE_MODE)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -546,6 +546,7 @@ enum fi_type {
 	FI_TYPE_CQ_EVENT_FLAGS,
 	FI_TYPE_MR_MODE,
 	FI_TYPE_OP_TYPE,
+	FI_TYPE_SIZE_T,
 };
 
 char *fi_tostr(const void *data, enum fi_type datatype);

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -546,7 +546,6 @@ enum fi_type {
 	FI_TYPE_CQ_EVENT_FLAGS,
 	FI_TYPE_MR_MODE,
 	FI_TYPE_OP_TYPE,
-	FI_TYPE_SIZE_T,
 };
 
 char *fi_tostr(const void *data, enum fi_type datatype);

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -190,6 +190,10 @@ int sock_msg_verify_ep_attr(struct fi_ep_attr *ep_attr,
 		if ((ep_attr->rx_ctx_cnt > SOCK_EP_MAX_RX_CNT) &&
 		    ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
 			return -FI_ENODATA;
+
+		if (ep_attr->auth_key_size &&
+		    (ep_attr->auth_key_size != sock_msg_ep_attr.auth_key_size))
+			return -FI_ENODATA;
 	}
 
 	if (sock_msg_verify_tx_attr(tx_attr) || sock_msg_verify_rx_attr(rx_attr))

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -502,6 +502,7 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->cq_data_size > prov_attr->cq_data_size) {
 		FI_INFO(prov, FI_LOG_CORE, "CQ data size too large\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, cq_data_size);
 		return -FI_ENODATA;
 	}
 
@@ -523,6 +524,7 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 
 	if (user_attr->mr_iov_limit > prov_attr->mr_iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "MR iov limit too large\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, mr_iov_limit);
 		return -FI_ENODATA;
 	}
 
@@ -567,6 +569,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 
 	if (user_attr->max_msg_size > prov_attr->max_msg_size) {
 		FI_INFO(prov, FI_LOG_CORE, "Max message size too large\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_msg_size);
 		return -FI_ENODATA;
 	}
 
@@ -580,7 +583,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		} else {
 			FI_INFO(prov, FI_LOG_CORE,
 				"Requested tx_ctx_cnt exceeds supported."
-				" Expected:%d, Requested%d\n",
+				" Expected:%zd, Requested%zd\n",
 				util_prov->info->domain_attr->max_ep_tx_ctx,
 				user_attr->tx_ctx_cnt);
 			return -FI_ENODATA;
@@ -596,16 +599,18 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 			}
 		} else {
 			FI_INFO(prov, FI_LOG_CORE,
-				"Requested rx_ctx_cnt exceeds supported\n");
+				"Requested rx_ctx_cnt exceeds supported."
+				" Expected: %zd, Requested:%zd\n",
+				util_prov->info->domain_attr->max_ep_rx_ctx,
+				user_attr->rx_ctx_cnt);
 			return -FI_ENODATA;
 		}
 	}
 
 	if (user_attr->auth_key_size &&
 	    (user_attr->auth_key_size != prov_attr->auth_key_size)) {
-		FI_INFO(prov, FI_LOG_CORE, "Unsupported authentification size. "
-			"Expected:%d, Requested%d\n",
-			prov_attr->auth_key_size, user_attr->auth_key_size);
+		FI_INFO(prov, FI_LOG_CORE, "Unsupported authentification size.");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, auth_key_size);
 		return -FI_ENODATA;
 	}
 
@@ -652,16 +657,20 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 
 	if (user_attr->total_buffered_recv > prov_attr->total_buffered_recv) {
 		FI_INFO(prov, FI_LOG_CORE, "total_buffered_recv too large\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+				  total_buffered_recv);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->size > prov_attr->size) {
 		FI_INFO(prov, FI_LOG_CORE, "size is greater than supported\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, size);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->iov_limit > prov_attr->iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "iov_limit too large\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, iov_limit);
 		return -FI_ENODATA;
 	}
 
@@ -708,21 +717,25 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 
 	if (user_attr->inject_size > prov_attr->inject_size) {
 		FI_INFO(prov, FI_LOG_CORE, "inject_size too large\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, inject_size);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->size > prov_attr->size) {
 		FI_INFO(prov, FI_LOG_CORE, "size is greater than supported\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, size);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->iov_limit > prov_attr->iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "iov_limit too large\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, iov_limit);
 		return -FI_ENODATA;
 	}
 
 	if (user_attr->rma_iov_limit > prov_attr->rma_iov_limit) {
 		FI_INFO(prov, FI_LOG_CORE, "rma_iov_limit too large\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, rma_iov_limit);
 		return -FI_ENODATA;
 	}
 

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -580,7 +580,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		} else {
 			FI_INFO(prov, FI_LOG_CORE,
 				"Requested tx_ctx_cnt exceeds supported."
-				" Expected:%d, supported%d\n",
+				" Expected:%d, Requested%d\n",
 				util_prov->info->domain_attr->max_ep_tx_ctx,
 				user_attr->tx_ctx_cnt);
 			return -FI_ENODATA;
@@ -599,6 +599,14 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 				"Requested rx_ctx_cnt exceeds supported\n");
 			return -FI_ENODATA;
 		}
+	}
+
+	if (user_attr->auth_key_size &&
+	    (user_attr->auth_key_size != prov_attr->auth_key_size)) {
+		FI_INFO(prov, FI_LOG_CORE, "Unsupported authentification size. "
+			"Expected:%d, Requested%d\n",
+			prov_attr->auth_key_size, user_attr->auth_key_size);
+		return -FI_ENODATA;
 	}
 
 	return 0;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -189,45 +189,57 @@ int fi_ibv_check_ep_attr(const struct fi_ep_attr *attr,
 	if (attr->max_msg_size > info->ep_attr->max_msg_size) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "Max message size too large\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
+				  max_msg_size);
 		return -FI_ENODATA;
 	}
 
 	if (attr->max_order_raw_size > info->ep_attr->max_order_raw_size) {
 		VERBS_INFO( FI_LOG_CORE,
 			   "max_order_raw_size exceeds supported size\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
+				  max_order_raw_size);
 		return -FI_ENODATA;
 	}
 
 	if (attr->max_order_war_size) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "max_order_war_size exceeds supported size\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
+				  max_order_war_size);
 		return -FI_ENODATA;
 	}
 
 	if (attr->max_order_waw_size > info->ep_attr->max_order_waw_size) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "max_order_waw_size exceeds supported size\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
+				  max_order_waw_size);
 		return -FI_ENODATA;
 	}
 
 	if (attr->tx_ctx_cnt > info->domain_attr->max_ep_tx_ctx) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "tx_ctx_cnt exceeds supported size\n");
+		VERBS_INFO(FI_LOG_CORE, "Supported: %zd\nRequested: %zd\n",
+			   info->domain_attr->max_ep_tx_ctx, attr->tx_ctx_cnt);
 		return -FI_ENODATA;
 	}
 
 	if ((attr->rx_ctx_cnt > info->domain_attr->max_ep_rx_ctx) &&
-			(attr->rx_ctx_cnt != FI_SHARED_CONTEXT)) {
+	    (attr->rx_ctx_cnt != FI_SHARED_CONTEXT)) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "rx_ctx_cnt exceeds supported size\n");
+		VERBS_INFO(FI_LOG_CORE, "Supported: %zd\nRequested: %zd\n",
+			   info->domain_attr->max_ep_rx_ctx, attr->rx_ctx_cnt);
 		return -FI_ENODATA;
 	}
 
 	if (attr->auth_key_size &&
 	    (attr->auth_key_size != info->ep_attr->auth_key_size)) {
-		VERBS_INFO(FI_LOG_CORE, "Unsupported authentification size. "
-			   "Expected:%d, Requested%d\n",
-			   info->ep_attr->auth_key_size, attr->auth_key_size);
+		VERBS_INFO(FI_LOG_CORE, "Unsupported authentification size.");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
+				  auth_key_size);
 		return -FI_ENODATA;
 	}
 
@@ -254,6 +266,7 @@ int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
 	if ((compare_mode & check_mode) != check_mode) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "Given rx_attr->mode not supported\n");
+		FI_INFO_MODE(&fi_ibv_prov, check_mode, compare_mode);
 		return -FI_ENODATA;
 	}
 
@@ -272,6 +285,7 @@ int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
 	if (attr->size > info->rx_attr->size) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "Given rx_attr->size is greater than supported\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->rx_attr, attr, size);
 		return -FI_ENODATA;
 	}
 
@@ -284,12 +298,16 @@ int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
 		VERBS_INFO(FI_LOG_CORE,
 			   "Given rx_attr->total_buffered_recv "
 			   "exceeds supported size\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->rx_attr, attr,
+				  total_buffered_recv);
 		return -FI_ENODATA;
 	}
 
 	if (attr->iov_limit > info->rx_attr->iov_limit) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "Given rx_attr->iov_limit greater than supported\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->rx_attr, attr,
+				  iov_limit);
 		return -FI_ENODATA;
 	}
 
@@ -302,13 +320,16 @@ int fi_ibv_check_tx_attr(const struct fi_tx_attr *attr,
 	if (attr->caps & ~(info->tx_attr->caps)) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "Given tx_attr->caps not supported\n");
+		FI_INFO_CHECK(&fi_ibv_prov, (info->tx_attr), attr, caps, FI_TYPE_CAPS);
 		return -FI_ENODATA;
 	}
 
 	if (((attr->mode ? attr->mode : hints->mode) &
-				info->tx_attr->mode) != info->tx_attr->mode) {
+	     info->tx_attr->mode) != info->tx_attr->mode) {
+		size_t user_mode = (attr->mode ? attr->mode : hints->mode);
 		VERBS_INFO(FI_LOG_CORE,
 			   "Given tx_attr->mode not supported\n");
+		FI_INFO_MODE(&fi_ibv_prov, info->tx_attr->mode, user_mode);
 		return -FI_ENODATA;
 	}
 
@@ -327,18 +348,23 @@ int fi_ibv_check_tx_attr(const struct fi_tx_attr *attr,
 	if (attr->size > info->tx_attr->size) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "Given tx_attr->size is greater than supported\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, (info->tx_attr), attr, size);
 		return -FI_ENODATA;
 	}
 
 	if (attr->iov_limit > info->tx_attr->iov_limit) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "Given tx_attr->iov_limit greater than supported\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, (info->tx_attr), attr,
+				  iov_limit);
 		return -FI_ENODATA;
 	}
 
 	if (attr->rma_iov_limit > info->tx_attr->rma_iov_limit) {
 		VERBS_INFO(FI_LOG_CORE,
 			   "Given tx_attr->rma_iov_limit greater than supported\n");
+		FI_INFO_CHECK_VAL(&fi_ibv_prov, (info->tx_attr), attr,
+				  rma_iov_limit);
 		return -FI_ENODATA;
 	}
 

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -223,6 +223,14 @@ int fi_ibv_check_ep_attr(const struct fi_ep_attr *attr,
 		return -FI_ENODATA;
 	}
 
+	if (attr->auth_key_size &&
+	    (attr->auth_key_size != info->ep_attr->auth_key_size)) {
+		VERBS_INFO(FI_LOG_CORE, "Unsupported authentification size. "
+			   "Expected:%d, Requested%d\n",
+			   info->ep_attr->auth_key_size, attr->auth_key_size);
+		return -FI_ENODATA;
+	}
+
 	return 0;
 }
 

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -621,11 +621,6 @@ static void fi_tostr_cq_event_flags(char *buf, uint64_t flags)
 	fi_remove_comma(buf);
 }
 
-static void fi_tostr_size_t(char *buf, size_t value)
-{
-	strcatf(buf, "%zd", value);
-}
-
 __attribute__((visibility ("default")))
 char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 {
@@ -633,7 +628,6 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 	uint64_t val64;
 	uint32_t val32;
 	int enumval;
-	size_t valSizeT;
 
 	if (!data)
 		return NULL;
@@ -641,7 +635,6 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 	val64 = *(const uint64_t *) data;
 	val32 = *(const uint32_t *) data;
 	enumval = *(const int *) data;
-	valSizeT = *(const size_t *) data;
 
 	if (!buf) {
 		buf = calloc(FI_BUFSIZ, 1);
@@ -720,9 +713,6 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 		break;
 	case FI_TYPE_OP_TYPE:
 		fi_tostr_op_type(buf, enumval);
-		break;
-	case FI_TYPE_SIZE_T:
-		fi_tostr_size_t(buf, valSizeT);
 		break;
 	default:
 		strcatf(buf, "Unknown type");

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -375,6 +375,8 @@ static void fi_tostr_ep_attr(char *buf, const struct fi_ep_attr *attr, const cha
 
 	strcatf(buf, "%s%stx_ctx_cnt: %zd\n", prefix, TAB, attr->tx_ctx_cnt);
 	strcatf(buf, "%s%srx_ctx_cnt: %zd\n", prefix, TAB, attr->rx_ctx_cnt);
+
+	strcatf(buf, "%s%sauth_key_size: %zd\n", prefix, TAB, attr->auth_key_size);
 }
 
 static void fi_tostr_resource_mgmt(char *buf, enum fi_resource_mgmt rm)

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -619,6 +619,11 @@ static void fi_tostr_cq_event_flags(char *buf, uint64_t flags)
 	fi_remove_comma(buf);
 }
 
+static void fi_tostr_size_t(char *buf, size_t value)
+{
+	strcatf(buf, "%zd", value);
+}
+
 __attribute__((visibility ("default")))
 char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 {
@@ -626,6 +631,7 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 	uint64_t val64;
 	uint32_t val32;
 	int enumval;
+	size_t valSizeT;
 
 	if (!data)
 		return NULL;
@@ -633,6 +639,7 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 	val64 = *(const uint64_t *) data;
 	val32 = *(const uint32_t *) data;
 	enumval = *(const int *) data;
+	valSizeT = *(const size_t *) data;
 
 	if (!buf) {
 		buf = calloc(FI_BUFSIZ, 1);
@@ -711,6 +718,9 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 		break;
 	case FI_TYPE_OP_TYPE:
 		fi_tostr_op_type(buf, enumval);
+		break;
+	case FI_TYPE_SIZE_T:
+		fi_tostr_size_t(buf, valSizeT);
 		break;
 	default:
 		strcatf(buf, "Unknown type");


### PR DESCRIPTION
The PR contains updates for self-implemented function in verbs and sockets providers.
fi_tostr function is updated to print out the value of `auth_key_size` field of EP attributes.