### PR TITLE
prov/psm2: Fix domain capability checking

### DIFF
--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -473,7 +473,7 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain_priv->util_domain.domain_fid.mr = &psmx2_mr_ops;
 	domain_priv->mr_mode = info->domain_attr->mr_mode;
 	domain_priv->mode = info->mode;
-	domain_priv->caps = info->caps;
+	domain_priv->caps = PSMX2_CAPS | PSMX2_DOM_CAPS;
 	domain_priv->fabric = fabric_priv;
 	domain_priv->progress_thread_enabled =
 		(info->domain_attr->data_progress == FI_PROGRESS_AUTO);

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -435,6 +435,7 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 {
 	struct psmx2_fid_fabric *fabric_priv;
 	struct psmx2_fid_domain *domain_priv;
+	int mr_mode = (info->domain_attr->mr_mode & FI_MR_BASIC) ? FI_MR_BASIC : 0;
 	int err;
 
 	FI_INFO(&psmx2_prov, FI_LOG_DOMAIN, "\n");
@@ -446,6 +447,13 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 				   util_fabric.fabric_fid);
 
 	if (fabric_priv->active_domain) {
+		if (mr_mode != fabric_priv->active_domain->mr_mode) {
+			FI_INFO(&psmx2_prov, FI_LOG_DOMAIN,
+				"mr_mode mismatch: expecting %s\n",
+				mr_mode ? "FI_MR_SCALABLE" : "FI_MR_BASIC");
+			return -FI_EINVAL;
+		}
+
 		psmx2_domain_acquire(fabric_priv->active_domain);
 		*domain = &fabric_priv->active_domain->util_domain.domain_fid;
 		return 0;
@@ -471,7 +479,7 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain_priv->util_domain.domain_fid.fid.ops = &psmx2_fi_ops;
 	domain_priv->util_domain.domain_fid.ops = &psmx2_domain_ops;
 	domain_priv->util_domain.domain_fid.mr = &psmx2_mr_ops;
-	domain_priv->mr_mode = info->domain_attr->mr_mode;
+	domain_priv->mr_mode = mr_mode;
 	domain_priv->mode = info->mode;
 	domain_priv->caps = PSMX2_CAPS | PSMX2_DOM_CAPS;
 	domain_priv->fabric = fabric_priv;


### PR DESCRIPTION
The provider allows fi_domain being called multiple times but internally
there is only one domain object. In the past, some optional features were
turned on/off when the domain was opened. A "caps" field was used to save
the caps used for the first fi_domain call in order to keep track of what
features were available to this domain and future fi_domain calls would
fail if more features were asked for.

As part of the work to support scalable endpoint, all the optional features
can now be turned on/off at endpoint creation time. The domain level caps
limitation has become obsolete.

Also check the mr_mode passed into later fi_domain calls to make sure it is
compatible with the existing settings.

Fixes #2847.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>
