### PR TITLE
prov/sockets: Fix memory leak in sock_getinfo error path

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1518,9 +1518,7 @@ struct fi_info *sock_fi_info(uint32_t version, enum fi_ep_type ep_type,
 	info->ep_attr->type = ep_type;
 	return info;
 err:
-	free(info->src_addr);
-	free(info->dest_addr);
-	free(info);
+	fi_freeinfo(info);
 	return NULL;
 }
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1350,7 +1350,8 @@ sock_pe_process_rx_tatomic(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 	}
 
 	rx_entry->rx_op = pe_entry->pe.rx.rx_op;
-	memcpy(&rx_entry->iov[0].ioc.addr, pe_entry->pe.rx.atomic_src, entry_len);
+	memcpy((void *) (uintptr_t) rx_entry->iov[0].ioc.addr,
+		pe_entry->pe.rx.atomic_src, entry_len);
 	rx_entry->addr = pe_entry->addr;
 	rx_entry->tag = pe_entry->tag;
 	rx_entry->data = pe_entry->data;


### PR DESCRIPTION
Fixes #2812

Signed-off-by: Sean Hefty <sean.hefty@intel.com>