### PR TITLE
prov/psm2: Add an environment vaiable for message inject size

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -144,6 +144,14 @@ The *psm2* provider checks for the following environment variables:
 
   By default affinity is not set.
 
+*FI_PSM2_INJECT_SIZE*
+: Maximum message size allowed for fi_inject and fi_tinject calls. This is
+  an experimental feature to allow some applications to override default
+  inject size limitation. This is only effective for messages. Inject size
+  for RMA operations is still limited to the default setting.
+
+  The default setting is 64.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -831,6 +831,7 @@ struct psmx2_env {
 	int sep;
 	int max_trx_ctxt;
 	int num_devunits;
+	int inject_size;
 };
 
 extern struct fi_ops_mr		psmx2_mr_ops;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -50,6 +50,7 @@ struct psmx2_env psmx2_env = {
 	.sep		= 0,
 	.max_trx_ctxt	= 1,
 	.num_devunits	= 1,
+	.inject_size	= PSMX2_INJECT_SIZE,
 };
 
 static void psmx2_init_env(void)
@@ -64,6 +65,7 @@ static void psmx2_init_env(void)
 	fi_param_get_int(&psmx2_prov, "timeout", &psmx2_env.timeout);
 	fi_param_get_int(&psmx2_prov, "prog_interval", &psmx2_env.prog_interval);
 	fi_param_get_str(&psmx2_prov, "prog_affinity", &psmx2_env.prog_affinity);
+	fi_param_get_int(&psmx2_prov, "inject_size", &psmx2_env.inject_size);
 }
 
 static int psmx2_check_sep_cap(void)
@@ -698,6 +700,9 @@ PROVIDER_INI
 			"of core_ids. Both <start> and <end> can be either the core_id "
 			"(when >=0) or core_id - num_cores (when <0). "
 			"(default: affinity not set)");
+
+	fi_param_define(&psmx2_prov, "inject_size", FI_PARAM_INT,
+			"Maximum message size for fi_inject and fi_tinject (default: 64).");
 
 	pthread_mutex_init(&psmx2_lib_mutex, NULL);
 	psmx2_init_count++;

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -282,7 +282,7 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 		no_completion = 1;
 
 	if (flags & FI_INJECT) {
-		if (len > PSMX2_INJECT_SIZE)
+		if (len > psmx2_env.inject_size)
 			return -FI_EMSGSIZE;
 
 		err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
@@ -459,7 +459,7 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 		no_completion = 1;
 
 	if (flags & FI_INJECT) {
-		if (len > PSMX2_INJECT_SIZE) {
+		if (len > psmx2_env.inject_size) {
 			free(req);
 			return -FI_EMSGSIZE;
 		}

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -685,7 +685,7 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 		no_completion = 1;
 
 	if (flags & FI_INJECT) {
-		if (len > PSMX2_INJECT_SIZE)
+		if (len > psmx2_env.inject_size)
 			return -FI_EMSGSIZE;
 
 		err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
@@ -939,7 +939,7 @@ psmx2_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf,
 	uint32_t tag32;
 	int err;
 
-	if (len > PSMX2_INJECT_SIZE)
+	if (len > psmx2_env.inject_size)
 		return -FI_EMSGSIZE;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
@@ -982,7 +982,7 @@ psmx2_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	int err;
 	size_t idx;
 
-	if (len > PSMX2_INJECT_SIZE)
+	if (len > psmx2_env.inject_size)
 		return -FI_EMSGSIZE;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
@@ -1137,7 +1137,7 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 		no_completion = 1;
 
 	if (flags & FI_INJECT) {
-		if (len > PSMX2_INJECT_SIZE) {
+		if (len > psmx2_env.inject_size) {
 			free(req);
 			return -FI_EMSGSIZE;
 		}


### PR DESCRIPTION
Currently the inject size is limited globally to 64 bytes. For message
sends, however, the low level transport actually allows larger inject
size. A new environment variable is now introduced to allow overriding
the default size limit for fi_inject and fi_tinject.

RMA inject size limit isn't affected by this variable.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>