### PR TITLE
util: Update utility check info function to support multiple fi_info

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -579,7 +579,15 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 int ofi_check_tx_attr(const struct fi_provider *prov,
 		      const struct fi_tx_attr *prov_attr,
 		      const struct fi_tx_attr *user_attr, uint64_t info_mode);
-int ofi_check_info(const struct util_prov *util_prov, uint32_t api_version,
+int ofi_prov_check_info(const struct util_prov *util_prov,
+			uint32_t api_version,
+			const struct fi_info *user_info);
+int ofi_prov_check_dup_info(const struct util_prov *util_prov,
+			    uint32_t api_version,
+			    const struct fi_info *user_info,
+			    struct fi_info **info);
+int ofi_check_info(const struct util_prov *util_prov,
+		   const struct fi_info *prov_info, uint32_t api_version,
 		   const struct fi_info *user_info);
 void ofi_alter_info(struct fi_info *info, const struct fi_info *hints,
 		    uint32_t api_version);

--- a/prov/mlx/src/mlx_domain.c
+++ b/prov/mlx/src/mlx_domain.c
@@ -83,7 +83,9 @@ int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_EINVAL;
 	}
 
-	ofi_status = ofi_check_info(&mlx_util_prov, fabric->api_version, info);
+	ofi_status = ofi_prov_check_info(&mlx_util_prov,
+					 fabric->api_version,
+					 info);
 	if (ofi_status) {
 		return ofi_status;
 	}
@@ -93,7 +95,8 @@ int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return -ENOMEM;
 	}
 
-	ofi_status = ofi_domain_init(fabric, info, &(domain->u_domain), context);
+	ofi_status = ofi_domain_init(fabric, info,
+				     &(domain->u_domain), context);
 	if (ofi_status) {
 		goto domain_free;
 	}

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -237,8 +237,9 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct rxd_domain *rxd_domain;
 	struct rxd_fabric *rxd_fabric;
 
-	rxd_fabric = container_of(fabric, struct rxd_fabric, util_fabric.fabric_fid);
-	ret = ofi_check_info(&rxd_util_prov, fabric->api_version, info);
+	rxd_fabric = container_of(fabric, struct rxd_fabric,
+				  util_fabric.fabric_fid);
+	ret = ofi_prov_check_info(&rxd_util_prov, fabric->api_version, info);
 	if (ret)
 		return ret;
 
@@ -246,8 +247,9 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!rxd_domain)
 		return -FI_ENOMEM;
 
-	ret = ofi_get_core_info(fabric->api_version, NULL, NULL, 0,
-				&rxd_util_prov, info, rxd_info_to_core, &dg_info);
+	ret = ofi_get_core_info(fabric->api_version, NULL, NULL,
+				0, &rxd_util_prov, info,
+				rxd_info_to_core, &dg_info);
 	if (ret)
 		goto err1;
 

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1723,15 +1723,19 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct fi_info *dg_info;
 	struct rxd_ep *rxd_ep;
 	struct rxd_domain *rxd_domain;
+	uint32_t api_version;
 
-	rxd_domain = container_of(domain, struct rxd_domain, util_domain.domain_fid);
-	ret = ofi_check_info(&rxd_util_prov, rxd_domain->util_domain.fabric->
-			     fabric_fid.api_version, info);
+	rxd_domain = container_of(domain, struct rxd_domain,
+				  util_domain.domain_fid);
+
+	api_version = rxd_domain->util_domain.fabric->fabric_fid.api_version;
+
+	ret = ofi_prov_check_info(&rxd_util_prov, api_version, info);
 	if (ret)
 		return ret;
 
-	ret = ofi_get_core_info(rxd_domain->util_domain.fabric->fabric_fid.api_version,
-				NULL, NULL, 0, &rxd_util_prov, info,
+	ret = ofi_get_core_info(api_version, NULL, NULL, 0,
+				&rxd_util_prov, info,
 				rxd_info_to_core, &dg_info);
 	if (ret)
 		return ret;
@@ -1742,7 +1746,8 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err1;
 	}
 
-	rxd_ep->addrlen = (info->src_addr) ? info->src_addrlen : info->dest_addrlen;
+	rxd_ep->addrlen = (info->src_addr) ? info->src_addrlen :
+					     info->dest_addrlen;
 	rxd_ep->do_local_mr = (rxd_domain->dg_mode & FI_LOCAL_MR) ? 1 : 0;
 	ret = fi_endpoint(rxd_domain->dg_domain, dg_info, ep, context);
 	if (ret)

--- a/prov/udp/src/udpx_domain.c
+++ b/prov/udp/src/udpx_domain.c
@@ -75,7 +75,7 @@ int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct util_domain *util_domain;
 	int ret;
 
-	ret = ofi_check_info(&udpx_util_prov, fabric->api_version, info);
+	ret = ofi_prov_check_info(&udpx_util_prov, fabric->api_version, info);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -76,8 +76,9 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	if (!info || !info->ep_attr || !info->rx_attr || !info->tx_attr)
 		return -FI_EINVAL;
 
-	ret = ofi_check_info(util_prov,
-			     util_domain->fabric->fabric_fid.api_version, info);
+	ret = ofi_prov_check_info(util_prov,
+				  util_domain->fabric->fabric_fid.api_version,
+				  info);
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
The discovered problem is if the provider uses utility function for info (`util_getinfo`, `ofi_check_info`) and has a multiple `fi_info` entries then it may cause only the first provider's `fi_info` will be checked (`util_prov`::`info `field). As a result it has an impact on `ofi_endpoint_init`, because if no the first of returned `fi_info` is used (e.x. second entry) then check of info that is under the hood of `ofi_endpoint_init` will be failed.

Impacted providers (mlx, udp, rxd) don't have this problem, because they have only one entry of `fi_info`, but they are updated to be compliant with updated utility function.

The solution has been tested with provider that has a multiple `fi_info` and uses utility function to check them. Smoke test passed for udp provider in fabtests (Travis and AppVeyor CI) .