### PR TITLE
Update FI_ADDR_STR documentation.

### DIFF
--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -276,7 +276,8 @@ number of addresses is specified through the count parameter.  The
 addr parameter references an array of addresses to insert into the AV.
 Addresses inserted into an address vector must be in the same format
 as specified in the addr_format field of the fi_info struct provided when
-opening the corresponding domain.
+opening the corresponding domain. When using the `FI_ADDR_STR` format,
+the `addr` parameter should reference an array of strings (char \*\*).
 
 For AV's of type FI_AV_MAP, once inserted addresses have been mapped,
 the mapped values are written into the buffer referenced by fi_addr.
@@ -342,8 +343,11 @@ application to specify the node and service names, similar to the
 fi_getinfo inputs, rather than an encoded address.  The node and service
 parameters are defined the same as fi_getinfo(3).  Node should be a string
 that corresponds to a hostname or network address.  The service string
-corresponds to a textual representation of a transport address.  Supported
-flags are the same as for fi_av_insert.
+corresponds to a textual representation of a transport address.
+Applications may also pass in an `FI_ADDR_STR` formatted address as the
+node parameter. In such cases, the service parameter must be NULL. See
+fi_getinfo.3 for details on using `FI_ADDR_STR`. Supported flags are the
+same as for fi_av_insert.
 
 ## fi_av_insertsym
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -581,10 +581,16 @@ fabric.  See `fi_av`(3).
   the string is address and/or provider specific, but in general follows
   a URI model:
 
-  address_format[://[node][:[service][/[field3]...]]]
+  address_format[://[node][:[service][/[field3]...][?[key=value][&k2=v2]...]]]
 
-  Examples: inet://10.31.6.12:7471, inet6://[fe80::6:12]:7471,
-  name://hostname:7471
+  Examples:
+  - fi_sockaddr://10.31.6.12:7471
+  - fi_sockaddr_in6://[fe80::6:12]:7471
+  - fi_sockaddr://10.31.6.12:7471?qos=3
+
+  Since the string formatted address does not contain any provider
+  information, the prov_name field of the fabric attribute structure should
+  be used to filter by provider if necessary.
 
 # FLAGS
 

--- a/src/common.c
+++ b/src/common.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2004, 2005 Topspin Communications.  All rights reserved.
- * Copyright (c) 2006 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013 Intel Corp., Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
  *
@@ -254,7 +254,7 @@ sa_sin:
 			return NULL;
 
 		size = snprintf(buf, MIN(*len, sizeof(str)),
-				"inet://%s:%" PRIu16, str,
+				"fi_sockaddr_in://%s:%" PRIu16, str,
 				ntohs(sin->sin_port));
 		break;
 	case FI_SOCKADDR_IN6:
@@ -265,27 +265,30 @@ sa_sin6:
 			return NULL;
 
 		size = snprintf(buf, MIN(*len, sizeof(str)),
-				"inet6://[%s]:%" PRIu16, str,
+				"fi_sockaddr_in6://[%s]:%" PRIu16, str,
 				ntohs(sin6->sin6_port));
 		break;
 	case FI_SOCKADDR_IB:
-		size = snprintf(buf, *len, "ib://%p", addr);
+		size = snprintf(buf, *len, "fi_sockaddr_ib://%p", addr);
 		break;
 	case FI_ADDR_PSMX:
-		size = snprintf(buf, *len, "psmx://%" PRIx64, *(uint64_t *) addr);
+		size = snprintf(buf, *len, "fi_addr_psmx://%" PRIx64,
+				*(uint64_t *)addr);
 		break;
 	case FI_ADDR_PSMX2:
-		size = snprintf(buf, *len, "psmx2://%" PRIx64 ":%" PRIx64,
-				*(uint64_t *) addr, *((uint64_t *) addr + 1));
+		size =
+		    snprintf(buf, *len, "fi_addr_psmx2://%" PRIx64 ":%" PRIx64,
+			     *(uint64_t *)addr, *((uint64_t *)addr + 1));
 		break;
 	case FI_ADDR_GNI:
-		size = snprintf(buf, *len, "gni://%" PRIx64, *(uint64_t *) addr);
+		size = snprintf(buf, *len, "fi_addr_gni://%" PRIx64,
+				*(uint64_t *)addr);
 		break;
 	case FI_ADDR_BGQ:
-		size = snprintf(buf, *len, "bgq://%p", addr);
+		size = snprintf(buf, *len, "fi_addr_bgq://%p", addr);
 		break;
 	case FI_ADDR_MLX:
-		size = snprintf(buf, *len, "mlx://%p", addr);
+		size = snprintf(buf, *len, "fi_addr_mlx://%p", addr);
 		break;
 	case FI_ADDR_STR:
 		size = snprintf(buf, *len, "%s", (const char *) addr);
@@ -311,21 +314,21 @@ static uint32_t ofi_addr_format(const char *str)
 		return FI_FORMAT_UNSPEC;
 
 	fmt[sizeof(fmt) - 1] = '\0';
-	if (!strcmp(fmt, "inet"))
+	if (!strcasecmp(fmt, "fi_sockaddr_in"))
 		return FI_SOCKADDR_IN;
-	else if (!strcmp(fmt, "inet6"))
+	else if (!strcasecmp(fmt, "fi_sockaddr_in6"))
 		return FI_SOCKADDR_IN6;
-	else if (!strcmp(fmt, "ib"))
+	else if (!strcasecmp(fmt, "fi_sockaddr_ib"))
 		return FI_SOCKADDR_IB;
-	else if (!strcmp(fmt, "psmx"))
+	else if (!strcasecmp(fmt, "fi_addr_psmx"))
 		return FI_ADDR_PSMX;
-	else if (!strcmp(fmt, "psmx2"))
+	else if (!strcasecmp(fmt, "fi_addr_psmx2"))
 		return FI_ADDR_PSMX2;
-	else if (!strcmp(fmt, "gni"))
+	else if (!strcasecmp(fmt, "fi_addr_gni"))
 		return FI_ADDR_GNI;
-	else if (!strcmp(fmt, "bgq"))
+	else if (!strcasecmp(fmt, "fi_addr_bgq"))
 		return FI_ADDR_BGQ;
-	else if (!strcmp(fmt, "mlx"))
+	else if (!strcasecmp(fmt, "fi_addr_mlx"))
 		return FI_ADDR_MLX;
 
 	return FI_FORMAT_UNSPEC;


### PR DESCRIPTION
- FI_ADDR_STR extended options are specified using URI syntax (after a
  question mark and separated by an ampersand).
- Explicitly document that the FI_ADDR_STR format does not contain
  provider information. If a specific provider is needed, the standard
  filtering API (prov_name) should be used.
- Disallow inet/inet6 as the address type for FI_ADDR_STR. The address
  type should refer to the Libfabric address enumeration type, or the
  word "name" if specifying a hostname.
- The addr field for the AV API now references an array of strings.

This closes #3064. 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>