### PR TITLE
prov/gni: Document limitations of regattr and regv.

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -22,6 +22,11 @@ support for common atomic operations and optimized collectives.
 The GNI provider runs on Cray XC systems running CLE 5.2 UP04 or higher
 using gcc version 4.9 or higher.
 
+When using the fi_mr_regattr() and fi_mr_regv() functions to register
+multiple region, users must register the memory region with 4K
+page alignment. Any other page address alignment will result in a return
+value of -FI_EINVAL.
+
 # SUPPORTED FEATURES
 
 The GNI provider supports the following features defined for the


### PR DESCRIPTION
Add notes to fi_gni man page to document page alignment restrictions.

upstream merge of ofi-cray/libfabric-cray#1373
[skip ci]

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@56f91615e245b80f26fca91823230cded7b9d7ad)