### PR TITLE
prov/gni: Restrict mr mode bits to basic

### DIFF
--- a/prov/gni/test/allocator.c
+++ b/prov/gni/test/allocator.c
@@ -39,6 +39,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 #define ALLOCD_WITH_NIC 0
 
@@ -61,6 +62,7 @@ void allocator_setup(void)
 
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 
 	hints->fabric_attr->prov_name = strdup("gni");
 

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -105,6 +105,7 @@ void rdm_api_setup_ep(void)
 
 	/* Get info about fabric services with the provided hints */
 	for (i = 0; i < NUMEPS; i++) {
+		hints[i]->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 		ret = fi_getinfo(fi_version(), NULL, 0, 0, hints[i],
 				 &fi[i]);
 		cr_assert(!ret, "fi_getinfo");
@@ -218,7 +219,7 @@ void rdm_api_setup(void)
 		hints[i]->domain_attr->cq_data_size = NUMEPS * 2;
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
 		hints[i]->mode = mode_bits;
-		hints[i]->domain_attr->mr_mode = FI_MR_BASIC;
+		hints[i]->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 		hints[i]->fabric_attr->prov_name = strdup("gni");
 	}
 }
@@ -454,6 +455,7 @@ Test(api, dom_caps)
 
 	hints[0]->mode = mode_bits;
 	hints[0]->fabric_attr->prov_name = strdup("gni");
+	hints[0]->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 
 	/* we only support REMOTE_COMM */
 	hints[0]->domain_attr->caps = FI_LOCAL_COMM;

--- a/prov/gni/test/api_cntr.c
+++ b/prov/gni/test/api_cntr.c
@@ -49,6 +49,7 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 #include "fi_ext_gni.h"
+#include "common.h"
 
 #if 1
 #define dbg_printf(...)
@@ -142,6 +143,7 @@ void api_cntr_setup(void)
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
 		hints[i]->mode = mode_bits;
 		hints[i]->fabric_attr->prov_name = strdup("gni");
+		hints[i]->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	}
 
 	/* Get info about fabric services with the provided hints */

--- a/prov/gni/test/api_cq.c
+++ b/prov/gni/test/api_cq.c
@@ -50,6 +50,7 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 #include "fi_ext_gni.h"
+#include "common.h"
 
 #if 1
 #define dbg_printf(...)
@@ -111,6 +112,7 @@ void api_cq_setup(void)
 
 		hints[i]->domain_attr->cq_data_size = NUMEPS * 2;
 		hints[i]->domain_attr->data_progress = FI_PROGRESS_AUTO;
+		hints[i]->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 		hints[i]->mode = mode_bits;
 		hints[i]->fabric_attr->prov_name = strdup("gni");
 	}

--- a/prov/gni/test/av.c
+++ b/prov/gni/test/av.c
@@ -139,6 +139,7 @@ static void av_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 

--- a/prov/gni/test/cancel.c
+++ b/prov/gni/test/cancel.c
@@ -53,6 +53,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 /* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
 static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
@@ -82,6 +83,7 @@ void cancel_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 

--- a/prov/gni/test/cm.c
+++ b/prov/gni/test/cm.c
@@ -54,6 +54,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 #if 1
 #define dbg_printf(...)
@@ -144,6 +145,7 @@ int cm_server_start(void)
 	srv_hints = fi_allocinfo();
 	srv_hints->fabric_attr->name = strdup("gni");
 	srv_hints->ep_attr->type = FI_EP_MSG;
+	srv_hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 
 	ret = fi_getinfo(fi_version(), inet_ntoa(loc_sa.sin_addr),
 			 DEF_PORT, FI_SOURCE, srv_hints, &srv_fi);
@@ -273,6 +275,7 @@ int cm_client_start_connect(void)
 	cli_hints->fabric_attr->name = strdup("gni");
 	cli_hints->caps = GNIX_EP_PRIMARY_CAPS;
 	cli_hints->ep_attr->type = FI_EP_MSG;
+	cli_hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 
 	ret = fi_getinfo(fi_version(), inet_ntoa(loc_sa.sin_addr),
 			 DEF_PORT, 0, cli_hints, &cli_fi);

--- a/prov/gni/test/cntr.c
+++ b/prov/gni/test/cntr.c
@@ -52,6 +52,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 #if 1
 #define dbg_printf(...)
@@ -102,6 +103,7 @@ static inline void cntr_setup_eps(const uint64_t caps)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 

--- a/prov/gni/test/common.h
+++ b/prov/gni/test/common.h
@@ -41,6 +41,7 @@
 #include <criterion/logging.h>
 #include "gnix_rdma_headers.h"
 #include "gnix.h"
+#include "fi_util.h"
 
 #define BLUE "\x1b[34m"
 #define COLOR_RESET "\x1b[0m"
@@ -66,4 +67,5 @@ static inline struct gnix_fid_ep *get_gnix_ep(struct fid_ep *fid_ep)
 	return container_of(fid_ep, struct gnix_fid_ep, ep_fid);
 }
 
+#define GNIX_DEFAULT_MR_MODE OFI_MR_BASIC_MAP
 #endif /* PROV_GNI_TEST_COMMON_H_ */

--- a/prov/gni/test/cq.c
+++ b/prov/gni/test/cq.c
@@ -50,6 +50,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 /* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
 static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
@@ -74,6 +75,7 @@ void setup()
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 

--- a/prov/gni/test/datagram.c
+++ b/prov/gni/test/datagram.c
@@ -52,6 +52,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 /* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
 static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
@@ -71,6 +72,7 @@ void dg_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 
@@ -100,6 +102,7 @@ void dg_setup_prog_manual(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->domain_attr->control_progress = FI_PROGRESS_MANUAL;
 	hints->mode = mode_bits;

--- a/prov/gni/test/dom.c
+++ b/prov/gni/test/dom.c
@@ -43,6 +43,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 static struct fid_fabric *fabric;
 static struct fi_info *fi;
@@ -56,6 +57,7 @@ static void setup(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->fabric_attr->prov_name = strdup("gni");
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);
 	cr_assert(ret == FI_SUCCESS, "fi_getinfo");

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -44,6 +44,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 static struct fi_info *hints;
 static struct fi_info *fi;
@@ -57,6 +58,7 @@ static void setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);
@@ -92,6 +94,8 @@ Test(endpoint_info, info)
 
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
+
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);

--- a/prov/gni/test/eq.c
+++ b/prov/gni/test/eq.c
@@ -38,6 +38,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 /* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
 static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
@@ -61,6 +62,7 @@ void _setup(void)
 	cr_assert(hints, "fi_allocinfo failed.");
 
 	hints->mode = mode_bits;
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);

--- a/prov/gni/test/fabric.c
+++ b/prov/gni/test/fabric.c
@@ -38,12 +38,12 @@
 #include <time.h>
 #include <string.h>
 
-
 #include "gnix.h"
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 #include "fi_ext_gni.h"
+#include "common.h"
 
 static struct fid_fabric *fabric;
 static struct fi_info *fi;
@@ -56,6 +56,7 @@ static void setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = FI_MR_BASIC;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(FI_VERSION(1, 0), NULL, 0, 0, hints, &fi);
@@ -78,9 +79,6 @@ static void teardown(void)
 }
 
 TestSuite(fabric, .init = setup, .fini = teardown);
-
-
-
 
 Test(fabric, simple)
 {

--- a/prov/gni/test/fi_addr_str.c
+++ b/prov/gni/test/fi_addr_str.c
@@ -289,6 +289,7 @@ static void fas_setup_common(uint32_t version)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
@@ -574,6 +575,7 @@ static void fas_getinfo_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -51,6 +51,7 @@
 #include "gnix_rdma_headers.h"
 #include "gnix.h"
 #include "gnix_mr.h"
+#include "common.h"
 
 #define CHECK_HOOK(name, args...) \
 	({ \
@@ -145,6 +146,7 @@ static void _mr_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);

--- a/prov/gni/test/mr_notifier.c
+++ b/prov/gni/test/mr_notifier.c
@@ -37,6 +37,7 @@
 #include "gnix_mr_notifier.h"
 
 #include <criterion/criterion.h>
+#include "common.h"
 
 static struct gnix_mr_notifier *mr_notifier;
 static void mr_notifier_setup(void)
@@ -238,6 +239,7 @@ static void mr_stressor_setup_common(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 

--- a/prov/gni/test/nic.c
+++ b/prov/gni/test/nic.c
@@ -44,6 +44,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 static struct fi_info *hints;
 static struct fi_info *fi;
@@ -57,6 +58,7 @@ static void setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -113,6 +113,7 @@ void common_atomic_setup(void)
 	cq_attr.wait_obj = 0;
 
 	hints->ep_attr->type = FI_EP_RDM;
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 	hints->fabric_attr->prov_name = strdup("gni");

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -110,6 +110,7 @@ void common_setup(void)
 
 	dgm_fail = 0;
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 	hints->caps |= FI_RMA | FI_READ | FI_REMOTE_READ |
@@ -324,6 +325,7 @@ void common_setup_1dom(void)
 
 	dgm_fail = 0;
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 	hints->caps |= FI_RMA | FI_READ | FI_REMOTE_READ |

--- a/prov/gni/test/rdm_dgram_stx.c
+++ b/prov/gni/test/rdm_dgram_stx.c
@@ -109,6 +109,7 @@ static void common_setup_stx(void)
 
 	dgm_fail = 0;
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->ep_attr->tx_ctx_cnt = FI_SHARED_CONTEXT;
 	hints->mode = mode_bits;
@@ -336,6 +337,7 @@ static void common_setup_stx_1dom(void)
 
 	dgm_fail = 0;
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->ep_attr->tx_ctx_cnt = FI_SHARED_CONTEXT;
 	hints->mode = mode_bits;

--- a/prov/gni/test/rdm_fi_pcd_trecv_msg.c
+++ b/prov/gni/test/rdm_fi_pcd_trecv_msg.c
@@ -53,6 +53,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 /* Both the send and recv paths use independent state machines within
  * each test to simulate the behavior you would expect in a client/server
@@ -339,6 +340,7 @@ static void rdm_fi_pdc_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 

--- a/prov/gni/test/rdm_rx_overrun.c
+++ b/prov/gni/test/rdm_rx_overrun.c
@@ -52,6 +52,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 #define NUM_EPS 61
 const int num_msgs = 10;
@@ -96,6 +97,7 @@ static void setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
 

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -284,6 +284,7 @@ void rdm_sr_setup(bool is_noreg, enum fi_progress pm)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->control_progress = pm;
 	hints->domain_attr->data_progress = pm;
@@ -312,6 +313,10 @@ void dgram_sr_setup(uint32_t version, bool is_noreg, enum fi_progress pm)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	if (FI_VERSION_LT(version, FI_VERSION(1, 5)))
+		hints->domain_attr->mr_mode = FI_MR_BASIC;
+	else
+		hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->control_progress = pm;
 	hints->domain_attr->data_progress = pm;
@@ -379,6 +384,7 @@ void rdm_sr_bnd_ep_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->mode = mode_bits;
 	hints->fabric_attr->prov_name = strdup("gni");
@@ -465,7 +471,6 @@ static void rdm_sr_teardown_nounreg(void)
 {
 	rdm_sr_teardown_common(false);
 }
-
 
 void rdm_sr_init_data(char *buf, int len, char seed)
 {
@@ -558,7 +563,6 @@ static inline void rdm_sr_check_err_cqe(struct fi_cq_err_entry *cqe, void *ctx,
 			cr_assert(cqe->buf == NULL, "error CQE address "
 				"mismatch");
 
-
 		if (flags & FI_REMOTE_CQ_DATA)
 			cr_assert(cqe->data == data, "error CQE data mismatch");
 	} else {
@@ -593,7 +597,6 @@ static inline void rdm_sr_check_cqe(struct fi_cq_tagged_entry *cqe, void *ctx,
 			cr_assert(cqe->buf == addr, "CQE address mismatch");
 		else
 			cr_assert(cqe->buf == NULL, "CQE address mismatch");
-
 
 	/* TODO: Remove GNIX_ALLOW_FI_REMOTE_CQ_DATA and only check flags for FI_RMA_EVENT */
 	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(flags, gnix_ep->caps))
@@ -696,7 +699,6 @@ static inline struct fi_cq_err_entry rdm_sr_check_canceled(struct fid_cq *cq)
 	 * when using api version >= 1.5.
 	 */
 	cr_assert(ee.err_data != &err_ep_name, "Invalid err_data ptr");
-
 
 	/* To test API-1.1: Reporting of unknown source addresses */
 	if ((hints->caps & FI_SOURCE) && ee.err == FI_EADDRNOTAVAIL) {

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -52,6 +52,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 #if 1
 #define dbg_printf(...)
@@ -93,8 +94,8 @@ static void setup_dom(enum fi_progress pm)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->data_progress = pm;
-
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 

--- a/prov/gni/test/sep.c
+++ b/prov/gni/test/sep.c
@@ -111,7 +111,7 @@ void sep_setup_common(int av_type)
 	hints->mode = FI_LOCAL_MR;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
-	hints->domain_attr->mr_mode = FI_MR_BASIC;
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 	hints->ep_attr->tx_ctx_cnt = ctx_cnt;
 	hints->ep_attr->rx_ctx_cnt = ctx_cnt;
@@ -361,7 +361,7 @@ void sep_setup_context(void)
 	hints->mode = FI_LOCAL_MR;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
-	hints->domain_attr->mr_mode = FI_MR_BASIC;
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	hints->ep_attr->tx_ctx_cnt = 0;
@@ -2350,7 +2350,7 @@ Test(scalable, av_insert)
 	hints->mode = FI_LOCAL_MR;
 	hints->domain_attr->cq_data_size = NUMEPS * 2;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
-	hints->domain_attr->mr_mode = FI_MR_BASIC;
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 	hints->ep_attr->tx_ctx_cnt = NUMCONTEXTS;
 	hints->ep_attr->rx_ctx_cnt = NUMCONTEXTS;

--- a/prov/gni/test/tags.c
+++ b/prov/gni/test/tags.c
@@ -47,6 +47,7 @@
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
 #include <criterion/parameterized.h>
+#include "common.h"
 
 /* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
 static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
@@ -347,6 +348,7 @@ static void __gnix_tags_bare_test_setup(void)
 	hints = fi_allocinfo();
 	cr_assert(hints, "fi_allocinfo");
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->domain_attr->cq_data_size = 4;
 	hints->mode = mode_bits;
 

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -41,7 +41,6 @@
 #include <string.h>
 #include <pthread.h>
 
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <inttypes.h>
@@ -54,6 +53,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 /* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
 static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
@@ -117,6 +117,7 @@ static void vc_setup_common(void)
 	size_t addrlen = 0;
 	struct gnix_fid_av *gnix_av;
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);
@@ -238,6 +239,7 @@ static void vc_conn_ping_setup(void)
 	struct fi_av_attr attr = {0};
 	size_t addrlen = 0;
 
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->name = strdup("gni");
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);
@@ -398,7 +400,6 @@ static void vc_conn_ping_setup_manual(void)
 	hints->mode = mode_bits;
 	vc_conn_ping_setup();
 }
-
 
 void vc_conn_ping_teardown(void)
 {

--- a/prov/gni/test/vc_lookup.c
+++ b/prov/gni/test/vc_lookup.c
@@ -66,6 +66,7 @@ void vc_lookup_setup(int av_type, int av_size)
 	hints = fi_allocinfo();
 
 	hints->mode = mode_bits;
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	/* Create endpoint */

--- a/prov/gni/test/wait.c
+++ b/prov/gni/test/wait.c
@@ -38,6 +38,7 @@
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
+#include "common.h"
 
 /* Note: Set to ~FI_NOTIFY_FLAGS_ONLY since this was written before api 1.5 */
 static uint64_t mode_bits = ~FI_NOTIFY_FLAGS_ONLY;
@@ -56,7 +57,7 @@ void wait_setup(void)
 	cr_assert(hints, "fi_allocinfo");
 
 	hints->mode = mode_bits;
-
+	hints->domain_attr->mr_mode = GNIX_DEFAULT_MR_MODE;
 	hints->fabric_attr->prov_name = strdup("gni");
 
 	ret = fi_getinfo(fi_version(), NULL, 0, 0, hints, &fi);


### PR DESCRIPTION
For the GNI provider, only basic memory registration is supported at
this time. This commit fixes the provider to only use basic memory
registration.

In addition, this commit resolves problems with the GNI provider
on fi_getinfo where the GNI fi_getinfo equivalent function call
would modify the hints structure, which is not permitted.

Requires patch for ofiwg/libfabric#3037
upstream merge of ofi-cray/libfabric-cray#1365

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@c125091d4c1ba6eec8962fafbfa8bef240bad720)