### PR TITLE
prov/gni: add back in missing lock

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -539,6 +539,8 @@ DIRECT_FN STATIC ssize_t gnix_cq_readerr(struct fid_cq *cq,
 
 	_gnix_prog_progress(&cq_priv->pset);
 
+	COND_ACQUIRE(cq_priv->requires_lock, &cq_priv->lock);
+
 	entry = _gnix_queue_dequeue(cq_priv->errors);
 	if (!entry) {
 		read_count = -FI_EAGAIN;


### PR DESCRIPTION
Add back in spin lock acquire which was accidentally
dropped as part of PR ofi-cray/libfabric-cray#1305.

upstream merge of ofi-cray/libfabric-cray#1376

Fixes ofi-cray/libfabric-cray#1359

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@753e5c88854c7e688524f6a5c19ca4a490493ef6)