### PR TITLE
prov/gni: runtime checks for version with authkeys

### DIFF
--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -539,7 +539,6 @@ __gnix_dom_ops_set_val(struct fid *fid, dom_ops_val_t t, void *val)
 	return FI_SUCCESS;
 }
 
-
 static struct fi_gni_ops_domain gnix_ops_domain = {
 	.set_val = __gnix_dom_ops_set_val,
 	.get_val = __gnix_dom_ops_get_val,
@@ -579,11 +578,9 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	fabric_priv = container_of(fabric, struct gnix_fid_fabric, fab_fid);
 
-#if 0 /* TODO: Enable after 1.5 version update */
 	if (FI_VERSION_LT(fabric->api_version, FI_VERSION(1, 5)) &&
 		(info->domain_attr->auth_key_size || info->domain_attr->auth_key))
 			return -FI_EINVAL;
-#endif
 
 	auth_key = GNIX_GET_AUTH_KEY(info->domain_attr->auth_key,
 			info->domain_attr->auth_key_size);

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -527,7 +527,7 @@ int _gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
 		GNIX_DEBUG(FI_LOG_EP_CTRL,
 			   "ep_priv->vc_table = %p, ep_priv->vc_table->vector = %p\n",
 			   ep_priv->vc_table, ep_priv->vc_table->vector);
-                if (ret != FI_SUCCESS) {
+		if (ret != FI_SUCCESS) {
 			GNIX_WARN(FI_LOG_EP_CTRL, "_gnix_vec_init returned %s\n",
 				  fi_strerror(ret));
 			goto err;
@@ -709,7 +709,6 @@ gnix_ep_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 	return _gnix_send(gnix_ep, (uint64_t)buf, len, NULL, dest_addr,
 			  NULL, flags, data, 0);
 }
-
 
 /*******************************************************************************
  * EP RMA API function implementations.
@@ -1061,7 +1060,6 @@ DIRECT_FN STATIC ssize_t gnix_ep_tinjectdata(struct fid_ep *ep, const void *buf,
 	return _ep_inject(ep, buf, len, data, dest_addr,
 			  FI_TAGGED | FI_REMOTE_CQ_DATA, tag);
 }
-
 
 /*******************************************************************************
  * EP atomic API implementation.
@@ -1468,7 +1466,6 @@ DIRECT_FN STATIC ssize_t gnix_ep_atomic_compwritemsg(struct fid_ep *ep,
  * Base EP API function implementations.
  ******************************************************************************/
 
-
 DIRECT_FN STATIC int gnix_ep_control(fid_t fid, int command, void *arg)
 {
 	int ret = FI_SUCCESS;
@@ -1531,7 +1528,6 @@ DIRECT_FN STATIC int gnix_ep_control(fid_t fid, int command, void *arg)
 err:
 	return ret;
 }
-
 
 static int __destruct_tag_storages(struct gnix_fid_ep *ep)
 {
@@ -2245,12 +2241,10 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 
 	domain_priv = container_of(domain, struct gnix_fid_domain, domain_fid);
 
-#if 0 /* TODO: Enable after 1.5 version update */
 	if (FI_VERSION_LT(domain_priv->fabric->fab_fid.api_version,
 		FI_VERSION(1, 5)) &&
 		(info->ep_attr->auth_key || info->ep_attr->auth_key_size))
 		return -FI_EINVAL;
-#endif
 
 	if (info->ep_attr->auth_key_size) {
 		auth_key = GNIX_GET_AUTH_KEY(info->ep_attr->auth_key,

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -289,7 +289,6 @@ DIRECT_FN int gnix_mr_regv(struct fid *fid, const struct iovec *iov,
 	return gnix_mr_regattr(fid, &attr, flags, mr);
 }
 
-
 DIRECT_FN int gnix_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	uint64_t flags, struct fid_mr **mr)
 {
@@ -305,13 +304,10 @@ DIRECT_FN int gnix_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	if (domain->mr_iov_limit < attr->iov_count)
 		return -FI_EOPNOTSUPP;
 
-#if 0 /* TODO: Enable after 1.5 version update */
 	if (FI_VERSION_LT(domain->fabric->fab_fid.api_version,
 		FI_VERSION(1, 5)) &&
 		(attr->auth_key || attr->auth_key_size))
 		return -FI_EINVAL;
-#endif
-
 
 	if (attr->auth_key_size) {
 		auth_key = GNIX_GET_AUTH_KEY(attr->auth_key, attr->auth_key_size);
@@ -419,7 +415,7 @@ static inline void *__gnix_generic_register(
 		}
 		_gnix_ref_get(nic);
 		pthread_mutex_unlock(&gnix_nic_list_lock);
-        }
+	    }
 
 	COND_ACQUIRE(nic->requires_lock, &nic->lock);
 	grc = GNI_MemRegister(nic->gni_nic_hndl, (uint64_t) address,
@@ -522,7 +518,6 @@ static int __gnix_destruct_registration(void *context)
 	return GNI_RC_SUCCESS;
 }
 
-
 #ifdef HAVE_UDREG
 void *__udreg_register(void *addr, uint64_t length, void *context)
 {
@@ -547,7 +542,6 @@ void *__udreg_register(void *addr, uint64_t length, void *context)
 		GNI_MEM_READWRITE, -1, auth_key);
 }
 
-
 uint32_t __udreg_deregister(void *registration, void *context)
 {
 	gni_return_t grc;
@@ -559,11 +553,10 @@ uint32_t __udreg_deregister(void *registration, void *context)
 	return (grc == GNI_RC_SUCCESS) ? 0 : 1;
 }
 
-
 /* Called via dreg when a cache is destroyed. */
 void __udreg_cache_destructor(void *context)
 {
-    /*  Nothing needed here. */
+	/*  Nothing needed here. */
 }
 
 static int __udreg_init(struct gnix_fid_domain *domain,
@@ -882,7 +875,6 @@ struct gnix_mr_ops cache_mr_ops = {
 	.flush_cache = __cache_flush,
 };
 
-
 static int __basic_mr_init(struct gnix_fid_domain *domain,
 		struct gnix_auth_key *auth_key)
 {
@@ -948,7 +940,6 @@ struct gnix_mr_ops basic_mr_ops = {
 	.flush_cache = NULL, // unsupported since there is no caching here
 };
 
-
 int _gnix_open_cache(struct gnix_fid_domain *domain, int type)
 {
 	if (type < 0 || type >= GNIX_MR_MAX_TYPE)
@@ -972,7 +963,6 @@ int _gnix_open_cache(struct gnix_fid_domain *domain, int type)
 	domain->mr_cache_type = type;
 	return FI_SUCCESS;
 }
-
 
 int _gnix_flush_registration_cache(struct gnix_fid_domain *domain)
 {


### PR DESCRIPTION
Added runtime checks to domain open, endpoint open, and
mr_regattr functions to ensure that auth keys are not provided
when the application has requested api version less than 1.5

upstream merge of ofi-cray/libfabric-cray#1366

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@17be70db6e91f43bc0a7468088e4a88a82e38219)