### PR TITLE
prov/psm2: Update string address format support based on recent API c…

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -439,7 +439,7 @@ struct psmx2_ep_name {
 };
 
 struct psmx2_string_name {
-	char			s[48];		/* "psmx2://<uint64_t>:<uint64_t>" */
+	char			s[64];		/* "fi_addr_psmx2://<uint64_t>:<uint64_t>" */
 };
 
 struct psmx2_cq_event {

--- a/prov/psm2/src/psmx2_cm.c
+++ b/prov/psm2/src/psmx2_cm.c
@@ -36,50 +36,40 @@ static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 {
 	struct psmx2_fid_ep *ep;
 	struct psmx2_fid_sep *sep;
-	struct psmx2_ep_name *epname;
-	struct psmx2_ep_name tmp_epname;
+	struct psmx2_ep_name epname;
 	size_t	addr_size;
-	int addr_format;
+	int err = 0;
 
 	ep = container_of(fid, struct psmx2_fid_ep, ep.fid);
 	if (!ep->domain)
 		return -FI_EBADF;
 
-	addr_format = ep->domain->addr_format;
-	if (addr_format == FI_ADDR_STR) {
-		addr_size = sizeof(struct psmx2_string_name);
-		epname = &tmp_epname;
-	} else {
-		addr_size = sizeof(struct psmx2_ep_name);
-		epname = addr;
-	}
-
-	if (*addrlen < addr_size) {
-		*addrlen = addr_size;
-		return -FI_ETOOSMALL;
-	}
-
-	memset(epname, 0, sizeof(*epname));
+	memset(&epname, 0, sizeof(epname));
 
 	if (ep->type == PSMX2_EP_REGULAR) {
-		epname->epid = ep->trx_ctxt->psm2_epid;
-		epname->vlane = ep->vlane;
-		epname->type = ep->type;
+		epname.epid = ep->trx_ctxt->psm2_epid;
+		epname.vlane = ep->vlane;
+		epname.type = ep->type;
 	} else {
 		sep = (struct psmx2_fid_sep *)ep;
-		epname->epid = sep->domain->base_trx_ctxt->psm2_epid;
-		epname->sep_id = sep->id;
-		epname->type = sep->type;
+		epname.epid = sep->domain->base_trx_ctxt->psm2_epid;
+		epname.sep_id = sep->id;
+		epname.type = sep->type;
 	}
 
-	if (addr_format == FI_ADDR_STR) {
-		memset(addr, 0, addr_size);
-		ofi_straddr(addr, addrlen, FI_ADDR_PSMX2, epname);
+	if (ep->domain->addr_format == FI_ADDR_STR) {
+		addr_size = *addrlen;
+		ofi_straddr(addr, &addr_size, FI_ADDR_PSMX2, &epname);
+	} else {
+		addr_size = sizeof(epname);
+		memcpy(addr, &epname, MIN(*addrlen, addr_size));
 	}
+
+	if (*addrlen < addr_size)
+		err = -FI_ETOOSMALL;
 
 	*addrlen = addr_size;
-
-	return 0;
+	return err;
 }
 
 struct fi_ops_cm psmx2_cm_ops = {


### PR DESCRIPTION
…hanges

(1) Increase the maximum string length to hold the longer address format name;
(2) Interpret input addr to fi_av_insert() as "char **";
(3) Due to (2) it is no longer necessary to pad the string to a fixed length.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>