### PR TITLE
prov/gni: add version check FI_NOTIFY_FLAGS_ONLY

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -484,6 +484,9 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 				goto err;
 			}
 			mode = hints->mode & ~GNIX_FAB_MODES_CLEAR;
+			if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
+				mode = hints->mode & ~FI_NOTIFY_FLAGS_ONLY;
+			}
 		}
 
 		GNIX_DEBUG(FI_LOG_FABRIC, "Passed mode check\n");


### PR DESCRIPTION
FI_NOTIFY_FLAGS_ONLY is only allowed when used with
applications requesting version 1.5 or greater of the
gni provider. Remove that mode when returning the info
struct when returning from fi_getinfo.

Add tests that verify the fi_info->mode returned by the
provider masks off FI_NOTIFY_FLAGS_ONLY when
version requested is less than 1.5 and is not masked
off for 1.5 and greater.

upstream merge of ofi-cray/libfabric-cray#1375

Signed-off-by: James Shimek <jshimek@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@a6e924a716ab28d91e32f6912b7df1be81b9320c)