### PR TITLE
prov/sockets: add LXOR float support

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -953,6 +953,11 @@ out:
 		*_dst = *_dst && *_src;					\
 		break;							\
 									\
+	case FI_LXOR:							\
+		*_cmp = *_dst;						\
+		*_dst = ((*_dst && !*_src) || (!*_dst && *_src));	\
+		break;							\
+									\
 	case FI_ATOMIC_READ:						\
 		*_cmp = *_dst;						\
 		break;							\


### PR DESCRIPTION
According to the fi_query_atomic in sockets, LXOR with float datatypes are supported but the PE does not support it
Add LXOR-float support in the PE

Signed-off-by: aingerson <alexia.ingerson@intel.com>