### PR TITLE
prov/psm2: Code refactoring for the string address support

### DIFF
--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -332,8 +332,9 @@ out:
 					event->cqe.err.err_data = &cq->error_data;
 					event->error = !!event->cqe.err.err;
 					if (av->addr_format == FI_ADDR_STR) {
-						psmx2_get_source_string_name(source, (void *)&cq->error_data);
-						event->cqe.err.err_data_size = sizeof(struct psmx2_string_name);
+						event->cqe.err.err_data_size = PSMX2_ERR_DATA_SIZE;
+						psmx2_get_source_string_name(source, (void *)&cq->error_data,
+									     &event->cqe.err.err_data_size);
 					} else {
 						psmx2_get_source_name(source, (void *)&cq->error_data);
 						event->cqe.err.err_data_size = sizeof(struct psmx2_ep_name);
@@ -686,8 +687,10 @@ static ssize_t psmx2_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 									   event->source);
 					if (source == FI_ADDR_NOTAVAIL) {
 						if (cq_priv->domain->addr_format == FI_ADDR_STR) {
-							psmx2_get_source_string_name(event->source, (void *)&cq_priv->error_data);
-							event->cqe.err.err_data_size = sizeof(struct psmx2_string_name);
+							event->cqe.err.err_data_size = PSMX2_ERR_DATA_SIZE;
+							psmx2_get_source_string_name(event->source,
+										     (void *)&cq_priv->error_data,
+										     &event->cqe.err.err_data_size);
 						} else {
 							psmx2_get_source_name(event->source, (void *)&cq_priv->error_data);
 							event->cqe.err.err_data_size = sizeof(struct psmx2_ep_name);

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -187,6 +187,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	int tx_ctx_cnt, rx_ctx_cnt;
 	int default_multi_ep = 0;
 	int addr_format = FI_ADDR_PSMX2;
+	size_t len;
 
 	FI_INFO(&psmx2_prov, FI_LOG_CORE,"\n");
 
@@ -600,11 +601,11 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->mode = mode;
 	psmx2_info->addr_format = addr_format;
 	if (addr_format == FI_ADDR_STR) {
-		psmx2_info->src_addr = psmx2_ep_name_to_string(src_addr);
-		psmx2_info->src_addrlen = sizeof(struct psmx2_string_name);
+		psmx2_info->src_addr = psmx2_ep_name_to_string(src_addr, &len);
+		psmx2_info->src_addrlen = len;
 		free(src_addr);
-		psmx2_info->dest_addr = psmx2_ep_name_to_string(dest_addr);
-		psmx2_info->dest_addrlen = sizeof(struct psmx2_string_name);
+		psmx2_info->dest_addr = psmx2_ep_name_to_string(dest_addr, &len);
+		psmx2_info->dest_addrlen = len;
 		free(dest_addr);
 	} else {
 		psmx2_info->src_addr = src_addr;

--- a/prov/psm2/src/psmx2_util.c
+++ b/prov/psm2/src/psmx2_util.c
@@ -90,20 +90,20 @@ char *psmx2_uuid_to_string(psm2_uuid_t uuid)
 	return s;
 }
 
-void *psmx2_ep_name_to_string(const struct psmx2_ep_name *name)
+void *psmx2_ep_name_to_string(const struct psmx2_ep_name *name, size_t *len)
 {
-	struct psmx2_string_name *s;
-	size_t len;
+	char *s;
 
 	if (!name)
 		return NULL;
 
-	s = calloc(1, sizeof(*s));
+	*len = PSMX2_MAX_STRING_NAME_LEN;
+
+	s = calloc(*len, 1);
 	if (!s)
 		return NULL;
 
-	len = sizeof(*s);
-	if (!ofi_straddr((void *)s, &len, FI_ADDR_PSMX2, name)) {
+	if (!ofi_straddr((void *)s, len, FI_ADDR_PSMX2, name)) {
 		free(s);
 		return NULL;
 	}


### PR DESCRIPTION
Eliminate the string_name structure.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>