### PR TITLE
win/utils: added getifaddr implementation

### DIFF
--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -167,6 +167,9 @@
 /* Define to 1 if adapter info API is defined. */
 #define HAVE_MIB_IPADDRTABLE 1
 
+/* Define to 1 if you have the `getifaddrs' function. */
+#define HAVE_GETIFADDRS 1
+
 /* The size of `void *', as computed by sizeof. */
 #ifdef _WIN64
 #define SIZEOF_VOID_P 8

--- a/include/windows/ifaddrs.h
+++ b/include/windows/ifaddrs.h
@@ -1,4 +1,34 @@
+/*
+* Copyright (c) 2016 Intel Corporation.  All rights reserved.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+* NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+* BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+* ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*/
 
 #pragma once
 
+#include <Winsock2.h>
+
+/* here is minimal subset of ifaddr API required for sockets & UDP
+   providers */
+struct ifaddrs {
+	struct ifaddrs  *ifa_next;    /* Next item in list */
+	char            *ifa_name;    /* Name of interface */
+	unsigned int     ifa_flags;   /* Flags from SIOCGIFFLAGS */
+	struct sockaddr *ifa_addr;    /* Address of interface */
+	struct sockaddr *ifa_netmask; /* Netmask of interface */
+
+	struct sockaddr_in in_addr;
+	struct sockaddr_in in_netmask;
+	char		   ad_name[16];
+};
+
+int getifaddrs(struct ifaddrs **ifap);
+void freeifaddrs(struct ifaddrs *ifa);
 

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -439,6 +439,7 @@
     <ClInclude Include="include\rdma\providers\fi_prov.h" />
     <ClInclude Include="include\windows\arpa\inet.h" />
     <ClInclude Include="include\windows\config.h" />
+    <ClInclude Include="include\windows\ifaddrs.h" />
     <ClInclude Include="include\windows\netinet\in.h" />
     <ClInclude Include="include\windows\netinet\ip.h" />
     <ClInclude Include="include\windows\netinet\tcp.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -285,7 +285,7 @@
     <ClCompile Include="prov\rxm\src\rxm_init.c">
       <Filter>Source Files\prov\rxm\src</Filter>
     </ClCompile>
-     <ClCompile Include="prov\rxm\src\rxm_rma.c">
+    <ClCompile Include="prov\rxm\src\rxm_rma.c">
       <Filter>Source Files\prov\rxm\src</Filter>
     </ClCompile>
     <ClCompile Include="src\iov.c">
@@ -532,6 +532,9 @@
     </ClInclude>
     <ClInclude Include="include\windows\sys\wait.h">
       <Filter>Header Files\windows\sys</Filter>
+    </ClInclude>
+    <ClInclude Include="include\windows\ifaddrs.h">
+      <Filter>Header Files\windows</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- added implementation of Linux call 'getifaddr' to
  Windows part, also added "struct ifaddrs" datatype
  and implementation of 'freeifaddrs'
- added header file where interfaces are declared
- all changes are windows specific

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>