### PR TITLE
common: Add new address format

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -178,6 +178,7 @@ enum {
 	FI_ADDR_MLX,
 	FI_ADDR_STR,		/* formatted char * */
 	FI_ADDR_PSMX2,		/* uint64_t[2] */
+	FI_ADDR_IB_UD,		/* uint64_t[4] */
 };
 
 #define FI_ADDR_UNSPEC		((uint64_t) -1)


### PR DESCRIPTION
The new address format consists from the LID, GID, QP number to be able communicate through verbs/UD
It is needed for the verbs provider with DGRAM EP type

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>