### PR TITLE
Revert "prov/bgq: Store msg data in context for fi_trecvmsg implementation"

### DIFF
--- a/prov/bgq/include/rdma/fi_direct_tagged.h
+++ b/prov/bgq/include/rdma/fi_direct_tagged.h
@@ -98,7 +98,6 @@ ssize_t fi_bgq_trecvmsg_generic (struct fid_ep *ep,
 			bgq_context->tag = msg->tag;
 			bgq_context->ignore = msg->ignore;
 			bgq_context->src_addr = (fi_addr_t ) (msg->addr);
-			bgq_context->data = msg->data;
 		}
 
 		context_rsh3b = (uint64_t)bgq_context >> 3;
@@ -118,7 +117,6 @@ ssize_t fi_bgq_trecvmsg_generic (struct fid_ep *ep,
 			bgq_context->tag = msg->tag;
 			bgq_context->ignore = msg->ignore;
 			bgq_context->src_addr = (fi_addr_t ) (msg->addr);
-			bgq_context->data = msg->data;
 		}
 
 		context_rsh3b = (uint64_t)bgq_context >> 3;
@@ -134,7 +132,6 @@ ssize_t fi_bgq_trecvmsg_generic (struct fid_ep *ep,
 		ext->bgq_context.byte_counter = (uint64_t)-1;
 		ext->bgq_context.tag = msg->tag;
 		ext->bgq_context.src_addr = (fi_addr_t ) (msg->addr);
-		ext->bgq_context.data = msg->data;
 		ext->bgq_context.ignore = msg->ignore;
 		ext->msg.op_context = msg->context;
 		ext->msg.iov_count = msg->iov_count;


### PR DESCRIPTION
Reverts ofiwg/libfabric#3008 - Based on response from Paul.