### PR TITLE
prov/psm2: Add option to adjust the locking level

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -86,7 +86,7 @@ The *psm2* provider checks for the following environment variables:
 : The *psm2* provider has a simple built-in name server that can be used
   to resolve an IP address or host name into a transport address needed
   by the *fi_av_insert* call. The main purpose of this name server is to
-  allow simple client-server type applications (such as those in *fabtest*)
+  allow simple client-server type applications (such as those in *fabtests*)
   to be written purely with libfabric, without using any out-of-band
   communication mechanism. For such applications, the server would run first,
   and the client would call *fi_getinfo* with the *node* parameter set to
@@ -113,7 +113,7 @@ The *psm2* provider checks for the following environment variables:
   be pipe-lined. However, the bandwidth is sub-optimal by doing this way.
 
   The *psm2* provider use PSM tag-matching message queue functions to achieve
-  higher bandwidth for large size RMA. It takes avdantage of the extra tag bits
+  higher bandwidth for large size RMA. It takes advantage of the extra tag bits
   available in PSM2 to separate the RMA traffic from the regular tagged message
   queue.
    
@@ -136,7 +136,7 @@ The *psm2* provider checks for the following environment variables:
   a progress thread is created to make progress calls from time to time.
   This option set the interval (microseconds) between progress calls.
 
-  The default setting is 1 if affininty is set, or 1000 if not. See
+  The default setting is 1 if affinity is set, or 1000 if not. See
   *FI_PSM2_PROG_AFFINITY*.
 
 *FI_PSM2_PROG_AFFINITY*
@@ -156,6 +156,19 @@ The *psm2* provider checks for the following environment variables:
   for RMA operations is still limited to the default setting.
 
   The default setting is 64.
+
+*FI_PSM2_LOCK_LEVEL*
+: When set, dictate the level of locking being used by the provider. Level
+  2 means all locks are enabled. Level 1 disables some locks and is suitable
+  for runs that limit the access to each PSM2 context to a single thread.
+  Level 0 disables all locks and thus is only suitable for single threaded
+  runs.
+
+  To use level 0 or level 1, wait object and auto progress mode cannot be
+  used because they introduce internal threads that may break the conditions
+  needed for these levels.
+
+  The default setting is 2.
 
 # SEE ALSO
 

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -163,10 +163,10 @@ static inline size_t psmx2_ioc_size(const struct fi_ioc *ioc, size_t count,
 			int i; \
 			TYPE *d = (dst); \
 			TYPE *r = (res); \
-			fastlock_acquire(&psmx2_atomic_lock); \
+			psmx2_lock(&psmx2_atomic_lock, 1); \
 			for (i=0; i<(cnt); i++) \
 				r[i] = d[i]; \
-			fastlock_release(&psmx2_atomic_lock); \
+			psmx2_unlock(&psmx2_atomic_lock, 1); \
 		} while (0)
 
 #define PSMX2_ATOMIC_WRITE(dst,src,cnt,OP,TYPE) \
@@ -174,10 +174,10 @@ static inline size_t psmx2_ioc_size(const struct fi_ioc *ioc, size_t count,
 			int i; \
 			TYPE *d = (dst); \
 			TYPE *s = (src); \
-			fastlock_acquire(&psmx2_atomic_lock); \
+			psmx2_lock(&psmx2_atomic_lock, 1); \
 			for (i=0; i<cnt; i++) \
 				OP(d[i],s[i]); \
-			fastlock_release(&psmx2_atomic_lock); \
+			psmx2_unlock(&psmx2_atomic_lock, 1); \
 		} while (0)
 
 #define PSMX2_ATOMIC_READWRITE(dst,src,res,cnt,OP,TYPE) \
@@ -186,12 +186,12 @@ static inline size_t psmx2_ioc_size(const struct fi_ioc *ioc, size_t count,
 			TYPE *d = (dst); \
 			TYPE *s = (src); \
 			TYPE *r = (res); \
-			fastlock_acquire(&psmx2_atomic_lock); \
+			psmx2_lock(&psmx2_atomic_lock, 1); \
 			for (i=0; i<(cnt); i++) {\
 				r[i] = d[i]; \
 				OP(d[i],s[i]); \
 			} \
-			fastlock_release(&psmx2_atomic_lock); \
+			psmx2_unlock(&psmx2_atomic_lock, 1); \
 		} while (0)
 
 #define PSMX2_ATOMIC_CSWAP(dst,src,cmp,res,cnt,CMP_OP,TYPE) \
@@ -201,13 +201,13 @@ static inline size_t psmx2_ioc_size(const struct fi_ioc *ioc, size_t count,
 			TYPE *s = (src); \
 			TYPE *c = (cmp); \
 			TYPE *r = (res); \
-			fastlock_acquire(&psmx2_atomic_lock); \
+			psmx2_lock(&psmx2_atomic_lock, 1); \
 			for (i=0; i<(cnt); i++) { \
 				r[i] = d[i]; \
 				if (c[i] CMP_OP d[i]) \
 					d[i] = s[i]; \
 			} \
-			fastlock_release(&psmx2_atomic_lock); \
+			psmx2_unlock(&psmx2_atomic_lock, 1); \
 		} while (0)
 
 #define PSMX2_ATOMIC_MSWAP(dst,src,cmp,res,cnt,TYPE) \
@@ -217,12 +217,12 @@ static inline size_t psmx2_ioc_size(const struct fi_ioc *ioc, size_t count,
 			TYPE *s = (src); \
 			TYPE *c = (cmp); \
 			TYPE *r = (res); \
-			fastlock_acquire(&psmx2_atomic_lock); \
+			psmx2_lock(&psmx2_atomic_lock, 1); \
 			for (i=0; i<(cnt); i++) { \
 				r[i] = d[i]; \
 				d[i] = (s[i] & c[i]) | (d[i] & ~c[i]); \
 			} \
-			fastlock_release(&psmx2_atomic_lock); \
+			psmx2_unlock(&psmx2_atomic_lock, 1); \
 		} while (0)
 
 static int psmx2_atomic_do_write(void *dest, void *src,

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -98,7 +98,7 @@ int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
 	switch (cmd) {
 	case PSMX2_AM_REQ_SEP_QUERY:
 		sep_id = args[0].u32w1;
-		fastlock_acquire(&domain->sep_lock);
+		psmx2_lock(&domain->sep_lock, 1);
 		entry = dlist_find_first_match(&domain->sep_list, psmx2_am_sep_match,
 					       (void *)(uintptr_t)sep_id);
 		if (!entry) {
@@ -120,7 +120,7 @@ int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
 					buf[i] = sep->ctxts[i].trx_ctxt->psm2_epid;
 			}
 		}
-		fastlock_release(&domain->sep_lock);
+		psmx2_unlock(&domain->sep_lock, 1);
 
 		rep_args[0].u32w0 = PSMX2_AM_REP_SEP_QUERY;
 		rep_args[0].u32w1 = op_error;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -51,6 +51,7 @@ struct psmx2_env psmx2_env = {
 	.max_trx_ctxt	= 1,
 	.num_devunits	= 1,
 	.inject_size	= PSMX2_INJECT_SIZE,
+	.lock_level	= 2,
 };
 
 static void psmx2_init_env(void)
@@ -66,6 +67,7 @@ static void psmx2_init_env(void)
 	fi_param_get_int(&psmx2_prov, "prog_interval", &psmx2_env.prog_interval);
 	fi_param_get_str(&psmx2_prov, "prog_affinity", &psmx2_env.prog_affinity);
 	fi_param_get_int(&psmx2_prov, "inject_size", &psmx2_env.inject_size);
+	fi_param_get_bool(&psmx2_prov, "lock_level", &psmx2_env.lock_level);
 }
 
 static int psmx2_check_sep_cap(void)
@@ -763,6 +765,9 @@ PROVIDER_INI
 
 	fi_param_define(&psmx2_prov, "inject_size", FI_PARAM_INT,
 			"Maximum message size for fi_inject and fi_tinject (default: 64).");
+
+	fi_param_define(&psmx2_prov, "lock_level", FI_PARAM_INT,
+			"How internal locking is used. 0 means no locking. (default: 2).");
 
 	pthread_mutex_init(&psmx2_lib_mutex, NULL);
 	psmx2_init_count++;

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -38,14 +38,14 @@ struct psmx2_fid_mr *psmx2_mr_get(struct psmx2_fid_domain *domain,
 	RbtIterator it;
 	struct psmx2_fid_mr *mr = NULL;
 
-	fastlock_acquire(&domain->mr_lock);
+	psmx2_lock(&domain->mr_lock, 1);
 	it = rbtFind(domain->mr_map, (void *)key);
 	if (!it)
 		goto exit;
 
 	rbtKeyValue(domain->mr_map, it, (void **)&key, (void **)&mr);
 exit:
-	fastlock_release(&domain->mr_lock);
+	psmx2_unlock(&domain->mr_lock, 1);
 	return mr;
 }
 
@@ -54,11 +54,11 @@ static inline void psmx2_mr_release_key(struct psmx2_fid_domain *domain,
 {
 	RbtIterator it;
 
-	fastlock_acquire(&domain->mr_lock);
+	psmx2_lock(&domain->mr_lock, 1);
 	it = rbtFind(domain->mr_map, (void *)key);
 	if (it)
 		rbtErase(domain->mr_map, it);
-	fastlock_release(&domain->mr_lock);
+	psmx2_unlock(&domain->mr_lock, 1);
 }
 
 static int psmx2_mr_reserve_key(struct psmx2_fid_domain *domain,
@@ -71,7 +71,7 @@ static int psmx2_mr_reserve_key(struct psmx2_fid_domain *domain,
 	int try_count;
 	int err = -FI_ENOKEY;
 
-	fastlock_acquire(&domain->mr_lock);
+	psmx2_lock(&domain->mr_lock, 1);
 
 	if (domain->mr_mode == FI_MR_BASIC) {
 		key = domain->mr_reserved_key;
@@ -93,7 +93,7 @@ static int psmx2_mr_reserve_key(struct psmx2_fid_domain *domain,
 		}
 	}
 
-	fastlock_release(&domain->mr_lock);
+	psmx2_unlock(&domain->mr_lock, 1);
 
 	return err;
 }

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -35,9 +35,9 @@
 static inline void psmx2_am_enqueue_rma(struct psmx2_trx_ctxt *trx_ctxt,
 				        struct psmx2_am_request *req)
 {
-	fastlock_acquire(&trx_ctxt->rma_queue.lock);
+	psmx2_lock(&trx_ctxt->rma_queue.lock, 2);
 	slist_insert_tail(&req->list_entry, &trx_ctxt->rma_queue.list);
-	fastlock_release(&trx_ctxt->rma_queue.lock);
+	psmx2_unlock(&trx_ctxt->rma_queue.lock, 2);
 }
 
 static inline void psmx2_iov_copy(struct iovec *iov, size_t count,


### PR DESCRIPTION
Allows the user to disable part or all of the internal locks used by the provider to achieve better performance. Certain conditions need to be met to maintain correctness, which are described in the updated man page.