### PR TITLE
Update connection management in util and rxm provider

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,7 +48,7 @@ common_srcs = \
 	prov/util/src/util_av.c     \
 	prov/util/src/util_cq.c     \
 	prov/util/src/util_domain.c \
-	prov/util/src/util_ep.c \
+	prov/util/src/util_ep.c     \
 	prov/util/src/util_eq.c     \
 	prov/util/src/util_fabric.c \
 	prov/util/src/util_main.c   \

--- a/include/fi.h
+++ b/include/fi.h
@@ -185,6 +185,12 @@ uint64_t fi_gettime_us(void);
 #define AF_IB 27
 #endif
 
+#define ofi_sin_addr(addr) (((struct sockaddr_in *)(addr))->sin_addr)
+#define ofi_sin_port(addr) (((struct sockaddr_in *)(addr))->sin_port)
+
+#define ofi_sin6_addr(addr) (((struct sockaddr_in6 *)(addr))->sin6_addr)
+#define ofi_sin6_port(addr) (((struct sockaddr_in6 *)(addr))->sin6_port)
+
 static inline size_t ofi_sizeofaddr(const struct sockaddr *address)
 {
 	return (address->sa_family == AF_INET ?
@@ -226,6 +232,8 @@ const char *ofi_straddr(char *buf, size_t *len,
 int ofi_str_toaddr(const char *str, uint32_t *addr_format,
 		   void **addr, size_t *len);
 
+int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
+		const struct sockaddr *sa2);
 /*
  * Key Index
  */

--- a/include/fi.h
+++ b/include/fi.h
@@ -191,6 +191,8 @@ uint64_t fi_gettime_us(void);
 #define ofi_sin6_addr(addr) (((struct sockaddr_in6 *)(addr))->sin6_addr)
 #define ofi_sin6_port(addr) (((struct sockaddr_in6 *)(addr))->sin6_port)
 
+#define OFI_ADDRSTRLEN (INET6_ADDRSTRLEN + 50)
+
 static inline size_t ofi_sizeofaddr(const struct sockaddr *address)
 {
 	return (address->sa_family == AF_INET ?

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -92,9 +92,6 @@
 	OFI_Q_READERR(prov, log, eq, "eq", fi_eq_readerr, 	\
 			fi_eq_strerror, ret, err_entry)
 
-#define ofi_sin_addr(addr) (((struct sockaddr_in *)(addr))->sin_addr)
-#define ofi_sin6_addr(addr) (((struct sockaddr_in6 *)(addr))->sin6_addr)
-
 #define FI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type)	\
 	do {										\
 		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",			\

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -745,7 +745,7 @@ ssize_t rxd_ep_connect(struct rxd_ep *ep, struct rxd_peer *peer, fi_addr_t addr)
 	dlist_insert_tail(&pkt_meta->entry, &tx_entry->pkt_list);
 	dlist_insert_tail(&tx_entry->entry, &ep->tx_entry_list);
 	peer->nxt_msg_id++;
-	peer->state = CMAP_CONNECTING;
+	peer->state = CMAP_CONNREQ_SENT;
 	return 0;
 err:
 	rxd_tx_entry_free(ep, tx_entry);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -37,7 +37,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
@@ -112,8 +111,6 @@ extern struct fi_ops_rma rxm_ops_rma;
 struct rxm_fabric {
 	struct util_fabric util_fabric;
 	struct fid_fabric *msg_fabric;
-	struct fid_eq *msg_eq;
-	pthread_t msg_listener_thread;
 };
 
 struct rxm_conn {
@@ -286,6 +283,7 @@ struct rxm_ep {
 	struct fi_info *rxm_info;
 	struct fi_info *msg_info;
 	struct fid_pep *msg_pep;
+	struct fid_eq *msg_eq;
 	struct fid_cq *msg_cq;
 	struct fid_ep *srx_ctx;
 	size_t comp_per_progress;
@@ -347,13 +345,15 @@ int rxm_cq_handle_data(struct rxm_rx_buf *rx_buf);
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  struct fid_ep **ep, void *context);
 
-void *rxm_msg_listener(void *arg);
-int rxm_msg_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
-		struct fi_info *msg_info);
-int rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
+void *rxm_conn_event_handler(void *arg);
+int rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
+		    fi_addr_t fi_addr);
+int rxm_conn_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 		void *data);
-void rxm_conn_close(void *arg);
-int rxm_get_conn(struct rxm_ep *rxm_ep, fi_addr_t fi_addr, struct rxm_conn **rxm_conn);
+struct util_cmap_handle *rxm_conn_alloc(void);
+void rxm_conn_close(struct util_cmap_handle *handle);
+void rxm_conn_free(struct util_cmap_handle *handle);
+int rxm_conn_signal(struct util_ep *util_ep);
 
 int rxm_ep_repost_buf(struct rxm_rx_buf *buf);
 int ofi_match_addr(fi_addr_t addr, fi_addr_t match_addr);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -33,28 +33,26 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <fi.h>
 #include <fi_util.h>
 #include "rxm.h"
 
-int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
-		struct rxm_conn *rxm_conn)
+static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
+			   struct rxm_conn *rxm_conn, void *context)
 {
 	struct rxm_domain *rxm_domain;
-	struct rxm_fabric *rxm_fabric;
 	struct fid_ep *msg_ep;
 	int ret;
 
 	rxm_domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain,
 			util_domain);
-	rxm_fabric = container_of(rxm_domain->util_domain.fabric, struct rxm_fabric,
-			util_fabric);
-	ret = fi_endpoint(rxm_domain->msg_domain, msg_info, &msg_ep, rxm_conn);
+	ret = fi_endpoint(rxm_domain->msg_domain, msg_info, &msg_ep, context);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to create msg_ep\n");
 		return ret;
 	}
 
-	ret = fi_ep_bind(msg_ep, &rxm_fabric->msg_eq->fid, 0);
+	ret = fi_ep_bind(msg_ep, &rxm_ep->msg_eq->fid, 0);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_FABRIC, "Unable to bind msg EP to EQ\n");
 		goto err;
@@ -79,7 +77,6 @@ int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to enable msg_ep\n");
 		goto err;
 	}
-
 	rxm_conn->msg_ep = msg_ep;
 	return 0;
 err:
@@ -87,53 +84,52 @@ err:
 	return ret;
 }
 
-void rxm_conn_close(void *arg)
+void rxm_conn_close(struct util_cmap_handle *handle)
 {
-	struct util_cmap_handle *handle = (struct util_cmap_handle *)arg;
 	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
-	int ret;
+	if (!rxm_conn->msg_ep)
+		return;
 
-	if ((rxm_conn->handle.state == CMAP_UNSPEC) || !rxm_conn->msg_ep)
-		goto out;
+	/* Assuming fi_close also shuts down the connection gracefully if the
+	 * endpoint is in connected state */
+	if (fi_close(&rxm_conn->msg_ep->fid))
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to close msg_ep\n");
+	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "Closed msg_ep\n");
+	rxm_conn->msg_ep = NULL;
+}
 
-	if (rxm_conn->handle.state == CMAP_CONNECTED) {
-		ret = fi_shutdown(rxm_conn->msg_ep, 0);
-		if (ret)
-			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-					"Unable to close connection\n");
-	}
-	ret = fi_close(&rxm_conn->msg_ep->fid);
-	if (ret)
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-				"Unable to close msg_ep\n");
-out:
-	free(rxm_conn);
+void rxm_conn_free(struct util_cmap_handle *handle)
+{
+	rxm_conn_close(handle);
+	free(container_of(handle, struct rxm_conn, handle));
+}
+
+struct util_cmap_handle *rxm_conn_alloc(void)
+{
+	struct rxm_conn *rxm_conn = calloc(1, sizeof(*rxm_conn));
+	return rxm_conn ? &rxm_conn->handle : NULL;
 }
 
 int rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
-		void *data)
+			    void *data)
 {
 	struct rxm_conn *rxm_conn;
 	struct rxm_cm_data *remote_cm_data = data;
 	struct rxm_cm_data cm_data;
+	struct util_cmap_handle *handle;
 	int ret;
 
-	if  (!(rxm_conn = calloc(1, sizeof(*rxm_conn)))) {
-		ret = -FI_ENOMEM;
+	ret = ofi_cmap_process_connreq(rxm_ep->util_ep.cmap,
+				       &remote_cm_data->name, &handle);
+	if (ret)
 		goto err1;
-	}
 
-	ret = ofi_cmap_add_handle(rxm_ep->util_ep.cmap, &rxm_conn->handle, CMAP_CONNECTING,
-			FI_ADDR_UNSPEC, &remote_cm_data->name,
-			sizeof(remote_cm_data->name));
-	if (ret) {
-		FI_WARN(&rxm_prov, FI_LOG_FABRIC, "Unable to add handle/peer\n");
-		goto err2;
-	}
+	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	rxm_conn->handle.remote_key = remote_cm_data->conn_id;
 
-	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn);
+	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn,
+			      (void *)rxm_conn->handle.key);
 	if (ret)
 		goto err2;
 
@@ -149,38 +145,24 @@ int rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 err2:
 	ofi_cmap_del_handle(&rxm_conn->handle);
 err1:
+	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL,
+		"Rejecting incoming connection request\n");
 	if (fi_reject(rxm_ep->msg_pep, msg_info->handle, NULL, 0))
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 				"Unable to reject incoming connection\n");
 	return ret;
 }
 
-static void rxm_msg_process_connect_event(fid_t fid, void *data, size_t datalen)
-{
-	struct rxm_conn *rxm_conn = (struct rxm_conn *)fid->context;
-	struct rxm_cm_data *cm_data;
-	ofi_cmap_update_state(&rxm_conn->handle, CMAP_CONNECTED);
-	if (datalen) {
-		cm_data = data;
-		rxm_conn->handle.remote_key = cm_data->conn_id;
-	}
-}
-static void rxm_msg_process_shutdown_event(fid_t fid)
-{
-	// TODO process shutdown - need to diff local and remote shutdown
-	return;
-}
-
-void *rxm_msg_listener(void *arg)
+void *rxm_conn_event_handler(void *arg)
 {
 	struct fi_eq_cm_entry *entry;
 	struct fi_eq_err_entry err_entry;
 	size_t datalen = sizeof(struct rxm_cm_data);
 	size_t len = sizeof(*entry) + datalen;
-	struct rxm_fabric *rxm_fabric = (struct rxm_fabric *)arg;
+	struct rxm_ep *rxm_ep = container_of(arg, struct rxm_ep, util_ep);
+	struct rxm_cm_data *cm_data;
 	uint32_t event;
 	ssize_t rd;
-	int ret;
 
 	entry = calloc(1, len);
 	if (!entry) {
@@ -188,51 +170,60 @@ void *rxm_msg_listener(void *arg)
 		return NULL;
 	}
 
-	FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Starting MSG listener thread\n");
+	FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Starting conn event handler\n");
 	while (1) {
-		rd = fi_eq_sread(rxm_fabric->msg_eq, &event, entry, len, -1, 0);
+		rd = fi_eq_sread(rxm_ep->msg_eq, &event, entry, len, -1, 0);
 		/* We would receive more bytes than sizeof *entry during CONNREQ */
 		if (rd < 0) {
 			if (rd == -FI_EAVAIL)
 				OFI_EQ_READERR(&rxm_prov, FI_LOG_FABRIC,
-						rxm_fabric->msg_eq, rd, err_entry);
+						rxm_ep->msg_eq, rd, err_entry);
 			else
 				FI_WARN(&rxm_prov, FI_LOG_FABRIC,
 						"msg: unable to fi_eq_sread\n");
+			if (err_entry.err == ECONNREFUSED) {
+				FI_DBG(&rxm_prov, FI_LOG_FABRIC,
+				       "Connection refused\n");
+				ofi_cmap_process_reject(rxm_ep->util_ep.cmap,
+							(uint64_t)err_entry.fid->context);
+			}
 			continue;
 		}
 
 		switch(event) {
 		case FI_NOTIFY:
-			FI_TRACE(&rxm_prov, FI_LOG_FABRIC, "Closing rxm msg listener\n");
+			FI_TRACE(&rxm_prov, FI_LOG_FABRIC,
+				 "Closing conn event handler");
 			free(entry);
 			return NULL;
 		case FI_CONNREQ:
 			if (rd != len)
-				goto err;
-			FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Got new connection\n");
-			ret = rxm_msg_process_connreq(entry->fid->context, entry->info,
-					entry->data);
-			if (ret)
 				FI_WARN(&rxm_prov, FI_LOG_FABRIC,
-						"Unable to process connection request\n");
+					"Received size (%d) not matching "
+					"expected (%d)\n", rd, len);
+			FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Got new connection\n");
+			cm_data = (void *)entry->data;
+			rxm_msg_process_connreq(rxm_ep, entry->info, entry->data);
 			break;
 		case FI_CONNECTED:
-			FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Connected\n");
-			rxm_msg_process_connect_event(entry->fid, entry->data,
-					rd - sizeof(*entry));
+			FI_DBG(&rxm_prov, FI_LOG_FABRIC,
+			       "Connection successful\n");
+			cm_data = (void *)entry->data;
+			ofi_cmap_process_connect(rxm_ep->util_ep.cmap,
+						 (uint64_t)entry->fid->context,
+						 (rd - sizeof(*entry)) ?
+						 &cm_data->conn_id : NULL);
 			break;
 		case FI_SHUTDOWN:
-			FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Received connection shutdown\n");
-			rxm_msg_process_shutdown_event(entry->fid);
+			FI_DBG(&rxm_prov, FI_LOG_FABRIC,
+			       "Received connection shutdown\n");
+			ofi_cmap_process_shutdown(rxm_ep->util_ep.cmap,
+						  (uint64_t)entry->fid->context);
 			break;
 		default:
-			FI_WARN(&rxm_prov, FI_LOG_FABRIC, "Unknown event: %u\n", event);
+			FI_WARN(&rxm_prov, FI_LOG_FABRIC,
+				"Unknown event: %u\n", event);
 		}
-		continue;
-err:
-		FI_WARN(&rxm_prov, FI_LOG_FABRIC,
-				"Received size (%d) not matching expected (%d)\n", rd, len);
 	}
 }
 
@@ -266,38 +257,34 @@ static int rxm_prepare_cm_data(struct fid_pep *pep, struct util_cmap_handle *han
 	return 0;
 }
 
-int rxm_msg_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
-		struct fi_info *msg_hints)
+int rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
+		    fi_addr_t fi_addr)
 {
+	struct rxm_ep *rxm_ep;
 	struct rxm_conn *rxm_conn;
 	struct fi_info *msg_info;
 	struct rxm_cm_data cm_data;
 	int ret;
 
-	assert(!msg_hints->dest_addr);
+	rxm_ep = container_of(util_ep, struct rxm_ep, util_ep);
 
-	msg_hints->dest_addrlen = rxm_ep->util_ep.av->addrlen;
-	msg_hints->dest_addr = mem_dup(ofi_av_get_addr(rxm_ep->util_ep.av,
-				fi_addr), msg_hints->dest_addrlen);
+	rxm_conn = container_of(handle, struct rxm_conn, handle);
+
+	free(rxm_ep->msg_info->dest_addr);
+	rxm_ep->msg_info->dest_addrlen = rxm_ep->util_ep.av->addrlen;
+	rxm_ep->msg_info->dest_addr = mem_dup(ofi_av_get_addr(rxm_ep->util_ep.av,
+							      fi_addr),
+					      rxm_ep->util_ep.av->addrlen);
 
 	ret = fi_getinfo(rxm_ep->util_ep.domain->fabric->fabric_fid.api_version,
-			 NULL, NULL, 0, msg_hints, &msg_info);
+			 NULL, NULL, 0, rxm_ep->msg_info, &msg_info);
 	if (ret)
 		return ret;
 
-	if  (!(rxm_conn = calloc(1, sizeof(*rxm_conn)))) {
-		ret = -FI_ENOMEM;
+	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn,
+			      (void *)rxm_conn->handle.key);
+	if (ret)
 		goto err1;
-	}
-
-	ret = ofi_cmap_add_handle(rxm_ep->util_ep.cmap, &rxm_conn->handle,
-			CMAP_CONNECTING, fi_addr, NULL, 0);
-	if (ret)
-		goto err2;
-
-	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn);
-	if (ret)
-		goto err2;
 
 	/* We have to send passive endpoint's address to the server since the
 	 * address from which connection request would be sent would have a
@@ -314,43 +301,23 @@ int rxm_msg_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
 	fi_freeinfo(msg_info);
 	return 0;
 err2:
-	ofi_cmap_del_handle(&rxm_conn->handle);
+	fi_close(&rxm_conn->msg_ep->fid);
+	rxm_conn->msg_ep = NULL;
 err1:
 	fi_freeinfo(msg_info);
 	return ret;
 }
 
-int rxm_get_conn(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
-		struct rxm_conn **rxm_conn)
+int rxm_conn_signal(struct util_ep *util_ep)
 {
-	struct util_cmap_handle *handle;
+	struct rxm_ep *rxm_ep = container_of(util_ep, struct rxm_ep, util_ep);
+	struct fi_eq_entry entry = {0};
+	ssize_t rd;
 
-	if (fi_addr > rxm_ep->util_ep.av->count) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Invalid fi_addr\n");
-		return -FI_EINVAL;
+	rd = fi_eq_write(rxm_ep->msg_eq, FI_NOTIFY, &entry, sizeof(entry), 0);
+	if (rd != sizeof(entry)) {
+		FI_WARN(&rxm_prov, FI_LOG_FABRIC, "Unable to signal\n");
+		return (int)rd;
 	}
-
-	handle = ofi_cmap_get_handle(rxm_ep->util_ep.cmap, fi_addr);
-	if (!handle)
-		goto connect;
-
-	switch (handle->state) {
-	case CMAP_CONNECTING:
-		return -FI_EAGAIN;
-	case CMAP_CONNECTED:
-		*rxm_conn = container_of(handle, struct rxm_conn, handle);
-		return 0;
-	default:
-		/* We shouldn't be here */
-		assert(0);
-	}
-
-connect:
-	if (rxm_msg_connect(rxm_ep, fi_addr, rxm_ep->msg_info)) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_DATA, "Unable to connect\n");
-		return -FI_EOTHER;
-	}
-	return -FI_EAGAIN;
+	return 0;
 }
-
-

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -82,15 +82,17 @@ err:
 ssize_t	rxm_ep_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		       uint64_t flags)
 {
+	struct util_cmap_handle *handle;
 	struct rxm_conn *rxm_conn;
 	struct rxm_ep *rxm_ep;
 	int ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 
-	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
+	ret = ofi_cmap_get_handle(rxm_ep->util_ep.cmap, msg->addr, &handle);
 	if (ret)
 		return ret;
+	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	return rxm_ep_rma_common(rxm_conn->msg_ep, rxm_ep, msg, flags,
 				 fi_readmsg);
@@ -225,15 +227,17 @@ err1:
 ssize_t	rxm_ep_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 			uint64_t flags)
 {
+	struct util_cmap_handle *handle;
 	struct rxm_conn *rxm_conn;
 	struct rxm_ep *rxm_ep;
 	int ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 
-	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
+	ret = ofi_cmap_get_handle(rxm_ep->util_ep.cmap, msg->addr, &handle);
 	if (ret)
 		return ret;
+	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	if (flags & FI_INJECT)
 		return rxm_ep_rma_inject(rxm_conn->msg_ep, rxm_ep, msg, flags);

--- a/src/common.c
+++ b/src/common.c
@@ -446,6 +446,30 @@ int ofi_str_toaddr(const char *str, uint32_t *addr_format,
 	return 0;
 }
 
+int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
+		 const struct sockaddr *sa2)
+{
+	int cmp;
+
+	switch (sa1->sa_family) {
+	case AF_INET:
+		cmp = memcmp(&ofi_sin_addr(sa1), &ofi_sin_addr(sa2),
+			     sizeof(ofi_sin_addr(sa1)));
+		return cmp ? cmp : memcmp(&ofi_sin_port(sa1),
+					  &ofi_sin_port(sa2),
+					  sizeof(ofi_sin_port(sa1)));
+	case AF_INET6:
+		cmp = memcmp(&ofi_sin6_addr(sa1), &ofi_sin6_addr(sa2),
+			     sizeof(ofi_sin6_addr(sa1)));
+		return cmp ? cmp : memcmp(&ofi_sin6_port(sa1),
+					  &ofi_sin_port(sa2),
+					  sizeof(ofi_sin6_port(sa1)));
+	default:
+		FI_WARN(prov, FI_LOG_FABRIC, "Invalid address format!\n");
+		assert(0);
+		return 0;
+	}
+}
 
 #ifndef HAVE_EPOLL
 


### PR DESCRIPTION
- common: Add a function to compare addresses	
- util: Augment cmap to handle additional states.
- rxm: Pass handle key as context for connection handling to avoid NULL
  pointer dereferences.
- rxm: Make the listener thread per endpoint to simplify processing connection
  events