### PR TITLE
Change utility provider names' prefix

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -648,7 +648,7 @@ int ofi_get_core_info_fabric(struct fi_fabric_attr *util_attr,
 
 
 #define OFI_NAME_DELIM	';'
-#define OFI_UTIL_PREFIX "ofi-"
+#define OFI_UTIL_PREFIX "ofi_"
 
 char *ofi_strdup_append(const char *head, const char *tail);
 // char *ofi_strdup_head(const char *str);

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -70,7 +70,7 @@ static void rxd_fini(void)
 }
 
 struct fi_provider rxd_prov = {
-	.name = "ofi-rxd",
+	.name = OFI_UTIL_PREFIX "rxd",
 	.version = FI_VERSION(RXD_MAJOR_VERSION, RXD_MINOR_VERSION),
 	.fi_version = RXD_FI_VERSION,
 	.getinfo = rxd_getinfo,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -145,7 +145,7 @@ static void rxm_fini(void)
 }
 
 struct fi_provider rxm_prov = {
-	.name = "ofi-rxm",
+	.name = OFI_UTIL_PREFIX "rxm",
 	.version = FI_VERSION(RXM_MAJOR_VERSION, RXM_MINOR_VERSION),
 	.fi_version = FI_VERSION(1, 5),
 	.getinfo = rxm_getinfo,


### PR DESCRIPTION
Change the prefix from "ofi-" to "ofi_" to allow valid env variable names
libfabric constructs a provider specific env variable by prefixing the provider
name to the variable name.