### PR TITLE
prov/gni: Refactor GNI provider FI_MULTI_RECV

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -277,6 +277,12 @@ address format. In order to populate the remote peer's address vector
 with this mechanism, the application must call fi_cq_readerr to get the
 source address followed by fi_av_insert on the populated err_data member.
 
+For FI_MULTI_RECV, the GNI provider generates a separate FI_MULTI_RECV CQ event
+once the receive buffer has been consumed.  Also, owing to the out-or-order nature
+of the Cray network, the CQ events associated with individual messages arriving in the
+receive buffer may be generated out of order with respect to the offset into the buffer
+into which the messages were received.
+
 # KNOWN BUGS
 
 The GNI provider currently treats the fi_shutdown() interface as a strictly

--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -154,7 +154,6 @@
 
 #define GNIX_MSG_RENDEZVOUS		(1ULL << 61)	/* MSG only flag */
 #define GNIX_MSG_GET_TAIL		(1ULL << 62)	/* MSG only flag */
-#define GNIX_MSG_MULTI_RECV_SUP		(1ULL << 63)	/* MSG only flag */
 
 /*
  * Cray gni provider supported flags for fi_getinfo argument for now, needs
@@ -718,6 +717,7 @@ enum gnix_fab_req_type {
 	GNIX_FAB_RQ_RECVV,
 	GNIX_FAB_RQ_TRECV,
 	GNIX_FAB_RQ_TRECVV,
+	GNIX_FAB_RQ_MRECV,
 	GNIX_FAB_RQ_AMO,
 	GNIX_FAB_RQ_FAMO,
 	GNIX_FAB_RQ_CAMO,
@@ -756,6 +756,9 @@ struct gnix_fab_req_msg {
 	size_t                       send_iov_cnt;
 	uint64_t                     send_flags;
 	size_t			     cum_send_len;
+	struct gnix_fab_req 	     *parent;
+	size_t                       mrecv_space_left;
+	uint64_t                     mrecv_buf_addr;
 
 	struct recv_info_t {
 		uint64_t	 recv_addr;
@@ -1001,6 +1004,9 @@ static inline int gnix_ops_allowed(struct gnix_fid_ep *ep,
  * @var work_fn	     the function called by the nic progress loop to initiate
  * the fabric request.
  * @var flags	      a set of bit patterns that apply to all message types
+ * @cb                optional call back to be invoked when ref cnt on this
+ *                    object drops to zero
+ * @ref_cnt           ref cnt for this object
  * @var iov_txds      A list of pending Rdma/CtFma GET txds.
  * @var iov_txd_cnt   The count of outstanding iov txds.
  * @var tx_failures   tx failure bits.
@@ -1017,6 +1023,8 @@ struct gnix_fab_req {
 	struct gnix_vc            *vc;
 	int                       (*work_fn)(void *);
 	uint64_t                  flags;
+	void                      (*cb)(void *);
+	struct gnix_reference     ref_cnt;
 
 	struct slist_entry           *int_tx_buf_e;
 	uint8_t                      *int_tx_buf;
@@ -1032,9 +1040,9 @@ struct gnix_fab_req {
 
 	/* common to rma/amo/msg */
 	union {
-		struct gnix_fab_req_rma rma;
-		struct gnix_fab_req_msg msg;
-		struct gnix_fab_req_amo amo;
+		struct gnix_fab_req_rma   rma;
+		struct gnix_fab_req_msg   msg;
+		struct gnix_fab_req_amo   amo;
 	};
 	char inject_buf[GNIX_INJECT_SIZE];
 };

--- a/prov/gni/include/gnix_msg.h
+++ b/prov/gni/include/gnix_msg.h
@@ -36,7 +36,11 @@
 
 ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len, void *desc,
 		   uint64_t src_addr, void *context, uint64_t flags,
-		   uint64_t tag, uint64_t ignore);
+		   uint64_t tag, uint64_t ignore, struct gnix_fab_req *req);
+
+ssize_t _gnix_recv_mr(struct gnix_fid_ep *ep, uint64_t buf, size_t len, void *desc,
+		      uint64_t src_addr, void *context, uint64_t flags,
+		      uint64_t tag, uint64_t ignore);
 
 ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 		   void *mdesc, uint64_t dest_addr, void *context,


### PR DESCRIPTION
The GNI provider implementation of FI_MULTI_RECV had to
be refactored to fix numerous issues with the original implementation.

With this refactor, the provider now handles the case where
messages can be received into a FI_MULTI_RECV buffer from numerous
different EPs.

With this refactor, receives of messages using the provider's
rendezvous protocol now function correctly.  Previously an application
would not be correctly notified when all messages had been transfered
into the buffer in the case that some transfers used the rendezvous
protocol.

In order to correctly notify the application when the buffer has
been released, a separate FI_MULTI_RECV CQ event is now generated
without the FI_RECV flag set.  See description of FI_MULTI_RECV
CQs in the fi_cq man page.

Fixes ofi-cray/libfabric-cray#1003
Fixes ofi-cray/libfabric-cray#1116

This PR does not address a truncated message reporting issue.
That will be handled as a separate PR as its not directly related to
problems with the original FI_MULTI_RECV implementation.

Relates to ofi-cray/libfabric-cray#1119
upstream merge of ofi-cray/libfabric-cray#1354

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@3bf7fafffc90a742a201e53115ccf4f750ce27a0)
(cherry picked from commit ofi-cray/libfabric-cray@72ba404a8132de7699590d96e233dc382a4c0c3d)
(cherry picked from commit ofi-cray/libfabric-cray@3e1105456cb8f28a70edb81bc4c160544d711e4b)
(cherry picked from commit ofi-cray/libfabric-cray@8632c67270c4a9afdf9effcd36c199ef0d90d08f)
(cherry picked from commit ofi-cray/libfabric-cray@64c1b83e478c91bd60d060ed0f3398973c139f00)
(cherry picked from commit ofi-cray/libfabric-cray@edfb1be5cb197ae7a491b85efb647889b77cae12)