### PR TITLE
prov/verbs: Update how tx,rx sizes and iov limits are reported.

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -193,6 +193,10 @@ uint64_t fi_gettime_us(void);
 
 #define OFI_ADDRSTRLEN (INET6_ADDRSTRLEN + 50)
 
+#define OFI_ENUM_VAL(X) X
+#define OFI_STR(X) #X
+#define OFI_STR_INT(X) OFI_STR(X)
+
 static inline size_t ofi_sizeofaddr(const struct sockaddr *address)
 {
 	return (address->sa_family == AF_INET ?

--- a/prov/rxm/src/rxm.c
+++ b/prov/rxm/src/rxm.c
@@ -48,7 +48,7 @@
 	} while (0)
 
 char *rxm_proto_state_str[] = {
-	RXM_PROTO_STATES(STR)
+	RXM_PROTO_STATES(OFI_STR)
 };
 
 struct rxm_tx_entry *rxm_tx_entry_get(struct rxm_send_queue *queue)

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -62,26 +62,6 @@
 #define RXM_BUF_SIZE 16384
 #define RXM_IOV_LIMIT 4
 
-/*
- * Macros to generate enums and associated string values
- * e.g.
- * #define RXM_STATES(FUNC)	\
- * 	FUNC(STATE1),		\
- * 	FUNC(STATE2),		\
- * 	...			\
- * 	FUNC(STATEn)
- *
- * enum rxm_state {
- * 	RXM_STATES(ENUM_VAL)
- * };
- *
- * char *rxm_state_str[] = {
- * 	RXM_STATES(STR)
- * };
- */
-#define ENUM(X) X
-#define STR(X) #X
-
 #define RXM_MR_LOCAL(info) \
 	((FI_VERSION_LT(info->fabric_attr->api_version, FI_VERSION(1, 5)) && \
 	  (info->mode & FI_LOCAL_MR)) || (info->domain_attr->mr_mode & FI_MR_LOCAL))
@@ -140,6 +120,24 @@ struct rxm_rma_iov {
 	struct ofi_rma_iov iov[];
 };
 
+/*
+ * Macros to generate enums and associated string values
+ * e.g.
+ * #define RXM_PROTO_STATES(FUNC)	\
+ * 	FUNC(STATE1),			\
+ * 	FUNC(STATE2),			\
+ * 	...				\
+ * 	FUNC(STATEn)
+ *
+ * enum rxm_state {
+ * 	RXM_PROTO_STATES(OFI_ENUM_VAL)
+ * };
+ *
+ * char *rxm_state_str[] = {
+ * 	RXM_PROTO_STATES(OFI_STR)
+ * };
+ */
+
 /* RXM protocol states / tx/rx context */
 #define RXM_PROTO_STATES(FUNC)	\
 	FUNC(RXM_NONE),		\
@@ -153,7 +151,7 @@ struct rxm_rma_iov {
 	FUNC(RXM_LMT_FINISH),
 
 enum rxm_proto_state {
-	RXM_PROTO_STATES(ENUM)
+	RXM_PROTO_STATES(OFI_ENUM_VAL)
 };
 
 extern char *rxm_proto_state_str[];

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -41,6 +41,12 @@ static void fi_ibv_fini(void);
 
 static const char *local_node = "localhost";
 
+size_t verbs_default_tx_size 		= 384;
+size_t verbs_default_rx_size 		= 384;
+size_t verbs_default_tx_iov_limit 	= 4;
+size_t verbs_default_rx_iov_limit 	= 4;
+size_t verbs_default_inline_size 	= 64;
+
 struct fi_provider fi_ibv_prov = {
 	.name = VERBS_PROV_NAME,
 	.version = VERBS_PROV_VERS,
@@ -391,6 +397,10 @@ VERBS_INI
 			"Only IBV_WR_SEND and IBV_WR_RDMA_WRITE_WITH_IMM are supported. "
 			"The last one is not applicable for iWarp. "
 			"(default: IBV_WR_SEND)");
+
+	fi_param_define(&fi_ibv_prov, "inline_size", FI_PARAM_INT,
+			"Default inline size to request when creating a queue pair "
+			"(default: " OFI_STR_INT(VERBS_DEFAULT_INLINE_SIZE) ")");
 
 	return &fi_ibv_prov;
 }

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -104,9 +104,15 @@
 
 #define VERBS_DEF_CQ_SIZE 1024
 #define VERBS_MR_IOV_LIMIT 1
+#define VERBS_DEFAULT_INLINE_SIZE 64
 
 extern struct fi_provider fi_ibv_prov;
 extern struct fi_info *verbs_info;
+
+extern size_t verbs_default_tx_size;
+extern size_t verbs_default_rx_size;
+extern size_t verbs_default_tx_iov_limit;
+extern size_t verbs_default_rx_iov_limit;
 
 struct verbs_addr {
 	struct dlist_entry entry;


### PR DESCRIPTION
- Use a default value for tx,rx sizes and iov limits only if user hasn't
  specifically requested a particular value for these attributes.
- Define a env variable for default inject / inline size that would be
  requested when creating a queue pair.