### PR TITLE
util & rxm: Coverity fixes

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -156,7 +156,7 @@ err1:
 void *rxm_conn_event_handler(void *arg)
 {
 	struct fi_eq_cm_entry *entry;
-	struct fi_eq_err_entry err_entry;
+	struct fi_eq_err_entry err_entry = {0};
 	size_t datalen = sizeof(struct rxm_cm_data);
 	size_t len = sizeof(*entry) + datalen;
 	struct rxm_ep *rxm_ep = container_of(arg, struct rxm_ep, util_ep);


### PR DESCRIPTION
This PR refactors the util cmap code to fix the following issues.

- Fix util_av and cmap locks not being obtained in the same order in different
  places.
- Fix locks not being unlocked in a few error cases.

Other issue fixed:
- Fix uninitialized variable access in rxm_conn.c