### PR TITLE
prov/rxd: fixed seg_no processing on acked packet

### DIFF
--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -814,6 +814,11 @@ static void rxd_handle_data(struct rxd_ep *ep, struct rxd_peer *peer,
 				       ctrl->conn_id);
 			goto repost;
 		} else {
+			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "invalid pkt: segno: %d "
+			       "expected:%d, rx-key:%d, ctrl_msg_id: %ld, "
+			       "rx_entry_msg_id: %ld\n",
+			       ctrl->seg_no, rx_entry->exp_seg_no, ctrl->rx_key,
+			       ctrl->msg_id, rx_entry->msg_id);
 			return;
 		}
 	}

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -472,14 +472,14 @@ void rxd_ep_free_acked_pkts(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
 	struct rxd_pkt_meta *pkt;
 	struct ofi_ctrl_hdr *ctrl;
 
-	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "freeing all [%p] pkts <= %d\n",
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "freeing all [%p] pkts < %d\n",
 		tx_entry->msg_id, last_acked);
 	while (!dlist_empty(&tx_entry->pkt_list)) {
 
 		pkt = container_of(tx_entry->pkt_list.next,
 				   struct rxd_pkt_meta, entry);
 		ctrl = (struct ofi_ctrl_hdr *) pkt->pkt_data;
-		if (ctrl->seg_no > last_acked)
+		if (ctrl->seg_no >= last_acked)
 			break;
 
 		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "freeing [%p] pkt:%d\n",


### PR DESCRIPTION
- on send/receive ack there is expected seg_no value
  sent to sender, and sender should clean all prior
  sent packets (excluding packet seg_no)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>