### PR TITLE
build: FI_CHECK_PACKAGE overwrites previous value

### DIFF
--- a/config/fi_check_package.m4
+++ b/config/fi_check_package.m4
@@ -130,7 +130,7 @@ AC_DEFUN([_FI_CHECK_PACKAGE_LIB], [
                           unset fi_Lib])])])])
 
     AS_IF([test "$fi_check_package_lib_happy" = "yes"],
-          [$1_LIBS="-l$2 $4"
+          [$1_LIBS="-l$2 $4 $$1_LIBS"
            $7], [$8])
 
     AS_VAR_POPDEF([fi_Lib])dnl


### PR DESCRIPTION
FI_CHECK_PACKAGE calls the internal macro
_FI_CHECK_PACKAGE_LIB, which then sets the value
of the corresponding component's LIBS to the
recently set library.

However, it should be appending to the existing value
and not overwriting it as there can be multiple
invocations of the FI_CHECK_PACKAGE macro in the configure
process.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>

@jsquyres @shefty What do you think?