### PR TITLE
prov/verbs: Refactor how default attributes are set in fi_info

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -104,7 +104,6 @@
 
 #define VERBS_DEF_CQ_SIZE 1024
 #define VERBS_MR_IOV_LIMIT 1
-#define VERBS_DEFAULT_INLINE_SIZE 64
 
 extern struct fi_provider fi_ibv_prov;
 extern struct fi_info *verbs_info;
@@ -113,6 +112,7 @@ extern size_t verbs_default_tx_size;
 extern size_t verbs_default_rx_size;
 extern size_t verbs_default_tx_iov_limit;
 extern size_t verbs_default_rx_iov_limit;
+extern size_t verbs_default_inline_size;
 
 struct verbs_addr {
 	struct dlist_entry entry;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -569,8 +569,9 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx, struct fi_info *info
 	info->domain_attr->ep_cnt 		= device_attr.max_qp;
 	info->domain_attr->tx_ctx_cnt 		= MIN(info->domain_attr->tx_ctx_cnt, device_attr.max_qp);
 	info->domain_attr->rx_ctx_cnt 		= MIN(info->domain_attr->rx_ctx_cnt, device_attr.max_qp);
-	info->domain_attr->max_ep_tx_ctx 	= device_attr.max_qp;
-	info->domain_attr->max_ep_rx_ctx 	= device_attr.max_qp;
+	info->domain_attr->max_ep_tx_ctx 	= MIN(info->domain_attr->tx_ctx_cnt, device_attr.max_qp);
+	info->domain_attr->max_ep_rx_ctx 	= MIN(info->domain_attr->rx_ctx_cnt, device_attr.max_qp);
+	info->domain_attr->max_ep_srx_ctx	= device_attr.max_qp;
 	info->domain_attr->mr_cnt		= device_attr.max_mr;
 
 	if (info->ep_attr->type == FI_EP_RDM)
@@ -580,8 +581,10 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx, struct fi_info *info
 	info->tx_attr->iov_limit 		= device_attr.max_sge;
 	info->tx_attr->rma_iov_limit		= device_attr.max_sge;
 
-	info->rx_attr->size 			= device_attr.max_qp_wr;
-	info->rx_attr->iov_limit 		= device_attr.max_sge;
+	info->rx_attr->size 			= MIN(device_attr.max_qp_wr,
+						      device_attr.max_srq_wr);
+	info->rx_attr->iov_limit 		= MIN(device_attr.max_sge,
+						      device_attr.max_srq_sge);
 
 	ret = fi_ibv_get_qp_cap(ctx, info);
 	if (ret)

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1000,7 +1000,8 @@ static int fi_ibv_fill_addr(struct rdma_addrinfo *rai, struct fi_info **info,
 	struct sockaddr *local_addr;
 	int ret;
 
-	if (rai->ai_src_addr && !ofi_is_loopback_addr(rai->ai_src_addr))
+	if (rai->ai_src_addr && (((*info)->ep_attr->type == FI_EP_MSG) ||
+	    !ofi_is_loopback_addr(rai->ai_src_addr)))
 		goto rai_to_fi;
 
 	if (!id->verbs)

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -216,18 +216,8 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 
 	memset(&attr, 0, sizeof attr);
 	if (_ep->scq) {
-		/* Fallback to default values if user hasn't requested a specific value.
-		 * This is to avoid increased memory usage when using max values. */
-		if (_ep->info->tx_attr->size == verbs_info->tx_attr->size)
-			attr.cap.max_send_wr = verbs_default_tx_size;
-		else
-			attr.cap.max_send_wr = _ep->info->tx_attr->size;
-
-		if (_ep->info->tx_attr->iov_limit == verbs_info->tx_attr->iov_limit)
-			attr.cap.max_send_sge = verbs_default_tx_iov_limit;
-		else
-			attr.cap.max_send_sge = _ep->info->tx_attr->iov_limit;
-
+		attr.cap.max_send_wr = _ep->info->tx_attr->size;
+		attr.cap.max_send_sge = _ep->info->tx_attr->iov_limit;
 		attr.send_cq = _ep->scq->cq;
 		pd = _ep->scq->domain->pd;
 	} else {
@@ -236,18 +226,8 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 	}
 
 	if (_ep->rcq) {
-		/* Fallback to default values if user hasn't requested a specific value.
-		 * This is to avoid increased memory usage when using max values. */
-		if (_ep->info->rx_attr->size == verbs_info->rx_attr->size)
-			attr.cap.max_recv_wr = verbs_default_rx_size;
-		else
-			attr.cap.max_recv_wr = _ep->info->rx_attr->size;
-
-		if (_ep->info->rx_attr->iov_limit == verbs_info->rx_attr->iov_limit)
-			attr.cap.max_recv_sge = verbs_default_rx_iov_limit;
-		else
-			attr.cap.max_recv_sge = _ep->info->rx_attr->iov_limit;
-
+		attr.cap.max_recv_wr = _ep->info->rx_attr->size;
+		attr.cap.max_recv_sge = _ep->info->rx_attr->iov_limit;
 		attr.recv_cq = _ep->rcq->cq;
 	} else {
 		attr.recv_cq = _ep->scq->cq;


### PR DESCRIPTION
-  Set default values for fi_info attributes in fi_info before returning it.
  We still use max values obtained from the device when checking hints.
  ofi_alter_info should update these default values with user requested ones.
- Define env variables to allow changing provider defined defaults.




