### PR TITLE
Updates to sockets, rxm and util providers

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -446,12 +446,15 @@ struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t ke
 int ofi_cmap_get_handle(struct util_cmap *cmap, fi_addr_t fi_addr,
 			struct util_cmap_handle **handle);
 
-void ofi_cmap_process_connect(struct util_cmap *cmap, uint64_t local_key,
+void ofi_cmap_process_connect(struct util_cmap *cmap,
+			      struct util_cmap_handle *handle,
 			      uint64_t *remote_key);
-void ofi_cmap_process_reject(struct util_cmap *cmap, uint64_t local_key);
+void ofi_cmap_process_reject(struct util_cmap *cmap,
+			     struct util_cmap_handle *handle);
 int ofi_cmap_process_connreq(struct util_cmap *cmap, void *addr,
 			     struct util_cmap_handle **handle);
-void ofi_cmap_process_shutdown(struct util_cmap *cmap, uint64_t local_key);
+void ofi_cmap_process_shutdown(struct util_cmap *cmap,
+			       struct util_cmap_handle *handle);
 void ofi_cmap_del_handle(struct util_cmap_handle *handle);
 void ofi_cmap_free(struct util_cmap *cmap);
 struct util_cmap *ofi_cmap_alloc(struct util_ep *ep,

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -377,6 +377,11 @@ int ofi_av_get_index(struct util_av *av, const void *addr);
 // for both AV and RX only connections.
 #define UTIL_CMAP_IDX_BITS 48
 
+enum ofi_cmap_signal {
+	OFI_CMAP_FREE,
+	OFI_CMAP_EXIT,
+};
+
 enum util_cmap_state {
 	CMAP_IDLE,
 	CMAP_CONNREQ_SENT,
@@ -411,7 +416,8 @@ typedef int (*ofi_cmap_connect_func)(struct util_ep *cmap,
 				     struct util_cmap_handle *handle,
 				     fi_addr_t fi_addr);
 typedef void *(*ofi_cmap_event_handler_func)(void *arg);
-typedef int (*ofi_cmap_signal_func)(struct util_ep *ep);
+typedef int (*ofi_cmap_signal_func)(struct util_ep *ep, void *context,
+				    enum ofi_cmap_signal signal);
 
 struct util_cmap_attr {
 	void 				*name;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -349,7 +349,8 @@ int rxm_conn_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 struct util_cmap_handle *rxm_conn_alloc(void);
 void rxm_conn_close(struct util_cmap_handle *handle);
 void rxm_conn_free(struct util_cmap_handle *handle);
-int rxm_conn_signal(struct util_ep *util_ep);
+int rxm_conn_signal(struct util_ep *util_ep, void *context,
+		    enum ofi_cmap_signal signal);
 
 int rxm_ep_repost_buf(struct rxm_rx_buf *buf);
 int ofi_match_addr(fi_addr_t addr, fi_addr_t match_addr);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -128,8 +128,7 @@ int rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 
 	rxm_conn->handle.remote_key = remote_cm_data->conn_id;
 
-	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn,
-			      &rxm_conn->handle);
+	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn, handle);
 	if (ret)
 		goto err2;
 
@@ -153,10 +152,41 @@ err1:
 	return ret;
 }
 
+static int rxm_conn_handle_notify(struct fi_eq_entry *eq_entry)
+{
+	switch((enum ofi_cmap_signal)eq_entry->data) {
+	case OFI_CMAP_FREE:
+		FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Freeing handle\n");
+		rxm_conn_free((struct util_cmap_handle *)eq_entry->context);
+		return 0;
+	case OFI_CMAP_EXIT:
+		FI_TRACE(&rxm_prov, FI_LOG_FABRIC, "Closing event handler\n");
+		return 1;
+	default:
+		FI_WARN(&rxm_prov, FI_LOG_FABRIC, "Unknown cmap signal\n");
+		return 1;
+	}
+}
+
+static void rxm_conn_handle_eq_err(struct rxm_ep *rxm_ep, ssize_t rd)
+{
+	struct fi_eq_err_entry err_entry = {0};
+
+	if (rd != -FI_EAVAIL) {
+		FI_WARN(&rxm_prov, FI_LOG_FABRIC, "Unable to fi_eq_sread\n");
+		return;
+	}
+	OFI_EQ_READERR(&rxm_prov, FI_LOG_FABRIC, rxm_ep->msg_eq, rd, err_entry);
+	if (err_entry.err == ECONNREFUSED) {
+		FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Connection refused\n");
+		ofi_cmap_process_reject(rxm_ep->util_ep.cmap,
+					err_entry.fid->context);
+	}
+}
+
 void *rxm_conn_event_handler(void *arg)
 {
 	struct fi_eq_cm_entry *entry;
-	struct fi_eq_err_entry err_entry = {0};
 	size_t datalen = sizeof(struct rxm_cm_data);
 	size_t len = sizeof(*entry) + datalen;
 	struct rxm_ep *rxm_ep = container_of(arg, struct rxm_ep, util_ep);
@@ -175,33 +205,23 @@ void *rxm_conn_event_handler(void *arg)
 		rd = fi_eq_sread(rxm_ep->msg_eq, &event, entry, len, -1, 0);
 		/* We would receive more bytes than sizeof *entry during CONNREQ */
 		if (rd < 0) {
-			if (rd == -FI_EAVAIL)
-				OFI_EQ_READERR(&rxm_prov, FI_LOG_FABRIC,
-						rxm_ep->msg_eq, rd, err_entry);
-			else
-				FI_WARN(&rxm_prov, FI_LOG_FABRIC,
-						"msg: unable to fi_eq_sread\n");
-			if (err_entry.err == ECONNREFUSED) {
-				FI_DBG(&rxm_prov, FI_LOG_FABRIC,
-				       "Connection refused\n");
-				ofi_cmap_process_reject(rxm_ep->util_ep.cmap,
-							err_entry.fid->context);
-			}
+			rxm_conn_handle_eq_err(rxm_ep, rd);
 			continue;
 		}
 
 		switch(event) {
 		case FI_NOTIFY:
-			FI_TRACE(&rxm_prov, FI_LOG_FABRIC,
-				 "Closing conn event handler");
-			free(entry);
-			return NULL;
+			if (rxm_conn_handle_notify((struct fi_eq_entry *)entry))
+				goto exit;
+			break;
 		case FI_CONNREQ:
-			if (rd != len)
+			FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Got new connection\n");
+			if (rd != len) {
 				FI_WARN(&rxm_prov, FI_LOG_FABRIC,
 					"Received size (%d) not matching "
 					"expected (%d)\n", rd, len);
-			FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Got new connection\n");
+				goto exit;
+			}
 			cm_data = (void *)entry->data;
 			rxm_msg_process_connreq(rxm_ep, entry->info, entry->data);
 			break;
@@ -223,8 +243,12 @@ void *rxm_conn_event_handler(void *arg)
 		default:
 			FI_WARN(&rxm_prov, FI_LOG_FABRIC,
 				"Unknown event: %u\n", event);
+			goto exit;
 		}
 	}
+exit:
+	free(entry);
+	return NULL;
 }
 
 static int rxm_prepare_cm_data(struct fid_pep *pep, struct util_cmap_handle *handle,
@@ -308,11 +332,15 @@ err1:
 	return ret;
 }
 
-int rxm_conn_signal(struct util_ep *util_ep)
+int rxm_conn_signal(struct util_ep *util_ep, void *context,
+		    enum ofi_cmap_signal signal)
 {
 	struct rxm_ep *rxm_ep = container_of(util_ep, struct rxm_ep, util_ep);
 	struct fi_eq_entry entry = {0};
 	ssize_t rd;
+
+	entry.context = context;
+	entry.data = (uint64_t)signal;
 
 	rd = fi_eq_write(rxm_ep->msg_eq, FI_NOTIFY, &entry, sizeof(entry), 0);
 	if (rd != sizeof(entry)) {

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -129,7 +129,7 @@ int rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 	rxm_conn->handle.remote_key = remote_cm_data->conn_id;
 
 	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn,
-			      (void *)rxm_conn->handle.key);
+			      &rxm_conn->handle);
 	if (ret)
 		goto err2;
 
@@ -185,7 +185,7 @@ void *rxm_conn_event_handler(void *arg)
 				FI_DBG(&rxm_prov, FI_LOG_FABRIC,
 				       "Connection refused\n");
 				ofi_cmap_process_reject(rxm_ep->util_ep.cmap,
-							(uint64_t)err_entry.fid->context);
+							err_entry.fid->context);
 			}
 			continue;
 		}
@@ -210,7 +210,7 @@ void *rxm_conn_event_handler(void *arg)
 			       "Connection successful\n");
 			cm_data = (void *)entry->data;
 			ofi_cmap_process_connect(rxm_ep->util_ep.cmap,
-						 (uint64_t)entry->fid->context,
+						 entry->fid->context,
 						 (rd - sizeof(*entry)) ?
 						 &cm_data->conn_id : NULL);
 			break;
@@ -218,7 +218,7 @@ void *rxm_conn_event_handler(void *arg)
 			FI_DBG(&rxm_prov, FI_LOG_FABRIC,
 			       "Received connection shutdown\n");
 			ofi_cmap_process_shutdown(rxm_ep->util_ep.cmap,
-						  (uint64_t)entry->fid->context);
+						  entry->fid->context);
 			break;
 		default:
 			FI_WARN(&rxm_prov, FI_LOG_FABRIC,
@@ -282,7 +282,7 @@ int rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
 		return ret;
 
 	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn,
-			      (void *)rxm_conn->handle.key);
+			      &rxm_conn->handle);
 	if (ret)
 		goto err1;
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1080,13 +1080,12 @@ static int ofi_cmap_match_peer(struct dlist_entry *entry, const void *addr)
 }
 
 /* Caller must hold cmap->lock */
-static void util_cmap_del_handle(struct util_cmap_handle *handle)
+static int util_cmap_del_handle(struct util_cmap_handle *handle)
 {
 	struct util_cmap *cmap = handle->cmap;
+	int ret;
 
-	if (handle->state == CMAP_SHUTDOWN)
-		goto free;
-
+	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Deleting handle\n");
 	if (handle->peer) {
 		dlist_remove(&handle->peer->entry);
 		free(handle->peer);
@@ -1094,18 +1093,21 @@ static void util_cmap_del_handle(struct util_cmap_handle *handle)
 	} else {
 		cmap->handles_av[handle->fi_addr] = 0;
 	}
-
-	/* TODO The following defers the handle deletion until we receive a
-	 * shutdown. Replace this with something better. Handle may not be freed
-	 * if we don't get a shutdown event */
-	if (handle->state == CMAP_CONNECTED) {
-		handle->state = CMAP_SHUTDOWN;
-		handle->cmap->attr.close(handle);
-		return;
-	}
-free:
 	util_cmap_clear_key(handle);
-	cmap->attr.free(handle);
+
+	handle->state = CMAP_SHUTDOWN;
+	handle->cmap->attr.close(handle);
+	/* Signal event handler thread to delete the handle. This is required
+	 * so that the event handler thread handles any pending events for this
+	 * ep correctly. Handle would be freed finally after processing the
+	 * events */
+	ret = cmap->attr.signal(cmap->ep, handle, OFI_CMAP_FREE);
+	if (ret) {
+		FI_WARN(cmap->av->prov, FI_LOG_FABRIC,
+			"Unable to signal event handler thread\n");
+		return ret;
+	}
+	return 0;
 }
 
 void ofi_cmap_del_handle(struct util_cmap_handle *handle)
@@ -1121,11 +1123,11 @@ static int util_cmap_alloc_handle(struct util_cmap *cmap, fi_addr_t fi_addr,
 				  enum util_cmap_state state,
 				  struct util_cmap_handle **handle)
 {
-	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
-	       "Allocating new handle for given fi_addr\n");
 	*handle = cmap->attr.alloc();
 	if (!*handle)
 		return -FI_ENOMEM;
+	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Allocated new handle: %p for "
+	       "fi_addr: %" PRIu64 "\n", *handle, fi_addr);
 	ofi_cmap_init_handle(*handle, cmap, state, fi_addr, NULL);
 	cmap->handles_av[fi_addr] = *handle;
 	return 0;
@@ -1138,8 +1140,6 @@ static int util_cmap_alloc_handle_peer(struct util_cmap *cmap, void *addr,
 {
 	struct util_cmap_peer *peer;
 
-	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
-	       "Allocating new handle for given addr\n");
 	peer = calloc(1, sizeof(*peer) + cmap->av->addrlen);
 	if (!peer)
 		return -FI_ENOMEM;
@@ -1148,6 +1148,8 @@ static int util_cmap_alloc_handle_peer(struct util_cmap *cmap, void *addr,
 		free(peer);
 		return -FI_ENOMEM;
 	}
+	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
+	       "Allocated new handle: %p for given addr\n", *handle);
 	ofi_cmap_init_handle(*handle, cmap, state, FI_ADDR_UNSPEC, peer);
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Adding handle to peer list\n");
 	peer->handle = *handle;
@@ -1199,13 +1201,27 @@ util_cmap_get_handle(struct util_cmap *cmap, fi_addr_t fi_addr, void *addr)
 void ofi_cmap_process_shutdown(struct util_cmap *cmap,
 			       struct util_cmap_handle *handle)
 {
-	ofi_cmap_del_handle(handle);
+	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
+		"Processing shutdown for handle: %p\n", handle);
+	fastlock_acquire(&cmap->lock);
+	if (handle->state > CMAP_SHUTDOWN) {
+		FI_WARN(cmap->av->prov, FI_LOG_EP_CTRL,
+			"Invalid handle on shutdown event\n");
+	} else if (handle->state != CMAP_SHUTDOWN) {
+		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Got remote shutdown\n");
+		util_cmap_del_handle(handle);
+	} else {
+		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Got local shutdown\n");
+	}
+	fastlock_release(&cmap->lock);
 }
 
 void ofi_cmap_process_connect(struct util_cmap *cmap,
 			      struct util_cmap_handle *handle,
 			      uint64_t *remote_key)
 {
+	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
+		"Processing connect for handle: %p\n", handle);
 	fastlock_acquire(&cmap->lock);
 	handle->state = CMAP_CONNECTED;
 	if (remote_key)
@@ -1216,6 +1232,8 @@ void ofi_cmap_process_connect(struct util_cmap *cmap,
 void ofi_cmap_process_reject(struct util_cmap *cmap,
 			     struct util_cmap_handle *handle)
 {
+	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
+		"Processing reject for handle: %p\n", handle);
 	fastlock_acquire(&cmap->lock);
 	switch (handle->state) {
 	case CMAP_CONNREQ_RECV:
@@ -1230,8 +1248,8 @@ void ofi_cmap_process_reject(struct util_cmap *cmap,
 		util_cmap_del_handle(handle);
 		break;
 	default:
-		FI_WARN(cmap->av->prov, FI_LOG_EP_CTRL,
-			"Invalid cmap state when receiving connection reject\n");
+		FI_WARN(cmap->av->prov, FI_LOG_EP_CTRL, "Invalid cmap state: "
+			"%d when receiving connection reject\n", handle->state);
 		assert(0);
 	}
 	fastlock_release(&cmap->lock);
@@ -1262,6 +1280,10 @@ int ofi_cmap_process_connreq(struct util_cmap *cmap, void *addr,
 		if (ret)
 			goto unlock;
 	}
+
+	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
+		"Processing connreq for handle: %p\n", handle);
+
 	switch (handle->state) {
 	case CMAP_CONNECTED:
 		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
@@ -1283,8 +1305,8 @@ int ofi_cmap_process_connreq(struct util_cmap *cmap, void *addr,
 			ret = -FI_EALREADY;
 		} else {
 			FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
-				"Closing our handle and re-using it to accept "
-				"remote connection: %p\n", handle);
+				"Re-using handle: %p to accept remote "
+				"connection\n", handle);
 			/* Re-use handle. If it receives FI_REJECT the handle
 			 * would not be deleted in this state */
 			handle->cmap->attr.close(handle);
@@ -1365,7 +1387,7 @@ static int util_cmap_event_handler_close(struct util_cmap *cmap)
 {
 	int ret;
 
-	ret = cmap->attr.signal(cmap->ep);
+	ret = cmap->attr.signal(cmap->ep, NULL, OFI_CMAP_EXIT);
 	if (ret) {
 		FI_WARN(cmap->av->prov, FI_LOG_FABRIC,
 			"Unable to signal event handler thread\n");
@@ -1390,6 +1412,7 @@ void ofi_cmap_free(struct util_cmap *cmap)
 	size_t i;
 
 	fastlock_acquire(&cmap->lock);
+	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Closing cmap\n");
 	for (i = 0; i < cmap->av->count; i++) {
 		if (cmap->handles_av[i])
 			util_cmap_del_handle(cmap->handles_av[i]);


### PR DESCRIPTION
- prov/sockets: On EP close remove any tear down events written to EQ by the EP
- util, ofi_rxm: Make CM context as cmap handle instead of keys
- prov/util: Move handle deletion to event handler thread









