### PR TITLE
prov/udp/rxd: fixed CQ double de-reference

### DIFF
--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1317,7 +1317,6 @@ static int rxd_ep_close(struct fid *fid)
 		fid_list_remove(&ep->util_ep.tx_cq->ep_list,
 				&ep->util_ep.tx_cq->ep_list_lock,
 				&ep->util_ep.ep_fid.fid);
-		ofi_atomic_dec32(&ep->util_ep.tx_cq->ref);
 	}
 
 	if (ep->util_ep.rx_cq) {
@@ -1327,7 +1326,6 @@ static int rxd_ep_close(struct fid *fid)
 					&ep->util_ep.rx_cq->ep_list_lock,
 					&ep->util_ep.ep_fid.fid);
 		}
-		ofi_atomic_dec32(&ep->util_ep.rx_cq->ref);
 	}
 
 	fastlock_destroy(&ep->lock);

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -562,11 +562,7 @@ static int udpx_ep_close(struct fid *fid)
 		fid_list_remove(&ep->util_ep.rx_cq->ep_list,
 				&ep->util_ep.rx_cq->ep_list_lock,
 				&ep->util_ep.ep_fid.fid);
-		ofi_atomic_dec32(&ep->util_ep.rx_cq->ref);
 	}
-
-	if (ep->util_ep.tx_cq)
-		ofi_atomic_dec32(&ep->util_ep.tx_cq->ref);
 
 	udpx_rx_cirq_free(ep->rxq);
 	ofi_close_socket(ep->sock);


### PR DESCRIPTION
- CQ is de-referenced in ofi_ep_close function, and
  not needed to decrement counters outside of this
  function to avoid issues in shutdown of OFI

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>