### PR TITLE
prov/gni: swat a compiler warning

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -71,7 +71,7 @@ static const struct fi_ops_cq gnix_cq_ops;
 /*******************************************************************************
  * Size array corresponding format type to format size.
  ******************************************************************************/
-static const size_t const format_sizes[] = {
+static const size_t format_sizes[] = {
 	[FI_CQ_FORMAT_UNSPEC]  = sizeof(GNIX_CQ_DEFAULT_FORMAT),
 	[FI_CQ_FORMAT_CONTEXT] = sizeof(struct fi_cq_entry),
 	[FI_CQ_FORMAT_MSG]     = sizeof(struct fi_cq_msg_entry),
@@ -79,7 +79,7 @@ static const size_t const format_sizes[] = {
 	[FI_CQ_FORMAT_TAGGED]  = sizeof(struct fi_cq_tagged_entry)
 };
 
-static const fill_entry const fill_function[] = {
+static const fill_entry fill_function[] = {
 	[FI_CQ_FORMAT_UNSPEC]  = fill_cq_entry,
 	[FI_CQ_FORMAT_CONTEXT] = fill_cq_entry,
 	[FI_CQ_FORMAT_MSG]     = fill_cq_msg,


### PR DESCRIPTION
swat a gcc 7.1.0 reported compiler warning

upstream merge of ofi-cray/libfabric-cray#1384

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@0625e0c0ad7484ec55f6537b6e1b697604f3e077)