### PR TITLE
common/ep: changed ofi_ep_bind_valid parameter

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -172,7 +172,8 @@ int ofi_send_allowed(uint64_t caps);
 int ofi_recv_allowed(uint64_t caps);
 int ofi_rma_initiate_allowed(uint64_t caps);
 int ofi_rma_target_allowed(uint64_t caps);
-int ofi_ep_bind_valid(struct fi_provider *prov, struct fid *bfid, uint64_t flags);
+int ofi_ep_bind_valid(const struct fi_provider *prov, struct fid *bfid,
+		      uint64_t flags);
 
 uint64_t fi_gettime_ms(void);
 uint64_t fi_gettime_us(void);

--- a/src/common.c
+++ b/src/common.c
@@ -149,7 +149,7 @@ int ofi_rma_target_allowed(uint64_t caps)
 	return 0;
 }
 
-int ofi_ep_bind_valid(struct fi_provider *prov, struct fid *bfid, uint64_t flags)
+int ofi_ep_bind_valid(const struct fi_provider *prov, struct fid *bfid, uint64_t flags)
 {
 	if (!bfid) {
 		FI_WARN(prov, FI_LOG_EP_CTRL, "NULL bind fid\n");


### PR DESCRIPTION
- changed first argument of ofi_ep_bind_valid to
  get const pointer to provider. this allows to
  use ep->domain->prov value as argument without
  const casting

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>