### PR TITLE
prov/rxd: fixed buf leak, added buf counter

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -88,6 +88,7 @@
 #define RXD_MAX_PKT_RETRY	50
 
 extern int rxd_progress_spin_count;
+extern int rxd_reposted_bufs;
 
 extern struct fi_provider rxd_prov;
 extern struct fi_info rxd_info;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -37,6 +37,7 @@
 #include "rxd.h"
 
 int rxd_progress_spin_count = 1000;
+int rxd_reposted_bufs = 0;
 
 static ssize_t rxd_ep_cancel(fid_t fid, void *context)
 {
@@ -191,6 +192,8 @@ int rxd_ep_repost_buff(struct rxd_rx_buf *buf)
 		      FI_ADDR_UNSPEC, &buf->context);
 	if (ret)
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "failed to repost\n");
+	else
+		rxd_reposted_bufs++;
 	return ret;
 }
 


### PR DESCRIPTION
- fixed buffer leak on processing in-ordered data start
  packet, incorrect packets and incorrect connection request
- added registered buffer counter and asserts to control
  number of registered buffers (to simplify handling
  out-of-buffers errors)

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>