### PR TITLE
prov/gni: Fix mr mode bits for pre-1.5 api reqs

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -555,10 +555,16 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 			if (ofi_check_mr_mode(version,
 					gnix_info->domain_attr->mr_mode,
 					hints->domain_attr->mr_mode) != FI_SUCCESS) {
+				GNIX_DEBUG(FI_LOG_FABRIC,
+					"failed mr_mode check\n");
 				goto err;
 			}
 
-			gnix_info->domain_attr->mr_mode = hints->domain_attr->mr_mode;
+			if (FI_VERSION_LT(version, FI_VERSION(1, 5)))
+				gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
+			else
+				gnix_info->domain_attr->mr_mode =
+					hints->domain_attr->mr_mode;
 
 			switch (hints->domain_attr->threading) {
 			case FI_THREAD_COMPLETION:


### PR DESCRIPTION
Fixes getinfo calls that provide hints with the wrong
values for the mr_mode when using the GNI provider
upstream merge of ofi-cray/libfabric-cray#1388

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@222f971ccf7e55e6063de187f7542ce60d24f1b4)