### PR TITLE
prov/rxm: Handle out of order send/recv completions from underlying provider

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -148,6 +148,7 @@ struct rxm_rma_iov {
 	FUNC(RXM_LMT_ACK_WAIT),	\
 	FUNC(RXM_LMT_READ),	\
 	FUNC(RXM_LMT_ACK_SENT), \
+	FUNC(RXM_LMT_ACK_RECVD),\
 	FUNC(RXM_LMT_FINISH),
 
 enum rxm_proto_state {
@@ -230,6 +231,7 @@ struct rxm_tx_entry {
 
 	/* Used for large messages */
 	struct fid_mr *mr[RXM_IOV_LIMIT];
+	struct rxm_rx_buf *rx_buf;
 };
 DECLARE_FREESTACK(struct rxm_tx_entry, rxm_txe_fs);
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -700,6 +700,11 @@ static ssize_t rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov
 
 	if ((flags & FI_INJECT) && !(flags & FI_COMPLETION)) {
 		if (pkt_size <= rxm_ep->msg_info->tx_attr->inject_size) {
+			if (tx_entry->state == RXM_LMT_TX) {
+				RXM_LOG_STATE_TX(FI_LOG_CQ, tx_entry,
+						 RXM_LMT_TX);
+				tx_entry->state = RXM_LMT_ACK_WAIT;
+			}
 			ret = fi_inject(rxm_conn->msg_ep, pkt, pkt_size, 0);
 			if (ret)
 				FI_DBG(&rxm_prov, FI_LOG_EP_DATA,


### PR DESCRIPTION
It was assumed earlier that the local send completion for "RTS" in the
rendezvous protocol for large messages would arrive before the recv
completion of the ack from remote side once the large message transfer
is complete. This is not correct as ordering is not guaranteed between
send and recv completions even though the send is supposed to complete
much earlier than incoming ack from remote side.

This patch fixes this issue. Also added some asserts.