### PR TITLE
prov/gni: don't let FI_OPT_MIN_MULTIRECV be 0

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -290,6 +290,9 @@ local operation.  That is, fi_shutdown() causes the local endpoint to be shut
 down, and a shutdown event to be generated on the local EQ.  However, a
 connected remote peer endpoint is not notified of a call to fi_shutdown().
 
+The GNI provider does not currently handle the case when FI_OPT_MULTI_RECV is set to 0
+and will return -FI_EINVAL if an application attempts to set this value to zero.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -3040,6 +3040,11 @@ DIRECT_FN STATIC int gnix_ep_setopt(fid_t fid, int level, int optname,
 	case FI_OPT_MIN_MULTI_RECV:
 		if (optlen != sizeof(size_t))
 			return -FI_EINVAL;
+		/*
+		 * see issue 1120
+		 */
+		if (*(size_t *)optval == 0UL)
+			return -FI_EINVAL;
 		gnix_ep->min_multi_recv = *(size_t *)optval;
 		break;
 	default:

--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -228,6 +228,14 @@ Test(endpoint, getsetopt)
 			(void *)&val, sizeof(size_t) - 1);
 	cr_assert(ret == -FI_EINVAL, "fi_setopt");
 
+	/*
+	 * see issue 1120
+	 */
+	val = 0UL;
+	ret = fi_setopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_MIN_MULTI_RECV,
+			(void *)&val, sizeof(size_t));
+	cr_assert(ret == -FI_EINVAL, "fi_setopt");
+
 	/* Test update. */
 	ret = fi_getopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_MIN_MULTI_RECV,
 			(void *)&val, &len);


### PR DESCRIPTION
Currently GNI provider doesn't correctly handle
FI_OPT_MIN_MULTIRECV being zero.  As a workaround
don't let an application set the EP opt to 0.

related to ofi-cray/libfabric-cray#1120

upstream merge of ofi-cray/libfabric-cray#1391

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@20454c0e4588e30278bcea343a5f85ea57873c1f)