### PR TITLE
prov/gni: fix a bind issue with SEPs

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -562,6 +562,9 @@ int _gnix_ep_init_vc(struct gnix_fid_ep *ep_priv)
 	gnix_hashtable_attr_t gnix_ht_attr;
 	gnix_vec_attr_t gnix_vec_attr;
 
+	GNIX_FATAL(FI_LOG_EP_CTRL,
+			   "_gnix_ep_init_vc av field NULL\n");
+
 	if (ep_priv->av->type == FI_AV_TABLE) {
 		/* Use array to store EP VCs when using FI_AV_TABLE. */
 		ep_priv->vc_table = calloc(1, sizeof(struct gnix_vector));


### PR DESCRIPTION
An SEP can be bound to an AV prior to or after
the SEP is used to create tx/rx contexts.

This commit allows for the first case to work.

Also remove erroneous code allowing bind of counter
objects to scalable eps.  This is not supported according
to the fi_scalable_ep_bind description in the fi_endpoint
man page.

Fixes ofi-cray/libfabric-cray#1386
upstream merge of ofi-cray/libfabric-cray#1394

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@29930faaf305e4e6d2a8ae8a75eb9e1496c9a9a6)