### PR TITLE
Add missing fields for input to fi_info and for fi_tostr.

### DIFF
--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -262,6 +262,8 @@ static void fi_tostr_mode(char *buf, uint64_t mode)
 	IFFLAGSTR(mode, FI_RX_CQ_DATA);
 	IFFLAGSTR(mode, FI_LOCAL_MR);
 	IFFLAGSTR(mode, FI_NOTIFY_FLAGS_ONLY);
+	IFFLAGSTR(mode, FI_RESTRICTED_COMP);
+	IFFLAGSTR(mode, FI_CONTEXT2);
 
 	fi_remove_comma(buf);
 }

--- a/util/info.c
+++ b/util/info.c
@@ -114,11 +114,14 @@ static int str2cap(char *inputstr, uint64_t *value)
 	ORCASE(FI_RMA);
 	ORCASE(FI_TAGGED);
 	ORCASE(FI_ATOMIC);
+	ORCASE(FI_ATOMICS);
+	ORCASE(FI_MULTICAST);
 
 	ORCASE(FI_READ);
 	ORCASE(FI_WRITE);
 	ORCASE(FI_RECV);
 	ORCASE(FI_SEND);
+	ORCASE(FI_TRANSMIT);
 	ORCASE(FI_REMOTE_READ);
 	ORCASE(FI_REMOTE_WRITE);
 
@@ -129,15 +132,23 @@ static int str2cap(char *inputstr, uint64_t *value)
 	ORCASE(FI_TRIGGER);
 	ORCASE(FI_FENCE);
 
+	ORCASE(FI_COMPLETION);
 	ORCASE(FI_EVENT);
 	ORCASE(FI_INJECT);
 	ORCASE(FI_INJECT_COMPLETE);
 	ORCASE(FI_TRANSMIT_COMPLETE);
 	ORCASE(FI_DELIVERY_COMPLETE);
+	ORCASE(FI_AFFINITY);
 
+	ORCASE(FI_SOURCE_ERR);
+	ORCASE(FI_LOCAL_COMM);
+	ORCASE(FI_REMOTE_COMM);
+	ORCASE(FI_SHARED_AV);
+	ORCASE(FI_PROV_ATTR_ONLY);
+	ORCASE(FI_NUMERICHOST);
 	ORCASE(FI_RMA_EVENT);
-	ORCASE(FI_NAMED_RX_CTX);
 	ORCASE(FI_SOURCE);
+	ORCASE(FI_NAMED_RX_CTX);
 	ORCASE(FI_DIRECTED_RECV);
 
 	fprintf(stderr, "error: Unrecognized capability: %s\n", inputstr);
@@ -148,12 +159,13 @@ static int str2cap(char *inputstr, uint64_t *value)
 static int str2mode(char *inputstr, uint64_t *value)
 {
 	ORCASE(FI_CONTEXT);
-	ORCASE(FI_CONTEXT2);
-	ORCASE(FI_LOCAL_MR);
 	ORCASE(FI_MSG_PREFIX);
 	ORCASE(FI_ASYNC_IOV);
 	ORCASE(FI_RX_CQ_DATA);
+	ORCASE(FI_LOCAL_MR);
+	ORCASE(FI_NOTIFY_FLAGS_ONLY);
 	ORCASE(FI_RESTRICTED_COMP);
+	ORCASE(FI_CONTEXT2);
 
 	fprintf(stderr, "error: Unrecognized mode: %s\n", inputstr);
 
@@ -166,6 +178,8 @@ static int str2ep_type(char *inputstr, enum fi_ep_type *value)
 	ORCASE(FI_EP_MSG);
 	ORCASE(FI_EP_DGRAM);
 	ORCASE(FI_EP_RDM);
+	ORCASE(FI_EP_SOCK_STREAM);
+	ORCASE(FI_EP_SOCK_DGRAM);
 
 	fprintf(stderr, "error: Unrecognized endpoint type: %s\n", inputstr);
 
@@ -180,6 +194,11 @@ static int str2addr_format(char *inputstr, uint32_t *value)
 	ORCASE(FI_SOCKADDR_IN6);
 	ORCASE(FI_SOCKADDR_IB);
 	ORCASE(FI_ADDR_PSMX);
+	ORCASE(FI_ADDR_GNI);
+	ORCASE(FI_ADDR_BGQ);
+	ORCASE(FI_ADDR_MLX);
+	ORCASE(FI_ADDR_STR);
+	ORCASE(FI_ADDR_PSMX2);
 
 	fprintf(stderr, "error: Unrecognized address format: %s\n", inputstr);
 


### PR DESCRIPTION
I think this mostly catches these up with latest headers.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>