### PR TITLE
usnic: fixed deadlock in eq_readerr().

### DIFF
--- a/prov/usnic/src/usdf_eq.c
+++ b/prov/usnic/src/usdf_eq.c
@@ -214,6 +214,7 @@ static ssize_t usdf_eq_readerr(struct fid_eq *feq,
 
 	/* make sure there is an error on top */
 	if (usdf_eq_empty(eq) || !usdf_eq_error(eq)) {
+		pthread_spin_unlock(&eq->eq_lock);
 		ret = -FI_EAGAIN;
 		goto done;
 	}


### PR DESCRIPTION
Coverity test detected returning without unlock. This cause by us moving
the unlock up higher trying to optimize the locking time. This patch
properly unlocks before return.

Signed-off-by: Thananon Patinyasakdikul <apatinya@cisco.com>