### PR TITLE
prov/rxm: Mode bits fixes

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -43,7 +43,8 @@ The RxM provider currently supports *FI_MSG*, *FI_TAGGED* and *FI_RMA* capabilit
 : FI_SOCKADDR, FI_SOCKADDR_IN
 
 *Memory Region*
-: FI_MR_BASIC
+: FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY MR mode bits would be
+  required from the app in case the core provider requires it.
 
 # LIMITATIONS
 


### PR DESCRIPTION
- Before calling fi_getinfo on core provider, disable modes that rxm can't
  support and add modes that rxm can support.
- Also update MR mode bit requirement in man page

Fixes #3167 