### PR TITLE
usnic: tidy up the 1.5 changes code.

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -511,4 +511,9 @@ void usdf_setup_fake_ibv_provider(void);
 /* passive endpoint functions */
 int usdf_pep_steal_socket(struct usdf_pep *pep, int *is_bound, int *sock_o);
 
+/* Utility functions */
+int usdf_catch_dom_attr(uint32_t version, struct fi_domain_attr *dom_attr);
+int usdf_catch_tx_attr(uint32_t version, struct fi_tx_attr *tx_attr);
+int usdf_catch_rx_attr(uint32_t version, struct fi_rx_attr *rx_attr);
+
 #endif /* _USDF_H_ */

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -441,3 +441,43 @@ int usdf_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 {
 	return -FI_EOPNOTSUPP;
 }
+
+int usdf_catch_dom_attr(uint32_t version, struct fi_domain_attr *dom_attr)
+{
+	/* version 1.5 introduced new bits. If the user asked for older
+	 * version, we can't return these new bits.
+	 */
+	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
+		/* We checked mr_mode compatibility before calling
+		 * this function. This means it is safe to return
+		 * 1.4 default mr_mode.
+		 */
+		dom_attr->mr_mode = FI_MR_BASIC;
+
+		dom_attr->caps &= ~FI_REMOTE_COMM;
+	}
+
+	return FI_SUCCESS;
+}
+
+int usdf_catch_tx_attr(uint32_t version, struct fi_tx_attr *tx_attr)
+{
+	/* In version < 1.5, FI_LOCAL_MR is required. */
+	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
+		if ((tx_attr->mode & FI_LOCAL_MR) == 0)
+			return -FI_ENODATA;
+	}
+
+	return FI_SUCCESS;
+}
+
+int usdf_catch_rx_attr(uint32_t version, struct fi_rx_attr *rx_attr)
+{
+	/* In version < 1.5, FI_LOCAL_MR is required. */
+	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
+		if ((rx_attr->mode & FI_LOCAL_MR) == 0)
+			return -FI_ENODATA;
+	}
+
+	return FI_SUCCESS;
+}

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -511,23 +511,8 @@ int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	if (ret < 0)
 		return -FI_ENODATA;
 
-	if (!hints || !hints->domain_attr) {
-		/* In version < 1.5, if no domain_attr provided,
-		 * we have to provide backward compatibility in case of
-		 * application compiled with version >= 1.5 but still
-		 * request < 1.5 such as Open MPI
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-			/* The default for mr_mode should be FI_MR_BASIC. */
-			defaults.mr_mode = FI_MR_BASIC;
-
-			/* FI_REMOTE_COMM is introduced in 1.5, we have to
-			 * remove that from the default for older version.
-			 */
-			defaults.caps &= ~FI_REMOTE_COMM;
-		}
+	if (!hints || !hints->domain_attr)
 		goto out;
-	}
 
 	switch (hints->domain_attr->threading) {
 	case FI_THREAD_UNSPEC:
@@ -571,13 +556,8 @@ int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	}
 
 	switch (hints->domain_attr->caps) {
-	case FI_REMOTE_COMM:
-		/* FI_REMOTE_COMM is introduced in 1.5, if the user give us
-		 * the flag, this must be a mistake. Fail.
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5)))
-			return -FI_ENODATA;
 	case 0:
+	case FI_REMOTE_COMM:
 		break;
 	default:
 		USDF_WARN_SYS(DOMAIN,
@@ -585,38 +565,26 @@ int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	switch (hints->domain_attr->mr_mode) {
-	case FI_MR_UNSPEC:
-		/* We still have to check here, in case of the user
-		 * provided domain_attr but not mr_mode bit.
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-			defaults.mr_mode = FI_MR_BASIC;
-		} else {
-			/* In >= 1.5, if mr_mode bit is unspecified, we will
-			 * look for FI_LOCAL_MR flag in fi_mode. If is not set,
-			 * we assume FI_MR_SCALABLE (which we don't support)
-			 * and fail.
-			 */
-			if ((hints->mode & FI_LOCAL_MR) == 0)
-				return -FI_ENODATA;
-		}
-		break;
-	default :
-		if (ofi_check_mr_mode(version, defaults.mr_mode, hints->domain_attr->mr_mode))
-			return -FI_ENODATA;
-	}
-
-	if (hints->domain_attr->mr_cnt <= USDF_DGRAM_MR_CNT) {
-		defaults.mr_cnt = hints->domain_attr->mr_cnt;
-	} else {
-		USDF_DBG_SYS(DOMAIN, "mr_count exceeded provider limit\n");
+	if (ofi_check_mr_mode(version, defaults.mr_mode,
+			      hints->domain_attr->mr_mode))
 		return -FI_ENODATA;
+
+	if (hints->domain_attr->mr_cnt) {
+		if (hints->domain_attr->mr_cnt <= USDF_DGRAM_MR_CNT) {
+			defaults.mr_cnt = hints->domain_attr->mr_cnt;
+		} else {
+			USDF_DBG_SYS(DOMAIN,
+				     "mr_count exceeded provider limit\n");
+			return -FI_ENODATA;
+		}
 	}
-
 out:
-	*fi->domain_attr = defaults;
+	/* catch the version change here. */
+	ret = usdf_catch_dom_attr(version, &defaults);
+	if (ret)
+		return ret;
 
+	*fi->domain_attr = defaults;
 	return FI_SUCCESS;
 }
 
@@ -624,6 +592,7 @@ int usdf_dgram_fill_tx_attr(uint32_t version, struct fi_info *hints,
 			    struct fi_info *fi,
 			    struct usd_device_attrs *dap)
 {
+	int ret;
 	struct fi_tx_attr defaults;
 	size_t entries;
 
@@ -641,12 +610,6 @@ int usdf_dgram_fill_tx_attr(uint32_t version, struct fi_info *hints,
 	/* clear the mode bits the app doesn't support */
 	if (hints->mode || hints->tx_attr->mode)
 		defaults.mode &= (hints->mode | hints->tx_attr->mode);
-
-	/* In version < 1.5 , FI_LOCAL_MR is required. */
-	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-		if ((defaults.mode & FI_LOCAL_MR) == 0)
-			return -FI_ENODATA;
-	}
 
 	defaults.op_flags |= hints->tx_attr->op_flags;
 
@@ -694,6 +657,11 @@ out:
 	if (!hints || (hints && !(hints->mode & FI_MSG_PREFIX)))
 		defaults.iov_limit -= 1;
 
+	/* catch version changes here. */
+	ret = usdf_catch_tx_attr(version, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->tx_attr = defaults;
 
 	return FI_SUCCESS;
@@ -702,6 +670,7 @@ out:
 int usdf_dgram_fill_rx_attr(uint32_t version, struct fi_info *hints,
 			    struct fi_info *fi, struct usd_device_attrs *dap)
 {
+	int ret;
 	struct fi_rx_attr defaults;
 	size_t entries;
 
@@ -719,12 +688,6 @@ int usdf_dgram_fill_rx_attr(uint32_t version, struct fi_info *hints,
 	/* clear the mode bits the app doesn't support */
 	if (hints->mode || hints->tx_attr->mode)
 		defaults.mode &= (hints->mode | hints->rx_attr->mode);
-
-	/* In version < 1.5, FI_LOCAL_MR is required. */
-	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-		if ((defaults.mode & FI_LOCAL_MR) == 0)
-			return -FI_ENODATA;
-	}
 
 	defaults.op_flags |= hints->rx_attr->op_flags;
 
@@ -769,6 +732,11 @@ out:
 	 */
 	if (!hints || (hints && !(hints->mode & FI_MSG_PREFIX)))
 		defaults.iov_limit -= 1;
+
+	/* catch version changes here. */
+	ret = usdf_catch_rx_attr(version, &defaults);
+	if (ret)
+		return ret;
 
 	*fi->rx_attr = defaults;
 

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -196,23 +196,8 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	if (ret < 0)
 		return -FI_ENODATA;
 
-	if (!hints || !hints->domain_attr) {
-		/* In version < 1.5, if no domain_attr provided,
-		 * we have to provide backward compatibility in case of
-		 * application compiled with version >= 1.5 but still
-		 * request < 1.5 such as Open MPI
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-			/* The default for mr_mode should be FI_MR_BASIC. */
-			defaults.mr_mode = FI_MR_BASIC;
-
-			/* FI_REMOTE_COMM is introduced in 1.5, we have to
-			 * remove that from the default for older version.
-			 */
-			defaults.caps &= ~FI_REMOTE_COMM;
-		}
+	if (!hints || !hints->domain_attr)
 		goto out;
-	}
 
 	/* how to handle fi_thread_fid, fi_thread_completion, etc?
 	 */
@@ -251,14 +236,8 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	}
 
 	switch (hints->domain_attr->caps) {
-	case FI_REMOTE_COMM:
-		/* FI_REMOTE_COMM is introduced in 1.5, if the user give us
-		 * the flag, this must be a mistake. Fail.
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5)))
-			return -FI_ENODATA;
-		defaults.caps = FI_REMOTE_COMM;
 	case 0:
+	case FI_REMOTE_COMM:
 		break;
 	default:
 		USDF_WARN_SYS(DOMAIN,
@@ -266,27 +245,9 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	switch (hints->domain_attr->mr_mode) {
-	case FI_MR_UNSPEC:
-		/* We still have to check here, in case of the user
-		 * provided domain_attr but not mr_mode bit.
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-			defaults.mr_mode = FI_MR_BASIC;
-		} else {
-			/* In >= 1.5, if mr_mode bit is unspecified, we will
-			 * look for FI_LOCAL_MR flag in fi_mode. If is not set,
-			 * we assume FI_MR_SCALABLE (which we don't support)
-			 * and fail.
-			 */
-			if ((hints->mode & FI_LOCAL_MR) == 0)
-				return -FI_ENODATA;
-		}
-		break;
-	default :
-		if (ofi_check_mr_mode(version, defaults.mr_mode, hints->domain_attr->mr_mode))
-			return -FI_ENODATA;
-	}
+	if (ofi_check_mr_mode(version, defaults.mr_mode,
+			      hints->domain_attr->mr_mode))
+		return -FI_ENODATA;
 
 	if (hints->domain_attr->mr_cnt <= USDF_MSG_MR_CNT) {
 		defaults.mr_cnt = hints->domain_attr->mr_cnt;
@@ -296,6 +257,11 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	}
 
 out:
+	/* catch the version changes here. */
+	ret = usdf_catch_dom_attr(version, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->domain_attr = defaults;
 
 	return FI_SUCCESS;
@@ -304,6 +270,7 @@ out:
 int usdf_msg_fill_tx_attr(uint32_t version, struct fi_info *hints,
 			  struct fi_info *fi)
 {
+	int ret;
 	struct fi_tx_attr defaults;
 
 	defaults = msg_dflt_tx_attr;
@@ -316,13 +283,8 @@ int usdf_msg_fill_tx_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	defaults.mode &= (hints->mode | hints->tx_attr->mode);
-
-	/* In version < 1.5, FI_LOCAL_MR is required. */
-	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-		if ((defaults.mode & FI_LOCAL_MR) == 0)
-			return -FI_ENODATA;
-	}
+	if (hints->mode || hints->tx_attr->mode)
+		defaults.mode &= (hints->mode | hints->tx_attr->mode);
 
 	defaults.op_flags |= hints->tx_attr->op_flags;
 
@@ -347,6 +309,11 @@ int usdf_msg_fill_tx_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 
 out:
+	/* catch version changes here. */
+	ret = usdf_catch_tx_attr(version, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->tx_attr = defaults;
 
 	return FI_SUCCESS;
@@ -354,6 +321,7 @@ out:
 
 int usdf_msg_fill_rx_attr(uint32_t version, struct fi_info *hints, struct fi_info *fi)
 {
+	int ret;
 	struct fi_rx_attr defaults;
 
 	defaults = msg_dflt_rx_attr;
@@ -366,13 +334,8 @@ int usdf_msg_fill_rx_attr(uint32_t version, struct fi_info *hints, struct fi_inf
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	defaults.mode &= (hints->mode | hints->rx_attr->mode);
-
-	/* In version < 1.5, FI_LOCAL_MR is required. */
-	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-		if ((defaults.mode & FI_LOCAL_MR) == 0)
-			return -FI_ENODATA;
-	}
+	if (hints->mode || hints->rx_attr->mode)
+		defaults.mode &= (hints->mode | hints->rx_attr->mode);
 
 	defaults.op_flags |= hints->rx_attr->op_flags;
 
@@ -394,6 +357,11 @@ int usdf_msg_fill_rx_attr(uint32_t version, struct fi_info *hints, struct fi_inf
 		return -FI_ENODATA;
 
 out:
+	/* catch version changes here. */
+	ret = usdf_catch_rx_attr(version, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->rx_attr = defaults;
 
 	return FI_SUCCESS;

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -200,23 +200,8 @@ int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	if (ret < 0)
 		return -FI_ENODATA;
 
-	if (!hints || !hints->domain_attr) {
-		/* In version < 1.5, if no domain_attr provided,
-		 * we have to provide backward compatibility in case of
-		 * application compiled with version >= 1.5 but still
-		 * request < 1.5 such as Open MPI
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-			/* The default for mr_mode should be FI_MR_BASIC. */
-			defaults.mr_mode = FI_MR_BASIC;
-
-			/* FI_REMOTE_COMM is introduced in 1.5, we have to
-			 * remove that from the default for older version.
-			 */
-			defaults.caps &= ~FI_REMOTE_COMM;
-		}
+	if (!hints || !hints->domain_attr)
 		goto out;
-	}
 
 	/* how to handle fi_thread_fid, fi_thread_completion, etc?
 	 */
@@ -255,13 +240,8 @@ int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	}
 
 	switch (hints->domain_attr->caps) {
-	case FI_REMOTE_COMM:
-		/* FI_REMOTE_COMM is introduced in 1.5, if the user give us
-		 * the flag, this must be a mistake. Fail.
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5)))
-			return -FI_ENODATA;
 	case 0:
+	case FI_REMOTE_COMM:
 		break;
 	default:
 		USDF_WARN_SYS(DOMAIN,
@@ -269,27 +249,9 @@ int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	switch (hints->domain_attr->mr_mode) {
-	case FI_MR_UNSPEC:
-		/* We still have to check here, in case of the user
-		 * provided domain_attr but not mr_mode bit.
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-			defaults.mr_mode = FI_MR_BASIC;
-		} else {
-			/* In >= 1.5, if mr_mode bit is unspecified, we will
-			 * look for FI_LOCAL_MR flag in fi_mode. If is not set,
-			 * we assume FI_MR_SCALABLE (which we don't support)
-			 * and fail.
-			 */
-			if ((hints->mode & FI_LOCAL_MR) == 0)
-				return -FI_ENODATA;
-		}
-		break;
-	default :
-		if (ofi_check_mr_mode(version, defaults.mr_mode, hints->domain_attr->mr_mode))
-			return -FI_ENODATA;
-	}
+	if (ofi_check_mr_mode(version, defaults.mr_mode,
+			      hints->domain_attr->mr_mode))
+		return -FI_ENODATA;
 
 	if (hints->domain_attr->mr_cnt <= USDF_RDM_MR_CNT) {
 		defaults.mr_cnt = hints->domain_attr->mr_cnt;
@@ -299,6 +261,11 @@ int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	}
 
 out:
+	/* catch the version changes here. */
+	ret = usdf_catch_dom_attr(version, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->domain_attr = defaults;
 
 	return FI_SUCCESS;
@@ -307,6 +274,7 @@ out:
 int usdf_rdm_fill_tx_attr(uint32_t version, struct fi_info *hints,
 			  struct fi_info *fi)
 {
+	int ret;
 	struct fi_tx_attr defaults;
 
 	defaults = rdm_dflt_tx_attr;
@@ -319,13 +287,9 @@ int usdf_rdm_fill_tx_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	defaults.mode &= (hints->mode | hints->tx_attr->mode);
+	if (hints->mode || hints->tx_attr->mode)
+		defaults.mode &= (hints->mode | hints->tx_attr->mode);
 
-	/* In version < 1.5, FI_LOCAL_MR is required. */
-	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-		if ((defaults.mode & FI_LOCAL_MR) == 0)
-			return -FI_ENODATA;
-	}
 	defaults.op_flags |= hints->tx_attr->op_flags;
 
 	if ((hints->tx_attr->msg_order | USDF_RDM_MSG_ORDER) !=
@@ -349,6 +313,11 @@ int usdf_rdm_fill_tx_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 
 out:
+	/* catch version changes here. */
+	ret = usdf_catch_tx_attr(version, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->tx_attr = defaults;
 
 	return FI_SUCCESS;
@@ -357,6 +326,7 @@ out:
 int usdf_rdm_fill_rx_attr(uint32_t version, struct fi_info *hints,
 			  struct fi_info *fi)
 {
+	int ret;
 	struct fi_rx_attr defaults;
 
 	defaults = rdm_dflt_rx_attr;
@@ -369,13 +339,8 @@ int usdf_rdm_fill_rx_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	defaults.mode &= (hints->mode | hints->rx_attr->mode);
-
-	/* In version < 1.5, FI_LOCAL_MR is required. */
-	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-		if ((defaults.mode & FI_LOCAL_MR) == 0)
-			return -FI_ENODATA;
-	}
+	if (hints->mode || hints->rx_attr->mode)
+		defaults.mode &= (hints->mode | hints->rx_attr->mode);
 
 	defaults.op_flags |= hints->rx_attr->op_flags;
 
@@ -397,6 +362,11 @@ int usdf_rdm_fill_rx_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 
 out:
+	/* catch version changes here. */
+	ret = usdf_catch_rx_attr(version, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->rx_attr = defaults;
 
 	return FI_SUCCESS;


### PR DESCRIPTION
This commits moved the handling of version changes to the end of
function. Now the provider will behave like 1.5 but will detect if the
user asked for older version at the end and should return appropriate
flags.

This commit also added some logical check missing from PR #3172.

Signed-off-by: Thananon Patinyasakdikul <apatinya@cisco.com>