### PR TITLE
prov/verbs: fix for rx_attr->size calculation

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -581,8 +581,10 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx, struct fi_info *info
 	info->tx_attr->iov_limit 		= device_attr.max_sge;
 	info->tx_attr->rma_iov_limit		= device_attr.max_sge;
 
-	info->rx_attr->size 			= MIN(device_attr.max_qp_wr,
-						      device_attr.max_srq_wr);
+	info->rx_attr->size 			= device_attr.max_srq_wr ?
+						  MIN(device_attr.max_qp_wr,
+						      device_attr.max_srq_wr) :
+						      device_attr.max_qp_wr;
 	info->rx_attr->iov_limit 		= MIN(device_attr.max_sge,
 						      device_attr.max_srq_sge);
 


### PR DESCRIPTION
- in case if shared context is not provided by verbs
  provider context size max_srq_wr value of device attributes
  object is NULL. for such cases max_srq_wr should be ignored
  on context size calculation

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>