### PR TITLE
usnic: refactored dom_attr modebits handling.

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -511,4 +511,12 @@ void usdf_setup_fake_ibv_provider(void);
 /* passive endpoint functions */
 int usdf_pep_steal_socket(struct usdf_pep *pep, int *is_bound, int *sock_o);
 
+/* Utility functions */
+int usdf_catch_dom_attr(uint32_t version, struct fi_info *hints,
+			struct fi_domain_attr *dom_attr);
+int usdf_catch_tx_attr(uint32_t version, struct fi_tx_attr *tx_attr);
+int usdf_catch_rx_attr(uint32_t version, struct fi_rx_attr *rx_attr);
+int usdf_check_mr_mode(uint32_t version, struct fi_info *hints,
+		       uint64_t prov_mode);
+
 #endif /* _USDF_H_ */

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -196,23 +196,8 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	if (ret < 0)
 		return -FI_ENODATA;
 
-	if (!hints || !hints->domain_attr) {
-		/* In version < 1.5, if no domain_attr provided,
-		 * we have to provide backward compatibility in case of
-		 * application compiled with version >= 1.5 but still
-		 * request < 1.5 such as Open MPI
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-			/* The default for mr_mode should be FI_MR_BASIC. */
-			defaults.mr_mode = FI_MR_BASIC;
-
-			/* FI_REMOTE_COMM is introduced in 1.5, we have to
-			 * remove that from the default for older version.
-			 */
-			defaults.caps &= ~FI_REMOTE_COMM;
-		}
-		goto out;
-	}
+	if (!hints || !hints->domain_attr)
+		goto catch;
 
 	/* how to handle fi_thread_fid, fi_thread_completion, etc?
 	 */
@@ -251,14 +236,8 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 	}
 
 	switch (hints->domain_attr->caps) {
-	case FI_REMOTE_COMM:
-		/* FI_REMOTE_COMM is introduced in 1.5, if the user give us
-		 * the flag, this must be a mistake. Fail.
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5)))
-			return -FI_ENODATA;
-		defaults.caps = FI_REMOTE_COMM;
 	case 0:
+	case FI_REMOTE_COMM:
 		break;
 	default:
 		USDF_WARN_SYS(DOMAIN,
@@ -266,27 +245,8 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	switch (hints->domain_attr->mr_mode) {
-	case FI_MR_UNSPEC:
-		/* We still have to check here, in case of the user
-		 * provided domain_attr but not mr_mode bit.
-		 */
-		if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-			defaults.mr_mode = FI_MR_BASIC;
-		} else {
-			/* In >= 1.5, if mr_mode bit is unspecified, we will
-			 * look for FI_LOCAL_MR flag in fi_mode. If is not set,
-			 * we assume FI_MR_SCALABLE (which we don't support)
-			 * and fail.
-			 */
-			if ((hints->mode & FI_LOCAL_MR) == 0)
-				return -FI_ENODATA;
-		}
-		break;
-	default :
-		if (ofi_check_mr_mode(version, defaults.mr_mode, hints->domain_attr->mr_mode))
-			return -FI_ENODATA;
-	}
+	if (usdf_check_mr_mode(version, hints, defaults.mr_mode))
+		return -FI_ENODATA;
 
 	if (hints->domain_attr->mr_cnt <= USDF_MSG_MR_CNT) {
 		defaults.mr_cnt = hints->domain_attr->mr_cnt;
@@ -295,7 +255,12 @@ int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-out:
+catch:
+	/* catch the version changes here. */
+	ret = usdf_catch_dom_attr(version, hints, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->domain_attr = defaults;
 
 	return FI_SUCCESS;
@@ -304,25 +269,21 @@ out:
 int usdf_msg_fill_tx_attr(uint32_t version, struct fi_info *hints,
 			  struct fi_info *fi)
 {
+	int ret;
 	struct fi_tx_attr defaults;
 
 	defaults = msg_dflt_tx_attr;
 
 	if (!hints || !hints->tx_attr)
-		goto out;
+		goto catch;
 
 	/* make sure we can support the caps that are requested*/
 	if (hints->tx_attr->caps & ~USDF_MSG_CAPS)
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	defaults.mode &= (hints->mode | hints->tx_attr->mode);
-
-	/* In version < 1.5, FI_LOCAL_MR is required. */
-	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-		if ((defaults.mode & FI_LOCAL_MR) == 0)
-			return -FI_ENODATA;
-	}
+	if (hints->mode || hints->tx_attr->mode)
+		defaults.mode &= (hints->mode | hints->tx_attr->mode);
 
 	defaults.op_flags |= hints->tx_attr->op_flags;
 
@@ -346,7 +307,12 @@ int usdf_msg_fill_tx_attr(uint32_t version, struct fi_info *hints,
 	if (hints->tx_attr->size > defaults.size)
 		return -FI_ENODATA;
 
-out:
+catch:
+	/* catch version changes here. */
+	ret = usdf_catch_tx_attr(version, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->tx_attr = defaults;
 
 	return FI_SUCCESS;
@@ -354,25 +320,21 @@ out:
 
 int usdf_msg_fill_rx_attr(uint32_t version, struct fi_info *hints, struct fi_info *fi)
 {
+	int ret;
 	struct fi_rx_attr defaults;
 
 	defaults = msg_dflt_rx_attr;
 
 	if (!hints || !hints->rx_attr)
-		goto out;
+		goto catch;
 
 	/* make sure we can support the capabilities that are requested */
 	if (hints->rx_attr->caps & ~USDF_MSG_CAPS)
 		return -FI_ENODATA;
 
 	/* clear the mode bits the app doesn't support */
-	defaults.mode &= (hints->mode | hints->rx_attr->mode);
-
-	/* In version < 1.5, FI_LOCAL_MR is required. */
-	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-		if ((defaults.mode & FI_LOCAL_MR) == 0)
-			return -FI_ENODATA;
-	}
+	if (hints->mode || hints->rx_attr->mode)
+		defaults.mode &= (hints->mode | hints->rx_attr->mode);
 
 	defaults.op_flags |= hints->rx_attr->op_flags;
 
@@ -393,7 +355,12 @@ int usdf_msg_fill_rx_attr(uint32_t version, struct fi_info *hints, struct fi_inf
 	if (hints->rx_attr->size > defaults.size)
 		return -FI_ENODATA;
 
-out:
+catch:
+	/* catch version changes here. */
+	ret = usdf_catch_rx_attr(version, &defaults);
+	if (ret)
+		return ret;
+
 	*fi->rx_attr = defaults;
 
 	return FI_SUCCESS;


### PR DESCRIPTION
This commits moved the handling of version changes to the end of
function. Now the provider will behave like 1.5 but will detect if the
user asked for older version at the end and should return appropriate
flags.

This commit also added some logical check missing from PR #3172.

Signed-off-by: Thananon Patinyasakdikul <apatinya@cisco.com>