### PR TITLE
prov/gni: Address locking issue in initialization

### DIFF
--- a/prov/gni/src/gnix_init.c
+++ b/prov/gni/src/gnix_init.c
@@ -56,6 +56,8 @@ __thread uint32_t gnix_debug_tid = ~(uint32_t) 0;
 ofi_atomic32_t gnix_debug_next_tid;
 #endif
 
+extern fastlock_t __gnix_alps_lock;
+
 /**
  * Helper for static computation of GNI CRC updating an intermediate crc
  * value based on the status of one bit in the data value.
@@ -151,6 +153,8 @@ void _gnix_init(void)
 	static int called=0;
 
 	if (called==0) {
+		fastlock_init(&__gnix_alps_lock);
+
 		if (sizeof(struct gnix_mr_key) != sizeof(uint64_t)) {
 			GNIX_FATAL(FI_LOG_FABRIC,
 				"gnix_mr_key size is invalid, "

--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -97,6 +97,7 @@ static int *gnix_app_totalPes;
 static int *gnix_app_nodePes;
 static int *gnix_app_peCpus;
 
+fastlock_t __gnix_alps_lock;
 
 int _gnix_get_cq_limit(void)
 {
@@ -246,12 +247,14 @@ static int __gnix_alps_init(void)
 	alpsAppLLIGni_t *rdmacred_rsp = NULL;
 	alpsAppGni_t *rdmacred_buf = NULL;
 
+	fastlock_acquire(&__gnix_alps_lock);
 	/* lli_lock doesn't return anything useful */
 	ret = alps_app_lli_lock();
 
 	if (alps_init) {
 		/* alps lli lock protects alps_init for now */
 		alps_app_lli_unlock();
+		fastlock_release(&__gnix_alps_lock);
 		return ret;
 	}
 
@@ -361,6 +364,7 @@ static int __gnix_alps_init(void)
 	ret = 0;
 err:
 	alps_app_lli_unlock();
+	fastlock_release(&__gnix_alps_lock);
 	if (rdmacred_rsp != NULL) {
 		free(rdmacred_rsp);
 	}


### PR DESCRIPTION
If access to the ALPS LLI library is not serialized
between threads, the channel can become corrupted with
unexpected bytes.

upstream merge of ofi-cray/libfabric-cray#1397

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@adf5dfdd85535f645058d2ebcd25a4eab4f35d00)