### PR TITLE
Have fi_info display MR modes in short display.

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -325,9 +325,8 @@ ssize_t fi_ibv_send(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr, size_t len
 ssize_t fi_ibv_send_buf(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 			const void *buf, size_t len, void *desc, void *context)
 {
-	struct ibv_sge sge;
+	struct ibv_sge sge = fi_ibv_init_sge(buf, len, desc);
 
-	fi_ibv_set_sge(sge, buf, len, desc);
 	wr->sg_list = &sge;
 
 	return fi_ibv_send(ep, wr, len, 1, context);
@@ -336,9 +335,8 @@ ssize_t fi_ibv_send_buf(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 ssize_t fi_ibv_send_buf_inline(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 			       const void *buf, size_t len)
 {
-	struct ibv_sge sge;
+	struct ibv_sge sge = fi_ibv_init_sge_inline(buf, len);
 
-	fi_ibv_set_sge_inline(sge, buf, len);
 	wr->sg_list = &sge;
 
 	return fi_ibv_send(ep, wr, len, 1, NULL);
@@ -394,7 +392,6 @@ static int fi_ibv_get_param_int(char *param_name, char *param_str,
 
 static void fi_ibv_fini(void)
 {
-	fi_ibv_free_info();
 }
 
 VERBS_INI

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -316,17 +316,12 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 {
 	struct fi_ibv_domain *_domain;
 	struct fi_ibv_fabric *fab;
-	struct fi_info *fi;
 	int param = 0, ret;
-
-	fi = fi_ibv_get_verbs_info(info->domain_attr->name);
-	if (!fi)
-		return -FI_EINVAL;
 
 	fab = container_of(fabric, struct fi_ibv_fabric,
 			   util_fabric.fabric_fid);
 	ret = ofi_check_domain_attr(&fi_ibv_prov, fabric->api_version,
-				    fi->domain_attr, info->domain_attr);
+				    fab->info->domain_attr, info->domain_attr);
 	if (ret)
 		return ret;
 
@@ -473,6 +468,8 @@ static int fi_ibv_fabric_close(fid_t fid)
 	ret = ofi_fabric_close(&fab->util_fabric);
 	if (ret)
 		return ret;
+
+	fi_freeinfo(fab->info);
 	free(fab);
 
 	return 0;
@@ -499,10 +496,10 @@ int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		  void *context)
 {
 	struct fi_ibv_fabric *fab;
-	struct fi_info *info;
+	struct fi_info *info, *cur;
 	int ret;
 
-	ret = fi_ibv_init_info();
+	ret = fi_ibv_init_info(&info);
 	if (ret)
 		return ret;
 
@@ -510,8 +507,8 @@ int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 	if (!fab)
 		return -FI_ENOMEM;
 
-	for (info = verbs_info; info; info = info->next) {
-		ret = ofi_fabric_init(&fi_ibv_prov, info->fabric_attr, attr,
+	for (cur = info; cur; cur = info->next) {
+		ret = ofi_fabric_init(&fi_ibv_prov, cur->fabric_attr, attr,
 				      &fab->util_fabric, context);
 		if (ret != -FI_ENODATA)
 			break;
@@ -520,6 +517,10 @@ int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		free(fab);
 		return ret;
 	}
+
+	fab->info = fi_dupinfo(cur);
+	if (!fab->info)
+		return -FI_ENOMEM;
 
 	*fabric = &fab->util_fabric.fabric_fid;
 	(*fabric)->fid.ops = &fi_ibv_fi_ops;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -73,14 +73,10 @@ static struct fi_info *
 fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event,
 		struct fi_info *pep_info)
 {
-	struct fi_info *info, *fi;
+	struct fi_info *info;
 	struct fi_ibv_connreq *connreq;
 
-	fi = fi_ibv_get_verbs_info(ibv_get_device_name(event->id->verbs->device));
-	if (!fi)
-		return NULL;
-
-	info = fi_dupinfo(fi);
+	info = fi_dupinfo(fab->info);
 	if (!info)
 		return NULL;
 

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -113,9 +113,8 @@ static ssize_t
 fi_ibv_msg_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	if (flags & FI_REMOTE_CQ_DATA) {
 		wr.opcode = IBV_WR_SEND_WITH_IMM;
 		wr.imm_data = htonl((uint32_t)msg->data);
@@ -132,9 +131,8 @@ fi_ibv_msg_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 		void *desc, fi_addr_t dest_addr, void *context)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND;
 
 	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
@@ -148,9 +146,8 @@ fi_ibv_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		    void *desc, uint64_t data, fi_addr_t dest_addr, void *context)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND_WITH_IMM;
 	wr.imm_data = htonl((uint32_t)data);
 
@@ -165,9 +162,8 @@ fi_ibv_msg_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
                  size_t count, fi_addr_t dest_addr, void *context)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND;
 
 	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
@@ -178,9 +174,8 @@ static ssize_t fi_ibv_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size
 		fi_addr_t dest_addr)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND;
 	wr.send_flags = IBV_SEND_INLINE;
 
@@ -193,9 +188,8 @@ static ssize_t fi_ibv_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, 
 		    uint64_t data, fi_addr_t dest_addr)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND_WITH_IMM;
 	wr.imm_data = htonl((uint32_t)data);
 	wr.send_flags = IBV_SEND_INLINE;

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -175,8 +175,7 @@ static int fi_ibv_msg_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 
 static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 {
-	struct ibv_qp_init_attr attr;
-	struct fi_info *verbs_info;
+	struct ibv_qp_init_attr attr = { 0 };
 	struct fi_ibv_msg_ep *_ep;
 	struct ibv_pd *pd;
 
@@ -208,13 +207,6 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 		return -FI_ENOCQ;
 	}
 
-	verbs_info = fi_ibv_get_verbs_info(_ep->info->domain_attr->name);
-	if (!verbs_info) {
-		VERBS_INFO(FI_LOG_EP_CTRL, "Unable to find matching verbs_info\n");
-		return -FI_EINVAL;
-	}
-
-	memset(&attr, 0, sizeof attr);
 	if (_ep->scq) {
 		attr.cap.max_send_wr = _ep->info->tx_attr->size;
 		attr.cap.max_send_sge = _ep->info->tx_attr->iov_limit;
@@ -249,8 +241,7 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 	attr.sq_sig_all = 0;
 	attr.qp_context = _ep;
 
-	return rdma_create_qp(_ep->id, pd, &attr) ?
-		-errno : 0;
+	return rdma_create_qp(_ep->id, pd, &attr) ? -errno : 0;
 }
 
 static int fi_ibv_msg_ep_control(struct fid *fid, int command, void *arg)
@@ -297,11 +288,7 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		return -FI_EINVAL;
 	}
 
-	fi = fi_ibv_get_verbs_info(info->domain_attr->name);
-	if (!fi) {
-		VERBS_INFO(FI_LOG_DOMAIN, "Unable to find matching verbs_info\n");
-		return -FI_EINVAL;
-	}
+	fi = dom->info;
 
 	if (info->ep_attr) {
 		ret = fi_ibv_check_ep_attr(info->ep_attr, fi);


### PR DESCRIPTION
This dis-ambiguates the verbs provider entries returned
with "fi_info".

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>