### PR TITLE
Do not cache a copy of struct fi_info in the verbs provider,

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -510,8 +510,8 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->ep_fid.fid.ops = &fi_ibv_rdm_ep_ops;
 	_ep->ep_fid.ops = &fi_ibv_rdm_ep_base_ops;
 	_ep->ep_fid.cm = &fi_ibv_rdm_tagged_ep_cm_ops;
-	_ep->ep_fid.msg = fi_ibv_rdm_ep_ops_msg();
-	_ep->ep_fid.rma = fi_ibv_rdm_ep_ops_rma();
+	_ep->ep_fid.msg = &fi_ibv_msg_ep_msg_ops;
+	_ep->ep_fid.rma = &fi_ibv_msg_ep_rma_ops;
 	_ep->ep_fid.tagged = &fi_ibv_rdm_tagged_ops;
 	_ep->tx_selective_completion = 0;
 	_ep->rx_selective_completion = 0;

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -392,7 +392,6 @@ static int fi_ibv_get_param_int(char *param_name, char *param_str,
 
 static void fi_ibv_fini(void)
 {
-	fi_ibv_free_info();
 }
 
 VERBS_INI

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -325,9 +325,8 @@ ssize_t fi_ibv_send(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr, size_t len
 ssize_t fi_ibv_send_buf(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 			const void *buf, size_t len, void *desc, void *context)
 {
-	struct ibv_sge sge;
+	struct ibv_sge sge = fi_ibv_init_sge(buf, len, desc);
 
-	fi_ibv_set_sge(sge, buf, len, desc);
 	wr->sg_list = &sge;
 
 	return fi_ibv_send(ep, wr, len, 1, context);
@@ -336,9 +335,8 @@ ssize_t fi_ibv_send_buf(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 ssize_t fi_ibv_send_buf_inline(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 			       const void *buf, size_t len)
 {
-	struct ibv_sge sge;
+	struct ibv_sge sge = fi_ibv_init_sge_inline(buf, len);
 
-	fi_ibv_set_sge_inline(sge, buf, len);
 	wr->sg_list = &sge;
 
 	return fi_ibv_send(ep, wr, len, 1, NULL);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -318,15 +318,12 @@ int fi_rbv_rdm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 			struct fid_cntr **cntr, void *context);
 int fi_ibv_rdm_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 			struct fid_av **av_fid, void *context);
-struct fi_ops_atomic *fi_ibv_msg_ep_ops_atomic(struct fi_ibv_msg_ep *ep);
-struct fi_ops_cm *fi_ibv_msg_ep_ops_cm(struct fi_ibv_msg_ep *ep);
-struct fi_ops_msg *fi_ibv_msg_ep_ops_msg(struct fi_ibv_msg_ep *ep);
-struct fi_ops_rma *fi_ibv_msg_ep_ops_rma(struct fi_ibv_msg_ep *ep);
 
-struct fi_ops_rma *fi_ibv_rdm_ep_ops_rma();
-struct fi_ops_msg *fi_ibv_rdm_ep_ops_msg();
-
-struct fi_ops_msg *fi_ibv_msg_srq_ep_ops_msg(struct fi_ibv_msg_ep *ep);
+struct fi_ops_atomic fi_ibv_msg_ep_atomic_ops;
+struct fi_ops_cm fi_ibv_msg_ep_cm_ops;
+struct fi_ops_msg fi_ibv_msg_ep_msg_ops;
+struct fi_ops_rma fi_ibv_msg_ep_rma_ops;
+struct fi_ops_msg fi_ibv_msg_srq_ep_msg_ops;
 
 struct fi_ibv_connreq {
 	struct fid		handle;
@@ -382,12 +379,10 @@ int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype
 			enum fi_op op, struct fi_atomic_attr *attr,
 			uint64_t flags);
 
-#define fi_ibv_set_sge(sge, buf, len, desc)				\
-	do {								\
-		sge.addr = (uintptr_t)buf;				\
-		sge.length = (uint32_t)len;				\
-		sge.lkey = (uint32_t)(uintptr_t)desc;			\
-	} while (0)
+#define fi_ibv_init_sge(buf, len, desc) (struct ibv_sge)		\
+	{ .addr = (uintptr_t)buf,					\
+	  .length = (uint32_t)len,					\
+	  .lkey = (uint32_t)(uintptr_t)desc }
 
 #define fi_ibv_set_sge_iov(sg_list, iov, count, desc, len)		\
 	do {								\
@@ -395,7 +390,7 @@ int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype
 		if (count) {						\
 			sg_list = alloca(sizeof(*sg_list) * count);	\
 			for (i = 0; i < count; i++) {			\
-				fi_ibv_set_sge(sg_list[i],		\
+				sg_list[i] = fi_ibv_init_sge(		\
 						iov[i].iov_base,	\
 						iov[i].iov_len,		\
 						desc[i]);		\
@@ -404,11 +399,7 @@ int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype
 		}							\
 	} while (0)
 
-#define fi_ibv_set_sge_inline(sge, buf, len)				\
-	do {								\
-		sge.addr = (uintptr_t)buf;				\
-		sge.length = (uint32_t)len;				\
-	} while (0)
+#define fi_ibv_init_sge_inline(buf, len) fi_ibv_init_sge(buf, len, NULL)
 
 #define fi_ibv_set_sge_iov_inline(sg_list, iov, count, len)		\
 	do {								\
@@ -416,7 +407,7 @@ int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype
 		if (count) {						\
 			sg_list = alloca(sizeof(*sg_list) * count);	\
 			for (i = 0; i < count; i++) {			\
-				fi_ibv_set_sge_inline(sg_list[i],	\
+				sg_list[i] = fi_ibv_init_sge_inline(	\
 						iov[i].iov_base,	\
 						iov[i].iov_len);	\
 				len += iov[i].iov_len;			\

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -106,7 +106,6 @@
 #define VERBS_MR_IOV_LIMIT 1
 
 extern struct fi_provider fi_ibv_prov;
-extern struct fi_info *verbs_info;
 
 extern size_t verbs_default_tx_size;
 extern size_t verbs_default_rx_size;
@@ -127,6 +126,8 @@ struct verbs_dev_info {
 
 struct fi_ibv_fabric {
 	struct util_fabric	util_fabric;
+	struct fi_info		*info;
+	struct fi_info		*all_infos;
 };
 
 int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
@@ -334,10 +335,8 @@ int fi_ibv_sockaddr_len(struct sockaddr *addr);
 
 
 int fi_ibv_init_info();
-void fi_ibv_free_info();
 int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, struct fi_info *hints, struct fi_info **info);
-struct fi_info *fi_ibv_get_verbs_info(const char *domain_name);
 int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags,
 		     struct rdma_addrinfo *rai);
 int fi_ibv_get_rdma_rai(const char *node, const char *service, uint64_t flags,

--- a/prov/verbs/src/verbs_atomic.c
+++ b/prov/verbs/src/verbs_atomic.c
@@ -438,7 +438,7 @@ fi_ibv_msg_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 			result_desc[0], msg->context);
 }
 
-static struct fi_ops_atomic fi_ibv_msg_ep_atomic_ops = {
+struct fi_ops_atomic fi_ibv_msg_ep_atomic_ops = {
 	.size		= sizeof(struct fi_ops_atomic),
 	.write		= fi_ibv_msg_ep_atomic_write,
 	.writev		= fi_ibv_msg_ep_atomic_writev,
@@ -454,8 +454,3 @@ static struct fi_ops_atomic fi_ibv_msg_ep_atomic_ops = {
 	.readwritevalid	= fi_ibv_msg_ep_atomic_readwritevalid,
 	.compwritevalid = fi_ibv_msg_ep_atomic_compwritevalid
 };
-
-struct fi_ops_atomic *fi_ibv_msg_ep_ops_atomic(struct fi_ibv_msg_ep *ep)
-{
-	return &fi_ibv_msg_ep_atomic_ops;
-}

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -217,7 +217,7 @@ static int fi_ibv_msg_ep_shutdown(struct fid_ep *ep, uint64_t flags)
 	return rdma_disconnect(_ep->id) ? -errno : 0;
 }
 
-static struct fi_ops_cm fi_ibv_msg_ep_cm_ops = {
+struct fi_ops_cm fi_ibv_msg_ep_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
 	.setname = fi_ibv_msg_ep_setname,
 	.getname = fi_ibv_msg_ep_getname,
@@ -229,12 +229,6 @@ static struct fi_ops_cm fi_ibv_msg_ep_cm_ops = {
 	.shutdown = fi_ibv_msg_ep_shutdown,
 	.join = fi_no_join,
 };
-
-struct fi_ops_cm *fi_ibv_msg_ep_ops_cm(struct fi_ibv_msg_ep *ep)
-{
-	return &fi_ibv_msg_ep_cm_ops;
-}
-
 
 static int fi_ibv_pep_setname(fid_t pep_fid, void *addr, size_t addrlen)
 {

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -113,9 +113,8 @@ static ssize_t
 fi_ibv_msg_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	if (flags & FI_REMOTE_CQ_DATA) {
 		wr.opcode = IBV_WR_SEND_WITH_IMM;
 		wr.imm_data = htonl((uint32_t)msg->data);
@@ -132,9 +131,8 @@ fi_ibv_msg_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 		void *desc, fi_addr_t dest_addr, void *context)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND;
 
 	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
@@ -148,9 +146,8 @@ fi_ibv_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		    void *desc, uint64_t data, fi_addr_t dest_addr, void *context)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND_WITH_IMM;
 	wr.imm_data = htonl((uint32_t)data);
 
@@ -165,9 +162,8 @@ fi_ibv_msg_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
                  size_t count, fi_addr_t dest_addr, void *context)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND;
 
 	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
@@ -178,9 +174,8 @@ static ssize_t fi_ibv_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size
 		fi_addr_t dest_addr)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND;
 	wr.send_flags = IBV_SEND_INLINE;
 
@@ -193,9 +188,8 @@ static ssize_t fi_ibv_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, 
 		    uint64_t data, fi_addr_t dest_addr)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 
-	memset(&wr, 0, sizeof(wr));
 	wr.opcode = IBV_WR_SEND_WITH_IMM;
 	wr.imm_data = htonl((uint32_t)data);
 	wr.send_flags = IBV_SEND_INLINE;
@@ -205,7 +199,7 @@ static ssize_t fi_ibv_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, 
 	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
 }
 
-static struct fi_ops_msg fi_ibv_msg_ep_msg_ops = {
+struct fi_ops_msg fi_ibv_msg_ep_msg_ops = {
 	.size = sizeof(struct fi_ops_msg),
 	.recv = fi_ibv_msg_ep_recv,
 	.recvv = fi_ibv_msg_ep_recvv,
@@ -218,12 +212,7 @@ static struct fi_ops_msg fi_ibv_msg_ep_msg_ops = {
 	.injectdata = fi_ibv_msg_ep_injectdata,
 };
 
-struct fi_ops_msg *fi_ibv_msg_ep_ops_msg(struct fi_ibv_msg_ep *ep)
-{
-	return &fi_ibv_msg_ep_msg_ops;
-}
-
-static struct fi_ops_msg fi_ibv_msg_srq_ep_msg_ops = {
+struct fi_ops_msg fi_ibv_msg_srq_ep_msg_ops = {
 	.size = sizeof(struct fi_ops_msg),
 	.recv = fi_no_msg_recv,
 	.recvv = fi_no_msg_recvv,
@@ -235,9 +224,3 @@ static struct fi_ops_msg fi_ibv_msg_srq_ep_msg_ops = {
 	.senddata = fi_ibv_msg_ep_senddata,
 	.injectdata = fi_ibv_msg_ep_injectdata,
 };
-
-struct fi_ops_msg *fi_ibv_msg_srq_ep_ops_msg(struct fi_ibv_msg_ep *ep)
-{
-	return &fi_ibv_msg_srq_ep_msg_ops;
-}
-

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -175,8 +175,7 @@ static int fi_ibv_msg_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 
 static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 {
-	struct ibv_qp_init_attr attr;
-	struct fi_info *verbs_info;
+	struct ibv_qp_init_attr attr = { 0 };
 	struct fi_ibv_msg_ep *_ep;
 	struct ibv_pd *pd;
 
@@ -208,13 +207,6 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 		return -FI_ENOCQ;
 	}
 
-	verbs_info = fi_ibv_get_verbs_info(_ep->info->domain_attr->name);
-	if (!verbs_info) {
-		VERBS_INFO(FI_LOG_EP_CTRL, "Unable to find matching verbs_info\n");
-		return -FI_EINVAL;
-	}
-
-	memset(&attr, 0, sizeof attr);
 	if (_ep->scq) {
 		attr.cap.max_send_wr = _ep->info->tx_attr->size;
 		attr.cap.max_send_sge = _ep->info->tx_attr->iov_limit;
@@ -296,11 +288,7 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		return -FI_EINVAL;
 	}
 
-	fi = fi_ibv_get_verbs_info(info->domain_attr->name);
-	if (!fi) {
-		VERBS_INFO(FI_LOG_DOMAIN, "Unable to find matching verbs_info\n");
-		return -FI_EINVAL;
-	}
+	fi = dom->info;
 
 	if (info->ep_attr) {
 		ret = fi_ibv_check_ep_attr(info->ep_attr, fi);

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -242,15 +242,14 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep)
 
 		/* Override the default ops to prevent the user from posting WRs to a
 		 * QP where a SRQ is attached to */
-		_ep->ep_fid.msg = fi_ibv_msg_srq_ep_ops_msg(_ep);
+		_ep->ep_fid.msg = &fi_ibv_msg_srq_ep_msg_ops;
 	}
 
 	attr.qp_type = IBV_QPT_RC;
 	attr.sq_sig_all = 0;
 	attr.qp_context = _ep;
 
-	return rdma_create_qp(_ep->id, pd, &attr) ?
-		-errno : 0;
+	return rdma_create_qp(_ep->id, pd, &attr) ? -errno : 0;
 }
 
 static int fi_ibv_msg_ep_control(struct fid *fid, int command, void *arg)
@@ -360,10 +359,10 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->ep_fid.fid.context = context;
 	_ep->ep_fid.fid.ops = &fi_ibv_msg_ep_ops;
 	_ep->ep_fid.ops = &fi_ibv_msg_ep_base_ops;
-	_ep->ep_fid.msg = fi_ibv_msg_ep_ops_msg(_ep);
-	_ep->ep_fid.cm = fi_ibv_msg_ep_ops_cm(_ep);
-	_ep->ep_fid.rma = fi_ibv_msg_ep_ops_rma(_ep);
-	_ep->ep_fid.atomic = fi_ibv_msg_ep_ops_atomic(_ep);
+	_ep->ep_fid.msg = &fi_ibv_msg_ep_msg_ops;
+	_ep->ep_fid.cm = &fi_ibv_msg_ep_cm_ops;
+	_ep->ep_fid.rma = &fi_ibv_msg_ep_rma_ops;
+	_ep->ep_fid.atomic = &fi_ibv_msg_ep_atomic_ops;
 
 	ofi_atomic_initialize32(&_ep->unsignaled_send_cnt, 0);
 	ofi_atomic_initialize32(&_ep->comp_pending, 0);

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -225,7 +225,7 @@ fi_ibv_msg_ep_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_
 	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
 }
 
-static struct fi_ops_rma fi_ibv_msg_ep_rma_ops = {
+struct fi_ops_rma fi_ibv_msg_ep_rma_ops = {
 	.size = sizeof(struct fi_ops_rma),
 	.read = fi_ibv_msg_ep_rma_read,
 	.readv = fi_ibv_msg_ep_rma_readv,
@@ -237,11 +237,6 @@ static struct fi_ops_rma fi_ibv_msg_ep_rma_ops = {
 	.writedata = fi_ibv_msg_ep_rma_writedata,
 	.injectdata = fi_ibv_msg_ep_rma_inject_writedata,
 };
-
-struct fi_ops_rma *fi_ibv_msg_ep_ops_rma(struct fi_ibv_msg_ep *ep)
-{
-	return &fi_ibv_msg_ep_rma_ops;
-}
 
 static inline ssize_t
 fi_ibv_rdm_ep_rma_preinit(void **desc, struct fi_ibv_rdm_buf **rdm_buf,


### PR DESCRIPTION
plus misc cleanups.

Instead keep just a copy of the used fi_info structure in the
domain object. This is a little more efficient and also more
correct since the list returned by ibv_get_device_list can change
between consecutive calls (since rdma-core v13).

Also use C99 compound assignment and initialization.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>