### PR TITLE
Updates to util and rxm providers

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -185,6 +185,7 @@ uint64_t fi_gettime_us(void);
 #define AF_IB 27
 #endif
 
+#define ofi_sa_family(addr) ((struct sockaddr *)(addr))->sa_family
 #define ofi_sin_addr(addr) (((struct sockaddr_in *)(addr))->sin_addr)
 #define ofi_sin_port(addr) (((struct sockaddr_in *)(addr))->sin_port)
 
@@ -240,6 +241,22 @@ int ofi_str_toaddr(const char *str, uint32_t *addr_format,
 
 int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
 		const struct sockaddr *sa2);
+void ofi_straddr_log_internal(const char *func, int line,
+			      const struct fi_provider *prov,
+			      enum fi_log_level level,
+			      enum fi_log_subsys subsys, char *log_str,
+			      const void *addr);
+
+#define ofi_straddr_log(...) \
+	ofi_straddr_log_internal(__func__, __LINE__, __VA_ARGS__)
+
+#if ENABLE_DEBUG
+#define ofi_straddr_dbg(prov, subsystem, ...) \
+	ofi_straddr_log(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
+#else
+#define ofi_straddr_dbg(prov, subsystem, ...) do {} while(0)
+#endif
+
 /*
  * Key Index
  */

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -383,10 +383,8 @@ int rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 		}
 	}
 
-	if (rx_buf->ep->rxm_info->caps & FI_DIRECTED_RECV)
-		match_attr.addr = rx_buf->conn->handle.fi_addr;
-	else
-		match_attr.addr = FI_ADDR_UNSPEC;
+	/* fi_addr would be FI_ADDR_UNSPEC if there is no corresponding AV entry */
+	match_attr.addr = rx_buf->conn->handle.fi_addr;
 
 	if (rx_buf->ep->rxm_info->caps & FI_SOURCE)
 		util_cq->src[ofi_cirque_windex(util_cq->cirq)] = rx_buf->conn->handle.fi_addr;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -994,7 +994,6 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 	struct util_cmap_attr attr;
 	struct rxm_ep *rxm_ep;
 	struct util_av *util_av;
-	char buf[OFI_ADDRSTRLEN];
 	void *name;
 	size_t len;
 	int ret = 0;
@@ -1015,11 +1014,8 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 			free(name);
 			return ret;
 		}
-		len = sizeof(buf);
-		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "local_name: %s\n",
-		       ofi_straddr(buf, &len,
-				   ofi_translate_addr_format(((struct sockaddr *)name)->sa_family),
-				   name));
+		ofi_straddr_dbg(&rxm_prov, FI_LOG_EP_CTRL, "local_name", name);
+
 		attr.name		= name;
 		attr.alloc 		= rxm_conn_alloc;
 		attr.close 		= rxm_conn_close;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -502,6 +502,8 @@ static void *sock_ep_cm_connect_handler(void *data)
 		goto out;
 	}
 
+	ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL, "Connecting to address",
+			&handle->dest_addr);
 	sock_set_sockopts_conn(sock_fd);
 	ret = connect(sock_fd, (struct sockaddr *)&handle->dest_addr,
 		      sizeof(handle->dest_addr));

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -661,6 +661,10 @@ static int ip_av_insert_addr(struct util_av *av, const void *addr,
 
 	if (fi_addr)
 		*fi_addr = !ret ? index : FI_ADDR_NOTAVAIL;
+
+	ofi_straddr_dbg(av->prov, FI_LOG_AV, "av_insert addr", addr);
+	FI_DBG(av->prov, FI_LOG_AV, "av_insert fi_addr: %" PRIu64 "\n", *fi_addr);
+
 	return ret;
 }
 
@@ -1259,13 +1263,10 @@ int ofi_cmap_process_connreq(struct util_cmap *cmap, void *addr,
 			     struct util_cmap_handle **handle_ret)
 {
 	struct util_cmap_handle *handle;
-#if ENABLE_DEBUG
-	char buf[OFI_ADDRSTRLEN];
-	uint32_t addr_format;
-	size_t len;
-#endif
 	int ret = 0, index;
 
+	ofi_straddr_dbg(cmap->av->prov, FI_LOG_EP_CTRL,
+			"Processing connreq for addr", addr);
 	index = ip_av_get_index(cmap->av, addr);
 	fastlock_acquire(&cmap->lock);
 	if (index < 0)
@@ -1291,14 +1292,11 @@ int ofi_cmap_process_connreq(struct util_cmap *cmap, void *addr,
 		ret = -FI_EALREADY;
 		break;
 	case CMAP_CONNREQ_SENT:
-#if ENABLE_DEBUG
-		addr_format = ofi_translate_addr_format(((struct sockaddr *)addr)->sa_family);
-		len = sizeof(buf);
-		FI_DBG(cmap->av->prov, FI_LOG_FABRIC, "local_name: %s\n",
-		       ofi_straddr(buf, &len, addr_format, cmap->attr.name));
-		FI_DBG(cmap->av->prov, FI_LOG_FABRIC, "remote_name: %s\n",
-		       ofi_straddr(buf, &len, addr_format, addr));
-#endif
+		ofi_straddr_dbg(cmap->av->prov, FI_LOG_EP_CTRL, "local_name",
+				cmap->attr.name);
+		ofi_straddr_dbg(cmap->av->prov, FI_LOG_EP_CTRL, "remote_name",
+				addr);
+
 		if (ofi_addr_cmp(cmap->av->prov, addr, cmap->attr.name) < 0) {
 			FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
 				"Remote name lower than local name.\n");

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1275,9 +1275,14 @@ int ofi_cmap_process_connreq(struct util_cmap *cmap, void *addr,
 		handle = util_cmap_get_handle(cmap, (fi_addr_t)index, addr);
 
 	if (!handle) {
-		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
-		       "No handle found for given addr\n");
-		ret = util_cmap_alloc_handle_peer(cmap, addr, CMAP_CONNREQ_RECV, &handle);
+		if (index < 0)
+			ret = util_cmap_alloc_handle_peer(cmap, addr,
+							  CMAP_CONNREQ_RECV,
+							  &handle);
+		else
+			ret = util_cmap_alloc_handle(cmap, (fi_addr_t)index,
+						     CMAP_CONNREQ_RECV,
+						     &handle);
 		if (ret)
 			goto unlock;
 	}

--- a/src/common.c
+++ b/src/common.c
@@ -471,6 +471,23 @@ int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
 	}
 }
 
+void ofi_straddr_log_internal(const char *func, int line,
+			      const struct fi_provider *prov,
+			      enum fi_log_level level,
+			      enum fi_log_subsys subsys, char *log_str,
+			      const void *addr)
+{
+	char buf[OFI_ADDRSTRLEN];
+	uint32_t addr_format;
+	size_t len = sizeof(buf);
+
+	if (fi_log_enabled(prov, level, subsys)) {
+		addr_format = ofi_translate_addr_format(ofi_sa_family(addr));
+		fi_log(prov, level, subsys, func, line, "%s: %s\n", log_str,
+		       ofi_straddr(buf, &len, addr_format, addr));
+	}
+}
+
 #ifndef HAVE_EPOLL
 
 int fi_epoll_create(struct fi_epoll **ep)


### PR DESCRIPTION
- Add a function for logging address in FI_ADDR_STR format
- prov/rxm: Fix an issue where fi_addr was not stored with connection info

Fixes #3196 


