### PR TITLE
v1.4.3: usnic: Properly handle invalid service argument.

### DIFF
--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -666,11 +666,11 @@ usdf_getinfo(uint32_t version, const char *node, const char *service,
 	if (node != NULL || service != NULL) {
 		ret = getaddrinfo(node, service, NULL, &ai);
 		if (ret != 0) {
-			USDF_DBG("getaddrinfo failed, likely bad node/service specified (%s:%s)\n",
-				node, service);
-			ret = -errno;
+			USDF_DBG("getaddrinfo failed: %d: <%s>\n", ret,
+				 gai_strerror(ret));
 			goto fail;
 		}
+
 		if (flags & FI_SOURCE) {
 			src = (struct sockaddr_in *)ai->ai_addr;
 		} else {


### PR DESCRIPTION
The value of errno when service is invalid can be 0, indicating a successful call. At this time, the info structure has not been set and is invalid. This causes a seg fault in the framework.

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>
(cherry picked from commit 149ca567d5fe35e4d25beffbe2448c0c749aec31)