### PR TITLE
util: Update cmap on av_insert + rxm bug fix

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -482,6 +482,7 @@ struct util_cmap {
 struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t key);
 int ofi_cmap_get_handle(struct util_cmap *cmap, fi_addr_t fi_addr,
 			struct util_cmap_handle **handle);
+void ofi_cmap_update(struct util_cmap *cmap, const void *addr, fi_addr_t fi_addr);
 
 void ofi_cmap_process_connect(struct util_cmap *cmap,
 			      struct util_cmap_handle *handle,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -80,7 +80,7 @@ static int rxm_match_unexp_msg_tagged(struct dlist_entry *item, const void *arg)
 	struct rxm_unexp_msg *unexp_msg;
 
 	unexp_msg = container_of(item, struct rxm_unexp_msg, entry);
-	return rxm_match_addr(attr->tag, unexp_msg->addr) &&
+	return rxm_match_addr(attr->addr, unexp_msg->addr) &&
 		rxm_match_tag(attr->tag, attr->ignore, unexp_msg->tag);
 }
 


### PR DESCRIPTION
- On av_insert, if a particular connection handle is found in peer list
  move it to handle array
- Fix a bug in address matching for unexpected tagged messages.
- Added more debug logging

Fixes #3196