### PR TITLE
prov/verbs: fix for #3198: do not cache info

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -49,6 +49,8 @@ extern struct dlist_entry fi_ibv_rdm_posted_queue;
 extern struct util_buf_pool* fi_ibv_rdm_request_pool;
 extern struct util_buf_pool* fi_ibv_rdm_extra_buffers_pool;
 extern struct fi_provider fi_ibv_prov;
+extern struct fi_ops_msg fi_ibv_rdm_ep_msg_ops;
+extern struct fi_ops_rma fi_ibv_rdm_ep_rma_ops;
 
 static int
 fi_ibv_rdm_find_max_inline(struct ibv_pd *pd, struct ibv_context *context)
@@ -510,8 +512,8 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 	_ep->ep_fid.fid.ops = &fi_ibv_rdm_ep_ops;
 	_ep->ep_fid.ops = &fi_ibv_rdm_ep_base_ops;
 	_ep->ep_fid.cm = &fi_ibv_rdm_tagged_ep_cm_ops;
-	_ep->ep_fid.msg = &fi_ibv_msg_ep_msg_ops;
-	_ep->ep_fid.rma = &fi_ibv_msg_ep_rma_ops;
+	_ep->ep_fid.msg = &fi_ibv_rdm_ep_msg_ops;
+	_ep->ep_fid.rma = &fi_ibv_rdm_ep_rma_ops;
 	_ep->ep_fid.tagged = &fi_ibv_rdm_tagged_ops;
 	_ep->tx_selective_completion = 0;
 	_ep->rx_selective_completion = 0;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -288,7 +288,7 @@ static ssize_t fi_ibv_rdm_injectdata(struct fid_ep *ep, const void *buf,
 	return -FI_ENOSYS;
 }
 
-static struct fi_ops_msg fi_ibv_rdm_ep_msg_ops = {
+struct fi_ops_msg fi_ibv_rdm_ep_msg_ops = {
 	.size = sizeof(struct fi_ops_msg),
 	.recv = fi_ibv_rdm_recv,
 	.recvv = fi_ibv_rdm_recvv,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -337,6 +337,8 @@ int fi_ibv_sockaddr_len(struct sockaddr *addr);
 int fi_ibv_init_info();
 int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, struct fi_info *hints, struct fi_info **info);
+struct fi_info *fi_ibv_get_verbs_info(struct fi_info *ilist,
+				      const char *domain_name);
 int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags,
 		     struct rdma_addrinfo *rai);
 int fi_ibv_get_rdma_rai(const char *node, const char *service, uint64_t flags,

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -316,12 +316,18 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 {
 	struct fi_ibv_domain *_domain;
 	struct fi_ibv_fabric *fab;
+	struct fi_info *fi;
 	int param = 0, ret;
 
 	fab = container_of(fabric, struct fi_ibv_fabric,
 			   util_fabric.fabric_fid);
+
+	fi = fi_ibv_get_verbs_info(fab->all_infos, info->domain_attr->name);
+	if (!fi)
+		return -FI_EINVAL;
+
 	ret = ofi_check_domain_attr(&fi_ibv_prov, fabric->api_version,
-				    fab->info->domain_attr, info->domain_attr);
+				    fi->domain_attr, info->domain_attr);
 	if (ret)
 		return ret;
 

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -35,7 +35,7 @@
 #include <fi_util.h>
 #include "fi_verbs.h"
 
-static struct fi_info *
+struct fi_info *
 fi_ibv_get_verbs_info(struct fi_info *ilist, const char *domain_name)
 {
 	struct fi_info *fi;

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -521,7 +521,7 @@ static ssize_t fi_ibv_rdm_ep_rma_inject_write(struct fid_ep *ep,
 	return ret;
 }
 
-static struct fi_ops_rma fi_ibv_rdm_ep_rma_ops = {
+struct fi_ops_rma fi_ibv_rdm_ep_rma_ops = {
 	.size		= sizeof(struct fi_ops_rma),
 	.read		= fi_ibv_rdm_ep_rma_read,
 	.readv		= fi_ibv_rdm_ep_rma_readv,


### PR DESCRIPTION
- there are too aggressive refactoring in PR
  https://github.com/ofiwg/libfabric/pull/3198
  we have to rollback small portion of changes and
  fix issue in initialization

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>