### PR TITLE
prov/verbs: fixed issue in close protocol

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -128,7 +128,11 @@ ssize_t fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_conn *conn)
 	case FI_VERBS_CONN_REJECTED:
 		conn->state = FI_VERBS_CONN_CLOSED;
 		break;
+	case FI_VERBS_CONN_CLOSED:
+		break;
 	default:
+		VERBS_WARN(FI_LOG_EP_CTRL, "Unknown connection state: %d\n",
+			  (int)conn->state);
 		ret = -FI_EOTHER;
 	}
 


### PR DESCRIPTION
- in some cases there could be race in closing
  verbs QP & connection states (when connection is closed
  simultaneously on both sides). In this case state
  'closed' should be processed without real actions.
- added minor debug output

Signed-off-by: Oblomov, Sergey <sergey.oblomov@intel.com>