### PR TITLE
prov/sockets: swat compiler warning

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -638,6 +638,7 @@ static int sock_node_matches_interface(struct slist *addr_list, const char *node
 	struct sockaddr_in addr;
 	int ret;
 
+	memset(&addr, 0, sizeof(addr));
 	memset(&ai, 0, sizeof(ai));
 	ai.ai_family = AF_INET;
 	ai.ai_socktype = SOCK_STREAM;


### PR DESCRIPTION
With gcc 6.3.0 I'm seeing this warning now as the sockets provider
code is being compiled

```
In file included from ./include/linux/osd.h:42:0,
                 from ./include/fi_osd.h:67,
                 from prov/sockets/src/sock_fabric.c:50:
prov/sockets/src/sock_fabric.c: In function 'sock_getinfo':
./include/unix/osd.h:142:62: warning: 'addr.sin6_addr.__in6_u.__u6_addr32[2]' may be used uninitialized in this function [-Wmaybe-uninitialized]
   (addr->sa_family == AF_INET6 &&
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[0] == 0 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[1] == 0 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[2] == 0 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
prov/sockets/src/sock_fabric.c:638:21: note: 'addr.sin6_addr.__in6_u.__u6_addr32[2]' was declared here
  struct sockaddr_in addr;
                     ^~~~
In file included from ./include/linux/osd.h:42:0,
                 from ./include/fi_osd.h:67,
                 from prov/sockets/src/sock_fabric.c:50:
./include/unix/osd.h:143:62: warning: 'addr.sin6_addr.__in6_u.__u6_addr32[3]' may be used uninitialized in this function [-Wmaybe-uninitialized]
   (addr->sa_family == AF_INET6 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[0] == 0 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[1] == 0 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[2] == 0 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[3] == ntohl(1));
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
prov/sockets/src/sock_fabric.c:638:21: note: 'addr.sin6_addr.__in6_u.__u6_addr32[3]' was declared here
  struct sockaddr_in addr;
```

This warning goes away if addr is memset to 0.

Signed-off-by: Howard Pritchard <hppritcha@gmail.com>