### PR TITLE
fabric/fence: Increase strength of FI_FENCE definition

### DIFF
--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -563,9 +563,16 @@ with atomic message calls.
   be used with messages smaller than inject_size.
 
 *FI_FENCE*
-: Indicates that the requested operation, also
-  known as the fenced operation, be deferred until all previous operations
-  targeting the same target endpoint have completed.
+: Applies to transmits.  Indicates that the requested operation, also
+  known as the fenced operation, and any operation posted after the
+  fenced operation will be deferred until all previous operations
+  targeting the same peer endpoint have completed.  Operations posted
+  after the fencing will see and/or replace the results of any
+  operations initiated prior to the fenced operation.
+  
+  The ordering of operations starting at the posting of the fenced
+  operation (inclusive) to the posting of a subsequent fenced operation
+  (exclusive) is controlled by the endpoint's ordering semantics.
 
 *FI_TAGGED*
 : Specifies that the target of the atomic operation is a tagged receive

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -272,8 +272,15 @@ fi_sendmsg.
 
 *FI_FENCE*
 : Applies to transmits.  Indicates that the requested operation, also
-  known as the fenced operation, be deferred until all previous operations
-  targeting the same target endpoint have completed.
+  known as the fenced operation, and any operation posted after the
+  fenced operation will be deferred until all previous operations
+  targeting the same peer endpoint have completed.  Operations posted
+  after the fencing will see and/or replace the results of any
+  operations initiated prior to the fenced operation.
+  
+  The ordering of operations starting at the posting of the fenced
+  operation (inclusive) to the posting of a subsequent fenced operation
+  (exclusive) is controlled by the endpoint's ordering semantics.
 
 *FI_MULTICAST*
 : Applies to transmits.  This flag indicates that the address specified

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -269,9 +269,16 @@ fi_writemsg.
   generated when the operation has been processed by the destination.
 
 *FI_FENCE*
-: Indicates that the requested operation, also
-  known as the fenced operation, be deferred until all previous operations
-  targeting the same target endpoint have completed.
+: Applies to transmits.  Indicates that the requested operation, also
+  known as the fenced operation, and any operation posted after the
+  fenced operation will be deferred until all previous operations
+  targeting the same peer endpoint have completed.  Operations posted
+  after the fencing will see and/or replace the results of any
+  operations initiated prior to the fenced operation.
+  
+  The ordering of operations starting at the posting of the fenced
+  operation (inclusive) to the posting of a subsequent fenced operation
+  (exclusive) is controlled by the endpoint's ordering semantics.
 
 # RETURN VALUE
 

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -270,8 +270,15 @@ and/or fi_tsendmsg.
 
 *FI_FENCE*
 : Applies to transmits.  Indicates that the requested operation, also
-  known as the fenced operation, be deferred until all previous operations
-  targeting the same target endpoint have completed.
+  known as the fenced operation, and any operation posted after the
+  fenced operation will be deferred until all previous operations
+  targeting the same peer endpoint have completed.  Operations posted
+  after the fencing will see and/or replace the results of any
+  operations initiated prior to the fenced operation.
+  
+  The ordering of operations starting at the posting of the fenced
+  operation (inclusive) to the posting of a subsequent fenced operation
+  (exclusive) is controlled by the endpoint's ordering semantics.
 
 The following flags may be used with fi_trecvmsg.
 


### PR DESCRIPTION
Fixes #3186

The FI_FENCE definition guarantees ordering of the fenced operation
against operations posted prior to the fenced operation.  However,
the behavior of operations posted after the fenced operation is
not defined.  It is unclear if such operations can pass the
fenced operation or operations posted prior to the fencing.

Clarify that the fencing applies to the entire queue of
operations.  Anything else renders the fence operation
essentially meaningless.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>