### PR TITLE
prov/rxm: Update data progress type to auto

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -85,6 +85,12 @@ RxM provider does not support the following features:
 
   * fi_cq_sread, fi_cq_sreadfrom and fi_cq_signal calls.
 
+## Auto progress
+
+When sending large messages, an app doing an sread or waiting on the CQ file descriptor
+may not get a completion when reading the CQ after being woken up from the wait.
+The app has to do sread or wait on the file descriptor again.
+
 ## Usage limitations
 
 RxM provider should work fine for client - server programs like fabtests. Support for MPI, SHMEM

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -62,7 +62,7 @@ struct fi_ep_attr rxm_ep_attr = {
 struct fi_domain_attr rxm_domain_attr = {
 	.threading = FI_THREAD_SAFE,
 	.control_progress = FI_PROGRESS_AUTO,
-	.data_progress = FI_PROGRESS_MANUAL,
+	.data_progress = FI_PROGRESS_AUTO,
 	.resource_mgmt = FI_RM_ENABLED,
 	.av_type = FI_AV_UNSPEC,
 	/* Advertise support for FI_MR_BASIC so that ofi_check_info call


### PR DESCRIPTION
With 2faac2b505 auto progress is possible in most cases. This patch handles
missing progress on fi_inject case.

On large message sends an app doing an sread or waiting on the CQ file descriptor
may not get a completion when reading the CQ after being woken up from the wait.
The app has to do sread or wait on the file descriptor again.