### PR TITLE
prov/gni: Multiplex kdreg events

### DIFF
--- a/prov/gni/Makefile.include
+++ b/prov/gni/Makefile.include
@@ -40,6 +40,7 @@ _gni_files = \
 	prov/gni/src/gnix_rma.c \
 	prov/gni/src/gnix_sep.c \
 	prov/gni/src/gnix_shmem.c \
+	prov/gni/src/gnix_smrn.c \
 	prov/gni/src/gnix_tags.c \
 	prov/gni/src/gnix_trigger.c \
 	prov/gni/src/gnix_util.c \
@@ -78,6 +79,7 @@ _gni_headers = \
 	prov/gni/include/gnix_queue.h \
 	prov/gni/include/gnix_rma.h \
 	prov/gni/include/gnix_shmem.h \
+	prov/gni/include/gnix_smrn.h \
 	prov/gni/include/gnix_tags.h \
 	prov/gni/include/gnix_trigger.h \
 	prov/gni/include/gnix_util.h \
@@ -92,12 +94,17 @@ bin_PROGRAMS += prov/gni/test/gnitest
 bin_SCRIPTS += prov/gni/test/run_gnitest
 nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/allocator.c \
+	prov/gni/test/api.c \
+	prov/gni/test/api_cq.c \
+	prov/gni/test/api_cntr.c \
 	prov/gni/test/av.c \
 	prov/gni/test/auth_key.c \
 	prov/gni/test/bitmap.c \
 	prov/gni/test/buddy_allocator.c \
 	prov/gni/test/cancel.c \
 	prov/gni/test/cntr.c \
+	prov/gni/test/cm.c \
+	prov/gni/test/common.c \
 	prov/gni/test/cq.c \
 	prov/gni/test/datagram.c \
 	prov/gni/test/dlist-utils.c \
@@ -116,23 +123,19 @@ nodist_prov_gni_test_gnitest_SOURCES = \
 	prov/gni/test/rdm_atomic.c \
 	prov/gni/test/rdm_fi_pcd_trecv_msg.c \
 	prov/gni/test/rdm_dgram_rma.c \
+	prov/gni/test/rdm_dgram_stx.c \
 	prov/gni/test/rdm_rx_overrun.c \
 	prov/gni/test/rdm_sr.c \
 	prov/gni/test/rdm_tagged_sr.c \
-	prov/gni/test/tags.c \
-	prov/gni/test/api.c \
-	prov/gni/test/api_cq.c \
-	prov/gni/test/api_cntr.c \
 	prov/gni/test/sep.c \
 	prov/gni/test/shmem.c \
+	prov/gni/test/smrn.c \
+	prov/gni/test/tags.c \
 	prov/gni/test/utils.c \
 	prov/gni/test/vc.c \
 	prov/gni/test/vc_lookup.c \
 	prov/gni/test/vector.c \
-	prov/gni/test/wait.c \
-	prov/gni/test/rdm_dgram_stx.c \
-	prov/gni/test/cm.c \
-	prov/gni/test/common.c
+	prov/gni/test/wait.c
 
 prov_gni_test_gnitest_LDFLAGS = $(CRAY_PMI_LIBS) $(gnitest_LDFLAGS) -static
 prov_gni_test_gnitest_CPPFLAGS = $(AM_CPPFLAGS) $(CRAY_PMI_CFLAGS) $(CRAY_XPMEM_CFLAGS) $(gnitest_CPPFLAGS)

--- a/prov/gni/include/gnix_mr_cache.h
+++ b/prov/gni/include/gnix_mr_cache.h
@@ -110,6 +110,7 @@
 
 /* provider includes */
 #include "gnix_util.h"
+#include "gnix_smrn.h"
 
 /* struct declarations */
 struct _gnix_fi_reg_context {
@@ -150,7 +151,7 @@ typedef struct gnix_mr_cache_attr {
 	void *reg_context;
 	void *dereg_context;
 	void *destruct_context;
-	struct gnix_mr_notifier *notifier;
+	struct gnix_smrn *smrn;
 	void *(*reg_callback)(void *handle, void *address, size_t length,
 			struct _gnix_fi_reg_context *fi_reg_context,
 			void *context);
@@ -189,6 +190,7 @@ struct gnix_mrce_storage {
 typedef struct gnix_mr_cache {
 	gnix_mrc_state_e state;
 	gnix_mr_cache_attr_t attr;
+	struct gnix_smrn_rq rq;
 	struct dlist_entry lru_head;
 	struct gnix_mrce_storage inuse;
 	struct gnix_mrce_storage stale;

--- a/prov/gni/include/gnix_smrn.h
+++ b/prov/gni/include/gnix_smrn.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PROV_GNI_INCLUDE_GNIX_SMRN_H
+#define PROV_GNI_INCLUDE_GNIX_SMRN_H
+
+#include "include/fi_list.h"
+#include "include/fi_lock.h"
+#include "config.h"
+
+#include "gnix_mr_notifier.h"
+
+/**
+ * @brief shared memory registration notifier
+ *
+ * @var   lock      Only used for set up and tear down (no guarantees
+ *                  if reading or writing while setting up or tearing down)
+ */
+struct gnix_smrn {
+	fastlock_t lock;
+	struct gnix_mr_notifier *notifier;
+	struct dlist_entry rq_head;
+	int references;
+};
+
+struct gnix_smrn_rq {
+	fastlock_t lock;
+	struct dlist_entry list;
+	struct dlist_entry entry;
+};
+
+struct gnix_smrn_context {
+	struct gnix_smrn_rq *rq;
+	uint64_t cookie;
+	struct dlist_entry entry;
+};
+
+int _gnix_smrn_init(void);
+
+/**
+ * @brief open the prepare for notifications
+ *
+ * @param[in,out] k     Empty and initialized gnix_smrn struct
+ * @return              FI_SUCESSS on success
+ *                      -FI_EBUSY if device already open
+ *                      -FI_ENODATA if user delta unavailable
+ *                      -fi_errno or -errno on other failures
+ */
+int _gnix_smrn_open(struct gnix_smrn **smrn);
+
+/**
+ * @brief close the kdreg device and zero the notifier
+ *
+ * @param[in] k         gnix_smrn struct
+ * @return              FI_SUCESSS on success
+ *                      -fi_errno or -errno on other failures
+ */
+int _gnix_smrn_close(struct gnix_smrn *mrn);
+
+/**
+ * @brief monitor a memory region
+ *
+ * @param[in] k         gnix_smrn struct
+ * @param[in] addr      address of memory region to monitor
+ * @param[in] len       length of memory region
+ * @param[in] cookie    user identifier associated with the region
+ * @return              FI_SUCESSS on success
+ *                      -fi_errno or -errno on failure
+ */
+int _gnix_smrn_monitor(struct gnix_smrn *smrn,
+	struct gnix_smrn_rq *rq,
+	void *addr,
+	uint64_t len,
+	uint64_t cookie,
+	struct gnix_smrn_context *context);
+
+/**
+ * @brief stop monitoring a memory region
+ *
+ * @param[in]  k        gnix_smrn struct
+ * @param[out] cookie   user identifier for notification event
+ * @return              FI_SUCESSS on success
+ *                      -fi_errno or -errno on failure
+ */
+int _gnix_smrn_unmonitor(struct gnix_smrn *smrn,
+	uint64_t cookie,
+	struct gnix_smrn_context *context);
+
+/**
+ * @brief get a monitoring event
+ *
+ * @param[in]  k        gnix_smrn struct
+ * @param[out] buf      buffer to write event data
+ * @param[in]  len      length of buffer
+ * @return              Number of bytes read on success
+ *                      -FI_EINVAL if invalid arguments
+ *                      -FI_EAGAIN if nothing to read
+ *                      -fi_errno or -errno on failure
+ */
+int _gnix_smrn_get_event(struct gnix_smrn *smrn,
+	struct gnix_smrn_rq *rq,
+	struct gnix_smrn_context **context);
+
+#endif

--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -45,6 +45,7 @@
 #include "gnix_xpmem.h"
 #include "gnix_hashtable.h"
 #include "gnix_auth_key.h"
+#include "gnix_smrn.h"
 
 #define GNIX_MR_MODE_DEFAULT FI_MR_BASIC
 #define GNIX_NUM_PTAGS 256
@@ -88,8 +89,7 @@ static void __domain_destruct(void *obj)
 					"registration cache\n");
 	}
 
-	/* TODO: known issue of multiple consumers of notifier notifications */
-	ret = _gnix_notifier_close(domain->mr_cache_attr.notifier);
+	ret = _gnix_smrn_close(domain->mr_cache_attr.smrn);
 	if (ret != FI_SUCCESS)
 		GNIX_FATAL(FI_LOG_MR, "failed to close MR notifier\n");
 
@@ -102,7 +102,6 @@ static void __domain_destruct(void *obj)
 
 	memset(domain, 0, sizeof *domain);
 	free(domain);
-
 }
 
 static void __stx_destruct(void *obj)
@@ -625,7 +624,7 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain->mr_cache_attr.dereg_context = NULL;
 	domain->mr_cache_attr.destruct_context = NULL;
 
-	ret = _gnix_notifier_open(&domain->mr_cache_attr.notifier);
+	ret = _gnix_smrn_open(&domain->mr_cache_attr.smrn);
 	if (ret != FI_SUCCESS)
 		goto err;
 

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -770,6 +770,7 @@ GNI_INI
 	gni_return_t status;
 	gni_version_info_t lib_version;
 	int num_devices;
+	int ret;
 
 	/*
 	 * if no GNI devices available, don't register as provider
@@ -799,7 +800,10 @@ GNI_INI
 	}
 
 	/* Initialize global MR notifier. */
-	_gnix_notifier_init();
+	ret = _gnix_smrn_init();
+	if (ret != FI_SUCCESS)
+		GNIX_FATAL(FI_LOG_FABRIC,
+			"failed to initialize global mr notifier\n");
 
 	/* Initialize global NIC data. */
 	_gnix_nic_init();

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -956,6 +956,10 @@ static int __cache_init(struct gnix_fid_domain *domain,
 	struct gnix_mr_cache_info *info =
 		GNIX_GET_MR_CACHE_INFO(domain, auth_key);
 
+#if !HAVE_KDREG
+	domain->mr_cache_attr.lazy_deregistration = 0;
+#endif
+
 	ret = _gnix_mr_cache_init(&info->mr_cache_ro,
 			&domain->mr_cache_attr);
 
@@ -1204,7 +1208,11 @@ gnix_mr_cache_attr_t _gnix_default_mr_cache_attr = {
 		.soft_reg_limit      = 4096,
 		.hard_reg_limit      = -1,
 		.hard_stale_limit    = 128,
+#if HAVE_KDREG
 		.lazy_deregistration = 1,
+#else
+		.lazy_deregistration = 0,
+#endif
 		.reg_callback        = __gnix_register_region,
 		.dereg_callback      = __gnix_deregister_region,
 		.destruct_callback   = __gnix_destruct_registration,

--- a/prov/gni/src/gnix_mr_cache.c
+++ b/prov/gni/src/gnix_mr_cache.c
@@ -494,7 +494,7 @@ __clear_notifier_events(gnix_mr_cache_t *cache)
 			__entry_set_retired(entry);
 			iter = rbtFind(cache->inuse.rb_tree,
 				       &entry->key);
-			if (likely(iter != NULL)) {
+			if (OFI_LIKELY(iter != NULL)) {
 				ret = rbtErase(cache->inuse.rb_tree,
 					       iter);
 				if (ret != RBT_STATUS_OK) {

--- a/prov/gni/src/gnix_mr_cache.c
+++ b/prov/gni/src/gnix_mr_cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Cray Inc. All rights reserved.
+ * Copyright (c) 2016-2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,6 +31,7 @@
  */
 
 #include <gnix_mr_cache.h>
+#include <gnix_smrn.h>
 #include <gnix_mr_notifier.h>
 #include <gnix.h>
 
@@ -76,6 +77,7 @@ typedef struct gnix_mr_cache_key {
  * @var   children   list of subsumed child entries
  */
 typedef struct gnix_mr_cache_entry {
+	struct gnix_smrn_context context;
 	cache_entry_state_t state;
 	gnix_mr_cache_key_t key;
 	ofi_atomic32_t ref_cnt;
@@ -124,7 +126,11 @@ gnix_mr_cache_attr_t __default_mr_cache_attr = {
 		.soft_reg_limit      = 4096,
 		.hard_reg_limit      = -1,
 		.hard_stale_limit    = 128,
+#if HAVE_KDREG
 		.lazy_deregistration = 1,
+#else
+		.lazy_deregistration = 0,
+#endif
 };
 
 /* Functions for using and manipulating cache entry state */
@@ -438,10 +444,10 @@ __clear_notifier_events(gnix_mr_cache_t *cache)
 {
 	int ret;
 	gnix_mr_cache_entry_t *entry;
+	struct gnix_smrn_context *context;
 	RbtIterator iter;
-	uint64_t cookie;
 
-	if (!cache->attr.notifier) {
+	if (!cache->attr.smrn) {
 		return;
 	}
 
@@ -449,126 +455,120 @@ __clear_notifier_events(gnix_mr_cache_t *cache)
 		return;
 	}
 
-	ret = _gnix_notifier_get_event(cache->attr.notifier,
-				       &cookie, sizeof(cookie));
-	while (ret > 0) {
-		if (ret == sizeof(cookie)) {
-			entry = (gnix_mr_cache_entry_t *) cookie;
-			switch (__entry_get_state(entry)) {
-			case GNIX_CES_INUSE:
-				/* First, warn that this might be a
-				 * problem.*/
-				if ((__notifier_warned == false) &&
-				    !__entry_is_merged(entry)) {
-					GNIX_WARN(FI_LOG_MR,
-						  "Registered memory region"
-						  " includes unmapped pages."
-						  "  Have you freed memory"
-						  " without closing the memory"
-						  " region?\n");
-					__notifier_warned = true;
-				}
+	ret = _gnix_smrn_get_event(cache->attr.smrn,
+				&cache->rq, &context);
+	while (ret == FI_SUCCESS) {
+		entry = container_of(context,
+					struct gnix_mr_cache_entry, context);
+		switch (__entry_get_state(entry)) {
+		case GNIX_CES_INUSE:
+			/* First, warn that this might be a
+			 * problem.*/
+			if ((__notifier_warned == false) &&
+			    !__entry_is_merged(entry)) {
+				GNIX_WARN(FI_LOG_MR,
+					  "Registered memory region"
+					  " includes unmapped pages."
+					  "  Have you freed memory"
+					  " without closing the memory"
+					  " region?\n");
+				__notifier_warned = true;
+			}
 
-				GNIX_DEBUG(FI_LOG_MR,
-					   "Marking unmapped entry (%p)"
-					   " as retired %llx:%llx\n", entry,
-					   entry->key.address,
-					   entry->key.length);
+			GNIX_DEBUG(FI_LOG_MR,
+				   "Marking unmapped entry (%p)"
+				   " as retired %llx:%llx\n", entry,
+				   entry->key.address,
+				   entry->key.length);
 
-				__entry_set_unmapped(entry);
+			__entry_set_unmapped(entry);
 
-				if (__entry_is_retired(entry)) {
-					/* Nothing to do */
-					break;
-				}
-
-				/* Retire this entry (remove from
-				 * inuse tree) */
-
-				__entry_set_retired(entry);
-				iter = rbtFind(cache->inuse.rb_tree,
-					       &entry->key);
-				if (OFI_LIKELY(iter != NULL)) {
-					ret = rbtErase(cache->inuse.rb_tree,
-						       iter);
-					if (ret != RBT_STATUS_OK) {
-						GNIX_FATAL(FI_LOG_MR,
-							   "Unmapped entry"
-							   " could not be"
-							   " removed from"
-							   " in usetree.\n");
-					}
-				} else {
-					/*  The only way we should get
-					 *  here is if we're in the
-					 *  middle of retiring this
-					 *  entry.  Not sure if this
-					 *  is worth a separate
-					 *  warning from the one
-					 *  above. */
-				}
-
+			if (__entry_is_retired(entry)) {
+				/* Nothing to do */
 				break;
-			case GNIX_CES_STALE:
-				__entry_set_unmapped(entry);
-				iter = rbtFind(cache->stale.rb_tree,
-					       &entry->key);
-				if (!iter) {
-					break;
-				}
+			}
 
-				ret = rbtErase(cache->stale.rb_tree, iter);
+			/* Retire this entry (remove from
+			 * inuse tree) */
+
+			__entry_set_retired(entry);
+			iter = rbtFind(cache->inuse.rb_tree,
+				       &entry->key);
+			if (likely(iter != NULL)) {
+				ret = rbtErase(cache->inuse.rb_tree,
+					       iter);
 				if (ret != RBT_STATUS_OK) {
 					GNIX_FATAL(FI_LOG_MR,
-						   "Unmapped entry could"
-						   " not be removed "
-						   " from stale tree.\n");
+						   "Unmapped entry"
+						   " could not be"
+						   " removed from"
+						   " in usetree.\n");
 				}
+			} else {
+				/*  The only way we should get
+				 *  here is if we're in the
+				 *  middle of retiring this
+				 *  entry.  Not sure if this
+				 *  is worth a separate
+				 *  warning from the one
+				 *  above. */
+			}
 
-				GNIX_DEBUG(FI_LOG_MR, "Removed unmapped entry"
-					   " (%p) from stale tree %llx:%llx\n",
+			break;
+		case GNIX_CES_STALE:
+			__entry_set_unmapped(entry);
+			iter = rbtFind(cache->stale.rb_tree,
+				       &entry->key);
+			if (!iter) {
+				break;
+			}
+
+			ret = rbtErase(cache->stale.rb_tree, iter);
+			if (ret != RBT_STATUS_OK) {
+				GNIX_FATAL(FI_LOG_MR,
+					   "Unmapped entry could"
+					   " not be removed "
+					   " from stale tree.\n");
+			}
+
+			GNIX_DEBUG(FI_LOG_MR, "Removed unmapped entry"
+				   " (%p) from stale tree %llx:%llx\n",
+				   entry, entry->key.address,
+				   entry->key.length);
+
+			if (__mr_cache_lru_remove(cache, entry) == FI_SUCCESS) {
+				GNIX_DEBUG(FI_LOG_MR, "Removed"
+					   " unmapped entry (%p)"
+					   " from lru list %llx:%llx\n",
 					   entry, entry->key.address,
 					   entry->key.length);
 
-				if (__mr_cache_lru_remove(cache, entry)
-				    == FI_SUCCESS) {
-					GNIX_DEBUG(FI_LOG_MR, "Removed"
-						   " unmapped entry (%p)"
-						   " from lru list %llx:%llx\n",
-						   entry, entry->key.address,
-						   entry->key.length);
+				ofi_atomic_dec32(&cache->stale.elements);
 
-					ofi_atomic_dec32(&cache->stale.elements);
-
-				} else {
-					GNIX_WARN(FI_LOG_MR, "Failed to remove"
-						  " unmapped entry"
-						  " from lru list (%p) %p\n",
-						  entry, iter);
-				}
-				
-				__mr_cache_entry_destroy(cache, entry);
-
-				break;
-			default:
-				GNIX_FATAL(FI_LOG_MR,
-					   "Unmapped entry (%p) in incorrect"
-					   " state: %d\n",
-					   entry, entry->state);
+			} else {
+				GNIX_WARN(FI_LOG_MR, "Failed to remove"
+					  " unmapped entry"
+					  " from lru list (%p) %p\n",
+					  entry, iter);
 			}
 
-		} else {
-			/* Should we do something else here? */
+			__mr_cache_entry_destroy(cache, entry);
+
+			break;
+		default:
 			GNIX_FATAL(FI_LOG_MR,
-				   "_gnix_notifier_get_event returned incomplete event\n");
+				   "Unmapped entry (%p) in incorrect"
+				   " state: %d\n",
+				   entry, entry->state);
 		}
-		ret = _gnix_notifier_get_event(cache->attr.notifier,
-					       &cookie, sizeof(cookie));
+
+		ret = _gnix_smrn_get_event(cache->attr.smrn,
+					&cache->rq, &context);
 	}
 	if (ret != -FI_EAGAIN) {
 		/* Should we do something else here? */
 		GNIX_WARN(FI_LOG_MR,
-			  "_gnix_notifier_get_event returned error: %s\n",
+			  "_gnix_smrn_get_event returned error: %s\n",
 			  fi_strerror(-ret));
 	}
 
@@ -581,7 +581,7 @@ __clear_notifier_events(gnix_mr_cache_t *cache)
  * @param[in] cache  a memory registration cache
  * @param[in] entry  a memory registration entry
  *
- * @return           return code from _gnix_notifier_monitor
+ * @return           return code from _gnix_smrn_monitor
  */
 static int
 __notifier_monitor(gnix_mr_cache_t *cache,
@@ -592,17 +592,19 @@ __notifier_monitor(gnix_mr_cache_t *cache,
 		return FI_SUCCESS;
 	}
 
-	if (cache->attr.notifier == NULL) {
+	if (cache->attr.smrn == NULL) {
 		return FI_SUCCESS;
 	}
 
 	GNIX_DEBUG(FI_LOG_MR, "monitoring entry=%p %llx:%llx\n", entry,
 		   entry->key.address, entry->key.length);
 
-	return  _gnix_notifier_monitor(cache->attr.notifier,
+	return  _gnix_smrn_monitor(cache->attr.smrn,
+						  &cache->rq,
 					      (void *) entry->key.address,
 					      entry->key.length,
-					      (uint64_t) entry);
+					      (uint64_t) &entry->context,
+						  &entry->context);
 }
 
 /**
@@ -623,7 +625,7 @@ __notifier_unmonitor(gnix_mr_cache_t *cache,
 		return;
 	}
 
-	if (cache->attr.notifier == NULL) {
+	if (cache->attr.smrn == NULL) {
 		return;
 	}
 
@@ -632,8 +634,9 @@ __notifier_unmonitor(gnix_mr_cache_t *cache,
 	if (!__entry_is_unmapped(entry)) {
 		GNIX_DEBUG(FI_LOG_MR, "unmonitoring entry=%p (state=%d)\n",
 			   entry, entry->state);
-		rc = _gnix_notifier_unmonitor(cache->attr.notifier,
-					      (uint64_t) entry);
+		rc = _gnix_smrn_unmonitor(cache->attr.smrn,
+						  (uint64_t) &entry->context,
+					      &entry->context);
 		if (rc != FI_SUCCESS) {
 			/* This probably is okay (ESRCH), because the
 			 * memory could have been unmapped in the
@@ -1038,6 +1041,10 @@ int _gnix_mr_cache_init(
 	cache_p->misses = 0;
 
 	cache_p->state = GNIX_MRC_STATE_READY;
+
+	dlist_init(&cache_p->rq.list);
+	dlist_init(&cache_p->rq.entry);
+	fastlock_init(&cache_p->rq.lock);
 
 	*cache = cache_p;
 

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -860,6 +860,8 @@ static int __gnix_rndzv_iov_req_complete(void *arg, gni_return_t tx_status)
 	struct gnix_tx_descriptor *txd = (struct gnix_tx_descriptor *)arg;
 	struct gnix_fab_req *req = txd->req;
 	int i, ret = FI_SUCCESS;
+	struct gnix_auth_key *info __attribute__ ((unused));
+	int rc;
 
 	GNIX_TRACE(FI_LOG_EP_DATA, "\n");
 
@@ -906,8 +908,6 @@ static int __gnix_rndzv_iov_req_complete(void *arg, gni_return_t tx_status)
 			}
 		} else {
 			if (req->msg.recv_flags & FI_LOCAL_MR) {
-				struct gnix_auth_key *info = NULL;
-				int rc;
 
 				if (req->gnix_ep->domain->using_vmdh) {
 					info = req->gnix_ep->auth_key;

--- a/prov/gni/src/gnix_smrn.c
+++ b/prov/gni/src/gnix_smrn.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "gnix_util.h"
+#include "gnix_smrn.h"
+
+static struct gnix_smrn global_smrn;
+
+int _gnix_smrn_init(void)
+{
+	int ret;
+
+	fastlock_init(&global_smrn.lock);
+	global_smrn.references = 0;
+	dlist_init(&global_smrn.rq_head);
+
+	ret = _gnix_notifier_init();
+
+	return ret;
+}
+
+int _gnix_smrn_open(struct gnix_smrn **smrn)
+{
+	struct gnix_smrn *tmp = &global_smrn;
+	int ret = FI_SUCCESS;
+
+	fastlock_acquire(&tmp->lock);
+	if (tmp->references == 0)
+		ret = _gnix_notifier_open(&tmp->notifier);
+
+	if (!ret)
+		tmp->references += 1;
+	fastlock_release(&tmp->lock);
+
+	if (!ret)
+		*smrn = tmp;
+
+	return ret;
+}
+
+int _gnix_smrn_close(struct gnix_smrn *smrn)
+{
+	int ret = FI_SUCCESS;
+
+	fastlock_acquire(&smrn->lock);
+	if (smrn->references == 0)
+		ret = -FI_EINVAL;
+
+	if (smrn->references == 1)
+		ret = _gnix_notifier_close(smrn->notifier);
+
+	if (!ret)
+		smrn->references -= 1;
+	fastlock_release(&smrn->lock);
+
+	return ret;
+}
+
+int _gnix_smrn_monitor(struct gnix_smrn *smrn,
+	struct gnix_smrn_rq *rq,
+	void *addr,
+	uint64_t len,
+	uint64_t cookie,
+	struct gnix_smrn_context *context)
+{
+	int ret;
+
+	if (!context || !rq || !smrn)
+		return -FI_EINVAL;
+
+	context->rq = rq;
+	context->cookie = cookie;
+
+	ret = _gnix_notifier_monitor(smrn->notifier, addr,
+				len, (uint64_t) context);
+	if (ret == FI_SUCCESS)
+		GNIX_DEBUG(FI_LOG_FABRIC,
+				"monitoring addr=%p len=%d cookie=%p "
+				"context=%p rq=%p notifier=%p\n",
+				addr, len, context->cookie,
+				context, rq, smrn->notifier);
+	return ret;
+}
+
+int _gnix_smrn_unmonitor(struct gnix_smrn *smrn,
+	uint64_t cookie,
+	struct gnix_smrn_context *context)
+{
+	if (!smrn)
+		return -FI_EINVAL;
+
+	if (cookie != context->cookie)
+		return -FI_EINVAL;
+
+	return _gnix_notifier_unmonitor(smrn->notifier, (uint64_t) context);
+}
+
+static void __gnix_smrn_read_events(struct gnix_smrn *smrn)
+{
+	int ret;
+	struct gnix_smrn_context *context;
+	struct gnix_smrn_rq *rq;
+	int len = sizeof(uint64_t);
+
+	do {
+		ret = _gnix_notifier_get_event(smrn->notifier,
+			(void *) &context, len);
+		if (ret != len) {
+			GNIX_DEBUG(FI_LOG_FABRIC,
+				"no more events to be read\n");
+			break;
+		}
+
+		GNIX_DEBUG(FI_LOG_FABRIC,
+			"found event, context=%p rq=%p cookie=%lx\n",
+			context, context->rq, context->cookie);
+
+		rq = context->rq;
+		fastlock_acquire(&rq->lock);
+		dlist_insert_tail(&context->entry, &rq->list);
+		fastlock_release(&rq->lock);
+	} while (ret == len);
+}
+
+int _gnix_smrn_get_event(struct gnix_smrn *smrn,
+	struct gnix_smrn_rq *rq,
+	struct gnix_smrn_context **context)
+{
+	int ret;
+
+	if (!smrn || !context)
+		return -FI_EINVAL;
+
+	__gnix_smrn_read_events(smrn);
+
+	fastlock_acquire(&rq->lock);
+	if (!dlist_empty(&rq->list)) {
+		dlist_pop_front(&rq->list, struct gnix_smrn_context,
+			*context, entry);
+		ret = FI_SUCCESS;
+	} else
+		ret = -FI_EAGAIN;
+	fastlock_release(&rq->lock);
+
+	return ret;
+}
+

--- a/prov/gni/src/gnix_xpmem.c
+++ b/prov/gni/src/gnix_xpmem.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 Los Alamos National Security, LLC.
  *                    All rights reserved.
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -78,12 +79,16 @@ static gnix_mr_cache_attr_t _gnix_xpmem_default_mr_cache_attr = {
 		.soft_reg_limit      = 128,
 		.hard_reg_limit      = 16384,
 		.hard_stale_limit    = 128,
+#if HAVE_KDREG
 		.lazy_deregistration = 1,
+#else
+		.lazy_deregistration = 0,
+#endif
 		.reg_callback        = __gnix_xpmem_attach_seg,
 		.dereg_callback      = __gnix_xpmem_detach_seg,
 		.destruct_callback   = __gnix_xpmem_destroy_mr_cache,
 		.elem_size           = sizeof(struct gnix_xpmem_access_handle),
-		.notifier            = NULL,
+		.smrn                = NULL,
 };
 
 /*******************************************************************************

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -240,6 +240,11 @@ static void no_cache_basic_setup(void)
 	_gnix_open_cache(domain, GNIX_MR_TYPE_NONE);
 }
 
+#if HAVE_KDREG
+# define KDREG_CHECK true
+#else
+# define KDREG_CHECK false
+#endif
 
 /* bare tests */
 TestSuite(mr_internal_bare,
@@ -249,7 +254,8 @@ TestSuite(mr_internal_bare,
 /* simple tests with lazy deregistration */
 TestSuite(mr_internal_cache,
 	  .init = internal_mr_setup,
-	  .fini = mr_teardown);
+	  .fini = mr_teardown,
+	  .disabled = KDREG_CHECK);
 
 #ifdef HAVE_UDREG
 TestSuite(mr_udreg_cache,

--- a/prov/gni/test/smrn.c
+++ b/prov/gni/test/smrn.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#include <stdio.h>
+#include <stdbool.h>
+#include <sys/mman.h>
+#include "gnix_smrn.h"
+
+#include <criterion/criterion.h>
+#include <criterion/logging.h>
+#include "common.h"
+
+#define GNIX_DEFAULT_RQ_CNT 4
+
+static struct gnix_smrn *smrn;
+static struct gnix_smrn_rq *rqs[GNIX_DEFAULT_RQ_CNT];
+static void **memory_regions;
+
+static void smrn_setup(void)
+{
+	int ret;
+	int i;
+	struct fi_info *info;
+
+	ret = fi_getinfo(FI_VERSION(1, 5), NULL, NULL, 0, NULL, &info);
+	cr_assert_eq(ret, FI_SUCCESS);
+
+	fi_freeinfo(info);
+
+	ret = _gnix_smrn_init();
+	cr_assert_eq(ret, 0, "_gnix_smrn_init failed, ret=%d\n", ret);
+
+	ret = _gnix_smrn_open(&smrn);
+	cr_assert(ret == 0, "_gnix_smrn_open failed");
+
+	for (i = 0; i < GNIX_DEFAULT_RQ_CNT; i++) {
+		rqs[i] = calloc(1, sizeof(*rqs[i]));
+		cr_assert_neq(rqs[i], NULL);
+
+		fastlock_init(&rqs[i]->lock);
+		dlist_init(&rqs[i]->list);
+		dlist_init(&rqs[i]->entry);
+	}
+}
+
+static void smrn_teardown(void)
+{
+	int ret;
+	int i;
+
+	ret = _gnix_smrn_close(smrn);
+	cr_assert(ret == 0, "_gnix_smrn_close failed");
+
+	for (i = 0; i < GNIX_DEFAULT_RQ_CNT; i++) {
+		free(rqs[i]);
+		rqs[i] = NULL;
+	}
+}
+
+TestSuite(smrn,
+	  .init = smrn_setup,
+	  .fini = smrn_teardown);
+
+#define RQ_ENTRIES 21
+#define REGIONS (GNIX_DEFAULT_RQ_CNT * RQ_ENTRIES)
+struct test_structure {
+	struct gnix_smrn_context context;
+	int pending;
+};
+
+Test(smrn, simple)
+{
+	const int regions = REGIONS;
+	void *addresses[REGIONS];
+	int i;
+	int len = 8129;
+	int ret;
+	struct gnix_smrn_rq *rq;
+	struct test_structure contexts[REGIONS] = {0};
+	struct gnix_smrn_context *current;
+	struct test_structure *iter;
+	int expected_events;
+
+	for (i = 0; i < regions; i++)
+		dlist_init(&contexts[i].context.entry);
+
+	for (i = 0; i < regions; i++) {
+		addresses[i] = mmap(NULL, len, PROT_READ | PROT_WRITE,
+				MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+		cr_assert_neq(addresses[i], MAP_FAILED);
+	}
+
+	for (i = 0; i < regions; i++) {
+		rq = rqs[i / (regions >> 2)];
+
+		ret = _gnix_smrn_monitor(smrn, rq,
+			addresses[i], len, (uint64_t) &contexts[i],
+			&contexts[i].context);
+		cr_assert_eq(ret, FI_SUCCESS);
+	}
+
+
+	for (i = 0; i < regions; i++) {
+		ret = munmap(addresses[i], len);
+		cr_assert_eq(ret, 0);
+
+		contexts[i].pending = 1;
+	}
+
+	expected_events = regions;
+	while (expected_events > 0) {
+		for (i = 0; i < GNIX_DEFAULT_RQ_CNT; i++) {
+			rq = rqs[i];
+
+			ret = _gnix_smrn_get_event(smrn, rq, &current);
+			if (ret == -FI_EAGAIN)
+				continue;
+
+			cr_assert_neq(ret, -FI_EINVAL);
+
+			iter = container_of(current,
+				struct test_structure, context);
+
+			cr_assert_eq(iter->pending, 1);
+			iter->pending = 0;
+
+			expected_events -= 1;
+		}
+	}
+}
+
+
+static void *thread_func(void *context)
+{
+	const int regions = RQ_ENTRIES;
+	void **addresses;
+	int i;
+	int len = 8129;
+	int ret;
+	struct gnix_smrn_rq *rq;
+	struct test_structure contexts[RQ_ENTRIES] = {0};
+	struct gnix_smrn_context *current;
+	struct test_structure *iter;
+	int expected_events;
+	int id = *(int *) context;
+
+	addresses = &memory_regions[id * RQ_ENTRIES];
+	rq = rqs[id];
+
+	for (i = 0; i < regions; i++)
+		dlist_init(&contexts[i].context.entry);
+
+	for (i = 0; i < regions; i++) {
+		ret = _gnix_smrn_monitor(smrn, rq,
+			addresses[i], len, (uint64_t) &contexts[i],
+			&contexts[i].context);
+		cr_assert_eq(ret, FI_SUCCESS);
+	}
+
+
+	for (i = 0; i < regions; i++) {
+		ret = munmap(addresses[i], len);
+		cr_assert_eq(ret, 0);
+
+		contexts[i].pending = 1;
+	}
+
+	expected_events = regions;
+	while (expected_events > 0) {
+		ret = _gnix_smrn_get_event(smrn, rq, &current);
+		if (ret == -FI_EAGAIN)
+			continue;
+		cr_assert_neq(ret, -FI_EINVAL);
+
+		iter = container_of(current, struct test_structure, context);
+
+		cr_assert_eq(iter->pending, 1);
+		iter->pending = 0;
+
+		expected_events -= 1;
+	}
+
+	pthread_exit(NULL);
+}
+
+
+Test(smrn, threaded)
+{
+	const int regions = REGIONS;
+	void *addresses[REGIONS];
+	int i;
+	int len = 8129;
+	int ret;
+	pthread_t threads[GNIX_DEFAULT_RQ_CNT];
+	int thread_ids[GNIX_DEFAULT_RQ_CNT];
+
+	memory_regions = (void **) &addresses;
+
+	for (i = 0; i < regions; i++) {
+		thread_ids[i] = i;
+	}
+
+	for (i = 0; i < regions; i++) {
+		addresses[i] = mmap(NULL, len, PROT_READ | PROT_WRITE,
+				MAP_ANONYMOUS | MAP_SHARED, -1, 0);
+		cr_assert_neq(addresses[i], MAP_FAILED);
+	}
+
+	for (i = 0; i < GNIX_DEFAULT_RQ_CNT; i++) {
+		ret = pthread_create(&threads[i], NULL, thread_func,
+				(void *) &thread_ids[i]);
+		cr_assert_eq(ret, 0);
+	}
+
+	for (i = 0; i < GNIX_DEFAULT_RQ_CNT; i++) {
+		pthread_join(threads[i], NULL);
+	}
+
+	memory_regions = NULL;
+}
+
+
+


### PR DESCRIPTION
With this commit, a shared memory registration notifier is
created to multiplex events from the kdreg notifier to the
various memory registration caches.

Also, if kdreg is not present, the lazy deregistration feature
for the internal cache will be forced to a disabled state
to ensure MDDs stay synchronized with virtual memory mappings

upstream merge of ofi-cray/libfabric-cray#1395
Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@fec1068a2c503be26b486fb5198b73b4a0e43031)