### PR TITLE
prov/gni: fix GNI provider bork up

### DIFF
--- a/prov/gni/src/gnix_buddy_allocator.c
+++ b/prov/gni/src/gnix_buddy_allocator.c
@@ -367,7 +367,7 @@ int _gnix_buddy_free(gnix_buddy_alloc_handle_t *alloc_handle, void *ptr,
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
-	if (OFI_UNLIEKLY(!alloc_handle || !len || len > alloc_handle->max ||
+	if (OFI_UNLIKELY(!alloc_handle || !len || len > alloc_handle->max ||
 			 ptr >= (void *) ((uint8_t *) alloc_handle->base +
 				      alloc_handle->len) ||
 		     ptr < alloc_handle->base)) {

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -222,7 +222,7 @@ static int __gnix_vc_get_vc_by_fi_addr(struct gnix_fid_ep *ep, fi_addr_t dest_ad
 		   ep->vc_table, ep->vc_table->vector);
 
 	av = ep->av;
-	if (unlikely(av == NULL)) {
+	if (OFI_UNLIKELY(av == NULL)) {
 		GNIX_WARN(FI_LOG_EP_CTRL, "av field NULL for ep %p\n", ep);
 		return -FI_EINVAL;
 	}


### PR DESCRIPTION
commit 2b80c7d9 borked up the GNI provider.

changes were made to GNI provider without
apparently asking fro a review from GNI crew,
nor being able to build it.

Fixing.  Hopefully this will not happen often.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>