### PR TITLE
prov/psm, sockets, util: Fix corruption reporting CQ errors to 1.4 users

### DIFF
--- a/include/fi_abi.h
+++ b/include/fi_abi.h
@@ -146,6 +146,25 @@ extern "C" {
 #endif /* HAVE_SYMVER_SUPPORT */
 
 
+/*
+ * The conversion from abi 1.0 requires being able to cast from a newer
+ * structure back to the older version.
+ */
+struct fi_cq_err_entry_1_0 {
+	void			*op_context;
+	uint64_t		flags;
+	size_t			len;
+	void			*buf;
+	uint64_t		data;
+	uint64_t		tag;
+	size_t			olen;
+	int			err;
+	int			prov_errno;
+	/* err_data is available until the next time the CQ is read */
+	void			*err_data;
+};
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -607,11 +607,18 @@ static ssize_t psmx_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 			       uint64_t flags)
 {
 	struct psmx_fid_cq *cq_priv;
+	uint32_t api_version;
+	size_t size;
 
 	cq_priv = container_of(cq, struct psmx_fid_cq, cq);
 
 	if (cq_priv->pending_error) {
-		memcpy(buf, &cq_priv->pending_error->cqe, sizeof *buf);
+		api_version = cq_priv->domain->fabric->util_fabric.
+			      fabric_fid.api_version;
+		size = FI_VERSION_GE(api_version, FI_VERSION(1, 5)) ?
+			sizeof(*buf) : sizeof(struct fi_cq_err_entry_1_0);
+
+		memcpy(buf, &cq_priv->pending_error->cqe, size);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
 		return 1;

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -746,11 +746,18 @@ static ssize_t psmx2_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 			        uint64_t flags)
 {
 	struct psmx2_fid_cq *cq_priv;
+	uint32_t api_version;
+	size_t size;
 
 	cq_priv = container_of(cq, struct psmx2_fid_cq, cq);
 
 	if (cq_priv->pending_error) {
-		memcpy(buf, &cq_priv->pending_error->cqe, sizeof *buf);
+		api_version = cq_priv->domain->fabric->util_fabric.
+			      fabric_fid.api_version;
+		size = FI_VERSION_GE(api_version, FI_VERSION(1, 5)) ?
+			sizeof(*buf) : sizeof(struct fi_cq_err_entry_1_0);
+
+		memcpy(buf, &cq_priv->pending_error->cqe, size);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
 		return 1;

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -442,7 +442,7 @@ static ssize_t sock_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 			buf->err_data_size = MIN(entry.err_data_size, err_data_size);
 			memcpy(buf->err_data, entry.err_data, buf->err_data_size);
 		} else {
-			*buf = entry;
+			memcpy(buf, &entry, sizeof(struct fi_cq_err_entry_1_0));
 		}
 
 		ret = 1;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -250,7 +250,7 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 		buf->err_data = err_buf_save;
 		buf->err_data_size = err_data_size;
 	} else {
-		*buf = err->err_entry;
+		memcpy(buf, &err->err_entry, sizeof(struct fi_cq_err_entry_1_0));
 	}
 	ret = 1;
 	free(err);


### PR DESCRIPTION
Fixes #3226

The size of the fi_cq_err_entry structure changed between the 1.4
and 1.5 API.  The updated structure includes a new data field.

The psm, psm2, socket, and util code copy the cq error data using
the size of the 1.5 structure.  As a result, an extra 8 bytes of
data may be written beyond the end of the application's structure.
This has produced stack corruptions, as seen in the
fi_rdm_tagged_peek fabtest when built against 1.4, but executed
against libfabric 1.5.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>