### PR TITLE
prov/bgq: fi_enbable failing for transmit or receive context on scalable endpoint

### DIFF
--- a/prov/bgq/src/fi_bgq_ep.c
+++ b/prov/bgq/src/fi_bgq_ep.c
@@ -446,7 +446,10 @@ static int fi_bgq_ep_tx_init (struct fi_bgq_ep *bgq_ep,
 	assert(bgq_ep->tx.state == FI_BGQ_EP_UNINITIALIZED);
 
 	if (bgq_ep->tx.stx) {
-
+#ifdef FI_BGQ_TRACE
+		fprintf(stderr,"fi_bgq_ep_tx_init - using tx shared on node not picking new fifos\n");
+		fflush(stderr);
+#endif
 		assert(bgq_domain == bgq_ep->tx.stx->domain);
 
 	} else {
@@ -455,7 +458,10 @@ static int fi_bgq_ep_tx_init (struct fi_bgq_ep *bgq_ep,
 		 * "exclusive" shared transmit context for use by only this
 		 * endpoint transmit context
 		 */
-
+#ifdef FI_BGQ_TRACE
+		fprintf(stderr,"fi_bgq_ep_tx_init - picking new fifos for new tx\n");
+		fflush(stderr);
+#endif
 		if (fi_bgq_stx_init(bgq_domain, 0, &bgq_ep->tx.exclusive_stx, NULL)) {
 			return -1;
 		}
@@ -1383,6 +1389,11 @@ static int fi_bgq_open_command_queues(struct fi_bgq_ep *bgq_ep)
 
 	bgq_domain = bgq_ep->domain;
 
+#ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_open_command_queues ofi_send_allowed(bgq_ep->tx.caps) is %016lx ofi_rma_initiate_allowed(bgq_ep->tx.caps) is %016lx ofi_recv_allowed(bgq_ep->rx.caps) is %016lx ofi_rma_target_allowed(bgq_ep->rx.caps) is %016lx\n",ofi_send_allowed(bgq_ep->tx.caps),ofi_rma_initiate_allowed(bgq_ep->tx.caps),ofi_recv_allowed(bgq_ep->rx.caps),ofi_rma_target_allowed(bgq_ep->rx.caps));
+	fflush(stderr);
+#endif
+
 	if (ofi_send_allowed(bgq_ep->tx.caps) || ofi_rma_initiate_allowed(bgq_ep->tx.caps)) {
 
 		/* verify there is a completion queue associated with the tx context */
@@ -1870,6 +1881,11 @@ err:
 int fi_bgq_endpoint_rx_tx (struct fid_domain *dom, struct fi_info *info,
 		struct fid_ep **ep, void *context, const ssize_t rx_index, const ssize_t tx_index)
 {
+#ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_endpoint_rx_tx called with rx_index %ld tx_index %ld\n",rx_index,tx_index);
+	fflush(stderr);
+#endif
+
 	int ret;
 	struct fi_bgq_ep *bgq_ep = NULL;
 	struct fi_bgq_domain *bgq_domain = NULL;
@@ -1927,19 +1943,33 @@ int fi_bgq_endpoint_rx_tx (struct fid_domain *dom, struct fi_info *info,
 
 	bgq_ep->rx.index = rx_index;
 	bgq_ep->tx.index = tx_index;
-	bgq_ep->rx.caps = info->rx_attr ? info->rx_attr->caps : info->caps;
-	bgq_ep->rx.caps |= FI_RECV;
 
-	bgq_ep->tx.caps = info->tx_attr ? info->tx_attr->caps : info->caps;
-
-	bgq_ep->tx.mode = info->tx_attr ? info->tx_attr->mode : 0;
-	bgq_ep->rx.mode = info->rx_attr ? info->rx_attr->mode : 0;
-
-	bgq_ep->tx.op_flags = info->tx_attr ? info->tx_attr->op_flags : 0;
-	bgq_ep->rx.op_flags = info->rx_attr ? info->rx_attr->op_flags : 0;
-
-	bgq_ep->rx.total_buffered_recv = info->rx_attr ?
+	if (rx_index >= 0) {
+		bgq_ep->rx.caps = info->rx_attr ? info->rx_attr->caps : info->caps;
+		bgq_ep->rx.caps |= FI_RECV;
+		bgq_ep->rx.mode = info->rx_attr ? info->rx_attr->mode : 0;
+		bgq_ep->rx.op_flags = info->rx_attr ? info->rx_attr->op_flags : 0;
+		bgq_ep->rx.total_buffered_recv = info->rx_attr ?
 			info->rx_attr->total_buffered_recv : 0;
+	}
+	else {
+		bgq_ep->rx.caps = 0;
+		bgq_ep->rx.mode = 0;
+		bgq_ep->rx.op_flags = 0;
+		bgq_ep->rx.total_buffered_recv = 0;
+	}
+
+	if (tx_index >= 0) {
+		bgq_ep->tx.caps = info->tx_attr ? info->tx_attr->caps : info->caps;
+		bgq_ep->tx.mode = info->tx_attr ? info->tx_attr->mode : 0;
+		bgq_ep->tx.op_flags = info->tx_attr ? info->tx_attr->op_flags : 0;
+	}
+	else {
+		bgq_ep->tx.caps = 0;
+		bgq_ep->tx.mode = 0;
+		bgq_ep->tx.op_flags = 0;
+	}
+
 
 	bgq_domain = container_of(dom, struct fi_bgq_domain, domain_fid);
 	bgq_ep->domain = bgq_domain;

--- a/prov/bgq/src/fi_bgq_sep.c
+++ b/prov/bgq/src/fi_bgq_sep.c
@@ -162,6 +162,9 @@ static int fi_bgq_tx_ctx(struct fid_ep *sep, int index,
 
 	info.fabric_attr = &fab_attr;
 	memcpy(info.fabric_attr, bgq_sep->info->fabric_attr, sizeof(*info.fabric_attr));
+#ifdef FI_BGQ_TRACE
+        fprintf(stderr,"fi_bgq_tx_ctx calling fi_bgq_endpoint_rx_tx with tx index %d\n",index);
+#endif
 
 	ret = fi_bgq_endpoint_rx_tx((struct fid_domain *)bgq_sep->domain,
 		&info, tx_ep, context, -1, index);
@@ -291,6 +294,9 @@ static int fi_bgq_rx_ctx(struct fid_ep *sep, int index,
 	memcpy(info.fabric_attr, bgq_sep->info->fabric_attr,
 			sizeof(*info.fabric_attr));
 
+#ifdef FI_BGQ_TRACE
+        fprintf(stderr,"fi_bgq_tx_ctx calling fi_bgq_endpoint_rx_tx with rx index %d\n",index);
+#endif
 	ret = fi_bgq_endpoint_rx_tx(&bgq_sep->domain->domain_fid, &info,
 			rx_ep, context, index, -1);
 	if (ret) {
@@ -412,6 +418,9 @@ int fi_bgq_scalable_ep (struct fid_domain *domain,
 	}
 	memcpy(bgq_sep->info->ep_attr, info->ep_attr, sizeof(struct fi_ep_attr));
 
+#ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_scalable_ep - called with %ld tx %ld rx\n",bgq_sep->info->ep_attr->tx_ctx_cnt,bgq_sep->info->ep_attr->rx_ctx_cnt);
+#endif
 	/*
 	 * fi_endpoint.3
 	 *


### PR DESCRIPTION
The fi_enable for a transmit context on a scalable endpoint was failing
because of the implementation specifics whereby the code was verifying the
existence of a recv_cq if the rx->caps happened to be set or unitiailized,
the fix is to clear the rx->caps for a transmit context on a scalable endpoint.
Vice-versa for the receive context.