### PR TITLE
prov/rxm: Avoid GCC compiler warnings about strict aliasing rules

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -113,7 +113,7 @@ void rxm_buf_release(struct rxm_buf_pool *pool, struct rxm_buf *buf)
 struct rxm_buf *rxm_buf_get(struct rxm_buf_pool *pool)
 {
 	struct rxm_buf *buf;
-	struct fid_mr *mr = NULL;
+	void *mr = NULL;
 
 	fastlock_acquire(&pool->lock);
 	if (pool->local_mr)
@@ -130,7 +130,7 @@ struct rxm_buf *rxm_buf_get(struct rxm_buf_pool *pool)
 	fastlock_release(&pool->lock);
 
 	if (pool->local_mr && mr)
-		buf->desc = fi_mr_desc(mr);
+		buf->desc = fi_mr_desc((struct fid_mr *)mr);
 	return buf;
 }
 


### PR DESCRIPTION
GCC compiler complains that strict aliasing rules is broken:

```
prov/rxm/src/rxm_ep.c: In function ‘rxm_buf_get’:
./include/fi_mem.h:247: warning: dereferencing pointer ‘mr.107’ does break strict-aliasing rules
prov/rxm/src/rxm_ep.c:120: note: initialized from here
```

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>