### PR TITLE
prov/psm2: Add support for lazy connection

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -201,6 +201,23 @@ The *psm2* provider checks for the following environment variables:
 
   The default setting is 2.
 
+*FI_PSM2_LAZY_CONN
+: Control when connections are established between PSM2 endpoints that OFI
+  endpoints are built on top of. When set to 0, connections are established
+  when addresses are inserted into the address vector. This is the eager
+  connection mode. When set to 1, connections are established when addresses
+  are used the first time in communication. This is the lazy connection mode.
+
+  Lazy connection mode may reduce the start-up time on large systems at the
+  expense of higher data path overhead.
+
+  When lazy connection mode is enabled, the address vector type is limited
+  to *FI_AV_TABLE*. This is handled differently by *fi_getinfo* and
+  *fi_av_open*. A call to *fi_getinfo* that asks for *FI_AV_MAP* would fail
+  but *fi_av_open* just forces *FI_AV_TABLE* silently.
+
+  The default setting is 0.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -814,6 +814,7 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size, len;
 	size_t idx;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -860,8 +861,8 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 		vlane = 0;
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -998,8 +999,8 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -1182,6 +1183,7 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size, len;
 	size_t idx;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1230,8 +1232,8 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -1398,8 +1400,8 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -1638,6 +1640,7 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 	int chunk_size, len;
 	void *tmp_buf = NULL;
 	size_t idx;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1688,8 +1691,8 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -1870,8 +1873,8 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -81,8 +81,8 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 			vlane = 0;
 		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
-			if (idx >= av->last)
-				return -FI_EINVAL;
+			if ((err = psmx2_av_check_table_idx(av,idx)))
+				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
 			vlane = av->vlanes[idx];
@@ -262,8 +262,8 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av,idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -437,9 +437,9 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
-		if (idx >= av->last) {
+		if ((err = psmx2_av_check_table_idx(av,idx))) {
 			free(req);
-			return -FI_EINVAL;
+			return err;
 		}
 
 		psm2_epaddr = av->epaddrs[idx];

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -596,6 +596,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	psm2_mq_tag_t psm2_tag, psm2_tagsel;
 	uint32_t tag32;
 	size_t idx;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -634,8 +635,8 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -745,6 +746,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	size_t total_len, long_len, short_len;
 	void *long_buf;
 	int i;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -780,8 +782,8 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -969,6 +971,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	size_t idx;
 	void *psm2_context;
 	int no_event;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1008,8 +1011,8 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -1157,6 +1160,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	size_t total_len, len, len_sent;
 	uint8_t *buf, *p;
 	int i;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1193,8 +1197,8 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -59,8 +59,8 @@ static ssize_t psmx2_tagged_peek_generic(struct fid_ep *ep,
 			vlane = 0;
 		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
-			if (idx >= av->last)
-				return -FI_EINVAL;
+			if ((err = psmx2_av_check_table_idx(av, idx)))
+				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
 			vlane = av->vlanes[idx];
@@ -285,8 +285,8 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 			vlane = 0;
 		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
-			if (idx >= av->last)
-				return -FI_EINVAL;
+			if ((err = psmx2_av_check_table_idx(av, idx)))
+				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
 			vlane = av->vlanes[idx];
@@ -407,8 +407,8 @@ psmx2_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf, size_t len,
 			vlane = 0;
 		} else {
 			idx = (size_t)src_addr;
-			if (idx >= av->last)
-				return -FI_EINVAL;
+			if ((err = psmx2_av_check_table_idx(av, idx)))
+				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
 			vlane = av->vlanes[idx];
@@ -519,8 +519,8 @@ psmx2_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf, size_t len,
 			vlane = 0;
 		} else {
 			idx = (size_t)src_addr;
-			if (idx >= av->last)
-				return -FI_EINVAL;
+			if ((err = psmx2_av_check_table_idx(av, idx)))
+				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
 			vlane = av->vlanes[idx];
@@ -667,8 +667,8 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 		vlane = 0;
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -811,8 +811,8 @@ psmx2_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 		vlane = 0;
 	} else {
 		idx = (size_t)dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -904,8 +904,8 @@ psmx2_tagged_send_no_event_av_table(struct fid_ep *ep, const void *buf,
 		vlane = 0;
 	} else {
 		idx = (size_t)dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -993,8 +993,8 @@ psmx2_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf,
 		vlane = 0;
 	} else {
 		idx = (size_t)dest_addr;
-		if (idx >= av->last)
-			return -FI_EINVAL;
+		if ((err = psmx2_av_check_table_idx(av, idx)))
+			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
 		vlane = av->vlanes[idx];
@@ -1117,9 +1117,9 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 		vlane = 0;
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
-		if (idx >= av->last) {
+		if ((err = psmx2_av_check_table_idx(av, idx))) {
 			free(req);
-			return -FI_EINVAL;
+			return err;
 		}
 
 		psm2_epaddr = av->epaddrs[idx];


### PR DESCRIPTION
Previously connections were established between PSM2 endpoints at
time fi_av_insert() was called. This had less overhead in the data
path, but could lead to long startup time on large systems.

An option is added to allow connections be established lazily, i.e.,
endpoints are connected upon first communication. This introduces
some runtime overhead but scale much better. This option also limits
the address vector type to FI_AV_TABLE only.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>