### PR TITLE
prov/verbs: Remove excessive variable

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -105,7 +105,6 @@ fi_ibv_rdm_start_overall_disconnection(struct fi_ibv_rdm_av_entry *av_entry)
 ssize_t fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_conn *conn)
 {
 	ssize_t ret = FI_SUCCESS;
-	ssize_t err = FI_SUCCESS;
 
 	VERBS_INFO(FI_LOG_AV, "Closing connection %p, state %d\n",
 		   conn, conn->state);
@@ -118,16 +117,14 @@ ssize_t fi_ibv_rdm_start_disconnection(struct fi_ibv_rdm_conn *conn)
 	}
 
 	switch (conn->state) {
-	case FI_VERBS_CONN_ALLOCATED:
-	case FI_VERBS_CONN_REMOTE_DISCONNECT:
-		ret = (ret == FI_SUCCESS) ? err : ret;
-		break;
 	case FI_VERBS_CONN_ESTABLISHED:
 		conn->state = FI_VERBS_CONN_LOCAL_DISCONNECT;
 		break;
 	case FI_VERBS_CONN_REJECTED:
 		conn->state = FI_VERBS_CONN_CLOSED;
 		break;
+	case FI_VERBS_CONN_ALLOCATED:
+	case FI_VERBS_CONN_REMOTE_DISCONNECT:
 	case FI_VERBS_CONN_CLOSED:
 		break;
 	default:


### PR DESCRIPTION
The variable `err` is never changed and its value = `FI_SUCCESS`
Even if `ret == FI_SUCCESS` after `rdma_disconnect` call in case of connection states = {`FI_VERBS_CONN_ALLOCATED`, `FI_VERBS_CONN_REMOTE_DISCONNECT`} it is set to `FI_SUCCESS`
Let's remove `err` variable to make code more readable.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>