### PR TITLE
prov/verbs: Set QP min_rnr_timer to a good value to fix performance issues

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -149,6 +149,9 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_RX_IOV_LIMIT*
 : Default maximum rx iov_limit (default: 4)
 
+*FI_VERBS_INLINE_SIZE*
+:  Default maximum inline size. Actual inject size returned in fi_info may be greater (default: 64)
+
 ### Variables specific to RDM endpoints
 
 *FI_VERBS_IFACE*

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -152,6 +152,9 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_INLINE_SIZE*
 :  Default maximum inline size. Actual inject size returned in fi_info may be greater (default: 64)
 
+*FI_VERBS_MIN_RNR_TIMER*
+: Set min_rnr_timer QP attribute (0 - 31) (default: 12)
+
 ### Variables specific to RDM endpoints
 
 *FI_VERBS_IFACE*

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -113,6 +113,8 @@ extern size_t verbs_default_tx_iov_limit;
 extern size_t verbs_default_rx_iov_limit;
 extern size_t verbs_default_inline_size;
 
+extern size_t verbs_min_rnr_timer;
+
 struct verbs_addr {
 	struct dlist_entry entry;
 	struct rdma_addrinfo *rai;
@@ -379,6 +381,7 @@ ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
 int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,
 			uint64_t flags);
+int fi_ibv_set_rnr_timer(struct ibv_qp *qp);
 
 #define fi_ibv_init_sge(buf, len, desc) (struct ibv_sge)		\
 	{ .addr = (uintptr_t)buf,					\


### PR DESCRIPTION
This is needed to avoid performance issues in streaming and bandwidth tests.
In those tests the sender could easily overrun the receiver and min_rnr_timer
determines how quick the receiver would communicate to the sender about lack
of posted receives for incoming sends requests.

Also added an env variable to allow user to modify default min_rnr_timer value.