### PR TITLE
Misc cleanups to verbs send functions.

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -279,34 +279,38 @@ static int fi_ibv_reap_comp(struct fi_ibv_msg_ep *ep)
 	return ret;
 }
 
-ssize_t fi_ibv_send(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr, size_t len,
-		    int count, void *context)
+// WR must be filled out by now except for context
+ssize_t
+fi_ibv_send(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr, void *context)
 {
 	struct ibv_send_wr *bad_wr;
 	int ret;
 
-	assert(ep->scq);
-	wr->num_sge = count;
 	wr->wr_id = (uintptr_t) context;
 
-	if (wr->send_flags & IBV_SEND_SIGNALED) {
-		assert((wr->wr_id & ep->scq->wr_id_mask) != ep->scq->send_signal_wr_id);
-		ofi_atomic_set32(&ep->unsignaled_send_cnt, 0);
-	} else {
-		if (VERBS_SIGNAL_SEND(ep)) {
-			ret = fi_ibv_signal_send(ep, wr);
-			if (ret)
-				return ret;
-		} else {
-			ofi_atomic_inc32(&ep->unsignaled_send_cnt);
+	if (ep->scq) {
 
-			if (ofi_atomic_get32(&ep->unsignaled_send_cnt) >=
-					VERBS_SEND_COMP_THRESH(ep)) {
-				ret = fi_ibv_reap_comp(ep);
+		if (wr->send_flags & IBV_SEND_SIGNALED) {
+			assert((wr->wr_id & ep->scq->wr_id_mask) !=
+				ep->scq->send_signal_wr_id);
+			ofi_atomic_set32(&ep->unsignaled_send_cnt, 0);
+		} else {
+			if (VERBS_SIGNAL_SEND(ep)) {
+				ret = fi_ibv_signal_send(ep, wr);
 				if (ret)
 					return ret;
+			} else {
+				ofi_atomic_inc32(&ep->unsignaled_send_cnt);
+
+				if (ofi_atomic_get32(&ep->unsignaled_send_cnt) >=
+						VERBS_SEND_COMP_THRESH(ep)) {
+					ret = fi_ibv_reap_comp(ep);
+					if (ret)
+						return ret;
+				}
 			}
 		}
+
 	}
 
 	ret = ibv_post_send(ep->id->qp, wr, &bad_wr);
@@ -328,8 +332,9 @@ ssize_t fi_ibv_send_buf(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 	struct ibv_sge sge = fi_ibv_init_sge(buf, len, desc);
 
 	wr->sg_list = &sge;
+	wr->num_sge = 1;
 
-	return fi_ibv_send(ep, wr, len, 1, context);
+	return fi_ibv_send(ep, wr, context);
 }
 
 ssize_t fi_ibv_send_buf_inline(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
@@ -338,8 +343,9 @@ ssize_t fi_ibv_send_buf_inline(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 	struct ibv_sge sge = fi_ibv_init_sge_inline(buf, len);
 
 	wr->sg_list = &sge;
+	wr->num_sge = 1;
 
-	return fi_ibv_send(ep, wr, len, 1, NULL);
+	return fi_ibv_send(ep, wr, NULL);
 }
 
 ssize_t fi_ibv_send_iov_flags(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
@@ -353,12 +359,14 @@ ssize_t fi_ibv_send_iov_flags(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 	else
 		fi_ibv_set_sge_iov(wr->sg_list, iov, count, desc, len);
 
-	wr->send_flags = VERBS_INJECT_FLAGS(ep, len, flags) | VERBS_COMP_FLAGS(ep, flags);
+	wr->num_sge = count;
+	wr->send_flags |= VERBS_INJECT_FLAGS(ep, len, flags);
+	wr->send_flags |= VERBS_COMP_FLAGS(ep, flags);
 
 	if (flags & FI_FENCE)
-		wr->send_flags = IBV_SEND_FENCE;
+		wr->send_flags |= IBV_SEND_FENCE;
 
-	return fi_ibv_send(ep, wr, len, count, context);
+	return fi_ibv_send(ep, wr, context);
 }
 
 static int fi_ibv_get_param_int(char *param_name, char *param_str,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -361,8 +361,7 @@ int fi_ibv_check_tx_attr(const struct fi_tx_attr *attr,
 			 const struct fi_info *hints, const struct fi_info *info);
 
 
-ssize_t fi_ibv_send(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr, size_t len,
-		    int count, void *context);
+ssize_t fi_ibv_send(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr, void *context);
 ssize_t fi_ibv_send_buf(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,
 			const void *buf, size_t len, void *desc, void *context);
 ssize_t fi_ibv_send_buf_inline(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -255,16 +255,12 @@ static int fi_ibv_open_device_by_name(struct fi_ibv_domain *domain, const char *
 		return -errno;
 
 	for (i = 0; dev_list[i] && ret; i++) {
-		if (domain->rdm) {
-			ret = strncmp(name, ibv_get_device_name(dev_list[i]->device),
-				      strlen(name) - strlen(verbs_rdm_domain.suffix));
-
-		} else {
-			ret = strcmp(name, ibv_get_device_name(dev_list[i]->device));
-		}
-
-		if (!ret)
+		const char *rdma_name = ibv_get_device_name(dev_list[i]->device);
+		ret = strncmp(name, rdma_name, strlen(rdma_name));
+		if (!ret) {
 			domain->verbs = dev_list[i];
+			break;
+		}
 	}
 	rdma_free_devices(dev_list);
 	return ret;

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -131,20 +131,20 @@ fi_ibv_msg_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **d
 		     uint64_t addr, uint64_t key, void *context)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 	size_t len = 0;
 
-	memset(&wr, 0, sizeof(wr));
+	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
+
 	wr.opcode = IBV_WR_RDMA_READ;
 	wr.wr.rdma.remote_addr = addr;
 	wr.wr.rdma.rkey = (uint32_t) key;
-
-	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
 	wr.send_flags = VERBS_COMP_READ(ep);
+	wr.num_sge = count;
 
 	fi_ibv_set_sge_iov(wr.sg_list, iov, count, desc, len);
 
-	return fi_ibv_send(ep, &wr, len, count, context);
+	return fi_ibv_send(ep, &wr, context);
 }
 
 static ssize_t
@@ -152,20 +152,20 @@ fi_ibv_msg_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 			uint64_t flags)
 {
 	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr;
+	struct ibv_send_wr wr = { 0 };
 	size_t len = 0;
 
-	memset(&wr, 0, sizeof(wr));
+	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
+
 	wr.opcode = IBV_WR_RDMA_READ;
 	wr.wr.rdma.remote_addr = msg->rma_iov->addr;
 	wr.wr.rdma.rkey = (uint32_t) msg->rma_iov->key;
-
-	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
 	wr.send_flags = VERBS_COMP_READ_FLAGS(ep, flags);
+	wr.num_sge = msg->iov_count;
 
-	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc,	len);
+	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc, len);
 
-	return fi_ibv_send(ep, &wr, len, msg->iov_count, msg->context);
+	return fi_ibv_send(ep, &wr, msg->context);
 }
 
 static ssize_t


### PR DESCRIPTION
Don't pass around length arguments and then just ignore
them. Fill out WR in upper layer fi_ibv_send* functions
and pass down to actual verbs send.

Don't drop other send flags when given FI_FENCE.
Don' assert a send CQ when it is never used.
Keep the looser info checking in verbs_domain.c.
Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>