### PR TITLE
fi_getinfo: Add const to hints parameter

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -690,7 +690,7 @@ void ofi_alter_info(struct fi_info *info, const struct fi_info *hints,
 struct fi_info *ofi_allocinfo_internal(void);
 int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		 const char *node, const char *service, uint64_t flags,
-		 struct fi_info *hints, struct fi_info **info);
+		 const struct fi_info *hints, struct fi_info **info);
 
 
 struct fid_list_entry {
@@ -711,16 +711,16 @@ void ofi_fabric_remove(struct util_fabric *fabric);
  * Utility Providers
  */
 
-typedef int (*ofi_alter_info_t)(uint32_t version, struct fi_info *src_info,
+typedef int (*ofi_alter_info_t)(uint32_t version, const struct fi_info *src_info,
 				struct fi_info *dest_info);
 
 int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 		      uint64_t flags, const struct util_prov *util_prov,
-		      struct fi_info *util_hints, ofi_alter_info_t info_to_core,
+		      const struct fi_info *util_hints, ofi_alter_info_t info_to_core,
 		      struct fi_info **core_info);
 int ofix_getinfo(uint32_t version, const char *node, const char *service,
 		 uint64_t flags, const struct util_prov *util_prov,
-		 struct fi_info *hints, ofi_alter_info_t info_to_core,
+		 const struct fi_info *hints, ofi_alter_info_t info_to_core,
 		 ofi_alter_info_t info_to_util, struct fi_info **info);
 int ofi_get_core_info_fabric(struct fi_fabric_attr *util_attr,
 			     struct fi_info **core_info);

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -426,7 +426,8 @@ struct fid {
 };
 
 int fi_getinfo(uint32_t version, const char *node, const char *service,
-	       uint64_t flags, struct fi_info *hints, struct fi_info **info);
+	       uint64_t flags, const struct fi_info *hints,
+	       struct fi_info **info);
 void fi_freeinfo(struct fi_info *info);
 struct fi_info *fi_dupinfo(const struct fi_info *info);
 

--- a/include/rdma/providers/fi_prov.h
+++ b/include/rdma/providers/fi_prov.h
@@ -65,7 +65,8 @@ struct fi_provider {
 	struct fi_context context;
 	const char *name;
 	int	(*getinfo)(uint32_t version, const char *node, const char *service,
-			uint64_t flags, struct fi_info *hints, struct fi_info **info);
+			uint64_t flags, const struct fi_info *hints,
+			struct fi_info **info);
 	int	(*fabric)(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 			void *context);
 	void	(*cleanup)(void);

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -17,7 +17,7 @@ fi_allocinfo / fi_dupinfo \- Allocate / duplicate an fi_info structure
 #include <rdma/fabric.h>
 
 int fi_getinfo(int version, const char *node, const char *service,
-        uint64_t flags, struct fi_info *hints, struct fi_info **info);
+        uint64_t flags, const struct fi_info *hints, struct fi_info **info);
 
 void fi_freeinfo(struct fi_info *info);
 

--- a/prov/bgq/include/rdma/bgq/fi_bgq.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq.h
@@ -181,21 +181,21 @@ struct fi_bgq_fabric {
 
 int fi_bgq_set_default_info(void);
 
-int fi_bgq_check_info(struct fi_info *info);
+int fi_bgq_check_info(const struct fi_info *info);
 
 int fi_bgq_fabric(struct fi_fabric_attr *attr,
 		struct fid_fabric **fabric, void *context);
 
-int fi_bgq_check_fabric_attr(struct fi_fabric_attr *attr);
+int fi_bgq_check_fabric_attr(const struct fi_fabric_attr *attr);
 
 int fi_bgq_domain(struct fid_fabric *fabric,
 		struct fi_info *info,
 		struct fid_domain **dom, void *context);
 
-int fi_bgq_check_domain_attr(struct fi_domain_attr *attr);
+int fi_bgq_check_domain_attr(const struct fi_domain_attr *attr);
 int fi_bgq_choose_domain(uint64_t caps,
 		struct fi_domain_attr *domain_attr,
-		struct fi_domain_attr *hints);
+		const struct fi_domain_attr *hints);
 
 int fi_bgq_alloc_default_domain_attr(struct fi_domain_attr **domain_attr);
 
@@ -215,13 +215,13 @@ int fi_bgq_endpoint(struct fid_domain *dom, struct fi_info *info,
 
 int fi_bgq_alloc_default_ep_attr(struct fi_ep_attr **ep_attr);
 
-int fi_bgq_check_ep_attr(struct fi_ep_attr *attr);
+int fi_bgq_check_ep_attr(const struct fi_ep_attr *attr);
 
 int fi_bgq_alloc_default_tx_attr(struct fi_tx_attr **tx_attr);
-int fi_bgq_check_tx_attr(struct fi_tx_attr *attr);
+int fi_bgq_check_tx_attr(const struct fi_tx_attr *attr);
 
 int fi_bgq_alloc_default_rx_attr(struct fi_rx_attr **rx_attr);
-int fi_bgq_check_rx_attr(struct fi_rx_attr *attr);
+int fi_bgq_check_rx_attr(const struct fi_rx_attr *attr);
 
 int fi_bgq_scalable_ep(struct fid_domain *dom, struct fi_info *info,
 		struct fid_ep **ep, void *context);

--- a/prov/bgq/src/fi_bgq_domain.c
+++ b/prov/bgq/src/fi_bgq_domain.c
@@ -286,7 +286,8 @@ err:
 	return -1;
 }
 
-int fi_bgq_choose_domain(uint64_t caps, struct fi_domain_attr *domain_attr, struct fi_domain_attr *hints)
+int fi_bgq_choose_domain(uint64_t caps, struct fi_domain_attr *domain_attr,
+			 const struct fi_domain_attr *hints)
 {
 	if (!domain_attr) {
 		goto err;
@@ -360,7 +361,7 @@ err:
 	return -errno;
 }
 
-int fi_bgq_check_domain_attr(struct fi_domain_attr *attr)
+int fi_bgq_check_domain_attr(const struct fi_domain_attr *attr)
 {
 	switch(attr->threading) {
 	case FI_THREAD_UNSPEC:

--- a/prov/bgq/src/fi_bgq_ep.c
+++ b/prov/bgq/src/fi_bgq_ep.c
@@ -1709,7 +1709,7 @@ err:
 	return -errno;
 }
 
-int fi_bgq_check_rx_attr(struct fi_rx_attr *attr)
+int fi_bgq_check_rx_attr(const struct fi_rx_attr *attr)
 {
 	/* TODO: more error checking of rx_attr */
 #ifdef TODO
@@ -1760,7 +1760,7 @@ err:
 	return -errno;
 }
 
-int fi_bgq_check_tx_attr(struct fi_tx_attr *attr)
+int fi_bgq_check_tx_attr(const struct fi_tx_attr *attr)
 {
 	if (attr->inject_size > FI_BGQ_INJECT_SIZE) {
 		FI_LOG(fi_bgq_global.prov, FI_LOG_DEBUG, FI_LOG_EP_DATA,
@@ -1827,7 +1827,7 @@ err:
 	return -errno;
 }
 
-int fi_bgq_check_ep_attr(struct fi_ep_attr *attr)
+int fi_bgq_check_ep_attr(const struct fi_ep_attr *attr)
 {
 	switch(attr->protocol) {
 		case FI_PROTO_UNSPEC:

--- a/prov/bgq/src/fi_bgq_fabric.c
+++ b/prov/bgq/src/fi_bgq_fabric.c
@@ -70,7 +70,7 @@ static struct fi_ops_fabric fi_bgq_ops_fabric = {
 	.eq_open	= fi_no_eq_open
 };
 
-int fi_bgq_check_fabric_attr(struct fi_fabric_attr *attr)
+int fi_bgq_check_fabric_attr(const struct fi_fabric_attr *attr)
 {
 	if (attr->name) {
 		if (strcmp(attr->name, FI_BGQ_FABRIC_NAME)) {

--- a/prov/bgq/src/fi_bgq_init.c
+++ b/prov/bgq/src/fi_bgq_init.c
@@ -40,7 +40,7 @@
 static int fi_bgq_init;
 static int fi_bgq_count;
 
-int fi_bgq_check_info(struct fi_info *info)
+int fi_bgq_check_info(const struct fi_info *info)
 {
 	int ret;
 
@@ -109,7 +109,7 @@ err:
 }
 
 static int fi_bgq_fillinfo(struct fi_info *fi, const char *node,
-		const char* service, struct fi_info *hints,
+		const char* service, const struct fi_info *hints,
 	        uint64_t flags)
 {
 	int ret;

--- a/prov/bgq/src/fi_bgq_init.c
+++ b/prov/bgq/src/fi_bgq_init.c
@@ -267,7 +267,7 @@ struct fi_bgq_global_data fi_bgq_global;
 
 static int fi_bgq_getinfo(uint32_t version, const char *node,
 		const char *service, uint64_t flags,
-		struct fi_info *hints, struct fi_info **info)
+		const struct fi_info *hints, struct fi_info **info)
 {
 
 	if (!((FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_MANUAL) || (FI_BGQ_FABRIC_DIRECT_PROGRESS == FI_PROGRESS_AUTO))){

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -716,7 +716,7 @@ err:
 }
 
 static int gnix_getinfo(uint32_t version, const char *node, const char *service,
-			uint64_t flags, struct fi_info *hints,
+			uint64_t flags, const struct fi_info *hints,
 			struct fi_info **info)
 {
 	int ret = 0;

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -303,7 +303,7 @@ static struct fi_info *_gnix_allocinfo(void)
 }
 
 static int __gnix_getinfo_resolve_node(const char *node, const char *service,
-				       uint64_t flags, struct fi_info *hints,
+				       uint64_t flags, const struct fi_info *hints,
 				       struct fi_info *info)
 {
 	int ret;
@@ -475,7 +475,7 @@ static inline int __gnix_check_mr_mode(int mr_mode)
 
 static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 			    const char *node, const char *service,
-			    uint64_t flags, struct fi_info *hints,
+			    uint64_t flags, const struct fi_info *hints,
 			    struct fi_info **info)
 {
 	uint64_t mode = GNIX_FAB_MODES;

--- a/prov/mlx/src/mlx_init.c
+++ b/prov/mlx/src/mlx_init.c
@@ -150,7 +150,7 @@ struct util_prov mlx_util_prov = {
 static int mlx_getinfo (
 			uint32_t version, const char *node,
 			const char *service, uint64_t flags,
-			struct fi_info *hints, struct fi_info **info)
+			const struct fi_info *hints, struct fi_info **info)
 {
 	int status = -ENODATA;
 	FI_INFO(&mlx_prov, FI_LOG_CORE,"\n");

--- a/prov/netdir/src/netdir_init.c
+++ b/prov/netdir/src/netdir_init.c
@@ -53,7 +53,8 @@ struct gl_data gl_data = {
 };
 
 int ofi_nd_getinfo(uint32_t version, const char *node, const char *service,
-		   uint64_t flags, struct fi_info *hints, struct fi_info **info)
+		   uint64_t flags, const struct fi_info *hints,
+		   struct fi_info **info)
 {
 	if (ofi_nd_util_prov.info) {
 		return util_getinfo(&ofi_nd_util_prov, version, node, service, flags,

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -168,7 +168,8 @@ static int psmx_reserve_tag_bits(int *caps, uint64_t *max_tag_value)
 }
 
 static int psmx_getinfo(uint32_t version, const char *node, const char *service,
-			uint64_t flags, struct fi_info *hints, struct fi_info **info)
+			uint64_t flags, const struct fi_info *hints,
+			struct fi_info **info)
 {
 	struct fi_info *psmx_info;
 	uint32_t cnt = 0;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -170,7 +170,7 @@ static void psmx2_update_sep_cap(void)
 
 static int psmx2_getinfo(uint32_t version, const char *node,
 			 const char *service, uint64_t flags,
-			 struct fi_info *hints, struct fi_info **info)
+			 const struct fi_info *hints, struct fi_info **info)
 {
 	struct fi_info *psmx2_info;
 	uint32_t cnt = 0;

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -345,9 +345,9 @@ struct rxd_pkt_meta {
 	char pkt_data[]; /* rxd_pkt_data*, followed by data */
 };
 
-int rxd_info_to_core(uint32_t version, struct fi_info *rxd_info,
+int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
 		     struct fi_info *core_info);
-int rxd_info_to_rxd(uint32_t version, struct fi_info *core_info,
+int rxd_info_to_rxd(uint32_t version, const struct fi_info *core_info,
 		    struct fi_info *info);
 
 int rxd_fabric(struct fi_fabric_attr *attr,

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -58,7 +58,8 @@ int rxd_info_to_rxd(uint32_t version, const struct fi_info *core_info,
 }
 
 static int rxd_getinfo(uint32_t version, const char *node, const char *service,
-			uint64_t flags, struct fi_info *hints, struct fi_info **info)
+			uint64_t flags, const struct fi_info *hints,
+			struct fi_info **info)
 {
 	return ofix_getinfo(version, node, service, flags, &rxd_util_prov,
 			    hints, rxd_info_to_core, rxd_info_to_rxd, info);

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -35,7 +35,7 @@
 #include <prov.h>
 #include "rxd.h"
 
-int rxd_info_to_core(uint32_t version, struct fi_info *rxd_info,
+int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
 		     struct fi_info *core_info)
 {
 	core_info->caps = FI_MSG;
@@ -44,7 +44,7 @@ int rxd_info_to_core(uint32_t version, struct fi_info *rxd_info,
 	return 0;
 }
 
-int rxd_info_to_rxd(uint32_t version, struct fi_info *core_info,
+int rxd_info_to_rxd(uint32_t version, const struct fi_info *core_info,
 		    struct fi_info *info)
 {
 	info->caps = rxd_info.caps;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -324,9 +324,9 @@ static inline uint64_t rxm_ep_rx_flags(struct fid_ep *ep_fid) {
 
 int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 			void *context);
-int rxm_info_to_core(uint32_t version, struct fi_info *rxm_info,
+int rxm_info_to_core(uint32_t version, const struct fi_info *rxm_info,
 		     struct fi_info *core_info);
-int rxm_info_to_rxm(uint32_t version, struct fi_info *core_info,
+int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 		    struct fi_info *info);
 int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			     struct fid_domain **dom, void *context);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -131,7 +131,8 @@ static int rxm_init_info(void)
 }
 
 static int rxm_getinfo(uint32_t version, const char *node, const char *service,
-			uint64_t flags, struct fi_info *hints, struct fi_info **info)
+			uint64_t flags, const struct fi_info *hints,
+			struct fi_info **info)
 {
 	struct fi_info *cur, *dup;
 	int ret;

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -35,7 +35,7 @@
 #include <prov.h>
 #include "rxm.h"
 
-int rxm_info_to_core(uint32_t version, struct fi_info *hints,
+int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 		     struct fi_info *core_info)
 {
 	core_info->caps = FI_MSG;
@@ -79,7 +79,7 @@ int rxm_info_to_core(uint32_t version, struct fi_info *hints,
 	return 0;
 }
 
-int rxm_info_to_rxm(uint32_t version, struct fi_info *core_info,
+int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 		    struct fi_info *info)
 {
 	info->caps = rxm_info.caps;

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -955,34 +955,38 @@ union sock_tx_op {
 };
 #define SOCK_EP_TX_ENTRY_SZ (sizeof(union sock_tx_op))
 
-int sock_verify_info(uint32_t version, struct fi_info *hints);
-int sock_verify_fabric_attr(struct fi_fabric_attr *attr);
-int sock_verify_domain_attr(uint32_t version, struct fi_domain_attr *attr);
+int sock_verify_info(uint32_t version, const struct fi_info *hints);
+int sock_verify_fabric_attr(const struct fi_fabric_attr *attr);
+int sock_verify_domain_attr(uint32_t version, const struct fi_domain_attr *attr);
 
 size_t sock_get_tx_size(size_t size);
-int sock_rdm_verify_ep_attr(struct fi_ep_attr *ep_attr, struct fi_tx_attr *tx_attr,
-			    struct fi_rx_attr *rx_attr);
-int sock_dgram_verify_ep_attr(struct fi_ep_attr *ep_attr, struct fi_tx_attr *tx_attr,
-			      struct fi_rx_attr *rx_attr);
-int sock_msg_verify_ep_attr(struct fi_ep_attr *ep_attr, struct fi_tx_attr *tx_attr,
-			    struct fi_rx_attr *rx_attr);
+int sock_rdm_verify_ep_attr(const struct fi_ep_attr *ep_attr,
+			    const struct fi_tx_attr *tx_attr,
+			    const struct fi_rx_attr *rx_attr);
+int sock_dgram_verify_ep_attr(const struct fi_ep_attr *ep_attr,
+			      const struct fi_tx_attr *tx_attr,
+			      const struct fi_rx_attr *rx_attr);
+int sock_msg_verify_ep_attr(const struct fi_ep_attr *ep_attr,
+			    const struct fi_tx_attr *tx_attr,
+			    const struct fi_rx_attr *rx_attr);
 int sock_get_src_addr(struct sockaddr_in *dest_addr,
 		      struct sockaddr_in *src_addr);
 int sock_get_src_addr_from_hostname(struct sockaddr_in *src_addr, const char *service);
 
 struct fi_info *sock_fi_info(uint32_t version, enum fi_ep_type ep_type,
-			     struct fi_info *hints, void *src_addr,
+			     const struct fi_info *hints, void *src_addr,
 			     void *dest_addr);
 int sock_msg_fi_info(uint32_t version, void *src_addr, void *dest_addr,
-		     struct fi_info *hints, struct fi_info **info);
+		     const struct fi_info *hints, struct fi_info **info);
 int sock_dgram_fi_info(uint32_t version, void *src_addr, void *dest_addr,
-		       struct fi_info *hints, struct fi_info **info);
+		       const struct fi_info *hints, struct fi_info **info);
 int sock_rdm_fi_info(uint32_t version, void *src_addr, void *dest_addr,
-		     struct fi_info *hints, struct fi_info **info);
+		     const struct fi_info *hints, struct fi_info **info);
 void free_fi_info(struct fi_info *info);
 
 int sock_msg_getinfo(uint32_t version, const char *node, const char *service,
-		uint64_t flags, struct fi_info *hints, struct fi_info **info);
+		uint64_t flags, const struct fi_info *hints,
+		struct fi_info **info);
 
 int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 		struct fid_domain **dom, void *context);

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -67,7 +67,7 @@ const struct fi_domain_attr sock_domain_attr = {
 	.mr_cnt = SOCK_DOMAIN_MR_CNT,
 };
 
-int sock_verify_domain_attr(uint32_t version, struct fi_domain_attr *attr)
+int sock_verify_domain_attr(uint32_t version, const struct fi_domain_attr *attr)
 {
 	if (!attr)
 		return 0;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1503,7 +1503,7 @@ out:
 
 
 struct fi_info *sock_fi_info(uint32_t version, enum fi_ep_type ep_type,
-			     struct fi_info *hints, void *src_addr,
+			     const struct fi_info *hints, void *src_addr,
 			     void *dest_addr)
 {
 	struct fi_info *info;

--- a/prov/sockets/src/sock_ep_dgram.c
+++ b/prov/sockets/src/sock_ep_dgram.c
@@ -146,9 +146,9 @@ static int sock_dgram_verify_tx_attr(const struct fi_tx_attr *attr)
 	return 0;
 }
 
-int sock_dgram_verify_ep_attr(struct fi_ep_attr *ep_attr,
-			    struct fi_tx_attr *tx_attr,
-			    struct fi_rx_attr *rx_attr)
+int sock_dgram_verify_ep_attr(const struct fi_ep_attr *ep_attr,
+			      const struct fi_tx_attr *tx_attr,
+			      const struct fi_rx_attr *rx_attr)
 {
 	if (ep_attr) {
 		switch (ep_attr->protocol) {
@@ -198,7 +198,7 @@ int sock_dgram_verify_ep_attr(struct fi_ep_attr *ep_attr,
 }
 
 int sock_dgram_fi_info(uint32_t version, void *src_addr, void *dest_addr,
-		       struct fi_info *hints, struct fi_info **info)
+		       const struct fi_info *hints, struct fi_info **info)
 {
 	*info = sock_fi_info(version, FI_EP_DGRAM, hints, src_addr, dest_addr);
 	if (!*info)

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -148,9 +148,9 @@ static int sock_msg_verify_tx_attr(const struct fi_tx_attr *attr)
 	return 0;
 }
 
-int sock_msg_verify_ep_attr(struct fi_ep_attr *ep_attr,
-			    struct fi_tx_attr *tx_attr,
-			    struct fi_rx_attr *rx_attr)
+int sock_msg_verify_ep_attr(const struct fi_ep_attr *ep_attr,
+			    const struct fi_tx_attr *tx_attr,
+			    const struct fi_rx_attr *rx_attr)
 {
 	if (ep_attr) {
 		switch (ep_attr->protocol) {
@@ -203,7 +203,7 @@ int sock_msg_verify_ep_attr(struct fi_ep_attr *ep_attr,
 }
 
 int sock_msg_fi_info(uint32_t version, void *src_addr, void *dest_addr,
-		     struct fi_info *hints, struct fi_info **info)
+		     const struct fi_info *hints, struct fi_info **info)
 {
 	*info = sock_fi_info(version, FI_EP_MSG, hints, src_addr, dest_addr);
 	if (!*info)

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -171,9 +171,9 @@ static int sock_rdm_verify_tx_attr(const struct fi_tx_attr *attr)
 	return 0;
 }
 
-int sock_rdm_verify_ep_attr(struct fi_ep_attr *ep_attr,
-			    struct fi_tx_attr *tx_attr,
-			    struct fi_rx_attr *rx_attr)
+int sock_rdm_verify_ep_attr(const struct fi_ep_attr *ep_attr,
+			    const struct fi_tx_attr *tx_attr,
+			    const struct fi_rx_attr *rx_attr)
 {
 	int ret;
 
@@ -242,7 +242,7 @@ int sock_rdm_verify_ep_attr(struct fi_ep_attr *ep_attr,
 }
 
 int sock_rdm_fi_info(uint32_t version, void *src_addr, void *dest_addr,
-		     struct fi_info *hints, struct fi_info **info)
+		     const struct fi_info *hints, struct fi_info **info)
 {
 	*info = sock_fi_info(version, FI_EP_RDM, hints, src_addr, dest_addr);
 	if (!*info)

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -666,7 +666,7 @@ static void sock_free_addr_list(struct slist *addr_list)
 }
 
 static int sock_getinfo(uint32_t version, const char *node, const char *service,
-			uint64_t flags, struct fi_info *hints,
+			uint64_t flags, const struct fi_info *hints,
 			struct fi_info **info)
 {
 	int ret = 0;

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -201,7 +201,7 @@ struct sock_fabric *sock_fab_list_head(void)
 	return fabric;
 }
 
-int sock_verify_fabric_attr(struct fi_fabric_attr *attr)
+int sock_verify_fabric_attr(const struct fi_fabric_attr *attr)
 {
 	if (!attr)
 		return 0;
@@ -215,7 +215,7 @@ int sock_verify_fabric_attr(struct fi_fabric_attr *attr)
 	return 0;
 }
 
-int sock_verify_info(uint32_t version, struct fi_info *hints)
+int sock_verify_info(uint32_t version, const struct fi_info *hints)
 {
 	uint64_t caps;
 	enum fi_ep_type ep_type;
@@ -403,7 +403,8 @@ out:
 	return ret;
 }
 
-static int sock_fi_checkinfo(struct fi_info *info, struct fi_info *hints)
+static int sock_fi_checkinfo(const struct fi_info *info,
+			     const struct fi_info *hints)
 {
 	if (hints && hints->domain_attr && hints->domain_attr->name &&
              strcmp(info->domain_attr->name, hints->domain_attr->name))
@@ -418,7 +419,7 @@ static int sock_fi_checkinfo(struct fi_info *info, struct fi_info *hints)
 
 static int sock_ep_getinfo(uint32_t version, const char *node,
 			   const char *service, uint64_t flags,
-			   struct fi_info *hints, enum fi_ep_type ep_type,
+			   const struct fi_info *hints, enum fi_ep_type ep_type,
 			   struct fi_info **info)
 {
 	struct addrinfo ai, *rai = NULL;
@@ -547,7 +548,7 @@ void sock_get_list_of_addr(struct slist *addr_list)
 #endif
 
 int sock_node_getinfo(uint32_t version, const char *node, const char *service,
-		      uint64_t flags, struct fi_info *hints, struct fi_info **info,
+		      uint64_t flags, const struct fi_info *hints, struct fi_info **info,
 		      struct fi_info **tail)
 {
 	enum fi_ep_type ep_type;

--- a/prov/udp/src/udpx_init.c
+++ b/prov/udp/src/udpx_init.c
@@ -112,7 +112,8 @@ static void udpx_getinfo_ifs(struct fi_info **info)
 #endif
 
 static int udpx_getinfo(uint32_t version, const char *node, const char *service,
-			uint64_t flags, struct fi_info *hints, struct fi_info **info)
+			uint64_t flags, const struct fi_info *hints,
+			struct fi_info **info)
 {
 	int ret;
 

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -496,7 +496,7 @@ int usdf_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 int usdf_domain_getname(uint32_t version, struct usd_device_attrs *dap,
 			char **name);
 bool usdf_domain_checkname(uint32_t version, struct usd_device_attrs *dap,
-			char *hint);
+			const char *hint);
 
 /* fi_ops_mr */
 int usdf_reg_mr(struct fid *fid, const void *buf, size_t len,
@@ -516,14 +516,14 @@ void usdf_setup_fake_ibv_provider(void);
 int usdf_pep_steal_socket(struct usdf_pep *pep, int *is_bound, int *sock_o);
 
 /* Utility functions */
-int usdf_catch_dom_attr(uint32_t version, struct fi_info *hints,
+int usdf_catch_dom_attr(uint32_t version, const struct fi_info *hints,
 			struct fi_domain_attr *dom_attr);
-int usdf_catch_tx_attr(uint32_t version, struct fi_tx_attr *tx_attr);
-int usdf_catch_rx_attr(uint32_t version, struct fi_rx_attr *rx_attr);
-int usdf_check_mr_mode(uint32_t version, struct fi_info *hints,
+int usdf_catch_tx_attr(uint32_t version, const struct fi_tx_attr *tx_attr);
+int usdf_catch_rx_attr(uint32_t version, const struct fi_rx_attr *rx_attr);
+int usdf_check_mr_mode(uint32_t version, const struct fi_info *hints,
 		       uint64_t prov_mode);
-struct sockaddr_in *usdf_format_to_sin(struct fi_info *info, const void *addr);
-void *usdf_sin_to_format(struct fi_info *info, void *addr, size_t *len);
-void usdf_free_sin_if_needed(struct fi_info *info, struct sockaddr_in *sin);
+struct sockaddr_in *usdf_format_to_sin(const struct fi_info *info, const void *addr);
+void *usdf_sin_to_format(const struct fi_info *info, void *addr, size_t *len);
+void usdf_free_sin_if_needed(const struct fi_info *info, struct sockaddr_in *sin);
 
 #endif /* _USDF_H_ */

--- a/prov/usnic/src/usdf_av.c
+++ b/prov/usnic/src/usdf_av.c
@@ -824,7 +824,7 @@ fi_addr_t usdf_av_lookup_addr(struct usdf_av *av,
 /* Return sockaddr_in pointer. Must be used with usdf_free_sin_if_needed()
  * to cleanup properly.
  */
-struct sockaddr_in *usdf_format_to_sin(struct fi_info *info, const void *addr)
+struct sockaddr_in *usdf_format_to_sin(const struct fi_info *info, const void *addr)
 {
 	struct sockaddr_in *sin;
 
@@ -846,7 +846,7 @@ struct sockaddr_in *usdf_format_to_sin(struct fi_info *info, const void *addr)
 
 /* Utility function to free the sockaddr_in allocated from usdf_format_to_sin()
  */
-void usdf_free_sin_if_needed(struct fi_info *info, struct sockaddr_in *sin)
+void usdf_free_sin_if_needed(const struct fi_info *info, struct sockaddr_in *sin)
 {
 	if (info && info->addr_format == FI_ADDR_STR)
 		free(sin);
@@ -855,7 +855,7 @@ void usdf_free_sin_if_needed(struct fi_info *info, struct sockaddr_in *sin)
 /* Convert sockaddr_in pointer to appropriate format.
  * If conversion happens, destroy the origin. (to minimize cleaning up code)
  */
-void *usdf_sin_to_format(struct fi_info *info, void *addr, size_t *len)
+void *usdf_sin_to_format(const struct fi_info *info, void *addr, size_t *len)
 {
 	size_t addr_strlen;
 	char *addrstr;

--- a/prov/usnic/src/usdf_dgram.h
+++ b/prov/usnic/src/usdf_dgram.h
@@ -57,13 +57,13 @@
 #define USDF_DGRAM_MR_CNT (USDF_MR_CNT)
 
 
-int usdf_dgram_fill_rx_attr(uint32_t version, struct fi_info *hints,
+int usdf_dgram_fill_rx_attr(uint32_t version, const struct fi_info *hints,
 		struct fi_info *fi, struct usd_device_attrs *dap);
-int usdf_dgram_fill_tx_attr(uint32_t version, struct fi_info *hints,
+int usdf_dgram_fill_tx_attr(uint32_t version, const struct fi_info *hints,
 		struct fi_info *fi, struct usd_device_attrs *dap);
-int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
+int usdf_dgram_fill_dom_attr(uint32_t version, const struct fi_info *hints,
 			     struct fi_info *fi, struct usd_device_attrs *dap);
-int usdf_dgram_fill_ep_attr(uint32_t version, struct fi_info *hints,
+int usdf_dgram_fill_ep_attr(uint32_t version, const struct fi_info *hints,
 		struct fi_info *fi, struct usd_device_attrs *dap);
 
 /* fi_ops_msg for DGRAM */

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -400,7 +400,7 @@ int usdf_domain_getname(uint32_t version, struct usd_device_attrs *dap,
  *    _valid_.
  */
 bool usdf_domain_checkname(uint32_t version, struct usd_device_attrs *dap,
-			   char *hint)
+			   const char *hint)
 {
 	char *reference;
 	bool valid;
@@ -458,7 +458,7 @@ int usdf_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 }
 
 /* Catch the version changes for domain_attr. */
-int usdf_catch_dom_attr(uint32_t version, struct fi_info *hints,
+int usdf_catch_dom_attr(uint32_t version, const struct fi_info *hints,
 			struct fi_domain_attr *dom_attr)
 {
 	/* version 1.5 introduced new bits. If the user asked for older
@@ -485,7 +485,7 @@ int usdf_catch_dom_attr(uint32_t version, struct fi_info *hints,
 }
 
 /* Catch the version changes for tx_attr. */
-int usdf_catch_tx_attr(uint32_t version, struct fi_tx_attr *tx_attr)
+int usdf_catch_tx_attr(uint32_t version, const struct fi_tx_attr *tx_attr)
 {
 	/* In version < 1.5, FI_LOCAL_MR is required. */
 	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
@@ -497,7 +497,7 @@ int usdf_catch_tx_attr(uint32_t version, struct fi_tx_attr *tx_attr)
 }
 
 /* Catch the version changes for rx_attr. */
-int usdf_catch_rx_attr(uint32_t version, struct fi_rx_attr *rx_attr)
+int usdf_catch_rx_attr(uint32_t version, const struct fi_rx_attr *rx_attr)
 {
 	/* In version < 1.5, FI_LOCAL_MR is required. */
 	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
@@ -511,7 +511,7 @@ int usdf_catch_rx_attr(uint32_t version, struct fi_rx_attr *rx_attr)
 /* A wrapper function to core utility function to check mr_mode bits.
  * We need to check some more things for backward compatibility.
  */
-int usdf_check_mr_mode(uint32_t version, struct fi_info *hints,
+int usdf_check_mr_mode(uint32_t version, const struct fi_info *hints,
 		       uint64_t prov_mode)
 {
 	int ret;

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -444,7 +444,7 @@ static const struct fi_domain_attr dgram_dflt_domain_attr = {
 /*******************************************************************************
  * Fill functions for attributes
  ******************************************************************************/
-int usdf_dgram_fill_ep_attr(uint32_t version, struct fi_info *hints, struct
+int usdf_dgram_fill_ep_attr(uint32_t version, const struct fi_info *hints, struct
 		fi_info *fi, struct usd_device_attrs *dap)
 {
 	struct fi_ep_attr defaults;
@@ -500,7 +500,7 @@ out:
 	return FI_SUCCESS;
 }
 
-int usdf_dgram_fill_dom_attr(uint32_t version, struct fi_info *hints,
+int usdf_dgram_fill_dom_attr(uint32_t version, const struct fi_info *hints,
 			     struct fi_info *fi, struct usd_device_attrs *dap)
 {
 	int ret;
@@ -588,7 +588,7 @@ catch:
 	return FI_SUCCESS;
 }
 
-int usdf_dgram_fill_tx_attr(uint32_t version, struct fi_info *hints,
+int usdf_dgram_fill_tx_attr(uint32_t version, const struct fi_info *hints,
 			    struct fi_info *fi,
 			    struct usd_device_attrs *dap)
 {
@@ -667,7 +667,7 @@ out:
 	return FI_SUCCESS;
 }
 
-int usdf_dgram_fill_rx_attr(uint32_t version, struct fi_info *hints,
+int usdf_dgram_fill_rx_attr(uint32_t version, const struct fi_info *hints,
 			    struct fi_info *fi, struct usd_device_attrs *dap)
 {
 	int ret;

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -143,7 +143,7 @@ static struct fi_ops_atomic usdf_msg_atomic_ops = {
 /*******************************************************************************
  * Fill functions for attributes
  ******************************************************************************/
-int usdf_msg_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
+int usdf_msg_fill_ep_attr(const struct fi_info *hints, struct fi_info *fi,
 		struct usd_device_attrs *dap)
 {
 	struct fi_ep_attr defaults;
@@ -185,7 +185,7 @@ out:
 	return FI_SUCCESS;
 }
 
-int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
+int usdf_msg_fill_dom_attr(uint32_t version, const struct fi_info *hints,
 			   struct fi_info *fi, struct usd_device_attrs *dap)
 {
 	int ret;
@@ -266,7 +266,7 @@ catch:
 	return FI_SUCCESS;
 }
 
-int usdf_msg_fill_tx_attr(uint32_t version, struct fi_info *hints,
+int usdf_msg_fill_tx_attr(uint32_t version, const struct fi_info *hints,
 			  struct fi_info *fi)
 {
 	int ret;
@@ -318,7 +318,7 @@ catch:
 	return FI_SUCCESS;
 }
 
-int usdf_msg_fill_rx_attr(uint32_t version, struct fi_info *hints, struct fi_info *fi)
+int usdf_msg_fill_rx_attr(uint32_t version, const struct fi_info *hints, struct fi_info *fi)
 {
 	int ret;
 	struct fi_rx_attr defaults;

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -146,7 +146,7 @@ static struct fi_ops_atomic usdf_rdm_atomic_ops = {
 /*******************************************************************************
  * Fill functions for attributes
  ******************************************************************************/
-int usdf_rdm_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
+int usdf_rdm_fill_ep_attr(const struct fi_info *hints, struct fi_info *fi,
 		struct usd_device_attrs *dap)
 {
 	struct fi_ep_attr defaults;
@@ -189,7 +189,7 @@ out:
 
 }
 
-int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
+int usdf_rdm_fill_dom_attr(uint32_t version, const struct fi_info *hints,
 			   struct fi_info *fi, struct usd_device_attrs *dap)
 {
 	int ret;
@@ -270,7 +270,7 @@ catch:
 	return FI_SUCCESS;
 }
 
-int usdf_rdm_fill_tx_attr(uint32_t version, struct fi_info *hints,
+int usdf_rdm_fill_tx_attr(uint32_t version, const struct fi_info *hints,
 			  struct fi_info *fi)
 {
 	int ret;
@@ -322,7 +322,7 @@ catch:
 	return FI_SUCCESS;
 }
 
-int usdf_rdm_fill_rx_attr(uint32_t version, struct fi_info *hints,
+int usdf_rdm_fill_rx_attr(uint32_t version, const struct fi_info *hints,
 			  struct fi_info *fi)
 {
 	int ret;

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -838,7 +838,7 @@ usdf_handle_node_and_service(const char *node, const char *service,
 
 static int
 usdf_getinfo(uint32_t version, const char *node, const char *service,
-	       uint64_t flags, struct fi_info *hints, struct fi_info **info)
+	       uint64_t flags, const struct fi_info *hints, struct fi_info **info)
 {
 	struct usdf_usnic_info *dp;
 	struct usdf_dev_entry *dep;

--- a/prov/usnic/src/usdf_fabric.c
+++ b/prov/usnic/src/usdf_fabric.c
@@ -108,7 +108,7 @@ static int usdf_fabric_getname(uint32_t version, struct usd_device_attrs *dap,
 }
 
 static bool usdf_fabric_checkname(uint32_t version,
-				  struct usd_device_attrs *dap, char *hint)
+				  struct usd_device_attrs *dap, const char *hint)
 {
 	int ret;
 	bool valid = false;
@@ -143,7 +143,7 @@ static bool usdf_fabric_checkname(uint32_t version,
 	return usdf_fabric_checkname(FI_VERSION(1, 3), dap, hint);
 }
 
-static int usdf_validate_hints(uint32_t version, struct fi_info *hints)
+static int usdf_validate_hints(uint32_t version, const struct fi_info *hints)
 {
 	struct fi_fabric_attr *fattrp;
 	size_t size;
@@ -309,7 +309,7 @@ fail:
 	return ret;		// fi_freeinfo() in caller frees all
 }
 
-static int validate_modebits(uint32_t version, struct fi_info *hints,
+static int validate_modebits(uint32_t version, const struct fi_info *hints,
 			       uint64_t supported, uint64_t *mode_out)
 {
 	uint64_t mode;
@@ -335,7 +335,7 @@ static int validate_modebits(uint32_t version, struct fi_info *hints,
 
 static int usdf_fill_info_dgram(
 	uint32_t version,
-	struct fi_info *hints,
+	const struct fi_info *hints,
 	void *src,
 	void *dest,
 	struct usd_device_attrs *dap,
@@ -430,7 +430,7 @@ fail:
 
 static int usdf_fill_info_msg(
 	uint32_t version,
-	struct fi_info *hints,
+	const struct fi_info *hints,
 	void *src,
 	void *dest,
 	struct usd_device_attrs *dap,
@@ -519,7 +519,7 @@ fail:
 
 static int usdf_fill_info_rdm(
 	uint32_t version,
-	struct fi_info *hints,
+	const struct fi_info *hints,
 	void *src,
 	void *dest,
 	struct usd_device_attrs *dap,
@@ -697,7 +697,7 @@ usdf_get_distance(
  * @return true on success, false on failure. For debug logging can be enabled
  *         to see why a device was disqualified.
  */
-static bool usdf_check_device(uint32_t version, struct fi_info *hints,
+static bool usdf_check_device(uint32_t version, const struct fi_info *hints,
 			      void *src, void *dest,
 			      struct usdf_dev_entry *dep)
 {
@@ -800,8 +800,8 @@ fail:
 
 static int
 usdf_handle_node_and_service(const char *node, const char *service,
-		uint64_t flags, void **src, void **dest, struct fi_info *hints,
-		struct addrinfo **ai)
+		uint64_t flags, void **src, void **dest,
+		const struct fi_info *hints, struct addrinfo **ai)
 {
 	int ret;
 	struct sockaddr_in *sin;

--- a/prov/usnic/src/usdf_msg.h
+++ b/prov/usnic/src/usdf_msg.h
@@ -92,13 +92,13 @@ struct usdf_msg_qe {
 
 int usdf_msg_post_recv(struct usdf_rx *rx, void *buf, size_t len);
 
-int usdf_msg_fill_tx_attr(uint32_t version, struct fi_info *hints,
+int usdf_msg_fill_tx_attr(uint32_t version, const struct fi_info *hints,
 			  struct fi_info *fi);
-int usdf_msg_fill_rx_attr(uint32_t version, struct fi_info *hints,
+int usdf_msg_fill_rx_attr(uint32_t version, const struct fi_info *hints,
 			  struct fi_info *fi);
-int usdf_msg_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
+int usdf_msg_fill_ep_attr(const struct fi_info *hints, struct fi_info *fi,
 		struct usd_device_attrs *dap);
-int usdf_msg_fill_dom_attr(uint32_t version, struct fi_info *hints,
+int usdf_msg_fill_dom_attr(uint32_t version, const struct fi_info *hints,
 			   struct fi_info *fi, struct usd_device_attrs *dap);
 
 void usdf_msg_ep_timeout(void *vep);

--- a/prov/usnic/src/usdf_rdm.h
+++ b/prov/usnic/src/usdf_rdm.h
@@ -141,13 +141,13 @@ struct usdf_rdm_connection {
 	struct usdf_rdm_connection *dc_hash_next;
 };
 
-int usdf_rdm_fill_ep_attr(struct fi_info *hints, struct fi_info *fi,
+int usdf_rdm_fill_ep_attr(const struct fi_info *hints, struct fi_info *fi,
 		struct usd_device_attrs *dap);
-int usdf_rdm_fill_dom_attr(uint32_t version, struct fi_info *hints,
+int usdf_rdm_fill_dom_attr(uint32_t version, const struct fi_info *hints,
 			   struct fi_info *fi, struct usd_device_attrs *dap);
-int usdf_rdm_fill_tx_attr(uint32_t version, struct fi_info *hints,
+int usdf_rdm_fill_tx_attr(uint32_t version, const struct fi_info *hints,
 			   struct fi_info *fi);
-int usdf_rdm_fill_rx_attr(uint32_t version, struct fi_info *hints,
+int usdf_rdm_fill_rx_attr(uint32_t version, const struct fi_info *hints,
 			  struct fi_info *fi);
 
 int usdf_rdm_post_recv(struct usdf_rx *rx, void *buf, size_t len);

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -133,7 +133,7 @@ const char *ofi_core_name(const char *str, size_t *len)
 
 }
 
-static int ofi_dup_addr(struct fi_info *info, struct fi_info *dup)
+static int ofi_dup_addr(const struct fi_info *info, struct fi_info *dup)
 {
 	dup->addr_format = info->addr_format;
 	if (info->src_addr) {
@@ -155,7 +155,7 @@ static int ofi_dup_addr(struct fi_info *info, struct fi_info *dup)
 }
 
 static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
-			    struct fi_info *util_info,
+			    const struct fi_info *util_info,
 			    ofi_alter_info_t info_to_core,
 			    struct fi_info **core_hints)
 {
@@ -260,7 +260,7 @@ err:
 
 int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 		      uint64_t flags, const struct util_prov *util_prov,
-		      struct fi_info *util_hints, ofi_alter_info_t info_to_core,
+		      const struct fi_info *util_hints, ofi_alter_info_t info_to_core,
 		      struct fi_info **core_info)
 {
 	struct fi_info *core_hints = NULL;
@@ -283,7 +283,7 @@ int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 
 int ofix_getinfo(uint32_t version, const char *node, const char *service,
 		 uint64_t flags, const struct util_prov *util_prov,
-		 struct fi_info *hints, ofi_alter_info_t info_to_core,
+		 const struct fi_info *hints, ofi_alter_info_t info_to_core,
 		 ofi_alter_info_t info_to_util, struct fi_info **info)
 {
 	struct fi_info *core_info, *util_info, *cur, *tail;

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -152,7 +152,7 @@ int util_find_domain(struct dlist_entry *item, const void *arg)
 
 int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		 const char *node, const char *service, uint64_t flags,
-		 struct fi_info *hints, struct fi_info **info)
+		 const struct fi_info *hints, struct fi_info **info)
 {
 	struct util_fabric *fabric;
 	struct util_domain *domain;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -336,7 +336,8 @@ int fi_ibv_sockaddr_len(struct sockaddr *addr);
 
 int fi_ibv_init_info();
 int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
-		   uint64_t flags, struct fi_info *hints, struct fi_info **info);
+		   uint64_t flags, const struct fi_info *hints,
+		   struct fi_info **info);
 struct fi_info *fi_ibv_get_verbs_info(struct fi_info *ilist,
 				      const char *domain_name);
 int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags,

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1151,9 +1151,10 @@ static int fi_ibv_set_default_info(struct fi_info *info)
 }
 
 static int fi_ibv_get_matching_info(uint32_t version, const char *dev_name,
-		struct fi_info *hints, struct fi_info **info, struct fi_info *verbs_info)
+		const struct fi_info *hints, struct fi_info **info,
+		const struct fi_info *verbs_info)
 {
-	struct fi_info *check_info;
+	const struct fi_info *check_info;
 	struct fi_info *fi, *tail;
 	int ret;
 

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1200,7 +1200,8 @@ err1:
 }
 
 int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
-		   uint64_t flags, struct fi_info *hints, struct fi_info **info)
+		   uint64_t flags, const struct fi_info *hints,
+		   struct fi_info **info)
 {
 	struct rdma_cm_id *id = NULL;
 	struct rdma_addrinfo *rai;

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -204,7 +204,7 @@ COMPAT_SYMVER(fi_dupinfo_1_0, fi_dupinfo, FABRIC_1.0);
 
 __attribute__((visibility ("default")))
 int fi_getinfo_1_0(uint32_t version, const char *node, const char *service,
-		    uint64_t flags, struct fi_info_1_0 *hints_1_0,
+		    uint64_t flags, const struct fi_info_1_0 *hints_1_0,
 		    struct fi_info_1_0 **info)
 {
 	struct fi_info *hints;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -637,7 +637,7 @@ static int ofi_layering_ok(const struct fi_provider *provider,
 __attribute__((visibility ("default")))
 int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 		const char *service, uint64_t flags,
-		struct fi_info *hints, struct fi_info **info)
+		const struct fi_info *hints, struct fi_info **info)
 {
 	struct ofi_prov *prov;
 	struct fi_info *tail, *cur;


### PR DESCRIPTION
We discovered a bug while working on a provider where the underlying code was modifying the hints passed into fi_getinfo().  Providers are not expected to modify the hints value.  To clarify this restriction and prevent future providers from running into the same problem, mark hints as const.

Before we can update fi_getinfo(), const must be propagated through the underlying provider calls where hints are referenced.  This includes structures referenced by hints, such as the domain or endpoint attributes.

All providers are updated, but I cannot build the gni, netdir, mlx, or bgq providers.

Note that this technically modifies the API.