### PR TITLE
Fix mlx warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,13 +329,13 @@ See the `fi_netdir(7)` man page for more details.
 
 The MLX provider enables applications using OFI to be run over UCX
 communication library. It uses libucp for connections control and data transfer operations.
-Supported UCP API version: 1.0
+Supported UCP API version: 1.2
 
 See the `fi_mlx(7)` man page for more details.
 
 #### Dependencies
 
-- The MLX provider requires UCP API 1.0 capable libucp and libucs (tested with hpcx v1.8.0).
+- The MLX provider requires UCP API 1.2 capable libucp and libucs (tested with hpcx v1.8.0, v1.9.7).
   If you are compiling Libfabric from source and want to enable MLX
   support, you will also need the matching header files for UCX.
   If the libraries and header files are not in default paths, specify them using:

--- a/prov/mlx/src/mlx_av.c
+++ b/prov/mlx/src/mlx_av.c
@@ -189,7 +189,7 @@ int mlx_av_open(
 		default:
 			return -EINVAL;
 		}
-		if (attr->flags && FI_EVENT){
+		if (attr->flags & FI_EVENT){
 			is_async = 1;
 		}
 		count = attr->count;

--- a/prov/mlx/src/mlx_ep.c
+++ b/prov/mlx/src/mlx_ep.c
@@ -94,6 +94,7 @@ static int mlx_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 
 	switch (bfid->fclass) {
 	case FI_CLASS_CQ:
+		cq = container_of(bfid, struct util_cq, cq_fid.fid);
 		status = ofi_ep_bind_cq(&ep->ep, cq, flags);
 		break;
 	case FI_CLASS_AV:

--- a/prov/mlx/src/mlx_tagged.c
+++ b/prov/mlx/src/mlx_tagged.c
@@ -39,7 +39,7 @@ static ssize_t mlx_tagged_recvmsg(
 				uint64_t flags)
 {
 	ucs_status_ptr_t status = NULL;
-	ucs_recv_callback_t cbf;
+	ucp_tag_recv_callback_t cbf;
 	struct mlx_ep* u_ep;
 	struct mlx_request *req;
 	struct util_cq* cq;


### PR DESCRIPTION
@alexander-sannikov @gladkovdmitry17 please apply this tiny fix to your PR, as it is required to compiler with `-Werror` using Clang.