### PR TITLE
prov/util: Fix MR_LOCAL check

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -599,7 +599,12 @@ int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 
 #define OFI_CHECK_MR_SCALABLE(mode) (!(mode & OFI_MR_BASIC_MAP))
 
-#define OFI_CHECK_MR_LOCAL(mode) (mode & FI_MR_LOCAL)
+/* FI_LOCAL_MR is valid in pre-libfaric-1.5 and can be valid in
+ * post-libfabric-1.5 */
+#define OFI_CHECK_MR_LOCAL(info) \
+	((info->domain_attr->mr_mode & FI_MR_LOCAL) || \
+	 (!(info->domain_attr->mr_mode & ~(FI_MR_BASIC | FI_MR_SCALABLE)) && \
+	  (info->mode & FI_LOCAL_MR)))
 
 struct ofi_mr_map {
 	const struct fi_provider *prov;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -258,7 +258,7 @@ static int rxm_lmt_tx_finish(struct rxm_tx_entry *tx_entry)
 	RXM_LOG_STATE_TX(FI_LOG_CQ, tx_entry, RXM_LMT_FINISH);
 	tx_entry->state = RXM_LMT_FINISH;
 
-	if (!OFI_CHECK_MR_LOCAL(tx_entry->ep->rxm_info->domain_attr->mr_mode))
+	if (!OFI_CHECK_MR_LOCAL(tx_entry->ep->rxm_info))
 		rxm_ep_msg_mr_closev(tx_entry->mr, tx_entry->count);
 
 	tx_entry->comp_flags |= FI_SEND;
@@ -327,7 +327,7 @@ int rxm_cq_handle_data(struct rxm_rx_buf *rx_buf)
 			return -FI_ETRUNC; // TODO copy data and write to CQ error
 		}
 
-		if (!OFI_CHECK_MR_LOCAL(rx_buf->ep->rxm_info->domain_attr->mr_mode)) {
+		if (!OFI_CHECK_MR_LOCAL(rx_buf->ep->rxm_info)) {
 			ret = rxm_match_iov(rx_buf->recv_entry->iov,
 					    rx_buf->recv_entry->desc,
 					    rx_buf->recv_entry->count, 0,
@@ -542,7 +542,7 @@ static int rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 
 		RXM_LOG_STATE_RX(FI_LOG_CQ, rx_buf, RXM_LMT_FINISH);
 		rx_buf->hdr.state = RXM_LMT_FINISH;
-		if (!OFI_CHECK_MR_LOCAL(rx_buf->ep->rxm_info->domain_attr->mr_mode))
+		if (!OFI_CHECK_MR_LOCAL(rx_buf->ep->rxm_info))
 			rxm_ep_msg_mr_closev(rx_buf->mr, RXM_IOV_LIMIT);
 		return rxm_finish_recv(rx_buf);
 	default:

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -189,8 +189,8 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	(*domain)->mr = &rxm_domain_mr_ops;
 	(*domain)->ops = &rxm_domain_ops;
 
-	rxm_domain->mr_local = OFI_CHECK_MR_LOCAL(msg_info->domain_attr->mr_mode) &&
-				!OFI_CHECK_MR_LOCAL(info->domain_attr->mr_mode);
+	rxm_domain->mr_local = OFI_CHECK_MR_LOCAL(msg_info) &&
+				!OFI_CHECK_MR_LOCAL(info);
 
 	fi_freeinfo(msg_info);
 	return 0;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -219,16 +219,16 @@ static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep)
 	rxm_domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain, util_domain);
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "MSG provider mr_mode & FI_MR_LOCAL: %d\n",
-			OFI_CHECK_MR_LOCAL(rxm_ep->msg_info->domain_attr->mr_mode));
+			OFI_CHECK_MR_LOCAL(rxm_ep->msg_info));
 
-	ret = rxm_buf_pool_create(OFI_CHECK_MR_LOCAL(rxm_ep->msg_info->domain_attr->mr_mode),
+	ret = rxm_buf_pool_create(OFI_CHECK_MR_LOCAL(rxm_ep->msg_info),
 				  rxm_ep->msg_info->tx_attr->size,
 				  sizeof(struct rxm_tx_buf), &rxm_ep->tx_pool,
 				  rxm_domain->msg_domain);
 	if (ret)
 	        return ret;
 
-	ret = rxm_buf_pool_create(OFI_CHECK_MR_LOCAL(rxm_ep->msg_info->domain_attr->mr_mode),
+	ret = rxm_buf_pool_create(OFI_CHECK_MR_LOCAL(rxm_ep->msg_info),
 				  rxm_ep->msg_info->rx_attr->size,
 				  sizeof(struct rxm_rx_buf), &rxm_ep->rx_pool,
 				  rxm_domain->msg_domain);
@@ -672,7 +672,7 @@ rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		fastlock_release(&rxm_ep->send_queue.lock);
 		pkt->ctrl_hdr.type = ofi_ctrl_large_data;
 
-		if (!OFI_CHECK_MR_LOCAL(rxm_ep->rxm_info->domain_attr->mr_mode)) {
+		if (!OFI_CHECK_MR_LOCAL(rxm_ep->rxm_info)) {
 			ret = rxm_ep_msg_mr_regv(rxm_ep, iov, tx_entry->count,
 						 FI_REMOTE_READ, tx_entry->mr);
 			if (ret)

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -144,9 +144,9 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 	/* If app supports FI_MR_LOCAL, prioritize requiring it for
 	 * better performance. */
 	if (hints && hints->domain_attr &&
-	    (OFI_CHECK_MR_LOCAL(hints->domain_attr->mr_mode))) {
+	    (OFI_CHECK_MR_LOCAL(hints))) {
 		for (cur = *info; cur; cur = cur->next) {
-			if (!OFI_CHECK_MR_LOCAL(cur->domain_attr->mr_mode))
+			if (!OFI_CHECK_MR_LOCAL(cur))
 				continue;
 			if (!(dup = fi_dupinfo(cur))) {
 				fi_freeinfo(*info);


### PR DESCRIPTION
We need to check FI_LOCAL_MR *mode* bit if none of the *mr_mode* bits
are set. This is needed for compatibility as per the MODE section in
fi_getinfo(3) manpage.
