### PR TITLE
prov/verbs: Fix unsuccessful fi_cancel and hanging in MPI_Finalize

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -235,9 +235,10 @@ static ssize_t fi_ibv_rdm_cancel(fid_t fid, void *ctx)
 	if (found) {
 		assert(container_of(found, struct fi_ibv_rdm_request,
 				    queue_entry) == request);
+		request->context->internal[0] = NULL;
 		fi_ibv_rdm_remove_from_posted_queue(request, ep_rdm);
 		VERBS_DBG(FI_LOG_EP_DATA, "\t\t-> SUCCESS, post recv %d\n",
-			ep_rdm->posted_recvs);
+ 			  ep_rdm->posted_recvs);
 		err = 0;
 	} else {
 		request = fi_ibv_rdm_take_first_match_from_postponed_queue

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -141,7 +141,7 @@ fi_ibv_rdm_take_first_from_unexp_queue()
 
 static inline void
 fi_ibv_rdm_move_to_posted_queue(struct fi_ibv_rdm_request *request,
-					struct fi_ibv_rdm_ep *ep)
+				struct fi_ibv_rdm_ep *ep)
 {
 	FI_IBV_RDM_DBG_REQUEST("move_to_posted_queue: ", request, FI_LOG_DEBUG);
 	dlist_insert_tail(&request->queue_entry, &fi_ibv_rdm_posted_queue);
@@ -269,7 +269,6 @@ fi_ibv_rdm_take_first_match_from_postponed_queue(dlist_func_t *match, const void
 			struct fi_ibv_rdm_request *request =
 				container_of(j, struct fi_ibv_rdm_request,
 					     queue_entry);
-		
 			fi_ibv_rdm_remove_from_postponed_queue(request);
 			return request;
 		}
@@ -278,6 +277,6 @@ fi_ibv_rdm_take_first_match_from_postponed_queue(dlist_func_t *match, const void
 	return NULL;
 }
 
-void fi_ibv_rdm_clean_queues();
+void fi_ibv_rdm_clean_queues(struct fi_ibv_rdm_ep* ep);
 
 #endif   // _VERBS_QUEING_H

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -194,6 +194,10 @@ void fi_ibv_rdm_clean_queues(struct fi_ibv_rdm_ep* ep)
 	}
 
 	while ((request = fi_ibv_rdm_take_first_from_posted_queue(ep))) {
+ 		/* Check `request->context->internal[0] == NULL` in fi_cancel
+		 * will handle the case that request was already canceled
+		 * internally by provider */
+		request->context->internal[0] = NULL;
 		if (request->iov_count > 0) {
 			util_buf_release(fi_ibv_rdm_extra_buffers_pool,
 					request->unexp_rbuf);


### PR DESCRIPTION
The PR fixes #3256 issue + fix an incorrect set of arguments of the prototype of the `fi_ibv_rdm_clean_queues` function