### PR TITLE
Idea for C++ binding of libfabric.

### DIFF
--- a/include/rdma/domain.hpp
+++ b/include/rdma/domain.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <rdma/fi_domain.h>
+#include <rdma/fi_atomic.h> // fi_query_atomic
+
+#include <rdma/ops.hpp>
+#include <rdma/endpoint.hpp>
+
+namespace fi {
+
+class av : public ops<struct fid_av> {
+public:
+	av(struct fid_domain *domain, struct fi_av_attr *attr, void *context) {
+		int ret = fi_av_open(domain, attr, &obj, context);
+		init(ret);
+	}
+};
+
+class cq : public ops<struct fid_cq> {
+public:
+	cq(struct fid_domain *domain, struct fi_cq_attr *attr, void *context) {
+		int ret = fi_cq_open(domain, attr, &obj, context);
+		init(ret);
+	}
+
+	// fi_ops_cq
+	defmethod(cq_read, obj)
+	defmethod(cq_readfrom, obj)
+	defmethod(cq_readerr, obj)
+	defmethod(cq_sread, obj)
+	defmethod(cq_sreadfrom, obj)
+	defmethod(cq_signal, obj)
+	defmethod(cq_strerror, obj)
+};
+
+class domain : public ops<struct fid_domain> {
+public:
+	// TODO: should we also make a fi::fabric consuming ctor ?
+	domain(struct fid_fabric *fabric, struct fi_info *info, void *context) {
+		int ret = fi_domain(fabric, info, &obj, context);
+		init(ret);
+	}
+
+	av av_open(struct fi_av_attr *attr, void *context) {
+		return fi::av(obj, attr, context);
+	}
+
+	cq cq_open(struct fi_cq_attr *attr, void *context) {
+		return fi::cq(obj, attr, context);
+	}
+
+	ep endpoint(struct fi_info *info, void *context) {
+		return fi::ep(obj, info, context);
+	}
+
+	ep scalable_ep(struct fi_info *info, void *context) {
+		return fi::sep(obj, info, context);
+	}
+
+	int query_atomic(enum fi_datatype datatype, enum fi_op op,
+			struct fi_atomic_attr *attr,
+			uint64_t flags) {
+		return fi_query_atomic(obj, datatype, op, attr, flags);
+	}
+
+};
+
+}

--- a/include/rdma/endpoint.hpp
+++ b/include/rdma/endpoint.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_tagged.h>
+#include <rdma/fi_atomic.h>
+
+#include <rdma/ops.hpp>
+
+namespace fi {
+
+class mc : public ops<struct fid_mc> {
+public:
+	// mutlicast object just exports an address
+	fi_addr_t addr;
+
+	mc(struct fid_ep *ep, const void *addr, uint64_t flags, void *context) {
+		int ret = fi_join(ep, addr, flags, &obj, context);
+		init(ret);
+		this->addr = obj->fi_addr;
+	}
+};
+
+class pep : public ops<struct fid_pep> {
+public:
+	pep(struct fid_fabric *fabric, struct fi_info *info, void *context) {
+		int ret = fi_passive_ep(fabric, info, &obj, context);
+		init(ret);
+	}
+
+	// fi_ops_ep
+	defmethod(cancel, FID(obj))
+	defmethod(getopt, FID(obj))
+	defmethod(setopt, FID(obj))
+
+	// fi_ops_cm
+	defmethod(setname, FID(obj))
+	defmethod(getname, FID(obj))
+	defmethod(listen, obj)
+	defmethod(reject, obj)
+};
+
+class ep : public ops<struct fid_ep> {
+protected:
+	// ctor only for sep
+	ep() {}
+public:
+	ep(struct fid_domain *domain, struct fi_info *info, void *context) {
+		int ret = fi_endpoint(domain, info, &obj, context);
+		init(ret);
+	}
+
+	// fi_ops_ep
+	defmethod(cancel, FID(obj))
+	defmethod(getopt, FID(obj))
+	defmethod(setopt, FID(obj))
+
+	// fi_ops_cm
+	defmethod(setname, FID(obj))
+	defmethod(getname, FID(obj))
+	defmethod(getpeer, obj)
+	defmethod(connect, obj)
+	defmethod(accept, obj)
+	defmethod(shutdown, obj)
+	
+	mc join(const void *addr, uint64_t flags, void *context) {
+		return fi::mc(obj, addr, flags, context);
+	}
+
+	// fi_ops_msg
+	defmethod(recv, obj)
+	defmethod(recvv, obj)
+	defmethod(recvmsg, obj)
+	defmethod(send, obj)
+	defmethod(sendv, obj)
+	defmethod(sendmsg, obj)
+	defmethod(inject, obj)
+	defmethod(senddata, obj)
+	defmethod(injectdata, obj)
+
+	// fi_ops_rma
+	defmethod(read, obj)
+	defmethod(readv, obj)
+	defmethod(readmsg, obj)
+	defmethod(write, obj)
+	defmethod(writev, obj)
+	defmethod(writemsg, obj)
+	defmethod(inject_write, obj)
+	defmethod(writedata, obj)
+	defmethod(injectdata_writedata, obj)
+	
+	// fi_ops_tagged
+	defmethod(trecv, obj)
+	defmethod(trecvv, obj)
+	defmethod(trecvmsg, obj)
+	defmethod(tsend, obj)
+	defmethod(tsendv, obj)
+	defmethod(tsendmsg, obj)
+	defmethod(tinject, obj)
+	defmethod(tsenddata, obj)
+	defmethod(tinjectdata, obj)
+	
+};
+
+class sep : public ep {
+public:
+	sep(struct fid_domain *domain, struct fi_info *info, void *context) {
+		int ret = fi_scalable_ep(domain, info, &obj, context);
+		init(ret);
+	}
+
+	defmethod(tx_context, obj)
+	defmethod(rx_context, obj)
+};
+
+} // fi::

--- a/include/rdma/eq.hpp
+++ b/include/rdma/eq.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <rdma/fi_eq.h>
+
+#include <rdma/ops.hpp>
+
+namespace fi {
+
+class eq : public ops<struct fid_eq> {
+public:
+	eq(struct fid_fabric *fabric, struct fi_eq_attr *attr, void *context) {
+		int ret = fi_eq_open(fabric, attr, &obj, context);
+		init(ret);
+	}
+
+	// fi_ops_eq
+	defmethod(eq_read, obj)
+	defmethod(eq_readerr, obj)
+	defmethod(eq_write, obj)
+	defmethod(eq_sread, obj)
+	defmethod(eq_strerror, obj)
+};
+
+class wait : public ops<struct fid_wait> {
+public:
+	wait(struct fid_fabric *fabric, struct fi_wait_attr *attr) {
+		int ret = fi_wait_open(fabric, attr, &obj);
+		init(ret);
+	}
+
+};
+
+}
+

--- a/include/rdma/errno.hpp
+++ b/include/rdma/errno.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <stdexcept>
+
+#include <rdma/fi_errno.h>
+
+namespace fi {
+
+// TODO: perhaps over-ride system_error and defer calling fi_strerror()
+// TODO: until what() is called? More efficient, but more code.
+// TODO: Or just throw a plain old int and let the callee deal with it.
+class fi_error : public std::runtime_error {
+public:
+	fi_error(int num) : std::runtime_error(fi_strerror(num)) {}
+};
+
+} // fi::

--- a/include/rdma/fabric.hpp
+++ b/include/rdma/fabric.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <rdma/fabric.h>
+
+#include <rdma/ops.hpp>
+#include <rdma/domain.hpp>
+#include <rdma/endpoint.hpp>
+#include <rdma/eq.hpp>
+
+namespace fi {
+
+class fabric : public ops<fid_fabric> {
+public:
+	fabric(struct fi_fabric_attr *attr, void *context) {
+		int ret = fi_fabric(attr, &obj, context);
+		init(ret);
+	};
+
+	// disambiguate class from function name
+	fi::domain domain(struct fi_info *info, void *context) {
+		return fi::domain(obj, info, context);
+	}
+
+	pep passive_ep(struct fi_info *info, void *context) {
+		return fi::pep(obj, info, context);
+	}
+
+	eq eq_open(struct fi_eq_attr *attr, void *context) {
+		return fi::eq(obj, attr, context);
+	}
+
+	wait wait_open(struct fi_wait_attr *attr) {
+		return fi::wait(obj, attr);
+	}
+
+	// TODO: use optional here?
+	wait trywait(int count);
+
+
+};
+
+} // fi::

--- a/include/rdma/ops.hpp
+++ b/include/rdma/ops.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <cstdio>
+#include <memory>
+
+#include <rdma/errno.hpp>
+
+#include <rdma/fabric.h>
+
+#define FID(obj) (&(obj->fid))
+
+// helper macro for defining methods
+// method is fi_$name sans the fi_ prefix, ie fi_write -> write
+#define defmethod(method, obj_ptr)	\
+	template <typename ...Args>	\
+	auto method(Args && ... args) -> \
+		decltype(fi_##method(obj_ptr, std::forward<Args>(args)...)) {	\
+		return fi_##method(obj_ptr, std::forward<Args>(args)...); \
+	}
+
+namespace fi {
+
+template<typename P>
+class ops {
+protected:
+	P *obj;
+
+	void init(int ret) {
+		if (ret)
+			throw fi_error(ret);
+	}
+
+public:
+	~ops() {
+		printf("Closing: %lu\n", obj->fid.fclass);
+		if (fi_close(&(obj->fid)))
+			printf("Failed closing\n");
+	}
+
+	//ops() {}
+	//ops(const ops&) = delete;
+
+	// generic bind for various fi_xxx_bind() calls:
+	int bind(struct fid *bfid, uint64_t flags) {
+		return obj->fid.ops->bind(FID(obj), bfid, flags);
+	}
+
+	defmethod(control, FID(obj))
+
+	// TODO: set errno to ret ? or throw an exception?
+	// should name be open_ops or ops_open?
+	void* ops_open(const char *name, uint64_t flags, void *context) {
+		void *ops;
+		int ret = fi_open_ops(FID(obj), name, flags, &ops, context);
+		if (ret) { ops = NULL; }
+		return ops;
+	}
+};
+
+}

--- a/util/test.cpp
+++ b/util/test.cpp
@@ -1,0 +1,31 @@
+#include <rdma/fabric.hpp>
+#include <rdma/domain.hpp>
+
+#include <stdio.h>
+
+int main (int argc, char *argv[]){
+
+	struct fi_info *fi, *hints = fi_allocinfo();
+	hints->mode = ~0;
+	hints->domain_attr->mode = ~0;
+	hints->domain_attr->mr_mode = ~0;
+	hints->fabric_attr->prov_name = (char*)"verbs";
+
+	fi_getinfo(FI_VERSION(1,5), NULL, 0, 0, hints, &fi);
+
+	try {
+		fi::fabric f(fi->fabric_attr, NULL);
+		fi::domain d = f.domain(fi, NULL);
+		fi::pep p = f.passive_ep(fi, NULL);
+		fi::ep ep = d.endpoint(fi, NULL);
+		fi::pep p2 = p;
+		if (p.listen())
+			printf("failed to listen\n");
+		else
+			printf("listening\n");
+	} catch (fi::fi_error &ex) {
+		printf("caught exception: %s\n", ex.what());
+	}
+
+	return 0;
+}


### PR DESCRIPTION
A very straight-forward binding of libfabric "objects" to
C++ classes with the appropriate fi_* methods minus the
explicit passing of fid_* structs and the fi_ prefix.
See the test.cpp for an example, compile like:
g++ -std=c++11 util/test.cpp -Iinclude -lfabric

This should be able to compile down to the equivalent C implementation /
efficiency-- but I have not checked.

Signed-off-by: pmmccorm <patrick.m.mccormick@intel.com>