### PR TITLE
Updates to util and rxm providers

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -298,8 +298,11 @@ ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
 ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		fi_addr_t *src_addr, const void *cond, int timeout);
 int ofi_cq_signal(struct fid_cq *cq_fid);
+int ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
+		 void *buf, uint64_t data, uint64_t tag);
 int ofi_cq_write_error(struct util_cq *cq,
 		       const struct fi_cq_err_entry *err_entry);
+int ofi_cq_write_error_peek(struct util_cq *cq, uint64_t tag, void *context);
 
 /*
  * Counter

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -241,6 +241,7 @@ struct rxm_recv_entry {
 	uint64_t flags;
 	uint64_t tag;
 	uint64_t ignore;
+	uint64_t comp_flags;
 };
 DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -333,8 +333,6 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 			 struct fid_cq **cq_fid, void *context);
 void rxm_cq_progress(struct rxm_ep *rxm_ep);
-int rxm_cq_comp(struct util_cq *util_cq, void *context, uint64_t flags, size_t len,
-		void *buf, uint64_t data, uint64_t tag);
 int rxm_cq_handle_data(struct rxm_rx_buf *rx_buf);
 
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -81,6 +81,11 @@
 	RXM_LOG_STATE(subsystem, rx_buf->pkt, rx_buf->hdr.state,	\
 		      next_state)
 
+#define RXM_DBG_ADDR_TAG(subsystem, log_str, addr, tag) 	\
+	FI_DBG(&rxm_prov, subsystem, log_str 			\
+	       " (fi_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 ")\n",\
+	       addr, tag)
+
 extern struct fi_provider rxm_prov;
 extern struct util_prov rxm_util_prov;
 extern struct fi_ops_rma rxm_ops_rma;

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -36,16 +36,23 @@
 		     FI_READ | FI_WRITE | FI_RECV | FI_SEND |		\
 		     FI_REMOTE_READ | FI_REMOTE_WRITE | FI_SOURCE)
 
+/* Since we are a layering provider, the attributes for which we rely on the
+ * core provider are set to full capability. This ensures that ofix_getinfo
+ * check hints succeeds and the core provider can accept / reject any capability
+ * requested by the app. */
+
 struct fi_tx_attr rxm_tx_attr = {
 	.caps = RXM_EP_CAPS,
-	.comp_order = FI_ORDER_STRICT,
+	.msg_order = ~0x0,
+	.comp_order = ~0x0,
 	.size = SIZE_MAX,
 	.iov_limit = RXM_IOV_LIMIT,
 };
 
 struct fi_rx_attr rxm_rx_attr = {
 	.caps = RXM_EP_CAPS,
-	.comp_order = FI_ORDER_STRICT,
+	.msg_order = ~0x0,
+	.comp_order = FI_ORDER_STRICT | FI_ORDER_DATA,
 	.size = 1024,
 	.iov_limit= RXM_IOV_LIMIT,
 };

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -236,7 +236,6 @@ static int rxm_lmt_tx_finish(struct rxm_tx_entry *tx_entry)
 	if (!OFI_CHECK_MR_LOCAL(tx_entry->ep->rxm_info))
 		rxm_ep_msg_mr_closev(tx_entry->mr, tx_entry->count);
 
-	tx_entry->comp_flags |= FI_SEND;
 	ret = rxm_finish_send(tx_entry);
 	if (ret)
 		return ret;
@@ -366,11 +365,9 @@ int rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 	case ofi_op_msg:
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "Got MSG op\n");
 		recv_queue = &rx_buf->ep->recv_queue;
-		rx_buf->comp_flags = FI_MSG;
 		break;
 	case ofi_op_tagged:
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "Got TAGGED op\n");
-		rx_buf->comp_flags = FI_TAGGED;
 		match_attr.tag = rx_buf->pkt.hdr.tag;
 		recv_queue = &rx_buf->ep->trecv_queue;
 		break;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -383,9 +383,9 @@ int rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 	entry = dlist_remove_first_match(&recv_queue->recv_list,
 					 recv_queue->match_recv, &match_attr);
 	if (!entry) {
-		FI_DBG(&rxm_prov, FI_LOG_CQ, "No matching recv found for "
-		       "incoming msg with fi_addr: %" PRIu64 " tag: %" PRIu64
-		       "\n", match_attr.addr, match_attr.tag);
+		RXM_DBG_ADDR_TAG(FI_LOG_CQ, "No matching recv found for "
+				 "incoming msg", match_attr.addr,
+				 match_attr.tag);
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "Enqueueing msg to unexpected msg"
 		       "queue\n");
 		rx_buf->unexp_msg.addr = match_attr.addr;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -409,32 +409,83 @@ static struct fi_ops_ep rxm_ops_ep = {
 };
 
 /* Caller must hold recv_queue->lock */
-static int rxm_check_unexp_msg_list(struct rxm_ep *rxm_ep,
-				    struct rxm_recv_queue *recv_queue,
-				    struct rxm_recv_entry *recv_entry,
-				    struct rxm_rx_buf **rx_buf)
+static struct rxm_rx_buf *
+rxm_check_unexp_msg_list(struct rxm_recv_queue *recv_queue, fi_addr_t addr,
+			 uint64_t tag, uint64_t ignore)
 {
-	struct rxm_recv_match_attr match_attr = {0};
+	struct rxm_recv_match_attr match_attr;
 	struct dlist_entry *entry;
 
 	if (dlist_empty(&recv_queue->unexp_msg_list))
-		return -FI_EAGAIN;
+		return NULL;
 
-	match_attr.addr = recv_entry->addr;
-	if (recv_queue->type == RXM_RECV_QUEUE_TAGGED)
-		match_attr.tag = recv_entry->tag;
-	match_attr.ignore = recv_entry->ignore;
+	match_attr.addr 	= addr;
+	match_attr.tag 		= tag;
+	match_attr.ignore 	= ignore;
 
-	entry = dlist_remove_first_match(&recv_queue->unexp_msg_list,
-					 recv_queue->match_unexp, &match_attr);
+	entry = dlist_find_first_match(&recv_queue->unexp_msg_list,
+				       recv_queue->match_unexp, &match_attr);
 	if (!entry)
-		return -FI_EAGAIN;
+		return NULL;
 
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Match for posted recv with fi_addr: "
-	       "%" PRIu64 " tag: %" PRIu64 " found in unexp msg list\n",
-	       match_attr.addr, match_attr.tag);
-	*rx_buf = container_of(entry, struct rxm_rx_buf, unexp_msg.entry);
-	return 0;
+	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Match for posted recv found in unexp"
+			 " msg list\n", match_attr.addr, match_attr.tag);
+
+	return container_of(entry, struct rxm_rx_buf, unexp_msg.entry);
+}
+
+static int rxm_ep_discard_recv(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf,
+			       void *context)
+{
+	int ret;
+
+	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Discarding message",
+			 rx_buf->unexp_msg.addr, rx_buf->unexp_msg.tag);
+
+	ret = ofi_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
+			    0, NULL, rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
+	if (ret)
+		return ret;
+	return rxm_ep_repost_buf(rx_buf);
+}
+
+static int rxm_ep_peek_recv(struct rxm_ep *rxm_ep, fi_addr_t addr, uint64_t tag,
+			    uint64_t ignore, void *context, uint64_t flags,
+			    struct rxm_recv_queue *recv_queue)
+{
+	struct rxm_rx_buf *rx_buf;
+
+	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Peeking message", addr, tag);
+
+	rxm_cq_progress(rxm_ep);
+
+	fastlock_acquire(&recv_queue->lock);
+
+	rx_buf = rxm_check_unexp_msg_list(recv_queue, addr, tag, ignore);
+	if (!rx_buf) {
+		fastlock_release(&recv_queue->lock);
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Message not found\n");
+		return ofi_cq_write_error_peek(rxm_ep->util_ep.rx_cq, tag,
+					       context);
+	}
+
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Message found\n");
+
+	if (flags & FI_DISCARD) {
+		dlist_remove(&rx_buf->unexp_msg.entry);
+		fastlock_release(&recv_queue->lock);
+		return rxm_ep_discard_recv(rxm_ep, rx_buf, context);
+	}
+
+	if (flags & FI_CLAIM) {
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Marking message for Claim\n");
+		((struct fi_context *)context)->internal[0] = rx_buf;
+		dlist_remove(&rx_buf->unexp_msg.entry);
+	}
+	fastlock_release(&recv_queue->lock);
+
+	return ofi_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
+			    0, NULL, rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
 }
 
 static int rxm_ep_recv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
@@ -444,11 +495,53 @@ static int rxm_ep_recv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
 {
 	struct rxm_recv_entry *recv_entry;
 	struct rxm_rx_buf *rx_buf;
-	int ret;
 	size_t i;
 
-	if (!(recv_entry = rxm_recv_entry_get(recv_queue)))
+	if (flags & (FI_PEEK | FI_CLAIM | FI_DISCARD))
+		assert(recv_queue->type == RXM_RECV_QUEUE_TAGGED);
+
+	src_addr = (rxm_ep->rxm_info->caps & FI_DIRECTED_RECV) ?
+		src_addr : FI_ADDR_UNSPEC;
+
+	if (flags & FI_PEEK)
+		return rxm_ep_peek_recv(rxm_ep, src_addr, tag, ignore, context,
+					flags, recv_queue);
+
+
+	if (flags & FI_CLAIM) {
+		rx_buf = ((struct fi_context *)context)->internal[0];
+		assert(rx_buf);
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Claim message\n");
+
+		if (flags & FI_DISCARD)
+			return rxm_ep_discard_recv(rxm_ep, rx_buf, context);
+	} else {
+		fastlock_acquire(&recv_queue->lock);
+		rx_buf = rxm_check_unexp_msg_list(recv_queue, src_addr, tag,
+						  ignore);
+		if (rx_buf)
+			dlist_remove(&rx_buf->unexp_msg.entry);
+		fastlock_release(&recv_queue->lock);
+	}
+
+	recv_entry = rxm_recv_entry_get(recv_queue);
+	if (!recv_entry)
 		return -FI_EAGAIN;
+
+	recv_entry->count 	= count;
+	recv_entry->addr 	= src_addr;
+	recv_entry->context 	= context;
+	recv_entry->flags 	= flags;
+	recv_entry->ignore 	= ignore;
+
+	if (recv_queue->type == RXM_RECV_QUEUE_TAGGED) {
+		recv_entry->tag 	= tag;
+		recv_entry->comp_flags 	= FI_TAGGED;
+	} else {
+		recv_entry->tag 	= 0;
+		recv_entry->comp_flags 	= FI_MSG;
+	}
+	recv_entry->comp_flags |= FI_RECV;
 
 	for (i = 0; i < count; i++) {
 		recv_entry->iov[i].iov_base = iov[i].iov_base;
@@ -456,42 +549,19 @@ static int rxm_ep_recv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
 		if (desc)
 			recv_entry->desc[i] = desc[i];
 	}
-	recv_entry->count 	= count;
-	recv_entry->addr 	= (rxm_ep->rxm_info->caps & FI_DIRECTED_RECV) ?
-				  src_addr : FI_ADDR_UNSPEC;
-	recv_entry->context 	= context;
-	recv_entry->flags 	= flags;
-	recv_entry->ignore 	= ignore;
-	if (recv_queue->type == RXM_RECV_QUEUE_TAGGED) {
-		recv_entry->tag 	= tag;
-		recv_entry->comp_flags 	= FI_TAGGED;
-	} else {
-		recv_entry->comp_flags 	= FI_MSG;
+
+	if (rx_buf) {
+		rx_buf->recv_entry = recv_entry;
+		return rxm_cq_handle_data(rx_buf);
 	}
-	recv_entry->comp_flags |= FI_RECV;
+
+	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Enqueuing recv", recv_entry->addr,
+			 recv_entry->tag);
 
 	fastlock_acquire(&recv_queue->lock);
-	ret = rxm_check_unexp_msg_list(rxm_ep, recv_queue, recv_entry, &rx_buf);
-	if (ret) {
-		if (ret == -FI_EAGAIN) {
-			dlist_insert_tail(&recv_entry->entry,
-					  &recv_queue->recv_list);
-			ret = 0;
-			FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Enqueuing recv with "
-			       "fi_addr: %" PRIu64 " tag: %" PRIu64 "\n",
-			       recv_entry->addr, recv_entry->tag);
-		} else {
-			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-					"Unable to check unexp msg list\n");
-			freestack_push(recv_queue->fs, recv_entry);
-		}
-		fastlock_release(&recv_queue->lock);
-	} else {
-		fastlock_release(&recv_queue->lock);
-		rx_buf->recv_entry = recv_entry;
-		ret = rxm_cq_handle_data(rx_buf);
-	}
-	return ret;
+	dlist_insert_tail(&recv_entry->entry, &recv_queue->recv_list);
+	fastlock_release(&recv_queue->lock);
+	return 0;
 }
 
 static ssize_t rxm_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -462,8 +462,13 @@ static int rxm_ep_recv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
 	recv_entry->context 	= context;
 	recv_entry->flags 	= flags;
 	recv_entry->ignore 	= ignore;
-	if (recv_queue->type == RXM_RECV_QUEUE_TAGGED)
-		recv_entry->tag = tag;
+	if (recv_queue->type == RXM_RECV_QUEUE_TAGGED) {
+		recv_entry->tag 	= tag;
+		recv_entry->comp_flags 	= FI_TAGGED;
+	} else {
+		recv_entry->comp_flags 	= FI_MSG;
+	}
+	recv_entry->comp_flags |= FI_RECV;
 
 	fastlock_acquire(&recv_queue->lock);
 	ret = rxm_check_unexp_msg_list(rxm_ep, recv_queue, recv_entry, &rx_buf);

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -999,8 +999,12 @@ static int fi_ibv_fill_addr(struct rdma_addrinfo *rai, struct fi_info **info,
 	struct sockaddr *local_addr;
 	int ret;
 
-	if (rai->ai_src_addr && (((*info)->ep_attr->type == FI_EP_MSG) ||
-	    !ofi_is_loopback_addr(rai->ai_src_addr)))
+	/*
+	 * TODO MPICH CH3 doesn't work with verbs provider without skipping the
+	 * loopback address. An alternative approach if there is one is needed
+	 * to allow both.
+	 */
+	if (rai->ai_src_addr && !ofi_is_loopback_addr(rai->ai_src_addr))
 		goto rai_to_fi;
 
 	if (!id->verbs)


### PR DESCRIPTION
-  prov/util: Add a common function to write completion entry to util_cq
- prov/rxm: Set completion flags on posting recv
- prov/rxm: Add support for FI_PEEK, FI_CLAIM and FI_DISCARD flags
- prov/rxm: Report correct ordering attributes in fi_getinfo








