### PR TITLE
prov/verbs: fix leak of Queue Pairs after fi_av_remove

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -96,7 +96,11 @@ fi_ibv_rdm_start_overall_disconnection(struct fi_ibv_rdm_av_entry *av_entry)
 				   "(%d) for %p\n", ret, conn);
 			err = ret;
 		}
-		HASH_DEL(av_entry->conn_hash, conn);
+		/*
+		 * do NOT remove entry of connection from HASH.
+		 * We will refer to the connection during
+		 * cleanup of the connections.
+		 */
 	}
 
 	return err;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -539,7 +539,7 @@ void check_and_repost_receives(struct fi_ibv_rdm_ep *ep,
 static inline int 
 fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 {
-	struct fi_ibv_rdm_conn *conn = (void *) wc->wr_id;
+	struct fi_ibv_rdm_conn *conn = (void *)wc->wr_id;
 
 	struct fi_ibv_rdm_buf *rbuf = 
 		fi_ibv_rdm_get_rbuf(conn, ep, conn->recv_processed);
@@ -549,9 +549,8 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 	FI_IBV_DBG_OPCODE(wc->opcode, "RECV");
 
 	if (!FI_IBV_RDM_CHECK_RECV_WC(wc)) {
-
-		VERBS_INFO(FI_LOG_EP_DATA, "conn %p state %d, wc status %d\n",
-			conn, conn->state, wc->status);
+		VERBS_DBG(FI_LOG_EP_DATA, "conn %p state %d, wc status %d\n",
+			  conn, conn->state, wc->status);
 		/* on QP error initiate disconnection procedure:
 		 * flush as many as possible preposted (and failed)
 		 * entries and after this set connection to 'closed' state */
@@ -564,8 +563,7 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 
 		conn->recv_preposted--;
 		if (wc->status == IBV_WC_WR_FLUSH_ERR &&
-		    conn->state == FI_VERBS_CONN_ESTABLISHED)
-		{
+		    conn->state == FI_VERBS_CONN_ESTABLISHED) {
 			/*
 			 * It means that remote side initiated disconnection
 			 * and QP is flushed earlier then disconnect event was
@@ -666,11 +664,9 @@ int fi_ibv_rdm_tagged_poll_recv(struct fi_ibv_rdm_ep *ep)
 		if (wc[i].status != IBV_WC_SUCCESS) {
 			struct fi_ibv_rdm_conn *conn = (void *)wc[i].wr_id;
 
-			if (wc[i].status == IBV_WC_WR_FLUSH_ERR && conn &&
-				conn->state != FI_VERBS_CONN_ESTABLISHED)
-			{
+			if ((wc[i].status == IBV_WC_WR_FLUSH_ERR) && conn &&
+			    (conn->state != FI_VERBS_CONN_ESTABLISHED))
 				return FI_SUCCESS;
-			}
 
 			VERBS_INFO(FI_LOG_EP_DATA, "got ibv_wc[%d].status = %d:%s\n",
 				i, wc[i].status, ibv_wc_status_str(wc[i].status));

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -336,7 +336,7 @@ struct fi_ibv_connreq {
 int fi_ibv_sockaddr_len(struct sockaddr *addr);
 
 
-int fi_ibv_init_info();
+int fi_ibv_init_info(struct fi_info **all_infos);
 int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, struct fi_info *hints, struct fi_info **info);
 struct fi_info *fi_ibv_get_verbs_info(struct fi_info *ilist,


### PR DESCRIPTION
Let's assume the following situation:
1. Invokes `fi_av_insert` for two addresses
2. Doing some work...
3. Invokes `fi_av_remove` for the 1st address:
    verbs provider performs the following actions:
    - initiates a disconnection
    - removes hash entry that represents the connection (code assumes that we will free memory for connection and performs destroying of QP and rdma ID later)
4. Invokes `fi_close`(endpoint). P.S. The same can also be done during `fi_close`(domain)
    verbs provider performs the following actions:
    - finds remaining connection (for the 2nd address)
        - initiates a disconnection
        - removes hash entry that represents the connection
        - free memory for connection and performs destroying of QP and rdma ID

This PR should fix the problem in the following manner:
- do NOT remove hash entry that represents the connection in `fi_av_remove` (only move `av_entry` to the list of removed AV entries)
- removes hash entry that represents the connection for the particular EP, free memory for the connection and performs destroying of QP and rdma ID during `fi_close`(endpoint)