### PR TITLE
prov/rxm: Remove shared context dependency on underlying MSG provider

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -356,6 +356,8 @@ int rxm_conn_signal(struct util_ep *util_ep, void *context,
 		    enum ofi_cmap_signal signal);
 
 int rxm_ep_repost_buf(struct rxm_rx_buf *buf);
+int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
+
 int ofi_match_addr(fi_addr_t addr, fi_addr_t match_addr);
 int ofi_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_tag);
 void rxm_pkt_init(struct rxm_pkt *pkt);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -81,7 +81,6 @@ int rxm_info_to_core(uint32_t version, struct fi_info *hints,
 	/* Remove caps that RxM can handle */
 	core_info->rx_attr->msg_order &= ~FI_ORDER_SAS;
 
-	core_info->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;
 	core_info->ep_attr->type = FI_EP_MSG;
 
 	return 0;


### PR DESCRIPTION
prov/rxm: Fix incorrect subsystem in logging + minor refactoring

prov/rxm: Remove shared context dependency on MSG provider: 
RxM needed a shared receive context from underlying MSG provider to conserve memory on pre-posted recvs. MSG providers sometime may not support shared receive contexts if the underlying hardware doesn't. Add a workaround in RxM provider to handle this. The trade-off here would be increased memory usage proportional to # of connections. This could be optimized later based on communication patterns.
