### PR TITLE
prov/sockets: Fix missing FI_CLAIM source info

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1134,6 +1134,7 @@ ssize_t sock_rx_claim_recv(struct sock_rx_ctx *rx_ctx, void *context,
 		pe_entry.data = rx_buffered->data;
 		pe_entry.context = rx_buffered->context;
 		pe_entry.flags = (flags | FI_MSG | FI_RECV);
+		pe_entry.addr = rx_buffered->addr;
 		if (is_tagged)
 			pe_entry.flags |= FI_TAGGED;
 


### PR DESCRIPTION
In the case of using FI_CLAIM, the source address was not being passed to
the completion, causing fi_cq_readfrom to always return 0 for the src_addr.

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>