### PR TITLE
prov/bgq: More scalable endpoint enablement fixes

### DIFF
--- a/prov/bgq/include/rdma/bgq/fi_bgq.h
+++ b/prov/bgq/include/rdma/bgq/fi_bgq.h
@@ -249,7 +249,7 @@ int fi_bgq_init_tagged_ops(struct fi_bgq_ep *bgq_ep, struct fi_info *info);
 int fi_bgq_enable_tagged_ops(struct fi_bgq_ep *bgq_ep);
 int fi_bgq_finalize_tagged_ops(struct fi_bgq_ep *bgq_ep);
 
-int fi_bgq_init_cm_ops(struct fi_bgq_ep *bgq_ep, struct fi_info *info);
+int fi_bgq_init_cm_ops(struct fid_ep *ep_fid, struct fi_info *info);
 int fi_bgq_finalize_cm_ops(struct fi_bgq_ep *bgq_ep);
 
 int fi_bgq_bind_ep_stx(struct fi_bgq_ep *ep,

--- a/prov/bgq/src/fi_bgq_domain.c
+++ b/prov/bgq/src/fi_bgq_domain.c
@@ -145,7 +145,7 @@ static int fi_bgq_mu_init(struct fi_bgq_domain *bgq_domain,
 		bgq_domain->rx.rfifo[n] = NULL;
 	}
 
-	const uint32_t subgroups_to_allocate_per_process = ppn == 64 ? 1 : ppn == 32 ? 2 : 4;
+	const uint32_t subgroups_to_allocate_per_process = ppn == 64 ? 1 : ppn == 32 ? 2 : ppn == 16 ? 4 : ppn == 8 ? 8 : ppn == 4 ? 16 : ppn == 2 ? 32 : 64;
 	for (n = 0; n < subgroups_to_allocate_per_process; ++n) {
 
 		const uint32_t requested_subgroup = subgroup_offset + n;
@@ -571,7 +571,7 @@ int fi_bgq_domain(struct fid_fabric *fabric,
 
 	if (fi_bgq_node_lock_allocate(&bgq_fabric->node, &bgq_domain->lock)) goto err;
 
-	fi_bgq_ref_inc(&bgq_fabric->ref_cnt, "fabric");
+	fi_bgq_ref_inc(&bgq_domain->fabric->ref_cnt, "fabric");
 
 	*dom = &bgq_domain->domain_fid;
 

--- a/prov/bgq/src/fi_bgq_ep.c
+++ b/prov/bgq/src/fi_bgq_ep.c
@@ -989,10 +989,6 @@ static int fi_bgq_ep_rx_init(struct fi_bgq_ep *bgq_ep)
 
 	bgq_ep->rx.self.fi = fi_bgq_addr_create(destination, fifo_map, rx);
 
-#ifdef FI_BGQ_TRACE
-	fprintf(stderr,"fi_bgq_ep_rx_init created addr:\n");
-	FI_BGQ_ADDR_DUMP(&bgq_ep->rx.self.fi);
-#endif
 	/* assign the mu reception fifos - all potential
 	 * reception fifos were allocated at domain initialization */
 	if (NULL == bgq_domain->rx.rfifo[fi_bgq_uid_get_rx(bgq_ep->rx.self.uid.fi)]) {
@@ -1006,6 +1002,10 @@ static int fi_bgq_ep_rx_init(struct fi_bgq_ep *bgq_ep)
 	}
 
 	bgq_ep->rx.poll.muspi_recfifo = bgq_domain->rx.rfifo[fi_bgq_uid_get_rx(bgq_ep->rx.self.uid.fi)];
+#ifdef FI_BGQ_TRACE
+	fprintf(stderr,"fi_bgq_ep_rx_init recfifo set to %u created addr:\n",fi_bgq_uid_get_rx(bgq_ep->rx.self.uid.fi));
+	FI_BGQ_ADDR_DUMP(&bgq_ep->rx.self.fi);
+#endif
 
 	bgq_ep->rx.poll.bat = bgq_domain->bat;
 
@@ -1921,7 +1921,7 @@ int fi_bgq_endpoint_rx_tx (struct fid_domain *dom, struct fi_info *info,
 	bgq_ep->ep_fid.fid.ops     = &fi_bgq_fi_ops;
 	bgq_ep->ep_fid.ops 	   = &fi_bgq_ep_ops;
 
-	ret = fi_bgq_init_cm_ops(bgq_ep, info);
+	ret = fi_bgq_init_cm_ops((struct fid_ep *)&(bgq_ep->ep_fid), info);
 	if (ret)
 		goto err;
 

--- a/prov/bgq/src/fi_bgq_sep.c
+++ b/prov/bgq/src/fi_bgq_sep.c
@@ -404,6 +404,10 @@ int fi_bgq_scalable_ep (struct fid_domain *domain,
 	bgq_sep->ep_fid.fid.ops		= &fi_bgq_fi_ops;
 	bgq_sep->ep_fid.ops		= &fi_bgq_sep_ops;
 
+        int ret = fi_bgq_init_cm_ops((struct fid_ep *)&(bgq_sep->ep_fid), info);
+        if (ret)
+                goto err;
+
 	bgq_sep->info = calloc(1, sizeof (struct fi_info));
 	if (!bgq_sep->info) {
 		errno = FI_ENOMEM;


### PR DESCRIPTION
More testing revealed further deficiencies in the scalable endpoint
implementation on BGQ which have now been fixed, including inadequate
utilization of rx bits in the fi_addr which put a ceiling of 16 recv
contexts (now can support 64 which is the number of hw threads on a node),
there were cm isues with the fi_getname not supporting scalable endpoints,
and further trace messages were added.

Signed-off-by: Paul Coffman <pcoffman@anl.gov>