### PR TITLE
prov/gni: add ability to detect local PE rank

### DIFF
--- a/prov/gni/configure.m4
+++ b/prov/gni/configure.m4
@@ -203,6 +203,8 @@ dnl Note kdreg only supplies an include file, no library
 
 
         AM_CONDITIONAL([HAVE_CRITERION], [test "x$have_criterion" = "xtrue"])
+        AS_IF([test "x$have_criterion" = "xtrue"],
+              [AC_DEFINE_UNQUOTED([HAVE_CRITERION], [1], [Define to 1 if criterion requested and available])])
 
         AC_SUBST(gni_CPPFLAGS)
         AC_SUBST(gni_LDFLAGS)

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -44,6 +44,9 @@
 #include <fi.h>
 
 extern struct fi_provider gnix_prov;
+#if HAVE_CRITERION
+extern int gnix_first_pe_on_node; /* globally visible for  criterion */
+#endif
 
 /*
  * For debug logging (ENABLE_DEBUG)
@@ -245,6 +248,7 @@ void _gnix_app_cleanup(void);
 int _gnix_job_fma_limit(uint32_t dev_id, uint8_t ptag, uint32_t *limit);
 int _gnix_job_cq_limit(uint32_t dev_id, uint8_t ptag, uint32_t *limit);
 int _gnix_pes_on_node(uint32_t *num_pes);
+int _gnix_pe_node_rank(int *pe_node_rank);
 int _gnix_nics_per_rank(uint32_t *nics_per_rank);
 void _gnix_dump_gni_res(uint8_t ptag);
 int _gnix_get_num_corespec_cpus(uint32_t *num_core_spec_cpus);

--- a/prov/gni/test/utils.c
+++ b/prov/gni/test/utils.c
@@ -84,6 +84,8 @@ Test(utils, alps)
 	uint8_t ptag;
 	uint32_t cookie, fmas, cqs, npes, npr;
 	void *addr = NULL;
+	char *cptr = NULL;
+	int lrank, trank;
 
 	_gnix_app_cleanup();
 
@@ -101,6 +103,27 @@ Test(utils, alps)
 
 	rc = _gnix_nics_per_rank(&npr);
 	cr_expect(!rc);
+
+	/*
+	 * TODO: this will need more work for CCM,
+	 * where the env. variables checked below
+	 * aren't defined
+	 */
+	rc = _gnix_pe_node_rank(&lrank);
+	if (rc != -FI_EADDRNOTAVAIL) {
+		cr_expect(!rc);
+
+		cptr = getenv("PMI_FORK_RANK");
+		if (cptr == NULL)
+			cptr = getenv("ALPS_APP_PE");
+		if (cptr != NULL) {
+			trank = atoi(cptr);
+			trank -= gnix_first_pe_on_node;
+			cr_expect(trank == lrank);
+		} else
+			cr_expect(0);
+	}
+
 
 	cqs /= GNIX_CQS_PER_EP;
 	cr_expect(((fmas > cqs ? cqs : fmas) / npes) == npr);


### PR DESCRIPTION
There may be some cases, when the GNI provider is being
used in the context of a job launcher like SLURM or ALPS,
in which the provider may need to use the local rank of
a process in deciding how to allocate Aries HW resources
to the process.

This commit adds a function to determine the "local rank".
This doesn't apply to processes not started via a SLURM
or ALPS based launch.

upstream merge of ofi-cray/libfabric-cray#1405

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@3cc29119afbead07c7dfbd1af9a64d03da3f9c01)