### PR TITLE
common: Move ofi_hex_str

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -487,6 +487,27 @@ int ofi_str_toaddr(const char *str, uint32_t *addr_format,
 	}
 }
 
+const char *ofi_hex_str(const uint8_t *data, size_t len)
+{
+	static char str[64];
+	const char hex[] = "0123456789abcdef";
+	size_t i, p;
+
+	if (len >= (sizeof(str) >> 1))
+		len = (sizeof(str) >> 1) - 1;
+
+	for (p = 0, i = 0; i < len; i++) {
+		str[p++] = hex[data[i] >> 4];
+		str[p++] = hex[data[i] & 0xF];
+	}
+
+	if (len == (sizeof(str) >> 1) - 1)
+		str[p++] = '~';
+
+	str[p] = '\0';
+	return str;
+}
+
 int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
 		 const struct sockaddr *sa2)
 {

--- a/src/log.c
+++ b/src/log.c
@@ -82,27 +82,6 @@ uint64_t log_mask;
 struct fi_filter prov_log_filter;
 
 
-const char *ofi_hex_str(const uint8_t *data, size_t len)
-{
-	static char str[64];
-	const char hex[] = "0123456789abcdef";
-	size_t i, p;
-
-	if (len >= (sizeof(str) >> 1))
-		len = (sizeof(str) >> 1) - 1;
-
-	for (p = 0, i = 0; i < len; i++) {
-		str[p++] = hex[data[i] >> 4];
-		str[p++] = hex[data[i] & 0xF];
-	}
-
-	if (len == (sizeof(str) >> 1) - 1)
-		str[p++] = '~';
-
-	str[p] = '\0';
-	return str;
-}
-
 static int fi_convert_log_str(const char *value)
 {
 	int i;


### PR DESCRIPTION
Move from log.c to common.c.  This function is used by DL providers
when using the debug build.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>