### PR TITLE
common: Use pthread_mutex_t and its initializer for fabric list lock

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -129,8 +129,6 @@ void ofi_create_filter(struct fi_filter *filter, const char *env_name);
 void ofi_free_filter(struct fi_filter *filter);
 int ofi_apply_filter(struct fi_filter *filter, const char *name);
 
-void fi_util_init(void);
-void fi_util_fini(void);
 void fi_log_init(void);
 void fi_log_fini(void);
 void fi_param_init(void);

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -740,9 +740,6 @@ struct fi_provider psmx2_prov = {
 
 PROVIDER_INI
 {
-#ifdef HAVE_PSM2_DL
-	fi_util_init();
-#endif
 	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
 
 	fi_param_define(&psmx2_prov, "name_server", FI_PARAM_BOOL,

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -39,24 +39,13 @@
 
 
 static DEFINE_LIST(fabric_list);
-static fastlock_t lock;
-
-
-void fi_util_init(void)
-{
-	fastlock_init(&lock);
-}
-
-void fi_util_fini(void)
-{
-	fastlock_destroy(&lock);
-}
+static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 
 void ofi_fabric_insert(struct util_fabric *fabric)
 {
-	fastlock_acquire(&lock);
+	pthread_mutex_lock(&lock);
 	dlist_insert_tail(&fabric->list_entry, &fabric_list);
-	fastlock_release(&lock);
+	pthread_mutex_unlock(&lock);
 }
 
 static int util_match_fabric(struct dlist_entry *item, const void *arg)
@@ -73,18 +62,18 @@ struct util_fabric *ofi_fabric_find(struct util_fabric_info *fabric_info)
 {
 	struct dlist_entry *item;
 
-	fastlock_acquire(&lock);
+	pthread_mutex_lock(&lock);
 	item = dlist_find_first_match(&fabric_list, util_match_fabric, fabric_info);
-	fastlock_release(&lock);
+	pthread_mutex_unlock(&lock);
 
 	return item ? container_of(item, struct util_fabric, list_entry) : NULL;
 }
 
 void ofi_fabric_remove(struct util_fabric *fabric)
 {
-	fastlock_acquire(&lock);
+	pthread_mutex_lock(&lock);
 	dlist_remove(&fabric->list_entry);
-	fastlock_release(&lock);
+	pthread_mutex_unlock(&lock);
 }
 
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -387,7 +387,6 @@ void fi_ini(void)
 
 	fi_param_init();
 	fi_log_init();
-	fi_util_init();
 	ofi_osd_init();
 
 	fi_param_define(NULL, "provider", FI_PARAM_STRING,
@@ -482,7 +481,6 @@ FI_DESTRUCTOR(fi_fini(void))
 	ofi_free_filter(&prov_filter);
 	fi_log_fini();
 	fi_param_fini();
-	fi_util_fini();
 	ofi_osd_fini();
 }
 


### PR DESCRIPTION
This is to avoid calling the fi_util_init function on DL provider init