### PR TITLE
prov/rxm: Extend the rxm to support the underlying providers with FI_CONTEXT mode set

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -86,6 +86,18 @@
 	       " (fi_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 ")\n",\
 	       addr, tag)
 
+#define RXM_GET_PROTO_STATE(comp)			\
+	(*(enum rxm_proto_state *)			\
+	  ((unsigned char *)(comp)->op_context +	\
+		offsetof(struct rxm_buf, state)))
+
+#define RXM_SET_PROTO_STATE(comp, new_state)				\
+do {									\
+	(*(enum rxm_proto_state *)					\
+	  ((unsigned char *)(comp)->op_context +			\
+		offsetof(struct rxm_buf, state))) = (new_state);	\
+} while (0)
+
 extern struct fi_provider rxm_prov;
 extern struct util_prov rxm_util_prov;
 extern struct fi_ops_rma rxm_ops_rma;
@@ -184,6 +196,8 @@ struct rxm_iov {
 
 struct rxm_buf {
 	/* Must stay at top */
+	struct fi_context fi_context;
+
 	enum rxm_proto_state state;
 
 	struct dlist_entry entry;
@@ -221,6 +235,8 @@ struct rxm_tx_buf {
 
 struct rxm_tx_entry {
 	/* Must stay at top */
+	struct fi_context fi_context;	
+
 	enum rxm_proto_state state;
 
 	struct rxm_ep *ep;

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -44,7 +44,7 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 	if (FI_VERSION_GE(version, FI_VERSION(1, 5)))
 		core_info->domain_attr->mr_mode |= FI_MR_LOCAL;
 	else
-		core_info->mode |= (FI_LOCAL_MR | FI_RX_CQ_DATA);
+		core_info->mode |= (FI_LOCAL_MR | FI_RX_CQ_DATA | FI_CONTEXT);
 
 	if (hints) {
 		/* No fi_info modes apart from FI_LOCAL_MR, FI_RX_CQ_DATA


### PR DESCRIPTION

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>