### PR TITLE
man/cntr: Allow for delay adding/setting counter values

### DIFF
--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -253,6 +253,13 @@ Fabric errno values are defined in
 
 # NOTES
 
+In order to support a variety of counter implementations, updates made to
+counter values (e.g. fi_cntr_set or fi_cntr_add) may not be immediately
+visible to counter read operations (i.e. fi_cntr_read or fi_cntr_readerr).
+A small, but undefined, delay may occur between the counter changing and
+the reported value being updated.  However, a final updated value will
+eventually be reflected in the read counter value, with the order of the
+updates maintained.
 
 # SEE ALSO
 


### PR DESCRIPTION
For hardware based counters, there may be a delay between
changing a counter value and the value being reflected in
reading the value.  Indicate this possibility in the man
page, clarifying that counter updates will eventually be
reflected in the order submitted.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>