### PR TITLE
man: Update the prov/rxm's man page

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -20,8 +20,6 @@ RxM provider requires the core provider to support the following features:
 
   * MSG endpoints (FI_EP_MSG)
 
-  * Shared receive contexts (FI_SHARED_CONTEXT)
-
   * RMA read/write (FI_RMA)
 
   * FI_OPT_CM_DATA_SIZE of atleast 24 bytes


### PR DESCRIPTION
Since #3267 there are no anymore SRX dependency on the underlying provider

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>