### PR TITLE
prov/sockets: Fix Coverity issue

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1868,10 +1868,10 @@ int sock_ep_get_conn(struct sock_ep_attr *attr, struct sock_tx_ctx *tx_ctx,
 		ret = sock_ep_connect(attr, av_index, &conn);
 
 	if (!conn) {
-		SOCK_LOG_ERROR("Error in connecting: %s\n",
-			       ret ? strerror(ret) :
-				     "No conn entry");
-		return ret ? ret : -FI_ENOENT;
+		SOCK_LOG_ERROR("Undable to find connection entry. "
+			       "Error in connecting: %s\n",
+			       strerror(ret));
+		return -FI_ENOENT;
 	}
 
 	*pconn = conn;


### PR DESCRIPTION
gcc complains about a possibility that fi_log called with unset parameter.
Coverity finds that if `!conn` takes true branch there is no possibility that `ret` is uset by some value. The value of the `ret` is always be negative in this case

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>