### PR TITLE
prov/psm,psm2: Always generate completion on error

### DIFF
--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -526,7 +526,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		req = (struct psmx_am_request *)(uintptr_t)args[1].u64;
 		op_error = (int)args[0].u32w1;
 		assert(req->op == PSMX_AM_REQ_ATOMIC_WRITE);
-		if (req->ep->send_cq && !req->no_event) {
+		if (req->ep->send_cq && (!req->no_event || op_error)) {
 			event = psmx_cq_create_event(
 					req->ep->send_cq,
 					req->atomic.context,
@@ -558,7 +558,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		if (!op_error)
 			memcpy(req->atomic.result, src, len);
 
-		if (req->ep->send_cq && !req->no_event) {
+		if (req->ep->send_cq && (!req->no_event || op_error)) {
 			event = psmx_cq_create_event(
 					req->ep->send_cq,
 					req->atomic.context,
@@ -695,7 +695,7 @@ static int psmx_atomic_self(int am_cmd,
 gen_local_event:
 	no_event = ((flags & PSMX_NO_COMPLETION) ||
 		    (ep->send_selective_completion && !(flags & FI_COMPLETION)));
-	if (ep->send_cq && !no_event) {
+	if (ep->send_cq && (!no_event || op_error)) {
 		event = psmx_cq_create_event(
 				ep->send_cq,
 				context,

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -252,7 +252,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		if (!req->error)
 			req->error = op_error;
 		if (eom) {
-			if (req->ep->send_cq && !req->no_event) {
+			if (req->ep->send_cq && (!req->no_event || req->error)) {
 				event = psmx_cq_create_event(
 						req->ep->send_cq,
 						req->write.context,
@@ -288,7 +288,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			req->read.len_read += len;
 		}
 		if (eom) {
-			if (req->ep->send_cq && !req->no_event) {
+			if (req->ep->send_cq && (!req->no_event || req->error)) {
 				event = psmx_cq_create_event(
 						req->ep->send_cq,
 						req->read.context,
@@ -398,7 +398,7 @@ static ssize_t psmx_rma_self(int am_cmd,
 	no_event = (flags & PSMX_NO_COMPLETION) ||
 		   (ep->send_selective_completion && !(flags & FI_COMPLETION));
 
-	if (ep->send_cq && !no_event) {
+	if (ep->send_cq && (!no_event || op_error)) {
 		event = psmx_cq_create_event(
 				ep->send_cq,
 				context,

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -583,7 +583,7 @@ int psmx2_am_atomic_handler_ext(psm2_am_token_t token,
 		req = (struct psmx2_am_request *)(uintptr_t)args[1].u64;
 		op_error = (int)args[0].u32w1;
 		assert(req->op == PSMX2_AM_REQ_ATOMIC_WRITE);
-		if (req->ep->send_cq && !req->no_event) {
+		if (req->ep->send_cq && (!req->no_event || op_error)) {
 			event = psmx2_cq_create_event(
 					req->ep->send_cq,
 					req->atomic.context,
@@ -621,7 +621,7 @@ int psmx2_am_atomic_handler_ext(psm2_am_token_t token,
 						req->atomic.datatype, src, len);
 		}
 
-		if (req->ep->send_cq && !req->no_event) {
+		if (req->ep->send_cq && (!req->no_event || op_error)) {
 			event = psmx2_cq_create_event(
 					req->ep->send_cq,
 					req->atomic.context,
@@ -758,7 +758,7 @@ static int psmx2_atomic_self(int am_cmd,
 gen_local_event:
 	no_event = ((flags & PSMX2_NO_COMPLETION) ||
 		    (ep->send_selective_completion && !(flags & FI_COMPLETION)));
-	if (ep->send_cq && !no_event) {
+	if (ep->send_cq && (!no_event || op_error)) {
 		event = psmx2_cq_create_event(
 				ep->send_cq,
 				context,

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -303,7 +303,7 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 		if (!req->error)
 			req->error = op_error;
 		if (eom) {
-			if (req->ep->send_cq && !req->no_event) {
+			if (req->ep->send_cq && (!req->no_event || req->error)) {
 				event = psmx2_cq_create_event(
 						req->ep->send_cq,
 						req->write.context,
@@ -347,7 +347,7 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 			if (!eom)
 				FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
 					"readv: short protocol finishes after long protocol.\n");
-			if (req->ep->send_cq && !req->no_event) {
+			if (req->ep->send_cq && (!req->no_event || req->error)) {
 				event = psmx2_cq_create_event(
 						req->ep->send_cq,
 						req->read.context,
@@ -499,7 +499,7 @@ static ssize_t psmx2_rma_self(int am_cmd,
 	no_event = (flags & PSMX2_NO_COMPLETION) ||
 		   (ep->send_selective_completion && !(flags & FI_COMPLETION));
 
-	if (ep->send_cq && !no_event) {
+	if (ep->send_cq && (!no_event || op_error)) {
 		event = psmx2_cq_create_event(
 				ep->send_cq,
 				context,


### PR DESCRIPTION
There was a bug in the completion generation logic that prevented
completion suppressed operations from generating CQ entries when
error happened. That could cause applications to hang mysteriously
instead of showing explicit runtime error.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>