### PR TITLE
prov/psm2: Fix a segfault when the provider is loaded dynamically

### DIFF
--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -96,8 +96,8 @@ static int psmx2_init_lib(int default_multi_ep)
 	if (psmx2_lib_initialized)
 		goto out;
 
-	if (default_multi_ep && !getenv("PSM2_MULTI_EP"))
-		putenv("PSM2_MULTI_EP=1");
+	if (default_multi_ep)
+		setenv("PSM2_MULTI_EP", "1", 0);
 
 	psm2_error_register_handler(NULL, PSM2_ERRHANDLER_NO_HANDLER);
 


### PR DESCRIPTION
Under certain condition, putenv() is called to add an environment
variable to automatically turn on the PSM2 multi EP support. This
works fine fine as a built-in provider. However, if the provider
is dynamically loaded, the environment becomes corrupted after the
provider is unloaded. This can cause the PSM2 library destructor
to segfault within a getenv() call upon exit() being called.

This is fixed by replacing putenv() with setenv(), which makes a
copy of the string arguments.

Fixes #3282 

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>