### PR TITLE
prov/psm2: Fix FI_PEEK matching by src_addr without FI_DIRECTED_RECV

### DIFF
--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -52,7 +52,7 @@ static ssize_t psmx2_tagged_peek_generic(struct fid_ep *ep,
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
-	if (src_addr != FI_ADDR_UNSPEC) {
+	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
 		av = ep_priv->av;
 		if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);


### PR DESCRIPTION
This commit fixes a bug where the FI_PEEK operation will match a message by
the source address when the application did not request the FI_DIRECTED_RECV
capability. This is particularly problematic if the application uses a
zero-allocated struct fi_msg_tagged and FI_AV_TABLE, since it will only
match messages that come from rank 0.

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>