### PR TITLE
prov/util: Add check for invalid core name to ofi_get_core_info_fabric

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -323,15 +323,16 @@ int ofi_get_core_info_fabric(struct fi_fabric_attr *util_attr,
 	size_t len;
 	int ret;
 
+	core_name = ofi_core_name(util_attr->prov_name, &len);
+	if (!core_name)
+		return -FI_ENODATA;
+
 	memset(&hints, 0, sizeof hints);
 	if (!(hints.fabric_attr = calloc(1, sizeof(*hints.fabric_attr))))
 		return -FI_ENOMEM;
 
 	hints.fabric_attr->name = util_attr->name;
 	hints.fabric_attr->api_version = util_attr->api_version;
-
-	core_name = ofi_core_name(util_attr->prov_name, &len);
-
 	if (!(hints.fabric_attr->prov_name = strndup(core_name, len))) {
 		ret = -FI_ENOMEM;
 		goto out;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -234,7 +234,7 @@ struct fi_ibv_rdm_buf_service_data {
 struct fi_ibv_rdm_buf {
 	struct fi_ibv_rdm_buf_service_data service_data;
 	struct fi_ibv_rdm_header header;
-	uint8_t payload;
+	uint64_t payload;
 };
 
 struct fi_ibv_rdm_cm {

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -72,7 +72,8 @@ static ssize_t fi_ibv_rdm_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	};
 	struct fi_ibv_rdm_request *request =
 		util_buf_alloc(fi_ibv_rdm_request_pool);
-
+	if (OFI_UNLIKELY(!request))
+		return -FI_EAGAIN;
 	fi_ibv_rdm_zero_request(request);
 	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -146,7 +146,8 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 
 	struct fi_ibv_rdm_request *request =
 		util_buf_alloc(fi_ibv_rdm_request_pool);
-
+	if (OFI_UNLIKELY(!request))
+		return -FI_EAGAIN;
 	fi_ibv_rdm_zero_request(request);
 	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
@@ -492,6 +493,8 @@ fi_ibv_rdm_process_recv(struct fi_ibv_rdm_ep *ep, struct fi_ibv_rdm_conn *conn,
 			request = found_request;
 		} else {
 			request = util_buf_alloc(fi_ibv_rdm_request_pool);
+			if (OFI_UNLIKELY(!request))
+				return;
 			fi_ibv_rdm_zero_request(request);
 
 			FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request,

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -249,6 +249,8 @@ fi_ibv_rdm_send_common(struct fi_ibv_rdm_send_start_data* sdata)
 {
 	struct fi_ibv_rdm_request *request =
 		util_buf_alloc(fi_ibv_rdm_request_pool);
+	if (OFI_UNLIKELY(!request))
+		return -FI_EAGAIN;
 	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 	/* Initial state */


### PR DESCRIPTION
It's possible an app can modify the fi_info and remove the core name.
At least protect against this by checking for a failure.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>