### PR TITLE
prov/psm,psm2: Cherry-picked patches for v1.5.x

### DIFF
--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -526,7 +526,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		req = (struct psmx_am_request *)(uintptr_t)args[1].u64;
 		op_error = (int)args[0].u32w1;
 		assert(req->op == PSMX_AM_REQ_ATOMIC_WRITE);
-		if (req->ep->send_cq && !req->no_event) {
+		if (req->ep->send_cq && (!req->no_event || op_error)) {
 			event = psmx_cq_create_event(
 					req->ep->send_cq,
 					req->atomic.context,
@@ -558,7 +558,7 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		if (!op_error)
 			memcpy(req->atomic.result, src, len);
 
-		if (req->ep->send_cq && !req->no_event) {
+		if (req->ep->send_cq && (!req->no_event || op_error)) {
 			event = psmx_cq_create_event(
 					req->ep->send_cq,
 					req->atomic.context,
@@ -695,7 +695,7 @@ static int psmx_atomic_self(int am_cmd,
 gen_local_event:
 	no_event = ((flags & PSMX_NO_COMPLETION) ||
 		    (ep->send_selective_completion && !(flags & FI_COMPLETION)));
-	if (ep->send_cq && !no_event) {
+	if (ep->send_cq && (!no_event || op_error)) {
 		event = psmx_cq_create_event(
 				ep->send_cq,
 				context,

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -252,7 +252,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 		if (!req->error)
 			req->error = op_error;
 		if (eom) {
-			if (req->ep->send_cq && !req->no_event) {
+			if (req->ep->send_cq && (!req->no_event || req->error)) {
 				event = psmx_cq_create_event(
 						req->ep->send_cq,
 						req->write.context,
@@ -288,7 +288,7 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			req->read.len_read += len;
 		}
 		if (eom) {
-			if (req->ep->send_cq && !req->no_event) {
+			if (req->ep->send_cq && (!req->no_event || req->error)) {
 				event = psmx_cq_create_event(
 						req->ep->send_cq,
 						req->read.context,
@@ -398,7 +398,7 @@ static ssize_t psmx_rma_self(int am_cmd,
 	no_event = (flags & PSMX_NO_COMPLETION) ||
 		   (ep->send_selective_completion && !(flags & FI_COMPLETION));
 
-	if (ep->send_cq && !no_event) {
+	if (ep->send_cq && (!no_event || op_error)) {
 		event = psmx_cq_create_event(
 				ep->send_cq,
 				context,

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -1365,8 +1365,10 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 	    !result_count)
 		return -FI_EINVAL;
 
-	while (count && !iov[count-1].count)
-		count--;
+	if (iov) {
+		while (count && !iov[count-1].count)
+			count--;
+	}
 
 	while (result_count && !resultv[result_count-1].count)
 		result_count--;

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -589,7 +589,7 @@ int psmx2_am_atomic_handler_ext(psm2_am_token_t token,
 		req = (struct psmx2_am_request *)(uintptr_t)args[1].u64;
 		op_error = (int)args[0].u32w1;
 		assert(req->op == PSMX2_AM_REQ_ATOMIC_WRITE);
-		if (req->ep->send_cq && !req->no_event) {
+		if (req->ep->send_cq && (!req->no_event || op_error)) {
 			event = psmx2_cq_create_event(
 					req->ep->send_cq,
 					req->atomic.context,
@@ -626,7 +626,7 @@ int psmx2_am_atomic_handler_ext(psm2_am_token_t token,
 						req->atomic.datatype, src, len);
 		}
 
-		if (req->ep->send_cq && !req->no_event) {
+		if (req->ep->send_cq && (!req->no_event || op_error)) {
 			event = psmx2_cq_create_event(
 					req->ep->send_cq,
 					req->atomic.context,
@@ -763,7 +763,7 @@ static int psmx2_atomic_self(int am_cmd,
 gen_local_event:
 	no_event = ((flags & PSMX2_NO_COMPLETION) ||
 		    (ep->send_selective_completion && !(flags & FI_COMPLETION)));
-	if (ep->send_cq && !no_event) {
+	if (ep->send_cq && (!no_event || op_error)) {
 		event = psmx2_cq_create_event(
 				ep->send_cq,
 				context,

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -466,10 +466,10 @@ static int psmx2_av_query_seps(struct psmx2_fid_av *av, size_t count, psm2_epid_
 	 * (1) ensure array "req->errors" is valid;
 	 * (2) to simplify the logic of generating the final completion event.
 	 */
-	while (ofi_atomic_get32(&req->pending))
-		psmx2_progress_all(av->domain);
 
 	if (req) {
+		while (ofi_atomic_get32(&req->pending))
+			psmx2_progress_all(av->domain);
 		error_count = ofi_atomic_get32(&req->error_count);
 		free(req);
 	}

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -170,6 +170,11 @@ psmx2_cq_create_event_from_status(struct psmx2_fid_cq *cq,
 	uint64_t flags;
 
 	switch((int)PSMX2_CTXT_TYPE(fi_context)) {
+	case PSMX2_NOCOMP_SEND_CONTEXT: /* error only */
+		op_context = NULL;
+		buf = NULL;
+		flags = FI_SEND | FI_MSG;
+		break;
 	case PSMX2_SEND_CONTEXT:
 		op_context = fi_context;
 		buf = PSMX2_CTXT_USER(fi_context);
@@ -187,6 +192,15 @@ psmx2_cq_create_event_from_status(struct psmx2_fid_cq *cq,
 		op_context = sendv_rep->user_context;
 		buf = sendv_rep->buf;
 		flags = FI_RECV | sendv_rep->comp_flag;
+		is_recv = 1;
+		break;
+	case PSMX2_NOCOMP_RECV_CONTEXT: /* error only */
+	case PSMX2_NOCOMP_RECV_CONTEXT_ALLOC: /* error only */
+		op_context = NULL;
+		buf = NULL;
+		flags = FI_RECV | FI_MSG;
+		if (psm2_status->msg_tag.tag2 & PSMX2_IMM_BIT)
+			flags |= FI_REMOTE_CQ_DATA;
 		is_recv = 1;
 		break;
 	case PSMX2_RECV_CONTEXT:
@@ -219,11 +233,13 @@ psmx2_cq_create_event_from_status(struct psmx2_fid_cq *cq,
 		flags = FI_RECV | FI_TAGGED;
 		is_recv = 1;
 		break;
+	case PSMX2_NOCOMP_READ_CONTEXT: /* error only */
 	case PSMX2_READ_CONTEXT:
 		op_context = PSMX2_CTXT_USER(fi_context);
 		buf = NULL;
 		flags = FI_READ | FI_RMA;
 		break;
+	case PSMX2_NOCOMP_WRITE_CONTEXT: /* error only */
 	case PSMX2_WRITE_CONTEXT:
 		op_context = PSMX2_CTXT_USER(fi_context);
 		buf = NULL;
@@ -364,12 +380,13 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 	struct psmx2_fid_cq *tmp_cq;
 	struct psmx2_fid_cntr *tmp_cntr;
 	struct psmx2_cq_event *event;
-	struct psmx2_am_request *read_req;
+	struct psmx2_am_request *read_req, *write_req;
 	int multi_recv;
 	int err;
 	int read_more = 1;
 	int read_count = 0;
 	void *event_buffer = count ? event_in : NULL;
+	struct fi_context dummy_context;
 
 	while (1) {
 		/* psm2_mq_ipeek and psm2_mq_test is suposed to be called
@@ -402,8 +419,12 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 			case PSMX2_SEND_CONTEXT:
 			case PSMX2_TSEND_CONTEXT:
 				tmp_cq = tmp_ep->send_cq;
-				/* Fall through */
+				tmp_cntr = tmp_ep->send_cntr;
+				break;
+
 			case PSMX2_NOCOMP_SEND_CONTEXT:
+				if (psm2_status.error_code)
+					tmp_cq = tmp_ep->send_cq;
 				tmp_cntr = tmp_ep->send_cntr;
 				break;
 
@@ -413,8 +434,12 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				    !psmx2_handle_sendv_req(tmp_ep, &psm2_status, 0))
 					continue;
 				tmp_cq = tmp_ep->recv_cq;
-				/* Fall through */
+				tmp_cntr = tmp_ep->recv_cntr;
+				break;
+
 			case PSMX2_NOCOMP_RECV_CONTEXT:
+				if (psm2_status.error_code)
+					tmp_cq = tmp_ep->recv_cq;
 				tmp_cntr = tmp_ep->recv_cntr;
 				break;
 
@@ -424,24 +449,37 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					psmx2_ep_put_op_context(tmp_ep, fi_context);
 					continue;
 				}
+				if (psm2_status.error_code) {
+					tmp_cq = tmp_ep->recv_cq;
+					PSMX2_CTXT_TYPE(&dummy_context) = PSMX2_NOCOMP_RECV_CONTEXT_ALLOC;
+					psm2_status.context = &dummy_context;
+				}
 				tmp_cntr = tmp_ep->recv_cntr;
 				psmx2_ep_put_op_context(tmp_ep, fi_context);
 				break;
 
 			case PSMX2_WRITE_CONTEXT:
 				tmp_cq = tmp_ep->send_cq;
-				/* Fall through */
-			case PSMX2_NOCOMP_WRITE_CONTEXT:
 				tmp_cntr = tmp_ep->write_cntr;
+				write_req = container_of(fi_context, struct psmx2_am_request,
+							 fi_context);
+				free(write_req);
+				break;
+
+			case PSMX2_NOCOMP_WRITE_CONTEXT:
+				if (psm2_status.error_code)
+					tmp_cq = tmp_ep->send_cq;
+				tmp_cntr = tmp_ep->write_cntr;
+				write_req = container_of(fi_context, struct psmx2_am_request,
+							 fi_context);
+				free(write_req);
 				break;
 
 			case PSMX2_READ_CONTEXT:
 				tmp_cq = tmp_ep->send_cq;
-				/* Fall throigh */
-			case PSMX2_NOCOMP_READ_CONTEXT:
+				tmp_cntr = tmp_ep->read_cntr;
 				read_req = container_of(fi_context, struct psmx2_am_request,
 							fi_context);
-				tmp_cntr = tmp_ep->read_cntr;
 				if (read_req->op == PSMX2_AM_REQ_READV) {
 					read_req->read.len_read += psm2_status.nbytes;
 					if (read_req->read.len_read < read_req->read.len) {
@@ -449,8 +487,35 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 							"readv: long protocol finishes early\n");
 						tmp_cq = NULL;
 						tmp_cntr = NULL;
+						if (psm2_status.error_code)
+							read_req->error = psmx2_errno(psm2_status.error_code);
+						/* Request to be freed in AM handler */
+						break;
 					}
 				}
+				free(read_req);
+				break;
+
+			case PSMX2_NOCOMP_READ_CONTEXT:
+				if (psm2_status.error_code)
+					tmp_cq = tmp_ep->send_cq;
+				tmp_cntr = tmp_ep->read_cntr;
+				read_req = container_of(fi_context, struct psmx2_am_request,
+							fi_context);
+				if (read_req->op == PSMX2_AM_REQ_READV) {
+					read_req->read.len_read += psm2_status.nbytes;
+					if (read_req->read.len_read < read_req->read.len) {
+						FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
+							"readv: long protocol finishes early\n");
+						tmp_cq = NULL;
+						tmp_cntr = NULL;
+						if (psm2_status.error_code)
+							read_req->error = psmx2_errno(psm2_status.error_code);
+						/* Request to be freed in AM handler */
+						break;
+					}
+				}
+				free(read_req);
 				break;
 
 			case PSMX2_MULTI_RECV_CONTEXT:
@@ -506,6 +571,8 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				  if (mr->cntr && mr->cntr != req->ep->remote_write_cntr)
 					psmx2_cntr_inc(mr->cntr);
 
+				  free(req);
+
 				  if (read_more)
 					continue;
 
@@ -520,6 +587,8 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				  req = container_of(fi_context, struct psmx2_am_request, fi_context);
 				  if (req->ep->remote_read_cntr)
 					psmx2_cntr_inc(req->ep->remote_read_cntr);
+
+				  free(req);
 
 				  continue;
 				}

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -94,8 +94,8 @@ static int psmx2_init_lib(int default_multi_ep)
 	if (psmx2_lib_initialized)
 		goto out;
 
-	if (default_multi_ep && !getenv("PSM2_MULTI_EP"))
-		putenv("PSM2_MULTI_EP=1");
+	if (default_multi_ep)
+		setenv("PSM2_MULTI_EP", "1", 0);
 
 	psm2_error_register_handler(NULL, PSM2_ERRHANDLER_NO_HANDLER);
 

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -304,7 +304,7 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 		if (!req->error)
 			req->error = op_error;
 		if (eom) {
-			if (req->ep->send_cq && !req->no_event) {
+			if (req->ep->send_cq && (!req->no_event || req->error)) {
 				event = psmx2_cq_create_event(
 						req->ep->send_cq,
 						req->write.context,
@@ -347,7 +347,7 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 			if (!eom)
 				FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
 					"readv: short protocol finishes after long protocol.\n");
-			if (req->ep->send_cq && !req->no_event) {
+			if (req->ep->send_cq && (!req->no_event || req->error)) {
 				event = psmx2_cq_create_event(
 						req->ep->send_cq,
 						req->read.context,
@@ -498,7 +498,7 @@ static ssize_t psmx2_rma_self(int am_cmd,
 	no_event = (flags & PSMX2_NO_COMPLETION) ||
 		   (ep->send_selective_completion && !(flags & FI_COMPLETION));
 
-	if (ep->send_cq && !no_event) {
+	if (ep->send_cq && (!no_event || op_error)) {
 		event = psmx2_cq_create_event(
 				ep->send_cq,
 				context,

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -52,7 +52,7 @@ static ssize_t psmx2_tagged_peek_generic(struct fid_ep *ep,
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
-	if (src_addr != FI_ADDR_UNSPEC) {
+	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
 		av = ep_priv->av;
 		if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -402,7 +402,8 @@ psmx2_tagged_recv_no_flag_av_table(struct fid_ep *ep, void *buf, size_t len,
 
 	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
 		av = ep_priv->av;
-		if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
+		assert(av != NULL);
+		if (PSMX2_SEP_ADDR_TEST(src_addr)) {
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 			vlane = 0;
 		} else {
@@ -514,7 +515,8 @@ psmx2_tagged_recv_no_event_av_table(struct fid_ep *ep, void *buf, size_t len,
 
 	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
 		av = ep_priv->av;
-		if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
+		assert(av != NULL);
+		if (PSMX2_SEP_ADDR_TEST(src_addr)) {
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 			vlane = 0;
 		} else {
@@ -806,7 +808,8 @@ psmx2_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	av = ep_priv->av;
-	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+	assert(av != NULL);
+	if (PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
 	} else {
@@ -899,7 +902,8 @@ psmx2_tagged_send_no_event_av_table(struct fid_ep *ep, const void *buf,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	av = ep_priv->av;
-	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+	assert(av != NULL);
+	if (PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
 	} else {
@@ -988,7 +992,8 @@ psmx2_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
 	av = ep_priv->av;
-	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+	assert(av != NULL);
+	if (PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
 	} else {


### PR DESCRIPTION
prov/psm2: Fix a segfault when the provider is loaded dynamically
prov/psm,psm2: Always generate completion on error
prov/psm2: Fix usage of NULL pointer given malloc failed 
prov/psm2: Added asserts to check for NULL av parameter
prov/psm2: Added NULL check for iov in atomic_readwritev
prov/psm2: Fix FI_PEEK matching by src_addr without FI_DIRECTED_RECV
