### PR TITLE
src/fabric: Fix to enforce prov ordering on register of DL providers

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -627,6 +627,37 @@ protocol value set to one.
 *FI_PROTO_SOCK_TCP*
 : The protocol is layered over TCP packets.
 
+*FI_PROTO_IWARP_RDM*
+: Reliable-datagram protocol implemented over iWarp reliable-connected
+  queue pairs.
+
+*FI_PROTO_IB_RDM*
+: Reliable-datagram protocol implemented over InfiniBand reliable-connected
+  queue pairs.
+
+*FI_PROTO_GNI*
+: Protocol runs over Cray GNI low-level interface.
+
+*FI_PROTO_RXM*
+: Reliable-datagram protocol implemented over message endpoints.  RXM is
+  a libfabric utility component that adds RDM endpoint semantics over
+  MSG endpoint semantics.
+
+*FI_PROTO_RXD*
+: Reliable-datagram protocol implemented over datagram endpoints.  RXD is
+  a libfabric utility component that adds RDM endpoint semantics over
+  DGRAM endpoint semantics.
+
+*FI_PROTO_NETWORKDIRECT*
+: Protocol runs over Microsoft NetworkDirect service provider interface.
+  This adds reliable-datagram semantics over the NetworkDirect connection-
+  oriented endpoint semantics.
+
+*FI_PROTO_PSMX2*
+: The protocol is based on an Intel proprietary protocol known as PSM2,
+  performance scaled messaging version 2.  PSMX2 is an extended version of the
+  PSM2 protocol to support the libfabric interfaces.
+
 ## protocol_version - Protocol Version
 
 Identifies which version of the protocol is employed by the provider.


### PR DESCRIPTION
DL providers are not correctly registered in the order
defined in src/fabric.c for known providers.

This results in unexpected providers being loaded that
may not be the preferred or fastest provider.

To resolve this issue, the registered provider list is now
preconfigured with the known providers and their ranking
such that the known providers are always registered in
the proper order.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>