### PR TITLE
common: Fix OFI_LIKELY/UNLIKELY definitions

### DIFF
--- a/include/fi_osd.h
+++ b/include/fi_osd.h
@@ -72,8 +72,8 @@ typedef long double long_double;
 #define OFI_LIKELY(x)	__builtin_expect((x), 1)
 #define OFI_UNLIKELY(x)	__builtin_expect((x), 0)
 #else
-#define OFI_LIKELY(x)
-#define OFI_UNLIKELY(x)
+#define OFI_LIKELY(x)	(x)
+#define OFI_UNLIKELY(x)	(x)
 #endif
 
 #endif /* _FI_OSD_H_ */


### PR DESCRIPTION
The macros convert to no-ops, rather than actual comparisons,
when GNUC is not present.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>