### PR TITLE
prov/util, rxm: Updates to connection management

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -448,7 +448,7 @@ typedef struct util_cmap_handle* (*ofi_cmap_alloc_handle_func)(void);
 typedef void (*ofi_cmap_handle_func)(struct util_cmap_handle *handle);
 typedef int (*ofi_cmap_connect_func)(struct util_ep *cmap,
 				     struct util_cmap_handle *handle,
-				     fi_addr_t fi_addr);
+				     const void *addr, size_t addrlen);
 typedef void *(*ofi_cmap_event_handler_func)(void *arg);
 typedef int (*ofi_cmap_signal_func)(struct util_ep *ep, void *context,
 				    enum ofi_cmap_signal signal);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -360,16 +360,7 @@ int rxm_cq_handle_data(struct rxm_rx_buf *rx_buf);
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  struct fid_ep **ep, void *context);
 
-void *rxm_conn_event_handler(void *arg);
-int rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
-		     const void *addr, size_t addrlen);
-int rxm_conn_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
-		void *data);
-struct util_cmap_handle *rxm_conn_alloc(void);
-void rxm_conn_close(struct util_cmap_handle *handle);
-void rxm_conn_free(struct util_cmap_handle *handle);
-int rxm_conn_signal(struct util_ep *util_ep, void *context,
-		    enum ofi_cmap_signal signal);
+struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep);
 
 int rxm_ep_repost_buf(struct rxm_rx_buf *buf);
 int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -362,7 +362,7 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 void *rxm_conn_event_handler(void *arg);
 int rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
-		    fi_addr_t fi_addr);
+		     const void *addr, size_t addrlen);
 int rxm_conn_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 		void *data);
 struct util_cmap_handle *rxm_conn_alloc(void);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -108,20 +108,21 @@ void rxm_conn_close(struct util_cmap_handle *handle)
 	rxm_conn->msg_ep = NULL;
 }
 
-void rxm_conn_free(struct util_cmap_handle *handle)
+static void rxm_conn_free(struct util_cmap_handle *handle)
 {
 	rxm_conn_close(handle);
 	free(container_of(handle, struct rxm_conn, handle));
 }
 
-struct util_cmap_handle *rxm_conn_alloc(void)
+static struct util_cmap_handle *rxm_conn_alloc(void)
 {
 	struct rxm_conn *rxm_conn = calloc(1, sizeof(*rxm_conn));
 	return rxm_conn ? &rxm_conn->handle : NULL;
 }
 
-int rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
-			    void *data)
+static int
+rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
+			void *data)
 {
 	struct rxm_conn *rxm_conn;
 	struct rxm_cm_data *remote_cm_data = data;
@@ -194,7 +195,7 @@ static void rxm_conn_handle_eq_err(struct rxm_ep *rxm_ep, ssize_t rd)
 	}
 }
 
-void *rxm_conn_event_handler(void *arg)
+static void *rxm_conn_event_handler(void *arg)
 {
 	struct fi_eq_cm_entry *entry;
 	size_t datalen = sizeof(struct rxm_cm_data);
@@ -291,8 +292,9 @@ static int rxm_prepare_cm_data(struct fid_pep *pep, struct util_cmap_handle *han
 	return 0;
 }
 
-int rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
-		     const void *addr, size_t addrlen)
+static int
+rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
+		 const void *addr, size_t addrlen)
 {
 	struct rxm_ep *rxm_ep;
 	struct rxm_conn *rxm_conn;
@@ -339,8 +341,8 @@ err1:
 	return ret;
 }
 
-int rxm_conn_signal(struct util_ep *util_ep, void *context,
-		    enum ofi_cmap_signal signal)
+static int rxm_conn_signal(struct util_ep *util_ep, void *context,
+			   enum ofi_cmap_signal signal)
 {
 	struct rxm_ep *rxm_ep = container_of(util_ep, struct rxm_ep, util_ep);
 	struct fi_eq_entry entry = {0};
@@ -355,4 +357,36 @@ int rxm_conn_signal(struct util_ep *util_ep, void *context,
 		return (int)rd;
 	}
 	return 0;
+}
+
+struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep)
+{
+	struct util_cmap_attr attr;
+	void *name;
+	size_t len;
+	int ret;
+
+	len = rxm_ep->msg_info->src_addrlen;
+	name = malloc(len);
+
+	/* Passive endpoint should already have fi_setname or fi_listen
+	 * called on it for this to work */
+	ret = fi_getname(&rxm_ep->msg_pep->fid, name, &len);
+	if (ret) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+			"Unable to fi_getname on msg_ep\n");
+		free(name);
+		return NULL;
+	}
+	ofi_straddr_dbg(&rxm_prov, FI_LOG_EP_CTRL, "local_name", name);
+
+	attr.name		= name;
+	attr.alloc 		= rxm_conn_alloc;
+	attr.close 		= rxm_conn_close;
+	attr.free 		= rxm_conn_free;
+	attr.connect 		= rxm_conn_connect;
+	attr.event_handler	= rxm_conn_event_handler;
+	attr.signal		= rxm_conn_signal;
+
+	return ofi_cmap_alloc(&rxm_ep->util_ep, &attr);
 }

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -292,7 +292,7 @@ static int rxm_prepare_cm_data(struct fid_pep *pep, struct util_cmap_handle *han
 }
 
 int rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
-		    fi_addr_t fi_addr)
+		     const void *addr, size_t addrlen)
 {
 	struct rxm_ep *rxm_ep;
 	struct rxm_conn *rxm_conn;
@@ -305,18 +305,15 @@ int rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
 	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	free(rxm_ep->msg_info->dest_addr);
-	rxm_ep->msg_info->dest_addrlen = rxm_ep->util_ep.av->addrlen;
-	rxm_ep->msg_info->dest_addr = mem_dup(ofi_av_get_addr(rxm_ep->util_ep.av,
-							      fi_addr),
-					      rxm_ep->util_ep.av->addrlen);
+	rxm_ep->msg_info->dest_addrlen = addrlen;
+	rxm_ep->msg_info->dest_addr = mem_dup(addr, rxm_ep->msg_info->dest_addrlen);
 
 	ret = fi_getinfo(rxm_ep->util_ep.domain->fabric->fabric_fid.api_version,
 			 NULL, NULL, 0, rxm_ep->msg_info, &msg_info);
 	if (ret)
 		return ret;
 
-	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn,
-			      &rxm_conn->handle);
+	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn, &rxm_conn->handle);
 	if (ret)
 		goto err1;
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -308,7 +308,8 @@ rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
 
 	free(rxm_ep->msg_info->dest_addr);
 	rxm_ep->msg_info->dest_addrlen = addrlen;
-	rxm_ep->msg_info->dest_addr = mem_dup(addr, rxm_ep->msg_info->dest_addrlen);
+	if (!(rxm_ep->msg_info->dest_addr = mem_dup(addr, rxm_ep->msg_info->dest_addrlen)))
+		return -FI_ENOMEM;
 
 	ret = fi_getinfo(rxm_ep->util_ep.domain->fabric->fabric_fid.api_version,
 			 NULL, NULL, 0, rxm_ep->msg_info, &msg_info);

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1484,6 +1484,7 @@ struct util_cmap *ofi_cmap_alloc(struct util_ep *ep,
 	return cmap;
 err3:
 	fastlock_destroy(&cmap->lock);
+	free(cmap->attr.name);
 err2:
 	free(cmap->handles_av);
 err1:

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1370,7 +1370,9 @@ int ofi_cmap_get_handle(struct util_cmap *cmap, fi_addr_t fi_addr,
 	}
 	switch (handle->state) {
 	case CMAP_IDLE:
-		ret = cmap->attr.connect(cmap->ep, handle, fi_addr);
+		ret = cmap->attr.connect(cmap->ep, handle,
+					 ofi_av_get_addr(cmap->av, fi_addr),
+					 cmap->av->addrlen);
 		if (ret) {
 			util_cmap_del_handle(handle);
 			goto unlock;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1292,7 +1292,14 @@ int ofi_cmap_process_connreq(struct util_cmap *cmap, void *addr,
 
 	ofi_straddr_dbg(cmap->av->prov, FI_LOG_EP_CTRL,
 			"Processing connreq for addr", addr);
-	index = ip_av_get_index(cmap->av, addr);
+
+	if (!ofi_addr_cmp(cmap->av->prov, addr, cmap->attr.name)) {
+		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
+			"Endpoint connects to itself. Not checking AV table\n");
+		index = -1;
+	} else {
+		index = ip_av_get_index(cmap->av, addr);
+	}
 	fastlock_acquire(&cmap->lock);
 	if (index < 0)
 		handle = util_cmap_get_handle_peer(cmap, addr);


### PR DESCRIPTION
- prov/util,rxm: Move some connection code to util
- prov/rxm: [refactor] Move cmap alloc to conn handler file

#### prov/util, rxm: Allow connection to self
Issue:
When two endpoints inititiate connection requests to each other at the same
time we have to drop one of those connections to keep memory usage low. We
compare the remote endpoint's listening address with that of local endpoint
to decide which connection to keep. The listening address is also the one used
to do a lookup in the AV table / cmap for fetching the corresponding connection
object.

Some middleware have communication patterns where an endpoint tries to talk to
itself. This causes a collision in the AV table / cmap lookup.

Fix:
To avoid this issue use the actual source address from which the connection
was initiated to do the lookup.