### PR TITLE
common/configure: Fix an incorrect searching of libraries

### DIFF
--- a/config/fi_check_package.m4
+++ b/config/fi_check_package.m4
@@ -103,9 +103,9 @@ AC_DEFUN([_FI_CHECK_PACKAGE_LIB], [
 
            AS_IF([test "$fi_check_package_lib_happy" = "no"],
                [AS_IF([test "$fi_check_package_libdir" != ""],
-                    [$1_LDFLAGS="$$1_LDFLAGS -L$fi_check_package_libdir/lib"
-                     LDFLAGS="$LDFLAGS -L$fi_check_package_libdir/lib"
-                     AC_VERBOSE([looking for library in lib])
+                    [$1_LDFLAGS="$$1_LDFLAGS -L$fi_check_package_libdir/lib64"
+                     LDFLAGS="$LDFLAGS -L$fi_check_package_libdir/lib64"
+                     AC_VERBOSE([looking for library in lib64])
                      AC_CHECK_LIB([$2], [$3],
                                [fi_check_package_lib_happy="yes"],
                                [fi_check_package_lib_happy="no"], [$4])
@@ -117,9 +117,9 @@ AC_DEFUN([_FI_CHECK_PACKAGE_LIB], [
 
            AS_IF([test "$fi_check_package_lib_happy" = "no"],
                [AS_IF([test "$fi_check_package_libdir" != ""],
-                    [$1_LDFLAGS="$$1_LDFLAGS -L$fi_check_package_libdir/lib64"
-                     LDFLAGS="$LDFLAGS -L$fi_check_package_libdir/lib64"
-                     AC_VERBOSE([looking for library in lib64])
+                    [$1_LDFLAGS="$$1_LDFLAGS -L$fi_check_package_libdir/lib"
+                     LDFLAGS="$LDFLAGS -L$fi_check_package_libdir/lib"
+                     AC_VERBOSE([looking for library in lib])
                      AC_CHECK_LIB([$2], [$3],
                                [fi_check_package_lib_happy="yes"],
                                [fi_check_package_lib_happy="no"], [$4])

--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -186,10 +186,10 @@ AC_DEFUN([FI_CHECK_PREFIX_DIR],[
 	       ])
 
 	# Check that base/lib or base/lib64 exists
-	 AS_IF([test -d "$1/lib"],
-	       [$2_LIBDIR="$1/lib"],
-	       [AS_IF([test -d "$1/lib64"],
-		      [$2_LIBDIR="$1/lib64"],
+	 AS_IF([test -d "$1/lib64"],
+	       [$2_LIBDIR="$1/lib64"],
+	       [AS_IF([test -d "$1/lib"],
+		      [$2_LIBDIR="$1/lib"],
 		      [AC_MSG_WARN([could not find "lib" or "lib64" subdirectories in supplied "$1" directory"])
 		       AC_MSG_ERROR([Cannot continue])
 		      ])


### PR DESCRIPTION
If the specified directory to `--enable-<prov>=<dir>` contains "/lib" and /lib64" sub-directory both, it leads that configure command uses only the `<dir>/lib` directory.

The goal of the PR is fix the problem to be able perform the searching not only in  `<dir>/lib`, but in  `<dir>/lib64` simultaneously.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>