### PR TITLE
prov/gni: remove test of deprecated interfaces

### DIFF
--- a/prov/gni/test/ep.c
+++ b/prov/gni/test/ep.c
@@ -282,6 +282,11 @@ Test(endpoint, getsetopt)
 	cr_assert(!ret, "fi_close endpoint");
 }
 
+/*
+ * size left interfaces have been deprecated
+ */
+
+#if 0
 Test(endpoint, sizeleft)
 {
 	int ret;
@@ -311,6 +316,7 @@ Test(endpoint, sizeleft)
 	ret = fi_close(&ep->fid);
 	cr_assert(!ret, "fi_close endpoint");
 }
+#endif
 
 Test(endpoint, getsetopt_gni_ep)
 {


### PR DESCRIPTION
The gnu compiler kept complaining about the criterion
tests that test the various size_left interfaces.
Ifdef the offending test out.  the GNI provider
and its criterion tests now compile without warning using
gcc 7.2.0 with this commit.

upstream merge of ofi-cray/libfabric-cray#1412

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@aee58303c5284b08304e4b4d924731fac6720589)