### PR TITLE
prov/gni: selective cherrypick of 3308

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -572,7 +572,7 @@ DIRECT_FN STATIC ssize_t gnix_cq_readerr(struct fid_cq *cq,
 		 */
 		if (FI_VERSION_LT(cq_priv->domain->fabric->fab_fid.api_version,
 		    FI_VERSION(1, 5)) || buf->err_data_size == 0) {
-			err_data_cpylen = sizeof(*cq_priv->err_data);
+			err_data_cpylen = sizeof(cq_priv->err_data);
 
 			memcpy(cq_priv->err_data, gnix_cq_err->err_data,
 				err_data_cpylen);
@@ -582,7 +582,7 @@ DIRECT_FN STATIC ssize_t gnix_cq_readerr(struct fid_cq *cq,
 			if (buf->err_data == NULL)
 				return -FI_EINVAL;
 
-			err_data_cpylen = MIN(buf->err_data_size, sizeof(*cq_priv->err_data));
+			err_data_cpylen = MIN(buf->err_data_size, sizeof(cq_priv->err_data));
 			memcpy(buf->err_data, gnix_cq_err->err_data, err_data_cpylen);
 		}
 		free(gnix_cq_err->err_data);


### PR DESCRIPTION
Selective cherrypick of #3308 back to 1.5.1
i.e. a96faa606784ebd1b9e721cdabff90b22b96fe65

Do not include the testing part since it has a bunch
of changes for scalable MR that we don't want to push
back to 1.5.1 and which cause mega conflicts and compiler 
problems for the tests.

Fixes ofi-cray/libfabric-cray#1409
upstream merge of ofi-cray/libfabric-cray#1410

Signed-off-by: Howard Pritchard <howardp@lanl.gov>