### PR TITLE
prov/gni: read error corruption fix

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -584,16 +584,17 @@ DIRECT_FN STATIC ssize_t gnix_cq_readerr(struct fid_cq *cq,
 
 			err_data_cpylen = MIN(buf->err_data_size, sizeof(*cq_priv->err_data));
 			memcpy(buf->err_data, gnix_cq_err->err_data, err_data_cpylen);
+			buf->err_data_size = err_data_cpylen;
 		}
 		free(gnix_cq_err->err_data);
 		gnix_cq_err->err_data = NULL;
-		buf->err_data_size = err_data_cpylen;
 	} else {
 		if (FI_VERSION_LT(cq_priv->domain->fabric->fab_fid.api_version,
-		    FI_VERSION(1, 5)) || buf->err_data_size == 0) {
+		    FI_VERSION(1, 5))) {
 			buf->err_data = NULL;
+		} else {
+			buf->err_data_size = 0;
 		}
-		buf->err_data_size = 0;
 	}
 
 	_gnix_queue_enqueue_free(cq_priv->errors, &event->item);


### PR DESCRIPTION
This commit fixes an issue reported in ofiwg/libfabric#3227.

If a pre-1.5 error structure was passed into fi_cq_readerr,
the GNI provider would write past the end of the structure
into stack memory. This would potentially corrupt user memory
in a way that would be difficult to detect.

upstream merge of ofi-cray/libfabric-cray#1411

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit 9a82c4d6db262b90ea898f1f927e6c8f17b0b6c8)