### PR TITLE
prov/psm2: Turn on user adjustable inject size for all operations

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -97,7 +97,6 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_MAX_TRX_CTXT	(80)
 #define PSMX2_ALL_TRX_CTXT	((void *)-1)
 #define PSMX2_MAX_MSG_SIZE	((0x1ULL << 32) - 1)
-#define PSMX2_INJECT_SIZE	(64)
 #define PSMX2_MSG_ORDER		FI_ORDER_SAS
 #define PSMX2_COMP_ORDER	FI_ORDER_NONE
 
@@ -295,7 +294,7 @@ struct psmx2_am_request {
 #define PSMX2_IOV_PROTO_PACK	0
 #define PSMX2_IOV_PROTO_MULTI	1
 #define PSMX2_IOV_MAX_SEQ_NUM	0x0FFF
-#define PSMX2_IOV_BUF_SIZE	PSMX2_INJECT_SIZE
+#define PSMX2_IOV_BUF_SIZE	64
 #define PSMX2_IOV_MAX_COUNT	(PSMX2_IOV_BUF_SIZE / sizeof(uint32_t) - 3)
 
 struct psmx2_iov_info {

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -50,7 +50,7 @@ struct psmx2_env psmx2_env = {
 	.sep		= 0,
 	.max_trx_ctxt	= 1,
 	.num_devunits	= 1,
-	.inject_size	= PSMX2_INJECT_SIZE,
+	.inject_size	= 64,
 	.lock_level	= 2,
 	.lazy_conn	= 0,
 };
@@ -400,12 +400,12 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 					PSMX2_OP_FLAGS);
 				goto err_out;
 			}
-			if (hints->tx_attr->inject_size > PSMX2_INJECT_SIZE) {
+			if (hints->tx_attr->inject_size > psmx2_env.inject_size) {
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
 					"hints->tx_attr->inject_size=%ld,"
 					"supported=%ld.\n",
 					hints->tx_attr->inject_size,
-					PSMX2_INJECT_SIZE);
+					psmx2_env.inject_size);
 				goto err_out;
 			}
 		}
@@ -556,12 +556,12 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 					PSMX2_COMP_ORDER);
 				goto err_out;
 			}
-			if (hints->tx_attr->inject_size > PSMX2_INJECT_SIZE) {
+			if (hints->tx_attr->inject_size > psmx2_env.inject_size) {
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
 					"hints->tx_attr->inject_size=%ld,"
 					"supported=%d.\n",
 					hints->tx_attr->inject_size,
-					PSMX2_INJECT_SIZE);
+					psmx2_env.inject_size);
 				goto err_out;
 			}
 			if (hints->tx_attr->iov_limit > PSMX2_IOV_MAX_COUNT) {
@@ -682,7 +682,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 					? hints->tx_attr->op_flags : 0;
 	psmx2_info->tx_attr->msg_order = PSMX2_MSG_ORDER;
 	psmx2_info->tx_attr->comp_order = PSMX2_COMP_ORDER;
-	psmx2_info->tx_attr->inject_size = PSMX2_INJECT_SIZE;
+	psmx2_info->tx_attr->inject_size = psmx2_env.inject_size;
 	psmx2_info->tx_attr->size = UINT64_MAX;
 	psmx2_info->tx_attr->iov_limit = PSMX2_IOV_MAX_COUNT;
 	psmx2_info->tx_attr->rma_iov_limit = 1;

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -1047,7 +1047,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 		return -FI_ENOMEM;
 
 	if (flags & FI_INJECT) {
-		if (len > PSMX2_INJECT_SIZE) {
+		if (len > psmx2_env.inject_size) {
 			psmx2_am_request_free(ep_priv->trx_ctxt, req);
 			return -FI_EMSGSIZE;
 		}


### PR DESCRIPTION
Previously the value set via FI_PSM2_INJECT_SIZE only affected
fi_inject and fi_tinject calls. Inject size for RMA operations
was still limited to 64. As the result, fi_getinfo didn't return
the user set value for the inject size.

Now that the RMA request allocation has been decoupled from the
buffer allocation, the user set inject size can be applied to all
operations and be reported via fi_getinfo.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>