### PR TITLE
prov/gni: swat compiler warnings

### DIFF
--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -2151,7 +2151,7 @@ static inline void __atomicinject(void)
 	double min_dp;
 	static gnix_mr_cache_t *cache;
 	struct gnix_fid_ep *ep_priv;
-	int already_registered;
+	int already_registered = 0;
 
 	/* i64 */
 	*((int64_t *)source) = SOURCE_DATA;

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -1695,7 +1695,7 @@ void do_inject_write(int len)
 	struct fi_cq_tagged_entry cqe;
 	static gnix_mr_cache_t *cache;
 	struct gnix_fid_ep *ep_priv;
-	int already_registered;
+	int already_registered = 0;
 
 	init_data(source, len, 0x23);
 	init_data(target, len, 0);

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -1208,7 +1208,7 @@ void do_inject(int len)
 	uint64_t r_e[NUMEPS] = {0};
 	static gnix_mr_cache_t *cache;
 	struct gnix_fid_ep *ep_priv;
-	int already_registered;
+	int already_registered = 0;
 
 	rdm_sr_init_data(source, len, 0x23);
 	rdm_sr_init_data(target, len, 0);

--- a/prov/gni/test/smrn.c
+++ b/prov/gni/test/smrn.c
@@ -226,7 +226,7 @@ Test(smrn, threaded)
 
 	memory_regions = (void **) &addresses;
 
-	for (i = 0; i < regions; i++) {
+	for (i = 0; i < GNIX_DEFAULT_RQ_CNT; i++) {
 		thread_ids[i] = i;
 	}
 


### PR DESCRIPTION
squash some compiler warnings when building the GNI provider
unit tests.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>