### PR TITLE
common/util, prov/sockets,verbs: Extend verification of tx/rx attributes

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -677,7 +677,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 int ofi_check_cq_attr(const struct fi_provider *prov,
 		      const struct fi_cq_attr *attr);
 int ofi_check_rx_attr(const struct fi_provider *prov,
-		      const struct fi_rx_attr *prov_attr,
+		      const struct fi_info *prov_info,
 		      const struct fi_rx_attr *user_attr, uint64_t info_mode);
 int ofi_check_tx_attr(const struct fi_provider *prov,
 		      const struct fi_tx_attr *prov_attr,

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1150,7 +1150,8 @@ static int sock_ep_tx_ctx(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
 		return -FI_EINVAL;
 
 	if (attr) {
-		if (ofi_check_tx_attr(&sock_prov, &sock_ep->tx_attr, attr, 0))
+		if (ofi_check_tx_attr(&sock_prov, sock_ep->attr->info.tx_attr,
+				      attr, 0))
 			return -FI_ENODATA;
 		tx_ctx = sock_tx_ctx_alloc(attr, context, 0);
 	} else {
@@ -1193,7 +1194,7 @@ static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 		return -FI_EINVAL;
 
 	if (attr) {
-		if (ofi_check_rx_attr(&sock_prov, &sock_ep->rx_attr, attr, 0))
+		if (ofi_check_rx_attr(&sock_prov, &sock_ep->attr->info, attr, 0))
 			return -FI_ENODATA;
 		rx_ctx = sock_rx_ctx_alloc(attr, context, 0);
 	} else {

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -563,13 +563,15 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 	const struct fi_ep_attr *prov_attr = prov_info->ep_attr;
 	const struct fi_provider *prov = util_prov->prov;
 
-	if (user_attr->type && (user_attr->type != prov_attr->type)) {
+	if ((user_attr->type != FI_EP_UNSPEC) &&
+	    (user_attr->type != prov_attr->type)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported endpoint type\n");
 		FI_INFO_CHECK(prov, prov_attr, user_attr, type, FI_TYPE_EP_TYPE);
 		return -FI_ENODATA;
 	}
 
-	if (user_attr->protocol && (user_attr->protocol != prov_attr->protocol)) {
+	if ((user_attr->protocol != FI_PROTO_UNSPEC) &&
+	    (user_attr->protocol != prov_attr->protocol)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported protocol\n");
 		FI_INFO_CHECK(prov, prov_attr, user_attr, protocol, FI_TYPE_PROTOCOL);
 		return -FI_ENODATA;
@@ -621,6 +623,30 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		}
 	}
 
+	if (user_attr->max_order_raw_size > prov_attr->max_order_raw_size) {
+		FI_INFO(prov, FI_LOG_CORE,
+			"Max order RAW size exceeds supported size\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+				  max_order_raw_size);
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->max_order_war_size > prov_attr->max_order_war_size) {
+		FI_INFO(prov, FI_LOG_CORE,
+			"Max order WAR size exceeds supported size\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+				  max_order_war_size);
+		return -FI_ENODATA;
+	}
+
+	if (user_attr->max_order_waw_size > prov_attr->max_order_waw_size) {
+		FI_INFO(prov, FI_LOG_CORE,
+			"Max order WAW size exceeds supported size\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+				  max_order_waw_size);
+		return -FI_ENODATA;
+	}
+
 	if (user_attr->auth_key_size &&
 	    (user_attr->auth_key_size != prov_attr->auth_key_size)) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported authentification size.");
@@ -632,9 +658,12 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 }
 
 int ofi_check_rx_attr(const struct fi_provider *prov,
-		      const struct fi_rx_attr *prov_attr,
+		      const struct fi_info *prov_info,
 		      const struct fi_rx_attr *user_attr, uint64_t info_mode)
 {
+	const struct fi_rx_attr *prov_attr = prov_info->rx_attr;
+	int rm_enabled = (prov_info->domain_attr->resource_mgmt == FI_RM_ENABLED);
+
 	if (user_attr->caps & ~(prov_attr->caps)) {
 		FI_INFO(prov, FI_LOG_CORE, "caps not supported\n");
 		FI_INFO_CHECK(prov, prov_attr, user_attr, caps, FI_TYPE_CAPS);
@@ -686,6 +715,15 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 		FI_INFO(prov, FI_LOG_CORE, "iov_limit too large\n");
 		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, iov_limit);
 		return -FI_ENODATA;
+	}
+
+	if (!rm_enabled &&
+	    user_attr->total_buffered_recv > prov_attr->total_buffered_recv) {
+		/* Just log a notification, but ignore the value */
+		FI_INFO(prov, FI_LOG_CORE,
+			"Total buffered recv size exceeds supported size\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr,
+				  total_buffered_recv);
 	}
 
 	return 0;
@@ -876,7 +914,7 @@ int ofi_check_info(const struct util_prov *util_prov,
 	}
 
 	if (user_info->rx_attr) {
-		ret = ofi_check_rx_attr(prov, prov_info->rx_attr,
+		ret = ofi_check_rx_attr(prov, prov_info,
 					user_info->rx_attr, user_info->mode);
 		if (ret)
 			return ret;

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -60,6 +60,14 @@ struct fi_provider fi_ibv_prov = {
 	.cleanup = fi_ibv_fini
 };
 
+struct util_prov fi_ibv_util_prov = {
+	.prov = &fi_ibv_prov,
+	.info = NULL,
+	/* The support of the shared recieve contexts
+	 * is dynamically calculated */
+	.flags = 0,
+};
+
 int fi_ibv_sockaddr_len(struct sockaddr *addr)
 {
 	if (!addr)
@@ -460,6 +468,8 @@ int fi_ibv_set_rnr_timer(struct ibv_qp *qp)
 
 static void fi_ibv_fini(void)
 {
+	fi_freeinfo((void *)fi_ibv_util_prov.info);
+	fi_ibv_util_prov.info = NULL;
 }
 
 VERBS_INI
@@ -515,6 +525,9 @@ VERBS_INI
 
 	if (fi_ibv_get_param_int("min_rnr_timer", "Set min_rnr_timer QP "
 				 "attribute (0 - 31)", &verbs_min_rnr_timer))
+		return NULL;
+
+	if (fi_ibv_init_info(&fi_ibv_util_prov.info))
 		return NULL;
 
 	return &fi_ibv_prov;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -106,6 +106,7 @@
 #define VERBS_MR_IOV_LIMIT 1
 
 extern struct fi_provider fi_ibv_prov;
+extern struct util_prov fi_ibv_util_prov;
 
 extern size_t verbs_default_tx_size;
 extern size_t verbs_default_rx_size;
@@ -128,8 +129,7 @@ struct verbs_dev_info {
 
 struct fi_ibv_fabric {
 	struct util_fabric	util_fabric;
-	struct fi_info		*info;
-	struct fi_info		*all_infos;
+	const struct fi_info	*info;
 };
 
 int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
@@ -336,12 +336,12 @@ struct fi_ibv_connreq {
 int fi_ibv_sockaddr_len(struct sockaddr *addr);
 
 
-int fi_ibv_init_info(struct fi_info **all_infos);
+int fi_ibv_init_info(const struct fi_info **all_infos);
 int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, const struct fi_info *hints,
 		   struct fi_info **info);
-struct fi_info *fi_ibv_get_verbs_info(struct fi_info *ilist,
-				      const char *domain_name);
+const struct fi_info *fi_ibv_get_verbs_info(const struct fi_info *ilist,
+					    const char *domain_name);
 int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags,
 		     struct rdma_addrinfo *rai);
 int fi_ibv_get_rdma_rai(const char *node, const char *service, uint64_t flags,
@@ -359,10 +359,8 @@ extern const struct verbs_ep_domain verbs_rdm_domain;
 int fi_ibv_check_ep_attr(const struct fi_ep_attr *attr,
 			 const struct fi_info *info);
 int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
-			 const struct fi_info *hints, const struct fi_info *info);
-int fi_ibv_check_tx_attr(const struct fi_tx_attr *attr,
-			 const struct fi_info *hints, const struct fi_info *info);
-
+			 const struct fi_info *hints,
+			 const struct fi_info *info);
 
 ssize_t fi_ibv_send(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr, void *context);
 ssize_t fi_ibv_send_buf(struct fi_ibv_msg_ep *ep, struct ibv_send_wr *wr,

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -35,10 +35,10 @@
 #include <fi_util.h>
 #include "fi_verbs.h"
 
-struct fi_info *
-fi_ibv_get_verbs_info(struct fi_info *ilist, const char *domain_name)
+const struct fi_info *
+fi_ibv_get_verbs_info(const struct fi_info *ilist, const char *domain_name)
 {
-	struct fi_info *fi;
+	const struct fi_info *fi;
 
 	for (fi = ilist; fi; fi = fi->next) {
 		if (!strcmp(fi->domain_attr->name, domain_name))
@@ -83,14 +83,15 @@ fi_ibv_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 
 static struct fi_info *
 fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event,
-		struct fi_info *pep_info)
+		     struct fi_info *pep_info)
 {
-	struct fi_info *info, *fi;
+	struct fi_info *info;
+	const struct fi_info *fi;
 	struct fi_ibv_connreq *connreq;
 	const char *devname = ibv_get_device_name(event->id->verbs->device);
 
 	if (strcmp(devname, fab->info->domain_attr->name)) {
-		fi = fi_ibv_get_verbs_info(fab->all_infos, devname);
+		fi = fi_ibv_get_verbs_info(fi_ibv_util_prov.info, devname);
 		if (!fi)
 			return NULL;
 	} else {

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -148,12 +148,13 @@ struct fi_ibv_rdm_sysaddr
 int fi_ibv_check_ep_attr(const struct fi_ep_attr *attr,
 			 const struct fi_info *info)
 {
-	if ((attr->type != FI_EP_UNSPEC) &&
-	    (attr->type != info->ep_attr->type)) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Unsupported endpoint type\n");
-		return -FI_ENODATA;
-	}
+	struct fi_ep_attr user_attr = *attr;
+	struct util_prov tmp_util_prov = {
+		.prov = &fi_ibv_prov,
+		.info = NULL,
+		.flags = info->domain_attr->max_ep_srx_ctx ?
+			UTIL_RX_SHARED_CTX : 0,
+	};
 
 	switch (attr->protocol) {
 	case FI_PROTO_UNSPEC:
@@ -169,199 +170,39 @@ int fi_ibv_check_ep_attr(const struct fi_ep_attr *attr,
 		return -FI_ENODATA;
 	}
 
-	if (attr->protocol_version > 1) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Unsupported protocol version\n");
-		return -FI_ENODATA;
-	}
+	/*
+	 * verbs provider requires more complex verification of the
+	 * protocol in compare to verification that is presented in
+	 * the utility function. Change the protocol to FI_PROTO_UNSPEC
+	 * to avoid verification of protocol in the ofi_check_ep_attr
+	 */
+	user_attr.protocol = FI_PROTO_UNSPEC;
 
-	if (attr->max_msg_size > info->ep_attr->max_msg_size) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Max message size too large\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
-				  max_msg_size);
-		return -FI_ENODATA;
-	}
-
-	if (attr->max_order_raw_size > info->ep_attr->max_order_raw_size) {
-		VERBS_INFO( FI_LOG_CORE,
-			   "max_order_raw_size exceeds supported size\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
-				  max_order_raw_size);
-		return -FI_ENODATA;
-	}
-
-	if (attr->max_order_war_size) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "max_order_war_size exceeds supported size\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
-				  max_order_war_size);
-		return -FI_ENODATA;
-	}
-
-	if (attr->max_order_waw_size > info->ep_attr->max_order_waw_size) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "max_order_waw_size exceeds supported size\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
-				  max_order_waw_size);
-		return -FI_ENODATA;
-	}
-
-	if (attr->tx_ctx_cnt > info->domain_attr->max_ep_tx_ctx) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "tx_ctx_cnt exceeds supported size\n");
-		VERBS_INFO(FI_LOG_CORE, "Supported: %zd\nRequested: %zd\n",
-			   info->domain_attr->max_ep_tx_ctx, attr->tx_ctx_cnt);
-		return -FI_ENODATA;
-	}
-
-	if ((attr->rx_ctx_cnt > info->domain_attr->max_ep_rx_ctx) &&
-	    (attr->rx_ctx_cnt != FI_SHARED_CONTEXT)) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "rx_ctx_cnt exceeds supported size\n");
-		VERBS_INFO(FI_LOG_CORE, "Supported: %zd\nRequested: %zd\n",
-			   info->domain_attr->max_ep_rx_ctx, attr->rx_ctx_cnt);
-		return -FI_ENODATA;
-	}
-
-	if (attr->auth_key_size &&
-	    (attr->auth_key_size != info->ep_attr->auth_key_size)) {
-		VERBS_INFO(FI_LOG_CORE, "Unsupported authentification size.");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->ep_attr, attr,
-				  auth_key_size);
-		return -FI_ENODATA;
-	}
-
-	return 0;
+	return ofi_check_ep_attr(&tmp_util_prov,
+				 info->fabric_attr->api_version,
+				 info, &user_attr);
 }
 
 int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
-			 const struct fi_info *hints, const struct fi_info *info)
+			 const struct fi_info *hints,
+			 const struct fi_info *info)
 {
-	uint64_t compare_mode, check_mode;
-	int rm_enabled;
+	uint64_t saved_prov_mode = info->rx_attr->mode;
+	int ret;
 
-	if (attr->caps & ~(info->rx_attr->caps)) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given rx_attr->caps not supported\n");
-		return -FI_ENODATA;
-	}
-
-	compare_mode = attr->mode ? attr->mode : hints->mode;
-
-	check_mode = (hints->caps & FI_RMA) ? info->rx_attr->mode :
+	info->rx_attr->mode = (hints->caps & FI_RMA) ?
+		info->rx_attr->mode :
 		(info->rx_attr->mode & ~FI_RX_CQ_DATA);
 
-	if ((compare_mode & check_mode) != check_mode) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given rx_attr->mode not supported\n");
-		FI_INFO_MODE(&fi_ibv_prov, check_mode, compare_mode);
-		return -FI_ENODATA;
-	}
+	ret = ofi_check_rx_attr(&fi_ibv_prov, info, attr, hints->mode);
 
-	if (attr->op_flags & ~(info->rx_attr->op_flags)) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given rx_attr->op_flags not supported\n");
-		return -FI_ENODATA;
-	}
+	info->rx_attr->mode = saved_prov_mode;
 
-	if (attr->msg_order & ~(info->rx_attr->msg_order)) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given rx_attr->msg_order not supported\n");
-		return -FI_ENODATA;
-	}
-
-	if (attr->size > info->rx_attr->size) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given rx_attr->size is greater than supported\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->rx_attr, attr, size);
-		return -FI_ENODATA;
-	}
-
-	rm_enabled =(info->domain_attr &&
-		     info->domain_attr->resource_mgmt == FI_RM_ENABLED);
-
-	if (!rm_enabled &&
-	    (attr->total_buffered_recv > info->rx_attr->total_buffered_recv))
-	{
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given rx_attr->total_buffered_recv "
-			   "exceeds supported size\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->rx_attr, attr,
-				  total_buffered_recv);
-		return -FI_ENODATA;
-	}
-
-	if (attr->iov_limit > info->rx_attr->iov_limit) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given rx_attr->iov_limit greater than supported\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, info->rx_attr, attr,
-				  iov_limit);
-		return -FI_ENODATA;
-	}
-
-	return 0;
-}
-
-int fi_ibv_check_tx_attr(const struct fi_tx_attr *attr,
-			 const struct fi_info *hints, const struct fi_info *info)
-{
-	if (attr->caps & ~(info->tx_attr->caps)) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given tx_attr->caps not supported\n");
-		FI_INFO_CHECK(&fi_ibv_prov, (info->tx_attr), attr, caps, FI_TYPE_CAPS);
-		return -FI_ENODATA;
-	}
-
-	if (((attr->mode ? attr->mode : hints->mode) &
-	     info->tx_attr->mode) != info->tx_attr->mode) {
-		size_t user_mode = (attr->mode ? attr->mode : hints->mode);
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given tx_attr->mode not supported\n");
-		FI_INFO_MODE(&fi_ibv_prov, info->tx_attr->mode, user_mode);
-		return -FI_ENODATA;
-	}
-
-	if (attr->op_flags & ~(info->tx_attr->op_flags)) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given tx_attr->op_flags not supported\n");
-		return -FI_ENODATA;
-	}
-
-	if (attr->msg_order & ~(info->tx_attr->msg_order)) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given tx_attr->msg_order not supported\n");
-		return -FI_ENODATA;
-	}
-
-	if (attr->size > info->tx_attr->size) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given tx_attr->size is greater than supported\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, (info->tx_attr), attr, size);
-		return -FI_ENODATA;
-	}
-
-	if (attr->iov_limit > info->tx_attr->iov_limit) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given tx_attr->iov_limit greater than supported\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, (info->tx_attr), attr,
-				  iov_limit);
-		return -FI_ENODATA;
-	}
-
-	if (attr->rma_iov_limit > info->tx_attr->rma_iov_limit) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "Given tx_attr->rma_iov_limit greater than supported\n");
-		FI_INFO_CHECK_VAL(&fi_ibv_prov, (info->tx_attr), attr,
-				  rma_iov_limit);
-		return -FI_ENODATA;
-	}
-
-	return 0;
+	return ret;
 }
 
 static int fi_ibv_check_hints(uint32_t version, const struct fi_info *hints,
-		const struct fi_info *info)
+			      const struct fi_info *info)
 {
 	int ret;
 	uint64_t prov_mode;
@@ -388,7 +229,8 @@ static int fi_ibv_check_hints(uint32_t version, const struct fi_info *hints,
 	}
 
 	if (hints->domain_attr) {
-		ret = ofi_check_domain_attr(&fi_ibv_prov, version, info->domain_attr,
+		ret = ofi_check_domain_attr(&fi_ibv_prov, version,
+					    info->domain_attr,
 					    hints->domain_attr);
 		if (ret)
 			return ret;
@@ -407,12 +249,13 @@ static int fi_ibv_check_hints(uint32_t version, const struct fi_info *hints,
 	}
 
 	if (hints->tx_attr) {
-		ret = fi_ibv_check_tx_attr(hints->tx_attr, hints, info);
+		ret = ofi_check_tx_attr(&fi_ibv_prov, info->tx_attr,
+					hints->tx_attr, hints->mode);
 		if (ret)
 			return ret;
 	}
 
-	return 0;
+	return FI_SUCCESS;
 }
 
 int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags,
@@ -550,7 +393,8 @@ err1:
 	return ret;
 }
 
-static int fi_ibv_get_device_attrs(struct ibv_context *ctx, struct fi_info *info)
+static int fi_ibv_get_device_attrs(struct ibv_context *ctx,
+				   struct fi_info *info)
 {
 	struct ibv_device_attr device_attr;
 	struct ibv_port_attr port_attr;
@@ -558,17 +402,22 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx, struct fi_info *info
 
 	ret = ibv_query_device(ctx, &device_attr);
 	if (ret) {
-		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "ibv_query_device", errno);
+		VERBS_INFO_ERRNO(FI_LOG_FABRIC,
+				 "ibv_query_device", errno);
 		return -errno;
 	}
 
 	info->domain_attr->cq_cnt 		= device_attr.max_cq;
 	info->domain_attr->ep_cnt 		= device_attr.max_qp;
-	info->domain_attr->tx_ctx_cnt 		= MIN(info->domain_attr->tx_ctx_cnt, device_attr.max_qp);
-	info->domain_attr->rx_ctx_cnt 		= MIN(info->domain_attr->rx_ctx_cnt, device_attr.max_qp);
-	info->domain_attr->max_ep_tx_ctx 	= MIN(info->domain_attr->tx_ctx_cnt, device_attr.max_qp);
-	info->domain_attr->max_ep_rx_ctx 	= MIN(info->domain_attr->rx_ctx_cnt, device_attr.max_qp);
-	info->domain_attr->max_ep_srx_ctx	= device_attr.max_qp;
+	info->domain_attr->tx_ctx_cnt 		= MIN(info->domain_attr->tx_ctx_cnt,
+						      device_attr.max_qp);
+	info->domain_attr->rx_ctx_cnt 		= MIN(info->domain_attr->rx_ctx_cnt,
+						      device_attr.max_qp);
+	info->domain_attr->max_ep_tx_ctx 	= MIN(info->domain_attr->tx_ctx_cnt,
+						      device_attr.max_qp);
+	info->domain_attr->max_ep_rx_ctx 	= MIN(info->domain_attr->rx_ctx_cnt,
+						      device_attr.max_qp);
+	info->domain_attr->max_ep_srx_ctx	= device_attr.max_srq;
 	info->domain_attr->mr_cnt		= device_attr.max_mr;
 
 	if (info->ep_attr->type == FI_EP_RDM)
@@ -581,9 +430,11 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx, struct fi_info *info
 	info->rx_attr->size 			= device_attr.max_srq_wr ?
 						  MIN(device_attr.max_qp_wr,
 						      device_attr.max_srq_wr) :
-						      device_attr.max_qp_wr;
-	info->rx_attr->iov_limit 		= MIN(device_attr.max_sge,
-						      device_attr.max_srq_sge);
+						  device_attr.max_qp_wr;
+	info->rx_attr->iov_limit 		= device_attr.max_srq_sge ?
+						  MIN(device_attr.max_sge,
+						      device_attr.max_srq_sge) :
+						  device_attr.max_sge;
 
 	ret = fi_ibv_get_qp_cap(ctx, info);
 	if (ret)
@@ -591,7 +442,8 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx, struct fi_info *info
 
 	ret = ibv_query_port(ctx, 1, &port_attr);
 	if (ret) {
-		VERBS_INFO_ERRNO(FI_LOG_FABRIC, "ibv_query_port", errno);
+		VERBS_INFO_ERRNO(FI_LOG_FABRIC,
+				 "ibv_query_port", errno);
 		return -errno;
 	}
 
@@ -691,12 +543,13 @@ static int fi_ibv_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 	switch (ctx->device->transport_type) {
 	case IBV_TRANSPORT_IB:
 		if(ibv_query_gid(ctx, 1, 0, &gid)) {
-			VERBS_INFO_ERRNO(FI_LOG_FABRIC, "ibv_query_gid", errno);
+			VERBS_INFO_ERRNO(FI_LOG_FABRIC,
+					 "ibv_query_gid", errno);
 			ret = -errno;
 			goto err;
 		}
 
-		name_len =  strlen(VERBS_IB_PREFIX) + INET6_ADDRSTRLEN;
+		name_len = strlen(VERBS_IB_PREFIX) + INET6_ADDRSTRLEN;
 
 		if (!(fi->fabric_attr->name = calloc(1, name_len + 1))) {
 			ret = -FI_ENOMEM;
@@ -1039,7 +892,7 @@ rai_to_fi:
 	return 0;
 }
 
-int fi_ibv_init_info(struct fi_info **all_infos)
+int fi_ibv_init_info(const struct fi_info **all_infos)
 {
 	struct ibv_context **ctx_list;
 	struct fi_info *fi = NULL, *tail = NULL;
@@ -1209,22 +1062,19 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 {
 	struct rdma_cm_id *id = NULL;
 	struct rdma_addrinfo *rai;
-	struct fi_info *raw_info;
+	const struct fi_info *raw_info = fi_ibv_util_prov.info;
 	const char *dev_name = NULL;
 	int ret;
 
-	ret = fi_ibv_init_info(&raw_info);
-	if (ret)
-		goto out;
-
 	ret = fi_ibv_create_ep(node, service, flags, hints, &rai, &id);
 	if (ret)
-		goto err_info;
+		goto out;
 
 	if (id->verbs)
 		dev_name = ibv_get_device_name(id->verbs->device);
 
-	ret = fi_ibv_get_matching_info(version, dev_name, hints, info, raw_info);
+	ret = fi_ibv_get_matching_info(version, dev_name, hints,
+				       info, raw_info);
 	if (ret)
 		goto err;
 
@@ -1238,8 +1088,6 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 
 err:
 	fi_ibv_destroy_ep(rai, &id);
-err_info:
-	fi_freeinfo(raw_info);
 out:
 	if (!ret || ret == -FI_ENOMEM || ret == -FI_ENODEV)
 		return ret;

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -297,7 +297,8 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 	}
 
 	if (info->tx_attr) {
-		ret = fi_ibv_check_tx_attr(info->tx_attr, info, fi);
+		ret = ofi_check_tx_attr(&fi_ibv_prov, fi->tx_attr,
+					info->tx_attr, info->mode);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
- Extend the utility functions for the attributes to support missed parameters
- Implement support of extended functions in the sockets provider
- Changes to the verbs provider:
1. Fix an issue where the underlying HW doesn't support SRQ
2. Implement support of extended functions and remove self-implemented

The separated part from #3269

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>