### PR TITLE
prov/verbs: Serialize an access to connection hash for AV entry

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -334,6 +334,7 @@ enum fi_rdm_cm_role {
 
 struct fi_ibv_rdm_av_entry {
 	/* association of conn and EPs */
+	pthread_mutex_t			conn_lock;
 	struct fi_ibv_rdm_conn		*conn_hash;
 	struct sockaddr_in		addr;
 	struct slist_entry		removed_next;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -224,6 +224,7 @@ static int fi_ibv_domain_close(fid_t fid)
 						struct fi_ibv_rdm_av_entry,
 						removed_next);
 			fi_ibv_rdm_overall_conn_cleanup(av_entry);
+			pthread_mutex_destroy(&av_entry->conn_lock);
 			ofi_freealign(av_entry);
 		}
 		rdma_destroy_ep(domain->rdm_cm->listener);


### PR DESCRIPTION
- Serialize an access to connection hash that can be accessed from CM thread and main thread.
- Replace `free()` by `ofi_freealign()`. This is minor changes, because `ofi_freealign()` is mapped to `free()`. Just to keep code style and be compliant with another place where `ofi_frealign(av_entry)` is used instead.

Fixes #3302 

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>