### PR TITLE
prov/verbs: Fix crash when trying to use atomics for the verbs/MSG

### DIFF
--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -292,6 +292,7 @@ static struct fi_ops_domain fi_ibv_domain_ops = {
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_ibv_srq_context,
+	.query_atomic = fi_ibv_query_atomic,
 };
 
 static struct fi_ops_domain fi_ibv_rdm_domain_ops = {

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -82,7 +82,7 @@ const struct fi_domain_attr verbs_domain_attr = {
 	.rx_ctx_cnt		= 1024,
 	.max_ep_tx_ctx		= 1,
 	.max_ep_rx_ctx		= 1,
-	.mr_iov_limit		= 1,
+	.mr_iov_limit		= VERBS_MR_IOV_LIMIT,
 	/* max_err_data is size of ibv_wc::vendor_err for CQ, 0 - for EQ */
 	.max_err_data		= sizeof_field(struct ibv_wc, vendor_err),
 };


### PR DESCRIPTION
- Add the functional pointer to the .query_atomic
- Some code cleanups (renaming _ep -> ep (fi_ibv_msg_ep type)
  and ep -> ep_fid (fid_ep type))
- Use `VERBS_MR_IOV_LIMIT` instead of `1` for the `fi_info::fi_domain_attr::mr_iov_limit` attribute

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>