### PR TITLE
prov/sockets: using one lock instead of two for tx_ctx ring buffer

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -644,8 +644,7 @@ struct sock_tx_ctx {
 	size_t fclass;
 
 	struct ofi_ringbuf rb;
-	fastlock_t wlock;
-	fastlock_t rlock;
+	fastlock_t rb_lock;
 
 	uint16_t tx_id;
 	uint8_t enabled;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -596,9 +596,9 @@ static ssize_t sock_tx_size_left(struct fid_ep *ep)
 	if (!tx_ctx->enabled)
 		return -FI_EOPBADSTATE;
 
-	fastlock_acquire(&tx_ctx->wlock);
+	fastlock_acquire(&tx_ctx->rb_lock);
 	num_left = ofi_rbavail(&tx_ctx->rb)/SOCK_EP_TX_ENTRY_SZ;
-	fastlock_release(&tx_ctx->wlock);
+	fastlock_release(&tx_ctx->rb_lock);
 	return num_left;
 }
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2476,11 +2476,11 @@ int sock_pe_progress_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx)
 		}
 	}
 
-	fastlock_acquire(&tx_ctx->rlock);
+	fastlock_acquire(&tx_ctx->rb_lock);
 	if (!ofi_rbempty(&tx_ctx->rb) && !dlist_empty(&pe->free_list)) {
 		ret = sock_pe_new_tx_entry(pe, tx_ctx);
 	}
-	fastlock_release(&tx_ctx->rlock);
+	fastlock_release(&tx_ctx->rb_lock);
 	if (ret < 0)
 		goto out;
 
@@ -2804,4 +2804,3 @@ void sock_pe_finalize(struct sock_pe *pe)
 	free(pe);
 	SOCK_LOG_DBG("Progress engine finalize: OK\n");
 }
-


### PR DESCRIPTION
This fixes the issue "Data races in socket provider" #3303. 

Currently two locks are being used for writing and reading of ring buffer in tx_ctx. This change serializes read/write accesses with one lock. 

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>