### PR TITLE
prov/sockets: Fix a bug where negative value is passed to strerror

### DIFF
--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -435,7 +435,7 @@ static ssize_t sock_ep_atomic_readwrite(struct fid_ep *ep, const void *buf,
 	};
 	struct fi_rma_ioc rma_iov = {
 		.addr = addr,
-		.count = ofi_total_ioc_cnt(&msg_iov, count),
+		.count = ofi_total_ioc_cnt(&msg_iov, 1),
 		.key = key,
 	};
 	struct fi_msg_atomic msg = {
@@ -535,7 +535,7 @@ static ssize_t sock_ep_atomic_compwrite(struct fid_ep *ep, const void *buf,
 	};
 	struct fi_rma_ioc rma_iov = {
 		.addr = addr,
-		.count = ofi_total_ioc_cnt(&msg_iov, count),
+		.count = ofi_total_ioc_cnt(&msg_iov, 1),
 		.key = key,
 	};
 	struct fi_msg_atomic msg = {

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1871,7 +1871,7 @@ int sock_ep_get_conn(struct sock_ep_attr *attr, struct sock_tx_ctx *tx_ctx,
 	if (!conn) {
 		SOCK_LOG_ERROR("Undable to find connection entry. "
 			       "Error in connecting: %s\n",
-			       strerror(ret));
+			       fi_strerror(-ret));
 		return -FI_ENOENT;
 	}
 


### PR DESCRIPTION
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>