### PR TITLE
logging: use printf attribute with fi_log()

### DIFF
--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -70,7 +70,7 @@ int fi_log_enabled(const struct fi_provider *prov, enum fi_log_level level,
 		   enum fi_log_subsys subsys);
 void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 	    enum fi_log_subsys subsys, const char *func, int line,
-	    const char *fmt, ...);
+	    const char *fmt, ...) __attribute__ ((__format__ (__printf__, 6, 7)));
 
 #define FI_LOG(prov, level, subsystem, ...)				\
 	do {								\

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -78,7 +78,7 @@ static int rxd_av_set_addrlen(struct rxd_av *av, const void *addr)
 		goto close;
 	}
 
-	FI_INFO(&rxd_prov, FI_LOG_AV, "set dgram address len: %d\n", len);
+	FI_INFO(&rxd_prov, FI_LOG_AV, "set dgram address len: %zu\n", len);
 	av->dg_addrlen = len;
 close:
 	fi_close(&tmp_av->fid);

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -141,7 +141,7 @@ static int rxd_cq_write_tagged(struct rxd_cq *cq,
 		return -FI_ENOSPC;
 
 	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
-		"report completion: %p\n", cq_entry->tag);
+	       "report completion: %" PRIx64 "\n", cq_entry->tag);
 
 	comp = ofi_cirque_tail(cq->util_cq.cirq);
 	*comp = *cq_entry;
@@ -427,8 +427,8 @@ static void rxd_progress_wait_rx(struct rxd_ep *ep,
 	ctrl.conn_id = rx_entry->peer;
 
 	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
-		"rx-entry wait over [%p], credits: %d\n",
-		rx_entry->msg_id, rx_entry->credits);
+	       "rx-entry wait over [%" PRIx64 "], credits: %d\n",
+	       rx_entry->msg_id, rx_entry->credits);
 	rxd_ep_reply_ack(ep, &ctrl, ofi_ctrl_ack, rx_entry->credits,
 		       rx_entry->key, rx_entry->peer_info->conn_data,
 		       ctrl.conn_id);
@@ -512,13 +512,13 @@ struct rxd_trecv_entry *rxd_get_trecv_entry(struct rxd_ep *ep,
 				       (void *)rx_entry);
 	if (!match) {
 		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
-			"no matching trecv entry, tag: %p\n",
-			rx_entry->op_hdr.tag);
+		       "no matching trecv entry, tag: %" PRIx64 "\n",
+		       rx_entry->op_hdr.tag);
 		return NULL;
 	}
 
-	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "matched - tag: %p\n",
-		rx_entry->op_hdr.tag);
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "matched - tag: %" PRIx64 "\n",
+	       rx_entry->op_hdr.tag);
 
 	dlist_remove(match);
 	trecv_entry = container_of(match, struct rxd_trecv_entry, entry);
@@ -614,8 +614,8 @@ void rxd_ep_handle_data_msg(struct rxd_ep *ep, struct rxd_peer *peer,
 	if (rx_entry->credits == 0) {
 		rxd_set_rx_credits(ep, rx_entry);
 
-		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "replying ack [%p] - %d\n",
-			ctrl->msg_id, ctrl->seg_no);
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "replying ack [%" PRIx64 "] - %d\n",
+		       ctrl->msg_id, ctrl->seg_no);
 
 		rxd_ep_reply_ack(ep, ctrl, ofi_ctrl_ack, rx_entry->credits,
 			       rx_entry->key, peer->conn_data, ctrl->conn_id);
@@ -625,12 +625,13 @@ void rxd_ep_handle_data_msg(struct rxd_ep *ep, struct rxd_peer *peer,
 		if (rx_entry->credits == 0) {
 			dlist_init(&rx_entry->wait_entry);
 			dlist_insert_tail(&rx_entry->wait_entry, &ep->wait_rx_list);
-			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "rx-entry %p - %d enqueued\n",
+			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "rx-entry %" PRIx64 " - %d enqueued\n",
 				ctrl->msg_id, ctrl->seg_no);
 		} else {
 			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
-				"rx_entry->op_hdr.size: %d, rx_entry->done: %d\n",
-				rx_entry->op_hdr.size, rx_entry->done);
+			       "rx_entry->op_hdr.size: %" PRIu64 ", rx_entry->done: %" PRId64 "\n",
+			       rx_entry->op_hdr.size,
+			       rx_entry->done);
 		}
 		return;
 	}
@@ -663,7 +664,7 @@ void rxd_ep_handle_data_msg(struct rxd_ep *ep, struct rxd_peer *peer,
 		rxd_rx_cq->write_fn(rxd_rx_cq, &cq_entry);
 		break;
 	case ofi_op_atomic:
-		/* Handle cntr */ 
+		/* Handle cntr */
 		cntr = ep->util_ep.rem_wr_cntr;
 		/* Handle CQ comp */
 		cq_entry.flags |= FI_ATOMIC;
@@ -781,8 +782,8 @@ void rxd_ep_check_unexp_tag_list(struct rxd_ep *ep, struct rxd_trecv_entry *trec
 
 		rx_entry = container_of(match, struct rxd_rx_entry, unexp_entry);
 		rx_entry->trecv = trecv_entry;
-		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "progressing unexp tagged recv [%p]\n",
-			rx_entry->msg_id);
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "progressing unexp tagged recv [%" PRIx64 "]\n",
+		       rx_entry->msg_id);
 
 		pkt_start = (struct rxd_pkt_data_start *) rx_entry->unexp_buf->buf;
 		rxd_ep_handle_data_msg(ep, rx_entry->peer_info, rx_entry, rx_entry->trecv->iov,
@@ -812,9 +813,10 @@ static void rxd_handle_data(struct rxd_ep *ep, struct rxd_peer *peer,
 	if (ret) {
 		if (ret == -FI_EALREADY) {
 			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "duplicate pkt: %d "
-				"expected:%d, rx-key:%d, ctrl_msg_id: %p\n",
-				ctrl->seg_no, rx_entry->exp_seg_no, ctrl->rx_key,
-				ctrl->msg_id);
+			       "expected:%d, rx-key:%" PRId64 ", ctrl_msg_id: %" PRIx64 "\n",
+			       ctrl->seg_no, rx_entry->exp_seg_no,
+			       ctrl->rx_key,
+			       ctrl->msg_id);
 
 			credits = ((rx_entry->msg_id == ctrl->msg_id) &&
 				  (rx_entry->last_win_seg == ctrl->seg_no)) ?
@@ -825,9 +827,10 @@ static void rxd_handle_data(struct rxd_ep *ep, struct rxd_peer *peer,
 			goto repost;
 		} else {
 			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "invalid pkt: segno: %d "
-			       "expected:%d, rx-key:%d, ctrl_msg_id: %ld, "
-			       "rx_entry_msg_id: %ld\n",
-			       ctrl->seg_no, rx_entry->exp_seg_no, ctrl->rx_key,
+			       "expected:%d, rx-key:%" PRId64 ", ctrl_msg_id: %ld, "
+			       "rx_entry_msg_id: %" PRIx64 "\n",
+			       ctrl->seg_no, rx_entry->exp_seg_no,
+			       ctrl->rx_key,
 			       ctrl->msg_id, rx_entry->msg_id);
 			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "invalid pkt: "
 			       "credits: %d, last win: %d\n",
@@ -1045,7 +1048,7 @@ static void rxd_handle_start_data(struct rxd_ep *ep, struct rxd_peer *peer,
 	rx_entry->credits = 1;
 	rx_entry->last_win_seg = 1;
 
-	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Assign rx_entry :%d for  %p\n",
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Assign rx_entry :%" PRId64 " for %" PRIx64 "\n",
 	       rx_entry->key, rx_entry->msg_id);
 
 	ep->credits--;
@@ -1056,8 +1059,8 @@ static void rxd_handle_start_data(struct rxd_ep *ep, struct rxd_peer *peer,
 		peer->exp_msg_id++;
 
 		/* reply ack, with no window = 0 */
-		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Sending wait-ACK [%p] - %d\n",
-			ctrl->msg_id, ctrl->seg_no);
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Sending wait-ACK [%" PRIx64 "] - %d\n",
+		       ctrl->msg_id, ctrl->seg_no);
 		goto out;
 	} else {
 		peer->exp_msg_id++;
@@ -1112,7 +1115,7 @@ void rxd_handle_recv_comp(struct rxd_ep *ep, struct fi_cq_msg_entry *comp)
 	default:
 		rxd_ep_repost_buff(rx_buf);
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
-			"invalid ctrl type \n", ctrl->type);
+			"invalid ctrl type %u\n", ctrl->type);
 	}
 
 	rxd_check_waiting_rx(ep);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -229,8 +229,8 @@ static void *rxm_conn_event_handler(void *arg)
 			FI_DBG(&rxm_prov, FI_LOG_FABRIC, "Got new connection\n");
 			if (rd != len) {
 				FI_WARN(&rxm_prov, FI_LOG_FABRIC,
-					"Received size (%d) not matching "
-					"expected (%d)\n", rd, len);
+					"Received size (%zd) not matching "
+					"expected (%zu)\n", rd, len);
 				goto exit;
 			}
 			cm_data = (void *)entry->data;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -623,7 +623,7 @@ void rxm_ep_msg_mr_closev(struct fid_mr **mr, size_t count)
 			ret = fi_close(&mr[i]->fid);
 			if (ret)
 				FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-					"Unable to close msg mr: %d\n", i);
+					"Unable to close msg mr: %zu\n", i);
 		}
 	}
 }
@@ -724,9 +724,8 @@ rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	if (pkt->hdr.size > rxm_ep->rxm_info->tx_attr->inject_size) {
 		if (flags & FI_INJECT) {
 			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-					"inject size supported: %d, msg size: %d\n",
-					rxm_tx_attr.inject_size,
-					pkt->hdr.size);
+				"inject size supported: %zu, msg size: %" PRIu64 "\n",
+				rxm_tx_attr.inject_size, pkt->hdr.size);
 			ret = -FI_EMSGSIZE;
 			goto done;
 		}
@@ -779,9 +778,9 @@ rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 			goto done;
 		} else {
 			progress = 1;
-			FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "passed data (size = %d) is too "
-				"big for MSG provider (max inject size = %d) \n",
-				(int)pkt_size, rxm_ep->msg_info->tx_attr->inject_size);
+			FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "passed data (size = %zu) is too "
+			       "big for MSG provider (max inject size = %" PRIu64 ") \n",
+			       pkt_size, rxm_ep->msg_info->tx_attr->inject_size);
 		}
 	}
 

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -418,8 +418,8 @@ static int usdf_pep_reject(struct fid_pep *fpep, fid_t handle, const void *param
 
 	if (paramlen > USDF_MAX_CONN_DATA) {
 		USDF_WARN_SYS(EP_CTRL,
-				"reject payload size %zu exceeds max %zu\n",
-				paramlen, USDF_MAX_CONN_DATA);
+			      "reject payload size %zu exceeds max %u\n",
+			      paramlen, USDF_MAX_CONN_DATA);
 		return -FI_EINVAL;
 	}
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -483,7 +483,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 		av->hash.slots = av->count;
 		av->hash.total_count = av->count + util_attr->overhead;
 		FI_INFO(av->prov, FI_LOG_AV,
-		       "FI_SOURCE requested, hash size %zu\n", av->hash.total_count);
+		       "FI_SOURCE requested, hash size %u\n", av->hash.total_count);
 	}
 
 	av->data = malloc((av->count * util_attr->addrlen) +
@@ -695,7 +695,7 @@ static int ip_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 
 	addrlen = ((struct sockaddr *) addr)->sa_family == AF_INET ?
 		  sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6);
-	FI_DBG(av->prov, FI_LOG_AV, "inserting %d addresses\n", count);
+	FI_DBG(av->prov, FI_LOG_AV, "inserting %zu addresses\n", count);
 	for (i = 0; i < count; i++) {
 		ret = ip_av_insert_addr(av, (const char *) addr + i * addrlen,
 					fi_addr ? &fi_addr[i] : NULL, context);

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -94,7 +94,7 @@ fi_ibv_rdm_start_overall_disconnection(struct fi_ibv_rdm_av_entry *av_entry)
 		ret = fi_ibv_rdm_start_disconnection(conn);
 		if (ret) {
 			VERBS_INFO(FI_LOG_AV, "Disconnection failed "
-				   "(%d) for %p\n", ret, conn);
+				   "(%zd) for %p\n", ret, conn);
 			err = ret;
 		}
 		/*
@@ -197,7 +197,7 @@ static int fi_ibv_rdm_av_insert(struct fid_av *av_fid, const void *addr,
 				fi_addr[i] = FI_ADDR_NOTAVAIL;
 
 			VERBS_INFO(FI_LOG_AV,
-				   "fi_av_insert: bad addr #%i\n", i);
+				   "fi_av_insert: bad addr #%zu\n", i);
 
 			if (av->flags & FI_EVENT) {
 				/* due to limited functionality of

--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -60,7 +60,7 @@ static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
 	     cq_entry = (ret < count) ? fi_ibv_rdm_take_first_from_cq(_cq) : NULL)
 	{
 		VERBS_DBG(FI_LOG_CQ,
-			  "\t\t-> found in ready: %p op_ctx %p, len %lu, tag 0x%llx\n",
+			  "\t\t-> found in ready: %p op_ctx %p, len %lu, tag 0x%" PRIx64 "\n",
 			  cq_entry, cq_entry->context, cq_entry->len,
 			  cq_entry->minfo.tag);
 

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -226,7 +226,7 @@ static ssize_t fi_ibv_rdm_cancel(fid_t fid, void *ctx)
 	struct fi_ibv_rdm_request *request = context->internal[0];
 
 	VERBS_DBG(FI_LOG_EP_DATA,
-		  "ep_cancel, match %p, tag 0x%llx, len %d, ctx %p\n",
+		  "ep_cancel, match %p, tag 0x%" PRIx64 ", len %" PRIu64 ", ctx %p\n",
 		  request, request->minfo.tag, request->len, request->context);
 
 	struct dlist_entry *found =
@@ -565,7 +565,7 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 		goto err2;
 	}
 
-	VERBS_INFO(FI_LOG_EP_CTRL, "inject_size: %d\n",
+	VERBS_INFO(FI_LOG_EP_CTRL, "inject_size: %zu\n",
 		   info->tx_attr->inject_size);
 
 	_ep->rndv_threshold = info->tx_attr->inject_size;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -434,11 +434,11 @@ fi_ibv_rdm_push_buff_pointer(char *area_start, size_t area_size,
 	char *buff = (char*)(*rdm_buff);
 	char *buff_tmp = buff + offset;
 
-	VERBS_DBG(FI_LOG_EP_DATA, "old_pointer: %p\n", *buff);
+	VERBS_DBG(FI_LOG_EP_DATA, "old_pointer: %p\n", buff);
 
 	buff = buff_tmp < (area_start + area_size) ? buff_tmp : area_start;
 	
-	VERBS_DBG(FI_LOG_EP_DATA, "new_pointer: %p\n", *buff);
+	VERBS_DBG(FI_LOG_EP_DATA, "new_pointer: %p\n", buff);
 
 	*rdm_buff = (struct fi_ibv_rdm_buf *)buff;
 }

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -534,7 +534,7 @@ fi_ibv_rdm_process_connect_request(struct rdma_cm_event *event,
 		ret = fi_ibv_rdm_pack_cm_params(&cm_params, conn, ep);
 		if (ret) {
 			VERBS_INFO(FI_LOG_AV, "Packing of CM parameters fails, "
-				   "ret = %d\n", ret);
+				   "ret = %zd\n", ret);
 			goto err;
 		}
 
@@ -565,7 +565,7 @@ fi_ibv_rdm_process_route_resolved(struct rdma_cm_event *event,
 	ret = fi_ibv_rdm_pack_cm_params(&cm_params, conn, ep);
 	if (ret) {
 		VERBS_INFO(FI_LOG_AV, "Packing of CM parameters fails, "
-			   "ret = %d \n", ret);
+			   "ret = %zd\n", ret);
 		return ret;
 	}
 
@@ -628,7 +628,7 @@ ssize_t fi_ibv_rdm_overall_conn_cleanup(struct fi_ibv_rdm_av_entry *av_entry)
 	HASH_ITER(hh, av_entry->conn_hash, conn, tmp) {
 		ret = fi_ibv_rdm_conn_cleanup(conn);
 		if (ret) {
-			VERBS_INFO(FI_LOG_AV, "Conn cleanup failed (%d) "
+			VERBS_INFO(FI_LOG_AV, "Conn cleanup failed (%zd) "
 				   "for av_entry = %p", ret, av_entry);
 			err = ret;
 		}
@@ -643,7 +643,7 @@ ssize_t fi_ibv_rdm_conn_cleanup(struct fi_ibv_rdm_conn *conn)
 	ssize_t ret = FI_SUCCESS;
 	ssize_t err = FI_SUCCESS;
 
-	VERBS_DBG(FI_LOG_AV, "conn %p, exp = %lld unexp = %lld\n", conn,
+	VERBS_DBG(FI_LOG_AV, "conn %p, exp = %zu unexp = %zu\n", conn,
 		     conn->exp_counter, conn->unexp_counter);
 
 	errno = 0;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -81,9 +81,9 @@ static ssize_t fi_ibv_rdm_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 				  &recv_data);
 
 	VERBS_DBG(FI_LOG_EP_DATA,
-		"conn %p, len %llu, rbuf %p, fi_ctx %p, posted_recv %d\n",
-		conn, recv_data.data_len, recv_data.dest_addr,
-		msg->context, ep_rdm->posted_recvs);
+		  "conn %p, len %zu, rbuf %p, fi_ctx %p, posted_recv %d\n",
+		  conn, recv_data.data_len, recv_data.dest_addr,
+		  msg->context, ep_rdm->posted_recvs);
 
 	if (!ret && !request->state.err) {
 		ret = rdm_trecv_second_event(request, ep_rdm);
@@ -263,8 +263,8 @@ static ssize_t fi_ibv_rdm_inject(struct fid_ep *ep_fid, const void *buf,
 				return -errno;
 			} else {
 				VERBS_DBG(FI_LOG_EP_DATA,
-					"posted %d bytes, conn %p, len %d\n",
-					sge.length, conn, len);
+					  "posted %d bytes, conn %p, len %zu\n",
+					  sge.length, conn, len);
 				return FI_SUCCESS;
 			}
 		}

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -92,7 +92,7 @@ static int fi_ibv_rdm_tagged_getname(fid_t fid, void *addr, size_t * addrlen)
 	if (fid->fclass == FI_CLASS_EP) {
  		ep = container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
 	} else {
-		VERBS_INFO(FI_LOG_EP_CTRL, "Invalid fid class: %d\n",
+		VERBS_INFO(FI_LOG_EP_CTRL, "Invalid fid class: %zd\n",
 			  fid->fclass);
 		return -FI_EINVAL;
 	}
@@ -170,9 +170,10 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 					  &recv_data);
 
 		VERBS_DBG(FI_LOG_EP_DATA,
-			"fi_recvfrom: conn %p, tag 0x%llx, len %llu, rbuf %p, fi_ctx %p, posted_recv %d\n",
-			conn, msg->tag, recv_data.data_len, recv_data.dest_addr,
-			msg->context, ep_rdm->posted_recvs);
+			  "fi_recvfrom: conn %p, tag 0x%" PRIx64 ", len %zu, rbuf %p, fi_ctx %p, posted_recv %d\n",
+			  conn, msg->tag, recv_data.data_len,
+			  recv_data.dest_addr, msg->context,
+			  ep_rdm->posted_recvs);
 
 		if (!ret && !request->state.err) {
 			ret = rdm_trecv_second_event(request, ep_rdm);
@@ -271,8 +272,8 @@ fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len,
 				return -errno;
 			} else {
 				VERBS_DBG(FI_LOG_EP_DATA,
-					"posted %d bytes, conn %p, len %d, tag 0x%llx\n",
-					sge.length, conn, len, tag);
+					  "posted %d bytes, conn %p, len %zu, tag 0x%" PRIx64 "\n",
+					  sge.length, conn, len, tag);
 				return FI_SUCCESS;
 			}
 		}
@@ -529,7 +530,7 @@ void check_and_repost_receives(struct fi_ibv_rdm_ep *ep,
 		int to_post = ep->rq_wr_depth - conn->recv_preposted;
 		ssize_t res = fi_ibv_rdm_repost_receives(conn, ep, to_post);
 		if (res < 0) {
-			VERBS_INFO(FI_LOG_EP_DATA, "repost recv failed %d\n", res);
+			VERBS_INFO(FI_LOG_EP_DATA, "repost recv failed %zd\n", res);
 			/* TODO: err code propagation */
 			abort();
 		}

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -63,7 +63,7 @@ static int fi_ibv_msg_ep_setname(fid_t ep_fid, void *addr, size_t addrlen)
 	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
 
 	if (addrlen != ep->info->src_addrlen) {
-		VERBS_INFO(FI_LOG_EP_CTRL,"addrlen expected: %d, got: %d.\n",
+		VERBS_INFO(FI_LOG_EP_CTRL,"addrlen expected: %zu, got: %zu.\n",
 			   ep->info->src_addrlen, addrlen);
 		return -FI_EINVAL;
 	}
@@ -238,7 +238,7 @@ static int fi_ibv_pep_setname(fid_t pep_fid, void *addr, size_t addrlen)
 	pep = container_of(pep_fid, struct fi_ibv_pep, pep_fid);
 
 	if (pep->src_addrlen && (addrlen != pep->src_addrlen)) {
-		VERBS_INFO(FI_LOG_FABRIC, "addrlen expected: %d, got: %d.\n",
+		VERBS_INFO(FI_LOG_FABRIC, "addrlen expected: %zu, got: %zu.\n",
 			   pep->src_addrlen, addrlen);
 		return -FI_EINVAL;
 	}

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -532,7 +532,7 @@ static int fi_ibv_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 			} else {
 				VERBS_INFO(FI_LOG_CORE,
 					   "rdm_buffer_size too small, "
-					   "should be greater then %d\n",
+					   "should be greater than %zu\n",
 					   sizeof (struct fi_ibv_rdm_rndv_header));
 				ret = -FI_EINVAL;
 				goto err;


### PR DESCRIPTION
The printf attribute checks that the format parameters correspond with
the given arguments.

Correct all the call sites that gcc warns about, by:
  - fixing the format,
  - casting the variable,
  - adding missing format,
  - or a combination of the above.

In addition indentation of affected lines have been corrected as well
to match the Linux coding style.

Signed-off-by: Frank Zago <fzago@cray.com>