### PR TITLE
common/windows: Add the missed including of the errno.h file

### DIFF
--- a/include/windows/pthread.h
+++ b/include/windows/pthread.h
@@ -35,6 +35,7 @@
 #include <WinSock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
The windows `pthread` wrappers doesn't include `errno.h` it produces the build errors on the some old version of the Intel Compiler.
Add the missed `#include <errno.h>` to be compliant with all version of the Intel Compiler.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>