### PR TITLE
prov/verbs: Add NULL check for hints

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1086,7 +1086,7 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 
 	ofi_alter_info(*info, hints, version);
 
-	if (!(hints->mode & FI_RX_CQ_DATA)) {
+	if (!hints || !(hints->mode & FI_RX_CQ_DATA)) {
 		for (cur = *info; cur; cur = cur->next)
 			cur->domain_attr->cq_data_size = 0;
 	}


### PR DESCRIPTION
Missed this piece of code in the previous PR.