### PR TITLE
prov/psm,psm2: Fix a race condition in completion queue

### DIFF
--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -47,10 +47,11 @@ static struct psmx_cq_event *psmx_cq_dequeue_event(struct psmx_fid_cq *cq)
 {
 	struct slist_entry *entry;
 
-	if (slist_empty(&cq->event_queue))
-		return NULL;
-
 	fastlock_acquire(&cq->lock);
+	if (slist_empty(&cq->event_queue)) {
+		fastlock_release(&cq->lock);
+		return NULL;
+	}
 	entry = slist_remove_head(&cq->event_queue);
 	cq->event_count--;
 	fastlock_release(&cq->lock);

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -48,10 +48,11 @@ static struct psmx2_cq_event *psmx2_cq_dequeue_event(struct psmx2_fid_cq *cq)
 {
 	struct slist_entry *entry;
 
-	if (slist_empty(&cq->event_queue))
-		return NULL;
-
 	psmx2_lock(&cq->lock, 2);
+	if (slist_empty(&cq->event_queue)) {
+		psmx2_unlock(&cq->lock, 2);
+		return NULL;
+	}
 	entry = slist_remove_head(&cq->event_queue);
 	cq->event_count--;
 	psmx2_unlock(&cq->lock, 2);


### PR DESCRIPTION
The emptiness checking and dequeue operation were incorrectly separated
by the lock. As the result in multithreaded runs NULL could be returned
from the dequeue operation, leading to an invalid non-NULL pointer after
adjustment with the container_of() macro.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>