### PR TITLE
prov/verbs: Match interface name only if corresponding env variable is defined

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -52,7 +52,7 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.fork_unsafe		= 0,
 	.use_odp		= 1,
 	.cqread_bunch_size	= 8,
-	.iface			= "ib",
+	.iface			= NULL,
 
 	.rdm			= {
 		.buffer_num		= FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM,

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -758,27 +758,31 @@ static int fi_ibv_getifaddrs(struct dlist_entry *verbs_devs)
 	}
 
 	/* select best iface name based on user's input */
-	iface_len = strlen(iface);
-	if (iface_len > IFNAMSIZ) {
-		VERBS_INFO(FI_LOG_EP_CTRL,
-			   "Too long iface name: %s, max: %d\n",
-			   iface, IFNAMSIZ);
-	
+	if (iface) {
+		iface_len = strlen(iface);
+		if (iface_len > IFNAMSIZ) {
+			VERBS_INFO(FI_LOG_EP_CTRL,
+				   "Too long iface name: %s, max: %d\n",
+				   iface, IFNAMSIZ);
+
+		}
+		for (ifa = ifaddr; ifa && !exact_match; ifa = ifa->ifa_next)
+			exact_match = !strcmp(ifa->ifa_name, iface);
 	}
-	for (ifa = ifaddr; ifa && !exact_match; ifa = ifa->ifa_next)
-		exact_match = !strcmp(ifa->ifa_name, iface);
 
 	for (ifa = ifaddr; ifa; ifa = ifa->ifa_next) {
 		if (!ifa->ifa_addr || !(ifa->ifa_flags & IFF_UP) ||
 				!strcmp(ifa->ifa_name, "lo"))
 			continue;
 
-		if(exact_match) {
-			if (strcmp(ifa->ifa_name, iface))
-				continue;
-		} else {
-			if (strncmp(ifa->ifa_name, iface, iface_len))
-				continue;
+		if (iface) {
+			if (exact_match) {
+				if (strcmp(ifa->ifa_name, iface))
+					continue;
+			} else {
+				if (strncmp(ifa->ifa_name, iface, iface_len))
+					continue;
+			}
 		}
 
 		switch (ifa->ifa_addr->sa_family) {


### PR DESCRIPTION
Without this fix verbs provider would return -FI_ENODATA on systems where the
IPoIB interface name has been changed from the default "ib0".