### PR TITLE
prov/psm2: Fix long RMA protocol tag collisions

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -124,6 +124,12 @@ extern struct fi_provider psmx2_prov;
 
 #define PSMX2_GET_TAG64(tag96)		(tag96.tag0 | ((uint64_t)tag96.tag1<<32))
 
+/* When using the long RMA protocol, set a bit in the unused SEQ bits to
+ * indicate whether or not the operation is a read or a write. This prevents tag
+ * collisions. */
+#define PSMX2_TAG32_LONG_WRITE(tag32) PSMX2_TAG32_SET_SEQ(tag32, 0x1)
+#define PSMX2_TAG32_LONG_READ(tag32)  PSMX2_TAG32_SET_SEQ(tag32, 0x2)
+
 /*
  * Canonical virtual address on X86_64 only uses 48 bits and the higher 16 bits
  * are sign extensions. We can put some extra information into the 16 bits.

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -560,6 +560,7 @@ int psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 
 	if ((req->op & PSMX2_AM_OP_MASK) == PSMX2_AM_REQ_WRITE_LONG) {
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, req->write.peer_vl, req->write.vl);
+		PSMX2_TAG32_LONG_WRITE(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req->write.context, tag32);
 		PSMX2_SET_TAG(psm2_tagsel, -1ULL, -1);
 		err = psm2_mq_irecv2(trx_ctxt->psm2_mq,
@@ -569,6 +570,7 @@ int psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 				     (void *)&req->fi_context, &psm2_req);
 	} else {
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, req->read.vl, req->read.peer_vl);
+		PSMX2_TAG32_LONG_READ(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req->read.context, tag32);
 		err = psm2_mq_isend2(trx_ctxt->psm2_mq,
 				     (psm2_epaddr_t)req->read.peer_addr,
@@ -686,6 +688,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 
 	if (psmx2_env.tagged_rma && len > chunk_size) {
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, vlane, ep_priv->vlane);
+		PSMX2_TAG32_LONG_READ(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 		PSMX2_SET_TAG(psm2_tagsel, -1ULL, -1);
 		psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
@@ -884,6 +887,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	/* Use the long protocol for the last segment */
 	if (long_len) {
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, vlane, ep_priv->vlane);
+		PSMX2_TAG32_LONG_READ(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 		PSMX2_SET_TAG(psm2_tagsel, -1ULL, -1);
 		psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
@@ -1087,6 +1091,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 
 	if (psmx2_env.tagged_rma && len > chunk_size) {
 		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, ep_priv->vlane, vlane);
+		PSMX2_TAG32_LONG_WRITE(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 		PSMX2_AM_SET_OP(args[0].u32w0, PSMX2_AM_REQ_WRITE_LONG);
 		args[0].u32w1 = len;
@@ -1329,6 +1334,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 		if (psmx2_env.tagged_rma && iov[i].iov_len > chunk_size &&
 		    len_sent + iov[i].iov_len == total_len) {
 			tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, ep_priv->vlane, vlane);
+			PSMX2_TAG32_LONG_WRITE(tag32);
 			PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 			PSMX2_AM_SET_OP(args[0].u32w0, PSMX2_AM_REQ_WRITE_LONG);
 			args[0].u32w1 = iov[i].iov_len;


### PR DESCRIPTION
The long RMA protocol uses psm2_mq_i{send,recv}2 to transfer the
payload and uses an active message to tell the destination node to either
post or send a buffer of a certain size. The protocol is currently using the
address of the active message request structure as a unique identifier in
the MQ operation tag. However there is no guarantee that this address will
be unique across nodes, which can lead to tag collisions which may cause the
RMA operation to fail with -FI_ETRUNC.

Take for example two nodes A and B.
-Node A calls fi_write() with B as the destination with a 512 MB payload
--Node A allocates an AM structure with address 0xDEADBEEF
--Node A calls psm2_mq_isend2 with a 512MB buffer with 0xDEADBEEF packed in the tag
--Node A sends the AM to B telling it to post a 512 MB buffer
-Node B simulateously calls fi_read() with A as the destination with a 128 MB payload
--Node B allocates an AM structure with address 0xDEADBEEF (by coincidence)
--Node A calls psm2_mq_irecv2 with a 128 MB buffer with 0xDEADBEEF packed in the tag
--Node B then receives the AM from node A with the instructions to post the
  512 MB buffer.

In the above example, a truncation error will be returned for the fi_write()
call since the buffer posted by node B's fi_read() call will have a matching
tag but is too small to fit the data.

This commit fixes this by setting a bit in the tag to indicate whether or
not the originating operation is a read or a write, which will make the tags
unique in an interleaved fi_write/fi_read situation as described above.

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>