### PR TITLE
prov/verbs: Check support of the Shared RX only for the MSG EP types

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -165,8 +165,9 @@ int fi_ibv_check_ep_attr(const struct fi_ep_attr *attr,
 	struct util_prov tmp_util_prov = {
 		.prov = &fi_ibv_prov,
 		.info = NULL,
-		.flags = info->domain_attr->max_ep_srx_ctx ?
-			UTIL_RX_SHARED_CTX : 0,
+		.flags = (info->domain_attr->max_ep_srx_ctx &&
+			  info->ep_attr->type == FI_EP_MSG) ?
+			 UTIL_RX_SHARED_CTX : 0,
 	};
 
 	switch (attr->protocol) {


### PR DESCRIPTION
Currently Shared RX feature is supported only by verbs/MSG. During checking a provided hints, the provider should expose support of the Shared RX only for the verbs/MSG instead of for all the EP types.
Add an additional check for the `info->ep_attr->type` for the checking possibility of Shared RX usage. 

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>