### PR TITLE
prov/util: Use a default av hash overhead if the caller doesn't specify it

### DIFF
--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -481,7 +481,10 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 
 	if (util_attr->flags & FI_SOURCE) {
 		av->hash.slots = av->count;
-		av->hash.total_count = av->count + util_attr->overhead;
+		if (util_attr->overhead)
+			av->hash.total_count = av->count + util_attr->overhead;
+		else
+			av->hash.total_count = av->count * 2;
 		FI_INFO(av->prov, FI_LOG_AV,
 		       "FI_SOURCE requested, hash size %u\n", av->hash.total_count);
 	}


### PR DESCRIPTION
This should fix #3381 

@shefty the AV size allocated is same as whatever the user requests (if it's non-zero). Should we allocate extra space to provide some buffer?