### PR TITLE
util: subset attr checking on creation of context

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -682,6 +682,8 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 int ofi_check_tx_attr(const struct fi_provider *prov,
 		      const struct fi_tx_attr *prov_attr,
 		      const struct fi_tx_attr *user_attr, uint64_t info_mode);
+int ofi_check_attr_subset(const struct fi_provider *prov,
+			uint64_t base_caps, uint64_t requested_caps);
 int ofi_prov_check_info(const struct util_prov *util_prov,
 			uint32_t api_version,
 			const struct fi_info *user_info);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1151,7 +1151,9 @@ static int sock_ep_tx_ctx(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
 
 	if (attr) {
 		if (ofi_check_tx_attr(&sock_prov, sock_ep->attr->info.tx_attr,
-				      attr, 0))
+				      attr, 0) ||
+			ofi_check_attr_subset(&sock_prov,
+				sock_ep->attr->info.tx_attr->caps, attr->caps))
 			return -FI_ENODATA;
 		tx_ctx = sock_tx_ctx_alloc(attr, context, 0);
 	} else {
@@ -1194,7 +1196,9 @@ static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 		return -FI_EINVAL;
 
 	if (attr) {
-		if (ofi_check_rx_attr(&sock_prov, &sock_ep->attr->info, attr, 0))
+		if (ofi_check_rx_attr(&sock_prov, &sock_ep->attr->info, attr, 0) ||
+			ofi_check_attr_subset(&sock_prov, sock_ep->attr->info.rx_attr->caps,
+				attr->caps))
 			return -FI_ENODATA;
 		rx_ctx = sock_rx_ctx_alloc(attr, context, 0);
 	} else {


### PR DESCRIPTION
Contexts that are created on a scalable endpoint can only
specify a subset of capabilities as supported by the base
endpoint.

The current sockets provider was merely checking if the
context created was supported by the provider, and not if
it was supported by the base endpoint.

The ofi utility code now expands the appropriate capabilities
and checks against the requested caps.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>