### PR TITLE
prov/verbs: Modifies a sequence of the MSG endpoint destroying

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1339,9 +1339,6 @@ static int fi_ibv_handle_sock_addr(const char *node, const char *service,
 	}
 
 	ret = fi_ibv_fill_addr(rai, info, id);
-	if (ret)
-		fi_freeinfo(*info);
-
 fn:
 	fi_ibv_destroy_ep(rai, &id);
 	return ret;

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -105,9 +105,6 @@ err:
 
 static void fi_ibv_free_msg_ep(struct fi_ibv_msg_ep *ep)
 {
-	if (ep->id)
-		rdma_destroy_ep(ep->id);
-
 	fi_freeinfo(ep->info);
 	free(ep);
 }
@@ -117,6 +114,8 @@ static int fi_ibv_msg_ep_close(fid_t fid)
 	struct fi_ibv_msg_ep *ep;
 
 	ep = container_of(fid, struct fi_ibv_msg_ep, ep_fid.fid);
+	rdma_destroy_ep(ep->id);
+
 	fi_ibv_cleanup_cq(ep);
 
 	VERBS_INFO(FI_LOG_DOMAIN, "EP %p was closed \n", ep);
@@ -375,6 +374,8 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 
 	return 0;
 err:
+	if (ep->id)
+		rdma_destroy_ep(ep->id);
 	fi_ibv_free_msg_ep(ep);
 	return ret;
 }

--- a/prov/verbs/src/verbs_srq.c
+++ b/prov/verbs/src/verbs_srq.c
@@ -195,6 +195,10 @@ int fi_ibv_srq_close(fid_t fid)
 	int ret;
 
 	srq_ep = container_of(fid, struct fi_ibv_srq_ep, ep_fid.fid);
+	ret = ibv_destroy_srq(srq_ep->srq);
+	if (ret)
+		VERBS_WARN(FI_LOG_EP_CTRL,
+			   "Cannot destroy SRQ rc=%d\n", ret);
 
 	/* All WCs from Receive CQ belongs to SRQ, no need to check EP. */
 	/* Assumes that all EP that associated with the SRQ have
@@ -204,11 +208,6 @@ int fi_ibv_srq_close(fid_t fid)
 	 * have `IBV_RECV_WR` type only */
 	fi_ibv_empty_wre_list(srq_ep->wre_pool, &srq_ep->wre_list, IBV_RECV_WR);
 	util_buf_pool_destroy(srq_ep->wre_pool);
-
-	ret = ibv_destroy_srq(srq_ep->srq);
-	if (ret)
-		VERBS_WARN(FI_LOG_EP_CTRL,
-			   "Cannot destroy SRQ rc=%d\n", ret);
 
 	free(srq_ep);
 


### PR DESCRIPTION
The sequence of the MSG endpoint destroying is incorrect and performed as follows:
1. tries to retrieve all WCs form the CQ
2. releases all WRE entries
3. destroys the WRE pool
4. destroys RDMA id
5. frees an associated fi_info and instance of the EP

When the WRE pool is freed, we should not refer to it. But when process polls CQ, there is possibility that we will refer to already destroyed WRE pool and the appropriate WRE entries that was released.

The fix that is proposed in this patch - re-order the sequence as follows:
1. tries to retrieve all WCs form the CQ
2. **_destroys RDMA id_**
3. releases all WRE entries
4. destroys the WRE pool
5. frees an associated fi_info and instance of the EP

Fixes #3389 

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>