### PR TITLE
prov/psm2: Fix format mismatch warnings

### DIFF
--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -290,8 +290,8 @@ int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 		if (psmx2_am_global.cnt >= PSMX2_AM_MAX_TRX_CTXT) {
 			psmx2_unlock(&psmx2_am_global.lock, 1);
 			FI_WARN(&psmx2_prov, FI_LOG_CORE,
-				"number of PSM2 endpoints exceed limit %d.\n"
-				"at indecies %d, %d\n", PSMX2_AM_MAX_TRX_CTXT);
+				"number of PSM2 endpoints exceed limit %d.\n",
+				PSMX2_AM_MAX_TRX_CTXT);
 			return -FI_EBUSY;
 		}
 

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -756,7 +756,7 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 
 		if (flags & (FI_READ | FI_SYMMETRIC)) {
 			FI_INFO(&psmx2_prov, FI_LOG_AV,
-				"attr->flags=%x, supported=%x\n",
+				"attr->flags=%"PRIu64", supported=%llu\n",
 				attr->flags, FI_EVENT);
 			return -FI_ENOSYS;
 		}

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -533,10 +533,12 @@ int psmx2_domain_check_features(struct psmx2_fid_domain *domain, int ep_cap)
 {
 	if ((domain->caps & ep_cap & ~PSMX2_SUB_CAPS) !=
 	    (ep_cap & ~PSMX2_SUB_CAPS)) {
+		uint64_t mask = ~PSMX2_SUB_CAPS;
 		FI_INFO(&psmx2_prov, FI_LOG_CORE,
-			"caps mismatch: domain->caps=%llx, "
-			"ep->caps=%llx, mask=%llx\n",
-			domain->caps, ep_cap, ~PSMX2_SUB_CAPS);
+			"caps mismatch: domain->caps=%s,\n ep->caps=%s,\n mask=%s\n",
+			fi_tostr(&domain->caps, FI_TYPE_CAPS),
+			fi_tostr(&ep_cap, FI_TYPE_CAPS),
+			fi_tostr(&mask, FI_TYPE_CAPS));
 		return -FI_EOPNOTSUPP;
 	}
 
@@ -553,10 +555,12 @@ int psmx2_domain_enable_ep(struct psmx2_fid_domain *domain,
 
 	if ((domain->caps & ep_cap & ~PSMX2_SUB_CAPS) !=
 	    (ep_cap & ~PSMX2_SUB_CAPS)) {
+		uint64_t mask = ~PSMX2_SUB_CAPS;
 		FI_INFO(&psmx2_prov, FI_LOG_CORE,
-			"caps mismatch: domain->caps=%llx, "
-			"ep->caps=%llx, mask=%llx\n",
-			domain->caps, ep_cap, ~PSMX2_SUB_CAPS);
+			"caps mismatch: domain->caps=%s,\n ep->caps=%s,\n mask=%s\n",
+			fi_tostr(&domain->caps, FI_TYPE_CAPS),
+			fi_tostr(&ep_cap, FI_TYPE_CAPS),
+			fi_tostr(&mask, FI_TYPE_CAPS));
 		return -FI_EOPNOTSUPP;
 	}
 

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -518,7 +518,8 @@ int psmx2_ep_open_internal(struct psmx2_fid_domain *domain_priv,
 	if (info && info->ep_attr && info->ep_attr->auth_key) {
 		if (info->ep_attr->auth_key_size != sizeof(psm2_uuid_t)) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
-				"Invalid auth_key_len %d, should be %d.\n",
+				"Invalid auth_key_len %"PRIu64
+				", should be %"PRIu64".\n",
 				info->ep_attr->auth_key_size,
 				sizeof(psm2_uuid_t));
 			goto errout;
@@ -921,14 +922,14 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 	if (info && info->ep_attr) {
 		if (info->ep_attr->tx_ctx_cnt > psmx2_env.max_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
-				"tx_ctx_cnt %d exceed limit %d.\n",
+				"tx_ctx_cnt %"PRIu64" exceed limit %d.\n",
 				info->ep_attr->tx_ctx_cnt,
 				psmx2_env.max_trx_ctxt);
 			goto errout;
 		}
 		if (info->ep_attr->rx_ctx_cnt > psmx2_env.max_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
-				"rx_ctx_cnt %d exceed limit %d.\n",
+				"rx_ctx_cnt %"PRIu64" exceed limit %d.\n",
 				info->ep_attr->rx_ctx_cnt,
 				psmx2_env.max_trx_ctxt);
 			goto errout;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -254,7 +254,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		} else {
 			dest_addr = addr;
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"'%s' is taken as dest_addr: <epid=0x%llx, vl=%d>\n",
+				"'%s' is taken as dest_addr: <epid=%"PRIu64", vl=%d>\n",
 				node, dest_addr->epid, dest_addr->vlane);
 		}
 		node = NULL;
@@ -311,7 +311,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 			ofi_ns_resolve_name(&ns, node, &svc);
 		if (dest_addr) {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"'%s:%u' resolved to <epid=0x%llx, vl=%d>:%d\n",
+				"'%s:%u' resolved to <epid=%"PRIu64", vl=%d>:%d\n",
 				node, svc0, dest_addr->epid,
 				dest_addr->vlane, svc);
 		} else {
@@ -366,7 +366,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 			if (hints->ep_attr->tx_ctx_cnt > psmx2_env.max_trx_ctxt &&
 			    hints->ep_attr->tx_ctx_cnt != FI_SHARED_CONTEXT) {
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->ep_attr->tx_ctx_cnt=%d, max=%d\n",
+					"hints->ep_attr->tx_ctx_cnt=%"PRIu64", max=%d\n",
 					hints->ep_attr->tx_ctx_cnt,
 					psmx2_env.max_trx_ctxt);
 				goto err_out;
@@ -375,7 +375,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 
 			if (hints->ep_attr->rx_ctx_cnt > psmx2_env.max_trx_ctxt) {
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->ep_attr->rx_ctx_cnt=%d, max=%d\n",
+					"hints->ep_attr->rx_ctx_cnt=%"PRIu64", max=%d\n",
 					hints->ep_attr->rx_ctx_cnt,
 					psmx2_env.max_trx_ctxt);
 				goto err_out;
@@ -384,26 +384,28 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		}
 
 		if ((hints->caps & PSMX2_CAPS) != hints->caps) {
+			uint64_t psmx2_caps = PSMX2_CAPS;
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"hints->caps=0x%llx, supported=0x%llx\n",
-				hints->caps, PSMX2_CAPS);
+				"hints->caps=%s,\n supported=%s\n",
+				fi_tostr(&hints->caps, FI_TYPE_CAPS),
+				fi_tostr(&psmx2_caps, FI_TYPE_CAPS));
 			goto err_out;
 		}
 
 		if (hints->tx_attr) {
 			if ((hints->tx_attr->op_flags & PSMX2_OP_FLAGS) !=
 			    hints->tx_attr->op_flags) {
+				uint64_t psmx2_op_flags = PSMX2_OP_FLAGS;
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->tx->flags=0x%llx, "
-					"supported=0x%llx\n",
-					hints->tx_attr->op_flags,
-					PSMX2_OP_FLAGS);
+					"hints->caps=%s,\n supported=%s\n",
+					fi_tostr(&hints->tx_attr->op_flags, FI_TYPE_OP_FLAGS),
+					fi_tostr(&psmx2_op_flags, FI_TYPE_OP_FLAGS));
 				goto err_out;
 			}
 			if (hints->tx_attr->inject_size > psmx2_env.inject_size) {
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->tx_attr->inject_size=%ld,"
-					"supported=%ld.\n",
+					"hints->tx_attr->inject_size=%"PRIu64
+					", supported=%d.\n",
 					hints->tx_attr->inject_size,
 					psmx2_env.inject_size);
 				goto err_out;
@@ -413,17 +415,23 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		if (hints->rx_attr &&
 		    (hints->rx_attr->op_flags & PSMX2_OP_FLAGS) !=
 		     hints->rx_attr->op_flags) {
-			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"hints->rx->flags=0x%llx, supported=0x%llx\n",
-				hints->rx_attr->op_flags, PSMX2_OP_FLAGS);
+			uint64_t psmx2_op_flags = PSMX2_OP_FLAGS;
+			FI_INFO(&psmx2_prov, FI_LOG_CORE, "hints->rx->flags=%s,\n"
+				" supported=%s.\n",
+				fi_tostr(&hints->rx_attr->op_flags,
+					 FI_TYPE_OP_FLAGS),
+				fi_tostr(&psmx2_op_flags,
+					 FI_TYPE_OP_FLAGS));
 			goto err_out;
 		}
 
 		if ((hints->caps & FI_TAGGED) || (hints->caps & FI_MSG)) {
 			if ((hints->mode & FI_CONTEXT) != FI_CONTEXT) {
+				uint64_t psmx2_mode = FI_CONTEXT;
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->mode=0x%llx, required=0x%llx\n",
-					hints->mode, FI_CONTEXT);
+					"hints->mode=%s,\n required=%s.\n",
+					fi_tostr(&hints->mode, FI_TYPE_MODE),
+					fi_tostr(&psmx2_mode, FI_TYPE_MODE));
 				goto err_out;
 			}
 		} else {
@@ -528,8 +536,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		if (hints->ep_attr) {
 			if (hints->ep_attr->max_msg_size > PSMX2_MAX_MSG_SIZE) {
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->ep_attr->max_msg_size=%ld,"
-					"supported=%ld.\n",
+					"hints->ep_attr->max_msg_size=%"PRIu64","
+					"supported=%llu.\n",
 					hints->ep_attr->max_msg_size,
 					PSMX2_MAX_MSG_SIZE);
 				goto err_out;
@@ -540,20 +548,22 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		if (hints->tx_attr) {
 			if ((hints->tx_attr->msg_order & PSMX2_MSG_ORDER) !=
 			    hints->tx_attr->msg_order) {
+				uint64_t psmx2_msg_order = PSMX2_MSG_ORDER;
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->tx_attr->msg_order=%lx,"
-					"supported=%lx.\n",
-					hints->tx_attr->msg_order,
-					PSMX2_MSG_ORDER);
+					"hints->tx_attr->msg_order=%s,\n"
+					"supported=%s.\n",
+					fi_tostr(&hints->tx_attr->msg_order, FI_TYPE_MSG_ORDER),
+					fi_tostr(&psmx2_msg_order, FI_TYPE_MSG_ORDER));
 				goto err_out;
 			}
 			if ((hints->tx_attr->comp_order & PSMX2_COMP_ORDER) !=
 			    hints->tx_attr->comp_order) {
+				uint64_t psmx2_comp_order = PSMX2_COMP_ORDER;
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->tx_attr->msg_order=%lx,"
-					"supported=%lx.\n",
-					hints->tx_attr->comp_order,
-					PSMX2_COMP_ORDER);
+					"hints->tx_attr->msg_order=%s,\n"
+					"supported=%s.\n",
+					fi_tostr(&hints->tx_attr->comp_order, FI_TYPE_MSG_ORDER),
+					fi_tostr(&psmx2_comp_order, FI_TYPE_MSG_ORDER));
 				goto err_out;
 			}
 			if (hints->tx_attr->inject_size > psmx2_env.inject_size) {
@@ -566,8 +576,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 			}
 			if (hints->tx_attr->iov_limit > PSMX2_IOV_MAX_COUNT) {
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->tx_attr->iov_limit=%ld,"
-					"supported=%d.\n",
+					"hints->tx_attr->iov_limit=%"PRIu64
+					", supported=%"PRIu64".\n",
 					hints->tx_attr->iov_limit,
 					PSMX2_IOV_MAX_COUNT);
 				goto err_out;
@@ -584,20 +594,20 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		if (hints->rx_attr) {
 			if ((hints->rx_attr->msg_order & PSMX2_MSG_ORDER) !=
 			    hints->rx_attr->msg_order) {
+				uint64_t psmx2_msg_order = PSMX2_MSG_ORDER;
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->rx_attr->msg_order=%lx,"
-					"supported=%lx.\n",
-					hints->rx_attr->msg_order,
-					PSMX2_MSG_ORDER);
+					"hints->rx_attr->msg_order=%s,\n supported=%s.\n",
+					fi_tostr(&hints->rx_attr->msg_order, FI_TYPE_MSG_ORDER),
+					fi_tostr(&psmx2_msg_order, FI_TYPE_MSG_ORDER));
 				goto err_out;
 			}
 			if ((hints->rx_attr->comp_order & PSMX2_COMP_ORDER) !=
 			    hints->rx_attr->comp_order) {
+				uint64_t psmx2_comp_order = PSMX2_COMP_ORDER;
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
-					"hints->rx_attr->msg_order=%lx,"
-					"supported=%lx.\n",
-					hints->rx_attr->comp_order,
-					PSMX2_COMP_ORDER);
+					"hints->rx_attr->comp_order=%s,\n supported=%s.\n",
+					fi_tostr(&hints->rx_attr->comp_order, FI_TYPE_MSG_ORDER),
+					fi_tostr(&psmx2_comp_order, FI_TYPE_MSG_ORDER));
 				goto err_out;
 			}
 			if (hints->rx_attr->iov_limit > 1) {

--- a/prov/psm2/src/psmx2_util.c
+++ b/prov/psm2/src/psmx2_util.c
@@ -122,13 +122,15 @@ struct psmx2_ep_name *psmx2_string_to_ep_name(const void *s)
 
 	if (ofi_str_toaddr(s, &fmt, &name, &len)) {
 		FI_INFO(&psmx2_prov, FI_LOG_CORE,
-			"invalid string address: %s.\n", s);
+			"invalid string address: %s.\n",
+			(const char *)s);
 		return NULL;
 	}
 
 	if (fmt != FI_ADDR_PSMX2) {
 		FI_INFO(&psmx2_prov, FI_LOG_CORE,
-			"invalid string address format: %s.\n", s);
+			"invalid string address format: %s.\n",
+			(const char *)s);
 		free(name);
 		return NULL;
 	}


### PR DESCRIPTION
The mismatch between types was fixed as follows:
- Change to use `fi_tostr` for the caps, modes, [msg|comp]_orders fields
- Replace the incorrect format specifiers to the proper ones (e.x. `%d` -> `%PRIu64` when type of the variable is `uint64_t`)

Fixes #3388 

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>