### PR TITLE
 prov/netdir: Fix warnings for the netdir related code

### DIFF
--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -838,7 +838,8 @@ static inline ofi_complex_## type ofi_complex_land_## type	\
 	(ofi_complex_## type a, ofi_complex_## type b)		\
 {								\
 	ofi_complex_## type res;				\
-	res.real = (a.real || a.imag) && (b.real || b.imag);	\
+	res.real = (type)(((a.real != 0) || (a.imag != 0)) &&	\
+		((b.real != 0) || (b.imag != 0)));		\
 	res.imag = 0;						\
 	return res;						\
 }								\
@@ -846,7 +847,8 @@ static inline ofi_complex_## type ofi_complex_lor_## type	\
 	(ofi_complex_## type a, ofi_complex_## type b)		\
 {								\
 	ofi_complex_## type res;				\
-	res.real = (a.real || a.imag) || (b.real || b.imag);	\
+	res.real = (type)(((a.real != 0) || (a.imag != 0)) &&	\
+		((b.real != 0) || (b.imag != 0)));		\
 	res.imag = 0;						\
 	return res;						\
 }								\
@@ -854,8 +856,10 @@ static inline ofi_complex_## type ofi_complex_lxor_## type	\
 	(ofi_complex_## type a, ofi_complex_## type b)		\
 {								\
 	ofi_complex_## type res;				\
-	res.real = ((a.real || a.imag) && !(b.real || b.imag)) || \
-		   (!(a.real || a.imag) && (b.real || b.imag));	\
+	res.real = (type)((((a.real != 0) || (a.imag != 0)) &&	\
+		    !((b.real != 0) || (b.imag != 0))) ||	\
+		   (!((a.real != 0) || (a.imag != 0)) &&	\
+		    ((b.real != 0) || (b.imag != 0))));		\
 	res.imag = 0;						\
 	return res;						\
 }

--- a/prov/netdir/src/netdir.h
+++ b/prov/netdir/src/netdir.h
@@ -68,7 +68,7 @@ extern "C" {
 
 
 extern struct gl_data {
-	size_t	inline_thr;
+	int	inline_thr;
 	int	prepost_cnt;
 	int	prepost_buf_cnt;
 	int	flow_control_cnt;
@@ -98,7 +98,7 @@ int ofi_nd_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		  void *context);
 
 int ofi_nd_getinfo(uint32_t version, const char *node, const char *service,
-		   uint64_t flags, struct fi_info *hints, struct fi_info **info);
+		   uint64_t flags, const struct fi_info *hints, struct fi_info **info);
 void ofi_nd_fini(void);
 
 int ofi_nd_mr_reg(struct fid *fid, const void *buf, size_t len,

--- a/prov/netdir/src/netdir_cntr.c
+++ b/prov/netdir/src/netdir_cntr.c
@@ -92,8 +92,6 @@ int ofi_nd_cntr_open(struct fid_domain *pdomain, struct fi_cntr_attr *attr,
 	assert(pdomain);
 	assert(pdomain->fid.fclass == FI_CLASS_DOMAIN);
 
-	HRESULT hr;
-
 	if (attr) {
 		if (attr->wait_obj != FI_WAIT_NONE &&
 		    attr->wait_obj != FI_WAIT_UNSPEC)

--- a/prov/netdir/src/netdir_ep.c
+++ b/prov/netdir/src/netdir_ep.c
@@ -222,7 +222,7 @@ int ofi_nd_endpoint(struct fid_domain *pdomain, struct fi_info *info,
 
 		hr = ep->connector->lpVtbl->Bind(ep->connector,
 						 &domain->addr.addr,
-						 ofi_sizeofaddr(&domain->addr.addr));
+						 (ULONG)ofi_sizeofaddr(&domain->addr.addr));
 		if (FAILED(hr))
 			goto fn_fail;
 
@@ -597,7 +597,7 @@ static int ofi_nd_ep_connect(struct fid_ep *pep, const void *addr,
 
 	hr = ep->connector->lpVtbl->Connect(
 		ep->connector, (IUnknown*)ep->qp,
-		(struct sockaddr*)addr, ofi_sizeofaddr((struct sockaddr*)addr),
+		(struct sockaddr*)addr, (ULONG)ofi_sizeofaddr((struct sockaddr*)addr),
 		ep->domain->ainfo.MaxInboundReadLimit,
 		ep->domain->ainfo.MaxOutboundReadLimit,
 		param, (ULONG)paramlen, &wait->base.ov);

--- a/prov/netdir/src/netdir_ep_msg.c
+++ b/prov/netdir/src/netdir_ep_msg.c
@@ -161,12 +161,12 @@ static int ofi_nd_ep_sendmsg_inline(struct nd_ep *ep,
 			ND2_SGE sge_def = {
 				.Buffer = msg->msg_iov[i].iov_base,
 				.BufferLength = (ULONG)msg->msg_iov[i].iov_len,
-				.MemoryRegionToken = (UINT32)(msg->desc[i])
+				.MemoryRegionToken = (UINT32)(uintptr_t)msg->desc[i]
 			};
 			sge_entry->entries[i + 1] = sge_def;
 		}
 
-		sge_entry->count = msg->iov_count + 1;
+		sge_entry->count = (ULONG)msg->iov_count + 1;
 	}
 
 	nd_send_entry *send_entry = ofi_nd_buf_alloc_nd_send_entry();
@@ -308,7 +308,7 @@ static int ofi_nd_ep_sendmsg_large(struct nd_ep *ep,
 		},
 		{
 			.Buffer = entry->notify_buf->location,
-			.BufferLength = (ULONG)sizeof(*entry->notify_buf->location) * msg->iov_count,
+			.BufferLength = (ULONG)(sizeof(*entry->notify_buf->location) * msg->iov_count),
 			.MemoryRegionToken = entry->notify_buf->token
 		}
 	};

--- a/prov/netdir/src/netdir_ep_rma.c
+++ b/prov/netdir/src/netdir_ep_rma.c
@@ -249,8 +249,8 @@ ofi_nd_ep_readmsg(struct fid_ep *pep, const struct fi_msg_rma *msg,
 
 		ND2_SGE sge = {
 			.Buffer = (void *)remote_addr[i],
-			.BufferLength = rma_iovecs[i].len,
-			.MemoryRegionToken = (UINT32)msg->desc[to_split_map[i]]
+			.BufferLength = (ULONG)rma_iovecs[i].len,
+			.MemoryRegionToken = (UINT32)(uintptr_t)msg->desc[to_split_map[i]]
 		};
 
 		hr = ep->qp->lpVtbl->Read(ep->qp, entries[i], &sge, 1,
@@ -408,8 +408,8 @@ ofi_nd_ep_writemsg(struct fid_ep *pep, const struct fi_msg_rma *msg,
 
 			ND2_SGE sge = {
 				.Buffer = (void *)remote_addr[i],
-				.BufferLength = rma_iovecs[i].len,
-				.MemoryRegionToken = (UINT32)msg->desc[to_split_map[i]]
+				.BufferLength = (ULONG)rma_iovecs[i].len,
+				.MemoryRegionToken = (UINT32)(uintptr_t)msg->desc[to_split_map[i]]
 			};
 
 			hr = ep->qp->lpVtbl->Write(ep->qp, entries[i], &sge, 1,
@@ -450,7 +450,7 @@ ofi_nd_ep_writemsg(struct fid_ep *pep, const struct fi_msg_rma *msg,
 
 			ND2_SGE sge = {
 				.Buffer = (void *)(buf + msg->rma_iov[i].len),
-				.BufferLength = msg->rma_iov[i].len,
+				.BufferLength = (ULONG)msg->rma_iov[i].len,
 				.MemoryRegionToken = main_entry->inline_buf->token
 			};
 

--- a/prov/netdir/src/netdir_eq.c
+++ b/prov/netdir/src/netdir_eq.c
@@ -77,8 +77,6 @@ int ofi_nd_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	assert(fabric);
 	assert(fabric->fid.fclass == FI_CLASS_FABRIC);
 
-	HRESULT hr;
-
 	if (attr) {
 		if (attr->wait_obj != FI_WAIT_NONE && attr->wait_obj != FI_WAIT_UNSPEC)
 			return -FI_EBADFLAGS;
@@ -105,14 +103,12 @@ int ofi_nd_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 
 	eq->iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
 	if (!eq->iocp || eq->iocp == INVALID_HANDLE_VALUE) {
-		DWORD err = GetLastError();
 		ofi_nd_eq_close(&eq->fid.fid);
 		return H2F(HRESULT_FROM_WIN32(GetLastError()));
 	}
 
 	eq->err = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
 	if (!eq->err || eq->err == INVALID_HANDLE_VALUE) {
-		DWORD err = GetLastError();
 		ofi_nd_eq_close(&eq->fid.fid);
 		return H2F(HRESULT_FROM_WIN32(GetLastError()));
 	}
@@ -143,8 +139,6 @@ static inline ssize_t ofi_nd_eq_ev2buf(struct nd_eq_event *ev,
 				       void *buf, size_t len)
 {
 	assert(ev);
-
-	ssize_t res;
 
 	size_t copylen = 0;
 	char* dst = (char *)buf;
@@ -261,7 +255,6 @@ static ssize_t ofi_nd_eq_readerr(struct fid_eq *peq,
 	DWORD bytes;
 	ULONG_PTR key;
 	OVERLAPPED *ov;
-	ULONG psize;
 
 	struct nd_eq_event *ev = NULL;
 

--- a/prov/netdir/src/netdir_iface.h
+++ b/prov/netdir/src/netdir_iface.h
@@ -114,7 +114,7 @@ struct nd_domain {
 	struct nd_eq			*eq;
 	struct fi_info			*info;
 
-	int				eq_flags;
+	uint64_t			eq_flags;
 
 	IND2Adapter			*adapter;
 	IND2CompletionQueue		*cq;
@@ -240,13 +240,12 @@ struct nd_ep {
 	LONG				connected;
 
 	struct dlist_entry		entry;
-
-	struct nd_queue_queue		send_queue;
 	struct {
 		nd_flow_block_flags	flags;
 		size_t			used_counter;
 		CRITICAL_SECTION	send_lock;
 	} send_op;
+	struct nd_queue_queue		send_queue;
 };
 
 struct nd_srx {
@@ -254,9 +253,9 @@ struct nd_srx {
 	struct fi_rx_attr	attr;
 	IND2SharedReceiveQueue	*srx;
 	struct nd_domain	*domain;
-	struct nd_queue_queue	prepost;
 	struct dlist_entry	received;
 	CRITICAL_SECTION	prepost_lock;
+	struct nd_queue_queue	prepost;
 };
 
 struct nd_mr {

--- a/prov/netdir/src/netdir_mr.c
+++ b/prov/netdir/src/netdir_mr.c
@@ -177,7 +177,7 @@ int ofi_nd_mr_reg(struct fid *fid, const void *buf, size_t len,
 		if (FAILED(hr))
 			goto fn_fail;
 		mr->fid.key = mr->mr->lpVtbl->GetRemoteToken(mr->mr);
-		mr->fid.mem_desc = (void*)mr->mr->lpVtbl->GetLocalToken(mr->mr);
+		mr->fid.mem_desc = (void *)(uintptr_t)mr->mr->lpVtbl->GetLocalToken(mr->mr);
 	}
 	else {
 		/* async memory registration */
@@ -285,7 +285,7 @@ static void ofi_nd_mr_ov_event(struct nd_event_base* base, DWORD bytes)
 	struct nd_mr *mr = container_of(ov->fid, struct nd_mr, fid.fid);
 	assert(mr->mr);
 	mr->fid.key = mr->mr->lpVtbl->GetRemoteToken(mr->mr);
-	mr->fid.mem_desc = (void*)mr->mr->lpVtbl->GetLocalToken(mr->mr);
+	mr->fid.mem_desc = (void *)(uintptr_t)mr->mr->lpVtbl->GetLocalToken(mr->mr);
 
 	struct fi_eq_entry entry = {.fid = ov->fid, .context = ov->context};
 	ofi_nd_mr_ov_free(base);
@@ -320,8 +320,6 @@ static void ofi_nd_mr_ov_err(struct nd_event_base* base, DWORD bytes,
 			     DWORD error)
 {
 	OFI_UNUSED(bytes);
-
-	HRESULT hr;
 
 	ofi_nd_mr_ov *ov = container_of(base, ofi_nd_mr_ov, base);
 

--- a/prov/netdir/src/netdir_ndinit.c
+++ b/prov/netdir/src/netdir_ndinit.c
@@ -221,27 +221,27 @@ static inline wchar_t *ofi_nd_get_provider_path(const WSAPROTOCOL_INFOW *proto)
 
 	res = WSCGetProviderPath((GUID*)&proto->ProviderId, prov, &len, &err);
 	if (res)
-		goto fn_profail;
+		goto fn1;
 
 	lenex = ExpandEnvironmentStringsW(prov, NULL, 0);
 	if (!lenex)
-		goto fn_profail;
+		goto fn1;
 
 	provex = (wchar_t*)malloc(lenex * sizeof(*provex));
 	if (!provex)
-		goto fn_profail;
+		goto fn1;
 
 	lenex = ExpandEnvironmentStringsW(prov, provex, lenex);
 	if (!lenex)
-		goto fn_profail;
+		goto fn2;
 
 	free(prov);
 	return provex;
 
-fn_profail:
+fn2:
+	free(provex);
+fn1:
 	free(prov);
-
-fn_fail:
 	return NULL;
 }
 
@@ -373,7 +373,7 @@ static HRESULT ofi_nd_create_adapter()
 		struct factory_t *factory = &ofi_nd_infra.class_factories.factory[i];
 		assert(factory->class_factory);
 
-		HRESULT hr = factory->class_factory->lpVtbl->CreateInstance(factory->class_factory,
+		hr = factory->class_factory->lpVtbl->CreateInstance(factory->class_factory,
 			NULL, &IID_IND2Provider, (void**)&factory->provider);
 		if (FAILED(hr))
 			return hr;
@@ -613,8 +613,6 @@ HRESULT ofi_nd_startup(ofi_nd_adapter_cb_t cb)
 
 HRESULT ofi_nd_shutdown()
 {
-	size_t i;
-
 	if (!ofi_nd_startup_done)
 		return S_OK;
 

--- a/prov/netdir/src/netdir_ov.h
+++ b/prov/netdir/src/netdir_ov.h
@@ -135,7 +135,7 @@ typedef struct nd_cq_entry {
 
 typedef struct nd_sge {
 	ND2_SGE	entries[256];
-	size_t	count;
+	ULONG	count;
 } nd_sge;
 
 struct nd_send_entry {
@@ -171,8 +171,8 @@ static inline void nd_buf_register_fini(void(*fini)(void))
 		do {
 			fin->next = nd_buf_fini_head;
 		} while (InterlockedCompareExchangePointer(
-			 (volatile PVOID*)&nd_buf_fini_head,
-			 fin, (volatile PVOID)fin->next) != fin->next);
+			 (PVOID *)&nd_buf_fini_head,
+			 fin, (PVOID)fin->next) != fin->next);
 	}
 	else {
 		ND_LOG_WARN(FI_LOG_CORE, "failed to allocate finalizer\n");

--- a/prov/netdir/src/netdir_pep.c
+++ b/prov/netdir/src/netdir_pep.c
@@ -454,15 +454,11 @@ static int ofi_nd_pep_reject(struct fid_pep *ppep, fid_t handle,
 {
 	assert(ppep);
 
-	int res = FI_SUCCESS;
-	HRESULT hr;
-
 	if (ppep->fid.fclass != FI_CLASS_PEP)
 		return -FI_EINVAL;
 	if (handle->fclass != FI_CLASS_CONNREQ)
 		return -FI_EINVAL;
 
-	struct nd_pep *pep = container_of(ppep, struct nd_pep, fid);
 	struct nd_connreq *connreq = container_of(handle, struct nd_connreq, handle);
 
 	assert(connreq->connector);

--- a/prov/netdir/src/netdir_unexp.c
+++ b/prov/netdir/src/netdir_unexp.c
@@ -121,8 +121,6 @@ HRESULT ofi_nd_unexp_fini(struct nd_ep *ep)
 	assert(ep);
 	assert(ep->fid.fid.fclass == FI_CLASS_EP);
 
-	int i;
-	HRESULT hr;
 	int total_count = (gl_data.prepost_cnt +
 		gl_data.flow_control_cnt) * gl_data.prepost_buf_cnt;
 


### PR DESCRIPTION
This patch is going to fix two problems:
- Conversion from int (condition) to float/double types.
- Warnings for the netdir provider related code

Fixes #3368 