### PR TITLE
man: extra newline leading to bad rendering

### DIFF
--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -636,7 +636,6 @@ memory registration attributes. This field is ignored unless the fabric is
 opened with API version 1.5 or greater.
 
 ## Max Error Data Size (max_err_data)
-
 : The maximum amount of error data, in bytes, that may be returned as part of
   a completion or event queue error.  This value corresponds to the
   err_data_size field in struct fi_cq_err_entry and struct fi_eq_err_entry.


### PR DESCRIPTION
The extra newline in markdown was leading to bad rendering to man.

Signed-off-by: Sayantan Sur <sayantan.sur@intel.com>