### PR TITLE
prov/rxd: Fix unchecked return value

### DIFF
--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -254,7 +254,9 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	fi_freeinfo(dg_info);
 	return 0;
 err4:
-	ofi_domain_close(&rxd_domain->util_domain);
+	if (ofi_domain_close(&rxd_domain->util_domain))
+		FI_WARN(&rxd_prov, FI_LOG_DOMAIN,
+			"ofi_domain_close failed");
 err3:
 	fi_close(&rxd_domain->dg_domain->fid);
 err2:


### PR DESCRIPTION
Coverity complains that the return value of the `ofi_domain_close` wasn't checked.
This patch fixes this issue by checking the return value and printing out a warning in case of the failure

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>