### PR TITLE
prov/verbs: Fix CQ resource leak in case of failure and avoid excessive type castings

### DIFF
--- a/prov/verbs/src/ep_dgram/verbs_dgram_av.c
+++ b/prov/verbs/src/ep_dgram/verbs_dgram_av.c
@@ -372,7 +372,7 @@ int fi_ibv_dgram_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	if (!attr || domain_fid->fid.fclass != FI_CLASS_DOMAIN)
 		return -FI_EINVAL;
 
-	av = (struct fi_ibv_dgram_av *)calloc(1, sizeof(*av));
+	av = calloc(1, sizeof(*av));
 	if (!av)
 		return -FI_ENOMEM;
 

--- a/prov/verbs/src/ep_dgram/verbs_dgram_cq.c
+++ b/prov/verbs/src/ep_dgram/verbs_dgram_cq.c
@@ -336,17 +336,19 @@ int fi_ibv_dgram_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 {
 	struct fi_ibv_dgram_cq *cq;
 	struct fi_ibv_domain *domain;
-	int ret = FI_SUCCESS;
-	size_t cq_size = 0;
+	int ret;
+	size_t cq_size;
 
-	cq = (struct fi_ibv_dgram_cq *)calloc(1, sizeof(*cq));
+	cq = calloc(1, sizeof(*cq));
 	if (!cq)
 		return -FI_ENOMEM;
 
 	domain = container_of(domain_fid, struct fi_ibv_domain,
 			      util_domain.domain_fid);
-	if (!domain)
-		return -FI_EINVAL;
+	if (!domain || (domain->ep_type != FI_EP_DGRAM)) {
+		ret = -FI_EINVAL;
+		goto err1;
+	}
 
 	assert(domain->ep_type == FI_EP_DGRAM);
 

--- a/prov/verbs/src/ep_dgram/verbs_dgram_ep.c
+++ b/prov/verbs/src/ep_dgram/verbs_dgram_ep.c
@@ -413,7 +413,7 @@ int fi_ibv_dgram_endpoint_open(struct fid_domain *domain_fid,
 	    domain_fid->fid.fclass != FI_CLASS_DOMAIN)
 		return -FI_EINVAL;
 
-	ep = (struct fi_ibv_dgram_ep *)calloc(1, sizeof(*ep));
+	ep = calloc(1, sizeof(*ep));
 	if (!ep)
 		return -FI_ENOMEM;
 


### PR DESCRIPTION
This PR is prepared to fix the following:
- The new upstreamed code of the verbs/DGRAM has resource leak in the `fi_cq_open` function
- Remove excessive type castings for the value returned from the `calloc` function

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>