### PR TITLE
prov/util, rxm: MR mode related updates

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -661,8 +661,8 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 			   FI_SHARED_AV | FI_TRIGGER | FI_FENCE | \
 			   FI_LOCAL_COMM | FI_REMOTE_COMM)
 
-int ofi_check_mr_mode(uint32_t api_version, uint32_t prov_mode,
-			     uint32_t user_mode);
+int ofi_check_mr_mode(uint32_t api_version, uint64_t user_info_caps,
+		      uint32_t prov_mode, uint32_t user_mode);
 int ofi_check_fabric_attr(const struct fi_provider *prov,
 			  const struct fi_fabric_attr *prov_attr,
 			  const struct fi_fabric_attr *user_attr);
@@ -670,7 +670,7 @@ int ofi_check_wait_attr(const struct fi_provider *prov,
 		        const struct fi_wait_attr *attr);
 int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 			  const struct fi_domain_attr *prov_attr,
-			  const struct fi_domain_attr *user_attr);
+			  const struct fi_info *user_info);
 int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		      const struct fi_info *prov_info,
 		      const struct fi_ep_attr *user_attr);

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -661,8 +661,9 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 			   FI_SHARED_AV | FI_TRIGGER | FI_FENCE | \
 			   FI_LOCAL_COMM | FI_REMOTE_COMM)
 
-int ofi_check_mr_mode(uint32_t api_version, uint64_t user_info_caps,
-		      uint32_t prov_mode, uint32_t user_mode);
+int ofi_check_mr_mode(const struct fi_provider *prov, uint32_t api_version,
+		      uint64_t user_info_caps, uint32_t prov_mode,
+		      uint32_t user_mode);
 int ofi_check_fabric_attr(const struct fi_provider *prov,
 			  const struct fi_fabric_attr *prov_attr,
 			  const struct fi_fabric_attr *user_attr);

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -613,6 +613,7 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 					hints->domain_attr->data_progress;
 
 			if (ofi_check_mr_mode(version,
+					hints->caps,
 					gnix_info->domain_attr->mr_mode,
 					hints->domain_attr->mr_mode) != FI_SUCCESS) {
 				GNIX_DEBUG(FI_LOG_DOMAIN,
@@ -673,7 +674,7 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 
 			ret = ofi_check_domain_attr(&gnix_prov, version,
 						    gnix_info->domain_attr,
-						    hints->domain_attr);
+						    hints);
 			if (ret) {
 				GNIX_WARN(FI_LOG_FABRIC,
 						  "GNI failed domain attributes check\n");

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -612,7 +612,8 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 				gnix_info->domain_attr->data_progress =
 					hints->domain_attr->data_progress;
 
-			if (ofi_check_mr_mode(version,
+			if (ofi_check_mr_mode(&gnix_prov,
+					version,
 					hints->caps,
 					gnix_info->domain_attr->mr_mode,
 					hints->domain_attr->mr_mode) != FI_SUCCESS) {

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -119,7 +119,13 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->ep_attr->max_msg_size = core_info->ep_attr->max_msg_size;
 
 	*info->domain_attr = *rxm_info.domain_attr;
-	info->domain_attr->mr_mode = core_info->domain_attr->mr_mode;
+	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
+		/* ofi_alter_info assumes version 1.5 or above mr_mode bits */
+		if (core_info->domain_attr->mr_mode == FI_MR_BASIC)
+			info->domain_attr->mr_mode |= OFI_MR_BASIC_MAP;
+	} else {
+		info->domain_attr->mr_mode |= core_info->domain_attr->mr_mode;
+	}
 	info->domain_attr->cq_data_size = MIN(core_info->domain_attr->cq_data_size,
 					      rxm_info.domain_attr->cq_data_size);
 

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -956,7 +956,7 @@ union sock_tx_op {
 
 int sock_verify_info(uint32_t version, const struct fi_info *hints);
 int sock_verify_fabric_attr(const struct fi_fabric_attr *attr);
-int sock_verify_domain_attr(uint32_t version, const struct fi_domain_attr *attr);
+int sock_verify_domain_attr(uint32_t version, const struct fi_info *info);
 
 size_t sock_get_tx_size(size_t size);
 int sock_rdm_verify_ep_attr(const struct fi_ep_attr *ep_attr,

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -131,8 +131,8 @@ int sock_verify_domain_attr(uint32_t version, const struct fi_info *info)
 		return -FI_ENODATA;
 	}
 
-	if (ofi_check_mr_mode(version, info->caps, sock_domain_attr.mr_mode,
-			      attr->mr_mode)) {
+	if (ofi_check_mr_mode(&sock_prov, version, info->caps,
+			      sock_domain_attr.mr_mode, attr->mr_mode)) {
 		FI_INFO(&sock_prov, FI_LOG_CORE,
 			"Invalid memory registration mode\n");
 		return -FI_ENODATA;

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -67,8 +67,10 @@ const struct fi_domain_attr sock_domain_attr = {
 	.mr_cnt = SOCK_DOMAIN_MR_CNT,
 };
 
-int sock_verify_domain_attr(uint32_t version, const struct fi_domain_attr *attr)
+int sock_verify_domain_attr(uint32_t version, const struct fi_info *info)
 {
+	const struct fi_domain_attr *attr = info->domain_attr;
+
 	if (!attr)
 		return 0;
 
@@ -129,7 +131,7 @@ int sock_verify_domain_attr(uint32_t version, const struct fi_domain_attr *attr)
 		return -FI_ENODATA;
 	}
 
-	if (ofi_check_mr_mode(version, sock_domain_attr.mr_mode,
+	if (ofi_check_mr_mode(version, info->caps, sock_domain_attr.mr_mode,
 			      attr->mr_mode)) {
 		FI_INFO(&sock_prov, FI_LOG_CORE,
 			"Invalid memory registration mode\n");
@@ -451,7 +453,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 
 	fab = container_of(fabric, struct sock_fabric, fab_fid);
 	if (info && info->domain_attr) {
-		ret = sock_verify_domain_attr(fabric->api_version, info->domain_attr);
+		ret = sock_verify_domain_attr(fabric->api_version, info);
 		if (ret)
 			return -FI_EINVAL;
 	}

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -276,7 +276,7 @@ int sock_verify_info(uint32_t version, const struct fi_info *hints)
 			return -FI_ENODATA;
 		}
 	}
-	ret = sock_verify_domain_attr(version, hints->domain_attr);
+	ret = sock_verify_domain_attr(version, hints);
 	if (ret)
 		return ret;
 

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -251,7 +251,8 @@ usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			return -FI_ENODATA;
 		}
 
-		if (ofi_check_mr_mode(fabric->api_version,
+		if (ofi_check_mr_mode(&usdf_ops,
+				      fabric->api_version,
 				      info->caps,
 				      OFI_MR_BASIC_MAP | FI_MR_LOCAL,
 				      info->domain_attr->mr_mode)) {
@@ -517,7 +518,7 @@ int usdf_check_mr_mode(uint32_t version, const struct fi_info *hints,
 {
 	int ret;
 
-	ret = ofi_check_mr_mode(version, hints->caps, prov_mode,
+	ret = ofi_check_mr_mode(&usdf_ops, version, hints->caps, prov_mode,
 				hints->domain_attr->mr_mode);
 
 	/* If ofi_check_mr_mode fails. */

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -252,6 +252,7 @@ usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		}
 
 		if (ofi_check_mr_mode(fabric->api_version,
+				      info->caps,
 				      OFI_MR_BASIC_MAP | FI_MR_LOCAL,
 				      info->domain_attr->mr_mode)) {
 			/* the caller ignored our fi_getinfo results */
@@ -516,7 +517,7 @@ int usdf_check_mr_mode(uint32_t version, const struct fi_info *hints,
 {
 	int ret;
 
-	ret = ofi_check_mr_mode(version, prov_mode,
+	ret = ofi_check_mr_mode(version, hints->caps, prov_mode,
 				hints->domain_attr->mr_mode);
 
 	/* If ofi_check_mr_mode fails. */

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -949,7 +949,10 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 			     uint64_t info_caps, uint32_t api_version)
 {
 	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5)))
-		attr->mr_mode = attr->mr_mode ? FI_MR_BASIC : FI_MR_SCALABLE;
+		attr->mr_mode = attr->mr_mode & OFI_MR_BASIC_MAP ?
+			FI_MR_BASIC : FI_MR_SCALABLE;
+	else
+		attr->mr_mode &= ~(FI_MR_BASIC | FI_MR_SCALABLE);
 
 	attr->caps = ofi_get_caps(info_caps, hints ? hints->caps : 0, attr->caps);
 	if (!hints)

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -426,9 +426,13 @@ static int fi_resource_mgmt_level(enum fi_resource_mgmt rm_model)
 /* If a provider supports basic registration mode it should set the FI_MR_BASIC
  * mode bit in prov_mode. Support for FI_MR_SCALABLE is indicated by not setting
  * any of OFI_MR_BASIC_MAP bits. */
-int ofi_check_mr_mode(uint32_t api_version, uint64_t user_info_caps,
-		      uint32_t prov_mode, uint32_t user_mode)
+int ofi_check_mr_mode(const struct fi_provider *prov, uint32_t api_version,
+		      uint64_t user_info_caps, uint32_t prov_mode,
+		      uint32_t user_mode)
 {
+	uint64_t prov_mode_log;
+	int ret;
+
 	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5))) {
 		if (!ofi_rma_target_allowed(user_info_caps) &&
 		    !(prov_mode & FI_MR_LOCAL))
@@ -438,15 +442,19 @@ int ofi_check_mr_mode(uint32_t api_version, uint64_t user_info_caps,
 
 		switch (user_mode) {
 		case FI_MR_UNSPEC:
-			return OFI_CHECK_MR_SCALABLE(prov_mode) ||
+			ret = OFI_CHECK_MR_SCALABLE(prov_mode) ||
 				OFI_CHECK_MR_BASIC(prov_mode) ?
 				0 : -FI_ENODATA;
+			break;
 		case FI_MR_BASIC:
-			return OFI_CHECK_MR_BASIC(prov_mode) ? 0 : -FI_ENODATA;
+			ret = OFI_CHECK_MR_BASIC(prov_mode) ? 0 : -FI_ENODATA;
+			break;
 		case FI_MR_SCALABLE:
-			return OFI_CHECK_MR_SCALABLE(prov_mode) ? 0 : -FI_ENODATA;
+			ret = OFI_CHECK_MR_SCALABLE(prov_mode) ? 0 : -FI_ENODATA;
+			break;
 		default:
-			return -FI_ENODATA;
+			ret = -FI_ENODATA;
+			break;
 		}
 	} else {
 		if (!ofi_rma_target_allowed(user_info_caps)) {
@@ -457,16 +465,28 @@ int ofi_check_mr_mode(uint32_t api_version, uint64_t user_info_caps,
 
 		if (user_mode & FI_MR_BASIC) {
 			if (!OFI_CHECK_MR_BASIC(prov_mode))
-				return -FI_ENODATA;
-			if ((user_mode & prov_mode & ~OFI_MR_BASIC_MAP) ==
-			    (prov_mode & ~OFI_MR_BASIC_MAP))
-				return 0;
-			return -FI_ENODATA;
+				ret = -FI_ENODATA;
+			else if ((user_mode & prov_mode & ~OFI_MR_BASIC_MAP) ==
+				 (prov_mode & ~OFI_MR_BASIC_MAP))
+				ret = 0;
+			else
+				ret = -FI_ENODATA;
 		} else {
-			return (((user_mode | FI_MR_BASIC) & prov_mode) == prov_mode) ?
-				0 : -FI_ENODATA;
+			ret = (((user_mode | FI_MR_BASIC) & prov_mode) ==
+			       prov_mode) ? 0 : -FI_ENODATA;
 		}
 	}
+
+	if (ret) {
+		FI_INFO(prov, FI_LOG_CORE, "Invalid memory registration mode\n");
+		if (FI_VERSION_GE(api_version, FI_VERSION(1, 5)))
+			prov_mode_log = prov_mode & ~(FI_MR_BASIC | FI_MR_SCALABLE);
+		else
+			prov_mode_log = prov_mode;
+		FI_INFO_MR_MODE(prov, prov_mode_log, user_mode);
+	}
+
+	return ret;
 }
 
 int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
@@ -519,12 +539,9 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 		return -FI_ENODATA;
 	}
 
-	if (ofi_check_mr_mode(api_version, user_info->caps, prov_attr->mr_mode,
-			       user_attr->mr_mode)) {
-		FI_INFO(prov, FI_LOG_CORE, "Invalid memory registration mode\n");
-		FI_INFO_MR_MODE(prov, prov_attr->mr_mode, user_attr->mr_mode);
+	if (ofi_check_mr_mode(prov, api_version, user_info->caps,
+			      prov_attr->mr_mode, user_attr->mr_mode))
 		return -FI_ENODATA;
-	}
 
 	/* following checks only apply to api 1.5 and beyond */
 	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5)))

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -327,7 +327,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_EINVAL;
 
 	ret = ofi_check_domain_attr(&fi_ibv_prov, fabric->api_version,
-				    fi->domain_attr, info->domain_attr);
+				    fi->domain_attr, info);
 	if (ret)
 		return ret;
 

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -246,7 +246,7 @@ static int fi_ibv_check_hints(uint32_t version, const struct fi_info *hints,
 	if (hints->domain_attr) {
 		ret = ofi_check_domain_attr(&fi_ibv_prov, version,
 					    info->domain_attr,
-					    hints->domain_attr);
+					    hints);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
The check for FI_MR_PROV_KEY, FI_MR_VIRT_ADDR and FI_MR_ALLOCATED are primarily
needed when the app requests FI_RMA capability. Don't do these checks for non-RMA
cases.
