### PR TITLE
common/appveyor: Exclude testing VS15 with v141 toolset from AppVeyor matrix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,6 @@
-image: Visual Studio 2015
+image:
+  - Visual Studio 2015
+  - Visual Studio 2017
 
 build:
   project: libfabric.sln
@@ -8,6 +10,13 @@ configuration:
   - Debug-v141
   - Release-v140
   - Release-v141
+
+matrix:
+  exclude:
+    - configuration: Debug-v141
+      image: Visual Studio 2015
+    - configuration: Release-v141
+      image: Visual Studio 2015
 
 before_build:
   - ps: .appveyor.ps1 -Verbose


### PR DESCRIPTION
This fixes failing VS15/v141 jobs in the AppVeyor.

The v141 toolset is introduced together with VS17
This is impossible to compile VS15 configuration with v141 toolset
But the compiling VS17/v140 is kept for the AppVeyor to check backward compatibility of our VS project

**Note: Please merge this together with ofiwg/fabtests#740 that fixes the same problem.**

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>