### PR TITLE
 man/verbs: Add mentions about verbs/DGRAM EP type to verbs' man page

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -32,6 +32,9 @@ FI_MSG, FI_RMA, FI_ATOMIC and shared receive contexts.
 #### RDM endpoints
 FI_MSG, FI_TAGGED, FI_RMA
 
+#### DGRAM endpoints
+FI_MSG
+
 ### Modes
 Verbs provider requires applications to support the following modes:
 
@@ -43,8 +46,11 @@ Verbs provider requires applications to support the following modes:
   * FI_CONTEXT for applications making uses of the experimental FI_EP_RDM capability.
 
 ### Addressing Formats
-Supported addressing formats include FI_SOCKADDR, FI_SOCKADDR_IN, FI_SOCKADDR_IN6,
-FI_SOCKADDR_IB
+Supported addressing formats include
+  * MSG and RDM EPs support:
+    FI_SOCKADDR, FI_SOCKADDR_IN, FI_SOCKADDR_IN6, FI_SOCKADDR_IB
+  * DGRAM supports:
+    FI_ADDR_IB_UD
 
 ### Progress
 Verbs provider supports FI_PROGRESS_AUTO: Asynchronous operations make forward
@@ -99,11 +105,8 @@ by the provider.
 ### Unsupported Features
 The following features are not supported in verbs provider:
 
-#### Unsupported Endpoint types
-FI_EP_DGRAM
-
 #### Unsupported Capabilities
-FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_TRIGGER, FI_MULTI_RECV, FI_RMA_EVENT
+FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_TRIGGER, FI_RMA_EVENT
 
 #### Other unsupported features
 Scalable endpoints, FABRIC_DIRECT
@@ -136,7 +139,8 @@ The support for fork in the provider has the following limitations:
 
 The verbs provider checks for the following environment variables.
 
-### Variables specific to MSG endpoints
+### Common variables:
+
 *FI_VERBS_TX_SIZE*
 :  Default maximum tx context size (default: 384)
 
@@ -144,10 +148,10 @@ The verbs provider checks for the following environment variables.
 :  Default maximum rx context size (default: 384)
 
 *FI_VERBS_TX_IOV_LIMIT*
-: Default maximum tx iov_limit (default: 4)
+: Default maximum tx iov_limit (default: 4). Note: RDM EP type supports only 1
 
 *FI_VERBS_RX_IOV_LIMIT*
-: Default maximum rx iov_limit (default: 4)
+: Default maximum rx iov_limit (default: 4). Note: RDM EP type supports only 1
 
 *FI_VERBS_INLINE_SIZE*
 :  Default maximum inline size. Actual inject size returned in fi_info may be greater (default: 64)
@@ -155,10 +159,23 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_MIN_RNR_TIMER*
 : Set min_rnr_timer QP attribute (0 - 31) (default: 12)
 
-### Variables specific to RDM endpoints
+*FI_VERBS_FORK_UNSAFE*
+: Enable safety of fork() system call for verbs provider. If you're sure that fork()
+  support isn't needed - No need to use this option, because extra memory will be
+  when enabling fork suppport (default: 0, i.e. Safety support is enabled)
 
-*FI_VERBS_IFACE*
-: The prefix or the full name of the network interface associated with the IB device (default: ib)
+*FI_VERBS_USE_ODP*
+: Enable On-Demand-Paging (ODP) experimental feature. The feature is supported only
+  on Mellanox OFED (default: 1)
+
+*FI_VERBS_CQREAD_BUNCH_SIZE*
+: The number of entries to be read from the verbs completion queue at a time (default: 8).
+
+*FI_VERBS_CQREAD_BUNCH_SIZE*
+: The number of entries to be read from the verbs completion queue at a time (default: 8).
+
+
+### Variables specific to RDM endpoints
 
 *FI_VERBS_RDM_BUFFER_NUM*
 : The number of pre-registered buffers for buffered operations between the endpoints,
@@ -170,9 +187,6 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_RDM_RNDV_SEG_SIZE*
 : The segment size for zero copy protocols (bytes)(default: 1073741824).
 
-*FI_VERBS_RDM_CQREAD_BUNCH_SIZE*
-: The number of entries to be read from the verbs completion queue at a time (default: 8).
-
 *FI_VERBS_RDM_THREAD_TIMEOUT*
 : The wake up timeout of the helper thread (usec) (default: 100).
 
@@ -180,6 +194,19 @@ The verbs provider checks for the following environment variables.
 : The operation code that will be used for eager messaging. Only IBV_WR_SEND and
   IBV_WR_RDMA_WRITE_WITH_IMM are supported. The last one is not applicable for iWarp.
   (default: IBV_WR_SEND)
+
+### Variables specific to DGRAM endpoints
+
+*FI_VERBS_DGRAM_USE_NAME_SERVER*
+: The option that enables/disables OFI Name Server thread. The NS thread is used to
+  resolve IP-addresses to provider specific addresses (default: 1, if "OMPI_COMM_WORLD_RANK"
+  and "PMI_RANK" environment variables aren't defined)
+
+*FI_VERBS_NAME_SERVVER_PORT*
+: The port on which Name Server thread listens incoming connections and requests (default: 5678)
+
+*FI_*
+: 
 
 ### Environment variables notes
 The fi_info utility would give the up-to-date information on environment variables:

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -65,10 +65,6 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.dgram			= {
 		.use_name_server	= 1,
 		.name_server_port	= 5678,
-		.device = {
-			.port_number	= 0, /* 0 - means all available ports */
-			.name		= NULL,
-		},
 	},
 };
 
@@ -722,36 +718,19 @@ static int fi_ibv_read_params(void)
 	if (fi_ibv_get_param_bool("dgram_use_name_server", "The option that "
 				  "enables/disables OFI Name Server thread that is used "
 				  "to resolve IP-addresses to provider specific "
-				  "addresses. If MPI is used, the NS is disenabled "
+				  "addresses. If MPI is used, the NS is disabled "
 				  "by default.", &fi_ibv_gl_data.dgram.use_name_server)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of dgram_use_name_server\n");
 		return -FI_EINVAL;
 	}
 	if (fi_ibv_get_param_int("dgram_name_server_port", "The port on which Name Server "
-				 "thread listens incoming connection and requestes.",
+				 "thread listens incoming connections and requestes.",
 				 &fi_ibv_gl_data.dgram.name_server_port) ||
 	    (fi_ibv_gl_data.dgram.name_server_port < 0 ||
 	     fi_ibv_gl_data.dgram.name_server_port > 65535)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of dgram_name_server_port\n");
-		return -FI_EINVAL;
-	}
-	if (fi_ibv_get_param_int("dgram_device_port_number", "Port number of device to be "
-				 "only used for generating fi_info. The parameter is "
-				 "ignored if device name wasn't specified.",
-				 &fi_ibv_gl_data.dgram.device.port_number) ||
-	    (fi_ibv_gl_data.dgram.device.port_number < 0 ||
-	     fi_ibv_gl_data.dgram.device.port_number > 31)) {
-		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of dgram_device_port_number\n");
-		return -FI_EINVAL;
-	}
-	if (fi_ibv_get_param_str("dgram_device_name", "The name of device to be "
-				 "only used for generating fi_info.",
-				 &fi_ibv_gl_data.dgram.device.name)) {
-		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of dgram_device_name\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -174,10 +174,6 @@ extern struct fi_ibv_gl_data {
 	struct {
 		int	use_name_server;
 		int	name_server_port;
-		struct {
-			int	port_number;
-			char	*name;
-		} device;
 	} dgram;
 } fi_ibv_gl_data;
 


### PR DESCRIPTION
This patch is prepared as a continuation of the verbs/DGRAM EP type enabling to verbs provider.
The intent of this PR is:
- Update verbs' man page to mention DGRAM EP type
- Fix some code typos and remove unused env varibale for the verbs/DGRAM