### PR TITLE
prov/verbs: Improve an output for the getinfo

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -160,6 +160,7 @@ int fi_ibv_av_entry_alloc(struct fi_ibv_domain *domain,
 	HASH_ADD(hh, domain->rdm_cm->av_hash, addr,
 		 FI_IBV_RDM_DFLT_ADDRLEN, (*av_entry));
 	ofi_atomic_initialize32(&(*av_entry)->sends_outgoing, 0);
+	ofi_atomic_initialize32(&(*av_entry)->recv_preposted, 0);
 	pthread_mutex_init(&(*av_entry)->conn_lock, NULL);
 
 	return ret;


### PR DESCRIPTION
This patch addresses the following:
- Add atomic initialization that has been missed during re-basing of th #3409 
- Make an output more informative to improve troubleshooting. Btw, seems the previous check maybe an issue in case of the compiler optimization. The second condition can be dropped by compiler if the `fi_ibv_handle_sock_addr` success, i.e. `fi_ibv_handle_ib_ud_addr` is dropped.