### PR TITLE
prov/gni: Enable smrn tests when kdreg is present

### DIFF
--- a/prov/gni/test/smrn.c
+++ b/prov/gni/test/smrn.c
@@ -42,6 +42,12 @@
 
 #define GNIX_DEFAULT_RQ_CNT 4
 
+#if HAVE_KDREG
+# define KDREG_CHECK false
+#else
+# define KDREG_CHECK true
+#endif
+
 static struct gnix_smrn *smrn;
 static struct gnix_smrn_rq *rqs[GNIX_DEFAULT_RQ_CNT];
 static void **memory_regions;
@@ -89,7 +95,8 @@ static void smrn_teardown(void)
 
 TestSuite(smrn,
 	  .init = smrn_setup,
-	  .fini = smrn_teardown);
+	  .fini = smrn_teardown,
+	  .disabled = KDREG_CHECK);
 
 #define RQ_ENTRIES 21
 #define REGIONS (GNIX_DEFAULT_RQ_CNT * RQ_ENTRIES)


### PR DESCRIPTION
Enables test when the pre-requisite library and functionality is
present.

upstream merge of ofi-cray/libfabric-cray#1416

Signed-off-by: James Swaro <jswaro@cray.com>
(cherry picked from commit ofi-cray/libfabric-cray@e9dce76227f91fb97b03f0b293408d81925d46a7)