### PR TITLE
prov/verbs: fix return code in fi_ibv_getifaddrs

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -803,6 +803,7 @@ static int fi_ibv_getifaddrs(struct dlist_entry *verbs_devs)
 			VERBS_WARN(FI_LOG_FABRIC,
 				   "inet_ntop failed: %s(%d)\n",
 				   strerror(errno), errno);
+			ret = -errno;
 			goto err1;
 		}
 


### PR DESCRIPTION
When inet_ntop fails in fi_ibv_getifaddrs, 0 would have been returned
indicating success. Return an error code instead.

Signed-off-by: Frank Zago <fzago@cray.com>