### PR TITLE
prov/verbs: Fix an incorrect return value for the cq_readerr

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -220,6 +220,8 @@ fi_ibv_rdm_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 		}
 
 		ret++;
+	} else {
+		return -FI_EAGAIN;
 	}
 
 	return ret;

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -259,6 +259,7 @@ static ssize_t fi_ibv_rdm_cancel(fid_t fid, void *ctx)
 			fi_ibv_rdm_move_to_errcq(ep_rdm->fi_rcq, request,
 						 FI_ECANCELED);
 		}
+		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
 	}
 
 	return err;


### PR DESCRIPTION
The intent of this patch is to fix `fi_recv_cancel` tests from fabtests.

There are two problems that this PR is having to fix:
- The incorrect return value for `fi_cq_readerr` (it should be `-FI_EAGAIN` instead `FI_SUCCESS` in case of empty Error list)
- Missing transition to right state for the `fi_cancel()`: The internal request object should be switched to `READY_TO_FREE` state. This fixes missing util_buf_release call for this object.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>