### PR TITLE
prov/verbs: Optimize multi-recv path and avoid usage of global memory pools

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_cq_ep_rdm.c
@@ -37,15 +37,6 @@
 #include "../fi_verbs.h"
 #include "verbs_queuing.h"
 
-struct util_buf_pool *fi_ibv_rdm_request_pool;
-struct util_buf_pool *fi_ibv_rdm_postponed_pool;
-
-/*
- * extra buffer size equal eager buffer size, it is used for any intermediate
- * needs like unexpected recv, pack/unpack noncontig messages, etc
- */
-struct util_buf_pool *fi_ibv_rdm_extra_buffers_pool;
-
 static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
                                              size_t count, fi_addr_t * src_addr)
 {
@@ -77,7 +68,9 @@ static ssize_t fi_ibv_rdm_tagged_cq_readfrom(struct fid_cq *cq, void *buf,
 		if (cq_entry->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
 			FI_IBV_RDM_DBG_REQUEST("to_pool: ", cq_entry, 
 						FI_LOG_DEBUG);
-			util_buf_release(fi_ibv_rdm_request_pool, cq_entry);
+			util_buf_release(
+				cq_entry->ep->fi_ibv_rdm_request_pool,
+				cq_entry);
 		} else {
 			cq_entry->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
 		}
@@ -214,7 +207,9 @@ fi_ibv_rdm_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 		if (err_request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
 			FI_IBV_RDM_DBG_REQUEST("to_pool: ", err_request,
 						FI_LOG_DEBUG);
-			util_buf_release(fi_ibv_rdm_request_pool, err_request);
+			util_buf_release(
+				err_request->ep->fi_ibv_rdm_request_pool,
+				err_request);
 		} else {
 			err_request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
 		}

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -501,6 +501,7 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 	fi_ibv_rdm_clean_queues(ep);
 
 	util_buf_pool_destroy(ep->fi_ibv_rdm_request_pool);
+	util_buf_pool_destroy(ep->fi_ibv_rdm_multi_request_pool);
 	util_buf_pool_destroy(ep->fi_ibv_rdm_extra_buffers_pool);
 	util_buf_pool_destroy(ep->fi_ibv_rdm_postponed_pool);
 
@@ -648,12 +649,18 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 		sizeof(struct fi_ibv_rdm_request),
 		FI_IBV_RDM_MEM_ALIGNMENT, 0, 100);
 
+	_ep->fi_ibv_rdm_multi_request_pool = util_buf_pool_create(
+		sizeof(struct fi_ibv_rdm_multi_request),
+		FI_IBV_RDM_MEM_ALIGNMENT, 0, 100);
+
 	_ep->fi_ibv_rdm_postponed_pool = util_buf_pool_create(
 		sizeof(struct fi_ibv_rdm_postponed_entry),
 		FI_IBV_RDM_MEM_ALIGNMENT, 0, 100);
 
 	_ep->fi_ibv_rdm_extra_buffers_pool = util_buf_pool_create(
 		_ep->buff_len, FI_IBV_RDM_MEM_ALIGNMENT, 0, 100);
+
+	dlist_init(&_ep->fi_ibv_rdm_multi_recv_list);
 
 	_ep->max_inline_rc = 
 		fi_ibv_rdm_find_max_inline(_ep->domain->pd, _ep->domain->verbs);

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -46,8 +46,6 @@
 extern struct fi_ops_tagged fi_ibv_rdm_tagged_ops;
 extern struct fi_ops_cm fi_ibv_rdm_tagged_ep_cm_ops;
 extern struct dlist_entry fi_ibv_rdm_posted_queue;
-extern struct util_buf_pool* fi_ibv_rdm_request_pool;
-extern struct util_buf_pool* fi_ibv_rdm_extra_buffers_pool;
 extern struct fi_provider fi_ibv_prov;
 extern struct fi_ops_msg fi_ibv_rdm_ep_msg_ops;
 extern struct fi_ops_rma fi_ibv_rdm_ep_rma_ops;
@@ -502,9 +500,9 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 	/* TODO: move queues & related pools cleanup to close CQ*/
 	fi_ibv_rdm_clean_queues(ep);
 
-	util_buf_pool_destroy(fi_ibv_rdm_request_pool);
-	util_buf_pool_destroy(fi_ibv_rdm_extra_buffers_pool);
-	util_buf_pool_destroy(fi_ibv_rdm_postponed_pool);
+	util_buf_pool_destroy(ep->fi_ibv_rdm_request_pool);
+	util_buf_pool_destroy(ep->fi_ibv_rdm_extra_buffers_pool);
+	util_buf_pool_destroy(ep->fi_ibv_rdm_postponed_pool);
 
 	fi_freeinfo(ep->info);
 
@@ -646,15 +644,15 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 	VERBS_INFO(FI_LOG_EP_CTRL, "recv preposted threshold: %d\n",
 		   _ep->recv_preposted_threshold);
 
-	fi_ibv_rdm_request_pool = util_buf_pool_create(
+	_ep->fi_ibv_rdm_request_pool = util_buf_pool_create(
 		sizeof(struct fi_ibv_rdm_request),
 		FI_IBV_RDM_MEM_ALIGNMENT, 0, 100);
 
-	fi_ibv_rdm_postponed_pool = util_buf_pool_create(
+	_ep->fi_ibv_rdm_postponed_pool = util_buf_pool_create(
 		sizeof(struct fi_ibv_rdm_postponed_entry),
 		FI_IBV_RDM_MEM_ALIGNMENT, 0, 100);
 
-	fi_ibv_rdm_extra_buffers_pool = util_buf_pool_create(
+	_ep->fi_ibv_rdm_extra_buffers_pool = util_buf_pool_create(
 		_ep->buff_len, FI_IBV_RDM_MEM_ALIGNMENT, 0, 100);
 
 	_ep->max_inline_rc = 

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -37,15 +37,6 @@
 #include <fi_list.h>
 #include "verbs_rdm.h"
 
-/*
- * managing of queues
- */
-
-extern struct dlist_entry fi_ibv_rdm_unexp_queue;
-/* TODO: implement posted recv queue per connection */
-extern struct dlist_entry fi_ibv_rdm_posted_queue;
-extern struct dlist_entry fi_ibv_rdm_postponed_queue;
-
 static inline void
 fi_ibv_rdm_move_to_cq(struct fi_ibv_rdm_cq *cq,
 		      struct fi_ibv_rdm_request *request)
@@ -106,11 +97,12 @@ fi_ibv_rdm_take_first_from_errcq(struct fi_ibv_rdm_cq *cq)
 }
 
 static inline void
-fi_ibv_rdm_move_to_unexpected_queue(struct fi_ibv_rdm_request *request)
+fi_ibv_rdm_move_to_unexpected_queue(struct fi_ibv_rdm_request *request,
+				    struct fi_ibv_rdm_ep *ep)
 {
 	FI_IBV_RDM_DBG_REQUEST("move_to_unexpected_queue: ", request,
 				FI_LOG_DEBUG);
-	dlist_insert_tail(&request->queue_entry, &fi_ibv_rdm_unexp_queue);
+	dlist_insert_tail(&request->queue_entry, &ep->fi_ibv_rdm_unexp_queue);
 #if ENABLE_DEBUG
 	request->minfo.conn->unexp_counter++;
 #endif // ENABLE_DEBUG
@@ -125,11 +117,11 @@ fi_ibv_rdm_remove_from_unexp_queue(struct fi_ibv_rdm_request *request)
 }
 
 static inline struct fi_ibv_rdm_request *
-fi_ibv_rdm_take_first_from_unexp_queue()
+fi_ibv_rdm_take_first_from_unexp_queue(struct fi_ibv_rdm_ep *ep)
 {
-	if (!dlist_empty(&fi_ibv_rdm_unexp_queue)) {
+	if (!dlist_empty(&ep->fi_ibv_rdm_unexp_queue)) {
 		struct fi_ibv_rdm_request *entry =
-			container_of(fi_ibv_rdm_unexp_queue.next,
+			container_of(ep->fi_ibv_rdm_unexp_queue.next,
 				     struct fi_ibv_rdm_request, queue_entry);
 		fi_ibv_rdm_remove_from_unexp_queue(entry);
 		return entry;
@@ -142,7 +134,7 @@ fi_ibv_rdm_move_to_posted_queue(struct fi_ibv_rdm_request *request,
 				struct fi_ibv_rdm_ep *ep)
 {
 	FI_IBV_RDM_DBG_REQUEST("move_to_posted_queue: ", request, FI_LOG_DEBUG);
-	dlist_insert_tail(&request->queue_entry, &fi_ibv_rdm_posted_queue);
+	dlist_insert_tail(&request->queue_entry, &ep->fi_ibv_rdm_posted_queue);
 	ofi_atomic_inc32(&ep->posted_recvs);
 #if ENABLE_DEBUG
 	if (request->minfo.conn) {
@@ -164,9 +156,9 @@ fi_ibv_rdm_remove_from_posted_queue(struct fi_ibv_rdm_request *request,
 static inline struct fi_ibv_rdm_request *
 fi_ibv_rdm_take_first_from_posted_queue(struct fi_ibv_rdm_ep* ep)
 {
-	if (!dlist_empty(&fi_ibv_rdm_posted_queue)) {
+	if (!dlist_empty(&ep->fi_ibv_rdm_posted_queue)) {
 		struct fi_ibv_rdm_request *entry =
-			container_of(fi_ibv_rdm_posted_queue.next,
+			container_of(ep->fi_ibv_rdm_posted_queue.next,
 				     struct fi_ibv_rdm_request, queue_entry);
 		fi_ibv_rdm_remove_from_posted_queue(entry, ep);
 		return entry;
@@ -195,7 +187,7 @@ fi_ibv_rdm_move_to_postponed_queue(struct fi_ibv_rdm_request *request)
 		conn->postponed_entry = entry;
 
 		dlist_insert_tail(&entry->queue_entry,
-				  &fi_ibv_rdm_postponed_queue);
+				  &conn->ep->fi_ibv_rdm_postponed_queue);
 	}
 	dlist_insert_tail(&request->queue_entry,
 			  &conn->postponed_requests_head);
@@ -264,11 +256,11 @@ fi_ibv_rdm_remove_from_postponed_queue(struct fi_ibv_rdm_request *request)
 }
 
 static inline struct fi_ibv_rdm_request *
-fi_ibv_rdm_take_first_from_postponed_queue()
+fi_ibv_rdm_take_first_from_postponed_queue(struct fi_ibv_rdm_ep *ep)
 {
-	if (!dlist_empty(&fi_ibv_rdm_postponed_queue)) {
+	if (!dlist_empty(&ep->fi_ibv_rdm_postponed_queue)) {
 		struct fi_ibv_rdm_postponed_entry *entry = 
-			container_of(fi_ibv_rdm_postponed_queue.next,
+			container_of(ep->fi_ibv_rdm_postponed_queue.next,
 				struct fi_ibv_rdm_postponed_entry, queue_entry);
 
 		if (!dlist_empty(&entry->conn->postponed_requests_head)) {
@@ -287,10 +279,12 @@ fi_ibv_rdm_take_first_from_postponed_queue()
 }
 
 static inline struct fi_ibv_rdm_request *
-fi_ibv_rdm_take_first_match_from_postponed_queue(dlist_func_t *match, const void *arg)
+fi_ibv_rdm_take_first_match_from_postponed_queue(dlist_func_t *match,
+						 const void *arg,
+						 struct fi_ibv_rdm_ep *ep)
 {
 	struct dlist_entry *i, *j;
-	dlist_foreach((&fi_ibv_rdm_postponed_queue), i) {
+	dlist_foreach((&ep->fi_ibv_rdm_postponed_queue), i) {
 		 struct fi_ibv_rdm_postponed_entry *entry = 
 			container_of(i, struct fi_ibv_rdm_postponed_entry,
 				     queue_entry);

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -204,6 +204,34 @@ fi_ibv_rdm_move_to_postponed_queue(struct fi_ibv_rdm_request *request)
 }
 
 static inline void
+fi_ibv_rdm_remove_from_multi_recv_list(struct fi_ibv_rdm_multi_request *request,
+				       struct fi_ibv_rdm_ep *ep)
+{
+	dlist_remove(&request->list_entry);
+}
+
+static inline void
+fi_ibv_rdm_add_to_multi_recv_list(struct fi_ibv_rdm_multi_request *request,
+				  struct fi_ibv_rdm_ep *ep)
+{
+	dlist_insert_tail(&request->list_entry,
+			  &ep->fi_ibv_rdm_multi_recv_list);
+}
+
+static inline struct fi_ibv_rdm_multi_request *
+fi_ibv_rdm_take_first_from_multi_recv_list(struct fi_ibv_rdm_ep *ep)
+{
+	if (!dlist_empty(&ep->fi_ibv_rdm_multi_recv_list)) {
+		struct fi_ibv_rdm_multi_request *entry;
+		dlist_pop_front(&ep->fi_ibv_rdm_multi_recv_list,
+				struct fi_ibv_rdm_multi_request,
+				entry, list_entry);
+		return entry;
+	}
+	return NULL;
+}
+
+static inline void
 fi_ibv_rdm_remove_from_postponed_queue(struct fi_ibv_rdm_request *request)
 {
 	FI_IBV_RDM_DBG_REQUEST("remove_from_postponed_queue: ", request,

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -46,8 +46,6 @@ extern struct dlist_entry fi_ibv_rdm_unexp_queue;
 extern struct dlist_entry fi_ibv_rdm_posted_queue;
 extern struct dlist_entry fi_ibv_rdm_postponed_queue;
 
-extern struct util_buf_pool* fi_ibv_rdm_postponed_pool;
-
 static inline void
 fi_ibv_rdm_move_to_cq(struct fi_ibv_rdm_cq *cq,
 		      struct fi_ibv_rdm_request *request)
@@ -187,7 +185,7 @@ fi_ibv_rdm_move_to_postponed_queue(struct fi_ibv_rdm_request *request)
 
 	if (dlist_empty(&conn->postponed_requests_head)) {
 		struct fi_ibv_rdm_postponed_entry *entry =
-			util_buf_alloc(fi_ibv_rdm_postponed_pool);
+			util_buf_alloc(conn->ep->fi_ibv_rdm_postponed_pool);
 		if (OFI_UNLIKELY(!entry)) {
 			VERBS_WARN(FI_LOG_EP_DATA, "Unable to alloc buffer");
 			return -FI_ENOMEM;
@@ -231,7 +229,7 @@ fi_ibv_rdm_remove_from_postponed_queue(struct fi_ibv_rdm_request *request)
 		conn->postponed_entry->queue_entry.prev = NULL;
 		conn->postponed_entry->conn = NULL;
 
-		util_buf_release(fi_ibv_rdm_postponed_pool,
+		util_buf_release(conn->ep->fi_ibv_rdm_postponed_pool,
 				 conn->postponed_entry);
 		conn->postponed_entry = NULL;
 	}

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -295,6 +295,9 @@ struct fi_ibv_rdm_ep {
 	 */
 	struct util_buf_pool	*fi_ibv_rdm_extra_buffers_pool;
 
+	struct dlist_entry	fi_ibv_rdm_posted_queue;
+	struct dlist_entry	fi_ibv_rdm_postponed_queue;
+	struct dlist_entry	fi_ibv_rdm_unexp_queue;
 	struct dlist_entry	fi_ibv_rdm_multi_recv_list;
 
 	size_t			addrlen;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -141,11 +141,13 @@ struct fi_ibv_rdm_rndv_header {
 
 struct fi_ibv_rdm_multi_request {
 	/* working request, will be renewed for every data arriving */
-	struct fi_ibv_rdm_request *prepost;
-	uint8_t *buf;
-	uint64_t len;
-	uint64_t offset;
-	uint64_t min_size;
+	struct dlist_entry		list_entry;
+	struct fi_ibv_rdm_request	*prepost;
+	struct fi_ibv_rdm_ep		*ep;
+	uint8_t				*buf;
+	uint64_t			len;
+	uint64_t			offset;
+	uint64_t			min_size;
 };
 
 struct fi_ibv_rdm_request {
@@ -271,32 +273,35 @@ struct fi_ibv_rdm_cntr {
 
 struct fi_ibv_rdm_ep {
 	struct fid_ep ep_fid;
-	struct fi_ibv_domain*	domain;
+	struct fi_ibv_domain	*domain;
 	struct slist_entry	list_entry;
-	struct fi_ibv_rdm_cq*	fi_scq;
-	struct fi_ibv_rdm_cq*	fi_rcq;
+	struct fi_ibv_rdm_cq	*fi_scq;
+	struct fi_ibv_rdm_cq	*fi_rcq;
 
-	struct fi_ibv_rdm_cntr*	send_cntr;
-	struct fi_ibv_rdm_cntr*	recv_cntr;
-	struct fi_ibv_rdm_cntr*	read_cntr;
-	struct fi_ibv_rdm_cntr*	write_cntr;
+	struct fi_ibv_rdm_cntr	*send_cntr;
+	struct fi_ibv_rdm_cntr	*recv_cntr;
+	struct fi_ibv_rdm_cntr	*read_cntr;
+	struct fi_ibv_rdm_cntr	*write_cntr;
 
-	struct fi_info*	info;
+	struct fi_info	*info;
 
-	struct util_buf_pool *fi_ibv_rdm_request_pool;
-	struct util_buf_pool *fi_ibv_rdm_postponed_pool;
+	struct util_buf_pool	*fi_ibv_rdm_request_pool;
+	struct util_buf_pool	*fi_ibv_rdm_multi_request_pool;
+	struct util_buf_pool	*fi_ibv_rdm_postponed_pool;
 	/*
 	 * extra buffer size equal eager buffer size,
 	 * it is used for any intermediate needs like
 	 * unexpected recv, pack/unpack noncontig messages, etc
 	 */
-	struct util_buf_pool *fi_ibv_rdm_extra_buffers_pool;
+	struct util_buf_pool	*fi_ibv_rdm_extra_buffers_pool;
+
+	struct dlist_entry	fi_ibv_rdm_multi_recv_list;
 
 	size_t			addrlen;
-	struct rdma_addrinfo*	rai;
+	struct rdma_addrinfo	*rai;
 	struct sockaddr_in	my_addr;
 
-	struct fi_ibv_av*	av;
+	struct fi_ibv_av	*av;
 	int		tx_selective_completion;
 	int 		rx_selective_completion;
 	size_t 		min_multi_recv_size;
@@ -308,8 +313,8 @@ struct fi_ibv_rdm_ep {
 	 * It must generate work completion in receive CQ
 	 */
 	enum ibv_wr_opcode	eopcode;
-	struct ibv_cq*		scq;
-	struct ibv_cq*		rcq;
+	struct ibv_cq		*scq;
+	struct ibv_cq		*rcq;
 
 	int	buff_len;
 	int	n_buffs;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -40,7 +40,6 @@
 #include "verbs_queuing.h"
 
 extern struct fi_provider fi_ibv_prov;
-extern struct util_buf_pool* fi_ibv_rdm_request_pool;
 
 static struct ibv_mr *
 fi_ibv_rdm_alloc_and_reg(struct fi_ibv_rdm_ep *ep,
@@ -809,7 +808,7 @@ fi_ibv_rdm_process_timewait_exit_event(struct rdma_cm_event *event,
 		(request = fi_ibv_rdm_take_first_from_posted_queue(ep))) {
 		request->context->internal[0] = NULL;
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
 }
 

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -35,9 +35,6 @@
 
 #include "verbs_rdm.h"
 
-extern struct util_buf_pool *fi_ibv_rdm_request_pool;
-extern struct util_buf_pool *fi_ibv_rdm_extra_buffers_pool;
-
 static ssize_t fi_ibv_rdm_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 				  uint64_t flags)
 {
@@ -71,12 +68,13 @@ static ssize_t fi_ibv_rdm_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		.ep = ep_rdm
 	};
 	struct fi_ibv_rdm_request *request =
-		util_buf_alloc(fi_ibv_rdm_request_pool);
+		util_buf_alloc(ep_rdm->fi_ibv_rdm_request_pool);
 	if (OFI_UNLIKELY(!request))
 		return -FI_EAGAIN;
-	fi_ibv_rdm_zero_request(request);
-	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
+	fi_ibv_rdm_zero_request(request);
+	request->ep = ep_rdm;
+	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 	ret = fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_RECV_START,
 				  &recv_data);
 
@@ -166,7 +164,7 @@ static ssize_t fi_ibv_rdm_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		 * to send immediately
 		 */
 		sdata.buf.iovec_arr =
-			util_buf_alloc(fi_ibv_rdm_extra_buffers_pool);
+			util_buf_alloc(ep_rdm->fi_ibv_rdm_extra_buffers_pool);
 		for (i = 0; i < msg->iov_count; i++) {
 			sdata.buf.iovec_arr[i].iov_base = msg->msg_iov[i].iov_base;
 			sdata.buf.iovec_arr[i].iov_len = msg->msg_iov[i].iov_len;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -43,10 +43,6 @@
 
 struct fi_ibv_rdm_cq fi_ibv_rdm_comp_queue;
 
-DEFINE_LIST(fi_ibv_rdm_posted_queue);
-DEFINE_LIST(fi_ibv_rdm_unexp_queue);
-DEFINE_LIST(fi_ibv_rdm_postponed_queue);
-
 static inline int fi_ibv_rdm_tagged_poll_send(struct fi_ibv_rdm_ep *ep);
 
 int
@@ -476,7 +472,7 @@ fi_ibv_rdm_process_recv(struct fi_ibv_rdm_ep *ep, struct fi_ibv_rdm_conn *conn,
 		}
 
 		struct dlist_entry *found_entry =
-			dlist_find_first_match(&fi_ibv_rdm_posted_queue,
+			dlist_find_first_match(&ep->fi_ibv_rdm_posted_queue,
 						fi_ibv_rdm_req_match_by_info,
 						&minfo);
 
@@ -710,7 +706,7 @@ static inline int fi_ibv_rdm_tagged_poll_send(struct fi_ibv_rdm_ep *ep)
 
 	struct fi_ibv_rdm_tagged_send_ready_data data = { .ep = ep };
 	struct dlist_entry *item;
-	dlist_foreach((&fi_ibv_rdm_postponed_queue), item) {
+	dlist_foreach((&ep->fi_ibv_rdm_postponed_queue), item) {
 		if (fi_ibv_rdm_postponed_process(item, &data)) {
 			/* we can't process all postponed items till foreach */
 			/* implementation is not safety for removing during  */

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -43,9 +43,6 @@
 
 struct fi_ibv_rdm_cq fi_ibv_rdm_comp_queue;
 
-extern struct util_buf_pool *fi_ibv_rdm_request_pool;
-extern struct util_buf_pool *fi_ibv_rdm_extra_buffers_pool;
-
 DEFINE_LIST(fi_ibv_rdm_posted_queue);
 DEFINE_LIST(fi_ibv_rdm_unexp_queue);
 DEFINE_LIST(fi_ibv_rdm_postponed_queue);
@@ -145,10 +142,11 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 	};
 
 	struct fi_ibv_rdm_request *request =
-		util_buf_alloc(fi_ibv_rdm_request_pool);
+		util_buf_alloc(ep_rdm->fi_ibv_rdm_request_pool);
 	if (OFI_UNLIKELY(!request))
 		return -FI_EAGAIN;
 	fi_ibv_rdm_zero_request(request);
+	request->ep = ep_rdm;
 	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 	if (flags & FI_PEEK) {
@@ -323,7 +321,7 @@ static ssize_t fi_ibv_rdm_tagged_sendmsg(struct fid_ep *ep,
 		container_of(ep, struct fi_ibv_rdm_ep, ep_fid);
 
 	struct fi_ibv_rdm_send_start_data sdata = {
-		.ep_rdm = container_of(ep, struct fi_ibv_rdm_ep, ep_fid),
+		.ep_rdm = ep_rdm,
 		.conn = ep_rdm->av->addr_to_conn(ep_rdm, msg->addr),
 		.data_len = 0,
 		.context = msg->context,
@@ -362,7 +360,7 @@ static ssize_t fi_ibv_rdm_tagged_sendmsg(struct fid_ep *ep,
 		 * to send immediately
 		 */
 		sdata.buf.iovec_arr =
-			util_buf_alloc(fi_ibv_rdm_extra_buffers_pool);
+			util_buf_alloc(ep_rdm->fi_ibv_rdm_extra_buffers_pool);
 		for (i = 0; i < msg->iov_count; i++) {
 			sdata.buf.iovec_arr[i].iov_base = msg->msg_iov[i].iov_base;
 			sdata.buf.iovec_arr[i].iov_len = msg->msg_iov[i].iov_len;
@@ -492,11 +490,11 @@ fi_ibv_rdm_process_recv(struct fi_ibv_rdm_ep *ep, struct fi_ibv_rdm_conn *conn,
 
 			request = found_request;
 		} else {
-			request = util_buf_alloc(fi_ibv_rdm_request_pool);
+			request = util_buf_alloc(ep->fi_ibv_rdm_request_pool);
 			if (OFI_UNLIKELY(!request))
 				return;
 			fi_ibv_rdm_zero_request(request);
-
+			request->ep = ep;
 			FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request,
 						FI_LOG_DEBUG);
 		}

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -41,8 +41,6 @@
 #include "verbs_queuing.h"
 #include "verbs_tagged_ep_rdm_states.h"
 
-struct fi_ibv_rdm_cq fi_ibv_rdm_comp_queue;
-
 static inline int fi_ibv_rdm_tagged_poll_send(struct fi_ibv_rdm_ep *ep);
 
 int

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -539,10 +539,9 @@ fi_ibv_rdm_try_unexp_recv(struct fi_ibv_rdm_request *request,
 
 	do {
 		found_entry =
-			dlist_find_first_match(&fi_ibv_rdm_unexp_queue,
-						fi_ibv_rdm_req_match_by_info3,
-						&rdata->peek_data);
-
+			dlist_find_first_match(&rdata->ep->fi_ibv_rdm_unexp_queue,
+					       fi_ibv_rdm_req_match_by_info3,
+					       &rdata->peek_data);
 		if (found_entry) {
 			ret = FI_SUCCESS;
 			found_request =
@@ -665,9 +664,9 @@ fi_ibv_rdm_tagged_peek_request(struct fi_ibv_rdm_request *request, void *data)
 	struct fi_ibv_rdm_tagged_recv_start_data *p = data;
 	struct fi_ibv_rdm_tagged_peek_data *peek_data = &p->peek_data;
 	struct dlist_entry *found_entry =
-		dlist_find_first_match(&fi_ibv_rdm_unexp_queue,
-					fi_ibv_rdm_req_match_by_info2,
-					&peek_data->minfo);
+		dlist_find_first_match(&p->ep->fi_ibv_rdm_unexp_queue,
+				       fi_ibv_rdm_req_match_by_info2,
+				       &peek_data->minfo);
 
 	/* TODO: to check behaviour for multi recv */
 	assert(!(peek_data->flags & FI_MULTI_RECV));
@@ -820,7 +819,7 @@ fi_ibv_rdm_init_unexp_recv_request(struct fi_ibv_rdm_request *request, void *dat
 		ret = -FI_EOTHER;
 	}
 
-	fi_ibv_rdm_move_to_unexpected_queue(request);
+	fi_ibv_rdm_move_to_unexpected_queue(request, p->ep);
 fn:
 	FI_IBV_RDM_HNDL_REQ_LOG_OUT();
 	return ret;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -39,10 +39,6 @@
 #include "verbs_queuing.h"
 #include "verbs_tagged_ep_rdm_states.h"
 
-extern struct dlist_entry fi_ibv_rdm_postponed_queue;
-extern struct util_buf_pool *fi_ibv_rdm_request_pool;
-extern struct util_buf_pool *fi_ibv_rdm_extra_buffers_pool;
-
 typedef ssize_t (*fi_ep_rdm_request_handler_t)
 	(struct fi_ibv_rdm_request *request, void *data);
 
@@ -233,13 +229,15 @@ fi_ibv_rdm_eager_send_lc(struct fi_ibv_rdm_request *request,
 	FI_IBV_RDM_DEC_SIG_POST_COUNTERS(request->minfo.conn, p->ep);
 
 	if (request->iov_count) {
-		util_buf_release(fi_ibv_rdm_extra_buffers_pool,
-				 request->iovec_arr);
+		util_buf_release(
+			request->ep->fi_ibv_rdm_extra_buffers_pool,
+			request->iovec_arr);
 	}
 
 	if (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(request->ep->fi_ibv_rdm_request_pool,
+				 request);
 	} else {
 		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
 	}
@@ -366,7 +364,8 @@ fi_ibv_rdm_rndv_rts_lc(struct fi_ibv_rdm_request *request,
 		request->state.eager = FI_IBV_STATE_EAGER_SEND_END;
 	} else { /* (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) */
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(request->ep->fi_ibv_rdm_request_pool,
+				 request);
 	}
 
 	FI_IBV_RDM_HNDL_REQ_LOG_OUT();
@@ -409,7 +408,9 @@ fi_ibv_rdm_rndv_end(struct fi_ibv_rdm_request *request,
 		fi_ibv_rdm_move_to_cq(p->ep->fi_scq, request);
 	} else if (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(
+			request->ep->fi_ibv_rdm_request_pool,
+			request);
 	}
 
 	FI_IBV_RDM_HNDL_REQ_LOG_OUT();
@@ -431,8 +432,9 @@ fi_ibv_rdm_copy_unexp_request(struct fi_ibv_rdm_request *request,
 			   unexp->len, request->len, request->minfo.conn,
 			   request->minfo.tag, request->minfo.tagmask);
 
-		util_buf_release(fi_ibv_rdm_extra_buffers_pool,
-				 unexp->unexp_rbuf);
+		util_buf_release(
+			unexp->ep->fi_ibv_rdm_extra_buffers_pool,
+			unexp->unexp_rbuf);
 		ret = -FI_ETRUNC;
 		return ret;
 	}
@@ -477,13 +479,14 @@ fi_ibv_rdm_repost_multi_recv(struct fi_ibv_rdm_request *request,
 	struct fi_ibv_rdm_multi_request *parent;
 	struct fi_ibv_rdm_request *prepost;
 
-	if (!(prepost = util_buf_alloc(fi_ibv_rdm_request_pool))) {
+	if (!(prepost = util_buf_alloc(ep->fi_ibv_rdm_request_pool))) {
 		VERBS_WARN(FI_LOG_EP_DATA, "Unable to allocate memory for "
 			   "multi recv prepost request\n");
 		return NULL;
 	}
 
 	fi_ibv_rdm_zero_request(prepost);
+	prepost->ep = ep;
 	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", prepost, FI_LOG_DEBUG);
 	FI_IBV_RDM_DBG_REQUEST("repost from: ", request, FI_LOG_DEBUG);
 
@@ -568,7 +571,9 @@ fi_ibv_rdm_try_unexp_recv(struct fi_ibv_rdm_request *request,
 						FI_IBV_STATE_EAGER_RECV_WAIT4RECV)));
 
 			FI_IBV_RDM_DBG_REQUEST("to_pool: ", found_request, FI_LOG_DEBUG);
-			util_buf_release(fi_ibv_rdm_request_pool, found_request);
+			util_buf_release(
+				found_request->ep->fi_ibv_rdm_request_pool,
+				found_request);
 
 			if (ret == FI_SUCCESS &&
 			    request->state.rndv == FI_IBV_STATE_RNDV_RECV_WAIT4RES) {
@@ -706,7 +711,9 @@ fi_ibv_rdm_tagged_peek_request(struct fi_ibv_rdm_request *request, void *data)
 			fi_ibv_rdm_move_to_cq(p->ep->fi_rcq, request);
 		} else {
 			FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-			util_buf_release(fi_ibv_rdm_request_pool, request);
+			util_buf_release(
+				request->ep->fi_ibv_rdm_request_pool,
+				request);
 		}
 		
 		FI_IBV_RDM_HNDL_REQ_LOG_OUT();
@@ -764,7 +771,14 @@ fi_ibv_rdm_init_unexp_recv_request(struct fi_ibv_rdm_request *request, void *dat
 
 		if (request->len > 0) {
 			request->unexp_rbuf =
-				util_buf_alloc(fi_ibv_rdm_extra_buffers_pool);
+				util_buf_alloc(request->ep->fi_ibv_rdm_extra_buffers_pool);
+			if (!request->unexp_rbuf) {
+				ret = -FI_ENOMEM;
+				VERBS_WARN(FI_LOG_EP_DATA,
+					   "Unable allocate memory from the pool "
+					   "for uenxpected buffer");
+				goto fn;
+			}
 			memcpy(request->unexp_rbuf, &rbuf->payload,
 			       request->len);
 		} else {
@@ -804,7 +818,7 @@ fi_ibv_rdm_init_unexp_recv_request(struct fi_ibv_rdm_request *request, void *dat
 	}
 
 	fi_ibv_rdm_move_to_unexpected_queue(request);
-
+fn:
 	FI_IBV_RDM_HNDL_REQ_LOG_OUT();
 	return ret;
 }
@@ -862,8 +876,9 @@ fi_ibv_rdm_eager_recv_got_pkt(struct fi_ibv_rdm_request *request, void *data)
 			} else {
 				FI_IBV_RDM_DBG_REQUEST("to_pool: ", request,
 							FI_LOG_DEBUG);
-				util_buf_release(fi_ibv_rdm_request_pool,
-						request);
+				util_buf_release(
+					request->ep->fi_ibv_rdm_request_pool,
+					request);
 			}
 		} else {
 			VERBS_INFO(FI_LOG_EP_DATA,
@@ -964,8 +979,9 @@ fi_ibv_rdm_eager_recv_process_unexp_pkt(struct fi_ibv_rdm_request *request,
 	}
 
 	if (request->unexp_rbuf) {
-		util_buf_release(fi_ibv_rdm_extra_buffers_pool,
-				request->unexp_rbuf);
+		util_buf_release(
+			request->ep->fi_ibv_rdm_extra_buffers_pool,
+			request->unexp_rbuf);
 		request->unexp_rbuf = NULL;
 	}
 
@@ -976,7 +992,8 @@ fi_ibv_rdm_eager_recv_process_unexp_pkt(struct fi_ibv_rdm_request *request,
 		fi_ibv_rdm_move_to_cq(p->ep->fi_rcq, request);
 	} else {
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(request->ep->fi_ibv_rdm_request_pool,
+				 request);
 	}
 
 	FI_IBV_RDM_HNDL_REQ_LOG_OUT();
@@ -1013,13 +1030,15 @@ fi_ibv_rdm_eager_recv_discard(struct fi_ibv_rdm_request *request, void *data)
 	fi_ibv_rdm_remove_from_unexp_queue(request);
 
 	if (request->unexp_rbuf) {
-		util_buf_release(fi_ibv_rdm_extra_buffers_pool,
-				request->unexp_rbuf);
+		util_buf_release(
+			request->ep->fi_ibv_rdm_extra_buffers_pool,
+			request->unexp_rbuf);
 		request->unexp_rbuf = NULL;
 	}
 
 	FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-	util_buf_release(fi_ibv_rdm_request_pool, request);
+	util_buf_release(request->ep->fi_ibv_rdm_request_pool,
+			 request);
 
 	FI_IBV_RDM_HNDL_REQ_LOG_OUT();
 	return FI_SUCCESS;
@@ -1241,7 +1260,9 @@ fi_ibv_rdm_rndv_recv_ack_lc(struct fi_ibv_rdm_request *request, void *data)
 
 	if (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(
+			request->ep->fi_ibv_rdm_request_pool,
+			request);
 	} else {
 		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
 		request->state.rndv = FI_IBV_STATE_RNDV_RECV_END;
@@ -1444,7 +1465,8 @@ fi_ibv_rdm_rma_inject_lc(struct fi_ibv_rdm_request *request, void *data)
 	FI_IBV_RDM_HNDL_REQ_LOG();
 
 	FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-	util_buf_release(fi_ibv_rdm_request_pool, request);
+	util_buf_release(request->ep->fi_ibv_rdm_request_pool,
+			 request);
 
 	FI_IBV_RDM_HNDL_REQ_LOG_OUT();
 
@@ -1483,7 +1505,9 @@ fi_ibv_rdm_rma_buffered_lc(struct fi_ibv_rdm_request *request, void *data)
 
 	if (request->state.eager == FI_IBV_STATE_EAGER_READY_TO_FREE) {
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(
+			request->ep->fi_ibv_rdm_request_pool,
+			request);
 	} else {
 		request->state.eager = FI_IBV_STATE_EAGER_READY_TO_FREE;
 	}
@@ -1532,7 +1556,9 @@ fi_ibv_rdm_rma_zerocopy_lc(struct fi_ibv_rdm_request *request, void *data)
 			request->state.rndv = FI_IBV_STATE_ZEROCOPY_RMA_END;
 		} else {
 			FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-			util_buf_release(fi_ibv_rdm_request_pool, request);
+			util_buf_release(
+				request->ep->fi_ibv_rdm_request_pool,
+				request);
 		}
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -181,7 +181,7 @@ void fi_ibv_rdm_clean_queues(struct fi_ibv_rdm_ep *ep)
 	struct fi_ibv_rdm_request *request;
 	struct fi_ibv_rdm_multi_request *multi_request;
 
-	while ((request = fi_ibv_rdm_take_first_from_unexp_queue())) {
+	while ((request = fi_ibv_rdm_take_first_from_unexp_queue(ep))) {
 		if (request->unexp_rbuf) {
 			util_buf_release(ep->fi_ibv_rdm_extra_buffers_pool,
 					 request->unexp_rbuf);
@@ -206,7 +206,7 @@ void fi_ibv_rdm_clean_queues(struct fi_ibv_rdm_ep *ep)
 		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
 
-	while ((request = fi_ibv_rdm_take_first_from_postponed_queue())) {
+	while ((request = fi_ibv_rdm_take_first_from_postponed_queue(ep))) {
 		if (request->iov_count > 0) {
 			util_buf_release(ep->fi_ibv_rdm_extra_buffers_pool,
 					 request->unexp_rbuf);

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -176,9 +176,10 @@ void fi_ibv_rdm_conn_init_cm_role(struct fi_ibv_rdm_conn *conn,
 	}
 }
 
-void fi_ibv_rdm_clean_queues(struct fi_ibv_rdm_ep* ep)
+void fi_ibv_rdm_clean_queues(struct fi_ibv_rdm_ep *ep)
 {
 	struct fi_ibv_rdm_request *request;
+	struct fi_ibv_rdm_multi_request *multi_request;
 
 	while ((request = fi_ibv_rdm_take_first_from_unexp_queue())) {
 		if (request->unexp_rbuf) {
@@ -188,6 +189,9 @@ void fi_ibv_rdm_clean_queues(struct fi_ibv_rdm_ep* ep)
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
 		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
+
+	while ((multi_request = fi_ibv_rdm_take_first_from_multi_recv_list(ep)))
+		util_buf_release(ep->fi_ibv_rdm_multi_request_pool, multi_request);
 
 	while ((request = fi_ibv_rdm_take_first_from_posted_queue(ep))) {
  		/* Check `request->context->internal[0] == NULL` in fi_cancel

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -40,10 +40,6 @@
 #include "verbs_rdm.h"
 #include "verbs_queuing.h"
 
-extern struct util_buf_pool *fi_ibv_rdm_request_pool;
-extern struct util_buf_pool *fi_ibv_rdm_extra_buffers_pool;
-extern struct util_buf_pool *fi_ibv_rdm_postponed_pool;
-
 size_t rdm_buffer_size(size_t buf_send_size)
 {
 	size_t size = buf_send_size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE +
@@ -186,11 +182,11 @@ void fi_ibv_rdm_clean_queues(struct fi_ibv_rdm_ep* ep)
 
 	while ((request = fi_ibv_rdm_take_first_from_unexp_queue())) {
 		if (request->unexp_rbuf) {
-			util_buf_release(fi_ibv_rdm_extra_buffers_pool,
-					request->unexp_rbuf);
+			util_buf_release(ep->fi_ibv_rdm_extra_buffers_pool,
+					 request->unexp_rbuf);
 		}
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
 
 	while ((request = fi_ibv_rdm_take_first_from_posted_queue(ep))) {
@@ -199,48 +195,48 @@ void fi_ibv_rdm_clean_queues(struct fi_ibv_rdm_ep* ep)
 		 * internally by provider */
 		request->context->internal[0] = NULL;
 		if (request->iov_count > 0) {
-			util_buf_release(fi_ibv_rdm_extra_buffers_pool,
-					request->unexp_rbuf);
+			util_buf_release(ep->fi_ibv_rdm_extra_buffers_pool,
+					 request->unexp_rbuf);
 		}
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
 
 	while ((request = fi_ibv_rdm_take_first_from_postponed_queue())) {
 		if (request->iov_count > 0) {
-			util_buf_release(fi_ibv_rdm_extra_buffers_pool,
-					request->unexp_rbuf);
+			util_buf_release(ep->fi_ibv_rdm_extra_buffers_pool,
+					 request->unexp_rbuf);
 		}
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
 
 	while ((request = fi_ibv_rdm_take_first_from_cq(ep->fi_scq))) {
 		if (request->iov_count > 0) {
-			util_buf_release(fi_ibv_rdm_extra_buffers_pool,
-					request->unexp_rbuf);
+			util_buf_release(ep->fi_ibv_rdm_extra_buffers_pool,
+					 request->unexp_rbuf);
 		}
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
 
 	while ((request = fi_ibv_rdm_take_first_from_cq(ep->fi_rcq))) {
 		if (request->iov_count > 0) {
-			util_buf_release(fi_ibv_rdm_extra_buffers_pool,
-					request->unexp_rbuf);
+			util_buf_release(ep->fi_ibv_rdm_extra_buffers_pool,
+					 request->unexp_rbuf);
 		}
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
 
 	while ((request = fi_ibv_rdm_take_first_from_errcq(ep->fi_scq))) {
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
 
 	while ((request = fi_ibv_rdm_take_first_from_errcq(ep->fi_rcq))) {
 		FI_IBV_RDM_DBG_REQUEST("to_pool: ", request, FI_LOG_DEBUG);
-		util_buf_release(fi_ibv_rdm_request_pool, request);
+		util_buf_release(ep->fi_ibv_rdm_request_pool, request);
 	}
 }
 
@@ -248,9 +244,10 @@ ssize_t
 fi_ibv_rdm_send_common(struct fi_ibv_rdm_send_start_data* sdata)
 {
 	struct fi_ibv_rdm_request *request =
-		util_buf_alloc(fi_ibv_rdm_request_pool);
+		util_buf_alloc(sdata->ep_rdm->fi_ibv_rdm_request_pool);
 	if (OFI_UNLIKELY(!request))
 		return -FI_EAGAIN;
+	request->ep = sdata->ep_rdm;
 	FI_IBV_RDM_DBG_REQUEST("get_from_pool: ", request, FI_LOG_DEBUG);
 
 	/* Initial state */

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -127,19 +127,20 @@ do {										\
 	const size_t max_str_len = 1024;					\
 	char str[max_str_len];							\
 	snprintf(str, max_str_len,						\
-		"%s request: %p, eager_state: %s, rndv_state: %s,"		\
-		" err_state: %ld, tag: 0x%lx, len: %lu, rest: %lu,"		\
-		"context: %p, connection: %p\n",				\
-		prefix,								\
-		request,							\
-		fi_ibv_rdm_req_eager_state_to_str(request->state.eager),	\
-		fi_ibv_rdm_req_rndv_state_to_str(request->state.rndv),		\
-		request->state.err,						\
-		request->minfo.tag,						\
-		request->len,							\
-		request->rest_len,						\
-		request->context,						\
-		request->minfo.conn);						\
+		 "%s request: %p, eager_state: %s, rndv_state: %s,"		\
+		 " err_state: %ld, tag: 0x%lx, len: %lu, rest: %lu,"		\
+		 "context: %p, connection: %p ep: %p\n",			\
+		 prefix,							\
+		 request,							\
+		 fi_ibv_rdm_req_eager_state_to_str(request->state.eager),	\
+		 fi_ibv_rdm_req_rndv_state_to_str(request->state.rndv),		\
+		 request->state.err,						\
+		 request->minfo.tag,						\
+		 request->len,							\
+		 request->rest_len,						\
+		 request->context,						\
+		 request->minfo.conn,						\
+		 request->ep);							\
 										\
 	switch (level)								\
 	{									\


### PR DESCRIPTION
This patch addresses the following problems:
- Optimization of the multi-recv path. Replace dynamic memory allocation in the critical path by allocation memory buffer from pool.
- Replace memory pools and queues from the global space to the memory pool and queues per EP
- Remove unused global completion queue