### PR TITLE
prov/sockets: create one listener thread per domain

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2017 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -367,7 +368,7 @@ static int sock_ep_cm_setname(fid_t fid, void *addr, size_t addrlen)
 	case FI_CLASS_EP:
 	case FI_CLASS_SEP:
 		sock_ep = container_of(fid, struct sock_ep, ep.fid);
-		if (sock_ep->attr->listener.listener_thread)
+		if (sock_ep->attr->conn_handle.do_listen)
 			return -FI_EINVAL;
 		memcpy(sock_ep->attr->src_addr, addr, addrlen);
 		return sock_conn_listen(sock_ep->attr);
@@ -588,7 +589,7 @@ static int sock_ep_cm_connect(struct fid_ep *ep, const void *addr,
 	if (!_eq || !addr || (paramlen > SOCK_EP_MAX_CM_DATA_SZ))
 		return -FI_EINVAL;
 
-	if (!_ep->attr->listener.listener_thread && sock_conn_listen(_ep->attr))
+	if (!_ep->attr->conn_handle.do_listen && sock_conn_listen(_ep->attr))
 		return -FI_EINVAL;
 
 	if (!_ep->attr->dest_addr) {
@@ -687,7 +688,7 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param, size_t paraml
 	if (!_ep->attr->eq || paramlen > SOCK_EP_MAX_CM_DATA_SZ)
 		return -FI_EINVAL;
 
-	if (!_ep->attr->listener.listener_thread && sock_conn_listen(_ep->attr))
+	if (!_ep->attr->conn_handle.do_listen && sock_conn_listen(_ep->attr))
 		return -FI_EINVAL;
 
 	handle = container_of(_ep->attr->info.handle,


### PR DESCRIPTION
With the current implementation, libfabric requires the creation
of many POSIX threads. The also opens opens many file descriptors
because a socket pair is created to signal each connection thread
blocked in epoll_wait().
The current implementation largely impacts the scalability of libfabric
with the socket provider.

Function sock_conn_listen() is responsible for listening for new
connection requests for all kinds of endpoints (MSG, RDM, DGRAM).
The problem is that a thread is created every-time the function
sock_conn_listen() gets executed.
This implementation is particularly inefficient when a server needs
to reply many to connections requests from many clients.

The patch fixes the scalability issue figured out in sock_conn_listen()
by adding one listener thread per OFI domain. This thread is
then responsible for listening connection requests for all EP that
are bound to this specific domain.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>