### PR TITLE
 pingpong: Add support of large addresses

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -100,6 +100,11 @@ static inline void ofi_osd_fini(void)
 {
 }
 
+static inline int ofi_getsockname(SOCKET fd, struct sockaddr *addr, socklen_t *len)
+{
+	return getsockname(fd, addr, len);
+}
+
 static inline SOCKET ofi_socket(int domain, int type, int protocol)
 {
 	return socket(domain, type, protocol);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -270,14 +270,11 @@ do						\
 #define ntohll _byteswap_uint64
 #define strncasecmp _strnicmp
 
-//#define INET_ADDRSTRLEN  (16)
-//#define INET6_ADDRSTRLEN (48)
-
 int fd_set_nonblock(int fd);
 
 int socketpair(int af, int type, int protocol, int socks[2]);
 void sock_get_ip_addr_table(struct slist *addr_list);
-
+int ofi_getsockname(SOCKET fd, struct sockaddr *addr, socklen_t *len);
 
 /*
  * Win32 error code should be passed as a parameter.

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -55,12 +55,14 @@ int udpx_setname(fid_t fid, void *addr, size_t addrlen)
 
 int udpx_getname(fid_t fid, void *addr, size_t *addrlen)
 {
-	struct udpx_ep *ep;
-	int ret;
+	struct udpx_ep *ep =
+		container_of(fid, struct udpx_ep, util_ep.ep_fid.fid);
+	size_t buflen = *addrlen;
 
-	ep = container_of(fid, struct udpx_ep, util_ep.ep_fid.fid);
-	ret = getsockname(ep->sock, addr, (socklen_t *)addrlen);
-	return ret ? -errno : 0;
+	if (ofi_getsockname(ep->sock, addr, (socklen_t *)addrlen))
+		return -ofi_sockerr();
+
+	return buflen < *addrlen ? -FI_ETOOSMALL : 0;
 }
 
 static int udpx_mc_close(struct fid *fid)

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -115,6 +115,23 @@ err:
 	return SOCKET_ERROR;
 }
 
+int ofi_getsockname(SOCKET fd, struct sockaddr *addr, socklen_t *len)
+{
+	struct sockaddr_storage sock_addr;
+	size_t sock_addr_len = sizeof(sock_addr);
+	int ret;
+
+	ret = getsockname(fd, &sock_addr, (socklen_t *)&sock_addr_len);
+	if (ret)
+		return ret;
+
+	if (addr)
+		memcpy(addr, &sock_addr, MIN(*len, sock_addr_len));
+	*len = sock_addr_len;
+
+	return FI_SUCCESS;
+}
+
 int fi_read_file(const char *dir, const char *file, char *buf, size_t size)
 {
 	char *path = 0;


### PR DESCRIPTION
The current limit of the addresses is 64 bytes that is too short for the MLX provider (UCX wrapper) - we're going to revive this provider.
This patch strives to avoid this limit by requesting the needed length of memory space that is needed for the address (`fi_getname` with the passed length = 0). After that the needed buffer is dynamically allocated and passes to the `fi_getname` again to retrieve the address.

Only UDP wasn't compliant with expected behavior. The UDP `fi_getname` has been aligned with correct behavior in this patch