### PR TITLE
prov/gni: Incorrect hints given to domain check fn

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -673,16 +673,6 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 					hints->domain_attr->caps;
 			}
 
-			ret = ofi_check_domain_attr(&gnix_prov, version,
-						    gnix_info->domain_attr,
-						    hints);
-			if (ret) {
-				GNIX_WARN(FI_LOG_FABRIC,
-						  "GNI failed domain attributes check\n");
-				goto err;
-			}
-
-			GNIX_DEBUG(FI_LOG_FABRIC, "Passed the domain attributes check\n");
 		}
 	}
 
@@ -692,6 +682,17 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 		goto err;
 
 	ofi_alter_info(gnix_info, hints, version);
+
+	ret = ofi_check_domain_attr(&gnix_prov, version,
+				    gnix_info->domain_attr,
+				    gnix_info);
+	if (ret) {
+		GNIX_WARN(FI_LOG_FABRIC,
+				  "GNI failed domain attributes check\n");
+		goto err;
+	}
+
+	GNIX_DEBUG(FI_LOG_FABRIC, "Passed the domain attributes check\n");
 
 	/* The provider may silently enable secondary
 	 * capabilities that do not introduce any overhead. */


### PR DESCRIPTION
This commit amends the GNI provider behavior with respect to the
ofi_check_domain_attr function and the returned info structure.
The provider was checking the contents of the wrong info
structure and had assumed that the contents were formatted correctly
for the ofi_check_domain_attr function. This commit addresses the
issue by shifting the relevant code to a later point in the
function and changes the fi_info structure to verify from 'hints'
to 'gnix_info'.

Signed-off-by: James Swaro <jswaro@cray.com>

closes #3433 