### PR TITLE
prov/socket: Fix sock_get_prefix_len to handle BE systems

### DIFF
--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1334,17 +1334,20 @@ int sock_srx_ctx(struct fid_domain *domain,
 	return 0;
 }
 
-int sock_get_prefix_len(uint32_t net_addr)
+#if HAVE_GETIFADDRS
+static int sock_get_prefix_len(uint32_t net_addr)
 {
+	uint32_t addr;
 	int count = 0;
-	while (net_addr > 0) {
-		net_addr = net_addr >> 1;
+
+	addr = ntohl(net_addr);
+	while (addr > 0) {
+		addr = addr << 1;
 		count++;
 	}
 	return count;
 }
 
-#if HAVE_GETIFADDRS
 char *sock_get_fabric_name(struct sockaddr_in *src_addr)
 {
 	int ret;


### PR DESCRIPTION
The prefix handling code assumes we're running on a little
endian system.  Support BE systems as well.

Move the call inside HAVE_GETIFADDRS check, since it is
only called from one location that's wrapped by that check.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>