### PR TITLE
common/cntr,cq: Add missed memory release in the util_cntr|cq_close

### DIFF
--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -205,6 +205,7 @@ static int util_cntr_close(struct fid *fid)
 	ret = ofi_cntr_cleanup(cntr);
 	if (ret)
 		return ret;
+	free(cntr);
 	return 0;
 }
 

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -385,6 +385,8 @@ static int util_cq_close(struct fid *fid)
 	ret = ofi_cq_cleanup(cq);
 	if (ret)
 		return ret;
+
+	free(cq);
 	return 0;
 }
 


### PR DESCRIPTION
This patch addresses problem where the `util_cq` and `util_cntr` objects aren't freed.
The `util_cq_close` and `util_cntr_close` functions are set as a function pointer to `fi_close()` function.

This solution fixes the problem in the same meaner as it's already done for the `util_eq`