### PR TITLE
include/fi_mem: add smr_freestack implementation for use with shared memory

### DIFF
--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -143,7 +143,7 @@ struct smr_inject_buf {
 
 OFI_DECLARE_CIRQUE(struct smr_cmd, smr_cmd_queue);
 OFI_DECLARE_CIRQUE(struct smr_resp, smr_resp_queue);
-DECLARE_FREESTACK(struct smr_inject_buf, smr_inject_pool);
+DECLARE_SMR_FREESTACK(struct smr_inject_buf, smr_inject_pool);
 
 static inline struct smr_peer *smr_peer(struct smr_region *smr)
 {

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -23,7 +23,7 @@ fi_tsend / fi_tsendv / fi_tsendmsg / fi_tinject / fi_tsenddata
 ssize_t fi_trecv(struct fid_ep *ep, void *buf, size_t len, void *desc,
 	fi_addr_t src_addr, uint64_t tag, uint64_t ignore, void *context);
 
-ssize_t fi_trecvv(struct fid_ep *ep, const struct iovec *iov, void *desc,
+ssize_t fi_trecvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 	size_t count, fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
 	void *context);
 
@@ -34,7 +34,7 @@ ssize_t fi_tsend(struct fid_ep *ep, const void *buf, size_t len,
 	void *desc, fi_addr_t dest_addr, uint64_t tag, void *context);
 
 ssize_t fi_tsendv(struct fid_ep *ep, const struct iovec *iov,
-	void *desc, size_t count, fi_addr_t dest_addr, uint64_t tag,
+	void **desc, size_t count, fi_addr_t dest_addr, uint64_t tag,
 	void *context);
 
 ssize_t fi_tsendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,


### PR DESCRIPTION
- smr_freestack mirrors original freestack implementation but with added base_addr of owning process to translate entry pointers from one address space to the other when pushing and popping.
- update shm provider to use smr_freestack instead of original freestack.
- also including an unrelated minor man page update.

Signed-off-by: aingerson <alexia.ingerson@intel.com>