### PR TITLE
common: Fix uninitialized global lock (appears on Windows)

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -133,6 +133,11 @@ enum {
 	UTIL_RX_SHARED_CTX = 1 << 1,
 };
 
+struct ofi_common_locks {
+	pthread_mutex_t ini_lock;
+	pthread_mutex_t util_fabric_lock;
+};
+
 /*
  * Provider details
  */

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -37,15 +37,14 @@
 #include <fi_util.h>
 #include <fi.h>
 
-
 static DEFINE_LIST(fabric_list);
-static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
+extern struct ofi_common_locks common_locks;
 
 void ofi_fabric_insert(struct util_fabric *fabric)
 {
-	pthread_mutex_lock(&lock);
+	pthread_mutex_lock(&common_locks.util_fabric_lock);
 	dlist_insert_tail(&fabric->list_entry, &fabric_list);
-	pthread_mutex_unlock(&lock);
+	pthread_mutex_unlock(&common_locks.util_fabric_lock);
 }
 
 static int util_match_fabric(struct dlist_entry *item, const void *arg)
@@ -62,18 +61,18 @@ struct util_fabric *ofi_fabric_find(struct util_fabric_info *fabric_info)
 {
 	struct dlist_entry *item;
 
-	pthread_mutex_lock(&lock);
+	pthread_mutex_lock(&common_locks.util_fabric_lock);
 	item = dlist_find_first_match(&fabric_list, util_match_fabric, fabric_info);
-	pthread_mutex_unlock(&lock);
+	pthread_mutex_unlock(&common_locks.util_fabric_lock);
 
 	return item ? container_of(item, struct util_fabric, list_entry) : NULL;
 }
 
 void ofi_fabric_remove(struct util_fabric *fabric)
 {
-	pthread_mutex_lock(&lock);
+	pthread_mutex_lock(&common_locks.util_fabric_lock);
 	dlist_remove(&fabric->list_entry);
-	pthread_mutex_unlock(&lock);
+	pthread_mutex_unlock(&common_locks.util_fabric_lock);
 }
 
 

--- a/src/common.c
+++ b/src/common.c
@@ -54,11 +54,17 @@
 #include <rdma/providers/fi_prov.h>
 #include <rdma/fi_errno.h>
 #include <fi.h>
+#include <fi_util.h>
 
 struct fi_provider core_prov = {
 	.name = "core",
 	.version = 1,
 	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION)
+};
+
+struct ofi_common_locks common_locks = {
+	.ini_lock = PTHREAD_MUTEX_INITIALIZER,
+	.util_fabric_lock = PTHREAD_MUTEX_INITIALIZER,
 };
 
 int fi_poll_fd(int fd, int timeout)

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -58,10 +58,9 @@ struct ofi_prov {
 
 static struct ofi_prov *prov_head, *prov_tail;
 int ofi_init = 0;
-pthread_mutex_t ofi_ini_lock = PTHREAD_MUTEX_INITIALIZER;
+extern struct ofi_common_locks common_locks;
 
 static struct fi_filter prov_filter;
-
 
 static int ofi_find_name(char **names, const char *name)
 {
@@ -413,8 +412,9 @@ static void ofi_ini_dir(const char *dir)
 		if (inif == NULL) {
 			FI_WARN(&core_prov, FI_LOG_CORE, "dlsym: %s\n", dlerror());
 			dlclose(dlhandle);
-		} else
+		} else {
 			ofi_register_provider((inif)(), dlhandle);
+		}
 	}
 
 libdl_done:
@@ -428,7 +428,7 @@ void fi_ini(void)
 {
 	char *param_val = NULL;
 
-	pthread_mutex_lock(&ofi_ini_lock);
+	pthread_mutex_lock(&common_locks.ini_lock);
 
 	if (ofi_init)
 		goto unlock;
@@ -506,7 +506,7 @@ libdl_done:
 	ofi_init = 1;
 
 unlock:
-	pthread_mutex_unlock(&ofi_ini_lock);
+	pthread_mutex_unlock(&common_locks.ini_lock);
 }
 
 FI_DESTRUCTOR(fi_fini(void))

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -47,7 +47,7 @@
 
 #include "rdma/providers/fi_log.h"
 
-extern pthread_mutex_t ofi_ini_lock;
+extern struct ofi_common_locks common_locks;
 static INIT_ONCE ofi_init_once = INIT_ONCE_STATIC_INIT;
 
 static char ofi_shm_prefix[] = "Local\\";
@@ -162,9 +162,14 @@ fn_nomem:
 
 static BOOL CALLBACK ofi_init_once_cb(PINIT_ONCE once, void* data, void** ctx)
 {
+	struct ofi_common_locks *locks = (struct ofi_common_locks *)data;
+
 	OFI_UNUSED(once);
 	OFI_UNUSED(ctx);
-	InitializeCriticalSection((CRITICAL_SECTION*)data);
+
+	InitializeCriticalSection(&locks->ini_lock);
+	InitializeCriticalSection(&locks->util_fabric_lock);
+
 	return TRUE;
 }
 
@@ -175,7 +180,8 @@ BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, LPVOID reserved)
 
 	switch (reason) {
 	case DLL_PROCESS_ATTACH:
-		InitOnceExecuteOnce(&ofi_init_once, ofi_init_once_cb, &ofi_ini_lock, 0);
+		InitOnceExecuteOnce(&ofi_init_once, ofi_init_once_cb,
+				    &common_locks, 0);
 		break;
 	case DLL_THREAD_ATTACH:
 		break;


### PR DESCRIPTION
The problem is the UDP provider crashes on Windows.
This appears because the global `pthread_mutex_t` lock in the `util_main.c` file is initialized by `PTHREAD_MUTEX_INITIALIZER` that is mapped to NULL for Windows. There is no static variant to initialize `CRITICAL_SECTION` (`pthread_mutex_t` is mapped to this type on Windows) object. The one way is to call `InitializeCriticalSection` for this object.

The main idea of this patch is initialize this mutex only once. It can be done by `InitOnceExecuteOnce` function during loading of the DLL library. This patch fixes this problem in the same way as it's done for the `ofi_ini_lock` from the `fabric.c` file. These two locks are combined into one instance of the `ofi_common_locks` structure.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>