### PR TITLE
prov/shm: Separate checks for process_vm_readv and shm_open

### DIFF
--- a/prov/shm/configure.m4
+++ b/prov/shm/configure.m4
@@ -10,11 +10,16 @@ dnl
 AC_DEFUN([FI_SHM_CONFIGURE],[
 	# Determine if we can support the shm provider
 	shm_happy=0
+	cma_happy=0
 	AS_IF([test x"$enable_shm" != x"no"],
 	      [
-	       # check if shm_open and CMA support are present
-	       AC_CHECK_FUNCS(shm_open,
-			      process_vm_readv,
+	       # check if CMA support are present
+	       AC_CHECK_FUNC([process_vm_readv],
+			     [cma_happy=1],
+			     [cma_happy=0])
+
+	       # check if SHM support are present
+	       AC_CHECK_FUNC([shm_open],
 			     [shm_happy=1],
 			     [shm_happy=0])
 
@@ -31,5 +36,6 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 				[shm_happy=0])])
 	      ])
 
-	AS_IF([test $shm_happy -eq 1], [$1], [$2])
+	AS_IF([test $shm_happy -eq 1 && \
+	       test $cma_happy -eq 1], [$1], [$2])
 ])


### PR DESCRIPTION
This fixes problem by adding the separate variable `cma_support` for the checking CMA support.
The previous solution reports that `process_vm_readv` is unsupported, but the next check assign 1 to `shm_happy` variable if the shm_open was found in the `librt` library. 

```
configure: *** Configuring shm provider
checking for process_vm_readv... no
checking for shm_open... (cached) no
checking sys/mman.h usability... yes
checking sys/mman.h presence... yes
checking for sys/mman.h... yes
looking for library without search path
checking for shm_open in -lrt... yes
configure: shm provider: disabled
```

This check disables SHM provider, if `process_vm_readv` isn't found. Is it expected behavior? Or Is there some fallback from the `process_vm_readv` to the some analog? If no, seems this patch might be as a solution.

Fixes #3446 

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>