### PR TITLE
prov/rxm: Fix resource leak

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1127,9 +1127,6 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		break;
 	case FI_CLASS_CQ:
 		cq = container_of(bfid, struct util_cq, cq_fid.fid);
-		ret = ofi_ep_bind_cq(&rxm_ep->util_ep, cq, flags);
-		if (ret)
-			return ret;
 
 		if (cq->wait) {
 			ret = ofi_wait_fd_add(cq->wait, rxm_ep->msg_cq_fd,
@@ -1137,6 +1134,13 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 					      &rxm_ep->util_ep.ep_fid.fid);
 			if (ret)
 				return ret;
+		}
+		ret = ofi_ep_bind_cq(&rxm_ep->util_ep, cq, flags);
+		if (ret) {
+			if (cq->wait && ofi_wait_fd_del(cq->wait, rxm_ep->msg_cq_fd))
+				FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
+					"Unable to delete wait fd from FD list");
+			return ret;
 		}
 		break;
 	case FI_CLASS_EQ:


### PR DESCRIPTION
This patch fixes resource leak if the `fi_getname` for an underlying MSG EP fails:
```
$ FI_LOG_LEVEL=warn I_MPI_OFI_PROVIDER="sockets;ofi_rxm" I_MPI_FABRICS=ofi mpirun -n 2 –ppn 1 manyget

[0] MPI startup(): ofi fabric is not available and fallback fabric is not enabled
libfabric:ofi_rxm:ep_ctrl:rxm_conn_cmap_alloc():380<warn> Unable to fi_getname on msg_ep
libfabric:ofi_rxm:av:ofi_av_close():438<warn> AV is busy
[1] MPI startup(): ofi fabric is not available and fallback fabric is not enabled
libfabric:ofi_rxm:ep_ctrl:rxm_conn_cmap_alloc():380<warn> Unable to fi_getname on msg_ep
libfabric:ofi_rxm:av:ofi_av_close():438<warn> AV is busy
```

After applying this patch:
```
$ FI_LOG_LEVEL=warn I_MPI_OFI_PROVIDER="sockets;ofi_rxm" I_MPI_FABRICS=ofi mpirun -n 2 –ppn 1 manyget
libfabric:ofi_rxm:ep_ctrl:rxm_conn_cmap_alloc():385<warn> Unable to fi_getname on msg_ep
libfabric:ofi_rxm:ep_ctrl:rxm_conn_cmap_alloc():385<warn> Unable to fi_getname on msg_ep
[0] MPI startup(): ofi fabric is not available and fallback fabric is not enabled
[1] MPI startup(): ofi fabric is not available and fallback fabric is not enabled

```

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>