### PR TITLE
util/rxm: Fixes to rxm provider when used over sockets

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -688,7 +688,7 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 			  const struct fi_info *user_info);
 int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 		      const struct fi_info *prov_info,
-		      const struct fi_ep_attr *user_attr);
+		      const struct fi_info *user_info);
 int ofi_check_cq_attr(const struct fi_provider *prov,
 		      const struct fi_cq_attr *attr);
 int ofi_check_rx_attr(const struct fi_provider *prov,

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -63,7 +63,10 @@ struct fi_ep_attr rxm_ep_attr = {
 	.protocol_version = 1,
 	.max_msg_size = SIZE_MAX,
 	.tx_ctx_cnt = 1,
-	.rx_ctx_cnt = 1
+	.rx_ctx_cnt = 1,
+	.max_order_raw_size = SIZE_MAX,
+	.max_order_war_size = SIZE_MAX,
+	.max_order_waw_size = SIZE_MAX,
 };
 
 struct fi_domain_attr rxm_domain_attr = {

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -470,7 +470,6 @@ static int rxm_handle_remote_write(struct rxm_ep *rxm_ep,
 static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 				  struct fi_cq_tagged_entry *comp)
 {
-	enum rxm_proto_state state = RXM_GET_PROTO_STATE(comp);
 	struct rxm_rx_buf *rx_buf = comp->op_context;
 	struct rxm_tx_entry *tx_entry = comp->op_context;
 
@@ -479,7 +478,7 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	if (comp->flags & FI_REMOTE_WRITE)
 		return rxm_handle_remote_write(rxm_ep, comp);
 
-	switch (state) {
+	switch (RXM_GET_PROTO_STATE(comp)) {
 	case RXM_TX_NOBUF:
 		assert(comp->flags & (FI_SEND | FI_WRITE | FI_READ));
 		return rxm_finish_send_nobuf(tx_entry);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -124,6 +124,9 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 
 	*info->ep_attr = *rxm_info.ep_attr;
 	info->ep_attr->max_msg_size = core_info->ep_attr->max_msg_size;
+	info->ep_attr->max_order_raw_size = core_info->ep_attr->max_order_raw_size;
+	info->ep_attr->max_order_war_size = core_info->ep_attr->max_order_war_size;
+	info->ep_attr->max_order_waw_size = core_info->ep_attr->max_order_waw_size;
 
 	*info->domain_attr = *rxm_info.domain_attr;
 	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -498,7 +498,7 @@ struct verbs_ep_domain {
 extern const struct verbs_ep_domain verbs_rdm_domain;
 extern const struct verbs_ep_domain verbs_dgram_domain;
 
-int fi_ibv_check_ep_attr(const struct fi_ep_attr *attr,
+int fi_ibv_check_ep_attr(const struct fi_info *hints,
 			 const struct fi_info *info);
 int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
 			 const struct fi_info *hints,

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -304,7 +304,7 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 	fi = dom->info;
 
 	if (info->ep_attr) {
-		ret = fi_ibv_check_ep_attr(info->ep_attr, fi);
+		ret = fi_ibv_check_ep_attr(info, fi);
 		if (ret)
 			return ret;
 	}


### PR DESCRIPTION
The following series reduces the number of failures seen running the ofi_rxm provider over sockets.  It corrects issues with fi_getinfo_test, and rdm EP tests using writedata.

With these changes, the ofi_rxm;sockets provider only fails with fi_rdm_tagged_peek test.