### PR TITLE
travis/appveyor: Use fabtests branch v1.5.x

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,6 +17,7 @@ after_build:
 before_test:
   - git clone https://github.com/ofiwg/fabtests
   - cd fabtests
+  - git checkout -b v1.5.x origin/v1.5.x
   - msbuild fabtests.sln
 
 test_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,7 @@ install:
 script:
     - git clone https://github.com/ofiwg/fabtests.git
     - cd fabtests
+    - git checkout -b v1.5.x origin/v1.5.x
     - ./autogen.sh
     - ./configure --prefix=$PREFIX --with-libfabric=$PREFIX
     - make -j2


### PR DESCRIPTION
Ensure that we're testing with the fabtests v1.5.x codebase, rather than upstream master.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>