### PR TITLE
prov/verbs: Add possibility to change timeout for the rdma_resolve_addr call

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -75,7 +75,8 @@ fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 		conn->id[0] = id;
 	}
 
-	if (rdma_resolve_addr(id, NULL, (struct sockaddr *)&conn->addr, 30000)) {
+	if (rdma_resolve_addr(id, NULL, (struct sockaddr *)&conn->addr,
+			      fi_ibv_gl_data.rdm.resolve_addr_timeout)) {
 		VERBS_INFO_ERRNO(FI_LOG_AV, "rdma_resolve_addr\n", errno);
 		return -errno;
 	}

--- a/prov/verbs/src/ep_rdm/verbs_utils.h
+++ b/prov/verbs/src/ep_rdm/verbs_utils.h
@@ -62,6 +62,7 @@ struct fi_ibv_msg_ep;
 
 #define FI_IBV_RDM_DFLT_ADDRLEN	(sizeof (struct sockaddr_in))
 
+#define FI_IBV_RDM_RESOLVE_ADDR_TIMEOUT (30000)
 #define FI_IBV_RDM_CM_THREAD_TIMEOUT (100)
 #define FI_IBV_RDM_MEM_ALIGNMENT (64)
 #define FI_IBV_RDM_BUF_ALIGNMENT (4096) /* TODO: Page or MTU size */

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -60,6 +60,7 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 		.rndv_seg_size		= FI_IBV_RDM_SEG_MAXSIZE,
 		.thread_timeout		= FI_IBV_RDM_CM_THREAD_TIMEOUT,
 		.eager_send_opcode	= "IBV_WR_SEND",
+		.resolve_addr_timeout	= FI_IBV_RDM_RESOLVE_ADDR_TIMEOUT,
 	},
 
 	.dgram			= {
@@ -690,6 +691,14 @@ static int fi_ibv_read_params(void)
 				 &fi_ibv_gl_data.rdm.eager_send_opcode)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of rdm_eager_send_opcode\n");
+		return -FI_EINVAL;
+	}
+	if (fi_ibv_get_param_int("rdm_resolve_addr_timeout", "Time (microseconds) to wait "
+				 "for address resolution to complete",
+				 &fi_ibv_gl_data.rdm.resolve_addr_timeout) ||
+	    (fi_ibv_gl_data.rdm.resolve_addr_timeout < 0)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid value of rdm_resolve_addr_timeout\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -169,6 +169,7 @@ extern struct fi_ibv_gl_data {
 		int	rndv_seg_size;
 		int	thread_timeout;
 		char	*eager_send_opcode;
+		int	resolve_addr_timeout;
 	} rdm;
 
 	struct {


### PR DESCRIPTION
Seems, verbs/RDM is weak when running 90 tasks/ranks in 45 nodes.
It's just a workaround for the #3458 issue

The intent of this patch is to evaluate good enough timeout value for the `rdma_resolve_addr` call running at this scale.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>