### PR TITLE
prov/gni: plug race condition in rma get path

### DIFF
--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -477,8 +477,7 @@ static int __gnix_rma_txd_complete(void *arg, gni_return_t tx_status)
 		 * complete. */
 		req->rma.status |= tx_status;
 
-		ofi_atomic_dec32(&req->rma.outstanding_txds);
-		if (ofi_atomic_get32(&req->rma.outstanding_txds)) {
+		if (ofi_atomic_dec32(&req->rma.outstanding_txds) == 1) {
 			_gnix_nic_tx_free(req->gnix_ep->nic, txd);
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "Received first RDMA chain TXD, req: %p\n",


### PR DESCRIPTION
There was a race condition in the rma get path
for unaligned source buffers.  There was an
atomic dec followed by an atomic read.  This
leads to a race condition when using the GNI
provider in multi-threaded conditions.

upstream merge of ofi-cray/libfabric-cray#1418

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ofi-cray/libfabric-cray@778825a043c469e8e75677309c38a5d188bbdb44)