### PR TITLE
prov/verbs: Re-transmit WRs after `transport retry counter exceeded` error

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -710,8 +710,14 @@ static int fi_ibv_rdm_poll_cq(struct fi_ibv_rdm_ep *ep)
 
 	ret = ibv_poll_cq(ep->scq, wc_count, wc);
 	for (i = 0; i < ret; ++i)
-		if (fi_ibv_rdm_process_send_wc(ep, &wc[i]))
-			fi_ibv_rdm_process_err_send_wc(ep, &wc[i]);
+		if (fi_ibv_rdm_process_send_wc(ep, &wc[i])) {
+			if (wc[i].status != IBV_WC_RETRY_EXC_ERR) {
+				fi_ibv_rdm_process_err_send_wc(ep, &wc[i]);
+			} else {
+				fi_ibv_rdm_proccess_retry_counter_exc(ep, &wc[i],
+								      ret - i);
+			}
+		}
 
 	return ret;
 }

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -228,12 +228,17 @@ static ssize_t fi_ibv_rdm_inject(struct fid_ep *ep_fid, const void *buf,
 			struct ibv_sge sge = {0};
 			struct ibv_send_wr wr = {0};
 			struct ibv_send_wr *bad_wr = NULL;
-
+			struct fi_ibv_rdm_service_request *sreq =
+				util_buf_alloc(ep->fi_ibv_rdm_service_request_pool);
+			if (OFI_UNLIKELY(!sreq)) {
+				assert(0);
+				return -FI_EAGAIN;
+			}
 			sge.addr = (uintptr_t)(void*)sbuf;
 			sge.length = size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE;
 			sge.lkey = conn->s_mr->lkey;
 
-			wr.wr_id = FI_IBV_RDM_PACK_SERVICE_WR(conn);
+			wr.wr_id = FI_IBV_RDM_PACK_SERVICE_WR(sreq);
 			wr.sg_list = &sge;
 			wr.num_sge = 1;
 			wr.wr.rdma.remote_addr = (uintptr_t)
@@ -250,13 +255,19 @@ static ssize_t fi_ibv_rdm_inject(struct fid_ep *ep_fid, const void *buf,
 
 			FI_IBV_RDM_SET_PKTTYPE(sbuf->header.service_tag,
 					       FI_IBV_RDM_MSG_PKT);
-			if ((len > 0) && (buf)) {
+			if ((len > 0) && (buf))
 				memcpy(&sbuf->payload, buf, len);
-			}
 
 			FI_IBV_RDM_INC_SIG_POST_COUNTERS(conn, ep,
 							 wr.send_flags);
+
+			sreq->conn = conn;
+			sreq->send_sge = sge;
+			sreq->send_wr = wr;
+
 			if (ibv_post_send(conn->qp[0], &wr, &bad_wr)) {
+				util_buf_release(ep->fi_ibv_rdm_service_request_pool,
+						 sreq);
 				assert(0);
 				return -errno;
 			} else {


### PR DESCRIPTION
The patch addressed the following problems:
- Memory leak in case of all/part of the pools are allocated, but `fi_endpoint()` fails
- Retrying of the send operations in case of the `IBV_WC_RETRY_EXC_ERR` WC status from ibv_poll_cq. The all outstanding WR will be returned back with status - `IBV_WC_WR_FLUSH_ERR`. We will resend all of them 


Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>