### PR TITLE
prov/verbs: Fix possbile crash by accessing not set EP-ops functions

### DIFF
--- a/prov/verbs/src/ep_dgram/verbs_dgram_ep.c
+++ b/prov/verbs/src/ep_dgram/verbs_dgram_ep.c
@@ -384,6 +384,7 @@ static struct fi_ops_cm fi_ibv_dgram_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 static struct fi_ops_ep fi_ibv_dgram_ep_ops = {

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -404,7 +404,15 @@ struct fi_ops_tagged fi_ibv_rdm_tagged_ops = {
 
 struct fi_ops_cm fi_ibv_rdm_tagged_ep_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
-	.getname = fi_ibv_rdm_tagged_getname,	/* TODO */
+	.getname = fi_ibv_rdm_tagged_getname,
+	.setname = fi_no_setname,
+	.getpeer = fi_no_getpeer,
+	.connect = fi_no_connect,
+	.listen = fi_no_listen,
+	.accept = fi_no_accept,
+	.reject = fi_no_reject,
+	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 static inline void


### PR DESCRIPTION
EP/RDM and EP/DGRAM has some non-implemented functions.
Just to avoid possible crash, set them to to the non-operational stub functions

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>