### PR TITLE
prov/usnic: swat a compiler warning

### DIFF
--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -746,6 +746,7 @@ out:
 static int usdf_ep_dgram_control(struct fid *fid, int command, void *arg)
 {
 	struct fid_ep *ep;
+	int ret;
 
 	USDF_TRACE_SYS(EP_CTRL, "\n");
 
@@ -754,15 +755,17 @@ static int usdf_ep_dgram_control(struct fid *fid, int command, void *arg)
 		ep = container_of(fid, struct fid_ep, fid);
 		switch (command) {
 		case FI_ENABLE:
-			return usdf_ep_dgram_enable(ep);
+			ret = usdf_ep_dgram_enable(ep);
 			break;
 		default:
-			return -FI_ENOSYS;
+			ret = -FI_ENOSYS;
 		}
 		break;
 	default:
-		return -FI_ENOSYS;
+		ret = -FI_ENOSYS;
 	}
+
+	return ret;
 }
 
 static struct fi_ops usdf_ep_dgram_ops = {

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -901,6 +901,7 @@ static struct fi_ops_msg usdf_msg_ops = {
 static int usdf_ep_msg_control(struct fid *fid, int command, void *arg)
 {
 	struct fid_ep *ep;
+	int ret;
 
 	USDF_TRACE_SYS(EP_CTRL, "\n");
 
@@ -909,15 +910,17 @@ static int usdf_ep_msg_control(struct fid *fid, int command, void *arg)
 		ep = container_of(fid, struct fid_ep, fid);
 		switch (command) {
 		case FI_ENABLE:
-			return usdf_ep_msg_enable(ep);
+			ret = usdf_ep_msg_enable(ep);
 			break;
 		default:
-			return -FI_ENOSYS;
+			ret = -FI_ENOSYS;
 		}
 		break;
 	default:
-		return -FI_ENOSYS;
+		ret = -FI_ENOSYS;
 	}
+
+	return ret;
 }
 
 static struct fi_ops usdf_ep_msg_ops = {

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -974,6 +974,7 @@ static struct fi_ops_msg usdf_rdm_ops = {
 static int usdf_ep_rdm_control(struct fid *fid, int command, void *arg)
 {
 	struct fid_ep *ep;
+	int ret;
 
 	USDF_TRACE_SYS(EP_CTRL, "\n");
 
@@ -982,15 +983,17 @@ static int usdf_ep_rdm_control(struct fid *fid, int command, void *arg)
 		ep = container_of(fid, struct fid_ep, fid);
 		switch (command) {
 		case FI_ENABLE:
-			return usdf_ep_rdm_enable(ep);
+			ret = usdf_ep_rdm_enable(ep);
 			break;
 		default:
-			return -FI_ENOSYS;
+			ret = -FI_ENOSYS;
 		}
 		break;
 	default:
-		return -FI_ENOSYS;
+		ret = -FI_ENOSYS;
 	}
+
+	return ret;
 }
 
 static struct fi_ops usdf_ep_rdm_ops = {


### PR DESCRIPTION
gcc 6.3.0 was complaining about no return value
when compiling parts of usnic provider.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>