### PR TITLE
prov/util: Restructure and fix mr_mode checks

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -602,11 +602,6 @@ int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
  */
 #define OFI_MR_BASIC_MAP (FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR)
 
-#define OFI_CHECK_MR_BASIC(mode) ((mode == FI_MR_BASIC) || \
-				  ((mode & OFI_MR_BASIC_MAP) == OFI_MR_BASIC_MAP))
-
-#define OFI_CHECK_MR_SCALABLE(mode) (!(mode & OFI_MR_BASIC_MAP))
-
 /* FI_LOCAL_MR is valid in pre-libfaric-1.5 and can be valid in
  * post-libfabric-1.5 */
 #define OFI_CHECK_MR_LOCAL(info) \
@@ -620,15 +615,6 @@ struct ofi_mr_map {
 	uint64_t		key;
 	enum fi_mr_mode		mode;
 };
-
-static inline void ofi_mr_mode_adjust(uint64_t info_caps, int *mr_mode)
-{
-	if (!ofi_rma_target_allowed(info_caps)) {
-		*mr_mode &= ~(FI_MR_PROV_KEY | FI_MR_VIRT_ADDR);
-		if (!(*mr_mode & FI_MR_LOCAL))
-			*mr_mode &= ~FI_MR_ALLOCATED;
-	}
-}
 
 /* If the app sets FI_MR_LOCAL, we ignore FI_LOCAL_MR.  So, if the
  * app doesn't set FI_MR_LOCAL, we need to check for FI_LOCAL_MR.
@@ -676,8 +662,7 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 			   FI_LOCAL_COMM | FI_REMOTE_COMM)
 
 int ofi_check_mr_mode(const struct fi_provider *prov, uint32_t api_version,
-		      uint64_t user_info_caps, uint32_t prov_mode,
-		      uint32_t user_mode);
+		      int prov_mode, const struct fi_info *user_info);
 int ofi_check_fabric_attr(const struct fi_provider *prov,
 			  const struct fi_fabric_attr *prov_attr,
 			  const struct fi_fabric_attr *user_attr);

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -271,7 +271,8 @@ static struct fi_info *_gnix_allocinfo(void)
 
 	gnix_info->domain_attr->name = strdup(gnix_dom_name);
 	gnix_info->domain_attr->cq_data_size = sizeof(uint64_t);
-	gnix_info->domain_attr->mr_mode = FI_MR_BASIC;
+	gnix_info->domain_attr->mr_mode = FI_MR_BASIC | FI_MR_SCALABLE |
+					  OFI_MR_BASIC_MAP;
 	gnix_info->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	gnix_info->domain_attr->mr_key_size = sizeof(uint64_t);
 	gnix_info->domain_attr->max_ep_tx_ctx = GNIX_SEP_MAX_CNT;
@@ -612,11 +613,9 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 				gnix_info->domain_attr->data_progress =
 					hints->domain_attr->data_progress;
 
-			if (ofi_check_mr_mode(&gnix_prov,
-					version,
-					hints->caps,
+			if (ofi_check_mr_mode(&gnix_prov, version,
 					gnix_info->domain_attr->mr_mode,
-					hints->domain_attr->mr_mode) != FI_SUCCESS) {
+					hints) != FI_SUCCESS) {
 				GNIX_DEBUG(FI_LOG_DOMAIN,
 					"failed ofi_check_mr_mode, "
 					"ret=%d\n", ret);
@@ -636,8 +635,10 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 					goto err;
 				}
 			} else {
+				/* FIXME: Check will not work with ofi_check_mr_mode
 				if (__gnix_check_mr_mode(mr_mode))
 					goto err;
+				*/
 
 				/* define the mode we return to the user
 				 * prefer basic until scalable

--- a/prov/netdir/src/netdir_init.c
+++ b/prov/netdir/src/netdir_init.c
@@ -113,7 +113,7 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 	info->domain_attr->data_progress = FI_PROGRESS_AUTO;
 	info->domain_attr->resource_mgmt = FI_RM_DISABLED;
 	info->domain_attr->av_type = FI_AV_UNSPEC;
-	info->domain_attr->mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL;
+	info->domain_attr->mr_mode = FI_MR_BASIC | OFI_MR_BASIC_MAP | FI_MR_LOCAL;
 	info->domain_attr->cq_cnt = (size_t)adapter->MaxCompletionQueueDepth;
 	info->domain_attr->mr_iov_limit = ND_MSG_IOV_LIMIT;
 	info->domain_attr->mr_cnt = OFI_ND_MAX_MR_CNT;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -62,6 +62,7 @@
 #define RXM_BUF_SIZE 16384
 #define RXM_IOV_LIMIT 4
 
+#define RXM_MR_MODES	(OFI_MR_BASIC_MAP | FI_MR_LOCAL)
 #define RXM_MR_VIRT_ADDR(info) ((info->domain_attr->mr_mode == FI_MR_BASIC) ||\
 				info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)
 

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -78,7 +78,7 @@ struct fi_domain_attr rxm_domain_attr = {
 	/* Advertise support for FI_MR_BASIC so that ofi_check_info call
 	 * doesn't fail at RxM level. If an app requires FI_MR_BASIC, it
 	 * would be passed down to core provider. */
-	.mr_mode = FI_MR_BASIC,
+	.mr_mode = FI_MR_BASIC | FI_MR_SCALABLE,
 	.cq_data_size = sizeof_field(struct ofi_op_hdr, data),
 	.cq_cnt = (1 << 16),
 	.ep_cnt = (1 << 15),

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -470,7 +470,6 @@ static int rxm_handle_remote_write(struct rxm_ep *rxm_ep,
 static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 				  struct fi_cq_tagged_entry *comp)
 {
-	enum rxm_proto_state state = RXM_GET_PROTO_STATE(comp);
 	struct rxm_rx_buf *rx_buf = comp->op_context;
 	struct rxm_tx_entry *tx_entry = comp->op_context;
 
@@ -479,7 +478,7 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	if (comp->flags & FI_REMOTE_WRITE)
 		return rxm_handle_remote_write(rxm_ep, comp);
 
-	switch (state) {
+	switch (RXM_GET_PROTO_STATE(comp)) {
 	case RXM_TX_NOBUF:
 		assert(comp->flags & (FI_SEND | FI_WRITE | FI_READ));
 		return rxm_finish_send_nobuf(tx_entry);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -129,13 +129,6 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->ep_attr->max_order_waw_size = core_info->ep_attr->max_order_waw_size;
 
 	*info->domain_attr = *rxm_info.domain_attr;
-	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-		/* ofi_alter_info assumes version 1.5 or above mr_mode bits */
-		if (core_info->domain_attr->mr_mode == FI_MR_BASIC)
-			info->domain_attr->mr_mode |= OFI_MR_BASIC_MAP;
-	} else {
-		info->domain_attr->mr_mode |= core_info->domain_attr->mr_mode;
-	}
 	info->domain_attr->cq_data_size = MIN(core_info->domain_attr->cq_data_size,
 					      rxm_info.domain_attr->cq_data_size);
 

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -51,7 +51,7 @@ const struct fi_domain_attr sock_domain_attr = {
 	.data_progress = FI_PROGRESS_AUTO,
 	.resource_mgmt = FI_RM_ENABLED,
 	/* Provider supports basic memory registration mode */
-	.mr_mode = FI_MR_BASIC,
+	.mr_mode = FI_MR_BASIC | FI_MR_SCALABLE,
 	.mr_key_size = sizeof(uint64_t),
 	.cq_data_size = sizeof(uint64_t),
 	.cq_cnt = SOCK_EP_MAX_CQ_CNT,
@@ -132,8 +132,8 @@ int sock_verify_domain_attr(uint32_t version, const struct fi_info *info)
 		return -FI_ENODATA;
 	}
 
-	if (ofi_check_mr_mode(&sock_prov, version, info->caps,
-			      sock_domain_attr.mr_mode, attr->mr_mode)) {
+	if (ofi_check_mr_mode(&sock_prov, version,
+			      sock_domain_attr.mr_mode, info)) {
 		FI_INFO(&sock_prov, FI_LOG_CORE,
 			"Invalid memory registration mode\n");
 		return -FI_ENODATA;

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -253,9 +253,8 @@ usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 		if (ofi_check_mr_mode(&usdf_ops,
 				      fabric->api_version,
-				      info->caps,
-				      OFI_MR_BASIC_MAP | FI_MR_LOCAL,
-				      info->domain_attr->mr_mode)) {
+				      FI_MR_BASIC | OFI_MR_BASIC_MAP | FI_MR_LOCAL,
+				      info)) {
 			/* the caller ignored our fi_getinfo results */
 			USDF_WARN_SYS(DOMAIN, "MR mode (%d) not supported\n",
 				      info->domain_attr->mr_mode);
@@ -518,9 +517,9 @@ int usdf_check_mr_mode(uint32_t version, const struct fi_info *hints,
 {
 	int ret;
 
-	ret = ofi_check_mr_mode(&usdf_ops, version, hints->caps, prov_mode,
-				hints->domain_attr->mr_mode);
+	ret = ofi_check_mr_mode(&usdf_ops, version, prov_mode, hints);
 
+	/* TODO: Checks below may not be needed */
 	/* If ofi_check_mr_mode fails. */
 	if (ret) {
 		/* Is it because the user give 0 as mr_mode? */

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -428,63 +428,74 @@ static int fi_resource_mgmt_level(enum fi_resource_mgmt rm_model)
 	}
 }
 
-/* If a provider supports basic registration mode it should set the FI_MR_BASIC
- * mode bit in prov_mode. Support for FI_MR_SCALABLE is indicated by not setting
- * any of OFI_MR_BASIC_MAP bits. */
-int ofi_check_mr_mode(const struct fi_provider *prov, uint32_t api_version,
-		      uint64_t user_info_caps, uint32_t prov_mode,
-		      uint32_t user_mode)
+/*
+ * Remove unneeded MR mode bits based on the requested capability bits.
+ */
+static int ofi_cap_mr_mode(uint64_t info_caps, int mr_mode)
 {
-	uint64_t prov_mode_log;
-	int ret;
-
-	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5))) {
-		if (!ofi_rma_target_allowed(user_info_caps) &&
-		    !(prov_mode & FI_MR_LOCAL))
+	if (!ofi_rma_target_allowed(info_caps)) {
+		if (!(mr_mode & FI_MR_LOCAL))
 			return 0;
 
-		prov_mode &= ~FI_MR_LOCAL; /* ignore local bit */
+		mr_mode &= ~(FI_MR_RAW | FI_MR_VIRT_ADDR |
+			     FI_MR_PROV_KEY | FI_MR_RMA_EVENT);
+	}
 
+	return mr_mode & ~(FI_MR_BASIC | FI_MR_SCALABLE);
+}
+
+/*
+ * Providers should set v1.0 registration modes (FI_MR_BASIC and
+ * FI_MR_SCALABLE) that they support, along with all required modes.
+ */
+int ofi_check_mr_mode(const struct fi_provider *prov, uint32_t api_version,
+		      int prov_mode, const struct fi_info *user_info)
+{
+	int user_mode = user_info->domain_attr->mr_mode;
+	int ret = -FI_ENODATA;
+
+	if ((prov_mode & FI_MR_LOCAL) &&
+	    !((user_info->mode & FI_LOCAL_MR) || (user_mode & FI_MR_LOCAL)))
+		goto out;
+
+	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5))) {
 		switch (user_mode) {
 		case FI_MR_UNSPEC:
-			ret = OFI_CHECK_MR_SCALABLE(prov_mode) ||
-				OFI_CHECK_MR_BASIC(prov_mode) ?
-				0 : -FI_ENODATA;
+			if (!(prov_mode & (FI_MR_SCALABLE | FI_MR_BASIC)))
+				goto out;
 			break;
 		case FI_MR_BASIC:
-			ret = OFI_CHECK_MR_BASIC(prov_mode) ? 0 : -FI_ENODATA;
+			if (!(prov_mode & FI_MR_BASIC))
+				goto out;
 			break;
 		case FI_MR_SCALABLE:
-			ret = OFI_CHECK_MR_SCALABLE(prov_mode) ? 0 : -FI_ENODATA;
+			if (!(prov_mode & FI_MR_SCALABLE))
+				goto out;
 			break;
 		default:
-			ret = -FI_ENODATA;
-			break;
+			goto out;
 		}
 	} else {
-		ofi_mr_mode_adjust(user_info_caps, (int *)&prov_mode);
-
 		if (user_mode & FI_MR_BASIC) {
-			if (!OFI_CHECK_MR_BASIC(prov_mode))
-				ret = -FI_ENODATA;
-			else if ((user_mode & prov_mode & ~OFI_MR_BASIC_MAP) ==
-				 (prov_mode & ~OFI_MR_BASIC_MAP))
-				ret = 0;
-			else
-				ret = -FI_ENODATA;
+			if ((user_mode & ~FI_MR_BASIC) ||
+			    !(prov_mode & FI_MR_BASIC))
+				goto out;
+		} else if (user_mode & FI_MR_SCALABLE) {
+			if ((user_mode & ~FI_MR_SCALABLE) ||
+			    !(prov_mode & FI_MR_SCALABLE))
+				goto out;
 		} else {
-			ret = (((user_mode | FI_MR_BASIC) & prov_mode) ==
-			       prov_mode) ? 0 : -FI_ENODATA;
+			prov_mode = ofi_cap_mr_mode(user_info->caps, prov_mode);
+			if ((user_mode & prov_mode) != prov_mode)
+				goto out;
 		}
 	}
 
+	ret = 0;
+out:
 	if (ret) {
 		FI_INFO(prov, FI_LOG_CORE, "Invalid memory registration mode\n");
-		if (FI_VERSION_GE(api_version, FI_VERSION(1, 5)))
-			prov_mode_log = prov_mode & ~(FI_MR_BASIC | FI_MR_SCALABLE);
-		else
-			prov_mode_log = prov_mode;
-		FI_INFO_MR_MODE(prov, prov_mode_log, user_mode);
+		FI_INFO_MR_MODE(prov, prov_mode, user_mode);
 	}
 
 	return ret;
@@ -540,8 +551,7 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 		return -FI_ENODATA;
 	}
 
-	if (ofi_check_mr_mode(prov, api_version, user_info->caps,
-			      prov_attr->mr_mode, user_attr->mr_mode))
+	if (ofi_check_mr_mode(prov, api_version, prov_attr->mr_mode, user_info))
 		return -FI_ENODATA;
 
 	/* following checks only apply to api 1.5 and beyond */
@@ -1017,13 +1027,20 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 				 const struct fi_domain_attr *hints,
 				 uint64_t info_caps, uint32_t api_version)
 {
-	ofi_mr_mode_adjust(info_caps, &attr->mr_mode);
+	int hints_mr_mode;
 
-	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5)))
-		attr->mr_mode = attr->mr_mode & OFI_MR_BASIC_MAP ?
-			FI_MR_BASIC : FI_MR_SCALABLE;
-	else
-		attr->mr_mode &= ~(FI_MR_BASIC | FI_MR_SCALABLE);
+	hints_mr_mode = hints ? hints->mr_mode : 0;
+	if (hints_mr_mode & (FI_MR_BASIC | FI_MR_SCALABLE)) {
+		attr->mr_mode = hints_mr_mode;
+	} else if (FI_VERSION_LT(api_version, FI_VERSION(1, 5))) {
+		attr->mr_mode = (attr->mr_mode && attr->mr_mode != FI_MR_SCALABLE) ?
+				FI_MR_BASIC : FI_MR_SCALABLE;
+	} else {
+		if ((hints_mr_mode & attr->mr_mode) != attr->mr_mode) {
+			attr->mr_mode = ofi_cap_mr_mode(info_caps,
+						attr->mr_mode & hints_mr_mode);
+		}
+	}
 
 	attr->caps = ofi_get_caps(info_caps, hints ? hints->caps : 0, attr->caps);
 	if (!hints)


### PR DESCRIPTION
Running an updated fi_getinfo_test to validate mr_mode, the
ofi_rxm;sockets provider fails.  The core issue is that the
mr_mode checks and subsequent alterations fail to handle
applications that request FI_MR_BASIC or FI_MR_SCALABLE when
running with api version 1.5 or new.

To fix this, we restructure the mr_mode checks in an attempt
to simplify things.  Providers now indicate if they support
FI_MR_BASIC and FI_MR_SCALABLE by explicitly setting those
mr_mode bits.  Previously, FI_MR_SCALABLE was assumed based
on no other bits being set.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>