### PR TITLE
prov/verbs: Some cleanups for verbs/RDM

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -67,6 +67,7 @@ fi_ibv_rdm_find_max_inline(struct ibv_pd *pd, struct ibv_context *context)
 	qp_attr.cap.max_recv_wr = 1;
 	qp_attr.cap.max_send_sge = 1;
 	qp_attr.cap.max_recv_sge = 1;
+	qp_attr.sq_sig_all = 1;
 
 	do {
 		if (qp)

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -75,12 +75,11 @@
 
 // Send/Recv counters control
 
-#define FI_IBV_RDM_INC_SIG_POST_COUNTERS(_connection, _ep, _send_flags)		\
+#define FI_IBV_RDM_INC_SIG_POST_COUNTERS(_connection, _ep)			\
 do {                                                                		\
 	int32_t sends_outgoing =						\
 		ofi_atomic_inc32(&(_connection)->av_entry->sends_outgoing);	\
 	ofi_atomic_inc32(&(_ep)->posted_sends);					\
-	(_send_flags) |= IBV_SEND_SIGNALED;                             	\
 										\
 	(void)sends_outgoing;							\
 	VERBS_DBG(FI_LOG_CQ, "SEND_COUNTER++, conn %p, sends_outgoing %d\n",    \

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -61,17 +61,17 @@
 
 // WR - work request
 #define FI_IBV_RDM_SERVICE_WR_MASK              ((uint64_t)0x1)
-#define FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(value) \
+#define FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(value)	\
         (value & FI_IBV_RDM_SERVICE_WR_MASK)
 
-#define FI_IBV_RDM_PACK_WR(value)               ((uint64_t)value)
-#define FI_IBV_RDM_UNPACK_WR(value)             ((void*)(uintptr_t)value)
+#define FI_IBV_RDM_PACK_WR(value)               ((uint64_t)(uintptr_t)(void *)value)
+#define FI_IBV_RDM_UNPACK_WR(value)             ((void *)(uintptr_t)value)
 
-#define FI_IBV_RDM_PACK_SERVICE_WR(value)       \
-        (((uint64_t)(uintptr_t)(void*)value) | FI_IBV_RDM_SERVICE_WR_MASK)
+#define FI_IBV_RDM_PACK_SERVICE_WR(value)					\
+        (((uint64_t)(uintptr_t)(void *)value) | FI_IBV_RDM_SERVICE_WR_MASK)
 
-#define FI_IBV_RDM_UNPACK_SERVICE_WR(value)     \
-        ((void*)(uintptr_t)(value & (~(FI_IBV_RDM_SERVICE_WR_MASK))))
+#define FI_IBV_RDM_UNPACK_SERVICE_WR(value)				\
+        ((void *)(uintptr_t)(value & (~(FI_IBV_RDM_SERVICE_WR_MASK))))
 
 // Send/Recv counters control
 
@@ -726,7 +726,7 @@ fi_ibv_rdm_process_send_wc(struct fi_ibv_rdm_ep *ep,
 	} else {
 		FI_IBV_DBG_OPCODE(wc->opcode, "SEND");
 		struct fi_ibv_rdm_request *request =
-			(void *)FI_IBV_RDM_UNPACK_WR(wc->wr_id);
+			FI_IBV_RDM_UNPACK_WR(wc->wr_id);
 
 		struct fi_ibv_rdm_tagged_send_completed_data data =
 			{ .ep = ep };
@@ -743,11 +743,10 @@ fi_ibv_rdm_process_err_send_wc(struct fi_ibv_rdm_ep *ep,
 	if (wc->status != IBV_WC_SUCCESS) {
 		struct fi_ibv_rdm_conn *conn;
 		if (FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wc->wr_id)) {
-			conn = FI_IBV_RDM_UNPACK_SERVICE_WR(
-					wc->wr_id);
+			conn = FI_IBV_RDM_UNPACK_SERVICE_WR(wc->wr_id);
 		} else {
 			struct fi_ibv_rdm_request *req =
-					(void *)wc->wr_id;
+				FI_IBV_RDM_UNPACK_WR(wc->wr_id);
 			conn = req->minfo.conn;
 			FI_IBV_RDM_DBG_REQUEST("to_pool: ", req,
 					       FI_LOG_DEBUG);

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -233,7 +233,7 @@ fi_ibv_rdm_tagged_init_qp_attributes(struct ibv_qp_init_attr *qp_attr,
 	qp_attr->cap.max_send_sge = 1;
 	qp_attr->cap.max_recv_sge = 1;
 	qp_attr->cap.max_inline_data = ep->max_inline_rc;
-
+	qp_attr->sq_sig_all = 1;
 }
 
 static inline int

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -95,7 +95,7 @@ fi_ibv_rdm_batch_repost_receives(struct fi_ibv_rdm_conn *conn,
 			sge[last].length = ep->buff_len;
 			sge[last].lkey = conn->r_mr->lkey;
 
-			wr[last].wr_id = (uintptr_t) conn;
+			wr[last].wr_id = (uintptr_t)conn;
 			wr[last].next = NULL;
 			wr[last].sg_list = &sge[last];
 			wr[last].num_sge = 1;
@@ -114,7 +114,7 @@ fi_ibv_rdm_batch_repost_receives(struct fi_ibv_rdm_conn *conn,
 		}
 	} else {
 		if (last >= 0) {
-			wr[last].wr_id = (uintptr_t) conn;
+			wr[last].wr_id = (uintptr_t)conn;
 			wr[last].next = NULL;
 			wr[last].sg_list = &sge[last];
 			wr[last].num_sge = 1;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -225,13 +225,13 @@ static ssize_t fi_ibv_rdm_inject(struct fid_ep *ep_fid, const void *buf,
 		struct fi_ibv_rdm_buf *sbuf = 
 			fi_ibv_rdm_prepare_send_resources(conn, ep);
 		if (sbuf) {
-			struct ibv_sge sge = {0};
 			struct ibv_send_wr wr = {0};
 			struct ibv_send_wr *bad_wr = NULL;
-
-			sge.addr = (uintptr_t)(void*)sbuf;
-			sge.length = size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE;
-			sge.lkey = conn->s_mr->lkey;
+			struct ibv_sge sge = {
+				.addr = (uintptr_t)(void*)sbuf,
+				.length = size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE,
+				.lkey = conn->s_mr->lkey,
+			};
 
 			wr.wr_id = FI_IBV_RDM_PACK_SERVICE_WR(conn);
 			wr.sg_list = &sge;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -254,8 +254,7 @@ static ssize_t fi_ibv_rdm_inject(struct fid_ep *ep_fid, const void *buf,
 				memcpy(&sbuf->payload, buf, len);
 			}
 
-			FI_IBV_RDM_INC_SIG_POST_COUNTERS(conn, ep,
-							 wr.send_flags);
+			FI_IBV_RDM_INC_SIG_POST_COUNTERS(conn, ep);
 			if (ibv_post_send(conn->qp[0], &wr, &bad_wr)) {
 				assert(0);
 				return -errno;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -227,13 +227,13 @@ fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len,
 		struct fi_ibv_rdm_buf *sbuf = 
 			fi_ibv_rdm_prepare_send_resources(conn, ep);
 		if (sbuf) {
-			struct ibv_sge sge = {0};
 			struct ibv_send_wr wr = {0};
 			struct ibv_send_wr *bad_wr = NULL;
-
-			sge.addr = (uintptr_t)(void*)sbuf;
-			sge.length = size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE;
-			sge.lkey = conn->s_mr->lkey;
+			struct ibv_sge sge = {
+				.addr = (uintptr_t)(void*)sbuf,
+				.length = size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE,
+				.lkey = conn->s_mr->lkey,
+			};
 
 			wr.wr_id = FI_IBV_RDM_PACK_SERVICE_WR(conn);
 			wr.sg_list = &sge;
@@ -419,13 +419,13 @@ static inline void
 fi_ibv_rdm_tagged_release_remote_sbuff(struct fi_ibv_rdm_conn *conn,
 					struct fi_ibv_rdm_ep *ep)
 {
-	struct ibv_sge sge;
-	sge.addr = (uint64_t) & conn->sbuf_ack_status;
-	sge.length = sizeof(conn->sbuf_ack_status);
-	sge.lkey = conn->ack_mr->lkey;
-
 	struct ibv_send_wr *bad_wr = NULL;
 	struct ibv_send_wr wr = { 0 };
+	struct ibv_sge sge = {
+		.addr = (uint64_t) &conn->sbuf_ack_status,
+		.length = sizeof(conn->sbuf_ack_status),
+		.lkey = conn->ack_mr->lkey,
+	};
 
 	wr.wr_id = FI_IBV_RDM_PACK_SERVICE_WR(conn);
 	wr.sg_list = &sge;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -256,8 +256,7 @@ fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len,
 				memcpy(&sbuf->payload, buf, len);
 			}
 
-			FI_IBV_RDM_INC_SIG_POST_COUNTERS(conn, ep,
-							 wr.send_flags);
+			FI_IBV_RDM_INC_SIG_POST_COUNTERS(conn, ep);
 			if (ibv_post_send(conn->qp[0], &wr, &bad_wr)) {
 				assert(0);
 				return -errno;
@@ -437,7 +436,7 @@ fi_ibv_rdm_tagged_release_remote_sbuff(struct fi_ibv_rdm_conn *conn,
 	/* w/o imm - do not put it into recv completion queue */
 	wr.opcode = IBV_WR_RDMA_WRITE;
 
-	FI_IBV_RDM_INC_SIG_POST_COUNTERS(conn, ep, wr.send_flags);
+	FI_IBV_RDM_INC_SIG_POST_COUNTERS(conn, ep);
 	VERBS_DBG(FI_LOG_EP_DATA,
 		"posted %d bytes, remote sbuff released\n", sge.length);
 	int ret = ibv_post_send(conn->qp[0], &wr, &bad_wr);

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -187,8 +187,7 @@ fi_ibv_rdm_eager_send_ready(struct fi_ibv_rdm_request *request, void *data)
 		}
 	}
 
-	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn,
-					 p->ep, wr.send_flags);
+	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep);
 	VERBS_DBG(FI_LOG_EP_DATA, "posted %d bytes, conn %p, tag 0x%" PRIx64 "\n",
 		  sge.length, request->minfo.conn, request->minfo.tag);
 
@@ -317,8 +316,7 @@ fi_ibv_rdm_rndv_rts_send_ready(struct fi_ibv_rdm_request *request, void *data)
 		  request->minfo.tag, request->len, request->src_addr, mr->rkey,
 		  request->context, (int)wr.imm_data, ofi_atomic_get32(&p->ep->posted_sends));
 
-	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep,
-		wr.send_flags);
+	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep);
 	VERBS_DBG(FI_LOG_EP_DATA, "posted %d bytes, conn %p, tag 0x%" PRIx64 "\n",
 		  sge.length, request->minfo.conn,
 		  request->minfo.tag);
@@ -1130,7 +1128,7 @@ fi_ibv_rdm_rndv_recv_post_read(struct fi_ibv_rdm_request *request, void *data)
 
 	request->rest_len -= seg_cursize;
 	request->post_counter++;
-	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep, wr.send_flags);
+	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep);
 	VERBS_DBG(FI_LOG_EP_DATA, "posted %d bytes, conn %p, tag 0x%" PRIx64 "\n",
 		  sge.length, request->minfo.conn, request->minfo.tag);
 	ret = ibv_post_send(request->minfo.conn->qp[0], &wr, &bad_wr);
@@ -1206,7 +1204,7 @@ fi_ibv_rdm_rndv_recv_read_lc(struct fi_ibv_rdm_request *request, void *data)
 	sge.lkey = conn->s_mr->lkey;
 	sbuf->service_data.pkt_len = ack_size;
 
-	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep, wr.send_flags);
+	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep);
 	VERBS_DBG(FI_LOG_EP_DATA,
 		  "posted %d bytes, conn %p, tag 0x%" PRIx64 ", request %p\n",
 		  sge.length, request->minfo.conn, request->minfo.tag, request);
@@ -1338,6 +1336,7 @@ fi_ibv_rdm_rma_inject_request(struct fi_ibv_rdm_request *request, void *data)
 	struct ibv_send_wr wr = { 0 };
 	struct ibv_send_wr *bad_wr = NULL;
 	struct fi_ibv_rdm_rma_start_data *p = data;
+	int ret;
 
 	request->minfo.conn = p->conn;
 	request->len = p->data_len;
@@ -1368,10 +1367,9 @@ fi_ibv_rdm_rma_inject_request(struct fi_ibv_rdm_request *request, void *data)
 		return -FI_EAGAIN;
 	}
 
-	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn,
-					 p->ep_rdm, wr.send_flags);
+	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep_rdm);
 
-	int ret = ibv_post_send(request->minfo.conn->qp[0], &wr, &bad_wr);
+	ret = ibv_post_send(request->minfo.conn->qp[0], &wr, &bad_wr);
 	request->state.eager = FI_IBV_STATE_EAGER_RMA_INJECT_WAIT4LC;
 	FI_IBV_RDM_HNDL_REQ_LOG_OUT();
 
@@ -1434,7 +1432,7 @@ fi_ibv_rdm_rma_post_ready(struct fi_ibv_rdm_request *request, void *data)
 
 	request->rest_len -= seg_cursize;
 	request->post_counter++;
-	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep_rdm, wr.send_flags);
+	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep_rdm);
 	int ret = ibv_post_send(request->minfo.conn->qp[0], &wr, &bad_wr);
 
 	if (request->rest_len) {


### PR DESCRIPTION
This patch is prepared to address the following:
- Utilize special macro instead of just casting
- verbs/RDM sets `IBV_SEND_SIGNALED` flag for each send operation. Remove this by setting `sq_sig_all` attribute during QP allocation.
- The QP is created twice for EP that has passive CM role.
   The first one is done during processing `RDMA_CM_EVENT_ADDR_RESOLVED` CM event
   The second one is done during processing connection request (`RDMA_CM_EVENT_CONNECT_REQUEST`)