### PR TITLE
prov/sockets optimization of sock_op_send structure

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -430,8 +430,6 @@ struct sock_op_send {
 	uint64_t context;
 	uint64_t dest_addr;
 	uint64_t buf;
-	uint64_t tag;
-	uint64_t data;
 	struct sock_ep *ep;
 	struct sock_conn *conn;
 };


### PR DESCRIPTION
tag field is not used for send. Data field is already accounted outside of this structure in sock_ep_sendmsg. So removing tag and data fields from the the structure as they are using up space in ring buffer for no reason.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>