### PR TITLE
prov/verbs: Fix hang in the MPI_Finalize during destroying of some EPs

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -391,7 +391,8 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 				/* No need to hold conn_lock during
 				 * CM progressing of the EP */
 				while (conn->state != FI_VERBS_CONN_ESTABLISHED &&
-				       conn->state != FI_VERBS_CONN_REJECTED) {
+				       conn->state != FI_VERBS_CONN_REJECTED &&
+				       conn->state != FI_VERBS_CONN_CLOSED) {
 					ret = fi_ibv_rdm_cm_progress(ep);
 					if (ret) {
 						VERBS_INFO(FI_LOG_AV, 


### PR DESCRIPTION
From time to time some MPI ranks (MPICH/CH4 device) hang in `fi_close` of a EP.
The `FI_VERBS_CONN_ESTABLISHED` -> `FI_VERBS_CONN_CLOSED` (conn_closed is received from remote side) leads to  this situation. We need to end up looping in case of `FI_VERBS_CONN_CLOSED`.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>