### PR TITLE
prov/verbs, util: getinfo updates + bug fixes

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -544,6 +544,16 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 			      prov_attr->mr_mode, user_attr->mr_mode))
 		return -FI_ENODATA;
 
+	if (user_attr->max_ep_stx_ctx > prov_attr->max_ep_stx_ctx) {
+		FI_INFO(prov, FI_LOG_CORE, "max_ep_stx_ctx greater than supported\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_ep_stx_ctx);
+	}
+
+	if (user_attr->max_ep_srx_ctx > prov_attr->max_ep_srx_ctx) {
+		FI_INFO(prov, FI_LOG_CORE, "max_ep_srx_ctx greater than supported\n");
+		FI_INFO_CHECK_VAL(prov, prov_attr, user_attr, max_ep_srx_ctx);
+	}
+
 	/* following checks only apply to api 1.5 and beyond */
 	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5)))
 		return 0;
@@ -622,7 +632,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 
 	if (user_attr->tx_ctx_cnt > prov_info->domain_attr->max_ep_tx_ctx) {
 		if (user_attr->tx_ctx_cnt == FI_SHARED_CONTEXT) {
-			if (!(util_prov->flags & UTIL_TX_SHARED_CTX)) {
+			if (!prov_info->domain_attr->max_ep_stx_ctx) {
 				FI_INFO(prov, FI_LOG_CORE,
 					"Shared tx context not supported\n");
 				return -FI_ENODATA;
@@ -639,7 +649,7 @@ int ofi_check_ep_attr(const struct util_prov *util_prov, uint32_t api_version,
 
 	if (user_attr->rx_ctx_cnt > prov_info->domain_attr->max_ep_rx_ctx) {
 		if (user_attr->rx_ctx_cnt == FI_SHARED_CONTEXT) {
-			if (!(util_prov->flags & UTIL_RX_SHARED_CTX)) {
+			if (!prov_info->domain_attr->max_ep_srx_ctx) {
 				FI_INFO(prov, FI_LOG_CORE,
 					"Shared rx context not supported\n");
 				return -FI_ENODATA;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1107,12 +1107,12 @@ static int fi_ibv_set_default_attr(struct fi_info *info, size_t *attr,
 				   size_t default_attr, char *attr_str)
 {
 	if (default_attr > *attr) {
-		VERBS_WARN(FI_LOG_FABRIC, "%s supported by domain: %s is less "
-			   "than provider's default\n", attr_str,
-			   info->domain_attr->name);
-		return -FI_EINVAL;
+		VERBS_WARN(FI_LOG_FABRIC, "Ignoring provider default value "
+			   "for %s as it is greater than the value supported "
+			   "by domain: %s\n", attr_str, info->domain_attr->name);
+	} else {
+		*attr = default_attr;
 	}
-	*attr = default_attr;
 	return 0;
 }
 


### PR DESCRIPTION
- prov/verbs: Don't throw error if default values are > supported by hardware
- prov/util: Add check for shared context counts
- prov/verbs: ACK CM event on error path