### PR TITLE
prov/verbs: Some code cleanups and simplifications

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -54,8 +54,8 @@ fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 		return FI_SUCCESS;
 
 	if (ep->is_closing) {
-		VERBS_INFO(FI_LOG_AV, "Attempt to start connection with addr "
-			   "%s:%u when ep is closing\n",
+		VERBS_INFO(FI_LOG_AV,
+			   "Attempt start connection with %s:%u when ep is closing\n",
 			   inet_ntoa(conn->addr.sin_addr),
 			   ntohs(conn->addr.sin_port));
 		return -FI_EOTHER;

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -50,14 +50,14 @@ fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 	struct rdma_cm_id *id = NULL;
 	assert(ep->domain->rdm_cm->listener);
 
-	if (conn->state != FI_VERBS_CONN_ALLOCATED) {
+	if (conn->state != FI_VERBS_CONN_ALLOCATED)
 		return FI_SUCCESS;
-	}
 
 	if (ep->is_closing) {
-		VERBS_INFO(FI_LOG_AV, "Attempt to start connection with addr %s:%u when ep is closing\n",
-			inet_ntoa(conn->addr.sin_addr),
-			ntohs(conn->addr.sin_port));
+		VERBS_INFO(FI_LOG_AV, "Attempt to start connection with addr "
+			   "%s:%u when ep is closing\n",
+			   inet_ntoa(conn->addr.sin_addr),
+			   ntohs(conn->addr.sin_port));
 		return -FI_EOTHER;
 	}
 
@@ -71,9 +71,7 @@ fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 
 	if (conn->cm_role == FI_VERBS_CM_ACTIVE || 
 	    conn->cm_role == FI_VERBS_CM_SELF)
-	{
 		conn->id[0] = id;
-	}
 
 	if (rdma_resolve_addr(id, NULL, (struct sockaddr *)&conn->addr, 30000)) {
 		VERBS_INFO_ERRNO(FI_LOG_AV, "rdma_resolve_addr\n", errno);
@@ -567,6 +565,34 @@ fi_ibv_rdm_conn_to_av_map_addr(struct fi_ibv_rdm_ep *ep,
 }
 
 static inline struct fi_ibv_rdm_conn *
+fi_ibv_rdm_conn_entry_alloc(struct fi_ibv_rdm_av_entry *av_entry,
+			    struct fi_ibv_rdm_ep *ep)
+{
+	struct fi_ibv_rdm_conn *conn;
+
+	if (ofi_memalign((void**) &conn,
+			 FI_IBV_RDM_MEM_ALIGNMENT,
+			 sizeof(*conn)))
+		return NULL;
+	memset(conn, 0, sizeof(*conn));
+	memcpy(&conn->addr, &av_entry->addr,
+	       FI_IBV_RDM_DFLT_ADDRLEN);
+	conn->ep = ep;
+	conn->av_entry = av_entry;
+	conn->state = FI_VERBS_CONN_ALLOCATED;
+	dlist_init(&conn->postponed_requests_head);
+	HASH_ADD(hh, av_entry->conn_hash, ep,
+		 sizeof(struct fi_ibv_rdm_ep *), conn);
+
+	/* Initiates connection to the peer */
+	pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
+	fi_ibv_rdm_start_connection(ep, conn);
+	pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
+
+	return conn;
+}
+
+static inline struct fi_ibv_rdm_conn *
 fi_ibv_rdm_av_map_addr_to_conn_add_new_conn(struct fi_ibv_rdm_ep *ep,
 					    fi_addr_t addr)
 {
@@ -577,27 +603,12 @@ fi_ibv_rdm_av_map_addr_to_conn_add_new_conn(struct fi_ibv_rdm_ep *ep,
 		pthread_mutex_lock(&av_entry->conn_lock);
 		HASH_FIND(hh, av_entry->conn_hash,
 			  &ep, sizeof(struct fi_ibv_rdm_ep *), conn);
-		if (!conn) {
-			if (ofi_memalign((void**)&conn,
-					 FI_IBV_RDM_MEM_ALIGNMENT,
-					 sizeof(*conn)))
-				goto fn;
-			memset(conn, 0, sizeof(*conn));
-		    	memcpy(&conn->addr, &av_entry->addr,
-			       FI_IBV_RDM_DFLT_ADDRLEN);
-			conn->ep = ep;
-			conn->av_entry = av_entry;
-			conn->state = FI_VERBS_CONN_ALLOCATED;
-			dlist_init(&conn->postponed_requests_head);
-			HASH_ADD(hh, av_entry->conn_hash, ep,
-				 sizeof(struct fi_ibv_rdm_ep *), conn);
-		}
-fn:
+		if (!conn)
+			conn = fi_ibv_rdm_conn_entry_alloc(av_entry, ep);
 		pthread_mutex_unlock(&av_entry->conn_lock);
-		return conn;
 	}
 
-	return NULL;
+	return conn;
 }
 
 static inline struct fi_ibv_rdm_conn *
@@ -611,27 +622,12 @@ fi_ibv_rdm_av_tbl_idx_to_conn_add_new_conn(struct fi_ibv_rdm_ep *ep,
 		pthread_mutex_lock(&av_entry->conn_lock);
 		HASH_FIND(hh, av_entry->conn_hash,
 			  &ep, sizeof(struct fi_ibv_rdm_ep *), conn);
-		if (!conn) {
-			if (ofi_memalign((void**)&conn,
-					 FI_IBV_RDM_MEM_ALIGNMENT,
-					 sizeof(*conn)))
-				goto fn;
-			memset(conn, 0, sizeof(*conn));
-		    	memcpy(&conn->addr, &av_entry->addr,
-			       FI_IBV_RDM_DFLT_ADDRLEN);
-			conn->ep = ep;
-			conn->av_entry = av_entry;
-			conn->state = FI_VERBS_CONN_ALLOCATED;
-			dlist_init(&conn->postponed_requests_head);
-			HASH_ADD(hh, av_entry->conn_hash, ep,
-				 sizeof(struct fi_ibv_rdm_ep *), conn);
-		}
-fn:
+		if (!conn)
+			conn = fi_ibv_rdm_conn_entry_alloc(av_entry, ep);
 		pthread_mutex_unlock(&av_entry->conn_lock);
-		return conn;
 	}
 
-	return NULL;
+	return conn;
 }
 
 int fi_ibv_rdm_av_open(struct fid_domain *domain, struct fi_av_attr *attr,

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -556,6 +556,8 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 		   info->tx_attr->inject_size);
 
 	_ep->rndv_threshold = info->tx_attr->inject_size;
+	_ep->iov_per_rndv_thr =
+		(_ep->rndv_threshold / sizeof(struct iovec));
 	VERBS_INFO(FI_LOG_EP_CTRL, "rndv_threshold: %d\n",
 		   _ep->rndv_threshold);
 

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -242,8 +242,7 @@ fi_ibv_rdm_remove_from_postponed_queue(struct fi_ibv_rdm_request *request)
 	dlist_remove(&request->queue_entry);
 	request->queue_entry.next = request->queue_entry.prev = NULL;
 
-	if (dlist_empty(&conn->postponed_requests_head))
-	{
+	if (dlist_empty(&conn->postponed_requests_head)) {
 		dlist_remove(&conn->postponed_entry->queue_entry);
 		conn->postponed_entry->queue_entry.next = 
 		conn->postponed_entry->queue_entry.prev = NULL;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -328,6 +328,7 @@ struct fi_ibv_rdm_ep {
 	int	max_inline_rc;
 	int	rndv_threshold;
 	int	rndv_seg_size;
+	size_t	iov_per_rndv_thr;
 	int	use_odp;
 	int	scq_depth;
 	int	rcq_depth;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -678,41 +678,25 @@ fi_ibv_rdm_rma_get_buf_head(struct fi_ibv_rdm_conn *conn,
 }
 
 static inline int
-fi_ibv_rdm_check_connection(struct fi_ibv_rdm_conn *conn,
-			    struct fi_ibv_rdm_ep *ep)
+fi_ibv_rdm_check_connection(struct fi_ibv_rdm_conn *conn)
 {
-	const int status = (conn->state == FI_VERBS_CONN_ESTABLISHED);
-	if (!status) {
-		pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
-		if (conn->state == FI_VERBS_CONN_ALLOCATED) {
-			fi_ibv_rdm_start_connection(ep, conn);
-		}
-		pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
-	}
-
-	return status;
+	return (conn->state == FI_VERBS_CONN_ESTABLISHED);
 }
 
 static inline struct fi_ibv_rdm_buf *
-fi_ibv_rdm_prepare_send_resources(struct fi_ibv_rdm_conn *conn,
-				  struct fi_ibv_rdm_ep *ep)
+fi_ibv_rdm_prepare_send_resources(struct fi_ibv_rdm_conn *conn)
 {
-	if (fi_ibv_rdm_check_connection(conn, ep)) {
-		return (!TSEND_RESOURCES_IS_BUSY(conn, ep)) ?
-			fi_ibv_rdm_get_sbuf_head(conn, ep) : NULL;
-	}
-	return NULL;
+	return (fi_ibv_rdm_check_connection(conn) &&
+		!TSEND_RESOURCES_IS_BUSY(conn, conn->ep)) ?
+		fi_ibv_rdm_get_sbuf_head(conn, conn->ep) : NULL;
 }
 
 static inline void *
-fi_ibv_rdm_rma_prepare_resources(struct fi_ibv_rdm_conn *conn,
-				 struct fi_ibv_rdm_ep *ep)
+fi_ibv_rdm_rma_prepare_resources(struct fi_ibv_rdm_conn *conn)
 {
-	if (fi_ibv_rdm_check_connection(conn, ep)) {
-		return (!RMA_RESOURCES_IS_BUSY(conn, ep)) ?
-			fi_ibv_rdm_rma_get_buf_head(conn, ep) : NULL;
-	}
-	return NULL;
+	return (fi_ibv_rdm_check_connection(conn) &&
+		!TSEND_RESOURCES_IS_BUSY(conn, conn->ep)) ?
+		fi_ibv_rdm_rma_get_buf_head(conn, conn->ep) : NULL;
 }
 
 static inline int

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -223,7 +223,7 @@ static ssize_t fi_ibv_rdm_inject(struct fid_ep *ep_fid, const void *buf,
 
 	if (in_order) {
 		struct fi_ibv_rdm_buf *sbuf = 
-			fi_ibv_rdm_prepare_send_resources(conn, ep);
+			fi_ibv_rdm_prepare_send_resources(conn);
 		if (sbuf) {
 			struct ibv_send_wr wr = {0};
 			struct ibv_send_wr *bad_wr = NULL;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -31,6 +31,7 @@
  * SOFTWARE.
  */
 
+#include "fi_iov.h"
 #include "fi_enosys.h"
 
 #include "verbs_rdm.h"
@@ -83,9 +84,8 @@ static ssize_t fi_ibv_rdm_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		  conn, recv_data.data_len, recv_data.dest_addr,
 		  msg->context, ofi_atomic_get32(&ep_rdm->posted_recvs));
 
-	if (!ret && !request->state.err) {
+	if (!ret && !request->state.err)
 		ret = rdm_trecv_second_event(request, ep_rdm);
-	}
 
 	return ret;
 }
@@ -123,11 +123,11 @@ static ssize_t fi_ibv_rdm_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 {
 	struct fi_ibv_rdm_ep *ep_rdm = 
 		container_of(ep, struct fi_ibv_rdm_ep, ep_fid);
-
+	size_t i;
 	struct fi_ibv_rdm_send_start_data sdata = {
 		.ep_rdm = ep_rdm,
 		.conn = ep_rdm->av->addr_to_conn(ep_rdm, msg->addr),
-		.data_len = 0,
+		.data_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count),
 		.context = msg->context,
 		.flags = FI_MSG | FI_SEND | GET_TX_COMP_FLAG(ep_rdm, flags),
 		.tag = 0,
@@ -135,34 +135,26 @@ static ssize_t fi_ibv_rdm_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		.buf.src_addr = NULL,
 		.iov_count = 0,
 		.imm = (uint32_t) 0,
-		.stype = IBV_RDM_SEND_TYPE_UND
+		.stype = IBV_RDM_SEND_TYPE_UND,
 	};
 
-	size_t i;
-	for (i = 0; i < msg->iov_count; i++) {
-		sdata.data_len += msg->msg_iov[i].iov_len;
-	}
-
-	if ((msg->iov_count > (sdata.ep_rdm->rndv_threshold / sizeof(struct iovec))) ||
-	    (msg->iov_count > 1 && (sdata.data_len > sdata.ep_rdm->rndv_threshold)))
-	{
-		return -FI_EMSGSIZE;
-	}
-
-	switch (msg->iov_count)
-	{
+	switch (msg->iov_count) {
 	case 1:
 		sdata.buf.src_addr = msg->msg_iov[0].iov_base;
 		sdata.stype = IBV_RDM_SEND_TYPE_GEN;
-		break;
+		/* FALL THROUGH */
 	case 0:
 		sdata.stype = IBV_RDM_SEND_TYPE_GEN;
+		if (sdata.data_len > sdata.ep_rdm->rndv_threshold)
+			return -FI_EMSGSIZE;
 		break;
 	default:
 		/* TODO: 
 		 * extra allocation & memcpy can be optimized if it's possible
 		 * to send immediately
 		 */
+		if (msg->iov_count > sdata.ep_rdm->iov_per_rndv_thr)
+			return -FI_EMSGSIZE;
 		sdata.buf.iovec_arr =
 			util_buf_alloc(ep_rdm->fi_ibv_rdm_extra_buffers_pool);
 		for (i = 0; i < msg->iov_count; i++) {
@@ -212,16 +204,12 @@ static ssize_t fi_ibv_rdm_inject(struct fid_ep *ep_fid, const void *buf,
 	struct fi_ibv_rdm_ep *ep =
 		container_of(ep_fid, struct fi_ibv_rdm_ep, ep_fid);
 	struct fi_ibv_rdm_conn *conn = ep->av->addr_to_conn(ep, dest_addr);
-
 	const size_t size = len + sizeof(struct fi_ibv_rdm_header);
 
-	if (len > ep->rndv_threshold) {
+	if (len > ep->rndv_threshold)
 		return -FI_EMSGSIZE;
-	}
 
-	const int in_order = (conn->postponed_entry) ? 0 : 1;
-
-	if (in_order) {
+	if (!conn->postponed_entry) {
 		struct fi_ibv_rdm_buf *sbuf = 
 			fi_ibv_rdm_prepare_send_resources(conn);
 		if (sbuf) {

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -63,7 +63,7 @@ fi_ibv_rdm_tagged_prepare_send_request(struct fi_ibv_rdm_request *request,
 		return !res;
 	}
 #endif // ENABLE_DEBUG
-	request->sbuf = fi_ibv_rdm_prepare_send_resources(request->minfo.conn, ep);
+	request->sbuf = fi_ibv_rdm_prepare_send_resources(request->minfo.conn);
 	return !!request->sbuf;
 }
 
@@ -72,7 +72,7 @@ fi_ibv_rdm_prepare_rma_request(struct fi_ibv_rdm_request *request,
 				struct fi_ibv_rdm_ep *ep)
 {
 	request->rmabuf =
-		fi_ibv_rdm_rma_prepare_resources(request->minfo.conn, ep);
+		fi_ibv_rdm_rma_prepare_resources(request->minfo.conn);
 	return !!request->rmabuf;
 }
 
@@ -225,7 +225,7 @@ fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len,
 
 	if (in_order) {
 		struct fi_ibv_rdm_buf *sbuf = 
-			fi_ibv_rdm_prepare_send_resources(conn, ep);
+			fi_ibv_rdm_prepare_send_resources(conn);
 		if (sbuf) {
 			struct ibv_send_wr wr = {0};
 			struct ibv_send_wr *bad_wr = NULL;

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -36,6 +36,7 @@
 
 #include <fi_list.h>
 #include <fi_enosys.h>
+#include <fi_iov.h>
 #include <rdma/fi_tagged.h>
 
 #include "verbs_queuing.h"
@@ -108,13 +109,12 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 	ssize_t ret = FI_SUCCESS;
 	struct fi_ibv_rdm_ep *ep_rdm =
 		container_of(ep_fid, struct fi_ibv_rdm_ep, ep_fid);
+	struct fi_ibv_rdm_conn *conn = ep_rdm->av->addr_to_conn(ep_rdm, msg->addr);
 
 	if (msg->iov_count > 1) {
 		assert(0);
 		return -FI_EMSGSIZE;
 	}
-
-	struct fi_ibv_rdm_conn *conn = ep_rdm->av->addr_to_conn(ep_rdm, msg->addr);
 
 	struct fi_ibv_rdm_tagged_recv_start_data recv_data = {
 		.peek_data = {
@@ -147,16 +147,14 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 		recv_data.peek_data.flags |= FI_COMPLETION;
 		ret = fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_RECV_PEEK,
 					  &recv_data);
-		if (ret == -FI_ENOMSG) {
+		if (ret == -FI_ENOMSG)
 			fi_ibv_rdm_tagged_poll(ep_rdm);
-		}
 	} else if (flags & FI_CLAIM) {
 		recv_data.peek_data.flags |= FI_COMPLETION;
 		ret = fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_RECV_START,
 					  &recv_data);
-		if (!ret) {
+		if (!ret)
 			ret = rdm_trecv_second_event(request, ep_rdm);
-		}
 	} else {
 		ret = fi_ibv_rdm_req_hndl(request, FI_IBV_EVENT_RECV_START,
 					  &recv_data);
@@ -166,9 +164,8 @@ fi_ibv_rdm_tagged_recvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg
 			  conn, msg->tag, recv_data.data_len, recv_data.dest_addr,
 			  msg->context, ofi_atomic_get32(&ep_rdm->posted_recvs));
 
-		if (!ret && !request->state.err) {
+		if (!ret && !request->state.err)
 			ret = rdm_trecv_second_event(request, ep_rdm);
-		}
 	}
 
 	return ret;
@@ -214,16 +211,12 @@ fi_ibv_rdm_tagged_inject(struct fid_ep *fid, const void *buf, size_t len,
 	struct fi_ibv_rdm_ep *ep =
 		container_of(fid, struct fi_ibv_rdm_ep, ep_fid);
 	struct fi_ibv_rdm_conn *conn = ep->av->addr_to_conn(ep, dest_addr);
-
 	const size_t size = len + sizeof(struct fi_ibv_rdm_header);
 
-	if (len > ep->rndv_threshold) {
+	if (len > ep->rndv_threshold)
 		return -FI_EMSGSIZE;
-	}
 
-	const int in_order = (conn->postponed_entry) ? 0 : 1;
-
-	if (in_order) {
+	if (!conn->postponed_entry) {
 		struct fi_ibv_rdm_buf *sbuf = 
 			fi_ibv_rdm_prepare_send_resources(conn);
 		if (sbuf) {
@@ -310,13 +303,13 @@ static ssize_t fi_ibv_rdm_tagged_sendto(struct fid_ep *fid, const void *buf,
 static ssize_t fi_ibv_rdm_tagged_sendmsg(struct fid_ep *ep,
 	const struct fi_msg_tagged *msg, uint64_t flags)
 {
-	struct fi_ibv_rdm_ep *ep_rdm = 
+	struct fi_ibv_rdm_ep *ep_rdm =
 		container_of(ep, struct fi_ibv_rdm_ep, ep_fid);
-
+	size_t i;
 	struct fi_ibv_rdm_send_start_data sdata = {
 		.ep_rdm = ep_rdm,
 		.conn = ep_rdm->av->addr_to_conn(ep_rdm, msg->addr),
-		.data_len = 0,
+		.data_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count),
 		.context = msg->context,
 		.flags = FI_TAGGED | FI_SEND | GET_TX_COMP_FLAG(ep_rdm, flags),
 		.tag = msg->tag,
@@ -324,34 +317,26 @@ static ssize_t fi_ibv_rdm_tagged_sendmsg(struct fid_ep *ep,
 		.buf.src_addr = NULL,
 		.iov_count = 0,
 		.imm = (uint32_t) 0,
-		.stype = IBV_RDM_SEND_TYPE_UND
+		.stype = IBV_RDM_SEND_TYPE_UND,
 	};
 
-	size_t i;
-	for (i = 0; i < msg->iov_count; i++) {
-		sdata.data_len += msg->msg_iov[i].iov_len;
-	}
-
-	if ((msg->iov_count > (sdata.ep_rdm->rndv_threshold / sizeof(struct iovec))) ||
-	    (msg->iov_count > 1 && (sdata.data_len > sdata.ep_rdm->rndv_threshold)))
-	{
-		return -FI_EMSGSIZE;
-	}
-
-	switch (msg->iov_count)
-	{
+	switch (msg->iov_count) {
 	case 1:
 		sdata.buf.src_addr = msg->msg_iov[0].iov_base;
 		sdata.stype = IBV_RDM_SEND_TYPE_GEN;
-		break;
+		/* FALL THROUGH  */
 	case 0:
 		sdata.stype = IBV_RDM_SEND_TYPE_GEN;
+		if (sdata.data_len > sdata.ep_rdm->rndv_threshold)
+			return -FI_EMSGSIZE;
 		break;
 	default:
 		/* TODO: 
 		 * extra allocation & memcpy can be optimized if it's possible
 		 * to send immediately
 		 */
+		if (msg->iov_count > sdata.ep_rdm->iov_per_rndv_thr)
+			return -FI_EMSGSIZE;
 		sdata.buf.iovec_arr =
 			util_buf_alloc(ep_rdm->fi_ibv_rdm_extra_buffers_pool);
 		for (i = 0; i < msg->iov_count; i++) {

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -1356,7 +1356,7 @@ fi_ibv_rdm_rma_inject_request(struct fi_ibv_rdm_request *request, void *data)
 
 	if ((request->len < p->ep_rdm->max_inline_rc) && 
 	    (!RMA_RESOURCES_IS_BUSY(request->minfo.conn, p->ep_rdm)) &&
-	    fi_ibv_rdm_check_connection(request->minfo.conn, p->ep_rdm)) {
+	    fi_ibv_rdm_check_connection(request->minfo.conn)) {
 		wr.send_flags |= IBV_SEND_INLINE;
 	} else if (fi_ibv_rdm_prepare_rma_request(request, p->ep_rdm)) {
 		memcpy(&request->rmabuf->payload, (void*)p->lbuf, p->data_len);

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -130,8 +130,7 @@ int fi_ibv_rdm_postponed_process(struct dlist_entry *postponed_item,
 
 		int res = 0;
 		if ((request->state.eager < FI_IBV_STATE_EAGER_RMA_INJECT) &&
-		    (request->sbuf == NULL))
-		{
+		    (request->sbuf == NULL)) {
 			res = fi_ibv_rdm_tagged_prepare_send_request(request,
 								 send_data->ep);
 		} else  {

--- a/prov/verbs/src/ep_rdm/verbs_utils.c
+++ b/prov/verbs/src/ep_rdm/verbs_utils.c
@@ -141,8 +141,7 @@ int fi_ibv_rdm_postponed_process(struct dlist_entry *postponed_item,
 			 * established
 			 */
 			assert(request->state.rndv != FI_IBV_STATE_RNDV_NOT_USED);
-			assert(fi_ibv_rdm_check_connection(request->minfo.conn,
-							   send_data->ep));
+			assert(fi_ibv_rdm_check_connection(request->minfo.conn));
 			if (request->state.eager <= FI_IBV_STATE_EAGER_RECV_END) {
 				res = !TSEND_RESOURCES_IS_BUSY(request->minfo.conn,
 							      send_data->ep);

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -244,14 +244,14 @@ fi_ibv_rdm_ep_rma_preinit(void **desc, struct fi_ibv_rdm_buf **rdm_buf,
 	assert(desc && rdm_buf);
 
 	if (*desc == NULL && len < ep->rndv_threshold) {
-		*rdm_buf = fi_ibv_rdm_rma_prepare_resources(conn, ep);
-		if (*rdm_buf) {
+		*rdm_buf = fi_ibv_rdm_rma_prepare_resources(conn);
+		if (*rdm_buf)
 			*desc = (void*)(uintptr_t)conn->rma_mr->lkey;
-		} else {
+		else
 			goto again;
-		}
-	} else if (!fi_ibv_rdm_check_connection(conn, ep) ||
-		RMA_RESOURCES_IS_BUSY(conn, ep) || conn->postponed_entry) {
+	} else if (!fi_ibv_rdm_check_connection(conn) ||
+		   RMA_RESOURCES_IS_BUSY(conn, ep) ||
+		   conn->postponed_entry) {
 		goto again;
 	}
 


### PR DESCRIPTION
- The connection is established in the `fi_ibv_rdm_check_connection` that checks state of the connections.
Simplifies the `fi_ibv_rdm_check_connection` function to just check the conn->state and no more actions.
The connection establishment is moved to the functions that allocates an Connection entry for the specified EP. It looks more natural.
- Some code cleanups:
   - Removes extra brackets
   - Introduce new filed to the EP - `iov_per_rndv_thr` to avoid each time calculation of the available count of the I/O vectors.
   - Use the utility `ofi_total_iov_len` function instead of self-implemented `for (...)`
