### PR TITLE
prov/sockets: Add support for keepalive

### DIFF
--- a/man/fi_sockets.7.md
+++ b/man/fi_sockets.7.md
@@ -81,8 +81,20 @@ The sockets provider checks for the following environment variables -
 *FI_SOCKETS_PE_AFFINITY*
 : If specified, progress thread is bound to the indicated range(s) of Linux virtual processor ID(s). This option is currently not supported on OS X. The usage is - id_start[-id_end[:stride]][,].
 
+*FI_SOCKETS_KEEPALIVE_ENABLE*
+: A boolean to enable the keepalive support.
+
+*FI_SOCKETS_KEEPALIVE_TIME*
+: An integer to specify the idle time in seconds before sending the first keepalive probe. Only relevant if *FI_SOCKETS_KEEPALIVE_ENABLE* is enabled.
+
+*FI_SOCKETS_KEEPALIVE_INTVL*
+: An integer to specify the time in seconds between individual keepalive probes. Only relevant if *FI_SOCKETS_KEEPALIVE_ENABLE* is enabled.
+
+*FI_SOCKETS_KEEPALIVE_PROBES*
+: An integer to specify the maximum number of keepalive probes sent before dropping the connection. Only relevant if *FI_SOCKETS_KEEPALIVE_ENABLE* is enabled.
+
 # LARGE SCALE JOBS
- 
+
 For large scale runs one can use these environment variables to set the default parameters e.g. size of the address vector(AV), completion queue (CQ), connection map etc. that satisfies the requirement of the particular benchmark. The recommended parameters for large scale runs are *FI_SOCKETS_MAX_CONN_RETRY*, *FI_SOCKETS_DEF_CONN_MAP_SZ*, *FI_SOCKETS_DEF_AV_SZ*, *FI_SOCKETS_DEF_CQ_SZ*, *FI_SOCKETS_DEF_EQ_SZ*.
 
 # SEE ALSO

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -165,7 +165,8 @@ enum {
 };
 
 enum {
-	SOCK_OPTS_NONBLOCK  = 1<<0
+	SOCK_OPTS_NONBLOCK  = 1<<0,
+	SOCK_OPTS_KEEPALIVE = 1<<1
 };
 
 #define SOCK_MAJOR_VERSION 2

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -164,6 +164,10 @@ enum {
 	SOCK_SIGNAL_WR_FD
 };
 
+enum {
+	SOCK_OPTS_NONBLOCK  = 1<<0
+};
+
 #define SOCK_MAJOR_VERSION 2
 #define SOCK_MINOR_VERSION 0
 
@@ -1124,11 +1128,9 @@ int sock_conn_start_listener_thread(struct sock_conn_listener *conn_listener);
 int sock_conn_stop_listener_thread(struct sock_conn_listener *conn_listener);
 void sock_conn_map_destroy(struct sock_ep_attr *ep_attr);
 void sock_conn_release_entry(struct sock_conn_map *map, struct sock_conn *conn);
-void sock_set_sockopts(int sock);
+void sock_set_sockopts(int sock, int sock_opts);
 int fd_set_nonblock(int fd);
-void sock_set_sockopt_reuseaddr(int sock);
 int sock_conn_map_init(struct sock_ep *ep, int init_size);
-void sock_set_sockopts_conn(int sock);
 
 struct sock_pe *sock_pe_init(struct sock_domain *domain);
 void sock_pe_add_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *ctx);

--- a/prov/sockets/include/sock_util.h
+++ b/prov/sockets/include/sock_util.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2017 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -51,6 +52,10 @@ extern int sock_eq_def_sz;
 #if ENABLE_DEBUG
 extern int sock_dgram_drop_rate;
 #endif
+extern int sock_keepalive_enable;
+extern int sock_keepalive_time;
+extern int sock_keepalive_intvl;
+extern int sock_keepalive_probes;
 
 #define _SOCK_LOG_DBG(subsys, ...) FI_DBG(&sock_prov, subsys, __VA_ARGS__)
 #define _SOCK_LOG_ERROR(subsys, ...) FI_WARN(&sock_prov, subsys, __VA_ARGS__)

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -191,7 +191,9 @@ static struct sock_conn *sock_conn_map_insert(struct sock_ep_attr *ep_attr,
 	map->table[index].addr = *addr;
 	map->table[index].sock_fd = conn_fd;
 	map->table[index].ep_attr = ep_attr;
-	sock_set_sockopts(conn_fd, SOCK_OPTS_NONBLOCK);
+	sock_set_sockopts(conn_fd, SOCK_OPTS_NONBLOCK |
+	                  (ep_attr->ep_type == FI_EP_MSG ?
+	                   SOCK_OPTS_KEEPALIVE : 0));
 
 	if (fi_epoll_add(map->epoll_set, conn_fd, &map->table[index]))
 		SOCK_LOG_ERROR("failed to add to epoll set: %d\n", conn_fd);
@@ -213,6 +215,45 @@ int fd_set_nonblock(int fd)
 	return ret;
 }
 
+#if !defined __APPLE__ && !defined _WIN32
+void sock_set_sockopt_keepalive(int sock)
+{
+	int optval;
+
+	/* Keepalive is disabled: now leave */
+	if (!sock_keepalive_enable)
+		return;
+
+	optval = 1;
+	if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval)))
+			SOCK_LOG_ERROR("setsockopt keepalive enable failed: %s\n",
+			               strerror(errno));
+
+	if (sock_keepalive_time != INT_MAX) {
+		optval = sock_keepalive_time;
+		if (setsockopt(sock, SOL_TCP, TCP_KEEPIDLE, &optval, sizeof(optval)))
+			SOCK_LOG_ERROR("setsockopt keepalive time failed: %s\n",
+			               strerror(errno));
+	}
+
+	if (sock_keepalive_intvl != INT_MAX) {
+		optval = sock_keepalive_intvl;
+		if (setsockopt(sock, SOL_TCP, TCP_KEEPINTVL, &optval, sizeof(optval)))
+			SOCK_LOG_ERROR("setsockopt keepalive intvl failed: %s\n",
+			               strerror(errno));
+	}
+
+	if (sock_keepalive_probes != INT_MAX) {
+		optval = sock_keepalive_probes;
+		if (setsockopt(sock, SOL_TCP, TCP_KEEPCNT, &optval, sizeof(optval)))
+			SOCK_LOG_ERROR("setsockopt keepalive intvl failed: %s\n",
+			               strerror(errno));
+	}
+}
+#else
+#define sock_set_sockopt_keepalive(sock) do {} while (0)
+#endif
+
 static void sock_set_sockopt_reuseaddr(int sock)
 {
 	int optval;
@@ -227,6 +268,8 @@ void sock_set_sockopts(int sock, int sock_opts)
 	optval = 1;
 
 	sock_set_sockopt_reuseaddr(sock);
+	if (sock_opts & SOCK_OPTS_KEEPALIVE)
+		sock_set_sockopt_keepalive(sock);
 	if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval)))
 		SOCK_LOG_ERROR("setsockopt nodelay failed\n");
 

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -512,7 +512,7 @@ static void *sock_ep_cm_connect_handler(void *data)
 
 	ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL, "Connecting to address",
 			&handle->dest_addr);
-	sock_set_sockopts(sock_fd, 0);
+	sock_set_sockopts(sock_fd, SOCK_OPTS_KEEPALIVE);
 	ret = connect(sock_fd, (struct sockaddr *)&handle->dest_addr,
 		      sizeof(handle->dest_addr));
 	if (ret < 0) {
@@ -1036,7 +1036,7 @@ static void *sock_pep_listener_thread(void *data)
 			continue;
 		}
 
-		sock_set_sockopts(conn_fd, 0);
+		sock_set_sockopts(conn_fd, SOCK_OPTS_KEEPALIVE);
 		handle = calloc(1, sizeof(*handle));
 		if (!handle) {
 			SOCK_LOG_ERROR("cannot allocate memory\n");

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -312,7 +312,7 @@ static int sock_pep_create_listener(struct sock_pep *pep)
 		pep->cm.sock = ofi_socket(p->ai_family, p->ai_socktype,
 				     p->ai_protocol);
 		if (pep->cm.sock >= 0) {
-			sock_set_sockopts(pep->cm.sock);
+			sock_set_sockopts(pep->cm.sock, SOCK_OPTS_NONBLOCK);
 			if (!bind(pep->cm.sock, s_res->ai_addr, s_res->ai_addrlen))
 				break;
 			SOCK_LOG_ERROR("failed to bind listener: %s\n",
@@ -329,7 +329,6 @@ static int sock_pep_create_listener(struct sock_pep *pep)
 		return -FI_EIO;
 	}
 
-	sock_set_sockopt_reuseaddr(pep->cm.sock);
 	if (pep->src_addr.sin_port == 0) {
 		addr_size = sizeof(addr);
 		if (getsockname(pep->cm.sock, (struct sockaddr *)&addr, &addr_size))
@@ -513,7 +512,7 @@ static void *sock_ep_cm_connect_handler(void *data)
 
 	ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL, "Connecting to address",
 			&handle->dest_addr);
-	sock_set_sockopts_conn(sock_fd);
+	sock_set_sockopts(sock_fd, 0);
 	ret = connect(sock_fd, (struct sockaddr *)&handle->dest_addr,
 		      sizeof(handle->dest_addr));
 	if (ret < 0) {
@@ -1037,7 +1036,7 @@ static void *sock_pep_listener_thread(void *data)
 			continue;
 		}
 
-		sock_set_sockopts_conn(conn_fd);
+		sock_set_sockopts(conn_fd, 0);
 		handle = calloc(1, sizeof(*handle));
 		if (!handle) {
 			SOCK_LOG_ERROR("cannot allocate memory\n");

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017 DataDirect Networks, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -67,6 +68,10 @@ int sock_eq_def_sz = SOCK_EQ_DEF_SZ;
 #if ENABLE_DEBUG
 int sock_dgram_drop_rate = 0;
 #endif
+int sock_keepalive_enable;
+int sock_keepalive_time = INT_MAX;
+int sock_keepalive_intvl = INT_MAX;
+int sock_keepalive_probes = INT_MAX;
 
 const struct fi_fabric_attr sock_fabric_attr = {
 	.fabric = NULL,
@@ -343,6 +348,11 @@ static void sock_read_default_params()
 #if ENABLE_DEBUG
 		fi_param_get_int(&sock_prov, "dgram_drop_rate", &sock_dgram_drop_rate);
 #endif
+		fi_param_get_bool(&sock_prov, "keepalive_enable", &sock_keepalive_enable);
+		fi_param_get_int(&sock_prov, "keepalive_time", &sock_keepalive_time);
+		fi_param_get_int(&sock_prov, "keepalive_intvl", &sock_keepalive_intvl);
+		fi_param_get_int(&sock_prov, "keepalive_probes", &sock_keepalive_probes);
+
 		read_default_params = 1;
 	}
 }
@@ -767,6 +777,18 @@ SOCKETS_INI
 	fi_param_define(&sock_prov, "pe_affinity", FI_PARAM_STRING,
 			"If specified, bind the progress thread to the indicated range(s) of Linux virtual processor ID(s). "
 			"This option is currently not supported on OS X. Usage: id_start[-id_end[:stride]][,]");
+
+	fi_param_define(&sock_prov, "keepalive_enable", FI_PARAM_BOOL,
+			"Enable keepalive support");
+
+	fi_param_define(&sock_prov, "keepalive_time", FI_PARAM_INT,
+			"Idle time in seconds before sending the first keepalive probe");
+
+	fi_param_define(&sock_prov, "keepalive_intvl", FI_PARAM_INT,
+			"Time in seconds between individual keepalive probes");
+
+	fi_param_define(&sock_prov, "keepalive_probes", FI_PARAM_INT,
+			"Maximum number of keepalive probes sent before dropping the connection");
 
 	fastlock_init(&sock_list_lock);
 	dlist_init(&sock_fab_list);


### PR DESCRIPTION
Please find a set of two patches to add the support of TCP keepalive to the `sockets` provider.
The patch introduces 4 new environment variables to deal with keepalive: 

* FI_SOCKETS_KEEPALIVE_ENABLE: A boolean to enable the keepalive support.

* FI_SOCKETS_KEEPALIVE_TIME: An integer to specify the idle time in seconds before sending the first
keepalive probe. Only relevant if FI_SOCKETS_KEEPALIVE_ENABLE is enabled.

* FI_SOCKETS_KEEPALIVE_INTVL: An integer to specify the time in seconds between individual keepalive probes. Only relevant if FI_SOCKETS_KEEPALIVE_ENABLE is enabled

* FI_SOCKETS_KEEPALIVE_PROBES: An integer to specify the maximum number of keepalive probes sent before dropping the connection. Only relevant if FI_SOCKETS_KEEPALIVE_ENABLE is enabled

This feature is currently unavailable for OSX and Windows. 
Man pages have been updated accordingly. 

Thanks for the review!

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>