### PR TITLE
prov/psm2: Allow all-to-all communication between SEP contexts

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -367,6 +367,7 @@ struct psmx2_trx_ctxt {
 	psm2_epid_t		psm2_epid;
 	psm2_mq_t		psm2_mq;
 	int			am_initialized;
+	int			id;
 	struct psm2_am_parameters psm2_am_param;
 
 	/* ep bound to this tx/rx context, NULL if multiplexed */
@@ -735,7 +736,7 @@ struct psmx2_fid_cntr {
 
 struct psmx2_ctxt_addr {
 	psm2_epid_t		epid;
-	psm2_epaddr_t		epaddr;
+	psm2_epaddr_t		*epaddrs;
 };
 
 struct psmx2_sep_addr {

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -32,6 +32,8 @@
 
 #include "psmx2.h"
 
+static int psmx2_trx_ctxt_cnt = 0;
+
 void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt)
 {
 	int err;
@@ -78,6 +80,13 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	struct psm2_ep_open_opts opts;
 	int should_retry = 0;
 	int err;
+
+	if (psmx2_trx_ctxt_cnt >= psmx2_env.max_trx_ctxt) {
+		FI_WARN(&psmx2_prov, FI_LOG_CORE,
+			"number of Tx/Rx contexts exceeds limit (%d).\n",
+			psmx2_env.max_trx_ctxt);
+		return NULL;
+	}
 
 	trx_ctxt = calloc(1, sizeof(*trx_ctxt));
 	if (!trx_ctxt) {
@@ -153,6 +162,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	fastlock_init(&trx_ctxt->trigger_queue.lock);
 	slist_init(&trx_ctxt->rma_queue.list);
 	slist_init(&trx_ctxt->trigger_queue.list);
+	trx_ctxt->id = psmx2_trx_ctxt_cnt++;
 
 	return trx_ctxt;
 


### PR DESCRIPTION
The address information of scalable endpoints is expanded to allow
connection be established between any pair of contexts from two
scalable endpoints. This eliminates the previous limitation of
only supporting pair-wise communication between scalable endpoints.

There is still one limitation remaining: communication between a
regular endpoint and a scalable endpoint is not supported.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>