### PR TITLE
MLX provider: Nameserver support (stage 1/3: MPI-CH3 is covered)

### DIFF
--- a/prov/mlx/src/mlx.h
+++ b/prov/mlx/src/mlx.h
@@ -65,9 +65,14 @@ extern "C" {
 #include <fi_util.h>
 #include <prov.h>
 
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <ifaddrs.h>
 
 #define FI_MLX_FABRIC_NAME "mlx"
 #define FI_MLX_DEFAULT_INJECT_SIZE 1024
+#define FI_MLX_DEFAULT_NS_PORT 12345
 #define FI_MLX_DEF_CQ_SIZE (1024)
 #define FI_MLX_DEF_MR_CNT (1 << 16)
 
@@ -83,9 +88,13 @@ extern "C" {
 #define FI_MLX_MODE_REQUIRED (0ULL)
 #define FI_MLX_MODE_SUPPORTED (FI_CONTEXT | FI_ASYNC_IOV)
 #define FI_MLX_OP_FLAGS (FI_SEND | FI_RECV)
-
+#define FI_MLX_ANY_SERVICE (0)
 struct mlx_global_descriptor{
 	ucp_config_t *config;
+	int use_ns;
+	int ns_port;
+	struct util_ns name_serv;
+	char *localhost;
 };
 
 struct mlx_fabric {
@@ -105,6 +114,9 @@ struct mlx_ep {
 	struct util_ep ep;
 	struct mlx_av *av; /*until AV is not implemented via utils*/
 	ucp_worker_h worker;
+	short service;
+	void *addr;
+	size_t addr_len;
 };
 
 struct mlx_av {
@@ -171,6 +183,8 @@ int mlx_av_open(
 		struct fid_domain *domain, struct fi_av_attr *attr,
 		struct fid_av **av, void *context);
 
+int mlx_ns_is_service_wildcard(void *svc);
+int mlx_ns_service_cmp(void *svc1, void *svc2);
 /* Callbacks */
 void mlx_send_callback_no_compl( void *request, ucs_status_t status);
 void mlx_send_callback( void *request, ucs_status_t status);

--- a/prov/mlx/src/mlx_cm.c
+++ b/prov/mlx/src/mlx_cm.c
@@ -32,7 +32,7 @@
 #include "mlx.h"
 #include <inttypes.h>
 
-static int mlx_cm_getname(
+static int mlx_cm_getname_mlx_format(
 			fid_t fid,
 			void *addr,
 			size_t *addrlen)
@@ -48,8 +48,12 @@ static int mlx_cm_getname(
 	status = ucp_worker_get_address( ep->worker,
 					(ucp_address_t **)&addr_local,
 					(size_t*) &addr_len_local );
-	if (status != UCS_OK)
+	if (status != UCS_OK) {
+		FI_WARN( &mlx_prov, FI_LOG_CORE,
+			"ucp_worker_get_address error!!!\n");
 		return MLX_TRANSLATE_ERRCODE(status);
+	}
+
 	if (addr_len_local > FI_MLX_MAX_NAME_LEN) {
 		FI_WARN( &mlx_prov, FI_LOG_CORE,
 			"Address returned by UCX is too long %"PRIu64"\n",
@@ -78,6 +82,71 @@ static int mlx_cm_getname(
 				(ucp_address_t *)addr_local);
 	return ofi_status;
 }
+
+static int mlx_cm_getname_ai_format(
+			fid_t fid,
+			void *addr,
+			size_t *addrlen)
+{
+	int ofi_status = FI_SUCCESS;
+	struct mlx_ep* ep;
+	ep = container_of(fid, struct mlx_ep, ep.ep_fid.fid);
+	if (ep->addr) {
+		if (ep->addr_len > *addrlen) {
+			ofi_status = -FI_ETOOSMALL;
+		} else {
+			memcpy(addr, ep->addr, ep->addr_len);
+		}
+		*addrlen = ep->addr_len;
+	} else {
+		char *hostname = mlx_descriptor.localhost;
+		int service = (((getpid() & 0xFFFF)));
+		struct addrinfo hints;
+		struct addrinfo *res;
+
+		memset(&hints, 0, sizeof(hints));
+		hints.ai_flags = 0;
+		hints.ai_family = AF_INET;
+		hints.ai_socktype = SOCK_STREAM;
+		hints.ai_protocol = IPPROTO_TCP;
+		hints.ai_addrlen = 0;
+		hints.ai_addr = NULL;
+		hints.ai_canonname = NULL;
+		hints.ai_next = NULL;
+
+		if(getaddrinfo(hostname, NULL, &hints, &res) != 0) {
+			FI_WARN( &mlx_prov, FI_LOG_CORE,
+					"Unable to resolve hostname:%s\n",hostname);
+		}
+		FI_INFO(&mlx_prov, FI_LOG_CORE,
+			"Loaded IPv4 address: [%"PRIu64"]%s:%d\n",
+			res->ai_addrlen, hostname, service);
+
+		memcpy(addr,res->ai_addr,res->ai_addrlen);
+		((struct sockaddr_in*)addr)->sin_port = htons((short)service);
+		freeaddrinfo(res);
+
+		*addrlen = sizeof(struct sockaddr);
+	}
+
+	return ofi_status;
+}
+
+static int mlx_cm_getname(
+			fid_t fid,
+			void *addr,
+			size_t *addrlen)
+{
+	int ofi_status = FI_SUCCESS;
+	if (mlx_descriptor.use_ns) {
+		ofi_status = mlx_cm_getname_ai_format(fid, addr, addrlen);
+	} else {
+		ofi_status = mlx_cm_getname_mlx_format(fid, addr, addrlen);
+	}
+	return ofi_status;
+}
+
+
 
 struct fi_ops_cm mlx_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),

--- a/prov/mlx/src/mlx_ep.c
+++ b/prov/mlx/src/mlx_ep.c
@@ -73,14 +73,33 @@ static int mlx_ep_setopt(fid_t fid, int level, int optname,
 
 static int mlx_ep_close(fid_t fid)
 {
-	struct mlx_ep *fid_ep;
-	fid_ep = container_of(fid, struct mlx_ep, ep.ep_fid.fid);
+	struct mlx_ep *ep;
+	ucs_status_t status = UCS_OK;
+	void *addr_local = NULL;
+	size_t addr_len_local;
 
-	ucp_worker_flush(fid_ep->worker);
-	ucp_worker_destroy(fid_ep->worker);
+	ep = container_of(fid, struct mlx_ep, ep.ep_fid.fid);
 
-	ofi_endpoint_close(&fid_ep->ep);
-	free(fid_ep);
+	if (mlx_descriptor.use_ns) {
+		status = ucp_worker_get_address( ep->worker,
+						(ucp_address_t **)&addr_local,
+						(size_t*) &addr_len_local );
+		if (status != UCS_OK)
+			return MLX_TRANSLATE_ERRCODE(status);
+
+		ofi_ns_del_local_name(&mlx_descriptor.name_serv,
+					  &ep->service, addr_local);
+
+		ucp_worker_release_address(
+					ep->worker,
+					(ucp_address_t *)addr_local);
+	}
+
+	ucp_worker_flush(ep->worker);
+	ucp_worker_destroy(ep->worker);
+
+	ofi_endpoint_close(&ep->ep);
+	free(ep);
 	return FI_SUCCESS;
 }
 
@@ -160,6 +179,10 @@ int mlx_ep_open( struct fid_domain *domain, struct fi_info *info,
 	worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
 	u_domain = container_of( domain, struct mlx_domain, u_domain.domain_fid);
 
+	void *addr_local = NULL;
+	size_t addr_len_local;
+
+
 	ep = (struct mlx_ep *) calloc(1, sizeof (struct mlx_ep));
 	if (!ep) {
 		return -ENOMEM;
@@ -178,6 +201,26 @@ int mlx_ep_open( struct fid_domain *domain, struct fi_info *info,
 		ofi_status = MLX_TRANSLATE_ERRCODE(status);
 		ofi_atomic_dec32(&(u_domain->u_domain.ref));
 		goto free_ep;
+	}
+
+	if (mlx_descriptor.use_ns) {
+		char tmpb [FI_MLX_MAX_NAME_LEN]={0};
+		status = ucp_worker_get_address( ep->worker,
+			(ucp_address_t **)&addr_local,
+			(size_t*) &addr_len_local );
+		if (status != UCS_OK)
+			return MLX_TRANSLATE_ERRCODE(status);
+		ep->service = (short)((getpid() & 0xFFFF ));
+		memcpy(tmpb,addr_local,addr_len_local);
+		FI_INFO(&mlx_prov, FI_LOG_CORE,
+			"PUBLISHED UCP address(size=%zd): [%hu] %s\n",
+			addr_len_local,ep->service,(char*)(addr_local));
+
+		ofi_ns_add_local_name(&mlx_descriptor.name_serv,
+			&ep->service, tmpb);
+
+		ucp_worker_release_address( ep->worker,
+			(ucp_address_t *)addr_local);
 	}
 
 	ep->ep.ep_fid.fid.ops = &mlx_fi_ops;

--- a/prov/mlx/src/mlx_fabric.c
+++ b/prov/mlx/src/mlx_fabric.c
@@ -35,6 +35,10 @@
 int mlx_fabric_close(struct fid *fid)
 {
 	int status;
+
+	if (mlx_descriptor.use_ns)
+		ofi_ns_stop_server (&mlx_descriptor.name_serv);
+
 	status = ofi_fabric_close(
 			container_of(fid, struct util_fabric, fabric_fid.fid));
 	return status;
@@ -57,6 +61,116 @@ static struct fi_ops_fabric mlx_fabric_ops = {
 	.trywait = fi_no_trywait,
 };
 
+int mlx_ns_service_cmp(void *svc1, void *svc2)
+{
+	int service1 = *(int *)svc1, service2 = *(int *)svc2;
+	if (service1 == FI_MLX_ANY_SERVICE ||
+	    service2 == FI_MLX_ANY_SERVICE)
+		return 0;
+	return (service1 < service2) ?
+		-1 : (service1 > service2);
+}
+
+int mlx_ns_is_service_wildcard(void *svc)
+{
+	return (*(int *)svc == FI_MLX_ANY_SERVICE);
+}
+
+#define MLX_IGNORED_LO_ADDR "127.0.0.1"
+static char* mlx_local_host_resolve()
+{
+	int status;
+	struct ifaddrs *ifaddr, *ifa;
+	char host[NI_MAXHOST];
+	char *iface = NULL;
+	char *result = NULL;
+
+	status = fi_param_get( &mlx_prov, "mlx_ns_iface",
+		&iface);
+	if (!status) {
+		iface = NULL;
+	}
+
+	if (-1 == getifaddrs(&ifaddr)) {
+		FI_WARN( &mlx_prov, FI_LOG_CORE,
+			"Unable to resolve local host address");
+		return NULL;
+	}
+
+	for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+		/*Ignore not IPv$ ifaces*/
+		if ((ifa->ifa_addr == NULL) ||
+				(ifa->ifa_addr->sa_family != AF_INET)) {
+			continue;
+		}
+
+		if (getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in),
+				host, NI_MAXHOST,
+				NULL, 0, NI_NUMERICHOST) != 0) {
+			host[0] = '\0';
+			continue;
+		}
+
+		/*Skip loopback device*/
+		if (strncmp(host, MLX_IGNORED_LO_ADDR,
+				strlen(MLX_IGNORED_LO_ADDR))==0) {
+			host[0] = '\0';
+			continue;
+		}
+
+		/* If iface name is specified */
+		if (iface && strcmp(iface, ifa->ifa_name)!=0) {
+			host[0] = '\0';
+			continue;
+		}
+
+		result = strdup(host);
+		break;
+	}
+	if (result == NULL) {
+		FI_WARN( &mlx_prov, FI_LOG_CORE,
+			"No IPv4-compatible interface was found. (match mask:%s)",
+			iface?iface:"*");
+	}
+	freeifaddrs(ifaddr);
+	return result;
+}
+
+int mlx_ns_start ()
+{
+	int status;
+	if (!mlx_descriptor.localhost)
+		mlx_descriptor.localhost = mlx_local_host_resolve();
+
+	if (!mlx_descriptor.localhost) {
+		FI_INFO(&mlx_prov, FI_LOG_CORE,
+			"Unable to resolve local host address:\n"
+			"\t - unable to start NS\n"
+			"\t - Please try MLX-adress format");
+		return -FI_EINVAL;
+	}
+
+	struct util_ns_attr ns_attr = {
+		.ns_hostname = mlx_descriptor.localhost,
+		.ns_port = (int)mlx_descriptor.ns_port,
+		.name_len = FI_MLX_MAX_NAME_LEN,
+		.service_len = sizeof(short),
+		.service_cmp = mlx_ns_service_cmp,
+		.is_service_wildcard = mlx_ns_is_service_wildcard,
+	};
+
+	status = ofi_ns_init(&ns_attr,
+			  &mlx_descriptor.name_serv);
+	if (status) {
+		FI_INFO(&mlx_prov, FI_LOG_CORE,
+			"ofi_ns_init returns %d\n", status);
+		return status;
+	}
+
+	ofi_ns_start_server(&mlx_descriptor.name_serv);
+	return FI_SUCCESS;
+}
+
 int mlx_fabric_open(
 		struct fi_fabric_attr *attr,
 		struct fid_fabric **fabric,
@@ -76,7 +190,7 @@ int mlx_fabric_open(
 	}
 
 	status = ofi_fabric_init(&mlx_prov, &mlx_fabric_attrs, attr,
-				 &(fabric_priv->u_fabric), context);
+			 &(fabric_priv->u_fabric), context);
 	if (status) {
 		FI_INFO( &mlx_prov, FI_LOG_CORE,
 			"Error in ofi_fabric_init: %d\n", status);
@@ -87,6 +201,13 @@ int mlx_fabric_open(
 	fabric_priv->u_fabric.fabric_fid.fid.ops = &mlx_fabric_fi_ops;
 	fabric_priv->u_fabric.fabric_fid.ops = &mlx_fabric_ops;
 	*fabric = &(fabric_priv->u_fabric.fabric_fid);
+
+	if (mlx_descriptor.use_ns) {
+		if(mlx_ns_start() != FI_SUCCESS) {
+			free(fabric_priv);
+			return status;
+		}
+	}
 
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
Implemented built-in NS support in MLX provider.
MPICH-CH3 usage scenario is covered.
 
Signed-off-by: Sannikov, Alexander <alexander.sannikov@intel.com>