### PR TITLE
prov/psm,psm2: Preserve FI_MR_SCALABLE mode bit in fi_getinfo

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -439,8 +439,16 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 				goto err_out;
 			}
 
-			if (hints->domain_attr->mr_mode & FI_MR_BASIC)
+			if (hints->domain_attr->mr_mode == FI_MR_BASIC) {
 				mr_mode = FI_MR_BASIC;
+			} else if (hints->domain_attr->mr_mode == FI_MR_SCALABLE) {
+				mr_mode = FI_MR_SCALABLE;
+			} else if (hints->domain_attr->mr_mode & (FI_MR_BASIC | FI_MR_SCALABLE)) {
+				FI_INFO(&psmx_prov, FI_LOG_CORE,
+					"hints->domain_attr->mr_mode has FI_MR_BASIC or FI_MR_SCALABLE "
+					"combined with other bits\n");
+				goto err_out;
+			}
 
 			switch (hints->domain_attr->threading) {
 			case FI_THREAD_UNSPEC:

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -475,8 +475,16 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 				goto err_out;
 			}
 
-			if (hints->domain_attr->mr_mode & FI_MR_BASIC)
+			if (hints->domain_attr->mr_mode == FI_MR_BASIC) {
 				mr_mode = FI_MR_BASIC;
+			} else if (hints->domain_attr->mr_mode == FI_MR_SCALABLE) {
+				mr_mode = FI_MR_SCALABLE;
+			} else if (hints->domain_attr->mr_mode & (FI_MR_BASIC | FI_MR_SCALABLE)) {
+				FI_INFO(&psmx2_prov, FI_LOG_CORE,
+					"hints->domain_attr->mr_mode has FI_MR_BASIC or FI_MR_SCALABLE "
+					"combined with other bits\n");
+				goto err_out;
+			}
 
 			switch (hints->domain_attr->threading) {
 			case FI_THREAD_UNSPEC:


### PR DESCRIPTION
According to latest API update, providers should preserve the FI_MR_SCALABLE
mr_mode bit passed in from the hints if the mode is supported, even though
setting mr_mode to 0 would indicate the same support level.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>