### PR TITLE
util: Fix double free issue with ofi_domain_init

### DIFF
--- a/prov/udp/src/udpx_domain.c
+++ b/prov/udp/src/udpx_domain.c
@@ -84,8 +84,10 @@ int udpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_ENOMEM;
 
 	ret = ofi_domain_init(fabric, info, util_domain, context);
-	if (ret)
+	if (ret) {
+		free(util_domain);
 		return ret;
+	}
 
 	*domain = &util_domain->domain_fid;
 	(*domain)->fid.ops = &udpx_domain_fi_ops;

--- a/prov/util/src/util_domain.c
+++ b/prov/util/src/util_domain.c
@@ -96,10 +96,8 @@ int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
 	domain->fabric = fabric;
 	domain->prov = fabric->prov;
 	ret = util_domain_init(domain, info);
-	if (ret) {
-		free(domain);
+	if (ret)
 		return ret;
-	}
 
 	domain->domain_fid.fid.fclass = FI_CLASS_DOMAIN;
 	domain->domain_fid.fid.context = context;


### PR DESCRIPTION
ofi_domain_init() was internally freeing the caller's memory on error and
most of the providers that use this function were also freeing the memory on
error. This commit removes the free from ofi_domain_init() and lets the
caller be responsible for freeing the memory they own.

Fixes #3511

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>