### PR TITLE
prov/shm: refactor address mapping and smr_cmd structure + coverity fix

### DIFF
--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -65,17 +65,34 @@ extern "C" {
 #endif
 
 
-/* SMR op_data: Specifies data source location */
+/* SMR op_src: Specifies data source location */
 enum {
 	smr_src_inline,	/* command data */
 	smr_src_inject,	/* inject buffers */
 	smr_src_iov,	/* reference iovec via CMA */
 };
 
+struct smr_op_hdr {
+	fi_addr_t		addr;
+	uint32_t		op;
+	uint32_t		op_src;
+
+	uint64_t		size;
+	uint64_t		data;
+	union {
+		uint64_t	tag;
+		uint8_t		iov_count;
+		struct {
+			uint8_t	datatype;
+			uint8_t	op;
+			uint8_t ioc_count;
+		} atomic;
+	};
+};
+
 struct smr_cmd_hdr {
-	struct ofi_op_hdr	op;
-	uint32_t		msg_id;
-	uint32_t		rx_key;
+	struct smr_op_hdr	op;
+	uint64_t		msg_id;
 };
 
 #define SMR_CMD_SIZE		128	/* align with 64-byte cache line */
@@ -83,7 +100,8 @@ struct smr_cmd_hdr {
 
 #define SMR_NAME_SIZE	32
 struct smr_addr {
-	char	name[SMR_NAME_SIZE];
+	char		name[SMR_NAME_SIZE];
+	fi_addr_t	addr;
 };
 
 union smr_cmd_data {
@@ -103,14 +121,17 @@ enum {
 };
 
 struct smr_region;
-DECLARE_FREESTACK(struct smr_region *, smr_peer);
+
+struct smr_peer {
+	struct smr_addr		peer;
+	struct smr_region	*region;
+};
 
 #define SMR_MAX_PEERS	256
 
 struct smr_map {
 	fastlock_t	lock;
-	struct smr_addr	peer_addr[SMR_MAX_PEERS];
-	struct smr_peer	peer;	/* must be last */
+	struct smr_peer	peers[SMR_MAX_PEERS];
 };
 
 struct smr_region {
@@ -129,12 +150,13 @@ struct smr_region {
 	size_t		cmd_queue_offset;
 	size_t		resp_queue_offset;
 	size_t		inject_pool_offset;
+	size_t		peer_addr_offset;
 	size_t		name_offset;
 };
 
 struct smr_resp {
-	uint32_t	msg_id;
-	uint32_t	status;
+	uint64_t	msg_id;
+	uint64_t	status;
 	uint64_t	flags;
 };
 
@@ -146,13 +168,9 @@ OFI_DECLARE_CIRQUE(struct smr_cmd, smr_cmd_queue);
 OFI_DECLARE_CIRQUE(struct smr_resp, smr_resp_queue);
 DECLARE_SMR_FREESTACK(struct smr_inject_buf, smr_inject_pool);
 
-static inline struct smr_peer *smr_peer(struct smr_region *smr)
-{
-	return &smr->map->peer;
-}
 static inline struct smr_region *smr_peer_region(struct smr_region *smr, int i)
 {
-	return smr->map->peer.buf[i];
+	return smr->map->peers[i].region;
 }
 static inline struct smr_cmd_queue *smr_cmd_queue(struct smr_region *smr)
 {
@@ -165,6 +183,10 @@ static inline struct smr_resp_queue *smr_resp_queue(struct smr_region *smr)
 static inline struct smr_inject_pool *smr_inject_pool(struct smr_region *smr)
 {
 	return (struct smr_inject_pool *) ((char *) smr + smr->inject_pool_offset);
+}
+static inline struct smr_addr *smr_peer_addr(struct smr_region *smr)
+{
+	return (struct smr_addr *) ((char *) smr + smr->peer_addr_offset); 
 }
 static inline const char *smr_name(struct smr_region *smr)
 {
@@ -185,9 +207,11 @@ struct smr_attr {
 int	smr_map_create(const struct fi_provider *prov, int peer_count,
 		       struct smr_map **map);
 int	smr_map_to_region(const struct fi_provider *prov,
-			  struct smr_region **peer_buf, char *name);
+			  struct smr_peer *peer_buf);
+void	smr_map_to_endpoint(struct smr_region *region, int index);
+void	smr_exchange_all_peers(struct smr_region *region);
 int	smr_map_add(const struct fi_provider *prov,
-		    struct smr_map *map, const char *name, int *id);
+		    struct smr_map *map, const char *name, int id);
 void	smr_map_del(struct smr_map *map, int id);
 void	smr_map_free(struct smr_map *map);
 

--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -140,8 +140,8 @@ struct smr_region {
 	uint16_t	flags;
 	int		pid;
 	fastlock_t	lock; /* lock for shm access
-				 To process cmd, need to hold smr->lock (for cmd),
-				 then rx_cq->lock (lock for posted recvs) */
+				 Must hold smr->lock before tx/rx cq locks
+				 in order to progress or post recv */
 	struct smr_map	*map;
 
 	size_t		total_size;

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -97,9 +97,9 @@ struct smr_ep_entry {
 	uint64_t		tag;
 	uint64_t		ignore;
 	struct iovec		iov[SMR_IOV_LIMIT];
-	uint8_t			iov_count;
-	uint8_t			flags;
-	uint8_t			resv[sizeof(size_t) - 2];
+	uint32_t		iov_count;
+	uint32_t		flags;
+	uint64_t		err;
 };
 
 struct smr_ep;
@@ -153,7 +153,6 @@ struct smr_ep {
 	size_t			rx_size;
 	const char		*name;
 	struct smr_region	*region;
-	uint32_t		msg_id;
 	struct smr_recv_fs	*recv_fs; /* protected by rx_cq lock */
 	struct smr_recv_queue	recv_queue;
 	struct smr_recv_queue	trecv_queue;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -125,7 +125,7 @@ static void smr_tx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags)
 }
 
 static void smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags,
-			 size_t len, void *buf, void *addr, uint64_t tag)
+			size_t len, void *buf, void *addr, uint64_t tag)
 {
 	struct fi_cq_tagged_entry *comp;
 
@@ -140,7 +140,7 @@ static void smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags,
 }
 
 static void smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
-			     size_t len, void *buf, void *addr, uint64_t tag)
+			    size_t len, void *buf, void *addr, uint64_t tag)
 {
 	ep->util_ep.rx_cq->src[ofi_cirque_windex(ep->util_ep.rx_cq->cirq)] =
 		(uint32_t) (uintptr_t) addr;
@@ -167,13 +167,16 @@ void smr_progress_resp(struct smr_ep *ep)
 	struct smr_resp *resp;
 
 	fastlock_acquire(&ep->region->lock);
-	while (!ofi_cirque_isempty(smr_resp_queue(ep->region))) {
+	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
+	while (!ofi_cirque_isempty(smr_resp_queue(ep->region)) &&
+	       !ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		resp = ofi_cirque_head(smr_resp_queue(ep->region));
-		if (resp->status)
+		if (resp->status == FI_EBUSY)
 			break;
-		ep->tx_comp(ep, NULL, resp->flags);
+		ep->tx_comp(ep, (void *) resp->msg_id, FI_SEND | resp->flags);
 		ofi_cirque_discard(smr_resp_queue(ep->region));
 	}
+	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&ep->region->lock);
 }
 
@@ -185,9 +188,9 @@ static int smr_progress_inline(struct smr_cmd *cmd, struct smr_ep_entry *entry)
 	if (ret != cmd->hdr.op.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		return -FI_EIO;
+		entry->err = FI_EIO;
 	}
-	return 0;
+	return ret;
 }
 
 static int smr_progress_inject(struct smr_cmd *cmd, struct smr_ep_entry *entry,
@@ -205,9 +208,7 @@ static int smr_progress_inject(struct smr_cmd *cmd, struct smr_ep_entry *entry,
 	if (ret != cmd->hdr.op.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
-		ret = -FI_EIO;
-	} else {
-		ret = 0;
+		entry->err = FI_EIO;
 	}
 	smr_freestack_push(smr_inject_pool(ep->region), tx_buf);
 
@@ -215,19 +216,16 @@ static int smr_progress_inject(struct smr_cmd *cmd, struct smr_ep_entry *entry,
 }
 
 static int smr_progress_iov(struct smr_cmd *cmd, struct smr_ep_entry *entry,
-			    struct smr_ep *ep, uint64_t flags)
+			    struct smr_ep *ep)
 {
 	struct smr_region *peer_smr;
 	struct smr_resp *resp;
 	int peer_id, ret;
 
-	peer_id = *(int *)ofi_av_get_addr(ep->util_ep.av,
-					  entry->addr);
+	peer_id = (int) cmd->hdr.op.addr;
 	peer_smr = smr_peer_region(ep->region, peer_id);
 	resp = (struct smr_resp *) ((char **) peer_smr +
 				    (size_t) cmd->hdr.op.data);
-	resp->msg_id = cmd->hdr.msg_id;
-	resp->flags = flags;
 
 	ret = process_vm_readv(peer_smr->pid, entry->iov,
 			       entry->iov_count, cmd->data.iov,
@@ -237,17 +235,18 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct smr_ep_entry *entry,
 		if (ret < 0) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"CMA write error\n");
-			ret = -errno;
+			entry->err = errno;
 		} else { 
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"partial read occurred\n");
-			ret = -FI_EIO;
+			entry->err = FI_EIO;
 		}
-	} else {
-		ret = 0;
 	}
 
-	resp->status = ret;
+	resp->msg_id = cmd->hdr.msg_id;
+	resp->flags = (cmd->hdr.op.op == ofi_op_tagged) ? FI_TAGGED : 0;
+	resp->status = entry->err; /* Must be set last */
+
 	return ret;
 }
 
@@ -268,12 +267,13 @@ void smr_progress_cmd(struct smr_ep *ep)
 
 		cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
 
-		recv_queue = (cmd->hdr.op.flags & FI_TAGGED) ?
+		recv_queue = (cmd->hdr.op.op == ofi_op_tagged) ?
 			      &ep->trecv_queue : &ep->recv_queue;
+
 		if (dlist_empty(&recv_queue->recv_list))
 			break;
 
-		match_attr.addr = FI_ADDR_UNSPEC;
+		match_attr.addr = cmd->hdr.op.addr;
 		match_attr.tag = cmd->hdr.op.tag;
 
 		dlist_entry = dlist_remove_first_match(&recv_queue->recv_list,
@@ -290,7 +290,7 @@ void smr_progress_cmd(struct smr_ep *ep)
 		}
 		entry = container_of(dlist_entry, struct smr_ep_entry, entry);
 
-		switch (cmd->hdr.op.op_data){
+		switch (cmd->hdr.op.op_src){
 		case smr_src_inline:
 			ret = smr_progress_inline(cmd, entry);
 			break;
@@ -298,15 +298,15 @@ void smr_progress_cmd(struct smr_ep *ep)
 			ret = smr_progress_inject(cmd, entry, ep);
 			break;
 		case smr_src_iov:
-			ret = smr_progress_iov(cmd, entry, ep, cmd->hdr.op.flags);
+			ret = smr_progress_iov(cmd, entry, ep);
 			break;
 		default:
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"unidentified operation type\n");
-			ret = -FI_EINVAL;
+			entry->err = FI_EINVAL;
 		}
-		ep->rx_comp(ep, entry->context, 0, ret, NULL, &addr,
-			    cmd->hdr.op.tag);
+		ep->rx_comp(ep, entry->context, entry->flags,
+			    ret, entry->iov[0].iov_base, &addr, cmd->hdr.op.tag);
 		freestack_push(ep->recv_fs, entry);
 		ofi_cirque_discard(smr_cmd_queue(ep->region));
 	}
@@ -339,7 +339,7 @@ static int smr_match_unexp(struct dlist_entry *item, const void *args)
 	struct smr_unexp_msg *unexp_msg;
 
 	unexp_msg = container_of(item, struct smr_unexp_msg, entry);
-	return smr_match_addr(FI_ADDR_UNSPEC, attr->addr) &&//TODO figure out addr
+	return smr_match_addr(unexp_msg->cmd.hdr.op.addr, attr->addr) &&
 	       smr_match_tag(unexp_msg->cmd.hdr.op.tag, attr->ignore, attr->tag);
 }
 
@@ -372,7 +372,7 @@ static int smr_check_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 	struct smr_match_attr match_attr;
 	struct smr_unexp_msg *unexp_msg;
 	struct dlist_entry *dlist_entry;
-	int ret;
+	int ret = 0;
 
 	match_attr.addr = entry->addr;
 	match_attr.ignore = entry->ignore;
@@ -385,7 +385,7 @@ static int smr_check_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 
 	unexp_msg = container_of(dlist_entry, struct smr_unexp_msg, entry);
 
-	switch (unexp_msg->cmd.hdr.op.op_data){
+	switch (unexp_msg->cmd.hdr.op.op_src){
 	case smr_src_inline:
 		ret = smr_progress_inline(&unexp_msg->cmd, entry);
 		break;
@@ -393,16 +393,15 @@ static int smr_check_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 		ret = smr_progress_inject(&unexp_msg->cmd, entry, ep);
 		break;
 	case smr_src_iov:
-		ret = smr_progress_iov(&unexp_msg->cmd, entry, ep,
-				       unexp_msg->cmd.hdr.op.flags);
+		ret = smr_progress_iov(&unexp_msg->cmd, entry, ep);
 		break;
 	default:
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unidentified operation type\n");
-		ret = -FI_EINVAL;
+		entry->err = FI_EINVAL;
 	}
-	ep->rx_comp(ep, entry->context, 0, ret, NULL, &entry->addr,
-		    entry->tag);
+	ep->rx_comp(ep, entry->context, FI_TAGGED, ret,
+		    entry->iov[0].iov_base, &entry->addr, entry->tag);
 	freestack_push(ep->unexp_fs, unexp_msg);
 
 	return 1;
@@ -426,6 +425,7 @@ static ssize_t smr_generic_recvmsg(struct fid_ep *ep_fid, const struct iovec *io
 		goto out;
 	}
 	entry = freestack_pop(ep->recv_fs);
+	memset(entry, 0, sizeof(*entry));
 
 	for (entry->iov_count = 0; entry->iov_count < iov_count;
 	     entry->iov_count++) {
@@ -481,50 +481,55 @@ ssize_t smr_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	return smr_generic_recvmsg(ep_fid, &msg_iov, 1, src_addr, 0, 0, context, 0);
 }
 
-static void smr_format_send(struct smr_cmd *cmd, const struct iovec *iov, size_t count)
+static void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id, void *context,
+			       uint32_t flags, uint64_t tag)
 {
-	cmd->hdr.op.version = OFI_OP_VERSION;
-	cmd->hdr.op.rx_index = 0;
-	cmd->hdr.op.op = ofi_op_msg;
-	cmd->hdr.op.op_data = smr_src_inline;
+	if (flags & FI_TAGGED) {
+		cmd->hdr.op.op = ofi_op_tagged;
+		cmd->hdr.op.tag = tag;
+	} else {
+		cmd->hdr.op.op = ofi_op_msg;
+	}
+	cmd->hdr.msg_id = (uint64_t) context;
+	cmd->hdr.op.addr = peer_id;
+}
 
+static void smr_format_inline(struct smr_cmd *cmd, fi_addr_t peer_id,
+			      const struct iovec *iov, size_t count,
+			      void *context, uint32_t flags, uint64_t tag)
+{
+	smr_generic_format(cmd, peer_id, context, flags, tag);
+	cmd->hdr.op.op_src = smr_src_inline;
 	cmd->hdr.op.data = 0;
-
 	cmd->hdr.op.size = ofi_copy_from_iov(cmd->data.msg, SMR_CMD_DATA_LEN,
 					     iov, count, 0);
 }
 
-static void smr_format_inject(struct smr_cmd *cmd, const struct iovec *iov, size_t count,
+static void smr_format_inject(struct smr_cmd *cmd, fi_addr_t peer_id,
+			      const struct iovec *iov, size_t count,
+			      void *context, uint32_t flags, uint64_t tag,
 			      struct smr_region *smr, struct smr_inject_buf *tx_buf)
 {
-	cmd->hdr.op.version = OFI_OP_VERSION;
-	cmd->hdr.op.rx_index = 0;
-	cmd->hdr.op.op = ofi_op_msg;
-	cmd->hdr.op.op_data = smr_src_inject;
-
-	cmd->hdr.op.size = 0;
+	smr_generic_format(cmd, peer_id, context, flags, tag);
+	cmd->hdr.op.op_src = smr_src_inject;
 	cmd->hdr.op.data = (char **) tx_buf - (char **) smr;
-
 	cmd->hdr.op.size = ofi_copy_from_iov(tx_buf->data, SMR_INJECT_SIZE,
 					     iov, count, 0);
 }
 
-static void smr_format_cma(struct smr_cmd *cmd, const struct iovec *iov, size_t count,
-			   size_t total_len, struct smr_region *smr,
-			   struct smr_resp *resp)
+static void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
+			   const struct iovec *iov, size_t count,
+			   size_t total_len, void *context, uint32_t flags, uint64_t tag,
+			   struct smr_region *smr, struct smr_resp *resp)
 {
 	int i;
 
-	cmd->hdr.op.version = OFI_OP_VERSION;
-	cmd->hdr.op.rx_index = 0;
-	cmd->hdr.op.op = ofi_op_msg;
-	cmd->hdr.op.op_data = smr_src_iov;
-
-	cmd->hdr.op.size = 0;
-	resp->status = -FI_EBUSY;
+	smr_generic_format(cmd, peer_id, context, flags, tag);
+	cmd->hdr.op.op_src = smr_src_iov;
+	resp->status = FI_EBUSY;
 	cmd->hdr.op.data = (uint64_t) ((char **) resp - (char **) smr);
 
-	for (i = 0; i < count; i++) {
+	for (cmd->hdr.op.size = i = 0; i < count; i++) {
 		cmd->data.iov[i].iov_base = iov[i].iov_base;
 		cmd->data.iov[i].iov_len = iov[i].iov_len;
 		cmd->hdr.op.size += iov[i].iov_len;
@@ -532,8 +537,6 @@ static void smr_format_cma(struct smr_cmd *cmd, const struct iovec *iov, size_t 
 	while (i < SMR_IOV_LIMIT)
 		cmd->data.iov[i++].iov_len = 0;
 }
-
-#define peer_is_mapped(addr) (addr.name[0] == '\0')
 
 static ssize_t smr_generic_sendmsg(struct fid_ep *ep_fid, const struct iovec *iov,
 				   size_t iov_count, fi_addr_t addr, uint64_t tag,
@@ -551,17 +554,21 @@ static ssize_t smr_generic_sendmsg(struct fid_ep *ep_fid, const struct iovec *io
 	assert(iov_count <= SMR_IOV_LIMIT);
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
-	peer_id = *(int *)ofi_av_get_addr(ep->util_ep.av, addr);
+	peer_id = (int) addr;
+	if (smr_peer_addr(ep->region)[peer_id].addr == FI_ADDR_UNSPEC) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"peer not ready to receive messages\n");
+		return -FI_EAGAIN;
+	}
+
 	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
 	if (ofi_cirque_isfull(ep->util_ep.tx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}
 
-	peer_smr = smr_peer_region(ep->region, peer_id);
-	if (!peer_is_mapped(ep->region->map->peer_addr[peer_id])) {
-		ret = smr_map_to_region(&smr_prov, &peer_smr,
-					ep->region->map->peer_addr[peer_id].name);
+	if (ep->region->map->peers[peer_id].peer.addr == FI_ADDR_UNSPEC) {
+		ret = smr_map_to_region(&smr_prov, &ep->region->map->peers[peer_id]);
 		if (ret) {
 			if (ret == -ENOENT)
 				ret = -FI_EAGAIN; 
@@ -569,6 +576,7 @@ static ssize_t smr_generic_sendmsg(struct fid_ep *ep_fid, const struct iovec *io
 		}
 	}
 
+	peer_smr = smr_peer_region(ep->region, peer_id);
 	fastlock_acquire(&peer_smr->lock);
 	if (ofi_cirque_isfull(smr_cmd_queue(peer_smr))) {
 		ret = -FI_EAGAIN;
@@ -579,19 +587,19 @@ static ssize_t smr_generic_sendmsg(struct fid_ep *ep_fid, const struct iovec *io
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 
-	cmd->hdr.msg_id = (ep->msg_id)++;
-	cmd->hdr.op.flags = flags;
-	cmd->hdr.op.tag = tag;
-
 	if (total_len <= SMR_CMD_DATA_LEN) {
-		smr_format_send(cmd, iov, iov_count);
+		smr_format_inline(cmd, smr_peer_addr(ep->region)[peer_id].addr, iov,
+				  iov_count, context, flags, tag);
 	} else if (total_len <= SMR_INJECT_SIZE) {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
-		smr_format_inject(cmd, iov, iov_count, peer_smr, tx_buf);
+		smr_format_inject(cmd, smr_peer_addr(ep->region)[peer_id].addr, iov,
+				  iov_count, context, flags, tag, peer_smr, tx_buf);
 	} else {
 		assert(!ofi_cirque_isfull(smr_resp_queue(ep->region)));
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
-		smr_format_cma(cmd, iov, iov_count, total_len, ep->region, resp);
+		smr_format_iov(cmd, smr_peer_addr(ep->region)[peer_id].addr, iov,
+			       iov_count, total_len, context, flags, tag,
+			       ep->region, resp);
 		ofi_cirque_commit(smr_resp_queue(ep->region));
 		goto commit;
 	}
@@ -648,12 +656,15 @@ ssize_t smr_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	msg_iov.iov_len = len;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
-	peer_id = *(int *)ofi_av_get_addr(ep->util_ep.av, dest_addr);
+	peer_id = (int) dest_addr;
+	if (smr_peer_addr(ep->region)[peer_id].addr == FI_ADDR_UNSPEC) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"peer not ready to receive messages\n");
+		return -FI_EAGAIN;
+	}
 
-	peer_smr = smr_peer_region(ep->region, peer_id);
-	if (!peer_is_mapped(ep->region->map->peer_addr[peer_id])) {
-		ret = smr_map_to_region(&smr_prov, &peer_smr,
-					ep->region->map->peer_addr[peer_id].name);
+	if (ep->region->map->peers[peer_id].peer.addr == FI_ADDR_UNSPEC) {
+		ret = smr_map_to_region(&smr_prov, &ep->region->map->peers[peer_id]);
 		if (ret) {
 			if (ret == -ENOENT)
 				ret = -FI_EAGAIN; 
@@ -661,6 +672,7 @@ ssize_t smr_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 		}
 	}
 
+	peer_smr = smr_peer_region(ep->region, peer_id);
 	fastlock_acquire(&peer_smr->lock);
 	if (ofi_cirque_isfull(smr_cmd_queue(peer_smr))) {
 		ret = -FI_EAGAIN;
@@ -669,12 +681,13 @@ ssize_t smr_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 
-	cmd->hdr.msg_id = (ep->msg_id)++;
 	if (len <= SMR_CMD_DATA_LEN) {
-		smr_format_send(cmd, &msg_iov, 1);
+		smr_format_inline(cmd, smr_peer_addr(ep->region)[peer_id].addr,
+				  &msg_iov, 1, NULL, 0, 0);
 	} else {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
-		smr_format_inject(cmd, &msg_iov, 1, peer_smr, tx_buf);
+		smr_format_inject(cmd, smr_peer_addr(ep->region)[peer_id].addr,
+				  &msg_iov, 1, NULL, 0, 0, peer_smr, tx_buf);
 	}
 
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
@@ -769,12 +782,15 @@ ssize_t smr_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	msg_iov.iov_len = len;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
-	peer_id = *(int *)ofi_av_get_addr(ep->util_ep.av, dest_addr);
+	peer_id = (int) dest_addr;
+	if (smr_peer_addr(ep->region)[peer_id].addr == FI_ADDR_UNSPEC) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"peer not ready to receive messages\n");
+		return -FI_EAGAIN;
+	}
 
-	peer_smr = smr_peer_region(ep->region, peer_id);
-	if (!peer_is_mapped(ep->region->map->peer_addr[peer_id])) {
-		ret = smr_map_to_region(&smr_prov, &peer_smr,
-					ep->region->map->peer_addr[peer_id].name);
+	if (ep->region->map->peers[peer_id].peer.addr == FI_ADDR_UNSPEC) {
+		ret = smr_map_to_region(&smr_prov, &ep->region->map->peers[peer_id]);
 		if (ret) {
 			if (ret == -ENOENT)
 				ret = -FI_EAGAIN; 
@@ -782,6 +798,7 @@ ssize_t smr_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 		}
 	}
 
+	peer_smr = smr_peer_region(ep->region, peer_id);
 	fastlock_acquire(&peer_smr->lock);
 	if (ofi_cirque_isfull(smr_cmd_queue(peer_smr))) {
 		ret = -FI_EAGAIN;
@@ -790,14 +807,13 @@ ssize_t smr_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 
-	cmd->hdr.msg_id = (ep->msg_id)++;
-	cmd->hdr.op.tag = tag;
-	cmd->hdr.op.flags = FI_TAGGED;
 	if (len <= SMR_CMD_DATA_LEN) {
-		smr_format_send(cmd, &msg_iov, 1);
+		smr_format_inline(cmd, smr_peer_addr(ep->region)[peer_id].addr, &msg_iov,
+				  1, NULL, FI_TAGGED, tag);
 	} else {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
-		smr_format_inject(cmd, &msg_iov, 1, peer_smr, tx_buf);
+		smr_format_inject(cmd, smr_peer_addr(ep->region)[peer_id].addr, &msg_iov,
+				  1, NULL, FI_TAGGED, tag, peer_smr, tx_buf);
 	}
 
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
@@ -933,6 +949,7 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 		attr.rx_count = ep->rx_size;
 		attr.tx_count = ep->tx_size;
 		ret = smr_create(&smr_prov, av->smr_map, &attr, &ep->region);
+		smr_exchange_all_peers(ep->region);
 		break;
 	default:
 		return -FI_ENOSYS;

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -43,13 +43,19 @@
 #include <fi_shm.h>
 
 
+static void smr_peer_addr_init(struct smr_addr *peer)
+{
+	memset(peer->name, 0, SMR_NAME_SIZE);
+	peer->addr = FI_ADDR_UNSPEC;
+}
+
 /* TODO: Determine if aligning SMR data helps performance */
 int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	       const struct smr_attr *attr, struct smr_region **smr)
 {
-	size_t total_size, cmd_queue_offset;
+	size_t total_size, cmd_queue_offset, peer_addr_offset;
 	size_t resp_queue_offset, inject_pool_offset, name_offset;
-	int fd, ret;
+	int fd, ret, i;
 	void *mapped_addr;
 
 	cmd_queue_offset = sizeof(**smr);
@@ -57,8 +63,9 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 			sizeof(struct smr_cmd) * attr->rx_count;
 	inject_pool_offset = resp_queue_offset + sizeof(struct smr_resp_queue) +
 			sizeof(struct smr_resp) * attr->tx_count;
-	name_offset = inject_pool_offset + sizeof(struct smr_inject_pool) +
+	peer_addr_offset = inject_pool_offset + sizeof(struct smr_inject_pool) +
 			sizeof(struct smr_inject_buf) * attr->tx_count;
+	name_offset = peer_addr_offset + sizeof(struct smr_addr) * SMR_MAX_PEERS;
 	total_size = name_offset + strlen(attr->name) + 1;
 	total_size = roundup_power_of_two(total_size);
 
@@ -97,11 +104,15 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	(*smr)->cmd_queue_offset = cmd_queue_offset;
 	(*smr)->resp_queue_offset = resp_queue_offset;
 	(*smr)->inject_pool_offset = inject_pool_offset;
+	(*smr)->peer_addr_offset = peer_addr_offset;
 	(*smr)->name_offset = name_offset;
 
 	smr_cmd_queue_init(smr_cmd_queue(*smr), attr->rx_count);
 	smr_resp_queue_init(smr_resp_queue(*smr), attr->tx_count);
 	smr_inject_pool_init(smr_inject_pool(*smr), attr->tx_count);
+	for (i = 0; i < SMR_MAX_PEERS; i++)
+		smr_peer_addr_init(&smr_peer_addr(*smr)[i]);
+
 	strncpy((char *) smr_name(*smr), attr->name, total_size - name_offset);
 	fastlock_release(&(*smr)->lock);
 
@@ -122,29 +133,29 @@ void smr_free(struct smr_region *smr)
 int smr_map_create(const struct fi_provider *prov, int peer_count,
 		   struct smr_map **map)
 {
+	int i;
 
-	(*map) = calloc(1, sizeof(struct smr_map) +
-			   peer_count * sizeof(struct smr_region *));
+	(*map) = calloc(1, sizeof(struct smr_map));
 	if (!*map) {
 		FI_WARN(prov, FI_LOG_DOMAIN, "failed to create SHM region group\n");
 		return -FI_ENOMEM;
 	}
 
+	for (i = 0; i < peer_count; i++)
+		smr_peer_addr_init(&(*map)->peers[i].peer);
+
 	fastlock_init(&(*map)->lock);
-	smr_peer_init(&(*map)->peer, peer_count);
-	memset((*map)->peer_addr, '\0', sizeof((*map)->peer_addr));
 
 	return 0;
 }
 
-int smr_map_to_region(const struct fi_provider *prov, struct smr_region **peer_buf,
-		      char *name)
+int smr_map_to_region(const struct fi_provider *prov, struct smr_peer *peer_buf)
 {
 	struct smr_region *peer;
 	size_t size;
 	int fd, ret = 0;
 
-	fd = shm_open(name, O_RDWR, S_IRUSR | S_IWUSR);
+	fd = shm_open(peer_buf->peer.name, O_RDWR, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		FI_WARN(prov, FI_LOG_AV, "shm_open error\n");
 		return -errno;
@@ -169,31 +180,58 @@ int smr_map_to_region(const struct fi_provider *prov, struct smr_region **peer_b
 	munmap(peer, sizeof(*peer));
 
 	peer = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-	*peer_buf = peer;
-	memset(name, '\0', SMR_NAME_SIZE);
+	peer_buf->region = peer;
 
 out:
 	close(fd);
 	return ret;
 }
 
-int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
-		const char *name, int *id)
+void smr_map_to_endpoint(struct smr_region *region, int index)
 {
-	struct smr_region **peer_buf;
+	struct smr_region *peer_smr;
+	struct smr_addr *local_peers, *peer_peers;
+	int peer_index;
+
+	local_peers = smr_peer_addr(region);
+
+	strncpy(smr_peer_addr(region)[index].name,
+		region->map->peers[index].peer.name, SMR_NAME_SIZE);
+	if (region->map->peers[index].peer.addr == FI_ADDR_UNSPEC)
+		return;
+
+	peer_smr = smr_peer_region(region, index);
+	peer_peers = smr_peer_addr(peer_smr);
+
+	for (peer_index = 0; peer_index < SMR_MAX_PEERS; peer_index++) {
+		if (!strncmp(smr_name(region),
+		    peer_peers[peer_index].name, SMR_NAME_SIZE))
+			break;
+	}
+	if (peer_index != SMR_MAX_PEERS) {
+		peer_peers[peer_index].addr = index;
+		local_peers[index].addr = peer_index;
+	}
+}
+
+void smr_exchange_all_peers(struct smr_region *region)
+{
+	int i;
+	for (i = 0; i < SMR_MAX_PEERS; i++)
+		smr_map_to_endpoint(region, i);
+}
+
+int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
+		const char *name, int id)
+{
 	int ret = 0;
 
 	fastlock_acquire(&map->lock);
-	if (!freestack_isempty(&map->peer)) {
-		peer_buf = freestack_pop(&map->peer);
-		*id = smr_peer_index(&map->peer, peer_buf);
-		strncpy(map->peer_addr[*id].name, name, SMR_NAME_SIZE);
-		map->peer_addr[*id].name[SMR_NAME_SIZE - 1] = '\0';
-		ret = smr_map_to_region(prov, peer_buf, map->peer_addr[*id].name);
-	} else {
-		FI_WARN(prov, FI_LOG_AV, "peer array is full\n");
-		ret = -FI_ENOMEM;
-	}
+	strncpy(map->peers[id].peer.name, name, SMR_NAME_SIZE);
+	map->peers[id].peer.name[SMR_NAME_SIZE - 1] = '\0';
+	ret = smr_map_to_region(prov, &map->peers[id]);
+	if (!ret)
+		map->peers[id].peer.addr = id;
 	fastlock_release(&map->lock);
 
 	return ret == -ENOENT ? 0 : ret;
@@ -201,30 +239,19 @@ int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
 
 void smr_map_del(struct smr_map *map, int id)
 {
-	struct smr_region *peer;
-	int size;
-
-	size = map->peer.size;
-	if (id < 0 || id >= size)
+	if (id >= SMR_MAX_PEERS || id < 0 ||
+	    map->peers[id].peer.addr == FI_ADDR_UNSPEC)
 		return;
 
-	peer = map->peer.buf[id];
-	if ((uintptr_t)peer < (uintptr_t)&map->peer.buf[0] ||
-	    (uintptr_t)peer >= (uintptr_t)&map->peer.buf[size])
-		return;
-
-	if (!peer->pid)
-		return;
-
-	munmap(peer, peer->total_size);
-	freestack_push(&map->peer, &map->peer.buf[id]);
+	munmap(map->peers[id].region, map->peers[id].region->total_size);
+	map->peers[id].peer.addr = FI_ADDR_UNSPEC;
 }
 
 void smr_map_free(struct smr_map *map)
 {
 	int i;
 
-	for (i = 0; i < map->peer.size; i++)
+	for (i = 0; i < SMR_MAX_PEERS; i++)
 		smr_map_del(map, i);
 
 	free(map);
@@ -232,17 +259,8 @@ void smr_map_free(struct smr_map *map)
 
 struct smr_region *smr_map_get(struct smr_map *map, int id)
 {
-	struct smr_region *peer;
-	int size;
-
-	size = map->peer.size;
-	if (id < 0 || id >= size)
+	if (id < 0 || id >= SMR_MAX_PEERS)
 		return NULL;
 
-	peer = map->peer.buf[id];
-	if ((uintptr_t)peer < (uintptr_t)&map->peer.buf[0] ||
-	    (uintptr_t)peer >= (uintptr_t)&map->peer.buf[size])
-		return NULL;
-
-	return peer;
+	return map->peers[id].region;
 }


### PR DESCRIPTION
- Change format of address storage so allow peers to exchange addresses through the shared memory region
- Create specific smr_cmd over ofi_cmd
- Increase msg_id to uint64_t and hold context
- Some renaming
- Fix inconsistent locking order reported by coverity

Signed-off-by: aingerson <alexia.ingerson@intel.com>