### PR TITLE
prov/util: Return RMA caps based on hints mr mode

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -624,6 +624,9 @@ int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	 (!(info->domain_attr->mr_mode & ~(FI_MR_BASIC | FI_MR_SCALABLE)) && \
 	  (info->mode & FI_LOCAL_MR)))
 
+#define OFI_MR_MODE_RMA_TARGET (FI_MR_RAW | FI_MR_VIRT_ADDR |\
+				 FI_MR_PROV_KEY | FI_MR_RMA_EVENT)
+
 struct ofi_mr_map {
 	const struct fi_provider *prov;
 	void			*rbtree;


### PR DESCRIPTION
prov/util: Advertise RMA target capability based on hints and provider mode

This patch handles the case when user passes zero in hints->caps.

ofi_alter_info through ofi_get_caps sets all supported caps by the provider
if hints->caps is zero. This can have the inadvertent effect of advertising
RMA target caps when the app doesn't support provider required mr_modes for
it.

Fix:
If a provider supports RMA target caps but require certain MR modes for the
support, check the hints for those modes and disable the caps if needed.