### PR TITLE
prov/psm2: Allow PSM2 epid be reused within the same session

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -203,9 +203,10 @@ union psmx2_pi {
 #define PSMX2_CTXT_USER(fi_context)	((fi_context)->internal[2])
 #define PSMX2_CTXT_EP(fi_context)	((fi_context)->internal[3])
 
-#define PSMX2_AM_RMA_HANDLER	0
-#define PSMX2_AM_ATOMIC_HANDLER	1
-#define PSMX2_AM_SEP_HANDLER	2
+#define PSMX2_AM_RMA_HANDLER		0
+#define PSMX2_AM_ATOMIC_HANDLER		1
+#define PSMX2_AM_SEP_HANDLER		2
+#define PSMX2_AM_TRX_CTXT_HANDLER	3
 
 #define PSMX2_AM_OP_MASK	0x000000FF
 #define PSMX2_AM_DST_MASK	0x0000FF00
@@ -241,6 +242,7 @@ enum {
 	PSMX2_AM_REQ_READV,
 	PSMX2_AM_REQ_SEP_QUERY,
 	PSMX2_AM_REP_SEP_QUERY,
+	PSMX2_AM_REQ_TRX_CTXT_DISCONNECT,
 };
 
 struct psmx2_am_request {
@@ -387,6 +389,10 @@ struct psmx2_trx_ctxt {
 	 * interleaved in a multithreaded environment.
 	 */
 	fastlock_t		poll_lock;
+
+	/* list of peers connected to this tx/rx context */
+	struct dlist_entry	peer_list;
+	fastlock_t		peer_lock;
 
 	struct dlist_entry	entry;
 };
@@ -836,6 +842,8 @@ struct psmx2_fid_mr {
 struct psmx2_epaddr_context {
 	struct psmx2_trx_ctxt	*trx_ctxt;
 	psm2_epid_t		epid;
+	psm2_epaddr_t		epaddr;
+	struct dlist_entry	entry;
 };
 
 struct psmx2_env {
@@ -1086,6 +1094,9 @@ int	psmx2_am_atomic_handler_ext(psm2_am_token_t token,
 				    struct psmx2_trx_ctxt *trx_ctxt);
 int	psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args, int nargs,
 			     void *src, uint32_t len);
+int	psmx2_am_trx_ctxt_handler_ext(psm2_am_token_t token,
+				      psm2_amarg_t *args, int nargs, void *src, uint32_t len,
+				      struct psmx2_trx_ctxt *trx_ctxt);
 void	psmx2_atomic_global_init(void);
 void	psmx2_atomic_global_fini(void);
 

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -215,7 +215,12 @@ static void psmx2_set_epaddr_context(struct psmx2_trx_ctxt *trx_ctxt,
 
 	context->trx_ctxt = trx_ctxt;
 	context->epid = epid;
+	context->epaddr = epaddr;
 	psm2_epaddr_setctxt(epaddr, context);
+
+	psmx2_lock(&trx_ctxt->peer_lock, 2);
+	dlist_insert_before(&context->entry, &trx_ctxt->peer_list);
+	psmx2_unlock(&trx_ctxt->peer_lock, 2);
 }
 
 int psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,


### PR DESCRIPTION
A session of a client-server application may have multiple clients
communicating with the same server. If some clients run on the same
node one after another, it is possible that the PSM2 endpoints they
open map to the same physical resource (i.e. with the same epid). In
order to work correctly under such situation, the connection states
associated with the reused epid need to be properly cleaned up at
both the client and the server side. The client side cleanup is done
automatically when the endpoint is closed before exiting. The server
side cleanup, however, requires calling psm2_ep_disconnect() explicitly.

The patch adds an AM based protocol to let all connected peers do the
cleanup when a PSM2 endpoint is about to be closed.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>