### PR TITLE
prov/shm: add cq errors, add pending command queue,+ coverity fix

### DIFF
--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -157,7 +157,6 @@ struct smr_region {
 struct smr_resp {
 	uint64_t	msg_id;
 	uint64_t	status;
-	uint64_t	flags;
 };
 
 struct smr_inject_buf {

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -114,6 +114,7 @@ struct smr_match_attr {
 	fi_addr_t	addr;
 	uint64_t	tag;
 	uint64_t	ignore;
+	uint64_t	ctx;
 };
 
 static inline int smr_match_addr(fi_addr_t addr, fi_addr_t match_addr)
@@ -127,20 +128,21 @@ static inline int smr_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_ta
 	return ((tag | ignore) == (match_tag | ignore));
 }
 
-struct smr_unexp_msg {
+struct smr_pending_cmd {
 	struct dlist_entry entry;
 	struct smr_cmd cmd;
 };
 
 DECLARE_FREESTACK(struct smr_ep_entry, smr_recv_fs);
-DECLARE_FREESTACK(struct smr_unexp_msg, smr_unexp_fs);
+DECLARE_FREESTACK(struct smr_pending_cmd, smr_unexp_fs);
+DECLARE_FREESTACK(struct smr_pending_cmd, smr_pend_fs);
 
 struct smr_recv_queue {
 	struct dlist_entry recv_list;
 	dlist_func_t *match_recv;
 };
 
-struct smr_unexp_queue {
+struct smr_pending_queue {
 	struct dlist_entry msg_list;
 	dlist_func_t *match_msg;
 };
@@ -157,7 +159,9 @@ struct smr_ep {
 	struct smr_recv_queue	recv_queue;
 	struct smr_recv_queue	trecv_queue;
 	struct smr_unexp_fs	*unexp_fs;
-	struct smr_unexp_queue	unexp_queue;
+	struct smr_pend_fs	*pend_fs;
+	struct smr_pending_queue	unexp_queue;
+	struct smr_pending_queue	pend_queue;
 };
 
 int smr_endpoint(struct fid_domain *domain, struct fi_info *info,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -103,11 +103,11 @@ struct smr_ep_entry {
 };
 
 struct smr_ep;
-typedef void (*smr_rx_comp_func)(struct smr_ep *ep, void *context,
+typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context,
 		uint64_t flags, size_t len, void *buf, void *addr,
-		uint64_t tag);
-typedef void (*smr_tx_comp_func)(struct smr_ep *ep, void *context,
-		uint64_t flags);
+		uint64_t tag, uint64_t err);
+typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context,
+		uint64_t flags, uint64_t err);
 
 
 struct smr_match_attr {

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -105,66 +105,116 @@ static struct fi_ops_ep smr_ep_ops = {
 	.tx_size_left = fi_no_tx_size_left,
 };
 
-static void smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags)
+static int smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags,
+		       uint64_t err)
 {
 	struct fi_cq_tagged_entry *comp;
+	struct util_cq_err_entry *entry;
 
 	comp = ofi_cirque_tail(ep->util_ep.tx_cq->cirq);
-	comp->op_context = context;
-	comp->flags = flags;
-	comp->len = 0;
-	comp->buf = NULL;
-	comp->data = 0;
+	if (err) {
+		if (!(entry = calloc(1, sizeof(*entry))))
+			return -FI_ENOMEM;
+		entry->err_entry.op_context = context;
+		entry->err_entry.flags = flags;
+		entry->err_entry.err = err;
+		entry->err_entry.prov_errno = -err;
+		slist_insert_tail(&entry->list_entry,
+				  &ep->util_ep.tx_cq->err_list);
+		comp->flags = UTIL_FLAG_ERROR;
+	} else {
+		comp->op_context = context;
+		comp->flags = flags;
+		comp->len = 0;
+		comp->buf = NULL;
+		comp->data = 0;
+	}
 	ofi_cirque_commit(ep->util_ep.tx_cq->cirq);
+	return 0;
 }
 
-static void smr_tx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags)
+static int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
+			      uint64_t err)
 {
-	smr_tx_comp(ep, context, flags);
+	int ret;
+
+	ret = smr_tx_comp(ep, context, flags, err);
+	if (ret)
+		return ret;
 	ep->util_ep.tx_cq->wait->signal(ep->util_ep.tx_cq->wait);
+	return 0;
 }
 
-static void smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags,
-			size_t len, void *buf, void *addr, uint64_t tag)
+static int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags,
+		       size_t len, void *buf, void *addr, uint64_t tag,
+		       uint64_t err)
 {
 	struct fi_cq_tagged_entry *comp;
+	struct util_cq_err_entry *entry;
 
 	comp = ofi_cirque_tail(ep->util_ep.rx_cq->cirq);
-	comp->op_context = context;
-	comp->flags = FI_RECV | flags;
-	comp->len = len;
-	comp->buf = buf;
-	comp->data = 0;
-	comp->tag = tag;
+	if (err) {
+		if (!(entry = calloc(1, sizeof(*entry))))
+			return -FI_ENOMEM;
+		entry->err_entry.op_context = context;
+		entry->err_entry.flags = FI_RECV | flags;
+		entry->err_entry.tag = tag;
+		entry->err_entry.err = err;
+		entry->err_entry.prov_errno = -err;
+		slist_insert_tail(&entry->list_entry,
+				  &ep->util_ep.rx_cq->err_list);
+		comp->flags = UTIL_FLAG_ERROR;
+	} else {
+		comp->op_context = context;
+		comp->flags = FI_RECV | flags;
+		comp->len = len;
+		comp->buf = buf;
+		comp->data = 0;
+		comp->tag = tag;
+	}
 	ofi_cirque_commit(ep->util_ep.rx_cq->cirq);
+	return 0;
 }
 
-static void smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
-			    size_t len, void *buf, void *addr, uint64_t tag)
+static int smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
+			   size_t len, void *buf, void *addr, uint64_t tag,
+			   uint64_t err)
 {
 	ep->util_ep.rx_cq->src[ofi_cirque_windex(ep->util_ep.rx_cq->cirq)] =
 		(uint32_t) (uintptr_t) addr;
-	smr_rx_comp(ep, context, flags, len, buf, addr, tag);
+	return smr_rx_comp(ep, context, flags, len, buf, addr, tag, err);
 }
 
-static void smr_rx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
-			       size_t len, void *buf, void *addr, uint64_t tag)
+static int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
+			      size_t len, void *buf, void *addr, uint64_t tag,
+			      uint64_t err)
 {
-	smr_rx_comp(ep, context, flags, len, buf, addr, tag);
+	int ret;
+
+	ret = smr_rx_comp(ep, context, flags, len, buf, addr, tag, err);
+	if (ret)
+		return ret;
 	ep->util_ep.rx_cq->wait->signal(ep->util_ep.rx_cq->wait);
+	return 0;
 }
 
-static void smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
-				   size_t len, void *buf, void *addr, uint64_t tag)
+static int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
+				  size_t len, void *buf, void *addr, uint64_t tag,
+				  uint64_t err)
 {
-	smr_rx_src_comp(ep, context, flags, len, buf, addr, tag);
-	ep->util_ep.rx_cq->wait->signal(ep->util_ep.rx_cq->wait);
+	int ret;
 
+	ret = smr_rx_src_comp(ep, context, flags, len, buf, addr, tag, err);
+	if (ret)
+		return ret;
+	ep->util_ep.rx_cq->wait->signal(ep->util_ep.rx_cq->wait);
+	return 0;
 }
 
 void smr_progress_resp(struct smr_ep *ep)
 {
 	struct smr_resp *resp;
+	int ret;
 
 	fastlock_acquire(&ep->region->lock);
 	fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
@@ -173,14 +223,20 @@ void smr_progress_resp(struct smr_ep *ep)
 		resp = ofi_cirque_head(smr_resp_queue(ep->region));
 		if (resp->status == FI_EBUSY)
 			break;
-		ep->tx_comp(ep, (void *) resp->msg_id, FI_SEND | resp->flags);
+		ret = ep->tx_comp(ep, (void *) resp->msg_id, FI_SEND | resp->flags,
+				  resp->status);
+		if (ret) {
+			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+				"unable to process tx completion\n");
+			break;
+		}
 		ofi_cirque_discard(smr_resp_queue(ep->region));
 	}
 	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&ep->region->lock);
 }
 
-static int smr_progress_inline(struct smr_cmd *cmd, struct smr_ep_entry *entry)
+static void  smr_progress_inline(struct smr_cmd *cmd, struct smr_ep_entry *entry)
 {
 	int ret;
 	ret = ofi_copy_to_iov(entry->iov, entry->iov_count, 0,
@@ -190,10 +246,9 @@ static int smr_progress_inline(struct smr_cmd *cmd, struct smr_ep_entry *entry)
 			"recv truncated");
 		entry->err = FI_EIO;
 	}
-	return ret;
 }
 
-static int smr_progress_inject(struct smr_cmd *cmd, struct smr_ep_entry *entry,
+static void smr_progress_inject(struct smr_cmd *cmd, struct smr_ep_entry *entry,
 			       struct smr_ep *ep)
 {
 	struct smr_inject_buf *tx_buf;
@@ -211,11 +266,9 @@ static int smr_progress_inject(struct smr_cmd *cmd, struct smr_ep_entry *entry,
 		entry->err = FI_EIO;
 	}
 	smr_freestack_push(smr_inject_pool(ep->region), tx_buf);
-
-	return ret;
 }
 
-static int smr_progress_iov(struct smr_cmd *cmd, struct smr_ep_entry *entry,
+static void smr_progress_iov(struct smr_cmd *cmd, struct smr_ep_entry *entry,
 			    struct smr_ep *ep)
 {
 	struct smr_region *peer_smr;
@@ -246,8 +299,6 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct smr_ep_entry *entry,
 	resp->msg_id = cmd->hdr.msg_id;
 	resp->flags = (cmd->hdr.op.op == ofi_op_tagged) ? FI_TAGGED : 0;
 	resp->status = entry->err; /* Must be set last */
-
-	return ret;
 }
 
 void smr_progress_cmd(struct smr_ep *ep)
@@ -292,21 +343,26 @@ void smr_progress_cmd(struct smr_ep *ep)
 
 		switch (cmd->hdr.op.op_src){
 		case smr_src_inline:
-			ret = smr_progress_inline(cmd, entry);
+			smr_progress_inline(cmd, entry);
 			break;
 		case smr_src_inject:
-			ret = smr_progress_inject(cmd, entry, ep);
+			smr_progress_inject(cmd, entry, ep);
 			break;
 		case smr_src_iov:
-			ret = smr_progress_iov(cmd, entry, ep);
+			smr_progress_iov(cmd, entry, ep);
 			break;
 		default:
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"unidentified operation type\n");
 			entry->err = FI_EINVAL;
 		}
-		ep->rx_comp(ep, entry->context, entry->flags,
-			    ret, entry->iov[0].iov_base, &addr, cmd->hdr.op.tag);
+		ret = ep->rx_comp(ep, entry->context, entry->flags,
+				  ret, entry->iov[0].iov_base, &addr, cmd->hdr.op.tag,
+				  entry->err);
+		if (ret) {
+			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+				"unable to process rx completion\n");
+		}
 		freestack_push(ep->recv_fs, entry);
 		ofi_cirque_discard(smr_cmd_queue(ep->region));
 	}
@@ -351,7 +407,7 @@ static void smr_init_recv_queue(struct smr_recv_queue *recv_queue,
 }
 
 static void smr_init_unexp_queue(struct smr_unexp_queue *unexp_queue,
-				 dlist_func_t *match_func)
+				   dlist_func_t *match_func)
 {
 	dlist_init(&unexp_queue->msg_list);
 	unexp_queue->match_msg = match_func;
@@ -387,21 +443,26 @@ static int smr_check_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 
 	switch (unexp_msg->cmd.hdr.op.op_src){
 	case smr_src_inline:
-		ret = smr_progress_inline(&unexp_msg->cmd, entry);
+		smr_progress_inline(&unexp_msg->cmd, entry);
 		break;
 	case smr_src_inject:
-		ret = smr_progress_inject(&unexp_msg->cmd, entry, ep);
+		smr_progress_inject(&unexp_msg->cmd, entry, ep);
 		break;
 	case smr_src_iov:
-		ret = smr_progress_iov(&unexp_msg->cmd, entry, ep);
+		smr_progress_iov(&unexp_msg->cmd, entry, ep);
 		break;
 	default:
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unidentified operation type\n");
 		entry->err = FI_EINVAL;
 	}
-	ep->rx_comp(ep, entry->context, FI_TAGGED, ret,
-		    entry->iov[0].iov_base, &entry->addr, entry->tag);
+	ret = ep->rx_comp(ep, entry->context, FI_TAGGED, ret,
+			  entry->iov[0].iov_base, &entry->addr, entry->tag,
+			  entry->err);
+	if (ret) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"unable to process rx completion\n");
+	}
 	freestack_push(ep->unexp_fs, unexp_msg);
 
 	return 1;
@@ -602,7 +663,12 @@ static ssize_t smr_generic_sendmsg(struct fid_ep *ep_fid, const struct iovec *io
 		ofi_cirque_commit(smr_resp_queue(ep->region));
 		goto commit;
 	}
-	ep->tx_comp(ep, context, FI_SEND | flags);
+	ret = ep->tx_comp(ep, context, FI_SEND | flags, 0);
+	if (ret) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"unable to process tx completion\n");
+		goto unlock_cq;
+	}
 
 commit:
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));


### PR DESCRIPTION
Report errors on cq:
- pass return value/error to tx_comp and rx_comp
- add error entry to err_list and make available for cq_readerr

Pending command queue:
- limit response ack to msg_id and status, get rid of flags
- add pending command queue to store incomplete commands
- look up pending command by context/msg_id and report flags through pending command

Also includes memory leak fix reported by coverity

Signed-off-by: aingerson <alexia.ingerson@intel.com>
