### PR TITLE
prov/verbs: Add support of different CQ formats for the verbs/RDM

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -332,7 +332,6 @@ struct fi_ibv_rdm_ep {
 	int	use_odp;
 	int	scq_depth;
 	int	rcq_depth;
-	int	cqread_bunch_size;
 
 	int	is_closing;
 	int	recv_preposted_threshold;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -388,16 +388,21 @@ struct fi_ibv_cq {
 	struct util_buf_pool	*wce_pool;
 };
 
+struct fi_ibv_rdm_request;
+typedef void (*fi_ibv_rdm_cq_read_entry)(struct fi_ibv_rdm_request *cq_entry,
+					 int index, void *buf);
+
 struct fi_ibv_rdm_cq {
-	struct fid_cq		cq_fid;
-	struct fi_ibv_domain	*domain;
-	struct fi_ibv_rdm_ep	*ep;
-	struct dlist_entry	request_cq;
-	struct dlist_entry	request_errcq;
-	uint64_t		flags;
-	size_t			entry_size;
-	int			read_bunch_size;
-	enum fi_cq_wait_cond	wait_cond;
+	struct fid_cq			cq_fid;
+	struct fi_ibv_domain		*domain;
+	struct fi_ibv_rdm_ep		*ep;
+	struct dlist_entry		request_cq;
+	struct dlist_entry		request_errcq;
+	uint64_t			flags;
+	size_t				entry_size;
+	fi_ibv_rdm_cq_read_entry	read_entry;
+	int				read_bunch_size;
+	enum fi_cq_wait_cond		wait_cond;
 };
 
 int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,


### PR DESCRIPTION
The intent of this patch is to fix possible an invalid memory read/write when user uses not `FI_CQ_FORMAT_TAGGED` CQ format for reading CQ entries (this becaomers a major issue when user reads a bunch of CQ entries, because verbs/RDM writes to a memory of next CQ entry buffer).


Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>