### PR TITLE
usnic: update MR mode checks

### DIFF
--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -520,8 +520,6 @@ int usdf_catch_dom_attr(uint32_t version, const struct fi_info *hints,
 			struct fi_domain_attr *dom_attr);
 int usdf_catch_tx_attr(uint32_t version, const struct fi_tx_attr *tx_attr);
 int usdf_catch_rx_attr(uint32_t version, const struct fi_rx_attr *rx_attr);
-int usdf_check_mr_mode(uint32_t version, const struct fi_info *hints,
-		       uint64_t prov_mode);
 struct sockaddr_in *usdf_format_to_sin(const struct fi_info *info, const void *addr);
 void *usdf_sin_to_format(const struct fi_info *info, void *addr, size_t *len);
 void usdf_free_sin_if_needed(const struct fi_info *info, struct sockaddr_in *sin);

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -480,6 +480,8 @@ int usdf_catch_dom_attr(uint32_t version, const struct fi_info *hints,
 			if (hints->domain_attr->caps == FI_REMOTE_COMM)
 				return -FI_EBADFLAGS;
 		}
+        } else {
+            dom_attr->mr_mode &= ~(FI_MR_BASIC | FI_MR_SCALABLE);
 	}
 
 	return FI_SUCCESS;

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -508,35 +508,3 @@ int usdf_catch_rx_attr(uint32_t version, const struct fi_rx_attr *rx_attr)
 
 	return FI_SUCCESS;
 }
-
-/* A wrapper function to core utility function to check mr_mode bits.
- * We need to check some more things for backward compatibility.
- */
-int usdf_check_mr_mode(uint32_t version, const struct fi_info *hints,
-		       uint64_t prov_mode)
-{
-	int ret;
-
-	ret = ofi_check_mr_mode(&usdf_ops, version, prov_mode, hints);
-
-	/* TODO: Checks below may not be needed */
-	/* If ofi_check_mr_mode fails. */
-	if (ret) {
-		/* Is it because the user give 0 as mr_mode? */
-		if (hints->domain_attr->mr_mode == 0) {
-			if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
-				/* If the version is < 1.5, it is ok.
-				 * We let this slide and catch it later on.
-				 */
-				return FI_SUCCESS;
-			} else if (hints->mode & FI_LOCAL_MR) {
-				/* If version is >= 1.5, we check fi_info mode
-				 * for FI_LOCAL_MR for backward compatibility.
-				 */
-				return FI_SUCCESS;
-			}
-		}
-	}
-
-	return ret;
-}

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -435,7 +435,7 @@ static const struct fi_domain_attr dgram_dflt_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_DISABLED,
-	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL,
+	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL | FI_MR_BASIC,
 	.cntr_cnt = USDF_DGRAM_CNTR_CNT,
 	.mr_iov_limit = USDF_DGRAM_MR_IOV_LIMIT,
 	.mr_cnt = USDF_DGRAM_MR_CNT,
@@ -565,7 +565,7 @@ int usdf_dgram_fill_dom_attr(uint32_t version, const struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	if (usdf_check_mr_mode(version, hints, defaults.mr_mode))
+	if (ofi_check_mr_mode(&usdf_ops, version, defaults.mr_mode, hints))
 		return -FI_ENODATA;
 
 	if (hints->domain_attr->mr_cnt) {

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -117,7 +117,7 @@ static const struct fi_domain_attr msg_dflt_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_DISABLED,
-	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL,
+	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL | FI_MR_BASIC,
 	.cntr_cnt = USDF_MSG_CNTR_CNT,
 	.mr_iov_limit = USDF_MSG_MR_IOV_LIMIT,
 	.mr_cnt = USDF_MSG_MR_CNT,
@@ -245,7 +245,7 @@ int usdf_msg_fill_dom_attr(uint32_t version, const struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	if (usdf_check_mr_mode(version, hints, defaults.mr_mode))
+	if (ofi_check_mr_mode(&usdf_ops, version, defaults.mr_mode, hints))
 		return -FI_ENODATA;
 
 	if (hints->domain_attr->mr_cnt <= USDF_MSG_MR_CNT) {

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -120,7 +120,7 @@ static const struct fi_domain_attr rdm_dflt_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_DISABLED,
-	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL,
+	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL | FI_MR_BASIC,
 	.cntr_cnt = USDF_RDM_CNTR_CNT,
 	.mr_iov_limit = USDF_RDM_MR_IOV_LIMIT,
 	.mr_cnt = USDF_RDM_MR_CNT,
@@ -249,7 +249,7 @@ int usdf_rdm_fill_dom_attr(uint32_t version, const struct fi_info *hints,
 		return -FI_ENODATA;
 	}
 
-	if (usdf_check_mr_mode(version, hints, defaults.mr_mode))
+	if (ofi_check_mr_mode(&usdf_ops, version, defaults.mr_mode, hints))
 		return -FI_ENODATA;
 
 	if (hints->domain_attr->mr_cnt <= USDF_RDM_MR_CNT) {


### PR DESCRIPTION
Update default endpoint flags to enable the usnic provider to work properly with the changes from da4f8f7e9223c68529db7dedd7c88c28957bb3f0. Also remove the now-unnecessary usdf_check_mr_mode() wrapper (and just use ofi_check_mr_mode() directly).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>