### PR TITLE
prov/psm,psm2: Minor coding style clean-up

### DIFF
--- a/prov/psm/configure.m4
+++ b/prov/psm/configure.m4
@@ -39,7 +39,7 @@ AC_DEFUN([FI_PSM_CONFIGURE],[
 		     ])
 	       AS_IF([test $psm_happy -eq 1],
 		     [AC_CHECK_TYPE([psm_epconn_t],
-		                    [],
+				    [],
 				    [psm_happy=0],
 				    [[#include <psm.h>]])])
 	      ])

--- a/prov/psm/src/psm_am.h
+++ b/prov/psm/src/psm_am.h
@@ -279,7 +279,7 @@ struct psm_am_parameters {
  */
 psm_error_t
 psm_am_get_parameters(psm_ep_t ep, struct psm_am_parameters *parameters,
-                      size_t sizeof_parameters_in,
+		      size_t sizeof_parameters_in,
 		      size_t *sizeof_parameters_out);
 
 

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -84,8 +84,8 @@ extern int psmx_am_compat_mode;
 
 #define PSMX_CAPS	(FI_TAGGED | FI_MSG | FI_ATOMICS | \
 			 FI_RMA | FI_MULTI_RECV | \
-                         FI_READ | FI_WRITE | FI_SEND | FI_RECV | \
-                         FI_REMOTE_READ | FI_REMOTE_WRITE | \
+			 FI_READ | FI_WRITE | FI_SEND | FI_RECV | \
+			 FI_REMOTE_READ | FI_REMOTE_WRITE | \
 			 FI_TRIGGER | FI_RMA_EVENT)
 
 #define PSMX_CAPS2	((PSMX_CAPS | FI_DIRECTED_RECV) & ~FI_TAGGED)

--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -1273,7 +1273,7 @@ static ssize_t psmx_atomic_compwrite(struct fid_ep *ep,
 					compare, compare_desc,
 					result, result_desc,
 					dest_addr, addr, key,
-				        datatype, op, context, ep_priv->tx_flags);
+					datatype, op, context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx_atomic_compwritemsg(struct fid_ep *ep,

--- a/prov/psm/src/psmx_av.c
+++ b/prov/psm/src/psmx_av.c
@@ -64,8 +64,8 @@ static void psmx_set_epaddr_context(struct psmx_fid_domain *domain,
 int psmx_epid_to_epaddr(struct psmx_fid_domain *domain,
 			psm_epid_t epid, psm_epaddr_t *epaddr)
 {
-        int err;
-        psm_error_t errors;
+	int err;
+	psm_error_t errors;
 	psm_epconn_t epconn;
 	struct psmx_epaddr_context *context;
 
@@ -78,13 +78,13 @@ int psmx_epid_to_epaddr(struct psmx_fid_domain *domain,
 		}
 	}
 
-        err = psm_ep_connect(domain->psm_ep, 1, &epid, NULL, &errors, epaddr, 30*1e9);
-        if (err != PSM_OK)
-                return psmx_errno(err);
+	err = psm_ep_connect(domain->psm_ep, 1, &epid, NULL, &errors, epaddr, 30*1e9);
+	if (err != PSM_OK)
+		return psmx_errno(err);
 
 	psmx_set_epaddr_context(domain,epid,*epaddr);
 
-        return 0;
+	return 0;
 }
 
 static int psmx_av_check_table_size(struct psmx_fid_av *av, size_t count)

--- a/prov/psm/src/psmx_fabric.c
+++ b/prov/psm/src/psmx_fabric.c
@@ -116,7 +116,7 @@ int psmx_fabric(struct fi_fabric_attr *attr,
 				  &fabric_priv->name_server);
 		if (ret) {
 			FI_INFO(&psmx_prov, FI_LOG_CORE,
-			        "ofi_ns_init returns %d\n", ret);
+				"ofi_ns_init returns %d\n", ret);
 			free(fabric_priv);
 			return ret;
 		}

--- a/prov/psm/src/psmx_msg2.c
+++ b/prov/psm/src/psmx_msg2.c
@@ -132,9 +132,9 @@ static struct psmx_unexp *psmx_am_search_and_dequeue_unexp(
 int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			psm_amarg_t *args, int nargs, void *src, uint32_t len)
 {
-        psm_amarg_t rep_args[8];
-        struct psmx_am_request *req;
-        struct psmx_cq_event *event;
+	psm_amarg_t rep_args[8];
+	struct psmx_am_request *req;
+	struct psmx_cq_event *event;
 	struct psmx_epaddr_context *epaddr_context;
 	struct psmx_fid_domain *domain;
 	int copy_len;
@@ -159,7 +159,7 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 	switch (cmd) {
 	case PSMX_AM_REQ_SEND:
 		assert(len == args[0].u32w1);
-                offset = args[3].u64;
+		offset = args[3].u64;
 		if (offset == 0) {
 			/* this is the first packet */
 			req = psmx_am_search_and_dequeue_recv(domain, (const void *)epaddr);
@@ -243,7 +243,7 @@ int psmx_am_msg_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 					rep_args, 3, NULL, 0, 0,
 					NULL, NULL );
 		}
-                break;
+		break;
 
 	case PSMX_AM_REP_SEND:
 		req = (struct psmx_am_request *)(uintptr_t)args[1].u64;
@@ -350,9 +350,9 @@ static ssize_t _psmx_recv2(struct fid_ep *ep, void *buf, size_t len,
 	int err = 0;
 	size_t idx;
 
-        ep_priv = container_of(ep, struct psmx_fid_ep, ep);
+	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 
-        if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
+	if ((ep_priv->caps & FI_DIRECTED_RECV) && src_addr != FI_ADDR_UNSPEC) {
 		av = ep_priv->av;
 		if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
@@ -439,7 +439,7 @@ static ssize_t psmx_recv2(struct fid_ep *ep, void *buf, size_t len,
 {
 	struct psmx_fid_ep *ep_priv;
 
-        ep_priv = container_of(ep, struct psmx_fid_ep, ep);
+	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 	return _psmx_recv2(ep, buf, len, desc, src_addr, context, ep_priv->rx_flags);
 }
 
@@ -558,7 +558,7 @@ static ssize_t psmx_send2(struct fid_ep *ep, const void *buf,
 {
 	struct psmx_fid_ep *ep_priv;
 
-        ep_priv = container_of(ep, struct psmx_fid_ep, ep);
+	ep_priv = container_of(ep, struct psmx_fid_ep, ep);
 	return _psmx_send2(ep, buf, len, desc, dest_addr, context, ep_priv->tx_flags);
 }
 

--- a/prov/psm/src/psmx_tagged.c
+++ b/prov/psm/src/psmx_tagged.c
@@ -560,7 +560,7 @@ ssize_t _psmx_tagged_send(struct fid_ep *ep, const void *buf, size_t len,
 ssize_t psmx_tagged_send_no_flag_av_map(struct fid_ep *ep, const void *buf,
 					size_t len, void *desc,
 					fi_addr_t dest_addr, uint64_t tag,
-				        void *context)
+					void *context)
 {
 	struct psmx_fid_ep *ep_priv;
 	psm_epaddr_t psm_epaddr;
@@ -631,7 +631,7 @@ ssize_t psmx_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
 ssize_t psmx_tagged_send_no_event_av_map(struct fid_ep *ep, const void *buf,
 					 size_t len, void *desc,
 					 fi_addr_t dest_addr, uint64_t tag,
-				         void *context)
+					 void *context)
 {
 	struct psmx_fid_ep *ep_priv;
 	psm_epaddr_t psm_epaddr;
@@ -859,8 +859,8 @@ static ssize_t psmx_tagged_sendv_no_flag_av_table(struct fid_ep *ep, const struc
 	}
 
 	return psmx_tagged_send_no_flag_av_table(ep, buf, len,
-					         desc ? desc[0] : NULL, dest_addr,
-					         tag, context);
+						 desc ? desc[0] : NULL, dest_addr,
+						 tag, context);
 }
 
 static ssize_t psmx_tagged_sendv_no_event_av_map(struct fid_ep *ep, const struct iovec *iov,
@@ -911,8 +911,8 @@ static ssize_t psmx_tagged_sendv_no_event_av_table(struct fid_ep *ep, const stru
 	}
 
 	return psmx_tagged_send_no_event_av_table(ep, buf, len,
-					         desc ? desc[0] : NULL,
-					         dest_addr, tag, context);
+						 desc ? desc[0] : NULL,
+						 dest_addr, tag, context);
 }
 
 static ssize_t psmx_tagged_inject(struct fid_ep *ep, const void *buf, size_t len,

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -83,8 +83,8 @@ extern struct fi_provider psmx2_prov;
 
 #define PSMX2_CAPS	(FI_TAGGED | FI_MSG | FI_ATOMICS | \
 			 FI_RMA | FI_MULTI_RECV | \
-                         FI_READ | FI_WRITE | FI_SEND | FI_RECV | \
-                         FI_REMOTE_READ | FI_REMOTE_WRITE | \
+			 FI_READ | FI_WRITE | FI_SEND | FI_RECV | \
+			 FI_REMOTE_READ | FI_REMOTE_WRITE | \
 			 FI_TRIGGER | FI_RMA_EVENT | FI_REMOTE_CQ_DATA | \
 			 FI_SOURCE | FI_SOURCE_ERR | FI_DIRECTED_RECV | \
 			 FI_NAMED_RX_CTX)
@@ -150,8 +150,8 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_ADDR_TO_VL(addr)		((uint8_t)((addr & PSMX2_VL_MASK) >> 56))
 #define PSMX2_ADDR_TO_EP(addr)		((psm2_epaddr_t) \
 						((addr & PSMX2_SIGN_MASK) ? \
-                                                 (addr | PSMX2_SIGN_EXT) : \
-                                                 (addr & PSMX2_EP_MASK)))
+						 (addr | PSMX2_SIGN_EXT) : \
+						 (addr & PSMX2_EP_MASK)))
 
 #define PSMX2_MAX_RX_CTX_BITS		(12)
 #define PSMX2_SEP_ADDR_FLAG		(0x000E000000000000UL)
@@ -1062,15 +1062,15 @@ static inline int psmx2_av_check_table_idx(struct psmx2_fid_av *av, size_t idx)
 	 * Avoid connecting to the same destination from multiple threads.
 	 */
 	if (!av->epaddrs[idx]) {
-                err = psmx2_epid_to_epaddr(av->domain->base_trx_ctxt,
-                                           av->epids[idx], &av->epaddrs[idx]);
-                if (err) {
-                        FI_WARN(&psmx2_prov, FI_LOG_AV,
-                                "fatal error: unable to translate epid %lx to epaddr.\n",
-                                av->epids[idx]);
-                        return err;
-                }
-        }
+		err = psmx2_epid_to_epaddr(av->domain->base_trx_ctxt,
+					   av->epids[idx], &av->epaddrs[idx]);
+		if (err) {
+			FI_WARN(&psmx2_prov, FI_LOG_AV,
+				"fatal error: unable to translate epid %lx to epaddr.\n",
+				av->epids[idx]);
+			return err;
+		}
+	}
 
 	return 0;
 }

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -2032,7 +2032,7 @@ static ssize_t psmx2_atomic_compwrite(struct fid_ep *ep,
 					      compare, compare_desc,
 					      result, result_desc,
 					      dest_addr, addr, key,
-			        	      datatype, op, context, ep_priv->tx_flags);
+					      datatype, op, context, ep_priv->tx_flags);
 }
 
 static ssize_t psmx2_atomic_compwritemsg(struct fid_ep *ep,

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -226,8 +226,8 @@ static void psmx2_set_epaddr_context(struct psmx2_trx_ctxt *trx_ctxt,
 int psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,
 			 psm2_epid_t epid, psm2_epaddr_t *epaddr)
 {
-        int err;
-        psm2_error_t errors;
+	int err;
+	psm2_error_t errors;
 	psm2_epconn_t epconn;
 	struct psmx2_epaddr_context *context;
 
@@ -240,18 +240,18 @@ int psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,
 		}
 	}
 
-        err = psm2_ep_connect(trx_ctxt->psm2_ep, 1, &epid, NULL, &errors,
+	err = psm2_ep_connect(trx_ctxt->psm2_ep, 1, &epid, NULL, &errors,
 			      epaddr, psmx2_conn_timeout(1));
-        if (err != PSM2_OK) {
+	if (err != PSM2_OK) {
 		FI_WARN(&psmx2_prov, FI_LOG_AV,
 			"psm2_ep_connect retured error %s, remote epid=%lx.\n",
 			psm2_error_get_string(err), epid);
-                return psmx2_errno(err);
+		return psmx2_errno(err);
 	}
 
 	psmx2_set_epaddr_context(trx_ctxt,epid,*epaddr);
 
-        return 0;
+	return 0;
 }
 
 psm2_epaddr_t psmx2_av_translate_sep(struct psmx2_fid_av *av,
@@ -357,10 +357,10 @@ static void psmx2_av_post_completion(struct psmx2_fid_av *av, void *context,
 }
 
 static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
-			        psm2_epid_t *epids, int *mask,
+				psm2_epid_t *epids, int *mask,
 				uint8_t *types, psm2_error_t *errors,
-			        psm2_epaddr_t *epaddrs,
-			        void *context)
+				psm2_epaddr_t *epaddrs,
+				void *context)
 {
 	int i;
 	psm2_epconn_t epconn;

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -822,7 +822,7 @@ static ssize_t psmx2_cq_read(struct fid_cq *cq, void *buf, size_t count)
 }
 
 static ssize_t psmx2_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
-			        uint64_t flags)
+				uint64_t flags)
 {
 	struct psmx2_fid_cq *cq_priv;
 	uint32_t api_version;

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -116,7 +116,7 @@ void psmx2_trx_ctxt_disconnect_peers(struct psmx2_trx_ctxt *trx_ctxt)
 {
 	struct dlist_entry *item, *tmp;
 	struct psmx2_epaddr_context *peer;
-        psm2_amarg_t arg;
+	psm2_amarg_t arg;
 
 	arg.u32w0 = PSMX2_AM_REQ_TRX_CTXT_DISCONNECT;
 

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -116,7 +116,7 @@ int psmx2_fabric(struct fi_fabric_attr *attr,
 				  &fabric_priv->name_server);
 		if (ret) {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-			        "ofi_ns_init returns %d\n", ret);
+				"ofi_ns_init returns %d\n", ret);
 			free(fabric_priv);
 			return ret;
 		}

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -725,7 +725,7 @@ static ssize_t psmx2_senddata(struct fid_ep *ep, const void *buf, size_t len,
 }
 
 static ssize_t psmx2_injectdata(struct fid_ep *ep, const void *buf, size_t len,
-			        uint64_t data, fi_addr_t dest_addr)
+				uint64_t data, fi_addr_t dest_addr)
 {
 	struct psmx2_fid_ep *ep_priv;
 

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -33,7 +33,7 @@
 #include "psmx2.h"
 
 static inline void psmx2_am_enqueue_rma(struct psmx2_trx_ctxt *trx_ctxt,
-				        struct psmx2_am_request *req)
+					struct psmx2_am_request *req)
 {
 	psmx2_lock(&trx_ctxt->rma_queue.lock, 2);
 	slist_insert_tail(&req->list_entry, &trx_ctxt->rma_queue.list);
@@ -943,8 +943,8 @@ static ssize_t psmx2_readmsg(struct fid_ep *ep,
 }
 
 static ssize_t psmx2_readv(struct fid_ep *ep, const struct iovec *iov,
-		           void **desc, size_t count, fi_addr_t src_addr,
-		           uint64_t addr, uint64_t key, void *context)
+			   void **desc, size_t count, fi_addr_t src_addr,
+			   uint64_t addr, uint64_t key, void *context)
 {
 	struct psmx2_fid_ep *ep_priv;
 
@@ -1153,8 +1153,8 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 }
 
 ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
-		             void **desc, size_t count, fi_addr_t dest_addr,
-		             uint64_t addr, uint64_t key, void *context,
+			     void **desc, size_t count, fi_addr_t dest_addr,
+			     uint64_t addr, uint64_t key, void *context,
 			     uint64_t flags, uint64_t data)
 {
 	struct psmx2_fid_ep *ep_priv;
@@ -1441,8 +1441,8 @@ static ssize_t psmx2_writemsg(struct fid_ep *ep,
 }
 
 static ssize_t psmx2_writev(struct fid_ep *ep, const struct iovec *iov,
-		            void **desc, size_t count, fi_addr_t dest_addr,
-		            uint64_t addr, uint64_t key, void *context)
+			    void **desc, size_t count, fi_addr_t dest_addr,
+			    uint64_t addr, uint64_t key, void *context)
 {
 	struct psmx2_fid_ep *ep_priv;
 
@@ -1486,8 +1486,8 @@ static ssize_t psmx2_writedata(struct fid_ep *ep, const void *buf, size_t len,
 }
 
 static ssize_t psmx2_injectdata(struct fid_ep *ep, const void *buf, size_t len,
-			        uint64_t data, fi_addr_t dest_addr, uint64_t addr,
-			        uint64_t key)
+				uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+				uint64_t key)
 {
 	struct psmx2_fid_ep *ep_priv;
 


### PR DESCRIPTION
Replace any occurrence of 8 consequent spaces with a tab unless it
is part of comments.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>