### PR TITLE
prov/shm: Fix resource leak and free error in smr_av_open()

### DIFF
--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -184,28 +184,30 @@ int smr_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	util_attr.addrlen = sizeof(int);
 	util_attr.overhead = 0;
 	util_attr.flags = 0;
-	if (attr->count > SMR_MAX_PEERS)
-		return -FI_ENOSYS;
+	if (attr->count > SMR_MAX_PEERS) {
+		ret = -FI_ENOSYS;
+		goto err_free_smr_av;
+	}
 
 	ret = ofi_av_init(util_domain, attr, &util_attr, &smr_av->util_av, context);
-	if (ret) {
-		free(&smr_av->util_av);
-		free(smr_av);
-		return ret;
-	}
+	if (ret)
+		goto err_free_smr_av;
 
 	*av = &smr_av->util_av.av_fid;
 	(*av)->fid.ops = &smr_av_fi_ops;
 	(*av)->ops = &smr_av_ops;
 
 	ret = smr_map_create(&smr_prov, SMR_MAX_PEERS, &smr_av->smr_map);
-	if (ret) {
-		ofi_av_close(&smr_av->util_av);
-		free(&smr_av->util_av);
-		free(smr_av);
-		return ret;
-	}
+	if (ret)
+		goto err_close_util_av;
 
 	return 0;
+
+err_close_util_av:
+	ofi_av_close(&smr_av->util_av);
+err_free_smr_av:
+	free(smr_av);
+
+	return ret;
 }
 


### PR DESCRIPTION
This patch fixes a resource leak on an error condition in
smr_av_open(). It also removes a call to free() for a pointer
that was not allocated via {m,c}alloc().

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>