### PR TITLE
common: Move useful GNI's list functions to the common code

### DIFF
--- a/include/fi_list.h
+++ b/include/fi_list.h
@@ -150,6 +150,50 @@ dlist_remove_first_match(struct dlist_entry *head, dlist_func_t *match,
 	return item;
 }
 
+/* splices list at the front of the list 'head'
+ *
+ * BEFORE:
+ * head:      HEAD->a->b->c->HEAD
+ * to_splice: HEAD->d->e->HEAD
+ *
+ * AFTER:
+ * head:      HEAD->d->e->a->b->c->HEAD
+ * to_splice: HEAD->HEAD (empty list)
+ */
+static inline void dlist_splice_head(struct dlist_entry *head,
+				     struct dlist_entry *to_splice)
+{
+	if (dlist_empty(to_splice))
+		return;
+
+	/* hook first element of 'head' to last element of 'to_splice' */
+	head->next->prev = to_splice->prev;
+	to_splice->prev->next = head->next;
+
+	/* put first element of 'to_splice' as first element of 'head' */
+	head->next = to_splice->next;
+	head->next->prev = head;
+
+	/* set list to empty */
+	dlist_init(to_splice);
+}
+
+/* splices list at the back of the list 'head'
+ *
+ * BEFORE:
+ * head:      HEAD->a->b->c->HEAD
+ * to_splice: HEAD->d->e->HEAD
+ *
+ * AFTER:
+ * head:      HEAD->a->b->c->d->e->HEAD
+ * to_splice: HEAD->HEAD (empty list)
+ */
+static inline void dlist_splice_tail(struct dlist_entry *head,
+				     struct dlist_entry *to_splice)
+{
+	dlist_splice_head(head->prev, to_splice);
+}
+
 /*
  * Single-linked list
  */

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -64,6 +64,11 @@ extern "C" {
 	((type *) ((char *)ptr - offsetof(type, field)))
 #endif
 
+#ifndef count_of
+#define count_of(x) 	\
+	((sizeof(x)/sizeof(0[x])) / ((size_t)(!(sizeof(x) % sizeof(0[x])))))
+#endif
+
 /* API version (which is not necessarily the same as the
  * tarball/libfabric package version number).
  */

--- a/prov/gni/include/gnix_util.h
+++ b/prov/gni/include/gnix_util.h
@@ -172,52 +172,6 @@ static inline void dlist_node_init(struct dlist_entry *e)
 	     e && (&e->member != h);					\
 	     e = n, n = dlist_entry((&e->member)->next, typeof(*e), member))
 
-/* splices list at the front of the list 'head'
- *
- * BEFORE:
- * head:      HEAD->a->b->c->HEAD
- * to_splice: HEAD->d->e->HEAD
- *
- * AFTER:
- * head:      HEAD->d->e->a->b->c->HEAD
- * to_splice: HEAD->HEAD (empty list)
- */
-static inline void dlist_splice_head(
-		struct dlist_entry *head,
-		struct dlist_entry *to_splice)
-{
-	if (dlist_empty(to_splice))
-		return;
-
-	/* hook first element of 'head' to last element of 'to_splice' */
-	head->next->prev = to_splice->prev;
-	to_splice->prev->next = head->next;
-
-	/* put first element of 'to_splice' as first element of 'head' */
-	head->next = to_splice->next;
-	head->next->prev = head;
-
-	/* set list to empty */
-	dlist_init(to_splice);
-}
-
-/* splices list at the back of the list 'head'
- *
- * BEFORE:
- * head:      HEAD->a->b->c->HEAD
- * to_splice: HEAD->d->e->HEAD
- *
- * AFTER:
- * head:      HEAD->a->b->c->d->e->HEAD
- * to_splice: HEAD->HEAD (empty list)
- */
-static inline void dlist_splice_tail(
-		struct dlist_entry *head,
-		struct dlist_entry *to_splice)
-{
-	dlist_splice_head(head->prev, to_splice);
-}
-
 #define rwlock_t pthread_rwlock_t
 #define rwlock_init(lock) pthread_rwlock_init(lock, NULL)
 #define rwlock_destroy(lock) pthread_rwlock_destroy(lock)


### PR DESCRIPTION
During outgoing development in the libfabric, the new macro `count_of` was introduced. This macro calculates count of element of any arrays and provides the following compile-time checks:
- The passed parameter `x` is an array (not a just pointer). It is possible due to the dividing by `((size_t)(!(sizeof(x) % sizeof(0[x]))))`.
- The passed parameter `x` isn't an array of C++ objects. It is possible due to the `0[x]` construction.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>