### PR TITLE
prov/psm2: Fix a bug for self-targeted RMA/atomic over SEP

### DIFF
--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -810,6 +810,7 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	int chunk_size, len;
 	size_t idx;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -854,6 +855,7 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -872,7 +874,8 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_WRITE, ep_priv,
-					 ep_priv->domain->eps[vlane],
+					 (sep_target ? ep_priv :
+					   ep_priv->domain->eps[vlane]),
 					 buf, count, desc, NULL, NULL, NULL,
 					 NULL, addr, key, datatype, op,
 					 context, flags);
@@ -947,6 +950,7 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 	size_t len;
 	uint8_t *buf;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -994,6 +998,7 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -1020,7 +1025,8 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 		psmx2_ioc_read(iov, count, datatype, buf, len);
 
 		err = psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_WRITE, ep_priv,
-					ep_priv->domain->eps[vlane],
+					(sep_target ? ep_priv :
+					  ep_priv->domain->eps[vlane]),
 					buf, len / ofi_datatype_size(datatype),
 					NULL, NULL, NULL, NULL, NULL, addr,
 					key, datatype, op, context, flags);
@@ -1183,6 +1189,7 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 	int chunk_size, len;
 	size_t idx;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1229,6 +1236,7 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -1247,7 +1255,9 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_READWRITE,
-					 ep_priv, ep_priv->domain->eps[vlane],
+					 ep_priv,
+					 (sep_target ? ep_priv :
+					   ep_priv->domain->eps[vlane]),
 					 buf, count, desc, NULL, NULL, result,
 					 result_desc, addr, key, datatype, op,
 					 context, flags);
@@ -1330,6 +1340,7 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 	uint8_t *buf, *result;
 	void *desc0, *result_desc0;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1401,6 +1412,7 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -1438,7 +1450,9 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 		}
 
 		err = psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_READWRITE,
-					ep_priv, ep_priv->domain->eps[vlane],
+					ep_priv,
+					(sep_target ? ep_priv :
+					  ep_priv->domain->eps[vlane]),
 					buf, len / ofi_datatype_size(datatype),
 					desc0, NULL, NULL, result, result_desc0,
 					addr, key, datatype, op, context, flags);
@@ -1652,6 +1666,7 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 	int chunk_size, len;
 	size_t idx;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1700,6 +1715,7 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -1718,7 +1734,9 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_COMPWRITE,
-					 ep_priv, ep_priv->domain->eps[vlane],
+					 ep_priv,
+					 (sep_target ? ep_priv :
+					   ep_priv->domain->eps[vlane]),
 					 buf, count, desc, compare,
 					 compare_desc, result, result_desc,
 					 addr, key, datatype, op,
@@ -1805,6 +1823,7 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 	uint8_t *buf, *compare, *result;
 	void *desc0, *compare_desc0, *result_desc0;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1872,6 +1891,7 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -1930,7 +1950,9 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 		}
 
 		err = psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_COMPWRITE,
-					ep_priv, ep_priv->domain->eps[vlane],
+					ep_priv,
+					(sep_target ? ep_priv :
+					  ep_priv->domain->eps[vlane]),
 					buf, len / ofi_datatype_size(datatype), desc0,
 					compare, compare_desc0, result, result_desc0,
 					addr, key, datatype, op, context, flags);

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -601,6 +601,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	uint32_t tag32;
 	size_t idx;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -637,6 +638,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -655,7 +657,8 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_rma_self(PSMX2_AM_REQ_READ, ep_priv,
-				      ep_priv->domain->eps[vlane],
+				      (sep_target ? ep_priv :
+					ep_priv->domain->eps[vlane]),
 				      buf, len, desc, addr, key,
 				      context, flags, 0);
 
@@ -752,6 +755,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	void *long_buf = NULL;
 	int i;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -785,6 +789,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -803,7 +808,8 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_rma_self(PSMX2_AM_REQ_READV, ep_priv,
-				      ep_priv->domain->eps[vlane],
+				      (sep_target ? ep_priv :
+					ep_priv->domain->eps[vlane]),
 				      (void *)iov, count, desc, addr,
 				      key, context, flags, 0);
 
@@ -984,6 +990,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	void *psm2_context;
 	int no_event;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1021,6 +1028,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -1039,7 +1047,8 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_rma_self(PSMX2_AM_REQ_WRITE, ep_priv,
-				      ep_priv->domain->eps[vlane],
+				      (sep_target ? ep_priv :
+					ep_priv->domain->eps[vlane]),
 				      (void *)buf, len, desc, addr,
 				      key, context, flags, data);
 
@@ -1177,6 +1186,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	uint8_t *buf, *p;
 	int i;
 	int err;
+	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1211,6 +1221,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		vlane = 0;
+		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
@@ -1229,7 +1240,8 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_rma_self(PSMX2_AM_REQ_WRITEV, ep_priv,
-				      ep_priv->domain->eps[vlane],
+				      (sep_target ? ep_priv :
+					ep_priv->domain->eps[vlane]),
 				      (void *)iov, count, desc, addr,
 				      key, context, flags, data);
 


### PR DESCRIPTION
The logic of setting the destination endpoint for self-targeted
RMA/atomic operations didn't take into account scalable endpoint
cases and thus could cause segfault when SEP was used.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>