### PR TITLE
Bug fixes for sockets, rxm, and util providers

### DIFF
--- a/include/fi_mem.h
+++ b/include/fi_mem.h
@@ -312,6 +312,9 @@ static inline void *util_buf_alloc_ex(struct util_buf_pool *pool, void **context
 	struct util_buf_footer *buf_ftr;
 
 	buf = util_buf_alloc(pool);
+	if (OFI_UNLIKELY(!buf))
+		return NULL;
+
 	buf_ftr = (struct util_buf_footer *) ((char *) buf + pool->data_sz);
 	assert(context);
 	*context = buf_ftr->region->context;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -300,6 +300,9 @@ int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)
 
 	for (i = 0; i < rxm_ep->msg_info->rx_attr->size; i++) {
 		rx_buf = (struct rxm_rx_buf *)rxm_buf_get(&rxm_ep->rx_pool);
+		if (OFI_UNLIKELY(!rx_buf))
+			return -FI_ENOMEM;
+
 		rx_buf->hdr.state = RXM_RX;
 		rx_buf->hdr.msg_ep = msg_ep;
 		rx_buf->ep = rxm_ep;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1918,7 +1918,7 @@ static int sock_pe_progress_tx_entry(struct sock_pe *pe,
 	int ret = 0;
 	struct sock_conn *conn = pe_entry->conn;
 
-	if (pe_entry->is_complete)
+	if (pe_entry->is_complete || !conn)
 		goto out;
 
 	if (sock_comm_is_disconnected(pe_entry)) {
@@ -1936,7 +1936,7 @@ static int sock_pe_progress_tx_entry(struct sock_pe *pe,
 		goto out;
 	}
 
-	if (!pe_entry->conn || pe_entry->pe.tx.send_done)
+	if (pe_entry->pe.tx.send_done)
 		goto out;
 
 	if (conn->tx_pe_entry != NULL && conn->tx_pe_entry != pe_entry) {


### PR DESCRIPTION
Commit 3a8755ad added a check for a disconnected connection as
part of progressing transmit requests.  However, the check was
added before the check for a valid connection.  The result is
that attempting to access the progress engine (pe) connection
(conn) can result in a segfault.

Problem was reported by Sandia OpenSHMEM developers.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>