### PR TITLE
prov/gni: Ignore requested key with basic reg

### DIFF
--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -263,9 +263,6 @@ int _gnix_mr_reg(struct fid *fid, const void *buf, size_t len,
 		}
 	}
 
-	if (!auth_key->using_vmdh && requested_key)
-		return -FI_EINVAL;
-
 	/* if this is a provider registration using VMDH and 0 was provided
 	 * as the key, pick any available */
 	if (auth_key->using_vmdh && reserved && !requested_key) {

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -615,7 +615,9 @@ Test(mr_internal_bare, invalid_requested_key)
 	ret = fi_mr_reg(dom, (void *) buf, buf_len, default_access,
 			default_offset, 1000,
 			default_flags, &mr, NULL);
-	cr_assert(ret == -FI_EINVAL, "ret=%d\n", ret);
+	cr_assert(ret == FI_SUCCESS, "ret=%d\n", ret);
+
+	cr_assert(fi_mr_key(mr) != 1000);
 }
 
 Test(mr_no_cache_scalable, invalid_user_requested_key)


### PR DESCRIPTION
This commit changes the behavior of the provider
to ignore the requested key when using basic registration.

Signed-off-by: James Swaro <jswaro@cray.com>