### PR TITLE
prov/rxm: Fix a MR access flag for a region that is used in the fi_read

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -299,9 +299,9 @@ ssize_t rxm_cq_handle_data(struct rxm_rx_buf *rx_buf)
 		}
 
 		if (!OFI_CHECK_MR_LOCAL(rx_buf->ep->rxm_info)) {
-		    ret = rxm_ep_msg_mr_regv(rx_buf->ep, rx_buf->recv_entry->iov,
-					     rx_buf->recv_entry->count, FI_WRITE,
-					     rx_buf->mr);
+			ret = rxm_ep_msg_mr_regv(rx_buf->ep, rx_buf->recv_entry->iov,
+						 rx_buf->recv_entry->count, FI_READ,
+						 rx_buf->mr);
 			if (ret)
 				return ret;
 

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -64,7 +64,8 @@ static ssize_t rxm_ep_rma_common(struct fid_ep *msg_ep, struct rxm_ep *rxm_ep,
 			  util_domain);
 	if (rxm_domain->mr_local) {
 		ret = rxm_ep_msg_mr_regv(rxm_ep, msg->msg_iov,
-					 msg->iov_count, FI_WRITE,
+					 msg->iov_count,
+					 comp_flags & (FI_WRITE | FI_READ),
 					 tx_entry->mr);
 		if (ret)
 			goto err;


### PR DESCRIPTION
The intent of this patch is to fix RxM's LMT.
The problem is only reproducible over iWarp devices.

The access flags for the region that is used in the fi_read should be `FI_READ` rather than `FI_WRITE`, because if `FI_READ` is specified for the region it means that the buffer can be used as a target buffer in the fi_read operations.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>