### PR TITLE
prov/psm2: Improve resource counting for Tx/Rx contexts

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -856,6 +856,7 @@ struct psmx2_env {
 	char *prog_affinity;
 	int sep;
 	int max_trx_ctxt;
+	int sep_trx_ctxt;
 	int num_devunits;
 	int inject_size;
 	int lock_level;

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -920,18 +920,18 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 		goto errout;
 
 	if (info && info->ep_attr) {
-		if (info->ep_attr->tx_ctx_cnt > psmx2_env.max_trx_ctxt) {
+		if (info->ep_attr->tx_ctx_cnt > psmx2_env.sep_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"tx_ctx_cnt %"PRIu64" exceed limit %d.\n",
 				info->ep_attr->tx_ctx_cnt,
-				psmx2_env.max_trx_ctxt);
+				psmx2_env.sep_trx_ctxt);
 			goto errout;
 		}
-		if (info->ep_attr->rx_ctx_cnt > psmx2_env.max_trx_ctxt) {
+		if (info->ep_attr->rx_ctx_cnt > psmx2_env.sep_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"rx_ctx_cnt %"PRIu64" exceed limit %d.\n",
 				info->ep_attr->rx_ctx_cnt,
-				psmx2_env.max_trx_ctxt);
+				psmx2_env.sep_trx_ctxt);
 			goto errout;
 		}
 		ctxt_cnt = info->ep_attr->tx_ctx_cnt;
@@ -970,8 +970,10 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 
 	for (i = 0; i < ctxt_cnt; i++) {
 		trx_ctxt = psmx2_trx_ctxt_alloc(domain_priv, src_addr, i);
-		if (!trx_ctxt)
+		if (!trx_ctxt) {
+			err = -FI_ENOMEM;
 			goto errout_free_ctxt;
+		}
 
 		sep_priv->ctxts[i].trx_ctxt = trx_ctxt;
 


### PR DESCRIPTION
prov/psm2: Improve resource counting for Tx/Rx contexts

Keep track of both the number of contexts supported on the system (the "max"
value), and the number of contexts that are available to the application (the
"free" value). Use them at different places where previously only the "free"
value was used.

A few issues have been addressed with this change:

(1) Premature "out of resource" error due to the "free" value being used
as the context allocation limit. The value is updated with each call to
fi_getinfo and can get smaller after some endpoints have been opened.

(2) Insufficient resource allocation could happen for the same reason when
the "free" value is used to determine the allocation size.

(3) Unable to utilize the last context for non-SEP runs due to different
interpretation of the limit for regular endpoints and scalable endpoints.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>