### PR TITLE
prov/gni: fix a problem with internal rcache

### DIFF
--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -636,9 +636,9 @@ static inline void *__gnix_generic_register(
 
 	GNIX_DEBUG(FI_LOG_MR,
 		"Params: hndl=%p addr=%p length=%d dst_cq_hndl=%p flags=%08x "
-		"vmdh_index=%d mem_hndl=%p\n",
+		"vmdh_index=%d mem_hndl=%p md=%p\n",
 		nic->gni_nic_hndl, address, length, dst_cq_hndl, flags,
-		vmdh_index, &md->mem_hndl);
+		vmdh_index, &md->mem_hndl, md);
 
 	grc = GNI_MemRegister(nic->gni_nic_hndl, (uint64_t) address,
 				  length,	dst_cq_hndl, flags,
@@ -698,13 +698,15 @@ static int __gnix_deregister_region(
 		void *context)
 {
 	struct gnix_fid_mem_desc *mr = (struct gnix_fid_mem_desc *) handle;
-	gni_return_t ret;
+	gni_return_t ret = GNI_RC_SUCCESS;
 	struct gnix_fid_domain *domain;
 	struct gnix_nic *nic;
 
 	domain = mr->domain;
 	nic = mr->nic;
 
+	GNIX_DEBUG(FI_LOG_MR,
+		"Params: deregister md=%p\n", handle);
 	COND_ACQUIRE(nic->requires_lock, &nic->lock);
 	ret = GNI_MemDeregister(nic->gni_nic_hndl, &mr->mem_hndl);
 	COND_RELEASE(nic->requires_lock, &nic->lock);


### PR DESCRIPTION
The GNI provider internal rcache had a bug when
trying to compute overlaps of incoming memory
registration requests with existing registrations
in the rcache.

The nature of the problem was such that it was almost
never encountered with OpenSHMEM or MPI applications,
but for Mercury, which was doing consecutive registrations
of buffers within a larger previously allocated virtual
memory range, the bug was hit.

Also add some better debug output for the MR subsys in
the GNI provider.

Thanks to Jerome Soumagne for reporting.

@soumagne

Signed-off-by: Howard Pritchard <howardp@lanl.gov>