### PR TITLE
prov/rxm: Bug fixes

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -462,7 +462,6 @@ static int rxm_handle_remote_write(struct rxm_ep *rxm_ep,
 static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 				  struct fi_cq_tagged_entry *comp)
 {
-	enum rxm_proto_state state = RXM_GET_PROTO_STATE(comp);
 	struct rxm_rx_buf *rx_buf = comp->op_context;
 	struct rxm_tx_entry *tx_entry = comp->op_context;
 
@@ -471,7 +470,7 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	if (comp->flags & FI_REMOTE_WRITE)
 		return rxm_handle_remote_write(rxm_ep, comp);
 
-	switch (state) {
+	switch (RXM_GET_PROTO_STATE(comp)) {
 	case RXM_TX_NOBUF:
 		assert(comp->flags & (FI_SEND | FI_WRITE | FI_READ));
 		return rxm_finish_send_nobuf(tx_entry);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -111,7 +111,9 @@ int rxm_finish_recv(struct rxm_rx_buf *rx_buf)
 		FI_DBG(&rxm_prov, FI_LOG_CQ, "writing recv completion\n");
 		ret = ofi_cq_write(rx_buf->ep->util_ep.rx_cq,
 				   rx_buf->recv_entry->context,
-				   rx_buf->recv_entry->comp_flags,
+				   rx_buf->recv_entry->comp_flags |
+				   (rx_buf->pkt.hdr.flags & OFI_REMOTE_CQ_DATA) ?
+				   FI_REMOTE_CQ_DATA : 0,
 				   rx_buf->pkt.hdr.size, NULL,
 				   rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
 		if (ret) {

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -161,13 +161,12 @@ static int rxm_match_iov(const struct iovec *iov, void **desc,
 
 	assert(count <= RXM_IOV_LIMIT);
 
-	if (match_len > ofi_total_iov_len(iov, count)) {
-		FI_WARN(&rxm_prov, FI_LOG_CQ, "match_len > iov size!\n");
-		return -FI_EINVAL;
-	}
-
 	for (i = 0; i < count; i++) {
-		assert(offset <= iov[i].iov_len);
+		if (offset >= iov[i].iov_len) {
+			offset -= iov[i].iov_len;
+			continue;
+		}
+
 		match_iov->iov[i].iov_base = (char *)iov[i].iov_base + offset;
 		match_iov->iov[i].iov_len = MIN(iov[i].iov_len - offset, match_len);
 		if (desc)
@@ -178,7 +177,12 @@ static int rxm_match_iov(const struct iovec *iov, void **desc,
 			break;
 		offset = 0;
 	}
-	assert(!match_len);
+
+	if (match_len) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "Given iov size < match_len!\n");
+		return -FI_ETOOSMALL;
+	}
+
 	match_iov->count = i + 1;
 	return FI_SUCCESS;
 }
@@ -194,24 +198,29 @@ static int rxm_match_rma_iov(struct rxm_recv_entry *recv_entry,
 
 	assert(rma_iov->count <= RXM_IOV_LIMIT);
 
-	for (i = 0, j = 0; i < rma_iov->count; i++) {
+	for (i = 0, j = 0; i < rma_iov->count; ) {
 		ret = rxm_match_iov(&recv_entry->iov[j], &recv_entry->desc[j],
-				    recv_entry->count, offset,
+				    recv_entry->count - j, offset,
 				    rma_iov->iov[i].len, &match_iov[i]);
 		if (ret)
 			return ret;
+
 		count = match_iov[i].count;
 		offset = match_iov[i].iov[count - 1].iov_len;
 
-		assert((j + count - 1) < recv_entry->count);
-		if (offset == recv_entry->iov[j + count - 1].iov_len) {
-			/* This iov has been completely used */
-			j += count;
-			offset = 0;
-		} else {
-			j += count - 1;
-		}
+		i++;
+		j += count - 1;
+
+		if (j >= recv_entry->count)
+			break;
 	}
+
+	if (i < rma_iov->count) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "posted recv_entry size < "
+			"rndv rma read size!\n");
+		return -FI_ETOOSMALL;
+	}
+
 	return FI_SUCCESS;
 }
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -152,10 +152,9 @@ static int rxm_buf_pool_create(int local_mr, size_t chunk_count, size_t size,
 		struct rxm_buf_pool *pool, void *pool_ctx)
 {
 	pool->pool = local_mr ?
-		util_buf_pool_create_ex(RXM_BUF_SIZE + size, 16, 0, chunk_count,
-					rxm_mr_buf_reg, rxm_mr_buf_close,
-					pool_ctx) :
-		util_buf_pool_create(RXM_BUF_SIZE, 16, 0, chunk_count);
+		util_buf_pool_create_ex(size, 16, 0, chunk_count, rxm_mr_buf_reg,
+					rxm_mr_buf_close, pool_ctx) :
+		util_buf_pool_create(size, 16, 0, chunk_count);
 	if (!pool->pool) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to create buf pool\n");
 		return -FI_ENOMEM;
@@ -221,10 +220,11 @@ static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep)
 	rxm_domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain, util_domain);
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "MSG provider mr_mode & FI_MR_LOCAL: %d\n",
-			OFI_CHECK_MR_LOCAL(rxm_ep->msg_info));
+	       OFI_CHECK_MR_LOCAL(rxm_ep->msg_info));
 
 	ret = rxm_buf_pool_create(OFI_CHECK_MR_LOCAL(rxm_ep->msg_info),
 				  rxm_ep->msg_info->tx_attr->size,
+				  rxm_ep->rxm_info->tx_attr->inject_size +
 				  sizeof(struct rxm_tx_buf), &rxm_ep->tx_pool,
 				  rxm_domain->msg_domain);
 	if (ret)
@@ -232,6 +232,7 @@ static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep)
 
 	ret = rxm_buf_pool_create(OFI_CHECK_MR_LOCAL(rxm_ep->msg_info),
 				  rxm_ep->msg_info->rx_attr->size,
+				  rxm_ep->rxm_info->tx_attr->inject_size +
 				  sizeof(struct rxm_rx_buf), &rxm_ep->rx_pool,
 				  rxm_domain->msg_domain);
 	if (ret)
@@ -284,8 +285,10 @@ int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 	rx_buf->hdr.state = RXM_RX;
 	rx_buf->ep = rxm_ep;
 
-	if (fi_recv(rx_buf->hdr.msg_ep, &rx_buf->pkt, RXM_BUF_SIZE,
-		    rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf)) {
+	if (fi_recv(rx_buf->hdr.msg_ep, &rx_buf->pkt,
+		    rxm_ep->rxm_info->tx_attr->inject_size +
+		    sizeof(struct rxm_pkt), rx_buf->hdr.desc,
+		    FI_ADDR_UNSPEC, rx_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to repost buf\n");
 		return -FI_EAVAIL;
 	}

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -870,7 +870,7 @@ static ssize_t rxm_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t le
 	};
 
 	return rxm_send(ep_fid, &iov, desc, 1, dest_addr, context, data,
-			rxm_ep_tx_flags(ep_fid));
+			rxm_ep_tx_flags(ep_fid) | FI_REMOTE_CQ_DATA);
 }
 
 static ssize_t rxm_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -882,7 +882,7 @@ static ssize_t rxm_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t 
 	};
 
 	return rxm_send(ep_fid, &iov, NULL, 1, dest_addr, NULL, data,
-			rxm_ep_tx_flags_inject(ep_fid));
+			rxm_ep_tx_flags_inject(ep_fid) | FI_REMOTE_CQ_DATA);
 }
 
 static struct fi_ops_msg rxm_ops_msg = {
@@ -987,7 +987,7 @@ static ssize_t rxm_ep_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t l
 	};
 
 	return rxm_tsend(ep_fid, &iov, desc, 1, dest_addr, context, data,
-			 rxm_ep_tx_flags(ep_fid), tag);
+			 rxm_ep_tx_flags(ep_fid) | FI_REMOTE_CQ_DATA, tag);
 }
 
 static ssize_t rxm_ep_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -999,7 +999,7 @@ static ssize_t rxm_ep_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t
 	};
 
 	return rxm_tsend(ep_fid, &iov, NULL, 1, dest_addr, NULL, data,
-			 rxm_ep_tx_flags_inject(ep_fid), tag);
+			 rxm_ep_tx_flags_inject(ep_fid) | FI_REMOTE_CQ_DATA, tag);
 }
 
 struct fi_ops_tagged rxm_ops_tagged = {

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -129,6 +129,7 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->ep_attr->max_order_waw_size = core_info->ep_attr->max_order_waw_size;
 
 	*info->domain_attr = *rxm_info.domain_attr;
+	info->domain_attr->mr_mode |= core_info->domain_attr->mr_mode;
 	info->domain_attr->cq_data_size = MIN(core_info->domain_attr->cq_data_size,
 					      rxm_info.domain_attr->cq_data_size);
 


### PR DESCRIPTION
Note: I've pulled in some patches from PR #3523 

- prov/rxm: Fix core provider mr_mode not being passed on to app 
- prov/rxm: Fix incorrect handling of CQ data 
- prov/rxm: Fix a crash when doing RMA over sockets core provider. 
- prov/rxm: Fix incorrect buf size for buf pool and posted recvs 
- prov/rxm: Refactor rma iov match code to fix klockworks issue 