### PR TITLE
Fix format string type warnings/errors

### DIFF
--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -827,7 +827,7 @@ static void rxd_handle_data(struct rxd_ep *ep, struct rxd_peer *peer,
 			goto repost;
 		} else {
 			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "invalid pkt: segno: %d "
-			       "expected:%d, rx-key:%" PRId64 ", ctrl_msg_id: %ld, "
+			       "expected:%d, rx-key:%" PRId64 ", ctrl_msg_id: %" PRIu64 ", "
 			       "rx_entry_msg_id: %" PRIx64 "\n",
 			       ctrl->seg_no, rx_entry->exp_seg_no,
 			       ctrl->rx_key,

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -514,7 +514,7 @@ static int rxd_ep_retry_pkt(struct rxd_ep *ep, struct rxd_tx_entry *tx_entry,
 //		return -FI_EIO;
 //	}
 //
-	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "retry packet : %2d, size: %" PRIx64 ", tx_id :%" PRIx64 "\n",
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "retry packet : %2d, size: %zd, tx_id :%" PRIx64 "\n",
 	       ctrl->seg_no, ctrl->type == ofi_ctrl_start_data ?
 	       ctrl->seg_size + sizeof(struct rxd_pkt_data_start) :
 	       ctrl->seg_size + sizeof(struct rxd_pkt_data),
@@ -702,7 +702,7 @@ ssize_t rxd_ep_start_xfer(struct rxd_ep *ep, struct rxd_peer *peer,
 		       pkt->ctrl.seg_no);
 	}
 
-	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "start msg %" PRIx64 ", size: %ld\n",
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "start msg %" PRIx64 ", size: %" PRIu64 "\n",
 	       pkt->ctrl.msg_id, tx_entry->op_hdr.size);
 	rxd_set_timeout(tx_entry);
 	dlist_insert_tail(&pkt_meta->entry, &tx_entry->pkt_list);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -787,7 +787,7 @@ rxm_ep_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		} else {
 			progress = 1;
 			FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "passed data (size = %zu) is too "
-			       "big for MSG provider (max inject size = %" PRIu64 ") \n",
+			       "big for MSG provider (max inject size = %zd)\n",
 			       pkt_size, rxm_ep->msg_info->tx_attr->inject_size);
 		}
 	}

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -132,7 +132,7 @@ static inline void sock_pe_discard_field(struct sock_pe_entry *pe_entry)
 	if (!pe_entry->rem)
 		goto out;
 
-	SOCK_LOG_DBG("Remaining for %p: %ld\n", pe_entry, pe_entry->rem);
+	SOCK_LOG_DBG("Remaining for %p: %" PRId64 "\n", pe_entry, pe_entry->rem);
 	ret = sock_comm_discard(pe_entry, pe_entry->rem);
 	SOCK_LOG_DBG("Discarded %ld\n", ret);
 


### PR DESCRIPTION
Fix the following format string warnings:
```
  CC       prov/sockets/src/src_libfabric_la-sock_progress.lo
../prov/sockets/src/sock_progress.c:135:52: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
        SOCK_LOG_DBG("Remaining for %p: %ld\n", pe_entry, pe_entry->rem);
                                        ~~~               ^~~~~~~~~~~~~
                                        %llu
../prov/sockets/src/sock_progress.c:63:57: note: expanded from macro 'SOCK_LOG_DBG'
#define SOCK_LOG_DBG(...) _SOCK_LOG_DBG(FI_LOG_EP_DATA, __VA_ARGS__)
                                                        ^~~~~~~~~~~
../prov/sockets/include/sock_util.h:55:63: note: expanded from macro '_SOCK_LOG_DBG'
#define _SOCK_LOG_DBG(subsys, ...) FI_DBG(&sock_prov, subsys, __VA_ARGS__)
                                                              ^~~~~~~~~~~
../include/rdma/providers/fi_log.h:93:40: note: expanded from macro 'FI_DBG'
        FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
                                              ^~~~~~~~~~~
../include/rdma/providers/fi_log.h:79:25: note: expanded from macro 'FI_LOG'
                                __func__, __LINE__, __VA_ARGS__);       \
                                                    ^~~~~~~~~~~
1 warning generated.
```
```
  CC       prov/rxm/src/src_libfabric_la-rxm_ep.lo
../prov/rxm/src/rxm_ep.c:791:21: warning: format specifies type 'unsigned long long' but the argument has type 'size_t' (aka 'unsigned long') [-Wformat]
                               pkt_size, rxm_ep->msg_info->tx_attr->inject_size);
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../include/rdma/providers/fi_log.h:93:40: note: expanded from macro 'FI_DBG'
        FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
../include/rdma/providers/fi_log.h:79:25: note: expanded from macro 'FI_LOG'
                                __func__, __LINE__, __VA_ARGS__);       \
                                                    ^~~~~~~~~~~
1 warning generated.
```
```
  CC       prov/rxd/src/src_libfabric_la-rxd_cq.lo
../prov/rxd/src/rxd_cq.c:834:11: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
                               ctrl->msg_id, rx_entry->msg_id);
                               ^~~~~~~~~~~~
../include/rdma/providers/fi_log.h:93:40: note: expanded from macro 'FI_DBG'
        FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
                                              ^~~~~~~~~~~
../include/rdma/providers/fi_log.h:79:25: note: expanded from macro 'FI_LOG'
                                __func__, __LINE__, __VA_ARGS__);       \
                                                    ^~~~~~~~~~~
1 warning generated.
```
```
  CC       prov/rxd/src/src_libfabric_la-rxd_ep.lo
../prov/rxd/src/rxd_ep.c:518:23: warning: format specifies type 'unsigned long long' but the argument has type 'unsigned long' [-Wformat]
               ctrl->seg_no, ctrl->type == ofi_ctrl_start_data ?
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../include/rdma/providers/fi_log.h:93:40: note: expanded from macro 'FI_DBG'
        FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
../include/rdma/providers/fi_log.h:79:25: note: expanded from macro 'FI_LOG'
                                __func__, __LINE__, __VA_ARGS__);       \
                                                    ^~~~~~~~~~~
../prov/rxd/src/rxd_ep.c:706:27: warning: format specifies type 'long' but the argument has type 'uint64_t' (aka 'unsigned long long') [-Wformat]
               pkt->ctrl.msg_id, tx_entry->op_hdr.size);
                                 ^~~~~~~~~~~~~~~~~~~~~
../include/rdma/providers/fi_log.h:93:40: note: expanded from macro 'FI_DBG'
        FI_LOG(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
                                              ^~~~~~~~~~~
../include/rdma/providers/fi_log.h:79:25: note: expanded from macro 'FI_LOG'
                                __func__, __LINE__, __VA_ARGS__);       \
                                                    ^~~~~~~~~~~
2 warnings generated.
```