### PR TITLE
prov/sockets: Move check for valid conn to top of progress function

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1868,7 +1868,7 @@ static int sock_pe_progress_tx_entry(struct sock_pe *pe,
 	int ret = 0;
 	struct sock_conn *conn = pe_entry->conn;
 
-	if (pe_entry->is_complete)
+	if (pe_entry->is_complete || !conn)
 		goto out;
 
 	if (sock_comm_is_disconnected(pe_entry)) {
@@ -1886,7 +1886,7 @@ static int sock_pe_progress_tx_entry(struct sock_pe *pe,
 		goto out;
 	}
 
-	if (!pe_entry->conn || pe_entry->pe.tx.send_done)
+	if (pe_entry->pe.tx.send_done)
 		goto out;
 
 	if (conn->tx_pe_entry != NULL && conn->tx_pe_entry != pe_entry) {


### PR DESCRIPTION
Commit 3a8755ad added a check for a disconnected connection as
part of progressing transmit requests.  However, the check was
added before the check for a valid connection.  The result is
that attempting to access the progress engine (pe) connection
(conn) can result in a segfault.

Problem was reported by Sandia OpenSHMEM developers.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>