### PR TITLE
prov/psm2: Allow completion suppression when fi_context is non-NULL.

### DIFF
--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -312,7 +312,7 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 		return 0;
 	}
 
-	if (no_completion && !context) {
+	if (no_completion) {
 		fi_context = &ep_priv->nocomp_send_context;
 	} else {
 		if (!context)

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -716,7 +716,7 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 		return 0;
 	}
 
-	if (no_completion && !context) {
+	if (no_completion) {
 		fi_context = &ep_priv->nocomp_send_context;
 	} else {
 		if (!context)


### PR DESCRIPTION
Previously, when the application set FI_SELECTIVE_COMPLETION and did
not enable FI_COMPLETION but the fi_context is not a NULL pointer,
the provider would enable a completion.  With this change, the
completion is suppressed.

It's possible that an application might want to use the fi_context as
a key to cancel an outstanding operation, but the man pages say that
providers ought to ignore fi_context if completions are supressed,
and so fi_cancel shouldn't be supported in that case.

Signed-off-by: Jim Snow <jim.m.snow@intel.com>