### PR TITLE
prov/netdir: Fix fi_ep_getname

### DIFF
--- a/prov/netdir/src/netdir_ep.c
+++ b/prov/netdir/src/netdir_ep.c
@@ -90,6 +90,7 @@ static struct fi_ops_cm ofi_nd_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = fi_no_reject,
 	.shutdown = ofi_nd_ep_shutdown,
+	.join = fi_no_join,
 };
 
 extern struct fi_ops_msg ofi_nd_ep_msg;

--- a/prov/netdir/src/netdir_init.c
+++ b/prov/netdir/src/netdir_init.c
@@ -123,7 +123,6 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 
 	info->caps = OFI_ND_CAPS;
 	info->addr_format = FI_SOCKADDR;
-	info->mode = FI_LOCAL_MR;
 
 	if (!ofi_nd_util_prov.info) {
 		ofi_nd_util_prov.info = info;

--- a/prov/netdir/src/netdir_pep.c
+++ b/prov/netdir/src/netdir_pep.c
@@ -85,6 +85,7 @@ static struct fi_ops_cm ofi_nd_cm_ops = {
 	.accept = fi_no_accept,
 	.reject = ofi_nd_pep_reject,
 	.shutdown = fi_no_shutdown,
+	.join = fi_no_join,
 };
 
 static struct fi_ops_ep ofi_nd_pep_ops = {


### PR DESCRIPTION
The fi_pingpong test fails for the NetDir provider.
This fixes `fi_getname` and removes `FI_LOCAL_MR` mode.

Btw, `GetLocalAddress` should return `ND_BUFFER_OVERFLOW` if size of provided buffer is too small. But how the ND document says that it is vendor-specific to return any value:
`When you implement this method, you should return the following return values. If you return others, try to use well-known values to aid in debugging issues.`

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>