### PR TITLE
src/fabric: Fix memory leak for prov_name string in struct ofi_prov

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -520,6 +520,7 @@ FI_DESTRUCTOR(fi_fini(void))
 		prov = prov_head;
 		prov_head = prov->next;
 		cleanup_provider(prov->provider, prov->dlhandle);
+		free(prov->prov_name);
 		free(prov);
 	}
 


### PR DESCRIPTION
-In ofi_create_prov_entry, prov_name is allocated and set in the ofi_prov
struct for the corresponding provider.

-At fi_fini the ofi_prov struct is freed, but prov_name is not freed at
close resulting in a memory leak for the prov_name strings.

-A free is now called to cleanup the memory allocated from strdup for
prov_name.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>