### PR TITLE
util: Add MR monitor

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
+
 #
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017 Intel Corporation, Inc. All right reserved.
 #
 # Makefile.am for libfabric
 
@@ -36,30 +38,31 @@ rdmaincludedir = $(includedir)/rdma
 rdmainclude_HEADERS =
 
 # internal utility functions shared by in-tree providers:
-common_srcs = \
-	src/common.c \
-	src/enosys.c \
-	src/rbtree.c \
-	src/fasthash.c \
-	src/indexer.c \
-	src/iov.c \
-	prov/util/src/util_atomic.c \
-	prov/util/src/util_attr.c   \
-	prov/util/src/util_av.c     \
-	prov/util/src/util_cq.c     \
-	prov/util/src/util_cntr.c   \
-	prov/util/src/util_domain.c \
-	prov/util/src/util_ep.c     \
-	prov/util/src/util_pep.c     \
-	prov/util/src/util_eq.c     \
-	prov/util/src/util_fabric.c \
-	prov/util/src/util_main.c   \
-	prov/util/src/util_poll.c   \
-	prov/util/src/util_wait.c   \
-	prov/util/src/util_buf.c    \
-	prov/util/src/util_mr.c     \
-	prov/util/src/util_ns.c     \
-	prov/util/src/util_shm.c
+common_srcs =				\
+	src/common.c			\
+	src/enosys.c			\
+	src/rbtree.c			\
+	src/fasthash.c			\
+	src/indexer.c			\
+	src/iov.c			\
+	prov/util/src/util_atomic.c	\
+	prov/util/src/util_attr.c	\
+	prov/util/src/util_av.c		\
+	prov/util/src/util_cq.c		\
+	prov/util/src/util_cntr.c	\
+	prov/util/src/util_domain.c	\
+	prov/util/src/util_ep.c		\
+	prov/util/src/util_pep.c	\
+	prov/util/src/util_eq.c		\
+	prov/util/src/util_fabric.c	\
+	prov/util/src/util_main.c	\
+	prov/util/src/util_poll.c	\
+	prov/util/src/util_wait.c	\
+	prov/util/src/util_buf.c	\
+	prov/util/src/util_mr.c		\
+	prov/util/src/util_ns.c		\
+	prov/util/src/util_shm.c	\
+	prov/util/src/util_mem_monitor.c
 
 if MACOS
 common_srcs += src/unix/osd.c
@@ -102,34 +105,35 @@ util_fi_pingpong_SOURCES = \
 util_fi_pingpong_LDADD = $(linkback)
 
 nodist_src_libfabric_la_SOURCES =
-src_libfabric_la_SOURCES = \
-	include/fi.h \
-	include/fi_abi.h \
-	include/fi_atom.h \
-	include/fi_enosys.h \
-	include/fi_file.h \
-	include/fi_indexer.h \
-	include/fi_iov.h \
-	include/fi_list.h \
-	include/fi_lock.h \
-	include/fi_mem.h \
-	include/fi_osd.h \
-	include/fi_proto.h \
-	include/fi_rbuf.h \
-	include/fi_shm.h \
-	include/fi_signal.h \
-	include/fi_util.h \
-	include/ofi_atomic.h \
-	include/fasthash.h \
-	include/rbtree.h \
-	include/prov.h \
-	include/rdma/providers/fi_log.h \
-	include/rdma/providers/fi_prov.h \
-	src/fabric.c \
-	src/fi_tostr.c \
-	src/log.c \
-	src/var.c \
-	src/abi_1_0.c \
+src_libfabric_la_SOURCES =			\
+	include/fi.h				\
+	include/fi_abi.h			\
+	include/fi_atom.h			\
+	include/fi_enosys.h			\
+	include/fi_file.h			\
+	include/fi_indexer.h			\
+	include/fi_iov.h			\
+	include/fi_list.h			\
+	include/fi_lock.h			\
+	include/fi_mem.h			\
+	include/fi_osd.h			\
+	include/fi_proto.h			\
+	include/fi_rbuf.h			\
+	include/fi_shm.h			\
+	include/fi_signal.h			\
+	include/fi_util.h			\
+	include/ofi_atomic.h			\
+	include/ofi_mr.h			\
+	include/fasthash.h			\
+	include/rbtree.h			\
+	include/prov.h				\
+	include/rdma/providers/fi_log.h		\
+	include/rdma/providers/fi_prov.h	\
+	src/fabric.c				\
+	src/fi_tostr.c				\
+	src/log.c				\
+	src/var.c				\
+	src/abi_1_0.c				\
 	$(common_srcs)
 
 src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017 Intel Corporation, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <inttypes.h>
+
+#include <fi.h>
+#include <fi_atom.h>
+#include <fi_util.h>
+#include <fi_lock.h>
+#include <fi_list.h>
+
+#ifndef _OFI_MR_H_
+#define _OFI_MR_H_
+
+
+/*
+ * Memory notifier - Report memory mapping changes to address ranges
+ */
+
+struct ofi_subscription;
+struct ofi_notification_queue;
+
+struct ofi_mem_monitor {
+	ofi_atomic32_t			refcnt;
+
+	int (*subscribe)(struct ofi_mem_monitor *notifier, void *addr,
+			 size_t len, struct ofi_subscription *subscription);
+	void (*unsubscribe)(struct ofi_mem_monitor *notifier, void *addr,
+			    size_t len, struct ofi_subscription *subscription);
+	struct ofi_subscription *(*get_event)(struct ofi_mem_monitor *notifier);
+};
+
+struct ofi_notification_queue {
+	struct ofi_mem_monitor		*monitor;
+	fastlock_t			lock;
+	struct dlist_entry		list;
+	int				refcnt;
+};
+
+struct ofi_subscription {
+	struct ofi_notification_queue	*nq;
+	struct dlist_entry		entry;
+};
+
+void ofi_monitor_init(struct ofi_mem_monitor *monitor);
+void ofi_monitor_cleanup(struct ofi_mem_monitor *monitor);
+void ofi_monitor_add_queue(struct ofi_mem_monitor *monitor,
+			   struct ofi_notification_queue *nq);
+void ofi_monitor_del_queue(struct ofi_notification_queue *nq);
+
+int ofi_monitor_subscribe(struct ofi_notification_queue *nq,
+			  void *addr, size_t len,
+			  struct ofi_subscription *subscription);
+void ofi_monitor_unsubscribe(void *addr, size_t len,
+			      struct ofi_subscription *subscription);
+struct ofi_subscription *ofi_monitor_get_event(struct ofi_notification_queue *nq);
+
+#endif /* _OFI_MR_H_ */

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
+ * Copyright (c) 2017 Intel Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <ofi_mr.h>
+
+
+void ofi_monitor_init(struct ofi_mem_monitor *monitor)
+{
+	ofi_atomic_initialize32(&monitor->refcnt, 0);
+}
+
+void ofi_monitor_cleanup(struct ofi_mem_monitor *monitor)
+{
+	assert(ofi_atomic_get32(&monitor->refcnt) == 0);
+}
+
+void ofi_monitor_add_queue(struct ofi_mem_monitor *monitor,
+			   struct ofi_notification_queue *nq)
+{
+	fastlock_init(&nq->lock);
+	dlist_init(&nq->list);
+	nq->refcnt = 0;
+
+	nq->monitor = monitor;
+	ofi_atomic_inc32(&monitor->refcnt);
+}
+
+void ofi_monitor_del_queue(struct ofi_notification_queue *nq)
+{
+	assert(dlist_empty(&nq->list) && (nq->refcnt == 0));
+	ofi_atomic_dec32(&nq->monitor->refcnt);
+	fastlock_destroy(&nq->lock);
+}
+
+int ofi_monitor_subscribe(struct ofi_notification_queue *nq,
+			  void *addr, size_t len,
+			  struct ofi_subscription *subscription)
+{
+	int ret;
+
+	FI_DBG(&core_prov, FI_LOG_MR,
+	       "subscribing addr=%p len=%zu subscription=%p nq=%p\n",
+	       addr, len, subscript, nq);
+
+	/* Ensure the subscription is initialized before we can get events */
+	dlist_init(&subscription->entry);
+	subscription->nq = nq;
+	fastlock_acquire(&nq->lock);
+	nq->refcnt++;
+	fastlock_release(&nq->lock);
+
+	ret = nq->monitor->subscribe(nq->monitor, addr, len, subscription);
+	if (OFI_UNLIKELY(ret)) {
+		FI_WARN(&core_prov, FI_LOG_MR,
+			"Failed (ret = %d) to monitor addr=%p len=%zu",
+			ret, addr, len);
+		fastlock_acquire(&nq->lock);
+		nq->refcnt--;
+		fastlock_release(&nq->lock);
+	}
+	return ret;
+}
+
+void ofi_monitor_unsubscribe(void *addr, size_t len,
+			     struct ofi_subscription *subscription)
+{
+	subscription->nq->monitor->unsubscribe(subscription->nq->monitor,
+						addr, len, subscription);
+	fastlock_acquire(&subscription->nq->lock);
+	dlist_remove_init(&subscription->entry);
+	subscription->nq->refcnt--;
+	fastlock_release(&subscription->nq->lock);
+}
+
+static void util_monitor_read_events(struct ofi_mem_monitor *monitor)
+{
+	struct ofi_subscription *subscription;
+
+	do {
+		subscription = monitor->get_event(monitor);
+		if (!subscription) {
+			FI_DBG(&core_prov, FI_LOG_MR,
+			       "no more events to be read\n");
+			break;
+		}
+
+		FI_DBG(&core_prov, FI_LOG_MR,
+		       "found event, context=%p nq=%p\n",
+		       subscription, subscription->nq);
+
+		fastlock_acquire(&subscription->nq->lock);
+		if (dlist_empty(&subscription->entry))
+			dlist_insert_tail(&subscription->entry,
+					  &subscription->nq->list);
+		fastlock_release(&subscription->nq->lock);
+	} while (1);
+}
+
+struct ofi_subscription *ofi_monitor_get_event(struct ofi_notification_queue *nq)
+{
+	struct ofi_subscription *subscription;
+
+	util_monitor_read_events(nq->monitor);
+
+	fastlock_acquire(&nq->lock);
+	if (!dlist_empty(&nq->list)) {
+		dlist_pop_front(&nq->list, struct ofi_subscription,
+				subscription, entry);
+		/* needed to protect against double insertions */
+		dlist_init(&subscription->entry);
+	} else {
+		subscription = NULL;
+	}
+	fastlock_release(&nq->lock);
+
+	return subscription;
+}


### PR DESCRIPTION
The MR monitor is a base implementation for memory management
notifications.  It will be used by a memory registration cache
in order to receive notifications of memory regions that are
modified.  For example a monitor region may be freed by the
application or the underlying pages modified.  The MR monitor
will report such changes to the user.

As a base implementation, the MR monitor doesn't do anything
other than define the function prototypes for what will become
the 'real' monitors.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>
Signed-off-by: Sean Hefty <sean.hefty@intel.com>