### PR TITLE
prov/sockets: plug an edge case for fi_av_remove

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2016, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2017  Los Alamos National Security, LLC.
+ *                     All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -398,8 +400,15 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 		for (i = 0; i < count; i++) {
         		idx = fi_addr[i] & sock_ep->attr->av->mask;
 			conn = idm_lookup(&sock_ep->attr->av_idm, idx);
-			if (conn && conn->sock_fd != -1) {
-				sock_ep_remove_conn(sock_ep->attr, conn);
+			if (conn) {
+				/*
+				 * check for conn either in connection progress or
+				 * already closed.
+				 */
+				if((conn != SOCK_CM_CONN_IN_PROGRESS)  &&
+					(conn->sock_fd != -1)) {
+					sock_ep_remove_conn(sock_ep->attr, conn);
+				}
 				idm_clear(&sock_ep->attr->av_idm, idx);
 			}
 		}


### PR DESCRIPTION
Turns out that there's an edge case in the sockets provider
fi_av_remove method where a socket conn in the table may
be in a connecting state.  This condition needs to be
checked for in order to avoid segfaults.

This behavior was observed highly irregularly (usually took
many 100s of runs) of Open MPI's IBM test suite.  Without
this patch, every few hundred runs on 4 processes one would
hit segfauls.

merge of PR #3567 back to v1.4.x

With this patch, the problem is no longer observed.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 8ea9c883e6e2b23358a81bbbbd387cfeadb53df8)