### PR TITLE
prov/util: Remove redundant NULL-check

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1132,8 +1132,7 @@ static uint64_t ofi_get_info_caps(const struct fi_info *prov_info,
 
 	prov_mode = prov_info->domain_attr->mr_mode;
 
-	if (!user_info || !ofi_rma_target_allowed(caps) ||
-	    !(prov_mode & OFI_MR_MODE_RMA_TARGET))
+	if (!ofi_rma_target_allowed(caps) || !(prov_mode & OFI_MR_MODE_RMA_TARGET))
 		return caps;
 
 	if (!user_info->domain_attr)


### PR DESCRIPTION
Coverity is complaining about this NULL-check since the pointer
is being dereferenced before the check. On examination, the only
location where this function is being called guarantees the pointer
to be valid, so I removed it.

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>

Fixes Coverity issue 208387.