### PR TITLE
prov/psm2: Replace virtual lanes with real PSM2 endpoints for supporting multiple endpoints 

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -93,7 +93,7 @@ Scalable endpoints
 
 Unsupported features
 : These features are unsupported: connection management, 
-  passive endpoint, shared receive context,
+  passive endpoint, shared send context, shared receive context,
   and send/inject with immediate data over tagged message queue.
 
 # RUNTIME PARAMETERS

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -353,7 +353,7 @@ struct psmx2_trx_ctxt {
 	int			id;
 	struct psm2_am_parameters psm2_am_param;
 
-	/* ep bound to this tx/rx context */
+	struct psmx2_fid_domain	*domain;
 	struct psmx2_fid_ep	*ep;
 
 	/* incoming req queue for AM based RMA request. */
@@ -396,12 +396,6 @@ struct psmx2_fid_domain {
 	fastlock_t		trx_ctxt_lock;
 	struct dlist_entry	trx_ctxt_list;
 
-	/*
-	 * The base hw context is multiplexed for all regular endpoints via
-	 * logical "virtual lanes".
-	 */
-	struct psmx2_trx_ctxt	*base_trx_ctxt;
-
 	ofi_atomic32_t		sep_cnt;
 	fastlock_t		sep_lock;
 	struct dlist_entry	sep_list;
@@ -410,6 +404,7 @@ struct psmx2_fid_domain {
 	pthread_t		progress_thread;
 
 	int			addr_format;
+	uint32_t		max_atomic_size;
 };
 
 #define PSMX2_EP_REGULAR	0

--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -286,6 +286,7 @@ int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 	size_t size;
 	int err = 0;
 	int idx;
+	uint32_t max_atomic_size;
 
 	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
 
@@ -295,6 +296,10 @@ int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 					     &size);
 		if (err)
 			return psmx2_errno(err);
+
+		max_atomic_size = trx_ctxt->psm2_am_param.max_request_short;
+		if (trx_ctxt->domain->max_atomic_size > max_atomic_size)
+			trx_ctxt->domain->max_atomic_size = max_atomic_size;
 
 		psmx2_lock(&psmx2_am_global.lock, 1);
 		if (psmx2_am_global.cnt >= PSMX2_AM_MAX_TRX_CTXT) {

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -35,7 +35,7 @@
 /* Atomics protocol:
  *
  * Atomics REQ:
- *	args[0].u32w0	cmd, dst_vl
+ *	args[0].u32w0	cmd
  *	args[0].u32w1	count
  *	args[1].u64	req
  *	args[2].u64	addr
@@ -429,21 +429,13 @@ int psmx2_am_atomic_handler_ext(psm2_am_token_t token,
 	struct psmx2_fid_cntr *mr_cntr = NULL;
 	void *tmp_buf;
 	psm2_epaddr_t epaddr;
-	uint8_t vlane;
 	int cmd;
 
 	psm2_am_get_source(token, &epaddr);
 
 	cmd = PSMX2_AM_GET_OP(args[0].u32w0);
 	domain = psmx2_active_fabric->active_domain;
-
-	if (trx_ctxt->ep) {
-		vlane = 0;
-		target_ep = trx_ctxt->ep;
-	} else {
-		vlane = PSMX2_AM_GET_DST(args[0].u32w0);
-		target_ep = domain->eps[vlane];
-	}
+	target_ep = trx_ctxt->ep;
 
 	switch (cmd) {
 	case PSMX2_AM_REQ_ATOMIC_WRITE:
@@ -805,12 +797,10 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	struct psmx2_am_request *req;
 	psm2_amarg_t args[8];
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size, len;
 	size_t idx;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -854,28 +844,22 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		 if (!dest_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
-		return psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_WRITE, ep_priv,
-					 (sep_target ? ep_priv :
-					   ep_priv->domain->eps[vlane]),
+		return psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_WRITE, ep_priv, ep_priv,
 					 buf, count, desc, NULL, NULL, NULL,
 					 NULL, addr, key, datatype, op,
 					 context, flags);
@@ -914,7 +898,6 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	req->cq_flags = FI_WRITE | FI_ATOMIC;
 
 	args[0].u32w0 = PSMX2_AM_REQ_ATOMIC_WRITE;
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 	args[0].u32w1 = count;
 	args[1].u64 = (uint64_t)(uintptr_t)req;
 	args[2].u64 = addr;
@@ -943,14 +926,12 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 	struct psmx2_am_request *req;
 	psm2_amarg_t args[8];
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size;
 	size_t idx;
 	size_t len;
 	uint8_t *buf;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -997,21 +978,17 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		 if (!dest_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
 	len = psmx2_ioc_size(iov, count, datatype);
@@ -1024,9 +1001,7 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 
 		psmx2_ioc_read(iov, count, datatype, buf, len);
 
-		err = psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_WRITE, ep_priv,
-					(sep_target ? ep_priv :
-					  ep_priv->domain->eps[vlane]),
+		err = psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_WRITE, ep_priv, ep_priv,
 					buf, len / ofi_datatype_size(datatype),
 					NULL, NULL, NULL, NULL, NULL, addr,
 					key, datatype, op, context, flags);
@@ -1070,7 +1045,6 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 	req->cq_flags = FI_WRITE | FI_ATOMIC;
 
 	args[0].u32w0 = PSMX2_AM_REQ_ATOMIC_WRITE;
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 	args[0].u32w1 = len / ofi_datatype_size(datatype);
 	args[1].u64 = (uint64_t)(uintptr_t)req;
 	args[2].u64 = addr;
@@ -1184,12 +1158,10 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 	struct psmx2_am_request *req;
 	psm2_amarg_t args[8];
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size, len;
 	size_t idx;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1235,29 +1207,23 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_READWRITE,
-					 ep_priv,
-					 (sep_target ? ep_priv :
-					   ep_priv->domain->eps[vlane]),
+					 ep_priv, ep_priv,
 					 buf, count, desc, NULL, NULL, result,
 					 result_desc, addr, key, datatype, op,
 					 context, flags);
@@ -1300,7 +1266,6 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 		req->cq_flags = FI_WRITE | FI_ATOMIC;
 
 	args[0].u32w0 = PSMX2_AM_REQ_ATOMIC_READWRITE;
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 	args[0].u32w1 = count;
 	args[1].u64 = (uint64_t)(uintptr_t)req;
 	args[2].u64 = addr;
@@ -1332,7 +1297,6 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 	struct psmx2_am_request *req;
 	psm2_amarg_t args[8];
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size;
 	size_t idx;
@@ -1340,7 +1304,6 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 	uint8_t *buf, *result;
 	void *desc0, *result_desc0;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1411,21 +1374,17 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
@@ -1450,9 +1409,7 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 		}
 
 		err = psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_READWRITE,
-					ep_priv,
-					(sep_target ? ep_priv :
-					  ep_priv->domain->eps[vlane]),
+					ep_priv, ep_priv,
 					buf, len / ofi_datatype_size(datatype),
 					desc0, NULL, NULL, result, result_desc0,
 					addr, key, datatype, op, context, flags);
@@ -1522,7 +1479,6 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 		req->cq_flags = FI_WRITE | FI_ATOMIC;
 
 	args[0].u32w0 = PSMX2_AM_REQ_ATOMIC_READWRITE;
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 	args[0].u32w1 = len / ofi_datatype_size(datatype);
 	args[1].u64 = (uint64_t)(uintptr_t)req;
 	args[2].u64 = addr;
@@ -1661,12 +1617,10 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 	struct psmx2_am_request *req;
 	psm2_amarg_t args[8];
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size, len;
 	size_t idx;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1714,29 +1668,23 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
 		return psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_COMPWRITE,
-					 ep_priv,
-					 (sep_target ? ep_priv :
-					   ep_priv->domain->eps[vlane]),
+					 ep_priv, ep_priv,
 					 buf, count, desc, compare,
 					 compare_desc, result, result_desc,
 					 addr, key, datatype, op,
@@ -1779,7 +1727,6 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 	req->cq_flags = FI_WRITE | FI_ATOMIC;
 
 	args[0].u32w0 = PSMX2_AM_REQ_ATOMIC_COMPWRITE;
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 	args[0].u32w1 = count;
 	args[1].u64 = (uint64_t)(uintptr_t)req;
 	args[2].u64 = addr;
@@ -1815,7 +1762,6 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 	struct psmx2_am_request *req;
 	psm2_amarg_t args[8];
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size;
 	size_t idx;
@@ -1823,7 +1769,6 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 	uint8_t *buf, *compare, *result;
 	void *desc0, *compare_desc0, *result_desc0;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1890,21 +1835,17 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
@@ -1950,9 +1891,7 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 		}
 
 		err = psmx2_atomic_self(PSMX2_AM_REQ_ATOMIC_COMPWRITE,
-					ep_priv,
-					(sep_target ? ep_priv :
-					  ep_priv->domain->eps[vlane]),
+					ep_priv, ep_priv,
 					buf, len / ofi_datatype_size(datatype), desc0,
 					compare, compare_desc0, result, result_desc0,
 					addr, key, datatype, op, context, flags);
@@ -2023,7 +1962,6 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 	req->cq_flags = FI_WRITE | FI_ATOMIC;
 
 	args[0].u32w0 = PSMX2_AM_REQ_ATOMIC_COMPWRITE;
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 	args[0].u32w1 = len / ofi_datatype_size(datatype);
 	args[1].u64 = (uint64_t)(uintptr_t)req;
 	args[2].u64 = addr;

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -2222,7 +2222,7 @@ int psmx2_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 	int ret;
 
 	domain_priv = container_of(domain, struct psmx2_fid_domain, util_domain.domain_fid);
-	chunk_size = domain_priv->base_trx_ctxt->psm2_am_param.max_request_short;
+	chunk_size = domain_priv->max_atomic_size;
 
 	if (flags & FI_TAGGED)
 		return -FI_EOPNOTSUPP;

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -846,10 +846,10 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		 if (!dest_addr)
 			return -FI_EINVAL;
@@ -980,10 +980,10 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		 if (!dest_addr)
 			return -FI_EINVAL;
@@ -1209,10 +1209,10 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
@@ -1376,10 +1376,10 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
@@ -1670,10 +1670,10 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
@@ -1837,10 +1837,10 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -32,9 +32,6 @@
 
 #include "psmx2.h"
 
-static void psmx2_av_post_completion(struct psmx2_fid_av *av, void *context,
-				     uint64_t data, int prov_errno);
-
 /*
  * SEP address query protocol:
  *
@@ -85,9 +82,9 @@ int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
 	int n, i, j;
 	uint8_t sep_id;
 	struct psmx2_fid_sep *sep;
-	struct psmx2_sep_addr *p;
 	struct psmx2_sep_query *req;
 	struct psmx2_fid_av *av;
+	psm2_epid_t *epids;
 	psm2_epid_t *buf = NULL;
 	int buflen;
 	struct dlist_entry *entry;
@@ -139,29 +136,18 @@ int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
 		i = args[2].u64;
 		if (op_error) {
 			ofi_atomic_inc32(&req->error_count);
-			if (av->flags & FI_EVENT)
-				psmx2_av_post_completion(av, req->context, i, op_error);
+			req->errors[i] = op_error;
 		} else {
 			n = args[3].u64;
-			p  = calloc(1, sizeof (struct psmx2_sep_addr) +
-				       n * sizeof(struct psmx2_ctxt_addr));
-			if (!p) {
+			epids = malloc(n * sizeof(psm2_epid_t));
+			if (!epids) {
 				ofi_atomic_inc32(&req->error_count);
 				req->errors[i] = PSM2_NO_MEMORY;
 			} else {
-				p->ctxt_cnt = n;
-				for (j=0; j<n; j++) {
-					p->ctxt_addrs[j].epid = ((psm2_epid_t *)src)[j];
-					p->ctxt_addrs[j].epaddrs =
-						calloc(psmx2_env.max_trx_ctxt,
-						       sizeof(psm2_epaddr_t));
-					if (!p->ctxt_addrs[j].epaddrs) {
-						ofi_atomic_inc32(&req->error_count);
-						req->errors[i] = PSM2_NO_MEMORY;
-						break;
-					}
-				}
-				av->sepaddrs[i] = p;
+				for (j=0; j<n; j++)
+					epids[j] = ((psm2_epid_t *)src)[j];
+				av->peers[i].sep_ctxt_cnt = n;
+				av->peers[i].sep_ctxt_epids = epids;
 			}
 		}
 		ofi_atomic_dec32(&req->pending);
@@ -263,37 +249,37 @@ psm2_epaddr_t psmx2_av_translate_sep(struct psmx2_fid_av *av,
 	psm2_epaddr_t epaddr;
 	int err;
 
-	if (!av->sepaddrs[idx])
+	if (av->peers[idx].type != PSMX2_EP_SCALABLE)
 		return NULL;
 
-	if (ctxt >= av->sepaddrs[idx]->ctxt_cnt)
+	if (ctxt >= av->peers[idx].sep_ctxt_cnt)
 		return NULL;
 
-	if (!av->sepaddrs[idx]->ctxt_addrs[ctxt].epaddrs[trx_ctxt->id]) {
+	if (!av->tables[trx_ctxt->id].sepaddrs[idx][ctxt]) {
 		err = psmx2_epid_to_epaddr(trx_ctxt,
-					   av->sepaddrs[idx]->ctxt_addrs[ctxt].epid,
+					   av->peers[idx].sep_ctxt_epids[ctxt],
 					   &epaddr);
 		if (err) {
 			FI_WARN(&psmx2_prov, FI_LOG_AV,
 				"fatal error: unable to translate epid %lx to epaddr.\n",
-				av->sepaddrs[idx]->ctxt_addrs[ctxt].epid);
+				av->peers[idx].sep_ctxt_epids[ctxt]);
 			return NULL;
 		}
 
-		av->sepaddrs[idx]->ctxt_addrs[ctxt].epaddrs[trx_ctxt->id] = epaddr;
+		av->tables[trx_ctxt->id].sepaddrs[idx][ctxt] = epaddr;
 	}
 
-	return av->sepaddrs[idx]->ctxt_addrs[ctxt].epaddrs[trx_ctxt->id];
+	return av->tables[trx_ctxt->id].sepaddrs[idx][ctxt];
 }
 
-static int psmx2_av_check_table_size(struct psmx2_fid_av *av, size_t count)
+static int psmx2_av_check_space(struct psmx2_fid_av *av, size_t count)
 {
-	size_t new_count;
 	psm2_epid_t *new_epids;
 	psm2_epaddr_t *new_epaddrs;
-	uint8_t *new_sepids;
-	uint8_t *new_types;
-	struct psmx2_sep_addr **new_sepaddrs;
+	psm2_epaddr_t **new_sepaddrs;
+	struct psmx2_av_peer *new_peers;
+	size_t new_count;
+	int i;
 
 	new_count = av->count;
 	while (new_count < av->last + count)
@@ -305,29 +291,31 @@ static int psmx2_av_check_table_size(struct psmx2_fid_av *av, size_t count)
 	new_epids = realloc(av->epids, new_count * sizeof(*new_epids));
 	if (!new_epids)
 		return -FI_ENOMEM;
-
 	av->epids = new_epids;
-	new_epaddrs = realloc(av->epaddrs, new_count * sizeof(*new_epaddrs));
-	if (!new_epaddrs)
+
+	new_peers = realloc(av->peers, new_count * sizeof(*new_peers));
+	if (!new_peers)
 		return -FI_ENOMEM;
+	av->peers = new_peers;
 
-	av->epaddrs = new_epaddrs;
-	new_sepids = realloc(av->sepids, new_count * sizeof(*new_sepids));
-	if (!new_sepids)
-		return -FI_ENOMEM;
+	for (i = 0; i < av->max_trx_ctxt; i++) {
+		if (!av->tables[i].trx_ctxt)
+			continue;
 
-	av->sepids = new_sepids;
-	new_types = realloc(av->types, new_count * sizeof(*new_types));
-	if (!new_types)
-		return -FI_ENOMEM;
+		new_epaddrs = realloc(av->tables[i].epaddrs,
+				      new_count * sizeof(*av->tables[i].epaddrs));
+		if (!new_epaddrs)
+			return -FI_ENOMEM;
 
-	av->types = new_types;
+		av->tables[i].epaddrs = new_epaddrs;
 
-	new_sepaddrs = realloc(av->sepaddrs, new_count * sizeof(*new_sepaddrs));
-	if (!new_sepaddrs)
-		return -FI_ENOMEM;
+		new_sepaddrs = realloc(av->tables[i].sepaddrs,
+				       new_count * sizeof(*av->tables[i].sepaddrs));
+		if (!new_sepaddrs)
+			return -FI_ENOMEM;
 
-	av->sepaddrs = new_sepaddrs;
+		av->tables[i].sepaddrs = new_sepaddrs;
+	}
 
 	av->count = new_count;
 	return 0;
@@ -356,20 +344,48 @@ static void psmx2_av_post_completion(struct psmx2_fid_av *av, void *context,
 	}
 }
 
-static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
-				psm2_epid_t *epids, int *mask,
-				uint8_t *types, psm2_error_t *errors,
-				psm2_epaddr_t *epaddrs,
-				void *context)
+static int psmx2_av_connect_trx_ctxt(struct psmx2_fid_av *av,
+				     int trx_ctxt_id,
+				     size_t av_idx_start,
+				     size_t count,
+				     psm2_error_t *errors)
 {
-	int i;
-	psm2_epconn_t epconn;
+	struct psmx2_trx_ctxt *trx_ctxt;
+	struct psmx2_sep_query *req;
+	struct psmx2_av_peer *peers;
 	struct psmx2_epaddr_context *epaddr_context;
+	psm2_epconn_t epconn;
+	psm2_ep_t ep;
+	psm2_epid_t *epids;
+	psm2_epaddr_t *epaddrs;
+	psm2_epaddr_t **sepaddrs;
+	psm2_amarg_t args[3];
+	int *mask;
 	int error_count = 0;
-	psm2_ep_t ep = av->domain->base_trx_ctxt->psm2_ep;
+	int to_connect = 0;
+	int sep_count = 0;
+	int i;
 
-	/* set up mask to prevent connecting to an already connected ep */
-	for (i=0; i<count; i++) {
+	trx_ctxt = av->tables[trx_ctxt_id].trx_ctxt;
+	ep = trx_ctxt->psm2_ep;
+	epids = av->epids + av_idx_start;
+	epaddrs = av->tables[trx_ctxt_id].epaddrs + av_idx_start;
+	sepaddrs = av->tables[trx_ctxt_id].sepaddrs + av_idx_start;
+	peers = av->peers + av_idx_start;
+
+	/* set up mask to avoid duplicated connection */
+
+	mask = calloc(count, sizeof(*mask));
+	if (!mask) {
+		for (i = 0; i < count; i++)
+			errors[i] = PSM2_NO_MEMORY;
+		error_count += count;
+		return error_count;
+	}
+
+	for (i = 0; i < count; i++) {
+		errors[i] = PSM2_OK;
+
 		if (psmx2_ep_epid_lookup(ep, epids[i], &epconn) == PSM2_OK) {
 			epaddr_context = psm2_epaddr_getctxt(epconn.addr);
 			if (epaddr_context && epaddr_context->epid == epids[i])
@@ -380,15 +396,30 @@ static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
 			mask[i] = 1;
 		}
 
-		if (mask[i] && psmx2_env.lazy_conn && types[i] != PSMX2_EP_SCALABLE) {
-			epaddrs[i] = NULL;
-			mask[i] = 0;
+		if (mask[i]) {
+			if (peers[i].type == PSMX2_EP_SCALABLE) {
+				if (peers[i].sep_ctxt_epids) {
+					mask[i] = 0;
+				} else {
+					to_connect++;
+					sep_count++;
+				}
+			} else if (psmx2_env.lazy_conn) {
+				epaddrs[i] = NULL;
+				mask[i] = 0;
+			} else {
+				to_connect++;
+			}
 		}
 	}
 
-	psm2_ep_connect(ep, count, epids, mask, errors, epaddrs, psmx2_conn_timeout(count));
+	if (to_connect)
+		psm2_ep_connect(ep, count, epids, mask, errors, epaddrs,
+				psmx2_conn_timeout(count));
 
-	for (i=0; i<count; i++){
+	/* check the connection results */
+
+	for (i = 0; i < count; i++) {
 		if (!mask[i]) {
 			errors[i] = PSM2_OK;
 			continue;
@@ -396,7 +427,7 @@ static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
 
 		if (errors[i] == PSM2_OK ||
 		    errors[i] == PSM2_EPID_ALREADY_CONNECTED) {
-			psmx2_set_epaddr_context(av->domain->base_trx_ctxt, epids[i], epaddrs[i]);
+			psmx2_set_epaddr_context(trx_ctxt, epids[i], epaddrs[i]);
 			errors[i] = PSM2_OK;
 		} else {
 			/* If duplicated addrs are passed to psm2_ep_connect(),
@@ -425,70 +456,122 @@ static int psmx2_av_connect_eps(struct psmx2_fid_av *av, size_t count,
 					"at the other side.\n");
 			epaddrs[i] = (void *)FI_ADDR_NOTAVAIL;
 			error_count++;
-
-			if (av->flags & FI_EVENT)
-				psmx2_av_post_completion(av, context, i, errors[i]);
 		}
+	}
+
+	free(mask);
+
+	if (sep_count) {
+
+		/* query SEP information */
+
+		psmx2_am_init(trx_ctxt); /* check AM handler installation */
+
+		req = malloc(sizeof *req);
+		if (req) {
+			req->av = av;
+			req->errors = errors;
+			ofi_atomic_initialize32(&req->error_count, 0);
+			ofi_atomic_initialize32(&req->pending, 0);
+		}
+
+		for (i = 0; i < count; i++) {
+			if (peers[i].type != PSMX2_EP_SCALABLE ||
+			    peers[i].sep_ctxt_epids ||
+			    errors[i] != PSM2_OK)
+				continue;
+
+			if (!req) {
+				errors[i] = PSM2_NO_MEMORY;
+				error_count++;
+				continue;
+			}
+
+			ofi_atomic_inc32(&req->pending);
+			args[0].u32w0 = PSMX2_AM_REQ_SEP_QUERY;
+			args[0].u32w1 = peers[i].sep_id;
+			args[1].u64 = (uint64_t)(uintptr_t)req;
+			args[2].u64 = av_idx_start + i;
+			psm2_am_request_short(epaddrs[i], PSMX2_AM_SEP_HANDLER,
+					      args, 3, NULL, 0, 0, NULL, NULL);
+		}
+
+		/*
+		 * make it synchronous for now to:
+		 * (1) ensure array "req->errors" is valid;
+		 * (2) to simplify the logic of generating the final
+		 *     completion event.
+		 */
+
+		if (req) {
+			while (ofi_atomic_get32(&req->pending))
+				psmx2_progress(trx_ctxt);
+			error_count += ofi_atomic_get32(&req->error_count);
+			free(req);
+		}
+	}
+
+	/* alloate context specific epaddrs for SEP */
+
+	for (i = 0; i < count; i++) {
+		if (peers[i].type == PSMX2_EP_SCALABLE &&
+		    peers[i].sep_ctxt_epids && !sepaddrs[i])
+			sepaddrs[i] = calloc(peers[i].sep_ctxt_cnt,
+					     sizeof(*sepaddrs[i]));
 	}
 
 	return error_count;
 }
 
-static int psmx2_av_query_seps(struct psmx2_fid_av *av, size_t count, psm2_epid_t *epids,
-			       uint8_t *sep_ids, uint8_t *types, psm2_error_t *errors,
-			       psm2_epaddr_t *epaddrs, void *context)
+int psmx2_av_add_trx_ctxt(struct psmx2_fid_av *av,
+			  struct psmx2_trx_ctxt *trx_ctxt,
+			  int connect_now)
 {
-	struct psmx2_sep_query *req;
-	psm2_amarg_t args[8];
-	int error_count = 0;
-	int i;
+	psm2_error_t *errors;
+	int id = trx_ctxt->id;
 
-	req = malloc(sizeof *req);
-
-	if (req) {
-		req->av = av;
-		req->context = context;
-		req->errors = errors;
-		ofi_atomic_initialize32(&req->error_count, 0);
-		ofi_atomic_initialize32(&req->pending, 0);
+	if (id >= av->max_trx_ctxt) {
+		FI_INFO(&psmx2_prov, FI_LOG_AV,
+			"trx_ctxt->id(%d) exceeds av->max_trx_ctxt(%d).\n",
+			id, av->max_trx_ctxt);
+		return -FI_EINVAL;
 	}
 
-	for (i=0; i<count; i++) {
-		if (types[i] != PSMX2_EP_SCALABLE)
-			continue;
-
-		if (errors[i] != PSM2_OK)
-			continue;
-
-		if (!req) {
-			errors[i] = PSM2_NO_MEMORY;
-			error_count++;
-			continue;
+	if (av->tables[id].trx_ctxt) {
+		if (av->tables[id].trx_ctxt == trx_ctxt) {
+			FI_INFO(&psmx2_prov, FI_LOG_AV,
+				"trx_ctxt(%p) with id(%d) already added.\n",
+				trx_ctxt, id);
+			return 0;
+		} else {
+			FI_INFO(&psmx2_prov, FI_LOG_AV,
+				"different trx_ctxt(%p) with same id(%d) already added.\n",
+				trx_ctxt, id);
+			return -FI_EINVAL;
 		}
-
-		ofi_atomic_inc32(&req->pending);
-		args[0].u32w0 = PSMX2_AM_REQ_SEP_QUERY;
-		args[0].u32w1 = sep_ids[i];
-		args[1].u64 = (uint64_t)(uintptr_t)req;
-		args[2].u64 = av->last + i;
-		psm2_am_request_short(epaddrs[i], PSMX2_AM_SEP_HANDLER,
-				      args, 3, NULL, 0, 0, NULL, NULL);
 	}
 
-	/*
-	 * make it synchronous for now to:
-	 * (1) ensure array "req->errors" is valid;
-	 * (2) to simplify the logic of generating the final completion event.
-	 */
+	av->tables[id].epaddrs = (psm2_epaddr_t *) calloc(av->count,
+							  sizeof(psm2_epaddr_t));
+	if (!av->tables[id].epaddrs)
+		return -FI_ENOMEM;
 
-	if (req) {
-		while (ofi_atomic_get32(&req->pending))
-			psmx2_progress_all(av->domain);
-		error_count = ofi_atomic_get32(&req->error_count);
-		free(req);
+	av->tables[id].sepaddrs = (psm2_epaddr_t **)calloc(av->count,
+							   sizeof(psm2_epaddr_t *));
+	if (!av->tables[id].sepaddrs)
+		return -FI_ENOMEM;
+
+	av->tables[id].trx_ctxt = trx_ctxt;
+
+	if (connect_now) {
+		errors = calloc(av->count, sizeof(*errors));
+		if (errors) {
+			psmx2_av_connect_trx_ctxt(av, id, 0, av->last, errors);
+			free(errors);
+		}
 	}
 
-	return error_count;
+	return 0;
 }
 
 static int psmx2_av_insert(struct fid_av *av, const void *addr,
@@ -496,18 +579,13 @@ static int psmx2_av_insert(struct fid_av *av, const void *addr,
 			   uint64_t flags, void *context)
 {
 	struct psmx2_fid_av *av_priv;
-	psm2_epid_t *epids;
-	uint8_t *sepids;
-	uint8_t *types;
-	struct psmx2_sep_addr **sepaddrs;
-	psm2_epaddr_t *epaddrs;
-	psm2_error_t *errors;
-	int *mask;
 	struct psmx2_ep_name *ep_name;
 	const struct psmx2_ep_name *names = addr;
 	const char **string_names = (void *)addr;
-	int error_count;
-	int i, ret;
+	psm2_error_t *errors;
+	int error_count = 0;
+	int i, idx, ret;
+	int sep_count = 0;
 
 	if (count && !addr) {
 		FI_INFO(&psmx2_prov, FI_LOG_AV,
@@ -520,62 +598,74 @@ static int psmx2_av_insert(struct fid_av *av, const void *addr,
 	if ((av_priv->flags & FI_EVENT) && !av_priv->eq)
 		return -FI_ENOEQ;
 
-	if (psmx2_av_check_table_size(av_priv, count))
+	if (psmx2_av_check_space(av_priv, count))
 		return -FI_ENOMEM;
 
-	epids = av_priv->epids + av_priv->last;
-	epaddrs = av_priv->epaddrs + av_priv->last;
-	sepids = av_priv->sepids + av_priv->last;
-	types = av_priv->types + av_priv->last;
-	sepaddrs = av_priv->sepaddrs + av_priv->last;
+	errors = calloc(count, sizeof(*errors));
+	if (!errors)
+		return -FI_ENOMEM;
 
-	for (i=0; i<count; i++) {
+	/* save the peer address information */
+	for (i = av_priv->last; i < av_priv->last + count; i++) {
 		if (av_priv->addr_format == FI_ADDR_STR) {
 			ep_name = psmx2_string_to_ep_name(string_names[i]);
 			if (!ep_name)
 				return -FI_EINVAL;
-			epids[i] = ep_name->epid;
-			sepids[i] = ep_name->sep_id;
-			types[i] = ep_name->type;
+			av_priv->epids[i] = ep_name->epid;
+			av_priv->peers[i].type = ep_name->type;
+			av_priv->peers[i].sep_id = ep_name->sep_id;
 			free(ep_name);
 		} else {
-			epids[i] = names[i].epid;
-			sepids[i] = names[i].sep_id;
-			types[i] = names[i].type;
+			av_priv->epids[i] = names[i].epid;
+			av_priv->peers[i].type = names[i].type;
+			av_priv->peers[i].sep_id = names[i].sep_id;
 		}
-		sepaddrs[i] = NULL;
+		av_priv->peers[i].sep_ctxt_cnt = 1;
+		av_priv->peers[i].sep_ctxt_epids = NULL;
+		if (av_priv->peers[i].type == PSMX2_EP_SCALABLE)
+			sep_count++;
 	}
 
-	errors = (psm2_error_t *) calloc(count, sizeof *errors);
-	mask = (int *) calloc(count, sizeof *mask);
-	if (!errors || !mask) {
-		free(mask);
-		free(errors);
-		return -FI_ENOMEM;
+	/*
+	 * try to establish connection when:
+	 *  (1) there are Tx/Rx context(s) bound to the AV; and
+	 *  (2) the connection is desired right now
+	 */
+	if (sep_count || !psmx2_env.lazy_conn) {
+		for (i = 0; i < av_priv->max_trx_ctxt; i++) {
+			if (!av_priv->tables[i].trx_ctxt)
+				continue;
+
+			error_count = psmx2_av_connect_trx_ctxt(av_priv, i,
+								av_priv->last,
+								count, errors);
+
+			if (error_count || psmx2_env.lazy_conn)
+				break;
+		}
 	}
-
-	error_count = psmx2_av_connect_eps(av_priv, count, epids, mask, types,
-					   errors, epaddrs, context);
-
-	error_count += psmx2_av_query_seps(av_priv, count, epids, sepids, types,
-					   errors, epaddrs, context);
 
 	if (fi_addr) {
-		for (i=0; i<count; i++) {
-			if (epaddrs[i] == (void *)FI_ADDR_NOTAVAIL)
+		for (i = 0; i < count; i++) {
+			idx = av_priv->last + i;
+			if (errors[i] != PSM2_OK)
 				fi_addr[i] = FI_ADDR_NOTAVAIL;
-			else if (types[i] == PSMX2_EP_SCALABLE)
-				fi_addr[i] = (av_priv->last + i) | PSMX2_SEP_ADDR_FLAG;
+			else if (av_priv->peers[idx].type == PSMX2_EP_SCALABLE)
+				fi_addr[i] = idx | PSMX2_SEP_ADDR_FLAG;
 			else if (av_priv->type == FI_AV_TABLE)
-				fi_addr[i] = av_priv->last + i;
+				fi_addr[i] = idx;
 			else
-				fi_addr[i] = PSMX2_EP_TO_ADDR(epaddrs[i]);
+				fi_addr[i] = PSMX2_EP_TO_ADDR(av_priv->tables[0].epaddrs[idx]);
 		}
 	}
 
 	av_priv->last += count;
 
 	if (av_priv->flags & FI_EVENT) {
+		if (error_count) {
+			for (i = 0; i < count; i++)
+				psmx2_av_post_completion(av_priv, context, i, errors[i]);
+		}
 		psmx2_av_post_completion(av_priv, context, count - error_count, 0);
 		ret = 0;
 	} else {
@@ -587,8 +677,6 @@ static int psmx2_av_insert(struct fid_av *av, const void *addr,
 		ret = count - error_count;
 	}
 
-	free(mask);
-	free(errors);
 	return ret;
 }
 
@@ -604,7 +692,7 @@ static int psmx2_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	struct psmx2_fid_av *av_priv;
 	struct psmx2_epaddr_context *context;
 	struct psmx2_ep_name name;
-	int idx;
+	int idx, sep_id;
 
 	if (!addr || !addrlen)
 		return -FI_EINVAL;
@@ -612,14 +700,26 @@ static int psmx2_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	av_priv = container_of(av, struct psmx2_fid_av, av);
 
 	memset(&name, 0, sizeof(name));
-	if (av_priv->type == FI_AV_TABLE) {
+
+	if (PSMX2_SEP_ADDR_TEST(fi_addr)) {
+		idx = PSMX2_SEP_ADDR_IDX(fi_addr);
+		sep_id = PSMX2_SEP_ADDR_CTXT(fi_addr, av_priv->rx_ctx_bits);
+		if (idx >= av_priv->last)
+			return -FI_EINVAL;
+
+		name.type = PSMX2_EP_SCALABLE;
+		name.epid = av_priv->epids[idx];
+		name.sep_id = sep_id;
+	} else if (av_priv->type == FI_AV_TABLE) {
 		idx = (int)(int64_t)fi_addr;
 		if (idx >= av_priv->last)
 			return -FI_EINVAL;
 
+		name.type = PSMX2_EP_REGULAR;
 		name.epid = av_priv->epids[idx];
 	} else {
 		context = psm2_epaddr_getctxt(PSMX2_ADDR_TO_EP(fi_addr));
+		name.type = PSMX2_EP_REGULAR;
 		name.epid = context->epid;
 	}
 
@@ -637,7 +737,7 @@ fi_addr_t psmx2_av_translate_source(struct psmx2_fid_av *av, fi_addr_t source)
 {
 	struct psmx2_epaddr_context *context;
 	psm2_epaddr_t epaddr;
-	int i;
+	int i, id;
 
 	epaddr = PSMX2_ADDR_TO_EP(source);
 
@@ -648,8 +748,9 @@ fi_addr_t psmx2_av_translate_source(struct psmx2_fid_av *av, fi_addr_t source)
 	if (av->type == FI_AV_MAP)
 		return source;
 
+	id = context->trx_ctxt->id;
 	for (i = av->last - 1; i >= 0; i--) {
-		if (av->epaddrs[i] == epaddr)
+		if (av->tables[id].epaddrs[i] == epaddr)
 			return (fi_addr_t)i;
 	}
 
@@ -669,18 +770,18 @@ static int psmx2_av_close(fid_t fid)
 
 	av = container_of(fid, struct psmx2_fid_av, av.fid);
 	psmx2_domain_release(av->domain);
-	free(av->epids);
-	free(av->epaddrs);
-	free(av->sepids);
-	free(av->types);
-	for (i=0; i<av->last; i++) {
-		if (!av->sepaddrs[i])
+	for (i = 0; i < av->max_trx_ctxt; i++) {
+		if (!av->tables[i].trx_ctxt)
 			continue;
-		for (j=0; j<av->sepaddrs[i]->ctxt_cnt; j++)
-			free(av->sepaddrs[i]->ctxt_addrs[j].epaddrs);
-		free(av->sepaddrs[i]);
+		free(av->tables[i].epaddrs);
+		if (av->tables[i].sepaddrs) {
+			for (j = 0; j < av->last; j++)
+				free(av->tables[i].sepaddrs[j]);
+		}
+		free(av->tables[i].sepaddrs);
 	}
-	free(av->sepaddrs);
+	free(av->peers);
+	free(av->epids);
 	free(av);
 	return 0;
 }
@@ -733,11 +834,12 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	size_t count = 64;
 	uint64_t flags = 0;
 	int rx_ctx_bits = PSMX2_MAX_RX_CTX_BITS;
+	size_t table_size;
 
 	domain_priv = container_of(domain, struct psmx2_fid_domain,
 				   util_domain.domain_fid);
 
-	if (psmx2_env.lazy_conn)
+	if (psmx2_env.lazy_conn || psmx2_env.max_trx_ctxt > 1)
 		type = FI_AV_TABLE;
 	else
 		type = FI_AV_MAP;
@@ -751,6 +853,11 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 			if (psmx2_env.lazy_conn) {
 				FI_INFO(&psmx2_prov, FI_LOG_AV,
 					"Lazy connection is enabled, force FI_AV_TABLE\n");
+				break;
+			}
+			if (psmx2_env.max_trx_ctxt > 1) {
+				FI_INFO(&psmx2_prov, FI_LOG_AV,
+					"Multi-EP is enabled, force FI_AV_TABLE\n");
 				break;
 			}
 			/* fall through */
@@ -791,7 +898,8 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		rx_ctx_bits = attr->rx_ctx_bits;
 	}
 
-	av_priv = (struct psmx2_fid_av *) calloc(1, sizeof *av_priv);
+	table_size = psmx2_env.max_trx_ctxt * sizeof(struct psmx2_av_table);
+	av_priv = (struct psmx2_fid_av *) calloc(1, sizeof(*av_priv) + table_size);
 	if (!av_priv)
 		return -FI_ENOMEM;
 
@@ -803,6 +911,7 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	av_priv->count = count;
 	av_priv->flags = flags;
 	av_priv->rx_ctx_bits = rx_ctx_bits;
+	av_priv->max_trx_ctxt = psmx2_env.max_trx_ctxt;
 	av_priv->addr_format = domain_priv->addr_format;
 
 	av_priv->av.fid.fclass = FI_CLASS_AV;

--- a/prov/psm2/src/psmx2_cm.c
+++ b/prov/psm2/src/psmx2_cm.c
@@ -48,7 +48,6 @@ static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 
 	if (ep->type == PSMX2_EP_REGULAR) {
 		epname.epid = ep->trx_ctxt->psm2_epid;
-		epname.vlane = ep->vlane;
 		epname.type = ep->type;
 	} else {
 		sep = (struct psmx2_fid_sep *)ep;

--- a/prov/psm2/src/psmx2_cm.c
+++ b/prov/psm2/src/psmx2_cm.c
@@ -51,7 +51,7 @@ static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 		epname.type = ep->type;
 	} else {
 		sep = (struct psmx2_fid_sep *)ep;
-		epname.epid = sep->domain->base_trx_ctxt->psm2_epid;
+		epname.epid = sep->ctxts[0].trx_ctxt->psm2_epid;
 		epname.sep_id = sep->id;
 		epname.type = sep->type;
 	}

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -335,8 +335,7 @@ psmx2_cq_create_event_from_status(struct psmx2_fid_cq *cq,
 
 out:
 	if (is_recv) {
-		uint8_t vlane = PSMX2_TAG32_GET_SRC(psm2_status->msg_tag.tag2);
-		fi_addr_t source = PSMX2_EP_TO_ADDR(psm2_status->msg_peer, vlane);
+		fi_addr_t source = PSMX2_EP_TO_ADDR(psm2_status->msg_peer);
 		if (event == event_in) {
 			if (src_addr) {
 				*src_addr = psmx2_av_translate_source(av, source);

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -470,7 +470,7 @@ static struct fi_ops_domain psmx2_domain_ops = {
 	.scalable_ep = psmx2_sep_open,
 	.cntr_open = psmx2_cntr_open,
 	.poll_open = fi_poll_create,
-	.stx_ctx = psmx2_stx_ctx,
+	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = psmx2_query_atomic,
 };

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -318,6 +318,7 @@ static int psmx2_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			return -FI_EINVAL;
 		ep->av = av;
 		psmx2_ep_optimize_ops(ep);
+		psmx2_av_add_trx_ctxt(av, ep->trx_ctxt, !psmx2_env.lazy_conn);
 		break;
 
 	case FI_CLASS_MR:

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -379,8 +379,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 				goto err_out;
 			}
 
-			if (hints->ep_attr->tx_ctx_cnt > psmx2_env.sep_trx_ctxt &&
-			    hints->ep_attr->tx_ctx_cnt != FI_SHARED_CONTEXT) {
+			if (hints->ep_attr->tx_ctx_cnt > psmx2_env.sep_trx_ctxt) {
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
 					"hints->ep_attr->tx_ctx_cnt=%"PRIu64", available=%d\n",
 					hints->ep_attr->tx_ctx_cnt,

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -271,8 +271,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		} else {
 			dest_addr = addr;
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"'%s' is taken as dest_addr: <epid=%"PRIu64", vl=%d>\n",
-				node, dest_addr->epid, dest_addr->vlane);
+				"'%s' is taken as dest_addr: <epid=%"PRIu64">\n",
+				node, dest_addr->epid);
 		}
 		node = NULL;
 	}
@@ -328,9 +328,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 			ofi_ns_resolve_name(&ns, node, &svc);
 		if (dest_addr) {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"'%s:%u' resolved to <epid=%"PRIu64", vl=%d>:%d\n",
-				node, svc0, dest_addr->epid,
-				dest_addr->vlane, svc);
+				"'%s:%u' resolved to <epid=%"PRIu64">:%d\n",
+				node, svc0, dest_addr->epid, svc);
 		} else {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE,
 				"failed to resolve '%s:%u'.\n", node, svc);

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -39,10 +39,8 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag, psm2_tagsel;
-	uint32_t tag32, tagsel32;
 	struct fi_context *fi_context;
 	int recv_flag = 0;
 	size_t idx;
@@ -78,28 +76,21 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 		av = ep_priv->av;
 		if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
-			vlane = 0;
 		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
 			if ((err = psmx2_av_check_table_idx(av,idx)))
 				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
-			vlane = av->vlanes[idx];
 		} else {
 			psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
-			vlane = PSMX2_ADDR_TO_VL(src_addr);
 		}
-		tag32 = PSMX2_TAG32(PSMX2_MSG_BIT, vlane, ep_priv->vlane);
-		tagsel32 = ~(PSMX2_IOV_BIT | PSMX2_IMM_BIT);
 	} else {
 		psm2_epaddr = 0;
-		tag32 = PSMX2_TAG32(PSMX2_MSG_BIT, 0, ep_priv->vlane);
-		tagsel32 = ~(PSMX2_IOV_BIT | PSMX2_IMM_BIT | PSMX2_SRC_BITS);
 	}
 
-	PSMX2_SET_TAG(psm2_tag, 0ULL, tag32);
-	PSMX2_SET_TAG(psm2_tagsel, 0ULL, tagsel32);
+	PSMX2_SET_TAG(psm2_tag, 0ULL, PSMX2_MSG_BIT);
+	PSMX2_SET_TAG(psm2_tagsel, 0ULL, ~(PSMX2_IOV_BIT | PSMX2_IMM_BIT));
 
 	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION)) {
 		fi_context = psmx2_ep_get_op_context(ep_priv);
@@ -218,7 +209,6 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag;
 	uint32_t tag32;
@@ -259,20 +249,17 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
 		if ((err = psmx2_av_check_table_idx(av,idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else  {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
-	tag32 = PSMX2_TAG32(PSMX2_MSG_BIT, ep_priv->vlane, vlane);
+	tag32 = PSMX2_MSG_BIT;
 	if (flags & FI_REMOTE_CQ_DATA)
 		tag32 |= PSMX2_IMM_BIT;
 	PSMX2_SET_TAG(psm2_tag, data, tag32);
@@ -344,10 +331,9 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag;
-	uint32_t tag32, tag32_base;
+	uint32_t tag32;
 	struct fi_context * fi_context;
 	int send_flag = 0;
 	int err;
@@ -411,7 +397,7 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 			}
 		}
 
-		tag32_base = PSMX2_MSG_BIT;
+		tag32 = PSMX2_MSG_BIT;
 		len = total_len;
 	} else {
 		req->iov_protocol = PSMX2_IOV_PROTO_MULTI;
@@ -427,14 +413,13 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 				*q++ = (uint32_t)iov[i].iov_len;
 		}
 
-		tag32_base = PSMX2_MSG_BIT | PSMX2_IOV_BIT;
+		tag32 = PSMX2_MSG_BIT | PSMX2_IOV_BIT;
 		len = (3 + real_count) * sizeof(uint32_t);
 	}
 
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
 		if ((err = psmx2_av_check_table_idx(av,idx))) {
@@ -443,13 +428,10 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 		}
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else  {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
-	tag32 = PSMX2_TAG32(tag32_base, ep_priv->vlane, vlane);
 	if (flags & FI_REMOTE_CQ_DATA)
 		tag32 |= PSMX2_IMM_BIT;
 	PSMX2_SET_TAG(psm2_tag, data, tag32);

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -78,10 +78,10 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
-			if ((err = psmx2_av_check_table_idx(av,idx)))
+			if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 				return err;
 
-			psm2_epaddr = av->epaddrs[idx];
+			psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 		} else {
 			psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
 		}
@@ -251,10 +251,10 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
-		if ((err = psmx2_av_check_table_idx(av,idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else  {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
 	}
@@ -422,12 +422,12 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
-		if ((err = psmx2_av_check_table_idx(av,idx))) {
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx))) {
 			free(req);
 			return err;
 		}
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else  {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
 	}

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -623,10 +623,10 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		if (!src_addr)
 			return -FI_EINVAL;
@@ -764,10 +764,10 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		if (!src_addr)
 			return -FI_EINVAL;
@@ -993,10 +993,10 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
@@ -1176,10 +1176,10 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -70,7 +70,7 @@ static inline void psmx2_iov_copy(struct iovec *iov, size_t count,
 /* RMA protocol:
  *
  * Write REQ:
- *	args[0].u32w0	cmd, src_vl, dst_vl, flag
+ *	args[0].u32w0	cmd, flag
  *	args[0].u32w1	len
  *	args[1].u64	req
  *	args[2].u64	addr
@@ -83,7 +83,7 @@ static inline void psmx2_iov_copy(struct iovec *iov, size_t count,
  *	args[1].u64	req
  *
  * Read REQ:
- *	args[0].u32w0	cmd, src_vl, dst_vl, flag
+ *	args[0].u32w0	cmd, flag
  *	args[0].u32w1	len
  *	args[1].u64	req
  *	args[2].u64	addr
@@ -113,7 +113,6 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 	uint64_t offset;
 	struct psmx2_fid_mr *mr;
 	psm2_epaddr_t epaddr;
-	uint8_t dst_vl, src_vl;
 	struct psmx2_fid_domain *domain;
 	struct psmx2_fid_ep *ep;
 
@@ -121,14 +120,7 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 
 	cmd = PSMX2_AM_GET_OP(args[0].u32w0);
 	domain = psmx2_active_fabric->active_domain;
-
-	if (trx_ctxt->ep) {
-		dst_vl = 0;
-		ep = trx_ctxt->ep;
-	} else {
-		dst_vl = PSMX2_AM_GET_DST(args[0].u32w0);
-		ep = domain->eps[dst_vl];
-	}
+	ep = trx_ctxt->ep;
 
 	eom = args[0].u32w0 & PSMX2_AM_EOM;
 	has_data = args[0].u32w0 & PSMX2_AM_DATA;
@@ -183,7 +175,6 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 		break;
 
 	case PSMX2_AM_REQ_WRITE_LONG:
-		src_vl = PSMX2_AM_GET_SRC(args[0].u32w0);
 		rma_len = args[0].u32w1;
 		rma_addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
@@ -214,8 +205,6 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 			req->write.key = key;
 			req->write.context = (void *)args[1].u64;
 			req->write.peer_addr = (void *)epaddr;
-			req->write.vl = dst_vl;
-			req->write.peer_vl = src_vl;
 			req->write.data = has_data ? args[4].u64 : 0;
 			req->cq_flags = FI_REMOTE_WRITE | FI_RMA |
 					(has_data ? FI_REMOTE_CQ_DATA : 0),
@@ -256,7 +245,6 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 		break;
 
 	case PSMX2_AM_REQ_READ_LONG:
-		src_vl = PSMX2_AM_GET_SRC(args[0].u32w0);
 		rma_len = args[0].u32w1;
 		rma_addr = (uint8_t *)(uintptr_t)args[2].u64;
 		key = args[3].u64;
@@ -288,8 +276,6 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 			req->read.key = key;
 			req->read.context = (void *)args[1].u64;
 			req->read.peer_addr = (void *)epaddr;
-			req->read.vl = dst_vl;
-			req->read.peer_vl = src_vl;
 			PSMX2_CTXT_TYPE(&req->fi_context) = PSMX2_REMOTE_READ_CONTEXT;
 			PSMX2_CTXT_USER(&req->fi_context) = mr;
 			psmx2_am_enqueue_rma(trx_ctxt, req);
@@ -559,7 +545,7 @@ int psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 	uint32_t tag32;
 
 	if ((req->op & PSMX2_AM_OP_MASK) == PSMX2_AM_REQ_WRITE_LONG) {
-		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, req->write.peer_vl, req->write.vl);
+		tag32 = PSMX2_RMA_BIT;
 		PSMX2_TAG32_LONG_WRITE(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req->write.context, tag32);
 		PSMX2_SET_TAG(psm2_tagsel, -1ULL, -1);
@@ -569,7 +555,7 @@ int psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 				     (void *)req->write.addr, req->write.len,
 				     (void *)&req->fi_context, &psm2_req);
 	} else {
-		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, req->read.vl, req->read.peer_vl);
+		tag32 = PSMX2_RMA_BIT;
 		PSMX2_TAG32_LONG_READ(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req->read.context, tag32);
 		err = psm2_mq_isend2(trx_ctxt->psm2_mq,
@@ -595,13 +581,11 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	int chunk_size;
 	size_t offset = 0;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag, psm2_tagsel;
 	uint32_t tag32;
 	size_t idx;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -637,28 +621,22 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		if (!src_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
-		vlane = PSMX2_ADDR_TO_VL(src_addr);
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
-		return psmx2_rma_self(PSMX2_AM_REQ_READ, ep_priv,
-				      (sep_target ? ep_priv :
-					ep_priv->domain->eps[vlane]),
+		return psmx2_rma_self(PSMX2_AM_REQ_READ, ep_priv, ep_priv,
 				      buf, len, desc, addr, key,
 				      context, flags, 0);
 
@@ -686,11 +664,9 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	chunk_size = ep_priv->trx_ctxt->psm2_am_param.max_reply_short;
 
 	args[0].u32w0 = 0;
-	PSMX2_AM_SET_SRC(args[0].u32w0, ep_priv->vlane);
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 
 	if (psmx2_env.tagged_rma && len > chunk_size) {
-		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, vlane, ep_priv->vlane);
+		tag32 = PSMX2_RMA_BIT;
 		PSMX2_TAG32_LONG_READ(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 		PSMX2_SET_TAG(psm2_tagsel, -1ULL, -1);
@@ -746,7 +722,6 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	int chunk_size;
 	size_t offset = 0;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag, psm2_tagsel;
 	uint32_t tag32;
@@ -755,7 +730,6 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	void *long_buf = NULL;
 	int i;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -788,28 +762,22 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = src_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		if (!src_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
-		vlane = PSMX2_ADDR_TO_VL(src_addr);
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
-		return psmx2_rma_self(PSMX2_AM_REQ_READV, ep_priv,
-				      (sep_target ? ep_priv :
-					ep_priv->domain->eps[vlane]),
+		return psmx2_rma_self(PSMX2_AM_REQ_READV, ep_priv, ep_priv,
 				      (void *)iov, count, desc, addr,
 				      key, context, flags, 0);
 
@@ -865,8 +833,6 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 
 	/* Use short protocol for all but the last segment (long_len) */
 	args[0].u32w0 = 0;
-	PSMX2_AM_SET_SRC(args[0].u32w0, ep_priv->vlane);
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 	PSMX2_AM_SET_OP(args[0].u32w0, PSMX2_AM_REQ_READ);
 	args[1].u64 = (uint64_t)(uintptr_t)req;
 	args[3].u64 = key;
@@ -891,7 +857,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 
 	/* Use the long protocol for the last segment */
 	if (long_len) {
-		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, vlane, ep_priv->vlane);
+		tag32 = PSMX2_RMA_BIT;
 		PSMX2_TAG32_LONG_READ(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 		PSMX2_SET_TAG(psm2_tagsel, -1ULL, -1);
@@ -982,7 +948,6 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag;
 	uint32_t tag32;
@@ -990,7 +955,6 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	void *psm2_context;
 	int no_event;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1027,28 +991,22 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
-		return psmx2_rma_self(PSMX2_AM_REQ_WRITE, ep_priv,
-				      (sep_target ? ep_priv :
-					ep_priv->domain->eps[vlane]),
+		return psmx2_rma_self(PSMX2_AM_REQ_WRITE, ep_priv, ep_priv,
 				      (void *)buf, len, desc, addr,
 				      key, context, flags, data);
 
@@ -1094,11 +1052,9 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	chunk_size = ep_priv->trx_ctxt->psm2_am_param.max_request_short;
 
 	args[0].u32w0 = 0;
-	PSMX2_AM_SET_SRC(args[0].u32w0, ep_priv->vlane);
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 
 	if (psmx2_env.tagged_rma && len > chunk_size) {
-		tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, ep_priv->vlane, vlane);
+		tag32 = PSMX2_RMA_BIT;
 		PSMX2_TAG32_LONG_WRITE(tag32);
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 		PSMX2_AM_SET_OP(args[0].u32w0, PSMX2_AM_REQ_WRITE_LONG);
@@ -1175,7 +1131,6 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag;
 	uint32_t tag32;
@@ -1186,7 +1141,6 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	uint8_t *buf, *p;
 	int i;
 	int err;
-	int sep_target = 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1220,28 +1174,22 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
-		sep_target = 1;
 	} else if (av && av->type == FI_AV_TABLE) {
 		idx = dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		if (!dest_addr)
 			return -FI_EINVAL;
 
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
 	epaddr_context = psm2_epaddr_getctxt((void *)psm2_epaddr);
 	if (epaddr_context->epid == ep_priv->trx_ctxt->psm2_epid)
-		return psmx2_rma_self(PSMX2_AM_REQ_WRITEV, ep_priv,
-				      (sep_target ? ep_priv :
-					ep_priv->domain->eps[vlane]),
+		return psmx2_rma_self(PSMX2_AM_REQ_WRITEV, ep_priv, ep_priv,
 				      (void *)iov, count, desc, addr,
 				      key, context, flags, data);
 
@@ -1289,8 +1237,6 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 		PSMX2_CTXT_EP(&req->fi_context) = ep_priv;
 
 		args[0].u32w0 = 0;
-		PSMX2_AM_SET_SRC(args[0].u32w0, ep_priv->vlane);
-		PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 		PSMX2_AM_SET_OP(args[0].u32w0, PSMX2_AM_REQ_WRITE);
 		args[0].u32w1 = len;
 		args[1].u64 = (uint64_t)(uintptr_t)req;
@@ -1333,8 +1279,6 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 
 	/* Case 2: send iov in sequence */
 	args[0].u32w0 = 0;
-	PSMX2_AM_SET_SRC(args[0].u32w0, ep_priv->vlane);
-	PSMX2_AM_SET_DST(args[0].u32w0, vlane);
 
 	len_sent = 0;
 	for (i=0; i<count; i++) {
@@ -1344,7 +1288,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 		/* Case 2.1: use long protocol for the last segment if it is large */
 		if (psmx2_env.tagged_rma && iov[i].iov_len > chunk_size &&
 		    len_sent + iov[i].iov_len == total_len) {
-			tag32 = PSMX2_TAG32(PSMX2_RMA_BIT, ep_priv->vlane, vlane);
+			tag32 = PSMX2_RMA_BIT;
 			PSMX2_TAG32_LONG_WRITE(tag32);
 			PSMX2_SET_TAG(psm2_tag, (uint64_t)req, tag32);
 			PSMX2_AM_SET_OP(args[0].u32w0, PSMX2_AM_REQ_WRITE_LONG);

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -42,11 +42,9 @@ static ssize_t psmx2_tagged_peek_generic(struct fid_ep *ep,
 	struct psmx2_fid_av *av;
 	struct psmx2_cq_event *event;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t req;
 	psm2_mq_status2_t psm2_status;
 	psm2_mq_tag_t psm2_tag, psm2_tagsel;
-	uint32_t tag32, tagsel32;
 	size_t idx;
 	int err;
 
@@ -56,28 +54,21 @@ static ssize_t psmx2_tagged_peek_generic(struct fid_ep *ep,
 		av = ep_priv->av;
 		if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
-			vlane = 0;
 		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
 			if ((err = psmx2_av_check_table_idx(av, idx)))
 				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
-			vlane = av->vlanes[idx];
 		} else {
 			psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
-			vlane = PSMX2_ADDR_TO_VL(src_addr);
 		}
-		tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
-		tagsel32 = -1;
 	} else {
 		psm2_epaddr = 0;
-		tag32 = PSMX2_TAG32(0, 0, ep_priv->vlane);
-		tagsel32 = ~PSMX2_SRC_BITS;
 	}
 
-	PSMX2_SET_TAG(psm2_tag, tag, tag32);
-	PSMX2_SET_TAG(psm2_tagsel, ~ignore, tagsel32);
+	PSMX2_SET_TAG(psm2_tag, tag, 0);
+	PSMX2_SET_TAG(psm2_tagsel, ~ignore, -1);
 
 	if (flags & (FI_CLAIM | FI_DISCARD))
 		err = psm2_mq_improbe2(ep_priv->trx_ctxt->psm2_mq,
@@ -115,9 +106,8 @@ static ssize_t psmx2_tagged_peek_generic(struct fid_ep *ep,
 			if (!event)
 				return -FI_ENOMEM;
 
-			vlane = PSMX2_TAG32_GET_SRC(psm2_status.msg_tag.tag2);
 			event->source_is_valid = 1;
-			event->source = PSMX2_EP_TO_ADDR(psm2_status.msg_peer, vlane);
+			event->source = PSMX2_EP_TO_ADDR(psm2_status.msg_peer);
 			event->source_av = ep_priv->av;
 			psmx2_cq_enqueue_event(ep_priv->recv_cq, event);
 		}
@@ -158,10 +148,8 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag, psm2_tagsel;
-	uint32_t tag32, tagsel32;	
 	struct fi_context *fi_context;
 	size_t idx;
 	int err;
@@ -233,9 +221,8 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 				if (!event)
 					return -FI_ENOMEM;
 
-				vlane = PSMX2_TAG32_GET_SRC(psm2_status.msg_tag.tag2);
 				event->source_is_valid = 1;
-				event->source = PSMX2_EP_TO_ADDR(psm2_status.msg_peer, vlane);
+				event->source = PSMX2_EP_TO_ADDR(psm2_status.msg_peer);
 				event->source_av = ep_priv->av;
 				psmx2_cq_enqueue_event(ep_priv->recv_cq, event);
 			}
@@ -282,28 +269,21 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 		av = ep_priv->av;
 		if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
-			vlane = 0;
 		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
 			if ((err = psmx2_av_check_table_idx(av, idx)))
 				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
-			vlane = av->vlanes[idx];
 		} else {
 			psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
-			vlane = PSMX2_ADDR_TO_VL(src_addr);
 		}
-		tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
-		tagsel32 = ~PSMX2_IOV_BIT;
 	} else {
 		psm2_epaddr = 0;
-		tag32 = PSMX2_TAG32(0, 0, ep_priv->vlane);
-		tagsel32 = ~(PSMX2_IOV_BIT | PSMX2_SRC_BITS);
 	}
 
-	PSMX2_SET_TAG(psm2_tag, tag, tag32);
-	PSMX2_SET_TAG(psm2_tagsel, ~ignore, tagsel32);
+	PSMX2_SET_TAG(psm2_tag, tag, 0);
+	PSMX2_SET_TAG(psm2_tagsel, ~ignore, ~PSMX2_IOV_BIT);
 
 	err = psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     &psm2_tag, &psm2_tagsel, 0, buf, len,
@@ -331,10 +311,8 @@ psmx2_tagged_recv_specialized(struct fid_ep *ep, void *buf, size_t len,
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag, psm2_tagsel;
-	uint32_t tag32, tagsel32;	
 	struct fi_context *fi_context;
 	size_t idx;
 	int err;
@@ -357,37 +335,27 @@ psmx2_tagged_recv_specialized(struct fid_ep *ep, void *buf, size_t len,
 		if (av_type == FI_AV_MAP) {
 			if (av && PSMX2_SEP_ADDR_TEST(src_addr)) {
 				psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
-				vlane = 0;
 			} else {
 				psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
-				vlane = PSMX2_ADDR_TO_VL(src_addr);
 			}
-			tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
-			tagsel32 = ~PSMX2_IOV_BIT;
 		} else { /* FI_AV_TABLE */
 			assert(av != NULL);
 			if (PSMX2_SEP_ADDR_TEST(src_addr)) {
 				psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
-				vlane = 0;
 			} else {
 				idx = (size_t)src_addr;
 				if ((err = psmx2_av_check_table_idx(av, idx)))
 					return err;
 
 				psm2_epaddr = av->epaddrs[idx];
-				vlane = av->vlanes[idx];
 			}
-			tag32 = PSMX2_TAG32(0, vlane, ep_priv->vlane);
-			tagsel32 = ~PSMX2_IOV_BIT;
 		}
 	} else {
 		psm2_epaddr = 0;
-		tag32 = PSMX2_TAG32(0, 0, ep_priv->vlane);
-		tagsel32 = ~(PSMX2_IOV_BIT | PSMX2_SRC_BITS);
 	}
 
-	PSMX2_SET_TAG(psm2_tag, tag, tag32);
-	PSMX2_SET_TAG(psm2_tagsel, ~ignore, tagsel32);
+	PSMX2_SET_TAG(psm2_tag, tag, 0);
+	PSMX2_SET_TAG(psm2_tagsel, ~ignore, ~PSMX2_IOV_BIT);
 
 	err = psm2_mq_irecv2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr,
 			     &psm2_tag, &psm2_tagsel, 0, buf, len,
@@ -578,10 +546,8 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag;
-	uint32_t tag32;
 	struct fi_context *fi_context;
 	size_t idx;
 	int err;
@@ -619,21 +585,17 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx)))
 			return err;
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
-	tag32 = PSMX2_TAG32(0, ep_priv->vlane, vlane);
-	PSMX2_SET_TAG(psm2_tag, tag, tag32);
+	PSMX2_SET_TAG(psm2_tag, tag, 0);
 
 	if ((flags & PSMX2_NO_COMPLETION) ||
 	    (ep_priv->send_selective_completion && !(flags & FI_COMPLETION)))
@@ -706,10 +668,8 @@ psmx2_tagged_send_specialized(struct fid_ep *ep, const void *buf,
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag;
-	uint32_t tag32;
 	struct fi_context *fi_context;
 	size_t idx;
 	int err;
@@ -718,29 +678,23 @@ psmx2_tagged_send_specialized(struct fid_ep *ep, const void *buf,
 	av = ep_priv->av;
 
 	if (av_type == FI_AV_MAP) {
-		if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		if (av && PSMX2_SEP_ADDR_TEST(dest_addr))
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-			vlane = 0;
-		} else {
+		else
 			psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-			vlane = PSMX2_ADDR_TO_VL(dest_addr);
-		}
 	} else { /* FI_AV_TABLE */
 		if (PSMX2_SEP_ADDR_TEST(dest_addr)) {
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-			vlane = 0;
 		} else {
 			idx = (size_t)dest_addr;
 			if ((err = psmx2_av_check_table_idx(av, idx)))
 				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
-			vlane = av->vlanes[idx];
 		}
 	}
 
-	tag32 = PSMX2_TAG32(0, ep_priv->vlane, vlane);
-	PSMX2_SET_TAG(psm2_tag, tag, tag32);
+	PSMX2_SET_TAG(psm2_tag, tag, 0);
 
 	if (enable_completion) {
 		fi_context = context;
@@ -819,9 +773,7 @@ psmx2_tagged_inject_specialized(struct fid_ep *ep, const void *buf,
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_tag_t psm2_tag;
-	uint32_t tag32;
 	size_t idx;
 	int err;
 
@@ -833,29 +785,23 @@ psmx2_tagged_inject_specialized(struct fid_ep *ep, const void *buf,
 	av = ep_priv->av;
 
 	if (av_type == FI_AV_MAP) {
-		if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
+		if (av && PSMX2_SEP_ADDR_TEST(dest_addr))
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-			vlane = 0;
-		} else {
+		else
 			psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-			vlane = PSMX2_ADDR_TO_VL(dest_addr);
-		}
 	} else { /* FI_AV_TABLE */
 		if (PSMX2_SEP_ADDR_TEST(dest_addr)) {
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-			vlane = 0;
 		} else {
 			idx = (size_t)dest_addr;
 			if ((err = psmx2_av_check_table_idx(av, idx)))
 				return err;
 
 			psm2_epaddr = av->epaddrs[idx];
-			vlane = av->vlanes[idx];
 		}
 	}
 
-	tag32 = PSMX2_TAG32(0, ep_priv->vlane, vlane);
-	PSMX2_SET_TAG(psm2_tag, tag, tag32);
+	PSMX2_SET_TAG(psm2_tag, tag, 0);
 
 	err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			    &psm2_tag, buf, len);
@@ -896,10 +842,9 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
 	psm2_epaddr_t psm2_epaddr;
-	uint8_t vlane;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag;
-	uint32_t tag32, tag32_base;
+	uint32_t tag32;
 	struct fi_context * fi_context;
 	int send_flag = 0;
 	int err;
@@ -964,7 +909,7 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 			}
 		}
 
-		tag32_base = 0;
+		tag32 = 0;
 		len = total_len;
 	} else {
 		req->iov_protocol = PSMX2_IOV_PROTO_MULTI;
@@ -980,14 +925,13 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 				*q++ = (uint32_t)iov[i].iov_len;
 		}
 
-		tag32_base = PSMX2_IOV_BIT;
+		tag32 = PSMX2_IOV_BIT;
 		len = (3 + real_count) * sizeof(uint32_t);
 	}
 
 	av = ep_priv->av;
 	if (av && PSMX2_SEP_ADDR_TEST(dest_addr)) {
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
-		vlane = 0;
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
 		if ((err = psmx2_av_check_table_idx(av, idx))) {
@@ -996,13 +940,10 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 		}
 
 		psm2_epaddr = av->epaddrs[idx];
-		vlane = av->vlanes[idx];
 	} else  {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
-		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 
-	tag32 = PSMX2_TAG32(tag32_base, ep_priv->vlane, vlane);
 	PSMX2_SET_TAG(psm2_tag, tag, tag32);
 
 	if ((flags & PSMX2_NO_COMPLETION) ||
@@ -1069,7 +1010,7 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 		PSMX2_CTXT_TYPE(fi_context) = PSMX2_IOV_SEND_CONTEXT;
 		PSMX2_CTXT_USER(fi_context) = req;
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
-		tag32 = PSMX2_TAG32(0, ep_priv->vlane, vlane);
+		tag32 = 0;
 		PSMX2_TAG32_SET_SEQ(tag32, req->iov_info.seq_num);
 		PSMX2_SET_TAG(psm2_tag, tag, tag32);
 		for (i=0; i<count; i++) {

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -56,10 +56,10 @@ static ssize_t psmx2_tagged_peek_generic(struct fid_ep *ep,
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
-			if ((err = psmx2_av_check_table_idx(av, idx)))
+			if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 				return err;
 
-			psm2_epaddr = av->epaddrs[idx];
+			psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 		} else {
 			psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
 		}
@@ -271,10 +271,10 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 		} else if (av && av->type == FI_AV_TABLE) {
 			idx = (size_t)src_addr;
-			if ((err = psmx2_av_check_table_idx(av, idx)))
+			if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 				return err;
 
-			psm2_epaddr = av->epaddrs[idx];
+			psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 		} else {
 			psm2_epaddr = PSMX2_ADDR_TO_EP(src_addr);
 		}
@@ -344,10 +344,10 @@ psmx2_tagged_recv_specialized(struct fid_ep *ep, void *buf, size_t len,
 				psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, src_addr);
 			} else {
 				idx = (size_t)src_addr;
-				if ((err = psmx2_av_check_table_idx(av, idx)))
+				if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 					return err;
 
-				psm2_epaddr = av->epaddrs[idx];
+				psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 			}
 		}
 	} else {
@@ -587,10 +587,10 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx)))
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 			return err;
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
 	}
@@ -687,10 +687,10 @@ psmx2_tagged_send_specialized(struct fid_ep *ep, const void *buf,
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		} else {
 			idx = (size_t)dest_addr;
-			if ((err = psmx2_av_check_table_idx(av, idx)))
+			if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 				return err;
 
-			psm2_epaddr = av->epaddrs[idx];
+			psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 		}
 	}
 
@@ -794,10 +794,10 @@ psmx2_tagged_inject_specialized(struct fid_ep *ep, const void *buf,
 			psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 		} else {
 			idx = (size_t)dest_addr;
-			if ((err = psmx2_av_check_table_idx(av, idx)))
+			if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx)))
 				return err;
 
-			psm2_epaddr = av->epaddrs[idx];
+			psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 		}
 	}
 
@@ -934,12 +934,12 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 		psm2_epaddr = psmx2_av_translate_sep(av, ep_priv->trx_ctxt, dest_addr);
 	} else  if (av && av->type == FI_AV_TABLE) {
 		idx = (size_t)dest_addr;
-		if ((err = psmx2_av_check_table_idx(av, idx))) {
+		if ((err = psmx2_av_check_table_idx(av, ep_priv->trx_ctxt, idx))) {
 			free(req);
 			return err;
 		}
 
-		psm2_epaddr = av->epaddrs[idx];
+		psm2_epaddr = av->tables[ep_priv->trx_ctxt->id].epaddrs[idx];
 	} else  {
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
 	}


### PR DESCRIPTION
This patch series rework the regular endpoint implementation to use separate PSM2 endpoints for different OFI endpoints instead of sharing a single PSM2 endpoint via the "virtual lane" mechanism. The address vector implementation is also updated to accommodate the change.
