### PR TITLE
prov/util,rxm: Fix race condition issue in util cmap

### DIFF
--- a/include/fi_indexer.h
+++ b/include/fi_indexer.h
@@ -45,7 +45,7 @@
  * indexer by setting free_list and size to 0.
  */
 
-union ofi_idx_entry {
+struct ofi_idx_entry {
 	void *item;
 	int   next;
 };
@@ -58,9 +58,10 @@ union ofi_idx_entry {
 
 struct indexer
 {
-	union ofi_idx_entry *array[OFI_IDX_ARRAY_SIZE];
-	int		 free_list;
-	int		 size;	/* Array size (used): [0, OFI_IDX_ARRAY_SIZE) */
+	struct ofi_idx_entry 	*array[OFI_IDX_ARRAY_SIZE];
+	int		 	free_list;
+	/* Array size (used): [0, OFI_IDX_ARRAY_SIZE) */
+	int		 	size;
 };
 
 #define ofi_idx_array_index(index) (index >> OFI_IDX_ENTRY_BITS)

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -429,7 +429,8 @@ int ofi_av_get_index(struct util_av *av, const void *addr);
 
 // TODO explore replacing this with a simple connection hash map that is common
 // for both AV and RX only connections.
-#define UTIL_CMAP_IDX_BITS 48
+
+#define UTIL_CMAP_IDX_BITS OFI_IDX_INDEX_BITS
 
 enum ofi_cmap_signal {
 	OFI_CMAP_FREE,

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -43,16 +43,8 @@ static struct rxm_conn *rxm_key2conn(struct rxm_ep *rxm_ep, uint64_t key)
 {
 	struct util_cmap_handle *handle;
 	handle = ofi_cmap_key2handle(rxm_ep->util_ep.cmap, key);
-	if (!handle) {
-		FI_WARN(&rxm_prov, FI_LOG_CQ, "Can't find handle!\n");
+	if (!handle)
 		return NULL;
-	}
-	if (handle->key != key) {
-		FI_WARN(&rxm_prov, FI_LOG_CQ,
-				"handle->key not matching with given key!\n");
-		return NULL;
-	}
-
 	return container_of(handle, struct rxm_conn, handle);
 }
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -517,7 +517,9 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	}
 }
 
-static ssize_t rxm_cq_read(struct fid_cq *msg_cq, struct fi_cq_tagged_entry *comp)
+static ssize_t rxm_cq_write_error(struct fid_cq *msg_cq,
+				  struct fi_cq_tagged_entry *comp,
+				  int err)
 {
 	struct rxm_tx_entry *tx_entry;
 	struct rxm_rx_buf *rx_buf;
@@ -526,21 +528,21 @@ static ssize_t rxm_cq_read(struct fid_cq *msg_cq, struct fi_cq_tagged_entry *com
 	void *op_context;
 	ssize_t ret;
 
-	ret = fi_cq_read(msg_cq, comp, 1);
-	if (ret >= 0 || ret == -FI_EAGAIN)
-		return ret;
-
 	op_context = comp->op_context;
 	memset(&err_entry, 0, sizeof(err_entry));
 
-	if (ret == -FI_EAVAIL) {
-		OFI_CQ_READERR(&rxm_prov, FI_LOG_CQ, msg_cq,
-				ret, err_entry);
-		if (ret < 0)
+	if (err == -FI_EAVAIL) {
+		OFI_CQ_READERR(&rxm_prov, FI_LOG_CQ, msg_cq, ret, err_entry);
+		if (ret < 0) {
 			FI_WARN(&rxm_prov, FI_LOG_CQ,
 					"Unable to fi_cq_readerr on msg cq\n");
-		else
+			err_entry.prov_errno = ret;
+			err = ret;
+		} else {
 			op_context = err_entry.op_context;
+		}
+	} else {
+		err_entry.prov_errno = err;
 	}
 
 	switch (RXM_GET_PROTO_STATE(comp)) {
@@ -560,11 +562,11 @@ static ssize_t rxm_cq_read(struct fid_cq *msg_cq, struct fi_cq_tagged_entry *com
 		break;
 	default:
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Invalid state!\n");
-		FI_WARN(&rxm_prov, FI_LOG_CQ, "msg cq readerr: %s\n",
+		if (err == -FI_EAVAIL)
+			FI_WARN(&rxm_prov, FI_LOG_CQ, "msg cq error info: %s\n",
 				fi_cq_strerror(msg_cq, err_entry.prov_errno,
-					err_entry.err_data, NULL, 0));
-		assert(0);
-		return err_entry.err;
+					       err_entry.err_data, NULL, 0));
+		return -FI_EOPBADSTATE;
 	}
 	return ofi_cq_write_error(util_cq, &err_entry);
 }
@@ -576,7 +578,7 @@ void rxm_cq_progress(struct rxm_ep *rxm_ep)
 	size_t comp_read = 0;
 
 	do {
-		ret = rxm_cq_read(rxm_ep->msg_cq, &comp);
+		ret = fi_cq_read(rxm_ep->msg_cq, &comp, 1);
 		if (ret == -FI_EAGAIN)
 			break;
 
@@ -592,7 +594,8 @@ void rxm_cq_progress(struct rxm_ep *rxm_ep)
 	} while (comp_read < rxm_ep->comp_per_progress);
 	return;
 err:
-	// TODO report error on RXM EP/domain since EP/CQ is broken.
+	if (rxm_cq_write_error(rxm_ep->msg_cq, &comp, ret))
+		assert(0);
 	return;
 }
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1052,13 +1052,14 @@ int ip_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
  * Connection map
  */
 
-/* Note: Callers should serialize access */
+/* Caller should hold cmap->lock */
 static void util_cmap_set_key(struct util_cmap_handle *handle)
 {
 	handle->key = ofi_idx2key(&handle->cmap->key_idx,
 		ofi_idx_insert(&handle->cmap->handles_idx, handle));
 }
 
+/* Caller should hold cmap->lock */
 static void util_cmap_clear_key(struct util_cmap_handle *handle)
 {
 	int index = ofi_key2idx(&handle->cmap->key_idx, handle->key);
@@ -1073,6 +1074,7 @@ struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t ke
 {
 	struct util_cmap_handle *handle;
 
+	fastlock_acquire(&cmap->lock);
 	if (!(handle = ofi_idx_lookup(&cmap->handles_idx,
 				      ofi_key2idx(&cmap->key_idx, key)))) {
 		FI_WARN(cmap->av->prov, FI_LOG_AV, "Invalid key!\n");
@@ -1080,9 +1082,10 @@ struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t ke
 		if (handle->key != key) {
 			FI_WARN(cmap->av->prov, FI_LOG_AV,
 				"handle->key not matching given key\n");
-			return NULL;
+			handle = NULL;
 		}
 	}
+	fastlock_release(&cmap->lock);
 	return handle;
 }
 

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -54,13 +54,13 @@
 
 static int ofi_idx_grow(struct indexer *idx)
 {
-	union ofi_idx_entry *entry;
+	struct ofi_idx_entry *entry;
 	int i, start_index;
 
 	if (idx->size >= OFI_IDX_ARRAY_SIZE)
 		goto nomem;
 
-	idx->array[idx->size] = calloc(OFI_IDX_ENTRY_SIZE, sizeof(union ofi_idx_entry));
+	idx->array[idx->size] = calloc(OFI_IDX_ENTRY_SIZE, sizeof(struct ofi_idx_entry));
 	if (!idx->array[idx->size])
 		goto nomem;
 
@@ -85,7 +85,7 @@ nomem:
 
 int ofi_idx_insert(struct indexer *idx, void *item)
 {
-	union ofi_idx_entry *entry;
+	struct ofi_idx_entry *entry;
 	int index;
 
 	if ((index = idx->free_list) == 0) {
@@ -101,19 +101,21 @@ int ofi_idx_insert(struct indexer *idx, void *item)
 
 void *ofi_idx_remove(struct indexer *idx, int index)
 {
-	union ofi_idx_entry *entry;
+	struct ofi_idx_entry *entry;
 	void *item;
+	int entry_index = ofi_idx_entry_index(index);
 
 	entry = idx->array[ofi_idx_array_index(index)];
-	item = entry[ofi_idx_entry_index(index)].item;
-	entry[ofi_idx_entry_index(index)].next = idx->free_list;
+	item = entry[entry_index].item;
+	entry[entry_index].item = NULL;
+	entry[entry_index].next = idx->free_list;
 	idx->free_list = index;
 	return item;
 }
 
 void ofi_idx_replace(struct indexer *idx, int index, void *item)
 {
-	union ofi_idx_entry *entry;
+	struct ofi_idx_entry *entry;
 
 	entry = idx->array[ofi_idx_array_index(index)];
 	entry[ofi_idx_entry_index(index)].item = item;


### PR DESCRIPTION
The issue was originally observed when running ofi_rxm over sockets provider in travis CI.

This PR contains the following patches:

- common: update indexer entry to struct
- prov/util: Fix # of bits used for connection index
- prov/util: rename function names to align with naming for static functions
- prov/rxm: Serialize access to cmap key_idx
- prov/rxm: improve CQ error handling