### PR TITLE
 util: Add Memory monitor and Rename MR to MR map

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017 Intel Corporation, Inc. All right reserved.
 #
 # Makefile.am for libfabric
 
@@ -36,30 +37,31 @@ rdmaincludedir = $(includedir)/rdma
 rdmainclude_HEADERS =
 
 # internal utility functions shared by in-tree providers:
-common_srcs = \
-	src/common.c \
-	src/enosys.c \
-	src/rbtree.c \
-	src/fasthash.c \
-	src/indexer.c \
-	src/iov.c \
-	prov/util/src/util_atomic.c \
-	prov/util/src/util_attr.c   \
-	prov/util/src/util_av.c     \
-	prov/util/src/util_cq.c     \
-	prov/util/src/util_cntr.c   \
-	prov/util/src/util_domain.c \
-	prov/util/src/util_ep.c     \
-	prov/util/src/util_pep.c     \
-	prov/util/src/util_eq.c     \
-	prov/util/src/util_fabric.c \
-	prov/util/src/util_main.c   \
-	prov/util/src/util_poll.c   \
-	prov/util/src/util_wait.c   \
-	prov/util/src/util_buf.c    \
-	prov/util/src/util_mr.c     \
-	prov/util/src/util_ns.c     \
-	prov/util/src/util_shm.c
+common_srcs =				\
+	src/common.c			\
+	src/enosys.c			\
+	src/rbtree.c			\
+	src/fasthash.c			\
+	src/indexer.c			\
+	src/iov.c			\
+	prov/util/src/util_atomic.c	\
+	prov/util/src/util_attr.c	\
+	prov/util/src/util_av.c		\
+	prov/util/src/util_cq.c		\
+	prov/util/src/util_cntr.c	\
+	prov/util/src/util_domain.c	\
+	prov/util/src/util_ep.c		\
+	prov/util/src/util_pep.c	\
+	prov/util/src/util_eq.c		\
+	prov/util/src/util_fabric.c	\
+	prov/util/src/util_main.c	\
+	prov/util/src/util_poll.c	\
+	prov/util/src/util_wait.c	\
+	prov/util/src/util_buf.c	\
+	prov/util/src/util_mr.c		\
+	prov/util/src/util_ns.c		\
+	prov/util/src/util_shm.c	\
+	prov/util/src/util_mem_monitor.c
 
 if MACOS
 common_srcs += src/unix/osd.c
@@ -102,34 +104,35 @@ util_fi_pingpong_SOURCES = \
 util_fi_pingpong_LDADD = $(linkback)
 
 nodist_src_libfabric_la_SOURCES =
-src_libfabric_la_SOURCES = \
-	include/fi.h \
-	include/fi_abi.h \
-	include/fi_atom.h \
-	include/fi_enosys.h \
-	include/fi_file.h \
-	include/fi_indexer.h \
-	include/fi_iov.h \
-	include/fi_list.h \
-	include/fi_lock.h \
-	include/fi_mem.h \
-	include/fi_osd.h \
-	include/fi_proto.h \
-	include/fi_rbuf.h \
-	include/fi_shm.h \
-	include/fi_signal.h \
-	include/fi_util.h \
-	include/ofi_atomic.h \
-	include/fasthash.h \
-	include/rbtree.h \
-	include/prov.h \
-	include/rdma/providers/fi_log.h \
-	include/rdma/providers/fi_prov.h \
-	src/fabric.c \
-	src/fi_tostr.c \
-	src/log.c \
-	src/var.c \
-	src/abi_1_0.c \
+src_libfabric_la_SOURCES =			\
+	include/fi.h				\
+	include/fi_abi.h			\
+	include/fi_atom.h			\
+	include/fi_enosys.h			\
+	include/fi_file.h			\
+	include/fi_indexer.h			\
+	include/fi_iov.h			\
+	include/fi_list.h			\
+	include/fi_lock.h			\
+	include/fi_mem.h			\
+	include/fi_osd.h			\
+	include/fi_proto.h			\
+	include/fi_rbuf.h			\
+	include/fi_shm.h			\
+	include/fi_signal.h			\
+	include/fi_util.h			\
+	include/ofi_atomic.h			\
+	include/ofi_mr.h			\
+	include/fasthash.h			\
+	include/rbtree.h			\
+	include/prov.h				\
+	include/rdma/providers/fi_log.h		\
+	include/rdma/providers/fi_prov.h	\
+	src/fabric.c				\
+	src/fi_tostr.c				\
+	src/log.c				\
+	src/var.c				\
+	src/abi_1_0.c				\
 	$(common_srcs)
 
 src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -58,7 +58,7 @@ common_srcs =				\
 	prov/util/src/util_poll.c	\
 	prov/util/src/util_wait.c	\
 	prov/util/src/util_buf.c	\
-	prov/util/src/util_mr.c		\
+	prov/util/src/util_mr_map.c	\
 	prov/util/src/util_ns.c		\
 	prov/util/src/util_shm.c	\
 	prov/util/src/util_mem_monitor.c

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017 Intel Corporation, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _OFI_MR_H_
+#define _OFI_MR_H_
+
+#if HAVE_CONFIG_H
+#  include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <inttypes.h>
+
+#include <fi.h>
+#include <fi_atom.h>
+#include <fi_lock.h>
+#include <fi_list.h>
+
+/*
+ * Memory notifier - Report memory mapping changes to address ranges
+ */
+
+struct ofi_subscription;
+struct ofi_notification_queue;
+
+struct ofi_mem_monitor {
+	ofi_atomic32_t			refcnt;
+
+	int (*subscribe)(struct ofi_mem_monitor *notifier, void *addr,
+			 size_t len, struct ofi_subscription *subscription);
+	void (*unsubscribe)(struct ofi_mem_monitor *notifier, void *addr,
+			    size_t len, struct ofi_subscription *subscription);
+	struct ofi_subscription *(*get_event)(struct ofi_mem_monitor *notifier);
+};
+
+struct ofi_notification_queue {
+	struct ofi_mem_monitor		*monitor;
+	fastlock_t			lock;
+	struct dlist_entry		list;
+	int				refcnt;
+};
+
+struct ofi_subscription {
+	struct ofi_notification_queue	*nq;
+	struct dlist_entry		entry;
+};
+
+void ofi_monitor_init(struct ofi_mem_monitor *monitor);
+void ofi_monitor_cleanup(struct ofi_mem_monitor *monitor);
+void ofi_monitor_add_queue(struct ofi_mem_monitor *monitor,
+			   struct ofi_notification_queue *nq);
+void ofi_monitor_del_queue(struct ofi_notification_queue *nq);
+
+int ofi_monitor_subscribe(struct ofi_notification_queue *nq,
+			  void *addr, size_t len,
+			  struct ofi_subscription *subscription);
+void ofi_monitor_unsubscribe(void *addr, size_t len,
+			      struct ofi_subscription *subscription);
+struct ofi_subscription *ofi_monitor_get_event(struct ofi_notification_queue *nq);
+
+#endif /* _OFI_MR_H_ */

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug-ICC|x64">
@@ -523,7 +523,7 @@
     <ClCompile Include="prov\util\src\util_eq.c" />
     <ClCompile Include="prov\util\src\util_fabric.c" />
     <ClCompile Include="prov\util\src\util_main.c" />
-    <ClCompile Include="prov\util\src\util_mr.c" />
+    <ClCompile Include="prov\util\src\util_mr_map.c" />
     <ClCompile Include="prov\util\src\util_ns.c" />
     <ClCompile Include="prov\util\src\util_poll.c" />
     <ClCompile Include="prov\util\src\util_wait.c" />

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug-ICC|x64">
@@ -527,6 +527,7 @@
     <ClCompile Include="prov\util\src\util_ns.c" />
     <ClCompile Include="prov\util\src\util_poll.c" />
     <ClCompile Include="prov\util\src\util_wait.c" />
+    <ClCompile Include="prov\util\src\util_mem_monitor.c" />
     <ClCompile Include="src\common.c" />
     <ClCompile Include="src\enosys.c">
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug-ICC|x64'">4127;869</DisableSpecificWarnings>
@@ -548,6 +549,7 @@
     <ClInclude Include="include\fi_abi.h" />
     <ClInclude Include="include\fi_atom.h" />
     <ClInclude Include="include\ofi_atomic.h" />
+    <ClInclude Include="include\ofi_mr.h" />
     <ClInclude Include="include\fi_enosys.h" />
     <ClInclude Include="include\fi_file.h" />
     <ClInclude Include="include\fi_indexer.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -219,9 +219,6 @@
     <ClCompile Include="prov\util\src\util_ep.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
-    <ClCompile Include="prov\util\src\util_mr.c">
-      <Filter>Source Files\prov\util</Filter>
-    </ClCompile>
     <ClCompile Include="prov\udp\src\udpx_attr.c">
       <Filter>Source Files\prov\udp\src</Filter>
     </ClCompile>
@@ -351,14 +348,17 @@
     <ClCompile Include="prov\util\src\util_ns.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
-    <ClCompile Include="prov\util\src\util_atomic.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="prov\util\src\util_cntr.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
     <ClCompile Include="prov\rxd\src\rxd_cntr.c">
       <Filter>Source Files\prov\rxd\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\util\src\util_atomic.c">
+      <Filter>Source Files\prov\util</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\util\src\util_mr_map.c">
+      <Filter>Source Files\prov\util</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -145,6 +145,9 @@
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
     <ClCompile Include="prov\util\src\util_wait.c">
+      <Filter>Source Files\prov\util</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\util\src\util_mem_monitor.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
     <ClCompile Include="src\windows\osd.c">
@@ -546,6 +549,9 @@
       <Filter>Header Files\windows</Filter>
     </ClInclude>
     <ClInclude Include="include\ofi_atomic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\ofi_mr.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -94,7 +94,7 @@ static int rxd_mr_close(struct fid *fid)
 	dom = mr->domain;
 
 	fastlock_acquire(&dom->util_domain.lock);
-	err = ofi_mr_remove(&dom->mr_map, mr->key);
+	err = ofi_mr_map_remove(&dom->mr_map, mr->key);
 	fastlock_release(&dom->util_domain.lock);
 	if (err)
 		return err;
@@ -138,7 +138,7 @@ static int rxd_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	_mr->domain = dom;
 	_mr->flags = flags;
 
-	ret = ofi_mr_insert(&dom->mr_map, attr, &key, _mr);
+	ret = ofi_mr_map_insert(&dom->mr_map, attr, &key, _mr);
 	if (ret != 0) {
 		goto err;
 	}
@@ -198,8 +198,8 @@ int rxd_mr_verify(struct rxd_domain *rxd_domain, ssize_t len,
 	int ret;
 
 	fastlock_acquire(&rxd_domain->util_domain.lock);
-	ret = ofi_mr_verify(&rxd_domain->mr_map, io_addr, len,
-		    key, access, NULL);
+	ret = ofi_mr_map_verify(&rxd_domain->mr_map, io_addr, len,
+				key, access, NULL);
 	fastlock_release(&rxd_domain->util_domain.lock);
 	return ret;
 }

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -51,13 +51,14 @@
 
 #include <fi.h>
 #include <ofi_atomic.h>
+#include <ofi_mr.h>
 #include <fi_enosys.h>
 #include <fi_indexer.h>
 #include <fi_rbuf.h>
 #include <fi_list.h>
 #include <fi_file.h>
 #include <fi_osd.h>
-#include "fi_util.h"
+#include <fi_util.h>
 
 #ifndef _SOCK_H_
 #define _SOCK_H_

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -199,7 +199,7 @@ static int sock_mr_close(struct fid *fid)
 	dom = mr->domain;
 
 	fastlock_acquire(&dom->lock);
-	err = ofi_mr_remove(&dom->mr_map, mr->key);
+	err = ofi_mr_map_remove(&dom->mr_map, mr->key);
 	if (err != 0)
 		SOCK_LOG_ERROR("MR Erase error %d \n", err);
 
@@ -257,7 +257,7 @@ struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint64_t key,
 
 	fastlock_acquire(&domain->lock);
 
-	err = ofi_mr_verify(&domain->mr_map, buf, len, key, access, (void **) &mr);
+	err = ofi_mr_map_verify(&domain->mr_map, buf, len, key, access, (void **) &mr);
 	if (err != 0) {
 		SOCK_LOG_ERROR("MR check failed\n");
 		mr = NULL;
@@ -304,7 +304,7 @@ static int sock_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	_mr->domain = dom;
 	_mr->flags = flags;
 
-	ret = ofi_mr_insert(&dom->mr_map, attr, &key, _mr);
+	ret = ofi_mr_map_insert(&dom->mr_map, attr, &key, _mr);
 	if (ret != 0)
 		goto err;
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -319,7 +319,8 @@ static void sock_pe_report_mr_completion(struct sock_domain *domain,
 
 	for (i = 0; i < pe_entry->msg_hdr.dest_iov_len; i++) {
 		fastlock_acquire(&domain->lock);
-		mr = ofi_mr_get(&domain->mr_map, pe_entry->pe.rx.rx_iov[i].iov.key);
+		mr = ofi_mr_map_get(&domain->mr_map,
+				    pe_entry->pe.rx.rx_iov[i].iov.key);
 		fastlock_release(&domain->lock);
 		if (!mr || (!mr->cq && !mr->cntr))
 			continue;

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2017 Cray Inc. All rights reserved.
+ * Copyright (c) 2017 Intel Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <ofi_mr.h>
+
+
+void ofi_monitor_init(struct ofi_mem_monitor *monitor)
+{
+	ofi_atomic_initialize32(&monitor->refcnt, 0);
+}
+
+void ofi_monitor_cleanup(struct ofi_mem_monitor *monitor)
+{
+	assert(ofi_atomic_get32(&monitor->refcnt) == 0);
+}
+
+void ofi_monitor_add_queue(struct ofi_mem_monitor *monitor,
+			   struct ofi_notification_queue *nq)
+{
+	fastlock_init(&nq->lock);
+	dlist_init(&nq->list);
+	nq->refcnt = 0;
+
+	nq->monitor = monitor;
+	ofi_atomic_inc32(&monitor->refcnt);
+}
+
+void ofi_monitor_del_queue(struct ofi_notification_queue *nq)
+{
+	assert(dlist_empty(&nq->list) && (nq->refcnt == 0));
+	ofi_atomic_dec32(&nq->monitor->refcnt);
+	fastlock_destroy(&nq->lock);
+}
+
+int ofi_monitor_subscribe(struct ofi_notification_queue *nq,
+			  void *addr, size_t len,
+			  struct ofi_subscription *subscription)
+{
+	int ret;
+
+	FI_DBG(&core_prov, FI_LOG_MR,
+	       "subscribing addr=%p len=%zu subscription=%p nq=%p\n",
+	       addr, len, subscription, nq);
+
+	/* Ensure the subscription is initialized before we can get events */
+	dlist_init(&subscription->entry);
+	subscription->nq = nq;
+	fastlock_acquire(&nq->lock);
+	nq->refcnt++;
+	fastlock_release(&nq->lock);
+
+	ret = nq->monitor->subscribe(nq->monitor, addr, len, subscription);
+	if (OFI_UNLIKELY(ret)) {
+		FI_WARN(&core_prov, FI_LOG_MR,
+			"Failed (ret = %d) to monitor addr=%p len=%zu",
+			ret, addr, len);
+		fastlock_acquire(&nq->lock);
+		nq->refcnt--;
+		fastlock_release(&nq->lock);
+	}
+	return ret;
+}
+
+void ofi_monitor_unsubscribe(void *addr, size_t len,
+			     struct ofi_subscription *subscription)
+{
+	subscription->nq->monitor->unsubscribe(subscription->nq->monitor,
+						addr, len, subscription);
+	fastlock_acquire(&subscription->nq->lock);
+	dlist_remove_init(&subscription->entry);
+	subscription->nq->refcnt--;
+	fastlock_release(&subscription->nq->lock);
+}
+
+static void util_monitor_read_events(struct ofi_mem_monitor *monitor)
+{
+	struct ofi_subscription *subscription;
+
+	do {
+		subscription = monitor->get_event(monitor);
+		if (!subscription) {
+			FI_DBG(&core_prov, FI_LOG_MR,
+			       "no more events to be read\n");
+			break;
+		}
+
+		FI_DBG(&core_prov, FI_LOG_MR,
+		       "found event, context=%p nq=%p\n",
+		       subscription, subscription->nq);
+
+		fastlock_acquire(&subscription->nq->lock);
+		if (dlist_empty(&subscription->entry))
+			dlist_insert_tail(&subscription->entry,
+					  &subscription->nq->list);
+		fastlock_release(&subscription->nq->lock);
+	} while (1);
+}
+
+struct ofi_subscription *ofi_monitor_get_event(struct ofi_notification_queue *nq)
+{
+	struct ofi_subscription *subscription;
+
+	util_monitor_read_events(nq->monitor);
+
+	fastlock_acquire(&nq->lock);
+	if (!dlist_empty(&nq->list)) {
+		dlist_pop_front(&nq->list, struct ofi_subscription,
+				subscription, entry);
+		/* needed to protect against double insertions */
+		dlist_init(&subscription->entry);
+	} else {
+		subscription = NULL;
+	}
+	fastlock_release(&nq->lock);
+
+	return subscription;
+}

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <fi_enosys.h>
 #include <fi_util.h>
+#include <ofi_mr.h>
 #include <assert.h>
 #include <rbtree.h>
 
@@ -55,8 +56,8 @@ dup_mr_attr(const struct fi_mr_attr *attr)
 	return dup_attr;
 }
 
-int ofi_mr_insert(struct ofi_mr_map *map, const struct fi_mr_attr *attr,
-		  uint64_t *key, void *context)
+int ofi_mr_map_insert(struct ofi_mr_map *map, const struct fi_mr_attr *attr,
+		      uint64_t *key, void *context)
 {
 	struct fi_mr_attr *item;
 
@@ -83,7 +84,7 @@ int ofi_mr_insert(struct ofi_mr_map *map, const struct fi_mr_attr *attr,
 	return 0;
 }
 
-void *ofi_mr_get(struct ofi_mr_map *map, uint64_t key)
+void *ofi_mr_map_get(struct ofi_mr_map *map, uint64_t key)
 {
 	struct fi_mr_attr *attr;
 	void *itr, *key_ptr;
@@ -96,9 +97,9 @@ void *ofi_mr_get(struct ofi_mr_map *map, uint64_t key)
 	return attr->context;
 }
 
-int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
-		  size_t len, uint64_t key, uint64_t access,
-		  void **context)
+int ofi_mr_map_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
+		      size_t len, uint64_t key, uint64_t access,
+		      void **context)
 {
 	struct fi_mr_attr *attr;
 	void *itr, *key_ptr, *addr;
@@ -129,7 +130,7 @@ int ofi_mr_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 	return 0;
 }
 
-int ofi_mr_remove(struct ofi_mr_map *map, uint64_t key)
+int ofi_mr_map_remove(struct ofi_mr_map *map, uint64_t key)
 {
 	struct fi_mr_attr *attr;
 	void *itr, *key_ptr;


### PR DESCRIPTION
The intent of this patch is to move MR functionality from utility header-file to the separate header-file and add Memory monitor from the Sean's #3569 PR.
The patch consists from the 2 commits:
- Cherry-pick commit from #3569 
- Rename utility "MR" to "MR map"
-- Apply changes to the sockets provider
-- Apply changes to the rxd provider
 