### PR TITLE
Fix for #3557: prov/sockets: do not retry after epoll_wait()

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -205,6 +205,8 @@ struct sock_conn {
 struct sock_conn_map {
 	struct sock_conn *table;
 	fi_epoll_t epoll_set;
+	void **epoll_ctxs;
+	int epoll_ctxs_sz;
 	int used;
 	int size;
 	fastlock_t lock;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2344,19 +2344,30 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe,
 				  struct sock_ep_attr *ep_attr,
 				  struct sock_rx_ctx *rx_ctx)
 {
-	int ret = 0, i, num_fds;
+	int i, num_fds;
 	struct sock_conn *conn;
 	struct sock_conn_map *map;
-	void *ep_contexts[SOCK_EPOLL_WAIT_EVENTS];
 
 	map = &ep_attr->cmap;
 
 	if (!map->used)
 		return 0;
 
-epoll_wait_retry:
-	num_fds = fi_epoll_wait(map->epoll_set, ep_contexts,
-			SOCK_EPOLL_WAIT_EVENTS, 0);
+	/* Need to extend the number of contexts for epoll */
+	if (map->epoll_ctxs_sz < map->used) {
+		uint64_t new_size = map->used * 2;
+		map->epoll_ctxs = realloc(map->epoll_ctxs,
+		                          sizeof(*map->epoll_ctxs) * new_size);
+		if (!map->epoll_ctxs)
+		{
+			map->epoll_ctxs_sz = 0;
+			return -FI_ENOMEM;
+		}
+		map->epoll_ctxs_sz = new_size;
+	}
+
+	num_fds = fi_epoll_wait(map->epoll_set, map->epoll_ctxs,
+	                        map->used, 0);
 	if (num_fds < 0 || num_fds == 0) {
 		if (num_fds < 0)
 			SOCK_LOG_ERROR("poll failed: %d\n",
@@ -2366,7 +2377,7 @@ epoll_wait_retry:
 
 	fastlock_acquire(&map->lock);
 	for (i = 0; i < num_fds; i++) {
-		conn = ep_contexts[i];
+		conn = map->epoll_ctxs[i];
 		if (!conn)
 			SOCK_LOG_ERROR("ofi_idm_lookup failed\n");
 
@@ -2377,11 +2388,7 @@ epoll_wait_retry:
 	}
 	fastlock_release(&map->lock);
 
-	/* There is possibly more fds to progress */
-	if (num_fds == SOCK_EPOLL_WAIT_EVENTS)
-		goto epoll_wait_retry;
-
-	return ret;
+	return 0;
 }
 
 int sock_pe_progress_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx)


### PR DESCRIPTION
The epoll set 'map->epoll_set' is configured in level-triggered
mode, meaning that epoll_wait() will continue reporting events
for the monitored file descriptors until the file descriptors
that generated the events are effectively read.

We mustn't retry epoll_wait() if the returned value is equal to
the maximum number of events specified in arguments (32 by default),
otherwise the same events for the same file descriptors will be
indefinitely reported by epoll_wait(). This will cause libfabric
to allocate RX buffers in a loop, leading to the exhaustion of the
memory on the machine.

While this patch only allows 32 connections to be progressed at max
with a single call to sock_pe_progress_rx_ep(), multiple calls to
sock_pe_progress_rx_ep() should fairly progress all the connections
registered in the epoll set anyway.

This bug was introduced in d8ac992fd("prov/sockets: make use of the
common fi_epoll_* interface").

Fixes #3557

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>