### PR TITLE
prov/shm: create default endpoint name on init

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -147,6 +147,17 @@ struct smr_pending_queue {
 	dlist_func_t *match_msg;
 };
 
+struct smr_fabric {
+	struct util_fabric	util_fabric;
+	int			dom_idx;
+};
+
+struct smr_domain {
+	struct util_domain	util_domain;
+	int			dom_idx;
+	int			ep_idx;
+};
+
 struct smr_ep {
 	struct util_ep		util_ep;
 	smr_rx_comp_func	rx_comp;

--- a/prov/shm/src/smr_fabric.c
+++ b/prov/shm/src/smr_fabric.c
@@ -69,18 +69,20 @@ int smr_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		void *context)
 {
 	int ret;
-	struct util_fabric *util_fabric;
+	struct smr_fabric *smr_fabric;
 
-	util_fabric = calloc(1, sizeof(*util_fabric));
-	if (!util_fabric)
+	smr_fabric = calloc(1, sizeof(*smr_fabric));
+	if (!smr_fabric)
 		return -FI_ENOMEM;
 
 	ret = ofi_fabric_init(&smr_prov, smr_info.fabric_attr, attr,
-			      util_fabric, context);
-	if (ret)
+			      &smr_fabric->util_fabric, context);
+	if (ret) {
+		free(smr_fabric);
 		return ret;
+	}
 
-	*fabric = &util_fabric->fabric_fid;
+	*fabric = &smr_fabric->util_fabric.fabric_fid;
 	(*fabric)->fid.ops = &smr_fabric_fi_ops;
 	(*fabric)->ops = &smr_fabric_ops;
 	return 0;


### PR DESCRIPTION
- add domain and endpoint counters
- ep_name = pid:dom_idx:ep_idx
- can still call fi_setname, just setting default for easy initialization
- still assuming out-of-band endpoint name exchange (or fi_setname)

Signed-off-by: aingerson <alexia.ingerson@intel.com>