### PR TITLE
util: Fix coverity issue (false-positive actually)

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -49,7 +49,9 @@ void ofi_monitor_add_queue(struct ofi_mem_monitor *monitor,
 {
 	fastlock_init(&nq->lock);
 	dlist_init(&nq->list);
+	fastlock_acquire(&nq->lock);
 	nq->refcnt = 0;
+	fastlock_release(&nq->lock);
 
 	nq->monitor = monitor;
 	ofi_atomic_inc32(&monitor->refcnt);


### PR DESCRIPTION
Coverity complains that we initilaize ref_cnt w/o NQ::lock held - CID [209353]( https://u2389337.ct.sendgrid.net/wf/click?upn=08onrYu34A-2BWcWUl-2F-2BfV0V05UPxvVjWch-2Bd2MGckcRb-2FSCqabEQT-2FUiYsE2p3yBDPW9oUWfnyZHxURWIS0a-2FmYjzNXEAns846z0FmqumnYo-3D_eVm0CEQ-2FtI-2Fu8SBfRY9SEJtCLmujXF2YqcBkLxltbg0Wdak9HAiFB6Po7bD20JPqKiBgggxpE2-2Bj4B8RGr3ILoKPvEY0SYqZtivgw3r7L85AkYr48UiGYssR6m9YZo65-2FPPcL2vnuWeC2otr07Od2SqzCZhGQljZqaEP3xVJYqv88rDmDauPFeQbrBOgGOhsHgbMI3JBcDWaglpetHwQI2vN0NRO5E6x-2Foou2zpydcE-3D)

Seems it's false-positive. But anyway, it could be fixed easily instead of marking as false-positive. 

@shefty @jswaro What do you think?

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>