### PR TITLE
prov/psm,psm2: Enable ordering of RMA operations

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -97,7 +97,8 @@ extern int psmx_am_compat_mode;
 
 #define PSMX_MAX_MSG_SIZE	((0x1ULL << 32) - 1)
 #define PSMX_INJECT_SIZE	(64)
-#define PSMX_MSG_ORDER	FI_ORDER_SAS
+#define PSMX_MSG_ORDER	(FI_ORDER_SAS | FI_ORDER_RAR | FI_ORDER_RAW | \
+			 FI_ORDER_WAR | FI_ORDER_WAW)
 #define PSMX_COMP_ORDER	FI_ORDER_NONE
 
 #define PSMX_MSG_BIT	(0x1ULL << 63)
@@ -138,6 +139,7 @@ union psmx_pi {
 #define PSMX_AM_CHUNK_SIZE	2032	/* The maximum that's actually working:
 					 * 2032 for inter-node, 2072 for intra-node.
 					 */
+#define PSMX_RMA_ORDER_SIZE	PSMX_AM_CHUNK_SIZE
 
 #define PSMX_AM_OP_MASK		0x0000FFFF
 #define PSMX_AM_FLAG_MASK	0xFFFF0000

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -607,6 +607,9 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	psmx_info->ep_attr->protocol = FI_PROTO_PSMX;
 	psmx_info->ep_attr->protocol_version = PSM_VERNO;
 	psmx_info->ep_attr->max_msg_size = PSMX_MAX_MSG_SIZE;
+	psmx_info->ep_attr->max_order_raw_size = PSMX_RMA_ORDER_SIZE;
+	psmx_info->ep_attr->max_order_war_size = PSMX_RMA_ORDER_SIZE;
+	psmx_info->ep_attr->max_order_waw_size = PSMX_RMA_ORDER_SIZE;
 	psmx_info->ep_attr->mem_tag_format = fi_tag_format(max_tag_value);
 	psmx_info->ep_attr->tx_ctx_cnt = 1;
 	psmx_info->ep_attr->rx_ctx_cnt = 1;

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -97,7 +97,9 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_MAX_TRX_CTXT	(80)
 #define PSMX2_ALL_TRX_CTXT	((void *)-1)
 #define PSMX2_MAX_MSG_SIZE	((0x1ULL << 32) - 1)
-#define PSMX2_MSG_ORDER		FI_ORDER_SAS
+#define PSMX2_RMA_ORDER_SIZE	(4096)
+#define PSMX2_MSG_ORDER		(FI_ORDER_SAS | FI_ORDER_RAR | FI_ORDER_RAW | \
+				 FI_ORDER_WAR | FI_ORDER_WAW)
 #define PSMX2_COMP_ORDER	FI_ORDER_NONE
 
 #define PSMX2_MSG_BIT	(0x80000000)

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -658,6 +658,9 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->ep_attr->protocol = FI_PROTO_PSMX2;
 	psmx2_info->ep_attr->protocol_version = PSM2_VERNO;
 	psmx2_info->ep_attr->max_msg_size = PSMX2_MAX_MSG_SIZE;
+	psmx2_info->ep_attr->max_order_raw_size = PSMX2_RMA_ORDER_SIZE;
+	psmx2_info->ep_attr->max_order_war_size = PSMX2_RMA_ORDER_SIZE;
+	psmx2_info->ep_attr->max_order_waw_size = PSMX2_RMA_ORDER_SIZE;
 	psmx2_info->ep_attr->mem_tag_format = fi_tag_format(max_tag_value);
 	psmx2_info->ep_attr->tx_ctx_cnt = tx_ctx_cnt;
 	psmx2_info->ep_attr->rx_ctx_cnt = rx_ctx_cnt;


### PR DESCRIPTION
Previously the ordered sizes were set to 0 due to the existence of
multiple data transfer paths for RMA operations. However, according to
current fi_endpoint man page, to satisfy the data ordering requirement
only RMA operations under the provider defined threshold need to be
considered. As the result, the provider can declare ordering of RMA
operations that take the small-size message path.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>