### PR TITLE
prov/sockets: do not retry after epoll_wait()

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -200,6 +200,8 @@ struct sock_conn {
 struct sock_conn_map {
 	struct sock_conn *table;
 	fi_epoll_t epoll_set;
+	void **epoll_ctxs;
+	int epoll_ctxs_sz;
 	int used;
 	int size;
 	fastlock_t lock;


### PR DESCRIPTION
The epoll set 'map->epoll_set' is configured in level-triggered
mode, meaning that epoll_wait() will continue reporting events
for the monitored file descriptors until the file descriptors
that generated the events are effectively read.

We mustn't retry epoll_wait() if the returned value is equal to
the maximum number of events specified in arguments (32 by default),
otherwise the same events for the same file descriptors will be
indefinitely reported by epoll_wait(). This will cause libfabric
to allocate RX buffers in a loop, leading to the exhaustion of the
memory on the machine.

The patch dynamically resizes the array of epoll contexts to match
the number of connections ysed in the connection map.
Array resizing for the epoll contexts must be done in
sock_pe_progress_rx_ep() and not in sock_conn_map_increase() as we
need to make sure that the epoll contexts are not altered while
fi_epoll_wait() is using them.

This bug was introduced in d8ac992fd("prov/sockets: make use of the
common fi_epoll_* interface").

Fixes #3557

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>

Updated PR #3584 to handle realloc failures