### PR TITLE
man: Clarify cq op_context is not valid for RMA writedata

### DIFF
--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -444,7 +444,14 @@ of these fields are the same for all CQ entry structure formats.
 *op_context*
 : The operation context is the application specified context value that
   was provided with an asynchronous operation.  The op_context field is
-  valid for all completions.
+  valid for all completions that are associated with an asynchronous
+  operation.
+  
+  For completion events that are not associated with a posted operation,
+  this field will be set to NULL.  This includes completions generated
+  at the target in response to RMA write operations that carry CQ data
+  (FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA flags set), when the FI_RX_CQ_DATA
+  mode bit is not required.
 
 *flags*
 : This specifies flags associated with the completed operation.  The


### PR DESCRIPTION
RMA writedata calls that generate a completion at the target
do not have an op_context available to return as part of a
completion unless FI_RX_CQ_DATA is set.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>