### PR TITLE
prov/psm2: Add option to include PSM2 library source and use link time optimization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,7 @@ AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects parallel-tests tar-ustar])
+AM_PROG_AS()
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 AC_CANONICAL_HOST

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -49,6 +49,12 @@
 #define FI_DEPRECATED_FIELD
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#define EXTERNALLY_VISIBLE externally_visible
+#else
+#define EXTERNALLY_VISIBLE
+#endif
+
 #if defined(_WIN32)
 #include <BaseTsd.h>
 #include <windows.h>

--- a/include/rdma/providers/fi_prov.h
+++ b/include/rdma/providers/fi_prov.h
@@ -57,7 +57,8 @@ extern "C" {
  * is loaded.
  */
 #define FI_EXT_INI \
-	__attribute__((visibility ("default"))) struct fi_provider* fi_prov_ini(void)
+	__attribute__((visibility ("default"),EXTERNALLY_VISIBLE)) \
+	struct fi_provider* fi_prov_ini(void)
 
 struct fi_provider {
 	uint32_t version;

--- a/prov/psm2/Makefile.include
+++ b/prov/psm2/Makefile.include
@@ -19,10 +19,152 @@ _psm2_files = \
 	prov/psm2/src/psmx2_wait.c \
 	prov/psm2/src/psmx2_util.c
 
+if HAVE_PSM2_SRC
+nodist_libpsmx2_fi_la_SOURCES = \
+	prov/psm2/src/psm2_revision.c \
+	prov/psm2/src/psm2/psm_am.c \
+	prov/psm2/src/psm2/psm2_am.h \
+	prov/psm2/src/psm2/psm_am_internal.h \
+	prov/psm2/src/psm2/psm.c \
+	prov/psm2/src/psm2/psm2.h \
+	prov/psm2/src/psm2/psm_context.c \
+	prov/psm2/src/psm2/psm_context.h \
+	prov/psm2/src/psm2/psm_diags.c \
+	prov/psm2/src/psm2/psm_ep.c \
+	prov/psm2/src/psm2/psm_ep.h \
+	prov/psm2/src/psm2/psm_ep_connect.c \
+	prov/psm2/src/psm2/psm_error.c \
+	prov/psm2/src/psm2/psm_error.h \
+	prov/psm2/src/psm2/psm_help.h \
+	prov/psm2/src/psm2/psm_lock.h \
+	prov/psm2/src/psm2/psm_log.h \
+	prov/psm2/src/psm2/psm_memcpy.c \
+	prov/psm2/src/psm2/psm_mock.c \
+	prov/psm2/src/psm2/psm_mpool.c \
+	prov/psm2/src/psm2/psm_mpool.h \
+	prov/psm2/src/psm2/psm_mq.c \
+	prov/psm2/src/psm2/psm2_mq.h \
+	prov/psm2/src/psm2/psm_mq_internal.h \
+	prov/psm2/src/psm2/psm_mq_recv.c \
+	prov/psm2/src/psm2/psm_mq_utils.c \
+	prov/psm2/src/psm2/psm_perf.c \
+	prov/psm2/src/psm2/psm_perf.h \
+	prov/psm2/src/psm2/psm_stats.c \
+	prov/psm2/src/psm2/psm_stats.h \
+	prov/psm2/src/psm2/psm_sysbuf.c \
+	prov/psm2/src/psm2/psm_sysbuf.h \
+	prov/psm2/src/psm2/psm_timer.c \
+	prov/psm2/src/psm2/psm_timer.h \
+	prov/psm2/src/psm2/psm_user.h \
+	prov/psm2/src/psm2/psm_utils.c \
+	prov/psm2/src/psm2/psm_utils.h \
+	prov/psm2/src/psm2/ptl.h \
+	prov/psm2/src/psm2/psmi_wrappers.c \
+	prov/psm2/src/psm2/psmi_wrappers.h \
+	prov/psm2/src/psm2/ptl_am/am_cuda_memhandle_cache.c \
+	prov/psm2/src/psm2/ptl_am/am_cuda_memhandle_cache.h \
+	prov/psm2/src/psm2/ptl_am/am_reqrep.c \
+	prov/psm2/src/psm2/ptl_am/am_reqrep_shmem.c \
+	prov/psm2/src/psm2/ptl_am/cmarwu.c \
+	prov/psm2/src/psm2/ptl_am/cmarw.h \
+	prov/psm2/src/psm2/ptl_am/psm_am_internal.h \
+	prov/psm2/src/psm2/ptl_am/ptl.c \
+	prov/psm2/src/psm2/ptl_am/ptl_fwd.h \
+	prov/psm2/src/psm2/ptl_ips/ips_crc32.c \
+	prov/psm2/src/psm2/ptl_ips/ips_epstate.c \
+	prov/psm2/src/psm2/ptl_ips/ips_epstate.h \
+	prov/psm2/src/psm2/ptl_ips/ipserror.c \
+	prov/psm2/src/psm2/ptl_ips/ipserror.h \
+	prov/psm2/src/psm2/ptl_ips/ips_expected_proto.h \
+	prov/psm2/src/psm2/ptl_ips/ips_opp_path_rec.c \
+	prov/psm2/src/psm2/ptl_ips/ips_path_rec.c \
+	prov/psm2/src/psm2/ptl_ips/ips_path_rec.h \
+	prov/psm2/src/psm2/ptl_ips/ips_proto.c \
+	prov/psm2/src/psm2/ptl_ips/ips_proto.h \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_am.c \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_am.h \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_connect.c \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_dump.c \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_expected.c \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_header.h \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_help.h \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_internal.h \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_mq.c \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_params.h \
+	prov/psm2/src/psm2/ptl_ips/ips_proto_recv.c \
+	prov/psm2/src/psm2/ptl_ips/ips_recvhdrq.c \
+	prov/psm2/src/psm2/ptl_ips/ips_recvhdrq.h \
+	prov/psm2/src/psm2/ptl_ips/ips_recvq.c \
+	prov/psm2/src/psm2/ptl_ips/ips_recvq.h \
+	prov/psm2/src/psm2/ptl_ips/ips_scb.c \
+	prov/psm2/src/psm2/ptl_ips/ips_scb.h \
+	prov/psm2/src/psm2/ptl_ips/ips_spio.c \
+	prov/psm2/src/psm2/ptl_ips/ips_spio.h \
+	prov/psm2/src/psm2/ptl_ips/ips_stats.h \
+	prov/psm2/src/psm2/ptl_ips/ips_subcontext.c \
+	prov/psm2/src/psm2/ptl_ips/ips_subcontext.h \
+	prov/psm2/src/psm2/ptl_ips/ips_tid.c \
+	prov/psm2/src/psm2/ptl_ips/ips_tid.h \
+	prov/psm2/src/psm2/ptl_ips/ips_tidcache.c \
+	prov/psm2/src/psm2/ptl_ips/ips_tidcache.h \
+	prov/psm2/src/psm2/ptl_ips/ips_tidflow.c \
+	prov/psm2/src/psm2/ptl_ips/ips_tidflow.h \
+	prov/psm2/src/psm2/ptl_ips/ips_writehdrq.c \
+	prov/psm2/src/psm2/ptl_ips/ips_writehdrq.h \
+	prov/psm2/src/psm2/ptl_ips/ptl.c \
+	prov/psm2/src/psm2/ptl_ips/ptl_fwd.h \
+	prov/psm2/src/psm2/ptl_ips/ptl_ips.h \
+	prov/psm2/src/psm2/ptl_ips/ptl_rcvthread.c \
+	prov/psm2/src/psm2/ptl_self/ptl.c \
+	prov/psm2/src/psm2/ptl_self/ptl_fwd.h \
+	prov/psm2/src/psm2/libuuid/psm_uuid.c \
+	prov/psm2/src/psm2/libuuid/psm_uuid.h \
+	prov/psm2/src/psm2/opa/opa_debug.c \
+	prov/psm2/src/psm2/opa/opa_dwordcpy-@psm2_ARCH@.c \
+	prov/psm2/src/psm2/opa/opa_i2cflash.c \
+	prov/psm2/src/psm2/opa/opa_proto.c \
+	prov/psm2/src/psm2/opa/opa_service.c \
+	prov/psm2/src/psm2/opa/opa_sysfs.c \
+	prov/psm2/src/psm2/opa/opa_syslog.c \
+	prov/psm2/src/psm2/opa/opa_time.c \
+	prov/psm2/src/psm2/opa/opa_utils.c \
+	prov/psm2/src/psm2/include/hfi1_deprecated.h \
+	prov/psm2/src/psm2/include/opa_byteorder.h \
+	prov/psm2/src/psm2/include/opa_common.h \
+	prov/psm2/src/psm2/include/opa_debug.h \
+	prov/psm2/src/psm2/include/opa_intf.h \
+	prov/psm2/src/psm2/include/opa_queue.h \
+	prov/psm2/src/psm2/include/opa_revision.h \
+	prov/psm2/src/psm2/include/opa_service.h \
+	prov/psm2/src/psm2/include/opa_udebug.h \
+	prov/psm2/src/psm2/include/opa_user.h \
+	prov/psm2/src/psm2/include/psm2_mock_testing.h \
+	prov/psm2/src/psm2/include/rbtree.h \
+	prov/psm2/src/psm2/include/linux-@psm2_ARCH@/bit_ops.h \
+	prov/psm2/src/psm2/include/linux-@psm2_ARCH@/sysdep.h \
+	prov/psm2/src/psm2/mpspawn/mpspawn_stats.h
+
+if HAVE_PSM2_X86_64
+nodist_libpsmx2_fi_la_SOURCES += \
+	prov/psm2/src/psm2/opa/opa_dwordcpy-x86_64-fast.S
+endif
+
+_psm2_cppflags = \
+	-I$(top_srcdir)/prov/psm2/src/psm2 \
+	-I$(top_srcdir)/prov/psm2/src/psm2/include \
+	-I$(top_srcdir)/prov/psm2/src/psm2/include/linux-i386 \
+	-I$(top_srcdir)/prov/psm2/src/psm2/mpspawn \
+	-I$(top_srcdir)/prov/psm2/src/psm2/ptl_ips \
+	-I$(top_srcdir)/prov/psm2/src/psm2/ptl_am \
+	-I$(top_srcdir)/prov/psm2/src/psm2/ptl_self \
+	-DNVALGRIND
+
+endif HAVE_PSM2_SRC
+
 if HAVE_PSM2_DL
 pkglib_LTLIBRARIES += libpsmx2-fi.la
 libpsmx2_fi_la_SOURCES = $(_psm2_files) $(common_srcs)
-libpsmx2_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(psm2_CPPFLAGS)
+libpsmx2_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(psm2_CPPFLAGS) $(_psm2_cppflags)
 libpsmx2_fi_la_LDFLAGS = \
     -module -avoid-version -shared -export-dynamic $(psm2_LDFLAGS)
 libpsmx2_fi_la_LIBADD = $(linkback) $(psm2_LIBS)
@@ -30,7 +172,7 @@ libpsmx2_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_PSM2_DL
 noinst_LTLIBRARIES += libpsmx2.la
 libpsmx2_la_SOURCES = $(_psm2_files)
-libpsmx2_la_CPPFLAGS = $(src_libfabric_la_CPPFLAGS) $(psm2_CPPFLAGS)
+libpsmx2_la_CPPFLAGS = $(src_libfabric_la_CPPFLAGS) $(psm2_CPPFLAGS) $(_psm2_cppflags)
 libpsmx2_la_LDFLAGS = $(psm2_LDFLAGS)
 libpsmx2_la_LIBADD = $(psm2_LIBS)
 src_libfabric_la_LIBADD += libpsmx2.la

--- a/prov/psm2/build-psm2.sh
+++ b/prov/psm2/build-psm2.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+########################################################################
+# This is a sample script for building the psm2 provider with three
+# different options:
+#
+# lib:  Link against external libpsm2.so;
+# src:  With PSM2 library source compiled in;
+# lto:  With PSM2 library source compiled in and with link-time
+#       optimization enabled.
+#
+# Please run the script from the top level directory of the source repo.
+#
+# The "psm", "usnic", and "verbs" providers are disabled to reduce the
+# building time. They can be enabled as needed.
+#
+# Please check that the following variables are either set to appropriate
+# values or can use the default values.
+#
+# PREFIX     Destination for installation
+# STAGE	     Name for sub-directory used for building
+# PSM2_HOME  Location for PSM2 header and libraries (for "lib" build)
+# PSM2_SRC   Location for PSM2 source code (for "src" and "lto" builds)
+########################################################################
+
+if [ $# -eq 0 ]; then
+	echo Usage: $0 '[lib|src|lto]'
+	exit 1
+fi
+
+case $1 in
+  lib)	options=""
+	cflags=""
+	ldflags=""
+	;;
+  src)	options="--with-psm2-src=${PSM2_SRC:-$HOME/scm/opa-psm2}"
+	cflags='CFLAGS="-O3"'
+	ldflags=""
+	;;
+  lto)	options="--with-psm2-src=${PSM2_SRC:-$HOME/scm/opa-psm2}"
+	cflags='CFLAGS="-O3 -flto -ffat-lto-objects -msse4.2"'
+	ldflags='LDFLAGS="-fuse-linker-plugin -flto-partition=none"'
+	;;
+*)	echo Invalid option: "$1"
+	exit 1
+	;;
+esac
+
+if [ ! -f ./autogen.sh ]; then
+	echo Please run the script from the top level directory.
+	exit 1
+fi
+
+./autogen.sh && \
+cd ${STAGE:-stage} && \
+eval ../configure \
+	$cflags $ldflags $options \
+	--prefix=${PREFIX:-$HOME/install/ofi} \
+	--enable-psm2=${PSM2_HOME:-yes} \
+	--disable-psm \
+	--disable-usnic \
+	--disable-verbs && \
+make && make install
+

--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -8,20 +8,61 @@ dnl $1: action if configured successfully
 dnl $2: action if not configured successfully
 dnl
 AC_DEFUN([FI_PSM2_CONFIGURE],[
-	# Determine if we can support the psm2 provider
-	psm2_happy=0
-	AS_IF([test x"$enable_psm2" != x"no"],
-	      [FI_CHECK_PACKAGE([psm2],
-				[psm2.h],
-				[psm2],
-				[psm2_init],
-				[],
-				[$psm2_PREFIX],
-				[$psm2_LIBDIR],
-				[psm2_happy=1],
-				[psm2_happy=0])
-	      ])
-
-	AS_IF([test $psm2_happy -eq 1], [$1], [$2])
+	 # Determine if we can support the psm2 provider
+	 psm2_ARCH=`uname -p | sed -e 's,\(i[456]86\|athlon$$\),i386,'`
+	 AM_CONDITIONAL([HAVE_PSM2_X86_64], [test x$psm2_ARCH = xx86_64])
+	 AC_SUBST([HAVE_PSM2_X86_64])
+	 AC_SUBST([psm2_ARCH])
+	 AS_IF([test x$with_psm2_src = x], [have_psm2_src=0], [have_psm2_src=1])
+	 AM_CONDITIONAL([HAVE_PSM2_SRC], [test x$have_psm2_src = x1])
+	 AC_DEFINE_UNQUOTED([HAVE_PSM2_SRC], $have_psm2_src, [PSM2 source is built-in])
+	 psm2_happy=0
+	 AS_IF([test x"$enable_psm2" != x"no"],
+	       [AS_IF([test x$have_psm2_src = x0],
+		      [
+			dnl build with stand-alone PSM2 library
+			FI_CHECK_PACKAGE([psm2],
+					 [psm2.h],
+					 [psm2],
+					 [psm2_init],
+					 [],
+					 [$psm2_PREFIX],
+					 [$psm2_LIBDIR],
+					 [psm2_happy=1],
+					 [psm2_happy=0])
+		      ],
+		      [
+			dnl build with PSM2 source code included
+			psm2_CPPFLAGS="-msse4.2"
+			FI_CHECK_PACKAGE([psm2],
+					 [rdma/hfi/hfi1_user.h],
+					 [uuid],
+					 [uuid_generate],
+					 [-lnuma],
+					 [],
+					 [],
+					 [psm2_happy=1],
+					 [psm2_happy=0])
+			AS_IF([test x$psm2_happy = x1],
+			      AS_IF([test -f $with_psm2_src/libpsm2.spec.in],
+				    [
+					$as_echo "$as_me: creating links for PSM2 source code."
+					mkdir -p $srcdir/prov/psm2/src/psm2
+					cp -srf $with_psm2_src/* $srcdir/prov/psm2/src/psm2/
+					ln -sf ../include/rbtree.h $srcdir/prov/psm2/src/psm2/ptl_ips/
+					ln -sf ../include/rbtree.h $srcdir/prov/psm2/src/psm2/ptl_am/
+				   ],
+				   [
+					$as_echo "$as_me: no PSM2 source under <$with_psm2_src>."
+					psm2_happy=0
+				   ]))
+		      ])
+	       ])
+	 AS_IF([test $psm2_happy -eq 1], [$1], [$2])
 ])
+
+AC_ARG_WITH([psm2-src],
+	    AC_HELP_STRING([--with-psm2-src=DIR],
+                           [Provide path to the source code of PSM2 library
+			    to be compiled into the provider]))
 

--- a/prov/psm2/src/psm2_revision.c
+++ b/prov/psm2/src/psm2_revision.c
@@ -1,0 +1,6 @@
+char psmi_hfi_revision[] = "libfabric: psm-hfi-gxxxxxxx_open";
+char psmi_hfi_IFS_version[]="";
+char psmi_hfi_build_timestamp[] ="2017-09-07 17:29:26+00:00";
+char psmi_hfi_sources_checksum[] ="5b993e9931792d37d21be38e668f3968ae6e8819";
+char psmi_hfi_git_checksum[] ="d7e63ede75bc080c68117cfa3f4e9e8b2d85e2cd";
+

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -33,9 +33,15 @@
 #ifndef _FI_PSM_VERSION_H_
 #define _FI_PSM_VERSION_H_
 
+#if HAVE_PSM2_SRC
+#include "psm2/psm2.h"
+#include "psm2/psm2_mq.h"
+#include "psm2/psm2_am.h"
+#else
 #include <psm2.h>
 #include <psm2_mq.h>
 #include <psm2_am.h>
+#endif
 
 #define PSMX2_PROV_NAME		"psm2"
 #define PSMX2_DOMAIN_NAME	"psm2"

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -113,7 +113,7 @@ struct fi_info_1_0 {
 	} while (0);
 
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 void fi_freeinfo_1_0(struct fi_info_1_0 *info)
 {
 	fi_freeinfo((struct fi_info *) info);
@@ -121,7 +121,7 @@ void fi_freeinfo_1_0(struct fi_info_1_0 *info)
 COMPAT_SYMVER(fi_freeinfo_1_0, fi_freeinfo, FABRIC_1.0);
 
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 struct fi_info_1_0 *fi_dupinfo_1_0(const struct fi_info_1_0 *info)
 {
 	struct fi_info *dup;
@@ -202,7 +202,7 @@ fail:
 }
 COMPAT_SYMVER(fi_dupinfo_1_0, fi_dupinfo, FABRIC_1.0);
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int fi_getinfo_1_0(uint32_t version, const char *node, const char *service,
 		    uint64_t flags, const struct fi_info_1_0 *hints_1_0,
 		    struct fi_info_1_0 **info)
@@ -225,7 +225,7 @@ int fi_getinfo_1_0(uint32_t version, const char *node, const char *service,
 }
 COMPAT_SYMVER(fi_getinfo_1_0, fi_getinfo, FABRIC_1.0);
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int fi_fabric_1_0(struct fi_fabric_attr_1_0 *attr_1_0,
 		  struct fid_fabric **fabric, void *context)
 {

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -530,7 +530,7 @@ FI_DESTRUCTOR(fi_fini(void))
 	ofi_osd_fini();
 }
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 void DEFAULT_SYMVER_PRE(fi_freeinfo)(struct fi_info *info)
 {
 	struct fi_info *next;
@@ -681,7 +681,7 @@ static int ofi_layering_ok(const struct fi_provider *provider,
 	return 1;
 }
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 		const char *service, uint64_t flags,
 		const struct fi_info *hints, struct fi_info **info)
@@ -788,7 +788,7 @@ err:
 }
 
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 struct fi_info *DEFAULT_SYMVER_PRE(fi_dupinfo)(const struct fi_info *info)
 {
 	struct fi_info *dup;
@@ -887,7 +887,7 @@ fail:
 }
 CURRENT_SYMVER(fi_dupinfo_, fi_dupinfo);
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr,
 		struct fid_fabric **fabric, void *context)
 {
@@ -920,7 +920,7 @@ int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr,
 }
 CURRENT_SYMVER(fi_fabric_, fi_fabric);
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 uint32_t DEFAULT_SYMVER_PRE(fi_version)(void)
 {
 	return FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION);
@@ -943,7 +943,7 @@ static const char *const errstr[] = {
 	[FI_EOVERRUN - FI_ERRNO_OFFSET] = "Queue has been overrun",
 };
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 const char *DEFAULT_SYMVER_PRE(fi_strerror)(int errnum)
 {
 	if (errnum < FI_ERRNO_OFFSET)

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -637,7 +637,7 @@ static void fi_tostr_cq_event_flags(char *buf, uint64_t flags)
 	fi_remove_comma(buf);
 }
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 {
 	static char *buf = NULL;

--- a/src/log.c
+++ b/src/log.c
@@ -130,7 +130,7 @@ void fi_log_fini(void)
 	ofi_free_filter(&prov_log_filter);
 }
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov,
 		enum fi_log_level level,
 		enum fi_log_subsys subsys)
@@ -143,7 +143,7 @@ int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov,
 }
 DEFAULT_SYMVER(fi_log_enabled_, fi_log_enabled, FABRIC_1.0);
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_level level,
 		enum fi_log_subsys subsys, const char *func, int line,
 		const char *fmt, ...)

--- a/src/var.c
+++ b/src/var.c
@@ -78,7 +78,7 @@ fi_find_param(const struct fi_provider *provider, const char *param_name)
 	return NULL;
 }
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int DEFAULT_SYMVER_PRE(fi_getparams)(struct fi_param **params, int *count)
 {
 	struct fi_param *vhead = NULL;
@@ -125,7 +125,7 @@ out:
 }
 DEFAULT_SYMVER(fi_getparams_, fi_getparams, FABRIC_1.0);
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 void DEFAULT_SYMVER_PRE(fi_freeparams)(struct fi_param *params)
 {
 	int i;
@@ -163,7 +163,7 @@ void fi_param_undefine(const struct fi_provider *provider)
 	}
 }
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int DEFAULT_SYMVER_PRE(fi_param_define)(const struct fi_provider *provider,
 		const char *param_name, enum fi_param_type type,
 		const char *help_string)
@@ -243,7 +243,7 @@ static int fi_parse_bool(const char *str_value)
 	return -1;
 }
 
-__attribute__((visibility ("default")))
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 		const char *param_name, void *value)
 {


### PR DESCRIPTION
Compiling the source code of PSM2 library together with the provider
allows more aggressive compile-time/link-time optimization. In addition,
the provider can be further optimized by having access to the internal
definitions of the PSM2 library.

This option is enabled with the configure option "--with-psm2-src=DIR".
The resulting provider no longer uses or depends on the stand-alone PSM2
library.

Exported symbols need additional "externally_visible" attribute to remain
public when  link time optimization is used.

A script is provided as an example for the new building options.