### PR TITLE
prov/verbs: Add support of setting CM thread affinity

### DIFF
--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -38,6 +38,8 @@
 #include <byteswap.h>
 #include <endian.h>
 #include <sys/mman.h>
+#include <string.h>
+#include <assert.h>
 
 #include "unix/osd.h"
 #include "rdma/fi_errno.h"

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -45,7 +45,7 @@
 #include <pthread.h>
 
 #include "unix/osd.h"
-
+#include "rdma/fi_errno.h"
 #include "config.h"
 
 #define pthread_yield pthread_yield_np

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -229,4 +229,6 @@ OFI_DEF_COMPLEX_OPS(long_double)
 #define ofi_atomic_sub_and_fetch(radix, ptr, val) __sync_sub_and_fetch((ptr), (val))
 #endif /* HAVE_BUILTIN_ATOMICS */
 
+int ofi_set_thread_affinity(const char *s);
+
 #endif /* _FI_UNIX_OSD_H_ */

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -888,6 +888,12 @@ typedef LONGLONG ofi_atomic_int_64_t;
 #define ofi_atomic_sub_and_fetch(radix, ptr, val) InterlockedAdd##radix((ofi_atomic_int_##radix##_t *)(ptr), -(ofi_atomic_int_##radix##_t)(val))
 #endif /* HAVE_BUILTIN_ATOMICS */
 
+static inline int ofi_set_thread_affinity(const char *s)
+{
+	OFI_UNUSED(s);
+	return -FI_ENOSYS;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -768,7 +768,7 @@ SOCKETS_INI
 
 	fi_param_define(&sock_prov, "pe_affinity", FI_PARAM_STRING,
 			"If specified, bind the progress thread to the indicated range(s) of Linux virtual processor ID(s). "
-			"This option is currently not supported on OS X. Usage: id_start[-id_end[:stride]][,]");
+			"This option is currently not supported on OS X and Windows. Usage: id_start[-id_end[:stride]][,]");
 
 	fi_param_define(&sock_prov, "keepalive_enable", FI_PARAM_BOOL,
 			"Enable keepalive support");

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -63,6 +63,7 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 		.rndv_seg_size		= FI_IBV_RDM_SEG_MAXSIZE,
 		.thread_timeout		= FI_IBV_RDM_CM_THREAD_TIMEOUT,
 		.eager_send_opcode	= "IBV_WR_SEND",
+		.cm_thread_affinity	= NULL,
 	},
 
 	.dgram			= {
@@ -698,6 +699,16 @@ static int fi_ibv_read_params(void)
 				 &fi_ibv_gl_data.rdm.eager_send_opcode)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of rdm_eager_send_opcode\n");
+		return -FI_EINVAL;
+	}
+	if (fi_ibv_get_param_str("rdm_cm_thread_affinity",
+				 "If specified, bind the CM thread to the indicated "
+				 "range(s) of Linux virtual processor ID(s). "
+				 "This option is currently not supported on OS X. "
+				 "Usage: id_start[-id_end[:stride]][,]",
+				 &fi_ibv_gl_data.rdm.cm_thread_affinity)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid thread affinity range provided in the rdm_cm_thread_affinity\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -171,6 +171,7 @@ extern struct fi_ibv_gl_data {
 		int	rndv_seg_size;
 		int	thread_timeout;
 		char	*eager_send_opcode;
+		char	*cm_thread_affinity;
 	} rdm;
 
 	struct {

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -40,6 +40,9 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <pthread.h>
+#ifdef __FreeBSD__
+#include <pthread_np.h>
+#endif
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
@@ -52,6 +55,12 @@
 
 #include "rdma/fi_errno.h"
 #include "rdma/providers/fi_log.h"
+
+#ifdef __FreeBSD__
+typedef cpuset_t ofi_cpu_set_t;
+#elif defined __linux__
+typedef cpu_set_t ofi_cpu_set_t;
+#endif
 
 int fi_fd_nonblock(int fd)
 {
@@ -203,4 +212,57 @@ int fi_read_file(const char *dir, const char *file, char *buf, size_t size)
 	return len;
 }
 
+int ofi_set_thread_affinity(const char *s)
+{
+#ifndef __APPLE__
+	char *saveptra = NULL, *saveptrb = NULL, *saveptrc = NULL;
+	char *dup_s, *a, *b, *c;
+	int j, first, last, stride, ret = FI_SUCCESS;
+	ofi_cpu_set_t mycpuset;
+	pthread_t mythread;
 
+	mythread = pthread_self();
+	CPU_ZERO(&mycpuset);
+
+	dup_s = strdup(s);
+	if (dup_s == NULL)
+		return -FI_ENOMEM;
+
+	a = strtok_r(dup_s, ",", &saveptra);
+	while (a) {
+		first = last = -1;
+		stride = 1;
+		b = strtok_r(a, "-", &saveptrb);
+		assert(b);
+		first = atoi(b);
+		/* Check for range delimiter */
+		b = strtok_r(NULL, "-", &saveptrb);
+		if (b) {
+			c = strtok_r(b, ":", &saveptrc);
+			assert(c);
+			last = atoi(c);
+			/* Check for stride */
+			c = strtok_r(NULL, ":", &saveptrc);
+			if (c)
+				stride = atoi(c);
+		}
+
+		if (last == -1)
+			last = first;
+
+		for (j = first; j <= last; j += stride)
+			CPU_SET(j, &mycpuset);
+		a =  strtok_r(NULL, ",", &saveptra);
+	}
+
+	ret = pthread_setaffinity_np(mythread, sizeof(mycpuset), &mycpuset);
+	if (ret)
+		ret = -errno;
+
+	free(dup_s);
+	return ret;
+#else
+	OFI_UNUSED(s);
+	return -FI_ENOSYS;
+#endif
+}

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -505,4 +505,3 @@ void freeifaddrs(struct ifaddrs *ifa)
 		ifa = next;
 	}
 }
-


### PR DESCRIPTION
This patch consists from 3 commits:
- Add setting thread affinity functionality to common code
- Replace the sockets' setting thread affinity by common one
- Enabling setting CM thread affinity in the verbs proider