### PR TITLE
v1.5.x:  psm2 provider critical path optimization for send and recv (2 patches)

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -121,8 +121,22 @@ extern struct fi_provider psmx2_prov;
 						tag96.tag1 = (uint32_t)(tag64>>32); \
 						tag96.tag2 = tag32; \
 					} while (0)
+#define PSMX2_SET_TAG_FIRST64(tag96,tag64) do { \
+						memcpy(&(tag96).tag0, &(tag64), sizeof(uint64_t)); \
+					} while (0)
+#define PSMX2_SET_TAG_LAST32(tag96,tag32) do { \
+						tag96.tag2 = tag32; \
+					} while (0)
 
-#define PSMX2_GET_TAG64(tag96)		(tag96.tag0 | ((uint64_t)tag96.tag1<<32))
+#define PSMX2_GET_TAG64(tag96)		(psmx2_get_tag64(&(tag96)))
+
+static inline uint64_t psmx2_get_tag64(const psm2_mq_tag_t *tag96)
+{
+	uint64_t tag64;
+
+	memcpy(&tag64, &tag96->tag0, sizeof(tag64));
+	return tag64;
+}
 
 /* When using the long RMA protocol, set a bit in the unused SEQ bits to
  * indicate whether or not the operation is a read or a write. This prevents tag
@@ -166,7 +180,7 @@ extern struct fi_provider psmx2_prov;
 /* Bits 60 .. 63 of the flag are provider specific */
 #define PSMX2_NO_COMPLETION	(1ULL << 60)
 
-#define PSMX2_CTXT_ALLOC_FLAG		0x80000000
+
 enum psmx2_context_type {
 	PSMX2_NOCOMP_SEND_CONTEXT = 1,
 	PSMX2_NOCOMP_RECV_CONTEXT,
@@ -184,7 +198,7 @@ enum psmx2_context_type {
 	PSMX2_SENDV_CONTEXT,
 	PSMX2_IOV_SEND_CONTEXT,
 	PSMX2_IOV_RECV_CONTEXT,
-	PSMX2_NOCOMP_RECV_CONTEXT_ALLOC = PSMX2_NOCOMP_RECV_CONTEXT | PSMX2_CTXT_ALLOC_FLAG,
+	PSMX2_NOCOMP_RECV_CONTEXT_ALLOC
 };
 
 struct psmx2_context {

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -743,7 +743,7 @@ void psmx2_ep_put_op_context(struct psmx2_fid_ep *ep,
 {
 	struct psmx2_context *context;
 
-	if (! (PSMX2_CTXT_TYPE(fi_context) & PSMX2_CTXT_ALLOC_FLAG))
+	if (PSMX2_CTXT_TYPE(fi_context) != PSMX2_NOCOMP_RECV_CONTEXT_ALLOC)
 		return;
 
 	context = container_of(fi_context, struct psmx2_context, fi_context);

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -943,8 +943,10 @@ psmx2_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf,
 	uint32_t tag32;
 	int err;
 
-	if (len > psmx2_env.inject_size)
+	if (OFI_UNLIKELY(len > psmx2_env.inject_size))
 		return -FI_EMSGSIZE;
+
+	PSMX2_SET_TAG_FIRST64(psm2_tag, tag);
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -957,7 +959,7 @@ psmx2_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf,
 		vlane = PSMX2_ADDR_TO_VL(dest_addr);
 	}
 	tag32 = PSMX2_TAG32(0, ep_priv->vlane, vlane);
-	PSMX2_SET_TAG(psm2_tag, tag, tag32);
+	PSMX2_SET_TAG_LAST32(psm2_tag, tag32);
 
 	err = psm2_mq_send2(ep_priv->trx_ctxt->psm2_mq, psm2_epaddr, 0,
 			    &psm2_tag, buf, len);
@@ -986,7 +988,7 @@ psmx2_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf,
 	int err;
 	size_t idx;
 
-	if (len > psmx2_env.inject_size)
+	if (OFI_UNLIKELY(len > psmx2_env.inject_size))
 		return -FI_EMSGSIZE;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);


### PR DESCRIPTION
These patches are targeted for improving MPI performance. 

@shefty This is for the stable branch, but doesn't create demand for a future new release by itself. 