### PR TITLE
prov/psm2: Allow specialization when FI_COMPLETION op_flag is set.

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -136,10 +136,16 @@ int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov,
 		enum fi_log_subsys subsys)
 {
 	struct fi_prov_context *ctx;
+	int ret = 1;
 
-	ctx = (struct fi_prov_context *) &prov->context;
-	return ((FI_LOG_TAG(ctx->disable_logging, level, subsys) & log_mask) ==
-		FI_LOG_TAG(ctx->disable_logging, level, subsys));
+	if (prov != NULL) {
+		ctx = (struct fi_prov_context *) &prov->context;
+		uint64_t tag = FI_LOG_TAG(ctx->disable_logging, level, subsys);
+
+		ret = (tag & log_mask) == tag;
+	}
+
+	return ret;
 }
 DEFAULT_SYMVER(fi_log_enabled_, fi_log_enabled, FABRIC_1.0);
 
@@ -150,11 +156,17 @@ void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_leve
 {
 	char buf[1024];
 	int size;
+	const char *provname =
+		prov == NULL
+			? "<unknown provider>"
+			: prov->name == NULL
+				? "<unnamed provider>"
+				: prov->name;
 
 	va_list vargs;
 
 	size = snprintf(buf, sizeof(buf), "%s:%s:%s:%s():%d<%s> ", PACKAGE,
-			prov->name, log_subsys[subsys], func, line,
+			provname, log_subsys[subsys], func, line,
 			log_levels[level]);
 
 	va_start(vargs, fmt);

--- a/src/log.c
+++ b/src/log.c
@@ -136,16 +136,10 @@ int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov,
 		enum fi_log_subsys subsys)
 {
 	struct fi_prov_context *ctx;
-	int ret = 1;
 
-	if (prov != NULL) {
-		ctx = (struct fi_prov_context *) &prov->context;
-		uint64_t tag = FI_LOG_TAG(ctx->disable_logging, level, subsys);
-
-		ret = (tag & log_mask) == tag;
-	}
-
-	return ret;
+	ctx = (struct fi_prov_context *) &prov->context;
+	return ((FI_LOG_TAG(ctx->disable_logging, level, subsys) & log_mask) ==
+		FI_LOG_TAG(ctx->disable_logging, level, subsys));
 }
 DEFAULT_SYMVER(fi_log_enabled_, fi_log_enabled, FABRIC_1.0);
 
@@ -156,17 +150,11 @@ void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_leve
 {
 	char buf[1024];
 	int size;
-	const char *provname =
-		prov == NULL
-			? "<unknown provider>"
-			: prov->name == NULL
-				? "<unnamed provider>"
-				: prov->name;
 
 	va_list vargs;
 
 	size = snprintf(buf, sizeof(buf), "%s:%s:%s:%s():%d<%s> ", PACKAGE,
-			provname, log_subsys[subsys], func, line,
+			prov->name, log_subsys[subsys], func, line,
 			log_levels[level]);
 
 	va_start(vargs, fmt);


### PR DESCRIPTION
Some applications set FI_SELECTIVE_COMPLETION in ep/cq bind flags and
set FI_COMPLETION in op_flags.  (This gives them a completion by
default, while allowing them to selectively disable completions by
using tsendmsg.)
    
With this change, those applications will get specialized (faster) 
versions of the tagged send/recv routines rather than the generic
(slow) versions.
    
Signed-off-by: Jim Snow <jim.m.snow@intel.com>
