### PR TITLE
prov/psm2: Enable PSM2 multi-ep feature by default

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -64,19 +64,9 @@ Progress
 Scalable endpoints
 : Scalable endpoints support depends on the multi-EP feature of the *PSM2*
   library. If the *PSM2* library has this feature, the availability is
-  further controlled by an environment variable *PSM2_MULTI_EP*, which by
-  default is 0 (disabled). It is important to set the environment variable
-  to 1 before using the scalable endpoint with the *psm2* provider.
-
-  For convenience, the *psm2* provider has a mechanism for application
-  to turn on the *PSM2* multi-EP feature programmatically, thus avoid the
-  need of manually setting the environment variable. To use this feature,
-  when the application calls fi_getinfo() the first time, it should pass
-  a non-NULL "hints" parameter with non-NULL "ep_attr" field and with
-  "hints->ep_attr->tx_ctx_cnt" set to be greater than 1. The *psm2*
-  provider treats this as a request to use scalable endpoint and thus
-  sets the default value of *PSM2_MULTI_EP* to 1. This mechanism, however,
-  has no effect if *PSM2_MULTI_EP* has already been set.
+  further controlled by an environment variable *PSM2_MULTI_EP*. The *psm2*
+  provider automatically sets this variable to 1 if it is not set. The
+  feature can be disabled explicitly by setting *PSM2_MULTI_EP* to 0.
 
   When creating a scalable endpoint, the actual number of contexts needed
   should be set in the "fi_info" structure passed to the *fi_scalable_ep*

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -828,7 +828,7 @@ struct psmx2_env {
 	int timeout;
 	int prog_interval;
 	char *prog_affinity;
-	int sep;
+	int multi_ep;
 	int max_trx_ctxt;
 	int sep_trx_ctxt;
 	int num_devunits;
@@ -891,7 +891,7 @@ static inline void psmx2_unlock(fastlock_t *lock, int lock_level)
 
 #ifdef PSM2_MULTI_EP_CAP
 
-static inline int psmx2_sep_ok(void)
+static inline int psmx2_multi_ep_ok(void)
 {
 	uint64_t caps = PSM2_MULTI_EP_CAP;
 	return (psm2_get_capability_mask(caps) == caps);
@@ -914,7 +914,7 @@ static inline psm2_epid_t psmx2_epaddr_to_epid(psm2_epaddr_t epaddr)
 
 #else
 
-static inline int psmx2_sep_ok(void)
+static inline int psmx2_multi_ep_ok(void)
 {
 	return 0;
 }

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -563,9 +563,6 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	FI_INFO(&psmx2_prov, FI_LOG_DOMAIN, "\n");
 
-	if (!psmx2_env.sep)
-		psmx2_domain_ops.scalable_ep = fi_no_scalable_ep;
-
 	fabric_priv = container_of(fabric, struct psmx2_fid_fabric,
 				   util_fabric.fabric_fid);
 


### PR DESCRIPTION
Now the provider depends more on the multi-ep feature it makes
sense to have it on by default. It can still be turned off manually
by setting PSM2_MULTI_EP=0.

Update the man page accordingly.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>