### PR TITLE
Topic/gni missing commits for v1.5.x

### DIFF
--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -488,7 +488,7 @@ static int __gnix_deregister_region(
 		/* release reference to nic */
 		_gnix_ref_put(nic);
 	} else {
-		GNIX_INFO(FI_LOG_MR, "failed to deregister memory"
+		GNIX_WARN(FI_LOG_MR, "failed to deregister memory"
 			  " region, entry=%p ret=%i\n", handle, ret);
 	}
 
@@ -988,7 +988,11 @@ gnix_mr_cache_attr_t _gnix_default_mr_cache_attr = {
 		.soft_reg_limit      = 4096,
 		.hard_reg_limit      = -1,
 		.hard_stale_limit    = 128,
+#if HAVE_KDREG
 		.lazy_deregistration = 1,
+#else
+		.lazy_deregistration = 0,
+#endif
 		.reg_callback        = __gnix_register_region,
 		.dereg_callback      = __gnix_deregister_region,
 		.destruct_callback   = __gnix_destruct_registration,

--- a/prov/gni/src/gnix_mr.c
+++ b/prov/gni/src/gnix_mr.c
@@ -204,11 +204,9 @@ static int __mr_reg(struct fid *fid, const void *buf, size_t len,
 			1 << GNIX_MR_PAGE_SHIFT);
 
 	/* call cache register op to retrieve the right entry */
-	fastlock_release(&domain->mr_cache_lock);
 	fastlock_acquire(&info->mr_cache_lock);
 	if (unlikely(!domain->mr_ops))
 		_gnix_open_cache(domain, GNIX_DEFAULT_CACHE_TYPE);
-	fastlock_release(&domain->mr_cache_lock);
 
 	if (unlikely(!domain->mr_ops->is_init(domain, auth_key))) {
 		rc = domain->mr_ops->init(domain, auth_key);

--- a/prov/gni/src/gnix_mr_cache.c
+++ b/prov/gni/src/gnix_mr_cache.c
@@ -124,7 +124,11 @@ gnix_mr_cache_attr_t __default_mr_cache_attr = {
 		.soft_reg_limit      = 4096,
 		.hard_reg_limit      = -1,
 		.hard_stale_limit    = 128,
+#if HAVE_KDREG
 		.lazy_deregistration = 1,
+#else
+		.lazy_deregistration = 0,
+#endif
 };
 
 /* Functions for using and manipulating cache entry state */

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -461,8 +461,7 @@ static int __gnix_rma_txd_complete(void *arg, gni_return_t tx_status)
 		 * complete. */
 		req->rma.status |= tx_status;
 
-		ofi_atomic_dec32(&req->rma.outstanding_txds);
-		if (ofi_atomic_get32(&req->rma.outstanding_txds)) {
+		if (ofi_atomic_dec32(&req->rma.outstanding_txds) == 1) {
 			_gnix_nic_tx_free(req->gnix_ep->nic, txd);
 			GNIX_INFO(FI_LOG_EP_DATA,
 				  "Received first RDMA chain TXD, req: %p\n",


### PR DESCRIPTION
Mercury crew found a number of issues when trying to use the 1.5.3rc1 tarball.  These cherry picks plus manual patches get them at least going now.  There does appear to be an underlying issue
possibly concerning Cray kdreg that Mercury seems to be hitting when using lazy memory deregistration, but that problem is not going to be resolved for the 1.5.3 release.

@soumagne
