### PR TITLE
prov/psm2: Fix multi-receive issues when paired with iov send

### DIFF
--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -649,6 +649,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					psm2_status.error_code = rep->error_code;
 
 					multi_recv = rep->multi_recv;
+					fi_context = rep->user_context;
 				}
 				break;
 			}

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -610,6 +610,9 @@ int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
 		}
 	}
 
+	if (multi_recv && recv_len < recv_req->min_buf_size)
+		rep->comp_flag |= FI_MULTI_RECV;
+
 	return 0;
 }
 


### PR DESCRIPTION
Fix the following two issues for the scenario that a message sent via the
iov send protocol is delivered into a multi-receive buffer: (1)incorrect
receive request for reposting the receive buffer; (2) missing FI_MULTI_RECV
completion flag.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>