### PR TITLE
prov/psm2: Update PSM2 prov to use PSM2 AM Handler with Context

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -1070,17 +1070,17 @@ int	psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 				struct psmx2_am_request *req);
 int	psmx2_process_trigger(struct psmx2_trx_ctxt *trx_ctxt,
 				struct psmx2_trigger *trigger);
-int	psmx2_am_rma_handler_ext(psm2_am_token_t token,
-				 psm2_amarg_t *args, int nargs, void *src, uint32_t len,
-				 struct psmx2_trx_ctxt *trx_ctxt);
-int	psmx2_am_atomic_handler_ext(psm2_am_token_t token,
-				    psm2_amarg_t *args, int nargs, void *src, uint32_t len,
-				    struct psmx2_trx_ctxt *trx_ctxt);
+int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
+			     int nargs, void *src, uint32_t len,
+			     void *hctx);
+int psmx2_am_atomic_handler(psm2_am_token_t token,
+				psm2_amarg_t *args, int nargs, void *src,
+				uint32_t len, void *hctx);
 int	psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args, int nargs,
-			     void *src, uint32_t len);
-int	psmx2_am_trx_ctxt_handler_ext(psm2_am_token_t token,
+			     void *src, uint32_t len, void *hctx);
+int	psmx2_am_trx_ctxt_handler(psm2_am_token_t token,
 				      psm2_amarg_t *args, int nargs, void *src, uint32_t len,
-				      struct psmx2_trx_ctxt *trx_ctxt);
+				      void *hctx);
 void	psmx2_atomic_global_init(void);
 void	psmx2_atomic_global_fini(void);
 

--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -32,220 +32,6 @@
 
 #include "psmx2.h"
 
-#define PSMX2_AM_MAX_TRX_CTXT PSMX2_MAX_TRX_CTXT
-static struct {
-	struct psmx2_trx_ctxt *trx_ctxts[PSMX2_AM_MAX_TRX_CTXT];
-	psm2_am_handler_fn_t rma_handlers[PSMX2_AM_MAX_TRX_CTXT];
-	psm2_am_handler_fn_t atomic_handlers[PSMX2_AM_MAX_TRX_CTXT];
-	psm2_am_handler_fn_t trx_ctxt_handlers[PSMX2_AM_MAX_TRX_CTXT];
-	fastlock_t lock;
-	int cnt;
-} psmx2_am_global;
-
-#define DEFINE_AM_HANDLERS(INDEX) \
-	static int psmx2_am_rma_handler_##INDEX( \
-			psm2_am_token_t token, psm2_amarg_t *args, \
-			int nargs, void *src, uint32_t len) \
-	{ \
-		return psmx2_am_rma_handler_ext( \
-				token, args, nargs, src, len, \
-				psmx2_am_global.trx_ctxts[INDEX]); \
-	} \
-	\
-	static int psmx2_am_atomic_handler_##INDEX( \
-			psm2_am_token_t token, psm2_amarg_t *args, \
-			int nargs, void *src, uint32_t len) \
-	{ \
-		return psmx2_am_atomic_handler_ext( \
-				token, args, nargs, src, len, \
-				psmx2_am_global.trx_ctxts[INDEX]); \
-	} \
-	static int psmx2_am_trx_ctxt_handler_##INDEX( \
-			psm2_am_token_t token, psm2_amarg_t *args, \
-			int nargs, void *src, uint32_t len) \
-	{ \
-		return psmx2_am_trx_ctxt_handler_ext( \
-				token, args, nargs, src, len, \
-				psmx2_am_global.trx_ctxts[INDEX]); \
-	}
-
-DEFINE_AM_HANDLERS(0)
-DEFINE_AM_HANDLERS(1)
-DEFINE_AM_HANDLERS(2)
-DEFINE_AM_HANDLERS(3)
-DEFINE_AM_HANDLERS(4)
-DEFINE_AM_HANDLERS(5)
-DEFINE_AM_HANDLERS(6)
-DEFINE_AM_HANDLERS(7)
-DEFINE_AM_HANDLERS(8)
-DEFINE_AM_HANDLERS(9)
-DEFINE_AM_HANDLERS(10)
-DEFINE_AM_HANDLERS(11)
-DEFINE_AM_HANDLERS(12)
-DEFINE_AM_HANDLERS(13)
-DEFINE_AM_HANDLERS(14)
-DEFINE_AM_HANDLERS(15)
-DEFINE_AM_HANDLERS(16)
-DEFINE_AM_HANDLERS(17)
-DEFINE_AM_HANDLERS(18)
-DEFINE_AM_HANDLERS(19)
-DEFINE_AM_HANDLERS(20)
-DEFINE_AM_HANDLERS(21)
-DEFINE_AM_HANDLERS(22)
-DEFINE_AM_HANDLERS(23)
-DEFINE_AM_HANDLERS(24)
-DEFINE_AM_HANDLERS(25)
-DEFINE_AM_HANDLERS(26)
-DEFINE_AM_HANDLERS(27)
-DEFINE_AM_HANDLERS(28)
-DEFINE_AM_HANDLERS(29)
-DEFINE_AM_HANDLERS(30)
-DEFINE_AM_HANDLERS(31)
-DEFINE_AM_HANDLERS(32)
-DEFINE_AM_HANDLERS(33)
-DEFINE_AM_HANDLERS(34)
-DEFINE_AM_HANDLERS(35)
-DEFINE_AM_HANDLERS(36)
-DEFINE_AM_HANDLERS(37)
-DEFINE_AM_HANDLERS(38)
-DEFINE_AM_HANDLERS(39)
-DEFINE_AM_HANDLERS(40)
-DEFINE_AM_HANDLERS(41)
-DEFINE_AM_HANDLERS(42)
-DEFINE_AM_HANDLERS(43)
-DEFINE_AM_HANDLERS(44)
-DEFINE_AM_HANDLERS(45)
-DEFINE_AM_HANDLERS(46)
-DEFINE_AM_HANDLERS(47)
-DEFINE_AM_HANDLERS(48)
-DEFINE_AM_HANDLERS(49)
-DEFINE_AM_HANDLERS(50)
-DEFINE_AM_HANDLERS(51)
-DEFINE_AM_HANDLERS(52)
-DEFINE_AM_HANDLERS(53)
-DEFINE_AM_HANDLERS(54)
-DEFINE_AM_HANDLERS(55)
-DEFINE_AM_HANDLERS(56)
-DEFINE_AM_HANDLERS(57)
-DEFINE_AM_HANDLERS(58)
-DEFINE_AM_HANDLERS(59)
-DEFINE_AM_HANDLERS(60)
-DEFINE_AM_HANDLERS(61)
-DEFINE_AM_HANDLERS(62)
-DEFINE_AM_HANDLERS(63)
-DEFINE_AM_HANDLERS(64)
-DEFINE_AM_HANDLERS(65)
-DEFINE_AM_HANDLERS(66)
-DEFINE_AM_HANDLERS(67)
-DEFINE_AM_HANDLERS(68)
-DEFINE_AM_HANDLERS(69)
-DEFINE_AM_HANDLERS(70)
-DEFINE_AM_HANDLERS(71)
-DEFINE_AM_HANDLERS(72)
-DEFINE_AM_HANDLERS(73)
-DEFINE_AM_HANDLERS(74)
-DEFINE_AM_HANDLERS(75)
-DEFINE_AM_HANDLERS(76)
-DEFINE_AM_HANDLERS(77)
-DEFINE_AM_HANDLERS(78)
-DEFINE_AM_HANDLERS(79)
-
-#define ASSIGN_AM_HANDLERS(INDEX) \
-	psmx2_am_global.rma_handlers[INDEX] =  psmx2_am_rma_handler_##INDEX; \
-	psmx2_am_global.atomic_handlers[INDEX] =  psmx2_am_atomic_handler_##INDEX; \
-	psmx2_am_global.trx_ctxt_handlers[INDEX] =  psmx2_am_trx_ctxt_handler_##INDEX;
-
-void psmx2_am_global_init(void)
-{
-	fastlock_init(&psmx2_am_global.lock);
-
-	ASSIGN_AM_HANDLERS(0)
-	ASSIGN_AM_HANDLERS(1)
-	ASSIGN_AM_HANDLERS(2)
-	ASSIGN_AM_HANDLERS(3)
-	ASSIGN_AM_HANDLERS(4)
-	ASSIGN_AM_HANDLERS(5)
-	ASSIGN_AM_HANDLERS(6)
-	ASSIGN_AM_HANDLERS(7)
-	ASSIGN_AM_HANDLERS(8)
-	ASSIGN_AM_HANDLERS(9)
-	ASSIGN_AM_HANDLERS(10)
-	ASSIGN_AM_HANDLERS(11)
-	ASSIGN_AM_HANDLERS(12)
-	ASSIGN_AM_HANDLERS(13)
-	ASSIGN_AM_HANDLERS(14)
-	ASSIGN_AM_HANDLERS(15)
-	ASSIGN_AM_HANDLERS(16)
-	ASSIGN_AM_HANDLERS(17)
-	ASSIGN_AM_HANDLERS(18)
-	ASSIGN_AM_HANDLERS(19)
-	ASSIGN_AM_HANDLERS(20)
-	ASSIGN_AM_HANDLERS(21)
-	ASSIGN_AM_HANDLERS(22)
-	ASSIGN_AM_HANDLERS(23)
-	ASSIGN_AM_HANDLERS(24)
-	ASSIGN_AM_HANDLERS(25)
-	ASSIGN_AM_HANDLERS(26)
-	ASSIGN_AM_HANDLERS(27)
-	ASSIGN_AM_HANDLERS(28)
-	ASSIGN_AM_HANDLERS(29)
-	ASSIGN_AM_HANDLERS(30)
-	ASSIGN_AM_HANDLERS(31)
-	ASSIGN_AM_HANDLERS(32)
-	ASSIGN_AM_HANDLERS(33)
-	ASSIGN_AM_HANDLERS(34)
-	ASSIGN_AM_HANDLERS(35)
-	ASSIGN_AM_HANDLERS(36)
-	ASSIGN_AM_HANDLERS(37)
-	ASSIGN_AM_HANDLERS(38)
-	ASSIGN_AM_HANDLERS(39)
-	ASSIGN_AM_HANDLERS(40)
-	ASSIGN_AM_HANDLERS(41)
-	ASSIGN_AM_HANDLERS(42)
-	ASSIGN_AM_HANDLERS(43)
-	ASSIGN_AM_HANDLERS(44)
-	ASSIGN_AM_HANDLERS(45)
-	ASSIGN_AM_HANDLERS(46)
-	ASSIGN_AM_HANDLERS(47)
-	ASSIGN_AM_HANDLERS(48)
-	ASSIGN_AM_HANDLERS(49)
-	ASSIGN_AM_HANDLERS(50)
-	ASSIGN_AM_HANDLERS(51)
-	ASSIGN_AM_HANDLERS(52)
-	ASSIGN_AM_HANDLERS(53)
-	ASSIGN_AM_HANDLERS(54)
-	ASSIGN_AM_HANDLERS(55)
-	ASSIGN_AM_HANDLERS(56)
-	ASSIGN_AM_HANDLERS(57)
-	ASSIGN_AM_HANDLERS(58)
-	ASSIGN_AM_HANDLERS(59)
-	ASSIGN_AM_HANDLERS(60)
-	ASSIGN_AM_HANDLERS(61)
-	ASSIGN_AM_HANDLERS(62)
-	ASSIGN_AM_HANDLERS(63)
-	ASSIGN_AM_HANDLERS(64)
-	ASSIGN_AM_HANDLERS(65)
-	ASSIGN_AM_HANDLERS(66)
-	ASSIGN_AM_HANDLERS(67)
-	ASSIGN_AM_HANDLERS(68)
-	ASSIGN_AM_HANDLERS(69)
-	ASSIGN_AM_HANDLERS(70)
-	ASSIGN_AM_HANDLERS(71)
-	ASSIGN_AM_HANDLERS(72)
-	ASSIGN_AM_HANDLERS(73)
-	ASSIGN_AM_HANDLERS(74)
-	ASSIGN_AM_HANDLERS(75)
-	ASSIGN_AM_HANDLERS(76)
-	ASSIGN_AM_HANDLERS(77)
-	ASSIGN_AM_HANDLERS(78)
-	ASSIGN_AM_HANDLERS(79)
-}
-
-void psmx2_am_global_fini(void)
-{
-	fastlock_destroy(&psmx2_am_global.lock);
-}
-
 int psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt)
 {
 	struct slist_entry *item;
@@ -279,13 +65,14 @@ int psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt)
 
 int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 {
-	psm2_am_handler_fn_t psmx2_am_handlers[4];
+	psm2_am_handler_2_fn_t psmx2_am_handlers[4];
+	struct psmx2_trx_ctxt *hctx[4];
 	int psmx2_am_handlers_idx[4];
 	int num_handlers = 4;
+
 	psm2_ep_t psm2_ep = trx_ctxt->psm2_ep;
 	size_t size;
 	int err = 0;
-	int idx;
 	uint32_t max_atomic_size;
 
 	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
@@ -301,25 +88,17 @@ int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 		if (trx_ctxt->domain->max_atomic_size > max_atomic_size)
 			trx_ctxt->domain->max_atomic_size = max_atomic_size;
 
-		psmx2_lock(&psmx2_am_global.lock, 1);
-		if (psmx2_am_global.cnt >= PSMX2_AM_MAX_TRX_CTXT) {
-			psmx2_unlock(&psmx2_am_global.lock, 1);
-			FI_WARN(&psmx2_prov, FI_LOG_CORE,
-				"number of PSM2 endpoints exceed limit %d.\n",
-				PSMX2_AM_MAX_TRX_CTXT);
-			return -FI_EBUSY;
-		}
-
-		idx = psmx2_am_global.cnt++;
-		psmx2_am_handlers[0] = psmx2_am_global.rma_handlers[idx];
-		psmx2_am_handlers[1] = psmx2_am_global.atomic_handlers[idx];
+		psmx2_am_handlers[0] = psmx2_am_rma_handler;
+		hctx[0] = trx_ctxt;
+		psmx2_am_handlers[1] = psmx2_am_atomic_handler;
+		hctx[1] = trx_ctxt;
 		psmx2_am_handlers[2] = psmx2_am_sep_handler;
-		psmx2_am_handlers[3] = psmx2_am_global.trx_ctxt_handlers[idx];
-		psmx2_am_global.trx_ctxts[idx] = trx_ctxt;
-		psmx2_unlock(&psmx2_am_global.lock, 1);
+		hctx[2] = trx_ctxt;
+		psmx2_am_handlers[3] = psmx2_am_trx_ctxt_handler;
+		hctx[3] = trx_ctxt;
 
-		err = psm2_am_register_handlers(psm2_ep, psmx2_am_handlers,
-						num_handlers, psmx2_am_handlers_idx);
+		err = psm2_am_register_handlers_2(psm2_ep, psmx2_am_handlers,
+						num_handlers, (void **)hctx, psmx2_am_handlers_idx);
 		if (err)
 			return psmx2_errno(err);
 

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -409,9 +409,9 @@ static int psmx2_atomic_do_compwrite(void *dest, void *src, void *compare,
 	return 0;
 }
 
-int psmx2_am_atomic_handler_ext(psm2_am_token_t token,
+int psmx2_am_atomic_handler(psm2_am_token_t token,
 				psm2_amarg_t *args, int nargs, void *src,
-				uint32_t len, struct psmx2_trx_ctxt *trx_ctxt)
+				uint32_t len, void *hctx)
 {
 	psm2_amarg_t rep_args[8];
 	int count;
@@ -430,6 +430,8 @@ int psmx2_am_atomic_handler_ext(psm2_am_token_t token,
 	void *tmp_buf;
 	psm2_epaddr_t epaddr;
 	int cmd;
+	struct psmx2_trx_ctxt *trx_ctxt;
+	trx_ctxt = (struct psmx2_trx_ctxt *)hctx;
 
 	psm2_am_get_source(token, &epaddr);
 

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -72,7 +72,7 @@ static void psmx2_am_sep_completion(void *buf)
 }
 
 int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
-			 int nargs, void *src, uint32_t len)
+			 int nargs, void *src, uint32_t len, void *hctx)
 {
 	struct psmx2_fid_domain *domain;
 	psm2_amarg_t rep_args[8];

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -200,7 +200,6 @@ static int psmx2_domain_close(fid_t fid)
 	free(domain);
 
 	psmx2_atomic_global_fini();
-	psmx2_am_global_fini();
 	return 0;
 }
 
@@ -235,7 +234,6 @@ static int psmx2_domain_init(struct psmx2_fid_domain *domain,
 {
 	int err;
 
-	psmx2_am_global_init();
 	psmx2_atomic_global_init();
 
 	err = fastlock_init(&domain->mr_lock);

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -97,9 +97,9 @@ static inline void psmx2_iov_copy(struct iovec *iov, size_t count,
  *	args[2].u64	offset
  */
 
-int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
-			     int nargs, void *src, uint32_t len,
-			     struct psmx2_trx_ctxt *trx_ctxt)
+int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
+		int nargs, void *src, uint32_t len,
+		void *hctx)
 {
 	psm2_amarg_t rep_args[8];
 	uint8_t *rma_addr;
@@ -115,6 +115,8 @@ int psmx2_am_rma_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
 	psm2_epaddr_t epaddr;
 	struct psmx2_fid_domain *domain;
 	struct psmx2_fid_ep *ep;
+	struct psmx2_trx_ctxt *trx_ctxt;
+	trx_ctxt = (struct psmx2_trx_ctxt *)hctx;
 
 	psm2_am_get_source(token, &epaddr);
 

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -90,15 +90,17 @@ static int psmx2_peer_match(struct dlist_entry *item, const void *arg)
 	return  (peer->epaddr == arg);
 }
 
-int psmx2_am_trx_ctxt_handler_ext(psm2_am_token_t token, psm2_amarg_t *args,
+int psmx2_am_trx_ctxt_handler(psm2_am_token_t token, psm2_amarg_t *args,
 				  int nargs, void *src, uint32_t len,
-				  struct psmx2_trx_ctxt *trx_ctxt)
+				  void *hctx)
 {
 	psm2_epaddr_t epaddr;
 	int err = 0;
 	int cmd;
 	struct disconnect_args *disconn;
 	pthread_t disconnect_thread;
+	struct psmx2_trx_ctxt *trx_ctxt;
+	trx_ctxt = (struct psmx2_trx_ctxt *)hctx;
 
 	psm2_am_get_source(token, &epaddr);
 	cmd = PSMX2_AM_GET_OP(args[0].u32w0);


### PR DESCRIPTION
-Update PSM2 provider to register the AM handlers with the new
psm2_am_register_handlers_2 function which allows for the user to
register AM handlers with a calling context.

-Changed to registering psm2_am_handler_2_fn_t AM handler functions
which include the calling context.

-Allows for removal of internal context tracking and simplifies the AM
handler code.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>