### PR TITLE
prov/psm2: Abstract the completion polling mechanism

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -1112,7 +1112,7 @@ int	psmx2_mr_validate(struct psmx2_fid_mr *mr, uint64_t addr, size_t len, uint64
 void	psmx2_cntr_check_trigger(struct psmx2_fid_cntr *cntr);
 void	psmx2_cntr_add_trigger(struct psmx2_fid_cntr *cntr, struct psmx2_trigger *trigger);
 
-int	psmx2_handle_sendv_req(struct psmx2_fid_ep *ep, psm2_mq_status2_t *psm2_status,
+int	psmx2_handle_sendv_req(struct psmx2_fid_ep *ep, PSMX2_STATUS_TYPE *status,
 			       int multi_recv);
 
 static inline void psmx2_cntr_inc(struct psmx2_fid_cntr *cntr)

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -50,5 +50,34 @@
 #define PSMX2_DEFAULT_UUID	"00FF00FF-0000-0000-0000-00FF00FF00FF"
 #define PROVIDER_INI		PSM2_INI
 
+#define PSMX2_STATUS_TYPE	psm2_mq_status2_t
+#define PSMX2_STATUS_ERROR(s)	((s)->error_code)
+#define PSMX2_STATUS_TAG(s)	((s)->msg_tag)
+#define PSMX2_STATUS_RCVLEN(s)	((s)->nbytes)
+#define PSMX2_STATUS_SNDLEN(s)	((s)->msg_length)
+#define PSMX2_STATUS_PEER(s)	((s)->msg_peer)
+#define PSMX2_STATUS_CONTEXT(s)	((s)->context)
+
+/*
+ * psm2_mq_test2 is called immediately after psm2_mq_ipeek with a lock held to
+ * prevent psm2_mq_ipeek from returning the same request multiple times under
+ * different threads.
+ */
+#define PSMX2_POLL_COMPLETION(trx_ctxt, psm2_req, psm2_status, status, err) \
+	do { \
+		if (psmx2_trylock(&(trx_ctxt)->poll_lock, 2)) { \
+			(err) = PSM2_MQ_NO_COMPLETIONS; \
+		} else { \
+			(err) = psm2_mq_ipeek((trx_ctxt)->psm2_mq, &(psm2_req), NULL); \
+			if ((err) == PSM2_OK) { \
+				psm2_mq_test2(&(psm2_req), &(psm2_status)); \
+				(status) = &(psm2_status); \
+			} \
+			psmx2_unlock(&(trx_ctxt)->poll_lock, 2); \
+		} \
+	} while(0)
+
+#define PSMX2_FREE_COMPLETION(trx_ctxt, status)
+
 #endif
 


### PR DESCRIPTION
Use macros to abstract the completion status data structure and the way
completion is polled from PSM2. This allows switching to a different
implementation with minial code change.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>