### PR TITLE
prov/shm: initial RMA implementation

### DIFF
--- a/include/fi_proto.h
+++ b/include/fi_proto.h
@@ -119,6 +119,7 @@ enum {
 	ofi_op_read_req,
 	ofi_op_read_rsp,
 	ofi_op_write,
+	ofi_op_write_rsp,
 	ofi_op_atomic,
 };
 

--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -104,6 +104,7 @@ struct smr_addr {
 	fi_addr_t	addr;
 };
 
+#define SMR_RMA_IOV_LIMIT	3 //TODO find a way to avoid this?
 union smr_cmd_data {
 	uint8_t			msg[SMR_CMD_DATA_LEN];
 	struct iovec		iov[SMR_CMD_DATA_LEN / sizeof(struct iovec)];

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -192,6 +192,7 @@ struct util_domain {
 	int			mr_mode;
 	uint32_t		addr_format;
 	enum fi_av_type		av_type;
+	struct ofi_mr_map	mr_map;
 };
 
 int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -146,6 +146,25 @@ int ofi_mr_map_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 		      size_t len, uint64_t key, uint64_t access,
 		      void **context);
 
+struct ofi_mr {
+	struct fid_mr mr_fid;
+	struct util_domain *domain;
+	uint64_t key;
+	uint64_t flags;
+};
+
+int ofi_mr_close(struct fid *fid);
+int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
+		   uint64_t flags, struct fid_mr **mr_fid);
+int ofi_mr_regv(struct fid *fid, const struct iovec *iov,
+	        size_t count, uint64_t access, uint64_t offset,
+		uint64_t requested_key, uint64_t flags,
+		struct fid_mr **mr_fid, void *context);
+int ofi_mr_reg(struct fid *fid, const void *buf, size_t len,
+	       uint64_t access, uint64_t offset, uint64_t requested_key,
+	       uint64_t flags, struct fid_mr **mr_fid, void *context);
+int ofi_mr_verify(struct ofi_mr_map *map, ssize_t len,
+		  uintptr_t *addr, uint64_t key, uint64_t access);
 
 /*
  * Memory registration cache

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -116,7 +116,7 @@ struct rxd_domain {
 
 	ssize_t max_mtu_sz;
 	int mr_mode;
-	struct ofi_mr_map mr_map;
+	struct ofi_mr_map mr_map;//TODO use util_domain mr_map instead
 };
 
 struct rxd_av {

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -70,7 +70,6 @@ extern struct fi_provider smr_prov;
 extern struct fi_info smr_info;
 extern struct util_prov smr_util_prov;
 
-int smr_check_info(struct fi_info *info);
 int smr_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		void *context);
 

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -48,7 +48,7 @@ struct fi_rx_attr smr_rx_attr = {
 };
 
 struct fi_ep_attr smr_ep_attr = {
-	.type = FI_EP_DGRAM,
+	.type = FI_EP_RDM,
 	.protocol = FI_PROTO_SHM,
 	.protocol_version = 1,
 	.max_msg_size = SIZE_MAX,

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -33,7 +33,7 @@
 #include "smr.h"
 
 struct fi_tx_attr smr_tx_attr = {
-	.caps = FI_MSG | FI_SEND,
+	.caps = FI_MSG | FI_SEND | FI_READ | FI_WRITE,
 	.comp_order = FI_ORDER_STRICT,
 	.inject_size = SMR_INJECT_SIZE,
 	.size = 1024,
@@ -63,7 +63,7 @@ struct fi_domain_attr smr_domain_attr = {
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_ENABLED,
 	.av_type = FI_AV_UNSPEC,
-	.mr_mode = FI_MR_BASIC,
+	.mr_mode = FI_MR_VIRT_ADDR,
 	.cq_cnt = (1 << 10),
 	.ep_cnt = (1 << 10),
 	.tx_ctx_cnt = (1 << 10),
@@ -78,7 +78,8 @@ struct fi_fabric_attr smr_fabric_attr = {
 };
 
 struct fi_info smr_info = {
-	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE | FI_TAGGED,
+	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE | FI_TAGGED | FI_RMA |
+		FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE,
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &smr_tx_attr,
 	.rx_attr = &smr_rx_attr,

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -76,7 +76,7 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct smr_domain *smr_domain;
 	struct smr_fabric *smr_fabric;
 
-	ret = smr_check_info(info);
+	ret = ofi_prov_check_info(&smr_util_prov, fabric->api_version, info);
 	if (ret)
 		return ret;
 

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -69,6 +69,13 @@ static struct fi_ops smr_domain_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
+static struct fi_ops_mr smr_mr_ops = {
+	.size = sizeof(struct fi_ops_mr),
+	.reg = ofi_mr_reg,
+	.regv = ofi_mr_regv,
+	.regattr = ofi_mr_regattr,
+};
+
 int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		struct fid_domain **domain, void *context)
 {
@@ -98,5 +105,7 @@ int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	*domain = &smr_domain->util_domain.domain_fid;
 	(*domain)->fid.ops = &smr_domain_fi_ops;
 	(*domain)->ops = &smr_domain_ops;
+	(*domain)->mr = &smr_mr_ops;
+
 	return 0;
 }

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -1046,6 +1046,8 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 		attr.rx_count = ep->rx_size;
 		attr.tx_count = ep->tx_size;
 		ret = smr_create(&smr_prov, av->smr_map, &attr, &ep->region);
+		if (ret)
+			return ret;
 		smr_exchange_all_peers(ep->region);
 		break;
 	default:

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -36,11 +36,6 @@
 #include "smr.h"
 
 
-int smr_check_info(struct fi_info *info)
-{
-	return ofi_prov_check_info(&smr_util_prov, smr_util_prov.prov->version, info);
-}
-
 static int smr_getinfo(uint32_t version, const char *node, const char *service,
 			uint64_t flags, const struct fi_info *hints, struct fi_info **info)
 {


### PR DESCRIPTION
- change EP type from DGRAM to RDM
- fix check_info bug
- simplify peer verification
- add MR registration calls
- implement RMA transfers using 2 methods:
 (1) send RMA by inserting 2 commands into and let peer do transfer through CMA call (for large writes and all reads) or inline (for smaller writes)
(2) no peer MR verification, local side does complete transfer using CMA call

Currently, method is chosen based on number of rma iovs, but can adapt later for increased performance based on other variables/settings

Signed-off-by: aingerson <alexia.ingerson@intel.com>