### PR TITLE
prov/psm2: Add an environment variable for automatic connection cleanup

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -208,6 +208,21 @@ The *psm2* provider checks for the following environment variables:
 
   The default setting is 0.
 
+*FI_PSM2_DISCONNECT
+: The provider has a mechanism to automatically send disconnection notifications
+  to all connected peers before the local endpoint is closed. As the response,
+  the peers call *psm2_ep_disconnect* to clean up the connection state at their
+  side. This allows the same PSM2 epid be used by different dynamically started
+  processes (clients) to communicate with the same peer (server). This mechanism,
+  however, introduce extra overhead to the finalization phase. For applications
+  that never reuse epids within the same session such overhead is unnecessary.
+
+  This option controls whether the automatic disconnection notification mechanism
+  should be enabled. For client-server application mentioned above, the client
+  side should set this option to 1, but the server should set it to 0.
+
+  The default setting is 0.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -835,6 +835,7 @@ struct psmx2_env {
 	int inject_size;
 	int lock_level;
 	int lazy_conn;
+	int disconnect;
 };
 
 extern struct fi_ops_mr		psmx2_mr_ops;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -54,6 +54,7 @@ struct psmx2_env psmx2_env = {
 	.inject_size	= 64,
 	.lock_level	= 2,
 	.lazy_conn	= 0,
+	.disconnect	= 0,
 };
 
 static void psmx2_init_env(void)
@@ -71,6 +72,7 @@ static void psmx2_init_env(void)
 	fi_param_get_int(&psmx2_prov, "inject_size", &psmx2_env.inject_size);
 	fi_param_get_bool(&psmx2_prov, "lock_level", &psmx2_env.lock_level);
 	fi_param_get_bool(&psmx2_prov, "lazy_conn", &psmx2_env.lazy_conn);
+	fi_param_get_bool(&psmx2_prov, "disconnect", &psmx2_env.disconnect);
 }
 
 static int psmx2_get_yes_no(char *s, int default_value)
@@ -825,6 +827,9 @@ PROVIDER_INI
 
 	fi_param_define(&psmx2_prov, "lazy_conn", FI_PARAM_BOOL,
 			"Whether to use lazy connection or not (default: no).");
+
+	fi_param_define(&psmx2_prov, "disconnect", FI_PARAM_BOOL,
+			"Whether to issue disconnect request when process ends (default: no).");
 
 	pthread_mutex_init(&psmx2_lib_mutex, NULL);
 	psmx2_init_count++;

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -171,7 +171,8 @@ void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt)
 	if (!trx_ctxt)
 		return;
 
-	psmx2_trx_ctxt_disconnect_peers(trx_ctxt);
+	if (psmx2_env.disconnect)
+		psmx2_trx_ctxt_disconnect_peers(trx_ctxt);
 
 	if (trx_ctxt->am_initialized)
 		psmx2_am_fini(trx_ctxt);


### PR DESCRIPTION
The automatic connection cleanup mechanism introduces extra overhead at
the finalization phase, which is unnecessary for most applications since
they never reuse epids within a session.

Add the environment variable FI_PSM2_DISCONNECT to control whether this
mechanism is used.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>