### PR TITLE
prov/util: Fix potential deadlock in name server thread

### DIFF
--- a/prov/util/src/util_ns.c
+++ b/prov/util/src/util_ns.c
@@ -63,7 +63,7 @@ int util_ns_##op##_socket_op(SOCKET sock, void *buf, size_t len)		\
 		ret = ofi_##op##_socket((sock),					\
 					(void *)((char *) (buf) + bytes),	\
 					(len) - bytes);				\
-		if (ret < 0)							\
+		if (ret <= 0)							\
 			return -1;						\
 	}									\
 	return 0;								\


### PR DESCRIPTION
Blocking read/write returns 0 only when the peer is closed or encounters
EOF. Keep issuing the same call will result in infinite loop. Treat 0 the
same way as error because the required bytes to read/write will never be
satisfied.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>