### PR TITLE
prov/verbs: Fix Coverity issues

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -667,7 +667,7 @@ static int fi_ibv_read_params(void)
 	}
 	if (fi_ibv_get_param_int("mr_cache_size", "Maximum number of cache entries",
 				 &fi_ibv_gl_data.mr_cache_size) ||
-	    (fi_ibv_gl_data.mr_cache_lazy_size < 0)) {
+	    (fi_ibv_gl_data.mr_cache_size < 0)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of mr_cache_size\n");
 		return -FI_EINVAL;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -177,7 +177,7 @@ static void fi_ibv_mem_notifier_finalize(struct fi_ibv_mem_notifier *notifier)
 		util_buf_pool_destroy(fi_ibv_mem_notifier->mem_ptrs_ent_pool);
 		fi_ibv_mem_notifier->prev_free_hook = NULL;
 		fi_ibv_mem_notifier->prev_realloc_hook = NULL;
-		pthread_mutex_lock(&fi_ibv_mem_notifier->lock);
+		pthread_mutex_unlock(&fi_ibv_mem_notifier->lock);
 		pthread_mutex_destroy(&fi_ibv_mem_notifier->lock);
 		free(fi_ibv_mem_notifier);
 		fi_ibv_mem_notifier = NULL;


### PR DESCRIPTION
This patch addresses Coverity issues that are reported  12/23/17:
- CID 215114: Copy-paste error
- CID 215113: Double lock of pthread mutex
this code doesn't cause program hanging because pthread mutex is marked as `Reentrant`