### PR TITLE
prov/verbs: Optimize verbs/RDM critical path

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -80,14 +80,13 @@ fi_ibv_rdm_start_connection(struct fi_ibv_rdm_ep *ep,
 	return FI_SUCCESS;
 }
 
-ssize_t
-fi_ibv_rdm_start_overall_disconnection(struct fi_ibv_rdm_av_entry *av_entry)
+/* Must call with `rdm_cm::cm_lock` held */
+ssize_t fi_ibv_rdm_start_overall_disconnection(struct fi_ibv_rdm_av_entry *av_entry)
 {
 	struct fi_ibv_rdm_conn *conn = NULL, *tmp = NULL;
 	ssize_t ret = FI_SUCCESS;
 	ssize_t err = FI_SUCCESS;
 
-	pthread_mutex_lock(&av_entry->conn_lock);
 	HASH_ITER(hh, av_entry->conn_hash, conn, tmp) {
 		ret = fi_ibv_rdm_start_disconnection(conn);
 		if (ret) {
@@ -101,7 +100,6 @@ fi_ibv_rdm_start_overall_disconnection(struct fi_ibv_rdm_av_entry *av_entry)
 		 * cleanup of the connections.
 		 */
 	}
-	pthread_mutex_unlock(&av_entry->conn_lock);
 
 	return err;
 }
@@ -159,7 +157,6 @@ int fi_ibv_av_entry_alloc(struct fi_ibv_domain *domain,
 		 FI_IBV_RDM_DFLT_ADDRLEN, (*av_entry));
 	ofi_atomic_initialize32(&(*av_entry)->sends_outgoing, 0);
 	ofi_atomic_initialize32(&(*av_entry)->recv_preposted, 0);
-	pthread_mutex_init(&(*av_entry)->conn_lock, NULL);
 
 	return ret;
 }
@@ -446,7 +443,6 @@ static int fi_ibv_rdm_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 		return -FI_EINVAL;
 
 	pthread_mutex_lock(&av->domain->rdm_cm->cm_lock);
-
 	for (i = 0; i < count; i++) {
 
 		if (fi_addr[i] == FI_ADDR_NOTAVAIL)
@@ -472,7 +468,6 @@ static int fi_ibv_rdm_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 		slist_insert_tail(&av_entry->removed_next,
 				  &av->domain->rdm_cm->av_removed_entry_head);
 	}
-
 	pthread_mutex_unlock(&av->domain->rdm_cm->cm_lock);
 	return ret;
 }
@@ -564,10 +559,7 @@ fi_ibv_rdm_conn_to_av_map_addr(struct fi_ibv_rdm_ep *ep,
     return fi_ibv_rdm_av_entry_to_av_map_addr(ep, conn->av_entry);
 }
 
-/* Must call with `rdm_cm::cm_lock` and `av_entry::conn_lock` held
- * - `rdm_cm::cm_lock` - to start a connections
- * - `av_entry::conn_lock` - to add a connection entry to av_entry::hash
- */
+/* Must call with `rdm_cm::cm_lock` held */
 static inline struct fi_ibv_rdm_conn *
 fi_ibv_rdm_conn_entry_alloc(struct fi_ibv_rdm_av_entry *av_entry,
 			    struct fi_ibv_rdm_ep *ep)
@@ -598,42 +590,40 @@ static inline struct fi_ibv_rdm_conn *
 fi_ibv_rdm_av_map_addr_to_conn_add_new_conn(struct fi_ibv_rdm_ep *ep,
 					    fi_addr_t addr)
 {
-	struct fi_ibv_rdm_conn *conn = NULL;
 	struct fi_ibv_rdm_av_entry *av_entry =
 		fi_ibv_rdm_av_map_addr_to_av_entry(ep, addr);
 	if (av_entry) {
+		struct fi_ibv_rdm_conn *conn;
 		pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
-		pthread_mutex_lock(&av_entry->conn_lock);
 		HASH_FIND(hh, av_entry->conn_hash,
 			  &ep, sizeof(struct fi_ibv_rdm_ep *), conn);
-		if (!conn)
+		if (OFI_UNLIKELY(!conn))
 			conn = fi_ibv_rdm_conn_entry_alloc(av_entry, ep);
-		pthread_mutex_unlock(&av_entry->conn_lock);
 		pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
+		return conn;
 	}
 
-	return conn;
+	return NULL;
 }
 
 static inline struct fi_ibv_rdm_conn *
 fi_ibv_rdm_av_tbl_idx_to_conn_add_new_conn(struct fi_ibv_rdm_ep *ep,
 					   fi_addr_t addr)
 {
-	struct fi_ibv_rdm_conn *conn = NULL;
 	struct fi_ibv_rdm_av_entry *av_entry =
 		fi_ibv_rdm_av_tbl_idx_to_av_entry(ep, addr);
 	if (av_entry) {
+		struct fi_ibv_rdm_conn *conn;
 		pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
-		pthread_mutex_lock(&av_entry->conn_lock);
 		HASH_FIND(hh, av_entry->conn_hash,
 			  &ep, sizeof(struct fi_ibv_rdm_ep *), conn);
-		if (!conn)
+		if (OFI_UNLIKELY(!conn))
 			conn = fi_ibv_rdm_conn_entry_alloc(av_entry, ep);
-		pthread_mutex_unlock(&av_entry->conn_lock);
 		pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
+		return conn;
 	}
 
-	return conn;
+	return NULL;
 }
 
 int fi_ibv_rdm_av_open(struct fid_domain *domain, struct fi_av_attr *attr,

--- a/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_av_ep_rdm.c
@@ -155,8 +155,8 @@ int fi_ibv_av_entry_alloc(struct fi_ibv_domain *domain,
 	memcpy(&(*av_entry)->addr, addr, FI_IBV_RDM_DFLT_ADDRLEN);
 	HASH_ADD(hh, domain->rdm_cm->av_hash, addr,
 		 FI_IBV_RDM_DFLT_ADDRLEN, (*av_entry));
-	ofi_atomic_initialize32(&(*av_entry)->sends_outgoing, 0);
-	ofi_atomic_initialize32(&(*av_entry)->recv_preposted, 0);
+	(*av_entry)->sends_outgoing = 0;
+	(*av_entry)->recv_preposted = 0;
 
 	return ret;
 }

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -229,14 +229,14 @@ static ssize_t fi_ibv_rdm_cancel(fid_t fid, void *ctx)
 		dlist_find_first_match(&ep_rdm->fi_ibv_rdm_posted_queue,
 					fi_ibv_rdm_req_match, request);
 	if (found) {
-		int32_t posted_recvs;
+		uint32_t posted_recvs;
 
 		assert(container_of(found, struct fi_ibv_rdm_request,
 				    queue_entry) == request);
 		request->context->internal[0] = NULL;
 		posted_recvs = fi_ibv_rdm_remove_from_posted_queue(request, ep_rdm);
 		(void)posted_recvs;
-		VERBS_DBG(FI_LOG_EP_DATA, "\t\t-> SUCCESS, post recv %d\n",
+		VERBS_DBG(FI_LOG_EP_DATA, "\t\t-> SUCCESS, post recv %"PRIu32"\n",
 			  posted_recvs);
 		err = 0;
 	} else {
@@ -347,7 +347,7 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 	ep->is_closing = 1;
 
 	/* All posted sends are waiting local completions */
-	while (ofi_atomic_get32(&ep->posted_sends) > 0 && ep->num_active_conns > 0)
+	while (ep->posted_sends > 0 && ep->num_active_conns > 0)
 		fi_ibv_rdm_tagged_poll(ep);
 
 	if (ep->send_cntr) {
@@ -619,8 +619,8 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 		goto err2;
 	}
 
-	ofi_atomic_initialize32(&_ep->posted_sends, 0);
-	ofi_atomic_initialize32(&_ep->posted_recvs, 0);
+	_ep->posted_sends = 0;
+	_ep->posted_recvs = 0;
 	_ep->recv_preposted_threshold = MAX(0.2 * _ep->rq_wr_depth, _ep->n_buffs);
 	VERBS_INFO(FI_LOG_EP_CTRL, "recv preposted threshold: %d\n",
 		   _ep->recv_preposted_threshold);

--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -164,10 +164,8 @@ static int fi_ibv_rdm_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		break;
 	case FI_CLASS_AV:
 		av = container_of(bfid, struct fi_ibv_av, av_fid.fid);
-		if (ep->domain != av->domain) {
+		if (ep->domain != av->domain)
 			return -FI_EINVAL;
-		}
-
 		ep->av = av;
 		break;
 	case FI_CLASS_CNTR:
@@ -376,7 +374,7 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 				 fi_ibv_rdm_ep_match, ep);
 
 	HASH_ITER(hh, ep->domain->rdm_cm->av_hash, av_entry, tmp) {
-		pthread_mutex_lock(&av_entry->conn_lock);
+		pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
 		HASH_FIND(hh, av_entry->conn_hash, &ep,
 			  sizeof(struct fi_ibv_rdm_ep *), conn);
 		if (conn) {
@@ -384,11 +382,11 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 			case FI_VERBS_CONN_ALLOCATED:
 			case FI_VERBS_CONN_ESTABLISHED:
 				ret = fi_ibv_rdm_start_disconnection(conn);
-				pthread_mutex_unlock(&av_entry->conn_lock);
+				pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
 				break;
 			case FI_VERBS_CONN_STARTED:
-				pthread_mutex_unlock(&av_entry->conn_lock);
-				/* No need to hold conn_lock during
+				pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
+				/* No need to hold `rdm_cm::cm_lock` during
 				 * CM progressing of the EP */
 				while (conn->state != FI_VERBS_CONN_ESTABLISHED &&
 				       conn->state != FI_VERBS_CONN_REJECTED &&
@@ -402,23 +400,23 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 				}
 				break;
 			default:
-				pthread_mutex_unlock(&av_entry->conn_lock);
+				pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
 				break;
 			}
 		} else {
-			pthread_mutex_unlock(&av_entry->conn_lock);
+			pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
 		}
 	}
 
         /* ok, all connections are initiated to disconnect. now wait
 	 * till all connections are switch to state 'closed' */
 	HASH_ITER(hh, ep->domain->rdm_cm->av_hash, av_entry, tmp) {
-		pthread_mutex_lock(&av_entry->conn_lock);
+		pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
 		HASH_FIND(hh, av_entry->conn_hash, &ep,
 			  sizeof(struct fi_ibv_rdm_ep *), conn);
-		pthread_mutex_unlock(&av_entry->conn_lock);
+		pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
 		if (conn) {
-			/* No need to hold conn_lock during
+			/* No need to hold `rdm_cm::cm_lock` during
 			 * polling of receive CQ */
 			while(conn->state != FI_VERBS_CONN_CLOSED &&
 			      conn->state != FI_VERBS_CONN_ALLOCATED) {
@@ -434,38 +432,38 @@ static int fi_ibv_rdm_ep_close(fid_t fid)
 
         /* now destroy all connections that wasn't removed from HASH */
 	HASH_ITER(hh, ep->domain->rdm_cm->av_hash, av_entry, tmp) {
-		pthread_mutex_lock(&av_entry->conn_lock);
+		pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
 		HASH_FIND(hh, av_entry->conn_hash, &ep,
 			  sizeof(struct fi_ibv_rdm_ep *), conn);
 		if (conn) {
 			HASH_DEL(av_entry->conn_hash, conn);
-			pthread_mutex_unlock(&av_entry->conn_lock);
-			/* No need to hold conn_lock during
+			pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
+			/* No need to hold `rdm_cm::cm_lock` during
 			 * connection cleanup */
 			fi_ibv_rdm_conn_cleanup(conn);
 		} else {
-			pthread_mutex_unlock(&av_entry->conn_lock);
+			pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
 		}
 	}
 
 	/* now destroy all connection that was removed from HASH */
 	slist_foreach(&ep->domain->rdm_cm->av_removed_entry_head,
 		      item, prev_item) {
-		(void) prev_item; /* Compiler complains about unused variable */
+		OFI_UNUSED(prev_item); /* Compiler complains about unused variable */
 		av_entry = container_of(item,
 					struct fi_ibv_rdm_av_entry,
 					removed_next);
-		pthread_mutex_lock(&av_entry->conn_lock);
+		pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
 		HASH_FIND(hh, av_entry->conn_hash, &ep,
 			  sizeof(struct fi_ibv_rdm_ep *), conn);
 		if (conn) {
 			HASH_DEL(av_entry->conn_hash, conn);
-			pthread_mutex_unlock(&av_entry->conn_lock);
-			/* No need to hold conn_lock during
+			pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
+			/* No need to hold `rdm_cm::cm_lock` during
 			 * connection cleanup */
 			fi_ibv_rdm_conn_cleanup(conn);
 		} else {
-			pthread_mutex_unlock(&av_entry->conn_lock);
+			pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
 		}
 		/* do NOT free av_entry and do NOT remove from
 		 * the List of removed AV entries, becasue we need to

--- a/prov/verbs/src/ep_rdm/verbs_queuing.h
+++ b/prov/verbs/src/ep_rdm/verbs_queuing.h
@@ -135,7 +135,7 @@ fi_ibv_rdm_move_to_posted_queue(struct fi_ibv_rdm_request *request,
 {
 	FI_IBV_RDM_DBG_REQUEST("move_to_posted_queue: ", request, FI_LOG_DEBUG);
 	dlist_insert_tail(&request->queue_entry, &ep->fi_ibv_rdm_posted_queue);
-	ofi_atomic_inc32(&ep->posted_recvs);
+	ep->posted_recvs++;
 #if ENABLE_DEBUG
 	if (request->minfo.conn) {
 		request->minfo.conn->exp_counter++;
@@ -143,14 +143,14 @@ fi_ibv_rdm_move_to_posted_queue(struct fi_ibv_rdm_request *request,
 #endif // ENABLE_DEBUG
 }
 
-static inline int32_t
+static inline uint32_t
 fi_ibv_rdm_remove_from_posted_queue(struct fi_ibv_rdm_request *request,
 				    struct fi_ibv_rdm_ep *ep)
 {
 	FI_IBV_RDM_DBG_REQUEST("remove_from_posted_queue: ", request,
 				FI_LOG_DEBUG);
 	dlist_remove(&request->queue_entry);
-	return ofi_atomic_dec32(&ep->posted_recvs);
+	return ep->posted_recvs--;
 }
 
 static inline struct fi_ibv_rdm_request *

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -59,7 +59,7 @@
  *                                    IBV_RDM_ST_PKTYPE_MASK
  */
 
-// WR - work request
+/* WR - work request */
 #define FI_IBV_RDM_SERVICE_WR_MASK              ((uint64_t)0x1)
 #define FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(value)	\
         (value & FI_IBV_RDM_SERVICE_WR_MASK)
@@ -73,8 +73,7 @@
 #define FI_IBV_RDM_UNPACK_SERVICE_WR(value)				\
         ((void *)(uintptr_t)(value & (~(FI_IBV_RDM_SERVICE_WR_MASK))))
 
-// Send/Recv counters control
-
+/* Send/Recv counters control */
 #define FI_IBV_RDM_INC_SIG_POST_COUNTERS(_connection, _ep)			\
 do {                                                                		\
 	int32_t sends_outgoing =						\
@@ -354,7 +353,6 @@ enum fi_rdm_cm_role {
 
 struct fi_ibv_rdm_av_entry {
 	/* association of conn and EPs */
-	pthread_mutex_t		conn_lock;
 	struct fi_ibv_rdm_conn	*conn_hash;
 	struct sockaddr_in	addr;
 	ofi_atomic32_t		sends_outgoing;

--- a/prov/verbs/src/ep_rdm/verbs_rdm.h
+++ b/prov/verbs/src/ep_rdm/verbs_rdm.h
@@ -74,36 +74,27 @@
         ((void *)(uintptr_t)(value & (~(FI_IBV_RDM_SERVICE_WR_MASK))))
 
 /* Send/Recv counters control */
-#define FI_IBV_RDM_INC_SIG_POST_COUNTERS(_connection, _ep)			\
-do {                                                                		\
-	int32_t sends_outgoing =						\
-		ofi_atomic_inc32(&(_connection)->av_entry->sends_outgoing);	\
-	ofi_atomic_inc32(&(_ep)->posted_sends);					\
-										\
-	(void)sends_outgoing;							\
-	VERBS_DBG(FI_LOG_CQ, "SEND_COUNTER++, conn %p, sends_outgoing %d\n",    \
-		  _connection, sends_outgoing);					\
+#define FI_IBV_RDM_INC_SIG_POST_COUNTERS(_connection, _ep)				\
+do {                                                                			\
+	(_connection)->av_entry->sends_outgoing++;					\
+	(_ep)->posted_sends++;								\
+	VERBS_DBG(FI_LOG_CQ, "SEND_COUNTER++, conn %p, sends_outgoing %"PRIu32"\n",	\
+		  _connection, (_connection)->av_entry->sends_outgoing);		\
 } while (0)
 
-#define FI_IBV_RDM_DEC_SIG_POST_COUNTERS(_connection, _ep)			\
-do {										\
-	int32_t sends_outgoing =						\
-		ofi_atomic_dec32(&(_connection)->av_entry->sends_outgoing);	\
-	int32_t posted_sends = ofi_atomic_dec32(&(_ep)->posted_sends);		\
-										\
-	(void)sends_outgoing;							\
-	(void)posted_sends;							\
-	VERBS_DBG(FI_LOG_CQ, "SEND_COUNTER--, conn %p, sends_outgoing %d\n",	\
-		  _connection, sends_outgoing);					\
-	assert(posted_sends >= 0);						\
-	assert(sends_outgoing >= 0);						\
+#define FI_IBV_RDM_DEC_SIG_POST_COUNTERS(_connection, _ep)				\
+do {											\
+	(_connection)->av_entry->sends_outgoing--;					\
+	(_ep)->posted_sends--;								\
+	VERBS_DBG(FI_LOG_CQ, "SEND_COUNTER--, conn %p, sends_outgoing %"PRIu32"\n",	\
+		  _connection, (_connection)->av_entry->sends_outgoing);		\
 } while (0)
 
-#define OUTGOING_POST_LIMIT(_connection, _ep)							\
-	(ofi_atomic_get32(&(_connection)->av_entry->sends_outgoing) >= (_ep)->sq_wr_depth - 1)
+#define OUTGOING_POST_LIMIT(_connection, _ep)					\
+	((_connection)->av_entry->sends_outgoing >= (_ep)->sq_wr_depth - 1)
 
 #define PEND_POST_LIMIT(_ep)						\
-	(ofi_atomic_get32(&(_ep)->posted_sends) > 0.5 * (_ep)->scq_depth)
+	((_ep)->posted_sends > 0.5 * (_ep)->scq_depth)
 
 #define TSEND_RESOURCES_IS_BUSY(_connection, _ep)			\
 	(OUTGOING_POST_LIMIT(_connection, _ep) || PEND_POST_LIMIT(_ep))
@@ -321,8 +312,8 @@ struct fi_ibv_rdm_ep {
 	int	n_buffs;
 	int	rq_wr_depth;    // RQ depth
 	int	sq_wr_depth;    // SQ depth
-	ofi_atomic32_t	posted_sends;
-	ofi_atomic32_t	posted_recvs;
+	uint32_t	posted_sends;
+	uint32_t	posted_recvs;
 	int	num_active_conns;
 	int	max_inline_rc;
 	int	rndv_threshold;
@@ -355,8 +346,8 @@ struct fi_ibv_rdm_av_entry {
 	/* association of conn and EPs */
 	struct fi_ibv_rdm_conn	*conn_hash;
 	struct sockaddr_in	addr;
-	ofi_atomic32_t		sends_outgoing;
-	ofi_atomic32_t		recv_preposted;
+	uint32_t		sends_outgoing;
+	uint32_t		recv_preposted;
 	struct slist_entry	removed_next;
 	UT_hash_handle		hh;
 };
@@ -742,10 +733,10 @@ fi_ibv_rdm_process_err_send_wc(struct fi_ibv_rdm_ep *ep,
 			util_buf_release(ep->fi_ibv_rdm_request_pool, req);
 		}
 		VERBS_INFO(FI_LOG_EP_DATA, "got ibv_wc.status = %d:%s, "
-			   "pend_send: %d, connection: %p, request = %p (%s)\n",
+			   "pend_send: %"PRIu32", connection: %p, request = %p (%s)\n",
 			   wc->status,
 			   ibv_wc_status_str(wc->status),
-			   ofi_atomic_get32(&ep->posted_sends), conn,
+			   ep->posted_sends, conn,
 			   (void *)wc->wr_id,
 			   FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wc->wr_id) ?
 				"service" : "not service");

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -100,7 +100,7 @@ fi_ibv_rdm_batch_repost_receives(struct fi_ibv_rdm_conn *conn,
 	}
 
 	if (ibv_post_recv(conn->qp[idx], wr, &bad_wr) == 0) {
-		ofi_atomic_add32(&conn->av_entry->recv_preposted, num_to_post);
+		conn->av_entry->recv_preposted += num_to_post;
 		return num_to_post;
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -364,7 +364,7 @@ fi_ibv_rdm_process_connect_request(const struct rdma_cm_event *event,
 		  FI_IBV_RDM_DFLT_ADDRLEN, av_entry);
 
 	if (!av_entry) {
-		ret = fi_ibv_av_entry_alloc(ep->domain,&av_entry, p);
+		ret = fi_ibv_av_entry_alloc(ep->domain, &av_entry, p);
 		if (ret)
 			return ret;
 
@@ -372,7 +372,6 @@ fi_ibv_rdm_process_connect_request(const struct rdma_cm_event *event,
 				   FI_IBV_MEM_ALIGNMENT,
 				   sizeof(*conn));
 		if (ret) {
-			pthread_mutex_destroy(&av_entry->conn_lock);
 			ofi_freealign(av_entry);
 			return -ret;
 		}
@@ -392,17 +391,14 @@ fi_ibv_rdm_process_connect_request(const struct rdma_cm_event *event,
 			   conn, conn->cm_role, inet_ntoa(conn->addr.sin_addr),
 			   ntohs(conn->addr.sin_port));
 	} else {
-		pthread_mutex_lock(&av_entry->conn_lock);
 		HASH_FIND(hh, av_entry->conn_hash, &ep,
 			  sizeof(struct fi_ibv_rdm_ep *), conn);
 		if (!conn) {
 			ret = ofi_memalign((void**)&conn,
 					   FI_IBV_MEM_ALIGNMENT,
 					   sizeof(*conn));
-			if (ret) {
-				pthread_mutex_unlock(&av_entry->conn_lock);
+			if (ret)
 				return -ret;
-			}
 			memset(conn, 0, sizeof(*conn));
 			conn->ep = ep;
 			conn->av_entry = av_entry;
@@ -412,7 +408,6 @@ fi_ibv_rdm_process_connect_request(const struct rdma_cm_event *event,
 			HASH_ADD(hh, av_entry->conn_hash, ep,
 				 sizeof(struct fi_ibv_rdm_ep *), conn);
 		}
-		pthread_mutex_unlock(&av_entry->conn_lock);
 		fi_ibv_rdm_conn_init_cm_role(conn, ep);
 		if (conn->cm_role != FI_VERBS_CM_ACTIVE) {
 			/*
@@ -551,13 +546,15 @@ fi_ibv_rdm_process_event_established(const struct rdma_cm_event *event,
 	return FI_SUCCESS;
 }
 
+/* since the function is invoked only in the `fi_ibv_domain_close`
+ * after CM progress thread is closed, it's unnecessary to call this
+ * with `rdm_cm::cm_lock held` */
 ssize_t fi_ibv_rdm_overall_conn_cleanup(struct fi_ibv_rdm_av_entry *av_entry)
 {
 	struct fi_ibv_rdm_conn *conn = NULL, *tmp = NULL;
 	ssize_t ret = FI_SUCCESS;
 	ssize_t err = FI_SUCCESS;
 
-	pthread_mutex_lock(&av_entry->conn_lock);
 	HASH_ITER(hh, av_entry->conn_hash, conn, tmp) {
 		ret = fi_ibv_rdm_conn_cleanup(conn);
 		if (ret) {
@@ -566,7 +563,6 @@ ssize_t fi_ibv_rdm_overall_conn_cleanup(struct fi_ibv_rdm_av_entry *av_entry)
 			err = ret;
 		}
 	}
-	pthread_mutex_unlock(&av_entry->conn_lock);
 
 	return err;
 }
@@ -743,6 +739,7 @@ fi_ibv_rdm_process_timewait_exit_event(const struct rdma_cm_event *event,
 	}
 }
 
+/* Must call with `rdm_cm::cm_lock held` */
 static ssize_t
 fi_ibv_rdm_process_event(const struct rdma_cm_event *event, struct fi_ibv_rdm_ep *ep)
 {
@@ -834,11 +831,8 @@ ssize_t fi_ibv_rdm_cm_progress(struct fi_ibv_rdm_ep *ep)
 		}
 
 		pthread_mutex_lock(&ep->domain->rdm_cm->cm_lock);
-
 		ret = fi_ibv_rdm_process_event(&event_copy, ep);
-
 		pthread_mutex_unlock(&ep->domain->rdm_cm->cm_lock);
-
 	} while (ret == FI_SUCCESS);
 
 	return ret;

--- a/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_msg.c
@@ -80,9 +80,9 @@ static ssize_t fi_ibv_rdm_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 				  &recv_data);
 
 	VERBS_DBG(FI_LOG_EP_DATA,
-		  "conn %p, len %zu, rbuf %p, fi_ctx %p, posted_recv %d\n",
+		  "conn %p, len %zu, rbuf %p, fi_ctx %p, posted_recv %"PRIu32"\n",
 		  conn, recv_data.data_len, recv_data.dest_addr,
-		  msg->context, ofi_atomic_get32(&ep_rdm->posted_recvs));
+		  msg->context, ep_rdm->posted_recvs);
 
 	if (!ret && !request->state.err)
 		ret = rdm_trecv_second_event(request, ep_rdm);

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -312,11 +312,11 @@ fi_ibv_rdm_rndv_rts_send_ready(struct fi_ibv_rdm_request *request, void *data)
 			       FI_IBV_RDM_RNDV_RTS_PKT);
 
 	VERBS_DBG(FI_LOG_EP_DATA,
-		  "fi_senddatato: RNDV conn %p, tag 0x%" PRIx64 ", len %" PRIu64
-		  ", src_addr %p, rkey 0x%"PRIx64", fi_ctx %p, imm %d, post_send %d\n",
+		  "fi_senddatato: RNDV conn %p, tag 0x%" PRIx64 ", len %"PRIu64", "
+		  "src_addr %p, rkey 0x%"PRIx64", fi_ctx %p, imm %d, post_sends %"PRIu32"\n",
 		  conn, request->minfo.tag, request->len, request->src_addr,
 		  header->mem_rkey, request->context, (int)wr.imm_data,
-		  ofi_atomic_get32(&p->ep->posted_sends));
+		  p->ep->posted_sends);
 
 	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep);
 	VERBS_DBG(FI_LOG_EP_DATA, "posted %d bytes, conn %p, tag 0x%" PRIx64 "\n",
@@ -1196,10 +1196,10 @@ fi_ibv_rdm_rndv_recv_read_lc(struct fi_ibv_rdm_request *request, void *data)
 		assert(request->rndv.md.mr);
 		p->ep->domain->internal_mr_dereg(&request->rndv.md);
 		VERBS_DBG(FI_LOG_EP_DATA,
-			  "SENDING RNDV ACK: conn %p, sends_outgoing = %d, "
-			  "post_send = %d\n",
-			  conn, ofi_atomic_get32(&conn->av_entry->sends_outgoing),
-			  ofi_atomic_get32(&p->ep->posted_sends));
+			  "SENDING RNDV ACK: conn %p, sends_outgoing = %"PRIu32", "
+			  "post_sends = %"PRIu32"\n",
+			  conn, conn->av_entry->sends_outgoing,
+			  p->ep->posted_sends);
 	} else {
 		VERBS_INFO_ERRNO(FI_LOG_EP_DATA, "ibv_post_send", errno);
 		assert(0);

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm_states.c
@@ -1140,19 +1140,35 @@ fi_ibv_rdm_rndv_recv_read_lc(struct fi_ibv_rdm_request *request, void *data)
 
 	struct fi_ibv_rdm_tagged_send_completed_data *p = data;
 	struct fi_ibv_rdm_conn *conn = request->minfo.conn;
-	struct ibv_send_wr wr = { 0 };
-	struct ibv_sge sge = { 0 };
-	struct ibv_send_wr *bad_wr = NULL;
 	struct fi_ibv_rdm_buf *sbuf = request->sbuf;
-	ssize_t ret = FI_SUCCESS;
 	const int ack_size = 
 		sizeof(struct fi_ibv_rdm_header) + sizeof(request->rndv.id);
+	struct ibv_sge sge = {
+		.addr = (uintptr_t)sbuf,
+		.length = ack_size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE,
+		.lkey = fi_ibv_mr_internal_lkey(&conn->s_md),
+	};
+	struct ibv_send_wr wr = {
+		.wr_id = FI_IBV_RDM_PACK_WR(request),
+		.opcode = p->ep->eopcode,
+		.sg_list = &sge,
+		.num_sge = 1,
+		.wr.rdma.remote_addr = 
+			(uintptr_t)fi_ibv_rdm_get_remote_addr(conn,
+							      request->sbuf),
+		.wr.rdma.rkey = conn->remote_rbuf_rkey,
+		.send_flags = (sge.length < p->ep->max_inline_rc) ?
+			       IBV_SEND_INLINE : 0,
+	};
+	struct ibv_send_wr *bad_wr = NULL;
+	ssize_t ret = FI_SUCCESS;
 
 	assert(request->len > (p->ep->rndv_threshold
 			       - sizeof(struct fi_ibv_rdm_header)));
 	assert(request->state.eager == FI_IBV_STATE_EAGER_RECV_END);
 	assert(request->state.rndv == FI_IBV_STATE_RNDV_RECV_WAIT4LC ||
 	       request->state.rndv == FI_IBV_STATE_RNDV_RECV_WAIT4RES);
+	assert(FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wr.wr_id) == 0);
 
 	FI_IBV_RDM_DEC_SIG_POST_COUNTERS(conn, p->ep);
 	request->post_counter--;
@@ -1168,24 +1184,8 @@ fi_ibv_rdm_rndv_recv_read_lc(struct fi_ibv_rdm_request *request, void *data)
 	sbuf->header.service_tag = 0;
 	FI_IBV_RDM_SET_PKTTYPE(sbuf->header.service_tag,
 			       FI_IBV_RDM_RNDV_ACK_PKT);
-
-	memcpy(&sbuf->payload, &request->rndv.id, sizeof(request->rndv.id));
-
-	wr.wr_id = FI_IBV_RDM_PACK_WR(request);
-	assert(FI_IBV_RDM_CHECK_SERVICE_WR_FLAG(wr.wr_id) == 0);
-	wr.opcode = p->ep->eopcode;
-	wr.sg_list = &sge;
-	wr.num_sge = 1;
-	wr.wr.rdma.remote_addr = 
-		(uintptr_t) fi_ibv_rdm_get_remote_addr(conn, request->sbuf);
-	wr.wr.rdma.rkey = conn->remote_rbuf_rkey;
-	wr.imm_data = 0;
-
-	sge.addr = (uintptr_t) sbuf;
-	sge.length = ack_size + FI_IBV_RDM_BUFF_SERVICE_DATA_SIZE;
-	wr.send_flags = (sge.length < p->ep->max_inline_rc) ? IBV_SEND_INLINE : 0;
-	sge.lkey = fi_ibv_mr_internal_lkey(&conn->s_md);
 	sbuf->service_data.pkt_len = ack_size;
+	memcpy(&sbuf->payload, &request->rndv.id, sizeof(request->rndv.id));
 
 	FI_IBV_RDM_INC_SIG_POST_COUNTERS(request->minfo.conn, p->ep);
 	VERBS_DBG(FI_LOG_EP_DATA,


### PR DESCRIPTION
This is initial patch that is applying some minor optimizations for the critical path.
It allows to reduce a latency by 0.04 usec for small messages.