### PR TITLE
prov/verbs: Select max inline size possible

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -748,6 +748,7 @@ void fi_ibv_empty_wre_list(struct util_buf_pool *wre_pool,
 			   struct dlist_entry *wre_list,
 			   enum fi_ibv_wre_type wre_type);
 void fi_ibv_cleanup_cq(struct fi_ibv_msg_ep *cur_ep);
+int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context);
 
 #define fi_ibv_init_sge(buf, len, desc) (struct ibv_sge)		\
 	{ .addr = (uintptr_t)buf,					\


### PR DESCRIPTION
- prov/verbs: Select highest possible inject size for verbs/MSG as well
- prov/rxm: Always do progress when fi_send from MSG provider returns -FI_EAGAIN