### PR TITLE
prov/psm2: Enable completion polling optimization when PSM2 source is compiled in

### DIFF
--- a/prov/psm2/Makefile.include
+++ b/prov/psm2/Makefile.include
@@ -21,7 +21,7 @@ _psm2_files = \
 	prov/psm2/src/psmx2_util.c
 
 if HAVE_PSM2_SRC
-nodist_libpsmx2_fi_la_SOURCES = \
+_psm2_nodist_files = \
 	prov/psm2/src/psm2_revision.c \
 	prov/psm2/src/psm2/psm_am.c \
 	prov/psm2/src/psm2/psm2_am.h \
@@ -146,7 +146,7 @@ nodist_libpsmx2_fi_la_SOURCES = \
 	prov/psm2/src/psm2/mpspawn/mpspawn_stats.h
 
 if HAVE_PSM2_X86_64
-nodist_libpsmx2_fi_la_SOURCES += \
+_psm2_nodist_files += \
 	prov/psm2/src/psm2/opa/opa_dwordcpy-x86_64-fast.S
 endif
 
@@ -165,6 +165,7 @@ endif HAVE_PSM2_SRC
 if HAVE_PSM2_DL
 pkglib_LTLIBRARIES += libpsmx2-fi.la
 libpsmx2_fi_la_SOURCES = $(_psm2_files) $(common_srcs)
+nodist_libpsmx2_fi_la_SOURCES = $(_psm2_nodist_files)
 libpsmx2_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(psm2_CPPFLAGS) $(_psm2_cppflags)
 libpsmx2_fi_la_LDFLAGS = \
     -module -avoid-version -shared -export-dynamic $(psm2_LDFLAGS)
@@ -173,6 +174,7 @@ libpsmx2_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_PSM2_DL
 noinst_LTLIBRARIES += libpsmx2.la
 libpsmx2_la_SOURCES = $(_psm2_files)
+nodist_libpsmx2_la_SOURCES = $(_psm2_nodist_files)
 libpsmx2_la_CPPFLAGS = $(src_libfabric_la_CPPFLAGS) $(psm2_CPPFLAGS) $(_psm2_cppflags)
 libpsmx2_la_LDFLAGS = $(psm2_LDFLAGS)
 libpsmx2_la_LIBADD = $(psm2_LIBS)

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -373,9 +373,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 		     struct psmx2_cq_event *event_in,
 		     int count, fi_addr_t *src_addr)
 {
-	psm2_mq_req_t psm2_req;
-	psm2_mq_status2_t psm2_status;
-	PSMX2_STATUS_TYPE *status;
+	PSMX2_STATUS_DECL(status);
 	struct fi_context *fi_context;
 	struct psmx2_fid_ep *tmp_ep;
 	struct psmx2_fid_cq *tmp_cq;
@@ -391,7 +389,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 	struct fi_context dummy_context;
 
 	while (1) {
-		PSMX2_POLL_COMPLETION(trx_ctxt, psm2_req, psm2_status, status, err);
+		PSMX2_POLL_COMPLETION(trx_ctxt, status, err);
 		if (err == PSM2_OK) {
 			fi_context = PSMX2_STATUS_CONTEXT(status);
 			if (!fi_context) {

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -58,6 +58,7 @@
 #if HAVE_PSM2_SRC
 
 #define PSMX2_STATUS_TYPE	struct psm2_mq_req
+#define PSMX2_STATUS_DECL(s)	struct psm2_mq_req *s
 #define PSMX2_STATUS_ERROR(s)	((s)->error_code)
 #define PSMX2_STATUS_TAG(s)	((s)->tag)
 #define PSMX2_STATUS_RCVLEN(s)	((s)->recv_msglen)
@@ -65,7 +66,7 @@
 #define PSMX2_STATUS_PEER(s)	((s)->peer)
 #define PSMX2_STATUS_CONTEXT(s)	((s)->context)
 
-#define PSMX2_POLL_COMPLETION(trx_ctxt, psm2_req, psm2_status, status, err) \
+#define PSMX2_POLL_COMPLETION(trx_ctxt, status, err) \
 	do { \
 		(err) = psm2_mq_ipeek_dequeue((trx_ctxt)->psm2_mq, &(status)); \
 	} while (0)
@@ -76,6 +77,7 @@
 #else /* !HAVE_PSM2_SRC */
 
 #define PSMX2_STATUS_TYPE	psm2_mq_status2_t
+#define PSMX2_STATUS_DECL(s)	psm2_mq_status2_t s##_priv, *s=&s##_priv
 #define PSMX2_STATUS_ERROR(s)	((s)->error_code)
 #define PSMX2_STATUS_TAG(s)	((s)->msg_tag)
 #define PSMX2_STATUS_RCVLEN(s)	((s)->nbytes)
@@ -88,16 +90,15 @@
  * prevent psm2_mq_ipeek from returning the same request multiple times under
  * different threads.
  */
-#define PSMX2_POLL_COMPLETION(trx_ctxt, psm2_req, psm2_status, status, err) \
+#define PSMX2_POLL_COMPLETION(trx_ctxt, status, err) \
 	do { \
 		if (psmx2_trylock(&(trx_ctxt)->poll_lock, 2)) { \
 			(err) = PSM2_MQ_NO_COMPLETIONS; \
 		} else { \
-			(err) = psm2_mq_ipeek((trx_ctxt)->psm2_mq, &(psm2_req), NULL); \
-			if ((err) == PSM2_OK) { \
-				psm2_mq_test2(&(psm2_req), &(psm2_status)); \
-				(status) = &(psm2_status); \
-			} \
+			psm2_mq_req_t psm2_req; \
+			(err) = psm2_mq_ipeek((trx_ctxt)->psm2_mq, &psm2_req, NULL); \
+			if ((err) == PSM2_OK) \
+				psm2_mq_test2(&psm2_req, (status)); \
 			psmx2_unlock(&(trx_ctxt)->poll_lock, 2); \
 		} \
 	} while(0)

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -37,6 +37,11 @@
 #include "psm2/psm2.h"
 #include "psm2/psm2_mq.h"
 #include "psm2/psm2_am.h"
+#ifdef VALGRIND_MAKE_MEM_DEFINED
+#undef VALGRIND_MAKE_MEM_DEFINED
+#endif
+#define PSM_IS_TEST /* keep plain malloc/realloc/calloc/memalign/free/strdup */
+#include "psm2/psm_mq_internal.h"
 #else
 #include <psm2.h>
 #include <psm2_mq.h>
@@ -49,6 +54,26 @@
 
 #define PSMX2_DEFAULT_UUID	"00FF00FF-0000-0000-0000-00FF00FF00FF"
 #define PROVIDER_INI		PSM2_INI
+
+#if HAVE_PSM2_SRC
+
+#define PSMX2_STATUS_TYPE	struct psm2_mq_req
+#define PSMX2_STATUS_ERROR(s)	((s)->error_code)
+#define PSMX2_STATUS_TAG(s)	((s)->tag)
+#define PSMX2_STATUS_RCVLEN(s)	((s)->recv_msglen)
+#define PSMX2_STATUS_SNDLEN(s)	((s)->send_msglen)
+#define PSMX2_STATUS_PEER(s)	((s)->peer)
+#define PSMX2_STATUS_CONTEXT(s)	((s)->context)
+
+#define PSMX2_POLL_COMPLETION(trx_ctxt, psm2_req, psm2_status, status, err) \
+	do { \
+		(err) = psm2_mq_ipeek_dequeue((trx_ctxt)->psm2_mq, &(status)); \
+	} while (0)
+
+#define PSMX2_FREE_COMPLETION(trx_ctxt, status) \
+	psm2_mq_req_free((trx_ctxt)->psm2_mq, status)
+
+#else /* !HAVE_PSM2_SRC */
 
 #define PSMX2_STATUS_TYPE	psm2_mq_status2_t
 #define PSMX2_STATUS_ERROR(s)	((s)->error_code)
@@ -78,6 +103,8 @@
 	} while(0)
 
 #define PSMX2_FREE_COMPLETION(trx_ctxt, status)
+
+#endif /* HAVE_PSM2_SRC */
 
 #endif
 


### PR DESCRIPTION
Include bug fix to the makefile, addition to the configure script, and new / updated completion polling macros.