### PR TITLE
prov/psm2: Update the definition of the PSM2 version string

### DIFF
--- a/prov/psm2/src/psm2_revision.c
+++ b/prov/psm2/src/psm2_revision.c
@@ -1,6 +1,21 @@
-char psmi_hfi_revision[] = "libfabric: psm-hfi-gxxxxxxx_open";
-char psmi_hfi_IFS_version[]="";
-char psmi_hfi_build_timestamp[] ="2017-09-07 17:29:26+00:00";
-char psmi_hfi_sources_checksum[] ="5b993e9931792d37d21be38e668f3968ae6e8819";
-char psmi_hfi_git_checksum[] ="d7e63ede75bc080c68117cfa3f4e9e8b2d85e2cd";
+#ifndef PSMX2_IFS_VERSION
+#define PSMX2_IFS_VERSION	""
+#endif
+
+#ifndef PSMX2_BUILD_TIMESTAMP
+#define PSMX2_BUILD_TIMESTAMP	"<not available>"
+#endif
+
+#ifndef PSMX2_SRC_CHECKSUM
+#define PSMX2_SRC_CHECKSUM	"<not available>"
+#endif
+
+#ifndef PSMX2_GIT_CHECKSUM
+#define PSMX2_GIT_CHECKSUM	""
+#endif
+
+char psmi_hfi_IFS_version[] = PSMX2_IFS_VERSION;
+char psmi_hfi_build_timestamp[] = PSMX2_BUILD_TIMESTAMP;
+char psmi_hfi_sources_checksum[] = PSMX2_SRC_CHECKSUM;
+char psmi_hfi_git_checksum[] = PSMX2_GIT_CHECKSUM;
 


### PR DESCRIPTION
The PSM2 library can output detailed version information when the
environment variable PSM2_IDENTIFY is set. A few externally defined
strings are needed to make this work. When the provider is built
together with the PSM2 source, these strings are defined by the
provider. Previously random definitions were used which wouldn't
match the actual build. This patch sets meaningful default values
and allows them be overridden at compile time.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>