### PR TITLE
prov/hook: Add framework for hooking all provider calls

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -62,7 +62,18 @@ common_srcs =				\
 	prov/util/src/util_ns.c		\
 	prov/util/src/util_shm.c	\
 	prov/util/src/util_mem_monitor.c\
-	prov/util/src/util_mr_cache.c
+	prov/util/src/util_mr_cache.c	\
+	prov/hook/src/hook.c		\
+	prov/hook/src/hook_av.c		\
+	prov/hook/src/hook_cm.c		\
+	prov/hook/src/hook_cntr.c	\
+	prov/hook/src/hook_cq.c		\
+	prov/hook/src/hook_domain.c	\
+	prov/hook/src/hook_ep.c		\
+	prov/hook/src/hook_eq.c		\
+	prov/hook/src/hook_wait.c	\
+	prov/hook/src/hook_xfer.c
+
 
 if MACOS
 common_srcs += src/unix/osd.c
@@ -128,6 +139,7 @@ src_libfabric_la_SOURCES =			\
 	include/rbtree.h			\
 	include/uthash.h			\
 	include/prov.h				\
+	prov/hook/src/hook.h			\
 	include/rdma/providers/fi_log.h		\
 	include/rdma/providers/fi_prov.h	\
 	src/fabric.c				\

--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <pthread.h>
+#include <stdio.h>
+#include "hook.h"
+
+
+struct fid *hook_to_hfid(const struct fid *fid)
+{
+	switch (fid->fclass) {
+	case FI_CLASS_FABRIC:
+		return &(container_of(fid, struct hook_fabric, fabric.fid)->
+			 hfabric->fid);
+	case FI_CLASS_DOMAIN:
+		return &(container_of(fid, struct hook_domain, domain.fid)->
+			 hdomain->fid);
+	case FI_CLASS_AV:
+		return &(container_of(fid, struct hook_av, av.fid)->
+			 hav->fid);
+	case FI_CLASS_WAIT:
+		return &(container_of(fid, struct hook_wait, wait.fid)->
+			 hwait->fid);
+	case FI_CLASS_POLL:
+		return &(container_of(fid, struct hook_poll, poll.fid)->
+			 hpoll->fid);
+	case FI_CLASS_EQ:
+		return &(container_of(fid, struct hook_eq, eq.fid)->
+			 heq->fid);
+	case FI_CLASS_CQ:
+		return &(container_of(fid, struct hook_cq, cq.fid)->
+			 hcq->fid);
+	case FI_CLASS_CNTR:
+		return &(container_of(fid, struct hook_cntr, cntr.fid)->
+			 hcntr->fid);
+	case FI_CLASS_SEP:
+	case FI_CLASS_EP:
+	case FI_CLASS_RX_CTX:
+	case FI_CLASS_SRX_CTX:
+	case FI_CLASS_TX_CTX:
+		return &(container_of(fid, struct hook_ep, ep.fid)->
+			 hep->fid);
+	case FI_CLASS_PEP:
+		return &(container_of(fid, struct hook_pep, pep.fid)->
+			 hpep->fid);
+	case FI_CLASS_STX_CTX:
+		return &(container_of(fid, struct hook_stx, stx.fid)->
+			 hstx->fid);
+	case FI_CLASS_MR:
+		return &(container_of(fid, struct hook_mr, mr.fid)->
+			 hmr->fid);
+	default:
+		return NULL;
+	}
+}
+
+static int hook_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+{
+	struct fid *hfid, *hbfid;
+
+	hfid = hook_to_hfid(fid);
+	hbfid = hook_to_hfid(bfid);
+	if (!hfid || !hbfid)
+		return -FI_EINVAL;
+
+	return hfid->ops->bind(hfid, hbfid, flags);
+}
+
+static int hook_control(struct fid *fid, int command, void *arg)
+{
+	struct fid *hfid;
+
+	hfid = hook_to_hfid(fid);
+	if (!hfid)
+		return -FI_EINVAL;
+
+	return hfid->ops->control(hfid, command, arg);
+}
+
+static int hook_ops_open(struct fid *fid, const char *name,
+			 uint64_t flags, void **ops, void *context)
+{
+	struct fid *hfid;
+
+	hfid = hook_to_hfid(fid);
+	if (!hfid)
+		return -FI_EINVAL;
+
+	return hfid->ops->ops_open(hfid, name, flags, ops, context);
+}
+
+static int hook_close(struct fid *fid)
+{
+	struct fid *hfid;
+	int ret;
+
+	hfid = hook_to_hfid(fid);
+	if (!hfid)
+		return -FI_EINVAL;
+
+	ret = hfid->ops->close(hfid);
+	if (!ret)
+		free(fid);
+	return ret;
+}
+
+struct fi_ops hook_fid_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = hook_close,
+	.bind = hook_bind,
+	.control = hook_control,
+	.ops_open = hook_ops_open,
+};
+
+static struct fi_ops_fabric hook_fabric_ops = {
+	.size = sizeof(struct fi_ops_fabric),
+	.domain = hook_domain,
+	.passive_ep = hook_passive_ep,
+	.eq_open = hook_eq_open,
+	.wait_open = hook_wait_open,
+	.trywait = hook_trywait,
+};
+
+int hook_fabric(struct fid_fabric *hfabric, struct fid_fabric **fabric)
+{
+	struct hook_fabric *fab;
+
+	fab = calloc(1, sizeof *fab);
+	if (!fab)
+		return -FI_ENOMEM;
+
+	fab->fabric.fid.fclass = FI_CLASS_FABRIC;
+	fab->fabric.fid.context = hfabric->fid.context;
+	fab->fabric.fid.ops = &hook_fid_ops;
+	fab->fabric.api_version = hfabric->api_version;
+	fab->fabric.ops = &hook_fabric_ops;
+
+	hfabric->fid.context = fab;
+	*fabric = &fab->fabric;
+
+	return 0;
+}

--- a/prov/hook/src/hook.h
+++ b/prov/hook/src/hook.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL); Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _OFI_HOOK_H_
+#define _OFI_HOOK_H_
+
+#include <rdma/fabric.h>
+#include <rdma/fi_atomic.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_tagged.h>
+
+
+/*
+ * Define hook structs so we can cast from fid to parent using simple cast.
+ * This lets us have a single close() call.
+ */
+
+extern struct fi_ops hook_fid_ops;
+struct fid *hook_to_hfid(const struct fid *fid);
+
+struct hook_fabric {
+	struct fid_fabric fabric;
+	struct fid_fabric *hfabric;
+};
+
+int hook_fabric(struct fid_fabric *hfabric, struct fid_fabric **fabric);
+
+
+struct hook_domain {
+	struct fid_domain domain;
+	struct fid_domain *hdomain;
+};
+
+int hook_domain(struct fid_fabric *fabric, struct fi_info *info,
+		struct fid_domain **domain, void *context);
+
+
+struct hook_av {
+	struct fid_av av;
+	struct fid_av *hav;
+};
+
+int hook_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+		 struct fid_av **av, void *context);
+
+
+struct hook_wait {
+	struct fid_wait wait;
+	struct fid_wait *hwait;
+};
+
+int hook_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		   struct fid_wait **waitset);
+int hook_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
+
+
+struct hook_poll {
+	struct fid_poll poll;
+	struct fid_poll *hpoll;
+};
+
+int hook_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
+		   struct fid_poll **pollset);
+
+
+struct hook_eq {
+	struct fid_eq eq;
+	struct fid_eq *heq;
+};
+
+int hook_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		 struct fid_eq **eq, void *context);
+
+
+struct hook_cq {
+	struct fid_cq cq;
+	struct fid_cq *hcq;
+};
+
+int hook_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+		 struct fid_cq **cq, void *context);
+
+
+struct hook_cntr {
+	struct fid_cntr cntr;
+	struct fid_cntr *hcntr;
+};
+
+int hook_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		   struct fid_cntr **cntr, void *context);
+
+
+struct hook_ep {
+	struct fid_ep ep;
+	struct fid_ep *hep;
+};
+
+int hook_endpoint(struct fid_domain *domain, struct fi_info *info,
+		  struct fid_ep **ep, void *context);
+int hook_scalable_ep(struct fid_domain *domain, struct fi_info *info,
+		     struct fid_ep **sep, void *context);
+int hook_srx_ctx(struct fid_domain *domain,
+		 struct fi_rx_attr *attr, struct fid_ep **rx_ep,
+		 void *context);
+
+extern struct fi_ops_cm hook_cm_ops;
+extern struct fi_ops_msg hook_msg_ops;
+extern struct fi_ops_rma hook_rma_ops;
+extern struct fi_ops_tagged hook_tagged_ops;
+extern struct fi_ops_atomic hook_atomic_ops;
+
+
+struct hook_pep {
+	struct fid_pep pep;
+	struct fid_pep *hpep;
+};
+
+int hook_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
+		    struct fid_pep **pep, void *context);
+
+
+struct hook_stx {
+	struct fid_stx stx;
+	struct fid_stx *hstx;
+};
+
+int hook_stx_ctx(struct fid_domain *domain,
+		 struct fi_tx_attr *attr, struct fid_stx **stx,
+		 void *context);
+
+
+struct hook_mr {
+	struct fid_mr mr;
+	struct fid_mr *hmr;
+};
+
+
+#endif /* _OFI_HOOK_H_ */

--- a/prov/hook/src/hook_av.c
+++ b/prov/hook/src/hook_av.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include "hook.h"
+
+
+static int
+hook_av_insert(struct fid_av *av, const void *addr, size_t count,
+	       fi_addr_t *fi_addr, uint64_t flags, void *context)
+{
+	struct hook_av *myav = container_of(av, struct hook_av, av);
+
+	return fi_av_insert(myav->hav, addr, count, fi_addr, flags, context);
+}
+
+static int
+hook_av_insertsvc(struct fid_av *av, const char *node,
+		  const char *service, fi_addr_t *fi_addr, uint64_t flags,
+		  void *context)
+{
+	struct hook_av *myav = container_of(av, struct hook_av, av);
+
+	return fi_av_insertsvc(myav->hav, node, service, fi_addr,
+			       flags, context);
+}
+
+static int
+hook_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
+		  const char *service, size_t svccnt, fi_addr_t *fi_addr,
+		  uint64_t flags, void *context)
+{
+	struct hook_av *myav = container_of(av, struct hook_av, av);
+
+	return fi_av_insertsym(myav->hav, node, nodecnt, service, svccnt,
+			       fi_addr, flags, context);
+}
+
+static int
+hook_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
+	       uint64_t flags)
+{
+	struct hook_av *myav = container_of(av, struct hook_av, av);
+
+	return fi_av_remove(myav->hav, fi_addr, count, flags);
+}
+
+static int
+hook_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
+	       size_t *addrlen)
+{
+	struct hook_av *myav = container_of(av, struct hook_av, av);
+
+	return fi_av_lookup(myav->hav, fi_addr, addr, addrlen);
+}
+
+static const char *
+hook_av_straddr(struct fid_av *av, const void *addr, char *buf, size_t *len)
+{
+	struct hook_av *myav = container_of(av, struct hook_av, av);
+
+	return fi_av_straddr(myav->hav, addr, buf, len);
+}
+
+static struct fi_ops_av hook_av_ops = {
+	.size = sizeof(struct fi_ops_av),
+	.insert = hook_av_insert,
+	.insertsvc = hook_av_insertsvc,
+	.insertsym = hook_av_insertsym,
+	.remove = hook_av_remove,
+	.lookup = hook_av_lookup,
+	.straddr = hook_av_straddr,
+};
+
+int hook_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+		 struct fid_av **av, void *context)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+	struct hook_av *myav;
+	int ret;
+
+	myav = calloc(1, sizeof *myav);
+	if (!myav)
+		return -FI_ENOMEM;
+
+	myav->av.fid.fclass = FI_CLASS_AV;
+	myav->av.fid.context = context;
+	myav->av.fid.ops = &hook_fid_ops;
+	myav->av.ops = &hook_av_ops;
+
+	ret = fi_av_open(dom->hdomain, attr, &myav->hav, &myav->av.fid);
+	if (ret)
+		free(myav);
+	else
+		*av = &myav->av;
+
+	return ret;
+}

--- a/prov/hook/src/hook_cm.c
+++ b/prov/hook/src/hook_cm.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "hook.h"
+
+
+static int hook_setname(fid_t fid, void *addr, size_t addrlen)
+{
+	return fi_setname(hook_to_hfid(fid), addr, addrlen);
+}
+
+static int hook_getname(fid_t fid, void *addr, size_t *addrlen)
+{
+	return fi_getname(hook_to_hfid(fid), addr, addrlen);
+}
+
+static int hook_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_getpeer(myep->hep, addr, addrlen);
+}
+
+static int hook_connect(struct fid_ep *ep, const void *addr,
+			const void *param, size_t paramlen)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_connect(myep->hep, addr, param, paramlen);
+}
+
+static int hook_listen(struct fid_pep *pep)
+{
+	struct hook_pep *mypep = container_of(pep, struct hook_pep, pep);
+
+	return fi_listen(mypep->hpep);
+}
+
+static int hook_accept(struct fid_ep *ep, const void *param, size_t paramlen)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_accept(myep->hep, param, paramlen);
+}
+
+static int hook_reject(struct fid_pep *pep, fid_t handle,
+		       const void *param, size_t paramlen)
+{
+	struct hook_pep *mypep = container_of(pep, struct hook_pep, pep);
+
+	return fi_reject(mypep->hpep, handle, param, paramlen);
+}
+
+static int hook_shutdown(struct fid_ep *ep, uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_shutdown(myep->hep, flags);
+}
+
+static int hook_join(struct fid_ep *ep, const void *addr, uint64_t flags,
+		     struct fid_mc **mc, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_join(myep->hep, addr, flags, mc, context);
+}
+
+struct fi_ops_cm hook_cm_ops = {
+	.size = sizeof(struct fi_ops_cm),
+	.setname = hook_setname,
+	.getname = hook_getname,
+	.getpeer = hook_getpeer,
+	.connect = hook_connect,
+	.listen = hook_listen,
+	.accept = hook_accept,
+	.reject = hook_reject,
+	.shutdown = hook_shutdown,
+	.join = hook_join,
+};

--- a/prov/hook/src/hook_cntr.c
+++ b/prov/hook/src/hook_cntr.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include "hook.h"
+
+
+static uint64_t hook_cntr_read(struct fid_cntr *cntr)
+{
+	struct hook_cntr *mycntr = container_of(cntr, struct hook_cntr, cntr);
+
+	return fi_cntr_read(mycntr->hcntr);
+}
+
+static uint64_t hook_cntr_readerr(struct fid_cntr *cntr)
+{
+	struct hook_cntr *mycntr = container_of(cntr, struct hook_cntr, cntr);
+
+	return fi_cntr_readerr(mycntr->hcntr);
+}
+
+static int hook_cntr_add(struct fid_cntr *cntr, uint64_t value)
+{
+	struct hook_cntr *mycntr = container_of(cntr, struct hook_cntr, cntr);
+
+	return fi_cntr_add(mycntr->hcntr, value);
+}
+
+static int hook_cntr_set(struct fid_cntr *cntr, uint64_t value)
+{
+	struct hook_cntr *mycntr = container_of(cntr, struct hook_cntr, cntr);
+
+	return fi_cntr_set(mycntr->hcntr, value);
+}
+
+static int hook_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int timeout)
+{
+	struct hook_cntr *mycntr = container_of(cntr, struct hook_cntr, cntr);
+
+	return fi_cntr_wait(mycntr->hcntr, threshold, timeout);
+}
+
+static int hook_cntr_adderr(struct fid_cntr *cntr, uint64_t value)
+{
+	struct hook_cntr *mycntr = container_of(cntr, struct hook_cntr, cntr);
+
+	return fi_cntr_adderr(mycntr->hcntr, value);
+}
+
+static int hook_cntr_seterr(struct fid_cntr *cntr, uint64_t value)
+{
+	struct hook_cntr *mycntr = container_of(cntr, struct hook_cntr, cntr);
+
+	return fi_cntr_seterr(mycntr->hcntr, value);
+}
+
+static struct fi_ops_cntr hook_cntr_ops = {
+	.size = sizeof(struct fi_ops_cntr),
+	.read = hook_cntr_read,
+	.readerr = hook_cntr_readerr,
+	.add = hook_cntr_add,
+	.set = hook_cntr_set,
+	.wait = hook_cntr_wait,
+	.adderr = hook_cntr_adderr,
+	.seterr = hook_cntr_seterr,
+};
+
+int hook_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		   struct fid_cntr **cntr, void *context)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+	struct hook_cntr *mycntr;
+	int ret;
+
+	mycntr = calloc(1, sizeof *mycntr);
+	if (!mycntr)
+		return -FI_ENOMEM;
+
+	mycntr->cntr.fid.fclass = FI_CLASS_CNTR;
+	mycntr->cntr.fid.context = context;
+	mycntr->cntr.fid.ops = &hook_fid_ops;
+	mycntr->cntr.ops = &hook_cntr_ops;
+
+	ret = fi_cntr_open(dom->hdomain, attr, &mycntr->hcntr,
+			   &mycntr->cntr.fid);
+	if (ret)
+		free(mycntr);
+	else
+		*cntr = &mycntr->cntr;
+
+	return ret;
+}

--- a/prov/hook/src/hook_cq.c
+++ b/prov/hook/src/hook_cq.c
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include "hook.h"
+
+
+static ssize_t hook_cq_read(struct fid_cq *cq, void *buf, size_t count)
+{
+	struct hook_cq *mycq = container_of(cq, struct hook_cq, cq);
+
+	return fi_cq_read(mycq->hcq, buf, count);
+}
+
+static ssize_t
+hook_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf, uint64_t flags)
+{
+	struct hook_cq *mycq = container_of(cq, struct hook_cq, cq);
+
+	return fi_cq_readerr(mycq->hcq, buf, flags);
+}
+
+static ssize_t
+hook_cq_readfrom(struct fid_cq *cq, void *buf, size_t count, fi_addr_t *src_addr)
+{
+	struct hook_cq *mycq = container_of(cq, struct hook_cq, cq);
+
+	return fi_cq_readfrom(mycq->hcq, buf, count, src_addr);
+}
+
+static ssize_t
+hook_cq_sread(struct fid_cq *cq, void *buf, size_t count,
+	      const void *cond, int timeout)
+{
+	struct hook_cq *mycq = container_of(cq, struct hook_cq, cq);
+
+	return fi_cq_sread(mycq->hcq, buf, count, cond, timeout);
+}
+
+static ssize_t
+hook_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
+		  fi_addr_t *src_addr, const void *cond, int timeout)
+{
+	struct hook_cq *mycq = container_of(cq, struct hook_cq, cq);
+
+	return fi_cq_sreadfrom(mycq->hcq, buf, count, src_addr, cond, timeout);
+}
+
+static int hook_cq_signal(struct fid_cq *cq)
+{
+	struct hook_cq *mycq = container_of(cq, struct hook_cq, cq);
+
+	return fi_cq_signal(mycq->hcq);
+}
+
+static const char *
+hook_cq_strerror(struct fid_cq *cq, int prov_errno,
+		 const void *err_data, char *buf, size_t len)
+{
+	struct hook_cq *mycq = container_of(cq, struct hook_cq, cq);
+
+	return fi_cq_strerror(mycq->hcq, prov_errno, err_data, buf,len);
+}
+
+static struct fi_ops_cq hook_cq_ops = {
+	.size = sizeof(struct fi_ops_cq),
+	.read = hook_cq_read,
+	.readfrom = hook_cq_readfrom,
+	.readerr = hook_cq_readerr,
+	.sread = hook_cq_sread,
+	.sreadfrom = hook_cq_sreadfrom,
+	.signal = hook_cq_signal,
+	.strerror = hook_cq_strerror,
+};
+
+int hook_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+		 struct fid_cq **cq, void *context)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+	struct hook_cq *mycq;
+	int ret;
+
+	mycq = calloc(1, sizeof *mycq);
+	if (!mycq)
+		return -FI_ENOMEM;
+
+	mycq->cq.fid.fclass = FI_CLASS_CQ;
+	mycq->cq.fid.context = context;
+	mycq->cq.fid.ops = &hook_fid_ops;
+	mycq->cq.ops = &hook_cq_ops;
+
+	ret = fi_cq_open(dom->hdomain, attr, &mycq->hcq, &mycq->cq.fid);
+	if (ret)
+		free(mycq);
+	else
+		*cq = &mycq->cq;
+
+	return ret;
+}

--- a/prov/hook/src/hook_domain.c
+++ b/prov/hook/src/hook_domain.c
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <sys/uio.h>
+#include "hook.h"
+
+
+static int hook_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
+			   uint64_t flags, struct fid_mr **mr)
+{
+	struct hook_domain *dom = container_of(fid, struct hook_domain, domain.fid);
+	struct hook_mr *mymr;
+	int ret;
+
+	mymr = calloc(1, sizeof *mymr);
+	if (!mymr)
+		return -FI_ENOMEM;
+
+	mymr->mr.fid.fclass = FI_CLASS_MR;
+	mymr->mr.fid.context = attr->context;
+	mymr->mr.fid.ops = &hook_fid_ops;
+
+	ret = fi_mr_regattr(dom->hdomain, attr, flags, &mymr->hmr);
+	if (ret) {
+		free(mymr);
+	} else {
+		mymr->mr.mem_desc = mymr->hmr->mem_desc;
+		mymr->mr.key = mymr->hmr->key;
+		*mr = &mymr->mr;
+	}
+
+	return ret;
+}
+
+static int hook_mr_regv(struct fid *fid, const struct iovec *iov,
+			size_t count, uint64_t access,
+			uint64_t offset, uint64_t requested_key,
+			uint64_t flags, struct fid_mr **mr, void *context)
+{
+	struct fi_mr_attr attr;
+
+	attr.mr_iov = iov;
+	attr.iov_count = count;
+	attr.access = access;
+	attr.offset = offset;
+	attr.requested_key = requested_key;
+	attr.context = context;
+	attr.auth_key_size = 0;
+	attr.auth_key = NULL;
+
+	return hook_mr_regattr(fid, &attr, flags, mr);
+}
+
+static int hook_mr_reg(struct fid *fid, const void *buf, size_t len,
+		       uint64_t access, uint64_t offset, uint64_t requested_key,
+		       uint64_t flags, struct fid_mr **mr, void *context)
+{
+	struct iovec iov;
+
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
+	return hook_mr_regv(fid, &iov, 1, access, offset, requested_key,
+			    flags, mr, context);
+}
+
+static struct fi_ops_mr hook_mr_ops = {
+	.size = sizeof(struct fi_ops_mr),
+	.reg = hook_mr_reg,
+	.regv = hook_mr_regv,
+	.regattr = hook_mr_regattr,
+};
+
+
+static int
+hook_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
+		  enum fi_op op, struct fi_atomic_attr *attr, uint64_t flags)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+
+	return fi_query_atomic(dom->hdomain, datatype, op, attr, flags);
+}
+
+static struct fi_ops_domain hook_domain_ops = {
+	.size = sizeof(struct fi_ops_domain),
+	.av_open = hook_av_open,
+	.cq_open = hook_cq_open,
+	.endpoint = hook_endpoint,
+	.scalable_ep = hook_scalable_ep,
+	.cntr_open = hook_cntr_open,
+	.poll_open = hook_poll_open,
+	.stx_ctx = hook_stx_ctx,
+	.srx_ctx = hook_srx_ctx,
+	.query_atomic = hook_query_atomic,
+};
+
+
+int hook_domain(struct fid_fabric *fabric, struct fi_info *info,
+		struct fid_domain **domain, void *context)
+{
+	struct hook_fabric *fab = container_of(fabric, struct hook_fabric, fabric);
+	struct hook_domain *dom;
+	int ret;
+
+	dom = calloc(1, sizeof *dom);
+	if (!dom)
+		return -FI_ENOMEM;
+
+	dom->domain.fid.fclass = FI_CLASS_DOMAIN;
+	dom->domain.fid.context = context;
+	dom->domain.fid.ops = &hook_fid_ops;
+	dom->domain.ops = &hook_domain_ops;
+	dom->domain.mr = &hook_mr_ops;
+
+	ret = fi_domain(fab->hfabric, info, &dom->hdomain, &dom->domain.fid);
+	if (ret)
+		free(dom);
+	else
+		*domain = &dom->domain;
+
+	return ret;
+}

--- a/prov/hook/src/hook_ep.c
+++ b/prov/hook/src/hook_ep.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <fi_enosys.h>
+#include "hook.h"
+
+
+static int hook_open_tx_ctx(struct fid_ep *sep, int index,
+			    struct fi_tx_attr *attr, struct fid_ep **tx_ep,
+			    void *context);
+static int hook_open_rx_ctx(struct fid_ep *sep, int index,
+			    struct fi_rx_attr *attr, struct fid_ep **rx_ep,
+			    void *context);
+
+
+static ssize_t hook_cancel(fid_t fid, void *context)
+{
+	return fi_cancel(hook_to_hfid(fid), context);
+}
+
+static int hook_getopt(fid_t fid, int level, int optname,
+		       void *optval, size_t *optlen)
+{
+	return fi_getopt(hook_to_hfid(fid), level, optname, optval, optlen);
+}
+
+static int hook_setopt(fid_t fid, int level, int optname,
+		       const void *optval, size_t optlen)
+{
+	return fi_setopt(hook_to_hfid(fid), level, optname, optval, optlen);
+}
+
+static int hook_tx_ctx(struct fid_ep *sep, int index,
+		       struct fi_tx_attr *attr, struct fid_ep **tx_ep,
+		       void *context)
+{
+	return hook_open_tx_ctx(sep, index, attr, tx_ep, context);
+}
+
+static int hook_rx_ctx(struct fid_ep *sep, int index,
+		       struct fi_rx_attr *attr, struct fid_ep **rx_ep,
+		       void *context)
+{
+	return hook_open_rx_ctx(sep, index, attr, rx_ep, context);
+}
+
+static struct fi_ops_ep hook_ep_ops = {
+	.size = sizeof(struct fi_ops_ep),
+	.cancel = hook_cancel,
+	.getopt = hook_getopt,
+	.setopt = hook_setopt,
+	.tx_ctx = hook_tx_ctx,
+	.rx_ctx = hook_rx_ctx,
+	.rx_size_left = fi_no_rx_size_left,
+	.tx_size_left = fi_no_tx_size_left,
+};
+
+
+static void hook_setup_ep(struct fid_ep *ep, int fclass, void *context)
+{
+	ep->fid.fclass = fclass;
+	ep->fid.context = context;
+	ep->fid.ops = &hook_fid_ops;
+	ep->ops = &hook_ep_ops;
+	ep->cm = &hook_cm_ops;
+	ep->msg = &hook_msg_ops;
+	ep->rma = &hook_rma_ops;
+	ep->tagged = &hook_tagged_ops;
+	ep->atomic = &hook_atomic_ops;
+}
+
+int hook_scalable_ep(struct fid_domain *domain, struct fi_info *info,
+		     struct fid_ep **sep, void *context)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+	struct hook_ep *mysep;
+	int ret;
+
+	mysep = calloc(1, sizeof *mysep);
+	if (!mysep)
+		return -FI_ENOMEM;
+
+	hook_setup_ep(&mysep->ep, FI_CLASS_SEP, context);
+	ret = fi_scalable_ep(dom->hdomain, info, &mysep->hep, &mysep->ep.fid);
+	if (ret)
+		free(mysep);
+	else
+		*sep = &mysep->ep;
+
+	return ret;
+}
+
+int hook_stx_ctx(struct fid_domain *domain,
+		 struct fi_tx_attr *attr, struct fid_stx **stx,
+		 void *context)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+	struct hook_stx *mystx;
+	int ret;
+
+	mystx = calloc(1, sizeof *mystx);
+	if (!mystx)
+		return -FI_ENOMEM;
+
+	mystx->stx.fid.fclass = FI_CLASS_STX_CTX;
+	mystx->stx.fid.context = context;
+	mystx->stx.fid.ops = &hook_fid_ops;
+	mystx->stx.ops = &hook_ep_ops;
+
+	ret = fi_stx_context(dom->hdomain, attr, &mystx->hstx, &mystx->stx.fid);
+	if (ret)
+		free(mystx);
+	else
+		*stx = &mystx->stx;
+
+	return ret;
+}
+
+int hook_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
+		 struct fid_ep **rx_ep, void *context)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+	struct hook_ep *srx;
+	int ret;
+
+	srx = calloc(1, sizeof *srx);
+	if (!srx)
+		return -FI_ENOMEM;
+
+	hook_setup_ep(&srx->ep, FI_CLASS_SRX_CTX, context);
+	ret = fi_srx_context(dom->hdomain, attr, &srx->hep, &srx->ep.fid);
+	if (ret)
+		free(srx);
+	else
+		*rx_ep = &srx->ep;
+
+	return ret;
+}
+
+static int hook_open_tx_ctx(struct fid_ep *sep, int index,
+			    struct fi_tx_attr *attr, struct fid_ep **tx_ep,
+			    void *context)
+{
+	struct hook_ep *mysep = container_of(sep, struct hook_ep, ep);
+	struct hook_ep *mytx;
+	int ret;
+
+	mytx = calloc(1, sizeof *mytx);
+	if (!mytx)
+		return -FI_ENOMEM;
+
+	hook_setup_ep(&mytx->ep, FI_CLASS_TX_CTX, context);
+	ret = fi_tx_context(mysep->hep, index, attr, &mytx->hep, &mytx->ep.fid);
+	if (ret)
+		free(mytx);
+	else
+		*tx_ep = &mytx->ep;
+
+	return ret;
+}
+
+static int hook_open_rx_ctx(struct fid_ep *sep, int index,
+			    struct fi_rx_attr *attr, struct fid_ep **rx_ep,
+			    void *context)
+{
+	struct hook_ep *mysep = container_of(sep, struct hook_ep, ep);
+	struct hook_ep *myrx;
+	int ret;
+
+	myrx = calloc(1, sizeof *myrx);
+	if (!myrx)
+		return -FI_ENOMEM;
+
+	hook_setup_ep(&myrx->ep, FI_CLASS_RX_CTX, context);
+	ret = fi_rx_context(mysep->hep, index, attr, &myrx->hep, &myrx->ep.fid);
+	if (ret)
+		free(myrx);
+	else
+		*rx_ep = &myrx->ep;
+
+	return ret;
+}
+
+int hook_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
+		    struct fid_pep **pep, void *context)
+{
+	struct hook_fabric *fab = container_of(fabric, struct hook_fabric, fabric);
+	struct hook_pep *mypep;
+	int ret;
+
+	mypep = calloc(1, sizeof *mypep);
+	if (!mypep)
+		return -FI_ENOMEM;
+
+	mypep->pep.fid.fclass = FI_CLASS_PEP;
+	mypep->pep.fid.context = context;
+	mypep->pep.fid.ops = &hook_fid_ops;
+	mypep->pep.ops = &hook_ep_ops;
+	mypep->pep.cm = &hook_cm_ops;
+
+	ret = fi_passive_ep(fab->hfabric, info, &mypep->hpep, &mypep->pep.fid);
+	if (ret)
+		free(mypep);
+	else
+		*pep = &mypep->pep;
+
+	return ret;
+}
+
+int hook_endpoint(struct fid_domain *domain, struct fi_info *info,
+		  struct fid_ep **ep, void *context)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+	struct hook_ep *myep;
+	int ret;
+
+	myep = calloc(1, sizeof *myep);
+	if (!myep)
+		return -FI_ENOMEM;
+
+	hook_setup_ep(&myep->ep, FI_CLASS_EP, context);
+	ret = fi_endpoint(dom->hdomain, info, &myep->hep, &myep->ep.fid);
+	if (ret)
+		free(myep);
+	else
+		*ep = &myep->ep;
+
+	return ret;
+}

--- a/prov/hook/src/hook_eq.c
+++ b/prov/hook/src/hook_eq.c
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include "hook.h"
+
+
+static int hook_eq_std_event(uint32_t event)
+{
+	return ((event >= FI_NOTIFY) && (event <= FI_JOIN_COMPLETE));
+}
+
+/*
+ * Convert the hooked fid reported in the event to ours.  Regardless
+ * of the event type, we cast to fi_eq_entry.  This works because we
+ * only touch the fid field, which is the first field in all EQ events
+ */
+static void hook_eq_map_fid(void *buf)
+{
+	struct fi_eq_entry *entry = buf;
+
+	entry->fid = entry->fid->context;
+}
+
+static ssize_t hook_eq_read(struct fid_eq *eq, uint32_t *event,
+			    void *buf, size_t len, uint64_t flags)
+{
+	struct hook_eq *myeq = container_of(eq, struct hook_eq, eq);
+	ssize_t ret;
+
+	ret = fi_eq_read(myeq->heq, event, buf, len, flags);
+	if ((ret > 0) && hook_eq_std_event(*event))
+		hook_eq_map_fid(buf);
+
+	return ret;
+}
+
+static ssize_t hook_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *buf,
+			       uint64_t flags)
+{
+	struct hook_eq *myeq = container_of(eq, struct hook_eq, eq);
+	ssize_t ret;
+
+	ret = fi_eq_readerr(myeq->heq, buf, flags);
+	if (ret > 0)
+		buf->fid = buf->fid->context;
+
+	return ret;
+}
+
+static ssize_t hook_eq_write(struct fid_eq *eq, uint32_t event,
+			     const void *buf, size_t len, uint64_t flags)
+{
+	struct hook_eq *myeq = container_of(eq, struct hook_eq, eq);
+
+	return fi_eq_write(myeq->heq, event, buf, len, flags);
+}
+
+static ssize_t hook_eq_sread(struct fid_eq *eq, uint32_t *event,
+			     void *buf, size_t len, int timeout, uint64_t flags)
+{
+	struct hook_eq *myeq = container_of(eq, struct hook_eq, eq);
+	ssize_t ret;
+
+	ret = fi_eq_sread(myeq->heq, event, buf, len, timeout, flags);
+	if ((ret > 0) && hook_eq_std_event(*event))
+		hook_eq_map_fid(buf);
+
+	return ret;
+}
+
+static const char *
+hook_eq_strerror(struct fid_eq *eq, int prov_errno,
+		 const void *err_data, char *buf, size_t len)
+{
+	struct hook_eq *myeq = container_of(eq, struct hook_eq, eq);
+
+	return fi_eq_strerror(myeq->heq, prov_errno, err_data, buf, len);
+}
+
+static struct fi_ops_eq hook_eq_ops = {
+	.size = sizeof(struct fi_ops_eq),
+	.read = hook_eq_read,
+	.readerr = hook_eq_readerr,
+	.write = hook_eq_write,
+	.sread = hook_eq_sread,
+	.strerror = hook_eq_strerror,
+};
+
+int hook_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		 struct fid_eq **eq, void *context)
+{
+	struct hook_fabric *fab = container_of(fabric, struct hook_fabric, fabric);
+	struct hook_eq *myeq;
+	int ret;
+
+	myeq = calloc(1, sizeof *myeq);
+	if (!myeq)
+		return -FI_ENOMEM;
+
+	myeq->eq.fid.fclass = FI_CLASS_EQ;
+	myeq->eq.fid.context = context;
+	myeq->eq.fid.ops = &hook_fid_ops;
+	myeq->eq.ops = &hook_eq_ops;
+
+	ret = fi_eq_open(fab->hfabric, attr, &myeq->heq, &myeq->eq.fid);
+	if (ret)
+		free(myeq);
+	else
+		*eq = &myeq->eq;
+
+	return ret;
+}

--- a/prov/hook/src/hook_wait.c
+++ b/prov/hook/src/hook_wait.c
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include "hook.h"
+
+
+static int hook_do_poll(struct fid_poll *pollset, void **context, int count)
+{
+	struct hook_poll *poll = container_of(pollset, struct hook_poll, poll);
+	struct fid *fid;
+	int i, ret;
+
+	ret = fi_poll(poll->hpoll, context, count);
+	for (i = 0; i < ret; i++) {
+		fid = context[i];
+		context[i] = fid->context;
+	}
+
+	return ret;
+}
+
+static int hook_poll_add(struct fid_poll *pollset, struct fid *event_fid,
+			 uint64_t flags)
+{
+	struct hook_poll *poll = container_of(pollset, struct hook_poll, poll);
+
+	return fi_poll_add(poll->hpoll, hook_to_hfid(event_fid), flags);
+}
+
+static int hook_poll_del(struct fid_poll *pollset, struct fid *event_fid,
+			 uint64_t flags)
+{
+	struct hook_poll *poll = container_of(pollset, struct hook_poll, poll);
+
+	return fi_poll_del(poll->hpoll, hook_to_hfid(event_fid), flags);
+}
+
+static struct fi_ops_poll hook_poll_ops = {
+	.size = sizeof(struct fi_ops_poll),
+	.poll = hook_do_poll,
+	.poll_add = hook_poll_add,
+	.poll_del = hook_poll_del,
+};
+
+int hook_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
+		   struct fid_poll **pollset)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+	struct hook_poll *poll;
+	int ret;
+
+	poll = calloc(1, sizeof *poll);
+	if (!poll)
+		return -FI_ENOMEM;
+
+	poll->poll.fid.fclass = FI_CLASS_POLL;
+	poll->poll.fid.ops = &hook_fid_ops;
+	poll->poll.ops = &hook_poll_ops;
+
+	ret = fi_poll_open(dom->hdomain, attr, &poll->hpoll);
+	if (ret)
+		free(poll);
+	else
+		*pollset = &poll->poll;
+
+	return ret;
+}
+
+
+int hook_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	struct hook_fabric *fab = container_of(fabric, struct hook_fabric, fabric);
+	struct fid *hfid;
+	int i, ret;
+
+	for (i = 0; i < count; i++) {
+		hfid = hook_to_hfid(fids[i]);
+		if (!hfid)
+			return -FI_EINVAL;
+
+		ret = fi_trywait(fab->hfabric, &hfid, 1);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int hook_do_wait(struct fid_wait *waitset, int timeout)
+{
+	struct hook_wait *wait = container_of(waitset, struct hook_wait, wait);
+
+	return fi_wait(wait->hwait, timeout);
+}
+
+static struct fi_ops_wait hook_wait_ops = {
+	.size = sizeof(struct fi_ops_wait),
+	.wait = hook_do_wait,
+};
+
+int hook_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+		   struct fid_wait **waitset)
+{
+	struct hook_fabric *fab = container_of(fabric, struct hook_fabric, fabric);
+	struct hook_wait *wait;
+	int ret;
+
+	wait = calloc(1, sizeof *wait);
+	if (!wait)
+		return -FI_ENOMEM;
+
+	wait->wait.fid.fclass = FI_CLASS_WAIT;
+	wait->wait.fid.ops = &hook_fid_ops;
+	wait->wait.ops = &hook_wait_ops;
+
+	ret = fi_wait_open(fab->hfabric, attr, &wait->hwait);
+	if (ret)
+		free(wait);
+	else
+		*waitset = &wait->wait;
+
+	return ret;
+}
+

--- a/prov/hook/src/hook_xfer.c
+++ b/prov/hook/src/hook_xfer.c
@@ -1,0 +1,508 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "hook.h"
+
+
+static ssize_t
+hook_atomic_write(struct fid_ep *ep,
+		  const void *buf, size_t count, void *desc,
+		  fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		  enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_atomic(myep->hep, buf, count, desc, dest_addr,
+			 addr, key, datatype, op, context);
+}
+
+static ssize_t
+hook_atomic_writev(struct fid_ep *ep,
+		   const struct fi_ioc *iov, void **desc, size_t count,
+		   fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		   enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_atomicv(myep->hep, iov, desc, count, dest_addr,
+			  addr, key, datatype, op, context);
+}
+
+static ssize_t
+hook_atomic_writemsg(struct fid_ep *ep,
+		     const struct fi_msg_atomic *msg, uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_atomicmsg(myep->hep, msg, flags);
+}
+
+static ssize_t
+hook_atomic_inject(struct fid_ep *ep, const void *buf, size_t count,
+		   fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		   enum fi_datatype datatype, enum fi_op op)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_inject_atomic(myep->hep, buf, count, dest_addr,
+				addr, key, datatype, op);
+}
+
+static ssize_t
+hook_atomic_readwrite(struct fid_ep *ep,
+		      const void *buf, size_t count, void *desc,
+		      void *result, void *result_desc,
+		      fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		      enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_fetch_atomic(myep->hep, buf, count, desc,
+			       result, result_desc, dest_addr,
+			       addr, key, datatype, op, context);
+}
+
+static ssize_t
+hook_atomic_readwritev(struct fid_ep *ep,
+		       const struct fi_ioc *iov, void **desc, size_t count,
+		       struct fi_ioc *resultv, void **result_desc,
+		       size_t result_count, fi_addr_t dest_addr,
+		       uint64_t addr, uint64_t key, enum fi_datatype datatype,
+		       enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_fetch_atomicv(myep->hep, iov, desc, count,
+				resultv, result_desc, result_count,
+				dest_addr, addr, key, datatype, op, context);
+}
+
+static ssize_t
+hook_atomic_readwritemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
+			 struct fi_ioc *resultv, void **result_desc,
+			 size_t result_count, uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_fetch_atomicmsg(myep->hep, msg, resultv, result_desc,
+				  result_count, flags);
+}
+
+static ssize_t
+hook_atomic_compwrite(struct fid_ep *ep,
+		      const void *buf, size_t count, void *desc,
+		      const void *compare, void *compare_desc,
+		      void *result, void *result_desc,
+		      fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		      enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_compare_atomic(myep->hep, buf, count, desc,
+				 compare, compare_desc, result, result_desc,
+				 dest_addr, addr, key, datatype, op, context);
+}
+
+static ssize_t
+hook_atomic_compwritev(struct fid_ep *ep,
+		       const struct fi_ioc *iov, void **desc, size_t count,
+		       const struct fi_ioc *comparev, void **compare_desc,
+		       size_t compare_count, struct fi_ioc *resultv,
+		       void **result_desc, size_t result_count,
+		       fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		       enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_compare_atomicv(myep->hep, iov, desc, count,
+				  comparev, compare_desc, compare_count,
+				  resultv, result_desc, result_count, dest_addr,
+				  addr, key, datatype, op, context);
+}
+static ssize_t
+hook_atomic_compwritemsg(struct fid_ep *ep,
+			 const struct fi_msg_atomic *msg,
+			 const struct fi_ioc *comparev, void **compare_desc,
+			 size_t compare_count, struct fi_ioc *resultv,
+			 void **result_desc, size_t result_count,
+			 uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_compare_atomicmsg(myep->hep, msg,
+				    comparev, compare_desc, compare_count,
+				    resultv, result_desc, result_count, flags);
+}
+
+static int
+hook_atomic_writevalid(struct fid_ep *ep, enum fi_datatype datatype,
+		       enum fi_op op, size_t *count)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_atomicvalid(myep->hep, datatype, op, count);
+}
+
+static int
+hook_atomic_readwritevalid(struct fid_ep *ep, enum fi_datatype datatype,
+			   enum fi_op op, size_t *count)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_fetch_atomicvalid(myep->hep, datatype, op, count);
+}
+
+static int
+hook_atomic_compwritevalid(struct fid_ep *ep, enum fi_datatype datatype,
+			   enum fi_op op, size_t *count)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_compare_atomicvalid(myep->hep, datatype, op, count);
+}
+
+struct fi_ops_atomic hook_atomic_ops = {
+	.size = sizeof(struct fi_ops_atomic),
+	.write = hook_atomic_write,
+	.writev = hook_atomic_writev,
+	.writemsg = hook_atomic_writemsg,
+	.inject = hook_atomic_inject,
+	.readwrite = hook_atomic_readwrite,
+	.readwritev = hook_atomic_readwritev,
+	.readwritemsg = hook_atomic_readwritemsg,
+	.compwrite = hook_atomic_compwrite,
+	.compwritev = hook_atomic_compwritev,
+	.compwritemsg = hook_atomic_compwritemsg,
+	.writevalid = hook_atomic_writevalid,
+	.readwritevalid = hook_atomic_readwritevalid,
+	.compwritevalid = hook_atomic_compwritevalid,
+};
+
+
+static ssize_t
+hook_msg_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+	      fi_addr_t src_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_recv(myep->hep, buf, len, desc, src_addr, context);
+}
+
+static ssize_t
+hook_msg_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+	       size_t count, fi_addr_t src_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_recvv(myep->hep, iov, desc, count, src_addr, context);
+}
+
+static ssize_t
+hook_msg_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_recvmsg(myep->hep, msg, flags);
+}
+
+static ssize_t
+hook_msg_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+	      fi_addr_t dest_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_send(myep->hep, buf, len, desc, dest_addr, context);
+}
+
+static ssize_t
+hook_msg_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+	       size_t count, fi_addr_t dest_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_sendv(myep->hep, iov, desc, count, dest_addr, context);
+}
+
+static ssize_t
+hook_msg_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
+		 uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_sendmsg(myep->hep, msg, flags);
+}
+
+static ssize_t
+hook_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
+		fi_addr_t dest_addr)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_inject(myep->hep, buf, len, dest_addr);
+}
+
+static ssize_t
+hook_msg_senddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		  uint64_t data, fi_addr_t dest_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_senddata(myep->hep, buf, len, desc, data, dest_addr, context);
+}
+
+static ssize_t
+hook_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+		    uint64_t data, fi_addr_t dest_addr)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_injectdata(myep->hep, buf, len, data, dest_addr);
+}
+
+struct fi_ops_msg hook_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = hook_msg_recv,
+	.recvv = hook_msg_recvv,
+	.recvmsg = hook_msg_recvmsg,
+	.send = hook_msg_send,
+	.sendv = hook_msg_sendv,
+	.sendmsg = hook_msg_sendmsg,
+	.inject = hook_msg_inject,
+	.senddata = hook_msg_senddata,
+	.injectdata = hook_msg_injectdata,
+};
+
+
+static ssize_t
+hook_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
+	      fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_read(myep->hep, buf, len, desc, src_addr, addr, key, context);
+}
+
+static ssize_t
+hook_rma_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+	       size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
+	       void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_readv(myep->hep, iov, desc, count, src_addr,
+			addr, key, context);
+}
+
+static ssize_t
+hook_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+		 uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_readmsg(myep->hep, msg, flags);
+}
+
+static ssize_t
+hook_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+	       fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_write(myep->hep, buf, len, desc, dest_addr,
+			addr, key, context);
+}
+
+static ssize_t
+hook_rma_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_writev(myep->hep, iov, desc, count, dest_addr,
+			 addr, key, context);
+}
+
+static ssize_t
+hook_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+		  uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_writemsg(myep->hep, msg, flags);
+}
+
+static ssize_t
+hook_rma_inject(struct fid_ep *ep, const void *buf, size_t len,
+		fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_inject_write(myep->hep, buf, len, dest_addr, addr, key);
+}
+
+static ssize_t
+hook_rma_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		   uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+		   uint64_t key, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_writedata(myep->hep, buf, len, desc, data,
+			    dest_addr, addr, key, context);
+}
+
+static ssize_t
+hook_rma_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+		    uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+		    uint64_t key)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_inject_writedata(myep->hep, buf, len, data, dest_addr,
+				   addr, key);
+}
+
+struct fi_ops_rma hook_rma_ops = {
+	.size = sizeof(struct fi_ops_rma),
+	.read = hook_rma_read,
+	.readv = hook_rma_readv,
+	.readmsg = hook_rma_readmsg,
+	.write = hook_rma_write,
+	.writev = hook_rma_writev,
+	.writemsg = hook_rma_writemsg,
+	.inject = hook_rma_inject,
+	.writedata = hook_rma_writedata,
+	.injectdata = hook_rma_injectdata,
+};
+
+
+static ssize_t
+hook_tagged_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+		 fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
+		 void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_trecv(myep->hep, buf, len, desc, src_addr,
+			tag, ignore, context);
+}
+
+static ssize_t
+hook_tagged_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		  size_t count, fi_addr_t src_addr, uint64_t tag,
+		  uint64_t ignore, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_trecvv(myep->hep, iov, desc, count, src_addr,
+			 tag, ignore, context);
+}
+
+static ssize_t
+hook_tagged_recvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+		    uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_trecvmsg(myep->hep, msg, flags);
+}
+
+static ssize_t
+hook_tagged_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		 fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_tsend(myep->hep, buf, len, desc, dest_addr, tag, context);
+}
+
+static ssize_t
+hook_tagged_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		  size_t count, fi_addr_t dest_addr, uint64_t tag,
+		  void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_tsendv(myep->hep, iov, desc, count, dest_addr, tag, context);
+}
+
+static ssize_t
+hook_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+		    uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_tsendmsg(myep->hep, msg, flags);
+}
+
+static ssize_t
+hook_tagged_inject(struct fid_ep *ep, const void *buf, size_t len,
+		   fi_addr_t dest_addr, uint64_t tag)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_tinject(myep->hep, buf, len, dest_addr, tag);
+}
+
+static ssize_t
+hook_tagged_senddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		     uint64_t data, fi_addr_t dest_addr, uint64_t tag,
+		     void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_tsenddata(myep->hep, buf, len, desc, data,
+			    dest_addr, tag, context);
+}
+
+static ssize_t
+hook_tagged_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+		       uint64_t data, fi_addr_t dest_addr, uint64_t tag)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+
+	return fi_tinjectdata(myep->hep, buf, len, data, dest_addr, tag);
+}
+
+struct fi_ops_tagged hook_tagged_ops = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = hook_tagged_recv,
+	.recvv = hook_tagged_recvv,
+	.recvmsg = hook_tagged_recvmsg,
+	.send = hook_tagged_send,
+	.sendv = hook_tagged_sendv,
+	.sendmsg = hook_tagged_sendmsg,
+	.inject = hook_tagged_inject,
+	.senddata = hook_tagged_senddata,
+	.injectdata = hook_tagged_injectdata,
+};


### PR DESCRIPTION
Introduce a new provider capable of hooking all calls to a
provider.  The intercepting provider can be used to enable debugging or
performance profiling over any provider.  Because the hook provider
is always built, it can be available even in release builds, with no impact if not enabled.

This PR adds the code for the hook provider, incorporates it into the build, but doesn't enable it.  Enabling will need to come in a follow on patch.  As a result, there's no way to test this code.

Although this is a large patch, since it hooks across the entire API.  Most of the code is straightforward and simply passes calls through to the hooked provider.

The plan is to introduce a new environment variable, FI_HOOK.  When set, the hook provider will inject itself between the application and whichever provider(s) are being used.  The value of FI_HOOK will determine which type of hook to enable.  For example, FI_HOOK=debug could be used to enable debug output, even in release builds.  FI_HOOK=profile could enable performance profiling.