### PR TITLE
prov/gni: plug a memory leak

### DIFF
--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -89,6 +89,8 @@ static void __domain_destruct(void *obj)
 					"registration cache\n");
 	}
 
+	free(domain->mr_cache_info);
+
 	ret = _gnix_smrn_close(domain->mr_cache_attr.smrn);
 	if (ret != FI_SUCCESS)
 		GNIX_FATAL(FI_LOG_MR, "failed to close MR notifier\n");


### PR DESCRIPTION
Plug a memory leak reported by a diligent valgrind user.
Thanks to @sougmagne for reporting.

Fixes #3663
Fixes ofi-cray/libfabric-cray#1425

Signed-off-by: Howard Pritchard <howardp@lanl.gov>