### PR TITLE
prov/shm: add data functions

### DIFF
--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2016-2018 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -72,12 +72,23 @@ enum {
 	smr_src_iov,	/* reference iovec via CMA */
 };
 
+/* 
+ * Unique smr_op_hdr for smr message protocol:
+ * 	addr - local fi_addr of peer sending msg (for shm lookup)
+ * 	op - type of op (ex. ofi_op_msg, defined in fi_proto.h)
+ * 	op_src - msg src (ex. smr_src_inline, defined above)
+ * 	op_flags - operation flags (ex. OFI_REMOTE_CQ_DATA, in fi_proto.h)
+ * 	src_data - src of additional op data (inject offset / resp offset)
+ * 	data - remote CQ data
+ */
 struct smr_op_hdr {
 	fi_addr_t		addr;
 	uint32_t		op;
-	uint32_t		op_src;
+	uint16_t		op_src;
+	uint16_t		op_flags;
 
 	uint64_t		size;
+	uint64_t		src_data;
 	uint64_t		data;
 	union {
 		uint64_t	tag;

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -30,7 +30,7 @@ ssize_t fi_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 ssize_t fi_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	uint64_t flags);
 
-ssize_t fi_send(struct fid_ep *ep, void *buf, size_t len,
+ssize_t fi_send(struct fid_ep *ep, const void *buf, size_t len,
 	void *desc, fi_addr_t dest_addr, void *context);
 
 ssize_t fi_sendv(struct fid_ep *ep, const struct iovec *iov,
@@ -39,13 +39,13 @@ ssize_t fi_sendv(struct fid_ep *ep, const struct iovec *iov,
 ssize_t fi_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	uint64_t flags);
 
-ssize_t fi_inject(struct fid_ep *ep, void *buf, size_t len,
+ssize_t fi_inject(struct fid_ep *ep, const void *buf, size_t len,
 	fi_addr_t dest_addr);
 
-ssize_t fi_senddata(struct fid_ep *ep, void *buf, size_t len,
+ssize_t fi_senddata(struct fid_ep *ep, const void *buf, size_t len,
 	void *desc, uint64_t data, fi_addr_t dest_addr, void *context);
 
-ssize_t fi_injectdata(struct fid_ep *ep, void *buf, size_t len,
+ssize_t fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 	uint64_t data, fi_addr_t dest_addr);
 ```
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -104,7 +104,7 @@ struct smr_ep_entry {
 struct smr_ep;
 typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context,
 		uint64_t flags, size_t len, void *buf, void *addr,
-		uint64_t tag, uint64_t err);
+		uint64_t tag, uint64_t data, uint64_t err);
 typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context,
 		uint64_t flags, uint64_t err);
 

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2015-2018 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -64,6 +64,7 @@ struct fi_domain_attr smr_domain_attr = {
 	.resource_mgmt = FI_RM_ENABLED,
 	.av_type = FI_AV_UNSPEC,
 	.mr_mode = FI_MR_VIRT_ADDR,
+	.cq_data_size = sizeof_field(struct smr_op_hdr, data),
 	.cq_cnt = (1 << 10),
 	.ep_cnt = (1 << 10),
 	.tx_ctx_cnt = (1 << 10),


### PR DESCRIPTION
- modify smr_op_hdr struct
	- include op_flags (for signaling CQ data)
	- differentiate between src_data (tx_buf/resp offset) and data
- make generic inject function to reuse for fi_inject, fi_tinject, fi_injectdata, and fi_tinjectdata
- add smr_rx_comp_flags to get rx completion flags
- fix some errors
	- check if rx_cq is full before committing
	- free recv entry if was processed in unexpected messages
- switch some "ret"s to "err"s when passing in before completion because coverity complained once before

Verified working on ubertest latency, bandwidth, and unit tests

Also updated license dates because it's 2018 now apparently :O

Throwing a man page error update in here as well

Signed-off-by: aingerson <alexia.ingerson@intel.com>
  