### PR TITLE
util/cq: Fix support for fi_cq_signal

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -299,6 +299,7 @@ struct util_cq {
 	struct slist		err_list;
 	fi_cq_read_func		read_entry;
 	int			internal_wait;
+	ofi_atomic32_t		signaled;
 	ofi_cq_progress_func	progress;
 };
 

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -50,6 +50,7 @@
 #include <netinet/in.h>
 
 #include <fi.h>
+#include <fi_atom.h>
 #include <ofi_atomic.h>
 #include <ofi_mr.h>
 #include <fi_enosys.h>
@@ -881,6 +882,7 @@ struct sock_cq {
 
 	struct fid_wait *waitset;
 	int signal;
+	ofi_atomic32_t signaled;
 
 	struct dlist_entry ep_list;
 	struct dlist_entry rx_list;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -267,8 +267,8 @@ unlock:
 	return ret;
 }
 
-ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
-		const void *cond, int timeout)
+ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
+		fi_addr_t *src_addr, const void *cond, int timeout)
 {
 	struct util_cq *cq;
 	uint64_t start;
@@ -279,7 +279,7 @@ ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
 	start = (timeout >= 0) ? fi_gettime_ms() : 0;
 
 	do {
-		ret = ofi_cq_read(cq_fid, buf, count);
+		ret = ofi_cq_readfrom(cq_fid, buf, count, src_addr);
 		if (ret != -FI_EAGAIN)
 			break;
 
@@ -295,15 +295,10 @@ ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
 	return ret;
 }
 
-ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
-		fi_addr_t *src_addr, const void *cond, int timeout)
+ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
+		const void *cond, int timeout)
 {
-	struct util_cq *cq;
-
-	cq = container_of(cq_fid, struct util_cq, cq_fid);
-	assert(cq->wait && cq->internal_wait);
-	fi_wait(&cq->wait->wait_fid, timeout);
-	return ofi_cq_readfrom(cq_fid, buf, count, src_addr);
+	return ofi_cq_sreadfrom(cq_fid, buf, count, NULL, cond, timeout);
 }
 
 int ofi_cq_signal(struct fid_cq *cq_fid)

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -283,11 +283,11 @@ ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		if (ret != -FI_EAGAIN)
 			break;
 
-		if (timeout >= 0) {
+		if (timeout >= 0)
 			timeout -= (int) (fi_gettime_ms() - start);
-			if (timeout <= 0)
-				return -FI_ETIMEDOUT;
-		}
+
+		if (timeout <= 0)
+			return -FI_EAGAIN;
 
 		if (ofi_atomic_get32(&cq->signaled)) {
 			ofi_atomic_set32(&cq->signaled, 0);
@@ -297,7 +297,7 @@ ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		ret = fi_wait(&cq->wait->wait_fid, timeout);
 	} while (!ret);
 
-	return ret;
+	return ret == -FI_ETIMEDOUT ? -FI_EAGAIN : ret;
 }
 
 ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -173,42 +173,6 @@ static void util_cq_read_tagged(void **dst, void *src)
 	*(char **)dst += sizeof(struct fi_cq_tagged_entry);
 }
 
-ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
-{
-	struct util_cq *cq;
-	struct fi_cq_tagged_entry *entry;
-	size_t i;
-
-	cq = container_of(cq_fid, struct util_cq, cq_fid);
-	fastlock_acquire(&cq->cq_lock);
-	if (ofi_cirque_isempty(cq->cirq)) {
-		fastlock_release(&cq->cq_lock);
-		cq->progress(cq);
-		fastlock_acquire(&cq->cq_lock);
-		if (ofi_cirque_isempty(cq->cirq)) {
-			i = -FI_EAGAIN;
-			goto out;
-		}
-	}
-
-	if (count > ofi_cirque_usedcnt(cq->cirq))
-		count = ofi_cirque_usedcnt(cq->cirq);
-
-	for (i = 0; i < count; i++) {
-		entry = ofi_cirque_head(cq->cirq);
-		if (entry->flags & UTIL_FLAG_ERROR) {
-			if (!i)
-				i = -FI_EAVAIL;
-			break;
-		}
-		cq->read_entry(&buf, entry);
-		ofi_cirque_discard(cq->cirq);
-	}
-out:
-	fastlock_release(&cq->cq_lock);
-	return i;
-}
-
 ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		fi_addr_t *src_addr)
 {
@@ -247,13 +211,19 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 				i = -FI_EAVAIL;
 			break;
 		}
-		src_addr[i] = cq->src[ofi_cirque_rindex(cq->cirq)];
+		if (src_addr && cq->src)
+			src_addr[i] = cq->src[ofi_cirque_rindex(cq->cirq)];
 		cq->read_entry(&buf, entry);
 		ofi_cirque_discard(cq->cirq);
 	}
 out:
 	fastlock_release(&cq->cq_lock);
 	return i;
+}
+
+ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
+{
+	return ofi_cq_readfrom(cq_fid, buf, count, NULL);
 }
 
 ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,


### PR DESCRIPTION
This series fixes (in theory) the handling of fi_cq_signal, so that any thread waiting in cq sread or sreadfrom will unblock and return when signal is called.  The current code does not unblock threads waiting in sread.  Sreadfrom will unblock, but has a separate issue that it may return prematurely before the timeout expires.

This PR is related to #3645, however, the fix only applies to code that uses the utility CQ.  A fix to the socket provider will follow.

The signal code itself is untested, pending enhancements to fabtests to test for correctness. That too will follow.