### PR TITLE
prov/psm2: Three patches for enabling shared tx context support

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -452,7 +452,8 @@ struct psmx2_cq_event {
 struct psmx2_fid_cq {
 	struct fid_cq			cq;
 	struct psmx2_fid_domain		*domain;
-	struct psmx2_trx_ctxt		*trx_ctxt;
+	struct psmx2_trx_ctxt		*tx;
+	struct psmx2_trx_ctxt		*rx;
 	int 				format;
 	int				entry_size;
 	size_t				event_count;
@@ -702,7 +703,8 @@ struct psmx2_fid_cntr {
 		struct util_cntr	util_cntr; /* for util_poll_run */
 	};
 	struct psmx2_fid_domain	*domain;
-	struct psmx2_trx_ctxt	*trx_ctxt;
+	struct psmx2_trx_ctxt	*tx;
+	struct psmx2_trx_ctxt	*rx;
 	int			events;
 	uint64_t		flags;
 	ofi_atomic64_t		counter;
@@ -749,7 +751,8 @@ struct psmx2_fid_ep {
 	struct psmx2_fid_domain	*domain;
 	/* above fields are common with sep */
 
-	struct psmx2_trx_ctxt	*trx_ctxt;
+	struct psmx2_trx_ctxt	*tx;
+	struct psmx2_trx_ctxt	*rx;
 	struct psmx2_fid_ep	*base_ep;
 	struct psmx2_fid_av	*av;
 	struct psmx2_fid_cq	*send_cq;

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -754,6 +754,7 @@ struct psmx2_fid_ep {
 	struct psmx2_trx_ctxt	*tx;
 	struct psmx2_trx_ctxt	*rx;
 	struct psmx2_fid_ep	*base_ep;
+	struct psmx2_fid_stx	*stx;
 	struct psmx2_fid_av	*av;
 	struct psmx2_fid_cq	*send_cq;
 	struct psmx2_fid_cq	*recv_cq;
@@ -803,6 +804,8 @@ struct psmx2_fid_sep {
 struct psmx2_fid_stx {
 	struct fid_stx		stx;
 	struct psmx2_fid_domain	*domain;
+	struct psmx2_trx_ctxt	*tx;
+	ofi_atomic32_t		ref;
 };
 
 struct psmx2_fid_mr {

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -449,11 +449,15 @@ struct psmx2_cq_event {
 
 #define PSMX2_ERR_DATA_SIZE		64	/* large enough to hold a string address */
 
+struct psmx2_poll_ctxt {
+	struct psmx2_trx_ctxt		*trx_ctxt;
+	struct slist_entry		list_entry;
+};
+
 struct psmx2_fid_cq {
 	struct fid_cq			cq;
 	struct psmx2_fid_domain		*domain;
-	struct psmx2_trx_ctxt		*tx;
-	struct psmx2_trx_ctxt		*rx;
+	struct slist			poll_list;
 	int 				format;
 	int				entry_size;
 	size_t				event_count;
@@ -703,8 +707,8 @@ struct psmx2_fid_cntr {
 		struct util_cntr	util_cntr; /* for util_poll_run */
 	};
 	struct psmx2_fid_domain	*domain;
-	struct psmx2_trx_ctxt	*tx;
-	struct psmx2_trx_ctxt	*rx;
+	struct slist		poll_list;
+	int			poll_all;
 	int			events;
 	uint64_t		flags;
 	ofi_atomic64_t		counter;

--- a/prov/psm2/src/psmx2_cm.c
+++ b/prov/psm2/src/psmx2_cm.c
@@ -47,7 +47,7 @@ static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 	memset(&epname, 0, sizeof(epname));
 
 	if (ep->type == PSMX2_EP_REGULAR) {
-		epname.epid = ep->trx_ctxt->psm2_epid;
+		epname.epid = ep->rx->psm2_epid;
 		epname.type = ep->type;
 	} else {
 		sep = (struct psmx2_fid_sep *)ep;

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -379,8 +379,15 @@ int psmx2_domain_enable_ep(struct psmx2_fid_domain *domain,
 	if (err)
 		return err;
 
-	if ((ep->caps & FI_RMA) || (ep->caps & FI_ATOMICS))
-		return psmx2_am_init(ep->trx_ctxt);
+	if ((ep->caps & FI_RMA) || (ep->caps & FI_ATOMICS)) {
+		if (ep->tx) {
+			err = psmx2_am_init(ep->tx);
+			if (err)
+				return err;
+		}
+		if (ep->rx && ep->rx != ep->tx)
+			return psmx2_am_init(ep->rx);
+	}
 
 	return 0;
 }

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -219,7 +219,7 @@ static struct fi_ops_domain psmx2_domain_ops = {
 	.scalable_ep = psmx2_sep_open,
 	.cntr_open = psmx2_cntr_open,
 	.poll_open = fi_poll_create,
-	.stx_ctx = fi_no_stx_context,
+	.stx_ctx = psmx2_stx_ctx,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = psmx2_query_atomic,
 };

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -390,7 +390,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 				goto err_out;
 			}
 
-			if (hints->ep_attr->tx_ctx_cnt > psmx2_env.sep_trx_ctxt) {
+			if (hints->ep_attr->tx_ctx_cnt > psmx2_env.sep_trx_ctxt &&
+			    hints->ep_attr->tx_ctx_cnt != FI_SHARED_CONTEXT) {
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
 					"hints->ep_attr->tx_ctx_cnt=%"PRIu64", available=%d\n",
 					hints->ep_attr->tx_ctx_cnt,

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -156,7 +156,7 @@ static int psmx2_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		if (mr->domain != cntr->domain)
 			return -FI_EINVAL;
 		mr->cntr = cntr;
-		cntr->trx_ctxt = PSMX2_ALL_TRX_CTXT;
+		cntr->rx = PSMX2_ALL_TRX_CTXT;
 		break;
 
 	default:

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -156,7 +156,7 @@ static int psmx2_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		if (mr->domain != cntr->domain)
 			return -FI_EINVAL;
 		mr->cntr = cntr;
-		cntr->rx = PSMX2_ALL_TRX_CTXT;
+		cntr->poll_all = 1;
 		break;
 
 	default:


### PR DESCRIPTION
prov/psm2: Keep Tx context and Rx context separate for each endpoint
prov/psm2: Add shared Tx context support
prov/psm2: Allow binding any number of endpoints to a CQ/counter
