### PR TITLE
prov/rxm: Optimizations of the critical path

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -210,9 +210,10 @@ struct rxm_buf {
 struct rxm_rx_buf {
 	/* Must stay at top */
 	struct rxm_buf hdr;
-
 	struct dlist_entry entry;
+
 	struct rxm_ep *ep;
+	struct dlist_entry repost_entry;
 	struct rxm_conn *conn;
 	struct rxm_recv_queue *recv_queue;
 	struct rxm_recv_entry *recv_entry;
@@ -310,6 +311,7 @@ struct rxm_ep {
 	struct rxm_buf_pool 	tx_pool;
 	struct rxm_buf_pool 	rx_pool;
 	struct dlist_entry	post_rx_list;
+	struct dlist_entry	repost_ready_list;
 
 	struct rxm_send_queue 	send_queue;
 	struct rxm_recv_queue 	recv_queue;
@@ -367,7 +369,6 @@ struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep);
 void rxm_ep_progress_one(struct util_ep *util_ep);
 void rxm_ep_progress_multi(struct util_ep *util_ep);
 
-int rxm_ep_repost_buf(struct rxm_rx_buf *buf);
 int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
 
 int rxm_ep_msg_mr_regv(struct rxm_ep *rxm_ep, const struct iovec *iov,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -337,11 +337,8 @@ static inline int rxm_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_ta
 	return ((tag | ignore) == (match_tag | ignore));
 }
 
-static inline uint64_t rxm_ep_tx_flags(struct fid_ep *ep_fid) {
-	struct util_ep *util_ep = container_of(ep_fid, struct util_ep,
-					       ep_fid);
-	return util_ep->tx_op_flags;
-}
+#define rxm_ep_rx_flags(rxm_ep)	((rxm_ep)->util_ep.rx_op_flags)
+#define rxm_ep_tx_flags(rxm_ep)	((rxm_ep)->util_ep.tx_op_flags)
 
 int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 			void *context);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -343,12 +343,6 @@ static inline uint64_t rxm_ep_tx_flags(struct fid_ep *ep_fid) {
 	return util_ep->tx_op_flags;
 }
 
-static inline uint64_t rxm_ep_rx_flags(struct fid_ep *ep_fid) {
-	struct util_ep *util_ep = container_of(ep_fid, struct util_ep,
-					       ep_fid);
-	return util_ep->rx_op_flags;
-}
-
 int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 			void *context);
 int rxm_info_to_core(uint32_t version, const struct fi_info *rxm_info,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -441,6 +441,9 @@ void rxm_buf_release(struct rxm_buf_pool *pool, struct rxm_buf *buf)
 		fastlock_release(&queue->lock);		\
 	} while (0)
 
+#define rxm_tx_entry_cleanup(entry)	(entry)->tx_buf = NULL
+#define rxm_recv_entry_cleanup(entry)
+
 #define RXM_DEFINE_QUEUE_ENTRY(type, queue_type)				\
 static inline struct rxm_ ## type ## _entry *					\
 rxm_ ## type ## _entry_get(struct rxm_ ## queue_type ## _queue *queue)		\
@@ -459,6 +462,7 @@ static inline void								\
 rxm_ ## type ## _entry_release(struct rxm_ ## queue_type ## _queue *queue,	\
 			       struct rxm_ ## type ## _entry *entry)		\
 {										\
+	rxm_ ## type ## _entry_cleanup(entry);					\
 	rxm_entry_push(queue, entry);						\
 }
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -394,7 +394,6 @@ struct rxm_buf *rxm_buf_get(struct rxm_buf_pool *pool)
 		fastlock_release(&pool->lock);
 		return NULL;
 	}
-	memset(buf, 0, sizeof(*buf));
 	fastlock_release(&pool->lock);
 	return buf;
 }
@@ -411,7 +410,6 @@ struct rxm_buf *rxm_buf_get_ex(struct rxm_buf_pool *pool)
 		fastlock_release(&pool->lock);
 		return NULL;
 	}
-	memset(buf, 0, sizeof(*buf));
 	fastlock_release(&pool->lock);
 	buf->desc = fi_mr_desc((struct fid_mr *)mr);
 	return buf;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -357,13 +357,15 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			     struct fid_domain **dom, void *context);
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 			 struct fid_cq **cq_fid, void *context);
-void rxm_cq_progress(struct rxm_ep *rxm_ep);
 ssize_t rxm_cq_handle_data(struct rxm_rx_buf *rx_buf);
 
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  struct fid_ep **ep, void *context);
 
 struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep);
+
+void rxm_ep_progress_one(struct util_ep *util_ep);
+void rxm_ep_progress_multi(struct util_ep *util_ep);
 
 int rxm_ep_repost_buf(struct rxm_rx_buf *buf);
 int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -503,8 +503,8 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	case RXM_LMT_ACK_SENT:
 		assert(comp->flags & FI_SEND);
 		rx_buf = tx_entry->context;
-		rxm_tx_entry_release(&tx_entry->ep->send_queue, tx_entry);
 		rxm_buf_release(&rx_buf->ep->tx_pool, (struct rxm_buf *)tx_entry->tx_buf);
+		rxm_tx_entry_release(&tx_entry->ep->send_queue, tx_entry);
 
 		RXM_LOG_STATE_RX(FI_LOG_CQ, rx_buf, RXM_LMT_FINISH);
 		rx_buf->hdr.state = RXM_LMT_FINISH;

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -225,6 +225,10 @@ RXM_INI
 			"be copied up to this size (default: ~16k). This would "
 			"also affect the supported inject size");
 
+	fi_param_define(&rxm_prov, "comp_per_progress", FI_PARAM_INT,
+			"Defines the maximum number of CQ entries (default: 1) "
+			"per progress.");
+
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");
 		return NULL;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -181,13 +181,13 @@ static ssize_t rxm_ep_rma_inject(struct fid_ep *msg_ep, struct rxm_ep *rxm_ep,
 	tx_buf = RXM_TX_BUF_GET(rxm_ep);
 	if (!tx_buf) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "TX queue full!\n");
-		rxm_cq_progress(rxm_ep);
+		rxm_ep_progress_multi(&rxm_ep->util_ep);
 		return -FI_EAGAIN;
 	}
 
 	tx_entry = rxm_tx_entry_get(&rxm_ep->send_queue);
 	if (!tx_entry) {
-		rxm_cq_progress(rxm_ep);
+		rxm_ep_progress_multi(&rxm_ep->util_ep);
 		ret = -FI_EAGAIN;
 		goto err1;
 	}
@@ -218,7 +218,7 @@ static ssize_t rxm_ep_rma_inject(struct fid_ep *msg_ep, struct rxm_ep *rxm_ep,
 	ret = fi_writemsg(msg_ep, &msg_rma, flags);
 	if (ret) {
 		if (ret == -FI_EAGAIN)
-			rxm_cq_progress(rxm_ep);
+			rxm_ep_progress_multi(&rxm_ep->util_ep);
 		goto err2;
 	}
 	return 0;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -116,8 +116,10 @@ static ssize_t rxm_ep_readv(struct fid_ep *ep_fid, const struct iovec *iov,
 		.context = context,
 		.data = 0,
 	};
+	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
+					     util_ep.ep_fid.fid);
 
-	return rxm_ep_readmsg(ep_fid, &msg, rxm_ep_tx_flags(ep_fid));
+	return rxm_ep_readmsg(ep_fid, &msg, rxm_ep_tx_flags(rxm_ep));
 }
 
 static ssize_t rxm_ep_read(struct fid_ep *ep_fid, void *buf, size_t len,
@@ -143,8 +145,10 @@ static ssize_t rxm_ep_read(struct fid_ep *ep_fid, void *buf, size_t len,
 		.context = context,
 		.data = 0,
 	};
+	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
+					     util_ep.ep_fid.fid);
 
-	return rxm_ep_readmsg(ep_fid, &msg, rxm_ep_tx_flags(ep_fid));
+	return rxm_ep_readmsg(ep_fid, &msg, rxm_ep_tx_flags(rxm_ep));
 }
 
 static ssize_t rxm_ep_rma_inject(struct fid_ep *msg_ep, struct rxm_ep *rxm_ep,
@@ -270,8 +274,10 @@ static ssize_t rxm_ep_writev(struct fid_ep *ep_fid, const struct iovec *iov,
 		.context = context,
 		.data = 0,
 	};
+	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
+					     util_ep.ep_fid.fid);
 
-	return rxm_ep_writemsg(ep_fid, &msg, rxm_ep_tx_flags(ep_fid));
+	return rxm_ep_writemsg(ep_fid, &msg, rxm_ep_tx_flags(rxm_ep));
 }
 
 static ssize_t rxm_ep_writedata(struct fid_ep *ep_fid, const void *buf,
@@ -298,8 +304,10 @@ static ssize_t rxm_ep_writedata(struct fid_ep *ep_fid, const void *buf,
 		.context = context,
 		.data = data,
 	};
+	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
+					     util_ep.ep_fid.fid);
 
-	return rxm_ep_writemsg(ep_fid, &msg, rxm_ep_tx_flags(ep_fid) |
+	return rxm_ep_writemsg(ep_fid, &msg, rxm_ep_tx_flags(rxm_ep) |
 			       FI_REMOTE_CQ_DATA);
 }
 
@@ -326,8 +334,10 @@ static ssize_t rxm_ep_write(struct fid_ep *ep_fid, const void *buf,
 		.context = context,
 		.data = 0,
 	};
+	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
+					     util_ep.ep_fid.fid);
 
-	return rxm_ep_writemsg(ep_fid, &msg, rxm_ep_tx_flags(ep_fid));
+	return rxm_ep_writemsg(ep_fid, &msg, rxm_ep_tx_flags(rxm_ep));
 }
 
 static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
@@ -353,9 +363,11 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 		.context = NULL,
 		.data = 0,
 	};
+	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
+					     util_ep.ep_fid.fid);
 
 	return rxm_ep_writemsg(ep_fid, &msg,
-			       (rxm_ep_tx_flags(ep_fid) & ~FI_COMPLETION) |
+			       (rxm_ep_tx_flags(rxm_ep) & ~FI_COMPLETION) |
 			       FI_INJECT);
 }
 
@@ -383,9 +395,11 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 		.context = NULL,
 		.data = data,
 	};
+	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
+					     util_ep.ep_fid.fid);
 
 	return rxm_ep_writemsg(ep_fid, &msg,
-			       (rxm_ep_tx_flags(ep_fid) & ~FI_COMPLETION) |
+			       (rxm_ep_tx_flags(rxm_ep) & ~FI_COMPLETION) |
 			       FI_INJECT | FI_REMOTE_CQ_DATA);
 }
 


### PR DESCRIPTION
This patch adds some optimizations for the  RxM critical path
- Inject and tagged inject paths are splitted into special function.
- Optimizations of CQ engine

**NOTE:**
The part of this PR contains some commits form #3686 that will be removed after #3686 is being merged into the master branch:
- Avoid excessive variable
- Minor changes to the RxM and utility/cmap code. This reduces only single instruction on critical path when the library is built by GCC
- RXM_NONE state has been removed as unneeded and used only in debug case
- Make TX/RX entry routines as static inline
- Simplifies conditions for MR_LOCAL and non-MR_LOCAL cases
- rxm_pkt_init() is doing an excessive memset()
- Remove function's declarations that are defined, but aren't implemented
- Mark some local functions as static