### PR TITLE
prov/psm2: Remove obsolete feature checking code

### DIFF
--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -217,7 +217,7 @@ int psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,
 	psm2_epconn_t epconn;
 	struct psmx2_epaddr_context *context;
 
-	err = psmx2_ep_epid_lookup(trx_ctxt->psm2_ep, epid, &epconn);
+	err = psm2_ep_epid_lookup2(trx_ctxt->psm2_ep, epid, &epconn);
 	if (err == PSM2_OK) {
 		context = psm2_epaddr_getctxt(epconn.addr);
 		if (context && context->epid  == epid) {
@@ -388,7 +388,7 @@ static int psmx2_av_connect_trx_ctxt(struct psmx2_fid_av *av,
 	for (i = 0; i < count; i++) {
 		errors[i] = PSM2_OK;
 
-		if (psmx2_ep_epid_lookup(ep, epids[i], &epconn) == PSM2_OK) {
+		if (psm2_ep_epid_lookup2(ep, epids[i], &epconn) == PSM2_OK) {
 			epaddr_context = psm2_epaddr_getctxt(epconn.addr);
 			if (epaddr_context && epaddr_context->epid == epids[i])
 				epaddrs[i] = epconn.addr;
@@ -437,7 +437,7 @@ static int psmx2_av_connect_trx_ctxt(struct psmx2_fid_av *av,
 			 * be reached". This should be treated the same as
 			 * "Endpoint already connected".
 			 */
-			if (psmx2_ep_epid_lookup(ep, epids[i], &epconn) == PSM2_OK) {
+			if (psm2_ep_epid_lookup2(ep, epids[i], &epconn) == PSM2_OK) {
 				epaddr_context = psm2_epaddr_getctxt(epconn.addr);
 				if (epaddr_context &&
 				    epaddr_context->epid == epids[i]) {
@@ -747,7 +747,7 @@ fi_addr_t psmx2_av_translate_source(struct psmx2_fid_av *av, fi_addr_t source)
 	int i, j;
 
 	epaddr = PSMX2_ADDR_TO_EP(source);
-	epid = psmx2_epaddr_to_epid(epaddr);
+	psm2_epaddr_to_epid(epaddr, &epid);
 
 	for (i = av->last - 1; i >= 0; i--) {
 		if (av->peers[i].type == PSMX2_EP_REGULAR) {

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -98,9 +98,10 @@ static int psmx2_get_yes_no(char *s, int default_value)
 
 static int psmx2_check_multi_ep_cap(void)
 {
+	uint64_t caps = PSM2_MULTI_EP_CAP;
 	char *s = getenv("PSM2_MULTI_EP");
 
-	if (psmx2_multi_ep_ok() && psmx2_get_yes_no(s, 0))
+	if (psm2_get_capability_mask(caps) == caps && psmx2_get_yes_no(s, 0))
 		psmx2_env.multi_ep = 1;
 	else
 		psmx2_env.multi_ep = 0;
@@ -147,7 +148,6 @@ static int psmx2_init_lib(void)
 	else
 		FI_INFO(&psmx2_prov, FI_LOG_CORE, "PSM2 multi-ep feature not available or disabled.\n");
 
-	psmx2_init_disconnect_func();
 	psmx2_lib_initialized = 1;
 
 out:


### PR DESCRIPTION
By now the required PSM2 library version should have included all the
features that were previously optional. It is no longer necessary to
check for those features.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>