### PR TITLE
prov/verbs: handle wildcard addresses correctly for passive EPs + bug fixes

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -197,11 +197,18 @@ uint64_t fi_gettime_us(void);
 #define OFI_STR(X) #X
 #define OFI_STR_INT(X) OFI_STR(X)
 
-static inline size_t ofi_sizeofaddr(const struct sockaddr *address)
+static inline size_t ofi_sizeofaddr(const struct sockaddr *addr)
 {
-	return (address->sa_family == AF_INET ?
-		sizeof(struct sockaddr_in) :
-		sizeof(struct sockaddr_in6));
+	switch (addr->sa_family) {
+	case AF_INET:
+		return sizeof(struct sockaddr_in);
+	case AF_INET6:
+		return sizeof(struct sockaddr_in6);
+	default:
+		FI_WARN(&core_prov, FI_LOG_CORE, "Unknown address format");
+		assert(0);
+		return 0;
+	}
 }
 
 static inline int ofi_equals_ipaddr(const struct sockaddr_in *addr1,

--- a/include/fi.h
+++ b/include/fi.h
@@ -172,6 +172,7 @@ int ofi_rma_initiate_allowed(uint64_t caps);
 int ofi_rma_target_allowed(uint64_t caps);
 int ofi_ep_bind_valid(const struct fi_provider *prov, struct fid *bfid,
 		      uint64_t flags);
+int ofi_check_rx_mode(const struct fi_info *info, uint64_t flags);
 
 uint64_t fi_gettime_ms(void);
 uint64_t fi_gettime_us(void);

--- a/include/fi.h
+++ b/include/fi.h
@@ -278,6 +278,8 @@ void ofi_straddr_log_internal(const char *func, int line,
 #define ofi_straddr_dbg(prov, subsystem, ...) do {} while(0)
 #endif
 
+int ofi_is_any_addr(struct sockaddr *sa);
+
 /*
  * Key Index
  */

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -95,19 +95,10 @@ struct util_prov fi_ibv_util_prov = {
 
 int fi_ibv_sockaddr_len(struct sockaddr *addr)
 {
-	if (!addr)
-		return 0;
-
-	switch (addr->sa_family) {
-	case AF_INET:
-		return sizeof(struct sockaddr_in);
-	case AF_INET6:
-		return sizeof(struct sockaddr_in6);
-	case AF_IB:
+	if (addr->sa_family == AF_IB)
 		return sizeof(struct sockaddr_ib);
-	default:
-		return 0;
-	}
+	else
+		return ofi_sizeofaddr(addr);
 }
 
 int fi_ibv_rdm_cm_bind_ep(struct fi_ibv_rdm_cm *cm, struct fi_ibv_rdm_ep *ep)

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -119,6 +119,9 @@
 #define FI_IBV_BUF_ALIGNMENT (4096) /* TODO: Page or MTU size */
 #define FI_IBV_POOL_BUF_CNT (100)
 
+#define VERBS_ANY_DOMAIN "verbs_any_domain"
+#define VERBS_ANY_FABRIC "verbs_any_fabric"
+
 /* NOTE:
  * When ibv_post_send/recv returns '-1' it means the following:
  * Deal with non-compliant libibverbs drivers which set errno

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -118,13 +118,8 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event,
 		goto err;
 	memcpy((*info)->dest_addr, rdma_get_peer_addr(event->id), (*info)->dest_addrlen);
 
-	VERBS_INFO(FI_LOG_CORE, "src_addr: %s:%d\n",
-		   inet_ntoa(((struct sockaddr_in *)(*info)->src_addr)->sin_addr),
-		   ntohs(((struct sockaddr_in *)(*info)->src_addr)->sin_port));
-
-	VERBS_INFO(FI_LOG_CORE, "dst_addr: %s:%d\n",
-		   inet_ntoa(((struct sockaddr_in *)(*info)->dest_addr)->sin_addr),
-		   ntohs(((struct sockaddr_in *)(*info)->dest_addr)->sin_port));
+	ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_EQ, "src", (*info)->src_addr);
+	ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_EQ, "dst", (*info)->dest_addr);
 
 	connreq = calloc(1, sizeof *connreq);
 	if (!connreq)

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -81,50 +81,50 @@ fi_ibv_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 	return sizeof(*entry);
 }
 
-static struct fi_info *
+static int
 fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event,
-		     struct fi_info *pep_info)
+		     struct fi_info *pep_info, struct fi_info **info)
 {
-	struct fi_info *info;
 	const struct fi_info *fi;
 	struct fi_ibv_connreq *connreq;
 	const char *devname = ibv_get_device_name(event->id->verbs->device);
+	int ret = -FI_ENOMEM;
 
 	if (strcmp(devname, fab->info->domain_attr->name)) {
 		fi = fi_ibv_get_verbs_info(fi_ibv_util_prov.info, devname);
 		if (!fi)
-			return NULL;
+			return -FI_ENODATA;
 	} else {
 		fi = fab->info;
 	}
 
-	info = fi_dupinfo(fi);
-	if (!info)
-		return NULL;
+	*info = fi_dupinfo(fi);
+	if (!*info)
+		return -FI_ENOMEM;
 
-	info->fabric_attr->fabric = &fab->util_fabric.fabric_fid;
-	if (!(info->fabric_attr->prov_name = strdup(VERBS_PROV_NAME)))
+	(*info)->fabric_attr->fabric = &fab->util_fabric.fabric_fid;
+	if (!((*info)->fabric_attr->prov_name = strdup(VERBS_PROV_NAME)))
 		goto err;
 
-	ofi_alter_info(info, pep_info, fab->util_fabric.fabric_fid.api_version);
+	ofi_alter_info((*info), pep_info, fab->util_fabric.fabric_fid.api_version);
 
-	info->src_addrlen = fi_ibv_sockaddr_len(rdma_get_local_addr(event->id));
-	if (!(info->src_addr = malloc(info->src_addrlen)))
+	(*info)->src_addrlen = fi_ibv_sockaddr_len(rdma_get_local_addr(event->id));
+	if (!((*info)->src_addr = malloc((*info)->src_addrlen)))
 		goto err;
-	memcpy(info->src_addr, rdma_get_local_addr(event->id), info->src_addrlen);
+	memcpy((*info)->src_addr, rdma_get_local_addr(event->id), (*info)->src_addrlen);
 
-	info->dest_addrlen = fi_ibv_sockaddr_len(rdma_get_peer_addr(event->id));
-	if (!(info->dest_addr = malloc(info->dest_addrlen)))
+	(*info)->dest_addrlen = fi_ibv_sockaddr_len(rdma_get_peer_addr(event->id));
+	if (!((*info)->dest_addr = malloc((*info)->dest_addrlen)))
 		goto err;
-	memcpy(info->dest_addr, rdma_get_peer_addr(event->id), info->dest_addrlen);
+	memcpy((*info)->dest_addr, rdma_get_peer_addr(event->id), (*info)->dest_addrlen);
 
 	VERBS_INFO(FI_LOG_CORE, "src_addr: %s:%d\n",
-		   inet_ntoa(((struct sockaddr_in *)info->src_addr)->sin_addr),
-		   ntohs(((struct sockaddr_in *)info->src_addr)->sin_port));
+		   inet_ntoa(((struct sockaddr_in *)(*info)->src_addr)->sin_addr),
+		   ntohs(((struct sockaddr_in *)(*info)->src_addr)->sin_port));
 
 	VERBS_INFO(FI_LOG_CORE, "dst_addr: %s:%d\n",
-		   inet_ntoa(((struct sockaddr_in *)info->dest_addr)->sin_addr),
-		   ntohs(((struct sockaddr_in *)info->dest_addr)->sin_port));
+		   inet_ntoa(((struct sockaddr_in *)(*info)->dest_addr)->sin_addr),
+		   ntohs(((struct sockaddr_in *)(*info)->dest_addr)->sin_port));
 
 	connreq = calloc(1, sizeof *connreq);
 	if (!connreq)
@@ -132,11 +132,11 @@ fi_ibv_eq_cm_getinfo(struct fi_ibv_fabric *fab, struct rdma_cm_event *event,
 
 	connreq->handle.fclass = FI_CLASS_CONNREQ;
 	connreq->id = event->id;
-	info->handle = &connreq->handle;
-	return info;
+	(*info)->handle = &connreq->handle;
+	return 0;
 err:
-	fi_freeinfo(info);
-	return NULL;
+	fi_freeinfo(*info);
+	return ret;
 }
 
 static ssize_t
@@ -153,10 +153,14 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 	switch (cma_event->event) {
 	case RDMA_CM_EVENT_CONNECT_REQUEST:
 		*event = FI_CONNREQ;
-		entry->info = fi_ibv_eq_cm_getinfo(eq->fab, cma_event, pep->info);
-		if (!entry->info) {
+		ret = fi_ibv_eq_cm_getinfo(eq->fab, cma_event, pep->info, &entry->info);
+		if (ret) {
 			rdma_destroy_id(cma_event->id);
-			return 0;
+			if (ret == -FI_ENODATA)
+				return 0;
+			eq->err.err = -ret;
+			eq->err.prov_errno = ret;
+			goto err;
 		}
 		break;
 	case RDMA_CM_EVENT_ESTABLISHED:
@@ -177,22 +181,18 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 	case RDMA_CM_EVENT_ROUTE_ERROR:
 	case RDMA_CM_EVENT_CONNECT_ERROR:
 	case RDMA_CM_EVENT_UNREACHABLE:
-		eq->err.fid = fid;
 		eq->err.err = cma_event->status;
-		return -FI_EAVAIL;
+		goto err;
 	case RDMA_CM_EVENT_REJECTED:
-		eq->err.fid = fid;
 		eq->err.err = ECONNREFUSED;
-		eq->err.prov_errno = cma_event->status;
-		return -FI_EAVAIL;
+		eq->err.prov_errno = -cma_event->status;
+		goto err;
 	case RDMA_CM_EVENT_DEVICE_REMOVAL:
-		eq->err.fid = fid;
 		eq->err.err = ENODEV;
-		return -FI_EAVAIL;
+		goto err;
 	case RDMA_CM_EVENT_ADDR_CHANGE:
-		eq->err.fid = fid;
 		eq->err.err = EADDRNOTAVAIL;
-		return -FI_EAVAIL;
+		goto err;
 	default:
 		return 0;
 	}
@@ -202,6 +202,9 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event
 	if (datalen)
 		memcpy(entry->data, cma_event->param.conn.private_data, datalen);
 	return sizeof(*entry) + datalen;
+err:
+	eq->err.fid = fid;
+	return -FI_EAVAIL;
 }
 
 ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -41,7 +41,6 @@
 
 #define VERBS_IB_PREFIX "IB-0x"
 #define VERBS_IWARP_FABRIC "Ethernet-iWARP"
-#define VERBS_ANY_FABRIC "Any RDMA fabric"
 
 #define VERBS_MSG_CAPS (FI_MSG | FI_RMA | FI_ATOMICS | FI_READ | FI_WRITE | \
 			FI_SEND | FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE | \
@@ -1170,14 +1169,45 @@ static int fi_ibv_set_default_info(struct fi_info *info)
 	return 0;
 }
 
+static struct fi_info *fi_ibv_get_passive_info(const struct fi_info *prov_info,
+					       const struct fi_info *hints)
+{
+	struct fi_info *info;
+
+	if (!(info = fi_dupinfo(hints)))
+		return NULL;
+
+	info->mode = prov_info->mode;
+	info->tx_attr->mode = prov_info->tx_attr->mode;
+	info->rx_attr->mode = prov_info->rx_attr->mode;
+	info->ep_attr->type = prov_info->ep_attr->type;
+
+	info->domain_attr->domain 	= prov_info->domain_attr->domain;
+	if (!info->domain_attr->name)
+		info->domain_attr->name = strdup(VERBS_ANY_DOMAIN);
+	info->domain_attr->mr_mode 	= prov_info->domain_attr->mr_mode;
+	info->domain_attr->mode 	= prov_info->domain_attr->mode;
+
+	info->fabric_attr->fabric = prov_info->fabric_attr->fabric;
+	if (!info->fabric_attr->name)
+		info->fabric_attr->name = strdup(VERBS_ANY_FABRIC);
+
+	/* prov_name is set by libfabric core */
+	free(info->fabric_attr->prov_name);
+	info->fabric_attr->prov_name = NULL;
+	return info;
+}
+
 static int fi_ibv_get_matching_info(uint32_t version,
 				    const struct fi_info *hints,
 				    struct fi_info **info,
-				    const struct fi_info *verbs_info)
+				    const struct fi_info *verbs_info,
+				    uint8_t is_any_addr)
 {
 	const struct fi_info *check_info = verbs_info;
 	struct fi_info *fi, *tail;
 	int ret;
+	uint8_t got_passive_info = 0;
 
 	*info = tail = NULL;
 
@@ -1191,15 +1221,25 @@ static int fi_ibv_get_matching_info(uint32_t version,
 				continue;
 		}
 
-		if (!(fi = fi_dupinfo(check_info))) {
-			ret = -FI_ENOMEM;
-			goto err;
-		}
+		if ((check_info->ep_attr->type == FI_EP_MSG) && is_any_addr) {
+			if (got_passive_info)
+				continue;
 
-		ret = fi_ibv_set_default_info(fi);
-		if (ret) {
-			fi_freeinfo(fi);
-			continue;
+			if (!(fi = fi_ibv_get_passive_info(check_info, hints))) {
+				ret = -FI_ENOMEM;
+				goto err;
+			}
+			got_passive_info = 1;
+		} else {
+			if (!(fi = fi_dupinfo(check_info))) {
+				ret = -FI_ENOMEM;
+				goto err;
+			}
+			ret = fi_ibv_set_default_info(fi);
+			if (ret) {
+				fi_freeinfo(fi);
+				continue;
+			}
 		}
 
 		if (!*info)
@@ -1375,6 +1415,31 @@ fn:
 	return ret;
 }
 
+static int fi_ibv_port_is_set(void *addr)
+{
+	if (!addr)
+		return 0;
+
+	switch (ofi_sa_family(addr)) {
+	case AF_INET:
+		return ofi_sin_port(addr) ? 1 : 0;
+	case AF_INET6:
+		return ofi_sin6_port(addr) ? 1 : 0;
+	default:
+		VERBS_WARN(FI_LOG_FABRIC, "Unknown address format\n");
+		return 0;
+	}
+}
+
+/* TODO revisit this if and when getinfo is refactored */
+static int fi_ibv_is_any_addr(const char *node, const char *service, const struct fi_info *hints)
+{
+	return (!node && (!hints || !hints->dest_addr) &&
+		((hints && ofi_is_any_addr(hints->src_addr) &&
+		  fi_ibv_port_is_set(hints->src_addr)) || service));
+}
+
+
 static int fi_ibv_get_match_infos(uint32_t version, const char *node,
 				  const char *service, uint64_t flags,
 				  const struct fi_info *hints,
@@ -1383,8 +1448,8 @@ static int fi_ibv_get_match_infos(uint32_t version, const char *node,
 {
 	int ret, ret_sock_addr, ret_ib_ud_addr;
 
-	ret = fi_ibv_get_matching_info(version, hints,
-				       info, *raw_info);
+	ret = fi_ibv_get_matching_info(version, hints, info, *raw_info,
+				       fi_ibv_is_any_addr(node, service, hints));
 	if (ret)
 		return ret;
 

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1432,7 +1432,7 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 
 	ofi_alter_info(*info, hints, version);
 
-	if (!hints || !(hints->mode & FI_RX_CQ_DATA)) {
+	if (!ofi_check_rx_mode(hints, FI_RX_CQ_DATA)) {
 		for (cur = *info; cur; cur = cur->next)
 			cur->domain_attr->cq_data_size = 0;
 	}

--- a/src/common.c
+++ b/src/common.c
@@ -572,6 +572,45 @@ void ofi_straddr_log_internal(const char *func, int line,
 	}
 }
 
+static int ofi_ipv4_is_any_addr(struct sockaddr *sa)
+{
+	struct in_addr ia_any = {
+		.s_addr = INADDR_ANY,
+	};
+
+	if (!sa)
+		return 0;
+
+	return !memcmp(&ofi_sin_addr(sa).s_addr, &ia_any, sizeof(ia_any));
+
+}
+
+static int ofi_ipv6_is_any_addr(struct sockaddr *sa)
+{
+	struct in6_addr ia6_any = IN6ADDR_ANY_INIT;
+
+	if (!sa)
+		return 0;
+
+	return !memcmp(&ofi_sin6_addr(sa), &ia6_any, sizeof(ia6_any));
+}
+
+int ofi_is_any_addr(struct sockaddr *sa)
+{
+	if (!sa)
+		return 0;
+
+	switch(sa->sa_family) {
+	case AF_INET:
+		return ofi_ipv4_is_any_addr(sa);
+	case AF_INET6:
+		return ofi_ipv6_is_any_addr(sa);
+	default:
+		FI_WARN(&core_prov, FI_LOG_CORE, "Unknown address format!\n");
+		return 0;
+	}
+}
+
 #ifndef HAVE_EPOLL
 
 int fi_epoll_create(struct fi_epoll **ep)

--- a/src/common.c
+++ b/src/common.c
@@ -186,6 +186,17 @@ int ofi_ep_bind_valid(const struct fi_provider *prov, struct fid *bfid, uint64_t
 	return FI_SUCCESS;
 }
 
+int ofi_check_rx_mode(const struct fi_info *info, uint64_t flags)
+{
+	if (!info)
+		return 0;
+
+	if (info->rx_attr && (info->rx_attr->mode & flags))
+		return 1;
+
+	return (info->mode & flags) ? 1 : 0;
+}
+
 uint64_t fi_gettime_ms(void)
 {
 	struct timeval now;


### PR DESCRIPTION
- prov/verbs: catch fatal errors on connection request
- common: Augment address sizeof function to handle AF_IB 
- prov/verbs: Update provider to use common address sizeof function
- prov/verbs: use ofi_straddr for address logging
- common: add a function to check if a sockadddr is a wildcard address
- prov/verbs: check for FI_RX_CQ_DATA in rx_attr as well
- prov/verbs: handle wildcard addresses correctly
