### PR TITLE
prov/gni: remove a trace macro from datagram path

### DIFF
--- a/prov/gni/src/gnix_datagram.c
+++ b/prov/gni/src/gnix_datagram.c
@@ -433,8 +433,6 @@ int  _gnix_dgram_poll(struct gnix_dgram_hndl *hndl,
 	nic = cm_nic->nic;
 	assert(nic != NULL);
 
-	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
-
 	if (type == GNIX_DGRAM_BLOCK) {
 		if (hndl->timeout_needed &&
 			(hndl->timeout_needed(hndl->timeout_data) == true))


### PR DESCRIPTION
When trying to debug problems in the GNI provider
using trace, the gnix_datagram poll method generates
way too much output.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>