### PR TITLE
prov/psm2: Optimize the conversion between 96-bit and 64-bit tags

### DIFF
--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -206,8 +206,7 @@ static inline int psmx2_cq_any_complete(struct psmx2_fid_cq *poll_cq,
 		event->cqe.err.flags = flags;
 		event->cqe.err.err = -psmx2_errno(PSMX2_STATUS_ERROR(status));
 		event->cqe.err.prov_errno = PSMX2_STATUS_ERROR(status);
-		event->cqe.err.tag = PSMX2_STATUS_TAG(status).tag0 |
-				     (((uint64_t)PSMX2_STATUS_TAG(status).tag1) << 32);
+		event->cqe.err.tag = PSMX2_GET_TAG64(PSMX2_STATUS_TAG(status));
 		event->cqe.err.olen = PSMX2_STATUS_SNDLEN(status) - PSMX2_STATUS_RCVLEN(status);
 		event->cqe.err.data = data;
 


### PR DESCRIPTION
Adopt a method that allows direct access of the first 64 bit of the
96-bit tag without breaking strict-aliasing rules. This should perform
better than the previous method that involves bit manipulation.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>