### PR TITLE
prov/psm2: Fix fi_cq_signal

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -468,6 +468,7 @@ struct psmx2_fid_cq {
 	struct util_wait		*wait;
 	int				wait_cond;
 	int				wait_is_local;
+	ofi_atomic32_t			signaled;
 	uint8_t				error_data[PSMX2_ERR_DATA_SIZE];
 };
 

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -1064,6 +1064,10 @@ static ssize_t psmx2_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 	event_count = cq_priv->event_count;
 	if (event_count < threshold) {
 		if (cq_priv->wait) {
+			if (ofi_atomic_get32(&cq_priv->signaled)) {
+				ofi_atomic_set32(&cq_priv->signaled, 0);
+				return -FI_ECANCELED;
+			}
 			fi_wait((struct fid_wait *)cq_priv->wait, timeout);
 		} else {
 			clock_gettime(CLOCK_REALTIME, &ts0);
@@ -1085,6 +1089,11 @@ static ssize_t psmx2_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 				/* CQ may be updated asynchronously by the AM handlers */
 				if (cq_priv->event_count > event_count)
 					break;
+
+				if (ofi_atomic_get32(&cq_priv->signaled)) {
+					ofi_atomic_set32(&cq_priv->signaled, 0);
+					return -FI_ECANCELED;
+				}
 
 				if (timeout < 0)
 					continue;
@@ -1113,6 +1122,7 @@ static int psmx2_cq_signal(struct fid_cq *cq)
 	struct psmx2_fid_cq *cq_priv;
 	cq_priv = container_of(cq, struct psmx2_fid_cq, cq);
 
+	ofi_atomic_set32(&cq_priv->signaled, 1);
 	if (cq_priv->wait)
 		cq_priv->wait->signal(cq_priv->wait);
 
@@ -1308,6 +1318,7 @@ int psmx2_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		cq_priv->wait_cond = attr->wait_cond;
 	}
 	cq_priv->wait_is_local = wait_is_local;
+	ofi_atomic_initialize32(&cq_priv->signaled, 0);
 
 	cq_priv->cq.fid.fclass = FI_CLASS_CQ;
 	cq_priv->cq.fid.context = context;


### PR DESCRIPTION
Check if the CQ has been signaled when waiting inside fi_cq_sread
and allow early return when the condition is true.

This is a follow up for commit 043e1dd (prov/util: Fix fi_cq_signal).

See #3666 

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>