### PR TITLE
prov/psm2: Initialize AM parameters for shared Tx context

### DIFF
--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -382,6 +382,9 @@ static int psmx2_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			return -FI_EINVAL;
 		ep->tx = stx->tx;
 		ep->stx = stx;
+		err = psmx2_domain_enable_ep(ep->domain, ep);
+		if (err)
+			return err;
 		ofi_atomic_inc32(&stx->ref);
 		break;
 


### PR DESCRIPTION
AM initialization depends on EP caps. Usually it is done when the
endpoint is created. When shared Tx context is used, the initialization
should be done inside fi_ep_bind.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>