### PR TITLE
prov/psm2: Refactor the handling of op context type

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -182,10 +182,11 @@ static inline uint64_t psmx2_get_tag64(psm2_mq_tag_t *tag96)
 /* Bits 60 .. 63 of the flag are provider specific */
 #define PSMX2_NO_COMPLETION	(1ULL << 60)
 
-#define PSMX2_CTXT_ALLOC_FLAG		0x80000000
 enum psmx2_context_type {
 	PSMX2_NOCOMP_SEND_CONTEXT = 1,
 	PSMX2_NOCOMP_RECV_CONTEXT,
+	PSMX2_NOCOMP_TSEND_CONTEXT,
+	PSMX2_NOCOMP_TRECV_CONTEXT,
 	PSMX2_NOCOMP_WRITE_CONTEXT,
 	PSMX2_NOCOMP_READ_CONTEXT,
 	PSMX2_SEND_CONTEXT,
@@ -200,7 +201,7 @@ enum psmx2_context_type {
 	PSMX2_SENDV_CONTEXT,
 	PSMX2_IOV_SEND_CONTEXT,
 	PSMX2_IOV_RECV_CONTEXT,
-	PSMX2_NOCOMP_RECV_CONTEXT_ALLOC = PSMX2_NOCOMP_RECV_CONTEXT | PSMX2_CTXT_ALLOC_FLAG,
+	PSMX2_MAX_CONTEXT_TYPE
 };
 
 struct psmx2_context {
@@ -800,7 +801,7 @@ struct psmx2_fid_ep {
 	uint64_t		caps;
 	ofi_atomic32_t		ref;
 	struct fi_context	nocomp_send_context;
-	struct fi_context	nocomp_recv_context;
+	struct fi_context	nocomp_tsend_context;
 	struct slist		free_context_list;
 	fastlock_t		context_lock;
 	size_t			min_multi_recv;

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -570,8 +570,8 @@ int psmx2_ep_open_internal(struct psmx2_fid_domain *domain_priv,
 
 	PSMX2_CTXT_TYPE(&ep_priv->nocomp_send_context) = PSMX2_NOCOMP_SEND_CONTEXT;
 	PSMX2_CTXT_EP(&ep_priv->nocomp_send_context) = ep_priv;
-	PSMX2_CTXT_TYPE(&ep_priv->nocomp_recv_context) = PSMX2_NOCOMP_RECV_CONTEXT;
-	PSMX2_CTXT_EP(&ep_priv->nocomp_recv_context) = ep_priv;
+	PSMX2_CTXT_TYPE(&ep_priv->nocomp_tsend_context) = PSMX2_NOCOMP_TSEND_CONTEXT;
+	PSMX2_CTXT_EP(&ep_priv->nocomp_tsend_context) = ep_priv;
 
 	if (ep_cap & FI_TAGGED)
 		ep_priv->ep.tagged = &psmx2_tagged_ops;
@@ -718,9 +718,6 @@ void psmx2_ep_put_op_context(struct psmx2_fid_ep *ep,
 			     struct fi_context *fi_context)
 {
 	struct psmx2_context *context;
-
-	if (! (PSMX2_CTXT_TYPE(fi_context) & PSMX2_CTXT_ALLOC_FLAG))
-		return;
 
 	context = container_of(fi_context, struct psmx2_context, fi_context);
 	context->list_entry.next = NULL;

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -94,7 +94,7 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 
 	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION)) {
 		fi_context = psmx2_ep_get_op_context(ep_priv);
-		PSMX2_CTXT_TYPE(fi_context) = PSMX2_NOCOMP_RECV_CONTEXT_ALLOC;
+		PSMX2_CTXT_TYPE(fi_context) = PSMX2_NOCOMP_RECV_CONTEXT;
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
 		PSMX2_CTXT_USER(fi_context) = buf;
 		PSMX2_CTXT_SIZE(fi_context) = len;

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -250,7 +250,7 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 
 	if (ep_priv->recv_selective_completion && !(flags & FI_COMPLETION)) {
 		fi_context = psmx2_ep_get_op_context(ep_priv);
-		PSMX2_CTXT_TYPE(fi_context) = PSMX2_NOCOMP_RECV_CONTEXT_ALLOC;
+		PSMX2_CTXT_TYPE(fi_context) = PSMX2_NOCOMP_TRECV_CONTEXT;
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
 		PSMX2_CTXT_USER(fi_context) = buf;
 		PSMX2_CTXT_SIZE(fi_context) = len;
@@ -325,7 +325,7 @@ psmx2_tagged_recv_specialized(struct fid_ep *ep, void *buf, size_t len,
 		PSMX2_CTXT_USER(fi_context) = buf;
 	} else {
 		fi_context = psmx2_ep_get_op_context(ep_priv);
-		PSMX2_CTXT_TYPE(fi_context) = PSMX2_NOCOMP_RECV_CONTEXT_ALLOC;
+		PSMX2_CTXT_TYPE(fi_context) = PSMX2_NOCOMP_TRECV_CONTEXT;
 	}
 	PSMX2_CTXT_EP(fi_context) = ep_priv;
 	PSMX2_CTXT_SIZE(fi_context) = len;
@@ -632,7 +632,7 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 	}
 
 	if (no_completion) {
-		fi_context = &ep_priv->nocomp_send_context;
+		fi_context = &ep_priv->nocomp_tsend_context;
 	} else {
 		if (!context)
 			return -FI_EINVAL;
@@ -702,7 +702,7 @@ psmx2_tagged_send_specialized(struct fid_ep *ep, const void *buf,
 		PSMX2_CTXT_USER(fi_context) = (void *)buf;
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
 	} else {
-		fi_context = &ep_priv->nocomp_send_context;
+		fi_context = &ep_priv->nocomp_tsend_context;
 	}
 
 	err = psm2_mq_isend2(ep_priv->tx->psm2_mq, psm2_epaddr, 0,


### PR DESCRIPTION
(1) Use a static array to define the completion flags for each context
    type. This allow merging a few switch cases without adding branch.

(2) Receive operations that don't generate completions always need
    allocated context in order to support iov send. Consolidate the
    "alloc" and "non-alloc" types into one.

(3) Add dedicated context types for tagged send/recv operations that
    don't generate completions. This allows correct flags be set in
    error CQE.

(4) Remove a redundant type checking when freeing allocated contexts.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>