### PR TITLE
prov/gni: fixes for UDREG use

### DIFF
--- a/prov/gni/src/gnix_dom.c
+++ b/prov/gni/src/gnix_dom.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
@@ -637,7 +637,11 @@ DIRECT_FN int gnix_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		fastlock_init(&domain->mr_cache_info[i].mr_cache_lock);
 	}
 
-	domain->udreg_reg_limit = 4096;
+	/*
+	 * we are likely sharing udreg entries with Craypich if we're using udreg
+	 * cache, so ask for only half the entries by default.
+	 */
+	domain->udreg_reg_limit = 2048;
 
 	dlist_init(&domain->nic_list);
 	dlist_init(&domain->list);

--- a/prov/gni/test/mr.c
+++ b/prov/gni/test/mr.c
@@ -260,9 +260,18 @@ TestSuite(mr_internal_cache,
 	  .disabled = KDREG_CHECK);
 
 #ifdef HAVE_UDREG
+/*
+ * mr_udreg_cache doesn't work if KDREG is enabled
+ * since by the time this testsuite is run, the kdreg device
+ * has been opened as part of the criterion test suite
+ * run.
+ * /dev/kdreg should really be fixed, but that's probably
+ * not going to happen.
+ */
 TestSuite(mr_udreg_cache,
 	  .init = udreg_setup,
-	  .fini = mr_teardown);
+	  .fini = mr_teardown,
+	  .disabled = ~KDREG_CHECK);
 #endif
 
 TestSuite(mr_no_cache_basic,


### PR DESCRIPTION
Turns out that when libfabric is used with an application that
is also using Cray MPICH, the GNI provider needs to use UDREG if
kdreg support is required.

Unfortunately there was a critical flag left out of the
UDREG attributes modes that caused the GNI provider to
use UDREG without using kdreg.  For applications (like
applications using mercury apparently) that are susceptible
to munmap operations under the covers in glibc's heap allocator,
this can lead to data corruption.

Also, it turns out that the GNI provider needs to be less
aggressive with kdreg entries since the Cray MPICH also uses
up some.

This commit addresses these two issues.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>