### PR TITLE
prov/psm2: Remove unnecessary dependencies from the configure script

### DIFF
--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -45,20 +45,18 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 					 [psm2_happy=0])
 			AS_IF([test x$psm2_happy = x1],
 			      AS_IF([test -f $with_psm2_src/libpsm2.spec.in],
-				    [AC_EGREP_HEADER(
-						psm2_am_register_handlers_2,
-						$with_psm2_src/psm2_am.h,
-						[
-							$as_echo "$as_me: creating links for PSM2 source code."
-							mkdir -p $srcdir/prov/psm2/src/psm2
-							cp -srf $with_psm2_src/* $srcdir/prov/psm2/src/psm2/
-							ln -sf ../include/rbtree.h $srcdir/prov/psm2/src/psm2/ptl_ips/
-							ln -sf ../include/rbtree.h $srcdir/prov/psm2/src/psm2/ptl_am/
-						],
-						[
-							$as_echo "$as_me: PSM2 source under <$with_psm2_src> is too old."
-							psm2_happy=0
-						])
+				    [AS_IF([grep -q psm2_am_register_handlers_2 $with_psm2_src/psm2_am.h],
+					   [
+						$as_echo "$as_me: creating links for PSM2 source code."
+						mkdir -p $srcdir/prov/psm2/src/psm2
+						cp -srf $with_psm2_src/* $srcdir/prov/psm2/src/psm2/
+						ln -sf ../include/rbtree.h $srcdir/prov/psm2/src/psm2/ptl_ips/
+						ln -sf ../include/rbtree.h $srcdir/prov/psm2/src/psm2/ptl_am/
+					   ],
+					   [
+						$as_echo "$as_me: PSM2 source under <$with_psm2_src> is too old."
+						psm2_happy=0
+					   ])
 				   ],
 				   [
 					$as_echo "$as_me: no PSM2 source under <$with_psm2_src>."


### PR DESCRIPTION
When configuring for building with PSM2 source included, the predefined
macro AC_EGREP_HEADER was used to check for the presence of a required
symbol. Instead of running a straight grep command, the macro would
call cpp to process the file and then run grep on the result. This was
an overkill here and created unnecessary dependencies on all the headers
included in the file being processed.

Use grep directly instead of the macro to check the condition.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>