### PR TITLE
prov/psm2: Reduce HW context usage for certain TX only endpoints

### DIFF
--- a/prov/psm2/src/psmx2_cm.c
+++ b/prov/psm2/src/psmx2_cm.c
@@ -47,7 +47,7 @@ static int psmx2_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 	memset(&epname, 0, sizeof(epname));
 
 	if (ep->type == PSMX2_EP_REGULAR) {
-		epname.epid = ep->rx->psm2_epid;
+		epname.epid = ep->rx ? ep->rx->psm2_epid : 0;
 		epname.type = ep->type;
 	} else {
 		sep = (struct psmx2_fid_sep *)ep;


### PR DESCRIPTION
Normally a HW context is allocated for each endpoint to be used for
both TX and RX operations. However, if an endpoint uses shared TX
context and doesn't need RX capability there is no need to allocate
a dedicated HW context. This make it possible to reduce the number
of HW contexts needed by using shared TX context.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>