### PR TITLE
[RFC] specfile: Enable building with PSM2 source

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -32,9 +32,11 @@ Development files for the libfabric library.
 
 %prep
 %setup -q -n %{name}-%{version}
+wget https://github.com/01org/opa-psm2/archive/PSM2_10.3-37.tar.gz
+gzip -dc PSM2_10.3-37.tar.gz | tar -xvvf -
 
 %build
-%configure %{configopts}
+%configure %{configopts} --with-psm2-src=$PWD/opa-psm2-PSM2_10.3-37
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
Automatically download source code for the PSM2 library and add
the proper configure option to build the psm2 provider with the
PSM2 library source included.

Requires internet connection to download the source.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

Depends on #3698 