### PR TITLE
prov/shm: various fixes and regorganizations

### DIFF
--- a/include/fi_mem.h
+++ b/include/fi_mem.h
@@ -146,18 +146,21 @@ do {								\
 	*(void **) local_p = (fs)->next;				\
 	(fs)->next = p;						\
 } while (0)
-#define smr_freestack_pop(fs) smr_freestack_pop_impl(fs,	\
-	(char **) fs + ((char **) (fs)->next - (char **) fs->base_addr))
+#define smr_freestack_pop(fs) smr_freestack_pop_impl(fs, fs->next)
 
-static inline void* smr_freestack_pop_impl(void *fs, void *fs_next)
+static inline void* smr_freestack_pop_impl(void *fs, void *next)
 {
+	void *local;
+
 	struct {
 		SMR_FREESTACK_HEADER
 	} *freestack = fs;
-	assert(!freestack_isempty(freestack));
+	assert(next != NULL);
 
-	freestack->next = *((void **)fs_next);
-	return fs_next;
+	local = (char **) fs + ((char **) next -
+		(char **) freestack->base_addr);
+	next = *((void **) local);
+	return local;
 }
 
 #define DECLARE_SMR_FREESTACK(entrytype, name)			\

--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -65,6 +65,8 @@ extern "C" {
 #endif
 
 
+#define SMR_CMD_SIZE		128	/* align with 64-byte cache line */
+
 /* SMR op_src: Specifies data source location */
 enum {
 	smr_src_inline,	/* command data */
@@ -81,7 +83,8 @@ enum {
  * 	src_data - src of additional op data (inject offset / resp offset)
  * 	data - remote CQ data
  */
-struct smr_op_hdr {
+struct smr_msg_hdr {
+	uint64_t		msg_id;
 	fi_addr_t		addr;
 	uint32_t		op;
 	uint16_t		op_src;
@@ -101,35 +104,42 @@ struct smr_op_hdr {
 	};
 };
 
-struct smr_cmd_hdr {
-	struct smr_op_hdr	op;
-	uint64_t		msg_id;
+#define SMR_MSG_DATA_LEN	(128 - sizeof(struct smr_msg_hdr))
+union smr_cmd_data {
+	uint8_t			msg[SMR_MSG_DATA_LEN];
+	struct iovec		iov[SMR_MSG_DATA_LEN / sizeof(struct iovec)];
 };
 
-#define SMR_CMD_SIZE		128	/* align with 64-byte cache line */
-#define SMR_CMD_DATA_LEN	(128 - sizeof(struct smr_cmd_hdr))
+struct smr_cmd_msg {
+	struct smr_msg_hdr	hdr;
+	union {
+		uint8_t		msg[SMR_MSG_DATA_LEN];
+		struct iovec	iov[SMR_MSG_DATA_LEN / sizeof(struct iovec)];
+	};
+};
+
+#define SMR_RMA_DATA_LEN	(128 - sizeof(uint64_t))
+struct smr_cmd_rma {
+	uint64_t		rma_count;
+	struct fi_rma_iov	rma_iov[SMR_RMA_DATA_LEN /
+					sizeof(struct fi_rma_iov)];
+};
+
+struct smr_cmd {
+	union {
+		struct smr_cmd_msg	msg;
+		struct smr_cmd_rma	rma;
+	};
+};
+
+enum {
+	SMR_INJECT_SIZE = 4096
+};
 
 #define SMR_NAME_SIZE	32
 struct smr_addr {
 	char		name[SMR_NAME_SIZE];
 	fi_addr_t	addr;
-};
-
-#define SMR_RMA_IOV_LIMIT	3 //TODO find a way to avoid this?
-union smr_cmd_data {
-	uint8_t			msg[SMR_CMD_DATA_LEN];
-	struct iovec		iov[SMR_CMD_DATA_LEN / sizeof(struct iovec)];
-	struct ofi_rma_iov	rma_iov[SMR_CMD_DATA_LEN / sizeof(struct ofi_rma_iov)];
-	struct ofi_rma_ioc	rma_ioc[SMR_CMD_DATA_LEN / sizeof(struct ofi_rma_ioc)];
-};
-
-struct smr_cmd {
-	struct smr_cmd_hdr	hdr;
-	union smr_cmd_data	data;
-};
-
-enum {
-	SMR_INJECT_SIZE = 4096
 };
 
 struct smr_region;

--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -167,6 +167,7 @@ struct smr_region {
 	struct smr_map	*map;
 
 	size_t		total_size;
+	size_t		cmd_cnt;
 
 	/* offsets from start of smr_region */
 	size_t		cmd_queue_offset;

--- a/include/fi_shm.h
+++ b/include/fi_shm.h
@@ -95,7 +95,6 @@ struct smr_msg_hdr {
 	uint64_t		data;
 	union {
 		uint64_t	tag;
-		uint8_t		iov_count;
 		struct {
 			uint8_t	datatype;
 			uint8_t	op;
@@ -107,15 +106,16 @@ struct smr_msg_hdr {
 #define SMR_MSG_DATA_LEN	(128 - sizeof(struct smr_msg_hdr))
 union smr_cmd_data {
 	uint8_t			msg[SMR_MSG_DATA_LEN];
-	struct iovec		iov[SMR_MSG_DATA_LEN / sizeof(struct iovec)];
+	struct {
+		uint8_t		iov_count;
+		struct iovec	iov[(SMR_MSG_DATA_LEN - 8) /
+				    sizeof(struct iovec)];
+	};
 };
 
 struct smr_cmd_msg {
 	struct smr_msg_hdr	hdr;
-	union {
-		uint8_t		msg[SMR_MSG_DATA_LEN];
-		struct iovec	iov[SMR_MSG_DATA_LEN / sizeof(struct iovec)];
-	};
+	union smr_cmd_data	data;
 };
 
 #define SMR_RMA_DATA_LEN	(128 - sizeof(uint64_t))

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -37,7 +37,8 @@ struct fi_tx_attr smr_tx_attr = {
 	.comp_order = FI_ORDER_STRICT,
 	.inject_size = SMR_INJECT_SIZE,
 	.size = 1024,
-	.iov_limit = SMR_IOV_LIMIT
+	.iov_limit = SMR_IOV_LIMIT,
+	.rma_iov_limit = SMR_IOV_LIMIT
 };
 
 struct fi_rx_attr smr_rx_attr = {
@@ -64,7 +65,7 @@ struct fi_domain_attr smr_domain_attr = {
 	.resource_mgmt = FI_RM_ENABLED,
 	.av_type = FI_AV_UNSPEC,
 	.mr_mode = FI_MR_VIRT_ADDR,
-	.cq_data_size = sizeof_field(struct smr_op_hdr, data),
+	.cq_data_size = sizeof_field(struct smr_msg_hdr, data),
 	.cq_cnt = (1 << 10),
 	.ep_cnt = (1 << 10),
 	.tx_ctx_cnt = (1 << 10),

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -269,7 +269,7 @@ void smr_progress_resp(struct smr_ep *ep)
 		resp = ofi_cirque_head(smr_resp_queue(ep->region));
 		if (resp->status == FI_EBUSY)
 			break;
-		match_attr.ctx = resp->msg_id;;
+		match_attr.ctx = resp->msg_id;
 		dlist_entry = dlist_remove_first_match(&ep->pend_queue.msg_list,
 						       ep->pend_queue.match_msg,
 						       &match_attr);
@@ -281,7 +281,7 @@ void smr_progress_resp(struct smr_ep *ep)
 		pending = container_of(dlist_entry, struct smr_pending_cmd, entry);
 
 		ret = ep->tx_comp(ep, (void *) resp->msg_id,
-				  smr_tx_comp_flags(pending->cmd.hdr.op.op),
+				  smr_tx_comp_flags(pending->cmd.msg.hdr.op),
 				  -(resp->status));
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
@@ -301,9 +301,9 @@ static int smr_progress_inline(struct smr_cmd *cmd, struct iovec *iov,
 	if (err)
 		return err;
 
-	*total_len = ofi_copy_to_iov(iov, iov_count, 0, cmd->data.msg,
-				     cmd->hdr.op.size);
-	if (*total_len != cmd->hdr.op.size) {
+	*total_len = ofi_copy_to_iov(iov, iov_count, 0, cmd->msg.msg,
+				     cmd->msg.hdr.size);
+	if (*total_len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
 		return -FI_EIO;
@@ -318,15 +318,15 @@ static int smr_progress_inject(struct smr_cmd *cmd, struct iovec *iov,
 	struct smr_inject_buf *tx_buf;
 	size_t inj_offset;
 
-	inj_offset = (size_t) cmd->hdr.op.src_data;
+	inj_offset = (size_t) cmd->msg.hdr.src_data;
 	tx_buf = (struct smr_inject_buf *) ((char **) ep->region +
 					    inj_offset);
 	if (err)
 		goto out;
 
 	*total_len = ofi_copy_to_iov(iov, iov_count, 0, tx_buf,
-				     cmd->hdr.op.size);
-	if (*total_len != cmd->hdr.op.size) {
+				     cmd->msg.hdr.size);
+	if (*total_len != cmd->msg.hdr.size) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"recv truncated");
 		err = -FI_EIO;
@@ -345,25 +345,25 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct iovec *iov,
 	struct smr_resp *resp;
 	int peer_id, ret;
 
-	peer_id = (int) cmd->hdr.op.addr;
+	peer_id = (int) cmd->msg.hdr.addr;
 	peer_smr = smr_peer_region(ep->region, peer_id);
 	resp = (struct smr_resp *) ((char **) peer_smr +
-				    (size_t) cmd->hdr.op.src_data);
+				    (size_t) cmd->msg.hdr.src_data);
 
 	if (err) {
 		ret = -err;
 		goto out;
 	}
 
-	if (cmd->hdr.op.op == ofi_op_read_req) {
+	if (cmd->msg.hdr.op == ofi_op_read_req) {
 		ret = process_vm_writev(peer_smr->pid, iov, iov_count,
-					cmd->data.iov, SMR_IOV_LIMIT, 0);
+					cmd->msg.iov, SMR_IOV_LIMIT, 0);
 	} else {
 		ret = process_vm_readv(peer_smr->pid, iov, iov_count,
-				       cmd->data.iov, SMR_IOV_LIMIT, 0);
+				       cmd->msg.iov, SMR_IOV_LIMIT, 0);
 	}
 
-	if (ret != cmd->hdr.op.size) {
+	if (ret != cmd->msg.hdr.size) {
 		if (ret < 0) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"CMA write error\n");
@@ -379,8 +379,6 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct iovec *iov,
 	}
 
 out:
-	resp->msg_id = cmd->hdr.msg_id;
-
 	//Status must be set last (signals peer: op done, valid resp entry)
 	resp->status = ret;
 
@@ -404,7 +402,7 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 		return -FI_ENOSPC;
 	}
 
-	recv_queue = (cmd->hdr.op.op == ofi_op_tagged) ?
+	recv_queue = (cmd->msg.hdr.op == ofi_op_tagged) ?
 		      &ep->trecv_queue : &ep->recv_queue;
 
 	if (dlist_empty(&recv_queue->recv_list)) {
@@ -413,8 +411,8 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 		return -FI_ENOMSG;
 	}
 
-	match_attr.addr = cmd->hdr.op.addr;
-	match_attr.tag = cmd->hdr.op.tag;
+	match_attr.addr = cmd->msg.hdr.addr;
+	match_attr.tag = cmd->msg.hdr.tag;
 
 	dlist_entry = dlist_remove_first_match(&recv_queue->recv_list,
 					       recv_queue->match_recv,
@@ -430,7 +428,7 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 	}
 	entry = container_of(dlist_entry, struct smr_ep_entry, entry);
 
-	switch (cmd->hdr.op.op_src) {
+	switch (cmd->msg.hdr.op_src) {
 	case smr_src_inline:
 		err = smr_progress_inline(cmd, entry->iov, entry->iov_count,
 					  &total_len, 0);
@@ -448,10 +446,10 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 			"unidentified operation type\n");
 		err = -FI_EINVAL;
 	}
-	ret = ep->rx_comp(ep, entry->context, smr_rx_comp_flags(cmd->hdr.op.op,
-			  cmd->hdr.op.op_flags), total_len,
-			  entry->iov[0].iov_base, &addr, cmd->hdr.op.tag,
-			  cmd->hdr.op.data, err);
+	ret = ep->rx_comp(ep, entry->context, smr_rx_comp_flags(cmd->msg.hdr.op,
+			  cmd->msg.hdr.op_flags), total_len,
+			  entry->iov[0].iov_base, &addr, cmd->msg.hdr.tag,
+			  cmd->msg.hdr.data, err);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process rx completion\n");
@@ -466,7 +464,8 @@ discard:
 static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 {
 	struct smr_domain *domain;
-	struct iovec iov[SMR_RMA_IOV_LIMIT];
+	struct smr_cmd *rma_cmd;
+	struct iovec iov[SMR_IOV_LIMIT];
 	size_t iov_count;
 	size_t total_len = 0;
 	int err, ret = 0;
@@ -474,39 +473,38 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	domain = container_of(ep->util_ep.domain, struct smr_domain,
 			      util_domain);
 
-	if (cmd->hdr.op.op_flags & OFI_REMOTE_CQ_DATA &&
+	if (cmd->msg.hdr.op_flags & OFI_REMOTE_CQ_DATA &&
 	    ofi_cirque_isfull(ep->util_ep.rx_cq->cirq)) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"rx cq full\n");
 		return -FI_ENOSPC;
 	}
 
-	for (iov_count = 0; iov_count < cmd->hdr.op.iov_count; iov_count++) {
+	ofi_cirque_discard(smr_cmd_queue(ep->region));
+	rma_cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
+
+	for (iov_count = 0; iov_count < rma_cmd->rma.rma_count; iov_count++) {
 		ret = ofi_mr_verify(&domain->util_domain.mr_map,
-				cmd->data.rma_iov[iov_count].len,
-				(uintptr_t *) &(cmd->data.rma_iov[iov_count].addr),
-				cmd->data.rma_iov[iov_count].key,
-				cmd->hdr.op.op == ofi_op_write ?
+				rma_cmd->rma.rma_iov[iov_count].len,
+				(uintptr_t *) &(rma_cmd->rma.rma_iov[iov_count].addr),
+				rma_cmd->rma.rma_iov[iov_count].key,
+				cmd->msg.hdr.op == ofi_op_write ?
 				FI_REMOTE_WRITE : FI_REMOTE_READ);
 		if (ret)
 			break;
 
-		iov[iov_count].iov_base = (void *) cmd->data.rma_iov[iov_count].addr;
-		iov[iov_count].iov_len = cmd->data.rma_iov[iov_count].len;
+		iov[iov_count].iov_base = (void *) rma_cmd->rma.rma_iov[iov_count].addr;
+		iov[iov_count].iov_len = rma_cmd->rma.rma_iov[iov_count].len;
 	}
-
 	ofi_cirque_discard(smr_cmd_queue(ep->region));
-	cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
 	if (ret)
-		goto discard;
+		return ret;
 
-	if (cmd->hdr.op.op != ofi_op_write &&
-	    cmd->hdr.op.op != ofi_op_read_req) {
-		ret = -FI_EINVAL;
-		goto discard;
-	}
+	if (cmd->msg.hdr.op != ofi_op_write &&
+	    cmd->msg.hdr.op != ofi_op_read_req)
+		return -FI_EINVAL;
 
-	switch (cmd->hdr.op.op_src) {
+	switch (cmd->msg.hdr.op_src) {
 	case smr_src_inline:
 		err = smr_progress_inline(cmd, iov, iov_count, &total_len, ret);
 		break;
@@ -521,19 +519,18 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 			"unidentified operation type\n");
 		err = -FI_EINVAL;
 	}
-	if (cmd->hdr.op.op_flags & OFI_REMOTE_CQ_DATA) {
-		ret = ep->rx_comp(ep, NULL, smr_rx_comp_flags(cmd->hdr.op.op,
-				  cmd->hdr.op.op_flags), total_len,
-				  NULL, &cmd->hdr.op.addr, 0,
-				  cmd->hdr.op.data, err);
+	if (cmd->msg.hdr.op_flags & OFI_REMOTE_CQ_DATA) {
+		ret = ep->rx_comp(ep, (void *) cmd->msg.hdr.msg_id,
+				  smr_rx_comp_flags(cmd->msg.hdr.op,
+				  cmd->msg.hdr.op_flags), total_len,
+				  NULL, &cmd->msg.hdr.addr, 0,
+				  cmd->msg.hdr.data, err);
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"unable to process rx completion\n");
 		}
 	}
 
-discard:
-	ofi_cirque_discard(smr_cmd_queue(ep->region));
 	return ret;
 }
 
@@ -548,7 +545,7 @@ void smr_progress_cmd(struct smr_ep *ep)
 	while (!ofi_cirque_isempty(smr_cmd_queue(ep->region))) {
 		cmd = ofi_cirque_head(smr_cmd_queue(ep->region));
 
-		switch (cmd->hdr.op.op) {
+		switch (cmd->msg.hdr.op) {
 		case ofi_op_msg:
 		case ofi_op_tagged:
 			ret = smr_progress_cmd_msg(ep, cmd);
@@ -604,8 +601,9 @@ static int smr_match_unexp(struct dlist_entry *item, const void *args)
 	struct smr_pending_cmd *unexp_msg;
 
 	unexp_msg = container_of(item, struct smr_pending_cmd, entry);
-	return smr_match_addr(unexp_msg->cmd.hdr.op.addr, attr->addr) &&
-	       smr_match_tag(unexp_msg->cmd.hdr.op.tag, attr->ignore, attr->tag);
+	return smr_match_addr(unexp_msg->cmd.msg.hdr.addr, attr->addr) &&
+	       smr_match_tag(unexp_msg->cmd.msg.hdr.tag, attr->ignore,
+			     attr->tag);
 }
 
 static int smr_match_ctx(struct dlist_entry *item, const void *args)
@@ -614,7 +612,7 @@ static int smr_match_ctx(struct dlist_entry *item, const void *args)
 	struct smr_pending_cmd *pending_msg;
 
 	pending_msg = container_of(item, struct smr_pending_cmd, entry);
-	return pending_msg->cmd.hdr.msg_id == attr->ctx;
+	return pending_msg->cmd.msg.hdr.msg_id == attr->ctx;
 }
 
 static void smr_init_recv_queue(struct smr_recv_queue *recv_queue,
@@ -649,6 +647,13 @@ static int smr_check_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 	size_t total_len = 0;
 	int ret = 0;
 
+	if (ofi_cirque_isfull(ep->util_ep.rx_cq->cirq)) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"rx cq full\n");
+		ret = -FI_EAGAIN;
+		goto push_entry;
+	}
+
 	match_attr.addr = entry->addr;
 	match_attr.ignore = entry->ignore;
 	match_attr.tag = entry->tag;
@@ -658,16 +663,9 @@ static int smr_check_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 	if (!dlist_entry)
 		return -FI_ENOMSG;
 
-	if (ofi_cirque_isfull(ep->util_ep.rx_cq->cirq)) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"rx cq full\n");
-		ret = -FI_EAGAIN;
-		goto push_entry;
-	}
-
 	unexp_msg = container_of(dlist_entry, struct smr_pending_cmd, entry);
 
-	switch (unexp_msg->cmd.hdr.op.op_src){
+	switch (unexp_msg->cmd.msg.hdr.op_src) {
 	case smr_src_inline:
 		entry->err = smr_progress_inline(&unexp_msg->cmd, entry->iov,
 						 entry->iov_count, &total_len, 0);
@@ -688,10 +686,10 @@ static int smr_check_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 		entry->err = FI_EINVAL;
 	}
 	ret = ep->rx_comp(ep, entry->context,
-			  smr_rx_comp_flags(unexp_msg->cmd.hdr.op.op,
-			  unexp_msg->cmd.hdr.op.op_flags), total_len,
+			  smr_rx_comp_flags(unexp_msg->cmd.msg.hdr.op,
+			  unexp_msg->cmd.msg.hdr.op_flags), total_len,
 			  entry->iov[0].iov_base, &entry->addr, entry->tag,
-			  unexp_msg->cmd.hdr.op.data, entry->err);
+			  unexp_msg->cmd.msg. hdr.data, entry->err);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process rx completion\n");
@@ -790,21 +788,19 @@ static void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id, void *con
 			       uint32_t op, uint64_t tag, uint64_t data,
 			       uint16_t op_flags)
 {
-	cmd->hdr.op.op = op;
-	cmd->hdr.op.op_flags = op_flags;
-	cmd->hdr.op.tag = tag;
-	cmd->hdr.msg_id = (uint64_t) context;
-	cmd->hdr.op.addr = peer_id;
-	cmd->hdr.op.data = data;
+	cmd->msg.hdr.op = op;
+	cmd->msg.hdr.op_flags = op_flags;
+	cmd->msg.hdr.tag = tag;
+	cmd->msg.hdr.msg_id = (uint64_t) context;
+	cmd->msg.hdr.addr = peer_id;
+	cmd->msg.hdr.data = data;
 }
 
-static void smr_format_rma(struct smr_cmd *cmd, fi_addr_t peer_id,
-			   const struct fi_rma_iov *rma_iov, size_t iov_count,
-			   void *context, uint32_t op, uint16_t op_flags)
+static void smr_format_rma(struct smr_cmd *cmd, const struct fi_rma_iov *rma_iov,
+			   size_t iov_count)
 {
-	smr_generic_format(cmd, peer_id, context, op, 0, 0, op_flags);
-	cmd->hdr.op.iov_count = iov_count;
-	memcpy(cmd->data.rma_iov, rma_iov, sizeof(*rma_iov) * iov_count);
+	cmd->rma.rma_count = iov_count;
+	memcpy(cmd->rma.rma_iov, rma_iov, sizeof(*rma_iov) * iov_count);
 }
 
 static void smr_format_inline(struct smr_cmd *cmd, fi_addr_t peer_id,
@@ -813,9 +809,9 @@ static void smr_format_inline(struct smr_cmd *cmd, fi_addr_t peer_id,
 			      uint64_t data, uint16_t op_flags)
 {
 	smr_generic_format(cmd, peer_id, context, op, tag, data, op_flags);
-	cmd->hdr.op.op_src = smr_src_inline;
-	cmd->hdr.op.size = ofi_copy_from_iov(cmd->data.msg, SMR_CMD_DATA_LEN,
-					     iov, count, 0);
+	cmd->msg.hdr.op_src = smr_src_inline;
+	cmd->msg.hdr.size = ofi_copy_from_iov(cmd->msg.msg, SMR_MSG_DATA_LEN,
+					      iov, count, 0);
 }
 
 static void smr_format_inject(struct smr_cmd *cmd, fi_addr_t peer_id,
@@ -826,10 +822,10 @@ static void smr_format_inject(struct smr_cmd *cmd, fi_addr_t peer_id,
 			      struct smr_inject_buf *tx_buf)
 {
 	smr_generic_format(cmd, peer_id, context, op, tag, data, op_flags);
-	cmd->hdr.op.op_src = smr_src_inject;
-	cmd->hdr.op.src_data = (char **) tx_buf - (char **) smr;
-	cmd->hdr.op.size = ofi_copy_from_iov(tx_buf->data, SMR_INJECT_SIZE,
-					     iov, count, 0);
+	cmd->msg.hdr.op_src = smr_src_inject;
+	cmd->msg.hdr.src_data = (char **) tx_buf - (char **) smr;
+	cmd->msg.hdr.size = ofi_copy_from_iov(tx_buf->data, SMR_INJECT_SIZE,
+					       iov, count, 0);
 }
 
 static void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
@@ -842,27 +838,27 @@ static void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
 	int i;
 
 	smr_generic_format(cmd, peer_id, context, op, tag, data, op_flags);
-	cmd->hdr.op.op_src = smr_src_iov;
+	cmd->msg.hdr.op_src = smr_src_iov;
 	resp->status = FI_EBUSY;
-	cmd->hdr.op.src_data = (uint64_t) ((char **) resp - (char **) smr);
+	resp->msg_id = (uint64_t) context;
+	cmd->msg.hdr.src_data = (uint64_t) ((char **) resp - (char **) smr);
 
-	for (cmd->hdr.op.size = i = 0; i < count; i++) {
-		cmd->data.iov[i].iov_base = iov[i].iov_base;
-		cmd->data.iov[i].iov_len = iov[i].iov_len;
-		cmd->hdr.op.size += iov[i].iov_len;
+	for (cmd->msg.hdr.size = i = 0; i < count; i++) {
+		cmd->msg.iov[i].iov_base = iov[i].iov_base;
+		cmd->msg.iov[i].iov_len = iov[i].iov_len;
+		cmd->msg.hdr.size += iov[i].iov_len;
 	}
 	while (i < SMR_IOV_LIMIT)
-		cmd->data.iov[i++].iov_len = 0;
+		cmd->msg.iov[i++].iov_len = 0;
 }
 
-static void smr_format_resp(struct smr_cmd *cmd, fi_addr_t peer_id,
-			    const struct fi_rma_iov *rma_iov, size_t count,
-			    size_t total_len, uint32_t op)
+static void smr_format_rma_resp(struct smr_cmd *cmd, fi_addr_t peer_id,
+				const struct fi_rma_iov *rma_iov, size_t count,
+				size_t total_len, uint32_t op)
 {
 	smr_generic_format(cmd, peer_id, NULL, op, 0, 0, 0);
-	memcpy(cmd->data.rma_iov, rma_iov, sizeof(*rma_iov) * count);
-	cmd->hdr.op.size = total_len;
-	cmd->hdr.op.iov_count = count;
+	cmd->msg.hdr.size = total_len;
+	cmd->msg.hdr.iov_count = count;
 }
 
 static ssize_t smr_generic_sendmsg(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -905,7 +901,7 @@ static ssize_t smr_generic_sendmsg(struct fid_ep *ep_fid, const struct iovec *io
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 
-	if (total_len <= SMR_CMD_DATA_LEN) {
+	if (total_len <= SMR_MSG_DATA_LEN) {
 		smr_format_inline(cmd, smr_peer_addr(ep->region)[peer_id].addr, iov,
 				  iov_count, context, op, tag, data, op_flags);
 	} else if (total_len <= SMR_INJECT_SIZE) {
@@ -1001,7 +997,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 
-	if (len <= SMR_CMD_DATA_LEN) {
+	if (len <= SMR_MSG_DATA_LEN) {
 		smr_format_inline(cmd, smr_peer_addr(ep->region)[peer_id].addr,
 				  &msg_iov, 1, NULL, op, tag, data, op_flags);
 	} else {
@@ -1160,7 +1156,7 @@ ssize_t smr_rma_fast(struct smr_ep *ep, const struct iovec *iov,
 	void **desc, int peer_id, void *context, uint32_t op)
 {
 	struct smr_region *peer_smr;
-	struct iovec rma_iovec[SMR_RMA_IOV_LIMIT];
+	struct iovec rma_iovec[SMR_IOV_LIMIT];
 	struct smr_cmd *cmd;
 	size_t total_len;
 	int ret, i;
@@ -1208,9 +1204,9 @@ ssize_t smr_rma_fast(struct smr_ep *ep, const struct iovec *iov,
 	ret = 0;
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
-	smr_format_resp(cmd, peer_id, rma_iov, rma_count, total_len,
-			(op == ofi_op_write) ? ofi_op_write_rsp :
-			ofi_op_read_rsp);
+	smr_format_rma_resp(cmd, peer_id, rma_iov, rma_count, total_len,
+			    (op == ofi_op_write) ? ofi_op_write_rsp :
+			    ofi_op_read_rsp);
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 
 comp:
@@ -1232,12 +1228,12 @@ ssize_t smr_generic_rma(struct fid_ep *ep_fid, const struct iovec *iov,
 	struct smr_inject_buf *tx_buf;
 	struct smr_resp *resp;
 	struct smr_cmd *cmd;
-	int peer_id;
+	int peer_id, comp = 1;
 	ssize_t ret = 0;
 	size_t total_len;
 
 	assert(iov_count <= SMR_IOV_LIMIT);
-	assert(rma_count <= SMR_RMA_IOV_LIMIT);
+	assert(rma_count <= SMR_IOV_LIMIT);
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
@@ -1264,12 +1260,9 @@ ssize_t smr_generic_rma(struct fid_ep *ep_fid, const struct iovec *iov,
 	}
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
-	smr_format_rma(cmd, peer_id, rma_iov, rma_count, context, op, op_flags);
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 	total_len = ofi_total_iov_len(iov, iov_count);
 
-	if (total_len <= SMR_CMD_DATA_LEN && op == ofi_op_write) {
+	if (total_len <= SMR_MSG_DATA_LEN && op == ofi_op_write) {
 		smr_format_inline(cmd, smr_peer_addr(ep->region)[peer_id].addr,
 				  iov, iov_count, context, op, 0, data, op_flags);
 	} else if (total_len <= SMR_INJECT_SIZE && op == ofi_op_write) {
@@ -1285,17 +1278,23 @@ ssize_t smr_generic_rma(struct fid_ep *ep_fid, const struct iovec *iov,
 			       ep->region, resp);
 		ofi_cirque_commit(smr_resp_queue(ep->region));
 		smr_post_pending(ep, cmd);
-		goto commit;
+		comp = 0;
 	}
+
+	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	smr_format_rma(cmd, rma_iov, rma_count);
+	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+
+	if (!comp)
+		goto unlock_cq;
+
 	ret = ep->tx_comp(ep, context, smr_tx_comp_flags(op), 0);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process tx completion\n");
-		goto unlock_cq;
 	}
 
-commit:
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 unlock_cq:
 	fastlock_release(&ep->util_ep.tx_cq->cq_lock);
 unlock_region:
@@ -1437,8 +1436,8 @@ ssize_t smr_rma_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	rma_iov.len = len;
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
-	smr_format_resp(cmd, peer_id, &rma_iov, 1, len,
-			ofi_op_read_rsp);
+	smr_format_rma_resp(cmd, peer_id, &rma_iov, 1, len,
+			    ofi_op_read_rsp);
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 
 unlock_region:
@@ -1498,11 +1497,8 @@ ssize_t smr_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	rma_iov.key = key;
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
-	smr_format_rma(cmd, peer_id, &rma_iov, 1, NULL, ofi_op_write, OFI_REMOTE_CQ_DATA);
-	ofi_cirque_commit(smr_cmd_queue(peer_smr));
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 
-	if (len <= SMR_CMD_DATA_LEN) {
+	if (len <= SMR_MSG_DATA_LEN) {
 		smr_format_inline(cmd, smr_peer_addr(ep->region)[peer_id].addr,
 				  &iov, 1, NULL, ofi_op_write, 0, data,
 				  OFI_REMOTE_CQ_DATA);
@@ -1514,6 +1510,10 @@ ssize_t smr_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	}
 
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	smr_format_rma(cmd, &rma_iov, 1);
+	ofi_cirque_commit(smr_cmd_queue(peer_smr));
+
 unlock_region:
 	fastlock_release(&peer_smr->lock);
 	return ret;

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -64,7 +64,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	inject_pool_offset = resp_queue_offset + sizeof(struct smr_resp_queue) +
 			sizeof(struct smr_resp) * attr->tx_count;
 	peer_addr_offset = inject_pool_offset + sizeof(struct smr_inject_pool) +
-			sizeof(struct smr_inject_buf) * attr->tx_count;
+			sizeof(struct smr_inject_buf) * attr->rx_count;
 	name_offset = peer_addr_offset + sizeof(struct smr_addr) * SMR_MAX_PEERS;
 	total_size = name_offset + strlen(attr->name) + 1;
 	total_size = roundup_power_of_two(total_size);
@@ -110,7 +110,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 
 	smr_cmd_queue_init(smr_cmd_queue(*smr), attr->rx_count);
 	smr_resp_queue_init(smr_resp_queue(*smr), attr->tx_count);
-	smr_inject_pool_init(smr_inject_pool(*smr), attr->tx_count);
+	smr_inject_pool_init(smr_inject_pool(*smr), attr->rx_count);
 	for (i = 0; i < SMR_MAX_PEERS; i++)
 		smr_peer_addr_init(&smr_peer_addr(*smr)[i]);
 

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -106,6 +106,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	(*smr)->inject_pool_offset = inject_pool_offset;
 	(*smr)->peer_addr_offset = peer_addr_offset;
 	(*smr)->name_offset = name_offset;
+	(*smr)->cmd_cnt = attr->rx_count;
 
 	smr_cmd_queue_init(smr_cmd_queue(*smr), attr->rx_count);
 	smr_resp_queue_init(smr_resp_queue(*smr), attr->tx_count);


### PR DESCRIPTION
Patches address two general areas:
- reorganization of cmd hdrs and data to make implementation easier and more intuitive and a better use of space (patches 1&2)
- issues causing unexpected message test to fail (patches 3&4)

Also includes various bug fixes and code cleaning
Verified working on ubertest. Now also passing unexpected message test.

Signed-off-by: aingerson <alexia.ingerson@intel.com>