### PR TITLE
prov/psm2: Limit exported symbols for DSO provider

### DIFF
--- a/prov/psm2/Makefile.include
+++ b/prov/psm2/Makefile.include
@@ -170,7 +170,8 @@ libpsmx2_fi_la_SOURCES = $(_psm2_files) $(common_srcs)
 nodist_libpsmx2_fi_la_SOURCES = $(_psm2_nodist_files)
 libpsmx2_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(psm2_CPPFLAGS) $(_psm2_cppflags)
 libpsmx2_fi_la_LDFLAGS = \
-    -module -avoid-version -shared -export-dynamic $(psm2_LDFLAGS)
+    -module -avoid-version -shared -export-dynamic \
+    -export-symbols-regex ^fi_prov_ini $(psm2_LDFLAGS)
 libpsmx2_fi_la_LIBADD = $(linkback) $(psm2_LIBS)
 libpsmx2_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_PSM2_DL


### PR DESCRIPTION
When built as DSO provider, too many symbols were exported and could
cause conflict with other shared libraries. One example was that a
DSO psm2 provider with PSM2 source compiled in could fail at API
version checking because an identically named function from the PSM
(not PSM2) library was used.

The only symbol needs to be exported by a DSO provider is "fi_prov_ini".
By limiting the exported symbol, all symbols that can be resolved
internally would not affect or be affected by other shared libraries.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>