### PR TITLE
prov/psm2: Add backward compatibility for earlier PSM2 libraries

### DIFF
--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -17,6 +17,7 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 	 AM_CONDITIONAL([HAVE_PSM2_SRC], [test x$have_psm2_src = x1])
 	 AC_DEFINE_UNQUOTED([HAVE_PSM2_SRC], $have_psm2_src, [PSM2 source is built-in])
 	 psm2_happy=0
+	 have_psm2_am_register_handlers_2=1
 	 AS_IF([test x"$enable_psm2" != x"no"],
 	       [AS_IF([test x$have_psm2_src = x0],
 		      [
@@ -30,6 +31,20 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 					 [$psm2_LIBDIR],
 					 [psm2_happy=1],
 					 [psm2_happy=0])
+			AS_IF([test x$psm2_happy = x0],
+			      [
+				$as_echo "$as_me: recheck psm2 with reduced feature set."
+				have_psm2_am_register_handlers_2=0
+				FI_CHECK_PACKAGE([psm2],
+						 [psm2.h],
+						 [psm2],
+						 [psm2_ep_epid_lookup2],
+						 [],
+						 [$psm2_PREFIX],
+						 [$psm2_LIBDIR],
+						 [psm2_happy=1],
+						 [psm2_happy=0])
+			      ])
 		      ],
 		      [
 			dnl build with PSM2 source code included
@@ -65,6 +80,9 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 		      ])
 	       ])
 	 AS_IF([test $psm2_happy -eq 1], [$1], [$2])
+	 AC_DEFINE_UNQUOTED([HAVE_PSM2_AM_REGISTER_HANDLERS_2],
+			    $have_psm2_am_register_handlers_2,
+			    [psm2_am_register_handlers_2 function is present])
 ])
 
 AC_ARG_WITH([psm2-src],

--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -32,6 +32,41 @@
 
 #include "psmx2.h"
 
+#if !HAVE_PSM2_AM_REGISTER_HANDLERS_2
+
+/* Macros to repeat operation 'x' for 1000 times */
+
+#define R10(p,x)  x(p##0) x(p##1) x(p##2) x(p##3) x(p##4) x(p##5) x(p##6) \
+		  x(p##7) x(p##8) x(p##9)
+#define R100(p,x) R10(p##0,x) R10(p##1,x) R10(p##2,x) R10(p##3,x) R10(p##4,x) \
+		  R10(p##5,x) R10(p##6,x) R10(p##7,x) R10(p##8,x) R10(p##9,x)
+#define R100A(x)  R10(,x) R10(1,x) R10(2,x) R10(3,x) R10(4,x) \
+                  R10(5,x) R10(6,x) R10(7,x) R10(8,x) R10(9,x)
+#define R1000(x)  R100A(x) R100(1,x) R100(2,x) R100(3,x) R100(4,x) R100(5,x) \
+		  R100(6,x) R100(7,x) R100(8,x) R100(9,x)
+
+#define DEFINE_AM_HANDLER(i) \
+	static int psmx2_am_handler_##i(psm2_am_token_t token, \
+					psm2_amarg_t *args, int nargs, \
+					void *src, uint32_t len) \
+	{ \
+		return psmx2_am_handlers_2[i](token, args, nargs, src, len, \
+					      psmx2_am_handler_ctxts[i]); \
+	}
+
+#define GET_AM_HANDLER(i) psmx2_am_handler_##i,
+
+R1000(DEFINE_AM_HANDLER)
+
+psm2_am_handler_fn_t psmx2_am_handlers[PSMX2_MAX_AM_HANDLERS] = {
+				R1000(GET_AM_HANDLER)
+		     };
+psm2_am_handler_2_fn_t psmx2_am_handlers_2[PSMX2_MAX_AM_HANDLERS];
+void *psmx2_am_handler_ctxts[PSMX2_MAX_AM_HANDLERS];
+int psmx2_am_handler_count = 0;
+
+#endif /* !HAVE_AM_REGISTER_HANDLERS_2 */
+
 int psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt)
 {
 	struct slist_entry *item;

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -107,5 +107,45 @@
 
 #endif /* HAVE_PSM2_SRC */
 
+#if !HAVE_PSM2_AM_REGISTER_HANDLERS_2
+
+#define PSMX2_MAX_AM_HANDLERS 1000
+
+typedef int (*psm2_am_handler_2_fn_t) (
+			psm2_am_token_t token,
+			psm2_amarg_t *args, int nargs,
+			void *src, uint32_t len, void *hctx);
+
+extern psm2_am_handler_fn_t psmx2_am_handlers[];
+extern psm2_am_handler_2_fn_t psmx2_am_handlers_2[];
+extern void *psmx2_am_handler_ctxts[];
+extern int psmx2_am_handler_count;
+
+static inline
+psm2_error_t psm2_am_register_handlers_2(
+			psm2_ep_t ep,
+			const psm2_am_handler_2_fn_t * handlers,
+			int num_handlers, void **hctx,
+			int *handlers_idx)
+{
+	int i;
+	int start = psmx2_am_handler_count;
+
+	if (start + num_handlers > PSMX2_MAX_AM_HANDLERS)
+		return PSM2_EP_NO_RESOURCES;
+
+	psmx2_am_handler_count += num_handlers;
+
+	for (i = 0; i < num_handlers; i++) {
+		psmx2_am_handlers_2[start + i] = handlers[i];
+		psmx2_am_handler_ctxts[start + i] = hctx[i];
+	}
+
+	return psm2_am_register_handlers(ep, psmx2_am_handlers + start,
+					 num_handlers, handlers_idx);
+}
+
+#endif /* !HAVE_PSM2_AM_REGISTER_HANDLERS_2 */
+
 #endif
 


### PR DESCRIPTION
The use of psm2_am_register_handlers_2 has allowed a large chunk of
redundant code being removed. However it requires the latest PSM2
library that is currently only available in source format from
https://github.com/01org/opa-psm2 and is not compatible with a
wide range of PSM2 libraries currently in use.

A new scheme is adopted to bring back the compatibility without
reintroducing the bulk of the old code removed by this new function.

Now the provider should work with PSM2 libraries from IFS 10.5 and
later (corresponding to PSM2 release 10.2.235 and later).

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>