### PR TITLE
common/iov: Fix ofi_copy_[to|from]_iov routines

### DIFF
--- a/include/fi_iov.h
+++ b/include/fi_iov.h
@@ -75,10 +75,11 @@ ofi_copy_to_iov(const struct iovec *iov, size_t iov_count, uint64_t iov_offset,
 		return ofi_copy_iov_buf(iov, iov_count, iov_offset, buf, bufsize,
 					OFI_COPY_BUF_TO_IOV);
 	} else {
+		assert(iov_count == 1);
 		uint64_t size = ((iov_offset > iov[0].iov_len) ?
 				 0 : MIN(bufsize, iov[0].iov_len - iov_offset));
 
-		memcpy(iov[0].iov_base, buf, size);
+		memcpy((char *)iov[0].iov_base + iov_offset, buf, size);
 		return size;
 	}
 }
@@ -91,10 +92,11 @@ ofi_copy_from_iov(void *buf, uint64_t bufsize,
 		return ofi_copy_iov_buf(iov, iov_count, iov_offset, buf, bufsize,
 					OFI_COPY_IOV_TO_BUF);
 	} else {
+		assert(iov_count == 1);
 		uint64_t size = ((iov_offset > iov[0].iov_len) ?
 				 0 : MIN(bufsize, iov[0].iov_len - iov_offset));
 
-		memcpy(buf, iov[0].iov_base, iov[0].iov_len);
+		memcpy(buf, (char *)iov[0].iov_base + iov_offset, size);
 		return size;
 	}
 }


### PR DESCRIPTION
Fix bug introduced in #3686 (commit - `046e9df`)

Bug is reproducible for the OFI/RxD provider when `iov_offset` > 0

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>