### PR TITLE
prov/psm2: Fix a segfault in fi_close(ep)

### DIFF
--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -245,10 +245,12 @@ static int psmx2_ep_close(fid_t fid)
 	if (ep->stx)
 		ofi_atomic_dec32(&ep->stx->ref);
 
-	ep_name.epid = ep->rx->psm2_epid;
+	if (ep->rx) {
+		ep_name.epid = ep->rx->psm2_epid;
 
-	ofi_ns_del_local_name(&ep->domain->fabric->name_server,
-			      &ep->service, &ep_name);
+		ofi_ns_del_local_name(&ep->domain->fabric->name_server,
+				      &ep->service, &ep_name);
+	}
 
 	trx_ctxt = ep->rx;
 	psmx2_ep_close_internal(ep);


### PR DESCRIPTION
There was a bug in the following commit that could cause segfault when
endpoints with NULL RX context were closed.

0dd75e1 prov/psm2: Reduce HW context usage for certain TX only endpoints

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>