### PR TITLE
util/ns: Restructuring and cleanups to name server code

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -135,6 +135,7 @@ src_libfabric_la_SOURCES =			\
 	include/fi_util.h			\
 	include/ofi_atomic.h			\
 	include/ofi_mr.h			\
+	include/ofi_net.h			\
 	include/fasthash.h			\
 	include/rbtree.h			\
 	include/uthash.h			\

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -728,35 +728,23 @@ typedef int(*ofi_ns_service_cmp_func_t)(void *svc1, void *svc2);
 typedef int(*ofi_ns_is_service_wildcard_func_t)(void *svc);
 
 struct util_ns {
+	pthread_t	ns_thread;
 	RbtHandle	ns_map;
+
 	char		*ns_hostname;
 	int		ns_port;
-	pthread_t	ns_thread;
 
-	size_t	name_len;
-	size_t	service_len;
+	size_t		name_len;
+	size_t		service_len;
 
-	int			is_initialized;
-	ofi_atomic32_t		ref;
+	int		is_initialized;
+	ofi_atomic32_t	ref;
 
 	ofi_ns_service_cmp_func_t	service_cmp;
-
 	ofi_ns_is_service_wildcard_func_t is_service_wildcard;
 };
 
-struct util_ns_attr {
-	char	*ns_hostname;
-	int	ns_port;
-
-	size_t	name_len;
-	size_t	service_len;
-
-	ofi_ns_service_cmp_func_t	service_cmp;
-
-	ofi_ns_is_service_wildcard_func_t is_service_wildcard;
-};
-
-int ofi_ns_init(struct util_ns_attr *attr, struct util_ns *ns);
+void ofi_ns_init(struct util_ns *ns);
 void ofi_ns_start_server(struct util_ns *ns);
 void ofi_ns_stop_server(struct util_ns *ns);
 int ofi_ns_add_local_name(struct util_ns *ns, void *service, void *name);

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -738,6 +738,7 @@ struct util_ns {
 	size_t		name_len;
 	size_t		service_len;
 
+	int		run;
 	int		is_initialized;
 	ofi_atomic32_t	ref;
 
@@ -746,8 +747,9 @@ struct util_ns {
 };
 
 void ofi_ns_init(struct util_ns *ns);
-void ofi_ns_start_server(struct util_ns *ns);
+int ofi_ns_start_server(struct util_ns *ns);
 void ofi_ns_stop_server(struct util_ns *ns);
+
 int ofi_ns_add_local_name(struct util_ns *ns, void *service, void *name);
 int ofi_ns_del_local_name(struct util_ns *ns, void *service, void *name);
 void *ofi_ns_resolve_name(struct util_ns *ns, const char *server,

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -728,11 +728,11 @@ typedef int(*ofi_ns_service_cmp_func_t)(void *svc1, void *svc2);
 typedef int(*ofi_ns_is_service_wildcard_func_t)(void *svc);
 
 struct util_ns {
-	pthread_t	ns_thread;
-	RbtHandle	ns_map;
+	pthread_t	thread;
+	RbtHandle	map;
 
-	char		*ns_hostname;
-	int		ns_port;
+	char		*hostname;
+	int		port;
 
 	size_t		name_len;
 	size_t		service_len;

--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -728,6 +728,7 @@ typedef int(*ofi_ns_service_cmp_func_t)(void *svc1, void *svc2);
 typedef int(*ofi_ns_is_service_wildcard_func_t)(void *svc);
 
 struct util_ns {
+	SOCKET		listen_sock;
 	pthread_t	thread;
 	RbtHandle	map;
 

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -92,6 +92,25 @@ static inline uint64_t ntohll(uint64_t x) { return x; }
 #endif
 
 
+static inline int ofi_recvall_socket(SOCKET sock, void *buf, size_t len)
+{
+	ssize_t ret;
+
+	ret = ofi_recv_socket(sock, buf, len, MSG_WAITALL);
+	return ret != len;
+}
+
+static inline int ofi_sendall_socket(SOCKET sock, const void *buf, size_t len)
+{
+	size_t sent;
+	ssize_t ret;
+
+	for (sent = 0, ret = 0; (sent < len) && (ret >= 0); sent += ret)
+		ret = ofi_send_socket(sock, ((char *) buf) + sent, len - sent, 0);
+
+	return ret != len;
+}
+
 /*
  * Address utility functions
  */

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _OFI_NET_H_
+#define _OFI_NET_H_
+
+#include "config.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+#include <netinet/in.h>
+#include <ifaddrs.h>
+
+#include <fi_osd.h>
+
+#include <rdma/fabric.h>
+#include <rdma/providers/fi_prov.h>
+#include <rdma/providers/fi_log.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+extern struct fi_provider core_prov;
+
+
+/*
+ * OS X doesn't have __BYTE_ORDER, Linux usually has BYTE_ORDER but not under
+ * all features.h flags
+ */
+#if !defined(BYTE_ORDER)
+#  if defined(__BYTE_ORDER) && \
+      defined(__LITTLE_ENDIAN) && \
+      defined(__BIG_ENDIAN)
+#    define BYTE_ORDER __BYTE_ORDER
+#    define LITTLE_ENDIAN __LITTLE_ENDIAN
+#    define BIG_ENDIAN __BIG_ENDIAN
+#  else
+#    error "cannot determine endianness!"
+#  endif
+#endif
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+#ifndef htonll
+static inline uint64_t htonll(uint64_t x) { return bswap_64(x); }
+#endif
+#ifndef ntohll
+static inline uint64_t ntohll(uint64_t x) { return bswap_64(x); }
+#endif
+#else
+#ifndef htonll
+static inline uint64_t htonll(uint64_t x) { return x; }
+#endif
+#ifndef ntohll
+static inline uint64_t ntohll(uint64_t x) { return x; }
+#endif
+#endif
+
+
+/*
+ * Address utility functions
+ */
+
+#ifndef AF_IB
+#define AF_IB 27
+#endif
+
+int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
+		const struct sockaddr *sa2);
+int ofi_getifaddrs(struct ifaddrs **ifap);
+
+#define ofi_sa_family(addr) ((struct sockaddr *)(addr))->sa_family
+#define ofi_sin_addr(addr) (((struct sockaddr_in *)(addr))->sin_addr)
+#define ofi_sin_port(addr) (((struct sockaddr_in *)(addr))->sin_port)
+
+#define ofi_sin6_addr(addr) (((struct sockaddr_in6 *)(addr))->sin6_addr)
+#define ofi_sin6_port(addr) (((struct sockaddr_in6 *)(addr))->sin6_port)
+
+#define OFI_ADDRSTRLEN (INET6_ADDRSTRLEN + 50)
+
+static inline size_t ofi_sizeofaddr(const struct sockaddr *addr)
+{
+	switch (addr->sa_family) {
+	case AF_INET:
+		return sizeof(struct sockaddr_in);
+	case AF_INET6:
+		return sizeof(struct sockaddr_in6);
+	default:
+		FI_WARN(&core_prov, FI_LOG_CORE, "Unknown address format");
+		assert(0);
+		return 0;
+	}
+}
+
+static inline int ofi_equals_ipaddr(const struct sockaddr_in *addr1,
+				    const struct sockaddr_in *addr2)
+{
+        return (addr1->sin_addr.s_addr == addr2->sin_addr.s_addr);
+}
+
+static inline int ofi_equals_sockaddr(const struct sockaddr_in *addr1,
+				      const struct sockaddr_in *addr2)
+{
+        return (ofi_equals_ipaddr(addr1, addr2) &&
+	       (addr1->sin_port == addr2->sin_port));
+}
+
+static inline int ofi_translate_addr_format(int family)
+{
+	switch (family) {
+	case AF_INET:
+		return FI_SOCKADDR_IN;
+	case AF_INET6:
+		return FI_SOCKADDR_IN6;
+	case AF_IB:
+		return FI_SOCKADDR_IB;
+	default:
+		return FI_FORMAT_UNSPEC;
+	}
+}
+
+static inline int ofi_get_sa_family(uint32_t addr_format)
+{
+	switch (addr_format) {
+	case FI_SOCKADDR_IN:
+		return AF_INET;
+	case FI_SOCKADDR_IN6:
+		return AF_INET6;
+	case FI_SOCKADDR_IB:
+		return AF_IB;
+	default:
+		return 0;
+	}
+}
+
+int ofi_is_any_addr(struct sockaddr *sa);
+
+
+/*
+ * Address logging
+ */
+const char *ofi_straddr(char *buf, size_t *len,
+			uint32_t addr_format, const void *addr);
+
+/* Returns allocated address to caller.  Caller must free.  */
+int ofi_str_toaddr(const char *str, uint32_t *addr_format,
+		   void **addr, size_t *len);
+
+void ofi_straddr_log_internal(const char *func, int line,
+			      const struct fi_provider *prov,
+			      enum fi_log_level level,
+			      enum fi_log_subsys subsys, char *log_str,
+			      const void *addr);
+
+#define ofi_straddr_log(...) \
+	ofi_straddr_log_internal(__func__, __LINE__, __VA_ARGS__)
+
+#if ENABLE_DEBUG
+#define ofi_straddr_dbg(prov, subsystem, ...) \
+	ofi_straddr_log(prov, FI_LOG_DEBUG, subsystem, __VA_ARGS__)
+#else
+#define ofi_straddr_dbg(prov, subsystem, ...) do {} while(0)
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _OFI_NET_H_ */

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -557,6 +557,7 @@
     <ClInclude Include="include\fi_atom.h" />
     <ClInclude Include="include\ofi_atomic.h" />
     <ClInclude Include="include\ofi_mr.h" />
+    <ClInclude Include="include\ofi_net.h" />
     <ClInclude Include="include\fi_enosys.h" />
     <ClInclude Include="include\fi_file.h" />
     <ClInclude Include="include\fi_indexer.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -554,6 +554,9 @@
     <ClInclude Include="include\ofi_mr.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="include\ofi_net.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="include\uthash.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/prov/mlx/src/mlx_fabric.c
+++ b/prov/mlx/src/mlx_fabric.c
@@ -138,7 +138,6 @@ static char* mlx_local_host_resolve()
 
 int mlx_ns_start ()
 {
-	int status;
 	if (!mlx_descriptor.localhost)
 		mlx_descriptor.localhost = mlx_local_host_resolve();
 
@@ -146,28 +145,20 @@ int mlx_ns_start ()
 		FI_INFO(&mlx_prov, FI_LOG_CORE,
 			"Unable to resolve local host address:\n"
 			"\t - unable to start NS\n"
-			"\t - Please try MLX-adress format");
+			"\t - Please try MLX-address format");
 		return -FI_EINVAL;
 	}
 
-	struct util_ns_attr ns_attr = {
-		.ns_hostname = mlx_descriptor.localhost,
-		.ns_port = (int)mlx_descriptor.ns_port,
-		.name_len = FI_MLX_MAX_NAME_LEN,
-		.service_len = sizeof(short),
-		.service_cmp = mlx_ns_service_cmp,
-		.is_service_wildcard = mlx_ns_is_service_wildcard,
-	};
+	mlx_descriptor.name_serv.ns_hostname = mlx_descriptor.localhost;
+	mlx_descriptor.name_serv.ns_port = (int) mlx_descriptor.ns_port;
+	mlx_descriptor.name_serv.name_len = FI_MLX_MAX_NAME_LEN;
+	mlx_descriptor.name_serv.service_len = sizeof(short);
+	mlx_descriptor.name_serv.service_cmp = mlx_ns_service_cmp;
+	mlx_descriptor.name_serv.is_service_wildcard = mlx_ns_is_service_wildcard;
 
-	status = ofi_ns_init(&ns_attr,
-			  &mlx_descriptor.name_serv);
-	if (status) {
-		FI_INFO(&mlx_prov, FI_LOG_CORE,
-			"ofi_ns_init returns %d\n", status);
-		return status;
-	}
-
+	ofi_ns_init(&mlx_descriptor.name_serv);
 	ofi_ns_start_server(&mlx_descriptor.name_serv);
+
 	return FI_SUCCESS;
 }
 

--- a/prov/mlx/src/mlx_fabric.c
+++ b/prov/mlx/src/mlx_fabric.c
@@ -149,8 +149,8 @@ int mlx_ns_start ()
 		return -FI_EINVAL;
 	}
 
-	mlx_descriptor.name_serv.ns_hostname = mlx_descriptor.localhost;
-	mlx_descriptor.name_serv.ns_port = (int) mlx_descriptor.ns_port;
+	mlx_descriptor.name_serv.hostname = mlx_descriptor.localhost;
+	mlx_descriptor.name_serv.port = (int) mlx_descriptor.ns_port;
 	mlx_descriptor.name_serv.name_len = FI_MLX_MAX_NAME_LEN;
 	mlx_descriptor.name_serv.service_len = sizeof(short);
 	mlx_descriptor.name_serv.service_cmp = mlx_ns_service_cmp;

--- a/prov/psm/src/psmx_fabric.c
+++ b/prov/psm/src/psmx_fabric.c
@@ -105,7 +105,7 @@ int psmx_fabric(struct fi_fabric_attr *attr,
 
 	psmx_get_uuid(fabric_priv->uuid);
 	if (psmx_env.name_server) {
-		fabric_priv->name_server.ns_port = psmx_uuid_to_port(fabric_priv->uuid);
+		fabric_priv->name_server.port = psmx_uuid_to_port(fabric_priv->uuid);
 		fabric_priv->name_server.name_len = sizeof(psm_epid_t);
 		fabric_priv->name_server.service_len = sizeof(int);
 		fabric_priv->name_server.service_cmp = psmx_ns_service_cmp;

--- a/prov/psm/src/psmx_fabric.c
+++ b/prov/psm/src/psmx_fabric.c
@@ -105,22 +105,13 @@ int psmx_fabric(struct fi_fabric_attr *attr,
 
 	psmx_get_uuid(fabric_priv->uuid);
 	if (psmx_env.name_server) {
-		struct util_ns_attr ns_attr = {
-			.ns_port = psmx_uuid_to_port(fabric_priv->uuid),
-			.name_len = sizeof(psm_epid_t),
-			.service_len = sizeof(int),
-			.service_cmp = psmx_ns_service_cmp,
-			.is_service_wildcard = psmx_ns_is_service_wildcard,
-		};
-		ret = ofi_ns_init(&ns_attr,
-				  &fabric_priv->name_server);
-		if (ret) {
-			FI_INFO(&psmx_prov, FI_LOG_CORE,
-				"ofi_ns_init returns %d\n", ret);
-			free(fabric_priv);
-			return ret;
-		}
+		fabric_priv->name_server.ns_port = psmx_uuid_to_port(fabric_priv->uuid);
+		fabric_priv->name_server.name_len = sizeof(psm_epid_t);
+		fabric_priv->name_server.service_len = sizeof(int);
+		fabric_priv->name_server.service_cmp = psmx_ns_service_cmp;
+		fabric_priv->name_server.is_service_wildcard = psmx_ns_is_service_wildcard;
 
+		ofi_ns_init(&fabric_priv->name_server);
 		ofi_ns_start_server(&fabric_priv->name_server);
 	}
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -263,7 +263,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 		psmx_get_uuid(uuid);
 
 		struct util_ns ns = {
-			.ns_port = psmx_uuid_to_port(uuid),
+			.port = psmx_uuid_to_port(uuid),
 			.name_len = sizeof(*dest_addr),
 			.service_len = sizeof(svc),
 			.service_cmp = psmx_ns_service_cmp,

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -259,23 +259,17 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 			"node '%s' service '%s' converted to <unit=%d, port=%d, service=%d>\n",
 			node, service, src_addr->unit, src_addr->port, src_addr->service);
 	} else if (node) {
-		struct util_ns ns = (const struct util_ns){ 0 };
-		struct util_ns_attr ns_attr = (const struct util_ns_attr){ 0 };
 		psm_uuid_t uuid;
-
 		psmx_get_uuid(uuid);
-		ns_attr.ns_port = psmx_uuid_to_port(uuid);
-		ns_attr.name_len = sizeof(*dest_addr);
-		ns_attr.service_len = sizeof(svc);
-		ns_attr.service_cmp = psmx_ns_service_cmp;
-		ns_attr.is_service_wildcard = psmx_ns_is_service_wildcard;
-		err = ofi_ns_init(&ns_attr, &ns);
-		if (err) {
-			FI_INFO(&psmx_prov, FI_LOG_CORE,
-				"ofi_ns_init returns %d\n", err);
-			err = -FI_ENODATA;
-			goto err_out;
-		}
+
+		struct util_ns ns = {
+			.ns_port = psmx_uuid_to_port(uuid),
+			.name_len = sizeof(*dest_addr),
+			.service_len = sizeof(svc),
+			.service_cmp = psmx_ns_service_cmp,
+			.is_service_wildcard = psmx_ns_is_service_wildcard,
+		};
+		ofi_ns_init(&ns);
 
 		if (service)
 			svc = atoi(service);

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -105,22 +105,13 @@ int psmx2_fabric(struct fi_fabric_attr *attr,
 
 	psmx2_get_uuid(fabric_priv->uuid);
 	if (psmx2_env.name_server) {
-		struct util_ns_attr ns_attr = {
-			.ns_port = psmx2_uuid_to_port(fabric_priv->uuid),
-			.name_len = sizeof(struct psmx2_ep_name),
-			.service_len = sizeof(int),
-			.service_cmp = psmx2_ns_service_cmp,
-			.is_service_wildcard = psmx2_ns_is_service_wildcard,
-		};
-		ret = ofi_ns_init(&ns_attr,
-				  &fabric_priv->name_server);
-		if (ret) {
-			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"ofi_ns_init returns %d\n", ret);
-			free(fabric_priv);
-			return ret;
-		}
+		fabric_priv->name_server.ns_port = psmx2_uuid_to_port(fabric_priv->uuid);
+		fabric_priv->name_server.name_len = sizeof(struct psmx2_ep_name);
+		fabric_priv->name_server.service_len = sizeof(int);
+		fabric_priv->name_server.service_cmp = psmx2_ns_service_cmp;
+		fabric_priv->name_server.is_service_wildcard = psmx2_ns_is_service_wildcard;
 
+		ofi_ns_init(&fabric_priv->name_server);
 		ofi_ns_start_server(&fabric_priv->name_server);
 	}
 

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -105,7 +105,7 @@ int psmx2_fabric(struct fi_fabric_attr *attr,
 
 	psmx2_get_uuid(fabric_priv->uuid);
 	if (psmx2_env.name_server) {
-		fabric_priv->name_server.ns_port = psmx2_uuid_to_port(fabric_priv->uuid);
+		fabric_priv->name_server.port = psmx2_uuid_to_port(fabric_priv->uuid);
 		fabric_priv->name_server.name_len = sizeof(struct psmx2_ep_name);
 		fabric_priv->name_server.service_len = sizeof(int);
 		fabric_priv->name_server.service_cmp = psmx2_ns_service_cmp;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -314,23 +314,17 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	}
 
 	if (!dest_addr && node && !(flags & FI_SOURCE)) {
-		struct util_ns ns = (const struct util_ns){ 0 };
-		struct util_ns_attr ns_attr = (const struct util_ns_attr){ 0 };
 		psm2_uuid_t uuid;
 
 		psmx2_get_uuid(uuid);
-		ns_attr.ns_port = psmx2_uuid_to_port(uuid);
-		ns_attr.name_len = sizeof(*dest_addr);
-		ns_attr.service_len = sizeof(svc);
-		ns_attr.service_cmp = psmx2_ns_service_cmp;
-		ns_attr.is_service_wildcard = psmx2_ns_is_service_wildcard;
-		err = ofi_ns_init(&ns_attr, &ns);
-		if (err) {
-			FI_INFO(&psmx2_prov, FI_LOG_CORE,
-				"ofi_ns_init returns %d\n", err);
-			err = -FI_ENODATA;
-			goto err_out;
-		}
+		struct util_ns ns = {
+			.ns_port = psmx2_uuid_to_port(uuid),
+			.name_len = sizeof(*dest_addr),
+			.service_len = sizeof(svc),
+			.service_cmp = psmx2_ns_service_cmp,
+			.is_service_wildcard = psmx2_ns_is_service_wildcard,
+		};
+		ofi_ns_init(&ns);
 
 		if (service)
 			svc = atoi(service);

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -318,7 +318,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 
 		psmx2_get_uuid(uuid);
 		struct util_ns ns = {
-			.ns_port = psmx2_uuid_to_port(uuid),
+			.port = psmx2_uuid_to_port(uuid),
 			.name_len = sizeof(*dest_addr),
 			.service_len = sizeof(svc),
 			.service_cmp = psmx2_ns_service_cmp,

--- a/prov/util/src/util_ns.c
+++ b/prov/util/src/util_ns.c
@@ -551,8 +551,6 @@ void ofi_ns_start_server(struct util_ns *ns)
 	if ((!ns->is_initialized) || (ofi_atomic_inc32(&ns->ref) > 1))
 		return;
 
-	ofi_osd_init();
-
 	ret = pthread_create(&ns->ns_thread, NULL,
 			     util_ns_name_server_func, (void *)ns);
 	if (ret) {
@@ -584,7 +582,6 @@ void ofi_ns_stop_server(struct util_ns *ns)
 	if (ns->is_initialized && !ofi_atomic_dec32(&ns->ref)) {
 
 		ns->is_initialized = 0;
-		ofi_osd_fini();
 
 		if (pthread_equal(ns->ns_thread, pthread_self()))
 			return;

--- a/prov/util/src/util_ns.c
+++ b/prov/util/src/util_ns.c
@@ -591,26 +591,12 @@ void ofi_ns_stop_server(struct util_ns *ns)
 	}
 }
 
-int ofi_ns_init(struct util_ns_attr *attr, struct util_ns *ns)
+void ofi_ns_init(struct util_ns *ns)
 {
-	if (!ns || !attr || !attr->name_len ||
-	    !attr->service_len || !attr->service_cmp)
-		return -FI_EINVAL;
+	assert(ns && ns->name_len && ns->service_len && ns->service_cmp);
 
-	if (ns->is_initialized)
-		return FI_SUCCESS;
-	else
+	if (!ns->is_initialized) {
 		ofi_atomic_initialize32(&ns->ref, 0);
-
-	ns->is_initialized = 1;
-
-	ns->name_len = attr->name_len;
-	ns->service_len = attr->service_len;
-	ns->service_cmp = attr->service_cmp;
-	ns->is_service_wildcard = attr->is_service_wildcard;
-	ns->ns_port = attr->ns_port;
-	if (attr->ns_hostname)
-		ns->ns_hostname = strdup(attr->ns_hostname);
-
-	return FI_SUCCESS;
+		ns->is_initialized = 1;
+	}
 }

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -556,22 +556,15 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 			/* Even if it's invoked not for the first time
 			 * (e.g. multiple domains per fabric), it's safe
 			 */
-			struct util_ns_attr ns_attr = {
-				.ns_port =
-					fi_ibv_gl_data.dgram.name_server_port,
-				.name_len = sizeof(struct ofi_ib_ud_ep_name),
-				.service_len = sizeof(int),
-				.service_cmp = fi_ibv_dgram_ns_service_cmp,
-				.is_service_wildcard =
-					fi_ibv_dgram_ns_is_service_wildcard,
-			};
-			ret = ofi_ns_init(&ns_attr,
-					  &fab->name_server);
-			if (ret) {
-				VERBS_INFO(FI_LOG_DOMAIN,
-					   "ofi_ns_init returns %d\n", ret);
-				goto err5;
-			}
+			fab->name_server.ns_port =
+					fi_ibv_gl_data.dgram.name_server_port;
+			fab->name_server.name_len = sizeof(struct ofi_ib_ud_ep_name);
+			fab->name_server.service_len = sizeof(int);
+			fab->name_server.service_cmp = fi_ibv_dgram_ns_service_cmp;
+			fab->name_server.is_service_wildcard =
+					fi_ibv_dgram_ns_is_service_wildcard;
+
+			ofi_ns_init(&fab->name_server);
 			ofi_ns_start_server(&fab->name_server);
 		}
 		_domain->util_domain.domain_fid.ops = &fi_ibv_dgram_domain_ops;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -556,7 +556,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 			/* Even if it's invoked not for the first time
 			 * (e.g. multiple domains per fabric), it's safe
 			 */
-			fab->name_server.ns_port =
+			fab->name_server.port =
 					fi_ibv_gl_data.dgram.name_server_port;
 			fab->name_server.name_len = sizeof(struct ofi_ib_ud_ep_name);
 			fab->name_server.service_len = sizeof(int);

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1297,9 +1297,8 @@ static int fi_ibv_del_info_not_belong_to_dev(const char *dev_name, struct fi_inf
 static int fi_ibv_resolve_ib_ud_dest_addr(const char *node, const char *service,
 					  struct ofi_ib_ud_ep_name **dest_addr)
 {
-	int ret, svc = VERBS_IB_UD_NS_ANY_SERVICE;
-	struct util_ns ns = { 0 };
-	struct util_ns_attr ns_attr = {
+	int svc = VERBS_IB_UD_NS_ANY_SERVICE;
+	struct util_ns ns = {
 		.ns_port = fi_ibv_gl_data.dgram.name_server_port,
 		.name_len = sizeof(**dest_addr),
 		.service_len = sizeof(svc),
@@ -1307,12 +1306,7 @@ static int fi_ibv_resolve_ib_ud_dest_addr(const char *node, const char *service,
 		.is_service_wildcard = fi_ibv_dgram_ns_is_service_wildcard,
 	};
 
-	ret = ofi_ns_init(&ns_attr, &ns);
-	if (ret) {
-		VERBS_INFO(FI_LOG_CORE,
-			   "ofi_ns_init returns %d\n", ret);
-		return -FI_ENODATA;
-	}
+	ofi_ns_init(&ns);
 
 	if (service)
 		svc = atoi(service);
@@ -1326,7 +1320,7 @@ static int fi_ibv_resolve_ib_ud_dest_addr(const char *node, const char *service,
 		return -FI_ENODATA;
 	}
 
-	return ret;
+	return 0;
 }
 
 static int fi_ibv_handle_ib_ud_addr(const char *node, const char *service,

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1299,7 +1299,7 @@ static int fi_ibv_resolve_ib_ud_dest_addr(const char *node, const char *service,
 {
 	int svc = VERBS_IB_UD_NS_ANY_SERVICE;
 	struct util_ns ns = {
-		.ns_port = fi_ibv_gl_data.dgram.name_server_port,
+		.port = fi_ibv_gl_data.dgram.name_server_port,
 		.name_len = sizeof(**dest_addr),
 		.service_len = sizeof(svc),
 		.service_cmp = fi_ibv_dgram_ns_service_cmp,


### PR DESCRIPTION
2nd attempt at cleaning up the name server code.  The changes are most identical to the first post.  Github closed my PR when I reset my master branch in order to run internal CI on the psm2 provider.

The main change is that I discovered via testing that closing a listening socket does NOT impact another thread calling accept on that socket (this may be system dependent).  Accept() can continue to block.  The cleanup code now sets a 'run' variable to false, connects to the server thread, and exits.  This unblocks the accepting thread.

The psm2 provider passes CI with these changes now.