### PR TITLE
prov/rxm: Set TX entry's comp_flags properly

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -698,7 +698,7 @@ rxm_ep_format_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	(*tx_entry)->context = context;
 	(*tx_entry)->flags = flags;
 	(*tx_entry)->tx_buf = *tx_buf;
-	(*tx_entry)->comp_flags |= comp_flags | FI_SEND;
+	(*tx_entry)->comp_flags = comp_flags | FI_SEND;
 
 	return FI_SUCCESS;
 err:


### PR DESCRIPTION
Set TX entry's comp_flags instead of ORed them

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>