### PR TITLE
prov/util: bug fix for ofi_cq_readfrom()

### DIFF
--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -181,14 +181,6 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 	ssize_t i;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
-	if (!cq->src) {
-		i = ofi_cq_read(cq_fid, buf, count);
-		if (i > 0) {
-			for (count = 0; count < (size_t)i; count++)
-				src_addr[i] = FI_ADDR_NOTAVAIL;
-		}
-		return i;
-	}
 
 	fastlock_acquire(&cq->cq_lock);
 	if (ofi_cirque_isempty(cq->cirq)) {


### PR DESCRIPTION
ofi_cq_read is modified to call ofi_cq_readfrom to avoid code duplication in #3666. But this function have already been calling ofi_cq_read in case of no cq->src - causing stack overflow by infinite recursion. 

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>