### PR TITLE
prov/tcp: code cleanup

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -216,7 +216,6 @@ struct tcpx_pe_entry {
 	enum tcpx_xfer_states	state;
 	struct ofi_op_hdr	msg_hdr;
 	union tcpx_iov		iov[TCPX_IOV_LIMIT];
-	struct dlist_entry	entry;
 	struct dlist_entry	ctx_entry;
 	struct ofi_ringbuf	comm_buf;
 	struct tcpx_ep		*ep;
@@ -227,15 +226,9 @@ struct tcpx_pe_entry {
 	uint64_t		data_len;
 	uint64_t		done_len;
 	uint64_t		iov_cnt;
-	uint8_t			is_pool_entry;
 };
 
 struct tcpx_progress {
-	struct tcpx_domain	*domain;
-	struct tcpx_pe_entry	pe_entry_table[TCPX_PE_MAX_ENTRIES];
-	struct dlist_entry	free_list;
-	struct dlist_entry	busy_list;
-	struct dlist_entry	pool_list;
 	struct dlist_entry	ep_list;
 	pthread_mutex_t		ep_list_lock;
 	struct util_buf_pool	*pe_entry_pool;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -116,13 +116,11 @@ ssize_t tcpx_comm_send(struct tcpx_pe_entry *pe_entry, const void *buf, size_t l
 ssize_t tcpx_comm_recv(struct tcpx_pe_entry *pe_entry, void *buf, size_t len);
 ssize_t tcpx_comm_flush(struct tcpx_pe_entry *pe_entry);
 
-int tcpx_progress_init(struct tcpx_domain *domain, struct tcpx_progress *progress);
-int tcpx_progress_close(struct tcpx_domain *domain);
+int tcpx_progress_init(struct tcpx_progress *progress);
+int tcpx_progress_close(struct tcpx_progress *progress);
 void tcpx_progress_signal(struct tcpx_progress *progress);
-int tcpx_progress_ep_add(struct tcpx_ep *ep, struct tcpx_progress *progress);
-int tcpx_progress_ep_remove(struct tcpx_ep *ep, struct tcpx_progress *progress);
-void tcpx_progress_posted_rx_cleanup(struct tcpx_ep *ep, struct tcpx_progress *progress);
-void tcpx_progress_pe_entry_cleanup(struct tcpx_ep *ep, struct tcpx_progress *progress);
+int tcpx_progress_ep_add(struct tcpx_progress *progress, struct tcpx_ep *ep);
+int tcpx_progress_ep_remove(struct tcpx_progress *progress, struct tcpx_ep *ep);
 
 enum tcpx_xfer_states {
 	TCPX_XFER_IDLE,

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -302,7 +302,7 @@ static int proc_conn_resp(struct poll_fd_mgr *poll_mgr,
 			      struct tcpx_domain,
 			      util_domain);
 
-	ret = tcpx_progress_ep_add(ep, &domain->progress);
+	ret = tcpx_progress_ep_add(&domain->progress, ep);
 err:
 	free(cm_entry);
 	return ret;
@@ -445,7 +445,7 @@ static void handle_accept_conn(struct poll_fd_mgr *poll_mgr,
 			      struct tcpx_domain,
 			      util_domain);
 
-	ret = tcpx_progress_ep_add(ep, &domain->progress);
+	ret = tcpx_progress_ep_add(&domain->progress, ep);
 	if (ret)
 		goto err;
 

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -57,7 +57,7 @@ static int tcpx_domain_close(fid_t fid)
 	tcpx_domain = container_of(fid, struct tcpx_domain,
 				   util_domain.domain_fid.fid);
 
-	ret = tcpx_progress_close(tcpx_domain);
+	ret = tcpx_progress_close(&tcpx_domain->progress);
 	if (ret)
 		return ret;
 
@@ -99,7 +99,7 @@ int tcpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	(*domain)->fid.ops = &tcpx_domain_fi_ops;
 	(*domain)->ops = &tcpx_domain_ops;
 
-	ret = tcpx_progress_init(tcpx_domain, &tcpx_domain->progress);
+	ret = tcpx_progress_init(&tcpx_domain->progress);
 	if (ret)
 		goto err2;
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -414,10 +414,7 @@ static int tcpx_ep_close(struct fid *fid)
 	tcpx_domain = container_of(ep->util_ep.domain,
 				   struct tcpx_domain, util_domain);
 
-	tcpx_progress_ep_remove(ep, &tcpx_domain->progress);
-	tcpx_progress_posted_rx_cleanup(ep, &tcpx_domain->progress);
-	tcpx_progress_pe_entry_cleanup(ep, &tcpx_domain->progress);
-
+	tcpx_progress_ep_remove(&tcpx_domain->progress, ep);
 	pthread_mutex_destroy(&ep->posted_rx_list_lock);
 	fastlock_destroy(&ep->rb_lock);
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -41,27 +41,6 @@
 #include <net/if.h>
 #include <fi_util.h>
 
-static int tcpx_progress_table_clean(struct tcpx_progress *progress)
-{
-	int i;
-	struct dlist_entry *entry;
-	struct tcpx_pe_entry *pe_entry;
-
-	for (i = 0; i < TCPX_PE_MAX_ENTRIES; i++) {
-		ofi_rbfree(&progress->pe_entry_table[i].comm_buf);
-	}
-
-	while(!dlist_empty(&progress->pool_list)) {
-		entry = progress->pool_list.next;
-		dlist_remove(entry);
-		pe_entry = container_of(entry, struct tcpx_pe_entry, entry);
-		ofi_rbfree(&pe_entry->comm_buf);
-		util_buf_release(progress->pe_entry_pool, pe_entry);
-	}
-
-	return FI_SUCCESS;
-}
-
 int tcpx_progress_close(struct tcpx_domain *domain)
 {
 	struct tcpx_progress *progress = &domain->progress;
@@ -83,7 +62,6 @@ int tcpx_progress_close(struct tcpx_domain *domain)
 	fd_signal_free(&progress->signal);
 	fastlock_destroy(&progress->signal_lock);
 	fi_epoll_close(progress->epoll_set);
-	tcpx_progress_table_clean(progress);
 	util_buf_pool_destroy(progress->posted_rx_pool);
 	util_buf_pool_destroy(progress->pe_entry_pool);
 	pthread_mutex_destroy(&progress->ep_list_lock);
@@ -99,28 +77,18 @@ void tcpx_progress_signal(struct tcpx_progress *progress)
 
 static struct tcpx_pe_entry *get_new_pe_entry(struct tcpx_progress *progress)
 {
-	struct dlist_entry *entry;
 	struct tcpx_pe_entry *pe_entry;
 
-	if (dlist_empty(&progress->free_list)) {
-		pe_entry = util_buf_alloc(progress->pe_entry_pool);
-		if (!pe_entry) {
-			FI_WARN(&tcpx_prov, FI_LOG_DOMAIN,"failed to get buffer\n");
-			return NULL;
-		}
-		memset(pe_entry, 0, sizeof(*pe_entry));
-		pe_entry->is_pool_entry = 1;
-		if (ofi_rbinit(&pe_entry->comm_buf, TCPX_PE_COMM_BUFF_SZ))
-			FI_WARN(&tcpx_prov, FI_LOG_DOMAIN,"failed to init comm-cache\n");
-		pe_entry->cache_sz = TCPX_PE_COMM_BUFF_SZ;
-		dlist_insert_tail(&pe_entry->entry, &progress->pool_list);
-	} else {
-		entry = progress->free_list.next;
-		dlist_remove(entry);
-		dlist_insert_tail(entry, &progress->busy_list);
-		pe_entry = container_of(entry, struct tcpx_pe_entry, entry);
-		assert(ofi_rbempty(&pe_entry->comm_buf));
+	pe_entry = util_buf_alloc(progress->pe_entry_pool);
+	if (!pe_entry) {
+		FI_WARN(&tcpx_prov, FI_LOG_DOMAIN,"failed to get buffer\n");
+		return NULL;
 	}
+	memset(pe_entry, 0, sizeof(*pe_entry));
+	if (ofi_rbinit(&pe_entry->comm_buf, TCPX_PE_COMM_BUFF_SZ))
+		FI_WARN(&tcpx_prov, FI_LOG_DOMAIN,"failed to init comm-cache\n");
+
+	pe_entry->cache_sz = TCPX_PE_COMM_BUFF_SZ;
 	return pe_entry;
 }
 
@@ -225,14 +193,8 @@ static void release_pe_entry(struct tcpx_pe_entry *pe_entry)
 	pe_entry->done_len = 0;
 	pe_entry->iov_cnt = 0;
 
-	if (pe_entry->is_pool_entry) {
-		ofi_rbfree(&pe_entry->comm_buf);
-		dlist_remove(&pe_entry->entry);
-		util_buf_release(domain->progress.pe_entry_pool, pe_entry);
-		return;
-	}
-	dlist_remove(&pe_entry->entry);
-	dlist_insert_tail(&pe_entry->entry, &domain->progress.free_list);
+	ofi_rbfree(&pe_entry->comm_buf);
+	util_buf_release(domain->progress.pe_entry_pool, pe_entry);
 }
 
 void tcpx_progress_posted_rx_cleanup(struct tcpx_ep *ep,
@@ -641,45 +603,10 @@ int tcpx_progress_ep_add(struct tcpx_ep *ep, struct tcpx_progress *progress)
 	return FI_SUCCESS;
 }
 
-static int tcpx_progress_table_init(struct tcpx_progress *progress)
-{
-	int i;
-
-	memset(&progress->pe_entry_table, 0,
-	       sizeof(struct tcpx_pe_entry) * TCPX_PE_MAX_ENTRIES);
-
-	dlist_init(&progress->free_list);
-	dlist_init(&progress->busy_list);
-	dlist_init(&progress->pool_list);
-
-	for (i = 0; i < TCPX_PE_MAX_ENTRIES; i++) {
-		dlist_insert_head(&progress->pe_entry_table[i].entry, &progress->free_list);
-		progress->pe_entry_table[i].cache_sz = TCPX_PE_COMM_BUFF_SZ;
-		if (ofi_rbinit(&progress->pe_entry_table[i].comm_buf, TCPX_PE_COMM_BUFF_SZ)) {
-			FI_WARN(&tcpx_prov, FI_LOG_DOMAIN,
-				"failed to init comm-cache\n");
-			goto err;
-		}
-	}
-	FI_DBG(&tcpx_prov, FI_LOG_DOMAIN,
-	       "Progress entry table init: OK\n");
-	return FI_SUCCESS;
-err:
-	while(i--) {
-		ofi_rbfree(&progress->pe_entry_table[i].comm_buf);
-	}
-	return FI_ENOMEM;
-}
-
 int tcpx_progress_init(struct tcpx_domain *domain,
 		       struct tcpx_progress *progress)
 {
 	int ret;
-
-	progress->domain = domain;
-	ret = tcpx_progress_table_init(progress);
-	if (ret)
-		return ret;
 
 	dlist_init(&progress->ep_list);
 	pthread_mutex_init(&progress->ep_list_lock, NULL);
@@ -740,6 +667,5 @@ err2:
 	util_buf_pool_destroy(progress->pe_entry_pool);
 err1:
 	pthread_mutex_destroy(&progress->ep_list_lock);
-	tcpx_progress_table_clean(progress);
 	return ret;
 }


### PR DESCRIPTION
commit 1:
Removed pe_entry_table and associated lists
commit 2:
Removed domain reference in progress structure
Changed function signatures for progress calls.
Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>