### PR TITLE
prov/psm2: Fix a compilation error

### DIFF
--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -211,7 +211,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 		return NULL;
 	}
 
-	err = util_buf_pool_create(&trx_ctxt->am_req_pool
+	err = util_buf_pool_create(&trx_ctxt->am_req_pool,
 				   sizeof(struct psmx2_am_request),
 				   sizeof(void *),
 				   0, /* max_cnt: unlimited */


### PR DESCRIPTION
The error was introduced by the following commit:

e027ef5 2018-01-20 util/buf: Update buf pool routines

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>