### PR TITLE
prov/psm2: Replace allocated context with reserved space in psm2_mq_req

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -204,11 +204,6 @@ enum psmx2_context_type {
 	PSMX2_MAX_CONTEXT_TYPE
 };
 
-struct psmx2_context {
-	struct fi_context fi_context;
-	struct slist_entry list_entry;
-};
-
 union psmx2_pi {
 	void	*p;
 	uint32_t i[2];
@@ -802,8 +797,9 @@ struct psmx2_fid_ep {
 	ofi_atomic32_t		ref;
 	struct fi_context	nocomp_send_context;
 	struct fi_context	nocomp_tsend_context;
-	struct slist		free_context_list;
-	fastlock_t		context_lock;
+
+	PSMX2_EP_DECL_OP_CONTEXT
+
 	size_t			min_multi_recv;
 	uint32_t		iov_seq_num;
 	int			service;
@@ -1000,8 +996,6 @@ struct	psmx2_ep_name *psmx2_string_to_ep_name(const void *s);
 int	psmx2_errno(int err);
 void	psmx2_query_mpi(void);
 
-struct	fi_context *psmx2_ep_get_op_context(struct psmx2_fid_ep *ep);
-void	psmx2_ep_put_op_context(struct psmx2_fid_ep *ep, struct fi_context *fi_context);
 void	psmx2_cq_enqueue_event(struct psmx2_fid_cq *cq, struct psmx2_cq_event *event);
 struct	psmx2_cq_event *psmx2_cq_create_event(struct psmx2_fid_cq *cq,
 					void *op_context, void *buf,

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -514,11 +514,11 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 			case PSMX2_NOCOMP_RECV_CONTEXT:
 				if (OFI_UNLIKELY((PSMX2_STATUS_TAG(status).tag2 & PSMX2_IOV_BIT) &&
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
-					psmx2_ep_put_op_context(ep, fi_context);
+					PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
 					continue;
 				}
-				psmx2_ep_put_op_context(ep, fi_context);
+				PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 				if (OFI_UNLIKELY(ep->recv_cq && PSMX2_STATUS_ERROR(status))) {
 					op_context = NULL;
 					buf = NULL;
@@ -547,11 +547,11 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 			case PSMX2_NOCOMP_TRECV_CONTEXT:
 				if (OFI_UNLIKELY((PSMX2_STATUS_TAG(status).tag2 & PSMX2_IOV_BIT) &&
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
-					psmx2_ep_put_op_context(ep, fi_context);
+					PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
 					continue;
 				}
-				psmx2_ep_put_op_context(ep, fi_context);
+				PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 				if (OFI_UNLIKELY(ep->recv_cq && PSMX2_STATUS_ERROR(status))) {
 					op_context = NULL;
 					buf = NULL;


### PR DESCRIPTION
For receives with completion suppressed, internal allocation of fi_context
was needed in order to be able to generate error completion events. When
compiled with PSM2 source code, it is possible to use reserved space inside
the request handle as fi_context.

The behavior is now controlled by a macro PSMX2_USE_REQ_CONTEXT. A non-zero
value enables the above mentioned optimization when the PSM2 source is
compiled in.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>