### PR TITLE
util/ns, prov/rxm: Fix Coverity issues

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -478,7 +478,7 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	case RXM_RX:
 		assert(!(comp->flags & FI_REMOTE_READ));
 		assert((rx_buf->pkt.hdr.version == OFI_OP_VERSION) &&
-		       (rx_buf->pkt.ctrl_hdr.version = OFI_CTRL_VERSION));
+		       (rx_buf->pkt.ctrl_hdr.version == OFI_CTRL_VERSION));
 
 		if (rx_buf->pkt.ctrl_hdr.type == ofi_ctrl_ack)
 			return rxm_lmt_handle_ack(rx_buf);

--- a/prov/util/src/util_ns.c
+++ b/prov/util/src/util_ns.c
@@ -557,7 +557,8 @@ void ofi_ns_stop_server(struct util_ns *ns)
 
 	ns->run = 0;
 	sock = util_ns_connect_server(ns, ns->hostname);
-	ofi_close_socket(sock);
+	if (sock != INVALID_SOCKET)
+		ofi_close_socket(sock);
 	util_ns_close_listen(ns);
 	(void) pthread_join(ns->thread, NULL);
 	rbtDelete(ns->map);


### PR DESCRIPTION
- util/ns: Coverity complains that there is a chance that `sock` can be negative value, but `ofi_close_socket` can't handle a negative value - [CID 257273](https://scan4.coverity.com/reports.htm#v27196/p10344/fileInstanceId=35561707&defectInstanceId=6629322&mergedDefectId=257273)
- prov/rxm: The `rx_buf->pkt.ctrl_hdr.version` field will be assigned the `OFI_CTRL_VERSION` value that it was intended to compare against, causing the result to always be true - [CID 259145](https://scan4.coverity.com/reports.htm#v27196/p10344/fileInstanceId=35769499&defectInstanceId=6663500&mergedDefectId=259145)

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>