### PR TITLE
prov/rxm: Fix broken send path (eager)

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -549,6 +549,7 @@ static ssize_t rxm_cq_write_error(struct fid_cq *msg_cq,
 	case RXM_TX:
 	case RXM_LMT_TX:
 		tx_entry = (struct rxm_tx_entry *)op_context;
+		tx_entry->tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_data;
 		util_cq = tx_entry->ep->util_ep.tx_cq;
 		break;
 	case RXM_LMT_ACK_SENT:

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -875,7 +875,7 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 {
 	struct util_cmap_handle *handle;
 	struct rxm_conn *rxm_conn;
-	struct rxm_tx_entry *tx_entry = NULL;
+	struct rxm_tx_entry *tx_entry;
 	struct rxm_tx_buf *tx_buf;
 	struct fid_mr **mr_iov;
 	size_t pkt_size = rxm_pkt_size;
@@ -957,6 +957,8 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 			return ret;
 		tx_entry->state = RXM_TX;
 		pkt_size += tx_buf->pkt.hdr.size;
+		ofi_copy_from_iov(tx_buf->pkt.data, tx_buf->pkt.hdr.size,
+				  iov, count, 0);
 	}
 
 	ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size,


### PR DESCRIPTION
The 1st commit of PR #3669 is causing send w/ zero payload buffer.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>