### PR TITLE
man: Remove confusing/contradictory text binding an EP to counters

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -328,7 +328,7 @@ together when binding an endpoint to a completion domain CQ.
   fi_inject(ep, ...);                 // no completion!
 ```
 
-An endpoint may also, or instead, be bound to a fabric counter.  When
+An endpoint may also be bound to a fabric counter.  When
 binding an endpoint to a counter, the following flags may be specified.
 
 *FI_SEND*


### PR DESCRIPTION
The fi_ep_bind documentation indicates that binding an EP to a CQ
is mandatory (in order to report errors).  However, later the man
page states that an EP may 'instead' be bound to a counter.

The intent is that CQs should always be available in order to provide
details on errors.  Fabtests adheres to this requirement.  Strike the
confusing 'instead of' text.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>