### PR TITLE
prov/tcp: remove ringbuf for send requests and simplify data structures

### DIFF
--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -68,7 +68,7 @@ static void tcpx_comm_recv_buffer(struct tcpx_pe_entry *pe_entry)
 		pe_entry->comm_buf.wcnt =
 		pe_entry->comm_buf.wpos = 0;
 
-	max_read = pe_entry->data_len - pe_entry->done_len;
+	max_read = pe_entry->msg_hdr.size - pe_entry->done_len;
 	ret = tcpx_comm_recv_socket(pe_entry->ep->conn_fd, (char *) pe_entry->comm_buf.buf,
 				    MIN(max_read, avail));
 	pe_entry->comm_buf.wpos += ret;


### PR DESCRIPTION
Simplified data structures, merged iov and inject under union.
Removed ring buffer in endpoint.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>