### PR TITLE
prov/psm2: Update makefile and configure script

### DIFF
--- a/prov/psm2/Makefile.include
+++ b/prov/psm2/Makefile.include
@@ -122,6 +122,10 @@ _psm2_nodist_files = \
 	prov/psm2/src/psm2/ptl_self/ptl_fwd.h \
 	prov/psm2/src/psm2/libuuid/psm_uuid.c \
 	prov/psm2/src/psm2/libuuid/psm_uuid.h \
+	prov/psm2/src/psm2/libuuid/parse.c \
+	prov/psm2/src/psm2/libuuid/pack.c \
+	prov/psm2/src/psm2/libuuid/unpack.c \
+	prov/psm2/src/psm2/libuuid/unparse.c \
 	prov/psm2/src/psm2/opa/opa_debug.c \
 	prov/psm2/src/psm2/opa/opa_dwordcpy-@psm2_ARCH@.c \
 	prov/psm2/src/psm2/opa/opa_i2cflash.c \


### PR DESCRIPTION
All the changes are related to building the provider with PSM2 source
included:

(1) Use the internal uuid implementation and remove libuuid from the
    dependencies. This is consistent with how the PSM2 library is built.

(2) In addition to checking the existence of hfi1_user.h, check that
    the header file has the correct version.

(3) Check both the header file and library of the numactl-devel package.

(4) Provide more descriptive output for failed checks.

(5) Add configure option "--with-numa=DIR" to allow non-standard location
    of the numactl-devel package.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>