### PR TITLE
core/net: Fix build warnings on windows

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -97,7 +97,7 @@ static inline int ofi_recvall_socket(SOCKET sock, void *buf, size_t len)
 	ssize_t ret;
 
 	ret = ofi_recv_socket(sock, buf, len, MSG_WAITALL);
-	return ret != len;
+	return (size_t) ret != len;
 }
 
 static inline int ofi_sendall_socket(SOCKET sock, const void *buf, size_t len)
@@ -108,7 +108,7 @@ static inline int ofi_sendall_socket(SOCKET sock, const void *buf, size_t len)
 	for (sent = 0, ret = 0; (sent < len) && (ret >= 0); sent += ret)
 		ret = ofi_send_socket(sock, ((char *) buf) + sent, len - sent, 0);
 
-	return ret != len;
+	return (size_t) ret != len;
 }
 
 /*


### PR DESCRIPTION
Fixes signed/unsigned comparison warning on windows.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>