### PR TITLE
prov/rxm: Remove setting of core MSG EP pointer for TX buffers

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -754,7 +754,6 @@ rxm_ep_format_tx_res_lightweight(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_con
 
 	assert((*tx_buf)->pkt.ctrl_hdr.type == ofi_ctrl_data);
 
-	(*tx_buf)->hdr.msg_ep = rxm_conn->msg_ep;
 	(*tx_buf)->pkt.ctrl_hdr.conn_id = rxm_conn->handle.remote_key;
 
 	(*tx_buf)->pkt.hdr.size = len;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -199,7 +199,6 @@ static ssize_t rxm_ep_rma_inject(struct fid_ep *msg_ep, struct rxm_ep *rxm_ep,
 	tx_entry->comp_flags = FI_RMA | FI_WRITE;
 	tx_entry->tx_buf = tx_buf;
 
-	tx_buf->hdr.msg_ep = msg_ep;
 	ofi_copy_from_iov(tx_buf->pkt.data, size, msg->msg_iov, msg->iov_count, 0);
 
 	iov.iov_base = &tx_buf->pkt.data;


### PR DESCRIPTION
Setting of MSG EP pointer for TX buffers is unnecessary. This can be removed.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>