### PR TITLE
prov/rxm: Split LMT TX buffer into separate pool

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -200,7 +200,8 @@ enum rxm_buf_pool_type {
 	RXM_BUF_POOL_TX_MSG	= 1,
 	RXM_BUF_POOL_TX_TAGGED	= 2,
 	RXM_BUF_POOL_TX_ACK	= 3,
-	RXM_BUF_POOL_MAX_VAL	= 4,
+	RXM_BUF_POOL_TX_LMT	= 4,
+	RXM_BUF_POOL_MAX_VAL	= 5,
 };
 
 struct rxm_buf {
@@ -417,7 +418,8 @@ rxm_tx_buf_release(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 {
 	assert((tx_buf->type == RXM_BUF_POOL_TX_MSG) ||
 	       (tx_buf->type == RXM_BUF_POOL_TX_TAGGED) ||
-	       (tx_buf->type == RXM_BUF_POOL_TX_ACK));
+	       (tx_buf->type == RXM_BUF_POOL_TX_ACK) ||
+	       (tx_buf->type == RXM_BUF_POOL_TX_LMT));
 	tx_buf->pkt.hdr.flags &= ~OFI_REMOTE_CQ_DATA;
 	rxm_buf_release(&rxm_ep->buf_pools[tx_buf->type],
 			(struct rxm_buf *)tx_buf);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -521,7 +521,6 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 		assert(comp->flags & FI_SEND);
 		RXM_LOG_STATE_TX(FI_LOG_CQ, tx_entry, RXM_LMT_ACK_WAIT);
 		RXM_SET_PROTO_STATE(comp, RXM_LMT_ACK_WAIT);
-		tx_entry->tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_data;
 		return 0;
 	case RXM_LMT_ACK_RECVD:
 		assert(comp->flags & FI_SEND);
@@ -579,7 +578,6 @@ static ssize_t rxm_cq_write_error(struct fid_cq *msg_cq,
 	case RXM_TX:
 	case RXM_LMT_TX:
 		tx_entry = (struct rxm_tx_entry *)op_context;
-		tx_entry->tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_data;
 		util_cq = tx_entry->ep->util_ep.tx_cq;
 		break;
 	case RXM_LMT_ACK_SENT:


### PR DESCRIPTION
This patch splits LMT protocol buffers into separate pool
This allows us to not set `rxm_pkt::ctrl_hdr::type` from `ofi_ctrl_large_data` to `ofi_ctrl_data` for the TX/MSG and TX/TAGGED buffers. As a result, this help us to minimize further development errors and avoid confusion.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>