### PR TITLE
prov/verbs: Update completion flags handling for verbs/FI_EP_MSG

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -328,6 +328,13 @@ int ofi_cq_write_error(struct util_cq *cq,
 		       const struct fi_cq_err_entry *err_entry);
 int ofi_cq_write_error_peek(struct util_cq *cq, uint64_t tag, void *context);
 
+static inline int ofi_need_completion(uint64_t cq_flags, uint64_t op_flags)
+{
+	return (!(cq_flags & FI_SELECTIVE_COMPLETION) ||
+		(op_flags & (FI_COMPLETION | FI_INJECT_COMPLETE |
+			     FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)));
+}
+
 /*
  * Counter
  */

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -98,9 +98,8 @@
 #define VERBS_INJECT(ep, len) VERBS_INJECT_FLAGS(ep, len, ep->info->tx_attr->op_flags)
 
 #define VERBS_SELECTIVE_COMP(ep) (ep->ep_flags & FI_SELECTIVE_COMPLETION)
-#define VERBS_COMP_FLAGS(ep, flags) ((!VERBS_SELECTIVE_COMP(ep) || \
-		(flags & (FI_COMPLETION | FI_TRANSMIT_COMPLETE))) ? \
-		IBV_SEND_SIGNALED : 0)
+#define VERBS_COMP_FLAGS(ep, flags) (ofi_need_completion(ep->ep_flags, flags) ?	\
+				     IBV_SEND_SIGNALED : 0)
 #define VERBS_COMP(ep) VERBS_COMP_FLAGS(ep, ep->info->tx_attr->op_flags)
 
 #define VERBS_WCE_CNT 1024


### PR DESCRIPTION
This patch fixes incorrect handling of case when `FI_INJECT` flag only set and cq_flags isn't set to `FI_SELECTIVE_COMPLETION`. Completion is generated by the prov/verbs/MSG in this case.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>