### PR TITLE
prov/rxm: Set mr_key_size from core provider

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -139,6 +139,7 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->domain_attr->mr_mode |= core_info->domain_attr->mr_mode;
 	info->domain_attr->cq_data_size = MIN(core_info->domain_attr->cq_data_size,
 					      rxm_info.domain_attr->cq_data_size);
+	info->domain_attr->mr_key_size = core_info->domain_attr->mr_key_size;
 
 	return 0;
 }


### PR DESCRIPTION
The RxM provider have to provide a proper value of the `fi_info::domain_attr::mr_key_size` parameter.
Since RxM provider uses core provider's MR functionality, RxM have to use value provided by core provider and report it to an user.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>