### PR TITLE
 prov/rxm: Add support of CNTR

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -65,6 +65,8 @@
 #include "rbtree.h"
 
 #define UTIL_FLAG_ERROR	(1ULL << 60)
+	
+#define OFI_CNTR_ENABLED	(1ULL << 61)
 
 #define OFI_Q_STRERROR(prov, log, q, q_str, entry, strerror)			\
 	FI_WARN(prov, log, "fi_" q_str "_readerr: err: %d, prov_err: %s (%d)\n",\

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -381,6 +381,18 @@ int rxm_ep_msg_mr_regv(struct rxm_ep *rxm_ep, const struct iovec *iov,
 		       size_t count, uint64_t access, struct fid_mr **mr);
 void rxm_ep_msg_mr_closev(struct fid_mr **mr, size_t count);
 
+static inline void rxm_cntr_inc(struct util_cntr *cntr)
+{
+	if (cntr)
+		cntr->cntr_fid.ops->add(&cntr->cntr_fid, 1);
+}
+
+static inline void rxm_cntr_incerr(struct util_cntr *cntr)
+{
+	if (cntr)
+		cntr->cntr_fid.ops->adderr(&cntr->cntr_fid, 1);
+}
+
 /* Caller must hold recv_queue->lock */
 static inline struct rxm_rx_buf *
 rxm_check_unexp_msg_list(struct rxm_recv_queue *recv_queue, fi_addr_t addr,

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -37,13 +37,36 @@
 #include <fi_util.h>
 #include "rxm.h"
 
+int rxm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		  struct fid_cntr **cntr_fid, void *context)
+{
+	int ret;
+	struct util_cntr *cntr;
+
+	cntr = calloc(1, sizeof(*cntr));
+	if (!cntr)
+		return -FI_ENOMEM;
+
+	ret = ofi_cntr_init(&rxm_prov, domain, attr, cntr,
+			    &ofi_cntr_progress, context);
+	if (ret)
+		goto free;
+
+	*cntr_fid = &cntr->cntr_fid;
+	return FI_SUCCESS;
+
+free:
+	free(cntr);
+	return ret;
+}
+
 static struct fi_ops_domain rxm_domain_ops = {
 	.size = sizeof(struct fi_ops_domain),
 	.av_open = ip_av_create,
 	.cq_open = rxm_cq_open,
 	.endpoint = rxm_endpoint,
 	.scalable_ep = fi_no_scalable_ep,
-	.cntr_open = fi_no_cntr_open,
+	.cntr_open = rxm_cntr_open,
 	.poll_open = fi_poll_create,
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -827,9 +827,13 @@ rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 		memcpy(tx_buf->pkt.data, buf, tx_buf->pkt.hdr.size);
 
 		ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size, 0);
-		if (OFI_UNLIKELY(ret))
+		if (OFI_UNLIKELY(ret)) {
 			FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
 			       "fi_inject for MSG provider failed\n");
+			rxm_cntr_incerr(rxm_ep->util_ep.tx_cntr);
+		} else {
+			rxm_cntr_inc(rxm_ep->util_ep.tx_cntr);
+		}
 		/* release allocated buffer for further reuse */
 		goto done_inject;
 	} else {
@@ -951,9 +955,13 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 				ofi_copy_from_iov(tx_buf->pkt.data, tx_buf->pkt.hdr.size,
 						  iov, count, 0);
 				ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, total_len, 0);
-				if (OFI_UNLIKELY(ret))
+				if (OFI_UNLIKELY(ret)) {
 					FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
 					       "fi_inject for MSG provider failed\n");
+					rxm_cntr_incerr(rxm_ep->util_ep.tx_cntr);
+				} else {
+					rxm_cntr_inc(rxm_ep->util_ep.tx_cntr);
+				}
 				/* release allocated buffer for further reuse */
 				goto done_inject;
 			}

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1325,16 +1325,17 @@ static int rxm_ep_trywait(void *arg)
 
 static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 {
+	struct rxm_ep *rxm_ep =
+		container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	struct util_cq *cq;
-	struct rxm_ep *rxm_ep;
-	struct util_av *util_av;
+	struct util_av *av;
+	struct util_cntr *cntr;
 	int ret = 0;
 
-	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	switch (bfid->fclass) {
 	case FI_CLASS_AV:
-		util_av = container_of(bfid, struct util_av, av_fid.fid);
-		ret = ofi_ep_bind_av(&rxm_ep->util_ep, util_av);
+		av = container_of(bfid, struct util_av, av_fid.fid);
+		ret = ofi_ep_bind_av(&rxm_ep->util_ep, av);
 		if (ret)
 			return ret;
 		break;
@@ -1356,6 +1357,9 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 			return ret;
 		}
 		break;
+	case FI_CLASS_CNTR:
+		cntr = container_of(bfid, struct util_cntr, cntr_fid.fid);
+		return ofi_ep_bind_cntr(&rxm_ep->util_ep, cntr, flags);
 	case FI_CLASS_EQ:
 		break;
 	default:

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -132,6 +132,8 @@ int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags)
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
+	ep->flags |= OFI_CNTR_ENABLED;
+
 	return fid_list_insert(&cntr->ep_list,
 			       &cntr->ep_list_lock,
 			       &ep->ep_fid.fid);
@@ -189,6 +191,7 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	ep->ep_fid.fid.context = context;
 	ep->domain = util_domain;
 	ep->caps = info->caps;
+	ep->flags = 0;
 	ep->progress = progress;
 	ep->tx_op_flags = info->tx_attr->op_flags;
 	ep->rx_op_flags = info->rx_attr->op_flags;


### PR DESCRIPTION
This PR adds support of CNTR objects for RxM provider (the 1st patch). This support is limited to `wait_obj = FI_WAIT_NONE` now. This restriction will be removed soon.
Also the 2nd patch changes behavior for `.wait` routine in case of `FI_WAIT_NONE` object is passed.