### PR TITLE
prov/shm, util: various updates and fixes

### DIFF
--- a/include/fi_util.h
+++ b/include/fi_util.h
@@ -630,6 +630,11 @@ int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 			   FI_SHARED_AV | FI_TRIGGER | FI_FENCE | \
 			   FI_LOCAL_COMM | FI_REMOTE_COMM)
 
+#define OFI_TX_MSG_CAPS (FI_MSG | FI_SEND)
+#define OFI_RX_MSG_CAPS (FI_MSG | FI_RECV)
+#define OFI_TX_RMA_CAPS (FI_RMA | FI_READ | FI_WRITE)
+#define OFI_RX_RMA_CAPS (FI_RMA | FI_REMOTE_READ | FI_REMOTE_WRITE)
+
 int ofi_check_mr_mode(const struct fi_provider *prov, uint32_t api_version,
 		      int prov_mode, const struct fi_info *user_info);
 int ofi_check_fabric_attr(const struct fi_provider *prov,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -161,6 +161,16 @@ struct smr_domain {
 	int			ep_idx;
 };
 
+#define SMR_PREFIX	"fi_shm://"
+#define SMR_PREFIX_NS	"fi_ns://"
+
+static inline const char *smr_no_prefix(const char *addr)
+{
+	char *start;
+
+	return (start = strstr(addr, "://")) ? start + 3 : addr;
+}
+
 struct smr_ep {
 	struct util_ep		util_ep;
 	smr_rx_comp_func	rx_comp;

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -32,8 +32,12 @@
 
 #include "smr.h"
 
+#define SMR_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | FI_ATOMICS)
+#define SMR_RX_CAPS (FI_SOURCE | OFI_RX_MSG_CAPS | FI_TAGGED | \
+		     OFI_RX_RMA_CAPS | FI_ATOMICS)
+
 struct fi_tx_attr smr_tx_attr = {
-	.caps = FI_MSG | FI_SEND | FI_READ | FI_WRITE,
+	.caps = SMR_TX_CAPS,
 	.comp_order = FI_ORDER_STRICT,
 	.inject_size = SMR_INJECT_SIZE,
 	.size = 1024,
@@ -42,7 +46,7 @@ struct fi_tx_attr smr_tx_attr = {
 };
 
 struct fi_rx_attr smr_rx_attr = {
-	.caps = FI_MSG | FI_RECV | FI_SOURCE,
+	.caps = SMR_RX_CAPS,
 	.comp_order = FI_ORDER_STRICT,
 	.size = 1024,
 	.iov_limit = SMR_IOV_LIMIT
@@ -80,8 +84,7 @@ struct fi_fabric_attr smr_fabric_attr = {
 };
 
 struct fi_info smr_info = {
-	.caps = FI_MSG | FI_SEND | FI_RECV | FI_SOURCE | FI_TAGGED | FI_RMA |
-		FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE | FI_ATOMICS,
+	.caps = SMR_TX_CAPS | SMR_RX_CAPS,
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &smr_tx_attr,
 	.rx_attr = &smr_rx_attr,

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -75,7 +75,8 @@ struct fi_domain_attr smr_domain_attr = {
 	.tx_ctx_cnt = (1 << 10),
 	.rx_ctx_cnt = (1 << 10),
 	.max_ep_tx_ctx = 1,
-	.max_ep_rx_ctx = 1
+	.max_ep_rx_ctx = 1,
+	.mr_iov_limit = SMR_IOV_LIMIT,
 };
 
 struct fi_fabric_attr smr_fabric_attr = {
@@ -85,6 +86,7 @@ struct fi_fabric_attr smr_fabric_attr = {
 
 struct fi_info smr_info = {
 	.caps = SMR_TX_CAPS | SMR_RX_CAPS,
+	.mode = FI_CONTEXT,
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &smr_tx_attr,
 	.rx_attr = &smr_rx_attr,

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -63,6 +63,7 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	struct smr_av *smr_av;
 	struct smr_ep *smr_ep;
 	struct dlist_entry *av_entry;
+	const char *ep_name;
 	int index, i, ret;
 	int succ_count = 0;
 
@@ -70,13 +71,14 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	smr_av = container_of(util_av, struct smr_av, util_av);
 
 	for (i = 0; i < count; i++) {
-		ret = ofi_av_insert_addr(util_av, &smr_names[i].name, 0, &index);
+		ep_name = smr_no_prefix((const char *) smr_names[i].name);
+		ret = ofi_av_insert_addr(util_av, ep_name, 0, &index);
 		if (ret) {
 			if (util_av->eq)
 				ofi_av_write_event(util_av, i, -ret, context);
 		} else {
 			ret = smr_map_add(&smr_prov, smr_av->smr_map,
-					  smr_names[i].name, index);
+					  ep_name, index);
 			if (ret) {
 				if (util_av->eq)
 					ofi_av_write_event(util_av, i, -ret, context);

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -35,6 +35,9 @@
 
 #include <fi_util.h>
 
+#define OFI_MSG_CAPS	(FI_SEND | FI_RECV)
+#define OFI_RMA_CAPS	(FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE)
+
 static int fi_valid_addr_format(uint32_t prov_format, uint32_t user_format)
 {
 	if (user_format == FI_FORMAT_UNSPEC)
@@ -1041,6 +1044,12 @@ static uint64_t ofi_get_caps(uint64_t info_caps, uint64_t hint_caps,
 		caps = (hint_caps & FI_PRIMARY_CAPS) |
 		       (attr_caps & FI_SECONDARY_CAPS);
 	}
+
+	if (caps & (FI_MSG | FI_TAGGED) && !(caps & OFI_MSG_CAPS))
+		caps |= OFI_MSG_CAPS;
+	if (caps & (FI_RMA | FI_ATOMICS) && !(caps & OFI_RMA_CAPS))
+		caps |= OFI_RMA_CAPS;
+
 	return caps;
 }
 
@@ -1158,7 +1167,7 @@ static uint64_t ofi_get_info_caps(const struct fi_info *prov_info,
 	if ((FI_VERSION_LT(api_version, FI_VERSION(1,5)) &&
 	    (user_mode == FI_MR_UNSPEC)) ||
 	    (user_mode == FI_MR_BASIC) ||
-	    ((user_mode & OFI_MR_MODE_RMA_TARGET) ==
+	    ((user_mode & prov_mode & OFI_MR_MODE_RMA_TARGET) == 
 	     (prov_mode & OFI_MR_MODE_RMA_TARGET)))
 		return caps;
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -191,6 +191,16 @@ out:
 	return ret;
 }
 
+void ofi_get_str_addr(const char *node, const char *service,
+		      char **addr, size_t *addrlen)
+{
+	if (!node || !strstr(node, "://"))
+		return;
+
+	*addr = strdup(node);
+	*addrlen = strlen(node) + 1;
+}
+
 int ofi_get_addr(uint32_t addr_format, uint64_t flags,
 		const char *node, const char *service,
 		void **addr, size_t *addrlen)
@@ -206,11 +216,7 @@ int ofi_get_addr(uint32_t addr_format, uint64_t flags,
 		return fi_get_sockaddr(AF_INET6, flags, node, service,
 				       (struct sockaddr **) addr, addrlen);
 	case FI_ADDR_STR:
-		if (!node)
-			return -FI_EINVAL;
-
-		*(char **)addr = strdup(node);
-		*addrlen = strlen(node) + 1;
+		ofi_get_str_addr(node, service, (char **) addr, addrlen);
 		return 0;
 	default:
 		return -FI_ENOSYS;


### PR DESCRIPTION
General improvements to the shm provider (see specific commits for details):
- fix trimming of provider capabilities in utility code
- set shm provider tx_attr and rx_attr caps correctly
- set shm provider MR iov limit and FI_CONTEXT mode
- standardize FI_ADDR_STR usage and format in util and shm code

Signed-off-by: aingerson <alexia.ingerson@intel.com>
