### PR TITLE
Cherry-pick to v1.5.x: prov/sockets: Fix #3217, bug in buffered receive path

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1167,8 +1167,11 @@ static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx)
 		pe_entry.data_len = 0;
 		pe_entry.buf = 0L;
 		for (i = 0; i < rx_posted->rx_op.dest_iov_len && rem > 0; i++) {
-			if (used_len >= rx_posted->rx_op.dest_iov_len) {
-				used_len -= rx_posted->rx_op.dest_iov_len;
+			/* Try to find the first iovec entry where the data
+			 * has not been consumed. In the common case, there
+			 * is only one iovec, i.e. a single buffer */
+			if (used_len >= rx_posted->iov[i].iov.len) {
+				used_len -= rx_posted->iov[i].iov.len;
 				continue;
 			}
 
@@ -1226,6 +1229,11 @@ static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx)
 		} else {
 			sock_pe_report_recv_completion(&pe_entry);
 		}
+
+		/* Mark that we are done processing the posted recv buff.
+		 * This allows another thread to grab it when calling
+		 * sock_rx_get_entry() */
+		rx_posted->is_busy = 0;
 
 		dlist_remove(&rx_buffered->entry);
 		sock_rx_release_entry(rx_buffered);


### PR DESCRIPTION
This bug fix was missed in the v1.5.2 and v1.5.3 releases. I want to make sure it gets into the branch in case of a v1.5.4.

Original PR:

This bug was found by testing GASNet, which has some tests that very
rigourously stress messaging endpoints. The behaviour was that tests would
sporadically hang when put under heavy loads.

The root cause is found in the provider's handling of previously buffered
messages (ones that came in without a matching receive buffer). When the
handler grabbed a posted buffer to place a buffered message into, it was not
marking that receive buffer as free once it was done with it, which causes
buffers posted with FI_MULTI_RECV to become unusable in the future, which
leads to the provider running out of receive buffers.

After fixing the root cause, there was also an issue in calculating the
position in which to place a message in such a multi-recv buffer, which this
patch also fixes.

Signed-off-by: Erik Paulson <erik.r.paulson@intel.com>
(cherry picked from commit 6c5d1314dcf4945241d0f740098f190a7d8575c1)