### PR TITLE
prov/rxm: Use send_queue freestack buf index for msg_id in LMT protocol

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -284,7 +284,6 @@ DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
 
 struct rxm_send_queue {
 	struct rxm_txe_fs *fs;
-	struct ofi_key_idx tx_key_idx;
 	fastlock_t lock;
 };
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -260,16 +260,11 @@ static int rxm_lmt_tx_finish(struct rxm_tx_entry *tx_entry)
 static int rxm_lmt_handle_ack(struct rxm_rx_buf *rx_buf)
 {
 	struct rxm_tx_entry *tx_entry;
-	uint64_t index;
 
 	FI_DBG(&rxm_prov, FI_LOG_CQ, "Got ACK for msg_id: 0x%" PRIx64 "\n",
-			rx_buf->pkt.ctrl_hdr.msg_id);
+	       rx_buf->pkt.ctrl_hdr.msg_id);
 
-	fastlock_acquire(&rx_buf->ep->send_queue.lock);
-	index = ofi_key2idx(&rx_buf->ep->send_queue.tx_key_idx,
-			    rx_buf->pkt.ctrl_hdr.msg_id);
-	tx_entry = &rx_buf->ep->send_queue.fs->buf[index];
-	fastlock_release(&rx_buf->ep->send_queue.lock);
+	tx_entry = &rx_buf->ep->send_queue.fs->buf[rx_buf->pkt.ctrl_hdr.msg_id];
 
 	assert(tx_entry->tx_buf->pkt.ctrl_hdr.msg_id == rx_buf->pkt.ctrl_hdr.msg_id);
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -230,7 +230,6 @@ static int rxm_send_queue_init(struct rxm_ep *rxm_ep, struct rxm_send_queue *sen
 		tx_entry->ep = rxm_ep;
 	}
 
-	ofi_key_idx_init(&send_queue->tx_key_idx, fi_size_bits(size));
 	fastlock_init(&send_queue->lock);
 	return 0;
 }
@@ -920,12 +919,8 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 		if (OFI_UNLIKELY(ret))
 			return ret;
 		tx_buf->pkt.hdr.op = op;
-		fastlock_acquire(&rxm_ep->send_queue.lock);
-		tx_buf->pkt.ctrl_hdr.msg_id =
-			ofi_idx2key(&rxm_ep->send_queue.tx_key_idx,
-				    rxm_txe_fs_index(rxm_ep->send_queue.fs,
-						     tx_entry));
-		fastlock_release(&rxm_ep->send_queue.lock);
+		tx_buf->pkt.ctrl_hdr.msg_id = rxm_txe_fs_index(rxm_ep->send_queue.fs,
+							       tx_entry);
 
 		if (!rxm_ep->rxm_mr_local) {
 			ret = rxm_ep_msg_mr_regv(rxm_ep, iov, tx_entry->count,


### PR DESCRIPTION
This patch use index of send_queue's buffer instead of calculating index for msg_id

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>