### PR TITLE
prov/psm2: Support opening multiple domains

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -361,9 +361,12 @@ struct psmx2_multi_recv {
 
 struct psmx2_fid_fabric {
 	struct util_fabric	util_fabric;
-	struct psmx2_fid_domain	*active_domain;
 	psm2_uuid_t		uuid;
 	struct util_ns		name_server;
+
+	/* list of all opened domains */
+	fastlock_t		domain_lock;
+	struct dlist_entry	domain_list;
 };
 
 struct psmx2_trx_ctxt {
@@ -410,10 +413,7 @@ struct psmx2_fid_domain {
 	uint64_t		mr_reserved_key;
 	RbtHandle		mr_map;
 
-	/*
-	 * A list of all opened hw contexts, including the base hw context.
-	 * The list is used for making progress.
-	 */
+	/* list of hw contexts opened for this domain */
 	fastlock_t		trx_ctxt_lock;
 	struct dlist_entry	trx_ctxt_list;
 
@@ -426,6 +426,8 @@ struct psmx2_fid_domain {
 
 	int			addr_format;
 	uint32_t		max_atomic_size;
+
+	struct dlist_entry	entry;
 };
 
 #define PSMX2_EP_REGULAR	0

--- a/prov/psm2/src/psmx2_wait.c
+++ b/prov/psm2/src/psmx2_wait.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
  *
  * This software is waitailable to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -47,7 +47,9 @@ static volatile int	psmx2_wait_thread_busy = 0;
 
 static void *psmx2_wait_progress(void *args)
 {
-	struct psmx2_fid_domain *domain = args;
+	struct psmx2_fid_fabric *fabric = args;
+	struct psmx2_fid_domain *domain;
+	struct dlist_entry *item;
 
 	psmx2_wait_thread_ready = 1;
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
@@ -61,8 +63,21 @@ static void *psmx2_wait_progress(void *args)
 		pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL);
 
 		psmx2_wait_thread_busy = 1;
-		while (psmx2_wait_thread_enabled)
-			psmx2_progress_all(domain);
+		while (psmx2_wait_thread_enabled) {
+			psmx2_lock(&fabric->domain_lock, 1);
+			dlist_foreach(&fabric->domain_list, item) {
+				domain = container_of(item, struct psmx2_fid_domain, entry);
+				if (domain->progress_thread_enabled &&
+				    domain->progress_thread != pthread_self())
+					continue;
+
+				psmx2_progress_all(domain);
+
+				if (!psmx2_wait_thread_enabled)
+					break;
+			}
+			psmx2_unlock(&fabric->domain_lock, 1);
+		}
 
 		psmx2_wait_thread_busy = 0;
 
@@ -72,15 +87,27 @@ static void *psmx2_wait_progress(void *args)
 	return NULL;
 }
 
-static void psmx2_wait_start_progress(struct psmx2_fid_domain *domain)
+static void psmx2_wait_start_progress(struct psmx2_fid_fabric *fabric)
 {
+	struct dlist_entry *item;
+	struct psmx2_fid_domain *domain;
+	int run_wait_thread = 0;
 	pthread_attr_t attr;
 	int err;
 
-	if (!domain)
+	if (!fabric)
 		return;
 
-	if (domain->progress_thread_enabled && domain->progress_thread != pthread_self())
+	psmx2_lock(&fabric->domain_lock, 1);
+	dlist_foreach(&fabric->domain_list, item) {
+		domain = container_of(item, struct psmx2_fid_domain, entry);
+		if (!domain->progress_thread_enabled ||
+		    domain->progress_thread == pthread_self())
+			run_wait_thread = 1;
+	}
+	psmx2_unlock(&fabric->domain_lock, 1);
+
+	if (!run_wait_thread)
 		return;
 
 	if (!psmx2_wait_thread) {
@@ -89,7 +116,7 @@ static void psmx2_wait_start_progress(struct psmx2_fid_domain *domain)
 		pthread_attr_init(&attr);
 		pthread_attr_setdetachstate(&attr,PTHREAD_CREATE_DETACHED);
 		err = pthread_create(&psmx2_wait_thread, &attr,
-				     psmx2_wait_progress, (void *)domain);
+				     psmx2_wait_progress, (void *)fabric);
 		if (err)
 			FI_WARN(&psmx2_prov, FI_LOG_EQ,
 				"cannot create wait progress thread\n");
@@ -122,7 +149,7 @@ static int psmx2_wait_wait(struct fid_wait *wait, int timeout)
 	wait_priv = container_of(wait, struct util_wait, wait_fid);
 	fabric = container_of(wait_priv->fabric, struct psmx2_fid_fabric, util_fabric);
 
-	psmx2_wait_start_progress(fabric->active_domain);
+	psmx2_wait_start_progress(fabric);
 
 	err = psmx2_wait_ops_save->wait(wait, timeout);
 


### PR DESCRIPTION
Previously multiple calls to fi_domain() would return the same domain
object. That allowed multiple upper layer libraries be used together
by the same process, but lacked the protection provided by separate
domains and didn't work when different domain attributes (e.g. MR mode)
were needed.

Adding true multi-domain support remove the above limitations.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>