### PR TITLE
prov/tcp removing thread for progress

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -123,6 +123,7 @@ int tcpx_progress_ep_add(struct tcpx_progress *progress, struct tcpx_ep *ep);
 int tcpx_progress_ep_remove(struct tcpx_progress *progress, struct tcpx_ep *ep);
 struct tcpx_pe_entry *pe_entry_alloc(struct tcpx_progress *progress);
 void pe_entry_release(struct tcpx_pe_entry *pe_entry);
+void tcpx_progress(struct util_ep *util_ep);
 
 enum tcpx_xfer_states {
 	TCPX_XFER_IDLE,
@@ -236,8 +237,6 @@ struct tcpx_progress {
 	struct fd_signal	signal;
 	fastlock_t		signal_lock;
 	fi_epoll_t		epoll_set;
-	pthread_t		progress_thread;
-	int			do_progress;
 };
 
 struct tcpx_domain {

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -457,11 +457,6 @@ static struct fi_ops_ep tcpx_ep_ops = {
 	.tx_size_left = fi_no_tx_size_left,
 };
 
-static void tcpx_manual_progress(struct util_ep *util_ep)
-{
-	return;
-}
-
 int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 		  struct fid_ep **ep_fid, void *context)
 {
@@ -474,7 +469,7 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 		return -FI_ENOMEM;
 
 	ret = ofi_endpoint_init(domain, &tcpx_util_prov, info, &ep->util_ep,
-				context, tcpx_manual_progress);
+				context, tcpx_progress);
 	if (ret)
 		goto err1;
 


### PR DESCRIPTION
Removed the thread for progress and letting cq read handle the progress. 

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>