### PR TITLE
fabric: Fix utility functions for tag format conversion

### DIFF
--- a/include/fi.h
+++ b/include/fi.h
@@ -147,9 +147,9 @@ static inline size_t fi_get_aligned_sz(size_t size, size_t alignment)
 #define FI_TAG_GENERIC	0xAAAAAAAAAAAAAAAAULL
 
 
-uint64_t fi_tag_bits(uint64_t mem_tag_format);
-uint64_t fi_tag_format(uint64_t tag_bits);
-uint8_t fi_size_bits(uint64_t num);
+uint64_t ofi_max_tag(uint64_t mem_tag_format);
+uint64_t ofi_tag_format(uint64_t max_tag);
+uint8_t ofi_msb(uint64_t num);
 
 int ofi_send_allowed(uint64_t caps);
 int ofi_recv_allowed(uint64_t caps);

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -509,7 +509,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 					PSMX_MAX_MSG_SIZE);
 				goto err_out;
 			}
-			max_tag_value = fi_tag_bits(hints->ep_attr->mem_tag_format);
+			max_tag_value = ofi_max_tag(hints->ep_attr->mem_tag_format);
 		}
 
 		if (hints->tx_attr) {
@@ -604,7 +604,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	psmx_info->ep_attr->max_order_raw_size = PSMX_RMA_ORDER_SIZE;
 	psmx_info->ep_attr->max_order_war_size = PSMX_RMA_ORDER_SIZE;
 	psmx_info->ep_attr->max_order_waw_size = PSMX_RMA_ORDER_SIZE;
-	psmx_info->ep_attr->mem_tag_format = fi_tag_format(max_tag_value);
+	psmx_info->ep_attr->mem_tag_format = ofi_tag_format(max_tag_value);
 	psmx_info->ep_attr->tx_ctx_cnt = 1;
 	psmx_info->ep_attr->rx_ctx_cnt = 1;
 

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -571,7 +571,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 					PSMX2_MAX_MSG_SIZE);
 				goto err_out;
 			}
-			max_tag_value = fi_tag_bits(hints->ep_attr->mem_tag_format);
+			max_tag_value = ofi_max_tag(hints->ep_attr->mem_tag_format);
 		}
 
 		if (hints->tx_attr) {
@@ -667,7 +667,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->ep_attr->max_order_raw_size = PSMX2_RMA_ORDER_SIZE;
 	psmx2_info->ep_attr->max_order_war_size = PSMX2_RMA_ORDER_SIZE;
 	psmx2_info->ep_attr->max_order_waw_size = PSMX2_RMA_ORDER_SIZE;
-	psmx2_info->ep_attr->mem_tag_format = fi_tag_format(max_tag_value);
+	psmx2_info->ep_attr->mem_tag_format = ofi_tag_format(max_tag_value);
 	psmx2_info->ep_attr->tx_ctx_cnt = tx_ctx_cnt;
 	psmx2_info->ep_attr->rx_ctx_cnt = rx_ctx_cnt;
 

--- a/src/common.c
+++ b/src/common.c
@@ -78,21 +78,22 @@ int fi_poll_fd(int fd, int timeout)
 	return ret == SOCKET_ERROR ? -ofi_sockerr() : ret;
 }
 
-uint64_t fi_tag_bits(uint64_t mem_tag_format)
+uint64_t ofi_max_tag(uint64_t mem_tag_format)
 {
-	return UINT64_MAX >> (ffsll(htonll(mem_tag_format)) -1);
+	return UINT64_MAX >> (64 - ofi_msb(mem_tag_format));
 }
 
-uint64_t fi_tag_format(uint64_t tag_bits)
+uint64_t ofi_tag_format(uint64_t max_tag)
 {
-	return FI_TAG_GENERIC >> (ffsll(htonll(tag_bits)) - 1);
+	return FI_TAG_GENERIC >> (64 - ofi_msb(max_tag));
 }
 
-uint8_t fi_size_bits(uint64_t num)
+uint8_t ofi_msb(uint64_t num)
 {
-	uint8_t size_bits = 0;
-	while (num >> ++size_bits);
-	return size_bits;
+	uint8_t msb = 0;
+	while (num >> msb)
+		msb++;
+	return msb;
 }
 
 int ofi_send_allowed(uint64_t caps)


### PR DESCRIPTION
The functions fi_tag_bits() and fi_tag_format() didn't work as
expected.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

Fixes #3751 

@shefty 