### PR TITLE
prov/shm: fi_cancel, no FI_CONTEXT, and man update

### DIFF
--- a/man/fi_shm.7.md
+++ b/man/fi_shm.7.md
@@ -18,23 +18,84 @@ between processes on the same system.
 
 # SUPPORTED FEATURES
 
-This release contains an initial implementation of the SHM provider.  It
-supports a minimal set of features useful for sending and
-receiving datagram messages over an unreliable endpoint.
+This release contains an initial implementation of the SHM provider that
+offers the following support:
 
 *Endpoint types*
-: The provider supports only endpoint type *FI_EP_DGRAM*.
+: The provider supports only endpoint type *FI_EP_RDM*.
 
 *Endpoint capabilities*
-: The following data transfer interface is supported: *fi_msg*.
+: Endpoints cna support any combinations of the following data transfer
+capabilities: *FI_MSG*, *FI_TAGGED*, *FI_RMA*, amd *FI_ATOMICS*.  These
+capabilities can be further defined by *FI_SEND*, *FI_RECV*, *FI_READ*,
+*FI_WRITE*, *FI_REMOTE_READ*, and *FI_REMOTE_WRITE* to limit the direction
+of operations.
 
 *Modes*
 : The provider does not require the use of any mode bits.
 
 *Progress*
-: The UDP provider supports *FI_PROGRESS_MANUAL*.  Receive side data buffers are
-  not modified outside of completion processing routines, and transmit
-  operations require the receiver to process requests before being completed.
+: The SHM provider supports *FI_PROGRESS_MANUAL*.  Receive side data buffers are
+  not modified outside of completion processing routines.  The provider processes
+  messages using three different methods, based on the size of the message.
+  For messages smaller than 4096 bytes, tx completions are generated immediately
+  after the send.  For larger messages, tx completions are not generated until
+  the receiving side has processed the message.
+
+*Address Format*
+: The SHM provider uses the address format FI_ADDR_STR, which follows the general
+  format pattern "[prefix]://[addr]".  The application can provide addresses
+  through the node or hints parameter.  As long as the address is in a valid
+  FI_ADDR_STR format (contains "://"), the address will be used as is.  If the
+  application input is incorrectly formatted or no input was provided, the SHM
+  provider will resolve it according to the following SHM provider standards:
+
+  (flags & FI_SOURCE) ? src_addr : dest_addr =
+   - if (node && service) : "fi_ns://node:service"
+   - if (service) : "fi_ns://service"
+   - if (node && !service) : "fi_shm://node"
+   - if (!node && !service) : "fi_shm://PID"
+
+   !(flags & FI_SOURCE)
+   - src_addr = "fi_shm://PID"
+
+  In other words, if the application provides a source and/or destination
+  address in an acceptable FI_ADDR_STR format (contains "://"), the call
+  to util_getinfo will successfully fill in src_addr and dest_addr with
+  the provided input.  If the input is not in an ADDR_STR format, the
+  shared memory provider will then create a proper FI_ADDR_STR address
+  with either the "fi_ns://" (node/service format) or "fi_shm://" (shm format)
+  prefixes signaling whether the addr is a "unique" address and does or does
+  not need an extra endpoint name identifier appended in order to make it
+  unique.  For the shared memory provider, we assume that the service
+  (with or without a node) is enough to make it unique, but a node alone is
+  not sufficient.  If only a node is provided, the "fi_shm://" prefix  is used
+  to signify that it is not a unique address.  If no node or service are
+  provided (and in the case of setting the src address without FI_SOURCE and
+  no hints), the process ID will be used as a default address.
+  On endpoint creation, if the src_addr has the "fi_shm://" prefix, the provider
+  will append ":[dom_idx]:[ep_idx]" as a unique endpoint name (essentially,
+  in place of a service).  In the case of the "fi_ns://" prefix (or any other
+  prefix if one was provided by the application), no supplemental information
+  is required to make it unique and it will remain with only the
+  application-defined address.  Note that the actual endpoint name will not
+  include the FI_ADDR_STR "*://" prefix since it cannot be included in any
+  shared memory region names. The provider will strip off the prefix before
+  setting the endpoint name. As a result, the addresses
+  "fi_prefix1://my_node:my_service" and "fi_prefix2://my_node:my_service"
+  would result in endpoints and regions of the same name.
+  The application can also override the endpoint name after creating an
+  endpoint using setname() without any address format restrictions.
+
+*Msg flags*
+  The provider currently only supports the FI_REMOTE_CQ_DATA msg flag.
+
+*MR registration mode*
+  The provider implements FI_MR_VIRT_ADDR memory mode.
+
+*Atomic operations*
+  The provider supports all combinations of datatype and operations as long
+  as the message is less than 4096 bytes (or 2048 for compare operations).
 
 # LIMITATIONS
 

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -48,13 +48,13 @@ static void smr_format_rma_ioc(struct smr_cmd *cmd, const struct fi_rma_ioc *rma
 static void smr_format_inline_atomic(struct smr_cmd *cmd, fi_addr_t peer_id,
 				     const struct iovec *iov, size_t count,
 				     const struct iovec *compv,
-				     size_t comp_count, void *context,
-				     uint32_t op, enum fi_datatype datatype,
+				     size_t comp_count,  uint32_t op,
+				     enum fi_datatype datatype,
 				     enum fi_op atomic_op)
 {
 	size_t comp_size;
 
-	smr_generic_format(cmd, peer_id, context, op, 0, datatype,
+	smr_generic_format(cmd, peer_id, op, 0, datatype,
 			   atomic_op, 0, 0);
 	cmd->msg.hdr.op_src = smr_src_inline;
 	switch (op) {
@@ -81,7 +81,7 @@ static void smr_format_inline_atomic(struct smr_cmd *cmd, fi_addr_t peer_id,
 static void smr_format_inject_atomic(struct smr_cmd *cmd, fi_addr_t peer_id,
 				     const struct iovec *iov, size_t count,
 				     const struct iovec *compv,
-				     size_t comp_count,void *context,
+				     size_t comp_count,
 				     uint32_t op, enum fi_datatype datatype,
 				     enum fi_op atomic_op,
 				     struct smr_region *smr,
@@ -89,7 +89,7 @@ static void smr_format_inject_atomic(struct smr_cmd *cmd, fi_addr_t peer_id,
 {
 	size_t comp_size;
 
-	smr_generic_format(cmd, peer_id, context, op, 0, datatype,
+	smr_generic_format(cmd, peer_id, op, 0, datatype,
 			   atomic_op, 0, 0);
 	cmd->msg.hdr.op_src = smr_src_inject;
 	cmd->msg.hdr.src_data = (char **) tx_buf - (char **) smr;
@@ -241,12 +241,12 @@ static ssize_t smr_generic_atomic(struct fid_ep *ep_fid,
 	if (total_len <= SMR_MSG_DATA_LEN) {
 		smr_format_inline_atomic(cmd, smr_peer_addr(ep->region)[peer_id].addr,
 					 iov, count, compare_iov, compare_count,
-					 context, op, datatype, atomic_op);
+					 op, datatype, atomic_op);
 	} else if (total_len <= SMR_INJECT_SIZE) {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
 		smr_format_inject_atomic(cmd, smr_peer_addr(ep->region)[peer_id].addr,
 					 iov, count, compare_iov, compare_count,
-					 context, op, datatype, atomic_op,
+					 op, datatype, atomic_op,
 					 peer_smr, tx_buf);
 	} else {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
@@ -371,12 +371,12 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	if (total_len <= SMR_MSG_DATA_LEN) {
 		smr_format_inline_atomic(cmd, smr_peer_addr(ep->region)[peer_id].addr,
-					 &iov, 1, NULL, 0, NULL, ofi_op_atomic,
+					 &iov, 1, NULL, 0, ofi_op_atomic,
 					 datatype, op);
 	} else if (total_len <= SMR_INJECT_SIZE) {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
 		smr_format_inject_atomic(cmd, smr_peer_addr(ep->region)[peer_id].addr,
-					 &iov, 1, NULL, 0, NULL, ofi_op_atomic,
+					 &iov, 1, NULL, 0, ofi_op_atomic,
 					 datatype, op, peer_smr, tx_buf);
 	}
 

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -86,7 +86,6 @@ struct fi_fabric_attr smr_fabric_attr = {
 
 struct fi_info smr_info = {
 	.caps = SMR_TX_CAPS | SMR_RX_CAPS,
-	.mode = FI_CONTEXT,
 	.addr_format = FI_ADDR_STR,
 	.tx_attr = &smr_tx_attr,
 	.rx_attr = &smr_rx_attr,

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -106,7 +106,7 @@ static int smr_match_recv_ctx(struct dlist_entry *item, const void *args)
 	return pending_recv->context == args;
 }
 
-static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_recv_queue *queue,
+static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 			      void *context)
 {
 	struct smr_ep_entry *recv_entry;
@@ -114,7 +114,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_recv_queue *queue,
 	int ret = 0;
 
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
-	entry = dlist_remove_first_match(&queue->recv_list, smr_match_recv_ctx,
+	entry = dlist_remove_first_match(&queue->list, smr_match_recv_ctx,
 					 context);
 	if (entry) {
 		recv_entry = container_of(entry, struct smr_ep_entry, entry);
@@ -190,48 +190,22 @@ static int smr_match_tagged(struct dlist_entry *item, const void *args)
 static int smr_match_unexp(struct dlist_entry *item, const void *args)
 {
 	struct smr_match_attr *attr = (struct smr_match_attr *)args;
-	struct smr_pending_cmd *unexp_msg;
+	struct smr_unexp_msg *unexp_msg;
 
-	unexp_msg = container_of(item, struct smr_pending_cmd, entry);
+	unexp_msg = container_of(item, struct smr_unexp_msg, entry);
 	return smr_match_addr(unexp_msg->cmd.msg.hdr.addr, attr->addr) &&
 	       smr_match_tag(unexp_msg->cmd.msg.hdr.tag, attr->ignore,
 			     attr->tag);
 }
 
-static int smr_match_cmd_ctx(struct dlist_entry *item, const void *args)
+static void smr_init_queue(struct smr_queue *queue,
+			   dlist_func_t *match_func)
 {
-	struct smr_match_attr *attr = (struct smr_match_attr *)args;
-	struct smr_pending_cmd *pending_msg;
-
-	pending_msg = container_of(item, struct smr_pending_cmd, entry);
-	return pending_msg->cmd.msg.hdr.msg_id == attr->ctx;
+	dlist_init(&queue->list);
+	queue->match_func = match_func;
 }
 
-static void smr_init_recv_queue(struct smr_recv_queue *recv_queue,
-				dlist_func_t *match_func)
-{
-	dlist_init(&recv_queue->recv_list);
-	recv_queue->match_recv = match_func;
-}
-
-static void smr_init_pending_queue(struct smr_pending_queue *queue,
-				   dlist_func_t *match_func)
-{
-	dlist_init(&queue->msg_list);
-	queue->match_msg = match_func;
-}
-
-void smr_post_pending(struct smr_ep *ep, struct smr_cmd *cmd)
-{
-	struct smr_pending_cmd *pend_cmd;
-
-	pend_cmd = freestack_pop(ep->pend_fs);
-	pend_cmd->cmd = *cmd;
-
-	dlist_insert_tail(&pend_cmd->entry, &ep->pend_queue.msg_list);
-}
-
-void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id, void *context,
+void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id,
 			uint32_t op, uint64_t tag, uint8_t datatype,
 			uint8_t atomic_op, uint64_t data,
 			uint16_t op_flags)
@@ -246,18 +220,16 @@ void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id, void *context,
 		cmd->msg.hdr.datatype = datatype;
 		cmd->msg.hdr.atomic_op = atomic_op;
 	}
-	cmd->msg.hdr.msg_id = (uint64_t) context;
 	cmd->msg.hdr.addr = peer_id;
 	cmd->msg.hdr.data = data;
 }
 
 void smr_format_inline(struct smr_cmd *cmd, fi_addr_t peer_id,
 		       const struct iovec *iov, size_t count,
-		       void *context, uint32_t op, uint64_t tag,
-		       uint64_t data, uint16_t op_flags)
+		       uint32_t op, uint64_t tag, uint64_t data,
+		       uint16_t op_flags)
 {
-	smr_generic_format(cmd, peer_id, context, op, tag, 0, 0, data,
-			   op_flags);
+	smr_generic_format(cmd, peer_id, op, tag, 0, 0, data, op_flags);
 	cmd->msg.hdr.op_src = smr_src_inline;
 	cmd->msg.hdr.size = ofi_copy_from_iov(cmd->msg.data.msg,
 					      SMR_MSG_DATA_LEN, iov, count, 0);
@@ -265,13 +237,11 @@ void smr_format_inline(struct smr_cmd *cmd, fi_addr_t peer_id,
 
 void smr_format_inject(struct smr_cmd *cmd, fi_addr_t peer_id,
 		       const struct iovec *iov, size_t count,
-		       void *context, uint32_t op, uint64_t tag,
-		       uint64_t data, uint16_t op_flags,
-		       struct smr_region *smr,
+		       uint32_t op, uint64_t tag, uint64_t data,
+		       uint16_t op_flags, struct smr_region *smr,
 		       struct smr_inject_buf *tx_buf)
 {
-	smr_generic_format(cmd, peer_id, context, op, tag, 0, 0,
-			   data, op_flags);
+	smr_generic_format(cmd, peer_id, op, tag, 0, 0, data, op_flags);
 	cmd->msg.hdr.op_src = smr_src_inject;
 	cmd->msg.hdr.src_data = (char **) tx_buf - (char **) smr;
 	cmd->msg.hdr.size = ofi_copy_from_iov(tx_buf->data, SMR_INJECT_SIZE,
@@ -279,21 +249,24 @@ void smr_format_inject(struct smr_cmd *cmd, fi_addr_t peer_id,
 }
 
 void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
-		    const struct iovec *iov, size_t count,
-		    size_t total_len, void *context, uint32_t op,
-		    uint64_t tag, uint64_t data, uint16_t op_flags,
-		    struct smr_region *smr,
-		    struct smr_resp *resp)
+		    const struct iovec *iov, size_t count, size_t total_len,
+		    uint32_t op, uint64_t tag, uint64_t data, uint16_t op_flags,
+		    struct smr_region *smr, struct smr_resp *resp,
+		    struct smr_cmd *pend_cmd)
 {
-	smr_generic_format(cmd, peer_id, context, op, tag, 0, 0, data, op_flags);
+	smr_generic_format(cmd, peer_id, op, tag, 0, 0, data, op_flags);
 	cmd->msg.hdr.op_src = smr_src_iov;
-	resp->status = FI_EBUSY;
-	resp->msg_id = (uint64_t) context;
 	cmd->msg.hdr.src_data = (uint64_t) ((char **) resp - (char **) smr);
 	cmd->msg.data.iov_count = count;
 	cmd->msg.hdr.size = total_len;
-
+	cmd->msg.hdr.msg_id = (uint64_t) (uintptr_t) pend_cmd;
 	memcpy(cmd->msg.data.iov, iov, sizeof(*iov) * count);
+
+	*pend_cmd = *cmd;
+
+	resp->msg_id = cmd->msg.hdr.msg_id;
+	resp->status = FI_EBUSY;
+
 }
 
 static int smr_ep_close(struct fid *fid)
@@ -483,10 +456,9 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ep->recv_fs = smr_recv_fs_create(info->rx_attr->size);
 	ep->unexp_fs = smr_unexp_fs_create(info->rx_attr->size);
 	ep->pend_fs = smr_pend_fs_create(info->tx_attr->size);
-	smr_init_recv_queue(&ep->recv_queue, smr_match_msg);
-	smr_init_recv_queue(&ep->trecv_queue, smr_match_tagged);
-	smr_init_pending_queue(&ep->unexp_queue, smr_match_unexp);
-	smr_init_pending_queue(&ep->pend_queue, smr_match_cmd_ctx);
+	smr_init_queue(&ep->recv_queue, smr_match_msg);
+	smr_init_queue(&ep->trecv_queue, smr_match_tagged);
+	smr_init_queue(&ep->unexp_queue, smr_match_unexp);
 
 	ep->util_ep.ep_fid.fid.ops = &smr_ep_fi_ops;
 	ep->util_ep.ep_fid.ops = &smr_ep_ops;


### PR DESCRIPTION
- implement fi_cancel
- eliminate the need for FI_CONTEXT mode by setting the msg_id internally using the pending cmd address
- update man/fi_shm to reflect current support

Signed-off-by: aingerson <alexia.ingerson@intel.com>