### PR TITLE
prov/psm2: Re-arrange how we use tag bits to support remote CQ data.

### DIFF
--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -456,7 +456,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				break;
 
 			case PSMX2_RECV_CONTEXT:
-				if (OFI_UNLIKELY((PSMX2_STATUS_TAG(status).tag2 & PSMX2_IOV_BIT) &&
+				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 						  !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
 					continue;
@@ -465,9 +465,9 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					op_context = fi_context;
 					buf = PSMX2_CTXT_USER(fi_context);
 					flags = psmx2_comp_flags[context_type];
-					if (PSMX2_STATUS_TAG(status).tag2 & PSMX2_IMM_BIT) {
+					if (PSMX2_HAS_IMM(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status)))) {
 						flags |= FI_REMOTE_CQ_DATA;
-						data = PSMX2_GET_TAG64(PSMX2_STATUS_TAG(status));
+						data = PSMX2_GET_CQDATA(PSMX2_STATUS_TAG(status));
 					} else {
 						data = 0;
 					}
@@ -487,7 +487,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				break;
 
 			case PSMX2_TRECV_CONTEXT:
-				if (OFI_UNLIKELY((PSMX2_STATUS_TAG(status).tag2 & PSMX2_IOV_BIT) &&
+				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
 					continue;
@@ -496,9 +496,15 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					op_context = fi_context;
 					buf = PSMX2_CTXT_USER(fi_context);
 					flags = psmx2_comp_flags[context_type];
+					if (PSMX2_HAS_IMM(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status)))) {
+						flags |= FI_REMOTE_CQ_DATA;
+						data = PSMX2_GET_CQDATA(PSMX2_STATUS_TAG(status));
+					} else {
+						data = 0;
+					}
 					err = psmx2_cq_rx_complete(
 							cq, ep->recv_cq, ep->av,
-							status, op_context, buf, flags, 0,
+							status, op_context, buf, flags, data,
 							event_in, count, &read_count,
 							&read_more, src_addr);
 					if (err) {
@@ -512,7 +518,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				break;
 
 			case PSMX2_NOCOMP_RECV_CONTEXT:
-				if (OFI_UNLIKELY((PSMX2_STATUS_TAG(status).tag2 & PSMX2_IOV_BIT) &&
+				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
@@ -523,9 +529,9 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					op_context = NULL;
 					buf = NULL;
 					flags = psmx2_comp_flags[context_type];
-					if (PSMX2_STATUS_TAG(status).tag2 & PSMX2_IMM_BIT) {
+					if (PSMX2_HAS_IMM(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status)))) {
 						flags |= FI_REMOTE_CQ_DATA;
-						data = PSMX2_GET_TAG64(PSMX2_STATUS_TAG(status));
+						data = PSMX2_GET_CQDATA(PSMX2_STATUS_TAG(status));
 					} else {
 						data = 0;
 					}
@@ -545,7 +551,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				break;
 
 			case PSMX2_NOCOMP_TRECV_CONTEXT:
-				if (OFI_UNLIKELY((PSMX2_STATUS_TAG(status).tag2 & PSMX2_IOV_BIT) &&
+				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
@@ -692,7 +698,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				break;
 
 			case PSMX2_MULTI_RECV_CONTEXT:
-				if (OFI_UNLIKELY((PSMX2_STATUS_TAG(status).tag2 & PSMX2_IOV_BIT) &&
+				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 				    !psmx2_handle_sendv_req(ep, status, 1))) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
 					continue;
@@ -702,9 +708,9 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					op_context = fi_context;
 					buf = multi_recv_req->buf + multi_recv_req->offset;
 					flags = psmx2_comp_flags[context_type];
-					if (PSMX2_STATUS_TAG(status).tag2 & PSMX2_IMM_BIT) {
+					if (PSMX2_HAS_IMM(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status)))) {
 						flags |= FI_REMOTE_CQ_DATA;
-						data = PSMX2_GET_TAG64(PSMX2_STATUS_TAG(status));
+						data = PSMX2_GET_CQDATA(PSMX2_STATUS_TAG(status));
 					} else {
 						data = 0;
 					}

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -221,7 +221,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	enum fi_progress control_progress = FI_PROGRESS_MANUAL;
 	enum fi_progress data_progress = FI_PROGRESS_MANUAL;
 	uint64_t caps = PSMX2_CAPS;
-	uint64_t max_tag_value = -1ULL;
+	uint64_t max_tag_value = PSMX2_MAX_TAG;
 	int err = -FI_ENODATA;
 	int svc0, svc = PSMX2_ANY_SERVICE;
 	glob_t glob_buf;

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -71,8 +71,8 @@ ssize_t psmx2_recv_generic(struct fid_ep *ep, void *buf, size_t len,
 		psm2_epaddr = 0;
 	}
 
-	PSMX2_SET_TAG(psm2_tag, 0ULL, PSMX2_MSG_BIT);
-	PSMX2_SET_TAG(psm2_tagsel, 0ULL, ~(PSMX2_IOV_BIT | PSMX2_IMM_BIT));
+	PSMX2_SET_TAG(psm2_tag, 0ULL, 0, PSMX2_MSG_BIT);
+	PSMX2_SET_IGNORE_MASK(psm2_tagsel, -1ULL);
 
 	enable_completion = !ep_priv->recv_selective_completion ||
 			    (flags & FI_COMPLETION);
@@ -206,13 +206,13 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 	psm2_epaddr_t psm2_epaddr;
 	psm2_mq_req_t psm2_req;
 	psm2_mq_tag_t psm2_tag;
-	uint32_t tag32;
 	struct fi_context * fi_context;
 	int send_flag = 0;
 	int err;
 	size_t idx;
 	int no_completion = 0;
 	struct psmx2_cq_event *event;
+	int have_data = (flags & FI_REMOTE_CQ_DATA) > 0;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -233,10 +233,7 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 		psm2_epaddr = PSMX2_ADDR_TO_EP(dest_addr);
 	}
 
-	tag32 = PSMX2_MSG_BIT;
-	if (flags & FI_REMOTE_CQ_DATA)
-		tag32 |= PSMX2_IMM_BIT;
-	PSMX2_SET_TAG(psm2_tag, data, tag32);
+	PSMX2_SET_TAG(psm2_tag, 0, data, PSMX2_IMM_BIT_SET(have_data) | PSMX2_MSG_BIT);
 
 	if ((flags & PSMX2_NO_COMPLETION) ||
 	    (ep_priv->send_selective_completion && !(flags & FI_COMPLETION)))
@@ -388,7 +385,8 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 
 	if (flags & FI_REMOTE_CQ_DATA)
 		tag32 |= PSMX2_IMM_BIT;
-	PSMX2_SET_TAG(psm2_tag, data, tag32);
+
+	PSMX2_SET_TAG(psm2_tag, 0ULL, data, tag32);
 
 	if ((flags & PSMX2_NO_COMPLETION) ||
 	    (ep_priv->send_selective_completion && !(flags & FI_COMPLETION)))
@@ -454,9 +452,7 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 		PSMX2_CTXT_TYPE(fi_context) = PSMX2_IOV_SEND_CONTEXT;
 		PSMX2_CTXT_USER(fi_context) = req;
 		PSMX2_CTXT_EP(fi_context) = ep_priv;
-		tag32 &= ~PSMX2_IOV_BIT;
-		PSMX2_TAG32_SET_SEQ(tag32, req->iov_info.seq_num);
-		PSMX2_SET_TAG(psm2_tag, data, tag32);
+		PSMX2_SET_TAG(psm2_tag, req->iov_info.seq_num, 0, PSMX2_IOV_PAYLOAD_BITS);
 		for (i=0; i<count; i++) {
 			if (iov[i].iov_len) {
 				err = psm2_mq_isend2(ep_priv->tx->psm2_mq,
@@ -524,17 +520,16 @@ int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
 	PSMX2_CTXT_USER(fi_context) = rep;
 	PSMX2_CTXT_EP(fi_context) = ep;
 
-	/* use the same tag, with IOV bit cleared, and seq_num added */
-	psm2_tag = PSMX2_STATUS_TAG(status);
-	psm2_tag.tag2 &= ~PSMX2_IOV_BIT;
-	PSMX2_TAG32_SET_SEQ(psm2_tag.tag2, rep->iov_info.seq_num);
-
-	rep->comp_flag = (psm2_tag.tag2 & PSMX2_MSG_BIT) ? FI_MSG : FI_TAGGED;
-	if (psm2_tag.tag2 & PSMX2_IMM_BIT)
+	rep->comp_flag = (PSMX2_GET_FLAGS(psm2_tag) & PSMX2_MSG_BIT) ? FI_MSG : FI_TAGGED;
+	if (PSMX2_GET_FLAGS(psm2_tag) & PSMX2_IMM_BIT)
 		rep->comp_flag |= FI_REMOTE_CQ_DATA;
 
-	/* match every bit of the tag */
-	PSMX2_SET_TAG(psm2_tagsel, -1UL, -1);
+	/* IOV payload uses a sequence number in place of a tag. */
+	PSMX2_SET_TAG(psm2_tag,
+			rep->iov_info.seq_num,
+			0,
+			PSMX2_IOV_PAYLOAD_BITS);
+	PSMX2_IOV_PAYLOAD_SET_IGNORE_MASK(psm2_tagsel, 0);
 
 	for (i=0; i<rep->iov_info.count; i++) {
 		if (recv_len) {
@@ -551,7 +546,7 @@ int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
 			recv_buf += len;
 			recv_len -= len;
 		} else {
-			/* recv buffer full, pust empty recvs */
+			/* recv buffer full, post empty recvs */
 			err = psm2_mq_irecv2(ep->rx->psm2_mq,
 					     PSMX2_STATUS_PEER(status),
 					     &psm2_tag, &psm2_tagsel,


### PR DESCRIPTION
With this change, we use 32 bits of PSM2's 96 bit tag for remote CQ
data, 4 bits for internal metadata, and 60 bits for the OFI tag.

This also enables fi_tsenddata.