### PR TITLE
build/sockets: Fix DL build with PMEM extensions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ common_srcs =				\
 	src/rbtree.c			\
 	src/fasthash.c			\
 	src/indexer.c			\
+	src/mem.c			\
 	src/iov.c			\
 	prov/util/src/util_atomic.c	\
 	prov/util/src/util_attr.c	\
@@ -149,7 +150,6 @@ src_libfabric_la_SOURCES =			\
 	src/fabric.c				\
 	src/fi_tostr.c				\
 	src/perf.c				\
-	src/mem.c				\
 	src/log.c				\
 	src/var.c				\
 	src/abi_1_0.c				\

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -754,6 +754,10 @@ struct fi_provider sock_prov = {
 
 SOCKETS_INI
 {
+#if HAVE_SOCKETS_DL
+	ofi_pmem_init();
+#endif
+
 	fi_param_define(&sock_prov, "pe_waittime", FI_PARAM_INT,
 			"How many milliseconds to spin while waiting for progress");
 


### PR DESCRIPTION
Move mem.c to common sources file.  This is needed for DL
provider builds.  Call pmem_init() routine for socket provider
DL builds.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>