### PR TITLE
util/av: Handle a named AV

### DIFF
--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -540,6 +540,11 @@ static int util_verify_av_attr(struct util_domain *domain,
 		return -FI_EINVAL;
 	}
 
+	if (attr->name) {
+		FI_WARN(domain->prov, FI_LOG_AV, "Shared AV is unsupported\n");
+		return -FI_ENOSYS;
+	}
+
 	if (attr->flags & ~(FI_EVENT | FI_READ | FI_SYMMETRIC)) {
 		FI_WARN(domain->prov, FI_LOG_AV, "invalid flags\n");
 		return -FI_EINVAL;


### PR DESCRIPTION
Currently utility AV implementation doesn't support Shared AV. If user sets `fi_av_attr::name` we should report that a named AV isn't supported.
This patch fixes this behavior by returning `-FI_ENOSYS` value in `fi_av_open()`

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>