### PR TITLE
util/wait: Update ofi_trywait to handle counter's wait fd

### DIFF
--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -42,6 +42,7 @@ int ofi_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
 {
 	struct util_cq *cq;
 	struct util_eq *eq;
+	struct util_cntr *cntr;
 	struct util_wait *wait;
 	int i, ret;
 
@@ -56,7 +57,9 @@ int ofi_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
 			wait = eq->wait;
 			break;
 		case FI_CLASS_CNTR:
-			return -FI_ENOSYS;
+			cntr = container_of(fids[i], struct util_cntr, cntr_fid.fid);
+			wait = cntr->wait;
+			break;
 		case FI_CLASS_WAIT:
 			wait = container_of(fids[i], struct util_wait, wait_fid.fid);
 			break;


### PR DESCRIPTION
This PR updates `ofi_trywait()` to handle counter's wait fds

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>