### PR TITLE
prov/rxm: Report FI_MULTI_RECV flag when buffer is completely consumed

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -278,6 +278,7 @@ struct rxm_recv_entry {
 	uint64_t ignore;
 	uint64_t comp_flags;
 	size_t total_len;
+	void *multi_recv_buf;
 };
 DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -567,6 +567,7 @@ rxm_ep_format_rx_res(struct rxm_ep *rxm_ep, const struct iovec *iov,
 	(*recv_entry)->flags 		= flags;
 	(*recv_entry)->ignore 		= ignore;
 	(*recv_entry)->tag		= tag;
+	(*recv_entry)->multi_recv_buf	= iov[0].iov_base;
 
 	for (i = 0; i < count; i++) {
 		(*recv_entry)->rxm_iov.iov[i].iov_base = iov[i].iov_base;


### PR DESCRIPTION
The man page [fi_cq(3)](https://ofiwg.github.io/libfabric/master/man/fi_cq.3.html) says that providers have to handle multi_recv in the following way:

"..._This completion flag indicates that the original receive buffer referenced by the completion has been consumed and was released by the provider. Providers may set this flag on the last message that is received into the multi- recv buffer, or may generate a separate completion that indicates that the buffer has been released._"

Align implementation of RxM's Multi_recv feature with defined behavior in man page:
When the buffer is consumed, the RxM provider generates separate CQ with only `FI_MULTI_RECV` flag set and points `cq::buf` at the begging of multi-recv buffer.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>