### PR TITLE
prov/psm2: Follow-up patches for supporting remote CQ data over tagged messages

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -103,11 +103,14 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_COMP_ORDER	FI_ORDER_NONE
 
 /*
+ * Four bits are reserved from the 64-bit tag space as a flags to identify the
+ * type and properties of the messages.
+ *
  * To conserve tag bits, we use a couple otherwise invalid bit combinations
  * to distinguish RMA long reads from long writes and distinguish iovec
  * payloads from regular messages.
  *
- * We never match on the immediate bit.  Regular tagged and untagged messages
+ * We never match on the immediate bit. Regular tagged and untagged messages
  * do not match on the iov bit, but the iov and imm bits are checked when we
  * process completions.
  *
@@ -123,32 +126,33 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_RMA_BIT		(0x40000000)
 #define PSMX2_IOV_BIT		(0x20000000)
 #define PSMX2_IMM_BIT		(0x10000000)
-#define PSMX2_IOV_PAYLOAD_BITS	(PSMX2_MSG_BIT | PSMX2_RMA_BIT)
 
-/* Set which flag bits to match on for tagged/msg.  IMM and IOV bits are ignored. */
-#define PSMX2_FLAG_MATCH_MASK \
-		(PSMX2_MSG_BIT | PSMX2_RMA_BIT | PSMX2_IOV_PAYLOAD_BITS)
-
-#define PSMX2_AM_FLAG_MATCH_MASK \
-		(PSMX2_MSG_BIT | PSMX2_RMA_BIT | PSMX2_IOV_BIT | PSMX2_LONG_READ_BIT | PSMX2_LONG_WRITE_BIT)
-
-#define PSMX2_IOV_PAYLOAD_FLAG_MATCH_MASK \
-		(PSMX2_MSG_BIT | PSMX2_RMA_BIT)
-
-#define PSMX2_IS_IOV_HEADER(flags) (((flags) & PSMX2_IOV_BIT) && !((flags) & PSMX2_RMA_BIT))
-#define PSMX2_IS_IOV_PAYLOAD(flags) (((flags) & PSMX2_IOV_PAYLOAD_FLAG_MATCH_MASK) == PSMX2_RMA_BIT | PSMX2_MSG_BIT)
-#define PSMX2_IS_RMA(flags) (((flags) & PSMX2_RMA_BIT) && !((flags) & PSMX2_MSG_BIT))
-#define PSMX2_IS_MSG(flags) ((flags) & PSMX2_FLAG_MATCH_MASK == PSMX2_MSG_BIT
-#define PSMX2_IS_TAGGED(flags) ((flags) & PSMX2_FLAG_MATCH_MASK == 0)
-#define PSMX2_HAS_IMM(flags) ((flags) & PSMX2_IMM_BIT)
+/* Top two bits of the flag are the message type */
+#define PSMX2_TYPE_TAGGED	(0)
+#define PSMX2_TYPE_MSG		PSMX2_MSG_BIT
+#define PSMX2_TYPE_RMA		PSMX2_RMA_BIT
+#define PSMX2_TYPE_IOV_PAYLOAD	(PSMX2_MSG_BIT | PSMX2_RMA_BIT)
+#define PSMX2_TYPE_MASK		(PSMX2_MSG_BIT | PSMX2_RMA_BIT)
 
 /*
- * When using the long RMA protocol, set IOV to indicate the operation
- * is a long write.  This prevents tag collisions with long reads.
- * IOV isn't used with rma, so that bit is safe to reuse.
+ * For RMA protocol, use the IOV bit to distinguish between long RMA write
+ * and long RMA read. This prevents tag collisions between reads/writes issued
+ * locally and the writes/reads issued by peers. RMA doesn't use this bit for
+ * IOV support so it's safe to do so.
  */
-#define PSMX2_LONG_READ_BIT	0
-#define PSMX2_LONG_WRITE_BIT	PSMX2_IOV_BIT
+#define PSMX2_RMA_TYPE_READ	PSMX2_TYPE_RMA
+#define PSMX2_RMA_TYPE_WRITE	(PSMX2_TYPE_RMA | PSMX2_IOV_BIT)
+#define PSMX2_RMA_TYPE_MASK	(PSMX2_TYPE_MASK | PSMX2_IOV_BIT)
+
+/* IOV header is only possible when the RMA bit is 0 */
+#define PSMX2_IOV_HEADER_MASK		(PSMX2_IOV_BIT | PSMX2_RMA_BIT)
+
+#define PSMX2_IS_IOV_HEADER(flags)	(((flags) & PSMX2_IOV_HEADER_MASK) == PSMX2_IOV_BIT)
+#define PSMX2_IS_IOV_PAYLOAD(flags)	(((flags) & PSMX2_TYPE_MASK) == PSMX2_TYPE_IOV_PAYLOAD)
+#define PSMX2_IS_RMA(flags)		(((flags) & PSMX2_TYPE_MASK) == PSMX2_TYPE_RMA)
+#define PSMX2_IS_MSG(flags)		(((flags) & PSMX2_TYPE_MASK) == PSMX2_TYPE_MSG)
+#define PSMX2_IS_TAGGED(flags)		(((flags) & PSMX2_TYPE_MASK) == PSMX2_TYPE_TAGGED)
+#define PSMX2_HAS_IMM(flags)		((flags) & PSMX2_IMM_BIT)
 
 /* Set a bit conditionally without branching.  Flag must be 1 or 0. */
 #define PSMX2_MSG_BIT_SET(flag) (-(uint32_t)flag & PSMX2_MSG_BIT)
@@ -156,49 +160,34 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_IOV_BIT_SET(flag) (-(uint32_t)flag & PSMX2_IOV_BIT)
 #define PSMX2_IMM_BIT_SET(flag) (-(uint32_t)flag & PSMX2_IMM_BIT)
 
-/* Top 32 bits of tag mask. */
-#define PSMX2_TAG_UPPER_MASK	((uint32_t)0x0fffffff)
-
-/* Whole 64 bits of tag mask. */
-#define PSMX2_TAG_FULL_MASK	((uint64_t)(((uint64_t)PSMX2_TAG_UPPER_MASK << 32) | 0xffffffff))
-
-#define PSMX2_MAX_TAG		PSMX2_TAG_FULL_MASK
-#define PSMX2_IGNORE_ALL	((~(uint64_t)PSMX2_FLAG_MATCH_MASK << 32) | 0xffffffff)
+#define PSMX2_TAG_UPPER_MASK	((uint32_t)0x0FFFFFFF)
+#define PSMX2_TAG_MASK		(0x0FFFFFFFFFFFFFFFULL)
+#define PSMX2_MAX_TAG		PSMX2_TAG_MASK
+#define PSMX2_MATCH_ALL		(-1ULL)
+#define PSMX2_MATCH_NONE	(0ULL)
 
 #define PSMX2_PRINT_TAG(tag96) \
-	printf("%s %x %x %x\n", __func__, tag96.tag0, tag96.tag1, tag96.tag2)
+	printf("%s: %08x %08x %08x\n", __func__, tag96.tag0, tag96.tag1, tag96.tag2)
 
-#define PSMX2_SET_TAG(tag96,tag,cq_data,flags) \
+#define PSMX2_SET_TAG_INTERNAL(tag96,tag,cq_data,flags) \
 	do { \
 		(tag96).tag0 = (uint32_t)(tag); \
-		(tag96).tag1 = (uint32_t) ( \
-				(((uint32_t)((uint64_t)(tag) >> 32)) & PSMX2_TAG_UPPER_MASK) | \
-				  ((flags) & ~PSMX2_TAG_UPPER_MASK) \
-		             ); \
+		(tag96).tag1 = (uint32_t)((((uint64_t)(tag) >> 32) & \
+					   PSMX2_TAG_UPPER_MASK) | (flags)); \
 		(tag96).tag2 = (cq_data); \
 	} while (0)
 
-#define PSMX2_SET_IGNORE_MASK_INTERNAL(tag96,ignore,ignore_mask) \
-	do { \
-		(tag96).tag0 = (uint32_t)~(ignore); \
-		(tag96).tag1 = (uint32_t) (\
-				((~(uint64_t)(ignore) >> 32) & PSMX2_TAG_UPPER_MASK) | (ignore_mask) \
-		             );\
-		(tag96).tag2 = 0; \
-	} while (0)
+#define PSMX2_SET_TAG(tag96,tag,cq_data,flags) \
+	PSMX2_SET_TAG_INTERNAL(tag96,tag,cq_data,flags)
 
-#define PSMX2_SET_IGNORE_MASK(tag96,ignore) \
-		PSMX2_SET_IGNORE_MASK_INTERNAL(tag96,ignore,PSMX2_FLAG_MATCH_MASK)
+#define PSMX2_SET_MASK(tagsel96,tag_mask,flag_mask) \
+	PSMX2_SET_TAG_INTERNAL(tagsel96,tag_mask,0,flag_mask)
 
-#define PSMX2_AM_SET_IGNORE_MASK(tag96,ignore) \
-		PSMX2_SET_IGNORE_MASK_INTERNAL(tag96,ignore,PSMX2_AM_FLAG_MATCH_MASK)
+#define PSMX2_GET_TAG64(tag96) \
+	((tag96).tag0 | ((uint64_t)((tag96).tag1 & PSMX2_TAG_UPPER_MASK)<<32))
 
-#define PSMX2_IOV_PAYLOAD_SET_IGNORE_MASK(tag96,ignore) \
-		PSMX2_SET_IGNORE_MASK_INTERNAL(tag96,ignore,PSMX2_IOV_PAYLOAD_FLAG_MATCH_MASK)
-
-#define PSMX2_GET_TAG64(tag96)		((tag96).tag0 | ((uint64_t)((tag96).tag1 & PSMX2_TAG_UPPER_MASK)<<32))
-#define PSMX2_GET_FLAGS(tag96)		((tag96).tag1 & ~PSMX2_TAG_UPPER_MASK)
-#define PSMX2_GET_CQDATA(tag96)		((tag96).tag2)
+#define PSMX2_GET_FLAGS(tag96)	((tag96).tag1 & ~PSMX2_TAG_UPPER_MASK)
+#define PSMX2_GET_CQDATA(tag96)	((tag96).tag2)
 
 /*
  * Canonical virtual address on X86_64 only uses 48 bits and the higher 16 bits
@@ -746,21 +735,21 @@ static inline void psmx2_unlock(fastlock_t *lock, int lock_level)
 }
 
 int	psmx2_fabric(struct fi_fabric_attr *attr,
-		    struct fid_fabric **fabric, void *context);
+		     struct fid_fabric **fabric, void *context);
 int	psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
-			 struct fid_domain **domain, void *context);
+			  struct fid_domain **domain, void *context);
 int	psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
-		     struct fid_ep **ep, void *context);
+		      struct fid_ep **ep, void *context);
 int	psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 		       struct fid_ep **sep, void *context);
 int	psmx2_stx_ctx(struct fid_domain *domain, struct fi_tx_attr *attr,
-		     struct fid_stx **stx, void *context);
+		      struct fid_stx **stx, void *context);
 int	psmx2_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
-		     struct fid_cq **cq, void *context);
+		      struct fid_cq **cq, void *context);
 int	psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
-		     struct fid_av **av, void *context);
+		      struct fid_av **av, void *context);
 int	psmx2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
-		       struct fid_cntr **cntr, void *context);
+		        struct fid_cntr **cntr, void *context);
 int	psmx2_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 			struct fid_wait **waitset);
 int	psmx2_wait_trywait(struct fid_fabric *fabric, struct fid **fids,
@@ -822,12 +811,12 @@ void	psmx2_query_mpi(void);
 
 void	psmx2_cq_enqueue_event(struct psmx2_fid_cq *cq, struct psmx2_cq_event *event);
 struct	psmx2_cq_event *psmx2_cq_create_event(struct psmx2_fid_cq *cq,
-					void *op_context, void *buf,
-					uint64_t flags, size_t len,
-					uint64_t data, uint64_t tag,
-					size_t olen, int err);
+					      void *op_context, void *buf,
+					      uint64_t flags, size_t len,
+					      uint64_t data, uint64_t tag,
+					      size_t olen, int err);
 int	psmx2_cq_poll_mq(struct psmx2_fid_cq *cq, struct psmx2_trx_ctxt *trx_ctxt,
-			struct psmx2_cq_event *event, int count, fi_addr_t *src_addr);
+			 struct psmx2_cq_event *event, int count, fi_addr_t *src_addr);
 
 int	psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,
 			     psm2_epid_t epid, psm2_epaddr_t *epaddr);
@@ -870,9 +859,9 @@ int	psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt);
 void	psmx2_am_fini(struct psmx2_trx_ctxt *trx_ctxt);
 int	psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt);
 int	psmx2_am_process_send(struct psmx2_trx_ctxt *trx_ctxt,
-				struct psmx2_am_request *req);
+			      struct psmx2_am_request *req);
 int	psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
-				struct psmx2_am_request *req);
+			     struct psmx2_am_request *req);
 int	psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 			     int nargs, void *src, uint32_t len,
 			     void *hctx);
@@ -882,8 +871,8 @@ int	psmx2_am_atomic_handler(psm2_am_token_t token,
 int	psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args, int nargs,
 			     void *src, uint32_t len, void *hctx);
 int	psmx2_am_trx_ctxt_handler(psm2_am_token_t token,
-				      psm2_amarg_t *args, int nargs, void *src, uint32_t len,
-				      void *hctx);
+				  psm2_amarg_t *args, int nargs, void *src, uint32_t len,
+				  void *hctx);
 void	psmx2_atomic_global_init(void);
 void	psmx2_atomic_global_fini(void);
 

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -544,8 +544,8 @@ int psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 
 	if ((req->op & PSMX2_AM_OP_MASK) == PSMX2_AM_REQ_WRITE_LONG) {
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req->write.context, 0,
-				PSMX2_LONG_WRITE_BIT | PSMX2_RMA_BIT);
-		PSMX2_AM_SET_IGNORE_MASK(psm2_tagsel, 0ULL);
+			      PSMX2_RMA_TYPE_WRITE);
+		PSMX2_SET_MASK(psm2_tagsel, PSMX2_MATCH_ALL, PSMX2_RMA_TYPE_MASK);
 		err = psm2_mq_irecv2(trx_ctxt->psm2_mq,
 				     (psm2_epaddr_t)req->write.peer_addr,
 				     &psm2_tag, &psm2_tagsel, 0,
@@ -553,7 +553,7 @@ int psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 				     (void *)&req->fi_context, &psm2_req);
 	} else {
 		PSMX2_SET_TAG(psm2_tag, (uint64_t)req->read.context, 0,
-				PSMX2_LONG_READ_BIT | PSMX2_RMA_BIT);
+			      PSMX2_RMA_TYPE_READ);
 		err = psm2_mq_isend2(trx_ctxt->psm2_mq,
 				     (psm2_epaddr_t)req->read.peer_addr,
 				     0, &psm2_tag,
@@ -639,8 +639,8 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	args[0].u32w0 = 0;
 
 	if (psmx2_env.tagged_rma && len > chunk_size) {
-		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, 0, PSMX2_RMA_BIT | PSMX2_LONG_READ_BIT);
-		PSMX2_AM_SET_IGNORE_MASK(psm2_tagsel, 0ULL);
+		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, 0, PSMX2_RMA_TYPE_READ);
+		PSMX2_SET_MASK(psm2_tagsel, PSMX2_MATCH_ALL, PSMX2_RMA_TYPE_MASK);
 		psm2_mq_irecv2(ep_priv->tx->psm2_mq, psm2_epaddr,
 			       &psm2_tag, &psm2_tagsel, 0, buf, len,
 			       (void *)&req->fi_context, &psm2_req);
@@ -805,8 +805,8 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 
 	/* Use the long protocol for the last segment */
 	if (long_len) {
-		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, 0, PSMX2_RMA_BIT | PSMX2_LONG_READ_BIT);
-		PSMX2_AM_SET_IGNORE_MASK(psm2_tagsel, 0ULL);
+		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, 0, PSMX2_RMA_TYPE_READ);
+		PSMX2_SET_MASK(psm2_tagsel, PSMX2_MATCH_ALL, PSMX2_RMA_TYPE_MASK);
 		psm2_mq_irecv2(ep_priv->tx->psm2_mq, psm2_epaddr,
 			       &psm2_tag, &psm2_tagsel, 0,
 			       long_buf, long_len,
@@ -977,7 +977,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	args[0].u32w0 = 0;
 
 	if (psmx2_env.tagged_rma && len > chunk_size) {
-		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, 0, PSMX2_RMA_BIT | PSMX2_LONG_WRITE_BIT);
+		PSMX2_SET_TAG(psm2_tag, (uint64_t)req, 0, PSMX2_RMA_TYPE_WRITE);
 		PSMX2_AM_SET_OP(args[0].u32w0, PSMX2_AM_REQ_WRITE_LONG);
 		args[0].u32w1 = len;
 		args[1].u64 = (uint64_t)req;
@@ -1186,7 +1186,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 		/* Case 2.1: use long protocol for the last segment if it is large */
 		if (psmx2_env.tagged_rma && iov[i].iov_len > chunk_size &&
 		    len_sent + iov[i].iov_len == total_len) {
-			PSMX2_SET_TAG(psm2_tag, (uint64_t)req, 0, PSMX2_RMA_BIT | PSMX2_LONG_WRITE_BIT);
+			PSMX2_SET_TAG(psm2_tag, (uint64_t)req, 0, PSMX2_RMA_TYPE_WRITE);
 			PSMX2_AM_SET_OP(args[0].u32w0, PSMX2_AM_REQ_WRITE_LONG);
 			args[0].u32w1 = iov[i].iov_len;
 			args[1].u64 = (uint64_t)req;

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -295,12 +295,12 @@ ssize_t psmx2_tagged_recv_generic(struct fid_ep *ep, void *buf,
 __attribute__((always_inline))
 static inline ssize_t
 psmx2_tagged_recv_specialized(struct fid_ep *ep, void *buf, size_t len,
-		void *desc, fi_addr_t src_addr,
-		uint64_t tag, uint64_t ignore,
-		void *context,
-		int enable_completion,
-		enum fi_av_type av_type,
-		int directed_receive)
+			      void *desc, fi_addr_t src_addr,
+			      uint64_t tag, uint64_t ignore,
+			      void *context,
+			      int enable_completion,
+			      enum fi_av_type av_type,
+			      int directed_receive)
 {
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
@@ -382,9 +382,9 @@ psmx2_tagged_recv_specialized(struct fid_ep *ep, void *buf, size_t len,
 /* op_flags=0, FI_SELECTIVE_COMPLETION not set, FI_AV_MAP, FI_DIRECTED_RECEIVE not set */
 static ssize_t
 psmx2_tagged_recv_no_flag_av_map_undirected(struct fid_ep *ep, void *buf, size_t len,
-				 void *desc, fi_addr_t src_addr,
-				 uint64_t tag, uint64_t ignore,
-				 void *context)
+					    void *desc, fi_addr_t src_addr,
+					    uint64_t tag, uint64_t ignore,
+					    void *context)
 {
 	return psmx2_tagged_recv_specialized(ep, buf, len, desc,
 			src_addr, tag, ignore, context, 1, FI_AV_MAP, 0);
@@ -393,9 +393,9 @@ psmx2_tagged_recv_no_flag_av_map_undirected(struct fid_ep *ep, void *buf, size_t
 /* op_flags=0, FI_SELECTIVE_COMPLETION not set, FI_AV_TABLE, FI_DIRECTED_RECEIVE not set */
 static ssize_t
 psmx2_tagged_recv_no_flag_av_table_undirected(struct fid_ep *ep, void *buf, size_t len,
-				   void *desc, fi_addr_t src_addr,
-				   uint64_t tag, uint64_t ignore,
-				   void *context)
+					      void *desc, fi_addr_t src_addr,
+					      uint64_t tag, uint64_t ignore,
+					      void *context)
 {
 	return psmx2_tagged_recv_specialized(ep, buf, len, desc,
 			src_addr, tag, ignore, context, 1, FI_AV_TABLE, 0);
@@ -404,9 +404,9 @@ psmx2_tagged_recv_no_flag_av_table_undirected(struct fid_ep *ep, void *buf, size
 /* op_flags=0, FI_SELECTIVE_COMPLETION set, FI_AV_MAP, FI_DIRECTED_RECEIVE not set */
 static ssize_t
 psmx2_tagged_recv_no_event_av_map_undirected(struct fid_ep *ep, void *buf, size_t len,
-				  void *desc, fi_addr_t src_addr,
-				  uint64_t tag, uint64_t ignore,
-				  void *context)
+					     void *desc, fi_addr_t src_addr,
+					     uint64_t tag, uint64_t ignore,
+					     void *context)
 {
 	return psmx2_tagged_recv_specialized(ep, buf, len, desc,
 			src_addr, tag, ignore, context, 0, FI_AV_MAP, 0);
@@ -415,9 +415,9 @@ psmx2_tagged_recv_no_event_av_map_undirected(struct fid_ep *ep, void *buf, size_
 /* op_flags=0, FI_SELECTIVE_COMPLETION set, FI_AV_TABLE, FI_DIRECTED_RECEIVE not set */
 static ssize_t
 psmx2_tagged_recv_no_event_av_table_undirected(struct fid_ep *ep, void *buf, size_t len,
-				    void *desc, fi_addr_t src_addr,
-				    uint64_t tag, uint64_t ignore,
-				    void *context)
+					       void *desc, fi_addr_t src_addr,
+					       uint64_t tag, uint64_t ignore,
+					       void *context)
 {
 	return psmx2_tagged_recv_specialized(ep, buf, len, desc,
 			src_addr, tag, ignore, context, 0, FI_AV_TABLE, 0);
@@ -426,9 +426,9 @@ psmx2_tagged_recv_no_event_av_table_undirected(struct fid_ep *ep, void *buf, siz
 /* op_flags=0, FI_SELECTIVE_COMPLETION not set, FI_AV_MAP, FI_DIRECTED_RECEIVE set */
 static ssize_t
 psmx2_tagged_recv_no_flag_av_map_directed(struct fid_ep *ep, void *buf, size_t len,
-				 void *desc, fi_addr_t src_addr,
-				 uint64_t tag, uint64_t ignore,
-				 void *context)
+					  void *desc, fi_addr_t src_addr,
+					  uint64_t tag, uint64_t ignore,
+					  void *context)
 {
 	return psmx2_tagged_recv_specialized(ep, buf, len, desc,
 			src_addr, tag, ignore, context, 1, FI_AV_MAP, 1);
@@ -437,9 +437,9 @@ psmx2_tagged_recv_no_flag_av_map_directed(struct fid_ep *ep, void *buf, size_t l
 /* op_flags=0, FI_SELECTIVE_COMPLETION not set, FI_AV_TABLE, FI_DIRECTED_RECEIVE set */
 static ssize_t
 psmx2_tagged_recv_no_flag_av_table_directed(struct fid_ep *ep, void *buf, size_t len,
-				   void *desc, fi_addr_t src_addr,
-				   uint64_t tag, uint64_t ignore,
-				   void *context)
+					    void *desc, fi_addr_t src_addr,
+					    uint64_t tag, uint64_t ignore,
+					    void *context)
 {
 	return psmx2_tagged_recv_specialized(ep, buf, len, desc,
 			src_addr, tag, ignore, context, 1, FI_AV_TABLE, 1);
@@ -448,9 +448,9 @@ psmx2_tagged_recv_no_flag_av_table_directed(struct fid_ep *ep, void *buf, size_t
 /* op_flags=0, FI_SELECTIVE_COMPLETION set, FI_AV_MAP, FI_DIRECTED_RECEIVE set */
 static ssize_t
 psmx2_tagged_recv_no_event_av_map_directed(struct fid_ep *ep, void *buf, size_t len,
-				  void *desc, fi_addr_t src_addr,
-				  uint64_t tag, uint64_t ignore,
-				  void *context)
+					   void *desc, fi_addr_t src_addr,
+					   uint64_t tag, uint64_t ignore,
+					   void *context)
 {
 	return psmx2_tagged_recv_specialized(ep, buf, len, desc,
 			src_addr, tag, ignore, context, 0, FI_AV_MAP, 1);
@@ -459,9 +459,9 @@ psmx2_tagged_recv_no_event_av_map_directed(struct fid_ep *ep, void *buf, size_t 
 /* op_flags=0, FI_SELECTIVE_COMPLETION set, FI_AV_TABLE, FI_DIRECTED_RECEIVE set */
 static ssize_t
 psmx2_tagged_recv_no_event_av_table_directed(struct fid_ep *ep, void *buf, size_t len,
-				    void *desc, fi_addr_t src_addr,
-				    uint64_t tag, uint64_t ignore,
-				    void *context)
+					     void *desc, fi_addr_t src_addr,
+					     uint64_t tag, uint64_t ignore,
+					     void *context)
 {
 	return psmx2_tagged_recv_specialized(ep, buf, len, desc,
 			src_addr, tag, ignore, context, 0, FI_AV_TABLE, 1);
@@ -545,10 +545,10 @@ PSMX2_TAGGED_RECVV_FUNC(_no_event_av_table_undirected)
 
 
 ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
-		const void *buf, size_t len,
-		void *desc, fi_addr_t dest_addr,
-		uint64_t tag, void *context,
-		uint64_t flags, uint64_t data)
+				  const void *buf, size_t len,
+				  void *desc, fi_addr_t dest_addr,
+				  uint64_t tag, void *context,
+				  uint64_t flags, uint64_t data)
 {
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
@@ -652,11 +652,12 @@ ssize_t psmx2_tagged_send_generic(struct fid_ep *ep,
 __attribute__((always_inline))
 static inline ssize_t
 psmx2_tagged_send_specialized(struct fid_ep *ep, const void *buf,
-		size_t len, void *desc,
-		fi_addr_t dest_addr, uint64_t tag,
-		void *context,
-		int enable_completion,
-		enum fi_av_type av_type)
+			      size_t len, void *desc,
+			      fi_addr_t dest_addr, uint64_t tag,
+			      void *context,
+			      int enable_completion,
+			      enum fi_av_type av_type,
+			      int has_data, uint64_t data)
 {
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
@@ -687,7 +688,10 @@ psmx2_tagged_send_specialized(struct fid_ep *ep, const void *buf,
 		}
 	}
 
-	PSMX2_SET_TAG(psm2_tag, tag, 0, PSMX2_TYPE_TAGGED);
+	if (has_data)
+		PSMX2_SET_TAG(psm2_tag, tag, data, PSMX2_TYPE_TAGGED | PSMX2_IMM_BIT);
+	else
+		PSMX2_SET_TAG(psm2_tag, tag, 0, PSMX2_TYPE_TAGGED);
 
 	if (enable_completion) {
 		fi_context = context;
@@ -714,54 +718,98 @@ psmx2_tagged_send_specialized(struct fid_ep *ep, const void *buf,
 /* op_flags=0, FI_SELECTIVE_COMPLETION not set, FI_AV_MAP */
 static ssize_t
 psmx2_tagged_send_no_flag_av_map(struct fid_ep *ep, const void *buf,
-		size_t len, void *desc,
-		fi_addr_t dest_addr, uint64_t tag,
-		void *context)
+				 size_t len, void *desc,
+				 fi_addr_t dest_addr, uint64_t tag,
+				 void *context)
 {
-	return psmx2_tagged_send_specialized(ep, buf, len, desc,
-			dest_addr, tag, context, 1, FI_AV_MAP);
+	return psmx2_tagged_send_specialized(ep, buf, len, desc, dest_addr,
+					     tag, context, 1, FI_AV_MAP, 0, 0);
 }
 
 /* op_flags=0, FI_SELECTIVE_COMPLETION not set, FI_AV_TABLE */
 static ssize_t
 psmx2_tagged_send_no_flag_av_table(struct fid_ep *ep, const void *buf,
-		size_t len, void *desc,
-		fi_addr_t dest_addr, uint64_t tag,
-		void *context)
+				   size_t len, void *desc,
+				   fi_addr_t dest_addr, uint64_t tag,
+				   void *context)
 {
-	return psmx2_tagged_send_specialized(ep, buf, len, desc,
-			dest_addr, tag, context, 1, FI_AV_TABLE);
+	return psmx2_tagged_send_specialized(ep, buf, len, desc, dest_addr, tag,
+					     context, 1, FI_AV_TABLE, 0, 0);
 }
 
 /* op_flags=0, FI_SELECTIVE_COMPLETION set, FI_AV_MAP */
 static ssize_t
 psmx2_tagged_send_no_event_av_map(struct fid_ep *ep, const void *buf,
-		size_t len, void *desc,
-		fi_addr_t dest_addr, uint64_t tag,
-		void *context)
+				  size_t len, void *desc,
+				  fi_addr_t dest_addr, uint64_t tag,
+				  void *context)
 {
-	return psmx2_tagged_send_specialized(ep, buf, len, desc,
-			dest_addr, tag, context, 0, FI_AV_MAP);
+	return psmx2_tagged_send_specialized(ep, buf, len, desc, dest_addr, tag,
+					     context, 0, FI_AV_MAP, 0, 0);
 }
 
 /* op_flags=0, FI_SELECTIVE_COMPLETION set, FI_AV_TABLE */
 static ssize_t
 psmx2_tagged_send_no_event_av_table(struct fid_ep *ep, const void *buf,
-		size_t len, void *desc,
-		fi_addr_t dest_addr, uint64_t tag,
-		void *context)
+				    size_t len, void *desc,
+				    fi_addr_t dest_addr, uint64_t tag,
+				    void *context)
 {
-	return psmx2_tagged_send_specialized(ep, buf, len, desc,
-			dest_addr, tag, context, 0, FI_AV_TABLE);
+	return psmx2_tagged_send_specialized(ep, buf, len, desc, dest_addr, tag,
+					     context, 0, FI_AV_TABLE, 0, 0);
+}
+
+/* op_flags=0, FI_SELECTIVE_COMPLETION not set, FI_AV_MAP */
+static ssize_t
+psmx2_tagged_senddata_no_flag_av_map(struct fid_ep *ep, const void *buf,
+				     size_t len, void *desc, uint64_t data,
+				     fi_addr_t dest_addr, uint64_t tag,
+				     void *context)
+{
+	return psmx2_tagged_send_specialized(ep, buf, len, desc, dest_addr, tag,
+					     context, 1, FI_AV_MAP, 1, data);
+}
+
+/* op_flags=0, FI_SELECTIVE_COMPLETION not set, FI_AV_TABLE */
+static ssize_t
+psmx2_tagged_senddata_no_flag_av_table(struct fid_ep *ep, const void *buf,
+				       size_t len, void *desc, uint64_t data,
+				       fi_addr_t dest_addr, uint64_t tag,
+				       void *context)
+{
+	return psmx2_tagged_send_specialized(ep, buf, len, desc, dest_addr, tag,
+					     context, 1, FI_AV_TABLE, 1, data);
+}
+
+/* op_flags=0, FI_SELECTIVE_COMPLETION set, FI_AV_MAP */
+static ssize_t
+psmx2_tagged_senddata_no_event_av_map(struct fid_ep *ep, const void *buf,
+				      size_t len, void *desc, uint64_t data,
+				      fi_addr_t dest_addr, uint64_t tag,
+				      void *context)
+{
+	return psmx2_tagged_send_specialized(ep, buf, len, desc, dest_addr, tag,
+					     context, 0, FI_AV_MAP, 1, data);
+}
+
+/* op_flags=0, FI_SELECTIVE_COMPLETION set, FI_AV_TABLE */
+static ssize_t
+psmx2_tagged_senddata_no_event_av_table(struct fid_ep *ep, const void *buf,
+					size_t len, void *desc, uint64_t data,
+					fi_addr_t dest_addr, uint64_t tag,
+					void *context)
+{
+	return psmx2_tagged_send_specialized(ep, buf, len, desc, dest_addr, tag,
+					     context, 0, FI_AV_TABLE, 1, data);
 }
 
 /* op_flags=0, FI_AV_MAP */
 __attribute__((always_inline))
 static inline ssize_t
 psmx2_tagged_inject_specialized(struct fid_ep *ep, const void *buf,
-		size_t len, fi_addr_t dest_addr,
-		uint64_t tag,
-		enum fi_av_type av_type)
+				size_t len, fi_addr_t dest_addr,
+				uint64_t tag, enum fi_av_type av_type,
+				int has_data, uint64_t data)
 {
 	struct psmx2_fid_ep *ep_priv;
 	struct psmx2_fid_av *av;
@@ -794,8 +842,10 @@ psmx2_tagged_inject_specialized(struct fid_ep *ep, const void *buf,
 		}
 	}
 
-	PSMX2_SET_TAG(psm2_tag, tag, 0, PSMX2_TYPE_TAGGED);
-
+	if (has_data)
+		PSMX2_SET_TAG(psm2_tag, tag, data, PSMX2_TYPE_TAGGED | PSMX2_IMM_BIT);
+	else
+		PSMX2_SET_TAG(psm2_tag, tag, 0, PSMX2_TYPE_TAGGED);
 
 	err = psm2_mq_send2(ep_priv->tx->psm2_mq, psm2_epaddr, 0,
 			    &psm2_tag, buf, len);
@@ -808,23 +858,45 @@ psmx2_tagged_inject_specialized(struct fid_ep *ep, const void *buf,
 
 	return 0;
 }
+
 /* op_flags=0, FI_AV_MAP */
 static ssize_t
 psmx2_tagged_inject_no_flag_av_map(struct fid_ep *ep, const void *buf,
-		size_t len, fi_addr_t dest_addr,
-		uint64_t tag)
+				   size_t len, fi_addr_t dest_addr,
+				   uint64_t tag)
 {
-	return psmx2_tagged_inject_specialized(ep, buf, len, dest_addr, tag, FI_AV_MAP);
+	return psmx2_tagged_inject_specialized(ep, buf, len, dest_addr, tag,
+					       FI_AV_MAP, 0, 0);
 }
-
 
 /* op_flags=0, FI_AV_TABLE */
 static ssize_t
 psmx2_tagged_inject_no_flag_av_table(struct fid_ep *ep, const void *buf,
-		size_t len, fi_addr_t dest_addr,
-		uint64_t tag)
+				     size_t len, fi_addr_t dest_addr,
+				     uint64_t tag)
 {
-	return psmx2_tagged_inject_specialized(ep, buf, len, dest_addr, tag, FI_AV_TABLE);
+	return psmx2_tagged_inject_specialized(ep, buf, len, dest_addr, tag,
+					       FI_AV_TABLE, 0, 0);
+}
+
+/* op_flags=0, FI_AV_MAP */
+static ssize_t
+psmx2_tagged_injectdata_no_flag_av_map(struct fid_ep *ep, const void *buf,
+				       size_t len, uint64_t data,
+				       fi_addr_t dest_addr, uint64_t tag)
+{
+	return psmx2_tagged_inject_specialized(ep, buf, len, dest_addr, tag,
+					       FI_AV_MAP, 1, data);
+}
+
+/* op_flags=0, FI_AV_TABLE */
+static ssize_t
+psmx2_tagged_injectdata_no_flag_av_table(struct fid_ep *ep, const void *buf,
+					 size_t len, uint64_t data,
+					 fi_addr_t dest_addr, uint64_t tag)
+{
+	return psmx2_tagged_inject_specialized(ep, buf, len, dest_addr, tag,
+					       FI_AV_TABLE, 1, data);
 }
 
 ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
@@ -1047,8 +1119,8 @@ static ssize_t psmx2_tagged_sendmsg(struct fid_ep *ep,
 }
 
 ssize_t psmx2_tagged_senddata(struct fid_ep *ep, const void *buf, size_t len,
-		void *desc, uint64_t data, fi_addr_t dest_addr, uint64_t tag,
-		void *context)
+			      void *desc, uint64_t data, fi_addr_t dest_addr,
+			      uint64_t tag, void *context)
 {
 	return psmx2_tagged_send_generic(ep, buf, len, desc, dest_addr,
 					 tag, context, FI_REMOTE_CQ_DATA, data);
@@ -1131,8 +1203,8 @@ struct fi_ops_tagged psmx2_tagged_ops##suffix = {	\
 	.sendv = psmx2_tagged_sendv##sendopt,		\
 	.sendmsg = psmx2_tagged_sendmsg,		\
 	.inject = psmx2_tagged_inject##injopt,		\
-	.senddata = psmx2_tagged_senddata,		\
-	.injectdata = psmx2_tagged_injectdata,		\
+	.senddata = psmx2_tagged_senddata##sendopt,	\
+	.injectdata = psmx2_tagged_injectdata##injopt,	\
 };
 
 PSMX2_TAGGED_OPS(,,,)

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -1106,6 +1106,21 @@ static ssize_t psmx2_tagged_inject(struct fid_ep *ep,
 					 0);
 }
 
+static ssize_t psmx2_tagged_injectdata(struct fid_ep *ep,
+				       const void *buf, size_t len, uint64_t data,
+				       fi_addr_t dest_addr, uint64_t tag)
+{
+	struct psmx2_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
+
+	return psmx2_tagged_send_generic(ep, buf, len, NULL, dest_addr,
+					 tag, NULL,
+					 ep_priv->tx_flags | FI_INJECT | FI_REMOTE_CQ_DATA |
+						  PSMX2_NO_COMPLETION,
+					 data);
+}
+
 #define PSMX2_TAGGED_OPS(suffix,sendopt,recvopt,injopt)	\
 struct fi_ops_tagged psmx2_tagged_ops##suffix = {	\
 	.size = sizeof(struct fi_ops_tagged),		\
@@ -1117,7 +1132,7 @@ struct fi_ops_tagged psmx2_tagged_ops##suffix = {	\
 	.sendmsg = psmx2_tagged_sendmsg,		\
 	.inject = psmx2_tagged_inject##injopt,		\
 	.senddata = psmx2_tagged_senddata,		\
-	.injectdata = fi_no_tagged_injectdata,		\
+	.injectdata = psmx2_tagged_injectdata,		\
 };
 
 PSMX2_TAGGED_OPS(,,,)


### PR DESCRIPTION
(1) Code refactoring
(2) Full implementation of fi_tsenddata and fi_tinjectdata, including specialization
