### PR TITLE
fabric: Fix a bug in ofi_msb()

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -91,8 +91,11 @@ uint64_t ofi_tag_format(uint64_t max_tag)
 uint8_t ofi_msb(uint64_t num)
 {
 	uint8_t msb = 0;
-	while (num >> msb)
+
+	while (num) {
 		msb++;
+		num >>= 1;
+	}
 	return msb;
 }
 


### PR DESCRIPTION
Right shifting 64 bits is NOP instead of resulting 0. As the result
the while loop wouldn't end for numbers with the top bit set.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>