### PR TITLE
prov/psm2: Ignore mem_tag_format input from hints

### DIFF
--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -571,7 +571,6 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 					PSMX2_MAX_MSG_SIZE);
 				goto err_out;
 			}
-			max_tag_value = ofi_max_tag(hints->ep_attr->mem_tag_format);
 		}
 
 		if (hints->tx_attr) {


### PR DESCRIPTION
This field is intended to be used as output only to convey the number
of tagged bits supported by a provider.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>