### PR TITLE
man: Update man pages for psm and psm2 providers

### DIFF
--- a/man/fi_psm.7.md
+++ b/man/fi_psm.7.md
@@ -22,7 +22,7 @@ to support a variety of libfabric data transfer APIs, including tagged
 message queue, message queue, RMA, and atomic operations.
 
 The *psm* provider can work with the psm2-compat library, which exposes
-a PSM 1.x interface over the Intel Omni-Path Fabric. 
+a PSM 1.x interface over the Intel Omni-Path Fabric.
 
 # LIMITATIONS
 
@@ -56,7 +56,7 @@ Modes
   referenced by the pointer must remain untouched until the request
   has completed. If none of *FI_TAGGED* and *FI_MSG* is asked for,
   the *FI_CONTEXT* mode is not required.
-  
+
 Progress
 : The *psm* provider requires manual progress. The application is
   expected to call *fi_cq_read* or *fi_cntr_read* function from time
@@ -67,7 +67,7 @@ Progress
   make auto progress.
 
 Unsupported features
-: These features are unsupported: connection management, 
+: These features are unsupported: connection management,
   scalable endpoint, passive endpoint, shared receive context,
   send/inject with immediate data.
 
@@ -80,7 +80,7 @@ The *psm* provider checks for the following environment variables:
   in the same job need to use the same UUID in order to be able to
   talk to each other. The PSM reference manual advises to keep UUID
   unique to each job. In practice, it generally works fine to reuse
-  UUID as long as (1) no two jobs with the same UUID are running at 
+  UUID as long as (1) no two jobs with the same UUID are running at
   the same time; and (2) previous jobs with the same UUID have exited
   normally. If running into "resource busy" or "connection failure"
   issues with unknown reason, it is advisable to manually set the UUID
@@ -92,18 +92,16 @@ The *psm* provider checks for the following environment variables:
 : The *psm* provider has a simple built-in name server that can be used
   to resolve an IP address or host name into a transport address needed
   by the *fi_av_insert* call. The main purpose of this name server is to
-  allow simple client-server type applications (such as those in *fabtest*)
+  allow simple client-server type applications (such as those in *fabtests*)
   to be written purely with libfabric, without using any out-of-band
-  communication mechanism. For such applications, the server would run first,
-  and the client would call *fi_getinfo* with the *node* parameter set to
-  the IP address or host name of the server. The resulting *fi_info* structure
-  would have the transport address of the server in the *dest_addr* field.
-
-  The name server won't work properly if there are more than one processes
-  from the same job (i.e. with the same UUID) running on the same node and
-  acting as servers. For such scenario it is recommended to have each
-  process getting local transport address with *fi_getname* and exchanging
-  the addresses with out-of-band mechanism.
+  communication mechanism. For such applications, the server would run first
+  to allow endpoints be created and registered with the name server, and
+  then the client would call *fi_getinfo* with the *node* parameter set to
+  the IP address or host name of the server. The resulting *fi_info*
+  structure would have the transport address of the endpoint created by the
+  server in the *dest_addr* field. Optionally the *service* parameter can
+  be used in addition to *node*. Notice that the *service* number is
+  interpreted by the provider and is not a TCP/IP port number.
 
   The name server is on by default. It can be turned off by setting the
   variable to 0. This may save a small amount of resource since a separate
@@ -121,7 +119,7 @@ The *psm* provider checks for the following environment variables:
   The *psm* provider use PSM tag-matching message queue functions to achieve
   higher bandwidth for large size RMA. For this purpose, a bit is reserved from
   the tag space to separate the RMA traffic from the regular tagged message queue.
-   
+
   The option is on by default. To turn it off set the variable to 0.
 
 *FI_PSM_AM_MSG*
@@ -155,10 +153,10 @@ The *psm* provider checks for the following environment variables:
 *FI_PSM_PROG_AFFINITY*
 : When set, specify the set of CPU cores to set the progress thread
   affinity to. The format is
-  `<start>[:<end>[:<stride>]][,<start>[:<end>[:<stride>]]]*`, 
+  `<start>[:<end>[:<stride>]][,<start>[:<end>[:<stride>]]]*`,
   where each triplet `<start>:<end>:<stride>` defines a block of
   core_ids. Both `<start>` and `<end>` can be either the `core_id`
-  (when >=0) or `core_id - num_cores` (when <0). 
+  (when >=0) or `core_id - num_cores` (when <0).
 
   By default affinity is not set.
 


### PR DESCRIPTION
(1) Enhanced name server functionality;
(2) Updated capabilities for the psm2 provider;
(3) Minor cosmetic fixes.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>