### PR TITLE
util/cntr: A few fixes plus minor code cleanups

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -352,14 +352,13 @@ struct util_cntr {
 	ofi_cntr_progress_func	progress;
 };
 
-int ofi_check_bind_cntr_flags(struct util_ep *ep, struct util_cntr *cntr,
-			      uint64_t flags);
-
 void ofi_cntr_progress(struct util_cntr *cntr);
 int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 		  struct fi_cntr_attr *attr, struct util_cntr *cntr,
 		  ofi_cntr_progress_func progress, void *context);
 int ofi_cntr_cleanup(struct util_cntr *cntr);
+
+
 /*
  * AV / addressing
  */

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -119,8 +119,7 @@ static int ofi_cntr_set(struct fid_cntr *cntr_fid, uint64_t value)
 
 	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
 
-	ofi_atomic_initialize64(&cntr->cnt, value);
-
+	ofi_atomic_set64(&cntr->cnt, value);
 	if (cntr->wait)
 		cntr->wait->signal(cntr->wait);
 
@@ -132,8 +131,7 @@ static int ofi_cntr_seterr(struct fid_cntr *cntr_fid, uint64_t value)
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
 	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
 
-	ofi_atomic_initialize64(&cntr->err, value);
-
+	ofi_atomic_set64(&cntr->err, value);
 	if (cntr->wait)
 		cntr->wait->signal(cntr->wait);
 

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -70,8 +70,8 @@ static int ofi_check_cntr_attr(const struct fi_provider *prov,
 static uint64_t ofi_cntr_read(struct fid_cntr *cntr_fid)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
-	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
 
+	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
 	cntr->progress(cntr);
 
 	return ofi_atomic_get64(&cntr->cnt);
@@ -80,8 +80,8 @@ static uint64_t ofi_cntr_read(struct fid_cntr *cntr_fid)
 static uint64_t ofi_cntr_readerr(struct fid_cntr *cntr_fid)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
-	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
 
+	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
 	cntr->progress(cntr);
 
 	return ofi_atomic_get64(&cntr->err);
@@ -90,11 +90,11 @@ static uint64_t ofi_cntr_readerr(struct fid_cntr *cntr_fid)
 static int ofi_cntr_add(struct fid_cntr *cntr_fid, uint64_t value)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
+
 	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
 
 	ofi_atomic_add64(&cntr->cnt, value);
-
-	if(cntr->wait)
+	if (cntr->wait)
 		cntr->wait->signal(cntr->wait);
 
 	return FI_SUCCESS;
@@ -103,11 +103,11 @@ static int ofi_cntr_add(struct fid_cntr *cntr_fid, uint64_t value)
 static int ofi_cntr_adderr(struct fid_cntr *cntr_fid, uint64_t value)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
+
 	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
 
 	ofi_atomic_add64(&cntr->err, value);
-
-	if(cntr->wait)
+	if (cntr->wait)
 		cntr->wait->signal(cntr->wait);
 
 	return FI_SUCCESS;
@@ -116,11 +116,12 @@ static int ofi_cntr_adderr(struct fid_cntr *cntr_fid, uint64_t value)
 static int ofi_cntr_set(struct fid_cntr *cntr_fid, uint64_t value)
 {
 	struct util_cntr *cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
+
 	assert(cntr->cntr_fid.fid.fclass == FI_CLASS_CNTR);
 
 	ofi_atomic_initialize64(&cntr->cnt, value);
 
-	if(cntr->wait)
+	if (cntr->wait)
 		cntr->wait->signal(cntr->wait);
 
 	return FI_SUCCESS;
@@ -133,7 +134,7 @@ static int ofi_cntr_seterr(struct fid_cntr *cntr_fid, uint64_t value)
 
 	ofi_atomic_initialize64(&cntr->err, value);
 
-	if(cntr->wait)
+	if (cntr->wait)
 		cntr->wait->signal(cntr->wait);
 
 	return FI_SUCCESS;
@@ -156,9 +157,10 @@ static int ofi_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 	current_ms = fi_gettime_ms();
 	finish_ms = (timeout < 0) ? UINT64_MAX : current_ms + timeout;
 	for (; timeout < 0 || current_ms < finish_ms;
-	    current_ms = fi_gettime_ms()) {
+	     current_ms = fi_gettime_ms()) {
 		timeout = timeout < 0 ? timeout : (int)(finish_ms - current_ms);
 		fi_wait(&cntr->wait->wait_fid, timeout);
+
 		cntr->progress(cntr);
 		if (threshold <= ofi_atomic_get64(&cntr->cnt))
 			return FI_SUCCESS;

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -185,8 +185,6 @@ int ofi_cntr_cleanup(struct util_cntr *cntr)
 	if (ofi_atomic_get32(&cntr->ref))
 		return -FI_EBUSY;
 
-	fastlock_destroy(&cntr->ep_list_lock);
-
 	if (cntr->wait) {
 		fi_poll_del(&cntr->wait->pollset->poll_fid,
 			    &cntr->cntr_fid.fid, 0);
@@ -194,6 +192,7 @@ int ofi_cntr_cleanup(struct util_cntr *cntr)
 	}
 
 	ofi_atomic_dec32(&cntr->domain->ref);
+	fastlock_destroy(&cntr->ep_list_lock);
 	return 0;
 }
 

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -209,32 +209,6 @@ static int util_cntr_close(struct fid *fid)
 	return 0;
 }
 
-int ofi_check_bind_cntr_flags(struct util_ep *ep, struct util_cntr *cntr,
-			      uint64_t flags)
-{
-	const struct fi_provider *prov = ep->domain->fabric->prov;
-
-	if (flags & ~(FI_TRANSMIT | FI_RECV | FI_READ  | FI_WRITE |
-		      FI_REMOTE_READ | FI_REMOTE_WRITE)) {
-		FI_WARN(prov, FI_LOG_EP_CTRL,
-			"Unsupported flags\n");
-		return -FI_EBADFLAGS;
-	}
-
-	if (((flags & FI_TRANSMIT) && ep->tx_cntr) ||
-	    ((flags & FI_RECV) && ep->rx_cntr) ||
-	    ((flags & FI_READ) && ep->rd_cntr) ||
-	    ((flags & FI_WRITE) && ep->wr_cntr) ||
-	    ((flags & FI_REMOTE_READ) && ep->rem_rd_cntr) ||
-	    ((flags & FI_REMOTE_WRITE) && ep->rem_wr_cntr)) {
-		FI_WARN(prov, FI_LOG_EP_CTRL,
-			"Duplicate CNTR binding\n");
-		return -FI_EINVAL;
-	}
-
-	return FI_SUCCESS;
-}
-
 static int fi_cntr_init(struct fid_domain *domain, struct fi_cntr_attr *attr,
 			struct util_cntr *cntr, void *context)
 {

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -96,11 +96,23 @@ int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av)
 
 int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags)
 {
-	int ret;
+	if (flags & ~(FI_TRANSMIT | FI_RECV | FI_READ  | FI_WRITE |
+		      FI_REMOTE_READ | FI_REMOTE_WRITE)) {
+		FI_WARN(ep->domain->fabric->prov, FI_LOG_EP_CTRL,
+			"Unsupported bind flags\n");
+		return -FI_EBADFLAGS;
+	}
 
-	ret = ofi_check_bind_cntr_flags(ep, cntr, flags);
-	if (ret)
-		return ret;
+	if (((flags & FI_TRANSMIT) && ep->tx_cntr) ||
+	    ((flags & FI_RECV) && ep->rx_cntr) ||
+	    ((flags & FI_READ) && ep->rd_cntr) ||
+	    ((flags & FI_WRITE) && ep->wr_cntr) ||
+	    ((flags & FI_REMOTE_READ) && ep->rem_rd_cntr) ||
+	    ((flags & FI_REMOTE_WRITE) && ep->rem_wr_cntr)) {
+		FI_WARN(ep->domain->fabric->prov, FI_LOG_EP_CTRL,
+			"Duplicate counter binding\n");
+		return -FI_EINVAL;
+	}
 
 	if (flags & FI_TRANSMIT) {
 		ep->tx_cntr = cntr;
@@ -134,8 +146,7 @@ int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags)
 
 	ep->flags |= OFI_CNTR_ENABLED;
 
-	return fid_list_insert(&cntr->ep_list,
-			       &cntr->ep_list_lock,
+	return fid_list_insert(&cntr->ep_list, &cntr->ep_list_lock,
 			       &ep->ep_fid.fid);
 }
 


### PR DESCRIPTION
Fix counter cleanup order.  Convert atomic initialize calls to atomic set where appropriate.  Trap for errors when waiting on counters.