### PR TITLE
prov/rxm: Remove excessive memset() for RX buffers

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -341,7 +341,7 @@ ssize_t rxm_cq_handle_data(struct rxm_rx_buf *rx_buf)
 	if (rx_buf->pkt.ctrl_hdr.type == ofi_ctrl_large_data) {
 		if (!rx_buf->conn) {
 			rx_buf->conn = rxm_key2conn(rx_buf->ep, rx_buf->pkt.ctrl_hdr.conn_id);
-			if (!rx_buf->conn)
+			if (OFI_UNLIKELY(!rx_buf->conn))
 				return -FI_EOTHER;
 		}
 
@@ -400,7 +400,7 @@ static ssize_t rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 	if ((rx_buf->ep->rxm_info->caps & (FI_SOURCE | FI_DIRECTED_RECV)) &&
 	    !rx_buf->conn) {
 		rx_buf->conn = rxm_key2conn(rx_buf->ep, rx_buf->pkt.ctrl_hdr.conn_id);
-		if (!rx_buf->conn)
+		if (OFI_UNLIKELY(!rx_buf->conn))
 			return -FI_EOTHER;
 		match_attr.addr = rx_buf->conn->handle.fi_addr;
 	} else {

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -662,7 +662,7 @@ static ssize_t rxm_cq_write_error(struct fid_cq *msg_cq,
 
 static inline int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 {
-	memset(&rx_buf->conn, 0, sizeof(*rx_buf) - offsetof(struct rxm_rx_buf, conn));
+	rx_buf->conn = NULL;
 	rx_buf->hdr.state = RXM_RX;
 
 	if (fi_recv(rx_buf->hdr.msg_ep, &rx_buf->pkt,


### PR DESCRIPTION
memset() call can be removed for RX buffers when re-posting of receive buffer.
Only rx_buf->conn should be set to NULL

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>