### PR TITLE
linux/rdpmc: Fix build failure with GCC <= 4.4.7

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -90,9 +90,11 @@ endif
 
 if LINUX
 common_srcs += src/unix/osd.c
+if HAVE_LINUX_PERF_RDPMC
 common_srcs += src/linux/rdpmc.c
-common_srcs += include/linux/osd.h
+endif
 common_srcs += include/linux/rdpmc.h
+common_srcs += include/linux/osd.h
 common_srcs += include/unix/osd.h
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -148,7 +148,15 @@ if test "$ac_cv_func_epoll_create" = yes; then
   AC_DEFINE([HAVE_EPOLL], [1], [Define if you have epoll support.])
 fi
 
-AC_CHECK_HEADERS_ONCE([linux/perf_event.h])
+AC_CHECK_HEADER([linux/perf_event.h],
+    [AC_CHECK_DECL([__builtin_ia32_rdpmc],
+        [linux_perf_rdpmc=1],
+        [linux_perf_rdpmc=0],
+        [#include <linux/perf_event.h>])],
+    [linux_perf_rdpmc=0])
+AC_DEFINE_UNQUOTED(HAVE_LINUX_PERF_RDPMC, [$linux_perf_rdpmc],
+    [Whether we have __builtin_ia32_rdpmc() and linux/perf_event.h file or not])
+AM_CONDITIONAL([HAVE_LINUX_PERF_RDPMC], [test "x$linux_perf_rdpmc" = "x1"])
 
 dnl Check for gcc atomic intrinsics
 AC_MSG_CHECKING(compiler support for c11 atomics)

--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -53,11 +53,4 @@ static inline int ofi_shm_remap(struct util_shm *shm,
 	return shm->ptr == MAP_FAILED ? -FI_EINVAL : FI_SUCCESS;
 }
 
-
-#ifdef HAVE_LINUX_PERF_EVENT_H
-#define HAVE_OFI_PERF
-#endif /* HAVE_LINUX_PERF_EVENT_H */
-
-
 #endif /* _LINUX_OSD_H_ */
-

--- a/include/linux/rdpmc.h
+++ b/include/linux/rdpmc.h
@@ -17,8 +17,7 @@
 #ifndef RDPMC_H
 #define RDPMC_H
 
-#ifdef HAVE_LINUX_PERF_EVENT_H
-
+#if HAVE_LINUX_PERF_RDPMC
 
 #include <linux/perf_event.h>
 #include <ofi_perf.h>
@@ -41,6 +40,6 @@ struct ofi_perf_ctx {
 };
 
 
-#endif /* HAVE_LINUX_PERF_EVENT_H */
+#endif /* HAVE_LINUX_PERF_RDPMC */
 
 #endif

--- a/include/ofi_perf.h
+++ b/include/ofi_perf.h
@@ -87,12 +87,12 @@ struct ofi_perf_data {
  * Performance management unit:
  *
  * Access to a PMU is platform specific.  If an osd.h file provides methods
- * to access a PMU, it should define HAVE_OFI_PERF and provide implementations
- * for the following functions.  Platforms that do not support PMUs will
- * default to no-op definitions.
+ * to access a PMU, it should define HAVE_LINUX_PERF_RDPMC and provide
+ * implementations for the following functions.  Platforms that do not
+ * support PMUs will default to no-op definitions.
  */
 
-#ifdef HAVE_OFI_PERF
+#if HAVE_LINUX_PERF_RDPMC
 
 struct ofi_perf_ctx;
 
@@ -101,7 +101,7 @@ int ofi_pmu_open(struct ofi_perf_ctx **ctx,
 uint64_t ofi_pmu_read(struct ofi_perf_ctx *ctx);
 void ofi_pmu_close(struct ofi_perf_ctx *ctx);
 
-#else /* HAVE_OFI_PERF */
+#else /* HAVE_LINUX_PERF_RDPMC */
 
 struct ofi_perf_ctx {
 	int dummy;
@@ -123,7 +123,7 @@ static inline uint64_t ofi_pmu_read(struct ofi_perf_ctx *ctx)
 static inline void ofi_pmu_close(struct ofi_perf_ctx *ctx)
 {
 }
-#endif /* HAVE_OFI_PERF */
+#endif /* HAVE_LINUX_PERF_RDPMC */
 
 
 static inline void ofi_perf_reset(struct ofi_perf_data *data)

--- a/src/linux/rdpmc.c
+++ b/src/linux/rdpmc.c
@@ -16,9 +16,6 @@
 
 #include "config.h"
 
-#ifdef HAVE_LINUX_PERF_EVENT_H
-
-
 /* Ring 3 RDPMC support */
 #include <unistd.h>
 #include <stdio.h>
@@ -232,6 +229,3 @@ inline void ofi_pmu_close(struct ofi_perf_ctx *ctx)
 	rdpmc_close(&ctx->ctx);
 	free(ctx);
 }
-
-
-#endif /* HAVE_LINUX_PERF_EVENT_H */


### PR DESCRIPTION
I've got the following build failure on RedHat 6.7 with gcc 4.4.7:

```
src/linux/rdpmc.c: In function ‘rdpmc_read’:
src/linux/rdpmc.c:152: warning: implicit declaration of function ‘__builtin_ia32_rdpmc’
```

It's not enough to check that `linux/perf_event.h` header file is present. We have to check that `__builtin_ia32_rdpmc` built-in is declared and can be used.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>