### PR TITLE
prov/verbs: max_inline depends on QP type

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_ep_rdm.c
@@ -584,7 +584,7 @@ int fi_ibv_rdm_open_ep(struct fid_domain *domain, struct fi_info *info,
 	dlist_init(&_ep->fi_ibv_rdm_multi_recv_list);
 
 	_ep->max_inline_rc =
-		fi_ibv_find_max_inline(_ep->domain->pd, _ep->domain->verbs);
+		fi_ibv_find_max_inline(_ep->domain->pd, _ep->domain->verbs, IBV_QPT_RC);
 
 	_ep->scq_depth = FI_IBV_RDM_TAGGED_DFLT_SCQ_SIZE;
 	_ep->rcq_depth = FI_IBV_RDM_TAGGED_DFLT_RCQ_SIZE;

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -353,7 +353,8 @@ int fi_ibv_set_rnr_timer(struct ibv_qp *qp)
 	return 0;
 }
 
-int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context)
+int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
+                           enum ibv_qp_type qp_type)
 {
 	struct ibv_qp_init_attr qp_attr;
 	struct ibv_qp *qp = NULL;
@@ -365,7 +366,7 @@ int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context)
 	memset(&qp_attr, 0, sizeof(qp_attr));
 	qp_attr.send_cq = cq;
 	qp_attr.recv_cq = cq;
-	qp_attr.qp_type = IBV_QPT_RC;
+	qp_attr.qp_type = qp_type;
 	qp_attr.cap.max_send_wr = 1;
 	qp_attr.cap.max_recv_wr = 1;
 	qp_attr.cap.max_send_sge = 1;
@@ -586,7 +587,7 @@ static int fi_ibv_read_params(void)
 			   "Invalid value of mr_cache_lazy_size\n");
 		return -FI_EINVAL;
 	}
-	
+
 
 	/* RDM-specific parameters */
 	if (fi_ibv_get_param_int("rdm_buffer_num", "The number of pre-registered "
@@ -670,7 +671,7 @@ static int fi_ibv_read_params(void)
 
 static void fi_ibv_fini(void)
 {
-	
+
 	fi_freeinfo((void *)fi_ibv_util_prov.info);
 	fi_ibv_util_prov.info = NULL;
 }

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -735,7 +735,8 @@ void fi_ibv_empty_wre_list(struct util_buf_pool *wre_pool,
 			   struct dlist_entry *wre_list,
 			   enum fi_ibv_wre_type wre_type);
 void fi_ibv_cleanup_cq(struct fi_ibv_msg_ep *cur_ep);
-int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context);
+int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
+                           enum ibv_qp_type qp_type);
 
 #define fi_ibv_init_sge(buf, len, desc) (struct ibv_sge)		\
 	{ .addr = (uintptr_t)buf,					\

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -413,6 +413,7 @@ static inline int fi_ibv_get_qp_cap(struct ibv_context *ctx,
 	struct ibv_cq *cq;
 	struct ibv_qp *qp;
 	struct ibv_qp_init_attr init_attr;
+	enum ibv_qp_type qp_type;
 	int ret = 0;
 
 	pd = ibv_alloc_pd(ctx);
@@ -428,6 +429,9 @@ static inline int fi_ibv_get_qp_cap(struct ibv_context *ctx,
 		goto err1;
 	}
 
+	qp_type = (info->ep_attr->type != FI_EP_DGRAM) ?
+			    IBV_QPT_RC : IBV_QPT_UD;
+
 	memset(&init_attr, 0, sizeof init_attr);
 	init_attr.send_cq = cq;
 	init_attr.recv_cq = cq;
@@ -435,10 +439,8 @@ static inline int fi_ibv_get_qp_cap(struct ibv_context *ctx,
 	init_attr.cap.max_recv_wr = fi_ibv_gl_data.def_rx_size;
 	init_attr.cap.max_send_sge = fi_ibv_gl_data.def_tx_iov_limit;
 	init_attr.cap.max_recv_sge = fi_ibv_gl_data.def_rx_iov_limit;
-	init_attr.cap.max_inline_data = fi_ibv_find_max_inline(pd, ctx);
-
-	init_attr.qp_type = (info->ep_attr->type != FI_EP_DGRAM) ?
-			    IBV_QPT_RC : IBV_QPT_UD;
+	init_attr.cap.max_inline_data = fi_ibv_find_max_inline(pd, ctx, qp_type);
+	init_attr.qp_type = qp_type;
 
 	qp = ibv_create_qp(pd, &init_attr);
 	if (!qp) {


### PR DESCRIPTION
Libfabric doesn't list the DGRAM Verbs EP on my system because
the call to ibv_create_qp() in fi_ibv_get_qp_cap() currently fails
with EINVAL:
libfabric:verbs:fabric:fi_ibv_get_qp_cap():445<info> ibv_create_qp: Invalid argument(22)

It turns out that the value for max_inline_data determined by the
function fi_ibv_find_max_inline() is too high, causing ibv_create_qp()
to return EINVAL.

It actually appears that the maximum of inline data depends on the
QP type. However, fi_ibv_find_max_inline() tries to always determine
the max inline data based on RC EPs.

E.g., with a Mellanox MT4115:
- UD: max_inline_data=512
- RC: max_inline_data=988

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>