### PR TITLE
prov/tcp Changes to message send/recv functions

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -41,6 +41,7 @@
 #include <complex.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
+#include <sys/uio.h>
 
 /* MSG_NOSIGNAL doesn't exist on OS X */
 #ifndef MSG_NOSIGNAL
@@ -142,6 +143,16 @@ static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count
 					const struct sockaddr *to, socklen_t tolen)
 {
 	return sendto(fd, buf, count, flags, to, tolen);
+}
+
+static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov, size_t iov_cnt)
+{
+	return writev(fd, iov, iov_cnt);
+}
+
+static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov, int iov_cnt)
+{
+	return readv(fd, iov, iov_cnt);
 }
 
 static inline int ofi_close_socket(SOCKET socket)

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -726,6 +726,9 @@ static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count
 	return sendto(fd, (const char*)buf, (int)count, flags, to, tolen);
 }
 
+ssize_t ofi_writev_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
+ssize_t ofi_readv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
+
 static inline int ofi_close_socket(SOCKET socket)
 {
 	return closesocket(socket);

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -505,3 +505,45 @@ void freeifaddrs(struct ifaddrs *ifa)
 		ifa = next;
 	}
 }
+
+ssize_t ofi_writev_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt)
+{
+	ssize_t size;
+	int ret, i;
+	WSABUF *wsa_buf;
+	DWORD flags = 0;
+
+	wsa_buf = (WSABUF *)alloca(iov_cnt * sizeof(WSABUF));
+
+	for (i = 0; i < iov_cnt; i++) {
+		wsa_buf[i].buf = (char *)iovec[i].iov_base;
+		wsa_buf[i].len = iovec[i].iov_len;
+	}
+
+	ret = WSASend(fd, wsa_buf, iov_cnt, &size, &flags, NULL, NULL);
+	if (ret)
+		size = (ssize_t)ret;
+
+	return size;
+}
+
+ssize_t ofi_readv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt)
+{
+	ssize_t size;
+	int ret,i;
+	WSABUF *wsa_buf;
+	DWORD flags = 0;
+
+	wsa_buf = (WSABUF *)alloca(iov_cnt *sizeof(WSABUF));
+
+	for (i = 0; i <iov_cnt; i++) {
+		wsa_buf[i].buf = (char *)iovec[i].iov_base;
+		wsa_buf[i].len = iovec[i].iov_len;
+	}
+
+	ret = WSARecv(fd, wsa_buf, iov_cnt, &size, &flags, NULL, NULL);
+	if (ret)
+		size = (ssize_t)ret;
+
+	return size;
+}


### PR DESCRIPTION
Currently tcp provider maintains a ring buffer in every send/recv queue entry (pe_entry). A smaller messages gets buffered in the ring buffer before its sent which involves copying multiple times. This results in unnecessary mem copies and mem usage.  This PR gets rid of ringbuffers.

With this PR, tcp provider can try sending each message using scatter-gather sockets calls. so inbest case scenarios, one syscall for sending the whole message (when message < mtu). In case of recv two syscalls for receving (one recv call for reading header and the other for receiving message data. 

For larger messages, tcp provider breaks the iovec appropriately before every call to sendmsg/recvmsg.