### PR TITLE
prov/psm2: Fix incorrect tag received from iov send

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -390,6 +390,7 @@ struct psmx2_sendv_reply {
 	struct fi_context fi_context;
 	int no_completion;
 	int multi_recv;
+	psm2_mq_tag_t tag;
 	uint8_t *buf;
 	void *user_context;
 	size_t iov_done;

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -868,6 +868,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					continue;
 				}
 
+				PSMX2_STATUS_TAG(status) = sendv_rep->tag;
 				PSMX2_STATUS_RCVLEN(status) = sendv_rep->bytes_received;
 				PSMX2_STATUS_SNDLEN(status) = sendv_rep->msg_length;
 				PSMX2_STATUS_ERROR(status) = sendv_rep->error_code;

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -508,6 +508,7 @@ int psmx2_handle_sendv_req(struct psmx2_fid_ep *ep,
 	memcpy(&rep->iov_info, recv_buf, PSMX2_STATUS_RCVLEN(status));
 
 	rep->user_context = PSMX2_STATUS_CONTEXT(status);
+	rep->tag = PSMX2_STATUS_TAG(status);
 	rep->buf = recv_buf;
 	rep->no_completion = 0;
 	rep->iov_done = 0;


### PR DESCRIPTION
As part of the recent changes to support remote CQ date over tagged
messages, the iov protocol was slightly modified to use a different tag
bit layout. As the result, the payload packets for iov sends no longer
carries the original tag information. That means the completion would
have incorrect tag field if generated in the old way.

Update the completion generation routine to handle the new iov protocol.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>