### PR TITLE
prov/sockets: Fix SOL_TCP not available on FreeBSD

### DIFF
--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -42,6 +42,7 @@
 
 #define ENODATA ENOMSG
 #define HOST_NAME_MAX  128
+#define SOL_TCP IPPROTO_TCP
 
 typedef cpuset_t cpu_set_t;
 


### PR DESCRIPTION
Compiling on FreeBSD gives the following errors:
prov/sockets/src/sock_conn.c:246:24: error: use of undeclared identifier 'SOL_TCP'
                if (setsockopt(sock, SOL_TCP, TCP_KEEPIDLE, &optval, sizeof(optval)))
                                     ^
prov/sockets/src/sock_conn.c:253:24: error: use of undeclared identifier 'SOL_TCP'
                if (setsockopt(sock, SOL_TCP, TCP_KEEPINTVL, &optval, sizeof(optval)))
                                     ^
prov/sockets/src/sock_conn.c:260:24: error: use of undeclared identifier 'SOL_TCP'
                if (setsockopt(sock, SOL_TCP, TCP_KEEPCNT, &optval, sizeof(optval)))

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>