### PR TITLE
prov/rxm: Implement postponed queue

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -111,6 +111,7 @@ struct rxm_fabric {
 
 struct rxm_conn {
 	struct fid_ep *msg_ep;
+	struct dlist_entry postponed_tx_list;
 	struct util_cmap_handle handle;
 };
 
@@ -251,7 +252,10 @@ struct rxm_tx_buf {
 
 struct rxm_tx_entry {
 	/* Must stay at top */
-	struct fi_context fi_context;	
+	union {
+		struct fi_context fi_context;
+		struct dlist_entry postponed_entry;
+	};
 
 	enum rxm_proto_state state;
 
@@ -324,7 +328,7 @@ struct rxm_ep {
 	size_t			min_multi_recv_size;
 
 	struct rxm_buf_pool	buf_pools[RXM_BUF_POOL_MAX_VAL];
-	
+
 	struct dlist_entry	post_rx_list;
 	struct dlist_entry	repost_ready_list;
 
@@ -380,6 +384,8 @@ int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
 int rxm_ep_msg_mr_regv(struct rxm_ep *rxm_ep, const struct iovec *iov,
 		       size_t count, uint64_t access, struct fid_mr **mr);
 void rxm_ep_msg_mr_closev(struct fid_mr **mr, size_t count);
+
+void rxm_conn_handle_postponed_tx_op(struct rxm_ep *rxm_ep, struct util_cmap_handle *handle);
 
 static inline void rxm_cntr_inc(struct util_cntr *cntr)
 {

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1272,17 +1272,16 @@ void ofi_cmap_process_shutdown(struct util_cmap *cmap,
 	fastlock_release(&cmap->lock);
 }
 
+/* Caller must hold cmap->lock */
 void ofi_cmap_process_connect(struct util_cmap *cmap,
 			      struct util_cmap_handle *handle,
 			      uint64_t *remote_key)
 {
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
 		"Processing connect for handle: %p\n", handle);
-	fastlock_acquire(&cmap->lock);
 	handle->state = CMAP_CONNECTED;
 	if (remote_key)
 		handle->remote_key = *remote_key;
-	fastlock_release(&cmap->lock);
 }
 
 void ofi_cmap_process_reject(struct util_cmap *cmap,


### PR DESCRIPTION
This patch adds mechanism to buffer messages before connection is established between peers.

This mechanism allows fi_[t]inject, fi_[t]send[msg,v] buffer data (or LMT request) and add the TX buffer into postponed queue. When the connection between peers is established, RxM provider goes through postponed queue and if there are any outstanding messages, it just sends them to an appropriate peer.

So, this allows avoid returning `-FI_EAGAIN` from OFI library and avoid burning CPU cycles while polling CQ and busy waiting for the connection to be established. Apps can do some computational work (if possible)

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>