### PR TITLE
prov/verbs,rxm: bug fixes and refactoring

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1543,8 +1543,8 @@ static int rxm_ep_get_core_info(uint32_t version, const struct fi_info *hints,
 				 rxm_info_to_core, info);
 }
 
-static int rxm_ep_msg_res_open(struct fi_info *rxm_fi_info,
-			       struct util_domain *util_domain, struct rxm_ep *rxm_ep)
+static int rxm_ep_msg_res_open(struct util_domain *util_domain,
+			       struct rxm_ep *rxm_ep)
 {
 	struct rxm_domain *rxm_domain;
 	struct fi_cq_attr cq_attr = { 0 };
@@ -1552,7 +1552,7 @@ static int rxm_ep_msg_res_open(struct fi_info *rxm_fi_info,
 	size_t max_prog_val;
 
 	ret = rxm_ep_get_core_info(util_domain->fabric->fabric_fid.api_version,
-				   rxm_fi_info, &rxm_ep->msg_info);
+				   rxm_ep->rxm_info, &rxm_ep->msg_info);
 	if (ret)
 		return ret;
 
@@ -1563,7 +1563,8 @@ static int rxm_ep_msg_res_open(struct fi_info *rxm_fi_info,
 
 	rxm_domain = container_of(util_domain, struct rxm_domain, util_domain);
 
-	cq_attr.size = rxm_fi_info->tx_attr->size + rxm_fi_info->rx_attr->size;
+	cq_attr.size = (rxm_ep->rxm_info->tx_attr->size +
+			rxm_ep->rxm_info->rx_attr->size);
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = FI_WAIT_FD;
 
@@ -1647,7 +1648,7 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	util_domain = container_of(domain, struct util_domain, domain_fid);
 
-	ret = rxm_ep_msg_res_open(info, util_domain, rxm_ep);
+	ret = rxm_ep_msg_res_open(util_domain, rxm_ep);
 	if (ret)
 		goto err2;
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1392,6 +1392,10 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 	case FI_CLASS_CQ:
 		cq = container_of(bfid, struct util_cq, cq_fid.fid);
 
+		ret = ofi_ep_bind_cq(&rxm_ep->util_ep, cq, flags);
+		if (ret)
+			return ret;
+
 		if (cq->wait) {
 			ret = ofi_wait_fd_add(cq->wait, rxm_ep->msg_cq_fd,
 					      rxm_ep_trywait, rxm_ep,
@@ -1399,17 +1403,14 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 			if (ret)
 				return ret;
 		}
-		ret = ofi_ep_bind_cq(&rxm_ep->util_ep, cq, flags);
-		if (ret) {
-			if (cq->wait && ofi_wait_fd_del(cq->wait, rxm_ep->msg_cq_fd))
-				FI_INFO(&rxm_prov, FI_LOG_EP_CTRL,
-					"Unable to delete wait fd from FD list");
-			return ret;
-		}
 		break;
 	case FI_CLASS_CNTR:
 		cntr = container_of(bfid, struct util_cntr, cntr_fid.fid);
+
 		ret = ofi_ep_bind_cntr(&rxm_ep->util_ep, cntr, flags);
+		if (ret)
+			return ret;
+
 		if (cntr->wait) {
 			ret = ofi_wait_fd_add(cntr->wait, rxm_ep->msg_cq_fd,
 					      rxm_ep_trywait, rxm_ep,

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -714,6 +714,7 @@ fi_ibv_msg_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t 
 	fastlock_release(&ep->wre_lock);
 
 	wre->ep = ep;
+	wre->srq = NULL;
 	wre->context = msg->context;
 	wre->wr_type = IBV_RECV_WR;
 

--- a/prov/verbs/src/verbs_srq.c
+++ b/prov/verbs/src/verbs_srq.c
@@ -113,6 +113,7 @@ fi_ibv_srq_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t 
 	fastlock_release(&ep->wre_lock);
 
 	wre->srq = ep;
+	wre->ep = NULL;
 	wre->context = msg->context;
 	wre->wr_type = IBV_RECV_WR;
 


### PR DESCRIPTION
- prov/verbs: fix missing initialization for wre
- prov/rxm: minor cleanups
- prov/rxm: rearrange bind cq/cntr 
- prov/rxm: delay cq_open until bind to determine if we need wait object