### PR TITLE
prov/rxm: Fix MR descriptor leak for RMA operations

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -552,6 +552,8 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	switch (RXM_GET_PROTO_STATE(comp)) {
 	case RXM_TX_NOBUF:
 		assert(comp->flags & (FI_SEND | FI_WRITE | FI_READ));
+		if (tx_entry->ep->msg_mr_local && !tx_entry->ep->rxm_mr_local)
+			rxm_ep_msg_mr_closev(tx_entry->mr, tx_entry->count);
 		return rxm_finish_send_nobuf(tx_entry);
 	case RXM_TX:
 		assert(comp->flags & (FI_SEND | FI_WRITE));


### PR DESCRIPTION
This patch fixes two problems:
- When RMA operations are completed, MR descriptors aren't released
- Entries of registered MR array are overridden by their desc (local key) 

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>