### PR TITLE
prov/util: ofi_get_core_info_fabric() must only return core providers

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -359,7 +359,8 @@ int ofi_get_core_info_fabric(struct fi_fabric_attr *util_attr,
 	}
 	hints.mode = ~0;
 
-	ret = fi_getinfo(util_attr->api_version, NULL, NULL, 0, &hints, core_info);
+	ret = fi_getinfo(util_attr->api_version, NULL, NULL, OFI_CORE_PROV_ONLY,
+	                 &hints, core_info);
 
 	free(hints.fabric_attr->prov_name);
 out:


### PR DESCRIPTION
Without this patch, fi_dom_test (fabtest) with tcpx enters an infinite
loop where rxm_fabric() calls fi_fabric_(), which calls rxm_fabric(),
etc...

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>