### PR TITLE
prov/psm2: Support two different tag layout schemes

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -218,6 +218,18 @@ The *psm2* provider checks for the following environment variables:
 
   The default setting is 0.
 
+*FI_PSM2_TAG_LAYOUT
+: Select how the 96-bit PSM2 tag bits are organized. Currently two choices are
+  available: *tag60* means starting from the most significant bit 32/4/60 bits
+  are used for CQ data, internal protocol flags, and application tag. *tag64*
+  means 4/28/64 division for flags/data/tag.
+
+  The default setting is *tag60*.
+
+  Notice that if the provider is compiled with *PSMX2_TAG_LAYOUT* defined to
+  1(means *tag60*) or 2(means *tag64*), the choice is fixed at compile time
+  and this runtime option is disabled.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),


### PR DESCRIPTION
The 96 bit tag provided by PSM2 is not enough to support 64 bit
application tag and 32 bit CQ data at the same time because a few
bits need to be reserved for the provider's internal protocols
for features such as untagged message, RMA, and iovec. As the
result, compromise has to be made to fit the most wanted feature
sets into the limited resource.

Support for remote CQ data over tagged message was added recently.
However, the application tag was reduced to 60 bit at the same
time. While new applications can adapt to the changes, existing
code may run into compatibility issue with the reduced tag space.

This patch implements a mechanism to allow different tag layout
schemes to coexist, being selected at compile time or at runtime.
In addition to the existing scheme, a new one is defined to allow
full 64 bit application tag at the expense of some remote CQ data
bits. This provides backward compatibility to existing applications.

A fixed scheme can be selected at compile time by defining the macro
PSMX2_TAG_LAYOUT to the desired value. If it is left at the default
definition, the tag layout scheme can be selected at runtime via the
environment variable FI_PSM2_TAG_LAYOUT.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>