### PR TITLE
prov/rxm: Report FI_ETRUNC error if posted recv buffer isn't large enough

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -327,6 +327,9 @@ int ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 int ofi_cq_write_error(struct util_cq *cq,
 		       const struct fi_cq_err_entry *err_entry);
 int ofi_cq_write_error_peek(struct util_cq *cq, uint64_t tag, void *context);
+int ofi_cq_write_error_trunc(struct util_cq *cq, void *context, uint64_t flags,
+			     size_t len, void *buf, uint64_t data, uint64_t tag,
+			     size_t olen);
 
 static inline int ofi_need_completion(uint64_t cq_flags, uint64_t op_flags)
 {

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -61,13 +61,31 @@ int ofi_cq_write_error(struct util_cq *cq,
 
 int ofi_cq_write_error_peek(struct util_cq *cq, uint64_t tag, void *context)
 {
-	struct fi_cq_err_entry err_entry = {0};
+	struct fi_cq_err_entry err_entry = {
+		.op_context	= context,
+		.flags		= FI_TAGGED | FI_RECV,
+		.tag		= tag,
+		.err		= FI_ENOMSG,
+		.prov_errno	= -FI_ENOMSG,
+	};
+	return ofi_cq_write_error(cq, &err_entry);
+}
 
-	err_entry.op_context    = context;
-	err_entry.flags         = FI_TAGGED | FI_RECV;
-	err_entry.tag		= tag;
-	err_entry.err           = FI_ENOMSG;
-	err_entry.prov_errno    = -FI_ENOMSG;
+int ofi_cq_write_error_trunc(struct util_cq *cq, void *context, uint64_t flags,
+			     size_t len, void *buf, uint64_t data, uint64_t tag,
+			     size_t olen)
+{
+	struct fi_cq_err_entry err_entry = {
+		.op_context	= context,
+		.flags		= flags,
+		.len		= len,
+		.buf		= buf,
+		.data		= data,
+		.tag		= tag,
+		.olen		= olen,
+		.err		= FI_ETRUNC,
+		.prov_errno	= -FI_ETRUNC,
+	};
 	return ofi_cq_write_error(cq, &err_entry);
 }
 


### PR DESCRIPTION
The RxM provider have to fill error CQ entry and report it to an user when posted recv buffer is smaller than size of incoming message

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>