### PR TITLE
prov/psm2: Enable auto selection of default tag layout

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -219,12 +219,14 @@ The *psm2* provider checks for the following environment variables:
   The default setting is 0.
 
 *FI_PSM2_TAG_LAYOUT
-: Select how the 96-bit PSM2 tag bits are organized. Currently two choices are
+: Select how the 96-bit PSM2 tag bits are organized. Currently three choices are
   available: *tag60* means starting from the most significant bit 32/4/60 bits
   are used for CQ data, internal protocol flags, and application tag. *tag64*
-  means 4/28/64 division for flags/data/tag.
+  means 4/28/64 division for flags/data/tag. *auto* means to choose either
+  *tag60* or *tag64* based on the the hints passed to fi_getinfo: use *tag64* if
+  *hints->domain_attr->cq_data_size* is 0, and *tag60* otherwise.
 
-  The default setting is *tag60*.
+  The default setting is *auto*.
 
   Notice that if the provider is compiled with *PSMX2_TAG_LAYOUT* defined to
   1(means *tag60*) or 2(means *tag64*), the choice is fixed at compile time

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -207,11 +207,6 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_TAG_UPPER_MASK	psmx2_tag_upper_mask
 #define PSMX2_DATA_MASK		psmx2_data_mask
 #define PSMX2_FLAGS_IDX		psmx2_flags_idx
-#define PSMX2_DEFAULT_TAG_LAYOUT	"tag60"
-#define PSMX2_DEFAULT_TAG_MASK		PSMX2_TAG_MASK_60
-#define PSMX2_DEFAULT_TAG_UPPER_MASK	PSMX2_TAG_UPPER_MASK_60
-#define PSMX2_DEFAULT_DATA_MASK		PSMX2_DATA_MASK_60
-#define PSMX2_DEFAULT_FLAGS_IDX		PSMX2_FLAGS_IDX_60
 extern uint64_t	psmx2_tag_mask;
 extern uint32_t	psmx2_tag_upper_mask;
 extern uint32_t	psmx2_data_mask;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -56,15 +56,15 @@ struct psmx2_env psmx2_env = {
 	.lazy_conn	= 0,
 	.disconnect	= 0,
 #if (PSMX2_TAG_LAYOUT == PSMX2_TAG_LAYOUT_RUNTIME)
-	.tag_layout	= PSMX2_DEFAULT_TAG_LAYOUT,
+	.tag_layout	= "auto",
 #endif
 };
 
 #if (PSMX2_TAG_LAYOUT == PSMX2_TAG_LAYOUT_RUNTIME)
-uint64_t psmx2_tag_mask		= PSMX2_DEFAULT_TAG_MASK;
-uint32_t psmx2_tag_upper_mask	= PSMX2_DEFAULT_TAG_UPPER_MASK;
-uint32_t psmx2_data_mask	= PSMX2_DEFAULT_DATA_MASK;
-int	 psmx2_flags_idx	= PSMX2_DEFAULT_FLAGS_IDX;
+uint64_t psmx2_tag_mask;
+uint32_t psmx2_tag_upper_mask;
+uint32_t psmx2_data_mask;
+int	 psmx2_flags_idx;
 #endif
 
 static void psmx2_init_env(void)
@@ -85,7 +85,12 @@ static void psmx2_init_env(void)
 	fi_param_get_bool(&psmx2_prov, "disconnect", &psmx2_env.disconnect);
 #if (PSMX2_TAG_LAYOUT == PSMX2_TAG_LAYOUT_RUNTIME)
 	fi_param_get_str(&psmx2_prov, "tag_layout", &psmx2_env.tag_layout);
+#endif
+}
 
+static void psmx2_init_tag_layout(int *cq_data_size)
+{
+#if (PSMX2_TAG_LAYOUT == PSMX2_TAG_LAYOUT_RUNTIME)
 	if (strcasecmp(psmx2_env.tag_layout, "tag60") == 0) {
 		psmx2_tag_upper_mask = PSMX2_TAG_UPPER_MASK_60;
 		psmx2_tag_mask = PSMX2_TAG_MASK_60;
@@ -97,11 +102,30 @@ static void psmx2_init_env(void)
 		psmx2_data_mask = PSMX2_DATA_MASK_64;
 		psmx2_flags_idx = PSMX2_FLAGS_IDX_64;
 	} else {
-		FI_INFO(&psmx2_prov, FI_LOG_CORE,
-			"Invalid tag layout '%s', using default value '%s'.\n",
-			psmx2_env.tag_layout, PSMX2_DEFAULT_TAG_LAYOUT);
+		if (strcasecmp(psmx2_env.tag_layout, "auto") != 0) {
+			FI_INFO(&psmx2_prov, FI_LOG_CORE,
+				"Invalid tag layout '%s', using 'auto'.\n",
+				psmx2_env.tag_layout);
+			psmx2_env.tag_layout = "auto";
+		}
+		if (*cq_data_size) {
+			psmx2_tag_upper_mask = PSMX2_TAG_UPPER_MASK_60;
+			psmx2_tag_mask = PSMX2_TAG_MASK_60;
+			psmx2_data_mask = PSMX2_DATA_MASK_60;
+			psmx2_flags_idx = PSMX2_FLAGS_IDX_60;
+		} else {
+			psmx2_tag_upper_mask = PSMX2_TAG_UPPER_MASK_64;
+			psmx2_tag_mask = PSMX2_TAG_MASK_64;
+			psmx2_data_mask = PSMX2_DATA_MASK_64;
+			psmx2_flags_idx = PSMX2_FLAGS_IDX_64;
+		}
 	}
 #endif
+	*cq_data_size = (PSMX2_DATA_MASK == 0xFFFFFFFFU) ? 4 : 0;
+
+	FI_INFO(&psmx2_prov, FI_LOG_CORE, "tag_mask: %016" PRIX64
+		", data_mask: %08" PRIX32 ", cq_data_size: %d\n",
+		PSMX2_TAG_MASK, PSMX2_DATA_MASK, *cq_data_size);
 }
 
 static int psmx2_get_yes_no(char *s, int default_value)
@@ -250,7 +274,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	enum fi_progress control_progress = FI_PROGRESS_MANUAL;
 	enum fi_progress data_progress = FI_PROGRESS_MANUAL;
 	uint64_t caps = PSMX2_CAPS;
-	uint64_t max_tag_value = PSMX2_MAX_TAG;
+	int cq_data_size = 0;
 	int err = -FI_ENODATA;
 	int svc0, svc = PSMX2_ANY_SERVICE;
 	glob_t glob_buf;
@@ -589,6 +613,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 					"hints->domain_attr->caps=%lx, shared AV is unsupported\n",
 					hints->domain_attr->caps);
 			}
+
+			cq_data_size = hints->domain_attr->cq_data_size;
 		}
 
 		if (hints->ep_attr) {
@@ -682,6 +708,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		/* TODO: check other fields of hints */
 	}
 
+	psmx2_init_tag_layout(&cq_data_size);
+
 	psmx2_info = fi_allocinfo();
 	if (!psmx2_info) {
 		err = -FI_ENOMEM;
@@ -695,7 +723,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->ep_attr->max_order_raw_size = PSMX2_RMA_ORDER_SIZE;
 	psmx2_info->ep_attr->max_order_war_size = PSMX2_RMA_ORDER_SIZE;
 	psmx2_info->ep_attr->max_order_waw_size = PSMX2_RMA_ORDER_SIZE;
-	psmx2_info->ep_attr->mem_tag_format = ofi_tag_format(max_tag_value);
+	psmx2_info->ep_attr->mem_tag_format = ofi_tag_format(PSMX2_MAX_TAG);
 	psmx2_info->ep_attr->tx_ctx_cnt = tx_ctx_cnt;
 	psmx2_info->ep_attr->rx_ctx_cnt = rx_ctx_cnt;
 
@@ -710,7 +738,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->domain_attr->av_type = av_type;
 	psmx2_info->domain_attr->mr_mode = mr_mode;
 	psmx2_info->domain_attr->mr_key_size = sizeof(uint64_t);
-	psmx2_info->domain_attr->cq_data_size = 4;
+	psmx2_info->domain_attr->cq_data_size = cq_data_size;
 	psmx2_info->domain_attr->cq_cnt = 65535;
 	psmx2_info->domain_attr->ep_cnt = 65535;
 	psmx2_info->domain_attr->tx_ctx_cnt = psmx2_env.sep_trx_ctxt;


### PR DESCRIPTION
Change the default tag layout setting to "auto" which would choose
the best option based on the hints passed to fi_getinfo(). More
specifically, "tag64" is used if "hints->domain_attr->cq_data_size"
is 0, and "tag60" is used otherwise.

The default selection can still be overridden by explicitly setting
FI_PSM2_TAG_LAYOUT to "tag60" or "tag64".

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>