### PR TITLE
prov/psm2: Improve how Tx/Rx context limits are handled

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -94,7 +94,6 @@ extern struct fi_provider psmx2_prov;
 
 #define PSMX2_DOM_CAPS	(FI_LOCAL_COMM | FI_REMOTE_COMM)
 
-#define PSMX2_MAX_TRX_CTXT	(80)
 #define PSMX2_ALL_TRX_CTXT	((void *)-1)
 #define PSMX2_MAX_MSG_SIZE	((0x1ULL << 32) - 1)
 #define PSMX2_RMA_ORDER_SIZE	(4096)
@@ -747,7 +746,7 @@ struct psmx2_env {
 	char *prog_affinity;
 	int multi_ep;
 	int max_trx_ctxt;
-	int sep_trx_ctxt;
+	int free_trx_ctxt;
 	int num_devunits;
 	int inject_size;
 	int lock_level;

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -950,18 +950,18 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 		goto errout;
 
 	if (info && info->ep_attr) {
-		if (info->ep_attr->tx_ctx_cnt > psmx2_env.sep_trx_ctxt) {
+		if (info->ep_attr->tx_ctx_cnt > psmx2_env.max_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"tx_ctx_cnt %"PRIu64" exceed limit %d.\n",
 				info->ep_attr->tx_ctx_cnt,
-				psmx2_env.sep_trx_ctxt);
+				psmx2_env.max_trx_ctxt);
 			goto errout;
 		}
-		if (info->ep_attr->rx_ctx_cnt > psmx2_env.sep_trx_ctxt) {
+		if (info->ep_attr->rx_ctx_cnt > psmx2_env.max_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"rx_ctx_cnt %"PRIu64" exceed limit %d.\n",
 				info->ep_attr->rx_ctx_cnt,
-				psmx2_env.sep_trx_ctxt);
+				psmx2_env.max_trx_ctxt);
 			goto errout;
 		}
 		ctxt_cnt = info->ep_attr->tx_ctx_cnt;


### PR DESCRIPTION
The number of "free contexts" is volatile and can't be depended on. Check
the user request against the "total contexts" instead. Let the PSM2 library
be the last and only place to determine if a free context is available.

Report the total number of contexts in "fi_info->domain_attr->max_ep_tx_ctx"
and "fi_info->domain_attr->max_ep_rx_ctx". This provides a static view of
the system limit that can actually be used by the application. Report the
current number of free contexts in "fi_info->domain_attr->tx_ctx_cnt" and
"fi_info->domain_attr->rx_ctx_cnt" to serve as a recommended value.

Remove the artificial limit PSMX2_MAX_TRX_CTXT that is no longer used.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>