### PR TITLE
prov/rxm: Implement postponed queue for RMA operations

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -158,6 +158,7 @@ struct rxm_rma_iov {
 #define RXM_PROTO_STATES(FUNC)	\
 	FUNC(RXM_TX_NOBUF),	\
 	FUNC(RXM_TX),		\
+	FUNC(RXM_TX_RMA),	\
 	FUNC(RXM_RX),		\
 	FUNC(RXM_LMT_TX),	\
 	FUNC(RXM_LMT_ACK_WAIT),	\
@@ -284,7 +285,7 @@ struct rxm_tx_entry {
 		struct rxm_rma_buf *rma_buf;
 	};
 
-	/* Used for large messages */
+	/* Used for large messages and RMA */
 	struct fid_mr *mr[RXM_IOV_LIMIT];
 	struct rxm_rx_buf *rx_buf;
 };
@@ -406,6 +407,9 @@ void rxm_ep_msg_mr_closev(struct fid_mr **mr, size_t count);
 void rxm_ep_handle_postponed_tx_op(struct rxm_ep *rxm_ep,
 				   struct rxm_conn *rxm_conn,
 				   struct rxm_tx_entry *tx_entry);
+void rxm_ep_handle_postponed_rma_op(struct rxm_ep *rxm_ep,
+				    struct rxm_conn *rxm_conn,
+				    struct rxm_tx_entry *tx_entry);
 
 static inline void rxm_cntr_inc(struct util_cntr *cntr)
 {

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -210,6 +210,8 @@ static void rxm_conn_handle_postponed_op(struct rxm_ep *rxm_ep,
 				tx_entry, postponed_entry);
 		if (!(tx_entry->comp_flags & FI_RMA))
 			 rxm_ep_handle_postponed_tx_op(rxm_ep, rxm_conn, tx_entry);
+		else
+			rxm_ep_handle_postponed_rma_op(rxm_ep, rxm_conn, tx_entry);
 	}
 }
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -576,8 +576,12 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 			rxm_ep_msg_mr_closev(tx_entry->mr, tx_entry->count);
 		return rxm_finish_send_nobuf(tx_entry);
 	case RXM_TX:
-		assert(comp->flags & (FI_SEND | FI_WRITE));
+		assert(comp->flags & FI_SEND);
 		return rxm_finish_send(tx_entry);
+	case RXM_TX_RMA:
+		assert(comp->flags & (FI_WRITE | FI_READ));
+		rxm_rma_buf_release(rxm_ep, tx_entry->rma_buf);
+		return rxm_finish_send_nobuf(tx_entry);
 	case RXM_RX:
 		assert(!(comp->flags & FI_REMOTE_READ));
 		assert((rx_buf->pkt.hdr.version == OFI_OP_VERSION) &&

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -154,7 +154,7 @@ static int rxm_mr_reg(struct fid *domain_fid, const void *buf, size_t len,
 	rxm_mr->mr_fid.fid.ops = &rxm_mr_ops;
 	/* Store msg_mr as rxm_mr descriptor so that we can get its key when
 	 * the app passes msg_mr as the descriptor in fi_send and friends.
-	 * The key would be used in large message transfer protocol. */
+	 * The key would be used in large message transfer protocol and RMA. */
 	rxm_mr->mr_fid.mem_desc = rxm_mr->msg_mr;
 	rxm_mr->mr_fid.key = fi_mr_key(rxm_mr->msg_mr);
 	*mr = &rxm_mr->mr_fid;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -144,6 +144,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 
 			switch (pool->type) {
 			case RXM_BUF_POOL_TX_MSG:
+			case RXM_BUF_POOL_RMA:
 				tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_data;
 				tx_buf->pkt.hdr.op = ofi_op_msg;
 				break;
@@ -310,6 +311,15 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 		if (ret)
 			goto err;
 	}
+
+	ret = rxm_buf_pool_create(rxm_ep,
+				  rxm_ep->msg_info->tx_attr->size,
+				  rxm_ep->rxm_info->tx_attr->inject_size +
+				  sizeof(struct rxm_rma_buf),
+				  &rxm_ep->buf_pools[RXM_BUF_POOL_RMA],
+				  RXM_BUF_POOL_RMA);
+	if (ret)
+		goto err;
 
 	return FI_SUCCESS;
 err:


### PR DESCRIPTION
- The 1st pathc applies some minor refactoring to RxM's RMA transport.
Some code is moved into common functions that will be re-used for implementing postponed queue for RMA
- The 2nd patch adds implementation of postponed queue for RMA operations

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>