### PR TITLE
prov/psm,psm2: Shortcut obviously unsuccessful fi_getinfo() calls

### DIFF
--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -616,7 +616,7 @@ static inline void psmx_domain_release(struct psmx_fid_domain *domain)
 	ofi_atomic_dec32(&domain->util_domain.ref);
 }
 
-int	psmx_domain_check_features(struct psmx_fid_domain *domain, int ep_cap);
+int	psmx_domain_check_features(struct psmx_fid_domain *domain, uint64_t ep_caps);
 int	psmx_domain_enable_ep(struct psmx_fid_domain *domain, struct psmx_fid_ep *ep);
 void	psmx_domain_disable_ep(struct psmx_fid_domain *domain, struct psmx_fid_ep *ep);
 

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -339,16 +339,21 @@ err_out:
 }
 
 static int psmx2_domain_check_features(struct psmx2_fid_domain *domain,
-				       uint64_t ep_cap)
+				       uint64_t ep_caps)
 {
-	if ((domain->caps & ep_cap & ~PSMX2_SUB_CAPS) !=
-	    (ep_cap & ~PSMX2_SUB_CAPS)) {
-		uint64_t mask = ~PSMX2_SUB_CAPS;
+	uint64_t domain_caps = domain->caps & ~PSMX2_SUB_CAPS;
+
+	ep_caps &= ~PSMX2_SUB_CAPS;
+
+	if ((domain_caps & ep_caps) != ep_caps) {
 		FI_INFO(&psmx2_prov, FI_LOG_CORE,
-			"caps mismatch: domain->caps=%s,\n ep->caps=%s,\n mask=%s\n",
-			fi_tostr(&domain->caps, FI_TYPE_CAPS),
-			fi_tostr(&ep_cap, FI_TYPE_CAPS),
-			fi_tostr(&mask, FI_TYPE_CAPS));
+			"caps mismatch: domain_caps=%s;\n",
+			fi_tostr(&domain_caps, FI_TYPE_CAPS));
+
+		FI_INFO(&psmx2_prov, FI_LOG_CORE,
+			"caps mismatch: ep_caps=%s.\n",
+			fi_tostr(&ep_caps, FI_TYPE_CAPS));
+
 		return -FI_EOPNOTSUPP;
 	}
 


### PR DESCRIPTION
Move some quick checks to the very beginning so that queries that are
apparently unsuitable for the provider will immediately return, thus
avoiding any further steps related to provider initialization.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>