### PR TITLE
prov/psm2: Use multiple provider instances for different tag layout

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -210,6 +210,7 @@ extern uint64_t	psmx2_tag_mask;
 extern uint32_t	psmx2_tag_upper_mask;
 extern uint32_t	psmx2_data_mask;
 extern int	psmx2_flags_idx;
+extern int	psmx2_tag_layout_locked;
 #endif
 
 #define PSMX2_FLAGS_MASK	((uint32_t)0xF0000000)
@@ -809,6 +810,7 @@ static inline void psmx2_unlock(fastlock_t *lock, int lock_level)
 		fastlock_release(lock);
 }
 
+void	psmx2_init_tag_layout(int *cq_data_size, int to_lock);
 int	psmx2_fabric(struct fi_fabric_attr *attr,
 		     struct fid_fabric **fabric, void *context);
 int	psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -276,6 +276,7 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct psmx2_fid_domain *domain_priv;
 	struct psmx2_ep_name *src_addr = info->src_addr;
 	int mr_mode = (info->domain_attr->mr_mode & FI_MR_BASIC) ? FI_MR_BASIC : 0;
+	int cq_data_size = info->domain_attr->cq_data_size;
 	int err;
 
 	FI_INFO(&psmx2_prov, FI_LOG_DOMAIN, "\n");
@@ -324,6 +325,12 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	psmx2_lock(&fabric_priv->domain_lock, 1);
 	dlist_insert_before(&domain_priv->entry, &fabric_priv->domain_list);
 	psmx2_unlock(&fabric_priv->domain_lock, 1);
+
+	psmx2_init_tag_layout(&cq_data_size, 1);
+	if (cq_data_size != info->domain_attr->cq_data_size)
+		FI_INFO(&psmx2_prov, FI_LOG_CORE,
+			"cq_data_size: asked %ld, got %d\n",
+			info->domain_attr->cq_data_size, cq_data_size);
 
 	*domain = &domain_priv->util_domain.domain_fid;
 	return 0;


### PR DESCRIPTION
Some applications may query the providers with empty hints and manually
filter the results. In such case, the tag layout being auto selected
would be missing remote CQ data support. Adding the alternative layout
as a second provider instance allows the application to see all the
available options and avoid skipping the provider unnecessarily.

Also add mechanism to prevent the tag layout being changed after a domain
has been opened.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>