### PR TITLE
configure: Introduce version suffix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,14 @@ debug_c_warn_flags="-Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-missing
 debug_c_other_flags="-fstack-protector-strong"
 picky_c_warn_flags="-Wno-long-long -Wmissing-prototypes -Wstrict-prototypes -Wcomment -pedantic"
 
+AC_ARG_WITH([build_id],
+	    [AC_HELP_STRING([--with-build_id],
+			    [Enable build_id annotation @<:@default=no@:>@])],
+	    [], [with_build_id=no])
+AS_IF([test x"$with_build_id" = x"no"], [with_build_id=""])
+AC_DEFINE_UNQUOTED([BUILD_ID],["$with_build_id"],
+                   [adds build_id to version if it was defined])
+
 AC_ARG_ENABLE([debug],
 	      [AS_HELP_STRING([--enable-debug],
 			      [Enable debugging @<:@default=no@:>@])

--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -192,3 +192,7 @@
 /* Version number of package */
 #define _FI_EXP(s) #s
 #define VERSION _FI_EXP(FI_MAJOR_VERSION) "." _FI_EXP(FI_MINOR_VERSION) ".0"
+
+#ifndef BUILD_ID
+#define BUILD_ID ""
+#endif

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -606,6 +606,7 @@ static void fi_tostr_atomic_op(char *buf, enum fi_op op)
 static void fi_tostr_version(char *buf)
 {
 	strcatf(buf, VERSION);
+	strcatf(buf, BUILD_ID);
 }
 
 static void fi_tostr_eq_event(char *buf, int type)


### PR DESCRIPTION
This patch introduces version suffix that can be applied to the library version by `--with-version_string=<string>`  

Examples on how this works:
1. `$ ./configure --with-version_suffix=RHEL7.4`
    `$ fi_info --version`
       `/p/pdsd/Users/dgladkov/ofi/bin/fi_info: 1.6.0rc1`
       `libfabric: 1.6.0rc1-RHEL7.4`
       `libfabric api: 1.6`

2. `$ ./configure`
    `$ fi_info --version`
       `/p/pdsd/Users/dgladkov/ofi/bin/fi_info: 1.6.0rc1`
       `libfabric: 1.6.0rc1`


Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>