### PR TITLE
prov/sockets: Fix possible removal of in use connection

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -403,14 +403,11 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
         		idx = fi_addr[i] & sock_ep->attr->av->mask;
 			conn = ofi_idm_lookup(&sock_ep->attr->av_idm, idx);
 			if (conn) {
-				/*
-				 * check for conn either in connection progress or
-				 * already closed.
+				/* A peer may be using the connection, so leave
+				 * it operational, just dissociate it from AV.
 				 */
-				if((conn != SOCK_CM_CONN_IN_PROGRESS)  &&
-					(conn->sock_fd != -1)) {
-					sock_ep_remove_conn(sock_ep->attr, conn);
-				}
+				if (conn->av_index == idx)
+					conn->av_index = FI_ADDR_NOTAVAIL;
 				ofi_idm_clear(&sock_ep->attr->av_idm, idx);
 			}
 		}


### PR DESCRIPTION
See Issue #3828.

An endpoint maintains a mirror of the associated AV used to map
the AV index to a specific tcp connection.  However, if an
address is inserted into the AV more than once (which happens
in some MPI use cases), there can be multiple mappings from
the endpoints av_idm (AV index map) to a given conn_map
(connection map) entry.

When an AV entry is removed, any connection that references that
entry is also removed.  This results in other av_idm entries that
reference that same connection pointing to a connection that
is no longer usable.

Although this is not a fail safe solution, when an AV entry is
removed, leave any associated connection to that entry connected.
This allows peers to continue sending to the local endpoint.
Instead, simply remove the association from the connection map
back to the AV itself (i.e. set the conn->av_index to
FI_ADDR_NOTAVAIL).

If another av_idm entry uses the same connection, this will result
in the conn->av_index being updated to match the new AV entry.

Note that there are still potential problems if an app inserts
the same address multiple times and uses recvfrom() calls to
match receive buffers based on the source.  There's no obvious
or non-obvious fix for this at the moment.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>