### PR TITLE
util: clear the FI_DIRECTED_RECV capability bit since the test does not use it

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -1439,6 +1439,11 @@ static int pp_getinfo(struct ct_pingpong *ct, struct fi_info *hints,
 		ct->rx_ctx_ptr = NULL;
 	}
 
+	if (hints && ((hints->caps & FI_DIRECTED_RECV) == 0)) {
+		(*info)->caps &= ~FI_DIRECTED_RECV;
+		(*info)->rx_attr->caps &= ~FI_DIRECTED_RECV;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
The pingpong test does not pass the source address with the various send operations and does not specify the FI_DIRECTED_RECV capability bit as a hint to fi_getinfo() accordingly.

However, according to the fi_getinfo man page (circa dcf66b):

> Providers may indicate support for additional capabilities beyond those requested when the use of expanded capabilities will not adversely affect performance or expose the application to communication beyond that which was requested.

An application may not request FI_DIRECTED_RECV but a provider may report that it is available anyway. Unless the application will use the FI_DIRECTED_RECV capability it must clear the FI_DIRECTED_RECV capability bit before creating fi objects (domain, endpoint, etc) otherwise the provider will not ignore the src_addr parameter as it ought to:

> FI_DIRECTED_RECV
> Requests that the communication endpoint use the source address of an incoming message when matching it with a receive buffer. If this capability is not set, then the src_addr parameter for msg and tagged receive operations is ignored.
