### PR TITLE
prov/psm2: Bug fix and improvements to tagged message

### DIFF
--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -36,9 +36,13 @@ static void psmx2_ep_optimize_ops(struct psmx2_fid_ep *ep)
 {
 	int send_completion;
 	int recv_completion;
+	uint64_t mask;
+
+	mask = PSMX2_OP_FLAGS &
+	       ~(FI_INJECT_COMPLETE | FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE);
 
 	if (ep->ep.tagged) {
-		if (ep->tx_flags & ~FI_COMPLETION || ep->rx_flags & ~FI_COMPLETION) {
+		if (ep->tx_flags & mask & ~FI_COMPLETION || ep->rx_flags & mask & ~FI_COMPLETION) {
 			ep->ep.tagged = &psmx2_tagged_ops;
 			FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
 				"generic tagged ops.\n");

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -716,7 +716,13 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 		/* TODO: check other fields of hints */
 	}
 
+	if (hints && (hints->caps & FI_REMOTE_CQ_DATA))
+		cq_data_size = 4;
+
 	psmx2_init_tag_layout(&cq_data_size, 0);
+
+	if (!cq_data_size)
+		caps &= ~FI_REMOTE_CQ_DATA;
 
 	psmx2_info = fi_allocinfo();
 	if (!psmx2_info) {
@@ -814,6 +820,7 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	    !psmx2_tag_layout_locked) {
 		psmx2_info_2 = fi_dupinfo(psmx2_info);
 		if (psmx2_info_2) {
+			psmx2_info_2->caps |= FI_REMOTE_CQ_DATA;
 			psmx2_info_2->ep_attr->mem_tag_format =
 					ofi_tag_format(PSMX2_TAG_MASK_60);
 			psmx2_info_2->domain_attr->cq_data_size = 4;

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -1125,8 +1125,14 @@ ssize_t psmx2_tagged_senddata(struct fid_ep *ep, const void *buf, size_t len,
 			      void *desc, uint64_t data, fi_addr_t dest_addr,
 			      uint64_t tag, void *context)
 {
+	struct psmx2_fid_ep *ep_priv;
+
+	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
+
 	return psmx2_tagged_send_generic(ep, buf, len, desc, dest_addr,
-					 tag, context, FI_REMOTE_CQ_DATA, data);
+					 tag, context,
+					 ep_priv->tx_flags | FI_REMOTE_CQ_DATA,
+					 data);
 }
 
 #define PSMX2_TAGGED_SENDV_FUNC(suffix)					\


### PR DESCRIPTION
* Improve automatic tag layout selection
* Reduce noise when optimizing tagged message functions
* Fix a bug in fi_tsenddata()

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>