### PR TITLE
common: Change provider priority (RxM before Verbs)

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -153,15 +153,15 @@ static struct ofi_prov *ofi_create_prov_entry(const char *prov_name)
  */
 static void ofi_ordered_provs_init(void)
 {
-	char *ordered_prov_names[] =
-			{"psm2", "psm", "usnic", "mlx", "verbs","gni",
-			 "bgq", "netdir", "ofi_rxm", "ofi_rxd",
-			/* Initialize the socket(s) provider last.  This will result in
-			 * it being the least preferred provider. */
+	char *ordered_prov_names[] = {
+		"psm2", "psm", "usnic", "mlx", "ofi_rxm", "verbs",
+		"gni", "bgq", "netdir", "ofi_rxd",
+		/* Initialize the socket(s) provider last.  This will result in
+		 * it being the least preferred provider. */
 
-			/* Before you add ANYTHING here, read the comment above!!! */
-			"UDP", "sockets", "tcp" /* NOTHING GOES HERE! */};
-			/* Seriously, read it! */
+		/* Before you add ANYTHING here, read the comment above!!! */
+		"UDP", "sockets", "tcp" /* NOTHING GOES HERE! */ };
+		/* Seriously, read it! */
 	int num_provs = sizeof(ordered_prov_names)/sizeof(ordered_prov_names[0]), i;
 
 	for (i = 0; i < num_provs; i++) {
@@ -484,12 +484,12 @@ libdl_done:
 	ofi_register_provider(PSM_INIT, NULL);
 	ofi_register_provider(USNIC_INIT, NULL);
 	ofi_register_provider(MLX_INIT, NULL);
+	ofi_register_provider(RXM_INIT, NULL);
 	ofi_register_provider(VERBS_INIT, NULL);
 	ofi_register_provider(GNI_INIT, NULL);
 	ofi_register_provider(BGQ_INIT, NULL);
 	ofi_register_provider(NETDIR_INIT, NULL);
 	ofi_register_provider(SHM_INIT, NULL);
-	ofi_register_provider(RXM_INIT, NULL);
 
 	{
 		/* TODO: RXD is not stable for now. Disable it by default */


### PR DESCRIPTION
This patch changes provider priority list:
RxM before Verbs  to ensure that RxM/verbs/MSG has a higher priority than verbs/RDM

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>