### PR TITLE
core: Reorder provider list to move rxm before verbs

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -154,8 +154,8 @@ static struct ofi_prov *ofi_create_prov_entry(const char *prov_name)
 static void ofi_ordered_provs_init(void)
 {
 	char *ordered_prov_names[] =
-			{"psm2", "psm", "usnic", "mlx", "verbs","gni",
-			 "bgq", "netdir", "ofi_rxm", "ofi_rxd",
+			{"psm2", "psm", "usnic", "mlx", "gni",
+			 "bgq", "netdir", "ofi_rxm", "ofi_rxd", "verbs",
 			/* Initialize the socket(s) provider last.  This will result in
 			 * it being the least preferred provider. */
 
@@ -484,12 +484,12 @@ libdl_done:
 	ofi_register_provider(PSM_INIT, NULL);
 	ofi_register_provider(USNIC_INIT, NULL);
 	ofi_register_provider(MLX_INIT, NULL);
-	ofi_register_provider(VERBS_INIT, NULL);
 	ofi_register_provider(GNI_INIT, NULL);
 	ofi_register_provider(BGQ_INIT, NULL);
 	ofi_register_provider(NETDIR_INIT, NULL);
 	ofi_register_provider(SHM_INIT, NULL);
 	ofi_register_provider(RXM_INIT, NULL);
+	ofi_register_provider(VERBS_INIT, NULL);
 
 	{
 		/* TODO: RXD is not stable for now. Disable it by default */


### PR DESCRIPTION
The rxm RDM EP support is more complete than that provided by
the verbs provider.  Move RxM before verbs, so that rxm RDM EPs
will be preferred over verbs.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>