### PR TITLE
prov/psm2: Minor tweaks to AV type checking and debugging output

### DIFF
--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -111,7 +111,7 @@ int psmx2_am_init(struct psmx2_trx_ctxt *trx_ctxt)
 	int err = 0;
 	uint32_t max_atomic_size;
 
-	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
+	FI_INFO(&psmx2_prov, FI_LOG_CORE, "epid %016lx\n", trx_ctxt->psm2_epid);
 
 	if (!trx_ctxt->am_initialized) {
 		err = psm2_am_get_parameters(psm2_ep, &trx_ctxt->psm2_am_param,

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -449,16 +449,11 @@ static int psmx2_av_connect_trx_ctxt(struct psmx2_fid_av *av,
 				}
 			}
 
-			FI_INFO(&psmx2_prov, FI_LOG_AV,
-				"%d: psm2_ep_connect returned %s. remote epid=%lx.\n",
-				i, psm2_error_get_string(errors[i]), epids[i]);
-			if (epids[i] == 0)
-				FI_INFO(&psmx2_prov, FI_LOG_AV,
-					"does the application depend on the provider"
-					"to resolve IP address into endpoint id? if so"
-					"check if the name server has started correctly"
-					"at the other side.\n");
-			epaddrs[i] = (void *)FI_ADDR_NOTAVAIL;
+			FI_WARN(&psmx2_prov, FI_LOG_AV,
+				"%d: psm2_ep_connect (%lx --> %lx): %s\n",
+				i, trx_ctxt->psm2_epid, epids[i],
+				psm2_error_get_string(errors[i]));
+			epaddrs[i] = NULL;
 			error_count++;
 		}
 	}
@@ -535,7 +530,7 @@ int psmx2_av_add_trx_ctxt(struct psmx2_fid_av *av,
 	int id = trx_ctxt->id;
 
 	if (id >= av->max_trx_ctxt) {
-		FI_INFO(&psmx2_prov, FI_LOG_AV,
+		FI_WARN(&psmx2_prov, FI_LOG_AV,
 			"trx_ctxt->id(%d) exceeds av->max_trx_ctxt(%d).\n",
 			id, av->max_trx_ctxt);
 		return -FI_EINVAL;
@@ -592,7 +587,7 @@ static int psmx2_av_insert(struct fid_av *av, const void *addr,
 	int sep_count = 0;
 
 	if (count && !addr) {
-		FI_INFO(&psmx2_prov, FI_LOG_AV,
+		FI_WARN(&psmx2_prov, FI_LOG_AV,
 			"the input address array is NULL.\n");
 		return -FI_EINVAL;
 	}

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -78,7 +78,7 @@ static void psmx2_ep_optimize_ops(struct psmx2_fid_ep *ep)
 					else
 						ep->ep.tagged = &psmx2_tagged_ops_no_flag_av_map_directed;
 					FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
-						"tagged ops optimized for op_flags=0\n");
+						"tagged ops optimized for op_flags=0 and directed receive\n");
 				}
 			} else {
 				if (!send_completion && !recv_completion) {

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -544,14 +544,8 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 
 		if (hints->domain_attr) {
 			switch (hints->domain_attr->av_type) {
-			case FI_AV_MAP:
-				if (psmx2_env.lazy_conn) {
-					FI_INFO(&psmx2_prov, FI_LOG_CORE,
-						"FI_AV_MAP is not supported when lazy connection is enabled.\n");
-					goto err_out;
-				}
-				/* fall through */
 			case FI_AV_UNSPEC:
+			case FI_AV_MAP:
 			case FI_AV_TABLE:
 				av_type = hints->domain_attr->av_type;
 				break;
@@ -740,9 +734,6 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	psmx2_info->ep_attr->mem_tag_format = ofi_tag_format(PSMX2_MAX_TAG);
 	psmx2_info->ep_attr->tx_ctx_cnt = tx_ctx_cnt;
 	psmx2_info->ep_attr->rx_ctx_cnt = rx_ctx_cnt;
-
-	if (psmx2_env.lazy_conn)
-		av_type = FI_AV_TABLE;
 
 	psmx2_info->domain_attr->threading = threading;
 	psmx2_info->domain_attr->control_progress = control_progress;

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -152,6 +152,8 @@ void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt)
 	if (!trx_ctxt)
 		return;
 
+	FI_INFO(&psmx2_prov, FI_LOG_CORE, "epid: %016lx\n", trx_ctxt->psm2_epid);
+
 	if (psmx2_env.disconnect)
 		psmx2_trx_ctxt_disconnect_peers(trx_ctxt);
 
@@ -254,7 +256,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 				   &trx_ctxt->psm2_ep, &trx_ctxt->psm2_epid);
 		if (err != PSM2_OK) {
 			FI_WARN(&psmx2_prov, FI_LOG_CORE,
-				"psm2_ep_open returns %d, errno=%d\n", err, errno);
+				"psm2_ep_open retry returns %d, errno=%d\n", err, errno);
 			err = psmx2_errno(err);
 			goto err_out_destroy_pool;
 		}


### PR DESCRIPTION
Always allow the application to ask for FI_AV_MAP or FI_AV_TABLE,
even though it may be forced to FI_AV_TABLE internally.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>