### PR TITLE
prov/psm,psm2: Move environment variable reading out from fi_getinfo()

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -290,8 +290,6 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 		return -FI_ENODATA;
 	}
 
-	psmx_init_env();
-
 	src_addr = calloc(1, sizeof(*src_addr));
 	if (!src_addr) {
 		FI_INFO(&psmx_prov, FI_LOG_CORE,
@@ -746,6 +744,8 @@ PROVIDER_INI
 			"of core_ids. Both <start> and <end> can be either the core_id "
 			"(when >=0) or core_id - num_cores (when <0). "
 			"(default: affinity not set)");
+
+	psmx_init_env();
 
 	pthread_mutex_init(&psmx_lib_mutex, NULL);
 	psmx_init_count++;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -375,7 +375,6 @@ static int psmx2_getinfo(uint32_t version, const char *node,
 	}
 
 	psmx2_env.num_devunits = cnt;
-	psmx2_init_env();
 
 	psmx2_update_sep_cap();
 	tx_ctx_cnt = psmx2_env.free_trx_ctxt;
@@ -916,6 +915,8 @@ PROVIDER_INI
 			"tag60 means 32/4/60 for data/flags/tag;"
 			"tag64 means 4/28/64 for flags/data/tag (default: tag60).");
 #endif
+
+	psmx2_init_env();
 
 	pthread_mutex_init(&psmx2_lib_mutex, NULL);
 	psmx2_init_count++;


### PR DESCRIPTION
These variables are not supposed to change during the run and thus
there is no need to recheck for each fi_getinfo() call.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>