### PR TITLE
prov/hook + shm: Change checks to asserts

### DIFF
--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -80,6 +80,7 @@ struct fid *hook_to_hfid(const struct fid *fid)
 		return &(container_of(fid, struct hook_mr, mr.fid)->
 			 hmr->fid);
 	default:
+		assert(0);
 		return NULL;
 	}
 }

--- a/prov/hook/src/hook.h
+++ b/prov/hook/src/hook.h
@@ -33,6 +33,8 @@
 #ifndef _OFI_HOOK_H_
 #define _OFI_HOOK_H_
 
+#include <assert.h>
+
 #include <rdma/fabric.h>
 #include <rdma/fi_atomic.h>
 #include <rdma/fi_cm.h>

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -205,34 +205,23 @@ static ssize_t smr_generic_atomic(struct fid_ep *ep_fid,
 	
 	switch (op) {
 	case ofi_op_atomic_compare:
-		if (!compare_ioc) {
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-				"no compare buffer given\n");
-			ret = -FI_EINVAL;
-			goto unlock_cq;
-		}
+		assert(compare_ioc);
 		smr_ioc_to_iov(compare_ioc, compare_iov, compare_count,
 			       ofi_datatype_size(datatype));
 		total_len *= 2;
 		/* fall through */
 	case ofi_op_atomic_fetch:
-		if (!result_ioc) {
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-				"no result buffer given\n");
-			ret = -FI_EINVAL;
-			goto unlock_cq;
-		}
+		assert(result_ioc);
 		smr_ioc_to_iov(result_ioc, result_iov, result_count,
 			       ofi_datatype_size(datatype));
 		/* fall through */
 	case ofi_op_atomic:
-		if (!ioc && atomic_op != FI_ATOMIC_READ) {
-			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-				"no atomic buffer given\n");
-			ret = -FI_EINVAL;
-			goto unlock_cq;
+		if (atomic_op != FI_ATOMIC_READ) {
+			assert(ioc);
+			smr_ioc_to_iov(ioc, iov, count, ofi_datatype_size(datatype));
+		} else {
+			count = 0;
 		}
-		smr_ioc_to_iov(ioc, iov, count, ofi_datatype_size(datatype));
 		break;
 	default:
 		break;


### PR DESCRIPTION
hook_to_hfid can return NULL in the default case.  This is an
unexpected code flow (coding error), but can trigger warnings
from static code analysis tools.  Add an assert to silence them.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>