### PR TITLE
prov/tcp bug fix for inject messages

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -207,8 +207,8 @@ struct tcpx_msg_data {
 		struct iovec		iov[TCPX_IOV_LIMIT+1];
 		struct fi_rma_iov	rma_iov[TCPX_IOV_LIMIT+1];
 		struct fi_rma_ioc	ram_ioc[TCPX_IOV_LIMIT+1];
-		uint8_t			inject[TCPX_MAX_INJECT_SZ];
 	};
+	uint8_t			inject[TCPX_MAX_INJECT_SZ];
 };
 
 struct tcpx_pe_entry {


### PR DESCRIPTION
Moving the inject out of union, as multiple fields being used in case of inject messages.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>