### PR TITLE
prov/tcp Bug fix to resize available rx buffers before passing to readv

### DIFF
--- a/include/ofi_iov.h
+++ b/include/ofi_iov.h
@@ -126,4 +126,6 @@ ofi_iov_within(const struct iovec *iov1, const struct iovec *iov2)
 
 void ofi_consume_iov(struct iovec *iovec, size_t *iovec_count, size_t offset);
 
+void ofi_truncate_iov(struct iovec *iov, size_t *iov_count, size_t trim_size);
+
 #endif /* _OFI_IOV_H_ */

--- a/src/iov.c
+++ b/src/iov.c
@@ -86,3 +86,17 @@ out:
 	iov[0].iov_base = (uint8_t *)iov[0].iov_base + consumed;
 	iov[0].iov_len -= consumed;
 }
+
+void ofi_truncate_iov(struct iovec *iov, size_t *iov_count, size_t trim_size)
+{
+	size_t i;
+
+	for (i = 0; i < *iov_count; i++) {
+		if (trim_size <= iov[i].iov_len) {
+			iov[i].iov_len = trim_size;
+			*iov_count = i + 1;
+			return;
+		}
+		trim_size -= iov[i].iov_len;
+	}
+}


### PR DESCRIPTION
App can post buffers larger than anticipated rx size for a rx transaction. To ensure message boundaries, the posted buffer has to be matched with the size of transfer. Otherwise, next message(s) would be read into this buffer advertently.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>