### PR TITLE
prov/usnic: Remove MR mode bits for RMA.

### DIFF
--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2018, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -251,10 +251,9 @@ usdf_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			return -FI_ENODATA;
 		}
 
-		if (ofi_check_mr_mode(&usdf_ops,
-				      fabric->api_version,
-				      FI_MR_BASIC | OFI_MR_BASIC_MAP | FI_MR_LOCAL,
-				      info)) {
+		if (ofi_check_mr_mode(
+			&usdf_ops, fabric->api_version,
+			FI_MR_BASIC | FI_MR_ALLOCATED | FI_MR_LOCAL, info)) {
 			/* the caller ignored our fi_getinfo results */
 			USDF_WARN_SYS(DOMAIN, "MR mode (%d) not supported\n",
 				      info->domain_attr->mr_mode);

--- a/prov/usnic/src/usdf_ep_dgram.c
+++ b/prov/usnic/src/usdf_ep_dgram.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2018, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -435,7 +435,7 @@ static const struct fi_domain_attr dgram_dflt_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_DISABLED,
-	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL | FI_MR_BASIC,
+	.mr_mode = FI_MR_ALLOCATED | FI_MR_LOCAL | FI_MR_BASIC,
 	.cntr_cnt = USDF_DGRAM_CNTR_CNT,
 	.mr_iov_limit = USDF_DGRAM_MR_IOV_LIMIT,
 	.mr_cnt = USDF_DGRAM_MR_CNT,

--- a/prov/usnic/src/usdf_ep_msg.c
+++ b/prov/usnic/src/usdf_ep_msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2018, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -117,7 +117,7 @@ static const struct fi_domain_attr msg_dflt_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_DISABLED,
-	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL | FI_MR_BASIC,
+	.mr_mode = FI_MR_ALLOCATED | FI_MR_LOCAL | FI_MR_BASIC,
 	.cntr_cnt = USDF_MSG_CNTR_CNT,
 	.mr_iov_limit = USDF_MSG_MR_IOV_LIMIT,
 	.mr_cnt = USDF_MSG_MR_CNT,

--- a/prov/usnic/src/usdf_ep_rdm.c
+++ b/prov/usnic/src/usdf_ep_rdm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2014-2018, Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -120,7 +120,7 @@ static const struct fi_domain_attr rdm_dflt_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_DISABLED,
-	.mr_mode = OFI_MR_BASIC_MAP | FI_MR_LOCAL | FI_MR_BASIC,
+	.mr_mode = FI_MR_ALLOCATED | FI_MR_LOCAL | FI_MR_BASIC,
 	.cntr_cnt = USDF_RDM_CNTR_CNT,
 	.mr_iov_limit = USDF_RDM_MR_IOV_LIMIT,
 	.mr_cnt = USDF_RDM_MR_CNT,


### PR DESCRIPTION
usNIC doesn't support RMA at the moment so it should not require
FI_MR_PROV_KEY and FI_MR_VIRT_ADDR.

This closes #3871. 

Signed-off-by: Ben Turrubiates <bturrubi@cisco.com>