### PR TITLE
core, verbs: Implement MR caching limitation with a total cached size

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -184,7 +184,7 @@ struct ofi_mr_entry {
 struct ofi_mr_cache {
 	struct util_domain		*domain;
 	struct ofi_notification_queue	nq;
-	size_t				size;
+	size_t				max_cached_cnt;
 	size_t				entry_data_size;
 
 	RbtHandle			mr_tree;

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -190,10 +190,10 @@ struct ofi_mr_cache {
 	RbtHandle			mr_tree;
 	struct dlist_entry		lru_list;
 
-	uint64_t			cached_cnt;
-	uint64_t			search_cnt;
-	uint64_t			delete_cnt;
-	uint64_t			hit_cnt;
+	size_t				cached_cnt;
+	size_t				search_cnt;
+	size_t				delete_cnt;
+	size_t				hit_cnt;
 
 	int				(*add_region)(struct ofi_mr_cache *cache,
 						      struct ofi_mr_entry *entry);

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -185,12 +185,14 @@ struct ofi_mr_cache {
 	struct util_domain		*domain;
 	struct ofi_notification_queue	nq;
 	size_t				max_cached_cnt;
+	size_t				max_cached_size;
 	size_t				entry_data_size;
 
 	RbtHandle			mr_tree;
 	struct dlist_entry		lru_list;
 
 	size_t				cached_cnt;
+	size_t				cached_size;
 	size_t				search_cnt;
 	size_t				delete_cnt;
 	size_t				hit_cnt;

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -570,7 +570,8 @@ char *fi_tostr(const void *data, enum fi_type datatype);
 enum fi_param_type {
 	FI_PARAM_STRING,
 	FI_PARAM_INT,
-	FI_PARAM_BOOL
+	FI_PARAM_BOOL,
+	FI_PARAM_SIZE_T,
 };
 
 struct fi_param {

--- a/include/rdma/providers/fi_prov.h
+++ b/include/rdma/providers/fi_prov.h
@@ -130,6 +130,11 @@ fi_param_get_bool(struct fi_provider *provider, const char *param_name, int *val
 	return fi_param_get(provider, param_name, value);
 }
 
+static inline int
+fi_param_get_size_t(struct fi_provider *provider, const char *param_name, size_t *value)
+{
+	return fi_param_get(provider, param_name, value);
+}
 
 #ifdef __cplusplus
 }

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -62,8 +62,11 @@ static void util_mr_free_entry(struct ofi_mr_cache *cache,
 		ofi_monitor_unsubscribe(&entry->subscription);
 	}
 	cache->delete_region(cache, entry);
-	free(entry);
+	assert((cache->cached_cnt != 0) &&
+	       (((ssize_t)cache->cached_size - (ssize_t)entry->iov.iov_len) >= 0));
 	cache->cached_cnt--;
+	cache->cached_size -= entry->iov.iov_len;
+	free(entry);
 }
 
 static void util_mr_uncache_entry(struct ofi_mr_cache *cache,
@@ -156,7 +159,9 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 		return ret;
 	}
 
-	if (++cache->cached_cnt > cache->max_cached_cnt) {
+	cache->cached_size += iov->iov_len;
+	if ((++cache->cached_cnt > cache->max_cached_cnt) ||
+	    (cache->cached_size > cache->max_cached_size)) {
 		(*entry)->cached = 0;
 	} else {
 		ret = ofi_monitor_subscribe(&cache->nq, iov->iov_base, iov->iov_len,
@@ -234,7 +239,8 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
 	cache->search_cnt++;
 
-	while ((cache->cached_cnt >= cache->max_cached_cnt) &&
+	while (((cache->cached_cnt >= cache->max_cached_cnt) ||
+		(cache->cached_size >= cache->max_cached_size)) &&
 	       ofi_mr_cache_flush(cache))
 		;
 
@@ -278,6 +284,7 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 	ofi_monitor_del_queue(&cache->nq);
 	ofi_atomic_dec32(&cache->domain->ref);
 	assert(cache->cached_cnt == 0);
+	assert(cache->cached_size == 0);
 }
 
 int ofi_mr_cache_init(struct util_domain *domain, struct ofi_mem_monitor *monitor,
@@ -294,6 +301,9 @@ int ofi_mr_cache_init(struct util_domain *domain, struct ofi_mem_monitor *monito
 
 	dlist_init(&cache->lru_list);
 	cache->cached_cnt = 0;
+	cache->cached_size = 0;
+	if (!cache->max_cached_size)
+		cache->max_cached_size = SIZE_MAX;
 	cache->search_cnt = 0;
 	cache->delete_cnt = 0;
 	cache->hit_cnt = 0;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -262,7 +262,7 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 	struct dlist_entry *tmp;
 
 	FI_INFO(cache->domain->prov, FI_LOG_MR, "MR cache stats: "
-		"searches %" PRIu64 ", deletes %" PRIu64 ", hits %" PRIu64 "\n",
+		"searches %zu, deletes %zu, hits %zu\n",
 		cache->search_cnt, cache->delete_cnt, cache->hit_cnt);
 
 	util_mr_cache_process_events(cache);

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -156,7 +156,7 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 		return ret;
 	}
 
-	if (++cache->cached_cnt > cache->size) {
+	if (++cache->cached_cnt > cache->max_cached_cnt) {
 		(*entry)->cached = 0;
 	} else {
 		ret = ofi_monitor_subscribe(&cache->nq, iov->iov_base, iov->iov_len,
@@ -234,7 +234,8 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
 	cache->search_cnt++;
 
-	while ((cache->cached_cnt >= cache->size) && ofi_mr_cache_flush(cache))
+	while ((cache->cached_cnt >= cache->max_cached_cnt) &&
+	       ofi_mr_cache_flush(cache))
 		;
 
 	iter = rbtFind(cache->mr_tree, (void *) attr->mr_iov);

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -59,7 +59,6 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.iface			= NULL,
 	.mr_cache_enable	= 0,
 	.mr_max_cached_cnt	= 4096,
-	.mr_cache_lazy_size	= 0,
 
 	.rdm			= {
 		.buffer_num		= FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM,
@@ -577,14 +576,6 @@ static int fi_ibv_read_params(void)
 	    (fi_ibv_gl_data.mr_max_cached_cnt < 0)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of mr_max_cached_cnt\n");
-		return -FI_EINVAL;
-	}
-	if (fi_ibv_get_param_int("mr_cache_lazy_size",
-				 "Minimum size of lazy deregistration",
-				 &fi_ibv_gl_data.mr_cache_lazy_size)  ||
-	    (fi_ibv_gl_data.mr_cache_lazy_size < 0)) {
-		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of mr_cache_lazy_size\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -59,6 +59,7 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.iface			= NULL,
 	.mr_cache_enable	= 0,
 	.mr_max_cached_cnt	= 4096,
+	.mr_max_cached_size	= ULONG_MAX,
 
 	.rdm			= {
 		.buffer_num		= FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM,
@@ -599,6 +600,13 @@ static int fi_ibv_read_params(void)
 	    (fi_ibv_gl_data.mr_max_cached_cnt < 0)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of mr_max_cached_cnt\n");
+		return -FI_EINVAL;
+	}
+	if (fi_ibv_get_param_size_t("mr_max_cached_size",
+				    "Maximum total size of cache entries",
+				    &fi_ibv_gl_data.mr_max_cached_size)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid value of mr_max_cached_size\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -268,6 +268,10 @@ static int fi_ibv_param_define(const char *param_name, const char *param_str,
 			snprintf(param_default_str, 256, "%d", *((int *)param_default));
 			param_default_sz = strlen(param_default_str);
 			break;
+		case FI_PARAM_SIZE_T:
+			snprintf(param_default_str, 256, "%zu", *((size_t *)param_default));
+			param_default_sz = strlen(param_default_str);
+			break;
 		default:
 			assert(0);
 			ret = -FI_EINVAL;
@@ -461,6 +465,25 @@ static int fi_ibv_get_param_bool(const char *param_name,
 		if ((*param_default != 1) && (*param_default != 0))
 			return -FI_EINVAL;
 	}
+
+	return 0;
+}
+
+static int fi_ibv_get_param_size_t(const char *param_name,
+				   const char *param_str,
+				   size_t *param_default)
+{
+	int ret;
+	size_t param;
+
+	ret = fi_ibv_param_define(param_name, param_str,
+				  FI_PARAM_SIZE_T,
+				  param_default);
+	if (ret)
+		return ret;
+
+	if (!fi_param_get_size_t(&fi_ibv_prov, param_name, &param))
+		*param_default = param;
 
 	return 0;
 }

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -58,7 +58,7 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.cqread_bunch_size	= 8,
 	.iface			= NULL,
 	.mr_cache_enable	= 0,
-	.mr_cache_size		= 4096,
+	.mr_max_cached_cnt	= 4096,
 	.mr_cache_lazy_size	= 0,
 
 	.rdm			= {
@@ -572,11 +572,11 @@ static int fi_ibv_read_params(void)
 			   "Invalid value of mr_cache_enable\n");
 		return -FI_EINVAL;
 	}
-	if (fi_ibv_get_param_int("mr_cache_size", "Maximum number of cache entries",
-				 &fi_ibv_gl_data.mr_cache_size) ||
-	    (fi_ibv_gl_data.mr_cache_size < 0)) {
+	if (fi_ibv_get_param_int("mr_max_cached_cnt", "Maximum number of cache entries",
+				 &fi_ibv_gl_data.mr_max_cached_cnt) ||
+	    (fi_ibv_gl_data.mr_max_cached_cnt < 0)) {
 		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of mr_cache_size\n");
+			   "Invalid value of mr_max_cached_cnt\n");
 		return -FI_EINVAL;
 	}
 	if (fi_ibv_get_param_int("mr_cache_lazy_size",

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -185,7 +185,6 @@ extern struct fi_ibv_gl_data {
 	char	*iface;
 	int	mr_cache_enable;
 	int	mr_max_cached_cnt;
-	int	mr_cache_lazy_size;
 
 	struct {
 		int	buffer_num;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -184,7 +184,7 @@ extern struct fi_ibv_gl_data {
 	int	cqread_bunch_size;
 	char	*iface;
 	int	mr_cache_enable;
-	int	mr_cache_size;
+	int	mr_max_cached_cnt;
 	int	mr_cache_lazy_size;
 
 	struct {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -185,6 +185,7 @@ extern struct fi_ibv_gl_data {
 	char	*iface;
 	int	mr_cache_enable;
 	int	mr_max_cached_cnt;
+	size_t	mr_max_cached_size;
 
 	struct {
 		int	buffer_num;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -204,7 +204,7 @@ static struct fi_ibv_mem_notifier *fi_ibv_mem_notifier_init(void)
 	ret = util_buf_pool_create(&fi_ibv_mem_notifier->mem_ptrs_ent_pool,
 				   sizeof(struct fi_ibv_mem_ptr_entry),
 				   FI_IBV_MEM_ALIGNMENT, 0,
-				   fi_ibv_gl_data.mr_cache_size);
+				   fi_ibv_gl_data.mr_max_cached_cnt);
 	if (ret)
 		goto err1;
 
@@ -477,7 +477,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		_domain->monitor.get_event = fi_ibv_monitor_get_event;
 		ofi_monitor_init(&_domain->monitor);
 
-		_domain->cache.max_cached_cnt = fi_ibv_gl_data.mr_cache_size;
+		_domain->cache.max_cached_cnt = fi_ibv_gl_data.mr_max_cached_cnt;
 		_domain->cache.entry_data_size = sizeof(struct fi_ibv_mem_desc);
 		_domain->cache.add_region = fi_ibv_mr_cache_entry_reg;
 		_domain->cache.delete_region = fi_ibv_mr_cache_entry_dereg;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -477,7 +477,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		_domain->monitor.get_event = fi_ibv_monitor_get_event;
 		ofi_monitor_init(&_domain->monitor);
 
-		_domain->cache.size = fi_ibv_gl_data.mr_cache_size;
+		_domain->cache.max_cached_cnt = fi_ibv_gl_data.mr_cache_size;
 		_domain->cache.entry_data_size = sizeof(struct fi_ibv_mem_desc);
 		_domain->cache.add_region = fi_ibv_mr_cache_entry_reg;
 		_domain->cache.delete_region = fi_ibv_mr_cache_entry_dereg;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -478,6 +478,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		ofi_monitor_init(&_domain->monitor);
 
 		_domain->cache.max_cached_cnt = fi_ibv_gl_data.mr_max_cached_cnt;
+		_domain->cache.max_cached_size = fi_ibv_gl_data.mr_max_cached_size;
 		_domain->cache.entry_data_size = sizeof(struct fi_ibv_mem_desc);
 		_domain->cache.add_region = fi_ibv_mr_cache_entry_reg;
 		_domain->cache.delete_region = fi_ibv_mr_cache_entry_dereg;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -485,15 +485,9 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 					&_domain->cache);
 		if (ret)
 			goto err4;
-		if (fi_ibv_gl_data.mr_cache_lazy_size) {
-			_domain->util_domain.domain_fid.mr = fi_ibv_mr_internal_ex_ops.fi_ops;
-			_domain->internal_mr_reg = fi_ibv_mr_internal_ex_ops.internal_mr_reg;
-			_domain->internal_mr_dereg = fi_ibv_mr_internal_ex_ops.internal_mr_dereg;
-		} else {
-			_domain->util_domain.domain_fid.mr = fi_ibv_mr_internal_cache_ops.fi_ops;
-			_domain->internal_mr_reg = fi_ibv_mr_internal_cache_ops.internal_mr_reg;
-			_domain->internal_mr_dereg = fi_ibv_mr_internal_cache_ops.internal_mr_dereg;
-		}
+		_domain->util_domain.domain_fid.mr = fi_ibv_mr_internal_cache_ops.fi_ops;
+		_domain->internal_mr_reg = fi_ibv_mr_internal_cache_ops.internal_mr_reg;
+		_domain->internal_mr_dereg = fi_ibv_mr_internal_cache_ops.internal_mr_dereg;
 	} else {
 		_domain->util_domain.domain_fid.mr = fi_ibv_mr_internal_ops.fi_ops;
 		_domain->internal_mr_reg = fi_ibv_mr_internal_ops.internal_mr_reg;

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -324,24 +324,6 @@ int fi_ibv_mr_internal_cache_dereg(struct fi_ibv_mem_desc *md)
 	return FI_SUCCESS;
 }
 
-static inline
-int fi_ibv_mr_internal_ex_reg(struct fi_ibv_domain *domain, void *buf,
-			      size_t len, uint64_t access,
-			      struct fi_ibv_mem_desc *md)
-{
-	return ((len >= fi_ibv_gl_data.mr_cache_lazy_size) ?
-		fi_ibv_mr_internal_cache_reg(domain, buf, len, access, md) :
-		fi_ibv_mr_internal_reg(domain, buf, len, access, md));
-}
-
-static inline
-int fi_ibv_mr_internal_ex_dereg(struct fi_ibv_mem_desc *md)
-{
-	return ((md->len >= fi_ibv_gl_data.mr_cache_lazy_size) ?
-		fi_ibv_mr_internal_cache_dereg(md) :
-		fi_ibv_mr_internal_dereg(md));
-}
-
 static int fi_ibv_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 			     uint64_t flags, struct fid_mr **mr)
 {
@@ -519,13 +501,3 @@ static int fi_ibv_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *att
 }
 
 FI_IBV_DEFINE_MR_REG_OPS(_cache_)
-
-static int fi_ibv_mr_ex_regattr(struct fid *fid, const struct fi_mr_attr *attr,
-				  uint64_t flags, struct fid_mr **mr)
-{
-	return ((attr->mr_iov[0].iov_len >= fi_ibv_gl_data.mr_cache_lazy_size) ?
-		fi_ibv_mr_cache_regattr(fid, attr, flags, mr) :
-		fi_ibv_mr_regattr(fid, attr, flags, mr));
-}
-
-FI_IBV_DEFINE_MR_REG_OPS(_ex_)

--- a/src/var.c
+++ b/src/var.c
@@ -275,7 +275,6 @@ int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 	}
 
 	switch (param->type) {
-	default:
 	case FI_PARAM_STRING:
 		* ((char **) value) = str_value;
 		FI_INFO(provider, FI_LOG_CORE,
@@ -292,6 +291,11 @@ int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 			"read bool var %s=%d\n", param_name, *(int *) value);
 		if (*(int *) value == -1)
 			ret = -FI_EINVAL;
+		break;
+	case FI_PARAM_SIZE_T:
+		* ((size_t *) value) = strtol(str_value, NULL, 0);
+		FI_INFO(provider, FI_LOG_CORE,
+			"read long var %s=%zu\n", param_name, *(size_t *) value);
 		break;
 	}
 


### PR DESCRIPTION
This PR adds the following updates to the core, utility, verbs code:
- core: New type of runtime params - `FI_PARAM_LONG`
- utility:
Implement MR caching limitation with a total cached size;
Change type of counters from `uint64_t` to `size_t` to align with their thresholds
- verbs:
Remove `FI_VERBS_MR_CACHE_LAZY_SIZE` variable
Rename `FI_VERBS_MR_CACHE_SIZE` to `FI_VERBS_MR_MAX_CACHED_CNT`
Add `FI_VERBS_MR_MAX_CACHED_SIZE` variable
