### PR TITLE
fabric: Introduce variable length message support

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -513,6 +513,25 @@ The following option levels and option names and parameters are defined.
   the maximum size of the data that may be present as part of a connection
   request event. This option is read only.
 
+- *FI_OPT_VARIABLE_THRESHOLD - size_t*
+: Defines the minimum size for variable length messages.  Transfers
+  equal to FI_OPT_VARIABLE_THRESHOLD size or smaller are handled as
+  standard message transfers.  Message transfers larger than the
+  threshold are handled by the provider as variable length transfers.
+
+  fi_getopt() will return the currently configured threshold, or the
+  provider's default threshold if one has not be set by the application.
+  fi_setopt() allows an application to configure the threshold.  If the
+  provider cannot support the requested threshold, it will fail the
+  fi_setopt() call with FI_EMSGSIZE.  Calling fi_setopt() with the
+  threshold set to SIZE_MAX will set the threshold to the maximum
+  supported by the provider.  fi_getopt() can then be used to retrieve
+  the set size.
+
+  In most cases, the sending and receiving endpoints must be
+  configured to use the same threshold value, and the threshold must be
+  set prior to enabling the endpoint.
+
 ## fi_rx_size_left (DEPRECATED)
 
 This function has been deprecated and will be removed in a future version

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -402,6 +402,16 @@ additional optimizations.
   completion semantics.  This flag requires that FI_RMA be set.
   This capability is experimental.
 
+*FI_VARIABLE_MSG*
+
+: Requests that the provider must notify a receiver when a variable
+  length message is ready to be received prior to attempting to place
+  the data.  Such notification will include the size of the message and
+  any associated message tag (for FI_TAGGED).  See 'Variable Length
+  Messages' in fi_msg.3 for full details.  Variable length messages
+  are any messages larger than an endpoint configurable size.  This
+  flag requires that FI_MSG and/or FI_TAGGED be set.
+
 Capabilities may be grouped into two general categories: primary and
 secondary.  Primary capabilities must explicitly be requested by an
 application, and a provider must enable support for only those primary
@@ -413,7 +423,7 @@ would not compromise performance or security.
 
 Primary capabilities: FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_MULTICAST,
 FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_READ, FI_WRITE, FI_RECV, FI_SEND,
-FI_REMOTE_READ, and FI_REMOTE_WRITE.
+FI_REMOTE_READ, FI_REMOTE_WRITE, and FI_VARIABLE_MSG.
 
 Secondary capabilities: FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_SHARED_AV,
 FI_TRIGGER, FI_FENCE, FI_LOCAL_COMM, FI_REMOTE_COMM, FI_SOURCE_ERR, FI_RMA_PMEM.


### PR DESCRIPTION
Applications often need to receive messages, but have no idea
how large the message will be until the sender posts it.  In
practical terms, the result is that many apps need to
implement a rendezvous protocol using some combination of
tagged messages + RMA, tagged messages, or normal messages + RMA.
This duplicates work that most of the OFI providers already do.
The apps must also guess the best way to do this, which may not
be optimal for a given provider.

This defines a new feature that abstracts the behavior that
applications are wanting -- the ability to receive a message
of variable length, with the size of the message determined
by the sender and given to the receiver as part of a 'pre'
completion event.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>