### PR TITLE
prov/psm2: Allow contexts be shared by Tx-only and Rx-only endpoints

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -487,12 +487,17 @@ struct psmx2_fid_fabric {
 	struct dlist_entry	domain_list;
 };
 
+#define PSMX2_TX	(1)
+#define PSMX2_RX	(2)
+#define PSMX2_TX_RX	(PSMX2_TX | PSMX2_RX)
+
 struct psmx2_trx_ctxt {
 	psm2_ep_t		psm2_ep;
 	psm2_epid_t		psm2_epid;
 	psm2_mq_t		psm2_mq;
 	int			am_initialized;
 	int			id;
+	int			usage_flags;
 	struct psm2_am_parameters psm2_am_param;
 
 	struct psmx2_fid_domain	*domain;
@@ -873,11 +878,10 @@ static inline void psmx2_domain_release(struct psmx2_fid_domain *domain)
 
 int	psmx2_domain_enable_ep(struct psmx2_fid_domain *domain, struct psmx2_fid_ep *ep);
 
-void	psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt);
+void	psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt, int usage_flags);
 struct	psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 					     struct psmx2_ep_name *src_addr,
-					     int sep_ctxt_idx);
-
+					     int sep_ctxt_idx, int usage_flags);
 
 static inline
 int	psmx2_ns_service_cmp(void *svc1, void *svc2)


### PR DESCRIPTION
The hardware contexts allocated by PSM2 always have both Tx and Rx
capability. Previously, endpoints (or STX context) that only need Tx
or Rx would still consume full hardware contexts, wasting half of the
capability. Applications using separate Tx and Rx endpoints would
consume more hardware contexts than those using combined Tx and Rx
endpoints.

This patch allows the unused Tx or Rx capability of existing contexts
be used for new endpoints that only need Rx or Tx capability.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>