### PR TITLE
 prov/rxm, util/av: Refactor unconnected TX op handling

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -535,6 +535,32 @@ void ofi_cmap_del_handle(struct util_cmap_handle *handle);
 void ofi_cmap_free(struct util_cmap *cmap);
 struct util_cmap *ofi_cmap_alloc(struct util_ep *ep,
 				 struct util_cmap_attr *attr);
+extern struct util_cmap_handle *
+util_cmap_get_handle(struct util_cmap *cmap, fi_addr_t fi_addr);
+extern int
+util_cmap_alloc_handle(struct util_cmap *cmap, fi_addr_t fi_addr,
+		       enum util_cmap_state state,
+		       struct util_cmap_handle **handle);
+/* Caller must hold `cmap::lock` */
+static inline struct util_cmap_handle *
+ofi_cmap_acquire_handle(struct util_cmap *cmap, fi_addr_t fi_addr)
+
+{
+	struct util_cmap_handle *handle =
+		util_cmap_get_handle(cmap, fi_addr);
+	if (!handle) {
+		int ret;
+
+		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
+		       "No handle found for given fi_addr\n");
+		ret = util_cmap_alloc_handle(cmap, fi_addr, CMAP_IDLE, &handle);
+		if (OFI_UNLIKELY(ret))
+			return NULL;
+	}
+	return handle;
+}
+int ofi_cmap_handle_connect(struct util_cmap *cmap, fi_addr_t fi_addr,
+			    struct util_cmap_handle *handle);
 
 /*
  * Poll set


### PR DESCRIPTION
This patch addresses comments that are received in the #3822:

- Split `ofi_cmap_get_handle` into two calls - 'acquire' handle and handling of CMAP state
- Refactor OFI/RxM provider's unconnected TX operations handling