### PR TITLE
prov/psm2: Skip inactive units in round-robin context allocation

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -832,6 +832,8 @@ void	psmx2_alter_prov_info(uint32_t api_version, const struct fi_info *hints,
 			      struct fi_info *info);
 
 void	psmx2_init_tag_layout(struct fi_info *info);
+int	psmx2_get_round_robin_unit(int idx);
+
 int	psmx2_fabric(struct fi_fabric_attr *attr,
 		     struct fid_fabric **fabric, void *context);
 int	psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -281,7 +281,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 
 	if (opts.unit < 0 && sep_ctxt_idx >= 0) {
 		should_retry = 1;
-		opts.unit = sep_ctxt_idx % psmx2_env.num_devunits;
+		opts.unit = psmx2_get_round_robin_unit(sep_ctxt_idx);
 		FI_INFO(&psmx2_prov, FI_LOG_CORE,
 			"sep %d: ep_open_opts: unit=%d\n", sep_ctxt_idx, opts.unit);
 	}


### PR DESCRIPTION
Although the round-robin context allocation would retry with different
options, skipping the inactive units in the first place eliminates the
unwanted error messages that may cause some automated test scripts to
fail.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>