### PR TITLE
prov/rxd: Fixes to mr_mode handling

### DIFF
--- a/prov/rxd/src/rxd_attr.c
+++ b/prov/rxd/src/rxd_attr.c
@@ -67,6 +67,7 @@ struct fi_domain_attr rxd_domain_attr = {
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_ENABLED,
 	.av_type = FI_AV_UNSPEC,
+	.mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP,
 	.mr_key_size = sizeof(uint64_t),
 	.cq_cnt = 128,
 	.ep_cnt = 128,

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -185,7 +185,7 @@ static ssize_t rxd_ep_recvv(struct fid_ep *ep, const struct iovec *iov, void **d
 
 static inline void *rxd_mr_desc(struct fid_mr *mr, struct rxd_ep *ep)
 {
-	return (ep->do_local_mr) ? fi_mr_desc(mr) : NULL;
+	return (ep->do_local_mr && mr) ? fi_mr_desc(mr) : NULL;
 }
 
 int rxd_ep_repost_buff(struct rxd_rx_buf *buf)

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -39,8 +39,25 @@ int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
 		     struct fi_info *core_info)
 {
 	core_info->caps = FI_MSG;
-	core_info->mode = FI_LOCAL_MR;
 	core_info->ep_attr->type = FI_EP_DGRAM;
+
+	if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
+		core_info->mode |= FI_LOCAL_MR;
+		core_info->domain_attr->mr_mode = FI_MR_UNSPEC;
+	} else {
+		core_info->domain_attr->mr_mode |= (FI_MR_LOCAL | OFI_MR_BASIC_MAP);
+	}
+
+	if (rxd_info) {
+		if (rxd_info->domain_attr) {
+			core_info->domain_attr->caps |= rxd_info->domain_attr->caps;
+		}
+		if (rxd_info->tx_attr) {
+			core_info->tx_attr->msg_order = rxd_info->tx_attr->msg_order;
+			core_info->tx_attr->comp_order = rxd_info->tx_attr->comp_order;
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Given the changes to the mr_mode and mode attribute semantics in v1.5,
this commit puts together a better core provider selector for RxD.

Signed-off-by: Raghu Raja <craghun@amazon.com>