### PR TITLE
prov/shm: various attr updates and atomic fetch without fast_rma support

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -75,6 +75,7 @@ enum {
 };
 
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
+#define SMR_RMA_REQ		(1 << 1)
 
 /* 
  * Unique smr_op_hdr for smr message protocol:

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -74,12 +74,14 @@ enum {
 	smr_src_iov,	/* reference iovec via CMA */
 };
 
+#define SMR_REMOTE_CQ_DATA	(1 << 0)
+
 /* 
  * Unique smr_op_hdr for smr message protocol:
  * 	addr - local fi_addr of peer sending msg (for shm lookup)
- * 	op - type of op (ex. ofi_op_msg, defined in fi_proto.h)
+ * 	op - type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	op_src - msg src (ex. smr_src_inline, defined above)
- * 	op_flags - operation flags (ex. OFI_REMOTE_CQ_DATA, in fi_proto.h)
+ * 	op_flags - operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
  * 	src_data - src of additional op data (inject offset / resp offset)
  * 	data - remote CQ data
  */

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -200,6 +200,8 @@ int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 int smr_verify_peer(struct smr_ep *ep, int peer_id);
 
+void smr_post_pend_resp(struct smr_cmd *cmd, struct smr_cmd *pend,
+			struct smr_resp *resp);
 void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id,
 		uint32_t op, uint64_t tag, uint8_t datatype, uint8_t atomic_op,
 		uint64_t data, uint64_t op_flags);

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -59,6 +59,9 @@ struct fi_ep_attr smr_ep_attr = {
 	.protocol = FI_PROTO_SHM,
 	.protocol_version = 1,
 	.max_msg_size = SIZE_MAX,
+	.max_order_raw_size = SIZE_MAX,
+	.max_order_waw_size = SIZE_MAX,
+	.max_order_war_size = SIZE_MAX,
 	.tx_ctx_cnt = 1,
 	.rx_ctx_cnt = 1
 };

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -79,6 +79,7 @@ struct fi_domain_attr smr_domain_attr = {
 	.max_ep_tx_ctx = 1,
 	.max_ep_rx_ctx = 1,
 	.mr_iov_limit = SMR_IOV_LIMIT,
+	.caps = FI_LOCAL_COMM,
 };
 
 struct fi_fabric_attr smr_fabric_attr = {

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -175,7 +175,7 @@ uint64_t smr_rx_comp_flags(uint32_t op, uint16_t op_flags)
 
 	flags = smr_rx_flags[op];
 
-	if (op_flags & OFI_REMOTE_CQ_DATA)
+	if (op_flags & SMR_REMOTE_CQ_DATA)
 		flags |= FI_REMOTE_CQ_DATA;
 
 	return flags;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -223,6 +223,14 @@ static void smr_init_queue(struct smr_queue *queue,
 	queue->match_func = match_func;
 }
 
+void smr_post_pend_resp(struct smr_cmd *cmd, struct smr_cmd *pend,
+			struct smr_resp *resp)
+{
+	*pend = *cmd;
+	resp->msg_id = (uint64_t) (uintptr_t) pend;
+	resp->status = FI_EBUSY;
+}
+
 void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id,
 			uint32_t op, uint64_t tag, uint8_t datatype,
 			uint8_t atomic_op, uint64_t data,
@@ -281,11 +289,7 @@ void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
 	cmd->msg.hdr.msg_id = (uint64_t) (uintptr_t) context;
 	memcpy(cmd->msg.data.iov, iov, sizeof(*iov) * count);
 
-	*pend_cmd = *cmd;
-
-	resp->msg_id = (uint64_t) (uintptr_t) pend_cmd;
-	resp->status = FI_EBUSY;
-
+	smr_post_pend_resp(cmd, pend_cmd, resp);
 }
 
 static int smr_ep_close(struct fid *fid)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -230,7 +230,7 @@ void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id,
 {
 	cmd->msg.hdr.op = op;
 	cmd->msg.hdr.op_flags = op_flags & FI_REMOTE_CQ_DATA ?
-				OFI_REMOTE_CQ_DATA : 0;
+				SMR_REMOTE_CQ_DATA : 0;
 	if (op == ofi_op_tagged) {
 		cmd->msg.hdr.tag = tag;
 	} else if (op == ofi_op_atomic ||

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -96,6 +96,9 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 		if (fast_rma) {
 			cur->domain_attr->mr_mode = FI_MR_VIRT_ADDR;
 			cur->tx_attr->msg_order = FI_ORDER_SAS;
+			cur->ep_attr->max_order_raw_size = 0;
+			cur->ep_attr->max_order_waw_size = 0;
+			cur->ep_attr->max_order_war_size = 0;
 		}
 	}
 	return 0;

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -37,6 +37,43 @@
 #include "ofi_iov.h"
 #include "smr.h"
 
+static int smr_progress_fetch(struct smr_ep *ep, struct smr_cmd *pending,
+			      uint64_t *ret)
+{
+	struct smr_region *peer_smr;
+	size_t inj_offset, size;
+	struct smr_inject_buf *tx_buf;
+	uint8_t *src;
+
+	peer_smr = smr_peer_region(ep->region, pending->msg.hdr.addr);
+	if (fastlock_tryacquire(&peer_smr->lock))
+		return -FI_EAGAIN;
+
+	inj_offset = (size_t) pending->msg.hdr.src_data;
+	tx_buf = (struct smr_inject_buf *) ((char **) peer_smr +
+					    inj_offset);
+
+	if (*ret)
+		goto out;
+
+	src = pending->msg.hdr.op == ofi_op_atomic_compare ?
+	      tx_buf->buf : tx_buf->data;
+	size = ofi_copy_to_iov(pending->msg.data.iov,
+			       pending->msg.data.iov_count,
+			       0, src, pending->msg.hdr.size);
+
+	if (size != pending->msg.hdr.size) {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+			"Incomplete atomic fetch buffer copied\n");
+		*ret = FI_EIO;
+	}
+
+out:
+	smr_freestack_push(smr_inject_pool(peer_smr), tx_buf);
+	peer_smr->cmd_cnt++;
+	fastlock_release(&peer_smr->lock);
+	return 0;
+}
 
 static void smr_progress_resp(struct smr_ep *ep)
 {
@@ -53,6 +90,9 @@ static void smr_progress_resp(struct smr_ep *ep)
 			break;
 
 		pending = (struct smr_cmd *) resp->msg_id;
+		if (pending->msg.hdr.op_flags & SMR_RMA_REQ &&
+			smr_progress_fetch(ep, pending, &resp->status))
+				break;
 
 		ret = ep->tx_comp(ep, (void *) (uintptr_t) pending->msg.hdr.msg_id,
 				  smr_tx_comp_flags(pending->msg.hdr.op),
@@ -183,16 +223,23 @@ static int smr_progress_multi_recv(struct smr_ep *ep, struct smr_queue *queue,
 }
 
 static void smr_do_atomic(void *src, void *dst, void *cmp, enum fi_datatype datatype,
-			  enum fi_op op, size_t cnt)
+			  enum fi_op op, size_t cnt, uint16_t flags)
 {
 	char tmp_result[SMR_INJECT_SIZE];
 
 	if (op >= OFI_SWAP_OP_START) {
 		ofi_atomic_swap_handlers[op - OFI_SWAP_OP_START][datatype](dst,
 			src, cmp, tmp_result, cnt);
+	} else if (flags & SMR_RMA_REQ) {
+		ofi_atomic_readwrite_handlers[op][datatype](dst, src,
+			tmp_result, cnt);
 	} else if (op != FI_ATOMIC_READ) {
 		ofi_atomic_write_handlers[op][datatype](dst, src, cnt);
 	}
+
+	if (flags & SMR_RMA_REQ)
+		memcpy(src, op == FI_ATOMIC_READ ? dst : tmp_result,
+		       cnt * ofi_datatype_size(datatype));
 }
 
 static int smr_progress_inline_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
@@ -215,7 +262,7 @@ static int smr_progress_inline_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
 	for (i = *len = 0; i < ioc_count && *len < cmd->msg.hdr.size; i++) {
 		smr_do_atomic(&src[*len], ioc[i].addr, comp ? &comp[*len] : NULL,
 			      cmd->msg.hdr.datatype, cmd->msg.hdr.atomic_op,
-			      ioc[i].count);
+			      ioc[i].count, cmd->msg.hdr.op_flags);
 		*len += ioc[i].count * ofi_datatype_size(cmd->msg.hdr.datatype);
 	}
 
@@ -256,7 +303,7 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
 	for (i = *len = 0; i < ioc_count && *len < cmd->msg.hdr.size; i++) {
 		smr_do_atomic(&src[*len], ioc[i].addr, comp ? &comp[*len] : NULL,
 			      cmd->msg.hdr.datatype, cmd->msg.hdr.atomic_op,
-			      ioc[i].count);
+			      ioc[i].count, cmd->msg.hdr.op_flags);
 		*len += ioc[i].count * ofi_datatype_size(cmd->msg.hdr.datatype);
 	}
 
@@ -267,7 +314,9 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
 	}
 
 out:
-	smr_freestack_push(smr_inject_pool(ep->region), tx_buf);
+	if (!(cmd->msg.hdr.op_flags & SMR_RMA_REQ))
+		smr_freestack_push(smr_inject_pool(ep->region), tx_buf);
+
 	return err;
 }
 
@@ -425,8 +474,10 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 
 static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 {
+	struct smr_region *peer_smr;
 	struct smr_domain *domain;
 	struct smr_cmd *rma_cmd;
+	struct smr_resp *resp;
 	struct fi_ioc ioc[SMR_IOV_LIMIT];
 	size_t ioc_count;
 	size_t total_len = 0;
@@ -454,9 +505,10 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 		ioc[ioc_count].count = rma_cmd->rma.rma_ioc[ioc_count].count;
 	}
 	ofi_cirque_discard(smr_cmd_queue(ep->region));
-	ep->region->cmd_cnt++;
-	if (ret)
+	if (ret) {
+		ep->region->cmd_cnt++;
 		return ret;
+	}
 
 	switch (cmd->msg.hdr.op_src) {
 	case smr_src_inline:
@@ -469,6 +521,14 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unidentified operation type\n");
 		err = -FI_EINVAL;
+	}
+	if (!(cmd->msg.hdr.op_flags & SMR_RMA_REQ)) {
+		ep->region->cmd_cnt++;
+	} else {
+		peer_smr = smr_peer_region(ep->region, cmd->msg.hdr.addr);
+		resp = (struct smr_resp *) ((char **) peer_smr +
+			    (size_t) cmd->msg.hdr.data);
+		resp->status = -err;
 	}
 
 	if (err)

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -365,7 +365,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	domain = container_of(ep->util_ep.domain, struct smr_domain,
 			      util_domain);
 
-	if (cmd->msg.hdr.op_flags & OFI_REMOTE_CQ_DATA &&
+	if (cmd->msg.hdr.op_flags & SMR_REMOTE_CQ_DATA &&
 	    ofi_cirque_isfull(ep->util_ep.rx_cq->cirq)) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"rx cq full\n");
@@ -408,7 +408,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 			"unidentified operation type\n");
 		err = -FI_EINVAL;
 	}
-	if (cmd->msg.hdr.op_flags & OFI_REMOTE_CQ_DATA) {
+	if (cmd->msg.hdr.op_flags & SMR_REMOTE_CQ_DATA) {
 		ret = ep->rx_comp(ep, (void *) cmd->msg.hdr.msg_id,
 				  smr_rx_comp_flags(cmd->msg.hdr.op,
 				  cmd->msg.hdr.op_flags), total_len,


### PR DESCRIPTION
- update domain_attr->caps to FI_LOCAL_COMM
- update max_order_sizes in ep_attr
- add atomic fetch support when fast_rma support is not enabled

See commit messages for more details. All tests in test_configs/shm/all.test and test_configs/shm/verify.test verified passing with these updates

Signed-off-by: aingerson <alexia.ingerson@intel.com>