### PR TITLE
util/wait: Fix failure in ofi_wait_fd_del

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -618,6 +618,7 @@ struct ofi_wait_fd_entry {
 	int 			fd;
 	ofi_wait_fd_try_func	try;
 	void			*arg;
+	ofi_atomic32_t		ref;
 };
 
 int ofi_wait_fd_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -155,39 +155,47 @@ static int ofi_wait_fd_match(struct dlist_entry *item, const void *arg)
 
 int ofi_wait_fd_del(struct util_wait *wait, int fd)
 {
+	int ret = 0;
 	struct ofi_wait_fd_entry *fd_entry;
 	struct dlist_entry *entry;
 	struct util_wait_fd *wait_fd = container_of(wait, struct util_wait_fd,
 						    util_wait);
 
 	fastlock_acquire(&wait_fd->lock);
-	entry = dlist_remove_first_match(&wait_fd->fd_list, ofi_wait_fd_match,
-					 &fd);
-	fastlock_release(&wait_fd->lock);
+	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_fd_match, &fd);
 	if (!entry) {
 		FI_INFO(wait->prov, FI_LOG_FABRIC,
-			"Given fd not found in wait list\n");
-		return -FI_EINVAL;
+			"Given fd not found in wait list - %p\n", wait_fd);
+		ret = -FI_EINVAL;
+		goto out;
 	}
-
+	fd_entry = container_of(entry, struct ofi_wait_fd_entry, entry);
+	if (ofi_atomic_dec32(&fd_entry->ref))
+		goto out;
 	fd_entry = container_of(entry, struct ofi_wait_fd_entry, entry);
 	fi_epoll_del(wait_fd->epoll_fd, fd_entry->fd);
 	free(fd_entry);
-	return 0;
+out:
+	fastlock_release(&wait_fd->lock);
+	return ret;
 }
 
 int ofi_wait_fd_add(struct util_wait *wait, int fd, ofi_wait_fd_try_func try,
 		    void *arg, void *context)
 {
 	struct ofi_wait_fd_entry *fd_entry;
+	struct dlist_entry *entry;
 	struct util_wait_fd *wait_fd = container_of(wait, struct util_wait_fd,
 						    util_wait);
 	int ret = 0;
 
 	fastlock_acquire(&wait_fd->lock);
-	if (dlist_find_first_match(&wait_fd->fd_list, ofi_wait_fd_match, &fd)) {
+	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_fd_match, &fd);
+	if (entry) {
 		FI_DBG(wait->prov, FI_LOG_EP_CTRL,
 			"wait_fd already added to util_wait fd_list \n");
+		fd_entry = container_of(entry, struct ofi_wait_fd_entry, entry);
+		ofi_atomic_inc32(&fd_entry->ref);
 		goto out;
 	}
 
@@ -206,6 +214,7 @@ int ofi_wait_fd_add(struct util_wait *wait, int fd, ofi_wait_fd_try_func try,
 	fd_entry->fd = fd;
 	fd_entry->try = try;
 	fd_entry->arg = arg;
+	ofi_atomic_initialize32(&fd_entry->ref, 1);
 
 	dlist_insert_tail(&fd_entry->entry, &wait_fd->fd_list);
 out:


### PR DESCRIPTION
Subsequent callings of `ofi_wait_fd_del()` fails with status `-FI_EINVAL`, when the same wait object is used for multiple CNTRs/CQs

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>