### PR TITLE
prov/verbs: Fix config check for librdmacm

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -34,7 +34,7 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 				[verbs_ibverbs_exp_happy=0])
 
 	       FI_CHECK_PACKAGE([verbs_rdmacm],
-				[rdma/rsocket.h],
+				[rdma/rdma_cma.h],
 				[rdmacm],
 				[rdma_create_qp],
 				[],


### PR DESCRIPTION
The configure checks are failed for the verbs provider if the rsockets isn't available

This fix is to check rdma/rdma_cma.h header file instead rdma/rsocket.h

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>