### PR TITLE
prov/shm: implement fi_av_remove

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -247,6 +247,7 @@ int	smr_map_create(const struct fi_provider *prov, int peer_count,
 int	smr_map_to_region(const struct fi_provider *prov,
 			  struct smr_peer *peer_buf);
 void	smr_map_to_endpoint(struct smr_region *region, int index);
+void	smr_unmap_from_endpoint(struct smr_region *region, int index);
 void	smr_exchange_all_peers(struct smr_region *region);
 int	smr_map_add(const struct fi_provider *prov,
 		    struct smr_map *map, const char *name, int id);

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -215,6 +215,25 @@ void smr_map_to_endpoint(struct smr_region *region, int index)
 	}
 }
 
+void smr_unmap_from_endpoint(struct smr_region *region, int index)
+{
+	struct smr_region *peer_smr;
+	struct smr_addr *local_peers, *peer_peers;
+	int peer_index;
+
+	local_peers = smr_peer_addr(region);
+
+	memset(local_peers[index].name, 0, SMR_NAME_SIZE);
+	peer_index = region->map->peers[index].peer.addr;
+	if (peer_index == FI_ADDR_UNSPEC)
+		return;
+
+	peer_smr = smr_peer_region(region, index);
+	peer_peers = smr_peer_addr(peer_smr);
+
+	peer_peers[peer_index].addr = FI_ADDR_UNSPEC;
+}
+
 void smr_exchange_all_peers(struct smr_region *region)
 {
 	int i;

--- a/prov/verbs/src/ep_dgram/verbs_dgram_av.c
+++ b/prov/verbs/src/ep_dgram/verbs_dgram_av.c
@@ -258,7 +258,9 @@ static int fi_ibv_dgram_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 				   "with status - %d\n", index, ret);
 			
 		slot = fi_ibv_dgram_av_slot(av_entry);
+		fastlock_acquire(&av->util_av.lock);
 		ret = ofi_av_remove_addr(&av->util_av, slot, index);
+		fastlock_release(&av->util_av.lock);
 		if (ret)
 			VERBS_WARN(FI_LOG_AV,
 				   "Removal of fi_addr %d failed\n",


### PR DESCRIPTION
- removing an address from the AV requires:
	- unmapping the region and removing it from the av->map
	- unmapping the region from the peer endpoint to mark that it is not in the AV which requires the addition of a new function smr_unmap_from_endpoint to counter the smr_map_to_endpoint call
- note that this patch moves the av lock acquire/release to outside the util av_remove function because the smr_av->map is protected by the av->lock as well. This mirrors the requirment in the util av_insert call which requires the lock to be held before calling the function
	- changed this in the two other calls to this function to be holding the lock before calling it (in prov/util/src/util_av.c and prov/verbs/src/ep_dgram/verbs_dgram_av.c)

Verified passing fi_av_xfer test

Signed-off-by: aingerson <alexia.ingerson@intel.com>