### PR TITLE
prov/sockets: Progress all rx contexts for a scalable endpoint

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -1148,6 +1148,9 @@ void sock_pe_add_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *ctx);
 void sock_pe_signal(struct sock_pe *pe);
 void sock_pe_poll_add(struct sock_pe *pe, int fd);
 void sock_pe_poll_del(struct sock_pe *pe, int fd);
+
+int sock_pe_progress_ep_rx(struct sock_pe *pe, struct sock_ep_attr *ep_attr);
+int sock_pe_progress_ep_tx(struct sock_pe *pe, struct sock_ep_attr *ep_attr);
 int sock_pe_progress_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx);
 int sock_pe_progress_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx);
 void sock_pe_remove_tx_ctx(struct sock_tx_ctx *tx_ctx);

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -108,7 +108,7 @@ int sock_cntr_progress(struct sock_cntr *cntr)
 		if (tx_ctx->use_shared)
 			sock_pe_progress_tx_ctx(cntr->domain->pe, tx_ctx->stx_ctx);
 		else
-			sock_pe_progress_tx_ctx(cntr->domain->pe, tx_ctx);
+			sock_pe_progress_ep_tx(cntr->domain->pe, tx_ctx->ep_attr);
 	}
 
 	for (entry = cntr->rx_list.next; entry != &cntr->rx_list;
@@ -118,7 +118,7 @@ int sock_cntr_progress(struct sock_cntr *cntr)
 		if (rx_ctx->use_shared)
 			sock_pe_progress_rx_ctx(cntr->domain->pe, rx_ctx->srx_ctx);
 		else
-			sock_pe_progress_rx_ctx(cntr->domain->pe, rx_ctx);
+			sock_pe_progress_ep_rx(cntr->domain->pe, rx_ctx->ep_attr);
 	}
 
 	fastlock_release(&cntr->list_lock);

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -121,7 +121,7 @@ int sock_cq_progress(struct sock_cq *cq)
 		if (tx_ctx->use_shared)
 			sock_pe_progress_tx_ctx(cq->domain->pe, tx_ctx->stx_ctx);
 		else
-			sock_pe_progress_tx_ctx(cq->domain->pe, tx_ctx);
+			sock_pe_progress_ep_tx(cq->domain->pe, tx_ctx->ep_attr);
 	}
 
 	for (entry = cq->rx_list.next; entry != &cq->rx_list;
@@ -133,7 +133,7 @@ int sock_cq_progress(struct sock_cq *cq)
 		if (rx_ctx->use_shared)
 			sock_pe_progress_rx_ctx(cq->domain->pe, rx_ctx->srx_ctx);
 		else
-			sock_pe_progress_rx_ctx(cq->domain->pe, rx_ctx);
+			sock_pe_progress_ep_rx(cq->domain->pe, rx_ctx->ep_attr);
 	}
 	fastlock_release(&cq->list_lock);
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2441,6 +2441,40 @@ out:
 	return ret;
 }
 
+int sock_pe_progress_ep_rx(struct sock_pe *pe, struct sock_ep_attr *ep_attr)
+{
+	struct sock_rx_ctx *rx_ctx;
+	int ret, i;
+
+	for (i = 0; i <= ep_attr->ep_attr.rx_ctx_cnt; i++) {
+		rx_ctx = ep_attr->rx_array[i];
+		if (!rx_ctx)
+			continue;
+
+		ret = sock_pe_progress_rx_ctx(pe, rx_ctx);
+		if (ret < 0)
+			return ret;
+	}
+	return 0;
+}
+
+int sock_pe_progress_ep_tx(struct sock_pe *pe, struct sock_ep_attr *ep_attr)
+{
+	struct sock_tx_ctx *tx_ctx;
+	int ret, i;
+
+	for (i = 0; i <= ep_attr->ep_attr.tx_ctx_cnt; i++) {
+		tx_ctx = ep_attr->tx_array[i];
+		if (!tx_ctx)
+			continue;
+
+		ret = sock_pe_progress_tx_ctx(pe, tx_ctx);
+		if (ret < 0)
+			return ret;
+	}
+	return 0;
+}
+
 void sock_pe_progress_rx_ctrl_ctx(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 				  struct sock_tx_ctx *tx_ctx)
 {


### PR DESCRIPTION
Sockets emulates the functionality of a scalable endpoint over a
single TCP socket.  As a result, data from multiple transmit/
receive contexts can show up in any order on the socket.

If the application polls a CQ associated with a specific rx
context, but data is at the head of the socket for a different
rx context, the CQ polling can get stuck unable to proceed.  This
can result in the application hanging.

To fix this, we need to progress any associated rx context that
is using the same underlying socket.

Fixes #3886

Signed-off-by: Sean Hefty <sean.hefty@intel.com>