### PR TITLE
prov/rxm: Fix multiple deletion of the same wait object

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -340,6 +340,7 @@ struct rxm_ep {
 	struct fid_eq 		*msg_eq;
 	struct fid_cq 		*msg_cq;
 	int			msg_cq_fd;
+	struct dlist_entry	msg_cq_fd_ref_list;
 	struct fid_ep 		*srx_ctx;
 	size_t 			comp_per_progress;
 	int			msg_mr_local;
@@ -354,6 +355,11 @@ struct rxm_ep {
 	struct rxm_send_queue	send_queue;
 	struct rxm_recv_queue	recv_queue;
 	struct rxm_recv_queue	trecv_queue;
+};
+
+struct rxm_ep_wait_ref {
+	struct util_wait	*wait;
+	struct dlist_entry	entry;
 };
 
 extern struct fi_provider rxm_prov;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1499,7 +1499,6 @@ static int rxm_ep_close(struct fid *fid)
 		retv = ret;
 	}
 
-
 	ret = rxm_ep_msg_res_close(rxm_ep);
 	if (ret)
 		retv = ret;
@@ -1527,7 +1526,7 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep, enum fi_wait_obj wait_obj)
 	ret = fi_cq_open(rxm_domain->msg_domain, &cq_attr, &rxm_ep->msg_cq, NULL);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to open MSG CQ\n");
-		return ret;;
+		return ret;
 	}
 
 	if (wait_obj != FI_WAIT_NONE) {

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -165,7 +165,8 @@ int ofi_wait_fd_del(struct util_wait *wait, int fd)
 	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_fd_match, &fd);
 	if (!entry) {
 		FI_INFO(wait->prov, FI_LOG_FABRIC,
-			"Given fd not found in wait list - %p\n", wait_fd);
+			"Given fd (%d) not found in wait list - %p\n",
+			fd, wait_fd);
 		ret = -FI_EINVAL;
 		goto out;
 	}
@@ -193,7 +194,8 @@ int ofi_wait_fd_add(struct util_wait *wait, int fd, ofi_wait_fd_try_func try,
 	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_fd_match, &fd);
 	if (entry) {
 		FI_DBG(wait->prov, FI_LOG_EP_CTRL,
-			"wait_fd already added to util_wait fd_list \n");
+		       "Given fd (%d) already added to wait list - %p \n",
+		       fd, wait_fd);
 		fd_entry = container_of(entry, struct ofi_wait_fd_entry, entry);
 		ofi_atomic_inc32(&fd_entry->ref);
 		goto out;


### PR DESCRIPTION
This patch contains the following bug fixes and optimizations:
- Adds printing of FD in util/wait code
- Removes excessive line and excessive semicolon
- Binding CNTR to EP passes wrong file descriptor, if CQ is opened and bound w/o wait object, but CNTR is opened w/ wait object
- E.x. an user opens single completion counter and binds with flags `FI_READ` and `FI_WRITE`, `util_ep::rd_cntr` and `util_ep::wr_cntr` point to the same cntr. `ofi_wait_fd_del` is called multiple time for the same `counter->wait`