### PR TITLE
prov/util Signal wait from ofi_cq_write

### DIFF
--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -110,6 +110,9 @@ int ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 	comp->data = data;
 	comp->tag = tag;
 	ofi_cirque_commit(cq->cirq);
+
+	if (cq->wait)
+		cq->wait->signal(cq->wait);
 out:
 	fastlock_release(&cq->cq_lock);
 	return ret;


### PR DESCRIPTION
util wait object should get a notification that cq in the pollset has new entry. This is useful for the case where User App is waiting on internal wait object (after getting it through control - GETWAIT).

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>