### PR TITLE
prov/util,rxm: optimizations

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -403,10 +403,12 @@ struct util_av {
 	struct dlist_entry	ep_list;
 };
 
+#define OFI_AV_HASH	(1 << 0)
+
 struct util_av_attr {
 	size_t			addrlen;
 	size_t			overhead;
-	uint64_t		flags;
+	int			flags;
 };
 
 int ofi_av_init(struct util_domain *domain,
@@ -423,6 +425,8 @@ void ofi_av_write_event(struct util_av *av, uint64_t data,
 
 int ip_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		 struct fid_av **av, void *context);
+int ip_av_create_flags(struct fid_domain *domain_fid, struct fi_av_attr *attr,
+		       struct fid_av **av, void *context, int flags);
 
 void *ofi_av_get_addr(struct util_av *av, int index);
 #define ip_av_get_addr ofi_av_get_addr

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -332,7 +332,7 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 
 	util_attr.addrlen = sizeof(fi_addr_t);
 	util_attr.overhead = attr->count;
-	util_attr.flags = FI_SOURCE;
+	util_attr.flags = OFI_AV_HASH;
 	if (attr->type == FI_AV_UNSPEC)
 		attr->type = FI_AV_TABLE;
 

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -60,9 +60,15 @@ free:
 	return ret;
 }
 
+int rxm_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
+		  struct fid_av **av, void *context)
+{
+	return ip_av_create_flags(domain_fid, attr, av, context, OFI_AV_HASH);
+}
+
 static struct fi_ops_domain rxm_domain_ops = {
 	.size = sizeof(struct fi_ops_domain),
-	.av_open = ip_av_create,
+	.av_open = rxm_av_create,
 	.cq_open = rxm_cq_open,
 	.endpoint = rxm_endpoint,
 	.scalable_ep = fi_no_scalable_ep,

--- a/prov/verbs/src/ep_dgram/verbs_dgram_av.c
+++ b/prov/verbs/src/ep_dgram/verbs_dgram_av.c
@@ -390,7 +390,7 @@ int fi_ibv_dgram_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	struct util_av_attr util_attr = {
 		.overhead = attr->count >> 1,
 		.flags = ((domain->util_domain.info_domain_caps & FI_SOURCE) ?
-			  FI_SOURCE : 0),
+			  OFI_AV_HASH : 0),
 		.addrlen = sizeof(struct ofi_ib_ud_ep_name),
 	};
 


### PR DESCRIPTION
- prov/util: use a separate flag to determine if we need to create av hash table
- prov/rxm: use ip_av_create_flags
- prov/rxm: don't include FI_DIRECTED_RECV, FI_SOURCE caps if they're not needed
