### PR TITLE
prov/sockets: Rename interface name knob

### DIFF
--- a/man/fi_sockets.7.md
+++ b/man/fi_sockets.7.md
@@ -93,6 +93,9 @@ The sockets provider checks for the following environment variables -
 *FI_SOCKETS_KEEPALIVE_PROBES*
 : An integer to specify the maximum number of keepalive probes sent before dropping the connection. Only relevant if *FI_SOCKETS_KEEPALIVE_ENABLE* is enabled.
 
+*FI_SOCKETS_IFACE*
+: The prefix or the name of the network interface (default: any)
+
 # LARGE SCALE JOBS
 
 For large scale runs one can use these environment variables to set the default parameters e.g. size of the address vector(AV), completion queue (CQ), connection map etc. that satisfies the requirement of the particular benchmark. The recommended parameters for large scale runs are *FI_SOCKETS_MAX_CONN_RETRY*, *FI_SOCKETS_DEF_CONN_MAP_SZ*, *FI_SOCKETS_DEF_AV_SZ*, *FI_SOCKETS_DEF_CQ_SZ*, *FI_SOCKETS_DEF_EQ_SZ*.

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -531,7 +531,7 @@ void sock_get_list_of_addr(struct slist *addr_list)
 	struct sock_host_list_entry *addr_entry;
 	struct ifaddrs *ifaddrs, *ifa;
 
-	fi_param_get_str(&sock_prov, "interface_name", &sock_interface_name);
+	fi_param_get_str(&sock_prov, "iface", &sock_interface_name);
 
 	ret = ofi_getifaddrs(&ifaddrs);
 	if (!ret) {
@@ -815,7 +815,7 @@ SOCKETS_INI
 	fi_param_define(&sock_prov, "keepalive_probes", FI_PARAM_INT,
 			"Maximum number of keepalive probes sent before dropping the connection");
 
-	fi_param_define(&sock_prov, "interface_name", FI_PARAM_STRING,
+	fi_param_define(&sock_prov, "iface", FI_PARAM_STRING,
 			"Specify interface name");
 
 	fastlock_init(&sock_list_lock);


### PR DESCRIPTION
This patch changes the name of knob and declares the knob in the sockets man page

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>