### PR TITLE
 prov/mlx: Fix compiler warning

### DIFF
--- a/man/fi_mlx.7.md
+++ b/man/fi_mlx.7.md
@@ -49,8 +49,8 @@ Unsupported features
 
 # RUNTIME PARAMETERS
 
-*FI_MLX_CONFI*
-: The path to the MLX configuration file(default: none).
+*FI_MLX_CONFIG*
+: The path to the MLX configuration file (default: none).
 
 *FI_MLX_TINJECT_LIMIT*
 : Maximal tinject message size (default: 1024).

--- a/prov/mlx/src/mlx_cm.c
+++ b/prov/mlx/src/mlx_cm.c
@@ -120,7 +120,7 @@ static int mlx_cm_getname_ai_format(
 		}
 		FI_INFO(&mlx_prov, FI_LOG_CORE,
 			"Loaded IPv4 address: [%"PRIu64"]%s:%d\n",
-			res->ai_addrlen, hostname, service);
+			(uint64_t)res->ai_addrlen, hostname, service);
 
 		memcpy(addr,res->ai_addr,res->ai_addrlen);
 		((struct sockaddr_in*)addr)->sin_port = htons((short)service);


### PR DESCRIPTION
This patch fixes the following:
- Compiler warning
- misprint in man page that was introduced in #3914 