### PR TITLE
prov/sockets: Fix use after free error handling triggered ops

### DIFF
--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -305,12 +305,11 @@ static inline int
 fi_mr_raw_attr(struct fid_mr *mr, uint64_t *base_addr,
 	       uint8_t *raw_key, size_t *key_size, uint64_t flags)
 {
-	struct fi_mr_raw_attr attr = {
-		.flags = flags,
-		.base_addr = base_addr,
-		.raw_key = raw_key,
-		.key_size = key_size
-	};
+	struct fi_mr_raw_attr attr;
+	attr.flags = flags;
+	attr.base_addr = base_addr;
+	attr.raw_key = raw_key;
+	attr.key_size = key_size;
 	return mr->fid.ops->control(&mr->fid, FI_GET_RAW_MR, &attr);
 }
 
@@ -318,13 +317,12 @@ static inline int
 fi_mr_map_raw(struct fid_domain *domain, uint64_t base_addr,
 	      uint8_t *raw_key, size_t key_size, uint64_t *key, uint64_t flags)
 {
-	struct fi_mr_map_raw map = {
-		.flags = flags,
-		.base_addr = base_addr,
-		.raw_key = raw_key,
-		.key_size = key_size,
-		.key = key
-	};
+	struct fi_mr_map_raw map;
+	map.flags = flags;
+	map.base_addr = base_addr;
+	map.raw_key = raw_key;
+	map.key_size = key_size;
+	map.key = key;
 	return domain->fid.ops->control(&domain->fid, FI_MAP_RAW_MR, &map);
 }
 


### PR DESCRIPTION
As part of updating a counter, an associated deferred work queue
is checked.  For example, sock_cntr_add() calls
sock_cntr_check_trigger_list() after the counter has been updated.

If an application is waiting on the counter to reach a specific
threshold, it can see that the counter has been set, then attempt
to free the counter, endpoint, and other resources.  This leads
to a condition where the checking of the trigger list may be
called after the counter has been freed.

There's not a great fix for this.  To help avoid potential use
after free issues, hold the counter mutex around the call to
check the trigger list.  Then in destroy acquire and release the
mutex.  This ensures that destroy block until counter updates
have fully completed.

This fixes a crash in MPI as a result of sock_pe_report_write_
completion() calling fi_cntr_addr() when handling a triggered
operation.  MPI frees the counter after fi_cntr_addr() has
incremented the counter, but before the sock_cntr_addr()
call can finish sock_cntr_check_triggere_list().

Signed-off-by: Sean Hefty <sean.hefty@intel.com>