### PR TITLE
pingpong: Remove unnecessary NULL-checking for hints

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -1445,7 +1445,7 @@ static int pp_getinfo(struct ct_pingpong *ct, struct fi_info *hints,
 		ct->rx_ctx_ptr = NULL;
 	}
 
-	if (hints && ((hints->caps & FI_DIRECTED_RECV) == 0)) {
+	if ((hints->caps & FI_DIRECTED_RECV) == 0) {
 		(*info)->caps &= ~FI_DIRECTED_RECV;
 		(*info)->rx_attr->caps &= ~FI_DIRECTED_RECV;
 	}


### PR DESCRIPTION
Fixes Coverity scan issue ([CID 264626](https://scan4.coverity.com/reports.htm#v27196/p10344/fileInstanceId=37919729&defectInstanceId=6984675&mergedDefectId=264626))

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>