### PR TITLE
prov/verbs:  Make all send requests signaled

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -149,10 +149,8 @@
 #define FI_IBV_RELEASE_WRE(ep, wre)			\
 ({							\
 	if (wre) {					\
-		fastlock_acquire(&ep->wre_lock);	\
-		dlist_remove(&wre->entry);		\
-		util_buf_release(ep->wre_pool, wre);	\
-		fastlock_release(&ep->wre_lock);	\
+		fi_ibv_release_wre(ep->wre_pool,	\
+				   &ep->wre_lock, wre);	\
 	}						\
 })
 
@@ -416,6 +414,7 @@ struct fi_ibv_cq {
 	fi_ibv_trywait_func	trywait;
 	ofi_atomic32_t		nevents;
 	struct util_buf_pool	*wce_pool;
+	ofi_atomic32_t		sends_outstanding;
 };
 
 struct fi_ibv_rdm_request;
@@ -720,6 +719,71 @@ void fi_ibv_empty_wre_list(struct util_buf_pool *wre_pool,
 void fi_ibv_cleanup_cq(struct fi_ibv_msg_ep *cur_ep);
 int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
                            enum ibv_qp_type qp_type);
+
+static inline void fi_ibv_release_wre(struct util_buf_pool *wre_pool,
+				      fastlock_t *wre_lock,
+				      struct fi_ibv_wre *wre)
+{
+	fastlock_acquire(wre_lock);
+	dlist_remove(&wre->entry);
+	wre->srq = NULL;
+	wre->ep = NULL;
+	util_buf_release(wre_pool, wre);
+	fastlock_release(wre_lock);
+}
+
+static inline int
+fi_ibv_process_wc(struct fi_ibv_cq *cq, struct ibv_wc *wc)
+{
+	struct fi_ibv_wre *wre;
+	int ret = 1;
+
+	/* Handle WR entry when user doesn't request the completion */
+	if (!wc->wr_id) {
+		ofi_atomic_dec32(&cq->sends_outstanding);
+		return 0;
+	}
+
+	/* Handle compeltions that should be provided to user */
+	wre = (struct fi_ibv_wre *)(uintptr_t)wc->wr_id;
+	assert(wre && (wre->ep || wre->srq));
+	wc->wr_id = (uintptr_t)wre->context;
+
+	if (OFI_UNLIKELY(wc->status == IBV_WC_WR_FLUSH_ERR)) {
+		/* Handle case where remote side destroys
+		 * the connection, but local side isn't aware
+		 * about that yet */
+		ret = 0;
+	}
+
+	if (wre->ep) {
+		fi_ibv_release_wre(wre->ep->wre_pool,
+				   &wre->ep->wre_lock, wre);
+	} else if (wre->srq) {
+		fi_ibv_release_wre(wre->srq->wre_pool,
+				   &wre->srq->wre_lock, wre);
+	} else {
+		/* Shouldn't go here */
+		assert(0);
+		return -FI_EINVAL;
+	}
+
+	return ret;
+}
+
+static inline int fi_ibv_wc_2_wce(struct fi_ibv_cq *cq,
+				  struct ibv_wc *wc,
+				  struct fi_ibv_wce **wce)
+
+{
+	*wce = util_buf_alloc(cq->wce_pool);
+	if (OFI_UNLIKELY(!*wce))
+		return -FI_ENOMEM;
+	memset(*wce, 0, sizeof(**wce));
+	(*wce)->wc = *wc;
+
+	return FI_SUCCESS;
+}
 
 #define fi_ibv_init_sge(buf, len, desc) (struct ibv_sge)		\
 	{ .addr = (uintptr_t)buf,					\

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -104,7 +104,6 @@
 
 #define VERBS_WCE_CNT 1024
 #define VERBS_WRE_CNT 1024
-#define VERBS_EPE_CNT 1024
 
 #define VERBS_DEF_CQ_SIZE 1024
 #define VERBS_MR_IOV_LIMIT 1
@@ -414,13 +413,8 @@ struct fi_ibv_cq {
 	fi_ibv_cq_read_entry	read_entry;
 	struct slist		wcq;
 	fastlock_t		lock;
-	struct slist		ep_list;
-	uint64_t		ep_cnt;
-	uint64_t		send_signal_wr_id;
-	uint64_t		wr_id_mask;
 	fi_ibv_trywait_func	trywait;
 	ofi_atomic32_t		nevents;
-	struct util_buf_pool	*epe_pool;
 	struct util_buf_pool	*wce_pool;
 };
 
@@ -639,20 +633,10 @@ struct fi_ibv_msg_ep {
 	struct fi_ibv_srq_ep	*srq_ep;
 	uint64_t		ep_flags;
 	struct fi_info		*info;
-	ofi_atomic32_t		unsignaled_send_cnt;
-	int32_t			send_signal_thr;
-	int32_t			send_comp_thr;
-	ofi_atomic32_t		comp_pending;
 	fastlock_t		wre_lock;
 	struct util_buf_pool	*wre_pool;
 	struct dlist_entry	wre_list;
-	uint64_t		ep_id;
 	struct fi_ibv_domain	*domain;
-};
-
-struct fi_ibv_msg_epe {
-	struct slist_entry	entry;
-	struct fi_ibv_msg_ep 	*ep;
 };
 
 int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -230,38 +230,6 @@ static void fi_ibv_cq_read_data_entry(struct ibv_wc *wc, int i, void *buf)
 	fi_ibv_handle_wc(wc, &entry[i].flags, &entry[i].len, &entry[i].data);
 }
 
-static int fi_ibv_match_ep_id(struct slist_entry *entry,
-			      const void *ep_id)
-{
-	struct fi_ibv_msg_epe *epe =
-		container_of(entry, struct fi_ibv_msg_epe, entry);
-
-	return (epe->ep->ep_id == (uint64_t)ep_id);
-}
-
-static inline int fi_ibv_handle_internal_signal_wc(struct fi_ibv_cq *cq,
-						   struct ibv_wc *wc)
-{
-	struct fi_ibv_msg_epe *epe;
-	struct slist_entry *entry;
-
-	entry = slist_remove_first_match(&cq->ep_list,
-					 fi_ibv_match_ep_id,
-					 (void *)wc->wr_id);
-	if (!entry) {
-		VERBS_WARN(FI_LOG_CQ, "No matching EP for :"
-			   "given signaled send completion\n");
-		return -FI_EOTHER;
-	}
-	epe = container_of(entry, struct fi_ibv_msg_epe, entry);
-	ofi_atomic_sub32(&epe->ep->unsignaled_send_cnt,
-			 epe->ep->send_signal_thr);
-	ofi_atomic_dec32(&epe->ep->comp_pending);
-	util_buf_release(cq->epe_pool, epe);
-
-	return FI_SUCCESS;
-}
-
 static inline int fi_ibv_wc_2_wce(struct fi_ibv_cq *cq,
 				  struct ibv_wc *wc,
 				  struct fi_ibv_wce **wce)
@@ -294,46 +262,43 @@ static inline int fi_ibv_poll_outstanding_cq(struct fi_ibv_msg_ep *ep,
 	if (ret <= 0)
 		return ret;
 
-	if ((wc.opcode == IBV_WC_RECV) ||
-	    (wc.opcode == IBV_WC_RECV_RDMA_WITH_IMM) ||
-	    ((wc.wr_id & cq->wr_id_mask) != cq->send_signal_wr_id)) {
-		wre = (struct fi_ibv_wre *)(uintptr_t)wc.wr_id;
-		if (wre->ep) {
-			wre_pool = wre->ep->wre_pool;
-			if ((wre->ep != ep) &&
-			    (wc.status != IBV_WC_WR_FLUSH_ERR)) {
-				ret = fi_ibv_wc_2_wce(cq, &wc, &wce);
-				if (ret) {
-					wre->ep = NULL;
-					ret = -FI_EAGAIN;
-					goto fn;
-				}
-				slist_insert_tail(&wce->entry, &cq->wcq);
+	/* Handle WR entry when user doesn't request the completion */
+	if (!wc.wr_id)
+		return 0;
+
+	wre = (struct fi_ibv_wre *)(uintptr_t)wc.wr_id;
+	if (wre->ep) {
+		wre_pool = wre->ep->wre_pool;
+		if ((wre->ep != ep) &&
+		    (wc.status != IBV_WC_WR_FLUSH_ERR)) {
+			ret = fi_ibv_wc_2_wce(cq, &wc, &wce);
+			if (ret) {
+				wre->ep = NULL;
+				ret = -FI_EAGAIN;
+				goto fn;
 			}
-			wre->ep = NULL;
-		} else {
-			/* WRE belongs to SRQ's wre pool and should be
-			 * handled or rejected if status == `IBV_WC_WR_FLUSH_ERR` */
-			assert(wre->srq);
-			wre_pool = wre->srq->wre_pool;
-			wre->srq = NULL;
-			if (wc.status != IBV_WC_WR_FLUSH_ERR) {
-				ret = fi_ibv_wc_2_wce(cq, &wc, &wce);
-				if (ret) {
-					ret = -FI_EAGAIN;
-					goto fn;
-				}
-				slist_insert_tail(&wce->entry, &cq->wcq);
-			}
+			slist_insert_tail(&wce->entry, &cq->wcq);
 		}
-fn:
-		dlist_remove(&wre->entry);
-		util_buf_release(wre_pool, wre);
-		return ret;
+		wre->ep = NULL;
 	} else {
-		ret = fi_ibv_handle_internal_signal_wc(cq, &wc);
-		return ret ? ret : 1;
+		/* WRE belongs to SRQ's wre pool and should be
+		 * handled or rejected if status == `IBV_WC_WR_FLUSH_ERR` */
+		assert(wre->srq);
+		wre_pool = wre->srq->wre_pool;
+		wre->srq = NULL;
+		if (wc.status != IBV_WC_WR_FLUSH_ERR) {
+			ret = fi_ibv_wc_2_wce(cq, &wc, &wce);
+			if (ret) {
+				ret = -FI_EAGAIN;
+				goto fn;
+			}
+			slist_insert_tail(&wce->entry, &cq->wcq);
+		}
 	}
+fn:
+	dlist_remove(&wre->entry);
+	util_buf_release(wre_pool, wre);
+	return ret;
 }
 
 /* Must call with `ep|srq::wre_lock` held */
@@ -396,41 +361,38 @@ ssize_t fi_ibv_poll_cq(struct fi_ibv_cq *cq, struct ibv_wc *wc)
 	if (ret <= 0)
 		return ret;
 
-	/* TODO Handle the case when app posts a send with same wr_id */
-	if ((wc->opcode == IBV_WC_RECV) ||
-	    (wc->opcode == IBV_WC_RECV_RDMA_WITH_IMM) ||
-	    ((wc->wr_id & cq->wr_id_mask) != cq->send_signal_wr_id)) {
-		wre = (struct fi_ibv_wre *)(uintptr_t)wc->wr_id;
-		assert(wre && (wre->ep || wre->srq));
-		wc->wr_id = (uintptr_t)wre->context;
+	/* Handle WR entry when user doesn't request the completion */
+	if (!wc->wr_id)
+		return 0;
 
-		if (wc->status == IBV_WC_WR_FLUSH_ERR) {
-			/* Handles case where remote side destroys
-			 * the connection, but local side isn't aware
-			 * about that yet */
-			ret = 0;
-		}
+	wre = (struct fi_ibv_wre *)(uintptr_t)wc->wr_id;
+	assert(wre && (wre->ep || wre->srq));
+	wc->wr_id = (uintptr_t)wre->context;
 
-		if (wre->ep) {
-			wre_pool = wre->ep->wre_pool;
-			wre_lock = &wre->ep->wre_lock;
-			wre->ep = NULL;
-		} else if (wre->srq) {
-			wre_pool = wre->srq->wre_pool;
-			wre_lock = &wre->srq->wre_lock;
-			wre->srq = NULL;
-		} else {
-			assert(0);
-			return -FI_EAVAIL;
-		}
-
-		fastlock_acquire(wre_lock);
-		dlist_remove(&wre->entry);
- 		util_buf_release(wre_pool, wre);
-		fastlock_release(wre_lock);
-	} else {
-		return fi_ibv_handle_internal_signal_wc(cq, wc);
+	if (wc->status == IBV_WC_WR_FLUSH_ERR) {
+		/* Handles case where remote side destroys
+		 * the connection, but local side isn't aware
+		 * about that yet */
+		ret = 0;
 	}
+
+	if (wre->ep) {
+		wre_pool = wre->ep->wre_pool;
+		wre_lock = &wre->ep->wre_lock;
+		wre->ep = NULL;
+	} else if (wre->srq) {
+		wre_pool = wre->srq->wre_pool;
+		wre_lock = &wre->srq->wre_lock;
+		wre->srq = NULL;
+	} else {
+		assert(0);
+		return -FI_EAVAIL;
+	}
+
+	fastlock_acquire(wre_lock);
+	dlist_remove(&wre->entry);
+	util_buf_release(wre_pool, wre);
+	fastlock_release(wre_lock);
 
 	return ret;
 }
@@ -607,7 +569,6 @@ static int fi_ibv_cq_control(fid_t fid, int command, void *arg)
 static int fi_ibv_cq_close(fid_t fid)
 {
 	struct fi_ibv_cq *cq;
-	struct fi_ibv_msg_epe *epe;
 	struct fi_ibv_wce *wce;
 	struct slist_entry *entry;
 	int ret;
@@ -624,14 +585,8 @@ static int fi_ibv_cq_close(fid_t fid)
 		util_buf_release(cq->wce_pool, wce);
 	}
 
-	while (!slist_empty(&cq->ep_list)) {
-		entry = slist_remove_head(&cq->ep_list);
-		epe = container_of(entry, struct fi_ibv_msg_epe, entry);
-		util_buf_release(cq->epe_pool, epe);
-	}
 	fastlock_release(&cq->lock);
 
-	util_buf_pool_destroy(cq->epe_pool);
 	util_buf_pool_destroy(cq->wce_pool);
 
 	fastlock_destroy(&cq->lock);
@@ -668,7 +623,6 @@ int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		   struct fid_cq **cq, void *context)
 {
 	struct fi_ibv_cq *_cq;
-	int ep_cnt_bits = 0;
 	size_t size;
 	int ret;
 
@@ -743,13 +697,6 @@ int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		goto err4;
 	}
 
-	ret = util_buf_pool_create(&_cq->epe_pool, sizeof(struct fi_ibv_msg_epe),
-				   16, 0, VERBS_EPE_CNT);
-	if (ret) {
-		VERBS_WARN(FI_LOG_CQ, "Failed to create epe_pool\n");
-		goto err5;
-	}
-
 	_cq->flags |= attr->flags;
 	_cq->wait_cond = attr->wait_cond;
 	_cq->cq_fid.fid.fclass = FI_CLASS_CQ;
@@ -774,26 +721,18 @@ int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	case FI_CQ_FORMAT_TAGGED:
 	default:
 		ret = -FI_ENOSYS;
-		goto err6;
+		goto err5;
 	}
 
 	fastlock_init(&_cq->lock);
 
 	slist_init(&_cq->wcq);
-	slist_init(&_cq->ep_list);
-
-	while (_cq->domain->info->domain_attr->ep_cnt >> ++ep_cnt_bits);
-
-	_cq->send_signal_wr_id = 0xffffffffffffc0de << ep_cnt_bits;
-	_cq->wr_id_mask = (~_cq->wr_id_mask) << ep_cnt_bits;
 
 	_cq->trywait = fi_ibv_cq_trywait;
 	ofi_atomic_initialize32(&_cq->nevents, 0);
 
 	*cq = &_cq->cq_fid;
 	return 0;
-err6:
-	util_buf_pool_destroy(_cq->epe_pool);
 err5:
 	util_buf_pool_destroy(_cq->wce_pool);
 err4:

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -815,12 +815,12 @@ static ssize_t
 fi_ibv_msg_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
                  size_t count, fi_addr_t dest_addr, void *context)
 {
-	struct fi_ibv_msg_ep *ep;
-	struct ibv_send_wr wr = { 0 };
+	struct fi_ibv_msg_ep *ep =
+		container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
+	struct ibv_send_wr wr = {
+		.opcode = IBV_WR_SEND,
+	};
 
-	wr.opcode = IBV_WR_SEND;
-
-	ep = container_of(ep_fid, struct fi_ibv_msg_ep, ep_fid);
 	return fi_ibv_send_iov(ep, &wr, iov, desc, count, context);
 }
 

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -243,7 +243,7 @@ static int fi_ibv_msg_ep_enable(struct fid_ep *ep_fid)
 	}
 
 	attr.qp_type = IBV_QPT_RC;
-	attr.sq_sig_all = 0;
+	attr.sq_sig_all = 1;
 	attr.qp_context = ep;
 
 	ret = rdma_create_qp(ep->id, pd, &attr);


### PR DESCRIPTION
This patch makes all Send Requests signaled.
Internal Send Requests will have `wr_id` set to 0.

This addresses performance issue for critical path when the unsignaled send count reaches `max_send_wr`. When verbs provider reaches the threshold of unsignaled send count, it send the next Send Request as signaled and polling to receive CQ entry for this.