### PR TITLE
common/tree: Fix Red-Black tree balance

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -236,7 +236,7 @@ static void ofi_delete_rebalance(struct ofi_rbmap *map, struct ofi_rbnode *node)
 				w->color = node->parent->color;
 				node->parent->color = BLACK;
 				w->right->color = BLACK;
-				ofi_rotate_right(map, node->parent);
+				ofi_rotate_left(map, node->parent);
 				node = map->root;
 			}
 		} else {


### PR DESCRIPTION
Fixes Coverity scan issue - CID [264630](https://scan4.coverity.com/reports.htm#v27196/p10344/fileInstanceId=38114255&defectInstanceId=7013005&mergedDefectId=264630)

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>