### PR TITLE
util/av: Handle possible incorrect slot value

### DIFF
--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -322,7 +322,12 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, int slot, int *inde
 	struct util_ep *ep;
 	int ret;
 
-	if (av->free_list == UTIL_NO_ENTRY) {
+	if (OFI_UNLIKELY(slot < 0 || slot >= av->hash.slots)) {
+		FI_WARN(av->prov, FI_LOG_AV, "invalid slot (%d)\n", slot);
+		return -FI_EINVAL;
+	}
+
+	if (OFI_UNLIKELY(av->free_list == UTIL_NO_ENTRY)) {
 		FI_WARN(av->prov, FI_LOG_AV, "AV is full\n");
 		return -FI_ENOSPC;
 	}


### PR DESCRIPTION
Fixes Coverity scan issue CID [266178](https://scan4.coverity.com/reports.htm#v27196/p10344/fileInstanceId=38219678&defectInstanceId=7036389&mergedDefectId=266178)

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>