### PR TITLE
util/av: Handle possible incorrect slot value (for v1.6.x)

### DIFF
--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -322,7 +322,12 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, int slot, int *inde
 	struct util_ep *ep;
 	int ret;
 
-	if (av->free_list == UTIL_NO_ENTRY) {
+	if (OFI_UNLIKELY(slot < 0 || slot >= av->hash.slots)) {
+		FI_WARN(av->prov, FI_LOG_AV, "invalid slot (%d)\n", slot);
+		return -FI_EINVAL;
+	}
+
+	if (OFI_UNLIKELY(av->free_list == UTIL_NO_ENTRY)) {
 		FI_WARN(av->prov, FI_LOG_AV, "AV is full\n");
 		return -FI_ENOSPC;
 	}


### PR DESCRIPTION
This is picked up from #3945 for the stable v1.6.x branch

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>