### PR TITLE
prov/rxm, util/av: Minor optimizations for acquiring connection info

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -545,26 +545,16 @@ extern int
 util_cmap_alloc_handle(struct util_cmap *cmap, fi_addr_t fi_addr,
 		       enum util_cmap_state state,
 		       struct util_cmap_handle **handle);
-/* Caller must hold `cmap::lock` */
+int ofi_cmap_handle_connect(struct util_cmap *cmap, fi_addr_t fi_addr,
+			    struct util_cmap_handle *handle);
+/* Caller must hold cmap->lock */
 static inline struct util_cmap_handle *
 ofi_cmap_acquire_handle(struct util_cmap *cmap, fi_addr_t fi_addr)
 
 {
-	struct util_cmap_handle *handle =
-		util_cmap_get_handle(cmap, fi_addr);
-	if (!handle) {
-		int ret;
-
-		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
-		       "No handle found for given fi_addr\n");
-		ret = util_cmap_alloc_handle(cmap, fi_addr, CMAP_IDLE, &handle);
-		if (OFI_UNLIKELY(ret))
-			return NULL;
-	}
-	return handle;
+	assert(fi_addr <= cmap->av->count);
+	return cmap->handles_av[fi_addr];
 }
-int ofi_cmap_handle_connect(struct util_cmap *cmap, fi_addr_t fi_addr,
-			    struct util_cmap_handle *handle);
 
 /*
  * Poll set

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1015,10 +1015,18 @@ rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 
 	fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
 	handle = ofi_cmap_acquire_handle(rxm_ep->util_ep.cmap, dest_addr);
-	if (OFI_UNLIKELY(!handle)) {
-		fastlock_release(&rxm_ep->util_ep.cmap->lock);
-		return -FI_EAGAIN;
-	} else if (OFI_UNLIKELY(handle->state != CMAP_CONNECTED)) {
+	if (OFI_UNLIKELY(!handle || handle->state != CMAP_CONNECTED)) {
+		if (OFI_UNLIKELY(!handle)) {
+			FI_DBG(&rxm_prov, FI_LOG_EP_CTRL,
+			       "No handle found for given fi_addr\n");
+			ret = util_cmap_alloc_handle(rxm_ep->util_ep.cmap,
+						     dest_addr, CMAP_IDLE,
+						     &handle);
+			if (OFI_UNLIKELY(ret)) {
+				fastlock_release(&rxm_ep->util_ep.cmap->lock);
+				return -FI_EAGAIN;
+			}
+		}
 		struct iovec iov = {
 			.iov_base = (void *)buf,
 			.iov_len = len,
@@ -1081,10 +1089,18 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 
 	fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
 	handle = ofi_cmap_acquire_handle(rxm_ep->util_ep.cmap, dest_addr);
-	if (OFI_UNLIKELY(!handle)) {
-		fastlock_release(&rxm_ep->util_ep.cmap->lock);
-		return -FI_EAGAIN;
-	} else if (OFI_UNLIKELY(handle->state != CMAP_CONNECTED)) {
+	if (OFI_UNLIKELY(!handle || handle->state != CMAP_CONNECTED)) {
+		if (OFI_UNLIKELY(!handle)) {
+			FI_DBG(&rxm_prov, FI_LOG_EP_CTRL,
+			       "No handle found for given fi_addr\n");
+			ret = util_cmap_alloc_handle(rxm_ep->util_ep.cmap,
+						     dest_addr, CMAP_IDLE,
+						     &handle);
+			if (OFI_UNLIKELY(ret)) {
+				fastlock_release(&rxm_ep->util_ep.cmap->lock);
+				return -FI_EAGAIN;
+			}
+		}
 		ret = ofi_cmap_handle_connect(rxm_ep->util_ep.cmap,
 					      dest_addr, handle);
 		if (OFI_UNLIKELY(ret != -FI_EAGAIN))

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1213,7 +1213,7 @@ int util_cmap_alloc_handle(struct util_cmap *cmap, fi_addr_t fi_addr,
 			   struct util_cmap_handle **handle)
 {
 	*handle = cmap->attr.alloc();
-	if (!*handle)
+	if (OFI_UNLIKELY(!*handle))
 		return -FI_ENOMEM;
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Allocated handle: %p for "
 	       "fi_addr: %" PRIu64 "\n", *handle, fi_addr);
@@ -1313,15 +1313,6 @@ out:
 }
 
 /* Caller must hold cmap->lock */
-struct util_cmap_handle *
-util_cmap_get_handle(struct util_cmap *cmap, fi_addr_t fi_addr)
-{
-	if (fi_addr > cmap->av->count) {
-		FI_WARN(cmap->av->prov, FI_LOG_EP_CTRL, "Invalid fi_addr\n");
-		return NULL;
-	}
-	return cmap->handles_av[fi_addr];
-}
 
 void ofi_cmap_process_shutdown(struct util_cmap *cmap,
 			       struct util_cmap_handle *handle)
@@ -1403,7 +1394,7 @@ int ofi_cmap_process_connreq(struct util_cmap *cmap, void *addr,
 	if (index < 0)
 		handle = util_cmap_get_handle_peer(cmap, addr);
 	else
-		handle = util_cmap_get_handle(cmap, (fi_addr_t)index);
+		handle = ofi_cmap_acquire_handle(cmap, (fi_addr_t)index);
 
 	if (!handle) {
 		if (index < 0)


### PR DESCRIPTION
This patch applies some minor performance optimizations to util/av code that allows RxM refactor handling case of unconnected EPs

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>