### PR TITLE
prov/psm2: Avoid unnecessary calls to psmx2_am_progress()

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -504,6 +504,7 @@ struct psmx2_trx_ctxt {
 	psm2_epid_t		psm2_epid;
 	psm2_mq_t		psm2_mq;
 	int			am_initialized;
+	int			am_progress;
 	int			id;
 	int			usage_flags;
 	struct psm2_am_parameters psm2_am_param;
@@ -1054,7 +1055,7 @@ static inline void psmx2_progress(struct psmx2_trx_ctxt *trx_ctxt)
 {
 	if (trx_ctxt) {
 		psmx2_cq_poll_mq(NULL, trx_ctxt, NULL, 0, NULL);
-		if (trx_ctxt->am_initialized)
+		if (trx_ctxt->am_progress)
 			psmx2_am_progress(trx_ctxt);
 	}
 }

--- a/prov/psm2/src/psmx2_attr.c
+++ b/prov/psm2/src/psmx2_attr.c
@@ -380,6 +380,13 @@ void psmx2_alter_prov_info(uint32_t api_version,
 			info->domain_attr->mr_mode = FI_MR_SCALABLE;
 
 		/*
+		 * Avoid automatically adding secondary caps that may negatively
+		 * impact performance.
+		 */
+		if (hints && hints->caps && !(hints->caps & FI_TRIGGER))
+			info->caps &= ~FI_TRIGGER;
+
+		/*
 		 * Special arrangement for auto tag layout selection.
 		 * See psmx2_init_prov_info(). Set this flag to allow
 		 * follow-up fi_getinfo() calls to pick the same tag

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -957,7 +957,7 @@ STATIC ssize_t psmx2_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 			if (ret > 0)
 				return ret;
 
-			if (poll_ctxt->trx_ctxt->am_initialized)
+			if (poll_ctxt->trx_ctxt->am_progress)
 				psmx2_am_progress(poll_ctxt->trx_ctxt);
 
 			(void) prev; /* suppress compiler warning */

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -388,6 +388,8 @@ STATIC int psmx2_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		err = psmx2_domain_enable_ep(ep->domain, ep);
 		if (err)
 			return err;
+		if (ep->caps & (FI_RMA | FI_TRIGGER))
+			stx->tx->am_progress = 1;
 		ofi_atomic_inc32(&stx->ref);
 		break;
 
@@ -612,6 +614,9 @@ int psmx2_ep_open_internal(struct psmx2_fid_domain *domain_priv,
 	psmx2_ep_optimize_ops(ep_priv);
 
 	PSMX2_EP_INIT_OP_CONTEXT(ep_priv);
+
+	if ((ep_cap & (FI_RMA | FI_TRIGGER)) && trx_ctxt)
+		trx_ctxt->am_progress = 1;
 
 	*ep_out = ep_priv;
 	return 0;


### PR DESCRIPTION
The function is used to process request queues associated with large size
RMA and triggered ops. Previously the initialization of the AM mechanism
was used as the condition to call this function. Since the AM mechanism is
now also used for non-RMA functionality, the condition has become overly
broad and could cause the function be called unnecessarily.

Change the condition to be the presence of FI_RMA or FI_TRIGGERED caps in
the associated endpoints.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>