### PR TITLE
util/av: Handle the deletion of the same address multiple times

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -375,6 +375,7 @@ int ofi_cntr_cleanup(struct util_cntr *cntr);
  */
 struct util_av_hash_entry {
 	int			index;
+	ofi_atomic32_t		use_cnt;
 	int			next;
 };
 


### PR DESCRIPTION
This fixes handling of multiple deletion of the same address.
The idea of this patch is the following:

- When an user inserts the address, AV functionality increments the
`use_cnt` value for this entry in AV hash table.
- When an user removes the address, AV functionality decrements the
use_cnt value for this entry in AV hash table. If the `use_cnt`
`value == 0`, the entry is deleted.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>