### PR TITLE
config: Remove -DNDEBUG flag for debug build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,8 +95,14 @@ AC_ARG_ENABLE([debug],
 
 AS_IF([test x"$enable_debug" != x"no"],
       [dbg=1
+       CFLAGS_save=
+       # Remove -DNDEBUG flag if set
+       for flag in $CFLAGS; do
+           if test "$flag" != "-DNDEBUG"; then
+               CFLAGS_save="$CFLAGS_save $flag"
+           fi
+       done
        # See if all the flags in $debug_c_other_flags work
-       CFLAGS_save=$CFLAGS
        good_flags=
        for flag in $debug_c_other_flags; do
            AC_MSG_CHECKING([to see if compiler supports $flag])


### PR DESCRIPTION
This patch removes -DNDEBUG flag for debug build to fix compiler warning and to make `assert` executable

This is an example of warning:
```
In file included from ./include/ofi.h:49:0,
                 from src/iov.c:37:
./include/ofi_lock.h: In function ‘fastlock_destroy’:
./include/ofi_lock.h:92:6: warning: variable ‘ret’ set but not used [-Wunused-but-set-variable]
  int ret;
      ^~~
./include/ofi_lock.h: In function ‘fastlock_acquire’:
./include/ofi_lock.h:102:6: warning: variable ‘ret’ set but not used [-Wunused-but-set-variable]
  int ret;
      ^~~
./include/ofi_lock.h: In function ‘fastlock_release’:
./include/ofi_lock.h:117:6: warning: variable ‘ret’ set but not used [-Wunused-but-set-variable]
  int ret;
      ^~~
libtool: compile:  /p/pdsd/opt/EM64T-LIN/compilers/gnu/gcc-7.1.0/bin/gcc -DHAVE_CONFIG_H -I. -I./include -D_GNU_SOURCE -D__USE_XOPEN2K8 -DSYSCONFDIR=\"/p/pdsd/Users/dgladkov/ofi_latest/etc\" -DRDMADIR=\"@rdmadir@\" -DPROVDLDIR=\"/p/pdsd/Users/dgladkov/ofi_latest/lib/libfabric\" -I./prov/sockets/include -I./prov/sockets -I./prov/verbs/src/ep_rdm -I./prov/verbs/src/ep_dgram -Wall -g -O0 -Wall -Wundef -Wpointer-arith -Wextra -Wno-unused-parameter -Wno-sign-compare -Wno-missing-field-initializers -fstack-protector-strong -fvisibility=hidden -O2 -DNDEBUG -Wall -Wundef -Wpointer-arith -MT prov/hook/src/src_libfabric_la-hook_ep.lo -MD -MP -MF prov/hook/src/.deps/src_libfabric_la-hook_ep.Tpo -c prov/hook/src/hook_ep.c -o prov/hook/src/src_libfabric_la-hook_ep.o >/dev/null 2>&1
```

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>