### PR TITLE
util/av: Don't check slot value if OFI_AV_HASH isn't set

### DIFF
--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -322,17 +322,16 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, int slot, int *inde
 	struct util_ep *ep;
 	int ret;
 
-	if (OFI_UNLIKELY(slot < 0 || slot >= av->hash.slots)) {
-		FI_WARN(av->prov, FI_LOG_AV, "invalid slot (%d)\n", slot);
-		return -FI_EINVAL;
-	}
-
 	if (OFI_UNLIKELY(av->free_list == UTIL_NO_ENTRY)) {
 		FI_WARN(av->prov, FI_LOG_AV, "AV is full\n");
 		return -FI_ENOSPC;
 	}
 
 	if (av->flags & OFI_AV_HASH) {
+		if (OFI_UNLIKELY(slot < 0 || slot >= av->hash.slots)) {
+			FI_WARN(av->prov, FI_LOG_AV, "invalid slot (%d)\n", slot);
+			return -FI_EINVAL;
+		}
 		ret = util_av_lookup_index(av, addr, slot);
 		if (ret != -FI_ENODATA) {
 			*index = ret;
@@ -441,7 +440,7 @@ int ofi_av_lookup_index(struct util_av *av, const void *addr, int slot)
 {
 	int ret;
 
-	if (slot < 0 || slot >= av->hash.slots) {
+	if (OFI_UNLIKELY(slot < 0 || slot >= av->hash.slots)) {
 		FI_WARN(av->prov, FI_LOG_AV, "invalid slot (%d)\n", slot);
 		return -FI_EINVAL;
 	}


### PR DESCRIPTION
We shouldn't check `slot` value for AV when `OFI_AV_HASH` isn't set.
This patch fixes this issue

Fixes #3951

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>