### PR TITLE
prov/rxm: Implement MR caching for Rendezvous protocol

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -291,6 +291,18 @@ RXM_INI
 			"(default: 1) that would be read per progress "
 			"(RxM CQ read).");
 
+	fi_param_define(&rxm_prov, "mr_cache_enable", FI_PARAM_BOOL,
+			"Enables Memory Region caching for Rendevouz protocol"
+			"(default: 0).");
+
+	fi_param_define(&rxm_prov, "mr_max_cached_cnt", FI_PARAM_INT,
+			"Maximum number of cache entrie"
+			"(default: 4096).");
+
+	fi_param_define(&rxm_prov, "mr_max_cached_size", FI_PARAM_SIZE_T,
+			"Maximum total size of cache entries"
+			"(default: 4 Gb).");
+
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");
 		return NULL;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -46,9 +46,9 @@ rxm_ep_rma_reg_iov(struct rxm_ep *rxm_ep, const struct iovec *msg_iov,
 	if (rxm_ep->msg_mr_local) {
 		if (!rxm_ep->rxm_mr_local) {
 			ssize_t ret =
-				rxm_ep_msg_mr_regv(rxm_ep, msg_iov, iov_count,
-						   comp_flags & (FI_WRITE | FI_READ),
-						   tx_entry->mr);
+				rxm_ep->mr_regv(rxm_ep, msg_iov, iov_count,
+						comp_flags & (FI_WRITE | FI_READ),
+						tx_entry->mr);
 			if (OFI_UNLIKELY(ret))
 				return ret;
 
@@ -357,7 +357,7 @@ cmap_err:
 		return ret;
 
 	if ((rxm_ep->msg_mr_local) && (!rxm_ep->rxm_mr_local))
-		rxm_ep_msg_mr_closev(tx_entry->mr, tx_entry->count);
+		rxm_ep->mr_closev(rxm_ep, tx_entry->mr, tx_entry->count);
 err:
 	rxm_tx_entry_release(&rxm_ep->send_queue, tx_entry);
 	return ret;


### PR DESCRIPTION
This is draft implementation of MR caching for Rendezvous protocol.
The most of code was copy-pasted (move to common?) w/ insignificant updates from verbs provider.

Btw, this fixes non-blocking MPI collectives for some tests on iWarp (e.x. for processes > 8 -- each rank will create 7 MSG EPs and allocate eager receive buffers for them). This doesn't register memory for eager buffers and used only for LMT and RMA  messages

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>