### PR TITLE
build: Check for presence of __cpuid_count

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -226,6 +226,21 @@ AC_TRY_LINK([#include <stdint.h>],
     ],
     [AC_MSG_RESULT(no)])
 
+dnl Check for gcc cpuid intrinsics
+AC_MSG_CHECKING(compiler support for cpuid)
+AC_TRY_LINK([
+     #include <stddef.h>
+     #include <cpuid.h>],
+    [
+     int a, b, c, d;
+     __cpuid_count(0, 0, a, b, c, d);
+    ],
+    [
+	AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_CPUID, 1, [Set to 1 to to use cpuid])
+    ],
+    [AC_MSG_RESULT(no)])
+
 dnl Check for glibc malloc hooks
 AC_MSG_CHECKING(compiler support for glibc malloc hooks)
 AC_TRY_LINK([#include <malloc.h>],

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -254,7 +254,7 @@ OFI_DEF_COMPLEX_OPS(long_double)
 int ofi_set_thread_affinity(const char *s);
 
 
-#if defined(__x86_64__) || defined(__amd64__)
+#if defined(HAVE_CPUID) && (defined(__x86_64__) || defined(__amd64__))
 
 #include <cpuid.h>
 


### PR DESCRIPTION
Older versions of icc and gcc do not support this intrinsic.  Sigh

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

Fixes #3958 