### PR TITLE
prov/netdir: Fix crash in the ND init

### DIFF
--- a/prov/netdir/src/netdir_ndinit.c
+++ b/prov/netdir/src/netdir_ndinit.c
@@ -571,6 +571,7 @@ static HRESULT ofi_nd_init(ofi_nd_adapter_cb_t cb)
 		cb(&ofi_nd_infra.adapters.adapter[j].info,
 		   ofi_nd_infra.adapters.adapter[j].name);
 
+	return hr;
 fn_protofail:
 	free(proto);
 fn_exit:


### PR DESCRIPTION
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>