### PR TITLE
configure: Fix compilation failure with icc 18

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -208,6 +208,21 @@ AC_TRY_LINK([#include <stdatomic.h>],
     ],
     [AC_MSG_RESULT(no)])
 
+
+AC_MSG_CHECKING(compiler support for c11 atomic `least` types)
+AC_TRY_LINK([#include <stdatomic.h>],
+    [atomic_int_least32_t a;
+     atomic_int_least64_t b;
+    ],
+    [
+        AC_MSG_RESULT(yes)
+        AC_DEFINE(HAVE_ATOMICS_LEAST_TYPES, 1,
+                  [Set to 1 to use c11 atomic `least` types])
+    ],
+    [
+        AC_MSG_RESULT(no)
+    ])
+
 dnl Check for gcc built-in atomics
 AC_MSG_CHECKING(compiler support for built-in atomics)
 AC_TRY_LINK([#include <stdint.h>],

--- a/include/ofi_atom.h
+++ b/include/ofi_atom.h
@@ -63,8 +63,13 @@ extern "C" {
 #endif
 
 #ifdef HAVE_ATOMICS
-	typedef atomic_int_least32_t	ofi_atomic_int32_t;
-	typedef atomic_int_least64_t	ofi_atomic_int64_t;
+#ifdef HAVE_ATOMICS_LEAST_TYPES
+typedef atomic_int_least32_t	ofi_atomic_int32_t;
+typedef atomic_int_least64_t	ofi_atomic_int64_t;
+#else
+typedef atomic_int	ofi_atomic_int32_t;
+typedef atomic_long	ofi_atomic_int64_t;
+#endif
 
 #define OFI_ATOMIC_DEFINE(radix)									\
 	typedef struct {										\


### PR DESCRIPTION
Fixes #3982 

with added checks the output of configure looks as follows:
```
checking compiler support for c11 atomics... yes
checking compiler support for c11 atomic `least` types... no
checking compiler support for built-in atomics... yes

```
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>