### PR TITLE
prov/psm2: Check iov limit in sendmsg

### DIFF
--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -594,7 +594,9 @@ STATIC ssize_t psmx2_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	if (!msg || (msg->iov_count && !msg->msg_iov))
 		return -FI_EINVAL;
 
-	if (msg->iov_count > 1) {
+	if (msg->iov_count > PSMX2_IOV_MAX_COUNT) {
+		return -FI_EINVAL;
+	} else if (msg->iov_count > 1) {
 		return psmx2_sendv_generic(ep, msg->msg_iov, msg->desc,
 					   msg->iov_count, msg->addr,
 					   msg->context, flags,

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -1114,7 +1114,9 @@ static ssize_t psmx2_tagged_sendmsg(struct fid_ep *ep,
 	if (!msg || (msg->iov_count && !msg->msg_iov))
 		return -FI_EINVAL;
 
-	if (msg->iov_count > 1) {
+	if (msg->iov_count > PSMX2_IOV_MAX_COUNT) {
+		return -FI_EINVAL;
+	} else if (msg->iov_count > 1) {
 		return psmx2_tagged_sendv_generic(ep, msg->msg_iov,
 						  msg->desc, msg->iov_count,
 						  msg->addr, msg->tag,


### PR DESCRIPTION
The iov limit was checked in sendv but not sendmsg. Add the check
to ensure consistent error handling.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>