### PR TITLE
prov/verbs: Fix ICC 18 warnings

### DIFF
--- a/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
+++ b/prov/verbs/src/ep_rdm/verbs_rdm_cm.c
@@ -521,10 +521,10 @@ fi_ibv_rdm_process_event_established(const struct rdma_cm_event *event,
 		(struct fi_ibv_rdm_conn *)event->id->context;
 
 	if (conn->state != FI_VERBS_CONN_STARTED &&
-	    conn->cm_role != FI_VERBS_CM_SELF)
-	{
-		VERBS_INFO(FI_LOG_AV, "state = %d, conn %p", conn->state, conn);
-		assert(0 && "Wrong state");
+	    conn->cm_role != FI_VERBS_CM_SELF) {
+		VERBS_WARN(FI_LOG_AV, "Wrong state! state = %d, conn %p",
+			   conn->state, conn);
+		assert(0);
 		return -FI_ECONNABORTED;
 	}
 

--- a/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
+++ b/prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c
@@ -558,9 +558,12 @@ fi_ibv_rdm_process_recv_wc(struct fi_ibv_rdm_ep *ep, struct ibv_wc *wc)
 			 */
 			fi_ibv_rdm_start_disconnection(conn);
 		} else {
-			assert("Error recv wc\n" &&
-			       (!ep->is_closing ||
-				conn->state != FI_VERBS_CONN_ESTABLISHED));
+			VERBS_DBG(FI_LOG_EP_DATA, "%s recv WC",
+				  ((!ep->is_closing ||
+				   conn->state != FI_VERBS_CONN_ESTABLISHED) ?
+				   "Expected" : "Error"));
+			assert(!ep->is_closing ||
+			       conn->state != FI_VERBS_CONN_ESTABLISHED);
 		}
 		conn->state = FI_VERBS_CONN_CLOSED;
 	}


### PR DESCRIPTION
This fixes the following warnings that only occur with ICC 18:
```
prov/verbs/src/ep_rdm/verbs_rdm_cm.c(527): warning #279: controlling expression is constant
                assert(0 && "Wrong state");

prov/verbs/src/ep_rdm/verbs_tagged_ep_rdm.c(561): warning #279: controlling expression is constant
                        assert("Error recv wc\n" &&

```

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>