### PR TITLE
prov/sockets: Fix segfault in sockets provider

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2446,7 +2446,7 @@ int sock_pe_progress_ep_rx(struct sock_pe *pe, struct sock_ep_attr *ep_attr)
 	struct sock_rx_ctx *rx_ctx;
 	int ret, i;
 
-	for (i = 0; i <= ep_attr->ep_attr.rx_ctx_cnt; i++) {
+	for (i = 0; i < ep_attr->ep_attr.rx_ctx_cnt; i++) {
 		rx_ctx = ep_attr->rx_array[i];
 		if (!rx_ctx)
 			continue;
@@ -2463,7 +2463,7 @@ int sock_pe_progress_ep_tx(struct sock_pe *pe, struct sock_ep_attr *ep_attr)
 	struct sock_tx_ctx *tx_ctx;
 	int ret, i;
 
-	for (i = 0; i <= ep_attr->ep_attr.tx_ctx_cnt; i++) {
+	for (i = 0; i < ep_attr->ep_attr.tx_ctx_cnt; i++) {
 		tx_ctx = ep_attr->tx_array[i];
 		if (!tx_ctx)
 			continue;


### PR DESCRIPTION
Fixes #3979.

This patch fixes out of boundary access for `rx_array` and `tx_array`.

These arrays are allocated [here (for example rx_array)](https://github.com/ofiwg/libfabric/blob/7bb4d2307cdd41ebebbf0ed1fb8d99fc18a76c54/prov/sockets/src/sock_ep.c#L1742)




Signed-off-by: Anatoliy Rozanov <anatoliy.rozanov@intel.com>