### PR TITLE
prov/verbs: Move CQEs polling after calling of ibv_post_send

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -411,7 +411,6 @@ struct fi_ibv_cq {
 	fi_ibv_trywait_func	trywait;
 	ofi_atomic32_t		nevents;
 	struct util_buf_pool	*wce_pool;
-	ofi_atomic32_t		sends_outstanding;
 };
 
 struct fi_ibv_rdm_request;
@@ -628,10 +627,8 @@ fi_ibv_process_wc(struct fi_ibv_cq *cq, struct ibv_wc *wc)
 	int ret = 1;
 
 	/* Handle WR entry when user doesn't request the completion */
-	if (!wc->wr_id) {
-		ofi_atomic_dec32(&cq->sends_outstanding);
+	if (!wc->wr_id)
 		return 0;
-	}
 
 	/* Handle compeltions that should be provided to user */
 	wre = (struct fi_ibv_wre *)(uintptr_t)wc->wr_id;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -247,7 +247,6 @@ static inline int fi_ibv_poll_outstanding_cq(struct fi_ibv_msg_ep *ep,
 
 	/* Handle WR entry when user doesn't request the completion */
 	if (!wc.wr_id) {
-		ofi_atomic_dec32(&cq->sends_outstanding);
 		/* To ensure the new iteration */
 		return 1;
 	}


### PR DESCRIPTION
This patch reduces # of instructions before `ibv_post_send`, i.e. before data is passed on a wire.
But total amount of instructions is the same as previous.

This should improve receive side, because we will do polling (if needed) after data is passed on a wire. i.e. receiver should receive data a bit earlier than it was in the previous realization. Is it viable?

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>