### PR TITLE
prov/rxm: Use locks for EP resources if FI_THREAD_SAFE is requested

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -195,6 +195,7 @@ struct util_domain {
 	uint32_t		addr_format;
 	enum fi_av_type		av_type;
 	struct ofi_mr_map	mr_map;
+	enum fi_threading	threading;
 };
 
 int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -306,6 +306,7 @@ struct rxm_recv_entry {
 DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
 
 struct rxm_send_queue {
+	struct rxm_ep *rxm_ep;
 	struct rxm_txe_fs *fs;
 	fastlock_t lock;
 };
@@ -316,6 +317,7 @@ enum rxm_recv_queue_type {
 };
 
 struct rxm_recv_queue {
+	struct rxm_ep *rxm_ep;
 	enum rxm_recv_queue_type type;
 	struct rxm_recv_fs *fs;
 	struct dlist_entry recv_list;
@@ -328,7 +330,7 @@ struct rxm_recv_queue {
 struct rxm_buf_pool {
 	struct util_buf_pool *pool;
 	enum rxm_buf_pool_type type;
-	struct rxm_ep *ep;
+	struct rxm_ep *rxm_ep;
 	fastlock_t lock;
 };
 
@@ -501,20 +503,20 @@ rxm_process_recv_entry(struct rxm_recv_queue *recv_queue,
 {
 	struct rxm_rx_buf *rx_buf;
 
-	fastlock_acquire(&recv_queue->lock);
+	recv_queue->rxm_ep->res_fastlock_acquire(&recv_queue->lock);
 	rx_buf = rxm_check_unexp_msg_list(recv_queue, recv_entry->addr,
 					  recv_entry->tag, recv_entry->ignore);
 	if (rx_buf) {
 		dlist_remove(&rx_buf->unexp_msg.entry);
 		rx_buf->recv_entry = recv_entry;
-		fastlock_release(&recv_queue->lock);
+		recv_queue->rxm_ep->res_fastlock_release(&recv_queue->lock);
 		return rxm_cq_handle_data(rx_buf);
 	}
 
 	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Enqueuing recv", recv_entry->addr,
 			 recv_entry->tag);
 	dlist_insert_tail(&recv_entry->entry, &recv_queue->recv_list);
-	fastlock_release(&recv_queue->lock);
+	recv_queue->rxm_ep->res_fastlock_release(&recv_queue->lock);
 
 	return FI_SUCCESS;
 }
@@ -524,22 +526,22 @@ struct rxm_buf *rxm_buf_get(struct rxm_buf_pool *pool)
 {
 	struct rxm_buf *buf;
 
-	fastlock_acquire(&pool->lock);
+	pool->rxm_ep->res_fastlock_acquire(&pool->lock);
 	buf = util_buf_alloc(pool->pool);
 	if (OFI_UNLIKELY(!buf)) {
-		fastlock_release(&pool->lock);
+		pool->rxm_ep->res_fastlock_release(&pool->lock);
 		return NULL;
 	}
-	fastlock_release(&pool->lock);
+	pool->rxm_ep->res_fastlock_release(&pool->lock);
 	return buf;
 }
 
 static inline
 void rxm_buf_release(struct rxm_buf_pool *pool, struct rxm_buf *buf)
 {
-	fastlock_acquire(&pool->lock);
+	pool->rxm_ep->res_fastlock_acquire(&pool->lock);
 	util_buf_release(pool->pool, buf);
-	fastlock_release(&pool->lock);
+	pool->rxm_ep->res_fastlock_release(&pool->lock);
 }
 
 static inline struct rxm_tx_buf *
@@ -590,19 +592,19 @@ rxm_rma_buf_release(struct rxm_ep *rxm_ep, struct rxm_rma_buf *rx_buf)
 			(struct rxm_buf *)rx_buf);
 }
 
-#define rxm_entry_pop(queue, entry)			\
-	do {						\
-		fastlock_acquire(&queue->lock);		\
-		entry = freestack_isempty(queue->fs) ?	\
-			NULL : freestack_pop(queue->fs);\
-		fastlock_release(&queue->lock);		\
+#define rxm_entry_pop(queue, entry)					\
+	do {								\
+		queue->rxm_ep->res_fastlock_acquire(&queue->lock);	\
+		entry = freestack_isempty(queue->fs) ?			\
+			NULL : freestack_pop(queue->fs);		\
+		queue->rxm_ep->res_fastlock_release(&queue->lock);	\
 	} while (0)
 
-#define rxm_entry_push(queue, entry)			\
-	do {						\
-		fastlock_acquire(&queue->lock);		\
-		freestack_push(queue->fs, entry);	\
-		fastlock_release(&queue->lock);		\
+#define rxm_entry_push(queue, entry)					\
+	do {								\
+		queue->rxm_ep->res_fastlock_acquire(&queue->lock);	\
+		freestack_push(queue->fs, entry);			\
+		queue->rxm_ep->res_fastlock_release(&queue->lock);	\
 	} while (0)
 
 #define rxm_tx_entry_cleanup(entry)		(entry)->tx_buf = NULL

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -332,6 +332,9 @@ struct rxm_buf_pool {
 	fastlock_t lock;
 };
 
+typedef void (*rxm_ep_res_fastlock_acquire_t)(fastlock_t *lock);
+typedef void (*rxm_ep_res_fastlock_release_t)(fastlock_t *lock);
+
 struct rxm_ep {
 	struct util_ep 		util_ep;
 	struct fi_info 		*rxm_info;
@@ -355,6 +358,9 @@ struct rxm_ep {
 	struct rxm_send_queue	send_queue;
 	struct rxm_recv_queue	recv_queue;
 	struct rxm_recv_queue	trecv_queue;
+
+	rxm_ep_res_fastlock_acquire_t	res_fastlock_acquire;
+	rxm_ep_res_fastlock_release_t	res_fastlock_release;
 };
 
 struct rxm_ep_wait_ref {

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -444,7 +444,7 @@ static ssize_t rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 		return -FI_EINVAL;
 	}
 
-	fastlock_acquire(&rx_buf->recv_queue->lock);
+	rx_buf->ep->res_fastlock_acquire(&rx_buf->recv_queue->lock);
 	entry = dlist_remove_first_match(&rx_buf->recv_queue->recv_list,
 					 rx_buf->recv_queue->match_recv, &match_attr);
 	if (!entry) {
@@ -457,10 +457,10 @@ static ssize_t rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 		rx_buf->unexp_msg.tag = match_attr.tag;
 		dlist_insert_tail(&rx_buf->unexp_msg.entry,
 				  &rx_buf->recv_queue->unexp_msg_list);
-		fastlock_release(&rx_buf->recv_queue->lock);
+		rx_buf->ep->res_fastlock_release(&rx_buf->recv_queue->lock);
 		return 0;
 	}
-	fastlock_release(&rx_buf->recv_queue->lock);
+	rx_buf->ep->res_fastlock_release(&rx_buf->recv_queue->lock);
 
 	rx_buf->recv_entry = container_of(entry, struct rxm_recv_entry, entry);
 	return rxm_cq_handle_data(rx_buf);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -43,6 +43,21 @@
 
 const size_t rxm_pkt_size = sizeof(struct rxm_pkt);
 
+
+static void rxm_fastlock_empty(fastlock_t *lock)
+{
+}
+
+static void rxm_fastlock_acquire(fastlock_t *lock)
+{
+	fastlock_acquire(lock);
+}
+
+static void rxm_fastlock_release(fastlock_t *lock)
+{
+	fastlock_release(lock);
+}
+
 static int rxm_match_recv_entry(struct dlist_entry *item, const void *arg)
 {
 	struct rxm_recv_match_attr *attr = (struct rxm_recv_match_attr *) arg;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -135,7 +135,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 	struct rxm_rx_buf *rx_buf;
 	void *mr_desc;
 
-	ret = rxm_mr_buf_reg(pool->ep, addr, len, context);
+	ret = rxm_mr_buf_reg(pool->rxm_ep, addr, len, context);
 	if (ret)
 		return ret;
 
@@ -144,16 +144,16 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 	for (i = 0; i < pool->pool->chunk_cnt; i++) {
 		if (pool->type == RXM_BUF_POOL_RX) {
 			rx_buf = (struct rxm_rx_buf *)((char *)addr + i * entry_sz);
-			rx_buf->ep = pool->ep;
+			rx_buf->ep = pool->rxm_ep;
 			rx_buf->hdr.desc = mr_desc;
 		} else {
 			tx_buf = (struct rxm_tx_buf *)((char *)addr + i * entry_sz);
 			tx_buf->type = pool->type;
 			tx_buf->pkt.ctrl_hdr.version = OFI_CTRL_VERSION;
 			tx_buf->pkt.hdr.version = OFI_OP_VERSION;
-			if (rxm_ep_tx_flags(pool->ep) & FI_TRANSMIT_COMPLETE)
+			if (rxm_ep_tx_flags(pool->rxm_ep) & FI_TRANSMIT_COMPLETE)
 				tx_buf->pkt.hdr.flags |= OFI_TRANSMIT_COMPLETE;
-			if (rxm_ep_tx_flags(pool->ep) & FI_DELIVERY_COMPLETE)
+			if (rxm_ep_tx_flags(pool->rxm_ep) & FI_DELIVERY_COMPLETE)
 				tx_buf->pkt.hdr.flags |= OFI_DELIVERY_COMPLETE;
 			tx_buf->hdr.desc = mr_desc;
 
@@ -187,7 +187,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 static inline void rxm_buf_close(void *pool_ctx, void *context)
 {
 	struct rxm_ep *rxm_ep =
-		(struct rxm_ep *)((struct rxm_buf_pool *)pool_ctx)->ep;
+		(struct rxm_ep *)((struct rxm_buf_pool *)pool_ctx)->rxm_ep;
 
 	if (rxm_ep->msg_mr_local) {
 		/* We would get a (fid_mr *) in context but
@@ -219,7 +219,7 @@ static int rxm_buf_pool_create(struct rxm_ep *rxm_ep,
 {
 	int ret;
 
-	pool->ep = rxm_ep;
+	pool->rxm_ep = rxm_ep;
 	pool->type = type;
 	ret = util_buf_pool_create_ex(&pool->pool, size, 16, 0, chunk_count,
 				      rxm_buf_reg, rxm_buf_close, pool);
@@ -236,6 +236,7 @@ static int rxm_send_queue_init(struct rxm_ep *rxm_ep, struct rxm_send_queue *sen
 {
 	ssize_t i;
 
+	send_queue->rxm_ep = rxm_ep;
 	send_queue->fs = rxm_txe_fs_create(size);
 	if (!send_queue->fs)
 		return -FI_ENOMEM;
@@ -247,11 +248,12 @@ static int rxm_send_queue_init(struct rxm_ep *rxm_ep, struct rxm_send_queue *sen
 	return 0;
 }
 
-static int rxm_recv_queue_init(struct rxm_recv_queue *recv_queue, size_t size,
-			       enum rxm_recv_queue_type type)
+static int rxm_recv_queue_init(struct rxm_ep *rxm_ep,  struct rxm_recv_queue *recv_queue,
+			       size_t size, enum rxm_recv_queue_type type)
 {
 	ssize_t i;
 
+	recv_queue->rxm_ep = rxm_ep;
 	recv_queue->type = type;
 	recv_queue->fs = rxm_recv_fs_create(size);
 	if (!recv_queue->fs)
@@ -361,13 +363,13 @@ static int rxm_ep_txrx_queue_init(struct rxm_ep *rxm_ep)
 	if (ret)
 		return ret;
 
-	ret = rxm_recv_queue_init(&rxm_ep->recv_queue,
+	ret = rxm_recv_queue_init(rxm_ep, &rxm_ep->recv_queue,
 				  rxm_ep->rxm_info->rx_attr->size,
 				  RXM_RECV_QUEUE_MSG);
 	if (ret)
 		goto err_recv_msg;
 
-	ret = rxm_recv_queue_init(&rxm_ep->trecv_queue,
+	ret = rxm_recv_queue_init(rxm_ep, &rxm_ep->trecv_queue,
 				  rxm_ep->rxm_info->rx_attr->size,
 				  RXM_RECV_QUEUE_TAGGED);
 	if (ret)
@@ -388,13 +390,22 @@ static void rxm_ep_txrx_queue_close(struct rxm_ep *rxm_ep)
 	rxm_send_queue_close(&rxm_ep->send_queue);
 }
 
-static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep)
+static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep,
+				struct util_domain *domain)
 {
 	int ret;
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL,
 	       "MSG provider mr_mode & FI_MR_LOCAL: %d\n",
 	       rxm_ep->msg_mr_local);
+
+	if (domain->threading != FI_THREAD_SAFE) {
+		rxm_ep->res_fastlock_acquire = rxm_fastlock_empty;
+		rxm_ep->res_fastlock_release = rxm_fastlock_empty;
+	} else {
+		rxm_ep->res_fastlock_acquire = rxm_fastlock_acquire;
+		rxm_ep->res_fastlock_release = rxm_fastlock_release;
+	}
 
 	ret = rxm_ep_txrx_pool_create(rxm_ep);
 	if (ret)
@@ -454,11 +465,11 @@ static int rxm_ep_cancel_recv(struct rxm_ep *rxm_ep,
 	struct rxm_recv_entry *recv_entry;
 	struct dlist_entry *entry;
 
-	fastlock_acquire(&recv_queue->lock);
+	rxm_ep->res_fastlock_acquire(&recv_queue->lock);
 	entry = dlist_remove_first_match(&recv_queue->recv_list,
 					 rxm_match_recv_entry_context,
 					 context);
-	fastlock_release(&recv_queue->lock);
+	rxm_ep->res_fastlock_release(&recv_queue->lock);
 	if (entry) {
 		recv_entry = container_of(entry, struct rxm_recv_entry, entry);
 		memset(&err_entry, 0, sizeof(err_entry));
@@ -551,11 +562,11 @@ static int rxm_ep_peek_recv(struct rxm_ep *rxm_ep, fi_addr_t addr, uint64_t tag,
 
 	rxm_ep_progress_multi(&rxm_ep->util_ep);
 
-	fastlock_acquire(&recv_queue->lock);
+	rxm_ep->res_fastlock_acquire(&recv_queue->lock);
 
 	rx_buf = rxm_check_unexp_msg_list(recv_queue, addr, tag, ignore);
 	if (!rx_buf) {
-		fastlock_release(&recv_queue->lock);
+		rxm_ep->res_fastlock_release(&recv_queue->lock);
 		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Message not found\n");
 		return ofi_cq_write_error_peek(rxm_ep->util_ep.rx_cq, tag,
 					       context);
@@ -565,7 +576,7 @@ static int rxm_ep_peek_recv(struct rxm_ep *rxm_ep, fi_addr_t addr, uint64_t tag,
 
 	if (flags & FI_DISCARD) {
 		dlist_remove(&rx_buf->unexp_msg.entry);
-		fastlock_release(&recv_queue->lock);
+		rxm_ep->res_fastlock_release(&recv_queue->lock);
 		return rxm_ep_discard_recv(rxm_ep, rx_buf, context);
 	}
 
@@ -574,7 +585,7 @@ static int rxm_ep_peek_recv(struct rxm_ep *rxm_ep, fi_addr_t addr, uint64_t tag,
 		((struct fi_context *)context)->internal[0] = rx_buf;
 		dlist_remove(&rx_buf->unexp_msg.entry);
 	}
-	fastlock_release(&recv_queue->lock);
+	rxm_ep->res_fastlock_release(&recv_queue->lock);
 
 	return ofi_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
 			    rx_buf->pkt.hdr.size, NULL,
@@ -1826,7 +1837,7 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	rxm_ep->min_multi_recv_size = rxm_ep->rxm_info->tx_attr->inject_size;
 
-	ret = rxm_ep_txrx_res_open(rxm_ep);
+	ret = rxm_ep_txrx_res_open(rxm_ep, util_domain);
 	if (ret)
 		goto err3;
 

--- a/prov/util/src/util_domain.c
+++ b/prov/util/src/util_domain.c
@@ -86,6 +86,7 @@ static int util_domain_init(struct util_domain *domain,
 	domain->addr_format = info->addr_format;
 	domain->av_type = info->domain_attr->av_type;
 	domain->name = strdup(info->domain_attr->name);
+	domain->threading = info->domain_attr->threading;
 	return domain->name ? 0 : -FI_ENOMEM;
 }
 


### PR DESCRIPTION
This PR improves latency for RxM provider by removing locks for Send/Recv queue and Tx/Rx resources from critical send and receive paths

MPICH/CH4/OFI/RxM/verbs results:

bytes | master | #3989
-- | -- | --
0 | 1.19 | 1.17
1 | 1.19 | 1.17
2 | 1.18 | 1.17
4 | 1.18 | 1.17
8 | 1.19 | 1.17
16 | 1.19 | 1.17
32 | 1.19 | 1.17
64 | 1.22 | 1.21



Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>