### PR TITLE
prov/verbs: Make fi_ibv_poll_cq static inline

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -592,7 +592,6 @@ int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
 			 const struct fi_info *hints,
 			 const struct fi_info *info);
 
-ssize_t fi_ibv_poll_cq(struct fi_ibv_cq *cq, struct ibv_wc *wc);
 int fi_ibv_cq_signal(struct fid_cq *cq);
 
 ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -340,6 +340,7 @@ void fi_ibv_cleanup_cq(struct fi_ibv_msg_ep *ep)
 }
 
 /* Must call with cq->lock held */
+static inline
 ssize_t fi_ibv_poll_cq(struct fi_ibv_cq *cq, struct ibv_wc *wc)
 {
 	ssize_t ret;


### PR DESCRIPTION
The `fi_ibv_poll_cq` can easily be `static inline`

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>