### PR TITLE
util/cq, prov/verbs: Use locks only if needed threading level set

### DIFF
--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -132,7 +132,23 @@ static inline void fastlock_release(fastlock_t *lock)
 
 #endif
 
+typedef void(*ofi_fastlock_acquire_t)(fastlock_t *lock);
+typedef void(*ofi_fastlock_release_t)(fastlock_t *lock);
 
+static inline void ofi_fastlock_acquire(fastlock_t *lock)
+{
+	fastlock_acquire(lock);
+}
+static inline void ofi_fastlock_release(fastlock_t *lock)
+{
+	fastlock_release(lock);
+}
+static inline void ofi_fastlock_acquire_noop(fastlock_t *lock)
+{
+}
+static inline void ofi_fastlock_release_noop(fastlock_t *lock)
+{
+}
 
 #ifdef __cplusplus
 }

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -295,6 +295,8 @@ struct util_cq {
 	struct dlist_entry	ep_list;
 	fastlock_t		ep_list_lock;
 	fastlock_t		cq_lock;
+	ofi_fastlock_acquire_t	cq_fastlock_acquire;
+	ofi_fastlock_release_t	cq_fastlock_release;
 
 	struct util_comp_cirq	*cirq;
 	fi_addr_t		*src;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -334,9 +334,6 @@ struct rxm_buf_pool {
 	fastlock_t lock;
 };
 
-typedef void (*rxm_ep_res_fastlock_acquire_t)(fastlock_t *lock);
-typedef void (*rxm_ep_res_fastlock_release_t)(fastlock_t *lock);
-
 struct rxm_ep {
 	struct util_ep 		util_ep;
 	struct fi_info 		*rxm_info;
@@ -361,8 +358,8 @@ struct rxm_ep {
 	struct rxm_recv_queue	recv_queue;
 	struct rxm_recv_queue	trecv_queue;
 
-	rxm_ep_res_fastlock_acquire_t	res_fastlock_acquire;
-	rxm_ep_res_fastlock_release_t	res_fastlock_release;
+	ofi_fastlock_acquire_t	res_fastlock_acquire;
+	ofi_fastlock_release_t	res_fastlock_release;
 };
 
 struct rxm_ep_wait_ref {

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -43,21 +43,6 @@
 
 const size_t rxm_pkt_size = sizeof(struct rxm_pkt);
 
-
-static void rxm_fastlock_empty(fastlock_t *lock)
-{
-}
-
-static void rxm_fastlock_acquire(fastlock_t *lock)
-{
-	fastlock_acquire(lock);
-}
-
-static void rxm_fastlock_release(fastlock_t *lock)
-{
-	fastlock_release(lock);
-}
-
 static int rxm_match_recv_entry(struct dlist_entry *item, const void *arg)
 {
 	struct rxm_recv_match_attr *attr = (struct rxm_recv_match_attr *) arg;
@@ -400,11 +385,11 @@ static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep,
 	       rxm_ep->msg_mr_local);
 
 	if (domain->threading != FI_THREAD_SAFE) {
-		rxm_ep->res_fastlock_acquire = rxm_fastlock_empty;
-		rxm_ep->res_fastlock_release = rxm_fastlock_empty;
+		rxm_ep->res_fastlock_acquire = ofi_fastlock_acquire_noop;
+		rxm_ep->res_fastlock_release = ofi_fastlock_release_noop;
 	} else {
-		rxm_ep->res_fastlock_acquire = rxm_fastlock_acquire;
-		rxm_ep->res_fastlock_release = rxm_fastlock_release;
+		rxm_ep->res_fastlock_acquire = ofi_fastlock_acquire;
+		rxm_ep->res_fastlock_release = ofi_fastlock_release;
 	}
 
 	ret = rxm_ep_txrx_pool_create(rxm_ep);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -390,6 +390,8 @@ struct fi_ibv_wre_pool {
 	fastlock_t		lock;
 	struct util_buf_pool	*pool;
 	struct dlist_entry	wre_list;
+	ofi_fastlock_acquire_t	pool_fastlock_acquire;
+	ofi_fastlock_release_t	pool_fastlock_release;
 };
 
 struct fi_ibv_wre {
@@ -612,12 +614,12 @@ int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
 static inline void fi_ibv_release_wre(struct fi_ibv_wre_pool *wre_pool,
 				      struct fi_ibv_wre *wre)
 {
-	fastlock_acquire(&wre_pool->lock);
+	wre_pool->pool_fastlock_acquire(&wre_pool->lock);
 	dlist_remove(&wre->entry);
 	wre->srq = NULL;
 	wre->ep = NULL;
 	util_buf_release(wre_pool->pool, wre);
-	fastlock_release(&wre_pool->lock);
+	wre_pool->pool_fastlock_release(&wre_pool->lock);
 }
 
 static inline int

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -416,6 +416,8 @@ struct fi_ibv_cq {
 	fi_ibv_trywait_func	trywait;
 	ofi_atomic32_t		nevents;
 	struct util_buf_pool	*wce_pool;
+	ofi_fastlock_acquire_t	cq_fastlock_acquire;
+	ofi_fastlock_release_t	cq_fastlock_release;
 };
 
 struct fi_ibv_rdm_request;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -315,9 +315,9 @@ void fi_ibv_cleanup_cq(struct fi_ibv_msg_ep *ep)
 	} while (ret > 0);
 
 	/* Handle WRs for which there were no appropriate WCs */
-	fastlock_acquire(&ep->wre_pool.lock);
+	ep->wre_pool.pool_fastlock_acquire(&ep->wre_pool.lock);
 	fi_ibv_empty_wre_list(&ep->wre_pool, IBV_RECV_WR);
-	fastlock_release(&ep->wre_pool.lock);
+	ep->wre_pool.pool_fastlock_release(&ep->wre_pool.lock);
 	ep->rcq->cq_fastlock_release(&ep->rcq->lock);
 
 	ep->scq->cq_fastlock_acquire(&ep->scq->lock);
@@ -325,9 +325,9 @@ void fi_ibv_cleanup_cq(struct fi_ibv_msg_ep *ep)
 		ret = fi_ibv_poll_outstanding_cq(ep, ep->scq);
 	} while (ret > 0);
 	/* Handle WRs for which there were no appropriate WCs */
-	fastlock_acquire(&ep->wre_pool.lock);
+	ep->wre_pool.pool_fastlock_acquire(&ep->wre_pool.lock);
 	fi_ibv_empty_wre_list(&ep->wre_pool, IBV_SEND_WR);
-	fastlock_release(&ep->wre_pool.lock);
+	ep->wre_pool.pool_fastlock_release(&ep->wre_pool.lock);
 	ep->scq->cq_fastlock_release(&ep->scq->lock);
 
 	fastlock_destroy(&ep->wre_pool.lock);

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -89,7 +89,7 @@ fi_ibv_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 
 	cq = container_of(cq_fid, struct fi_ibv_cq, cq_fid);
 
-	fastlock_acquire(&cq->lock);
+	cq->cq_fastlock_acquire(&cq->lock);
 	if (slist_empty(&cq->wcq))
 		goto err;
 
@@ -100,7 +100,7 @@ fi_ibv_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 	api_version = cq->domain->util_domain.fabric->fabric_fid.api_version;
 
 	slist_entry = slist_remove_head(&cq->wcq);
-	fastlock_release(&cq->lock);
+	cq->cq_fastlock_release(&cq->lock);
 
 	wce = container_of(slist_entry, struct fi_ibv_wce, entry);
 
@@ -122,7 +122,7 @@ fi_ibv_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 	util_buf_release(cq->wce_pool, wce);
 	return sizeof(*entry);
 err:
-	fastlock_release(&cq->lock);
+	cq->cq_fastlock_release(&cq->lock);
 	return -FI_EAGAIN;
 }
 
@@ -309,7 +309,7 @@ void fi_ibv_cleanup_cq(struct fi_ibv_msg_ep *ep)
 {
 	int ret;
 
-	fastlock_acquire(&ep->rcq->lock);
+	ep->rcq->cq_fastlock_acquire(&ep->rcq->lock);
 	do {
 		ret = fi_ibv_poll_outstanding_cq(ep, ep->rcq);
 	} while (ret > 0);
@@ -318,9 +318,9 @@ void fi_ibv_cleanup_cq(struct fi_ibv_msg_ep *ep)
 	fastlock_acquire(&ep->wre_pool.lock);
 	fi_ibv_empty_wre_list(&ep->wre_pool, IBV_RECV_WR);
 	fastlock_release(&ep->wre_pool.lock);
-	fastlock_release(&ep->rcq->lock);
+	ep->rcq->cq_fastlock_release(&ep->rcq->lock);
 
-	fastlock_acquire(&ep->scq->lock);
+	ep->scq->cq_fastlock_acquire(&ep->scq->lock);
 	do {
 		ret = fi_ibv_poll_outstanding_cq(ep, ep->scq);
 	} while (ret > 0);
@@ -328,7 +328,7 @@ void fi_ibv_cleanup_cq(struct fi_ibv_msg_ep *ep)
 	fastlock_acquire(&ep->wre_pool.lock);
 	fi_ibv_empty_wre_list(&ep->wre_pool, IBV_SEND_WR);
 	fastlock_release(&ep->wre_pool.lock);
-	fastlock_release(&ep->scq->lock);
+	ep->scq->cq_fastlock_release(&ep->scq->lock);
 
 	fastlock_destroy(&ep->wre_pool.lock);
 	util_buf_pool_destroy(ep->wre_pool.pool);
@@ -357,7 +357,7 @@ static ssize_t fi_ibv_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 
 	cq = container_of(cq_fid, struct fi_ibv_cq, cq_fid);
 
-	fastlock_acquire(&cq->lock);
+	cq->cq_fastlock_acquire(&cq->lock);
 
 	for (i = 0; i < count; i++) {
 		if (!slist_empty(&cq->wcq)) {
@@ -381,7 +381,7 @@ static ssize_t fi_ibv_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 		if (wc.status) {
 			wce = util_buf_alloc(cq->wce_pool);
 			if (!wce) {
-				fastlock_release(&cq->lock);
+				cq->cq_fastlock_release(&cq->lock);
 				return -FI_ENOMEM;
 			}
 			memset(wce, 0, sizeof(*wce));
@@ -394,7 +394,7 @@ static ssize_t fi_ibv_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 		cq->read_entry(&wc, i, buf);
 	}
 
-	fastlock_release(&cq->lock);
+	cq->cq_fastlock_release(&cq->lock);
 	return i ? i : (ret ? ret : -FI_EAGAIN);
 }
 
@@ -436,7 +436,7 @@ static int fi_ibv_cq_trywait(struct fid *fid)
 		return -FI_EINVAL;
 	}
 
-	fastlock_acquire(&cq->lock);
+	cq->cq_fastlock_acquire(&cq->lock);
 	if (!slist_empty(&cq->wcq))
 		goto out;
 
@@ -479,7 +479,7 @@ static int fi_ibv_cq_trywait(struct fid *fid)
 err:
 	util_buf_release(cq->wce_pool, wce);
 out:
-	fastlock_release(&cq->lock);
+	cq->cq_fastlock_release(&cq->lock);
 	return ret;
 }
 
@@ -528,14 +528,14 @@ static int fi_ibv_cq_close(fid_t fid)
 	if (ofi_atomic_get32(&cq->nevents))
 		ibv_ack_cq_events(cq->cq, ofi_atomic_get32(&cq->nevents));
 
-	fastlock_acquire(&cq->lock);
+	cq->cq_fastlock_acquire(&cq->lock);
 	while (!slist_empty(&cq->wcq)) {
 		entry = slist_remove_head(&cq->wcq);
 		wce = container_of(entry, struct fi_ibv_wce, entry);
 		util_buf_release(cq->wce_pool, wce);
 	}
 
-	fastlock_release(&cq->lock);
+	cq->cq_fastlock_release(&cq->lock);
 
 	util_buf_pool_destroy(cq->wce_pool);
 
@@ -582,6 +582,14 @@ int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 
 	_cq->domain = container_of(domain, struct fi_ibv_domain,
 				   util_domain.domain_fid);
+	if ((_cq->domain->info->domain_attr->threading == FI_THREAD_DOMAIN) ||
+	    (_cq->domain->info->domain_attr->threading == FI_THREAD_COMPLETION)) {
+		_cq->cq_fastlock_acquire = ofi_fastlock_acquire_noop;
+		_cq->cq_fastlock_release = ofi_fastlock_release_noop;
+	} else {
+		_cq->cq_fastlock_acquire = ofi_fastlock_acquire;
+		_cq->cq_fastlock_release = ofi_fastlock_release;
+	}
 	/*
 	 * RDM and DGRAM CQ functionalities are moved to correspond
 	 * separated functions

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -224,7 +224,7 @@ err:
 }
 
 ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
-		const void *buf, size_t len)
+			      const void *buf, size_t len)
 {
 	struct fi_ibv_eq_entry *entry;
 

--- a/prov/verbs/src/verbs_msg_ep.c
+++ b/prov/verbs/src/verbs_msg_ep.c
@@ -538,13 +538,13 @@ static inline int fi_ibv_poll_reap_unsig_cq(struct fi_ibv_msg_ep *ep)
 	struct ibv_wc wc[10];
 	int ret, i;
 
-	fastlock_acquire(&ep->scq->lock);
+	ep->scq->cq_fastlock_acquire(&ep->scq->lock);
 	/* TODO: retrieve WCs as much as possbile in a single
 	 * ibv_poll_cq call */
 	while (1) {
 		ret = ibv_poll_cq(ep->scq->cq, 10, wc);
 		if (ret <= 0) {
-			fastlock_release(&ep->scq->lock);
+			ep->scq->cq_fastlock_release(&ep->scq->lock);
 			return ret;
 		}
 
@@ -556,7 +556,7 @@ static inline int fi_ibv_poll_reap_unsig_cq(struct fi_ibv_msg_ep *ep)
 		}
 	}
 
-	fastlock_release(&ep->scq->lock);
+	ep->scq->cq_fastlock_release(&ep->scq->lock);
 	return FI_SUCCESS;
 }
 


### PR DESCRIPTION
This patch applies optimizations for verbs provider (only CQ and WRE handling) and util/cq like #3992 for rxm provider.