### PR TITLE
  util/cq, prov/rxm: Reduce instruction counts

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -409,24 +409,23 @@ ssize_t rxm_cq_handle_data(struct rxm_rx_buf *rx_buf)
 
 static ssize_t rxm_handle_recv_comp(struct rxm_rx_buf *rx_buf)
 {
-	struct rxm_recv_match_attr match_attr;
+	struct rxm_recv_match_attr match_attr = {
+		.addr = FI_ADDR_UNSPEC,
+	};
 	struct dlist_entry *entry;
-	struct util_cq *util_cq;
 
-	util_cq = rx_buf->ep->util_ep.rx_cq;
-
-	if ((rx_buf->ep->rxm_info->caps & (FI_SOURCE | FI_DIRECTED_RECV)) &&
-	    !rx_buf->conn) {
-		rx_buf->conn = rxm_key2conn(rx_buf->ep, rx_buf->pkt.ctrl_hdr.conn_id);
+	if (rx_buf->ep->rxm_info->caps & (FI_SOURCE | FI_DIRECTED_RECV)) {
+		rx_buf->conn =
+			rxm_key2conn(rx_buf->ep, rx_buf->pkt.ctrl_hdr.conn_id);
 		if (OFI_UNLIKELY(!rx_buf->conn))
 			return -FI_EOTHER;
 		match_attr.addr = rx_buf->conn->handle.fi_addr;
-	} else {
-		match_attr.addr = FI_ADDR_UNSPEC;
-	}
 
-	if (rx_buf->ep->rxm_info->caps & FI_SOURCE)
-		util_cq->src[ofi_cirque_windex(util_cq->cirq)] = rx_buf->conn->handle.fi_addr;
+		if (rx_buf->ep->rxm_info->caps & FI_SOURCE)
+			rx_buf->ep->util_ep.rx_cq->src[
+				ofi_cirque_windex(rx_buf->ep->util_ep.rx_cq->cirq)] =
+					rx_buf->conn->handle.fi_addr;
+	}
 
 	switch(rx_buf->pkt.hdr.op) {
 	case ofi_op_msg:

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -89,32 +89,6 @@ int ofi_cq_write_error_trunc(struct util_cq *cq, void *context, uint64_t flags,
 	return ofi_cq_write_error(cq, &err_entry);
 }
 
-int ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
-		 void *buf, uint64_t data, uint64_t tag)
-{
-	struct fi_cq_tagged_entry *comp;
-	int ret = 0;
-
-	cq->cq_fastlock_acquire(&cq->cq_lock);
-	if (OFI_UNLIKELY(ofi_cirque_isfull(cq->cirq))) {
-		FI_DBG(cq->domain->prov, FI_LOG_CQ, "util_cq cirq is full!\n");
-		ret = -FI_EAGAIN;
-		goto out;
-	}
-
-	comp = ofi_cirque_tail(cq->cirq);
-	comp->op_context = context;
-	comp->flags = flags;
-	comp->len = len;
-	comp->buf = buf;
-	comp->data = data;
-	comp->tag = tag;
-	ofi_cirque_commit(cq->cirq);
-out:
-	cq->cq_fastlock_release(&cq->cq_lock);
-	return ret;
-}
-
 int ofi_check_cq_attr(const struct fi_provider *prov,
 		      const struct fi_cq_attr *attr)
 {


### PR DESCRIPTION
This PR prepares small optimizations and reduces ~10 instructions in the code that is responsible to handle CQ entries