### PR TITLE
prov/verbs: Remove fi_ibv_invoke_post macro

### DIFF
--- a/prov/verbs/src/ep_dgram/verbs_dgram.h
+++ b/prov/verbs/src/ep_dgram/verbs_dgram.h
@@ -229,6 +229,19 @@ struct fi_ibv_dgram_ep {
 
 extern struct fi_ops_msg fi_ibv_dgram_msg_ops;
 
+static inline ssize_t
+fi_ibv_dgram_handle_post(ssize_t ret, struct fi_ibv_dgram_wr_entry *wr_entry,
+			 struct fi_ibv_dgram_buf_pool *grh_pool)
+{
+	if (OFI_UNLIKELY(ret)) {
+		ret = fi_ibv_handle_post(ret);
+		if (wr_entry)
+			fi_ibv_dgram_wr_entry_release(
+				grh_pool, (struct fi_ibv_dgram_wr_entry_hdr *)wr_entry);
+	}
+	return ret;
+}
+
 static inline struct fi_ibv_dgram_av_entry*
 fi_ibv_dgram_av_lookup_av_entry(struct fi_ibv_dgram_av *av, int index)
 {

--- a/prov/verbs/src/verbs_srq.c
+++ b/prov/verbs/src/verbs_srq.c
@@ -100,6 +100,7 @@ fi_ibv_srq_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t 
 		.next = NULL,
 	};
 	size_t i;
+	struct ibv_recv_wr *bad_wr;
 
 	assert(ep->srq);
 
@@ -126,8 +127,8 @@ fi_ibv_srq_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t 
 	}
 	wr.sg_list = sge;
 
-	return FI_IBV_INVOKE_POST(srq_recv, recv, ep->srq, &wr,
-				  FI_IBV_RELEASE_WRE(ep, wre));
+	return fi_ibv_msg_handle_post(ibv_post_srq_recv(ep->srq, &wr, &bad_wr),
+				      wre, &ep->wre_pool);
 }
 
 static ssize_t


### PR DESCRIPTION
This patch removes `FI_IBV_INVOKE_POST` macro for MSG and DGRAM code that was requested in some previous PR for verbs

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>