### PR TITLE
prov/psm2: Fix potential duplication of iov send completion

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -442,6 +442,7 @@ struct psmx2_iov_info {
 struct psmx2_sendv_request {
 	struct fi_context fi_context;
 	struct fi_context fi_context_iov;
+	PSMX2_STATUS_TYPE *status;
 	void *user_context;
 	int iov_protocol;
 	int no_completion;

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -800,9 +800,10 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 
 			case PSMX2_SENDV_CONTEXT:
 				sendv_req = PSMX2_CTXT_USER(fi_context);
+				sendv_req->iov_done++;
 				if (sendv_req->iov_protocol == PSMX2_IOV_PROTO_MULTI &&
-				    sendv_req->iov_done < sendv_req->iov_info.count) {
-					PSMX2_FREE_COMPLETION(trx_ctxt, status);
+				    sendv_req->iov_done < sendv_req->iov_info.count + 1) {
+					sendv_req->status = status;
 					continue;
 				}
 				if (ep->send_cq && !sendv_req->no_completion) {
@@ -830,10 +831,10 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 			case PSMX2_IOV_SEND_CONTEXT:
 				sendv_req = PSMX2_CTXT_USER(fi_context);
 				sendv_req->iov_done++;
-				if (sendv_req->iov_done < sendv_req->iov_info.count) {
-					PSMX2_FREE_COMPLETION(trx_ctxt, status);
+				PSMX2_FREE_COMPLETION(trx_ctxt, status);
+				if (sendv_req->iov_done < sendv_req->iov_info.count + 1)
 					continue;
-				}
+				status = sendv_req->status;
 				if (ep->send_cq && !sendv_req->no_completion) {
 					op_context = sendv_req->user_context;
 					buf = NULL;


### PR DESCRIPTION
Under rare condition, it was possible that completions were generated
by both the iov message header and the message body. Fix by counting
the header together with the body before generating completion.

Also make sure iov send completions have tag set in a way consistent
with non-iov sends, even though it is not required by the API.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>