### PR TITLE
prov/rxm: Fix matching for RMA I/O vectors

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -151,10 +151,11 @@ static int rxm_match_rma_iov(struct rxm_recv_entry *recv_entry,
 			return ret;
 
 		count = match_iov[i].count;
-		offset = match_iov[i].iov[count - 1].iov_len;
 
-		i++;
 		j += count - 1;
+		offset = (((count - 1) == 0) ? offset : 0) +
+			match_iov[i].iov[count - 1].iov_len;
+		i++;
 
 		if (j >= recv_entry->rxm_iov.count)
 			break;


### PR DESCRIPTION
This fixes matching of the I/O vectors for RMA

The error occurs if a posted (receive) I/O vector is large enough to contain I/O vector(s) that will be gathered from remote side.
We should adjust `offset` by adding `iov_len` while we can fill the same posted I/O vector.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>