### PR TITLE
prov/rxm: Fix matching for RMA I/O vectors (for v1.6)

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -151,10 +151,11 @@ static int rxm_match_rma_iov(struct rxm_recv_entry *recv_entry,
 			return ret;
 
 		count = match_iov[i].count;
-		offset = match_iov[i].iov[count - 1].iov_len;
 
-		i++;
 		j += count - 1;
+		offset = (((count - 1) == 0) ? offset : 0) +
+			match_iov[i].iov[count - 1].iov_len;
+		i++;
 
 		if (j >= recv_entry->rxm_iov.count)
 			break;


### PR DESCRIPTION
This is a back-port of #4009 for v1.6.x stable branch

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>