### PR TITLE
 util/cmap. prov/rxm: Implement support for static connection mechanism 

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -498,6 +498,7 @@ typedef int (*ofi_cmap_signal_func)(struct util_ep *ep, void *context,
 
 struct util_cmap_attr {
 	void 				*name;
+	int				lazy_conn;
 	ofi_cmap_alloc_handle_func 	alloc;
 	ofi_cmap_handle_func 		close;
 	ofi_cmap_handle_func 		free;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -390,7 +390,7 @@ struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep)
 	struct util_cmap *cmap = NULL;
 	void *name;
 	size_t len;
-	int ret;
+	int ret, lazy_conn = 1;
 
 	len = rxm_ep->msg_info->src_addrlen;
 	name = calloc(1, len);
@@ -408,9 +408,12 @@ struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep)
 			"Unable to fi_getname on msg_ep\n");
 		goto fn;
 	}
+
 	ofi_straddr_dbg(&rxm_prov, FI_LOG_EP_CTRL, "local_name", name);
+	fi_param_get_bool(&rxm_prov, "lazy_conn", &lazy_conn);
 
 	attr.name		= name;
+	attr.lazy_conn		= lazy_conn;
 	attr.alloc 		= rxm_conn_alloc;
 	attr.close 		= rxm_conn_close;
 	attr.free 		= rxm_conn_free;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1007,7 +1007,7 @@ rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 		};
 		ret = ofi_cmap_handle_connect(rxm_ep->util_ep.cmap,
 					      dest_addr, handle);
-		if (OFI_UNLIKELY(ret != -FI_EAGAIN))
+		if (OFI_UNLIKELY(ret && (ret != -FI_EAGAIN)))
 			goto cmap_err;
 		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_send(rxm_ep, rxm_conn, NULL, 1,
@@ -1077,7 +1077,7 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 		}
 		ret = ofi_cmap_handle_connect(rxm_ep->util_ep.cmap,
 					      dest_addr, handle);
-		if (OFI_UNLIKELY(ret != -FI_EAGAIN))
+		if (OFI_UNLIKELY(ret && (ret != -FI_EAGAIN)))
 			goto cmap_err;
 		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_send(

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -292,6 +292,9 @@ RXM_INI
 			"(default: 1) that would be read per progress "
 			"(RxM CQ read).");
 
+	fi_param_define(&rxm_prov, "lazy_conn", FI_PARAM_BOOL,
+			"Defines whether to use lazy connection or not (default: yes).");
+
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");
 		return NULL;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -330,7 +330,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 		}
 		ret = ofi_cmap_handle_connect(rxm_ep->util_ep.cmap,
 					      msg->addr, handle);
-		if (OFI_UNLIKELY(ret != -FI_EAGAIN))
+		if (OFI_UNLIKELY(ret && (ret != -FI_EAGAIN)))
 			goto cmap_err;
 		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_rma(rxm_ep, rxm_conn,
@@ -458,7 +458,7 @@ rxm_ep_rma_inject(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 		}
 		ret = ofi_cmap_handle_connect(rxm_ep->util_ep.cmap,
 					      msg->addr, handle);
-		if (OFI_UNLIKELY(ret != -FI_EAGAIN))
+		if (OFI_UNLIKELY(ret && (ret != -FI_EAGAIN)))
 			goto cmap_err;
 		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_rma(rxm_ep, rxm_conn, total_size,


### PR DESCRIPTION
This PR implements support for static connections mechanism (the opposite side for lazy connections that are already implemented) on util/cmap level and usage of this mechanism in RXM by setting `FI_OFI_RXM_LAZY_CONN=0` environment variable.
The static connection means that connection establishment is initiated when an application is inserting an EP name into AV.