### PR TITLE
prov/rxm: Implement direct-copy algorithm

### DIFF
--- a/include/ofi_proto.h
+++ b/include/ofi_proto.h
@@ -55,6 +55,7 @@ enum {
 	ofi_ctrl_start_data,
 	ofi_ctrl_data,
 	ofi_ctrl_large_data,
+	ofi_ctrl_seg_data,
 	ofi_ctrl_ack,
 	ofi_ctrl_nack,
 	ofi_ctrl_discard,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -292,6 +292,19 @@ RXM_INI
 			"(default: 1) that would be read per progress "
 			"(RxM CQ read).");
 
+	fi_param_define(&rxm_prov, "direct_copy_thr", FI_PARAM_SIZE_T,
+			"Set this environment variable to control the RxM direct-copy "
+			"protocol threshold (default: 256 Kb). "
+			"Data transfer algorithms are selected based on the "
+			"following scheme: "
+			"1) Messages shorter than or equal to <nbytes> are sent using "
+			"the eager protocol through the internal pre-registered buffers. "
+			"This approach is faster for short messages. "
+			"2) Messages larger than <nbytes> are sent using the "
+			"direct-copy protocol. It splits message to small ones and "
+			"sends them to the peer (each segment <= BUFFER_SIZE value). "
+			"This approach is faster for large messages.");
+
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");
 		return NULL;


### PR DESCRIPTION
The RxM support two protocols for data transfers:
- Eager - for messages that lower than buffer size (16384 bytes,
or value defined by user)
- Rendezvous - for messages that higher than buffer size

This PR adds the new protocol (direct-copy protocol) and defines new
run-time parameter FI_OFI_RXM_DIRECT_COPY_THR that sets maximum size
of messages for which Rendezvous protocol is used instead of direct-copy
protocol. The lower size of messages for which the direct copy protocol
is used = eager threshold (i.e. buffer size).

The direct-copy protocol operates as follows:
Splits the message into small ones and sends them one by one to the peer.
The size of segmented messages is <= eager threshold (i.e. 16384 bytes).

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>