### PR TITLE
prov/tcp: few fixes/optimizations to the provider

### DIFF
--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -424,7 +424,7 @@ err1:
 static void handle_accept_conn(struct poll_fd_mgr *poll_mgr,
 			       struct poll_fd_info *poll_info)
 {
-	struct fi_eq_cm_entry cm_entry;
+	struct fi_eq_cm_entry cm_entry = {0};
 	struct fi_eq_err_entry err_entry;
 	struct tcpx_ep *ep;
 	int ret;

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -304,13 +304,16 @@ static int proc_conn_resp(struct poll_fd_mgr *poll_mgr,
 	cm_entry->fid = poll_info->fid;
 	memcpy(cm_entry->data, poll_info->cm_data, poll_info->cm_data_sz);
 
+	ret = tcpx_ep_msg_xfer_enable(ep);
+	if (ret)
+		goto err;
+
 	ret = (int) fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED, cm_entry,
 				sizeof(*cm_entry) + poll_info->cm_data_sz, 0);
 	if (ret < 0) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
 		goto err;
 	}
-	ret = tcpx_ep_msg_xfer_enable(ep);
 err:
 	free(cm_entry);
 	return ret;
@@ -438,13 +441,16 @@ static void handle_accept_conn(struct poll_fd_mgr *poll_mgr,
 
 	cm_entry.fid =  poll_info->fid;
 
+	ret = tcpx_ep_msg_xfer_enable(ep);
+	if (ret)
+		goto err;
+
 	ret = (int) fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED,
 				&cm_entry, sizeof(cm_entry), 0);
 	if (ret < 0) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
 	}
 
-	tcpx_ep_msg_xfer_enable(ep);
 	return;
 err:
 	memset(&err_entry, 0, sizeof err_entry);

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -154,7 +154,6 @@ static int handle_poll_list(struct poll_fd_mgr *poll_mgr)
 	int ret = FI_SUCCESS;
 	int id = 0;
 
-	fastlock_acquire(&poll_mgr->lock);
 	while (!dlist_empty(&poll_mgr->list)) {
 		poll_item = container_of(poll_mgr->list.next,
 					 struct poll_fd_info, entry);
@@ -164,8 +163,7 @@ static int handle_poll_list(struct poll_fd_mgr *poll_mgr)
 			id = poll_fds_find_dup(poll_mgr, poll_item);
 			assert(id > 0);
 			if (id <= 0) {
-				ret = -FI_EINVAL;
-				goto err;
+				return -FI_EINVAL;
 			}
 
 			poll_fds_swap_del_last(poll_mgr, id);
@@ -184,8 +182,6 @@ static int handle_poll_list(struct poll_fd_mgr *poll_mgr)
 		else
 			poll_item->flags |= POLL_MGR_ACK;
 	}
-err:
-	fastlock_release(&poll_mgr->lock);
 	return ret;
 }
 
@@ -518,11 +514,13 @@ static void *tcpx_conn_mgr_thread(void *data)
 		}
 
 		if (poll_mgr->poll_fds[0].revents & POLLIN) {
+			fastlock_acquire(&tcpx_fabric->poll_mgr.lock);
 			fd_signal_reset(&poll_mgr->signal);
 			if (handle_poll_list(poll_mgr)) {
 				FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 					"fd list add or remove failed\n");
 			}
+			fastlock_release(&tcpx_fabric->poll_mgr.lock);
 		}
 		handle_fd_events(poll_mgr);
 	}
@@ -534,7 +532,9 @@ void tcpx_conn_mgr_close(struct tcpx_fabric *tcpx_fabric)
 	struct poll_fd_info *poll_info;
 
 	tcpx_fabric->poll_mgr.run = 0;
+	fastlock_acquire(&tcpx_fabric->poll_mgr.lock);
 	fd_signal_set(&tcpx_fabric->poll_mgr.signal);
+	fastlock_release(&tcpx_fabric->poll_mgr.lock);
 
 	if (tcpx_fabric->conn_mgr_thread &&
 	    pthread_join(tcpx_fabric->conn_mgr_thread, NULL)) {

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -95,7 +95,6 @@ void tcpx_pe_entry_release(struct tcpx_pe_entry *pe_entry)
 	tcpx_cq = container_of(cq, struct tcpx_cq, util_cq);
 
 	fastlock_acquire(&cq->cq_lock);
-	dlist_remove(&pe_entry->entry);
 	util_buf_release(tcpx_cq->pe_entry_pool, pe_entry);
 	fastlock_release(&cq->cq_lock);
 }

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -70,8 +70,8 @@ struct tcpx_pe_entry *tcpx_pe_entry_alloc(struct tcpx_cq *tcpx_cq)
 		FI_INFO(&tcpx_prov, FI_LOG_DOMAIN,"failed to get buffer\n");
 		return NULL;
 	}
-	memset(pe_entry, 0, sizeof(*pe_entry));
 	fastlock_release(&tcpx_cq->util_cq.cq_lock);
+	memset(pe_entry, 0, sizeof(*pe_entry));
 	return pe_entry;
 }
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -342,8 +342,8 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 
 	fastlock_acquire(&tcpx_fabric->poll_mgr.lock);
 	dlist_insert_tail(&fd_info->entry, &tcpx_fabric->poll_mgr.list);
-	fastlock_release(&tcpx_fabric->poll_mgr.lock);
 	fd_signal_set(&tcpx_fabric->poll_mgr.signal);
+	fastlock_release(&tcpx_fabric->poll_mgr.lock);
 	return 0;
 }
 
@@ -377,8 +377,8 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 
 	fastlock_acquire(&tcpx_fabric->poll_mgr.lock);
 	dlist_insert_tail(&fd_info->entry, &tcpx_fabric->poll_mgr.list);
-	fastlock_release(&tcpx_fabric->poll_mgr.lock);
 	fd_signal_set(&tcpx_fabric->poll_mgr.signal);
+	fastlock_release(&tcpx_fabric->poll_mgr.lock);
 	return 0;
 }
 
@@ -713,8 +713,8 @@ static int tcpx_pep_fi_close(struct fid *fid)
 		dlist_insert_tail(&pep->poll_info.entry,
 				  &tcpx_fabric->poll_mgr.list);
 	pep->state = TCPX_PEP_CLOSED;
-	fastlock_release(&tcpx_fabric->poll_mgr.lock);
 	fd_signal_set(&tcpx_fabric->poll_mgr.signal);
+	fastlock_release(&tcpx_fabric->poll_mgr.lock);
 
 	while (!(pep->poll_info.flags & POLL_MGR_ACK))
 		sleep(0);
@@ -810,8 +810,8 @@ static int tcpx_pep_listen(struct fid_pep *pep)
 	fastlock_acquire(&tcpx_fabric->poll_mgr.lock);
 	tcpx_pep->state = TCPX_PEP_LISTENING;
 	dlist_insert_tail(&tcpx_pep->poll_info.entry, &tcpx_fabric->poll_mgr.list);
-	fastlock_release(&tcpx_fabric->poll_mgr.lock);
 	fd_signal_set(&tcpx_fabric->poll_mgr.signal);
+	fastlock_release(&tcpx_fabric->poll_mgr.lock);
 
 	return 0;
 }

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -84,6 +84,7 @@ err:
 done:
 	tcpx_cq_report_completion(pe_entry->ep->util_ep.tx_cq,
 				  pe_entry, ret);
+	dlist_remove(&pe_entry->entry);
 	tcpx_pe_entry_release(pe_entry);
 }
 
@@ -112,6 +113,7 @@ err:
 done:
 	tcpx_cq_report_completion(pe_entry->ep->util_ep.rx_cq,
 				  pe_entry, ret);
+	dlist_remove(&pe_entry->entry);
 	tcpx_pe_entry_release(pe_entry);
 }
 


### PR DESCRIPTION
I've been reading code for prov/tcp the last few days and I've found some bugs, which I address in this PR.
@vkrishna, can you please review these patches when you have time? Thank you!

PS: the new code for tcpx is way easier to read than the sockets provider! 

Regards,
Sylvain