### PR TITLE
 prov/rxm: Various optimizations to the provider

### DIFF
--- a/include/ofi_proto.h
+++ b/include/ofi_proto.h
@@ -58,6 +58,7 @@ enum {
 	ofi_ctrl_ack,
 	ofi_ctrl_nack,
 	ofi_ctrl_discard,
+	ofi_ctrl_seg_data,
 };
 
 /*

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -405,7 +405,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			     struct fid_domain **dom, void *context);
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 			 struct fid_cq **cq_fid, void *context);
-ssize_t rxm_cq_handle_data(struct rxm_rx_buf *rx_buf);
+ssize_t rxm_cq_handle_rx_buf(struct rxm_rx_buf *rx_buf);
 
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  struct fid_ep **ep, void *context);
@@ -525,7 +525,7 @@ rxm_process_recv_entry(struct rxm_recv_queue *recv_queue,
 		dlist_remove(&rx_buf->unexp_msg.entry);
 		rx_buf->recv_entry = recv_entry;
 		recv_queue->rxm_ep->res_fastlock_release(&recv_queue->lock);
-		return rxm_cq_handle_data(rx_buf);
+		return rxm_cq_handle_rx_buf(rx_buf);
 	}
 
 	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Enqueuing recv", recv_entry->addr,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -235,7 +235,6 @@ struct rxm_rx_buf {
 	struct rxm_ep *ep;
 	struct dlist_entry repost_entry;
 	struct rxm_conn *conn;
-	struct rxm_recv_queue *recv_queue;
 	struct rxm_recv_entry *recv_entry;
 	struct rxm_unexp_msg unexp_msg;
 	uint64_t comp_flags;
@@ -307,6 +306,7 @@ struct rxm_recv_entry {
 	uint64_t ignore;
 	uint64_t comp_flags;
 	size_t total_len;
+	struct rxm_recv_queue *recv_queue;
 	void *multi_recv_buf;
 };
 DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -249,13 +249,17 @@ static int rxm_recv_queue_init(struct rxm_ep *rxm_ep,  struct rxm_recv_queue *re
 	if (type == RXM_RECV_QUEUE_MSG) {
 		recv_queue->match_recv = rxm_match_recv_entry;
 		recv_queue->match_unexp = rxm_match_unexp_msg;
-		for (i = recv_queue->fs->size - 1; i >= 0; i--)
+		for (i = recv_queue->fs->size - 1; i >= 0; i--) {
 			recv_queue->fs->buf[i].comp_flags = FI_MSG | FI_RECV;
+			recv_queue->fs->buf[i].recv_queue = recv_queue;
+		}
 	} else {
 		recv_queue->match_recv = rxm_match_recv_entry_tagged;
 		recv_queue->match_unexp = rxm_match_unexp_msg_tagged;
-		for (i = recv_queue->fs->size - 1; i >= 0; i--)
+		for (i = recv_queue->fs->size - 1; i >= 0; i--) {
 			recv_queue->fs->buf[i].comp_flags = FI_TAGGED | FI_RECV;
+			recv_queue->fs->buf[i].recv_queue = recv_queue;
+		}
 	}
 	fastlock_init(&recv_queue->lock);
 	return 0;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -667,7 +667,7 @@ static ssize_t rxm_ep_recv_common_flags(struct rxm_ep *rxm_ep, const struct iove
 		if (OFI_UNLIKELY(ret))
 			return ret;
 		rx_buf->recv_entry = recv_entry;
-		return rxm_cq_handle_data(rx_buf);
+		return rxm_cq_handle_rx_buf(rx_buf);
 	} else {
 		return rxm_ep_recv_common(rxm_ep, iov, desc, count, src_addr,
 					  tag, ignore, context, flags | op_flags,


### PR DESCRIPTION
This PR consists of the following patches:
- **common/proto: Add new type of message**
The new message type will be used in SAR (Segmentation And Reassembly)
protocol for message transfers
- **prov/rxm: Move CQ handling functions to common code**
This patch moves rxm_cq_log_comp() and rxm_finish_send_nobuf()
functions to rxm.h header file for further re-use across RxM
source code.
This will be needed for SAR protocol implementation.
- **prov/rxm: Optimize function that handles RX buffers**
The rxm_cq_handle_data() function is getting long. Handling of
message type that is being added makes the function longer.
The function was renamed to rxm_cq_handle_rx_buf() to reflect its
intent better. So, rxm_cq_handle_rx_buf() uses switch-case statement
to call an appropriate function:
- rxm_cq_handle_large_data() to handle rendezvous protocol message
- rxm_cq_handle_data() to handle eager protocol message
- **prov/rxm: Remove pointer to Recv queue from RX buffer**
Remove pointer to Recv queue from RX buffer structure.
This in unnecessary to store the pointer in this structure. The RX entry
can store the pointer to Recv queue to which it belongs at the EP
initialization stage. So, it reduces overhead and it's needed for futher
changes.
The function rxm_handle_recv_comp() was splitted into two stages:
- filling of rxm_match_attr object that is being passed to
rxm_cq_match_rx_buf()
- calling rxm_cq_match_rx_buf() that searching matched recv entry in
an appropriate Recv queue (FI_MSG or FI_TAGGED).