### PR TITLE
prov/rxm: Fix crash with log level = debug

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -480,7 +480,7 @@ static inline void rxm_cq_log_comp(uint64_t flags)
 {
 #if ENABLE_DEBUG
 	FI_DBG(&rxm_prov, FI_LOG_CQ, "Reporting %s completion\n",
-	       fi_tostr((void *)flags, FI_TYPE_CQ_EVENT_FLAGS));
+	       fi_tostr((void *)&flags, FI_TYPE_CQ_EVENT_FLAGS));
 #else
 	/* NOP */
 #endif


### PR DESCRIPTION
The fi_tostr expects pointer to the uint64_t, but rxm passes
the value of uint64_t and casts it to (void *).
The fix is to pass pointer to value of uint64_t instead.

This bug was added in #4031 PR

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>