### PR TITLE
common: allow layering more than one utility provider

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -162,6 +162,8 @@ int ofi_check_rx_mode(const struct fi_info *info, uint64_t flags);
 uint64_t fi_gettime_ms(void);
 uint64_t fi_gettime_us(void);
 
+int ofi_rm_substr(char *str, const char *substr);
+int ofi_rm_substr_delim(char *str, const char *substr, const char delim);
 char **ofi_split_and_alloc(const char *s, const char *delim, size_t *count);
 void ofi_free_string_array(char **s);
 

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -162,7 +162,7 @@ int ofi_check_rx_mode(const struct fi_info *info, uint64_t flags);
 uint64_t fi_gettime_ms(void);
 uint64_t fi_gettime_us(void);
 
-char **ofi_split_and_alloc(const char *s, const char *delim);
+char **ofi_split_and_alloc(const char *s, const char *delim, size_t *count);
 void ofi_free_string_array(char **s);
 
 #define OFI_ENUM_VAL(X) X

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -756,6 +756,14 @@ void ofi_fabric_remove(struct util_fabric *fabric);
  * Utility Providers
  */
 
+#define OFI_NAME_DELIM	';'
+#define OFI_UTIL_PREFIX "ofi_"
+
+static inline int ofi_has_util_prefix(const char *str)
+{
+	return !strncasecmp(str, OFI_UTIL_PREFIX, strlen(OFI_UTIL_PREFIX));
+}
+
 typedef int (*ofi_alter_info_t)(uint32_t version, const struct fi_info *src_info,
 				struct fi_info *dest_info);
 
@@ -770,9 +778,6 @@ int ofix_getinfo(uint32_t version, const char *node, const char *service,
 int ofi_get_core_info_fabric(struct fi_fabric_attr *util_attr,
 			     struct fi_info **core_info);
 
-
-#define OFI_NAME_DELIM	';'
-#define OFI_UTIL_PREFIX "ofi_"
 
 char *ofi_strdup_append(const char *head, const char *tail);
 // char *ofi_strdup_head(const char *str);

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -775,7 +775,8 @@ int ofix_getinfo(uint32_t version, const char *node, const char *service,
 		 uint64_t flags, const struct util_prov *util_prov,
 		 const struct fi_info *hints, ofi_alter_info_t info_to_core,
 		 ofi_alter_info_t info_to_util, struct fi_info **info);
-int ofi_get_core_info_fabric(struct fi_fabric_attr *util_attr,
+int ofi_get_core_info_fabric(const struct fi_provider *prov,
+			     const struct fi_fabric_attr *util_attr,
 			     struct fi_info **core_info);
 
 
@@ -784,6 +785,7 @@ char *ofi_strdup_append(const char *head, const char *tail);
 // char *ofi_strdup_tail(const char *str);
 const char *ofi_util_name(const char *prov_name, size_t *len);
 const char *ofi_core_name(const char *prov_name, size_t *len);
+int ofi_exclude_prov_name(char **prov_name, const char *util_prov_name);
 
 
 int ofi_shm_map(struct util_shm *shm, const char *name, size_t size,

--- a/prov/mrail/src/mrail_init.c
+++ b/prov/mrail/src/mrail_init.c
@@ -39,7 +39,7 @@ size_t mrail_num_info = 0;
 
 static inline char **mrail_split_addr_strc(const char *addr_strc)
 {
-	char **addr_strv = ofi_split_and_alloc(addr_strc, ",");
+	char **addr_strv = ofi_split_and_alloc(addr_strc, ",", NULL);
 	if (!addr_strv) {
 		FI_WARN(&mrail_prov, FI_LOG_CORE,
 			"Unable to split a FI_ADDR_STRV string\n");

--- a/prov/rxm/src/rxm_fabric.c
+++ b/prov/rxm/src/rxm_fabric.c
@@ -89,7 +89,7 @@ int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 	if (ret)
 		goto err1;
 
-	ret = ofi_get_core_info_fabric(attr, &msg_info);
+	ret = ofi_get_core_info_fabric(&rxm_prov, attr, &msg_info);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_FABRIC, "Unable to get core info!\n");
 		ret = -FI_EINVAL;

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -89,11 +89,6 @@ char *ofi_strdup_append(const char *head, const char *tail)
 	return str;
 }
 
-static int ofi_has_util_prefix(const char *str)
-{
-	return !strncasecmp(str, OFI_UTIL_PREFIX, strlen(OFI_UTIL_PREFIX));
-}
-
 const char *ofi_util_name(const char *str, size_t *len)
 {
 	char *delim;

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -132,6 +132,41 @@ const char *ofi_core_name(const char *str, size_t *len)
 
 }
 
+int ofi_exclude_prov_name(char **prov_name_list, const char *util_prov_name)
+{
+	char *exclude, *name, *name_exclude;
+	int ret = -FI_ENOMEM;
+
+	name = strdup(*prov_name_list);
+	if (!name)
+		return -FI_ENOMEM;
+
+	ofi_rm_substr_delim(name, util_prov_name, OFI_NAME_DELIM);
+
+	exclude = malloc(strlen(util_prov_name) + 2);
+	if (!exclude)
+		goto out;
+
+	exclude[0] = '^';
+	strcpy(&exclude[1], util_prov_name);
+
+	if (strlen(name)) {
+		name_exclude = ofi_strdup_append(name, exclude);
+		free(exclude);
+		if (!name_exclude)
+			goto out;
+		free(*prov_name_list);
+		*prov_name_list = name_exclude;
+	} else {
+		free(*prov_name_list);
+		*prov_name_list = exclude;
+	}
+	ret = 0;
+out:
+	free(name);
+	return ret;
+}
+
 static int ofi_dup_addr(const struct fi_info *info, struct fi_info *dup)
 {
 	dup->addr_format = info->addr_format;
@@ -158,8 +193,7 @@ static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 			    ofi_alter_info_t info_to_core,
 			    struct fi_info **core_hints)
 {
-	const char *core_name;
-	size_t len;
+	int ret = -FI_ENOMEM;
 
 	if (!(*core_hints = fi_allocinfo()))
 		return -FI_ENOMEM;
@@ -185,17 +219,18 @@ static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 		}
 
 		if (util_info->fabric_attr->prov_name) {
-			core_name = ofi_core_name(util_info->fabric_attr->
-						  prov_name, &len);
-			if (core_name) {
-				(*core_hints)->fabric_attr->prov_name =
-					strndup(core_name, len);
-				if (!(*core_hints)->fabric_attr->prov_name) {
-					FI_WARN(prov, FI_LOG_FABRIC,
-						"Unable to alloc prov name\n");
-					goto err;
-				}
+			(*core_hints)->fabric_attr->prov_name =
+				strdup(util_info->fabric_attr->prov_name);
+			if (!(*core_hints)->fabric_attr->prov_name) {
+				FI_WARN(prov, FI_LOG_FABRIC,
+					"Unable to alloc prov name\n");
+				goto err;
 			}
+			ret = ofi_exclude_prov_name(
+					&(*core_hints)->fabric_attr->prov_name,
+					prov->name);
+			if (ret)
+				goto err;
 		}
 	}
 
@@ -212,7 +247,7 @@ static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 
 err:
 	fi_freeinfo(*core_hints);
-	return -FI_ENOMEM;
+	return ret;
 }
 
 static int ofi_info_to_util(uint32_t version, const struct fi_provider *prov,
@@ -330,28 +365,34 @@ int ofix_getinfo(uint32_t version, const char *node, const char *service,
 }
 
 /* Caller should use only fabric_attr in returned core_info */
-int ofi_get_core_info_fabric(struct fi_fabric_attr *util_attr,
+int ofi_get_core_info_fabric(const struct fi_provider *prov,
+			     const struct fi_fabric_attr *util_attr,
 			     struct fi_info **core_info)
 {
 	struct fi_info hints;
-	const char *core_name;
-	size_t len;
 	int ret;
 
-	core_name = ofi_core_name(util_attr->prov_name, &len);
-	if (!core_name)
+	/* ofix_getinfo() would append utility provider name after core / lower
+	 * layer provider name */
+	if (!strstr(util_attr->prov_name, prov->name))
 		return -FI_ENODATA;
 
 	memset(&hints, 0, sizeof hints);
 	if (!(hints.fabric_attr = calloc(1, sizeof(*hints.fabric_attr))))
 		return -FI_ENOMEM;
 
-	hints.fabric_attr->name = util_attr->name;
-	hints.fabric_attr->api_version = util_attr->api_version;
-	if (!(hints.fabric_attr->prov_name = strndup(core_name, len))) {
+	hints.fabric_attr->prov_name = strdup(util_attr->prov_name);
+	if (!hints.fabric_attr->prov_name) {
 		ret = -FI_ENOMEM;
 		goto out;
 	}
+
+	ret = ofi_exclude_prov_name(&hints.fabric_attr->prov_name, prov->name);
+	if (ret)
+		goto out;
+
+	hints.fabric_attr->name = util_attr->name;
+	hints.fabric_attr->api_version = util_attr->api_version;
 	hints.mode = ~0;
 
 	ret = fi_getinfo(util_attr->api_version, NULL, NULL, OFI_CORE_PROV_ONLY,

--- a/src/common.c
+++ b/src/common.c
@@ -751,7 +751,7 @@ int ofi_cpu_supports(unsigned func, unsigned reg, unsigned bit)
  *
  * Returns NULL on failure.
  */
-char **ofi_split_and_alloc(const char *s, const char *delim)
+char **ofi_split_and_alloc(const char *s, const char *delim, size_t *count)
 {
 	int i, n;
 	char *tmp;
@@ -791,6 +791,8 @@ char **ofi_split_and_alloc(const char *s, const char *delim)
 	}
 	assert(i == n);
 
+	if (count)
+		*count = n;
 	return arr;
 
 cleanup:

--- a/src/common.c
+++ b/src/common.c
@@ -745,6 +745,47 @@ int ofi_cpu_supports(unsigned func, unsigned reg, unsigned bit)
 	return cpuinfo[reg] & bit;
 }
 
+/* String utility functions */
+
+int ofi_rm_substr(char *str, const char *substr)
+{
+	char *dest, *src;
+
+	dest = strstr(str, substr);
+	if (!dest)
+		return -FI_EINVAL;
+
+	src = dest + strlen(substr);
+	memmove(dest, src, strlen(src) + 1);
+	return 0;
+}
+
+int ofi_rm_substr_delim(char *str, const char *substr, const char delim)
+{
+	char *pattern;
+	size_t len = strlen(substr) + 2; // account for delim and null char
+	int ret;
+
+	pattern = malloc(len);
+	if (!pattern)
+		return -FI_ENOMEM;
+
+	snprintf(pattern, len, "%c%s", delim, substr);
+	ret = ofi_rm_substr(str, pattern);
+	if (!ret)
+		goto out;
+
+	snprintf(pattern, len, "%s%c", substr, delim);
+	ret = ofi_rm_substr(str, pattern);
+	if (!ret)
+		goto out;
+
+	ret = ofi_rm_substr(str, substr);
+out:
+	free(pattern);
+	return ret;
+}
+
 /* Split the given string "s" using the specified delimiter(s) in the string
  * "delim" and return an array of strings. The array is terminated with a NULL
  * pointer. Returned array should be freed with ofi_free_string_array().

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -568,23 +568,41 @@ static void ofi_set_prov_attr(struct fi_fabric_attr *attr,
 
 /*
  * The layering of utility providers over core providers follows these rules.
- * 1. If both are specified, then only return that layering
- * 2. If a utility provider is specified, return it over any* core provider.
- * 3. If a core provider is specified, return any utility provider that can
- *    layer over it, plus the core provider itself, if possible.
- * 4* A utility provider will not layer over the sockets provider unless the
- *    user explicitly requests that combination.
- *
- * Utility providers use an internal flag, OFI_CORE_PROV_ONLY, to indicate
- * that only core providers should respond to an fi_getinfo query.  This
- * prevents utility providers from layering over other utility providers.
+ * 0. Provider names are delimited by ";"
+ * 1. Rules when # of providers <= 2:
+ *    1a. If both are specified, then only return that layering
+ *    1b. If a utility provider is specified, return it over any* core provider.
+ *    1c. If a core provider is specified, return any utility provider that can
+ *        layer over it, plus the core provider itself, if possible.
+ *    1d. A utility provider will not layer over the sockets provider unless the
+ *        user explicitly requests that combination.
+ *    1e. OFI_CORE_PROV_ONLY flag prevents utility providers layering over other
+ *        utility providers.
+ * 2. If both the providers are utility providers or if more than two providers
+ *    are specified, the rightmost provider would be compared.
+ * 3. If any provider has a caret symbol "^" is prefixed before any provider
+ *    name it would be excluded (internal use only). These excluded providers
+ *    should be listed only at the end.
  */
 static int ofi_layering_ok(const struct fi_provider *provider,
-			   const char *util_name, size_t util_len,
-			   const char *core_name, size_t core_len,
+			   char **prov_vec, size_t count,
 			   uint64_t flags)
 {
+	char *prov_name;
+	int i;
+
+	/* Excluded providers must be at the end */
+	for (i = count - 1; i >= 0; i--) {
+		if (prov_vec[i][0] != '^')
+		    break;
+
+		if (!strcasecmp(&prov_vec[i][1], provider->name))
+			return 0;
+	}
+	count = i + 1;
+
 	if (flags & OFI_CORE_PROV_ONLY) {
+		assert((count == 1) || (count == 0));
 		if (ofi_is_util_prov(provider)) {
 			FI_INFO(&core_prov, FI_LOG_CORE,
 				"Need core provider, skipping util %s\n",
@@ -592,35 +610,39 @@ static int ofi_layering_ok(const struct fi_provider *provider,
 			return 0;
 		}
 
-		if ((!core_len || !core_name) &&
-		    !strcasecmp(provider->name, "sockets")) {
+		if ((count == 0) && !strcasecmp(provider->name, "sockets")) {
 			FI_INFO(&core_prov, FI_LOG_CORE,
 				"Skipping util;sockets layering\n");
 			return 0;
 		}
 	}
 
-	if (util_len && util_name) {
-		assert(!(flags & OFI_CORE_PROV_ONLY));
-		if ((strlen(provider->name) != util_len) ||
-		    strncasecmp(util_name, provider->name, util_len))
-			return 0;
+	if (!count)
+		return 1;
 
-	} else if (core_len && core_name) {
-		if (!strncasecmp(core_name, "sockets", core_len) &&
-		    ofi_is_util_prov(provider)) {
+	/* To maintain backward compatibility with the previous behaviour of
+	 * ofi_layering_ok we need to check if the # of providers is two or
+	 * fewer. In such a case, we have to be agnostic to the ordering of
+	 * core and utility providers */
+
+	if ((count == 1) && ofi_is_util_prov(provider) &&
+	    !ofi_has_util_prefix(prov_vec[0])) {
+		if (!strcasecmp(prov_vec[0], "sockets")) {
 			FI_INFO(&core_prov, FI_LOG_CORE,
 				"Sockets requested, skipping util layering\n");
 			return 0;
+		} else {
+			return 1;
 		}
-
-		if (!ofi_is_util_prov(provider) &&
-		    ((strlen(provider->name) != core_len) ||
-		     strncasecmp(core_name, provider->name, core_len)))
-			return 0;
 	}
 
-	return 1;
+	if ((count == 2) && ofi_has_util_prefix(prov_vec[0]) &&
+	    !ofi_has_util_prefix(prov_vec[1]))
+		prov_name = prov_vec[0];
+	else
+		prov_name = prov_vec[count - 1];
+
+	return !strcasecmp(provider->name, prov_name);
 }
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
@@ -630,8 +652,8 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 {
 	struct ofi_prov *prov;
 	struct fi_info *tail, *cur;
-	const char *util_name = NULL, *core_name = NULL;
-	size_t util_len = 0, core_len = 0;
+	char **prov_vec = NULL;
+	size_t count = 0;
 	int ret;
 
 	if (!ofi_init)
@@ -648,10 +670,12 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 	}
 
 	if (hints && hints->fabric_attr && hints->fabric_attr->prov_name) {
-		util_name = ofi_util_name(hints->fabric_attr->prov_name,
-					  &util_len);
-		core_name = ofi_core_name(hints->fabric_attr->prov_name,
-					  &core_len);
+		prov_vec = ofi_split_and_alloc(hints->fabric_attr->prov_name,
+					       ";", &count);
+		if (!prov_vec)
+			return -FI_ENOMEM;
+		FI_DBG(&core_prov, FI_LOG_CORE, "hints prov_name: %s\n",
+		       hints->fabric_attr->prov_name);
 	}
 
 	*info = tail = NULL;
@@ -659,8 +683,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 		if (!prov->provider)
 			continue;
 
-		if (!ofi_layering_ok(prov->provider, util_name, util_len,
-				     core_name, core_len, flags))
+		if (!ofi_layering_ok(prov->provider, prov_vec, count, flags))
 			continue;
 
 		if (FI_VERSION_LT(prov->provider->fi_version, version)) {
@@ -701,6 +724,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 		ofi_set_prov_attr(tail->fabric_attr, prov->provider);
 		tail->fabric_attr->api_version = version;
 	}
+	ofi_free_string_array(prov_vec);
 
 	return *info ? 0 : -FI_ENODATA;
 }

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -311,8 +311,8 @@ void ofi_create_filter(struct fi_filter *filter, const char *raw_filter)
 		++raw_filter;
 	}
 
-	filter->names = ofi_split_and_alloc(raw_filter, ",");
-	if (!filter->names)
+	filter->names= ofi_split_and_alloc(raw_filter, ",", NULL);
+	if (filter->names)
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"unable to parse filter from: %s\n", raw_filter);
 }
@@ -410,7 +410,7 @@ void fi_ini(void)
 	if (!provdir)
 		provdir = PROVDLDIR;
 
-	dirs = ofi_split_and_alloc(provdir, ":");
+	dirs = ofi_split_and_alloc(provdir, ":", NULL);
 	if (dirs) {
 		for (n = 0; dirs[n]; ++n) {
 			ofi_ini_dir(dirs[n]);


### PR DESCRIPTION
This patch enables layering utility providers on top of each other. This allows providers like ofi_mrail (multi-rail) to layer over ofi_rxm provider.

- Ordering would be enforced if `hints->fabric_attr->name` lists more than two providers. The rightmost provider would be the top layer.
- Otherwise the existing behavior of not checking the order is maintained.
- The patch also allows excluding providers with a caret symbol - `^`. This is for internal use only and enables an utility provider to not layer over itself or certain other providers. Excluded providers should be listed at the end.

This PR is WIP and needs some more changes around `ofix_getinfo`.