### PR TITLE
prov/tcp: fixing the usage of fi_eq_write

### DIFF
--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -288,6 +288,7 @@ static int proc_conn_resp(struct poll_fd_mgr *poll_mgr,
 {
 	struct ofi_ctrl_hdr conn_resp;
 	struct fi_eq_cm_entry *cm_entry;
+	ssize_t len;
 	int ret = FI_SUCCESS;
 
 	assert(poll_mgr->poll_fds[index].revents == POLLIN);
@@ -308,10 +309,11 @@ static int proc_conn_resp(struct poll_fd_mgr *poll_mgr,
 	if (ret)
 		goto err;
 
-	ret = (int) fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED, cm_entry,
+	len = fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED, cm_entry,
 				sizeof(*cm_entry) + poll_info->cm_data_sz, 0);
-	if (ret < 0) {
+	if (len < 0) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
+		ret = (int) len;
 		goto err;
 	}
 err:

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -45,6 +45,7 @@
 int tcpx_ep_shutdown_report(struct tcpx_ep *ep, fid_t fid)
 {
 	struct fi_eq_cm_entry cm_entry = {0};
+	ssize_t len;
 
 	fastlock_acquire(&ep->cm_state_lock);
 	if (ep->cm_state == TCPX_EP_SHUTDOWN) {
@@ -55,8 +56,12 @@ int tcpx_ep_shutdown_report(struct tcpx_ep *ep, fid_t fid)
 	fastlock_release(&ep->cm_state_lock);
 
 	cm_entry.fid = fid;
-	return fi_eq_write(&ep->util_ep.eq->eq_fid, FI_SHUTDOWN,
-			  &cm_entry, sizeof(cm_entry), 0);
+	len =  fi_eq_write(&ep->util_ep.eq->eq_fid, FI_SHUTDOWN,
+			   &cm_entry, sizeof(cm_entry), 0);
+	if (len < 0)
+		return (int) len;
+
+	return FI_SUCCESS;
 }
 
 void process_tx_pe_entry(struct tcpx_pe_entry *pe_entry)


### PR DESCRIPTION
Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>