### PR TITLE
prov/verbs: Makes all sends signaled

### DIFF
--- a/prov/verbs/src/ep_dgram/verbs_dgram.h
+++ b/prov/verbs/src/ep_dgram/verbs_dgram.h
@@ -64,7 +64,6 @@ struct fi_ibv_dgram_wr_entry_hdr {
 	struct dlist_entry		entry;
 	void				*desc;
 	struct fi_ibv_dgram_ep		*ep;
-	int32_t				comp_unsignaled_cnt;
 	void				*context;
 	uint64_t			flags;
 	handle_wr_cb			suc_cb;
@@ -222,8 +221,6 @@ struct fi_ibv_dgram_ep {
 	struct ofi_ib_ud_ep_name	ep_name;
 	int				service;
 	int				ep_flags;
-	int32_t				max_unsignaled_send_cnt;
-	ofi_atomic32_t			unsignaled_send_cnt;
 };
 
 extern struct fi_ops_msg fi_ibv_dgram_msg_ops;

--- a/prov/verbs/src/ep_dgram/verbs_dgram_cq.c
+++ b/prov/verbs/src/ep_dgram/verbs_dgram_cq.c
@@ -127,12 +127,6 @@ int fi_ibv_dgram_tx_cq_comp(struct util_cq *util_cq,
 			    struct util_cntr *util_cntr,
 			    struct ibv_wc *wc)
 {
-	struct fi_ibv_dgram_wr_entry *wr_entry =
-		(struct fi_ibv_dgram_wr_entry *)(uintptr_t)wc->wr_id;
-
-	ofi_atomic_sub32(&wr_entry->hdr.ep->unsignaled_send_cnt,
-			 wr_entry->hdr.ep->max_unsignaled_send_cnt);
-
 	return fi_ibv_dgram_cq_cntr_comp(util_cq, util_cntr, wc);
 }
 
@@ -140,12 +134,6 @@ int fi_ibv_dgram_tx_cq_report_error(struct util_cq *util_cq,
 				    struct util_cntr *util_cntr,
 				    struct ibv_wc *wc)
 {
-	struct fi_ibv_dgram_wr_entry *wr_entry =
-		(struct fi_ibv_dgram_wr_entry *)(uintptr_t)wc->wr_id;
-
-	ofi_atomic_sub32(&wr_entry->hdr.ep->unsignaled_send_cnt,
-			 wr_entry->hdr.ep->max_unsignaled_send_cnt);
-
 	return fi_ibv_dgram_cq_cntr_report_error(util_cq, util_cntr, wc);
 }
 
@@ -162,10 +150,6 @@ int fi_ibv_dgram_tx_cq_no_action(struct util_cq *util_cq,
 {
 	struct fi_ibv_dgram_wr_entry *wr_entry =
 		(struct fi_ibv_dgram_wr_entry *)(uintptr_t)wc->wr_id;
-	
-
-	ofi_atomic_sub32(&wr_entry->hdr.ep->unsignaled_send_cnt,
-			 wr_entry->hdr.ep->max_unsignaled_send_cnt);
 
 	fi_ibv_dgram_wr_entry_release(
 		&wr_entry->hdr.ep->grh_pool,

--- a/prov/verbs/src/ep_dgram/verbs_dgram_ep.c
+++ b/prov/verbs/src/ep_dgram/verbs_dgram_ep.c
@@ -454,9 +454,6 @@ int fi_ibv_dgram_endpoint_open(struct fid_domain *domain_fid,
 	ep->service = (info->src_addr) ?
 			(((struct ofi_ib_ud_ep_name *)info->src_addr)->service) :
 			(((getpid() & 0x7FFF) << 16) + ((uintptr_t)ep & 0xFFFF));
-	
-	ofi_atomic_initialize32(&ep->unsignaled_send_cnt, 0);
-	ep->max_unsignaled_send_cnt = ep->info->tx_attr->size / 2;
 
 	*ep_fid = &ep->util_ep.ep_fid;
 	(*ep_fid)->cm = &fi_ibv_dgram_cm_ops;


### PR DESCRIPTION
Fixes #4038

This patch removes usage if unsignaled sends from verbs/DGRAM as it is already done for verbs/MSG.
And there were places when verbs/DGRAM did `util_buf_release` twice for the same allocated buffer

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>