### PR TITLE
prov/rxm: Add run-time parameter for SAR protocol

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -90,12 +90,17 @@ The ofi_rxm provider checks for the following environment variables.
 *FI_OFI_RXM_BUFFER_SIZE*
 : Defines the transmit buffer size / inject size. Messages of size less than this
   would be transmitted via an eager protocol and those above would be transmitted
-  via a rendezvous protocol. Transmit data would be copied up to this size
-  (default: ~16k).
+  via a rendezvous or SAR (Segmentation And Reassembly) protocol. Transmit data
+  would be copied up to this size (default: ~16k).
 
 *FI_OFI_RXM_COMP_PER_PROGRESS*
 : Defines the maximum number of MSG provider CQ entries (default: 1) that would
   be read per progress (RxM CQ read).
+
+*FI_OFI_RXM_SAR_LIMIT*
+: Set this environment variable to control the RxM SAR (Segmentation And Reassembly)
+  protocol. Messages of size greater than this (default: 256 Kb) would be transmitted
+  via rendezvous protocol.
 
 
 # SEE ALSO

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -60,7 +60,8 @@
 #define RXM_MAJOR_VERSION 1
 #define RXM_MINOR_VERSION 0
 
-#define RXM_BUF_SIZE 16384
+#define RXM_BUF_SIZE	16384
+#define RXM_SAR_LIMIT	262144
 #define RXM_IOV_LIMIT 4
 
 #define RXM_MR_MODES	(OFI_MR_BASIC_MAP | FI_MR_LOCAL)
@@ -354,6 +355,7 @@ struct rxm_ep {
 	int			msg_mr_local;
 	int			rxm_mr_local;
 	size_t			min_multi_recv_size;
+	size_t			sar_limit;
 
 	struct rxm_buf_pool	buf_pools[RXM_BUF_POOL_MAX];
 

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -284,13 +284,20 @@ RXM_INI
 			"Defines the transmit buffer size / inject size. Messages"
 			" of size less than this would be transmitted via an "
 			"eager protocol and those above would be transmitted "
-			"via a rendezvous protocol. Transmit data would be copied"
-			" up to this size (default: ~16k).");
+			"via a rendezvous or SAR (Segmentation And Reassembly) "
+			"protocol. Transmit data would be copied up to this size "
+			"(default: ~16k).");
 
 	fi_param_define(&rxm_prov, "comp_per_progress", FI_PARAM_INT,
 			"Defines the maximum number of MSG provider CQ entries "
 			"(default: 1) that would be read per progress "
 			"(RxM CQ read).");
+
+	fi_param_define(&rxm_prov, "sar_limit", FI_PARAM_SIZE_T,
+			"Set this environment variable to control the RxM SAR "
+			"(Segmentation And Reassembly) protocol. "
+			"Messages of size greater than this (default: 256 Kb) "
+			"would be transmitted via rendezvous protocol.");
 
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");


### PR DESCRIPTION
This patch updates initialization routine of RxM provider
to define FI_OFI_RXM_SAR_LIMIT environment variable.
The value of this parameter is stored in objects of the rxm_ep
structure (RxM EPs).
If the passed value is less than min(FI_OFI_RXM_SAR_LIMIT;
sizeof(struct rxm_pkt)) (i.e. RxM inject size), then the SAR protocol
wouldn't be used. If the value isn't passed, the SAR limit is set to
the default one (256 Kb = 262144 bytes).
This patch add description of this variable to the fi_rxm(7) man page.

Also this patch appliesminor updates to the description of
FI_OFI_RXM_BUFFER_SIZE variable in both the source code and the man page.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>