### PR TITLE
prov/rxm: Add new protocol state

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -160,6 +160,7 @@ struct rxm_rma_iov {
 	FUNC(RXM_TX),		\
 	FUNC(RXM_TX_RMA),	\
 	FUNC(RXM_RX),		\
+	FUNC(RXM_SAR_TX),	\
 	FUNC(RXM_LMT_TX),	\
 	FUNC(RXM_LMT_ACK_WAIT),	\
 	FUNC(RXM_LMT_READ),	\


### PR DESCRIPTION
This patch add new protocl mstate - RXM_SAR_TX - that would be used
by SAR protocol to send segments to peer.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>