### PR TITLE
Enable ability to hook provider calls

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 #
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2017 Intel Corporation, Inc. All right reserved.
+# Copyright (c) 2017-2018 Intel Corporation, Inc. All right reserved.
 #
 # Makefile.am for libfabric
 
@@ -73,6 +73,7 @@ common_srcs =				\
 	prov/hook/src/hook_domain.c	\
 	prov/hook/src/hook_ep.c		\
 	prov/hook/src/hook_eq.c		\
+	prov/hook/src/hook_perf.c	\
 	prov/hook/src/hook_wait.c	\
 	prov/hook/src/hook_xfer.c
 
@@ -149,6 +150,7 @@ src_libfabric_la_SOURCES =			\
 	include/uthash.h			\
 	include/ofi_prov.h			\
 	prov/hook/src/hook.h			\
+	prov/hook/src/hook_perf.h		\
 	include/rdma/providers/fi_log.h		\
 	include/rdma/providers/fi_prov.h	\
 	src/fabric.c				\

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,18 +64,7 @@ common_srcs =				\
 	prov/util/src/util_ns.c		\
 	prov/util/src/util_shm.c	\
 	prov/util/src/util_mem_monitor.c\
-	prov/util/src/util_mr_cache.c	\
-	prov/hook/src/hook.c		\
-	prov/hook/src/hook_av.c		\
-	prov/hook/src/hook_cm.c		\
-	prov/hook/src/hook_cntr.c	\
-	prov/hook/src/hook_cq.c		\
-	prov/hook/src/hook_domain.c	\
-	prov/hook/src/hook_ep.c		\
-	prov/hook/src/hook_eq.c		\
-	prov/hook/src/hook_perf.c	\
-	prov/hook/src/hook_wait.c	\
-	prov/hook/src/hook_xfer.c
+	prov/util/src/util_mr_cache.c
 
 
 if MACOS
@@ -159,6 +148,17 @@ src_libfabric_la_SOURCES =			\
 	src/log.c				\
 	src/var.c				\
 	src/abi_1_0.c				\
+	prov/hook/src/hook.c			\
+	prov/hook/src/hook_av.c			\
+	prov/hook/src/hook_cm.c			\
+	prov/hook/src/hook_cntr.c		\
+	prov/hook/src/hook_cq.c			\
+	prov/hook/src/hook_domain.c		\
+	prov/hook/src/hook_ep.c			\
+	prov/hook/src/hook_eq.c			\
+	prov/hook/src/hook_perf.c		\
+	prov/hook/src/hook_wait.c		\
+	prov/hook/src/hook_xfer.c		\
 	$(common_srcs)
 
 src_libfabric_la_CPPFLAGS = $(AM_CPPFLAGS)

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -120,6 +120,7 @@ void fi_log_fini(void);
 void fi_param_init(void);
 void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
+void ofi_hook_install(struct fid_fabric *hfabric, struct fid_fabric **fabric);
 
 const char *ofi_hex_str(const uint8_t *data, size_t len);
 

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -120,6 +120,7 @@ void fi_log_fini(void);
 void fi_param_init(void);
 void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
+void ofi_hook_init(void);
 void ofi_hook_install(struct fid_fabric *hfabric, struct fid_fabric **fabric);
 
 const char *ofi_hex_str(const uint8_t *data, size_t len);

--- a/include/ofi_perf.h
+++ b/include/ofi_perf.h
@@ -153,9 +153,7 @@ static inline void ofi_perf_end(struct ofi_perf_ctx *ctx,
 
 struct ofi_perfset {
 	const struct fi_provider *prov;
-	char			**names;
 	size_t			size;
-	size_t			count;
 	struct ofi_perf_ctx	*ctx;
 	struct ofi_perf_data	*data;
 };
@@ -166,9 +164,7 @@ int ofi_perfset_create(const struct fi_provider *prov,
 		       uint32_t flags);
 void ofi_perfset_close(struct ofi_perfset *set);
 
-struct ofi_perf_data *ofi_perfset_data(struct ofi_perfset *set,
-				       const char *name);
-void ofi_perfset_log(struct ofi_perfset *set);
+void ofi_perfset_log(struct ofi_perfset *set, const char **names);
 
 
 #ifdef __cplusplus

--- a/include/ofi_perf.h
+++ b/include/ofi_perf.h
@@ -35,6 +35,7 @@
 
 #include "config.h"
 
+#include <assert.h>
 #include <string.h>
 #include <ofi_osd.h>
 #include <rdma/providers/fi_prov.h>

--- a/include/ofi_perf.h
+++ b/include/ofi_perf.h
@@ -83,6 +83,12 @@ struct ofi_perf_data {
 };
 
 
+void ofi_perf_init(void);
+extern enum ofi_perf_domain	perf_domain;
+extern uint32_t			perf_cntr;
+extern uint32_t			perf_flags;
+
+
 /*
  * Performance management unit:
  *

--- a/include/ofi_perf.h
+++ b/include/ofi_perf.h
@@ -166,6 +166,18 @@ void ofi_perfset_close(struct ofi_perfset *set);
 
 void ofi_perfset_log(struct ofi_perfset *set, const char **names);
 
+static inline void ofi_perfset_start(struct ofi_perfset *set, size_t index)
+{
+	assert(index < set->size);
+	ofi_perf_start(set->ctx, &set->data[index]);
+}
+
+static inline void ofi_perfset_end(struct ofi_perfset *set, size_t index)
+{
+	assert(index < set->size);
+	ofi_perf_end(set->ctx, &set->data[index]);
+}
+
 
 #ifdef __cplusplus
 }

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -262,6 +262,17 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="prov\hook\src\hook.c" />
+    <ClCompile Include="prov\hook\src\hook_av.c" />
+    <ClCompile Include="prov\hook\src\hook_cm.c" />
+    <ClCompile Include="prov\hook\src\hook_cntr.c" />
+    <ClCompile Include="prov\hook\src\hook_cq.c" />
+    <ClCompile Include="prov\hook\src\hook_domain.c" />
+    <ClCompile Include="prov\hook\src\hook_ep.c" />
+    <ClCompile Include="prov\hook\src\hook_eq.c" />
+    <ClCompile Include="prov\hook\src\hook_perf.c" />
+    <ClCompile Include="prov\hook\src\hook_wait.c" />
+    <ClCompile Include="prov\hook\src\hook_xfer.c" />
     <ClCompile Include="prov\netdir\src\netdir_cntr.c" />
     <ClCompile Include="prov\netdir\src\netdir_ep_msg.c" />
     <ClCompile Include="prov\netdir\src\netdir_ep_rma.c" />
@@ -611,6 +622,8 @@
     <ClInclude Include="include\windows\sys\uio.h" />
     <ClInclude Include="include\windows\sys\wait.h" />
     <ClInclude Include="include\windows\unistd.h" />
+    <ClInclude Include="prov\hook\src\hook.h" />
+    <ClInclude Include="prov\hook\src\hook_perf.h" />
     <ClInclude Include="prov\netdir\src\netdir_buf.h" />
     <ClInclude Include="prov\netdir\src\netdir_cq.h" />
     <ClInclude Include="prov\netdir\src\netdir_queue.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -97,6 +97,12 @@
     <Filter Include="Source Files\prov\tcp\src">
       <UniqueIdentifier>{8c151366-dd08-48d5-aa21-50a500cbde73}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\prov\hook">
+      <UniqueIdentifier>{b85ecf6c-fb76-4d65-a7f0-cba470a0adee}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\prov\hook\src">
+      <UniqueIdentifier>{b4689956-b61f-4c5b-b827-9af0797ea087}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\common.c">
@@ -402,6 +408,39 @@
     <ClCompile Include="prov\util\src\util_pep.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
+    <ClCompile Include="prov\hook\src\hook.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_av.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_cm.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_cntr.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_cq.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_domain.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_ep.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_eq.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_perf.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_wait.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
+    <ClCompile Include="prov\hook\src\hook_xfer.c">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\fasthash.h">
@@ -616,6 +655,12 @@
     </ClInclude>
     <ClInclude Include="include\windows\netdb.h">
       <Filter>Header Files\windows</Filter>
+    </ClInclude>
+    <ClInclude Include="prov\hook\src\hook.h">
+      <Filter>Source Files\prov\hook\src</Filter>
+    </ClInclude>
+    <ClInclude Include="prov\hook\src\hook_perf.h">
+      <Filter>Source Files\prov\hook\src</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -87,6 +87,12 @@ struct fid *hook_to_hfid(const struct fid *fid)
 	}
 }
 
+struct fid_wait *hook_to_hwait(const struct fid_wait *wait)
+{
+	return container_of(wait, struct hook_wait, wait)->hwait;
+}
+
+
 static int hook_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
 	struct fid *hfid, *hbfid;
@@ -203,6 +209,7 @@ static int hook_fabric(struct fid_fabric *hfabric, struct fid_fabric **fabric,
 		return ret;
 
 	fab->hclass = hclass;
+	fab->hfabric = hfabric;
 	fab->fabric.fid.fclass = FI_CLASS_FABRIC;
 	fab->fabric.fid.context = hfabric->fid.context;
 	fab->fabric.fid.ops = &hook_fabric_fid_ops;

--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -34,6 +34,7 @@
 #include <pthread.h>
 #include <stdio.h>
 #include "hook.h"
+#include "hook_perf.h"
 
 
 struct fid *hook_to_hfid(const struct fid *fid)

--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -85,7 +85,6 @@ struct fid *hook_to_hfid(const struct fid *fid)
 		return &(container_of(fid, struct hook_mr, mr.fid)->
 			 hmr->fid);
 	default:
-		assert(0);
 		return NULL;
 	}
 }

--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -38,6 +38,9 @@
 #include "hook_perf.h"
 
 
+static uint32_t hooks_enabled;
+
+
 struct fid *hook_to_hfid(const struct fid *fid)
 {
 	switch (fid->fclass) {
@@ -223,5 +226,44 @@ static int hook_fabric(struct fid_fabric *hfabric, struct fid_fabric **fabric,
 
 void ofi_hook_install(struct fid_fabric *hfabric, struct fid_fabric **fabric)
 {
-	hook_fabric(hfabric, fabric, HOOK_NOOP);
+	int hooks, hclass, ret;
+
+	*fabric = hfabric;
+	if (!hooks_enabled)
+		return;
+
+	for (hooks = hooks_enabled, hclass = 0; hooks;
+	     hooks >>= 1, hclass++) {
+		if (hooks & 0x1) {
+			ret = hook_fabric(hfabric, fabric,
+					  (enum hook_class) hclass);
+			if (ret)
+				return;
+			hfabric = *fabric;
+		}
+	}
+}
+
+void ofi_hook_init(void)
+{
+	char *param_val = NULL;
+
+	fi_param_define(NULL, "hook", FI_PARAM_STRING,
+			"Intercept calls to underlying provider and apply "
+			"the specified functionality to them.  Hook option: "
+			"perf (gather performance data)");
+	fi_param_get_str(NULL, "hook", &param_val);
+
+	hooks_enabled = 0;
+	if (!param_val)
+		return;
+
+	if (!strcasecmp(param_val, "noop")) {
+		FI_INFO(&core_prov, FI_LOG_CORE, "Noop hook requested\n");
+		hooks_enabled |= (1 << HOOK_NOOP);
+	}
+	if (!strcasecmp(param_val, "perf")) {
+		FI_INFO(&core_prov, FI_LOG_CORE, "Perf hook requested\n");
+		hooks_enabled |= (1 << HOOK_PERF);
+	}
 }

--- a/prov/hook/src/hook.h
+++ b/prov/hook/src/hook.h
@@ -45,6 +45,11 @@
 #include <rdma/fi_tagged.h>
 
 
+enum hook_class {
+	HOOK_NOOP,
+	HOOK_PERF,
+};
+
 /*
  * Define hook structs so we can cast from fid to parent using simple cast.
  * This lets us have a single close() call.
@@ -56,9 +61,8 @@ struct fid *hook_to_hfid(const struct fid *fid);
 struct hook_fabric {
 	struct fid_fabric fabric;
 	struct fid_fabric *hfabric;
+	enum hook_class   hclass;
 };
-
-int hook_fabric(struct fid_fabric *hfabric, struct fid_fabric **fabric);
 
 
 struct hook_domain {

--- a/prov/hook/src/hook.h
+++ b/prov/hook/src/hook.h
@@ -45,6 +45,10 @@
 #include <rdma/fi_tagged.h>
 
 
+/*
+ * Hooks are installed from top down.
+ * Values must start at 0 and increment by one.
+ */
 enum hook_class {
 	HOOK_NOOP,
 	HOOK_PERF,

--- a/prov/hook/src/hook.h
+++ b/prov/hook/src/hook.h
@@ -57,6 +57,8 @@ enum hook_class {
 
 extern struct fi_ops hook_fid_ops;
 struct fid *hook_to_hfid(const struct fid *fid);
+struct fid_wait *hook_to_hwait(const struct fid_wait *wait);
+
 
 struct hook_fabric {
 	struct fid_fabric fabric;

--- a/prov/hook/src/hook.h
+++ b/prov/hook/src/hook.h
@@ -64,6 +64,7 @@ int hook_fabric(struct fid_fabric *hfabric, struct fid_fabric **fabric);
 struct hook_domain {
 	struct fid_domain domain;
 	struct fid_domain *hdomain;
+	struct hook_fabric *fabric;
 };
 
 int hook_domain(struct fid_fabric *fabric, struct fi_info *info,
@@ -73,6 +74,7 @@ int hook_domain(struct fid_fabric *fabric, struct fi_info *info,
 struct hook_av {
 	struct fid_av av;
 	struct fid_av *hav;
+	struct hook_domain *domain;
 };
 
 int hook_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
@@ -82,6 +84,7 @@ int hook_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 struct hook_wait {
 	struct fid_wait wait;
 	struct fid_wait *hwait;
+	struct hook_fabric *fabric;
 };
 
 int hook_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
@@ -92,6 +95,7 @@ int hook_trywait(struct fid_fabric *fabric, struct fid **fids, int count);
 struct hook_poll {
 	struct fid_poll poll;
 	struct fid_poll *hpoll;
+	struct hook_domain *domain;
 };
 
 int hook_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
@@ -101,6 +105,7 @@ int hook_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 struct hook_eq {
 	struct fid_eq eq;
 	struct fid_eq *heq;
+	struct hook_fabric *fabric;
 };
 
 int hook_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
@@ -110,6 +115,7 @@ int hook_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 struct hook_cq {
 	struct fid_cq cq;
 	struct fid_cq *hcq;
+	struct hook_domain *domain;
 };
 
 int hook_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
@@ -119,6 +125,7 @@ int hook_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 struct hook_cntr {
 	struct fid_cntr cntr;
 	struct fid_cntr *hcntr;
+	struct hook_domain *domain;
 };
 
 int hook_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
@@ -128,6 +135,7 @@ int hook_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 struct hook_ep {
 	struct fid_ep ep;
 	struct fid_ep *hep;
+	struct hook_domain *domain;
 };
 
 int hook_endpoint(struct fid_domain *domain, struct fi_info *info,
@@ -148,6 +156,7 @@ extern struct fi_ops_atomic hook_atomic_ops;
 struct hook_pep {
 	struct fid_pep pep;
 	struct fid_pep *hpep;
+	struct hook_fabric *fabric;
 };
 
 int hook_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
@@ -157,6 +166,7 @@ int hook_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 struct hook_stx {
 	struct fid_stx stx;
 	struct fid_stx *hstx;
+	struct hook_domain *domain;
 };
 
 int hook_stx_ctx(struct fid_domain *domain,
@@ -167,6 +177,7 @@ int hook_stx_ctx(struct fid_domain *domain,
 struct hook_mr {
 	struct fid_mr mr;
 	struct fid_mr *hmr;
+	struct hook_domain *domain;
 };
 
 

--- a/prov/hook/src/hook_av.c
+++ b/prov/hook/src/hook_av.c
@@ -112,6 +112,7 @@ int hook_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (!myav)
 		return -FI_ENOMEM;
 
+	myav->domain = dom;
 	myav->av.fid.fclass = FI_CLASS_AV;
 	myav->av.fid.context = context;
 	myav->av.fid.ops = &hook_fid_ops;

--- a/prov/hook/src/hook_cntr.c
+++ b/prov/hook/src/hook_cntr.c
@@ -105,6 +105,7 @@ int hook_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	if (!mycntr)
 		return -FI_ENOMEM;
 
+	mycntr->domain = dom;
 	mycntr->cntr.fid.fclass = FI_CLASS_CNTR;
 	mycntr->cntr.fid.context = context;
 	mycntr->cntr.fid.ops = &hook_fid_ops;

--- a/prov/hook/src/hook_cntr.c
+++ b/prov/hook/src/hook_cntr.c
@@ -99,6 +99,7 @@ int hook_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 {
 	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
 	struct hook_cntr *mycntr;
+	struct fi_cntr_attr hattr;
 	int ret;
 
 	mycntr = calloc(1, sizeof *mycntr);
@@ -111,7 +112,11 @@ int hook_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	mycntr->cntr.fid.ops = &hook_fid_ops;
 	mycntr->cntr.ops = &hook_cntr_ops;
 
-	ret = fi_cntr_open(dom->hdomain, attr, &mycntr->hcntr,
+	hattr = *attr;
+	if (attr->wait_obj == FI_WAIT_SET)
+		hattr.wait_set = hook_to_hwait(attr->wait_set);
+
+	ret = fi_cntr_open(dom->hdomain, &hattr, &mycntr->hcntr,
 			   &mycntr->cntr.fid);
 	if (ret)
 		free(mycntr);

--- a/prov/hook/src/hook_cq.c
+++ b/prov/hook/src/hook_cq.c
@@ -113,6 +113,7 @@ int hook_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (!mycq)
 		return -FI_ENOMEM;
 
+	mycq->domain = dom;
 	mycq->cq.fid.fclass = FI_CLASS_CQ;
 	mycq->cq.fid.context = context;
 	mycq->cq.fid.ops = &hook_fid_ops;

--- a/prov/hook/src/hook_cq.c
+++ b/prov/hook/src/hook_cq.c
@@ -107,6 +107,7 @@ int hook_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 {
 	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
 	struct hook_cq *mycq;
+	struct fi_cq_attr hattr;
 	int ret;
 
 	mycq = calloc(1, sizeof *mycq);
@@ -119,7 +120,11 @@ int hook_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	mycq->cq.fid.ops = &hook_fid_ops;
 	mycq->cq.ops = &hook_cq_ops;
 
-	ret = fi_cq_open(dom->hdomain, attr, &mycq->hcq, &mycq->cq.fid);
+	hattr = *attr;
+	if (attr->wait_obj == FI_WAIT_SET)
+		hattr.wait_set = hook_to_hwait(attr->wait_set);
+
+	ret = fi_cq_open(dom->hdomain, &hattr, &mycq->hcq, &mycq->cq.fid);
 	if (ret)
 		free(mycq);
 	else

--- a/prov/hook/src/hook_domain.c
+++ b/prov/hook/src/hook_domain.c
@@ -46,6 +46,7 @@ static int hook_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	if (!mymr)
 		return -FI_ENOMEM;
 
+	mymr->domain = dom;
 	mymr->mr.fid.fclass = FI_CLASS_MR;
 	mymr->mr.fid.context = attr->context;
 	mymr->mr.fid.ops = &hook_fid_ops;
@@ -135,6 +136,7 @@ int hook_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (!dom)
 		return -FI_ENOMEM;
 
+	dom->fabric = fab;
 	dom->domain.fid.fclass = FI_CLASS_DOMAIN;
 	dom->domain.fid.context = context;
 	dom->domain.fid.ops = &hook_fid_ops;

--- a/prov/hook/src/hook_ep.c
+++ b/prov/hook/src/hook_ep.c
@@ -248,12 +248,19 @@ int hook_endpoint(struct fid_domain *domain, struct fi_info *info,
 {
 	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
 	struct hook_ep *myep;
+	struct fid *saved_fid;
 	int ret;
 
 	myep = calloc(1, sizeof *myep);
 	if (!myep)
 		return -FI_ENOMEM;
 
+	saved_fid = info->handle;
+	if (saved_fid) {
+		info->handle = hook_to_hfid(info->handle);
+		if (!info->handle)
+			info->handle = saved_fid;
+	}
 	myep->domain = dom;
 	hook_setup_ep(&myep->ep, FI_CLASS_EP, context);
 	ret = fi_endpoint(dom->hdomain, info, &myep->hep, &myep->ep.fid);
@@ -262,5 +269,6 @@ int hook_endpoint(struct fid_domain *domain, struct fi_info *info,
 	else
 		*ep = &myep->ep;
 
+	info->handle = saved_fid;
 	return ret;
 }

--- a/prov/hook/src/hook_ep.c
+++ b/prov/hook/src/hook_ep.c
@@ -110,6 +110,7 @@ int hook_scalable_ep(struct fid_domain *domain, struct fi_info *info,
 	if (!mysep)
 		return -FI_ENOMEM;
 
+	mysep->domain = dom;
 	hook_setup_ep(&mysep->ep, FI_CLASS_SEP, context);
 	ret = fi_scalable_ep(dom->hdomain, info, &mysep->hep, &mysep->ep.fid);
 	if (ret)
@@ -132,6 +133,7 @@ int hook_stx_ctx(struct fid_domain *domain,
 	if (!mystx)
 		return -FI_ENOMEM;
 
+	mystx->domain = dom;
 	mystx->stx.fid.fclass = FI_CLASS_STX_CTX;
 	mystx->stx.fid.context = context;
 	mystx->stx.fid.ops = &hook_fid_ops;
@@ -157,6 +159,7 @@ int hook_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
 	if (!srx)
 		return -FI_ENOMEM;
 
+	srx->domain = dom;
 	hook_setup_ep(&srx->ep, FI_CLASS_SRX_CTX, context);
 	ret = fi_srx_context(dom->hdomain, attr, &srx->hep, &srx->ep.fid);
 	if (ret)
@@ -179,6 +182,7 @@ static int hook_open_tx_ctx(struct fid_ep *sep, int index,
 	if (!mytx)
 		return -FI_ENOMEM;
 
+	mytx->domain = mysep->domain;
 	hook_setup_ep(&mytx->ep, FI_CLASS_TX_CTX, context);
 	ret = fi_tx_context(mysep->hep, index, attr, &mytx->hep, &mytx->ep.fid);
 	if (ret)
@@ -201,6 +205,7 @@ static int hook_open_rx_ctx(struct fid_ep *sep, int index,
 	if (!myrx)
 		return -FI_ENOMEM;
 
+	myrx->domain = mysep->domain;
 	hook_setup_ep(&myrx->ep, FI_CLASS_RX_CTX, context);
 	ret = fi_rx_context(mysep->hep, index, attr, &myrx->hep, &myrx->ep.fid);
 	if (ret)
@@ -222,6 +227,7 @@ int hook_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	if (!mypep)
 		return -FI_ENOMEM;
 
+	mypep->fabric = fab;
 	mypep->pep.fid.fclass = FI_CLASS_PEP;
 	mypep->pep.fid.context = context;
 	mypep->pep.fid.ops = &hook_fid_ops;
@@ -248,6 +254,7 @@ int hook_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (!myep)
 		return -FI_ENOMEM;
 
+	myep->domain = dom;
 	hook_setup_ep(&myep->ep, FI_CLASS_EP, context);
 	ret = fi_endpoint(dom->hdomain, info, &myep->hep, &myep->ep.fid);
 	if (ret)

--- a/prov/hook/src/hook_eq.c
+++ b/prov/hook/src/hook_eq.c
@@ -121,6 +121,7 @@ int hook_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 {
 	struct hook_fabric *fab = container_of(fabric, struct hook_fabric, fabric);
 	struct hook_eq *myeq;
+	struct fi_eq_attr hattr;
 	int ret;
 
 	myeq = calloc(1, sizeof *myeq);
@@ -133,7 +134,11 @@ int hook_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	myeq->eq.fid.ops = &hook_fid_ops;
 	myeq->eq.ops = &hook_eq_ops;
 
-	ret = fi_eq_open(fab->hfabric, attr, &myeq->heq, &myeq->eq.fid);
+	hattr = *attr;
+	if (attr->wait_obj == FI_WAIT_SET)
+		hattr.wait_set = hook_to_hwait(attr->wait_set);
+
+	ret = fi_eq_open(fab->hfabric, &hattr, &myeq->heq, &myeq->eq.fid);
 	if (ret)
 		free(myeq);
 	else

--- a/prov/hook/src/hook_eq.c
+++ b/prov/hook/src/hook_eq.c
@@ -127,6 +127,7 @@ int hook_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	if (!myeq)
 		return -FI_ENOMEM;
 
+	myeq->fabric = fab;
 	myeq->eq.fid.fclass = FI_CLASS_EQ;
 	myeq->eq.fid.context = context;
 	myeq->eq.fid.ops = &hook_fid_ops;

--- a/prov/hook/src/hook_eq.c
+++ b/prov/hook/src/hook_eq.c
@@ -36,7 +36,7 @@
 
 static int hook_eq_std_event(uint32_t event)
 {
-	return event <= FI_JOIN_COMPLETE;
+	return (event > FI_NOTIFY) && (event <= FI_JOIN_COMPLETE);
 }
 
 /*

--- a/prov/hook/src/hook_perf.c
+++ b/prov/hook/src/hook_perf.c
@@ -1,0 +1,657 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "hook_perf.h"
+#include "ofi_perf.h"
+
+
+const char *perf_counters_str[] = {
+	HOOK_FOREACH(OFI_STR)
+};
+
+
+static inline struct ofi_perfset *perf_set(struct hook_ep *ep)
+{
+	return &container_of(ep->domain->fabric, struct perf_fabric,
+			     fabric_hook)->perf_set;
+}
+
+/*
+static ssize_t
+perf_atomic_write(struct fid_ep *ep,
+		  const void *buf, size_t count, void *desc,
+		  fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		  enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_atomic(myep->hep, buf, count, desc, dest_addr,
+			addr, key, datatype, op, context);
+	return ret;
+}
+
+static ssize_t
+perf_atomic_writev(struct fid_ep *ep,
+		   const struct fi_ioc *iov, void **desc, size_t count,
+		   fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		   enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_atomicv(myep->hep, iov, desc, count, dest_addr,
+			 addr, key, datatype, op, context);
+	return ret;
+}
+
+static ssize_t
+perf_atomic_writemsg(struct fid_ep *ep,
+		     const struct fi_msg_atomic *msg, uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_atomicmsg(myep->hep, msg, flags);
+	return ret;
+}
+
+static ssize_t
+perf_atomic_inject(struct fid_ep *ep, const void *buf, size_t count,
+		   fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		   enum fi_datatype datatype, enum fi_op op)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_inject_atomic(myep->hep, buf, count, dest_addr,
+			       addr, key, datatype, op);
+	return ret;
+}
+
+static ssize_t
+perf_atomic_readwrite(struct fid_ep *ep,
+		      const void *buf, size_t count, void *desc,
+		      void *result, void *result_desc,
+		      fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		      enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_fetch_atomic(myep->hep, buf, count, desc,
+			      result, result_desc, dest_addr,
+			      addr, key, datatype, op, context);
+	return ret;
+}
+
+static ssize_t
+perf_atomic_readwritev(struct fid_ep *ep,
+		       const struct fi_ioc *iov, void **desc, size_t count,
+		       struct fi_ioc *resultv, void **result_desc,
+		       size_t result_count, fi_addr_t dest_addr,
+		       uint64_t addr, uint64_t key, enum fi_datatype datatype,
+		       enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_fetch_atomicv(myep->hep, iov, desc, count,
+			       resultv, result_desc, result_count,
+			       dest_addr, addr, key, datatype, op, context);
+	return ret;
+}
+
+static ssize_t
+perf_atomic_readwritemsg(struct fid_ep *ep, const struct fi_msg_atomic *msg,
+			 struct fi_ioc *resultv, void **result_desc,
+			 size_t result_count, uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_fetch_atomicmsg(myep->hep, msg, resultv, result_desc,
+				 result_count, flags);
+	return ret;
+}
+
+static ssize_t
+perf_atomic_compwrite(struct fid_ep *ep,
+		      const void *buf, size_t count, void *desc,
+		      const void *compare, void *compare_desc,
+		      void *result, void *result_desc,
+		      fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		      enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_compare_atomic(myep->hep, buf, count, desc,
+				compare, compare_desc, result, result_desc,
+				dest_addr, addr, key, datatype, op, context);
+	return ret;
+}
+
+static ssize_t
+perf_atomic_compwritev(struct fid_ep *ep,
+		       const struct fi_ioc *iov, void **desc, size_t count,
+		       const struct fi_ioc *comparev, void **compare_desc,
+		       size_t compare_count, struct fi_ioc *resultv,
+		       void **result_desc, size_t result_count,
+		       fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		       enum fi_datatype datatype, enum fi_op op, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_compare_atomicv(myep->hep, iov, desc, count,
+				 comparev, compare_desc, compare_count,
+				 resultv, result_desc, result_count, dest_addr,
+				 addr, key, datatype, op, context);
+	return ret;
+}
+
+static ssize_t
+perf_atomic_compwritemsg(struct fid_ep *ep,
+			 const struct fi_msg_atomic *msg,
+			 const struct fi_ioc *comparev, void **compare_desc,
+			 size_t compare_count, struct fi_ioc *resultv,
+			 void **result_desc, size_t result_count,
+			 uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_compare_atomicmsg(myep->hep, msg,
+				   comparev, compare_desc, compare_count,
+				   resultv, result_desc, result_count, flags);
+	return ret;
+}
+
+static int
+perf_atomic_writevalid(struct fid_ep *ep, enum fi_datatype datatype,
+		       enum fi_op op, size_t *count)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_atomicvalid(myep->hep, datatype, op, count);
+	return ret;
+}
+
+static int
+perf_atomic_readwritevalid(struct fid_ep *ep, enum fi_datatype datatype,
+			   enum fi_op op, size_t *count)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_fetch_atomicvalid(myep->hep, datatype, op, count);
+	return ret;
+}
+
+static int
+perf_atomic_compwritevalid(struct fid_ep *ep, enum fi_datatype datatype,
+			   enum fi_op op, size_t *count)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ret = fi_compare_atomicvalid(myep->hep, datatype, op, count);
+	return ret;
+}
+
+struct fi_ops_atomic perf_atomic_ops = {
+	.size = sizeof(struct fi_ops_atomic),
+	.write = perf_atomic_write,
+	.writev = perf_atomic_writev,
+	.writemsg = perf_atomic_writemsg,
+	.inject = perf_atomic_inject,
+	.readwrite = perf_atomic_readwrite,
+	.readwritev = perf_atomic_readwritev,
+	.readwritemsg = perf_atomic_readwritemsg,
+	.compwrite = perf_atomic_compwrite,
+	.compwritev = perf_atomic_compwritev,
+	.compwritemsg = perf_atomic_compwritemsg,
+	.writevalid = perf_atomic_writevalid,
+	.readwritevalid = perf_atomic_readwritevalid,
+	.compwritevalid = perf_atomic_compwritevalid,
+};
+*/
+
+
+static ssize_t
+perf_msg_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+	      fi_addr_t src_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_recv);
+	ret = fi_recv(myep->hep, buf, len, desc, src_addr, context);
+	ofi_perfset_end(perf_set(myep), perf_recv);
+	return ret;
+}
+
+static ssize_t
+perf_msg_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+	       size_t count, fi_addr_t src_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_recvv);
+	ret = fi_recvv(myep->hep, iov, desc, count, src_addr, context);
+	ofi_perfset_end(perf_set(myep), perf_recvv);
+	return ret;
+}
+
+static ssize_t
+perf_msg_recvmsg(struct fid_ep *ep, const struct fi_msg *msg, uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_recvmsg);
+	ret = fi_recvmsg(myep->hep, msg, flags);
+	ofi_perfset_end(perf_set(myep), perf_recvmsg);
+	return ret;
+}
+
+static ssize_t
+perf_msg_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+	      fi_addr_t dest_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_send);
+	ret = fi_send(myep->hep, buf, len, desc, dest_addr, context);
+	ofi_perfset_end(perf_set(myep), perf_send);
+	return ret;
+}
+
+static ssize_t
+perf_msg_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+	       size_t count, fi_addr_t dest_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_sendv);
+	ret = fi_sendv(myep->hep, iov, desc, count, dest_addr, context);
+	ofi_perfset_end(perf_set(myep), perf_sendv);
+	return ret;
+}
+
+static ssize_t
+perf_msg_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
+		 uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_sendmsg);
+	ret = fi_sendmsg(myep->hep, msg, flags);
+	ofi_perfset_end(perf_set(myep), perf_sendmsg);
+	return ret;
+}
+
+static ssize_t
+perf_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
+		fi_addr_t dest_addr)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_inject);
+	ret = fi_inject(myep->hep, buf, len, dest_addr);
+	ofi_perfset_end(perf_set(myep), perf_inject);
+	return ret;
+}
+
+static ssize_t
+perf_msg_senddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		  uint64_t data, fi_addr_t dest_addr, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_senddata);
+	ret = fi_senddata(myep->hep, buf, len, desc, data, dest_addr, context);
+	ofi_perfset_end(perf_set(myep), perf_senddata);
+	return ret;
+}
+
+static ssize_t
+perf_msg_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+		    uint64_t data, fi_addr_t dest_addr)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_injectdata);
+	ret = fi_injectdata(myep->hep, buf, len, data, dest_addr);
+	ofi_perfset_end(perf_set(myep), perf_injectdata);
+	return ret;
+}
+
+struct fi_ops_msg perf_msg_ops = {
+	.size = sizeof(struct fi_ops_msg),
+	.recv = perf_msg_recv,
+	.recvv = perf_msg_recvv,
+	.recvmsg = perf_msg_recvmsg,
+	.send = perf_msg_send,
+	.sendv = perf_msg_sendv,
+	.sendmsg = perf_msg_sendmsg,
+	.inject = perf_msg_inject,
+	.senddata = perf_msg_senddata,
+	.injectdata = perf_msg_injectdata,
+};
+
+
+static ssize_t
+perf_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
+	      fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_read);
+	ret = fi_read(myep->hep, buf, len, desc, src_addr, addr, key, context);
+	ofi_perfset_end(perf_set(myep), perf_read);
+	return ret;
+}
+
+static ssize_t
+perf_rma_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+	       size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
+	       void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_readv);
+	ret = fi_readv(myep->hep, iov, desc, count, src_addr,
+		       addr, key, context);
+	ofi_perfset_end(perf_set(myep), perf_readv);
+	return ret;
+}
+
+static ssize_t
+perf_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+		 uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_readmsg);
+	ret = fi_readmsg(myep->hep, msg, flags);
+	ofi_perfset_end(perf_set(myep), perf_readmsg);
+	return ret;
+}
+
+static ssize_t
+perf_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+	       fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_write);
+	ret = fi_write(myep->hep, buf, len, desc, dest_addr,
+		       addr, key, context);
+	ofi_perfset_end(perf_set(myep), perf_write);
+	return ret;
+}
+
+static ssize_t
+perf_rma_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+		void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_writev);
+	ret = fi_writev(myep->hep, iov, desc, count, dest_addr,
+			addr, key, context);
+	ofi_perfset_end(perf_set(myep), perf_writev);
+	return ret;
+}
+
+static ssize_t
+perf_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
+		  uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_writemsg);
+	ret = fi_writemsg(myep->hep, msg, flags);
+	ofi_perfset_end(perf_set(myep), perf_writemsg);
+	return ret;
+}
+
+static ssize_t
+perf_rma_inject(struct fid_ep *ep, const void *buf, size_t len,
+		fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_inject_write);
+	ret = fi_inject_write(myep->hep, buf, len, dest_addr, addr, key);
+	ofi_perfset_end(perf_set(myep), perf_inject_write);
+	return ret;
+}
+
+static ssize_t
+perf_rma_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		   uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+		   uint64_t key, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_writedata);
+	ret = fi_writedata(myep->hep, buf, len, desc, data,
+			   dest_addr, addr, key, context);
+	ofi_perfset_end(perf_set(myep), perf_writedata);
+	return ret;
+}
+
+static ssize_t
+perf_rma_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+		    uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+		    uint64_t key)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_inject_writedata);
+	ret = fi_inject_writedata(myep->hep, buf, len, data, dest_addr,
+				  addr, key);
+	ofi_perfset_end(perf_set(myep), perf_inject_writedata);
+	return ret;
+}
+
+struct fi_ops_rma perf_rma_ops = {
+	.size = sizeof(struct fi_ops_rma),
+	.read = perf_rma_read,
+	.readv = perf_rma_readv,
+	.readmsg = perf_rma_readmsg,
+	.write = perf_rma_write,
+	.writev = perf_rma_writev,
+	.writemsg = perf_rma_writemsg,
+	.inject = perf_rma_inject,
+	.writedata = perf_rma_writedata,
+	.injectdata = perf_rma_injectdata,
+};
+
+
+static ssize_t
+perf_tagged_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
+		 fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
+		 void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_trecv);
+	ret = fi_trecv(myep->hep, buf, len, desc, src_addr,
+		       tag, ignore, context);
+	ofi_perfset_end(perf_set(myep), perf_trecv);
+	return ret;
+}
+
+static ssize_t
+perf_tagged_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		  size_t count, fi_addr_t src_addr, uint64_t tag,
+		  uint64_t ignore, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_trecvv);
+	ret = fi_trecvv(myep->hep, iov, desc, count, src_addr,
+			tag, ignore, context);
+	ofi_perfset_end(perf_set(myep), perf_trecvv);
+	return ret;
+}
+
+static ssize_t
+perf_tagged_recvmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+		    uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_trecvmsg);
+	ret = fi_trecvmsg(myep->hep, msg, flags);
+	ofi_perfset_end(perf_set(myep), perf_trecvmsg);
+	return ret;
+}
+
+static ssize_t
+perf_tagged_send(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		 fi_addr_t dest_addr, uint64_t tag, void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_tsend);
+	ret = fi_tsend(myep->hep, buf, len, desc, dest_addr, tag, context);
+	ofi_perfset_end(perf_set(myep), perf_tsend);
+	return ret;
+}
+
+static ssize_t
+perf_tagged_sendv(struct fid_ep *ep, const struct iovec *iov, void **desc,
+		  size_t count, fi_addr_t dest_addr, uint64_t tag,
+		  void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_tsendv);
+	ret = fi_tsendv(myep->hep, iov, desc, count, dest_addr, tag, context);
+	ofi_perfset_end(perf_set(myep), perf_tsendv);
+	return ret;
+}
+
+static ssize_t
+perf_tagged_sendmsg(struct fid_ep *ep, const struct fi_msg_tagged *msg,
+		    uint64_t flags)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_tsendmsg);
+	ret = fi_tsendmsg(myep->hep, msg, flags);
+	ofi_perfset_end(perf_set(myep), perf_tsendmsg);
+	return ret;
+}
+
+static ssize_t
+perf_tagged_inject(struct fid_ep *ep, const void *buf, size_t len,
+		   fi_addr_t dest_addr, uint64_t tag)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_tinject);
+	ret = fi_tinject(myep->hep, buf, len, dest_addr, tag);
+	ofi_perfset_end(perf_set(myep), perf_tinject);
+	return ret;
+}
+
+static ssize_t
+perf_tagged_senddata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
+		     uint64_t data, fi_addr_t dest_addr, uint64_t tag,
+		     void *context)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_tsenddata);
+	ret = fi_tsenddata(myep->hep, buf, len, desc, data,
+			   dest_addr, tag, context);
+	ofi_perfset_end(perf_set(myep), perf_tsenddata);
+	return ret;
+}
+
+static ssize_t
+perf_tagged_injectdata(struct fid_ep *ep, const void *buf, size_t len,
+		       uint64_t data, fi_addr_t dest_addr, uint64_t tag)
+{
+	struct hook_ep *myep = container_of(ep, struct hook_ep, ep);
+	ssize_t ret;
+
+	ofi_perfset_start(perf_set(myep), perf_tinjectdata);
+	ret = fi_tinjectdata(myep->hep, buf, len, data, dest_addr, tag);
+	ofi_perfset_end(perf_set(myep), perf_tinjectdata);
+	return ret;
+}
+
+struct fi_ops_tagged perf_tagged_ops = {
+	.size = sizeof(struct fi_ops_tagged),
+	.recv = perf_tagged_recv,
+	.recvv = perf_tagged_recvv,
+	.recvmsg = perf_tagged_recvmsg,
+	.send = perf_tagged_send,
+	.sendv = perf_tagged_sendv,
+	.sendmsg = perf_tagged_sendmsg,
+	.inject = perf_tagged_inject,
+	.senddata = perf_tagged_senddata,
+	.injectdata = perf_tagged_injectdata,
+};

--- a/prov/hook/src/hook_perf.h
+++ b/prov/hook/src/hook_perf.h
@@ -43,6 +43,9 @@ struct perf_fabric {
 	struct ofi_perfset perf_set;
 };
 
+int hook_perf_create(struct hook_fabric **fabric);
+void hook_perf_destroy(struct hook_fabric *fabric);
+
 
 #define HOOK_FOREACH(DECL)		\
 	DECL(perf_recv),		\

--- a/prov/hook/src/hook_perf.h
+++ b/prov/hook/src/hook_perf.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL); Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _HOOK_PERF_H_
+#define _HOOK_PERF_H_
+
+#include "hook.h"
+#include "ofi.h"
+#include "ofi_perf.h"
+
+
+struct perf_fabric {
+	struct hook_fabric fabric_hook;
+	struct ofi_perfset perf_set;
+};
+
+
+#define HOOK_FOREACH(DECL)		\
+	DECL(perf_recv),		\
+	DECL(perf_recvv),		\
+	DECL(perf_recvmsg),		\
+	DECL(perf_send),		\
+	DECL(perf_sendv),		\
+	DECL(perf_sendmsg),		\
+	DECL(perf_inject),		\
+	DECL(perf_senddata),		\
+	DECL(perf_injectdata),		\
+	DECL(perf_read),		\
+	DECL(perf_readv),		\
+	DECL(perf_readmsg),		\
+	DECL(perf_write),		\
+	DECL(perf_writev),		\
+	DECL(perf_writemsg),		\
+	DECL(perf_inject_write),	\
+	DECL(perf_writedata),		\
+	DECL(perf_inject_writedata),	\
+	DECL(perf_trecv),		\
+	DECL(perf_trecvv),		\
+	DECL(perf_trecvmsg),		\
+	DECL(perf_tsend),		\
+	DECL(perf_tsendv),		\
+	DECL(perf_tsendmsg),		\
+	DECL(perf_tinject),		\
+	DECL(perf_tsenddata),		\
+	DECL(perf_tinjectdata),		\
+	DECL(perf_cq_read),		\
+	DECL(perf_cq_readfrom),		\
+	DECL(perf_cntr_read),		\
+	DECL(perf_cntr_add),		\
+	DECL(perf_cntr_set),		\
+	DECL(perf_size)
+
+enum perf_counters {
+	HOOK_FOREACH(OFI_ENUM_VAL)
+};
+
+extern const char *perf_counters_str[];
+
+extern struct fi_ops_msg perf_msg_ops;
+extern struct fi_ops_rma perf_rma_ops;
+extern struct fi_ops_tagged perf_tagged_ops;
+
+
+#endif /* _HOOK_PERF_H_ */

--- a/prov/hook/src/hook_wait.c
+++ b/prov/hook/src/hook_wait.c
@@ -83,6 +83,7 @@ int hook_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 	if (!poll)
 		return -FI_ENOMEM;
 
+	poll->domain = dom;
 	poll->poll.fid.fclass = FI_CLASS_POLL;
 	poll->poll.fid.ops = &hook_fid_ops;
 	poll->poll.ops = &hook_poll_ops;
@@ -139,6 +140,7 @@ int hook_wait_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 	if (!wait)
 		return -FI_ENOMEM;
 
+	wait->fabric = fab;
 	wait->wait.fid.fclass = FI_CLASS_WAIT;
 	wait->wait.fid.ops = &hook_fid_ops;
 	wait->wait.ops = &hook_wait_ops;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -380,6 +380,7 @@ void fi_ini(void)
 	ofi_osd_init();
 	ofi_pmem_init();
 	ofi_perf_init();
+	ofi_hook_init();
 
 	fi_param_define(NULL, "provider", FI_PARAM_STRING,
 			"Only use specified provider (default: all available)");
@@ -887,6 +888,8 @@ int DEFAULT_SYMVER_PRE(fi_fabric)(struct fi_fabric_attr *attr,
 			(*fabric)->api_version = attr->api_version;
 		FI_INFO(&core_prov, FI_LOG_CORE, "Opened fabric: %s\n",
 			attr->name);
+
+		ofi_hook_install(*fabric, fabric);
 	}
 
 	return ret;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -44,6 +44,7 @@
 #include "ofi_util.h"
 #include "ofi.h"
 #include "ofi_prov.h"
+#include "ofi_perf.h"
 
 #ifdef HAVE_LIBDL
 #include <dlfcn.h>
@@ -378,6 +379,7 @@ void fi_ini(void)
 	fi_log_init();
 	ofi_osd_init();
 	ofi_pmem_init();
+	ofi_perf_init();
 
 	fi_param_define(NULL, "provider", FI_PARAM_STRING,
 			"Only use specified provider (default: all available)");

--- a/src/perf.c
+++ b/src/perf.c
@@ -103,7 +103,7 @@ void ofi_perfset_log(struct ofi_perfset *set, const char *names[])
 		if (!set->data[i].sum)
 			continue;
 
-		FI_INFO(set->prov, FI_LOG_CORE, "PERF (%s) "
+		FI_TRACE(set->prov, FI_LOG_CORE, "PERF (%s) "
 			"events=%" PRIu64 " avg=%g\n",
 			names && names[i] ? names[i] : "unknown",
 			set->data[i].events,

--- a/src/perf.c
+++ b/src/perf.c
@@ -42,6 +42,28 @@
 #include <rdma/providers/fi_log.h>
 
 
+enum ofi_perf_domain	perf_domain = OFI_PMU_CPU;
+uint32_t		perf_cntr = OFI_PMC_CPU_INSTR;
+uint32_t		perf_flags;
+
+
+void ofi_perf_init(void)
+{
+	char *param_val = NULL;
+
+	fi_param_define(NULL, "perf_cntr", FI_PARAM_STRING,
+			"Performance counter to analyze (default: cpu_instr). "
+			"Options: cpu_instr, cpu_cycles.");
+	fi_param_get_str(NULL, "perf_cntr", &param_val);
+	if (!param_val)
+		return;
+
+	if (!strcasecmp(param_val, "cpu_cycles")) {
+		perf_domain = OFI_PMU_CPU;
+		perf_cntr = OFI_PMC_CPU_CYCLES;
+	}
+}
+
 int ofi_perfset_create(const struct fi_provider *prov,
 		       struct ofi_perfset *set, size_t size,
 		       enum ofi_perf_domain domain, uint32_t cntr_id,

--- a/src/perf.c
+++ b/src/perf.c
@@ -100,7 +100,7 @@ void ofi_perfset_log(struct ofi_perfset *set, const char *names[])
 	size_t i;
 
 	for (i = 0; i < set->size; i++) {
-		if (!set->data[i].sum)
+		if (!set->data[i].events)
 			continue;
 
 		FI_TRACE(set->prov, FI_LOG_CORE, "PERF (%s) "


### PR DESCRIPTION
This series expands the hooking provider and enables it.  It allows the ability to hook all calls to a provider in order to capture data or modify the calls.  It adds the ability to capture performance data (from the PMU) for all msg, rma, and tagged operations.  Hooking is controlled via environment variables (updates to the man pages to document them are still needed).

For now, performance data is limited to CPU cycle or instruction counts.  Future additions can expand this.

Hooking works with most fabtests.  However, hooking will not work with triggered operations of any kind.

There are a couple of additional enhancements that I need to make, but this series is already getting long and should be good enough to continue building off of.