### PR TITLE
prov/rxm: Updates structures and add separate pool for SAR

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -212,7 +212,8 @@ enum rxm_buf_pool_type {
 	RXM_BUF_POOL_TX_TAGGED,
 	RXM_BUF_POOL_TX_ACK,
 	RXM_BUF_POOL_TX_LMT,
-	RXM_BUF_POOL_TX_END	= RXM_BUF_POOL_TX_LMT,
+	RXM_BUF_POOL_TX_SAR,
+	RXM_BUF_POOL_TX_END	= RXM_BUF_POOL_TX_SAR,
 	RXM_BUF_POOL_RMA,
 	RXM_BUF_POOL_MAX,
 };
@@ -584,7 +585,8 @@ rxm_tx_buf_get(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
 	assert((type == RXM_BUF_POOL_TX_MSG) ||
 	       (type == RXM_BUF_POOL_TX_TAGGED) ||
 	       (type == RXM_BUF_POOL_TX_ACK) ||
-	       (type == RXM_BUF_POOL_TX_LMT));
+	       (type == RXM_BUF_POOL_TX_LMT) ||
+	       (type == RXM_BUF_POOL_TX_SAR));
 	return (struct rxm_tx_buf *)rxm_buf_get(&rxm_ep->buf_pools[type]);
 }
 
@@ -594,7 +596,8 @@ rxm_tx_buf_release(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 	assert((tx_buf->type == RXM_BUF_POOL_TX_MSG) ||
 	       (tx_buf->type == RXM_BUF_POOL_TX_TAGGED) ||
 	       (tx_buf->type == RXM_BUF_POOL_TX_ACK) ||
-	       (tx_buf->type == RXM_BUF_POOL_TX_LMT));
+	       (tx_buf->type == RXM_BUF_POOL_TX_LMT) ||
+	       (tx_buf->type == RXM_BUF_POOL_TX_SAR));
 	assert((tx_buf->pkt.ctrl_hdr.type == ofi_ctrl_data) ||
 	       (tx_buf->pkt.ctrl_hdr.type == ofi_ctrl_large_data) ||
 	       (tx_buf->pkt.ctrl_hdr.type == ofi_ctrl_ack));

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -159,6 +159,9 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			case RXM_BUF_POOL_TX_LMT:
 				tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_large_data;
 				break;
+			case RXM_BUF_POOL_TX_SAR:
+				tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_seg_data;
+				break;
 			default:
 				assert(0);
 				break;


### PR DESCRIPTION
This PR does the following:
- prov/rxm: Update TX/RX entry for SAR protocol needs
The commit applies the following updates to structures:
- TX entry with new fields that are related to SAR protocol:
  `segs_left` - current remained (not completed) count of segments
  `msg_id` - message identifier
  `in_flight_tx_buf_list` - the list of TX buffers tht contains buffer
  that aren't completed yet, but already sent
  `rxm_iov` - I/O vectors
  `iov_offset` - current offset across all I/O vectors
- RX entry wth new fields that are related to SAR protocol:
  `total_recv_len` - current total recv size
  `msg_id` - value that is used to match correct RX buffers to the
  RX entry
- prov/rxm: Use separate buffer pool for SAR protocol
Added necessary updates to use separate buffer pool for SAR protocol needs