### PR TITLE
prov/verbs: Use utility CQ for implementation of verbs CQ

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -347,8 +347,7 @@ struct fi_ibv_wce {
 };
 
 struct fi_ibv_cq {
-	struct fid_cq		cq_fid;
-	struct fi_ibv_domain	*domain;
+	struct util_cq		util_cq;
 	struct ibv_comp_channel	*channel;
 	struct ibv_cq		*cq;
 	size_t			entry_size;
@@ -362,8 +361,6 @@ struct fi_ibv_cq {
 	fi_ibv_trywait_func	trywait;
 	ofi_atomic32_t		nevents;
 	struct util_buf_pool	*wce_pool;
-	ofi_fastlock_acquire_t	cq_fastlock_acquire;
-	ofi_fastlock_release_t	cq_fastlock_release;
 };
 
 struct fi_ibv_rdm_request;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -615,7 +615,7 @@ static int fi_ibv_trywait(struct fid_fabric *fabric, struct fid **fids, int coun
 	for (i = 0; i < count; i++) {
 		switch (fids[i]->fclass) {
 		case FI_CLASS_CQ:
-			cq = container_of(fids[i], struct fi_ibv_cq, cq_fid.fid);
+			cq = container_of(fids[i], struct fi_ibv_cq, util_cq.cq_fid.fid);
 			ret = cq->trywait(fids[i]);
 			if (ret)
 				return ret;


### PR DESCRIPTION
This patch enables usage of utility CQ for verbs provider.
This is used to control flags, thread level, references.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>