### PR TITLE
util/mr_cache, prov/verbs: Implement new MR caching path w/o merging regions (for v1.6.x)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@ v1.6.0, Wed Mar 14, 2018
 -- Add const to fi_getinfo() hints parameter
 -- Improve use of epoll for better scalability
 -- Fixes to generic name service
+-- Implemented support of MR caching without merging of regions
 
 ## GNI
 -- Fix a problem with the GNI waitset implementation

--- a/include/ofi_iov.h
+++ b/include/ofi_iov.h
@@ -118,6 +118,20 @@ ofi_iov_right(const struct iovec *iov1, const struct iovec *iov2)
 }
 
 static inline bool
+ofi_iov_shifted_left(const struct iovec *iov1, const struct iovec *iov2)
+{
+	return ((iov1->iov_base < iov2->iov_base) &&
+		(ofi_iov_end(iov1) < ofi_iov_end(iov2)));
+}
+
+static inline bool
+ofi_iov_shifted_right(const struct iovec *iov1, const struct iovec *iov2)
+{
+	return ((iov1->iov_base > iov2->iov_base) &&
+		(ofi_iov_end(iov1) > ofi_iov_end(iov2)));
+}
+
+static inline bool
 ofi_iov_within(const struct iovec *iov1, const struct iovec *iov2)
 {
 	return (iov1->iov_base >= iov2->iov_base) &&

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -186,6 +186,7 @@ struct ofi_mr_cache {
 	struct ofi_notification_queue	nq;
 	size_t				max_cached_cnt;
 	size_t				max_cached_size;
+	int				merge_regions;
 	size_t				entry_data_size;
 
 	RbtHandle			mr_tree;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -38,6 +38,17 @@
 #include <ofi_mr.h>
 #include <ofi_list.h>
 
+static int util_mr_find_within(void *a, void *b)
+{
+	struct iovec *iov1 = a, *iov2 = b;
+
+	if (ofi_iov_shifted_left(iov1, iov2))
+		return -1;
+	else if (ofi_iov_shifted_right(iov1, iov2))
+		return 1;
+	else
+		return 0;
+}
 
 static int util_mr_find_overlap(void *a, void *b)
 {
@@ -252,6 +263,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 
 	rbtKeyValue(cache->mr_tree, iter, (void **) &iov, (void **) entry);
 
+	/* This branch is always false if the merging entries wasn't requested */
 	if (!ofi_iov_within(attr->mr_iov, iov))
 		return util_mr_cache_merge(cache, attr, iter, entry);
 
@@ -292,7 +304,9 @@ int ofi_mr_cache_init(struct util_domain *domain, struct ofi_mem_monitor *monito
 {
 	assert(cache->add_region && cache->delete_region);
 
-	cache->mr_tree = rbtNew(util_mr_find_overlap);
+	cache->mr_tree = rbtNew(cache->merge_regions ?
+				util_mr_find_overlap :
+				util_mr_find_within);
 	if (!cache->mr_tree)
 		return -FI_ENOMEM;
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -60,6 +60,7 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.mr_cache_enable	= 0,
 	.mr_max_cached_cnt	= 4096,
 	.mr_max_cached_size	= ULONG_MAX,
+	.mr_cache_merge_regions	= 0,
 
 	.rdm			= {
 		.buffer_num		= FI_IBV_RDM_TAGGED_DFLT_BUFFER_NUM,
@@ -589,13 +590,15 @@ static int fi_ibv_read_params(void)
 			   "Invalid value of iface\n");
 		return -FI_EINVAL;
 	}
-	if (fi_ibv_get_param_bool("mr_cache_enable", "Enable Memory Region caching",
+	if (fi_ibv_get_param_bool("mr_cache_enable",
+				  "Enable Memory Region caching",
 				  &fi_ibv_gl_data.mr_cache_enable)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of mr_cache_enable\n");
 		return -FI_EINVAL;
 	}
-	if (fi_ibv_get_param_int("mr_max_cached_cnt", "Maximum number of cache entries",
+	if (fi_ibv_get_param_int("mr_max_cached_cnt",
+				 "Maximum number of cache entries",
 				 &fi_ibv_gl_data.mr_max_cached_cnt) ||
 	    (fi_ibv_gl_data.mr_max_cached_cnt < 0)) {
 		VERBS_WARN(FI_LOG_CORE,
@@ -607,6 +610,14 @@ static int fi_ibv_read_params(void)
 				    &fi_ibv_gl_data.mr_max_cached_size)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of mr_max_cached_size\n");
+		return -FI_EINVAL;
+	}
+	if (fi_ibv_get_param_bool("mr_cache_merge_regions",
+				  "Enable the merging of MR regions for MR "
+				  "caching functionality",
+				  &fi_ibv_gl_data.mr_cache_merge_regions)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid value of mr_cache_merge_regions\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -186,6 +186,7 @@ extern struct fi_ibv_gl_data {
 	int	mr_cache_enable;
 	int	mr_max_cached_cnt;
 	size_t	mr_max_cached_size;
+	int	mr_cache_merge_regions;
 
 	struct {
 		int	buffer_num;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -479,6 +479,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 
 		_domain->cache.max_cached_cnt = fi_ibv_gl_data.mr_max_cached_cnt;
 		_domain->cache.max_cached_size = fi_ibv_gl_data.mr_max_cached_size;
+		_domain->cache.merge_regions = fi_ibv_gl_data.mr_cache_merge_regions;
 		_domain->cache.entry_data_size = sizeof(struct fi_ibv_mem_desc);
 		_domain->cache.add_region = fi_ibv_mr_cache_entry_reg;
 		_domain->cache.delete_region = fi_ibv_mr_cache_entry_dereg;


### PR DESCRIPTION
This is back-port of #3974 

This fixes some boundary cases for MPI ring-based algorithm on large data