### PR TITLE
prov/psm2: Avoid polling PSM2 in a nested loop

### DIFF
--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -398,15 +398,14 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 	int err;
 	int context_type;
 
-	while (read_more) {
-
+	{
 		PSMX2_POLL_COMPLETION(trx_ctxt, status, err);
 
 		if (err == PSM2_OK) {
 			fi_context = PSMX2_STATUS_CONTEXT(status);
 			if (OFI_UNLIKELY(!fi_context)) {
 				PSMX2_FREE_COMPLETION(trx_ctxt, status);
-				continue;
+				return read_count;
 			}
 
 			ep = PSMX2_CTXT_EP(fi_context);
@@ -459,7 +458,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 						  !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					continue;
+					return read_count;
 				}
 				if (ep->recv_cq) {
 					op_context = fi_context;
@@ -490,7 +489,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					continue;
+					return read_count;
 				}
 				if (ep->recv_cq) {
 					op_context = fi_context;
@@ -522,7 +521,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					continue;
+					return read_count;
 				}
 				PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 				if (OFI_UNLIKELY(ep->recv_cq && PSMX2_STATUS_ERROR(status))) {
@@ -555,7 +554,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					continue;
+					return read_count;
 				}
 				PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 				if (OFI_UNLIKELY(ep->recv_cq && PSMX2_STATUS_ERROR(status))) {
@@ -637,7 +636,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 							am_req->error = psmx2_errno(PSMX2_STATUS_ERROR(status));
 						/* Request to be freed in AM handler */
 						PSMX2_FREE_COMPLETION(trx_ctxt, status);
-						continue;
+						return read_count;
 					}
 				}
 				op_context = PSMX2_CTXT_USER(fi_context);
@@ -673,7 +672,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 							am_req->error = psmx2_errno(PSMX2_STATUS_ERROR(status));
 						/* Request to be freed in AM handler */
 						PSMX2_FREE_COMPLETION(trx_ctxt, status);
-						continue;
+						return read_count;
 					}
 				}
 				op_context = PSMX2_CTXT_USER(fi_context);
@@ -701,7 +700,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 				    !psmx2_handle_sendv_req(ep, status, 1))) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					continue;
+					return read_count;
 				}
 				multi_recv_req = PSMX2_CTXT_USER(fi_context);
 				if (ep->recv_cq) {
@@ -804,7 +803,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				if (sendv_req->iov_protocol == PSMX2_IOV_PROTO_MULTI &&
 				    sendv_req->iov_done < sendv_req->iov_info.count + 1) {
 					sendv_req->status = status;
-					continue;
+					return read_count;
 				}
 				if (ep->send_cq && !sendv_req->no_completion) {
 					op_context = sendv_req->user_context;
@@ -833,7 +832,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				sendv_req->iov_done++;
 				PSMX2_FREE_COMPLETION(trx_ctxt, status);
 				if (sendv_req->iov_done < sendv_req->iov_info.count + 1)
-					continue;
+					return read_count;
 				status = sendv_req->status;
 				if (ep->send_cq && !sendv_req->no_completion) {
 					op_context = sendv_req->user_context;
@@ -866,7 +865,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					sendv_rep->error_code = PSMX2_STATUS_ERROR(status);
 				if (sendv_rep->iov_done < sendv_rep->iov_info.count) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					continue;
+					return read_count;
 				}
 
 				PSMX2_STATUS_TAG(status) = sendv_rep->tag;


### PR DESCRIPTION
In a typical usage model applications call fi_cq_read in a loop to poll
completions. This would put PSM2 polling action inside a nested loop
because PSM2 is polled in a loop inside fi_cq_read. Such nested polling
has shown negative performance impact on some platforms. Remove the loop
inside fi_cq_read to avoid the issue.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>