### PR TITLE
prov/util: Use variable to control AV addr size (for v.1.6.x)

### DIFF
--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -550,10 +550,18 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 			const struct util_av_attr *util_attr)
 {
 	int *entry, i, ret = 0;
+	size_t max_count;
+
+	if (attr->count) {
+		max_count = attr->count;
+	} else {
+		if (fi_param_get_size_t(NULL, "universe_size", &max_count))
+			max_count = UTIL_DEFAULT_AV_SIZE;
+	}
 
 	ofi_atomic_initialize32(&av->ref, 0);
 	fastlock_init(&av->lock);
-	av->count = attr->count ? attr->count : UTIL_DEFAULT_AV_SIZE;
+	av->count = max_count ? max_count : UTIL_DEFAULT_AV_SIZE;
 	av->count = roundup_power_of_two(av->count);
 	av->addrlen = util_attr->addrlen;
 	av->flags = util_attr->flags | attr->flags;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -452,6 +452,11 @@ void fi_ini(void)
 			" (default: no). Setting this to yes could improve"
 			" performance at the expense of making fork() potentially"
 			" unsafe");
+	fi_param_define(NULL, "universe_size", FI_PARAM_SIZE_T,
+			"Defines the maximum number of processes that will be"
+			" used by distribute OFI application. The provider uses"
+			" this to optimize resource allocations"
+			" (default: OFI service specific)");
 	fi_param_get_str(NULL, "provider", &param_val);
 	ofi_create_filter(&prov_filter, param_val);
 


### PR DESCRIPTION
This is a back-port of #4067 for v1.6.x branch

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>