### PR TITLE
prov/psm2: Make completion of iov send case the same as non iov case

### DIFF
--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -830,9 +830,10 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 			case PSMX2_IOV_SEND_CONTEXT:
 				sendv_req = PSMX2_CTXT_USER(fi_context);
 				sendv_req->iov_done++;
-				PSMX2_FREE_COMPLETION(trx_ctxt, status);
-				if (sendv_req->iov_done < sendv_req->iov_info.count + 1)
-					return read_count;
+                                if (sendv_req->iov_done < sendv_req->iov_info.count + 1) {
+                                        sendv_req->status = status;
+                                        return read_count;
+                                }
 				status = sendv_req->status;
 				if (ep->send_cq && !sendv_req->no_completion) {
 					op_context = sendv_req->user_context;


### PR DESCRIPTION
Completion of `iov send` is assumed to work consistently as `non iov send`. 