### PR TITLE
prov/psm2: Fix incorrect completion event for iov send

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -442,7 +442,7 @@ struct psmx2_iov_info {
 struct psmx2_sendv_request {
 	struct fi_context fi_context;
 	struct fi_context fi_context_iov;
-	PSMX2_STATUS_TYPE *status;
+	PSMX2_STATUS_DECL(status);
 	void *user_context;
 	int iov_protocol;
 	int no_completion;

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -398,6 +398,8 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 	int err;
 	int context_type;
 
+	PSMX2_STATUS_INIT(status);
+
 	{
 		PSMX2_POLL_COMPLETION(trx_ctxt, status, err);
 
@@ -802,7 +804,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				sendv_req->iov_done++;
 				if (sendv_req->iov_protocol == PSMX2_IOV_PROTO_MULTI &&
 				    sendv_req->iov_done < sendv_req->iov_info.count + 1) {
-					sendv_req->status = status;
+					PSMX2_STATUS_SAVE(status, sendv_req->status);
 					return read_count;
 				}
 				if (ep->send_cq && !sendv_req->no_completion) {

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -340,6 +340,8 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 	if (!req)
 		return -FI_ENOMEM;
 
+	PSMX2_STATUS_INIT(req->status);
+
 	if (total_len <= PSMX2_IOV_BUF_SIZE) {
 		req->iov_protocol = PSMX2_IOV_PROTO_PACK;
 		p = req->buf;

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -952,6 +952,8 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 	if (!req)
 		return -FI_ENOMEM;
 
+	PSMX2_STATUS_INIT(req->status);
+
 	if (total_len <= PSMX2_IOV_BUF_SIZE) {
 		req->iov_protocol = PSMX2_IOV_PROTO_PACK;
 		p = req->buf;

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -63,6 +63,8 @@
 
 #define PSMX2_STATUS_TYPE	struct psm2_mq_req
 #define PSMX2_STATUS_DECL(s)	struct psm2_mq_req *s
+#define PSMX2_STATUS_INIT(s)
+#define PSMX2_STATUS_SAVE(s,t)	do { t = s; } while (0)
 #define PSMX2_STATUS_ERROR(s)	((s)->error_code)
 #define PSMX2_STATUS_TAG(s)	((s)->tag)
 #define PSMX2_STATUS_RCVLEN(s)	((s)->recv_msglen)
@@ -86,7 +88,9 @@
 #define PSMX2_USE_REQ_CONTEXT	0
 
 #define PSMX2_STATUS_TYPE	psm2_mq_status2_t
-#define PSMX2_STATUS_DECL(s)	psm2_mq_status2_t s##_priv, *s=&s##_priv
+#define PSMX2_STATUS_DECL(s)	psm2_mq_status2_t s##_priv, *s
+#define PSMX2_STATUS_INIT(s)	do { s = &s##_priv; } while (0)
+#define PSMX2_STATUS_SAVE(s,t)	do { *(t) = *(s); } while (0)
 #define PSMX2_STATUS_ERROR(s)	((s)->error_code)
 #define PSMX2_STATUS_TAG(s)	((s)->msg_tag)
 #define PSMX2_STATUS_RCVLEN(s)	((s)->nbytes)


### PR DESCRIPTION
A pointer saved for later use to generate iov send completion event could
refer to a variable on the stack and thus could lead to data corruption if
accessed across different invocations of the enclosing function.

Fix by saving the content instead if the pointer refers to a stack variable.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>