### PR TITLE
prov/verbs: Fix CQ progress engine initialization

### DIFF
--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -515,6 +515,12 @@ static struct fi_ops fi_ibv_cq_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
+static void fi_ibv_util_cq_progress_noop(struct util_cq *cq)
+{
+	/* This routine shouldn't be called */
+	assert(0);
+}
+
 int fi_ibv_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		   struct fid_cq **cq_fid, void *context)
 {
@@ -532,8 +538,8 @@ int fi_ibv_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 
 	/* verbs uses its own implementation of wait objects for CQ */
 	tmp_attr.wait_obj = FI_WAIT_NONE;
-	ret = ofi_cq_init(&fi_ibv_prov, domain_fid, &tmp_attr,
-			  &cq->util_cq, NULL, context);
+	ret = ofi_cq_init(&fi_ibv_prov, domain_fid, &tmp_attr, &cq->util_cq,
+			  fi_ibv_util_cq_progress_noop, context);
 	if (ret)
 		goto err1;
 	/*


### PR DESCRIPTION
The utility ofi_cq_init expects that progress routine is not a NULL.
verbs doesn't uses this, therefore it passes NULL as the progress
routine.The problem is fixed by passing non-operation callback that
isn't used by utility CQ.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>