### PR TITLE
prov/sockets: Fixup formatting from commit f2118d27

### DIFF
--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -262,8 +262,9 @@ ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	}
 
 	sock_tx_ctx_write_op_send(tx_ctx, &tx_op, flags, (uintptr_t) msg->context,
-			msg->addr, (uintptr_t)((msg->iov_count > 0) ? msg->msg_iov[0].iov_base : NULL),
-			ep_attr, conn);
+				  msg->addr, (uintptr_t) ((msg->iov_count > 0) ?
+				  msg->msg_iov[0].iov_base : NULL),
+				  ep_attr, conn);
 
 	if (flags & FI_REMOTE_CQ_DATA)
 		sock_tx_ctx_write(tx_ctx, &msg->data, sizeof(msg->data));
@@ -605,9 +606,10 @@ ssize_t sock_ep_tsendmsg(struct fid_ep *ep,
 	}
 
 	sock_tx_ctx_write_op_tsend(tx_ctx, &tx_op, flags,
-			(uintptr_t) msg->context, msg->addr,
-      (uintptr_t)((msg->iov_count > 0) ? msg->msg_iov[0].iov_base : NULL),
-			ep_attr, conn, msg->tag);
+				   (uintptr_t) msg->context, msg->addr,
+				   (uintptr_t) ((msg->iov_count > 0) ?
+				    msg->msg_iov[0].iov_base : NULL),
+				    ep_attr, conn, msg->tag);
 
 	if (flags & FI_REMOTE_CQ_DATA)
 		sock_tx_ctx_write(tx_ctx, &msg->data, sizeof(msg->data));


### PR DESCRIPTION
Fixes code formatting issues from patch:
prov/sockets: Fix accessing msg's iovec without checking its length

Signed-off-by: Sean Hefty <sean.hefty@intel.com>