### PR TITLE
common: Fix issue for built-in atomics

### DIFF
--- a/include/ofi_atom.h
+++ b/include/ofi_atom.h
@@ -136,7 +136,7 @@ typedef atomic_long	ofi_atomic_int64_t;
 #    define ofi_atomic_ptr(atomic) (&((atomic)->val))
 #  else
 #    define ATOMIC_T(radix) int##radix##_t
-#    define ofi_atomic_ptr(atomic) (atomic)
+#    define ofi_atomic_ptr(atomic) (&(atomic))
 #  endif
 
 #define OFI_ATOMIC_DEFINE(radix)									\


### PR DESCRIPTION
This patch fixes the following problem:
The helper macro has to return address of variable, but it return its value.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>