### PR TITLE
prov/verbs: Unconditionally disable multi-threaded support for mlx4/mlx5

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -729,6 +729,8 @@ static void fi_ibv_fini(void)
 
 VERBS_INI
 {
+	setenv("MLX4_SINGLE_THREADED", "1", 0);
+	setenv("MLX5_SINGLE_THREADED", "1", 0);
 	if (fi_ibv_read_params()|| fi_ibv_init_info(&fi_ibv_util_prov.info))
 		return NULL;
 	return &fi_ibv_prov;


### PR DESCRIPTION
This is a part of optimization for mlx HW. This improves latency and reduces instruction counts for send/recv path (~20).
This is possible, because multi-threaded support is improved for verbs providers (acquiring locks to protect TX/RX CQs when accessing `ibv_post_[send|recv]` routines) in the #4084 PR.

This PR should be merged into master after #4084 #4083 will be merged.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>