### PR TITLE
[v1.6.x] prov/rxm: fix a bug in matching directed receives

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -376,10 +376,9 @@ extern struct fi_tx_attr rxm_tx_attr;
 extern struct fi_rx_attr rxm_rx_attr;
 
 // TODO move to common code?
-static inline int rxm_match_addr(fi_addr_t addr, fi_addr_t match_addr)
+static inline int rxm_match_addr(fi_addr_t recv_addr, fi_addr_t rx_addr)
 {
-	return (addr == FI_ADDR_UNSPEC) || (match_addr == FI_ADDR_UNSPEC) ||
-		(addr == match_addr);
+	return (recv_addr == FI_ADDR_UNSPEC) || (recv_addr == rx_addr);
 }
 
 static inline int rxm_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_tag)

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -76,7 +76,7 @@ static int rxm_match_unexp_msg(struct dlist_entry *item, const void *arg)
 	struct rxm_unexp_msg *unexp_msg;
 
 	unexp_msg = container_of(item, struct rxm_unexp_msg, entry);
-	return rxm_match_addr(unexp_msg->addr, attr->addr);
+	return rxm_match_addr(attr->addr, unexp_msg->addr);
 }
 
 static int rxm_match_unexp_msg_tagged(struct dlist_entry *item, const void *arg)


### PR DESCRIPTION
Fix a bug where received messages whose source hasn't been determined
were matching with directed receives.