### PR TITLE
prov/psm2: Reset Tx/Rx context counter when fabric is initialized

### DIFF
--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -32,6 +32,7 @@
 
 #include "psmx2.h"
 
+extern int psmx2_trx_ctxt_cnt;
 struct psmx2_fid_fabric *psmx2_active_fabric = NULL;
 
 static int psmx2_fabric_close(fid_t fid)
@@ -138,6 +139,7 @@ int psmx2_fabric(struct fi_fabric_attr *attr,
 
 	*fabric = &fabric_priv->util_fabric.fabric_fid;
 	psmx2_active_fabric = fabric_priv;
+	psmx2_trx_ctxt_cnt = 0;
 
 	return 0;
 }

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -32,7 +32,7 @@
 
 #include "psmx2.h"
 
-static int psmx2_trx_ctxt_cnt = 0;
+int psmx2_trx_ctxt_cnt = 0;
 
 /*
  * Tx/Rx context disconnect protocol:


### PR DESCRIPTION
This fixes the fi_ubertest error:
ft_recv_test_info(): ../complex/ft_main.c:673, ret=-107 (Transport endpoint
is not connected)

The cause of the error is shown in the following log message:
libfabric:psm2:core:psmx2_trx_ctxt_alloc():273<warn> number of Tx/Rx contexts
exceeds limit (24).

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>