### PR TITLE
 prov/rxm: Disable usage of SRX by default

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -386,6 +386,7 @@ struct rxm_ep {
 	struct dlist_entry	msg_cq_fd_ref_list;
 	struct fid_ep 		*srx_ctx;
 	size_t 			comp_per_progress;
+	size_t 			eager_pkt_size;
 	int			msg_mr_local;
 	int			rxm_mr_local;
 	size_t			min_multi_recv_size;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -664,10 +664,8 @@ static inline int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 	rx_buf->conn = NULL;
 	rx_buf->hdr.state = RXM_RX;
 
-	if (fi_recv(rx_buf->hdr.msg_ep, &rx_buf->pkt,
-		    rx_buf->ep->rxm_info->tx_attr->inject_size +
-		    sizeof(struct rxm_pkt), rx_buf->hdr.desc,
-		    FI_ADDR_UNSPEC, rx_buf)) {
+	if (fi_recv(rx_buf->hdr.msg_ep, &rx_buf->pkt, rx_buf->ep->eager_pkt_size,
+		    rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to repost buf\n");
 		return -FI_EAVAIL;
 	}

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1753,6 +1753,7 @@ static int rxm_ep_msg_res_open(struct util_domain *util_domain,
 {
 	int ret;
 	size_t max_prog_val;
+	int use_srx;
 	struct rxm_domain *rxm_domain =
 		container_of(util_domain, struct rxm_domain, util_domain);
 
@@ -1768,7 +1769,10 @@ static int rxm_ep_msg_res_open(struct util_domain *util_domain,
 
 	dlist_init(&rxm_ep->msg_cq_fd_ref_list);
 
-	if (rxm_ep->msg_info->ep_attr->rx_ctx_cnt == FI_SHARED_CONTEXT) {
+	if (fi_param_get_bool(&rxm_prov, "use_srx", &use_srx))
+		use_srx = 0;
+
+	if ((rxm_ep->msg_info->ep_attr->rx_ctx_cnt == FI_SHARED_CONTEXT) && use_srx) {
 		ret = fi_srx_context(rxm_domain->msg_domain, rxm_ep->msg_info->rx_attr,
 				     &rxm_ep->srx_ctx, NULL);
 		if (ret) {

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1766,6 +1766,8 @@ static int rxm_ep_msg_res_open(struct util_domain *util_domain,
 			   rxm_ep->msg_info->rx_attr->size) / 2;
 	rxm_ep->comp_per_progress = (rxm_ep->comp_per_progress > max_prog_val) ?
 				    max_prog_val : rxm_ep->comp_per_progress;
+	rxm_ep->eager_pkt_size =
+		rxm_ep->rxm_info->tx_attr->inject_size + sizeof(struct rxm_pkt);
 
 	dlist_init(&rxm_ep->msg_cq_fd_ref_list);
 

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -299,6 +299,13 @@ RXM_INI
 			"Messages of size greater than this (default: 256 Kb) "
 			"would be transmitted via rendezvous protocol.");
 
+	fi_param_define(&rxm_prov, "use_srx", FI_PARAM_BOOL,
+			"Set this enivronment variable to control the RxM "
+			"receive path. If this variable set to 1 (default: 0), "
+			"the RxM uses Shared Receive Context. This mode improves "
+			"memory consumption, but it may increase small message "
+			"latency as a side-effect.");
+
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");
 		return NULL;


### PR DESCRIPTION
This significantly improves latency (~10%), but increase memory consumption
This isn't optimal scheme on a large scale.

We need to implement automatic decision whether we have to use SRX instead. It should be done based on how many process will be run (use PMI in the AV?).