### PR TITLE
fabric: Introduce new mode bit FI_BUFFERED_RECV

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -171,6 +171,11 @@ typedef struct fid *fid_t;
 #define FI_DIRECTED_RECV	(1ULL << 59)
 
 
+/* Tagged messages, buffered receives, CQ flags */
+#define FI_CLAIM		(1ULL << 59)
+#define FI_DISCARD		(1ULL << 58)
+
+
 struct fi_ioc {
 	void			*addr;
 	size_t			count;
@@ -301,6 +306,7 @@ enum {
 #define FI_NOTIFY_FLAGS_ONLY	(1ULL << 54)
 #define FI_RESTRICTED_COMP	(1ULL << 53)
 #define FI_CONTEXT2		(1ULL << 52)
+#define FI_BUFFERED_RECV	(1ULL << 51)
 
 struct fi_tx_attr {
 	uint64_t		caps;
@@ -599,6 +605,11 @@ struct fi_context2 {
 	void			*internal[8];
 };
 #endif
+
+struct fi_recv_context {
+	struct fid_ep		*ep;
+	void			*context;
+};
 
 #ifdef __cplusplus
 }

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -158,6 +158,7 @@ typedef struct fid *fid_t;
 #define FI_AFFINITY		(1ULL << 29)
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 
+#define FI_VARIABLE_MSG		(1ULL << 48)
 #define FI_RMA_PMEM		(1ULL << 49)
 #define FI_SOURCE_ERR		(1ULL << 50)
 #define FI_LOCAL_COMM		(1ULL << 51)

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -60,6 +60,7 @@ enum {
 enum {
 	FI_OPT_MIN_MULTI_RECV,		/* size_t */
 	FI_OPT_CM_DATA_SIZE,		/* size_t */
+	FI_OPT_BUFFERED_LIMIT,		/* size_t */
 };
 
 struct fi_ops_ep {

--- a/include/rdma/fi_tagged.h
+++ b/include/rdma/fi_tagged.h
@@ -41,8 +41,6 @@
 extern "C" {
 #endif
 
-#define FI_CLAIM		(1ULL << 59)
-#define FI_DISCARD		(1ULL << 58)
 
 struct fi_msg_tagged {
 	const struct iovec	*msg_iov;

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -594,6 +594,20 @@ operation.  The following completion flags are defined.
   buffer has been released, and the completion entry is not associated
   with a received message.
 
+*FI_MORE*
+: See the 'Buffered Receives' section in `fi_msg`(3) for more details.
+  This flag is associated with receive completions on endpoints that
+  have FI_BUFFERED_RECV mode enabled.  When set to one, it indicates that
+  the buffer referenced by the completion is limited by the
+  FI_OPT_BUFFERED_LIMIT threshold, and additional message data must be
+  retrieved by the application using an FI_CLAIM operation.  
+
+*FI_CLAIM*
+: See the 'Buffered Receives' section in `fi_msg`(3) for more details.
+  This flag is set on completions associated with receive operations
+  that claim buffered receive data.  Note that this flag only applies
+  to endpoints configured with the FI_BUFFERED_RECV mode bit.
+
 # NOTES
 
 A completion queue must be bound to at least one enabled endpoint before any

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -513,12 +513,11 @@ The following option levels and option names and parameters are defined.
   the maximum size of the data that may be present as part of a connection
   request event. This option is read only.
 
-- *FI_OPT_VARIABLE_THRESHOLD - size_t*
-: Defines the minimum size for variable length messages.  Transfers
-  equal to FI_OPT_VARIABLE_THRESHOLD size or smaller are handled as
-  standard message transfers.  Message transfers larger than the
-  threshold are handled by the provider as variable length transfers.
-
+- *FI_OPT_BUFFERED_LIMIT - size_t*
+: Defines the maximum size of a buffered message that will be reported
+  to users as part of a receive completion when the FI_BUFFERED_RECV mode
+  is enabled on an endpoint.
+  
   fi_getopt() will return the currently configured threshold, or the
   provider's default threshold if one has not be set by the application.
   fi_setopt() allows an application to configure the threshold.  If the

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -555,6 +555,17 @@ supported set of modes will be returned in the info structure(s).
   and counters among endpoints, transmit contexts, and receive contexts that
   have the same set of capability flags.
 
+*FI_BUFFERED_RECV*
+: The buffered receive mode bit indicates that the provider owns the
+  data buffer(s) that are accessed by the networking layer for received
+  messages.  Typically, this implies that data must be copied from the
+  provider buffer into the application buffer.  Applications that can
+  handle message processing from network allocated data buffers can set
+  this mode bit to avoid copies.  For full details on application
+  requirements to support this mode, see the 'Buffered Receives' section
+  in `fi_msg`(3).  This mode bit applies to FI_MSG and FI_TAGGED receive
+  operations.
+
 # ADDRESSING FORMATS
 
 Multiple fabric interfaces take as input either a source or

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -379,74 +379,21 @@ message being sent.  It indicates that the recipient of a message does
 not know the amount of data to expect prior to the message arriving.
 It is most commonly used when the size of message transfers varies
 greatly, with very large messages interspersed with much smaller
-messages.  Variable messages are not subject to max message length
+messages, making receive side message buffering difficult to manage.
+Variable messages are not subject to max message length
 restrictions (i.e. struct fi_ep_attr::max_msg_size limits), and may
 be up to the maximum value of size_t (e.g. SIZE_MAX) in length.
 
-Variable messages are associated with a variable message threshold.
-The variable threshold indicates the size above which a transfer
-becomes a variable message.  The completion mechanism of variable
-messages differ from standard receive completions; however,
-completions at the sender remain unchanged.  Messages smaller than the
-threshold are treated as standard messages (or tagged messages if
-using the fi_tagged.3 operations).  That is, they consume posted
-application receive buffers and generate standard completions, including
-generating any possible errors that may arise.  The variable message
-threshold is configurable per endpoint, subject to provider limitations.
-Under most conditions, the threshold limit must be the same at both the
-sending and receiving endpoints, and must be configured prior to
-enabling the endpoint.
-
-When a variable message is ready to be received, a notification is
-generated on the associated receive completion queue.  Such
-completions will have the FI_VARIABLE_MSG flag set as part of the CQ
-entry.  The entry will report the length of the message to the receiver.
-Since variable message notifications are not directly associated with
-an application's posted receive operation, the CQ entry's op_context
-field will point to a struct fi_var_context.
-
-{% highlight c %}
-struct fi_var_context {
-	void *op_context;
-};
-{% endhighlight %}
-
-After being notified that a variable message is ready to be received,
-applications should either claim or discard the message.  To claim a
-message, an application must post a receive operation with the
-FI_CLAIM flag set.  The struct fi_var_context returned as part of the
-notification must be provided as the receive operation's context.  The
-struct fi_var_context contains an op_context field.  Applications may
-modify this field prior to claiming the message.  When the claim
-operation completes, a standard receive completion entry will be
-generated on the completion queue.  The op_context of the associated
-CQ entry will be set to the op_context value passed in through
-the fi_var_context structure.
-
-Applications that do not wish to receive a variable message that they
-were notified of may discard it.  To discard a message, an application
-must post a receive operation with the FI_DISCARD flag set.  The
-receive context should be the struct fi_var_context from the
-notification.  When the FI_DISCARD flag is set, the receive input
-buffer(s) and length parameters are ignored.
-
-The use of the FI_CLAIM and FI_DISCARD operation flags is also
-described with respect to tagged message transfers in fi_tagged.3.
-Variable length tagged messages will include the message tag as part
-of the message notification.
+Variable length messages support requests that the provider allocate and
+manage the network message buffers.  As a result, the application
+requirements and provider behavior is identical as those defined
+for supporting the FI_BUFFERED_RECV mode bit.  See the Buffered
+Receive section above for details.  The main difference is that buffered
+receives are limited by the fi_ep_attr::max_msg_size threshold, whereas
+variable length messages are not.
 
 Support for variable messages is indicated through the FI_VARIABLE_MSG
-capability bit.  Additionally, the variable length message threshold
-may be obtained and/or adjusted using an endpoint's
-fi_getopt/fi_setopt operations.
-
-The handling of variable message headers follows all message ordering
-restrictions assigned to and endpoint.  For example, completions
-may indicate the order in which variable messages arrived at the
-receiver.  However, the transfer of variable message data should be
-treated as conceptually occurring out of band.  No ordering within or
-between the data of variable messages is implied.
-
+capability bit.
 
 # NOTES
 

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -208,6 +208,7 @@ static void fi_tostr_caps(char *buf, uint64_t caps)
 	IFFLAGSTR(caps, FI_TRIGGER);
 	IFFLAGSTR(caps, FI_FENCE);
 
+	IFFLAGSTR(caps, FI_VARIABLE_MSG);
 	IFFLAGSTR(caps, FI_RMA_PMEM);
 	IFFLAGSTR(caps, FI_SOURCE_ERR);
 	IFFLAGSTR(caps, FI_LOCAL_COMM);
@@ -274,6 +275,7 @@ static void fi_tostr_mode(char *buf, uint64_t mode)
 	IFFLAGSTR(mode, FI_NOTIFY_FLAGS_ONLY);
 	IFFLAGSTR(mode, FI_RESTRICTED_COMP);
 	IFFLAGSTR(mode, FI_CONTEXT2);
+	IFFLAGSTR(mode, FI_BUFFERED_RECV);
 
 	fi_remove_comma(buf);
 }
@@ -644,6 +646,8 @@ static void fi_tostr_cq_event_flags(char *buf, uint64_t flags)
 	IFFLAGSTR(flags, FI_REMOTE_WRITE);
 	IFFLAGSTR(flags, FI_REMOTE_CQ_DATA);
 	IFFLAGSTR(flags, FI_MULTI_RECV);
+	IFFLAGSTR(flags, FI_MORE);
+	IFFLAGSTR(flags, FI_CLAIM);
 	fi_remove_comma(buf);
 }
 

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -96,20 +96,9 @@ static void strcatf(char *dest, const char *fmt, ...)
 	va_end (arglist);
 }
 
-static void fi_tostr_flags(char *buf, uint64_t flags)
+static void fi_tostr_opflags(char *buf, uint64_t flags)
 {
-	IFFLAGSTR(flags, FI_MSG);
-	IFFLAGSTR(flags, FI_RMA);
-	IFFLAGSTR(flags, FI_TAGGED);
-	IFFLAGSTR(flags, FI_ATOMIC);
 	IFFLAGSTR(flags, FI_MULTICAST);
-
-	IFFLAGSTR(flags, FI_READ);
-	IFFLAGSTR(flags, FI_WRITE);
-	IFFLAGSTR(flags, FI_RECV);
-	IFFLAGSTR(flags, FI_SEND);
-	IFFLAGSTR(flags, FI_REMOTE_READ);
-	IFFLAGSTR(flags, FI_REMOTE_WRITE);
 
 	IFFLAGSTR(flags, FI_MULTI_RECV);
 	IFFLAGSTR(flags, FI_REMOTE_CQ_DATA);
@@ -125,7 +114,8 @@ static void fi_tostr_flags(char *buf, uint64_t flags)
 	IFFLAGSTR(flags, FI_DELIVERY_COMPLETE);
 	IFFLAGSTR(flags, FI_AFFINITY);
 
-	IFFLAGSTR(flags, FI_RMA_PMEM);
+	IFFLAGSTR(flags, FI_CLAIM);
+	IFFLAGSTR(flags, FI_DISCARD);
 
 	fi_remove_comma(buf);
 }
@@ -200,17 +190,33 @@ static void fi_tostr_order(char *buf, uint64_t flags)
 
 static void fi_tostr_caps(char *buf, uint64_t caps)
 {
+	IFFLAGSTR(caps, FI_MSG);
+	IFFLAGSTR(caps, FI_RMA);
+	IFFLAGSTR(caps, FI_TAGGED);
+	IFFLAGSTR(caps, FI_ATOMIC);
+	IFFLAGSTR(caps, FI_MULTICAST);
+
+	IFFLAGSTR(caps, FI_READ);
+	IFFLAGSTR(caps, FI_WRITE);
+	IFFLAGSTR(caps, FI_RECV);
+	IFFLAGSTR(caps, FI_SEND);
+	IFFLAGSTR(caps, FI_REMOTE_READ);
+	IFFLAGSTR(caps, FI_REMOTE_WRITE);
+
+	IFFLAGSTR(caps, FI_MULTI_RECV);
+	IFFLAGSTR(caps, FI_REMOTE_CQ_DATA);
+	IFFLAGSTR(caps, FI_TRIGGER);
+	IFFLAGSTR(caps, FI_FENCE);
+
 	IFFLAGSTR(caps, FI_RMA_PMEM);
 	IFFLAGSTR(caps, FI_SOURCE_ERR);
 	IFFLAGSTR(caps, FI_LOCAL_COMM);
 	IFFLAGSTR(caps, FI_REMOTE_COMM);
 	IFFLAGSTR(caps, FI_SHARED_AV);
-	IFFLAGSTR(caps, FI_NUMERICHOST);
 	IFFLAGSTR(caps, FI_RMA_EVENT);
 	IFFLAGSTR(caps, FI_SOURCE);
 	IFFLAGSTR(caps, FI_NAMED_RX_CTX);
 	IFFLAGSTR(caps, FI_DIRECTED_RECV);
-	fi_tostr_flags(buf, caps);
 
 	fi_remove_comma(buf);
 }
@@ -306,7 +312,7 @@ static void fi_tostr_tx_attr(char *buf, const struct fi_tx_attr *attr,
 	strcatf(buf, " ]\n");
 
 	strcatf(buf, "%s%sop_flags: [ ", prefix, TAB);
-	fi_tostr_flags(buf, attr->op_flags);
+	fi_tostr_opflags(buf, attr->op_flags);
 	strcatf(buf, " ]\n");
 
 	strcatf(buf, "%s%smsg_order: [ ", prefix, TAB);
@@ -341,7 +347,7 @@ static void fi_tostr_rx_attr(char *buf, const struct fi_rx_attr *attr,
 	strcatf(buf, " ]\n");
 
 	strcatf(buf, "%s%sop_flags: [ ", prefix, TAB);
-	fi_tostr_flags(buf, attr->op_flags);
+	fi_tostr_opflags(buf, attr->op_flags);
 	strcatf(buf, " ]\n");
 
 	strcatf(buf, "%s%smsg_order: [ ", prefix, TAB);
@@ -674,7 +680,7 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 		fi_tostr_caps(buf, *val64);
 		break;
 	case FI_TYPE_OP_FLAGS:
-		fi_tostr_flags(buf, *val64);
+		fi_tostr_opflags(buf, *val64);
 		break;
 	case FI_TYPE_ADDR_FORMAT:
 		fi_tostr_addr_format(buf, *val32);


### PR DESCRIPTION
This bit separates out part of the FI_VARIABLE_MSG feature.
As a mode bit, providers that must provide receive side
buffering can report receive completions to applications
by referencing their buffers directly.  This avoids a
data on the receive side.  The rxm and rxd providers both
can use this function with applications that support the
new mode bit.

Most of the description for FI_BUFFERED_RECV is taken
from the FI_VARIABLE_MSG definition.  However, some
modifications are made to that definition based on
mapping to implementation details.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>