### PR TITLE
prov/rxm: Reduce instructions on critical path

### DIFF
--- a/include/ofi_osd.h
+++ b/include/ofi_osd.h
@@ -33,6 +33,7 @@
 #ifndef _OFI_OSD_H_
 #define _OFI_OSD_H_
 
+#include <stdint.h>
 
 /* We use macros to create atomic and complex function definitions,
  * and we can't have spaces in function names */
@@ -75,5 +76,35 @@ typedef long double long_double;
 #define OFI_LIKELY(x)	(x)
 #define OFI_UNLIKELY(x)	(x)
 #endif
+
+enum {
+	OFI_ENDIAN_UNKNOWN,
+	OFI_ENDIAN_BIG,
+	OFI_ENDIAN_LITTLE,
+	OFI_ENDIAN_BIG_WORD,	/* Middle-endian, Honeywell 316 style */
+	OFI_ENDIAN_LITTLE_WORD,	/* Middle-endian, PDP-11 style */
+};
+
+static inline int ofi_detect_endianness(void)
+{
+	union {
+		uint8_t data[sizeof(uint32_t)];
+		uint32_t value;
+	} checker = {
+		.data = { 0x00, 0x01, 0x02, 0x03 },
+	};
+	switch (checker.value) {
+	case 0x00010203UL:
+		return OFI_ENDIAN_BIG;
+	case 0x03020100UL:
+		return OFI_ENDIAN_LITTLE;
+	case 0x02030001UL:
+		return OFI_ENDIAN_BIG_WORD;
+	case 0x01000302UL:
+		return OFI_ENDIAN_LITTLE_WORD;
+	default:
+		return OFI_ENDIAN_UNKNOWN;
+	}
+}
 
 #endif /* _OFI_OSD_H_ */

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -556,7 +556,7 @@ struct util_cmap {
 struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t key);
 int ofi_cmap_get_handle(struct util_cmap *cmap, fi_addr_t fi_addr,
 			struct util_cmap_handle **handle);
-void ofi_cmap_update(struct util_cmap *cmap, const void *addr, fi_addr_t fi_addr);
+int ofi_cmap_update(struct util_cmap *cmap, const void *addr, fi_addr_t fi_addr);
 
 void ofi_cmap_process_conn_notify(struct util_cmap *cmap,
 				  struct util_cmap_handle *handle);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -576,30 +576,30 @@ rxm_process_recv_entry(struct rxm_recv_queue *recv_queue,
 	return FI_SUCCESS;
 }
 
+static inline struct rxm_conn *
+rxm_acquire_conn(struct rxm_ep *rxm_ep, fi_addr_t fi_addr)
+{
+	return container_of(ofi_cmap_acquire_handle(rxm_ep->util_ep.cmap,
+						    fi_addr),
+			    struct rxm_conn, handle);
+}
+
+
 /* Caller must hold `cmap::lock` */
 static inline int
-rxm_ep_handle_unconnected(struct rxm_ep *rxm_ep, struct util_cmap_handle **handle,
+rxm_ep_handle_unconnected(struct rxm_ep *rxm_ep, struct util_cmap_handle *handle,
 			  fi_addr_t dest_addr)
 {
 	int ret;
 
-	if (OFI_UNLIKELY(!*handle)) {
-		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL,
-		       "No handle found for given fi_addr\n");
-		ret = util_cmap_alloc_handle(rxm_ep->util_ep.cmap,
-					     dest_addr, CMAP_IDLE,
-					     handle);
-		if (OFI_UNLIKELY(ret))
-			return -FI_ENOMEM;
-	}
-	if ((*handle)->state == CMAP_CONNECTED_NOTIFY) {
-		ofi_cmap_process_conn_notify(rxm_ep->util_ep.cmap, *handle);
+	if (handle->state == CMAP_CONNECTED_NOTIFY) {
+		ofi_cmap_process_conn_notify(rxm_ep->util_ep.cmap, handle);
 		return 0;
 	}
 	/* Since we handling unoonnected state and `cmap:lock`
 	 * is on hold, it shouldn't return 0 */
 	ret = ofi_cmap_handle_connect(rxm_ep->util_ep.cmap,
-				      dest_addr, *handle);
+				      dest_addr, handle);
 	if (OFI_UNLIKELY(ret != -FI_EAGAIN))
 		return ret;
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -136,6 +136,7 @@ struct rxm_mr {
 struct rxm_ep_wire_proto {
 	uint8_t	ctrl_version;
 	uint8_t	op_version;
+	uint8_t endianness;
 	uint8_t padding[6];
 	uint64_t eager_size;
 };

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -60,7 +60,7 @@
 #define RXM_MAJOR_VERSION 1
 #define RXM_MINOR_VERSION 0
 
-#define RXM_OP_VERSION		2
+#define RXM_OP_VERSION		3
 #define RXM_CTRL_VERSION	3
 
 #define RXM_BUF_SIZE	16384

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -60,7 +60,8 @@
 #define RXM_MAJOR_VERSION 1
 #define RXM_MINOR_VERSION 0
 
-#define RXM_CTRL_VERSION 3
+#define RXM_OP_VERSION		2
+#define RXM_CTRL_VERSION	3
 
 #define RXM_BUF_SIZE	16384
 #define RXM_SAR_LIMIT	262144
@@ -134,7 +135,8 @@ struct rxm_mr {
 
 struct rxm_ep_wire_proto {
 	uint8_t	ctrl_version;
-	uint8_t ctrl_version_pad[7];
+	uint8_t	op_version;
+	uint8_t padding[6];
 	uint64_t eager_size;
 };
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -157,6 +157,14 @@ rxm_conn_verify_cm_data(struct rxm_cm_data *remote_cm_data,
 			local_cm_data->proto.ctrl_version);
 		goto err;
 	}
+	if (remote_cm_data->proto.op_version != local_cm_data->proto.op_version) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+			"op_version of two peers (%"PRIu8" vs %"PRIu8")"
+			"are mismatched\n",
+			remote_cm_data->proto.op_version,
+			local_cm_data->proto.op_version);
+		goto err;
+	}
 	if (remote_cm_data->proto.eager_size != local_cm_data->proto.eager_size) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 			"inject_size of two peers (%"PRIu64" vs %"PRIu64")"
@@ -179,6 +187,7 @@ rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 	struct rxm_cm_data cm_data = {
 		.proto = {
 			.ctrl_version = RXM_CTRL_VERSION,
+			.op_version = RXM_OP_VERSION,
 			.eager_size = rxm_ep->rxm_info->tx_attr->inject_size,
 		},
 	};
@@ -388,6 +397,7 @@ rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
 	struct rxm_cm_data cm_data = {
 		.proto = {
 			.ctrl_version = RXM_CTRL_VERSION,
+			.op_version = RXM_OP_VERSION,
 			.eager_size = rxm_ep->rxm_info->tx_attr->inject_size,
 		},
 	};

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -149,6 +149,14 @@ static inline int
 rxm_conn_verify_cm_data(struct rxm_cm_data *remote_cm_data,
 			struct rxm_cm_data *local_cm_data)
 {
+	if (remote_cm_data->proto.endianness != local_cm_data->proto.endianness) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+			"endianness of two peers (%"PRIu8" vs %"PRIu8")"
+			"are mismatched\n",
+			remote_cm_data->proto.endianness,
+			local_cm_data->proto.endianness);
+		goto err;
+	}
 	if (remote_cm_data->proto.ctrl_version != local_cm_data->proto.ctrl_version) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 			"ctrl_version of two peers (%"PRIu8" vs %"PRIu8")"
@@ -188,6 +196,7 @@ rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 		.proto = {
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
+			.endianness = ofi_detect_endianness(),
 			.eager_size = rxm_ep->rxm_info->tx_attr->inject_size,
 		},
 	};
@@ -398,6 +407,7 @@ rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
 		.proto = {
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
+			.endianness = ofi_detect_endianness(),
 			.eager_size = rxm_ep->rxm_info->tx_attr->inject_size,
 		},
 	};

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1013,9 +1013,7 @@ rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 		     uint64_t tag, uint64_t comp_flags,
 		     struct rxm_buf_pool *pool)
 {
-	struct util_cmap_handle *handle;
 	struct rxm_conn *rxm_conn;
-	struct rxm_tx_entry *tx_entry = NULL;
 	struct rxm_tx_buf *tx_buf;
 	size_t pkt_size = rxm_pkt_size + len;
 	ssize_t ret;
@@ -1023,18 +1021,17 @@ rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 	assert(len <= rxm_ep->rxm_info->tx_attr->inject_size);
 
 	fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
-	handle = ofi_cmap_acquire_handle(rxm_ep->util_ep.cmap, dest_addr);
-	if (OFI_UNLIKELY(!handle || handle->state != CMAP_CONNECTED)) {
+	rxm_conn = rxm_acquire_conn(rxm_ep, dest_addr);
+	if (OFI_UNLIKELY(rxm_conn->handle.state != CMAP_CONNECTED)) {
 		struct iovec iov = {
 			.iov_base = (void *)buf,
 			.iov_len = len,
 		};
-		ret = rxm_ep_handle_unconnected(rxm_ep, &handle, dest_addr);
+		ret = rxm_ep_handle_unconnected(rxm_ep, &rxm_conn->handle, dest_addr);
 		if (!ret)
 			goto inject_continue;
 		else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
 			goto cmap_err;
-		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_send(rxm_ep, rxm_conn, NULL, 1,
 					   &iov, NULL, len, data, flags,
 					   tag, comp_flags, pool, 0);
@@ -1044,7 +1041,6 @@ cmap_err:
 	}
 inject_continue:
 	fastlock_release(&rxm_ep->util_ep.cmap->lock);
-	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	assert(dlist_empty(&rxm_conn->postponed_tx_list));
 
@@ -1057,6 +1053,8 @@ inject_continue:
 		memcpy(tx_buf->pkt.data, buf, tx_buf->pkt.hdr.size);
 		return rxm_ep_inject_send(rxm_ep, rxm_conn, tx_buf, pkt_size);
 	} else {
+		struct rxm_tx_entry *tx_entry;
+
 		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "passed data (size = %zu) "
 		       "is too big for MSG provider (max inject size = %zd)\n",
 		       pkt_size, rxm_ep->msg_info->tx_attr->inject_size);
@@ -1078,7 +1076,6 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 		   uint64_t flags, uint64_t tag, uint64_t comp_flags,
 		   struct rxm_buf_pool *pool, uint8_t op)
 {
-	struct util_cmap_handle *handle;
 	struct rxm_conn *rxm_conn;
 	struct rxm_tx_entry *tx_entry;
 	struct rxm_tx_buf *tx_buf;
@@ -1088,14 +1085,13 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 	assert(count <= rxm_ep->rxm_info->tx_attr->iov_limit);
 
 	fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
-	handle = ofi_cmap_acquire_handle(rxm_ep->util_ep.cmap, dest_addr);
-	if (OFI_UNLIKELY(!handle || handle->state != CMAP_CONNECTED)) {
-		ret = rxm_ep_handle_unconnected(rxm_ep, &handle, dest_addr);
+	rxm_conn = rxm_acquire_conn(rxm_ep, dest_addr);
+	if (OFI_UNLIKELY(rxm_conn->handle.state != CMAP_CONNECTED)) {
+		ret = rxm_ep_handle_unconnected(rxm_ep, &rxm_conn->handle, dest_addr);
 		if (!ret)
 			goto send_continue;
 		else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
 			goto cmap_err;
-		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_send(
 				rxm_ep, rxm_conn, context, count, iov,
 				desc, data_len, data, flags, tag, comp_flags,
@@ -1109,7 +1105,6 @@ cmap_err:
 	}
 send_continue:
 	fastlock_release(&rxm_ep->util_ep.cmap->lock);
-	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	assert(dlist_empty(&rxm_conn->postponed_tx_list));
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -136,10 +136,6 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			tx_buf->type = pool->type;
 			tx_buf->pkt.ctrl_hdr.version = RXM_CTRL_VERSION;
 			tx_buf->pkt.hdr.version = OFI_OP_VERSION;
-			if (rxm_ep_tx_flags(pool->rxm_ep) & FI_TRANSMIT_COMPLETE)
-				tx_buf->pkt.hdr.flags |= OFI_TRANSMIT_COMPLETE;
-			if (rxm_ep_tx_flags(pool->rxm_ep) & FI_DELIVERY_COMPLETE)
-				tx_buf->pkt.hdr.flags |= OFI_DELIVERY_COMPLETE;
 			tx_buf->hdr.desc = mr_desc;
 
 			switch (pool->type) {
@@ -775,7 +771,7 @@ rxm_ep_format_tx_res_lightweight(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_con
 	(*tx_buf)->pkt.hdr.tag = tag;
 
 	if (flags & FI_REMOTE_CQ_DATA) {
-		(*tx_buf)->pkt.hdr.flags = OFI_REMOTE_CQ_DATA;
+		(*tx_buf)->pkt.hdr.flags = FI_REMOTE_CQ_DATA;
 		(*tx_buf)->pkt.hdr.data = data;
 	}
 

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -312,20 +312,18 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 {
 	struct rxm_tx_entry *tx_entry;
 	struct fi_msg_rma msg_rma = *msg;
-	struct util_cmap_handle *handle;
 	struct rxm_conn *rxm_conn;
 	void *mr_desc[RXM_IOV_LIMIT] = { 0 };
 	int ret;
 
 	fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
-	handle = ofi_cmap_acquire_handle(rxm_ep->util_ep.cmap, msg->addr);
-	if (OFI_UNLIKELY(!handle || handle->state != CMAP_CONNECTED)) {
-		ret = rxm_ep_handle_unconnected(rxm_ep, &handle, msg->addr);
+	rxm_conn = rxm_acquire_conn(rxm_ep, msg->addr);
+	if (OFI_UNLIKELY(rxm_conn->handle.state != CMAP_CONNECTED)) {
+		ret = rxm_ep_handle_unconnected(rxm_ep, &rxm_conn->handle, msg->addr);
 		if (!ret)
 			goto rma_continue;
 		else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
 			goto cmap_err;
-		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_rma(rxm_ep, rxm_conn,
 					  ofi_total_iov_len(msg->msg_iov,
 							    msg->iov_count),
@@ -336,7 +334,6 @@ cmap_err:
 	}
 rma_continue:
 	fastlock_release(&rxm_ep->util_ep.cmap->lock);
-	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	ret = rxm_ep_format_rma_res_lightweight(rxm_ep, flags, comp_flags,
 						msg, &tx_entry);
@@ -431,20 +428,18 @@ rxm_ep_rma_inject(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 {
 	struct rxm_tx_entry *tx_entry;
 	struct rxm_rma_buf *rma_buf;
-	struct util_cmap_handle *handle;
 	struct rxm_conn *rxm_conn;
 	size_t total_size = ofi_total_iov_len(msg->msg_iov, msg->iov_count);
 	ssize_t ret;
 
 	fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
-	handle = ofi_cmap_acquire_handle(rxm_ep->util_ep.cmap, msg->addr);
-	if (OFI_UNLIKELY(!handle || handle->state != CMAP_CONNECTED)) {
-		ret = rxm_ep_handle_unconnected(rxm_ep, &handle, msg->addr);
+	rxm_conn = rxm_acquire_conn(rxm_ep, msg->addr);
+	if (OFI_UNLIKELY(rxm_conn->handle.state != CMAP_CONNECTED)) {
+		ret = rxm_ep_handle_unconnected(rxm_ep, &rxm_conn->handle, msg->addr);
 		if (!ret)
 			goto rma_inject_continue;
 		else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
 			goto cmap_err;
-		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_rma(rxm_ep, rxm_conn, total_size,
 					  flags, FI_WRITE, msg);
 cmap_err:
@@ -453,7 +448,6 @@ cmap_err:
 	}
 rma_inject_continue:
 	fastlock_release(&rxm_ep->util_ep.cmap->lock);
-	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	if (OFI_UNLIKELY(total_size > rxm_ep->rxm_info->tx_attr->inject_size))
 		return -FI_EMSGSIZE;


### PR DESCRIPTION
This PR improves instructions flow for TX/RX and RMA paths 
- The 1st commit:
Add run-time endiannes detector. This approach allows to detect 4 different endian byte format.
- The 2nd commit:
prov/rxm: Check RXM op version two peers during connection establishment procedure
- The 3rd commit:
prov/rxm: Check endianness of two peers during connection establishment procedure
- The 4th commit:
The pkt::hdr::flags can be set only to FI_REMOTE_CQ_DATA, because RxM handles.
Increment OP version to ensure wire protocol compatibility 
only this flag on receiver side.
- The 5th commit:
An allocation of connection handle gives an opportunity to remove
check for NULL on critical path.
So, we can easily use rxm_conn converted from handle when performing
send or rma operation.


Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>