### PR TITLE
prov/rxm: Fix bug when saved msg EP wasn't destroyed

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -109,6 +109,13 @@ static void rxm_conn_close(struct util_cmap_handle *handle)
 static void rxm_conn_free(struct util_cmap_handle *handle)
 {
 	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
+
+	/* This handles case when saved_msg_ep wasn't closed */
+	if (rxm_conn->saved_msg_ep) {
+		if (fi_close(&rxm_conn->saved_msg_ep->fid))
+			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to close saved msg_ep\n");
+	}
+
 	if (!rxm_conn->msg_ep)
 		return;
 


### PR DESCRIPTION
Such situtation may happen only when an application issues transmit operations
that are deffered and then completed when the connection is successfully
established.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>