### PR TITLE
prov/psm2: Fix irregular performance drop for aggregated RMA operations

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -506,6 +506,7 @@ struct psmx2_trx_ctxt {
 	psm2_mq_t		psm2_mq;
 	int			am_initialized;
 	int			am_progress;
+	int			am_poll_count;
 	int			id;
 	int			usage_flags;
 	struct psm2_am_parameters psm2_am_param;
@@ -1072,6 +1073,21 @@ static inline void psmx2_progress_all(struct psmx2_fid_domain *domain)
 		psmx2_progress(trx_ctxt);
 	}
 	psmx2_unlock(&domain->trx_ctxt_lock, 1);
+}
+
+/*
+ * There is a limitation in PSM2 AM implementation that can cause significant
+ * delay if too many AM requests are enqueued in a row without progress calls
+ * being made in between. As a workaround, call this function after each AM
+ * request is enqueued whenever possible.
+ */
+#define PSMX2_AM_POLL_INTERVAL	64
+static inline void psmx2_am_poll(struct psmx2_trx_ctxt *trx_ctxt)
+{
+	if (OFI_UNLIKELY(++trx_ctxt->am_poll_count > PSMX2_AM_POLL_INTERVAL)) {
+		trx_ctxt->am_poll_count = 0;
+		psm2_poll(trx_ctxt->psm2_ep);
+	}
 }
 
 #ifdef __cplusplus

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -877,7 +877,7 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	psm2_am_request_short(psm2_epaddr,
 			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
 			      (void *)buf, len, am_flags, NULL, NULL);
-
+	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
 
@@ -996,7 +996,7 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 	psm2_am_request_short(psm2_epaddr,
 			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
 			      (void *)buf, len, am_flags, NULL, NULL);
-
+	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
 
@@ -1193,7 +1193,7 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 	psm2_am_request_short(psm2_epaddr,
 			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
 			      (void *)buf, (buf?len:0), am_flags, NULL, NULL);
-
+	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
 
@@ -1376,7 +1376,7 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 	psm2_am_request_short(psm2_epaddr,
 			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
 			      (void *)buf, (buf?len:0), am_flags, NULL, NULL);
-
+	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
 
@@ -1595,7 +1595,7 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
 			      (void *)buf, len * 2, am_flags,
 			      NULL, NULL);
-
+	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
 
@@ -1803,7 +1803,7 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 	psm2_am_request_short(psm2_epaddr,
 			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
 			      buf, len * 2, am_flags, NULL, NULL);
-
+	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
 

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -649,7 +649,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 		args[3].u64 = key;
 		psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER,
 				      args, 4, NULL, 0, 0, NULL, NULL);
-
+		psmx2_am_poll(ep_priv->tx);
 		return 0;
 	}
 
@@ -662,6 +662,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 		args[4].u64 = offset;
 		psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER,
 				      args, 5, NULL, 0, 0, NULL, NULL);
+		psmx2_am_poll(ep_priv->tx);
 		addr += chunk_size;
 		len -= chunk_size;
 		offset += chunk_size;
@@ -673,7 +674,7 @@ ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 	args[4].u64 = offset;
 	psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER,
 			      args, 5, NULL, 0, 0, NULL, NULL);
-
+	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
 
@@ -785,6 +786,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 		args[4].u64 = offset;
 		psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER,
 				      args, 5, NULL, 0, 0, NULL, NULL);
+		psmx2_am_poll(ep_priv->tx);
 		addr += chunk_size;
 		short_len -= chunk_size;
 		offset += chunk_size;
@@ -797,6 +799,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 	args[4].u64 = offset;
 	psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER,
 			      args, 5, NULL, 0, 0, NULL, NULL);
+	psmx2_am_poll(ep_priv->tx);
 
 	/* Use the long protocol for the last segment */
 	if (long_len) {
@@ -814,6 +817,7 @@ ssize_t psmx2_readv_generic(struct fid_ep *ep, const struct iovec *iov,
 		args[3].u64 = key;
 		psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER,
 				      args, 4, NULL, 0, 0, NULL, NULL);
+		psmx2_am_poll(ep_priv->tx);
 	}
 
 	return 0;
@@ -996,6 +1000,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 
 		psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args,
 				      nargs, NULL, 0, am_flags, NULL, NULL);
+		psmx2_am_poll(ep_priv->tx);
 
 		psm2_mq_isend2(ep_priv->tx->psm2_mq, psm2_epaddr, 0,
 			       &psm2_tag, buf, len, psm2_context, &psm2_req);
@@ -1013,6 +1018,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 		psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args,
 				      nargs, (void *)buf, chunk_size, am_flags,
 				      NULL, NULL);
+		psmx2_am_poll(ep_priv->tx);
 		buf = (const uint8_t *)buf + chunk_size;
 		addr += chunk_size;
 		len -= chunk_size;
@@ -1031,7 +1037,7 @@ ssize_t psmx2_write_generic(struct fid_ep *ep, const void *buf, size_t len,
 	}
 	psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args, nargs,
 			      (void *)buf, len, am_flags, NULL, NULL);
-
+	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
 
@@ -1145,7 +1151,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 		}
 		psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args, nargs,
 				      (void *)buf, len, am_flags, NULL, NULL);
-
+		psmx2_am_poll(ep_priv->tx);
 		return 0;
 	}
 
@@ -1203,6 +1209,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 
 			psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args,
 					      nargs, NULL, 0, am_flags, NULL, NULL);
+			psmx2_am_poll(ep_priv->tx);
 
 			psm2_mq_isend2(ep_priv->tx->psm2_mq, psm2_epaddr, 0,
 				       &psm2_tag, iov[i].iov_base, iov[i].iov_len,
@@ -1224,6 +1231,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 			psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args,
 					      nargs, (void *)buf, chunk_size, am_flags,
 					      NULL, NULL);
+			psmx2_am_poll(ep_priv->tx);
 			buf += chunk_size;
 			addr += chunk_size;
 			len -= chunk_size;
@@ -1245,6 +1253,7 @@ ssize_t psmx2_writev_generic(struct fid_ep *ep, const struct iovec *iov,
 		}
 		psm2_am_request_short(psm2_epaddr, PSMX2_AM_RMA_HANDLER, args, nargs,
 				      (void *)buf, len, am_flags, NULL, NULL);
+		psmx2_am_poll(ep_priv->tx);
 
 		addr += len;
 		len_sent += len;


### PR DESCRIPTION
Applications like MPI may aggregate a sequence of RMA operations and
issue them in a batch (e.g. via MPI_Win_flush). A limitation in the AM
implementation of the PSM2 library can lead to sudden performance drop
for such aggregated RMA operations. A workaround is provided here to
prevent the limitation from being triggered.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>