### PR TITLE
prov/tcp: Add missed capabilities

### DIFF
--- a/prov/tcp/src/tcpx_attr.c
+++ b/prov/tcp/src/tcpx_attr.c
@@ -34,9 +34,14 @@
 
 #define TCPX_DOMAIN_CAPS FI_LOCAL_COMM | FI_REMOTE_COMM
 
+#define TCPX_MSG_ORDER (FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_RAS |	\
+			FI_ORDER_WAR | FI_ORDER_WAW | FI_ORDER_WAS |	\
+			FI_ORDER_SAR | FI_ORDER_SAW | FI_ORDER_SAS)
+
 static struct fi_tx_attr tcpx_tx_attr = {
 	.caps = FI_MSG | FI_SEND,
 	.comp_order = FI_ORDER_STRICT,
+	.msg_order = TCPX_MSG_ORDER,
 	.inject_size = 64,
 	.size = 1024,
 	.iov_limit = TCPX_IOV_LIMIT,
@@ -46,6 +51,7 @@ static struct fi_tx_attr tcpx_tx_attr = {
 static struct fi_rx_attr tcpx_rx_attr = {
 	.caps = FI_MSG | FI_RECV,
 	.comp_order = FI_ORDER_STRICT,
+	.msg_order = TCPX_MSG_ORDER,
 	.total_buffered_recv = 0,
 	.size = 1024,
 	.iov_limit = TCPX_IOV_LIMIT
@@ -67,8 +73,9 @@ static struct fi_domain_attr tcpx_domain_attr = {
 	.control_progress = FI_PROGRESS_AUTO,
 	.data_progress = FI_PROGRESS_AUTO,
 	.resource_mgmt = FI_RM_ENABLED,
+	.mr_mode = FI_MR_SCALABLE | FI_MR_BASIC,
+	.mr_key_size = sizeof(uint64_t),
 	.av_type = FI_AV_UNSPEC,
-	.mr_mode = 0,
 	.cq_data_size = sizeof(uint64_t),
 	.cq_cnt = 256,
 	.ep_cnt = 8192,


### PR DESCRIPTION
This gives a possibility to run MPICH/CH4 over RxM/tcp provider

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>