### PR TITLE
prov/rxm: Fix leak of fi_info

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -340,6 +340,7 @@ static void *rxm_conn_event_handler(void *arg)
 				goto exit;
 			}
 			rxm_msg_process_connreq(rxm_ep, entry->info, entry->data);
+			fi_freeinfo(entry->info);
 			break;
 		case FI_CONNECTED:
 			FI_DBG(&rxm_prov, FI_LOG_FABRIC,


### PR DESCRIPTION
fi_eq.3 man page says:
A connection request (FI_CONNREQ) event indicates that a remote endpoint
wishes to establish a new connection to a listening, or passive, endpoint.
The fid is the passive endpoint. Information regarding the requested,
active endpoint’s capabilities and attributes are available from the info
field. The application is responsible for freeing this structure by
calling fi_freeinfo when it is no longer needed.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>