### PR TITLE
prov/verbs: Add missing free event channel in fi_ibv_domain_close()

### DIFF
--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -267,6 +267,7 @@ static int fi_ibv_domain_close(fid_t fid)
 			ofi_freealign(av_entry);
 		}
 		rdma_destroy_ep(domain->rdm_cm->listener);
+		rdma_destroy_event_channel(domain->rdm_cm->ec);
 		free(domain->rdm_cm);
 		break;
 	case FI_EP_DGRAM:


### PR DESCRIPTION
Application leaked a small amount of memory and a file
descriptor when a verbs RDM domain was destroyed.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>