### PR TITLE
prov/verbs, rxm: fix incorrect reporting and handling of tx, rx attributes 

### DIFF
--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -49,6 +49,7 @@ struct fi_tx_attr rxm_tx_attr = {
 	.comp_order = ~0x0ULL,
 	.size = SIZE_MAX,
 	.iov_limit = RXM_IOV_LIMIT,
+	.rma_iov_limit = RXM_IOV_LIMIT,
 };
 
 struct fi_rx_attr rxm_rx_attr = {

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -126,6 +126,7 @@ const struct fi_tx_attr verbs_tx_attr = {
 	.msg_order		= VERBS_MSG_ORDER,
 	.comp_order		= FI_ORDER_STRICT,
 	.inject_size		= 0,
+	.rma_iov_limit		= 1,
 };
 
 const struct fi_tx_attr verbs_rdm_tx_attr = {
@@ -515,7 +516,6 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx,
 
 	info->tx_attr->size 			= device_attr.max_qp_wr;
 	info->tx_attr->iov_limit 		= device_attr.max_sge;
-	info->tx_attr->rma_iov_limit		= device_attr.max_sge;
 
 	info->rx_attr->size 			= device_attr.max_srq_wr ?
 						  MIN(device_attr.max_qp_wr,


### PR DESCRIPTION
@shefty I've added FI_ORDER_DATA to RxM since as per the definition it seemed RxM can support it implicitly. RxM copies the received data in order to application buffers. Please review.