### PR TITLE
prov/rxm: Use separate list of the posted RX buffers per connection

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -115,10 +115,12 @@ struct rxm_fabric {
 struct rxm_conn {
 	struct fid_ep *msg_ep;
 	struct dlist_entry postponed_tx_list;
+	struct dlist_entry posted_rx_list;
 	struct util_cmap_handle handle;
 	/* This is saved MSG EP fid, that hasn't been closed during
 	 * handling of CONN_RECV in CMAP_CONNREQ_SENT for passive side */
 	struct fid_ep *saved_msg_ep;
+	struct dlist_entry saved_posted_rx_list;
 };
 
 struct rxm_domain {
@@ -396,7 +398,7 @@ struct rxm_ep {
 
 	struct rxm_buf_pool	buf_pools[RXM_BUF_POOL_MAX];
 
-	struct dlist_entry	post_rx_list;
+	struct dlist_entry	posted_srx_list;
 	struct dlist_entry	repost_ready_list;
 
 	struct rxm_send_queue	send_queue;
@@ -454,7 +456,10 @@ void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 void rxm_ep_progress_one(struct util_ep *util_ep);
 void rxm_ep_progress_multi(struct util_ep *util_ep);
 
-int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
+int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep,
+		       struct dlist_entry *posted_rx_list);
+void rxm_ep_cleanup_posted_rx_list(struct rxm_ep *rxm_ep,
+				   struct dlist_entry *posted_rx_list);
 
 static inline
 void rxm_ep_msg_mr_closev(struct fid_mr **mr, size_t count)

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -82,7 +82,7 @@ static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 	}
 
 	if (!rxm_ep->srx_ctx) {
-		ret = rxm_ep_prepost_buf(rxm_ep, msg_ep);
+		ret = rxm_ep_prepost_buf(rxm_ep, msg_ep, &rxm_conn->posted_rx_list);
 		if (ret)
 			goto err;
 	}
@@ -97,9 +97,12 @@ err:
 static void rxm_conn_close(struct util_cmap_handle *handle)
 {
 	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
+
 	if (!rxm_conn->msg_ep)
 		return;
-
+	/* Save the preposted RX list for further cleanup */
+	dlist_splice_tail(&rxm_conn->saved_posted_rx_list,
+			  &rxm_conn->posted_rx_list);
 	rxm_conn->saved_msg_ep = rxm_conn->msg_ep;
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL,
 	       "Saved MSG EP fid for further deletion in main thread\n");
@@ -108,17 +111,20 @@ static void rxm_conn_close(struct util_cmap_handle *handle)
 
 static void rxm_conn_free(struct util_cmap_handle *handle)
 {
+	struct rxm_ep *rxm_ep = container_of(handle->cmap->ep, struct rxm_ep, util_ep);
 	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	/* This handles case when saved_msg_ep wasn't closed */
 	if (rxm_conn->saved_msg_ep) {
+		rxm_ep_cleanup_posted_rx_list(rxm_ep, &rxm_conn->saved_posted_rx_list);
 		if (fi_close(&rxm_conn->saved_msg_ep->fid))
-			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to close saved msg_ep\n");
+			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+				"Unable to close saved msg_ep\n");
 	}
 
 	if (!rxm_conn->msg_ep)
 		return;
-
+	rxm_ep_cleanup_posted_rx_list(rxm_ep, &rxm_conn->posted_rx_list);
 	/* Assuming fi_close also shuts down the connection gracefully if the
 	 * endpoint is in connected state */
 	if (fi_close(&rxm_conn->msg_ep->fid))
@@ -131,9 +137,12 @@ static void rxm_conn_free(struct util_cmap_handle *handle)
 
 static void rxm_conn_connected_handler(struct util_cmap_handle *handle)
 {
+	struct rxm_ep *rxm_ep = container_of(handle->cmap->ep, struct rxm_ep, util_ep);
 	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
+
 	if (!rxm_conn->saved_msg_ep)
 		return;
+	rxm_ep_cleanup_posted_rx_list(rxm_ep, &rxm_conn->saved_posted_rx_list);
 	/* Assuming fi_close also shuts down the connection gracefully if the
 	 * endpoint is in connected state */
 	if (fi_close(&rxm_conn->saved_msg_ep->fid))
@@ -147,7 +156,8 @@ static struct util_cmap_handle *rxm_conn_alloc(void)
 	struct rxm_conn *rxm_conn = calloc(1, sizeof(*rxm_conn));
 	if (OFI_UNLIKELY(!rxm_conn))
 		return NULL;
-
+	dlist_init(&rxm_conn->posted_rx_list);
+	dlist_init(&rxm_conn->saved_posted_rx_list);
 	dlist_init(&rxm_conn->postponed_tx_list);
 	return &rxm_conn->handle;
 }

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -730,7 +730,8 @@ static inline int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 	return FI_SUCCESS;
 }
 
-int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)
+int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep,
+		       struct dlist_entry *posted_rx_list)
 {
 	struct rxm_rx_buf *rx_buf;
 	int ret;
@@ -748,7 +749,8 @@ int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)
 			rxm_rx_buf_release(rxm_ep, rx_buf);
 			return ret;
 		}
-		dlist_insert_tail(&rx_buf->entry, &rxm_ep->post_rx_list);
+
+		dlist_insert_tail(&rx_buf->entry, posted_rx_list);
 	}
 	return 0;
 }

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -200,12 +200,13 @@ static void rxm_buf_pool_destroy(struct rxm_buf_pool *pool)
 	util_buf_pool_destroy(pool->pool);
 }
 
-static void rxm_ep_cleanup_post_rx_list(struct rxm_ep *rxm_ep)
+void rxm_ep_cleanup_posted_rx_list(struct rxm_ep *rxm_ep,
+				   struct dlist_entry *posted_rx_list)
 {
 	struct rxm_rx_buf *rx_buf;
-	while (!dlist_empty(&rxm_ep->post_rx_list)) {
-		dlist_pop_front(&rxm_ep->post_rx_list, struct rxm_rx_buf,
-				rx_buf, entry);
+
+	while (!dlist_empty(posted_rx_list)) {
+		dlist_pop_front(posted_rx_list, struct rxm_rx_buf, rx_buf, entry);
 		rxm_rx_buf_release(rxm_ep, rx_buf);
 	}
 }
@@ -327,7 +328,7 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 				  RXM_BUF_POOL_RX);
 	if (ret)
 		return ret;
-	dlist_init(&rxm_ep->post_rx_list);
+	dlist_init(&rxm_ep->posted_srx_list);
 	dlist_init(&rxm_ep->repost_ready_list);
 
 	/* Allocates resources for TX pools */
@@ -451,7 +452,7 @@ static void rxm_ep_txrx_res_close(struct rxm_ep *rxm_ep)
 {
 	rxm_ep_txrx_queue_close(rxm_ep);
 
-	rxm_ep_cleanup_post_rx_list(rxm_ep);
+	rxm_ep_cleanup_posted_rx_list(rxm_ep, &rxm_ep->posted_srx_list);
 	rxm_ep_txrx_pool_destroy(rxm_ep);
 }
 
@@ -1675,7 +1676,8 @@ static int rxm_ep_ctrl(struct fid *fid, int command, void *arg)
 			return -FI_ENOMEM;
 
 		if (rxm_ep->srx_ctx) {
-			ret = rxm_ep_prepost_buf(rxm_ep, rxm_ep->srx_ctx);
+			ret = rxm_ep_prepost_buf(rxm_ep, rxm_ep->srx_ctx,
+						 &rxm_ep->posted_srx_list);
 			if (ret) {
 				ofi_cmap_free(rxm_ep->util_ep.cmap);
 				FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,


### PR DESCRIPTION
This helps to avoid leak of the RX buffers that were preposted for closed
MSG EP in case of bi-directional connection (passive side of connection).

Before the connection is established and new MSG EP is allocated, move
old preposted RX buffers to the temporarily list and then cleanup the list.

When we have multiple spawned and then destroyed processes, the memory growths for every spawned processes. 
The following situation:
`spawn 1 proc -> destroy 1 proc -> spawn 2 proc -> destroy 2 proc -> ... -> spawn N proc -> destroy N proc
`would lead that (N * (rx-attr->size)) RX buffers will be available in RX buffers pool.
In this situation we can re-use allocated buffers that are no longer needed for the destroyed connection.
With this PR, RxM will allocate only (1 * (rx_attr->size)) RX buffers, if the sequence is followed as it in my example above.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>