### PR TITLE
prov/rxm: Fix reposting of multiple iovecs for FI_MULTI_RECV + optimizations

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -514,9 +514,10 @@ struct util_cmap_peer {
 	uint8_t addr[];
 };
 
-typedef struct util_cmap_handle* (*ofi_cmap_alloc_handle_func)(void);
+typedef struct util_cmap_handle*
+(*ofi_cmap_alloc_handle_func)(struct util_cmap *cmap);
 typedef void (*ofi_cmap_handle_func)(struct util_cmap_handle *handle);
-typedef int (*ofi_cmap_connect_func)(struct util_ep *cmap,
+typedef int (*ofi_cmap_connect_func)(struct util_ep *ep,
 				     struct util_cmap_handle *handle,
 				     const void *addr, size_t addrlen);
 typedef void *(*ofi_cmap_event_handler_func)(void *arg);

--- a/include/windows/pthread.h
+++ b/include/windows/pthread.h
@@ -41,12 +41,13 @@
 
 #define PTHREAD_MUTEX_INITIALIZER {0}
 
-#define pthread_cond_signal WakeConditionVariable
-#define pthread_cond_broadcast WakeAllConditionVariable
 #define pthread_mutex_init(mutex, attr) (InitializeCriticalSection(mutex), 0)
 #define pthread_mutex_destroy(mutex) (DeleteCriticalSection(mutex), 0)
 #define pthread_cond_init(cond, attr) (InitializeConditionVariable(cond), 0)
 #define pthread_cond_destroy(x)	/* nothing to do */
+#define pthread_cond_signal WakeConditionVariable
+#define pthread_cond_broadcast WakeAllConditionVariable
+#define pthread_cond_wait(cond, mutex) (SleepConditionVariableCS(cond, mutex, INFINITE), 0)
 
 typedef CRITICAL_SECTION	pthread_mutex_t;
 typedef CONDITION_VARIABLE	pthread_cond_t;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -313,7 +313,12 @@ struct rxm_tx_entry {
 		struct {
 			size_t segs_left;
 			uint64_t msg_id;
+			/* These lists for the TX buffers that are: */
+			/* - Has been successfully sent to the peer */
 			struct dlist_entry in_flight_tx_buf_list;
+			/* - Has been queued until it would be possbile
+			 *   to send it  */
+			struct dlist_entry deferred_tx_buf_list;
 			struct rxm_iov rxm_iov;
 			uint64_t iov_offset;
 		};

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -94,6 +94,45 @@ err:
 	return ret;
 }
 
+static int
+rxm_send_queue_init(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+		    struct rxm_send_queue *send_queue, size_t size)
+{
+	ssize_t i;
+
+	send_queue->rxm_conn = rxm_conn;
+	send_queue->rxm_ep = rxm_ep;
+	send_queue->fs = rxm_txe_fs_create(size);
+	if (!send_queue->fs)
+		return -FI_ENOMEM;
+
+	for (i = send_queue->fs->size - 1; i >= 0; i--) {
+		send_queue->fs->buf[i].conn = rxm_conn;
+		send_queue->fs->buf[i].ep = rxm_ep;
+	}
+
+	fastlock_init(&send_queue->lock);
+	return 0;
+}
+
+static void rxm_send_queue_close(struct rxm_send_queue *send_queue)
+{
+	if (send_queue->fs) {
+		struct rxm_tx_entry *tx_entry;
+		ssize_t i;
+
+		for (i = send_queue->fs->size - 1; i >= 0; i--) {
+			tx_entry = &send_queue->fs->buf[i];
+			if (tx_entry->tx_buf) {
+				rxm_tx_buf_release(tx_entry->ep, tx_entry->tx_buf);
+				tx_entry->tx_buf = NULL;
+			}
+		}
+		rxm_txe_fs_free(send_queue->fs);
+	}
+	fastlock_destroy(&send_queue->lock);
+}
+
 static void rxm_conn_close(struct util_cmap_handle *handle)
 {
 	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
@@ -131,6 +170,7 @@ static void rxm_conn_free(struct util_cmap_handle *handle)
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to close msg_ep\n");
 	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "Closed msg_ep\n");
 	rxm_conn->msg_ep = NULL;
+	rxm_send_queue_close(&rxm_conn->send_queue);
 
 	free(container_of(handle, struct rxm_conn, handle));
 }
@@ -151,11 +191,19 @@ static void rxm_conn_connected_handler(struct util_cmap_handle *handle)
 	rxm_conn->saved_msg_ep = NULL;
 }
 
-static struct util_cmap_handle *rxm_conn_alloc(void)
+static struct util_cmap_handle *rxm_conn_alloc(struct util_cmap *cmap)
 {
+	int ret;
+	struct rxm_ep *rxm_ep = container_of(cmap->ep, struct rxm_ep, util_ep);
 	struct rxm_conn *rxm_conn = calloc(1, sizeof(*rxm_conn));
 	if (OFI_UNLIKELY(!rxm_conn))
 		return NULL;
+	ret = rxm_send_queue_init(rxm_ep, rxm_conn, &rxm_conn->send_queue,
+				  rxm_ep->rxm_info->tx_attr->size);
+	if (ret) {
+		free(rxm_conn);
+		return NULL;
+	}
 	dlist_init(&rxm_conn->posted_rx_list);
 	dlist_init(&rxm_conn->saved_posted_rx_list);
 	dlist_init(&rxm_conn->postponed_tx_list);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -765,6 +765,9 @@ rxm_ep_format_tx_res_lightweight(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_con
 
 	assert((((*tx_buf)->pkt.ctrl_hdr.type == ofi_ctrl_data) &&
 		 (len <= rxm_ep->rxm_info->tx_attr->inject_size)) ||
+	       ((len > rxm_ep->rxm_info->tx_attr->inject_size) &&
+		(len <= rxm_ep->sar_limit) &&
+		((*tx_buf)->pkt.ctrl_hdr.type == ofi_ctrl_seg_data)) ||
 	       ((*tx_buf)->pkt.ctrl_hdr.type == ofi_ctrl_large_data));
 
 	(*tx_buf)->pkt.ctrl_hdr.conn_id = rxm_conn->handle.remote_key;
@@ -776,6 +779,21 @@ rxm_ep_format_tx_res_lightweight(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_con
 		(*tx_buf)->pkt.hdr.flags |= FI_REMOTE_CQ_DATA;
 		(*tx_buf)->pkt.hdr.data = data;
 	}
+
+	return FI_SUCCESS;
+}
+
+static inline ssize_t
+rxm_ep_alloc_tx_entry(struct rxm_conn *rxm_conn, void *context, uint8_t count,
+		      uint64_t flags, struct rxm_tx_entry **tx_entry)
+{
+	*tx_entry = rxm_tx_entry_get(&rxm_conn->send_queue);
+	if (OFI_UNLIKELY(!*tx_entry))
+		return -FI_EAGAIN;
+
+	(*tx_entry)->count = count;
+	(*tx_entry)->context = context;
+	(*tx_entry)->flags = flags;
 
 	return FI_SUCCESS;
 }
@@ -930,6 +948,122 @@ rxm_ep_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	/* release allocated buffer for further reuse */
 	rxm_tx_buf_release(rxm_ep, tx_buf);
 	return ret;
+}
+
+static inline struct rxm_tx_buf *
+rxm_ep_sar_tx_prepare_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+			      size_t total_len, size_t seg_num, size_t seg_len,
+			      uint64_t data, uint64_t flags, uint64_t tag,
+			      struct rxm_tx_entry *tx_entry)
+{
+	struct rxm_tx_buf *tx_buf;
+	ssize_t ret;
+
+	ret = rxm_ep_format_tx_res_lightweight(rxm_ep, rxm_conn, total_len, data,
+					       flags, tag, &tx_buf,
+					       &rxm_ep->buf_pools[RXM_BUF_POOL_TX_SAR]);
+	if (OFI_UNLIKELY(ret))
+		return NULL;
+
+	tx_buf->pkt.ctrl_hdr.msg_id = tx_entry->msg_id;
+	tx_buf->pkt.ctrl_hdr.seg_no = seg_num;
+	tx_buf->pkt.ctrl_hdr.seg_size = seg_len;
+
+	ofi_copy_from_iov(tx_buf->pkt.data, seg_len, tx_entry->rxm_iov.iov,
+			  tx_entry->rxm_iov.count, tx_entry->iov_offset);
+	tx_entry->iov_offset += seg_len;
+
+	return tx_buf;
+}
+
+static inline ssize_t
+rxm_ep_sar_tx_send_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+			   struct rxm_tx_buf *tx_buf, struct rxm_tx_entry *tx_entry)
+{
+	size_t pkt_size = rxm_pkt_size + tx_buf->pkt.ctrl_hdr.seg_size;
+	ssize_t ret = 0;
+
+	if (pkt_size > rxm_ep->msg_info->tx_attr->inject_size) {
+		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size,
+			      tx_buf->hdr.desc, 0, tx_entry);
+		if (OFI_UNLIKELY(ret))
+			return ret;
+	} else {
+		ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size, 0);
+		if (OFI_UNLIKELY(ret))
+			return ret;
+		if (!--tx_entry->segs_left)
+			return rxm_finish_send_nobuf(tx_entry);
+	}
+	return ret;
+}
+
+static inline size_t
+rxm_ep_sar_calc_seg_num(size_t data_len, size_t inject_size)
+{
+	return (data_len / inject_size + ((data_len % inject_size) ? 1 : 0));
+}
+
+static inline ssize_t
+rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+		   void *context, uint8_t count, const struct iovec *iov,
+		   size_t data_len, uint64_t data, uint64_t flags, uint64_t tag)
+{
+	struct rxm_tx_entry *tx_entry;
+	size_t seg_num =
+		rxm_ep_sar_calc_seg_num(data_len, rxm_ep->rxm_info->tx_attr->inject_size);
+	size_t i, total_len = data_len;
+	ssize_t ret;
+	int send_failed;
+
+	ret = rxm_ep_alloc_tx_entry(rxm_conn, context, count, flags, &tx_entry);
+	if (OFI_UNLIKELY(ret))
+		return ret;
+	tx_entry->state = RXM_SAR_TX;
+	dlist_init(&tx_entry->in_flight_tx_buf_list);
+	dlist_init(&tx_entry->deferred_tx_buf_list);
+	tx_entry->iov_offset = 0;
+	for (i = 0; i < count; i++)
+		tx_entry->rxm_iov.iov[i] = iov[i];
+	tx_entry->rxm_iov.count = count;
+	tx_entry->segs_left = seg_num;
+	tx_entry->msg_id = rxm_txe_fs_index(rxm_conn->send_queue.fs, tx_entry);
+	while (total_len) {
+		struct rxm_tx_buf *tx_buf;
+		size_t seg_len = total_len / seg_num;
+
+		tx_buf = rxm_ep_sar_tx_prepare_segment(rxm_ep, rxm_conn, data_len, seg_num,
+						       seg_len, data, flags, tag, tx_entry);
+		if (OFI_UNLIKELY(!tx_buf)) {
+			tx_entry->msg_id = UINT64_MAX;
+			while (!dlist_empty(&tx_entry->deferred_tx_buf_list)) {
+				dlist_pop_front(&tx_entry->in_flight_tx_buf_list,
+						struct rxm_tx_buf, tx_buf, in_flight_entry);
+				rxm_tx_buf_release(tx_entry->ep, tx_buf);
+			}
+			return -FI_EAGAIN;
+		}
+
+		dlist_init(&tx_buf->in_flight_entry);
+		if (!send_failed) {
+			ret = rxm_ep_sar_tx_send_segment(rxm_ep, rxm_conn, tx_buf, tx_entry);
+			if (OFI_UNLIKELY(ret)) {
+				send_failed = 1;
+				dlist_insert_tail(&tx_buf->in_flight_entry,
+						  &tx_entry->deferred_tx_buf_list);
+			} else {
+				dlist_insert_tail(&tx_buf->in_flight_entry,
+						  &tx_entry->in_flight_tx_buf_list);
+			}
+		} else {
+			dlist_insert_tail(&tx_buf->in_flight_entry,
+					  &tx_entry->deferred_tx_buf_list);
+		}
+		seg_num--;
+		total_len -= seg_len;
+	}
+
+	return 0;
 }
 
 void rxm_ep_handle_postponed_tx_op(struct rxm_ep *rxm_ep,
@@ -1133,8 +1267,8 @@ send_continue:
 	} else {
 		assert(!(flags & FI_INJECT));
 		if (data_len <= rxm_ep->sar_limit) {
-			assert(0);
-			return -FI_ENOSYS;
+			return rxm_ep_sar_tx_send(rxm_ep, rxm_conn, context, count, iov,
+						  data_len, data, flags, tag);
 		} else {
 			assert(data_len > rxm_ep->sar_limit);
 			ret = rxm_ep_alloc_lmt_tx_res(rxm_ep, rxm_conn, context,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -233,23 +233,6 @@ static int rxm_buf_pool_create(struct rxm_ep *rxm_ep,
 	return 0;
 }
 
-static int rxm_send_queue_init(struct rxm_ep *rxm_ep, struct rxm_send_queue *send_queue,
-			       size_t size)
-{
-	ssize_t i;
-
-	send_queue->rxm_ep = rxm_ep;
-	send_queue->fs = rxm_txe_fs_create(size);
-	if (!send_queue->fs)
-		return -FI_ENOMEM;
-
-	for (i = send_queue->fs->size - 1; i >= 0; i--)
-		send_queue->fs->buf[i].ep = rxm_ep;
-
-	fastlock_init(&send_queue->lock);
-	return 0;
-}
-
 static int rxm_recv_queue_init(struct rxm_ep *rxm_ep,  struct rxm_recv_queue *recv_queue,
 			       size_t size, enum rxm_recv_queue_type type)
 {
@@ -290,24 +273,6 @@ static int rxm_recv_queue_init(struct rxm_ep *rxm_ep,  struct rxm_recv_queue *re
 	}
 	fastlock_init(&recv_queue->lock);
 	return 0;
-}
-
-static void rxm_send_queue_close(struct rxm_send_queue *send_queue)
-{
-	if (send_queue->fs) {
-		struct rxm_tx_entry *tx_entry;
-		ssize_t i;
-
-		for (i = send_queue->fs->size - 1; i >= 0; i--) {
-			tx_entry = &send_queue->fs->buf[i];
-			if (tx_entry->tx_buf) {
-				rxm_tx_buf_release(tx_entry->ep, tx_entry->tx_buf);
-				tx_entry->tx_buf = NULL;
-			}
-		}
-		rxm_txe_fs_free(send_queue->fs);
-	}
-	fastlock_destroy(&send_queue->lock);
 }
 
 static void rxm_recv_queue_close(struct rxm_recv_queue *recv_queue)
@@ -374,16 +339,11 @@ static int rxm_ep_txrx_queue_init(struct rxm_ep *rxm_ep)
 {
 	int ret;
 
-	ret = rxm_send_queue_init(rxm_ep, &rxm_ep->send_queue,
-				  rxm_ep->rxm_info->tx_attr->size);
-	if (ret)
-		return ret;
-
 	ret = rxm_recv_queue_init(rxm_ep, &rxm_ep->recv_queue,
 				  rxm_ep->rxm_info->rx_attr->size,
 				  RXM_RECV_QUEUE_MSG);
 	if (ret)
-		goto err_recv_msg;
+		return ret;
 
 	ret = rxm_recv_queue_init(rxm_ep, &rxm_ep->trecv_queue,
 				  rxm_ep->rxm_info->rx_attr->size,
@@ -394,8 +354,6 @@ static int rxm_ep_txrx_queue_init(struct rxm_ep *rxm_ep)
 	return FI_SUCCESS;
 err_recv_tag:
 	rxm_recv_queue_close(&rxm_ep->recv_queue);
-err_recv_msg:
-	rxm_send_queue_close(&rxm_ep->send_queue);
 	return ret;
 }
 
@@ -403,7 +361,6 @@ static void rxm_ep_txrx_queue_close(struct rxm_ep *rxm_ep)
 {
 	rxm_recv_queue_close(&rxm_ep->trecv_queue);
 	rxm_recv_queue_close(&rxm_ep->recv_queue);
-	rxm_send_queue_close(&rxm_ep->send_queue);
 }
 
 static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep,
@@ -824,10 +781,10 @@ rxm_ep_format_tx_res_lightweight(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_con
 }
 
 static inline ssize_t
-rxm_ep_format_tx_entry(struct rxm_ep *rxm_ep, void *context, uint8_t count, uint64_t flags,
+rxm_ep_format_tx_entry(struct rxm_conn *rxm_conn, void *context, uint8_t count, uint64_t flags,
 		       struct rxm_tx_buf *tx_buf, struct rxm_tx_entry **tx_entry)
 {
-	*tx_entry = rxm_tx_entry_get(&rxm_ep->send_queue);
+	*tx_entry = rxm_tx_entry_get(&rxm_conn->send_queue);
 	if (OFI_UNLIKELY(!*tx_entry))
 		return -FI_EAGAIN;
 
@@ -854,7 +811,7 @@ rxm_ep_format_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	if (OFI_UNLIKELY(ret))
 		return ret;
 
-	ret = rxm_ep_format_tx_entry(rxm_ep, context, count, flags,
+	ret = rxm_ep_format_tx_entry(rxm_conn, context, count, flags,
 				     *tx_buf, tx_entry);
 	if (OFI_UNLIKELY(ret))
 		goto err;
@@ -881,7 +838,7 @@ rxm_ep_normal_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 				"fi_send for MSG provider failed\n");
 		rxm_tx_buf_release(rxm_ep, tx_entry->tx_buf);
-		rxm_tx_entry_release(&rxm_ep->send_queue, tx_entry);
+		rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
 	}
 	return ret;
 }
@@ -903,7 +860,7 @@ rxm_ep_alloc_lmt_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	if (OFI_UNLIKELY(ret))
 		return ret;
 	tx_buf->pkt.hdr.op = op;
-	tx_buf->pkt.ctrl_hdr.msg_id = rxm_txe_fs_index(rxm_ep->send_queue.fs,
+	tx_buf->pkt.ctrl_hdr.msg_id = rxm_txe_fs_index(rxm_conn->send_queue.fs,
 						       (*tx_entry));
 	if (!rxm_ep->rxm_mr_local) {
 		ret = rxm_ep_msg_mr_regv(rxm_ep, iov, (*tx_entry)->count,
@@ -919,7 +876,7 @@ rxm_ep_alloc_lmt_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	return rxm_rma_iov_init(rxm_ep, &(*tx_entry)->tx_buf->pkt.data, iov,
 				count, mr_iov);
 err:
-	rxm_tx_entry_release(&rxm_ep->send_queue, (*tx_entry));
+	rxm_tx_entry_release(&rxm_conn->send_queue, (*tx_entry));
 	rxm_tx_buf_release(rxm_ep, tx_buf);
 	return ret;
 }
@@ -952,7 +909,7 @@ err:
 	if (!rxm_ep->rxm_mr_local)
 		rxm_ep_msg_mr_closev(tx_entry->mr, tx_entry->count);
 	rxm_tx_buf_release(rxm_ep, tx_entry->tx_buf);
-	rxm_tx_entry_release(&rxm_ep->send_queue, tx_entry);
+	rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
 	return ret;
 }
 
@@ -992,7 +949,7 @@ void rxm_ep_handle_postponed_tx_op(struct rxm_ep *rxm_ep,
 		(void) rxm_ep_inject_send(rxm_ep, rxm_conn,
 					  tx_entry->tx_buf, tx_size);
 		/* Release TX entry for futher reuse */
-		rxm_tx_entry_release(&rxm_ep->send_queue, tx_entry);
+		rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
 	} else if (tx_entry->tx_buf->pkt.hdr.size >
 			rxm_ep->rxm_info->tx_attr->inject_size) {
 		struct rxm_rma_iov *rma_iov =
@@ -1178,7 +1135,7 @@ send_continue:
 		    (total_len <= rxm_ep->msg_info->tx_attr->inject_size))
 			return rxm_ep_inject_send(rxm_ep, rxm_conn, tx_buf, total_len);
 
-		ret = rxm_ep_format_tx_entry(rxm_ep, context, (uint8_t)count,
+		ret = rxm_ep_format_tx_entry(rxm_conn, context, (uint8_t)count,
 					     flags, tx_buf, &tx_entry);
 		if (OFI_UNLIKELY(ret)) {
 			rxm_tx_buf_release(rxm_ep, tx_buf);

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1269,7 +1269,7 @@ int util_cmap_alloc_handle(struct util_cmap *cmap, fi_addr_t fi_addr,
 			   enum util_cmap_state state,
 			   struct util_cmap_handle **handle)
 {
-	*handle = cmap->attr.alloc();
+	*handle = cmap->attr.alloc(cmap);
 	if (OFI_UNLIKELY(!*handle))
 		return -FI_ENOMEM;
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Allocated handle: %p for "
@@ -1289,7 +1289,7 @@ static int util_cmap_alloc_handle_peer(struct util_cmap *cmap, void *addr,
 	peer = calloc(1, sizeof(*peer) + cmap->av->addrlen);
 	if (!peer)
 		return -FI_ENOMEM;
-	*handle = cmap->attr.alloc();
+	*handle = cmap->attr.alloc(cmap);
 	if (!*handle) {
 		free(peer);
 		return -FI_ENOMEM;


### PR DESCRIPTION
This PR implements the following:
- prov/rxm: fix bug in rxm_match_iov
We should use different iterators for match_iov::iov and iov::iov as
they are not related to each other.
- prov/rxm: Optimize handling of `FI_MULTI_RECV` flag
This improves handling for posted single buffer (iov_count == 1)