### PR TITLE
prov/rxd: out-of-order reliability mode and other enhancements

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -81,6 +81,8 @@ extern "C" {
 		_a > _b ? _a : _b; })
 #endif
 
+#define ofi_div_ceil(a, b) ((a + b - 1) / b)
+
 
 /*
  * CPU specific features

--- a/man/fi_rxd.7.md
+++ b/man/fi_rxd.7.md
@@ -52,6 +52,12 @@ The *rxd* provider checks for the following environment variables:
 : Number of times to read the core provider's CQ for a segment completion
   before trying to progress sends. Default is 1000.
 
+*FI_RXD_OOO_RDM*
+: Toggles out-of-order reliability mode. This indicates that the rxd provider
+  can assume the core provider will not drop any packets, but might deliver
+  packets out of order. As a result, resending is turned off and the receiver
+  will reassemble all received packets. This mode is turned off by default.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -83,8 +83,11 @@
 #define RXD_LAST		(1 << 4)
 #define RXD_CTRL		(1 << 5)
 
-extern int rxd_progress_spin_count;
+struct rxd_env {
+	int spin_count;
+};
 
+extern struct rxd_env rxd_env;
 extern struct fi_provider rxd_prov;
 extern struct fi_info rxd_info;
 extern struct fi_fabric_attr rxd_fabric_attr;

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -85,6 +85,7 @@
 
 struct rxd_env {
 	int spin_count;
+	int ooo_rdm;
 };
 
 extern struct rxd_env rxd_env;
@@ -192,6 +193,8 @@ struct rxd_x_entry {
 	uint32_t next_start;
 	uint64_t retry_time;
 	uint8_t retry_cnt;
+	uint32_t num_segs;
+	uint64_t seg_size;
 
 	uint32_t flags;
 	uint8_t iov_count;
@@ -211,6 +214,7 @@ struct rxd_ctrl_hdr {
 	uint16_t window;
 	uint64_t size;
 	uint64_t data;
+	uint64_t seg_size;
 };
 
 struct rxd_pkt_hdr {

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -221,8 +221,10 @@ static int rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
 		if (cntr)
 			cntr->cntr_fid.ops->add(&cntr->cntr_fid, 1);
 	} else {
+		memset(&err_entry, 0, sizeof(err_entry));
 		err_entry.op_context = rx_entry->cq_entry.op_context;
 		err_entry.flags = (FI_MSG | FI_RECV);
+		err_entry.len = rx_entry->bytes_done;
 		err_entry.err = FI_ETRUNC;
 		err_entry.prov_errno = -FI_ETRUNC;
 		rxd_cq_report_error(rx_cq, &err_entry);

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -188,8 +188,8 @@ void rxd_cq_report_tx_comp(struct rxd_cq *cq, struct rxd_x_entry *tx_entry)
 	cq->write_fn(cq, &tx_entry->cq_entry);
 }
 
-static int rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
-			struct rxd_pkt_entry *pkt_entry, size_t size)
+static void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
+			     struct rxd_pkt_entry *pkt_entry, size_t size)
 {
 	struct fi_cq_err_entry err_entry;
 	struct rxd_cq *rx_cq = rxd_ep_rx_cq(ep);
@@ -202,18 +202,20 @@ static int rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
 			       size - sizeof(struct rxd_pkt_hdr) - ep->prefix_size);
 
 	rx_entry->bytes_done += done;
-	if (rx_entry->next_seg_no == rx_entry->next_start)
-		rx_entry->next_start += rx_entry->window;
 	rx_entry->next_seg_no++;
 
 	if (rx_entry->next_seg_no < rx_entry->num_segs) {
-		rx_entry->state = RXD_CTS;
-		return RXD_CTS;
+		if (rx_entry->next_seg_no == rx_entry->next_start) {
+			rx_entry->next_start += rx_entry->window;
+			rxd_ep_post_ack(ep, rx_entry);
+		} else {
+			rx_entry->state = RXD_CTS;
+		}
+		return;
 	}
-
-	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
 	rxd_ep_post_ack(ep, rx_entry);
 
+	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
 	/* Handle CQ comp */
 	if (rx_entry->bytes_done == rx_entry->cq_entry.len) {
 		rx_cq->write_fn(rx_cq, &rx_entry->cq_entry);
@@ -229,11 +231,9 @@ static int rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
 		err_entry.prov_errno = -FI_ETRUNC;
 		rxd_cq_report_error(rx_cq, &err_entry);
 	}
-
-	rxd_rx_entry_free(ep, rx_entry);
 	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
 
-	return RXD_FREE;
+	rxd_rx_entry_free(ep, rx_entry);
 }
 
 static int rxd_check_pkt_ids(struct rxd_x_entry *rx_entry,
@@ -256,21 +256,24 @@ void rxd_post_cts(struct rxd_ep *rxd_ep, struct rxd_x_entry *rx_entry,
 	struct rxd_pkt_entry *pkt_entry;
 	int ret;
 
-	rx_entry->peer = rts_pkt->peer;
-	rx_entry->window = rts_pkt->pkt->ctrl.window;
-	rx_entry->key = rts_pkt->pkt->hdr.key;
-	rx_entry->tx_id = rts_pkt->pkt->hdr.tx_id;
-	rx_entry->seg_size = rts_pkt->pkt->ctrl.seg_size;
-	rx_entry->state = RXD_ACK;
-	rx_entry->next_start = rx_entry->window;
-	rx_entry->num_segs = ofi_div_ceil(rts_pkt->pkt->ctrl.size,
-					  rts_pkt->pkt->ctrl.seg_size);
+	if (rx_entry->state == RXD_RTS) {
+		rx_entry->peer = rts_pkt->peer;
+		rx_entry->key = rts_pkt->pkt->hdr.key;
+		rx_entry->tx_id = rts_pkt->pkt->hdr.tx_id;
+		rx_entry->seg_size = rts_pkt->pkt->ctrl.seg_size;
+		rx_entry->num_segs = ofi_div_ceil(rts_pkt->pkt->ctrl.size,
+						  rts_pkt->pkt->ctrl.seg_size);
+		rx_entry->window = rts_pkt->pkt->ctrl.window;
+		rx_entry->next_start = rx_entry->window;
 
-	if (rts_pkt->pkt->hdr.flags & RXD_REMOTE_CQ_DATA) {
-		rx_entry->cq_entry.flags |= FI_REMOTE_CQ_DATA;
-		rx_entry->cq_entry.data = rts_pkt->pkt->ctrl.data;
+		if (rts_pkt->pkt->hdr.flags & RXD_REMOTE_CQ_DATA) {
+			rx_entry->cq_entry.flags |= FI_REMOTE_CQ_DATA;
+			rx_entry->cq_entry.data = rts_pkt->pkt->ctrl.data;
+		}
+		rx_entry->cq_entry.len = rts_pkt->pkt->ctrl.size;
+
+		rx_entry->state = RXD_ACK;
 	}
-	rx_entry->cq_entry.len = rts_pkt->pkt->ctrl.size;
 
 	pkt_entry = rxd_get_tx_pkt(rxd_ep);
 	if (!pkt_entry)
@@ -299,7 +302,6 @@ static void rxd_handle_data(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
 {
 	struct rxd_x_entry *rx_entry, tmp_entry;
 	uint32_t pkt_seg_no = pkt_entry->pkt->hdr.seg_no;
-	int ret;
 
 	rx_entry = &ep->rx_fs->buf[pkt_entry->pkt->hdr.rx_id];
 
@@ -317,19 +319,12 @@ static void rxd_handle_data(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
 		return;
 	}
 
-	if (pkt_seg_no == rx_entry->next_seg_no || rxd_env.ooo_rdm) {
-		ret = rxd_ep_recv_data(ep, rx_entry, pkt_entry, comp->len);
-		if (ret == RXD_FREE)
-			return;
-	} else if (rx_entry->state != RXD_ACK) {
-		goto post_ack;
-	}
-
-	if ((pkt_seg_no + 1) != rx_entry->next_start)
-		return;
-
-post_ack:
-	rxd_ep_post_ack(ep, rx_entry);
+	if (pkt_seg_no == rx_entry->next_seg_no || rxd_env.ooo_rdm)
+		rxd_ep_recv_data(ep, rx_entry, pkt_entry, comp->len);
+	else if (rx_entry->state != RXD_ACK ||
+		(rx_entry->next_seg_no == rx_entry->next_start &&
+		(pkt_seg_no + 1) == rx_entry->next_start))
+		rxd_ep_post_ack(ep, rx_entry);
 }
 
 static int rxd_check_active(struct rxd_ep *ep, struct rxd_pkt_entry *rts_pkt)
@@ -423,6 +418,7 @@ static void rxd_handle_cts(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
 	tx_entry->state = RXD_CTS;
 	tx_entry->rx_id = cts_pkt->pkt->hdr.rx_id;
 	tx_entry->peer_x_addr = cts_pkt->pkt->hdr.peer;
+	tx_entry->window = cts_pkt->pkt->ctrl.window;
 
 	if (tx_entry->flags & RXD_INJECT) {
 		pkt = container_of(slist_remove_head(&tx_entry->pkt_list),
@@ -526,7 +522,7 @@ void rxd_handle_recv_comp(struct rxd_ep *ep, struct fi_cq_msg_entry *comp)
 	}
 
 out:
-	if (!ret) {
+	if (ret != -FI_ENOMSG) {
 		rxd_release_rx_pkt(ep, pkt_entry);
 		rxd_ep_post_buf(ep);
 	}

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -36,8 +36,6 @@
 #include <ofi_iov.h>
 #include "rxd.h"
 
-int rxd_progress_spin_count = 1000;
-
 static uint32_t rxd_flags(uint64_t fi_flags)
 {
 	uint32_t rxd_flags = 0;
@@ -930,7 +928,7 @@ static void rxd_ep_progress(struct util_ep *util_ep)
 
 	fastlock_acquire(&ep->util_ep.lock);
 	for(ret = 1, i = 0;
-	    ret > 0 && (!rxd_progress_spin_count || i < rxd_progress_spin_count);
+	    ret > 0 && (!rxd_env.spin_count || i < rxd_env.spin_count);
 	    i++) {
 		ret = fi_cq_read(ep->dg_cq, &cq_entry, 1);
 		if (ret == -FI_EAGAIN)

--- a/prov/rxd/src/rxd_fabric.c
+++ b/prov/rxd/src/rxd_fabric.c
@@ -112,8 +112,6 @@ int rxd_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 	free(hints.fabric_attr);
 	fi_freeinfo(dg_info);
 
-	fi_param_get_int(&rxd_prov, "spin_count", &rxd_progress_spin_count);
-
 	return 0;
 err4:
 	fi_freeinfo(dg_info);

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -35,6 +35,15 @@
 #include <ofi_prov.h>
 #include "rxd.h"
 
+struct rxd_env rxd_env = {
+	.spin_count	= 1000,
+};
+
+static void rxd_init_env(void)
+{
+	fi_param_get_int(&rxd_prov, "spin_count", &rxd_env.spin_count);
+}
+
 int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
 		     struct fi_info *core_info)
 {
@@ -83,6 +92,8 @@ RXD_INI
 {
 	fi_param_define(&rxd_prov, "spin_count", FI_PARAM_INT,
 			"Number of iterations to receive packets (0 - infinite)");
+
+	rxd_init_env();
 
 	return &rxd_prov;
 }

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -37,11 +37,13 @@
 
 struct rxd_env rxd_env = {
 	.spin_count	= 1000,
+	.ooo_rdm	= 0,
 };
 
 static void rxd_init_env(void)
 {
 	fi_param_get_int(&rxd_prov, "spin_count", &rxd_env.spin_count);
+	fi_param_get_bool(&rxd_prov, "ooo_rdm", &rxd_env.ooo_rdm);
 }
 
 int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
@@ -92,6 +94,8 @@ RXD_INI
 {
 	fi_param_define(&rxd_prov, "spin_count", FI_PARAM_INT,
 			"Number of iterations to receive packets (0 - infinite)");
+	fi_param_define(&rxd_prov, "ooo_rdm", FI_PARAM_BOOL,
+			"Turn on out of order reliability mode (default: no)");
 
 	rxd_init_env();
 


### PR DESCRIPTION
- restructures environment variables to make future additions easier
- add FI_RXD_OOO_RDM environment variable to turn on out-of-order reliability mode (turn of retries, add reassembly of segments)
- coverity initialization fix
- reorganization to minimize amount of initialization, better readability, lock move, and removal of unnecessary return variable

Signed-off-by: aingerson <alexia.ingerson@intel.com>