### PR TITLE
prov/rxm: Remove redundant code + fix resetting of TX buffer during releasing

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -651,7 +651,7 @@ rxm_tx_buf_release(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 	assert((tx_buf->pkt.ctrl_hdr.type == ofi_ctrl_data) ||
 	       (tx_buf->pkt.ctrl_hdr.type == ofi_ctrl_large_data) ||
 	       (tx_buf->pkt.ctrl_hdr.type == ofi_ctrl_ack));
-	tx_buf->pkt.hdr.flags &= ~OFI_REMOTE_CQ_DATA;
+	tx_buf->pkt.hdr.flags &= ~FI_REMOTE_CQ_DATA;
 	rxm_buf_release(&rxm_ep->buf_pools[tx_buf->type],
 			(struct rxm_buf *)tx_buf);
 }

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -154,11 +154,14 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 
 			switch (pool->type) {
 			case RXM_BUF_POOL_TX_MSG:
+				tx_buf->pkt.hdr.flags = FI_MSG;
+				/* fall through */
 			case RXM_BUF_POOL_RMA:
 				tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_data;
 				tx_buf->pkt.hdr.op = ofi_op_msg;
 				break;
 			case RXM_BUF_POOL_TX_TAGGED:
+				tx_buf->pkt.hdr.flags = FI_TAGGED;
 				tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_data;
 				tx_buf->pkt.hdr.op = ofi_op_tagged;
 				break;
@@ -792,7 +795,7 @@ rxm_ep_format_tx_res_lightweight(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_con
 	(*tx_buf)->pkt.hdr.tag = tag;
 
 	if (flags & FI_REMOTE_CQ_DATA) {
-		(*tx_buf)->pkt.hdr.flags = FI_REMOTE_CQ_DATA;
+		(*tx_buf)->pkt.hdr.flags |= FI_REMOTE_CQ_DATA;
 		(*tx_buf)->pkt.hdr.data = data;
 	}
 


### PR DESCRIPTION
The PR does the following:
- prov/rxm: Fix the reseting of TX buffer packet flags
The flags should be reseted by FI_REMOTE_CQ_DATA rather than OFI_REMOTE_CQ_DATA,
because when TX buffer is allocated, FI_REMOTE_CQ_DATA is set to the flags,
if requested by user.
- prov/rxm: Preset FI_MSG and FI_TAGGED for TX buffers during EP setup
It is possible to preset hdr.flags to FI_TAGGED and FI_MSG based on
the type of the message once when allocated buffer pool.
- prov/rxm: Don't pass comp_flags into internal send/inject functions
We can drop redundant argument comp_flags and just use TX buffer hdr.flags
that are already set to the FI_MSG or FI_TAGGED.