### PR TITLE
prov/tcp: optimization: Maintain buf pool array with preset fields

### DIFF
--- a/prov/tcp/src/tcpx_attr.c
+++ b/prov/tcp/src/tcpx_attr.c
@@ -35,7 +35,7 @@
 #define TCPX_DOMAIN_CAPS FI_LOCAL_COMM | FI_REMOTE_COMM
 
 #define TCPX_MSG_ORDER (FI_ORDER_RAR | FI_ORDER_RAW | FI_ORDER_RAS |	\
-			FI_ORDER_WAW | FI_ORDER_WAS |	\
+			FI_ORDER_WAW | FI_ORDER_WAS |			\
 			FI_ORDER_SAW | FI_ORDER_SAS)
 
 static struct fi_tx_attr tcpx_tx_attr = {

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -311,7 +311,7 @@ static int proc_conn_resp(struct poll_fd_mgr *poll_mgr,
 		goto err;
 
 	len = fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED, cm_entry,
-				sizeof(*cm_entry) + poll_info->cm_data_sz, 0);
+			  sizeof(*cm_entry) + poll_info->cm_data_sz, 0);
 	if (len < 0) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
 		ret = (int) len;

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -251,7 +251,7 @@ int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		goto free_cq;
 
 	ret = ofi_cq_init(&tcpx_prov, domain, attr, &tcpx_cq->util_cq,
-			   &ofi_cq_progress, context);
+			  &ofi_cq_progress, context);
 	if (ret)
 		goto destroy_pool;
 

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -37,13 +37,21 @@
 
 #define TCPX_DEF_CQ_SIZE (1024)
 
+static void tcpx_buf_pools_destroy(struct tcpx_buf_pool *buf_pools)
+{
+	int i;
+
+	for (i = 0; i < TCPX_OP_CODE_MAX; i++)
+		util_buf_pool_destroy(buf_pools[i].pool);
+}
+
 static int tcpx_cq_close(struct fid *fid)
 {
 	int ret;
 	struct tcpx_cq *tcpx_cq;
 
 	tcpx_cq = container_of(fid, struct tcpx_cq, util_cq.cq_fid.fid);
-	util_buf_pool_destroy(tcpx_cq->xfer_entry_pool);
+	tcpx_buf_pools_destroy(tcpx_cq->buf_pools);
 	ret = ofi_cq_cleanup(&tcpx_cq->util_cq);
 	if (ret)
 		return ret;
@@ -52,7 +60,8 @@ static int tcpx_cq_close(struct fid *fid)
 	return 0;
 }
 
-struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *tcpx_cq)
+struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *tcpx_cq,
+					      enum tcpx_xfer_op_codes type)
 {
 	struct tcpx_xfer_entry *xfer_entry;
 
@@ -64,25 +73,25 @@ struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *tcpx_cq)
 		return NULL;
 	}
 
-	xfer_entry = util_buf_alloc(tcpx_cq->xfer_entry_pool);
+	xfer_entry = util_buf_alloc(tcpx_cq->buf_pools[type].pool);
 	if (!xfer_entry) {
 		tcpx_cq->util_cq.cq_fastlock_release(&tcpx_cq->util_cq.cq_lock);
 		FI_INFO(&tcpx_prov, FI_LOG_DOMAIN,"failed to get buffer\n");
 		return NULL;
 	}
 	tcpx_cq->util_cq.cq_fastlock_release(&tcpx_cq->util_cq.cq_lock);
-	memset(xfer_entry, 0, sizeof(*xfer_entry));
 	return xfer_entry;
 }
 
 void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
-			   struct tcpx_xfer_entry *xfer_entry)
+			     struct tcpx_xfer_entry *xfer_entry)
 {
 	if (xfer_entry->ep->cur_rx_entry == xfer_entry)
 		xfer_entry->ep->cur_rx_entry = NULL;
 
 	tcpx_cq->util_cq.cq_fastlock_acquire(&tcpx_cq->util_cq.cq_lock);
-	util_buf_release(tcpx_cq->xfer_entry_pool, xfer_entry);
+	util_buf_release(tcpx_cq->buf_pools[xfer_entry->msg_hdr.hdr.op_data].pool,
+			 xfer_entry);
 	tcpx_cq->util_cq.cq_fastlock_release(&tcpx_cq->util_cq.cq_lock);
 }
 
@@ -150,6 +159,80 @@ static struct fi_ops tcpx_cq_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
+/* Using this function to preset some values of buffers managed by util_buf_pool api.
+ * Note that the util_buf_pool uses first sizeof(slist_entry) bytes in every buffer
+ * internally for keeping buf list. So don't try to set those values. They won't stick
+ */
+static int tcpx_buf_pool_init(void *pool_ctx, void *addr,
+			      size_t len, void **context)
+{
+	struct tcpx_buf_pool *pool = (struct tcpx_buf_pool *)pool_ctx;
+	struct tcpx_xfer_entry *xfer_entry;
+	int i;
+
+	for (i = 0; i < pool->pool->chunk_cnt; i++) {
+		xfer_entry = (struct tcpx_xfer_entry *)
+			((char *)addr + i * pool->pool->entry_sz);
+
+		xfer_entry->msg_hdr.hdr.version = OFI_CTRL_VERSION;
+		xfer_entry->msg_hdr.hdr.op_data = pool->op_type;
+		switch (pool->op_type) {
+		case TCPX_OP_MSG_RECV:
+		case TCPX_OP_MSG_SEND:
+			xfer_entry->msg_hdr.hdr.op = ofi_op_msg;
+			break;
+		case TCPX_OP_WRITE:
+		case TCPX_OP_REMOTE_WRITE:
+			xfer_entry->msg_hdr.hdr.op = ofi_op_write;
+			break;
+		case TCPX_OP_READ_REQ:
+			xfer_entry->msg_hdr.hdr.op = ofi_op_read_req;
+			xfer_entry->msg_hdr.hdr.size =
+				htonll(sizeof(xfer_entry->msg_hdr));
+			xfer_entry->flags = TCPX_NO_COMPLETION;
+			break;
+		case TCPX_OP_READ_RSP:
+			xfer_entry->msg_hdr.hdr.op = ofi_op_read_rsp;
+			break;
+		case TCPX_OP_REMOTE_READ:
+			xfer_entry->flags = TCPX_NO_COMPLETION;
+			break;
+		default:
+			assert(0);
+			break;
+		}
+	}
+	return FI_SUCCESS;
+}
+
+void tcpx_buf_pool_close(void *pool_ctx, void *context)
+{
+}
+
+static int tcpx_buf_pools_create(struct tcpx_buf_pool *buf_pools)
+{
+	int i, ret;
+
+	for (i = 0; i < TCPX_OP_CODE_MAX; i++) {
+		buf_pools[i].op_type = i;
+
+		ret = util_buf_pool_create_ex(&buf_pools[i].pool,
+					      sizeof(struct tcpx_xfer_entry),
+					      16, 0, 1024, tcpx_buf_pool_init,
+					      tcpx_buf_pool_close, &buf_pools[i]);
+		if (ret) {
+			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Unable to create buf pool\n");
+			goto err;
+		}
+	}
+	return 0;
+err:
+	while (i--) {
+		util_buf_pool_destroy(buf_pools[i].pool);
+	}
+	return -FI_ENOMEM;
+}
+
 int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq_fid, void *context)
 {
@@ -163,9 +246,7 @@ int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (!attr->size)
 		attr->size = TCPX_DEF_CQ_SIZE;
 
-	ret =  util_buf_pool_create(&tcpx_cq->xfer_entry_pool,
-				    sizeof(struct tcpx_xfer_entry),
-				    16, 0, 1024);
+	ret = tcpx_buf_pools_create(tcpx_cq->buf_pools);
 	if (ret)
 		goto free_cq;
 
@@ -179,7 +260,7 @@ int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	return 0;
 
 destroy_pool:
-	util_buf_pool_destroy(tcpx_cq->xfer_entry_pool);
+	tcpx_buf_pools_destroy(tcpx_cq->buf_pools);
 free_cq:
 	free(tcpx_cq);
 	return ret;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -64,7 +64,7 @@ static ssize_t tcpx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 
 	assert(msg->iov_count < TCPX_IOV_LIMIT);
 
-	recv_entry = tcpx_xfer_entry_alloc(tcpx_cq);
+	recv_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_MSG_RECV);
 	if (!recv_entry)
 		return -FI_EAGAIN;
 
@@ -127,19 +127,13 @@ static ssize_t tcpx_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	tcpx_cq = container_of(tcpx_ep->util_ep.tx_cq, struct tcpx_cq,
 			       util_cq);
 
-	tx_entry = tcpx_xfer_entry_alloc(tcpx_cq);
+	tx_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_MSG_SEND);
 	if (!tx_entry)
 		return -FI_EAGAIN;
 
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
-
 	data_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count);
-
 	assert(!(flags & FI_INJECT) || (data_len <= TCPX_MAX_INJECT_SZ));
-
-	tx_entry->msg_hdr.hdr.version = OFI_CTRL_VERSION;
-	tx_entry->msg_hdr.hdr.op = ofi_op_msg;
-	tx_entry->msg_hdr.hdr.op_data = TCPX_OP_MSG_SEND;
 	tx_entry->msg_hdr.hdr.size = htonll(data_len + sizeof(tx_entry->msg_hdr));
 
 	tx_entry->msg_data.iov[0].iov_base = (void *) &tx_entry->msg_hdr;

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -116,8 +116,8 @@ static void tcpx_getinfo_ifs(struct fi_info **info)
 #endif
 
 static int tcpx_getinfo(uint32_t version, const char *node, const char *service,
-			 uint64_t flags, const struct fi_info *hints,
-			 struct fi_info **info)
+			uint64_t flags, const struct fi_info *hints,
+			struct fi_info **info)
 {
 	int ret;
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -235,7 +235,7 @@ static int tcpx_match_read_rsp(struct dlist_entry *entry, const void *arg)
 	struct tcpx_rx_detect *rx_detect = (struct tcpx_rx_detect *) arg;
 
 	xfer_entry = container_of(entry, struct tcpx_xfer_entry,
-				entry);
+				  entry);
 	return (xfer_entry->msg_hdr.hdr.remote_idx ==
 		ntohll(rx_detect->hdr.hdr.remote_idx));
 }
@@ -369,7 +369,7 @@ static void tcpx_process_rx_msg(struct tcpx_ep *ep)
 			goto err;
 
 		if (tcpx_get_rx_entry(&ep->rx_detect,
-					 &ep->cur_rx_entry))
+				      &ep->cur_rx_entry))
 			return;
 	}
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -196,9 +196,7 @@ static void tcpx_prepare_rx_remote_read_resp(struct tcpx_xfer_entry *resp_entry)
 			resp_entry->msg_data.iov[i+1].iov_len;
 	}
 
-	resp_entry->msg_hdr.hdr.version = OFI_CTRL_VERSION;
 	resp_entry->msg_hdr.hdr.op = ofi_op_read_rsp;
-	resp_entry->msg_hdr.hdr.op_data = TCPX_OP_REMOTE_READ_RSP;
 	resp_entry->msg_hdr.hdr.size =
 		htonll(resp_entry->msg_hdr.hdr.size);
 
@@ -286,14 +284,13 @@ static int tcpx_get_rx_entry(struct tcpx_rx_detect *rx_detect,
 		}
 		break;
 	case ofi_op_read_req:
-		rx_entry = tcpx_xfer_entry_alloc(tcpx_cq);
+		rx_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_REMOTE_READ);
 		if (!rx_entry)
 			return -FI_EAGAIN;
 
 		rx_entry->msg_hdr = rx_detect->hdr;
-		rx_entry->msg_hdr.hdr.op_data =	TCPX_OP_REMOTE_READ_REQ;
+		rx_entry->msg_hdr.hdr.op_data =	TCPX_OP_REMOTE_READ;
 		rx_entry->ep = tcpx_ep;
-		rx_entry->flags = TCPX_NO_COMPLETION;
 		rx_entry->done_len = sizeof(rx_detect->hdr);
 
 		ret = tcpx_validate_rx_rma_data(rx_entry, FI_REMOTE_READ);
@@ -305,7 +302,7 @@ static int tcpx_get_rx_entry(struct tcpx_rx_detect *rx_detect,
 		}
 		break;
 	case ofi_op_write:
-		rx_entry = tcpx_xfer_entry_alloc(tcpx_cq);
+		rx_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_REMOTE_WRITE);
 		if (!rx_entry)
 			return -FI_EAGAIN;
 
@@ -346,7 +343,7 @@ static int tcpx_get_rx_entry(struct tcpx_rx_detect *rx_detect,
 					entry);
 
 		rx_entry->msg_hdr = rx_detect->hdr;
-		rx_entry->msg_hdr.hdr.op_data = TCPX_OP_READ;
+		rx_entry->msg_hdr.hdr.op_data = TCPX_OP_READ_RSP;
 		rx_entry->done_len = sizeof(rx_detect->hdr);
 		break;
 	default:
@@ -383,10 +380,10 @@ static void tcpx_process_rx_msg(struct tcpx_ep *ep)
 	case TCPX_OP_REMOTE_WRITE:
 		process_rx_remote_write_entry(ep->cur_rx_entry);
 		break;
-	case TCPX_OP_READ:
+	case TCPX_OP_READ_RSP:
 		process_rx_read_entry(ep->cur_rx_entry);
 		break;
- 	case TCPX_OP_REMOTE_READ_REQ:
+ 	case TCPX_OP_REMOTE_READ:
 		tcpx_prepare_rx_remote_read_resp(ep->cur_rx_entry);
 		ep->cur_rx_entry = NULL;
 		break;

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -80,7 +80,7 @@ static void tcpx_rma_read_recv_entry_fill(struct tcpx_xfer_entry *recv_entry,
 }
 
 static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
-		uint64_t flags)
+				uint64_t flags)
 {
 	struct tcpx_ep *tcpx_ep;
 	struct tcpx_cq *tcpx_cq;
@@ -117,7 +117,7 @@ static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 }
 
 static ssize_t tcpx_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
-		fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
+			     fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
 {
 	struct iovec msg_iov = {
 		.iov_base = (void *)buf,
@@ -143,8 +143,8 @@ static ssize_t tcpx_rma_read(struct fid_ep *ep, void *buf, size_t len, void *des
 }
 
 static ssize_t tcpx_rma_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
-		void *context)
+			      size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
+			      void *context)
 {
 	struct fi_rma_iov rma_iov = {
 		.addr = addr,
@@ -166,7 +166,7 @@ static ssize_t tcpx_rma_readv(struct fid_ep *ep, const struct iovec *iov, void *
 }
 
 static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
-		uint64_t flags)
+				 uint64_t flags)
 {
 	struct tcpx_ep *tcpx_ep;
 	struct tcpx_cq *tcpx_cq;
@@ -238,7 +238,7 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 }
 
 static ssize_t tcpx_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
+			      fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
 {
 	struct iovec msg_iov = {
 		.iov_base = (void *)buf,
@@ -264,8 +264,8 @@ static ssize_t tcpx_rma_write(struct fid_ep *ep, const void *buf, size_t len, vo
 }
 
 static ssize_t tcpx_rma_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
-		size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		void *context)
+			       size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+			       void *context)
 {
 	struct fi_rma_iov rma_iov = {
 		.addr = addr,
@@ -288,8 +288,8 @@ static ssize_t tcpx_rma_writev(struct fid_ep *ep, const struct iovec *iov, void 
 
 
 static ssize_t tcpx_rma_writedata(struct fid_ep *ep, const void *buf, size_t len, void *desc,
-		uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
-		void *context)
+				  uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
+				  void *context)
 {
 	struct iovec msg_iov = {
 		.iov_base = (void *)buf,
@@ -315,7 +315,7 @@ static ssize_t tcpx_rma_writedata(struct fid_ep *ep, const void *buf, size_t len
 }
 
 static ssize_t tcpx_rma_inject(struct fid_ep *ep, const void *buf, size_t len,
-		fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+			       fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
 	struct iovec msg_iov = {
 		.iov_base = (void *)buf,
@@ -341,7 +341,7 @@ static ssize_t tcpx_rma_inject(struct fid_ep *ep, const void *buf, size_t len,
 }
 
 static ssize_t tcpx_rma_injectdata(struct fid_ep *ep, const void *buf, size_t len,
-		uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key)
+				   uint64_t data, fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
 	struct iovec msg_iov = {
 		.iov_base = (void *)buf,

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -53,24 +53,14 @@ static void tcpx_rma_read_send_entry_fill(struct tcpx_xfer_entry *send_entry,
 					  struct tcpx_ep *tcpx_ep,
 					  const struct fi_msg_rma *msg)
 {
-	send_entry->msg_hdr.hdr.version = OFI_CTRL_VERSION;
-	send_entry->msg_hdr.hdr.op = ofi_op_read_req;
-	send_entry->msg_hdr.hdr.op_data = TCPX_OP_READ;
-	send_entry->msg_hdr.hdr.size = htonll(sizeof(send_entry->msg_hdr));
-
 	memcpy(send_entry->msg_hdr.rma_iov, msg->rma_iov,
 	       msg->rma_iov_count * sizeof(msg->rma_iov[0]));
-
 	send_entry->msg_hdr.rma_iov_cnt = msg->rma_iov_count;
 
 	send_entry->msg_data.iov[0].iov_base = (void *) &send_entry->msg_hdr;
 	send_entry->msg_data.iov[0].iov_len = sizeof(send_entry->msg_hdr);
 	send_entry->msg_data.iov_cnt = 1;
-
-	send_entry->flags |= TCPX_NO_COMPLETION;
-	send_entry->msg_hdr.hdr.flags = htonl(send_entry->msg_hdr.hdr.flags);
 	send_entry->ep = tcpx_ep;
-	send_entry->context = msg->context;
 	send_entry->done_len = 0;
 }
 
@@ -79,24 +69,14 @@ static void tcpx_rma_read_recv_entry_fill(struct tcpx_xfer_entry *recv_entry,
 					  const struct fi_msg_rma *msg,
 					  uint64_t flags)
 {
-	uint64_t data_len;
-
-	data_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count);
-
-	recv_entry->msg_hdr.hdr.version = OFI_CTRL_VERSION;
-	recv_entry->msg_hdr.hdr.op = ofi_op_read_rsp;
-	recv_entry->msg_hdr.hdr.op_data = TCPX_OP_READ;
-	recv_entry->msg_hdr.hdr.size = htonll(sizeof(recv_entry->msg_hdr) +
-					      data_len);
-	recv_entry->msg_hdr.hdr.flags = 0;
-	recv_entry->ep = tcpx_ep;
-	recv_entry->context = msg->context;
-	recv_entry->done_len = 0;
-	recv_entry->flags = flags | FI_RMA | FI_READ;
 	memcpy(&recv_entry->msg_data.iov[0], &msg->msg_iov[0],
 	       msg->iov_count * sizeof(struct iovec));
 
 	recv_entry->msg_data.iov_cnt = msg->iov_count;
+	recv_entry->ep = tcpx_ep;
+	recv_entry->context = msg->context;
+	recv_entry->done_len = 0;
+	recv_entry->flags = flags | FI_RMA | FI_READ;
 }
 
 static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
@@ -114,13 +94,12 @@ static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
 	assert(msg->rma_iov_count <= TCPX_IOV_LIMIT);
 
-	send_entry = tcpx_xfer_entry_alloc(tcpx_cq);
+	send_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_READ_REQ);
 	if (!send_entry)
 		return -FI_EAGAIN;
 
-	recv_entry = tcpx_xfer_entry_alloc(tcpx_cq);
+	recv_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_READ_RSP);
 	if (!recv_entry) {
-		send_entry->msg_hdr.hdr.op_data = TCPX_OP_READ;
 		tcpx_xfer_entry_release(tcpx_cq, send_entry);
 		return -FI_EAGAIN;
 	}
@@ -198,7 +177,7 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 	tcpx_cq = container_of(tcpx_ep->util_ep.tx_cq, struct tcpx_cq,
 			       util_cq);
 
-	send_entry = tcpx_xfer_entry_alloc(tcpx_cq);
+	send_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_WRITE);
 	if (!send_entry)
 		return -FI_EAGAIN;
 


### PR DESCRIPTION
Instead of filling the fixed fields along fast path (send/recv/read/write), pre-initialize them once at the buffer pool creation.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>