### PR TITLE
prov/mrail: Return one fi_info per rail.

### DIFF
--- a/prov/mrail/src/mrail_init.c
+++ b/prov/mrail/src/mrail_init.c
@@ -128,6 +128,13 @@ int mrail_get_core_info(uint32_t version, const char *node, const char *service,
 		else
 			fi->next = info;
 		fi = info;
+
+		/* We only want the first fi_info entry per rail */
+		if (info->next) {
+			fi_freeinfo(info->next);
+			info->next = NULL;
+		}
+
 	}
 	goto out;
 err:


### PR DESCRIPTION
Signed-off-by: yohann <yohann.burette@intel.com>