### PR TITLE
core: Add circular-queue based sliding receive window utility

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -125,6 +125,7 @@ src_libfabric_la_SOURCES =			\
 	include/ofi_mem.h			\
 	include/ofi_osd.h			\
 	include/ofi_proto.h			\
+	include/ofi_recvwin.h			\
 	include/ofi_rbuf.h			\
 	include/ofi_shm.h			\
 	include/ofi_signal.h			\

--- a/include/ofi_recvwin.h
+++ b/include/ofi_recvwin.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * This utility provides a sliding receive window implementation. It uses a
+ * circular queue to order incoming messages based on the message ID in the
+ * transport protocol.
+ */
+
+#if !defined(FI_RECVWIN_H)
+#define FI_RECVWIN_H
+
+#include "config.h"
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <ofi.h>
+#include <ofi_rbuf.h>
+
+#define OFI_DECL_RECVWIN_BUF(entrytype, name)				\
+OFI_DECLARE_CIRQUE(entrytype, recvwin_cirq);				\
+struct name {								\
+	uint64_t exp_msg_id;						\
+	unsigned int win_size;						\
+	struct recvwin_cirq *pending;					\
+};									\
+									\
+static inline struct name *						\
+ofi_recvwin_buf_alloc(struct name *recvq, unsigned int size)		\
+{									\
+	assert(size == roundup_power_of_two(size));			\
+	recvq->exp_msg_id = 0;						\
+	recvq->win_size	= size;						\
+	recvq->pending	= recvwin_cirq_create(recvq->win_size);		\
+	return recvq;							\
+}									\
+									\
+static inline void							\
+ofi_recvwin_free(struct name *recvq)					\
+{									\
+	recvwin_cirq_free(recvq->pending);				\
+}									\
+									\
+static inline int							\
+ofi_recvwin_queue_msg(struct name *recvq, entrytype * msg, uint64_t id)	\
+{									\
+	int write_idx;							\
+									\
+	assert(ofi_recvwin_is_allowed(recvq, id));			\
+	write_idx = ofi_cirque_rindex(recvq->pending)			\
+		    + (id - recvq->exp_msg_id);				\
+	recvq->pending->buf[write_idx] = *msg;				\
+	ofi_cirque_commit(recvq->pending);				\
+	return 0;							\
+}									\
+									\
+static inline entrytype *						\
+ofi_recvwin_get_next_msg(struct name *recvq)				\
+{									\
+	if (ofi_cirque_head(recvq->pending)) {				\
+		ofi_recvwin_exp_inc(recvq);				\
+		return ofi_cirque_remove(recvq->pending);		\
+	} else {							\
+		return NULL;						\
+	}								\
+}									\
+									\
+static inline void							\
+ofi_recvwin_slide(struct name *recvq)					\
+{									\
+	ofi_recvwin_exp_inc(recvq);					\
+	ofi_cirque_discard(recvq->pending);				\
+	ofi_cirque_commit(recvq->pending);				\
+}
+
+#define ofi_recvwin_peek(rq)		(ofi_cirque_head(rq->pending))
+#define ofi_recvwin_is_empty(rq)	(ofi_cirque_isempty(rq->pending))
+#define ofi_recvwin_exp_inc(rq)		((rq)->exp_msg_id++)
+#define ofi_recvwin_is_exp(rq, id)	((rq)->exp_msg_id == id)
+#define ofi_recvwin_next_exp_id(rq)	((rq)->exp_msg_id)
+#define ofi_recvwin_is_delayed(rq, id)	((rq)->exp_msg_id > id)
+#define ofi_recvwin_is_allowed(rq, id)	(id >= rq->exp_msg_id \
+					&& id < (rq->win_size + rq->exp_msg_id))
+
+#endif /* FI_RECVWIN_H */


### PR DESCRIPTION
This commit adds a simple header that both utility and core providers
can use to implement packet ordering for `FI_ORDER_*` guarantees. The
reorder buffer utilizes a circular queue to hold packets that arrive
early on the rx side. The buffer can hold entries of any entry type as
declared using `OFI_DECL_RECVWIN_BUF`.

Signed-off-by: Raghu Raja <craghun@amazon.com>