### PR TITLE
man/rxd: fix rxd environment variable name

### DIFF
--- a/man/fi_rxd.7.md
+++ b/man/fi_rxd.7.md
@@ -48,11 +48,11 @@ tested.
 
 The *rxd* provider checks for the following environment variables:
 
-*FI_RXD_SPIN_COUNT*
+*FI_OFI_RXD_SPIN_COUNT*
 : Number of times to read the core provider's CQ for a segment completion
   before trying to progress sends. Default is 1000.
 
-*FI_RXD_OOO_RDM*
+*FI_OFI_RXD_OOO_RDM*
 : Toggles out-of-order reliability mode. This indicates that the rxd provider
   can assume the core provider will not drop any packets, but might deliver
   packets out of order. As a result, resending is turned off and the receiver


### PR DESCRIPTION
Signed-off-by: aingerson <alexia.ingerson@intel.com>