### PR TITLE
[v1.6.x] prov/rxm: serialize access to repost_ready_list

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -213,7 +213,10 @@ static int rxm_finish_recv(struct rxm_rx_buf *rx_buf, size_t done_len)
 			rxm_cntr_inc(rx_buf->ep->util_ep.rx_cntr);
 	}
 
+	fastlock_acquire(&rx_buf->ep->util_ep.lock);
 	dlist_insert_tail(&rx_buf->repost_entry, &rx_buf->ep->repost_ready_list);
+	fastlock_release(&rx_buf->ep->util_ep.lock);
+
 	if (rx_buf->recv_entry->flags & FI_MULTI_RECV) {
 		struct rxm_iov rxm_iov;
 
@@ -330,8 +333,12 @@ static int rxm_lmt_tx_finish(struct rxm_tx_entry *tx_entry)
 	ret = rxm_finish_send(tx_entry);
 	if (ret)
 		return ret;
+
+	fastlock_acquire(&tx_entry->ep->util_ep.lock);
 	dlist_insert_tail(&tx_entry->rx_buf->repost_entry,
 			  &tx_entry->ep->repost_ready_list);
+	fastlock_release(&tx_entry->ep->util_ep.lock);
+
 	return ret;
 }
 
@@ -552,10 +559,13 @@ static int rxm_handle_remote_write(struct rxm_ep *rxm_ep,
 		return ret;
 	}
 	rxm_cntr_inc(rxm_ep->util_ep.rem_wr_cntr);
-	if (comp->op_context)
+	if (comp->op_context) {
+		fastlock_acquire(&rxm_ep->util_ep.lock);
 		dlist_insert_tail(&((struct rxm_rx_buf *)
 					comp->op_context)->repost_entry,
 				  &rxm_ep->repost_ready_list);
+		fastlock_release(&rxm_ep->util_ep.lock);
+	}
 	return 0;
 }
 
@@ -730,11 +740,13 @@ int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)
 static inline void rxm_cq_repost_rx_buffers(struct rxm_ep *rxm_ep)
 {
 	struct rxm_rx_buf *buf;
+	fastlock_acquire(&rxm_ep->util_ep.lock);
 	while (!dlist_empty(&rxm_ep->repost_ready_list)) {
 		dlist_pop_front(&rxm_ep->repost_ready_list, struct rxm_rx_buf,
 				buf, repost_entry);
 		(void) rxm_ep_repost_buf(buf);
 	}
+	fastlock_release(&rxm_ep->util_ep.lock);
 }
 
 static int rxm_cq_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
@@ -791,8 +803,12 @@ static int rxm_cq_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
 					   &err_entry);
 			if (rx_buf->ep->util_ep.flags & OFI_CNTR_ENABLED)
 				rxm_cntr_incerr(rx_buf->ep->util_ep.rx_cntr);
+
+			fastlock_acquire(&rx_buf->ep->util_ep.lock);
 			dlist_insert_tail(&rx_buf->repost_entry,
 					  &rx_buf->ep->repost_ready_list);
+			fastlock_release(&rx_buf->ep->util_ep.lock);
+
 			if (!(rx_buf->recv_entry->flags & FI_MULTI_RECV))
 				rxm_recv_entry_release(recv_queue,
 						       rx_buf->recv_entry);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -521,8 +521,11 @@ static int rxm_ep_discard_recv(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf,
 	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Discarding message",
 			 rx_buf->unexp_msg.addr, rx_buf->unexp_msg.tag);
 
+	fastlock_acquire(&rxm_ep->util_ep.lock);
 	dlist_insert_tail(&rx_buf->repost_entry,
 			  &rx_buf->ep->repost_ready_list);
+	fastlock_release(&rxm_ep->util_ep.lock);
+
 	return ofi_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
 			    0, NULL, rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
 }


### PR DESCRIPTION
(cherry picked from commit e5baf8928e7217836a94b4fb927fb6b9746d7582)