### PR TITLE
prov/rxm, verbs: Use the RX attribute size of a core provider

### DIFF
--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -56,7 +56,7 @@ struct fi_rx_attr rxm_rx_attr = {
 	.caps = RXM_EP_CAPS | FI_MULTI_RECV,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_STRICT | FI_ORDER_DATA,
-	.size = 1024,
+	.size = SIZE_MAX,
 	.iov_limit= RXM_IOV_LIMIT,
 };
 

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -129,7 +129,7 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->rx_attr->mode		= info->mode;
 	info->rx_attr->msg_order 	= core_info->rx_attr->msg_order;
 	info->rx_attr->comp_order 	= core_info->rx_attr->comp_order;
-	info->rx_attr->size		= rxm_info.rx_attr->size;
+	info->rx_attr->size		= core_info->rx_attr->size;
 	info->rx_attr->iov_limit 	= MIN(rxm_info.rx_attr->iov_limit,
 					      core_info->rx_attr->iov_limit);
 


### PR DESCRIPTION
There are run-time parameters `FI_VERBS_RX_SIZE` and `FI_VERBS_TX_SIZE` that adjust verbs' provider default value for the `rx_attr::size` and `tx_attr::size` respectively.
But the `rx_attr::size` can be adjusted for RxM/verbs provider due to hard-coded value (1024). The patch fixes this issue.
