### PR TITLE
prov/shm: Optimize receive code paths

### DIFF
--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -57,10 +57,8 @@ static ssize_t smr_generic_recvmsg(struct smr_ep *ep, const struct iovec *iov,
 	entry = freestack_pop(ep->recv_fs);
 	memset(entry, 0, sizeof(*entry));
 
-	for (entry->iov_count = 0; entry->iov_count < iov_count;
-	     entry->iov_count++) {
-		entry->iov[entry->iov_count] = iov[entry->iov_count];
-	}
+	entry->iov_count = iov_count;
+	memcpy(&entry->iov, iov, sizeof(*iov) * iov_count);
 
 	entry->context = context;
 	entry->flags = flags;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -340,7 +340,7 @@ ssize_t smr_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	msg_iov.iov_len = len;
 
 	return smr_generic_recvmsg(ep, &msg_iov, 1, src_addr, tag, ignore,
-				   context, FI_TAGGED | smr_ep_tx_flags(ep));
+				   context, FI_TAGGED | smr_ep_rx_flags(ep));
 }
 
 ssize_t smr_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -352,7 +352,7 @@ ssize_t smr_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
 	return smr_generic_recvmsg(ep, iov, count, src_addr, tag, ignore,
-				   context, FI_TAGGED | smr_ep_tx_flags(ep));
+				   context, FI_TAGGED | smr_ep_rx_flags(ep));
 }
 
 ssize_t smr_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -55,7 +55,6 @@ static ssize_t smr_generic_recvmsg(struct smr_ep *ep, const struct iovec *iov,
 		goto out;
 	}
 	entry = freestack_pop(ep->recv_fs);
-	memset(entry, 0, sizeof(*entry));
 
 	entry->iov_count = iov_count;
 	memcpy(&entry->iov, iov, sizeof(*iov) * iov_count);
@@ -65,6 +64,7 @@ static ssize_t smr_generic_recvmsg(struct smr_ep *ep, const struct iovec *iov,
 	entry->addr = addr;
 	entry->tag = tag;
 	entry->ignore = ignore;
+	entry->err = 0;
 
 	if (flags & FI_TAGGED) {
 		ret = smr_progress_unexp(ep, entry);


### PR DESCRIPTION
Note bug fix in first commit.  Other commits optimize the recv paths for tagged and untagged messages.