### PR TITLE
prov/rxm: Set FI_ORDER_NONE for tx and rx completion ordering

### DIFF
--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -46,7 +46,7 @@
 struct fi_tx_attr rxm_tx_attr = {
 	.caps = RXM_EP_CAPS,
 	.msg_order = ~0x0ULL,
-	.comp_order = ~0x0ULL,
+	.comp_order = FI_ORDER_NONE,
 	.size = SIZE_MAX,
 	.iov_limit = RXM_IOV_LIMIT,
 	.rma_iov_limit = RXM_IOV_LIMIT,
@@ -55,7 +55,7 @@ struct fi_tx_attr rxm_tx_attr = {
 struct fi_rx_attr rxm_rx_attr = {
 	.caps = RXM_EP_CAPS | FI_MULTI_RECV,
 	.msg_order = ~0x0ULL,
-	.comp_order = FI_ORDER_STRICT | FI_ORDER_DATA,
+	.comp_order = FI_ORDER_NONE,
 	.size = SIZE_MAX,
 	.iov_limit= RXM_IOV_LIMIT,
 };

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -115,7 +115,7 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->tx_attr->caps		= rxm_info.tx_attr->caps;
 	info->tx_attr->mode		= info->mode;
 	info->tx_attr->msg_order 	= core_info->tx_attr->msg_order;
-	info->tx_attr->comp_order 	= core_info->tx_attr->comp_order;
+	info->tx_attr->comp_order 	= rxm_info.tx_attr->comp_order;
 	info->tx_attr->inject_size	= rxm_info.tx_attr->inject_size;
 	/* Export TX queue size same as that of MSG provider as we post TX
 	 * operations directly */
@@ -128,7 +128,7 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->rx_attr->caps		= rxm_info.rx_attr->caps;
 	info->rx_attr->mode		= info->mode;
 	info->rx_attr->msg_order 	= core_info->rx_attr->msg_order;
-	info->rx_attr->comp_order 	= core_info->rx_attr->comp_order;
+	info->rx_attr->comp_order 	= rxm_info.rx_attr->comp_order;
 	info->rx_attr->size		= core_info->rx_attr->size;
 	info->rx_attr->iov_limit 	= MIN(rxm_info.rx_attr->iov_limit,
 					      core_info->rx_attr->iov_limit);


### PR DESCRIPTION
RxM doesn't support `FI_ORDER_STRICT`, because RxM is a provider that supports RDM EP and doesn't add synchronization logic for different destination paths to report CQ entries in a strict ordering.


Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>