### PR TITLE
fi_mr_unspec and ge 1.5 API adjustments

### DIFF
--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2014 Intel Corporation, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  *
@@ -612,7 +612,9 @@ static int _gnix_ep_getinfo(enum fi_ep_type ep_type, uint32_t version,
 				/* define the mode we return to the user
 				 * prefer basic until scalable
 				 * has more testing time */
-				if (mr_mode & FI_MR_BASIC)
+				if (mr_mode == FI_MR_UNSPEC)
+					mr_mode = OFI_MR_BASIC_MAP;
+				else if (mr_mode & FI_MR_BASIC)
 					mr_mode = OFI_MR_BASIC_MAP;
 				else if ((mr_mode & GNIX_MR_BASIC_REQ) ==
 							GNIX_MR_BASIC_REQ)

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation. All rights reserved.
  * Copyright (c) 2018, Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2018      Los Alamos National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -498,7 +500,8 @@ int ofi_check_mr_mode(const struct fi_provider *prov, uint32_t api_version,
 				goto out;
 		} else {
 			prov_mode = ofi_cap_mr_mode(user_info->caps, prov_mode);
-			if ((user_mode & prov_mode) != prov_mode)
+			if (user_mode &&
+				(user_mode & prov_mode) != prov_mode)
 				goto out;
 		}
 	}
@@ -1087,7 +1090,8 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 		attr->mr_mode = (attr->mr_mode && attr->mr_mode != FI_MR_SCALABLE) ?
 				FI_MR_BASIC : FI_MR_SCALABLE;
 	} else {
-		if ((hints_mr_mode & attr->mr_mode) != attr->mr_mode) {
+		if (hints_mr_mode &&
+			(hints_mr_mode & attr->mr_mode) != attr->mr_mode) {
 			attr->mr_mode = ofi_cap_mr_mode(info_caps,
 						attr->mr_mode & hints_mr_mode);
 		}


### PR DESCRIPTION
We are trying to bring an OFI BTL online in the Open MPI
and encountering turbulence with the memory registration
model (domain attr mr_mode).

At first we had provider specific code to specify the >= 1.5 API
to keep various providers pacified.  Reviewers did not approve
of this provider specific bit encoding.  So we switched to
using FI_MR_UNSPEC while still using the >= 1.5 API.  Well
that caused problems with several providers, including the GNI
one.

Seems that there are several places in the mr_mode checks in
the utilities code that doesn't take into account the possible
use of FI_MR_UNSPEC while also using the >= 1.5 API.

This PR fixes the checks that cause the case of FI_MR_UNSPEC
to fail.

Otherwise, if this isn't right, what should we be setting the domain
attr mr_mode bits to be in our Open MPI OFI BTL such that it can
work with either fn FI_MR_BASIC or FI_MR_SCALABLE type providers?

Signed-off-by: Howard Pritchard <howardp@lanl.gov>