### PR TITLE
prov/tcp; fix connection hang issue

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -102,6 +102,7 @@ enum poll_fd_type {
 	CONNECT_SOCK,
 	PASSIVE_SOCK,
 	ACCEPT_SOCK,
+	CONNREQ_HANDLE,
 };
 
 enum poll_fd_state {
@@ -134,6 +135,7 @@ struct poll_fd_mgr {
 
 struct tcpx_conn_handle {
 	struct fid		handle;
+	struct tcpx_pep		*pep;
 	SOCKET			conn_fd;
 };
 


### PR DESCRIPTION
Issue: When app tries to connect itself within the same process, connection manager thread hangs.

In Current implementaion, on passive endpoint side, the connection manager thread waits for the cm data in blocking read after accepting the socket connection. Since the same thread handles sending cm data for the connect socket, thread hangs.

With this patch, new socket created in accept, waits for the poll event instead of just blocking on read.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>