### PR TITLE
common, rxm, rxd: Fix corruption of user buffer

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -69,6 +69,9 @@ static inline void *mem_dup(const void *src, size_t size)
  */
 #define FREESTACK_EMPTY	NULL
 
+#define freestack_get_next(user_buf)	((char *)user_buf - sizeof(void *))
+#define freestack_get_user_buf(entry)	((char *)entry + sizeof(void *))
+
 #define FREESTACK_HEADER 					\
 	size_t		size;					\
 	void		*next;					\
@@ -76,8 +79,8 @@ static inline void *mem_dup(const void *src, size_t size)
 #define freestack_isempty(fs)	((fs)->next == FREESTACK_EMPTY)
 #define freestack_push(fs, p)					\
 do {								\
-	*(void **) p = (fs)->next;				\
-	(fs)->next = p;						\
+	*(void **) (freestack_get_next(p)) = (fs)->next;	\
+	(fs)->next = (freestack_get_next(p));			\
 } while (0)
 #define freestack_pop(fs) freestack_pop_impl(fs, (fs)->next)
 
@@ -88,40 +91,47 @@ static inline void* freestack_pop_impl(void *fs, void *fs_next)
 	} *freestack = fs;
 	assert(!freestack_isempty(freestack));
 	freestack->next = *((void **)fs_next);
-	return fs_next;
+	return freestack_get_user_buf(fs_next);
 }
 
 #define DECLARE_FREESTACK(entrytype, name)			\
+struct name ## _entry {						\
+	void		*next;					\
+	entrytype	buf;					\
+};								\
 struct name {							\
 	FREESTACK_HEADER					\
-	entrytype	buf[];					\
+	struct name ## _entry	entry[];			\
 };								\
 								\
 static inline void name ## _init(struct name *fs, size_t size)	\
 {								\
 	ssize_t i;						\
 	assert(size == roundup_power_of_two(size));		\
-	assert(sizeof(fs->buf[0]) >= sizeof(void *));		\
+	assert(sizeof(fs->entry[0].buf) >= sizeof(void *));	\
 	fs->size = size;					\
 	fs->next = FREESTACK_EMPTY;				\
 	for (i = size - 1; i >= 0; i--)				\
-		freestack_push(fs, &fs->buf[i]);		\
+		freestack_push(fs, &fs->entry[i].buf);		\
 }								\
 								\
 static inline struct name * name ## _create(size_t size)	\
 {								\
 	struct name *fs;					\
-	fs = calloc(1, sizeof(*fs) + sizeof(entrytype) *	\
-		    (roundup_power_of_two(size)));		\
+	fs = calloc(1, sizeof(*fs) +				\
+		       sizeof(struct name ## _entry) *		\
+		       (roundup_power_of_two(size)));		\
 	if (fs)							\
 		name ##_init(fs, roundup_power_of_two(size));	\
 	return fs;						\
 }								\
 								\
 static inline int name ## _index(struct name *fs,		\
-		entrytype *entry)				\
+				 entrytype *entry)		\
 {								\
-	return (int)(entry - fs->buf);				\
+	return (int)((struct name ## _entry *)			\
+			(freestack_get_next(entry))		\
+			- (struct name ## _entry *)fs->entry);	\
 }								\
 								\
 static inline void name ## _free(struct name *fs)		\

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -313,7 +313,7 @@ static void rxd_handle_data(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
 	struct rxd_x_entry *rx_entry, tmp_entry;
 	uint32_t pkt_seg_no = pkt_entry->pkt->hdr.seg_no;
 
-	rx_entry = &ep->rx_fs->buf[pkt_entry->pkt->hdr.rx_id];
+	rx_entry = &ep->rx_fs->entry[pkt_entry->pkt->hdr.rx_id].buf;
 
 	if (!(rx_entry->state == RXD_CTS || rx_entry->state == RXD_ACK) ||
 	    rxd_check_pkt_ids(rx_entry, pkt_entry)) {
@@ -431,7 +431,7 @@ static void rxd_handle_cts(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
 	struct rxd_pkt_entry *pkt;
 	struct rxd_x_entry *tx_entry;
 
-	tx_entry = &ep->tx_fs->buf[cts_pkt->pkt->hdr.tx_id];
+	tx_entry = &ep->tx_fs->entry[cts_pkt->pkt->hdr.tx_id].buf;
 	if (tx_entry->state != RXD_RTS ||
 	    tx_entry->key != cts_pkt->pkt->hdr.key)
 		return;
@@ -469,7 +469,7 @@ static void rxd_handle_ack(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
 	struct util_cntr *cntr = ep->util_ep.tx_cntr;
 	struct rxd_x_entry *tx_entry;
 
-	tx_entry = &ep->tx_fs->buf[pkt_entry->pkt->hdr.tx_id];
+	tx_entry = &ep->tx_fs->entry[pkt_entry->pkt->hdr.tx_id].buf;
 	if (rxd_check_pkt_ids(tx_entry, pkt_entry) ||
 	    tx_entry->state != RXD_CTS)
 		return;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -107,8 +107,8 @@ rxm_send_queue_init(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		return -FI_ENOMEM;
 
 	for (i = send_queue->fs->size - 1; i >= 0; i--) {
-		send_queue->fs->buf[i].conn = rxm_conn;
-		send_queue->fs->buf[i].ep = rxm_ep;
+		send_queue->fs->entry[i].buf.conn = rxm_conn;
+		send_queue->fs->entry[i].buf.ep = rxm_ep;
 	}
 
 	fastlock_init(&send_queue->lock);
@@ -122,7 +122,7 @@ static void rxm_send_queue_close(struct rxm_send_queue *send_queue)
 		ssize_t i;
 
 		for (i = send_queue->fs->size - 1; i >= 0; i--) {
-			tx_entry = &send_queue->fs->buf[i];
+			tx_entry = &send_queue->fs->entry[i].buf;
 			if (tx_entry->tx_buf) {
 				rxm_tx_buf_release(tx_entry->ep, tx_entry->tx_buf);
 				tx_entry->tx_buf = NULL;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -326,7 +326,7 @@ static int rxm_lmt_handle_ack(struct rxm_rx_buf *rx_buf)
 	FI_DBG(&rxm_prov, FI_LOG_CQ, "Got ACK for msg_id: 0x%" PRIx64 "\n",
 	       rx_buf->pkt.ctrl_hdr.msg_id);
 
-	tx_entry = &rxm_conn->send_queue.fs->buf[rx_buf->pkt.ctrl_hdr.msg_id];
+	tx_entry = &rxm_conn->send_queue.fs->entry[rx_buf->pkt.ctrl_hdr.msg_id].buf;
 
 	assert(tx_entry->tx_buf->pkt.ctrl_hdr.msg_id == rx_buf->pkt.ctrl_hdr.msg_id);
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -255,8 +255,8 @@ static int rxm_recv_queue_init(struct rxm_ep *rxm_ep,  struct rxm_recv_queue *re
 			recv_queue->match_unexp = rxm_match_noop;
 		}
 		for (i = recv_queue->fs->size - 1; i >= 0; i--) {
-			recv_queue->fs->buf[i].comp_flags = FI_MSG | FI_RECV;
-			recv_queue->fs->buf[i].recv_queue = recv_queue;
+			recv_queue->fs->entry[i].buf.comp_flags = FI_MSG | FI_RECV;
+			recv_queue->fs->entry[i].buf.recv_queue = recv_queue;
 		}
 	} else {
 		if (rxm_ep->rxm_info->caps & FI_DIRECTED_RECV) {
@@ -267,8 +267,8 @@ static int rxm_recv_queue_init(struct rxm_ep *rxm_ep,  struct rxm_recv_queue *re
 			recv_queue->match_unexp = rxm_match_unexp_msg_tag;
 		}
 		for (i = recv_queue->fs->size - 1; i >= 0; i--) {
-			recv_queue->fs->buf[i].comp_flags = FI_TAGGED | FI_RECV;
-			recv_queue->fs->buf[i].recv_queue = recv_queue;
+			recv_queue->fs->entry[i].buf.comp_flags = FI_TAGGED | FI_RECV;
+			recv_queue->fs->entry[i].buf.recv_queue = recv_queue;
 		}
 	}
 	fastlock_init(&recv_queue->lock);


### PR DESCRIPTION
This PR fixes the corruption of users buffer in the freestack. `freestack_push` (`smr_freestack_push`) corrupts the first byte of the user data by setting the fs->next. Added the ctx field that is used by freestack implementation to set service data without touching user buffers.

The freestack functionality allocates an array of user's buffers and then pushes them into a LIFO list. Every user buffers contains reference to the previous value (the reference is assigned in the `freestack_push`). But this is set directly to the user buffer that leads to user's data corruption.
This PR fixes this by wrapping every user's buffer in the allocated array into structure that includes a pointer to the previous buffer in the freestack and the user's data. This solution helps to avoid user's data corruption