### PR TITLE
 contrib/cray: Add LD_LIBRARY_PATH to environment

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -48,6 +48,9 @@ pipeline {
             }
         }
         stage('Test: Phase 1') {
+            environment {
+                LD_LIBRARY_PATH = "$TMP_INSTALL_PATH/lib:$LD_LIBRARY_PATH"
+            }
             failFast true
             parallel {
                 stage('Unit tests') {
@@ -56,9 +59,6 @@ pipeline {
                     }
                 }
                 stage('Smoke tests') {
-                    environment {
-                        LD_LIBRARY_PATH = "$TMP_INSTALL_PATH/lib:$LD_LIBRARY_PATH"
-                    }
                     steps {
                         echo 'checking for the presence of the verbs provider'
                         script {
@@ -72,9 +72,6 @@ pipeline {
                     }
                 }
                 stage('Fabtests') {
-                    environment {
-                        LD_LIBRARY_PATH = "$TMP_INSTALL_PATH/lib:$LD_LIBRARY_PATH"
-                    }
                     steps {
                         // ignore the return code for fabtests until we can establish a fingerprint
                         timeout (time: 20, unit: 'MINUTES') {
@@ -106,6 +103,9 @@ pipeline {
             }
         }
         stage("Test: Phase 2") {
+            environment {
+                LD_LIBRARY_PATH = "$TMP_INSTALL_PATH/lib:$LD_LIBRARY_PATH"
+            }
             failFast true
             parallel {
                 stage("System tests") {
@@ -118,6 +118,9 @@ pipeline {
                         MPIR_CVAR_OFI_USE_PROVIDER = 'verbs'
                     }
                     steps {
+                        echo "checking ldd"
+                        launch "ldd $OMB_BUILD_PATH/pt2pt/osu_latency", 1, 1
+
                         echo "checking potential hosts"
                         launch "hostname", 4, 1
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -496,6 +496,15 @@ static void tcpx_ep_tx_rx_queues_release(struct tcpx_ep *ep)
 				       struct tcpx_cq, util_cq);
 		tcpx_xfer_entry_release(tcpx_cq, xfer_entry);
 	}
+
+	while (!slist_empty(&ep->rma_read_queue)) {
+		entry = ep->rma_read_queue.head;
+		xfer_entry = container_of(entry, struct tcpx_xfer_entry, entry);
+		slist_remove_head(&ep->rma_read_queue);
+		tcpx_cq = container_of(xfer_entry->ep->util_ep.tx_cq,
+				       struct tcpx_cq, util_cq);
+		tcpx_xfer_entry_release(tcpx_cq, xfer_entry);
+	}
 	fastlock_release(&ep->lock);
 }
 


### PR DESCRIPTION
This should help us to pick up the newest library rather than
the system default library.

Signed-off-by: James Swaro <jswaro@cray.com>