### PR TITLE
prov/rxm: Don't overwrite failed return value creating CQ

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1499,9 +1499,7 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep, enum fi_wait_obj wait_obj)
 
 	return 0;
 err:
-	ret = fi_close(&rxm_ep->msg_cq->fid);
-	if (ret)
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to close msg CQ\n");
+	fi_close(&rxm_ep->msg_cq->fid);
 	return ret;
 }
 


### PR DESCRIPTION
When running the cq_test over rxm;tcp on windows, the
ep_bind call fails (unable to allocate the tcp cq, since
there's no fd on windows).  However, the failure code is
lost, since it's overwritten when closing the cq on the
error path.

Instead, simply close the cq and return the original error
code.  This avoids the crash.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>