### PR TITLE
prov/sockets: suppress another gcc warning

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -684,7 +684,7 @@ static int sock_node_matches_interface(struct slist *addr_list, const char *node
 		SOCK_LOG_DBG("getaddrinfo failed!\n");
 		return -FI_EINVAL;
 	}
-	addr = *(struct sockaddr_in *)rai->ai_addr;
+	memcpy(&addr, rai->ai_addr, sizeof(struct sockaddr_in));
 	freeaddrinfo(rai);
 
 	return sock_addr_matches_interface(addr_list, &addr);


### PR DESCRIPTION
At least for GCC 6.3 and 7.3, this rather prominent warning
appears everytime I build libfabric:

```
prov/sockets/src/sock_fabric.c: In function 'sock_getinfo':
./include/unix/osd.h:199:62: warning: 'addr.sin6_addr.__in6_u.__u6_addr32[2]' may be used uninitialized in this function [-Wmaybe-uninitialized]
   (addr->sa_family == AF_INET6 &&
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[0] == 0 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[1] == 0 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
   ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[2] == 0 &&
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
prov/sockets/src/sock_fabric.c:677:21: note: 'addr.sin6_addr.__in6_u.__u6_addr32[2]' was declared here
  struct sockaddr_in addr = { 0 };
                     ^~~~
In file included from ./include/linux/osd.h:44:0,
                 from ./include/ofi_osd.h:68,
                 from prov/sockets/src/sock_fabric.c:51:
```

This commit makes the gcc compiler happier and it stops giving
this compiler warning.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>