### PR TITLE
prov/gni: Fix user provided authorization key

### DIFF
--- a/prov/gni/include/fi_ext_gni.h
+++ b/prov/gni/include/fi_ext_gni.h
@@ -166,8 +166,9 @@ struct fi_gni_auth_key {
 	};
 };
 
-#define GNIX_PROV_DEFAULT_AUTH_KEY NULL
-#define GNIX_PROV_DEFAULT_AUTH_KEYLEN 0
+extern uint8_t* gnix_default_auth_key;
+#define GNIX_PROV_DEFAULT_AUTH_KEY gnix_default_auth_key
+#define GNIX_PROV_DEFAULT_AUTH_KEYLEN sizeof(struct fi_gni_auth_key)
 
 #define FI_GNI_FAB_OPS_2 "fab ops 2"
 struct fi_gni_auth_key_ops_fab {

--- a/prov/gni/src/gnix_mbox_allocator.c
+++ b/prov/gni/src/gnix_mbox_allocator.c
@@ -39,6 +39,7 @@
 
 #include "gnix_mbox_allocator.h"
 #include "gnix_nic.h"
+#include "fi_ext_gni.h"
 
 /**
  * Will attempt to find a directory in the hugetlbfs with the given page size.
@@ -299,6 +300,7 @@ static int __create_slab(struct gnix_mbox_alloc_handle *handle)
 	int vmdh_index = -1;
 	int flags = GNI_MEM_READWRITE;
 	struct gnix_auth_key *info;
+	struct fi_gni_auth_key key;
 
 	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
@@ -343,8 +345,10 @@ static int __create_slab(struct gnix_mbox_alloc_handle *handle)
 
 	COND_ACQUIRE(handle->nic_handle->requires_lock, &handle->nic_handle->lock);
 	if (handle->nic_handle->using_vmdh) {
-		info = _gnix_auth_key_lookup(GNIX_PROV_DEFAULT_AUTH_KEY,
-				GNIX_PROV_DEFAULT_AUTH_KEYLEN);
+		key.type = GNIX_AKT_RAW;
+		key.raw.protection_key = handle->nic_handle->cookie;
+
+		info = _gnix_auth_key_lookup((uint8_t *) &key, sizeof(key));
 		assert(info);
 
 		if (!handle->nic_handle->mdd_resources_set) {

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -44,6 +44,7 @@
 #include "gnix_vc.h"
 #include "gnix_mbox_allocator.h"
 #include "gnix_util.h"
+#include "fi_ext_gni.h"
 
 /*
  * TODO: make this a domain parameter
@@ -205,6 +206,7 @@ static int __nic_setup_irq_cq(struct gnix_nic *nic)
 	int vmdh_index = -1;
 	int flags = GNI_MEM_READWRITE;
 	struct gnix_auth_key *info;
+	struct fi_gni_auth_key key;
 
 	len = (size_t)sysconf(_SC_PAGESIZE);
 
@@ -221,8 +223,10 @@ static int __nic_setup_irq_cq(struct gnix_nic *nic)
 	nic->irq_mmap_len = len;
 
 	if (nic->using_vmdh) {
-		info = _gnix_auth_key_lookup(GNIX_PROV_DEFAULT_AUTH_KEY,
-				GNIX_PROV_DEFAULT_AUTH_KEYLEN);
+		key.type = GNIX_AKT_RAW;
+		key.raw.protection_key = nic->cookie;
+
+		info = _gnix_auth_key_lookup((uint8_t *) &key, sizeof(key));
 		assert(info);
 
 		if (!nic->mdd_resources_set) {


### PR DESCRIPTION
If an authorization key is provided by the user the mbox and nic allocations will fail due to the fact that the default key is hard-coded.

The solution for the hard-coded arguments is to use the cookie stored with the nic to create a `struct fi_gni_auth_key` for the actual key lookup. This also requires a different handling of the default auth key within the functions of gnix_auth_key.c.

This will fix the issues for #4153 