### PR TITLE
prov/gni: fix a debug print statement

### DIFF
--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -1472,7 +1472,7 @@ ssize_t _gnix_rma(struct gnix_fid_ep *ep, enum gnix_fab_req_type fr_type,
 	rc = _gnix_vc_ep_get_vc(ep, dest_addr, &vc);
 	if (rc) {
 		GNIX_INFO(FI_LOG_EP_DATA,
-			  "_gnix_vc_ep_get_vc() failed, addr: %lx, rc:\n",
+			  "_gnix_vc_ep_get_vc() failed, addr: %lx, rc:%d\n",
 			  dest_addr, rc);
 		goto err_get_vc;
 	}


### PR DESCRIPTION
Add a missing %d to a debug print statement.
Thanks to Philip Davis for reporting.

Fixes #4135

Signed-off-by: Howard Pritchard <howardp@lanl.gov>