### PR TITLE
prov/verbs: verbs/msg doesn't generate CQE if a context is NULL

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -108,6 +108,8 @@
 #define VERBS_DEF_CQ_SIZE 1024
 #define VERBS_MR_IOV_LIMIT 1
 
+#define VERBS_INJECT_FLAG	((uint64_t)-1)
+
 #define FI_IBV_EP_TYPE(info)						\
 	((info && info->ep_attr) ? info->ep_attr->type : FI_EP_MSG)
 
@@ -588,20 +590,18 @@ static inline ssize_t fi_ibv_handle_post(ssize_t ret)
 static inline int
 fi_ibv_process_wc(struct fi_ibv_cq *cq, struct ibv_wc *wc)
 {
-	int ret = 1;
-
 	/* Handle WR entry when user doesn't request the completion */
-	if (!wc->wr_id)
+	if (wc->wr_id == VERBS_INJECT_FLAG)
 		return 0;
 
 	if (OFI_UNLIKELY(wc->status == IBV_WC_WR_FLUSH_ERR)) {
-		/* Handle case where remote side destroys
+		/* Handle case when remote side destroys
 		 * the connection, but local side isn't aware
 		 * about that yet */
-		ret = 0;
+		return 0;
 	}
 
-	return ret;
+	return 1;
 }
 
 static inline int fi_ibv_wc_2_wce(struct fi_ibv_cq *cq,

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -243,7 +243,7 @@ static inline int fi_ibv_poll_outstanding_cq(struct fi_ibv_ep *ep,
 		return ret;
 
 	/* Handle WR entry when user doesn't request the completion */
-	if (!wc.wr_id) {
+	if (wc.wr_id == VERBS_INJECT_FLAG) {
 		/* To ensure the new iteration */
 		return 1;
 	}

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -877,6 +877,8 @@ fi_ibv_send_buf(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
 {
 	struct ibv_sge sge = fi_ibv_init_sge(buf, len, desc);
 
+	assert(wr->wr_id != VERBS_INJECT_FLAG);
+
 	wr->sg_list = &sge;
 	wr->num_sge = 1;
 
@@ -888,6 +890,8 @@ fi_ibv_send_buf_inline(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
 		       const void *buf, size_t len)
 {
 	struct ibv_sge sge = fi_ibv_init_sge_inline(buf, len);
+
+	assert(wr->wr_id == VERBS_INJECT_FLAG);
 
 	wr->sg_list = &sge;
 	wr->num_sge = 1;
@@ -1040,6 +1044,7 @@ static ssize_t fi_ibv_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
+		.wr_id = VERBS_INJECT_FLAG,
 		.opcode = IBV_WR_SEND,
 		.send_flags = IBV_SEND_INLINE,
 	};
@@ -1053,6 +1058,7 @@ static ssize_t fi_ibv_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, 
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
+		.wr_id = VERBS_INJECT_FLAG,
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
 		.send_flags = IBV_SEND_INLINE,
@@ -1432,6 +1438,7 @@ fi_ibv_msg_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf, size_t le
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
+		.wr_id = VERBS_INJECT_FLAG,
 		.opcode = IBV_WR_RDMA_WRITE,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
@@ -1449,6 +1456,7 @@ fi_ibv_msg_ep_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
+		.wr_id = VERBS_INJECT_FLAG,
 		.opcode = IBV_WR_RDMA_WRITE_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
 		.wr.rdma.remote_addr = addr,


### PR DESCRIPTION
Fixes #4186

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>