### PR TITLE
contrib/cray: Remove true statement from test

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -73,10 +73,9 @@ pipeline {
                 }
                 stage('Fabtests') {
                     steps {
-                        // ignore the return code for fabtests until we can establish a fingerprint
                         timeout (time: 20, unit: 'MINUTES') {
                             script {
-                                def command = '$FABTEST_PATH/bin/runfabtests.sh -p $FABTEST_PATH/bin -v -T 60 \'ofi_rxm;verbs\' 10.100.49.8 10.100.49.9 || true'
+                                def command = '$FABTEST_PATH/bin/runfabtests.sh -p $FABTEST_PATH/bin -v -T 60 \'ofi_rxm;verbs\' 10.100.49.8 10.100.49.9'
                                 launch "$command", 1, 1, 'wham-0-cn8'
                             }
                         }


### PR DESCRIPTION
The fabtests seem to be passing now. No sense in fingerprinting that test
when all tests now pass.

Signed-off-by: James Swaro <jswaro@cray.com>