### PR TITLE
prov/rxm: Improve support of SAR protocol

### DIFF
--- a/include/ofi_proto.h
+++ b/include/ofi_proto.h
@@ -90,8 +90,10 @@ enum {
  * rx_key: This is the receiver's identifier for a message (receive side
  *     equivalent of msg_id).  Key returned by the Rx side, that the
  *     Tx side includes in subsequent packets.  This field is used for
- *     rendezvous and segmentation and reassembly protocols.
+ *     rendezvous protocol.
  *     The rx_key may be formed similar to message_id.
+ * seg_num: This is the total number of segments that is sent by sender
+ *     in a segmentation and reassembly (SAR) protocol.
  */
 struct ofi_ctrl_hdr {
 	uint8_t			version;
@@ -103,6 +105,7 @@ struct ofi_ctrl_hdr {
 	union {
 		uint64_t	conn_data;
 		uint64_t	rx_key;
+		uint64_t	segs_cnt;
 	};
 };
 


### PR DESCRIPTION
- **prov/rxm: Improve support of SAR protocol [RX side]** 
This improvement adds support of core providers that doesn't keep
ordering on receive side
First received SAR messages sets expected number of segments and then
`segs_left` value of RX entry is decremented.
Comparing `segs_left` with 1 means that we expecting the last SAR segment.
- **prov/rxm: Improve support of SAR protocol [TX side]**
Added support of providers that doesn't keep orderign of generating
TX CQ entries.
This implemented by removing in_flight_list queue and storing TX entry
per every TX buffer (pointer to TX buffer is passed as a context to fi_send)
