### PR TITLE
prov/rxm: Implement separate pool for inject operations

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -216,6 +216,7 @@ enum rxm_buf_pool_type {
 	RXM_BUF_POOL_START	= RXM_BUF_POOL_RX,
 	RXM_BUF_POOL_TX,
 	RXM_BUF_POOL_TX_START	= RXM_BUF_POOL_TX,
+	RXM_BUF_POOL_TX_INJECT,
 	RXM_BUF_POOL_TX_ACK,
 	RXM_BUF_POOL_TX_LMT,
 	RXM_BUF_POOL_TX_SAR,
@@ -663,6 +664,7 @@ static inline struct rxm_tx_buf *
 rxm_tx_buf_get(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
 {
 	assert((type == RXM_BUF_POOL_TX) ||
+	       (type == RXM_BUF_POOL_TX_INJECT) ||
 	       (type == RXM_BUF_POOL_TX_ACK) ||
 	       (type == RXM_BUF_POOL_TX_LMT) ||
 	       (type == RXM_BUF_POOL_TX_SAR));
@@ -673,6 +675,7 @@ static inline void
 rxm_tx_buf_release(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 {
 	assert((tx_buf->type == RXM_BUF_POOL_TX) ||
+	       (tx_buf->type == RXM_BUF_POOL_TX_INJECT) ||
 	       (tx_buf->type == RXM_BUF_POOL_TX_ACK) ||
 	       (tx_buf->type == RXM_BUF_POOL_TX_LMT) ||
 	       (tx_buf->type == RXM_BUF_POOL_TX_SAR));

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -214,9 +214,8 @@ struct rxm_rma_iov_storage {
 enum rxm_buf_pool_type {
 	RXM_BUF_POOL_RX		= 0,
 	RXM_BUF_POOL_START	= RXM_BUF_POOL_RX,
-	RXM_BUF_POOL_TX_MSG,
-	RXM_BUF_POOL_TX_START	= RXM_BUF_POOL_TX_MSG,
-	RXM_BUF_POOL_TX_TAGGED,
+	RXM_BUF_POOL_TX,
+	RXM_BUF_POOL_TX_START	= RXM_BUF_POOL_TX,
 	RXM_BUF_POOL_TX_ACK,
 	RXM_BUF_POOL_TX_LMT,
 	RXM_BUF_POOL_TX_SAR,
@@ -663,8 +662,7 @@ void rxm_buf_release(struct rxm_buf_pool *pool, struct rxm_buf *buf)
 static inline struct rxm_tx_buf *
 rxm_tx_buf_get(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
 {
-	assert((type == RXM_BUF_POOL_TX_MSG) ||
-	       (type == RXM_BUF_POOL_TX_TAGGED) ||
+	assert((type == RXM_BUF_POOL_TX) ||
 	       (type == RXM_BUF_POOL_TX_ACK) ||
 	       (type == RXM_BUF_POOL_TX_LMT) ||
 	       (type == RXM_BUF_POOL_TX_SAR));
@@ -674,8 +672,7 @@ rxm_tx_buf_get(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
 static inline void
 rxm_tx_buf_release(struct rxm_ep *rxm_ep, struct rxm_tx_buf *tx_buf)
 {
-	assert((tx_buf->type == RXM_BUF_POOL_TX_MSG) ||
-	       (tx_buf->type == RXM_BUF_POOL_TX_TAGGED) ||
+	assert((tx_buf->type == RXM_BUF_POOL_TX) ||
 	       (tx_buf->type == RXM_BUF_POOL_TX_ACK) ||
 	       (tx_buf->type == RXM_BUF_POOL_TX_LMT) ||
 	       (tx_buf->type == RXM_BUF_POOL_TX_SAR));

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -151,17 +151,11 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			tx_buf->hdr.desc = mr_desc;
 
 			switch (pool->type) {
-			case RXM_BUF_POOL_TX_MSG:
-				tx_buf->pkt.hdr.flags = FI_MSG;
-				/* fall through */
 			case RXM_BUF_POOL_RMA:
-				tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_data;
 				tx_buf->pkt.hdr.op = ofi_op_msg;
-				break;
-			case RXM_BUF_POOL_TX_TAGGED:
-				tx_buf->pkt.hdr.flags = FI_TAGGED;
+				/* fall through */
+			case RXM_BUF_POOL_TX:
 				tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_data;
-				tx_buf->pkt.hdr.op = ofi_op_tagged;
 				break;
 			case RXM_BUF_POOL_TX_ACK:
 				tx_buf->pkt.ctrl_hdr.type = ofi_ctrl_ack;
@@ -1120,7 +1114,7 @@ static inline ssize_t
 rxm_ep_postpone_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		     void *context, uint8_t count, const struct iovec *iov,
 		     void **desc, size_t len, uint64_t data, uint64_t flags,
-		     uint64_t tag, struct rxm_buf_pool *pool, uint8_t op)
+		     uint64_t tag, uint8_t op, uint64_t comp_flags)
 {
 	struct rxm_tx_entry *tx_entry;
 	struct rxm_tx_buf *tx_buf;
@@ -1136,9 +1130,12 @@ rxm_ep_postpone_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	} else {
 		ssize_t ret = rxm_ep_format_tx_res(rxm_ep, rxm_conn, context, count,
 						   len, data, flags, tag,
-						   &tx_buf, &tx_entry, pool);
+						   &tx_buf, &tx_entry,
+						   &rxm_ep->buf_pools[RXM_BUF_POOL_TX]);
 		if (OFI_UNLIKELY(ret))
 			return ret;
+		tx_buf->pkt.hdr.op = op;
+		tx_buf->pkt.hdr.flags = comp_flags;
 		ofi_copy_from_iov(tx_buf->pkt.data, tx_buf->pkt.hdr.size,
 				  iov, count, 0);
 		tx_entry->state = RXM_TX;
@@ -1152,7 +1149,7 @@ rxm_ep_postpone_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 static inline ssize_t
 rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 		     fi_addr_t dest_addr, uint64_t data, uint64_t flags,
-		     uint64_t tag, struct rxm_buf_pool *pool)
+		     uint64_t tag, uint8_t op, uint64_t comp_flags)
 {
 	struct rxm_conn *rxm_conn;
 	struct rxm_tx_buf *tx_buf;
@@ -1175,7 +1172,7 @@ rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 			goto cmap_err;
 		ret = rxm_ep_postpone_send(rxm_ep, rxm_conn, NULL, 1,
 					   &iov, NULL, len, data, flags,
-					   tag, pool, 0);
+					   tag, op, comp_flags);
 cmap_err:
 		fastlock_release(&rxm_ep->util_ep.cmap->lock);
 		return ret;
@@ -1186,11 +1183,14 @@ inject_continue:
 	assert(dlist_empty(&rxm_conn->deferred_tx_list));
 
 	if (pkt_size <= rxm_ep->msg_info->tx_attr->inject_size) {
-		ret = rxm_ep_format_tx_res_lightweight(rxm_ep, rxm_conn, len,
-						       data, flags, tag,
-						       &tx_buf, pool);
+		ret = rxm_ep_format_tx_res_lightweight(
+						rxm_ep, rxm_conn, len,
+						data, flags, tag, &tx_buf,
+						&rxm_ep->buf_pools[RXM_BUF_POOL_TX]);
 		if (OFI_UNLIKELY(ret))
 	    		return ret;
+		tx_buf->pkt.hdr.op = op;
+		tx_buf->pkt.hdr.flags = comp_flags;
 		memcpy(tx_buf->pkt.data, buf, tx_buf->pkt.hdr.size);
 		return rxm_ep_inject_send(rxm_ep, rxm_conn, tx_buf, pkt_size);
 	} else {
@@ -1201,9 +1201,12 @@ inject_continue:
 		       pkt_size, rxm_ep->msg_info->tx_attr->inject_size);
 		ret = rxm_ep_format_tx_res(rxm_ep, rxm_conn, NULL, 1,
 					   len, data, flags, tag,
-					   &tx_buf, &tx_entry, pool);
+					   &tx_buf, &tx_entry,
+					   &rxm_ep->buf_pools[RXM_BUF_POOL_TX]);
 		if (OFI_UNLIKELY(ret))
 			return ret;
+		tx_buf->pkt.hdr.op = op;
+		tx_buf->pkt.hdr.flags = comp_flags;
 		memcpy(tx_buf->pkt.data, buf, tx_buf->pkt.hdr.size);
 		tx_entry->state = RXM_TX;
 		return rxm_ep_normal_send(rxm_ep, rxm_conn, tx_entry, pkt_size);
@@ -1214,7 +1217,7 @@ inject_continue:
 static ssize_t
 rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 		   size_t count, fi_addr_t dest_addr, void *context, uint64_t data,
-		   uint64_t flags, uint64_t tag, struct rxm_buf_pool *pool, uint8_t op)
+		   uint64_t flags, uint64_t tag, uint8_t op, uint64_t comp_flags)
 {
 	struct rxm_conn *rxm_conn;
 	struct rxm_tx_entry *tx_entry;
@@ -1232,13 +1235,9 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 			goto send_continue;
 		else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
 			goto cmap_err;
-		ret = rxm_ep_postpone_send(
-				rxm_ep, rxm_conn, context, count, iov,
-				desc, data_len, data, flags, tag,
-				(data_len <=
-					rxm_ep->rxm_info->tx_attr->inject_size ?
-				 pool :
-				 &rxm_ep->buf_pools[RXM_BUF_POOL_TX_LMT]), op);
+		ret = rxm_ep_postpone_send(rxm_ep, rxm_conn, context, count,
+					   iov, desc, data_len, data, flags,
+					   tag, op, comp_flags);
 cmap_err:
 		fastlock_release(&rxm_ep->util_ep.cmap->lock);
 		return ret;
@@ -1251,10 +1250,14 @@ send_continue:
 	if (data_len <= rxm_ep->rxm_info->tx_attr->inject_size) {
 		size_t total_len = sizeof(struct rxm_pkt) + data_len;
 
-		ret = rxm_ep_format_tx_res_lightweight(rxm_ep, rxm_conn, data_len, data,
-						       flags, tag, &tx_buf, pool);
+		ret = rxm_ep_format_tx_res_lightweight(
+					rxm_ep, rxm_conn, data_len, data,
+					flags, tag, &tx_buf,
+					&rxm_ep->buf_pools[RXM_BUF_POOL_TX]);
 		if (OFI_UNLIKELY(ret))
 			return ret;
+		tx_buf->pkt.hdr.op = op;
+		tx_buf->pkt.hdr.flags = comp_flags;
 		ofi_copy_from_iov(tx_buf->pkt.data, tx_buf->pkt.hdr.size,
 				  iov, count, 0);
 
@@ -1298,8 +1301,7 @@ static ssize_t rxm_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	return rxm_ep_send_common(rxm_ep, msg->msg_iov, msg->desc, msg->iov_count,
 				  msg->addr, msg->context, msg->data,
 				  flags | (rxm_ep_tx_flags(rxm_ep) & FI_COMPLETION),
-				  0, &rxm_ep->buf_pools[RXM_BUF_POOL_TX_MSG],
-				  ofi_op_msg);
+				  0, ofi_op_msg, FI_MSG);
 }
 
 static ssize_t rxm_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -1313,9 +1315,7 @@ static ssize_t rxm_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 					     util_ep.ep_fid.fid);
 
 	return rxm_ep_send_common(rxm_ep, &iov, &desc, 1, dest_addr, context, 0,
-				  rxm_ep_tx_flags(rxm_ep), 0,
-				  &rxm_ep->buf_pools[RXM_BUF_POOL_TX_MSG],
-				  ofi_op_msg);
+				  rxm_ep_tx_flags(rxm_ep), 0, ofi_op_msg, FI_MSG);
 }
 
 static ssize_t rxm_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -1326,8 +1326,7 @@ static ssize_t rxm_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 					     util_ep.ep_fid.fid);
 
 	return rxm_ep_send_common(rxm_ep, iov, desc, count, dest_addr, context, 0,
-				  rxm_ep_tx_flags(rxm_ep), 0,
-				  &rxm_ep->buf_pools[RXM_BUF_POOL_TX_MSG], ofi_op_msg);
+				  rxm_ep_tx_flags(rxm_ep), 0, ofi_op_msg, FI_MSG);
 }
 
 static ssize_t rxm_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -1338,7 +1337,7 @@ static ssize_t rxm_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	return rxm_ep_inject_common(rxm_ep, buf, len, dest_addr, 0,
 				    rxm_ep->util_ep.inject_op_flags, 0,
-				    &rxm_ep->buf_pools[RXM_BUF_POOL_TX_MSG]);
+				    ofi_op_msg, FI_MSG);
 }
 
 static ssize_t rxm_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -1354,8 +1353,7 @@ static ssize_t rxm_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t le
 
 	return rxm_ep_send_common(rxm_ep, &iov, desc, 1, dest_addr, context, data,
 				  rxm_ep_tx_flags(rxm_ep) | FI_REMOTE_CQ_DATA,
-				  0, &rxm_ep->buf_pools[RXM_BUF_POOL_TX_MSG],
-				  ofi_op_msg);
+				  0, ofi_op_msg, FI_MSG);
 }
 
 static ssize_t rxm_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -1366,7 +1364,7 @@ static ssize_t rxm_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t 
 
 	return rxm_ep_inject_common(rxm_ep, buf, len, dest_addr, data,
 				    rxm_ep->util_ep.inject_op_flags | FI_REMOTE_CQ_DATA,
-				    0, &rxm_ep->buf_pools[RXM_BUF_POOL_TX_MSG]);
+				    0, ofi_op_msg, FI_MSG);
 }
 
 static struct fi_ops_msg rxm_ops_msg = {
@@ -1431,8 +1429,7 @@ static ssize_t rxm_ep_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged
 	return rxm_ep_send_common(rxm_ep, msg->msg_iov, msg->desc, msg->iov_count,
 				  msg->addr, msg->context, msg->data,
 				  flags | (rxm_ep_tx_flags(rxm_ep) & FI_COMPLETION),
-				  msg->tag, &rxm_ep->buf_pools[RXM_BUF_POOL_TX_TAGGED],
-				  ofi_op_tagged);
+				  msg->tag, ofi_op_tagged, FI_TAGGED);
 }
 
 static ssize_t rxm_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -1447,9 +1444,8 @@ static ssize_t rxm_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 					     util_ep.ep_fid.fid);
 
 	return rxm_ep_send_common(rxm_ep, &iov, &desc, 1, dest_addr, context, 0,
-				  rxm_ep_tx_flags(rxm_ep), tag,
-				  &rxm_ep->buf_pools[RXM_BUF_POOL_TX_TAGGED],
-				  ofi_op_tagged);
+				  rxm_ep_tx_flags(rxm_ep), tag, ofi_op_tagged,
+				  FI_TAGGED);
 }
 
 static ssize_t rxm_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -1460,9 +1456,8 @@ static ssize_t rxm_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
 					     util_ep.ep_fid.fid);
 
 	return rxm_ep_send_common(rxm_ep, iov, desc, count, dest_addr, context, 0,
-				  rxm_ep_tx_flags(rxm_ep), tag,
-				  &rxm_ep->buf_pools[RXM_BUF_POOL_TX_TAGGED],
-				  ofi_op_tagged);
+				  rxm_ep_tx_flags(rxm_ep), tag, ofi_op_tagged,
+				  FI_TAGGED);
 }
 
 static ssize_t rxm_ep_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -1473,7 +1468,7 @@ static ssize_t rxm_ep_tinject(struct fid_ep *ep_fid, const void *buf, size_t len
 
 	return rxm_ep_inject_common(rxm_ep, buf, len, dest_addr, 0,
 				    rxm_ep->util_ep.inject_op_flags, tag,
-				    &rxm_ep->buf_pools[RXM_BUF_POOL_TX_TAGGED]);
+				    ofi_op_tagged, FI_TAGGED);
 }
 
 static ssize_t rxm_ep_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -1489,8 +1484,7 @@ static ssize_t rxm_ep_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t l
 
 	return rxm_ep_send_common(rxm_ep, &iov, desc, 1, dest_addr, context, data,
 				  rxm_ep_tx_flags(rxm_ep) | FI_REMOTE_CQ_DATA,
-				  tag, &rxm_ep->buf_pools[RXM_BUF_POOL_TX_TAGGED],
-				  ofi_op_tagged);
+				  tag, ofi_op_tagged, FI_TAGGED);
 }
 
 static ssize_t rxm_ep_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -1501,7 +1495,7 @@ static ssize_t rxm_ep_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t
 
 	return rxm_ep_inject_common(rxm_ep, buf, len, dest_addr, data,
 				    rxm_ep->util_ep.inject_op_flags | FI_REMOTE_CQ_DATA,
-				    tag, &rxm_ep->buf_pools[RXM_BUF_POOL_TX_TAGGED]);
+				    tag, ofi_op_tagged, FI_TAGGED);
 }
 
 struct fi_ops_tagged rxm_ops_tagged = {


### PR DESCRIPTION
- **prov/rxm: Replace rxm_pkt_size by direct calling sizeof()**
- **prov/rxm: Use common pool for TAGGED and MSG TX operations**
- **prov/rxm: Implement separate pool for inject operations**
Use TX buffers allocated from separate TX pool for inject operations, if
a size is <= core_prov::tx_attr::inject_size.
Fix the following sizes of allocated buffers for differents pools:
-- ACK - sizeof(rxm_pkt) + sizeof(rxm_tx_buf)
-- LMT - sizeof(rxm_rma_iov) * iov_limit + sizeof(struct ofi_rma_iov) +
         sizeof(struct rxm_tx_buf)
It's not neccessary to allocate buffer_size + sizeof(rxm_tx_buf) for these pools