### PR TITLE
prov/rxm: Address Coverity scan issue

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -290,8 +290,7 @@ static void rxm_recv_queue_close(struct rxm_recv_queue *recv_queue)
 
 static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 {
-	size_t i;
-	int ret;
+	int ret, i;
 	size_t queue_sizes[RXM_BUF_POOL_MAX] = {
 		rxm_ep->msg_info->rx_attr->size,	/* RX */
 		rxm_ep->msg_info->tx_attr->size,	/* TX */


### PR DESCRIPTION
This addresses [CID-293079](https://scan4.coverity.com/reports.htm#v27196/p10344/fileInstanceId=45757273&defectInstanceId=8524319&mergedDefectId=293079)

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>