### PR TITLE
prov/rxm: Don't consider RxM pkt size twice

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -306,7 +306,8 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 		rxm_ep->rxm_info->tx_attr->inject_size +
 		sizeof(struct rxm_tx_buf),			/* TX */
 		rxm_ep->msg_info->tx_attr->inject_size +
-		sizeof(struct rxm_tx_buf),			/* TX INJECT */
+		sizeof(struct rxm_tx_buf) -
+		sizeof(struct rxm_pkt),				/* TX INJECT */
 		sizeof(struct rxm_tx_buf),			/* TX ACK */
 		sizeof(struct rxm_rma_iov) +
 		rxm_ep->rxm_info->tx_attr->iov_limit *


### PR DESCRIPTION
The maximum possible length of user buffer that can be injected is calculated as follows:
core provider inject size (`rxm_ep->msg_info->tx_attr->inject_size`) - RxM packet size (`struct rxm_pkt`)

The size of buffers that are allocated from TX INJECT pool should have size:
`rxm_ep->msg_info->tx_attr->inject_size + sizeof(struct rxm_tx_buf) - sizeof(struct rxm_pkt)`

The other pools isn't impacted by this, because `rxm_ep->rxm_info->tx_attr->inject_size` takes into account the size of the RxM packet.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>