### PR TITLE
prov/rxm: Refactor deferred queue (TX inject)

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -285,10 +285,7 @@ struct rxm_rma_buf {
 
 struct rxm_tx_entry {
 	/* Must stay at top */
-	union {
-		struct fi_context fi_context;
-		struct dlist_entry deferred_entry;
-	};
+	struct fi_context fi_context;
 
 	enum rxm_proto_state state;
 
@@ -495,13 +492,6 @@ err:
 	rxm_ep_msg_mr_closev(mr, count);
 	return ret;
 }
-
-void rxm_ep_handle_deferred_tx_op(struct rxm_ep *rxm_ep,
-				  struct rxm_conn *rxm_conn,
-				  struct rxm_tx_entry *tx_entry);
-void rxm_ep_handle_deferred_rma_op(struct rxm_ep *rxm_ep,
-				   struct rxm_conn *rxm_conn,
-				   struct rxm_tx_entry *tx_entry);
 
 static inline void rxm_cntr_inc(struct util_cntr *cntr)
 {

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -285,7 +285,10 @@ struct rxm_rma_buf {
 
 struct rxm_tx_entry {
 	/* Must stay at top */
-	struct fi_context fi_context;
+	union {
+		struct fi_context fi_context;
+		struct dlist_entry deferred_entry;
+	};
 
 	enum rxm_proto_state state;
 
@@ -393,6 +396,7 @@ struct rxm_ep {
 
 	struct dlist_entry	posted_srx_list;
 	struct dlist_entry	repost_ready_list;
+	struct dlist_entry	conn_deferred_list;
 
 	struct rxm_recv_queue	recv_queue;
 	struct rxm_recv_queue	trecv_queue;
@@ -403,8 +407,16 @@ struct rxm_ep {
 
 struct rxm_conn {
 	struct fid_ep *msg_ep;
+
+	/* Identifier to be posted into rxm_ep::conn_deferred_list.
+	 * This should notify CQ handling function to progress the
+	 * rxm_conn::deferred_op_list. When the deferred_op_list is
+	 * empty, this connection has to be removed from
+	 * rxm_ep::conn_deferred_list */
+	struct dlist_entry conn_deferred_entry;
+	struct dlist_entry deferred_op_list;
+
 	struct rxm_send_queue send_queue;
-	struct dlist_entry deferred_tx_list;
 	struct dlist_entry posted_rx_list;
 	struct dlist_entry sar_rx_msg_list;
 	struct util_cmap_handle handle;
@@ -594,6 +606,8 @@ rxm_acquire_conn(struct rxm_ep *rxm_ep, fi_addr_t fi_addr)
 			    struct rxm_conn, handle);
 }
 
+void rxm_ep_progress_conn_deferred_list(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn);
+void rxm_ep_progress_deferred_list(struct rxm_ep *rxm_ep);
 
 /* Caller must hold `cmap::lock` */
 static inline int
@@ -603,6 +617,9 @@ rxm_ep_handle_unconnected(struct rxm_ep *rxm_ep, struct util_cmap_handle *handle
 	int ret;
 
 	if (handle->state == CMAP_CONNECTED_NOTIFY) {
+		rxm_ep_progress_conn_deferred_list(
+					rxm_ep, container_of(handle, struct rxm_conn,
+							     handle));
 		ofi_cmap_process_conn_notify(rxm_ep->util_ep.cmap, handle);
 		return 0;
 	}
@@ -614,6 +631,42 @@ rxm_ep_handle_unconnected(struct rxm_ep *rxm_ep, struct util_cmap_handle *handle
 		return ret;
 
 	return -FI_EAGAIN;
+}
+
+static inline ssize_t
+rxm_ep_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+		   struct rxm_tx_buf *tx_buf, size_t pkt_size)
+{
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting inject with length: %" PRIu64
+	       " tag: 0x%" PRIx64 "\n", tx_buf->pkt.hdr.size, tx_buf->pkt.hdr.tag);
+	ssize_t ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size, 0);
+	if (OFI_UNLIKELY(ret)) {
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
+		       "fi_inject for MSG provider failed\n");
+		rxm_cntr_incerr(rxm_ep->util_ep.tx_cntr);
+	} else {
+		rxm_cntr_inc(rxm_ep->util_ep.tx_cntr);
+	}
+	return ret;
+}
+
+static inline ssize_t
+rxm_ep_normal_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+		   struct rxm_tx_entry *tx_entry, size_t pkt_size)
+{
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting send with length: %" PRIu64
+	       " tag: 0x%" PRIx64 "\n", tx_entry->tx_buf->pkt.hdr.size,
+	       tx_entry->tx_buf->pkt.hdr.tag);
+	ssize_t ret = fi_send(rxm_conn->msg_ep, &tx_entry->tx_buf->pkt, pkt_size,
+			      tx_entry->tx_buf->hdr.desc, 0, tx_entry);
+	if (OFI_UNLIKELY(ret)) {
+		if (ret == -FI_EAGAIN)
+			rxm_ep_progress_multi(&rxm_ep->util_ep);
+		else
+			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+				"fi_send for MSG provider failed\n");
+	}
+	return ret;
 }
 
 static inline

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -207,7 +207,6 @@ static struct util_cmap_handle *rxm_conn_alloc(struct util_cmap *cmap)
 	dlist_init(&rxm_conn->posted_rx_list);
 	dlist_init(&rxm_conn->sar_rx_msg_list);
 	dlist_init(&rxm_conn->saved_posted_rx_list);
-	dlist_init(&rxm_conn->deferred_tx_list);
 	return &rxm_conn->handle;
 }
 
@@ -344,22 +343,6 @@ static void rxm_conn_handle_eq_err(struct rxm_ep *rxm_ep, ssize_t rd)
 	}
 }
 
-static void rxm_conn_handle_deferred_op(struct rxm_ep *rxm_ep,
-					struct util_cmap_handle *handle)
-{
-	struct rxm_tx_entry *tx_entry;
-	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
-
-	while (!dlist_empty(&rxm_conn->deferred_tx_list)) {
-		dlist_pop_front(&rxm_conn->deferred_tx_list, struct rxm_tx_entry,
-				tx_entry, deferred_entry);
-		if (!(tx_entry->comp_flags & FI_RMA))
-			rxm_ep_handle_deferred_tx_op(rxm_ep, rxm_conn, tx_entry);
-		else
-			rxm_ep_handle_deferred_rma_op(rxm_ep, rxm_conn, tx_entry);
-	}
-}
-
 static void *rxm_conn_event_handler(void *arg)
 {
 	struct fi_eq_cm_entry *entry;
@@ -410,7 +393,6 @@ static void *rxm_conn_event_handler(void *arg)
 						 entry->fid->context,
 						 ((rd - sizeof(*entry)) ?
 						  &cm_data->conn_id : NULL));
-			rxm_conn_handle_deferred_op(rxm_ep, entry->fid->context);
 			fastlock_release(&rxm_ep->util_ep.cmap->lock);
 			break;
 		case FI_SHUTDOWN:

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1011,6 +1011,9 @@ void rxm_ep_progress_one(struct util_ep *util_ep)
 			return;
 	}
 
+	if (OFI_UNLIKELY(!dlist_empty(&rxm_ep->conn_deferred_list)))
+		rxm_ep_progress_deferred_list(rxm_ep);
+
 	ret = fi_cq_read(rxm_ep->msg_cq, &comp, 1);
 	if (ret == -FI_EAGAIN || !ret)
 		return;
@@ -1045,6 +1048,9 @@ void rxm_ep_progress_multi(struct util_ep *util_ep)
 		if (ret > 0)
 			return;
 	}
+
+	if (OFI_UNLIKELY(!dlist_empty(&rxm_ep->conn_deferred_list)))
+		rxm_ep_progress_deferred_list(rxm_ep);
 
 	do {
 		ret = fi_cq_read(rxm_ep->msg_cq, &comp, 1);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -321,6 +321,7 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 
 	dlist_init(&rxm_ep->posted_srx_list);
 	dlist_init(&rxm_ep->repost_ready_list);
+	dlist_init(&rxm_ep->conn_deferred_list);
 
 	for (i = 0; i < RXM_BUF_POOL_MAX; i++) {
 		ret = rxm_buf_pool_create(rxm_ep, queue_sizes[i], entry_sizes[i],
@@ -828,27 +829,6 @@ err:
 }
 
 static inline ssize_t
-rxm_ep_normal_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-		   struct rxm_tx_entry *tx_entry, size_t pkt_size)
-{
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting send with length: %" PRIu64
-	       " tag: 0x%" PRIx64 "\n", tx_entry->tx_buf->pkt.hdr.size,
-	       tx_entry->tx_buf->pkt.hdr.tag);
-	ssize_t ret = fi_send(rxm_conn->msg_ep, &tx_entry->tx_buf->pkt, pkt_size,
-			      tx_entry->tx_buf->hdr.desc, 0, tx_entry);
-	if (OFI_UNLIKELY(ret)) {
-		if (ret == -FI_EAGAIN)
-			rxm_ep_progress_multi(&rxm_ep->util_ep);
-		else
-			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-				"fi_send for MSG provider failed\n");
-		rxm_tx_buf_release(rxm_ep, tx_entry->tx_buf);
-		rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
-	}
-	return ret;
-}
-
-static inline ssize_t
 rxm_ep_alloc_lmt_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void *context,
 			uint8_t count, const struct iovec *iov, void **desc, size_t data_len,
 			uint64_t data, uint64_t flags, uint64_t comp_flags, uint64_t tag,
@@ -916,25 +896,6 @@ err:
 		rxm_ep_msg_mr_closev(tx_entry->mr, tx_entry->count);
 	rxm_tx_buf_release(rxm_ep, tx_entry->tx_buf);
 	rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
-	return ret;
-}
-
-static inline ssize_t
-rxm_ep_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-		   struct rxm_tx_buf *tx_buf, size_t pkt_size)
-{
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting inject with length: %" PRIu64
-	       " tag: 0x%" PRIx64 "\n", tx_buf->pkt.hdr.size, tx_buf->pkt.hdr.tag);
-	ssize_t ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size, 0);
-	if (OFI_UNLIKELY(ret)) {
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-		       "fi_inject for MSG provider failed\n");
-		rxm_cntr_incerr(rxm_ep->util_ep.tx_cntr);
-	} else {
-		rxm_cntr_inc(rxm_ep->util_ep.tx_cntr);
-	}
-	/* release allocated buffer for further reuse */
-	rxm_tx_buf_release(rxm_ep, tx_buf);
 	return ret;
 }
 
@@ -1051,84 +1012,142 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void *conte
 	return 0;
 }
 
-void rxm_ep_handle_deferred_tx_op(struct rxm_ep *rxm_ep,
-				  struct rxm_conn *rxm_conn,
-				  struct rxm_tx_entry *tx_entry)
+static inline ssize_t
+rxm_ep_inject_deferred_tx(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+			  struct rxm_tx_entry *tx_entry)
+{
+	ssize_t ret = rxm_ep_inject_send(rxm_ep, rxm_conn, tx_entry->tx_buf,
+					 tx_entry->tx_buf->pkt.hdr.size +
+					 sizeof(struct rxm_pkt));
+	if (OFI_UNLIKELY(!ret)) {
+		dlist_remove(&tx_entry->deferred_entry);
+		rxm_tx_buf_release(rxm_ep, tx_entry->tx_buf);
+		free(tx_entry);
+	}
+	return ret;
+}
+
+static inline ssize_t
+rxm_ep_send_deferred_tx(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+			struct rxm_tx_entry *def_tx_entry)
 {
 	ssize_t ret;
-	size_t tx_size = sizeof(struct rxm_pkt) + tx_entry->tx_buf->pkt.hdr.size;
+	struct rxm_tx_entry *tx_entry = rxm_tx_entry_get(&rxm_conn->send_queue);
+	if (OFI_UNLIKELY(!tx_entry))
+		return -FI_EAGAIN;
 
-	tx_entry->tx_buf->pkt.ctrl_hdr.conn_id = rxm_conn->handle.remote_key;
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-	       "Send deferred TX request (len - %zd) for %p conn\n",
-	       tx_entry->tx_buf->pkt.hdr.size, rxm_conn);
+	tx_entry->state = def_tx_entry->state;
+	rxm_fill_tx_entry(def_tx_entry->context, def_tx_entry->count,
+			  def_tx_entry->flags, def_tx_entry->comp_flags,
+			  def_tx_entry->tx_buf, tx_entry);
 
-	if ((tx_size <= rxm_ep->msg_info->tx_attr->inject_size) &&
-	    (tx_entry->flags & FI_INJECT) && !(tx_entry->flags & FI_COMPLETION))  {
-		(void) rxm_ep_inject_send(rxm_ep, rxm_conn,
-					  tx_entry->tx_buf, tx_size);
-		/* Release TX entry for futher reuse */
-		rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
-	} else if (tx_entry->tx_buf->pkt.hdr.size >
-			rxm_ep->rxm_info->tx_attr->inject_size) {
-		struct rxm_rma_iov *rma_iov =
-			(struct rxm_rma_iov *)&tx_entry->tx_buf->pkt.data;
-		ret = rxm_ep_lmt_tx_send(rxm_ep, rxm_conn, tx_entry,
-					 sizeof(struct rxm_pkt) + sizeof(*rma_iov) +
-					 sizeof(*rma_iov->iov) * tx_entry->count);
-		if (OFI_UNLIKELY(ret)) {
-			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-				"Unable to perform deferred large send operation\n");
-			rxm_cq_write_error(rxm_ep->util_ep.tx_cq,
-					   rxm_ep->util_ep.tx_cntr,
-					   tx_entry->context, (int)ret);
-		}
+	ret = rxm_ep_normal_send(rxm_ep, rxm_conn, tx_entry,
+				 tx_entry->tx_buf->pkt.hdr.size +
+				 sizeof(struct rxm_pkt));
+	if (!ret) {
+		dlist_remove(&def_tx_entry->deferred_entry);
+		free(def_tx_entry);
 	} else {
-		ret = rxm_ep_normal_send(rxm_ep, rxm_conn, tx_entry, tx_size);
-		if (OFI_UNLIKELY(ret)) {
-			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-				"Unable to perform deferred send operation\n");
-			rxm_cq_write_error(rxm_ep->util_ep.tx_cq,
-					   rxm_ep->util_ep.tx_cntr,
-					   tx_entry->context, (int)ret);
+		rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
+	}
+	return ret;
+}
+
+void rxm_ep_progress_conn_deferred_list(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn)
+{
+	ssize_t ret = 0;
+
+	while (!dlist_empty(&rxm_conn->deferred_op_list) && !ret) {
+		struct rxm_tx_entry *tx_entry =
+			container_of(rxm_conn->deferred_op_list.next,
+				     struct rxm_tx_entry, deferred_entry);
+		if ((tx_entry->flags & FI_INJECT) &&
+		    !(tx_entry->flags & FI_COMPLETION) &&
+		    ((tx_entry->tx_buf->pkt.hdr.size + sizeof(struct rxm_pkt)) <=
+					rxm_ep->msg_info->tx_attr->inject_size)) {
+			ret = rxm_ep_inject_deferred_tx(rxm_ep, rxm_conn, tx_entry);
+		} else {
+			ret = rxm_ep_send_deferred_tx(rxm_ep, rxm_conn, tx_entry);
 		}
 	}
 }
 
-static inline ssize_t
-rxm_ep_postpone_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-		     void *context, uint8_t count, const struct iovec *iov,
-		     void **desc, size_t len, uint64_t data, uint64_t flags,
-		     uint64_t tag, uint8_t op, uint64_t comp_flags)
+void rxm_ep_progress_deferred_list(struct rxm_ep *rxm_ep)
 {
-	struct rxm_tx_entry *tx_entry;
-	struct rxm_tx_buf *tx_buf;
+	struct rxm_conn *rxm_conn;
+	struct dlist_entry *tmp;
 
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-	       "Buffer TX request (len - %zd) for %p conn\n", len, rxm_conn);
+	dlist_foreach_container_safe(&rxm_ep->conn_deferred_list,
+				     struct rxm_conn, rxm_conn,
+				     conn_deferred_entry, tmp) {
+		if (OFI_UNLIKELY((rxm_conn->handle.state != CMAP_CONNECTED) &&
+				 (rxm_conn->handle.state != CMAP_CONNECTED_NOTIFY)))
+			continue;
+		rxm_ep_progress_conn_deferred_list(rxm_ep, rxm_conn);
 
-	if (len > rxm_ep->rxm_info->tx_attr->inject_size) {
-		if (rxm_ep_alloc_lmt_tx_res(rxm_ep, rxm_conn, context, count,
-					    iov, desc, len, data, flags,
-					    comp_flags, tag, op, &tx_entry) < 0)
-			return -FI_EAGAIN;
-	} else {
-		ssize_t ret = rxm_ep_format_tx_res(rxm_ep, rxm_conn, context, count,
-						   len, data, flags, comp_flags,
-						   tag, &tx_buf, &tx_entry,
-						   &rxm_ep->buf_pools[RXM_BUF_POOL_TX]);
-		if (OFI_UNLIKELY(ret))
-			return ret;
-		tx_buf->pkt.hdr.op = op;
-		tx_buf->pkt.hdr.flags |= comp_flags;
-		ofi_copy_from_iov(tx_buf->pkt.data, tx_buf->pkt.hdr.size,
-				  iov, count, 0);
-		tx_entry->state = RXM_TX;
+		if (dlist_empty(&rxm_conn->deferred_op_list))
+			dlist_remove(&rxm_conn->conn_deferred_entry);
 	}
+}
 
-	dlist_insert_tail(&tx_entry->deferred_entry, &rxm_conn->deferred_tx_list);
+static ssize_t
+rxm_ep_defer_tx_inject_iov(struct rxm_ep *rxm_ep, const struct iovec *iov,
+			   size_t count, fi_addr_t dest_addr, void *context,
+			   uint64_t data, uint64_t flags, uint64_t tag,
+			   uint8_t op, uint64_t comp_flags, struct rxm_conn *rxm_conn)
+{
+	int ret;
+	struct rxm_buf_pool *tx_pool;
+	size_t len = ofi_total_iov_len(iov, count);
+	struct rxm_tx_entry *tx_entry = calloc(1, sizeof(*tx_entry));
+	if (OFI_UNLIKELY(!tx_entry))
+		return -FI_EAGAIN;
 
-	return FI_SUCCESS;
+	tx_pool = ((flags & FI_INJECT) && !(flags & FI_COMPLETION) &&
+		   (len + sizeof(struct rxm_pkt) <=
+			rxm_ep->msg_info->tx_attr->inject_size)) ?
+		  &rxm_ep->buf_pools[RXM_BUF_POOL_TX_INJECT] :
+		  &rxm_ep->buf_pools[RXM_BUF_POOL_TX];
+
+	ret = rxm_ep_format_tx_res_lightweight(
+			rxm_ep, rxm_conn, len, data, flags,
+			tag, &tx_entry->tx_buf, tx_pool);
+	if (ret)
+		goto err1;
+	tx_entry->state = RXM_TX;
+	rxm_fill_tx_entry(context, count, flags, comp_flags, tx_entry->tx_buf, tx_entry);
+	tx_entry->tx_buf->pkt.hdr.op = op;
+	tx_entry->tx_buf->pkt.hdr.flags |= comp_flags;;
+
+	ofi_copy_from_iov(tx_entry->tx_buf->pkt.data, tx_entry->tx_buf->pkt.hdr.size,
+			  iov, count, 0);
+
+	rxm_ep->util_ep.tx_cq->cq_fastlock_acquire(&rxm_ep->util_ep.tx_cq->cq_lock);
+	if (dlist_empty(&rxm_conn->deferred_op_list)) {
+		dlist_insert_tail(&rxm_conn->conn_deferred_entry,
+				  &rxm_ep->conn_deferred_list);
+	}
+	dlist_insert_tail(&tx_entry->deferred_entry, &rxm_conn->deferred_op_list);
+	rxm_ep->util_ep.tx_cq->cq_fastlock_release(&rxm_ep->util_ep.tx_cq->cq_lock);
+
+	return 0;
+err1:
+	free(tx_entry);
+	return ret;
+}
+
+static ssize_t
+rxm_ep_defer_tx_inject_buf(struct rxm_ep *rxm_ep, const void *buf, size_t len,
+			   fi_addr_t dest_addr, void *context, uint64_t data,
+			   uint64_t flags, uint64_t tag, uint8_t op,
+			   uint64_t comp_flags, struct rxm_conn *rxm_conn)
+{
+	const struct iovec iov = {
+		.iov_base = (void *)buf,
+		.iov_len = len
+	};
+	return rxm_ep_defer_tx_inject_iov(rxm_ep, &iov, 1, dest_addr, context, data,
+					  flags, tag, op, comp_flags, rxm_conn);
 }
 
 static inline ssize_t
@@ -1147,13 +1166,22 @@ rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 	rxm_conn = rxm_acquire_conn(rxm_ep, dest_addr);
 	if (OFI_UNLIKELY(rxm_conn->handle.state != CMAP_CONNECTED)) {
 		ret = rxm_ep_handle_unconnected(rxm_ep, &rxm_conn->handle, dest_addr);
+		fastlock_release(&rxm_ep->util_ep.cmap->lock);
 		if (!ret)
 			goto inject_continue;
-		fastlock_release(&rxm_ep->util_ep.cmap->lock);
-		return ret;
+		else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
+			return ret;
+
+		goto defer;
 	}
-inject_continue:
 	fastlock_release(&rxm_ep->util_ep.cmap->lock);
+
+inject_continue:
+	if (OFI_UNLIKELY(!dlist_empty(&rxm_conn->deferred_op_list))) {
+		rxm_ep_progress_multi(&rxm_ep->util_ep);
+		if (!dlist_empty(&rxm_conn->deferred_op_list))
+			goto defer;
+	}
 
 	if (pkt_size <= rxm_ep->msg_info->tx_attr->inject_size) {
 		ret = rxm_ep_format_tx_res_lightweight(
@@ -1164,25 +1192,41 @@ inject_continue:
 		tx_buf->pkt.hdr.op = op;
 		tx_buf->pkt.hdr.flags |= comp_flags;
 		memcpy(tx_buf->pkt.data, buf, tx_buf->pkt.hdr.size);
-		return rxm_ep_inject_send(rxm_ep, rxm_conn, tx_buf, pkt_size);
+		ret = rxm_ep_inject_send(rxm_ep, rxm_conn, tx_buf, pkt_size);
+		/* release allocated buffer for further reuse */
+		rxm_tx_buf_release(rxm_ep, tx_buf);
+		if (OFI_UNLIKELY(ret))
+			goto defer;
+		return ret;
 	} else {
 		struct rxm_tx_entry *tx_entry;
 
 		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "passed data (size = %zu) "
 		       "is too big for MSG provider (max inject size = %zd)\n",
 		       pkt_size, rxm_ep->msg_info->tx_attr->inject_size);
+
 		ret = rxm_ep_format_tx_res(rxm_ep, rxm_conn, NULL, 1,
 					   len, data, flags, comp_flags,
 					   tag, &tx_buf, &tx_entry,
 					   &rxm_ep->buf_pools[RXM_BUF_POOL_TX]);
 		if (OFI_UNLIKELY(ret))
-			return ret;
+			goto defer;
 		tx_buf->pkt.hdr.op = op;
 		tx_buf->pkt.hdr.flags |= comp_flags;
 		memcpy(tx_buf->pkt.data, buf, tx_buf->pkt.hdr.size);
 		tx_entry->state = RXM_TX;
-		return rxm_ep_normal_send(rxm_ep, rxm_conn, tx_entry, pkt_size);
+		ret = rxm_ep_normal_send(rxm_ep, rxm_conn, tx_entry, pkt_size);
+		if (OFI_UNLIKELY(ret)) {
+			rxm_tx_buf_release(rxm_ep, tx_entry->tx_buf);
+			rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
+			goto defer;
+		}
+		return ret;
 	}
+
+defer:
+	return rxm_ep_defer_tx_inject_buf(rxm_ep, buf, len, dest_addr, NULL, data,
+					  flags, tag, op, comp_flags, rxm_conn);
 }
 
 // TODO handle all flags
@@ -1203,13 +1247,28 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 	rxm_conn = rxm_acquire_conn(rxm_ep, dest_addr);
 	if (OFI_UNLIKELY(rxm_conn->handle.state != CMAP_CONNECTED)) {
 		ret = rxm_ep_handle_unconnected(rxm_ep, &rxm_conn->handle, dest_addr);
+		fastlock_release(&rxm_ep->util_ep.cmap->lock);
 		if (!ret)
 			goto send_continue;
-		fastlock_release(&rxm_ep->util_ep.cmap->lock);
+		else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
+			return ret;
+
+		if (data_len <= rxm_ep->rxm_info->tx_attr->inject_size)
+			goto defer_inject;
 		return ret;
 	}
-send_continue:
 	fastlock_release(&rxm_ep->util_ep.cmap->lock);
+
+send_continue:
+	if (OFI_UNLIKELY(!dlist_empty(&rxm_conn->deferred_op_list))) {
+		rxm_ep_progress_multi(&rxm_ep->util_ep);
+		if (!dlist_empty(&rxm_conn->deferred_op_list)) {
+			if (data_len <= rxm_ep->rxm_info->tx_attr->inject_size)
+				goto defer_inject;
+			else
+				return -FI_EAGAIN;
+		}
+	}
 
 	if (data_len <= rxm_ep->rxm_info->tx_attr->inject_size) {
 		size_t total_len = sizeof(struct rxm_pkt) + data_len;
@@ -1226,7 +1285,12 @@ send_continue:
 			tx_buf->pkt.hdr.flags |= comp_flags;
 			ofi_copy_from_iov(tx_buf->pkt.data, tx_buf->pkt.hdr.size,
 					  iov, count, 0);
-			return rxm_ep_inject_send(rxm_ep, rxm_conn, tx_buf, total_len);
+			ret = rxm_ep_inject_send(rxm_ep, rxm_conn, tx_buf, total_len);
+			/* release allocated buffer for further reuse */
+			rxm_tx_buf_release(rxm_ep, tx_buf);
+			if (OFI_UNLIKELY(ret))
+				goto defer_inject;
+			return ret;
 		}
 
 		ret = rxm_ep_format_tx_res(rxm_ep, rxm_conn, context,
@@ -1240,7 +1304,13 @@ send_continue:
 		ofi_copy_from_iov(tx_buf->pkt.data, tx_buf->pkt.hdr.size,
 				  iov, count, 0);
 		tx_entry->state = RXM_TX;
-		return rxm_ep_normal_send(rxm_ep, rxm_conn, tx_entry, total_len);
+		ret = rxm_ep_normal_send(rxm_ep, rxm_conn, tx_entry, total_len);
+		if (OFI_UNLIKELY(ret)) {
+			rxm_tx_buf_release(rxm_ep, tx_entry->tx_buf);
+			rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
+			goto defer_inject;
+		}
+		return ret;
 	} else {
 		assert(!(flags & FI_INJECT));
 		if (data_len <= rxm_ep->sar_limit) {
@@ -1258,6 +1328,11 @@ send_continue:
 						  sizeof(struct rxm_pkt) + ret);
 		}
 	}
+
+defer_inject:
+	return rxm_ep_defer_tx_inject_iov(rxm_ep, iov, count, dest_addr,
+					  context, data, flags, tag, op,
+					  comp_flags, rxm_conn);
 }
 
 static ssize_t rxm_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -178,46 +178,6 @@ err:
 	return ret;
 }
 
-void rxm_ep_handle_deferred_rma_op(struct rxm_ep *rxm_ep,
-				   struct rxm_conn *rxm_conn,
-				   struct rxm_tx_entry *tx_entry)
-{
-	ssize_t ret;
-
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-	       "Perform deferred RMA operation (len - %zd) for %p conn\n",
-	       tx_entry->rma_buf->pkt.hdr.size, rxm_conn);
-
-	if (tx_entry->comp_flags & FI_WRITE) {
-		uint64_t flags = ((tx_entry->flags & FI_INJECT) ?
-				  ((tx_entry->flags & ~FI_INJECT) |
-				   FI_COMPLETION) : tx_entry->flags);
-		ret = fi_writemsg(rxm_conn->msg_ep,
-				  &tx_entry->rma_buf->msg,
-				  flags);
-		if (OFI_UNLIKELY(ret)) {
-			rxm_cq_write_error(rxm_ep->util_ep.tx_cq,
-					   rxm_ep->util_ep.wr_cntr,
-					   tx_entry->context, (int)ret);
-			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-				"Unable to perform deferred RMA write operation\n");
-		}
-	} else if (tx_entry->comp_flags & FI_READ) {
-		ret = fi_readmsg(rxm_conn->msg_ep,
-				 &tx_entry->rma_buf->msg,
-				 tx_entry->flags);
-		if (OFI_UNLIKELY(ret)) {
-			rxm_cq_write_error(rxm_ep->util_ep.tx_cq,
-					   rxm_ep->util_ep.rd_cntr,
-					   tx_entry->context, (int)ret);
-			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-				"Unable to perform deferred RMA read operation\n");
-		}
-	} else {
-		assert(0);
-	}
-}
-
 static inline ssize_t
 rxm_ep_format_rma_inject_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			     size_t total_size, uint64_t flags, uint64_t comp_flags,
@@ -263,33 +223,6 @@ err:
 	return ret;
 }
 
-static inline int
-rxm_ep_postpone_rma(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-		    size_t total_size, uint64_t flags,
-		    uint64_t comp_flags, const struct fi_msg_rma *orig_msg)
-{
-	struct rxm_tx_entry *tx_entry;
-	struct rxm_rma_buf *rma_buf;
-	int ret;
-
-	if (flags & FI_INJECT) {
-		assert(comp_flags & FI_WRITE);
-		ret = rxm_ep_format_rma_inject_res(rxm_ep, rxm_conn, total_size,
-						   flags, comp_flags, orig_msg,
-						   &rma_buf, &tx_entry);
-	} else {
-		ret = rxm_ep_format_rma_non_inject_res(rxm_ep, rxm_conn, total_size,
-						       flags, comp_flags, orig_msg,
-						       &rma_buf, &tx_entry);
-	}
-	if (OFI_UNLIKELY(ret))
-		return ret;
-
-	dlist_insert_tail(&tx_entry->deferred_entry, &rxm_conn->deferred_tx_list);
-
-	return ret;
-}
-
 static ssize_t
 rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t flags,
 		  rxm_rma_msg_fn rma_msg, uint64_t comp_flags)
@@ -308,13 +241,6 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 		ret = rxm_ep_handle_unconnected(rxm_ep, &rxm_conn->handle, msg->addr);
 		if (!ret)
 			goto rma_continue;
-		else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
-			goto cmap_err;
-		ret = rxm_ep_postpone_rma(rxm_ep, rxm_conn,
-					  ofi_total_iov_len(msg->msg_iov,
-							    msg->iov_count),
-					  flags, comp_flags, msg);
-cmap_err:
 		fastlock_release(&rxm_ep->util_ep.cmap->lock);
 		return ret;
 	}
@@ -426,11 +352,6 @@ rxm_ep_rma_inject(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 		ret = rxm_ep_handle_unconnected(rxm_ep, &rxm_conn->handle, msg->addr);
 		if (!ret)
 			goto rma_inject_continue;
-		else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
-			goto cmap_err;
-		ret = rxm_ep_postpone_rma(rxm_ep, rxm_conn, total_size,
-					  flags, FI_WRITE, msg);
-cmap_err:
 		fastlock_release(&rxm_ep->util_ep.cmap->lock);
 		return ret;
 	}

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -79,7 +79,7 @@ rxm_ep_rma_fill_msg(struct fi_msg_rma *msg_rma, struct iovec *iov,
 	msg_rma->data = orig_msg->data;
 }
 
-static inline void
+/*static inline void
 rxm_ep_rma_fill_msg_no_buf(struct rxm_rma_buf *rma_buf,
 			   struct rxm_tx_entry *tx_entry,
 			   const struct fi_msg_rma *orig_msg)
@@ -89,7 +89,7 @@ rxm_ep_rma_fill_msg_no_buf(struct rxm_rma_buf *rma_buf,
 	rxm_ep_rma_fill_msg(&rma_buf->msg, rma_buf->rxm_iov.iov,
 			    rma_buf->rxm_iov.count, rma_buf->rxm_iov.desc,
 			    &rma_buf->rxm_rma_iov, tx_entry, orig_msg);
-}
+}*/
 
 static inline void
 rxm_ep_rma_fill_msg_buf(struct rxm_rma_buf *rma_buf,
@@ -194,7 +194,7 @@ rxm_ep_format_rma_inject_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	return ret;
 }
 
-static inline ssize_t
+/*static inline ssize_t
 rxm_ep_format_rma_non_inject_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 				 size_t total_size, uint64_t flags, uint64_t comp_flags,
 				 const struct fi_msg_rma *orig_msg, struct rxm_rma_buf **rma_buf,
@@ -206,7 +206,7 @@ rxm_ep_format_rma_non_inject_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_con
 		return ret;
 
 	ret = rxm_ep_rma_reg_iov(rxm_ep, (*rma_buf)->rxm_iov.iov,
-				 /* addr of desc from rma_buf will be assign to itself */
+				 // addr of desc from rma_buf will be assign to itself
 				 orig_msg->desc,
 				 (*rma_buf)->rxm_iov.desc,
 				 orig_msg->iov_count,
@@ -221,7 +221,7 @@ err:
 	rxm_rma_buf_release(rxm_ep, (*tx_entry)->rma_buf);
 	rxm_tx_entry_release(&rxm_conn->send_queue, *tx_entry);
 	return ret;
-}
+}*/
 
 static ssize_t
 rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t flags,

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -292,12 +292,9 @@ ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
 
 int ofi_cq_signal(struct fid_cq *cq_fid)
 {
-	struct util_cq *cq;
-
-	cq = container_of(cq_fid, struct util_cq, cq_fid);
-	assert(cq->wait);
+	struct util_cq *cq = container_of(cq_fid, struct util_cq, cq_fid);
 	ofi_atomic_set32(&cq->signaled, 1);
-	cq->wait->signal(cq->wait);
+	util_cq_signal(cq);
 	return 0;
 }
 


### PR DESCRIPTION
This PR does the following:
- prov/rxm: Remove deferred queue that is used before connections is established
- prov/rxm: Implemented deferred queue [TX inject]
The new implementation of deferred queue (covers FI_INJECT only) is used for the following cases:
-- before a connection has not bee established yet
-- if fi_send/fi_inject fails or lack of TX queue resources

The rxm_ep object contains the common `conn_deferred_list` list of connections that require the progressing their deferred queues. When a operation needs to be queued into deferred queue, it is inserted into tail of the `rxm_conn::deferred_op_list` queue. If the connection entry hasn't been inserted yet to `conn_deferred_list` list, this is done to enable the progressing for this conenction.

The progressing of connection's deferred queues is done within CQ progressing. If the connection's deferred queue is empty after progressing, the connection entry is removed from `conn_deferred_list` list.

This patch enables possibility to defer inejct operations only. RMA and TX SAR, LMT will be done in further patches.
Also this patch fixes problems with simultaneous access to core provider's fi_send/fi_inject and RxM shared resources (TX queue, TX pools) from different threads (CM and main).
I successfully run MPICH/CH4 rxm/tcp and rxm/verbs successfully on OSU and IMB_MPI1 benchmarks. 