### PR TITLE
prov/rxm: Move fill of TX entry into separate function

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -742,6 +742,18 @@ rxm_ ## type ## _entry_release(struct rxm_ ## queue_type ## _queue *queue,	\
 RXM_DEFINE_QUEUE_ENTRY(tx, send);
 RXM_DEFINE_QUEUE_ENTRY(recv, recv);
 
+static inline void
+rxm_fill_tx_entry(void *context, uint8_t count, uint64_t flags,
+		  uint64_t comp_flags, struct rxm_tx_buf *tx_buf,
+		  struct rxm_tx_entry *tx_entry)
+{
+	tx_entry->context = context;
+	tx_entry->count = count;
+	tx_entry->flags = flags;
+	tx_entry->tx_buf = tx_buf;
+	tx_entry->comp_flags = comp_flags | FI_SEND;
+}
+
 static inline int rxm_finish_send_nobuf(struct rxm_tx_entry *tx_entry)
 {
 	int ret;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -799,13 +799,7 @@ rxm_ep_format_tx_entry(struct rxm_conn *rxm_conn, void *context, uint8_t count,
 	*tx_entry = rxm_tx_entry_get(&rxm_conn->send_queue);
 	if (OFI_UNLIKELY(!*tx_entry))
 		return -FI_EAGAIN;
-
-	(*tx_entry)->count = count;
-	(*tx_entry)->context = context;
-	(*tx_entry)->flags = flags;
-	(*tx_entry)->tx_buf = tx_buf;
-	(*tx_entry)->comp_flags = comp_flags | FI_SEND;
-
+	rxm_fill_tx_entry(context, count, flags, comp_flags, tx_buf, *tx_entry);
 	return FI_SUCCESS;
 }
 


### PR DESCRIPTION
This is PR created to cover comment from #4208 

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>