### PR TITLE
cmap, prov/rxm: Implement command queue

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -675,6 +675,7 @@ struct util_cmap {
 
 	struct dlist_entry peer_list;
 	struct util_cmap_attr attr;
+	int event_handler_closing;
 	pthread_t event_handler_thread;
 	fastlock_t lock;
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -676,7 +676,6 @@ struct util_cmap {
 	struct dlist_entry peer_list;
 	struct util_cmap_attr attr;
 	pthread_t event_handler_thread;
-	int av_updated;
 	fastlock_t lock;
 
 	struct dlist_ts cmd_queue;

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -634,6 +634,9 @@ typedef int (*ofi_cmap_signal_func)(struct util_ep *ep, void *context,
 
 struct util_cmap_attr {
 	void 				*name;
+	struct {
+		int use_cmd_queue : 1;
+	} config;
 	ofi_cmap_alloc_handle_func 	alloc;
 	ofi_cmap_handle_func 		close;
 	ofi_cmap_handle_func 		free;
@@ -641,6 +644,20 @@ struct util_cmap_attr {
 	ofi_cmap_handle_func		connected_handler;
 	ofi_cmap_event_handler_func	event_handler;
 	ofi_cmap_signal_func		signal;
+};
+
+enum util_cmap_cmd_type {
+	UTIL_CMAP_CMD_AV_UPD,
+	UTIL_CMAP_CMD_CONNREQ_ACCEPT,
+	UTIL_CMAP_CMD_CONNECTED,
+	UTIL_CMAP_CMD_CONN_CLOSE,
+	UTIL_CMAP_CMD_CONN_FREE,
+};
+
+struct util_cmap_cmd {
+	struct dlist_entry entry;
+	enum util_cmap_cmd_type type;
+	char data[];
 };
 
 struct util_cmap {
@@ -661,6 +678,13 @@ struct util_cmap {
 	pthread_t event_handler_thread;
 	int av_updated;
 	fastlock_t lock;
+
+	struct dlist_ts cmd_queue;
+	/* This ensures that this command posted once to the CMD queue
+	 * until it is read (when it is read, it has to be zeroed) */
+	struct util_cmap_cmd *av_upd_cmd;
+	size_t cmd_write;
+	size_t cmd_read;
 };
 
 struct util_cmap_handle *ofi_cmap_key2handle(struct util_cmap *cmap, uint64_t key);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -454,6 +454,11 @@ struct rxm_ep {
 	ofi_fastlock_release_t	res_fastlock_release;
 };
 
+struct rxm_conn_close {
+	struct fid_ep *msg_ep;
+	struct dlist_entry posted_rx_list;
+};
+
 struct rxm_conn {
 	struct fid_ep *msg_ep;
 
@@ -468,9 +473,23 @@ struct rxm_conn {
 	struct rxm_send_queue send_queue;
 	struct dlist_entry sar_rx_msg_list;
 	struct util_cmap_handle handle;
+
 	/* This is saved MSG EP fid, that hasn't been closed during
 	 * handling of CONN_RECV in CMAP_CONNREQ_SENT for passive side */
 	struct fid_ep *saved_msg_ep;
+};
+
+struct rxm_cmap_cmd_data {
+	/* common stuff */
+	struct rxm_conn *rxm_conn;
+
+	/* cmd-specific stuff */
+	union {
+		struct {
+			struct fi_info *msg_info;
+			struct rxm_cm_data cm_data;
+		} connreq_cmd;
+	};
 };
 
 struct rxm_ep_wait_ref {

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -655,6 +655,13 @@ rxm_acquire_conn(struct rxm_ep *rxm_ep, fi_addr_t fi_addr)
 			    struct rxm_conn, handle);
 }
 
+void rxm_conn_close_msg_ep(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn);
+int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
+		    struct rxm_conn *rxm_conn);
+int rxm_send_queue_init(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+			struct rxm_send_queue *send_queue, size_t size);
+void rxm_send_queue_close(struct rxm_send_queue *send_queue);
+
 void rxm_ep_progress_conn_deferred_list(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn);
 void rxm_ep_progress_deferred_list(struct rxm_ep *rxm_ep);
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -535,7 +535,18 @@ static int rxm_conn_signal(struct util_ep *util_ep, void *context,
 
 struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep)
 {
-	struct util_cmap_attr attr;
+	struct util_cmap_attr attr = {
+		.config = {
+			.use_cmd_queue	= 1,
+		},
+		.alloc			= rxm_conn_alloc,
+		.close 			= rxm_conn_close,
+		.free 			= rxm_conn_free,
+		.connect 		= rxm_conn_connect,
+		.connected_handler	= rxm_conn_connected_handler,
+		.event_handler		= rxm_conn_event_handler,
+		.signal			= rxm_conn_signal,
+	};
 	struct util_cmap *cmap = NULL;
 	void *name;
 	size_t len;
@@ -559,14 +570,7 @@ struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep)
 	}
 	ofi_straddr_dbg(&rxm_prov, FI_LOG_EP_CTRL, "local_name", name);
 
-	attr.name		= name;
-	attr.alloc 		= rxm_conn_alloc;
-	attr.close 		= rxm_conn_close;
-	attr.free 		= rxm_conn_free;
-	attr.connect 		= rxm_conn_connect;
-	attr.connected_handler	= rxm_conn_connected_handler;
-	attr.event_handler	= rxm_conn_event_handler;
-	attr.signal		= rxm_conn_signal;
+	attr.name = name;
 
 	cmap = ofi_cmap_alloc(&rxm_ep->util_ep, &attr);
 	if (!cmap)

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1077,8 +1077,13 @@ fn:
 			break;
 		case UTIL_CMAP_CMD_CONNECTED:
 			cmd_data = (struct rxm_cmap_cmd_data *)cmd->data;
-			ret = rxm_ep_prepost_buf(rxm_ep, cmd_data->rxm_conn->msg_ep,
-						 &cmd_data->rxm_conn->posted_rx_list);
+			ret = rxm_ep_prepost_buf(rxm_ep, cmd_data->rxm_conn->msg_ep);
+			break;
+		case UTIL_CMAP_CMD_CONN_FREE:
+			cmd_data = (struct rxm_cmap_cmd_data *)cmd->data;
+			rxm_conn_close_msg_ep(rxm_ep, cmd_data->rxm_conn);
+			rxm_send_queue_close(&cmd_data->rxm_conn->send_queue);
+			free(cmd_data->rxm_conn);
 			break;
 		default:
 			break;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1075,6 +1075,11 @@ rxm_conn_handle_cmap_cmd_queue(struct rxm_ep *rxm_ep)
 fn:
 			fi_freeinfo(cmd_data->connreq_cmd.msg_info);
 			break;
+		case UTIL_CMAP_CMD_CONNECTED:
+			cmd_data = (struct rxm_cmap_cmd_data *)cmd->data;
+			ret = rxm_ep_prepost_buf(rxm_ep, cmd_data->rxm_conn->msg_ep,
+						 &cmd_data->rxm_conn->posted_rx_list);
+			break;
 		default:
 			break;
 		}

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1000,16 +1000,10 @@ static int rxm_cq_reprocess_recv_queues(struct rxm_ep *rxm_ep)
 	int count = 0;
 
 	fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
-
-	if (!rxm_ep->util_ep.cmap->av_updated)
-		goto unlock;
-
-	rxm_ep->util_ep.cmap->av_updated = 0;
-
 	count += rxm_cq_reprocess_directed_recvs(&rxm_ep->recv_queue);
 	count += rxm_cq_reprocess_directed_recvs(&rxm_ep->trecv_queue);
-unlock:
 	fastlock_release(&rxm_ep->util_ep.cmap->lock);
+
 	return count;
 }
 
@@ -1040,6 +1034,34 @@ static inline ssize_t rxm_ep_read_msg_cq(struct rxm_ep *rxm_ep)
 	return ret;
 }
 
+static inline ssize_t
+rxm_conn_handle_cmap_cmd_queue(struct rxm_ep *rxm_ep)
+{
+	ssize_t ret = 0;
+	struct util_cmap_cmd *cmd;
+
+	while (!dlist_ts_empty(&rxm_ep->util_ep.cmap->cmd_queue)) {
+		dlist_ts_pop_front(&rxm_ep->util_ep.cmap->cmd_queue,
+				   struct util_cmap_cmd, cmd, entry);
+		if (!cmd)
+			continue;
+		rxm_ep->util_ep.cmap->cmd_read++;
+		switch (cmd->type) {
+		case UTIL_CMAP_CMD_AV_UPD:
+			free(cmd);
+			rxm_ep->util_ep.cmap->av_upd_cmd = NULL;
+			ret = rxm_cq_reprocess_recv_queues(rxm_ep);
+			if (ret > 0)
+				return -FI_EAGAIN;
+			break;
+		default:
+			free(cmd);
+			break;
+		}
+	}
+	return ret;
+}
+
 void rxm_ep_progress_one(struct util_ep *util_ep)
 {
 	struct rxm_ep *rxm_ep =
@@ -1048,9 +1070,9 @@ void rxm_ep_progress_one(struct util_ep *util_ep)
 
 	rxm_cq_repost_rx_buffers(rxm_ep);
 
-	if (OFI_UNLIKELY(rxm_ep->util_ep.cmap->av_updated)) {
-		ret = rxm_cq_reprocess_recv_queues(rxm_ep);
-		if (ret > 0)
+	if (util_ep->cmap->cmd_read < util_ep->cmap->cmd_write) {	
+		ret = rxm_conn_handle_cmap_cmd_queue(rxm_ep);
+		if (ret)
 			return;
 	}
 
@@ -1069,9 +1091,9 @@ void rxm_ep_progress_multi(struct util_ep *util_ep)
 
 	rxm_cq_repost_rx_buffers(rxm_ep);
 
-	if (OFI_UNLIKELY(rxm_ep->util_ep.cmap->av_updated)) {
-		ret = rxm_cq_reprocess_recv_queues(rxm_ep);
-		if (ret > 0)
+	if (util_ep->cmap->cmd_read < util_ep->cmap->cmd_write) {	
+		ret = rxm_conn_handle_cmap_cmd_queue(rxm_ep);
+		if (ret)
 			return;
 	}
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1061,6 +1061,20 @@ rxm_conn_handle_cmap_cmd_queue(struct rxm_ep *rxm_ep)
 					"Unable to close saved msg_ep\n");
 			cmd_data->rxm_conn->saved_msg_ep = NULL;
 			break;
+		case UTIL_CMAP_CMD_CONNREQ_ACCEPT:
+			cmd_data = (struct rxm_cmap_cmd_data *)cmd->data;
+			assert(!cmd_data->rxm_conn->msg_ep);
+			ret = rxm_msg_ep_open(rxm_ep, cmd_data->connreq_cmd.msg_info,
+					      cmd_data->rxm_conn);
+			if (ret)
+				goto fn;
+			ret = fi_accept(cmd_data->rxm_conn->msg_ep,
+					&cmd_data->connreq_cmd.cm_data,
+					sizeof(cmd_data->connreq_cmd.cm_data));
+			assert(!ret);
+fn:
+			fi_freeinfo(cmd_data->connreq_cmd.msg_info);
+			break;
 		default:
 			break;
 		}

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1624,6 +1624,7 @@ void ofi_cmap_free(struct util_cmap *cmap)
 
 	fastlock_acquire(&cmap->lock);
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Closing cmap\n");
+	cmap->event_handler_closing = 1;
 	for (i = 0; i < cmap->av->count; i++) {
 		if (cmap->handles_av[i])
 			util_cmap_del_handle(cmap->handles_av[i]);
@@ -1678,6 +1679,8 @@ struct util_cmap *ofi_cmap_alloc(struct util_ep *ep,
 
 	dlist_ts_init(&cmap->cmd_queue);
 	cmap->cmd_write = cmap->cmd_read = 0;
+
+	cmap->event_handler_closing = 0;
 
 	if (pthread_create(&cmap->event_handler_thread, 0,
 			   cmap->attr.event_handler, ep)) {


### PR DESCRIPTION
The command queue is used to notify main thread that owns device(domain) resources to perform actions based on commands from CM AV::CMAP.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>