### PR TITLE
prov/rxm: Refactor handling of deferred TX inject

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -331,7 +331,7 @@ static inline void *util_buf_get_ex(struct util_buf_pool *pool, void **context)
 
 static inline void *util_buf_alloc(struct util_buf_pool *pool)
 {
-	if (!util_buf_avail(pool)) {
+	if (OFI_UNLIKELY(!util_buf_avail(pool))) {
 		if (util_buf_grow(pool))
 			return NULL;
 	}


### PR DESCRIPTION
This patch addresses the following:
If a TX buffer is already allocated, it isn't allocated second time from a pool.