### PR TITLE
prov/shm: fix smr_region size allocation

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -177,7 +177,12 @@ struct smr_region {
 	struct smr_map	*map;
 
 	size_t		total_size;
-	size_t		cmd_cnt;
+	size_t		cmd_cnt; /* Doubles as a tracker for number of cmds AND
+				    number of inject buffers available for use,
+				    to ensure 1:1 ratio of cmds to inject bufs.
+				    Might not always be paired consistently with
+				    cmd alloc/free depending on protocol
+				    (Ex. unexpected messages, RMA requests) */
 
 	/* offsets from start of smr_region */
 	size_t		cmd_queue_offset;

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -64,7 +64,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	inject_pool_offset = resp_queue_offset + sizeof(struct smr_resp_queue) +
 			sizeof(struct smr_resp) * attr->tx_count;
 	peer_addr_offset = inject_pool_offset + sizeof(struct smr_inject_pool) +
-			sizeof(struct smr_inject_buf) * attr->rx_count;
+			sizeof(struct smr_inject_pool_entry) * attr->rx_count;
 	name_offset = peer_addr_offset + sizeof(struct smr_addr) * SMR_MAX_PEERS;
 	total_size = name_offset + strlen(attr->name) + 1;
 	total_size = roundup_power_of_two(total_size);


### PR DESCRIPTION
- fix inject pool allocation in smr_region creation based on recent smr_freestack changes
- clarify cmd_cnt usage

Signed-off-by: aingerson <alexia.ingerson@intel.com>