### PR TITLE
prov/psm,psm2: Always try to make progress when fi_cntr_read is called

### DIFF
--- a/prov/psm/src/psmx_cntr.c
+++ b/prov/psm/src/psmx_cntr.c
@@ -210,18 +210,13 @@ void psmx_cntr_add_trigger(struct psmx_fid_cntr *cntr, struct psmx_trigger *trig
 	psmx_cntr_check_trigger(cntr);
 }
 
-#define PSMX_CNTR_POLL_THRESHOLD 100
 static uint64_t psmx_cntr_read(struct fid_cntr *cntr)
 {
 	struct psmx_fid_cntr *cntr_priv;
-	static int poll_cnt = 0;
 
 	cntr_priv = container_of(cntr, struct psmx_fid_cntr, cntr);
 
-	if (poll_cnt++ == PSMX_CNTR_POLL_THRESHOLD) {
-		psmx_progress(cntr_priv->domain);
-		poll_cnt = 0;
-	}
+	psmx_progress(cntr_priv->domain);
 
 	return ofi_atomic_get64(&cntr_priv->counter);
 }

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -103,30 +103,25 @@ void psmx2_cntr_add_trigger(struct psmx2_fid_cntr *cntr,
 	psmx2_cntr_check_trigger(cntr);
 }
 
-#define PSMX2_CNTR_POLL_THRESHOLD 100
 DIRECT_FN
 STATIC uint64_t psmx2_cntr_read(struct fid_cntr *cntr)
 {
 	struct psmx2_fid_cntr *cntr_priv;
 	struct psmx2_poll_ctxt *poll_ctxt;
 	struct slist_entry *item, *prev;
-	static int poll_cnt = 0;
 
 	cntr_priv = container_of(cntr, struct psmx2_fid_cntr, cntr);
 
-	if (poll_cnt++ >= PSMX2_CNTR_POLL_THRESHOLD) {
-		if (cntr_priv->poll_all) {
-			psmx2_progress_all(cntr_priv->domain);
-		} else {
-			slist_foreach(&cntr_priv->poll_list, item, prev) {
-				poll_ctxt = container_of(item,
-							 struct psmx2_poll_ctxt,
-							 list_entry);
-				psmx2_progress(poll_ctxt->trx_ctxt);
-				(void) prev; /* suppress compiler warning */
-			}
+	if (cntr_priv->poll_all) {
+		psmx2_progress_all(cntr_priv->domain);
+	} else {
+		slist_foreach(&cntr_priv->poll_list, item, prev) {
+			poll_ctxt = container_of(item,
+						 struct psmx2_poll_ctxt,
+						 list_entry);
+			psmx2_progress(poll_ctxt->trx_ctxt);
+			(void) prev; /* suppress compiler warning */
 		}
-		poll_cnt = 0;
 	}
 
 	return ofi_atomic_get64(&cntr_priv->counter);


### PR DESCRIPTION
Previously fi_cntr_read would make progress calls at one percent frequency
in order to keep the average overhead of the function itself low. This could
actually have negative impact on the performance in case fi_cntr_read was the
only means of making progress because a large number of calls might be needed
even though per-call overhead was low.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>