### PR TITLE
prov/sockets: Add support for IPv6 addressing

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -119,6 +119,13 @@ static inline int ofi_sendall_socket(SOCKET sock, const void *buf, size_t len)
 #define AF_IB 27
 #endif
 
+union ofi_sock_ip {
+	struct sockaddr		sa;
+	struct sockaddr_in	sin;
+	struct sockaddr_in6	sin6;
+	uint8_t			align[32];
+};
+
 int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
 		const struct sockaddr *sa2);
 int ofi_getifaddrs(struct ifaddrs **ifap);

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -141,7 +141,19 @@ static inline size_t ofi_sizeofaddr(const struct sockaddr *addr)
 		return sizeof(struct sockaddr_in6);
 	default:
 		FI_WARN(&core_prov, FI_LOG_CORE, "Unknown address format");
-		assert(0);
+		return 0;
+	}
+}
+
+static inline size_t ofi_sizeofip(const struct sockaddr *addr)
+{
+	switch (addr->sa_family) {
+	case AF_INET:
+		return sizeof(struct in_addr);
+	case AF_INET6:
+		return sizeof(struct in6_addr);
+	default:
+		FI_WARN(&core_prov, FI_LOG_CORE, "Unknown address format");
 		return 0;
 	}
 }
@@ -284,6 +296,10 @@ static inline int ofi_equals_sockaddr(const struct sockaddr *addr1,
 
 int ofi_is_only_src_port_set(const char *node, const char *service,
 			     uint64_t flags, const struct fi_info *hints);
+
+size_t ofi_mask_addr(struct sockaddr *maskaddr, const struct sockaddr *srcaddr,
+		     const struct sockaddr *netmask);
+
 
 /*
  * Address logging

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -179,19 +179,7 @@ static inline int ofi_translate_addr_format(int family)
 	}
 }
 
-static inline int ofi_get_sa_family(uint32_t addr_format)
-{
-	switch (addr_format) {
-	case FI_SOCKADDR_IN:
-		return AF_INET;
-	case FI_SOCKADDR_IN6:
-		return AF_INET6;
-	case FI_SOCKADDR_IB:
-		return AF_IB;
-	default:
-		return 0;
-	}
-}
+uint16_t ofi_get_sa_family(const struct fi_info *info);
 
 static inline int ofi_ipv4_is_any_addr(struct sockaddr *sa)
 {

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -245,6 +245,18 @@ static inline void ofi_addr_set_port(struct sockaddr *addr, uint16_t port)
 	}
 }
 
+static inline void * ofi_get_ipaddr(const struct sockaddr *addr)
+{
+	switch (addr->sa_family) {
+	case AF_INET:
+		return &ofi_sin_addr((const struct sockaddr_in *) addr);
+	case AF_INET6:
+		return &ofi_sin6_addr((const struct sockaddr_in6 *) addr);
+	default:
+		return NULL;
+	}
+}
+
 static inline int ofi_equals_ipaddr(const struct sockaddr *addr1,
 				    const struct sockaddr *addr2)
 {

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -483,7 +483,7 @@ int ofi_get_addr(uint32_t addr_format, uint64_t flags,
 int ofi_get_src_addr(uint32_t addr_format,
 		     const void *dest_addr, size_t dest_addrlen,
 		     void **src_addr, size_t *src_addrlen);
-void ofi_getnodename(char *buf, int buflen);
+void ofi_getnodename(uint16_t sa_family, char *buf, int buflen);
 int ofi_av_get_index(struct util_av *av, const void *addr);
 
 /*

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -132,7 +132,7 @@ struct rxm_ep_wire_proto {
 };
 
 struct rxm_cm_data {
-	struct sockaddr name;
+	union ofi_sock_ip name;
 	uint64_t conn_id;
 	struct rxm_ep_wire_proto proto;
 };

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -431,7 +431,7 @@ exit:
 }
 
 static int rxm_prepare_cm_data(struct fid_pep *pep, struct util_cmap_handle *handle,
-		struct rxm_cm_data *cm_data)
+			       struct rxm_cm_data *cm_data)
 {
 	size_t cm_data_size = 0;
 	size_t name_size = sizeof(cm_data->name);
@@ -449,7 +449,6 @@ static int rxm_prepare_cm_data(struct fid_pep *pep, struct util_cmap_handle *han
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "MSG EP CM data size too small\n");
 		return -FI_EOTHER;
 	}
-
 	ret = fi_getname(&pep->fid, &cm_data->name, &name_size);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to get msg pep name\n");

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -962,7 +962,8 @@ struct sock_conn_req_handle {
 };
 
 struct sock_host_list_entry {
-	char hostname[HOST_NAME_MAX];
+	char ipstr[INET6_ADDRSTRLEN];
+	struct sockaddr_in ipaddr;
 	struct slist_entry entry;
 };
 

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -543,7 +543,6 @@ struct sock_ep_cm_entry {
 struct sock_conn_handle {
 	int sock;
 	int do_listen;
-	char service[NI_MAXSERV];
 };
 
 struct sock_ep_attr {

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -73,7 +73,8 @@ int sock_av_get_addr_index(struct sock_av *av, struct sockaddr_in *addr)
 		if (!av_addr->valid)
 			continue;
 
-		 if (ofi_equals_sockaddr(addr, (struct sockaddr_in *)&av_addr->addr))
+		 if (ofi_equals_sockaddr((struct sockaddr *) addr,
+					 (struct sockaddr *) &av_addr->addr))
 			return i;
 	}
 	SOCK_LOG_DBG("failed to get index in AV\n");

--- a/prov/sockets/src/sock_comm.c
+++ b/prov/sockets/src/sock_comm.c
@@ -55,9 +55,8 @@ static ssize_t sock_comm_send_socket(struct sock_conn *conn,
 			ret = 0;
 		} else if (ofi_sockerr() == EPIPE) {
 			conn->connected = 0;
-			SOCK_LOG_DBG("Disconnected: %s:%d\n",
-				     inet_ntoa(conn->addr.sin_addr),
-				     ntohs(conn->addr.sin_port));
+			SOCK_LOG_DBG("Disconnected port: %d\n",
+				     ofi_addr_get_port(&conn->addr.sa));
 		} else {
 			SOCK_LOG_DBG("write error: %s\n",
 				     strerror(ofi_sockerr()));
@@ -136,9 +135,8 @@ static ssize_t sock_comm_recv_socket(struct sock_conn *conn,
 	ret = ofi_recv_socket(conn->sock_fd, buf, len, 0);
 	if (ret == 0) {
 		conn->connected = 0;
-		SOCK_LOG_DBG("Disconnected: %s:%d\n",
-			     inet_ntoa(conn->addr.sin_addr),
-			     ntohs(conn->addr.sin_port));
+		SOCK_LOG_DBG("Disconnected: port %d\n",
+			     ofi_addr_get_port(&conn->addr.sa));
 		return ret;
 	}
 

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -432,6 +432,8 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 	if (ret) {
 		SOCK_LOG_ERROR("failed to bind listener: %s\n",
 			       strerror(ofi_sockerr()));
+		ofi_straddr_log(&sock_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
+				"bind failed to addr: ", &addr.sa);
 		ret = -ofi_sockerr();
 		goto err;
 	}

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -69,7 +69,7 @@ ssize_t sock_conn_send_src_addr(struct sock_ep_attr *ep_attr, struct sock_tx_ctx
 	SOCK_LOG_DBG("New conn msg on TX: %p using conn: %p\n", tx_ctx, conn);
 
 	total_len = 0;
-	tx_op.src_iov_len = sizeof(struct sockaddr_in);
+	tx_op.src_iov_len = sizeof(union ofi_sock_ip);
 	total_len = tx_op.src_iov_len + sizeof(struct sock_op_send);
 
 	sock_tx_ctx_start(tx_ctx);
@@ -80,7 +80,7 @@ ssize_t sock_conn_send_src_addr(struct sock_ep_attr *ep_attr, struct sock_tx_ctx
 
 	sock_tx_ctx_write_op_send(tx_ctx, &tx_op, 0, (uintptr_t) NULL, 0, 0,
 				   ep_attr, conn);
-	sock_tx_ctx_write(tx_ctx, ep_attr->src_addr, sizeof(struct sockaddr_in));
+	sock_tx_ctx_write(tx_ctx, ep_attr->src_addr, sizeof(union ofi_sock_ip));
 	sock_tx_ctx_commit(tx_ctx);
 	conn->address_published = 1;
 	return 0;
@@ -179,7 +179,7 @@ static int sock_conn_get_next_index(struct sock_conn_map *map)
 }
 
 static struct sock_conn *sock_conn_map_insert(struct sock_ep_attr *ep_attr,
-				struct sockaddr_in *addr, int conn_fd,
+				union ofi_sock_ip *addr, int conn_fd,
 				int addr_published)
 {
 	int index;
@@ -316,7 +316,7 @@ static void *sock_conn_listener_thread(void *arg)
 	void *ep_contexts[SOCK_EPOLL_WAIT_EVENTS];
 	struct sock_ep_attr *ep_attr;
 	int num_fds, i, conn_fd;
-	struct sockaddr_in remote;
+	union ofi_sock_ip remote;
 	socklen_t addr_size;
 
 	while (conn_listener->do_listen) {
@@ -336,8 +336,9 @@ static void *sock_conn_listener_thread(void *arg)
 				continue;
 			}
 
+			memset(&remote, 0, sizeof remote);
 			addr_size = sizeof(remote);
-			conn_fd = accept(conn_handle->sock, (struct sockaddr *) &remote,
+			conn_fd = accept(conn_handle->sock, &remote.sa,
 			                 &addr_size);
 			SOCK_LOG_DBG("CONN: accepted conn-req: %d\n", conn_fd);
 			if (conn_fd < 0) {
@@ -345,9 +346,6 @@ static void *sock_conn_listener_thread(void *arg)
 				               strerror(ofi_sockerr()));
 				continue;
 			}
-
-			SOCK_LOG_DBG("ACCEPT: %s, %d\n", inet_ntoa(remote.sin_addr),
-				     ntohs(remote.sin_port));
 
 			ep_attr = container_of(conn_handle, struct sock_ep_attr, conn_handle);
 			fastlock_acquire(&ep_attr->cmap.lock);
@@ -412,18 +410,19 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 	struct addrinfo hints = { 0 };
 	int listen_fd = 0, ret;
 	socklen_t addr_size;
-	struct sockaddr_in addr;
+	union ofi_sock_ip addr;
 	struct sock_conn_handle *conn_handle = &ep_attr->conn_handle;
 	char service[NI_MAXSERV] = {0};
 	char *port;
-	char ipaddr[24];
+	char ipaddr[INET6_ADDRSTRLEN];
 
-	hints.ai_family = AF_INET;
+	hints.ai_family = ep_attr->src_addr->sa.sa_family;
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_flags = AI_PASSIVE;
 
-	memcpy(&addr, ep_attr->src_addr, sizeof(addr));
-	if (getnameinfo((void *)ep_attr->src_addr, sizeof(*ep_attr->src_addr),
+	addr = *ep_attr->src_addr;
+	if (getnameinfo(&ep_attr->src_addr->sa,
+			ofi_sizeofaddr(&ep_attr->src_addr->sa),
 			NULL, 0, conn_handle->service,
 			sizeof(conn_handle->service), NI_NUMERICSERV)) {
 		SOCK_LOG_ERROR("could not resolve src_addr\n");
@@ -433,11 +432,13 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 	if (ep_attr->ep_type == FI_EP_MSG) {
 		memset(conn_handle->service, 0, NI_MAXSERV);
 		port = NULL;
-		addr.sin_port = 0;
-	} else
+		ofi_addr_set_port(&addr.sa, 0);
+	} else {
 		port = conn_handle->service;
+	}
 
-	inet_ntop(addr.sin_family, &addr.sin_addr, ipaddr, sizeof(ipaddr));
+	inet_ntop(addr.sa.sa_family, ofi_get_ipaddr(&addr.sa),
+		  ipaddr, sizeof(ipaddr));
 	ret = getaddrinfo(ipaddr, port, &hints, &s_res);
 	if (ret) {
 		SOCK_LOG_ERROR("no available AF_INET address, service %s, %s\n",
@@ -467,19 +468,19 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 
 	if (atoi(conn_handle->service) == 0) {
 		addr_size = sizeof(addr);
-		if (getsockname(listen_fd, (struct sockaddr *) &addr,
-				&addr_size))
+		if (getsockname(listen_fd, &addr.sa, &addr_size))
 			goto err;
 		snprintf(conn_handle->service, sizeof(conn_handle->service), "%d",
-			 ntohs(addr.sin_port));
+			 ofi_addr_get_port(&addr.sa));
 		SOCK_LOG_DBG("Bound to port: %s - %d\n",
 			     conn_handle->service, getpid());
-		ep_attr->msg_src_port = ntohs(addr.sin_port);
+		ep_attr->msg_src_port = ofi_addr_get_port(&addr.sa);
 	}
 
-	if (ep_attr->src_addr->sin_addr.s_addr == 0) {
+	if (ofi_is_any_addr(&ep_attr->src_addr->sa)) {
 		snprintf(service, sizeof service, "%s", conn_handle->service);
-		ret = sock_get_src_addr_from_hostname(ep_attr->src_addr, service);
+		ret = sock_get_src_addr_from_hostname(ep_attr->src_addr,
+				service, ep_attr->src_addr->sa.sa_family);
 		if (ret)
 			goto err;
 	}
@@ -490,9 +491,9 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 		goto err;
 	}
 
-	if (((struct sockaddr_in *) (ep_attr->src_addr))->sin_port == 0) {
-		((struct sockaddr_in *) (ep_attr->src_addr))->sin_port =
-			htons(atoi(conn_handle->service));
+	if (ofi_addr_get_port(&ep_attr->src_addr->sa) == 0) {
+		ofi_addr_set_port(&ep_attr->src_addr->sa,
+				  htons(atoi(conn_handle->service)));
 	}
 
 	conn_handle->sock = listen_fd;
@@ -522,7 +523,7 @@ int sock_ep_connect(struct sock_ep_attr *ep_attr, fi_addr_t index,
 	int conn_fd = -1, ret;
 	int do_retry = sock_conn_retry;
 	struct sock_conn *new_conn;
-	struct sockaddr_in addr;
+	union ofi_sock_ip addr;
 	socklen_t lon;
 	int valopt = 0;
 	struct pollfd poll_fd;
@@ -532,9 +533,9 @@ int sock_ep_connect(struct sock_ep_attr *ep_attr, fi_addr_t index,
 		   passed to endpoint */
 		assert(ep_attr->dest_addr);
 		addr = *ep_attr->dest_addr;
-		addr.sin_port = htons(ep_attr->msg_dest_port);
+		ofi_addr_set_port(&addr.sa, ep_attr->msg_dest_port);
 	} else {
-		addr = *((struct sockaddr_in *)&ep_attr->av->table[index].addr);
+		addr = ep_attr->av->table[index].addr;
 	}
 
 do_connect:
@@ -545,7 +546,7 @@ do_connect:
 	if (*conn != SOCK_CM_CONN_IN_PROGRESS)
 		return FI_SUCCESS;
 
-	conn_fd = ofi_socket(AF_INET, SOCK_STREAM, 0);
+	conn_fd = ofi_socket(addr.sa.sa_family, SOCK_STREAM, 0);
 	if (conn_fd == -1) {
 		SOCK_LOG_ERROR("failed to create conn_fd, errno: %d\n",
 			       ofi_sockerr());
@@ -561,12 +562,7 @@ do_connect:
 		return -FI_EOTHER;
 	}
 
-	SOCK_LOG_DBG("Connecting to: %s:%d\n", inet_ntoa(addr.sin_addr),
-		     ntohs(addr.sin_port));
-	SOCK_LOG_DBG("Connecting using address:%s\n",
-		     inet_ntoa(ep_attr->src_addr->sin_addr));
-
-	ret = connect(conn_fd, (struct sockaddr *) &addr, sizeof addr);
+	ret = connect(conn_fd, &addr.sa, ofi_sizeofaddr(&addr.sa));
 	if (ret < 0) {
 		if (OFI_SOCK_TRY_CONN_AGAIN(ofi_sockerr())) {
 			poll_fd.fd = conn_fd;
@@ -591,22 +587,12 @@ do_connect:
 				SOCK_LOG_DBG("Error in connection() "
 					     "%d - %s - %d\n",
 					     valopt, strerror(valopt), conn_fd);
-				SOCK_LOG_DBG("Connecting to: %s:%d\n",
-					     inet_ntoa(addr.sin_addr),
-					     ntohs(addr.sin_port));
-				SOCK_LOG_DBG("Connecting using address:%s\n",
-				inet_ntoa(ep_attr->src_addr->sin_addr));
 				goto retry;
 			}
 			goto out;
 		} else {
 			SOCK_LOG_DBG("Timeout or error() - %s: %d\n",
 				     strerror(ofi_sockerr()), conn_fd);
-			SOCK_LOG_DBG("Connecting to: %s:%d\n",
-				     inet_ntoa(addr.sin_addr),
-				     ntohs(addr.sin_port));
-			SOCK_LOG_DBG("Connecting using address:%s\n",
-				     inet_ntoa(ep_attr->src_addr->sin_addr));
 			goto retry;
 		}
 	} else {
@@ -626,10 +612,6 @@ retry:
 
 	SOCK_LOG_ERROR("Connect error, retrying - %s - %d\n",
 		       strerror(ofi_sockerr()), conn_fd);
-	SOCK_LOG_DBG("Connecting to: %s:%d\n", inet_ntoa(addr.sin_addr),
-			ntohs(addr.sin_port));
-	SOCK_LOG_DBG("Connecting using address:%s\n",
-			inet_ntoa(ep_attr->src_addr->sin_addr));
         goto do_connect;
 
 out:

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -80,6 +80,9 @@ ssize_t sock_conn_send_src_addr(struct sock_ep_attr *ep_attr, struct sock_tx_ctx
 
 	sock_tx_ctx_write_op_send(tx_ctx, &tx_op, 0, (uintptr_t) NULL, 0, 0,
 				   ep_attr, conn);
+
+	ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL, "sending src addr: ",
+			ep_attr->src_addr);
 	sock_tx_ctx_write(tx_ctx, ep_attr->src_addr, sizeof(union ofi_sock_ip));
 	sock_tx_ctx_commit(tx_ctx);
 	conn->address_published = 1;
@@ -341,6 +344,9 @@ static void *sock_conn_listener_thread(void *arg)
 			conn_fd = accept(conn_handle->sock, &remote.sa,
 			                 &addr_size);
 			SOCK_LOG_DBG("CONN: accepted conn-req: %d\n", conn_fd);
+			ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL,
+					"accepted peer addr: ", &remote.sa);
+
 			if (conn_fd < 0) {
 				SOCK_LOG_ERROR("failed to accept: %s\n",
 				               strerror(ofi_sockerr()));
@@ -441,6 +447,8 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 	if (!ofi_addr_get_port(&ep_attr->src_addr->sa))
 		ofi_addr_set_port(&ep_attr->src_addr->sa, ep_attr->msg_src_port);
 
+	ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL, "listening at addr: ",
+			&addr.sa);
 	ret = listen(listen_fd, sock_cm_def_map_sz);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to listen socket: %s\n",
@@ -518,6 +526,8 @@ do_connect:
 		return -FI_EOTHER;
 	}
 
+	ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL, "connecting to addr: ",
+			&addr.sa);
 	ret = connect(conn_fd, &addr.sa, ofi_sizeofaddr(&addr.sa));
 	if (ret < 0) {
 		if (OFI_SOCK_TRY_CONN_AGAIN(ofi_sockerr())) {

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1515,7 +1515,7 @@ struct fi_info *sock_fi_info(uint32_t version, enum fi_ep_type ep_type,
 	} else {
 		sock_get_src_addr_from_hostname(info->src_addr, NULL,
 			dest_addr ? ((struct sockaddr *) dest_addr)->sa_family :
-			0);
+			ofi_get_sa_family(hints));
 	}
 
 	info->src_addrlen = ofi_sizeofaddr(info->src_addr);

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1575,7 +1575,7 @@ int sock_get_src_addr_from_hostname(union ofi_sock_ip *src_addr,
 	ai.ai_family = sa_family;
 	ai.ai_socktype = SOCK_STREAM;
 
-	ofi_getnodename(hostname, sizeof(hostname));
+	ofi_getnodename(sa_family, hostname, sizeof(hostname));
 	ret = getaddrinfo(hostname, service, &ai, &rai);
 	if (ret) {
 		SOCK_LOG_DBG("getaddrinfo failed!\n");

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1363,7 +1363,7 @@ char *sock_get_fabric_name(struct sockaddr_in *src_addr)
 		if (ifa->ifa_addr == NULL || !(ifa->ifa_flags & IFF_UP) ||
 		     (ifa->ifa_addr->sa_family != AF_INET))
 			continue;
-		if (ofi_equals_ipaddr((struct sockaddr_in *)ifa->ifa_addr, src_addr)) {
+		if (ofi_equals_ipaddr(ifa->ifa_addr, (struct sockaddr *) src_addr)) {
 			host_addr = (struct sockaddr_in *)ifa->ifa_addr;
 			net_addr = (struct sockaddr_in *)ifa->ifa_netmask;
 			/* set fabric name to the network_adress in the format of a.b.c.d/e */
@@ -1397,7 +1397,7 @@ char *sock_get_domain_name(struct sockaddr_in *src_addr)
 		if (ifa->ifa_addr == NULL || !(ifa->ifa_flags & IFF_UP) ||
 		     (ifa->ifa_addr->sa_family != AF_INET))
 			continue;
-		if (ofi_equals_ipaddr((struct sockaddr_in *)ifa->ifa_addr, src_addr)) {
+		if (ofi_equals_ipaddr(ifa->ifa_addr, (struct sockaddr *) src_addr)) {
 			domain_name = strdup(ifa->ifa_name);
 			goto out;
 		}
@@ -1833,7 +1833,8 @@ struct sock_conn *sock_ep_lookup_conn(struct sock_ep_attr *attr, fi_addr_t index
 		if (!attr->cmap.table[i].connected)
 			continue;
 
-		if (ofi_equals_sockaddr(&attr->cmap.table[i].addr, addr)) {
+		if (ofi_equals_sockaddr((struct sockaddr *) &attr->cmap.table[i].addr,
+					(struct sockaddr *) addr)) {
 			conn = &attr->cmap.table[i];
 			if (conn->av_index == FI_ADDR_NOTAVAIL)
 				conn->av_index = idx;

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -656,7 +656,7 @@ static int sock_ep_cm_connect(struct fid_ep *ep, const void *addr,
 		if (!_ep->attr->dest_addr)
 			return -FI_ENOMEM;
 	}
-	memcpy(_ep->attr->dest_addr, addr, sizeof(*_ep->attr->dest_addr));
+	memcpy(_ep->attr->dest_addr, addr, ofi_sizeofaddr(addr));
 
 	req = calloc(1, sizeof(*req));
 	if (!req)
@@ -672,8 +672,9 @@ static int sock_ep_cm_connect(struct fid_ep *ep, const void *addr,
 	req->hdr.port = htons(_ep->attr->msg_src_port);
 	req->hdr.cm_data_sz = htons(paramlen);
 	req->caps = _ep->attr->info.caps;
-	memcpy(&req->src_addr, _ep->attr->src_addr, sizeof(req->src_addr));
-	memcpy(&handle->dest_addr, addr, sizeof(handle->dest_addr));
+	memcpy(&req->src_addr, _ep->attr->src_addr,
+	       ofi_sizeofaddr(&_ep->attr->src_addr->sa));
+	memcpy(&handle->dest_addr, addr, ofi_sizeofaddr(addr));
 
 	cm_head = &_ep->attr->domain->cm_head;
 	_ep->attr->info.handle = (void*) handle;
@@ -694,8 +695,8 @@ static int sock_ep_cm_connect(struct fid_ep *ep, const void *addr,
 	ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL, "Connecting to address",
 			&handle->dest_addr);
 	sock_set_sockopts(sock_fd, SOCK_OPTS_KEEPALIVE);
-	ret = connect(sock_fd, (struct sockaddr *)&handle->dest_addr,
-		      sizeof(handle->dest_addr));
+	ret = connect(sock_fd, &handle->dest_addr.sa,
+		      ofi_sizeofaddr(&handle->dest_addr.sa));
 	if (ret < 0) {
 		SOCK_LOG_ERROR("connect failed : %s\n",
 			       strerror(ofi_sockerr()));

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -1319,7 +1319,15 @@ int sock_msg_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 			if (!hints.ai_family)
 				hints.ai_family = AF_INET;
 
-			ret = getaddrinfo("localhost", NULL, &hints, &result);
+			if (hints.ai_family == AF_INET) {
+				ret = getaddrinfo("127.0.0.1", NULL, &hints,
+						  &result);
+			} else if (hints.ai_family == AF_INET6) {
+				ret = getaddrinfo("::1", NULL, &hints, &result);
+			} else {
+				ret = getaddrinfo("localhost", NULL, &hints,
+						  &result);
+			}
 			if (ret) {
 				ret = -FI_EINVAL;
 				SOCK_LOG_DBG("getaddrinfo failed!\n");

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -1314,8 +1314,10 @@ int sock_msg_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 				info->src_addrlen);
 		} else {
 			memset(&hints, 0, sizeof(hints));
-			hints.ai_family = AF_INET;
 			hints.ai_socktype = SOCK_STREAM;
+			hints.ai_family = ofi_get_sa_family(info);
+			if (!hints.ai_family)
+				hints.ai_family = AF_INET;
 
 			ret = getaddrinfo("localhost", NULL, &hints, &result);
 			if (ret) {

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -419,6 +419,7 @@ int sock_get_src_addr(union ofi_sock_ip *dest_addr,
 		SOCK_LOG_DBG("getsockname failed\n");
 		ret = -ofi_sockerr();
 	}
+
 out:
 	ofi_close_socket(sock);
 	return ret;
@@ -485,6 +486,14 @@ static int sock_ep_getinfo(uint32_t version, const char *node,
 			src_addr = &sip;
 	}
 
+	if (dest_addr) {
+		ofi_straddr_log(&sock_prov, FI_LOG_INFO, FI_LOG_CORE,
+				"dest addr: ", dest_addr);
+	}
+	if (src_addr) {
+		ofi_straddr_log(&sock_prov, FI_LOG_INFO, FI_LOG_CORE,
+				"src addr: ", src_addr);
+	}
 	switch (ep_type) {
 	case FI_EP_MSG:
 		ret = sock_msg_fi_info(version, src_addr, dest_addr, hints, info);
@@ -519,6 +528,9 @@ static void sock_insert_loopback_addr(struct slist *addr_list)
 
 	addr_entry->ipaddr.sin.sin_family = AF_INET;
 	addr_entry->ipaddr.sin.sin_addr.s_addr = INADDR_LOOPBACK;
+	ofi_straddr_log(&sock_prov, FI_LOG_INFO, FI_LOG_CORE,
+			"available addr: ", &addr_entry->ipaddr);
+
 	strncpy(addr_entry->ipstr, "127.0.0.1", sizeof(addr_entry->ipstr));
 	slist_insert_tail(&addr_entry->entry, addr_list);
 
@@ -528,6 +540,9 @@ static void sock_insert_loopback_addr(struct slist *addr_list)
 
 	addr_entry->ipaddr.sin6.sin6_family = AF_INET6;
 	addr_entry->ipaddr.sin6.sin6_addr = in6addr_loopback;
+	ofi_straddr_log(&sock_prov, FI_LOG_INFO, FI_LOG_CORE,
+			"available addr: ", &addr_entry->ipaddr);
+
 	strncpy(addr_entry->ipstr, "::1", sizeof(addr_entry->ipstr));
 	slist_insert_tail(&addr_entry->entry, addr_list);
 }
@@ -577,6 +592,9 @@ void sock_get_list_of_addr(struct slist *addr_list)
 
 			memcpy(&addr_entry->ipaddr, ifa->ifa_addr,
 			       ofi_sizeofaddr(ifa->ifa_addr));
+			ofi_straddr_log(&sock_prov, FI_LOG_INFO, FI_LOG_CORE,
+					"available addr: ", ifa->ifa_addr);
+
 			if (!inet_ntop(ifa->ifa_addr->sa_family,
 					ofi_get_ipaddr(ifa->ifa_addr),
 					addr_entry->ipstr,

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -451,6 +451,7 @@ static int sock_ep_getinfo(uint32_t version, const char *node,
 
 	memset(&ai, 0, sizeof(ai));
 	ai.ai_socktype = SOCK_STREAM;
+	ai.ai_family = ofi_get_sa_family(hints);
 	if (flags & FI_NUMERICHOST)
 		ai.ai_flags |= AI_NUMERICHOST;
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1451,32 +1451,25 @@ static int sock_pe_process_rx_conn_msg(struct sock_pe *pe,
 	uint64_t len, data_len;
 	struct sock_ep_attr *ep_attr;
 	struct sock_conn_map *map;
-	struct sockaddr_in *addr;
+	union ofi_sock_ip *addr;
 	struct sock_conn *conn;
 	uint64_t index;
 
 	if (!pe_entry->comm_addr) {
-		pe_entry->comm_addr = calloc(1, sizeof(struct sockaddr_in));
+		pe_entry->comm_addr = calloc(1, sizeof(union ofi_sock_ip));
 		if (!pe_entry->comm_addr)
 			return -FI_ENOMEM;
 	}
 
 	len = sizeof(struct sock_msg_hdr);
-	data_len = sizeof(struct sockaddr_in);
+	data_len = sizeof(union ofi_sock_ip);
 	if (sock_pe_recv_field(pe_entry, pe_entry->comm_addr, data_len, len)) {
 		return 0;
 	}
 
-	SOCK_LOG_DBG("got conn msg from %s:%d\n",
-		inet_ntoa(((struct sockaddr_in *)&pe_entry->conn->addr)->sin_addr),
-		ntohs(((struct sockaddr_in *)&pe_entry->conn->addr)->sin_port));
-	SOCK_LOG_DBG("on behalf of %s:%d\n",
-		inet_ntoa(((struct sockaddr_in *)pe_entry->comm_addr)->sin_addr),
-		ntohs(((struct sockaddr_in *)pe_entry->comm_addr)->sin_port));
-
 	ep_attr = pe_entry->conn->ep_attr;
 	map = &ep_attr->cmap;
-	addr = (struct sockaddr_in *) pe_entry->comm_addr;
+	addr = pe_entry->comm_addr;
 	pe_entry->conn->addr = *addr;
 
 	index = (ep_attr->ep_type == FI_EP_MSG) ? 0 : sock_av_get_addr_index(ep_attr->av, addr);

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -694,12 +694,7 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 				goto err3;
 		}
 	} else {
-		if (info->src_addr)
-			af = ((const struct sockaddr *) info->src_addr)->sa_family;
-		else if (info->dest_addr)
-			af = ((const struct sockaddr *) info->dest_addr)->sa_family;
-		else
-			af = ofi_get_sa_family(info->addr_format);
+		af = ofi_get_sa_family(info);
 
 		ep->conn_fd = ofi_socket(af, SOCK_STREAM, 0);
 		if (ep->conn_fd == INVALID_SOCKET) {

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -104,7 +104,7 @@ out:
 
 }
 
-void ofi_getnodename(char *buf, int buflen)
+void ofi_getnodename(uint16_t sa_family, char *buf, int buflen)
 {
 	int ret;
 	struct addrinfo ai, *rai = NULL;
@@ -115,7 +115,7 @@ void ofi_getnodename(char *buf, int buflen)
 	buf[buflen - 1] = '\0';
 	if (ret == 0) {
 		memset(&ai, 0, sizeof(ai));
-		ai.ai_family = AF_INET;
+		ai.ai_family = sa_family  ? sa_family : AF_INET;
 		ret = getaddrinfo(buf, NULL, &ai, &rai);
 		if (!ret) {
 			freeaddrinfo(rai);
@@ -127,10 +127,16 @@ void ofi_getnodename(char *buf, int buflen)
 	ret = ofi_getifaddrs(&ifaddrs);
 	if (!ret) {
 		for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
-			if (ifa->ifa_addr == NULL || !(ifa->ifa_flags & IFF_UP) ||
-			    ((ifa->ifa_addr->sa_family != AF_INET) &&
-			     (ifa->ifa_addr->sa_family != AF_INET6)))
+			if (ifa->ifa_addr == NULL || !(ifa->ifa_flags & IFF_UP))
 				continue;
+
+			if (sa_family) {
+				if (ifa->ifa_addr->sa_family != sa_family)
+					continue;
+			} else if ((ifa->ifa_addr->sa_family != AF_INET) &&
+				   (ifa->ifa_addr->sa_family != AF_INET6)) {
+				continue;
+			}
 
 			ret = getnameinfo(ifa->ifa_addr, ofi_sizeofaddr(ifa->ifa_addr),
 				  	  buf, buflen, NULL, 0, NI_NUMERICHOST);
@@ -143,7 +149,7 @@ void ofi_getnodename(char *buf, int buflen)
 		freeifaddrs(ifaddrs);
 	}
 #endif
-	/* no reasonable address found, try loopback */
+	/* no reasonable address found, use ipv4 loopback */
 	strncpy(buf, "127.0.0.1", buflen);
 	buf[buflen - 1] = '\0';
 }

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -128,10 +128,11 @@ void ofi_getnodename(char *buf, int buflen)
 	if (!ret) {
 		for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
 			if (ifa->ifa_addr == NULL || !(ifa->ifa_flags & IFF_UP) ||
-			     (ifa->ifa_addr->sa_family != AF_INET))
+			    ((ifa->ifa_addr->sa_family != AF_INET) &&
+			     (ifa->ifa_addr->sa_family != AF_INET6)))
 				continue;
 
-			ret = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in),
+			ret = getnameinfo(ifa->ifa_addr, ofi_sizeofaddr(ifa->ifa_addr),
 				  	  buf, buflen, NULL, 0, NI_NUMERICHOST);
 			buf[buflen - 1] = '\0';
 			if (ret == 0) {

--- a/src/common.c
+++ b/src/common.c
@@ -222,12 +222,6 @@ uint16_t ofi_get_sa_family(const struct fi_info *info)
 	if (!info)
 		return 0;
 
-	if (info->src_addr)
-		return ((struct sockaddr *) info->src_addr)->sa_family;
-
-	if (info->dest_addr)
-		return ((struct sockaddr *) info->dest_addr)->sa_family;
-
 	switch (info->addr_format) {
 	case FI_SOCKADDR_IN:
 		return AF_INET;
@@ -235,6 +229,14 @@ uint16_t ofi_get_sa_family(const struct fi_info *info)
 		return AF_INET6;
 	case FI_SOCKADDR_IB:
 		return AF_IB;
+	case FI_SOCKADDR:
+	case FI_FORMAT_UNSPEC:
+		if (info->src_addr)
+			return ((struct sockaddr *) info->src_addr)->sa_family;
+
+		if (info->dest_addr)
+			return ((struct sockaddr *) info->dest_addr)->sa_family;
+		/* fall through */
 	default:
 		return 0;
 	}

--- a/src/common.c
+++ b/src/common.c
@@ -598,6 +598,36 @@ out:
 	return ((flags & FI_SOURCE) && service) ? 1 : 0;
 }
 
+
+size_t ofi_mask_addr(struct sockaddr *maskaddr, const struct sockaddr *srcaddr,
+		     const struct sockaddr *netmask)
+{
+	size_t i, size, len = 0;
+	uint8_t *ip, *mask, bits;
+
+	memcpy(maskaddr, srcaddr, ofi_sizeofaddr(srcaddr));
+	size = ofi_sizeofip(srcaddr);
+	ip = ofi_get_ipaddr(maskaddr);
+	mask = ofi_get_ipaddr(netmask);
+
+	if (!size || !ip || !mask)
+		return 0;
+
+	for (i = 0; i < size; i++) {
+		ip[i] &= mask[i];
+
+		if (mask[i] == 0xff) {
+			len += 8;
+		} else {
+			for (bits = mask[i]; bits; bits >>= 1) {
+				if (bits & 0x1)
+					len++;
+			}
+		}
+	}
+	return len;
+}
+
 void ofi_straddr_log_internal(const char *func, int line,
 			      const struct fi_provider *prov,
 			      enum fi_log_level level,

--- a/src/common.c
+++ b/src/common.c
@@ -217,6 +217,29 @@ uint64_t fi_gettime_us(void)
 	return now.tv_sec * 1000000 + now.tv_usec;
 }
 
+uint16_t ofi_get_sa_family(const struct fi_info *info)
+{
+	if (!info)
+		return 0;
+
+	if (info->src_addr)
+		return ((struct sockaddr *) info->src_addr)->sa_family;
+
+	if (info->dest_addr)
+		return ((struct sockaddr *) info->dest_addr)->sa_family;
+
+	switch (info->addr_format) {
+	case FI_SOCKADDR_IN:
+		return AF_INET;
+	case FI_SOCKADDR_IN6:
+		return AF_INET6;
+	case FI_SOCKADDR_IB:
+		return AF_IB;
+	default:
+		return 0;
+	}
+}
+
 const char *ofi_straddr(char *buf, size_t *len,
 			uint32_t addr_format, const void *addr)
 {


### PR DESCRIPTION
Changes do not work.
Posting as work in progress to add ipv6 support to the socket provider. These changes currently break MSG EP support and have not been tested with ipv6 addresses yet.