### PR TITLE
prov/rxm: keep src addr reporting in sync with completion entry reporting.

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -394,18 +394,16 @@ static inline void util_cq_signal(struct util_cq *cq)
 	assert(cq->wait);
 	cq->wait->signal(cq->wait);
 }
+
 static inline int
-ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
-	     void *buf, uint64_t data, uint64_t tag)
+ofi_cq_write_thread_unsafe(struct util_cq *cq, void *context, uint64_t flags,
+			   size_t len, void *buf, uint64_t data, uint64_t tag)
 {
 	struct fi_cq_tagged_entry *comp;
-	int ret = 0;
 
-	cq->cq_fastlock_acquire(&cq->cq_lock);
 	if (ofi_cirque_isfull(cq->cirq)) {
 		FI_DBG(cq->domain->prov, FI_LOG_CQ, "util_cq cirq is full!\n");
-		ret = -FI_EAGAIN;
-		goto out;
+		return -FI_EAGAIN;
 	}
 
 	comp = ofi_cirque_tail(cq->cirq);
@@ -416,10 +414,34 @@ ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 	comp->data = data;
 	comp->tag = tag;
 	ofi_cirque_commit(cq->cirq);
-out:
+	return 0;
+}
+
+static inline int
+ofi_cq_write(struct util_cq *cq, void *context, uint64_t flags, size_t len,
+	     void *buf, uint64_t data, uint64_t tag)
+{
+	int ret;
+	cq->cq_fastlock_acquire(&cq->cq_lock);
+	ret = ofi_cq_write_thread_unsafe(cq, context, flags, len, buf, data, tag);
 	cq->cq_fastlock_release(&cq->cq_lock);
 	return ret;
 }
+
+static inline int
+ofi_cq_write_src(struct util_cq *cq, void *context, uint64_t flags, size_t len,
+		 void *buf, uint64_t data, uint64_t tag, fi_addr_t src)
+{
+	int ret;
+
+	cq->cq_fastlock_acquire(&cq->cq_lock);
+	ret = ofi_cq_write_thread_unsafe(cq, context, flags, len, buf, data, tag);
+	if (!ret)
+		cq->src[ofi_cirque_windex(cq->cirq)] = src;
+	cq->cq_fastlock_release(&cq->cq_lock);
+	return ret;
+}
+
 int ofi_cq_write_error(struct util_cq *cq,
 		       const struct fi_cq_err_entry *err_entry);
 int ofi_cq_write_error_peek(struct util_cq *cq, uint64_t tag, void *context);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -825,3 +825,18 @@ static inline int rxm_finish_send_nobuf(struct rxm_tx_entry *tx_entry)
 	rxm_tx_entry_release(&tx_entry->conn->send_queue, tx_entry);
 	return 0;
 }
+
+static inline int rxm_cq_write_recv_comp(struct rxm_rx_buf *rx_buf,
+					 void *context, uint64_t flags,
+					 size_t len, char *buf)
+{
+	if (rx_buf->ep->rxm_info->caps & FI_SOURCE)
+		return ofi_cq_write_src(rx_buf->ep->util_ep.rx_cq, context,
+					flags, len, buf, rx_buf->pkt.hdr.data,
+					rx_buf->pkt.hdr.tag,
+					rx_buf->conn->handle.fi_addr);
+	else
+		return ofi_cq_write(rx_buf->ep->util_ep.rx_cq, context,
+				    flags, len, buf, rx_buf->pkt.hdr.data,
+				    rx_buf->pkt.hdr.tag);
+}

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1297,7 +1297,7 @@ static int util_cmap_alloc_handle_peer(struct util_cmap *cmap, void *addr,
 	ofi_straddr_dbg(cmap->av->prov, FI_LOG_AV, "Allocated handle for addr",
 			addr);
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "handle: %p\n", *handle);
-	util_cmap_init_handle(*handle, cmap, state, FI_ADDR_UNSPEC, peer);
+	util_cmap_init_handle(*handle, cmap, state, FI_ADDR_NOTAVAIL, peer);
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Adding handle to peer list\n");
 	peer->handle = *handle;
 	memcpy(peer->addr, addr, cmap->av->addrlen);


### PR DESCRIPTION
- prov/util: initialize fi_addr in util_cmap_handle to correct macro
- prov/util: add a cq write function that also reports source address
- prov/rxm: keep src addr reporting in sync with completion entry