### PR TITLE
prov/mrail: add support for claiming large messages

### DIFF
--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -134,6 +134,8 @@ struct mrail_recv {
 	void 			*context;
 	uint64_t 		flags;
 	uint64_t 		comp_flags;
+	struct mrail_hdr	hdr;
+	struct mrail_ep		*ep;
 	struct dlist_entry 	entry;
 	fi_addr_t 		addr;
 	uint64_t 		tag;
@@ -232,11 +234,11 @@ mrail_pop_recv(struct mrail_ep *mrail_ep)
 }
 
 static inline void
-mrail_push_recv(struct mrail_ep *mrail_ep, struct mrail_recv *recv)
+mrail_push_recv(struct mrail_recv *recv)
 {
-	fastlock_acquire(&mrail_ep->util_ep.lock);
-	freestack_push(mrail_ep->recv_fs, recv);
-	fastlock_release(&mrail_ep->util_ep.lock);
+	fastlock_acquire(&recv->ep->util_ep.lock);
+	freestack_push(recv->ep->recv_fs, recv);
+	fastlock_release(&recv->ep->util_ep.lock);
 }
 
 static inline struct fi_info *mrail_get_info_cached(char *name)

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -181,6 +181,23 @@ mrail_match_recv_handle_unexp(struct mrail_recv_queue *recv_queue, uint64_t tag,
 	return container_of(entry, struct mrail_recv, entry);
 }
 
+static void mrail_init_recv(struct mrail_recv *recv, void *arg)
+{
+	recv->ep		= arg;
+	recv->iov[0].iov_base 	= &recv->hdr;
+	recv->iov[0].iov_len 	= sizeof(recv->hdr);
+	recv->comp_flags	= FI_RECV;
+}
+
+#define mrail_recv_assert(recv)						\
+({									\
+	assert(recv->ep == mrail_ep);					\
+	assert(recv->iov[0].iov_base == &recv->hdr);			\
+	assert(recv->iov[0].iov_len == sizeof(recv->hdr));		\
+	assert(recv->comp_flags & FI_RECV);				\
+	assert(recv->count <= mrail_ep->info->rx_attr->iov_limit + 1);	\
+})
+
 static void mrail_recv_queue_init(struct fi_provider *prov,
 				  struct mrail_recv_queue *recv_queue,
 				  dlist_func_t match_recv,
@@ -207,17 +224,17 @@ mrail_recv_common(struct mrail_ep *mrail_ep, struct mrail_recv_queue *recv_queue
 
 	recv = mrail_pop_recv(mrail_ep);
 	if (!recv)
-		return -FI_ENOMEM;
+		return -FI_EAGAIN;
 
-	recv->count 		= count;
+	recv->count 		= count + 1;
 	recv->context 		= context;
 	recv->flags 		= flags;
-	recv->comp_flags 	= comp_flags | FI_RECV;
+	recv->comp_flags 	|= comp_flags;
 	recv->addr	 	= src_addr;
 	recv->tag 		= tag;
 	recv->ignore 		= ignore;
 
-	memcpy(recv->iov, iov, sizeof(*iov) * count);
+	memcpy(&recv->iov[1], iov, sizeof(*iov) * count);
 
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting recv of length: %zu "
 	       "src_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 " ignore: 0x%" PRIx64
@@ -277,7 +294,7 @@ static ssize_t mrail_trecv(struct fid_ep *ep_fid, void *buf, size_t len,
 }
 
 static void mrail_copy_iov_hdr(struct mrail_hdr *hdr, struct iovec *iov_dest,
-			     const struct iovec *iov_src, size_t count)
+			       const struct iovec *iov_src, size_t count)
 {
 	iov_dest[0].iov_base = hdr;
 	iov_dest[0].iov_len = sizeof(*hdr);
@@ -309,9 +326,8 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	msg.context	= context;
 	msg.data	= data;
 
-	// TODO remove this once we support large messages
-	assert(len < mrail_ep->rails[i].info->tx_attr->inject_size);
-	flags |= FI_INJECT;
+	if (len < mrail_ep->rails[i].info->tx_attr->inject_size)
+		flags |= FI_INJECT;
 
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting send of length: %" PRIu64
 	       " dest_addr: 0x%" PRIx64 " on rail: %d\n", len, dest_addr, i);
@@ -347,8 +363,8 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	msg.context	= context;
 	msg.data	= data;
 
-	assert(len < mrail_ep->rails[i].info->tx_attr->inject_size);
-	flags |= FI_INJECT;
+	if (len < mrail_ep->rails[i].info->tx_attr->inject_size)
+		flags |= FI_INJECT;
 
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting tsend of length: %" PRIu64
 	       " dest_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 " on rail: %d\n",
@@ -761,7 +777,8 @@ int mrail_ep_open(struct fid_domain *domain_fid, struct fi_info *info,
 		rxq_total_size += fi->rx_attr->size;
 	}
 
-	mrail_ep->recv_fs = mrail_recv_fs_create(rxq_total_size, NULL, NULL);
+	mrail_ep->recv_fs = mrail_recv_fs_create(rxq_total_size, mrail_init_recv,
+						 mrail_ep);
 	if (!mrail_ep->recv_fs) {
 		ret = -FI_ENOMEM;
 		goto err;

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -332,7 +332,7 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	struct iovec *iov_dest = alloca(sizeof(*iov_dest) * (count + 1));
 	struct mrail_hdr hdr = MRAIL_HDR_INITIALIZER_TAGGED(tag);
 	uint32_t i = mrail_get_tx_rail(mrail_ep);
-	struct fi_msg_tagged msg;
+	struct fi_msg msg;
 	ssize_t ret;
 
 	fi_addr_t *rail_fi_addr = ofi_av_get_addr(mrail_ep->util_ep.av,
@@ -346,7 +346,6 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	msg.addr	= rail_fi_addr[i];
 	msg.context	= context;
 	msg.data	= data;
-	msg.tag		= tag;
 
 	assert(len < mrail_ep->rails[i].info->tx_attr->inject_size);
 	flags |= FI_INJECT;
@@ -354,7 +353,7 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting tsend of length: %" PRIu64
 	       " dest_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 " on rail: %d\n",
 	       len, dest_addr, tag, i);
-	ret = fi_tsendmsg(mrail_ep->rails[i].ep, &msg, flags);
+	ret = fi_sendmsg(mrail_ep->rails[i].ep, &msg, flags);
 	if (ret)
 		FI_WARN(&mrail_prov, FI_LOG_EP_DATA,
 			"Unable to fi_sendmsg on rail: %" PRIu32 "\n", i);

--- a/prov/mrail/src/mrail_init.c
+++ b/prov/mrail/src/mrail_init.c
@@ -94,6 +94,9 @@ int mrail_get_core_info(uint32_t version, const char *node, const char *service,
 			if (hints->tx_attr->iov_limit)
 				core_hints->tx_attr->iov_limit =
 					hints->tx_attr->iov_limit + 1;
+			if (hints->rx_attr->iov_limit)
+				core_hints->rx_attr->iov_limit =
+					hints->rx_attr->iov_limit + 1;
 			core_hints->tx_attr->op_flags &= ~FI_COMPLETION;
 		}
 	}
@@ -230,6 +233,11 @@ static int mrail_getinfo(uint32_t version, const char *node, const char *service
 	/* Account for one iovec buffer used for mrail header */
 	assert(fi->tx_attr->iov_limit);
 	fi->tx_attr->iov_limit--;
+
+	/* Claiming messages larger than FI_OPT_BUFFERED_LIMIT would consume
+	 * a scatter/gather entry for mrail_hdr */
+	fi->rx_attr->iov_limit--;
+
 	if (fi->tx_attr->inject_size < sizeof(struct mrail_hdr))
 		fi->tx_attr->inject_size = 0;
 	else


### PR DESCRIPTION
Note: RxM support for claiming large messages (rndv protocol) in the context of buffered recv is still a TODO.