### PR TITLE
prov/rxd: AV bug fixes and small message optimization

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -82,6 +82,7 @@
 #define RXD_RETRY		(1 << 3)
 #define RXD_LAST		(1 << 4)
 #define RXD_CTRL		(1 << 5)
+#define RXD_INLINE		(1 << 6)
 
 struct rxd_env {
 	int spin_count;
@@ -223,6 +224,8 @@ struct rxd_ctrl_hdr {
 	uint64_t tag;
 	uint32_t op;
 	uint32_t seg_size;
+	uint8_t source[RXD_NAME_LENGTH];
+	void *inline_data;
 };
 
 struct rxd_pkt_hdr {
@@ -237,16 +240,13 @@ struct rxd_pkt_hdr {
 struct rxd_pkt {
 	struct rxd_pkt_hdr hdr;
 	union {
-		struct {
-			struct rxd_ctrl_hdr ctrl;
-			uint8_t source[];
-		};
+		struct rxd_ctrl_hdr ctrl;
 		void *data;
 	};
 };
 
-#define RXD_CTRL_PKT_SIZE (sizeof(struct rxd_ctrl_hdr) +		\
-			   sizeof(struct rxd_pkt_hdr) + RXD_NAME_LENGTH)
+#define RXD_CTRL_PKT_SIZE (sizeof(struct rxd_ctrl_hdr) +	\
+			   sizeof(struct rxd_pkt_hdr))
 
 struct rxd_pkt_entry {
 	struct dlist_entry d_entry;
@@ -334,7 +334,8 @@ void rxd_tx_entry_progress(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 			   int try_send);
 void rxd_handle_send_comp(struct rxd_ep *ep, struct fi_cq_msg_entry *comp);
 void rxd_handle_recv_comp(struct rxd_ep *ep, struct fi_cq_msg_entry *comp);
-
+void rxd_progress_inline(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry,
+			 struct rxd_x_entry *rx_entry);
 
 /* CQ sub-functions */
 void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry);

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -215,38 +215,37 @@ DECLARE_FREESTACK(struct rxd_x_entry, rxd_rx_fs);
 #define rxd_ep_rx_flags(rxd_ep) ((rxd_ep)->util_ep.rx_op_flags)
 #define rxd_ep_tx_flags(rxd_ep) ((rxd_ep)->util_ep.tx_op_flags)
 
-struct rxd_ctrl_hdr {
-	uint32_t version;
-	uint16_t type;
-	uint16_t window;
-	uint64_t size;
-	uint64_t data;
-	uint64_t tag;
-	uint32_t op;
-	uint32_t seg_size;
-	uint8_t source[RXD_NAME_LENGTH];
-	void *inline_data;
-};
-
 struct rxd_pkt_hdr {
+	uint32_t version;
+	uint32_t flags;
 	uint32_t tx_id;
 	uint32_t rx_id;
 	uint32_t key;
 	uint32_t seg_no;
 	fi_addr_t peer;
-	uint64_t flags;
 };
 
-struct rxd_pkt {
+struct rxd_ctrl_hdr {
+	uint8_t type;
+	uint8_t window;
+	uint16_t seg_size;
+	uint32_t op;
+	uint64_t size;
+	uint64_t data;
+	uint64_t tag;
+	uint8_t source[RXD_NAME_LENGTH];
+};
+
+struct rxd_ctrl_pkt {
+	struct rxd_pkt_hdr pkt_hdr;
+	struct rxd_ctrl_hdr ctrl_hdr;
+	char data[];
+};
+
+struct rxd_data_pkt {
 	struct rxd_pkt_hdr hdr;
-	union {
-		struct rxd_ctrl_hdr ctrl;
-		void *data;
-	};
+	char data[];
 };
-
-#define RXD_CTRL_PKT_SIZE (sizeof(struct rxd_ctrl_hdr) +	\
-			   sizeof(struct rxd_pkt_hdr))
 
 struct rxd_pkt_entry {
 	struct dlist_entry d_entry;
@@ -255,17 +254,27 @@ struct rxd_pkt_entry {
 	struct fi_context context;
 	struct fid_mr *mr;
 	fi_addr_t peer;
-	struct rxd_pkt *pkt;
+	void *pkt;
 };
+
+static inline struct rxd_ctrl_pkt *rxd_get_ctrl_pkt(struct rxd_pkt_entry *pkt_entry)
+{
+	return (struct rxd_ctrl_pkt *) (pkt_entry->pkt);
+}
+
+static inline struct rxd_data_pkt *rxd_get_data_pkt(struct rxd_pkt_entry *pkt_entry)
+{
+	return (struct rxd_data_pkt *) (pkt_entry->pkt);
+}
 
 static inline int rxd_is_ctrl_pkt(struct rxd_pkt_entry *pkt_entry)
 {
-	return (pkt_entry->pkt->hdr.flags & RXD_CTRL);
+	return (rxd_get_ctrl_pkt(pkt_entry))->pkt_hdr.flags & RXD_CTRL;
 }
 
 static inline void rxd_set_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
-	pkt_entry->pkt = (struct rxd_pkt *) ((char *) pkt_entry +
+	pkt_entry->pkt = (void *) ((char *) pkt_entry +
 			  sizeof(*pkt_entry) + ep->prefix_size);
 }
 

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -156,7 +156,7 @@ static int rxd_match_unexp(struct dlist_entry *item, const void *arg)
 
 	return rxd_match_addr(rx_entry->peer, pkt_entry->peer) &&
 	       rxd_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore,
-			     pkt_entry->pkt->ctrl.tag);
+			     rxd_get_ctrl_pkt(pkt_entry)->ctrl_hdr.tag);
 }
 
 static void rxd_ep_check_unexp_msg_list(struct rxd_ep *ep, struct dlist_entry *list,
@@ -174,7 +174,7 @@ static void rxd_ep_check_unexp_msg_list(struct rxd_ep *ep, struct dlist_entry *l
 
 		pkt_entry = container_of(match, struct rxd_pkt_entry, d_entry);
 
-		if (pkt_entry->pkt->hdr.flags & RXD_INLINE)
+		if (rxd_get_ctrl_pkt(pkt_entry)->pkt_hdr.flags & RXD_INLINE)
 			rxd_progress_inline(ep, pkt_entry, rx_entry);
 		else
 			rxd_post_cts(ep, rx_entry, pkt_entry);
@@ -375,28 +375,31 @@ static void rxd_init_data_pkt(struct rxd_ep *ep,
 			      struct rxd_x_entry *tx_entry,
 			      struct rxd_pkt_entry *pkt_entry)
 {
+	struct rxd_data_pkt *data_pkt;
 	uint32_t seg_size;
 
 	seg_size = tx_entry->cq_entry.len - tx_entry->bytes_done;
 	seg_size = MIN(tx_entry->seg_size, seg_size);
 
 	rxd_set_pkt(ep, pkt_entry);
-	pkt_entry->pkt->hdr.rx_id = tx_entry->rx_id;
-	pkt_entry->pkt->hdr.seg_no = tx_entry->next_seg_no++;
-	pkt_entry->pkt->hdr.tx_id = tx_entry->tx_id;
-	pkt_entry->pkt->hdr.key = tx_entry->key;
-	pkt_entry->pkt->hdr.peer = tx_entry->peer_x_addr;
+	data_pkt = rxd_get_data_pkt(pkt_entry);
 
-	pkt_entry->pkt_size = ofi_copy_from_iov(&pkt_entry->pkt->data, seg_size,
+	data_pkt->hdr.rx_id = tx_entry->rx_id;
+	data_pkt->hdr.seg_no = tx_entry->next_seg_no++;
+	data_pkt->hdr.tx_id = tx_entry->tx_id;
+	data_pkt->hdr.key = tx_entry->key;
+	data_pkt->hdr.peer = tx_entry->peer_x_addr;
+
+	pkt_entry->pkt_size = ofi_copy_from_iov(data_pkt->data, seg_size,
 						tx_entry->iov,
 						tx_entry->iov_count,
 						tx_entry->bytes_done);
 
 	tx_entry->bytes_done += pkt_entry->pkt_size;
 	if (tx_entry->bytes_done == tx_entry->cq_entry.len)
-		pkt_entry->pkt->hdr.flags = RXD_LAST;
+		data_pkt->hdr.flags = RXD_LAST;
 	else
-		pkt_entry->pkt->hdr.flags = 0;
+		data_pkt->hdr.flags = 0;
 
 	pkt_entry->pkt_size += sizeof(struct rxd_pkt_hdr) + ep->prefix_size;
 }
@@ -404,17 +407,21 @@ static void rxd_init_data_pkt(struct rxd_ep *ep,
 void rxd_init_ctrl_pkt(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
 		       struct rxd_pkt_entry *pkt_entry, uint32_t type)
 {
+	struct rxd_ctrl_pkt *ctrl_pkt;
+
 	x_entry->retry_cnt = 0;
 	rxd_set_pkt(ep, pkt_entry);
-	pkt_entry->pkt->hdr.flags = x_entry->flags | RXD_CTRL;
-	pkt_entry->pkt->hdr.tx_id = x_entry->tx_id;
-	pkt_entry->pkt->hdr.rx_id = x_entry->rx_id;
-	pkt_entry->pkt->hdr.key = x_entry->key;
-	pkt_entry->pkt->hdr.peer = x_entry->peer;
-	pkt_entry->pkt->ctrl.type = type;
-	pkt_entry->pkt->ctrl.window = x_entry->window;
-	pkt_entry->pkt->ctrl.version = RXD_PROTOCOL_VERSION;
-	pkt_entry->pkt_size = RXD_CTRL_PKT_SIZE + ep->prefix_size;
+	ctrl_pkt = rxd_get_ctrl_pkt(pkt_entry);
+
+	ctrl_pkt->pkt_hdr.version = RXD_PROTOCOL_VERSION;
+	ctrl_pkt->pkt_hdr.flags = x_entry->flags | RXD_CTRL;
+	ctrl_pkt->pkt_hdr.tx_id = x_entry->tx_id;
+	ctrl_pkt->pkt_hdr.rx_id = x_entry->rx_id;
+	ctrl_pkt->pkt_hdr.key = x_entry->key;
+	ctrl_pkt->pkt_hdr.peer = x_entry->peer;
+	ctrl_pkt->ctrl_hdr.type = type;
+	ctrl_pkt->ctrl_hdr.window = x_entry->window;
+	pkt_entry->pkt_size = sizeof(struct rxd_ctrl_pkt) + ep->prefix_size;
 }
 
 struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov,
@@ -501,7 +508,7 @@ void rxd_ep_free_acked_pkts(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
 		pkt_entry = container_of(x_entry->pkt_list.head,
 				   struct rxd_pkt_entry, s_entry);
 		if (!rxd_is_ctrl_pkt(pkt_entry) &&
-		    pkt_entry->pkt->hdr.seg_no > last_acked)
+		    rxd_get_data_pkt(pkt_entry)->hdr.seg_no > last_acked)
 			break;
 		slist_remove_head(&x_entry->pkt_list);
 		rxd_release_tx_pkt(ep, pkt_entry);
@@ -532,6 +539,7 @@ void rxd_tx_entry_progress(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 static ssize_t rxd_ep_post_rts(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry)
 {
 	struct rxd_pkt_entry *pkt_entry;
+	struct rxd_ctrl_pkt *rts_pkt;
 	ssize_t ret;
 	size_t addrlen;
 
@@ -540,31 +548,32 @@ static ssize_t rxd_ep_post_rts(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_ent
 		return -FI_ENOMEM;
 
 	rxd_init_ctrl_pkt(rxd_ep, tx_entry, pkt_entry, RXD_RTS);
+	rts_pkt = rxd_get_ctrl_pkt(pkt_entry);
 	addrlen = RXD_NAME_LENGTH;
-	memset(pkt_entry->pkt->ctrl.source, 0, RXD_NAME_LENGTH);
-	ret = fi_getname(&rxd_ep->dg_ep->fid, (void *) pkt_entry->pkt->ctrl.source,
+	memset(rts_pkt->ctrl_hdr.source, 0, RXD_NAME_LENGTH);
+	ret = fi_getname(&rxd_ep->dg_ep->fid, (void *) rts_pkt->ctrl_hdr.source,
 			 &addrlen);
 	if (ret) {
 		rxd_release_tx_pkt(rxd_ep, pkt_entry);
 		return ret;
 	}
 
-	pkt_entry->pkt->ctrl.size = tx_entry->cq_entry.len;
-	pkt_entry->pkt->ctrl.data = tx_entry->cq_entry.data;
-	pkt_entry->pkt->ctrl.tag = tx_entry->cq_entry.tag;
-	pkt_entry->pkt->ctrl.seg_size = tx_entry->seg_size;
+	rts_pkt->ctrl_hdr.size = tx_entry->cq_entry.len;
+	rts_pkt->ctrl_hdr.data = tx_entry->cq_entry.data;
+	rts_pkt->ctrl_hdr.tag = tx_entry->cq_entry.tag;
+	rts_pkt->ctrl_hdr.seg_size = tx_entry->seg_size;
 
 	if (tx_entry->cq_entry.flags & FI_TAGGED)
-		pkt_entry->pkt->ctrl.op = ofi_op_tagged;
+		rts_pkt->ctrl_hdr.op = ofi_op_tagged;
 	else
-		pkt_entry->pkt->ctrl.op = ofi_op_msg;
+		rts_pkt->ctrl_hdr.op = ofi_op_msg;
 
 	if (pkt_entry->pkt_size + tx_entry->cq_entry.len <=
 	    rxd_ep_domain(rxd_ep)->max_mtu_sz) {
 		tx_entry->flags |= RXD_INLINE;
-		pkt_entry->pkt->hdr.flags |= RXD_INLINE;
+		rts_pkt->pkt_hdr.flags |= RXD_INLINE;
 		pkt_entry->pkt_size += ofi_copy_from_iov(
-				       &pkt_entry->pkt->ctrl.inline_data,
+				       rts_pkt->data,
 				       tx_entry->cq_entry.len, tx_entry->iov,
 				       tx_entry->iov_count, 0);
 		tx_entry->state = RXD_CTS;
@@ -581,6 +590,7 @@ static ssize_t rxd_ep_post_rts(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_ent
 ssize_t rxd_ep_post_ack(struct rxd_ep *rxd_ep, struct rxd_x_entry *rx_entry)
 {
 	struct rxd_pkt_entry *pkt_entry;
+	struct rxd_ctrl_pkt *ack_pkt;
 	int ret;
 
 	pkt_entry = rxd_get_tx_pkt(rxd_ep);
@@ -588,9 +598,10 @@ ssize_t rxd_ep_post_ack(struct rxd_ep *rxd_ep, struct rxd_x_entry *rx_entry)
 		return -FI_ENOMEM;
 
 	rxd_init_ctrl_pkt(rxd_ep, rx_entry, pkt_entry, RXD_ACK);
-	pkt_entry->pkt->hdr.seg_no = rx_entry->next_seg_no;
+	ack_pkt = rxd_get_ctrl_pkt(pkt_entry);
+	ack_pkt->pkt_hdr.seg_no = rx_entry->next_seg_no;
 
-	pkt_entry->pkt->ctrl.window = rx_entry->window;
+	ack_pkt->ctrl_hdr.window = rx_entry->window;
 
 	ret = rxd_ep_retry_pkt(rxd_ep, pkt_entry, rx_entry);
 
@@ -1175,7 +1186,7 @@ static void rxd_ep_progress(struct util_ep *util_ep)
 		     pkt_item = pkt_item->next) {
 			pkt_entry = container_of(pkt_item, struct rxd_pkt_entry,
 						 s_entry);
-			pkt_entry->pkt->hdr.flags |= RXD_RETRY;
+			rxd_get_ctrl_pkt(pkt_entry)->pkt_hdr.flags |= RXD_RETRY;
 			ret = rxd_ep_retry_pkt(ep, pkt_entry, tx_entry);
 			if (ret || rxd_is_ctrl_pkt(pkt_entry))
 				break;


### PR DESCRIPTION
- various AV bug fixes
- eliminate the need for a CTS and data message when sending small messages (save data within RTS and ACK right away)

Verified working on ubertest test_configs/ofi_rxd/udp,test and also with data verification