### PR TITLE
prov/rxm: Fix incorrect behavior of deferred queue

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -619,10 +619,14 @@ rxm_ep_handle_unconnected(struct rxm_ep *rxm_ep, struct util_cmap_handle *handle
 	int ret;
 
 	if (handle->state == CMAP_CONNECTED_NOTIFY) {
-		rxm_ep_progress_conn_deferred_list(
-					rxm_ep, container_of(handle, struct rxm_conn,
-							     handle));
+		struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn,
+							 handle);
 		ofi_cmap_process_conn_notify(rxm_ep->util_ep.cmap, handle);
+		if (!dlist_empty(&rxm_conn->deferred_op_list)) {
+			rxm_ep_progress_conn_deferred_list(rxm_ep, rxm_conn);
+			if (dlist_empty(&rxm_conn->deferred_op_list))
+				dlist_remove(&rxm_conn->conn_deferred_entry);
+		}
 		return 0;
 	}
 	/* Since we handling unoonnected state and `cmap:lock`


### PR DESCRIPTION
There are two problems fiexd in the patch:
- applications does several sends -> TX requests moved to
  deferred queue -> flushing TX requests -> after N successful
  sends, N+1 fi_send/fi_inject fails -> hangs (the progress are
  not called)
  Solution: move progress of deferred queue after calling of fi_cq_read
- rxm_conn entry added twice to RxM EP deferred progress list,
  because the entry is not deleted in rxm_ep_handle_unconnected
  when the all deferred requests for this connection were sent
  and queue is empty
  Solution: added removal of rxm_conn entry from RxM EP deferred
  progress list in rxm_ep_handle_unconnected

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>