### PR TITLE
Select patches from PR #4231 + additional fixes

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -131,10 +131,10 @@ static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
 	return recv(fd, buf, count, flags);
 }
 
-static inline ssize_t ofi_recvfrom_socket(SOCKET fd, const void *buf, size_t count, int flags,
-					  const struct sockaddr *to, socklen_t tolen)
+static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
+					  struct sockaddr *from, socklen_t *fromlen)
 {
-	return sendto(fd, buf, count, flags, to, tolen);
+	return recvfrom(fd, buf, count, flags, from, fromlen);
 }
 
 static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -712,10 +712,10 @@ static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
 	return recv(fd, (char *)buf, (int)count, flags);
 }
 
-static inline ssize_t ofi_recvfrom_socket(SOCKET fd, const void *buf, size_t count, int flags,
-					  const struct sockaddr *to, socklen_t tolen)
+static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
+					  struct sockaddr *from, socklen_t *fromlen)
 {
-	return sendto(fd, (const char*)buf, (int)count, flags, to, tolen);
+	return recvfrom(fd, (char*)buf, (int)count, flags, from, fromlen);
 }
 
 static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -115,9 +115,11 @@ static int poll_fds_add_item(struct poll_fd_mgr *poll_mgr,
 
 	if (poll_mgr->nfds >= poll_mgr->max_nfds) {
 		ret = poll_fd_resize(poll_mgr, poll_mgr->max_nfds << 1);
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
-			"memory allocation failed\n");
-		return ret;
+		if (ret) {
+			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			        "memory allocation failed\n");
+			return ret;
+		}
 	}
 
 	poll_mgr->poll_info[poll_mgr->nfds] = *poll_info;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -550,8 +550,8 @@ static int tcpx_ep_close(struct fid *fid)
 	tcpx_ep_tx_rx_queues_release(ep);
 	tcpx_cq_wait_ep_del(ep);
 	ofi_close_socket(ep->conn_fd);
-	fastlock_destroy(&ep->lock);
 	ofi_endpoint_close(&ep->util_ep);
+	fastlock_destroy(&ep->lock);
 
 	free(ep);
 	return 0;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -323,9 +323,6 @@ int ofi_cq_cleanup(struct util_cq *cq)
 	if (ofi_atomic_get32(&cq->ref))
 		return -FI_EBUSY;
 
-	fastlock_destroy(&cq->cq_lock);
-	fastlock_destroy(&cq->ep_list_lock);
-
 	while (!slist_empty(&cq->err_list)) {
 		entry = slist_remove_head(&cq->err_list);
 		err = container_of(entry, struct util_cq_err_entry, list_entry);
@@ -341,6 +338,8 @@ int ofi_cq_cleanup(struct util_cq *cq)
 
 	ofi_atomic_dec32(&cq->domain->ref);
 	util_comp_cirq_free(cq->cirq);
+	fastlock_destroy(&cq->cq_lock);
+	fastlock_destroy(&cq->ep_list_lock);
 	free(cq->src);
 	return 0;
 }

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -220,8 +220,6 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 
 int ofi_endpoint_close(struct util_ep *util_ep)
 {
-	fastlock_destroy(&util_ep->lock);
-
 	if (util_ep->tx_cq) {
 		fid_list_remove(&util_ep->tx_cq->ep_list,
 				&util_ep->tx_cq->ep_list_lock,
@@ -289,5 +287,6 @@ int ofi_endpoint_close(struct util_ep *util_ep)
 	if (util_ep->eq)
 		ofi_atomic_dec32(&util_ep->eq->ref);
 	ofi_atomic_dec32(&util_ep->domain->ref);
+	fastlock_destroy(&util_ep->lock);
 	return 0;
 }

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -319,11 +319,11 @@ static int util_wait_fd_close(struct fid *fid)
 		return ret;
 
 	assert(dlist_empty(&wait->fd_list));
-	fastlock_destroy(&wait->lock);
 
 	fi_epoll_del(wait->epoll_fd, wait->signal.fd[FI_READ_FD]);
 	fd_signal_free(&wait->signal);
 	fi_epoll_close(wait->epoll_fd);
+	fastlock_destroy(&wait->lock);
 	free(wait);
 	return 0;
 }


### PR DESCRIPTION
This grabs 3 patches from #4231, plus adds a related fix based on the problem Sylvain reported.

I think 1 more patch from 4231 is ready for merging, but the sendmsg patch highlights an issue with the base implementation of that call on windows.