### PR TITLE
osd/windows: Rework sendmsg/recvmsg calls

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -159,6 +159,30 @@ static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov, int iov_cnt
 	return readv(fd, iov, iov_cnt);
 }
 
+static inline ssize_t
+ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags)
+{
+	return sendmsg(fd, msg, flags);
+}
+
+static inline ssize_t
+ofi_sendmsg_udp(SOCKET fd, const struct msghdr *msg, int flags)
+{
+	return sendmsg(fd, msg, flags);
+}
+
+static inline ssize_t
+ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
+{
+	return recvmsg(fd, msg, flags);
+}
+
+static inline ssize_t
+ofi_recvmsg_udp(SOCKET fd, struct msghdr *msg, int flags)
+{
+	return recvmsg(fd, msg, flags);
+}
+
 static inline int ofi_shutdown(SOCKET socket, int how)
 {
 	return shutdown(socket, how);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -18,6 +18,7 @@
 #include "config.h"
 
 #include <WinSock2.h>
+#include <Mswsock.h>
 #include <ws2tcpip.h>
 #include <windows.h>
 #include <io.h>
@@ -712,8 +713,9 @@ static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
 	return recv(fd, (char *)buf, (int)count, flags);
 }
 
-static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
-					  struct sockaddr *from, socklen_t *fromlen)
+static inline ssize_t
+ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
+		    struct sockaddr *from, socklen_t *fromlen)
 {
 	return recvfrom(fd, (char*)buf, (int)count, flags, from, fromlen);
 }
@@ -724,14 +726,29 @@ static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
 	return send(fd, (const char*)buf, (int)count, flags);
 }
 
-static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
-					const struct sockaddr *to, socklen_t tolen)
+static inline ssize_t
+ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
+		  const struct sockaddr *to, socklen_t tolen)
 {
 	return sendto(fd, (const char*)buf, (int)count, flags, to, tolen);
 }
 
 ssize_t ofi_writev_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
 ssize_t ofi_readv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
+ssize_t ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags);
+ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags);
+
+static inline ssize_t
+ofi_sendmsg_udp(SOCKET fd, const struct msghdr *msg, int flags)
+{
+	DWORD bytes;
+	int ret;
+
+	ret = WSASendMsg(fd, msg, flags, &bytes, NULL, NULL);
+	return ret ? ret : bytes;
+}
+
+ssize_t ofi_recvmsg_udp(SOCKET fd, struct msghdr *msg, int flags);
 
 static inline int ofi_shutdown(SOCKET socket, int how)
 {

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -293,7 +293,7 @@ static void udpx_ep_progress(struct util_ep *util_ep)
 	hdr.msg_iov = entry->iov;
 	hdr.msg_iovlen = entry->iov_count;
 
-	ret = recvmsg(ep->sock, &hdr, 0);
+	ret = ofi_recvmsg_udp(ep->sock, &hdr, 0);
 	if (ret >= 0) {
 		ep->rx_comp(ep, entry->context, 0, ret, NULL, &addr);
 		ofi_cirque_discard(ep->rxq);
@@ -453,7 +453,7 @@ static ssize_t udpx_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		goto out;
 	}
 
-	ret = sendmsg(ep->sock, &hdr, 0);
+	ret = ofi_sendmsg_udp(ep->sock, &hdr, 0);
 	if (ret >= 0) {
 		ep->tx_comp(ep, msg->context);
 		ret = 0;


### PR DESCRIPTION
Windows does not support socket send or receive calls that
take an iovec on a streaming socket.  The current abstraction
ends up allocating a buffer, copying the iovec in/out of it,
and using the standard send/recv calls.

Optimize this by separating the sendmsg/recvmsg calls based
on the socket type.  For UDP sockets, we can use WSASendMsg/
WSARecvMsg.  For TCP sockets, we iterate over the iovec.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>