### PR TITLE
prov/tcp: fix progression of net messages in blocking mode

### DIFF
--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -434,8 +434,16 @@ void tcpx_progress(struct util_ep *util_ep)
 
 static int tcpx_try_func(void *util_ep)
 {
-	/* nothing to do here. When endpoints
-	   have incoming data, cq drives progress*/
+
+	struct tcpx_ep *ep;
+	ep = container_of(util_ep, struct tcpx_ep, util_ep);
+
+	if (!slist_empty(&ep->tx_queue))
+		return -FI_EAGAIN;
+
+	if (!ep->cur_rx_entry)
+		return -FI_EAGAIN;
+
 	return FI_SUCCESS;
 }
 


### PR DESCRIPTION
This is a patch for the issue #4247 where the tcp provider fails
to correctly make progress of network messages when blocking-mode
(with poll() or epoll_wait()) is used.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>