### PR TITLE
util/cq: Fix out-of-space issue in Circular queue

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -365,7 +365,7 @@ struct util_cq {
 	struct util_comp_cirq	*cirq;
 	fi_addr_t		*src;
 
-	struct slist		err_list;
+	struct slist		oflow_err_list;
 	fi_cq_read_func		read_entry;
 	int			internal_wait;
 	ofi_atomic32_t		signaled;

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -64,7 +64,8 @@
 
 #include "rbtree.h"
 
-#define UTIL_FLAG_ERROR	(1ULL << 60)
+#define UTIL_FLAG_ERROR		(1ULL << 60)
+#define UTIL_FLAG_OVERFLOW	(1ULL << 61)
 	
 #define OFI_CNTR_ENABLED	(1ULL << 61)
 
@@ -338,13 +339,19 @@ int ofi_wait_fd_del(struct util_wait *wait, int fd);
  * entries on the CQ.  This allows poll sets to drive progress
  * without introducing private interfaces to the CQ.
  */
-#define FI_DEFAULT_CQ_SIZE	1024
 
 typedef void (*fi_cq_read_func)(void **dst, void *src);
 
 struct util_cq_err_entry {
 	struct fi_cq_err_entry	err_entry;
 	struct slist_entry	list_entry;
+};
+
+struct util_cq_oflow_entry {
+	struct fi_cq_tagged_entry	*parent_comp;
+	struct fi_cq_tagged_entry	comp;
+	fi_addr_t			src;
+	struct slist_entry		list_entry;
 };
 
 OFI_DECLARE_CIRQUE(struct fi_cq_tagged_entry, util_comp_cirq);
@@ -389,24 +396,21 @@ ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
 ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		fi_addr_t *src_addr, const void *cond, int timeout);
 int ofi_cq_signal(struct fid_cq *cq_fid);
+
+int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags, size_t len,
+			  void *buf, uint64_t data, uint64_t tag, fi_addr_t src);
+
 static inline void util_cq_signal(struct util_cq *cq)
 {
 	assert(cq->wait);
 	cq->wait->signal(cq->wait);
 }
 
-static inline int
-ofi_cq_write_thread_unsafe(struct util_cq *cq, void *context, uint64_t flags,
-			   size_t len, void *buf, uint64_t data, uint64_t tag)
+static inline void
+ofi_cq_write_comp_entry(struct util_cq *cq, void *context, uint64_t flags,
+			size_t len, void *buf, uint64_t data, uint64_t tag)
 {
-	struct fi_cq_tagged_entry *comp;
-
-	if (ofi_cirque_isfull(cq->cirq)) {
-		FI_DBG(cq->domain->prov, FI_LOG_CQ, "util_cq cirq is full!\n");
-		return -FI_EAGAIN;
-	}
-
-	comp = ofi_cirque_tail(cq->cirq);
+	struct fi_cq_tagged_entry *comp = ofi_cirque_tail(cq->cirq);
 	comp->op_context = context;
 	comp->flags = flags;
 	comp->len = len;
@@ -414,6 +418,17 @@ ofi_cq_write_thread_unsafe(struct util_cq *cq, void *context, uint64_t flags,
 	comp->data = data;
 	comp->tag = tag;
 	ofi_cirque_commit(cq->cirq);
+}
+
+static inline int
+ofi_cq_write_thread_unsafe(struct util_cq *cq, void *context, uint64_t flags,
+			   size_t len, void *buf, uint64_t data, uint64_t tag)
+{
+	if (OFI_UNLIKELY(ofi_cirque_isfull(cq->cirq))) {
+		return ofi_cq_write_overflow(cq, context, flags, len,
+					     buf, data, tag, 0);
+	}
+	ofi_cq_write_comp_entry(cq, context, flags, len, buf, data, tag);
 	return 0;
 }
 
@@ -432,14 +447,15 @@ static inline int
 ofi_cq_write_src(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 		 void *buf, uint64_t data, uint64_t tag, fi_addr_t src)
 {
-	int ret;
-
 	cq->cq_fastlock_acquire(&cq->cq_lock);
-	ret = ofi_cq_write_thread_unsafe(cq, context, flags, len, buf, data, tag);
-	if (!ret)
-		cq->src[ofi_cirque_windex(cq->cirq)] = src;
+	if (OFI_UNLIKELY(ofi_cirque_isfull(cq->cirq))) {
+		return ofi_cq_write_overflow(cq, context, flags, len,
+					     buf, data, tag, 0);
+	}
+	ofi_cq_write_comp_entry(cq, context, flags, len, buf, data, tag);
+	cq->src[ofi_cirque_windex(cq->cirq)] = src;
 	cq->cq_fastlock_release(&cq->cq_lock);
-	return ret;
+	return 0;
 }
 
 int ofi_cq_write_error(struct util_cq *cq,

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -342,14 +342,9 @@ int ofi_wait_fd_del(struct util_wait *wait, int fd);
 
 typedef void (*fi_cq_read_func)(void **dst, void *src);
 
-struct util_cq_err_entry {
-	struct fi_cq_err_entry	err_entry;
-	struct slist_entry	list_entry;
-};
-
-struct util_cq_oflow_entry {
+struct util_cq_oflow_err_entry {
 	struct fi_cq_tagged_entry	*parent_comp;
-	struct fi_cq_tagged_entry	comp;
+	struct fi_cq_err_entry		comp;
 	fi_addr_t			src;
 	struct slist_entry		list_entry;
 };
@@ -425,6 +420,8 @@ ofi_cq_write_thread_unsafe(struct util_cq *cq, void *context, uint64_t flags,
 			   size_t len, void *buf, uint64_t data, uint64_t tag)
 {
 	if (OFI_UNLIKELY(ofi_cirque_isfull(cq->cirq))) {
+		FI_DBG(cq->domain->prov, FI_LOG_CQ,
+		       "util_cq cirq is full!\n");
 		return ofi_cq_write_overflow(cq, context, flags, len,
 					     buf, data, tag, 0);
 	}
@@ -449,6 +446,8 @@ ofi_cq_write_src(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 {
 	cq->cq_fastlock_acquire(&cq->cq_lock);
 	if (OFI_UNLIKELY(ofi_cirque_isfull(cq->cirq))) {
+		FI_DBG(cq->domain->prov, FI_LOG_CQ,
+		       "util_cq cirq is full!\n");
 		return ofi_cq_write_overflow(cq, context, flags, len,
 					     buf, data, tag, 0);
 	}

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -169,14 +169,14 @@ void rxd_rx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry)
 {
 	struct fi_cq_tagged_entry cq_entry = {0};
-	struct util_cq_err_entry *entry = calloc(1, sizeof(*entry));
+	struct util_cq_oflow_err_entry *entry = calloc(1, sizeof(*entry));
 	if (!entry) {
 		FI_WARN(&rxd_prov, FI_LOG_CQ,
 			"out of memory, cannot report CQ error\n");
 		return;
 	}
 
-	entry->err_entry = *err_entry;
+	entry->comp = *err_entry;
 	slist_insert_tail(&entry->list_entry, &cq->util_cq.oflow_err_list);
 	cq_entry.flags = UTIL_FLAG_ERROR;
 	cq->write_fn(cq, &cq_entry);

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -177,7 +177,7 @@ void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry)
 	}
 
 	entry->err_entry = *err_entry;
-	slist_insert_tail(&entry->list_entry, &cq->util_cq.err_list);
+	slist_insert_tail(&entry->list_entry, &cq->util_cq.oflow_err_list);
 	cq_entry.flags = UTIL_FLAG_ERROR;
 	cq->write_fn(cq, &cq_entry);
 }

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -52,7 +52,7 @@ int smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags, uint64_t err)
 		entry->err_entry.err = err;
 		entry->err_entry.prov_errno = -err;
 		slist_insert_tail(&entry->list_entry,
-				  &ep->util_ep.tx_cq->err_list);
+				  &ep->util_ep.tx_cq->oflow_err_list);
 		comp->flags = UTIL_FLAG_ERROR;
 	} else {
 		comp->op_context = context;
@@ -94,7 +94,7 @@ int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags, size_t len,
 		entry->err_entry.err = err;
 		entry->err_entry.prov_errno = -err;
 		slist_insert_tail(&entry->list_entry,
-				  &ep->util_ep.rx_cq->err_list);
+				  &ep->util_ep.rx_cq->oflow_err_list);
 		comp->flags = UTIL_FLAG_ERROR;
 	} else {
 		comp->op_context = context;

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -41,16 +41,16 @@
 int smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags, uint64_t err)
 {
 	struct fi_cq_tagged_entry *comp;
-	struct util_cq_err_entry *entry;
+	struct util_cq_oflow_err_entry *entry;
 
 	comp = ofi_cirque_tail(ep->util_ep.tx_cq->cirq);
 	if (err) {
 		if (!(entry = calloc(1, sizeof(*entry))))
 			return -FI_ENOMEM;
-		entry->err_entry.op_context = context;
-		entry->err_entry.flags = flags;
-		entry->err_entry.err = err;
-		entry->err_entry.prov_errno = -err;
+		entry->comp.op_context = context;
+		entry->comp.flags = flags;
+		entry->comp.err = err;
+		entry->comp.prov_errno = -err;
 		slist_insert_tail(&entry->list_entry,
 				  &ep->util_ep.tx_cq->oflow_err_list);
 		comp->flags = UTIL_FLAG_ERROR;
@@ -82,17 +82,17 @@ int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags, size_t len,
 		uint64_t err)
 {
 	struct fi_cq_tagged_entry *comp;
-	struct util_cq_err_entry *entry;
+	struct util_cq_oflow_err_entry *entry;
 
 	comp = ofi_cirque_tail(ep->util_ep.rx_cq->cirq);
 	if (err) {
 		if (!(entry = calloc(1, sizeof(*entry))))
 			return -FI_ENOMEM;
-		entry->err_entry.op_context = context;
-		entry->err_entry.flags = flags;
-		entry->err_entry.tag = tag;
-		entry->err_entry.err = err;
-		entry->err_entry.prov_errno = -err;
+		entry->comp.op_context = context;
+		entry->comp.flags = flags;
+		entry->comp.tag = tag;
+		entry->comp.err = err;
+		entry->comp.prov_errno = -err;
 		slist_insert_tail(&entry->list_entry,
 				  &ep->util_ep.rx_cq->oflow_err_list);
 		comp->flags = UTIL_FLAG_ERROR;

--- a/prov/verbs/src/verbs_dgram_cq.c
+++ b/prov/verbs/src/verbs_dgram_cq.c
@@ -83,7 +83,7 @@ int fi_ibv_dgram_cq_cntr_report_error(struct util_cq *util_cq,
 	struct fi_cq_tagged_entry *comp;
 	struct fi_ibv_dgram_wr_entry *wr_entry =
 		(struct fi_ibv_dgram_wr_entry *)(uintptr_t)wc->wr_id;
-	struct util_cq_err_entry *err = calloc(1, sizeof(*err));
+	struct util_cq_oflow_err_entry *err = calloc(1, sizeof(*err));
 	if (!err) {
 		VERBS_WARN(FI_LOG_CQ, "Unable to allocate "
 				      "util_cq_err_entry\n");
@@ -92,7 +92,7 @@ int fi_ibv_dgram_cq_cntr_report_error(struct util_cq *util_cq,
 
 	err_entry.op_context = wr_entry->hdr.context;
 	err_entry.flags = wr_entry->hdr.flags;
-	err->err_entry = err_entry;
+	err->comp = err_entry;
 
 	if (util_cntr)
 		util_cntr->cntr_fid.ops->adderr(&util_cntr->cntr_fid, 1);

--- a/prov/verbs/src/verbs_dgram_cq.c
+++ b/prov/verbs/src/verbs_dgram_cq.c
@@ -98,7 +98,7 @@ int fi_ibv_dgram_cq_cntr_report_error(struct util_cq *util_cq,
 		util_cntr->cntr_fid.ops->adderr(&util_cntr->cntr_fid, 1);
 
 	fastlock_acquire(&util_cq->cq_lock);
-	slist_insert_tail(&err->list_entry, &util_cq->err_list);
+	slist_insert_tail(&err->list_entry, &util_cq->oflow_err_list);
 
 	/* Signal that there is err entry */
 	comp = ofi_cirque_tail(util_cq->cirq);


### PR DESCRIPTION
If an user doesn't read CQ entries as fast as it's needed to avoid
out of space issue in a circular buffer of CQ, the utility CQ reports
to a provider that there is no space. For instance, RxM generates an error
CQ entry. This is not right behavior. Provider shouldn't silently drop the
entry.

This patch fixes the isses described above by implementing bufferization
of CQ entries that don't fit into the circular queue until the space won't
be available.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>