### PR TITLE
prov/rxm: Fix truncation of data in SAR protocol

### DIFF
--- a/include/ofi_proto.h
+++ b/include/ofi_proto.h
@@ -67,13 +67,6 @@ enum {
  *
  * version: OFI_CTRL_VERSION
  * type
- * seg_size:
- *     Data packets - size of current message, in bytes.
- *     Large data packets - size of current message, 2 ^ seg_size, in bytes
- *     Ctrl packets - number of segments in window allowed past seg_no.
- * seg_no:
- *     Data packets - position 0..(n-1) of segment in current message.
- *     Ctrl packets - last segment ack'ed.
  * conn_id: Communication identifier.  Conn_id values are exchanged between
  *     peer endpoints as part of communication setup.  This field is valid
  *     as part of the first message in any data transfer.
@@ -81,6 +74,13 @@ enum {
  *     Unique number identifying all segments of a message
  *     Message id can be formed using an equation similar to:
  *     (seq_no++ << tx size) | tx_key
+ * seg_size:
+ *     Data packets - size of current message, in bytes.
+ *     Large data packets - size of current message, 2 ^ seg_size, in bytes
+ *     Ctrl packets - number of segments in window allowed past seg_no.
+ * seg_no:
+ *     Data packets - position 0..(n-1) of segment in current message.
+ *     Ctrl packets - last segment ack'ed.
  * conn_data: Connection specific data.  This may be set to the index
  *     of the transmit endpoint's address in its local AV, which may
  *     be used as a hint at the Rx side to locate the Tx EP address in
@@ -92,20 +92,19 @@ enum {
  *     Tx side includes in subsequent packets.  This field is used for
  *     rendezvous protocol.
  *     The rx_key may be formed similar to message_id.
- * seg_num: This is the total number of segments that is sent by sender
- *     in a segmentation and reassembly (SAR) protocol.
+ * ctrl_data: This is provider specific data for remote side
  */
 struct ofi_ctrl_hdr {
-	uint8_t			version;
-	uint8_t			type;
-	uint16_t		seg_size;
-	uint32_t		seg_no;
-	uint64_t		conn_id;
-	uint64_t		msg_id;
+	uint8_t				version;
+	uint8_t				type;
+	uint16_t			seg_size;
+	uint32_t			seg_no;
+	uint64_t			conn_id;
+	uint64_t			msg_id;
 	union {
-		uint64_t	conn_data;
-		uint64_t	rx_key;
-		uint64_t	segs_cnt;
+		uint64_t		conn_data;
+		uint64_t		rx_key;
+		uint64_t		ctrl_data;
 	};
 };
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -260,15 +260,17 @@ static inline int rxm_finish_sar_segment_send(struct rxm_tx_buf *tx_buf)
 	if (!--tx_entry->segs_left) {
 		return rxm_finish_send_nobuf(tx_entry);
 	} else if (!dlist_empty(&tx_entry->deferred_tx_buf_list)) {
-		ssize_t ret;
+		ssize_t ret = 0;
 
-		tx_buf = container_of(tx_entry->deferred_tx_buf_list.next,
-				      struct rxm_tx_buf, hdr.entry);
-		ret = fi_send(tx_entry->conn->msg_ep, &tx_buf->pkt,
-			      sizeof(tx_buf->pkt) + tx_buf->pkt.ctrl_hdr.seg_size,
-			      tx_buf->hdr.desc, 0, tx_buf);
-		if (!ret)
-			dlist_remove(&tx_buf->hdr.entry);
+		while (!dlist_empty(&tx_entry->deferred_tx_buf_list) && !ret) {
+			tx_buf = container_of(tx_entry->deferred_tx_buf_list.next,
+					      struct rxm_tx_buf, hdr.entry);
+			ret = fi_send(tx_entry->conn->msg_ep, &tx_buf->pkt,
+				      sizeof(tx_buf->pkt) + tx_buf->pkt.ctrl_hdr.seg_size,
+				      tx_buf->hdr.desc, 0, tx_buf);
+			if (!ret)
+				dlist_remove(&tx_buf->hdr.entry);
+		}
 	}
 	/* This branch takes true, when it's impossible to allocate TX buffer */
 	if (OFI_UNLIKELY((tx_entry->msg_id == UINT64_MAX) &&
@@ -361,19 +363,16 @@ ssize_t rxm_cq_handle_seg_data(struct rxm_rx_buf *rx_buf)
 					    rx_buf->pkt.ctrl_hdr.seg_size);
 	rx_buf->recv_entry->total_recv_len += done_len;
 	/* Check that this isn't last segment */
-	if (((rx_buf->recv_entry->total_recv_len == done_len /* this is a first segment */) ||
-	     (rx_buf->recv_entry->segs_left != 1 /* this is neither a first nor a last segment */)) &&
+	if (rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) != RXM_SAR_SEG_LAST &&
 	/* and message isn't truncated */
 	    (done_len == rx_buf->pkt.ctrl_hdr.seg_size)) {
 		if (rx_buf->recv_entry->msg_id == UINT64_MAX) {
 			rx_buf->conn = rxm_key2conn(rx_buf->ep,
 						    rx_buf->pkt.ctrl_hdr.conn_id);
 			rx_buf->recv_entry->msg_id = rx_buf->pkt.ctrl_hdr.msg_id;
-			rx_buf->recv_entry->segs_left = rx_buf->pkt.ctrl_hdr.segs_cnt;
 			dlist_insert_tail(&rx_buf->recv_entry->sar_entry,
 					  &rx_buf->conn->sar_rx_msg_list);
 		}
-		rx_buf->recv_entry->segs_left--;
 		/* The RX buffer can be reposted for further re-use */
 		rx_buf->recv_entry = NULL;
 		rx_buf->ep->res_fastlock_acquire(&rx_buf->ep->util_ep.lock);
@@ -382,7 +381,6 @@ ssize_t rxm_cq_handle_seg_data(struct rxm_rx_buf *rx_buf)
 		rx_buf->ep->res_fastlock_release(&rx_buf->ep->util_ep.lock);
 		return FI_SUCCESS;
 	}
-	rx_buf->recv_entry->segs_left--;
 	dlist_remove(&rx_buf->recv_entry->sar_entry);
 	/* Mark rxm_recv_entry::msg_id as unknown for futher re-use */
 	rx_buf->recv_entry->msg_id = UINT64_MAX;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -31,6 +31,7 @@
  */
 
 #include <inttypes.h>
+#include <math.h>
 
 #include "ofi.h"
 #include <ofi_util.h>
@@ -909,9 +910,9 @@ err:
 
 static inline struct rxm_tx_buf *
 rxm_ep_sar_tx_prepare_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-			      size_t total_len, size_t seg_num, size_t seg_len,
-			      uint64_t data, uint64_t flags, uint64_t tag,
-			      uint64_t comp_flags, uint8_t op,
+			      size_t total_len, size_t seg_len, uint64_t data,
+			      uint64_t flags, uint64_t tag, uint64_t comp_flags,
+			      uint8_t op, enum rxm_sar_seg_type seg_type,
 			      struct rxm_tx_entry *tx_entry)
 {
 	struct rxm_tx_buf *tx_buf;
@@ -925,9 +926,9 @@ rxm_ep_sar_tx_prepare_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	tx_buf->pkt.hdr.op = op;
 	tx_buf->pkt.ctrl_hdr.msg_id = tx_entry->msg_id;
-	tx_buf->pkt.ctrl_hdr.seg_no = seg_num;
 	tx_buf->pkt.ctrl_hdr.seg_size = seg_len;
-	tx_buf->pkt.ctrl_hdr.segs_cnt = tx_entry->segs_left;
+	rxm_sar_set_seg_type(&tx_buf->pkt.ctrl_hdr, seg_type);
+	
 	tx_buf->pkt.hdr.flags |= comp_flags;
 
 	tx_buf->tx_entry = tx_entry;
@@ -939,12 +940,6 @@ rxm_ep_sar_tx_prepare_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	return tx_buf;
 }
 
-static inline size_t
-rxm_ep_sar_calc_segs_cnt(size_t data_len, size_t inject_size)
-{
-	return (data_len / inject_size + ((data_len % inject_size) ? 1 : 0));
-}
-
 static inline ssize_t
 rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void *context,
 		   uint8_t count, const struct iovec *iov, size_t data_len,
@@ -952,11 +947,10 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void *conte
 		   uint64_t tag, uint8_t op)
 {
 	struct rxm_tx_entry *tx_entry;
-	size_t segs_cnt =
-		rxm_ep_sar_calc_segs_cnt(data_len, rxm_ep->rxm_info->tx_attr->inject_size);
 	size_t i, total_len = data_len, seg_len;
 	ssize_t ret;
-	int send_failed = 0;
+	int send_failed = 0, use_eager_size = 0;
+	enum rxm_sar_seg_type seg_type = RXM_SAR_SEG_FIRST;
 
 	ret = rxm_ep_format_tx_entry(rxm_conn, context, count, flags,
 				     comp_flags, NULL, &tx_entry);
@@ -967,26 +961,37 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void *conte
 	tx_entry->iov_offset = 0;
 	for (i = 0; i < count; i++)
 		tx_entry->rxm_iov.iov[i] = iov[i];
+
 	tx_entry->rxm_iov.count = count;
-	tx_entry->segs_left = segs_cnt;
 	tx_entry->msg_id = rxm_txe_fs_index(rxm_conn->send_queue.fs, tx_entry);
-	
-	seg_len = fi_get_aligned_sz(total_len / segs_cnt, 64);
+	seg_len = rxm_ep->rxm_info->tx_attr->inject_size;
+
+	tx_entry->segs_left = 0;
 
 	while (total_len) {
 		struct rxm_tx_buf *tx_buf;
 
-		if (total_len < seg_len)
+		if (!use_eager_size) {
+			seg_len = RXM_SAR_DIVIDER << tx_entry->segs_left;
+			if (seg_len >= rxm_ep->rxm_info->tx_attr->inject_size) {
+				use_eager_size = 1;
+				seg_len = rxm_ep->rxm_info->tx_attr->inject_size;
+			}
+		}
+
+		if (seg_len >= total_len) {
 			seg_len = total_len;
+			seg_type = RXM_SAR_SEG_LAST;
+		}
 
 		tx_buf = rxm_ep_sar_tx_prepare_segment(rxm_ep, rxm_conn, data_len,
-						       segs_cnt - 1, seg_len, data,
-						       flags, tag, comp_flags, op,
+						       seg_len, data, flags, tag,
+						       comp_flags, op, seg_type,
 						       tx_entry);
 		if (OFI_UNLIKELY(!tx_buf)) {
 			tx_entry->msg_id = UINT64_MAX;
-			if (segs_cnt == tx_entry->segs_left) {
-				/* if YX buffer allocation for the first segment fails,
+			if (seg_type == RXM_SAR_SEG_FIRST) {
+				/* if TX buffer allocation for the first segment fails,
 				 * release TX entry and report to user */
 				rxm_tx_entry_release(&rxm_conn->send_queue, tx_entry);
 			}
@@ -1004,7 +1009,7 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void *conte
 				      tx_buf->pkt.ctrl_hdr.seg_size,
 				      tx_buf->hdr.desc, 0, tx_buf);
 			if (OFI_UNLIKELY(ret)) {
-				if (segs_cnt == tx_entry->segs_left) {
+				if (seg_type == RXM_SAR_SEG_FIRST) {
 					/* if the sending for the first segment fails,
 					 * release resources and report this to user */
 					rxm_tx_buf_release(tx_entry->ep, tx_buf);
@@ -1019,8 +1024,10 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void *conte
 			dlist_insert_tail(&tx_buf->hdr.entry,
 					  &tx_entry->deferred_tx_buf_list);
 		}
-		segs_cnt--;
+
+		tx_entry->segs_left++;
 		total_len -= seg_len;
+		seg_type = RXM_SAR_SEG_MIDDLE;
 	}
 
 	return 0;


### PR DESCRIPTION
This PR fixes the following issues:
- prov/rxm: Fix truncation of data in SAR protocol
The patch fixes problems with truncated messages received due to
incorrect calculation of segment size/numbers.
Also this patch adds minimal number of segments and maximum segment
size to enable adjusting SAR protocol.
- prov/rxm: Added reporting of errors in SAR protocol