### PR TITLE
osd/windows: Remove an excessive definition of HAVE_TCP provider macro

### DIFF
--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -68,14 +68,14 @@
 /* Define to 1 if you have the <rdma/rsocket.h> header file. */
 /* #undef HAVE_RDMA_RSOCKET_H */
 
-/* sockets provider is built */
-#define HAVE_SOCKETS 1
-
 /* UDP provider is built */
 #define HAVE_UDP 1
 
-/* TCP provider is built */
-#define HAVE_TCP 1
+/* UDP provider is built as DSO */
+/* #undef HAVE_UDP_DL */
+
+/* sockets provider is built */
+#define HAVE_SOCKETS 1
 
 /* sockets provider is built as DSO */
 /* #undef HAVE_SOCKETS_DL */


### PR DESCRIPTION
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>