### PR TITLE
prov/rxm: Fixes for SAR protocol

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -190,11 +190,14 @@ struct rxm_pkt {
 };
 
 union rxm_sar_ctrl_data {
-	enum rxm_sar_seg_type {
-		RXM_SAR_SEG_FIRST	= 1,
-		RXM_SAR_SEG_MIDDLE	= 2,
-		RXM_SAR_SEG_LAST	= 3,	
-	} seg_type : 2;
+	struct {
+		enum rxm_sar_seg_type {
+			RXM_SAR_SEG_FIRST	= 1,
+			RXM_SAR_SEG_MIDDLE	= 2,
+			RXM_SAR_SEG_LAST	= 3,	
+		} seg_type : 2;
+		uint32_t offset;
+	};
 	uint64_t align;
 };
 
@@ -207,7 +210,19 @@ rxm_sar_get_seg_type(struct ofi_ctrl_hdr *ctrl_hdr)
 static inline void
 rxm_sar_set_seg_type(struct ofi_ctrl_hdr *ctrl_hdr, enum rxm_sar_seg_type seg_type)
 {
-    ((union rxm_sar_ctrl_data *)&(ctrl_hdr->ctrl_data))->seg_type = seg_type;
+	((union rxm_sar_ctrl_data *)&(ctrl_hdr->ctrl_data))->seg_type = seg_type;
+}
+
+static inline uint32_t
+rxm_sar_get_offset(struct ofi_ctrl_hdr *ctrl_hdr)
+{
+	return ((union rxm_sar_ctrl_data *)&(ctrl_hdr->ctrl_data))->offset;
+}
+
+static inline void
+rxm_sar_set_offset(struct ofi_ctrl_hdr *ctrl_hdr, uint32_t offset)
+{
+	((union rxm_sar_ctrl_data *)&(ctrl_hdr->ctrl_data))->offset = offset;
 }
 
 struct rxm_recv_match_attr {
@@ -363,7 +378,12 @@ struct rxm_recv_entry {
 	struct {
 		struct dlist_entry sar_entry;
 		size_t total_recv_len;
+		size_t segs_rcvd;
 		uint64_t msg_id;
+		/* This is used when a message with the `RXM_SAR_SEG_LAST`
+		 * flag is receved, but not all messages has been received
+		 * yet */
+		size_t last_seg_no;
 	};
 };
 DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
@@ -414,7 +434,11 @@ struct rxm_ep {
 	int			msg_mr_local;
 	int			rxm_mr_local;
 	size_t			min_multi_recv_size;
+
 	size_t			sar_limit;
+	/* This defines maximum index of a segment for
+	 * which segment length mast be calculated. */
+	uint32_t		sar_max_calc_seg_no;
 
 	struct rxm_buf_pool	buf_pools[RXM_BUF_POOL_MAX];
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -358,12 +358,15 @@ ssize_t rxm_cq_handle_seg_data(struct rxm_rx_buf *rx_buf)
 {
 	uint64_t done_len = ofi_copy_to_iov(rx_buf->recv_entry->rxm_iov.iov,
 					    rx_buf->recv_entry->rxm_iov.count,
-					    rx_buf->pkt.hdr.size,
+					    rxm_sar_get_offset(&rx_buf->pkt.ctrl_hdr),
 					    rx_buf->pkt.data,
 					    rx_buf->pkt.ctrl_hdr.seg_size);
 	rx_buf->recv_entry->total_recv_len += done_len;
+	rx_buf->recv_entry->segs_rcvd++;
 	/* Check that this isn't last segment */
-	if (rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) != RXM_SAR_SEG_LAST &&
+	if (((rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) != RXM_SAR_SEG_LAST) &&
+	     (!rx_buf->recv_entry->last_seg_no ||
+	      (rx_buf->recv_entry->last_seg_no != rx_buf->pkt.ctrl_hdr.seg_no))) &&
 	/* and message isn't truncated */
 	    (done_len == rx_buf->pkt.ctrl_hdr.seg_size)) {
 		if (rx_buf->recv_entry->msg_id == UINT64_MAX) {
@@ -380,18 +383,20 @@ ssize_t rxm_cq_handle_seg_data(struct rxm_rx_buf *rx_buf)
 				  &rx_buf->ep->repost_ready_list);
 		rx_buf->ep->res_fastlock_release(&rx_buf->ep->util_ep.lock);
 		return FI_SUCCESS;
+	} else if ((rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) == RXM_SAR_SEG_LAST) &&
+		   (rx_buf->recv_entry->segs_rcvd != (rx_buf->pkt.ctrl_hdr.seg_no + 1))) {
+		/* Handle case when the segment with the `RXM_SAR_SEG_LAST` flag
+		 * is received, but not all segments were received yet. We should
+		 * wait untill all segments will be received. */
+		rx_buf->recv_entry->last_seg_no = rx_buf->pkt.ctrl_hdr.seg_no;
 	}
 	dlist_remove(&rx_buf->recv_entry->sar_entry);
 	/* Mark rxm_recv_entry::msg_id as unknown for futher re-use */
 	rx_buf->recv_entry->msg_id = UINT64_MAX;
-
-	/* The hdr::size contains offset (bytes) that should be applied when
-	 * performing copying segment data to the destination buffer.
-	 * The total size of messages = last segment size + offset from hdr::size */
-	rx_buf->pkt.hdr.size += done_len;
-
 	done_len = rx_buf->recv_entry->total_recv_len;
 	rx_buf->recv_entry->total_recv_len = 0;
+	rx_buf->recv_entry->segs_rcvd = 0;
+	rx_buf->recv_entry->last_seg_no = 0;
 	return rxm_finish_recv(rx_buf, done_len);
 }
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -908,6 +908,13 @@ err:
 	return ret;
 }
 
+static inline size_t
+rxm_ep_sar_estimate_segments_num(struct rxm_ep *rxm_ep, size_t data_len)
+{
+	/* This is rough estimation of the number of the segments to be sent */
+	return (data_len / rxm_ep->rxm_info->tx_attr->inject_size);
+}
+
 static inline struct rxm_tx_buf *
 rxm_ep_sar_tx_prepare_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			      size_t total_len, size_t seg_len, size_t seg_no,
@@ -1373,11 +1380,14 @@ send_continue:
 		return ret;
 	} else {
 		assert(!(flags & FI_INJECT));
-		if (data_len <= rxm_ep->sar_limit) {
+		if ((data_len <= rxm_ep->sar_limit) &&
+		    /* Roughly estimate whether all SAR segments can be sent w/o
+		     * retransmission due to lack of space in the TX queue */
+		    (rxm_ep_sar_estimate_segments_num(rxm_ep, data_len) <=
+						rxm_ep->rxm_info->tx_attr->size)) {
 			return rxm_ep_sar_tx_send(rxm_ep, rxm_conn, context, count, iov,
 						  data_len, data, flags, comp_flags, tag, op);
 		} else {
-			assert(data_len > rxm_ep->sar_limit);
 			ret = rxm_ep_alloc_lmt_tx_res(rxm_ep, rxm_conn, context,
 						      (uint8_t)count, iov, desc,
 						      data_len, data, flags, comp_flags,


### PR DESCRIPTION
- **prov/rxm: Fix the buffered receive with SAR protocol**
Set an offest into ctrl_data field of ctrl_hdr instead of use
offset from pkt.hdr.size that is used by the buffred receive
functionality to report total size of messages received.
- **prov/rxm: Implement rough estimation of the number of the segments**
RxM estimates how much segments have to be sent to transfer an entire
message. If the number of the segments greater than TX queue size of
core provider, RxM uses Rendezvous protocol to transfer the message as
a fallback.