### PR TITLE
Revert "prov/rxm: Don't consider RxM pkt size twice"

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -307,8 +307,7 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 		rxm_ep->rxm_info->tx_attr->inject_size +
 		sizeof(struct rxm_tx_buf),			/* TX */
 		rxm_ep->msg_info->tx_attr->inject_size +
-		sizeof(struct rxm_tx_buf) -
-		sizeof(struct rxm_pkt),				/* TX INJECT */
+		sizeof(struct rxm_tx_buf),			/* TX INJECT */
 		sizeof(struct rxm_tx_buf),			/* TX ACK */
 		sizeof(struct rxm_rma_iov) +
 		rxm_ep->rxm_info->tx_attr->iov_limit *


### PR DESCRIPTION
This reverts commit ee9ab13e468f0eab6566825cc4d390aeff377bf2.