### PR TITLE
prov/util,rxm: refactoring + bug fixes

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -290,9 +290,8 @@ struct rxm_rx_buf {
 	uint8_t repost;
 
 	/* Used for large messages */
-	struct rxm_iov match_iov[RXM_IOV_LIMIT];
 	struct rxm_rma_iov *rma_iov;
-	size_t index;
+	size_t rma_iov_index;
 	struct fid_mr *mr[RXM_IOV_LIMIT];
 
 	/* Must stay at bottom */

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1712,6 +1712,7 @@ static int rxm_ep_close(struct fid *fid)
 		retv = ret;
 
 	ofi_endpoint_close(&rxm_ep->util_ep);
+	fi_freeinfo(rxm_ep->rxm_info);
 	free(rxm_ep);
 	return retv;
 }

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1625,6 +1625,7 @@ void ofi_cmap_free(struct util_cmap *cmap)
 	util_cmap_event_handler_close(cmap);
 	free(cmap->handles_av);
 	free(cmap->attr.name);
+	ofi_idx_reset(&cmap->handles_idx);
 	fastlock_release(&cmap->lock);
 	fastlock_destroy(&cmap->lock);
 	free(cmap);

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -148,6 +148,7 @@ void *util_buf_get(struct util_buf_pool *pool)
 	entry = slist_remove_head(&pool->buf_list);
 	buf_ftr = (struct util_buf_footer *) ((char *) entry + pool->attr.size);
 	buf_ftr->region->num_used++;
+	assert(buf_ftr->region->num_used);
 	return entry;
 }
 
@@ -157,6 +158,7 @@ void util_buf_release(struct util_buf_pool *pool, void *buf)
 	struct util_buf_footer *buf_ftr;
 
 	buf_ftr = (struct util_buf_footer *) ((char *) buf + pool->attr.size);
+	assert(buf_ftr->region->num_used);
 	buf_ftr->region->num_used--;
 	slist_insert_head(&util_buf->entry, &pool->buf_list);
 }


### PR DESCRIPTION
- prov/util,rxm: fix memory leaks
- prov/util: add debug asserts to avoid size_t underflow/overflow
- prov/rxm: move writing truncation error to a functon 
- prov/rxm: make use of ofi_copy_iov_desc 