### PR TITLE
prov/rxm: Reprocess directed receives for FI_DIRECTED_RECV enabled

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -983,17 +983,19 @@ static int rxm_cq_reprocess_recv_queues(struct rxm_ep *rxm_ep)
 {
 	int count = 0;
 
-	fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
+	if (rxm_ep->rxm_info->caps & FI_DIRECTED_RECV) {
+		fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
 
-	if (!rxm_ep->util_ep.cmap->av_updated)
-		goto unlock;
+		if (!rxm_ep->util_ep.cmap->av_updated)
+			goto unlock;
 
-	rxm_ep->util_ep.cmap->av_updated = 0;
+		rxm_ep->util_ep.cmap->av_updated = 0;
 
-	count += rxm_cq_reprocess_directed_recvs(&rxm_ep->recv_queue);
-	count += rxm_cq_reprocess_directed_recvs(&rxm_ep->trecv_queue);
+		count += rxm_cq_reprocess_directed_recvs(&rxm_ep->recv_queue);
+		count += rxm_cq_reprocess_directed_recvs(&rxm_ep->trecv_queue);
 unlock:
-	fastlock_release(&rxm_ep->util_ep.cmap->lock);
+		fastlock_release(&rxm_ep->util_ep.cmap->lock);
+	}
 	return count;
 }
 


### PR DESCRIPTION
prov/rxm: Reprocess directed receives when AV updated only in case of FI_DIRECTED_RECV enabled

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>