### PR TITLE
prov/rxm: Don't emulate RxM inject over MSG EP fi_send

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -432,6 +432,7 @@ struct rxm_ep {
 	struct fid_ep 		*srx_ctx;
 	size_t 			comp_per_progress;
 	size_t 			eager_pkt_size;
+	size_t 			eager_size;
 	int			msg_mr_local;
 	int			rxm_mr_local;
 	size_t			min_multi_recv_size;

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -48,6 +48,7 @@ struct fi_tx_attr rxm_tx_attr = {
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
 	.size = SIZE_MAX,
+	.inject_size = SIZE_MAX,
 	.iov_limit = RXM_IOV_LIMIT,
 	.rma_iov_limit = RXM_IOV_LIMIT,
 };

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -253,7 +253,7 @@ rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
 			.endianness = ofi_detect_endianness(),
-			.eager_size = rxm_ep->rxm_info->tx_attr->inject_size,
+			.eager_size = rxm_ep->eager_size,
 		},
 	};
 	struct util_cmap_handle *handle;
@@ -457,7 +457,7 @@ rxm_conn_connect(struct util_ep *util_ep, struct util_cmap_handle *handle,
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
 			.endianness = ofi_detect_endianness(),
-			.eager_size = rxm_ep->rxm_info->tx_attr->inject_size,
+			.eager_size = rxm_ep->eager_size,
 		},
 	};
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -105,7 +105,7 @@ static int rxm_finish_buf_recv(struct rxm_rx_buf *rx_buf)
 
 	assert(rx_buf->pkt.hdr.size <= rx_buf->ep->sar_limit);
 
-	if (rx_buf->pkt.hdr.size > rx_buf->ep->rxm_info->tx_attr->inject_size)
+	if (rx_buf->pkt.hdr.size > rx_buf->ep->eager_size)
 		flags |= FI_MORE;
 
 	FI_DBG(&rxm_prov, FI_LOG_CQ, "writing buffered recv completion: "

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -116,7 +116,8 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	info->tx_attr->mode		= info->mode;
 	info->tx_attr->msg_order 	= core_info->tx_attr->msg_order;
 	info->tx_attr->comp_order 	= rxm_info.tx_attr->comp_order;
-	info->tx_attr->inject_size	= rxm_info.tx_attr->inject_size;
+	info->tx_attr->inject_size	= core_info->tx_attr->inject_size
+					  - sizeof(struct rxm_pkt);
 	/* Export TX queue size same as that of MSG provider as we post TX
 	 * operations directly */
 	info->tx_attr->size 		= core_info->tx_attr->size;
@@ -150,20 +151,6 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 
 static int rxm_init_info(void)
 {
-	int param;
-
-	if (!fi_param_get_int(&rxm_prov, "buffer_size", &param)) {
-		if (param > sizeof(struct rxm_pkt)) {
-			rxm_info.tx_attr->inject_size = param;
-		} else {
-			FI_WARN(&rxm_prov, FI_LOG_CORE,
-				"Requested buffer size too small\n");
-			return -FI_EINVAL;
-		}
-	} else {
-		rxm_info.tx_attr->inject_size = RXM_BUF_SIZE;
-	}
-	rxm_info.tx_attr->inject_size -= sizeof(struct rxm_pkt);
 	rxm_util_prov.info = &rxm_info;
 	return 0;
 }


### PR DESCRIPTION
If core provider requires data progress in case of non-inject send,
the emulating of fi_inject over fi_send can't provide this

Also it simplifies fi_inject path of RxM.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>