### PR TITLE
prov/rxm: Always reset av_updated field

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -641,6 +641,7 @@ struct util_cmap_attr {
 	ofi_cmap_handle_func		connected_handler;
 	ofi_cmap_event_handler_func	event_handler;
 	ofi_cmap_signal_func		signal;
+	ofi_cmap_handle_func		av_updated_handler;
 };
 
 struct util_cmap {
@@ -659,7 +660,6 @@ struct util_cmap {
 	struct dlist_entry peer_list;
 	struct util_cmap_attr attr;
 	pthread_t event_handler_thread;
-	int av_updated;
 	fastlock_t lock;
 };
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -183,6 +183,95 @@ static void rxm_conn_connected_handler(struct util_cmap_handle *handle)
 	rxm_conn->saved_msg_ep = NULL;
 }
 
+static int rxm_conn_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
+{
+	struct rxm_rx_buf *rx_buf;
+	struct dlist_entry *entry, *tmp_entry;
+	struct rxm_recv_match_attr match_attr;
+	struct dlist_entry rx_buf_list;
+	struct fi_cq_err_entry err_entry = {0};
+	int ret, count = 0;
+
+	dlist_init(&rx_buf_list);
+
+	recv_queue->rxm_ep->res_fastlock_acquire(&recv_queue->lock);
+
+	dlist_foreach_container_safe(&recv_queue->unexp_msg_list,
+				     struct rxm_rx_buf, rx_buf,
+				     unexp_msg.entry, tmp_entry) {
+		if (rx_buf->unexp_msg.addr == rx_buf->conn->handle.fi_addr)
+			continue;
+
+		assert(rx_buf->unexp_msg.addr == FI_ADDR_NOTAVAIL);
+
+		match_attr.addr = rx_buf->unexp_msg.addr =
+			rx_buf->conn->handle.fi_addr;
+		match_attr.tag = rx_buf->unexp_msg.tag;
+
+		entry = dlist_remove_first_match(&recv_queue->recv_list,
+						 recv_queue->match_recv,
+						 &match_attr);
+		if (!entry)
+			continue;
+
+		dlist_remove(&rx_buf->unexp_msg.entry);
+		rx_buf->recv_entry = container_of(entry, struct rxm_recv_entry,
+						  entry);
+		dlist_insert_tail(&rx_buf->unexp_msg.entry, &rx_buf_list);
+	}
+	recv_queue->rxm_ep->res_fastlock_release(&recv_queue->lock);
+
+	while (!dlist_empty(&rx_buf_list)) {
+		dlist_pop_front(&rx_buf_list, struct rxm_rx_buf,
+				rx_buf, unexp_msg.entry);
+		ret = rxm_cq_handle_rx_buf(rx_buf);
+		if (ret) {
+			err_entry.op_context = rx_buf;
+			err_entry.flags = rx_buf->recv_entry->comp_flags;
+			err_entry.len = rx_buf->pkt.hdr.size;
+			err_entry.data = rx_buf->pkt.hdr.data;
+			err_entry.tag = rx_buf->pkt.hdr.tag;
+			err_entry.err = ret;
+			err_entry.prov_errno = ret;
+			ofi_cq_write_error(recv_queue->rxm_ep->util_ep.rx_cq,
+					   &err_entry);
+			if (rx_buf->ep->util_ep.flags & OFI_CNTR_ENABLED)
+				rxm_cntr_incerr(rx_buf->ep->util_ep.rx_cntr);
+
+			rxm_enqueue_rx_buf_for_repost_check(rx_buf);
+
+			if (!(rx_buf->recv_entry->flags & FI_MULTI_RECV))
+				rxm_recv_entry_release(recv_queue,
+						       rx_buf->recv_entry);
+		}
+		count++;
+	}
+	return count;
+}
+
+static void rxm_conn_reprocess_recv_queues(struct rxm_ep *rxm_ep)
+{
+	if (rxm_ep->rxm_info->caps & FI_DIRECTED_RECV) {
+		int count = 0;
+
+		fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
+		count += rxm_conn_reprocess_directed_recvs(&rxm_ep->recv_queue);
+		count += rxm_conn_reprocess_directed_recvs(&rxm_ep->trecv_queue);
+		fastlock_release(&rxm_ep->util_ep.cmap->lock);
+
+		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL,
+		       "Reprocessed directed recvs - %d\n", count);
+	}
+}
+
+static void
+rxm_conn_av_updated_handler(struct util_cmap_handle *handle)
+{
+	struct rxm_ep *rxm_ep = container_of(handle->cmap->ep, struct rxm_ep, util_ep);
+
+	rxm_conn_reprocess_recv_queues(rxm_ep);
+}
+
 static struct util_cmap_handle *rxm_conn_alloc(struct util_cmap *cmap)
 {
 	int ret;
@@ -553,6 +642,7 @@ struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep)
 	attr.connected_handler	= rxm_conn_connected_handler;
 	attr.event_handler	= rxm_conn_event_handler;
 	attr.signal		= rxm_conn_signal;
+	attr.av_updated_handler	= rxm_conn_av_updated_handler;
 
 	cmap = ofi_cmap_alloc(&rxm_ep->util_ep, &attr);
 	if (!cmap)

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -1368,7 +1368,9 @@ int ofi_cmap_update(struct util_cmap *cmap, const void *addr, fi_addr_t fi_addr)
 		goto out;
 	}
 	util_cmap_move_handle(handle, fi_addr);
-	cmap->av_updated = 1;
+
+	if (cmap->attr.av_updated_handler)
+		cmap->attr.av_updated_handler(handle);
 out:
 	fastlock_release(&cmap->lock);
 	return ret;


### PR DESCRIPTION
This fixes issue when FI_DIRECTED_RECV is not enabled:
The av_updated is not reset and caller of fi_cq_read is entered
to the reporcess every time.

Also this removes branch from from fi_cq_read

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>