### PR TITLE
prov/rxm: fill missing rxm_conn in rx_buf when SRX is not used

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -485,6 +485,10 @@ rxm_cq_match_rx_buf(struct rxm_rx_buf *rx_buf,
 		rx_buf->hdr.state = RXM_RX;
 		rx_buf->hdr.msg_ep = msg_ep;
 		rx_buf->repost = 1;
+		if (!rxm_ep->srx_ctx)
+			rx_buf->conn = container_of(msg_ep->fid.context,
+						    struct rxm_conn,
+						    handle);
 
 		rxm_enqueue_rx_buf_for_repost(rx_buf);
 		return 0;


### PR DESCRIPTION
Fixes #4283 

@jswaro This should fix the error that you see when running MPICH.