### PR TITLE
Revert "prov/rxm: Enable IPv6 support in RxM"

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -135,7 +135,7 @@ struct rxm_ep_wire_proto {
 };
 
 struct rxm_cm_data {
-	union ofi_sock_ip name;
+	struct sockaddr name;
 	uint64_t conn_id;
 	struct rxm_ep_wire_proto proto;
 };

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -496,7 +496,7 @@ exit:
 }
 
 static int rxm_prepare_cm_data(struct fid_pep *pep, struct util_cmap_handle *handle,
-			       struct rxm_cm_data *cm_data)
+		struct rxm_cm_data *cm_data)
 {
 	size_t cm_data_size = 0;
 	size_t name_size = sizeof(cm_data->name);
@@ -514,6 +514,7 @@ static int rxm_prepare_cm_data(struct fid_pep *pep, struct util_cmap_handle *han
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "MSG EP CM data size too small\n");
 		return -FI_EOTHER;
 	}
+
 	ret = fi_getname(&pep->fid, &cm_data->name, &name_size);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to get msg pep name\n");


### PR DESCRIPTION
This reverts commit c86ef2d0970a260d490412f932e9a31bcf82a3e2.

struct ofi_sock_ip (along with other info) doesn't fit within most
verbs devices CM data.