### PR TITLE
prov/tcp: signal the eq wait when new fd is added to it

### DIFF
--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -325,6 +325,7 @@ static void client_send_connreq(struct util_wait *wait,
 	if (ret)
 		goto err;
 
+	wait->signal(wait);
 	return;
 err:
 	memset(&err_entry, 0, sizeof err_entry);
@@ -379,7 +380,7 @@ static void server_sock_accept(struct util_wait *wait,
 			      NULL, (void *) cm_ctx);
 	if (ret)
 		goto err3;
-
+	wait->signal(wait);
 	return;
 err3:
 	free(cm_ctx);


### PR DESCRIPTION
when epoll is not supported natively in OS (i.e macOS), libfabric uses the
poll implementation for the epoll API. In case of poll we need to
explictily signal any blocked threads on wait object to include a new
fd. On the other hand epoll does not need this. So the
failures are happening only macOS in our CI. This patch fixes those failures.