### PR TITLE
Update format specifiers in FI_DBG messages

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -255,7 +255,7 @@ static int rxm_finish_recv(struct rxm_rx_buf *rx_buf, size_t done_len)
 
 		FI_DBG(&rxm_prov, FI_LOG_CQ,
 		       "Repost Multi-Recv entry: "
-		       "consumed len = %zu, remain len = %zu\n",
+		       "consumed len = %"PRIu64", remain len = %zu\n",
 		       rx_buf->pkt.hdr.size,
 		       rx_buf->recv_entry->total_len);
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -946,7 +946,7 @@ void rxm_ep_handle_postponed_tx_op(struct rxm_ep *rxm_ep,
 
 	tx_entry->tx_buf->pkt.ctrl_hdr.conn_id = rxm_conn->handle.remote_key;
 	FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-	       "Send deffered TX request (len - %zd) for %p conn\n",
+	       "Send deffered TX request (len - %"PRIu64") for %p conn\n",
 	       tx_entry->tx_buf->pkt.hdr.size, rxm_conn);
 
 	if ((tx_size <= rxm_ep->msg_info->tx_attr->inject_size) &&

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -189,7 +189,7 @@ void rxm_ep_handle_postponed_rma_op(struct rxm_ep *rxm_ep,
 	struct fi_cq_err_entry err_entry;
 
 	FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-	       "Perform deffered RMA operation (len - %zd) for %p conn\n",
+	       "Perform deffered RMA operation (len - %"PRIu64") for %p conn\n",
 	       tx_entry->rma_buf->pkt.hdr.size, rxm_conn);
 
 	if (tx_entry->comp_flags & FI_WRITE) {

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -124,7 +124,7 @@ static void util_monitor_read_events(struct ofi_mem_monitor *monitor)
 		}
 
 		FI_DBG(&core_prov, FI_LOG_MR,
-		       "found event, context=%p, addr=%p, len=%"PRIu64" nq=%p\n",
+		       "found event, context=%p, addr=%p, len=%zu nq=%p\n",
 		       subscription, subscription->addr,
 		       subscription->len, subscription->nq);
 

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -65,7 +65,7 @@ static int util_mr_find_overlap(void *a, void *b)
 static void util_mr_free_entry(struct ofi_mr_cache *cache,
 			       struct ofi_mr_entry *entry)
 {
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "free %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "free %p (len: %zu)\n",
 	       entry->iov.iov_base, entry->iov.iov_len);
 
 	assert(!entry->cached);
@@ -121,7 +121,7 @@ bool ofi_mr_cache_flush(struct ofi_mr_cache *cache)
 	dlist_pop_front(&cache->lru_list, struct ofi_mr_entry,
 			entry, lru_entry);
 	dlist_init(&entry->lru_entry);
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "flush %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "flush %p (len: %zu)\n",
 	       entry->iov.iov_base, entry->iov.iov_len);
 
 	util_mr_uncache_entry(cache, entry);
@@ -131,7 +131,7 @@ bool ofi_mr_cache_flush(struct ofi_mr_cache *cache)
 
 void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
 {
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "delete %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "delete %p (len: %zu)\n",
 	       entry->iov.iov_base, entry->iov.iov_len);
 	cache->delete_cnt++;
 
@@ -152,7 +152,7 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 {
 	int ret;
 
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "create %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "create %p (len: %zu)\n",
 	       iov->iov_base, iov->iov_len);
 
 	util_mr_cache_process_events(cache);
@@ -208,7 +208,7 @@ util_mr_cache_merge(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 			    (void **) &old_entry);
 
 		FI_DBG(cache->domain->prov, FI_LOG_MR,
-		       "merging %p (len: %" PRIu64 ") with %p (len: %" PRIu64 ")\n",
+		       "merging %p (len: %zu) with %p (len: %zu)\n",
 		       iov.iov_base, iov.iov_len,
 		       old_entry->iov.iov_base, old_entry->iov.iov_len);
 
@@ -216,7 +216,7 @@ util_mr_cache_merge(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 			MAX(ofi_iov_end(&iov), ofi_iov_end(old_iov))) -
 			((uintptr_t) MIN(iov.iov_base, old_iov->iov_base));
 		iov.iov_base = MIN(iov.iov_base, old_iov->iov_base);
-		FI_DBG(cache->domain->prov, FI_LOG_MR, "merged %p (len: %" PRIu64 ")\n",
+		FI_DBG(cache->domain->prov, FI_LOG_MR, "merged %p (len: %zu)\n",
 		       iov.iov_base, iov.iov_len);
 
 		rbtErase(cache->mr_tree, iter);
@@ -246,7 +246,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	util_mr_cache_process_events(cache);
 
 	assert(attr->iov_count == 1);
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "search %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "search %p (len: %zu)\n",
 	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
 	cache->search_cnt++;
 


### PR DESCRIPTION
Looks like types of several fields have changed from uint64_t, size_t, and ssize_t.  Update format specifiers in FI_DBG messages to match the updated types.