### PR TITLE
fix warning missing-field-initializers

### DIFF
--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -341,7 +341,9 @@ static inline int
 fi_mr_refresh(struct fid_mr *mr, const struct iovec *iov, size_t count,
 	      uint64_t flags)
 {
-	struct fi_mr_modify modify = {0};
+	struct fi_mr_modify modify = {0, 
+		{NULL, 0, 0, 0, 0, NULL, 0, NULL}
+	};
 	modify.flags = flags;
 	modify.attr.mr_iov = iov;
 	modify.attr.iov_count = count;


### PR DESCRIPTION
When compiling c++ code against libfabric, the compiler gives a warning about an uninitialized member