### PR TITLE
prov/mrail: Fix mrail's getinfo returning only one info per rail

### DIFF
--- a/prov/mrail/src/mrail_fabric.c
+++ b/prov/mrail/src/mrail_fabric.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -73,7 +74,7 @@ static struct fi_ops_fabric mrail_fabric_ops = {
 int mrail_fabric_open(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		      void *context)
 {
-	struct fi_info *fi;
+	struct fi_info *fi, *info;
 	struct mrail_fabric *mrail_fabric;
 	size_t i;
 	int ret;
@@ -82,7 +83,14 @@ int mrail_fabric_open(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 	if (!mrail_fabric)
 		return -FI_ENOMEM;
 
-	mrail_fabric->info = mrail_get_info_cached(attr->name);
+	ret = mrail_get_info_cached(attr->name, attr->prov_name, &info);
+	if (ret)
+		return ret;
+
+	// We don't want to use a list to open the fabric
+	info->next = NULL;
+
+	mrail_fabric->info = info;
 	if (!mrail_fabric->info) {
 		free(mrail_fabric);
 		return -FI_EINVAL;


### PR DESCRIPTION
Mrail's getinfo was only returning one info struct per rail. This caused
a bug where only one unique provider was being returned to the caller.
Every other provider was being dropped.

This fix makes getinfo return one info struct per provider detected.
All info structs are cached for internal usage.

This caused a change in mrail's info cache. The info cache now stores
structs from only the latest getinfo call and stores all info structs
for every rail instead of one info struct per rail. This commit turns
the stored cache into an array of lists.

Fixes #4203

Signed-off-by: William Zhang <wilzhang@amazon.com>