### PR TITLE
prov/gni: Fix stale data issue with SMSG buffers

### DIFF
--- a/prov/gni/src/gnix_mbox_allocator.c
+++ b/prov/gni/src/gnix_mbox_allocator.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2015,2017 Cray Inc.  All rights reserved.
+ * Copyright (c) 2015,2017-2018 Cray Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -553,6 +553,11 @@ static int __fill_mbox(struct gnix_mbox_alloc_handle *handle,
 		ret = -FI_EINVAL;
 		goto err_invalid;
 	}
+
+	/* On some systems, the page may not be zero'd from first use.
+		Memset it here */
+	memset((void *) ((uint64_t) out->base + out->offset),
+		0x0, handle->mbox_size);
 
 	ret = _gnix_test_and_set_bit(slab->used, position);
 	if (ret != 0) {

--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
@@ -219,6 +219,10 @@ static int __nic_setup_irq_cq(struct gnix_nic *nic)
 
 	nic->irq_mmap_addr = mmap_addr;
 	nic->irq_mmap_len = len;
+
+	/* On some systems, the page may not be zero'd from first use.
+		 Memset it here */
+	memset(mmap_addr, 0x0, len);
 
 	if (nic->using_vmdh) {
 		info = _gnix_auth_key_lookup(GNIX_PROV_DEFAULT_AUTH_KEY,


### PR DESCRIPTION
SMSG buffers could contain stale data in the slab when first
allocated on some systems or when reused. This commit fixes that by
zero'ing the memory allocated upon first use, regardless of assumptions
that may have been made about the underlying implementation.

Signed-off-by: James Swaro <jswaro@cray.com>