### PR TITLE
prov/verbs, rxm: bug fixes

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -240,8 +240,10 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 		return ret;
 
 	if (port_save) {
-		for (cur = *info; cur; cur = cur->next)
+		for (cur = *info; cur; cur = cur->next) {
+			assert(cur->src_addr);
 			ofi_addr_set_port(cur->src_addr, port_save);
+		}
 	}
 
 	rxm_alter_info(hints, *info);


### PR DESCRIPTION
- prov/rxm: add an assert for fi_info->src_addr
- prov/rxm: fix missing src addr info in case of connections to self
- prov/verbs: don't report unusable fi_info (no source IP address)