### PR TITLE
prov/sockets: Add FI_SOCKETS_CONN_TIMEOUT parameter

### DIFF
--- a/man/fi_sockets.7.md
+++ b/man/fi_sockets.7.md
@@ -60,6 +60,9 @@ The sockets provider checks for the following environment variables -
 *FI_SOCKETS_PE_WAITTIME*
 : An integer value that specifies how many milliseconds to spin while waiting for progress in *FI_PROGRESS_AUTO* mode.
 
+*FI_SOCKETS_CONN_TIMEOUT*
+: An integer value that specifies how many milliseconds to wait for one connection establishment.
+
 *FI_SOCKETS_MAX_CONN_RETRY*
 : An integer value that specifies the number of socket connection retries before reporting as failure.
 

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -104,6 +104,7 @@
 #define SOCK_EP_MAX_RETRY (5)
 #define SOCK_EP_MAX_CM_DATA_SZ (256)
 #define SOCK_CM_DEF_BACKLOG (128)
+#define SOCK_CM_DEF_TIMEOUT (15000)
 #define SOCK_CM_DEF_RETRY (5)
 #define SOCK_CM_CONN_IN_PROGRESS ((struct sock_conn *)(0x1L))
 

--- a/prov/sockets/include/sock_util.h
+++ b/prov/sockets/include/sock_util.h
@@ -44,6 +44,7 @@ extern const char sock_dom_name[];
 extern const char sock_prov_name[];
 extern struct fi_provider sock_prov;
 extern int sock_pe_waittime;
+extern int sock_conn_timeout;
 extern int sock_conn_retry;
 extern int sock_cm_def_map_sz;
 extern int sock_av_def_sz;

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -536,7 +536,7 @@ do_connect:
 			poll_fd.fd = conn_fd;
 			poll_fd.events = POLLOUT;
 
-			ret = poll(&poll_fd, 1, 15 * 1000);
+			ret = poll(&poll_fd, 1, sock_conn_timeout);
 			if (ret < 0) {
 				SOCK_LOG_DBG("poll failed\n");
 				goto retry;
@@ -569,7 +569,6 @@ do_connect:
 
 retry:
 	do_retry--;
-	sleep(10);
 	if (!do_retry)
 		goto err;
 

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -60,6 +60,7 @@ int sock_pe_waittime = SOCK_PE_WAITTIME;
 const char sock_fab_name[] = "IP";
 const char sock_dom_name[] = "sockets";
 const char sock_prov_name[] = "sockets";
+int sock_conn_timeout = SOCK_CM_DEF_TIMEOUT;
 int sock_conn_retry = SOCK_CM_DEF_RETRY;
 int sock_cm_def_map_sz = SOCK_CMAP_DEF_SZ;
 int sock_av_def_sz = SOCK_AV_DEF_SZ;
@@ -350,6 +351,7 @@ static void sock_read_default_params()
 {
 	if (!read_default_params) {
 		fi_param_get_int(&sock_prov, "pe_waittime", &sock_pe_waittime);
+		fi_param_get_int(&sock_prov, "conn_timeout", &sock_conn_timeout);
 		fi_param_get_int(&sock_prov, "max_conn_retry", &sock_conn_retry);
 		fi_param_get_int(&sock_prov, "def_conn_map_sz", &sock_cm_def_map_sz);
 		fi_param_get_int(&sock_prov, "def_av_sz", &sock_av_def_sz);
@@ -869,6 +871,9 @@ SOCKETS_INI
 
 	fi_param_define(&sock_prov, "pe_waittime", FI_PARAM_INT,
 			"How many milliseconds to spin while waiting for progress");
+
+	fi_param_define(&sock_prov, "conn_timeout", FI_PARAM_INT,
+			"How many milliseconds to wait for one connection establishment");
 
 	fi_param_define(&sock_prov, "max_conn_retry", FI_PARAM_INT,
 			"Number of connection retries before reporting as failure");


### PR DESCRIPTION
Make the 15s connection timeout configurable via environment
variable FI_SOCKETS_CONN_TIMEOUT. Also, remove the sleep(10) in
sock_ep_get_conn(). For example,

  export FI_SOCKETS_MAX_CONN_RETRY=1    # try only once
  export FI_SOCKETS_CONN_TIMEOUT=2000   # time out after 2s

Signed-off-by: Wei Li <liw2@boro-70.boro.hpdd.intel.com>
Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>