### PR TITLE
[v1.6.x]  prov/rxm: make postpone/defer requests opt-in

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -103,6 +103,7 @@ do {									\
 extern struct fi_provider rxm_prov;
 extern struct util_prov rxm_util_prov;
 extern struct fi_ops_rma rxm_ops_rma;
+extern int rxm_defer_requests;
 
 struct rxm_fabric {
 	struct util_fabric util_fabric;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1029,7 +1029,7 @@ rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 		};
 		ret = ofi_cmap_handle_connect(rxm_ep->util_ep.cmap,
 					      dest_addr, handle);
-		if (OFI_UNLIKELY(ret != -FI_EAGAIN))
+		if (ret && (!rxm_defer_requests || OFI_UNLIKELY(ret != -FI_EAGAIN)))
 			goto cmap_err;
 		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_send(rxm_ep, rxm_conn, NULL, 1,
@@ -1091,7 +1091,7 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 	} else if (OFI_UNLIKELY(handle->state != CMAP_CONNECTED)) {
 		ret = ofi_cmap_handle_connect(rxm_ep->util_ep.cmap,
 					      dest_addr, handle);
-		if (OFI_UNLIKELY(ret != -FI_EAGAIN))
+		if (ret && (!rxm_defer_requests || OFI_UNLIKELY(ret != -FI_EAGAIN)))
 			goto cmap_err;
 		rxm_conn = container_of(handle, struct rxm_conn, handle);
 		ret = rxm_ep_postpone_send(

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -38,6 +38,8 @@
 #include <ofi_prov.h>
 #include "rxm.h"
 
+int rxm_defer_requests = 0;
+
 char *rxm_proto_state_str[] = {
 	RXM_PROTO_STATES(OFI_STR)
 };
@@ -293,6 +295,12 @@ RXM_INI
 			"Defines the maximum number of MSG provider CQ entries "
 			"(default: 1) that would be read per progress "
 			"(RxM CQ read).");
+
+	fi_param_define(&rxm_prov, "defer_requests", FI_PARAM_BOOL,
+			"Defer requests when connection is not established "
+			"(default: false)\n");
+
+	fi_param_get_bool(&rxm_prov, "defer_requests", &rxm_defer_requests);
 
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");


### PR DESCRIPTION
This resolves a hang in mpi_stress test for high # of ranks.