### PR TITLE
prov/rxm: Remove deferred queue

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -280,7 +280,6 @@ static struct util_cmap_handle *rxm_conn_alloc(struct util_cmap *cmap)
 		return NULL;
 	}
 	dlist_init(&rxm_conn->sar_rx_msg_list);
-	dlist_init(&rxm_conn->deferred_op_list);
 	return &rxm_conn->handle;
 }
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -937,9 +937,6 @@ void rxm_ep_progress_one(struct util_ep *util_ep)
 	rxm_cq_repost_rx_buffers(rxm_ep);
 
 	(void) rxm_ep_read_msg_cq(rxm_ep);
-
-	if (OFI_UNLIKELY(!dlist_empty(&rxm_ep->conn_deferred_list)))
-		rxm_ep_progress_deferred_list(rxm_ep);
 }
 
 void rxm_ep_progress_multi(struct util_ep *util_ep)
@@ -953,9 +950,6 @@ void rxm_ep_progress_multi(struct util_ep *util_ep)
 
 	do {
 		ret = rxm_ep_read_msg_cq(rxm_ep);
-
-		if (OFI_UNLIKELY(!dlist_empty(&rxm_ep->conn_deferred_list)))
-			rxm_ep_progress_deferred_list(rxm_ep);
 	} while ((++comp_read < rxm_ep->comp_per_progress) && (ret > 0));
 }
 


### PR DESCRIPTION
The deferred queue is not needed and leads to poor performance due to
if stetement on the critical path

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>