### PR TITLE
prov/rxm: Implement knob to use fair queues

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -249,7 +249,7 @@ static inline int rxm_finish_sar_segment_send(struct rxm_tx_buf *tx_buf)
 		rxm_cq_write_error(tx_entry->ep->util_ep.tx_cq,
 				   tx_entry->ep->util_ep.tx_cntr,
 				   tx_entry->context, -FI_ENOMEM);
-		rxm_tx_entry_release(&tx_entry->conn->send_queue, tx_entry);
+		rxm_tx_entry_release(tx_entry->conn->send_queue, tx_entry);
 	}
 	return FI_SUCCESS;
 }
@@ -291,7 +291,7 @@ static int rxm_lmt_handle_ack(struct rxm_rx_buf *rx_buf)
 	FI_DBG(&rxm_prov, FI_LOG_CQ, "Got ACK for msg_id: 0x%" PRIx64 "\n",
 	       rx_buf->pkt.ctrl_hdr.msg_id);
 
-	tx_entry = &rxm_conn->send_queue.fs->entry[rx_buf->pkt.ctrl_hdr.msg_id].buf;
+	tx_entry = &rxm_conn->send_queue->fs->entry[rx_buf->pkt.ctrl_hdr.msg_id].buf;
 
 	assert(tx_entry->tx_buf->pkt.ctrl_hdr.msg_id == rx_buf->pkt.ctrl_hdr.msg_id);
 
@@ -579,7 +579,7 @@ static ssize_t rxm_lmt_send_ack(struct rxm_rx_buf *rx_buf)
 	}
 	assert(tx_buf->pkt.ctrl_hdr.type == ofi_ctrl_ack);
 
-	tx_entry = rxm_tx_entry_get(&rx_buf->conn->send_queue);
+	tx_entry = rxm_tx_entry_get(rx_buf->conn->send_queue);
 	if (OFI_UNLIKELY(!tx_entry)) {
 		ret = -FI_EAGAIN;
 		goto err1;
@@ -603,7 +603,7 @@ static ssize_t rxm_lmt_send_ack(struct rxm_rx_buf *rx_buf)
 	}
 	return 0;
 err2:
-	rxm_tx_entry_release(&rx_buf->conn->send_queue, tx_entry);
+	rxm_tx_entry_release(rx_buf->conn->send_queue, tx_entry);
 err1:
 	rxm_tx_buf_release(rx_buf->ep, tx_buf);
 	return ret;
@@ -722,7 +722,7 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 		assert(comp->flags & FI_SEND);
 		rx_buf = tx_entry->context;
 		rxm_tx_buf_release(rx_buf->ep, tx_entry->tx_buf);
-		rxm_tx_entry_release(&tx_entry->conn->send_queue, tx_entry);
+		rxm_tx_entry_release(tx_entry->conn->send_queue, tx_entry);
 		return rxm_finish_send_lmt_ack(rx_buf);
 	default:
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Invalid state!\n");

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -293,6 +293,10 @@ RXM_INI
 			"memory consumption, but it may increase small message "
 			"latency as a side-effect.");
 
+	fi_param_define(&rxm_prov, "use_fair_tx_queues", FI_PARAM_BOOL,
+			"The environment variable controls whether RxM should use "
+			"TX queue per connection or shared TX queue (default: 0).");
+
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");
 		return NULL;


### PR DESCRIPTION
Having of TX queues per connection gives total queue size more
than MSG CQ allows. It leads to the case that CQ is overrun.

The PR implements the shared TX queue (rxm_conn has a pointer to
the shared TX queue). This is default behavior.
If fair TX queues is needed (per connection TX queue), this can be
enabled by specifying FI_OFI_RXM_USE_FAIR_TX_QUEUES=1. In this case,
rxm_ep::send_queue is NULL.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>