### PR TITLE
prov/psm2: Remove stale info from address vector when disconnecting

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -938,6 +938,9 @@ int	psmx2_av_add_trx_ctxt(struct psmx2_fid_av *av, struct psmx2_trx_ctxt *trx_ct
 psm2_epaddr_t psmx2_av_translate_sep(struct psmx2_fid_av *av,
 				     struct psmx2_trx_ctxt *trx_ctxt, fi_addr_t addr);
 
+void	psmx2_av_remove_conn(struct psmx2_fid_av *av, struct psmx2_trx_ctxt *trx_ctxt,
+			     psm2_epaddr_t epaddr);
+
 static inline int psmx2_av_check_table_idx(struct psmx2_fid_av *av,
 					   struct psmx2_trx_ctxt *trx_ctxt,
 					   size_t idx)

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -100,6 +100,8 @@ int psmx2_am_trx_ctxt_handler(psm2_am_token_t token, psm2_amarg_t *args,
 			dlist_remove_first_match(&trx_ctxt->peer_list,
 						 psmx2_peer_match, epaddr);
 			psmx2_unlock(&trx_ctxt->peer_lock, 2);
+			if (trx_ctxt->ep && trx_ctxt->ep->av)
+				psmx2_av_remove_conn(trx_ctxt->ep->av, trx_ctxt, epaddr);
 			disconn->ep = trx_ctxt->psm2_ep;
 			disconn->epaddr = epaddr;
 			pthread_create(&disconnect_thread, NULL,


### PR DESCRIPTION
The "epaddr" info stored in address vector becomes invalid when the
corresponding peer is disconnected. Usually it's not an issue because
the entry is not supposed to be used later. However, if an application
uses fi_cq_readfrom to get the source address of incoming messages,
and multiple senders reuse the same HW address (successively, not
concurrently), the receiver may reuse old entries for new peers and
thus attempt to use the stale information instead of setting up new
connections.

Fix by removing stale "epaddr" information from the address vector
when the peer is disconnected.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>