### PR TITLE
WIP: prov/verbs: First attempt at providing IB async events to EQ

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -263,6 +263,7 @@ struct fi_ibv_eq {
 	fastlock_t		lock;
 	struct dlistfd_head	list_head;
 	struct rdma_event_channel *channel;
+	struct dlist_entry	domain_list;
 	uint64_t		flags;
 	struct fi_eq_err_entry	err;
 	int			epfd;
@@ -312,6 +313,7 @@ struct fi_ibv_domain {
 	/* The EQ is utilized by verbs/MSG */
 	struct fi_ibv_eq		*eq;
 	uint64_t			eq_flags;
+	struct dlist_entry		eq_dlentry;
 
 	/* Indicates that MSG endpoints should use the XRC transport.
 	 * TODO: Move selection of XRC/RC to endpoint info from domain */
@@ -725,6 +727,9 @@ int fi_ibv_cq_signal(struct fid_cq *cq);
 
 ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
 		const void *buf, size_t len);
+
+int fi_ibv_eq_attach_domain(struct fi_ibv_eq *eq, struct fi_ibv_domain *domain);
+int fi_ibv_eq_dettach_domain(struct fi_ibv_eq *eq, struct fi_ibv_domain *domain);
 
 int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,


### PR DESCRIPTION
This patch is a WIP! Please don't merge it in the current state!!

This patch is an draft to provide an initial support of IB async events into the verbs provider. 
Async event are particularly interesting to report out-of-bound events such as a network device removal, CQ overrun into the EQ, etc...

The patch is not perfect yet but I would appreciate your initial thoughts :-)

Among the things I need to fix:
1/ only MSG and RDM endpoints are supported as for now. I should provide similar support for DGRAM endpoints.
2/ `fi_ibv_eq_read` now has to iterate through all the domains the EQ has been bound to in order to check for new async events. This make `fi_ibv_eq_read` more costly in terms of CPU cycles.
3/ Right now, `eq->err.err` is set to the error value reported by the verbs. We should have kind of wrapper to use generic error codes provided by libfabric.

Thanks for your feeback!

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>