### PR TITLE
prov/tcp: fix wrong conditions in tcpx_try_func()

### DIFF
--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -444,11 +444,11 @@ static int tcpx_try_func(void *util_ep)
 			       struct util_wait_fd, util_wait);
 
 	fastlock_acquire(&ep->lock);
-	if (slist_empty(&ep->tx_queue) && !ep->send_ready_monitor) {
+	if (!slist_empty(&ep->tx_queue) && !ep->send_ready_monitor) {
 		ep->send_ready_monitor = true;
 		events = FI_EPOLL_IN | FI_EPOLL_OUT;
 		goto epoll_mod;
-	} else if (!slist_empty(&ep->tx_queue) && ep->send_ready_monitor) {
+	} else if (slist_empty(&ep->tx_queue) && ep->send_ready_monitor) {
 		ep->send_ready_monitor = false;
 		events = FI_EPOLL_IN;
 		goto epoll_mod;

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -108,7 +108,7 @@ static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 
 	fastlock_acquire(&tcpx_ep->lock);
 	slist_insert_tail(&recv_entry->entry, &tcpx_ep->rma_read_queue);
-	slist_insert_tail(&send_entry->entry, &tcpx_ep->tx_queue);
+	tcpx_tx_queue_insert(tcpx_ep, send_entry);
 	fastlock_release(&tcpx_ep->lock);
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
@vkrishna I've finally had a chance to test your recent patches, which add the progression of endpoints in blocking polling mode. I've found a bug, which I address in this patch. 
I still have some bugs where the `tcp` provider stops progressing messages in blocking mode. I'll dig into the problem and I will probably post some additional patches in the next days.

This patch fixes a bug that has been introduced in commit
55192cde9a86f92b50cf6c427447ccfefe2ef5cd("prov/tcp: Modify which
poll events the endpoint's sock can be blocked on")

- FI_EPOLL_OUT must be monitored when ep->tx_queue is not empty
and send_ready_monitor is set to false.
- FI_EPOLL_OUT must be unmonitored when ep->tx_queue is empty and
send_ready_monitor is set to true.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>