### PR TITLE
prov/psm,psm2: Enforce FI_RMA_EVENT checking when updating counters

### DIFF
--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -409,14 +409,16 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			psmx_atomic_do_write(addr, src, datatype, op, count);
 
 			target_ep = mr->domain->atomics_ep;
-			cntr = target_ep->remote_write_cntr;
-			mr_cntr = mr->cntr;
+			if (target_ep->caps & FI_RMA_EVENT) {
+				cntr = target_ep->remote_write_cntr;
+				mr_cntr = mr->cntr;
 
-			if (cntr)
-				psmx_cntr_inc(cntr);
+				if (cntr)
+					psmx_cntr_inc(cntr);
 
-			if (mr_cntr && mr_cntr != cntr)
-				psmx_cntr_inc(mr_cntr);
+				if (mr_cntr && mr_cntr != cntr)
+					psmx_cntr_inc(mr_cntr);
+			}
 		}
 
 		rep_args[0].u32w0 = PSMX_AM_REP_ATOMIC_WRITE;
@@ -454,18 +456,20 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				op_error = -FI_ENOMEM;
 
 			target_ep = mr->domain->atomics_ep;
-			if (op == FI_ATOMIC_READ) {
-				cntr = target_ep->remote_read_cntr;
-			} else {
-				cntr = target_ep->remote_write_cntr;
-				mr_cntr = mr->cntr;
+			if (target_ep->caps & FI_RMA_EVENT) {
+				if (op == FI_ATOMIC_READ) {
+					cntr = target_ep->remote_read_cntr;
+				} else {
+					cntr = target_ep->remote_write_cntr;
+					mr_cntr = mr->cntr;
+				}
+
+				if (cntr)
+					psmx_cntr_inc(cntr);
+
+				if (mr_cntr && mr_cntr != cntr)
+					psmx_cntr_inc(mr_cntr);
 			}
-
-			if (cntr)
-				psmx_cntr_inc(cntr);
-
-			if (mr_cntr && mr_cntr != cntr)
-				psmx_cntr_inc(mr_cntr);
 		} else {
 			tmp_buf = NULL;
 		}
@@ -502,14 +506,16 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				op_error = -FI_ENOMEM;
 
 			target_ep = mr->domain->atomics_ep;
-			cntr = target_ep->remote_write_cntr;
-			mr_cntr = mr->cntr;
+			if (target_ep->caps & FI_RMA_EVENT) {
+				cntr = target_ep->remote_write_cntr;
+				mr_cntr = mr->cntr;
 
-			if (cntr)
-				psmx_cntr_inc(cntr);
+				if (cntr)
+					psmx_cntr_inc(cntr);
 
-			if (mr_cntr && mr_cntr != cntr)
-				psmx_cntr_inc(mr_cntr);
+				if (mr_cntr && mr_cntr != cntr)
+					psmx_cntr_inc(mr_cntr);
+			}
 		} else {
 			tmp_buf = NULL;
 		}
@@ -679,18 +685,20 @@ static int psmx_atomic_self(int am_cmd,
 	}
 
 	target_ep = mr->domain->atomics_ep;
-	if (op == FI_ATOMIC_READ) {
-		cntr = target_ep->remote_read_cntr;
-	} else {
-		cntr = target_ep->remote_write_cntr;
-		mr_cntr = mr->cntr;
+	if (target_ep->caps & FI_RMA_EVENT) {
+		if (op == FI_ATOMIC_READ) {
+			cntr = target_ep->remote_read_cntr;
+		} else {
+			cntr = target_ep->remote_write_cntr;
+			mr_cntr = mr->cntr;
+		}
+
+		if (cntr)
+			psmx_cntr_inc(cntr);
+
+		if (mr_cntr && mr_cntr != cntr)
+			psmx_cntr_inc(mr_cntr);
 	}
-
-	if (cntr)
-		psmx_cntr_inc(cntr);
-
-	if (mr_cntr && mr_cntr != cntr)
-		psmx_cntr_inc(mr_cntr);
 
 gen_local_event:
 	no_event = ((flags & PSMX_NO_COMPLETION) ||

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -476,11 +476,13 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 					}
 				  }
 
-				  if (mr->domain->rma_ep->remote_write_cntr)
-					psmx_cntr_inc(mr->domain->rma_ep->remote_write_cntr);
+				  if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+					  if (mr->domain->rma_ep->remote_write_cntr)
+						psmx_cntr_inc(mr->domain->rma_ep->remote_write_cntr);
 
-				  if (mr->cntr && mr->cntr != mr->domain->rma_ep->remote_write_cntr)
-					psmx_cntr_inc(mr->cntr);
+					  if (mr->cntr && mr->cntr != mr->domain->rma_ep->remote_write_cntr)
+						psmx_cntr_inc(mr->cntr);
+				  }
 
 				  if (read_more)
 					continue;
@@ -493,8 +495,10 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 				  struct fi_context *fi_context = psm_status.context;
 				  struct psmx_fid_mr *mr;
 				  mr = PSMX_CTXT_USER(fi_context);
-				  if (mr->domain->rma_ep->remote_read_cntr)
-					psmx_cntr_inc(mr->domain->rma_ep->remote_read_cntr);
+				  if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+					  if (mr->domain->rma_ep->remote_read_cntr)
+						psmx_cntr_inc(mr->domain->rma_ep->remote_read_cntr);
+				  }
 
 				  continue;
 				}

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -152,7 +152,11 @@ static int psmx_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			return -FI_EBUSY;
 		if (mr->domain != cntr->domain)
 			return -FI_EINVAL;
-		mr->cntr = cntr;
+		if (flags) {
+			if (flags != FI_REMOTE_WRITE)
+				return -FI_EINVAL;
+			mr->cntr = cntr;
+		}
 		break;
 
 	default:

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -122,11 +122,13 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 						err = -FI_ENOMEM;
 				}
 
-				if (mr->domain->rma_ep->remote_write_cntr)
-					psmx_cntr_inc(mr->domain->rma_ep->remote_write_cntr);
+				if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+					if (mr->domain->rma_ep->remote_write_cntr)
+						psmx_cntr_inc(mr->domain->rma_ep->remote_write_cntr);
 
-				if (mr->cntr && mr->cntr != mr->domain->rma_ep->remote_write_cntr)
-					psmx_cntr_inc(mr->cntr);
+					if (mr->cntr && mr->cntr != mr->domain->rma_ep->remote_write_cntr)
+						psmx_cntr_inc(mr->cntr);
+				}
 			}
 		}
 		if (eom || op_error) {
@@ -203,8 +205,10 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				NULL, NULL );
 
 		if (eom && !op_error) {
-			if (mr->domain->rma_ep->remote_read_cntr)
-				psmx_cntr_inc(mr->domain->rma_ep->remote_read_cntr);
+			if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+				if (mr->domain->rma_ep->remote_read_cntr)
+					psmx_cntr_inc(mr->domain->rma_ep->remote_read_cntr);
+			}
 		}
 		break;
 
@@ -388,11 +392,13 @@ static ssize_t psmx_rma_self(int am_cmd,
 				err = -FI_ENOMEM;
 		}
 
-		if (cntr)
-			psmx_cntr_inc(cntr);
+		if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+			if (cntr)
+				psmx_cntr_inc(cntr);
 
-		if (mr_cntr)
-			psmx_cntr_inc(mr_cntr);
+			if (mr_cntr)
+				psmx_cntr_inc(mr_cntr);
+		}
 	}
 
 	no_event = (flags & PSMX_NO_COMPLETION) ||

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -453,14 +453,16 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 			addr += mr->offset;
 			psmx2_atomic_do_write(addr, src, datatype, op, count);
 
-			cntr = rx->ep->remote_write_cntr;
-			mr_cntr = mr->cntr;
+			if (rx->ep->caps & FI_RMA_EVENT) {
+				cntr = rx->ep->remote_write_cntr;
+				mr_cntr = mr->cntr;
 
-			if (cntr)
-				psmx2_cntr_inc(cntr, 0);
+				if (cntr)
+					psmx2_cntr_inc(cntr, 0);
 
-			if (mr_cntr && mr_cntr != cntr)
-				psmx2_cntr_inc(mr_cntr, 0);
+				if (mr_cntr && mr_cntr != cntr)
+					psmx2_cntr_inc(mr_cntr, 0);
+			}
 		}
 
 		rep_args[0].u32w0 = PSMX2_AM_REP_ATOMIC_WRITE;
@@ -499,18 +501,20 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 			else
 				op_error = -FI_ENOMEM;
 
-			if (op == FI_ATOMIC_READ) {
-				cntr = rx->ep->remote_read_cntr;
-			} else {
-				cntr = rx->ep->remote_write_cntr;
-				mr_cntr = mr->cntr;
+			if (rx->ep->caps & FI_RMA_EVENT) {
+				if (op == FI_ATOMIC_READ) {
+					cntr = rx->ep->remote_read_cntr;
+				} else {
+					cntr = rx->ep->remote_write_cntr;
+					mr_cntr = mr->cntr;
+				}
+
+				if (cntr)
+					psmx2_cntr_inc(cntr, 0);
+
+				if (mr_cntr && mr_cntr != cntr)
+					psmx2_cntr_inc(mr_cntr, 0);
 			}
-
-			if (cntr)
-				psmx2_cntr_inc(cntr, 0);
-
-			if (mr_cntr && mr_cntr != cntr)
-				psmx2_cntr_inc(mr_cntr, 0);
 		} else {
 			tmp_buf = NULL;
 		}
@@ -550,14 +554,16 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 			else
 				op_error = -FI_ENOMEM;
 
-			cntr = rx->ep->remote_write_cntr;
-			mr_cntr = mr->cntr;
+			if (rx->ep->caps & FI_RMA_EVENT) {
+				cntr = rx->ep->remote_write_cntr;
+				mr_cntr = mr->cntr;
 
-			if (cntr)
-				psmx2_cntr_inc(cntr, 0);
+				if (cntr)
+					psmx2_cntr_inc(cntr, 0);
 
-			if (mr_cntr && mr_cntr != cntr)
-				psmx2_cntr_inc(mr_cntr, 0);
+				if (mr_cntr && mr_cntr != cntr)
+					psmx2_cntr_inc(mr_cntr, 0);
+			}
 		} else {
 			tmp_buf = NULL;
 		}
@@ -733,18 +739,20 @@ static int psmx2_atomic_self(int am_cmd,
 		break;
 	}
 
-	if (op == FI_ATOMIC_READ) {
-		cntr = ep->remote_read_cntr;
-	} else {
-		cntr = ep->remote_write_cntr;
-		mr_cntr = mr->cntr;
+	if (ep->caps & FI_RMA_EVENT) {
+		if (op == FI_ATOMIC_READ) {
+			cntr = ep->remote_read_cntr;
+		} else {
+			cntr = ep->remote_write_cntr;
+			mr_cntr = mr->cntr;
+		}
+
+		if (cntr)
+			psmx2_cntr_inc(cntr, 0);
+
+		if (mr_cntr && mr_cntr != cntr)
+			psmx2_cntr_inc(mr_cntr, 0);
 	}
-
-	if (cntr)
-		psmx2_cntr_inc(cntr, 0);
-
-	if (mr_cntr && mr_cntr != cntr)
-		psmx2_cntr_inc(mr_cntr, 0);
 
 	op_error = err;
 

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -777,12 +777,14 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					}
 				}
 
-				if (am_req->ep->remote_write_cntr)
-					psmx2_cntr_inc(am_req->ep->remote_write_cntr, 0);
+				if (am_req->ep->caps & FI_RMA_EVENT) {
+					if (am_req->ep->remote_write_cntr)
+						psmx2_cntr_inc(am_req->ep->remote_write_cntr, 0);
 
-				mr = PSMX2_CTXT_USER(fi_context);
-				if (mr->cntr && mr->cntr != am_req->ep->remote_write_cntr)
-					psmx2_cntr_inc(mr->cntr, 0);
+					mr = PSMX2_CTXT_USER(fi_context);
+					if (mr->cntr && mr->cntr != am_req->ep->remote_write_cntr)
+						psmx2_cntr_inc(mr->cntr, 0);
+				}
 
 				/* NOTE: am_req->tmpbuf is unused here */
 				psmx2_am_request_free(trx_ctxt, am_req);
@@ -791,8 +793,10 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 
 			case PSMX2_REMOTE_READ_CONTEXT:
 				am_req = container_of(fi_context, struct psmx2_am_request, fi_context);
-				if (am_req->ep->remote_read_cntr)
-					psmx2_cntr_inc(am_req->ep->remote_read_cntr, 0);
+				if (am_req->ep->caps & FI_RMA_EVENT) {
+					if (am_req->ep->remote_read_cntr)
+						psmx2_cntr_inc(am_req->ep->remote_read_cntr, 0);
+				}
 
 				/* NOTE: am_req->tmpbuf is unused here */
 				psmx2_am_request_free(trx_ctxt, am_req);

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -156,8 +156,12 @@ STATIC int psmx2_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			return -FI_EBUSY;
 		if (mr->domain != cntr->domain)
 			return -FI_EINVAL;
-		mr->cntr = cntr;
-		cntr->poll_all = 1;
+		if (flags) {
+			if (flags != FI_REMOTE_WRITE)
+				return -FI_EINVAL;
+			mr->cntr = cntr;
+			cntr->poll_all = 1;
+		}
 		break;
 
 	default:

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -154,11 +154,13 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 						err = -FI_ENOMEM;
 				}
 
-				if (rx->ep->remote_write_cntr)
-					psmx2_cntr_inc(rx->ep->remote_write_cntr, 0);
+				if (rx->ep->caps & FI_RMA_EVENT) {
+					if (rx->ep->remote_write_cntr)
+						psmx2_cntr_inc(rx->ep->remote_write_cntr, 0);
 
-				if (mr->cntr && mr->cntr != rx->ep->remote_write_cntr)
-					psmx2_cntr_inc(mr->cntr, 0);
+					if (mr->cntr && mr->cntr != rx->ep->remote_write_cntr)
+						psmx2_cntr_inc(mr->cntr, 0);
+				}
 			}
 		}
 		if (eom || op_error) {
@@ -238,8 +240,10 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 				NULL, NULL );
 
 		if (eom && !op_error) {
-			if (rx->ep->remote_read_cntr)
-				psmx2_cntr_inc(rx->ep->remote_read_cntr, 0);
+			if (rx->ep->caps & FI_RMA_EVENT) {
+				if (rx->ep->remote_read_cntr)
+					psmx2_cntr_inc(rx->ep->remote_read_cntr, 0);
+			}
 		}
 		break;
 
@@ -475,11 +479,13 @@ static ssize_t psmx2_rma_self(int am_cmd,
 				err = -FI_ENOMEM;
 		}
 
-		if (cntr)
-			psmx2_cntr_inc(cntr, 0);
+		if (ep->caps & FI_RMA_EVENT) {
+			if (cntr)
+				psmx2_cntr_inc(cntr, 0);
 
-		if (mr_cntr)
-			psmx2_cntr_inc(mr_cntr, 0);
+			if (mr_cntr)
+				psmx2_cntr_inc(mr_cntr, 0);
+		}
 	}
 
 	no_event = (flags & PSMX2_NO_COMPLETION) ||


### PR DESCRIPTION
Add the missing check to ensure that target side counter update for RMA
operations only happens when the FI_RMA_EVENT capability is enabled for
the associated endpoint.

Also make sure the flags used for binding MR to counter only contains
supported values (currently only FI_REMOTE_WRITE is valid).

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>