### PR TITLE
prov/tcp: add support for getpeer() function

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -110,6 +110,11 @@ static inline int ofi_getsockname(SOCKET fd, struct sockaddr *addr, socklen_t *l
 	return getsockname(fd, addr, len);
 }
 
+static inline int ofi_getpeername(SOCKET fd, struct sockaddr *addr, socklen_t *len)
+{
+	return getpeername(fd, addr, len);
+}
+
 static inline SOCKET ofi_socket(int domain, int type, int protocol)
 {
 	return socket(domain, type, protocol);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -278,6 +278,7 @@ int fd_set_nonblock(int fd);
 int socketpair(int af, int type, int protocol, int socks[2]);
 void sock_get_ip_addr_table(struct slist *addr_list);
 int ofi_getsockname(SOCKET fd, struct sockaddr *addr, socklen_t *len);
+int ofi_getpeername(SOCKET fd, struct sockaddr *addr, socklen_t *len);
 
 /*
  * Win32 error code should be passed as a parameter.

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -483,11 +483,25 @@ static int tcpx_ep_getname(fid_t fid, void *addr, size_t *addrlen)
 	return (addrlen_in < *addrlen)? -FI_ETOOSMALL: FI_SUCCESS;
 }
 
+static int tcpx_ep_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
+{
+	struct tcpx_ep *tcpx_ep;
+	size_t addrlen_in = *addrlen;
+	int ret;
+
+	tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
+	ret = ofi_getpeername(tcpx_ep->conn_fd, addr, (socklen_t *)addrlen);
+	if (ret)
+		return -ofi_sockerr();
+
+	return (addrlen_in < *addrlen)? -FI_ETOOSMALL: FI_SUCCESS;
+}
+
 static struct fi_ops_cm tcpx_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
 	.setname = fi_no_setname,
 	.getname = tcpx_ep_getname,
-	.getpeer = fi_no_getpeer,
+	.getpeer = tcpx_ep_getpeer,
 	.connect = tcpx_ep_connect,
 	.listen = fi_no_listen,
 	.accept = tcpx_ep_accept,

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -131,6 +131,23 @@ int ofi_getsockname(SOCKET fd, struct sockaddr *addr, socklen_t *len)
 	return FI_SUCCESS;
 }
 
+int ofi_getpeername(SOCKET fd, struct sockaddr *addr, socklen_t *len)
+{
+	struct sockaddr_storage sock_addr;
+	socklen_t sock_addr_len = sizeof(sock_addr);
+	int ret;
+
+	ret = getpeername(fd, (struct sockaddr *) &sock_addr, &sock_addr_len);
+	if (ret)
+		return ret;
+
+	if (addr)
+		memcpy(addr, &sock_addr, MIN(*len, sock_addr_len));
+	*len = sock_addr_len;
+
+	return FI_SUCCESS;
+}
+
 int fi_read_file(const char *dir, const char *file, char *buf, size_t size)
 {
 	char *path = 0;


### PR DESCRIPTION
This patch adds the support of fi_getpeer() call into the
tcp provider.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>