### PR TITLE
[v1.6.x] prov/rxm: fix tx, rx and CQ sizes

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -97,6 +97,36 @@ The ofi_rxm provider checks for the following environment variables.
 : Defines the maximum number of MSG provider CQ entries (default: 1) that would
   be read per progress (RxM CQ read).
 
+*FI_OFI_RXM_TX_SIZE*
+: Defines default TX context size (default: 1024)
+
+*FI_OFI_RXM_RX_SIZE*
+: Defines default RX context size (default: 1024)
+
+*FI_OFI_RXM_MSG_TX_SIZE*
+: Defines FI_EP_MSG TX size that would be requested (default: 128).
+
+*FI_OFI_RXM_MSG_RX_SIZE*
+: Defines FI_EP_MSG RX size that would be requested (default: 128).
+
+*FI_UNIVERSE_SIZE*
+: Defines the expected number of ranks / peers an endpoint would communicate
+with (default: 256).
+
+# Tuning
+
+## Bandwidth
+
+To optimize for bandwidth, ensure you use higher values than default for
+FI_OFI_RXM_TX_SIZE, FI_OFI_RXM_RX_SIZE, FI_OFI_RXM_MSG_TX_SIZE, FI_OFI_RXM_MSG_RX_SIZE
+subject to memory limits of the system and the tx and rx sizes supported by the
+MSG provider.
+
+## Memory
+
+To conserve memory, ensure FI_UNIVERSE_SIZE set to what is required. Similarly
+check that FI_OFI_RXM_TX_SIZE, FI_OFI_RXM_RX_SIZE, FI_OFI_RXM_MSG_TX_SIZE and
+FI_OFI_RXM_MSG_RX_SIZE env variables are set to only required values.
 
 # SEE ALSO
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -105,6 +105,9 @@ extern struct util_prov rxm_util_prov;
 extern struct fi_ops_rma rxm_ops_rma;
 extern int rxm_defer_requests;
 
+extern size_t rxm_msg_tx_size;
+extern size_t rxm_msg_rx_size;
+
 struct rxm_fabric {
 	struct util_fabric util_fabric;
 	struct fid_fabric *msg_fabric;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -107,6 +107,7 @@ extern int rxm_defer_requests;
 
 extern size_t rxm_msg_tx_size;
 extern size_t rxm_msg_rx_size;
+extern size_t rxm_def_univ_size;
 
 struct rxm_fabric {
 	struct util_fabric util_fabric;

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -47,7 +47,7 @@ struct fi_tx_attr rxm_tx_attr = {
 	.caps = RXM_EP_CAPS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = SIZE_MAX,
+	.size = 1024,
 	.iov_limit = RXM_IOV_LIMIT,
 	.rma_iov_limit = RXM_IOV_LIMIT,
 };
@@ -56,7 +56,7 @@ struct fi_rx_attr rxm_rx_attr = {
 	.caps = RXM_EP_CAPS | FI_MULTI_RECV,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = SIZE_MAX,
+	.size = 1024,
 	.iov_limit= RXM_IOV_LIMIT,
 };
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1488,8 +1488,8 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep, enum fi_wait_obj wait_obj)
 
 	assert((wait_obj == FI_WAIT_NONE) || (wait_obj == FI_WAIT_FD));
 
-	cq_attr.size = (rxm_ep->rxm_info->tx_attr->size +
-			rxm_ep->rxm_info->rx_attr->size);
+	cq_attr.size = (rxm_ep->msg_info->tx_attr->size +
+			rxm_ep->msg_info->rx_attr->size) * rxm_def_univ_size;
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = wait_obj;
 

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -41,6 +41,7 @@
 int rxm_defer_requests = 0;
 size_t rxm_msg_tx_size		= 128;
 size_t rxm_msg_rx_size		= 128;
+size_t rxm_def_univ_size	= 256;
 
 char *rxm_proto_state_str[] = {
 	RXM_PROTO_STATES(OFI_STR)
@@ -325,6 +326,7 @@ RXM_INI
 	fi_param_get_size_t(&rxm_prov, "rx_size", &rxm_info.rx_attr->size);
 	fi_param_get_size_t(&rxm_prov, "msg_tx_size", &rxm_msg_tx_size);
 	fi_param_get_size_t(&rxm_prov, "msg_rx_size", &rxm_msg_rx_size);
+	fi_param_get_size_t(NULL, "universe_size", &rxm_def_univ_size);
 
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");


### PR DESCRIPTION
This PR has the following fixes cherry-picked from master (#4332 ):

- prov/rxm: make tx, rx queue sizes independent of MSG provider
- prov/rxm: define default rxm univ size and use it for calculating MSG CQ size
- prov/rxm: man page updates

