### PR TITLE
util/recvwin: Fix write index to be within bound

### DIFF
--- a/include/ofi_recvwin.h
+++ b/include/ofi_recvwin.h
@@ -79,8 +79,9 @@ ofi_recvwin_queue_msg(struct name *recvq, entrytype * msg, uint64_t id)	\
 	int write_idx;							\
 									\
 	assert(ofi_recvwin_is_allowed(recvq, id));			\
-	write_idx = ofi_cirque_rindex(recvq->pending)			\
-		    + (id - recvq->exp_msg_id);				\
+	write_idx = (ofi_cirque_rindex(recvq->pending)			\
+		    + (id - recvq->exp_msg_id))				\
+		    & recvq->pending->size_mask;			\
 	recvq->pending->buf[write_idx] = *msg;				\
 	ofi_cirque_commit(recvq->pending);				\
 	return 0;							\


### PR DESCRIPTION
Add size mask in generating write index, else write
index can fall out of bound.

Change-Id: Ia0a55b92e444a4d1c7fc71b8c239dcbb4b569611
Signed-off-by: Mohan Gandhi <mohgan@amazon.com>