### PR TITLE
prov/rxm: Close MSG EPs in the application thread

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -417,6 +417,11 @@ struct rxm_buf_pool {
 	fastlock_t lock;
 };
 
+struct rxm_msg_ep_entry {
+	struct dlist_entry list_entry;
+	struct fid_ep *msg_ep;
+};
+
 struct rxm_ep {
 	struct util_ep 		util_ep;
 	struct fi_info 		*rxm_info;
@@ -448,6 +453,8 @@ struct rxm_ep {
 	struct rxm_send_queue	*send_queue;
 	struct rxm_recv_queue	recv_queue;
 	struct rxm_recv_queue	trecv_queue;
+
+	struct dlist_entry	close_ready_msg_eps;
 
 	ofi_fastlock_acquire_t	res_fastlock_acquire;
 	ofi_fastlock_release_t	res_fastlock_release;
@@ -494,6 +501,8 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  struct fid_ep **ep, void *context);
 
 struct util_cmap *rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep);
+void rxm_conn_save_msg_ep(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn);
+void rxm_conn_close_saved_msg_ep(struct rxm_msg_ep_entry *entry);
 void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 			void *op_context, int err);
 void rxm_ep_progress_one(struct util_ep *util_ep);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1616,6 +1616,7 @@ static int rxm_ep_close(struct fid *fid)
 		container_of(fid, struct rxm_ep, util_ep.ep_fid.fid);
 	struct rxm_ep_wait_ref *wait_ref;
 	struct dlist_entry *tmp_list_entry;
+	struct rxm_msg_ep_entry *entry;
 
 	dlist_foreach_container_safe(&rxm_ep->msg_cq_fd_ref_list,
 				     struct rxm_ep_wait_ref,
@@ -1631,6 +1632,12 @@ static int rxm_ep_close(struct fid *fid)
 
 	if (rxm_ep->util_ep.cmap)
 		ofi_cmap_free(rxm_ep->util_ep.cmap);
+
+	dlist_foreach_container_safe(&rxm_ep->close_ready_msg_eps,
+				     struct rxm_msg_ep_entry, entry,
+				     list_entry, tmp_list_entry) {
+		rxm_conn_close_saved_msg_ep(entry);
+	}
 
 	ret = rxm_listener_close(rxm_ep);
 	if (ret)
@@ -2083,6 +2090,8 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ret = rxm_ep_msg_res_open(rxm_ep);
 	if (ret)
 		goto err2;
+
+	dlist_init(&rxm_ep->close_ready_msg_eps);
 
 	rxm_ep->msg_mr_local = ofi_mr_local(rxm_ep->msg_info);
 	rxm_ep->rxm_mr_local = ofi_mr_local(rxm_ep->rxm_info);


### PR DESCRIPTION
This patch moves logic that closes MSG EPs from the CM thread
(rxm_conn_close/rxm_conn_free) to the application thread in order
to not operate with MSG provider resources from different threads.

This gives possibility to use OFI/rxm/verbs stack with
MLX5(4)_SINGLE_THREADED=1 env enabled.

The list of the MSG EPs is cleaned in the application thread when the
application thread becomes aware of an established connection and
when the application is closing RxM EP. So, both these places make sure
that all MSG EPs are closed.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>