### PR TITLE
v1.6.x: cherry-picked fixes for psm and psm2

### DIFF
--- a/prov/psm/src/psmx_atomic.c
+++ b/prov/psm/src/psmx_atomic.c
@@ -409,14 +409,16 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 			psmx_atomic_do_write(addr, src, datatype, op, count);
 
 			target_ep = mr->domain->atomics_ep;
-			cntr = target_ep->remote_write_cntr;
-			mr_cntr = mr->cntr;
+			if (target_ep->caps & FI_RMA_EVENT) {
+				cntr = target_ep->remote_write_cntr;
+				mr_cntr = mr->cntr;
 
-			if (cntr)
-				psmx_cntr_inc(cntr);
+				if (cntr)
+					psmx_cntr_inc(cntr);
 
-			if (mr_cntr && mr_cntr != cntr)
-				psmx_cntr_inc(mr_cntr);
+				if (mr_cntr && mr_cntr != cntr)
+					psmx_cntr_inc(mr_cntr);
+			}
 		}
 
 		rep_args[0].u32w0 = PSMX_AM_REP_ATOMIC_WRITE;
@@ -454,18 +456,20 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				op_error = -FI_ENOMEM;
 
 			target_ep = mr->domain->atomics_ep;
-			if (op == FI_ATOMIC_READ) {
-				cntr = target_ep->remote_read_cntr;
-			} else {
-				cntr = target_ep->remote_write_cntr;
-				mr_cntr = mr->cntr;
+			if (target_ep->caps & FI_RMA_EVENT) {
+				if (op == FI_ATOMIC_READ) {
+					cntr = target_ep->remote_read_cntr;
+				} else {
+					cntr = target_ep->remote_write_cntr;
+					mr_cntr = mr->cntr;
+				}
+
+				if (cntr)
+					psmx_cntr_inc(cntr);
+
+				if (mr_cntr && mr_cntr != cntr)
+					psmx_cntr_inc(mr_cntr);
 			}
-
-			if (cntr)
-				psmx_cntr_inc(cntr);
-
-			if (mr_cntr && mr_cntr != cntr)
-				psmx_cntr_inc(mr_cntr);
 		} else {
 			tmp_buf = NULL;
 		}
@@ -502,14 +506,16 @@ int psmx_am_atomic_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				op_error = -FI_ENOMEM;
 
 			target_ep = mr->domain->atomics_ep;
-			cntr = target_ep->remote_write_cntr;
-			mr_cntr = mr->cntr;
+			if (target_ep->caps & FI_RMA_EVENT) {
+				cntr = target_ep->remote_write_cntr;
+				mr_cntr = mr->cntr;
 
-			if (cntr)
-				psmx_cntr_inc(cntr);
+				if (cntr)
+					psmx_cntr_inc(cntr);
 
-			if (mr_cntr && mr_cntr != cntr)
-				psmx_cntr_inc(mr_cntr);
+				if (mr_cntr && mr_cntr != cntr)
+					psmx_cntr_inc(mr_cntr);
+			}
 		} else {
 			tmp_buf = NULL;
 		}
@@ -679,18 +685,20 @@ static int psmx_atomic_self(int am_cmd,
 	}
 
 	target_ep = mr->domain->atomics_ep;
-	if (op == FI_ATOMIC_READ) {
-		cntr = target_ep->remote_read_cntr;
-	} else {
-		cntr = target_ep->remote_write_cntr;
-		mr_cntr = mr->cntr;
+	if (target_ep->caps & FI_RMA_EVENT) {
+		if (op == FI_ATOMIC_READ) {
+			cntr = target_ep->remote_read_cntr;
+		} else {
+			cntr = target_ep->remote_write_cntr;
+			mr_cntr = mr->cntr;
+		}
+
+		if (cntr)
+			psmx_cntr_inc(cntr);
+
+		if (mr_cntr && mr_cntr != cntr)
+			psmx_cntr_inc(mr_cntr);
 	}
-
-	if (cntr)
-		psmx_cntr_inc(cntr);
-
-	if (mr_cntr && mr_cntr != cntr)
-		psmx_cntr_inc(mr_cntr);
 
 gen_local_event:
 	no_event = ((flags & PSMX_NO_COMPLETION) ||

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -642,6 +642,7 @@ static ssize_t psmx_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 
 	cq_priv = container_of(cq, struct psmx_fid_cq, cq);
 
+	fastlock_acquire(&cq_priv->lock);
 	if (cq_priv->pending_error) {
 		api_version = cq_priv->domain->fabric->util_fabric.
 			      fabric_fid.api_version;
@@ -651,8 +652,10 @@ static ssize_t psmx_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 		memcpy(buf, &cq_priv->pending_error->cqe, size);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
+		fastlock_release(&cq_priv->lock);
 		return 1;
 	}
+	fastlock_release(&cq_priv->lock);
 
 	return -FI_EAGAIN;
 }

--- a/prov/psm/src/psmx_cq.c
+++ b/prov/psm/src/psmx_cq.c
@@ -476,11 +476,13 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 					}
 				  }
 
-				  if (mr->domain->rma_ep->remote_write_cntr)
-					psmx_cntr_inc(mr->domain->rma_ep->remote_write_cntr);
+				  if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+					  if (mr->domain->rma_ep->remote_write_cntr)
+						psmx_cntr_inc(mr->domain->rma_ep->remote_write_cntr);
 
-				  if (mr->cntr && mr->cntr != mr->domain->rma_ep->remote_write_cntr)
-					psmx_cntr_inc(mr->cntr);
+					  if (mr->cntr && mr->cntr != mr->domain->rma_ep->remote_write_cntr)
+						psmx_cntr_inc(mr->cntr);
+				  }
 
 				  if (read_more)
 					continue;
@@ -493,8 +495,10 @@ int psmx_cq_poll_mq(struct psmx_fid_cq *cq, struct psmx_fid_domain *domain,
 				  struct fi_context *fi_context = psm_status.context;
 				  struct psmx_fid_mr *mr;
 				  mr = PSMX_CTXT_USER(fi_context);
-				  if (mr->domain->rma_ep->remote_read_cntr)
-					psmx_cntr_inc(mr->domain->rma_ep->remote_read_cntr);
+				  if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+					  if (mr->domain->rma_ep->remote_read_cntr)
+						psmx_cntr_inc(mr->domain->rma_ep->remote_read_cntr);
+				  }
 
 				  continue;
 				}

--- a/prov/psm/src/psmx_mr.c
+++ b/prov/psm/src/psmx_mr.c
@@ -152,7 +152,11 @@ static int psmx_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			return -FI_EBUSY;
 		if (mr->domain != cntr->domain)
 			return -FI_EINVAL;
-		mr->cntr = cntr;
+		if (flags) {
+			if (flags != FI_REMOTE_WRITE)
+				return -FI_EINVAL;
+			mr->cntr = cntr;
+		}
 		break;
 
 	default:

--- a/prov/psm/src/psmx_rma.c
+++ b/prov/psm/src/psmx_rma.c
@@ -122,11 +122,13 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 						err = -FI_ENOMEM;
 				}
 
-				if (mr->domain->rma_ep->remote_write_cntr)
-					psmx_cntr_inc(mr->domain->rma_ep->remote_write_cntr);
+				if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+					if (mr->domain->rma_ep->remote_write_cntr)
+						psmx_cntr_inc(mr->domain->rma_ep->remote_write_cntr);
 
-				if (mr->cntr && mr->cntr != mr->domain->rma_ep->remote_write_cntr)
-					psmx_cntr_inc(mr->cntr);
+					if (mr->cntr && mr->cntr != mr->domain->rma_ep->remote_write_cntr)
+						psmx_cntr_inc(mr->cntr);
+				}
 			}
 		}
 		if (eom || op_error) {
@@ -203,8 +205,10 @@ int psmx_am_rma_handler(psm_am_token_t token, psm_epaddr_t epaddr,
 				NULL, NULL );
 
 		if (eom && !op_error) {
-			if (mr->domain->rma_ep->remote_read_cntr)
-				psmx_cntr_inc(mr->domain->rma_ep->remote_read_cntr);
+			if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+				if (mr->domain->rma_ep->remote_read_cntr)
+					psmx_cntr_inc(mr->domain->rma_ep->remote_read_cntr);
+			}
 		}
 		break;
 
@@ -388,11 +392,13 @@ static ssize_t psmx_rma_self(int am_cmd,
 				err = -FI_ENOMEM;
 		}
 
-		if (cntr)
-			psmx_cntr_inc(cntr);
+		if (mr->domain->rma_ep->caps & FI_RMA_EVENT) {
+			if (cntr)
+				psmx_cntr_inc(cntr);
 
-		if (mr_cntr)
-			psmx_cntr_inc(mr_cntr);
+			if (mr_cntr)
+				psmx_cntr_inc(mr_cntr);
+		}
 	}
 
 	no_event = (flags & PSMX_NO_COMPLETION) ||

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -930,6 +930,9 @@ int	psmx2_av_add_trx_ctxt(struct psmx2_fid_av *av, struct psmx2_trx_ctxt *trx_ct
 psm2_epaddr_t psmx2_av_translate_sep(struct psmx2_fid_av *av,
 				     struct psmx2_trx_ctxt *trx_ctxt, fi_addr_t addr);
 
+void	psmx2_av_remove_conn(struct psmx2_fid_av *av, struct psmx2_trx_ctxt *trx_ctxt,
+			     psm2_epaddr_t epaddr);
+
 static inline int psmx2_av_check_table_idx(struct psmx2_fid_av *av,
 					   struct psmx2_trx_ctxt *trx_ctxt,
 					   size_t idx)

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -453,14 +453,16 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 			addr += mr->offset;
 			psmx2_atomic_do_write(addr, src, datatype, op, count);
 
-			cntr = rx->ep->remote_write_cntr;
-			mr_cntr = mr->cntr;
+			if (rx->ep->caps & FI_RMA_EVENT) {
+				cntr = rx->ep->remote_write_cntr;
+				mr_cntr = mr->cntr;
 
-			if (cntr)
-				psmx2_cntr_inc(cntr, 0);
+				if (cntr)
+					psmx2_cntr_inc(cntr, 0);
 
-			if (mr_cntr && mr_cntr != cntr)
-				psmx2_cntr_inc(mr_cntr, 0);
+				if (mr_cntr && mr_cntr != cntr)
+					psmx2_cntr_inc(mr_cntr, 0);
+			}
 		}
 
 		rep_args[0].u32w0 = PSMX2_AM_REP_ATOMIC_WRITE;
@@ -499,18 +501,20 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 			else
 				op_error = -FI_ENOMEM;
 
-			if (op == FI_ATOMIC_READ) {
-				cntr = rx->ep->remote_read_cntr;
-			} else {
-				cntr = rx->ep->remote_write_cntr;
-				mr_cntr = mr->cntr;
+			if (rx->ep->caps & FI_RMA_EVENT) {
+				if (op == FI_ATOMIC_READ) {
+					cntr = rx->ep->remote_read_cntr;
+				} else {
+					cntr = rx->ep->remote_write_cntr;
+					mr_cntr = mr->cntr;
+				}
+
+				if (cntr)
+					psmx2_cntr_inc(cntr, 0);
+
+				if (mr_cntr && mr_cntr != cntr)
+					psmx2_cntr_inc(mr_cntr, 0);
 			}
-
-			if (cntr)
-				psmx2_cntr_inc(cntr, 0);
-
-			if (mr_cntr && mr_cntr != cntr)
-				psmx2_cntr_inc(mr_cntr, 0);
 		} else {
 			tmp_buf = NULL;
 		}
@@ -550,14 +554,16 @@ int psmx2_am_atomic_handler(psm2_am_token_t token,
 			else
 				op_error = -FI_ENOMEM;
 
-			cntr = rx->ep->remote_write_cntr;
-			mr_cntr = mr->cntr;
+			if (rx->ep->caps & FI_RMA_EVENT) {
+				cntr = rx->ep->remote_write_cntr;
+				mr_cntr = mr->cntr;
 
-			if (cntr)
-				psmx2_cntr_inc(cntr, 0);
+				if (cntr)
+					psmx2_cntr_inc(cntr, 0);
 
-			if (mr_cntr && mr_cntr != cntr)
-				psmx2_cntr_inc(mr_cntr, 0);
+				if (mr_cntr && mr_cntr != cntr)
+					psmx2_cntr_inc(mr_cntr, 0);
+			}
 		} else {
 			tmp_buf = NULL;
 		}
@@ -733,18 +739,20 @@ static int psmx2_atomic_self(int am_cmd,
 		break;
 	}
 
-	if (op == FI_ATOMIC_READ) {
-		cntr = ep->remote_read_cntr;
-	} else {
-		cntr = ep->remote_write_cntr;
-		mr_cntr = mr->cntr;
+	if (ep->caps & FI_RMA_EVENT) {
+		if (op == FI_ATOMIC_READ) {
+			cntr = ep->remote_read_cntr;
+		} else {
+			cntr = ep->remote_write_cntr;
+			mr_cntr = mr->cntr;
+		}
+
+		if (cntr)
+			psmx2_cntr_inc(cntr, 0);
+
+		if (mr_cntr && mr_cntr != cntr)
+			psmx2_cntr_inc(mr_cntr, 0);
 	}
-
-	if (cntr)
-		psmx2_cntr_inc(cntr, 0);
-
-	if (mr_cntr && mr_cntr != cntr)
-		psmx2_cntr_inc(mr_cntr, 0);
 
 	op_error = err;
 

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -832,6 +832,35 @@ fi_addr_t psmx2_av_translate_source(struct psmx2_fid_av *av, fi_addr_t source)
 	return ret;
 }
 
+void psmx2_av_remove_conn(struct psmx2_fid_av *av,
+			  struct psmx2_trx_ctxt *trx_ctxt,
+			  psm2_epaddr_t epaddr)
+{
+	psm2_epid_t epid;
+	int i, j;
+
+	psm2_epaddr_to_epid(epaddr, &epid);
+
+	psmx2_lock(&av->lock, 1);
+
+	for (i = 0; i < av->last; i++) {
+		if (av->peers[i].type == PSMX2_EP_REGULAR) {
+			if (av->epids[i] == epid &&
+			    av->tables[trx_ctxt->id].epaddrs[i] == epaddr)
+				av->tables[trx_ctxt->id].epaddrs[i] = NULL;
+		} else {
+			for (j=0; j<av->peers[i].sep_ctxt_cnt; j++) {
+				if (av->peers[i].sep_ctxt_epids[j] == epid &&
+				    av->tables[trx_ctxt->id].sepaddrs[i] &&
+				    av->tables[trx_ctxt->id].sepaddrs[i][j] == epaddr)
+					    av->tables[trx_ctxt->id].sepaddrs[i][j] = NULL;
+			}
+		}
+	}
+
+	psmx2_unlock(&av->lock, 1);
+}
+
 static const char *psmx2_av_straddr(struct fid_av *av, const void *addr,
 				    char *buf, size_t *len)
 {

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -777,12 +777,14 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					}
 				}
 
-				if (am_req->ep->remote_write_cntr)
-					psmx2_cntr_inc(am_req->ep->remote_write_cntr, 0);
+				if (am_req->ep->caps & FI_RMA_EVENT) {
+					if (am_req->ep->remote_write_cntr)
+						psmx2_cntr_inc(am_req->ep->remote_write_cntr, 0);
 
-				mr = PSMX2_CTXT_USER(fi_context);
-				if (mr->cntr && mr->cntr != am_req->ep->remote_write_cntr)
-					psmx2_cntr_inc(mr->cntr, 0);
+					mr = PSMX2_CTXT_USER(fi_context);
+					if (mr->cntr && mr->cntr != am_req->ep->remote_write_cntr)
+						psmx2_cntr_inc(mr->cntr, 0);
+				}
 
 				/* NOTE: am_req->tmpbuf is unused here */
 				psmx2_am_request_free(trx_ctxt, am_req);
@@ -791,8 +793,10 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 
 			case PSMX2_REMOTE_READ_CONTEXT:
 				am_req = container_of(fi_context, struct psmx2_am_request, fi_context);
-				if (am_req->ep->remote_read_cntr)
-					psmx2_cntr_inc(am_req->ep->remote_read_cntr, 0);
+				if (am_req->ep->caps & FI_RMA_EVENT) {
+					if (am_req->ep->remote_read_cntr)
+						psmx2_cntr_inc(am_req->ep->remote_read_cntr, 0);
+				}
 
 				/* NOTE: am_req->tmpbuf is unused here */
 				psmx2_am_request_free(trx_ctxt, am_req);

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -1043,6 +1043,7 @@ static ssize_t psmx2_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 
 	cq_priv = container_of(cq, struct psmx2_fid_cq, cq);
 
+	psmx2_lock(&cq_priv->lock, 2);
 	if (cq_priv->pending_error) {
 		api_version = cq_priv->domain->fabric->util_fabric.
 			      fabric_fid.api_version;
@@ -1052,8 +1053,10 @@ static ssize_t psmx2_cq_readerr(struct fid_cq *cq, struct fi_cq_err_entry *buf,
 		memcpy(buf, &cq_priv->pending_error->cqe, size);
 		free(cq_priv->pending_error);
 		cq_priv->pending_error = NULL;
+		psmx2_unlock(&cq_priv->lock, 2);
 		return 1;
 	}
+	psmx2_unlock(&cq_priv->lock, 2);
 
 	return -FI_EAGAIN;
 }

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -155,8 +155,12 @@ static int psmx2_mr_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			return -FI_EBUSY;
 		if (mr->domain != cntr->domain)
 			return -FI_EINVAL;
-		mr->cntr = cntr;
-		cntr->poll_all = 1;
+		if (flags) {
+			if (flags != FI_REMOTE_WRITE)
+				return -FI_EINVAL;
+			mr->cntr = cntr;
+			cntr->poll_all = 1;
+		}
 		break;
 
 	default:

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -154,11 +154,13 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 						err = -FI_ENOMEM;
 				}
 
-				if (rx->ep->remote_write_cntr)
-					psmx2_cntr_inc(rx->ep->remote_write_cntr, 0);
+				if (rx->ep->caps & FI_RMA_EVENT) {
+					if (rx->ep->remote_write_cntr)
+						psmx2_cntr_inc(rx->ep->remote_write_cntr, 0);
 
-				if (mr->cntr && mr->cntr != rx->ep->remote_write_cntr)
-					psmx2_cntr_inc(mr->cntr, 0);
+					if (mr->cntr && mr->cntr != rx->ep->remote_write_cntr)
+						psmx2_cntr_inc(mr->cntr, 0);
+				}
 			}
 		}
 		if (eom || op_error) {
@@ -238,8 +240,10 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 				NULL, NULL );
 
 		if (eom && !op_error) {
-			if (rx->ep->remote_read_cntr)
-				psmx2_cntr_inc(rx->ep->remote_read_cntr, 0);
+			if (rx->ep->caps & FI_RMA_EVENT) {
+				if (rx->ep->remote_read_cntr)
+					psmx2_cntr_inc(rx->ep->remote_read_cntr, 0);
+			}
 		}
 		break;
 
@@ -475,11 +479,13 @@ static ssize_t psmx2_rma_self(int am_cmd,
 				err = -FI_ENOMEM;
 		}
 
-		if (cntr)
-			psmx2_cntr_inc(cntr, 0);
+		if (ep->caps & FI_RMA_EVENT) {
+			if (cntr)
+				psmx2_cntr_inc(cntr, 0);
 
-		if (mr_cntr)
-			psmx2_cntr_inc(mr_cntr, 0);
+			if (mr_cntr)
+				psmx2_cntr_inc(mr_cntr, 0);
+		}
 	}
 
 	no_event = (flags & PSMX2_NO_COMPLETION) ||

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -100,6 +100,8 @@ int psmx2_am_trx_ctxt_handler(psm2_am_token_t token, psm2_amarg_t *args,
 			dlist_remove_first_match(&trx_ctxt->peer_list,
 						 psmx2_peer_match, epaddr);
 			psmx2_unlock(&trx_ctxt->peer_lock, 2);
+			if (trx_ctxt->ep && trx_ctxt->ep->av)
+				psmx2_av_remove_conn(trx_ctxt->ep->av, trx_ctxt, epaddr);
 			disconn->ep = trx_ctxt->psm2_ep;
 			disconn->epaddr = epaddr;
 			pthread_create(&disconnect_thread, NULL,


### PR DESCRIPTION
* prov/psm,psm2: Enforce FI_RMA_EVENT checking when updating counters
* prov/psm2: Remove stale info from address vector when disconnecting
* prov/psm,psm2: Fix race condition in fi_cq_readerr()
