### PR TITLE
 prov/psm2, sockets: Adjust maximum message sizes

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -109,7 +109,7 @@ extern struct fi_provider psmx2_prov;
 #define PSMX2_DOM_CAPS	(FI_LOCAL_COMM | FI_REMOTE_COMM)
 
 #define PSMX2_ALL_TRX_CTXT	((void *)-1)
-#define PSMX2_MAX_MSG_SIZE	((0x1ULL << 32) - 1)
+#define PSMX2_MAX_MSG_SIZE	((0x1ULL << 32) - 8192) /* 8k allocated for all psm2 library headers */
 #define PSMX2_RMA_ORDER_SIZE	(4096)
 #define PSMX2_MSG_ORDER		(FI_ORDER_SAS | FI_ORDER_RAR | FI_ORDER_RAW | \
 				 FI_ORDER_WAR | FI_ORDER_WAW)

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -64,7 +64,7 @@
 #ifndef _SOCK_H_
 #define _SOCK_H_
 
-#define SOCK_EP_MAX_MSG_SZ (1<<23)
+#define SOCK_EP_MAX_MSG_SZ (SIZE_MAX - 4096) /* 4k allocated for all sockets headers */
 #define SOCK_EP_MAX_INJECT_SZ ((1<<8) - 1)
 #define SOCK_EP_MAX_BUFF_RECV (1<<26)
 #define SOCK_EP_MAX_ORDER_RAW_SZ SOCK_EP_MAX_MSG_SZ


### PR DESCRIPTION
- prov/sockets: Increase maximum message size
- prov/psm2: Adjust psm2 maximum message size to consider libpsm2 headers