### PR TITLE
prov/tcp: remove socket from the eq wait list when closing the endpoint

### DIFF
--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -539,6 +539,9 @@ static int tcpx_ep_close(struct fid *fid)
 
 	tcpx_ep_tx_rx_queues_release(ep);
 	tcpx_cq_wait_ep_del(ep);
+	if (ep->util_ep.eq->wait)
+		ofi_wait_fd_del(ep->util_ep.eq->wait, ep->conn_fd);
+
 	ofi_close_socket(ep->conn_fd);
 	ofi_endpoint_close(&ep->util_ep);
 	fastlock_destroy(&ep->lock);


### PR DESCRIPTION
During connection management, the socket gets added to the eq wait list for processing connreq send, connreq responses. So when the endpoint is being closed, we should remove the socket from the eq wait list.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>