### PR TITLE
prov/rxm: Allocate TX queues per connectio with size based on MSG TX queue

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -256,7 +256,7 @@ static struct util_cmap_handle *rxm_conn_alloc(struct util_cmap *cmap)
 	if (OFI_UNLIKELY(!rxm_conn))
 		return NULL;
 	ret = rxm_conn_send_queue_init(rxm_ep, rxm_conn,
-				       rxm_ep->rxm_info->tx_attr->size);
+				       rxm_ep->msg_info->tx_attr->size);
 	if (ret) {
 		free(rxm_conn);
 		return NULL;


### PR DESCRIPTION
When used fair TX queues, RxM must allocate TX queues with size not greater
than can be transmitted via MSG provider's TX queue.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>