### PR TITLE
prov/rxm: Refactor SAR

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -103,7 +103,7 @@ static int rxm_finish_buf_recv(struct rxm_rx_buf *rx_buf)
 {
 	uint64_t flags = rx_buf->pkt.hdr.flags | FI_RECV;
 
-	assert(rx_buf->pkt.hdr.size <= rx_buf->ep->sar_limit);
+	assert(rx_buf->pkt.hdr.size <= rx_buf->ep->sar.limit);
 
 	if (rx_buf->pkt.hdr.size > rx_buf->ep->rxm_info->tx_attr->inject_size)
 		flags |= FI_MORE;


### PR DESCRIPTION
The patch moves calculations of SAR segments count to the layer that
issues SAR transmissions. It helps to know how much segements are needed
to send full message before we issued rxm_ep_sar_tx_send().
The functionality will be used to check the number of free entries in the MSG
provider's TX queue and RxM will decide which protocl should be used - SAR
or Rendezvous.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>