### PR TITLE
prov/verbs: Fix bad fallthrough

### DIFF
--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -71,6 +71,8 @@ static int fi_ibv_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 			assert(0);
 			return -FI_EINVAL;
 		}
+		break;
+
 	default:
 		return -EINVAL;
 	}


### PR DESCRIPTION
Found by gcc-8.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>