### PR TITLE
osd, prov/sockets: Define the maximum socket buffer size

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -79,6 +79,8 @@
 #define OFI_SOCK_TRY_CONN_AGAIN(err)	\
 	((err) == EINPROGRESS)
 
+#define OFI_MAX_SOCKET_BUF_SIZE	SIZE_MAX
+
 struct util_shm
 {
 	int		shared_fd;

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -40,6 +40,8 @@
 extern "C" {
 #endif
 
+#define OFI_MAX_SOCKET_BUF_SIZE	INT_MAX
+
 /*
  * The following defines redefine the Windows Socket
  * errors as BSD errors.

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -64,7 +64,8 @@
 #ifndef _SOCK_H_
 #define _SOCK_H_
 
-#define SOCK_EP_MAX_MSG_SZ (SIZE_MAX - 4096) /* 4k allocated for all sockets headers */
+/* 4k allocated for all sockets headers */
+#define SOCK_EP_MAX_MSG_SZ (OFI_MAX_SOCKET_BUF_SIZE - 4096)
 #define SOCK_EP_MAX_INJECT_SZ ((1<<8) - 1)
 #define SOCK_EP_MAX_BUFF_RECV (1<<26)
 #define SOCK_EP_MAX_ORDER_RAW_SZ SOCK_EP_MAX_MSG_SZ


### PR DESCRIPTION
WinSockAPI and BSD Sockets have a different type of length parameter for their
send/recv functions. WinSockAPI uses int, BSD Sockets uses size_t.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>