### PR TITLE
prov/rxm: Improve Rendezvous protocol

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -376,10 +376,11 @@ ssize_t rxm_cq_handle_large_data(struct rxm_rx_buf *rx_buf)
 	rx_buf->rma_iov_index = 0;
 
 	if (!rx_buf->ep->rxm_mr_local) {
-		ret = rxm_ep_msg_mr_regv(rx_buf->ep,
-					 rx_buf->recv_entry->rxm_iov.iov,
-					 rx_buf->recv_entry->rxm_iov.count,
-					 FI_READ, rx_buf->mr);
+		ret = rxm_ep_msg_mr_regv_lim(rx_buf->ep,
+					     rx_buf->recv_entry->rxm_iov.iov,
+					     rx_buf->recv_entry->rxm_iov.count,
+					     rx_buf->pkt.hdr.size,
+					     FI_READ, rx_buf->mr);
 		if (OFI_UNLIKELY(ret))
 			return ret;
 


### PR DESCRIPTION
RxM on the receiver side registers the MR for the receiver's I/O vector with
the total length of the I/O vector entries when the LMT request is received.
This patch changes behavior to register the MR for the receiver's I/O vector
with the length received from the LMT request (sender's I/O vector total length).

So, this reduces registration time of the MR in the following case (just an example):

Sender side:
fi_send(buf, 1000); -> fi_cq_read();
Receiver side:
fi_recv(buf, 10000000); -> fi_cq_read();

w/ the patch:
RxM will register MR with length = 1000 on the sender and receiver sides.

w/o the patch:
RxM will register MR with length = 1000 on the sender side and 10000000 -
on the receiver side.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>