### PR TITLE
prov/rstream: poll 2 cq.fds model

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -570,6 +570,8 @@ enum {
 	FI_SETOPSFLAG,		/* uint64_t flags */
 	FI_ALIAS,		/* struct fi_alias * */
 	FI_GETWAIT,		/* void * wait object */
+	FI_TX_GETWAIT,		/* void * wait tx object */
+	FI_RX_GETWAIT,		/* void * wait rx object */
 	FI_ENABLE,		/* NULL */
 	FI_BACKLOG,		/* integer * */
 	FI_GET_RAW_MR,		/* fi_mr_raw_attr */

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -41,6 +41,10 @@
 extern "C" {
 #endif
 
+struct fi_ctrl_args {
+	void *args;
+	int *num_args;
+};
 
 struct fi_msg {
 	const struct iovec	*msg_iov;

--- a/prov/rstream/src/rstream.h
+++ b/prov/rstream/src/rstream.h
@@ -125,6 +125,8 @@ struct rstream_ep {
 	struct rstream_rmr_data remote_data;
 	struct fid_cq *recv_cq;
 	struct fid_cq *send_cq;
+	int rcqfd;
+	int scqfd;
 	struct rstream_window qp_win;
 	struct fi_context *rx_ctxs;
 	uint32_t rx_ctx_index;
@@ -154,6 +156,11 @@ struct rstream_timer {
 
 extern ssize_t rstream_post_cq_data_recv(struct rstream_ep *ep,
 	const struct fi_cq_data_entry *cq_entry);
+
+extern int rstream_can_send_tx(struct rstream_ep *ep);
+extern int rstream_can_send_rx(struct rstream_ep *ep);
+extern int rstream_can_recv_tx(struct rstream_ep *ep);
+extern int rstream_can_recv_rx(struct rstream_ep *ep);
 
 extern int rstream_info_to_rstream(uint32_t version, const struct fi_info *core_info,
 	struct fi_info *info);

--- a/prov/rstream/src/rstream_fabric.c
+++ b/prov/rstream/src/rstream_fabric.c
@@ -24,6 +24,32 @@ static int rstream_control(struct fid *fid, int command, void *arg)
 	return -FI_ENOSYS;
 }
 
+int rstream_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+{
+	int ret;
+	struct rstream_ep *rstream_ep;
+	struct rstream_fabric *rstream_fabric;
+	int num_fids = 2;
+	struct fid *rstream_fids[num_fids];
+
+	if (count != 1)
+		return -FI_ENOSYS;
+
+	if (fids[0]->fclass == FI_CLASS_EP) {
+		rstream_ep = container_of(fids[0], struct rstream_ep,
+			util_ep.ep_fid.fid);
+		rstream_fabric = container_of(fabric, struct rstream_fabric,
+			util_fabric.fabric_fid);
+		rstream_fids[0] = &rstream_ep->send_cq->fid;
+		rstream_fids[1] = &rstream_ep->recv_cq->fid;
+		ret = fi_trywait(rstream_fabric->msg_fabric, rstream_fids,
+			num_fids);
+		return ret;
+	}
+
+	return -FI_EINVAL;
+}
+
 static struct fi_ops rstream_fabric_fi_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = rstream_fabric_close,
@@ -38,7 +64,7 @@ static struct fi_ops_fabric rstream_fabric_ops = {
 	.passive_ep = rstream_passive_ep,
 	.eq_open = rstream_eq_open,
 	.wait_open = fi_no_wait_open,
-	.trywait = ofi_trywait
+	.trywait = rstream_trywait
 };
 
 int rstream_fabric_open(struct fi_fabric_attr *attr, struct fid_fabric **fabric,


### PR DESCRIPTION
Use case: 
This model intends for the ULP to ask for the endpoint fd for polling. As a reminder the user has no notion of a CQ, thus the opaque mapping between the user EP and provider CQ. However, in order for this particular implementation to work the user must be aware that more than 1 fd might be necessary. This was enabled by extending fi_control to to accept an fi_ctrl struct in order to extend the number of args passed between user and provider.  

Note: don't get attached to the 2 fd model since 1 fd is on the way 

Features:
-FI_PEEK send/recv implemented
 -test if ready to send or recv
-trywait: enables verbs to arm cqs
-new fi_control(ep->fd) model (fd to use for poll)
 -added FI_TX_GETWAIT/FI_RX_GETWAIT (finer grain wait model)
  -enables rstream to pick cqfd based on requirements
  -both fds can be returned (user must provide enough space for both)

Signed-off-by: kseager <kayla.seager@intel.com>