### PR TITLE
v1.6.x: cherry-picked fixes for psm2

### DIFF
--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -9,7 +9,7 @@ dnl $2: action if not configured successfully
 dnl
 AC_DEFUN([FI_PSM2_CONFIGURE],[
 	 # Determine if we can support the psm2 provider
-	 psm2_ARCH=`uname -p | sed -e 's,\(i[456]86\|athlon$$\),i386,'`
+	 psm2_ARCH=`uname -m | sed -e 's,\(i[456]86\|athlon$$\),i386,'`
 	 AM_CONDITIONAL([HAVE_PSM2_X86_64], [test x$psm2_ARCH = xx86_64])
 	 AC_SUBST([HAVE_PSM2_X86_64])
 	 AC_SUBST([psm2_ARCH])

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -866,6 +866,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					psmx2_cntr_inc(ep->send_cntr, PSMX2_STATUS_ERROR(status));
 				free(sendv_req);
 				PSMX2_FREE_COMPLETION(trx_ctxt, status);
+				PSMX2_STATUS_INIT(status);
 				break;
 
 			case PSMX2_IOV_RECV_CONTEXT:

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -400,14 +400,15 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 
 	PSMX2_STATUS_INIT(status);
 
-	{
+	while (read_more) {
+
 		PSMX2_POLL_COMPLETION(trx_ctxt, status, err);
 
 		if (err == PSM2_OK) {
 			fi_context = PSMX2_STATUS_CONTEXT(status);
 			if (OFI_UNLIKELY(!fi_context)) {
 				PSMX2_FREE_COMPLETION(trx_ctxt, status);
-				return read_count;
+				continue;
 			}
 
 			ep = PSMX2_CTXT_EP(fi_context);
@@ -432,6 +433,11 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				}
 				if (ep->send_cntr)
 					psmx2_cntr_inc(ep->send_cntr, PSMX2_STATUS_ERROR(status));
+
+				/* Bi-directional send/recv performance tweak for KNL */
+				if (PSMX2_STATUS_SNDLEN(status) > 16384)
+					read_more = 0;
+
 				PSMX2_FREE_COMPLETION(trx_ctxt, status);
 				break;
 
@@ -460,7 +466,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 						  !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					return read_count;
+					continue;
 				}
 				if (ep->recv_cq) {
 					op_context = fi_context;
@@ -491,7 +497,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					return read_count;
+					continue;
 				}
 				if (ep->recv_cq) {
 					op_context = fi_context;
@@ -523,7 +529,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					return read_count;
+					continue;
 				}
 				PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 				if (OFI_UNLIKELY(ep->recv_cq && PSMX2_STATUS_ERROR(status))) {
@@ -556,7 +562,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 						 !psmx2_handle_sendv_req(ep, status, 0))) {
 					PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					return read_count;
+					continue;
 				}
 				PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
 				if (OFI_UNLIKELY(ep->recv_cq && PSMX2_STATUS_ERROR(status))) {
@@ -638,7 +644,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 							am_req->error = psmx2_errno(PSMX2_STATUS_ERROR(status));
 						/* Request to be freed in AM handler */
 						PSMX2_FREE_COMPLETION(trx_ctxt, status);
-						return read_count;
+						continue;
 					}
 				}
 				op_context = PSMX2_CTXT_USER(fi_context);
@@ -674,7 +680,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 							am_req->error = psmx2_errno(PSMX2_STATUS_ERROR(status));
 						/* Request to be freed in AM handler */
 						PSMX2_FREE_COMPLETION(trx_ctxt, status);
-						return read_count;
+						continue;
 					}
 				}
 				op_context = PSMX2_CTXT_USER(fi_context);
@@ -702,7 +708,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(status))) &&
 				    !psmx2_handle_sendv_req(ep, status, 1))) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					return read_count;
+					continue;
 				}
 				multi_recv_req = PSMX2_CTXT_USER(fi_context);
 				if (ep->recv_cq) {
@@ -809,7 +815,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				if (sendv_req->iov_protocol == PSMX2_IOV_PROTO_MULTI &&
 				    sendv_req->iov_done < sendv_req->iov_info.count + 1) {
 					PSMX2_STATUS_SAVE(status, sendv_req->status);
-					return read_count;
+					continue;
 				}
 				if (ep->send_cq && !sendv_req->no_completion) {
 					op_context = sendv_req->user_context;
@@ -838,7 +844,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 				sendv_req->iov_done++;
 				PSMX2_FREE_COMPLETION(trx_ctxt, status);
 				if (sendv_req->iov_done < sendv_req->iov_info.count + 1)
-					return read_count;
+					continue;
 				status = sendv_req->status;
 				if (ep->send_cq && !sendv_req->no_completion) {
 					op_context = sendv_req->user_context;
@@ -871,7 +877,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 					sendv_rep->error_code = PSMX2_STATUS_ERROR(status);
 				if (sendv_rep->iov_done < sendv_rep->iov_info.count) {
 					PSMX2_FREE_COMPLETION(trx_ctxt, status);
-					return read_count;
+					continue;
 				}
 
 				PSMX2_STATUS_TAG(status) = sendv_rep->tag;


### PR DESCRIPTION
* prov/psm2: Fix memory corruption related to sendv (Jianxin Xiong)
* prov/psm2: Reintroduce nested polling, with a tweak (Jianxin Xiong)
* prov/psm2: fix CPU detection (Holger HoffstÃ¤tte)
