### PR TITLE
prov/gni: rework SEP setup

### DIFF
--- a/prov/gni/include/gnix.h
+++ b/prov/gni/include/gnix.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2016 Cisco Systems, Inc.  All rights reserved.
  *
@@ -606,6 +606,7 @@ struct gnix_fid_ep {
  *                      this sep
  * @var rx_ep_table     array of pointers to rx contexts instantiated using
  *                      this sep
+ * @var enabled         array of bool to track enabling of embedded eps
  * @var cm_nic          gnix cm nic associated with this SEP.
  * @var av              address vector bound to this SEP
  * @var my_name         ep name for this endpoint
@@ -623,6 +624,7 @@ struct gnix_fid_sep {
 	struct fid_ep **ep_table;
 	struct fid_ep **tx_ep_table;
 	struct fid_ep **rx_ep_table;
+	bool *enabled;
 	struct gnix_cm_nic *cm_nic;
 	struct gnix_fid_av *av;
 	struct gnix_ep_name my_name;
@@ -647,6 +649,7 @@ struct gnix_fid_trx {
 	struct gnix_fid_sep *sep;
 	uint64_t op_flags;
 	uint64_t caps;
+	int index;
 	struct gnix_reference ref_cnt;
 };
 

--- a/prov/gni/include/gnix_ep.h
+++ b/prov/gni/include/gnix_ep.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -172,6 +172,14 @@ typedef ssize_t (*trecvmsg_func_t)(struct fid_ep *ep,
  * @param[in] ep	pointer to a EP
  */
 int  _gnix_ep_int_tx_pool_grow(struct gnix_fid_ep *ep);
+
+/**
+ * Internal function for initializing tx buffer pool
+ *
+ * @param[in] ep	pointer to a EP
+ */
+int _gnix_ep_int_tx_pool_init(struct gnix_fid_ep *ep);
+
 
 /*
  * inline functions
@@ -350,11 +358,18 @@ int _gnix_ep_alloc(struct fid_domain *domain, struct fi_info *info,
 int _gnix_ep_init_vc(struct gnix_fid_ep *ep_priv);
 
 /**
- * Internal function for enabling an ep
+ * Internal function for enabling ep tx resources
  *
  * @param[in] ep_priv	 pointer to a previously allocated EP
  */
-int _gnix_ep_enable(struct gnix_fid_ep *ep_priv);
+int _gnix_ep_tx_enable(struct gnix_fid_ep *ep_priv);
+
+/**
+ * Internal function for enabling ep rx resources
+ *
+ * @param[in] ep_priv	 pointer to a previously allocated EP
+ */
+int _gnix_ep_rx_enable(struct gnix_fid_ep *ep_priv);
 
 /*******************************************************************************
  * API Functions


### PR DESCRIPTION
Turns out the effort to get MPI RMA over OFI in
Open MPI is flushing out latent bugs in the GNI
provider's SEP implementation.

This flushes out a problem with enabling SEP
tx/rx contexts.  We were actually doubly allocating
resources in cases where an app enables both the tx
and rx, and not initializing some resources the
underlying EP needed.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 982057431f189db627b4f2c6dc8f98bd59290ad2)