### PR TITLE
prov/gni: Fix interrupt for gni cq wait

### DIFF
--- a/prov/gni/src/gnix_nic.c
+++ b/prov/gni/src/gnix_nic.c
@@ -163,13 +163,12 @@ try_again:
 		retry = 1;
 		break;
 	case GNI_RC_TIMEOUT:
-		retry = 1;
-		break;
 	case GNI_RC_NOT_DONE:
+        /* Invalid state indicates call interrupted by signal using various tools */
+	case GNI_RC_INVALID_STATE:
 		retry = 1;
 		break;
 	case GNI_RC_INVALID_PARAM:
-	case GNI_RC_INVALID_STATE:
 	case GNI_RC_ERROR_RESOURCE:
 	case GNI_RC_ERROR_NOMEM:
 		retry = 0;


### PR DESCRIPTION
While using hpctoolkit with Sandia OpenSHMEM on Cray progress thread
was getting confused by interrupts being generated by the toolkit,
leading to much sadness. With this change the tool works.

merge from PR #4276

Signed-off-by: Srdjan Milakovic <srdjan@rice.edu>
(cherry picked from commit c3dcbc13901a51d308dc6e387a6f185351cee19e)