### PR TITLE
prov/rxm: Use separate pkt structures for msg and tagged ops

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -441,7 +441,8 @@ struct rxm_ep {
 	} sar;
 
 	/* This is used only in non-FI_THREAD_SAFE case */
-	struct rxm_tx_buf	*inject_tx_buf;
+	struct rxm_pkt		*inject_tx_pkt;
+	struct rxm_pkt		*tinject_tx_pkt;
 
 	struct rxm_buf_pool	*buf_pools;
 
@@ -716,11 +717,11 @@ rxm_acquire_conn_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
 
 static inline ssize_t
 rxm_ep_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-		   struct rxm_tx_buf *tx_buf, size_t pkt_size)
+		   struct rxm_pkt *tx_pkt, size_t pkt_size)
 {
 	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting inject with length: %" PRIu64
-	       " tag: 0x%" PRIx64 "\n", tx_buf->pkt.hdr.size, tx_buf->pkt.hdr.tag);
-	ssize_t ret = fi_inject(rxm_conn->msg_ep, &tx_buf->pkt, pkt_size, 0);
+	       " tag: 0x%" PRIx64 "\n", pkt_size, tx_pkt->hdr.tag);
+	ssize_t ret = fi_inject(rxm_conn->msg_ep, tx_pkt, pkt_size, 0);
 	if (OFI_UNLIKELY(ret)) {
 		if (ret == -FI_EAGAIN)
 			rxm_ep_progress_multi(&rxm_ep->util_ep);


### PR DESCRIPTION
This patch targets reducing latency numbers for messages with size <= MSG provider inject size
This patch saves ~5 instruction on critical path and simplifies code path by presetting Completion flags (`FI_MSG` or `FI_TAGGED`) and Operation code (`ofi_op_msg` or `ofi_op_tagged`) and using `struct rxm_pkt` instead of `struct rxm_tx_buf`

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>