### PR TITLE
prov/rxm, util: Enable support of explicit usege of util CQ FD

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -382,6 +382,7 @@ int ofi_check_bind_cq_flags(struct util_ep *ep, struct util_cq *cq,
 			    uint64_t flags);
 void ofi_cq_progress(struct util_cq *cq);
 int ofi_cq_cleanup(struct util_cq *cq);
+int ofi_cq_control(struct fid *fid, int command, void *arg);
 ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count);
 ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		fi_addr_t *src_addr);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -983,7 +983,7 @@ static struct fi_ops rxm_cq_fi_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = rxm_cq_close,
 	.bind = fi_no_bind,
-	.control = fi_no_control,
+	.control = ofi_cq_control,
 	.ops_open = fi_no_ops_open,
 };
 

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -468,6 +468,21 @@ int ofi_cq_cleanup(struct util_cq *cq)
 	return 0;
 }
 
+int ofi_cq_control(struct fid *fid, int command, void *arg)
+{
+	struct util_cq *cq = container_of(fid, struct util_cq, cq_fid.fid);
+
+	switch (command) {
+	case FI_GETWAIT:
+		if (!cq->wait)
+			return -FI_ENODATA;
+		return fi_control(&cq->wait->wait_fid.fid, FI_GETWAIT, arg);
+	default:
+		FI_INFO(cq->wait->prov, FI_LOG_CQ, "Unsupported command\n");
+		return -FI_ENOSYS;
+	}
+}
+
 static int util_cq_close(struct fid *fid)
 {
 	struct util_cq *cq;
@@ -486,7 +501,7 @@ static struct fi_ops util_cq_fi_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = util_cq_close,
 	.bind = fi_no_bind,
-	.control = fi_no_control,
+	.control = ofi_cq_control,
 	.ops_open = fi_no_ops_open,
 };
 


### PR DESCRIPTION
This patch implements `fi_control()` for utility CQ that can handle
`FI_GETWAIT` command. This is almost the same as for EQ.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>