### PR TITLE
prov/verbs: detect string format of wildcard address

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -289,8 +289,8 @@ static inline int ofi_equals_sockaddr(const struct sockaddr *addr1,
 		ofi_equals_ipaddr(addr1, addr2);
 }
 
-int ofi_is_only_src_port_set(const char *node, const char *service,
-			     uint64_t flags, const struct fi_info *hints);
+int ofi_is_wildcard_listen_addr(const char *node, const char *service,
+				uint64_t flags, const struct fi_info *hints);
 
 size_t ofi_mask_addr(struct sockaddr *maskaddr, const struct sockaddr *srcaddr,
 		     const struct sockaddr *netmask);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -222,7 +222,7 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 	int ret;
 
 	/* Avoid getting wild card address from MSG provider */
-	if (ofi_is_only_src_port_set(node, service, flags, hints)) {
+	if (ofi_is_wildcard_listen_addr(node, service, flags, hints)) {
 		if (service) {
 			ret = getaddrinfo(NULL, service, NULL, &ai);
 			if (ret) {

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1215,7 +1215,7 @@ static int fi_ibv_get_matching_info(uint32_t version,
 				    const struct fi_info *hints,
 				    struct fi_info **info,
 				    const struct fi_info *verbs_info,
-				    uint8_t only_srcport_set)
+				    uint8_t passive)
 {
 	const struct fi_info *check_info = verbs_info;
 	struct fi_info *fi, *tail;
@@ -1234,7 +1234,7 @@ static int fi_ibv_get_matching_info(uint32_t version,
 				continue;
 		}
 
-		if ((check_info->ep_attr->type == FI_EP_MSG) && only_srcport_set) {
+		if ((check_info->ep_attr->type == FI_EP_MSG) && passive) {
 			if (got_passive_info)
 				continue;
 
@@ -1453,8 +1453,8 @@ static int fi_ibv_get_match_infos(uint32_t version, const char *node,
 
 	// TODO check for AF_IB addr
 	ret = fi_ibv_get_matching_info(version, hints, info, *raw_info,
-				       ofi_is_only_src_port_set(node, service,
-								flags, hints));
+				       ofi_is_wildcard_listen_addr(node, service,
+								   flags, hints));
 	if (ret)
 		return ret;
 


### PR DESCRIPTION
When an app passes a wildcard address in string format as node argument to
fi_getinfo, we should return a passive fi_info.