### PR TITLE
[v1.6.x] prov/verbs: detect string format of wildcard address

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -258,8 +258,8 @@ static inline void ofi_addr_set_port(struct sockaddr *addr, uint16_t port)
 	}
 }
 
-int ofi_is_only_src_port_set(const char *node, const char *service,
-			     uint64_t flags, const struct fi_info *hints);
+int ofi_is_wildcard_listen_addr(const char *node, const char *service,
+				uint64_t flags, const struct fi_info *hints);
 
 /*
  * Address logging

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -211,7 +211,7 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 	int ret;
 
 	/* Avoid getting wild card address from MSG provider */
-	if (ofi_is_only_src_port_set(node, service, flags, hints)) {
+	if (ofi_is_wildcard_listen_addr(node, service, flags, hints)) {
 		if (service) {
 			ret = getaddrinfo(NULL, service, NULL, &ai);
 			if (ret) {

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1215,7 +1215,7 @@ static int fi_ibv_get_matching_info(uint32_t version,
 				    const struct fi_info *hints,
 				    struct fi_info **info,
 				    const struct fi_info *verbs_info,
-				    uint8_t only_srcport_set)
+				    uint8_t passive)
 {
 	const struct fi_info *check_info = verbs_info;
 	struct fi_info *fi, *tail;
@@ -1234,7 +1234,7 @@ static int fi_ibv_get_matching_info(uint32_t version,
 				continue;
 		}
 
-		if ((check_info->ep_attr->type == FI_EP_MSG) && only_srcport_set) {
+		if ((check_info->ep_attr->type == FI_EP_MSG) && passive) {
 			if (got_passive_info)
 				continue;
 
@@ -1453,8 +1453,8 @@ static int fi_ibv_get_match_infos(uint32_t version, const char *node,
 
 	// TODO check for AF_IB addr
 	ret = fi_ibv_get_matching_info(version, hints, info, *raw_info,
-				       ofi_is_only_src_port_set(node, service,
-								flags, hints));
+				       ofi_is_wildcard_listen_addr(node, service,
+								   flags, hints));
 	if (ret)
 		return ret;
 

--- a/src/common.c
+++ b/src/common.c
@@ -49,6 +49,9 @@
 #include <inttypes.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
 
 #include <ofi_signal.h>
 #include <rdma/providers/fi_prov.h>
@@ -559,11 +562,42 @@ int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
 	}
 }
 
-int ofi_is_only_src_port_set(const char *node, const char *service,
-			     uint64_t flags, const struct fi_info *hints)
+static int ofi_is_any_addr_port(struct sockaddr *addr)
 {
-	if (node)
+	switch (ofi_sa_family(addr)) {
+	case AF_INET:
+		return (ofi_ipv4_is_any_addr(addr) &&
+			ofi_sin_port(addr));
+	case AF_INET6:
+		return (ofi_ipv6_is_any_addr(addr) &&
+			ofi_sin6_port(addr));
+	default:
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Unknown address format\n");
 		return 0;
+	}
+}
+
+int ofi_is_wildcard_listen_addr(const char *node, const char *service,
+				uint64_t flags, const struct fi_info *hints)
+{
+	struct addrinfo *res = NULL;
+	int ret;
+
+	if (node) {
+		ret = getaddrinfo(node, service, NULL, &res);
+		if (ret) {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+				"getaddrinfo failed!\n");
+			return 0;
+		}
+		if (ofi_is_any_addr_port(res->ai_addr)) {
+			freeaddrinfo(res);
+			goto out;
+		}
+		freeaddrinfo(res);
+		return 0;
+	}
 
 	if (hints) {
 		if (hints->dest_addr)
@@ -572,17 +606,7 @@ int ofi_is_only_src_port_set(const char *node, const char *service,
 		if (!hints->src_addr)
 			goto out;
 
-		switch (ofi_sa_family(hints->src_addr)) {
-		case AF_INET:
-			return (ofi_ipv4_is_any_addr(hints->src_addr) &&
-				ofi_sin_port(hints->src_addr));
-		case AF_INET6:
-			return (ofi_ipv6_is_any_addr(hints->src_addr) &&
-				ofi_sin6_port(hints->src_addr));
-		default:
-			FI_WARN(&core_prov, FI_LOG_CORE, "Unknown address format\n");
-			return 0;
-		}
+		return ofi_is_any_addr_port(hints->src_addr);
 	}
 out:
 	return ((flags & FI_SOURCE) && service) ? 1 : 0;


### PR DESCRIPTION
When an app passes a wildcard address in string format as node argument to
fi_getinfo, we should return a passive fi_info.

(cherry picked from commit 575075e108a3fea82ac3c17643d7210d7986373a)