### PR TITLE
util/mr_cache, mem_monitor: Minor bug-fixing + improvements

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -194,6 +194,32 @@ struct ofi_mr_entry {
 	uint8_t				data[];
 };
 
+struct ofi_mr_storage;
+
+typedef void (*ofi_mr_destroy_t)(struct ofi_mr_storage *storage);
+typedef struct ofi_mr_entry *(*ofi_mr_find_t)(struct ofi_mr_storage *storage,
+					      const struct iovec *key);
+typedef int (*ofi_mr_insert_t)(struct ofi_mr_storage *storage,
+			       struct iovec *key,
+			       struct ofi_mr_entry *entry);
+typedef int (*ofi_mr_erase_t)(struct ofi_mr_storage *storage,
+			      struct ofi_mr_entry *entry);
+
+enum ofi_mr_storage_type {
+	OFI_MR_STORAGE_DEFAULT = 0,
+	OFI_MR_STORAGE_RBT,
+	OFI_MR_STORAGE_USER,
+};
+
+struct ofi_mr_storage {
+	enum ofi_mr_storage_type type;
+	void *storage;
+	ofi_mr_destroy_t destroy;
+	ofi_mr_find_t find;
+	ofi_mr_insert_t insert;
+	ofi_mr_erase_t erase;
+};
+
 struct ofi_mr_cache {
 	struct util_domain		*domain;
 	struct ofi_notification_queue	nq;
@@ -201,6 +227,8 @@ struct ofi_mr_cache {
 	size_t				max_cached_size;
 	int				merge_regions;
 	size_t				entry_data_size;
+
+	struct ofi_mr_storage		mr_storage;
 
 	RbtHandle			mr_tree;
 	struct dlist_entry		lru_list;

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -106,7 +106,8 @@ void ofi_monitor_unsubscribe(struct ofi_subscription *subscription)
 					       subscription->len,
 					       subscription);
 	fastlock_acquire(&subscription->nq->lock);
-	dlist_init(&subscription->entry);
+	if (!dlist_empty(&subscription->entry))
+		dlist_remove_init(&subscription->entry);
 	subscription->nq->refcnt--;
 	fastlock_release(&subscription->nq->lock);
 }

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -84,12 +84,8 @@ static void util_mr_free_entry(struct ofi_mr_cache *cache,
 static void util_mr_uncache_entry(struct ofi_mr_cache *cache,
 				  struct ofi_mr_entry *entry)
 {
-	RbtIterator iter;
-
 	assert(entry->cached);
-	iter = rbtFind(cache->mr_tree, &entry->iov);
-	assert(iter);
-	rbtErase(cache->mr_tree, iter);
+	cache->mr_storage.erase(&cache->mr_storage, entry);
 	entry->cached = 0;
 }
 
@@ -182,7 +178,8 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 	    (cache->cached_size > cache->max_cached_size)) {
 		(*entry)->cached = 0;
 	} else {
-		if (rbtInsert(cache->mr_tree, &(*entry)->iov, *entry)) {
+		if (cache->mr_storage.insert(&cache->mr_storage,
+					     &(*entry)->iov, *entry)) {
 			ret = -FI_ENOMEM;
 			goto err;
 		}
@@ -204,20 +201,17 @@ err:
 
 static int
 util_mr_cache_merge(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
-		    RbtIterator iter, struct ofi_mr_entry **entry)
+		    struct ofi_mr_entry *old_entry, struct ofi_mr_entry **entry)
 {
 	struct iovec iov, *old_iov;
-	struct ofi_mr_entry *old_entry;
 
 	iov = *attr->mr_iov;
 	do {
-		rbtKeyValue(cache->mr_tree, iter, (void **) &old_iov,
-			    (void **) &old_entry);
-
 		FI_DBG(cache->domain->prov, FI_LOG_MR,
 		       "merging %p (len: %" PRIu64 ") with %p (len: %" PRIu64 ")\n",
 		       iov.iov_base, iov.iov_len,
 		       old_entry->iov.iov_base, old_entry->iov.iov_len);
+		old_iov = &old_entry->iov;
 
 		iov.iov_len = ((uintptr_t)
 			MAX(ofi_iov_end(&iov), ofi_iov_end(old_iov))) -
@@ -232,7 +226,7 @@ util_mr_cache_merge(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 			ofi_monitor_unsubscribe(&old_entry->subscription);
 			old_entry->subscribed = 0;
 		}
-		rbtErase(cache->mr_tree, iter);
+		cache->mr_storage.erase(&cache->mr_storage, old_entry);
 		old_entry->cached = 0;
 
 		if (old_entry->use_cnt == 0) {
@@ -240,7 +234,7 @@ util_mr_cache_merge(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 			util_mr_free_entry(cache, old_entry); 
 		}
 
-	} while ((iter = rbtFind(cache->mr_tree, &iov)));
+	} while ((old_entry = cache->mr_storage.find(&cache->mr_storage, &iov)));
 
 	return util_mr_cache_create(cache, &iov, attr->access, entry);
 }
@@ -248,9 +242,6 @@ util_mr_cache_merge(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 			struct ofi_mr_entry **entry)
 {
-	RbtIterator iter;
-	struct iovec *iov;
-
 	util_mr_cache_process_events(cache);
 
 	assert(attr->iov_count == 1);
@@ -263,17 +254,15 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	       ofi_mr_cache_flush(cache))
 		;
 
-	iter = rbtFind(cache->mr_tree, (void *) attr->mr_iov);
-	if (!iter) {
+	*entry = cache->mr_storage.find(&cache->mr_storage, attr->mr_iov);
+	if (!*entry) {
 		return util_mr_cache_create(cache, attr->mr_iov,
 					    attr->access, entry);
 	}
 
-	rbtKeyValue(cache->mr_tree, iter, (void **) &iov, (void **) entry);
-
 	/* This branch is always false if the merging entries wasn't requested */
-	if (!ofi_iov_within(attr->mr_iov, iov))
-		return util_mr_cache_merge(cache, attr, iter, entry);
+	if (!ofi_iov_within(attr->mr_iov, &(*entry)->iov))
+		return util_mr_cache_merge(cache, attr, *entry, entry);
 
 	cache->hit_cnt++;
 	if ((*entry)->use_cnt++ == 0)
@@ -300,7 +289,7 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 		dlist_remove_init(&entry->lru_entry);
 		util_mr_free_entry(cache, entry);
 	}
-	rbtDelete(cache->mr_tree);
+	cache->mr_storage.destroy(&cache->mr_storage);
 	ofi_monitor_del_queue(&cache->nq);
 	ofi_atomic_dec32(&cache->domain->ref);
 	util_buf_pool_destroy(cache->entry_pool);
@@ -308,17 +297,91 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 	assert(cache->cached_size == 0);
 }
 
-int ofi_mr_cache_init(struct util_domain *domain, struct ofi_mem_monitor *monitor,
+static void ofi_mr_rbt_storage_destroy(struct ofi_mr_storage *storage)
+{
+	rbtDelete((RbtHandle)storage->storage);
+}
+
+static struct ofi_mr_entry *ofi_mr_rbt_storage_find(struct ofi_mr_storage *storage,
+						    const struct iovec *key)
+{
+	struct ofi_mr_entry *entry;
+	RbtIterator iter = rbtFind((RbtHandle)storage->storage, (void *)key);
+	if (OFI_UNLIKELY(!iter))
+		return iter;
+
+	rbtKeyValue(storage->storage, iter, (void *)&key, (void *)&entry);
+	return entry;
+}
+
+static int ofi_mr_rbt_storage_insert(struct ofi_mr_storage *storage,
+				     struct iovec *key,
+				     struct ofi_mr_entry *entry)
+{
+	int ret = rbtInsert((RbtHandle)storage->storage,
+			    (void *)&entry->iov, (void *)entry);
+	if (ret != RBT_STATUS_OK) {
+		switch (ret) {
+		case RBT_STATUS_MEM_EXHAUSTED:
+			return -FI_ENOMEM;
+		case RBT_STATUS_DUPLICATE_KEY:
+			return -FI_EALREADY;
+		default:
+			return -FI_EAVAIL;
+		}
+	}
+	return ret;
+}
+
+static int ofi_mr_rbt_storage_erase(struct ofi_mr_storage *storage,
+				    struct ofi_mr_entry *entry)
+{
+	RbtIterator iter = rbtFind(storage->storage, &entry->iov);
+	assert(iter);
+	return (rbtErase((RbtHandle)storage->storage, iter) != RBT_STATUS_OK) ?
+	       -FI_EAVAIL : 0;
+}
+
+static int ofi_mr_cache_init_rbt_storage(struct ofi_mr_cache *cache)
+{
+	cache->mr_storage.storage = rbtNew(cache->merge_regions ?
+					   util_mr_find_overlap :
+					   util_mr_find_within);
+	if (!cache->mr_storage.storage)
+		return -FI_ENOMEM;
+	cache->mr_storage.destroy = ofi_mr_rbt_storage_destroy;
+	cache->mr_storage.find = ofi_mr_rbt_storage_find;
+	cache->mr_storage.insert = ofi_mr_rbt_storage_insert;
+	cache->mr_storage.erase = ofi_mr_rbt_storage_erase;
+	return 0;
+}
+
+static int ofi_mr_cache_init_storage(struct ofi_mr_cache *cache)
+{
+	switch (cache->mr_storage.type) {
+	case OFI_MR_STORAGE_DEFAULT:
+	case OFI_MR_STORAGE_RBT:
+		return ofi_mr_cache_init_rbt_storage(cache);
+	case OFI_MR_STORAGE_USER:
+		if (!(cache->mr_storage.storage &&
+		      cache->mr_storage.destroy && cache->mr_storage.find &&
+		      cache->mr_storage.insert && cache->mr_storage.erase))
+			return -FI_EINVAL;
+		break;
+	}
+	return 0;
+}
+
+int ofi_mr_cache_init(struct util_domain *domain,
+		      struct ofi_mem_monitor *monitor,
 		      struct ofi_mr_cache *cache)
 {
 	int ret;
 	assert(cache->add_region && cache->delete_region);
 
-	cache->mr_tree = rbtNew(cache->merge_regions ?
-				util_mr_find_overlap :
-				util_mr_find_within);
-	if (!cache->mr_tree)
-		return -FI_ENOMEM;
+	ret = ofi_mr_cache_init_storage(cache);
+	if (ret)
+		return ret;
 
 	cache->domain = domain;
 	ofi_atomic_inc32(&domain->ref);
@@ -344,6 +407,6 @@ int ofi_mr_cache_init(struct util_domain *domain, struct ofi_mem_monitor *monito
 err:
 	ofi_atomic_dec32(&cache->domain->ref);
 	ofi_monitor_del_queue(&cache->nq);
-	rbtDelete(cache->mr_tree);
+	cache->mr_storage.destroy(&cache->mr_storage);
 	return ret;
 }


### PR DESCRIPTION
This PR implement the following commits:
- util/mr_cache: Change the sequence between the MR tree and the subscription when allocate/release the new MR entry. This is needed for futher re-use (will prepare new PR that fixes some major bugs and improves performance).
- util/mem_monitor: Remove a subscription entry from NQ list when unsubscribed from a MR entry (to avoid read-after-free issue)
- util/mr_cache: Add support of MR storage as a plugin. This patch makes possible to implement new types of MR storage (Red-Black Tree (default), AVL Tree (will be added), User defined and etc).
