### PR TITLE
Revert "prov/psm2: Avoid long delay in psm2_ep_close"

### DIFF
--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -32,40 +32,6 @@
 
 #include "psmx2.h"
 
-static void psmx2_set_epaddr_context(struct psmx2_trx_ctxt *trx_ctxt,
-				     psm2_epid_t epid, psm2_epaddr_t epaddr)
-{
-	struct psmx2_epaddr_context *context;
-
-	context = (void *)psm2_epaddr_getctxt(epaddr);
-	if (context) {
-		if (context->trx_ctxt != trx_ctxt || context->epid != epid) {
-			FI_WARN(&psmx2_prov, FI_LOG_AV,
-				"trx_ctxt or epid doesn't match\n");
-			context = NULL;
-		}
-	}
-
-	if (context)
-		return;
-
-	context = malloc(sizeof *context);
-	if (!context) {
-		FI_WARN(&psmx2_prov, FI_LOG_AV,
-			"cannot allocate context\n");
-		return;
-	}
-
-	context->trx_ctxt = trx_ctxt;
-	context->epid = epid;
-	context->epaddr = epaddr;
-	psm2_epaddr_setctxt(epaddr, context);
-
-	psmx2_lock(&trx_ctxt->peer_lock, 2);
-	dlist_insert_before(&context->entry, &trx_ctxt->peer_list);
-	psmx2_unlock(&trx_ctxt->peer_lock, 2);
-}
-
 /*
  * SEP address query protocol:
  *
@@ -118,8 +84,6 @@ int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
 	struct psmx2_fid_sep *sep;
 	struct psmx2_sep_query *req;
 	struct psmx2_fid_av *av;
-	psm2_epaddr_t src_epaddr;
-	psm2_epid_t src_epid;
 	psm2_epid_t *epids;
 	psm2_epid_t *buf = NULL;
 	int buflen;
@@ -128,15 +92,6 @@ int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
 
 	cmd = PSMX2_AM_GET_OP(args[0].u32w0);
 	domain = trx_ctxt->domain;
-
-	/*
-	 * the implicit connection to the AM source needs also to be disconnected
-	 * to avoid long delay inside psm2_ep_close. make sure the source is added
-	 * to the peer list.
-	 */
-	psm2_am_get_source(token, &src_epaddr);
-	psm2_epaddr_to_epid(src_epaddr, &src_epid);
-	psmx2_set_epaddr_context(trx_ctxt, src_epid, src_epaddr);
 
 	switch (cmd) {
 	case PSMX2_AM_REQ_SEP_QUERY:
@@ -224,6 +179,40 @@ static inline double psmx2_conn_timeout(int sec)
 		return PSMX2_MAX_CONN_TIMEOUT * 1e9;
 
 	return sec * 1e9;
+}
+
+static void psmx2_set_epaddr_context(struct psmx2_trx_ctxt *trx_ctxt,
+				     psm2_epid_t epid, psm2_epaddr_t epaddr)
+{
+	struct psmx2_epaddr_context *context;
+
+	context = (void *)psm2_epaddr_getctxt(epaddr);
+	if (context) {
+		if (context->trx_ctxt != trx_ctxt || context->epid != epid) {
+			FI_WARN(&psmx2_prov, FI_LOG_AV,
+				"trx_ctxt or epid doesn't match\n");
+			context = NULL;
+		}
+	}
+
+	if (context)
+		return;
+
+	context = malloc(sizeof *context);
+	if (!context) {
+		FI_WARN(&psmx2_prov, FI_LOG_AV,
+			"cannot allocate context\n");
+		return;
+	}
+
+	context->trx_ctxt = trx_ctxt;
+	context->epid = epid;
+	context->epaddr = epaddr;
+	psm2_epaddr_setctxt(epaddr, context);
+
+	psmx2_lock(&trx_ctxt->peer_lock, 2);
+	dlist_insert_before(&context->entry, &trx_ctxt->peer_list);
+	psmx2_unlock(&trx_ctxt->peer_lock, 2);
 }
 
 int psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,


### PR DESCRIPTION
This reverts commit 41f25577e0bfbbdfd895eaf85601d5ce77145d69.

Sporadic assertion failures have been observed inside psm2_ep_disconnect2().
Disable the patch until the issue is fixed.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>