### PR TITLE
prov/rstream: tx_mr return len improvement

### DIFF
--- a/prov/rstream/src/rstream.h
+++ b/prov/rstream/src/rstream.h
@@ -97,8 +97,13 @@ struct rstream_cm_data {
 	uint8_t reserved;
 };
 
+struct rstream_ctx_data {
+	struct fi_context ctx;
+	size_t len;
+};
+
 struct rstream_tx_ctx {
-	struct fi_context *tx_ctxs;
+	struct rstream_ctx_data *tx_ctxs;
 	uint32_t num_in_use;
 	uint32_t free_index;
 	uint32_t front;

--- a/prov/rstream/src/rstream_ep.c
+++ b/prov/rstream/src/rstream_ep.c
@@ -237,13 +237,13 @@ int rstream_ep_open(struct fid_domain *domain, struct fi_info *info,
 	rstream_ep->qp_win.ctrl_credits = RSTREAM_MAX_CTRL_TX;
 	rstream_ep->qp_win.max_rx_credits = rstream_info.rx_attr->size;
 
-	rstream_ep->tx_ctx.tx_ctxs = (struct fi_context *)
-		calloc(1, sizeof(struct fi_context) *
-		rstream_ep->qp_win.max_tx_credits);
+	rstream_ep->tx_ctx.tx_ctxs = (struct rstream_ctx_data *)
+		calloc(rstream_ep->qp_win.max_tx_credits,
+		sizeof(*rstream_ep->tx_ctx.tx_ctxs));
 	assert(rstream_ep->tx_ctx.tx_ctxs);
 	rstream_ep->rx_ctxs = (struct fi_context *)
-		calloc(1, sizeof(struct fi_context) *
-		rstream_ep->qp_win.max_rx_credits);
+		calloc(rstream_ep->qp_win.max_rx_credits,
+		sizeof(*rstream_ep->rx_ctxs));
 	assert(rstream_ep->rx_ctxs);
 
 	*ep_fid = &rstream_ep->util_ep.ep_fid;


### PR DESCRIPTION
-previously waited for recv side completion for tx_mr segment return
-this is too strong of a requirement, tx completion is sufficient

Signed-off-by: kseager <kayla.seager@intel.com>