### PR TITLE
 prov/verbs, util/mem_monitor: Fix notification mechanism for MR cache 

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -101,10 +101,10 @@ struct ofi_notification_queue;
 struct ofi_mem_monitor {
 	ofi_atomic32_t			refcnt;
 
-	int (*subscribe)(struct ofi_mem_monitor *notifier, void *addr,
-			 size_t len, struct ofi_subscription *subscription);
-	void (*unsubscribe)(struct ofi_mem_monitor *notifier, void *addr,
-			    size_t len, struct ofi_subscription *subscription);
+	int (*subscribe)(struct ofi_mem_monitor *notifier,
+			 struct ofi_subscription *subscription);
+	void (*unsubscribe)(struct ofi_mem_monitor *notifier,
+			    struct ofi_subscription *subscription);
 };
 
 struct ofi_notification_queue {
@@ -117,8 +117,7 @@ struct ofi_notification_queue {
 struct ofi_subscription {
 	struct ofi_notification_queue	*nq;
 	struct dlist_entry		entry;
-	void				*addr;
-	size_t				len;
+	struct iovec			iov;
 };
 
 void ofi_monitor_init(struct ofi_mem_monitor *monitor);
@@ -137,8 +136,8 @@ ofi_monitor_add_event_to_nq(struct ofi_subscription *subscription)
 {
 	FI_DBG(&core_prov, FI_LOG_MR,
 	       "Add event to NQ, context=%p, addr=%p, len=%"PRIu64" nq=%p\n",
-	       subscription, subscription->addr,
-	       subscription->len, subscription->nq);
+	       subscription, subscription->iov.iov_base,
+	       subscription->iov.iov_len, subscription->nq);
 	fastlock_acquire(&subscription->nq->lock);
 	if (dlist_empty(&subscription->entry))
 		dlist_insert_tail(&subscription->entry,

--- a/include/rbtree.h
+++ b/include/rbtree.h
@@ -95,5 +95,12 @@ RbtIterator rbtFindLeftmost(RbtHandle h, void *key,
 RbtIterator rbtFind(RbtHandle h, void *key);
 // returns iterator associated with key
 
+void rbtTraversal(RbtHandle h, RbtIterator it, void *handler_arg,
+          void(*handler)(void *arg, RbtIterator it));
+// tree traversal that visits (applies handler()) each node in the tree data
+//   strucutre exactly once.
+
+void *rbtRoot(RbtHandle h);
+// returns the root of the tree
 
 #endif /* RBTREE_H_ */

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -78,13 +78,13 @@ int ofi_monitor_subscribe(struct ofi_notification_queue *nq,
 	dlist_init(&subscription->entry);
 
 	subscription->nq = nq;
-	subscription->addr = addr;
-	subscription->len = len;
+	subscription->iov.iov_base = addr;
+	subscription->iov.iov_len = len;
 	fastlock_acquire(&nq->lock);
 	nq->refcnt++;
 	fastlock_release(&nq->lock);
 
-	ret = nq->monitor->subscribe(nq->monitor, addr, len, subscription);
+	ret = nq->monitor->subscribe(nq->monitor, subscription);
 	if (OFI_UNLIKELY(ret)) {
 		FI_WARN(&core_prov, FI_LOG_MR,
 			"Failed (ret = %d) to monitor addr=%p len=%zu",
@@ -100,10 +100,8 @@ void ofi_monitor_unsubscribe(struct ofi_subscription *subscription)
 {
 	FI_DBG(&core_prov, FI_LOG_MR,
 	       "unsubscribing addr=%p len=%zu subscription=%p\n",
-	       subscription->addr, subscription->len, subscription);
+	       subscription->iov.iov_base, subscription->iov.iov_len, subscription);
 	subscription->nq->monitor->unsubscribe(subscription->nq->monitor,
-					       subscription->addr,
-					       subscription->len,
 					       subscription);
 	fastlock_acquire(&subscription->nq->lock);
 	if (!dlist_empty(&subscription->entry))

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -112,36 +112,9 @@ void ofi_monitor_unsubscribe(struct ofi_subscription *subscription)
 	fastlock_release(&subscription->nq->lock);
 }
 
-static void util_monitor_read_events(struct ofi_mem_monitor *monitor)
-{
-	struct ofi_subscription *subscription;
-
-	do {
-		subscription = monitor->get_event(monitor);
-		if (!subscription) {
-			FI_DBG(&core_prov, FI_LOG_MR,
-			       "no more events to be read\n");
-			break;
-		}
-
-		FI_DBG(&core_prov, FI_LOG_MR,
-		       "found event, context=%p, addr=%p, len=%"PRIu64" nq=%p\n",
-		       subscription, subscription->addr,
-		       subscription->len, subscription->nq);
-
-		fastlock_acquire(&subscription->nq->lock);
-		if (dlist_empty(&subscription->entry))
-			dlist_insert_tail(&subscription->entry,
-					   &subscription->nq->list);
-		fastlock_release(&subscription->nq->lock);
-	} while (1);
-}
-
 struct ofi_subscription *ofi_monitor_get_event(struct ofi_notification_queue *nq)
 {
 	struct ofi_subscription *subscription;
-
-	util_monitor_read_events(nq->monitor);
 
 	fastlock_acquire(&nq->lock);
 	if (!dlist_empty(&nq->list)) {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -430,7 +430,6 @@ struct fi_ibv_mem_ptr_entry {
 struct fi_ibv_mem_notifier {
 	struct fi_ibv_mem_ptr_entry	*mem_ptrs_hash;
 	struct util_buf_pool		*mem_ptrs_ent_pool;
-	struct dlist_entry		event_list;
 	ofi_mem_free_hook		prev_free_hook;
 	ofi_mem_realloc_hook		prev_realloc_hook;
 	int				ref_cnt;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -420,16 +420,8 @@ struct fi_ibv_mr_internal_ops {
 	fi_ibv_mr_dereg_cb	internal_mr_dereg;
 };
 
-struct fi_ibv_mem_ptr_entry {
-	struct dlist_entry	entry;
-	void			*addr;
-	struct ofi_subscription *subscription;
-	UT_hash_handle		hh;
-};
-
 struct fi_ibv_mem_notifier {
-	struct fi_ibv_mem_ptr_entry	*mem_ptrs_hash;
-	struct util_buf_pool		*mem_ptrs_ent_pool;
+	RbtHandle			subscr_storage;
 	ofi_mem_free_hook		prev_free_hook;
 	ofi_mem_realloc_hook		prev_realloc_hook;
 	int				ref_cnt;
@@ -447,10 +439,10 @@ int fi_ibv_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 			      struct ofi_mr_entry *entry);
 void fi_ibv_mr_cache_entry_dereg(struct ofi_mr_cache *cache,
 				 struct ofi_mr_entry *entry);
-int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier, void *addr,
-			     size_t len, struct ofi_subscription *subscription);
-void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier, void *addr,
-				size_t len, struct ofi_subscription *subscription);
+int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier,
+			     struct ofi_subscription *subscription);
+void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier,
+				struct ofi_subscription *subscription);
 struct ofi_subscription *fi_ibv_monitor_get_event(struct ofi_mem_monitor *notifier);
 
 struct fi_ibv_srq_ep {

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -124,11 +124,7 @@ void fi_ibv_mem_notifier_free_hook(void *ptr, const void *caller)
 	if (!entry)
 		goto out;
 	VERBS_DBG(FI_LOG_MR, "Catch free hook for %p, entry - %p\n", ptr, entry);
-
-	if (!dlist_empty(&entry->entry))
-		dlist_remove_init(&entry->entry);
-	dlist_insert_tail(&entry->entry,
-			  &fi_ibv_mem_notifier->event_list);
+	ofi_monitor_add_event_to_nq(entry->subscription);
 out:
 	FI_IBV_MEMORY_HOOK_END(fi_ibv_mem_notifier)
 }
@@ -150,11 +146,7 @@ void *fi_ibv_mem_notifier_realloc_hook(void *ptr, size_t size, const void *calle
 	if (!entry)
 		goto out;
 	VERBS_DBG(FI_LOG_MR, "Catch realloc hook for %p, entry - %p\n", ptr, entry);
-
-	if (!dlist_empty(&entry->entry))
-		dlist_remove_init(&entry->entry);
-	dlist_insert_tail(&entry->entry,
-			  &fi_ibv_mem_notifier->event_list);
+	ofi_monitor_add_event_to_nq(entry->subscription);
 out:
 	FI_IBV_MEMORY_HOOK_END(fi_ibv_mem_notifier)
 	return ret_ptr;
@@ -208,8 +200,6 @@ static struct fi_ibv_mem_notifier *fi_ibv_mem_notifier_init(void)
 	if (pthread_mutex_init(&fi_ibv_mem_notifier->lock, &mutex_attr))
 		goto err2;
 	pthread_mutexattr_destroy(&mutex_attr);
-
-	dlist_init(&fi_ibv_mem_notifier->event_list);
 
 	pthread_mutex_lock(&fi_ibv_mem_notifier->lock);
 	fi_ibv_mem_notifier->prev_free_hook = ofi_get_mem_free_hook();
@@ -469,7 +459,6 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		_domain->notifier = fi_ibv_mem_notifier_init();
 		_domain->monitor.subscribe = fi_ibv_monitor_subscribe;
 		_domain->monitor.unsubscribe = fi_ibv_monitor_unsubscribe;
-		_domain->monitor.get_event = fi_ibv_monitor_get_event;
 		ofi_monitor_init(&_domain->monitor);
 
 		_domain->cache.max_cached_cnt = fi_ibv_gl_data.mr_max_cached_cnt;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -32,6 +32,7 @@
 
 #include "config.h"
 
+#include "ofi_iov.h"
 #include "ep_rdm/verbs_rdm.h"
 
 #include "fi_verbs.h"
@@ -108,9 +109,39 @@ static void *fi_ibv_rdm_cm_progress_thread(void *dom)
 	return NULL;
 }
 
+void fi_ibv_mem_notifier_handle_hook(void *arg, RbtIterator iter)
+{
+	struct iovec *key;
+	struct ofi_subscription *subscription;
+
+	rbtKeyValue(fi_ibv_mem_notifier->subscr_storage, iter,
+		    (void *)&key, (void *)&subscription);
+
+	VERBS_DBG(FI_LOG_MR, "Write event for region %p:%lu\n",
+		  key->iov_base, key->iov_len);
+	ofi_monitor_add_event_to_nq(subscription);
+}
+
+static inline void
+fi_ibv_mem_notifier_search_iov(struct fi_ibv_mem_notifier *notifier,
+			       struct iovec *iov)
+{
+	RbtIterator iter;
+	iter = rbtFind(notifier->subscr_storage, (void *)iov);
+	if (iter) {
+		VERBS_DBG(FI_LOG_MR, "Catch hook for memory %p:%lu\n",
+			  iov->iov_base, iov->iov_len);
+		rbtTraversal(fi_ibv_mem_notifier->subscr_storage, iter, NULL,
+			     fi_ibv_mem_notifier_handle_hook);
+	}
+}
+
 void fi_ibv_mem_notifier_free_hook(void *ptr, const void *caller)
 {
-	struct fi_ibv_mem_ptr_entry *entry;
+	struct iovec iov = {
+		.iov_base = ptr,
+		.iov_len = malloc_usable_size(ptr),
+	};
 	OFI_UNUSED(caller);
 
 	FI_IBV_MEMORY_HOOK_BEGIN(fi_ibv_mem_notifier)
@@ -119,19 +150,17 @@ void fi_ibv_mem_notifier_free_hook(void *ptr, const void *caller)
 
 	if (!ptr)
 		goto out;
-
-	HASH_FIND(hh, fi_ibv_mem_notifier->mem_ptrs_hash, &ptr, sizeof(void *), entry);
-	if (!entry)
-		goto out;
-	VERBS_DBG(FI_LOG_MR, "Catch free hook for %p, entry - %p\n", ptr, entry);
-	ofi_monitor_add_event_to_nq(entry->subscription);
+	fi_ibv_mem_notifier_search_iov(fi_ibv_mem_notifier, &iov);
 out:
 	FI_IBV_MEMORY_HOOK_END(fi_ibv_mem_notifier)
 }
 
 void *fi_ibv_mem_notifier_realloc_hook(void *ptr, size_t size, const void *caller)
 {
-	struct fi_ibv_mem_ptr_entry *entry;
+	struct iovec iov = {
+		.iov_base = ptr,
+		.iov_len = malloc_usable_size(ptr),
+	};
 	void *ret_ptr;
 	OFI_UNUSED(caller);
 
@@ -141,12 +170,7 @@ void *fi_ibv_mem_notifier_realloc_hook(void *ptr, size_t size, const void *calle
 
 	if (!ptr)
 		goto out;
-
-	HASH_FIND(hh, fi_ibv_mem_notifier->mem_ptrs_hash, &ptr, sizeof(void *), entry);
-	if (!entry)
-		goto out;
-	VERBS_DBG(FI_LOG_MR, "Catch realloc hook for %p, entry - %p\n", ptr, entry);
-	ofi_monitor_add_event_to_nq(entry->subscription);
+	fi_ibv_mem_notifier_search_iov(fi_ibv_mem_notifier, &iov);
 out:
 	FI_IBV_MEMORY_HOOK_END(fi_ibv_mem_notifier)
 	return ret_ptr;
@@ -161,7 +185,7 @@ static void fi_ibv_mem_notifier_finalize(struct fi_ibv_mem_notifier *notifier)
 	if (--fi_ibv_mem_notifier->ref_cnt == 0) {
 		ofi_set_mem_free_hook(fi_ibv_mem_notifier->prev_free_hook);
 		ofi_set_mem_realloc_hook(fi_ibv_mem_notifier->prev_realloc_hook);
-		util_buf_pool_destroy(fi_ibv_mem_notifier->mem_ptrs_ent_pool);
+		rbtDelete(fi_ibv_mem_notifier->subscr_storage);
 		fi_ibv_mem_notifier->prev_free_hook = NULL;
 		fi_ibv_mem_notifier->prev_realloc_hook = NULL;
 		pthread_mutex_unlock(&fi_ibv_mem_notifier->lock);
@@ -174,10 +198,35 @@ static void fi_ibv_mem_notifier_finalize(struct fi_ibv_mem_notifier *notifier)
 #endif
 }
 
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
+static int fi_ibv_mem_notifier_find_within(void *a, void *b)
+{
+	struct iovec *iov1 = a, *iov2 = b;
+
+	if (ofi_iov_shifted_left(iov1, iov2))
+		return -1;
+	else if (ofi_iov_shifted_right(iov1, iov2))
+		return 1;
+	else
+		return 0;
+}
+
+static int fi_ibv_mem_notifier_find_overlap(void *a, void *b)
+{
+	struct iovec *iov1 = a, *iov2 = b;
+
+	if (ofi_iov_left(iov1, iov2))
+		return -1;
+	else if (ofi_iov_right(iov1, iov2))
+		return 1;
+	else
+		return 0;
+}
+#endif
+
 static struct fi_ibv_mem_notifier *fi_ibv_mem_notifier_init(void)
 {
 #ifdef HAVE_GLIBC_MALLOC_HOOKS
-	int ret;
 	pthread_mutexattr_t mutex_attr;
 	if (fi_ibv_mem_notifier) {
 		/* already initialized */
@@ -188,11 +237,11 @@ static struct fi_ibv_mem_notifier *fi_ibv_mem_notifier_init(void)
 	if (!fi_ibv_mem_notifier)
 		goto fn;
 
-	ret = util_buf_pool_create(&fi_ibv_mem_notifier->mem_ptrs_ent_pool,
-				   sizeof(struct fi_ibv_mem_ptr_entry),
-				   FI_IBV_MEM_ALIGNMENT, 0,
-				   fi_ibv_gl_data.mr_max_cached_cnt);
-	if (ret)
+	fi_ibv_mem_notifier->subscr_storage =
+		rbtNew(fi_ibv_gl_data.mr_cache_merge_regions ?
+		       fi_ibv_mem_notifier_find_overlap :
+		       fi_ibv_mem_notifier_find_within);
+	if (!fi_ibv_mem_notifier->subscr_storage)
 		goto err1;
 
 	pthread_mutexattr_init(&mutex_attr);
@@ -212,7 +261,7 @@ fn:
 	return fi_ibv_mem_notifier;
 
 err2:
-	util_buf_pool_destroy(fi_ibv_mem_notifier->mem_ptrs_ent_pool);
+	rbtDelete(fi_ibv_mem_notifier->subscr_storage);
 err1:
 	free(fi_ibv_mem_notifier);
 	fi_ibv_mem_notifier = NULL;

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -376,56 +376,43 @@ static struct fi_ops fi_ibv_mr_cache_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
-int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier, void *addr,
-			     size_t len, struct ofi_subscription *subscription)
+int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier,
+			     struct ofi_subscription *subscription)
 {
 	struct fi_ibv_domain *domain =
 		container_of(notifier, struct fi_ibv_domain, monitor);
-	struct fi_ibv_mem_ptr_entry *entry;
-	int ret = FI_SUCCESS;
+	int ret;
 
 	pthread_mutex_lock(&domain->notifier->lock);
 	ofi_set_mem_free_hook(domain->notifier->prev_free_hook);
 	ofi_set_mem_realloc_hook(domain->notifier->prev_realloc_hook);
 
-	entry = util_buf_alloc(domain->notifier->mem_ptrs_ent_pool);
-	if (OFI_UNLIKELY(!entry)) {
-		ret = -FI_ENOMEM;
-		goto fn;
-	}
+	ret = (rbtInsert(domain->notifier->subscr_storage,
+		         (void *)&subscription->iov,
+			 (void *)subscription) != RBT_STATUS_OK) ?
+	       -FI_EAVAIL : FI_SUCCESS;
 
-	entry->addr = addr;
-	entry->subscription = subscription;
-	dlist_init(&entry->entry);
-	HASH_ADD(hh, domain->notifier->mem_ptrs_hash, addr, sizeof(void *), entry);
-
-fn:
 	ofi_set_mem_free_hook(fi_ibv_mem_notifier_free_hook);
 	ofi_set_mem_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
 	pthread_mutex_unlock(&domain->notifier->lock);
 	return ret;
 }
 
-void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier, void *addr,
-				size_t len, struct ofi_subscription *subscription)
+void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier,
+				struct ofi_subscription *subscription)
 {
 	struct fi_ibv_domain *domain =
 		container_of(notifier, struct fi_ibv_domain, monitor);
-	struct fi_ibv_mem_ptr_entry *entry;
+	RbtIterator iter;
 
 	pthread_mutex_lock(&domain->notifier->lock);
 	ofi_set_mem_free_hook(domain->notifier->prev_free_hook);
 	ofi_set_mem_realloc_hook(domain->notifier->prev_realloc_hook);
 
-	HASH_FIND(hh, domain->notifier->mem_ptrs_hash, &addr, sizeof(void *), entry);
-	assert(entry);
-
-	HASH_DEL(domain->notifier->mem_ptrs_hash, entry);
-
-	if (!dlist_empty(&entry->entry))
-		dlist_remove_init(&entry->entry);
-
-	util_buf_release(domain->notifier->mem_ptrs_ent_pool, entry);
+	iter = rbtFind(domain->notifier->subscr_storage,
+		       (void *)&subscription->iov);
+	assert(iter);
+	rbtErase(domain->notifier->subscr_storage, iter);
 
 	ofi_set_mem_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
 	ofi_set_mem_free_hook(fi_ibv_mem_notifier_free_hook);

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -432,32 +432,6 @@ void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier, void *addr,
 	pthread_mutex_unlock(&domain->notifier->lock);
 }
 
-struct ofi_subscription *
-fi_ibv_monitor_get_event(struct ofi_mem_monitor *notifier)
-{
-	struct fi_ibv_domain *domain =
-		container_of(notifier, struct fi_ibv_domain, monitor);
-	struct fi_ibv_mem_ptr_entry *entry;
-
-	pthread_mutex_lock(&domain->notifier->lock);
-	if (!dlist_empty(&domain->notifier->event_list)) {
-		dlist_pop_front(&domain->notifier->event_list,
-				struct fi_ibv_mem_ptr_entry,
-				entry, entry);
-		VERBS_DBG(FI_LOG_MR,
-			  "Retrieve %p (entry %p) from event list\n",
-			  entry->addr, entry);
-		/* needed to protect against double insertions */
-		dlist_init(&entry->entry);
-
-		pthread_mutex_unlock(&domain->notifier->lock);
-		return entry->subscription;
-	} else {
-		pthread_mutex_unlock(&domain->notifier->lock);
-		return NULL;
-	}
-}
-
 int fi_ibv_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 			      struct ofi_mr_entry *entry)
 {

--- a/src/rbtree.c
+++ b/src/rbtree.c
@@ -434,3 +434,24 @@ void *rbtFind(RbtHandle h, void *key) {
     }
     return NULL;
 }
+
+void rbtTraversal(RbtHandle h, RbtIterator it, void *handler_arg,
+          void(*handler)(void *arg, RbtIterator it)) {
+    RbtType *rbt = h;
+    NodeType *root = it;
+
+    // apply handler for:
+    // -o the root of the tree/subtree
+    handler(handler_arg, it);
+    // - the left subtree
+    if (root->left != SENTINEL)
+        rbtTraversal(h, root->left, handler_arg, handler);
+    // - the right subtree
+    if (root->right != SENTINEL)
+        rbtTraversal(h, root->right, handler_arg, handler);
+}
+
+void *rbtRoot(RbtHandle h) {
+    RbtType *rbt = h;
+    return rbt->root;
+}


### PR DESCRIPTION
This PR consists from 3 commits:
- **util/mem_monitor, prov/verbs: Write free/realloc events from hooks to NQ event list**
The current implementation works as follows:
Events from free/realloc hooks (if an user subscribes on this memory address)
are written to its own intermediate event list and then they are written to
a NQ's event list.

The commint improves current implementation by removing intermediate event list
of notifier. The notifier (verbs global notifier) inserts events directly
into the NQ's event list.
- **common/rbtree: Add tree traversal and get root routine**
The commit adds two routines:
-- tree traversal that applies user-provided handler function for each node
-- get root of a tree
- **prov/verbs, util/mem_monitor: Fix notofication mechanism for MR cache**
The commit fixes notification mechanism provided by Verbs.
The issue was that if user allocates large buffer (ptr:size) and issues
fi_mr_reg() for the segments (ptr1:size1, ptr2:size2, ..., ptrN:sizeN)
of this buffer. And then calls free() for large buffer, the segements won't
be released (The notification will be generated only for the first segment,
if ptr = ptr1).
This commit replaces UT Hash by Red-Black Tree for searching regions for
which the notifier should generate events.