### PR TITLE
util/cmap:  Fix handling of simultaneous connection establishment

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -70,31 +70,30 @@
 
 #define OFI_CNTR_ENABLED	(1ULL << 61)
 
-#define OFI_Q_STRERROR(prov, log, q, q_str, entry, strerror)			\
-	FI_WARN(prov, log, "fi_" q_str "_readerr: err: %d, prov_err: %s (%d)\n",\
-			entry.err,						\
-			strerror(q, entry.prov_errno, entry.err_data, NULL, 0), \
-			entry.prov_errno)
+#define OFI_Q_STRERROR(prov, log, q, q_str, entry, strerror)					\
+	FI_WARN(prov, log, "fi_" q_str "_readerr: err: %d, prov_err: %s (%d)\n",		\
+		(entry).err,strerror((q), (entry).prov_errno, (entry).err_data, NULL, 0),	\
+		(entry).prov_errno)
 
 #define OFI_Q_READERR(prov, log, q, q_str, readerr, strerror, ret, err_entry)	\
 	do {									\
-		ret = readerr(q, &err_entry, 0);				\
-		if (ret != sizeof(err_entry)) {					\
+		(ret) = readerr((q), &(err_entry), 0);				\
+		if ((ret) != sizeof(err_entry)) {				\
 			FI_WARN(prov, log,					\
-					"Unable to fi_" q_str "_readerr\n");	\
+				"Unable to fi_" q_str "_readerr\n");		\
 		} else {							\
 			OFI_Q_STRERROR(prov, log, q, q_str,			\
-					err_entry, strerror);			\
+				       err_entry, strerror);			\
 		}								\
 	} while (0)
 
 #define OFI_CQ_READERR(prov, log, cq, ret, err_entry)		\
 	OFI_Q_READERR(prov, log, cq, "cq", fi_cq_readerr,	\
-			fi_cq_strerror, ret, err_entry)
+		      fi_cq_strerror, ret, err_entry)
 
 #define OFI_EQ_READERR(prov, log, eq, ret, err_entry)		\
 	OFI_Q_READERR(prov, log, eq, "eq", fi_eq_readerr, 	\
-			fi_eq_strerror, ret, err_entry)
+		      fi_eq_strerror, ret, err_entry)
 
 #define FI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type)	\
 	do {										\

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -608,6 +608,11 @@ enum util_cmap_state {
 	CMAP_SHUTDOWN,
 };
 
+enum util_cmap_reject_flag {
+	CMAP_REJECT_GENUINE,
+	CMAP_REJECT_SIMULT_CONN,
+};
+
 struct util_cmap_handle {
 	struct util_cmap *cmap;
 	enum util_cmap_state state;
@@ -685,9 +690,11 @@ void ofi_cmap_process_connect(struct util_cmap *cmap,
 			      struct util_cmap_handle *handle,
 			      uint64_t *remote_key);
 void ofi_cmap_process_reject(struct util_cmap *cmap,
-			     struct util_cmap_handle *handle);
+			     struct util_cmap_handle *handle,
+			     enum util_cmap_reject_flag cm_reject_flag);
 int ofi_cmap_process_connreq(struct util_cmap *cmap, void *addr,
-			     struct util_cmap_handle **handle);
+			     struct util_cmap_handle **handle_ret,
+			     enum util_cmap_reject_flag *cm_reject_flag);
 void ofi_cmap_process_shutdown(struct util_cmap *cmap,
 			       struct util_cmap_handle *handle);
 void ofi_cmap_del_handle(struct util_cmap_handle *handle);

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -754,6 +754,9 @@ struct util_event {
 
 int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		 struct fid_eq **eq_fid, void *context);
+void ofi_eq_handle_err_entry(uint32_t api_version,
+			     struct fi_eq_err_entry *err_entry,
+			     struct fi_eq_err_entry *user_err_entry);
 
 /*
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -741,6 +741,9 @@ struct util_eq {
 	const struct fi_provider *prov;
 
 	struct slist		list;
+	/* This contains error data that are read by user and need to
+	 * be freed in subsequent fi_eq_readerr call against the EQ */
+	void			*saved_err_data;
 	int			internal_wait;
 };
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -70,7 +70,6 @@
 #define RXM_SAR_TX_ERROR	UINT64_MAX
 #define RXM_SAR_RX_INIT		UINT64_MAX
 
-
 #define RXM_IOV_LIMIT 4
 
 #define RXM_MR_MODES	(OFI_MR_BASIC_MAP | FI_MR_LOCAL)
@@ -443,7 +442,7 @@ struct rxm_msg_eq_entry {
 	ssize_t			rd;
 	uint32_t		event;
 	/* Used for connection refusal */
-	void			*context;
+	struct fi_eq_err_entry	err_entry;
 	/* must stay at the bottom */
 	struct fi_eq_cm_entry	cm_entry;
 };

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -137,11 +137,11 @@ struct rxm_ep_wire_proto {
 	uint8_t	ctrl_version;
 	uint8_t	op_version;
 	uint8_t endianness;
-	uint8_t padding[6];
 	uint64_t eager_size;
 };
 
 struct rxm_cm_data {
+	uint32_t prov_version;
 	struct sockaddr name;
 	uint64_t conn_id;
 	struct rxm_ep_wire_proto proto;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -953,7 +953,7 @@ static int tcpx_pep_reject(struct fid_pep *pep, fid_t handle,
 	memset(&hdr, 0, sizeof(hdr));
 	hdr.version = OFI_CTRL_VERSION;
 	hdr.type = ofi_ctrl_nack;
-	hdr.seg_size = paramlen;
+	hdr.seg_size = htons((uint16_t) paramlen);
 
 	ofi_send_socket(tcpx_handle->conn_fd, &hdr,
 			sizeof(hdr), 0);

--- a/prov/tcp/src/tcpx_eq.c
+++ b/prov/tcp/src/tcpx_eq.c
@@ -68,9 +68,17 @@ static ssize_t tcpx_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 	if (event)
 		*event = entry->event;
 	if (buf) {
-		ret = MIN(len, (size_t)entry->size);
-		memcpy(buf, entry->data, ret);
-	}  else {
+		if (flags & UTIL_FLAG_ERROR) {
+			assert((size_t)entry->size == sizeof(struct fi_eq_err_entry));
+			ofi_eq_handle_err_entry(eq->fabric->fabric_fid.api_version,
+						(struct fi_eq_err_entry *)entry->data,
+						(struct fi_eq_err_entry *)buf);
+			ret = (ssize_t)entry->size;
+		} else {
+			ret = MIN(len, (size_t)entry->size);
+			memcpy(buf, entry->data, ret);
+		}
+	} else {
 		ret = 0;
 	}
 

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -36,6 +36,32 @@
 #include <ofi_enosys.h>
 #include <ofi_util.h>
 
+void ofi_eq_handle_err_entry(uint32_t api_version,
+			     struct fi_eq_err_entry *err_entry,
+			     struct fi_eq_err_entry *user_err_entry)
+{
+	if ((FI_VERSION_GE(api_version, FI_VERSION(1, 5)))
+	    && user_err_entry->err_data && user_err_entry->err_data_size) {
+		void *err_data = user_err_entry->err_data;
+		size_t err_data_size = MIN(err_entry->err_data_size,
+					   user_err_entry->err_data_size);
+
+		memcpy(err_data, err_entry->err_data, err_data_size);
+
+		*user_err_entry = *err_entry;
+		user_err_entry->err_data = err_data;
+		user_err_entry->err_data_size = err_data_size;
+
+		free(err_entry->err_data);
+		err_entry->err_data = NULL;
+		err_entry->err_data_size = 0;
+	} else {
+		*user_err_entry = *err_entry;
+	}
+
+	err_entry->err = 0;
+	err_entry->prov_errno = 0;
+}
 
 static ssize_t util_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 			    void *buf, size_t len, uint64_t flags)
@@ -64,8 +90,16 @@ static ssize_t util_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 	if (event)
 		*event = entry->event;
 	if (buf) {
-		ret = MIN(len, (size_t)entry->size);
-		memcpy(buf, entry->data, ret);
+		if (flags & UTIL_FLAG_ERROR) {
+			assert((size_t)entry->size == sizeof(struct fi_eq_err_entry));
+			ofi_eq_handle_err_entry(eq->fabric->fabric_fid.api_version,
+						(struct fi_eq_err_entry *)entry->data,
+						(struct fi_eq_err_entry *)buf);
+			ret = (ssize_t)entry->size;
+		} else {
+			ret = MIN(len, (size_t)entry->size);
+			memcpy(buf, entry->data, ret);
+		}
 	}  else {
 		ret = 0;
 	}
@@ -94,7 +128,7 @@ static ssize_t util_eq_write(struct fid_eq *eq_fid, uint32_t event,
 	struct util_event *entry;
 
 	eq = container_of(eq_fid, struct util_eq, eq_fid);
-	entry = malloc(sizeof(*entry) + len);
+	entry = calloc(1, sizeof(*entry) + len);
 	if (!entry)
 		return -FI_ENOMEM;
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -110,6 +110,8 @@
 
 #define VERBS_INJECT_FLAG	((uint64_t)-1)
 
+#define VERBS_CM_DATA_SIZE	(56 - sizeof(struct fi_ibv_cm_data_hdr))
+
 #define VERBS_DGRAM_MSG_PREFIX_SIZE	(40)
 
 #define FI_IBV_EP_TYPE(info)						\
@@ -433,6 +435,11 @@ struct fi_ops_msg fi_ibv_msg_srq_ep_msg_ops;
 struct fi_ibv_connreq {
 	struct fid		handle;
 	struct rdma_cm_id	*id;
+};
+
+struct fi_ibv_cm_data_hdr {
+	uint8_t	size;
+	char	data[];
 };
 
 int fi_ibv_sockaddr_len(struct sockaddr *addr);

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -34,7 +34,6 @@
 
 #include "fi_verbs.h"
 
-#define VERBS_CM_DATA_SIZE 56
 #define VERBS_RESOLVE_TIMEOUT 2000	// ms
 
 static int fi_ibv_ep_getopt(fid_t fid, int level, int optname,

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -34,6 +34,7 @@
 
 #include <ifaddrs.h>
 #include <net/if.h>
+#include <stdint.h>
 
 #include "fi_verbs.h"
 
@@ -83,8 +84,9 @@ const struct fi_domain_attr verbs_domain_attr = {
 	.max_ep_tx_ctx		= 1,
 	.max_ep_rx_ctx		= 1,
 	.mr_iov_limit		= VERBS_MR_IOV_LIMIT,
-	/* max_err_data is size of ibv_wc::vendor_err for CQ, 0 - for EQ */
-	.max_err_data		= sizeof_field(struct ibv_wc, vendor_err),
+	/* max_err_data is size of ibv_wc::vendor_err for CQ, UINT8_MAX - for EQ */
+	.max_err_data		= MAX(sizeof_field(struct ibv_wc, vendor_err),
+				      UINT8_MAX),
 };
 
 const struct fi_ep_attr verbs_ep_attr = {


### PR DESCRIPTION
When RxM provider handles a connection request for connection handle with
connection state = `CMAP_CONNREQ_SENT` (it means that both peers send
a connection request to each other) and its address is lower than
remote side's address, it closes MSG EP and doesn't delete the connection
handle. But the remote side sends connection reject and this leads that
handle will be deleted.

The fix is pretty simple - don't delete connection if reject/shutdown is
received by provider in case of bi-directional connection establishment.
This handle will be re-used by provider to accept the connection request.

The issue is pretty stable to be reproduced with RxM/tcp provider on MPI
collective operations with ranks >= 4. When the issue is reprocuded,
fi_[t]send*/inject operations fail with `-FI_ENOTCONN` error.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>