### PR TITLE
 prov/rxm: Don't increment error counter when inject operation failed

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -771,37 +771,6 @@ rxm_acquire_conn_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
 	return 0;
 }
 
-static inline ssize_t
-rxm_ep_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-		   struct rxm_pkt *tx_pkt, size_t pkt_size)
-{
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting inject with length: %" PRIu64
-	       " tag: 0x%" PRIx64 "\n", pkt_size, tx_pkt->hdr.tag);
-	ssize_t ret = fi_inject(rxm_conn->msg_ep, tx_pkt, pkt_size, 0);
-	if (OFI_UNLIKELY(ret)) {
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-		       "fi_inject for MSG provider failed\n");
-		if (OFI_LIKELY(ret == -FI_EAGAIN)) {
-			rxm_ep_progress_multi(&rxm_ep->util_ep);
-		} else {
-			rxm_cntr_incerr(rxm_ep->util_ep.tx_cntr);
-		}
-	} else {
-		rxm_cntr_inc(rxm_ep->util_ep.tx_cntr);
-	}
-	return ret;
-}
-
-static inline ssize_t
-rxm_ep_normal_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-		   struct rxm_tx_entry *tx_entry, size_t pkt_size)
-{
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting send with length: %" PRIu64
-	       " tag: 0x%" PRIx64 "\n", pkt_size, tx_entry->tx_buf->pkt.hdr.tag);
-	return fi_send(rxm_conn->msg_ep, &tx_entry->tx_buf->pkt, pkt_size,
-		       tx_entry->tx_buf->hdr.desc, 0, tx_entry);
-}
-
 /* Returns FI_SUCCESS if the SAR deferred TX queue is empty,
  * otherwise, it returns -FI_EAGAIN or error from MSG provider */
 static inline ssize_t

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -797,16 +797,14 @@ rxm_ep_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting inject with length: %" PRIu64
 	       " tag: 0x%" PRIx64 "\n", pkt_size, tx_pkt->hdr.tag);
 	ssize_t ret = fi_inject(rxm_conn->msg_ep, tx_pkt, pkt_size, 0);
-	if (OFI_UNLIKELY(ret)) {
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-		       "fi_inject for MSG provider failed\n");
-		if (OFI_LIKELY(ret == -FI_EAGAIN)) {
-			rxm_ep_progress_multi(&rxm_ep->util_ep);
-		} else {
-			rxm_cntr_incerr(rxm_ep->util_ep.tx_cntr);
-		}
-	} else {
+	if (OFI_LIKELY(!ret)) {
 		rxm_cntr_inc(rxm_ep->util_ep.tx_cntr);
+	} else {
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
+		       "fi_inject for MSG provider failed with ret - %" PRIu64"\n",
+		       ret);
+		if (OFI_LIKELY(ret == -FI_EAGAIN))
+			rxm_ep_progress_multi(&rxm_ep->util_ep);
 	}
 	return ret;
 }

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -791,6 +791,37 @@ static ssize_t rxm_rma_iov_init(struct rxm_ep *rxm_ep, void *buf,
 }
 
 static inline ssize_t
+rxm_ep_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+		   struct rxm_pkt *tx_pkt, size_t pkt_size)
+{
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting inject with length: %" PRIu64
+	       " tag: 0x%" PRIx64 "\n", pkt_size, tx_pkt->hdr.tag);
+	ssize_t ret = fi_inject(rxm_conn->msg_ep, tx_pkt, pkt_size, 0);
+	if (OFI_UNLIKELY(ret)) {
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
+		       "fi_inject for MSG provider failed\n");
+		if (OFI_LIKELY(ret == -FI_EAGAIN)) {
+			rxm_ep_progress_multi(&rxm_ep->util_ep);
+		} else {
+			rxm_cntr_incerr(rxm_ep->util_ep.tx_cntr);
+		}
+	} else {
+		rxm_cntr_inc(rxm_ep->util_ep.tx_cntr);
+	}
+	return ret;
+}
+
+static inline ssize_t
+rxm_ep_normal_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
+		   struct rxm_tx_entry *tx_entry, size_t pkt_size)
+{
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting send with length: %" PRIu64
+	       " tag: 0x%" PRIx64 "\n", pkt_size, tx_entry->tx_buf->pkt.hdr.tag);
+	return fi_send(rxm_conn->msg_ep, &tx_entry->tx_buf->pkt, pkt_size,
+		       tx_entry->tx_buf->hdr.desc, 0, tx_entry);
+}
+
+static inline ssize_t
 rxm_ep_format_tx_res_lightweight(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 				 size_t len, uint64_t data, uint64_t flags, uint64_t tag,
 				 struct rxm_tx_buf **tx_buf, struct rxm_buf_pool *pool)

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -320,16 +320,14 @@ rxm_ep_rma_inject(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 					      msg->rma_iov->addr,
 					      msg->rma_iov->key);
 		}
-		if (OFI_UNLIKELY(ret)) {
-			FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-				"fi_inject_write* for MSG provider failed\n");
-			if (OFI_LIKELY(ret == -FI_EAGAIN)) {
-				rxm_ep_progress_multi(&rxm_ep->util_ep);
-			} else {
-				rxm_cntr_incerr(rxm_ep->util_ep.wr_cntr);
-			}
-		} else {
+		if (OFI_LIKELY(!ret)) {
 			rxm_cntr_inc(rxm_ep->util_ep.wr_cntr);
+		} else {
+			FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
+			       "fi_inject_write* for MSG provider failed with ret - %"
+			       PRIu64"\n", ret);
+			if (OFI_LIKELY(ret == -FI_EAGAIN))
+				rxm_ep_progress_multi(&rxm_ep->util_ep);
 		}
 		return ret;
 	}


### PR DESCRIPTION
This PR includes the following commits:
- Move send/inject helper function to EP code from header file, because they are used only EP code
- Remove increment of error counter when inject operation failed, because the result of operation is returned to an user immediately