### PR TITLE
prox/rxm: Remove assert since SAR is disabled.

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -99,8 +99,6 @@ static int rxm_finish_buf_recv(struct rxm_rx_buf *rx_buf)
 {
 	uint64_t flags = rx_buf->pkt.hdr.flags | FI_RECV;
 
-	assert(rx_buf->pkt.hdr.size <= rx_buf->ep->sar.limit);
-
 	if (rx_buf->pkt.hdr.size > rx_buf->ep->rxm_info->tx_attr->inject_size)
 		flags |= FI_MORE;
 


### PR DESCRIPTION
Signed-off-by: yohann <yohann.burette@intel.com>