### PR TITLE
prov/verbs: Fix memory notifier usage for multiple domains

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -367,6 +367,16 @@ struct fi_ibv_mem_notifier {
 	pthread_mutex_t			lock;
 };
 
+struct fi_ibv_subscr_entry {
+	struct dlist_entry	entry;
+	struct ofi_subscription	*subscription;
+};
+
+struct fi_ibv_monitor_entry {
+	struct dlist_entry	subscription_list;
+	struct iovec		iov;
+};
+
 void fi_ibv_mem_notifier_free_hook(void *ptr, const void *caller);
 void *fi_ibv_mem_notifier_realloc_hook(void *ptr, size_t size, const void *caller);
 

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -75,14 +75,18 @@ static int fi_ibv_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 void fi_ibv_mem_notifier_handle_hook(void *arg, RbtIterator iter)
 {
 	struct iovec *key;
-	struct ofi_subscription *subscription;
+	struct fi_ibv_subscr_entry *subscr_entry;
+	struct fi_ibv_monitor_entry *entry;
 
 	rbtKeyValue(fi_ibv_mem_notifier->subscr_storage, iter,
-		    (void *)&key, (void *)&subscription);
+		    (void *)&key, (void *)&entry);
+	dlist_foreach_container(&entry->subscription_list, struct fi_ibv_subscr_entry,
+				subscr_entry, entry) {
+		ofi_monitor_add_event_to_nq(subscr_entry->subscription);
+	}
 
 	VERBS_DBG(FI_LOG_MR, "Write event for region %p:%lu\n",
 		  key->iov_base, key->iov_len);
-	ofi_monitor_add_event_to_nq(subscription);
 }
 
 static inline void


### PR DESCRIPTION
Handle duplicated insertion to rbtree by having abstraction entry
that may contain several sucription entries.
This allows to useVerbs notification mechanism (and as a result
MR caching functionality) per several domains.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>