### PR TITLE
contrib/cray: Send pipeline email notifications 

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -287,6 +287,29 @@ pipeline {
                 }
             }
         }
+        changed {
+            script {
+                // send email when the state of the pipeline changes
+                // only sends email to @cray.com
+                def emailBody = '${SCRIPT, template="libfabric-template.groovy"}'
+                def providers = []
+                def defaultMailer = ''
+
+                if (env.BRANCH_NAME == 'master') {
+                    defaultMailer = mailingList()
+                } else {
+                    providers.add ( [$class: 'CulpritsRecipientProvider'] )
+                    providers.add ( [$class: 'RequesterRecipientProvider'] )
+                    providers.add ( [$class: 'DevelopersRecipientProvider'] )
+                }
+                emailext subject: '$DEFAULT_SUBJECT',
+                    body: emailBody,
+                    mimeType: 'text/html',
+                    recipientProviders: providers,
+                    replyTo: '$DEFAULT_REPLYTO',
+                    to: defaultMailer
+             }
+        }
     }
     environment {
         GIT_SHORT_COMMIT = "$GIT_COMMIT"


### PR DESCRIPTION
Added email notification section to send email when
the state of the pipeline changes.

@tonyzinger  @rmeegan 