### PR TITLE
core: Handle struct fid_nic through various API calls

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -118,6 +118,7 @@ void ofi_free_filter(struct fi_filter *filter);
 int ofi_apply_filter(struct fi_filter *filter, const char *name);
 
 int ofi_nic_close(struct fid *fid);
+struct fid_nic *ofi_nic_dup(const struct fid_nic *nic);
 
 void fi_log_init(void);
 void fi_log_fini(void);

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -117,6 +117,8 @@ void ofi_create_filter(struct fi_filter *filter, const char *env_name);
 void ofi_free_filter(struct fi_filter *filter);
 int ofi_apply_filter(struct fi_filter *filter, const char *name);
 
+int ofi_nic_close(struct fid *fid);
+
 void fi_log_init(void);
 void fi_log_fini(void);
 void fi_param_init(void);

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -63,6 +63,17 @@ static inline void *mem_dup(const void *src, size_t size)
 	return dest;
 }
 
+static inline int ofi_str_dup(const char *src, char **dst)
+{
+	if (src) {
+		*dst = strdup(src);
+		if (!*dst)
+			return -FI_ENOMEM;
+	} else {
+		*dst = NULL;
+	}
+	return 0;
+}
 
 /*
  * Buffer pool (free stack) template

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -483,7 +483,8 @@ struct fi_ops {
 	int	(*bind)(struct fid *fid, struct fid *bfid, uint64_t flags);
 	int	(*control)(struct fid *fid, int command, void *arg);
 	int	(*ops_open)(struct fid *fid, const char *name,
-			uint64_t flags, void **ops, void *context);
+			    uint64_t flags, void **ops, void *context);
+	int	(*tostr)(const struct fid *fid, char *buf, size_t len);
 };
 
 /* All fabric interface descriptors must start with this structure */
@@ -626,7 +627,7 @@ enum fi_type {
 	FI_TYPE_CQ_EVENT_FLAGS,
 	FI_TYPE_MR_MODE,
 	FI_TYPE_OP_TYPE,
-	FI_TYPE_DEVICE_ATTR,
+	FI_TYPE_FID,
 };
 
 char *fi_tostr(const void *data, enum fi_type datatype);

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -430,7 +430,7 @@ struct fi_bus_attr {
 	enum fi_bus_type	bus_type;
 	union {
 		struct fi_pci_attr	pci;
-	};
+	} attr;
 };
 
 enum fi_link_state {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -579,6 +579,7 @@ enum {
 	FI_CANCEL_WORK,		/* struct fi_deferred_work */
 	FI_FLUSH_WORK,		/* NULL */
 	FI_REFRESH,		/* mr: fi_mr_modify */
+	FI_DUP,			/* struct fid ** */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -141,6 +141,9 @@ datatype or field value.
 *FI_TYPE_OP_TYPE*
 : enum fi_op_type
 
+*FI_TYPE_FID*
+: struct fid *
+
 fi_tostr() will return a pointer to an internal libfabric buffer that
 should not be modified, and will be overwritten the next time
 fi_tostr() is invoked.  fi_tostr() is not thread safe.

--- a/man/fi_nic.3.md
+++ b/man/fi_nic.3.md
@@ -49,7 +49,7 @@ struct fi_bus_attr {
 	enum fi_bus_type       bus_type;
 	union {
 		struct fi_pci_attr pci;
-	};
+	} attr;
 };
 
 struct fi_link_attr {
@@ -96,19 +96,19 @@ the system.
 : Indicates the type of system bus where the NIC is located.  Valid values
   are FI_BUS_PCI or FI_BUS_UNKNOWN.
 
-*pci.domain_id*
+*attr.pci.domain_id*
 : The domain where the PCI bus is located.  Valid only if bus_type is
   FI_BUS_PCI.
 
-*pci.bus_id*
+*attr.pci.bus_id*
 : The PCI bus identifier where the device is located.  Valid only if
   bus_type is FI_BUS_PCI.
 
-*pci.device_id*
+*attr.pci.device_id*
 : The identifier on the PCI bus where the device is located.  Valid only
   if bus_type is FI_BUS_PCI.
 
-*pci.function_id*
+*attr.pci.function_id*
 : The function on the device being referenced.  Valid only if bus_type is
   FI_BUS_PCI.
 

--- a/man/fi_nic.3.md
+++ b/man/fi_nic.3.md
@@ -141,9 +141,11 @@ into the fabric.
 Provider attributes reference provider specific details of the device.
 These attributes are both provider and device specific.  The attributes
 can be interpretted by [`fi_tostr`(3)](fi_tostr.3.html).  Applications
-may also use the other attribute fields to determine an appropriate
-structure to cast the attributes to.  The format and definition of this
-field is outside the scope of libfabric.
+may also use the other attribute fields, such as related fi_fabric_attr:
+prov_name field, to determine an appropriate structure to cast the
+attributes.  The format and definition of this field is outside the
+scope of the libfabric core framework, but may be available as part
+of a provider specific header file included with libfabric package.
 
 # NOTES
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -512,9 +512,23 @@ int ofi_nic_close(struct fid *fid)
 	return 0;
 }
 
+int ofi_nic_control(struct fid *fid, int command, void *arg)
+{
+	struct fid_nic **nic = (struct fid_nic **) arg;
+
+	switch(command) {
+	case FI_DUP:
+		*nic = ofi_nic_dup(*nic);
+		return *nic ? FI_SUCCESS : -FI_ENOMEM;
+	default:
+		return -FI_ENOSYS;
+	}
+}
+
 struct fi_ops default_nic_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = ofi_nic_close,
+	.control = ofi_nic_control,
 };
 
 static int ofi_dup_dev_attr(const struct fi_device_attr *attr,

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -512,6 +512,108 @@ int ofi_nic_close(struct fid *fid)
 	return 0;
 }
 
+struct fi_ops default_nic_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = ofi_nic_close,
+};
+
+static int ofi_dup_dev_attr(const struct fi_device_attr *attr,
+			    struct fi_device_attr **dup_attr)
+{
+	*dup_attr = calloc(1, sizeof(**dup_attr));
+	if (!*dup_attr)
+		return -FI_ENOMEM;
+
+	if (ofi_str_dup(attr->name, &(*dup_attr)->name) ||
+	    ofi_str_dup(attr->device_id, &(*dup_attr)->device_id) ||
+	    ofi_str_dup(attr->device_version, &(*dup_attr)->device_version) ||
+	    ofi_str_dup(attr->vendor_id, &(*dup_attr)->vendor_id) ||
+	    ofi_str_dup(attr->driver, &(*dup_attr)->driver) ||
+	    ofi_str_dup(attr->firmware, &(*dup_attr)->firmware))
+		return -FI_ENOMEM;
+
+	return 0;
+}
+
+static int ofi_dup_bus_attr(const struct fi_bus_attr *attr,
+			    struct fi_bus_attr **dup_attr)
+{
+	*dup_attr = calloc(1, sizeof(**dup_attr));
+	if (!*dup_attr)
+		return -FI_ENOMEM;
+
+	**dup_attr = *attr;
+	return 0;
+}
+
+static int ofi_dup_link_attr(const struct fi_link_attr *attr,
+			     struct fi_link_attr **dup_attr)
+{
+	*dup_attr = calloc(1, sizeof(**dup_attr));
+	if (!*dup_attr)
+		return -FI_ENOMEM;
+
+	if (ofi_str_dup(attr->address, &(*dup_attr)->address) ||
+	    ofi_str_dup(attr->network_type, &(*dup_attr)->network_type))
+		return -FI_ENOMEM;
+
+	(*dup_attr)->mtu = attr->mtu;
+	(*dup_attr)->speed = attr->speed;
+	(*dup_attr)->state = attr->state;
+	return 0;
+}
+
+struct fid_nic *ofi_nic_dup(const struct fid_nic *nic)
+{
+	struct fid_nic *dup_nic;
+	int ret;
+
+	dup_nic = calloc(1, sizeof(*dup_nic));
+	if (!dup_nic)
+		return NULL;
+
+	if (!nic) {
+		dup_nic->fid.fclass = FI_CLASS_NIC;
+		dup_nic->device_attr = calloc(1, sizeof(*dup_nic->device_attr));
+		dup_nic->bus_attr = calloc(1, sizeof(*dup_nic->bus_attr));
+		dup_nic->link_attr = calloc(1, sizeof(*dup_nic->link_attr));
+
+		if (!dup_nic->device_attr || !dup_nic->bus_attr ||
+		    !dup_nic->link_attr)
+			goto fail;
+
+		dup_nic->fid.ops = &default_nic_ops;
+		return dup_nic;
+	}
+
+	assert(nic->fid.fclass == FI_CLASS_NIC);
+	dup_nic->fid = nic->fid;
+
+	if (nic->device_attr) {
+		ret = ofi_dup_dev_attr(nic->device_attr, &dup_nic->device_attr);
+		if (ret)
+			goto fail;
+	}
+
+	if (nic->bus_attr) {
+		ret = ofi_dup_bus_attr(nic->bus_attr, &dup_nic->bus_attr);
+		if (ret)
+			goto fail;
+	}
+
+	if (nic->link_attr) {
+		ret = ofi_dup_link_attr(nic->link_attr, &dup_nic->link_attr);
+		if (ret)
+			goto fail;
+	}
+
+	return dup_nic;
+
+fail:
+	ofi_nic_close(&dup_nic->fid);
+	return NULL;
+}
+
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 void DEFAULT_SYMVER_PRE(fi_freeinfo)(struct fi_info *info)
 {

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -481,6 +481,37 @@ FI_DESTRUCTOR(fi_fini(void))
 	ofi_osd_fini();
 }
 
+/* The provider must free any prov_attr data prior to calling this
+ * routine.
+ */
+int ofi_nic_close(struct fid *fid)
+{
+	struct fid_nic *nic = (struct fid_nic *) fid;
+
+	assert(fid && fid->fclass == FI_CLASS_NIC);
+
+	if (nic->device_attr) {
+		free(nic->device_attr->name);
+		free(nic->device_attr->device_id);
+		free(nic->device_attr->device_version);
+		free(nic->device_attr->vendor_id);
+		free(nic->device_attr->driver);
+		free(nic->device_attr->firmware);
+		free(nic->device_attr);
+	}
+
+	free(nic->bus_attr);
+
+	if (nic->link_attr) {
+		free(nic->link_attr->address);
+		free(nic->link_attr->network_type);
+		free(nic->link_attr);
+	}
+
+	free(nic);
+	return 0;
+}
+
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 void DEFAULT_SYMVER_PRE(fi_freeinfo)(struct fi_info *info)
 {

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -64,20 +64,20 @@
  *
  * Printing functions are generally named after this pattern:
  *
- * struct fi_info : fi_tostr_info(..., struct fi_info, ...)
- * fi_info->caps  : fi_tostr_caps(..., typeof(caps), ...)
+ * struct fi_info : ofi_tostr_info(..., struct fi_info, ...)
+ * fi_info->caps  : ofi_tostr_caps(..., typeof(caps), ...)
  */
 
-#define FI_BUFSIZ 8192
+#define OFI_BUFSIZ 8192
 
 #define TAB "    "
 
 #define CASEENUMSTR(SYM) \
-	case SYM: { strcatf(buf, #SYM); break; }
+	case SYM: { ofi_strcatf(buf, #SYM); break; }
 #define IFFLAGSTR(flags, SYM) \
-	do { if (flags & SYM) strcatf(buf, #SYM ", "); } while(0)
+	do { if (flags & SYM) ofi_strcatf(buf, #SYM ", "); } while(0)
 
-static void fi_remove_comma(char *buffer)
+static void ofi_remove_comma(char *buffer)
 {
 	size_t sz = strlen(buffer);
 	if (sz < 2)
@@ -86,25 +86,25 @@ static void fi_remove_comma(char *buffer)
 		buffer[sz-2] = '\0';
 }
 
-static void strcatf(char *dest, const char *fmt, ...)
+static void ofi_strcatf(char *dest, const char *fmt, ...)
 {
-	size_t len = strnlen(dest,FI_BUFSIZ);
+	size_t len = strnlen(dest,OFI_BUFSIZ);
 	va_list arglist;
 
 	va_start (arglist, fmt);
-	vsnprintf(&dest[len], FI_BUFSIZ - 1 - len, fmt, arglist);
+	vsnprintf(&dest[len], OFI_BUFSIZ - 1 - len, fmt, arglist);
 	va_end (arglist);
 }
 
-static void fi_tostr_fid(char *buf, const struct fid *fid)
+static void ofi_tostr_fid(char *buf, const struct fid *fid)
 {
 	if (!fid || !FI_CHECK_OP(fid->ops, struct fi_ops, tostr))
-		strcatf(buf, "%p\n", fid);
+		ofi_strcatf(buf, "%p\n", fid);
 	else
-		fid->ops->tostr(fid, buf, FI_BUFSIZ - strnlen(buf, FI_BUFSIZ));
+		fid->ops->tostr(fid, buf, OFI_BUFSIZ - strnlen(buf, OFI_BUFSIZ));
 }
 
-static void fi_tostr_opflags(char *buf, uint64_t flags)
+static void ofi_tostr_opflags(char *buf, uint64_t flags)
 {
 	IFFLAGSTR(flags, FI_MULTICAST);
 
@@ -125,10 +125,10 @@ static void fi_tostr_opflags(char *buf, uint64_t flags)
 	IFFLAGSTR(flags, FI_CLAIM);
 	IFFLAGSTR(flags, FI_DISCARD);
 
-	fi_remove_comma(buf);
+	ofi_remove_comma(buf);
 }
 
-static void fi_tostr_addr_format(char *buf, uint32_t addr_format)
+static void oofi_tostr_addr_format(char *buf, uint32_t addr_format)
 {
 	switch (addr_format) {
 	CASEENUMSTR(FI_FORMAT_UNSPEC);
@@ -144,26 +144,26 @@ static void fi_tostr_addr_format(char *buf, uint32_t addr_format)
 	CASEENUMSTR(FI_ADDR_STR);
 	default:
 		if (addr_format & FI_PROV_SPECIFIC)
-			strcatf(buf, "Provider specific");
+			ofi_strcatf(buf, "Provider specific");
 		else
-			strcatf(buf, "Unknown");
+			ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_progress(char *buf, enum fi_progress progress)
+static void ofi_tostr_progress(char *buf, enum fi_progress progress)
 {
 	switch (progress) {
 	CASEENUMSTR(FI_PROGRESS_UNSPEC);
 	CASEENUMSTR(FI_PROGRESS_AUTO);
 	CASEENUMSTR(FI_PROGRESS_MANUAL);
 	default:
-		strcatf(buf, "Unknown");
+		ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_threading(char *buf, enum fi_threading threading)
+static void ofi_tostr_threading(char *buf, enum fi_threading threading)
 {
 	switch (threading) {
 	CASEENUMSTR(FI_THREAD_UNSPEC);
@@ -173,12 +173,12 @@ static void fi_tostr_threading(char *buf, enum fi_threading threading)
 	CASEENUMSTR(FI_THREAD_COMPLETION);
 	CASEENUMSTR(FI_THREAD_ENDPOINT);
 	default:
-		strcatf(buf, "Unknown");
+		ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_order(char *buf, uint64_t flags)
+static void ofi_tostr_order(char *buf, uint64_t flags)
 {
 	IFFLAGSTR(flags, FI_ORDER_NONE);
 	IFFLAGSTR(flags, FI_ORDER_RAR);
@@ -193,10 +193,10 @@ static void fi_tostr_order(char *buf, uint64_t flags)
 	IFFLAGSTR(flags, FI_ORDER_STRICT);
 	IFFLAGSTR(flags, FI_ORDER_DATA);
 
-	fi_remove_comma(buf);
+	ofi_remove_comma(buf);
 }
 
-static void fi_tostr_caps(char *buf, uint64_t caps)
+static void ofi_tostr_caps(char *buf, uint64_t caps)
 {
 	IFFLAGSTR(caps, FI_MSG);
 	IFFLAGSTR(caps, FI_RMA);
@@ -227,10 +227,10 @@ static void fi_tostr_caps(char *buf, uint64_t caps)
 	IFFLAGSTR(caps, FI_NAMED_RX_CTX);
 	IFFLAGSTR(caps, FI_DIRECTED_RECV);
 
-	fi_remove_comma(buf);
+	ofi_remove_comma(buf);
 }
 
-static void fi_tostr_ep_type(char *buf, enum fi_ep_type ep_type)
+static void ofi_tostr_ep_type(char *buf, enum fi_ep_type ep_type)
 {
 	switch (ep_type) {
 	CASEENUMSTR(FI_EP_UNSPEC);
@@ -240,12 +240,12 @@ static void fi_tostr_ep_type(char *buf, enum fi_ep_type ep_type)
 	CASEENUMSTR(FI_EP_SOCK_STREAM);
 	CASEENUMSTR(FI_EP_SOCK_DGRAM);
 	default:
-		strcatf(buf, "Unknown");
+		ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_protocol(char *buf, uint32_t protocol)
+static void ofi_tostr_protocol(char *buf, uint32_t protocol)
 {
 	switch (protocol) {
 	CASEENUMSTR(FI_PROTO_UNSPEC);
@@ -267,14 +267,14 @@ static void fi_tostr_protocol(char *buf, uint32_t protocol)
 	CASEENUMSTR(FI_PROTO_RSTREAM);
 	default:
 		if (protocol & FI_PROV_SPECIFIC)
-			strcatf(buf, "Provider specific");
+			ofi_strcatf(buf, "Provider specific");
 		else
-			strcatf(buf, "Unknown");
+			ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_mode(char *buf, uint64_t mode)
+static void ofi_tostr_mode(char *buf, uint64_t mode)
 {
 	IFFLAGSTR(mode, FI_CONTEXT);
 	IFFLAGSTR(mode, FI_MSG_PREFIX);
@@ -286,10 +286,10 @@ static void fi_tostr_mode(char *buf, uint64_t mode)
 	IFFLAGSTR(mode, FI_CONTEXT2);
 	IFFLAGSTR(mode, FI_BUFFERED_RECV);
 
-	fi_remove_comma(buf);
+	ofi_remove_comma(buf);
 }
 
-static void fi_tostr_addr(char *buf, uint32_t addr_format, void *addr)
+static void ofi_tostr_addr(char *buf, uint32_t addr_format, void *addr)
 {
 	char *p;
 	size_t len;
@@ -297,7 +297,7 @@ static void fi_tostr_addr(char *buf, uint32_t addr_format, void *addr)
 	p = buf + strlen(buf);
 
 	if (addr == NULL) {
-		strcatf(p, "(null)");
+		ofi_strcatf(p, "(null)");
 		return;
 	}
 
@@ -305,128 +305,128 @@ static void fi_tostr_addr(char *buf, uint32_t addr_format, void *addr)
 	ofi_straddr(p, &len, addr_format, addr);
 }
 
-static void fi_tostr_tx_attr(char *buf, const struct fi_tx_attr *attr,
+static void ofi_tostr_tx_attr(char *buf, const struct fi_tx_attr *attr,
 			     const char *prefix)
 {
 	if (!attr) {
-		strcatf(buf, "%sfi_tx_attr: (null)\n", prefix);
+		ofi_strcatf(buf, "%sfi_tx_attr: (null)\n", prefix);
 		return;
 	}
 
-	strcatf(buf, "%sfi_tx_attr:\n", prefix);
-	strcatf(buf, "%s%scaps: [ ", prefix, TAB);
-	fi_tostr_caps(buf, attr->caps);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%sfi_tx_attr:\n", prefix);
+	ofi_strcatf(buf, "%s%scaps: [ ", prefix, TAB);
+	ofi_tostr_caps(buf, attr->caps);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%smode: [ ", prefix, TAB);
-	fi_tostr_mode(buf, attr->mode);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%s%smode: [ ", prefix, TAB);
+	ofi_tostr_mode(buf, attr->mode);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%sop_flags: [ ", prefix, TAB);
-	fi_tostr_opflags(buf, attr->op_flags);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%s%sop_flags: [ ", prefix, TAB);
+	ofi_tostr_opflags(buf, attr->op_flags);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%smsg_order: [ ", prefix, TAB);
-	fi_tostr_order(buf, attr->msg_order);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%s%smsg_order: [ ", prefix, TAB);
+	ofi_tostr_order(buf, attr->msg_order);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%scomp_order: [ ", prefix, TAB);
-	fi_tostr_order(buf, attr->comp_order);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%s%scomp_order: [ ", prefix, TAB);
+	ofi_tostr_order(buf, attr->comp_order);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%sinject_size: %zd\n", prefix, TAB, attr->inject_size);
-	strcatf(buf, "%s%ssize: %zd\n", prefix, TAB, attr->size);
-	strcatf(buf, "%s%siov_limit: %zd\n", prefix, TAB, attr->iov_limit);
-	strcatf(buf, "%s%srma_iov_limit: %zd\n", prefix, TAB, attr->rma_iov_limit);
+	ofi_strcatf(buf, "%s%sinject_size: %zd\n", prefix, TAB, attr->inject_size);
+	ofi_strcatf(buf, "%s%ssize: %zd\n", prefix, TAB, attr->size);
+	ofi_strcatf(buf, "%s%siov_limit: %zd\n", prefix, TAB, attr->iov_limit);
+	ofi_strcatf(buf, "%s%srma_iov_limit: %zd\n", prefix, TAB, attr->rma_iov_limit);
 }
 
-static void fi_tostr_rx_attr(char *buf, const struct fi_rx_attr *attr,
+static void ofi_tostr_rx_attr(char *buf, const struct fi_rx_attr *attr,
 			     const char *prefix)
 {
 	if (!attr) {
-		strcatf(buf, "%sfi_rx_attr: (null)\n", prefix);
+		ofi_strcatf(buf, "%sfi_rx_attr: (null)\n", prefix);
 		return;
 	}
 
-	strcatf(buf, "%sfi_rx_attr:\n", prefix);
-	strcatf(buf, "%s%scaps: [ ", prefix, TAB);
-	fi_tostr_caps(buf, attr->caps);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%sfi_rx_attr:\n", prefix);
+	ofi_strcatf(buf, "%s%scaps: [ ", prefix, TAB);
+	ofi_tostr_caps(buf, attr->caps);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%smode: [ ", prefix, TAB);
-	fi_tostr_mode(buf, attr->mode);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%s%smode: [ ", prefix, TAB);
+	ofi_tostr_mode(buf, attr->mode);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%sop_flags: [ ", prefix, TAB);
-	fi_tostr_opflags(buf, attr->op_flags);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%s%sop_flags: [ ", prefix, TAB);
+	ofi_tostr_opflags(buf, attr->op_flags);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%smsg_order: [ ", prefix, TAB);
-	fi_tostr_order(buf, attr->msg_order);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%s%smsg_order: [ ", prefix, TAB);
+	ofi_tostr_order(buf, attr->msg_order);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%scomp_order: [ ", prefix, TAB);
-	fi_tostr_order(buf, attr->comp_order);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%s%scomp_order: [ ", prefix, TAB);
+	ofi_tostr_order(buf, attr->comp_order);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%stotal_buffered_recv: %zd\n", prefix, TAB, attr->total_buffered_recv);
-	strcatf(buf, "%s%ssize: %zd\n", prefix, TAB, attr->size);
-	strcatf(buf, "%s%siov_limit: %zd\n", prefix, TAB, attr->iov_limit);
+	ofi_strcatf(buf, "%s%stotal_buffered_recv: %zd\n", prefix, TAB, attr->total_buffered_recv);
+	ofi_strcatf(buf, "%s%ssize: %zd\n", prefix, TAB, attr->size);
+	ofi_strcatf(buf, "%s%siov_limit: %zd\n", prefix, TAB, attr->iov_limit);
 }
 
-static void fi_tostr_ep_attr(char *buf, const struct fi_ep_attr *attr, const char *prefix)
+static void ofi_tostr_ep_attr(char *buf, const struct fi_ep_attr *attr, const char *prefix)
 {
 	if (!attr) {
-		strcatf(buf, "%sfi_ep_attr: (null)\n", prefix);
+		ofi_strcatf(buf, "%sfi_ep_attr: (null)\n", prefix);
 		return;
 	}
 
-	strcatf(buf, "%sfi_ep_attr:\n", prefix);
-	strcatf(buf, "%s%stype: ", prefix, TAB);
-	fi_tostr_ep_type(buf, attr->type);
-	strcatf(buf, "\n");
-	strcatf(buf, "%s%sprotocol: ", prefix, TAB);
-	fi_tostr_protocol(buf, attr->protocol);
-	strcatf(buf, "\n");
-	strcatf(buf, "%s%sprotocol_version: %d\n", prefix, TAB, attr->protocol_version);
-	strcatf(buf, "%s%smax_msg_size: %zd\n", prefix, TAB, attr->max_msg_size);
-	strcatf(buf, "%s%smsg_prefix_size: %zd\n", prefix, TAB, attr->msg_prefix_size);
-	strcatf(buf, "%s%smax_order_raw_size: %zd\n", prefix, TAB, attr->max_order_raw_size);
-	strcatf(buf, "%s%smax_order_war_size: %zd\n", prefix, TAB, attr->max_order_war_size);
-	strcatf(buf, "%s%smax_order_waw_size: %zd\n", prefix, TAB, attr->max_order_waw_size);
-	strcatf(buf, "%s%smem_tag_format: 0x%016llx\n", prefix, TAB, attr->mem_tag_format);
+	ofi_strcatf(buf, "%sfi_ep_attr:\n", prefix);
+	ofi_strcatf(buf, "%s%stype: ", prefix, TAB);
+	ofi_tostr_ep_type(buf, attr->type);
+	ofi_strcatf(buf, "\n");
+	ofi_strcatf(buf, "%s%sprotocol: ", prefix, TAB);
+	ofi_tostr_protocol(buf, attr->protocol);
+	ofi_strcatf(buf, "\n");
+	ofi_strcatf(buf, "%s%sprotocol_version: %d\n", prefix, TAB, attr->protocol_version);
+	ofi_strcatf(buf, "%s%smax_msg_size: %zd\n", prefix, TAB, attr->max_msg_size);
+	ofi_strcatf(buf, "%s%smsg_prefix_size: %zd\n", prefix, TAB, attr->msg_prefix_size);
+	ofi_strcatf(buf, "%s%smax_order_raw_size: %zd\n", prefix, TAB, attr->max_order_raw_size);
+	ofi_strcatf(buf, "%s%smax_order_war_size: %zd\n", prefix, TAB, attr->max_order_war_size);
+	ofi_strcatf(buf, "%s%smax_order_waw_size: %zd\n", prefix, TAB, attr->max_order_waw_size);
+	ofi_strcatf(buf, "%s%smem_tag_format: 0x%016llx\n", prefix, TAB, attr->mem_tag_format);
 
-	strcatf(buf, "%s%stx_ctx_cnt: %zd\n", prefix, TAB, attr->tx_ctx_cnt);
-	strcatf(buf, "%s%srx_ctx_cnt: %zd\n", prefix, TAB, attr->rx_ctx_cnt);
+	ofi_strcatf(buf, "%s%stx_ctx_cnt: %zd\n", prefix, TAB, attr->tx_ctx_cnt);
+	ofi_strcatf(buf, "%s%srx_ctx_cnt: %zd\n", prefix, TAB, attr->rx_ctx_cnt);
 
-	strcatf(buf, "%s%sauth_key_size: %zd\n", prefix, TAB, attr->auth_key_size);
+	ofi_strcatf(buf, "%s%sauth_key_size: %zd\n", prefix, TAB, attr->auth_key_size);
 }
 
-static void fi_tostr_resource_mgmt(char *buf, enum fi_resource_mgmt rm)
+static void ofi_tostr_resource_mgmt(char *buf, enum fi_resource_mgmt rm)
 {
 	switch (rm) {
 	CASEENUMSTR(FI_RM_UNSPEC);
 	CASEENUMSTR(FI_RM_DISABLED);
 	CASEENUMSTR(FI_RM_ENABLED);
 	default:
-		strcatf(buf, "Unknown");
+		ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_av_type(char *buf, enum fi_av_type type)
+static void ofi_tostr_av_type(char *buf, enum fi_av_type type)
 {
 	switch (type) {
 	CASEENUMSTR(FI_AV_UNSPEC);
 	CASEENUMSTR(FI_AV_MAP);
 	CASEENUMSTR(FI_AV_TABLE);
 	default:
-		strcatf(buf, "Unknown");
+		ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_mr_mode(char *buf, int mr_mode)
+static void ofi_tostr_mr_mode(char *buf, int mr_mode)
 {
 	IFFLAGSTR(mr_mode, FI_MR_BASIC);
 	IFFLAGSTR(mr_mode, FI_MR_SCALABLE);
@@ -438,10 +438,10 @@ static void fi_tostr_mr_mode(char *buf, int mr_mode)
 	IFFLAGSTR(mr_mode, FI_MR_MMU_NOTIFY);
 	IFFLAGSTR(mr_mode, FI_MR_RMA_EVENT);
 
-	fi_remove_comma(buf);
+	ofi_remove_comma(buf);
 }
 
-static void fi_tostr_op_type(char *buf, int op_type)
+static void ofi_tostr_op_type(char *buf, int op_type)
 {
 	switch (op_type) {
 	CASEENUMSTR(FI_OP_RECV);
@@ -456,121 +456,121 @@ static void fi_tostr_op_type(char *buf, int op_type)
 	CASEENUMSTR(FI_OP_CNTR_SET);
 	CASEENUMSTR(FI_OP_CNTR_ADD);
 	default:
-		strcatf(buf, "Unknown");
+		ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_domain_attr(char *buf, const struct fi_domain_attr *attr,
+static void ofi_tostr_domain_attr(char *buf, const struct fi_domain_attr *attr,
 				 const char *prefix)
 {
 	if (!attr) {
-		strcatf(buf, "%sfi_domain_attr: (null)\n", prefix);
+		ofi_strcatf(buf, "%sfi_domain_attr: (null)\n", prefix);
 		return;
 	}
 
-	strcatf(buf, "%sfi_domain_attr:\n", prefix);
+	ofi_strcatf(buf, "%sfi_domain_attr:\n", prefix);
 
-	strcatf(buf, "%s%sdomain: 0x%x\n", prefix, TAB, attr->domain);
+	ofi_strcatf(buf, "%s%sdomain: 0x%x\n", prefix, TAB, attr->domain);
 
-	strcatf(buf, "%s%sname: %s\n", prefix, TAB, attr->name);
-	strcatf(buf, "%s%sthreading: ", prefix, TAB);
-	fi_tostr_threading(buf, attr->threading);
-	strcatf(buf, "\n");
+	ofi_strcatf(buf, "%s%sname: %s\n", prefix, TAB, attr->name);
+	ofi_strcatf(buf, "%s%sthreading: ", prefix, TAB);
+	ofi_tostr_threading(buf, attr->threading);
+	ofi_strcatf(buf, "\n");
 
-	strcatf(buf, "%s%scontrol_progress: ", prefix,TAB);
-	fi_tostr_progress(buf, attr->control_progress);
-	strcatf(buf, "\n");
-	strcatf(buf, "%s%sdata_progress: ", prefix, TAB);
-	fi_tostr_progress(buf, attr->data_progress);
-	strcatf(buf, "\n");
-	strcatf(buf, "%s%sresource_mgmt: ", prefix, TAB);
-	fi_tostr_resource_mgmt(buf, attr->resource_mgmt);
-	strcatf(buf, "\n");
-	strcatf(buf, "%s%sav_type: ", prefix, TAB);
-	fi_tostr_av_type(buf, attr->av_type);
-	strcatf(buf, "\n");
-	strcatf(buf, "%s%smr_mode: [ ", prefix, TAB);
-	fi_tostr_mr_mode(buf, attr->mr_mode);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%s%scontrol_progress: ", prefix,TAB);
+	ofi_tostr_progress(buf, attr->control_progress);
+	ofi_strcatf(buf, "\n");
+	ofi_strcatf(buf, "%s%sdata_progress: ", prefix, TAB);
+	ofi_tostr_progress(buf, attr->data_progress);
+	ofi_strcatf(buf, "\n");
+	ofi_strcatf(buf, "%s%sresource_mgmt: ", prefix, TAB);
+	ofi_tostr_resource_mgmt(buf, attr->resource_mgmt);
+	ofi_strcatf(buf, "\n");
+	ofi_strcatf(buf, "%s%sav_type: ", prefix, TAB);
+	ofi_tostr_av_type(buf, attr->av_type);
+	ofi_strcatf(buf, "\n");
+	ofi_strcatf(buf, "%s%smr_mode: [ ", prefix, TAB);
+	ofi_tostr_mr_mode(buf, attr->mr_mode);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%smr_key_size: %zd\n", prefix, TAB, attr->mr_key_size);
-	strcatf(buf, "%s%scq_data_size: %zd\n", prefix, TAB, attr->cq_data_size);
-	strcatf(buf, "%s%scq_cnt: %zd\n", prefix, TAB, attr->cq_cnt);
-	strcatf(buf, "%s%sep_cnt: %zd\n", prefix, TAB, attr->ep_cnt);
-	strcatf(buf, "%s%stx_ctx_cnt: %zd\n", prefix, TAB, attr->tx_ctx_cnt);
-	strcatf(buf, "%s%srx_ctx_cnt: %zd\n", prefix, TAB, attr->rx_ctx_cnt);
-	strcatf(buf, "%s%smax_ep_tx_ctx: %zd\n", prefix, TAB, attr->max_ep_tx_ctx);
-	strcatf(buf, "%s%smax_ep_rx_ctx: %zd\n", prefix, TAB, attr->max_ep_rx_ctx);
-	strcatf(buf, "%s%smax_ep_stx_ctx: %zd\n", prefix, TAB, attr->max_ep_stx_ctx);
-	strcatf(buf, "%s%smax_ep_srx_ctx: %zd\n", prefix, TAB, attr->max_ep_srx_ctx);
-	strcatf(buf, "%s%scntr_cnt: %zd\n", prefix, TAB, attr->cntr_cnt);
-	strcatf(buf, "%s%smr_iov_limit: %zd\n", prefix, TAB, attr->mr_iov_limit);
+	ofi_strcatf(buf, "%s%smr_key_size: %zd\n", prefix, TAB, attr->mr_key_size);
+	ofi_strcatf(buf, "%s%scq_data_size: %zd\n", prefix, TAB, attr->cq_data_size);
+	ofi_strcatf(buf, "%s%scq_cnt: %zd\n", prefix, TAB, attr->cq_cnt);
+	ofi_strcatf(buf, "%s%sep_cnt: %zd\n", prefix, TAB, attr->ep_cnt);
+	ofi_strcatf(buf, "%s%stx_ctx_cnt: %zd\n", prefix, TAB, attr->tx_ctx_cnt);
+	ofi_strcatf(buf, "%s%srx_ctx_cnt: %zd\n", prefix, TAB, attr->rx_ctx_cnt);
+	ofi_strcatf(buf, "%s%smax_ep_tx_ctx: %zd\n", prefix, TAB, attr->max_ep_tx_ctx);
+	ofi_strcatf(buf, "%s%smax_ep_rx_ctx: %zd\n", prefix, TAB, attr->max_ep_rx_ctx);
+	ofi_strcatf(buf, "%s%smax_ep_stx_ctx: %zd\n", prefix, TAB, attr->max_ep_stx_ctx);
+	ofi_strcatf(buf, "%s%smax_ep_srx_ctx: %zd\n", prefix, TAB, attr->max_ep_srx_ctx);
+	ofi_strcatf(buf, "%s%scntr_cnt: %zd\n", prefix, TAB, attr->cntr_cnt);
+	ofi_strcatf(buf, "%s%smr_iov_limit: %zd\n", prefix, TAB, attr->mr_iov_limit);
 
-	strcatf(buf, "%scaps: [ ", TAB);
-	fi_tostr_caps(buf, attr->caps);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%scaps: [ ", TAB);
+	ofi_tostr_caps(buf, attr->caps);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%smode: [ ", TAB);
-	fi_tostr_mode(buf, attr->mode);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%smode: [ ", TAB);
+	ofi_tostr_mode(buf, attr->mode);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%s%sauth_key_size: %zd\n", prefix, TAB, attr->auth_key_size);
-	strcatf(buf, "%s%smax_err_data: %zd\n", prefix, TAB, attr->max_err_data);
-	strcatf(buf, "%s%smr_cnt: %zd\n", prefix, TAB, attr->mr_cnt);
+	ofi_strcatf(buf, "%s%sauth_key_size: %zd\n", prefix, TAB, attr->auth_key_size);
+	ofi_strcatf(buf, "%s%smax_err_data: %zd\n", prefix, TAB, attr->max_err_data);
+	ofi_strcatf(buf, "%s%smr_cnt: %zd\n", prefix, TAB, attr->mr_cnt);
 }
 
-static void fi_tostr_fabric_attr(char *buf, const struct fi_fabric_attr *attr,
+static void ofi_tostr_fabric_attr(char *buf, const struct fi_fabric_attr *attr,
 				 const char *prefix)
 {
 	if (!attr) {
-		strcatf(buf, "%sfi_fabric_attr: (null)\n", prefix);
+		ofi_strcatf(buf, "%sfi_fabric_attr: (null)\n", prefix);
 		return;
 	}
 
-	strcatf(buf, "%sfi_fabric_attr:\n", prefix);
-	strcatf(buf, "%s%sname: %s\n", prefix, TAB, attr->name);
-	strcatf(buf, "%s%sprov_name: %s\n", prefix, TAB, attr->prov_name);
-	strcatf(buf, "%s%sprov_version: %d.%d\n", prefix, TAB,
+	ofi_strcatf(buf, "%sfi_fabric_attr:\n", prefix);
+	ofi_strcatf(buf, "%s%sname: %s\n", prefix, TAB, attr->name);
+	ofi_strcatf(buf, "%s%sprov_name: %s\n", prefix, TAB, attr->prov_name);
+	ofi_strcatf(buf, "%s%sprov_version: %d.%d\n", prefix, TAB,
 		FI_MAJOR(attr->prov_version), FI_MINOR(attr->prov_version));
-	strcatf(buf, "%s%sapi_version: %d.%d\n", prefix, TAB,
+	ofi_strcatf(buf, "%s%sapi_version: %d.%d\n", prefix, TAB,
 		FI_MAJOR(attr->api_version), FI_MINOR(attr->api_version));
 }
 
-static void fi_tostr_info(char *buf, const struct fi_info *info)
+static void ofi_tostr_info(char *buf, const struct fi_info *info)
 {
-	strcatf(buf, "fi_info:\n");
-	strcatf(buf, "%scaps: [ ", TAB);
-	fi_tostr_caps(buf, info->caps);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "fi_info:\n");
+	ofi_strcatf(buf, "%scaps: [ ", TAB);
+	ofi_tostr_caps(buf, info->caps);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%smode: [ ", TAB);
-	fi_tostr_mode(buf, info->mode);
-	strcatf(buf, " ]\n");
+	ofi_strcatf(buf, "%smode: [ ", TAB);
+	ofi_tostr_mode(buf, info->mode);
+	ofi_strcatf(buf, " ]\n");
 
-	strcatf(buf, "%saddr_format: ", TAB);
-	fi_tostr_addr_format(buf, info->addr_format);
-	strcatf(buf, "\n");
+	ofi_strcatf(buf, "%saddr_format: ", TAB);
+	oofi_tostr_addr_format(buf, info->addr_format);
+	ofi_strcatf(buf, "\n");
 
-	strcatf(buf, "%ssrc_addrlen: %zd\n", TAB, info->src_addrlen);
-	strcatf(buf, "%sdest_addrlen: %zd\n", TAB, info->dest_addrlen);
-	strcatf(buf, "%ssrc_addr: ", TAB);
-	fi_tostr_addr(buf, info->addr_format, info->src_addr);
-	strcatf(buf, "\n");
-	strcatf(buf, "%sdest_addr: ", TAB);
-	fi_tostr_addr(buf, info->addr_format, info->dest_addr);
-	strcatf(buf, "\n");
-	strcatf(buf, "%shandle: ", TAB);
-	fi_tostr_fid(buf, info->handle);
+	ofi_strcatf(buf, "%ssrc_addrlen: %zd\n", TAB, info->src_addrlen);
+	ofi_strcatf(buf, "%sdest_addrlen: %zd\n", TAB, info->dest_addrlen);
+	ofi_strcatf(buf, "%ssrc_addr: ", TAB);
+	ofi_tostr_addr(buf, info->addr_format, info->src_addr);
+	ofi_strcatf(buf, "\n");
+	ofi_strcatf(buf, "%sdest_addr: ", TAB);
+	ofi_tostr_addr(buf, info->addr_format, info->dest_addr);
+	ofi_strcatf(buf, "\n");
+	ofi_strcatf(buf, "%shandle: ", TAB);
+	ofi_tostr_fid(buf, info->handle);
 
-	fi_tostr_tx_attr(buf, info->tx_attr, TAB);
-	fi_tostr_rx_attr(buf, info->rx_attr, TAB);
-	fi_tostr_ep_attr(buf, info->ep_attr, TAB);
-	fi_tostr_domain_attr(buf, info->domain_attr, TAB);
-	fi_tostr_fabric_attr(buf, info->fabric_attr, TAB);
+	ofi_tostr_tx_attr(buf, info->tx_attr, TAB);
+	ofi_tostr_rx_attr(buf, info->rx_attr, TAB);
+	ofi_tostr_ep_attr(buf, info->ep_attr, TAB);
+	ofi_tostr_domain_attr(buf, info->domain_attr, TAB);
+	ofi_tostr_fabric_attr(buf, info->fabric_attr, TAB);
 }
 
-static void fi_tostr_atomic_type(char *buf, enum fi_datatype type)
+static void ofi_tostr_atomic_type(char *buf, enum fi_datatype type)
 {
 	switch (type) {
 	CASEENUMSTR(FI_INT8);
@@ -588,12 +588,12 @@ static void fi_tostr_atomic_type(char *buf, enum fi_datatype type)
 	CASEENUMSTR(FI_LONG_DOUBLE);
 	CASEENUMSTR(FI_LONG_DOUBLE_COMPLEX);
 	default:
-		strcatf(buf, "Unknown");
+		ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_atomic_op(char *buf, enum fi_op op)
+static void ofi_tostr_atomic_op(char *buf, enum fi_op op)
 {
 	switch (op) {
 	CASEENUMSTR(FI_MIN);
@@ -616,18 +616,18 @@ static void fi_tostr_atomic_op(char *buf, enum fi_op op)
 	CASEENUMSTR(FI_CSWAP_GT);
 	CASEENUMSTR(FI_MSWAP);
 	default:
-		strcatf(buf, "Unknown");
+		ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_version(char *buf)
+static void ofi_tostr_version(char *buf)
 {
-	strcatf(buf, VERSION);
-	strcatf(buf, BUILD_ID);
+	ofi_strcatf(buf, VERSION);
+	ofi_strcatf(buf, BUILD_ID);
 }
 
-static void fi_tostr_eq_event(char *buf, int type)
+static void ofi_tostr_eq_event(char *buf, int type)
 {
 	switch (type) {
 	CASEENUMSTR(FI_NOTIFY);
@@ -637,12 +637,12 @@ static void fi_tostr_eq_event(char *buf, int type)
 	CASEENUMSTR(FI_MR_COMPLETE);
 	CASEENUMSTR(FI_AV_COMPLETE);
 	default:
-		strcatf(buf, "Unknown");
+		ofi_strcatf(buf, "Unknown");
 		break;
 	}
 }
 
-static void fi_tostr_cq_event_flags(char *buf, uint64_t flags)
+static void ofi_tostr_cq_event_flags(char *buf, uint64_t flags)
 {
 	IFFLAGSTR(flags, FI_SEND);
 	IFFLAGSTR(flags, FI_RECV);
@@ -658,7 +658,7 @@ static void fi_tostr_cq_event_flags(char *buf, uint64_t flags)
 	IFFLAGSTR(flags, FI_MULTI_RECV);
 	IFFLAGSTR(flags, FI_MORE);
 	IFFLAGSTR(flags, FI_CLAIM);
-	fi_remove_comma(buf);
+	ofi_remove_comma(buf);
 }
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
@@ -677,7 +677,7 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 	enumval = (const int *) data;
 
 	if (!buf) {
-		buf = calloc(FI_BUFSIZ, 1);
+		buf = calloc(OFI_BUFSIZ, 1);
 		if (!buf)
 			return NULL;
 	}
@@ -685,80 +685,80 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 
 	switch (datatype) {
 	case FI_TYPE_INFO:
-		fi_tostr_info(buf, data);
+		ofi_tostr_info(buf, data);
 		break;
 	case FI_TYPE_EP_TYPE:
-		fi_tostr_ep_type(buf, *enumval);
+		ofi_tostr_ep_type(buf, *enumval);
 		break;
 	case FI_TYPE_CAPS:
-		fi_tostr_caps(buf, *val64);
+		ofi_tostr_caps(buf, *val64);
 		break;
 	case FI_TYPE_OP_FLAGS:
-		fi_tostr_opflags(buf, *val64);
+		ofi_tostr_opflags(buf, *val64);
 		break;
 	case FI_TYPE_ADDR_FORMAT:
-		fi_tostr_addr_format(buf, *val32);
+		oofi_tostr_addr_format(buf, *val32);
 		break;
 	case FI_TYPE_TX_ATTR:
-		fi_tostr_tx_attr(buf, data, "");
+		ofi_tostr_tx_attr(buf, data, "");
 		break;
 	case FI_TYPE_RX_ATTR:
-		fi_tostr_rx_attr(buf, data, "");
+		ofi_tostr_rx_attr(buf, data, "");
 		break;
 	case FI_TYPE_EP_ATTR:
-		fi_tostr_ep_attr(buf, data, "");
+		ofi_tostr_ep_attr(buf, data, "");
 		break;
 	case FI_TYPE_DOMAIN_ATTR:
-		fi_tostr_domain_attr(buf, data, "");
+		ofi_tostr_domain_attr(buf, data, "");
 		break;
 	case FI_TYPE_FABRIC_ATTR:
-		fi_tostr_fabric_attr(buf, data, "");
+		ofi_tostr_fabric_attr(buf, data, "");
 		break;
 	case FI_TYPE_THREADING:
-		fi_tostr_threading(buf, *enumval);
+		ofi_tostr_threading(buf, *enumval);
 		break;
 	case FI_TYPE_PROGRESS:
-		fi_tostr_progress(buf, *enumval);
+		ofi_tostr_progress(buf, *enumval);
 		break;
 	case FI_TYPE_PROTOCOL:
-		fi_tostr_protocol(buf, *val32);
+		ofi_tostr_protocol(buf, *val32);
 		break;
 	case FI_TYPE_MSG_ORDER:
-		fi_tostr_order(buf, *val64);
+		ofi_tostr_order(buf, *val64);
 		break;
 	case FI_TYPE_MODE:
-		fi_tostr_mode(buf, *val64);
+		ofi_tostr_mode(buf, *val64);
 		break;
 	case FI_TYPE_AV_TYPE:
-		fi_tostr_av_type(buf, *enumval);
+		ofi_tostr_av_type(buf, *enumval);
 		break;
 	case FI_TYPE_ATOMIC_TYPE:
-		fi_tostr_atomic_type(buf, *enumval);
+		ofi_tostr_atomic_type(buf, *enumval);
 		break;
 	case FI_TYPE_ATOMIC_OP:
-		fi_tostr_atomic_op(buf, *enumval);
+		ofi_tostr_atomic_op(buf, *enumval);
 		break;
 	case FI_TYPE_VERSION:
-		fi_tostr_version(buf);
+		ofi_tostr_version(buf);
 		break;
 	case FI_TYPE_EQ_EVENT:
-		fi_tostr_eq_event(buf, *enumval);
+		ofi_tostr_eq_event(buf, *enumval);
 		break;
 	case FI_TYPE_CQ_EVENT_FLAGS:
-		fi_tostr_cq_event_flags(buf, *val64);
+		ofi_tostr_cq_event_flags(buf, *val64);
 		break;
 	case FI_TYPE_MR_MODE:
 		/* mr_mode was an enum converted to int flags */
-		fi_tostr_mr_mode(buf, *enumval);
+		ofi_tostr_mr_mode(buf, *enumval);
 		break;
 	case FI_TYPE_OP_TYPE:
-		fi_tostr_op_type(buf, *enumval);
+		ofi_tostr_op_type(buf, *enumval);
 		break;
 	case FI_TYPE_FID:
-		fi_tostr_fid(buf, data);
+		ofi_tostr_fid(buf, data);
 		break;
 	default:
-		strcatf(buf, "Unknown type");
+		ofi_strcatf(buf, "Unknown type");
 		break;
 	}
 	return buf;


### PR DESCRIPTION
Check for and handle fid_nic when referenced by an fi_info structure.

We use the fid_nic ops to route calls to the correct provider, with default implementations of calls provided.  For example, now to free a fid_nic, we call fi_close(fid_nic).  The provider can set ops->close to an internal call, or simply use the common cleanup function ofi_nic_close().  The provider specific call can call ofi_nic_close() internally as well.  This gives the provider a way to cleanup the prov_attr structure if one is used.

Similarly, we can duplicate a fid_nic by using a new fi_control() command, FI_DUP.  E.g. fi_control(fid_nic, FI_DUP, &fid_nic_ptr).  The fi_dupinfo() call will invoke fi_control(... FI_DUP...) for any fi_info->handle that exists (with proper checks).  This will route the dup operation to the provider control function, which can be set to something internal or the common ofi_nic_dup() function.

If this approach makes sense, the control operation will be expanded to support a new FI_TOSTR command.

Although the new control commands target fid_nic, they can easily be expanded for any FID type, which would allow printing internal details on things like endpoints and completion queues.