### PR TITLE
windows: Add support of old Windows SDKs

### DIFF
--- a/Libfabric.Build.Default.props
+++ b/Libfabric.Build.Default.props
@@ -1,28 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="Libfabric.Build.Default.props"/>
-  <Import Condition="'$(Clang)'!=''" Project="Libfabric.Build.Clang.Default.props"/>
   <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'==''">
-    <!-- Default the installed latest Win10 SDK -->
-    <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>
-    <WindowsSdkInstallFolder_10 Condition="'$(WindowsSdkInstallFolder_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10>
-    <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
-    <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
+    <!-- Default the installed latest Win10.0 SDK -->
+    <WindowsSdkInstallFolder_10_0 Condition="'$(WindowsSdkInstallFolder_10_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10_0>
+    <WindowsSdkInstallFolder_10_0 Condition="'$(WindowsSdkInstallFolder_10_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@InstallationFolder)</WindowsSdkInstallFolder_10_0>
+    <WindowsTargetPlatformVersion_10_0 Condition="'$(WindowsTargetPlatformVersion_10_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10_0>
+    <WindowsTargetPlatformVersion_10_0 Condition="'$(WindowsTargetPlatformVersion_10_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10_0>
     <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
-    <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' != '' and !$(WindowsTargetPlatformVersion_10.EndsWith('.0'))">$(WindowsTargetPlatformVersion_10).0</WindowsTargetPlatformVersion_10>
+    <WindowsTargetPlatformVersion_10_0 Condition="'$(WindowsTargetPlatformVersion_10_0)' != '' and !$(WindowsTargetPlatformVersion_10_0.EndsWith('.0'))">$(WindowsTargetPlatformVersion_10_0).0</WindowsTargetPlatformVersion_10_0>
+    <WindowsTargetPlatformVersion>$(WindowsTargetPlatformVersion_10_0)</WindowsTargetPlatformVersion>
 
-    <WindowsTargetPlatformVersion>$(WindowsTargetPlatformVersion_10)</WindowsTargetPlatformVersion>
+    <!-- Default the installed latest Win8.1 SDK -->
+    <WindowsSdkInstallFolder_8_1 Condition="'$(WindowsSdkInstallFolder_8_1)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)</WindowsSdkInstallFolder_8_1>
+    <WindowsSdkInstallFolder_8_1 Condition="'$(WindowsSdkInstallFolder_8_1)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v8.1@InstallationFolder)</WindowsSdkInstallFolder_8_1>
+    <WindowsTargetPlatformVersion_8_1 Condition="'$(WindowsTargetPlatformVersion_8_1)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.1@ProductVersion)</WindowsTargetPlatformVersion_8_1>
+    <WindowsTargetPlatformVersion_8_1 Condition="'$(WindowsTargetPlatformVersion_8_1)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v8.1@ProductVersion)</WindowsTargetPlatformVersion_8_1>
+    <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
+    <WindowsTargetPlatformVersion_8_1 Condition="'$(WindowsTargetPlatformVersion_8_1)' != '' and !$(WindowsTargetPlatformVersion_8_1.EndsWith('.0'))">$(WindowsTargetPlatformVersion_8_1).0</WindowsTargetPlatformVersion_8_1>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(WindowsTargetPlatformVersion_8_1)</WindowsTargetPlatformVersion>
 
-    <!-- Default back to 10.0.10240.0 if the ARM version of the Win10 SDK is not installed -->
-    <WindowsTargetPlatformVersion Condition="'$(Platform)'=='ARM' and !Exists('$(WindowsSdkInstallFolder_10)\Include\$(WindowsTargetPlatformVersion_10)\shared\ksarm.h')">10.0.10240.0</WindowsTargetPlatformVersion>
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Unless indicated otherwise, statically link the C++ Runtime into ChakraCore.dll -->
-    <RuntimeLib Condition="'$(RuntimeLib)'==''">static_library</RuntimeLib>
+    <!-- Default the installed latest Win8.0 SDK -->
+    <WindowsSdkInstallFolder_8_0 Condition="'$(WindowsSdkInstallFolder_8_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0@InstallationFolder)</WindowsSdkInstallFolder_8_0>
+    <WindowsSdkInstallFolder_8_0 Condition="'$(WindowsSdkInstallFolder_8_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v8.0@InstallationFolder)</WindowsSdkInstallFolder_8_0>
+    <WindowsTargetPlatformVersion_8_0 Condition="'$(WindowsTargetPlatformVersion_8_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v8.0@ProductVersion)</WindowsTargetPlatformVersion_8_0>
+    <WindowsTargetPlatformVersion_8_0 Condition="'$(WindowsTargetPlatformVersion_8_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v8.0@ProductVersion)</WindowsTargetPlatformVersion_8_0>
+    <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
+    <WindowsTargetPlatformVersion_8_0 Condition="'$(WindowsTargetPlatformVersion_8_0)' != '' and !$(WindowsTargetPlatformVersion_8_0.EndsWith('.0'))">$(WindowsTargetPlatformVersion_8_0).0</WindowsTargetPlatformVersion_8_0>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(WindowsTargetPlatformVersion_8_0)</WindowsTargetPlatformVersion>
 
-    <NtTargetVersion>$(NtTargetVersion_Win7)</NtTargetVersion>
-    <!-- On ARM we depend an API that was added in Win8 timeframe, specifically GetCurrentThreadLimits.
-         Note that for ARM we don't need to support running on Win7, so it's fine to require Win8 as minimum. -->
-    <NtTargetVersion Condition="'$(Platform)'=='ARM' or '$(Platform)'=='Arm64'">$(NtTargetVersion_Win8)</NtTargetVersion>
+    <!-- Default the installed latest Win7.1 SDK -->
+    <WindowsSdkInstallFolder_7_1 Condition="'$(WindowsSdkInstallFolder_7_1)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1@InstallationFolder)</WindowsSdkInstallFolder_7_1>
+    <WindowsSdkInstallFolder_7_1 Condition="'$(WindowsSdkInstallFolder_7_1)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v7.1@InstallationFolder)</WindowsSdkInstallFolder_7_1>
+    <WindowsTargetPlatformVersion_7_1 Condition="'$(WindowsTargetPlatformVersion_7_1)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.1@ProductVersion)</WindowsTargetPlatformVersion_7_1>
+    <WindowsTargetPlatformVersion_7_1 Condition="'$(WindowsTargetPlatformVersion_7_1)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v7.1@ProductVersion)</WindowsTargetPlatformVersion_7_1>
+    <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
+    <WindowsTargetPlatformVersion_7_1 Condition="'$(WindowsTargetPlatformVersion_7_1)' != '' and !$(WindowsTargetPlatformVersion_7_1.EndsWith('.0'))">$(WindowsTargetPlatformVersion_7_1).0</WindowsTargetPlatformVersion_7_1>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(WindowsTargetPlatformVersion_7_1)</WindowsTargetPlatformVersion>
+
+    <!-- Default the installed latest Win7.1 SDK -->
+    <WindowsSdkInstallFolder_7_0 Condition="'$(WindowsSdkInstallFolder_7_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0@InstallationFolder)</WindowsSdkInstallFolder_7_0>
+    <WindowsSdkInstallFolder_7_0 Condition="'$(WindowsSdkInstallFolder_7_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v7.0@InstallationFolder)</WindowsSdkInstallFolder_7_0>
+    <WindowsTargetPlatformVersion_7_0 Condition="'$(WindowsTargetPlatformVersion_7_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v7.0@ProductVersion)</WindowsTargetPlatformVersion_7_0>
+    <WindowsTargetPlatformVersion_7_0 Condition="'$(WindowsTargetPlatformVersion_7_0)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v7.0@ProductVersion)</WindowsTargetPlatformVersion_7_0>
+    <!-- Sometimes the version in the registry has to .0 suffix, and sometimes it doesn't. Check and add it -->
+    <WindowsTargetPlatformVersion_7_0 Condition="'$(WindowsTargetPlatformVersion_7_0)' != '' and !$(WindowsTargetPlatformVersion_7_0.EndsWith('.0'))">$(WindowsTargetPlatformVersion_7_0).0</WindowsTargetPlatformVersion_7_0>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">$(WindowsTargetPlatformVersion_7_0)</WindowsTargetPlatformVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Currently libfabirc's VS projects support only Windows SDK 10.0.
Add support of older ones (8.1, 8.0, 7.1, 7.0) by checking instalaltion
path of SKDs and choose the more new.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>