### PR TITLE
prov/rxm, mrail: enable buffered recv for large messages.

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -83,6 +83,8 @@ extern "C" {
 
 #define ofi_div_ceil(a, b) ((a + b - 1) / b)
 
+#define OFI_MAGIC_64 (0x0F1C0DE0F1C0DE64)
+
 
 /*
  * CPU specific features

--- a/include/ofi_list.h
+++ b/include/ofi_list.h
@@ -460,28 +460,24 @@ slist_find_first_match(const struct slist *list, slist_func_t *match,
 	return NULL;
 }
 
-static inline void slist_insert_order(struct slist *list, slist_func_t *order,
-				      struct slist_entry *entry)
+static inline void
+slist_insert_before_first_match(struct slist *list, slist_func_t *match,
+				struct slist_entry *entry)
 {
-	struct slist_entry *prev;
+	struct slist_entry *cur, *prev;
 
-	if (slist_empty(list)) {
-		slist_insert_head(entry, list);
-		return;
+	slist_foreach(list, cur, prev) {
+		if (match(cur, entry)) {
+			if (!prev) {
+				slist_insert_head(entry, list);
+			} else {
+				entry->next = prev->next;
+				prev->next = entry;
+			}
+			return;
+		}
 	}
-
-	/* Note: the order function should return the entry that precedes the
-	 * new one.
-	 * e.g. when inserting 3 into (1, 2, 4), the order function should
-	 * 	return 2.
-	 */
-	prev = slist_find_first_match(list, order, entry);
-	if (prev) {
-		entry->next = prev->next;
-		prev->next = entry;
-	} else {
-		slist_insert_tail(entry, list);
-	}
+	slist_insert_tail(entry, list);
 }
 
 static inline void slist_remove(struct slist *list,

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -249,6 +249,7 @@ struct util_buf_pool;
 typedef int (*util_buf_region_alloc_hndlr) (void *pool_ctx, void *addr, size_t len,
 					    void **context);
 typedef void (*util_buf_region_free_hndlr) (void *pool_ctx, void *context);
+typedef void (*util_buf_region_init_func) (void *pool_ctx, void *buf);
 
 struct util_buf_attr {
 	size_t 				size;
@@ -257,6 +258,7 @@ struct util_buf_attr {
 	size_t 				chunk_cnt;
 	util_buf_region_alloc_hndlr 	alloc_hndlr;
 	util_buf_region_free_hndlr 	free_hndlr;
+	util_buf_region_init_func 	init;
 	void 				*ctx;
 	uint8_t				track_used;
 };

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -60,6 +60,7 @@ enum {
 enum {
 	FI_OPT_MIN_MULTI_RECV,		/* size_t */
 	FI_OPT_CM_DATA_SIZE,		/* size_t */
+	FI_OPT_BUFFERED_MIN,		/* size_t */
 	FI_OPT_BUFFERED_LIMIT,		/* size_t */
 	FI_OPT_SEND_BUF_SIZE,
 	FI_OPT_RECV_BUF_SIZE,

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -531,6 +531,17 @@ The following option levels and option names and parameters are defined.
   configured to use the same threshold value, and the threshold must be
   set prior to enabling the endpoint.
 
+- *FI_OPT_BUFFERED_MIN - size_t*
+: Defines the minimum size of a buffered message that will be reported.
+  Applications would set this to a size that's big enough to decide whether
+  to discard or claim a buffered receive or when to claim a buffered receive
+  on getting a buffered receive completion. The value is typically used by a
+  provider when sending a rendezvous protocol request where it would send
+  atleast FI_OPT_BUFFERED_MIN bytes of application data along with it. A smaller
+  sized renedezvous protocol message usually results in better latency for the
+  overall transfer of a large message.
+
+
 ## fi_rx_size_left (DEPRECATED)
 
 This function has been deprecated and will be removed in a future version

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -335,12 +335,13 @@ managed buffer where the start of the received message is located, and
 'len' will be set to the total size of the message.
 
 The maximum sized message that a provider can buffer is limited by
-an FI_OPT_BUFFERED_LIMIT.  This threshold can be obtained and may be adjusted
+an FI_OPT_BUFFERED_LIMIT. This threshold can be obtained and may be adjusted
 by the application using the fi_getopt and fi_setopt calls, respectively.
-Any adjustments must be made prior to enabling the endpoint. The
-CQ entry 'buf' will point to a buffer that is the _minimum_ of 'len' and
-the FI_OPT_BUFFERED_LIMIT value.  If the sent message is larger than the
-buffered limit, the CQ entry 'flags' will have the FI_MORE bit set.
+Any adjustments must be made prior to enabling the endpoint. The CQ entry 'buf'
+will point to a buffer of received data. If the sent message is larger than the
+buffered amount, the CQ entry 'flags' will have the FI_MORE bit set. When the
+FI_MORE bit is set, 'buf' will reference at least FI_OPT_BUFFERED_MIN bytes
+of data (see fi_endpoint.3 for more info).
 
 After being notified that a buffered receive has arrived,
 applications must either claim or discard the message.  Typically,

--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -116,6 +116,14 @@ struct mrail_hdr {
 	uint64_t 	tag;
 };
 
+struct mrail_tx_buf {
+	/* context should stay at top and would get overwritten on
+	 * util buf release */
+	void			*context;
+	struct mrail_ep		*ep;
+	struct mrail_hdr	hdr;
+};
+
 struct mrail_pkt {
 	struct mrail_hdr	hdr;
 	char 			data[];
@@ -211,6 +219,7 @@ struct mrail_ep {
 
 	struct util_buf_pool	*req_pool;
 	struct util_buf_pool 	*ooo_recv_pool;
+	struct util_buf_pool 	*tx_buf_pool;
 	struct slist		deferred_reqs;
 };
 

--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -121,6 +121,7 @@ struct mrail_tx_buf {
 	 * util buf release */
 	void			*context;
 	struct mrail_ep		*ep;
+	uint64_t		flags;
 	struct mrail_hdr	hdr;
 };
 

--- a/prov/mrail/src/mrail_cq.c
+++ b/prov/mrail/src/mrail_cq.c
@@ -192,17 +192,8 @@ static int mrail_ooo_recv_before(struct slist_entry *item, const void *arg)
 	struct mrail_ooo_recv *ooo_recv;
 	struct mrail_ooo_recv *new_recv;
 
-	/* Check whether the given item's follower has a higher seq_no. */
-
-	if (!item->next) {
-		/* item is the last element in the list */
-		return 0;
-	}
-
-	ooo_recv = container_of(item->next, struct mrail_ooo_recv, entry);
-	new_recv = container_of((struct slist_entry *)arg,
-			struct mrail_ooo_recv, entry);
-
+	ooo_recv = container_of(item, struct mrail_ooo_recv, entry);
+	new_recv = container_of(arg, struct mrail_ooo_recv, entry);
 	return (new_recv->seq_no < ooo_recv->seq_no);
 }
 
@@ -223,7 +214,8 @@ static void mrail_save_ooo_recv(struct mrail_ep *mrail_ep,
 	ooo_recv->seq_no = seq_no;
 	memcpy(&ooo_recv->comp, comp, sizeof(*comp));
 
-	slist_insert_order(queue, mrail_ooo_recv_before, &ooo_recv->entry);
+	slist_insert_before_first_match(queue, mrail_ooo_recv_before,
+					&ooo_recv->entry);
 
 	FI_DBG(&mrail_prov, FI_LOG_CQ, "saved ooo_recv seq=%d\n", seq_no);
 }

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -304,6 +304,23 @@ static void mrail_copy_iov_hdr(struct mrail_hdr *hdr, struct iovec *iov_dest,
 	memcpy(&iov_dest[1], iov_src, sizeof(*iov_src) * count);
 }
 
+static struct mrail_tx_buf *mrail_get_tx_buf(struct mrail_ep *mrail_ep,
+					     void *context, uint32_t seq,
+					     uint8_t op)
+{
+	struct mrail_tx_buf *tx_buf = util_buf_alloc(mrail_ep->tx_buf_pool);
+	if (OFI_UNLIKELY(!tx_buf))
+		return NULL;
+
+	assert(tx_buf->ep == mrail_ep);
+	assert(tx_buf->hdr.version == MRAIL_HDR_VERSION);
+
+	tx_buf->context		= context;
+	tx_buf->hdr.op		= op;
+	tx_buf->hdr.seq		= htonl(seq);
+	return tx_buf;
+}
+
 static ssize_t
 mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		  size_t count, size_t len, fi_addr_t dest_addr, uint64_t data,
@@ -313,7 +330,7 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 						 util_ep.ep_fid.fid);
 	struct mrail_peer_info *peer_info;
 	struct iovec *iov_dest = alloca(sizeof(*iov_dest) * (count + 1));
-	struct mrail_hdr hdr = MRAIL_HDR_INITIALIZER_MSG;
+	struct mrail_tx_buf *tx_buf;
 	uint32_t i = mrail_get_tx_rail(mrail_ep);
 	struct fi_msg msg;
 	ssize_t ret;
@@ -322,30 +339,40 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	ofi_ep_lock_acquire(&mrail_ep->util_ep);
 
-	hdr.seq = peer_info->seq_no++;
-	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "sending seq=%d\n", hdr.seq);
-	hdr.seq = htonl(hdr.seq);
-	mrail_copy_iov_hdr(&hdr, iov_dest, iov, count);
+	tx_buf = mrail_get_tx_buf(mrail_ep, context, peer_info->seq_no++,
+				  ofi_op_msg);
+	if (OFI_UNLIKELY(!tx_buf)) {
+		ret = -FI_ENOMEM;
+		goto err1;
+	}
+	mrail_copy_iov_hdr(&tx_buf->hdr, iov_dest, iov, count);
 
 	msg.msg_iov 	= iov_dest;
 	msg.desc    	= desc;
 	msg.iov_count	= count + 1;
 	msg.addr	= dest_addr;
-	msg.context	= context;
+	msg.context	= tx_buf;
 	msg.data	= data;
 
 	if (len < mrail_ep->rails[i].info->tx_attr->inject_size)
 		flags |= FI_INJECT;
 
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting send of length: %" PRIu64
-	       " dest_addr: 0x%" PRIx64 " on rail: %d\n", len, dest_addr, i);
+	       " dest_addr: 0x%" PRIx64 "  seq: %d on rail: %d\n",
+	       len, dest_addr, peer_info->seq_no - 1, i);
+
 	ret = fi_sendmsg(mrail_ep->rails[i].ep, &msg, flags);
 	if (ret) {
 		FI_WARN(&mrail_prov, FI_LOG_EP_DATA,
 			"Unable to fi_sendmsg on rail: %" PRIu32 "\n", i);
-		peer_info->seq_no--;
+		goto err2;
 	}
-
+	ofi_ep_lock_release(&mrail_ep->util_ep);
+	return ret;
+err2:
+	util_buf_release(mrail_ep->tx_buf_pool, tx_buf);
+err1:
+	peer_info->seq_no--;
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 	return ret;
 }
@@ -359,7 +386,7 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 						 util_ep.ep_fid.fid);
 	struct mrail_peer_info *peer_info;
 	struct iovec *iov_dest = alloca(sizeof(*iov_dest) * (count + 1));
-	struct mrail_hdr hdr = MRAIL_HDR_INITIALIZER_TAGGED(tag);
+	struct mrail_tx_buf *tx_buf;
 	uint32_t i = mrail_get_tx_rail(mrail_ep);
 	struct fi_msg msg;
 	ssize_t ret;
@@ -368,31 +395,41 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	ofi_ep_lock_acquire(&mrail_ep->util_ep);
 
-	hdr.seq = peer_info->seq_no++;
-	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "sending seq=%d\n", hdr.seq);
-	hdr.seq = htonl(hdr.seq);
-	mrail_copy_iov_hdr(&hdr, iov_dest, iov, count);
+	tx_buf = mrail_get_tx_buf(mrail_ep, context, peer_info->seq_no++,
+				  ofi_op_tagged);
+	if (OFI_UNLIKELY(!tx_buf)) {
+		ret = -FI_ENOMEM;
+		goto err1;
+	}
+	tx_buf->hdr.tag = tag;
+	mrail_copy_iov_hdr(&tx_buf->hdr, iov_dest, iov, count);
 
 	msg.msg_iov 	= iov_dest;
 	msg.desc    	= desc;
 	msg.iov_count	= count + 1;
 	msg.addr	= dest_addr;
-	msg.context	= context;
+	msg.context	= tx_buf;
 	msg.data	= data;
 
 	if (len < mrail_ep->rails[i].info->tx_attr->inject_size)
 		flags |= FI_INJECT;
 
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting tsend of length: %" PRIu64
-	       " dest_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 " on rail: %d\n",
-	       len, dest_addr, tag, i);
+	       " dest_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 " seq: %d"
+	       " on rail: %d\n", len, dest_addr, tag, peer_info->seq_no - 1, i);
+
 	ret = fi_sendmsg(mrail_ep->rails[i].ep, &msg, flags);
 	if (ret) {
 		FI_WARN(&mrail_prov, FI_LOG_EP_DATA,
 			"Unable to fi_sendmsg on rail: %" PRIu32 "\n", i);
-		peer_info->seq_no--;
+		goto err2;
 	}
-
+	ofi_ep_lock_release(&mrail_ep->util_ep);
+	return ret;
+err2:
+	util_buf_release(mrail_ep->tx_buf_pool, tx_buf);
+err1:
+	peer_info->seq_no--;
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 	return ret;
 }
@@ -543,6 +580,78 @@ static int mrail_getname(fid_t fid, void *addr, size_t *addrlen)
 	return 0;
 }
 
+
+static void mrail_tx_buf_init(void *pool_ctx, void *buf)
+{
+	struct mrail_ep *mrail_ep = pool_ctx;
+	struct mrail_tx_buf *tx_buf = buf;
+
+	tx_buf->ep		= mrail_ep;
+	tx_buf->hdr.version	= MRAIL_HDR_VERSION;
+}
+
+static void mrail_ep_free_bufs(struct mrail_ep *mrail_ep)
+{
+	if (mrail_ep->req_pool)
+		util_buf_pool_destroy(mrail_ep->req_pool);
+
+	if (mrail_ep->ooo_recv_pool)
+		util_buf_pool_destroy(mrail_ep->ooo_recv_pool);
+
+	if (mrail_ep->tx_buf_pool)
+		util_buf_pool_destroy(mrail_ep->tx_buf_pool);
+
+	if (mrail_ep->recv_fs)
+		mrail_recv_fs_free(mrail_ep->recv_fs);
+}
+
+static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
+{
+	struct util_buf_attr attr = {
+		.size		= sizeof(struct mrail_tx_buf),
+		.alignment	= sizeof(void *),
+		.max_cnt	= 0,
+		.chunk_cnt	= 64,
+		.alloc_hndlr	= NULL,
+		.free_hndlr	= NULL,
+		.init		= mrail_tx_buf_init,
+		.ctx		= mrail_ep,
+	};
+	size_t buf_size, rxq_total_size = 0;
+	struct fi_info *fi;
+	int ret;
+
+	for (fi = mrail_ep->info->next; fi; fi = fi->next)
+		rxq_total_size += fi->rx_attr->size;
+
+	mrail_ep->recv_fs = mrail_recv_fs_create(rxq_total_size, mrail_init_recv,
+						 mrail_ep);
+	if (!mrail_ep->recv_fs)
+		return -FI_ENOMEM;
+
+	ret = util_buf_pool_create(&mrail_ep->ooo_recv_pool,
+				   sizeof(struct mrail_ooo_recv),
+				   sizeof(void *), 0, 64);
+	if (!mrail_ep->ooo_recv_pool)
+		goto err;
+
+	ret = util_buf_pool_create_attr(&attr, &mrail_ep->tx_buf_pool);
+	if (!mrail_ep->tx_buf_pool)
+		goto err;
+
+	buf_size = (sizeof(struct mrail_req) +
+		    (mrail_ep->num_eps * sizeof(struct mrail_subreq)));
+
+	ret = util_buf_pool_create(&mrail_ep->req_pool, buf_size,
+				   sizeof(void *), 0, 64);
+	if (ret)
+		goto err;
+	return 0;
+err:
+	mrail_ep_free_bufs(mrail_ep);
+	return ret;
+}
+
 static int mrail_ep_close(fid_t fid)
 {
 	struct mrail_ep *mrail_ep =
@@ -550,9 +659,7 @@ static int mrail_ep_close(fid_t fid)
 	int ret, retv = 0;
 	size_t i;
 
-	util_buf_pool_destroy(mrail_ep->req_pool);
-	util_buf_pool_destroy(mrail_ep->ooo_recv_pool);
-	mrail_recv_fs_free(mrail_ep->recv_fs);
+	mrail_ep_free_bufs(mrail_ep);
 
 	for (i = 0; i < mrail_ep->num_eps; i++) {
 		ret = fi_close(&mrail_ep->rails[i].ep->fid);
@@ -746,8 +853,7 @@ int mrail_ep_open(struct fid_domain *domain_fid, struct fi_info *info,
 			     util_domain.domain_fid);
 	struct mrail_ep *mrail_ep;
 	struct fi_info *fi;
-	size_t i, rxq_total_size;
-	size_t buf_size;
+	size_t i;
 	int ret;
 
 	if (strcmp(mrail_domain->info->domain_attr->name,
@@ -780,8 +886,7 @@ int mrail_ep_open(struct fid_domain *domain_fid, struct fi_info *info,
 		goto err;
 	}
 
-	for (i = 0, fi = mrail_ep->info->next, rxq_total_size = 0; fi;
-	     fi = fi->next, i++) {
+	for (i = 0, fi = mrail_ep->info->next; fi; fi = fi->next, i++) {
 		fi->tx_attr->op_flags &= ~FI_COMPLETION;
 		ret = fi_endpoint(mrail_domain->domains[i], fi,
 				  &mrail_ep->rails[i].ep, mrail_ep);
@@ -791,32 +896,11 @@ int mrail_ep_open(struct fid_domain *domain_fid, struct fi_info *info,
 			goto err;
 		}
 		mrail_ep->rails[i].info = fi;
-		rxq_total_size += fi->rx_attr->size;
 	}
 
-	mrail_ep->recv_fs = mrail_recv_fs_create(rxq_total_size, mrail_init_recv,
-						 mrail_ep);
-	if (!mrail_ep->recv_fs) {
-		ret = -FI_ENOMEM;
+	ret = mrail_ep_alloc_bufs(mrail_ep);
+	if (ret)
 		goto err;
-	}
-
-	ret = util_buf_pool_create(&mrail_ep->ooo_recv_pool,
-			sizeof(struct mrail_ooo_recv), sizeof(void *), 0, 64);
-	if (!mrail_ep->ooo_recv_pool) {
-		ret = -FI_ENOMEM;
-		goto err;
-	}
-
-	buf_size = sizeof(struct mrail_req) +
-		(mrail_ep->num_eps * sizeof(struct mrail_subreq));
-
-	ret = util_buf_pool_create(&mrail_ep->req_pool, buf_size,
-			sizeof(void *), 0, 64);
-	if (ret) {
-		ret = -FI_ENOMEM;
-		goto err;
-	}
 
 	slist_init(&mrail_ep->deferred_reqs);
 

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -738,7 +738,7 @@ static int mrail_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 static int mrail_ep_ctrl(struct fid *fid, int command, void *arg)
 {
 	struct mrail_ep *mrail_ep;
-	size_t i;
+	size_t i, buf_recv_min = sizeof(struct mrail_hdr);
 	int ret;
 
 	mrail_ep = container_of(fid, struct mrail_ep, util_ep.ep_fid.fid);
@@ -750,6 +750,12 @@ static int mrail_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (!mrail_ep->util_ep.av)
 			return -FI_ENOAV;
 		for (i = 0; i < mrail_ep->num_eps; i++) {
+			ret = fi_setopt(&mrail_ep->rails[i].ep->fid,
+					FI_OPT_ENDPOINT, FI_OPT_BUFFERED_MIN,
+					&buf_recv_min, sizeof(buf_recv_min));
+			if (ret)
+				return ret;
+
 			ret = fi_enable(mrail_ep->rails[i].ep);
 			if (ret)
 				return ret;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -151,6 +151,9 @@ struct rxm_rndv_hdr {
 	uint8_t count;
 };
 
+#define rxm_pkt_rndv_data(rxm_pkt) \
+	((rxm_pkt)->data + sizeof(struct rxm_rndv_hdr))
+
 /*
  * Macros to generate enums and associated string values
  * e.g.

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -146,9 +146,9 @@ struct rxm_cm_data {
 	struct rxm_ep_wire_proto proto;
 };
 
-struct rxm_rma_iov {
+struct rxm_rndv_hdr {
+	struct ofi_rma_iov iov[RXM_IOV_LIMIT];
 	uint8_t count;
-	struct ofi_rma_iov iov[];
 };
 
 /*
@@ -297,8 +297,8 @@ struct rxm_rx_buf {
 	uint8_t repost;
 
 	/* Used for large messages */
-	struct rxm_rma_iov *rma_iov;
-	size_t rma_iov_index;
+	struct rxm_rndv_hdr *rndv_hdr;
+	size_t rndv_rma_index;
 	struct fid_mr *mr[RXM_IOV_LIMIT];
 
 	/* Must stay at bottom */

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -469,6 +469,8 @@ struct rxm_ep {
 	int			msg_mr_local;
 	int			rxm_mr_local;
 	size_t			min_multi_recv_size;
+	size_t			buffered_min;
+	size_t			buffered_limit;
 
 	struct {
 		size_t		limit;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -359,9 +359,9 @@ rxm_cq_lmt_read_prepare_deferred(struct rxm_tx_entry **tx_entry, size_t index,
 		return -FI_ENOMEM;
 	}
 	(*tx_entry)->rma_buf->rxm_rma_iov.iov[0].addr =
-		(*tx_entry)->rx_buf->rma_iov->iov[index].addr;
+		(*tx_entry)->rx_buf->rndv_hdr->iov[index].addr;
 	(*tx_entry)->rma_buf->rxm_rma_iov.iov[0].key =
-		(*tx_entry)->rx_buf->rma_iov->iov[index].key;
+		(*tx_entry)->rx_buf->rndv_hdr->iov[index].key;
 	for (i = 0; i < count; i++) {
 		(*tx_entry)->rma_buf->rxm_iov.iov[i] = iov[i];
 		(*tx_entry)->rma_buf->rxm_iov.desc[i] = desc[i];
@@ -393,8 +393,8 @@ ssize_t rxm_cq_handle_large_data(struct rxm_rx_buf *rx_buf)
 	       "Got incoming recv with msg_id: 0x%" PRIx64 "\n",
 	       rx_buf->pkt.ctrl_hdr.msg_id);
 
-	rx_buf->rma_iov = (struct rxm_rma_iov *)rx_buf->pkt.data;
-	rx_buf->rma_iov_index = 0;
+	rx_buf->rndv_hdr = (struct rxm_rndv_hdr *)rx_buf->pkt.data;
+	rx_buf->rndv_rma_index = 0;
 
 	if (!rx_buf->ep->rxm_mr_local) {
 		total_recv_len = MIN(rx_buf->recv_entry->total_len,
@@ -419,14 +419,16 @@ ssize_t rxm_cq_handle_large_data(struct rxm_rx_buf *rx_buf)
 				     rx_buf->pkt.hdr.size);
 	}
 
-	assert(rx_buf->rma_iov->count && (rx_buf->rma_iov->count <= RXM_IOV_LIMIT));
+	assert(rx_buf->rndv_hdr->count &&
+	       (rx_buf->rndv_hdr->count <= RXM_IOV_LIMIT));
 
 	RXM_LOG_STATE_RX(FI_LOG_CQ, rx_buf, RXM_LMT_READ);
 	rx_buf->hdr.state = RXM_LMT_READ;
 
-	for (i = 0; i < rx_buf->rma_iov->count; i++) {
-		size_t copy_len = MIN(rx_buf->rma_iov->iov[i].len,
+	for (i = 0; i < rx_buf->rndv_hdr->count; i++) {
+		size_t copy_len = MIN(rx_buf->rndv_hdr->iov[i].len,
 				      total_recv_len);
+
 		ret = ofi_copy_iov_desc(&iov[0], &desc[0], &count,
 					&rx_buf->recv_entry->rxm_iov.iov[0],
 					&rx_buf->recv_entry->rxm_iov.desc[0],
@@ -439,8 +441,8 @@ ssize_t rxm_cq_handle_large_data(struct rxm_rx_buf *rx_buf)
 		}
 		total_recv_len -= copy_len;
 		ret = fi_readv(rx_buf->conn->msg_ep, iov, desc, count, 0,
-			       rx_buf->rma_iov->iov[i].addr,
-			       rx_buf->rma_iov->iov[i].key, rx_buf);
+			       rx_buf->rndv_hdr->iov[i].addr,
+			       rx_buf->rndv_hdr->iov[i].key, rx_buf);
 		if (OFI_UNLIKELY(ret)) {
 			if (OFI_LIKELY(ret == -FI_EAGAIN)) {
 				ret = rxm_cq_lmt_read_prepare_deferred(
@@ -776,7 +778,7 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	case RXM_LMT_READ:
 		rx_buf = comp->op_context;
 		assert(comp->flags & FI_READ);
-		if (++rx_buf->rma_iov_index < rx_buf->rma_iov->count)
+		if (++rx_buf->rndv_rma_index < rx_buf->rndv_hdr->count)
 			return 0;
 		else if (sizeof(rx_buf->pkt) > rxm_ep->msg_info->tx_attr->inject_size)
 			return rxm_lmt_send_ack(rx_buf);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -437,7 +437,8 @@ static void rxm_ep_txrx_queue_close(struct rxm_ep *rxm_ep)
 static void rxm_ep_txrx_res_close(struct rxm_ep *rxm_ep)
 {
 	rxm_ep_txrx_queue_close(rxm_ep);
-	rxm_ep_txrx_pool_destroy(rxm_ep);
+	if (rxm_ep->buf_pools)
+		rxm_ep_txrx_pool_destroy(rxm_ep);
 	if (rxm_ep->util_ep.domain->threading != FI_THREAD_SAFE) {
 		free(rxm_ep->inject_tx_pkt);
 		rxm_ep->inject_tx_pkt = NULL;
@@ -517,19 +518,34 @@ static ssize_t rxm_ep_cancel(fid_t fid_ep, void *context)
 	return 0;
 }
 
-// TODO add support for FI_OPT_BUFFERED_LIMIT
 static int rxm_ep_getopt(fid_t fid, int level, int optname, void *optval,
 			 size_t *optlen)
 {
 	struct rxm_ep *rxm_ep =
 		container_of(fid, struct rxm_ep, util_ep.ep_fid);
 
-	if ((level != FI_OPT_ENDPOINT) || (optname != FI_OPT_MIN_MULTI_RECV))
+	if (level != FI_OPT_ENDPOINT)
 		return -FI_ENOPROTOOPT;
 
-	*(size_t *)optval = rxm_ep->min_multi_recv_size;
-	*optlen = sizeof(size_t);
-
+	switch (optname) {
+	case FI_OPT_MIN_MULTI_RECV:
+		assert(sizeof(rxm_ep->min_multi_recv_size) == sizeof(size_t));
+		*(size_t *)optval = rxm_ep->min_multi_recv_size;
+		*optlen = sizeof(size_t);
+		break;
+	case FI_OPT_BUFFERED_MIN:
+		assert(sizeof(rxm_ep->buffered_min) == sizeof(size_t));
+		*(size_t *)optval = rxm_ep->buffered_min;
+		*optlen = sizeof(size_t);
+		break;
+	case FI_OPT_BUFFERED_LIMIT:
+		assert(sizeof(rxm_ep->buffered_limit) == sizeof(size_t));
+		*(size_t *)optval = rxm_ep->buffered_limit;
+		*optlen = sizeof(size_t);
+		break;
+	default:
+		return -FI_ENOPROTOOPT;
+	}
 	return FI_SUCCESS;
 }
 
@@ -538,13 +554,50 @@ static int rxm_ep_setopt(fid_t fid, int level, int optname,
 {
 	struct rxm_ep *rxm_ep =
 		container_of(fid, struct rxm_ep, util_ep.ep_fid);
+	int ret = FI_SUCCESS;
 
-	if ((level != FI_OPT_ENDPOINT) || (optname != FI_OPT_MIN_MULTI_RECV))
+	if (level != FI_OPT_ENDPOINT)
 		return -FI_ENOPROTOOPT;
 
-	rxm_ep->min_multi_recv_size = *(size_t *)optval;
-
-	return FI_SUCCESS;
+	switch (optname) {
+	case FI_OPT_MIN_MULTI_RECV:
+		rxm_ep->min_multi_recv_size = *(size_t *)optval;
+		break;
+	case FI_OPT_BUFFERED_MIN:
+		if (rxm_ep->buf_pools) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+				"Endpoint already enabled. Can't set opt now!\n");
+			ret = -FI_EOPBADSTATE;
+		} else if (*(size_t *)optval > rxm_ep->buffered_limit) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+			"Invalid value for FI_OPT_BUFFERED_MIN: %zu "
+			"( > FI_OPT_BUFFERED_LIMIT: %zu)\n",
+			*(size_t *)optval, rxm_ep->buffered_limit);
+			ret = -FI_EINVAL;
+		} else {
+			rxm_ep->buffered_min = *(size_t *)optval;
+		}
+		break;
+	case FI_OPT_BUFFERED_LIMIT:
+		if (rxm_ep->buf_pools) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+				"Endpoint already enabled. Can't set opt now!\n");
+			ret = -FI_EOPBADSTATE;
+		/* We do not check for maximum as we allow sizes up to SIZE_MAX */
+		} else if (*(size_t *)optval < rxm_ep->buffered_min) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+			"Invalid value for FI_OPT_BUFFERED_LIMIT: %zu"
+			" ( < FI_OPT_BUFFERED_MIN: %zu)\n",
+			*(size_t *)optval, rxm_ep->buffered_min);
+			ret = -FI_EINVAL;
+		} else {
+			rxm_ep->buffered_limit = *(size_t *)optval;
+		}
+		break;
+	default:
+		ret = -FI_ENOPROTOOPT;
+	}
+	return ret;
 }
 
 static struct fi_ops_ep rxm_ops_ep = {
@@ -2050,13 +2103,20 @@ static int rxm_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (!rxm_ep->util_ep.av || !rxm_ep->util_ep.cmap)
 			return -FI_EOPBADSTATE;
 
+		/* At the time of enabling endpoint, FI_OPT_BUFFERED_MIN,
+		 * FI_OPT_BUFFERED_LIMIT should have been frozen so we can
+		 * create the rendezvous protocol message pool with the right
+		 * size */
+		ret = rxm_ep_txrx_pool_create(rxm_ep);
+		if (ret)
+			return ret;
+
 		if (rxm_ep->srx_ctx) {
 			ret = rxm_ep_prepost_buf(rxm_ep, rxm_ep->srx_ctx);
 			if (ret) {
-				ofi_cmap_free(rxm_ep->util_ep.cmap);
 				FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 					"Unable to prepost recv bufs\n");
-				return ret;
+				goto err;
 			}
 		}
 		break;
@@ -2064,6 +2124,9 @@ static int rxm_ep_ctrl(struct fid *fid, int command, void *arg)
 		return -FI_ENOSYS;
 	}
 	return 0;
+err:
+	rxm_ep_txrx_pool_destroy(rxm_ep);
+	return ret;
 }
 
 static struct fi_ops rxm_ep_fi_ops = {
@@ -2267,19 +2330,13 @@ static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep)
 
 	dlist_init(&rxm_ep->deferred_tx_conn_queue);
 
-	ret = rxm_ep_txrx_pool_create(rxm_ep);
-	if (ret)
-		goto err1;
-
 	ret = rxm_ep_txrx_queue_init(rxm_ep);
 	if (ret)
-		goto err2;
+		goto err1;
 
 	rxm_ep_sar_init(rxm_ep);
 
 	return FI_SUCCESS;
-err2:
-	rxm_ep_txrx_pool_destroy(rxm_ep);
 err1:
 	if (rxm_ep->util_ep.domain->threading != FI_THREAD_SAFE) {
 		free(rxm_ep->inject_tx_pkt);
@@ -2328,6 +2385,16 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 	rxm_ep->rxm_mr_local = ofi_mr_local(rxm_ep->rxm_info);
 
 	rxm_ep->min_multi_recv_size = rxm_ep->rxm_info->tx_attr->inject_size;
+
+	if (rxm_ep->msg_info->tx_attr->inject_size >
+	    (sizeof(struct rxm_pkt) + sizeof(struct rxm_rndv_hdr)))
+		rxm_ep->buffered_min = (rxm_ep->msg_info->tx_attr->inject_size -
+					(sizeof(struct rxm_pkt) +
+					 sizeof(struct rxm_rndv_hdr)));
+	else
+		assert(!rxm_ep->buffered_min);
+
+	rxm_ep->buffered_limit = rxm_ep->rxm_info->tx_attr->inject_size;
 
 	ret = rxm_ep_txrx_res_open(rxm_ep);
 	if (ret)

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -81,6 +81,14 @@ int util_buf_grow(struct util_buf_pool *pool)
 	for (i = 0; i < pool->attr.chunk_cnt; i++) {
 		util_buf = (union util_buf *)
 			(buf_region->mem_region + i * pool->entry_sz);
+
+		if (pool->attr.init) {
+#if ENABLE_DEBUG
+			util_buf->entry.next = (void *)OFI_MAGIC_64;
+#endif
+			pool->attr.init(pool->attr.ctx, util_buf);
+			assert(util_buf->entry.next == (void *)OFI_MAGIC_64);
+		}
 		util_buf_set_region(util_buf, buf_region, pool);
 		slist_insert_tail(&util_buf->entry, &pool->buf_list);
 	}


### PR DESCRIPTION
- prov/rxm: make the header used for rendezvous protocol fixed size
- common: add a minimum buffered recv limit option
- prov/rxm: add support for buffered limit opts
- prov/rxm: add support for buffered recv for rendezvous protocol messages 
- prov/util: add a initializer function for util buffer pool 
- prov/mrail: add a buffer pool for mrail header
- prov/mrail: set correct values for buffered limits 
- prov/mrail: remove selective completion requirement from underlying provider
- common, mrail: fix slist_insert_order function 