### PR TITLE
prov/rxm: Fix handling of truncated messages in Rendezvous protocol

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -610,8 +610,7 @@ rxm_ep_msg_mr_regv_lim(struct rxm_ep *rxm_ep, const struct iovec *iov, size_t co
 		container_of(rxm_ep->util_ep.domain, struct rxm_domain, util_domain);
  
 	for (i = 0; i < count && total_reg_len; i++) {
-		size_t len = iov[i].iov_len <= total_reg_len ?
-			     iov[i].iov_len : total_reg_len;
+		size_t len = MIN(iov[i].iov_len, total_reg_len);
 		ret = fi_mr_reg(rxm_domain->msg_domain, iov[i].iov_base,
 				len, access, 0, 0, 0, &mr[i], NULL);
 		if (ret)


### PR DESCRIPTION
This patch fixes case when the length of the supplied buffer is smaller than
the length of the message that will be read by fi_readv().

The problem was reproduced with MPICH errors/pt2pt/truncmsg1 test.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>