### PR TITLE
prov/psm2: AM Large Size RMA usage of Fast Path isend/irecv in PSM2

### DIFF
--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -18,6 +18,7 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 	 AC_DEFINE_UNQUOTED([HAVE_PSM2_SRC], $have_psm2_src, [PSM2 source is built-in])
 	 psm2_happy=0
 	 have_psm2_am_register_handlers_2=1
+	 have_psm2_mq_fp_msg=1
 	 AS_IF([test x"$enable_psm2" != x"no"],
 	       [AS_IF([test x$have_psm2_src = x0],
 		      [
@@ -25,7 +26,7 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 			FI_CHECK_PACKAGE([psm2],
 					 [psm2.h],
 					 [psm2],
-					 [psm2_am_register_handlers_2],
+					 [psm2_mq_fp_msg],
 					 [],
 					 [$psm2_PREFIX],
 					 [$psm2_LIBDIR],
@@ -33,7 +34,21 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 					 [psm2_happy=0])
 			AS_IF([test x$psm2_happy = x0],
 			      [
-				$as_echo "$as_me: recheck psm2 with reduced feature set."
+				$as_echo "$as_me: recheck psm2 without psm2_mq_fp_msg."
+				have_psm2_mq_fp_msg=0
+				FI_CHECK_PACKAGE([psm2],
+						 [psm2.h],
+						 [psm2],
+						 [psm2_am_register_handlers_2],
+						 [],
+						 [$psm2_PREFIX],
+						 [$psm2_LIBDIR],
+						 [psm2_happy=1],
+						 [psm2_happy=0])
+			      ])
+			AS_IF([test x$psm2_happy = x0],
+			      [
+				$as_echo "$as_me: recheck psm2 without psm2_am_register_handlers_2."
 				have_psm2_am_register_handlers_2=0
 				FI_CHECK_PACKAGE([psm2],
 						 [psm2.h],
@@ -107,6 +122,9 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 	 AC_DEFINE_UNQUOTED([HAVE_PSM2_AM_REGISTER_HANDLERS_2],
 			    $have_psm2_am_register_handlers_2,
 			    [psm2_am_register_handlers_2 function is present])
+	 AC_DEFINE_UNQUOTED([HAVE_PSM2_MQ_FP_MSG],
+			    $have_psm2_mq_fp_msg,
+			    [psm2_mq_fp_msg function is present])
 ])
 
 AC_ARG_WITH([psm2-src],

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -514,8 +514,10 @@ struct psmx2_trx_ctxt {
 	struct psmx2_fid_domain	*domain;
 	struct psmx2_fid_ep	*ep;
 
+#if !HAVE_PSM2_MQ_FP_MSG
 	/* incoming req queue for AM based RMA request. */
 	struct psmx2_req_queue	rma_queue;
+#endif
 
 	/* triggered operations that are ready to be processed */
 	struct psmx2_req_queue	trigger_queue;

--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -71,9 +71,10 @@ int psmx2_am_handler_count = 0;
 int psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt)
 {
 	struct slist_entry *item;
-	struct psmx2_am_request *req;
 	struct psmx2_trigger *trigger;
 
+#if !HAVE_PSM2_MQ_FP_MSG
+	struct psmx2_am_request *req;
 	if (psmx2_env.tagged_rma) {
 		psmx2_lock(&trx_ctxt->rma_queue.lock, 2);
 		while (!slist_empty(&trx_ctxt->rma_queue.list)) {
@@ -85,6 +86,7 @@ int psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt)
 		}
 		psmx2_unlock(&trx_ctxt->rma_queue.lock, 2);
 	}
+#endif
 
 	psmx2_lock(&trx_ctxt->trigger_queue.lock, 2);
 	while (!slist_empty(&trx_ctxt->trigger_queue.list)) {

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -385,7 +385,11 @@ STATIC int psmx2_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		err = psmx2_domain_enable_ep(ep->domain, ep);
 		if (err)
 			return err;
+#if HAVE_PSM2_MQ_FP_MSG
+		if (ep->caps & FI_TRIGGER)
+#else
 		if (ep->caps & (FI_RMA | FI_TRIGGER))
+#endif
 			stx->tx->am_progress = 1;
 		ofi_atomic_inc32(&stx->ref);
 		break;
@@ -611,8 +615,11 @@ int psmx2_ep_open_internal(struct psmx2_fid_domain *domain_priv,
 	psmx2_ep_optimize_ops(ep_priv);
 
 	PSMX2_EP_INIT_OP_CONTEXT(ep_priv);
-
+#if HAVE_PSM2_MQ_FP_MSG
+	if ((ep_cap & FI_TRIGGER) && trx_ctxt)
+#else
 	if ((ep_cap & (FI_RMA | FI_TRIGGER)) && trx_ctxt)
+#endif
 		trx_ctxt->am_progress = 1;
 
 	*ep_out = ep_priv;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -506,8 +506,9 @@ PROVIDER_INI
 {
 	FI_INFO(&psmx2_prov, FI_LOG_CORE, "build options: HAVE_PSM2_SRC=%d, "
 			"HAVE_PSM2_AM_REGISTER_HANDLERS_2=%d, "
+			"HAVE_PSM2_MQ_FP_MSG=%d, "
 			"PSMX2_USE_REQ_CONTEXT=%d\n", HAVE_PSM2_SRC,
-			HAVE_PSM2_AM_REGISTER_HANDLERS_2, PSMX2_USE_REQ_CONTEXT);
+			HAVE_PSM2_AM_REGISTER_HANDLERS_2, HAVE_PSM2_MQ_FP_MSG, PSMX2_USE_REQ_CONTEXT);
 
 	fi_param_define(&psmx2_prov, "name_server", FI_PARAM_BOOL,
 			"Whether to turn on the name server or not "

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -33,6 +33,7 @@
 #include "psmx2.h"
 #include "psmx2_trigger.h"
 
+#if !HAVE_PSM2_MQ_FP_MSG
 static inline void psmx2_am_enqueue_rma(struct psmx2_trx_ctxt *trx_ctxt,
 					struct psmx2_am_request *req)
 {
@@ -40,6 +41,7 @@ static inline void psmx2_am_enqueue_rma(struct psmx2_trx_ctxt *trx_ctxt,
 	slist_insert_tail(&req->list_entry, &trx_ctxt->rma_queue.list);
 	psmx2_unlock(&trx_ctxt->rma_queue.lock, 2);
 }
+#endif
 
 static inline void psmx2_iov_copy(struct iovec *iov, size_t count,
 				  size_t offset, const void *src,
@@ -115,6 +117,11 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 	struct psmx2_fid_mr *mr;
 	psm2_epaddr_t epaddr;
 	struct psmx2_trx_ctxt *rx;
+
+#if HAVE_PSM2_MQ_FP_MSG
+	psm2_mq_req_t psm2_req;
+	psm2_mq_tag_t psm2_tag, psm2_tagsel;
+#endif
 
 	psm2_am_get_source(token, &epaddr);
 	cmd = PSMX2_AM_GET_OP(args[0].u32w0);
@@ -210,7 +217,28 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 					(has_data ? FI_REMOTE_CQ_DATA : 0),
 			PSMX2_CTXT_TYPE(&req->fi_context) = PSMX2_REMOTE_WRITE_CONTEXT;
 			PSMX2_CTXT_USER(&req->fi_context) = mr;
+#if HAVE_PSM2_MQ_FP_MSG
+			PSMX2_SET_TAG(psm2_tag, (uint64_t)req->write.context, 0,
+					PSMX2_RMA_TYPE_WRITE);
+			PSMX2_SET_MASK(psm2_tagsel, PSMX2_MATCH_ALL, PSMX2_RMA_TYPE_MASK);
+			op_error = psm2_mq_fp_msg(rx->psm2_ep, rx->psm2_mq,
+						 (psm2_epaddr_t)epaddr,
+						 &psm2_tag, &psm2_tagsel, 0,
+						 (void *)rma_addr, rma_len,
+						 (void *)&req->fi_context, PSM2_MQ_IRECV_FP, &psm2_req);
+			if (op_error) {
+				rep_args[0].u32w0 = PSMX2_AM_REP_WRITE | eom;
+				rep_args[0].u32w1 = op_error;
+				rep_args[1].u64 = args[1].u64;
+				err = psm2_am_reply_short(token, PSMX2_AM_RMA_HANDLER,
+							  rep_args, 2, NULL, 0, 0,
+							  NULL, NULL );
+				psmx2_am_request_free(rx, req);
+				break;
+			}
+#else
 			psmx2_am_enqueue_rma(rx, req);
+#endif
 		}
 		break;
 
@@ -282,7 +310,28 @@ int psmx2_am_rma_handler(psm2_am_token_t token, psm2_amarg_t *args,
 			req->read.peer_addr = (void *)epaddr;
 			PSMX2_CTXT_TYPE(&req->fi_context) = PSMX2_REMOTE_READ_CONTEXT;
 			PSMX2_CTXT_USER(&req->fi_context) = mr;
+#if HAVE_PSM2_MQ_FP_MSG
+			PSMX2_SET_TAG(psm2_tag, (uint64_t)req->read.context, 0,
+			PSMX2_RMA_TYPE_READ);
+			op_error = psm2_mq_fp_msg(rx->psm2_ep, rx->psm2_mq,
+				  (psm2_epaddr_t)req->read.peer_addr,
+				 &psm2_tag, 0, 0,
+				 (void *)req->read.addr, req->read.len,
+				 (void *)&req->fi_context, PSM2_MQ_ISEND_FP, &psm2_req);
+			if (op_error) {
+				rep_args[0].u32w0 = PSMX2_AM_REP_READ | eom;
+				rep_args[0].u32w1 = op_error;
+				rep_args[1].u64 = args[1].u64;
+				rep_args[2].u64 = 0;
+				err = psm2_am_reply_short(token, PSMX2_AM_RMA_HANDLER,
+						rep_args, 3, NULL, 0, 0,
+						NULL, NULL );
+				psmx2_am_request_free(rx, req);
+				break;
+			}
+#else
 			psmx2_am_enqueue_rma(rx, req);
+#endif
 		}
 		break;
 
@@ -541,6 +590,7 @@ void psmx2_am_ack_rma(struct psmx2_am_request *req)
 			      PSM2_AM_FLAG_NOREPLY, NULL, NULL);
 }
 
+#if !HAVE_PSM2_MQ_FP_MSG
 int psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 			 struct psmx2_am_request *req)
 {
@@ -569,6 +619,7 @@ int psmx2_am_process_rma(struct psmx2_trx_ctxt *trx_ctxt,
 
 	return psmx2_errno(err);
 }
+#endif
 
 ssize_t psmx2_read_generic(struct fid_ep *ep, void *buf, size_t len,
 			   void *desc, fi_addr_t src_addr,

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -323,13 +323,15 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 		goto err_out_close_ep;
 	}
 
+#if !HAVE_PSM2_MQ_FP_MSG
+	fastlock_init(&trx_ctxt->rma_queue.lock);
+	slist_init(&trx_ctxt->rma_queue.list);
+#endif
 	fastlock_init(&trx_ctxt->peer_lock);
 	fastlock_init(&trx_ctxt->poll_lock);
 	fastlock_init(&trx_ctxt->am_req_pool_lock);
-	fastlock_init(&trx_ctxt->rma_queue.lock);
 	fastlock_init(&trx_ctxt->trigger_queue.lock);
 	dlist_init(&trx_ctxt->peer_list);
-	slist_init(&trx_ctxt->rma_queue.list);
 	slist_init(&trx_ctxt->trigger_queue.list);
 	trx_ctxt->id = psmx2_trx_ctxt_cnt++;
 	trx_ctxt->domain = domain;


### PR DESCRIPTION
-Updated OFI PSM2 to use the new psm2_mq_fp_msg functionality in PSM2
that allows for a user to enqueue isends/irecvs into the MQ from within
an AM handler.

-Removes the need for tracking large RMAs with an internal queue and
improves the speed at which the target of RMAs can respond to read/write
requests. This greatly increases the performance in several areas making
RMA usage quicker with OFI PSM2.

-Added backwards compatability support for checking if psm2_mq_fp_msg is
available in the provided psm2 and instead compile with the previous
large size AM support enabled. This check is enabled in the
configure.m4.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>