### PR TITLE
prov/mrail: Add basic support for counters.

### DIFF
--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -355,3 +355,10 @@ void mrail_free_req(struct mrail_ep *mrail_ep, struct mrail_req *req)
 void mrail_progress_deferred_reqs(struct mrail_ep *mrail_ep);
 
 void mrail_poll_cq(struct util_cq *cq);
+
+static inline void mrail_cntr_incerr(struct util_cntr *cntr)
+{
+       if (cntr) {
+               cntr->cntr_fid.ops->adderr(&cntr->cntr_fid, 1);
+       }
+}

--- a/prov/mrail/src/mrail_domain.c
+++ b/prov/mrail/src/mrail_domain.c
@@ -222,13 +222,36 @@ static struct fi_ops_mr mrail_domain_mr_ops = {
 	.regattr = fi_no_mr_regattr,
 };
 
+int mrail_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
+		struct fid_cntr **cntr_fid, void *context)
+{
+	int ret;
+	struct util_cntr *cntr;
+
+	cntr = calloc(1, sizeof(*cntr));
+	if (!cntr)
+		return -FI_ENOMEM;
+
+	ret = ofi_cntr_init(&mrail_prov, domain, attr, cntr,
+			&ofi_cntr_progress, context);
+	if (ret)
+		goto error;
+
+	*cntr_fid = &cntr->cntr_fid;
+	return FI_SUCCESS;
+
+error:
+	free(cntr);
+	return ret;
+}
+
 static struct fi_ops_domain mrail_domain_ops = {
 	.size = sizeof(struct fi_ops_domain),
 	.av_open = mrail_av_open,
 	.cq_open = mrail_cq_open,
 	.endpoint = mrail_ep_open,
 	.scalable_ep = fi_no_scalable_ep,
-	.cntr_open = fi_no_cntr_open,
+	.cntr_open = mrail_cntr_open,
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -382,6 +382,8 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		FI_WARN(&mrail_prov, FI_LOG_EP_DATA,
 			"Unable to fi_sendmsg on rail: %" PRIu32 "\n", i);
 		goto err2;
+	} else if (!(flags & FI_COMPLETION)) {
+		ofi_ep_tx_cntr_inc(&mrail_ep->util_ep);
 	}
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 	return ret;
@@ -439,6 +441,8 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		FI_WARN(&mrail_prov, FI_LOG_EP_DATA,
 			"Unable to fi_sendmsg on rail: %" PRIu32 "\n", i);
 		goto err2;
+	} else if (!(flags & FI_COMPLETION)) {
+		ofi_ep_tx_cntr_inc(&mrail_ep->util_ep);
 	}
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 	return ret;

--- a/prov/mrail/src/mrail_rma.c
+++ b/prov/mrail/src/mrail_rma.c
@@ -400,9 +400,11 @@ static ssize_t mrail_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 		FI_WARN(&mrail_prov, FI_LOG_EP_DATA,
 			"Unable to post inject write on rail: %" PRIu32 "\n",
 			rail);
+		return ret;
 	}
+	ofi_ep_wr_cntr_inc(&mrail_ep->util_ep);
 
-	return ret;
+	return 0;
 }
 
 struct fi_ops_rma mrail_ops_rma = {

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -116,31 +116,37 @@ int ofi_ep_bind_cntr(struct util_ep *ep, struct util_cntr *cntr, uint64_t flags)
 
 	if (flags & FI_TRANSMIT) {
 		ep->tx_cntr = cntr;
+		ep->tx_cntr_inc = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_RECV) {
 		ep->rx_cntr = cntr;
+		ep->rx_cntr_inc = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_READ) {
 		ep->rd_cntr = cntr;
+		ep->rd_cntr_inc = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_WRITE) {
 		ep->wr_cntr = cntr;
+		ep->wr_cntr_inc = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_REMOTE_READ) {
 		ep->rem_rd_cntr = cntr;
+		ep->rem_rd_cntr_inc = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
 	if (flags & FI_REMOTE_WRITE) {
 		ep->rem_wr_cntr = cntr;
+		ep->rem_wr_cntr_inc = ofi_cntr_inc;
 		ofi_atomic_inc32(&cntr->ref);
 	}
 
@@ -210,6 +216,12 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 		((info->tx_attr->op_flags &
 		  ~(FI_COMPLETION | FI_INJECT_COMPLETE |
 		    FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)) | FI_INJECT);
+	ep->tx_cntr_inc 	= ofi_cntr_inc_noop;
+	ep->rx_cntr_inc 	= ofi_cntr_inc_noop;
+	ep->rd_cntr_inc 	= ofi_cntr_inc_noop;
+	ep->wr_cntr_inc 	= ofi_cntr_inc_noop;
+	ep->rem_rd_cntr_inc 	= ofi_cntr_inc_noop;
+	ep->rem_wr_cntr_inc 	= ofi_cntr_inc_noop;
 	ep->type = info->ep_attr->type;
 	ofi_atomic_inc32(&util_domain->ref);
 	if (util_domain->eq)


### PR DESCRIPTION
FI_RECV, FI_SEND, FI_READ and FI_WRITE supported. An additional protocol would
be needed in order to support FI_REMOTE_READ and FI_REMOTE_WRITE.

Signed-off-by: yohann <yohann.burette@intel.com>