### PR TITLE
prov/verbs: Fix completion handling

### DIFF
--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -243,12 +243,12 @@ static inline int fi_ibv_poll_outstanding_cq(struct fi_ibv_ep *ep,
 		return ret;
 
 	/* Handle WR entry when user doesn't request the completion */
-	if (wc.wr_id == VERBS_INJECT_FLAG) {
+	if (wc.wr_id == VERBS_NO_COMP_FLAG) {
 		/* To ensure the new iteration */
 		return 1;
 	}
 
-	if (wc.status != IBV_WC_WR_FLUSH_ERR) {
+	if (OFI_LIKELY(wc.status != IBV_WC_WR_FLUSH_ERR)) {
 		ret = fi_ibv_wc_2_wce(cq, &wc, &wce);
 		if (OFI_UNLIKELY(ret)) {
 			ret = -FI_EAGAIN;

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -143,9 +143,9 @@ fi_ibv_dgram_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
-		.wr_id = (uintptr_t)context,
+		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
-		.send_flags = VERBS_INJECT(ep, len) | VERBS_COMP(ep),
+		.send_flags = VERBS_INJECT(ep, len),
 	};
 
 	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &wr))
@@ -162,10 +162,10 @@ fi_ibv_dgram_ep_senddata(struct fid_ep *ep_fid, const void *buf,
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
-		.wr_id = (uintptr_t)context,
+		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
-		.send_flags = VERBS_INJECT(ep, len) | VERBS_COMP(ep),
+		.send_flags = VERBS_INJECT(ep, len),
 	};
 
 	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &wr))
@@ -181,7 +181,7 @@ fi_ibv_dgram_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
-		.wr_id = VERBS_INJECT_FLAG,
+		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
 		.send_flags = IBV_SEND_INLINE,
@@ -224,7 +224,7 @@ fi_ibv_dgram_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
-		.wr_id = VERBS_INJECT_FLAG,
+		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND,
 		.send_flags = IBV_SEND_INLINE,
 	};

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -115,9 +115,9 @@ fi_ibv_msg_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
-		.wr_id = (uintptr_t)context,
+		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
-		.send_flags = VERBS_INJECT(ep, len) | VERBS_COMP(ep),
+		.send_flags = VERBS_INJECT(ep, len),
 	};
 
 	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
@@ -130,10 +130,10 @@ fi_ibv_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
-		.wr_id = (uintptr_t)context,
+		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
-		.send_flags = VERBS_INJECT(ep, len) | VERBS_COMP(ep),
+		.send_flags = VERBS_INJECT(ep, len),
 	};
 
 	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
@@ -159,7 +159,7 @@ static ssize_t fi_ibv_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
-		.wr_id = VERBS_INJECT_FLAG,
+		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND,
 		.send_flags = IBV_SEND_INLINE,
 	};
@@ -173,7 +173,7 @@ static ssize_t fi_ibv_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, 
 	struct fi_ibv_ep *ep =
 		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
-		.wr_id = VERBS_INJECT_FLAG,
+		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
 		.send_flags = IBV_SEND_INLINE,


### PR DESCRIPTION
With FI_SELECTIVE_COMPLETION setting, the applications running with the
verbs provider still gets completion entries for RDMA and MSG messages without
a FI_COMPLETION flag.

The problem is fixed by setting VERBS_NO_COMP_FLAG to wr_id in case of
completion shouldn't be generated for this operation. When polling CQ,
this completions will be silently discarded.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>