### PR TITLE
prov/psm2: Prevent calls to dequeue event given no MQ events

### DIFF
--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -984,6 +984,9 @@ STATIC ssize_t psmx2_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 
 	read_count = 0;
 	for (i = 0; i < count; i++) {
+		if (slist_empty(&cq_priv->event_queue))
+			break;
+
 		event = psmx2_cq_dequeue_event(cq_priv);
 		if (event) {
 			if (!event->error) {


### PR DESCRIPTION
-During psmx2_cq_readfrom if no events are read from poll_mq, then
 psmx2_cq_dequeue_event will be called before exiting
 even if there are no events in the cq->event_queue slist.

-Avoid unnecessary locking overhead associated with the dequeue_event
 function by checking if the queue is empty in advance.

-This improves the latency & bandwidth for MPI usecases by up to 2-3% by
 removing the lock during cq_read calls when 0 events are read.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>