### PR TITLE
prov/psm2: Lock optimization for FI_THREAD_DOMAIN

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -536,6 +536,10 @@ struct psmx2_trx_ctxt {
 	struct dlist_entry	entry;
 };
 
+typedef void (*psmx2_lock_fn_t) (fastlock_t *lock, int lock_level);
+typedef int (*psmx2_trylock_fn_t) (fastlock_t *lock, int lock_level);
+typedef void (*psmx2_unlock_fn_t) (fastlock_t *lock, int lock_level);
+
 struct psmx2_fid_domain {
 	struct util_domain	util_domain;
 	struct psmx2_fid_fabric	*fabric;
@@ -562,6 +566,32 @@ struct psmx2_fid_domain {
 	uint32_t		max_atomic_size;
 
 	struct dlist_entry	entry;
+
+	/* Lock/Unlock function pointers set based on FI_THREAD model */
+	psmx2_lock_fn_t av_lock_fn;
+	psmx2_unlock_fn_t av_unlock_fn;
+	psmx2_lock_fn_t am_req_pool_lock_fn;
+	psmx2_unlock_fn_t am_req_pool_unlock_fn;
+	psmx2_lock_fn_t trx_ctxt_lock_fn;
+	psmx2_unlock_fn_t trx_ctxt_unlock_fn;
+	psmx2_lock_fn_t rma_queue_lock_fn;
+	psmx2_unlock_fn_t rma_queue_unlock_fn;
+	psmx2_lock_fn_t trigger_queue_lock_fn;
+	psmx2_unlock_fn_t trigger_queue_unlock_fn;
+	psmx2_lock_fn_t peer_lock_fn;
+	psmx2_unlock_fn_t peer_unlock_fn;
+	psmx2_lock_fn_t sep_lock_fn;
+	psmx2_unlock_fn_t sep_unlock_fn;
+	psmx2_lock_fn_t trigger_lock_fn;
+	psmx2_unlock_fn_t trigger_unlock_fn;
+	psmx2_lock_fn_t cq_lock_fn;
+	psmx2_unlock_fn_t cq_unlock_fn;
+	psmx2_lock_fn_t mr_lock_fn;
+	psmx2_unlock_fn_t mr_unlock_fn;
+	psmx2_lock_fn_t context_lock_fn;
+	psmx2_unlock_fn_t context_unlock_fn;
+	psmx2_trylock_fn_t poll_trylock_fn;
+	psmx2_unlock_fn_t poll_unlock_fn;
 };
 
 #define PSMX2_EP_REGULAR	0
@@ -834,6 +864,33 @@ static inline void psmx2_unlock(fastlock_t *lock, int lock_level)
 		fastlock_release(lock);
 }
 
+/* Specialized lock functions used based on FI_THREAD model */
+
+static inline void psmx2_lock_disabled(fastlock_t *lock, int lock_level)
+{
+	return;
+}
+
+static inline int psmx2_trylock_disabled(fastlock_t *lock, int lock_level)
+{
+	return 0;
+}
+
+static inline void psmx2_lock_enabled(fastlock_t *lock, int lock_level)
+{
+	fastlock_acquire(lock);
+}
+
+static inline void psmx2_unlock_enabled(fastlock_t *lock, int lock_level)
+{
+	fastlock_release(lock);
+}
+
+static inline int psmx2_trylock_enabled(fastlock_t *lock, int lock_level)
+{
+	return fastlock_tryacquire(lock);
+}
+
 int	psmx2_init_prov_info(const struct fi_info *hints, struct fi_info **info);
 void	psmx2_update_prov_info(struct fi_info *info,
 			       struct psmx2_ep_name *src_addr,
@@ -947,7 +1004,7 @@ static inline int psmx2_av_check_table_idx(struct psmx2_fid_av *av,
 {
 	int err = 0;
 
-	psmx2_lock(&av->lock, 1);
+	av->domain->av_lock_fn(&av->lock, 1);
 
 	if (OFI_UNLIKELY(idx >= av->last)) {
 		FI_WARN(&psmx2_prov, FI_LOG_AV,
@@ -966,7 +1023,7 @@ static inline int psmx2_av_check_table_idx(struct psmx2_fid_av *av,
 	}
 
 out:
-	psmx2_unlock(&av->lock, 1);
+	av->domain->av_unlock_fn(&av->lock, 1);
 	return err;
 }
 
@@ -1000,9 +1057,9 @@ struct psmx2_am_request *psmx2_am_request_alloc(struct psmx2_trx_ctxt *trx_ctxt)
 {
 	struct psmx2_am_request *req;
 
-	psmx2_lock(&trx_ctxt->am_req_pool_lock, 2);
+	trx_ctxt->domain->am_req_pool_lock_fn(&trx_ctxt->am_req_pool_lock, 2);
 	req = util_buf_alloc(trx_ctxt->am_req_pool);
-	psmx2_unlock(&trx_ctxt->am_req_pool_lock, 2);
+	trx_ctxt->domain->am_req_pool_unlock_fn(&trx_ctxt->am_req_pool_lock, 2);
 
 	if (req)
 		memset(req, 0, sizeof(*req));
@@ -1013,9 +1070,9 @@ struct psmx2_am_request *psmx2_am_request_alloc(struct psmx2_trx_ctxt *trx_ctxt)
 static inline void psmx2_am_request_free(struct psmx2_trx_ctxt *trx_ctxt,
 					 struct psmx2_am_request *req)
 {
-	psmx2_lock(&trx_ctxt->am_req_pool_lock, 2);
+	trx_ctxt->domain->am_req_pool_lock_fn(&trx_ctxt->am_req_pool_lock, 2);
 	util_buf_release(trx_ctxt->am_req_pool, req);
-	psmx2_unlock(&trx_ctxt->am_req_pool_lock, 2);
+	trx_ctxt->domain->am_req_pool_unlock_fn(&trx_ctxt->am_req_pool_lock, 2);
 }
 
 struct	psmx2_fid_mr *psmx2_mr_get(struct psmx2_fid_domain *domain, uint64_t key);
@@ -1076,12 +1133,12 @@ static inline void psmx2_progress_all(struct psmx2_fid_domain *domain)
 	struct dlist_entry *item;
 	struct psmx2_trx_ctxt *trx_ctxt;
 
-	psmx2_lock(&domain->trx_ctxt_lock, 1);
+	domain->trx_ctxt_lock_fn(&domain->trx_ctxt_lock, 1);
 	dlist_foreach(&domain->trx_ctxt_list, item) {
 		trx_ctxt = container_of(item, struct psmx2_trx_ctxt, entry);
 		psmx2_progress(trx_ctxt);
 	}
-	psmx2_unlock(&domain->trx_ctxt_lock, 1);
+	domain->trx_ctxt_unlock_fn(&domain->trx_ctxt_lock, 1);
 }
 
 /*

--- a/prov/psm2/src/psmx2_am.c
+++ b/prov/psm2/src/psmx2_am.c
@@ -75,26 +75,26 @@ int psmx2_am_progress(struct psmx2_trx_ctxt *trx_ctxt)
 	struct psmx2_trigger *trigger;
 
 	if (psmx2_env.tagged_rma) {
-		psmx2_lock(&trx_ctxt->rma_queue.lock, 2);
+		trx_ctxt->domain->rma_queue_lock_fn(&trx_ctxt->rma_queue.lock, 2);
 		while (!slist_empty(&trx_ctxt->rma_queue.list)) {
 			item = slist_remove_head(&trx_ctxt->rma_queue.list);
 			req = container_of(item, struct psmx2_am_request, list_entry);
-			psmx2_unlock(&trx_ctxt->rma_queue.lock, 2);
+			trx_ctxt->domain->rma_queue_unlock_fn(&trx_ctxt->rma_queue.lock, 2);
 			psmx2_am_process_rma(trx_ctxt, req);
-			psmx2_lock(&trx_ctxt->rma_queue.lock, 2);
+			trx_ctxt->domain->rma_queue_lock_fn(&trx_ctxt->rma_queue.lock, 2);
 		}
-		psmx2_unlock(&trx_ctxt->rma_queue.lock, 2);
+		trx_ctxt->domain->rma_queue_unlock_fn(&trx_ctxt->rma_queue.lock, 2);
 	}
 
-	psmx2_lock(&trx_ctxt->trigger_queue.lock, 2);
+	trx_ctxt->domain->trigger_queue_lock_fn(&trx_ctxt->trigger_queue.lock, 2);
 	while (!slist_empty(&trx_ctxt->trigger_queue.list)) {
 		item = slist_remove_head(&trx_ctxt->trigger_queue.list);
 		trigger = container_of(item, struct psmx2_trigger, list_entry);
-		psmx2_unlock(&trx_ctxt->trigger_queue.lock, 2);
+		trx_ctxt->domain->trigger_queue_unlock_fn(&trx_ctxt->trigger_queue.lock, 2);
 		psmx2_process_trigger(trx_ctxt, trigger);
-		psmx2_lock(&trx_ctxt->trigger_queue.lock, 2);
+		trx_ctxt->domain->trigger_queue_lock_fn(&trx_ctxt->trigger_queue.lock, 2);
 	}
-	psmx2_unlock(&trx_ctxt->trigger_queue.lock, 2);
+	trx_ctxt->domain->trigger_queue_unlock_fn(&trx_ctxt->trigger_queue.lock, 2);
 
 	return 0;
 }

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -96,7 +96,7 @@ int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
 	switch (cmd) {
 	case PSMX2_AM_REQ_SEP_QUERY:
 		sep_id = args[0].u32w1;
-		psmx2_lock(&domain->sep_lock, 1);
+		domain->sep_lock_fn(&domain->sep_lock, 1);
 		entry = dlist_find_first_match(&domain->sep_list, psmx2_am_sep_match,
 					       (void *)(uintptr_t)sep_id);
 		if (!entry) {
@@ -118,7 +118,7 @@ int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
 					buf[i] = sep->ctxts[i].trx_ctxt->psm2_epid;
 			}
 		}
-		psmx2_unlock(&domain->sep_lock, 1);
+		domain->sep_unlock_fn(&domain->sep_lock, 1);
 
 		rep_args[0].u32w0 = PSMX2_AM_REP_SEP_QUERY;
 		rep_args[0].u32w1 = op_error;
@@ -210,9 +210,9 @@ static void psmx2_set_epaddr_context(struct psmx2_trx_ctxt *trx_ctxt,
 	context->epaddr = epaddr;
 	psm2_epaddr_setctxt(epaddr, context);
 
-	psmx2_lock(&trx_ctxt->peer_lock, 2);
+	trx_ctxt->domain->peer_lock_fn(&trx_ctxt->peer_lock, 2);
 	dlist_insert_before(&context->entry, &trx_ctxt->peer_list);
-	psmx2_unlock(&trx_ctxt->peer_lock, 2);
+	trx_ctxt->domain->peer_unlock_fn(&trx_ctxt->peer_lock, 2);
 }
 
 int psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,
@@ -514,7 +514,7 @@ int psmx2_av_add_trx_ctxt(struct psmx2_fid_av *av,
 	int id = trx_ctxt->id;
 	int err = 0;
 
-	psmx2_lock(&av->lock, 1);
+	av->domain->av_lock_fn(&av->lock, 1);
 
 	if (id >= av->max_trx_ctxt) {
 		FI_WARN(&psmx2_prov, FI_LOG_AV,
@@ -564,7 +564,7 @@ int psmx2_av_add_trx_ctxt(struct psmx2_fid_av *av,
 	}
 
 out:
-	psmx2_unlock(&av->lock, 1);
+	av->domain->av_unlock_fn(&av->lock, 1);
 	return err;
 }
 
@@ -586,7 +586,7 @@ STATIC int psmx2_av_insert(struct fid_av *av, const void *addr,
 
 	av_priv = container_of(av, struct psmx2_fid_av, av);
 
-	psmx2_lock(&av_priv->lock, 1);
+	av_priv->domain->av_lock_fn(&av_priv->lock, 1);
 
 	if ((av_priv->flags & FI_EVENT) && !av_priv->eq) {
 		ret = -FI_ENOEQ;
@@ -681,7 +681,7 @@ STATIC int psmx2_av_insert(struct fid_av *av, const void *addr,
 
 out:
 	free(errors);
-	psmx2_unlock(&av_priv->lock, 1);
+	av_priv->domain->av_unlock_fn(&av_priv->lock, 1);
 	return ret;
 }
 
@@ -709,7 +709,7 @@ STATIC int psmx2_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 
 	memset(&name, 0, sizeof(name));
 
-	psmx2_lock(&av_priv->lock, 1);
+	av_priv->domain->av_lock_fn(&av_priv->lock, 1);
 
 	if (PSMX2_SEP_ADDR_TEST(fi_addr)) {
 		idx = PSMX2_SEP_ADDR_IDX(fi_addr);
@@ -742,7 +742,7 @@ STATIC int psmx2_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	}
 
 out:
-	psmx2_unlock(&av_priv->lock, 1);
+	av_priv->domain->av_unlock_fn(&av_priv->lock, 1);
 	return err;
 }
 
@@ -756,7 +756,7 @@ psm2_epaddr_t psmx2_av_translate_sep(struct psmx2_fid_av *av,
 	psm2_error_t errors;
 	int err;
 
-	psmx2_lock(&av->lock, 1);
+	av->domain->av_lock_fn(&av->lock, 1);
 
 	if (av->peers[idx].type != PSMX2_EP_SCALABLE ||
 	    ctxt >= av->peers[idx].sep_ctxt_cnt)
@@ -785,7 +785,7 @@ psm2_epaddr_t psmx2_av_translate_sep(struct psmx2_fid_av *av,
 	epaddr = av->tables[trx_ctxt->id].sepaddrs[idx][ctxt];
 
 out:
-	psmx2_unlock(&av->lock, 1);
+	av->domain->av_unlock_fn(&av->lock, 1);
 	return epaddr;
 }
 
@@ -799,7 +799,7 @@ fi_addr_t psmx2_av_translate_source(struct psmx2_fid_av *av, fi_addr_t source)
 	epaddr = PSMX2_ADDR_TO_EP(source);
 	psm2_epaddr_to_epid(epaddr, &epid);
 
-	psmx2_lock(&av->lock, 1);
+	av->domain->av_lock_fn(&av->lock, 1);
 
 	for (i = av->last - 1; i >= 0 && !found; i--) {
 		if (av->peers[i].type == PSMX2_EP_REGULAR) {
@@ -820,7 +820,7 @@ fi_addr_t psmx2_av_translate_source(struct psmx2_fid_av *av, fi_addr_t source)
 		}
 	}
 
-	psmx2_unlock(&av->lock, 1);
+	av->domain->av_unlock_fn(&av->lock, 1);
 	return ret;
 }
 

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -42,7 +42,7 @@ void psmx2_cntr_check_trigger(struct psmx2_fid_cntr *cntr)
 	if (!cntr->trigger)
 		return;
 
-	psmx2_lock(&cntr->trigger_lock, 2);
+	cntr->domain->trigger_lock_fn(&cntr->trigger_lock, 2);
 
 	trigger = cntr->trigger;
 	while (trigger) {
@@ -65,10 +65,10 @@ void psmx2_cntr_check_trigger(struct psmx2_fid_cntr *cntr)
 		}
 
 		if (trx_ctxt->am_initialized) {
-			psmx2_lock(&trx_ctxt->trigger_queue.lock, 2);
+			cntr->domain->trigger_queue_lock_fn(&trx_ctxt->trigger_queue.lock, 2);
 			slist_insert_tail(&trigger->list_entry,
 					  &trx_ctxt->trigger_queue.list);
-			psmx2_unlock(&trx_ctxt->trigger_queue.lock, 2);
+			cntr->domain->trigger_queue_unlock_fn(&trx_ctxt->trigger_queue.lock, 2);
 		} else {
 			psmx2_process_trigger(trx_ctxt, trigger);
 		}
@@ -76,7 +76,7 @@ void psmx2_cntr_check_trigger(struct psmx2_fid_cntr *cntr)
 		trigger = cntr->trigger;
 	}
 
-	psmx2_unlock(&cntr->trigger_lock, 2);
+	cntr->domain->trigger_unlock_fn(&cntr->trigger_lock, 2);
 }
 
 void psmx2_cntr_add_trigger(struct psmx2_fid_cntr *cntr,
@@ -84,7 +84,7 @@ void psmx2_cntr_add_trigger(struct psmx2_fid_cntr *cntr,
 {
 	struct psmx2_trigger *p, *q;
 
-	psmx2_lock(&cntr->trigger_lock, 2);
+	cntr->domain->trigger_lock_fn(&cntr->trigger_lock, 2);
 
 	q = NULL;
 	p = cntr->trigger;
@@ -98,7 +98,7 @@ void psmx2_cntr_add_trigger(struct psmx2_fid_cntr *cntr,
 		cntr->trigger = trigger;
 	trigger->next = p;
 
-	psmx2_unlock(&cntr->trigger_lock, 2);
+	cntr->domain->trigger_unlock_fn(&cntr->trigger_lock, 2);
 
 	psmx2_cntr_check_trigger(cntr);
 }

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -828,9 +828,9 @@ static int psmx2_sep_close(fid_t fid)
 			psmx2_ep_close_internal(sep->ctxts[i].ep);
 	}
 
-	psmx2_lock(&sep->domain->sep_lock, 1);
+	sep->domain->sep_lock_fn(&sep->domain->sep_lock, 1);
 	dlist_remove(&sep->entry);
-	psmx2_unlock(&sep->domain->sep_lock, 1);
+	sep->domain->sep_unlock_fn(&sep->domain->sep_lock, 1);
 
 	psmx2_domain_release(sep->domain);
 	free(sep);
@@ -1044,9 +1044,9 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 
 	sep_priv->id = ofi_atomic_inc32(&domain_priv->sep_cnt);
 
-	psmx2_lock(&domain_priv->sep_lock, 1);
+	domain_priv->sep_lock_fn(&domain_priv->sep_lock, 1);
 	dlist_insert_before(&sep_priv->entry, &domain_priv->sep_list);
-	psmx2_unlock(&domain_priv->sep_lock, 1);
+	domain_priv->sep_unlock_fn(&domain_priv->sep_lock, 1);
 
 	ep_name.epid = sep_priv->ctxts[0].trx_ctxt->psm2_epid;
 	ep_name.sep_id = sep_priv->id;

--- a/prov/psm2/src/psmx2_mr.c
+++ b/prov/psm2/src/psmx2_mr.c
@@ -38,14 +38,14 @@ struct psmx2_fid_mr *psmx2_mr_get(struct psmx2_fid_domain *domain,
 	RbtIterator it;
 	struct psmx2_fid_mr *mr = NULL;
 
-	psmx2_lock(&domain->mr_lock, 1);
+	domain->mr_lock_fn(&domain->mr_lock, 1);
 	it = rbtFind(domain->mr_map, (void *)key);
 	if (!it)
 		goto exit;
 
 	rbtKeyValue(domain->mr_map, it, (void **)&key, (void **)&mr);
 exit:
-	psmx2_unlock(&domain->mr_lock, 1);
+	domain->mr_unlock_fn(&domain->mr_lock, 1);
 	return mr;
 }
 
@@ -54,11 +54,11 @@ static inline void psmx2_mr_release_key(struct psmx2_fid_domain *domain,
 {
 	RbtIterator it;
 
-	psmx2_lock(&domain->mr_lock, 1);
+	domain->mr_lock_fn(&domain->mr_lock, 1);
 	it = rbtFind(domain->mr_map, (void *)key);
 	if (it)
 		rbtErase(domain->mr_map, it);
-	psmx2_unlock(&domain->mr_lock, 1);
+	domain->mr_unlock_fn(&domain->mr_lock, 1);
 }
 
 static int psmx2_mr_reserve_key(struct psmx2_fid_domain *domain,
@@ -71,7 +71,7 @@ static int psmx2_mr_reserve_key(struct psmx2_fid_domain *domain,
 	int try_count;
 	int err = -FI_ENOKEY;
 
-	psmx2_lock(&domain->mr_lock, 1);
+	domain->mr_lock_fn(&domain->mr_lock, 1);
 
 	if (domain->mr_mode == FI_MR_BASIC) {
 		key = domain->mr_reserved_key;
@@ -93,7 +93,7 @@ static int psmx2_mr_reserve_key(struct psmx2_fid_domain *domain,
 		}
 	}
 
-	psmx2_unlock(&domain->mr_lock, 1);
+	domain->mr_unlock_fn(&domain->mr_lock, 1);
 
 	return err;
 }

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -36,9 +36,9 @@
 static inline void psmx2_am_enqueue_rma(struct psmx2_trx_ctxt *trx_ctxt,
 					struct psmx2_am_request *req)
 {
-	psmx2_lock(&trx_ctxt->rma_queue.lock, 2);
+	trx_ctxt->domain->rma_queue_lock_fn(&trx_ctxt->rma_queue.lock, 2);
 	slist_insert_tail(&req->list_entry, &trx_ctxt->rma_queue.list);
-	psmx2_unlock(&trx_ctxt->rma_queue.lock, 2);
+	trx_ctxt->domain->rma_queue_unlock_fn(&trx_ctxt->rma_queue.lock, 2);
 }
 
 static inline void psmx2_iov_copy(struct iovec *iov, size_t count,

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -96,10 +96,10 @@ int psmx2_am_trx_ctxt_handler(psm2_am_token_t token, psm2_amarg_t *args,
 		 */
 		disconn = malloc(sizeof(*disconn));
 		if (disconn) {
-			psmx2_lock(&trx_ctxt->peer_lock, 2);
+			trx_ctxt->domain->peer_lock_fn(&trx_ctxt->peer_lock, 2);
 			dlist_remove_first_match(&trx_ctxt->peer_list,
 						 psmx2_peer_match, epaddr);
-			psmx2_unlock(&trx_ctxt->peer_lock, 2);
+			trx_ctxt->domain->peer_unlock_fn(&trx_ctxt->peer_lock, 2);
 			if (trx_ctxt->ep && trx_ctxt->ep->av)
 				psmx2_av_remove_conn(trx_ctxt->ep->av, trx_ctxt, epaddr);
 			disconn->ep = trx_ctxt->psm2_ep;
@@ -129,12 +129,12 @@ void psmx2_trx_ctxt_disconnect_peers(struct psmx2_trx_ctxt *trx_ctxt)
 
 	/* use local peer_list to avoid entering AM handler while holding the lock */
 	dlist_init(&peer_list);
-	psmx2_lock(&trx_ctxt->peer_lock, 2);
+	trx_ctxt->domain->peer_lock_fn(&trx_ctxt->peer_lock, 2);
 	dlist_foreach_safe(&trx_ctxt->peer_list, item, tmp) {
 		dlist_remove(item);
 		dlist_insert_before(item, &peer_list);
 	}
-	psmx2_unlock(&trx_ctxt->peer_lock, 2);
+	trx_ctxt->domain->peer_unlock_fn(&trx_ctxt->peer_lock, 2);
 
 	dlist_foreach_safe(&peer_list, item, tmp) {
 		peer = container_of(item, struct psmx2_epaddr_context, entry);
@@ -176,9 +176,9 @@ void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt, int usage_flags)
 	FI_INFO(&psmx2_prov, FI_LOG_CORE, "epid: %016lx (%s)\n",
 		trx_ctxt->psm2_epid, psmx2_usage_flags_to_string(old_flags));
 
-	psmx2_lock(&trx_ctxt->domain->trx_ctxt_lock, 1);
+	trx_ctxt->domain->trx_ctxt_lock_fn(&trx_ctxt->domain->trx_ctxt_lock, 1);
 	dlist_remove(&trx_ctxt->entry);
-	psmx2_unlock(&trx_ctxt->domain->trx_ctxt_lock, 1);
+	trx_ctxt->domain->trx_ctxt_unlock_fn(&trx_ctxt->domain->trx_ctxt_lock, 1);
 
 	if (psmx2_env.disconnect)
 		psmx2_trx_ctxt_disconnect_peers(trx_ctxt);
@@ -231,12 +231,12 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 
 	/* Check existing allocations first if only Tx or Rx is needed */
 	if (compatible_flags) {
-		psmx2_lock(&domain->trx_ctxt_lock, 1);
+		domain->trx_ctxt_lock_fn(&domain->trx_ctxt_lock, 1);
 		dlist_foreach(&domain->trx_ctxt_list, item) {
 			trx_ctxt = container_of(item, struct psmx2_trx_ctxt, entry);
 			if (compatible_flags == trx_ctxt->usage_flags) {
 				trx_ctxt->usage_flags |= asked_flags;
-				psmx2_unlock(&domain->trx_ctxt_lock, 1);
+				domain->trx_ctxt_unlock_fn(&domain->trx_ctxt_lock, 1);
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
 					"use existing context. epid: %016lx "
 					"(%s -> tx+rx).\n", trx_ctxt->psm2_epid,
@@ -244,7 +244,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 				return trx_ctxt;
 			}
 		}
-		psmx2_unlock(&domain->trx_ctxt_lock, 1);
+		domain->trx_ctxt_unlock_fn(&domain->trx_ctxt_lock, 1);
 	}
 
 	if (psmx2_trx_ctxt_cnt >= psmx2_env.max_trx_ctxt) {
@@ -335,9 +335,9 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	trx_ctxt->domain = domain;
 	trx_ctxt->usage_flags = asked_flags;
 
-	psmx2_lock(&domain->trx_ctxt_lock, 1);
+	domain->trx_ctxt_lock_fn(&domain->trx_ctxt_lock, 1);
 	dlist_insert_before(&trx_ctxt->entry, &domain->trx_ctxt_list);
-	psmx2_unlock(&domain->trx_ctxt_lock, 1);
+	domain->trx_ctxt_unlock_fn(&domain->trx_ctxt_lock, 1);
 
 	return trx_ctxt;
 


### PR DESCRIPTION
- Add Specialized functions for lock/unlock/trylock
  given locks are enabled or disabled.

- Add function pointers to psmx2_fid_domain to set
  lock/unlock functions for each individual lock
  that is related to a specific domain.

- By default, all locks are enabled with all the
  lock/unlock function pointers per domain set
  to the lock enabled functions.

- Given a user requests FI_THREAD_DOMAIN OFI psm2
  disables the locks for all uses of domain related objects
  by setting the corresponding lock function pointers to the
  lock disabled functions.

- If FI_RMA or FI_ATOMIC is set in the capabilities, then
  cq_lock, rma_queue_lock, & am_req_pool_lock must always
  be taken even with FI_THREAD_DOMAIN.

- The use of FI_PSM2_LOCK_LEVEL overrides this behavior
  set in the domain_attr and uses the default original levels
  compared to the user passed in lock_level.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>