### PR TITLE
util_buf.c: add support for huge pages on Linux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017-2018 Intel Corporation, Inc. All right reserved.
+# Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
 #
 # Makefile.am for libfabric
 
@@ -81,6 +82,7 @@ endif
 
 if LINUX
 common_srcs += src/unix/osd.c
+common_srcs += src/linux/osd.c
 if HAVE_LINUX_PERF_RDPMC
 common_srcs += src/linux/rdpmc.c
 endif

--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Intel Corp, Inc. All rights reserved.
+ * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,6 +50,21 @@ typedef cpuset_t cpu_set_t;
 static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
 {
 	return -1;
+}
+
+static inline ssize_t ofi_get_hugepage_size(void)
+{
+	return -FI_ENOSYS;
+}
+
+static inline int ofi_alloc_hugepage_buf(void **memptr, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+static inline int ofi_free_hugepage_buf(void *memptr, size_t size)
+{
+	return -FI_ENOSYS;
 }
 
 #endif /* _FREEBSD_OSD_H_ */

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -272,6 +273,7 @@ struct util_buf_attr {
 	util_buf_region_init_func 	init;
 	void 				*ctx;
 	uint8_t				track_used;
+	uint8_t				is_mmap_region;
 };
 
 struct util_buf_pool {
@@ -285,6 +287,7 @@ struct util_buf_pool {
 struct util_buf_region {
 	struct slist_entry entry;
 	char *mem_region;
+	size_t size;
 	void *context;
 #if ENABLE_DEBUG
 	size_t num_used;

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
+ * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -65,6 +66,21 @@ extern "C" {
 static inline int ofi_shm_remap(struct util_shm *shm, size_t newsize, void **mapped)
 {
 	return -1;
+}
+
+static inline ssize_t ofi_get_hugepage_size(void)
+{
+	return -FI_ENOSYS;
+}
+
+static inline int ofi_alloc_hugepage_buf(void **memptr, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+static inline int ofi_free_hugepage_buf(void *memptr, size_t size)
+{
+	return -FI_ENOSYS;
 }
 
 #ifdef __cplusplus

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2016 Intel Corporation.  All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
@@ -836,6 +837,21 @@ static inline int ofi_sysconf(int name)
 }
 
 int ofi_shm_unmap(struct util_shm *shm);
+
+static inline ssize_t ofi_get_hugepage_size(void)
+{
+	return -FI_ENOSYS;
+}
+
+static inline int ofi_alloc_hugepage_buf(void **memptr, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+static inline int ofi_free_hugepage_buf(void *memptr, size_t size)
+{
+	return -FI_ENOSYS;
+}
 
 static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 	return (addr->sa_family == AF_INET &&


### PR DESCRIPTION
Use mmap() on Linux to allocate buf pool memory regions in huge pages
when the initial buf pool allocation is greater than or equal to the
system default huge page size. Fallback on ofi_memalign() if determining
the huge page size or the mmap fails for any reason.  Add stubs for
other platforms to add huge page support for those in the future if
needed.

Fixes #4421

Signed-off-by: Robert Wespetal <wesper@amazon.com>