### PR TITLE
Fixes and updates for cron/infrastructure scripts

### DIFF
--- a/config/cron-make-nightly-tarball.pl
+++ b/config/cron-make-nightly-tarball.pl
@@ -35,7 +35,6 @@ use File::Basename;
 use Getopt::Long;
 
 my $libfabric_dir_arg;
-my $fabtests_dir_arg;
 my $download_dir_arg;
 my $libfabric_coverity_token_arg;
 my $fabtests_coverity_token_arg;
@@ -45,7 +44,6 @@ my $verbose_arg;
 my $debug_arg;
 
 my $ok = Getopt::Long::GetOptions("libfabric-source-dir=s" => \$libfabric_dir_arg,
-                                  "fabtests-source-dir=s" => \$fabtests_dir_arg,
                                   "download-dir=s" => \$download_dir_arg,
                                   "libfabric-coverity-token=s" => \$libfabric_coverity_token_arg,
                                   "fabtests-coverity-token=s" => \$fabtests_coverity_token_arg,
@@ -56,14 +54,13 @@ my $ok = Getopt::Long::GetOptions("libfabric-source-dir=s" => \$libfabric_dir_ar
                                   );
 
 if ($help_arg || !$ok) {
-    print "$0 --libfabric-source-dir libfabric_git_tree --fabtests-source-dir fabtests_git_tree --download-dir download_tree\n";
+    print "$0 --libfabric-source-dir libfabric_git_tree --download-dir download_tree\n";
     exit($ok);
 }
 
 # Sanity checks
-die "Must specify --libfabric-source-dir, --fabtests-source-dir, --download-dir, and --logfile-dir"
+die "Must specify --libfabric-source-dir, --download-dir, and --logfile-dir"
     if (!defined($libfabric_dir_arg) || $libfabric_dir_arg eq "" ||
-        !defined($fabtests_dir_arg) || $fabtests_dir_arg eq "" ||
         !defined($download_dir_arg) || $download_dir_arg eq "" ||
         !defined($logfile_dir_arg) || $logfile_dir_arg eq "");
 die "$libfabric_dir_arg is not a valid directory"
@@ -140,7 +137,6 @@ sub get_git_version {
 
 sub make_tarball {
     my $base_name = shift;
-    my $source_dir = shift;
     my $version = shift;
     my $installdir = shift;
 
@@ -251,14 +247,13 @@ verbose("*** Building libfabric...\n");
 chdir($libfabric_dir_arg);
 git_cleanup();
 my $libfabric_version = get_git_version();
-my $rebuilt_libfabric = make_tarball("libfabric", $libfabric_dir_arg,
-    $libfabric_version, $installdir);
+my $rebuilt_libfabric = make_tarball("libfabric",
+				     $libfabric_version, $installdir);
 
 verbose("\n\n*** Building fabtests...\n");
-chdir($fabtests_dir_arg);
-git_cleanup();
+chdir('fabtests');
 my $fabtests_version = get_git_version();
-my $rebuilt_fabtests = make_tarball("fabtests", $fabtests_dir_arg,
+my $rebuilt_fabtests = make_tarball("fabtests",
                                     $fabtests_version, $installdir);
 
 if ($rebuilt_libfabric || $rebuilt_fabtests) {

--- a/config/cron-run-all-md2nroff.pl
+++ b/config/cron-run-all-md2nroff.pl
@@ -271,7 +271,7 @@ if ($old_head ne $new_head) {
     close(GIT);
 
     # Create a new pull request
-    my $cmd_base = "curl ";
+    my $cmd_base = "curl --silent ";
     $cmd_base .= "-H 'Content-Type: application/json' ";
     $cmd_base .= "-H 'Authorization: token $pat' ";
     $cmd_base .= "-H 'User-Agent: OFIWG-bot' ";

--- a/config/cron-run-all-md2nroff.pl
+++ b/config/cron-run-all-md2nroff.pl
@@ -148,21 +148,38 @@ if (defined($pages_branch_arg)) {
 }
 
 #####################################################################
+# Look for all markdown man pages
+#####################################################################
 
-# Find all the *.\d.md files in the source repo
-verbose("*** Finding markdown man pages...\n");
+# Find all libfabric *.\d.md files
+verbose("*** Finding libfabric markdown man pages...\n");
 opendir(DIR, "source/man");
-my @markdown_files = grep { /\.\d\.md$/ && -f "source/man/$_" } readdir(DIR);
+my @libfabric_markdown_files =
+    map { "source/man/" . $_ }
+    grep { /\.\d\.md$/ && -f "source/man/$_" } readdir(DIR);
 closedir(DIR);
-verbose("Found: @markdown_files\n");
+verbose("Found: @libfabric_markdown_files\n");
 
+# Find all fabtests *.\d.md files
+verbose("*** Finding fabtests markdown man pages...\n");
+opendir(DIR, "source/fabtests/man");
+my @fabtests_markdown_files =
+    map { "source/fabtests/man/" . $_ }
+    grep { /\.\d\.md$/ && -f "source/fabtests/man/$_" } readdir(DIR);
+closedir(DIR);
+verbose("Found: @fabtests_markdown_files\n");
+
+#####################################################################
+# Publish any changes to man pages to the gh-pages branch
+# (only libfabric -- not fabtests)
 #####################################################################
 
 # Copy each of the markdown files to the pages branch checkout
 if (defined($pages_branch_arg)) {
     chdir("pages/master");
-    foreach my $file (@markdown_files) {
-        doit(0, "cp ../../source/man/$file man/$file", "loop-cp");
+    foreach my $file (@libfabric_markdown_files) {
+        my $base = basename($file);
+        doit(0, "cp $tmpdir/$file man/$base", "loop-cp");
 
         # Is there a new man page?  If so, we need to "git add" it.
         my $out = `git status --porcelain man/$file`;
@@ -190,11 +207,12 @@ if (defined($pages_branch_arg)) {
     push(@headings, { section=>3, title=>"API documentation" });
     foreach my $h (@headings) {
         print OUT "\n* $h->{title}\n";
-        foreach my $file (sort(@markdown_files)) {
-            if ($file =~ /\.$h->{section}\.md$/) {
-                $file =~ m/^(.+)\.$h->{section}\.md$/;
-                my $base = $1;
-                print OUT "  * [$base($h->{section})]($base.$h->{section}.html)\n";
+        foreach my $file (sort(@libfabric_markdown_files)) {
+            my $base = basename($file);
+            if ($base =~ /\.$h->{section}\.md$/) {
+                $base =~ m/^(.+)\.$h->{section}\.md$/;
+                my $shortname = $1;
+                print OUT "  * [$shortname($h->{section})]($shortname.$h->{section}.html)\n";
             }
         }
     }
@@ -210,12 +228,17 @@ if (defined($pages_branch_arg)) {
 }
 
 #####################################################################
+# Look for changes to .md files and generate nroff files on master
+#####################################################################
+
+my @markdown_files = (@libfabric_markdown_files,
+                      @fabtests_markdown_files);
 
 # Now process each of the Markdown files in the source repo and
 # generate new nroff man pages.
-chdir("$tmpdir/source/man");
+chdir("$tmpdir");
 foreach my $file (@markdown_files) {
-    doit(0, "../config/md2nroff.pl --source $file", "loop2-md2nroff");
+    doit(0, "$tmpdir/source/config/md2nroff.pl --source $file", "loop2-md2nroff");
 
     # Did we generate a new man page?  If so, we need to "git add" it.
     my $man_file = basename($file);
@@ -232,6 +255,8 @@ foreach my $file (@markdown_files) {
         if ($out =~ /^\?\?/);
 }
 
+#####################################################################
+
 # Similar to above: commit the newly-generated nroff pages and push
 # them back upstream.  If nothing changed, these will be no-ops.  Note
 # that there are mandatory CI checks on master, which means we can't
@@ -241,6 +266,7 @@ foreach my $file (@markdown_files) {
 
 # Try to delete the old pr branch first (it's ok to fail -- i.e., if
 # it wasn't there).
+chdir("$tmpdir/source");
 my $pr_branch_name = "pr/update-nroff-generated-man-pages";
 doit(1, "git branch -D $pr_branch_name");
 doit(0, "git checkout -b $pr_branch_name");


### PR DESCRIPTION
Note that Coverity builds are still broken on the new OFI server (flatbed2) for a reason that I don't quite understand yet.  This PR fixes a bunch of stuff and sets us up on flatbed with the notable exception of Coverity builds.