### PR TITLE
hook: allow multiple hooks to be enabled

### DIFF
--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <string.h>
 #include <ofi.h>
 #include "hook.h"
 #include "hook_perf.h"
@@ -259,11 +260,11 @@ void ofi_hook_init(void)
 	if (!param_val)
 		return;
 
-	if (!strcasecmp(param_val, "noop")) {
+	if (strcasestr(param_val, "noop")) {
 		FI_INFO(&core_prov, FI_LOG_CORE, "Noop hook requested\n");
 		hooks_enabled |= (1 << HOOK_NOOP);
 	}
-	if (!strcasecmp(param_val, "perf")) {
+	if (strcasestr(param_val, "perf")) {
 		FI_INFO(&core_prov, FI_LOG_CORE, "Perf hook requested\n");
 		hooks_enabled |= (1 << HOOK_PERF);
 	}


### PR DESCRIPTION
Allow multiple hooks to be enabled at the same time when
specified in the FI_HOOK variable (e.g. FI_HOOK=perf:noop)

Signed-off-by: Ignacio Hernandez <ignacio.hernandez@intel.com>