### PR TITLE
prov/tcp: bugfix - clear msg header flags before using

### DIFF
--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -185,6 +185,7 @@ static ssize_t tcpx_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	data_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count);
 	assert(!(flags & FI_INJECT) || (data_len <= TCPX_MAX_INJECT_SZ));
 	tx_entry->msg_hdr.hdr.size = htonll(data_len + sizeof(tx_entry->msg_hdr));
+	tx_entry->msg_hdr.hdr.flags = 0;
 
 	tx_entry->msg_data.iov[0].iov_base = (void *) &tx_entry->msg_hdr;
 	tx_entry->msg_data.iov[0].iov_len = sizeof(tx_entry->msg_hdr);

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -189,6 +189,7 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 	send_entry->msg_hdr.hdr.op = ofi_op_write;
 	send_entry->msg_hdr.hdr.op_data = TCPX_OP_WRITE;
 	send_entry->msg_hdr.hdr.size = htonll(data_len + sizeof(send_entry->msg_hdr));
+	send_entry->msg_hdr.hdr.flags = 0;
 
 	memcpy(send_entry->msg_hdr.rma_iov, msg->rma_iov,
 	       msg->rma_iov_count * sizeof(msg->rma_iov[0]));


### PR DESCRIPTION
Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>