### PR TITLE
hook: allow multiple hooks to be enabled

### DIFF
--- a/prov/hook/src/hook.h
+++ b/prov/hook/src/hook.h
@@ -52,6 +52,7 @@
 enum hook_class {
 	HOOK_NOOP,
 	HOOK_PERF,
+	MAX_HOOKS
 };
 
 /*


### PR DESCRIPTION
Allow multiple hooks to be enabled at the same time when
specified in the FI_HOOK variable (e.g. FI_HOOK=perf:noop)

Signed-off-by: Ignacio Hernandez <ignacio.hernandez@intel.com>