### PR TITLE
prov/rxd: redefine and reorganize packet headers

### DIFF
--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -59,8 +59,8 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 	ofi_ioc_to_iov(ioc, iov, count, ofi_datatype_size(datatype));
 
 	assert(ofi_total_iov_len(iov, count) <= (op == RXD_ATOMIC_COMPARE) ?
-	       rxd_ep_domain(rxd_ep)->max_inline_sz / 2 :
-	       rxd_ep_domain(rxd_ep)->max_inline_sz);
+	       rxd_ep_domain(rxd_ep)->max_inline_atom / 2 :
+	       rxd_ep_domain(rxd_ep)->max_inline_atom);
 
 	ofi_ioc_to_iov(result_ioc, res_iov, result_count, ofi_datatype_size(datatype));
 	ofi_ioc_to_iov(compare_ioc, comp_iov, compare_count, ofi_datatype_size(datatype));
@@ -164,7 +164,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	iov.iov_base = (void *) buf;
 	iov.iov_len = count * ofi_datatype_size(datatype);
-	assert(iov.iov_len <= rxd_ep_domain(rxd_ep)->max_inline_sz);
+	assert(iov.iov_len <= rxd_ep_domain(rxd_ep)->max_inline_atom);
 
 	rma_iov.addr = addr;
 	rma_iov.len = count * ofi_datatype_size(datatype);
@@ -358,8 +358,8 @@ int rxd_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 				  util_domain.domain_fid);
 	attr->size = ofi_datatype_size(datatype);
 
-	total_size = (flags & FI_COMPARE_ATOMIC) ?  rxd_domain->max_inline_sz / 2 :
-		      rxd_domain->max_inline_sz;
+	total_size = (flags & FI_COMPARE_ATOMIC) ?  rxd_domain->max_inline_atom / 2 :
+		      rxd_domain->max_inline_atom;
 	attr->count = total_size / attr->size;
 
 	return ret;

--- a/prov/rxd/src/rxd_attr.c
+++ b/prov/rxd/src/rxd_attr.c
@@ -39,7 +39,7 @@
 struct fi_tx_attr rxd_tx_attr = {
 	.caps = RXD_EP_CAPS,
 	.comp_order = FI_ORDER_STRICT,
-	.inject_size = RXD_MAX_MTU_SIZE - sizeof(struct rxd_op_pkt),
+	.inject_size = RXD_MAX_MTU_SIZE - sizeof(struct rxd_atom_pkt),
 	.size = (1ULL << RXD_MAX_TX_BITS),
 	.iov_limit = RXD_IOV_LIMIT,
 	.rma_iov_limit = 0,
@@ -68,7 +68,7 @@ struct fi_domain_attr rxd_domain_attr = {
 	.data_progress = FI_PROGRESS_MANUAL,
 	.resource_mgmt = FI_RM_ENABLED,
 	.av_type = FI_AV_UNSPEC,
-	.cq_data_size = sizeof_field(struct rxd_op_pkt, cq_data),
+	.cq_data_size = sizeof_field(struct rxd_op_hdr, cq_data),
 	.mr_key_size = sizeof(uint64_t),
 	.cq_cnt = 128,
 	.ep_cnt = 128,

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -237,7 +237,6 @@ static void rxd_complete_rx(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 	}
 
 out:
-	ep->peers[rx_entry->peer].rx_msg_id = rx_entry->msg_id;
 	rxd_rx_entry_free(ep, rx_entry);
 }
 
@@ -256,38 +255,18 @@ out:
 	rxd_tx_entry_free(ep, tx_entry);
 }
 
-static int rxd_comp_pkt_msg_id(struct dlist_entry *item, const void *arg)
+static int rxd_comp_pkt_seq_no(struct dlist_entry *item, const void *arg)
 {
-	struct rxd_op_pkt *list_op = (struct rxd_op_pkt *)
-				     ((container_of(item,
-				     struct rxd_pkt_entry, d_entry))->pkt);
-	struct rxd_op_pkt *new_op = (struct rxd_op_pkt *)
-				    ((container_of((struct dlist_entry *) arg,
-				    struct rxd_pkt_entry, d_entry))->pkt);
+	struct rxd_base_hdr *list_hdr;
+	struct rxd_base_hdr *new_hdr;
 
-	return new_op->pkt_hdr.msg_id > list_op->pkt_hdr.msg_id;
-}
+	list_hdr = rxd_get_base_hdr(container_of(item,
+				   struct rxd_pkt_entry, d_entry));
 
-static int rxd_comp_rx_msg_id(struct dlist_entry *item, const void *arg)
-{
-	struct rxd_x_entry *list_rx = container_of(item, struct rxd_x_entry, entry);
-	struct rxd_x_entry *new_rx = container_of((struct dlist_entry *) arg,
-						  struct rxd_x_entry, entry);
+	new_hdr = rxd_get_base_hdr(container_of((struct dlist_entry *) arg,
+				  struct rxd_pkt_entry, d_entry));
 
-	return new_rx->msg_id > list_rx->msg_id;
-}
-
-static void rxd_progress_buf_cq(struct rxd_ep *ep, fi_addr_t peer)
-{
-	struct rxd_x_entry *rx_entry;
-
-	dlist_foreach_container(&ep->peers[peer].buf_cq, struct rxd_x_entry,
-				rx_entry, entry) {
-		if (rx_entry->msg_id != ep->peers[peer].rx_msg_id + 1)
-			return;
-
-		rxd_complete_rx(ep, rx_entry);
-	}
+	return new_hdr->seq_no > list_hdr->seq_no;
 }
 
 static void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
@@ -298,7 +277,12 @@ static void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
 	struct iovec *iov;
 	size_t iov_count;
 
-	offset = pkt->base_hdr.type == RXD_DATA_READ ? 0 : rxd_domain->max_inline_sz;
+	if (pkt->base_hdr.type == RXD_DATA_READ)
+		offset = 0;
+	else if (x_entry->op == RXD_WRITE)
+		offset = rxd_domain->max_inline_rma;
+	else
+		offset = rxd_domain->max_inline_msg;
 
 	if (x_entry->cq_entry.flags & FI_ATOMIC) {
 		iov = x_entry->res_iov;
@@ -309,28 +293,21 @@ static void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
 	}
 
 	done = ofi_copy_to_iov(iov, iov_count, offset +
-			       (pkt->pkt_hdr.seg_no * rxd_domain->max_seg_sz),
+			       (pkt->ext_hdr.seg_no * rxd_domain->max_seg_sz),
 			       pkt->msg, size - sizeof(struct rxd_data_pkt) -
 			       ep->prefix_size);
 
 	x_entry->bytes_done += done;
-	ep->peers[pkt->pkt_hdr.peer].rx_seq_no++;
+	ep->peers[pkt->base_hdr.peer].rx_seq_no++;
 	x_entry->next_seg_no++;
 
 	if (x_entry->next_seg_no < x_entry->num_segs) {
-		if (!(ep->peers[pkt->pkt_hdr.peer].rx_seq_no %
-		    ep->peers[pkt->pkt_hdr.peer].rx_window))
-			rxd_ep_send_ack(ep, pkt->pkt_hdr.peer);
+		if (!(ep->peers[pkt->base_hdr.peer].rx_seq_no %
+		    ep->peers[pkt->base_hdr.peer].rx_window))
+			rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 		return;
 	}
-	rxd_ep_send_ack(ep, pkt->pkt_hdr.peer);
-
-	if (!rxd_env.retry && x_entry->msg_id !=
-	    ep->peers[pkt->pkt_hdr.peer].rx_msg_id + 1) {
-		dlist_insert_order(&ep->peers[pkt->pkt_hdr.peer].buf_cq,
-				   &rxd_comp_rx_msg_id, &x_entry->entry);
-		return;
-	}
+	rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 
 	if (x_entry->cq_entry.flags & FI_READ) {
 		fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
@@ -342,24 +319,7 @@ static void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
 		fastlock_release(&ep->util_ep.rx_cq->cq_lock);
 	}
 
-	//TODO add tx_cq buf?
-	if (!rxd_env.retry)
-		rxd_progress_buf_cq(ep, pkt->pkt_hdr.peer);
-
-	rxd_ep_send_ack(ep, pkt->pkt_hdr.peer);
-}
-
-static int rxd_matching_ids(struct rxd_x_entry *rx_entry,
-			    struct rxd_pkt_entry *pkt_entry)
-{
-	struct rxd_pkt_hdr *pkt_hdr = rxd_get_pkt_hdr(pkt_entry);
-
-	if (rxd_pkt_type(pkt_entry) == RXD_DATA_READ)
-		return (rx_entry->tx_id == pkt_hdr->rx_id) &&
-		       (rx_entry->msg_id == pkt_hdr->msg_id);
-	return (rx_entry->tx_id == pkt_hdr->tx_id) &&
-	       (rx_entry->rx_id == pkt_hdr->rx_id) &&
-	       (rx_entry->msg_id == pkt_hdr->msg_id);
+	rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 }
 
 static int rxd_verify_active(struct rxd_ep *ep, fi_addr_t addr, fi_addr_t peer_addr)
@@ -380,13 +340,13 @@ static int rxd_verify_active(struct rxd_ep *ep, fi_addr_t addr, fi_addr_t peer_a
 
 static int rxd_move_tx_op(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 {
-	struct rxd_pkt_hdr *hdr = rxd_get_pkt_hdr(tx_entry->op_pkt);
+	struct rxd_base_hdr *hdr = rxd_get_base_hdr(tx_entry->op_pkt);
 
 	if (ep->peers[tx_entry->peer].unacked_cnt >= rxd_env.max_unacked)
 		return 0;
 
-	hdr->seq_no = ep->peers[tx_entry->peer].tx_seq_no++;
-	tx_entry->start_seq = hdr->seq_no;
+	tx_entry->start_seq = rxd_set_pkt_seq(&ep->peers[tx_entry->peer],
+					      tx_entry->op_pkt);
 	if (tx_entry->op != RXD_READ_REQ && tx_entry->num_segs > 1) {
 		ep->peers[tx_entry->peer].tx_seq_no = tx_entry->start_seq +
 						      tx_entry->num_segs;
@@ -488,66 +448,59 @@ static int rxd_send_cts(struct rxd_ep *rxd_ep, struct rxd_rts_pkt *rts_pkt,
 
 static int rxd_match_msg(struct dlist_entry *item, const void *arg)
 {
-	struct rxd_op_pkt *pkt = (struct rxd_op_pkt *) arg;
+	struct rxd_base_hdr *hdr = rxd_get_base_hdr((struct rxd_pkt_entry *) arg);
 	struct rxd_x_entry *rx_entry;
 
 	rx_entry = container_of(item, struct rxd_x_entry, entry);
 
-	return rxd_match_addr(rx_entry->peer, pkt->pkt_hdr.peer);
+	return rxd_match_addr(rx_entry->peer, hdr->peer);
 }
 
 static int rxd_match_tmsg(struct dlist_entry *item, const void *arg)
 {
-	struct rxd_op_pkt *pkt = (struct rxd_op_pkt *) arg;
+	struct rxd_msg_pkt *pkt = (struct rxd_msg_pkt *)
+				  (((struct rxd_pkt_entry *) arg)->pkt);
 	struct rxd_x_entry *rx_entry;
 
 	rx_entry = container_of(item, struct rxd_x_entry, entry);
 
-	return rxd_match_addr(rx_entry->peer, pkt->pkt_hdr.peer) &&
-	       rxd_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore, pkt->tag);
+	return rxd_match_addr(rx_entry->peer, pkt->base_hdr.peer) &&
+	       rxd_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore,
+			     pkt->tag);
 }
 
-static void rxd_handle_data(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
-			    struct rxd_pkt_entry *pkt_entry)
+static void rxd_handle_data(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	struct rxd_data_pkt *pkt = (struct rxd_data_pkt *) (pkt_entry->pkt);
 	struct rxd_x_entry *x_entry;
 
 	x_entry = pkt->base_hdr.type == RXD_DATA_READ ?
-		  &ep->tx_fs->entry[pkt->pkt_hdr.rx_id].buf :
-		  &ep->rx_fs->entry[pkt->pkt_hdr.rx_id].buf;
+		  &ep->tx_fs->entry[pkt->ext_hdr.rx_id].buf :
+		  &ep->rx_fs->entry[pkt->ext_hdr.rx_id].buf;
 
-	if (!rxd_matching_ids(x_entry, pkt_entry) ||
-	    x_entry->op == RXD_NO_OP) {
-	    	if (pkt->pkt_hdr.flags & RXD_LAST)
-			rxd_ep_send_ack(ep, pkt->pkt_hdr.peer);
-		return;
-	}
-
-	if (pkt->pkt_hdr.seq_no == ep->peers[pkt->pkt_hdr.peer].rx_seq_no ||
+	if (pkt->base_hdr.seq_no == ep->peers[pkt->base_hdr.peer].rx_seq_no ||
 	    !rxd_env.retry)
-		rxd_ep_recv_data(ep, x_entry, pkt, comp->len);
-	else if (ep->peers[pkt->pkt_hdr.peer].last_tx_ack !=
-		 ep->peers[pkt->pkt_hdr.peer].rx_seq_no) {
-		rxd_ep_send_ack(ep, pkt->pkt_hdr.peer);
+		rxd_ep_recv_data(ep, x_entry, pkt, pkt_entry->pkt_size);
+	else if (ep->peers[pkt->base_hdr.peer].last_tx_ack !=
+		 ep->peers[pkt->base_hdr.peer].rx_seq_no) {
+		rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 	}
 }
 
 static void rxd_check_post_unexp(struct rxd_ep *ep, struct dlist_entry *list,
 				 struct rxd_pkt_entry *pkt_entry)
 {
-	struct rxd_pkt_entry *unexp;
-	struct rxd_op_pkt *unexp_pkt;
-	struct rxd_op_pkt *pkt = (struct rxd_op_pkt *) (pkt_entry->pkt);
+	struct rxd_pkt_entry *unexp_entry;
+	struct rxd_base_hdr *new_hdr = rxd_get_base_hdr(pkt_entry);
+	struct rxd_base_hdr *unexp_hdr;
 
 	if (!rxd_env.retry)
 		goto insert;
 
-	dlist_foreach_container(list, struct rxd_pkt_entry, unexp, d_entry) {
-		unexp_pkt = (struct rxd_op_pkt *) (unexp->pkt);
-		if (unexp_pkt->pkt_hdr.tx_id == pkt->pkt_hdr.tx_id &&
-		    unexp_pkt->pkt_hdr.msg_id == pkt->pkt_hdr.msg_id &&
-		    unexp_pkt->pkt_hdr.peer == pkt->pkt_hdr.peer) {
+	dlist_foreach_container(list, struct rxd_pkt_entry, unexp_entry, d_entry) {
+		unexp_hdr = rxd_get_base_hdr(unexp_entry);
+		if (unexp_hdr->seq_no == new_hdr->seq_no &&
+		    unexp_hdr->peer == new_hdr->peer) {
 			rxd_release_repost_rx(ep, pkt_entry);
 			return;
 		}
@@ -557,8 +510,7 @@ insert:
 	dlist_insert_tail(&pkt_entry->d_entry, list);
 }
 
-static void rxd_handle_rts(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
-			   struct rxd_pkt_entry *pkt_entry)
+static void rxd_handle_rts(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	struct rxd_av *rxd_av;
 	struct ofi_rbnode *node;
@@ -587,22 +539,29 @@ static void rxd_handle_rts(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
 static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 					struct rxd_pkt_entry *pkt_entry)
 {
-	struct rxd_op_pkt *pkt = (struct rxd_op_pkt *) (pkt_entry->pkt);
+	struct rxd_x_entry *rx_entry;
 	struct dlist_entry *unexp_list;
 	struct dlist_entry *match;
+	struct rxd_base_hdr *hdr = rxd_get_base_hdr(pkt_entry);
 
-	if (pkt->base_hdr.type == ofi_op_tagged) {
+	if (rxd_pkt_type(pkt_entry) == ofi_op_tagged) {
 		match = dlist_remove_first_match(&ep->rx_tag_list, &rxd_match_tmsg,
-					 (void *) pkt);
+					 (void *) pkt_entry);
 		unexp_list = &ep->unexp_tag_list;
 	} else {
 		match = dlist_remove_first_match(&ep->rx_list, &rxd_match_msg,
-					 (void *) pkt);
+					 (void *) pkt_entry);
 		unexp_list = &ep->unexp_list;
 	}
 
-	if (match)
-		return container_of(match, struct rxd_x_entry, entry);
+	if (match) {
+		rx_entry = container_of(match, struct rxd_x_entry, entry);
+		rx_entry->cq_entry.len = MIN(rx_entry->cq_entry.len,
+			hdr->type == RXD_OP_INLINE ? pkt_entry->pkt_size - sizeof(*hdr) -
+			ep->prefix_size : rxd_get_op_hdr(pkt_entry)->size);
+		rx_entry->start_seq = hdr->seq_no;
+		return rx_entry;
+	}
 
 	rxd_check_post_unexp(ep, unexp_list, pkt_entry);
 	return NULL;
@@ -612,14 +571,14 @@ static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 static void rxd_progress_buf_ops(struct rxd_ep *ep, fi_addr_t peer)
 {
 	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_op_pkt *pkt;
+	struct rxd_base_hdr *hdr;
 	struct rxd_x_entry *rx_entry;
 
 	while (!dlist_empty(&ep->peers[peer].buf_ops)) {
 		pkt_entry = container_of((&ep->peers[peer].buf_ops)->next,
 					struct rxd_pkt_entry, d_entry);
-		pkt = (struct rxd_op_pkt *) (pkt_entry->pkt);
-		if (pkt->pkt_hdr.seq_no != ep->peers[peer].rx_seq_no)
+		hdr = rxd_get_base_hdr(pkt_entry);
+		if (hdr->seq_no != ep->peers[peer].rx_seq_no)
 			return;
 
 		rx_entry = rxd_match_rx(ep, pkt_entry);
@@ -644,75 +603,115 @@ void rxd_do_atomic(void *src, void *dst, void *cmp, enum fi_datatype datatype,
 	}
 }
 
-void rxd_progress_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry,
-		     struct rxd_x_entry *rx_entry)
+void rxd_progress_inline_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry,
+			    struct rxd_x_entry *rx_entry)
 {
-	struct rxd_op_pkt *op = (struct rxd_op_pkt *) (pkt_entry->pkt);
+	struct rxd_inline_pkt *pkt = (struct rxd_inline_pkt *) (pkt_entry->pkt);
+
+	rx_entry->bytes_done = ofi_copy_to_iov(rx_entry->iov,
+					       rx_entry->iov_count, 0, pkt->msg,
+					       rx_entry->cq_entry.len);
+}
+
+void rxd_progress_msg_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry,
+			 struct rxd_x_entry *rx_entry)
+{
+	struct rxd_msg_pkt *pkt = (struct rxd_msg_pkt *) (pkt_entry->pkt);
+
+	rx_entry->bytes_done = ofi_copy_to_iov(rx_entry->iov,
+					       rx_entry->iov_count, 0, pkt->msg,
+					       pkt->op_hdr.num_segs == 1 ?
+					       pkt->op_hdr.size :
+					       rxd_ep_domain(ep)->max_inline_msg);
+}
+
+void rxd_progress_rma_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry,
+			 struct rxd_x_entry *rx_entry)
+{
+	struct rxd_rma_pkt *pkt = (struct rxd_rma_pkt *) (pkt_entry->pkt);
+
+	rx_entry->bytes_done = ofi_copy_to_iov(rx_entry->iov,
+					       rx_entry->iov_count, 0, pkt->msg,
+					       pkt->op_hdr.num_segs == 1 ?
+					       pkt->op_hdr.size :
+					       rxd_ep_domain(ep)->max_inline_rma);
+}
+
+void rxd_progress_atom_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry,
+			 struct rxd_x_entry *rx_entry)
+{
+	struct rxd_atom_pkt *pkt = (struct rxd_atom_pkt *) (pkt_entry->pkt);
 	char *src, *cmp;
 	size_t len;
 	int i;
 
-	if (rx_entry->cq_entry.flags & FI_ATOMIC) {
-		src = op->msg;
-		cmp = op->base_hdr.type == RXD_ATOMIC_COMPARE ?
-				op->msg + op->size : NULL;
+	src = pkt->msg;
+	cmp = pkt->base_hdr.type == RXD_ATOMIC_COMPARE ? pkt->msg +
+		pkt->op_hdr.size : NULL;
 
-		for (i = len = 0; i < op->iov_count; i++) {
-			rxd_do_atomic(&src[len],
-				      rx_entry->iov[i].iov_base,
-				      cmp ? &cmp[len] : NULL,
-				      op->datatype, op->atomic_op,
-				      rx_entry->iov[i].iov_len /
-				      ofi_datatype_size(op->datatype));
-			len += rx_entry->iov[i].iov_len;
-		}
-		if (op->base_hdr.type == RXD_ATOMIC)
-			rx_entry->bytes_done = len;
+	for (i = len = 0; i < pkt->iov_count; i++) {
+		rxd_do_atomic(&src[len], rx_entry->iov[i].iov_base,
+			      cmp ? &cmp[len] : NULL, pkt->datatype, pkt->atomic_op,
+			      rx_entry->iov[i].iov_len /
+			      ofi_datatype_size(pkt->datatype));
+		len += rx_entry->iov[i].iov_len;
+	}
+
+	if (pkt->base_hdr.type == RXD_ATOMIC)
+		rx_entry->bytes_done = len;
+}
+
+void rxd_progress_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry,
+		     struct rxd_x_entry *rx_entry)
+{
+	struct rxd_base_hdr *base_hdr = rxd_get_base_hdr(pkt_entry);
+	struct rxd_op_hdr *op_hdr = rxd_get_op_hdr(pkt_entry);
+
+	if (base_hdr->type == RXD_OP_INLINE) {
+		rxd_progress_inline_op(ep, pkt_entry, rx_entry);
 	} else {
-		rx_entry->bytes_done = ofi_copy_to_iov(rx_entry->iov,
-					rx_entry->iov_count, 0, op->msg,
-					op->num_segs == 1 ? op->size :
-					rxd_ep_domain(ep)->max_inline_sz);
-	}
-
-	ep->peers[op->pkt_hdr.peer].curr_tx_id = op->pkt_hdr.tx_id;
-	ep->peers[op->pkt_hdr.peer].curr_rx_id = rx_entry->rx_id;
-	ep->peers[op->pkt_hdr.peer].rx_msg_id = op->pkt_hdr.msg_id;
-	rx_entry->cq_entry.len = MIN(rx_entry->cq_entry.len, op->size);
-	if (op->pkt_hdr.flags & RXD_REMOTE_CQ_DATA) {
-		rx_entry->cq_entry.flags |= FI_REMOTE_CQ_DATA;
-		rx_entry->cq_entry.data = op->cq_data;
-	}
-	rx_entry->peer = op->pkt_hdr.peer;
-	rx_entry->msg_id = op->pkt_hdr.msg_id;
-
-	if (op->num_segs == 1) {
-		if (!(rx_entry->cq_entry.flags & FI_READ)) {
-			rxd_complete_rx(ep, rx_entry);
-			if (!rxd_env.retry)
-				rxd_progress_buf_cq(ep, op->pkt_hdr.peer);
+		if (rx_entry->cq_entry.flags & FI_ATOMIC)
+			rxd_progress_atom_op(ep, pkt_entry, rx_entry);
+		else if (rx_entry->cq_entry.flags & FI_RMA)
+			rxd_progress_rma_op(ep, pkt_entry, rx_entry);
+		else
+			rxd_progress_msg_op(ep, pkt_entry, rx_entry);
+	
+		if (op_hdr->flags & RXD_REMOTE_CQ_DATA) {
+			rx_entry->cq_entry.flags |= FI_REMOTE_CQ_DATA;
+			rx_entry->cq_entry.data = op_hdr->cq_data;
 		}
+	
+		ep->peers[base_hdr->peer].curr_tx_id = op_hdr->tx_id;
+		ep->peers[base_hdr->peer].curr_rx_id = rx_entry->rx_id;
+	}
+	rx_entry->peer = base_hdr->peer;
+
+	if (base_hdr->type == RXD_OP_INLINE || op_hdr->num_segs == 1) {
+		if (!(rx_entry->cq_entry.flags & FI_READ))
+			rxd_complete_rx(ep, rx_entry);
 		return;
 	}
 
-	rx_entry->tx_id = op->pkt_hdr.tx_id;
-	rx_entry->num_segs = op->num_segs;
+	rx_entry->tx_id = op_hdr->tx_id;
+	rx_entry->num_segs = op_hdr->num_segs;
 	rx_entry->next_seg_no++;
 
-	dlist_insert_tail(&rx_entry->entry, &ep->peers[op->pkt_hdr.peer].rx_list);
+	dlist_insert_tail(&rx_entry->entry, &ep->peers[base_hdr->peer].rx_list);
 }
 
-static int rxd_verify_iov(struct rxd_ep *ep, struct rxd_op_pkt *pkt, struct iovec *iov)
+static int rxd_verify_iov(struct rxd_ep *ep, struct ofi_rma_iov *rma,
+			  size_t count, uint32_t type, struct iovec *iov)
 {
 	struct util_domain *util_domain = &rxd_ep_domain(ep)->util_domain;
 	int i, ret;
 
-	for (i = 0; i < pkt->iov_count; i++) {
-		ret = ofi_mr_verify(&util_domain->mr_map, pkt->rma[i].len,
-				(uintptr_t *)(&pkt->rma[i].addr), pkt->rma[i].key,
-				ofi_rx_mr_reg_flags(pkt->base_hdr.type, 0));
-		iov[i].iov_base = (void *) pkt->rma[i].addr;
-		iov[i].iov_len = pkt->rma[i].len;
+	for (i = 0; i < count; i++) {
+		ret = ofi_mr_verify(&util_domain->mr_map, rma[i].len,
+			(uintptr_t *)(&rma[i].addr), rma[i].key,
+			ofi_rx_mr_reg_flags(type, 0));
+		iov[i].iov_base = (void *) rma[i].addr;
+		iov[i].iov_len = rma[i].len;
 		if (ret) {
 			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not verify MR\n");
 			return -FI_EACCES; 
@@ -722,10 +721,11 @@ static int rxd_verify_iov(struct rxd_ep *ep, struct rxd_op_pkt *pkt, struct iove
 }
 
 static struct rxd_x_entry *rxd_rma_read_entry_init(struct rxd_ep *ep,
-			struct rxd_op_pkt *pkt)
+			struct rxd_pkt_entry *pkt_entry)
 {
 	struct rxd_x_entry *tx_entry;
 	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
+	struct rxd_rma_pkt *pkt = (struct rxd_rma_pkt *) (pkt_entry->pkt);
 	int ret;
 
 	if (freestack_isempty(ep->tx_fs)) {
@@ -736,29 +736,29 @@ static struct rxd_x_entry *rxd_rma_read_entry_init(struct rxd_ep *ep,
 	tx_entry = freestack_pop(ep->tx_fs);
 
 	tx_entry->tx_id = rxd_x_fs_index(ep->tx_fs, tx_entry);
-	tx_entry->rx_id = pkt->pkt_hdr.tx_id;
-	tx_entry->msg_id = pkt->pkt_hdr.msg_id;
+	tx_entry->rx_id = pkt->op_hdr.tx_id;
 
 	tx_entry->op = RXD_DATA_READ;
-	tx_entry->peer = pkt->pkt_hdr.peer;
+	tx_entry->peer = pkt->base_hdr.peer;
 	//TODO RMA event capability
 	tx_entry->flags = RXD_NO_TX_COMP;
 	tx_entry->bytes_done = 0;
 	tx_entry->next_seg_no = 0;
-	tx_entry->num_segs = ofi_div_ceil(pkt->size, rxd_domain->max_seg_sz);
+	tx_entry->num_segs = ofi_div_ceil(pkt->op_hdr.size, rxd_domain->max_seg_sz);
 
- 	ret = rxd_verify_iov(ep, pkt, tx_entry->iov);
+ 	ret = rxd_verify_iov(ep, pkt->rma, pkt->iov_count,
+			     pkt->base_hdr.type, tx_entry->iov);
 	if (ret)
 		return NULL;
 
 	tx_entry->iov_count = pkt->iov_count;
 	tx_entry->cq_entry.flags = FI_RMA | FI_READ;
-	tx_entry->cq_entry.len = pkt->size;
+	tx_entry->cq_entry.len = pkt->op_hdr.size;
 
 	dlist_insert_tail(&tx_entry->entry, &ep->peers[tx_entry->peer].tx_list);
 
 	//TODO check ret?
-	rxd_ep_send_ack(ep, pkt->pkt_hdr.peer);
+	rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 
 	rxd_progress_tx_list(ep, &ep->peers[tx_entry->peer]);
 
@@ -766,22 +766,43 @@ static struct rxd_x_entry *rxd_rma_read_entry_init(struct rxd_ep *ep,
 }
 
 static struct rxd_x_entry *rxd_rma_rx_entry_init(struct rxd_ep *ep,
-			struct rxd_op_pkt *pkt)
+			struct rxd_pkt_entry *pkt_entry)
 {
 	struct iovec iov[RXD_IOV_LIMIT];
+	struct rxd_rma_pkt *pkt = (struct rxd_rma_pkt *) (pkt_entry->pkt);
 	int ret;
 
-	ret = rxd_verify_iov(ep, pkt, iov);
+	ret = rxd_verify_iov(ep, pkt->rma, pkt->iov_count,
+			     pkt->base_hdr.type, iov);
 	if (ret)
 		return NULL;
 
-	return rxd_rx_entry_init(ep, iov, pkt->iov_count, 0, 0, NULL, pkt->pkt_hdr.peer,
-				 pkt->base_hdr.type, pkt->pkt_hdr.flags);
+	return rxd_rx_entry_init(ep, iov, pkt->iov_count, 0, 0, NULL,
+				 pkt->base_hdr.peer, pkt->base_hdr.type,
+				 pkt->op_hdr.flags);
+}
+
+static struct rxd_x_entry *rxd_atom_rx_entry_init(struct rxd_ep *ep,
+			struct rxd_pkt_entry *pkt_entry)
+{
+	struct iovec iov[RXD_IOV_LIMIT];
+	struct rxd_atom_pkt *pkt = (struct rxd_atom_pkt *) (pkt_entry->pkt);
+	int ret;
+
+	ret = rxd_verify_iov(ep, pkt->rma, pkt->iov_count,
+			     pkt->base_hdr.type, iov);
+	if (ret)
+		return NULL;
+
+	return rxd_rx_entry_init(ep, iov, pkt->iov_count, 0, 0, NULL,
+				 pkt->base_hdr.peer, pkt->base_hdr.type,
+				 pkt->op_hdr.flags);
 }
 
 static struct rxd_x_entry *rxd_rx_atomic_fetch(struct rxd_ep *ep,
-			struct rxd_op_pkt *pkt)
+			struct rxd_pkt_entry *pkt_entry)
 {
+	struct rxd_atom_pkt *pkt = (struct rxd_atom_pkt *) (pkt_entry->pkt);
 	struct rxd_x_entry *tx_entry;
 	int ret;
 
@@ -799,23 +820,23 @@ static struct rxd_x_entry *rxd_rx_atomic_fetch(struct rxd_ep *ep,
 		return NULL;
 	}
 	tx_entry->tx_id = rxd_x_fs_index(ep->tx_fs, tx_entry);
-	tx_entry->rx_id = pkt->pkt_hdr.tx_id;
-	tx_entry->msg_id = pkt->pkt_hdr.msg_id;
+	tx_entry->rx_id = pkt->op_hdr.tx_id;
 
 	tx_entry->op = RXD_DATA_READ;
-	tx_entry->peer = pkt->pkt_hdr.peer;
+	tx_entry->peer = pkt->base_hdr.peer;
 	tx_entry->flags = RXD_NO_TX_COMP;
 	tx_entry->bytes_done = 0;
 	tx_entry->next_seg_no = 0;
 	tx_entry->num_segs = 1;
 
- 	ret = rxd_verify_iov(ep, pkt, tx_entry->iov);
+ 	ret = rxd_verify_iov(ep, pkt->rma, pkt->iov_count,
+			     pkt->base_hdr.type, tx_entry->iov);
 	if (ret)
 		return NULL;
 
 	tx_entry->iov_count = pkt->iov_count;
 	tx_entry->cq_entry.flags = FI_READ | FI_ATOMIC;
-	tx_entry->cq_entry.len = pkt->size;
+	tx_entry->cq_entry.len = pkt->op_hdr.size;
 
 	rxd_init_data_pkt(ep, tx_entry, tx_entry->op_pkt);
 	if (tx_entry->bytes_done != tx_entry->cq_entry.len)
@@ -823,49 +844,51 @@ static struct rxd_x_entry *rxd_rx_atomic_fetch(struct rxd_ep *ep,
 
 	dlist_insert_tail(&tx_entry->entry, &ep->peers[tx_entry->peer].tx_list);
 
-	rxd_ep_send_ack(ep, pkt->pkt_hdr.peer);
+	rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 
 	rxd_progress_tx_list(ep, &ep->peers[tx_entry->peer]);
 
 	return tx_entry;
 }
 
-static void rxd_handle_op(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
-			  struct rxd_pkt_entry *pkt_entry)
+static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	struct rxd_x_entry *rx_entry;
-	struct rxd_op_pkt *pkt = (struct rxd_op_pkt *) (pkt_entry->pkt);
+	struct rxd_base_hdr *hdr = rxd_get_base_hdr(pkt_entry);
 
-	if (pkt->pkt_hdr.seq_no != ep->peers[pkt->pkt_hdr.peer].rx_seq_no) {
+	if (hdr->seq_no != ep->peers[hdr->peer].rx_seq_no) {
 		if (!rxd_env.retry) {
 			rxd_remove_rx_pkt(ep, pkt_entry);
-			dlist_insert_order(&ep->peers[pkt->pkt_hdr.peer].buf_ops,
-					   &rxd_comp_pkt_msg_id, &pkt_entry->d_entry);
-			ep->peers[pkt->pkt_hdr.peer].rx_seq_no++;
+			dlist_insert_order(&ep->peers[hdr->peer].buf_ops,
+					   &rxd_comp_pkt_seq_no, &pkt_entry->d_entry);
+			ep->peers[hdr->peer].rx_seq_no++;
 			return;
 		}
 
-		if (ep->peers[pkt->pkt_hdr.peer].rx_seq_no !=
-		    ep->peers[pkt->pkt_hdr.peer].last_tx_ack)
+		if (ep->peers[hdr->peer].rx_seq_no != ep->peers[hdr->peer].last_tx_ack)
 			goto ack;
 		goto release;
 	}
 
-	ep->peers[pkt->pkt_hdr.peer].rx_seq_no++;
-	switch (pkt->base_hdr.type) {
+	ep->peers[hdr->peer].rx_seq_no++;
+	switch (hdr->type) {
 	case RXD_MSG:
 	case RXD_TAGGED:
+	case RXD_OP_INLINE:
 		rx_entry = rxd_match_rx(ep, pkt_entry);
 		break;
 	case RXD_READ_REQ:
-		rx_entry = rxd_rma_read_entry_init(ep, pkt);
+		rx_entry = rxd_rma_read_entry_init(ep, pkt_entry);
 		break;
 	case RXD_ATOMIC_FETCH:
 	case RXD_ATOMIC_COMPARE:
-		rx_entry = rxd_rx_atomic_fetch(ep, pkt);
+		rx_entry = rxd_rx_atomic_fetch(ep, pkt_entry);
+		break;
+	case RXD_ATOMIC:
+		rx_entry = rxd_atom_rx_entry_init(ep, pkt_entry);
 		break;
 	default:
-		rx_entry = rxd_rma_rx_entry_init(ep, pkt);
+		rx_entry = rxd_rma_rx_entry_init(ep, pkt_entry);
 	}
 	if (!rx_entry) {
 		rxd_remove_rx_pkt(ep, pkt_entry);
@@ -873,53 +896,53 @@ static void rxd_handle_op(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
 	}
 
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
-	if (pkt->base_hdr.type != RXD_READ_REQ)
+	if (hdr->type != RXD_READ_REQ)
 		rxd_progress_op(ep, pkt_entry, rx_entry);
 
-	if (!rxd_env.retry && !dlist_empty(&ep->peers[pkt->pkt_hdr.peer].buf_ops))
-		rxd_progress_buf_ops(ep, pkt->pkt_hdr.peer);
+	if (!rxd_env.retry && !dlist_empty(&ep->peers[hdr->peer].buf_ops))
+		rxd_progress_buf_ops(ep, hdr->peer);
 
 	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
 
 ack:
-	rxd_ep_send_ack(ep, pkt->pkt_hdr.peer);
+	rxd_ep_send_ack(ep, hdr->peer);
 release:
 	rxd_remove_rx_pkt(ep, pkt_entry);
 	rxd_release_repost_rx(ep, pkt_entry);
 }
 
-static void rxd_handle_cts(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
-			   struct rxd_pkt_entry *pkt_entry)
+static void rxd_handle_cts(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	struct rxd_cts_pkt *cts = (struct rxd_cts_pkt *) (pkt_entry->pkt);
 
 	rxd_update_peer(ep, cts->peer_addr, cts->dg_addr);
 }
 
-static void rxd_handle_ack(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
-			   struct rxd_pkt_entry *ack_entry)
+static void rxd_handle_ack(struct rxd_ep *ep, struct rxd_pkt_entry *ack_entry)
 {
 	struct rxd_x_entry *tx_entry;
 	struct rxd_ack_pkt *ack = (struct rxd_ack_pkt *) (ack_entry->pkt);
 	struct rxd_pkt_entry *pkt_entry;
-	fi_addr_t peer = ack->pkt_hdr.peer;
-	struct rxd_pkt_hdr *hdr;
+	fi_addr_t peer = ack->base_hdr.peer;
+	struct rxd_base_hdr *hdr;
+	struct rxd_op_hdr *op_hdr;
 
-	ep->peers[peer].last_rx_ack = ack->pkt_hdr.seq_no;
+	ep->peers[peer].last_rx_ack = ack->base_hdr.seq_no;
 	while (!dlist_empty(&ep->peers[peer].unacked)) {
 		pkt_entry = container_of((&ep->peers[peer].unacked)->next,
 					struct rxd_pkt_entry, d_entry);
-		hdr = rxd_get_pkt_hdr(pkt_entry);
-		if (hdr->seq_no >= ack->pkt_hdr.seq_no)
+		hdr = rxd_get_base_hdr(pkt_entry);
+		if (hdr->seq_no >= ack->base_hdr.seq_no)
 			break;
 
-		tx_entry = &ep->tx_fs->entry[hdr->tx_id].buf;
-		if (rxd_pkt_type(pkt_entry) <= RXD_ATOMIC_COMPARE &&
-		    tx_entry->cq_entry.flags & (FI_WRITE | FI_SEND)) {
-			if (tx_entry->num_segs > 1 &&
-			    ack->pkt_hdr.msg_id == tx_entry->msg_id) {
-				tx_entry->rx_id = ack->pkt_hdr.rx_id;
-				ep->peers[peer].blocking = 0;
+		if (rxd_pkt_type(pkt_entry) <= RXD_ATOMIC_COMPARE) {
+			op_hdr = rxd_get_op_hdr(pkt_entry);
+			tx_entry = &ep->tx_fs->entry[op_hdr->tx_id].buf;
+			if (tx_entry->cq_entry.flags & (FI_WRITE | FI_SEND)) {
+				if (tx_entry->num_segs > 1) {
+					tx_entry->rx_id = ack->ext_hdr.rx_id;
+					ep->peers[peer].blocking = 0;
+				}
 			}
 		}
 		dlist_remove(&pkt_entry->d_entry);
@@ -927,7 +950,7 @@ static void rxd_handle_ack(struct rxd_ep *ep, struct fi_cq_msg_entry *comp,
 	     	ep->peers[peer].unacked_cnt--;
 	}
 
-	rxd_progress_tx_list(ep, &ep->peers[ack->pkt_hdr.peer]);
+	rxd_progress_tx_list(ep, &ep->peers[ack->base_hdr.peer]);
 } 
 
 void rxd_handle_recv_comp(struct rxd_ep *ep, struct fi_cq_msg_entry *comp)
@@ -940,22 +963,23 @@ void rxd_handle_recv_comp(struct rxd_ep *ep, struct fi_cq_msg_entry *comp)
 	pkt_entry = container_of(comp->op_context, struct rxd_pkt_entry, context);
 	ep->posted_bufs--;
 
+	pkt_entry->pkt_size = comp->len;
 	switch (rxd_pkt_type(pkt_entry)) {
 	case RXD_RTS:
-		rxd_handle_rts(ep, comp, pkt_entry);
+		rxd_handle_rts(ep, pkt_entry);
 		break;
 	case RXD_CTS:
-		rxd_handle_cts(ep, comp, pkt_entry);
+		rxd_handle_cts(ep, pkt_entry);
 		break;
 	case RXD_ACK:
-		rxd_handle_ack(ep, comp, pkt_entry);
+		rxd_handle_ack(ep, pkt_entry);
 		break;
 	case RXD_DATA:
 	case RXD_DATA_READ:
-		rxd_handle_data(ep, comp, pkt_entry);
+		rxd_handle_data(ep, pkt_entry);
 		break;
 	default:
-		rxd_handle_op(ep, comp, pkt_entry);
+		rxd_handle_op(ep, pkt_entry);
 		release = 0;
 		break;
 	}

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -125,8 +125,14 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err2;
 
 	rxd_domain->max_mtu_sz = MIN(dg_info->ep_attr->max_msg_size, RXD_MAX_MTU_SIZE);
-	rxd_domain->max_inline_sz = rxd_domain->max_mtu_sz - sizeof(struct rxd_op_pkt) -
-				    dg_info->ep_attr->msg_prefix_size;
+	rxd_domain->max_inline_sz = rxd_domain->max_mtu_sz - sizeof(struct rxd_base_hdr) -
+						dg_info->ep_attr->msg_prefix_size;
+	rxd_domain->max_inline_msg = rxd_domain->max_mtu_sz - sizeof(struct rxd_msg_pkt) -
+						dg_info->ep_attr->msg_prefix_size;
+	rxd_domain->max_inline_rma = rxd_domain->max_mtu_sz - sizeof(struct rxd_rma_pkt) -
+						dg_info->ep_attr->msg_prefix_size;
+	rxd_domain->max_inline_atom = rxd_domain->max_mtu_sz - sizeof(struct rxd_atom_pkt) -
+						dg_info->ep_attr->msg_prefix_size;
 	rxd_domain->max_seg_sz = rxd_domain->max_mtu_sz - sizeof(struct rxd_data_pkt) -
 				 dg_info->ep_attr->msg_prefix_size;
 	rxd_domain->mr_mode = dg_info->domain_attr->mr_mode;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -255,11 +255,10 @@ void rxd_init_data_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 	data_pkt->base_hdr.type = tx_entry->cq_entry.flags & FI_READ ?
 				  RXD_DATA_READ : RXD_DATA;
 
-	data_pkt->pkt_hdr.rx_id = tx_entry->rx_id;
-	data_pkt->pkt_hdr.seg_no = tx_entry->next_seg_no++;
-	data_pkt->pkt_hdr.tx_id = tx_entry->tx_id;
-	data_pkt->pkt_hdr.msg_id = tx_entry->msg_id;
-	data_pkt->pkt_hdr.peer = ep->peers[tx_entry->peer].peer_addr;
+	data_pkt->ext_hdr.rx_id = tx_entry->rx_id;
+	data_pkt->ext_hdr.tx_id = tx_entry->tx_id;
+	data_pkt->ext_hdr.seg_no = tx_entry->next_seg_no++;
+	data_pkt->base_hdr.peer = ep->peers[tx_entry->peer].peer_addr;
 
 	pkt_entry->pkt_size = ofi_copy_from_iov(data_pkt->msg, seg_size,
 						tx_entry->iov,
@@ -267,10 +266,8 @@ void rxd_init_data_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 						tx_entry->bytes_done);
 
 	tx_entry->bytes_done += pkt_entry->pkt_size;
-	data_pkt->pkt_hdr.flags = (tx_entry->bytes_done == tx_entry->cq_entry.len) ?
-				   RXD_LAST : 0;
 
-	pkt_entry->pkt_size += sizeof(struct rxd_data_pkt) + ep->prefix_size;
+	pkt_entry->pkt_size += sizeof(*data_pkt) + ep->prefix_size;
 }
 
 struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov,
@@ -281,6 +278,7 @@ struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov
 {
 	struct rxd_x_entry *tx_entry;
 	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
+	size_t max;
 
 	if (freestack_isempty(ep->tx_fs)) {
 		FI_INFO(&rxd_prov, FI_LOG_EP_CTRL, "no-more tx entries\n");
@@ -291,7 +289,6 @@ struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov
 
 	tx_entry->tx_id = rxd_x_fs_index(ep->tx_fs, tx_entry);
 	tx_entry->rx_id = 0;
-	tx_entry->msg_id = ep->peers[addr].tx_msg_id++;
 
 	tx_entry->op = op;
 	tx_entry->peer = addr;
@@ -314,15 +311,21 @@ struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov
 	tx_entry->cq_entry.flags = ofi_tx_cq_flags(op);
 	tx_entry->cq_entry.tag = tag;
 
-	if (tx_entry->cq_entry.len <= rxd_domain->max_inline_sz ||
+	max = tx_entry->cq_entry.flags & FI_RMA ? rxd_domain->max_inline_rma :
+		rxd_domain->max_inline_msg;
+
+	if (tx_entry->op == RXD_MSG && tx_entry->cq_entry.len <=
+	    rxd_domain->max_inline_sz) {
+		tx_entry->op = RXD_OP_INLINE;
+		tx_entry->num_segs = 1;
+	} else if (tx_entry->cq_entry.len <= max ||
 	    tx_entry->cq_entry.flags & FI_ATOMIC) {
 		tx_entry->num_segs = 1;
 	} else if (tx_entry->cq_entry.flags & FI_READ) {
 		tx_entry->num_segs = ofi_div_ceil(tx_entry->cq_entry.len,
 						  rxd_domain->max_seg_sz);
 	} else {
-		tx_entry->num_segs = ofi_div_ceil(tx_entry->cq_entry.len -
-						  rxd_domain->max_inline_sz,
+		tx_entry->num_segs = ofi_div_ceil(tx_entry->cq_entry.len - max,
 						  rxd_domain->max_seg_sz) + 1;
 	}
 
@@ -382,10 +385,10 @@ ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 
 		if (ep->peers[tx_entry->peer].unacked_cnt < rxd_env.max_unacked) {
 			data = (struct rxd_data_pkt *) (pkt_entry->pkt);
-			data->pkt_hdr.seq_no = tx_entry->start_seq +
-					       data->pkt_hdr.seg_no;
+			data->base_hdr.seq_no = tx_entry->start_seq +
+					        data->ext_hdr.seg_no;
 			if (data->base_hdr.type != RXD_DATA_READ)
-				data->pkt_hdr.seq_no++;
+				data->base_hdr.seq_no++;
 
 			rxd_insert_unacked(ep, tx_entry->peer, pkt_entry);
 		}
@@ -436,70 +439,173 @@ ssize_t rxd_ep_send_rts(struct rxd_ep *rxd_ep, int dg_addr)
 	return rxd_ep_retry_pkt(rxd_ep, pkt_entry);
 }
 
+static void rxd_init_base_hdr(struct rxd_ep *rxd_ep, struct rxd_pkt_entry *pkt_entry,
+			      struct rxd_x_entry *tx_entry)
+{
+	struct rxd_base_hdr *hdr = rxd_get_base_hdr(pkt_entry);
+
+	hdr->version = RXD_PROTOCOL_VERSION;
+	hdr->type = tx_entry->op;
+	hdr->seq_no = 0;
+	hdr->peer = rxd_ep->peers[tx_entry->peer].peer_addr;
+}
+
+static void rxd_init_ext_hdr(struct rxd_pkt_entry *pkt_entry,
+			     struct rxd_x_entry *tx_entry)
+{
+	struct rxd_ext_hdr *hdr = rxd_get_ext_hdr(pkt_entry);
+
+	hdr->tx_id = tx_entry->tx_id;
+	hdr->rx_id = tx_entry->rx_id;
+}
+
+static void rxd_init_op_hdr(struct rxd_pkt_entry *pkt_entry,
+			    struct rxd_x_entry *tx_entry)
+{
+	struct rxd_op_hdr *hdr = rxd_get_op_hdr(pkt_entry);
+
+	hdr->cq_data = tx_entry->cq_entry.data;
+	hdr->size = tx_entry->cq_entry.len;
+	hdr->num_segs = tx_entry->num_segs;
+	hdr->flags = tx_entry->flags;
+	hdr->tx_id = tx_entry->tx_id;
+}
+
+static void rxd_init_inline_op(struct rxd_ep *rxd_ep, struct rxd_pkt_entry *pkt_entry,
+			       struct rxd_x_entry *tx_entry)
+{
+	struct rxd_inline_pkt *pkt = (struct rxd_inline_pkt *) (pkt_entry->pkt);
+
+	tx_entry->bytes_done = ofi_copy_from_iov(pkt->msg,
+						 tx_entry->cq_entry.len,
+						 tx_entry->iov,
+						 tx_entry->iov_count, 0);
+
+	pkt_entry->pkt_size = tx_entry->bytes_done + sizeof(*pkt) + rxd_ep->prefix_size;
+}
+
+static void rxd_init_msg_op(struct rxd_ep *rxd_ep, struct rxd_pkt_entry *pkt_entry,
+			    struct rxd_x_entry *tx_entry)
+{
+	struct rxd_msg_pkt *pkt = (struct rxd_msg_pkt *) (pkt_entry->pkt);
+
+	rxd_init_op_hdr(pkt_entry, tx_entry);
+	rxd_init_ext_hdr(pkt_entry, tx_entry);
+
+	pkt->tag = tx_entry->cq_entry.tag;
+
+	tx_entry->bytes_done = ofi_copy_from_iov(pkt->msg,
+						 rxd_ep_domain(rxd_ep)->max_inline_msg,
+						 tx_entry->iov,
+						 tx_entry->iov_count, 0);
+
+	pkt_entry->pkt_size = tx_entry->bytes_done + sizeof(*pkt) + rxd_ep->prefix_size;
+}
+
+static void rxd_init_rma_op(struct rxd_ep *rxd_ep, struct rxd_pkt_entry *pkt_entry,
+			    struct rxd_x_entry *tx_entry,
+			    const struct fi_rma_iov *rma_iov, size_t rma_count)
+{
+	struct rxd_rma_pkt *pkt = (struct rxd_rma_pkt *) (pkt_entry->pkt);
+
+	rxd_init_op_hdr(pkt_entry, tx_entry);
+	rxd_init_ext_hdr(pkt_entry, tx_entry);
+
+	memcpy(pkt->rma, rma_iov, sizeof(*rma_iov) * rma_count);
+	pkt->iov_count = rma_count;
+
+	pkt_entry->peer = tx_entry->peer;
+	pkt_entry->pkt_size = sizeof(*pkt) + rxd_ep->prefix_size;
+
+	if (tx_entry->op == RXD_READ_REQ)
+		return;
+
+	tx_entry->bytes_done = ofi_copy_from_iov(pkt->msg,
+					 	 rxd_ep_domain(rxd_ep)->max_inline_rma,
+						 tx_entry->iov,
+						 tx_entry->iov_count, 0);
+
+	pkt_entry->pkt_size += tx_entry->bytes_done;
+}
+
+static void rxd_init_atomic_op(struct rxd_ep *rxd_ep, struct rxd_pkt_entry *pkt_entry,
+			       struct rxd_x_entry *tx_entry,
+			       const struct fi_rma_iov *rma_iov, size_t rma_count,
+			       const struct iovec *comp_iov, size_t comp_count,
+			       enum fi_datatype datatype, enum fi_op atomic_op)
+{
+	struct rxd_atom_pkt *pkt = (struct rxd_atom_pkt *) (pkt_entry->pkt);
+	size_t len;
+
+	rxd_init_op_hdr(pkt_entry, tx_entry);
+	rxd_init_ext_hdr(pkt_entry, tx_entry);
+
+	tx_entry->bytes_done = ofi_copy_from_iov(pkt->msg,
+					 	 rxd_ep_domain(rxd_ep)->max_inline_atom,
+						 tx_entry->iov,
+						 tx_entry->iov_count, 0);
+
+	memcpy(pkt->rma, rma_iov, sizeof(*rma_iov) * rma_count);
+	pkt->iov_count = rma_count;
+	pkt->datatype = datatype;
+	pkt->atomic_op = atomic_op;
+
+	pkt_entry->peer = tx_entry->peer;
+	pkt_entry->pkt_size = tx_entry->bytes_done + sizeof(*pkt) + rxd_ep->prefix_size;
+
+	if (tx_entry->op != RXD_ATOMIC_COMPARE)
+		return;
+
+	len = ofi_copy_from_iov(pkt->msg + tx_entry->cq_entry.len,
+				tx_entry->cq_entry.len,
+				comp_iov, comp_count, 0);
+	if (len != tx_entry->cq_entry.len) {
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
+			"compare data length mismatch\n");
+	}
+
+	pkt_entry->pkt_size += len;
+}
+
 int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry,
 		   const struct fi_rma_iov *rma_iov, size_t rma_count,
 		   const struct iovec *comp_iov, size_t comp_count,
 		   enum fi_datatype datatype, enum fi_op atomic_op)
 {
 	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_domain *rxd_domain = rxd_ep_domain(rxd_ep);
-	struct rxd_op_pkt *op;
-	size_t len;
 	int ret = 0;
 
 	pkt_entry = rxd_get_tx_pkt(rxd_ep);
 	if (!pkt_entry)
 		return -FI_ENOMEM;
 
-	op = (struct rxd_op_pkt *) (pkt_entry->pkt);
-	pkt_entry->peer = tx_entry->peer;
+	rxd_init_base_hdr(rxd_ep, pkt_entry, tx_entry);
 
-	op->base_hdr.version = RXD_PROTOCOL_VERSION;
-	op->base_hdr.type = tx_entry->op;
-
-	op->tag = tx_entry->cq_entry.tag;
-	op->cq_data = tx_entry->cq_entry.data;
-	op->size = tx_entry->cq_entry.len;
-	op->num_segs = tx_entry->num_segs;
-
-	op->pkt_hdr.flags = tx_entry->flags;
-	op->pkt_hdr.tx_id = tx_entry->tx_id;
-	op->pkt_hdr.peer = rxd_ep->peers[tx_entry->peer].peer_addr;
-	op->pkt_hdr.msg_id = tx_entry->msg_id;
-
-	if (tx_entry->op != RXD_READ_REQ) {
-		tx_entry->bytes_done = ofi_copy_from_iov(op->msg,
-							 rxd_domain->max_inline_sz,
-							 tx_entry->iov,
-							 tx_entry->iov_count, 0);
-		if (tx_entry->op == RXD_ATOMIC_COMPARE) {
-			len = ofi_copy_from_iov(op->msg + tx_entry->cq_entry.len,
-						tx_entry->cq_entry.len,
-						comp_iov, comp_count, 0);
-			if (len != tx_entry->cq_entry.len) {
-				FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
-					"compare data length mismatch\n");
-			}
-		}
-	}
-
-	pkt_entry->pkt_size = tx_entry->bytes_done + sizeof(*op) + rxd_ep->prefix_size;
-
-	if (rma_count) {
-		memcpy(op->rma, rma_iov, sizeof(*rma_iov) * rma_count);
-		op->iov_count = rma_count;
-		if (tx_entry->cq_entry.flags & FI_ATOMIC) {
-			op->datatype = datatype;
-			op->atomic_op = atomic_op;
-		}
+	switch (tx_entry->op) {
+	case RXD_READ_REQ:
+	case RXD_WRITE:
+		rxd_init_rma_op(rxd_ep, pkt_entry, tx_entry, rma_iov, rma_count);
+		break;
+	case RXD_ATOMIC:
+	case RXD_ATOMIC_FETCH:
+	case RXD_ATOMIC_COMPARE:
+		rxd_init_atomic_op(rxd_ep, pkt_entry, tx_entry, rma_iov, rma_count,
+				   comp_iov, comp_count, datatype, atomic_op);
+		break;
+	case RXD_MSG:
+	case RXD_TAGGED:
+		rxd_init_msg_op(rxd_ep, pkt_entry, tx_entry);
+		break;
+	default:
+		rxd_init_inline_op(rxd_ep, pkt_entry, tx_entry);
 	}
 
 	if (rxd_ep->peers[tx_entry->peer].unacked_cnt < rxd_env.max_unacked &&
 	    rxd_ep->peers[tx_entry->peer].peer_addr != FI_ADDR_UNSPEC &&
 	    !rxd_ep->peers[tx_entry->peer].blocking) {
-		op->pkt_hdr.seq_no = rxd_ep->peers[tx_entry->peer].tx_seq_no++;
-		tx_entry->start_seq = op->pkt_hdr.seq_no;
-		if (tx_entry->op != RXD_READ_REQ && op->num_segs > 1) {
+		tx_entry->start_seq = rxd_set_pkt_seq(&rxd_ep->peers[tx_entry->peer],
+						      pkt_entry);
+		if (tx_entry->op != RXD_READ_REQ && tx_entry->num_segs > 1) {
 			rxd_ep->peers[tx_entry->peer].blocking = 1;
 			rxd_ep->peers[tx_entry->peer].tx_seq_no = tx_entry->start_seq +
 								  tx_entry->num_segs;
@@ -509,8 +615,7 @@ int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry,
 		tx_entry->op_pkt = pkt_entry;
 	}
 
-	if (tx_entry->op != RXD_READ_REQ && !(tx_entry->cq_entry.flags & FI_ATOMIC) &&
-	    !(tx_entry->flags & RXD_INJECT))
+	if (tx_entry->op != RXD_READ_REQ && tx_entry->num_segs > 1)
 		ret = rxd_ep_post_data_pkts(rxd_ep, tx_entry);
 
 	return ret == -FI_ENOMEM ? ret : 0;
@@ -534,12 +639,11 @@ void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer)
 
 	ack->base_hdr.version = RXD_PROTOCOL_VERSION;
 	ack->base_hdr.type = RXD_ACK;
-	ack->pkt_hdr.peer = rxd_ep->peers[peer].peer_addr;
-	ack->pkt_hdr.seq_no = rxd_ep->peers[peer].rx_seq_no;
-	ack->pkt_hdr.msg_id = rxd_ep->peers[peer].rx_msg_id;
-	ack->pkt_hdr.tx_id = rxd_ep->peers[peer].curr_tx_id;
-	ack->pkt_hdr.rx_id = rxd_ep->peers[peer].curr_rx_id;
-	rxd_ep->peers[peer].last_tx_ack = ack->pkt_hdr.seq_no;
+	ack->base_hdr.peer = rxd_ep->peers[peer].peer_addr;
+	ack->base_hdr.seq_no = rxd_ep->peers[peer].rx_seq_no;
+	ack->ext_hdr.tx_id = rxd_ep->peers[peer].curr_tx_id;
+	ack->ext_hdr.rx_id = rxd_ep->peers[peer].curr_rx_id;
+	rxd_ep->peers[peer].last_tx_ack = ack->base_hdr.seq_no;
 
 	ret = rxd_ep_retry_pkt(rxd_ep, pkt_entry);
 	if (ret)
@@ -743,42 +847,38 @@ struct fi_ops_cm rxd_ep_cm = {
 	.join = fi_no_join,
 };
 
-static void rxd_remove_from_list(struct rxd_ep *ep, struct dlist_entry *list,
-				 uint32_t tx_id)
+static void rxd_peer_timeout(struct rxd_ep *rxd_ep, struct rxd_peer *peer)
 {
-	struct dlist_entry *entry = list->next;
+	struct fi_cq_err_entry err_entry;
+	struct rxd_x_entry *tx_entry;
 	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_pkt_hdr *hdr;
-	int removed = -1; 
 
-	while (entry) {
-		pkt_entry = container_of(entry, struct rxd_pkt_entry, d_entry);
-		entry = entry->next;
-		hdr = rxd_get_pkt_hdr(pkt_entry);
-		if (hdr->tx_id != tx_id && removed == tx_id)
-			break;
-		if (hdr->tx_id == tx_id) {
-			dlist_remove(&pkt_entry->d_entry);
-			rxd_release_tx_pkt(ep, pkt_entry);
-			removed = tx_id;
-		}
+	while (!dlist_empty(&peer->tx_list)) {
+		dlist_pop_front(&peer->tx_list, struct rxd_x_entry, tx_entry, entry);
+		memset(&err_entry, 0, sizeof(struct fi_cq_err_entry));
+		rxd_tx_entry_free(rxd_ep, tx_entry);
+		err_entry.op_context = tx_entry->cq_entry.op_context;
+		err_entry.flags = tx_entry->cq_entry.flags;
+		err_entry.err = FI_ECONNREFUSED;
+		err_entry.prov_errno = 0;
+		rxd_cq_report_error(rxd_ep_tx_cq(rxd_ep), &err_entry);
 	}
-}
 
-static void rxd_ep_remove_msg_pkts(struct rxd_ep *ep, struct rxd_peer *peer,
-				   uint32_t tx_id)
-{
-	rxd_remove_from_list(ep, &peer->unacked, tx_id);
+	while (!dlist_empty(&peer->unacked)) {
+		dlist_pop_front(&peer->unacked, struct rxd_pkt_entry, pkt_entry,
+				d_entry);
+		rxd_release_tx_pkt(rxd_ep, pkt_entry);
+	     	peer->unacked_cnt--;
+	}
+
 }
 
 static void rxd_ep_progress(struct util_ep *util_ep)
 {
 	struct rxd_peer *peer;
-	struct fi_cq_err_entry err_entry;
-	struct rxd_x_entry *tx_entry;
 	struct fi_cq_msg_entry cq_entry;
 	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_pkt_hdr *hdr;
+	struct rxd_base_hdr *hdr;
 	struct rxd_ep *ep;
 	uint64_t current;
 	ssize_t ret;
@@ -810,20 +910,11 @@ static void rxd_ep_progress(struct util_ep *util_ep)
 				continue;
 
 			if (rxd_pkt_type(pkt_entry) != RXD_RTS) {
-				hdr = rxd_get_pkt_hdr(pkt_entry);
+				hdr = rxd_get_base_hdr(pkt_entry);
 				if (pkt_entry->retry_cnt > RXD_MAX_PKT_RETRY) {
-					memset(&err_entry, 0, sizeof(struct fi_cq_err_entry));
-					rxd_ep_remove_msg_pkts(ep, peer, hdr->tx_id);
-					tx_entry = &ep->tx_fs->entry[hdr->tx_id].buf;
-					rxd_tx_entry_free(ep, tx_entry);
-					err_entry.op_context = tx_entry->cq_entry.op_context;
-					err_entry.flags = (FI_MSG | FI_SEND);
-					err_entry.err = FI_ECONNREFUSED;
-					err_entry.prov_errno = 0;
-					rxd_cq_report_error(rxd_ep_tx_cq(ep), &err_entry);
-					continue;
+					rxd_peer_timeout(ep, &ep->peers[hdr->peer]);
+					break;
 				}
-				hdr->flags |= RXD_RETRY;
 			}
 			ret = rxd_ep_retry_pkt(ep, pkt_entry);
 			if (ret)
@@ -921,8 +1012,6 @@ static void rxd_init_peer(struct rxd_ep *ep, uint64_t dg_addr)
 	ep->peers[dg_addr].rx_seq_no = 0;
 	ep->peers[dg_addr].last_rx_ack = 0;
 	ep->peers[dg_addr].last_tx_ack = 0;
-	ep->peers[dg_addr].tx_msg_id = 0;
-	ep->peers[dg_addr].rx_msg_id = 0;
 	ep->peers[dg_addr].rx_window = rxd_env.max_unacked;
 	ep->peers[dg_addr].blocking = 0;
 	ep->peers[dg_addr].unacked_cnt = 0;
@@ -931,7 +1020,6 @@ static void rxd_init_peer(struct rxd_ep *ep, uint64_t dg_addr)
 	dlist_init(&ep->peers[dg_addr].rx_list);
 	dlist_init(&ep->peers[dg_addr].rma_rx_list);
 	dlist_init(&ep->peers[dg_addr].buf_ops);
-	dlist_init(&ep->peers[dg_addr].buf_cq);
 }
 
 int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -67,7 +67,7 @@ int rxd_info_to_rxd(uint32_t version, const struct fi_info *core_info,
 
 	*info->tx_attr = *rxd_info.tx_attr;
 	info->tx_attr->inject_size = MIN(core_info->ep_attr->max_msg_size,
-			RXD_MAX_MTU_SIZE) - sizeof(struct rxd_op_pkt) -
+			RXD_MAX_MTU_SIZE) - sizeof(struct rxd_atom_pkt) -
 			core_info->ep_attr->msg_prefix_size;
 	*info->rx_attr = *rxd_info.rx_attr;
 	*info->ep_attr = *rxd_info.ep_attr;

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -40,14 +40,19 @@ static int rxd_match_unexp(struct dlist_entry *item, const void *arg)
 {
 	struct rxd_x_entry *rx_entry = (struct rxd_x_entry *) arg;
 	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_op_pkt *op;
+	struct rxd_base_hdr *hdr;
 
 	pkt_entry = container_of(item, struct rxd_pkt_entry, d_entry);
-	op = (struct rxd_op_pkt *) (pkt_entry->pkt);
+	hdr = rxd_get_base_hdr(pkt_entry);
 
-	return rxd_match_addr(rx_entry->peer, op->pkt_hdr.peer) &&
-	       rxd_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore,
-	       op->tag);
+	if (!rxd_match_addr(rx_entry->peer, hdr->peer))
+		return 0;
+
+	if (hdr->type != RXD_TAGGED)
+		return 1;
+
+	return rxd_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore,
+			    ((struct rxd_msg_pkt *) (pkt_entry->pkt))->tag);
 }
 
 static void rxd_ep_check_unexp_msg_list(struct rxd_ep *ep, struct dlist_entry *list,
@@ -55,7 +60,7 @@ static void rxd_ep_check_unexp_msg_list(struct rxd_ep *ep, struct dlist_entry *l
 {
 	struct dlist_entry *match;
 	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_op_pkt *op;
+	struct rxd_base_hdr *hdr;
 
 	match = dlist_remove_first_match(list, &rxd_match_unexp,
 					 (void *) rx_entry);
@@ -66,11 +71,14 @@ static void rxd_ep_check_unexp_msg_list(struct rxd_ep *ep, struct dlist_entry *l
 	dlist_remove(&rx_entry->entry);
 
 	pkt_entry = container_of(match, struct rxd_pkt_entry, d_entry);
-	op = (struct rxd_op_pkt *) (pkt_entry->pkt);
-	dlist_insert_tail(&rx_entry->entry, &ep->peers[op->pkt_hdr.peer].rx_list);
+	hdr = rxd_get_base_hdr(pkt_entry);
+	rx_entry->cq_entry.len = MIN(rx_entry->cq_entry.len,
+		hdr->type == RXD_OP_INLINE ? pkt_entry->pkt_size - sizeof(*hdr) -
+		ep->prefix_size : rxd_get_op_hdr(pkt_entry)->size);
+	dlist_insert_tail(&rx_entry->entry, &ep->peers[hdr->peer].rx_list);
 
 	rxd_progress_op(ep, pkt_entry, rx_entry);
-	rxd_ep_send_ack(ep, op->pkt_hdr.peer);
+	rxd_ep_send_ack(ep, hdr->peer);
 	rxd_release_repost_rx(ep, pkt_entry);
 }
 
@@ -165,7 +173,7 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	assert(iov_count <= RXD_IOV_LIMIT);
 	assert(ofi_total_iov_len(iov, iov_count) <=
-	       rxd_ep_domain(rxd_ep)->max_inline_sz);
+	       rxd_ep_domain(rxd_ep)->max_inline_msg);
 
 	dg_addr = rxd_av_dg_addr(rxd_ep_av(rxd_ep), addr);
 

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -47,7 +47,7 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	ssize_t ret = -FI_EAGAIN;
 
 	assert(iov_count <= RXD_IOV_LIMIT && rma_count <= RXD_IOV_LIMIT);
-	assert(ofi_total_iov_len(iov, iov_count) <= rxd_ep_domain(rxd_ep)->max_inline_sz);
+	assert(ofi_total_iov_len(iov, iov_count) <= rxd_ep_domain(rxd_ep)->max_inline_rma);
 
 	dg_addr = rxd_av_dg_addr(rxd_ep_av(rxd_ep), addr);
 


### PR DESCRIPTION
- separate packet definitions to optimize space for each type of packet
- create optimized "OP_INLINE" packet with only minimal 16 byte header
- eliminate msg_id - not needed
- eliminate buf_cq (messages might complete out of order - not strict)
- change seq_no to uint64_t
- set max_inline_sz, msg, rma, and atom
- remove some unneeded flags (RXD_RETRY and RXD_LAST)
- on pkt timeout, timeout all outstanding txs for that peer, since the peer is unresponsive

Signed-off-by: aingerson <alexia.ingerson@intel.com>