### PR TITLE
prov/psm2: MQ to Completion Queue Event conversion optimization

### DIFF
--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -19,6 +19,7 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 	 psm2_happy=0
 	 have_psm2_am_register_handlers_2=1
 	 have_psm2_mq_fp_msg=1
+	 have_psm2_mq_req_user=1
 	 AS_IF([test x"$enable_psm2" != x"no"],
 	       [AS_IF([test x$have_psm2_src = x0],
 		      [
@@ -26,12 +27,26 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 			FI_CHECK_PACKAGE([psm2],
 					 [psm2.h],
 					 [psm2],
-					 [psm2_mq_fp_msg],
+					 [psm2_mq_ipeek_dequeue_multi],
 					 [],
 					 [$psm2_PREFIX],
 					 [$psm2_LIBDIR],
 					 [psm2_happy=1],
 					 [psm2_happy=0])
+			AS_IF([test x$psm2_happy = x0],
+			      [
+				$as_echo "$as_me: recheck psm2 without psm2_mq_ipeek_dequeue_multi."
+				have_psm2_mq_req_user=0
+				FI_CHECK_PACKAGE([psm2],
+						 [psm2.h],
+						 [psm2],
+						 [psm2_mq_fp_msg],
+						 [],
+						 [$psm2_PREFIX],
+						 [$psm2_LIBDIR],
+						 [psm2_happy=1],
+						 [psm2_happy=0])
+			      ])
 			AS_IF([test x$psm2_happy = x0],
 			      [
 				$as_echo "$as_me: recheck psm2 without psm2_mq_fp_msg."
@@ -125,6 +140,9 @@ AC_DEFUN([FI_PSM2_CONFIGURE],[
 	 AC_DEFINE_UNQUOTED([HAVE_PSM2_MQ_FP_MSG],
 			    $have_psm2_mq_fp_msg,
 			    [psm2_mq_fp_msg function is present])
+	 AC_DEFINE_UNQUOTED([HAVE_PSM2_MQ_REQ_USER],
+			    $have_psm2_mq_req_user,
+			    [psm2_mq_ipeek_dequeue_multi function is present])
 ])
 
 AC_ARG_WITH([psm2-src],

--- a/prov/psm2/src/psmx2_cq.c
+++ b/prov/psm2/src/psmx2_cq.c
@@ -152,6 +152,688 @@ out:
 	return event;
 }
 
+static uint64_t psmx2_comp_flags[PSMX2_MAX_CONTEXT_TYPE] = {
+	[PSMX2_NOCOMP_SEND_CONTEXT]	= FI_SEND | FI_MSG,
+	[PSMX2_NOCOMP_RECV_CONTEXT]	= FI_RECV | FI_MSG,
+	[PSMX2_NOCOMP_TSEND_CONTEXT]	= FI_SEND | FI_TAGGED,
+	[PSMX2_NOCOMP_TRECV_CONTEXT]	= FI_RECV | FI_TAGGED,
+	[PSMX2_NOCOMP_WRITE_CONTEXT]	= FI_WRITE | FI_RMA,
+	[PSMX2_NOCOMP_READ_CONTEXT]	= FI_READ | FI_RMA,
+	[PSMX2_SEND_CONTEXT]		= FI_SEND | FI_MSG,
+	[PSMX2_RECV_CONTEXT]		= FI_RECV | FI_MSG,
+	[PSMX2_MULTI_RECV_CONTEXT]	= FI_RECV | FI_MSG,
+	[PSMX2_TSEND_CONTEXT]		= FI_SEND | FI_TAGGED,
+	[PSMX2_TRECV_CONTEXT]		= FI_RECV | FI_TAGGED,
+	[PSMX2_WRITE_CONTEXT]		= FI_WRITE | FI_RMA,
+	[PSMX2_READ_CONTEXT]		= FI_READ | FI_RMA,
+	[PSMX2_REMOTE_WRITE_CONTEXT]	= FI_REMOTE_WRITE | FI_RMA,
+	[PSMX2_REMOTE_READ_CONTEXT]	= FI_REMOTE_READ | FI_RMA,
+	[PSMX2_SENDV_CONTEXT]		= FI_SEND,
+	[PSMX2_IOV_SEND_CONTEXT]	= FI_SEND,
+	[PSMX2_IOV_RECV_CONTEXT]	= FI_RECV,
+};
+
+
+#if HAVE_PSM2_MQ_REQ_USER
+
+/*
+ * Translate "status" into completion event. A few factors determine where to
+ * save the event.
+ *
+ * If:
+ *
+ * (1) the CQE is for the CQ being polled; and
+ * (2) event buffer is supplied (event_in != NULL); and
+ * (3) the CQE is not an error entry,
+ *
+ * then the event is written to the event buffer directly. Otherwise a CQE is
+ * allocated on the corresponding CQ.
+ *
+ * The function doesn't use PSMX2_STATUS_CONTEXT(status) because the context
+ * field could refer to an allocated descriptor that may have already been
+ * freed. All the information that are dependent on the field are obtained
+ * in advance and passed in as separate parameters ("op_context", "buf",
+ * "flags", and "data").
+ *
+ * The flag "event_saved" is set to indicate to the caller that the event
+ * was saved to the user's provided buffer, otherwise the event was an error
+ * or the event has been saved to the comp_cq slist.
+ */
+
+__attribute__((always_inline))
+static inline int psmx2_cq_any_complete(struct psmx2_fid_cq *poll_cq,
+					struct psmx2_fid_cq *comp_cq,
+					struct psmx2_fid_av *av,
+					PSMX2_STATUS_TYPE *status,
+					void *op_context,
+					void *buf,
+					uint64_t flags,
+					uint64_t data,
+					struct psmx2_cq_event *event_in,
+					int *event_saved,
+					fi_addr_t *src_addr)
+{
+	struct psmx2_cq_event *event = event_in;
+
+	*event_saved = 1;
+
+	if (OFI_UNLIKELY(PSMX2_STATUS_ERROR(status))) {
+		*event_saved = 0;
+		event = psmx2_cq_alloc_event(comp_cq);
+		if (!event)
+			return -FI_ENOMEM;
+
+		event->error = 1;
+		event->cqe.err.op_context = op_context;
+		event->cqe.err.flags = flags;
+		event->cqe.err.err = -psmx2_errno(PSMX2_STATUS_ERROR(status));
+		event->cqe.err.prov_errno = PSMX2_STATUS_ERROR(status);
+		event->cqe.err.tag = PSMX2_GET_TAG64(PSMX2_STATUS_TAG(status));
+		event->cqe.err.olen = PSMX2_STATUS_SNDLEN(status) - PSMX2_STATUS_RCVLEN(status);
+		event->cqe.err.data = data;
+
+		psmx2_cq_enqueue_event(comp_cq, event);
+		return 0;
+	}
+
+	if (OFI_UNLIKELY(poll_cq != comp_cq || !event)) {
+		*event_saved = 0;
+		event = psmx2_cq_alloc_event(comp_cq);
+		if (!event)
+			return -FI_ENOMEM;
+
+		event->error = 0;
+	}
+
+	if (src_addr) {
+		fi_addr_t source = PSMX2_EP_TO_ADDR(PSMX2_STATUS_PEER(status));
+
+		if (event == event_in) {
+			src_addr[0] = psmx2_av_translate_source(av, source);
+			if (src_addr[0] == FI_ADDR_NOTAVAIL) {
+				event = psmx2_cq_alloc_event(comp_cq);
+				if (!event)
+					return -FI_ENOMEM;
+
+				event->cqe = event_in->cqe;
+				event->cqe.err.err = FI_EADDRNOTAVAIL;
+				event->cqe.err.err_data = &comp_cq->error_data;
+				event->error = !!event->cqe.err.err;
+				if (av->addr_format == FI_ADDR_STR) {
+					event->cqe.err.err_data_size = PSMX2_ERR_DATA_SIZE;
+					psmx2_get_source_string_name(source, (void *)&comp_cq->error_data,
+									 &event->cqe.err.err_data_size);
+				} else {
+					psmx2_get_source_name(source, (void *)&comp_cq->error_data);
+					event->cqe.err.err_data_size = sizeof(struct psmx2_ep_name);
+				}
+
+				return -FI_EAVAIL;
+			}
+		} else {
+			event->source_is_valid = 1;
+			event->source = source;
+			event->source_av = av;
+		}
+	}
+
+	switch (comp_cq->format) {
+	case FI_CQ_FORMAT_CONTEXT:
+		event->cqe.context.op_context = op_context;
+		break;
+
+	case FI_CQ_FORMAT_MSG:
+		event->cqe.msg.op_context = op_context;
+		event->cqe.msg.flags = flags;
+		event->cqe.msg.len = PSMX2_STATUS_RCVLEN(status);
+		break;
+
+	case FI_CQ_FORMAT_DATA:
+		event->cqe.data.op_context = op_context;
+		event->cqe.data.buf = buf;
+		event->cqe.data.flags = flags;
+		event->cqe.data.len = PSMX2_STATUS_RCVLEN(status);
+		event->cqe.data.data = data;
+		break;
+
+	case FI_CQ_FORMAT_TAGGED:
+		event->cqe.tagged.op_context = op_context;
+		event->cqe.tagged.buf = buf;
+		event->cqe.tagged.flags = flags;
+		event->cqe.tagged.len = PSMX2_STATUS_RCVLEN(status);
+		event->cqe.tagged.data = data;
+		event->cqe.tagged.tag = PSMX2_GET_TAG64(PSMX2_STATUS_TAG(status));
+		break;
+
+	default:
+		FI_WARN(&psmx2_prov, FI_LOG_CQ,
+			"unsupported CQ format %d\n", comp_cq->format);
+		if (event != event_in)
+			psmx2_cq_free_event(comp_cq, event);
+		return -FI_EINVAL;
+	}
+
+	if (OFI_UNLIKELY(event != event_in))
+		psmx2_cq_enqueue_event(comp_cq, event);
+
+	return 0;
+}
+
+static inline int psmx2_cq_tx_complete(struct psmx2_fid_cq *poll_cq,
+				       struct psmx2_fid_cq *comp_cq,
+				       struct psmx2_fid_av *av,
+				       PSMX2_STATUS_TYPE *status,
+				       void *op_context,
+				       void *buf,
+				       uint64_t flags,
+				       uint64_t data,
+				       struct psmx2_cq_event *event_in,
+				       int *event_saved)
+{
+	return psmx2_cq_any_complete(poll_cq, comp_cq, av, status,
+				     op_context, buf, flags, data,
+				     event_in, event_saved, NULL);
+}
+
+static inline int psmx2_cq_rx_complete(struct psmx2_fid_cq *poll_cq,
+				       struct psmx2_fid_cq *comp_cq,
+				       struct psmx2_fid_av *av,
+				       PSMX2_STATUS_TYPE *status,
+				       void *op_context,
+				       void *buf,
+				       uint64_t flags,
+				       uint64_t data,
+				       struct psmx2_cq_event *event_in,
+				       fi_addr_t *src_addr,
+				       int *event_saved)
+{
+	return psmx2_cq_any_complete(poll_cq, comp_cq, av, status,
+				     op_context, buf, flags, data,
+				     event_in, event_saved, src_addr);
+}
+
+int
+psmx2_mq_status_copy(struct psm2_mq_req_user *req, void *status_array, int entry_index)
+{
+	struct fi_context *fi_context;
+	struct psmx2_fid_ep *ep;
+	struct psmx2_fid_mr *mr;
+	struct psmx2_am_request *am_req;
+	struct psmx2_multi_recv *multi_recv_req;
+	struct psmx2_sendv_request *sendv_req;
+	struct psmx2_sendv_reply *sendv_rep;
+	psm2_mq_req_t psm2_req;
+	size_t len_remaining;
+	void *op_context;
+	void *buf;
+	uint64_t flags;
+	uint64_t data;
+	int err;
+	int context_type;
+	int event_saved = 0;
+	void *entry = NULL;
+
+	struct psmx2_status_data *status_data = status_array;
+
+	if (OFI_LIKELY(status_data->event_buffer && status_data->poll_cq))
+		entry = (uint8_t *)status_data->event_buffer +
+				(entry_index * status_data->poll_cq->entry_size);
+
+	fi_context = PSMX2_STATUS_CONTEXT(req);
+
+	if (OFI_UNLIKELY(!fi_context))
+		return 0;
+
+	context_type = (int)PSMX2_CTXT_TYPE(fi_context);
+	flags = psmx2_comp_flags[context_type];
+	ep = PSMX2_CTXT_EP(fi_context);
+
+	switch (context_type) {
+	case PSMX2_SEND_CONTEXT:
+	case PSMX2_TSEND_CONTEXT:
+		if (ep->send_cq) {
+			op_context = fi_context;
+			buf = PSMX2_CTXT_USER(fi_context);
+			err = psmx2_cq_tx_complete(
+					status_data->poll_cq, ep->send_cq, ep->av,
+					req, op_context, buf, flags, 0,
+					entry, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->send_cntr)
+			psmx2_cntr_inc(ep->send_cntr, PSMX2_STATUS_ERROR(req));
+
+		/* Bi-directional send/recv performance tweak for KNL */
+		if (event_saved && PSMX2_STATUS_SNDLEN(req) > 16384)
+			event_saved++;
+		break;
+
+	case PSMX2_NOCOMP_SEND_CONTEXT:
+	case PSMX2_NOCOMP_TSEND_CONTEXT:
+		if (OFI_UNLIKELY(ep->send_cq && PSMX2_STATUS_ERROR(req))) {
+			err = psmx2_cq_tx_complete(
+					status_data->poll_cq, ep->send_cq, ep->av,
+					req, NULL, NULL, flags, 0,
+					entry, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->send_cntr)
+			psmx2_cntr_inc(ep->send_cntr, PSMX2_STATUS_ERROR(req));
+		break;
+
+	case PSMX2_RECV_CONTEXT:
+		if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(req))) &&
+				  !psmx2_handle_sendv_req(ep, req, 0))) {
+			return 0;
+		}
+		if (ep->recv_cq) {
+			op_context = fi_context;
+			buf = PSMX2_CTXT_USER(fi_context);
+			data = 0;
+			if (PSMX2_HAS_IMM(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(req)))) {
+				flags |= FI_REMOTE_CQ_DATA;
+				data = PSMX2_GET_CQDATA(PSMX2_STATUS_TAG(req));
+			}
+			err = psmx2_cq_rx_complete(
+					status_data->poll_cq, ep->recv_cq, ep->av,
+					req, op_context, buf, flags, data,
+					entry, status_data->src_addr, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->recv_cntr)
+			psmx2_cntr_inc(ep->recv_cntr, PSMX2_STATUS_ERROR(req));
+		break;
+
+	case PSMX2_TRECV_CONTEXT:
+		if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(req))) &&
+				 !psmx2_handle_sendv_req(ep, req, 0))) {
+			return 0;
+		}
+		if (ep->recv_cq) {
+			op_context = fi_context;
+			buf = PSMX2_CTXT_USER(fi_context);
+			data = 0;
+			if (PSMX2_HAS_IMM(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(req)))) {
+				flags |= FI_REMOTE_CQ_DATA;
+				data = PSMX2_GET_CQDATA(PSMX2_STATUS_TAG(req));
+			}
+			err = psmx2_cq_rx_complete(
+					status_data->poll_cq, ep->recv_cq, ep->av,
+					req, op_context, buf, flags, data,
+					entry, status_data->src_addr, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->recv_cntr)
+			psmx2_cntr_inc(ep->recv_cntr, PSMX2_STATUS_ERROR(req));
+		break;
+
+	case PSMX2_NOCOMP_RECV_CONTEXT:
+		if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(req))) &&
+				 !psmx2_handle_sendv_req(ep, req, 0))) {
+			PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
+			return 0;
+		}
+		PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
+		if (OFI_UNLIKELY(ep->recv_cq && PSMX2_STATUS_ERROR(req))) {
+			data = 0;
+			if (PSMX2_HAS_IMM(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(req)))) {
+				flags |= FI_REMOTE_CQ_DATA;
+				data = PSMX2_GET_CQDATA(PSMX2_STATUS_TAG(req));
+			}
+			err = psmx2_cq_rx_complete(
+					status_data->poll_cq, ep->recv_cq, ep->av,
+					req, NULL, NULL, flags, data,
+					entry, status_data->src_addr, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->recv_cntr)
+			psmx2_cntr_inc(ep->recv_cntr, PSMX2_STATUS_ERROR(req));
+		break;
+
+	case PSMX2_NOCOMP_TRECV_CONTEXT:
+		if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(req))) &&
+				 !psmx2_handle_sendv_req(ep, req, 0))) {
+			PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
+			return 0;
+		}
+		PSMX2_EP_PUT_OP_CONTEXT(ep, fi_context);
+		if (OFI_UNLIKELY(ep->recv_cq && PSMX2_STATUS_ERROR(req))) {
+			err = psmx2_cq_rx_complete(
+					status_data->poll_cq, ep->recv_cq, ep->av,
+					req, NULL, NULL, flags, 0,
+					entry, status_data->src_addr, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->recv_cntr)
+			psmx2_cntr_inc(ep->recv_cntr, PSMX2_STATUS_ERROR(req));
+		break;
+
+	case PSMX2_WRITE_CONTEXT:
+		am_req = container_of(fi_context, struct psmx2_am_request,
+					  fi_context);
+		op_context = PSMX2_CTXT_USER(fi_context);
+		free(am_req->tmpbuf);
+		psmx2_am_request_free(status_data->trx_ctxt, am_req);
+		if (ep->send_cq) {
+			err = psmx2_cq_tx_complete(
+					status_data->poll_cq, ep->send_cq, ep->av,
+					req, op_context, NULL, flags, 0,
+					entry, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->write_cntr)
+			psmx2_cntr_inc(ep->write_cntr, PSMX2_STATUS_ERROR(req));
+		break;
+
+	case PSMX2_NOCOMP_WRITE_CONTEXT:
+		am_req = container_of(fi_context, struct psmx2_am_request,
+					  fi_context);
+		op_context = PSMX2_CTXT_USER(fi_context);
+		free(am_req->tmpbuf);
+		psmx2_am_request_free(status_data->trx_ctxt, am_req);
+		if (OFI_UNLIKELY(ep->send_cq && PSMX2_STATUS_ERROR(req))) {
+			err = psmx2_cq_tx_complete(
+					status_data->poll_cq, ep->send_cq, ep->av,
+					req, op_context, NULL, flags, 0,
+					entry, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->write_cntr)
+			psmx2_cntr_inc(ep->write_cntr, PSMX2_STATUS_ERROR(req));
+		break;
+
+	case PSMX2_READ_CONTEXT:
+		am_req = container_of(fi_context, struct psmx2_am_request,
+					  fi_context);
+		if (OFI_UNLIKELY(am_req->op == PSMX2_AM_REQ_READV)) {
+			am_req->read.len_read += PSMX2_STATUS_RCVLEN(req);
+			if (am_req->read.len_read < am_req->read.len) {
+				FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
+					"readv: long protocol finishes early\n");
+				if (PSMX2_STATUS_ERROR(req))
+					am_req->error = psmx2_errno(PSMX2_STATUS_ERROR(req));
+				/* Request to be freed in AM handler */
+				return 0;
+			}
+		}
+		op_context = PSMX2_CTXT_USER(fi_context);
+		free(am_req->tmpbuf);
+		psmx2_am_request_free(status_data->trx_ctxt, am_req);
+		if (ep->send_cq) {
+			err = psmx2_cq_tx_complete(
+					status_data->poll_cq, ep->send_cq, ep->av,
+					req, op_context, NULL, flags, 0,
+					entry, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->read_cntr)
+			psmx2_cntr_inc(ep->read_cntr, PSMX2_STATUS_ERROR(req));
+		break;
+
+	case PSMX2_NOCOMP_READ_CONTEXT:
+		am_req = container_of(fi_context, struct psmx2_am_request,
+					  fi_context);
+		if (OFI_UNLIKELY(am_req->op == PSMX2_AM_REQ_READV)) {
+			am_req->read.len_read += PSMX2_STATUS_RCVLEN(req);
+			if (am_req->read.len_read < am_req->read.len) {
+				FI_INFO(&psmx2_prov, FI_LOG_EP_DATA,
+					"readv: long protocol finishes early\n");
+				if (PSMX2_STATUS_ERROR(req))
+					am_req->error = psmx2_errno(PSMX2_STATUS_ERROR(req));
+				/* Request to be freed in AM handler */
+				return 0;
+			}
+		}
+		op_context = PSMX2_CTXT_USER(fi_context);
+		free(am_req->tmpbuf);
+		psmx2_am_request_free(status_data->trx_ctxt, am_req);
+		if (OFI_UNLIKELY(ep->send_cq && PSMX2_STATUS_ERROR(req))) {
+			err = psmx2_cq_tx_complete(
+					status_data->poll_cq, ep->send_cq, ep->av,
+					req, op_context, NULL, flags, 0,
+					entry, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->read_cntr)
+			psmx2_cntr_inc(ep->read_cntr, PSMX2_STATUS_ERROR(req));
+		break;
+
+	case PSMX2_MULTI_RECV_CONTEXT:
+		if (OFI_UNLIKELY(PSMX2_IS_IOV_HEADER(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(req))) &&
+			!psmx2_handle_sendv_req(ep, req, 1))) {
+			return 0;
+		}
+		multi_recv_req = PSMX2_CTXT_USER(fi_context);
+		if (ep->recv_cq) {
+			op_context = fi_context;
+			buf = multi_recv_req->buf + multi_recv_req->offset;
+			data = 0;
+			if (PSMX2_HAS_IMM(PSMX2_GET_FLAGS(PSMX2_STATUS_TAG(req)))) {
+				flags |= FI_REMOTE_CQ_DATA;
+				data = PSMX2_GET_CQDATA(PSMX2_STATUS_TAG(req));
+			}
+			if (multi_recv_req->offset + PSMX2_STATUS_RCVLEN(req) +
+				multi_recv_req->min_buf_size > multi_recv_req->len)
+				flags |= FI_MULTI_RECV;	/* buffer used up */
+			err = psmx2_cq_rx_complete(
+					status_data->poll_cq, ep->recv_cq, ep->av,
+					req, op_context, buf, flags, data,
+					entry, status_data->src_addr, &event_saved);
+			if (OFI_UNLIKELY(err))
+				return err;
+		}
+		if (ep->recv_cntr)
+			psmx2_cntr_inc(ep->recv_cntr, PSMX2_STATUS_ERROR(req));
+
+		/* repost multi-recv buffer */
+		multi_recv_req->offset += PSMX2_STATUS_RCVLEN(req);
+		len_remaining = multi_recv_req->len - multi_recv_req->offset;
+		if (len_remaining >= multi_recv_req->min_buf_size) {
+			if (len_remaining > PSMX2_MAX_MSG_SIZE)
+				len_remaining = PSMX2_MAX_MSG_SIZE;
+			err = psm2_mq_irecv2(ep->rx->psm2_mq,
+						 multi_recv_req->src_addr, &multi_recv_req->tag,
+						 &multi_recv_req->tagsel, multi_recv_req->flag,
+						 multi_recv_req->buf + multi_recv_req->offset,
+						 len_remaining,
+						 (void *)fi_context, &psm2_req);
+			if (OFI_UNLIKELY(err != PSM2_OK))
+				return psmx2_errno(err);
+			PSMX2_CTXT_REQ(fi_context) = psm2_req;
+		} else {
+			free(multi_recv_req);
+		}
+		break;
+
+	case PSMX2_REMOTE_WRITE_CONTEXT:
+		am_req = container_of(fi_context, struct psmx2_am_request, fi_context);
+		if (am_req->op & PSMX2_AM_FORCE_ACK) {
+			am_req->error = psmx2_errno(PSMX2_STATUS_ERROR(req));
+			psmx2_am_ack_rma(am_req);
+		}
+
+		if (am_req->ep->recv_cq && (am_req->cq_flags & FI_REMOTE_CQ_DATA)) {
+			flags |= FI_REMOTE_CQ_DATA;
+			err = psmx2_cq_rx_complete(
+					status_data->poll_cq, am_req->ep->recv_cq, am_req->ep->av,
+					req, NULL, NULL, flags, am_req->write.data,
+					entry, status_data->src_addr, &event_saved);
+			if (OFI_UNLIKELY(err)) {
+				psmx2_am_request_free(status_data->trx_ctxt, am_req);
+				return err;
+			}
+		}
+
+		if (am_req->ep->caps & FI_RMA_EVENT) {
+			if (am_req->ep->remote_write_cntr)
+				psmx2_cntr_inc(am_req->ep->remote_write_cntr, 0);
+
+			mr = PSMX2_CTXT_USER(fi_context);
+			if (mr->cntr && mr->cntr != am_req->ep->remote_write_cntr)
+				psmx2_cntr_inc(mr->cntr, 0);
+		}
+
+		/* NOTE: am_req->tmpbuf is unused here */
+		psmx2_am_request_free(status_data->trx_ctxt, am_req);
+		break;
+
+	case PSMX2_REMOTE_READ_CONTEXT:
+		am_req = container_of(fi_context, struct psmx2_am_request, fi_context);
+		if (am_req->ep->caps & FI_RMA_EVENT) {
+			if (am_req->ep->remote_read_cntr)
+				psmx2_cntr_inc(am_req->ep->remote_read_cntr, 0);
+		}
+
+		/* NOTE: am_req->tmpbuf is unused here */
+		psmx2_am_request_free(status_data->trx_ctxt, am_req);
+		break;
+
+	case PSMX2_SENDV_CONTEXT:
+		sendv_req = PSMX2_CTXT_USER(fi_context);
+		sendv_req->iov_done++;
+		if (sendv_req->iov_protocol == PSMX2_IOV_PROTO_MULTI &&
+			sendv_req->iov_done < sendv_req->iov_info.count + 1) {
+			sendv_req->tag = req->tag;
+			return 0;
+		}
+		if (ep->send_cq && !sendv_req->no_completion) {
+			op_context = sendv_req->user_context;
+			flags |= sendv_req->comp_flag;
+			err = psmx2_cq_tx_complete(
+					status_data->poll_cq, ep->send_cq, ep->av,
+					req, op_context, NULL, flags, 0,
+					entry, &event_saved);
+			if (OFI_UNLIKELY(err)) {
+				free(sendv_req);
+				return err;
+			}
+		}
+		if (ep->send_cntr)
+			psmx2_cntr_inc(ep->send_cntr, PSMX2_STATUS_ERROR(req));
+		free(sendv_req);
+		break;
+
+	case PSMX2_IOV_SEND_CONTEXT:
+		sendv_req = PSMX2_CTXT_USER(fi_context);
+		sendv_req->iov_done++;
+		if (sendv_req->iov_done < sendv_req->iov_info.count + 1)
+			return 0;
+		req->tag = sendv_req->tag;
+		if (ep->send_cq && !sendv_req->no_completion) {
+			op_context = sendv_req->user_context;
+			flags |= sendv_req->comp_flag;
+			err = psmx2_cq_tx_complete(
+					status_data->poll_cq, ep->send_cq, ep->av,
+					req, op_context, NULL, flags, 0,
+					entry, &event_saved);
+			if (OFI_UNLIKELY(err)) {
+				free(sendv_req);
+				return err;
+			}
+		}
+		if (ep->send_cntr)
+			psmx2_cntr_inc(ep->send_cntr, PSMX2_STATUS_ERROR(req));
+		free(sendv_req);
+		break;
+
+	case PSMX2_IOV_RECV_CONTEXT:
+		sendv_rep = PSMX2_CTXT_USER(fi_context);
+		sendv_rep->iov_done++;
+		sendv_rep->msg_length += PSMX2_STATUS_SNDLEN(req);
+		sendv_rep->bytes_received += PSMX2_STATUS_RCVLEN(req);
+		if (PSMX2_STATUS_ERROR(req) != PSM2_OK)
+			sendv_rep->error_code = PSMX2_STATUS_ERROR(req);
+		if (sendv_rep->iov_done < sendv_rep->iov_info.count)
+			return 0;
+
+		PSMX2_STATUS_TAG(req) = sendv_rep->tag;
+		PSMX2_STATUS_RCVLEN(req) = sendv_rep->bytes_received;
+		PSMX2_STATUS_SNDLEN(req) = sendv_rep->msg_length;
+		PSMX2_STATUS_ERROR(req) = sendv_rep->error_code;
+
+		if (ep->recv_cq && !sendv_rep->no_completion) {
+			op_context = sendv_rep->user_context;
+			buf = sendv_rep->buf;
+			flags |= sendv_rep->comp_flag;
+			err = psmx2_cq_rx_complete(
+					status_data->poll_cq, ep->recv_cq, ep->av,
+					req, op_context, buf, flags, 0,
+					entry, status_data->src_addr, &event_saved);
+			if (OFI_UNLIKELY(err)) {
+				free(sendv_rep);
+				return err;
+			}
+		}
+		if (ep->recv_cntr)
+			psmx2_cntr_inc(ep->recv_cntr, PSMX2_STATUS_ERROR(req));
+
+		if (sendv_rep->multi_recv) {
+			/* repost the multi-recv buffer */
+			fi_context = sendv_rep->user_context;
+			multi_recv_req = PSMX2_CTXT_USER(fi_context);
+			multi_recv_req->offset += PSMX2_STATUS_RCVLEN(req);
+			len_remaining = multi_recv_req->len - multi_recv_req->offset;
+			if (len_remaining >= multi_recv_req->min_buf_size) {
+				if (len_remaining > PSMX2_MAX_MSG_SIZE)
+					len_remaining = PSMX2_MAX_MSG_SIZE;
+				err = psm2_mq_irecv2(ep->rx->psm2_mq,
+							 multi_recv_req->src_addr, &multi_recv_req->tag,
+							 &multi_recv_req->tagsel, multi_recv_req->flag,
+							 multi_recv_req->buf + multi_recv_req->offset,
+							 len_remaining,
+							 (void *)fi_context, &psm2_req);
+				if (OFI_UNLIKELY(err != PSM2_OK)) {
+					free(sendv_rep);
+					return psmx2_errno(err);
+				}
+				PSMX2_CTXT_REQ(fi_context) = psm2_req;
+			} else {
+				free(multi_recv_req);
+			}
+		}
+
+		free(sendv_rep);
+		break;
+	}
+
+	return event_saved;
+}
+
+int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
+		     struct psmx2_trx_ctxt *trx_ctxt,
+		     struct psmx2_cq_event *event_in,
+		     int count, fi_addr_t *src_addr)
+{
+	struct psmx2_status_data status_data;
+
+	/* psm2_mq_ipeek_dequeue_multi needs non-zero count to make progress */
+	if (!count) {
+		event_in = NULL;
+		count = 1;
+	}
+
+	status_data.poll_cq = cq;
+	status_data.event_buffer = event_in;
+	status_data.src_addr = src_addr;
+	status_data.trx_ctxt = trx_ctxt;
+
+	psm2_mq_ipeek_dequeue_multi(trx_ctxt->psm2_mq, &status_data,
+			psmx2_mq_status_copy, &count);
+	return count;
+}
+
+#else /* !HAVE_PSM2_MQ_REQ_USER */
+
 /*
  * Translate "status" into completion event. A few factors determine where to
  * save the event.
@@ -352,27 +1034,6 @@ static inline int psmx2_cq_rx_complete(struct psmx2_fid_cq *poll_cq,
 				     event_in, count, read_count,
 				     read_more, src_addr, 1);
 }
-
-static uint64_t psmx2_comp_flags[PSMX2_MAX_CONTEXT_TYPE] = {
-	[PSMX2_NOCOMP_SEND_CONTEXT]	= FI_SEND | FI_MSG,
-	[PSMX2_NOCOMP_RECV_CONTEXT]	= FI_RECV | FI_MSG,
-	[PSMX2_NOCOMP_TSEND_CONTEXT]	= FI_SEND | FI_TAGGED,
-	[PSMX2_NOCOMP_TRECV_CONTEXT]	= FI_RECV | FI_TAGGED,
-	[PSMX2_NOCOMP_WRITE_CONTEXT]	= FI_WRITE | FI_RMA,
-	[PSMX2_NOCOMP_READ_CONTEXT]	= FI_READ | FI_RMA,
-	[PSMX2_SEND_CONTEXT]		= FI_SEND | FI_MSG,
-	[PSMX2_RECV_CONTEXT]		= FI_RECV | FI_MSG,
-	[PSMX2_MULTI_RECV_CONTEXT]	= FI_RECV | FI_MSG,
-	[PSMX2_TSEND_CONTEXT]		= FI_SEND | FI_TAGGED,
-	[PSMX2_TRECV_CONTEXT]		= FI_RECV | FI_TAGGED,
-	[PSMX2_WRITE_CONTEXT]		= FI_WRITE | FI_RMA,
-	[PSMX2_READ_CONTEXT]		= FI_READ | FI_RMA,
-	[PSMX2_REMOTE_WRITE_CONTEXT]	= FI_REMOTE_WRITE | FI_RMA,
-	[PSMX2_REMOTE_READ_CONTEXT]	= FI_REMOTE_READ | FI_RMA,
-	[PSMX2_SENDV_CONTEXT]		= FI_SEND,
-	[PSMX2_IOV_SEND_CONTEXT]	= FI_SEND,
-	[PSMX2_IOV_RECV_CONTEXT]	= FI_RECV,
-};
 
 int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 		     struct psmx2_trx_ctxt *trx_ctxt,
@@ -944,6 +1605,7 @@ int psmx2_cq_poll_mq(struct psmx2_fid_cq *cq,
 
 	return read_count;
 }
+#endif
 
 DIRECT_FN
 STATIC ssize_t psmx2_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
@@ -977,7 +1639,7 @@ STATIC ssize_t psmx2_cq_readfrom(struct fid_cq *cq, void *buf, size_t count,
 		}
 	}
 
-	if (cq_priv->pending_error)
+	if (OFI_UNLIKELY(cq_priv->pending_error != NULL))
 		return -FI_EAVAIL;
 
 	assert(buf || !count);

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -340,7 +340,9 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 	if (!req)
 		return -FI_ENOMEM;
 
+#if !HAVE_PSM2_MQ_REQ_USER
 	PSMX2_STATUS_INIT(req->status);
+#endif
 
 	if (total_len <= PSMX2_IOV_BUF_SIZE) {
 		req->iov_protocol = PSMX2_IOV_PROTO_PACK;

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -952,7 +952,9 @@ ssize_t psmx2_tagged_sendv_generic(struct fid_ep *ep,
 	if (!req)
 		return -FI_ENOMEM;
 
+#if !HAVE_PSM2_MQ_REQ_USER
 	PSMX2_STATUS_INIT(req->status);
+#endif
 
 	if (total_len <= PSMX2_IOV_BUF_SIZE) {
 		req->iov_protocol = PSMX2_IOV_PROTO_PACK;

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -40,8 +40,6 @@
 #ifdef VALGRIND_MAKE_MEM_DEFINED
 #undef VALGRIND_MAKE_MEM_DEFINED
 #endif
-#define PSM_IS_TEST /* keep plain malloc/realloc/calloc/memalign/free/strdup */
-#include "psm2/psm_mq_internal.h"
 #else
 #include <psm2.h>
 #include <psm2_mq.h>
@@ -55,34 +53,22 @@
 #define PSMX2_DEFAULT_UUID	"00FF00FF-0000-0000-0000-00FF00FF00FF"
 #define PROVIDER_INI		PSM2_INI
 
-#if HAVE_PSM2_SRC
+#if HAVE_PSM2_MQ_REQ_USER
 
 #ifndef PSMX2_USE_REQ_CONTEXT
 #define PSMX2_USE_REQ_CONTEXT	1
 #endif
 
 #define PSMX2_MQ_REQ_USER(s)	((struct psm2_mq_req_user *)(s))
+#define PSMX2_STATUS_TYPE	struct psm2_mq_req_user
+#define PSMX2_STATUS_ERROR(s)	((s)->error_code)
+#define PSMX2_STATUS_TAG(s)	((s)->tag)
+#define PSMX2_STATUS_RCVLEN(s)	((s)->recv_msglen)
+#define PSMX2_STATUS_SNDLEN(s)	((s)->send_msglen)
+#define PSMX2_STATUS_PEER(s)	((s)->peer)
+#define PSMX2_STATUS_CONTEXT(s)	((s)->context)
 
-#define PSMX2_STATUS_TYPE	struct psm2_mq_req
-#define PSMX2_STATUS_DECL(s)	struct psm2_mq_req *s
-#define PSMX2_STATUS_INIT(s)
-#define PSMX2_STATUS_SAVE(s,t)	do { t = s; } while (0)
-#define PSMX2_STATUS_ERROR(s)	(PSMX2_MQ_REQ_USER(s)->error_code)
-#define PSMX2_STATUS_TAG(s)	(PSMX2_MQ_REQ_USER(s)->tag)
-#define PSMX2_STATUS_RCVLEN(s)	(PSMX2_MQ_REQ_USER(s)->recv_msglen)
-#define PSMX2_STATUS_SNDLEN(s)	(PSMX2_MQ_REQ_USER(s)->send_msglen)
-#define PSMX2_STATUS_PEER(s)	(PSMX2_MQ_REQ_USER(s)->peer)
-#define PSMX2_STATUS_CONTEXT(s)	(PSMX2_MQ_REQ_USER(s)->context)
-
-#define PSMX2_POLL_COMPLETION(trx_ctxt, status, err) \
-	do { \
-		(err) = psm2_mq_ipeek_dequeue((trx_ctxt)->psm2_mq, &(status)); \
-	} while (0)
-
-#define PSMX2_FREE_COMPLETION(trx_ctxt, status) \
-	psm2_mq_req_free((trx_ctxt)->psm2_mq, status)
-
-#else /* !HAVE_PSM2_SRC */
+#else /* !HAVE_PSM2_MQ_REQ_USER */
 
 #ifdef PSMX2_USE_REQ_CONTEXT
 #undef PSMX2_USE_REQ_CONTEXT
@@ -122,8 +108,7 @@
 
 #define PSMX2_FREE_COMPLETION(trx_ctxt, status)
 
-#endif /* HAVE_PSM2_SRC */
-
+#endif
 /*
  * Provide backward compatibility for older PSM2 libraries that lack the
  * psm2_am_register_handlers_2 function.
@@ -170,7 +155,7 @@ psm2_error_t psm2_am_register_handlers_2(
 #endif /* !HAVE_PSM2_AM_REGISTER_HANDLERS_2 */
 
 /*
- * Use reserved space within psm2_mq_req for fi_context instead of
+ * Use reserved space within psm2_mq_req_user for fi_context instead of
  * allocating from a internal queue.
  *
  * Only work when compiled with PSM2 source. Can be turned off by


### PR DESCRIPTION
-Updated PSM2 MQ to CQE conversion to use a new function psm2_mq_ipeek_dequeue_multi
which allows for a callback to be used to process the MQ entries into CQE events
to pass back to the user.

-PSM2 status structure now defaulted to psm2_mq_req_user with the structure being
exported by libpsm2 for reading by users.

-New callback function psmx2_mq_status_copy performs conversion of MQ request to
CQE event.

-New struct psmx2_status_data, is used to pass the user's event buffer along with
 the poll CQ, src_addr, & trx_ctx to PSM2 for use in the callback when processing
 each MQ request.

-All conditionals now assume the most common path will be when the user's event buffer
 is used to store the events.

-psmx2_cq_any_complete updated to reduce branches given the most common
 usecases by customers.

-Added configure option HAVE_PSM2_MQ_REQ_USER to check if the libpsm2
being built includes psm2_mq_req_user & psm2_mq_ipeek_dequeue_multi.

-Added ifdefs to fall back to old CQ functionality support given libpsm2
does not include the required symbols.

Signed-off-by: Spruit, Neil R <neil.r.spruit@intel.com>