### PR TITLE
prov/rxm: Correct pad in RXM wire protocol structure (#35)

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -136,7 +136,7 @@ struct rxm_ep_wire_proto {
 	uint8_t	ctrl_version;
 	uint8_t	op_version;
 	uint8_t endianness;
-	uint8_t padding[6];
+	uint8_t padding[5];
 	uint64_t eager_size;
 };
 


### PR DESCRIPTION
@shefty - This patch corrects the RxM wire protocol pad value that caused a wasteful alignment. The Verbs experimental XRC implementation uses some of the wasted space in implementing the sharing of XRC QP.

I was not sure if the RXM_CTRL_VERSION was the right thing to bump, but it seems like a version must be bumped to detect the differences in the structure alignment.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>