### PR TITLE
prov/gni: Signal wait set if error entry is added to CQ

### DIFF
--- a/prov/gni/src/gnix_cq.c
+++ b/prov/gni/src/gnix_cq.c
@@ -351,6 +351,9 @@ ssize_t _gnix_cq_add_error(struct gnix_fid_cq *cq, void *op_context,
 
 	_gnix_queue_enqueue(cq->errors, &event->item);
 
+	if (cq->wait)
+		_gnix_signal_wait_obj(cq->wait);
+
 err:
 	COND_RELEASE(cq->requires_lock, &cq->lock);
 


### PR DESCRIPTION
When using gni with FI_SOURCE/FI_SOURCE_ERR and wait sets, adding an error entry (with the source addr information) to the completion queue was not signaled. Therefore, we were always waiting in the wait set. This fix should probably be backported to other release branches.