### PR TITLE
Re-working of hooking providers

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -101,10 +101,16 @@ enum {
 int ofi_cpu_supports(unsigned func, unsigned reg, unsigned bit);
 
 
-/* Restrict to size of struct fi_context */
+enum ofi_prov_type {
+	OFI_PROV_CORE,
+	OFI_PROV_UTIL,
+	OFI_PROV_HOOK,
+};
+
+/* Restrict to size of struct fi_provider::context (struct fi_context) */
 struct fi_prov_context {
+	enum ofi_prov_type type;
 	int disable_logging;
-	int is_util_prov;
 };
 
 struct fi_filter {

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -129,12 +129,15 @@ int ofi_nic_close(struct fid *fid);
 struct fid_nic *ofi_nic_dup(const struct fid_nic *nic);
 int ofi_nic_tostr(const struct fid *fid_nic, char *buf, size_t len);
 
+struct fi_provider *ofi_get_hook(const char *name);
+
 void fi_log_init(void);
 void fi_log_fini(void);
 void fi_param_init(void);
 void fi_param_fini(void);
 void fi_param_undefine(const struct fi_provider *provider);
 void ofi_hook_init(void);
+void ofi_hook_fini(void);
 void ofi_hook_install(struct fid_fabric *hfabric, struct fid_fabric **fabric,
 		      struct fi_provider *prov);
 

--- a/include/ofi_prov.h
+++ b/include/ofi_prov.h
@@ -228,4 +228,12 @@ RSTREAM_INI ;
 #  define RSTREAM_INIT NULL
 #endif
 
+#  define PERF_HOOK_INI INI_SIG(fi_perf_hook_ini)
+#  define PERF_HOOK_INIT fi_perf_hook_ini()
+PERF_HOOK_INI ;
+
+#  define NOOP_HOOK_INI INI_SIG(fi_noop_hook_ini)
+#  define NOOP_HOOK_INIT fi_noop_hook_ini()
+NOOP_HOOK_INI ;
+
 #endif /* _OFI_PROV_H_ */

--- a/man/fi_hook.7.md
+++ b/man/fi_hook.7.md
@@ -19,9 +19,16 @@ selected calls or debugging information.
 # SUPPORTED FEATURES
 
 Hooking support is enabled through the FI_HOOK environment variable.  To
-enable hooking, FI_HOOK must be set to one of the following values:
+enable hooking, FI_HOOK must be set to the name of one or more of the
+available hooking providers.  When multiple hooks are specified, the
+names must be separated by a semi-colon.  To obtain a list of hooking
+providers available on the current system, one can use the fi_info
+utility with the '--env' command line option.  Hooking providers are
+usually identified by 'hook' appearing in the provider name.
 
-*perf*
+Known hooking providers include the following:
+
+*ofi_perf_hook*
 : This hooks 'fast path' data operation calls.  Performance data is
   captured on call entrance and exit, in order to provide an average of
   how long each call takes to complete.  See the PERFORMANCE HOOKS section

--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -34,12 +34,14 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <ofi.h>
+
 #include "hook.h"
 #include "hook_perf.h"
+#include "ofi_prov.h"
 
 
-static uint8_t hooks_enabled[MAX_HOOKS];
-static uint8_t num_hooks_enabled;
+static char **hooks;
+static size_t hook_cnt;
 
 
 struct fid *hook_to_hfid(const struct fid *fid)
@@ -153,7 +155,7 @@ static int hook_fabric_close(struct fid *fid)
 	fab = container_of(fid, struct hook_fabric, fabric.fid);
 	switch (fab->hclass) {
 	case HOOK_PERF:
-		hook_perf_destroy(fab);
+		perf_hook_destroy(fab);
 		break;
 	default:
 		break;
@@ -186,59 +188,80 @@ static struct fi_ops_fabric hook_fabric_ops = {
 	.trywait = hook_trywait,
 };
 
-static int hook_fabric(struct fid_fabric *hfabric, struct fid_fabric **fabric,
-			enum ofi_hook_class hclass, struct fi_provider *prov)
+void hook_fabric_init(struct hook_fabric *fabric, enum ofi_hook_class hclass,
+		      struct fid_fabric *hfabric, struct fi_provider *hprov)
 {
+	fabric->hclass = hclass;
+	fabric->hfabric = hfabric;
+	fabric->prov = hprov;
+	fabric->fabric.fid.fclass = FI_CLASS_FABRIC;
+	fabric->fabric.fid.context = hfabric->fid.context;
+	fabric->fabric.fid.ops = &hook_fabric_fid_ops;
+	fabric->fabric.api_version = hfabric->api_version;
+	fabric->fabric.ops = &hook_fabric_ops;
+
+	hfabric->fid.context = fabric;
+}
+
+static int noop_hook_fabric(struct fi_fabric_attr *attr,
+			    struct fid_fabric **fabric, void *context)
+{
+	struct fi_provider *hprov = context;
 	struct hook_fabric *fab;
-	int ret = 0;
 
-	switch (hclass) {
-	case HOOK_NOOP:
-		FI_TRACE(prov, FI_LOG_FABRIC, "Installing noop hook\n");
-		fab = calloc(1, sizeof *fab);
-		if (!fab)
-			return -FI_ENOMEM;
-		fab->prov = prov;
-		break;
-	case HOOK_PERF:
-		FI_TRACE(prov, FI_LOG_FABRIC, "Installing perf hook\n");
-		ret = hook_perf_create(&fab, prov);
-		break;
-	default:
-		FI_WARN(&core_prov, FI_LOG_FABRIC, "Invalid hook specified\n");
-		return -FI_ENOSYS;
-	}
+	FI_TRACE(hprov, FI_LOG_FABRIC, "Installing noop hook\n");
+	fab = calloc(1, sizeof *fab);
+	if (!fab)
+		return -FI_ENOMEM;
 
-	if (ret)
-		return ret;
-
-	fab->hclass = hclass;
-	fab->hfabric = hfabric;
-	fab->fabric.fid.fclass = FI_CLASS_FABRIC;
-	fab->fabric.fid.context = hfabric->fid.context;
-	fab->fabric.fid.ops = &hook_fabric_fid_ops;
-	fab->fabric.api_version = hfabric->api_version;
-	fab->fabric.ops = &hook_fabric_ops;
-
-	hfabric->fid.context = fab;
+	hook_fabric_init(fab, HOOK_NOOP, attr->fabric, hprov);
 	*fabric = &fab->fabric;
 	return 0;
 }
 
+struct fi_provider noop_hook_prov = {
+	.version = FI_VERSION(1,0),
+	/* We're a pass-through provider, so the fi_version is always the latest */
+	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+	.name = "ofi_noop_hook",
+	.getinfo = NULL,
+	.fabric = noop_hook_fabric,
+	.cleanup = NULL,
+};
+
+NOOP_HOOK_INI
+{
+	return &noop_hook_prov;
+}
+
+/*
+ * Call the fabric() interface of the hooking provider.  We pass in the
+ * fabric being hooked via the fabric attributes and the corresponding
+ * fi_provider structure as the context.
+ */
 void ofi_hook_install(struct fid_fabric *hfabric, struct fid_fabric **fabric,
 		      struct fi_provider *prov)
 {
-	int hook, ret;
+	struct fi_provider *hook_prov;
+	struct fi_fabric_attr attr;
+	int i, ret;
 
 	*fabric = hfabric;
-	if (!num_hooks_enabled)
+	if (!hook_cnt || !hooks)
 		return;
 
-	for (hook = 0; hook < num_hooks_enabled; hook++) {
-		ret = hook_fabric(hfabric, fabric,
-				  hooks_enabled[hook], prov);
+	memset(&attr, 0, sizeof attr);
+
+	for (i = 0; i < hook_cnt; i++) {
+		hook_prov = ofi_get_hook(hooks[i]);
+		if (!hook_prov)
+			continue;
+
+		attr.fabric = hfabric;
+		ret = hook_prov->fabric(&attr, fabric, prov);
 		if (ret)
-			return;
+			continue;
+
 		hfabric = *fabric;
 	}
 }
@@ -246,9 +269,6 @@ void ofi_hook_install(struct fid_fabric *hfabric, struct fid_fabric **fabric,
 void ofi_hook_init(void)
 {
 	char *param_val = NULL;
-	char **strv;
-	int i;
-	size_t cnt;
 
 	fi_param_define(NULL, "hook", FI_PARAM_STRING,
 			"Intercept calls to underlying provider and apply "
@@ -256,32 +276,14 @@ void ofi_hook_init(void)
 			"perf (gather performance data)");
 	fi_param_get_str(NULL, "hook", &param_val);
 
-	num_hooks_enabled = 0;
 	if (!param_val)
 		return;
 
-	strv = ofi_split_and_alloc(param_val, ";", &cnt);
-	if (!strv)
-		return;
+	hooks = ofi_split_and_alloc(param_val, ";", &hook_cnt);
+}
 
-	if (cnt > MAX_HOOKS) {
-		FI_WARN(&core_prov, FI_LOG_FABRIC, "Requested more hooks than "
-			"known, only processing %d\n", MAX_HOOKS);
-		cnt = MAX_HOOKS;
-	}
-
-	for (i = 0; i< cnt; i++) {
-		if (!strcmp(strv[i], "noop")) {
-			FI_INFO(&core_prov, FI_LOG_CORE, "Noop hook requested\n");
-			hooks_enabled[num_hooks_enabled] = HOOK_NOOP;
-			num_hooks_enabled++;
-
-		} else if (!strcmp(strv[i], "perf")) {
-			FI_INFO(&core_prov, FI_LOG_CORE, "Perf hook requested\n");
-			hooks_enabled[num_hooks_enabled] = HOOK_PERF;
-			num_hooks_enabled++;
-		}
-	}
-
-	ofi_free_string_array(strv);
+void ofi_hook_fini(void)
+{
+	if (hooks)
+		ofi_free_string_array(hooks);
 }

--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -187,7 +187,7 @@ static struct fi_ops_fabric hook_fabric_ops = {
 };
 
 static int hook_fabric(struct fid_fabric *hfabric, struct fid_fabric **fabric,
-			enum hook_class hclass, struct fi_provider *prov)
+			enum ofi_hook_class hclass, struct fi_provider *prov)
 {
 	struct hook_fabric *fab;
 	int ret = 0;

--- a/prov/hook/src/hook.h
+++ b/prov/hook/src/hook.h
@@ -49,7 +49,7 @@
  * Hooks are installed from top down.
  * Values must start at 0 and increment by one.
  */
-enum hook_class {
+enum ofi_hook_class {
 	HOOK_NOOP,
 	HOOK_PERF,
 	MAX_HOOKS
@@ -68,7 +68,7 @@ struct fid_wait *hook_to_hwait(const struct fid_wait *wait);
 struct hook_fabric {
 	struct fid_fabric	fabric;
 	struct fid_fabric	*hfabric;
-	enum hook_class		hclass;
+	enum ofi_hook_class	hclass;
 	struct fi_provider	*prov;
 };
 

--- a/prov/hook/src/hook.h
+++ b/prov/hook/src/hook.h
@@ -44,6 +44,8 @@
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 
+#include <rdma/providers/fi_prov.h>
+
 
 /*
  * Hooks are installed from top down.
@@ -54,6 +56,7 @@ enum ofi_hook_class {
 	HOOK_PERF,
 	MAX_HOOKS
 };
+
 
 /*
  * Define hook structs so we can cast from fid to parent using simple cast.
@@ -71,6 +74,9 @@ struct hook_fabric {
 	enum ofi_hook_class	hclass;
 	struct fi_provider	*prov;
 };
+
+void hook_fabric_init(struct hook_fabric *fabric, enum ofi_hook_class hclass,
+		      struct fid_fabric *hfabric, struct fi_provider *hprov);
 
 
 struct hook_domain {

--- a/prov/hook/src/hook_ep.c
+++ b/prov/hook/src/hook_ep.c
@@ -87,7 +87,7 @@ static struct fi_ops_ep hook_ep_ops = {
 };
 
 
-static void hook_setup_ep(enum hook_class hclass, struct fid_ep *ep,
+static void hook_setup_ep(enum ofi_hook_class hclass, struct fid_ep *ep,
 			  int fclass, void *context)
 {
 	ep->fid.fclass = fclass;

--- a/prov/hook/src/hook_perf.h
+++ b/prov/hook/src/hook_perf.h
@@ -43,8 +43,7 @@ struct perf_fabric {
 	struct ofi_perfset perf_set;
 };
 
-int hook_perf_create(struct hook_fabric **fabric, struct fi_provider *prov);
-void hook_perf_destroy(struct hook_fabric *fabric);
+void perf_hook_destroy(struct hook_fabric *fabric);
 
 
 #define HOOK_FOREACH(DECL)		\


### PR DESCRIPTION
This series re-works how hooking providers are published and accessed by the core.  Hooking providers now register the same as other providers.  That is, they publish a struct fi_provider with the core.  Hooking providers are identified by the lack of support for getinfo().  This change will allow external providers to be used as hooks.  It also provides a mechanism to programmatically report what hooks are available in the current libfabric install.

Hooks are still identified using a string name.  The name can either be the provider name (e.g. ofi_perf_hook) or a shortened version of the provider name (e.g. perf).  Shortened names are expanded by prefixing with 'ofi_' and suffixing with '_hook'.  This provides backwards compatibility with previous names.

Hooks are now installed by calling the hooking provider's fabric() interface.  The underlying fabric being hooked is passed in as the fi_fabric_attr::fabric field.  And the hooked provider is given as the context parameter.