### PR TITLE
Update for mr_test

### DIFF
--- a/fabtests/unit/mr_test.c
+++ b/fabtests/unit/mr_test.c
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
 
 	hints->mode = ~0;
 	hints->domain_attr->mode = ~0;
-	hints->domain_attr->mr_mode = ~(FI_MR_BASIC | FI_MR_SCALABLE);
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
 
 	hints->caps |= FI_MSG | FI_RMA;
 


### PR DESCRIPTION
 - Patch includes change for the mr_mode
   because of changes in libfabric
   documentation for scalable memory
   registration for version 1.5 and later.

Signed-off-by: Aleksandra Justa <aleksandra.justa@intel.com>