### PR TITLE
fabric/headers: Include sys/uio.h in files that reference iovec

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -114,6 +114,7 @@ struct fi_rma_iov remote;
 struct ft_opts opts;
 
 struct test_size_param test_size[] = {
+	{ 1 <<  0, 0 },
 	{ 1 <<  1, 0 }, { (1 <<  1) + (1 <<  0), 0 },
 	{ 1 <<  2, 0 }, { (1 <<  2) + (1 <<  1), 0 },
 	{ 1 <<  3, 0 }, { (1 <<  3) + (1 <<  2), 0 },

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -37,6 +37,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <sys/types.h>
+#include <sys/uio.h>
 
 #ifdef __GNUC__
 #define FI_DEPRECATED_FUNC __attribute__((deprecated))


### PR DESCRIPTION
Include a necessary header file for struct iovec.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>