### PR TITLE
util/buf: Allocate buffers with lowest index

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -277,29 +277,38 @@ struct util_buf_attr {
 	void 				*ctx;
 	uint8_t				track_used;
 	uint8_t				is_mmap_region;
+	uint8_t				indexing;
 };
 
 struct util_buf_pool {
 	size_t 			entry_sz;
 	size_t 			num_allocated;
-	struct slist		buf_list;
+	union {
+		struct slist		buffers;
+		struct dlist_entry	regions;
+	} list;
 	struct util_buf_region	**regions_table;
 	size_t			regions_cnt;
 	struct util_buf_attr	attr;
 };
 
 struct util_buf_region {
-	struct slist_entry entry;
+	struct dlist_entry entry;
+	struct dlist_entry buf_list;
 	char *mem_region;
 	size_t size;
 	void *context;
+	struct util_buf_pool *pool;
 #ifndef NDEBUG
 	size_t num_used;
 #endif
 };
 
 struct util_buf_footer {
-	struct slist_entry entry;
+	union {
+		struct slist_entry slist;
+		struct dlist_entry dlist;
+	} entry;
 	struct util_buf_region *region;
 	size_t index;
 };
@@ -325,11 +334,6 @@ static inline int util_buf_pool_create(struct util_buf_pool **pool,
 				       NULL, NULL, NULL);
 }
 
-static inline int util_buf_avail(struct util_buf_pool *pool)
-{
-	return !slist_empty(&pool->buf_list);
-}
-
 int util_buf_grow(struct util_buf_pool *pool);
 
 static inline struct util_buf_footer *
@@ -348,8 +352,10 @@ static inline void *util_buf_get(struct util_buf_pool *pool)
 {
 	struct util_buf_footer *buf_ftr;
 
-	slist_remove_head_container(&pool->buf_list, struct util_buf_footer,
-				    buf_ftr, entry);
+	assert(!pool->attr.indexing);
+
+	slist_remove_head_container(&pool->list.buffers, struct util_buf_footer,
+				    buf_ftr, entry.slist);
 	assert(++buf_ftr->region->num_used);
 	return util_buf_get_data(pool, buf_ftr);
 }
@@ -357,18 +363,61 @@ static inline void *util_buf_get(struct util_buf_pool *pool)
 static inline void util_buf_release(struct util_buf_pool *pool, void *buf)
 {
 	assert(util_buf_get_ftr(pool, buf)->region->num_used--);
-	slist_insert_head(&util_buf_get_ftr(pool, buf)->entry, &pool->buf_list);
+	assert(!pool->attr.indexing);
+	slist_insert_head(&util_buf_get_ftr(pool, buf)->entry.slist, &pool->list.buffers);
+}
+
+static inline void *util_buf_indexed_get(struct util_buf_pool *pool)
+{
+	struct util_buf_footer *buf_ftr;
+	struct util_buf_region *buf_region;
+
+	assert(pool->attr.indexing);
+
+	buf_region = container_of(pool->list.regions.next,
+				  struct util_buf_region, entry);
+	dlist_pop_front(&buf_region->buf_list, struct util_buf_footer,
+			buf_ftr, entry.dlist);
+	assert(++buf_ftr->region->num_used);
+	if (dlist_empty(&buf_region->buf_list))
+		dlist_remove_init(&buf_region->entry);
+	return util_buf_get_data(pool, buf_ftr);
+}
+
+int util_buf_is_lower(struct dlist_entry *item, const void *arg);
+int util_buf_region_is_lower(struct dlist_entry *item, const void *arg);
+
+static inline void util_buf_indexed_release(struct util_buf_pool *pool, void *buf)
+{
+	struct util_buf_footer *buf_ftr;
+
+	assert(pool->attr.indexing);
+
+	buf_ftr = util_buf_get_ftr(pool, buf);
+
+	assert(buf_ftr->region->num_used--);
+
+	dlist_insert_order(&buf_ftr->region->buf_list,
+			   util_buf_is_lower, &buf_ftr->entry.dlist);
+
+	if (dlist_empty(&buf_ftr->region->entry)) {
+		dlist_insert_order(&pool->list.regions,
+				   util_buf_region_is_lower,
+				   &buf_ftr->region->entry);
+	}
 }
 
 static inline size_t util_get_buf_index(struct util_buf_pool *pool, void *buf)
 {
 	assert(util_buf_get_ftr(pool, buf)->region->num_used);
+	assert(pool->attr.indexing);
 	return util_buf_get_ftr(pool, buf)->index;
 }
 
 static inline void *util_buf_get_by_index(struct util_buf_pool *pool, size_t index)
 {
 	void *buf;
+	assert(pool->attr.indexing);
 	buf = pool->regions_table[(size_t)(index / pool->attr.chunk_cnt)]->
 		mem_region + (index % pool->attr.chunk_cnt) * pool->entry_sz;
 	assert(util_buf_get_ftr(pool, buf)->region->num_used);
@@ -380,37 +429,48 @@ static inline void *util_buf_get_ctx(struct util_buf_pool *pool, void *buf)
 	return util_buf_get_ftr(pool, buf)->region->context;
 }
 
-static inline void *util_buf_get_ex(struct util_buf_pool *pool, void **context)
+static inline int util_buf_avail(struct util_buf_pool *pool)
 {
-	void *buf;
-
-	buf = util_buf_get(pool);
-	*context = util_buf_get_ctx(pool, buf);
-	return buf;
+	return !slist_empty(&pool->list.buffers);
 }
 
-static inline void *util_buf_alloc(struct util_buf_pool *pool)
+static inline int util_buf_indexed_avail(struct util_buf_pool *pool)
 {
-	if (OFI_UNLIKELY(!util_buf_avail(pool))) {
-		if (util_buf_grow(pool))
-			return NULL;
-	}
-	return util_buf_get(pool);
+	return !dlist_empty(&pool->list.regions);
 }
 
-static inline void *util_buf_alloc_ex(struct util_buf_pool *pool, void **context)
-{
-	void *buf;
-
-	buf = util_buf_alloc(pool);
-	if (OFI_UNLIKELY(!buf))
-		return NULL;
-
-	assert(context);
-	*context = util_buf_get_ctx(pool, buf);
-	return buf;
+#define UTIL_BUF_DEFINE_GETTERS(name)						\
+static inline void *util_buf ## name ## get_ex(struct util_buf_pool *pool,	\
+					       void **context)			\
+{										\
+	void *buf = util_buf ## name ## get(pool);				\
+	assert(context);							\
+	*context = util_buf_get_ctx(pool, buf);					\
+	return buf;								\
+}										\
+										\
+static inline void *util_buf ## name ## alloc(struct util_buf_pool *pool)	\
+{										\
+	if (OFI_UNLIKELY(!util_buf ## name ## avail(pool))) {			\
+		if (util_buf_grow(pool))					\
+			return NULL;						\
+	}									\
+	return util_buf ## name ## get(pool);					\
+}										\
+										\
+static inline void *util_buf ## name ## alloc_ex(struct util_buf_pool *pool,	\
+						 void **context)		\
+{										\
+	void *buf = util_buf ## name ## alloc(pool);				\
+	if (OFI_UNLIKELY(!buf))							\
+		return NULL;							\
+	assert(context);							\
+	*context = util_buf_get_ctx(pool, buf);					\
+	return buf;								\
 }
 
+UTIL_BUF_DEFINE_GETTERS(_);
+UTIL_BUF_DEFINE_GETTERS(_indexed_);
 
 void util_buf_pool_destroy(struct util_buf_pool *pool);
 

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -283,7 +283,6 @@ struct util_buf_pool {
 	size_t 			entry_sz;
 	size_t 			num_allocated;
 	struct slist		buf_list;
-	struct slist		region_list;
 	struct util_buf_region	**regions_table;
 	size_t			regions_cnt;
 	struct util_buf_attr	attr;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -265,7 +265,7 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr)
 		ofi_atomic_inc32(&entry->use_cnt);
 		return 0;
 	} else {
-		entry = util_buf_alloc(av->av_entry_pool);
+		entry = util_buf_indexed_alloc(av->av_entry_pool);
 		if (!entry)
 			return -FI_ENOMEM;
 		if (fi_addr)
@@ -306,7 +306,7 @@ int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr)
 		return FI_SUCCESS;
 
 	HASH_DELETE(hh, av->hash, av_entry);
-	util_buf_release(av->av_entry_pool, av_entry);
+	util_buf_indexed_release(av->av_entry_pool, av_entry);
 	return 0;
 }
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -406,6 +406,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 		/* Don't use track of buffer, because user can close
 		 * the AV without prior deletion of addresses */
 		.track_used	= 0,
+		.indexing	= 1,
 	};
 
 	/* TODO: Handle FI_READ */

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -127,7 +127,6 @@ int util_buf_grow(struct util_buf_pool *pool)
 		slist_insert_tail(&buf_ftr->entry, &pool->buf_list);
 	}
 
-	slist_insert_tail(&buf_region->entry, &pool->region_list);
 	pool->num_allocated += pool->attr.chunk_cnt;
 	return 0;
 err3:
@@ -163,7 +162,6 @@ int util_buf_pool_create_attr(struct util_buf_attr *attr,
 		(*buf_pool)->attr.is_mmap_region = 1;
 
 	slist_init(&(*buf_pool)->buf_list);
-	slist_init(&(*buf_pool)->region_list);
 
 	return FI_SUCCESS;
 }
@@ -190,13 +188,12 @@ int util_buf_pool_create_ex(struct util_buf_pool **buf_pool,
 
 void util_buf_pool_destroy(struct util_buf_pool *pool)
 {
-	struct slist_entry *entry;
 	struct util_buf_region *buf_region;
 	int ret;
+	size_t i;
 
-	while (!slist_empty(&pool->region_list)) {
-		entry = slist_remove_head(&pool->region_list);
-		buf_region = container_of(entry, struct util_buf_region, entry);
+	for (i = 0; i < pool->regions_cnt; i++) {
+		buf_region = pool->regions_table[i];
 #if ENABLE_DEBUG
 		if (pool->attr.track_used)
 			assert(buf_region->num_used == 0);

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -213,6 +213,7 @@ int util_buf_pool_create_ex(struct util_buf_pool **buf_pool,
 		.free_hndlr	= free_hndlr,
 		.ctx		= pool_ctx,
 		.track_used	= 1,
+		.indexing	= 0,
 	};
 	return util_buf_pool_create_attr(&attr, buf_pool);
 }

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -57,6 +57,9 @@ int util_buf_grow(struct util_buf_pool *pool)
 	if (!buf_region)
 		return -1;
 
+	buf_region->pool = pool;
+	dlist_init(&buf_region->buf_list);
+
 	if (pool->attr.is_mmap_region) {
 		hp_size = ofi_get_hugepage_size();
 		if (hp_size < 0)
@@ -116,15 +119,40 @@ int util_buf_grow(struct util_buf_pool *pool)
 
 		if (pool->attr.init) {
 #if ENABLE_DEBUG
-			buf_ftr->entry.next = (void *) OFI_MAGIC_64;
-#endif
+			if (!pool->attr.indexing) {
+				buf_ftr->entry.slist.next = (void *) OFI_MAGIC_64;
+
+				pool->attr.init(pool->attr.ctx, buf);
+
+				assert(buf_ftr->entry.slist.next == (void *) OFI_MAGIC_64);
+			} else {
+				buf_ftr->entry.dlist.next = (void *) OFI_MAGIC_64;
+				buf_ftr->entry.dlist.prev = (void *) OFI_MAGIC_64;
+
+				pool->attr.init(pool->attr.ctx, buf);
+
+				assert((buf_ftr->entry.dlist.next == (void *) OFI_MAGIC_64) &&
+				       (buf_ftr->entry.dlist.prev == (void *) OFI_MAGIC_64));
+			}
+#else
 			pool->attr.init(pool->attr.ctx, buf);
-			assert(buf_ftr->entry.next == (void *) OFI_MAGIC_64);
+#endif
 		}
 
 		buf_ftr->region = buf_region;
 		buf_ftr->index = pool->num_allocated + i;
-		slist_insert_tail(&buf_ftr->entry, &pool->buf_list);
+		if (!pool->attr.indexing) {
+			slist_insert_tail(&buf_ftr->entry.slist,
+					  &pool->list.buffers);
+		} else {
+			dlist_insert_tail(&buf_ftr->entry.dlist,
+					  &buf_region->buf_list);
+		}
+	}
+
+	if (pool->attr.indexing) {
+		dlist_insert_tail(&buf_region->entry,
+				  &pool->list.regions);
 	}
 
 	pool->num_allocated += pool->attr.chunk_cnt;
@@ -161,7 +189,10 @@ int util_buf_pool_create_attr(struct util_buf_attr *attr,
 	else
 		(*buf_pool)->attr.is_mmap_region = 1;
 
-	slist_init(&(*buf_pool)->buf_list);
+	if (!(*buf_pool)->attr.indexing)
+		slist_init(&(*buf_pool)->list.buffers);
+	else
+		dlist_init(&(*buf_pool)->list.regions);
 
 	return FI_SUCCESS;
 }
@@ -217,4 +248,35 @@ void util_buf_pool_destroy(struct util_buf_pool *pool)
 	}
 	free(pool->regions_table);
 	free(pool);
+}
+
+int util_buf_is_lower(struct dlist_entry *item, const void *arg)
+{
+	struct util_buf_footer *buf_ftr1 =
+		container_of((struct dlist_entry *)arg,
+			     struct util_buf_footer, entry.dlist);
+	struct util_buf_footer *buf_ftr2 =
+		container_of(item, struct util_buf_footer, entry.dlist);
+	return (buf_ftr1->index < buf_ftr2->index);
+}
+
+int util_buf_region_is_lower(struct dlist_entry *item, const void *arg)
+{
+	struct util_buf_region *buf_region1 =
+		container_of((struct dlist_entry *)arg,
+			     struct util_buf_region, entry);
+	struct util_buf_region *buf_region2 =
+		container_of(item, struct util_buf_region, entry);
+	struct util_buf_footer *buf_region1_head =
+		container_of(buf_region1->buf_list.next,
+			     struct util_buf_footer, entry.dlist);
+	struct util_buf_footer *buf_region2_head =
+		container_of(buf_region2->buf_list.next,
+			     struct util_buf_footer, entry.dlist);
+	size_t buf_region1_index =
+		(size_t)(buf_region1_head->index / buf_region1->pool->attr.chunk_cnt);
+	size_t buf_region2_index =
+		(size_t)(buf_region2_head->index / buf_region2->pool->attr.chunk_cnt);
+
+	return (buf_region1_index < buf_region2_index);
 }


### PR DESCRIPTION
Currently, the utility buffer implementation allocates buffers from LRU list of buffers. This leads that it's impossible to determine what the index will be next.
Since utility AV uses utility buffer functionality to allocate `struct util_av_entry` and FI address, utility buffer has to allocate buffer with the lowest index from free buffer list.
This is done by adding new capability `indexing` = `{0, 1}` that should be set by user (e.g AV) to enable ordered allocation of buffers. The user which set `indexing = 1` has to use `util_buf_indexed_get` and `util_buf_indexed_release` and vice versa (`indexing = 0` - `util_buf_get`/`util_buf_release`).
- `util_buf_indexed_get` allocates buffer by retrieving the head of the buffer list (`util_buf_region::buf_list`) from the region that is the head of the regions list (`util_buf_pool::list.regions`).
- `util_buf_indexed_release` releases buffer by adding it to an appropriate place of the buffer list (`util_buf_region::buf_list`) and then adding the appropriate buffer region to the regions list (`util_buf_pool::list.regions`) if it was empty. The appropriate places in the buffer and regions lists are defined by doing sequential comparisons of elements (comparable: indices of region and indices of buffer).

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>