### PR TITLE
util_buf: Always enable footer and use it to track buffers

### DIFF
--- a/include/ofi_list.h
+++ b/include/ofi_list.h
@@ -40,6 +40,8 @@
 #include <sys/types.h>
 #include <stdlib.h>
 
+#include <rdma/fabric.h>
+
 #include <ofi_signal.h>
 #include <ofi_lock.h>
 

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -277,7 +277,6 @@ struct util_buf_attr {
 	void 				*ctx;
 	uint8_t				track_used;
 	uint8_t				is_mmap_region;
-	uint8_t				use_ftr;
 };
 
 struct util_buf_pool {
@@ -407,25 +406,9 @@ static inline void *util_buf_alloc_ex(struct util_buf_pool *pool, void **context
 	return buf;
 }
 
-#if ENABLE_DEBUG
-static inline int util_buf_use_ftr(struct util_buf_pool *pool)
-{
-	OFI_UNUSED(pool);
-	return 1;
-}
-#else
-static inline int util_buf_use_ftr(struct util_buf_pool *pool)
-{
-	return (pool->attr.alloc_hndlr ||
-		pool->attr.free_hndlr ||
-		pool->attr.use_ftr) ? 1 : 0;
-}
-#endif
-
 static inline void *util_buf_get_ctx(struct util_buf_pool *pool, void *buf)
 {
 	struct util_buf_footer *buf_ftr;
-	assert(util_buf_use_ftr(pool));
 	buf_ftr = (struct util_buf_footer *) ((char *) buf + pool->attr.size);
 	return buf_ftr->region->context;
 }

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -294,19 +294,15 @@ struct util_buf_region {
 	char *mem_region;
 	size_t size;
 	void *context;
-#if ENABLE_DEBUG
+#ifndef NDEBUG
 	size_t num_used;
 #endif
 };
 
 struct util_buf_footer {
+	struct slist_entry entry;
 	struct util_buf_region *region;
 	size_t index;
-};
-
-union util_buf {
-	struct slist_entry entry;
-	uint8_t data[0];
 };
 
 int util_buf_pool_create_attr(struct util_buf_attr *attr,
@@ -337,48 +333,60 @@ static inline int util_buf_avail(struct util_buf_pool *pool)
 
 int util_buf_grow(struct util_buf_pool *pool);
 
-#if ENABLE_DEBUG
+static inline struct util_buf_footer *
+util_buf_get_ftr(struct util_buf_pool *pool, void *buf)
+{
+	return (struct util_buf_footer *) ((char *) buf + pool->attr.size);
+}
 
-void *util_buf_get(struct util_buf_pool *pool);
-void util_buf_release(struct util_buf_pool *pool, void *buf);
-size_t util_get_buf_index(struct util_buf_pool *pool, void *buf);
-void *util_buf_get_by_index(struct util_buf_pool *pool, size_t index);
-
-#else
+static inline void *util_buf_get_data(struct util_buf_pool *pool,
+			       struct util_buf_footer *buf_ftr)
+{
+	return ((char *) buf_ftr - pool->attr.size);
+}
 
 static inline void *util_buf_get(struct util_buf_pool *pool)
 {
-	return slist_remove_head(&pool->buf_list);
+	struct util_buf_footer *buf_ftr;
+
+	slist_remove_head_container(&pool->buf_list, struct util_buf_footer,
+				    buf_ftr, entry);
+	assert(++buf_ftr->region->num_used);
+	return util_buf_get_data(pool, buf_ftr);
 }
 
 static inline void util_buf_release(struct util_buf_pool *pool, void *buf)
 {
-	slist_insert_head(&((union util_buf * )buf)->entry, &pool->buf_list);
+	assert(util_buf_get_ftr(pool, buf)->region->num_used--);
+	slist_insert_head(&util_buf_get_ftr(pool, buf)->entry, &pool->buf_list);
 }
 
 static inline size_t util_get_buf_index(struct util_buf_pool *pool, void *buf)
 {
-	return ((struct util_buf_footer *)((char *)buf + pool->attr.size))->index;
+	assert(util_buf_get_ftr(pool, buf)->region->num_used);
+	return util_buf_get_ftr(pool, buf)->index;
 }
 
 static inline void *util_buf_get_by_index(struct util_buf_pool *pool, size_t index)
 {
-	return (union util_buf *)(pool->regions_table[
-		(size_t)(index / pool->attr.chunk_cnt)]->mem_region +
-		(index % pool->attr.chunk_cnt) * pool->entry_sz);
+	void *buf;
+	buf = pool->regions_table[(size_t)(index / pool->attr.chunk_cnt)]->
+		mem_region + (index % pool->attr.chunk_cnt) * pool->entry_sz;
+	assert(util_buf_get_ftr(pool, buf)->region->num_used);
+	return buf;
 }
 
-#endif
+static inline void *util_buf_get_ctx(struct util_buf_pool *pool, void *buf)
+{
+	return util_buf_get_ftr(pool, buf)->region->context;
+}
 
 static inline void *util_buf_get_ex(struct util_buf_pool *pool, void **context)
 {
-	union util_buf *buf;
-	struct util_buf_footer *buf_ftr;
+	void *buf;
 
 	buf = util_buf_get(pool);
-	buf_ftr = (struct util_buf_footer *) ((char *) buf + pool->attr.size);
-	assert(context);
-	*context = buf_ftr->region->context;
+	*context = util_buf_get_ctx(pool, buf);
 	return buf;
 }
 
@@ -393,25 +401,17 @@ static inline void *util_buf_alloc(struct util_buf_pool *pool)
 
 static inline void *util_buf_alloc_ex(struct util_buf_pool *pool, void **context)
 {
-	union util_buf *buf;
-	struct util_buf_footer *buf_ftr;
+	void *buf;
 
 	buf = util_buf_alloc(pool);
 	if (OFI_UNLIKELY(!buf))
 		return NULL;
 
-	buf_ftr = (struct util_buf_footer *) ((char *) buf + pool->attr.size);
 	assert(context);
-	*context = buf_ftr->region->context;
+	*context = util_buf_get_ctx(pool, buf);
 	return buf;
 }
 
-static inline void *util_buf_get_ctx(struct util_buf_pool *pool, void *buf)
-{
-	struct util_buf_footer *buf_ftr;
-	buf_ftr = (struct util_buf_footer *) ((char *) buf + pool->attr.size);
-	return buf_ftr->region->context;
-}
 
 void util_buf_pool_destroy(struct util_buf_pool *pool);
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -406,7 +406,6 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 		/* Don't use track of buffer, because user can close
 		 * the AV without prior deletion of addresses */
 		.track_used	= 0,
-		.use_ftr	= 1,
 	};
 
 	/* TODO: Handle FI_READ */

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -105,20 +105,18 @@ int util_buf_grow(struct util_buf_pool *pool)
 			goto err2;
 	}
 
-	if (util_buf_use_ftr(pool)) {
-		if (!(pool->regions_cnt % UTIL_BUF_POOL_REGION_CHUNK_CNT)) {
-			struct util_buf_region **new_table =
-				realloc(pool->regions_table,
-					(pool->regions_cnt +
-					 UTIL_BUF_POOL_REGION_CHUNK_CNT) *
-					sizeof(*pool->regions_table));
-			if (!new_table)
-				goto err3;
-			pool->regions_table = new_table;
-		}
-		pool->regions_table[pool->regions_cnt] = buf_region;
-		pool->regions_cnt++;
+	if (!(pool->regions_cnt % UTIL_BUF_POOL_REGION_CHUNK_CNT)) {
+		struct util_buf_region **new_table =
+			realloc(pool->regions_table,
+				(pool->regions_cnt +
+				 UTIL_BUF_POOL_REGION_CHUNK_CNT) *
+				sizeof(*pool->regions_table));
+		if (!new_table)
+			goto err3;
+		pool->regions_table = new_table;
 	}
+	pool->regions_table[pool->regions_cnt] = buf_region;
+	pool->regions_cnt++;
 
 	buf_ftr.region = buf_region;
 
@@ -133,10 +131,8 @@ int util_buf_grow(struct util_buf_pool *pool)
 			assert(util_buf->entry.next == (void *)OFI_MAGIC_64);
 		}
 
-		if (util_buf_use_ftr(pool)) {
-			buf_ftr.index = pool->num_allocated + i;
-			util_buf_set_ftr(util_buf, &buf_ftr, pool);
-		}
+		buf_ftr.index = pool->num_allocated + i;
+		util_buf_set_ftr(util_buf, &buf_ftr, pool);
 
 		slist_insert_tail(&util_buf->entry, &pool->buf_list);
 	}
@@ -166,8 +162,7 @@ int util_buf_pool_create_attr(struct util_buf_attr *attr,
 
 	(*buf_pool)->attr = *attr;
 
-	entry_sz = util_buf_use_ftr(*buf_pool) ?
-		(attr->size + sizeof(struct util_buf_footer)) : attr->size;
+	entry_sz = (attr->size + sizeof(struct util_buf_footer));
 	(*buf_pool)->entry_sz = fi_get_aligned_sz(entry_sz, attr->alignment);
 
 	hp_size = ofi_get_hugepage_size();
@@ -198,11 +193,6 @@ int util_buf_pool_create_ex(struct util_buf_pool **buf_pool,
 		.alloc_hndlr	= alloc_hndlr,
 		.free_hndlr	= free_hndlr,
 		.ctx		= pool_ctx,
-#if ENABLE_DEBUG
-		.use_ftr	= 1,
-#else
-		.use_ftr	= 0,
-#endif
 		.track_used	= 1,
 	};
 	return util_buf_pool_create_attr(&attr, buf_pool);
@@ -234,7 +224,6 @@ void util_buf_release(struct util_buf_pool *pool, void *buf)
 
 size_t util_get_buf_index(struct util_buf_pool *pool, void *buf)
 {
-	assert(util_buf_use_ftr(pool));
  	struct util_buf_footer *buf_ftr =
 		(struct util_buf_footer *) ((char *) buf + pool->attr.size);
 	assert(buf_ftr->region->num_used);
@@ -242,7 +231,6 @@ size_t util_get_buf_index(struct util_buf_pool *pool, void *buf)
 }
 void *util_buf_get_by_index(struct util_buf_pool *pool, size_t index)
 {
-	assert(util_buf_use_ftr(pool));
  	struct util_buf_region *buf_region =
 		pool->regions_table[(size_t)(index / pool->attr.chunk_cnt)];
 	char *mem_region = buf_region->mem_region;

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -39,23 +39,15 @@
 #include <ofi.h>
 #include <ofi_osd.h>
 
-static inline void util_buf_set_ftr(union util_buf *buf,
-				    struct util_buf_footer *ftr,
-				    struct util_buf_pool *pool)
-{
-	struct util_buf_footer *buf_ftr =
-		(struct util_buf_footer *) ((char *) buf + pool->attr.size);
-	*buf_ftr = *ftr;
-}
 
 int util_buf_grow(struct util_buf_pool *pool)
 {
+	void *buf;
 	int ret;
 	size_t i;
-	union util_buf *util_buf;
 	struct util_buf_region *buf_region;
 	ssize_t hp_size;
-	struct util_buf_footer buf_ftr;
+	struct util_buf_footer *buf_ftr;
 
 	if (pool->attr.max_cnt && pool->num_allocated >= pool->attr.max_cnt) {
 		return -1;
@@ -118,23 +110,21 @@ int util_buf_grow(struct util_buf_pool *pool)
 	pool->regions_table[pool->regions_cnt] = buf_region;
 	pool->regions_cnt++;
 
-	buf_ftr.region = buf_region;
-
 	for (i = 0; i < pool->attr.chunk_cnt; i++) {
-		util_buf = (union util_buf *)
-			(buf_region->mem_region + i * pool->entry_sz);
+		buf = (buf_region->mem_region + i * pool->entry_sz);
+		buf_ftr = util_buf_get_ftr(pool, buf);
+
 		if (pool->attr.init) {
 #if ENABLE_DEBUG
-			util_buf->entry.next = (void *)OFI_MAGIC_64;
+			buf_ftr->entry.next = (void *) OFI_MAGIC_64;
 #endif
-			pool->attr.init(pool->attr.ctx, util_buf);
-			assert(util_buf->entry.next == (void *)OFI_MAGIC_64);
+			pool->attr.init(pool->attr.ctx, buf);
+			assert(buf_ftr->entry.next == (void *) OFI_MAGIC_64);
 		}
 
-		buf_ftr.index = pool->num_allocated + i;
-		util_buf_set_ftr(util_buf, &buf_ftr, pool);
-
-		slist_insert_tail(&util_buf->entry, &pool->buf_list);
+		buf_ftr->region = buf_region;
+		buf_ftr->index = pool->num_allocated + i;
+		slist_insert_tail(&buf_ftr->entry, &pool->buf_list);
 	}
 
 	slist_insert_tail(&buf_region->entry, &pool->region_list);
@@ -197,51 +187,6 @@ int util_buf_pool_create_ex(struct util_buf_pool **buf_pool,
 	};
 	return util_buf_pool_create_attr(&attr, buf_pool);
 }
-
-#if ENABLE_DEBUG
-void *util_buf_get(struct util_buf_pool *pool)
-{
-	struct slist_entry *entry;
-	struct util_buf_footer *buf_ftr;
-
-	entry = slist_remove_head(&pool->buf_list);
-	buf_ftr = (struct util_buf_footer *) ((char *) entry + pool->attr.size);
-	buf_ftr->region->num_used++;
-	assert(buf_ftr->region->num_used);
-	return entry;
-}
-
-void util_buf_release(struct util_buf_pool *pool, void *buf)
-{
-	union util_buf *util_buf = buf;
-	struct util_buf_footer *buf_ftr;
-
-	buf_ftr = (struct util_buf_footer *) ((char *) buf + pool->attr.size);
-	assert(buf_ftr->region->num_used);
-	buf_ftr->region->num_used--;
-	slist_insert_head(&util_buf->entry, &pool->buf_list);
-}
-
-size_t util_get_buf_index(struct util_buf_pool *pool, void *buf)
-{
- 	struct util_buf_footer *buf_ftr =
-		(struct util_buf_footer *) ((char *) buf + pool->attr.size);
-	assert(buf_ftr->region->num_used);
-	return buf_ftr->index;
-}
-void *util_buf_get_by_index(struct util_buf_pool *pool, size_t index)
-{
- 	struct util_buf_region *buf_region =
-		pool->regions_table[(size_t)(index / pool->attr.chunk_cnt)];
-	char *mem_region = buf_region->mem_region;
-	union util_buf *buf = (union util_buf *)(mem_region +
-		(index % pool->attr.chunk_cnt) * pool->entry_sz);
-	struct util_buf_footer *buf_ftr =
-		(struct util_buf_footer *)((char *)buf + pool->attr.size);
- 	assert(buf_ftr->region->num_used);
- 	return buf;
-}
-#endif
 
 void util_buf_pool_destroy(struct util_buf_pool *pool)
 {


### PR DESCRIPTION
This is related to discussions in PR #4543.  The buffer footer's are always enabled, with the slist entry used to track the request moved into the footer.  This avoids overlapping with user data, which allows the user to pre-format portions of the data as an optimization.

Several cleanups are applied around supporting this change.