### PR TITLE
fabtests, prov/rxm: updates to counters and fi_poll test

### DIFF
--- a/fabtests/functional/poll.c
+++ b/fabtests/functional/poll.c
@@ -151,7 +151,9 @@ static int send_recv()
 				printf("Send counter poll-event\n");
 				tx_cntr_val = fi_cntr_read(txcntr);
 				if (tx_cntr_val > tx_seq) {
-					printf("Invalid tx counter event\n");
+					FT_ERR("Invalid tx counter event\n");
+					FT_ERR("expected: %" PRIu64 ", found: "
+					       "%d\n", tx_seq, tx_cntr_val);
 					return -1;
 				}
 				continue;
@@ -159,12 +161,14 @@ static int send_recv()
 				printf("Recv counter poll-event\n");
 				rx_cntr_val = fi_cntr_read(rxcntr);
 				if (rx_cntr_val > rx_seq) {
-					printf("Invalid rx counter event\n");
+					FT_ERR("Invalid rx counter event\n");
+					FT_ERR("expected: %" PRIu64 ", found: "
+					       "%d\n", rx_seq, rx_cntr_val);
 					return -1;
 				}
 				continue;
 			} else {
-				printf("Unknown completion received\n");
+				FT_ERR("Unknown completion received\n");
 				return -1;
 			}
 

--- a/fabtests/test_configs/ofi_rxm/ofi_rxm.exclude
+++ b/fabtests/test_configs/ofi_rxm/ofi_rxm.exclude
@@ -7,7 +7,6 @@
 ^dgram|-e dgram
 
 cm_data
-poll -t counter
 rdm_rma_simple
 trigger
 shared_ctx
@@ -15,7 +14,6 @@ scalable_ep
 shared_av
 multi_mr
 atomic
-inj_complete
 
 # Remove this once ubertest supports setting MR modes
 ubertest

--- a/fabtests/test_configs/verbs/verbs.exclude
+++ b/fabtests/test_configs/verbs/verbs.exclude
@@ -4,7 +4,6 @@
 -k
 
 dgram
-^poll
 
 # This test requires FI_RMA_EVENT
 rdm_rma_simple

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -749,12 +749,6 @@ err:
 	return ret;
 }
 
-static inline void rxm_cntr_inc(struct util_cntr *cntr)
-{
-	if (cntr)
-		cntr->cntr_fid.ops->add(&cntr->cntr_fid, 1);
-}
-
 static inline void rxm_cntr_incerr(struct util_cntr *cntr)
 {
 	if (cntr)
@@ -1112,11 +1106,11 @@ static inline int rxm_finish_send_nobuf(struct rxm_tx_entry *tx_entry)
 	}
 	if (tx_entry->ep->util_ep.flags & OFI_CNTR_ENABLED) {
 		if (tx_entry->comp_flags & FI_SEND)
-			rxm_cntr_inc(tx_entry->ep->util_ep.tx_cntr);
+			ofi_ep_tx_cntr_inc(&tx_entry->ep->util_ep);
 		else if (tx_entry->comp_flags & FI_WRITE)
-			rxm_cntr_inc(tx_entry->ep->util_ep.wr_cntr);
+			ofi_ep_wr_cntr_inc(&tx_entry->ep->util_ep);
 		else
-			rxm_cntr_inc(tx_entry->ep->util_ep.rd_cntr);
+			ofi_ep_rem_rd_cntr_inc(&tx_entry->ep->util_ep);
 	}
 	rxm_tx_entry_release(tx_entry->conn->send_queue, tx_entry);
 	return 0;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -157,8 +157,7 @@ static int rxm_finish_recv(struct rxm_rx_buf *rx_buf, size_t done_len)
 			if (ret)
 				return ret;
 		}
-		if (rx_buf->ep->util_ep.flags & OFI_CNTR_ENABLED)
-			rxm_cntr_inc(rx_buf->ep->util_ep.rx_cntr);
+		ofi_ep_rx_cntr_inc(&rx_buf->ep->util_ep);
 	}
 
 	if (rx_buf->recv_entry->flags & FI_MULTI_RECV) {
@@ -709,7 +708,7 @@ static int rxm_handle_remote_write(struct rxm_ep *rxm_ep,
 				"Unable to write remote write completion\n");
 		return ret;
 	}
-	rxm_cntr_inc(rxm_ep->util_ep.rem_wr_cntr);
+	ofi_ep_rem_wr_cntr_inc(&rxm_ep->util_ep);
 	if (comp->op_context)
 		rxm_enqueue_rx_buf_for_repost_check(comp->op_context);
 	return 0;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -850,7 +850,7 @@ rxm_ep_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	       " tag: 0x%" PRIx64 "\n", pkt_size, tx_pkt->hdr.tag);
 	ssize_t ret = fi_inject(rxm_conn->msg_ep, tx_pkt, pkt_size, 0);
 	if (OFI_LIKELY(!ret)) {
-		rxm_cntr_inc(rxm_ep->util_ep.tx_cntr);
+		ofi_ep_tx_cntr_inc(&rxm_ep->util_ep);
 	} else {
 		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
 		       "fi_inject for MSG provider failed with ret - %" PRId64"\n",

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1454,8 +1454,6 @@ rxm_ep_send_inject(struct rxm_ep *rxm_ep, const struct iovec *iov, size_t count,
 		}
 		rxm_cq_log_comp(comp_flags);
 	}
-	if (rxm_ep->util_ep.flags & OFI_CNTR_ENABLED)
-		rxm_cntr_inc(rxm_ep->util_ep.tx_cntr);
 	return FI_SUCCESS;
 }
 

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -321,7 +321,7 @@ rxm_ep_rma_inject(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 					      msg->rma_iov->key);
 		}
 		if (OFI_LIKELY(!ret)) {
-			rxm_cntr_inc(rxm_ep->util_ep.wr_cntr);
+			ofi_ep_wr_cntr_inc(&rxm_ep->util_ep);
 		} else {
 			FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
 			       "fi_inject_write* for MSG provider failed with ret - %"


### PR DESCRIPTION
- fabtests: add some logging to fi_poll test 
- prov/rxm: fix counter increment for inject ops (not needed for v1.6.x)
- prov/rxm: use util_ep counter increment functions which don't have branches
- fabtests: enable some tests for verbs, rxm providers