### PR TITLE
contrib/cray: remove unnecessary srun 

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -96,7 +96,6 @@ pipeline {
                             sh "make -j12 install"
                         }
                         tee ('fabtests.log') {
-                            sh 'srun -n 2 --ntasks-per-node 1 ldd contrib/cray/bin/fabtest_wrapper.sh'
                             sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 60'
                         }
                     }


### PR DESCRIPTION
In a prior commit, a srun of ldd was left in accidentally and was
not caught in review. This should be removed.

Signed-off-by: James Swaro <jswaro@cray.com>