### PR TITLE
fabtests, prov/rxm: fix missing check for fi_addr in av_insert + new tests

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1106,7 +1106,7 @@ int ft_init_av_dst_addr(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
 			return ret;
 		}
 
-		ret = (int) ft_tx(ep, remote_fi_addr, addrlen, &tx_ctx);
+		ret = (int) ft_tx(ep, *remote_addr, addrlen, &tx_ctx);
 		if (ret)
 			return ret;
 
@@ -1118,12 +1118,18 @@ int ft_init_av_dst_addr(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
 		if (ret)
 			return ret;
 
+		/* Test passing NULL fi_addr on one of the sides (server) if
+		 * AV type is FI_AV_TABLE */
 		ret = ft_av_insert(av_ptr, (char *) rx_buf + ft_rx_prefix_size(),
-				1, remote_addr, 0, NULL);
+				   1, ((fi->domain_attr->av_type == FI_AV_TABLE) ?
+				       NULL : remote_addr), 0, NULL);
 		if (ret)
 			return ret;
 
-		ret = (int) ft_tx(ep, remote_fi_addr, 1, &tx_ctx);
+		if (fi->domain_attr->av_type == FI_AV_TABLE)
+			*remote_addr = 0;
+
+		ret = (int) ft_tx(ep, *remote_addr, 1, &tx_ctx);
 		if (ret)
 			return ret;
 	}

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -70,13 +70,18 @@ rxm_av_insert_cmap(struct fid_av *av_fid, const void *addr, size_t count,
 {
 	struct util_av *av = container_of(av_fid, struct util_av, av_fid);
 	struct rxm_ep *rxm_ep;
+	fi_addr_t fi_addr_tmp;
 	size_t i;
 	int ret = 0;
 
 	dlist_foreach_container(&av->ep_list, struct rxm_ep,
 				rxm_ep, util_ep.av_entry) {
 		for (i = 0; i < count; i++) {
-			ret = rxm_cmap_update(rxm_ep->cmap, addr, fi_addr[i]);
+			fi_addr_tmp = (fi_addr ? fi_addr[i] :
+				       ofi_av_lookup_fi_addr(av, addr));
+			if (fi_addr_tmp == FI_ADDR_NOTAVAIL)
+				continue;
+			ret = rxm_cmap_update(rxm_ep->cmap, addr, fi_addr_tmp);
 			if (OFI_UNLIKELY(ret)) {
 				FI_WARN(&rxm_prov, FI_LOG_AV,
 					"Unable to update CM for OFI endpoints\n");


### PR DESCRIPTION
- prov/rxm: check for fi_addr before calling cmap update (bug fix not needed for v1.6.x)
- fabtests/unit: add a test for fi_av_insert with NULL fi_addr arg 
- fabtests/common: test passing NULL fi_addr to fi_av_insert 

Fixes #4551 