### PR TITLE
prov/rxm: Make a clearer name for rma functions and structure

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -364,7 +364,7 @@ struct rxm_iov {
 	uint8_t count;
 };
 
-struct rxm_rma_iov_storage {
+struct rxm_rma_iov {
 	struct fi_rma_iov iov[RXM_IOV_LIMIT];
 	uint8_t count;
 };
@@ -438,7 +438,7 @@ struct rxm_rma_buf {
 
 	struct fi_msg_rma msg;
 	struct rxm_iov rxm_iov;
-	struct rxm_rma_iov_storage rxm_rma_iov;
+	struct rxm_rma_iov rxm_rma_iov;
 
 	/* Must stay at bottom */
 	struct rxm_pkt pkt;


### PR DESCRIPTION
`rxm_ep_format_rma_res_lightweight` doesn't reflect actual goal of this function.
Rename the function to `rxm_ep_form_rma_entry` instead.

Also rename `rxm_ep_format_rma_buf` to `rxm_ep_form_rma_buf`

`rxm_rma_iov_storage` is a little bit long name, rename the structure to
`rxm_rma_iov`.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>