### PR TITLE
prov/rxd: FI_MULTI_RECV support and freestack to buffer pool change

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -81,6 +81,7 @@
 #define RXD_INJECT		(1 << 3)
 #define RXD_TAG_HDR		(1 << 4)
 #define RXD_INLINE		(1 << 5)
+#define RXD_MULTI_RECV		(1 << 6)
 
 struct rxd_env {
 	int spin_count;
@@ -169,6 +170,7 @@ struct rxd_ep {
 	size_t prefix_size;
 	uint32_t posted_bufs;
 	uint32_t rx_list_size;
+	size_t min_multi_recv_size;
 	int do_local_mr;
 
 	struct util_buf_pool *tx_pkt_pool;
@@ -242,6 +244,8 @@ static inline uint32_t rxd_flags(uint64_t fi_flags)
 		rxd_flags |= RXD_REMOTE_CQ_DATA;
 	if (fi_flags & FI_INJECT)
 		rxd_flags |= RXD_INJECT;
+	if (fi_flags & FI_MULTI_RECV)
+		rxd_flags |= RXD_MULTI_RECV;
 
 	return rxd_flags;
 }
@@ -416,6 +420,9 @@ void rxd_progress_op(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
 		     struct rxd_atom_hdr *atom_hdr,
 		     void **msg, size_t size);
 void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer);
+struct rxd_x_entry *rxd_progress_multi_recv(struct rxd_ep *ep,
+					    struct rxd_x_entry *rx_entry,
+					    size_t total_size);
 
 /* CQ sub-functions */
 void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry);

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -169,7 +169,6 @@ struct rxd_ep {
 	size_t tx_size;
 	size_t prefix_size;
 	uint32_t posted_bufs;
-	uint32_t rx_list_size;
 	size_t min_multi_recv_size;
 	int do_local_mr;
 
@@ -177,8 +176,8 @@ struct rxd_ep {
 	struct util_buf_pool *rx_pkt_pool;
 	struct slist rx_pkt_list;
 
-	struct rxd_x_fs *tx_fs;
-	struct rxd_x_fs *rx_fs;
+	struct util_buf_pool *tx_entry_pool;
+	struct util_buf_pool *rx_entry_pool;
 
 	struct dlist_entry unexp_list;
 	struct dlist_entry unexp_tag_list;
@@ -234,7 +233,6 @@ struct rxd_x_entry {
 	struct rxd_pkt_entry *pkt;
 	struct dlist_entry entry;
 };
-DECLARE_FREESTACK(struct rxd_x_entry, rxd_x_fs);
 
 static inline uint32_t rxd_flags(uint64_t fi_flags)
 {
@@ -362,6 +360,9 @@ void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer);
 struct rxd_pkt_entry *rxd_get_tx_pkt(struct rxd_ep *ep);
 void rxd_release_rx_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt);
 void rxd_release_tx_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt);
+struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep);
+struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep);
+void rxd_release_rx_entry(struct rxd_ep *ep, struct rxd_x_entry *x_entry);
 int rxd_ep_retry_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry);
 ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
 void rxd_insert_unacked(struct rxd_ep *ep, fi_addr_t peer,

--- a/prov/rxd/src/rxd_attr.c
+++ b/prov/rxd/src/rxd_attr.c
@@ -34,7 +34,7 @@
 
 #define RXD_EP_CAPS (FI_MSG | FI_TAGGED | FI_RMA | FI_ATOMIC | FI_SEND | FI_RECV | \
 		     FI_READ | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE |	\
-		     FI_SOURCE | FI_DIRECTED_RECV)
+		     FI_SOURCE | FI_DIRECTED_RECV | FI_MULTI_RECV)
 
 struct fi_tx_attr rxd_tx_attr = {
 	.caps = RXD_EP_CAPS,

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -126,8 +126,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	fastlock_acquire(&rxd_ep->util_ep.lock);
 	fastlock_acquire(&rxd_ep->util_ep.rx_cq->cq_lock);
 
-	if (ofi_cirque_isfull(rxd_ep->util_ep.rx_cq->cirq) ||
-	    rxd_ep->rx_list_size >= rxd_ep->rx_size) {
+	if (ofi_cirque_isfull(rxd_ep->util_ep.rx_cq->cirq)) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}
@@ -141,7 +140,6 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		goto out;
 	}
 
-	rxd_ep->rx_list_size++;
 	if (op == ofi_op_tagged) {
 		unexp_list = &rxd_ep->unexp_tag_list;
 		rx_list = &rxd_ep->rx_tag_list;

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -55,10 +55,13 @@ static int rxd_match_unexp(struct dlist_entry *item, const void *arg)
 			     rxd_get_tag_hdr(pkt_entry)->tag);
 }
 
-static void rxd_ep_check_unexp_msg_list(struct rxd_ep *ep, struct dlist_entry *list,
+static int rxd_ep_check_unexp_msg_list(struct rxd_ep *ep,
+					struct dlist_entry *unexp_list,
+					struct dlist_entry *rx_list,
 					struct rxd_x_entry *rx_entry)
 {
 	struct dlist_entry *match;
+	struct rxd_x_entry *progress_entry, *dup_entry = NULL;
 	struct rxd_pkt_entry *pkt_entry;
 	struct rxd_base_hdr *base_hdr;
 	struct rxd_sar_hdr *sar_hdr = NULL;
@@ -67,29 +70,42 @@ static void rxd_ep_check_unexp_msg_list(struct rxd_ep *ep, struct dlist_entry *l
 	struct rxd_atom_hdr *atom_hdr = NULL;
 	struct rxd_rma_hdr *rma_hdr = NULL;
 	void *msg = NULL;
-	size_t msg_size;
+	size_t msg_size, total_size;
 
-	match = dlist_remove_first_match(list, &rxd_match_unexp, (void *) rx_entry);
-	if (!match)
-		return;
+	while (!dlist_empty(unexp_list)) {
+		match = dlist_remove_first_match(unexp_list, &rxd_match_unexp,
+						 (void *) rx_entry);
+		if (!match)
+			return 0;
+	
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "progressing unexp msg entry\n");
+	
+		pkt_entry = container_of(match, struct rxd_pkt_entry, d_entry);
+		base_hdr = rxd_get_base_hdr(pkt_entry);
+	
+		rxd_unpack_hdrs(pkt_entry->pkt_size, base_hdr, &sar_hdr, &tag_hdr,
+				&data_hdr, &rma_hdr, &atom_hdr, &msg, &msg_size);
+	
+		total_size = sar_hdr ? sar_hdr->size : msg_size;
+		if (rx_entry->flags & RXD_MULTI_RECV)
+			dup_entry = rxd_progress_multi_recv(ep, rx_entry, total_size);
 
-	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "progressing unexp msg entry\n");
-	dlist_remove(&rx_entry->entry);
+		progress_entry = dup_entry ? dup_entry : rx_entry;
+	
+		progress_entry->cq_entry.len = MIN(rx_entry->cq_entry.len, total_size);
+		dlist_insert_tail(&progress_entry->entry,
+				  &ep->peers[base_hdr->peer].rx_list);
+	
+		rxd_progress_op(ep, progress_entry, pkt_entry, base_hdr, sar_hdr, tag_hdr,
+				data_hdr, rma_hdr, atom_hdr, &msg, msg_size);
+		rxd_release_repost_rx(ep, pkt_entry);
+		rxd_ep_send_ack(ep, base_hdr->peer);
 
-	pkt_entry = container_of(match, struct rxd_pkt_entry, d_entry);
-	base_hdr = rxd_get_base_hdr(pkt_entry);
+		if (!dup_entry)
+			return 1;
+	}
 
-	rxd_unpack_hdrs(pkt_entry->pkt_size, base_hdr, &sar_hdr, &tag_hdr,
-			&data_hdr, &rma_hdr, &atom_hdr, &msg, &msg_size);
-
-	rx_entry->cq_entry.len = MIN(rx_entry->cq_entry.len,
-		sar_hdr ? sar_hdr->size : msg_size);
-	dlist_insert_tail(&rx_entry->entry, &ep->peers[base_hdr->peer].rx_list);
-
-	rxd_progress_op(ep, rx_entry, pkt_entry, base_hdr, sar_hdr, tag_hdr, data_hdr,
-			rma_hdr, atom_hdr, &msg, msg_size);
-	rxd_ep_send_ack(ep, base_hdr->peer);
-	rxd_release_repost_rx(ep, pkt_entry);
+	return 0;
 }
 
 ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
@@ -100,9 +116,10 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	ssize_t ret = 0;
 	struct rxd_av *rxd_av;
 	struct rxd_x_entry *rx_entry;
-	struct dlist_entry *unexp_list;
+	struct dlist_entry *unexp_list, *rx_list;
 
 	assert(iov_count <= RXD_IOV_LIMIT);
+	assert(!(rxd_flags & RXD_MULTI_RECV) || iov_count == 1);
 
 	rxd_av = rxd_ep_av(rxd_ep);
 
@@ -125,10 +142,19 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	}
 
 	rxd_ep->rx_list_size++;
-	unexp_list = (op == ofi_op_tagged) ? &rxd_ep->unexp_tag_list :
-		      &rxd_ep->unexp_list;
-	if (!dlist_empty(unexp_list))
-		rxd_ep_check_unexp_msg_list(rxd_ep, unexp_list, rx_entry);
+	if (op == ofi_op_tagged) {
+		unexp_list = &rxd_ep->unexp_tag_list;
+		rx_list = &rxd_ep->rx_tag_list;
+	} else {
+		unexp_list = &rxd_ep->unexp_list;
+		rx_list = &rxd_ep->rx_list;
+	}
+
+	if (!dlist_empty(unexp_list) &&
+	    rxd_ep_check_unexp_msg_list(rxd_ep, unexp_list, rx_list, rx_entry))
+		goto out;	
+
+	dlist_insert_tail(&rx_entry->entry, rx_list);
 out:
 	fastlock_release(&rxd_ep->util_ep.rx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);


### PR DESCRIPTION
- Add FI_MULTI_RECV support
- Change tx and rx freestacks to buffer pools for proper MULTI_RECV support and to allow x_entry pool to grow (gets rid of funky size*2 freestack size definition)
