### PR TITLE
prov/tcp: improve small messages xfer rate by reducing num of sys calls per transfer

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -70,7 +70,7 @@
 #define TCPX_MAX_INJECT_SZ	(64)
 
 #define MAX_EPOLL_EVENTS	100
-#define STAGE_BUF_SIZE		4096
+#define STAGE_BUF_SIZE		512
 
 extern struct fi_provider	tcpx_prov;
 extern struct util_prov		tcpx_util_prov;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -69,7 +69,8 @@
 #define TCPX_IOV_LIMIT		(4)
 #define TCPX_MAX_INJECT_SZ	(64)
 
-#define MAX_EPOLL_EVENTS 100
+#define MAX_EPOLL_EVENTS	100
+#define STAGE_BUF_SIZE		4096
 
 extern struct fi_provider	tcpx_prov;
 extern struct util_prov		tcpx_util_prov;
@@ -149,6 +150,13 @@ typedef int (*tcpx_rx_process_fn_t)(struct tcpx_xfer_entry *rx_entry);
 typedef void (*tcpx_ep_progress_func_t)(struct tcpx_ep *ep);
 typedef int (*tcpx_get_rx_func_t)(struct tcpx_ep *ep);
 
+struct stage_buf {
+	uint8_t			buf[STAGE_BUF_SIZE];
+	size_t			size;
+	size_t			len;
+	size_t			off;
+};
+
 struct tcpx_ep {
 	struct util_ep		util_ep;
 	SOCKET			conn_fd;
@@ -166,6 +174,7 @@ struct tcpx_ep {
 	fastlock_t		lock;
 	tcpx_ep_progress_func_t progress_func;
 	tcpx_get_rx_func_t	get_rx_entry[ofi_op_write + 1];
+	struct stage_buf	stage_buf;
 	bool			send_ready_monitor;
 };
 
@@ -227,7 +236,9 @@ void tcpx_cq_report_completion(struct util_cq *cq,
 
 int tcpx_recv_msg_data(struct tcpx_xfer_entry *recv_entry);
 int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry);
-int tcpx_recv_hdr(SOCKET sock, struct tcpx_rx_detect *rx_detect);
+int tcpx_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
+		  struct tcpx_rx_detect *rx_detect);
+int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf);
 
 struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq,
 					      enum tcpx_xfer_op_codes type);

--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -60,7 +60,23 @@ int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry)
 	return FI_SUCCESS;
 }
 
-int tcpx_recv_hdr(SOCKET sock, struct tcpx_rx_detect *rx_detect)
+static ssize_t tcpx_read_from_buffer(struct stage_buf *sbuf,
+				     uint8_t *buf, size_t len)
+{
+	size_t rem_size;
+	ssize_t ret;
+
+	assert(sbuf->len >= sbuf->off);
+	rem_size = sbuf->len - sbuf->off;
+	assert(rem_size);
+	ret = (rem_size >= len)? len : rem_size;
+	memcpy(buf, &sbuf->buf[sbuf->off], ret);
+	sbuf->off += ret;
+	return ret;
+}
+
+int tcpx_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
+		  struct tcpx_rx_detect *rx_detect)
 {
 	void *rem_buf;
 	size_t rem_len;
@@ -69,7 +85,11 @@ int tcpx_recv_hdr(SOCKET sock, struct tcpx_rx_detect *rx_detect)
 	rem_buf = (uint8_t *) &rx_detect->hdr + rx_detect->done_len;
 	rem_len = sizeof(rx_detect->hdr) - rx_detect->done_len;
 
-	bytes_recvd = ofi_recv_socket(sock, rem_buf, rem_len, 0);
+	if (sbuf->len != sbuf->off) {
+		bytes_recvd = tcpx_read_from_buffer(sbuf, rem_buf, rem_len);
+	} else {
+		bytes_recvd = ofi_recv_socket(sock, rem_buf, rem_len, 0);
+	}
 	if (bytes_recvd <= 0)
 		return (bytes_recvd)? -ofi_sockerr(): -FI_ENOTCONN;
 
@@ -77,13 +97,42 @@ int tcpx_recv_hdr(SOCKET sock, struct tcpx_rx_detect *rx_detect)
 	return (rem_len == bytes_recvd)? FI_SUCCESS : -FI_EAGAIN;
 }
 
+static ssize_t tcpx_readv_from_buffer(struct stage_buf *sbuf,
+				      struct iovec *iov,
+				      int iov_cnt)
+{
+	ssize_t ret = 0;
+	size_t bytes_read;
+	int i;
+
+	if (iov_cnt == 1)
+		return tcpx_read_from_buffer(sbuf, iov[0].iov_base,
+					     iov[0].iov_len);
+
+	for (i = 0; i < iov_cnt; i++) {
+		bytes_read = tcpx_read_from_buffer(sbuf, iov[i].iov_base,
+						   iov[i].iov_len);
+		ret += bytes_read;
+		if ((bytes_read < iov[i].iov_len) ||
+		    !(sbuf->len - sbuf->off))
+			break;
+	}
+	return ret;
+}
+
 int tcpx_recv_msg_data(struct tcpx_xfer_entry *rx_entry)
 {
 	ssize_t bytes_recvd;
 
-	bytes_recvd = ofi_readv_socket(rx_entry->ep->conn_fd,
-				       rx_entry->msg_data.iov,
-				       rx_entry->msg_data.iov_cnt);
+	if (rx_entry->ep->stage_buf.len != rx_entry->ep->stage_buf.off) {
+		bytes_recvd = tcpx_readv_from_buffer(&rx_entry->ep->stage_buf,
+						rx_entry->msg_data.iov,
+						rx_entry->msg_data.iov_cnt);
+	 }else {
+		bytes_recvd = ofi_readv_socket(rx_entry->ep->conn_fd,
+					       rx_entry->msg_data.iov,
+					       rx_entry->msg_data.iov_cnt);
+	}
 	if (bytes_recvd <= 0)
 		return (bytes_recvd)? -ofi_sockerr(): -FI_ENOTCONN;
 
@@ -94,5 +143,19 @@ int tcpx_recv_msg_data(struct tcpx_xfer_entry *rx_entry)
 				bytes_recvd);
 		return -FI_EAGAIN;
 	}
+	return FI_SUCCESS;
+}
+
+int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf)
+{
+	int bytes_recvd;
+
+	bytes_recvd = ofi_recv_socket(sock, stage_buf->buf,
+				      stage_buf->size, 0);
+	if (bytes_recvd <= 0)
+		return (bytes_recvd)? -ofi_sockerr(): -FI_ENOTCONN;
+
+	stage_buf->len = bytes_recvd;
+	stage_buf->off = 0;
 	return FI_SUCCESS;
 }

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -836,6 +836,10 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err3;
 
+	ep->stage_buf.size = STAGE_BUF_SIZE;
+	ep->stage_buf.len = 0;
+	ep->stage_buf.off = 0;
+
 	slist_init(&ep->rx_queue);
 	slist_init(&ep->tx_queue);
 	slist_init(&ep->rma_read_queue);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -588,6 +588,38 @@ int tcpx_get_rx_entry_op_read_rsp(struct tcpx_ep *tcpx_ep)
 	return FI_SUCCESS;
 }
 
+static void tcpx_process_stage_buffer(struct tcpx_ep *ep)
+{
+	int ret;
+
+	while (ep->stage_buf.len != ep->stage_buf.off) {
+		if (!ep->cur_rx_entry) {
+			ret = tcpx_recv_hdr(ep->conn_fd, &ep->stage_buf,
+					    &ep->rx_detect);
+			if (OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
+				return;
+
+			if (ret)
+				goto err1;
+
+			ret = ep->get_rx_entry[ep->rx_detect.hdr.hdr.op](ep);
+			if (ret == -FI_EAGAIN)
+				return;
+			if (ret)
+				goto err2;
+		}
+		assert(ep->cur_rx_proc_fn != NULL);
+		ep->cur_rx_proc_fn(ep->cur_rx_entry);
+	}
+	return;
+err2:
+	tcpx_report_error(ep, ret);
+	return;
+err1:
+	if (ret == -FI_ENOTCONN)
+		tcpx_ep_shutdown_report(ep, &ep->util_ep.ep_fid.fid);
+}
+
 static void tcpx_process_rx_msg(struct tcpx_ep *ep)
 {
 	int ret;
@@ -597,6 +629,9 @@ static void tcpx_process_rx_msg(struct tcpx_ep *ep)
 			ret = tcpx_read_to_buffer(ep->conn_fd, &ep->stage_buf);
 			if (ret && !OFI_SOCK_TRY_SND_RCV_AGAIN(-ret))
 				goto err1;
+
+			tcpx_process_stage_buffer(ep);
+			return;
 		}
 
 		ret = tcpx_recv_hdr(ep->conn_fd, &ep->stage_buf,


### PR DESCRIPTION
tcp provider performs two socket read calls to OS even for small messages. To reduce that overhead, read the first 4k bytes in the OS buffer to local buffer and process it. For only msgs larger than 4k would need more than one read call to get the message.