### PR TITLE
[v1.6.x] cherry-picked bug fixes and related commits from master

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -88,10 +88,10 @@ struct ofi_notification_queue;
 struct ofi_mem_monitor {
 	ofi_atomic32_t			refcnt;
 
-	int (*subscribe)(struct ofi_mem_monitor *notifier, void *addr,
-			 size_t len, struct ofi_subscription *subscription);
-	void (*unsubscribe)(struct ofi_mem_monitor *notifier, void *addr,
-			    size_t len, struct ofi_subscription *subscription);
+	int (*subscribe)(struct ofi_mem_monitor *notifier,
+			 struct ofi_subscription *subscription);
+	void (*unsubscribe)(struct ofi_mem_monitor *notifier,
+			    struct ofi_subscription *subscription);
 };
 
 struct ofi_notification_queue {
@@ -104,8 +104,7 @@ struct ofi_notification_queue {
 struct ofi_subscription {
 	struct ofi_notification_queue	*nq;
 	struct dlist_entry		entry;
-	void				*addr;
-	size_t				len;
+	struct iovec			iov;
 };
 
 void ofi_monitor_init(struct ofi_mem_monitor *monitor);
@@ -124,8 +123,8 @@ ofi_monitor_add_event_to_nq(struct ofi_subscription *subscription)
 {
 	FI_DBG(&core_prov, FI_LOG_MR,
 	       "Add event to NQ, context=%p, addr=%p, len=%"PRIu64" nq=%p\n",
-	       subscription, subscription->addr,
-	       subscription->len, subscription->nq);
+	       subscription, subscription->iov.iov_base,
+	       subscription->iov.iov_len, subscription->nq);
 	fastlock_acquire(&subscription->nq->lock);
 	if (dlist_empty(&subscription->entry))
 		dlist_insert_tail(&subscription->entry,

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -92,7 +92,6 @@ struct ofi_mem_monitor {
 			 size_t len, struct ofi_subscription *subscription);
 	void (*unsubscribe)(struct ofi_mem_monitor *notifier, void *addr,
 			    size_t len, struct ofi_subscription *subscription);
-	struct ofi_subscription *(*get_event)(struct ofi_mem_monitor *notifier);
 };
 
 struct ofi_notification_queue {
@@ -120,7 +119,19 @@ int ofi_monitor_subscribe(struct ofi_notification_queue *nq,
 			  struct ofi_subscription *subscription);
 void ofi_monitor_unsubscribe(struct ofi_subscription *subscription);
 struct ofi_subscription *ofi_monitor_get_event(struct ofi_notification_queue *nq);
-
+static inline void
+ofi_monitor_add_event_to_nq(struct ofi_subscription *subscription)
+{
+	FI_DBG(&core_prov, FI_LOG_MR,
+	       "Add event to NQ, context=%p, addr=%p, len=%"PRIu64" nq=%p\n",
+	       subscription, subscription->addr,
+	       subscription->len, subscription->nq);
+	fastlock_acquire(&subscription->nq->lock);
+	if (dlist_empty(&subscription->entry))
+		dlist_insert_tail(&subscription->entry,
+				  &subscription->nq->list);
+	fastlock_release(&subscription->nq->lock);
+}
 
 /*
  * MR map

--- a/include/rbtree.h
+++ b/include/rbtree.h
@@ -95,5 +95,12 @@ RbtIterator rbtFindLeftmost(RbtHandle h, void *key,
 RbtIterator rbtFind(RbtHandle h, void *key);
 // returns iterator associated with key
 
+void rbtTraversal(RbtHandle h, RbtIterator it, void *handler_arg,
+          void(*handler)(void *arg, RbtIterator it));
+// tree traversal that visits (applies handler()) each node in the tree data
+//   strucutre exactly once.
+
+void *rbtRoot(RbtHandle h);
+// returns the root of the tree
 
 #endif /* RBTREE_H_ */

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -936,6 +936,28 @@ ofi_cpuid(unsigned func, unsigned subfunc, unsigned cpuinfo[4])
 
 #endif /* defined(_M_X64) || defined(_M_AMD64) */
 
+typedef void (*ofi_mem_free_hook)(void *, const void *);
+typedef void *(*ofi_mem_realloc_hook)(void *, size_t, const void *);
+
+static inline void ofi_set_mem_free_hook(ofi_mem_free_hook free_hook)
+{
+	OFI_UNUSED(free_hook);
+}
+
+static inline void ofi_set_mem_realloc_hook(ofi_mem_realloc_hook realloc_hook)
+{
+	OFI_UNUSED(realloc_hook);
+}
+
+static inline ofi_mem_free_hook ofi_get_mem_free_hook(void)
+{
+	return NULL;
+}
+
+static inline ofi_mem_realloc_hook ofi_get_mem_realloc_hook(void)
+{
+	return NULL;
+}
 
 #ifdef __cplusplus
 }

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -727,7 +727,8 @@ static ssize_t rxm_cq_write_error(struct fid_cq *msg_cq,
 					       err_entry.err_data, NULL, 0));
 		return -FI_EOPBADSTATE;
 	}
-	rxm_cntr_incerr(util_cntr);
+	if (util_cntr)
+		rxm_cntr_incerr(util_cntr);
 	return ofi_cq_write_error(util_cq, &err_entry);
 }
 

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -106,7 +106,8 @@ void ofi_monitor_unsubscribe(struct ofi_subscription *subscription)
 					       subscription->len,
 					       subscription);
 	fastlock_acquire(&subscription->nq->lock);
-	dlist_init(&subscription->entry);
+	if (!dlist_empty(&subscription->entry))
+		dlist_remove_init(&subscription->entry);
 	subscription->nq->refcnt--;
 	fastlock_release(&subscription->nq->lock);
 }

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -78,13 +78,13 @@ int ofi_monitor_subscribe(struct ofi_notification_queue *nq,
 	dlist_init(&subscription->entry);
 
 	subscription->nq = nq;
-	subscription->addr = addr;
-	subscription->len = len;
+	subscription->iov.iov_base = addr;
+	subscription->iov.iov_len = len;
 	fastlock_acquire(&nq->lock);
 	nq->refcnt++;
 	fastlock_release(&nq->lock);
 
-	ret = nq->monitor->subscribe(nq->monitor, addr, len, subscription);
+	ret = nq->monitor->subscribe(nq->monitor, subscription);
 	if (OFI_UNLIKELY(ret)) {
 		FI_WARN(&core_prov, FI_LOG_MR,
 			"Failed (ret = %d) to monitor addr=%p len=%zu",
@@ -100,10 +100,8 @@ void ofi_monitor_unsubscribe(struct ofi_subscription *subscription)
 {
 	FI_DBG(&core_prov, FI_LOG_MR,
 	       "unsubscribing addr=%p len=%zu subscription=%p\n",
-	       subscription->addr, subscription->len, subscription);
+	       subscription->iov.iov_base, subscription->iov.iov_len, subscription);
 	subscription->nq->monitor->unsubscribe(subscription->nq->monitor,
-					       subscription->addr,
-					       subscription->len,
 					       subscription);
 	fastlock_acquire(&subscription->nq->lock);
 	if (!dlist_empty(&subscription->entry))

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -112,36 +112,9 @@ void ofi_monitor_unsubscribe(struct ofi_subscription *subscription)
 	fastlock_release(&subscription->nq->lock);
 }
 
-static void util_monitor_read_events(struct ofi_mem_monitor *monitor)
-{
-	struct ofi_subscription *subscription;
-
-	do {
-		subscription = monitor->get_event(monitor);
-		if (!subscription) {
-			FI_DBG(&core_prov, FI_LOG_MR,
-			       "no more events to be read\n");
-			break;
-		}
-
-		FI_DBG(&core_prov, FI_LOG_MR,
-		       "found event, context=%p, addr=%p, len=%zu nq=%p\n",
-		       subscription, subscription->addr,
-		       subscription->len, subscription->nq);
-
-		fastlock_acquire(&subscription->nq->lock);
-		if (dlist_empty(&subscription->entry))
-			dlist_insert_tail(&subscription->entry,
-					   &subscription->nq->list);
-		fastlock_release(&subscription->nq->lock);
-	} while (1);
-}
-
 struct ofi_subscription *ofi_monitor_get_event(struct ofi_notification_queue *nq)
 {
 	struct ofi_subscription *subscription;
-
-	util_monitor_read_events(nq->monitor);
 
 	fastlock_acquire(&nq->lock);
 	if (!dlist_empty(&nq->list)) {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -49,7 +49,6 @@
 #include <assert.h>
 #include <pthread.h>
 #include <sys/epoll.h>
-#include <malloc.h>
 
 #include <infiniband/ib.h>
 #include <infiniband/verbs.h>
@@ -157,16 +156,16 @@
 	}						\
 })
 
-#define FI_IBV_MEMORY_HOOK_BEGIN(notifier)					\
-{										\
-	pthread_mutex_lock(&notifier->lock);					\
-	fi_ibv_mem_notifier_set_free_hook(notifier->prev_free_hook);		\
-	fi_ibv_mem_notifier_set_realloc_hook(notifier->prev_realloc_hook);	\
+#define FI_IBV_MEMORY_HOOK_BEGIN(notifier)			\
+{								\
+	pthread_mutex_lock(&notifier->lock);			\
+	ofi_set_mem_free_hook(notifier->prev_free_hook);	\
+	ofi_set_mem_realloc_hook(notifier->prev_realloc_hook);	\
 
-#define FI_IBV_MEMORY_HOOK_END(notifier)					\
-	fi_ibv_mem_notifier_set_realloc_hook(fi_ibv_mem_notifier_realloc_hook);	\
-	fi_ibv_mem_notifier_set_free_hook(fi_ibv_mem_notifier_free_hook);	\
-	pthread_mutex_unlock(&notifier->lock);					\
+#define FI_IBV_MEMORY_HOOK_END(notifier)				\
+	ofi_set_mem_realloc_hook(fi_ibv_mem_notifier_realloc_hook);	\
+	ofi_set_mem_free_hook(fi_ibv_mem_notifier_free_hook);		\
+	pthread_mutex_unlock(&notifier->lock);				\
 }
 
 extern struct fi_provider fi_ibv_prov;
@@ -350,9 +349,6 @@ typedef int(*fi_ibv_mr_reg_cb)(struct fi_ibv_domain *domain, void *buf,
 			       struct fi_ibv_mem_desc *md);
 typedef int(*fi_ibv_mr_dereg_cb)(struct fi_ibv_mem_desc *md);
 
-void fi_ibv_mem_notifier_free_hook(void *ptr, const void *caller);
-void *fi_ibv_mem_notifier_realloc_hook(void *ptr, size_t size, const void *caller);
-
 struct fi_ibv_mem_notifier;
 
 struct fi_ibv_domain {
@@ -472,9 +468,6 @@ fi_ibv_mr_internal_lkey(struct fi_ibv_mem_desc *md)
 	return md->mr->lkey;
 }
 
-typedef void (*fi_ibv_mem_free_hook)(void *, const void *);
-typedef void *(*fi_ibv_mem_realloc_hook)(void *, size_t, const void *);
-
 struct fi_ibv_mr_internal_ops {
 	struct fi_ops_mr	*fi_ops;
 	fi_ibv_mr_reg_cb	internal_mr_reg;
@@ -492,11 +485,14 @@ struct fi_ibv_mem_notifier {
 	struct fi_ibv_mem_ptr_entry	*mem_ptrs_hash;
 	struct util_buf_pool		*mem_ptrs_ent_pool;
 	struct dlist_entry		event_list;
-	fi_ibv_mem_free_hook		prev_free_hook;
-	fi_ibv_mem_realloc_hook		prev_realloc_hook;
+	ofi_mem_free_hook		prev_free_hook;
+	ofi_mem_realloc_hook		prev_realloc_hook;
 	int				ref_cnt;
 	pthread_mutex_t			lock;
 };
+
+void fi_ibv_mem_notifier_free_hook(void *ptr, const void *caller);
+void *fi_ibv_mem_notifier_realloc_hook(void *ptr, size_t size, const void *caller);
 
 extern struct fi_ibv_mr_internal_ops fi_ibv_mr_internal_ops;
 extern struct fi_ibv_mr_internal_ops fi_ibv_mr_internal_cache_ops;
@@ -511,114 +507,6 @@ int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier, void *addr,
 void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier, void *addr,
 				size_t len, struct ofi_subscription *subscription);
 struct ofi_subscription *fi_ibv_monitor_get_event(struct ofi_mem_monitor *notifier);
-
-static inline void
-fi_ibv_mem_notifier_set_free_hook(fi_ibv_mem_free_hook free_hook)
-{
-#ifdef HAVE_GLIBC_MALLOC_HOOKS
-# ifdef __INTEL_COMPILER /* ICC */
-#  pragma warning push
-#  pragma warning disable 1478
-	__free_hook = free_hook;
-#  pragma warning pop
-# elif defined __clang__ /* Clang */
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	__free_hook = free_hook;
-#  pragma clang diagnostic pop
-# elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) /* GCC >= 4.6 */
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	__free_hook = free_hook;
-#  pragma GCC diagnostic pop
-# else /* others */
-	__free_hook = free_hook;
-# endif
-#else /* !HAVE_GLIBC_MALLOC_HOOKS */
-	OFI_UNUSED(free_hook);
-#endif /* HAVE_GLIBC_MALLOC_HOOKS */
-}
-
-static inline void
-fi_ibv_mem_notifier_set_realloc_hook(fi_ibv_mem_realloc_hook realloc_hook)
-{
-#ifdef HAVE_GLIBC_MALLOC_HOOKS
-# ifdef __INTEL_COMPILER /* ICC */
-#  pragma warning push
-#  pragma warning disable 1478
-	__realloc_hook = realloc_hook;
-#  pragma warning pop
-# elif defined __clang__ /* Clang */
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	__realloc_hook = realloc_hook;
-#  pragma clang diagnostic pop
-# elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) /* GCC >= 4.6 */
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	__realloc_hook = realloc_hook;
-#  pragma GCC diagnostic pop
-# else /* others */
-	__realloc_hook = realloc_hook;
-# endif
-#else /* !HAVE_GLIBC_MALLOC_HOOKS */
-	OFI_UNUSED(realloc_hook);
-#endif /* HAVE_GLIBC_MALLOC_HOOKS */
-}
-
-static inline fi_ibv_mem_free_hook
-fi_ibv_mem_notifier_get_free_hook(void)
-{
-#ifdef HAVE_GLIBC_MALLOC_HOOKS
-# ifdef __INTEL_COMPILER /* ICC */
-#  pragma warning push
-#  pragma warning disable 1478
-	return __free_hook;
-#  pragma warning pop
-# elif defined __clang__ /* Clang */
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	return __free_hook;
-#  pragma clang diagnostic pop
-# elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) /* GCC >= 4.6 */
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	return __free_hook;
-#  pragma GCC diagnostic pop
-# else /* others */
-	return __free_hook;
-# endif
-#else /* !HAVE_GLIBC_MALLOC_HOOKS */
-	return NULL;
-#endif /* HAVE_GLIBC_MALLOC_HOOKS */
-}
-
-static inline fi_ibv_mem_realloc_hook
-fi_ibv_mem_notifier_get_realloc_hook(void)
-{
-#ifdef HAVE_GLIBC_MALLOC_HOOKS
-# ifdef __INTEL_COMPILER /* ICC */
-#  pragma warning push
-#  pragma warning disable 1478
-	return __realloc_hook;
-#  pragma warning pop
-# elif defined __clang__ /* Clang */
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wdeprecated-declarations"
-	return __realloc_hook;
-#  pragma clang diagnostic pop
-# elif __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6) /* GCC >= 4.6 */
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-	return __realloc_hook;
-#  pragma GCC diagnostic pop
-# else /* others */
-	return __realloc_hook;
-# endif
-#else /* !HAVE_GLIBC_MALLOC_HOOKS */
-	return NULL;
-#endif /* HAVE_GLIBC_MALLOC_HOOKS */
-}
 
 struct fi_ibv_srq_ep {
 	struct fid_ep		ep_fid;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -474,16 +474,8 @@ struct fi_ibv_mr_internal_ops {
 	fi_ibv_mr_dereg_cb	internal_mr_dereg;
 };
 
-struct fi_ibv_mem_ptr_entry {
-	struct dlist_entry	entry;
-	void			*addr;
-	struct ofi_subscription *subscription;
-	UT_hash_handle		hh;
-};
-
 struct fi_ibv_mem_notifier {
-	struct fi_ibv_mem_ptr_entry	*mem_ptrs_hash;
-	struct util_buf_pool		*mem_ptrs_ent_pool;
+	RbtHandle			subscr_storage;
 	ofi_mem_free_hook		prev_free_hook;
 	ofi_mem_realloc_hook		prev_realloc_hook;
 	int				ref_cnt;
@@ -501,10 +493,10 @@ int fi_ibv_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 			      struct ofi_mr_entry *entry);
 void fi_ibv_mr_cache_entry_dereg(struct ofi_mr_cache *cache,
 				 struct ofi_mr_entry *entry);
-int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier, void *addr,
-			     size_t len, struct ofi_subscription *subscription);
-void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier, void *addr,
-				size_t len, struct ofi_subscription *subscription);
+int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier,
+			     struct ofi_subscription *subscription);
+void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier,
+				struct ofi_subscription *subscription);
 struct ofi_subscription *fi_ibv_monitor_get_event(struct ofi_mem_monitor *notifier);
 
 struct fi_ibv_srq_ep {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -484,7 +484,6 @@ struct fi_ibv_mem_ptr_entry {
 struct fi_ibv_mem_notifier {
 	struct fi_ibv_mem_ptr_entry	*mem_ptrs_hash;
 	struct util_buf_pool		*mem_ptrs_ent_pool;
-	struct dlist_entry		event_list;
 	ofi_mem_free_hook		prev_free_hook;
 	ofi_mem_realloc_hook		prev_realloc_hook;
 	int				ref_cnt;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -172,8 +172,8 @@ static void fi_ibv_mem_notifier_finalize(struct fi_ibv_mem_notifier *notifier)
 	assert(fi_ibv_mem_notifier && (notifier == fi_ibv_mem_notifier));
 	pthread_mutex_lock(&fi_ibv_mem_notifier->lock);
 	if (--fi_ibv_mem_notifier->ref_cnt == 0) {
-		fi_ibv_mem_notifier_set_free_hook(fi_ibv_mem_notifier->prev_free_hook);
-		fi_ibv_mem_notifier_set_realloc_hook(fi_ibv_mem_notifier->prev_realloc_hook);
+		ofi_set_mem_free_hook(fi_ibv_mem_notifier->prev_free_hook);
+		ofi_set_mem_realloc_hook(fi_ibv_mem_notifier->prev_realloc_hook);
 		util_buf_pool_destroy(fi_ibv_mem_notifier->mem_ptrs_ent_pool);
 		fi_ibv_mem_notifier->prev_free_hook = NULL;
 		fi_ibv_mem_notifier->prev_realloc_hook = NULL;
@@ -217,10 +217,10 @@ static struct fi_ibv_mem_notifier *fi_ibv_mem_notifier_init(void)
 	dlist_init(&fi_ibv_mem_notifier->event_list);
 
 	pthread_mutex_lock(&fi_ibv_mem_notifier->lock);
-	fi_ibv_mem_notifier->prev_free_hook = fi_ibv_mem_notifier_get_free_hook();
-	fi_ibv_mem_notifier->prev_realloc_hook = fi_ibv_mem_notifier_get_realloc_hook();
-	fi_ibv_mem_notifier_set_free_hook(fi_ibv_mem_notifier_free_hook);
-	fi_ibv_mem_notifier_set_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
+	fi_ibv_mem_notifier->prev_free_hook = ofi_get_mem_free_hook();
+	fi_ibv_mem_notifier->prev_realloc_hook = ofi_get_mem_realloc_hook();
+	ofi_set_mem_free_hook(fi_ibv_mem_notifier_free_hook);
+	ofi_set_mem_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
 	fi_ibv_mem_notifier->ref_cnt++;
 	pthread_mutex_unlock(&fi_ibv_mem_notifier->lock);
 fn:

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -32,6 +32,7 @@
 
 #include "config.h"
 
+#include "ofi_iov.h"
 #include "ep_rdm/verbs_rdm.h"
 #include "ep_dgram/verbs_dgram.h"
 
@@ -113,9 +114,39 @@ static void *fi_ibv_rdm_cm_progress_thread(void *dom)
 	return NULL;
 }
 
+void fi_ibv_mem_notifier_handle_hook(void *arg, RbtIterator iter)
+{
+	struct iovec *key;
+	struct ofi_subscription *subscription;
+
+	rbtKeyValue(fi_ibv_mem_notifier->subscr_storage, iter,
+		    (void *)&key, (void *)&subscription);
+
+	VERBS_DBG(FI_LOG_MR, "Write event for region %p:%lu\n",
+		  key->iov_base, key->iov_len);
+	ofi_monitor_add_event_to_nq(subscription);
+}
+
+static inline void
+fi_ibv_mem_notifier_search_iov(struct fi_ibv_mem_notifier *notifier,
+			       struct iovec *iov)
+{
+	RbtIterator iter;
+	iter = rbtFind(notifier->subscr_storage, (void *)iov);
+	if (iter) {
+		VERBS_DBG(FI_LOG_MR, "Catch hook for memory %p:%lu\n",
+			  iov->iov_base, iov->iov_len);
+		rbtTraversal(fi_ibv_mem_notifier->subscr_storage, iter, NULL,
+			     fi_ibv_mem_notifier_handle_hook);
+	}
+}
+
 void fi_ibv_mem_notifier_free_hook(void *ptr, const void *caller)
 {
-	struct fi_ibv_mem_ptr_entry *entry;
+	struct iovec iov = {
+		.iov_base = ptr,
+		.iov_len = malloc_usable_size(ptr),
+	};
 	OFI_UNUSED(caller);
 
 	FI_IBV_MEMORY_HOOK_BEGIN(fi_ibv_mem_notifier)
@@ -124,19 +155,17 @@ void fi_ibv_mem_notifier_free_hook(void *ptr, const void *caller)
 
 	if (!ptr)
 		goto out;
-
-	HASH_FIND(hh, fi_ibv_mem_notifier->mem_ptrs_hash, &ptr, sizeof(void *), entry);
-	if (!entry)
-		goto out;
-	VERBS_DBG(FI_LOG_MR, "Catch free hook for %p, entry - %p\n", ptr, entry);
-	ofi_monitor_add_event_to_nq(entry->subscription);
+	fi_ibv_mem_notifier_search_iov(fi_ibv_mem_notifier, &iov);
 out:
 	FI_IBV_MEMORY_HOOK_END(fi_ibv_mem_notifier)
 }
 
 void *fi_ibv_mem_notifier_realloc_hook(void *ptr, size_t size, const void *caller)
 {
-	struct fi_ibv_mem_ptr_entry *entry;
+	struct iovec iov = {
+		.iov_base = ptr,
+		.iov_len = malloc_usable_size(ptr),
+	};
 	void *ret_ptr;
 	OFI_UNUSED(caller);
 
@@ -146,12 +175,7 @@ void *fi_ibv_mem_notifier_realloc_hook(void *ptr, size_t size, const void *calle
 
 	if (!ptr)
 		goto out;
-
-	HASH_FIND(hh, fi_ibv_mem_notifier->mem_ptrs_hash, &ptr, sizeof(void *), entry);
-	if (!entry)
-		goto out;
-	VERBS_DBG(FI_LOG_MR, "Catch realloc hook for %p, entry - %p\n", ptr, entry);
-	ofi_monitor_add_event_to_nq(entry->subscription);
+	fi_ibv_mem_notifier_search_iov(fi_ibv_mem_notifier, &iov);
 out:
 	FI_IBV_MEMORY_HOOK_END(fi_ibv_mem_notifier)
 	return ret_ptr;
@@ -166,7 +190,7 @@ static void fi_ibv_mem_notifier_finalize(struct fi_ibv_mem_notifier *notifier)
 	if (--fi_ibv_mem_notifier->ref_cnt == 0) {
 		ofi_set_mem_free_hook(fi_ibv_mem_notifier->prev_free_hook);
 		ofi_set_mem_realloc_hook(fi_ibv_mem_notifier->prev_realloc_hook);
-		util_buf_pool_destroy(fi_ibv_mem_notifier->mem_ptrs_ent_pool);
+		rbtDelete(fi_ibv_mem_notifier->subscr_storage);
 		fi_ibv_mem_notifier->prev_free_hook = NULL;
 		fi_ibv_mem_notifier->prev_realloc_hook = NULL;
 		pthread_mutex_unlock(&fi_ibv_mem_notifier->lock);
@@ -179,10 +203,35 @@ static void fi_ibv_mem_notifier_finalize(struct fi_ibv_mem_notifier *notifier)
 #endif
 }
 
+#ifdef HAVE_GLIBC_MALLOC_HOOKS
+static int fi_ibv_mem_notifier_find_within(void *a, void *b)
+{
+	struct iovec *iov1 = a, *iov2 = b;
+
+	if (ofi_iov_shifted_left(iov1, iov2))
+		return -1;
+	else if (ofi_iov_shifted_right(iov1, iov2))
+		return 1;
+	else
+		return 0;
+}
+
+static int fi_ibv_mem_notifier_find_overlap(void *a, void *b)
+{
+	struct iovec *iov1 = a, *iov2 = b;
+
+	if (ofi_iov_left(iov1, iov2))
+		return -1;
+	else if (ofi_iov_right(iov1, iov2))
+		return 1;
+	else
+		return 0;
+}
+#endif
+
 static struct fi_ibv_mem_notifier *fi_ibv_mem_notifier_init(void)
 {
 #ifdef HAVE_GLIBC_MALLOC_HOOKS
-	int ret;
 	pthread_mutexattr_t mutex_attr;
 	if (fi_ibv_mem_notifier) {
 		/* already initialized */
@@ -193,11 +242,11 @@ static struct fi_ibv_mem_notifier *fi_ibv_mem_notifier_init(void)
 	if (!fi_ibv_mem_notifier)
 		goto fn;
 
-	ret = util_buf_pool_create(&fi_ibv_mem_notifier->mem_ptrs_ent_pool,
-				   sizeof(struct fi_ibv_mem_ptr_entry),
-				   FI_IBV_MEM_ALIGNMENT, 0,
-				   fi_ibv_gl_data.mr_max_cached_cnt);
-	if (ret)
+	fi_ibv_mem_notifier->subscr_storage =
+		rbtNew(fi_ibv_gl_data.mr_cache_merge_regions ?
+		       fi_ibv_mem_notifier_find_overlap :
+		       fi_ibv_mem_notifier_find_within);
+	if (!fi_ibv_mem_notifier->subscr_storage)
 		goto err1;
 
 	pthread_mutexattr_init(&mutex_attr);
@@ -217,7 +266,7 @@ fn:
 	return fi_ibv_mem_notifier;
 
 err2:
-	util_buf_pool_destroy(fi_ibv_mem_notifier->mem_ptrs_ent_pool);
+	rbtDelete(fi_ibv_mem_notifier->subscr_storage);
 err1:
 	free(fi_ibv_mem_notifier);
 	fi_ibv_mem_notifier = NULL;

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -385,8 +385,8 @@ int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier, void *addr,
 	int ret = FI_SUCCESS;
 
 	pthread_mutex_lock(&domain->notifier->lock);
-	fi_ibv_mem_notifier_set_free_hook(domain->notifier->prev_free_hook);
-	fi_ibv_mem_notifier_set_realloc_hook(domain->notifier->prev_realloc_hook);
+	ofi_set_mem_free_hook(domain->notifier->prev_free_hook);
+	ofi_set_mem_realloc_hook(domain->notifier->prev_realloc_hook);
 
 	entry = util_buf_alloc(domain->notifier->mem_ptrs_ent_pool);
 	if (OFI_UNLIKELY(!entry)) {
@@ -400,8 +400,8 @@ int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier, void *addr,
 	HASH_ADD(hh, domain->notifier->mem_ptrs_hash, addr, sizeof(void *), entry);
 
 fn:
-	fi_ibv_mem_notifier_set_free_hook(fi_ibv_mem_notifier_free_hook);
-	fi_ibv_mem_notifier_set_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
+	ofi_set_mem_free_hook(fi_ibv_mem_notifier_free_hook);
+	ofi_set_mem_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
 	pthread_mutex_unlock(&domain->notifier->lock);
 	return ret;
 }
@@ -414,8 +414,8 @@ void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier, void *addr,
 	struct fi_ibv_mem_ptr_entry *entry;
 
 	pthread_mutex_lock(&domain->notifier->lock);
-	fi_ibv_mem_notifier_set_free_hook(domain->notifier->prev_free_hook);
-	fi_ibv_mem_notifier_set_realloc_hook(domain->notifier->prev_realloc_hook);
+	ofi_set_mem_free_hook(domain->notifier->prev_free_hook);
+	ofi_set_mem_realloc_hook(domain->notifier->prev_realloc_hook);
 
 	HASH_FIND(hh, domain->notifier->mem_ptrs_hash, &addr, sizeof(void *), entry);
 	assert(entry);
@@ -427,8 +427,8 @@ void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier, void *addr,
 
 	util_buf_release(domain->notifier->mem_ptrs_ent_pool, entry);
 
-	fi_ibv_mem_notifier_set_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
-	fi_ibv_mem_notifier_set_free_hook(fi_ibv_mem_notifier_free_hook);
+	ofi_set_mem_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
+	ofi_set_mem_free_hook(fi_ibv_mem_notifier_free_hook);
 	pthread_mutex_unlock(&domain->notifier->lock);
 }
 

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -376,56 +376,43 @@ static struct fi_ops fi_ibv_mr_cache_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
-int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier, void *addr,
-			     size_t len, struct ofi_subscription *subscription)
+int fi_ibv_monitor_subscribe(struct ofi_mem_monitor *notifier,
+			     struct ofi_subscription *subscription)
 {
 	struct fi_ibv_domain *domain =
 		container_of(notifier, struct fi_ibv_domain, monitor);
-	struct fi_ibv_mem_ptr_entry *entry;
-	int ret = FI_SUCCESS;
+	int ret;
 
 	pthread_mutex_lock(&domain->notifier->lock);
 	ofi_set_mem_free_hook(domain->notifier->prev_free_hook);
 	ofi_set_mem_realloc_hook(domain->notifier->prev_realloc_hook);
 
-	entry = util_buf_alloc(domain->notifier->mem_ptrs_ent_pool);
-	if (OFI_UNLIKELY(!entry)) {
-		ret = -FI_ENOMEM;
-		goto fn;
-	}
+	ret = (rbtInsert(domain->notifier->subscr_storage,
+		         (void *)&subscription->iov,
+			 (void *)subscription) != RBT_STATUS_OK) ?
+	       -FI_EAVAIL : FI_SUCCESS;
 
-	entry->addr = addr;
-	entry->subscription = subscription;
-	dlist_init(&entry->entry);
-	HASH_ADD(hh, domain->notifier->mem_ptrs_hash, addr, sizeof(void *), entry);
-
-fn:
 	ofi_set_mem_free_hook(fi_ibv_mem_notifier_free_hook);
 	ofi_set_mem_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
 	pthread_mutex_unlock(&domain->notifier->lock);
 	return ret;
 }
 
-void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier, void *addr,
-				size_t len, struct ofi_subscription *subscription)
+void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier,
+				struct ofi_subscription *subscription)
 {
 	struct fi_ibv_domain *domain =
 		container_of(notifier, struct fi_ibv_domain, monitor);
-	struct fi_ibv_mem_ptr_entry *entry;
+	RbtIterator iter;
 
 	pthread_mutex_lock(&domain->notifier->lock);
 	ofi_set_mem_free_hook(domain->notifier->prev_free_hook);
 	ofi_set_mem_realloc_hook(domain->notifier->prev_realloc_hook);
 
-	HASH_FIND(hh, domain->notifier->mem_ptrs_hash, &addr, sizeof(void *), entry);
-	assert(entry);
-
-	HASH_DEL(domain->notifier->mem_ptrs_hash, entry);
-
-	if (!dlist_empty(&entry->entry))
-		dlist_remove_init(&entry->entry);
-
-	util_buf_release(domain->notifier->mem_ptrs_ent_pool, entry);
+	iter = rbtFind(domain->notifier->subscr_storage,
+		       (void *)&subscription->iov);
+	assert(iter);
+	rbtErase(domain->notifier->subscr_storage, iter);
 
 	ofi_set_mem_realloc_hook(fi_ibv_mem_notifier_realloc_hook);
 	ofi_set_mem_free_hook(fi_ibv_mem_notifier_free_hook);

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -432,32 +432,6 @@ void fi_ibv_monitor_unsubscribe(struct ofi_mem_monitor *notifier, void *addr,
 	pthread_mutex_unlock(&domain->notifier->lock);
 }
 
-struct ofi_subscription *
-fi_ibv_monitor_get_event(struct ofi_mem_monitor *notifier)
-{
-	struct fi_ibv_domain *domain =
-		container_of(notifier, struct fi_ibv_domain, monitor);
-	struct fi_ibv_mem_ptr_entry *entry;
-
-	pthread_mutex_lock(&domain->notifier->lock);
-	if (!dlist_empty(&domain->notifier->event_list)) {
-		dlist_pop_front(&domain->notifier->event_list,
-				struct fi_ibv_mem_ptr_entry,
-				entry, entry);
-		VERBS_DBG(FI_LOG_MR,
-			  "Retrieve %p (entry %p) from event list\n",
-			  entry->addr, entry);
-		/* needed to protect against double insertions */
-		dlist_init(&entry->entry);
-
-		pthread_mutex_unlock(&domain->notifier->lock);
-		return entry->subscription;
-	} else {
-		pthread_mutex_unlock(&domain->notifier->lock);
-		return NULL;
-	}
-}
-
 int fi_ibv_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 			      struct ofi_mr_entry *entry)
 {

--- a/src/rbtree.c
+++ b/src/rbtree.c
@@ -434,3 +434,24 @@ void *rbtFind(RbtHandle h, void *key) {
     }
     return NULL;
 }
+
+void rbtTraversal(RbtHandle h, RbtIterator it, void *handler_arg,
+          void(*handler)(void *arg, RbtIterator it)) {
+    RbtType *rbt = h;
+    NodeType *root = it;
+
+    // apply handler for:
+    // -o the root of the tree/subtree
+    handler(handler_arg, it);
+    // - the left subtree
+    if (root->left != SENTINEL)
+        rbtTraversal(h, root->left, handler_arg, handler);
+    // - the right subtree
+    if (root->right != SENTINEL)
+        rbtTraversal(h, root->right, handler_arg, handler);
+}
+
+void *rbtRoot(RbtHandle h) {
+    RbtType *rbt = h;
+    return rbt->root;
+}


### PR DESCRIPTION
- common/osd: Add memory hooks setters and getters 
- prov/verbs: Use common memory hooks 
-  util/mem_monitor: Remove a subscription entry from NQ list when unsubscribed from a MR entry
- common/rbtree: Add tree traversal and get root routines 
- util/mem_monitor, prov/verbs: Write free/realloc events from hooks to NQ event list
- prov/verbs, util/mem_monitor: Fix notofication mechanism for MR cache 
- prov/rxm: fix a crash when incrementing error counter 
