### PR TITLE
prov/psm2: Clean up CQ/counter poll list when endpoint is closed

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -529,6 +529,12 @@ struct psmx2_trx_ctxt {
 	struct dlist_entry	peer_list;
 	fastlock_t		peer_lock;
 
+	/* number of pathes this tx/rx context can be polled. this include
+	 * CQs and counters, as well as domain->trx_ctxt_list.
+	 */
+	ofi_atomic32_t		poll_refcnt;
+	int			poll_active;
+
 	struct dlist_entry	entry;
 };
 
@@ -1100,7 +1106,7 @@ static inline void psmx2_get_source_string_name(psm2_epaddr_t source, char *name
 
 static inline void psmx2_progress(struct psmx2_trx_ctxt *trx_ctxt)
 {
-	if (trx_ctxt) {
+	if (trx_ctxt && trx_ctxt->poll_active) {
 #if HAVE_PSM2_MQ_REQ_USER
 		psmx2_cq_poll_mq(NULL, trx_ctxt, NULL, 1, NULL);
 #else

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -276,6 +276,8 @@ static int psmx2_cntr_close(fid_t fid)
 	while (!slist_empty(&cntr->poll_list)) {
 		entry = slist_remove_head(&cntr->poll_list);
 		item = container_of(entry, struct psmx2_poll_ctxt, list_entry);
+		if (!ofi_atomic_dec32(&item->trx_ctxt->poll_refcnt))
+			free(item->trx_ctxt);
 		free(item);
 	}
 

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -254,6 +254,7 @@ static int psmx2_add_poll_ctxt(struct slist *list, struct psmx2_trx_ctxt *trx_ct
 	if (!item)
 		return -FI_ENOMEM;
 
+	ofi_atomic_inc32(&trx_ctxt->poll_refcnt);
 	item->trx_ctxt = trx_ctxt;
 	slist_insert_tail(&item->list_entry, list);
 	return 0;

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -176,6 +176,9 @@ void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt, int usage_flags)
 	FI_INFO(&psmx2_prov, FI_LOG_CORE, "epid: %016lx (%s)\n",
 		trx_ctxt->psm2_epid, psmx2_usage_flags_to_string(old_flags));
 
+	trx_ctxt->am_progress = 0;
+	trx_ctxt->poll_active = 0;
+
 	trx_ctxt->domain->trx_ctxt_lock_fn(&trx_ctxt->domain->trx_ctxt_lock, 1);
 	dlist_remove(&trx_ctxt->entry);
 	trx_ctxt->domain->trx_ctxt_unlock_fn(&trx_ctxt->domain->trx_ctxt_lock, 1);
@@ -213,7 +216,9 @@ void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt, int usage_flags)
 	fastlock_destroy(&trx_ctxt->am_req_pool_lock);
 	fastlock_destroy(&trx_ctxt->poll_lock);
 	fastlock_destroy(&trx_ctxt->peer_lock);
-	free(trx_ctxt);
+
+	if (!ofi_atomic_dec32(&trx_ctxt->poll_refcnt))
+		free(trx_ctxt);
 }
 
 struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
@@ -336,6 +341,8 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	trx_ctxt->id = psmx2_trx_ctxt_cnt++;
 	trx_ctxt->domain = domain;
 	trx_ctxt->usage_flags = asked_flags;
+	trx_ctxt->poll_active = 1;
+	ofi_atomic_initialize32(&trx_ctxt->poll_refcnt, 1); /* take one ref for domain->trx_ctxt_list */
 
 	domain->trx_ctxt_lock_fn(&domain->trx_ctxt_lock, 1);
 	dlist_insert_before(&trx_ctxt->entry, &domain->trx_ctxt_list);


### PR DESCRIPTION
Fix potential run-time errors when a CQ/counter is polled after one or more
endpoints bound to it have been closed.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>