### PR TITLE
travis: Provide newer ibverbs/rdma-core to support XRC builds in linux with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,31 @@ addons:
     apt:
         packages:
             - rpm
-            - libibverbs-dev
-            - librdmacm-dev
             - libnl-3-200
             - libnl-3-dev
             - libnl-route-3-200
             - libnl-route-3-dev
             - libnuma-dev
+# required for rdma-core
+            - build-essential
+            - debhelper
+            - dh-systemd
+            - fakeroot
+            - gcc
+            - git
+            - libudev-dev
+            - make
+            - ninja-build
+            - pandoc
+            - pkg-config
+            - python
+            - valgrind
+            - sparse
+            - wget
+            - abi-compliance-checker
+            - abi-dumper
+# 32 bit support packages
+            - gcc-multilib
     ssh_known_hosts:
         - www.openfabrics.org
         - git.kernel.org
@@ -39,10 +57,15 @@ before_install:
 
 install:
     - ./autogen.sh
+    # Build rdma-core because ubuntu trusty doesn't have a sufficiently new version of ibverbs/rdma-core
     # Build verbs only in linux as OS X doesn't have verbs support
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then
+        RDMA_CORE_BRANCH=v13 ;
+        git clone --depth 1 -b $RDMA_CORE_BRANCH https://github.com/linux-rdma/rdma-core.git && cd rdma-core && bash build.sh && cd - ;
+        RDMA_CORE_PATH=$PWD/rdma-core/build ;
+        export LD_LIBRARY_PATH="$RDMA_CORE_PATH/lib:$LD_LIBRARY_PATH" ;
         LIBFABRIC_CONFIGURE_ARGS="$LIBFABRIC_CONFIGURE_ARGS --enable-usnic
-        --enable-verbs --enable-mlx=$HOME/mlx";
+        --enable-verbs=$RDMA_CORE_PATH --enable-mlx=$HOME/mlx";
         UCX_BRANCH=v1.2.x;
         git clone --depth 1 -b $UCX_BRANCH https://github.com/openucx/ucx.git && cd ucx && ./autogen.sh && ./configure --prefix=$HOME/mlx CFLAGS="-w" && make -j2 install && cd -;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     - ./autogen.sh
     # Build verbs only in linux as OS X doesn't have verbs support
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-        LIBRARY_CONFIGURE_ARGS="$LIBFABRIC_CONFIGURE_ARGS --enable-usnic
+        LIBFABRIC_CONFIGURE_ARGS="$LIBFABRIC_CONFIGURE_ARGS --enable-usnic
         --enable-verbs --enable-mlx=$HOME/mlx";
         UCX_BRANCH=v1.2.x;
         git clone --depth 1 -b $UCX_BRANCH https://github.com/openucx/ucx.git && cd ucx && ./autogen.sh && ./configure --prefix=$HOME/mlx CFLAGS="-w" && make -j2 install && cd -;


### PR DESCRIPTION
This PR is meant to address a deficiency in the current Travis CI build environment. With the XRC PR, Travis CI does not provide a sufficiently recent version to build the XRC implementation. The intent of this PR is to build a newer rdma-core for the Travis CI container and use that rdma-core build to compile the new feature. 