### PR TITLE
prov/sockets: Enable MSG EP when calling fi_accept

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -781,8 +781,9 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param, size_t paraml
 			return ret;
 		}
 	}
-    /* Monitor the handle prior to report the event */
+	/* Monitor the handle prior to report the event */
 	sock_ep_cm_monitor_handle(cm_head, handle, FI_EPOLL_IN);
+	sock_ep_enable(ep);
 
 	cm_entry.fid = &handle->ep->ep.fid;
 	SOCK_LOG_DBG("reporting FI_CONNECTED\n");


### PR DESCRIPTION
The endpoint should transition into the enabled state on
fi_accept() automatically.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>