### PR TITLE
prov/sockets: Enable MSG EP when calling fi_accept

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -714,6 +714,8 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param, size_t paraml
 		SOCK_LOG_ERROR("Couldnt create accept handler\n");
 		return -FI_ENOMEM;
 	}
+
+	sock_ep_enable(ep);
 	return 0;
 }
 


### PR DESCRIPTION
The endpoint should transition into the enabled state on
fi_accept() automatically.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>