### PR TITLE
common, prov/rstream: fix logging and missing error checking

### DIFF
--- a/prov/rstream/src/rstream_init.c
+++ b/prov/rstream/src/rstream_init.c
@@ -109,6 +109,8 @@ static int rstream_getinfo(uint32_t version, const char *node,
 
 	ret = ofix_getinfo(version, node, service, flags, &rstream_util_prov,
 		hints, rstream_info_to_core, rstream_info_to_rstream, info);
+	if (ret)
+		return ret;
 
 	if (port_save) {
 		for (cur = *info; cur; cur = cur->next) {

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -379,7 +379,7 @@ void ofi_create_filter(struct fi_filter *filter, const char *raw_filter)
 	}
 
 	filter->names= ofi_split_and_alloc(raw_filter, ",", NULL);
-	if (filter->names)
+	if (!filter->names)
 		FI_WARN(&core_prov, FI_LOG_CORE,
 			"unable to parse filter from: %s\n", raw_filter);
 }


### PR DESCRIPTION
- common: don't print warning log when provider filter is created successfully
- prov/rstream: fix missing return value check 