### PR TITLE
fabtests, prov/rxm: bug fixes + add ubertest config

### DIFF
--- a/fabtests/test_configs/verbs/all.test
+++ b/fabtests/test_configs/verbs/all.test
@@ -1,4 +1,167 @@
 #: "Suite of tests for the verbs provider"
+#: "
+# TODO
+#  - Disable INJECT, INJECTDATA for verbs until the failure is debugged
+#    In pingpong test, we get a FLUSH error on recv CQ but no error on send
+#    queue when we don't read send completions for ibv_post_sends.
+#  - Debug WRITEDATA, WRITEMSG, READMSG for RxM before enabling
+#  - Test without FI_MR_LOCAL for RxM
+#  - disable quick test for some configs (takes long time on some fabric)
+#  - Adding more tests results in timeout in runfabtests.sh - fix the script"
+{
+	prov_name: verbs,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDDATA,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_MSG,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	test_class: [
+		FT_CAP_MSG,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	test_flags: FT_FLAG_QUICKTEST,
+},
+{
+	prov_name: verbs,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_MSG,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	test_class: [
+		FT_CAP_MSG,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	msg_flags: FI_REMOTE_CQ_DATA,
+},
+{
+	prov_name: verbs,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_WRITEDATA,
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+		FT_FUNC_READMSG,
+	],
+	ep_type: [
+		FI_EP_MSG,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	test_flags: FT_FLAG_QUICKTEST,
+},
+{
+	prov_name: verbs,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_WRITEMSG,
+	],
+	ep_type: [
+		FI_EP_MSG,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	msg_flags: FI_REMOTE_CQ_DATA,
+	test_flags: FT_FLAG_QUICKTEST,
+},
+{
+	prov_name: verbs,
+	test_type: [
+		FT_TEST_LATENCY,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+	],
+	ep_type: [
+		FI_EP_MSG,
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	eq_wait_obj: [
+		FI_WAIT_NONE,
+		FI_WAIT_UNSPEC,
+		FI_WAIT_FD,
+	],
+	cq_wait_obj: [
+		FI_WAIT_NONE,
+	],
+	test_class: [
+		FT_CAP_MSG,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
+	test_flags: FT_FLAG_QUICKTEST,
+},
+{
+	prov_name: verbs,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
+	],
+	ep_type: [
+		FI_EP_MSG,
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	eq_wait_obj: [
+		FI_WAIT_NONE,
+	],
+	cq_wait_obj: [
+		FI_WAIT_NONE,
+		FI_WAIT_UNSPEC,
+		FI_WAIT_FD,
+	],
+	test_class: [
+		FT_CAP_MSG,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
+	test_flags: FT_FLAG_QUICKTEST,
+},
 {
 	prov_name: verbs,
 	test_type: [
@@ -8,51 +171,22 @@
 	class_function: [
 		FT_FUNC_SEND,
 		FT_FUNC_SENDV,
-		FT_FUNC_SENDMSG,
+		FT_FUNC_SENDDATA,
 		FT_FUNC_INJECT,
 		FT_FUNC_INJECTDATA,
 	],
 	ep_type: [
-		FI_EP_MSG,
+		FI_EP_RDM,
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
+		FT_CAP_TAGGED,
 	],
-},
-{
-	prov_name: verbs,
-	test_type: [
-		FT_TEST_LATENCY,
-	],
-	class_function: [
-		FT_FUNC_SEND,
-	],
-	ep_type: [
-		FI_EP_MSG,
-	],
-	comp_type: [
-		FT_COMP_QUEUE,
-	],
-	eq_wait_obj: [
-		FI_WAIT_NONE,
-		FI_WAIT_UNSPEC,
-		FI_WAIT_FD,
-	],
-	cq_wait_obj: [
-		FI_WAIT_NONE,
-	],
-	mode: [
-		FT_MODE_ALL,
-	],
-	test_class: [
-		FT_CAP_MSG,
-	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
 },
 {
 	prov_name: verbs,
@@ -61,26 +195,44 @@
 		FT_TEST_BANDWIDTH,
 	],
 	class_function: [
-		FT_FUNC_SEND,
+		FT_FUNC_SENDMSG,
 	],
 	ep_type: [
-		FI_EP_MSG,
+		FI_EP_RDM,
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	eq_wait_obj: [
-		FI_WAIT_NONE,
-	],
-	cq_wait_obj: [
-		FI_WAIT_NONE,
-		FI_WAIT_UNSPEC,
-		FI_WAIT_FD,
-	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
+		FT_CAP_TAGGED,
 	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
+	msg_flags: FI_REMOTE_CQ_DATA,
+},
+{
+	prov_name: verbs,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
+	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
+	test_flags: FT_FLAG_QUICKTEST,
 },

--- a/fabtests/test_configs/verbs/verbs.exclude
+++ b/fabtests/test_configs/verbs/verbs.exclude
@@ -20,6 +20,3 @@ recv_cancel -e msg
 unexpected_msg -e msg
 rdm.+atomic
 inj_complete
-
-# Remove this once ubertest supports setting MR modes
-ubertest

--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -870,8 +870,7 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->mode = (set->mode[series->cur_mode] == FT_MODE_NONE) ?
 			0 : set->mode[series->cur_mode];
 
-	if (set->msg_flags == FI_REMOTE_CQ_DATA)
-		info->mode |= FI_RX_CQ_DATA;
+	info->mode |= FI_RX_CQ_DATA;
 
 	info->ep_type = set->ep_type[series->cur_ep];
 	info->av_type = set->av_type[series->cur_av];

--- a/fabtests/ubertest/uber.c
+++ b/fabtests/ubertest/uber.c
@@ -327,19 +327,6 @@ static int ft_recv_test_info(void)
 	return 0;
 }
 
-static int ft_skip_info(struct fi_info *hints, struct fi_info *info)
-{
-	size_t len;
-
-	//check needed to skip utility providers, unless requested
-	if (!ft_util_name(hints->fabric_attr->prov_name, &len) &&
-		strcmp(hints->fabric_attr->prov_name,
-		info->fabric_attr->prov_name))
-		return 1;
-
-	return 0;
-}
-
 static int ft_transfer_subindex(int subindex, int *remote_idx)
 {
 	int ret;
@@ -373,9 +360,6 @@ static int ft_fw_process_list_server(struct fi_info *hints, struct fi_info *info
 
 	for (subindex = 1, fabric_info = info; fabric_info;
 	     fabric_info = fabric_info->next, subindex++) {
-
-		if (ft_skip_info(hints, fabric_info))
-			continue;
 
 		ret = ft_check_info(hints, fabric_info);
 		if (ret)
@@ -476,9 +460,6 @@ static int ft_fw_process_list_client(struct fi_info *hints, struct fi_info *info
 			ret = ft_transfer_subindex(subindex, &remote_idx);
 			if (ret)
 				return ret;
-
-			if (ft_skip_info(hints, fabric_info))
-				continue;
 
 			ret = ft_check_info(hints, fabric_info);
 			if (ret)

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -77,25 +77,29 @@
 		(entry).err,strerror((q), (entry).prov_errno, (entry).err_data, NULL, 0),	\
 		(entry).prov_errno)
 
-#define OFI_Q_READERR(prov, log, q, q_str, readerr, strerror, ret, err_entry)	\
-	do {									\
-		(ret) = readerr((q), &(err_entry), 0);				\
-		if ((ret) != sizeof(err_entry)) {				\
-			FI_WARN(prov, log,					\
-				"Unable to fi_" q_str "_readerr\n");		\
-		} else {							\
-			OFI_Q_STRERROR(prov, log, q, q_str,			\
-				       err_entry, strerror);			\
-		}								\
+#define OFI_CQ_READERR(prov, log, cq, ret, err_entry)			\
+	do {								\
+		(ret) = fi_cq_readerr((cq), &(err_entry), 0);		\
+		if ((ret) < 0) {					\
+			FI_WARN(prov, log,				\
+				"Unable to fi_cq_readerr: %zd\n", ret);	\
+		} else {						\
+			OFI_Q_STRERROR(prov, log, cq, "cq",		\
+				       err_entry, fi_cq_strerror);	\
+		}							\
 	} while (0)
 
-#define OFI_CQ_READERR(prov, log, cq, ret, err_entry)		\
-	OFI_Q_READERR(prov, log, cq, "cq", fi_cq_readerr,	\
-		      fi_cq_strerror, ret, err_entry)
-
-#define OFI_EQ_READERR(prov, log, eq, ret, err_entry)		\
-	OFI_Q_READERR(prov, log, eq, "eq", fi_eq_readerr, 	\
-		      fi_eq_strerror, ret, err_entry)
+#define OFI_EQ_READERR(prov, log, eq, ret, err_entry)			\
+	do {								\
+		(ret) = fi_eq_readerr((eq), &(err_entry), 0);		\
+		if ((ret) != sizeof(err_entry)) {			\
+			FI_WARN(prov, log,				\
+				"Unable to fi_eq_readerr: %zd\n", ret);	\
+		} else {						\
+			OFI_Q_STRERROR(prov, log, eq, "eq",		\
+				       err_entry, fi_eq_strerror);	\
+		}							\
+	} while (0)
 
 #define FI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type)	\
 	do {										\

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -72,35 +72,6 @@
 
 #define OFI_CNTR_ENABLED	(1ULL << 61)
 
-#define OFI_Q_STRERROR(prov, log, q, q_str, entry, strerror)					\
-	FI_WARN(prov, log, "fi_" q_str "_readerr: err: %d, prov_err: %s (%d)\n",		\
-		(entry).err,strerror((q), (entry).prov_errno, (entry).err_data, NULL, 0),	\
-		(entry).prov_errno)
-
-#define OFI_CQ_READERR(prov, log, cq, ret, err_entry)			\
-	do {								\
-		(ret) = fi_cq_readerr((cq), &(err_entry), 0);		\
-		if ((ret) < 0) {					\
-			FI_WARN(prov, log,				\
-				"Unable to fi_cq_readerr: %zd\n", ret);	\
-		} else {						\
-			OFI_Q_STRERROR(prov, log, cq, "cq",		\
-				       err_entry, fi_cq_strerror);	\
-		}							\
-	} while (0)
-
-#define OFI_EQ_READERR(prov, log, eq, ret, err_entry)			\
-	do {								\
-		(ret) = fi_eq_readerr((eq), &(err_entry), 0);		\
-		if ((ret) != sizeof(err_entry)) {			\
-			FI_WARN(prov, log,				\
-				"Unable to fi_eq_readerr: %zd\n", ret);	\
-		} else {						\
-			OFI_Q_STRERROR(prov, log, eq, "eq",		\
-				       err_entry, fi_eq_strerror);	\
-		}							\
-	} while (0)
-
 #define FI_INFO_FIELD(provider, prov_attr, user_attr, prov_str, user_str, type)	\
 	do {										\
 		FI_INFO(provider, FI_LOG_CORE, prov_str ": %s\n",			\

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -115,6 +115,35 @@ do {									\
 	((void *) rxm_buf_get_by_index(&(rxm_ep)->buf_pools[pool_type],		\
 				       (uint64_t) msg_id))
 
+#define RXM_Q_STRERROR(prov, log, q, q_str, entry, strerror)					\
+	FI_WARN(prov, log, "fi_" q_str "_readerr: err: %d, prov_err: %s (%d)\n",		\
+		(entry).err,strerror((q), (entry).prov_errno, (entry).err_data, NULL, 0),	\
+		(entry).prov_errno)
+
+#define RXM_CQ_READERR(prov, log, cq, ret, err_entry)			\
+	do {								\
+		(ret) = fi_cq_readerr((cq), &(err_entry), 0);		\
+		if ((ret) < 0) {					\
+			FI_WARN(prov, log,				\
+				"Unable to fi_cq_readerr: %zd\n", ret);	\
+		} else {						\
+			RXM_Q_STRERROR(prov, log, cq, "cq",		\
+				       err_entry, fi_cq_strerror);	\
+		}							\
+	} while (0)
+
+#define RXM_EQ_READERR(prov, log, eq, ret, err_entry)			\
+	do {								\
+		(ret) = fi_eq_readerr((eq), &(err_entry), 0);		\
+		if ((ret) != sizeof(err_entry)) {			\
+			FI_WARN(prov, log,				\
+				"Unable to fi_eq_readerr: %zd\n", ret);	\
+		} else {						\
+			RXM_Q_STRERROR(prov, log, eq, "eq",		\
+				       err_entry, fi_eq_strerror);	\
+		}							\
+	} while (0)
+
 extern struct fi_provider rxm_prov;
 extern struct util_prov rxm_util_prov;
 extern struct fi_ops_rma rxm_ops_rma;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1201,7 +1201,7 @@ static ssize_t rxm_eq_sread(struct rxm_ep *rxm_ep, size_t len,
 		return rd;
 	}
 
-	OFI_EQ_READERR(&rxm_prov, FI_LOG_EP_CTRL, rxm_ep->msg_eq, rd, entry->err_entry);
+	RXM_EQ_READERR(&rxm_prov, FI_LOG_EP_CTRL, rxm_ep->msg_eq, rd, entry->err_entry);
 
 	if (entry->err_entry.err == ECONNREFUSED) {
 		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "Connection refused\n");

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -907,7 +907,7 @@ static void rxm_cq_read_write_error(struct rxm_ep *rxm_ep)
 	struct util_cntr *util_cntr = NULL;
 	ssize_t ret;
 
-	OFI_CQ_READERR(&rxm_prov, FI_LOG_CQ, rxm_ep->msg_cq, ret,
+	RXM_CQ_READERR(&rxm_prov, FI_LOG_CQ, rxm_ep->msg_cq, ret,
 		       err_entry);
 	if (ret < 0) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1886,6 +1886,11 @@ static int rxm_ep_close(struct fid *fid)
 	if (rxm_ep->cmap)
 		rxm_cmap_free(rxm_ep->cmap);
 
+	// TODO move this to cmap_free and encapsulate eq progress fns
+	// these vars shouldn't be accessed outside rxm_conn file
+	fastlock_destroy(&rxm_ep->msg_eq_entry_list_lock);
+	slistfd_free(&rxm_ep->msg_eq_entry_list);
+
 	ret = rxm_listener_close(rxm_ep);
 	if (ret)
 		retv = ret;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2182,45 +2182,16 @@ err:
 	return ret;
 }
 
-static int rxm_info_to_core_srx_ctx(uint32_t version, const struct fi_info *rxm_hints,
-				    struct fi_info *core_hints)
-{
-	int ret;
-
-	ret = rxm_info_to_core(version, rxm_hints, core_hints);
-	if (ret)
-		return ret;
-	core_hints->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;
-	return 0;
-}
-
-static int rxm_ep_get_core_info(uint32_t version, const struct fi_info *hints,
-				struct fi_info **info)
-{
-	int ret;
-
-	ret = ofi_get_core_info(version, NULL, NULL, 0, &rxm_util_prov, hints,
-				rxm_info_to_core_srx_ctx, info);
-	if (!ret)
-		return 0;
-
-	FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Shared receive context not "
-		"supported by MSG provider.\n");
-
-	return ofi_get_core_info(version, NULL, NULL, 0, &rxm_util_prov, hints,
-				 rxm_info_to_core, info);
-}
-
 static int rxm_ep_msg_res_open(struct rxm_ep *rxm_ep)
 {
 	int ret;
 	size_t max_prog_val;
-	int use_srx;
 	struct rxm_domain *rxm_domain =
 		container_of(rxm_ep->util_ep.domain, struct rxm_domain, util_domain);
 
-	ret = rxm_ep_get_core_info(rxm_ep->util_ep.domain->fabric->fabric_fid.api_version,
-				   rxm_ep->rxm_info, &rxm_ep->msg_info);
+	ret = ofi_get_core_info(rxm_ep->util_ep.domain->fabric->fabric_fid.api_version,
+				NULL, NULL, 0, &rxm_util_prov, rxm_ep->rxm_info,
+				rxm_info_to_core, &rxm_ep->msg_info);
 	if (ret)
 		return ret;
 
@@ -2231,10 +2202,7 @@ static int rxm_ep_msg_res_open(struct rxm_ep *rxm_ep)
 	rxm_ep->eager_pkt_size =
 		rxm_ep->rxm_info->tx_attr->inject_size + sizeof(struct rxm_pkt);
 
-	if (fi_param_get_bool(&rxm_prov, "use_srx", &use_srx))
-		use_srx = 0;
-
-	if ((rxm_ep->msg_info->ep_attr->rx_ctx_cnt == FI_SHARED_CONTEXT) && use_srx) {
+	if (rxm_ep->msg_info->ep_attr->rx_ctx_cnt == FI_SHARED_CONTEXT) {
 		ret = fi_srx_context(rxm_domain->msg_domain, rxm_ep->msg_info->rx_attr,
 				     &rxm_ep->srx_ctx, NULL);
 		if (ret) {

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -80,6 +80,8 @@ void rxm_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
 int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 		     struct fi_info *core_info)
 {
+	int use_srx = 0;
+
 	rxm_info_to_core_mr_modes(version, hints, core_info);
 
 	core_info->mode |= FI_RX_CQ_DATA | FI_CONTEXT;
@@ -106,6 +108,11 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 		}
 	}
 	core_info->ep_attr->type = FI_EP_MSG;
+	if (!fi_param_get_bool(&rxm_prov, "use_srx", &use_srx) && use_srx) {
+		FI_DBG(&rxm_prov, FI_LOG_FABRIC,
+		       "Requesting shared receive context from core provider\n");
+		core_info->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;
+	}
 
 	core_info->tx_attr->size = rxm_msg_tx_size;
 	core_info->rx_attr->size = rxm_msg_rx_size;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1208,9 +1208,21 @@ static int fi_ibv_get_matching_info(uint32_t version,
 	*info = tail = NULL;
 
 	for ( ; check_info; check_info = check_info->next) {
+		VERBS_DBG(FI_LOG_FABRIC, "Checking domain: %s\n",
+			  check_info->domain_attr->name);
+
 		if (hints) {
-			VERBS_DBG(FI_LOG_FABRIC, "Checking domain: %s\n",
-				  check_info->domain_attr->name);
+			if ((check_info->ep_attr->protocol ==
+			     FI_PROTO_RDMA_CM_IB_XRC) &&
+			    (!hints->ep_attr ||
+			     (hints->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT))) {
+				VERBS_INFO(FI_LOG_FABRIC,
+					   "hints->ep_attr->rx_ctx_cnt != "
+					   "FI_SHARED_CONTEXT. Skipping "
+					   "XRC FI_EP_MSG endpoints\n");
+				continue;
+			}
+
 			ret = fi_ibv_check_hints(version, hints,
 						 check_info);
 			if (ret)
@@ -1238,6 +1250,8 @@ static int fi_ibv_get_matching_info(uint32_t version,
 			}
 		}
 
+		VERBS_DBG(FI_LOG_FABRIC, "Adding fi_info for domain: %s\n",
+			  fi->domain_attr->name);
 		if (!*info)
 			*info = fi;
 		else

--- a/src/common.c
+++ b/src/common.c
@@ -620,7 +620,8 @@ int ofi_is_wildcard_listen_addr(const char *node, const char *service,
 	struct addrinfo *res = NULL;
 	int ret;
 
-	if (hints && hints->addr_format != FI_SOCKADDR &&
+	if (hints && hints->addr_format != FI_FORMAT_UNSPEC &&
+	    hints->addr_format != FI_SOCKADDR &&
 	    hints->addr_format != FI_SOCKADDR_IN &&
 	    hints->addr_format != FI_SOCKADDR_IN6)
 		return 0;


### PR DESCRIPTION
- util: fix reading CQ errors 
- prov/rxm: fix file descriptor and memory leaks
- fabtests/ubertest: don't skip utility providers 
- fabtests/ubertest: support FI_RX_CQ_DATA by default 
- fabtests/ubertest: add test config for testing verbs;ofi_rxm
- fabtests/test_config: update verbs exclude file to run ubertes