### PR TITLE
prov/verbs: Discard destination address when allocated PEP

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -70,7 +70,6 @@ struct fi_context *tx_ctx_arr = NULL, *rx_ctx_arr = NULL;
 uint64_t remote_cq_data = 0;
 
 uint64_t tx_seq, rx_seq, tx_cq_cntr, rx_cq_cntr;
-int ft_skip_mr = 0;
 int (*ft_mr_alloc_func)(void);
 uint64_t ft_tag = 0;
 int ft_parent_proc = 0;
@@ -398,8 +397,9 @@ static int ft_alloc_msgs(void)
 
 	remote_cq_data = ft_init_cq_data(fi);
 
-	if (!ft_mr_alloc_func && !ft_skip_mr && ((fi->domain_attr->mr_mode & FI_MR_LOCAL) ||
-				(fi->caps & (FI_RMA | FI_ATOMIC)))) {
+	if (!ft_mr_alloc_func && !ft_check_opts(FT_OPT_SKIP_REG_MR) &&
+	    ((fi->domain_attr->mr_mode & FI_MR_LOCAL) ||
+	     (fi->caps & (FI_RMA | FI_ATOMIC)))) {
 		ret = fi_mr_reg(domain, buf, buf_size, ft_info_to_mr_access(fi),
 				0, FT_MR_KEY, 0, &mr, NULL);
 		if (ret) {
@@ -409,6 +409,7 @@ static int ft_alloc_msgs(void)
 		mr_desc = ft_check_mr_local_flag(fi) ? fi_mr_desc(mr) : NULL;
 	} else {
 		if (ft_mr_alloc_func) {
+			assert(!ft_check_opts(FT_OPT_SKIP_REG_MR));
 			ret = ft_mr_alloc_func();
 			if (ret)
 				return ret;

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -355,13 +355,12 @@ void ft_free_bit_combo(uint64_t *combo)
  * buffer is large enough for a control message used to exchange addressing
  * data.
  */
-int ft_alloc_msgs(void)
+static int ft_alloc_msgs(void)
 {
 	int ret;
 	long alignment = 1;
 
-	/* TODO: support multi-recv tests */
-	if (fi->rx_attr->op_flags == FI_MULTI_RECV)
+	if (ft_check_opts(FT_OPT_SKIP_MSG_ALLOC))
 		return 0;
 
 	tx_size = opts.options & FT_OPT_SIZE ?
@@ -985,7 +984,7 @@ int ft_enable_ep_recv(void)
 	if (ret)
 		return ret;
 
-	if (fi->rx_attr->op_flags != FI_MULTI_RECV &&
+	if (!ft_check_opts(FT_OPT_SKIP_MSG_ALLOC) &&
 	    (fi->caps & (FI_MSG | FI_TAGGED))) {
 		/* Initial receive will get remote address for unconnected EPs */
 		ret = ft_post_rx(ep, MAX(rx_size, FT_MAX_CTRL_MSG), &rx_ctx);

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1052,26 +1052,25 @@ int ft_init_av(void)
 int ft_exchange_addresses_oob(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
 		fi_addr_t *remote_addr)
 {
+	char buf[FT_MAX_CTRL_MSG];
 	int ret;
 	size_t addrlen = FT_MAX_CTRL_MSG;
 
-	ret = fi_getname(&ep_ptr->fid, (char *) tx_buf + ft_tx_prefix_size(),
-			 &addrlen);
+	ret = fi_getname(&ep_ptr->fid, buf, &addrlen);
 	if (ret) {
 		FT_PRINTERR("fi_getname", ret);
 		return ret;
 	}
 
-	ret = ft_sock_send(oob_sock, (char *) tx_buf + ft_tx_prefix_size(),  FT_MAX_CTRL_MSG);
+	ret = ft_sock_send(oob_sock, buf, FT_MAX_CTRL_MSG);
 	if (ret)
 		return ret;
 
-	ret = ft_sock_recv(oob_sock, (char *) rx_buf + ft_rx_prefix_size(), FT_MAX_CTRL_MSG);
+	ret = ft_sock_recv(oob_sock, buf, FT_MAX_CTRL_MSG);
 	if (ret)
 		return ret;
 
-	ret = ft_av_insert(av_ptr, (char *) rx_buf + ft_rx_prefix_size(),
-			1, remote_addr, 0, NULL);
+	ret = ft_av_insert(av_ptr, buf, 1, remote_addr, 0, NULL);
 	if (ret)
 		return ret;	
 
@@ -2313,8 +2312,8 @@ void eq_readerr(struct fid_eq *eq, const char *eq_str)
 
 int ft_sync()
 {
+	char buf;
 	int ret;
-	int result;
 
 	if (opts.dst_addr) {
 		if (!opts.oob_port) {
@@ -2324,11 +2323,11 @@ int ft_sync()
 
 			ret = ft_rx(ep, 1);
 		} else {
-			ret = ft_sock_send(oob_sock, &tx_buf, 1);
+			ret = ft_sock_send(oob_sock, &buf, 1);
 			if (ret)
 				return ret;
 
-			ret = ft_sock_recv(oob_sock, &result, 1);
+			ret = ft_sock_recv(oob_sock, &buf, 1);
 			if (ret)
 				return ret;
 		}
@@ -2340,11 +2339,11 @@ int ft_sync()
 
 			ret = ft_tx(ep, remote_fi_addr, 1, &tx_ctx);
 		} else {
-			ret = ft_sock_recv(oob_sock, &result, 1);
+			ret = ft_sock_recv(oob_sock, &buf, 1);
 			if (ret)
 				return ret;
 
-			ret = ft_sock_send(oob_sock, &tx_buf, 1);
+			ret = ft_sock_send(oob_sock, &buf, 1);
 			if (ret)
 				return ret;
 		}

--- a/fabtests/functional/cm_data.c
+++ b/fabtests/functional/cm_data.c
@@ -446,7 +446,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE | FT_OPT_SKIP_REG_MR;
 
 	hints = fi_allocinfo();
 	if (!hints)
@@ -476,7 +476,6 @@ int main(int argc, char **argv)
 	hints->ep_attr->type	= FI_EP_MSG;
 	hints->caps		= FI_MSG;
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP;
-	ft_skip_mr = 1;
 
 	ret = run();
 

--- a/fabtests/functional/multi_ep.c
+++ b/fabtests/functional/multi_ep.c
@@ -277,6 +277,7 @@ int main(int argc, char **argv)
 
 	opts = INIT_OPTS;
 	opts.transfer_size = 256;
+	opts.options |= FT_OPT_SKIP_REG_MR;
 
 	hints = fi_allocinfo();
 	if (!hints)
@@ -307,7 +308,6 @@ int main(int argc, char **argv)
 	if (optind < argc)
 		opts.dst_addr = argv[optind];
 
-	ft_skip_mr = 1;
 	hints->caps = FI_MSG;
 	hints->mode = FI_CONTEXT;
 

--- a/fabtests/functional/rdm_atomic.c
+++ b/fabtests/functional/rdm_atomic.c
@@ -379,9 +379,6 @@ static int alloc_ep_res(struct fi_info *fi)
 	int ret;
 	int mr_local = !!(fi->domain_attr->mr_mode & FI_MR_LOCAL);
 
-	/* Prevent memory registration by ft_alloc_active_res() -> ft_alloc_msgs() */
-	ft_skip_mr = 1;
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;
@@ -488,6 +485,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
+	opts.options |= FT_OPT_SKIP_REG_MR;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/functional/rdm_deferred_wq.c
+++ b/fabtests/functional/rdm_deferred_wq.c
@@ -578,7 +578,8 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.options = FT_OPT_SIZE | FT_OPT_RX_CNTR | FT_OPT_TX_CNTR;
+	opts.options = FT_OPT_SIZE | FT_OPT_RX_CNTR | FT_OPT_TX_CNTR |
+		       FT_OPT_SKIP_REG_MR;
 
 	hints = fi_allocinfo();
 	if (!hints)
@@ -633,7 +634,6 @@ int main(int argc, char **argv)
 	hints->domain_attr->mr_mode = (FI_MR_LOCAL | FI_MR_VIRT_ADDR |
 				       FI_MR_ALLOCATED);
 
-	ft_skip_mr = 1;
 	ret = ft_init_fabric();
 	if (ret)
 		return ret;

--- a/fabtests/functional/rdm_multi_recv.c
+++ b/fabtests/functional/rdm_multi_recv.c
@@ -227,9 +227,6 @@ static int alloc_ep_res(struct fi_info *fi)
 		return ret;
 	}
 
-	/* Prevent memory registration by ft_alloc_active_res() -> ft_alloc_msgs() */
-	ft_skip_mr = 1;
-
 	ret = ft_alloc_active_res(fi);
 	if (ret)
 		return ret;

--- a/fabtests/functional/rdm_multi_recv.c
+++ b/fabtests/functional/rdm_multi_recv.c
@@ -327,7 +327,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.options |= FT_OPT_SIZE;
+	opts.options |= FT_OPT_SIZE | FT_OPT_SKIP_MSG_ALLOC;
 	use_recvmsg = 0;
 
 	hints = fi_allocinfo();

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -214,7 +214,7 @@ int main(int argc, char **argv)
 	int ret;
 
 	opts = INIT_OPTS;
-	opts.options |= FT_OPT_OOB_SYNC;
+	opts.options |= FT_OPT_OOB_SYNC | FT_OPT_SKIP_MSG_ALLOC;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -116,6 +116,7 @@ enum {
 	FT_OPT_CQ_SHARED	= 1 << 10,
 	FT_OPT_OOB_SYNC		= 1 << 11,
 	FT_OPT_SKIP_MSG_ALLOC	= 1 << 12,
+	FT_OPT_SKIP_REG_MR	= 1 << 13,
 };
 
 /* for RMA tests --- we want to be able to select fi_writedata, but there is no
@@ -217,7 +218,6 @@ int ft_sock_send(int fd, void *msg, size_t len);
 int ft_sock_recv(int fd, void *msg, size_t len);
 int ft_sock_sync(int value);
 void ft_sock_shutdown(int fd);
-extern int ft_skip_mr;
 extern int (*ft_mr_alloc_func)(void);
 extern uint64_t ft_tag;
 extern int ft_parent_proc;

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -115,6 +115,7 @@ enum {
 	FT_OPT_BW		= 1 << 9,
 	FT_OPT_CQ_SHARED	= 1 << 10,
 	FT_OPT_OOB_SYNC		= 1 << 11,
+	FT_OPT_SKIP_MSG_ALLOC	= 1 << 12,
 };
 
 /* for RMA tests --- we want to be able to select fi_writedata, but there is no

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -993,8 +993,7 @@ int fi_ibv_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		goto err1;
 	}
 
-	/* Need to be able to make reciprocal XRC connections */
-	if (fi_ibv_is_xrc(_pep->info) && _pep->info->dest_addr) {
+	if (_pep->info->dest_addr || _pep->info->dest_addrlen) {
 		free(_pep->info->dest_addr);
 		_pep->info->dest_addr = NULL;
 		_pep->info->dest_addrlen = 0;


### PR DESCRIPTION
RxM will allocate a passive endpoint using the fi_info structure
allocated for an active endpoint.  As a result, the info::
dest_addr field may be set.  This triggers the assertion in
fi_ibv_eq_cm_getinfo() that dest_addr is null.

The issue is that when the passive endpoint is created, the
fi_info passed in is copied to the PEP.  This includes the
dest_addr, if present.

It turns out that the xrc code discards the dest_addr.  Remove
the xrc portion of the check and always discard (i.e. ignore)
the dest_addr if present.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>