### PR TITLE
prov/rxd: bug fixes, enable provider, add to Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,10 +66,10 @@ prov/*/*.spec
 .vs
 fabtests.spec
 
-ubertest/fabtest
-ubertest/fi_ubertest
+fabtests/ubertest/fabtest
+fabtests/ubertest/fi_ubertest
 
-benchmarks/fi_*
-functional/fi_*
-unit/fi_*
+fabtests/benchmarks/fi_*
+fabtests/functional/fi_*
+fabtests/unit/fi_*
 pingpong/fi_*

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -382,3 +382,4 @@ test:
 	./scripts/runfabtests.sh -vvv -S $(os_excludes)
 	./scripts/runfabtests.sh -vvv -S $(os_excludes) -R -f ./test_configs/udp/udp.exclude udp
 	./scripts/runfabtests.sh -vvv -S $(os_excludes) -R -f ./test_configs/tcp/tcp.exclude tcp
+	./scripts/runfabtests.sh -vvv -S $(os_excludes) -R -f ./test_configs/ofi_rxd/ofi_rxd.exclude "UDP;ofi_rxd"

--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -83,6 +83,7 @@ nobase_dist_config_DATA = \
 	test_configs/psm2/verify.test \
 	test_configs/psm2/psm2.exclude \
 	test_configs/ofi_rxm/ofi_rxm.exclude \
+	test_configs/ofi_rxd/ofi_rxd.exclude \
 	test_configs/ofi_rxd/udp.test \
 	test_configs/shm/all.test \
 	test_configs/shm/verify.test

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -53,7 +53,7 @@ declare GOOD_ADDR=""
 declare -i VERBOSE=0
 declare -i SKIP_NEG=0
 declare COMPLEX_CFG
-declare TIMEOUT_VAL="90"
+declare TIMEOUT_VAL="120"
 declare STRICT_MODE=0
 declare REGEX=0
 declare FORK=0

--- a/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
+++ b/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
@@ -1,0 +1,26 @@
+# Regex patterns of tests to exclude in runfabtests.sh
+
+^msg|-e msg
+^dgram|-e dgram
+
+# Exclude tests that use sread/polling until issues are resolved
+-S
+rdm_cntr_pingpong
+poll
+cq_data
+
+# Exclude tests with unsupported capabilities
+rdm_rma_simple
+rdm_tagged_peek
+cm_data
+trigger
+shared_ctx
+scalable_ep
+shared_av
+multi_mr
+
+# Exclude because it takes too long
+ubertest
+
+# Exclude unexpected test until bug is resolved
+unexpected_msg

--- a/fabtests/test_configs/verbs/all.test
+++ b/fabtests/test_configs/verbs/all.test
@@ -111,7 +111,6 @@
 	],
 	ep_type: [
 		FI_EP_MSG,
-		FI_EP_RDM,
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
@@ -142,7 +141,6 @@
 	],
 	ep_type: [
 		FI_EP_MSG,
-		FI_EP_RDM,
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
@@ -157,80 +155,6 @@
 	],
 	test_class: [
 		FT_CAP_MSG,
-	],
-	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
-	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
-	test_flags: FT_FLAG_QUICKTEST,
-},
-{
-	prov_name: verbs,
-	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
-	],
-	class_function: [
-		FT_FUNC_SEND,
-		FT_FUNC_SENDV,
-		FT_FUNC_SENDDATA,
-		FT_FUNC_INJECT,
-		FT_FUNC_INJECTDATA,
-	],
-	ep_type: [
-		FI_EP_RDM,
-	],
-	comp_type: [
-		FT_COMP_QUEUE,
-	],
-	test_class: [
-		FT_CAP_MSG,
-		FT_CAP_TAGGED,
-	],
-	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
-	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
-},
-{
-	prov_name: verbs,
-	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
-	],
-	class_function: [
-		FT_FUNC_SENDMSG,
-	],
-	ep_type: [
-		FI_EP_RDM,
-	],
-	comp_type: [
-		FT_COMP_QUEUE,
-	],
-	test_class: [
-		FT_CAP_MSG,
-		FT_CAP_TAGGED,
-	],
-	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
-	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],
-	msg_flags: FI_REMOTE_CQ_DATA,
-},
-{
-	prov_name: verbs,
-	test_type: [
-		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
-	],
-	class_function: [
-		FT_FUNC_WRITE,
-		FT_FUNC_WRITEV,
-		FT_FUNC_READ,
-		FT_FUNC_READV,
-	],
-	ep_type: [
-		FI_EP_RDM,
-	],
-	comp_type: [
-		FT_COMP_QUEUE,
-	],
-	test_class: [
-		FT_CAP_RMA,
 	],
 	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
 	progress: [FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO],

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -375,7 +375,7 @@ int rxd_ep_retry_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry);
 ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
 void rxd_insert_unacked(struct rxd_ep *ep, fi_addr_t peer,
 			struct rxd_pkt_entry *pkt_entry);
-ssize_t rxd_ep_send_rts(struct rxd_ep *rxd_ep, fi_addr_t rxd_addr);
+ssize_t rxd_send_rts_if_needed(struct rxd_ep *rxd_ep, fi_addr_t rxd_addr);
 int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry,
 		   const struct fi_rma_iov *rma_iov, size_t rma_count,
 		   const struct iovec *comp_iov, size_t comp_count,

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -192,6 +192,7 @@ struct rxd_ep {
 	struct dlist_entry rx_list;
 	struct dlist_entry rx_tag_list;
 	struct dlist_entry active_peers;
+	struct dlist_entry rts_sent_list;
 
 	struct rxd_peer peers[];
 };

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -83,6 +83,7 @@
 #define RXD_TAG_HDR		(1 << 4)
 #define RXD_INLINE		(1 << 5)
 #define RXD_MULTI_RECV		(1 << 6)
+#define RXD_CANCELLED		(1 << 7)
 
 struct rxd_env {
 	int spin_count;

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -74,8 +74,11 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
 	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked))
-		rxd_ep_send_rts(rxd_ep, rxd_addr);
+	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
+		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
+		if (ret)
+			goto out;
+	}
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, count, res_iov, result_count, rma_count,
 				     data, 0, context, rxd_addr, op, rxd_flags);
@@ -177,8 +180,11 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
 	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked))
-		rxd_ep_send_rts(rxd_ep, rxd_addr);
+	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
+		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
+		if (ret)
+			goto out;
+	}
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, &iov, 1, NULL, 0, 1, 0, 0, NULL,
 				     rxd_addr, ofi_op_atomic,

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -73,12 +73,9 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 		goto out;
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
-	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
-		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
-		if (ret)
-			goto out;
-	}
+	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
+	if (ret)
+		goto out;
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, count, res_iov, result_count, rma_count,
 				     data, 0, context, rxd_addr, op, rxd_flags);
@@ -179,12 +176,9 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto out;
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
-	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
-		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
-		if (ret)
-			goto out;
-	}
+	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
+	if (ret)
+		goto out;
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, &iov, 1, NULL, 0, 1, 0, 0, NULL,
 				     rxd_addr, ofi_op_atomic,

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1117,6 +1117,7 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err2;
 
+	memcpy(dg_info->src_addr, info->src_addr, info->src_addrlen);
 	rxd_ep->do_local_mr = (rxd_domain->mr_mode & FI_MR_LOCAL) ? 1 : 0;
 
 	ret = fi_endpoint(rxd_domain->dg_domain, dg_info, &rxd_ep->dg_ep, rxd_ep);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -482,7 +482,7 @@ int rxd_ep_retry_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 	return ret;
 }
 
-ssize_t rxd_ep_send_rts(struct rxd_ep *rxd_ep, fi_addr_t rxd_addr)
+static ssize_t rxd_ep_send_rts(struct rxd_ep *rxd_ep, fi_addr_t rxd_addr)
 {
 	struct rxd_pkt_entry *pkt_entry;
 	struct rxd_rts_pkt *rts_pkt;
@@ -514,6 +514,14 @@ ssize_t rxd_ep_send_rts(struct rxd_ep *rxd_ep, fi_addr_t rxd_addr)
 	dlist_insert_tail(&rxd_ep->peers[rxd_addr].entry, &rxd_ep->rts_sent_list);
 
 	return rxd_ep_retry_pkt(rxd_ep, pkt_entry);
+}
+
+ssize_t rxd_send_rts_if_needed(struct rxd_ep *ep, fi_addr_t addr)
+{
+	if (ep->peers[addr].peer_addr == FI_ADDR_UNSPEC &&
+	    dlist_empty(&ep->peers[addr].unacked))
+		return rxd_ep_send_rts(ep, addr);
+	return 0;
 }
 
 static void rxd_init_base_hdr(struct rxd_ep *rxd_ep, void **ptr,

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -602,7 +602,7 @@ int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry,
 	struct rxd_pkt_entry *pkt_entry;
 	struct rxd_base_hdr *base_hdr;
 	int ret = 0;
-	size_t len;
+	size_t len, avail;
 	void *ptr;
 
 	pkt_entry = rxd_get_tx_pkt(rxd_ep);
@@ -613,29 +613,36 @@ int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry,
 	ptr = (void *) base_hdr;
 	rxd_init_base_hdr(rxd_ep, &ptr, tx_entry);
 
-	if (!(tx_entry->flags & RXD_INLINE))
-		rxd_init_sar_hdr(&ptr, tx_entry, rma_count); 
-	if (tx_entry->flags & RXD_TAG_HDR)
+	avail = rxd_ep_domain(rxd_ep)->max_inline_msg;
+
+	if (!(tx_entry->flags & RXD_INLINE)) {
+		rxd_init_sar_hdr(&ptr, tx_entry, rma_count);
+		avail -= sizeof(struct rxd_sar_hdr);
+	}
+	if (tx_entry->flags & RXD_TAG_HDR) {
 		rxd_init_tag_hdr(&ptr, tx_entry);
-	if (tx_entry->flags & RXD_REMOTE_CQ_DATA)
+		avail -= sizeof(struct rxd_tag_hdr);
+	}
+	if (tx_entry->flags & RXD_REMOTE_CQ_DATA) {
 		rxd_init_data_hdr(&ptr, tx_entry);
+		avail -= sizeof(struct rxd_data_hdr);
+	}
 	if (tx_entry->cq_entry.flags & (FI_RMA | FI_ATOMIC)) {
 		rxd_init_rma_hdr(&ptr, rma_iov, rma_count);
-		if (tx_entry->cq_entry.flags & FI_ATOMIC)
+		avail -= sizeof(struct ofi_rma_iov) * rma_count;
+		if (tx_entry->cq_entry.flags & FI_ATOMIC) {
 			rxd_init_atom_hdr(&ptr, datatype, atomic_op);
+			avail -= sizeof(struct rxd_atom_hdr);
+		}
 	}
 	if (tx_entry->op != RXD_READ_REQ && atomic_op != FI_ATOMIC_READ) {
 		tx_entry->bytes_done = rxd_init_msg(&ptr, tx_entry->iov,
 						    tx_entry->iov_count,
-						    tx_entry->cq_entry.len,
-						    rxd_ep_domain(rxd_ep)->max_mtu_sz -
-						    rxd_ep->prefix_size -
-			 			    ((char *) ptr - (char *) base_hdr));
+						    tx_entry->cq_entry.len, avail);
 		if (tx_entry->op == RXD_ATOMIC_COMPARE) {
+			avail -= tx_entry->bytes_done;
 			len = rxd_init_msg(&ptr, comp_iov, comp_count,
-					   tx_entry->cq_entry.len,
-					   rxd_ep_domain(rxd_ep)->max_mtu_sz -
-			 		   ((char *) ptr - (char *) base_hdr));
+					   tx_entry->cq_entry.len, avail);
 			if (len != tx_entry->bytes_done) {
 				FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
 					"compare data length mismatch\n");

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -211,12 +211,9 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		goto out;
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
-	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
-		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
-		if (ret)
-			goto out;
-	}
+	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
+	if (ret)
+		goto out;
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, 0, data,
 				     tag, NULL, rxd_addr, op, rxd_flags | RXD_INJECT);
@@ -255,12 +252,9 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		goto out;
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
-	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
-		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
-		if (ret)
-			goto out;
-	}
+	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
+	if (ret)
+		goto out;
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, 0,
 				     data, tag, context, rxd_addr, op, rxd_flags);

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -212,8 +212,11 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
 	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked))
-		rxd_ep_send_rts(rxd_ep, rxd_addr);
+	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
+		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
+		if (ret)
+			goto out;
+	}
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, 0, data,
 				     tag, NULL, rxd_addr, op, rxd_flags | RXD_INJECT);
@@ -253,8 +256,11 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
 	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked))
-		rxd_ep_send_rts(rxd_ep, rxd_addr);
+	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
+		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
+		if (ret)
+			goto out;
+	}
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, 0,
 				     data, tag, context, rxd_addr, op, rxd_flags);

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -58,12 +58,9 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	}
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
-	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
-		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
-		if (ret)
-			goto out;
-	}
+	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
+	if (ret)
+		goto out;
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count, data,
 				     0, context, rxd_addr, op, rxd_flags);
@@ -110,12 +107,9 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	}
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
-	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
-		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
-		if (ret)
-			goto out;
-	}
+	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
+	if (ret)
+		goto out;
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count,
 				     data, 0, context, rxd_addr, op, rxd_flags);

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -59,8 +59,11 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
 	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked))
-		rxd_ep_send_rts(rxd_ep, rxd_addr);
+	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
+		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
+		if (ret)
+			goto out;
+	}
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count, data,
 				     0, context, rxd_addr, op, rxd_flags);
@@ -108,8 +111,11 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
 	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC &&
-	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked))
-		rxd_ep_send_rts(rxd_ep, rxd_addr);
+	    dlist_empty(&rxd_ep->peers[rxd_addr].unacked)) {
+		ret = rxd_ep_send_rts(rxd_ep, rxd_addr);
+		if (ret)
+			goto out;
+	}
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count,
 				     data, 0, context, rxd_addr, op, rxd_flags);

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -506,16 +506,7 @@ libdl_done:
 	ofi_register_provider(VERBS_INIT, NULL);
 	ofi_register_provider(RSTREAM_INIT, NULL);
 	ofi_register_provider(MRAIL_INIT, NULL);
-
-	{
-		/* TODO: RXD is not stable for now. Disable it by default */
-		int enable_rxd = 0;
-		fi_param_define(NULL, "rxd_enable", FI_PARAM_BOOL,
-				"Enable RXD provider (default: no)");
-		fi_param_get_bool(NULL, "rxd_enable", &enable_rxd);
-		if (enable_rxd)
-			ofi_register_provider(RXD_INIT, NULL);
-	}
+	ofi_register_provider(RXD_INIT, NULL);
 
 	ofi_register_provider(UDP_INIT, NULL);
 	ofi_register_provider(SOCKETS_INIT, NULL);


### PR DESCRIPTION
Summary:
- enable provider by default
- AV return bug fixes
- peer connection organization/retrying of connection packets
- add retry warning message
- recv_cancel fix to maintain sequence numbers
- length calculation fix/clean
- add exclude file
- add UDP;ofi_rxd to make test for Travis

Also throwing a gitignore fix in here (add fabtests/* extension since repos were merged)

Updated:
Added commit to enable psm2;ofi_rxd by copying resolved address needed for the name server.
Added commit to re-enable skipping of utility providers in ubertest.

