### PR TITLE
prov/verbs: Set XRC info EP attribute rx_ctx_cnt

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -522,8 +522,10 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx,
 						  MIN(device_attr.max_sge,
 						      device_attr.max_srq_sge) :
 						  device_attr.max_sge;
-	if (protocol == FI_PROTO_RDMA_CM_IB_XRC)
+	if (protocol == FI_PROTO_RDMA_CM_IB_XRC) {
 		info->rx_attr->iov_limit = MIN(info->rx_attr->iov_limit, 1);
+		info->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;
+	}
 
 	ret = fi_ibv_get_qp_cap(ctx, info, protocol);
 	if (ret)


### PR DESCRIPTION
XRC requires the use of shared receive context; reflect this in the EP attrs
to indicate the XRC MSG_EP are configured to use a fi_srx_context.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>