### PR TITLE
util/cq: Use ofi_cq_progress by default if NULL is passed to ofi_cq_init

### DIFF
--- a/prov/mlx/src/mlx_cq.c
+++ b/prov/mlx/src/mlx_cq.c
@@ -46,7 +46,7 @@ int mlx_cq_open (
 
 	status = ofi_cq_init(
 			&mlx_prov, domain, 
-			attr, u_cq, &ofi_cq_progress, context);
+			attr, u_cq, NULL, context);
 	if (status) {
 		free(u_cq);
 		return status;

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -1128,7 +1128,7 @@ int rxd_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		return -FI_ENOMEM;
 
 	ret = ofi_cq_init(&rxd_prov, domain, attr, &cq->util_cq,
-			  &ofi_cq_progress, context);
+			  NULL, context);
 	if (ret)
 		goto free;
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1105,7 +1105,7 @@ static struct fi_ops_cq rxm_cq_ops = {
 };
 
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
-		 struct fid_cq **cq_fid, void *context)
+		struct fid_cq **cq_fid, void *context)
 {
 	struct util_cq *util_cq;
 	int ret;
@@ -1114,8 +1114,7 @@ int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (!util_cq)
 		return -FI_ENOMEM;
 
-	ret = ofi_cq_init(&rxm_prov, domain, attr, util_cq, &ofi_cq_progress,
-			context);
+	ret = ofi_cq_init(&rxm_prov, domain, attr, util_cq, NULL, context);
 	if (ret)
 		goto err1;
 

--- a/prov/shm/src/smr_cq.c
+++ b/prov/shm/src/smr_cq.c
@@ -50,7 +50,7 @@ int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (!util_cq)
 		return -FI_ENOMEM;
 
-	ret = ofi_cq_init(&smr_prov, domain, attr, util_cq, ofi_cq_progress, context);
+	ret = ofi_cq_init(&smr_prov, domain, attr, util_cq, NULL, context);
 	if (ret)
 		return ret;
 

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -247,7 +247,7 @@ int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		goto free_cq;
 
 	ret = ofi_cq_init(&tcpx_prov, domain, attr, &tcpx_cq->util_cq,
-			  &ofi_cq_progress, context);
+			  NULL, context);
 	if (ret)
 		goto destroy_pool;
 

--- a/prov/udp/src/udpx_cq.c
+++ b/prov/udp/src/udpx_cq.c
@@ -67,7 +67,7 @@ int udpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		return -FI_ENOMEM;
 
 	ret = ofi_cq_init(&udpx_prov, domain, attr, cq,
-			   &ofi_cq_progress, context);
+			  NULL, context);
 	if (ret) {
 		free(cq);
 		return ret;


### PR DESCRIPTION
Since almost all providers use ofi_cq_progress directly, we can move in to
utility code.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>