### PR TITLE
ubertest: Skip memory registration if not required

### DIFF
--- a/fabtests/ubertest/domain.c
+++ b/fabtests/ubertest/domain.c
@@ -274,6 +274,9 @@ static int ft_setup_mr_control(struct ft_mr_control *ctrl)
 	int ret;
 	uint64_t access;
 
+	if (!(fabric_info->caps & (FI_RMA | FI_ATOMIC)))
+		return 0;
+
 	size = ft_ctrl.size_array[ft_ctrl.size_cnt - 1];
 	if (!ctrl->buf) {
 		ctrl->buf = calloc(1, size);


### PR DESCRIPTION
The ft_mr_ctrl buffer and registration are only used by RMA
and atomic tests.  Skip registration if not needed.  This re-enables
ubertest over udp provider.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>