### PR TITLE
util/cq: Use ofi_cq_progress by default if progress function is null

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1375,11 +1375,9 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 				"Ran out of buffers from Eager buffer pool\n");
 			return -FI_EAGAIN;
 		}
+
 		rxm_ep_format_tx_buf_pkt(rxm_conn, data_len, op, data, tag,
 					 flags, &tx_buf->pkt);
-		if (OFI_UNLIKELY(ret))
-			return ret;
-
 		ofi_copy_from_iov(tx_buf->pkt.data, tx_buf->pkt.hdr.size,
 				  iov, count, 0);
 		tx_buf->app_context = context;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -774,7 +774,7 @@ static int ip_av_nodesym_getaddr(struct util_av *av, const char *node,
 	return count;
 err:
 	freeaddrinfo(ai);
-	free(addr);
+	free(*addr);
 	return ret;
 }
 

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -238,7 +238,7 @@ static int fi_ibv_msg_alloc_xrc_params(void **adjusted_param,
 		return -FI_ENOMEM;
 	}
 
-	if (paramlen)
+	if (*paramlen)
 		memcpy((cm_data + 1), param, *paramlen);
 
 	*paramlen = cm_datalen;

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -513,8 +513,10 @@ int fi_ibv_domain_xrc_init(struct fi_ibv_domain *domain)
 rbmap_err:
 	(void)ibv_close_xrcd(domain->xrc.xrcd);
 xrcd_err:
-	close(domain->xrc.xrcd_fd);
-	domain->xrc.xrcd_fd = -1;
+	if (domain->xrc.xrcd_fd >= 0) {
+		close(domain->xrc.xrcd_fd);
+		domain->xrc.xrcd_fd = -1;
+	}
 	return ret;
 }
 


### PR DESCRIPTION
Nearly all providers specify ofi_cq_progress as their progress
function.  Allow providers to specify null and have the util
code set ofi_cq_progress or ofi_cq_progress_ts as the default
in this case, based on the app's selected threading level.

This isolates the cq progress checks into one location for
most providers.

Based on patch from Dmitry Gladkov <dmitry.gladkov@intel.com>

Signed-off-by: Sean Hefty <sean.hefty@intel.com>