### PR TITLE
prov/rxm: Fix support of WAS, RAS message orderings + small code refactoring

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1191,15 +1191,9 @@ rxm_ep_inject_common_data_fast(struct rxm_ep *rxm_ep, const void *buf, size_t le
 
 	assert(len <= rxm_ep->rxm_info->tx_attr->inject_size);
 
-	ret = rxm_acquire_conn_connect(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		return ret;
-
-	if (OFI_UNLIKELY(!dlist_empty(&rxm_conn->deferred_tx_queue))) {
-		rxm_ep_progress_multi(&rxm_ep->util_ep);
-		if (!dlist_empty(&rxm_conn->deferred_tx_queue))
-			return -FI_EAGAIN;
-	}
 
 	if (pkt_size <= rxm_ep->msg_info->tx_attr->inject_size) {
 		inject_pkt->hdr.size = len;
@@ -1226,15 +1220,9 @@ rxm_ep_inject_common_fast(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 
 	assert(len <= rxm_ep->rxm_info->tx_attr->inject_size);
 
-	ret = rxm_acquire_conn_connect(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		return ret;
-
-	if (OFI_UNLIKELY(!dlist_empty(&rxm_conn->deferred_tx_queue))) {
-		rxm_ep_progress_multi(&rxm_ep->util_ep);
-		if (!dlist_empty(&rxm_conn->deferred_tx_queue))
-			return -FI_EAGAIN;
-	}
 
 	if (pkt_size <= rxm_ep->msg_info->tx_attr->inject_size) {
 		inject_pkt->hdr.size = len;
@@ -1259,15 +1247,9 @@ rxm_ep_inject_common(struct rxm_ep *rxm_ep, const void *buf, size_t len,
 
 	assert(len <= rxm_ep->rxm_info->tx_attr->inject_size);
 
-	ret = rxm_acquire_conn_connect(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		return ret;
-
-	if (OFI_UNLIKELY(!dlist_empty(&rxm_conn->deferred_tx_queue))) {
-		rxm_ep_progress_multi(&rxm_ep->util_ep);
-		if (!dlist_empty(&rxm_conn->deferred_tx_queue))
-			return -FI_EAGAIN;
-	}
 
 	if (pkt_size <= rxm_ep->msg_info->tx_attr->inject_size) {
 		struct rxm_tx_base_buf *tx_buf = (struct rxm_tx_base_buf *)
@@ -1350,15 +1332,9 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, const struct iovec *iov, void **desc,
 
 	assert(count <= rxm_ep->rxm_info->tx_attr->iov_limit);
 
-	ret = rxm_acquire_conn_connect(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		return ret;
-
-	if (OFI_UNLIKELY(!dlist_empty(&rxm_conn->deferred_tx_queue))) {
-		rxm_ep_progress_multi(&rxm_ep->util_ep);
-		if (!dlist_empty(&rxm_conn->deferred_tx_queue))
-			return -FI_EAGAIN;
-	}
 
 	if (data_len <= rxm_ep->rxm_info->tx_attr->inject_size) {
 		struct rxm_tx_eager_buf *tx_buf;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -73,7 +73,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 
 	assert(msg->rma_iov_count <= rxm_ep->rxm_info->tx_attr->rma_iov_limit);
 
-	ret = rxm_acquire_conn_connect(rxm_ep, msg->addr, &rxm_conn);
+	ret = rxm_ep_prepare_tx(rxm_ep, msg->addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		return ret;
 
@@ -264,7 +264,7 @@ rxm_ep_rma_inject_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, ui
 
 	assert(total_size <= rxm_ep->rxm_info->tx_attr->inject_size);
 
-	ret = rxm_acquire_conn_connect(rxm_ep, msg->addr, &rxm_conn);
+	ret = rxm_ep_prepare_tx(rxm_ep, msg->addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		return ret;
 
@@ -406,7 +406,7 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
 					     util_ep.ep_fid.fid);
 
-	ret = rxm_acquire_conn_connect(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		return ret;
 
@@ -438,7 +438,7 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 	struct rxm_conn *rxm_conn;
 	struct rxm_ep *rxm_ep = container_of(ep_fid, struct rxm_ep,
 					     util_ep.ep_fid.fid);
-	ret = rxm_acquire_conn_connect(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		return ret;
 


### PR DESCRIPTION
RxM supports WAS, RAS message orderings by design if a core provider supports them.
But it was broken when deferred TX queue was implemented for deferred protocol
messages of SAR and RNDV protocols.

The commit fixes it by checking the deferred TX queue of the particular connection in
the RMA operations. If the deferred TX queue is empty, it performs RMA operation, else
it return -FI_EAGAIN to the caller.

This patch impelements `rxm_ep_prepare_tx()` functions that acquires connections and
checks deferred queue.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>