### PR TITLE
prov/verbs: Improve address handling in fi_getinfo

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -965,7 +965,7 @@ static void fi_ibv_sockaddr_set_port(struct sockaddr *sa, uint16_t port)
 	}
 }
 
-/* the `rai` parameter is used for the MSG/RDM EP types */
+/* the `rai` parameter is used for the MSG EP type */
 /* the `fmt`, `[src | dest]_addr` parameters are used for the DGRAM EP type */
 /* if the `fmt` parameter isn't used, pass FI_FORMAT_UNSPEC */
 static int fi_ibv_set_info_addrs(struct fi_info *info,
@@ -1278,8 +1278,7 @@ static int fi_ibv_del_info_not_belong_to_dev(const char *dev_name, struct fi_inf
 	*info = NULL;
 
 	while (check_info) {
-		/* Use strncmp since verbs RDM domain name
-		 * would have "-rdm" suffix */
+		/* Use strncmp since verbs domain names would have "-<ep_type>" suffix */
 		if (dev_name && strncmp(dev_name, check_info->domain_attr->name,
 					strlen(dev_name))) {
 			/* This branch removing `check_info` entry from the list */

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1441,6 +1441,22 @@ fn:
 	return ret;
 }
 
+static inline int
+fi_ibv_hints_match_dgram_ep(const struct fi_info *hints)
+{
+	return (hints && ((hints->addr_format == FI_ADDR_IB_UD) ||
+			  (hints->ep_attr && (hints->ep_attr->type == FI_EP_DGRAM))));
+}
+
+static inline int
+fi_ibv_hints_match_msg_ep(const struct fi_info *hints)
+{
+	return (hints && ((hints->addr_format == FI_SOCKADDR) ||
+			  (hints->addr_format == FI_SOCKADDR_IN) ||
+			  (hints->addr_format == FI_SOCKADDR_IN6) ||
+			  (hints->addr_format == FI_SOCKADDR_IB) ||
+			  (hints->ep_attr && (hints->ep_attr->type == FI_EP_MSG))));
+}
 
 static int fi_ibv_get_match_infos(uint32_t version, const char *node,
 				  const char *service, uint64_t flags,
@@ -1457,21 +1473,45 @@ static int fi_ibv_get_match_infos(uint32_t version, const char *node,
 	if (ret)
 		return ret;
 
-	if (hints && (hints->addr_format == FI_ADDR_IB_UD)) {
+	/* Check if the user requested to support DGRAM EP type only */
+	if (fi_ibv_hints_match_dgram_ep(hints)) {
 		/* This is case when only IB UD addresses are passed */
 		ret = fi_ibv_handle_ib_ud_addr(node, service, flags, info);
-		if (ret)
+		if (ret) {
+			VERBS_INFO(FI_LOG_CORE,
+				   "Handling of the IB UD address fails - %d, "
+				   "support of this was requested thru the passed hints\n",
+				   ret);
 			fi_freeinfo(*info);
+		}
+		return ret;
+	}
+
+	/* Check if the user requested to support MSG EP type only */
+	if (fi_ibv_hints_match_msg_ep(hints)) {
+		ret = fi_ibv_handle_sock_addr(node, service, flags, hints, info);
+		if (ret) {
+			VERBS_INFO(FI_LOG_CORE,
+				   "Handling of the socket address fails - %d, but the "
+				   "support of this was requested thru the passed hints\n",
+				   ret);
+			if (*info)
+				fi_freeinfo(*info);
+		} else {
+			if (!*info)
+				return -FI_ENODATA;
+		}
 		return ret;
 	}
 
 	ret_sock_addr = fi_ibv_handle_sock_addr(node, service, flags, hints, info);
-	if (ret_sock_addr)
+	if (ret_sock_addr) {
 		VERBS_INFO(FI_LOG_CORE, "Handling of the socket address fails - %d\n",
 			   ret_sock_addr);
-
-	if (!*info)
-		return -FI_ENODATA;
+	} else {
+		if (!*info)
+			return -FI_ENODATA;
+	}
 
 	ret_ib_ud_addr = fi_ibv_handle_ib_ud_addr(node, service, flags, info);
 	if (ret_ib_ud_addr)


### PR DESCRIPTION
This patch improves checks for IB UD addresses (verbs/DGRAM only) by adding
additional check for EP type. If an application requsts FI_EP_DGRAM we can
check for only IB UD addresses and don't check for Sockets addresses.

Also it adds separate branch for MSG EP type - checks for FI_EP_MSG EP type and
addres type == FI_SOCKADDR*.

As a results, this patch fixes fi_getinfo_test tests (that set destination
address) with RxD/Verbs/DGRAM provider.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>