### PR TITLE
prov/util: set addr_format correctly + reenable unexpected test for RxD

### DIFF
--- a/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
+++ b/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
@@ -21,6 +21,3 @@ multi_mr
 
 # Exclude because it takes too long
 ubertest
-
-# Exclude unexpected test until bug is resolved
-unexpected_msg

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -677,7 +677,7 @@ void *ofi_av_get_addr(struct util_av *av, fi_addr_t fi_addr);
 #define ofi_ip_av_get_addr ofi_av_get_addr
 fi_addr_t ofi_ip_av_get_fi_addr(struct util_av *av, const void *addr);
 
-int ofi_get_addr(uint32_t addr_format, uint64_t flags,
+int ofi_get_addr(uint32_t *addr_format, uint64_t flags,
 		 const char *node, const char *service,
 		 void **addr, size_t *addrlen);
 int ofi_get_src_addr(uint32_t addr_format,

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -192,7 +192,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		}
 
 		if (flags & FI_SOURCE) {
-			ret = ofi_get_addr((*info)->addr_format, flags,
+			ret = ofi_get_addr(&(*info)->addr_format, flags,
 					  node, service, &(*info)->src_addr,
 					  &(*info)->src_addrlen);
 			if (ret) {
@@ -204,7 +204,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		} else {
 			if (node || service) {
 				copy_dest = 0;
-				ret = ofi_get_addr((*info)->addr_format,
+				ret = ofi_get_addr(&(*info)->addr_format,
 						   flags, node, service,
 						   &(*info)->dest_addr,
 						   &(*info)->dest_addrlen);
@@ -225,6 +225,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 					goto err;
 				}
 				(*info)->src_addrlen = hints->src_addrlen;
+				(*info)->addr_format = hints->addr_format;
 			}
 		}
 
@@ -236,6 +237,7 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 				goto err;
 			}
 			(*info)->dest_addrlen = hints->dest_addrlen;
+			(*info)->addr_format = hints->addr_format;
 		}
 
 		if ((*info)->dest_addr && !(*info)->src_addr) {


### PR DESCRIPTION
UDP;ofi_rxd was failing the fi_unexpected_msg test because UDP wasn't setting the address format correctly

This resolves the issue and re-enables the test for rxd