### PR TITLE
prov/rstream: Disable rstream provider

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -505,7 +505,7 @@ libdl_done:
 	ofi_register_provider(SHM_INIT, NULL);
 	ofi_register_provider(RXM_INIT, NULL);
 	ofi_register_provider(VERBS_INIT, NULL);
-	ofi_register_provider(RSTREAM_INIT, NULL);
+	/* ofi_register_provider(RSTREAM_INIT, NULL); - no support */
 	ofi_register_provider(MRAIL_INIT, NULL);
 	ofi_register_provider(RXD_INIT, NULL);
 


### PR DESCRIPTION
It is close for 1.7, but the maintainer will not be available
for support.  Remove it from the 1.7 release.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>