### PR TITLE
prov/verbs: add a lightweight function that gets rdma_addrinfo and rdma_cm_id

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -1101,4 +1101,8 @@ fi_ibv_dgram_send_msg(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
 	return fi_ibv_send_msg(ep, wr, &new_msg, flags);
 }
 
+int fi_ibv_get_rai_id(const char *node, const char *service, uint64_t flags,
+		      const struct fi_info *hints, struct rdma_addrinfo **rai,
+		      struct rdma_cm_id **id);
+
 #endif /* FI_VERBS_H */


### PR DESCRIPTION
The function returns rdma_addrinfo and rdma_cm_id that corresponds to a valid
verbs device if the parameters don't correspond to a wildcard address. Unlike
fi_ibv_create_ep, fi_ibv_get_rai_id doesn't create the QP. Update fi_ibv_getinfo
to use this function.

This fixes an issue where an utility provider may need to call fi_getinfo with
CM fi_info as hints. Without this fix rdma_create_ep invoked in fi_ibv_getinfo
would return "address already in use" error. Utility providers call fi_getinfo
on a fi_domain or fi_endpoint call to resolve the right core provider info for
creating core provider domain or endpoint resource.