### PR TITLE
prov/rxm: Fix handling of addresses inserted several times

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -258,7 +258,7 @@ int rxm_cmap_move_handle_to_peer_list(struct rxm_cmap *cmap, int index);
 static inline struct rxm_cmap_handle *
 rxm_cmap_acquire_handle(struct rxm_cmap *cmap, fi_addr_t fi_addr)
 {
-	assert(fi_addr <= cmap->num_allocated);
+	assert(fi_addr < cmap->num_allocated);
 	return cmap->handles_av[fi_addr];
 }
 

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -77,7 +77,6 @@ rxm_av_insert_cmap(struct fid_av *av_fid, const void *addr, size_t count,
 
 	dlist_foreach_container(&av->ep_list, struct rxm_ep,
 				rxm_ep, util_ep.av_entry) {
-		
 		for (i = 0; i < count; i++) {
 			cur_addr = (const void *) ((char *) addr + i * av->addrlen);
 			fi_addr_tmp = (fi_addr ? fi_addr[i] :


### PR DESCRIPTION
This patch fixes the issues where application inserts the same
addresses several times. util/av searches the addresses in the
hash. If utl/av finds some address in the hash, it returns
address's fi_addr to the user.
So, relying on this fact, this fix is to check handles_av array
and retrieve the CMAP handle if this is known `fi_addr`.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>