### PR TITLE
man pages: ensure to capture new man pages

### DIFF
--- a/config/cron-run-all-md2nroff.pl
+++ b/config/cron-run-all-md2nroff.pl
@@ -182,8 +182,8 @@ if (defined($pages_branch_arg)) {
         doit(0, "cp $tmpdir/$file man/$base", "loop-cp");
 
         # Is there a new man page?  If so, we need to "git add" it.
-        my $out = `git status --porcelain man/$file`;
-        doit(0, "git add man/$file", "loop-git-add")
+        my $out = `git status --porcelain man/$base`;
+        doit(0, "git add man/$base", "loop-git-add")
             if ($out =~ /^\?\?/);
     }
 


### PR DESCRIPTION
Use the right variable name to make sure that we find new pages (i.e.,
that aren't already tracked by git and specifically need to be "git
add"ed).

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>