### PR TITLE
prov/rxm: Fix protocol limits handling

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -646,6 +646,7 @@ struct rxm_ep {
 	struct rxm_buf_pool	*buf_pools;
 
 	struct dlist_entry	repost_ready_list;
+	size_t			rx_buf_size;
 	struct dlist_entry	deferred_tx_conn_queue;
 
 	struct rxm_recv_queue	recv_queue;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -987,8 +987,7 @@ static inline int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 		rx_buf->conn = NULL;
 	rx_buf->hdr.state = RXM_RX;
 
-	if (fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
-		    rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
+	if (fi_recv(rx_buf->msg_ep, &rx_buf->pkt, rx_buf->ep->rx_buf_size,
 		    rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to repost buf\n");
 		return -FI_EAVAIL;

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -165,17 +165,12 @@ static int rxm_init_info(void)
 	size_t param;
 
 	if (!fi_param_get_size_t(&rxm_prov, "buffer_size", &param)) {
-		if (param > sizeof(struct rxm_pkt)) {
-			rxm_info.tx_attr->inject_size = param;
-		} else {
-			FI_WARN(&rxm_prov, FI_LOG_CORE,
-				"Requested buffer size too small\n");
-			return -FI_EINVAL;
-		}
+		rxm_info.tx_attr->inject_size = param;
 	} else {
-		rxm_info.tx_attr->inject_size = RXM_BUF_SIZE;
+		rxm_info.tx_attr->inject_size =
+			RXM_BUF_SIZE - sizeof(struct rxm_pkt);
 	}
-	rxm_info.tx_attr->inject_size -= sizeof(struct rxm_pkt);
+
 	rxm_util_prov.info = &rxm_info;
 	return 0;
 }


### PR DESCRIPTION
This commits fixes the handling of protocol limits:
- Use FI_OFI_RXM_BUFFER_SIZE value set by user for Eager (not substracting
sizeof(struct rxm_pkt) value). It is safe, because we allocate all buffers
with size = eager_limit = RxM fi_info::tx_attr::inject_size
- Set SAR limit to 0, if Eager limit = 0.
- Define the rx_buf_size field in the RxM EP that is used for preposting
receive buffers. rx_buf_size is a maximum needed value to implement the protocols
(Buffered minimum + RNDV header size OR Eager limit)

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>