### PR TITLE
prov/psm2: Temporarily disable the use of psm2_mq_fp_msg due to instability

### DIFF
--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -30,8 +30,8 @@
  * SOFTWARE.
  */
 
-#include "psmx2.h"
 #include "ofi_prov.h"
+#include "psmx2.h"
 #include <glob.h>
 #include <dlfcn.h>
 

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -53,6 +53,12 @@
 #define PSMX2_DEFAULT_UUID	"00FF00FF-0000-0000-0000-00FF00FF00FF"
 #define PROVIDER_INI		PSM2_INI
 
+/* Temporarily disable the use of psm2_mq_fp_msg due to instability */
+#ifdef HAVE_PSM2_MQ_FP_MSG
+#undef HAVE_PSM2_MQ_FP_MSG
+#endif
+#define HAVE_PSM2_MQ_FP_MSG	0
+
 #if HAVE_PSM2_MQ_REQ_USER
 
 #ifndef PSMX2_USE_REQ_CONTEXT


### PR DESCRIPTION
Unstable MPI RMA operations have been observed when the newly introduced
psm2_mq_fp_msg function is used for large size RMA. Temporarily disable the
use of this function until it is fixed in the PSM2 library.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>