### PR TITLE
prov/gni: fix a problem with double free

### DIFF
--- a/prov/gni/include/gnix_vc.h
+++ b/prov/gni/include/gnix_vc.h
@@ -101,6 +101,7 @@ enum gnix_vc_conn_req_type {
  *                           associated
  * @var smsg_mbox            pointer to GNI SMSG mailbox used by this VC
  *                           to exchange SMSG messages with its peer
+ * @var gnix_ep_name         cache for storing remote endpoint name
  * @var gni_ep               GNI endpoint for this VC
  * @var outstanding_fab_reqs Count of outstanding libfabric level requests
  *                           associated with this endpoint.

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
- * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
+ * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -400,11 +400,15 @@ static int __recv_completion_src(
 		fi_addr_t src_addr)
 {
 	ssize_t rc;
+	char *buffer;
 
 	GNIX_DBG_TRACE(FI_LOG_TRACE, "\n");
 
 	if ((req->msg.recv_flags & FI_COMPLETION) && ep->recv_cq) {
 		if (src_addr == FI_ADDR_NOTAVAIL) {
+			buffer = malloc(GNIX_CQ_MAX_ERR_DATA_SIZE);
+			memcpy(buffer, req->vc->gnix_ep_name,
+				sizeof(struct gnix_ep_name));
 			rc = _gnix_cq_add_error(ep->recv_cq,
 						req->user_context,
 						flags,
@@ -415,7 +419,7 @@ static int __recv_completion_src(
 						0,
 						FI_EADDRNOTAVAIL,
 						0,
-						req->vc->gnix_ep_name,
+						buffer,
 						sizeof(struct gnix_ep_name));
 		} else {
 			rc = _gnix_cq_add_event(ep->recv_cq,

--- a/prov/gni/src/gnix_vc.c
+++ b/prov/gni/src/gnix_vc.c
@@ -1510,6 +1510,7 @@ int _gnix_vc_alloc(struct gnix_fid_ep *ep_priv,
 	if (ret != FI_SUCCESS)
 		goto err;
 	vc_ptr->vc_id = remote_id;
+	vc_ptr->gnix_ep_name = NULL;
 
 	*vc = vc_ptr;
 
@@ -1640,6 +1641,11 @@ int _gnix_vc_destroy(struct gnix_vc *vc)
 		      fi_strerror(-ret));
 
 	_gnix_free_bitmap(&vc->flags);
+
+	if (vc->gnix_ep_name != NULL) {
+		free(vc->gnix_ep_name);
+		vc->gnix_ep_name = NULL;
+	}
 
 	/*
 	 * put VC back on the freelist


### PR DESCRIPTION
retain the gnix_ep_name field in the vc struct
if needed and free in vc destructor.  make a copy
of the content of the gnix_ep_name when reporting back
to the application using FI_SOURCE_ERR.

fixes #4521

Signed-off-by: Howard Pritchard <howardp@lanl.gov>