### PR TITLE
prov/verbs: Fix segfault caused by XRC CM REJ message handling for non-application rejects

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -118,6 +118,8 @@
 #define VERBS_CM_DATA_SIZE	(FI_IBV_CM_DATA_SIZE -		\
 				 sizeof(struct fi_ibv_cm_data_hdr))
 
+#define FI_IBV_CM_REJ_CONSUMER_DEFINED	28
+
 #define VERBS_DGRAM_MSG_PREFIX_SIZE	(40)
 
 #define FI_IBV_EP_TYPE(info)						\

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -244,8 +244,10 @@ static void fi_ibv_eq_skip_xrc_cm_data(const void **priv_data,
 {
 	const struct fi_ibv_xrc_cm_data *cm_data = *priv_data;
 
-	*priv_data = (cm_data + 1);
-	*priv_data_len -= sizeof(*cm_data);
+	if (*priv_data_len > sizeof(*cm_data)) {
+		*priv_data = (cm_data + 1);
+		*priv_data_len -= sizeof(*cm_data);
+	}
 }
 
 static int

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -33,7 +33,6 @@
 
 #include "config.h"
 
-#include <infiniband/cm.h>	/* For Reject Codes */
 #include <ofi_util.h>
 #include "fi_verbs.h"
 
@@ -413,7 +412,7 @@ fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
 	}
 
 	/* If reject comes from remote provider peer */
-	if (cma_event->status == IB_CM_REJ_CONSUMER_DEFINED) {
+	if (cma_event->status == FI_IBV_CM_REJ_CONSUMER_DEFINED) {
 		if (cma_event->param.conn.private_data_len &&
 		    fi_ibv_eq_set_xrc_info(cma_event, &xrc_info)) {
 			VERBS_WARN(FI_LOG_FABRIC,
@@ -459,7 +458,11 @@ fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 	 * ID(s) since  RDMA CM is used for connection setup only */
 	*acked = 1;
 	rdma_ack_cm_event(cma_event);
-	fi_ibv_free_xrc_conn_setup(ep);
+
+	/* TODO: Ultimately we will want to initiate freeing of the connection
+	 * resources here with fi_ibv_free_xrc_conn_setup(ep); however, timewait
+	 * issues in larger fabrics need to be resolved first. The resources
+	 * will be freed at EP close if not freed here */
 
 	return ret;
 }


### PR DESCRIPTION
This PR fixes two XRC CM REJ message handling segfaults associated with CM REJ messages that are initiated from the CM, not the peer provider (two commits). It also temporarily disables the early release of XRC connection resources letting the existing EP close normal processing handle it (one commit). The latter is to allow correct operation until resources remaining in the timed wait state can be further addressed.