### PR TITLE
prov/rxm: Rework locking around progress

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -736,8 +736,7 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 int rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep);
 void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 			void *op_context, int err);
-void rxm_ep_progress_one(struct util_ep *util_ep);
-void rxm_ep_progress_multi(struct util_ep *util_ep);
+void rxm_ep_progress(struct util_ep *util_ep);
 
 int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
 void rxm_ep_progress_deferred_queues(struct rxm_ep *rxm_ep);
@@ -1005,7 +1004,7 @@ rxm_ep_prepare_tx(struct rxm_ep *rxm_ep, fi_addr_t dest_addr,
 		return ret;
 
 	if (OFI_UNLIKELY(!dlist_empty(&(*rxm_conn)->deferred_tx_queue))) {
-		rxm_ep_progress_multi(&rxm_ep->util_ep);
+		rxm_ep_progress(&rxm_ep->util_ep);
 		if (!dlist_empty(&(*rxm_conn)->deferred_tx_queue))
 			return -FI_EAGAIN;
 	}

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -739,7 +739,6 @@ void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 void rxm_ep_progress(struct util_ep *util_ep);
 
 int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
-void rxm_ep_progress_deferred_queues(struct rxm_ep *rxm_ep);
 
 int rxm_ep_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,
@@ -766,6 +765,9 @@ static inline struct rxm_conn *rxm_key2conn(struct rxm_ep *rxm_ep, uint64_t key)
 {
 	return (struct rxm_conn *)rxm_cmap_key2handle(rxm_ep->cmap, key);
 }
+
+void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
+				    struct rxm_conn *rxm_conn);
 
 struct rxm_deferred_tx_entry *
 rxm_ep_alloc_deferred_tx_entry(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -127,8 +127,8 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		return -FI_EINVAL;
 	}
 
-	tx_buf = (struct rxm_tx_atomic_buf *)rxm_tx_buf_get(rxm_ep,
-						RXM_BUF_POOL_TX_ATOMIC);
+	tx_buf = (struct rxm_tx_atomic_buf *)
+		 rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX_ATOMIC);
 	if (OFI_UNLIKELY(!tx_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from Atomic buffer pool\n");

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -72,7 +72,7 @@ rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, len,
 			      tx_buf->hdr.desc, 0, tx_buf);
 	if (ret == -FI_EAGAIN)
-		rxm_ep_progress(&rxm_ep->util_ep);
+		rxm_ep_do_progress(&rxm_ep->util_ep);
 
 	return ret;
 }
@@ -127,12 +127,14 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		return -FI_EINVAL;
 	}
 
+	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 	tx_buf = (struct rxm_tx_atomic_buf *)
 		 rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX_ATOMIC);
 	if (OFI_UNLIKELY(!tx_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from Atomic buffer pool\n");
-		return -FI_EAGAIN;
+		ret = -FI_EAGAIN;
+		goto unlock;
 	}
 
 	rxm_ep_format_atomic_pkt_hdr(rxm_conn, tx_buf, tot_len, op,
@@ -158,7 +160,8 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	ret = rxm_ep_send_atomic_req(rxm_ep, rxm_conn, tx_buf, tot_len);
 	if (ret)
 		rxm_tx_buf_release(rxm_ep, RXM_BUF_POOL_TX_ATOMIC, tx_buf);
-
+unlock:
+	ofi_ep_lock_release(&rxm_ep->util_ep);
 	return ret;
 }
 

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -72,7 +72,7 @@ rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, len,
 			      tx_buf->hdr.desc, 0, tx_buf);
 	if (ret == -FI_EAGAIN)
-		rxm_ep_progress_multi(&rxm_ep->util_ep);
+		rxm_ep_progress(&rxm_ep->util_ep);
 
 	return ret;
 }

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1020,7 +1020,7 @@ static int rxm_conn_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
 			if (rx_buf->ep->util_ep.flags & OFI_CNTR_ENABLED)
 				rxm_cntr_incerr(rx_buf->ep->util_ep.rx_cntr);
 
-			rxm_enqueue_rx_buf_for_repost_check(rx_buf);
+			rxm_rx_buf_release(recv_queue->rxm_ep, rx_buf);
 
 			if (!(rx_buf->recv_entry->flags & FI_MULTI_RECV))
 				rxm_recv_entry_release(recv_queue,

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -418,7 +418,6 @@ int rxm_cmap_update(struct rxm_cmap *cmap, const void *addr, fi_addr_t fi_addr)
 	return 0;
 }
 
-/* Caller must hold cmap->lock */
 void rxm_cmap_process_shutdown(struct rxm_cmap *cmap,
 			       struct rxm_cmap_handle *handle)
 {
@@ -974,7 +973,6 @@ static int rxm_conn_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
 
 	dlist_init(&rx_buf_list);
 
-	recv_queue->rxm_ep->cmap->acquire(&recv_queue->rxm_ep->cmap->lock);
 	ofi_ep_lock_acquire(&recv_queue->rxm_ep->util_ep);
 
 	dlist_foreach_container_safe(&recv_queue->unexp_msg_list,
@@ -1001,7 +999,6 @@ static int rxm_conn_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
 		dlist_insert_tail(&rx_buf->unexp_msg.entry, &rx_buf_list);
 	}
 	ofi_ep_lock_release(&recv_queue->rxm_ep->util_ep);
-	recv_queue->rxm_ep->cmap->release(&recv_queue->rxm_ep->cmap->lock);
 
 	while (!dlist_empty(&rx_buf_list)) {
 		dlist_pop_front(&rx_buf_list, struct rxm_rx_buf,

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1310,23 +1310,7 @@ static inline ssize_t rxm_ep_read_msg_cq(struct rxm_ep *rxm_ep)
 	return ret;
 }
 
-void rxm_ep_progress_one(struct util_ep *util_ep)
-{
-	struct rxm_ep *rxm_ep =
-		container_of(util_ep, struct rxm_ep, util_ep);
-
-	if (!slistfd_empty(&rxm_ep->msg_eq_entry_list))
-		rxm_conn_process_eq_events(rxm_ep);
-
-	rxm_cq_repost_rx_buffers(rxm_ep);
-
-	(void) rxm_ep_read_msg_cq(rxm_ep);
-
-	if (OFI_UNLIKELY(!dlist_empty(&rxm_ep->deferred_tx_conn_queue)))
-		rxm_ep_progress_deferred_queues(rxm_ep);
-}
-
-void rxm_ep_progress_multi(struct util_ep *util_ep)
+void rxm_ep_progress(struct util_ep *util_ep)
 {
 	struct rxm_ep *rxm_ep =
 		container_of(util_ep, struct rxm_ep, util_ep);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -568,7 +568,7 @@ rxm_cq_match_rx_buf(struct rxm_rx_buf *rx_buf,
 				  &recv_queue->unexp_msg_list);
 		ofi_ep_lock_release(&recv_queue->rxm_ep->util_ep);
 
-		rx_buf = rxm_rx_buf_get(rxm_ep);
+		rx_buf = rxm_rx_buf_alloc(rxm_ep);
 		if (OFI_UNLIKELY(!rx_buf)) {
 			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 				"Ran out of buffers from RX buffer pool\n");
@@ -664,7 +664,7 @@ static ssize_t rxm_rndv_send_ack(struct rxm_rx_buf *rx_buf)
 	assert(rx_buf->conn);
 
 	rx_buf->recv_entry->rndv.tx_buf = (struct rxm_tx_base_buf *)
-		rxm_tx_buf_get(rx_buf->ep, RXM_BUF_POOL_TX_ACK);
+		rxm_tx_buf_alloc(rx_buf->ep, RXM_BUF_POOL_TX_ACK);
 	if (OFI_UNLIKELY(!rx_buf->recv_entry->rndv.tx_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ,
 			"Ran out of buffers from ACK buffer pool\n");
@@ -887,8 +887,8 @@ static inline ssize_t rxm_handle_atomic_req(struct rxm_ep *rxm_ep,
 	if (OFI_UNLIKELY(!rx_buf->conn))
 		return -FI_EOTHER;
 
-	resp_buf = (struct rxm_tx_atomic_buf *) rxm_tx_buf_get(rxm_ep,
-							RXM_BUF_POOL_TX_ATOMIC);
+	resp_buf = (struct rxm_tx_atomic_buf *)
+		   rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX_ATOMIC);
 	if (OFI_UNLIKELY(!resp_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Unable to allocate from Atomic buffer pool\n");
@@ -1241,7 +1241,7 @@ int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)
 	size_t i;
 
 	for (i = 0; i < rxm_ep->msg_info->rx_attr->size; i++) {
-		rx_buf = rxm_rx_buf_get(rxm_ep);
+		rx_buf = rxm_rx_buf_alloc(rxm_ep);
 		if (OFI_UNLIKELY(!rx_buf)) {
 			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 				"Ran out of buffers from RX buffer pool\n");

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1004,11 +1004,6 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 
 	switch (RXM_GET_PROTO_STATE(comp->op_context)) {
 	case RXM_TX:
-		tx_eager_buf = comp->op_context;
-		assert(comp->flags & FI_SEND);
-		ret = rxm_finish_eager_send(rxm_ep, tx_eager_buf);
-		rxm_tx_buf_release(rxm_ep, RXM_BUF_POOL_TX, tx_eager_buf);
-		return ret;
 	case RXM_INJECT_TX:
 		tx_eager_buf = comp->op_context;
 		assert(comp->flags & FI_SEND);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1219,11 +1219,9 @@ rxm_ep_inject_send_fast(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		ret = rxm_ep_msg_inject_send(rxm_ep, rxm_conn, inject_pkt,
 					      pkt_size, rxm_ep->util_ep.tx_cntr_inc);
 	} else {
-		ofi_ep_lock_acquire(&rxm_ep->util_ep);
 		ret = rxm_ep_emulate_inject(rxm_ep, rxm_conn, buf, len, pkt_size,
 					    inject_pkt->hdr.data, inject_pkt->hdr.flags,
 					    inject_pkt->hdr.tag, inject_pkt->hdr.op);
-		ofi_ep_lock_release(&rxm_ep->util_ep);
 	}
 	return ret;
 }

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -818,8 +818,10 @@ static ssize_t rxm_ep_recv_common_flags(struct rxm_ep *rxm_ep, const struct iove
 
 		assert(flags & FI_DISCARD);
 		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Discarding buffered receive\n");
+		ofi_ep_lock_acquire(&rxm_ep->util_ep);
 		dlist_insert_tail(&rx_buf->repost_entry,
 				  &rx_buf->ep->repost_ready_list);
+		ofi_ep_lock_release(&rxm_ep->util_ep);
 		return 0;
 	}
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2152,14 +2152,12 @@ err:
 static int rxm_ep_eq_entry_list_trywait(void *arg)
 {
 	struct rxm_ep *rxm_ep = (struct rxm_ep *)arg;
+	int ret;
 
 	fastlock_acquire(&rxm_ep->msg_eq_entry_list_lock);
-	if (!slistfd_empty(&rxm_ep->msg_eq_entry_list)) {
-		fastlock_release(&rxm_ep->msg_eq_entry_list_lock);
-		return -FI_EAGAIN;
-	}
+	ret = slistfd_empty(&rxm_ep->msg_eq_entry_list) ? 0 : -FI_EAGAIN;
 	fastlock_release(&rxm_ep->msg_eq_entry_list_lock);
-	return 0;
+	return ret;
 }
 
 static int rxm_ep_trywait(void *arg)

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1553,8 +1553,7 @@ sar_finish:
 	return ret;
 }
 
-static void
-rxm_ep_conn_progress_deferred_queue(struct rxm_ep *rxm_ep,
+void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 				    struct rxm_conn *rxm_conn)
 {
 	struct rxm_deferred_tx_entry *def_tx_entry;
@@ -1619,16 +1618,6 @@ rxm_ep_conn_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			free(def_tx_entry);
 			break;
 		}
-	}
-}
-
-void rxm_ep_progress_deferred_queues(struct rxm_ep *rxm_ep)
-{
-	struct dlist_entry *conn_entry_tmp;
-	struct rxm_conn *rxm_conn;
-	dlist_foreach_container_safe(&rxm_ep->deferred_tx_conn_queue, struct rxm_conn,
-				     rxm_conn, deferred_conn_entry, conn_entry_tmp) {
-		rxm_ep_conn_progress_deferred_queue(rxm_ep, rxm_conn);
 	}
 }
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -326,37 +326,6 @@ static void rxm_recv_entry_init(struct rxm_recv_entry *entry, void *arg)
 		entry->comp_flags |= FI_TAGGED;
 }
 
-static inline struct rxm_recv_entry *
-rxm_recv_entry_pop_thread_unsafe(struct rxm_recv_queue *recv_queue)
-{
-	return (freestack_isempty(recv_queue->fs) ?
-		NULL : freestack_pop(recv_queue->fs));
-}
-
-static inline void
-rxm_recv_entry_push_thread_unsafe(struct rxm_recv_queue *recv_queue,
-				  struct rxm_recv_entry *entry)
-{
-	freestack_push(recv_queue->fs, entry);
-}
-
-static struct rxm_recv_entry *
-rxm_recv_entry_pop_thread_safe(struct rxm_recv_queue *recv_queue)
-{
-	void *entry;
-
-	entry = rxm_recv_entry_pop_thread_unsafe(recv_queue);
-
-	return entry;
-}
-
-static void
-rxm_recv_entry_push_thread_safe(struct rxm_recv_queue *recv_queue,
-				struct rxm_recv_entry *entry)
-{
-	rxm_recv_entry_push_thread_unsafe(recv_queue, entry);
-}
-
 static int rxm_recv_queue_init(struct rxm_ep *rxm_ep,  struct rxm_recv_queue *recv_queue,
 			       size_t size, enum rxm_recv_queue_type type)
 {
@@ -384,14 +353,6 @@ static int rxm_recv_queue_init(struct rxm_ep *rxm_ep,  struct rxm_recv_queue *re
 			recv_queue->match_recv = rxm_match_recv_entry_tag;
 			recv_queue->match_unexp = rxm_match_unexp_msg_tag;
 		}
-	}
-
-	if (rxm_ep->util_ep.domain->threading != FI_THREAD_SAFE) {
-		recv_queue->pop = rxm_recv_entry_pop_thread_unsafe;
-		recv_queue->push = rxm_recv_entry_push_thread_unsafe;
-	} else {
-		recv_queue->pop = rxm_recv_entry_pop_thread_safe;
-		recv_queue->push = rxm_recv_entry_push_thread_safe;
 	}
 
 	return 0;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -218,7 +218,7 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, 
 	ret = fi_writemsg(rxm_conn->msg_ep, &rxm_rma_msg, flags);
 	if (OFI_UNLIKELY(ret)) {
 		if (ret == -FI_EAGAIN)
-			rxm_ep_progress_multi(&rxm_ep->util_ep);
+			rxm_ep_progress(&rxm_ep->util_ep);
 		goto err;
 	}
 	return 0;
@@ -292,7 +292,7 @@ rxm_ep_rma_inject_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, ui
 			       "fi_inject_write* for MSG provider failed with ret - %"
 			       PRId64"\n", ret);
 			if (OFI_LIKELY(ret == -FI_EAGAIN))
-				rxm_ep_progress_multi(&rxm_ep->util_ep);
+				rxm_ep_progress(&rxm_ep->util_ep);
 		}
 		return ret;
 	} else {
@@ -421,7 +421,7 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 			       "fi_inject_write for MSG provider failed with ret - %"
 			       PRId64"\n", ret);
 			if (OFI_LIKELY(ret == -FI_EAGAIN))
-				rxm_ep_progress_multi(&rxm_ep->util_ep);
+				rxm_ep_progress(&rxm_ep->util_ep);
 		}
 		return ret;
 	} else {
@@ -453,7 +453,7 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 			       "fi_inject_writedata for MSG provider failed with ret - %"
 			       PRId64"\n", ret);
 			if (OFI_LIKELY(ret == -FI_EAGAIN))
-				rxm_ep_progress_multi(&rxm_ep->util_ep);
+				rxm_ep_progress(&rxm_ep->util_ep);
 		}
 		return ret;
 	} else {

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -78,7 +78,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 	if (OFI_UNLIKELY(ret))
 		return ret;
 
-	rma_buf = rxm_rma_buf_get(rxm_ep);
+	rma_buf = rxm_rma_buf_alloc(rxm_ep);
 	if (OFI_UNLIKELY(!rma_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from RMA buffer pool\n");
@@ -201,7 +201,7 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, 
 
 	assert(msg->rma_iov_count <= rxm_ep->rxm_info->tx_attr->rma_iov_limit);
 
-	rma_buf = rxm_rma_buf_get(rxm_ep);
+	rma_buf = rxm_rma_buf_alloc(rxm_ep);
 	if (OFI_UNLIKELY(!rma_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from RMA buffer pool\n");

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -78,11 +78,13 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 	if (OFI_UNLIKELY(ret))
 		return ret;
 
+	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 	rma_buf = rxm_rma_buf_alloc(rxm_ep);
 	if (OFI_UNLIKELY(!rma_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from RMA buffer pool\n");
-		return -FI_ENOMEM;
+		ret = -FI_ENOMEM;
+		goto unlock;
 	}
 
 	rma_buf->app_context = msg->context;
@@ -92,18 +94,21 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 				 msg_rma.iov_count, comp_flags & (FI_WRITE | FI_READ),
 				 rma_buf);
 	if (OFI_UNLIKELY(ret))
-		goto err;
+		goto release;
+
 	msg_rma.desc = mr_desc;
 	msg_rma.context = rma_buf;
 
 	ret = rma_msg(rxm_conn->msg_ep, &msg_rma, flags);
 	if (OFI_LIKELY(!ret))
-		return ret;
+		goto unlock;
 
 	if ((rxm_ep->msg_mr_local) && (!rxm_ep->rxm_mr_local))
 		rxm_ep_msg_mr_closev(rma_buf->mr.mr, rma_buf->mr.count);
-err:
+release:
 	rxm_rma_buf_release(rxm_ep, rma_buf);
+unlock:
+	ofi_ep_lock_release(&rxm_ep->util_ep);
 	return ret;
 }
 
@@ -201,11 +206,13 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, 
 
 	assert(msg->rma_iov_count <= rxm_ep->rxm_info->tx_attr->rma_iov_limit);
 
+	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 	rma_buf = rxm_rma_buf_alloc(rxm_ep);
 	if (OFI_UNLIKELY(!rma_buf)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"Ran out of buffers from RMA buffer pool\n");
-		return -FI_ENOMEM;
+		ret = -FI_ENOMEM;
+		goto unlock;
 	}
 
 	rma_buf->pkt.hdr.size = total_size;
@@ -218,12 +225,11 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, 
 	ret = fi_writemsg(rxm_conn->msg_ep, &rxm_rma_msg, flags);
 	if (OFI_UNLIKELY(ret)) {
 		if (ret == -FI_EAGAIN)
-			rxm_ep_progress(&rxm_ep->util_ep);
-		goto err;
+			rxm_ep_do_progress(&rxm_ep->util_ep);
+		rxm_rma_buf_release(rxm_ep, rma_buf);
 	}
-	return 0;
-err:
-	rxm_rma_buf_release(rxm_ep, rma_buf);
+unlock:
+	ofi_ep_lock_release(&rxm_ep->util_ep);
 	return ret;
 }
 


### PR DESCRIPTION
RxM can drive progress across an EP from several call sites.  The result is that while serialization is provided on individual queues, structures, and lists, the overall progress model is not thread safe.  This can be seen by the app as receiving messages out of order, or received messages being associated with the wrong posted buffer.

To fix this, we need to serialize the progress handling at a higher level.  However, this requires restructuring the locking, so that the EP lock can be held across the full handling of messages.  Care must be taken that we don't lose locks where they are needed, and that we don't introduce nested locking/deadlocks.

This series provides several patches to restructure and simplify the code.  We then move the EP locking up to the desired functions, so that all progress is serialized on an EP.  Progress can be initiated as part of completion processing, driven by connection processes (EQ events), or started as part of a transfer.