### PR TITLE
prov/rxm: Fix fi_inject_atomic() RMA IOC count

### DIFF
--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -233,7 +233,7 @@ rxm_ep_atomic_inject(struct fid_ep *ep_fid, const void *buf, size_t count,
 	};
 	struct fi_rma_ioc rma_iov = {
 		.addr = addr,
-		.count = 1,
+		.count = count,
 		.key = key,
 	};
 	struct fi_msg_atomic msg = {


### PR DESCRIPTION
Correctly set the RMA IOC count member for fi_inject_atomic() API
implementation.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>