### PR TITLE
fabtests/hpcs: add hpcs scalable unit test framework

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -98,6 +98,10 @@ libfabtests_la_SOURCES = \
 	include/unix/osd.h \
 	include/ft_osd.h
 
+if HPCS
+SUBDIRS = . hpcs
+endif
+
 benchmarks_srcs = \
 	benchmarks/benchmark_shared.h \
 	benchmarks/benchmark_shared.c

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -141,6 +141,7 @@ ifdef(AX_MPI,
 			[ AC_MSG_ERROR([No suitable MPI provided, set MPICC])])]) ],
 	[AS_IF([test $hpcs -eq 1], [
 		AS_IF([test -n "$MPICC"], [
-			AC_CONFIG_FILES([hpcs/Makefile hpcs/src/harness/Makefile])],[ AC_MSG_ERROR([No suitable MPI provided, set MPICC])] )])])
+			AC_CONFIG_FILES([hpcs/Makefile hpcs/src/harness/Makefile])],
+			[ AC_MSG_ERROR([No suitable MPI provided, set MPICC])] )])])
 
 AC_OUTPUT

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -51,8 +51,7 @@ AC_ARG_ENABLE([debug],
 AC_ARG_ENABLE([hpcs],
 	[AS_HELP_STRING([--enable-hpcs],
 			[Enable building hpcs - default NO])],
-	[CC="$MPICC"
-	 hpcs=1],
+	[hpcs=1],
 	[hpcs=0])
 
 AM_CONDITIONAL([HPCS], [test $hpcs -eq 1])
@@ -130,18 +129,18 @@ AC_CHECK_FUNC([epoll_create1], [have_epoll=1], [have_epoll=0])
 AC_DEFINE_UNQUOTED([HAVE_EPOLL], [$have_epoll],
 		   [Defined to 1 if Linux epoll is available])
 
-AC_CONFIG_FILES([Makefile fabtests.spec])
+AC_CONFIG_FILES([Makefile hpcs/Makefile hpcs/src/harness/Makefile fabtests.spec])
 
 dnl HPCS depends on MPI, so we use AX_MPI to help with configuring MPI compiler.
 dnl AX_MPI is usually part of the autoconf-archive package, but we should not
 dnl assume it's universally installed.
 ifdef(AX_MPI,
 	[AS_IF([test $hpcs -eq 1], [
-		AX_MPI([AC_CONFIG_FILES([hpcs/Makefile hpcs/src/harness/Makefile])],
-			[ AC_MSG_ERROR([No suitable MPI provided, set MPICC])])]) ],
+		AX_MPI(	[CC="$MPICC"],
+			[AC_MSG_ERROR([No suitable MPI provided, set MPICC])])]) ],
 	[AS_IF([test $hpcs -eq 1], [
-		AS_IF([test -n "$MPICC"], [
-			AC_CONFIG_FILES([hpcs/Makefile hpcs/src/harness/Makefile])],
-			[ AC_MSG_ERROR([No suitable MPI provided, set MPICC])] )])])
+		AS_IF([test -n "$MPICC"],
+			[CC="$MPICC"],
+			[AC_MSG_ERROR([No suitable MPI provided, set MPICC])] )])])
 
 AC_OUTPUT

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -48,6 +48,15 @@ AC_ARG_ENABLE([debug],
 	 dbg=1],
 	[dbg=0])
 
+AC_ARG_ENABLE([hpcs],
+	[AS_HELP_STRING([--enable-hpcs],
+			[Enable building hpcs - default NO])],
+	[CC="$MPICC"
+	 hpcs=1],
+	[hpcs=0])
+
+AM_CONDITIONAL([HPCS], [test $hpcs -eq 1])
+
 AC_DEFINE_UNQUOTED([ENABLE_DEBUG], [$dbg],
 	[defined to 1 if configured with --enable-debug])
 
@@ -122,4 +131,16 @@ AC_DEFINE_UNQUOTED([HAVE_EPOLL], [$have_epoll],
 		   [Defined to 1 if Linux epoll is available])
 
 AC_CONFIG_FILES([Makefile fabtests.spec])
+
+dnl HPCS depends on MPI, so we use AX_MPI to help with configuring MPI compiler.
+dnl AX_MPI is usually part of the autoconf-archive package, but we should not
+dnl assume it's universally installed.
+ifdef(AX_MPI,
+	[AS_IF([test $hpcs -eq 1], [
+		AX_MPI([AC_CONFIG_FILES([hpcs/Makefile hpcs/src/harness/Makefile])],
+			[ AC_MSG_ERROR([No suitable MPI provided, set MPICC])])]) ],
+	[AS_IF([test $hpcs -eq 1], [
+		AS_IF([test -n "$MPICC"], [
+			AC_CONFIG_FILES([hpcs/Makefile hpcs/src/harness/Makefile])],[ AC_MSG_ERROR([No suitable MPI provided, set MPICC])] )])])
+
 AC_OUTPUT

--- a/fabtests/fabtests.spec.in
+++ b/fabtests/fabtests.spec.in
@@ -16,7 +16,7 @@ Fabtests provides a set of examples that uses libfabric - a high-performance fab
 %setup -q -n %{name}-%{version}
 
 %build
-%configure %{?_with_libfabric}
+%configure %{?_with_libfabric} %{?_enable_hpcs}
 make %{?_smp_mflags}
 
 %install

--- a/fabtests/hpcs/Makefile.am
+++ b/fabtests/hpcs/Makefile.am
@@ -25,6 +25,7 @@ libpattern_la_CFLAGS = $(libcore_la_CFLAGS)
 
 
 hpcs_sendrecv_SOURCES = src/test/sendrecv.c \
+			src/test/generic.c \
 			include/test/user.h
 
 hpcs_sendrecv_CFLAGS = $(libcore_la_CFLAGS)
@@ -35,6 +36,7 @@ hpcs_sendrecv_LDADD = \
 	libpattern.la
 
 hpcs_onesided_SOURCES = src/test/onesided.c \
+			src/test/generic.c \
 			include/test/user.h
 
 hpcs_onesided_CFLAGS = $(libcore_la_CFLAGS)

--- a/fabtests/hpcs/Makefile.am
+++ b/fabtests/hpcs/Makefile.am
@@ -1,0 +1,47 @@
+bin_PROGRAMS = \
+	hpcs_sendrecv \
+	hpcs_onesided
+
+noinst_LTLIBRARIES = 	libcore.la \
+			libpattern.la
+
+libcore_la_SOURCES = \
+	src/core/core.c \
+	include/core/user.h
+
+libcore_la_CFLAGS = \
+	$(AM_CFLAGS) \
+	-I$(srcdir)/include
+
+libpattern_la_SOURCES = \
+	src/pattern/alltoall.c \
+	src/pattern/self.c \
+	src/pattern/alltoone.c \
+	include/pattern/user.h \
+	src/pattern/util.h
+
+libpattern_la_CFLAGS = $(libcore_la_CFLAGS)
+
+
+hpcs_sendrecv_SOURCES = src/test/sendrecv.c \
+			include/test/user.h
+
+hpcs_sendrecv_CFLAGS = $(libcore_la_CFLAGS)
+
+hpcs_sendrecv_LDADD = \
+	src/harness/libharness.la \
+	libcore.la \
+	libpattern.la
+
+hpcs_onesided_SOURCES = src/test/onesided.c \
+			include/test/user.h
+
+hpcs_onesided_CFLAGS = $(libcore_la_CFLAGS)
+
+hpcs_onesided_LDADD = \
+	src/harness/libharness.la \
+	libcore.la \
+	libpattern.la
+
+SUBDIRS = src/harness .
+

--- a/fabtests/hpcs/Makefile.am
+++ b/fabtests/hpcs/Makefile.am
@@ -17,6 +17,7 @@ libpattern_la_SOURCES = \
 	src/pattern/alltoall.c \
 	src/pattern/self.c \
 	src/pattern/alltoone.c \
+	src/pattern/ring.c \
 	include/pattern/user.h \
 	src/pattern/util.h
 

--- a/fabtests/hpcs/include/core/user.h
+++ b/fabtests/hpcs/include/core/user.h
@@ -43,60 +43,34 @@
  * -----------------------------------------------------------------------------
  * CORE API
  * -----------------------------------------------------------------------------
- *
- * Core combines a test and pattern, and drives the callback routines in each.
- * Arguments are positional in argv.  The arguments are:
- *
- * argv[0]: Provider Name (%128s): The name of the provider to use for
- * transport.  Corresponds to the OFI option "prov_name".
- *
- * argv[1]: Domains per Process (%zu): The number of OFI domains that should be
- * created per process.
- *
- * argv[2]: Endpoints per Domain (%zu): The number of OFI endpoints to create
- * per domain.
- *
- * argv[3]: Transfers per EP Pair (%zu): The number of transfers between each
- * endpoint pair that should occur (i.e., repetitions).
- *
- * argv[4]: Window Size (%zu): Window size is directly related to the amount of
- * memory each process is allowed to consume.  The exact consumption depends on
- * the specific test implementation.  Operations which require a context
- * (FI_CONTEXT) or will generate a completion in a completion queue will consume
- * resources controlled by window size.
- *
- * argv[5]: Callback Order (char *): Test callback ordering refers to whether or
- * not the TX test callbacks or the RX test callbacks are executed before the
- * other.  This allows testing of expected vs. unexpected data transfers, but at
- * a not-insignificant runtime cost.  Possible values are:
- * "CALLBACK_ORDER_NONE", "CALLBACK_ORDER_EXPECTED", and
- * "CALLBACK_ORDER_UNEXPECTED".  No test callback ordering guarantees generally
- * means whatever is the most convenient execution order in terms of the pattern
- * generator, but can only safely be used with the FI_MSG and FI_TAGGED
- * interfaces.  Data transfers within the FI_RMA/FI_ATOMIC scope can only safely
- * be run with expected test callback ordering, or internal errors may be
- * generated and reported.
- *
- * argv[6-9]: Completion Object Sharing (%u):  Whether or not the TX counters,
- * RX counters, TX completion queue, and RX completion queue respectively should
- * be shared.  Counter or completion queue sharing is a concept that has no
- * bearing on the logic specific to any test implementations, but can have
- * significant impacts on the logic paths taken by the fabric provider, and is
- * thus provided as a configurable option.  A shared counter or completion queue
- * (1) will be shared by all endpoints in a domain, whereas an unshared counter
- * (0) will be bound to only a single endpoint.
- *
- * num_mpi_ranks: The number of MPI ranks in the job (i.e., the total number of
- * processes).
- *
- * our_mpi_rank: This process's MPI rank.
  */
 
 /* type signature of address exchange callback that harness passes to core */
-typedef int (address_exchange_t) (void *my_address, void *addresses, int size, int count);
+typedef int (address_exchange_t) (void *my_address,
+			void *addresses, int size, int count);
 
 /* synchronization barrier callback signature */
 typedef void (barrier_t) ();
+
+/*
+ * Core combines a test and pattern, and drives the callback routines in each.
+ *
+ * Core doesn't interact with MPI directly, rather it's passed some data about
+ *     the MPI environment and callback functions that invoke MPI functionality.
+ *
+ * Arguments:
+ *
+ *  argc,argv: command line arguments passed from main (in harness.c).  This
+ *     includes the pattern and test arguments, which are separated out by core.
+ *
+ *  num_mpi_ranks: number of ranks in MPI job.
+ *
+ *  our_mpi_rank: MPI rank of current process.
+ *
+ *  address_exchange: MPI allgather function used to share host addresses.
+ *
+ *  barrier: MPI barrier function.
+ */
 
 int core(
 		const int argc,

--- a/fabtests/hpcs/include/core/user.h
+++ b/fabtests/hpcs/include/core/user.h
@@ -52,6 +52,14 @@ typedef int (address_exchange_t) (void *my_address,
 /* synchronization barrier callback signature */
 typedef void (barrier_t) ();
 
+/* wrapper around MPI callbacks and job metadata */
+struct job {
+	address_exchange_t	*address_exchange;
+	barrier_t		*barrier;
+	size_t			rank;
+	size_t			ranks;
+};
+
 /*
  * Core combines a test and pattern, and drives the callback routines in each.
  *
@@ -72,13 +80,7 @@ typedef void (barrier_t) ();
  *  barrier: MPI barrier function.
  */
 
-int core(
-		const int argc,
-		char * const *argv,
-		const int num_mpi_ranks,
-		const int our_mpi_rank,
-		address_exchange_t address_exchange,
-		barrier_t barrier);
+int core(const int argc, char * const *argv, struct job *job);
 
 void hpcs_error(const char* format, ...);
 void hpcs_verbose(const char* format, ...);

--- a/fabtests/hpcs/include/core/user.h
+++ b/fabtests/hpcs/include/core/user.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "pattern/user.h"
+#include "test/user.h"
+
+
+/*
+ * -----------------------------------------------------------------------------
+ * CORE API
+ * -----------------------------------------------------------------------------
+ *
+ * Core combines a test and pattern, and drives the callback routines in each.
+ * Arguments are positional in argv.  The arguments are:
+ *
+ * argv[0]: Provider Name (%128s): The name of the provider to use for
+ * transport.  Corresponds to the OFI option "prov_name".
+ *
+ * argv[1]: Domains per Process (%zu): The number of OFI domains that should be
+ * created per process.
+ *
+ * argv[2]: Endpoints per Domain (%zu): The number of OFI endpoints to create
+ * per domain.
+ *
+ * argv[3]: Transfers per EP Pair (%zu): The number of transfers between each
+ * endpoint pair that should occur (i.e., repetitions).
+ *
+ * argv[4]: Window Size (%zu): Window size is directly related to the amount of
+ * memory each process is allowed to consume.  The exact consumption depends on
+ * the specific test implementation.  Operations which require a context
+ * (FI_CONTEXT) or will generate a completion in a completion queue will consume
+ * resources controlled by window size.
+ *
+ * argv[5]: Callback Order (char *): Test callback ordering refers to whether or
+ * not the TX test callbacks or the RX test callbacks are executed before the
+ * other.  This allows testing of expected vs. unexpected data transfers, but at
+ * a not-insignificant runtime cost.  Possible values are:
+ * "CALLBACK_ORDER_NONE", "CALLBACK_ORDER_EXPECTED", and
+ * "CALLBACK_ORDER_UNEXPECTED".  No test callback ordering guarantees generally
+ * means whatever is the most convenient execution order in terms of the pattern
+ * generator, but can only safely be used with the FI_MSG and FI_TAGGED
+ * interfaces.  Data transfers within the FI_RMA/FI_ATOMIC scope can only safely
+ * be run with expected test callback ordering, or internal errors may be
+ * generated and reported.
+ *
+ * argv[6-9]: Completion Object Sharing (%u):  Whether or not the TX counters,
+ * RX counters, TX completion queue, and RX completion queue respectively should
+ * be shared.  Counter or completion queue sharing is a concept that has no
+ * bearing on the logic specific to any test implementations, but can have
+ * significant impacts on the logic paths taken by the fabric provider, and is
+ * thus provided as a configurable option.  A shared counter or completion queue
+ * (1) will be shared by all endpoints in a domain, whereas an unshared counter
+ * (0) will be bound to only a single endpoint.
+ *
+ * num_mpi_ranks: The number of MPI ranks in the job (i.e., the total number of
+ * processes).
+ *
+ * our_mpi_rank: This process's MPI rank.
+ */
+
+/* type signature of address exchange callback that harness passes to core */
+typedef int (address_exchange_t) (void *my_address, void *addresses, int size, int count);
+
+/* synchronization barrier callback signature */
+typedef void (barrier_t) ();
+
+int core(
+		const int argc,
+		char * const *argv,
+		const int num_mpi_ranks,
+		const int our_mpi_rank,
+		address_exchange_t address_exchange,
+		barrier_t barrier);
+
+void hpcs_error(const char* format, ...);
+void hpcs_verbose(const char* format, ...);

--- a/fabtests/hpcs/include/pattern/user.h
+++ b/fabtests/hpcs/include/pattern/user.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <stdlib.h>
+
+
+/*
+ * -----------------------------------------------------------------------------
+ * TRAFFIC PATTERN API
+ * -----------------------------------------------------------------------------
+ *
+ * A pattern can be described as a connectivity matrix between TX and RX
+ * endpoints, with TX endpoints as rows and RX endpoints as columns.  Example:
+ *
+ *     EP0 EP1 EP2
+ * EP0  1   0   1
+ * EP1  0   1   0
+ * EP2  0   0   1
+ *
+ * The above pattern shows every endpoint sending to itself, with endpoint 0
+ * additionaly sending to endpoint 2.
+ */
+
+#define PATTERN_API_VERSION_MAJOR 0
+#define PATTERN_API_VERSION_MINOR 0
+
+/* Initial value for iterator position. */
+#define PATTERN_NO_CURRENT (-1)
+
+/*
+ * USER ARGUMENTS
+ *
+ * Each pattern is allowed to take arbitrary user arguments that it defines.
+ * The caller does not do anything with these arguments other than store a
+ * pointer to an implementation-defined region of memory that each pattern
+ * privately knows how to interpret.  This pointer is provided in every
+ * callback, allowing each pattern to change its behavior depending on any
+ * user-provided arguments.
+ *
+ * The arguments are provided to a pattern in the standard C style of command
+ * line arguments, although they may not have necessarily come from a command
+ * line. The caller will provide each pattern an opportunity to parse and
+ * internally store these arguments prior to calling any other callbacks.
+ *
+ * Each pattern is responsible for allocating and freeing the memory it needs to
+ * store the parsed version of its arguments.  The caller will call
+ * pattern_free_arguments when the pattern is done being used (when no more
+ * callbacks will be called).
+ *
+ * argc and argv: user arguments specific to this pattern, after parsing will be
+ * passed as "arguments" to each callback.
+ *
+ * arguments: the parsed version of the arguments.
+ */
+
+struct pattern_arguments;
+
+typedef int(*pattern_parse_arguments)(
+		const int argc,
+		char * const *argv,
+		struct pattern_arguments **arguments);
+
+typedef void (*pattern_free_arguments)(
+		struct pattern_arguments *arguments);
+
+
+/*
+ * TRAFFIC PATTERN GENERATION
+ *
+ * All calculations required for using a pattern happen on-demand, as buffering
+ * the pattern would not scale for large numbers of endpoints.
+ *
+ * Due to limitations of the C programming language, patterns are generated
+ * rather than specified.  The caller provides a TX and RX index pair, and the
+ * pattern generator returns the next TX and RX index pair as outputs.
+ *
+ * There are two kinds of pattern generators that may be implemented: TX (row)
+ * major, and RX (column) major.  A pattern implementation must have at least
+ * one of them implemented, and implementing both may provide efficiency
+ * benefits.
+ *
+ * The caller may wish to get the first valid index pair in some range.  This
+ * can be done by passing in the index pair immediately before the start of the
+ * range of interest.  For example, if the caller is interested in TX = [6] and
+ * RX = [10-20], the caller may invoke the TX major pattern generator with TX =
+ * 6 and RX = 9.  If the caller is interested in TX = [3-4] and RX = [0], they
+ * may invoke the TX major pattern generator with TX = 2 and RX = <rx_count> -
+ * 1.  Generators will automatically wrap around at the end of the row or
+ * column, but may overshoot the submatrix of interest, so callers must be
+ * careful to detect if the generator has traversed outside the bounds of
+ * interest.
+ *
+ * arguments: the parsed version of the arguments.
+ *
+ * size: the number of endpoints in the job (size of the square pattern matrix).
+ *
+ * current: the pair from which to search for the next valid pair.
+ *
+ * next: the next valid pair found in the pattern.
+ */
+
+typedef int (*pattern_next_sender)(
+		const struct pattern_arguments *arguments,
+		int my_rank,
+		int num_ranks,
+		int *cur_sender);
+
+typedef int (*pattern_next_receiver) (
+		const struct pattern_arguments *arguments,
+		int my_rank,
+		int num_ranks,
+		int *cur_receiver);
+
+/*
+ * CALLER INTERFACE
+ *
+ * The caller receives the callbacks as function pointers in the struct
+ * pattern_api.  The caller will call the pattern_api function, which must be
+ * defined by the pattern as a global symbol.  A declaration of it is provided
+ * here that the pattern must define.  The pattern may set either tx_major or
+ * rx_major to NULL if it only has an implementation for one of them.
+ */
+
+struct pattern_api {
+	pattern_parse_arguments parse_arguments;
+	pattern_free_arguments free_arguments;
+
+	pattern_next_sender next_sender;
+	pattern_next_receiver next_receiver;
+};
+
+
+/* List of patterns defined in source files under pattern directory. */
+
+struct pattern_api a2a_pattern_api(void);
+struct pattern_api self_pattern_api(void);
+struct pattern_api alltoone_pattern_api(void);

--- a/fabtests/hpcs/include/pattern/user.h
+++ b/fabtests/hpcs/include/pattern/user.h
@@ -33,7 +33,8 @@
 #pragma once
 
 #include <stdlib.h>
-
+#include <stdbool.h>
+#include <errno.h>
 
 /*
  * -----------------------------------------------------------------------------
@@ -128,19 +129,25 @@ typedef void (*pattern_free_arguments)(
  * current: the pair from which to search for the next valid pair.
  *
  * next: the next valid pair found in the pattern.
+ *
+ * threshold: triggered op threshold (we don't need to trigger receives, but
+ *	patterns may nevertheless need to use the threshold as an internal
+ *	counter).
  */
 
 typedef int (*pattern_next_sender)(
 		const struct pattern_arguments *arguments,
 		int my_rank,
 		int num_ranks,
-		int *cur_sender);
+		int *cur_sender,
+		int *threshold);
 
 typedef int (*pattern_next_receiver) (
 		const struct pattern_arguments *arguments,
 		int my_rank,
 		int num_ranks,
-		int *cur_receiver);
+		int *cur_receiver,
+		int *threshold);
 
 /*
  * CALLER INTERFACE
@@ -155,9 +162,9 @@ typedef int (*pattern_next_receiver) (
 struct pattern_api {
 	pattern_parse_arguments parse_arguments;
 	pattern_free_arguments free_arguments;
-
 	pattern_next_sender next_sender;
 	pattern_next_receiver next_receiver;
+	bool enable_triggered;
 };
 
 
@@ -166,3 +173,4 @@ struct pattern_api {
 struct pattern_api a2a_pattern_api(void);
 struct pattern_api self_pattern_api(void);
 struct pattern_api alltoone_pattern_api(void);
+struct pattern_api ring_pattern_api(void);

--- a/fabtests/hpcs/include/test/user.h
+++ b/fabtests/hpcs/include/test/user.h
@@ -1,0 +1,492 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#pragma once
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include <rdma/fabric.h>
+
+
+/*
+ * -----------------------------------------------------------------------------
+ * TEST API
+ * -----------------------------------------------------------------------------
+ *
+ * The test callbacks define test code to be run a certain number of times and
+ * with certain ordering guarantees.  These details are described in the
+ * documentation comments for each callback.  A test is therefore written by
+ * providing implementations of all the callbacks described here.  The ordering
+ * guarantees ensure that test code can be written in a way to avoid deadlock
+ * while placing as few constraints on the ordering and completion of callbacks
+ * as possible, which allows for callbacks to be executed in a multithreaded
+ * way. Users should structure their test callback code with the ordering
+ * guarantees in mind to avoid unexpected behavior and deadlocks.
+ *
+ * A test implementation also defines a configuration that is processed by the
+ * caller.  For example, how to size and align buffers.
+ */
+
+#define TEST_API_VERSION_MAJOR 0
+#define TEST_API_VERSION_MINOR 0
+
+/*
+ * USER ARGUMENTS
+ *
+ * Each test is allowed to take arbitrary user arguments that it defines.  The
+ * caller does not do anything with these arguments other than store a pointer
+ * to an implementation-defined region of memory that each test privately knows
+ * how to interpret.  This pointer is provided in every callback, allowing each
+ * test to change its behavior depending on any user-provided arguments.
+ *
+ * The arguments are provided to a test in the standard C style of command line
+ * arguments, although they may not have necessarily come from a command line.
+ * The caller will provide each test an opportunity to parse and internally
+ * store these arguments prior to calling any other callbacks.
+ *
+ * Each test is only responsible for allocating the memory it needs to store the
+ * parsed version of its arguments, and the caller will free this memory at the
+ * end of the test by calling test_free_arguments (when no more callbacks will
+ * be called).
+ *
+ * argc and argv: user arguments specific to this test, after parsing will be
+ * passed as "user_arguments" to each callback.
+ *
+ * arguments: the parsed version of the arguments.
+ *
+ * buffer_size: output variable to tell core the size of the per-operation
+ *		buffer it needs to allocate.
+ */
+
+struct test_arguments;
+
+typedef int (*test_parse_arguments)(
+	const int argc,
+	char * const *argv,
+	struct test_arguments **arguments,
+	size_t *buffer_size
+);
+
+typedef void (*test_free_arguments)(
+	struct test_arguments *arguments
+);
+
+
+/*
+ * CONFIGURATION
+ *
+ * Functions and data structures for describing and generating the test
+ * configuration.  This configuration is read by the caller to perform correct
+ * initialization and to provide the correct resources to each callback.
+ *
+ * Data object sharing refers to how to distribute unique data objects,
+ * depending on the test's requirements.  For tests which wish to really stress
+ * high volumes of concurrent send/recv with a very large workload, unique TX
+ * and RX data objects probably aren't needed for every unique transfer.  By
+ * contrast, for tests which want to do data validity checking, reusing RX data
+ * objects isn't feasible, so each transfer might have to have its own unique
+ * buffer. The same applies for fetching atomics and FI_READ operations, which
+ * may require unique TX data objects.
+ */
+
+enum data_object_sharing {
+	DATA_OBJECT_PER_TRANSFER,
+	DATA_OBJECT_PER_EP_PAIR,
+	DATA_OBJECT_PER_ENDPOINT,
+	DATA_OBJECT_PER_DOMAIN
+};
+
+struct test_config {
+	uint64_t minimum_caps;
+
+	bool tx_use_cntr;
+	bool rx_use_cntr;
+	bool tx_use_cq;
+	bool rx_use_cq;
+
+	bool rx_use_mr;
+
+	size_t tx_buffer_size;
+	size_t rx_buffer_size;
+	size_t tx_buffer_alignment;
+	size_t rx_buffer_alignment;
+
+	enum data_object_sharing tx_data_object_sharing;
+	enum data_object_sharing rx_data_object_sharing;
+
+	/* number of fi_contexts to allocate for per-iteration state */
+	size_t tx_context_count;
+	size_t rx_context_count;
+
+	uint64_t mr_rx_flags;
+};
+
+typedef struct test_config (*test_config)(
+	const struct test_arguments *arguments
+);
+
+enum op_state {
+	DONE = 0,
+	PENDING
+};
+
+struct context_info {
+	struct fi_context	fi_context;
+	struct op_context	*op_context;
+};
+
+struct op_context {
+	struct context_info	*ctxinfo;
+	enum op_state		state;
+	uint8_t			*buf;
+	uint64_t		core_context;
+	uint64_t		test_context;
+	struct fid_mr		*tx_mr;
+	uint64_t		test_state; /* reserved for test internal accounting */
+};
+
+/*
+ * DATA OBJECT SETUP
+ *
+ * Setup any required data objects, including filling the buffers with initial
+ * data, creating memory regions, and associating buffers with the memory
+ * regions.  The memory backing these data objects is allocated and freed by the
+ * caller.
+ *
+ * If the test configuration specifies that a memory region should be used for
+ * RX, then in addition to test_rx_init_buffer, a corresponding
+ * test_rx_create_mr will also be called.  test_tx_create_mr will be called if
+ * the provider sets the FI_MR_LOCAL mode bit.
+ *
+ * arguments: the parsed version of the arguments.
+ *
+ * buffer: the buffer to initialize (and associate with a memory region).
+ *
+ * key: the key with which to create the memory region (decided automatically by
+ * the caller).
+ *
+ * buffer: the buffer to initialize and possibly associate with a memory region
+ * (allocated automatically by the caller).
+ */
+
+typedef void (*test_tx_init_buffer)(
+	const struct test_arguments *arguments,
+	uint8_t *buffer
+);
+
+typedef void (*test_rx_init_buffer)(
+	const struct test_arguments *arguments,
+	uint8_t *buffer
+);
+
+typedef struct fid_mr *(*test_tx_create_mr)(
+	const struct test_arguments *arguments,
+	struct fid_domain *domain,
+	const uint64_t key,
+	uint8_t *buffer,
+	size_t len,
+	uint64_t access
+);
+
+typedef struct fid_mr *(*test_rx_create_mr)(
+	const struct test_arguments *arguments,
+	struct fid_domain *domain,
+	const uint64_t key,
+	uint8_t *buffer,
+	size_t len,
+	uint64_t access
+);
+
+
+/*
+ * DATA TRANSFER WINDOW USAGE
+ *
+ * Returns a number corresponding to the amount of a window that a given
+ * transfer callback is expected to consume locally.  Effectively, this maps to
+ * the number of contexts and completion queue slots that will be consumed.
+ * Users who wish to use selective completion may return 0 here instead of 1,
+ * which will result in no context memory to be provided and an expectation that
+ * no completion queue slots will be used.  The result of these are used to
+ * determine the start and end of each transfer window.  Completion queue slot
+ * resource exhaustion can be achieved by causing more completions to actually
+ * generate than what are reported by these calls, which would require
+ * requesting a context size sufficient for multiple contexts per transfer.
+ *
+ * arguments: the parsed version of the arguments.
+ *
+ * transfer_id: uniquely identifies the transfer between a pair of endpoints,
+ * useful for creating triggered chains and using as messaging tags.
+ *
+ * transfer_count: the total number of transfers that will occur between a pair
+ * of endpoints.
+ */
+
+typedef size_t (*test_tx_window_usage)(
+	const struct test_arguments *arguments,
+	const size_t transfer_id,
+	const size_t transfer_count
+);
+
+typedef size_t (*test_rx_window_usage)(
+	const struct test_arguments *arguments,
+	const size_t transfer_id,
+	const size_t transfer_count
+);
+
+
+/*
+ * DATA TRANSFER
+ *
+ * Execute a single unit of the TX or RX functionality under test.  If the test
+ * is being run with unexpected messaging, then each TX call is guaranteed to
+ * finish before the corresponding RX call starts, and vice-versa for running
+ * with expected messaging.  The expected completion use case is that each call
+ * will cause a single completion to be generated for each kind of completion
+ * object that exists.  Users who wish to do multiple operations or multiple
+ * transfers as a single "unit" should map these to individual transfer
+ * callbacks and make use of the provided transfer_id to differentiate between
+ * them.
+ *
+ * arguments: the parsed version of the arguments.
+ *
+ * transfer_id: uniquely identifies the transfer between a pair of endpoints,
+ * useful for creating triggered chains and using as messaging tags.
+ *
+ * transfer_count: the total number of transfers that will occur between a pair
+ * of endpoints.
+ *
+ * rx_address: the fabric address of the RX endpoint.
+ *
+ * endpoint: the local endpoint from which to initiate or receive the transfer.
+ *
+ * context: context requested for the operation, will be set to NULL if no
+ * contexts were requested.
+ *
+ * buffer: the buffer from which to send or into which data will be received.
+ *
+ * desc: the memory descriptor associated with the data buffer.
+ *
+ * rank: sender's rank (used to compute offset in one-sided communication).
+ *
+ * offset: memory write offset, if needed.
+ *
+ * tx_cntr: the local endpoint's TX counter, provided for setting
+ * up triggered chains.
+ *
+ * rx_cntr: the local endpoint's RX counter, provided for setting up
+ * triggered chains.
+ */
+
+typedef int (*test_tx_transfer)(
+	const struct test_arguments *arguments,
+	const size_t transfer_id,
+	const size_t transfer_count,
+	const fi_addr_t rx_address,
+	struct fid_ep *endpoint,
+	struct op_context *op_context,
+	uint8_t *buffer,
+	void *desc,
+	uint64_t key,
+	int rank,
+	struct fid_cntr *tx_cntr,
+	struct fid_cntr *rx_cntr
+);
+
+typedef int (*test_rx_transfer)(
+	const struct test_arguments *arguments,
+	const size_t transfer_id,
+	const size_t transfer_count,
+	const fi_addr_t tx_address,
+	struct fid_ep *endpoint,
+	struct op_context *op_context,
+	uint8_t *buffer,
+	void *desc,
+	struct fid_cntr *tx_cntr,
+	struct fid_cntr *rx_cntr
+);
+
+
+/*
+ * DATA TRANSFER COMPLETION
+ *
+ * Called after every transfer window to process completions generated during
+ * that window.  The frequency at which these are called are determined by
+ * options which affect the window size.  Called once per completion object.
+ *
+ * arguments: the parsed version of the arguments.
+ *
+ * completion_count: the number of completions that occurred during the last
+ * transfer window.
+ *
+ * cntr: the TX or RX counter from which to consume counting completions.
+ *
+ * cq: the TX or RX completion queue from which to consume completion events.
+ */
+
+typedef int (*test_tx_cntr_completion)(
+	const struct test_arguments *arguments,
+	const size_t completion_count,
+	struct fid_cntr *cntr
+);
+
+typedef int (*test_rx_cntr_completion)(
+	const struct test_arguments *arguments,
+	const size_t completion_count,
+	struct fid_cntr *cntr
+);
+
+typedef int (*test_tx_cq_completion)(
+	const struct test_arguments *arguments,
+	struct op_context **op_context,
+	struct fid_cq *cq
+);
+
+typedef int (*test_rx_cq_completion)(
+	const struct test_arguments *arguments,
+	struct op_context **op_context,
+	struct fid_cq *cq
+);
+
+
+/*
+ * DATA OBJECT PROCESSING
+ *
+ * Called once per data object on each process after all data transfers have
+ * completed.  Performs RX data validity checking, and TX data validity checking
+ * in the case of a fetching atomic or an RMA read.
+ *
+ * arguments: the parsed version of the arguments.
+ *
+ * transfer_count: the total number of transfers that occurred between each pair
+ * of endpoints.
+ *
+ * buffer: the buffer into which data was received or from which data was sent.
+ *
+ * rx_peers: number of peers we're receiving from in this pattern (useful for
+ * validating atomic add).
+ */
+
+typedef int (*test_tx_datacheck)(
+	const struct test_arguments *arguments,
+	const uint8_t *buffer
+);
+
+typedef int (*test_rx_datacheck)(
+	const struct test_arguments *arguments,
+	const uint8_t *buffer,
+	size_t rx_peers
+);
+
+
+/*
+ * DATA OBJECT TEARDOWN
+ *
+ * Undo any setup done during the setup_buffer or setup_mr calls.  These are
+ * called after the data object in question is done being used by the data
+ * transfer calls.  The memory backing the data objects will be freed
+ * automatically.
+ *
+ * arguments: the parsed version of the arguments.
+ *
+ * buffer: pointer to the memory backing the buffer or memory region to
+ * finialize.
+ *
+ * mr: the memory region to destroy.
+ */
+
+typedef int (*test_tx_fini_buffer)(
+	const struct test_arguments *arguments,
+	uint8_t *buffer
+);
+
+typedef int (*test_rx_fini_buffer)(
+	const struct test_arguments *arguments,
+	uint8_t *buffer
+);
+
+typedef int (*test_tx_destroy_mr)(
+	const struct test_arguments *arguments,
+	struct fid_mr *mr
+);
+
+typedef int (*test_rx_destroy_mr)(
+	const struct test_arguments *arguments,
+	struct fid_mr *mr
+);
+
+
+/*
+ * CALLER INTERFACE
+ *
+ * The caller receives the callbacks as function pointers in the struct
+ * test_api.  The caller will call the test_api function, which must be defined
+ * by the test as a global symbol.  A declaration of it is provided here that
+ * the test must define.  If a test's configuration is such that certain
+ * callbacks will not be called, then setting those fields to a NULL pointer is
+ * acceptable.
+ */
+
+struct test_api {
+
+	test_parse_arguments parse_arguments;
+	test_free_arguments free_arguments;
+
+	test_config config;
+
+	test_tx_init_buffer tx_init_buffer;
+	test_rx_init_buffer rx_init_buffer;
+	test_tx_create_mr tx_create_mr;
+	test_rx_create_mr rx_create_mr;
+
+	test_tx_window_usage tx_window_usage;
+	test_rx_window_usage rx_window_usage;
+
+	test_tx_transfer tx_transfer;
+	test_rx_transfer rx_transfer;
+
+	test_tx_cntr_completion tx_cntr_completion;
+	test_rx_cntr_completion rx_cntr_completion;
+	test_tx_cq_completion tx_cq_completion;
+	test_rx_cq_completion rx_cq_completion;
+
+	test_tx_datacheck tx_datacheck;
+	test_rx_datacheck rx_datacheck;
+
+	test_tx_fini_buffer tx_fini_buffer;
+	test_rx_fini_buffer rx_fini_buffer;
+	test_tx_destroy_mr tx_destroy_mr;
+	test_rx_destroy_mr rx_destroy_mr;
+};
+
+struct test_api test_api (void);

--- a/fabtests/hpcs/man/hpcs.1.md
+++ b/fabtests/hpcs/man/hpcs.1.md
@@ -1,0 +1,138 @@
+---
+layout:page
+title: hpcs(1)
+tagline: High-Performance Connection Scaling test framework
+---
+{% include JB/setup %}
+
+# NAME
+
+hpcs-sendrecv
+hpcs-onesided
+
+# SYNOPSIS
+```
+	hpcs-sendrecv [CORE OPTIONS] -- [PATTERN OPTIONS] -- [TEST OPTIONS]
+	hpcs-onesided [CORE OPTIONS] -- [PATTERN OPTIONS] -- [TEST OPTIONS]
+```
+
+# DESCRIPTION
+
+HPCS is an OFI-level test framework designed to generate network traffic between an arbitrary number of nodes, to enable large-scale testing at the OFI layer.
+
+MPI is often used for multi-node tests, but failures tend to be opaque and those tests only stress whatever portion of OFI that particular MPI uses.  HPCS allows us to do similar scale-out tests, but with libfabric communication primitives.
+
+HPCS uses MPI for some basic out-of-band startup and communication barriers.  We recommend against using an OFI-enabled MPI in most cases, to ensure that HPCS test runs are only testing those parts of OFI invoked by HPCS directly.
+
+An HPCS application is composed of a core module, a pattern, and a test, which each accept certain arguments.
+
+The HPCS core is the base framework.  It handles initialization and drives callbacks from the other two components.
+
+A pattern defines which nodes send or receive from which other nodes.  Patterns are selected with a command line argument passed to core. The currently available patterns are "self", "alltoall", "alltoone", and "ring".
+
+A test defines the low-level OFI primitives that a sending node will use to initiate traffic and the receiving node will use to receive, along with how data validity is checked and how OFI resources are allocated and released.  Only one test may be compiled in at once and therefore we provide separate binaries for each test (currently "sendrecv" and "onesided").
+
+HPCS determines number of ranks and local rank number directly from MPI.
+
+## CORE OPTIONS
+
+*-p, --prov=\<provider\>*
+: Specify provider.
+
+*-w, --window=\<window\>*
+: Control how many parallel operations can be outstanding at a time.
+
+*-o, --order=[expected|unexpected|none]*
+: Impose ordering between sends and receives.  (Both expected and unexpected use MPI barriers to ensure ordering.)
+
+*-i, --iterations=\<n\>*
+: Run the same test/pattern multiple times.
+
+*-p, --pattern=[self|alltoall|alltoone|ring]*
+: Select pattern.
+
+*-v, --verbose*
+
+*-h, --help*
+
+## SELF, ALL-TO-ALL PATTERN OPTIONS
+
+The self and all-to-all patterns take no arguments.  As the names suggest, in a self pattern, each rank initiates a transfer with itself, and in all-to-all, every rank initiates a transfer with every other rank including itself.
+
+## ALL-TO-ONE PATTERN OPTIONS
+
+The all-to-one pattern initiates transfers from every rank to a single target rank.
+
+*-t, --target=\<rank\>*
+: Send to a particular target rank (default 0).
+
+*-h, --help*
+
+## RING PATTERN OPTIONS
+
+In a ring pattern, a leader sends a message to its immediate rank (N+1)%N peer, which sends to its next peer, and so on until the last peer sends a message back to the leader.  The ring pattern uses triggered ops.
+
+*-l, --leader=\<rank\>*
+: Set a particular rank as the leader node.  Setting leader to -1 results in no leader, which is expected to deadlock if triggered ops are working as expected.
+
+*-r, --rings=\<n\>*
+: Execute multiple rings concurrently.  Leaders are chosen sequentially.  The number of rings cannot exceed the number of ranks in the job.
+
+*-m, --multi-ring*
+: Each rank is the leader of a single ring, and they all execute concurrently.
+
+*-v, --verbose*
+
+*-h, --help*
+
+## SEND-RECV TEST OPTIONS
+
+The send-recv test uses plain tagged message sends and receives.
+
+*-s, --size=\<n\>*
+: Message length.
+
+*-w, --workqueue*
+: Use new triggered ops experimental workqueue API rather than the stable API.  This only matters for patterns that use triggered ops, such as ring.
+
+*-h, --help*
+
+## ONE-SIDED TEST OPTIONS
+
+The onesided test may use RMA reads, writes, or atomics, though read support may be deprecated, as it relies on using counters in a way that is no longer officially supported.  (Well behaved providers should simply refuse the relevant counter binding, in which case the test prints a message that the test was skipped and HPCS returns 0.)
+
+Onesided tests should be run with "expected" ordering.
+
+*-s, --size=\<n\>*
+: Message length.
+
+*-m, --offset-mode=[same-offset|different-offset]*
+: Control whether all peers write into the same buffer at the same offset, or at different offsets.  Usually, the latter is preferred for RMA writes but the former can be useful for testing atomics.  (Warning: different-offset doesn't currently work properly with all-to-one and ring patterns.)
+
+*-o, --op=[read|write|add]*
+: Set what operation is being tested.  The add test performs an atomic increment on the target buffer.
+
+*-r, --repeat=\<n\>*
+: Perform the given operation multiple times.  This is expected to perform better in most cases than increasing  the "--iterations" core argument, as the onesided test does not begin a later iteration until completions from the previous iteration are done whereas repeated operations will be sent eagerly, and HPCS will wait for the whole batch to complete at once.  RMA writes just overwrite the same buffer with the same content multiple times, so atomic adds are preferred if one wants to ensure that the right number of operations completed on the target.
+
+*-w, --workqueue*
+: Use new triggered ops experimental workqueue API rather than the stable API.  This only matters for patterns
+ that use triggered ops, such as ring.
+
+*-h, --help*
+
+# EXAMPLES
+
+```
+	$ mpiexec.hydra -n 2 hpcs_sendrecv --order=unexpected --pattern=alltoall -- -- --size=4
+```
+
+Run a basic send/recv unexpected tagged message test between two nodes using Hydra as the MPI launcher.  Both ranks send a single message of four bytes to themselves and the other.
+
+```
+	$ mpiexec.hydra -n 3 hpcs_onesided --order=expected --pattern=alltoone -- --target=2 -- --offset-mode=same-offset --op=add --repeat=20
+```
+
+Run an atomics test, sending twenty atomic increments each from all three ranks to rank 2.  The same buffer/offset is used on the target, so it should be incremented sixty times.
+
+

--- a/fabtests/hpcs/src/core/core.c
+++ b/fabtests/hpcs/src/core/core.c
@@ -1,0 +1,1344 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHWARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. const NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER const AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS const THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <limits.h>
+#include <stdarg.h>
+
+#include <rdma/fi_errno.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+
+#include <core/user.h>
+#include <pattern/user.h>
+#include <test/user.h>
+
+/* size of buffer to store fi_getname() result */
+#define NAMELEN 256
+
+/* buffer size for storing hostnames */
+#define HOSTLEN 256
+
+static int verbose = 0;
+
+/*
+ * Struct which tracks a single domain and the resources created within its
+ * scope, including endpoints, completion objects, and data objects.  The
+ * lengths of the object arrays depend on the window size or the sharing
+ * configuration requested for that kind of object.
+ */
+struct domain_state {
+	struct fid_domain *domain;
+	struct fid_ep *endpoint;
+
+	struct fid_av *av;
+
+	/* Will contain only one completion object if
+	 * COMPLETION_OBJECT_PER_DOMAIN const was specified. */
+	struct fid_cntr *tx_cntr;
+	struct fid_cntr *rx_cntr;
+	struct fid_cq *tx_cq;
+	struct fid_cq *rx_cq;
+
+	/* array indexed by rank */
+	fi_addr_t *addresses;
+};
+
+struct ofi_state {
+	struct fid_fabric *fabric;
+	struct domain_state *domain_state;
+};
+
+enum callback_order {
+	CALLBACK_ORDER_NONE,
+	CALLBACK_ORDER_EXPECTED,
+	CALLBACK_ORDER_UNEXPECTED
+};
+
+struct arguments {
+	char prov_name[128];
+	size_t window_size;
+	size_t buffer_size;
+	enum callback_order callback_order;
+	size_t iterations;
+
+	struct pattern_api pattern_api;
+	struct test_api test_api;
+
+	struct pattern_arguments *pattern_arguments;
+	struct test_arguments *test_arguments;
+};
+
+#define DEFAULT_WINDOW_SIZE 10
+#define DEFAULT_CALLBACK_ORDER CALLBACK_ORDER_NONE
+
+int init_ofi_cntrs(
+		const size_t num,
+		struct fid_domain *domain,
+		struct fid_cntr *cntrs[])
+{
+	int our_ret = FI_SUCCESS;
+	size_t i;
+	int ret;
+
+	struct fi_cntr_attr cntr_attr = {0};
+	cntr_attr.events = FI_CNTR_EVENTS_COMP;
+	cntr_attr.wait_obj = FI_WAIT_UNSPEC;
+
+	for (i = 0; i < num; i += 1) {
+		ret = fi_cntr_open(domain, &cntr_attr, cntrs + i, NULL);
+		if (ret) {
+			our_ret = ret;
+			goto err_cntr_open;
+		}
+	}
+
+err_cntr_open:
+
+	return our_ret;
+}
+
+int init_ofi_cqs(
+		const size_t num,
+		const size_t cq_size,
+		struct fid_domain *domain,
+		struct fid_cq **cqs)
+{
+	int our_ret = FI_SUCCESS;
+	size_t i;
+	int ret;
+
+	struct fi_cq_attr cq_attr = {0};
+	cq_attr.size = cq_size;
+	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cq_attr.wait_obj = FI_WAIT_UNSPEC;
+
+	for (i = 0; i < num; i += 1) {
+		ret = fi_cq_open(domain, &cq_attr, cqs + i, NULL);
+		if (ret) {
+			our_ret = ret;
+			goto err_cq_open;
+		}
+	}
+
+err_cq_open:
+
+	return our_ret;
+}
+
+int init_ofi_completion(
+		const struct arguments *arguments,
+		const struct test_config *test_config,
+		struct domain_state *domain_state,
+		size_t cq_size)
+{
+	int ret;
+
+	if (test_config->tx_use_cntr) {
+		ret = init_ofi_cntrs(
+				1,
+				domain_state->domain,
+				&domain_state->tx_cntr);
+		if (ret) {
+			hpcs_error("error initializing tx counters, ret=%d\n", ret);
+			goto err_init_tx_cntrs;
+		}
+	}
+
+	if (test_config->rx_use_cntr) {
+		ret = init_ofi_cntrs(
+				1,
+				domain_state->domain,
+				&domain_state->rx_cntr);
+		if (ret) {
+			hpcs_error("error initializing rx counters, ret=%d\n", ret);
+			goto err_init_rx_cntrs;
+		}
+	}
+
+	ret = init_ofi_cqs(
+			1,
+			cq_size,
+			domain_state->domain,
+			&domain_state->tx_cq);
+	if (ret) {
+		hpcs_error("initializing ofi tx cq failed\n");
+		goto err_init_tx_cqs;
+	}
+
+	ret = init_ofi_cqs(
+			1,
+			arguments->window_size,
+			domain_state->domain,
+			&domain_state->rx_cq);
+	if (ret) {
+		hpcs_error("initializing ofi rx cq failed\n");
+		goto err_init_rx_cqs;
+	}
+
+err_init_rx_cqs:
+err_init_tx_cqs:
+err_init_rx_cntrs:
+err_init_tx_cntrs:
+
+	return ret;
+}
+
+
+/*
+ * Binds a domain's completion objects to an endpoint.  Does not have a
+ * corresponding unbind function, since completion objects are implicitly
+ * unbound when they are freed.
+ */
+int bind_ofi_endpoint_completion(struct domain_state *domain_state)
+{
+	int ret;
+
+	if (domain_state->tx_cq) {
+		/* If we have a tx counter, suppress cq completions by default. */
+		uint64_t flags =
+				domain_state->tx_cntr == NULL
+					? FI_TRANSMIT
+					: FI_TRANSMIT | FI_SELECTIVE_COMPLETION;
+
+		ret = fi_ep_bind(domain_state->endpoint, &domain_state->tx_cq->fid, flags);
+		if (ret) {
+			hpcs_error("binding tx cq to ep failed\n");
+			goto err;
+		}
+	}
+
+	if (domain_state->rx_cq) {
+		ret = fi_ep_bind(domain_state->endpoint, &domain_state->rx_cq->fid, FI_RECV);
+		if (ret) {
+			hpcs_error("binding rx cq to ep failed\n");
+			goto err;
+		}
+	}
+
+	if (domain_state->tx_cntr) {
+		ret = fi_ep_bind(domain_state->endpoint, &domain_state->tx_cntr->fid, FI_TRANSMIT);
+		if (ret) {
+			hpcs_error("binding tx counter to ep failed\n");
+			goto err;
+		}
+	}
+err:
+	return ret;
+}
+
+
+int init_ofi_endpoint(
+		struct fi_info *info,
+		struct domain_state *domain_state,
+		struct fid_ep **endpoint)
+{
+	int ret;
+
+	ret = fi_endpoint(domain_state->domain, info, endpoint, NULL);
+	if (ret) {
+		hpcs_error("fi_endpoint failed\n");
+		return ret;
+	}
+
+	return 0;
+}
+
+int init_ofi_domain(
+		const struct arguments *arguments,
+		const struct test_config *test_config,
+		struct fid_fabric *fabric,
+		struct fi_info *info,
+		struct domain_state *domain_state,
+		address_exchange_t address_exchange,
+		int num_mpi_ranks,
+		int our_mpi_rank)
+{
+	int ret;
+	int i;
+	uint8_t *names = NULL;
+	uint8_t our_name[NAMELEN];
+	void *context = NULL;
+	size_t len = NAMELEN;
+
+	size_t cq_size = arguments->window_size * num_mpi_ranks *
+			(test_config->tx_context_count + test_config->rx_context_count);
+
+	struct fi_av_attr av_attr = (struct fi_av_attr) {
+		.type = FI_AV_MAP,
+		.count = num_mpi_ranks,
+		.name = NULL
+	};
+
+	ret = fi_domain(fabric, info, &domain_state->domain, context);
+	if (ret) {
+		hpcs_error("fi_domain failed\n");
+		goto err;
+	}
+
+	ret = init_ofi_endpoint(
+		info,
+		domain_state,
+		&domain_state->endpoint
+	);
+	if (ret) {
+		hpcs_error( "init_ofi_endpoint failed\n");
+		goto err;
+	}
+
+	ret = init_ofi_completion(arguments, test_config, domain_state, cq_size);
+	if (ret) {
+		hpcs_error("init_ofi_completion failed\n");
+		goto err;
+	}
+
+	ret = bind_ofi_endpoint_completion(domain_state);
+	if (ret) {
+		hpcs_error("bind_ofi_endpoint_completion failed\n");
+		goto err;
+	}
+
+	ret = fi_av_open(domain_state->domain, &av_attr, &domain_state->av, NULL);
+	if (ret) {
+		hpcs_error("unable to open address vector\n");
+		goto err;
+	}
+
+	ret = fi_ep_bind(domain_state->endpoint, &domain_state->av->fid, 0);
+
+	ret = fi_enable(domain_state->endpoint);
+	if (ret) {
+		hpcs_error("error enabling endpoint\n");
+		goto err;
+	}
+
+	ret = fi_getname(&domain_state->endpoint->fid, &our_name, &len);
+
+	if (ret) {
+		hpcs_error("error determining local endpoint name\n");
+		goto err;
+	}
+
+	names = malloc(len * num_mpi_ranks);
+	if (names == NULL) {
+		hpcs_error("error allocating memory for address exchange\n");
+		ret = -1;
+		goto err;
+	}
+
+	ret = address_exchange(&our_name, names, len, num_mpi_ranks);
+	if (ret) {
+		hpcs_error("error exchanging addresses\n");
+		goto err;
+	}
+
+	ret = fi_av_insert(domain_state->av,
+			   names,
+			   num_mpi_ranks,
+			   domain_state->addresses,
+			   0,
+			   NULL);
+	if (ret != num_mpi_ranks) {
+		hpcs_error("unable to insert all addresses into AV table\n");
+		ret = -1;
+		goto err;
+	}
+	else {
+		ret = 0;
+	}
+
+	if(verbose){
+		hpcs_verbose("Rank %d peer addresses: ", our_mpi_rank);
+		for (i=0; i<num_mpi_ranks; i++) {
+			printf("%d:%lx ", i, (uint64_t)(domain_state->addresses[i]));
+		}
+		printf("\n");
+	}
+
+
+err:
+	free (names);
+	return ret;
+}
+
+/* Initializes OFI.  Calls fi_allocinfo, fi_getinfo, fi_fabric.  Local resources
+ * will be cleaned up on finish / error, returned resources must be cleaned up
+ * by calling fini_ofi. */
+
+int init_ofi(
+		const struct arguments *arguments,
+		const void *test_arguments,
+		const struct test_config *test_config,
+		struct ofi_state *ofi_state,
+		address_exchange_t address_exchange,
+		int num_mpi_ranks,
+		int our_mpi_rank)
+{
+	int our_ret = FI_SUCCESS;
+	int ret;
+
+	struct fi_info *hints;
+	struct fi_info *info;
+
+	hints = fi_allocinfo();
+	if (!hints) {
+		our_ret = -FI_ENOMEM;
+		goto err_allocinfo;
+	}
+
+	hints->fabric_attr->prov_name = strdup(arguments->prov_name);
+	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
+	hints->domain_attr->mr_mode = FI_MR_RMA_EVENT;
+	hints->domain_attr->mr_key_size = 4;
+	hints->caps = test_config->minimum_caps;
+	hints->mode = FI_CONTEXT;
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->tx_attr->op_flags = FI_DELIVERY_COMPLETE;
+
+	const char *node = NULL;
+	const char *service = "2042";
+	const uint64_t flags = 0;
+
+	ret = fi_getinfo(
+			fi_version (),
+			node,
+			service,
+			flags,
+			hints,
+			&info);
+	if (ret) {
+		our_ret = ret;
+		goto err_getinfo;
+	}
+
+	void *context = NULL;
+	ret = fi_fabric(
+			info->fabric_attr,
+			&ofi_state->fabric,
+			context);
+	if (ret) {
+		hpcs_error("fi_fabric failed\n");
+		our_ret = ret;
+		goto err_fabric;
+	}
+
+	fi_addr_t* domain_state_addr = ofi_state->domain_state->addresses;
+
+	*ofi_state->domain_state = (struct domain_state) {0};
+
+	ofi_state->domain_state->addresses = domain_state_addr;
+
+	ret = init_ofi_domain(
+			arguments,
+			test_config,
+			ofi_state->fabric,
+			info,
+			ofi_state->domain_state,
+			address_exchange,
+			num_mpi_ranks,
+			our_mpi_rank);
+	if (ret) {
+		hpcs_error("init_ofi_domain failed\n");
+		our_ret = ret;
+		goto err_init_domains;
+	}
+	else {
+		hpcs_verbose("init_ofi_domain complete, Using %s provider\n",
+			     info->fabric_attr->name);
+		goto err_allocinfo;
+	}
+
+err_init_domains:
+err_fabric:
+
+	fi_freeinfo(info);
+err_getinfo:
+
+	fi_freeinfo(hints);
+err_allocinfo:
+
+	return our_ret;
+}
+
+int fini_ofi_completion(struct domain_state *domain_state)
+{
+	int ret;
+
+	if (domain_state->tx_cntr != NULL) {
+		ret = fi_close(&domain_state->tx_cntr->fid);
+		if (ret) {
+			hpcs_error("unable to close tx counter\n");
+			return -1;
+		}
+		domain_state->tx_cntr = NULL;
+	}
+
+	if (domain_state->rx_cntr != NULL) {
+		ret = fi_close(&domain_state->rx_cntr->fid);
+		if (ret) {
+			hpcs_error("unable to close rx counter\n");
+			return -1;
+		}
+		domain_state->rx_cntr = NULL;
+	}
+
+	if (domain_state->tx_cq != NULL) {
+		ret = fi_close(&domain_state->tx_cq->fid);
+		if (ret) {
+			hpcs_error("unable to close tx cq\n");
+			return -1;
+		}
+		domain_state->tx_cq = NULL;
+	}
+
+	if (domain_state->rx_cq != NULL) {
+		ret = fi_close(&domain_state->rx_cq->fid);
+		if (ret) {
+			hpcs_error("unable to close rx cq\n");
+			return -1;
+		}
+		domain_state->rx_cq = NULL;
+	}
+
+	return ret;
+}
+
+int fini_ofi_domain(struct domain_state *domain_state)
+{
+	int ret = 0;
+
+	ret = fi_close(&domain_state->endpoint->fid);
+	if (ret) {
+		hpcs_error("unable to close endpoint\n");
+		return ret;
+	}
+	domain_state->endpoint = NULL;
+
+	ret = fi_close(&domain_state->av->fid);
+	if (ret) {
+		hpcs_error("unable to close address vector\n");
+		return ret;
+	}
+
+	ret = fini_ofi_completion(domain_state);
+	if (ret)
+		return ret;
+
+	ret = fi_close(&domain_state->domain->fid);
+	if (ret) {
+		hpcs_error("unable to close domain\n");
+		return ret;
+	}
+	domain_state->domain = NULL;
+
+	return 0;
+}
+
+/*
+ * Finalizes OFI.  Safely cleans up resources created by init_ofi.  Takes a
+ * "best effort" approach - goes as far as it can and returns the first error
+ * encountered.
+ */
+int fini_ofi(struct ofi_state *ofi_state)
+{
+	int ret;
+
+	ret = fini_ofi_domain(ofi_state->domain_state);
+	if (ret)
+		return ret;
+
+	ofi_state->domain_state = NULL;
+
+	ret = fi_close(&ofi_state->fabric->fid);
+	if (ret) {
+		hpcs_error("unable to close fabric\n");
+		return ret;
+	}
+
+	return 0;
+}
+
+/*
+ * HPCS uses groups of arguments separated by a "-" or "--" (which are treated
+ * as special by getopt, and cause it to stop parsing arguments).
+ *
+ * This function updates argc and argv to start at the next group of args,
+ * with argv[0] pointing to the separator.
+ */
+void next_args(int *argc, char * const**argv)
+{
+	int i;
+
+	/* 0th element is either binary name or previous separator. */
+	for (i=1; i<*argc; i++) {
+		if (strcmp((*argv)[i], "-") == 0 || strcmp((*argv)[i], "--") == 0)
+			break;
+	}
+
+	if (i < *argc) {
+		*argc = *argc - i;
+		*argv = &(*argv)[i];
+	} else {
+		*argc = 0;
+		*argv = NULL;
+	}
+
+	/* Current option index global variable must be reset. */
+	optind = 1;
+}
+
+static int parse_arguments(int argc, char * const* argv,
+		struct arguments **arguments)
+{
+	int longopt_idx, op, onesided = 0, ret = 0;
+	struct option longopt[] = {
+		{"prov", required_argument, 0, 'p'},
+		{"window", required_argument, 0, 'w'},
+		{"order", required_argument, 0, 'o'},
+		{"pattern", required_argument, 0, 'a'},
+		{"iterations", required_argument, 0, 'n'},
+		{"verbose", no_argument, &verbose, 1},
+		{"help", no_argument, 0, 'h'},
+		{0}
+	};
+
+	struct arguments *args = calloc(sizeof (struct arguments), 1);
+	int have_pattern = 0;
+
+	*args = (struct arguments) {
+		.prov_name = "",
+		.window_size = DEFAULT_WINDOW_SIZE,
+		.callback_order = DEFAULT_CALLBACK_ORDER,
+		.pattern_api = {0},
+		.iterations = 1
+	};
+
+	if (args == NULL)
+		return -ENOMEM;
+
+	if(strstr(argv[0], "onesided") != NULL)
+		onesided = 1;
+
+	while ((op = getopt_long(argc, argv, "vp:w:o:a:n:h", longopt, &longopt_idx)) != -1) {
+		switch (op) {
+		case 0:
+			if (longopt[longopt_idx].flag != 0)
+				printf("verbose mode enabled\n");
+			break;
+		case 'p':
+			if (sscanf(optarg, "%127s", args->prov_name) != 1)
+				return -EINVAL;
+			break;
+		case 'w':
+			if (sscanf(optarg, "%zu", &args->window_size) != 1)
+				return -EINVAL;
+			break;
+		case 'o':
+			if (strcmp(optarg, "none") == 0)
+				args->callback_order = CALLBACK_ORDER_NONE;
+			else if (strcmp(optarg, "expected") == 0)
+				args->callback_order = CALLBACK_ORDER_EXPECTED;
+			else if (strcmp(optarg, "unexpected") == 0)
+			{
+				if(onesided) {
+					hpcs_error("Unexpected is not supported"
+						   " in onesided test\n");
+					return -EINVAL;
+				}
+
+
+				args->callback_order = CALLBACK_ORDER_UNEXPECTED;
+			}
+			else
+				return -EINVAL;
+			break;
+		case 'a':
+			if ((!strcmp(optarg, "alltoall")) || (!strcmp(optarg, "a2a")))
+				args->pattern_api = a2a_pattern_api ();
+			else if (!strcmp(optarg, "self"))
+				args->pattern_api = self_pattern_api ();
+			else if (!strcmp(optarg, "alltoone"))
+				args->pattern_api = alltoone_pattern_api ();
+			else
+				return -EINVAL;
+			have_pattern = 1;
+			break;
+		case 'n':
+			if (sscanf(optarg, "%zu", &args->iterations) != 1)
+				return -EINVAL;
+			break;
+		case 'v':
+			verbose = 1;
+			break;
+		case 'h':
+		default:
+			hpcs_error("usage: %s [core-args] -- [pattern args] -- [test-args]\n", argv[0]);
+			hpcs_error("[core-args] := "
+				   "\t[-p | --prov=<provider name>]\n"
+				   "\t[-w | --window=<size>]\n"
+				   "\t[-o | --order=<expected|unexpected|none>]\n"
+				   "\t[-n | --iterations=<n>]\n"
+				   "\t -a | --pattern=<self|alltoall|alltoone>\n"
+				   "\t[-h | --help]\n");
+			return -1;
+		}
+	}
+
+	if (!have_pattern) {
+		hpcs_error("you must specify a pattern\n");
+		return -EINVAL;
+	}
+
+	args->test_api = test_api();
+
+	next_args(&argc, &argv);
+
+	ret = args->pattern_api.parse_arguments(argc, argv,
+			&args->pattern_arguments);
+
+	if (ret) {
+		hpcs_error("failed to parse pattern arguments\n");
+		return ret;
+	}
+
+	next_args(&argc, &argv);
+
+	ret = args->test_api.parse_arguments(argc, argv,
+			&args->test_arguments,
+                	&args->buffer_size);
+
+	*arguments = args;
+
+	if (ret) {
+		hpcs_error("failed to parse test arguments\n");
+		return ret;
+	}
+
+	return 0;
+}
+
+static void free_arguments (struct arguments *arguments)
+{
+	struct pattern_api _pattern_api = arguments->pattern_api;
+
+	struct test_api _test_api = test_api ();
+
+	_pattern_api.free_arguments (arguments->pattern_arguments);
+	_test_api.free_arguments (arguments->test_arguments);
+
+	free (arguments);
+}
+
+#define DATA_BUF(base, counter) ((base) + ((counter % window) * size))
+#define CONTEXT(base, counter) (&base[counter % window])
+
+static int core_inner (
+		struct domain_state *domain_state,
+		struct arguments *arguments,
+		struct pattern_api *pattern,
+		struct test_api *test,
+		struct test_config *test_config,
+		size_t rank,
+		size_t ranks,
+		address_exchange_t address_exchange,
+		barrier_t barrier)
+{
+	size_t i, j;
+	int ret;
+	size_t size = arguments->buffer_size;
+	size_t window = arguments->window_size;
+	size_t iterations = arguments->iterations;
+
+	struct op_context tx_context [window];
+	struct op_context rx_context [window];
+	uint8_t *tx_buf = calloc(window, size);
+	uint8_t *rx_buf = calloc(window, size);
+	uint64_t *keys = calloc(ranks, sizeof(uint64_t));
+
+	struct test_arguments *test_args = arguments->test_arguments;
+	struct pattern_arguments *pattern_args = arguments->pattern_arguments;
+
+	int tx_window = window, rx_window = window;
+	enum callback_order order = arguments->callback_order;
+
+	struct fid_mr *rx_mr = NULL;
+	int do_tx_reg = test_config->tx_use_cntr;
+
+	uint64_t recvs_posted = 0, sends_posted = 0;
+	uint64_t recvs_done = 0, sends_done = 0;
+
+	memset((char*)&tx_context[0], 0, sizeof(tx_context[0])*window);
+	memset((char*)&rx_context[0], 0, sizeof(rx_context[0])*window);
+
+	for (i = 0; i < window; i++) {
+		tx_context[i].ctxinfo =
+				calloc(test_config->tx_context_count*sizeof(struct context_info), 1);
+		rx_context[i].ctxinfo =
+				calloc(test_config->rx_context_count*sizeof(struct context_info), 1);
+
+		if (tx_context[i].ctxinfo == NULL || rx_context[i].ctxinfo == NULL)
+			return -FI_ENOMEM;
+
+		/* Populate backlinks. */
+		for (j = 0; j < test_config->tx_context_count; j++) {
+			tx_context[i].ctxinfo[j].op_context = &tx_context[i];
+		}
+
+		for (j = 0; j < test_config->rx_context_count; j++) {
+			rx_context[i].ctxinfo[j].op_context = &rx_context[i];
+		}
+
+	}
+
+	if (tx_buf == NULL || rx_buf == NULL || keys == NULL) {
+		hpcs_error("unable to allocate memory\n");
+		ret = -ENOMEM;
+		goto err_mem;
+	}
+
+	hpcs_verbose("Beginning test: buffer_size=%ld window=%ld iterations=%ld %s%s%s\n",
+			size, window, iterations,
+			order == CALLBACK_ORDER_UNEXPECTED ? "unexpected" : "",
+			order == CALLBACK_ORDER_EXPECTED ? "expected" : "",
+			order == CALLBACK_ORDER_NONE ? "undefined order" : "");
+
+	/*
+	 * One-sided tests create a single memory region, and then share
+	 * that key with peers (who may each write to some offset).
+	 */
+	if (test->rx_create_mr != NULL && test_config->rx_use_mr) {
+		uint64_t my_key;
+
+		if (window < ranks) {
+			hpcs_error("for one-sided communication, window must be >= number of ranks\n");
+			return (-EINVAL);
+		}
+
+		/* Key can be any arbitrary number. */
+		rx_mr = test->rx_create_mr(test_args, domain_state->domain, 42+rank,
+				rx_buf, window*size, test_config->mr_rx_flags);
+		if (rx_mr == NULL) {
+			hpcs_error("failed to create target memory region\n");
+			return -1;
+		}
+
+		my_key = fi_mr_key(rx_mr);
+		address_exchange(&my_key, keys, sizeof(uint64_t), ranks);
+
+		if (verbose) {
+			hpcs_verbose("mr key exchange complete: rank %ld my_key %ld len %ld keys: ",
+					rank, my_key, window*size);
+			for (i=0; i<ranks; i++) {
+				printf("%ld ", keys[i]);
+			}
+			printf("\n");
+		}
+
+		if (test_config->rx_use_cntr) {
+			if (domain_state->rx_cntr) {
+				ret = fi_mr_bind(rx_mr, &domain_state->rx_cntr->fid, test_config->mr_rx_flags);
+				if (ret) {
+					hpcs_error("fi_mr_bind (rx_cntr) failed: %d\n", ret);
+
+					/*
+					 * Binding an MR with FI_REMOTE_READ isn't defined by the OFI spec,
+	 				 * so we don't consider this a failure.
+ 					 */
+					if (test_config->mr_rx_flags & FI_REMOTE_READ) {
+						hpcs_error("FI_REMOTE_READ memory region bind flag unsupported by this provider, skipping test.\n");
+						return 0;
+					}
+
+					return -1;
+				}
+			} else {
+				hpcs_error("no rx counter to bind mr to\n");
+				return -EINVAL;
+			}
+		}
+
+		ret = fi_mr_enable(rx_mr);
+		if (ret)
+			hpcs_error("fi_mr_enable failed: %d\n", ret);
+
+		barrier();
+	}
+
+
+	for (i = 0; i < iterations; i++) {
+		int cur_sender = PATTERN_NO_CURRENT;
+		int cur_receiver = PATTERN_NO_CURRENT;
+		int prev;
+		int completions_done = 0, rx_done = 0, tx_done = 0;
+		struct op_context* op_context;
+
+		uint64_t recvs_done_prev = recvs_done;
+		uint64_t sends_done_prev = sends_done;
+
+		while (!completions_done || !rx_done || !tx_done) {
+			/* post receives */
+			while (!rx_done) {
+				if (order == CALLBACK_ORDER_UNEXPECTED && !tx_done)
+					break;
+
+				prev = cur_sender;
+				if (pattern->next_sender(pattern_args, rank, ranks, &cur_sender) != 0) {
+					rx_done = 1;
+					if (order == CALLBACK_ORDER_EXPECTED)
+						barrier();
+					break;
+				}
+
+				/*
+				 * Doing window check after calling next_sender allows us to
+				 * mark receives as done if our window is zero but there are
+				 * no more senders.
+				 */
+				if (rx_window == 0) {
+					cur_sender = prev;
+					break;
+				}
+
+				op_context = CONTEXT(rx_context, recvs_posted);
+				if (op_context->state != DONE) {
+					cur_sender = prev;
+					break;
+				}
+
+				test->rx_init_buffer(test_args, DATA_BUF(rx_buf, recvs_posted));
+
+
+				/* fprintf(stdout, "Posting rx:  rank %d, sender %d\n", rank, cur_sender); */
+
+				op_context->buf = DATA_BUF(rx_buf, recvs_posted);
+
+				ret = test->rx_transfer(test_args, cur_sender,
+						1, domain_state->addresses[cur_sender],
+						domain_state->endpoint,
+						op_context,
+						op_context->buf,
+						NULL, NULL, NULL);
+
+
+				if (ret == -FI_EAGAIN) {
+					cur_sender = prev;
+					break;
+				}
+
+				hpcs_verbose("rx_transfer initiated: ctx %p "
+					     "from rank %ld\n",
+					     op_context, cur_sender);
+
+				if (ret) {
+					hpcs_error("test receive failed, ret=%d\n", ret);
+					return ret;
+				}
+
+				op_context->state = PENDING;
+				op_context->core_context = recvs_posted;
+
+				recvs_posted++;
+				rx_window--;
+			};
+
+			/* post send(s) */
+			while (!tx_done) {
+				if (order == CALLBACK_ORDER_EXPECTED && !rx_done)
+                                        break;
+
+				prev = cur_receiver;
+				if (pattern->next_receiver(pattern_args, rank, ranks, &cur_receiver) != 0) {
+					if (order == CALLBACK_ORDER_UNEXPECTED)
+						barrier();
+					tx_done = 1;
+					break;
+				}
+
+				if (tx_window == 0) {
+					cur_receiver = prev;
+					break;
+				}
+
+				op_context = CONTEXT(tx_context, sends_posted);
+				if (op_context->state != DONE) {
+					cur_receiver = prev;
+					break;
+				}
+
+				test->tx_init_buffer(test_args, DATA_BUF(tx_buf, sends_posted));
+
+				struct fid_mr* mr = NULL;
+				void *mr_desc = NULL;
+				if (do_tx_reg) {
+					mr = test->tx_create_mr(test_args,
+							domain_state->domain,
+							0, /* key */
+							DATA_BUF(tx_buf, sends_posted),
+							size,
+							FI_SEND);
+					if (mr == NULL) {
+						ret = -1;
+						goto err_mem;
+					}
+
+					if (test_config->tx_use_cntr) {
+						if (domain_state->tx_cntr) {
+							ret = fi_mr_bind(mr, &domain_state->tx_cntr->fid, FI_SEND);
+							if (ret) {
+								hpcs_error("fi_mr_bind (tx_cntr) failed: ret %d\n", ret);
+								return -1;
+							}
+						} else {
+							hpcs_error("no counter to bind tx memory region to\n");
+							return -EINVAL;
+						}
+					}
+
+					mr_desc = fi_mr_desc(mr);
+				}
+
+				/* fprintf(stdout, "Posting tx:  rank %d, receiver %d\n", rank, cur_receiver);*/
+
+				op_context->buf = DATA_BUF(tx_buf, sends_posted);
+				op_context->tx_mr = mr;
+
+				ret = test->tx_transfer(test_args, rank,
+						1, domain_state->addresses[cur_receiver],
+						domain_state->endpoint,
+						op_context,
+						op_context->buf,
+						mr_desc, keys[cur_receiver], rank, NULL, NULL);
+
+				if (ret == -FI_EAGAIN) {
+					cur_receiver = prev;
+					break;
+				}
+
+				hpcs_verbose("tx_transfer initiated from rank %ld "
+					     "to rank %d: ctx %p key %ld ret %d\n",
+					     rank, cur_receiver, op_context,
+					     keys[cur_receiver], ret);
+
+				if (ret) {
+					hpcs_error("tx_transfer failed, ret=%d\n", ret);
+					return ret;
+				}
+
+				op_context->state = PENDING;
+				op_context->core_context = sends_posted;
+
+				sends_posted++;
+				tx_window--;
+			};
+
+			/* poll completions */
+			if (test_config->rx_use_cq) {
+				while ((ret = test->rx_cq_completion(test_args,
+						&op_context,
+						domain_state->rx_cq)) != -FI_EAGAIN) {
+					if (ret) {
+						hpcs_error("cq_completion (rx) failed, ret=%d\n", ret);
+						return -1;
+					}
+
+					if (test->rx_datacheck(test_args, op_context->buf, 0)) {
+						hpcs_error("rx data check error at iteration %ld\n", i);
+						return -1;
+					}
+
+					op_context->state = DONE;
+					recvs_done++;
+					rx_window++;
+
+					hpcs_verbose("ctx %p receive %ld complete\n",
+						     op_context, op_context->core_context);
+				}
+			}
+
+			if (test_config->tx_use_cq) {
+				while ((ret = test->tx_cq_completion(test_args,
+						&op_context,
+						domain_state->tx_cq)) != -FI_EAGAIN) {
+					if (ret) {
+						hpcs_error("cq_completion (tx) failed, ret=%d\n", ret);
+						return -1;
+					}
+					hpcs_verbose("Received tx completion for ctx %lx\n",
+						     op_context);
+
+					if (test->tx_datacheck(test_args, op_context->buf)) {
+						hpcs_error("tx data check error at iteration %ld\n", i);
+						return -1;
+					}
+
+					if (do_tx_reg && test->tx_destroy_mr != NULL) {
+						ret = test->tx_destroy_mr(test_args, op_context->tx_mr);
+						if (ret) {
+							hpcs_error("unable to release tx memory region\n");
+							return -1;
+						}
+					}
+
+					op_context->state = DONE;
+					op_context->test_state = 0;
+					sends_done++;
+					tx_window++;
+
+					hpcs_verbose("ctx %p send %ld complete\n",
+						     op_context, op_context->core_context);
+				}
+			}
+
+			/*
+			 * Counters are generally used for RMA/atomics and completion is handled
+			 * as all-or-nothing rather than individual completions.
+			 */
+			if (rx_done && tx_done) {
+				if (test_config->tx_use_cntr && sends_done < sends_posted) {
+					ret = test->tx_cntr_completion(test_args, sends_posted, domain_state->tx_cntr);
+					if (ret) {
+						hpcs_error("cntr_completion (tx) failed, ret=%d\n", ret);
+						return -1;
+					}
+
+					for (j = sends_done_prev; j < sends_posted; j++) {
+						op_context = CONTEXT(tx_context, j);
+
+						if (do_tx_reg && test->tx_destroy_mr != NULL) {
+							ret = test->tx_destroy_mr(test_args, op_context->tx_mr);
+							if (ret) {
+								hpcs_error("unable to release tx memory region\n");
+								return -1;
+							}
+						}
+						sends_done++;
+						op_context->state = DONE;
+						op_context->test_state = 0;
+						tx_window++;
+					}
+
+					if (sends_done != sends_posted) {
+						hpcs_error("tx accounting internal error\n");
+						return -EFAULT;
+					}
+
+					hpcs_verbose("TX counter completion done\n");
+				}
+
+				if (test_config->rx_use_cntr && recvs_done < recvs_posted) {
+					ret = test->rx_cntr_completion(test_args, recvs_posted, domain_state->rx_cntr);
+					if (ret) {
+						hpcs_error("cntr_completion (rx) failed, ret=%d\n", ret);
+						return -1;
+					}
+
+					for (j = recvs_done_prev; j < recvs_posted; j++) {
+						op_context = CONTEXT(rx_context, j);
+						recvs_done++;
+						op_context->state = DONE;
+						op_context->test_state = 0;
+						rx_window++;
+					}
+
+					/* 
+					 * note: counter tests use rx_buf directly,
+					 * rather than DATA_BUF(rx_buf, j)
+					 */
+
+					if (test->rx_datacheck(test_args, rx_buf, recvs_posted - recvs_done_prev)) {
+						hpcs_error("rx data check error at iteration %ld\n", i);
+						return -1;
+					}
+
+					test->rx_init_buffer(test_args, rx_buf);
+
+					if (recvs_done != recvs_posted) {
+						hpcs_error("rx accounting internal error\n");
+						return -EFAULT;
+					}
+
+					hpcs_verbose("rx counter completion done\n");
+				}
+			}
+
+			if (recvs_posted == recvs_done && sends_posted == sends_done) {
+				completions_done = 1;
+			} else {
+				hpcs_verbose("recvs_posted=%ld, recvs_done=%ld, sends_posted=%ld, sends_done=%ld\n",
+					      recvs_posted, recvs_done, sends_posted, sends_done);
+				usleep(50000);
+			}
+		}
+	}
+
+	/*
+	 * OFI docs are unclear about proper order of closing memory region
+	 * and counter that are bound to each other.
+	 */
+	if (rx_mr != NULL && test->rx_destroy_mr != NULL) {
+		ret = test->rx_destroy_mr(test_args, rx_mr);
+		if (ret) {
+			hpcs_error("unable to release rx memory region\n");
+			return -1;
+		}
+	}
+
+	/* Make sure all our peers are done before exiting. */
+	barrier();
+	ret = 0;
+
+err_mem:
+	if (tx_buf)
+		free(tx_buf);
+
+	if (rx_buf)
+		free(rx_buf);
+
+	if (keys)
+		free(keys);
+
+	return ret;
+}
+
+int core (
+		const int argc,
+		char * const *argv,
+		const int num_mpi_ranks,
+		const int our_mpi_rank,
+		address_exchange_t address_exchange,
+		barrier_t barrier)
+{
+	int ret;
+
+	struct arguments *arguments = NULL;
+	struct test_api test = test_api ();
+	struct test_config test_config = {0};
+	struct ofi_state ofi_state = {0};
+	struct domain_state domain_state = {0};
+	struct pattern_api pattern = {0};
+
+	fi_addr_t addresses[num_mpi_ranks];
+
+	/*
+	struct fid_cntr *tx_cntrs [num_tx_cntr (arguments, test_config)];
+	struct fid_cntr *rx_cntrs [num_rx_cntr (arguments, test_config)];
+	*/
+
+	ret = parse_arguments(argc, argv, &arguments);
+
+	if (ret < 0)
+		return -EINVAL;
+
+	pattern = arguments->pattern_api;
+
+	test_config = test.config(arguments->test_arguments);
+
+	hpcs_verbose("Initializing ofi resources\n");
+
+	domain_state.addresses = &addresses[0];
+
+	ofi_state.domain_state = &domain_state;
+
+	ret = init_ofi(
+			arguments,
+			arguments->test_arguments,
+			&test_config,
+			&ofi_state,
+			address_exchange,
+			num_mpi_ranks,
+			our_mpi_rank);
+	if (ret) {
+		hpcs_error("Init_ofi failed, ret=%d\n", ret);
+		return -1;
+	} else {
+		hpcs_verbose("OFI resource initialization successful\n");
+	}
+
+	ret = core_inner(&domain_state, arguments, &pattern, &test, &test_config,
+			our_mpi_rank, num_mpi_ranks, address_exchange, barrier);
+
+	if (ret) {
+		hpcs_error("Test failed, ret=%d\n", ret);
+		return -1;
+	}
+
+	ret = fini_ofi(&ofi_state);
+	if (ret) {
+		hpcs_error("Resource cleanup failed, ret=%d\n", ret);
+		return -1;
+	}
+
+	free_arguments(arguments);
+
+	return 0;
+}
+
+
+
+void hpcs_error(const char* format, ...)
+{
+	char hostname[HOSTLEN];
+
+        gethostname(hostname, HOSTLEN);
+	hostname[HOSTLEN-1]='\0';
+
+	va_list args;
+	fprintf(stderr, "%s: ", hostname);
+        va_start(args, format);
+        vfprintf(stderr, format, args);
+        va_end (args);
+
+}
+
+void hpcs_verbose(const char* format, ...)
+{
+	char hostname[HOSTLEN];
+
+	if(!verbose)
+		return;
+
+        gethostname(hostname, HOSTLEN);
+	hostname[HOSTLEN-1]='\0';
+
+	va_list args;
+	fprintf(stdout, "%s: ", hostname);
+        va_start(args, format);
+        vfprintf(stdout, format, args);
+        va_end (args);
+
+}

--- a/fabtests/hpcs/src/harness/Makefile.am
+++ b/fabtests/hpcs/src/harness/Makefile.am
@@ -1,0 +1,10 @@
+noinst_LTLIBRARIES = libharness.la
+
+libharness_la_SOURCES = harness.c
+
+libharness_la_CFLAGS = \
+        $(AM_CFLAGS) \
+        -I$(srcdir)/../../include
+
+clean-local:
+	@echo "Cleaning"

--- a/fabtests/hpcs/src/harness/harness.c
+++ b/fabtests/hpcs/src/harness/harness.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <mpi.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+
+#include <core/user.h>
+
+static int num_mpi_ranks = 0;
+static int our_mpi_rank = 0;
+
+/*
+ * We'd like to keep mpi dependencies out of core and libfabric dependencies
+ * out of harness, so when core needs to exchange addresses it does so via
+ * this callback routine passed into core's main loop.
+ */
+int address_exchange(void *my_address, void *addresses, int size, int count)
+{
+	int ret;
+
+	if (count != num_mpi_ranks)
+		return EXIT_FAILURE;
+
+	ret = MPI_Allgather(my_address, size, MPI_BYTE,
+			addresses, size, MPI_BYTE,
+			MPI_COMM_WORLD);
+
+	if (ret)
+		fprintf(stderr, "address exchange failed, ret=%d\n", ret);
+
+	return ret;
+}
+
+/*
+ * Core uses this callback to synchronize job to force expected or unexpected.
+ */
+void barrier()
+{
+	MPI_Barrier(MPI_COMM_WORLD);
+}
+
+int main(const int argc, char * const *argv)
+{
+	int our_ret = 0;
+	int ret;
+
+	/* TODO: can support multiple "test cores" per run by dynamically
+	 * loading and unloading here and storing the results of these calls. */
+
+	ret = MPI_Init(NULL, NULL);
+	if (ret) {
+		our_ret = ret;
+		goto err_mpi_init;
+	}
+
+	ret = MPI_Comm_size(MPI_COMM_WORLD, &num_mpi_ranks);
+	if (ret) {
+		our_ret = EXIT_FAILURE;
+		goto err_mpi_comm_size;
+	}
+
+	ret = MPI_Comm_rank(MPI_COMM_WORLD, &our_mpi_rank);
+	if (ret != MPI_SUCCESS) {
+		our_ret = EXIT_FAILURE;
+		goto err_mpi_comm_rank;
+	}
+
+	ret = core(argc, argv,
+			num_mpi_ranks, our_mpi_rank,
+			address_exchange, barrier);
+	if (ret) {
+		fprintf(stderr, "TEST FAILED\n");
+		our_ret = EXIT_FAILURE;
+		goto err_core;
+	}
+
+	fprintf(stderr, "TEST PASSED\n");
+
+err_core:
+err_mpi_comm_rank:
+err_mpi_comm_size:
+
+	ret = MPI_Finalize();
+	if (ret) {
+		our_ret = our_ret ? our_ret : ret;
+	}
+err_mpi_init:
+
+	return our_ret;
+}

--- a/fabtests/hpcs/src/harness/harness.c
+++ b/fabtests/hpcs/src/harness/harness.c
@@ -74,6 +74,7 @@ int main(const int argc, char * const *argv)
 {
 	int our_ret = 0;
 	int ret;
+	struct job job;
 
 	/* TODO: can support multiple "test cores" per run by dynamically
 	 * loading and unloading here and storing the results of these calls. */
@@ -96,9 +97,14 @@ int main(const int argc, char * const *argv)
 		goto err_mpi_comm_rank;
 	}
 
-	ret = core(argc, argv,
-			num_mpi_ranks, our_mpi_rank,
-			address_exchange, barrier);
+	job = (struct job) {
+		.address_exchange = address_exchange,
+		.barrier = barrier,
+		.ranks = num_mpi_ranks,
+		.rank = our_mpi_rank
+	};
+
+	ret = core(argc, argv, &job);
 	if (ret) {
 		fprintf(stderr, "TEST FAILED\n");
 		our_ret = EXIT_FAILURE;

--- a/fabtests/hpcs/src/pattern/alltoall.c
+++ b/fabtests/hpcs/src/pattern/alltoall.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <pattern/user.h>
+#include "util.h"
+
+#define PATTERN_API_VERSION_MAJOR 0
+#define PATTERN_API_VERSION_MINOR 0
+
+struct pattern_arguments {};
+
+static int parse_arguments(
+		const int argc,
+		char * const *argv,
+		struct pattern_arguments **arguments)
+{
+	*arguments = NULL;
+	return 0;
+}
+
+static void free_arguments(struct pattern_arguments *arguments)
+{
+	return;
+}
+
+static int pattern_next(
+		const struct pattern_arguments *arguments,
+		int my_rank,
+		int num_ranks,
+		int *cur)
+{
+	int next = *cur + 1;
+
+	if (next >= num_ranks)
+		return -1;
+
+	*cur = next;
+	return 0;
+}
+
+
+struct pattern_api a2a_pattern_api(void)
+{
+	struct pattern_api pattern_api = {
+		.parse_arguments = &parse_arguments,
+		.free_arguments = &free_arguments,
+		.next_sender = &pattern_next,
+		.next_receiver = &pattern_next
+	};
+	return pattern_api;
+}

--- a/fabtests/hpcs/src/pattern/alltoall.c
+++ b/fabtests/hpcs/src/pattern/alltoall.c
@@ -56,12 +56,13 @@ static int pattern_next(
 		const struct pattern_arguments *arguments,
 		int my_rank,
 		int num_ranks,
-		int *cur)
+		int *cur,
+		int *threshold)
 {
 	int next = *cur + 1;
 
 	if (next >= num_ranks)
-		return -1;
+		return -ENODATA;
 
 	*cur = next;
 	return 0;

--- a/fabtests/hpcs/src/pattern/alltoone.c
+++ b/fabtests/hpcs/src/pattern/alltoone.c
@@ -94,18 +94,19 @@ static int ato_pattern_next_sender(
 		const struct pattern_arguments *arguments,
 		int my_rank,
 		int num_ranks,
-		int *cur)
+		int *cur,
+		int *threshold)
 {
 	if (my_rank == arguments->target_rank){
 		int next = *cur + 1;
 
 		if (next >= num_ranks)
-			return -1;
+			return -ENODATA;
 
 		*cur = next;
 		return 0;
 	} else {
-		return -1;
+		return -ENODATA;
 	}
 }
 
@@ -113,14 +114,15 @@ static int ato_pattern_next_receiver(
 		const struct pattern_arguments *arguments,
 		int my_rank,
 		int num_ranks,
-		int *cur)
+		int *cur,
+		int *threshold)
 {
 	if (*cur == PATTERN_NO_CURRENT) {
 		*cur = arguments->target_rank;
 		return 0;
 	}
 
-	return -1;
+	return -ENODATA;
 }
 
 

--- a/fabtests/hpcs/src/pattern/alltoone.c
+++ b/fabtests/hpcs/src/pattern/alltoone.c
@@ -57,27 +57,24 @@ static int ato_parse_arguments(
 		{0}
 	};
 
-	struct pattern_arguments *args = calloc(sizeof(struct pattern_arguments), 1);
+	struct pattern_arguments *args = calloc(sizeof(*args), 1);
 	if (args == NULL)
 		return -FI_ENOMEM;
 
 	*args = (struct pattern_arguments) {.target_rank = 0};
 
-	if (argc > 0 && argv != NULL) {
-		while ((op = getopt_long(argc, argv, "t:h", longopt, &longopt_idx)) != -1) {
-			switch (op) {
-			case 't':
-				if (sscanf(optarg, "%zu", &args->target_rank) != 1)
-					return -FI_EINVAL;
-				break;
-			case 'h':
-			default:
-				fprintf(stderr, "<pattern arguments> :=\n"
-						"\t[-t | --target-rank=<rank>]\n"
-						"\t[-h | --help]\n");
+	while ((op = getopt_long(argc, argv, "t:h", longopt, &longopt_idx)) != -1) {
+		switch (op) {
+		case 't':
+			if (sscanf(optarg, "%zu", &args->target_rank) != 1)
 				return -FI_EINVAL;
-				break;
-			}
+			break;
+		case 'h':
+		default:
+			fprintf(stderr, "<pattern arguments> :=\n"
+					"\t[-t | --target-rank=<rank>]\n"
+					"\t[-h | --help]\n");
+			return -FI_EINVAL;
 		}
 	}
 

--- a/fabtests/hpcs/src/pattern/alltoone.c
+++ b/fabtests/hpcs/src/pattern/alltoone.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <getopt.h>
+#include <rdma/fi_errno.h>
+
+#include <pattern/user.h>
+#include "util.h"
+
+#define PATTERN_API_VERSION_MAJOR 0
+#define PATTERN_API_VERSION_MINOR 0
+
+struct pattern_arguments {
+	uint64_t target_rank;
+};
+
+static int ato_parse_arguments(
+		const int argc,
+		char * const *argv,
+		struct pattern_arguments **arguments)
+{
+	int longopt_idx=0, op;
+	static struct option longopt[] = {
+		{"target-rank", required_argument, 0, 't'},
+		{"help", no_argument, 0, 'h'},
+		{0}
+	};
+
+	struct pattern_arguments *args = calloc(sizeof(struct pattern_arguments), 1);
+	if (args == NULL)
+		return -FI_ENOMEM;
+
+	*args = (struct pattern_arguments) {.target_rank = 0};
+
+	if (argc > 0 && argv != NULL) {
+		while ((op = getopt_long(argc, argv, "t:h", longopt, &longopt_idx)) != -1) {
+			switch (op) {
+			case 't':
+				if (sscanf(optarg, "%zu", &args->target_rank) != 1)
+					return -FI_EINVAL;
+				break;
+			case 'h':
+			default:
+				fprintf(stderr, "<pattern arguments> :=\n"
+						"\t[-t | --target-rank=<rank>]\n"
+						"\t[-h | --help]\n");
+				return -FI_EINVAL;
+				break;
+			}
+		}
+	}
+
+	*arguments = args;
+	return 0;
+}
+
+static void ato_free_arguments(struct pattern_arguments *arguments)
+{
+	return;
+}
+
+static int ato_pattern_next_sender(
+		const struct pattern_arguments *arguments,
+		int my_rank,
+		int num_ranks,
+		int *cur)
+{
+	if (my_rank == arguments->target_rank){
+		int next = *cur + 1;
+
+		if (next >= num_ranks)
+			return -1;
+
+		*cur = next;
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+static int ato_pattern_next_receiver(
+		const struct pattern_arguments *arguments,
+		int my_rank,
+		int num_ranks,
+		int *cur)
+{
+	if (*cur == PATTERN_NO_CURRENT) {
+		*cur = arguments->target_rank;
+		return 0;
+	}
+
+	return -1;
+}
+
+
+struct pattern_api alltoone_pattern_api(void)
+{
+	struct pattern_api pattern_api = {
+		.parse_arguments = &ato_parse_arguments,
+		.free_arguments = &ato_free_arguments,
+		.next_sender = &ato_pattern_next_sender,
+		.next_receiver = &ato_pattern_next_receiver
+	};
+	return pattern_api;
+}

--- a/fabtests/hpcs/src/pattern/ring.c
+++ b/fabtests/hpcs/src/pattern/ring.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * The ring pattern creates a chain of rx-triggered sends, such that rank
+ * R sends a message to rank (R+1)%N after receiving from rank (N-1)%N.
+ *
+ * The pattern assigns one rank as the leader (rank 0 by default), and the
+ * final message in the chain is receied by the leader, forming a ring.
+ *
+ * (Explicitly setting the leader as -1 is allowed, in which case there
+ * is no leader.  This is expected to deadlock, which is a way to verify
+ * that triggered ops aren't firing prematurely.)
+ *
+ * The pattern may execute up to N rings simultaneously.  Each ring has a
+ * different leader, chosen sequentially.  The --multi-ring argument
+ * simply runs N rings, with every rank being the leader of a single ring.
+ *
+ * The pattern does not allow any rank to be the leader of more than one
+ * ring.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <getopt.h>
+#include <rdma/fi_errno.h>
+
+#include <pattern/user.h>
+#include <core/user.h>
+#include "util.h"
+
+#define PATTERN_API_VERSION_MAJOR 0
+#define PATTERN_API_VERSION_MINOR 0
+
+/*
+ * Leader is the node that sends first in a triggered ops case.  If leader
+ * is -1, there is no leader.
+ *
+ * Rings is the number of concurrent rings (the leader of each subsequent ring
+ * is the leader's rank plus one mod N).  If rings is -1, the number of rings
+ * will equal the number of ranks.
+ */
+struct pattern_arguments {
+	int leader;
+	int rings;
+	int verbose;
+};
+
+static int ring_parse_arguments(
+		const int argc,
+		char * const *argv,
+		struct pattern_arguments **arguments)
+{
+	int longopt_idx=0, op;
+	static struct option longopt[] = {
+		{"leader", required_argument, 0, 'l'},
+		{"rings", required_argument, 0, 'r'},
+		{"multi-ring", no_argument, 0, 'm'},
+		{"verbose", no_argument, 0, 'v'},
+		{"help", no_argument, 0, 'h'},
+		{0}
+	};
+
+	int have_rings=0, have_multi_ring=0;
+
+	struct pattern_arguments *args = calloc(sizeof(struct pattern_arguments), 1);
+	if (args == NULL)
+		return -FI_ENOMEM;
+
+	*args = (struct pattern_arguments) {.leader = 0, .rings = 1};
+
+	if (argc > 0 && argv != NULL) {
+		while ((op = getopt_long(argc, argv, "l:r:mh", longopt, &longopt_idx)) != -1) {
+			switch (op) {
+			case 'l':
+				if (sscanf(optarg, "%d", &args->leader) != 1) {
+					hpcs_error("unable to parse --leader argument\n");
+					return -EINVAL;
+				}
+				if (args->leader < 0)
+					hpcs_error("ring pattern has no leader; deadlock expected if triggered ops are working correctly\n");
+				break;
+			case 'r':
+				if (sscanf(optarg, "%u", &args->rings) != 1) {
+					hpcs_error("unable to parse --rings argument\n");
+					return -EINVAL;
+				}
+				have_rings = 1;
+				break;
+			case 'm':
+				args->rings = -1;
+				have_multi_ring = 1;
+				break;
+			case 'v':
+				args->verbose = 1;
+				break;
+			case 'h':
+			default:
+				fprintf(stderr, "<pattern arguments> :=\n"
+						"\t[-l | --leader=<rank>]\n"
+						"\t[-r | --rings=<rings> | -m | --multi-ring]\n"
+						"\t[-v | --verbose]\n"
+						"\t[-h | --help]\n");
+				return -EINVAL;
+				break;
+			}
+		}
+	}
+
+	if (have_rings && have_multi_ring) {
+		hpcs_error("--rings and --multi-ring arguments are mutually exclusive\n");
+		return -EINVAL;
+	}
+
+	*arguments = args;
+	return 0;
+}
+
+static void ring_free_arguments(struct pattern_arguments *arguments)
+{
+	free(arguments);
+}
+
+/*
+ * Note: this does not handle the case where rings > num_ranks.
+ */
+static inline int ring_pattern_next(int is_sender,
+		const struct pattern_arguments *arguments,
+		int my_rank,
+		int num_ranks,
+		int *cur,
+		int *threshold)
+{
+	int leader = arguments->leader;
+	int rings = arguments->rings < 0
+			? num_ranks
+			: arguments->rings;
+	int is_leader, max_threshold;
+
+	/*
+	 * Current node is a leader of some ring if it's within the
+	 * first N ranks beginning with the leader (wrapping around),
+	 * where N is the total number of rings.
+	 */
+
+	if (leader < 0)
+		is_leader = 0;
+	else if (leader + rings <= num_ranks)
+		is_leader = my_rank >= leader && my_rank < leader + rings;
+	else
+		is_leader = my_rank >= leader || my_rank < (leader + rings) - num_ranks;
+
+	max_threshold = is_leader ? rings - 1 : rings;
+
+	if (rings > num_ranks) {
+		hpcs_error("Ring pattern does not support a number of rings that exceeds number of ranks.\n");
+		return -EINVAL;
+	}
+
+	if (arguments->verbose) {
+		printf("%d ring_pattern_next_%s(... %d, %d) leader:%d rings:%d is_leader:%d max_threshold:%d\n",
+				my_rank,
+				is_sender ? "sender" : "receiver",
+				*cur, *threshold,
+				leader, rings, is_leader, max_threshold);
+	}
+
+	if (*cur == PATTERN_NO_CURRENT) {
+		int peer_rank = (my_rank + (is_sender ? num_ranks - 1 : 1)) % num_ranks;
+
+		*cur = peer_rank % num_ranks;
+		*threshold = is_leader ? 0 : 1;
+	} else if (*threshold < max_threshold) {
+		*threshold = *threshold + 1;
+	} else {
+		if (arguments->verbose)
+			printf("\t-> done\n");
+		return -ENODATA;
+	}
+
+	if (arguments->verbose)
+		printf("\t-> cur:%d, threshold:%d\n", *cur, *threshold);
+	return 0;
+}
+
+static int ring_pattern_next_sender(
+		const struct pattern_arguments *arguments,
+		int my_rank,
+		int num_ranks,
+		int *cur,
+		int *threshold)
+{
+	return ring_pattern_next(1, arguments, my_rank, num_ranks, cur, threshold);
+}
+
+
+static int ring_pattern_next_receiver(
+		const struct pattern_arguments *arguments,
+		int my_rank,
+		int num_ranks,
+		int *cur,
+		int *threshold)
+{
+	return ring_pattern_next(0, arguments, my_rank, num_ranks, cur, threshold);
+}
+
+
+struct pattern_api ring_pattern_api(void)
+{
+	struct pattern_api pattern_api = {
+		.parse_arguments = &ring_parse_arguments,
+		.free_arguments = &ring_free_arguments,
+		.next_sender = &ring_pattern_next_sender,
+		.next_receiver = &ring_pattern_next_receiver,
+		.enable_triggered = 1
+	};
+	return pattern_api;
+}

--- a/fabtests/hpcs/src/pattern/ring.c
+++ b/fabtests/hpcs/src/pattern/ring.c
@@ -94,45 +94,42 @@ static int ring_parse_arguments(
 
 	struct pattern_arguments *args = calloc(sizeof(struct pattern_arguments), 1);
 	if (args == NULL)
-		return -FI_ENOMEM;
+	return -FI_ENOMEM;
 
 	*args = (struct pattern_arguments) {.leader = 0, .rings = 1};
 
-	if (argc > 0 && argv != NULL) {
-		while ((op = getopt_long(argc, argv, "l:r:mh", longopt, &longopt_idx)) != -1) {
-			switch (op) {
-			case 'l':
-				if (sscanf(optarg, "%d", &args->leader) != 1) {
-					hpcs_error("unable to parse --leader argument\n");
-					return -EINVAL;
-				}
-				if (args->leader < 0)
-					hpcs_error("ring pattern has no leader; deadlock expected if triggered ops are working correctly\n");
-				break;
-			case 'r':
-				if (sscanf(optarg, "%u", &args->rings) != 1) {
-					hpcs_error("unable to parse --rings argument\n");
-					return -EINVAL;
-				}
-				have_rings = 1;
-				break;
-			case 'm':
-				args->rings = -1;
-				have_multi_ring = 1;
-				break;
-			case 'v':
-				args->verbose = 1;
-				break;
-			case 'h':
-			default:
-				fprintf(stderr, "<pattern arguments> :=\n"
-						"\t[-l | --leader=<rank>]\n"
-						"\t[-r | --rings=<rings> | -m | --multi-ring]\n"
-						"\t[-v | --verbose]\n"
-						"\t[-h | --help]\n");
+	while ((op = getopt_long(argc, argv, "l:r:mh", longopt, &longopt_idx)) != -1) {
+		switch (op) {
+		case 'l':
+			if (sscanf(optarg, "%d", &args->leader) != 1) {
+				hpcs_error("unable to parse --leader argument\n");
 				return -EINVAL;
-				break;
 			}
+			if (args->leader < 0)
+			hpcs_error("ring pattern has no leader; deadlock expected if triggered ops are working correctly\n");
+			break;
+		case 'r':
+			if (sscanf(optarg, "%u", &args->rings) != 1) {
+				hpcs_error("unable to parse --rings argument\n");
+				return -EINVAL;
+			}
+			have_rings = 1;
+			break;
+		case 'm':
+			args->rings = -1;
+			have_multi_ring = 1;
+			break;
+		case 'v':
+			args->verbose = 1;
+			break;
+		case 'h':
+		default:
+			fprintf(stderr, "<pattern arguments> :=\n"
+					"\t[-l | --leader=<rank>]\n"
+					"\t[-r | --rings=<rings> | -m | --multi-ring]\n"
+					"\t[-v | --verbose]\n"
+					"\t[-h | --help]\n");
+			return -EINVAL;
 		}
 	}
 

--- a/fabtests/hpcs/src/pattern/self.c
+++ b/fabtests/hpcs/src/pattern/self.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <pattern/user.h>
+#include "util.h"
+
+#define PATTERN_API_VERSION_MAJOR 0
+#define PATTERN_API_VERSION_MINOR 0
+
+struct pattern_arguments {};
+
+static int parse_arguments(
+		const int argc,
+		char * const *argv,
+		struct pattern_arguments **arguments)
+{
+	*arguments = NULL;
+	return 0;
+}
+
+static void free_arguments(struct pattern_arguments *arguments)
+{
+	return;
+}
+
+static int self_pattern_next(
+		const struct pattern_arguments *arguments,
+		int my_rank,
+		int num_ranks,
+		int *cur)
+{
+	if (*cur == PATTERN_NO_CURRENT) {
+		*cur = my_rank;
+		return 0;
+	}
+
+	return -1;
+}
+
+struct pattern_api
+self_pattern_api(void)
+{
+	struct pattern_api pattern_api = {
+		.parse_arguments = &parse_arguments,
+		.free_arguments = &free_arguments,
+		.next_sender = &self_pattern_next,
+		.next_receiver = &self_pattern_next
+	};
+	return pattern_api;
+}

--- a/fabtests/hpcs/src/pattern/self.c
+++ b/fabtests/hpcs/src/pattern/self.c
@@ -56,14 +56,15 @@ static int self_pattern_next(
 		const struct pattern_arguments *arguments,
 		int my_rank,
 		int num_ranks,
-		int *cur)
+		int *cur,
+		int *threshold)
 {
 	if (*cur == PATTERN_NO_CURRENT) {
 		*cur = my_rank;
 		return 0;
 	}
 
-	return -1;
+	return -ENODATA;
 }
 
 struct pattern_api

--- a/fabtests/hpcs/src/pattern/util.h
+++ b/fabtests/hpcs/src/pattern/util.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <pattern/user.h>

--- a/fabtests/hpcs/src/test/generic.c
+++ b/fabtests/hpcs/src/test/generic.c
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <limits.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <unistd.h>
+
+#include <rdma/fi_errno.h>
+#include <rdma/fi_eq.h>
+
+#include <test/user.h>
+
+struct test_arguments {
+};
+
+void test_generic_free_arguments(struct test_arguments *arguments)
+{
+	free (arguments);
+}
+
+void test_generic_tx_init_buffer(const struct test_arguments *arguments,
+		uint8_t *buffer, size_t len)
+{
+	memset(buffer, UINT8_MAX, len);
+}
+
+void test_generic_rx_init_buffer(const struct test_arguments *arguments,
+		uint8_t *buffer, size_t len)
+{
+	memset(buffer, 0, len);
+}
+
+static struct fid_mr *test_generic_create_mr(const struct test_arguments *arguments,
+		struct fid_domain *domain, const uint64_t key,
+		uint8_t *buffer, size_t len, uint64_t access, uint64_t flags)
+{
+	int ret;
+	struct fid_mr *mr;
+
+	ret = fi_mr_reg(domain, buffer, len, access, 0, key, flags, &mr, NULL);
+	if (ret)
+		goto err_mr_reg;
+
+	return mr;
+
+err_mr_reg:
+	fprintf(stderr, "fi_mr_reg failed\n");
+	return NULL;
+}
+
+struct fid_mr *test_generic_tx_create_mr(const struct test_arguments *arguments,
+		struct fid_domain *domain, const uint64_t key,
+		uint8_t *buffer, size_t len, uint64_t access, uint64_t flags)
+{
+	return test_generic_create_mr(arguments, domain, key,
+			buffer, len, access, flags);
+}
+
+struct fid_mr *test_generic_rx_create_mr(const struct test_arguments *arguments,
+		struct fid_domain *domain, const uint64_t key,
+		uint8_t *buffer, size_t len, uint64_t access, uint64_t flags)
+{
+	return test_generic_create_mr(arguments, domain, key,
+			buffer, len, access, flags);
+}
+
+int test_generic_tx_destroy_mr(const struct test_arguments *arguments, struct fid_mr *mr)
+{
+	return fi_close(&mr->fid);
+}
+
+int test_generic_rx_destroy_mr(const struct test_arguments *arguments, struct fid_mr *mr)
+{
+	return fi_close(&mr->fid);
+}
+
+size_t test_generic_tx_window_usage(const struct test_arguments *arguments,
+		const size_t transfer_id, const size_t transfer_count)
+{
+	return 1;
+}
+
+size_t test_generic_rx_window_usage(const struct test_arguments *arguments,
+		const size_t transfer_id, const size_t transfer_count)
+{
+	return 1;
+}
+
+int test_generic_tx_transfer(const struct test_arguments *arguments,
+		const size_t transfer_id, const size_t transfer_count,
+		const fi_addr_t rx_address, struct fid_ep *endpoint,
+		struct op_context *op_context, uint8_t *buffer,
+		void *desc, uint64_t key, int rank, uint64_t flags)
+{
+	return 0;
+}
+
+int test_generic_rx_transfer(const struct test_arguments *arguments,
+		const size_t transfer_id, const size_t transfer_count,
+		const fi_addr_t tx_address, struct fid_ep *endpoint,
+		struct op_context *op_context, uint8_t *buffer,
+		void *desc, uint64_t flags)
+{
+	return 0;
+}
+
+static int generic_cntr_completion(const struct test_arguments *arguments,
+		const size_t completion_count, struct fid_cntr *cntr)
+{
+	return fi_cntr_wait(cntr, completion_count, -1);
+}
+
+
+int test_generic_tx_cntr_completion(const struct test_arguments *arguments,
+		const size_t completion_count, struct fid_cntr *cntr)
+{
+	return generic_cntr_completion(arguments, completion_count, cntr);
+}
+
+int test_generic_rx_cntr_completion(const struct test_arguments *arguments,
+		const size_t completion_count, struct fid_cntr *cntr)
+{
+	return generic_cntr_completion(arguments, completion_count, cntr);
+}
+
+/*
+ * This function and core assumes that there is only one cq completion
+ * per tx or rx transfer.  Tests that need more than one completion per
+ * transfer should implement their own completion logic (possibly calling
+ * this in a loop) or use counters.
+ */
+static int test_generic_cq_completion(const struct test_arguments *args,
+		struct op_context **op_contextp, struct fid_cq *cq)
+{
+	ssize_t ret;
+	struct fi_cq_tagged_entry cq_entry;
+	struct context_info *ctxinfo;
+	struct op_context *op_context;
+
+	ret = fi_cq_read(cq, (void *) &cq_entry, 1);
+
+	if (ret == 1) {
+		ctxinfo = (struct context_info *)(cq_entry.op_context);
+		op_context = ctxinfo->op_context;
+		op_context->test_state++;
+		*op_contextp = op_context;
+		return 0;
+	}
+
+	if (ret == -FI_EAVAIL) {
+		struct fi_cq_err_entry err;
+
+		ret = fi_cq_readerr(cq, &err, 0);
+		if (ret < 0) {
+			fprintf(stderr, "unable to read error completion\n");
+		} else {
+			fprintf(stderr,
+					"cq_read error ctx %p len %ld tag %ld err %d (%s) prov_errno %d err_data %p err_data_size %ld\n",
+					err.op_context, err.len, err.tag,
+					err.err,
+					fi_cq_strerror(cq, err.prov_errno, err.err_data, NULL, 0),
+					err.prov_errno, err.err_data,
+					err.err_data_size);
+		}
+
+		return -FI_EFAULT;
+	}
+
+	return ret;
+}
+
+int test_generic_tx_cq_completion(const struct test_arguments *args,
+		struct op_context **context, struct fid_cq *cq)
+{
+	return test_generic_cq_completion(args, context, cq);
+}
+
+int test_generic_rx_cq_completion(const struct test_arguments *args,
+		struct op_context **context, struct fid_cq *cq)
+{
+	return test_generic_cq_completion(args, context, cq);
+}
+
+static int test_generic_datacheck(const struct test_arguments *arguments,
+		const uint8_t *buffer, size_t len)
+{
+	size_t i;
+
+	for (i = 0; i < len; i++) {
+		if (((uint8_t *) buffer)[i] != UINT8_MAX) {
+			fprintf(stderr, "datacheck failed at byte %zu (expected %u, found %u)\n",
+					i, UINT8_MAX, buffer[i]);
+			return -FI_EIO;
+		}
+	}
+
+	return 0;
+}
+
+int test_generic_tx_datacheck(const struct test_arguments *arguments,
+		const uint8_t *buffer, size_t len)
+{
+	return test_generic_datacheck(arguments, buffer, len);
+}
+
+int test_generic_rx_datacheck(const struct test_arguments *args,
+		const uint8_t *buffer, size_t len, size_t rx_peers)
+{
+	return test_generic_datacheck(args, buffer, len);
+}
+
+int test_generic_tx_fini_buffer(const struct test_arguments *arguments,
+		uint8_t *buffer)
+{
+	return 0;
+}
+
+int test_generic_rx_fini_buffer(const struct test_arguments *arguments,
+		uint8_t *buffer)
+{
+	return 0;
+}
+

--- a/fabtests/hpcs/src/test/generic.h
+++ b/fabtests/hpcs/src/test/generic.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <inttypes.h>
+
+#include <rdma/fi_errno.h>
+#include <rdma/fi_eq.h>
+
+#include <test/user.h>
+
+struct test_arguments;
+
+void generic_free_arguments(struct test_arguments *arguments);
+
+void generic_tx_init_buffer(const struct test_arguments *arguments,
+		uint8_t *buffer, size_t len);
+
+void generic_rx_init_buffer(const struct test_arguments *arguments,
+		uint8_t *buffer, size_t len);
+
+struct fid_mr *generic_create_mr(const struct test_arguments *arguments,
+		struct fid_domain *domain,
+		const uint64_t key, uint8_t *buffer,
+		size_t len, uint64_t access);
+
+int generic_destroy_mr(const struct test_arguments *arguments,
+		struct fid_mr *mr);
+
+size_t generic_tx_window_usage(const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count);
+
+size_t generic_rx_window_usage(const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count);
+
+int generic_tx_transfer(const struct test_arguments *arguments,
+		const size_t transfer_id, const size_t transfer_count,
+		const fi_addr_t rx_address, struct fid_ep *endpoint,
+		struct op_context *op_context, uint8_t *buffer,
+		void *desc, uint64_t key, int rank, uint64_t flags);
+
+int generic_rx_transfer(const struct test_arguments *arguments,
+		const size_t transfer_id, const size_t transfer_count,
+		const fi_addr_t tx_address, struct fid_ep *endpoint,
+		struct op_context *op_context, uint8_t *buffer,
+		void *desc, uint64_t flags);
+
+int generic_tx_cntr_completion(const struct test_arguments *arguments,
+		const size_t completion_count, struct fid_cntr *cntr);
+
+int generic_rx_cntr_completion(const struct test_arguments *arguments,
+		const size_t completion_count, struct fid_cntr *cntr);
+
+int generic_tx_cq_completion(const struct test_arguments *args,
+		struct op_context **context, struct fid_cq *cq);
+
+int generic_rx_cq_completion(const struct test_arguments *args,
+		struct op_context **context, struct fid_cq *cq);
+
+int generic_tx_datacheck(const struct test_arguments *arguments,
+		const uint8_t *buffer, size_t len);
+
+int generic_rx_datacheck(const struct test_arguments *args,
+		const uint8_t *buffer, size_t rx_peers, size_t len);
+
+static int generic_fini_buffer(const struct test_arguments *arguments,
+		uint8_t *buffer);

--- a/fabtests/hpcs/src/test/onesided.c
+++ b/fabtests/hpcs/src/test/onesided.c
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <limits.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <rdma/fi_errno.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_rma.h>
+#include <rdma/fi_atomic.h>
+
+#include <test/user.h>
+
+
+_Static_assert((TEST_API_VERSION_MAJOR == 0), "bad version");
+
+enum dest_mode {
+	SHARED_DEST,	/* senders all write to same offset */
+	SEPARATE_DEST	/* senders write to different offset */
+};
+
+enum test_op {
+	READ,
+	WRITE,
+	ADD
+};
+
+struct test_arguments {
+	size_t transfer_size;
+	enum dest_mode dest_mode;
+	enum test_op test_op;
+	size_t repeat;
+};
+
+#define DEFAULT_TRANSFER_SIZE 4
+#define DEFAULT_DEST_MODE SEPARATE_DEST
+#define DEFAULT_TEST_OP WRITE
+
+static int parse_arguments(
+		const int argc,
+		char * const *argv,
+		struct test_arguments **arguments,
+		size_t *buffer_size)
+{
+	int longopt_idx=0, op;
+	static struct option longopt[] = {
+		{"size", required_argument, 0, 's'},
+		{"dest-mode", required_argument, 0, 'd'},
+		{"op", required_argument, 0, 'o'},
+		{"repeat", required_argument, 0, 'r'},
+		{"help", no_argument, 0, 'h'},
+		{0}
+	};
+
+	struct test_arguments *args = calloc(sizeof(struct test_arguments), 1);
+	if (!args)
+		return -ENOMEM;
+
+	*args = (struct test_arguments) {
+		.transfer_size = DEFAULT_TRANSFER_SIZE,
+		.dest_mode = DEFAULT_DEST_MODE,
+		.test_op = DEFAULT_TEST_OP,
+		.repeat = 1
+	};
+
+	if (argc > 0 && argv != NULL) {
+		while ((op = getopt_long(argc, argv, "s:d:o:r:h", longopt, &longopt_idx)) != -1) {
+			switch (op) {
+			case 's':
+				if (sscanf(optarg, "%zu", &args->transfer_size) != 1) {
+					fprintf(stderr, "failed to parse transfer size\n");
+					return -EINVAL;
+				}
+				break;
+			case 'd':
+				if (strcmp(optarg, "shared-dest") == 0) {
+					args->dest_mode = SHARED_DEST;
+				} else if (strcmp(optarg, "separate-dest") == 0) {
+					args->dest_mode = SEPARATE_DEST;
+				} else {
+					fprintf(stderr, "unable to parse one-sided destination buffer mode\n");
+					return -EINVAL;
+				}
+				break;
+			case 'o':
+				if (strcmp(optarg, "write") == 0) {
+					args->test_op = WRITE;
+				} else if (strcmp(optarg, "read") == 0) {
+					args->test_op = READ;
+				} else if (strcmp(optarg, "add") == 0) {
+					args->test_op = ADD;
+				} else {
+					fprintf(stderr, "unable to parse one-sided test op\n");
+					return -EINVAL;
+				}
+				break;
+			case 'r':
+				if (sscanf(optarg, "%zu", &args->repeat) != 1)
+				 	return -EINVAL;
+				break;
+			case 'h':
+			default:
+				fprintf(stderr, "<test arguments> := \n"
+						"\t[-s | --size=<transfer size>]\n"
+						"\t[-d | --dest_mode=<shared_dest|separate_dest>]\n"
+						"\t[-o | --op=<write|read|add>]\n"
+						"\t[-r | --repeat<N>]\n"
+						"\t[-h | --help]\n");
+				return -EINVAL;
+			}
+		}
+	}
+
+	*buffer_size = args->transfer_size;
+	*arguments = args;
+
+	return 0;
+}
+
+static
+void free_arguments(struct test_arguments *arguments)
+{
+	free (arguments);
+	return;
+}
+
+
+static
+struct test_config config(const struct test_arguments *arguments)
+{
+	struct test_config config = {
+
+		.minimum_caps = FI_RMA | FI_ATOMIC | FI_RMA_EVENT,
+
+		.tx_use_cntr = false,
+		.rx_use_cntr = true,
+		.tx_use_cq = true,
+		.rx_use_cq = false,
+
+		.rx_use_mr = true,
+
+		.tx_buffer_size = arguments->transfer_size,
+		.rx_buffer_size = arguments->transfer_size,
+		.tx_buffer_alignment = 0,
+		.rx_buffer_alignment = 0,
+
+		.tx_data_object_sharing = DATA_OBJECT_PER_DOMAIN,
+		.rx_data_object_sharing = DATA_OBJECT_PER_TRANSFER,
+
+		.tx_context_count = arguments->repeat,
+		.rx_context_count = arguments->repeat,
+
+		.mr_rx_flags =
+				arguments->test_op == READ
+					? FI_REMOTE_READ
+					: FI_REMOTE_WRITE
+	};
+
+	return config;
+}
+
+
+static void tx_init_buffer(
+		const struct test_arguments *arguments,
+		uint8_t *buffer)
+{
+	switch (arguments->test_op) {
+	case WRITE:
+		memset (buffer, UCHAR_MAX, arguments->transfer_size);
+		break;
+	case READ:
+		memset (buffer, 0, arguments->transfer_size);
+		break;
+	case ADD:
+		memset (buffer, 1, arguments->transfer_size);
+		break;
+	}
+}
+
+static void rx_init_buffer(
+		const struct test_arguments *arguments,
+		uint8_t *buffer)
+{
+	switch (arguments->test_op) {
+	case WRITE:
+	case ADD:
+		memset (buffer, 0, arguments->transfer_size);
+		break;
+	case READ:
+		memset (buffer, UCHAR_MAX, arguments->transfer_size);
+		break;
+	}
+}
+
+struct fid_mr *create_mr(
+		const struct test_arguments *arguments,
+		struct fid_domain *domain,
+		const uint64_t key,
+		uint8_t *buffer,
+		size_t len,
+		uint64_t access)
+{
+	int ret;
+	struct fid_mr *mr;
+	const uint64_t offset = 0;
+	const uint64_t flags = FI_RMA_EVENT;
+	void *context = NULL;
+
+	ret = fi_mr_reg(
+			domain,
+			buffer,
+			len,
+			access,
+			offset,
+			key,
+			flags,
+			&mr,
+			context);
+	if (ret)
+		goto err_mr_reg;
+
+	return mr;
+
+err_mr_reg:
+	fprintf(stderr, "fi_mr_reg failed\n");
+	return NULL;
+}
+
+static int destroy_mr(const struct test_arguments *arguments, struct fid_mr *mr)
+{
+	return fi_close(&mr->fid);
+}
+
+static size_t tx_window_usage(
+		const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count)
+{
+	return 1;
+}
+
+static size_t rx_window_usage (
+		const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count)
+{
+	return 1;
+}
+
+
+static int tx_transfer(
+		const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count,
+		const fi_addr_t rx_address,
+		struct fid_ep *endpoint,
+		struct op_context *op_context,
+		uint8_t *buffer,
+		void *desc,
+		uint64_t key,
+		int rank,
+		struct fid_cntr *tx_cntr,
+		struct fid_cntr *rx_cntr
+){
+	size_t addr = 0;
+	int ret = 0;
+	int i;
+	struct context_info *ctxinfo = op_context->ctxinfo;
+
+	switch (arguments->dest_mode) {
+	case SHARED_DEST:
+		break;
+	case SEPARATE_DEST:
+		addr = rank * arguments->transfer_size;
+		break;
+	default:
+		return -FI_EINVAL;
+		break;
+	}
+
+	for (i=0; i<arguments->repeat; i++) {
+		switch (arguments->test_op) {
+		case WRITE:
+			ret = fi_write(endpoint,
+					buffer,
+					arguments->transfer_size,
+					desc,
+					rx_address,
+					addr,
+					key,
+					&ctxinfo[i].fi_context);
+			break;
+		case READ:
+			ret = fi_read(endpoint,
+					buffer,
+					arguments->transfer_size,
+					desc,
+					rx_address,
+					addr,
+					key,
+					&ctxinfo[i].fi_context);
+			break;
+
+		case ADD:
+			ret = fi_atomic(endpoint,
+					buffer,
+					arguments->transfer_size,
+					desc,
+					rx_address,
+					addr,
+					key,
+					FI_UINT8,
+					FI_SUM,
+					&ctxinfo[i]);
+			break;
+
+		default:
+			return -FI_ENOSYS;
+			break;
+		}
+	}
+
+	return ret;
+}
+
+/* RMA memory region for receive is set up in advance; nothing to do. */
+static int rx_transfer(
+		const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count,
+		const fi_addr_t tx_address,
+		struct fid_ep *endpoint,
+		struct op_context *op_context,
+		uint8_t *buffer,
+		void *desc,
+		struct fid_cntr *tx_cntr,
+		struct fid_cntr *rx_cntr)
+{
+	return 0;
+}
+
+
+static int tx_cntr_completion(
+		const struct test_arguments *arguments,
+		const size_t completion_count,
+		struct fid_cntr *cntr)
+{
+	return fi_cntr_wait(cntr, completion_count*arguments->repeat, -1);
+}
+
+static int rx_cntr_completion(
+		const struct test_arguments *arguments,
+		const size_t completion_count,
+		struct fid_cntr *cntr)
+{
+	return fi_cntr_wait(cntr, completion_count*arguments->repeat, -1);
+}
+
+static int cq_completion(
+		const struct test_arguments *args,
+		struct op_context **op_contextp,
+		struct fid_cq *cq)
+{
+	ssize_t ret;
+	struct fi_cq_tagged_entry cq_entry;
+	struct context_info *ctxinfo;
+	struct op_context *op_context;
+
+	while (1) {
+		ret = fi_cq_read(cq, (void *) &cq_entry, 1);
+
+		if (ret == 1) {
+			ctxinfo = (struct context_info *)(cq_entry.op_context);
+			op_context = ctxinfo->op_context;
+			op_context->test_state++;
+
+			if (op_context->test_state == args->repeat) {
+				*op_contextp = op_context;
+				break;
+			}
+
+			continue;
+		}
+
+		if (ret == -FI_EAVAIL) {
+			struct fi_cq_err_entry err;
+
+			ret = fi_cq_readerr(cq, &err, 0);
+			if (ret < 0) {
+				fprintf(stderr, "unable to read error completion\n");
+			} else {
+				fprintf(stderr,
+						"cq_read error ctx %p len %ld tag %ld err %d (%s) prov_errno %d err_data %p err_data_size %ld\n",
+						err.op_context, err.len, err.tag,
+						err.err,
+						fi_cq_strerror(cq, err.prov_errno, err.err_data, NULL, 0),
+						err.prov_errno, err.err_data,
+						err.err_data_size);
+			}
+		}
+
+		return ret;
+	}
+
+	return 0;
+}
+
+static int tx_cq_completion(
+		const struct test_arguments *args,
+		struct op_context **context,
+		struct fid_cq *cq)
+{
+	return cq_completion(args, context, cq);
+}
+
+
+static int datacheck(
+		const struct test_arguments *arguments,
+		const uint8_t *buffer,
+		uint8_t expected,
+		size_t len)
+{
+	int our_ret = FI_SUCCESS;
+	size_t b;
+
+	for (b = 0; b < len; b += 1) {
+		if (((uint8_t *) buffer)[b] != expected) {
+			fprintf (stderr, "datacheck failed at byte %zu (expected %u, got %u)\n",
+					b, expected, ((uint8_t *) buffer)[b]);
+			our_ret = -EIO;
+			goto err_data_check;
+		}
+	}
+
+err_data_check:
+	return our_ret;
+}
+
+static int tx_datacheck(
+		const struct test_arguments *arguments,
+		const uint8_t *buffer)
+{
+	uint8_t expected;
+
+	switch (arguments->test_op) {
+	case READ:
+	case WRITE:
+		expected = UINT8_MAX; break;
+	case ADD:
+		expected = 1; break;
+	default:
+		return -FI_EINVAL;
+	}
+
+	return datacheck(
+		arguments,
+		buffer,
+		expected,
+		arguments->transfer_size);
+}
+
+static int rx_datacheck(
+		const struct test_arguments *args,
+		const uint8_t *buffer,
+		size_t rx_peers)
+{
+	uint8_t expected;
+	size_t len;
+
+	switch (args->test_op) {
+	case READ:
+	case WRITE:
+		expected = UINT8_MAX;
+		break;
+	case ADD:
+		expected =
+			args->test_op == ADD
+				? args->dest_mode == SHARED_DEST
+					? rx_peers * args->repeat
+					: args->repeat
+				: UINT8_MAX;
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+
+	len = args->dest_mode == SHARED_DEST
+		? args->transfer_size
+		: args->transfer_size * rx_peers;
+
+	return datacheck(
+			args,
+			buffer,
+			expected,
+			len);
+}
+
+
+static int fini_buffer(
+	const struct test_arguments *arguments,
+	uint8_t *buffer)
+{
+	return 0;
+}
+
+struct test_api test_api(void)
+{
+	struct test_api api = {
+		.parse_arguments = &parse_arguments,
+		.free_arguments = &free_arguments,
+
+		.config = &config,
+
+		.tx_init_buffer = &tx_init_buffer,
+		.rx_init_buffer = &rx_init_buffer,
+		.tx_create_mr = &create_mr,
+		.rx_create_mr = &create_mr,
+
+		.tx_window_usage = &tx_window_usage,
+		.rx_window_usage = &rx_window_usage,
+
+		.tx_transfer = &tx_transfer,
+		.rx_transfer = &rx_transfer,
+		.tx_cntr_completion = &tx_cntr_completion,
+		.rx_cntr_completion = &rx_cntr_completion,
+		.tx_cq_completion = &tx_cq_completion,
+		.rx_cq_completion = NULL,
+
+		.tx_datacheck = &tx_datacheck,
+		.rx_datacheck = &rx_datacheck,
+
+		.tx_fini_buffer = &fini_buffer,
+		.rx_fini_buffer = &fini_buffer,
+		.tx_destroy_mr = &destroy_mr,
+		.rx_destroy_mr = &destroy_mr
+	};
+
+	return api;
+}

--- a/fabtests/hpcs/src/test/onesided.c
+++ b/fabtests/hpcs/src/test/onesided.c
@@ -46,9 +46,6 @@
 
 #include <test/user.h>
 
-
-_Static_assert((TEST_API_VERSION_MAJOR == 0), "bad version");
-
 enum dest_mode {
 	SHARED_DEST,	/* senders all write to same offset */
 	SEPARATE_DEST	/* senders write to different offset */
@@ -83,6 +80,7 @@ static int parse_arguments(
 	static struct option longopt[] = {
 		{"size", required_argument, 0, 's'},
 		{"dest-mode", required_argument, 0, 'd'},
+		{"offset-mode", required_argument, 0, 'm'},
 		{"op", required_argument, 0, 'o'},
 		{"repeat", required_argument, 0, 'r'},
 		{"workqueue", no_argument, 0, 'w'},
@@ -101,55 +99,58 @@ static int parse_arguments(
 		.repeat = 1
 	};
 
-	if (argc > 0 && argv != NULL) {
-		while ((op = getopt_long(argc, argv, "s:d:o:r:wh", longopt, &longopt_idx)) != -1) {
-			switch (op) {
-			case 's':
-				if (sscanf(optarg, "%zu", &args->transfer_size) != 1) {
-					fprintf(stderr, "failed to parse transfer size\n");
-					return -EINVAL;
-				}
-				break;
-			case 'd':
-				if (strcmp(optarg, "shared-dest") == 0) {
-					args->dest_mode = SHARED_DEST;
-				} else if (strcmp(optarg, "separate-dest") == 0) {
-					args->dest_mode = SEPARATE_DEST;
-				} else {
-					fprintf(stderr, "unable to parse one-sided destination buffer mode\n");
-					return -EINVAL;
-				}
-				break;
-			case 'o':
-				if (strcmp(optarg, "write") == 0) {
-					args->test_op = WRITE;
-				} else if (strcmp(optarg, "read") == 0) {
-					args->test_op = READ;
-				} else if (strcmp(optarg, "add") == 0) {
-					args->test_op = ADD;
-				} else {
-					fprintf(stderr, "unable to parse one-sided test op\n");
-					return -EINVAL;
-				}
-				break;
-			case 'r':
-				if (sscanf(optarg, "%zu", &args->repeat) != 1)
-				 	return -EINVAL;
-				break;
-			case 'w':
-				args->use_workqueue = 1;
-				break;
-			case 'h':
-			default:
-				fprintf(stderr, "<test arguments> := \n"
-						"\t[-s | --size=<transfer size>]\n"
-						"\t[-d | --dest_mode=<shared_dest|separate_dest>]\n"
-						"\t[-o | --op=<write|read|add>]\n"
-						"\t[-r | --repeat<N>]\n"
-						"\t[-w | --workqueue]\n"
-						"\t[-h | --help]\n");
+	while ((op = getopt_long(argc, argv, "s:d:m:o:r:wh", longopt, &longopt_idx)) != -1) {
+		switch (op) {
+		case 's':
+			if (sscanf(optarg, "%zu", &args->transfer_size) != 1) {
+				fprintf(stderr, "failed to parse transfer size\n");
 				return -EINVAL;
 			}
+			break;
+		case 'd':
+		case 'm':
+			if (strcmp(optarg, "shared-dest") == 0 ||
+					strcmp(optarg, "same-offset") == 0)
+			{
+				args->dest_mode = SHARED_DEST;
+			} else if (strcmp(optarg, "separate-dest") == 0 ||
+					strcmp(optarg, "different-offset") == 0)
+			{
+				args->dest_mode = SEPARATE_DEST;
+			} else {
+				fprintf(stderr, "unable to parse one-sided destination buffer mode\n");
+				return -EINVAL;
+			}
+			break;
+		case 'o':
+			if (strcmp(optarg, "write") == 0) {
+				args->test_op = WRITE;
+			} else if (strcmp(optarg, "read") == 0) {
+				args->test_op = READ;
+			} else if (strcmp(optarg, "add") == 0) {
+				args->test_op = ADD;
+			} else {
+				fprintf(stderr, "unable to parse one-sided test op\n");
+				return -EINVAL;
+			}
+			break;
+		case 'r':
+			if (sscanf(optarg, "%zu", &args->repeat) != 1)
+			 	return -EINVAL;
+			break;
+		case 'w':
+			args->use_workqueue = 1;
+			break;
+		case 'h':
+		default:
+			fprintf(stderr, "<test arguments> := \n"
+					"\t[-s | --size=<transfer size>]\n"
+					"\t[-m | --offset-mode=<same-offset|different-offset>]\n"
+					"\t[-o | --op=<write|read|add>]\n"
+					"\t[-r | --repeat<n>]\n"
+					"\t[-w | --workqueue]\n"
+					"\t[-h | --help]\n");
+			return -EINVAL;
 		}
 	}
 
@@ -204,91 +205,43 @@ struct test_config config(const struct test_arguments *arguments)
 
 static void tx_init_buffer(
 		const struct test_arguments *arguments,
-		uint8_t *buffer)
-{
-	switch (arguments->test_op) {
-	case WRITE:
-		memset (buffer, UCHAR_MAX, arguments->transfer_size);
-		break;
-	case READ:
-		memset (buffer, 0, arguments->transfer_size);
-		break;
-	case ADD:
-		memset (buffer, 1, arguments->transfer_size);
-		break;
-	}
-}
-
-static void rx_init_buffer(
-		const struct test_arguments *arguments,
-		uint8_t *buffer)
-{
-	switch (arguments->test_op) {
-	case WRITE:
-	case ADD:
-		memset (buffer, 0, arguments->transfer_size);
-		break;
-	case READ:
-		memset (buffer, UCHAR_MAX, arguments->transfer_size);
-		break;
-	}
-}
-
-struct fid_mr *create_mr(
-		const struct test_arguments *arguments,
-		struct fid_domain *domain,
-		const uint64_t key,
 		uint8_t *buffer,
-		size_t len,
-		uint64_t access)
+		size_t len)
 {
-	int ret;
-	struct fid_mr *mr;
-	const uint64_t offset = 0;
-	const uint64_t flags = FI_RMA_EVENT;
-	void *context = NULL;
-
-	ret = fi_mr_reg(
-			domain,
-			buffer,
-			len,
-			access,
-			offset,
-			key,
-			flags,
-			&mr,
-			context);
-	if (ret)
-		goto err_mr_reg;
-
-	return mr;
-
-err_mr_reg:
-	fprintf(stderr, "fi_mr_reg failed\n");
-	return NULL;
+	switch (arguments->test_op) {
+	case WRITE:
+		memset(buffer, UCHAR_MAX, arguments->transfer_size);
+		break;
+	case READ:
+		memset(buffer, 0, arguments->transfer_size);
+		break;
+	case ADD:
+		memset(buffer, 1, arguments->transfer_size);
+		break;
+	}
 }
 
-static int destroy_mr(const struct test_arguments *arguments, struct fid_mr *mr)
+static struct fid_mr *rx_create_mr(const struct test_arguments *arguments,
+                struct fid_domain *domain, const uint64_t key,
+                uint8_t *buffer, size_t len, uint64_t access, uint64_t flags)
 {
-	return fi_close(&mr->fid);
+	return test_generic_rx_create_mr(arguments, domain, key,
+			buffer, len, access, flags | FI_RMA_EVENT);
 }
 
-static size_t tx_window_usage(
-		const struct test_arguments *arguments,
-		const size_t transfer_id,
-		const size_t transfer_count)
+static void rx_init_buffer(const struct test_arguments *arguments,
+		uint8_t *buffer, size_t len)
 {
-	return 1;
+	switch (arguments->test_op) {
+	case WRITE:
+	case ADD:
+		memset(buffer, 0, arguments->transfer_size);
+		break;
+	case READ:
+		memset(buffer, UCHAR_MAX, arguments->transfer_size);
+		break;
+	}
 }
-
-static size_t rx_window_usage (
-		const struct test_arguments *arguments,
-		const size_t transfer_id,
-		const size_t transfer_count)
-{
-	return 1;
-}
-
 
 static int tx_transfer(
 		const struct test_arguments *arguments,
@@ -301,8 +254,6 @@ static int tx_transfer(
 		void *desc,
 		uint64_t key,
 		int rank,
-		struct fid_cntr *tx_cntr,
-		struct fid_cntr *rx_cntr,
 		uint64_t flags
 ){
 	size_t addr = 0;
@@ -439,105 +390,17 @@ static int tx_transfer(
 }
 
 /* RMA memory region for receive is set up in advance; nothing to do. */
-static int rx_transfer(
-		const struct test_arguments *arguments,
-		const size_t transfer_id,
-		const size_t transfer_count,
-		const fi_addr_t tx_address,
-		struct fid_ep *endpoint,
+static int rx_transfer(const struct test_arguments *arguments,
+		const size_t transfer_id, const size_t transfer_count,
+		const fi_addr_t tx_address, struct fid_ep *endpoint,
 		struct op_context *op_context,
-		uint8_t *buffer,
-		void *desc,
-		struct fid_cntr *tx_cntr,
-		struct fid_cntr *rx_cntr,
-		uint64_t flags)
+		uint8_t *buffer, void *desc, uint64_t flags)
 {
 	return 0;
 }
 
-
-static int tx_cntr_completion(
-		const struct test_arguments *arguments,
-		const size_t completion_count,
-		struct fid_cntr *cntr)
-{
-	return fi_cntr_wait(cntr, completion_count*arguments->repeat, -1);
-}
-
-static int rx_cntr_completion(
-		const struct test_arguments *arguments,
-		const size_t completion_count,
-		struct fid_cntr *cntr)
-{
-	return fi_cntr_wait(cntr, completion_count*arguments->repeat, -1);
-}
-
-int cq_completion(
-		const struct test_arguments *args,
-		struct op_context **op_contextp,
-		struct fid_cq *cq)
-{
-	ssize_t ret;
-	struct fi_cq_tagged_entry cq_entry;
-	struct context_info *ctxinfo;
-	struct op_context *op_context;
-
-	while (1) {
-		ret = fi_cq_read(cq, (void *) &cq_entry, 1);
-
-		if (ret == 1) {
-			ctxinfo = (struct context_info *)(cq_entry.op_context);
-			op_context = ctxinfo->op_context;
-			op_context->test_state++;
-
-			if (op_context->test_state == args->repeat) {
-				*op_contextp = op_context;
-				break;
-			}
-
-			continue;
-		}
-
-		if (ret == -FI_EAVAIL) {
-			struct fi_cq_err_entry err;
-
-			ret = fi_cq_readerr(cq, &err, 0);
-			if (ret < 0) {
-				fprintf(stderr, "unable to read error completion\n");
-			} else {
-				fprintf(stderr,
-						"cq_read error ctx %p len %ld tag %ld err %d (%s) prov_errno %d err_data %p err_data_size %ld\n",
-						err.op_context, err.len, err.tag,
-						err.err,
-						fi_cq_strerror(cq, err.prov_errno, err.err_data, NULL, 0),
-						err.prov_errno, err.err_data,
-						err.err_data_size);
-			}
-		}
-
-		return ret;
-	}
-
-	return 0;
-}
-
-#ifdef __GNUC__
-__attribute__ ((unused))
-#endif
-static int tx_cq_completion(
-		const struct test_arguments *args,
-		struct op_context **context,
-		struct fid_cq *cq)
-{
-	return cq_completion(args, context, cq);
-}
-
-
-static int datacheck(
-		const struct test_arguments *arguments,
-		const uint8_t *buffer,
-		uint8_t expected,
-		size_t len)
+static int datacheck(const struct test_arguments *arguments,
+		const uint8_t *buffer, uint8_t expected, size_t len)
 {
 	int our_ret = FI_SUCCESS;
 	size_t b;
@@ -555,9 +418,8 @@ err_data_check:
 	return our_ret;
 }
 
-static int tx_datacheck(
-		const struct test_arguments *arguments,
-		const uint8_t *buffer)
+static int tx_datacheck(const struct test_arguments *arguments,
+		const uint8_t *buffer, size_t len)
 {
 	uint8_t expected;
 
@@ -571,20 +433,13 @@ static int tx_datacheck(
 		return -FI_EINVAL;
 	}
 
-	return datacheck(
-		arguments,
-		buffer,
-		expected,
-		arguments->transfer_size);
+	return datacheck(arguments, buffer, expected, arguments->transfer_size);
 }
 
-static int rx_datacheck(
-		const struct test_arguments *args,
-		const uint8_t *buffer,
-		size_t rx_peers)
+static int rx_datacheck(const struct test_arguments *args,
+		const uint8_t *buffer, size_t len, size_t rx_peers)
 {
 	uint8_t expected;
-	size_t len;
 
 	switch (args->test_op) {
 	case READ:
@@ -607,19 +462,7 @@ static int rx_datacheck(
 		? args->transfer_size
 		: args->transfer_size * rx_peers;
 
-	return datacheck(
-			args,
-			buffer,
-			expected,
-			len);
-}
-
-
-static int fini_buffer(
-	const struct test_arguments *arguments,
-	uint8_t *buffer)
-{
-	return 0;
+	return datacheck(args, buffer, expected, len);
 }
 
 struct test_api test_api(void)
@@ -632,26 +475,26 @@ struct test_api test_api(void)
 
 		.tx_init_buffer = &tx_init_buffer,
 		.rx_init_buffer = &rx_init_buffer,
-		.tx_create_mr = &create_mr,
-		.rx_create_mr = &create_mr,
+		.tx_create_mr = &test_generic_tx_create_mr,
+		.rx_create_mr = &rx_create_mr,
 
-		.tx_window_usage = &tx_window_usage,
-		.rx_window_usage = &rx_window_usage,
+		.tx_window_usage = &test_generic_tx_window_usage,
+		.rx_window_usage = &test_generic_rx_window_usage,
 
 		.tx_transfer = &tx_transfer,
 		.rx_transfer = &rx_transfer,
-		.tx_cntr_completion = &tx_cntr_completion,
-		.rx_cntr_completion = &rx_cntr_completion,
+		.tx_cntr_completion = &test_generic_tx_cntr_completion,
+		.rx_cntr_completion = &test_generic_rx_cntr_completion,
 		.tx_cq_completion = NULL,
 		.rx_cq_completion = NULL,
 
 		.tx_datacheck = &tx_datacheck,
 		.rx_datacheck = &rx_datacheck,
 
-		.tx_fini_buffer = &fini_buffer,
-		.rx_fini_buffer = &fini_buffer,
-		.tx_destroy_mr = &destroy_mr,
-		.rx_destroy_mr = &destroy_mr
+		.tx_fini_buffer = &test_generic_tx_fini_buffer,
+		.rx_fini_buffer = &test_generic_rx_fini_buffer,
+		.tx_destroy_mr = &test_generic_tx_destroy_mr,
+		.rx_destroy_mr = &test_generic_rx_destroy_mr
 	};
 
 	return api;

--- a/fabtests/hpcs/src/test/sendrecv.c
+++ b/fabtests/hpcs/src/test/sendrecv.c
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2017-2018 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <limits.h>
+#include <string.h>
+#include <stdio.h>
+#include <errno.h>
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+#include <unistd.h>
+#include <getopt.h>
+
+#include <rdma/fi_errno.h>
+#include <rdma/fi_eq.h>
+#include <rdma/fi_tagged.h>
+
+#include <test/user.h>
+
+
+_Static_assert((TEST_API_VERSION_MAJOR == 0), "bad version");
+
+#define DEFAULT_TRANSFER_SIZE 4
+
+struct test_arguments {
+	size_t transfer_size;
+};
+
+static int parse_arguments(
+		const int argc,
+		char * const *argv,
+		struct test_arguments **arguments,
+		size_t *buffer_size)
+{
+	int longopt_idx=0, op;
+	static struct option longopt[] = {
+		{"size", required_argument, 0, 's'},
+		{"help", no_argument, 0, 'h'},
+		{0}
+	};
+
+	struct test_arguments *args = calloc(sizeof(struct test_arguments), 1);
+	if (args == NULL)
+		return -ENOMEM;
+
+	*args = (struct test_arguments) {
+		.transfer_size = DEFAULT_TRANSFER_SIZE
+	};
+
+	if (argc > 0 && argv != NULL) {
+		while ((op = getopt_long(argc, argv, "s:h", longopt, &longopt_idx)) != -1) {
+			switch (op) {
+			case 's':
+				if (sscanf(optarg, "%zu", &args->transfer_size) != 1)
+					return -EINVAL;
+				break;
+			case 'h':
+			default:
+				fprintf(stderr, "<test arguments> :=\n"
+						"\t[-s | --size=<size>]\n"
+						"\t[-h | --help]\n");
+				return -EINVAL;
+				break;
+			}
+		}
+	}
+
+	*buffer_size = args->transfer_size;
+	*arguments = args;
+
+	return 0;
+}
+
+void free_arguments (struct test_arguments *arguments)
+{
+	free (arguments);
+	return;
+}
+
+
+static struct test_config config(const struct test_arguments *arguments)
+{
+	struct test_config config = {
+
+		.minimum_caps = FI_TAGGED | FI_SEND | FI_RECV,
+
+		.tx_use_cntr = false,
+		.rx_use_cntr = false,
+		.tx_use_cq = true,
+		.rx_use_cq = true,
+
+		.rx_use_mr = false,
+
+		.tx_buffer_size = arguments->transfer_size,
+		.rx_buffer_size = arguments->transfer_size,
+		.tx_buffer_alignment = 0,
+		.rx_buffer_alignment = 0,
+
+		.tx_data_object_sharing = DATA_OBJECT_PER_DOMAIN,
+		.rx_data_object_sharing = DATA_OBJECT_PER_TRANSFER,
+
+		.tx_context_count = 1,
+		.rx_context_count = 1,
+	};
+
+	return config;
+}
+
+
+static void tx_init_buffer(
+		const struct test_arguments *arguments,
+		uint8_t *buffer)
+{
+	memset(buffer, UCHAR_MAX, arguments->transfer_size);
+}
+
+static void rx_init_buffer(
+		const struct test_arguments *arguments,
+		uint8_t *buffer)
+{
+	memset (buffer, 0, arguments->transfer_size);
+}
+
+static struct fid_mr *tx_create_mr(
+		const struct test_arguments *arguments,
+		struct fid_domain *domain,
+		const uint64_t key,
+		uint8_t *buffer,
+		size_t len,
+		uint64_t access)
+{
+	int ret;
+
+	struct fid_mr *mr;
+
+	const uint64_t offset = 0;
+	const uint64_t flags = 0;
+	void *context = NULL;
+	ret = fi_mr_reg (
+			domain,
+			buffer,
+			arguments->transfer_size,
+			access,
+			offset,
+			key,
+			flags,
+			&mr,
+			context);
+	if (ret)
+		goto err_mr_reg;
+
+	return mr;
+
+err_mr_reg:
+	fprintf(stderr, "fi_mr_reg failed (ret %d)\n", ret);
+
+	return NULL;
+}
+
+static int destroy_mr(const struct test_arguments *arguments, struct fid_mr *mr)
+{
+        return fi_close(&mr->fid);
+}
+
+static size_t tx_window_usage(
+		const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count)
+{
+	return 1;
+}
+
+static size_t rx_window_usage(
+		const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count)
+{
+	return 1;
+}
+
+static int tx_transfer(
+		const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count,
+		const fi_addr_t rx_address,
+		struct fid_ep *endpoint,
+		struct op_context *op_context,
+		uint8_t *buffer,
+		void *desc,
+		uint64_t key,
+		int rank,
+		struct fid_cntr *tx_cntr,
+		struct fid_cntr *rx_cntr)
+{
+	const uint64_t tag = transfer_id;
+	return fi_tsend (
+			endpoint,
+			buffer,
+			arguments->transfer_size,
+			desc,
+			rx_address,
+			tag,
+			&op_context->ctxinfo[0].fi_context);
+}
+
+static int rx_transfer(
+		const struct test_arguments *arguments,
+		const size_t transfer_id,
+		const size_t transfer_count,
+		const fi_addr_t tx_address,
+		struct fid_ep *endpoint,
+		struct op_context *op_context,
+		uint8_t *buffer,
+		void *desc,
+		struct fid_cntr *tx_cntr,
+		struct fid_cntr *rx_cntr)
+{
+	const uint64_t tag = transfer_id;
+	const uint64_t ignore = 0;
+	return fi_trecv(
+			endpoint,
+			buffer,
+			arguments->transfer_size,
+			desc,
+			tx_address,
+			tag,
+			ignore,
+			&op_context->ctxinfo[0].fi_context);
+}
+
+
+static int tx_cntr_completion(
+		const struct test_arguments *arguments,
+		const size_t completion_count,
+		struct fid_cntr *cntr)
+{
+	return fi_cntr_wait (cntr, completion_count, -1);
+}
+
+static int rx_cntr_completion (
+	const struct test_arguments *arguments,
+	const size_t completion_count,
+	struct fid_cntr *cntr)
+{
+	return fi_cntr_wait(cntr, completion_count, -1);
+}
+
+static int cq_completion (
+	struct op_context **context,
+	struct fid_cq *cq)
+{
+	ssize_t ret;
+	struct fi_cq_tagged_entry cq_entry;
+
+	ret = fi_cq_read (cq, (void *) &cq_entry, 1);
+	if (ret == 1) {
+		struct context_info *ctxinfo = (struct context_info *)(cq_entry.op_context);
+		*context = ctxinfo->op_context;
+		return 0;
+	}
+
+	return ret;
+}
+
+static int tx_cq_completion(
+		const struct test_arguments *arguments,
+		struct op_context **context,
+		struct fid_cq *cq)
+{
+	return cq_completion(context, cq);
+}
+
+static int rx_cq_completion(
+		const struct test_arguments *arguments,
+		struct op_context **context,
+		struct fid_cq *cq)
+{
+	return cq_completion(context, cq);
+}
+
+
+static int datacheck(
+		const struct test_arguments *arguments,
+		const uint8_t *buffer)
+{
+	int our_ret = FI_SUCCESS;
+	size_t b;
+
+	for (b = 0; b < arguments->transfer_size; b += 1) {
+		if (((uint8_t *) buffer)[b] != UINT8_MAX) {
+			fprintf(stderr, "datacheck failed at byte %zu\n", b);
+			our_ret = -EIO;
+			goto err_data_check;
+		}
+	}
+
+err_data_check:
+	return our_ret;
+}
+
+static int tx_datacheck(
+		const struct test_arguments *arguments,
+		const uint8_t *buffer)
+{
+	return datacheck(arguments, buffer);
+}
+
+static int rx_datacheck(
+		const struct test_arguments *arguments,
+		const uint8_t *buffer,
+		size_t rx_peers)
+{
+	return datacheck(arguments, buffer);
+}
+
+static int tx_fini_buffer(
+		const struct test_arguments *arguments,
+		uint8_t *buffer)
+{
+	return 0;
+}
+
+static int rx_fini_buffer(
+		const struct test_arguments *arguments,
+		uint8_t *buffer)
+{
+	return 0;
+}
+
+
+struct test_api test_api(void)
+{
+	struct test_api api = {
+		.parse_arguments = &parse_arguments,
+		.free_arguments = &free_arguments,
+
+		.config = &config,
+
+		.tx_init_buffer = &tx_init_buffer,
+		.rx_init_buffer = &rx_init_buffer,
+		.tx_create_mr = &tx_create_mr,
+		.rx_create_mr = NULL,
+
+		.tx_window_usage = &tx_window_usage,
+		.rx_window_usage = &rx_window_usage,
+
+		.tx_transfer = &tx_transfer,
+		.rx_transfer = &rx_transfer,
+		.tx_cntr_completion = &tx_cntr_completion,
+		.rx_cntr_completion = &rx_cntr_completion,
+		.tx_cq_completion = &tx_cq_completion,
+		.rx_cq_completion = &rx_cq_completion,
+
+		.tx_datacheck = &tx_datacheck,
+		.rx_datacheck = &rx_datacheck,
+
+		.tx_fini_buffer = &tx_fini_buffer,
+		.rx_fini_buffer = &rx_fini_buffer,
+		.tx_destroy_mr = &destroy_mr,
+		.rx_destroy_mr = NULL
+	};
+
+	return api;
+}


### PR DESCRIPTION
HPCS (high-performance connection scaling) is a unit test framework to generate network traffic between an arbitrary number of nodes according to some traffic pattern.

HPCS uses MPI for address exchange, node identity, and barriers and OFI for the actual data transfer.