### PR TITLE
test_configs/ofi_rxd: disable prefix tests

### DIFF
--- a/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
+++ b/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
@@ -3,6 +3,9 @@
 ^msg|-e msg
 ^dgram|-e dgram
 
+# Exclude all prefix tests
+-k
+
 # Exclude tests that use sread/polling until issues are resolved
 -S
 rdm_cntr_pingpong


### PR DESCRIPTION
The RxD provider doesn't use msg_prefix so exclude those tests.

(The Intel CI tests master periodically in "Strict" mode which treats all "Notrun" results as failures)

Signed-off-by: aingerson <alexia.ingerson@intel.com>