### PR TITLE
prov/rxm: Update man page to note FI_EAGAIN return for on-demand connection setup

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -163,6 +163,12 @@ To conserve memory, ensure FI_UNIVERSE_SIZE set to what is required. Similarly
 check that FI_OFI_RXM_TX_SIZE, FI_OFI_RXM_RX_SIZE, FI_OFI_RXM_MSG_TX_SIZE and
 FI_OFI_RXM_MSG_RX_SIZE env variables are set to only required values.
 
+# NOTES
+
+The data transfer API may return -FI_EAGAIN during on-demand connection setup
+of the core provider FI_MSG_EP. See [`fi_msg`(3)](fi_msg.3.html) for a detailed
+description of handling FI_EAGAIN.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),


### PR DESCRIPTION
Explicitly note that in addition to the expected FI_EAGAIN error return cases described in the fi_msg man page, that FI_EAGAIN should also be expected during on-demand connection setup of the core provider message EP.

Application feedback has indicated that FI_EAGAIN was not expected for the first data transfer operation.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>