### PR TITLE
man: MAN page updates for fi_verbs(7) and fi_rxm(7)

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -44,13 +44,13 @@ result in a stall. See also the ERRORS section in fi_msg(3).
 
 # SUPPORTED FEATURES
 
-The RxM provider currently supports *FI_MSG*, *FI_TAGGED* and *FI_RMA* capabilities.
+The RxM provider currently supports *FI_MSG*, *FI_TAGGED*, *FI_RMA* and *FI_ATOMIC* capabilities.
 
 *Endpoint types*
 : The provider supports only *FI_EP_RDM*.
 
 *Endpoint capabilities*
-: The following data transfer interface is supported: *FI_MSG*, *FI_TAGGED*, *FI_RMA*.
+: The following data transfer interface is supported: *FI_MSG*, *FI_TAGGED*, *FI_RMA*, *FI_ATOMIC*.
 
 *Progress*
 : The RxM provider supports both *FI_PROGRESS_MANUAL* and *FI_PROGRESS_AUTO*.
@@ -73,8 +73,6 @@ up. Please refer to the corresponding MSG provider man pages to find about those
 RxM provider does not support the following features:
 
   * op_flags: FI_FENCE.
-
-  * FI_ATOMIC
 
   * Scalable endpoints
 
@@ -105,6 +103,13 @@ because RxM uses a rendezvous protocol for large message sends. An app would get
 woken up from waiting on CQ fd when rendezvous protocol request completes but it
 would have to wait again to get an ACK from the receiver indicating completion of
 large message transfer by remote RMA read.
+
+## FI_ATOMIC limitations
+
+The FI_ATOMIC capability will only be listed in the fi_info if the fi_info
+hints parameter specifies FI_ATOMIC. If FI_ATOMIC is requested, message order
+FI_ORDER_RAR, FI_ORDER_RAW, FI_ORDER_WAR, FI_ORDER_WAW, FI_ORDER_SAR, and
+FI_ORDER_SAW can not be supported.
 
 # RUNTIME PARAMETERS
 

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -159,6 +159,10 @@ The support for fork in the provider has the following limitations:
     marks the entire page that a memory region belongs to as not to be re-mapped
     when the process is forked (MADV_DONTFORK).
 
+### XRC Transport
+The XRC transport is intended to be used when layered with the RXM provider and
+requires the use of shared receive contexts. See [`fi_rxm`(7)](fi_rxm.7.thml).
+
 # RUNTIME PARAMETERS
 
 The verbs provider checks for the following environment variables.
@@ -202,6 +206,9 @@ The verbs provider checks for the following environment variables.
 
 *FI_VERBS_MR_MAX_CACHED_SIZE*
 : Maximum total size of cache entries (default: 4 GB)
+
+*FI_VERBS_PREFER_XRC*
+: Prioritize XRC transport fi_info before RC transport fi_info (default: 0, RC fi_info will be before XRC fi_info)
 
 ### Variables specific to RDM (internal - deprecated) endpoints
 


### PR DESCRIPTION
MAN page update commits to reflect support for FI_ATOMIC in fi_rxm(7), and mention XRC limitations and the new FI_VERBS_PREFER_XRC parameter in fi_verbs(7).