### PR TITLE
prov/rxm: Fix lack of MSG CQ progress

### DIFF
--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -240,7 +240,7 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
 
 	cq->cq_fastlock_acquire(&cq->cq_lock);
-	if (ofi_cirque_isempty(cq->cirq)) {
+	if (ofi_cirque_isempty(cq->cirq) || !count) {
 		cq->cq_fastlock_release(&cq->cq_lock);
 		cq->progress(cq);
 		cq->cq_fastlock_acquire(&cq->cq_lock);


### PR DESCRIPTION
Most of OFI applications implemnts send-progress-retry logic in case of
`fi_send`/`fi_inject` operations returns -FI_EAGAIN.
Some of them don't provide the buffer(s) for completions (i.e.
`fi_cq_[s]read` with `count` = 0), because they don't know how to handle
unexpected completions.
If there is at least one CQ entry (for the previous operations) in circular
queue (utility CQ storage for the completions that ready to read by user)
and such application calls handles -FI_EAGAIN from `fi_send`/`fi_inject` with
`fi_cq_read(..., count = 0)`, it leads to hang in this send-progress-retry.

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>