### PR TITLE
prov/rxm: Add connection events progress

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -249,8 +249,6 @@ int rxm_cmap_handle_unconnected(struct rxm_ep *rxm_ep, struct rxm_cmap_handle *h
 void rxm_cmap_del_handle_ts(struct rxm_cmap_handle *handle);
 void rxm_cmap_free(struct rxm_cmap *cmap);
 int rxm_cmap_alloc(struct rxm_ep *rxm_ep, struct rxm_cmap_attr *attr);
-int rxm_cmap_handle_connect(struct rxm_cmap *cmap, fi_addr_t fi_addr,
-			    struct rxm_cmap_handle *handle);
 /* Caller must hold cmap->lock */
 int rxm_cmap_move_handle_to_peer_list(struct rxm_cmap *cmap, int index);
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -229,8 +229,6 @@ struct rxm_cmap {
 struct rxm_ep;
 
 struct rxm_cmap_handle *rxm_cmap_key2handle(struct rxm_cmap *cmap, uint64_t key);
-int rxm_cmap_get_handle(struct rxm_cmap *cmap, fi_addr_t fi_addr,
-			struct rxm_cmap_handle **handle);
 int rxm_cmap_update(struct rxm_cmap *cmap, const void *addr, fi_addr_t fi_addr);
 
 void rxm_cmap_process_conn_notify(struct rxm_cmap *cmap,

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -657,24 +657,6 @@ int rxm_cmap_handle_unconnected(struct rxm_ep *rxm_ep, struct rxm_cmap_handle *h
 	return -FI_EAGAIN;
 }
 
-int rxm_cmap_get_handle(struct rxm_cmap *cmap, fi_addr_t fi_addr,
-			struct rxm_cmap_handle **handle_ret)
-{
-	int ret;
-
-	cmap->acquire(&cmap->lock);
-	*handle_ret = rxm_cmap_acquire_handle(cmap, fi_addr);
-	if (OFI_UNLIKELY(!*handle_ret)) {
-		ret = -FI_EAGAIN;
-		goto unlock;
-	}
-
-	ret = rxm_cmap_handle_connect(cmap, fi_addr, *handle_ret);
-unlock:
-	cmap->release(&cmap->lock);
-	return ret;
-}
-
 static int rxm_cmap_cm_thread_close(struct rxm_cmap *cmap)
 {
 	int ret;


### PR DESCRIPTION
This patch reduces number of simultaneous connections by adding
connection events progress in the function that handles initiates
connections to the remoteside in case of them is unconnected
(dynamic connections).

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>