### PR TITLE
prov/rxd: various fixes

### DIFF
--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -1044,8 +1044,11 @@ static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 				      &tag_hdr, &data_hdr, &rma_hdr, &atom_hdr,
 				      &msg, &msg_size);
 	if (!rx_entry) {
-		rxd_remove_rx_pkt(ep, pkt_entry);
-		return;
+		if (base_hdr->type == RXD_MSG || base_hdr->type == RXD_TAGGED) {
+			rxd_remove_rx_pkt(ep, pkt_entry);
+			return;
+		}
+		goto release;
 	}
 
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -687,6 +687,9 @@ static struct rxd_x_entry *rxd_rma_rx_entry_init(struct rxd_ep *ep,
 	rx_entry = rxd_rx_entry_init(ep, iov, iov_count, 0, 0, NULL,
 				     base_hdr->peer, base_hdr->type,
 				     base_hdr->flags);
+	if (!rx_entry)
+		return NULL;
+
 	rx_entry->start_seq = base_hdr->seq_no;
 
 	return rx_entry;

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -69,8 +69,11 @@ int rxd_info_to_rxd(uint32_t version, const struct fi_info *core_info,
 
 	*info->tx_attr = *rxd_info.tx_attr;
 	info->tx_attr->inject_size = MIN(core_info->ep_attr->max_msg_size,
-			RXD_MAX_MTU_SIZE) - sizeof(struct rxd_base_hdr) -
-			core_info->ep_attr->msg_prefix_size;
+			RXD_MAX_MTU_SIZE) - (sizeof(struct rxd_base_hdr) +
+			core_info->ep_attr->msg_prefix_size +
+			sizeof(struct rxd_rma_hdr) + (RXD_IOV_LIMIT *
+			sizeof(struct ofi_rma_iov)) + sizeof(struct rxd_atom_hdr));
+
 	*info->rx_attr = *rxd_info.rx_attr;
 	*info->ep_attr = *rxd_info.ep_attr;
 	*info->domain_attr = *rxd_info.domain_attr;

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -82,10 +82,11 @@ static int rxd_ep_check_unexp_msg_list(struct rxd_ep *ep,
 	
 		pkt_entry = container_of(match, struct rxd_pkt_entry, d_entry);
 		base_hdr = rxd_get_base_hdr(pkt_entry);
-	
-		rxd_unpack_hdrs(pkt_entry->pkt_size, base_hdr, &sar_hdr, &tag_hdr,
+
+		rxd_unpack_hdrs(pkt_entry->pkt_size - ep->rx_prefix_size,
+				base_hdr, &sar_hdr, &tag_hdr,
 				&data_hdr, &rma_hdr, &atom_hdr, &msg, &msg_size);
-	
+
 		total_size = sar_hdr ? sar_hdr->size : msg_size;
 		if (rx_entry->flags & RXD_MULTI_RECV)
 			dup_entry = rxd_progress_multi_recv(ep, rx_entry, total_size);

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -52,10 +52,8 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	fastlock_acquire(&rxd_ep->util_ep.lock);
 	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
-	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq)) {
-		ret = -FI_EAGAIN;
+	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
-	}
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
@@ -103,10 +101,8 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	fastlock_acquire(&rxd_ep->util_ep.lock);
 	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
-	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq)) {
-		ret = -FI_EAGAIN;
+	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
-	}
 
 	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);


### PR DESCRIPTION
- NULL check
- release and repost recv packet if RMA entry could not be initialized
- fix max_inline calculation
- set inject size for usage with tagged, RMA, and atomic injects
- subtract prefix size when progressing unexpected packets
- get rid of unnecessary return set