### PR TITLE
prov/psm,psm2: Disable name server when PMIx is in use

### DIFF
--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -53,7 +53,7 @@ struct psmx_env psmx_env = {
 
 static void psmx_init_env(void)
 {
-	if (getenv("OMPI_COMM_WORLD_RANK") || getenv("PMI_RANK"))
+	if (getenv("OMPI_COMM_WORLD_RANK") || getenv("PMI_RANK") || getenv("PMIx_RANK"))
 		psmx_env.name_server = 0;
 
 	fi_param_get_bool(&psmx_prov, "name_server", &psmx_env.name_server);

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -69,7 +69,7 @@ int	 psmx2_tag_layout_locked = 0;
 
 static void psmx2_init_env(void)
 {
-	if (getenv("OMPI_COMM_WORLD_RANK") || getenv("PMI_RANK"))
+	if (getenv("OMPI_COMM_WORLD_RANK") || getenv("PMI_RANK") || getenv("PMIx_RANK"))
 		psmx2_env.name_server = 0;
 
 	fi_param_get_bool(&psmx2_prov, "name_server", &psmx2_env.name_server);


### PR DESCRIPTION
Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

Fix #4720 