### PR TITLE
contrib/buildrpm,contrib/cray: Change prefix for pipeline generated RPMs

### DIFF
--- a/contrib/buildrpm/buildrpmLibfabric.sh
+++ b/contrib/buildrpm/buildrpmLibfabric.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Copyright (c) 2016-2017   Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2019    Cray Inc.  All rights reserved.
 #
 # This software is available to you under a choice of one of two
 # licenses.  You may choose to be licensed under the terms of the GNU
@@ -159,7 +160,7 @@ while getopts nomi:e:dc:r:svh flag; do
          ;;
       c) configure_options="$configure_options $OPTARG"
          ;;
-      r) configure_options="$rpmbuild_options $OPTARG"
+      r) rpmbuild_options="$rpmbuild_options $OPTARG"
          ;;
       s) unpack_spec="true"
          ;;

--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -364,7 +364,13 @@ pipeline {
                 stage("Create RPMs") {
                     steps {
                         sh 'make dist-bzip2'
-                        sh '$WORKSPACE/contrib/buildrpm/buildrpmLibfabric.sh -i verbs -i sockets -osmv $(ls libfabric-*.tar.bz2)'
+                        sh '''$WORKSPACE/contrib/buildrpm/buildrpmLibfabric.sh \
+                                -i verbs \
+                                -i sockets \
+                                -smv \
+                                -r '--define "_prefix /opt/cray/libfabric/$version"' \
+                                -r '--define "modulefile_path /opt/cray/modulefiles"' \
+                                $(ls libfabric-*.tar.bz2)'''
                     }
                     post {
                         success {


### PR DESCRIPTION
This PR addresses two issues:

- In the build RPM script, it seems that the new arguments for RPM build are being prepended to the incorrect variable.
- For Cray builds, the default installation prefix should be different to accommodate different installation namespaces. 

closes #4723 