### PR TITLE
contrib/buildrpm: Add options for RPM creation

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -4,6 +4,9 @@
 # Define install_modulefile to 1 if you want this RPM to install a modulefile.
 %{!?install_modulefile: %define install_modulefile 0}
 
+# Define install_default_module_version to 1 if you want this RPM to install a .version file
+%{!?install_default_module_version: %define install_default_module_version 0}
+
 # Path to install modulefiles in
 %{!?modulefile_path: %define modulefile_path /usr/share/Modules/modulefiles}
 
@@ -62,6 +65,13 @@ prepend-path PATH %{_prefix}/bin
 prepend-path LD_LIBRARY_PATH %{_libdir}
 prepend-path MANPATH %{_mandir}
 EOF
+%if %{install_default_module_version}
+cat <<EOF >%{buildroot}/%{modulefile_path}/%{name}/.version
+#%Module1.0
+##
+set ModulesVersion "%{version}"
+EOF
+%endif
 %endif
 
 %makeinstall installdirs
@@ -82,6 +92,9 @@ rm -rf %{buildroot}
 %{_bindir}/fi_pingpong
 %if %{install_modulefile}
 %{modulefile_path}/%{name}/%{version}
+%if %{install_default_module_version}
+%{modulefile_path}/%{name}/.version
+%endif
 %endif
 %dir %{_libdir}/libfabric/
 %doc AUTHORS COPYING README


### PR DESCRIPTION
Adds variables to enable creation of default version file
for the Modules package, change module prefix, and change
installation prefix.

Signed-off-by: James Swaro <jswaro@cray.com>

closes #4724 