### PR TITLE
prov/psm2: Add runtime parameter for connection timeout

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -155,6 +155,11 @@ The *psm2* provider checks for the following environment variables:
 
   The default setting is 5.
 
+*FI_PSM2_CONN_TIMEOUT*
+: Timeout (seconds) for establishing connection between two PSM endpoints.
+
+  The default setting is 5.
+
 *FI_PSM2_PROG_INTERVAL*
 : When auto progress is enabled (asked via the hints to *fi_getinfo*),
   a progress thread is created to make progress calls from time to time.

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -821,6 +821,7 @@ struct psmx2_env {
 	char	*uuid;
 	int	delay;
 	int	timeout;
+	int	conn_timeout;
 	int	prog_interval;
 	char	*prog_affinity;
 	int	multi_ep;

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -165,20 +165,6 @@ int psmx2_am_sep_handler(psm2_am_token_t token, psm2_amarg_t *args,
 	return err;
 }
 
-#define PSMX2_MIN_CONN_TIMEOUT	5
-#define PSMX2_MAX_CONN_TIMEOUT	30
-
-static inline double psmx2_conn_timeout(int sec)
-{
-	if (sec < PSMX2_MIN_CONN_TIMEOUT)
-		return PSMX2_MIN_CONN_TIMEOUT * 1e9;
-
-	if (sec > PSMX2_MAX_CONN_TIMEOUT)
-		return PSMX2_MAX_CONN_TIMEOUT * 1e9;
-
-	return sec * 1e9;
-}
-
 static void psmx2_set_epaddr_context(struct psmx2_trx_ctxt *trx_ctxt,
 				     psm2_epid_t epid, psm2_epaddr_t epaddr)
 {
@@ -230,8 +216,8 @@ int psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,
 		}
 	}
 
-	err = psm2_ep_connect(trx_ctxt->psm2_ep, 1, &epid, NULL, &errors,
-			      epaddr, psmx2_conn_timeout(1));
+	err = psm2_ep_connect(trx_ctxt->psm2_ep, 1, &epid, NULL, &errors, epaddr,
+			      (int64_t) psmx2_env.conn_timeout * 1000000000LL);
 	if (err == PSM2_OK || err == PSM2_EPID_ALREADY_CONNECTED) {
 		psmx2_set_epaddr_context(trx_ctxt, epid, *epaddr);
 		return 0;

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -45,6 +45,7 @@ struct psmx2_env psmx2_env = {
 	.uuid		= PSMX2_DEFAULT_UUID,
 	.delay		= 0,
 	.timeout	= 5,
+	.conn_timeout	= 5,
 	.prog_interval	= -1,
 	.prog_affinity	= NULL,
 	.multi_ep	= 0,
@@ -77,6 +78,7 @@ static void psmx2_init_env(void)
 	fi_param_get_str(&psmx2_prov, "uuid", &psmx2_env.uuid);
 	fi_param_get_int(&psmx2_prov, "delay", &psmx2_env.delay);
 	fi_param_get_int(&psmx2_prov, "timeout", &psmx2_env.timeout);
+	fi_param_get_int(&psmx2_prov, "conn_timeout", &psmx2_env.conn_timeout);
 	fi_param_get_int(&psmx2_prov, "prog_interval", &psmx2_env.prog_interval);
 	fi_param_get_str(&psmx2_prov, "prog_affinity", &psmx2_env.prog_affinity);
 	fi_param_get_int(&psmx2_prov, "inject_size", &psmx2_env.inject_size);
@@ -584,6 +586,9 @@ PROVIDER_INI
 
 	fi_param_define(&psmx2_prov, "timeout", FI_PARAM_INT,
 			"Timeout (seconds) for gracefully closing the PSM2 endpoint");
+
+	fi_param_define(&psmx2_prov, "conn_timeout", FI_PARAM_INT,
+			"Timeout (seconds) for establishing connection between two PSM2 endpoints");
 
 	fi_param_define(&psmx2_prov, "prog_interval", FI_PARAM_INT,
 			"Interval (microseconds) between progress calls made in the "


### PR DESCRIPTION
Define new environment variable FI_PSM2_CONN_TIMEOUT to control timeout
of connection establishment. Larger value (the default is 5 seconds)
may be necessary for large scale runs.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>