### PR TITLE
core/buf_pool: Zero newly allocated memory

### DIFF
--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -91,6 +91,7 @@ int util_buf_grow(struct util_buf_pool *pool)
 			goto err1;
 	}
 
+	memset(buf_region->mem_region, 0, buf_region->size);
 	if (pool->attr.alloc_hndlr) {
 		ret = pool->attr.alloc_hndlr(pool->attr.ctx,
 					     buf_region->mem_region,


### PR DESCRIPTION
The tcp provider uses the buffer pool, but does not fully
initialize newly allocated buffer entries.  This results in
applications accessing uninitialized memory.  As a fix and
to prevent similar issues appearing in other providers or
future code, always zero new buffer allocations.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>