### PR TITLE
travis: enable address sanitizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ env:
         # do not know how to fix
         #- MAKE_FLAGS="AM_CFLAGS=-Werror"
         - MAKE_FLAGS=
+        - ASAN_OPTIONS=detect_leaks=0
 
 # Brew update GNU Autotools so that autogen can succeed
 before_install:
@@ -98,7 +99,7 @@ install:
     - ./configure $LIBFABRIC_CONFIGURE_ARGS --enable-debug
     - make -j2 $MAKE_FLAGS
     # Test regular build
-    - ./configure $LIBFABRIC_CONFIGURE_ARGS
+    - CFLAGS="-fsanitize=address" ./configure $LIBFABRIC_CONFIGURE_ARGS
     - make -j2 $MAKE_FLAGS
     - make install
     - make test
@@ -108,7 +109,7 @@ install:
 script:
     - cd fabtests
     - ./autogen.sh
-    - ./configure --prefix=$PREFIX --with-libfabric=$PREFIX
+    - CFLAGS="-fsanitize=address" ./configure --prefix=$PREFIX --with-libfabric=$PREFIX
     # Do not use MAKE_FLAGS here because we use AM_CFLAGS in the
     # normal fabtests' Makefile.am (i.e., overriding it on the command
     # line removes information that we need to build fabtests itself).


### PR DESCRIPTION
!!DO NOT MERGE!!

This patch enables the thread sanitizer into Travis testing to verify invalid memory accesses.
As you can see, the TCP provider now fails multiple tests. 

We should get all these tests fixed as they reflect some bugs in the code. 
Also, I would suggest to always run all the CI tests with the address sanitizer as it works very well at reporting nasty bugs. 

PS: I'm not sure why ASAN doesn't report the symbols in the backtrace (I enabled debug mode, but it still fails). I'll try to fix it.
