### PR TITLE
prov/verbs: Workaround for #4672 and IBV_WC_WR_FLUSH_ERR WCs

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -933,8 +933,7 @@ static inline int fi_ibv_poll_reap_unsig_cq(struct fi_ibv_ep *ep)
 		}
 
 		for (i = 0; i < ret; i++) {
-			if (!fi_ibv_process_wc(cq, &wc[i]) ||
-			    OFI_UNLIKELY(wc[i].status == IBV_WC_WR_FLUSH_ERR))
+			if (!fi_ibv_process_wc(cq, &wc[i]))
 				continue;
 			if (OFI_LIKELY(!fi_ibv_wc_2_wce(cq, &wc[i], &wce)))
 				slist_insert_tail(&wce->entry, &cq->wcq);

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -248,14 +248,12 @@ static inline int fi_ibv_poll_outstanding_cq(struct fi_ibv_ep *ep,
 		return 1;
 	}
 
-	if (OFI_LIKELY(wc.status != IBV_WC_WR_FLUSH_ERR)) {
-		ret = fi_ibv_wc_2_wce(cq, &wc, &wce);
-		if (OFI_UNLIKELY(ret)) {
-			ret = -FI_EAGAIN;
-			goto fn;
-		}
-		slist_insert_tail(&wce->entry, &cq->wcq);
+	ret = fi_ibv_wc_2_wce(cq, &wc, &wce);
+	if (OFI_UNLIKELY(ret)) {
+		ret = -FI_EAGAIN;
+		goto fn;
 	}
+	slist_insert_tail(&wce->entry, &cq->wcq);
 	ret = 1;
 fn:
 
@@ -326,17 +324,6 @@ static ssize_t fi_ibv_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 
 		/* Insert error entry into wcq */
 		if (OFI_UNLIKELY(wc.status)) {
-			if (wc.status == IBV_WC_WR_FLUSH_ERR) {
-				/* Handle case when remote side destroys
-				 * the connection, but local side isn't aware
-				 * about that yet */
-				VERBS_DBG(FI_LOG_CQ,
-					  "Ignoring WC with status "
-					  "IBV_WC_WR_FLUSH_ERR(%d)\n",
-					  wc.status);
-				i--;
-				continue;
-			}
 			wce = util_buf_alloc(cq->wce_pool);
 			if (!wce) {
 				cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);


### PR DESCRIPTION
Since the patch fe16dd1("prov/verbs: Fix a bug during connection
shutdown from remote side") that attempts to fix an issue with
IWarp, the Verbs provider silently skips every WCs failed with
the status IBV_WC_WR_FLUSH_ERR.
This causes the end-user application to never receive these WCs
for network protocols other than IWarp, which is a regression
since Libfabric 1.4.0.

This patch works around the problem and add a selective code path
if the CQ is for an IWarp device.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>