### PR TITLE
prov/rxm: Remove excessive RX buffer in Rendezvous TX

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -487,7 +487,6 @@ struct rxm_tx_rndv_buf {
 
 	void *app_context;
 	uint64_t flags;
-	struct rxm_rx_buf *rx_buf;
 	struct fid_mr *mr[RXM_IOV_LIMIT];
 	uint8_t count;
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -321,7 +321,6 @@ static int rxm_rndv_tx_finish(struct rxm_ep *rxm_ep, struct rxm_tx_rndv_buf *tx_
 	assert(ofi_tx_cq_flags(tx_buf->pkt.hdr.op) & FI_SEND);
 	ofi_ep_tx_cntr_inc(&rxm_ep->util_ep);
 
-	rxm_rx_buf_release(rxm_ep, tx_buf->rx_buf);
 	rxm_tx_buf_release(rxm_ep, RXM_BUF_POOL_TX_RNDV, tx_buf);
 
 	return ret;
@@ -338,7 +337,7 @@ static int rxm_rndv_handle_ack(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf)
 
 	assert(tx_buf->pkt.ctrl_hdr.msg_id == rx_buf->pkt.ctrl_hdr.msg_id);
 
-	tx_buf->rx_buf = rx_buf;
+	rxm_rx_buf_release(rxm_ep, rx_buf);
 
 	if (tx_buf->hdr.state == RXM_RNDV_ACK_WAIT) {
 		return rxm_rndv_tx_finish(rxm_ep, tx_buf);


### PR DESCRIPTION
Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>