### PR TITLE
prov/tcp: Use fi_dupinfo to copy fi_info

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -113,7 +113,7 @@ struct tcpx_conn_handle {
 
 struct tcpx_pep {
 	struct util_pep 	util_pep;
-	struct fi_info		info;
+	struct fi_info		*info;
 	SOCKET			sock;
 	struct tcpx_cm_context	cm_ctx;
 };

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -284,7 +284,7 @@ static void server_recv_connreq(struct util_wait *wait,
 		goto err1;
 
 	cm_entry->fid = &handle->pep->util_pep.pep_fid.fid;
-	cm_entry->info = fi_dupinfo(&handle->pep->info);
+	cm_entry->info = fi_dupinfo(handle->pep->info);
 	if (!cm_entry->info)
 		goto err2;
 


### PR DESCRIPTION
tcpx_passive_ep use a structure assignment to make a copy of
struct fi_info.  However, this does not result in a deep
copy of the structure, which can lead to a double free
condition.  Use fi_dupinfo to make a deep copy correctly.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>