### PR TITLE
fabtests/stream: Fix static function declaration

### DIFF
--- a/fabtests/functional/stream_msg.c
+++ b/fabtests/functional/stream_msg.c
@@ -77,7 +77,7 @@ int recv_stream(struct fid_ep *ep, char *msg, size_t msg_len)
 	return offset;
 }
 
-int static send_greeting(struct fid_ep *ep)
+static int send_greeting(struct fid_ep *ep)
 {
 	const size_t msg_len = strlen(msg);
 	char buffer[msg_len];
@@ -99,7 +99,7 @@ int static send_greeting(struct fid_ep *ep)
 	return 0;
 }
 
-int static recv_greeting(struct fid_ep *ep)
+static int recv_greeting(struct fid_ep *ep)
 {
 	const size_t msg_len = strlen(msg);
 	char buffer[msg_len];


### PR DESCRIPTION
Static goes before int.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>