### PR TITLE
prov/tcp: Couple of memory leak fixes

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -144,6 +144,7 @@ int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
 int ofi_getifaddrs(struct ifaddrs **ifap);
 void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
 			  struct slist *addr_list);
+void ofi_free_list_of_addr(struct slist *addr_list);
 
 #define ofi_sa_family(addr) ((struct sockaddr *)(addr))->sa_family
 #define ofi_sin_addr(addr) (((struct sockaddr_in *)(addr))->sin_addr)

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -622,19 +622,6 @@ static int sock_node_matches_interface(struct slist *addr_list, const char *node
 	return sock_addr_matches_interface(addr_list, &addr.sa);
 }
 
-static void sock_free_addr_list(struct slist *addr_list)
-{
-	struct slist_entry *entry;
-	struct ofi_addr_list_entry *host_entry;
-
-	while (!slist_empty(addr_list)) {
-		entry = slist_remove_head(addr_list);
-		host_entry = container_of(entry, struct ofi_addr_list_entry,
-					  entry);
-		free(host_entry);
-	}
-}
-
 static int sock_getinfo(uint32_t version, const char *node, const char *service,
 			uint64_t flags, const struct fi_info *hints,
 			struct fi_info **info)
@@ -695,7 +682,7 @@ static int sock_getinfo(uint32_t version, const char *node, const char *service,
 
 static void fi_sockets_fini(void)
 {
-	sock_free_addr_list(&sock_addr_list);
+	ofi_free_list_of_addr(&sock_addr_list);
 	fastlock_destroy(&sock_list_lock);
 }
 

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -91,6 +91,7 @@ static void tcpx_getinfo_ifs(struct fi_info **info)
 		*/
 	}
 
+	ofi_free_list_of_addr(&addr_list);
 	fi_freeinfo(*info);
 	*info = head;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -952,6 +952,16 @@ void fi_epoll_close(struct fi_epoll *ep)
 #endif
 
 
+void ofi_free_list_of_addr(struct slist *addr_list)
+{
+	struct ofi_addr_list_entry *addr_entry;
+
+	while (!slist_empty(addr_list)) {
+		slist_remove_head_container(addr_list, struct ofi_addr_list_entry,
+					    addr_entry, entry);
+		free(addr_entry);
+	}
+}
 
 static inline
 void ofi_insert_loopback_addr(struct fi_provider *prov, struct slist *addr_list)


### PR DESCRIPTION
This allows the fi_getinfo_test to run cleanly without reported memory leaks.