### PR TITLE
prov/rxm: Optimize CQ + bug-fixing

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -264,6 +264,7 @@ struct util_buf_pool;
 typedef int (*util_buf_region_alloc_hndlr) (void *pool_ctx, void *addr, size_t len,
 					    void **context);
 typedef void (*util_buf_region_free_hndlr) (void *pool_ctx, void *context);
+typedef void (*util_buf_region_unavail_hndlr) (void *pool_ctx);
 typedef void (*util_buf_region_init_func) (void *pool_ctx, void *buf);
 
 struct util_buf_attr {
@@ -273,6 +274,7 @@ struct util_buf_attr {
 	size_t 				chunk_cnt;
 	util_buf_region_alloc_hndlr 	alloc_hndlr;
 	util_buf_region_free_hndlr 	free_hndlr;
+	util_buf_region_unavail_hndlr	unavail_hndlr;
 	util_buf_region_init_func 	init;
 	void 				*ctx;
 	uint8_t				track_used;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -654,7 +654,8 @@ struct rxm_ep {
 	struct fid_cq 		*msg_cq;
 	int			msg_cq_fd;
 	struct fid_ep 		*srx_ctx;
-	size_t 			comp_per_progress;
+	uint8_t			comp_per_progress;
+	struct fi_cq_data_entry	*comp_ents;
 	int			msg_mr_local;
 	int			rxm_mr_local;
 	size_t			min_multi_recv_size;
@@ -724,7 +725,9 @@ int rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep);
 void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 			void *op_context, int err);
 void rxm_ep_progress_unsafe(struct util_ep *util_ep);
+void rxm_ep_progress_multi_unsafe(struct util_ep *util_ep);
 void rxm_ep_progress(struct util_ep *util_ep);
+void rxm_ep_progress_multi(struct util_ep *util_ep);
 
 int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -723,8 +723,8 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 int rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep);
 void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 			void *op_context, int err);
+void rxm_ep_progress_unsafe(struct util_ep *util_ep);
 void rxm_ep_progress(struct util_ep *util_ep);
-void rxm_ep_do_progress(struct util_ep *util_ep);
 
 int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
 

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -72,7 +72,7 @@ rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, len,
 			      tx_buf->hdr.desc, 0, tx_buf);
 	if (ret == -FI_EAGAIN)
-		rxm_ep_do_progress(&rxm_ep->util_ep);
+		rxm_ep_progress_unsafe(&rxm_ep->util_ep);
 
 	return ret;
 }

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -72,7 +72,7 @@ rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		ret = fi_send(rxm_conn->msg_ep, &tx_buf->pkt, len,
 			      tx_buf->hdr.desc, 0, tx_buf);
 	if (ret == -FI_EAGAIN)
-		rxm_ep_progress_unsafe(&rxm_ep->util_ep);
+		rxm_ep_progress_multi_unsafe(&rxm_ep->util_ep);
 
 	return ret;
 }

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1267,7 +1267,8 @@ int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)
 	return 0;
 }
 
-void rxm_ep_do_progress(struct util_ep *util_ep)
+/* Must call with EP lock held */
+void rxm_ep_progress_unsafe(struct util_ep *util_ep)
 {
 	struct rxm_ep *rxm_ep = container_of(util_ep, struct rxm_ep, util_ep);
 	struct fi_cq_data_entry comp;
@@ -1316,7 +1317,7 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 void rxm_ep_progress(struct util_ep *util_ep)
 {
 	ofi_ep_lock_acquire(util_ep);
-	rxm_ep_do_progress(util_ep);
+	rxm_ep_progress_unsafe(util_ep);
 	ofi_ep_lock_release(util_ep);
 }
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -987,6 +987,7 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	ssize_t ret;
 	struct rxm_rx_buf *rx_buf;
 	struct rxm_tx_sar_buf *tx_sar_buf;
+	struct rxm_tx_base_buf *tx_base_buf;
 	struct rxm_tx_eager_buf *tx_eager_buf;
 	struct rxm_tx_rndv_buf *tx_rndv_buf;
 	struct rxm_tx_atomic_buf *tx_atomic_buf;
@@ -999,12 +1000,16 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 
 	switch (RXM_GET_PROTO_STATE(comp->op_context)) {
 	case RXM_TX:
-	case RXM_INJECT_TX:
 		tx_eager_buf = comp->op_context;
 		assert(comp->flags & FI_SEND);
 		ret = rxm_finish_eager_send(rxm_ep, tx_eager_buf);
 		rxm_tx_buf_release(rxm_ep, RXM_BUF_POOL_TX, tx_eager_buf);
 		return ret;
+	case RXM_INJECT_TX:
+		tx_base_buf = comp->op_context;
+		assert(comp->flags & FI_SEND);
+		rxm_tx_buf_release(rxm_ep, RXM_BUF_POOL_TX_INJECT, tx_base_buf);
+		return 0;
 	case RXM_SAR_TX:
 		tx_sar_buf = comp->op_context;
 		assert(comp->flags & FI_SEND);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -262,6 +262,14 @@ static inline void rxm_buf_close(void *pool_ctx, void *context)
 	}
 }
 
+static inline void rxm_buf_handle_unavail(void *pool_ctx)
+{
+	struct rxm_buf_pool *pool = (struct rxm_buf_pool *)pool_ctx;
+	struct rxm_ep *rxm_ep = pool->rxm_ep;
+
+	rxm_ep_progress_multi_unsafe(&rxm_ep->util_ep);
+}
+
 static void rxm_buf_pool_destroy(struct rxm_buf_pool *pool)
 {
 	/* This indicates whether the pool is allocated or not */
@@ -282,6 +290,8 @@ static int rxm_buf_pool_create(struct rxm_ep *rxm_ep,
 		.chunk_cnt	= chunk_count,
 		.alloc_hndlr	= rxm_buf_reg,
 		.free_hndlr	= rxm_buf_close,
+		.unavail_hndlr	= ((type == RXM_BUF_POOL_RX) ?
+				   NULL : rxm_buf_handle_unavail),
 		.ctx		= pool,
 		.track_used	= 0,
 	};

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -225,7 +225,7 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, 
 	ret = fi_writemsg(rxm_conn->msg_ep, &rxm_rma_msg, flags);
 	if (OFI_UNLIKELY(ret)) {
 		if (ret == -FI_EAGAIN)
-			rxm_ep_do_progress(&rxm_ep->util_ep);
+			rxm_ep_progress_unsafe(&rxm_ep->util_ep);
 		rxm_rma_buf_release(rxm_ep, rma_buf);
 	}
 unlock:

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -225,7 +225,7 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, 
 	ret = fi_writemsg(rxm_conn->msg_ep, &rxm_rma_msg, flags);
 	if (OFI_UNLIKELY(ret)) {
 		if (ret == -FI_EAGAIN)
-			rxm_ep_progress_unsafe(&rxm_ep->util_ep);
+			rxm_ep_progress_multi_unsafe(&rxm_ep->util_ep);
 		rxm_rma_buf_release(rxm_ep, rma_buf);
 	}
 unlock:
@@ -298,7 +298,7 @@ rxm_ep_rma_inject_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, ui
 			       "fi_inject_write* for MSG provider failed with ret - %"
 			       PRId64"\n", ret);
 			if (OFI_LIKELY(ret == -FI_EAGAIN))
-				rxm_ep_progress(&rxm_ep->util_ep);
+				rxm_ep_progress_multi(&rxm_ep->util_ep);
 		}
 		return ret;
 	} else {
@@ -427,7 +427,7 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 			       "fi_inject_write for MSG provider failed with ret - %"
 			       PRId64"\n", ret);
 			if (OFI_LIKELY(ret == -FI_EAGAIN))
-				rxm_ep_progress(&rxm_ep->util_ep);
+				rxm_ep_progress_multi(&rxm_ep->util_ep);
 		}
 		return ret;
 	} else {
@@ -459,7 +459,7 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 			       "fi_inject_writedata for MSG provider failed with ret - %"
 			       PRId64"\n", ret);
 			if (OFI_LIKELY(ret == -FI_EAGAIN))
-				rxm_ep_progress(&rxm_ep->util_ep);
+				rxm_ep_progress_multi(&rxm_ep->util_ep);
 		}
 		return ret;
 	} else {

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -49,6 +49,17 @@ int util_buf_grow(struct util_buf_pool *pool)
 	ssize_t hp_size;
 	struct util_buf_footer *buf_ftr;
 
+	if ((pool->num_allocated > 0) && pool->attr.unavail_hndlr) {
+		pool->attr.unavail_hndlr(pool->attr.ctx);
+		if (!pool->attr.indexing.ordered) {
+			if (util_buf_avail(pool))
+				return 0;
+		} else {
+			if (util_buf_indexed_avail(pool))
+				return 0;
+		}
+	}
+
 	if (pool->attr.max_cnt && pool->num_allocated >= pool->attr.max_cnt) {
 		return -1;
 	}


### PR DESCRIPTION
This PR does the following things:
- optimizes CQ by implementing multi and single version of progress for each RxM EP CQ.
- fixes out-of-memory kill by Linux OOM killer in the case when user does a large number of `fi_tinject`s with the size > than supported by core provider.  It leads that RxM providers allocates a large number of TX requests (core providers completes them internally, but RxM doesn't read them, becasue cokre provider reports `FI_SUCCESS` for `fi_send`) w/o reading completion for a long time. Solution: if TX buffer pool doesn't have enough space - progress CQ and if there is still no space shrink TX buffer pool.
