### PR TITLE
prov/tcp: fix memory leak

### DIFF
--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -953,7 +953,12 @@ static int tcpx_pep_reject(struct fid_pep *pep, fid_t handle,
 		(void) ofi_sendall_socket(tcpx_handle->conn_fd, param, paramlen);
 
 	ofi_shutdown(tcpx_handle->conn_fd, SHUT_RDWR);
-	return ofi_close_socket(tcpx_handle->conn_fd);
+	ret = ofi_close_socket(tcpx_handle->conn_fd);
+	if (ret)
+		return ret;
+
+	free(tcpx_handle);
+	return FI_SUCCESS;
 }
 
 static struct fi_ops_cm tcpx_pep_cm_ops = {


### PR DESCRIPTION
handle allocated by tcp provider for FI_CONNREQ notifications. App would use it to either create a new active ep or reject the request. In both cases, handle has to be freed after expected action. Reject path is not freeing it. This patch fixes that.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>