### PR TITLE
linux/osd: fix ethtool preprocessor directives

### DIFF
--- a/src/linux/osd.c
+++ b/src/linux/osd.c
@@ -71,7 +71,7 @@ ssize_t ofi_get_hugepage_size(void)
 	return val * 1024;
 }
 
-#if HAVE_ETHTOOL
+#ifdef HAVE_ETHTOOL
 
 #if HAVE_DECL_ETHTOOL_CMD_SPEED
 static inline uint32_t ofi_ethtool_cmd_speed(struct ethtool_cmd *ecmd)

--- a/src/linux/osd.c
+++ b/src/linux/osd.c
@@ -71,9 +71,9 @@ ssize_t ofi_get_hugepage_size(void)
 	return val * 1024;
 }
 
-#ifdef HAVE_ETHTOOL
+#if HAVE_ETHTOOL == 1
 
-#ifdef HAVE_DECL_ETHTOOL_CMD_SPEED
+#if HAVE_DECL_ETHTOOL_CMD_SPEED == 1
 static inline uint32_t ofi_ethtool_cmd_speed(struct ethtool_cmd *ecmd)
 {
 	return ethtool_cmd_speed(ecmd);
@@ -85,7 +85,7 @@ static inline uint32_t ofi_ethtool_cmd_speed(struct ethtool_cmd *ecmd)
 }
 #endif /* HAVE_DECL_ETHTOOL_CMD_SPEED */
 
-#ifdef HAVE_DECL_SPEED_UNKNOWN
+#if HAVE_DECL_SPEED_UNKNOWN == 1
 static inline int ofi_ethtool_is_known(uint32_t speed_mbps)
 {
 	return (speed_mbps != SPEED_UNKNOWN);

--- a/src/linux/osd.c
+++ b/src/linux/osd.c
@@ -71,9 +71,9 @@ ssize_t ofi_get_hugepage_size(void)
 	return val * 1024;
 }
 
-#if HAVE_ETHTOOL == 1
+#if HAVE_ETHTOOL
 
-#if HAVE_DECL_ETHTOOL_CMD_SPEED == 1
+#if HAVE_DECL_ETHTOOL_CMD_SPEED
 static inline uint32_t ofi_ethtool_cmd_speed(struct ethtool_cmd *ecmd)
 {
 	return ethtool_cmd_speed(ecmd);
@@ -85,7 +85,7 @@ static inline uint32_t ofi_ethtool_cmd_speed(struct ethtool_cmd *ecmd)
 }
 #endif /* HAVE_DECL_ETHTOOL_CMD_SPEED */
 
-#if HAVE_DECL_SPEED_UNKNOWN == 1
+#if HAVE_DECL_SPEED_UNKNOWN
 static inline int ofi_ethtool_is_known(uint32_t speed_mbps)
 {
 	return (speed_mbps != SPEED_UNKNOWN);


### PR DESCRIPTION
Configure checks puts macro definitions of supported ethtool functionality: `#define HAVE_ETHTOOL,` `#define HAVE_DECL_SPEED_UNKNOWN`, etc. in config.h. So, `#ifdef` directives in src/linux/osd.c are always true even in cases when target machine doesn't support some of these features. That results in compilation error. 
This PR fixes this problem.