### PR TITLE
[v1.7.x] prov/verbs, rxm: fix for FI_RX_CQ_DATA and default buffered min

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -133,7 +133,8 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 		    struct fi_info *info)
 {
 	info->caps = rxm_info.caps;
-	info->mode = core_info->mode | rxm_info.mode;
+	// TODO find which other modes should be filtered
+	info->mode = (core_info->mode & ~FI_RX_CQ_DATA) | rxm_info.mode;
 
 	info->tx_attr->caps		= rxm_info.tx_attr->caps;
 	info->tx_attr->mode		= info->mode;
@@ -147,7 +148,7 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 					      core_info->tx_attr->rma_iov_limit);
 
 	info->rx_attr->caps		= rxm_info.rx_attr->caps;
-	info->rx_attr->mode		= info->mode;
+	info->rx_attr->mode		= info->rx_attr->mode & ~FI_RX_CQ_DATA;
 	info->rx_attr->msg_order 	= core_info->rx_attr->msg_order;
 	info->rx_attr->comp_order 	= rxm_info.rx_attr->comp_order;
 	info->rx_attr->size 		= rxm_info.rx_attr->size;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1544,12 +1544,40 @@ static int fi_ibv_get_match_infos(uint32_t version, const char *node,
 	return FI_SUCCESS;
 }
 
+static void fi_ibv_alter_info(const struct fi_info *hints, struct fi_info *info)
+{
+	struct fi_info *cur;
+
+	if (!ofi_check_rx_mode(hints, FI_RX_CQ_DATA)) {
+		for (cur = info; cur; cur = cur->next)
+			cur->domain_attr->cq_data_size = 0;
+	} else {
+		for (cur = info; cur; cur = cur->next) {
+			/* App may just set rx_attr.mode */
+			if (!hints || (hints->mode & FI_RX_CQ_DATA))
+				cur->mode |= FI_RX_CQ_DATA;
+			assert(cur->rx_attr->mode & FI_RX_CQ_DATA);
+		}
+	}
+
+	if (!hints || !hints->tx_attr || !hints->tx_attr->inject_size) {
+		for (cur = info; cur; cur = cur->next) {
+			if (cur->ep_attr->type != FI_EP_MSG)
+				continue;
+			/* The default inline size is usually smaller.
+			 * This is to avoid drop in throughput */
+			cur->tx_attr->inject_size =
+				MIN(cur->tx_attr->inject_size,
+				    fi_ibv_gl_data.def_inline_size);
+		}
+	}
+}
+
 int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, const struct fi_info *hints,
 		   struct fi_info **info)
 {
 	int ret;
-	const struct fi_info *cur;
 
 	ret = fi_ibv_get_match_infos(version, node, service,
 				     flags, hints,
@@ -1559,21 +1587,7 @@ int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
 
 	ofi_alter_info(*info, hints, version);
 
-	if (!ofi_check_rx_mode(hints, FI_RX_CQ_DATA)) {
-		for (cur = *info; cur; cur = cur->next)
-			cur->domain_attr->cq_data_size = 0;
-	}
-
-	if (!hints || !hints->tx_attr || !hints->tx_attr->inject_size) {
-		for (cur = *info; cur; cur = cur->next) {
-			if (cur->ep_attr->type != FI_EP_MSG)
-				continue;
-			/* The default inline size is usually smaller.
-			 * This is to avoid drop in throughput */
-			cur->tx_attr->inject_size = MIN(cur->tx_attr->inject_size,
-							fi_ibv_gl_data.def_inline_size);
-		}
-	}
+	fi_ibv_alter_info(hints, *info);
 out:
 	if (!ret || ret == -FI_ENOMEM || ret == -FI_ENODEV)
 		return ret;


### PR DESCRIPTION
- prov/verbs: fix FI_RX_CQ_DATA not being set in info->mode on return from fi_getinfo
- prov/rxm: fix setting default buffered min limit 