### PR TITLE
prov/rxm: fix truncation error when using SAR protocol with eager_limit > 64KB

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1360,7 +1360,10 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 				rxm_ep_do_progress(&rxm_ep->util_ep);
 			rxm_tx_buf_release(rxm_ep, RXM_BUF_POOL_TX, tx_buf);
 		}
-	} else if (data_len <= rxm_ep->sar_limit) {
+	} else if (data_len <= rxm_ep->sar_limit &&
+		   /* SAR uses eager_limit as segment size */
+		   (rxm_ep->eager_limit <
+		    (1ULL << (8 * sizeof_field(struct ofi_ctrl_hdr, seg_size))))) {
 		ret = rxm_ep_sar_tx_send(rxm_ep, rxm_conn, context,
 					 count, iov, data_len,
 					 rxm_ep_sar_calc_segs_cnt(rxm_ep, data_len),


### PR DESCRIPTION
SAR protocol uses eager limit as segment size. The seg_size field in ofi_ctrl_hdr
is limited to 16 bits, so we should check if segment size fits before employing
SAR protocol.

An alternative solution is to use bigger type (e.g. uint32_t) for seg_size but
that would increase latency for small messages.