### PR TITLE
prov/shm: add SELECTIVE_COMPLETION support and other fixes

### DIFF
--- a/fabtests/test_configs/shm/all.test
+++ b/fabtests/test_configs/shm/all.test
@@ -36,6 +36,96 @@
 		FT_TEST_BANDWIDTH,
 	],
 	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	tx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	tx_op_flags: [
+		FI_COMPLETION,
+	],
+	msg_flags: [
+		FI_COMPLETION,
+	],
+},
+{
+	prov_name: shm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	tx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	msg_flags: [
+		FI_COMPLETION,
+	],
+},
+{
+	prov_name: shm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SENDMSG,
+	],
+	ep_type: [
+		FI_EP_RDM,
+	],
+	mode: [
+		FT_MODE_ALL,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	tx_cq_bind_flags: [
+		FI_SELECTIVE_COMPLETION,
+	],
+	tx_op_flags: [
+		FI_COMPLETION,
+	],
+},
+{
+	prov_name: shm,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
 		FT_FUNC_WRITE,
 		FT_FUNC_WRITEV,
 		FT_FUNC_WRITEMSG,

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -76,6 +76,7 @@ enum {
 
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
 #define SMR_RMA_REQ		(1 << 1)
+#define SMR_COMPLETION		(1 << 2)
 
 /* 
  * Unique smr_op_hdr for smr message protocol:

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -76,7 +76,9 @@ enum {
 
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
 #define SMR_RMA_REQ		(1 << 1)
-#define SMR_COMPLETION		(1 << 2)
+#define SMR_TX_COMPLETION	(1 << 2)
+#define SMR_RX_COMPLETION	(1 << 3)
+#define SMR_MULTI_RECV		(1 << 4)
 
 /* 
  * Unique smr_op_hdr for smr message protocol:

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -241,6 +241,11 @@ struct util_ep {
 	uint64_t		tx_op_flags;
 	uint64_t		inject_op_flags;
 
+	/* flags to be ORed in to flags for *msg API calls
+	 * to properly handle FI_SELECTIVE_COMPLETION bind */
+	uint64_t		tx_msg_flags;
+	uint64_t		rx_msg_flags;
+
 	/* CNTR entries */
 	struct util_cntr	*tx_cntr;     /* transmit/send */
 	struct util_cntr	*rx_cntr;     /* receive       */

--- a/man/fi_shm.7.md
+++ b/man/fi_shm.7.md
@@ -105,8 +105,6 @@ structures
 
 EPs must be bound to both RX and TX CQs.
 
-No support for selective completions or multi-recv.
-
 No support for counters.
 
 # RUNTIME PARAMETERS

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -851,9 +851,8 @@ static ssize_t rxm_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 					     util_ep.ep_fid.fid);
 
 	return rxm_ep_recv_common_flags(rxm_ep, msg->msg_iov, msg->desc, msg->iov_count,
-					msg->addr, 0, 0, msg->context,
-					flags, (rxm_ep_rx_flags(rxm_ep) & FI_COMPLETION),
-					&rxm_ep->recv_queue);
+					msg->addr, 0, 0, msg->context, flags,
+					rxm_ep->util_ep.rx_msg_flags, &rxm_ep->recv_queue);
 }
 
 static ssize_t rxm_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
@@ -1560,8 +1559,7 @@ static ssize_t rxm_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	return rxm_ep_send_common(rxm_ep, rxm_conn, msg->msg_iov, msg->desc,
 				  msg->iov_count, msg->context, msg->data,
-				  flags | (rxm_ep_tx_flags(rxm_ep) & FI_COMPLETION),
-				  0, ofi_op_msg,
+				  flags | rxm_ep->util_ep.tx_msg_flags, 0, ofi_op_msg,
 				  ((flags & FI_REMOTE_CQ_DATA) ?
 				   rxm_conn->inject_data_pkt : rxm_conn->inject_pkt));
 }
@@ -1729,7 +1727,7 @@ static ssize_t rxm_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged
 
 	return rxm_ep_recv_common_flags(rxm_ep, msg->msg_iov, msg->desc, msg->iov_count,
 					msg->addr, msg->tag, msg->ignore, msg->context,
-					flags, (rxm_ep_rx_flags(rxm_ep) & FI_COMPLETION),
+					flags, rxm_ep->util_ep.rx_msg_flags,
 					&rxm_ep->trecv_queue);
 }
 
@@ -1775,9 +1773,8 @@ static ssize_t rxm_ep_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged
 
 	return rxm_ep_send_common(rxm_ep, rxm_conn, msg->msg_iov, msg->desc,
 				  msg->iov_count, msg->context, msg->data,
-				  flags | (rxm_ep_tx_flags(rxm_ep) & FI_COMPLETION),
-				  msg->tag, ofi_op_tagged,
-				  ((flags & FI_REMOTE_CQ_DATA) ?
+				  flags | rxm_ep->util_ep.tx_msg_flags, msg->tag,
+				  ofi_op_tagged, ((flags & FI_REMOTE_CQ_DATA) ?
 				   rxm_conn->tinject_data_pkt : rxm_conn->tinject_pkt));
 }
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -101,16 +101,16 @@ struct smr_ep_entry {
 	uint64_t		ignore;
 	struct iovec		iov[SMR_IOV_LIMIT];
 	uint32_t		iov_count;
-	uint32_t		flags;
+	uint64_t		flags;
 	uint64_t		err;
 };
 
 struct smr_ep;
 typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context,
-		uint64_t flags, size_t len, void *buf, void *addr,
+		uint64_t flags, uint64_t msg_flags, size_t len, void *buf, void *addr,
 		uint64_t tag, uint64_t data, uint64_t err);
 typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context,
-		uint64_t flags, uint64_t err);
+		uint64_t flags, uint16_t op_flags, uint64_t err);
 
 
 struct smr_match_attr {
@@ -218,19 +218,21 @@ void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
 		void *context, struct smr_region *smr, struct smr_resp *resp,
 		struct smr_cmd *pend);
 
-int smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags, uint64_t err);
+int smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags,
+		uint16_t op_flags, uint64_t err);
 int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
-		       uint64_t err);
-int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags, size_t len,
-		void *buf, void *addr, uint64_t tag, uint64_t data,
+		       uint16_t op_flags, uint64_t err);
+int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags,
+		uint64_t msg_flags, size_t len, void *buf, void *addr,
+		uint64_t tag, uint64_t data,
 		uint64_t err);
 int smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
-		    size_t len, void *buf, void *addr, uint64_t tag,
-		    uint64_t data, uint64_t err);
-int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
+		    uint64_t msg_flags, size_t len, void *buf, void *addr,
+		    uint64_t tag, uint64_t data, uint64_t err);
+int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags, uint64_t msg_flags,
 		       size_t len, void *buf, void *addr, uint64_t tag,
 		       uint64_t data, uint64_t err);
-int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
+int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint64_t flags, uint64_t msg_flags,
 			   size_t len, void *buf, void *addr, uint64_t tag,
 			   uint64_t data, uint64_t err);
 uint64_t smr_rx_cq_flags(uint32_t op, uint16_t op_flags);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -101,16 +101,16 @@ struct smr_ep_entry {
 	uint64_t		ignore;
 	struct iovec		iov[SMR_IOV_LIMIT];
 	uint32_t		iov_count;
-	uint64_t		flags;
+	uint16_t		flags;
 	uint64_t		err;
 };
 
 struct smr_ep;
-typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context,
-		uint64_t flags, uint64_t msg_flags, size_t len, void *buf, void *addr,
+typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, size_t len, void *buf, void *addr,
 		uint64_t tag, uint64_t data, uint64_t err);
-typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context,
-		uint64_t flags, uint16_t op_flags, uint64_t err);
+typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, uint64_t err);
 
 
 struct smr_match_attr {
@@ -218,23 +218,22 @@ void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
 		void *context, struct smr_region *smr, struct smr_resp *resp,
 		struct smr_cmd *pend);
 
-int smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags,
-		uint16_t op_flags, uint64_t err);
-int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
-		       uint16_t op_flags, uint64_t err);
-int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags,
-		uint64_t msg_flags, size_t len, void *buf, void *addr,
-		uint64_t tag, uint64_t data,
-		uint64_t err);
-int smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
-		    uint64_t msg_flags, size_t len, void *buf, void *addr,
-		    uint64_t tag, uint64_t data, uint64_t err);
-int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags, uint64_t msg_flags,
-		       size_t len, void *buf, void *addr, uint64_t tag,
-		       uint64_t data, uint64_t err);
-int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint64_t flags, uint64_t msg_flags,
-			   size_t len, void *buf, void *addr, uint64_t tag,
-			   uint64_t data, uint64_t err);
+int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, uint64_t err);
+int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, uint64_t err);
+int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, size_t len, void *buf, void *addr,
+		uint64_t tag, uint64_t data, uint64_t err);
+int smr_rx_src_comp(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, size_t len, void *buf, void *addr,
+		uint64_t tag, uint64_t data, uint64_t err);
+int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, size_t len, void *buf, void *addr,
+		uint64_t tag, uint64_t data, uint64_t err);
+int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, size_t len, void *buf, void *addr,
+		uint64_t tag, uint64_t data, uint64_t err);
 uint64_t smr_rx_cq_flags(uint32_t op, uint16_t op_flags);
 
 void smr_ep_progress(struct util_ep *util_ep);

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -312,8 +312,7 @@ static ssize_t smr_atomic_writemsg(struct fid_ep *ep_fid,
 				  NULL, NULL, 0, NULL, NULL, 0, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic,
-				  flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
+				  ofi_op_atomic, flags | ep->util_ep.tx_msg_flags);
 }
 
 static ssize_t smr_atomic_writev(struct fid_ep *ep_fid,
@@ -435,7 +434,7 @@ static ssize_t smr_atomic_readwritemsg(struct fid_ep *ep_fid,
 				  msg->rma_iov, msg->rma_iov_count,
 				  msg->datatype, msg->op, msg->context,
 				  ofi_op_atomic_fetch,
-				  flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
+				  flags | ep->util_ep.tx_msg_flags);
 }
 
 static ssize_t smr_atomic_readwritev(struct fid_ep *ep_fid,
@@ -505,7 +504,7 @@ static ssize_t smr_atomic_compwritemsg(struct fid_ep *ep_fid,
 				  msg->rma_iov, msg->rma_iov_count,
 				  msg->datatype, msg->op, msg->context,
 				  ofi_op_atomic_compare,
-				  flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
+				  flags | ep->util_ep.tx_msg_flags);
 }
 
 static ssize_t smr_atomic_compwritev(struct fid_ep *ep_fid,

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -282,8 +282,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 				"unable to fetch results");
 	}
 
-	ret = ep->tx_comp(ep, context, ofi_tx_cq_flags(op),
-			  cmd->msg.hdr.op_flags, err);
+	ret = ep->tx_comp(ep, context, op, cmd->msg.hdr.op_flags, err);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process tx completion\n");

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -50,12 +50,12 @@ static void smr_format_inline_atomic(struct smr_cmd *cmd, fi_addr_t peer_id,
 				     const struct iovec *compv,
 				     size_t comp_count,  uint32_t op,
 				     enum fi_datatype datatype,
-				     enum fi_op atomic_op)
+				     enum fi_op atomic_op, uint64_t op_flags)
 {
 	size_t comp_size;
 
 	smr_generic_format(cmd, peer_id, op, 0, datatype,
-			   atomic_op, 0, 0);
+			   atomic_op, 0, op_flags);
 	cmd->msg.hdr.op_src = smr_src_inline;
 	switch (op) {
 	case ofi_op_atomic:
@@ -87,12 +87,12 @@ static void smr_format_inject_atomic(struct smr_cmd *cmd, fi_addr_t peer_id,
 				     uint32_t op, enum fi_datatype datatype,
 				     enum fi_op atomic_op,
 				     struct smr_region *smr,
-				     struct smr_inject_buf *tx_buf)
+				     struct smr_inject_buf *tx_buf, uint64_t op_flags)
 {
 	size_t comp_size;
 
 	smr_generic_format(cmd, peer_id, op, 0, datatype,
-			   atomic_op, 0, 0);
+			   atomic_op, 0, op_flags);
 	cmd->msg.hdr.op_src = smr_src_inject;
 	cmd->msg.hdr.src_data = (char **) tx_buf - (char **) smr;
 
@@ -170,16 +170,16 @@ static void smr_post_fetch_resp(struct smr_ep *ep, struct smr_cmd *cmd,
 	ofi_cirque_commit(smr_resp_queue(ep->region));
 }
 
-static ssize_t smr_generic_atomic(struct fid_ep *ep_fid,
+static ssize_t smr_generic_atomic(struct smr_ep *ep,
 			const struct fi_ioc *ioc, void **desc, size_t count,
 			const struct fi_ioc *compare_ioc, void **compare_desc,
 			size_t compare_count, struct fi_ioc *result_ioc,
 			void **result_desc, size_t result_count,
 			fi_addr_t addr, const struct fi_rma_ioc *rma_ioc,
 			size_t rma_count, enum fi_datatype datatype,
-			enum fi_op atomic_op, void *context, uint32_t op)
+			enum fi_op atomic_op, void *context, uint32_t op,
+			uint64_t op_flags)
 {
-	struct smr_ep *ep;
 	struct smr_domain *domain;
 	struct smr_region *peer_smr;
 	struct smr_inject_buf *tx_buf;
@@ -197,7 +197,6 @@ static ssize_t smr_generic_atomic(struct fid_ep *ep_fid,
 	assert(compare_count <= SMR_IOV_LIMIT);
 	assert(rma_count <= SMR_IOV_LIMIT);
 
-	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 	domain = container_of(ep->util_ep.domain, struct smr_domain, util_domain);
 
 	peer_id = (int) addr;
@@ -251,13 +250,13 @@ static ssize_t smr_generic_atomic(struct fid_ep *ep_fid,
 	if (total_len <= SMR_MSG_DATA_LEN && !(flags & SMR_RMA_REQ)) {
 		smr_format_inline_atomic(cmd, smr_peer_addr(ep->region)[peer_id].addr,
 					 iov, count, compare_iov, compare_count,
-					 op, datatype, atomic_op);
+					 op, datatype, atomic_op, op_flags);
 	} else if (total_len <= SMR_INJECT_SIZE) {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
 		smr_format_inject_atomic(cmd, smr_peer_addr(ep->region)[peer_id].addr,
 					 iov, count, result_iov, result_count,
 					 compare_iov, compare_count, op, datatype,
-					 atomic_op, peer_smr, tx_buf);
+					 atomic_op, peer_smr, tx_buf, op_flags);
 	} else {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"message too large\n");
@@ -283,7 +282,8 @@ static ssize_t smr_generic_atomic(struct fid_ep *ep_fid,
 				"unable to fetch results");
 	}
 
-	ret = ep->tx_comp(ep, context, ofi_tx_cq_flags(op), err);
+	ret = ep->tx_comp(ep, context, ofi_tx_cq_flags(op),
+			  cmd->msg.hdr.op_flags, err);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process tx completion\n");
@@ -301,22 +301,30 @@ unlock_region:
 	return ret;
 }
 
-static ssize_t smr_atomic_writemsg(struct fid_ep *ep,
+static ssize_t smr_atomic_writemsg(struct fid_ep *ep_fid,
 			const struct fi_msg_atomic *msg, uint64_t flags)
 {
+	struct smr_ep *ep;
+
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
+
 	return smr_generic_atomic(ep, msg->msg_iov, msg->desc, msg->iov_count,
 				  NULL, NULL, 0, NULL, NULL, 0, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic);
+				  ofi_op_atomic,
+				  flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
 }
 
-static ssize_t smr_atomic_writev(struct fid_ep *ep,
+static ssize_t smr_atomic_writev(struct fid_ep *ep_fid,
 			const struct fi_ioc *iov, void **desc, size_t count,
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op, void *context)
 {
+	struct smr_ep *ep;
 	struct fi_rma_ioc rma_iov;
+
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
 	rma_iov.addr = addr;
 	rma_iov.count = ofi_total_ioc_cnt(iov, count);
@@ -324,16 +332,19 @@ static ssize_t smr_atomic_writev(struct fid_ep *ep,
 
 	return smr_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, NULL,
 				  NULL, 0, dest_addr, &rma_iov, 1, datatype,
-				  op, context, ofi_op_atomic);
+				  op, context, ofi_op_atomic, smr_ep_tx_flags(ep));
 }
 
-static ssize_t smr_atomic_write(struct fid_ep *ep, const void *buf, size_t count,
+static ssize_t smr_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t count,
 			void *desc, fi_addr_t dest_addr, uint64_t addr,
 			uint64_t key, enum fi_datatype datatype, enum fi_op op,
 			void *context)
 {
+	struct smr_ep *ep;
 	struct fi_ioc iov;
 	struct fi_rma_ioc rma_iov;
+
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
 	iov.addr = (void *) buf;
 	iov.count = count;
@@ -344,7 +355,7 @@ static ssize_t smr_atomic_write(struct fid_ep *ep, const void *buf, size_t count
 
 	return smr_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, NULL, NULL, 0,
 				  dest_addr, &rma_iov, 1, datatype, op, context,
-				  ofi_op_atomic);
+				  ofi_op_atomic, smr_ep_tx_flags(ep));
 }
 
 static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
@@ -390,12 +401,12 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	if (total_len <= SMR_MSG_DATA_LEN) {
 		smr_format_inline_atomic(cmd, smr_peer_addr(ep->region)[peer_id].addr,
 					 &iov, 1, NULL, 0, ofi_op_atomic,
-					 datatype, op);
+					 datatype, op, 0);
 	} else if (total_len <= SMR_INJECT_SIZE) {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
 		smr_format_inject_atomic(cmd, smr_peer_addr(ep->region)[peer_id].addr,
 					 &iov, 1, NULL, 0, NULL, 0, ofi_op_atomic,
-					 datatype, op, peer_smr, tx_buf);
+					 datatype, op, peer_smr, tx_buf, 0);
 	}
 
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
@@ -410,26 +421,34 @@ unlock_region:
 	return ret;
 }
 
-static ssize_t smr_atomic_readwritemsg(struct fid_ep *ep,
+static ssize_t smr_atomic_readwritemsg(struct fid_ep *ep_fid,
 			const struct fi_msg_atomic *msg, struct fi_ioc *resultv,
 			void **result_desc, size_t result_count, uint64_t flags)
 {
+	struct smr_ep *ep;
+
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
+
 	return smr_generic_atomic(ep, msg->msg_iov, msg->desc, msg->iov_count,
 				  NULL, NULL, 0, resultv, result_desc,
 				  result_count, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic_fetch);
+				  ofi_op_atomic_fetch,
+				  flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
 }
 
-static ssize_t smr_atomic_readwritev(struct fid_ep *ep,
+static ssize_t smr_atomic_readwritev(struct fid_ep *ep_fid,
 			const struct fi_ioc *iov, void **desc, size_t count,
 			struct fi_ioc *resultv, void **result_desc,
 			size_t result_count, fi_addr_t dest_addr, uint64_t addr,
 			uint64_t key, enum fi_datatype datatype, enum fi_op op,
 			void *context)
 {
+	struct smr_ep *ep;
 	struct fi_rma_ioc rma_iov;
+
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
 	rma_iov.addr = addr;
 	rma_iov.count = ofi_total_ioc_cnt(iov, count);
@@ -438,17 +457,20 @@ static ssize_t smr_atomic_readwritev(struct fid_ep *ep,
 	return smr_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, resultv,
 				  result_desc, result_count, dest_addr,
 				  &rma_iov, 1, datatype, op, context,
-				  ofi_op_atomic_fetch);
+				  ofi_op_atomic_fetch, smr_ep_tx_flags(ep));
 }
 
-static ssize_t smr_atomic_readwrite(struct fid_ep *ep, const void *buf,
+static ssize_t smr_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
 			size_t count, void *desc, void *result,
 			void *result_desc, fi_addr_t dest_addr, uint64_t addr,
 			uint64_t key, enum fi_datatype datatype, enum fi_op op,
 			void *context)
 {
+	struct smr_ep *ep;
 	struct fi_ioc iov, resultv;
 	struct fi_rma_ioc rma_iov;
+
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
 	iov.addr = (void *) buf;
 	iov.count = count;
@@ -462,25 +484,31 @@ static ssize_t smr_atomic_readwrite(struct fid_ep *ep, const void *buf,
 
 	return smr_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, &resultv,
 				  &result_desc, 1, dest_addr, &rma_iov, 1,
-				  datatype, op, context, ofi_op_atomic_fetch);
+				  datatype, op, context, ofi_op_atomic_fetch,
+				  smr_ep_tx_flags(ep));
 }
 
-static ssize_t smr_atomic_compwritemsg(struct fid_ep *ep,
+static ssize_t smr_atomic_compwritemsg(struct fid_ep *ep_fid,
 			const struct fi_msg_atomic *msg,
 			const struct fi_ioc *comparev, void **compare_desc,
 			size_t compare_count, struct fi_ioc *resultv,
 			void **result_desc, size_t result_count, uint64_t flags)
 {
+	struct smr_ep *ep;
+
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
+
 	return smr_generic_atomic(ep, msg->msg_iov, msg->desc, msg->iov_count,
 				  comparev, compare_desc, compare_count,
 				  resultv, result_desc,
 				  result_count, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic_compare);
+				  ofi_op_atomic_compare,
+				  flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
 }
 
-static ssize_t smr_atomic_compwritev(struct fid_ep *ep,
+static ssize_t smr_atomic_compwritev(struct fid_ep *ep_fid,
 			const struct fi_ioc *iov, void **desc, size_t count,
 			const struct fi_ioc *comparev, void **compare_desc,
 			size_t compare_count, struct fi_ioc *resultv,
@@ -488,7 +516,10 @@ static ssize_t smr_atomic_compwritev(struct fid_ep *ep,
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op, void *context)
 {
+	struct smr_ep *ep;
 	struct fi_rma_ioc rma_iov;
+
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
 	rma_iov.addr = addr;
 	rma_iov.count = ofi_total_ioc_cnt(iov, count);
@@ -497,17 +528,21 @@ static ssize_t smr_atomic_compwritev(struct fid_ep *ep,
 	return smr_generic_atomic(ep, iov, desc, count, comparev, compare_desc,
 				  compare_count, resultv, result_desc,
 				  result_count, dest_addr, &rma_iov, 1,
-				  datatype, op, context, ofi_op_atomic_compare);
+				  datatype, op, context, ofi_op_atomic_compare,
+				  smr_ep_tx_flags(ep));
 }
 
-static ssize_t smr_atomic_compwrite(struct fid_ep *ep, const void *buf,
+static ssize_t smr_atomic_compwrite(struct fid_ep *ep_fid, const void *buf,
 			size_t count, void *desc, const void *compare,
 			void *compare_desc, void *result, void *result_desc,
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op, void *context)
 {
+	struct smr_ep *ep;
 	struct fi_ioc iov, resultv, comparev;
 	struct fi_rma_ioc rma_iov;
+
+	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
 	iov.addr = (void *) buf;
 	iov.count = count;
@@ -525,7 +560,7 @@ static ssize_t smr_atomic_compwrite(struct fid_ep *ep, const void *buf,
 	return smr_generic_atomic(ep, &iov, &desc, 1, &comparev, &compare_desc,
 				  1, &resultv, &result_desc, 1, dest_addr,
 				  &rma_iov, 1, datatype, op, context,
-				  ofi_op_atomic_compare);
+				  ofi_op_atomic_compare, smr_ep_tx_flags(ep));
 }
 
 int smr_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -75,6 +75,7 @@ struct fi_domain_attr smr_domain_attr = {
 	.resource_mgmt = FI_RM_ENABLED,
 	.av_type = FI_AV_UNSPEC,
 	.mr_mode = FI_MR_SCALABLE,
+	.mr_key_size = sizeof_field(struct fi_rma_iov, key),
 	.cq_data_size = sizeof_field(struct smr_msg_hdr, data),
 	.cq_cnt = (1 << 10),
 	.ep_cnt = (1 << 10),

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -211,7 +211,7 @@ int smr_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (!smr_av)
 		return -FI_ENOMEM;
 
-	util_attr.addrlen = sizeof(int);
+	util_attr.addrlen = SMR_NAME_SIZE;
 	util_attr.flags = 0;
 	if (attr->count > SMR_MAX_PEERS) {
 		ret = -FI_ENOSYS;

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -37,8 +37,8 @@
 #include "ofi_iov.h"
 #include "smr.h"
 
-int smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags,
-		uint16_t op_flags, uint64_t err)
+int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, uint64_t err)
 {
 	struct fi_cq_tagged_entry *comp;
 	struct util_cq_oflow_err_entry *entry;
@@ -48,15 +48,15 @@ int smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags,
 		if (!(entry = calloc(1, sizeof(*entry))))
 			return -FI_ENOMEM;
 		entry->comp.op_context = context;
-		entry->comp.flags = flags;
+		entry->comp.flags = ofi_tx_cq_flags(op);
 		entry->comp.err = err;
 		entry->comp.prov_errno = -err;
 		slist_insert_tail(&entry->list_entry,
 				  &ep->util_ep.tx_cq->oflow_err_list);
 		comp->flags = UTIL_FLAG_ERROR;
-	} else if (op_flags & SMR_COMPLETION) {
+	} else if (flags & SMR_TX_COMPLETION) {
 		comp->op_context = context;
-		comp->flags = flags;
+		comp->flags = ofi_tx_cq_flags(op);
 		comp->len = 0;
 		comp->buf = NULL;
 		comp->data = 0;
@@ -67,21 +67,21 @@ int smr_tx_comp(struct smr_ep *ep, void *context, uint64_t flags,
 	return 0;
 }
 
-int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
-		       uint16_t op_flags, uint64_t err)
+int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, uint64_t err)
 {
 	int ret;
 
-	ret = smr_tx_comp(ep, context, flags, op_flags, err);
+	ret = smr_tx_comp(ep, context, op, flags, err);
 	if (ret)
 		return ret;
 	ep->util_ep.tx_cq->wait->signal(ep->util_ep.tx_cq->wait);
 	return 0;
 }
 
-int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags, uint64_t msg_flags,
-		size_t len, void *buf, void *addr, uint64_t tag, uint64_t data,
-		uint64_t err)
+int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
+		uint16_t flags, size_t len, void *buf, void *addr,
+		uint64_t tag, uint64_t data, uint64_t err)
 {
 	struct fi_cq_tagged_entry *comp;
 	struct util_cq_oflow_err_entry *entry;
@@ -91,16 +91,16 @@ int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags, uint64_t msg_f
 		if (!(entry = calloc(1, sizeof(*entry))))
 			return -FI_ENOMEM;
 		entry->comp.op_context = context;
-		entry->comp.flags = flags;
+		entry->comp.flags = smr_rx_cq_flags(op, flags);
 		entry->comp.tag = tag;
 		entry->comp.err = err;
 		entry->comp.prov_errno = -err;
 		slist_insert_tail(&entry->list_entry,
 				  &ep->util_ep.rx_cq->oflow_err_list);
 		comp->flags = UTIL_FLAG_ERROR;
-	} else if (flags & FI_REMOTE_CQ_DATA || msg_flags & FI_COMPLETION) {
+	} else if (flags & SMR_REMOTE_CQ_DATA || flags & SMR_RX_COMPLETION) {
 		comp->op_context = context;
-		comp->flags = flags;
+		comp->flags = smr_rx_cq_flags(op, flags);
 		comp->len = len;
 		comp->buf = buf;
 		comp->data = data;
@@ -112,36 +112,36 @@ int smr_rx_comp(struct smr_ep *ep, void *context, uint64_t flags, uint64_t msg_f
 	return 0;
 }
 
-int smr_rx_src_comp(struct smr_ep *ep, void *context, uint64_t flags,
-		    uint64_t msg_flags, size_t len, void *buf, void *addr,
+int smr_rx_src_comp(struct smr_ep *ep, void *context, uint32_t op,
+		    uint16_t flags, size_t len, void *buf, void *addr,
 		    uint64_t tag, uint64_t data, uint64_t err)
 {
 	ep->util_ep.rx_cq->src[ofi_cirque_windex(ep->util_ep.rx_cq->cirq)] =
 		(uint32_t) (uintptr_t) addr;
-	return smr_rx_comp(ep, context, flags, msg_flags, len, buf, addr, tag,
+	return smr_rx_comp(ep, context, op, flags, len, buf, addr, tag,
 			   data, err);
 }
 
-int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
-		       uint64_t msg_flags, size_t len, void *buf, void *addr,
+int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
+		       uint16_t flags, size_t len, void *buf, void *addr,
 		       uint64_t tag, uint64_t data, uint64_t err)
 {
 	int ret;
 
-	ret = smr_rx_comp(ep, context, flags, msg_flags, len, buf, addr, tag, data, err);
+	ret = smr_rx_comp(ep, context, op, flags, len, buf, addr, tag, data, err);
 	if (ret)
 		return ret;
 	ep->util_ep.rx_cq->wait->signal(ep->util_ep.rx_cq->wait);
 	return 0;
 }
 
-int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint64_t flags,
-			   uint64_t msg_flags, size_t len, void *buf, void *addr,
+int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
+			   uint16_t flags, size_t len, void *buf, void *addr,
 			   uint64_t tag, uint64_t data, uint64_t err)
 {
 	int ret;
 
-	ret = smr_rx_src_comp(ep, context, flags, msg_flags, len, buf, addr,
+	ret = smr_rx_src_comp(ep, context, op, flags, len, buf, addr,
 			      tag, data, err);
 	if (ret)
 		return ret;
@@ -158,6 +158,9 @@ uint64_t smr_rx_cq_flags(uint32_t op, uint16_t op_flags)
 
 	if (op_flags & SMR_REMOTE_CQ_DATA)
 		flags |= FI_REMOTE_CQ_DATA;
+
+	if (op_flags & SMR_MULTI_RECV)
+		flags |= FI_MULTI_RECV;
 
 	return flags;
 }

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -136,9 +136,8 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 					 context);
 	if (entry) {
 		recv_entry = container_of(entry, struct smr_ep_entry, entry);
-		ret = ep->rx_comp(ep, (void *) recv_entry->context,
-				  recv_entry->flags | FI_RECV,
-				  recv_entry->flags & FI_COMPLETION ? SMR_COMPLETION : 0, 0,
+		ret = ep->rx_comp(ep, (void *) recv_entry->context, ofi_op_msg,
+				  recv_entry->flags, 0,
 				  NULL, (void *) recv_entry->addr,
 				  recv_entry->tag, 0, FI_ECANCELED);
 		freestack_push(ep->recv_fs, recv_entry);
@@ -243,7 +242,7 @@ void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id,
 	if (op_flags & FI_REMOTE_CQ_DATA)
 		cmd->msg.hdr.op_flags |= SMR_REMOTE_CQ_DATA;
 	if (op_flags & FI_COMPLETION)
-		cmd->msg.hdr.op_flags |= SMR_COMPLETION;
+		cmd->msg.hdr.op_flags |= SMR_TX_COMPLETION;
 
 	if (op == ofi_op_tagged) {
 		cmd->msg.hdr.tag = tag;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -137,7 +137,8 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 	if (entry) {
 		recv_entry = container_of(entry, struct smr_ep_entry, entry);
 		ret = ep->rx_comp(ep, (void *) recv_entry->context,
-				  recv_entry->flags | FI_RECV, 0,
+				  recv_entry->flags | FI_RECV,
+				  recv_entry->flags & FI_COMPLETION ? SMR_COMPLETION : 0, 0,
 				  NULL, (void *) recv_entry->addr,
 				  recv_entry->tag, 0, FI_ECANCELED);
 		freestack_push(ep->recv_fs, recv_entry);
@@ -237,8 +238,13 @@ void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id,
 			uint64_t op_flags)
 {
 	cmd->msg.hdr.op = op;
-	cmd->msg.hdr.op_flags = op_flags & FI_REMOTE_CQ_DATA ?
-				SMR_REMOTE_CQ_DATA : 0;
+	cmd->msg.hdr.op_flags = 0;
+
+	if (op_flags & FI_REMOTE_CQ_DATA)
+		cmd->msg.hdr.op_flags |= SMR_REMOTE_CQ_DATA;
+	if (op_flags & FI_COMPLETION)
+		cmd->msg.hdr.op_flags |= SMR_COMPLETION;
+
 	if (op == ofi_op_tagged) {
 		cmd->msg.hdr.tag = tag;
 	} else if (op == ofi_op_atomic ||
@@ -312,31 +318,19 @@ static int smr_ep_close(struct fid *fid)
 
 static int smr_ep_bind_cq(struct smr_ep *ep, struct util_cq *cq, uint64_t flags)
 {
-	int ret = 0;
+	int ret;
 
-	if (flags & ~(FI_TRANSMIT | FI_RECV)) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"unsupported flags\n");
-		return -FI_EBADFLAGS;
-	}
-
-	if (((flags & FI_TRANSMIT) && ep->util_ep.tx_cq) ||
-	    ((flags & FI_RECV) && ep->util_ep.rx_cq)) {
-		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
-			"duplicate CQ binding\n");
-		return -FI_EINVAL;
-	}
+	ret = ofi_ep_bind_cq(&ep->util_ep, cq, flags);
+	if (ret)
+		return ret;
 
 	if (flags & FI_TRANSMIT) {
 		ep->util_ep.tx_cq = cq;
-		ofi_atomic_inc32(&cq->ref);
 		ep->tx_comp = cq->wait ? smr_tx_comp_signal : smr_tx_comp;
 	}
 
 	if (flags & FI_RECV) {
 		ep->util_ep.rx_cq = cq;
-		ofi_atomic_inc32(&cq->ref);
-
 		if (cq->wait) {
 			ep->rx_comp = (cq->domain->info_domain_caps & FI_SOURCE) ?
 				      smr_rx_src_comp_signal :

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -428,7 +428,7 @@ static int smr_endpoint_name(char *name, char *addr, size_t addrlen,
 		return -FI_EINVAL;
 
 	start = smr_no_prefix((const char *) addr);
-	if (strstr(addr, SMR_PREFIX))
+	if (strstr(addr, SMR_PREFIX) || dom_idx || ep_idx)
 		snprintf(name, SMR_NAME_SIZE, "%s:%d:%d", start, dom_idx,
 			 ep_idx);
 	else

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -191,7 +191,10 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 				  iov, iov_count, op, tag, data, op_flags,
 				  peer_smr, tx_buf);
 	} else {
-		assert(!ofi_cirque_isfull(smr_resp_queue(ep->region)));
+		if (ofi_cirque_isfull(smr_resp_queue(ep->region))) {
+			ret = -FI_EAGAIN;
+			goto unlock_cq;
+		}
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 		pend = freestack_pop(ep->pend_fs);
 		smr_format_iov(cmd, smr_peer_addr(ep->region)[peer_id].addr, iov,

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -38,7 +38,19 @@
 #include "smr.h"
 
 
-static inline struct smr_ep_entry *smr_get_recv_entry(struct smr_ep *ep)
+static inline uint16_t smr_convert_rx_flags(uint64_t fi_flags)
+{
+	uint16_t flags = 0;
+
+	if (fi_flags & FI_COMPLETION)
+		flags |= SMR_RX_COMPLETION;
+	if (fi_flags & FI_MULTI_RECV)
+		flags |= SMR_MULTI_RECV;
+
+	return flags;
+}
+
+static inline struct smr_ep_entry *smr_get_recv_entry(struct smr_ep *ep, uint64_t flags)
 {
 	struct smr_ep_entry *entry;
 
@@ -50,6 +62,8 @@ static inline struct smr_ep_entry *smr_get_recv_entry(struct smr_ep *ep)
 	entry->tag = 0; /* does this need to be set? */
 	entry->ignore = 0; /* does this need to be set? */
 	entry->err = 0;
+	entry->flags = smr_convert_rx_flags(flags);
+
 	return entry;
 }
 
@@ -65,7 +79,7 @@ ssize_t smr_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
-	entry = smr_get_recv_entry(ep);
+	entry = smr_get_recv_entry(ep, flags | ep->util_ep.rx_msg_flags);
 	if (!entry) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -75,7 +89,6 @@ ssize_t smr_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	memcpy(&entry->iov, msg->msg_iov, sizeof(*msg->msg_iov) * msg->iov_count);
 
 	entry->context = msg->context;
-	entry->flags = flags | ep->util_ep.rx_msg_flags;
 	entry->addr = msg->addr;
 
 	dlist_insert_tail(&entry->entry, &ep->recv_queue.list);
@@ -96,7 +109,7 @@ ssize_t smr_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	assert(!(smr_ep_rx_flags(ep) & FI_MULTI_RECV) || count == 1);
 
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
-	entry = smr_get_recv_entry(ep);
+	entry = smr_get_recv_entry(ep, smr_ep_rx_flags(ep));
 	if (!entry) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -106,7 +119,6 @@ ssize_t smr_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	memcpy(&entry->iov, iov, sizeof(*iov) * count);
 
 	entry->context = context;
-	entry->flags = smr_ep_rx_flags(ep);
 	entry->addr = src_addr;
 
 	dlist_insert_tail(&entry->entry, &ep->recv_queue.list);
@@ -124,7 +136,7 @@ ssize_t smr_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
-	entry = smr_get_recv_entry(ep);
+	entry = smr_get_recv_entry(ep, smr_ep_rx_flags(ep));
 	if (!entry) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -135,7 +147,6 @@ ssize_t smr_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	entry->iov[0].iov_len = len;
 
 	entry->context = context;
-	entry->flags = smr_ep_rx_flags(ep);
 	entry->addr = src_addr;
 
 	dlist_insert_tail(&entry->entry, &ep->recv_queue.list);
@@ -203,7 +214,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 		ofi_cirque_commit(smr_resp_queue(ep->region));
 		goto commit;
 	}
-	ret = ep->tx_comp(ep, context, ofi_tx_cq_flags(op), cmd->msg.hdr.op_flags, 0);
+	ret = ep->tx_comp(ep, context, op, cmd->msg.hdr.op_flags, 0);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process tx completion\n");
@@ -354,7 +365,7 @@ struct fi_ops_msg smr_msg_ops = {
 	.injectdata = smr_injectdata,
 };
 
-static inline struct smr_ep_entry *smr_get_trecv_entry(struct smr_ep *ep)
+static inline struct smr_ep_entry *smr_get_trecv_entry(struct smr_ep *ep, uint64_t flags)
 {
 	struct smr_ep_entry *entry;
 
@@ -363,6 +374,8 @@ static inline struct smr_ep_entry *smr_get_trecv_entry(struct smr_ep *ep)
 
 	entry = freestack_pop(ep->recv_fs);
 	entry->err = 0;
+	entry->flags = smr_convert_rx_flags(flags);
+
 	return entry;
 }
 
@@ -388,7 +401,7 @@ ssize_t smr_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
-	entry = smr_get_trecv_entry(ep);
+	entry = smr_get_trecv_entry(ep, smr_ep_rx_flags(ep));
 	if (!entry) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -399,7 +412,6 @@ ssize_t smr_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	entry->iov[0].iov_len = len;
 
 	entry->context = context;
-	entry->flags = smr_ep_rx_flags(ep);
 	entry->addr = src_addr;
 	entry->tag = tag;
 	entry->ignore = ignore;
@@ -423,7 +435,7 @@ ssize_t smr_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	assert(!(smr_ep_rx_flags(ep) & FI_MULTI_RECV) || count == 1);
 
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
-	entry = smr_get_trecv_entry(ep);
+	entry = smr_get_trecv_entry(ep, smr_ep_rx_flags(ep));
 	if (!entry) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -433,7 +445,6 @@ ssize_t smr_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	memcpy(&entry->iov, iov, sizeof(*iov) * count);
 
 	entry->context = context;
-	entry->flags = smr_ep_rx_flags(ep);
 	entry->addr = src_addr;
 	entry->tag = tag;
 	entry->ignore = ignore;
@@ -456,7 +467,7 @@ ssize_t smr_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
-	entry = smr_get_trecv_entry(ep);
+	entry = smr_get_trecv_entry(ep, flags | ep->util_ep.rx_msg_flags);
 	if (!entry) {
 		ret = -FI_EAGAIN;
 		goto out;
@@ -466,7 +477,6 @@ ssize_t smr_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	memcpy(&entry->iov, msg->msg_iov, sizeof(*msg->msg_iov) * msg->iov_count);
 
 	entry->context = msg->context;
-	entry->flags = flags | ep->util_ep.rx_msg_flags;
 	entry->addr = msg->addr;
 	entry->tag = msg->tag;
 	entry->ignore = msg->ignore;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -75,7 +75,7 @@ ssize_t smr_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	memcpy(&entry->iov, msg->msg_iov, sizeof(*msg->msg_iov) * msg->iov_count);
 
 	entry->context = msg->context;
-	entry->flags = flags | (smr_ep_rx_flags(ep) & FI_COMPLETION);
+	entry->flags = flags | ep->util_ep.rx_msg_flags;
 	entry->addr = msg->addr;
 
 	dlist_insert_tail(&entry->entry, &ep->recv_queue.list);
@@ -256,8 +256,7 @@ ssize_t smr_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	return smr_generic_sendmsg(ep, msg->msg_iov, msg->iov_count,
 				   msg->addr, 0, msg->data, msg->context,
-				   ofi_op_msg,
-				   flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
+				   ofi_op_msg, flags | ep->util_ep.tx_msg_flags);
 }
 
 static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
@@ -467,7 +466,7 @@ ssize_t smr_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	memcpy(&entry->iov, msg->msg_iov, sizeof(*msg->msg_iov) * msg->iov_count);
 
 	entry->context = msg->context;
-	entry->flags = flags | (smr_ep_rx_flags(ep) & FI_COMPLETION);
+	entry->flags = flags | ep->util_ep.rx_msg_flags;
 	entry->addr = msg->addr;
 	entry->tag = msg->tag;
 	entry->ignore = msg->ignore;
@@ -516,8 +515,7 @@ ssize_t smr_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	return smr_generic_sendmsg(ep, msg->msg_iov, msg->iov_count,
 				   msg->addr, msg->tag, msg->data, msg->context,
-				   ofi_op_tagged,
-				   flags | (smr_ep_tx_flags(ep) | FI_COMPLETION));
+				   ofi_op_tagged, flags | ep->util_ep.tx_msg_flags);
 }
 
 ssize_t smr_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -95,8 +95,8 @@ static void smr_progress_resp(struct smr_ep *ep)
 				break;
 
 		ret = ep->tx_comp(ep, (void *) (uintptr_t) pending->msg.hdr.msg_id,
-				  ofi_tx_cq_flags(pending->msg.hdr.op),
-				  pending->msg.hdr.op_flags, -(resp->status));
+				  pending->msg.hdr.op, pending->msg.hdr.op_flags,
+				  -(resp->status));
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 				"unable to process tx completion\n");
@@ -207,7 +207,8 @@ static int smr_progress_multi_recv(struct smr_ep *ep, struct smr_queue *queue,
 
 	left = entry->iov[0].iov_len - len;
 	if (left < ep->min_multi_recv_size) {
-		ret = ep->rx_comp(ep, entry->context, FI_MULTI_RECV, entry->flags, 0, 0,
+		ret = ep->rx_comp(ep, entry->context, ofi_op_msg,
+				  SMR_MULTI_RECV | entry->flags, 0, 0,
 				  &entry->addr, 0, 0, 0);
 		freestack_push(ep->recv_fs, entry);
 		return ret;
@@ -381,9 +382,9 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 			"unidentified operation type\n");
 		err = -FI_EINVAL;
 	}
-	ret = ep->rx_comp(ep, entry->context, smr_rx_cq_flags(cmd->msg.hdr.op,
-			  cmd->msg.hdr.op_flags), entry->flags, total_len,
-			  entry->iov[0].iov_base, &addr, cmd->msg.hdr.tag,
+	ret = ep->rx_comp(ep, entry->context, cmd->msg.hdr.op,
+			  cmd->msg.hdr.op_flags | (entry->flags & ~SMR_MULTI_RECV),
+			  total_len, entry->iov[0].iov_base, &addr, cmd->msg.hdr.tag,
 			  cmd->msg.hdr.data, err);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
@@ -392,7 +393,7 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 	ofi_cirque_discard(smr_cmd_queue(ep->region));
 	ep->region->cmd_cnt++;
 
-	if (entry->flags & FI_MULTI_RECV) {
+	if (entry->flags & SMR_MULTI_RECV) {
 		ret = smr_progress_multi_recv(ep, recv_queue, entry, total_len);
 		return ret;
 	}
@@ -459,9 +460,8 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	}
 	if (cmd->msg.hdr.op_flags & SMR_REMOTE_CQ_DATA) {
 		ret = ep->rx_comp(ep, (void *) cmd->msg.hdr.msg_id,
-				  smr_rx_cq_flags(cmd->msg.hdr.op,
-				  cmd->msg.hdr.op_flags), cmd->msg.hdr.op_flags,
-				  total_len, NULL, &cmd->msg.hdr.addr, 0,
+				  cmd->msg.hdr.op, cmd->msg.hdr.op_flags,
+				  total_len, iov[0].iov_base, &cmd->msg.hdr.addr, 0,
 				  cmd->msg.hdr.data, err);
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
@@ -642,9 +642,8 @@ int smr_progress_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 			"unidentified operation type\n");
 		entry->err = FI_EINVAL;
 	}
-	ret = ep->rx_comp(ep, entry->context,
-			  smr_rx_cq_flags(unexp_msg->cmd.msg.hdr.op,
-			  unexp_msg->cmd.msg.hdr.op_flags), entry->flags,
+	ret = ep->rx_comp(ep, entry->context, unexp_msg->cmd.msg.hdr.op,
+			  unexp_msg->cmd.msg.hdr.op_flags | entry->flags,
 			  total_len, entry->iov[0].iov_base, &entry->addr, entry->tag,
 			  unexp_msg->cmd.msg. hdr.data, entry->err);
 	if (ret) {
@@ -655,7 +654,7 @@ int smr_progress_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 	ep->region->cmd_cnt++;
 	freestack_push(ep->unexp_fs, unexp_msg);
 
-	if (entry->flags & FI_MULTI_RECV) {
+	if (entry->flags & SMR_MULTI_RECV) {
 		ret = smr_progress_multi_recv(ep, &ep->trecv_queue, entry,
 					      total_len);
 		return ret ? ret : -FI_ENOMSG;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -159,7 +159,10 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 				  iov, iov_count, op, 0, data, op_flags,
 				  peer_smr, tx_buf);
 	} else {
-		assert(!ofi_cirque_isfull(smr_resp_queue(ep->region)));
+		if (ofi_cirque_isfull(smr_resp_queue(ep->region))) {
+			ret = -FI_EAGAIN;
+			goto unlock_cq;
+		}
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 		pend = freestack_pop(ep->pend_fs);
 		smr_format_iov(cmd, smr_peer_addr(ep->region)[peer_id].addr,

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -247,7 +247,7 @@ ssize_t smr_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
 			       ofi_op_read_req, 0,
-			       flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
+			       flags | ep->util_ep.tx_msg_flags);
 }
 
 ssize_t smr_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
@@ -295,12 +295,12 @@ ssize_t smr_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	struct smr_ep *ep;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
-	
+
 	return smr_generic_rma(ep, msg->msg_iov, msg->iov_count,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
 			       ofi_op_write, msg->data,
-			       flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
+			       flags | ep->util_ep.tx_msg_flags);
 }
 
 ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -47,16 +47,17 @@ static void smr_format_rma_iov(struct smr_cmd *cmd, const struct fi_rma_iov *rma
 
 static void smr_format_rma_resp(struct smr_cmd *cmd, fi_addr_t peer_id,
 				const struct fi_rma_iov *rma_iov, size_t count,
-				size_t total_len, uint32_t op)
+				size_t total_len, uint32_t op, uint64_t op_flags)
 {
-	smr_generic_format(cmd, peer_id, op, 0, 0, 0, 0, 0);
+	smr_generic_format(cmd, peer_id, op, 0, 0, 0, 0, op_flags);
 	cmd->msg.hdr.size = total_len;
 }
 
 ssize_t smr_rma_fast(struct smr_region *peer_smr, struct smr_cmd *cmd,
 		     const struct iovec *iov, size_t iov_count,
 		     const struct fi_rma_iov *rma_iov, size_t rma_count,
-		     void **desc, int peer_id, void *context, uint32_t op)
+		     void **desc, int peer_id, void *context, uint32_t op,
+		     uint64_t op_flags)
 {
 	struct iovec rma_iovec[SMR_IOV_LIMIT];
 	size_t total_len;
@@ -92,7 +93,7 @@ ssize_t smr_rma_fast(struct smr_region *peer_smr, struct smr_cmd *cmd,
 
 	smr_format_rma_resp(cmd, peer_id, rma_iov, rma_count, total_len,
 			    (op == ofi_op_write) ? ofi_op_write_rsp :
-			    ofi_op_read_rsp);
+			    ofi_op_read_rsp, op_flags);
 
 	return 0;
 }
@@ -108,6 +109,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	struct smr_resp *resp;
 	struct smr_cmd *cmd, *pend;
 	int peer_id, cmds, err = 0, comp = 1;
+	uint16_t comp_flags;
 	ssize_t ret = 0;
 	size_t total_len;
 
@@ -141,7 +143,8 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 
 	if (cmds == 1) {
 		err = smr_rma_fast(peer_smr, cmd, iov, iov_count, rma_iov,
-				   rma_count, desc, peer_id, context, op);
+				   rma_count, desc, peer_id, context, op, op_flags);
+		comp_flags = cmd->msg.hdr.op_flags;
 		goto commit_comp;
 	}
 
@@ -166,6 +169,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		comp = 0;
 	}
 
+	comp_flags = cmd->msg.hdr.op_flags;
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
@@ -178,7 +182,7 @@ commit_comp:
 	if (!comp)
 		goto unlock_cq;
 
-	ret = ep->tx_comp(ep, context, ofi_tx_cq_flags(op), err);
+	ret = ep->tx_comp(ep, context, ofi_tx_cq_flags(op), comp_flags, err);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process tx completion\n");
@@ -239,7 +243,8 @@ ssize_t smr_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	return smr_generic_rma(ep, msg->msg_iov, msg->iov_count,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
-			       ofi_op_read_req, 0, flags);
+			       ofi_op_read_req, 0,
+			       flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
 }
 
 ssize_t smr_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
@@ -287,11 +292,12 @@ ssize_t smr_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	struct smr_ep *ep;
 
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
-
+	
 	return smr_generic_rma(ep, msg->msg_iov, msg->iov_count,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
-			       ofi_op_write, msg->data, flags);
+			       ofi_op_write, msg->data,
+			       flags | (smr_ep_tx_flags(ep) & FI_COMPLETION));
 }
 
 ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
@@ -336,7 +342,7 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 
 	if (cmds == 1) {
 		ret = smr_rma_fast(peer_smr, cmd, &iov, 1, &rma_iov, 1, NULL,
-				   peer_id, NULL, ofi_op_write);
+				   peer_id, NULL, ofi_op_write, flags);
 		goto commit;
 	}
 
@@ -380,7 +386,8 @@ ssize_t smr_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	rma_iov.key = key;
 
 	return smr_generic_rma(ep, &iov, 1, &rma_iov, 1, &desc, dest_addr, context,
-			       ofi_op_write, data, FI_REMOTE_CQ_DATA);
+			       ofi_op_write, data,
+			       FI_REMOTE_CQ_DATA | smr_ep_tx_flags(ep));
 }
 
 ssize_t smr_rma_inject(struct fid_ep *ep_fid, const void *buf,

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -185,7 +185,7 @@ commit_comp:
 	if (!comp)
 		goto unlock_cq;
 
-	ret = ep->tx_comp(ep, context, ofi_tx_cq_flags(op), comp_flags, err);
+	ret = ep->tx_comp(ep, context, op, comp_flags, err);
 	if (ret) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"unable to process tx completion\n");

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -46,15 +46,19 @@ int ofi_ep_bind_cq(struct util_ep *ep, struct util_cq *cq, uint64_t flags)
 
 	if (flags & FI_TRANSMIT) {
 		ep->tx_cq = cq;
-		if (!(flags & FI_SELECTIVE_COMPLETION))
+		if (!(flags & FI_SELECTIVE_COMPLETION)) {
 			ep->tx_op_flags |= FI_COMPLETION;
+			ep->tx_msg_flags = FI_COMPLETION;
+		}
 		ofi_atomic_inc32(&cq->ref);
 	}
 
 	if (flags & FI_RECV) {
 		ep->rx_cq = cq;
-		if (!(flags & FI_SELECTIVE_COMPLETION))
+		if (!(flags & FI_SELECTIVE_COMPLETION)) {
 			ep->rx_op_flags |= FI_COMPLETION;
+			ep->rx_msg_flags = FI_COMPLETION;
+		}
 		ofi_atomic_inc32(&cq->ref);
 	}
 
@@ -212,6 +216,8 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	ep->progress = progress;
 	ep->tx_op_flags = info->tx_attr->op_flags;
 	ep->rx_op_flags = info->rx_attr->op_flags;
+	ep->tx_msg_flags = 0;
+	ep->rx_msg_flags = 0;
 	ep->inject_op_flags =
 		((info->tx_attr->op_flags &
 		  ~(FI_COMPLETION | FI_INJECT_COMPLETE |

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -88,7 +88,6 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 		goto err2;
 	}
 
-	/* TODO: If we unlink here, can other processes open the region? */
 	close(fd);
 
 	*smr = mapped_addr;
@@ -129,6 +128,7 @@ err1:
 void smr_free(struct smr_region *smr)
 {
 	shm_unlink(smr_name(smr));
+	munmap(smr, smr->total_size);
 }
 
 int smr_map_create(const struct fi_provider *prov, int peer_count,


### PR DESCRIPTION
- fix shm unmapping to allow ubertest to run
- add selective completion support in shm provider
- add SELECTIVE_COMPLETION tests to shm and sockets to check all cases
- change assert to check and return
- man page update
- add util_ep->tx_msg_flags and util_ep->rx_msg_flags to check for default flags for msg functions and update in the rxm provider
- set mr_key_size
- address fixes