### PR TITLE
[v1.7.x]prov/verbs: Fix double free of connection request info in XRC fi_accept error path 

### DIFF
--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -334,13 +334,13 @@ int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
 	fi_ibv_next_xrc_conn_state(ep);
 
 	ret = rdma_accept(ep->tgt_id, &conn_param);
-	if (ret) {
+	if (OFI_UNLIKELY(ret)) {
 		ret = -errno;
 		VERBS_INFO_ERRNO(FI_LOG_EP_CTRL,
-				 "XRC TGT, ibv_open_qp", errno);
+				 "XRC TGT, rdma_accept", errno);
 		fi_ibv_prev_xrc_conn_state(ep);
-	}
-	free(connreq);
+	} else
+		free(connreq);
 	return ret;
 }
 


### PR DESCRIPTION

Connection request handle will be freed on subsequent fi_reject().
This makes XRC consistent with RC implementation.

(fix from commit: 893eb199a7f683102546914cd120b3b307dd122c)

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>