### PR TITLE
configury: Fix mm aware atomic test

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,13 +243,13 @@ AC_TRY_LINK([#include <stdint.h>],
 dnl Check for gcc memory model aware built-in atomics
 dnl If supported check to see if not internal to compiler
 AC_MSG_CHECKING(compiler support for built-in memory model aware atomics)
-AC_TRY_LINK([#include <stdint.h>],
+AC_TRY_COMPILE([#include <stdint.h>],
     [uint64_t d;
      uint64_t s;
      uint64_t c;
      uint64_t r;
       r = __atomic_fetch_add(&d, s, __ATOMIC_SEQ_CST);
-      __atomic_load(&d, &r, __ATOMIC_SEQ_CST);
+      r = __atomic_load_8(&d, __ATOMIC_SEQ_CST);
       __atomic_exchange(&d, &s, &r, __ATOMIC_SEQ_CST);
       __atomic_compare_exchange(&d,&c,&s,0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
      #if defined(__PPC__) && !defined(__PPC64__)


### PR DESCRIPTION
1. Do not use a link test before checking whether libatomic is
required to provide __atomic built-in symbols.

2. Include usage of an __atomic_load_n function in compilation test,
since some old compilers (e.g. Clang 3.4) support __atomic_load but
not __atomic_load_n.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>