### PR TITLE
man/endpoint: Clarify counter and cq completions with FI_SELECTIVE_CO…

### DIFF
--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -81,17 +81,21 @@ int fi_cntr_wait(struct fid_cntr *cntr, uint64_t threshold,
 
 Counters record the number of requested operations that have
 completed.  Counters can provide a light-weight completion mechanism
-by suppressing the generation of a full completion event.  They are
+by allowing the suppression of CQ completion entries.  They are
 useful for applications that only need to know the number of requests
 that have completed, and not details about each request.  For example,
 counters may be useful for implementing credit based flow control or
-tracking the number of remote processes which have responded to a
+tracking the number of remote processes that have responded to a
 request.
 
 Counters typically only count successful completions.  However, if an
 operation completes in error, it may increment an associated error
 value.  That is, a counter actually stores two distinct values, with
 error completions updating an error specific value.
+
+Counters are updated following the completion event semantics defined
+in [`fi_cq`(3)](fi_cq.3.html).  The timing of the update is based
+on the type of transfer and any specified operation flags.
 
 ## fi_cntr_open
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -471,7 +471,7 @@ supported set of modes will be returned in the info structure(s).
   operation does not generate a completion (i.e. the endpoint was
   configured with FI_SELECTIVE_COMPLETION and the operation was not
   initiated with the FI_COMPLETION flag) then the context parameter is
-  ignored by the fabric provider.The structure is specified in 
+  ignored by the fabric provider.  The structure is specified in
   rdma/fabric.h.
 
 *FI_CONTEXT2*

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -160,16 +160,18 @@ struct fi_msg {
 
 ## fi_inject
 
-The send inject call is an optimized version of fi_send.  The
-fi_inject function behaves as if the FI_INJECT transfer flag were
-set, and FI_COMPLETION were not.  That is, the data buffer is
-available for reuse immediately on returning from fi_inject, and
-no completion event will be generated for this send.  The completion
-event will be suppressed even if the CQ was bound without
-FI_SELECTIVE_COMPLETION or the endpoint's op_flags contain
-FI_COMPLETION.  See the flags discussion below for more details. The
-requested message size that can be used with fi_inject is limited
-by inject_size.
+The send inject call is an optimized version of fi_send with the
+following characteristics.  The data buffer is available for reuse
+immediately on return from the call, and no CQ entry will be written
+if the transfer completes successfully.
+
+Conceptually, this means that the fi_inject function behaves as if
+the FI_INJECT transfer flag were set, selective completions are enabled,
+and the FI_COMPLETION flag is not specified.  Note that the CQ entry
+will be suppressed even if the default behavior of the endpoint is
+to write CQ entries for all successful completions.  See the flags
+discussion below for more details. The requested message size that
+can be used with fi_inject is limited by inject_size.
 
 ## fi_senddata
 

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -180,15 +180,8 @@ struct fi_rma_iov {
 
 ## fi_inject_write
 
-The write inject call is an optimized version of fi_write.  The
-fi_inject_write function behaves as if the FI_INJECT transfer flag
-were set, and FI_COMPLETION were not.  That is, the data buffer is
-available for reuse immediately on returning from
-fi_inject_write, and no completion event will be generated for this
-write.  The completion event will be suppressed even if the endpoint
-has not been configured with FI_SELECTIVE_COMPLETION.  See the flags
-discussion below for more details. The requested message size that
-can be used with fi_inject_write is limited by inject_size.
+The write inject call is an optimized version of fi_write.  It provides
+similar completion semantics as fi_inject [`fi_msg`(3)](fi_msg.3.html).
 
 ## fi_writedata
 

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -183,15 +183,8 @@ struct fi_msg_tagged {
 
 ## fi_tinject
 
-The tagged inject call is an optimized version of fi_tsend.  The
-fi_tinject function behaves as if the FI_INJECT transfer flag were
-set, and FI_COMPLETION were not.  That is, the data buffer is
-available for reuse immediately on returning from fi_tinject, and
-no completion event will be generated for this send.  The completion
-event will be suppressed even if the endpoint has not been configured
-with FI_SELECTIVE_COMPLETION.  See the flags discussion below for more
-details. The requested message size that can be used with fi_tinject is
-limited by inject_size.
+The tagged inject call is an optimized version of fi_tsend.  It provides
+similar completion semantics as fi_inject [`fi_msg`(3)](fi_msg.3.html).
 
 ## fi_tsenddata
 


### PR DESCRIPTION
…MPLETION

This is an attempt to clarify and remove confusion around
the behavior of FI_SELECTIVE_COMPLETION, FI_INJECT, inject
operations, and counters.

The API and intended behavior are not changed.

The FI_SELECTIVE_COMPLETION examples are removed, as they apparently
just confuse people.  The man pages try to strict to precising defining
only the functions and what flags are valid for each call.

The wording around fi_ep_bind is moved around, so that all general
comments come first, followed by valid flags for ep->cq binding, then
flags for ep->cntr binding.  The more precise term 'cq completion' is
used in place of just 'completion' entry.

The counter man page is updated to indicate when a counter is
updated.

The inject call description is also updated to state the behavior
only, without referencing flags, as that results in confusion as well.
Other inject operations are updated to refer to fi_inject, in order
to avoid duplicating text.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>