### PR TITLE
contrib/buildrpm: Add libfabric tag to path

### DIFF
--- a/contrib/buildrpm/buildrpmLibfabric.sh
+++ b/contrib/buildrpm/buildrpmLibfabric.sh
@@ -261,7 +261,7 @@ if [[ -n "$install_in_opt" ]]; then
   if [[ -z "$prefix" ]] ; then
     prefix=$default_opt_prefix
   fi
-  prefix="$prefix/$version"
+  prefix="$prefix/libfabric/$version"
 
   if [[ -n "$modulepath" ]] ; then
     verbose "Setting RPM module path to: $modulepath"
@@ -269,7 +269,7 @@ if [[ -n "$install_in_opt" ]]; then
   fi
 else
   if [[ -z "$prefix" ]] ; then
-    prefix="$default_prefix"
+    prefix="$default_prefix/libfabric"
   fi
 fi
 


### PR DESCRIPTION
The 'libfabric' tag was missing from the package path. RPMs were installing
to /opt/my/prefix rather than /opt/my/prefix/libfabric. This commit fixes
that issue.

Signed-off-by: James Swaro <jswaro@cray.com>

@tonyzinger @jsquyres 