### PR TITLE
configury: Fix mm aware atomic test (2nd try)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,9 +242,11 @@ AC_TRY_LINK([#include <stdint.h>],
 
 dnl Check for gcc memory model aware built-in atomics
 dnl If supported check to see if not internal to compiler
+LIBS_save=$LIBS
+AC_SEARCH_LIBS([__atomic_load_8], [atomic])
 AC_MSG_CHECKING(compiler support for built-in memory model aware atomics)
-AC_TRY_COMPILE([#include <stdint.h>],
-    [uint64_t d;
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdint.h>]],
+    [[uint64_t d;
      uint64_t s;
      uint64_t c;
      uint64_t r;
@@ -257,13 +259,16 @@ AC_TRY_COMPILE([#include <stdint.h>],
      #else
        return 0;
      #endif
-    ],
+    ]])],
     [
         AC_MSG_RESULT(yes)
-        AC_SEARCH_LIBS([__atomic_load_8], [atomic])
         AC_DEFINE(HAVE_BUILTIN_MM_ATOMICS, 1, [Set to 1 to use built-in intrinsics memory model aware atomics])
     ],
-    [AC_MSG_RESULT(no)])
+    [
+        AC_MSG_RESULT(no)
+        LIBS=$LIBS_save
+    ])
+unset LIBS_save
 
 dnl Check for gcc cpuid intrinsics
 AC_MSG_CHECKING(compiler support for cpuid)


### PR DESCRIPTION
The previous attempt to fix this test was wrong because AC_TRY_COMPILE
succeeded in compiling the test case if implicit function declaration
was allowed. Now the strategy is:

1. Use AC_SEARCH_LIBS to detect if atomic symbols are internal to the
   compiler, or provided by -latomic. Set LIBS accordingly.

2. Use AC_TRY_LINK to build the main test case. If the test is
   unsuccessful, restore LIBS to its prior state.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>