### PR TITLE
prov/rxm: minor refactoring + bug fix and updates for fabtests

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2509,7 +2509,7 @@ int64_t get_elapsed(const struct timespec *b, const struct timespec *a,
 	return elapsed / p;
 }
 
-void show_perf(char *name, int tsize, int iters, struct timespec *start,
+void show_perf(char *name, size_t tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter)
 {
 	static int header = 1;
@@ -2550,7 +2550,7 @@ void show_perf(char *name, int tsize, int iters, struct timespec *start,
 		usec_per_xfer, 1.0/usec_per_xfer);
 }
 
-void show_perf_mr(int tsize, int iters, struct timespec *start,
+void show_perf_mr(size_t tsize, int iters, struct timespec *start,
 		  struct timespec *end, int xfers_per_iter, int argc, char *argv[])
 {
 	static int header = 1;
@@ -2572,7 +2572,7 @@ void show_perf_mr(int tsize, int iters, struct timespec *start,
 	usec_per_xfer = ((float)elapsed / iters / xfers_per_iter);
 
 	printf("- { ");
-	printf("xfer_size: %d, ", tsize);
+	printf("xfer_size: %zu, ", tsize);
 	printf("iterations: %d, ", iters);
 	printf("total: %lld, ", total);
 	printf("time: %f, ", elapsed / 1000000.0);

--- a/fabtests/functional/multi_mr.c
+++ b/fabtests/functional/multi_mr.c
@@ -155,7 +155,7 @@ static int init_multi_mr_res()
 
 		if (verbose) {
 			printf("MR_REG:domain_ptr, buf_ptr, mr_size, mr_ptr, mr_key)\n");
-			printf("%p, %p, %d, %p, %lu)\n",
+			printf("%p, %p, %zu, %p, %lu)\n",
 					domain,
 					mr_res_array[i].buf,
 					opts.transfer_size,

--- a/fabtests/functional/rdm_multi_domain.c
+++ b/fabtests/functional/rdm_multi_domain.c
@@ -173,7 +173,7 @@ static int init_ep_mr_res(struct test_domain *domain, struct fi_info *info)
 	}
 
 	if (verbose) {
-		printf("fi_mr_reg(fi_domain = %p,buffer = %p,size = %d,",
+		printf("fi_mr_reg(fi_domain = %p,buffer = %p,size = %zu,",
 				domain->dom, domain->buf, opts.transfer_size);
 		printf("memory_region = %p,mr_key %ld)\n",
 				domain->mr, (unsigned long)fi_mr_key(domain->mr));

--- a/fabtests/functional/rdm_multi_recv.c
+++ b/fabtests/functional/rdm_multi_recv.c
@@ -100,6 +100,16 @@ int wait_for_recv_completion(int num_completions)
 		if (comp.len)
 			num_completions--;
 
+		if (ft_check_opts(FT_OPT_VERIFY_DATA | FT_OPT_ACTIVE)) {
+			if (comp.len != opts.transfer_size) {
+				FT_ERR("comp.len != opts.transfer_size");
+				return -FI_EOTHER;
+			}
+			ret = ft_check_buf(comp.buf, opts.transfer_size);
+			if (ret)
+				return ret;
+		}
+
 		if (comp.flags & FI_MULTI_RECV) {
 			i = (comp.op_context == &ctx_multi_recv[0]) ? 0 : 1;
 
@@ -331,7 +341,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "Mh" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "Mhv" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
 			ft_parseinfo(op, optarg, hints);
@@ -339,6 +349,9 @@ int main(int argc, char **argv)
 			break;
 		case 'M':
 			use_recvmsg = 1;
+			break;
+		case 'v':
+			opts.options |= FT_OPT_VERIFY_DATA;
 			break;
 		case '?':
 		case 'h':

--- a/fabtests/functional/resmgmt_test.c
+++ b/fabtests/functional/resmgmt_test.c
@@ -223,7 +223,7 @@ int main(int argc, char **argv)
 			break;
 		case 'l':
 			opts.transfer_size = strtoul(optarg, NULL, 0);
-			printf("Testing Message Size: %d\n", opts.transfer_size);
+			printf("Testing Message Size: %zu\n", opts.transfer_size);
 			break;
 		case 't':
 			tagged = 1;

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -109,8 +109,9 @@ static int wait_recvs()
 
 	if ((ret == 1) && send_data) {
 		if (entry.data != opts.transfer_size) {
-			printf("ERROR incorrect remote CQ data value. Got %lu, expected %d\n",
-					(unsigned long)entry.data, opts.transfer_size);
+			printf("ERROR incorrect remote CQ data value. Got %lu,"
+			       " expected %zu\n", (unsigned long)entry.data,
+			       opts.transfer_size);
 			return -FI_EOTHER;
 		}
 	}

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -71,7 +71,7 @@ static inline int ft_exit_code(int ret)
 #define ft_sa_family(addr) (((struct sockaddr *)(addr))->sa_family)
 
 struct test_size_param {
-	int size;
+	size_t size;
 	int enable_flags;
 };
 
@@ -136,7 +136,7 @@ enum ft_atomic_opcodes {
 struct ft_opts {
 	int iterations;
 	int warmup_iterations;
-	int transfer_size;
+	size_t transfer_size;
 	int window_size;
 	int av_size;
 	int verbose;
@@ -448,9 +448,9 @@ void eq_readerr(struct fid_eq *eq, const char *eq_str);
 
 int64_t get_elapsed(const struct timespec *b, const struct timespec *a,
 		enum precision p);
-void show_perf(char *name, int tsize, int iters, struct timespec *start,
+void show_perf(char *name, size_t tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter);
-void show_perf_mr(int tsize, int iters, struct timespec *start,
+void show_perf_mr(size_t tsize, int iters, struct timespec *start,
 		struct timespec *end, int xfers_per_iter, int argc, char *argv[]);
 
 int ft_send_recv_greeting(struct fid_ep *ep);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -946,8 +946,7 @@ rxm_process_recv_entry(struct rxm_recv_queue *recv_queue,
 		}
 	}
 
-	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Enqueuing recv", recv_entry->addr,
-			 recv_entry->tag);
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Enqueuing recv\n");
 	dlist_insert_tail(&recv_entry->entry, &recv_queue->recv_list);
 
 	return FI_SUCCESS;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -201,9 +201,9 @@ static int rxm_finish_recv(struct rxm_rx_buf *rx_buf, size_t done_len)
 		}
 
 		FI_DBG(&rxm_prov, FI_LOG_CQ,
-		       "Repost Multi-Recv entry: "
+		       "Repost Multi-Recv entry: %p "
 		       "consumed len = %zu, remain len = %zu\n",
-		       recv_size, recv_entry->total_len);
+		       recv_entry, recv_size, recv_entry->total_len);
 
 		rxm_iov = recv_entry->rxm_iov;
 		ret = rxm_match_iov(/* prev iovecs */
@@ -1217,17 +1217,19 @@ static void rxm_cq_read_write_error(struct rxm_ep *rxm_ep)
 
 static inline int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 {
+	int ret;
+
 	if (rx_buf->ep->srx_ctx)
 		rx_buf->conn = NULL;
 	rx_buf->hdr.state = RXM_RX;
 
-	if (fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
-		    rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
-		    rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf)) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to repost buf\n");
-		return -FI_EAVAIL;
-	}
-	return FI_SUCCESS;
+	ret = fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
+		      rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
+		      rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf);
+	if (ret)
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+			"Unable to repost buf: %d\n", ret);
+	return ret;
 }
 
 int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -997,9 +997,10 @@ static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
 	if (comp->flags & FI_REMOTE_WRITE)
 		return rxm_handle_remote_write(rxm_ep, comp);
 
+	assert(RXM_GET_PROTO_STATE(comp->op_context) != RXM_INJECT_TX);
+
 	switch (RXM_GET_PROTO_STATE(comp->op_context)) {
 	case RXM_TX:
-	case RXM_INJECT_TX:
 		tx_eager_buf = comp->op_context;
 		assert(comp->flags & FI_SEND);
 		ret = rxm_finish_eager_send(rxm_ep, tx_eager_buf);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -33,6 +33,7 @@
 #include <inttypes.h>
 #include <math.h>
 
+#include <rdma/fabric.h>
 #include "ofi.h"
 #include <ofi_util.h>
 
@@ -744,9 +745,18 @@ rxm_ep_post_recv(struct rxm_ep *rxm_ep, const struct iovec *iov,
 	if (OFI_UNLIKELY(ret))
 		return ret;
 
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting recv with length: %zu "
-	       "tag: 0x%" PRIx64 " ignore: 0x%" PRIx64 "\n",
-	       recv_entry->total_len, recv_entry->tag, recv_entry->ignore);
+	if (recv_queue->type == RXM_RECV_QUEUE_MSG)
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting recv with length: %zu "
+		       "addr: 0x%" PRIx64 "\n", recv_entry->total_len,
+		       recv_entry->addr);
+	else
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting trecv with "
+		       "length: %zu addr: 0x%" PRIx64 " tag: 0x%" PRIx64
+		       " ignore: 0x%" PRIx64 "\n", recv_entry->total_len,
+		       recv_entry->addr, recv_entry->tag, recv_entry->ignore);
+
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "recv op_flags: %s\n",
+	       fi_tostr(&recv_entry->flags, FI_TYPE_OP_FLAGS));
 	ret = rxm_process_recv_entry(recv_queue, recv_entry);
 
 	return ret;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -777,11 +777,11 @@ rxm_ep_recv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
 	return ret;
 }
 
-static ssize_t rxm_ep_recv_common_flags(struct rxm_ep *rxm_ep, const struct iovec *iov,
-					void **desc, size_t count, fi_addr_t src_addr,
-					uint64_t tag, uint64_t ignore, void *context,
-					uint64_t flags, uint64_t op_flags,
-					struct rxm_recv_queue *recv_queue)
+static ssize_t
+rxm_ep_recv_common_flags(struct rxm_ep *rxm_ep, const struct iovec *iov,
+			 void **desc, size_t count, fi_addr_t src_addr,
+			 uint64_t tag, uint64_t ignore, void *context,
+			 uint64_t flags, struct rxm_recv_queue *recv_queue)
 {
 	struct rxm_recv_entry *recv_entry;
 	struct fi_recv_context *recv_ctx;
@@ -822,7 +822,7 @@ static ssize_t rxm_ep_recv_common_flags(struct rxm_ep *rxm_ep, const struct iove
 
 	if (!(flags & FI_CLAIM)) {
 		ret = rxm_ep_post_recv(rxm_ep, iov, desc, count, src_addr,
-				       tag, ignore, context, flags | op_flags,
+				       tag, ignore, context, flags,
 				       recv_queue);
 		goto unlock;
 	}
@@ -838,7 +838,7 @@ static ssize_t rxm_ep_recv_common_flags(struct rxm_ep *rxm_ep, const struct iove
 
 claim:
 	ret = rxm_ep_format_rx_res(rxm_ep, iov, desc, count, src_addr,
-				   tag, ignore, context, flags | op_flags,
+				   tag, ignore, context, flags,
 				   recv_queue, &recv_entry);
 	if (OFI_UNLIKELY(ret))
 		goto unlock;
@@ -861,8 +861,9 @@ static ssize_t rxm_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 					     util_ep.ep_fid.fid);
 
 	return rxm_ep_recv_common_flags(rxm_ep, msg->msg_iov, msg->desc, msg->iov_count,
-					msg->addr, 0, 0, msg->context, flags,
-					rxm_ep->util_ep.rx_msg_flags, &rxm_ep->recv_queue);
+					msg->addr, 0, 0, msg->context,
+					flags | rxm_ep->util_ep.rx_msg_flags,
+					&rxm_ep->recv_queue);
 }
 
 static ssize_t rxm_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
@@ -1737,7 +1738,7 @@ static ssize_t rxm_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged
 
 	return rxm_ep_recv_common_flags(rxm_ep, msg->msg_iov, msg->desc, msg->iov_count,
 					msg->addr, msg->tag, msg->ignore, msg->context,
-					flags, rxm_ep->util_ep.rx_msg_flags,
+					flags | rxm_ep->util_ep.rx_msg_flags,
 					&rxm_ep->trecv_queue);
 }
 


### PR DESCRIPTION
- prov/rxm: add some logging 
- fabtests: use size_t for some size types to fix comparison warnings 
- fabtests: add data integrity verification to multi recv test 
- prov/rxm: merge op_flags and flags args in rxm_ep_recv_common_flags 
- prov/rxm: remove RXM_INJECT_TX state from MSG CQ completion handler