### PR TITLE
prov/tcp: Fixes for memory leaks

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -367,6 +367,8 @@ static inline void *util_buf_get(struct util_buf_pool *pool)
 
 static inline void util_buf_release(struct util_buf_pool *pool, void *buf)
 {
+	assert(util_buf_get_ftr(pool, buf)->region);
+	assert(util_buf_get_ftr(pool, buf)->region->pool == pool);
 	assert(util_buf_get_ftr(pool, buf)->region->num_used--);
 	assert(!pool->attr.indexing.ordered);
 	slist_insert_head(&util_buf_get_ftr(pool, buf)->entry.slist, &pool->list.buffers);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -265,6 +265,8 @@ struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq,
 					      enum tcpx_xfer_op_codes type);
 void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
 			     struct tcpx_xfer_entry *xfer_entry);
+void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
+			   struct tcpx_xfer_entry *xfer_entry);
 
 void tcpx_progress(struct util_ep *util_ep);
 void tcpx_ep_progress(struct tcpx_ep *ep);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -267,6 +267,9 @@ void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
 			     struct tcpx_xfer_entry *xfer_entry);
 void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 			   struct tcpx_xfer_entry *xfer_entry);
+struct tcpx_xfer_entry *
+tcpx_srx_dequeue(struct tcpx_rx_ctx *srx_ctx);
+
 
 void tcpx_progress(struct util_ep *util_ep);
 void tcpx_ep_progress(struct tcpx_ep *ep);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -267,6 +267,7 @@ void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
 			     struct tcpx_xfer_entry *xfer_entry);
 void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 			   struct tcpx_xfer_entry *xfer_entry);
+void tcpx_rx_msg_release(struct tcpx_xfer_entry *rx_entry);
 struct tcpx_xfer_entry *
 tcpx_srx_dequeue(struct tcpx_rx_ctx *srx_ctx);
 

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -51,6 +51,7 @@ static int tcpx_srx_ctx_close(struct fid *fid)
 		util_buf_release(srx_ctx->buf_pool, xfer_entry);
 	}
 
+	util_buf_pool_destroy(srx_ctx->buf_pool);
 	fastlock_destroy(&srx_ctx->lock);
 	free(srx_ctx);
 	return FI_SUCCESS;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -270,6 +270,21 @@ static struct fi_ops_cm tcpx_cm_ops = {
 	.join = fi_no_join,
 };
 
+void tcpx_rx_msg_release(struct tcpx_xfer_entry *rx_entry)
+{
+	struct tcpx_cq *tcpx_cq;
+
+	assert(rx_entry->hdr.base_hdr.op_data == TCPX_OP_MSG_RECV);
+
+	if (rx_entry->ep->srx_ctx) {
+		tcpx_srx_xfer_release(rx_entry->ep->srx_ctx, rx_entry);
+	} else {
+		tcpx_cq = container_of(rx_entry->ep->util_ep.rx_cq,
+				       struct tcpx_cq, util_cq);
+		tcpx_xfer_entry_release(tcpx_cq, rx_entry);
+	}
+}
+
 static void tcpx_ep_tx_rx_queues_release(struct tcpx_ep *ep)
 {
 	struct slist_entry *entry;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -451,14 +451,13 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 			handle = container_of(info->handle,
 					      struct tcpx_conn_handle, handle);
 			ep->conn_fd = handle->conn_fd;
+			ep->hdr_bswap = handle->endian_match ?
+					tcpx_hdr_none : tcpx_hdr_bswap;
 			free(handle);
 
 			ret = tcpx_setup_socket(ep->conn_fd);
 			if (ret)
 				goto err3;
-
-			ep->hdr_bswap = (handle->endian_match)?
-				tcpx_hdr_none:tcpx_hdr_bswap;
 		}
 	} else {
 		ep->conn_fd = ofi_socket(ofi_get_sa_family(info), SOCK_STREAM, 0);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -231,9 +231,7 @@ static int process_srx_entry(struct tcpx_xfer_entry *rx_entry)
 		rx_entry->ep->cur_rx_entry = NULL;
 	}
 
-	fastlock_acquire(&rx_entry->ep->srx_ctx->lock);
-	util_buf_release(rx_entry->ep->srx_ctx->buf_pool, rx_entry);
-	fastlock_release(&rx_entry->ep->srx_ctx->lock);
+	tcpx_srx_xfer_release(rx_entry->ep->srx_ctx, rx_entry);
 	return FI_SUCCESS;
 }
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -486,7 +486,11 @@ int tcpx_get_rx_entry_op_read_req(struct tcpx_ep *tcpx_ep)
 	struct tcpx_cq *tcpx_cq;
 	int ret;
 
-	tcpx_cq = container_of(tcpx_ep->util_ep.rx_cq,
+	/* The read request will generate a response once done,
+	 * so the xfer_entry will become a transmit and returned
+	 * to the tx cq buffer pool.
+	 */
+	tcpx_cq = container_of(tcpx_ep->util_ep.tx_cq,
 			       struct tcpx_cq, util_cq);
 
 	rx_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_REMOTE_READ);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -159,7 +159,6 @@ static int tcpx_prepare_rx_entry_resp(struct tcpx_xfer_entry *rx_entry)
 
 	tcpx_cq_report_completion(rx_entry->ep->util_ep.rx_cq,
 				  rx_entry, 0);
-	slist_remove_head(&rx_entry->ep->rx_queue);
 	tcpx_rx_msg_release(rx_entry);
 	return FI_SUCCESS;
 }

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -520,7 +520,7 @@ int tcpx_get_rx_entry_op_msg(struct tcpx_ep *tcpx_ep)
 			"posted rx buffer size is not big enough\n");
 		tcpx_cq_report_completion(rx_entry->ep->util_ep.rx_cq,
 					  rx_entry, -ret);
-		tcpx_xfer_entry_release(tcpx_cq, rx_entry);
+		tcpx_rx_msg_release(rx_entry);
 		return ret;
 	}
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -463,7 +463,6 @@ int tcpx_get_rx_entry_op_msg(struct tcpx_ep *tcpx_ep)
 {
 	struct tcpx_xfer_entry *rx_entry;
 	struct tcpx_xfer_entry *tx_entry;
-	struct slist_entry *entry;
 	struct tcpx_cq *tcpx_cq;
 	struct tcpx_rx_detect *rx_detect = &tcpx_ep->rx_detect;
 	int ret;
@@ -473,9 +472,8 @@ int tcpx_get_rx_entry_op_msg(struct tcpx_ep *tcpx_ep)
 
 	if (rx_detect->hdr.base_hdr.op_data == TCPX_OP_MSG_RESP) {
 		assert(!slist_empty(&tcpx_ep->tx_rsp_pend_queue));
-		entry = tcpx_ep->tx_rsp_pend_queue.head;
-		tx_entry = container_of(entry, struct tcpx_xfer_entry,
-					entry);
+		tx_entry = container_of(tcpx_ep->tx_rsp_pend_queue.head,
+					struct tcpx_xfer_entry, entry);
 
 		tcpx_cq = container_of(tcpx_ep->util_ep.tx_cq, struct tcpx_cq,
 				       util_cq);
@@ -490,25 +488,18 @@ int tcpx_get_rx_entry_op_msg(struct tcpx_ep *tcpx_ep)
 
 	if (tcpx_ep->srx_ctx){
 		tcpx_ep->cur_rx_proc_fn = process_srx_entry;
-		fastlock_acquire(&tcpx_ep->srx_ctx->lock);
-		if (slist_empty(&tcpx_ep->srx_ctx->rx_queue)) {
-			fastlock_release(&tcpx_ep->srx_ctx->lock);
+		rx_entry = tcpx_srx_dequeue(tcpx_ep->srx_ctx);
+		if (!rx_entry)
 			return -FI_EAGAIN;
-		}
-
-		entry = slist_remove_head(&tcpx_ep->srx_ctx->rx_queue);
-		fastlock_release(&tcpx_ep->srx_ctx->lock);
 
 	} else {
 		if (slist_empty(&tcpx_ep->rx_queue))
 			return -FI_EAGAIN;
 
 		tcpx_ep->cur_rx_proc_fn = process_rx_entry;
-		entry = slist_remove_head(&tcpx_ep->rx_queue);
+		rx_entry = container_of(slist_remove_head(&tcpx_ep->rx_queue),
+					struct tcpx_xfer_entry, entry);
 	}
-
-	rx_entry = container_of(entry, struct tcpx_xfer_entry,
-				entry);
 
 	memcpy(&rx_entry->hdr, &tcpx_ep->rx_detect.hdr,
 	       (size_t) tcpx_ep->rx_detect.hdr.base_hdr.payload_off);

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -37,16 +37,6 @@
 #include <ofi_util.h>
 #include <unistd.h>
 
-static inline struct tcpx_xfer_entry *
-tcpx_srx_xfer_alloc(struct tcpx_rx_ctx *srx_ctx)
-{
-	struct tcpx_xfer_entry *recv_entry;
-
-	fastlock_acquire(&srx_ctx->lock);
-	recv_entry = util_buf_alloc(srx_ctx->buf_pool);
-	fastlock_release(&srx_ctx->lock);
-	return recv_entry;
-}
 
 void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 			   struct tcpx_xfer_entry *xfer_entry)
@@ -54,6 +44,20 @@ void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 	fastlock_acquire(&srx_ctx->lock);
 	util_buf_release(srx_ctx->buf_pool, xfer_entry);
 	fastlock_release(&srx_ctx->lock);
+}
+
+static inline void tcpx_srx_recv_init(struct tcpx_xfer_entry *recv_entry,
+				      uint64_t base_flags, void *context)
+{
+	recv_entry->flags = base_flags | FI_MSG | FI_RECV;
+	recv_entry->context = context;
+}
+
+static inline void tcpx_srx_recv_init_iov(struct tcpx_xfer_entry *recv_entry,
+					  size_t count, const struct iovec *iov)
+{
+	recv_entry->iov_cnt = count;
+	memcpy(&recv_entry->iov[0], iov, count * sizeof(*iov));
 }
 
 struct tcpx_xfer_entry *
@@ -77,25 +81,25 @@ static ssize_t tcpx_srx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 {
 	struct tcpx_xfer_entry *recv_entry;
 	struct tcpx_rx_ctx *srx_ctx;
+	ssize_t ret = FI_SUCCESS;
 
 	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
 
-	recv_entry = tcpx_srx_xfer_alloc(srx_ctx);
-	if (!recv_entry)
-		return -FI_EAGAIN;
-
-	recv_entry->iov_cnt = msg->iov_count;
-	memcpy(&recv_entry->iov[0], &msg->msg_iov[0],
-	       msg->iov_count * sizeof(struct iovec));
-
-	recv_entry->flags = flags | FI_MSG | FI_RECV;
-	recv_entry->context = msg->context;
-
 	fastlock_acquire(&srx_ctx->lock);
+	recv_entry = util_buf_alloc(srx_ctx->buf_pool);
+	if (!recv_entry) {
+		ret = -FI_EAGAIN;
+		goto unlock;
+	}
+
+	tcpx_srx_recv_init(recv_entry, flags, msg->context);
+	tcpx_srx_recv_init_iov(recv_entry, msg->iov_count, msg->msg_iov);
+
 	slist_insert_tail(&recv_entry->entry, &srx_ctx->rx_queue);
+unlock:
 	fastlock_release(&srx_ctx->lock);
-	return FI_SUCCESS;
+	return ret;
 }
 
 static ssize_t tcpx_srx_recv(struct fid_ep *ep, void *buf, size_t len, void *desc,
@@ -103,24 +107,26 @@ static ssize_t tcpx_srx_recv(struct fid_ep *ep, void *buf, size_t len, void *des
 {
 	struct tcpx_xfer_entry *recv_entry;
 	struct tcpx_rx_ctx *srx_ctx;
+	ssize_t ret = FI_SUCCESS;
 
 	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
 
-	recv_entry = tcpx_srx_xfer_alloc(srx_ctx);
-	if (!recv_entry)
-		return -FI_EAGAIN;
+	fastlock_acquire(&srx_ctx->lock);
+	recv_entry = util_buf_alloc(srx_ctx->buf_pool);
+	if (!recv_entry) {
+		ret = -FI_EAGAIN;
+		goto unlock;
+	}
 
+	tcpx_srx_recv_init(recv_entry, 0, context);
 	recv_entry->iov_cnt = 1;
 	recv_entry->iov[0].iov_base = buf;
 	recv_entry->iov[0].iov_len = len;
 
-	recv_entry->flags = FI_MSG | FI_RECV;
-	recv_entry->context = context;
-
-	fastlock_acquire(&srx_ctx->lock);
 	slist_insert_tail(&recv_entry->entry, &srx_ctx->rx_queue);
+unlock:
 	fastlock_release(&srx_ctx->lock);
-	return FI_SUCCESS;
+	return ret;
 }
 
 static ssize_t tcpx_srx_recvv(struct fid_ep *ep, const struct iovec *iov, void **desc,
@@ -128,24 +134,25 @@ static ssize_t tcpx_srx_recvv(struct fid_ep *ep, const struct iovec *iov, void *
 {
 	struct tcpx_xfer_entry *recv_entry;
 	struct tcpx_rx_ctx *srx_ctx;
+	ssize_t ret = FI_SUCCESS;
 
 	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
 	assert(count <= TCPX_IOV_LIMIT);
 
-	recv_entry = tcpx_srx_xfer_alloc(srx_ctx);
-	if (!recv_entry)
-		return -FI_EAGAIN;
-
-	recv_entry->iov_cnt = count;
-	memcpy(recv_entry->iov, iov, count * sizeof(*iov));
-
-	recv_entry->flags = FI_MSG | FI_RECV;
-	recv_entry->context = context;
-
 	fastlock_acquire(&srx_ctx->lock);
+	recv_entry = util_buf_alloc(srx_ctx->buf_pool);
+	if (!recv_entry) {
+		ret = -FI_EAGAIN;
+		goto unlock;
+	}
+
+	tcpx_srx_recv_init(recv_entry, 0, context);
+	tcpx_srx_recv_init_iov(recv_entry, count, iov);
+
 	slist_insert_tail(&recv_entry->entry, &srx_ctx->rx_queue);
+unlock:
 	fastlock_release(&srx_ctx->lock);
-	return FI_SUCCESS;
+	return ret;
 }
 
 struct fi_ops_msg tcpx_srx_msg_ops = {

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -56,6 +56,22 @@ void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 	fastlock_release(&srx_ctx->lock);
 }
 
+struct tcpx_xfer_entry *
+tcpx_srx_dequeue(struct tcpx_rx_ctx *srx_ctx)
+{
+	struct tcpx_xfer_entry *xfer_entry;
+
+	fastlock_acquire(&srx_ctx->lock);
+	if (!slist_empty(&srx_ctx->rx_queue)) {
+		xfer_entry = container_of(slist_remove_head(&srx_ctx->rx_queue),
+					  struct tcpx_xfer_entry, entry);
+	} else {
+		xfer_entry = NULL;
+	}
+	fastlock_release(&srx_ctx->lock);
+	return xfer_entry;
+}
+
 static ssize_t tcpx_srx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 				uint64_t flags)
 {

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -41,6 +41,9 @@
 void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 			   struct tcpx_xfer_entry *xfer_entry)
 {
+	if (xfer_entry->ep->cur_rx_entry == xfer_entry)
+		xfer_entry->ep->cur_rx_entry = NULL;
+
 	fastlock_acquire(&srx_ctx->lock);
 	util_buf_release(srx_ctx->buf_pool, xfer_entry);
 	fastlock_release(&srx_ctx->lock);

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -38,7 +38,7 @@
 #include <unistd.h>
 
 static inline struct tcpx_xfer_entry *
-tcpx_srx_ctx_rx_entry_alloc(struct tcpx_rx_ctx *srx_ctx)
+tcpx_srx_xfer_alloc(struct tcpx_rx_ctx *srx_ctx)
 {
 	struct tcpx_xfer_entry *recv_entry;
 
@@ -46,6 +46,14 @@ tcpx_srx_ctx_rx_entry_alloc(struct tcpx_rx_ctx *srx_ctx)
 	recv_entry = util_buf_alloc(srx_ctx->buf_pool);
 	fastlock_release(&srx_ctx->lock);
 	return recv_entry;
+}
+
+void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
+			   struct tcpx_xfer_entry *xfer_entry)
+{
+	fastlock_acquire(&srx_ctx->lock);
+	util_buf_release(srx_ctx->buf_pool, xfer_entry);
+	fastlock_release(&srx_ctx->lock);
 }
 
 static ssize_t tcpx_srx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
@@ -57,7 +65,7 @@ static ssize_t tcpx_srx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
 
-	recv_entry = tcpx_srx_ctx_rx_entry_alloc(srx_ctx);
+	recv_entry = tcpx_srx_xfer_alloc(srx_ctx);
 	if (!recv_entry)
 		return -FI_EAGAIN;
 
@@ -82,7 +90,7 @@ static ssize_t tcpx_srx_recv(struct fid_ep *ep, void *buf, size_t len, void *des
 
 	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
 
-	recv_entry = tcpx_srx_ctx_rx_entry_alloc(srx_ctx);
+	recv_entry = tcpx_srx_xfer_alloc(srx_ctx);
 	if (!recv_entry)
 		return -FI_EAGAIN;
 
@@ -108,7 +116,7 @@ static ssize_t tcpx_srx_recvv(struct fid_ep *ep, const struct iovec *iov, void *
 	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
 	assert(count <= TCPX_IOV_LIMIT);
 
-	recv_entry = tcpx_srx_ctx_rx_entry_alloc(srx_ctx);
+	recv_entry = tcpx_srx_xfer_alloc(srx_ctx);
 	if (!recv_entry)
 		return -FI_EAGAIN;
 


### PR DESCRIPTION
This series fixes an issue where buffers may be returned to the wrong buffer pool.  The last 2 patches in the series need to be examined for correctness.  The last one fixes what I believe is an issue that would result in losing application posted receives.  This looks to be severe enough that I'm surprised that the provider works well at all.  But because it is working makes me question the fix.  The second to last one merges two functions that conceptually should be doing the same thing.  However, they are notable differences between them, so the merged function needs to be examine to see which of the two functions it needs to match.