### PR TITLE
[v1.6.x] prov/rxm: repost directed recv when AV updated only FI_DIRECTED_RECV is used

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -856,18 +856,20 @@ static int rxm_cq_reprocess_recv_queues(struct rxm_ep *rxm_ep)
 {
 	int count = 0;
 
-	fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
+	if (rxm_ep->rxm_info->caps & FI_DIRECTED_RECV) {
+		fastlock_acquire(&rxm_ep->util_ep.cmap->lock);
 
-	if (!rxm_ep->util_ep.cmap->av_updated) {
+		if (!rxm_ep->util_ep.cmap->av_updated) {
+			fastlock_release(&rxm_ep->util_ep.cmap->lock);
+			return 0;
+		}
+
+		rxm_ep->util_ep.cmap->av_updated = 0;
 		fastlock_release(&rxm_ep->util_ep.cmap->lock);
-		return 0;
+
+		count += rxm_cq_reprocess_directed_recvs(&rxm_ep->recv_queue);
+		count += rxm_cq_reprocess_directed_recvs(&rxm_ep->trecv_queue);
 	}
-
-	rxm_ep->util_ep.cmap->av_updated = 0;
-	fastlock_release(&rxm_ep->util_ep.cmap->lock);
-
-	count += rxm_cq_reprocess_directed_recvs(&rxm_ep->recv_queue);
-	count += rxm_cq_reprocess_directed_recvs(&rxm_ep->trecv_queue);
 	return count;
 }
 


### PR DESCRIPTION
cherry picked from commit c6c6ef79f250b1a88479c8d008b58d0e1e319cd3