### PR TITLE
util/bufpool: Cleanups and fixes around buffer pool usage.

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -446,38 +446,69 @@ static inline int util_buf_indexed_avail(struct util_buf_pool *pool)
 	return !dlist_empty(&pool->list.regions);
 }
 
-#define UTIL_BUF_DEFINE_GETTERS(name)						\
-static inline void *util_buf ## name ## get_ex(struct util_buf_pool *pool,	\
-					       void **context)			\
-{										\
-	void *buf = util_buf ## name ## get(pool);				\
-	assert(context);							\
-	*context = util_buf_get_ctx(pool, buf);					\
-	return buf;								\
-}										\
-										\
-static inline void *util_buf ## name ## alloc(struct util_buf_pool *pool)	\
-{										\
-	if (OFI_UNLIKELY(!util_buf ## name ## avail(pool))) {			\
-		if (util_buf_grow(pool))					\
-			return NULL;						\
-	}									\
-	return util_buf ## name ## get(pool);					\
-}										\
-										\
-static inline void *util_buf ## name ## alloc_ex(struct util_buf_pool *pool,	\
-						 void **context)		\
-{										\
-	void *buf = util_buf ## name ## alloc(pool);				\
-	if (OFI_UNLIKELY(!buf))							\
-		return NULL;							\
-	assert(context);							\
-	*context = util_buf_get_ctx(pool, buf);					\
-	return buf;								\
+static inline void *util_buf_get_ex(struct util_buf_pool *pool,
+				    void **context)
+{
+	void *buf = util_buf_get(pool);
+
+	assert(context);
+	*context = util_buf_get_ctx(pool, buf);
+	return buf;
 }
 
-UTIL_BUF_DEFINE_GETTERS(_);
-UTIL_BUF_DEFINE_GETTERS(_indexed_);
+static inline void *util_buf_alloc(struct util_buf_pool *pool)
+{
+	if (OFI_UNLIKELY(!util_buf_avail(pool))) {
+		if (util_buf_grow(pool))
+			return NULL;
+	}
+	return util_buf_get(pool);
+}
+
+static inline void *util_buf_alloc_ex(struct util_buf_pool *pool,
+				      void **context)
+{
+	void *buf = util_buf_alloc(pool);
+
+	assert(context);
+	if (OFI_UNLIKELY(!buf))
+		return NULL;
+
+	*context = util_buf_get_ctx(pool, buf);
+	return buf;
+}
+
+static inline void *util_buf_indexed_get_ex(struct util_buf_pool *pool,
+					    void **context)
+{
+	void *buf = util_buf_indexed_get(pool);
+
+	assert(context);
+	*context = util_buf_get_ctx(pool, buf);
+	return buf;
+}
+
+static inline void *util_buf_indexed_alloc(struct util_buf_pool *pool)
+{
+	if (OFI_UNLIKELY(!util_buf_indexed_avail(pool))) {
+		if (util_buf_grow(pool))
+			return NULL;
+	}
+	return util_buf_indexed_get(pool);
+}
+
+static inline void *util_buf_indexed_alloc_ex(struct util_buf_pool *pool,
+						 void **context)
+{
+	void *buf = util_buf_indexed_alloc(pool);
+
+	assert(context);
+	if (OFI_UNLIKELY(!buf))
+		return NULL;
+
+	*context = util_buf_get_ctx(pool, buf);
+	return buf;
+}
 
 void util_buf_pool_destroy(struct util_buf_pool *pool);
 

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -298,6 +298,7 @@ struct ofi_bufpool_region {
 	struct dlist_entry 		buf_list;
 	char 				*mem_region;
 	size_t 				size;
+	size_t				index;
 	void 				*context;
 	struct ofi_bufpool 		*pool;
 #ifndef NDEBUG

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -390,7 +390,7 @@ static inline size_t ofi_buf_index(struct ofi_bufpool *pool, void *buf)
 	return ofi_buf_ftr(pool, buf)->index;
 }
 
-static inline void *ofi_buf_index_get(struct ofi_bufpool *pool, size_t index)
+static inline void *ofi_bufpool_get_ibuf(struct ofi_bufpool *pool, size_t index)
 {
 	void *buf;
 

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -264,10 +264,11 @@ enum {
 	OFI_BUFPOOL_MMAPPED		= 1 << 3,
 };
 
-typedef int (*ofi_bufpool_alloc_fn)(void *pool_ctx, void *addr, size_t len,
-				    void **context);
-typedef void (*ofi_bufpool_free_fn)(void *pool_ctx, void *context);
-typedef void (*ofi_bufpool_init_fn)(void *pool_ctx, void *buf);
+struct ofi_bufpool_region;
+
+typedef int (*ofi_bufpool_alloc_fn)(struct ofi_bufpool_region *region);
+typedef void (*ofi_bufpool_free_fn)(struct ofi_bufpool_region *region);
+typedef void (*ofi_bufpool_init_fn)(struct ofi_bufpool_region *region, void *buf);
 
 struct ofi_bufpool_attr {
 	size_t 				size;

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -308,10 +308,10 @@ struct ofi_bufpool_region {
 
 struct ofi_bufpool_ftr {
 	union {
-		struct slist_entry slist;
-		struct dlist_entry dlist;
+		struct slist_entry	slist;
+		struct dlist_entry	dlist;
 	} entry;
-	struct ofi_bufpool_region *region;
+	struct ofi_bufpool_region	*region;
 	size_t index;
 };
 
@@ -367,9 +367,7 @@ static inline void ofi_ibuf_free(struct ofi_bufpool *pool, void *buf)
 	struct ofi_bufpool_ftr *buf_ftr;
 
 	assert(pool->attr.indexing.ordered);
-
 	buf_ftr = ofi_buf_ftr(pool, buf);
-
 	assert(buf_ftr->region->num_used--);
 
 	dlist_insert_order(&buf_ftr->region->buf_list,
@@ -392,9 +390,11 @@ static inline size_t ofi_buf_index(struct ofi_bufpool *pool, void *buf)
 static inline void *ofi_buf_index_get(struct ofi_bufpool *pool, size_t index)
 {
 	void *buf;
+
 	assert(pool->attr.indexing.used);
 	buf = pool->regions_table[(size_t)(index / pool->attr.chunk_cnt)]->
 		mem_region + (index % pool->attr.chunk_cnt) * pool->entry_sz;
+
 	assert(ofi_buf_ftr(pool, buf)->region->num_used);
 	return buf;
 }

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -468,19 +468,6 @@ static inline void *util_buf_indexed_alloc(struct util_buf_pool *pool)
 	return util_buf_get_data(pool, buf_ftr);
 }
 
-static inline void *util_buf_indexed_alloc_ex(struct util_buf_pool *pool,
-						 void **context)
-{
-	void *buf = util_buf_indexed_alloc(pool);
-
-	assert(context);
-	if (OFI_UNLIKELY(!buf))
-		return NULL;
-
-	*context = util_buf_get_ctx(pool, buf);
-	return buf;
-}
-
 void util_buf_pool_destroy(struct util_buf_pool *pool);
 
 

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -446,16 +446,6 @@ static inline int util_buf_indexed_avail(struct util_buf_pool *pool)
 	return !dlist_empty(&pool->list.regions);
 }
 
-static inline void *util_buf_get_ex(struct util_buf_pool *pool,
-				    void **context)
-{
-	void *buf = util_buf_get(pool);
-
-	assert(context);
-	*context = util_buf_get_ctx(pool, buf);
-	return buf;
-}
-
 static inline void *util_buf_alloc(struct util_buf_pool *pool)
 {
 	if (OFI_UNLIKELY(!util_buf_avail(pool))) {
@@ -474,16 +464,6 @@ static inline void *util_buf_alloc_ex(struct util_buf_pool *pool,
 	if (OFI_UNLIKELY(!buf))
 		return NULL;
 
-	*context = util_buf_get_ctx(pool, buf);
-	return buf;
-}
-
-static inline void *util_buf_indexed_get_ex(struct util_buf_pool *pool,
-					    void **context)
-{
-	void *buf = util_buf_indexed_get(pool);
-
-	assert(context);
 	*context = util_buf_get_ctx(pool, buf);
 	return buf;
 }

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -293,6 +293,7 @@ struct ofi_bufpool {
 
 	struct ofi_bufpool_region	**region_table;
 	size_t				region_cnt;
+	size_t				region_size;
 	struct ofi_bufpool_attr		attr;
 };
 
@@ -300,7 +301,6 @@ struct ofi_bufpool_region {
 	struct dlist_entry		entry;
 	struct dlist_entry 		free_list;
 	char 				*mem_region;
-	size_t 				size;
 	size_t				index;
 	void 				*context;
 	struct ofi_bufpool 		*pool;

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -258,22 +258,19 @@ static inline void name ## _free(struct name *fs)		\
  * Buffer Pool
  */
 
-#define UTIL_BUF_POOL_REGION_CHUNK_CNT	16
+typedef int (*ofi_bufpool_alloc_fn)(void *pool_ctx, void *addr, size_t len,
+				    void **context);
+typedef void (*ofi_bufpool_free_fn)(void *pool_ctx, void *context);
+typedef void (*ofi_bufpool_init_fn)(void *pool_ctx, void *buf);
 
-struct util_buf_pool;
-typedef int (*util_buf_region_alloc_hndlr) (void *pool_ctx, void *addr, size_t len,
-					    void **context);
-typedef void (*util_buf_region_free_hndlr) (void *pool_ctx, void *context);
-typedef void (*util_buf_region_init_func) (void *pool_ctx, void *buf);
-
-struct util_buf_attr {
+struct ofi_bufpool_attr {
 	size_t 				size;
 	size_t 				alignment;
 	size_t	 			max_cnt;
 	size_t 				chunk_cnt;
-	util_buf_region_alloc_hndlr 	alloc_hndlr;
-	util_buf_region_free_hndlr 	free_hndlr;
-	util_buf_region_init_func 	init;
+	ofi_bufpool_alloc_fn 		alloc_fn;
+	ofi_bufpool_free_fn 		free_fn;
+	ofi_bufpool_init_fn 		init_fn;
 	void 				*ctx;
 	uint8_t				track_used;
 	uint8_t				is_mmap_region;
@@ -285,190 +282,188 @@ struct util_buf_attr {
 	} indexing;
 };
 
-struct util_buf_pool {
-	size_t 			entry_sz;
-	size_t 			num_allocated;
+struct ofi_bufpool {
+	size_t 				entry_sz;
+	size_t 				num_allocated;
 	union {
 		struct slist		buffers;
 		struct dlist_entry	regions;
 	} list;
-	struct util_buf_region	**regions_table;
-	size_t			regions_cnt;
-	struct util_buf_attr	attr;
+	struct ofi_bufpool_region	**regions_table;
+	size_t				regions_cnt;
+	struct ofi_bufpool_attr		attr;
 };
 
-struct util_buf_region {
-	struct dlist_entry entry;
-	struct dlist_entry buf_list;
-	char *mem_region;
-	size_t size;
-	void *context;
-	struct util_buf_pool *pool;
+struct ofi_bufpool_region {
+	struct dlist_entry		 entry;
+	struct dlist_entry 		buf_list;
+	char 				*mem_region;
+	size_t 				size;
+	void 				*context;
+	struct ofi_bufpool 		*pool;
 #ifndef NDEBUG
-	size_t num_used;
+	size_t 				num_used;
 #endif
 };
 
-struct util_buf_footer {
+struct ofi_bufpool_ftr {
 	union {
 		struct slist_entry slist;
 		struct dlist_entry dlist;
 	} entry;
-	struct util_buf_region *region;
+	struct ofi_bufpool_region *region;
 	size_t index;
 };
 
-int util_buf_pool_create_attr(struct util_buf_attr *attr,
-			      struct util_buf_pool **buf_pool);
+int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
+			    struct ofi_bufpool **buf_pool);
 
-/* create buffer pool with alloc/free handlers */
-int util_buf_pool_create_ex(struct util_buf_pool **buf_pool,
-			    size_t size, size_t alignment,
-			    size_t max_cnt, size_t chunk_cnt,
-			    util_buf_region_alloc_hndlr alloc_hndlr,
-			    util_buf_region_free_hndlr free_hndlr,
-			    void *pool_ctx);
+int ofi_bufpool_create_ex(struct ofi_bufpool **buf_pool,
+			  size_t size, size_t alignment,
+			  size_t max_cnt, size_t chunk_cnt,
+			  ofi_bufpool_alloc_fn alloc_fn,
+			  ofi_bufpool_free_fn free_fn,
+			  void *pool_ctx);
 
-/* create buffer pool */
-static inline int util_buf_pool_create(struct util_buf_pool **pool,
-				       size_t size, size_t alignment,
-				       size_t max_cnt, size_t chunk_cnt)
+static inline int ofi_bufpool_create(struct ofi_bufpool **pool,
+				     size_t size, size_t alignment,
+				     size_t max_cnt, size_t chunk_cnt)
 {
-	return util_buf_pool_create_ex(pool, size, alignment,
-				       max_cnt, chunk_cnt,
-				       NULL, NULL, NULL);
+	return ofi_bufpool_create_ex(pool, size, alignment,
+				     max_cnt, chunk_cnt,
+				     NULL, NULL, NULL);
 }
 
-int util_buf_grow(struct util_buf_pool *pool);
+void ofi_bufpool_destroy(struct ofi_bufpool *pool);
 
-static inline struct util_buf_footer *
-util_buf_get_ftr(struct util_buf_pool *pool, void *buf)
+int ofi_bufpool_grow(struct ofi_bufpool *pool);
+
+static inline struct ofi_bufpool_ftr *
+ofi_buf_ftr(struct ofi_bufpool *pool, void *buf)
 {
-	return (struct util_buf_footer *) ((char *) buf + pool->attr.size);
+	return (struct ofi_bufpool_ftr *) ((char *) buf + pool->attr.size);
 }
 
-static inline void *util_buf_get_data(struct util_buf_pool *pool,
-			       struct util_buf_footer *buf_ftr)
+static inline void *ofi_buf_data(struct ofi_bufpool *pool,
+			         struct ofi_bufpool_ftr *buf_ftr)
 {
 	return ((char *) buf_ftr - pool->attr.size);
 }
 
-static inline void util_buf_release(struct util_buf_pool *pool, void *buf)
+static inline void ofi_buf_free(struct ofi_bufpool *pool, void *buf)
 {
-	assert(util_buf_get_ftr(pool, buf)->region);
-	assert(util_buf_get_ftr(pool, buf)->region->pool == pool);
-	assert(util_buf_get_ftr(pool, buf)->region->num_used--);
+	assert(ofi_buf_ftr(pool, buf)->region);
+	assert(ofi_buf_ftr(pool, buf)->region->pool == pool);
+	assert(ofi_buf_ftr(pool, buf)->region->num_used--);
 	assert(!pool->attr.indexing.ordered);
-	slist_insert_head(&util_buf_get_ftr(pool, buf)->entry.slist, &pool->list.buffers);
+	slist_insert_head(&ofi_buf_ftr(pool, buf)->entry.slist, &pool->list.buffers);
 }
 
-int util_buf_is_lower(struct dlist_entry *item, const void *arg);
-int util_buf_region_is_lower(struct dlist_entry *item, const void *arg);
+int ofi_ibuf_is_lower(struct dlist_entry *item, const void *arg);
+int ofi_ibufpool_region_is_lower(struct dlist_entry *item, const void *arg);
 
-static inline void util_buf_indexed_release(struct util_buf_pool *pool, void *buf)
+static inline void ofi_ibuf_free(struct ofi_bufpool *pool, void *buf)
 {
-	struct util_buf_footer *buf_ftr;
+	struct ofi_bufpool_ftr *buf_ftr;
 
 	assert(pool->attr.indexing.ordered);
 
-	buf_ftr = util_buf_get_ftr(pool, buf);
+	buf_ftr = ofi_buf_ftr(pool, buf);
 
 	assert(buf_ftr->region->num_used--);
 
 	dlist_insert_order(&buf_ftr->region->buf_list,
-			   util_buf_is_lower, &buf_ftr->entry.dlist);
+			   ofi_ibuf_is_lower, &buf_ftr->entry.dlist);
 
 	if (dlist_empty(&buf_ftr->region->entry)) {
 		dlist_insert_order(&pool->list.regions,
-				   util_buf_region_is_lower,
+				   ofi_ibufpool_region_is_lower,
 				   &buf_ftr->region->entry);
 	}
 }
 
-static inline size_t util_get_buf_index(struct util_buf_pool *pool, void *buf)
+static inline size_t ofi_buf_index(struct ofi_bufpool *pool, void *buf)
 {
-	assert(util_buf_get_ftr(pool, buf)->region->num_used);
+	assert(ofi_buf_ftr(pool, buf)->region->num_used);
 	assert(pool->attr.indexing.used);
-	return util_buf_get_ftr(pool, buf)->index;
+	return ofi_buf_ftr(pool, buf)->index;
 }
 
-static inline void *util_buf_get_by_index(struct util_buf_pool *pool, size_t index)
+static inline void *ofi_buf_index_get(struct ofi_bufpool *pool, size_t index)
 {
 	void *buf;
 	assert(pool->attr.indexing.used);
 	buf = pool->regions_table[(size_t)(index / pool->attr.chunk_cnt)]->
 		mem_region + (index % pool->attr.chunk_cnt) * pool->entry_sz;
-	assert(util_buf_get_ftr(pool, buf)->region->num_used);
+	assert(ofi_buf_ftr(pool, buf)->region->num_used);
 	return buf;
 }
 
-static inline void *util_buf_get_ctx(struct util_buf_pool *pool, void *buf)
+static inline void *ofi_buf_region_ctx(struct ofi_bufpool *pool, void *buf)
 {
-	return util_buf_get_ftr(pool, buf)->region->context;
+	return ofi_buf_ftr(pool, buf)->region->context;
 }
 
-static inline int util_buf_avail(struct util_buf_pool *pool)
+static inline int ofi_bufpool_empty(struct ofi_bufpool *pool)
 {
-	return !slist_empty(&pool->list.buffers);
+	return slist_empty(&pool->list.buffers);
 }
 
-static inline int util_buf_indexed_avail(struct util_buf_pool *pool)
+static inline int ofi_ibufpool_empty(struct ofi_bufpool *pool)
 {
-	return !dlist_empty(&pool->list.regions);
+	return dlist_empty(&pool->list.regions);
 }
 
-static inline void *util_buf_alloc(struct util_buf_pool *pool)
+static inline void *ofi_buf_alloc(struct ofi_bufpool *pool)
 {
-	struct util_buf_footer *buf_ftr;
+	struct ofi_bufpool_ftr *buf_ftr;
 
 	assert(!pool->attr.indexing.ordered);
-	if (OFI_UNLIKELY(!util_buf_avail(pool))) {
-		if (util_buf_grow(pool))
+	if (OFI_UNLIKELY(ofi_bufpool_empty(pool))) {
+		if (ofi_bufpool_grow(pool))
 			return NULL;
 	}
 
-	slist_remove_head_container(&pool->list.buffers, struct util_buf_footer,
+	slist_remove_head_container(&pool->list.buffers, struct ofi_bufpool_ftr,
 				    buf_ftr, entry.slist);
 	assert(++buf_ftr->region->num_used);
-	return util_buf_get_data(pool, buf_ftr);
+	return ofi_buf_data(pool, buf_ftr);
 }
 
-static inline void *util_buf_alloc_ex(struct util_buf_pool *pool,
-				      void **context)
+static inline void *ofi_buf_alloc_ex(struct ofi_bufpool *pool,
+				     void **context)
 {
-	void *buf = util_buf_alloc(pool);
+	void *buf = ofi_buf_alloc(pool);
 
 	assert(context);
 	if (OFI_UNLIKELY(!buf))
 		return NULL;
 
-	*context = util_buf_get_ctx(pool, buf);
+	*context = ofi_buf_region_ctx(pool, buf);
 	return buf;
 }
 
-static inline void *util_buf_indexed_alloc(struct util_buf_pool *pool)
+static inline void *ofi_ibuf_alloc(struct ofi_bufpool *pool)
 {
-	struct util_buf_footer *buf_ftr;
-	struct util_buf_region *buf_region;
+	struct ofi_bufpool_ftr *buf_ftr;
+	struct ofi_bufpool_region *buf_region;
 
 	assert(pool->attr.indexing.ordered);
-	if (OFI_UNLIKELY(!util_buf_indexed_avail(pool))) {
-		if (util_buf_grow(pool))
+	if (OFI_UNLIKELY(ofi_ibufpool_empty(pool))) {
+		if (ofi_bufpool_grow(pool))
 			return NULL;
 	}
 
 	buf_region = container_of(pool->list.regions.next,
-				  struct util_buf_region, entry);
-	dlist_pop_front(&buf_region->buf_list, struct util_buf_footer,
+				  struct ofi_bufpool_region, entry);
+	dlist_pop_front(&buf_region->buf_list, struct ofi_bufpool_ftr,
 			buf_ftr, entry.dlist);
 	assert(++buf_ftr->region->num_used);
 
 	if (dlist_empty(&buf_region->buf_list))
 		dlist_remove_init(&buf_region->entry);
-	return util_buf_get_data(pool, buf_ftr);
+	return ofi_buf_data(pool, buf_ftr);
 }
-
-void util_buf_pool_destroy(struct util_buf_pool *pool);
 
 
 /*

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -246,7 +246,7 @@ struct ofi_mr_cache {
 	size_t				search_cnt;
 	size_t				delete_cnt;
 	size_t				hit_cnt;
-	struct util_buf_pool		*entry_pool;
+	struct ofi_bufpool		*entry_pool;
 
 	int				(*add_region)(struct ofi_mr_cache *cache,
 						      struct ofi_mr_entry *entry);

--- a/include/ofi_tree.h
+++ b/include/ofi_tree.h
@@ -74,8 +74,11 @@ struct ofi_rbmap {
 					   void *key, void *data);
 };
 
-
-void ofi_rbmap_init(struct ofi_rbmap *map);
+struct ofi_rbmap *
+ofi_rbmap_create(int (*compare)(struct ofi_rbmap *map, void *key, void *data));
+void ofi_rbmap_destroy(struct ofi_rbmap *map);
+void ofi_rbmap_init(struct ofi_rbmap *map,
+		int (*compare)(struct ofi_rbmap *map, void *key, void *data));
 void ofi_rbmap_cleanup(struct ofi_rbmap *map);
 
 struct ofi_rbnode *ofi_rbmap_find(struct ofi_rbmap *map, void *key);

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -640,7 +640,7 @@ struct util_av {
 	const struct fi_provider *prov;
 
 	struct util_av_entry	*hash;
-	struct util_buf_pool	*av_entry_pool;
+	struct ofi_bufpool	*av_entry_pool;
 
 	void			*context;
 	uint64_t		flags;

--- a/prov/mlx/src/mlx.h
+++ b/prov/mlx/src/mlx.h
@@ -105,7 +105,7 @@ struct mlx_domain {
 	struct util_domain u_domain;
 	ucp_context_h context;
 
-	struct util_buf_pool *fast_path_pool;
+	struct ofi_bufpool *fast_path_pool;
 	fastlock_t fpp_lock;
 };
 

--- a/prov/mlx/src/mlx_domain.c
+++ b/prov/mlx/src/mlx_domain.c
@@ -116,10 +116,9 @@ int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	}
 	fastlock_init(&(domain->fpp_lock));
 
-	ofi_status = ofi_bufpool_create(
-			&domain->fast_path_pool,
-			sizeof(struct mlx_request),
-			16, 0, 1024 );
+	ofi_status = ofi_bufpool_create(&domain->fast_path_pool,
+					sizeof(struct mlx_request),
+					16, 0, 1024);
 	if (ofi_status)
 		goto cleanup_mlx;
 

--- a/prov/mlx/src/mlx_domain.c
+++ b/prov/mlx/src/mlx_domain.c
@@ -43,7 +43,7 @@ static int mlx_domain_close(fid_t fid)
 	ucp_cleanup(domain->context);
 	status = ofi_domain_close( &(domain->u_domain));
 	if (!status) {
-		util_buf_pool_destroy(domain->fast_path_pool);
+		ofi_bufpool_destroy(domain->fast_path_pool);
 		free(domain);
 	}
 	return status;
@@ -116,7 +116,7 @@ int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	}
 	fastlock_init(&(domain->fpp_lock));
 
-	ofi_status = util_buf_pool_create(
+	ofi_status = ofi_bufpool_create(
 			&domain->fast_path_pool,
 			sizeof(struct mlx_request),
 			16, 0, 1024 );

--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -219,9 +219,9 @@ struct mrail_ep {
 	struct mrail_recv_queue recv_queue;
 	struct mrail_recv_queue trecv_queue;
 
-	struct util_buf_pool	*req_pool;
-	struct util_buf_pool 	*ooo_recv_pool;
-	struct util_buf_pool 	*tx_buf_pool;
+	struct ofi_bufpool	*req_pool;
+	struct ofi_bufpool 	*ooo_recv_pool;
+	struct ofi_bufpool 	*tx_buf_pool;
 	struct slist		deferred_reqs;
 };
 
@@ -337,7 +337,7 @@ struct mrail_req *mrail_alloc_req(struct mrail_ep *mrail_ep)
 	struct mrail_req *req;
 
 	ofi_ep_lock_acquire(&mrail_ep->util_ep);
-	req = util_buf_alloc(mrail_ep->req_pool);
+	req = ofi_buf_alloc(mrail_ep->req_pool);
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 
 	return req;
@@ -347,7 +347,7 @@ static inline
 void mrail_free_req(struct mrail_ep *mrail_ep, struct mrail_req *req)
 {
 	ofi_ep_lock_acquire(&mrail_ep->util_ep);
-	util_buf_release(mrail_ep->req_pool, req);
+	ofi_buf_free(mrail_ep->req_pool, req);
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 }
 

--- a/prov/mrail/src/mrail_cq.c
+++ b/prov/mrail/src/mrail_cq.c
@@ -186,7 +186,7 @@ static int mrail_process_ooo_recvs(struct mrail_ep *mrail_ep,
 		}
 
 		ofi_ep_lock_acquire(&mrail_ep->util_ep);
-		util_buf_release(mrail_ep->ooo_recv_pool, ooo_recv);
+		ofi_buf_free(mrail_ep->ooo_recv_pool, ooo_recv);
 		ooo_recv = mrail_get_next_recv(peer_info);
 	}
 	ofi_ep_lock_release(&mrail_ep->util_ep);
@@ -212,7 +212,7 @@ static void mrail_save_ooo_recv(struct mrail_ep *mrail_ep,
 	struct slist *queue = &peer_info->ooo_recv_queue;
 	struct mrail_ooo_recv *ooo_recv;
 
-	ooo_recv = util_buf_alloc(mrail_ep->ooo_recv_pool);
+	ooo_recv = ofi_buf_alloc(mrail_ep->ooo_recv_pool);
 	if (!ooo_recv) {
 		FI_WARN(&mrail_prov, FI_LOG_CQ, "Cannot allocate ooo_recv\n");
 		assert(0);
@@ -408,7 +408,7 @@ void mrail_poll_cq(struct util_cq *cq)
 				}
 			}
 			ofi_ep_lock_acquire(&tx_buf->ep->util_ep);
-			util_buf_release(tx_buf->ep->tx_buf_pool, tx_buf);
+			ofi_buf_free(tx_buf->ep->tx_buf_pool, tx_buf);
 			ofi_ep_lock_release(&tx_buf->ep->util_ep);
 		} else {
 			/* We currently cannot support FI_REMOTE_READ and
@@ -426,7 +426,7 @@ void mrail_poll_cq(struct util_cq *cq)
 
 err2:
 	ofi_ep_lock_acquire(&tx_buf->ep->util_ep);
-	util_buf_release(tx_buf->ep->tx_buf_pool, tx_buf);
+	ofi_buf_free(tx_buf->ep->tx_buf_pool, tx_buf);
 	ofi_ep_lock_release(&tx_buf->ep->util_ep);
 err1:
 	// TODO write error to cq

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -643,8 +643,8 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 		return -FI_ENOMEM;
 
 	ret = ofi_bufpool_create(&mrail_ep->ooo_recv_pool,
-				   sizeof(struct mrail_ooo_recv),
-				   sizeof(void *), 0, 64);
+				 sizeof(struct mrail_ooo_recv),
+				 sizeof(void *), 0, 64);
 	if (!mrail_ep->ooo_recv_pool)
 		goto err;
 
@@ -656,7 +656,7 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 		    (mrail_ep->num_eps * sizeof(struct mrail_subreq)));
 
 	ret = ofi_bufpool_create(&mrail_ep->req_pool, buf_size,
-				   sizeof(void *), 0, 64);
+				 sizeof(void *), 0, 64);
 	if (ret)
 		goto err;
 	return 0;

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -594,12 +594,11 @@ static int mrail_getname(fid_t fid, void *addr, size_t *addrlen)
 }
 
 
-static void mrail_tx_buf_init(void *pool_ctx, void *buf)
+static void mrail_tx_buf_init(struct ofi_bufpool_region *region, void *buf)
 {
-	struct mrail_ep *mrail_ep = pool_ctx;
 	struct mrail_tx_buf *tx_buf = buf;
 
-	tx_buf->ep		= mrail_ep;
+	tx_buf->ep		= region->pool->attr.context;
 	tx_buf->hdr.version	= MRAIL_HDR_VERSION;
 }
 
@@ -623,10 +622,7 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 	struct ofi_bufpool_attr attr = {
 		.size		= sizeof(struct mrail_tx_buf),
 		.alignment	= sizeof(void *),
-		.max_cnt	= 0,
 		.chunk_cnt	= 64,
-		.alloc_fn	= NULL,
-		.free_fn	= NULL,
 		.init_fn	= mrail_tx_buf_init,
 		.context	= mrail_ep,
 	};

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -628,7 +628,7 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 		.alloc_fn	= NULL,
 		.free_fn	= NULL,
 		.init_fn	= mrail_tx_buf_init,
-		.ctx		= mrail_ep,
+		.context	= mrail_ep,
 	};
 	size_t buf_size, rxq_total_size = 0;
 	struct fi_info *fi;

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -323,7 +323,7 @@ static struct mrail_tx_buf *mrail_get_tx_buf(struct mrail_ep *mrail_ep,
 					     void *context, uint32_t seq,
 					     uint8_t op, uint64_t flags)
 {
-	struct mrail_tx_buf *tx_buf = util_buf_alloc(mrail_ep->tx_buf_pool);
+	struct mrail_tx_buf *tx_buf = ofi_buf_alloc(mrail_ep->tx_buf_pool);
 	if (OFI_UNLIKELY(!tx_buf))
 		return NULL;
 
@@ -388,7 +388,7 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 	return ret;
 err2:
-	util_buf_release(mrail_ep->tx_buf_pool, tx_buf);
+	ofi_buf_free(mrail_ep->tx_buf_pool, tx_buf);
 err1:
 	peer_info->seq_no--;
 	ofi_ep_lock_release(&mrail_ep->util_ep);
@@ -447,7 +447,7 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 	return ret;
 err2:
-	util_buf_release(mrail_ep->tx_buf_pool, tx_buf);
+	ofi_buf_free(mrail_ep->tx_buf_pool, tx_buf);
 err1:
 	peer_info->seq_no--;
 	ofi_ep_lock_release(&mrail_ep->util_ep);
@@ -606,13 +606,13 @@ static void mrail_tx_buf_init(void *pool_ctx, void *buf)
 static void mrail_ep_free_bufs(struct mrail_ep *mrail_ep)
 {
 	if (mrail_ep->req_pool)
-		util_buf_pool_destroy(mrail_ep->req_pool);
+		ofi_bufpool_destroy(mrail_ep->req_pool);
 
 	if (mrail_ep->ooo_recv_pool)
-		util_buf_pool_destroy(mrail_ep->ooo_recv_pool);
+		ofi_bufpool_destroy(mrail_ep->ooo_recv_pool);
 
 	if (mrail_ep->tx_buf_pool)
-		util_buf_pool_destroy(mrail_ep->tx_buf_pool);
+		ofi_bufpool_destroy(mrail_ep->tx_buf_pool);
 
 	if (mrail_ep->recv_fs)
 		mrail_recv_fs_free(mrail_ep->recv_fs);
@@ -620,14 +620,14 @@ static void mrail_ep_free_bufs(struct mrail_ep *mrail_ep)
 
 static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 {
-	struct util_buf_attr attr = {
+	struct ofi_bufpool_attr attr = {
 		.size		= sizeof(struct mrail_tx_buf),
 		.alignment	= sizeof(void *),
 		.max_cnt	= 0,
 		.chunk_cnt	= 64,
-		.alloc_hndlr	= NULL,
-		.free_hndlr	= NULL,
-		.init		= mrail_tx_buf_init,
+		.alloc_fn	= NULL,
+		.free_fn	= NULL,
+		.init_fn	= mrail_tx_buf_init,
 		.ctx		= mrail_ep,
 	};
 	size_t buf_size, rxq_total_size = 0;
@@ -642,20 +642,20 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 	if (!mrail_ep->recv_fs)
 		return -FI_ENOMEM;
 
-	ret = util_buf_pool_create(&mrail_ep->ooo_recv_pool,
+	ret = ofi_bufpool_create(&mrail_ep->ooo_recv_pool,
 				   sizeof(struct mrail_ooo_recv),
 				   sizeof(void *), 0, 64);
 	if (!mrail_ep->ooo_recv_pool)
 		goto err;
 
-	ret = util_buf_pool_create_attr(&attr, &mrail_ep->tx_buf_pool);
+	ret = ofi_bufpool_create_attr(&attr, &mrail_ep->tx_buf_pool);
 	if (!mrail_ep->tx_buf_pool)
 		goto err;
 
 	buf_size = (sizeof(struct mrail_req) +
 		    (mrail_ep->num_eps * sizeof(struct mrail_subreq)));
 
-	ret = util_buf_pool_create(&mrail_ep->req_pool, buf_size,
+	ret = ofi_bufpool_create(&mrail_ep->req_pool, buf_size,
 				   sizeof(void *), 0, 64);
 	if (ret)
 		goto err;

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -514,7 +514,7 @@ struct psmx2_trx_ctxt {
 	struct psmx2_req_queue	trigger_queue;
 
 	/* request pool for RMA/atomic ops */
-	struct util_buf_pool	*am_req_pool;
+	struct ofi_bufpool	*am_req_pool;
 	fastlock_t		am_req_pool_lock;
 
 	/* lock to prevent the sequence of psm2_mq_ipeek and psm2_mq_test be
@@ -1112,7 +1112,7 @@ struct psmx2_am_request *psmx2_am_request_alloc(struct psmx2_trx_ctxt *trx_ctxt)
 	struct psmx2_am_request *req;
 
 	trx_ctxt->domain->am_req_pool_lock_fn(&trx_ctxt->am_req_pool_lock, 0);
-	req = util_buf_alloc(trx_ctxt->am_req_pool);
+	req = ofi_buf_alloc(trx_ctxt->am_req_pool);
 	trx_ctxt->domain->am_req_pool_unlock_fn(&trx_ctxt->am_req_pool_lock, 0);
 
 	if (req)
@@ -1125,7 +1125,7 @@ static inline void psmx2_am_request_free(struct psmx2_trx_ctxt *trx_ctxt,
 					 struct psmx2_am_request *req)
 {
 	trx_ctxt->domain->am_req_pool_lock_fn(&trx_ctxt->am_req_pool_lock, 0);
-	util_buf_release(trx_ctxt->am_req_pool, req);
+	ofi_buf_free(trx_ctxt->am_req_pool, req);
 	trx_ctxt->domain->am_req_pool_unlock_fn(&trx_ctxt->am_req_pool_lock, 0);
 }
 

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -267,10 +267,8 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	}
 
 	err = ofi_bufpool_create(&trx_ctxt->am_req_pool,
-				   sizeof(struct psmx2_am_request),
-				   sizeof(void *),
-				   0, /* max_cnt: unlimited */
-				   64); /* chunk_cnt */
+				 sizeof(struct psmx2_am_request),
+				 sizeof(void *), 0, 64);
 	if (err) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"failed to allocate am_req_pool.\n");

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -212,7 +212,7 @@ void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt, int usage_flags)
 	if (err != PSM2_OK)
 		psm2_ep_close(trx_ctxt->psm2_ep, PSM2_EP_CLOSE_FORCE, 0);
 
-	util_buf_pool_destroy(trx_ctxt->am_req_pool);
+	ofi_bufpool_destroy(trx_ctxt->am_req_pool);
 	fastlock_destroy(&trx_ctxt->am_req_pool_lock);
 	fastlock_destroy(&trx_ctxt->poll_lock);
 	fastlock_destroy(&trx_ctxt->peer_lock);
@@ -266,7 +266,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 		return NULL;
 	}
 
-	err = util_buf_pool_create(&trx_ctxt->am_req_pool,
+	err = ofi_bufpool_create(&trx_ctxt->am_req_pool,
 				   sizeof(struct psmx2_am_request),
 				   sizeof(void *),
 				   0, /* max_cnt: unlimited */
@@ -356,7 +356,7 @@ err_out_close_ep:
 		psm2_ep_close(trx_ctxt->psm2_ep, PSM2_EP_CLOSE_FORCE, 0);
 
 err_out_destroy_pool:
-	util_buf_pool_destroy(trx_ctxt->am_req_pool);
+	ofi_bufpool_destroy(trx_ctxt->am_req_pool);
 
 err_out:
 	free(trx_ctxt);

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -189,12 +189,12 @@ struct rxd_ep {
 	int dg_cq_fd;
 	size_t pending_cnt;
 
-	struct util_buf_pool *tx_pkt_pool;
-	struct util_buf_pool *rx_pkt_pool;
+	struct ofi_bufpool *tx_pkt_pool;
+	struct ofi_bufpool *rx_pkt_pool;
 	struct slist rx_pkt_list;
 
-	struct util_buf_pool *tx_entry_pool;
-	struct util_buf_pool *rx_entry_pool;
+	struct ofi_bufpool *tx_entry_pool;
+	struct ofi_bufpool *rx_entry_pool;
 
 	struct dlist_entry unexp_list;
 	struct dlist_entry unexp_tag_list;

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -334,6 +334,7 @@ static int rxd_av_close(struct fid *fid)
 	if (ret)
 		return ret;
 
+	ofi_rbmap_cleanup(&av->rbmap);
 	ret = ofi_av_close(&av->util_av);
 	if (ret)
 		return ret;
@@ -396,8 +397,7 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	if (ret)
 		goto err1;
 
-	av->rbmap.compare = &rxd_tree_compare;
-	ofi_rbmap_init(&av->rbmap);
+	ofi_rbmap_init(&av->rbmap, rxd_tree_compare);
 	for (i = 0; i < attr->count; av->fi_addr_table[i++] = FI_ADDR_UNSPEC)
 		;
 	for (i = 0; i < rxd_env.max_peers; i++) {

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -938,10 +938,10 @@ static struct rxd_x_entry *rxd_get_data_x_entry(struct rxd_ep *ep,
 			struct rxd_data_pkt *data_pkt)
 {
 	if (data_pkt->base_hdr.type == RXD_DATA)
-		return util_buf_get_by_index(ep->rx_entry_pool,
+		return ofi_buf_index_get(ep->rx_entry_pool,
 			     ep->peers[data_pkt->base_hdr.peer].curr_rx_id);
 
-	return util_buf_get_by_index(ep->tx_entry_pool, data_pkt->ext_hdr.tx_id);
+	return ofi_buf_index_get(ep->tx_entry_pool, data_pkt->ext_hdr.tx_id);
 }
 
 static void rxd_progress_buf_pkts(struct rxd_ep *ep, fi_addr_t peer)

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -938,10 +938,10 @@ static struct rxd_x_entry *rxd_get_data_x_entry(struct rxd_ep *ep,
 			struct rxd_data_pkt *data_pkt)
 {
 	if (data_pkt->base_hdr.type == RXD_DATA)
-		return ofi_buf_index_get(ep->rx_entry_pool,
+		return ofi_bufpool_get_ibuf(ep->rx_entry_pool,
 			     ep->peers[data_pkt->base_hdr.peer].curr_rx_id);
 
-	return ofi_buf_index_get(ep->tx_entry_pool, data_pkt->ext_hdr.tx_id);
+	return ofi_bufpool_get_ibuf(ep->tx_entry_pool, data_pkt->ext_hdr.tx_id);
 }
 
 static void rxd_progress_buf_pkts(struct rxd_ep *ep, fi_addr_t peer)

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -42,8 +42,8 @@ struct rxd_pkt_entry *rxd_get_tx_pkt(struct rxd_ep *ep)
 	void *mr = NULL;
 
 	pkt_entry = ep->do_local_mr ?
-		    util_buf_alloc_ex(ep->tx_pkt_pool, &mr) :
-		    util_buf_alloc(ep->tx_pkt_pool);
+		    ofi_buf_alloc_ex(ep->tx_pkt_pool, &mr) :
+		    ofi_buf_alloc(ep->tx_pkt_pool);
 
 	if (!pkt_entry)
 		return NULL;
@@ -61,8 +61,8 @@ static struct rxd_pkt_entry *rxd_get_rx_pkt(struct rxd_ep *ep)
 	void *mr = NULL;
 
 	pkt_entry = ep->do_local_mr ?
-		    util_buf_alloc_ex(ep->rx_pkt_pool, &mr) :
-		    util_buf_alloc(ep->rx_pkt_pool);
+		    ofi_buf_alloc_ex(ep->rx_pkt_pool, &mr) :
+		    ofi_buf_alloc(ep->rx_pkt_pool);
 
 	if (!pkt_entry)
 		return NULL;
@@ -77,11 +77,11 @@ struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep)
 {
 	struct rxd_x_entry *tx_entry;
 
-	tx_entry = util_buf_indexed_alloc(ep->tx_entry_pool);
+	tx_entry = ofi_ibuf_alloc(ep->tx_entry_pool);
 	if (!tx_entry)
 		return NULL;
 
-	tx_entry->tx_id = util_get_buf_index(ep->tx_entry_pool, tx_entry);
+	tx_entry->tx_id = ofi_buf_index(ep->tx_entry_pool, tx_entry);
 
 	return tx_entry;
 }
@@ -90,33 +90,33 @@ struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep)
 {
 	struct rxd_x_entry *rx_entry;
 
-	rx_entry = util_buf_indexed_alloc(ep->rx_entry_pool);
+	rx_entry = ofi_ibuf_alloc(ep->rx_entry_pool);
 	if (!rx_entry)
 		return NULL;
 
-	rx_entry->rx_id = util_get_buf_index(ep->rx_entry_pool, rx_entry);
+	rx_entry->rx_id = ofi_buf_index(ep->rx_entry_pool, rx_entry);
 
 	return rx_entry;
 }
 
 void rxd_release_tx_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt)
 {
-	util_buf_release(ep->tx_pkt_pool, pkt);
+	ofi_buf_free(ep->tx_pkt_pool, pkt);
 }
 
 void rxd_release_rx_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt)
 {
-	util_buf_release(ep->rx_pkt_pool, pkt);
+	ofi_buf_free(ep->rx_pkt_pool, pkt);
 }
 
 static void rxd_release_tx_entry(struct rxd_ep *ep, struct rxd_x_entry *x_entry)
 {
-	util_buf_indexed_release(ep->tx_entry_pool, x_entry);
+	ofi_ibuf_free(ep->tx_entry_pool, x_entry);
 }
 
 void rxd_release_rx_entry(struct rxd_ep *ep, struct rxd_x_entry *x_entry)
 {
-	util_buf_indexed_release(ep->rx_entry_pool, x_entry);
+	ofi_ibuf_free(ep->rx_entry_pool, x_entry);
 }
 
 static int rxd_match_ctx(struct dlist_entry *item, const void *arg)
@@ -728,10 +728,10 @@ void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer)
 
 static void rxd_ep_free_res(struct rxd_ep *ep)
 {
-	util_buf_pool_destroy(ep->tx_pkt_pool);
-	util_buf_pool_destroy(ep->rx_pkt_pool);
-	util_buf_pool_destroy(ep->tx_entry_pool);
-	util_buf_pool_destroy(ep->rx_entry_pool);
+	ofi_bufpool_destroy(ep->tx_pkt_pool);
+	ofi_bufpool_destroy(ep->rx_pkt_pool);
+	ofi_bufpool_destroy(ep->tx_entry_pool);
+	ofi_bufpool_destroy(ep->rx_entry_pool);
 }
 
 static void rxd_close_peer(struct rxd_ep *ep, struct rxd_peer *peer)
@@ -1136,7 +1136,7 @@ out:
 	fastlock_release(&ep->util_ep.lock);
 }
 
-static int rxd_buf_region_alloc_hndlr(void *pool_ctx, void *addr, size_t len,
+static int rxd_buf_region_alloc_fn(void *pool_ctx, void *addr, size_t len,
 				void **context)
 {
 	int ret;
@@ -1149,7 +1149,7 @@ static int rxd_buf_region_alloc_hndlr(void *pool_ctx, void *addr, size_t len,
 	return ret;
 }
 
-static void rxd_buf_region_free_hndlr(void *pool_ctx, void *context)
+static void rxd_buf_region_free_fn(void *pool_ctx, void *context)
 {
 	fi_close((struct fid *) context);
 }
@@ -1157,7 +1157,7 @@ static void rxd_buf_region_free_hndlr(void *pool_ctx, void *context)
 int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 {
 	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
-	struct util_buf_attr entry_pool_attr = {
+	struct ofi_bufpool_attr entry_pool_attr = {
 		.size		= sizeof(struct rxd_x_entry),
 		.alignment	= RXD_BUF_POOL_ALIGNMENT,
 		.max_cnt	= 0,
@@ -1167,33 +1167,33 @@ int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 		},
 	};
 
-	int ret = util_buf_pool_create_ex(
+	int ret = ofi_bufpool_create_ex(
 		&ep->tx_pkt_pool,
 		rxd_domain->max_mtu_sz + sizeof(struct rxd_pkt_entry),
 		RXD_BUF_POOL_ALIGNMENT, 0, RXD_TX_POOL_CHUNK_CNT,
-	        ep->do_local_mr ? rxd_buf_region_alloc_hndlr : NULL,
-		ep->do_local_mr ? rxd_buf_region_free_hndlr : NULL,
+	        ep->do_local_mr ? rxd_buf_region_alloc_fn : NULL,
+		ep->do_local_mr ? rxd_buf_region_free_fn : NULL,
 		rxd_domain);
 	if (ret)
 		return -FI_ENOMEM;
 
-	ret = util_buf_pool_create_ex(
+	ret = ofi_bufpool_create_ex(
 		&ep->rx_pkt_pool,
 		rxd_domain->max_mtu_sz + sizeof (struct rxd_pkt_entry),
 		RXD_BUF_POOL_ALIGNMENT, 0, RXD_RX_POOL_CHUNK_CNT,
-	        ep->do_local_mr ? rxd_buf_region_alloc_hndlr : NULL,
-		ep->do_local_mr ? rxd_buf_region_free_hndlr : NULL,
+	        ep->do_local_mr ? rxd_buf_region_alloc_fn : NULL,
+		ep->do_local_mr ? rxd_buf_region_free_fn : NULL,
 		rxd_domain);
 	if (ret)
 		goto err;
 
 	entry_pool_attr.chunk_cnt = ep->tx_size;
-	ret = util_buf_pool_create_attr(&entry_pool_attr, &ep->tx_entry_pool);
+	ret = ofi_bufpool_create_attr(&entry_pool_attr, &ep->tx_entry_pool);
 	if (ret)
 		goto err;
 
 	entry_pool_attr.chunk_cnt = ep->rx_size;
-	ret = util_buf_pool_create_attr(&entry_pool_attr, &ep->rx_entry_pool);
+	ret = ofi_bufpool_create_attr(&entry_pool_attr, &ep->rx_entry_pool);
 	if (ret)
 		goto err;
 
@@ -1210,16 +1210,16 @@ int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 	return 0;
 err:
 	if (ep->tx_pkt_pool)
-		util_buf_pool_destroy(ep->tx_pkt_pool);
+		ofi_bufpool_destroy(ep->tx_pkt_pool);
 
 	if (ep->rx_pkt_pool)
-		util_buf_pool_destroy(ep->rx_pkt_pool);
+		ofi_bufpool_destroy(ep->rx_pkt_pool);
 
 	if (ep->tx_entry_pool)
-		util_buf_pool_destroy(ep->tx_entry_pool);
+		ofi_bufpool_destroy(ep->tx_entry_pool);
 
 	if (ep->rx_entry_pool)
-		util_buf_pool_destroy(ep->rx_entry_pool);
+		ofi_bufpool_destroy(ep->rx_entry_pool);
 
 	return -FI_ENOMEM;
 }

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1136,22 +1136,21 @@ out:
 	fastlock_release(&ep->util_ep.lock);
 }
 
-static int rxd_buf_region_alloc_fn(void *pool_ctx, void *addr, size_t len,
-				void **context)
+static int rxd_buf_region_alloc_fn(struct ofi_bufpool_region *region)
 {
-	int ret;
+	struct rxd_domain *domain = region->pool->attr.context;
 	struct fid_mr *mr;
-	struct rxd_domain *domain = pool_ctx;
+	int ret;
 
-	ret = fi_mr_reg(domain->dg_domain, addr, len,
+	ret = fi_mr_reg(domain->dg_domain, region->mem_region, region->size,
 			FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL);
-	*context = mr;
+	region->context = mr;
 	return ret;
 }
 
-static void rxd_buf_region_free_fn(void *pool_ctx, void *context)
+static void rxd_buf_region_free_fn(struct ofi_bufpool_region *region)
 {
-	fi_close((struct fid *) context);
+	fi_close(region->context);
 }
 
 int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1142,7 +1142,8 @@ static int rxd_buf_region_alloc_fn(struct ofi_bufpool_region *region)
 	struct fid_mr *mr;
 	int ret;
 
-	ret = fi_mr_reg(domain->dg_domain, region->mem_region, region->size,
+	ret = fi_mr_reg(domain->dg_domain, region->mem_region,
+			region->pool->region_size,
 			FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL);
 	region->context = mr;
 	return ret;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1275,10 +1275,9 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 				 dg_info->ep_attr->msg_prefix_size : 0;
 	rxd_ep->rx_prefix_size = dg_info->rx_attr->mode & FI_MSG_PREFIX ?
 				 dg_info->ep_attr->msg_prefix_size : 0;
-	fi_freeinfo(dg_info);
-
 	rxd_ep->rx_size = MIN(dg_info->rx_attr->size, info->rx_attr->size);
 	rxd_ep->tx_size = MIN(dg_info->tx_attr->size, info->tx_attr->size);
+	fi_freeinfo(dg_info);
 
 	rxd_ep->next_retry = -1;
 	ret = rxd_ep_init_res(rxd_ep, info);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -1032,7 +1032,7 @@ void rxm_buf_release(struct rxm_buf_pool *pool, struct rxm_buf *buf)
 static inline struct rxm_buf *
 rxm_buf_get_by_index(struct rxm_buf_pool *pool, size_t index)
 {
-	return ofi_buf_index_get(pool->pool, index);
+	return ofi_bufpool_get_ibuf(pool->pool, index);
 }
 
 static inline

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -622,7 +622,7 @@ struct rxm_recv_queue {
 
 struct rxm_buf_pool {
 	enum rxm_buf_pool_type type;
-	struct util_buf_pool *pool;
+	struct ofi_bufpool *pool;
 	struct rxm_ep *rxm_ep;
 };
 
@@ -1020,25 +1020,25 @@ rxm_ep_format_tx_buf_pkt(struct rxm_conn *rxm_conn, size_t len, uint8_t op,
 
 static inline struct rxm_buf *rxm_buf_alloc(struct rxm_buf_pool *pool)
 {
-	return util_buf_alloc(pool->pool);
+	return ofi_buf_alloc(pool->pool);
 }
 
 static inline
 void rxm_buf_release(struct rxm_buf_pool *pool, struct rxm_buf *buf)
 {
-	util_buf_release(pool->pool, buf);
+	ofi_buf_free(pool->pool, buf);
 }
 
 static inline struct rxm_buf *
 rxm_buf_get_by_index(struct rxm_buf_pool *pool, size_t index)
 {
-	return util_buf_get_by_index(pool->pool, index);
+	return ofi_buf_index_get(pool->pool, index);
 }
 
 static inline
 size_t rxm_get_buf_index(struct rxm_buf_pool *pool, struct rxm_buf *buf)
 {
-	return util_get_buf_index(pool->pool, buf);
+	return ofi_buf_index(pool->pool, buf);
 }
 
 static inline struct rxm_buf *
@@ -1072,7 +1072,7 @@ rxm_rx_buf_release(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf)
 		dlist_insert_tail(&rx_buf->repost_entry,
 				  &rx_buf->ep->repost_ready_list);
 	} else {
-		util_buf_release(rxm_ep->buf_pools[RXM_BUF_POOL_RX].pool,
+		ofi_buf_free(rxm_ep->buf_pools[RXM_BUF_POOL_RX].pool,
 				 rx_buf);
 	}
 }

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -275,6 +275,7 @@ static int rxm_buf_pool_create(struct rxm_ep *rxm_ep,
 			       struct rxm_buf_pool *pool,
 			       enum rxm_buf_pool_type type)
 {
+	int ret;
 	struct ofi_bufpool_attr attr = {
 		.size		= size,
 		.alignment	= 16,
@@ -283,30 +284,16 @@ static int rxm_buf_pool_create(struct rxm_ep *rxm_ep,
 		.alloc_fn	= rxm_buf_reg,
 		.free_fn	= rxm_buf_close,
 		.ctx		= pool,
-		.track_used	= 0,
+		.flags		= OFI_BUFPOOL_NO_TRACK,
 	};
-	int ret;
-
-	switch (type) {
-	case RXM_BUF_POOL_TX_RNDV:
-	case RXM_BUF_POOL_TX_ATOMIC:
-	case RXM_BUF_POOL_TX_SAR:
-		attr.indexing.used = 1;
-		break;
-	default:
-		attr.indexing.used = 0;
-		break;
-	}
 
 	pool->rxm_ep = rxm_ep;
 	pool->type = type;
 	ret = ofi_bufpool_create_attr(&attr, &pool->pool);
-	if (ret) {
+	if (ret)
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to create buf pool\n");
-		return -FI_ENOMEM;
-	}
 
-	return 0;
+	return ret;
 }
 
 static void rxm_recv_entry_init(struct rxm_recv_entry *entry, void *arg)

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -132,7 +132,8 @@ static int rxm_buf_reg(struct ofi_bufpool_region *region)
 	if ((pool->type != RXM_BUF_POOL_TX_INJECT) &&
 	    pool->rxm_ep->msg_mr_local) {
 		ret = rxm_mr_buf_reg(pool->rxm_ep, region->mem_region,
-				     region->size, &region->context);
+				     region->pool->region_size,
+				     &region->context);
 	} else {
 		ret = 0;
 	}

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -140,7 +140,7 @@ static void rxm_buf_reg_set_common(struct rxm_buf *hdr, struct rxm_pkt *pkt,
 static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 {
 	struct rxm_buf_pool *pool = (struct rxm_buf_pool *)pool_ctx;
-	size_t i, entry_sz = pool->pool->entry_sz;
+	size_t i, entry_size = pool->pool->entry_size;
 	int ret;
 	void *mr_desc;
 	uint8_t type;
@@ -167,7 +167,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 		switch (pool->type) {
 		case RXM_BUF_POOL_RX:
 			rx_buf = (struct rxm_rx_buf *)
-				((char *)addr + i * entry_sz);
+				((char *)addr + i * entry_size);
 			rx_buf->ep = pool->rxm_ep;
 
 			hdr = &rx_buf->hdr;
@@ -176,7 +176,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			break;
 		case RXM_BUF_POOL_TX:
 			tx_eager_buf = (struct rxm_tx_eager_buf *)
-				((char *)addr + i * entry_sz);
+				((char *)addr + i * entry_size);
 			tx_eager_buf->hdr.state = RXM_TX;
 
 			hdr = &tx_eager_buf->hdr;
@@ -185,7 +185,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			break;
 		case RXM_BUF_POOL_TX_INJECT:
 			tx_base_buf = (struct rxm_tx_base_buf *)
-				((char *)addr + i * entry_sz);
+				((char *)addr + i * entry_size);
 			tx_base_buf->hdr.state = RXM_INJECT_TX;
 
 			hdr = NULL;
@@ -194,7 +194,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			break;
 		case RXM_BUF_POOL_TX_SAR:
 			tx_sar_buf = (struct rxm_tx_sar_buf *)
-				((char *)addr + i * entry_sz);
+				((char *)addr + i * entry_size);
 			tx_sar_buf->hdr.state = RXM_SAR_TX;
 
 			hdr = &tx_sar_buf->hdr;
@@ -203,7 +203,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			break;
 		case RXM_BUF_POOL_TX_RNDV:
 			tx_rndv_buf = (struct rxm_tx_rndv_buf *)
-				((char *)addr + i * entry_sz);
+				((char *)addr + i * entry_size);
 
 			hdr = &tx_rndv_buf->hdr;
 			pkt = &tx_rndv_buf->pkt;
@@ -211,7 +211,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			break;
 		case RXM_BUF_POOL_TX_ATOMIC:
 			tx_atomic_buf = (struct rxm_tx_atomic_buf *)
-				((char *)addr + i * entry_sz);
+				((char *)addr + i * entry_size);
 
 			hdr = &tx_atomic_buf->hdr;
 			pkt = &tx_atomic_buf->pkt;
@@ -219,7 +219,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			break;
 		case RXM_BUF_POOL_TX_ACK:
 			tx_base_buf = (struct rxm_tx_base_buf *)
-				((char *)addr + i * entry_sz);
+				((char *)addr + i * entry_size);
 			tx_base_buf->pkt.hdr.op = ofi_op_msg;
 
 			hdr = &tx_base_buf->hdr;
@@ -228,7 +228,7 @@ static int rxm_buf_reg(void *pool_ctx, void *addr, size_t len, void **context)
 			break;
 		case RXM_BUF_POOL_RMA:
 			rma_buf = (struct rxm_rma_buf *)
-				((char *)addr + i * entry_sz);
+				((char *)addr + i * entry_size);
 			rma_buf->pkt.hdr.op = ofi_op_msg;
 			rma_buf->hdr.state = RXM_RMA;
 
@@ -283,7 +283,7 @@ static int rxm_buf_pool_create(struct rxm_ep *rxm_ep,
 		.chunk_cnt	= chunk_count,
 		.alloc_fn	= rxm_buf_reg,
 		.free_fn	= rxm_buf_close,
-		.ctx		= pool,
+		.context	= pool,
 		.flags		= OFI_BUFPOOL_NO_TRACK,
 	};
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -266,7 +266,7 @@ static void rxm_buf_pool_destroy(struct rxm_buf_pool *pool)
 {
 	/* This indicates whether the pool is allocated or not */
 	if (pool->rxm_ep) {
-		util_buf_pool_destroy(pool->pool);
+		ofi_bufpool_destroy(pool->pool);
 	}
 }
 
@@ -275,13 +275,13 @@ static int rxm_buf_pool_create(struct rxm_ep *rxm_ep,
 			       struct rxm_buf_pool *pool,
 			       enum rxm_buf_pool_type type)
 {
-	struct util_buf_attr attr = {
+	struct ofi_bufpool_attr attr = {
 		.size		= size,
 		.alignment	= 16,
 		.max_cnt	= 0,
 		.chunk_cnt	= chunk_count,
-		.alloc_hndlr	= rxm_buf_reg,
-		.free_hndlr	= rxm_buf_close,
+		.alloc_fn	= rxm_buf_reg,
+		.free_fn	= rxm_buf_close,
 		.ctx		= pool,
 		.track_used	= 0,
 	};
@@ -300,7 +300,7 @@ static int rxm_buf_pool_create(struct rxm_ep *rxm_ep,
 
 	pool->rxm_ep = rxm_ep;
 	pool->type = type;
-	ret = util_buf_pool_create_attr(&attr, &pool->pool);
+	ret = ofi_bufpool_create_attr(&attr, &pool->pool);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to create buf pool\n");
 		return -FI_ENOMEM;

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -865,8 +865,8 @@ struct sock_pe {
 	int signal_fds[2];
 	uint64_t waittime;
 
-	struct util_buf_pool *pe_rx_pool;
-	struct util_buf_pool *atomic_rx_pool;
+	struct ofi_bufpool *pe_rx_pool;
+	struct ofi_bufpool *atomic_rx_pool;
 	struct dlist_entry free_list;
 	struct dlist_entry busy_list;
 	struct dlist_entry pool_list;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -160,14 +160,14 @@ static void sock_pe_release_entry(struct sock_pe *pe,
 		pe_entry->conn->rx_pe_entry = NULL;
 
 	if (pe_entry->type == SOCK_PE_RX && pe_entry->pe.rx.atomic_cmp) {
-		util_buf_release(pe->atomic_rx_pool, pe_entry->pe.rx.atomic_cmp);
-		util_buf_release(pe->atomic_rx_pool, pe_entry->pe.rx.atomic_src);
+		ofi_buf_free(pe->atomic_rx_pool, pe_entry->pe.rx.atomic_cmp);
+		ofi_buf_free(pe->atomic_rx_pool, pe_entry->pe.rx.atomic_src);
 	}
 
 	if (pe_entry->is_pool_entry) {
 		ofi_rbfree(&pe_entry->comm_buf);
 		dlist_remove(&pe_entry->entry);
-		util_buf_release(pe->pe_rx_pool, pe_entry);
+		ofi_buf_free(pe->pe_rx_pool, pe_entry);
 		return;
 	}
 
@@ -205,7 +205,7 @@ static struct sock_pe_entry *sock_pe_acquire_entry(struct sock_pe *pe)
 	struct sock_pe_entry *pe_entry;
 
 	if (dlist_empty(&pe->free_list)) {
-		pe_entry = util_buf_alloc(pe->pe_rx_pool);
+		pe_entry = ofi_buf_alloc(pe->pe_rx_pool);
 		SOCK_LOG_DBG("Getting rx pool entry\n");
 		if (pe_entry) {
 			memset(pe_entry, 0, sizeof(*pe_entry));
@@ -885,8 +885,8 @@ static int sock_pe_recv_atomic_hdrs(struct sock_pe *pe,
 	int i;
 
 	if (!pe_entry->pe.rx.atomic_cmp) {
-		pe_entry->pe.rx.atomic_cmp = util_buf_alloc(pe->atomic_rx_pool);
-		pe_entry->pe.rx.atomic_src = util_buf_alloc(pe->atomic_rx_pool);
+		pe_entry->pe.rx.atomic_cmp = ofi_buf_alloc(pe->atomic_rx_pool);
+		pe_entry->pe.rx.atomic_src = ofi_buf_alloc(pe->atomic_rx_pool);
 		if (!pe_entry->pe.rx.atomic_cmp || !pe_entry->pe.rx.atomic_src)
 			return -FI_ENOMEM;
 	}
@@ -2698,7 +2698,7 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 	pe->domain = domain;
 
 	
-	ret = util_buf_pool_create(&pe->pe_rx_pool,
+	ret = ofi_bufpool_create(&pe->pe_rx_pool,
 				   sizeof(struct sock_pe_entry),
 				   16, 0, 1024);
 	if (ret) {
@@ -2706,7 +2706,7 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 		goto err1;
 	}
 
-	ret = util_buf_pool_create(&pe->atomic_rx_pool,
+	ret = ofi_bufpool_create(&pe->atomic_rx_pool,
 				   SOCK_EP_MAX_ATOMIC_SZ,
 				   16, 0, 32);
 	if (ret) {
@@ -2745,9 +2745,9 @@ err5:
 err4:
 	fi_epoll_close(pe->epoll_set);
 err3:
-	util_buf_pool_destroy(pe->atomic_rx_pool);
+	ofi_bufpool_destroy(pe->atomic_rx_pool);
 err2:
-	util_buf_pool_destroy(pe->pe_rx_pool);
+	ofi_bufpool_destroy(pe->pe_rx_pool);
 err1:
 	fastlock_destroy(&pe->lock);
 	free(pe);
@@ -2764,11 +2764,11 @@ static void sock_pe_free_util_pool(struct sock_pe *pe)
 		pe_entry = container_of(entry, struct sock_pe_entry, entry);
 		ofi_rbfree(&pe_entry->comm_buf);
 		dlist_remove(&pe_entry->entry);
-		util_buf_release(pe->pe_rx_pool, pe_entry);
+		ofi_buf_free(pe->pe_rx_pool, pe_entry);
 	}
 
-	util_buf_pool_destroy(pe->pe_rx_pool);
-	util_buf_pool_destroy(pe->atomic_rx_pool);
+	ofi_bufpool_destroy(pe->pe_rx_pool);
+	ofi_bufpool_destroy(pe->atomic_rx_pool);
 }
 
 void sock_pe_finalize(struct sock_pe *pe)

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2699,16 +2699,14 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 
 	
 	ret = ofi_bufpool_create(&pe->pe_rx_pool,
-				   sizeof(struct sock_pe_entry),
-				   16, 0, 1024);
+				 sizeof(struct sock_pe_entry), 16, 0, 1024);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to create buffer pool\n");
 		goto err1;
 	}
 
 	ret = ofi_bufpool_create(&pe->atomic_rx_pool,
-				   SOCK_EP_MAX_ATOMIC_SZ,
-				   16, 0, 32);
+				 SOCK_EP_MAX_ATOMIC_SZ, 16, 0, 32);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to create atomic rx buffer pool\n");
 		goto err2;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -163,7 +163,7 @@ struct tcpx_rx_detect {
 struct tcpx_rx_ctx {
 	struct fid_ep		rx_fid;
 	struct slist		rx_queue;
-	struct util_buf_pool	*buf_pool;
+	struct ofi_bufpool	*buf_pool;
 	fastlock_t		lock;
 };
 
@@ -224,7 +224,7 @@ struct tcpx_domain {
 };
 
 struct tcpx_buf_pool {
-	struct util_buf_pool	*pool;
+	struct ofi_bufpool	*pool;
 	enum tcpx_xfer_op_codes	op_type;
 };
 

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -186,7 +186,7 @@ static int tcpx_buf_pool_init(void *pool_ctx, void *addr,
 
 	for (i = 0; i < pool->pool->attr.chunk_cnt; i++) {
 		xfer_entry = (struct tcpx_xfer_entry *)
-			((char *)addr + i * pool->pool->entry_sz);
+			((char *)addr + i * pool->pool->entry_size);
 
 		xfer_entry->hdr.base_hdr.version = TCPX_HDR_VERSION;
 		xfer_entry->hdr.base_hdr.op_data = pool->op_type;

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -224,9 +224,9 @@ static int tcpx_buf_pools_create(struct tcpx_buf_pool *buf_pools)
 		buf_pools[i].op_type = i;
 
 		ret = ofi_bufpool_create_ex(&buf_pools[i].pool,
-					      sizeof(struct tcpx_xfer_entry),
-					      16, 0, 1024, tcpx_buf_pool_init,
-					      NULL, &buf_pools[i]);
+					    sizeof(struct tcpx_xfer_entry),
+					    16, 0, 1024, tcpx_buf_pool_init,
+					    NULL, &buf_pools[i]);
 		if (ret) {
 			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 				"Unable to create buf pool\n");
@@ -234,11 +234,12 @@ static int tcpx_buf_pools_create(struct tcpx_buf_pool *buf_pools)
 		}
 	}
 	return 0;
+
 err:
-	while (i--) {
+	while (i--)
 		ofi_bufpool_destroy(buf_pools[i].pool);
-	}
-	return -FI_ENOMEM;
+
+	return -ret;
 }
 
 int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -177,16 +177,15 @@ static struct fi_ops tcpx_cq_fi_ops = {
  * Note that the ofi_bufpool uses first sizeof(slist_entry) bytes in every buffer
  * internally for keeping buf list. So don't try to set those values. They won't stick
  */
-static int tcpx_buf_pool_init(void *pool_ctx, void *addr,
-			      size_t len, void **context)
+static int tcpx_buf_pool_init(struct ofi_bufpool_region *region)
 {
-	struct tcpx_buf_pool *pool = (struct tcpx_buf_pool *)pool_ctx;
+	struct tcpx_buf_pool *pool = region->pool->attr.context;
 	struct tcpx_xfer_entry *xfer_entry;
 	int i;
 
 	for (i = 0; i < pool->pool->attr.chunk_cnt; i++) {
 		xfer_entry = (struct tcpx_xfer_entry *)
-			((char *)addr + i * pool->pool->entry_size);
+			((char *) region->mem_region + i * pool->pool->entry_size);
 
 		xfer_entry->hdr.base_hdr.version = TCPX_HDR_VERSION;
 		xfer_entry->hdr.base_hdr.op_data = pool->op_type;

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -173,59 +173,53 @@ static struct fi_ops tcpx_cq_fi_ops = {
 	.ops_open = fi_no_ops_open,
 };
 
-/* Using this function to preset some values of buffers managed by ofi_bufpool api.
- * Note that the ofi_bufpool uses first sizeof(slist_entry) bytes in every buffer
- * internally for keeping buf list. So don't try to set those values. They won't stick
- */
-static int tcpx_buf_pool_init(struct ofi_bufpool_region *region)
+static void tcpx_buf_pool_init(struct ofi_bufpool_region *region, void *buf)
 {
 	struct tcpx_buf_pool *pool = region->pool->attr.context;
-	struct tcpx_xfer_entry *xfer_entry;
-	int i;
+	struct tcpx_xfer_entry *xfer_entry = buf;
 
-	for (i = 0; i < pool->pool->attr.chunk_cnt; i++) {
-		xfer_entry = (struct tcpx_xfer_entry *)
-			((char *) region->mem_region + i * pool->pool->entry_size);
+	xfer_entry->hdr.base_hdr.version = TCPX_HDR_VERSION;
+	xfer_entry->hdr.base_hdr.op_data = pool->op_type;
 
-		xfer_entry->hdr.base_hdr.version = TCPX_HDR_VERSION;
-		xfer_entry->hdr.base_hdr.op_data = pool->op_type;
-		switch (pool->op_type) {
-		case TCPX_OP_MSG_RECV:
-		case TCPX_OP_MSG_SEND:
-		case TCPX_OP_MSG_RESP:
-			xfer_entry->hdr.base_hdr.op = ofi_op_msg;
-			break;
-		case TCPX_OP_WRITE:
-		case TCPX_OP_REMOTE_WRITE:
-			xfer_entry->hdr.base_hdr.op = ofi_op_write;
-			break;
-		case TCPX_OP_READ_REQ:
-			xfer_entry->hdr.base_hdr.op = ofi_op_read_req;
-			break;
-		case TCPX_OP_READ_RSP:
-			xfer_entry->hdr.base_hdr.op = ofi_op_read_rsp;
-			break;
-		case TCPX_OP_REMOTE_READ:
-			break;
-		default:
-			assert(0);
-			break;
-		}
+	switch (pool->op_type) {
+	case TCPX_OP_MSG_RECV:
+	case TCPX_OP_MSG_SEND:
+	case TCPX_OP_MSG_RESP:
+		xfer_entry->hdr.base_hdr.op = ofi_op_msg;
+		break;
+	case TCPX_OP_WRITE:
+	case TCPX_OP_REMOTE_WRITE:
+		xfer_entry->hdr.base_hdr.op = ofi_op_write;
+		break;
+	case TCPX_OP_READ_REQ:
+		xfer_entry->hdr.base_hdr.op = ofi_op_read_req;
+		break;
+	case TCPX_OP_READ_RSP:
+		xfer_entry->hdr.base_hdr.op = ofi_op_read_rsp;
+		break;
+	case TCPX_OP_REMOTE_READ:
+		break;
+	default:
+		assert(0);
+		break;
 	}
-	return FI_SUCCESS;
 }
 
 static int tcpx_buf_pools_create(struct tcpx_buf_pool *buf_pools)
 {
 	int i, ret;
+	struct ofi_bufpool_attr attr = {
+		.size = sizeof(struct tcpx_xfer_entry),
+		.alignment = 16,
+		.chunk_cnt = 1024,
+		.init_fn = tcpx_buf_pool_init,
+	};
 
 	for (i = 0; i < TCPX_OP_CODE_MAX; i++) {
 		buf_pools[i].op_type = i;
 
-		ret = ofi_bufpool_create_ex(&buf_pools[i].pool,
-					    sizeof(struct tcpx_xfer_entry),
-					    16, 0, 1024, tcpx_buf_pool_init,
-					    NULL, &buf_pools[i]);
+		attr.context = &buf_pools[i];
+		ret = ofi_bufpool_create_attr(&attr, &buf_pools[i].pool);
 		if (ret) {
 			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 				"Unable to create buf pool\n");

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -87,8 +87,7 @@ static int tcpx_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
 		goto err1;
 
 	ret = ofi_bufpool_create(&srx_ctx->buf_pool,
-				   sizeof(struct tcpx_xfer_entry),
-				   16, 0, 1024);
+				 sizeof(struct tcpx_xfer_entry), 16, 0, 1024);
 	if (ret)
 		goto err2;
 

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -48,10 +48,10 @@ static int tcpx_srx_ctx_close(struct fid *fid)
 	while (!slist_empty(&srx_ctx->rx_queue)) {
 		entry = slist_remove_head(&srx_ctx->rx_queue);
 		xfer_entry = container_of(entry, struct tcpx_xfer_entry, entry);
-		util_buf_release(srx_ctx->buf_pool, xfer_entry);
+		ofi_buf_free(srx_ctx->buf_pool, xfer_entry);
 	}
 
-	util_buf_pool_destroy(srx_ctx->buf_pool);
+	ofi_bufpool_destroy(srx_ctx->buf_pool);
 	fastlock_destroy(&srx_ctx->lock);
 	free(srx_ctx);
 	return FI_SUCCESS;
@@ -86,7 +86,7 @@ static int tcpx_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
 	if (ret)
 		goto err1;
 
-	ret = util_buf_pool_create(&srx_ctx->buf_pool,
+	ret = ofi_bufpool_create(&srx_ctx->buf_pool,
 				   sizeof(struct tcpx_xfer_entry),
 				   16, 0, 1024);
 	if (ret)

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -45,7 +45,7 @@ void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 		xfer_entry->ep->cur_rx_entry = NULL;
 
 	fastlock_acquire(&srx_ctx->lock);
-	util_buf_release(srx_ctx->buf_pool, xfer_entry);
+	ofi_buf_free(srx_ctx->buf_pool, xfer_entry);
 	fastlock_release(&srx_ctx->lock);
 }
 
@@ -90,7 +90,7 @@ static ssize_t tcpx_srx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	assert(msg->iov_count <= TCPX_IOV_LIMIT);
 
 	fastlock_acquire(&srx_ctx->lock);
-	recv_entry = util_buf_alloc(srx_ctx->buf_pool);
+	recv_entry = ofi_buf_alloc(srx_ctx->buf_pool);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
 		goto unlock;
@@ -115,7 +115,7 @@ static ssize_t tcpx_srx_recv(struct fid_ep *ep, void *buf, size_t len, void *des
 	srx_ctx = container_of(ep, struct tcpx_rx_ctx, rx_fid);
 
 	fastlock_acquire(&srx_ctx->lock);
-	recv_entry = util_buf_alloc(srx_ctx->buf_pool);
+	recv_entry = ofi_buf_alloc(srx_ctx->buf_pool);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
 		goto unlock;
@@ -143,7 +143,7 @@ static ssize_t tcpx_srx_recvv(struct fid_ep *ep, const struct iovec *iov, void *
 	assert(count <= TCPX_IOV_LIMIT);
 
 	fastlock_acquire(&srx_ctx->lock);
-	recv_entry = util_buf_alloc(srx_ctx->buf_pool);
+	recv_entry = ofi_buf_alloc(srx_ctx->buf_pool);
 	if (!recv_entry) {
 		ret = -FI_EAGAIN;
 		goto unlock;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -242,8 +242,9 @@ int ofi_get_addr(uint32_t *addr_format, uint64_t flags,
 
 void *ofi_av_get_addr(struct util_av *av, fi_addr_t fi_addr)
 {
-	struct util_av_entry *entry =
-		ofi_buf_index_get(av->av_entry_pool, fi_addr);
+	struct util_av_entry *entry;
+
+	entry = ofi_buf_index_get(av->av_entry_pool, fi_addr);
 	return entry->addr;
 }
 
@@ -308,8 +309,9 @@ int ofi_av_elements_iter(struct util_av *av, ofi_av_apply_func apply, void *arg)
  */
 int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr)
 {
-	struct util_av_entry *av_entry =
-		ofi_buf_index_get(av->av_entry_pool, fi_addr);
+	struct util_av_entry *av_entry;
+
+	av_entry = ofi_buf_index_get(av->av_entry_pool, fi_addr);
 	if (!av_entry)
 		return -FI_ENOENT;
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -243,7 +243,7 @@ int ofi_get_addr(uint32_t *addr_format, uint64_t flags,
 void *ofi_av_get_addr(struct util_av *av, fi_addr_t fi_addr)
 {
 	struct util_av_entry *entry =
-		util_buf_get_by_index(av->av_entry_pool, fi_addr);
+		ofi_buf_index_get(av->av_entry_pool, fi_addr);
 	return entry->addr;
 }
 
@@ -272,15 +272,15 @@ int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr)
 	HASH_FIND(hh, av->hash, addr, av->addrlen, entry);
 	if (entry) {
 		if (fi_addr)
-			*fi_addr = util_get_buf_index(av->av_entry_pool, entry);
+			*fi_addr = ofi_buf_index(av->av_entry_pool, entry);
 		ofi_atomic_inc32(&entry->use_cnt);
 		return 0;
 	} else {
-		entry = util_buf_indexed_alloc(av->av_entry_pool);
+		entry = ofi_ibuf_alloc(av->av_entry_pool);
 		if (!entry)
 			return -FI_ENOMEM;
 		if (fi_addr)
-			*fi_addr = util_get_buf_index(av->av_entry_pool, entry);
+			*fi_addr = ofi_buf_index(av->av_entry_pool, entry);
 		memcpy(entry->addr, addr, av->addrlen);
 		ofi_atomic_initialize32(&entry->use_cnt, 1);
 		HASH_ADD(hh, av->hash, addr, av->addrlen, entry);
@@ -295,7 +295,7 @@ int ofi_av_elements_iter(struct util_av *av, ofi_av_apply_func apply, void *arg)
 
 	HASH_ITER(hh, av->hash, av_entry, av_entry_tmp) {
 		ret = apply(av, av_entry->addr,
-			    util_get_buf_index(av->av_entry_pool, av_entry),
+			    ofi_buf_index(av->av_entry_pool, av_entry),
 			    arg);
 		if (OFI_UNLIKELY(ret))
 			return ret;
@@ -309,7 +309,7 @@ int ofi_av_elements_iter(struct util_av *av, ofi_av_apply_func apply, void *arg)
 int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr)
 {
 	struct util_av_entry *av_entry =
-		util_buf_get_by_index(av->av_entry_pool, fi_addr);
+		ofi_buf_index_get(av->av_entry_pool, fi_addr);
 	if (!av_entry)
 		return -FI_ENOENT;
 
@@ -317,7 +317,7 @@ int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr)
 		return FI_SUCCESS;
 
 	HASH_DELETE(hh, av->hash, av_entry);
-	util_buf_indexed_release(av->av_entry_pool, av_entry);
+	ofi_ibuf_free(av->av_entry_pool, av_entry);
 	return 0;
 }
 
@@ -329,7 +329,7 @@ fi_addr_t ofi_av_lookup_fi_addr(struct util_av *av, const void *addr)
 	HASH_FIND(hh, av->hash, addr, av->addrlen, entry);
 	fastlock_release(&av->lock);
 
-	return entry ? util_get_buf_index(av->av_entry_pool, entry) :
+	return entry ? ofi_buf_index(av->av_entry_pool, entry) :
 		       FI_ADDR_NOTAVAIL;
 }
 
@@ -365,7 +365,7 @@ int ofi_av_bind(struct fid *av_fid, struct fid *eq_fid, uint64_t flags)
 static void util_av_close(struct util_av *av)
 {
 	HASH_CLEAR(hh, av->hash);
-	util_buf_pool_destroy(av->av_entry_pool);
+	ofi_bufpool_destroy(av->av_entry_pool);
 }
 
 int ofi_av_close_lightweight(struct util_av *av)
@@ -409,7 +409,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 {
 	int ret = 0;
 	size_t max_count;
-	struct util_buf_attr pool_attr = {
+	struct ofi_bufpool_attr pool_attr = {
 		.size		= util_attr->addrlen +
 				  sizeof(struct util_av_entry),
 		.alignment	= 16,
@@ -447,7 +447,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 	av->hash = NULL;
 
 	pool_attr.chunk_cnt = av->count;
-	ret = util_buf_pool_create_attr(&pool_attr, &av->av_entry_pool);
+	ret = ofi_bufpool_create_attr(&pool_attr, &av->av_entry_pool);
 	if (ret)
 		return ret;
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -244,7 +244,7 @@ void *ofi_av_get_addr(struct util_av *av, fi_addr_t fi_addr)
 {
 	struct util_av_entry *entry;
 
-	entry = ofi_buf_index_get(av->av_entry_pool, fi_addr);
+	entry = ofi_bufpool_get_ibuf(av->av_entry_pool, fi_addr);
 	return entry->addr;
 }
 
@@ -311,7 +311,7 @@ int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr)
 {
 	struct util_av_entry *av_entry;
 
-	av_entry = ofi_buf_index_get(av->av_entry_pool, fi_addr);
+	av_entry = ofi_bufpool_get_ibuf(av->av_entry_pool, fi_addr);
 	if (!av_entry)
 		return -FI_ENOENT;
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -416,11 +416,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 		.max_cnt	= 0,
 		/* Don't use track of buffer, because user can close
 		 * the AV without prior deletion of addresses */
-		.track_used	= 0,
-		.indexing	= {
-			.used		= 1,
-			.ordered	= 1,
-		},
+		.flags		= OFI_BUFPOOL_NO_TRACK | OFI_BUFPOOL_INDEXED,
 	};
 
 	/* TODO: Handle FI_READ */
@@ -447,11 +443,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 	av->hash = NULL;
 
 	pool_attr.chunk_cnt = av->count;
-	ret = ofi_bufpool_create_attr(&pool_attr, &av->av_entry_pool);
-	if (ret)
-		return ret;
-
-	return ret;
+	return ofi_bufpool_create_attr(&pool_attr, &av->av_entry_pool);
 }
 
 static int util_verify_av_attr(struct util_domain *domain,

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -54,9 +54,8 @@ int ofi_bufpool_grow(struct ofi_bufpool *pool)
 	ssize_t hp_size;
 	struct ofi_bufpool_ftr *buf_ftr;
 
-	if (pool->attr.max_cnt && pool->num_allocated >= pool->attr.max_cnt) {
+	if (pool->attr.max_cnt && pool->num_allocated >= pool->attr.max_cnt)
 		return -1;
-	}
 
 	buf_region = calloc(1, sizeof(*buf_region));
 	if (!buf_region)
@@ -241,6 +240,7 @@ void ofi_bufpool_destroy(struct ofi_bufpool *pool)
 #endif
 		if (pool->attr.free_fn)
 			pool->attr.free_fn(pool->attr.ctx, buf_region->context);
+
 		if (pool->attr.is_mmap_region) {
 			ret = ofi_free_hugepage_buf(buf_region->mem_region,
 						    buf_region->size);
@@ -262,31 +262,29 @@ void ofi_bufpool_destroy(struct ofi_bufpool *pool)
 
 int ofi_ibuf_is_lower(struct dlist_entry *item, const void *arg)
 {
-	struct ofi_bufpool_ftr *buf_ftr1 =
-		container_of((struct dlist_entry *)arg,
-			     struct ofi_bufpool_ftr, entry.dlist);
-	struct ofi_bufpool_ftr *buf_ftr2 =
-		container_of(item, struct ofi_bufpool_ftr, entry.dlist);
-	return (buf_ftr1->index < buf_ftr2->index);
+	struct ofi_bufpool_ftr *ftr1, *ftr2;
+
+	ftr1 = container_of(arg, struct ofi_bufpool_ftr, entry.dlist);
+	ftr2 = container_of(item, struct ofi_bufpool_ftr, entry.dlist);
+
+	return ftr1->index < ftr2->index;
 }
 
 int ofi_ibufpool_region_is_lower(struct dlist_entry *item, const void *arg)
 {
-	struct ofi_bufpool_region *buf_region1 =
-		container_of((struct dlist_entry *)arg,
-			     struct ofi_bufpool_region, entry);
-	struct ofi_bufpool_region *buf_region2 =
-		container_of(item, struct ofi_bufpool_region, entry);
-	struct ofi_bufpool_ftr *buf_region1_head =
-		container_of(buf_region1->buf_list.next,
-			     struct ofi_bufpool_ftr, entry.dlist);
-	struct ofi_bufpool_ftr *buf_region2_head =
-		container_of(buf_region2->buf_list.next,
-			     struct ofi_bufpool_ftr, entry.dlist);
-	size_t buf_region1_index =
-		(size_t)(buf_region1_head->index / buf_region1->pool->attr.chunk_cnt);
-	size_t buf_region2_index =
-		(size_t)(buf_region2_head->index / buf_region2->pool->attr.chunk_cnt);
+	struct ofi_bufpool_region *reg1, *reg2;
+	struct ofi_bufpool_ftr *ftr1, *ftr2;
+	size_t index1, index2;
 
-	return (buf_region1_index < buf_region2_index);
+	reg1 = container_of(arg, struct ofi_bufpool_region, entry);
+	reg2 = container_of(item, struct ofi_bufpool_region, entry);
+
+	ftr1 = container_of(reg1->buf_list.next, struct ofi_bufpool_ftr,
+			    entry.dlist);
+	ftr2 = container_of(reg2->buf_list.next, struct ofi_bufpool_ftr,
+			    entry.dlist);
+
+	index1 = (size_t) (ftr1->index / reg1->pool->attr.chunk_cnt);
+	index2 = (size_t) (ftr2->index / reg2->pool->attr.chunk_cnt);
+	return index1 < index2;
 }

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -120,7 +120,7 @@ int ofi_bufpool_grow(struct ofi_bufpool *pool)
 		pool->regions_table = new_table;
 	}
 	pool->regions_table[pool->regions_cnt] = buf_region;
-	pool->regions_cnt++;
+	buf_region->index = pool->regions_cnt++;
 
 	for (i = 0; i < pool->attr.chunk_cnt; i++) {
 		buf = (buf_region->mem_region + i * pool->entry_sz);
@@ -268,18 +268,9 @@ int ofi_ibuf_is_lower(struct dlist_entry *item, const void *arg)
 int ofi_ibufpool_region_is_lower(struct dlist_entry *item, const void *arg)
 {
 	struct ofi_bufpool_region *reg1, *reg2;
-	struct ofi_bufpool_ftr *ftr1, *ftr2;
-	size_t index1, index2;
 
 	reg1 = container_of(arg, struct ofi_bufpool_region, entry);
 	reg2 = container_of(item, struct ofi_bufpool_region, entry);
 
-	ftr1 = container_of(reg1->buf_list.next, struct ofi_bufpool_ftr,
-			    entry.dlist);
-	ftr2 = container_of(reg2->buf_list.next, struct ofi_bufpool_ftr,
-			    entry.dlist);
-
-	index1 = (size_t) (ftr1->index / reg1->pool->attr.chunk_cnt);
-	index2 = (size_t) (ftr2->index / reg2->pool->attr.chunk_cnt);
-	return index1 < index2;
+	return reg1->index < reg2->index;
 }

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -79,7 +79,7 @@ static void util_mr_free_entry(struct ofi_mr_cache *cache,
 	cache->cached_cnt--;
 	cache->cached_size -= entry->iov.iov_len;
 	
-	util_buf_release(cache->entry_pool, entry);
+	ofi_buf_free(cache->entry_pool, entry);
 }
 
 static void util_mr_uncache_entry(struct ofi_mr_cache *cache,
@@ -155,7 +155,7 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 
 	util_mr_cache_process_events(cache);
 
-	*entry = util_buf_alloc(cache->entry_pool);
+	*entry = ofi_buf_alloc(cache->entry_pool);
 	if (OFI_UNLIKELY(!*entry))
 		return -FI_ENOMEM;
 
@@ -169,7 +169,7 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 		}
 		if (ret) {
 			assert(!ofi_mr_cache_flush(cache));
-			util_buf_release(cache->entry_pool, *entry);
+			ofi_buf_free(cache->entry_pool, *entry);
 			return ret;
 		}
 	}
@@ -293,7 +293,7 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 	cache->mr_storage.destroy(&cache->mr_storage);
 	ofi_monitor_del_queue(&cache->nq);
 	ofi_atomic_dec32(&cache->domain->ref);
-	util_buf_pool_destroy(cache->entry_pool);
+	ofi_bufpool_destroy(cache->entry_pool);
 	assert(cache->cached_cnt == 0);
 	assert(cache->cached_size == 0);
 }
@@ -397,7 +397,7 @@ int ofi_mr_cache_init(struct util_domain *domain,
 	cache->hit_cnt = 0;
 	ofi_monitor_add_queue(monitor, &cache->nq);
 
-	ret = util_buf_pool_create(&cache->entry_pool,
+	ret = ofi_bufpool_create(&cache->entry_pool,
 				   sizeof(struct ofi_mr_entry) +
 				   cache->entry_data_size,
 				   16, 0, cache->max_cached_cnt);

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -208,8 +208,9 @@ int ofi_mr_close(struct fid *fid)
 static struct fi_ops ofi_mr_fi_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = ofi_mr_close,
+	.bind = fi_no_bind,
 	.control = fi_no_control,
-	.ops_open = fi_no_ops_open,
+	.ops_open = fi_no_ops_open
 };
 
 int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -378,7 +378,7 @@ struct fi_ibv_cq {
 	struct slist		wcq;
 	fi_ibv_trywait_func	trywait;
 	ofi_atomic32_t		nevents;
-	struct util_buf_pool	*wce_pool;
+	struct ofi_bufpool	*wce_pool;
 
 	struct {
 		/* The list of XRC SRQ contexts associated with this CQ */
@@ -852,7 +852,7 @@ static inline int fi_ibv_wc_2_wce(struct fi_ibv_cq *cq,
 				  struct fi_ibv_wce **wce)
 
 {
-	*wce = util_buf_alloc(cq->wce_pool);
+	*wce = ofi_buf_alloc(cq->wce_pool);
 	if (OFI_UNLIKELY(!*wce))
 		return -FI_ENOMEM;
 	memset(*wce, 0, sizeof(**wce));

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -507,16 +507,13 @@ int fi_ibv_domain_xrc_init(struct fi_ibv_domain *domain)
 	}
 
 	fastlock_init(&domain->xrc.ini_mgmt_lock);
-	domain->xrc.ini_conn_rbmap = calloc(1,
-			sizeof(*domain->xrc.ini_conn_rbmap));
 
+	domain->xrc.ini_conn_rbmap = ofi_rbmap_create(fi_ibv_ini_conn_compare);
 	if (!domain->xrc.ini_conn_rbmap) {
 		ret = -ENOMEM;
 		VERBS_INFO_ERRNO(FI_LOG_DOMAIN, "XRC INI QP RB Tree", -ret);
 		goto rbmap_err;
 	}
-	domain->xrc.ini_conn_rbmap->compare = &fi_ibv_ini_conn_compare;
-	ofi_rbmap_init(domain->xrc.ini_conn_rbmap);
 
 	domain->use_xrc = 1;
 	return FI_SUCCESS;
@@ -557,7 +554,7 @@ int fi_ibv_domain_xrc_cleanup(struct fi_ibv_domain *domain)
 		domain->xrc.xrcd_fd = -1;
 	}
 
-	ofi_rbmap_cleanup(domain->xrc.ini_conn_rbmap);
+	ofi_rbmap_destroy(domain->xrc.ini_conn_rbmap);
 	fastlock_destroy(&domain->xrc.ini_mgmt_lock);
 #endif /* VERBS_HAVE_XRC */
 	return 0;

--- a/src/tree.c
+++ b/src/tree.c
@@ -50,9 +50,10 @@
 #include <rdma/fi_errno.h>
 
 
-void ofi_rbmap_init(struct ofi_rbmap *map)
+void ofi_rbmap_init(struct ofi_rbmap *map,
+		int (*compare)(struct ofi_rbmap *map, void *key, void *data))
 {
-	assert(map->compare);
+	map->compare = compare;
 
 	map->root = &map->sentinel;
 	map->sentinel.left = &map->sentinel;
@@ -62,13 +63,14 @@ void ofi_rbmap_init(struct ofi_rbmap *map)
 	map->sentinel.data = NULL;
 }
 
-struct ofi_rbmap *ofi_rbmap_create(void)
+struct ofi_rbmap *
+ofi_rbmap_create(int (*compare)(struct ofi_rbmap *map, void *key, void *data))
 {
 	struct ofi_rbmap *map;
 
 	map = calloc(1, sizeof *map);
 	if (map)
-		ofi_rbmap_init(map);
+		ofi_rbmap_init(map, compare);
 	return map;
 }
 

--- a/src/tree.c
+++ b/src/tree.c
@@ -62,6 +62,16 @@ void ofi_rbmap_init(struct ofi_rbmap *map)
 	map->sentinel.data = NULL;
 }
 
+struct ofi_rbmap *ofi_rbmap_create(void)
+{
+	struct ofi_rbmap *map;
+
+	map = calloc(1, sizeof *map);
+	if (map)
+		ofi_rbmap_init(map);
+	return map;
+}
+
 static void ofi_delete_tree(struct ofi_rbmap *map, struct ofi_rbnode *node)
 {
 	if (node == &map->sentinel)
@@ -75,6 +85,11 @@ static void ofi_delete_tree(struct ofi_rbmap *map, struct ofi_rbnode *node)
 void ofi_rbmap_cleanup(struct ofi_rbmap *map)
 {
 	ofi_delete_tree(map, map->root);
+}
+
+void ofi_rbmap_destroy(struct ofi_rbmap *map)
+{
+	ofi_rbmap_cleanup(map);
 	free(map);
 }
 


### PR DESCRIPTION
The real goal here is to avoid future issues using the buffer pool.  But the list of commits is getting a little long already, so these are just the 'pre' changes.  This series has the following theme:

1. Applies the 'ofi' prefix in place of the 'util' prefix for all buffer pool structures and interfaces.
2. Add several white space and variable cleanups to the code.
3. Simplifies the buffer pool attributes

The rename is by far the biggest change.  However, a few cleanups were applied prior to the name change in order to make that easier (by removing some macros).

This modifies several providers.  @a-ilango @aingerson @j-xiong @vkrishna 