### PR TITLE
test_configs/freebsd: Exclude msg_epoll

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -6,6 +6,10 @@ if MACOS
 os_excludes = -f ./test_configs/osx.exclude
 endif
 
+if FREEBSD
+os_excludes = -f ./test_configs/freebsd.exclude
+endif
+
 bin_PROGRAMS = \
 	functional/fi_av_xfer \
 	functional/fi_msg \

--- a/fabtests/test_configs/freebsd.exclude
+++ b/fabtests/test_configs/freebsd.exclude
@@ -1,0 +1,4 @@
+# Regex patterns of tests to exclude in runfabtests.sh
+
+# Exclude msg_epoll test as FreeBSD doesn't have epoll system call
+msg_epoll


### PR DESCRIPTION
FreeBSD does not have epoll.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>