### PR TITLE
test_configs/shm.exclude: exclude av_test

### DIFF
--- a/fabtests/test_configs/shm/shm.exclude
+++ b/fabtests/test_configs/shm/shm.exclude
@@ -18,3 +18,4 @@ shared_ctx
 scalable_ep
 shared_av
 multi_mr
+av_test


### PR DESCRIPTION
av_test does not support FI_ADDR_STR

Signed-off-by: aingerson <alexia.ingerson@intel.com>