### PR TITLE
C++ compatibility fixes

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -107,9 +107,9 @@ do {								\
 
 static inline void* freestack_pop_impl(void *fs, void *fs_next)
 {
-	struct {
+	struct _freestack {
 		FREESTACK_HEADER
-	} *freestack = fs;
+	} *freestack = (struct _freestack *)fs;
 	assert(!freestack_isempty(freestack));
 	freestack->next = *((void **)fs_next);
 	freestack_init_next(fs_next);
@@ -150,7 +150,7 @@ name ## _create(size_t size, name ## _entry_init_func init,	\
 		void *arg)					\
 {								\
 	struct name *fs;					\
-	fs = calloc(1, sizeof(*fs) +				\
+	fs = (struct name*) calloc(1, sizeof(*fs) +		\
 		       sizeof(struct name ## _entry) *		\
 		       (roundup_power_of_two(size)));		\
 	if (fs)							\
@@ -197,9 +197,9 @@ static inline void* smr_freestack_pop_impl(void *fs, void *next)
 {
 	void *local;
 
-	struct {
+	struct _freestack {
 		SMR_FREESTACK_HEADER
-	} *freestack = fs;
+	} *freestack = (struct _freestack*) fs;
 	assert(next != NULL);
 
 	local = (char **) fs + ((char **) next -
@@ -233,7 +233,7 @@ static inline void name ## _init(struct name *fs, size_t size)	\
 static inline struct name * name ## _create(size_t size)	\
 {								\
 	struct name *fs;					\
-	fs = calloc(1, sizeof(*fs) + sizeof(entrytype) *	\
+	fs = (struct name*) calloc(1, sizeof(*fs) + sizeof(entrytype) *	\
 		    (roundup_power_of_two(size)));		\
 	if (fs)							\
 		name ##_init(fs, roundup_power_of_two(size));	\

--- a/include/ofi_rbuf.h
+++ b/include/ofi_rbuf.h
@@ -72,7 +72,7 @@ static inline void name ## _init(struct name *cq, size_t size)	\
 static inline struct name * name ## _create(size_t size)	\
 {								\
 	struct name *cq;					\
-	cq = calloc(1, sizeof(*cq) + sizeof(entrytype) *	\
+	cq = (struct name*) calloc(1, sizeof(*cq) + sizeof(entrytype) *	\
 		    (roundup_power_of_two(size)));		\
 	if (cq)							\
 		name ##_init(cq, roundup_power_of_two(size));	\

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -67,6 +67,10 @@
 #include "rbtree.h"
 #include "uthash.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define UTIL_FLAG_ERROR		(1ULL << 60)
 #define UTIL_FLAG_OVERFLOW	(1ULL << 61)
 
@@ -363,7 +367,7 @@ struct util_wait {
 
 	enum fi_wait_obj	wait_obj;
 	fi_wait_signal_func	signal;
-	fi_wait_try_func	try;
+	fi_wait_try_func	wait_try;
 };
 
 int fi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
@@ -383,7 +387,7 @@ typedef int (*ofi_wait_fd_try_func)(void *arg);
 struct ofi_wait_fd_entry {
 	struct dlist_entry	entry;
 	int 			fd;
-	ofi_wait_fd_try_func	try;
+	ofi_wait_fd_try_func	wait_try;
 	void			*arg;
 	ofi_atomic32_t		ref;
 };
@@ -391,7 +395,7 @@ struct ofi_wait_fd_entry {
 int ofi_wait_fd_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		struct fid_wait **waitset);
 int ofi_wait_fd_add(struct util_wait *wait, int fd, uint32_t events,
-		    ofi_wait_fd_try_func try, void *arg, void *context);
+		    ofi_wait_fd_try_func wait_try, void *arg, void *context);
 int ofi_wait_fd_del(struct util_wait *wait, int fd);
 
 /*
@@ -917,5 +921,9 @@ int ofi_ns_add_local_name(struct util_ns *ns, void *service, void *name);
 int ofi_ns_del_local_name(struct util_ns *ns, void *service, void *name);
 void *ofi_ns_resolve_name(struct util_ns *ns, const char *server,
 			  void *service);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _OFI_UTIL_H_ */


### PR DESCRIPTION
Three types of fixes:
 * missing extern "C"
 * implicit casts from void*
 * the "try" reserved word

Signed-off-by: Chris Dolan <chrisdolan@google.com>