### PR TITLE
RxM: Defensive code against a null pointer deref.

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1203,6 +1203,7 @@ rxm_conn_handle_event(struct rxm_ep *rxm_ep, struct rxm_msg_eq_entry *entry)
 		fi_freeinfo(entry->cm_entry.info);
 		break;
 	case FI_CONNECTED:
+		assert(entry->cm_entry.fid->context);
 		FI_DBG(&rxm_prov, FI_LOG_FABRIC,
 		       "Connection successful\n");
 		rxm_ep->cmap->acquire(&rxm_ep->cmap->lock);


### PR DESCRIPTION
If RxM receives a FI_CONNECTED event from the underlying MSG provider,
RxM assumes the context is the cmap handle and dereferences it. This
should always be safe, but it can be hard to debug in optimized code
if the context is incorrectly null. This is not a performance
sensitive code path so an extra defensive check is harmless.

Signed-off-by: Chris Dolan <chrisdolan@google.com>