### PR TITLE
RxM: expand name buffer to support IPv6.

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -289,7 +289,7 @@ struct rxm_ep_wire_proto {
 };
 
 struct rxm_cm_data {
-	struct sockaddr name;
+	struct sockaddr_storage name;
 	uint64_t conn_id;
 	struct rxm_ep_wire_proto proto;
 };


### PR DESCRIPTION
Use "struct sockaddr_storage" (128 bytes) instead of "struct sockaddr"
(16 bytes) to transmit the fi_getname() address to peers. This allows
sockaddr_in6 to fit with lots of room to spare. Note that this does
change RxM's cmap metadata wire format incompatibly.

Signed-off-by: Chris Dolan <chrisdolan@google.com>