### PR TITLE
RxM: do not exceed rx limit for msg provider.

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1239,7 +1239,10 @@ int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)
 	int ret;
 	size_t i;
 
-	for (i = 0; i < rxm_ep->msg_info->rx_attr->size; i++) {
+	/* -1 because we always post the next recv before releasing the previous
+	 * one. Without the -1 we routinely exceeded the recv pool size for the
+	 * sockets provider, for example. */
+	for (i = 0; i < rxm_ep->msg_info->rx_attr->size - 1; i++) {
 		rx_buf = rxm_rx_buf_alloc(rxm_ep);
 		if (OFI_UNLIKELY(!rx_buf)) {
 			FI_WARN(&rxm_prov, FI_LOG_EP_DATA,


### PR DESCRIPTION
rx_attr->size is the size of the recv pool in the sockets provider. If we
prepost that many, then the pool is exhausted. When recvs complete, RxM
always preposts a new one before releasing the old one, so we're always
using one more buffer than the pool can support. There had been a leak in
the non-pool code for sockets that was triggered by this. A mitigation is
just to avoid exhausting the pool by pre-posting one less recv.

An alternative solution would be for RxM to cancel all preposted recvs on
close instead of just letting the core provider handle it.

Even with the sockets memory leak fixed, this is still better because we
won't ask for more than the core provider has declared it can support.

Signed-off-by: Chris Dolan <chrisdolan@google.com>