### PR TITLE
Fix memory leak on check failure in sockets getinfo

### DIFF
--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -505,8 +505,10 @@ static int sock_ep_getinfo(uint32_t version, const char *node,
 	if (rai)
 		freeaddrinfo(rai);
 
-	if (ret == 0)
-		return sock_fi_checkinfo(*info, hints);
+	if (ret == 0) {
+		ret = sock_fi_checkinfo(*info, hints);
+		if (ret) fi_freeinfo(*info);
+	}
 
 	return ret;
 }


### PR DESCRIPTION
Signed-off-by: Chris Dolan <chrisdolan@google.com>