### PR TITLE
test_configs/osx: Re-enable msg_sockets

### DIFF
--- a/fabtests/test_configs/osx.exclude
+++ b/fabtests/test_configs/osx.exclude
@@ -2,4 +2,3 @@
 
 # Exclude msg_epoll test as OSX doesn't have epoll system call
 msg_epoll
-msg_sockets


### PR DESCRIPTION
This issue was fixed in https://github.com/ofiwg/libfabric/pull/4028.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>