### PR TITLE
prov/rxm: optimize MSG_EP connect code path and do minor refactoring

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -595,28 +595,34 @@ unlock:
 	return ret;
 }
 
-/* Caller must hold `cmap::lock` */
-static int rxm_cmap_handle_connect(struct rxm_cmap *cmap, fi_addr_t fi_addr,
-				   struct rxm_cmap_handle *handle)
+int rxm_cmap_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
+		     struct rxm_cmap_handle *handle)
 {
-	int ret;
+	int ret = FI_SUCCESS;
+
+	/* Progress connection events to detect any incoming connections
+	 * from peer corresponding to fi_addr */
+	if (!slistfd_empty(&rxm_ep->msg_eq_entry_list))
+		rxm_conn_process_eq_events(rxm_ep);
+
+	rxm_ep->cmap->acquire(&rxm_ep->cmap->lock);
 
 	switch (handle->state) {
 	case RXM_CMAP_CONNECTED_NOTIFY:
-		rxm_cmap_process_conn_notify(cmap, handle);
-		/* Fall through */
-	case RXM_CMAP_CONNECTED:
-		return FI_SUCCESS;
+		rxm_cmap_process_conn_notify(rxm_ep->cmap, handle);
+		break;
 	case RXM_CMAP_IDLE:
-		ret = rxm_conn_connect(cmap->ep, handle,
-				       ofi_av_get_addr(cmap->av, fi_addr));
+		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "initiating MSG_EP connect "
+		       "for fi_addr: %" PRIu64 "\n", fi_addr);
+		ret = rxm_conn_connect(rxm_ep->cmap->ep, handle,
+				       ofi_av_get_addr(rxm_ep->cmap->av,
+						       fi_addr));
 		if (ret) {
 			rxm_cmap_del_handle(handle);
-			return ret;
+		} else {
+			handle->state = RXM_CMAP_CONNREQ_SENT;
+			ret = -FI_EAGAIN;
 		}
-		handle->state = RXM_CMAP_CONNREQ_SENT;
-		ret = -FI_EAGAIN;
-		// TODO sleep on event fd instead of busy polling
 		break;
 	case RXM_CMAP_CONNREQ_SENT:
 	case RXM_CMAP_CONNREQ_RECV:
@@ -625,25 +631,13 @@ static int rxm_cmap_handle_connect(struct rxm_cmap *cmap, fi_addr_t fi_addr,
 		ret = -FI_EAGAIN;
 		break;
 	default:
-		FI_WARN(cmap->av->prov, FI_LOG_EP_CTRL,
+		FI_WARN(rxm_ep->cmap->av->prov, FI_LOG_EP_CTRL,
 			"Invalid cmap handle state\n");
 		assert(0);
 		ret = -FI_EOPBADSTATE;
 	}
-	return ret;
-}
-
-/* Caller must hold cmap->lock */
-int rxm_cmap_handle_unconnected(struct rxm_ep *rxm_ep, struct rxm_cmap_handle *handle,
-				fi_addr_t dest_addr)
-{
-	/* Progress connection events */
 	rxm_ep->cmap->release(&rxm_ep->cmap->lock);
-	if (!slistfd_empty(&rxm_ep->msg_eq_entry_list))
-		rxm_conn_process_eq_events(rxm_ep);
-	rxm_ep->cmap->acquire(&rxm_ep->cmap->lock);
-
-	return rxm_cmap_handle_connect(rxm_ep->cmap, dest_addr, handle);
+	return ret;
 }
 
 static int rxm_cmap_cm_thread_close(struct rxm_cmap *cmap)

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1224,9 +1224,9 @@ static inline int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 		rx_buf->conn = NULL;
 	rx_buf->hdr.state = RXM_RX;
 
-	ret = fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
-		      rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
-		      rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf);
+	ret = (int)fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
+			   rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
+			   rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf);
 	if (ret)
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 			"Unable to repost buf: %d\n", ret);


### PR DESCRIPTION
- prov/rxm: avoid fi_getinfo roundtrip during FI_EP_MSG connect 
- prov/rxm: minor refactoring to simplify code 
- prov/rxm: add a cast for fi_recv return value 