### PR TITLE
Fix uninitialized pointer in sock_ep cm_entry.info

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -785,6 +785,7 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param, size_t paraml
 	sock_ep_cm_monitor_handle(cm_head, handle, FI_EPOLL_IN);
 	sock_ep_enable(ep);
 
+	memset(&cm_entry, 0, sizeof(cm_entry));
 	cm_entry.fid = &handle->ep->ep.fid;
 	SOCK_LOG_DBG("reporting FI_CONNECTED\n");
 	if (sock_eq_report_event(ep_attr->eq, FI_CONNECTED, &cm_entry,


### PR DESCRIPTION
Signed-off-by: Chris Dolan <chrisdolan@google.com>