### PR TITLE
Add FI_MR_RAW support to sockets provider.

### DIFF
--- a/fabtests/unit/getinfo_test.c
+++ b/fabtests/unit/getinfo_test.c
@@ -413,7 +413,8 @@ static int init_mr_basic(struct fi_info *hints)
 
 static int check_mr_basic(struct fi_info *info)
 {
-	return (info->domain_attr->mr_mode != FI_MR_BASIC) ?
+	int mr_mode = info->domain_attr->mr_mode & ~FI_MR_RAW;
+	return (mr_mode != FI_MR_BASIC) ?
 		EXIT_FAILURE : 0;
 }
 
@@ -426,7 +427,8 @@ static int init_mr_scalable(struct fi_info *hints)
 
 static int check_mr_scalable(struct fi_info *info)
 {
-	return (info->domain_attr->mr_mode != FI_MR_SCALABLE) ?
+	int mr_mode = info->domain_attr->mr_mode & ~FI_MR_RAW;
+	return (mr_mode != FI_MR_SCALABLE) ?
 		EXIT_FAILURE : 0;
 }
 
@@ -445,8 +447,8 @@ static int test_mr_v1_0(char *node, char *service, uint64_t flags,
 
 static int check_mr_unspec(struct fi_info *info)
 {
-	return (info->domain_attr->mr_mode != FI_MR_BASIC &&
-		info->domain_attr->mr_mode != FI_MR_SCALABLE) ?
+	int mr_mode = info->domain_attr->mr_mode & ~FI_MR_RAW;
+	return (mr_mode != FI_MR_BASIC && mr_mode != FI_MR_SCALABLE) ?
 		EXIT_FAILURE : 0;
 }
 
@@ -457,6 +459,7 @@ static int test_mr_modes(char *node, char *service, uint64_t flags,
 	uint64_t *mr_modes;
 	int i, cnt, ret;
 
+	hints->caps |= FI_RMA;
 	ret = ft_alloc_bit_combo(0, FI_MR_LOCAL | FI_MR_RAW | FI_MR_VIRT_ADDR |
 			FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_MMU_NOTIFY |
 			FI_MR_RMA_EVENT | FI_MR_ENDPOINT, &mr_modes, &cnt);

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -249,11 +249,18 @@ struct sock_domain {
 
 	enum fi_progress	progress_mode;
 	struct ofi_mr_map	mr_map;
+	struct ofi_mr_map	peer_raw_mr_map;
 	struct sock_pe		*pe;
 	struct dlist_entry	dom_list_entry;
 	struct fi_domain_attr	attr;
 	struct sock_conn_listener conn_listener;
 	struct sock_ep_cm_head cm_head;
+};
+
+struct sock_peer_mr_raw_attr {
+	uint64_t local_key;
+	size_t key_size;
+	uint8_t raw_key[];
 };
 
 /* move to fi_trigger.h when removing experimental tag from work queues */
@@ -344,8 +351,10 @@ struct sock_cntr {
 struct sock_mr {
 	struct fid_mr mr_fid;
 	struct sock_domain *domain;
-	uint64_t key;
+	uint64_t map_key;
 	uint64_t flags;
+	void* raw_key;
+	size_t raw_key_len;
 	struct sock_cntr *cntr;
 	struct sock_cq *cq;
 };
@@ -1108,7 +1117,8 @@ void sock_cntr_remove_rx_ctx(struct sock_cntr *cntr, struct sock_rx_ctx *rx_ctx)
 
 
 struct sock_mr *sock_mr_verify_key(struct sock_domain *domain, uint64_t key,
-				   uintptr_t *buf, size_t len, uint64_t access);
+				   uintptr_t *buf, size_t len, void* raw_key,
+				   size_t raw_key_len, uint64_t access);
 struct sock_mr *sock_mr_verify_desc(struct sock_domain *domain, void *desc,
 				    void *buf, size_t len, uint64_t access);
 

--- a/prov/sockets/src/sock_atomic.c
+++ b/prov/sockets/src/sock_atomic.c
@@ -241,6 +241,26 @@ ssize_t sock_ep_tx_atomic(struct fid_ep *ep,
 	}
 #endif
 
+	if (tx_ctx->domain->attr.mr_mode & FI_MR_RAW && !(flags & FI_TAGGED)) {
+		void *itr, *key_ptr;
+		struct sock_peer_mr_raw_attr *stored_attr;
+		fastlock_acquire(&tx_ctx->domain->lock);
+		for (i = 0; i < msg->rma_iov_count; i++) {
+			itr = rbtFind(tx_ctx->domain->peer_raw_mr_map.rbtree,
+			              (void*)&msg->rma_iov[i].key);
+			if (!itr) {
+				ret = -FI_ENODATA;
+				break;
+			}
+			rbtKeyValue(tx_ctx->domain->peer_raw_mr_map.rbtree, itr, &key_ptr,
+			            (void **) &stored_attr);
+			assert(stored_attr->key_size == tx_ctx->domain->attr.mr_key_size);
+			sock_tx_ctx_write(tx_ctx, stored_attr->raw_key, stored_attr->key_size);
+		}
+		fastlock_release(&tx_ctx->domain->lock);
+		if (ret) goto err;
+	}
+
 	sock_tx_ctx_commit(tx_ctx);
 	return 0;
 

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -64,7 +64,7 @@ extern struct fi_ops_ep sock_ep_ops;
 extern struct fi_ops sock_ep_fi_ops;
 extern struct fi_ops_ep sock_ctx_ep_ops;
 
-extern const struct fi_domain_attr sock_domain_attr;
+extern struct fi_domain_attr sock_domain_attr;
 extern const struct fi_fabric_attr sock_fabric_attr;
 
 const struct fi_tx_attr sock_stx_attr = {
@@ -1468,6 +1468,7 @@ static void sock_set_domain_attr(uint32_t api_version, void *src_addr,
 		attr->control_progress = sock_domain_attr.control_progress;
 	if (attr->data_progress == FI_PROGRESS_UNSPEC)
 		attr->data_progress = sock_domain_attr.data_progress;
+	attr->mr_mode &= ~FI_MR_RAW;
 	if (FI_VERSION_LT(api_version, FI_VERSION(1, 5))) {
 		if (attr->mr_mode == FI_MR_UNSPEC)
 			attr->mr_mode = FI_MR_SCALABLE;
@@ -1475,6 +1476,8 @@ static void sock_set_domain_attr(uint32_t api_version, void *src_addr,
 		if ((attr->mr_mode != FI_MR_BASIC) &&
 		    (attr->mr_mode != FI_MR_SCALABLE))
 			attr->mr_mode = 0;
+		if (sock_domain_attr.mr_mode & FI_MR_RAW)
+			attr->mr_mode |= FI_MR_RAW;
 	}
 
 	if (attr->cq_cnt == 0)

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -71,6 +71,7 @@ uint64_t SOCK_EP_RDM_CAP = SOCK_EP_RDM_CAP_BASE;
 uint64_t SOCK_EP_MSG_SEC_CAP = SOCK_EP_MSG_SEC_CAP_BASE;
 uint64_t SOCK_EP_MSG_CAP = SOCK_EP_MSG_CAP_BASE;
 
+extern struct fi_domain_attr sock_domain_attr;
 
 const struct fi_fabric_attr sock_fabric_attr = {
 	.fabric = NULL,
@@ -741,6 +742,9 @@ SOCKETS_INI
 	fi_param_define(&sock_prov, "iface", FI_PARAM_STRING,
 			"Specify interface name");
 
+	fi_param_define(&sock_prov, "mr_key_size", FI_PARAM_SIZE_T,
+			"RMA key size in bytes, default 8");
+
 	fastlock_init(&sock_list_lock);
 	dlist_init(&sock_fab_list);
 	dlist_init(&sock_dom_list);
@@ -753,5 +757,10 @@ SOCKETS_INI
 	fi_param_define(&sock_prov, "dgram_drop_rate", FI_PARAM_INT,
 			"Drop every Nth dgram frame (debug only)");
 #endif
+
+	fi_param_get_size_t(&sock_prov, "mr_key_size", &sock_domain_attr.mr_key_size);
+	if (sock_domain_attr.mr_key_size > sizeof(uint64_t))
+		sock_domain_attr.mr_mode |= FI_MR_RAW;
+
 	return &sock_prov;
 }


### PR DESCRIPTION
To enable this, set an option like "FI_SOCKETS_MR_KEY_SIZE=16" to
override the default of 8 (= uint64_t). Values smaller than 8 are
ignored. All peers need to agree on this value implicitly or the TCP
stream will be appear corrupted.

On the memory-owner side, the key is composed of a 64-bit map key (as
before) plus rand() bytes to fill the remainder. The RMA validation
function now requires this key data when the key size is larger than
the default. When a peer invokes an RMA or atomic op, the peer adds
this raw key after the header but before any data payload.

The exhaustive domain_attr.mr_mode tests did not consider this
setting, so I masked off the FI_MR_RAW bit in the tests.

Signed-off-by: Chris Dolan <chrisdolan@google.com>