### PR TITLE
RxM: add support for FI_MR_RAW

### DIFF
--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -321,7 +321,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	    (msg_info->domain_attr->mr_mode & (FI_MR_BASIC | FI_MR_SCALABLE)))
 		msg_info->domain_attr->mr_mode = FI_MR_BASIC;
 	else
-		msg_info->domain_attr->mr_mode |= FI_MR_PROV_KEY;
+		msg_info->domain_attr->mr_mode |= FI_MR_PROV_KEY | FI_MR_RAW;
 
 	ret = fi_domain(rxm_fabric->msg_fabric, msg_info,
 			&rxm_domain->msg_domain, context);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -76,7 +76,7 @@ void rxm_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
 		 * providers that support only FI_MR_SCALABLE aren't dropped */
 		core_info->domain_attr->mr_mode = FI_MR_UNSPEC;
 	} else {
-		core_info->domain_attr->mr_mode |= FI_MR_LOCAL;
+		core_info->domain_attr->mr_mode |= FI_MR_LOCAL | FI_MR_RAW;
 		if (!hints || !ofi_rma_target_allowed(hints->caps))
 			core_info->domain_attr->mr_mode |= OFI_MR_BASIC_MAP;
 		else if (hints->domain_attr)


### PR DESCRIPTION
This is a backward-compatible change to the RxM wire format for RMA
use cases which use large auth keys. If the core provider says that it
supports FI_MR_RAW _or_ the declared key size is larger than 64 bits
(when would you ever have the latter without the former??) then the
memory owner uses fi_mr_raw_attr to add the full RMA auth key and
base_addr to a new area in the packet header. The peer receives that
auth key and registers it temporarily via fi_mr_map_raw.

I chose to resend the key with every header, which is consistent with
the current implementation. One could imagine saving a some wire bytes
by sending it just once and remembering which peers you sent it to,
but that added complexity is unlikely to be worth a few bytes
especially if we'd need to support re-keying.

Caveat: this implementation assumes that the raw key size is a
constant and that all peers agree on it. This could be generalized by
including the key size in the header too, but that makes it trickier
to compute the available payload size in the packet because of the
variable-sized header.