### PR TITLE
prov/verbs: Fix shared XRC INI QP connection setup scheduling error

### DIFF
--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -270,6 +270,8 @@ void fi_ibv_ep_ini_conn_rejected(struct fi_ibv_xrc_ep *ep)
 	fastlock_acquire(&domain->xrc.ini_mgmt_lock);
 	fi_ibv_log_ep_conn(ep, "INI Connection Rejected");
 
+	if (ep->ini_conn->state == FI_IBV_INI_QP_CONNECTING)
+		ep->ini_conn->state = FI_IBV_INI_QP_UNCONNECTED;
 	fi_ibv_put_shared_ini_conn(ep);
 	fastlock_release(&domain->xrc.ini_mgmt_lock);
 }


### PR DESCRIPTION
If the physical INI XRC QP is rejected, allow any reciprocal INI
XRC QP connections pending on that QP to be scheduled.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>