### PR TITLE
prov/tcp; Fixes the issue with mpich ic2 test.

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -758,6 +758,7 @@ struct util_event {
 
 int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		 struct fid_eq **eq_fid, void *context);
+void ofi_eq_remove_fid_events(struct util_eq *eq, fid_t fid);
 void ofi_eq_handle_err_entry(uint32_t api_version, uint64_t flags,
 			     struct fi_eq_err_entry *err_entry,
 			     struct fi_eq_err_entry *user_err_entry);

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -632,9 +632,12 @@ static int tcpx_pep_reject(struct fid_pep *pep, fid_t handle,
 	hdr.type = ofi_ctrl_nack;
 	hdr.seg_size = htons((uint16_t) paramlen);
 
-	ret = ofi_sendall_socket(tcpx_handle->conn_fd, &hdr, sizeof(hdr));
-	if (!ret && paramlen)
-		(void) ofi_sendall_socket(tcpx_handle->conn_fd, param, paramlen);
+	ret = ofi_send_socket(tcpx_handle->conn_fd, &hdr,
+			      sizeof(hdr), MSG_NOSIGNAL);
+
+	if ((ret == sizeof(hdr)) && paramlen)
+		(void) ofi_send_socket(tcpx_handle->conn_fd, param,
+				       paramlen, MSG_NOSIGNAL);
 
 	ofi_shutdown(tcpx_handle->conn_fd, SHUT_RDWR);
 	ret = ofi_close_socket(tcpx_handle->conn_fd);

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -341,6 +341,8 @@ static int tcpx_ep_close(struct fid *fid)
 	if (ep->util_ep.eq->wait)
 		ofi_wait_fd_del(ep->util_ep.eq->wait, ep->conn_fd);
 
+	ofi_eq_remove_fid_events(ep->util_ep.eq,
+				  &ep->util_ep.ep_fid.fid);
 	ofi_close_socket(ep->conn_fd);
 	ofi_endpoint_close(&ep->util_ep);
 	fastlock_destroy(&ep->lock);


### PR DESCRIPTION
RxM over TCP case:
In rxm when two processes try to connect to each other at same time, they accept or reject connection based on whose address is higher. The process that accepts the connection 1 would go ahead and close the other connection 2. But the peer may reject the connection 2 later, resulting in broken pipe. 

This patch suppresses broken pipe on reject. Also pending eq events are removed on ep close, avoiding any actions on closed ep based on stale events. 