### PR TITLE
man/sread: Add clarifying text to sread return values

### DIFF
--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -382,6 +382,10 @@ similar to the non-blocking calls, with the exception that the calls
 will not return until either a completion has been read from the CQ or
 an error or timeout occurs.
 
+Threads blocking in this function will return to the caller if
+they are signaled by some external source.  This is true even if
+the timeout has not occurred or was specified as infinite.
+
 It is invalid for applications to call these functions if the CQ
 has been configured with a wait object of FI_WAIT_NONE or FI_WAIT_SET.
 
@@ -761,6 +765,13 @@ fi_cq_sread / fi_cq_sreadfrom
   the completion queue.  On error, a negative value corresponding to
   fabric errno is returned.  If no completions are available to
   return from the CQ, -FI_EAGAIN will be returned.
+
+fi_cq_sread / fi_cq_sreadfrom
+: On success, returns the number of completion events retrieved from
+  the completion queue.  On error, a negative value corresponding to
+  fabric errno is returned.  If the timeout expires or the calling
+  thread is signaled and no data is available to be read from the
+  completion queue, -FI_EAGAIN is returned.
 
 fi_cq_strerror
 : Returns a character string interpretation of the provider specific

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -355,6 +355,10 @@ exception that the calls will not return until either an event has
 been read from the EQ or an error or timeout occurs.  Specifying a
 negative timeout means an infinite timeout.
 
+Threads blocking in this function will return to the caller if
+they are signaled by some external source.  This is true even if
+the timeout has not occurred or was specified as infinite.
+
 It is invalid for applications to call this function if the EQ
 has been configured with a wait object of FI_WAIT_NONE or FI_WAIT_SET.
 
@@ -491,10 +495,17 @@ fi_eq_open
 : Returns 0 on success.  On error, a negative value corresponding to
   fabric errno is returned.
 
-fi_eq_read / fi_eq_readerr / fi_eq_sread
+fi_eq_read / fi_eq_readerr
 : On success, returns the number of bytes read from the
   event queue.  On error, a negative value corresponding to fabric
   errno is returned.  If no data is available to be read from the
+  event queue, -FI_EAGAIN is returned.
+
+fi_eq_sread
+: On success, returns the number of bytes read from the
+  event queue.  On error, a negative value corresponding to fabric
+  errno is returned.  If the timeout expires or the calling
+  thread is signaled and no data is available to be read from the
   event queue, -FI_EAGAIN is returned.
 
 fi_eq_write


### PR DESCRIPTION
This affects cq and eq sread calls.  Both allow for something
to wake up the blocked thread.  If the wake-up is not the result
of a fatal error, sread will return EAGAIN.

The only implication here is that the thread may return prior
to any timeout value expiring.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>