### PR TITLE
prov/sockets: fix double lock acquisition

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -612,9 +612,9 @@ err:
 	handle->ep->attr->info.handle = NULL;
 	/* Register handle for later deletion */
 	handle->state = SOCK_CONN_HANDLE_DELETED;
-	fastlock_acquire(&cm_head->signal_lock);
+	/* `cm_head::signal_lock` has already been held
+	 * in `sock_ep_cm_thread` function */
 	sock_ep_cm_add_to_msg_list(cm_head, handle);
-	fastlock_release(&cm_head->signal_lock);
 out:
 	free(param);
 	free(cm_entry);


### PR DESCRIPTION
Backtrace is the following:

0 in pthread_spin_lock (&cm_head->signal_lock)
1 in sock_ep_cm_connect_handler () **Tries to acquire cm_head->signal_lock**
2 in sock_ep_cm_handle_rx ()
3 in in sock_ep_cm_thread () **Holds cm_head->signal_lock**

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>