### PR TITLE
util/bufpool: Final set of changes, switch from footer to header to simplify APIs

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -343,54 +343,62 @@ void ofi_bufpool_destroy(struct ofi_bufpool *pool);
 
 int ofi_bufpool_grow(struct ofi_bufpool *pool);
 
-static inline struct ofi_bufpool_hdr *
-ofi_buf_hdr(struct ofi_bufpool *pool, void *buf)
+static inline struct ofi_bufpool_hdr *ofi_buf_hdr(void *buf)
 {
 	return (struct ofi_bufpool_hdr *)
 		((char *) buf - sizeof(struct ofi_bufpool_hdr));
 }
 
-static inline void *ofi_buf_data(struct ofi_bufpool *pool,
-			         struct ofi_bufpool_hdr *buf_hdr)
+static inline void *ofi_buf_data(struct ofi_bufpool_hdr *buf_hdr)
 {
 	return buf_hdr + 1;
 }
 
-static inline void ofi_buf_free(struct ofi_bufpool *pool, void *buf)
+static inline struct ofi_bufpool_region *ofi_buf_region(void *buf)
 {
-	assert(ofi_buf_hdr(pool, buf)->region);
-	assert(ofi_buf_hdr(pool, buf)->region->pool == pool);
-	assert(ofi_buf_hdr(pool, buf)->region->use_cnt--);
-	assert(!(pool->attr.flags & OFI_BUFPOOL_INDEXED));
-	slist_insert_head(&ofi_buf_hdr(pool, buf)->entry.slist,
-			  &pool->free_list.entries);
+	assert(ofi_buf_hdr(buf)->region);
+	return ofi_buf_hdr(buf)->region;
+}
+
+static inline struct ofi_bufpool *ofi_buf_pool(void *buf)
+{
+	assert(ofi_buf_region(buf)->pool);
+	return ofi_buf_region(buf)->pool;
+}
+
+static inline void ofi_buf_free(void *buf)
+{
+	assert(ofi_buf_region(buf)->use_cnt--);
+	assert(!(ofi_buf_pool(buf)->attr.flags & OFI_BUFPOOL_INDEXED));
+	slist_insert_head(&ofi_buf_hdr(buf)->entry.slist,
+			  &ofi_buf_pool(buf)->free_list.entries);
 }
 
 int ofi_ibuf_is_lower(struct dlist_entry *item, const void *arg);
 int ofi_ibufpool_region_is_lower(struct dlist_entry *item, const void *arg);
 
-static inline void ofi_ibuf_free(struct ofi_bufpool *pool, void *buf)
+static inline void ofi_ibuf_free(void *buf)
 {
 	struct ofi_bufpool_hdr *buf_hdr;
 
-	assert(pool->attr.flags & OFI_BUFPOOL_INDEXED);
-	buf_hdr = ofi_buf_hdr(pool, buf);
-	assert(buf_hdr->region->use_cnt--);
+	assert(ofi_buf_pool(buf)->attr.flags & OFI_BUFPOOL_INDEXED);
+	assert(ofi_buf_region(buf)->use_cnt--);
+	buf_hdr = ofi_buf_hdr(buf);
 
 	dlist_insert_order(&buf_hdr->region->free_list,
 			   ofi_ibuf_is_lower, &buf_hdr->entry.dlist);
 
 	if (dlist_empty(&buf_hdr->region->entry)) {
-		dlist_insert_order(&pool->free_list.regions,
+		dlist_insert_order(&buf_hdr->region->pool->free_list.regions,
 				   ofi_ibufpool_region_is_lower,
 				   &buf_hdr->region->entry);
 	}
 }
 
-static inline size_t ofi_buf_index(struct ofi_bufpool *pool, void *buf)
+static inline size_t ofi_buf_index(void *buf)
 {
-	assert(ofi_buf_hdr(pool, buf)->region->use_cnt);
-	return ofi_buf_hdr(pool, buf)->index;
+	assert(ofi_buf_region(buf)->use_cnt);
+	return ofi_buf_hdr(buf)->index;
 }
 
 static inline void *ofi_bufpool_get_ibuf(struct ofi_bufpool *pool, size_t index)
@@ -400,13 +408,8 @@ static inline void *ofi_bufpool_get_ibuf(struct ofi_bufpool *pool, size_t index)
 	buf = pool->region_table[(size_t)(index / pool->attr.chunk_cnt)]->
 		mem_region + (index % pool->attr.chunk_cnt) * pool->entry_size;
 
-	assert(ofi_buf_hdr(pool, buf)->region->use_cnt);
+	assert(ofi_buf_region(buf)->use_cnt);
 	return buf;
-}
-
-static inline void *ofi_buf_region_ctx(struct ofi_bufpool *pool, void *buf)
-{
-	return ofi_buf_hdr(pool, buf)->region->context;
 }
 
 static inline int ofi_bufpool_empty(struct ofi_bufpool *pool)
@@ -432,7 +435,7 @@ static inline void *ofi_buf_alloc(struct ofi_bufpool *pool)
 	slist_remove_head_container(&pool->free_list.entries,
 				struct ofi_bufpool_hdr, buf_hdr, entry.slist);
 	assert(++buf_hdr->region->use_cnt);
-	return ofi_buf_data(pool, buf_hdr);
+	return ofi_buf_data(buf_hdr);
 }
 
 static inline void *ofi_buf_alloc_ex(struct ofi_bufpool *pool,
@@ -444,7 +447,7 @@ static inline void *ofi_buf_alloc_ex(struct ofi_bufpool *pool,
 	if (OFI_UNLIKELY(!buf))
 		return NULL;
 
-	*context = ofi_buf_region_ctx(pool, buf);
+	*context = ofi_buf_region(buf)->context;
 	return buf;
 }
 
@@ -467,7 +470,7 @@ static inline void *ofi_ibuf_alloc(struct ofi_bufpool *pool)
 
 	if (dlist_empty(&buf_region->free_list))
 		dlist_remove_init(&buf_region->entry);
-	return ofi_buf_data(pool, buf_hdr);
+	return ofi_buf_data(buf_hdr);
 }
 
 

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -293,6 +293,7 @@ struct ofi_bufpool {
 
 	struct ofi_bufpool_region	**region_table;
 	size_t				region_cnt;
+	size_t				alloc_size;
 	size_t				region_size;
 	struct ofi_bufpool_attr		attr;
 };
@@ -300,6 +301,7 @@ struct ofi_bufpool {
 struct ofi_bufpool_region {
 	struct dlist_entry		entry;
 	struct dlist_entry 		free_list;
+	char				*alloc_region;
 	char 				*mem_region;
 	size_t				index;
 	void 				*context;

--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -347,7 +347,7 @@ static inline
 void mrail_free_req(struct mrail_ep *mrail_ep, struct mrail_req *req)
 {
 	ofi_ep_lock_acquire(&mrail_ep->util_ep);
-	ofi_buf_free(mrail_ep->req_pool, req);
+	ofi_buf_free(req);
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 }
 

--- a/prov/mrail/src/mrail_cq.c
+++ b/prov/mrail/src/mrail_cq.c
@@ -186,7 +186,7 @@ static int mrail_process_ooo_recvs(struct mrail_ep *mrail_ep,
 		}
 
 		ofi_ep_lock_acquire(&mrail_ep->util_ep);
-		ofi_buf_free(mrail_ep->ooo_recv_pool, ooo_recv);
+		ofi_buf_free(ooo_recv);
 		ooo_recv = mrail_get_next_recv(peer_info);
 	}
 	ofi_ep_lock_release(&mrail_ep->util_ep);
@@ -408,7 +408,7 @@ void mrail_poll_cq(struct util_cq *cq)
 				}
 			}
 			ofi_ep_lock_acquire(&tx_buf->ep->util_ep);
-			ofi_buf_free(tx_buf->ep->tx_buf_pool, tx_buf);
+			ofi_buf_free(tx_buf);
 			ofi_ep_lock_release(&tx_buf->ep->util_ep);
 		} else {
 			/* We currently cannot support FI_REMOTE_READ and
@@ -426,7 +426,7 @@ void mrail_poll_cq(struct util_cq *cq)
 
 err2:
 	ofi_ep_lock_acquire(&tx_buf->ep->util_ep);
-	ofi_buf_free(tx_buf->ep->tx_buf_pool, tx_buf);
+	ofi_buf_free(tx_buf);
 	ofi_ep_lock_release(&tx_buf->ep->util_ep);
 err1:
 	// TODO write error to cq

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -388,7 +388,7 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 	return ret;
 err2:
-	ofi_buf_free(mrail_ep->tx_buf_pool, tx_buf);
+	ofi_buf_free(tx_buf);
 err1:
 	peer_info->seq_no--;
 	ofi_ep_lock_release(&mrail_ep->util_ep);
@@ -447,7 +447,7 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 	return ret;
 err2:
-	ofi_buf_free(mrail_ep->tx_buf_pool, tx_buf);
+	ofi_buf_free(tx_buf);
 err1:
 	peer_info->seq_no--;
 	ofi_ep_lock_release(&mrail_ep->util_ep);

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -1125,7 +1125,7 @@ static inline void psmx2_am_request_free(struct psmx2_trx_ctxt *trx_ctxt,
 					 struct psmx2_am_request *req)
 {
 	trx_ctxt->domain->am_req_pool_lock_fn(&trx_ctxt->am_req_pool_lock, 0);
-	ofi_buf_free(trx_ctxt->am_req_pool, req);
+	ofi_buf_free(req);
 	trx_ctxt->domain->am_req_pool_unlock_fn(&trx_ctxt->am_req_pool_lock, 0);
 }
 

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -381,11 +381,8 @@ int rxd_ep_post_buf(struct rxd_ep *ep);
 void rxd_release_repost_rx(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry);
 void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer);
 struct rxd_pkt_entry *rxd_get_tx_pkt(struct rxd_ep *ep);
-void rxd_release_rx_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt);
-void rxd_release_tx_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt);
 struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep);
 struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep);
-void rxd_release_rx_entry(struct rxd_ep *ep, struct rxd_x_entry *x_entry);
 int rxd_ep_send_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry);
 ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
 void rxd_insert_unacked(struct rxd_ep *ep, fi_addr_t peer,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -1017,28 +1017,6 @@ rxm_ep_format_tx_buf_pkt(struct rxm_conn *rxm_conn, size_t len, uint8_t op,
 	pkt->hdr.data = data;
 }
 
-static inline struct rxm_buf *rxm_buf_alloc(struct rxm_buf_pool *pool)
-{
-	return ofi_buf_alloc(pool->pool);
-}
-
-static inline
-void rxm_buf_release(struct rxm_buf_pool *pool, struct rxm_buf *buf)
-{
-	ofi_buf_free(pool->pool, buf);
-}
-
-static inline struct rxm_buf *
-rxm_buf_get_by_index(struct rxm_buf_pool *pool, size_t index)
-{
-	return ofi_bufpool_get_ibuf(pool->pool, index);
-}
-
-static inline
-size_t rxm_get_buf_index(struct rxm_buf_pool *pool, struct rxm_buf *buf)
-{
-	return ofi_buf_index(pool->pool, buf);
-}
 
 static inline struct rxm_buf *
 rxm_tx_buf_alloc(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
@@ -1049,19 +1027,14 @@ rxm_tx_buf_alloc(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
 	       (type == RXM_BUF_POOL_TX_RNDV) ||
 	       (type == RXM_BUF_POOL_TX_ATOMIC) ||
 	       (type == RXM_BUF_POOL_TX_SAR));
-	return rxm_buf_alloc(&rxm_ep->buf_pools[type]);
+	return ofi_buf_alloc(rxm_ep->buf_pools[type].pool);
 }
 
-static inline void
-rxm_tx_buf_release(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type, void *tx_buf)
-{
-	rxm_buf_release(&rxm_ep->buf_pools[type], (struct rxm_buf *)tx_buf);
-}
 
 static inline struct rxm_rx_buf *rxm_rx_buf_alloc(struct rxm_ep *rxm_ep)
 {
 	return (struct rxm_rx_buf *)
-		rxm_buf_alloc(&rxm_ep->buf_pools[RXM_BUF_POOL_RX]);
+		ofi_buf_alloc(rxm_ep->buf_pools[RXM_BUF_POOL_RX].pool);
 }
 
 static inline void
@@ -1071,22 +1044,14 @@ rxm_rx_buf_release(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf)
 		dlist_insert_tail(&rx_buf->repost_entry,
 				  &rx_buf->ep->repost_ready_list);
 	} else {
-		ofi_buf_free(rxm_ep->buf_pools[RXM_BUF_POOL_RX].pool,
-				 rx_buf);
+		ofi_buf_free(rx_buf);
 	}
 }
 
 static inline struct rxm_rma_buf *rxm_rma_buf_alloc(struct rxm_ep *rxm_ep)
 {
 	return (struct rxm_rma_buf *)
-		rxm_buf_alloc(&rxm_ep->buf_pools[RXM_BUF_POOL_RMA]);
-}
-
-static inline void
-rxm_rma_buf_release(struct rxm_ep *rxm_ep, struct rxm_rma_buf *rx_buf)
-{
-	rxm_buf_release(&rxm_ep->buf_pools[RXM_BUF_POOL_RMA],
-			(struct rxm_buf *)rx_buf);
+		ofi_buf_alloc(rxm_ep->buf_pools[RXM_BUF_POOL_RMA].pool);
 }
 
 static inline

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -140,8 +140,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	rxm_ep_format_atomic_pkt_hdr(rxm_conn, tx_buf, tot_len, op,
 				msg->datatype, msg->op, flags, msg->data,
 				msg->rma_iov, msg->rma_iov_count);
-	tx_buf->pkt.ctrl_hdr.msg_id = rxm_tx_buf_2_msg_id(rxm_ep,
-					  RXM_BUF_POOL_TX_ATOMIC, tx_buf);
+	tx_buf->pkt.ctrl_hdr.msg_id = ofi_buf_index(tx_buf);
 	tx_buf->app_context = msg->context;
 
 	atomic_hdr = (struct rxm_atomic_hdr *) tx_buf->pkt.data;
@@ -159,7 +158,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	ret = rxm_ep_send_atomic_req(rxm_ep, rxm_conn, tx_buf, tot_len);
 	if (ret)
-		rxm_tx_buf_release(rxm_ep, RXM_BUF_POOL_TX_ATOMIC, tx_buf);
+		ofi_buf_free(tx_buf);
 unlock:
 	ofi_ep_lock_release(&rxm_ep->util_ep);
 	return ret;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -106,7 +106,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 	if ((rxm_ep->msg_mr_local) && (!rxm_ep->rxm_mr_local))
 		rxm_ep_msg_mr_closev(rma_buf->mr.mr, rma_buf->mr.count);
 release:
-	rxm_rma_buf_release(rxm_ep, rma_buf);
+	ofi_buf_free(rma_buf);
 unlock:
 	ofi_ep_lock_release(&rxm_ep->util_ep);
 	return ret;
@@ -227,7 +227,7 @@ rxm_ep_rma_emulate_inject_msg(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, 
 	if (OFI_UNLIKELY(ret)) {
 		if (ret == -FI_EAGAIN)
 			rxm_ep_do_progress(&rxm_ep->util_ep);
-		rxm_rma_buf_release(rxm_ep, rma_buf);
+		ofi_buf_free(rma_buf);
 	}
 unlock:
 	ofi_ep_lock_release(&rxm_ep->util_ep);

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -160,14 +160,14 @@ static void sock_pe_release_entry(struct sock_pe *pe,
 		pe_entry->conn->rx_pe_entry = NULL;
 
 	if (pe_entry->type == SOCK_PE_RX && pe_entry->pe.rx.atomic_cmp) {
-		ofi_buf_free(pe->atomic_rx_pool, pe_entry->pe.rx.atomic_cmp);
-		ofi_buf_free(pe->atomic_rx_pool, pe_entry->pe.rx.atomic_src);
+		ofi_buf_free(pe_entry->pe.rx.atomic_cmp);
+		ofi_buf_free(pe_entry->pe.rx.atomic_src);
 	}
 
 	if (pe_entry->is_pool_entry) {
 		ofi_rbfree(&pe_entry->comm_buf);
 		dlist_remove(&pe_entry->entry);
-		ofi_buf_free(pe->pe_rx_pool, pe_entry);
+		ofi_buf_free(pe_entry);
 		return;
 	}
 
@@ -2762,7 +2762,7 @@ static void sock_pe_free_util_pool(struct sock_pe *pe)
 		pe_entry = container_of(entry, struct sock_pe_entry, entry);
 		ofi_rbfree(&pe_entry->comm_buf);
 		dlist_remove(&pe_entry->entry);
-		ofi_buf_free(pe->pe_rx_pool, pe_entry);
+		ofi_buf_free(pe_entry);
 	}
 
 	ofi_bufpool_destroy(pe->pe_rx_pool);

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -96,8 +96,7 @@ void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
 	xfer_entry->context = 0;
 
 	tcpx_cq->util_cq.cq_fastlock_acquire(&tcpx_cq->util_cq.cq_lock);
-	ofi_buf_free(tcpx_cq->buf_pools[xfer_entry->hdr.base_hdr.op_data].pool,
-			 xfer_entry);
+	ofi_buf_free(xfer_entry);
 	tcpx_cq->util_cq.cq_fastlock_release(&tcpx_cq->util_cq.cq_lock);
 }
 

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -48,7 +48,7 @@ static int tcpx_srx_ctx_close(struct fid *fid)
 	while (!slist_empty(&srx_ctx->rx_queue)) {
 		entry = slist_remove_head(&srx_ctx->rx_queue);
 		xfer_entry = container_of(entry, struct tcpx_xfer_entry, entry);
-		ofi_buf_free(srx_ctx->buf_pool, xfer_entry);
+		ofi_buf_free(xfer_entry);
 	}
 
 	ofi_bufpool_destroy(srx_ctx->buf_pool);

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -45,7 +45,7 @@ void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 		xfer_entry->ep->cur_rx_entry = NULL;
 
 	fastlock_acquire(&srx_ctx->lock);
-	ofi_buf_free(srx_ctx->buf_pool, xfer_entry);
+	ofi_buf_free(xfer_entry);
 	fastlock_release(&srx_ctx->lock);
 }
 

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -134,7 +134,7 @@ retry:
 
 	for (i = 0; i < pool->attr.chunk_cnt; i++) {
 		buf = (buf_region->mem_region + i * pool->entry_size);
-		buf_hdr = ofi_buf_hdr(pool, buf);
+		buf_hdr = ofi_buf_hdr(buf);
 
 		if (pool->attr.init_fn) {
 #if ENABLE_DEBUG

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -79,7 +79,7 @@ static void util_mr_free_entry(struct ofi_mr_cache *cache,
 	cache->cached_cnt--;
 	cache->cached_size -= entry->iov.iov_len;
 	
-	ofi_buf_free(cache->entry_pool, entry);
+	ofi_buf_free(entry);
 }
 
 static void util_mr_uncache_entry(struct ofi_mr_cache *cache,
@@ -169,7 +169,7 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 		}
 		if (ret) {
 			assert(!ofi_mr_cache_flush(cache));
-			ofi_buf_free(cache->entry_pool, *entry);
+			ofi_buf_free(*entry);
 			return ret;
 		}
 	}

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -119,7 +119,7 @@ fi_ibv_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 			sizeof(wce->wc.vendor_err));
 	}
 
-	ofi_buf_free(cq->wce_pool, wce);
+	ofi_buf_free(wce);
 	return 1;
 err:
 	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
@@ -316,7 +316,7 @@ static ssize_t fi_ibv_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 			entry = slist_remove_head(&cq->wcq);
 			wce = container_of(entry, struct fi_ibv_wce, entry);
 			cq->read_entry(&wce->wc, (char *)buf + i * cq->entry_size);
-			ofi_buf_free(cq->wce_pool, wce);
+			ofi_buf_free(wce);
 			continue;
 		}
 
@@ -435,7 +435,7 @@ static int fi_ibv_cq_trywait(struct fid *fid)
 
 	ret = FI_SUCCESS;
 err:
-	ofi_buf_free(cq->wce_pool, wce);
+	ofi_buf_free(wce);
 out:
 	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
 	return ret;
@@ -505,7 +505,7 @@ static int fi_ibv_cq_close(fid_t fid)
 	while (!slist_empty(&cq->wcq)) {
 		entry = slist_remove_head(&cq->wcq);
 		wce = container_of(entry, struct fi_ibv_wce, entry);
-		ofi_buf_free(cq->wce_pool, wce);
+		ofi_buf_free(wce);
 	}
 	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
 


### PR DESCRIPTION
Add an extra buffer to each region, which allows each entry to reference the previous entry's footer as its header.  Using a header allows using a fixed sized offset to jump between the user's buffer and the header. 
This removes the need to provide the pool as input into several calls, most notably free.  With that change, we remove the chance of a caller returning the buffer to the wrong pool, leading to difficult to isolate data corruption issues.  It also allows further optimizations in the providers where they are tracking the pool, simply to handle the free case.