### PR TITLE
prov/util,shm,rxd,rxm: optimize cntr function array

### DIFF
--- a/include/ofi_proto.h
+++ b/include/ofi_proto.h
@@ -129,6 +129,7 @@ enum {
 	ofi_op_atomic_fetch,
 	ofi_op_atomic_compare,
 	ofi_op_read_async,
+	ofi_op_last,
 };
 
 #define OFI_REMOTE_CQ_DATA	(1 << 0)

--- a/include/ofi_proto.h
+++ b/include/ofi_proto.h
@@ -124,10 +124,11 @@ enum {
 	ofi_op_read_req,
 	ofi_op_read_rsp,
 	ofi_op_write,
-	ofi_op_write_rsp,
+	ofi_op_write_async,
 	ofi_op_atomic,
 	ofi_op_atomic_fetch,
 	ofi_op_atomic_compare,
+	ofi_op_read_async,
 };
 
 #define OFI_REMOTE_CQ_DATA	(1 << 0)

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -556,10 +556,11 @@ static const uint64_t ofi_rx_flags[] = {
 	[ofi_op_read_req] = FI_RMA | FI_REMOTE_READ,
 	[ofi_op_read_rsp] = FI_RMA | FI_REMOTE_READ,
 	[ofi_op_write] = FI_RMA | FI_REMOTE_WRITE,
-	[ofi_op_write_rsp] = FI_RMA | FI_REMOTE_WRITE,
+	[ofi_op_write_async] = FI_RMA | FI_REMOTE_WRITE,
 	[ofi_op_atomic] = FI_ATOMIC | FI_REMOTE_WRITE,
 	[ofi_op_atomic_fetch] = FI_ATOMIC | FI_REMOTE_READ,
 	[ofi_op_atomic_compare] = FI_ATOMIC | FI_REMOTE_READ,
+	[ofi_op_read_async] = FI_RMA | FI_REMOTE_READ,
 };
 
 static inline uint64_t ofi_rx_cq_flags(uint32_t op)
@@ -572,9 +573,11 @@ static const uint64_t ofi_tx_flags[] = {
 	[ofi_op_tagged] = FI_SEND | FI_TAGGED,
 	[ofi_op_read_req] = FI_RMA | FI_READ,
 	[ofi_op_write] = FI_RMA | FI_WRITE,
+	[ofi_op_write_async] = FI_RMA | FI_WRITE,
 	[ofi_op_atomic] = FI_ATOMIC | FI_WRITE,
 	[ofi_op_atomic_fetch] = FI_ATOMIC | FI_READ,
 	[ofi_op_atomic_compare] = FI_ATOMIC | FI_READ,
+	[ofi_op_read_async] = FI_RMA | FI_READ,
 };
 
 static inline uint64_t ofi_tx_cq_flags(uint32_t op)

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -543,35 +543,13 @@ static inline int ofi_need_completion(uint64_t cq_flags, uint64_t op_flags)
 			     FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)));
 }
 
-static const uint64_t ofi_rx_flags[] = {
-	[ofi_op_msg] = FI_RECV,
-	[ofi_op_tagged] = FI_RECV | FI_TAGGED,
-	[ofi_op_read_req] = FI_RMA | FI_REMOTE_READ,
-	[ofi_op_read_rsp] = FI_RMA | FI_REMOTE_READ,
-	[ofi_op_write] = FI_RMA | FI_REMOTE_WRITE,
-	[ofi_op_write_async] = FI_RMA | FI_REMOTE_WRITE,
-	[ofi_op_atomic] = FI_ATOMIC | FI_REMOTE_WRITE,
-	[ofi_op_atomic_fetch] = FI_ATOMIC | FI_REMOTE_READ,
-	[ofi_op_atomic_compare] = FI_ATOMIC | FI_REMOTE_READ,
-	[ofi_op_read_async] = FI_RMA | FI_REMOTE_READ,
-};
+extern uint64_t ofi_rx_flags[ofi_op_last];
+extern uint64_t ofi_tx_flags[ofi_op_last];
 
 static inline uint64_t ofi_rx_cq_flags(uint32_t op)
 {
 	return ofi_rx_flags[op];
 }
-
-static const uint64_t ofi_tx_flags[] = {
-	[ofi_op_msg] = FI_SEND,
-	[ofi_op_tagged] = FI_SEND | FI_TAGGED,
-	[ofi_op_read_req] = FI_RMA | FI_READ,
-	[ofi_op_write] = FI_RMA | FI_WRITE,
-	[ofi_op_write_async] = FI_RMA | FI_WRITE,
-	[ofi_op_atomic] = FI_ATOMIC | FI_WRITE,
-	[ofi_op_atomic_fetch] = FI_ATOMIC | FI_READ,
-	[ofi_op_atomic_compare] = FI_ATOMIC | FI_READ,
-	[ofi_op_read_async] = FI_RMA | FI_READ,
-};
 
 static inline uint64_t ofi_tx_cq_flags(uint32_t op)
 {

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -326,15 +326,8 @@ static inline void ofi_ep_rem_wr_cntr_inc(struct util_ep *ep)
 }
 
 typedef void (*ofi_ep_cntr_inc_func)(struct util_ep *);
-
-static const ofi_ep_cntr_inc_func ofi_ep_cntr_inc_funcs[] = {
-	[FI_TRANSMIT] = ofi_ep_tx_cntr_inc,
-	[FI_RECV] = ofi_ep_rx_cntr_inc,
-	[FI_READ] = ofi_ep_rd_cntr_inc,
-	[FI_WRITE] = ofi_ep_wr_cntr_inc,
-	[FI_REMOTE_READ] = ofi_ep_rem_rd_cntr_inc,
-	[FI_REMOTE_WRITE] = ofi_ep_rem_wr_cntr_inc,
-};
+extern ofi_ep_cntr_inc_func ofi_ep_tx_cntr_inc_funcs[ofi_op_last];
+extern ofi_ep_cntr_inc_func ofi_ep_rx_cntr_inc_funcs[ofi_op_last];
 
 /*
  * Tag and address match

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -450,7 +450,5 @@ struct rxd_x_entry *rxd_progress_multi_recv(struct rxd_ep *ep,
 /* CQ sub-functions */
 void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry);
 void rxd_cq_report_tx_comp(struct rxd_cq *cq, struct rxd_x_entry *tx_entry);
-void rxd_cntr_report_tx_comp(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
-void rxd_cntr_report_rx_comp(struct rxd_ep *ep, struct rxd_x_entry *rx_entry);
 
 #endif

--- a/prov/rxd/src/rxd_cntr.c
+++ b/prov/rxd/src/rxd_cntr.c
@@ -108,24 +108,6 @@ free:
 	return ret;
 }
 
-void rxd_cntr_report_tx_comp(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
-{
-	uint64_t flags = tx_entry->cq_entry.flags &
-			 (FI_SEND | FI_WRITE | FI_READ);
-
-	assert(ofi_lsb(flags) == ofi_msb(flags));
-	ofi_ep_cntr_inc_funcs[flags](&ep->util_ep);
-}
-
-void rxd_cntr_report_rx_comp(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
-{
-	uint64_t flags = rx_entry->cq_entry.flags &
-			(FI_RECV | FI_REMOTE_WRITE | FI_REMOTE_READ);
-
-	assert(ofi_lsb(flags) == ofi_msb(flags));
-	ofi_ep_cntr_inc_funcs[flags](&ep->util_ep);
-}
-
 void rxd_cntr_report_error(struct rxd_ep *ep, struct fi_cq_err_entry *err)
 {
         struct util_cntr *cntr;

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -215,7 +215,7 @@ static void rxd_complete_rx(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 		goto out;
 
 	if (rx_entry->bytes_done == rx_entry->cq_entry.len) {
-		rxd_cntr_report_rx_comp(ep, rx_entry);
+		ofi_ep_rx_cntr_inc_funcs[rx_entry->op](&ep->util_ep);
 		if (write_cq)
 			rx_cq->write_fn(rx_cq, &rx_entry->cq_entry);
 	} else if (write_cq) {
@@ -242,7 +242,7 @@ static void rxd_complete_tx(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 	tx_cq->write_fn(tx_cq, &tx_entry->cq_entry);
 
 out:
-	rxd_cntr_report_tx_comp(ep, tx_entry);
+	ofi_ep_tx_cntr_inc_funcs[tx_entry->op](&ep->util_ep);
 	rxd_tx_entry_free(ep, tx_entry);
 }
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -248,7 +248,9 @@ static inline int rxm_finish_rma(struct rxm_ep *rxm_ep, struct rxm_rma_buf *rma_
 
 	assert(((comp_flags & FI_WRITE) && !(comp_flags & FI_READ)) ||
 	       ((comp_flags & FI_READ) && !(comp_flags & FI_WRITE)));
-	ofi_ep_cntr_inc_funcs[comp_flags & (FI_WRITE | FI_READ)](&rxm_ep->util_ep);
+
+	ofi_ep_tx_cntr_inc_funcs[comp_flags & FI_WRITE ? ofi_op_write :
+				 ofi_op_read_req](&rxm_ep->util_ep);
 
 	if (!(rma_buf->flags & FI_INJECT) && !rxm_ep->rxm_mr_local && rxm_ep->msg_mr_local) {
 		rxm_ep_msg_mr_closev(rma_buf->mr.mr, rma_buf->mr.count);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -65,7 +65,7 @@
 
 
 #define SMR_MAJOR_VERSION 1
-#define SMR_MINOR_VERSION 0
+#define SMR_MINOR_VERSION 1
 
 extern struct fi_provider smr_prov;
 extern struct fi_info smr_info;

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -241,8 +241,6 @@ int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, size_t len, void *buf, void *addr,
 		uint64_t tag, uint64_t data, uint64_t err);
-void smr_cntr_report_tx_comp(struct smr_ep *ep, uint32_t op);
-void smr_cntr_report_rx_comp(struct smr_ep *ep, uint32_t op);
 
 uint64_t smr_rx_cq_flags(uint32_t op, uint16_t op_flags);
 

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -414,7 +414,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
 
-	smr_cntr_report_tx_comp(ep, ofi_op_atomic);
+	ofi_ep_tx_cntr_inc_funcs[ofi_op_atomic](&ep->util_ep);
 unlock_region:
 	fastlock_release(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_cntr.c
+++ b/prov/shm/src/smr_cntr.c
@@ -59,21 +59,3 @@ free:
 	free(cntr);
 	return ret;
 }
-
-void smr_cntr_report_tx_comp(struct smr_ep *ep, uint32_t op)
-{
-	uint64_t flags = ofi_tx_cq_flags(op) &
-			 (FI_SEND | FI_WRITE | FI_READ);
-
-	assert(ofi_lsb(flags) == ofi_msb(flags));
-	ofi_ep_cntr_inc_funcs[flags](&ep->util_ep);
-}
-
-void smr_cntr_report_rx_comp(struct smr_ep *ep, uint32_t op)
-{
-	uint64_t flags = ofi_rx_cq_flags(op) &
-			(FI_RECV | FI_REMOTE_WRITE | FI_REMOTE_READ);
-
-	assert(ofi_lsb(flags) == ofi_msb(flags));
-	ofi_ep_cntr_inc_funcs[flags](&ep->util_ep);
-}

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -40,7 +40,7 @@
 int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint16_t flags, uint64_t err)
 {
-	smr_cntr_report_tx_comp(ep, op);
+	ofi_ep_tx_cntr_inc_funcs[op](&ep->util_ep);
 
 	if (!err && !(flags & SMR_TX_COMPLETION))
 		return 0;
@@ -92,7 +92,7 @@ int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op, uint16_t flag
 		    size_t len, void *buf, void *addr, uint64_t tag, uint64_t data,
 		    uint64_t err)
 {
-	smr_cntr_report_rx_comp(ep, op);
+	ofi_ep_rx_cntr_inc_funcs[op](&ep->util_ep);
 
 	if (!err && !(flags & (SMR_REMOTE_CQ_DATA | SMR_RX_COMPLETION)))
 		return 0;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -312,7 +312,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 				  &msg_iov, 1, op, tag, data, op_flags,
 				  peer_smr, tx_buf);
 	}
-	smr_cntr_report_tx_comp(ep, op);
+	ofi_ep_tx_cntr_inc_funcs[op](&ep->util_ep);
 	peer_smr->cmd_cnt--;
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 unlock:

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -563,7 +563,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			break;
 		case ofi_op_write_async:
 		case ofi_op_read_async:
-			smr_cntr_report_rx_comp(ep, cmd->msg.hdr.op);
+			ofi_ep_rx_cntr_inc_funcs[cmd->msg.hdr.op](&ep->util_ep);
 			ofi_cirque_discard(smr_cmd_queue(ep->region));
 			ep->region->cmd_cnt++;
 			break;

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -561,8 +561,8 @@ static void smr_progress_cmd(struct smr_ep *ep)
 		case ofi_op_read_req:
 			ret = smr_progress_cmd_rma(ep, cmd);
 			break;
-		case ofi_op_write_rsp:
-		case ofi_op_read_rsp:
+		case ofi_op_write_async:
+		case ofi_op_read_async:
 			smr_cntr_report_rx_comp(ep, cmd->msg.hdr.op);
 			ofi_cirque_discard(smr_cmd_queue(ep->region));
 			ep->region->cmd_cnt++;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -92,8 +92,8 @@ ssize_t smr_rma_fast(struct smr_region *peer_smr, struct smr_cmd *cmd,
 	}
 
 	smr_format_rma_resp(cmd, peer_id, rma_iov, rma_count, total_len,
-			    (op == ofi_op_write) ? ofi_op_write_rsp :
-			    ofi_op_read_rsp, op_flags);
+			    (op == ofi_op_write) ? ofi_op_write_async :
+			    ofi_op_read_async, op_flags);
 
 	return 0;
 }

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -369,7 +369,7 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 commit:
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
-	smr_cntr_report_tx_comp(ep, ofi_op_write);
+	ofi_ep_tx_cntr_inc_funcs[ofi_op_write](&ep->util_ep);
 unlock_region:
 	fastlock_release(&peer_smr->lock);
 	return ret;

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -313,3 +313,28 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 	return 0;
 }
 
+ofi_ep_cntr_inc_func ofi_ep_tx_cntr_inc_funcs[] = {
+	[ofi_op_msg] = ofi_ep_tx_cntr_inc,
+	[ofi_op_tagged] = ofi_ep_tx_cntr_inc,
+	[ofi_op_read_req] = ofi_ep_rd_cntr_inc,
+	[ofi_op_read_rsp] = ofi_ep_rem_rd_cntr_inc,
+	[ofi_op_write] = ofi_ep_wr_cntr_inc,
+	[ofi_op_write_async] = ofi_ep_wr_cntr_inc,
+	[ofi_op_atomic] = ofi_ep_wr_cntr_inc,
+	[ofi_op_atomic_fetch] = ofi_ep_rd_cntr_inc,
+	[ofi_op_atomic_compare] = ofi_ep_rd_cntr_inc,
+	[ofi_op_read_async] = ofi_ep_rd_cntr_inc,
+};
+
+ofi_ep_cntr_inc_func ofi_ep_rx_cntr_inc_funcs[] = {
+	[ofi_op_msg] = ofi_ep_rx_cntr_inc,
+	[ofi_op_tagged] = ofi_ep_rx_cntr_inc,
+	[ofi_op_read_req] = ofi_ep_rem_rd_cntr_inc,
+	[ofi_op_read_rsp] = ofi_ep_rd_cntr_inc,
+	[ofi_op_write] = ofi_ep_rem_wr_cntr_inc,
+	[ofi_op_write_async] = ofi_ep_rem_wr_cntr_inc,
+	[ofi_op_atomic] = ofi_ep_rem_wr_cntr_inc,
+	[ofi_op_atomic_fetch] = ofi_ep_rem_rd_cntr_inc,
+	[ofi_op_atomic_compare] = ofi_ep_rem_rd_cntr_inc,
+	[ofi_op_read_async] = ofi_ep_rem_rd_cntr_inc,
+};

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -670,3 +670,30 @@ err1:
 	ofi_cq_cleanup(cq);
 	return ret;
 }
+
+uint64_t ofi_rx_flags[] = {
+	[ofi_op_msg] = FI_RECV,
+	[ofi_op_tagged] = FI_RECV | FI_TAGGED,
+	[ofi_op_read_req] = FI_RMA | FI_REMOTE_READ,
+	[ofi_op_read_rsp] = FI_RMA | FI_REMOTE_READ,
+	[ofi_op_write] = FI_RMA | FI_REMOTE_WRITE,
+	[ofi_op_write_async] = FI_RMA | FI_REMOTE_WRITE,
+	[ofi_op_atomic] = FI_ATOMIC | FI_REMOTE_WRITE,
+	[ofi_op_atomic_fetch] = FI_ATOMIC | FI_REMOTE_READ,
+	[ofi_op_atomic_compare] = FI_ATOMIC | FI_REMOTE_READ,
+	[ofi_op_read_async] = FI_RMA | FI_READ,
+};
+
+uint64_t ofi_tx_flags[] = {
+	[ofi_op_msg] = FI_SEND,
+	[ofi_op_tagged] = FI_SEND | FI_TAGGED,
+	[ofi_op_read_req] = FI_RMA | FI_READ,
+	[ofi_op_read_rsp] = FI_RMA | FI_READ,
+	[ofi_op_write] = FI_RMA | FI_WRITE,
+	[ofi_op_write_async] = FI_RMA | FI_WRITE,
+	[ofi_op_atomic] = FI_ATOMIC | FI_WRITE,
+	[ofi_op_atomic_fetch] = FI_ATOMIC | FI_READ,
+	[ofi_op_atomic_compare] = FI_ATOMIC | FI_READ,
+	[ofi_op_read_async] = FI_RMA | FI_RMA,
+};
+


### PR DESCRIPTION
Change counter function declaration from using flags (256->8192) to the op enums (1->9)

Signed-off-by: aingerson <alexia.ingerson@intel.com>