### PR TITLE
prov/rxm: handle canceled receives from MSG provider

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1165,34 +1165,38 @@ static void rxm_cq_read_write_error(struct rxm_ep *rxm_ep)
 
 	switch (state) {
 	case RXM_SAR_TX:
-		assert(err_entry.flags & FI_SEND);
 		sar_buf = err_entry.op_context;
 		err_entry.op_context = sar_buf->app_context;
 		err_entry.flags = ofi_tx_cq_flags(sar_buf->pkt.hdr.op);
 		break;
 	case RXM_TX:
-		assert(err_entry.flags & FI_SEND);
 		eager_buf = err_entry.op_context;
 		err_entry.op_context = eager_buf->app_context;
 		err_entry.flags = ofi_tx_cq_flags(eager_buf->pkt.hdr.op);
 		break;
 	case RXM_RNDV_TX:
-		assert(err_entry.flags & FI_SEND);
 		rndv_buf = err_entry.op_context;
 		err_entry.op_context = rndv_buf->app_context;
 		err_entry.flags = ofi_tx_cq_flags(rndv_buf->pkt.hdr.op);
 		break;
+	case RXM_RX:
+		/* Silently drop any MSG CQ error entries for canceled receive
+		 * operations as these are internal to RxM. This situation can
+		 * happen when the MSG EP receives a reject / shutdown and CM
+		 * thread hasn't handled the event yet. */
+		if (err_entry.err == FI_ECANCELED) {
+			/* No need to re-post these buffers. Free directly */
+			ofi_buf_free((struct rxm_rx_buf *)err_entry.op_context);
+			return;
+		}
+		/* fall through */
 	case RXM_RNDV_ACK_SENT:
 		/* fall through */
-	case RXM_RX:
-		/* fall through */
 	case RXM_RNDV_READ:
-		assert(((state == RXM_RNDV_ACK_SENT) && (err_entry.flags & FI_SEND)) ||
-		       ((state == RXM_RX) && (err_entry.flags & FI_RECV)) ||
-		       ((state == RXM_RNDV_READ) && (err_entry.flags & FI_READ)));
 		rx_buf = (struct rxm_rx_buf *)err_entry.op_context;
 		util_cq = rx_buf->ep->util_ep.rx_cq;
 		util_cntr = rx_buf->ep->util_ep.rx_cntr;
+		assert(rx_buf->recv_entry);
 		err_entry.op_context = rx_buf->recv_entry->context;
 		err_entry.flags = rx_buf->recv_entry->comp_flags;
 		break;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -933,8 +933,7 @@ static inline int fi_ibv_poll_reap_unsig_cq(struct fi_ibv_ep *ep)
 		}
 
 		for (i = 0; i < ret; i++) {
-			if (!fi_ibv_process_wc(cq, &wc[i]) ||
-			    OFI_UNLIKELY(wc[i].status == IBV_WC_WR_FLUSH_ERR))
+			if (!fi_ibv_process_wc(cq, &wc[i]))
 				continue;
 			if (OFI_LIKELY(!fi_ibv_wc_2_wce(cq, &wc[i], &wce)))
 				slist_insert_tail(&wce->entry, &cq->wcq);

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -105,8 +105,11 @@ fi_ibv_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry,
 	wce = container_of(slist_entry, struct fi_ibv_wce, entry);
 
 	entry->op_context = (void *)(uintptr_t)wce->wc.wr_id;
-	entry->err = EIO;
 	entry->prov_errno = wce->wc.status;
+	if (wce->wc.status == IBV_WC_WR_FLUSH_ERR)
+		entry->err = FI_ECANCELED;
+	else
+		entry->err = EIO;
 	fi_ibv_handle_wc(&wce->wc, &entry->flags, &entry->len, &entry->data);
 
 	if ((FI_VERSION_GE(api_version, FI_VERSION(1, 5))) &&


### PR DESCRIPTION
This PR cherry-picks @sydidelot 's commit from #4756 and adds additional handling needed in verbs and rxm providers.

Since app thread can read MSG CQ before the CM thread has handled shutdown or reject we may end up getting error entries for canceled receives and that needs to be handle in rxm.

This should also avoid de-referencing a NULL `rx_buf->recv_entry` and is a replacement fix for the commit in PR #4821 . @chrisdolan would you be able to verify that you don't see any NULL pointer de-referencing in your app?