### PR TITLE
prov/rxm: Fix sending of non-inline atomic response protocol message

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -758,7 +758,7 @@ rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
 	};
 	struct fi_msg msg = {
 		.msg_iov = &iov,
-		.desc = NULL,
+		.desc = &resp_buf->hdr.desc,
 		.iov_count = 1,
 		.context = resp_buf,
 		.data = 0,


### PR DESCRIPTION
Correctly set the tx buffer descriptor when returning atomic response with
fi_send.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>