### PR TITLE
prov/rxd: cq, cntr, flag fixes

### DIFF
--- a/fabtests/ubertest/cq.c
+++ b/fabtests/ubertest/cq.c
@@ -335,7 +335,10 @@ static size_t ft_comp_x(struct fid_cq *cq, struct ft_xcontrol *ft_x,
 		return -1;
 	}
 
-	return (ret == -FI_EAGAIN && timeout) ? ret : completions;
+	if (completions)
+		return completions;
+
+	return (ret == -FI_EAGAIN && timeout) ? ret : 0;
 }
 
 static int ft_cntr_x(struct fid_cntr *cntr, struct ft_xcontrol *ft_x,

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -329,6 +329,18 @@ typedef void (*ofi_ep_cntr_inc_func)(struct util_ep *);
 extern ofi_ep_cntr_inc_func ofi_ep_tx_cntr_inc_funcs[ofi_op_last];
 extern ofi_ep_cntr_inc_func ofi_ep_rx_cntr_inc_funcs[ofi_op_last];
 
+static inline void ofi_ep_tx_cntr_inc_func(struct util_ep *ep, uint8_t op)
+{
+	assert(op < ofi_op_last);
+	ofi_ep_tx_cntr_inc_funcs[op](ep);
+}
+
+static inline void ofi_ep_rx_cntr_inc_func(struct util_ep *ep, uint8_t op)
+{
+	assert(op < ofi_op_last);
+	ofi_ep_rx_cntr_inc_funcs[op](ep);
+}
+
 /*
  * Tag and address match
  */

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -188,6 +188,8 @@ struct rxd_ep {
 	int next_retry;
 	int dg_cq_fd;
 	size_t pending_cnt;
+	uint32_t tx_flags;
+	uint32_t rx_flags;
 
 	struct ofi_bufpool *tx_pkt_pool;
 	struct ofi_bufpool *rx_pkt_pool;
@@ -278,9 +280,6 @@ static inline uint32_t rxd_rx_flags(uint64_t fi_flags)
 
 	return rxd_flags | RXD_NO_RX_COMP;
 }
-
-#define rxd_ep_rx_flags(rxd_ep) (rxd_rx_flags((rxd_ep)->util_ep.rx_op_flags))
-#define rxd_ep_tx_flags(rxd_ep) (rxd_tx_flags((rxd_ep)->util_ep.tx_op_flags))
 
 struct rxd_pkt_entry {
 	struct dlist_entry d_entry;

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -253,7 +253,7 @@ struct rxd_x_entry {
 	struct dlist_entry entry;
 };
 
-static inline uint32_t rxd_flags(uint64_t fi_flags)
+static inline uint32_t rxd_tx_flags(uint64_t fi_flags)
 {
 	uint32_t rxd_flags = 0;
 
@@ -261,14 +261,26 @@ static inline uint32_t rxd_flags(uint64_t fi_flags)
 		rxd_flags |= RXD_REMOTE_CQ_DATA;
 	if (fi_flags & FI_INJECT)
 		rxd_flags |= RXD_INJECT;
-	if (fi_flags & FI_MULTI_RECV)
-		rxd_flags |= RXD_MULTI_RECV;
+	if (fi_flags & FI_COMPLETION)
+		return rxd_flags;
 
-	return rxd_flags;
+	return rxd_flags | RXD_NO_TX_COMP;
 }
 
-#define rxd_ep_rx_flags(rxd_ep) (rxd_flags((rxd_ep)->util_ep.rx_op_flags))
-#define rxd_ep_tx_flags(rxd_ep) (rxd_flags((rxd_ep)->util_ep.tx_op_flags))
+static inline uint32_t rxd_rx_flags(uint64_t fi_flags)
+{
+	uint32_t rxd_flags = 0;
+
+	if (fi_flags & FI_MULTI_RECV)
+		rxd_flags |= RXD_MULTI_RECV;
+	if (fi_flags & FI_COMPLETION)
+		return rxd_flags;
+
+	return rxd_flags | RXD_NO_RX_COMP;
+}
+
+#define rxd_ep_rx_flags(rxd_ep) (rxd_rx_flags((rxd_ep)->util_ep.rx_op_flags))
+#define rxd_ep_tx_flags(rxd_ep) (rxd_tx_flags((rxd_ep)->util_ep.tx_op_flags))
 
 struct rxd_pkt_entry {
 	struct dlist_entry d_entry;

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -125,7 +125,7 @@ static ssize_t rxd_atomic_writev(struct fid_ep *ep_fid,
 	return rxd_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, NULL,
 				  NULL, 0, dest_addr, &rma_iov, 1, 0, datatype,
 				  op, context, ofi_op_atomic,
-				  rxd_ep_tx_flags(ep));
+				  ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t count,
@@ -148,7 +148,7 @@ static ssize_t rxd_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t c
 
 	return rxd_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, NULL, NULL, 0,
 				  dest_addr, &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic, rxd_ep_tx_flags(ep));
+				  ofi_op_atomic, ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
@@ -233,7 +233,7 @@ static ssize_t rxd_atomic_readwritev(struct fid_ep *ep_fid,
 	return rxd_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, resultv,
 				  result_desc, result_count, dest_addr,
 				  &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic_fetch, rxd_ep_tx_flags(ep));
+				  ofi_op_atomic_fetch, ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
@@ -261,7 +261,7 @@ static ssize_t rxd_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
 	return rxd_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, &resultv,
 				  &result_desc, 1, dest_addr, &rma_iov, 1, 0,
 				  datatype, op, context, ofi_op_atomic_fetch,
-				  rxd_ep_tx_flags(ep));
+				  ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_compwritemsg(struct fid_ep *ep_fid,
@@ -305,7 +305,7 @@ static ssize_t rxd_atomic_compwritev(struct fid_ep *ep_fid,
 				  compare_count, resultv, result_desc,
 				  result_count, dest_addr, &rma_iov, 1, 0,
 				  datatype, op, context, ofi_op_atomic_compare,
-				  rxd_ep_tx_flags(ep));
+				  ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_compwrite(struct fid_ep *ep_fid, const void *buf,
@@ -336,7 +336,7 @@ static ssize_t rxd_atomic_compwrite(struct fid_ep *ep_fid, const void *buf,
 	return rxd_generic_atomic(ep, &iov, &desc, 1, &comparev, &compare_desc,
 				  1, &resultv, &result_desc, 1, dest_addr,
 				  &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic_compare, rxd_ep_tx_flags(ep));
+				  ofi_op_atomic_compare, ep->tx_flags);
 }
 
 int rxd_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -67,7 +67,6 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 	ofi_rma_ioc_to_iov(rma_ioc, rma_iov, rma_count, ofi_datatype_size(datatype));
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -88,7 +87,6 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }
@@ -171,7 +169,6 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	rma_iov.key = key;
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -192,7 +189,6 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -104,7 +104,8 @@ static ssize_t rxd_atomic_writemsg(struct fid_ep *ep_fid,
 				  NULL, NULL, 0, NULL, NULL, 0, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count, msg->data,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic, rxd_flags(flags));
+				  ofi_op_atomic, rxd_tx_flags(flags |
+				  ep->util_ep.tx_msg_flags));
 }
 
 static ssize_t rxd_atomic_writev(struct fid_ep *ep_fid,
@@ -209,7 +210,8 @@ static ssize_t rxd_atomic_readwritemsg(struct fid_ep *ep_fid,
 				  result_count, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count, msg->data,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic_fetch, rxd_flags(flags));
+				  ofi_op_atomic_fetch, rxd_tx_flags(flags |
+				  ep->util_ep.tx_msg_flags));
 }
 
 static ssize_t rxd_atomic_readwritev(struct fid_ep *ep_fid,
@@ -278,7 +280,8 @@ static ssize_t rxd_atomic_compwritemsg(struct fid_ep *ep_fid,
 				  result_count, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count, msg->data,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic_compare, rxd_flags(flags));
+				  ofi_op_atomic_compare, rxd_tx_flags(flags |
+				  ep->util_ep.tx_msg_flags));
 }
 
 static ssize_t rxd_atomic_compwritev(struct fid_ep *ep_fid,

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -141,8 +141,7 @@ static void rxd_complete_rx(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 	      rx_entry->cq_entry.flags & FI_RECV))
 		rx_cq->write_fn(rx_cq, &rx_entry->cq_entry);
 
-	assert(rx_entry->op < ofi_op_last);
-	ofi_ep_rx_cntr_inc_funcs[rx_entry->op](&ep->util_ep);
+	ofi_ep_rx_cntr_inc_func(&ep->util_ep, rx_entry->op);
 
 out:
 	rxd_rx_entry_free(ep, rx_entry);
@@ -155,8 +154,7 @@ static void rxd_complete_tx(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 	if (!(tx_entry->flags & RXD_NO_TX_COMP))
 		tx_cq->write_fn(tx_cq, &tx_entry->cq_entry);
 
-	assert(tx_entry->op < ofi_op_last);
-	ofi_ep_tx_cntr_inc_funcs[tx_entry->op](&ep->util_ep);
+	ofi_ep_tx_cntr_inc_func(&ep->util_ep, tx_entry->op);
 
 	rxd_tx_entry_free(ep, tx_entry);
 }

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -216,8 +216,8 @@ static void rxd_verify_active(struct rxd_ep *ep, fi_addr_t addr, fi_addr_t peer_
 {
 	struct rxd_pkt_entry *pkt_entry;
 
-	if (ep->peers[addr].peer_addr == peer_addr &&
-	    ep->peers[addr].peer_addr != FI_ADDR_UNSPEC)
+	if (ep->peers[addr].peer_addr != FI_ADDR_UNSPEC &&
+	    ep->peers[addr].peer_addr != peer_addr)
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
 			"overwriting active peer - unexpected behavior\n");
 

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -392,6 +392,7 @@ void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer)
 			if (ofi_before(tx_entry->start_seq + (tx_entry->num_segs - 1),
 			    head_seq)) {
 				if (tx_entry->op == RXD_DATA_READ) {
+					tx_entry->op = ofi_op_read_req;
 					fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
 					rxd_complete_rx(ep, tx_entry);
 					fastlock_release(&ep->util_ep.rx_cq->cq_lock);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -274,6 +274,9 @@ static int rxd_ep_enable(struct rxd_ep *ep)
 	if (ret)
 		return ret;
 
+	ep->tx_flags = rxd_tx_flags(ep->util_ep.tx_op_flags);
+	ep->rx_flags = rxd_rx_flags(ep->util_ep.rx_op_flags);
+
 	fastlock_acquire(&ep->util_ep.lock);
 	for (i = 0; i < ep->rx_size; i++) {
 		ret = rxd_ep_post_buf(ep);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -128,7 +128,11 @@ static ssize_t rxd_ep_cancel_recv(struct rxd_ep *ep, struct dlist_entry *list,
 	err_entry.flags = rx_entry->cq_entry.flags;
 	err_entry.err = FI_ECANCELED;
 	err_entry.prov_errno = 0;
-	rxd_cq_report_error(rxd_ep_rx_cq(ep), &err_entry);
+	ret = ofi_cq_write_error(&rxd_ep_rx_cq(ep)->util_cq, &err_entry);
+	if (ret) {
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not write error entry\n");
+		goto out;
+	}
 
 	rx_entry->flags |= RXD_CANCELLED;
 
@@ -1015,6 +1019,7 @@ static void rxd_peer_timeout(struct rxd_ep *rxd_ep, struct rxd_peer *peer)
 	struct fi_cq_err_entry err_entry;
 	struct rxd_x_entry *tx_entry;
 	struct rxd_pkt_entry *pkt_entry;
+	int ret;
 
 	while (!dlist_empty(&peer->tx_list)) {
 		dlist_pop_front(&peer->tx_list, struct rxd_x_entry, tx_entry, entry);
@@ -1024,7 +1029,9 @@ static void rxd_peer_timeout(struct rxd_ep *rxd_ep, struct rxd_peer *peer)
 		err_entry.flags = tx_entry->cq_entry.flags;
 		err_entry.err = FI_ECONNREFUSED;
 		err_entry.prov_errno = 0;
-		rxd_cq_report_error(rxd_ep_tx_cq(rxd_ep), &err_entry);
+		ret = ofi_cq_write_error(&rxd_ep_tx_cq(rxd_ep)->util_cq, &err_entry);
+		if (ret)
+			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not write error entry\n");
 	}
 
 	while (!dlist_empty(&peer->unacked)) {

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -120,7 +120,6 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	assert(!(rxd_flags & RXD_MULTI_RECV) || iov_count == 1);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.rx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.rx_cq->cirq)) {
 		ret = -FI_EAGAIN;
@@ -151,7 +150,6 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	dlist_insert_tail(&rx_entry->entry, rx_list);
 out:
-	fastlock_release(&rxd_ep->util_ep.rx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }
@@ -207,7 +205,6 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	       rxd_ep_domain(rxd_ep)->max_inline_msg);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -227,7 +224,6 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }
@@ -248,7 +244,6 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 					     op, rxd_flags);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -268,7 +263,6 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -180,7 +180,7 @@ static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *d
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, 0, ~0, context,
-				      ofi_op_msg, rxd_ep_rx_flags(ep));
+				      ofi_op_msg, ep->rx_flags);
 }
 
 static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -191,7 +191,7 @@ static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr,
-				      0, ~0, context, ofi_op_msg, rxd_ep_rx_flags(ep));
+				      0, ~0, context, ofi_op_msg, ep->rx_flags);
 }
 
 ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
@@ -296,7 +296,7 @@ static ssize_t rxd_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void
 
 	return rxd_ep_generic_sendmsg(ep, iov, count, dest_addr, 0,
 				      0, context, ofi_op_msg,
-				      rxd_ep_tx_flags(ep));
+				      ep->tx_flags);
 }
 
 static ssize_t rxd_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -312,7 +312,7 @@ static ssize_t rxd_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, 0,
 				      0, context, ofi_op_msg,
-				      rxd_ep_tx_flags(ep));
+				      ep->tx_flags);
 }
 
 static ssize_t rxd_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -343,7 +343,7 @@ static ssize_t rxd_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t le
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, 0, data, context,
-				      ofi_op_msg, rxd_ep_tx_flags(ep) |
+				      ofi_op_msg, ep->tx_flags |
 				      RXD_REMOTE_CQ_DATA);
 }
 

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -165,7 +165,7 @@ static ssize_t rxd_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count,
 				      msg->addr, 0, ~0, msg->context, ofi_op_msg,
-				      rxd_flags(flags));
+				      rxd_rx_flags(flags | ep->util_ep.rx_msg_flags));
 }
 
 static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
@@ -282,7 +282,8 @@ static ssize_t rxd_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	return rxd_ep_generic_sendmsg(ep, msg->msg_iov, msg->iov_count,
 				   msg->addr, 0, msg->data, msg->context,
-				   ofi_op_msg, rxd_flags(flags));
+				   ofi_op_msg, rxd_tx_flags(flags |
+				   ep->util_ep.tx_msg_flags));
 
 }
 

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -61,8 +61,10 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count, data,
 				     0, context, rxd_addr, op, rxd_flags);
-	if (!tx_entry)
+	if (!tx_entry) {
+		ret = -FI_EAGAIN;
 		goto out;
+	}
 
 	ret = rxd_ep_send_op(rxd_ep, tx_entry, rma_iov, rma_count, NULL, 0, 0, 0);
 	if (ret) {
@@ -108,8 +110,10 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count,
 				     data, 0, context, rxd_addr, op, rxd_flags);
-	if (!tx_entry)
+	if (!tx_entry) {
+		ret = -FI_EAGAIN;
 		goto out;
+	}
 
 	ret = rxd_ep_send_op(rxd_ep, tx_entry, rma_iov, rma_count, NULL, 0, 0, 0);
 	if (ret)

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -50,7 +50,6 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	assert(ofi_total_iov_len(iov, iov_count) <= rxd_ep_domain(rxd_ep)->max_inline_rma);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -77,7 +76,6 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	ret = 0;
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }
@@ -99,7 +97,6 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	assert(iov_count <= RXD_IOV_LIMIT && rma_count <= RXD_IOV_LIMIT);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -119,7 +116,6 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -141,7 +141,7 @@ ssize_t rxd_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
 			       src_addr, context, ofi_op_read_req, 0,
-			       rxd_ep_tx_flags(ep));
+			       ep->tx_flags);
 }
 
 ssize_t rxd_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -159,7 +159,7 @@ ssize_t rxd_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	return rxd_generic_rma(ep, iov, count, &rma_iov, 1, desc,
 			       src_addr, context, ofi_op_read_req, 0,
-			       rxd_ep_tx_flags(ep));
+			       ep->tx_flags);
 }
 
 ssize_t rxd_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
@@ -193,7 +193,7 @@ ssize_t rxd_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc
 
 	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
 			       dest_addr, context, ofi_op_write, 0,
-			       rxd_ep_tx_flags(ep));
+			       ep->tx_flags);
 }
 
 ssize_t rxd_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -211,7 +211,7 @@ ssize_t rxd_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	return rxd_generic_rma(ep, iov, count, &rma_iov, 1, desc,
 			       dest_addr, context, ofi_op_write, 0,
-			       rxd_ep_tx_flags(ep));
+			       ep->tx_flags);
 }
 
 
@@ -247,7 +247,7 @@ ssize_t rxd_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	return rxd_generic_rma(ep, &iov, 1, &rma_iov, 1, &desc,
 			       dest_addr, context, ofi_op_write, data,
-			       rxd_ep_tx_flags(ep) | RXD_REMOTE_CQ_DATA);
+			       ep->tx_flags | RXD_REMOTE_CQ_DATA);
 }
 
 ssize_t rxd_inject_write(struct fid_ep *ep_fid, const void *buf,

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -172,7 +172,8 @@ ssize_t rxd_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	return rxd_generic_rma(ep, msg->msg_iov, msg->iov_count,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
-			       ofi_op_read_req, msg->data, rxd_flags(flags));
+			       ofi_op_read_req, msg->data, rxd_tx_flags(flags |
+			       ep->util_ep.tx_msg_flags));
 }
 
 ssize_t rxd_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
@@ -224,7 +225,8 @@ ssize_t rxd_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	return rxd_generic_rma(ep, msg->msg_iov, msg->iov_count,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
-			       ofi_op_write, msg->data, rxd_flags(flags));
+			       ofi_op_write, msg->data, rxd_tx_flags(flags |
+			       ep->util_ep.tx_msg_flags));
 }
 
 ssize_t rxd_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,

--- a/prov/rxd/src/rxd_tagged.c
+++ b/prov/rxd/src/rxd_tagged.c
@@ -49,7 +49,7 @@ ssize_t rxd_ep_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, tag, ignore,
 				      context, ofi_op_tagged,
-				      rxd_ep_tx_flags(ep) | RXD_TAG_HDR);
+				      ep->rx_flags | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -62,7 +62,7 @@ ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **des
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr, tag, ignore,
 				      context, ofi_op_tagged,
-				      rxd_ep_tx_flags(ep) | RXD_TAG_HDR);
+				      ep->rx_flags | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
@@ -91,7 +91,7 @@ ssize_t rxd_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	return rxd_ep_generic_sendmsg(ep, &msg_iov, 1, dest_addr, tag,
 				      0, context, ofi_op_tagged,
-				      rxd_ep_tx_flags(ep) | RXD_TAG_HDR);
+				      ep->tx_flags | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -104,7 +104,7 @@ ssize_t rxd_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	return rxd_ep_generic_sendmsg(ep, iov, count, dest_addr, tag,
 				      0, context, ofi_op_tagged,
-				      rxd_ep_tx_flags(ep) | RXD_TAG_HDR);
+				      ep->tx_flags | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
@@ -149,7 +149,7 @@ ssize_t rxd_ep_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, tag, data, context,
-				      ofi_op_tagged, rxd_ep_tx_flags(ep) |
+				      ofi_op_tagged, ep->tx_flags |
 				      RXD_REMOTE_CQ_DATA | RXD_TAG_HDR);
 }
 

--- a/prov/rxd/src/rxd_tagged.c
+++ b/prov/rxd/src/rxd_tagged.c
@@ -74,7 +74,8 @@ ssize_t rxd_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count, msg->addr,
 				      msg->tag, msg->ignore, msg->context,
-				      ofi_op_tagged, rxd_flags(flags) | RXD_TAG_HDR);
+				      ofi_op_tagged, rxd_rx_flags(flags |
+				      ep->util_ep.rx_msg_flags) | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -115,7 +116,8 @@ ssize_t rxd_ep_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	return rxd_ep_generic_sendmsg(ep, msg->msg_iov, msg->iov_count,
 				      msg->addr, msg->tag, msg->data, msg->context,
-				      ofi_op_tagged, rxd_flags(flags) | RXD_TAG_HDR);
+				      ofi_op_tagged, rxd_tx_flags(flags |
+				      ep->util_ep.tx_msg_flags) | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -249,8 +249,10 @@ static inline int rxm_finish_rma(struct rxm_ep *rxm_ep, struct rxm_rma_buf *rma_
 	assert(((comp_flags & FI_WRITE) && !(comp_flags & FI_READ)) ||
 	       ((comp_flags & FI_READ) && !(comp_flags & FI_WRITE)));
 
-	ofi_ep_tx_cntr_inc_funcs[comp_flags & FI_WRITE ? ofi_op_write :
-				 ofi_op_read_req](&rxm_ep->util_ep);
+	if (comp_flags & FI_WRITE)
+		ofi_ep_wr_cntr_inc(&rxm_ep->util_ep);
+	else
+		ofi_ep_rd_cntr_inc(&rxm_ep->util_ep);
 
 	if (!(rma_buf->flags & FI_INJECT) && !rxm_ep->rxm_mr_local && rxm_ep->msg_mr_local) {
 		rxm_ep_msg_mr_closev(rma_buf->mr.mr, rma_buf->mr.count);

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -414,7 +414,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
 
-	ofi_ep_tx_cntr_inc_funcs[ofi_op_atomic](&ep->util_ep);
+	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_atomic);
 unlock_region:
 	fastlock_release(&peer_smr->lock);
 	return ret;

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -40,7 +40,7 @@
 int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 		    uint16_t flags, uint64_t err)
 {
-	ofi_ep_tx_cntr_inc_funcs[op](&ep->util_ep);
+	ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
 
 	if (!err && !(flags & SMR_TX_COMPLETION))
 		return 0;
@@ -92,7 +92,7 @@ int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op, uint16_t flag
 		    size_t len, void *buf, void *addr, uint64_t tag, uint64_t data,
 		    uint64_t err)
 {
-	ofi_ep_rx_cntr_inc_funcs[op](&ep->util_ep);
+	ofi_ep_rx_cntr_inc_func(&ep->util_ep, op);
 
 	if (!err && !(flags & (SMR_REMOTE_CQ_DATA | SMR_RX_COMPLETION)))
 		return 0;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -312,7 +312,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 				  &msg_iov, 1, op, tag, data, op_flags,
 				  peer_smr, tx_buf);
 	}
-	ofi_ep_tx_cntr_inc_funcs[op](&ep->util_ep);
+	ofi_ep_tx_cntr_inc_func(&ep->util_ep, op);
 	peer_smr->cmd_cnt--;
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 unlock:

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -563,7 +563,7 @@ static void smr_progress_cmd(struct smr_ep *ep)
 			break;
 		case ofi_op_write_async:
 		case ofi_op_read_async:
-			ofi_ep_rx_cntr_inc_funcs[cmd->msg.hdr.op](&ep->util_ep);
+			ofi_ep_rx_cntr_inc_func(&ep->util_ep, cmd->msg.hdr.op);
 			ofi_cirque_discard(smr_cmd_queue(ep->region));
 			ep->region->cmd_cnt++;
 			break;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -369,7 +369,7 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 commit:
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
-	ofi_ep_tx_cntr_inc_funcs[ofi_op_write](&ep->util_ep);
+	ofi_ep_tx_cntr_inc_func(&ep->util_ep, ofi_op_write);
 unlock_region:
 	fastlock_release(&peer_smr->lock);
 	return ret;


### PR DESCRIPTION
- Add util_ep->msg_flags
- Pre-calculate flags
- Correctly use cntr functions
- Use util_cq write functions

- Also includes small fabtests fix related to completions