### PR TITLE
osd/freebsd: Fix missing header include

### DIFF
--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -38,6 +38,7 @@
 #include <pthread_np.h>
 
 #include "unix/osd.h"
+#include "rdma/fi_errno.h"
 
 #define bswap_64 bswap64
 


### PR DESCRIPTION
Include fi_errno.h to avoid undeclared identifier FI_ENOSYS.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>