### PR TITLE
prov/mlx: Do not enabled unless explicitly requested

### DIFF
--- a/prov/mlx/configure.m4
+++ b/prov/mlx/configure.m4
@@ -10,7 +10,7 @@ dnl
 AC_DEFUN([FI_MLX_CONFIGURE],[
     # Determine if we can support the mxm provider
     mlx_happy=0
-    AS_IF([test x"$enable_mlx" != x"no"],
+    AS_IF([test x"$enable_mlx" = x"yes"],
               [FI_CHECK_PACKAGE([mlx],
                     [ucp/api/ucp.h],
                     [ucp],


### PR DESCRIPTION
The underlying ucx library has not maintained backwards
compatibility.  This can result in build errors because of
modified or removed APIs.  Disable the mlx provider by
default.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>