### PR TITLE
Remove "the the" from manpages, comments, and license.

### DIFF
--- a/fabtests/COPYING
+++ b/fabtests/COPYING
@@ -1,5 +1,5 @@
 This software is available to you under a choice of one of two
-licenses.  You may choose to be licensed under the terms of the the
+licenses.  You may choose to be licensed under the terms of the
 BSD license or the GNU General Public License (GPL) Version
 2, both included below.
 

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -647,7 +647,7 @@ option is similar to delivery complete, but requires the intended recipient
 to sign for the letter.
 
 The 'commit complete' level has different semantics than the previously
-mentioned levels.  Commit complete would be closer to the the letter
+mentioned levels.  Commit complete would be closer to the letter
 arriving at the destination and being placed into a fire proof safe.
 
 The operational flags for the described completion levels are defined below.

--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -316,7 +316,7 @@ parsed and converted to FI_ADDR_GNI for use within the GNI provider.
 *FI_ADDR_STR* is formatted as follows:
 gni;node;service;GNIX_AV_STR_ADDR_VERSION;device_addr;cdm_id;name_type;cm_nic_cdm_id;cookie;rx_ctx_cnt;key_offset
 
-The GNI provider sets the domain attribute *cntr_cnt* to the the CQ limit divided by 2.
+The GNI provider sets the domain attribute *cntr_cnt* to the CQ limit divided by 2.
 
 The GNI provider sets the domain attribute *cq_cnt* to the CQ limit divided by 2.
 

--- a/prov/gni/src/gnix_util.c
+++ b/prov/gni/src/gnix_util.c
@@ -547,7 +547,7 @@ int _gnix_job_disable_unassigned_cpus(void)
 	return gnix_write_proc_job("disable_affinity_unassigned_cpus");
 }
 
-/* Indicate that the next task spawned should adhere to the the affinity rules. */
+/* Indicate that the next task spawned should adhere to the affinity rules. */
 int _gnix_job_enable_affinity_apply(void)
 {
 	return gnix_write_proc_job("enable_affinity_apply");

--- a/prov/psm/src/psm_am.h
+++ b/prov/psm/src/psm_am.h
@@ -126,7 +126,7 @@ void (*psm_am_completion_fn_t)(void *context);
  * multiple times to register additonal handlers. The maximum number of handlers
  * that can be registered is limited to the max_handlers value returned by
  * psm_am_get_parameters(). Handlers are associated with a PSM end-point. The
- * handlers are allocated index numbers in the the handler table for that end-point.
+ * handlers are allocated index numbers in the handler table for that end-point.
  * The allocated index for the handler function in handlers[i] is returned in
  * handlers_idx[i] for i in (0, num_handlers]. These handler index values are
  * used in the psm_am_request_short() and psm_am_reply_short() functions.

--- a/prov/usnic/src/usdf_rdm.c
+++ b/prov/usnic/src/usdf_rdm.c
@@ -688,7 +688,7 @@ static inline ssize_t _usdf_rdm_send_vector(struct fid_ep *fep,
 
 	tot_len = 0;
 	if (flags & FI_INJECT) {
-		/* copy to the the wqe's tiny injection buffer */
+		/* copy to the wqe's tiny injection buffer */
 		for (i = 0; i < count; ++i) {
 			assert(tot_len + iov[i].iov_len <=
 			       USDF_RDM_MAX_INJECT_SIZE);


### PR DESCRIPTION
In #4854, @j-xiong pointed out more instances of this typo in the man pages. I fixed those and went on a further pedantic rampage, removing it from code comments and the fabtest dual-license as well.