### PR TITLE
prov/rxd: Fix crash resulting from double free in error case

### DIFF
--- a/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
+++ b/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
@@ -1,7 +1,9 @@
 # Regex patterns of tests to exclude in runfabtests.sh
 
-^msg|-e msg
-^dgram|-e dgram
+^fi_msg
+-e msg
+^fi_dgram
+-e dgram
 
 # Exclude all prefix tests
 -k

--- a/fabtests/test_configs/ofi_rxm/ofi_rxm.exclude
+++ b/fabtests/test_configs/ofi_rxm/ofi_rxm.exclude
@@ -3,8 +3,10 @@
 # Exclude all prefix tests
 -k
 
-^msg|-e msg
-^dgram|-e dgram
+^fi_msg
+-e msg
+^fi_dgram
+-e dgram
 
 cm_data
 rdm_rma_simple

--- a/fabtests/test_configs/ofi_rxm/verbs/exclude
+++ b/fabtests/test_configs/ofi_rxm/verbs/exclude
@@ -3,8 +3,10 @@
 # Exclude all prefix tests
 -k
 
-^msg|-e msg
-^dgram|-e dgram
+^fi_msg
+-e msg
+^fi_dgram
+-e dgram
 
 cm_data
 rdm_rma_simple

--- a/fabtests/test_configs/osx.exclude
+++ b/fabtests/test_configs/osx.exclude
@@ -5,3 +5,4 @@ msg_epoll
 
 # Does not work with utility providers because of epoll limitations
 rdm_cntr_pingpong
+unexpected_msg

--- a/fabtests/test_configs/psm2/psm2.exclude
+++ b/fabtests/test_configs/psm2/psm2.exclude
@@ -6,7 +6,8 @@
 # av_test supports only FI_SOCKADDR
 av_test
 
-^msg|-e msg
+^fi_msg
+-e msg
 
 cm_data
 shared_ctx

--- a/fabtests/test_configs/shm/shm.exclude
+++ b/fabtests/test_configs/shm/shm.exclude
@@ -1,7 +1,9 @@
 # Regex patterns of tests to exclude in runfabtests.sh
 
-^msg|-e msg
-^dgram|-e dgram
+^fi_msg
+-e msg
+^fi_dgram
+-e dgram
 
 # Exclude tests that use sread/polling
 -S

--- a/fabtests/test_configs/tcp/tcp.exclude
+++ b/fabtests/test_configs/tcp/tcp.exclude
@@ -1,6 +1,7 @@
 # Regex patterns of tests to exclude in runfabtests.sh
 
-dgram
+^fi_dgram
+-e dgram
 
 rdm_rma_simple
 rdm_rma_trigger

--- a/fabtests/test_configs/udp/udp.exclude
+++ b/fabtests/test_configs/udp/udp.exclude
@@ -5,7 +5,7 @@ cq_data
 inj_complete -e dgram
 
 # No utility provider available for MSG EP support
-msg
+^fi_msg
 -e msg
 cm_data
 

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -790,9 +790,11 @@ static int rxd_ep_close(struct fid *fid)
 	if (ret)
 		return ret;
 
-	ret = fi_close(&ep->dg_cq->fid);
-	if (ret)
-		return ret;
+	if (ep->dg_cq) {
+		ret = fi_close(&ep->dg_cq->fid);
+		if (ret)
+			return ret;
+	}
 
 	while (!slist_empty(&ep->rx_pkt_list)) {
 		entry = slist_remove_head(&ep->rx_pkt_list);
@@ -899,6 +901,7 @@ static int rxd_dg_cq_open(struct rxd_ep *rxd_ep, enum fi_wait_obj wait_obj)
 	return 0;
 err:
 	fi_close(&rxd_ep->dg_cq->fid);
+	rxd_ep->dg_cq = NULL;
 	return ret;
 }
 
@@ -949,8 +952,6 @@ static int rxd_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 
 		if (!ep->dg_cq) {
 			ret = rxd_dg_cq_open(ep, cntr->wait ? FI_WAIT_FD : FI_WAIT_NONE);
-			if (ret)
-				return ret;
 		} else if (!ep->dg_cq_fd && cntr->wait) {
 			/* Reopen CQ with WAIT fd set */
 			ret = fi_close(&ep->dg_cq->fid);
@@ -959,12 +960,13 @@ static int rxd_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 					"Unable to close dg CQ: %s\n",
 					fi_strerror(-ret));
 				return ret;
-			} else {
-				ret = rxd_dg_cq_open(ep, FI_WAIT_FD);
-				if (ret)
-					return ret;
 			}
+
+			ep->dg_cq = NULL;
+			ret = rxd_dg_cq_open(ep, FI_WAIT_FD);
 		}
+		if (ret)
+			return ret;
 
 		if (cntr->wait)
 			ret = rxd_ep_wait_fd_add(ep, cntr->wait);


### PR DESCRIPTION
Crash shows up when running fi_rdm_cntr_pingpong on OS X.  OS X doesn't support epoll, which results in a failure obtaining the underlying fd.