### PR TITLE
prov/rxm: bug fixes for atomics

### DIFF
--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -74,6 +74,14 @@ rxm_ep_send_atomic_req(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	if (ret == -FI_EAGAIN)
 		rxm_ep_do_progress(&rxm_ep->util_ep);
 
+	if (OFI_LIKELY(!ret))
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "sent atomic request: op: %"
+		       PRIu8 " msg_id: 0x%" PRIx64 "\n", tx_buf->pkt.hdr.op,
+		       tx_buf->pkt.ctrl_hdr.msg_id);
+	else if (OFI_UNLIKELY(ret != -FI_EAGAIN))
+		FI_WARN(&rxm_prov, FI_LOG_EP_DATA, "unable to send atomic "
+			"request: op: %" PRIu8 " msg_id: 0x%" PRIx64 "\n",
+			tx_buf->pkt.hdr.op, tx_buf->pkt.ctrl_hdr.msg_id);
 	return ret;
 }
 
@@ -98,8 +106,8 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	       msg->rma_iov_count <= RXM_IOV_LIMIT);
 
 	if (flags & FI_REMOTE_CQ_DATA) {
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-		       "Atomic with remote CQ data not supported\n");
+		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+			"atomic with remote CQ data not supported\n");
 		return -FI_EINVAL;
 	}
 
@@ -122,8 +130,8 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			sizeof(struct rxm_pkt);
 
 	if (tot_len > rxm_ep->eager_limit) {
-		FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
-		       "atomic data too large %" PRId64 "\n", tot_len);
+		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+			"atomic data too large %zu\n", tot_len);
 		return -FI_EINVAL;
 	}
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -949,15 +949,15 @@ static inline ssize_t rxm_handle_atomic_resp(struct rxm_ep *rxm_ep,
 
 	tx_buf = ofi_bufpool_get_ibuf(rxm_ep->buf_pools[RXM_BUF_POOL_TX_ATOMIC].pool,
 				      rx_buf->pkt.ctrl_hdr.msg_id);
-	FI_DBG(&rxm_prov, FI_LOG_CQ,
-	       "Received Atomic Response for msg_id: 0x%" PRIx64 "\n",
+	FI_DBG(&rxm_prov, FI_LOG_CQ, "received atomic response: op: %" PRIu8
+	       " msg_id: 0x%" PRIx64 "\n", rx_buf->pkt.hdr.op,
 	       rx_buf->pkt.ctrl_hdr.msg_id);
 
 	assert(!(rx_buf->comp_flags & ~(FI_RECV | FI_REMOTE_CQ_DATA)));
 
 	if (resp_hdr->status) {
-		FI_DBG(&rxm_prov, FI_LOG_CQ,
-		       "Bad Atomic response status %d\n", ntohl(resp_hdr->status));
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+		       "bad atomic response status %d\n", ntohl(resp_hdr->status));
 		rxm_cq_write_error(rxm_ep->util_ep.tx_cq,
 				   rxm_ep->util_ep.tx_cntr,
 				   tx_buf->app_context, ntohl(resp_hdr->status));

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -974,10 +974,17 @@ static inline ssize_t rxm_handle_atomic_resp(struct rxm_ep *rxm_ep,
 					   ofi_tx_cq_flags(tx_buf->pkt.hdr.op),
 					   tx_buf->app_context, tx_buf->flags);
 done:
-	if (tx_buf->pkt.hdr.atomic.op == ofi_op_atomic)
+	if (tx_buf->pkt.hdr.op == ofi_op_atomic) {
 		ofi_ep_wr_cntr_inc(&rxm_ep->util_ep);
-	else
+	} else if (tx_buf->pkt.hdr.op == ofi_op_atomic_compare ||
+		   tx_buf->pkt.hdr.op == ofi_op_atomic_fetch) {
 		ofi_ep_rd_cntr_inc(&rxm_ep->util_ep);
+	} else {
+		FI_WARN(&rxm_prov, FI_LOG_CQ, "unknown atomic request op!\n");
+		rxm_cq_write_error(rxm_ep->util_ep.tx_cq, NULL,
+				   tx_buf->app_context, ntohl(resp_hdr->status));
+		assert(0);
+	}
 
 	rxm_rx_buf_release(rxm_ep, rx_buf);
 	ofi_buf_free(tx_buf);


### PR DESCRIPTION
This PR fixes wrong counters being incremented for atomic ops. Also adds some logging to aid in debugging.