### PR TITLE
prov/verbs: check the presence of rdmacm_create_qp_ex for XRC

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -42,6 +42,17 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 				[$verbs_LIBDIR],
 				[verbs_rdmacm_happy=1],
 				[verbs_rdmacm_happy=0])
+
+	       FI_CHECK_PACKAGE([verbs_rdmacm_ex],
+				[rdma/rdma_cma.h],
+				[rdmacm],
+				[rdma_create_qp_ex],
+				[],
+				[$verbs_PREFIX],
+				[$verbs_LIBDIR],
+				[verbs_rdmacm_ex_happy=1],
+				[verbs_rdmacm_ex_happy=0])
+
 	      ])
 
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
@@ -67,7 +78,8 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 
 	#See if we have XRC support
 	VERBS_HAVE_XRC=0
-	AS_IF([test $verbs_ibverbs_happy -eq 1],[
+	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
+	       test $verbs_rdmacm_ex_happy -eq 1],[
 		AC_CHECK_DECL([IBV_QPT_XRC_SEND],
 			[VERBS_HAVE_XRC=1],[],
 			[#include <infiniband/verbs.h>])


### PR DESCRIPTION
The code for XRC requires the support of rdmacm_create_qp_ex, which
is not always available. On some platforms like Centos 7.x, this
would result in an error due to implicit declaration of function
rdma_create_qp_ex:

prov/verbs/src/verbs_domain_xrc.c:89:2: warning: implicit declaration
of function 'rdma_create_qp_ex' [-Wimplicit-function-declaration]

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>