### PR TITLE
[V1.7.x] prov/rxm: Cherry pick of additional RXM atomic fixes

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -754,7 +754,7 @@ rxm_atomic_send_respmsg(struct rxm_ep *rxm_ep, struct rxm_conn *conn,
 	};
 	struct fi_msg msg = {
 		.msg_iov = &iov,
-		.desc = NULL,
+		.desc = &resp_buf->hdr.desc,
 		.iov_count = 1,
 		.context = resp_buf,
 		.data = 0,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -217,6 +217,9 @@ static void rxm_alter_info(const struct fi_info *hints, struct fi_info *info)
 					~(RXM_ATOMIC_UNSUPPORTED_MSG_ORDER);
 				cur->rx_attr->msg_order &=
 					~(RXM_ATOMIC_UNSUPPORTED_MSG_ORDER);
+				cur->ep_attr->max_order_raw_size = 0;
+				cur->ep_attr->max_order_war_size = 0;
+				cur->ep_attr->max_order_waw_size = 0;
 			} else {
 				cur->caps &= ~FI_ATOMIC;
 				cur->tx_attr->caps &= ~FI_ATOMIC;
@@ -253,6 +256,12 @@ static int rxm_validate_atomic_hints(const struct fi_info *hints)
 	if (!hints || !(hints->caps & FI_ATOMIC))
 		return 0;
 
+	if (hints->domain_attr &&
+	    hints->domain_attr->data_progress == FI_PROGRESS_AUTO) {
+		FI_DBG(&rxm_prov, FI_LOG_FABRIC,
+		       "FI_ATOMIC does not support data FI_PROGRESS_AUTO\n");
+		return -FI_EINVAL;
+	}
 	if (hints->tx_attr && (hints->tx_attr->msg_order &
 			       RXM_ATOMIC_UNSUPPORTED_MSG_ORDER)) {
 		FI_DBG(&rxm_prov, FI_LOG_FABRIC,


### PR DESCRIPTION
Additional cherry picked fixes for RXM Atomic support:
prov/rxm: Fix returned fi_info attributes when FI_ATOMIC is specified
prov/rxm: Fix sending of non-inline atomic response protocol message