### PR TITLE
fabtests: Add option to enable OOB address exchange only

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -572,7 +572,7 @@ static int ft_init_oob(void)
 	int ret, op, err;
 	struct addrinfo *ai = NULL;
 
-	if (!(opts.options & FT_OPT_OOB_SYNC) || oob_sock != -1)
+	if (!(opts.options & FT_OPT_OOB_CTRL) || oob_sock != -1)
 		return 0;
 
 	if (!opts.oob_port)
@@ -2316,7 +2316,7 @@ int ft_sync()
 	int ret;
 
 	if (opts.dst_addr) {
-		if (!opts.oob_port) {
+		if (!(opts.options & FT_OPT_OOB_SYNC)) {
 			ret = ft_tx(ep, remote_fi_addr, 1, &tx_ctx);
 			if (ret)
 				return ret;
@@ -2332,7 +2332,7 @@ int ft_sync()
 				return ret;
 		}
 	} else {
-		if (!opts.oob_port) {
+		if (!(opts.options & FT_OPT_OOB_SYNC)) {
 			ret = ft_rx(ep, 1);
 			if (ret)
 				return ret;
@@ -2589,6 +2589,8 @@ void ft_addr_usage()
 	FT_PRINT_OPTS_USAGE("-s <address>", "source address");
 	FT_PRINT_OPTS_USAGE("-b[=<oob_port>]", "enable out-of-band address exchange and "
 			"synchronization over the, optional, port");
+	FT_PRINT_OPTS_USAGE("-E[=<oob_port>]", "enable out-of-band address exchange only "
+			"over the, optional, port");
 }
 
 void ft_usage(char *name, char *desc)
@@ -2719,6 +2721,9 @@ void ft_parse_addr_opts(int op, char *optarg, struct ft_opts *opts)
 		break;
 	case 'b':
 		opts->options |= FT_OPT_OOB_SYNC;
+		/* fall through */
+	case 'E':
+		opts->options |= FT_OPT_OOB_ADDR_EXCH;
 		if (optarg && strlen(optarg) > 1)
 			opts->oob_port = optarg + 1;
 		else

--- a/fabtests/functional/av_xfer.c
+++ b/fabtests/functional/av_xfer.c
@@ -197,7 +197,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.options |= FT_OPT_SIZE | FT_OPT_OOB_SYNC;
+	opts.options |= FT_OPT_SIZE | FT_OPT_OOB_CTRL;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
 	int ret;
 
 	opts = INIT_OPTS;
-	opts.options |= FT_OPT_OOB_SYNC | FT_OPT_SKIP_MSG_ALLOC;
+	opts.options |= FT_OPT_OOB_CTRL | FT_OPT_SKIP_MSG_ALLOC;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -117,6 +117,8 @@ enum {
 	FT_OPT_OOB_SYNC		= 1 << 11,
 	FT_OPT_SKIP_MSG_ALLOC	= 1 << 12,
 	FT_OPT_SKIP_REG_MR	= 1 << 13,
+	FT_OPT_OOB_ADDR_EXCH	= 1 << 14,
+	FT_OPT_OOB_CTRL		= FT_OPT_OOB_SYNC | FT_OPT_OOB_ADDR_EXCH,
 };
 
 /* for RMA tests --- we want to be able to select fi_writedata, but there is no
@@ -224,7 +226,7 @@ extern int ft_parent_proc;
 extern int ft_socket_pair[2];
 extern int sock;
 extern int listen_sock;
-#define ADDR_OPTS "B:P:s:a:b::"
+#define ADDR_OPTS "B:P:s:a:b::E::"
 #define FAB_OPTS "f:d:p:"
 #define INFO_OPTS FAB_OPTS "e:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -273,6 +273,11 @@ the list available for that test.
   synchronization.  A port for the out-of-band connection may be specified
   as part of this option to override the default.
 
+*-E[=oob_port]*
+: Enables out-of-band (via sockets) address exchange only. A port for the
+  out-of-band connection may be specified as part of this option to override
+  the default. Cannot be used together with the '-b' option.
+
 *-I <number>*
 : Number of data transfer iterations.
 


### PR DESCRIPTION
The '-b' option enables OOB address exchange and test synchronization.
However, some tests rely on the synchronization to make progress over
certain providers. They won't work with OOB channel turned on.

Add the '-E' option that enables address exchange over the OOB channel
but keeps test synchronization going through the provider.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>