### PR TITLE
[v1.7.x] prov/tcp: fix for tcpx_recv_hdr returning FI_ENOTCONN

### DIFF
--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -85,6 +85,9 @@ int tcpx_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
 	rem_buf = (uint8_t *) &rx_detect->hdr + rx_detect->done_len;
 	rem_len = sizeof(rx_detect->hdr) - rx_detect->done_len;
 
+	if (!rem_len)
+		return FI_SUCCESS;
+
 	if (sbuf->len != sbuf->off) {
 		bytes_recvd = tcpx_read_from_buffer(sbuf, rem_buf, rem_len);
 	} else {


### PR DESCRIPTION
when get_rx_entry fails, there is a possibility that tcpx_recv_hdr will return FI_ENOTCONN - when called after full header already read from socket. This patch eliminates that case.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>