### PR TITLE
[v1.7.x] prov/rxm: cherry-pick eager limit fix

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -959,8 +959,7 @@ rxm_process_recv_entry(struct rxm_recv_queue *recv_queue,
 		}
 	}
 
-	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Enqueuing recv", recv_entry->addr,
-			 recv_entry->tag);
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Enqueuing recv\n");
 	dlist_insert_tail(&recv_entry->entry, &recv_queue->recv_list);
 
 	return FI_SUCCESS;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -65,6 +65,7 @@
 #define RXM_CTRL_VERSION	3
 
 #define RXM_BUF_SIZE	16384
+extern size_t rxm_eager_limit;
 
 #define RXM_SAR_LIMIT	131072
 #define RXM_SAR_TX_ERROR	UINT64_MAX

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -129,7 +129,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	tot_len = buf_len + cmp_len + sizeof(struct rxm_atomic_hdr) +
 			sizeof(struct rxm_pkt);
 
-	if (tot_len > rxm_ep->eager_limit) {
+	if (tot_len > rxm_eager_limit) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"atomic data too large %zu\n", tot_len);
 		return -FI_EINVAL;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -201,9 +201,9 @@ static int rxm_finish_recv(struct rxm_rx_buf *rx_buf, size_t done_len)
 		}
 
 		FI_DBG(&rxm_prov, FI_LOG_CQ,
-		       "Repost Multi-Recv entry: "
+		       "Repost Multi-Recv entry: %p "
 		       "consumed len = %zu, remain len = %zu\n",
-		       recv_size, recv_entry->total_len);
+		       recv_entry, recv_size, recv_entry->total_len);
 
 		rxm_iov = recv_entry->rxm_iov;
 		ret = rxm_match_iov(/* prev iovecs */
@@ -1241,17 +1241,19 @@ static void rxm_cq_read_write_error(struct rxm_ep *rxm_ep)
 
 static inline int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 {
+	int ret;
+
 	if (rx_buf->ep->srx_ctx)
 		rx_buf->conn = NULL;
 	rx_buf->hdr.state = RXM_RX;
 
-	if (fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
-		    rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
-		    rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf)) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to repost buf\n");
-		return -FI_EAVAIL;
-	}
-	return FI_SUCCESS;
+	ret = fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
+		      rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
+		      rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf);
+	if (ret)
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+			"Unable to repost buf: %d\n", ret);
+	return ret;
 }
 
 int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1247,9 +1247,9 @@ static inline int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 		rx_buf->conn = NULL;
 	rx_buf->hdr.state = RXM_RX;
 
-	ret = fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
-		      rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
-		      rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf);
+	ret = (int)fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
+			   rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
+			   rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf);
 	if (ret)
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 			"Unable to repost buf: %d\n", ret);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1248,7 +1248,7 @@ static inline int rxm_ep_repost_buf(struct rxm_rx_buf *rx_buf)
 	rx_buf->hdr.state = RXM_RX;
 
 	ret = (int)fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
-			   rx_buf->ep->eager_limit + sizeof(struct rxm_pkt),
+			   rxm_eager_limit + sizeof(struct rxm_pkt),
 			   rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf);
 	if (ret)
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -33,6 +33,7 @@
 #include <inttypes.h>
 #include <math.h>
 
+#include <rdma/fabric.h>
 #include "ofi.h"
 #include <ofi_util.h>
 
@@ -744,9 +745,18 @@ rxm_ep_post_recv(struct rxm_ep *rxm_ep, const struct iovec *iov,
 	if (OFI_UNLIKELY(ret))
 		return ret;
 
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting recv with length: %zu "
-	       "tag: 0x%" PRIx64 " ignore: 0x%" PRIx64 "\n",
-	       recv_entry->total_len, recv_entry->tag, recv_entry->ignore);
+	if (recv_queue->type == RXM_RECV_QUEUE_MSG)
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting recv with length: %zu "
+		       "addr: 0x%" PRIx64 "\n", recv_entry->total_len,
+		       recv_entry->addr);
+	else
+		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting trecv with "
+		       "length: %zu addr: 0x%" PRIx64 " tag: 0x%" PRIx64
+		       " ignore: 0x%" PRIx64 "\n", recv_entry->total_len,
+		       recv_entry->addr, recv_entry->tag, recv_entry->ignore);
+
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "recv op_flags: %s\n",
+	       fi_tostr(&recv_entry->flags, FI_TYPE_OP_FLAGS));
 	ret = rxm_process_recv_entry(recv_queue, recv_entry);
 
 	return ret;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -382,9 +382,9 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 		[RXM_BUF_POOL_RMA] = rxm_ep->msg_info->tx_attr->size,
 	};
 	size_t entry_sizes[] = {		
-		[RXM_BUF_POOL_RX] = rxm_ep->eager_limit +
+		[RXM_BUF_POOL_RX] = rxm_eager_limit +
 				    sizeof(struct rxm_rx_buf),
-		[RXM_BUF_POOL_TX] = rxm_ep->eager_limit +
+		[RXM_BUF_POOL_TX] = rxm_eager_limit +
 				    sizeof(struct rxm_tx_eager_buf),
 		[RXM_BUF_POOL_TX_INJECT] = rxm_ep->inject_limit +
 					   sizeof(struct rxm_tx_base_buf),
@@ -392,11 +392,11 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 		[RXM_BUF_POOL_TX_RNDV] = sizeof(struct rxm_rndv_hdr) +
 					 rxm_ep->buffered_min +
 					 sizeof(struct rxm_tx_rndv_buf),
-		[RXM_BUF_POOL_TX_ATOMIC] = rxm_ep->eager_limit +
+		[RXM_BUF_POOL_TX_ATOMIC] = rxm_eager_limit +
 					 sizeof(struct rxm_tx_atomic_buf),
-		[RXM_BUF_POOL_TX_SAR] = rxm_ep->eager_limit +
+		[RXM_BUF_POOL_TX_SAR] = rxm_eager_limit +
 					sizeof(struct rxm_tx_sar_buf),
-		[RXM_BUF_POOL_RMA] = rxm_ep->eager_limit +
+		[RXM_BUF_POOL_RMA] = rxm_eager_limit +
 				     sizeof(struct rxm_rma_buf),
 	};
 
@@ -1030,8 +1030,8 @@ err:
 static inline size_t
 rxm_ep_sar_calc_segs_cnt(struct rxm_ep *rxm_ep, size_t data_len)
 {
-	return (data_len + rxm_ep->eager_limit - 1) /
-	       rxm_ep->eager_limit;
+	return (data_len + rxm_eager_limit - 1) /
+	       rxm_eager_limit;
 }
 
 static inline struct rxm_tx_sar_buf *
@@ -1124,14 +1124,14 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	assert(segs_cnt >= 2);	
 
 	first_tx_buf = rxm_ep_sar_tx_prepare_segment(rxm_ep, rxm_conn, context, data_len,
-						     rxm_ep->eager_limit, 0, data, flags,
+						     rxm_eager_limit, 0, data, flags,
 						     tag, op, RXM_SAR_SEG_FIRST, &msg_id);
 	if (OFI_UNLIKELY(!first_tx_buf))
 		return -FI_EAGAIN;
 
-	ofi_copy_from_iov(first_tx_buf->pkt.data, rxm_ep->eager_limit,
+	ofi_copy_from_iov(first_tx_buf->pkt.data, rxm_eager_limit,
 			  iov, count, iov_offset);
-	iov_offset += rxm_ep->eager_limit;
+	iov_offset += rxm_eager_limit;
 
 	ret = fi_send(rxm_conn->msg_ep, &first_tx_buf->pkt, sizeof(struct rxm_pkt) +
 		      first_tx_buf->pkt.ctrl_hdr.seg_size, first_tx_buf->hdr.desc, 0, first_tx_buf);
@@ -1142,12 +1142,12 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		return ret;
 	}
 
-	remain_len -= rxm_ep->eager_limit;
+	remain_len -= rxm_eager_limit;
 
 	for (i = 1; i < segs_cnt; i++) {
 		ret = rxm_ep_sar_tx_prepare_and_send_segment(
 					rxm_ep, rxm_conn, context, data_len, remain_len,
-					msg_id, rxm_ep->eager_limit, i, segs_cnt, data,
+					msg_id, rxm_eager_limit, i, segs_cnt, data,
 					flags, tag, op, iov, count, &iov_offset, &tx_buf);
 		if (OFI_UNLIKELY(ret)) {
 			if (OFI_LIKELY(ret == -FI_EAGAIN)) {
@@ -1180,7 +1180,7 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			rxm_tx_buf_release(rxm_ep, RXM_BUF_POOL_TX_SAR, first_tx_buf);
 			return ret;
 		}
-		remain_len -= rxm_ep->eager_limit;
+		remain_len -= rxm_eager_limit;
 	}
 
 	return 0;
@@ -1195,9 +1195,7 @@ rxm_ep_emulate_inject(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	struct rxm_tx_eager_buf *tx_buf;
 	ssize_t ret;
 
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "passed data (size = %zu) "
-	       "is too big for MSG provider (max inject size = %zd)\n",
-	       pkt_size, rxm_ep->inject_limit);
+	assert(pkt_size <= rxm_ep->rxm_info->tx_attr->inject_size);
 
 	tx_buf = (struct rxm_tx_eager_buf *)
 		  rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX);
@@ -1230,7 +1228,7 @@ rxm_ep_inject_send_fast(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	size_t pkt_size = sizeof(struct rxm_pkt) + len;
 	ssize_t ret;
 
-	assert(len <= rxm_ep->eager_limit);
+	assert(len <= rxm_ep->rxm_info->tx_attr->inject_size);
 
 	if (pkt_size <= rxm_ep->inject_limit) {
 		inject_pkt->hdr.size = len;
@@ -1253,7 +1251,7 @@ rxm_ep_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	size_t pkt_size = sizeof(struct rxm_pkt) + len;
 	ssize_t ret;
 
-	assert(len <= rxm_ep->eager_limit);
+	assert(len <= rxm_ep->rxm_info->tx_attr->inject_size);
 
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 	if (pkt_size <= rxm_ep->inject_limit) {
@@ -1346,15 +1344,16 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	ssize_t ret;
 
 	assert(count <= rxm_ep->rxm_info->tx_attr->iov_limit);
-	assert((!(flags & FI_INJECT) && (data_len > rxm_ep->eager_limit)) ||
-	       (data_len <= rxm_ep->eager_limit));
+	assert((!(flags & FI_INJECT) &&
+		(data_len > rxm_ep->rxm_info->tx_attr->inject_size)) ||
+	       (data_len <= rxm_ep->rxm_info->tx_attr->inject_size));
 
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 	if (total_len <= rxm_ep->inject_limit) {
 		ret = rxm_ep_inject_send_common(rxm_ep, iov, count, rxm_conn,
 						context, data, flags, tag, op,
 						data_len, total_len, inject_pkt);
-	} else if (data_len <= rxm_ep->eager_limit) {
+	} else if (data_len <= rxm_eager_limit) {
 		struct rxm_tx_eager_buf *tx_buf = (struct rxm_tx_eager_buf *)
 			rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX);
 
@@ -1381,7 +1380,7 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		}
 	} else if (data_len <= rxm_ep->sar_limit &&
 		   /* SAR uses eager_limit as segment size */
-		   (rxm_ep->eager_limit <
+		   (rxm_eager_limit <
 		    (1ULL << (8 * sizeof_field(struct ofi_ctrl_hdr, seg_size))))) {
 		ret = rxm_ep_sar_tx_send(rxm_ep, rxm_conn, context,
 					 count, iov, data_len,
@@ -1448,7 +1447,7 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 		}
 
 		def_tx_entry->sar_seg.next_seg_no++;
-		def_tx_entry->sar_seg.remain_len -= def_tx_entry->rxm_ep->eager_limit;
+		def_tx_entry->sar_seg.remain_len -= rxm_eager_limit;
 
 		if (def_tx_entry->sar_seg.next_seg_no == def_tx_entry->sar_seg.segs_cnt) {
 			assert(rxm_sar_get_seg_type(&tx_buf->pkt.ctrl_hdr) == RXM_SAR_SEG_LAST);
@@ -1461,7 +1460,7 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 				def_tx_entry->rxm_ep, def_tx_entry->rxm_conn,
 				def_tx_entry->sar_seg.app_context,
 				def_tx_entry->sar_seg.total_len, def_tx_entry->sar_seg.remain_len,
-				def_tx_entry->sar_seg.msg_id, def_tx_entry->rxm_ep->eager_limit,
+				def_tx_entry->sar_seg.msg_id, rxm_eager_limit,
 				def_tx_entry->sar_seg.next_seg_no, def_tx_entry->sar_seg.segs_cnt,
 				def_tx_entry->sar_seg.payload.data, def_tx_entry->sar_seg.flags,
 				def_tx_entry->sar_seg.payload.tag, def_tx_entry->sar_seg.op,
@@ -1478,7 +1477,7 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 			return ret;
 		}
 		def_tx_entry->sar_seg.next_seg_no++;
-		def_tx_entry->sar_seg.remain_len -= def_tx_entry->rxm_ep->eager_limit;
+		def_tx_entry->sar_seg.remain_len -= rxm_eager_limit;
 	}
 
 sar_finish:
@@ -2213,11 +2212,8 @@ static void rxm_ep_sar_init(struct rxm_ep *rxm_ep)
 {
 	size_t param;
 
-	/* The SAR initialization must be done after Eager is initialized */
-	assert(rxm_ep->eager_limit > 0);
-
 	if (!fi_param_get_size_t(&rxm_prov, "sar_limit", &param)) {
-		if (param <= rxm_ep->eager_limit) {
+		if (param <= rxm_eager_limit) {
 			FI_WARN(&rxm_prov, FI_LOG_CORE,
 				"Requsted SAR limit (%zd) less or equal "
 				"Eager limit (%zd). SAR limit won't be used. "
@@ -2225,14 +2221,14 @@ static void rxm_ep_sar_init(struct rxm_ep *rxm_ep)
 				"transmitted via Inject/Eager protocol. "
 				"Messages of size > SAR limit would be "
 				"transmitted via Rendezvous protocol\n",
-				param, rxm_ep->eager_limit);
-			param = rxm_ep->eager_limit;
+				param, rxm_eager_limit);
+			param = rxm_eager_limit;
 		}
 
 		rxm_ep->sar_limit = param;
 	} else {
 		size_t sar_limit = rxm_ep->msg_info->tx_attr->size *
-				   rxm_ep->eager_limit;
+				   rxm_eager_limit;
 
 		rxm_ep->sar_limit = (sar_limit > RXM_SAR_LIMIT) ?
 				    RXM_SAR_LIMIT : sar_limit;
@@ -2254,7 +2250,6 @@ static void rxm_ep_settings_init(struct rxm_ep *rxm_ep)
 	rxm_ep->rxm_mr_local = ofi_mr_local(rxm_ep->rxm_info);
 
 	rxm_ep->inject_limit = rxm_ep->msg_info->tx_attr->inject_size;
-	rxm_ep->eager_limit = rxm_ep->rxm_info->tx_attr->inject_size;
 
 	/* Favor a default buffered_min size that's small enough to be
 	 * injected by FI_EP_MSG provider */
@@ -2264,13 +2259,13 @@ static void rxm_ep_settings_init(struct rxm_ep *rxm_ep)
 		rxm_ep->buffered_min = MIN((rxm_ep->inject_limit -
 					(sizeof(struct rxm_pkt) +
 					 sizeof(struct rxm_rndv_hdr))),
-					   rxm_ep->eager_limit);
+					   rxm_eager_limit);
 
 	assert(!rxm_ep->min_multi_recv_size);
-	rxm_ep->min_multi_recv_size = rxm_ep->eager_limit;
+	rxm_ep->min_multi_recv_size = rxm_eager_limit;
 
 	assert(!rxm_ep->buffered_limit);
-	rxm_ep->buffered_limit = rxm_ep->eager_limit;
+	rxm_ep->buffered_limit = rxm_eager_limit;
 
 	rxm_ep_sar_init(rxm_ep);
 
@@ -2280,13 +2275,15 @@ static void rxm_ep_settings_init(struct rxm_ep *rxm_ep)
 		"\t\t Completions per progress: MSG - %zu\n"
 	        "\t\t Buffered min: %zu\n"
 	        "\t\t Min multi recv size: %zu\n"
-		"\t\t Protocol limits: MSG Inject - %zu, "
-				      "Eager - %zu, "
-				      "SAR - %zu\n",
+	        "\t\t FI_EP_MSG provider inject size: %zu\n"
+	        "\t\t rxm inject size: %zu\n"
+		"\t\t Protocol limits: Eager: %zu, "
+				      "SAR: %zu\n",
 		rxm_ep->msg_mr_local, rxm_ep->rxm_mr_local,
 		rxm_ep->comp_per_progress, rxm_ep->buffered_min,
 		rxm_ep->min_multi_recv_size, rxm_ep->inject_limit,
-		rxm_ep->eager_limit, rxm_ep->sar_limit);
+		rxm_ep->rxm_info->tx_attr->inject_size,
+		rxm_eager_limit, rxm_ep->sar_limit);
 }
 
 static int rxm_ep_txrx_res_open(struct rxm_ep *rxm_ep)

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -49,6 +49,7 @@
 size_t rxm_msg_tx_size		= 128;
 size_t rxm_msg_rx_size		= 128;
 size_t rxm_def_univ_size	= 256;
+size_t rxm_eager_limit		= RXM_BUF_SIZE - sizeof(struct rxm_pkt);
 
 char *rxm_proto_state_str[] = {
 	RXM_PROTO_STATES(OFI_STR)
@@ -176,16 +177,14 @@ static int rxm_init_info(void)
 
 	if (!fi_param_get_size_t(&rxm_prov, "buffer_size", &param)) {
 		if (param > sizeof(struct rxm_pkt)) {
-			rxm_info.tx_attr->inject_size = param;
+			rxm_eager_limit = param - sizeof(struct rxm_pkt);
 		} else {
 			FI_WARN(&rxm_prov, FI_LOG_CORE,
 				"Requested buffer size too small\n");
 			return -FI_EINVAL;
 		}
-	} else {
-		rxm_info.tx_attr->inject_size = RXM_BUF_SIZE;
 	}
-	rxm_info.tx_attr->inject_size -= sizeof(struct rxm_pkt);
+	rxm_info.tx_attr->inject_size = rxm_eager_limit;
 	rxm_util_prov.info = &rxm_info;
 	return 0;
 }
@@ -341,12 +340,15 @@ struct fi_provider rxm_prov = {
 RXM_INI
 {
 	fi_param_define(&rxm_prov, "buffer_size", FI_PARAM_SIZE_T,
-			"Defines the transmit buffer size / inject size. Messages"
-			" of size less than this would be transmitted via an "
-			"eager protocol and those above would be transmitted "
-			"via a rendezvous or SAR (Segmentation And Reassembly) "
-			"protocol. Transmit data would be copied up to this size "
-			"(default: ~16k).");
+			"Defines the transmit buffer size / inject size "
+			"(default: 16 KB). Eager protocol would be used to "
+			"transmit messages of size less than eager limit "
+			"(FI_OFI_RXM_BUFFER_SIZE - RxM header size (64 B)). "
+			"Any message whose size is greater than eager limit would"
+			" be transmitted via rendezvous or SAR "
+			"(Segmentation And Reassembly) protocol depending on "
+			"value of FI_OFI_RXM_SAR_LIMIT). Also, transmit data "
+			"would be copied up to eager limit.");
 
 	fi_param_define(&rxm_prov, "comp_per_progress", FI_PARAM_INT,
 			"Defines the maximum number of MSG provider CQ entries "
@@ -354,10 +356,13 @@ RXM_INI
 			"(RxM CQ read).");
 
 	fi_param_define(&rxm_prov, "sar_limit", FI_PARAM_SIZE_T,
-			"Set this environment variable to control the RxM SAR "
-			"(Segmentation And Reassembly) protocol. "
-			"Messages of size greater than this (default: 256 Kb) "
-			"would be transmitted via rendezvous protocol.");
+			"Set this environment variable to enable and control "
+			"RxM SAR  (Segmentation And Reassembly) protocol "
+			"(default: 256 KB). This value should be set greater than "
+			" eager limit (FI_OFI_RXM_BUFFER_SIZE - RxM protocol "
+			"header size (64 B)) for SAR to take effect. Messages "
+			"of size greater than this would be transmitted via "
+			"rendezvous protocol.");
 
 	fi_param_define(&rxm_prov, "use_srx", FI_PARAM_BOOL,
 			"Set this enivronment variable to control the RxM "


### PR DESCRIPTION
This PR cherry-picks the eager limit fix from #4874 without the API changes. This also includes some harmless minor patches to avoid merge conflicts.