### PR TITLE
prov/verbs: Add missing include for S_IWUSR

### DIFF
--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -29,8 +29,11 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 #include "config.h"
 #include "fi_verbs.h"
+#include <sys/stat.h>
+
 
 /* Domain XRC INI QP RBTree key */
 struct fi_ibv_ini_conn_key {


### PR DESCRIPTION
Problem reported by Yuri in PR #4861

Signed-off-by: Sean Hefty <sean.hefty@intel.com>