### PR TITLE
prov/tcp: adding a port_range variables

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -75,9 +75,12 @@
 #define MAX_EPOLL_EVENTS	100
 #define STAGE_BUF_SIZE		512
 
+#define TCPX_PORT_MAX_RANGE	(USHRT_MAX)
+
 extern struct fi_provider	tcpx_prov;
 extern struct util_prov		tcpx_util_prov;
 extern struct fi_info		tcpx_info;
+extern struct tcpx_port_range	port_range;
 struct tcpx_xfer_entry;
 struct tcpx_ep;
 
@@ -106,6 +109,11 @@ struct tcpx_cm_context {
 	enum tcpx_cm_event_type	type;
 	size_t			cm_data_sz;
 	char			cm_data[TCPX_MAX_CM_DATA_SIZE];
+};
+
+struct tcpx_port_range {
+	int high;
+	int low;
 };
 
 struct tcpx_conn_handle {
@@ -240,6 +248,8 @@ int tcpx_create_fabric(struct fi_fabric_attr *attr,
 
 int tcpx_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		    struct fid_pep **pep, void *context);
+
+int tcpx_set_port_range(void);
 
 int tcpx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		     struct fid_domain **domain, void *context);

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -39,6 +39,7 @@
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <ofi_util.h>
+#include <stdlib.h>
 
 #if HAVE_GETIFADDRS
 static void tcpx_getinfo_ifs(struct fi_info **info)
@@ -116,6 +117,19 @@ static int tcpx_getinfo(uint32_t version, const char *node, const char *service,
 	return 0;
 }
 
+struct tcpx_port_range port_range = {
+	.low  = 0,
+	.high = 0,
+};
+
+static void tcpx_init_env(void)
+{
+	srand(getpid());
+
+	fi_param_get_int(&tcpx_prov, "port_high_range", &port_range.high);
+	fi_param_get_int(&tcpx_prov, "port_low_range", &port_range.low);
+}
+
 static void fi_tcp_fini(void)
 {
 	/* empty as of now */
@@ -137,6 +151,14 @@ TCP_INI
 #endif
 	fi_param_define(&tcpx_prov, "iface", FI_PARAM_STRING,
 			"Specify interface name");
+
+	fi_param_define(&tcpx_prov,"port_low_range", FI_PARAM_INT,
+			"define port low range");
+
+	fi_param_define(&tcpx_prov,"port_high_range", FI_PARAM_INT,
+			"define port high range");
+
+	tcpx_init_env();
 
 	return &tcpx_prov;
 }


### PR DESCRIPTION
Added options `FI_TCP_PORT_HIGH_RANGE`  and `FI_TCP_PORT_LOW_RANGE` in tcp provider in order to use a specific range of ports for launching applications.
 
Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>