### PR TITLE
[v1.7.x] /prov/tcp, /prov/sockets Cherry picked few fixes 

### DIFF
--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -785,6 +785,7 @@ static int sock_ep_cm_accept(struct fid_ep *ep, const void *param, size_t paraml
 	sock_ep_cm_monitor_handle(cm_head, handle, FI_EPOLL_IN);
 	sock_ep_enable(ep);
 
+	memset(&cm_entry, 0, sizeof(cm_entry));
 	cm_entry.fid = &handle->ep->ep.fid;
 	SOCK_LOG_DBG("reporting FI_CONNECTED\n");
 	if (sock_eq_report_event(ep_attr->eq, FI_CONNECTED, &cm_entry,

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -612,9 +612,9 @@ err:
 	handle->ep->attr->info.handle = NULL;
 	/* Register handle for later deletion */
 	handle->state = SOCK_CONN_HANDLE_DELETED;
-	fastlock_acquire(&cm_head->signal_lock);
+	/* `cm_head::signal_lock` has already been held
+	 * in `sock_ep_cm_thread` function */
 	sock_ep_cm_add_to_msg_list(cm_head, handle);
-	fastlock_release(&cm_head->signal_lock);
 out:
 	free(param);
 	free(cm_entry);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -113,7 +113,7 @@ struct tcpx_conn_handle {
 
 struct tcpx_pep {
 	struct util_pep 	util_pep;
-	struct fi_info		info;
+	struct fi_info		*info;
 	SOCKET			sock;
 	struct tcpx_cm_context	cm_ctx;
 };

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -246,6 +246,7 @@ void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
 			     struct tcpx_xfer_entry *xfer_entry);
 void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 			   struct tcpx_xfer_entry *xfer_entry);
+void tcpx_rx_msg_release(struct tcpx_xfer_entry *rx_entry);
 struct tcpx_xfer_entry *
 tcpx_srx_dequeue(struct tcpx_rx_ctx *srx_ctx);
 

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -244,6 +244,8 @@ struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq,
 					      enum tcpx_xfer_op_codes type);
 void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
 			     struct tcpx_xfer_entry *xfer_entry);
+void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
+			   struct tcpx_xfer_entry *xfer_entry);
 
 void tcpx_progress(struct util_ep *util_ep);
 void tcpx_ep_progress(struct tcpx_ep *ep);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -246,6 +246,9 @@ void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
 			     struct tcpx_xfer_entry *xfer_entry);
 void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 			   struct tcpx_xfer_entry *xfer_entry);
+struct tcpx_xfer_entry *
+tcpx_srx_dequeue(struct tcpx_rx_ctx *srx_ctx);
+
 
 void tcpx_progress(struct util_ep *util_ep);
 void tcpx_ep_progress(struct tcpx_ep *ep);

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -284,7 +284,7 @@ static void server_recv_connreq(struct util_wait *wait,
 		goto err1;
 
 	cm_entry->fid = &handle->pep->util_pep.pep_fid.fid;
-	cm_entry->info = fi_dupinfo(&handle->pep->info);
+	cm_entry->info = fi_dupinfo(handle->pep->info);
 	if (!cm_entry->info)
 		goto err2;
 

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -267,6 +267,7 @@ static void server_recv_connreq(struct util_wait *wait,
 	struct tcpx_conn_handle *handle;
 	struct fi_eq_cm_entry *cm_entry;
 	struct ofi_ctrl_hdr conn_req;
+	socklen_t len;
 	int ret;
 
 	assert(cm_ctx->fid->fclass == FI_CLASS_CONNREQ);
@@ -287,6 +288,15 @@ static void server_recv_connreq(struct util_wait *wait,
 	cm_entry->info = fi_dupinfo(handle->pep->info);
 	if (!cm_entry->info)
 		goto err2;
+
+	len = cm_entry->info->dest_addrlen = handle->pep->info->src_addrlen;
+	cm_entry->info->dest_addr = malloc(len);
+	if (!cm_entry->info->dest_addr)
+		goto err3;
+
+	ret = ofi_getpeername(handle->conn_fd, cm_entry->info->dest_addr, &len);
+	if (ret)
+		goto err3;
 
 	cm_entry->info->handle = &handle->handle;
 	memcpy(cm_entry->data, cm_ctx->cm_data, cm_ctx->cm_data_sz);

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -51,6 +51,7 @@ static int tcpx_srx_ctx_close(struct fid *fid)
 		util_buf_release(srx_ctx->buf_pool, xfer_entry);
 	}
 
+	util_buf_pool_destroy(srx_ctx->buf_pool);
 	fastlock_destroy(&srx_ctx->lock);
 	free(srx_ctx);
 	return FI_SUCCESS;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -958,7 +958,12 @@ static int tcpx_pep_reject(struct fid_pep *pep, fid_t handle,
 				       paramlen, MSG_NOSIGNAL);
 
 	ofi_shutdown(tcpx_handle->conn_fd, SHUT_RDWR);
-	return ofi_close_socket(tcpx_handle->conn_fd);
+	ret = ofi_close_socket(tcpx_handle->conn_fd);
+	if (ret)
+		return ret;
+
+	free(tcpx_handle);
+	return FI_SUCCESS;
 }
 
 static struct fi_ops_cm tcpx_pep_cm_ops = {

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -608,6 +608,21 @@ static struct fi_ops_cm tcpx_cm_ops = {
 	.join = fi_no_join,
 };
 
+void tcpx_rx_msg_release(struct tcpx_xfer_entry *rx_entry)
+{
+	struct tcpx_cq *tcpx_cq;
+
+	assert(rx_entry->msg_hdr.hdr.op_data == TCPX_OP_MSG_RECV);
+
+	if (rx_entry->ep->srx_ctx) {
+		tcpx_srx_xfer_release(rx_entry->ep->srx_ctx, rx_entry);
+	} else {
+		tcpx_cq = container_of(rx_entry->ep->util_ep.rx_cq,
+				       struct tcpx_cq, util_cq);
+		tcpx_xfer_entry_release(tcpx_cq, rx_entry);
+	}
+}
+
 static void tcpx_ep_tx_rx_queues_release(struct tcpx_ep *ep)
 {
 	struct slist_entry *entry;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -527,11 +527,11 @@ static int tcpx_pep_sock_create(struct tcpx_pep *pep)
 {
 	int ret, af;
 
-	switch (pep->info.addr_format) {
+	switch (pep->info->addr_format) {
 	case FI_SOCKADDR:
 	case FI_SOCKADDR_IN:
 	case FI_SOCKADDR_IN6:
-		af = ((struct sockaddr *)pep->info.src_addr)->sa_family;
+		af = ((struct sockaddr *)pep->info->src_addr)->sa_family;
 		break;
 	default:
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
@@ -552,8 +552,8 @@ static int tcpx_pep_sock_create(struct tcpx_pep *pep)
 		goto err;
 	}
 
-	ret = bind(pep->sock, pep->info.src_addr,
-		   (socklen_t) pep->info.src_addrlen);
+	ret = bind(pep->sock, pep->info->src_addr,
+		   (socklen_t) pep->info->src_addrlen);
 	if (ret) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"failed to bind listener: %s\n",
@@ -841,6 +841,7 @@ static int tcpx_pep_fi_close(struct fid *fid)
 
 	ofi_close_socket(pep->sock);
 	ofi_pep_close(&pep->util_pep);
+	fi_freeinfo(pep->info);
 	free(pep);
 	return 0;
 }
@@ -886,16 +887,16 @@ static int tcpx_pep_setname(fid_t fid, void *addr, size_t addrlen)
 		tcpx_pep->sock = INVALID_SOCKET;
 	}
 
-	if (tcpx_pep->info.src_addr) {
-		free(tcpx_pep->info.src_addr);
-		tcpx_pep->info.src_addrlen = 0;
+	if (tcpx_pep->info->src_addr) {
+		free(tcpx_pep->info->src_addr);
+		tcpx_pep->info->src_addrlen = 0;
 	}
 
 
-	tcpx_pep->info.src_addr = mem_dup(addr, addrlen);
-	if (!tcpx_pep->info.src_addr)
+	tcpx_pep->info->src_addr = mem_dup(addr, addrlen);
+	if (!tcpx_pep->info->src_addr)
 		return -FI_ENOMEM;
-	tcpx_pep->info.src_addrlen = addrlen;
+	tcpx_pep->info->src_addrlen = addrlen;
 
 	return tcpx_pep_sock_create(tcpx_pep);
 }
@@ -1034,8 +1035,10 @@ int tcpx_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	_pep->util_pep.pep_fid.cm = &tcpx_pep_cm_ops;
 	_pep->util_pep.pep_fid.ops = &tcpx_pep_ops;
 
+	_pep->info = fi_dupinfo(info);
+	if (!_pep->info)
+		goto err2;
 
-	_pep->info = *info;
 	_pep->cm_ctx.fid = &_pep->util_pep.pep_fid.fid;
 	_pep->cm_ctx.type = SERVER_SOCK_ACCEPT;
 	_pep->cm_ctx.cm_data_sz = 0;
@@ -1046,9 +1049,11 @@ int tcpx_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	if (info->src_addr) {
 		ret = tcpx_pep_sock_create(_pep);
 		if (ret)
-			goto err2;
+			goto err3;
 	}
 	return FI_SUCCESS;
+err3:
+	fi_freeinfo(_pep->info);
 err2:
 	ofi_pep_close(&_pep->util_pep);
 err1:

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -128,7 +128,7 @@ done:
 
 static int tcpx_prepare_rx_entry_resp(struct tcpx_xfer_entry *rx_entry)
 {
-	struct tcpx_cq *tcpx_rx_cq, *tcpx_tx_cq;
+	struct tcpx_cq *tcpx_tx_cq;
 	struct tcpx_xfer_entry *resp_entry;
 
 	tcpx_tx_cq = container_of(rx_entry->ep->util_ep.tx_cq,
@@ -153,10 +153,7 @@ static int tcpx_prepare_rx_entry_resp(struct tcpx_xfer_entry *rx_entry)
 
 	tcpx_cq_report_completion(rx_entry->ep->util_ep.rx_cq,
 				  rx_entry, 0);
-	slist_remove_head(&rx_entry->ep->rx_queue);
-	tcpx_rx_cq = container_of(rx_entry->ep->util_ep.rx_cq,
-			       struct tcpx_cq, util_cq);
-	tcpx_xfer_entry_release(tcpx_rx_cq, rx_entry);
+	tcpx_rx_msg_release(rx_entry);
 	return FI_SUCCESS;
 }
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -226,9 +226,7 @@ static int process_srx_entry(struct tcpx_xfer_entry *rx_entry)
 		rx_entry->ep->cur_rx_entry = NULL;
 	}
 
-	fastlock_acquire(&rx_entry->ep->srx_ctx->lock);
-	util_buf_release(rx_entry->ep->srx_ctx->buf_pool, rx_entry);
-	fastlock_release(&rx_entry->ep->srx_ctx->lock);
+	tcpx_srx_xfer_release(rx_entry->ep->srx_ctx, rx_entry);
 	return FI_SUCCESS;
 }
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -501,7 +501,11 @@ int tcpx_get_rx_entry_op_read_req(struct tcpx_ep *tcpx_ep)
 	struct tcpx_cq *tcpx_cq;
 	int ret;
 
-	tcpx_cq = container_of(tcpx_ep->util_ep.rx_cq,
+	/* The read request will generate a response once done,
+	 * so the xfer_entry will become a transmit and returned
+	 * to the tx cq buffer pool.
+	 */
+	tcpx_cq = container_of(tcpx_ep->util_ep.tx_cq,
 			       struct tcpx_cq, util_cq);
 
 	rx_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_REMOTE_READ);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -476,7 +476,7 @@ int tcpx_get_rx_entry_op_msg(struct tcpx_ep *tcpx_ep)
 			"posted rx buffer size is not big enough\n");
 		tcpx_cq_report_completion(rx_entry->ep->util_ep.rx_cq,
 					  rx_entry, -ret);
-		tcpx_xfer_entry_release(tcpx_cq, rx_entry);
+		tcpx_rx_msg_release(rx_entry);
 		return ret;
 	}
 

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -59,6 +59,22 @@ void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 	fastlock_release(&srx_ctx->lock);
 }
 
+struct tcpx_xfer_entry *
+tcpx_srx_dequeue(struct tcpx_rx_ctx *srx_ctx)
+{
+	struct tcpx_xfer_entry *xfer_entry;
+
+	fastlock_acquire(&srx_ctx->lock);
+	if (!slist_empty(&srx_ctx->rx_queue)) {
+		xfer_entry = container_of(slist_remove_head(&srx_ctx->rx_queue),
+					  struct tcpx_xfer_entry, entry);
+	} else {
+		xfer_entry = NULL;
+	}
+	fastlock_release(&srx_ctx->lock);
+	return xfer_entry;
+}
+
 static ssize_t tcpx_srx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 				uint64_t flags)
 {


### PR DESCRIPTION
The following original commits were modified to resolve conflicts
3cc855f prov/tcp: Remove duplicate rx_queue removal
f05a18b prov/tcp: Fix returning srx xfer_entry to cq buffer pool
 9c0ff17 prov/tcp: set cm_entry->info->dest_addr when writing FI_CONNREQ event
