### PR TITLE
prov/verbs, rxm: avoid CQ overrun and empty receive queue

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -174,6 +174,12 @@ The data transfer API may return -FI_EAGAIN during on-demand connection setup
 of the core provider FI_MSG_EP. See [`fi_msg`(3)](fi_msg.3.html) for a detailed
 description of handling FI_EAGAIN.
 
+# Troubleshooting / Known issues
+
+If an RxM endpoint is expected to communicate with more peers than the default
+value of FI_UNIVERSE_SIZE (256) CQ overruns can happen. To avoid this set a
+higher value for FI_UNIVERSE_SIZE. CQ overrun can make a MSG endpoint unusable.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -253,6 +253,12 @@ When running an app over verbs provider with Valgrind, there may be reports of
 memory leak in functions from dependent libraries (e.g. libibverbs, librdmacm).
 These leaks are safe to ignore.
 
+The provider protects CQ overruns that may happen because more TX operations were
+posted to endpoints than CQ size. On the receive side, it isn't expected to
+overrun the CQ. In case it happens the application developer should take care
+not to post excess receives without draining the CQ. CQ overruns can make the
+MSG endpoints unusable.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -734,7 +734,7 @@ void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 void rxm_ep_progress(struct util_ep *util_ep);
 void rxm_ep_do_progress(struct util_ep *util_ep);
 
-int rxm_ep_prepost_buf(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
+int rxm_msg_ep_prepost_recv(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
 
 int rxm_ep_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,
@@ -1022,10 +1022,22 @@ rxm_tx_buf_alloc(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
 }
 
 
-static inline struct rxm_rx_buf *rxm_rx_buf_alloc(struct rxm_ep *rxm_ep)
+static inline struct rxm_rx_buf *
+rxm_rx_buf_alloc(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep, uint8_t repost)
 {
-	return (struct rxm_rx_buf *)
+	struct rxm_rx_buf *rx_buf =
 		ofi_buf_alloc(rxm_ep->buf_pools[RXM_BUF_POOL_RX].pool);
+	if (OFI_LIKELY((long int)rx_buf)) {
+		assert(rx_buf->ep == rxm_ep);
+		rx_buf->hdr.state = RXM_RX;
+		rx_buf->msg_ep = msg_ep;
+		rx_buf->repost = repost;
+
+		if (!rxm_ep->srx_ctx)
+			rx_buf->conn = container_of(msg_ep->fid.context,
+						    struct rxm_conn, handle);
+	}
+	return rx_buf;
 }
 
 static inline void

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -838,7 +838,7 @@ static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 	}
 
 	if (!rxm_ep->srx_ctx) {
-		ret = rxm_ep_prepost_buf(rxm_ep, msg_ep);
+		ret = rxm_msg_ep_prepost_recv(rxm_ep, msg_ep);
 		if (ret)
 			goto err;
 	}

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2328,11 +2328,11 @@ static int rxm_ep_ctrl(struct fid *fid, int command, void *arg)
 			return ret;
 
 		if (rxm_ep->srx_ctx) {
-			ret = rxm_ep_prepost_buf(rxm_ep, rxm_ep->srx_ctx);
+			ret = rxm_msg_ep_prepost_recv(rxm_ep, rxm_ep->srx_ctx);
 			if (ret) {
 				rxm_cmap_free(rxm_ep->cmap);
 				FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-					"Unable to prepost recv bufs\n");
+					"unable to prepost recv bufs\n");
 				goto err;
 			}
 		}


### PR DESCRIPTION
The Infiniband spec doesn't say if the send queue space should be freed after
a WR is processed. Based on the implementation, we may need to track available
space in CQ to avoid overflowing it (which renders any QPs bound to it unusable).
Use an atomic counter to track available space and return -FI_EAGAIN on
ibv_post_send when we don't have credits.


@mmarcini, this PR updates libfabric verbs provider to avoid CQ overrun.