### PR TITLE
core: Support layered provider names in FI_PROVIDER

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -64,6 +64,7 @@
 extern "C" {
 #endif
 
+#define OFI_GETINFO_INTERNAL	(1ULL << 58)
 #define OFI_CORE_PROV_ONLY	(1ULL << 59)
 
 #define sizeof_field(type, field) sizeof(((type *)0)->field)

--- a/prov/mrail/src/mrail_init.c
+++ b/prov/mrail/src/mrail_init.c
@@ -165,7 +165,7 @@ int mrail_get_core_info(uint32_t version, const char *node, const char *service,
 		FI_DBG(&mrail_prov, FI_LOG_CORE,
 		       "--- Begin fi_getinfo for rail: %zd ---\n", i);
 
-		ret = fi_getinfo(version, NULL, NULL, 0, core_hints, &info);
+		ret = fi_getinfo(version, NULL, NULL, OFI_GETINFO_INTERNAL, core_hints, &info);
 
 		FI_DBG(&mrail_prov, FI_LOG_CORE,
 		       "--- End fi_getinfo for rail: %zd ---\n", i);


### PR DESCRIPTION
The environment variable FI_PROVIDER is a comma separated list of provider
names that are allowed to be used. Previously layered provider names were
not supported and a definition such as FI_PROVIDER="verbs;ofi_rxm" would
eliminate all providers because any core provider would fail to register
due to not matching the name "verbs;ofi_rxm".

This patch extends the FI_PROVIDER usage to allow layered provider names
while remain fully backward compatible with previous implementation in all
other aspects.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>