### PR TITLE
prov/rxm: don't access tx_cq when app doesn't bind it with endpoint

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -976,6 +976,7 @@ rxm_ep_prepare_tx(struct rxm_ep *rxm_ep, fi_addr_t dest_addr,
 {
 	ssize_t ret;
 
+	assert(rxm_ep->util_ep.tx_cq);
 	*rxm_conn = (struct rxm_conn *)rxm_cmap_acquire_handle(rxm_ep->cmap,
 							       dest_addr);
 	if (OFI_UNLIKELY(!*rxm_conn))

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1151,7 +1151,7 @@ static int rxm_conn_handle_notify(struct fi_eq_entry *eq_entry)
 
 static void rxm_conn_wake_up_wait_obj(struct rxm_ep *rxm_ep)
 {
-	if (rxm_ep->util_ep.tx_cq->wait)
+	if (rxm_ep->util_ep.tx_cq && rxm_ep->util_ep.tx_cq->wait)
 		util_cq_signal(rxm_ep->util_ep.tx_cq);
 	if (rxm_ep->util_ep.tx_cntr && rxm_ep->util_ep.tx_cntr->wait)
 		util_cntr_signal(rxm_ep->util_ep.tx_cntr);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -745,6 +745,7 @@ rxm_ep_recv_common(struct rxm_ep *rxm_ep, const struct iovec *iov,
 {
 	ssize_t ret;
 
+	assert(rxm_ep->util_ep.rx_cq);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 	ret = rxm_ep_post_recv(rxm_ep, iov, desc, count, src_addr,
 			       tag, ignore, context, op_flags, recv_queue);
@@ -763,6 +764,7 @@ rxm_ep_recv_common_flags(struct rxm_ep *rxm_ep, const struct iovec *iov,
 	struct rxm_rx_buf *rx_buf;
 	ssize_t ret = 0;
 
+	assert(rxm_ep->util_ep.rx_cq);
 	assert(count <= rxm_ep->rxm_info->rx_attr->iov_limit);
 	assert(!(flags & FI_PEEK) ||
 		(recv_queue->type == RXM_RECV_QUEUE_TAGGED));


### PR DESCRIPTION
Also add some asserts to check for tx_cq/rx_cq in tx/rx calls.