### PR TITLE
prov/GNI: add fallback when no huge pages

### DIFF
--- a/prov/gni/include/gnix_mbox_allocator.h
+++ b/prov/gni/include/gnix_mbox_allocator.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -100,6 +101,8 @@ struct gnix_slab {
  * @var mbox_size	Size per each mailbox.
  * @var mpmmap		Mailboxes per mmap slab.
  * @var slab_list	List of slab objects.
+ *
+ * @note  If HUGETLBFS is not available, memory is allocated via ANON mmap.
  */
 struct gnix_mbox_alloc_handle {
 	struct gnix_nic *nic_handle;
@@ -190,4 +193,9 @@ int _gnix_mbox_free(struct gnix_mbox *ptr);
  */
 extern ofi_atomic32_t file_id_counter;
 
+/*
+ * safety valve for disabling mbox allocator fallback to base pages
+ */
+
+extern bool gnix_mbox_alloc_allow_fallback;
 #endif /* _GNIX_MBOX_ALLOCATOR_ */

--- a/prov/gni/src/gnix_fabric.c
+++ b/prov/gni/src/gnix_fabric.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -62,6 +63,7 @@
 #include "gnix_nameserver.h"
 #include "gnix_wait.h"
 #include "gnix_xpmem.h"
+#include "gnix_mbox_allocator.h"
 
 /* check if only one bit of a set is enabled, when one is required */
 #define IS_EXCLUSIVE(x) \
@@ -774,6 +776,8 @@ GNI_INI
 
 	if (getenv("GNIX_DISABLE_XPMEM") != NULL)
 		gnix_xpmem_disabled = true;
+	if (getenv("GNIX_MBOX_FALLBACK_DISABLE") != NULL)
+		gnix_mbox_alloc_allow_fallback = false;
 
 	return (provider);
 }


### PR DESCRIPTION
There may be cases where huge pages are not available
on a node type where a libfabric application may
wish to use the GNI provider.

This commit provides a fallback to use base pages.
The fallback can be disabled via an environment variable:

export GNIX_MBOX_FALLBACK_DISABLE=1

Fixes #4911

Signed-off-by: Howard Pritchard <howardp@lanl.gov>