### PR TITLE
prov/mrail: Always generate lower level send completions

### DIFF
--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -377,7 +377,7 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	       " dest_addr: 0x%" PRIx64 "  seq: %d on rail: %d\n",
 	       len, dest_addr, peer_info->seq_no - 1, i);
 
-	ret = fi_sendmsg(mrail_ep->rails[i].ep, &msg, flags);
+	ret = fi_sendmsg(mrail_ep->rails[i].ep, &msg, flags | FI_COMPLETION);
 	if (ret) {
 		FI_WARN(&mrail_prov, FI_LOG_EP_DATA,
 			"Unable to fi_sendmsg on rail: %" PRIu32 "\n", i);
@@ -436,7 +436,7 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	       " dest_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 " seq: %d"
 	       " on rail: %d\n", len, dest_addr, tag, peer_info->seq_no - 1, i);
 
-	ret = fi_sendmsg(mrail_ep->rails[i].ep, &msg, flags);
+	ret = fi_sendmsg(mrail_ep->rails[i].ep, &msg, flags | FI_COMPLETION);
 	if (ret) {
 		FI_WARN(&mrail_prov, FI_LOG_EP_DATA,
 			"Unable to fi_sendmsg on rail: %" PRIu32 "\n", i);


### PR DESCRIPTION
The tx_buf allocated for a message send is freed when the lower level
completion is processed. This should not affect the final completion
generation because that is determined by the flags stored in tx_buf.

This fixes the following assertion failure with debugging build:

"../prov/util/src/util_buf.c:239: ofi_bufpool_destroy: Assertion
`(pool->attr.flags & OFI_BUFPOOL_NO_TRACK) || (buf_region->use_cnt == 0)'
failed."

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>