### PR TITLE
prov/rxm: limit outstanding rendezvous protocol requests

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -496,6 +496,7 @@ struct rxm_tx_rndv_buf {
 	uint64_t flags;
 	struct fid_mr *mr[RXM_IOV_LIMIT];
 	uint8_t count;
+	struct rxm_conn *conn;
 
 	/* Must stay at bottom */
 	struct rxm_pkt pkt;
@@ -700,6 +701,9 @@ struct rxm_conn {
 	/* This is saved MSG EP fid, that hasn't been closed during
 	 * handling of CONN_RECV in RXM_CMAP_CONNREQ_SENT for passive side */
 	struct fid_ep *saved_msg_ep;
+
+	/* Limit RNDV sends based on peer rx queue size to avoid increased
+	 * memory usage at peer */
 	uint32_t rndv_tx_credits;
 };
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -239,12 +239,14 @@ union rxm_cm_data {
 		uint8_t op_version;
 		uint16_t port;
 		uint8_t padding[2];
-		uint64_t eager_size;
+		uint32_t eager_size;
+		uint32_t rx_size;
 		uint64_t client_conn_id;
 	} connect;
 
 	struct _accept {
 		uint64_t server_conn_id;
+		uint32_t rx_size;
 	} accept;
 
 	struct _reject {
@@ -258,9 +260,6 @@ int rxm_cmap_update(struct rxm_cmap *cmap, const void *addr, fi_addr_t fi_addr);
 
 void rxm_cmap_process_conn_notify(struct rxm_cmap *cmap,
 				  struct rxm_cmap_handle *handle);
-void rxm_cmap_process_connect(struct rxm_cmap *cmap,
-			      struct rxm_cmap_handle *handle,
-			      uint64_t *remote_key);
 void rxm_cmap_process_reject(struct rxm_cmap *cmap,
 			     struct rxm_cmap_handle *handle,
 			     enum rxm_cmap_reject_reason cm_reject_reason);
@@ -701,6 +700,7 @@ struct rxm_conn {
 	/* This is saved MSG EP fid, that hasn't been closed during
 	 * handling of CONN_RECV in RXM_CMAP_CONNREQ_SENT for passive side */
 	struct fid_ep *saved_msg_ep;
+	uint32_t rndv_tx_credits;
 };
 
 extern struct fi_provider rxm_prov;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -166,15 +166,29 @@ enum rxm_cmap_signal {
 	RXM_CMAP_EXIT,
 };
 
+#define RXM_CM_STATES(FUNC)		\
+	FUNC(RXM_CMAP_IDLE),		\
+	FUNC(RXM_CMAP_CONNREQ_SENT),	\
+	FUNC(RXM_CMAP_CONNREQ_RECV),	\
+	FUNC(RXM_CMAP_ACCEPT),		\
+	FUNC(RXM_CMAP_CONNECTED_NOTIFY),\
+	FUNC(RXM_CMAP_CONNECTED),	\
+	FUNC(RXM_CMAP_SHUTDOWN),	\
+
 enum rxm_cmap_state {
-	RXM_CMAP_IDLE,
-	RXM_CMAP_CONNREQ_SENT,
-	RXM_CMAP_CONNREQ_RECV,
-	RXM_CMAP_ACCEPT,
-	RXM_CMAP_CONNECTED_NOTIFY,
-	RXM_CMAP_CONNECTED,
-	RXM_CMAP_SHUTDOWN,
+	RXM_CM_STATES(OFI_ENUM_VAL)
 };
+
+extern char *rxm_cm_state_str[];
+
+#define RXM_CM_UPDATE_STATE(handle, new_state)				\
+	do {								\
+		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "[CM] handle: "	\
+		       "%p %s -> %s\n",	handle,				\
+		       rxm_cm_state_str[handle->state],			\
+		       rxm_cm_state_str[new_state]);			\
+		handle->state = new_state;				\
+	} while (0)
 
 struct rxm_cmap_handle {
 	struct rxm_cmap *cmap;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -449,20 +449,22 @@ void rxm_cmap_process_conn_notify(struct rxm_cmap *cmap,
 /* Caller must hold cmap->lock */
 void rxm_cmap_process_connect(struct rxm_cmap *cmap,
 			      struct rxm_cmap_handle *handle,
-			      uint64_t *remote_key)
+			      union rxm_cm_data *cm_data)
 {
-	struct rxm_conn *rxm_conn;
+	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
 	       "Processing connect for handle: %p\n", handle);
+	if (cm_data) {
+		assert(handle->state == RXM_CMAP_CONNREQ_SENT);
+		handle->remote_key = cm_data->accept.server_conn_id;
+		rxm_conn->rndv_tx_credits = cm_data->accept.rx_size;
+	} else {
+		assert(handle->state == RXM_CMAP_CONNREQ_RECV);
+	}
 	handle->state = RXM_CMAP_CONNECTED_NOTIFY;
-	if (remote_key)
-		handle->remote_key = *remote_key;
-
 	/* Set the remote key to the inject packets */
 	if (cmap->ep->domain->threading != FI_THREAD_SAFE) {
-		rxm_conn = container_of(handle, struct rxm_conn, handle);
-
 		rxm_conn->inject_pkt->ctrl_hdr.conn_id = rxm_conn->handle.remote_key;
 		rxm_conn->inject_data_pkt->ctrl_hdr.conn_id = rxm_conn->handle.remote_key;
 		rxm_conn->tinject_pkt->ctrl_hdr.conn_id = rxm_conn->handle.remote_key;
@@ -1046,7 +1048,7 @@ rxm_conn_verify_cm_data(union rxm_cm_data *remote_cm_data,
 	}
 	if (remote_cm_data->connect.eager_size != local_cm_data->connect.eager_size) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "cm data eager_size mismatch "
-			"(local: %" PRIu64 ", remote:  %" PRIu64 ")\n",
+			"(local: %" PRIu32 ", remote:  %" PRIu32 ")\n",
 			local_cm_data->connect.eager_size,
 			remote_cm_data->connect.eager_size);
 		goto err;
@@ -1054,6 +1056,18 @@ rxm_conn_verify_cm_data(union rxm_cm_data *remote_cm_data,
 	return FI_SUCCESS;
 err:
 	return -FI_EINVAL;
+}
+
+static size_t rxm_conn_get_rx_size(struct rxm_ep *rxm_ep,
+				   struct fi_info *msg_info)
+{
+	/* TODO add env variable to tune the value for shared context case */
+	if (msg_info->ep_attr->rx_ctx_cnt == FI_SHARED_CONTEXT)
+		return MAX(MIN(16, msg_info->rx_attr->size),
+			   (msg_info->rx_attr->size /
+			    rxm_ep->util_ep.av->count));
+	else
+		return msg_info->rx_attr->size;
 }
 
 static int
@@ -1080,6 +1094,9 @@ rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 	struct sockaddr_storage remote_pep_addr;
 	int ret, rv;
 
+	assert(sizeof(uint32_t) == sizeof(cm_data.accept.rx_size));
+	assert(msg_info->rx_attr->size <= (uint32_t)-1);
+
 	if (rxm_conn_verify_cm_data(remote_cm_data, &cm_data)) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 			"CM data mismatch was detected\n");
@@ -1099,15 +1116,18 @@ rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 	rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	rxm_conn->handle.remote_key = remote_cm_data->connect.client_conn_id;
+	rxm_conn->rndv_tx_credits = remote_cm_data->connect.rx_size;
+	assert(rxm_conn->rndv_tx_credits);
 
 	ret = rxm_msg_ep_open(rxm_ep, msg_info, rxm_conn, handle);
 	if (ret)
 		goto err2;
 
 	cm_data.accept.server_conn_id = rxm_conn->handle.key;
+	cm_data.accept.rx_size = rxm_conn_get_rx_size(rxm_ep, msg_info);
 
 	ret = fi_accept(rxm_conn->msg_ep, &cm_data.accept.server_conn_id,
-			sizeof(cm_data.accept.server_conn_id));
+			sizeof(cm_data.accept));
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_FABRIC,
 			"Unable to accept incoming connection\n");
@@ -1227,7 +1247,7 @@ rxm_conn_handle_event(struct rxm_ep *rxm_ep, struct rxm_msg_eq_entry *entry)
 		rxm_cmap_process_connect(rxm_ep->cmap,
 					 entry->cm_entry.fid->context,
 					 ((entry->rd - sizeof(entry->cm_entry)) ?
-					  &cm_data->accept.server_conn_id : NULL));
+					  cm_data : NULL));
 		rxm_conn_wake_up_wait_obj(rxm_ep);
 		rxm_ep->cmap->release(&rxm_ep->cmap->lock);
 		break;
@@ -1430,6 +1450,11 @@ rxm_conn_connect(struct util_ep *util_ep, struct rxm_cmap_handle *handle,
 		},
 	};
 
+	assert(sizeof(uint32_t) == sizeof(cm_data.connect.eager_size));
+	assert(sizeof(uint32_t) == sizeof(cm_data.connect.rx_size));
+	assert(rxm_ep->rxm_info->tx_attr->inject_size <= (uint32_t)-1);
+	assert(rxm_ep->msg_info->rx_attr->size <= (uint32_t)-1);
+
 	free(rxm_ep->msg_info->dest_addr);
 	rxm_ep->msg_info->dest_addrlen = rxm_ep->msg_info->src_addrlen;
 
@@ -1447,6 +1472,8 @@ rxm_conn_connect(struct util_ep *util_ep, struct rxm_cmap_handle *handle,
 	ret = rxm_prepare_cm_data(rxm_ep->msg_pep, &rxm_conn->handle, &cm_data);
 	if (ret)
 		goto err;
+
+	cm_data.connect.rx_size = rxm_conn_get_rx_size(rxm_ep, rxm_ep->msg_info);
 
 	ret = fi_connect(rxm_conn->msg_ep, rxm_ep->msg_info->dest_addr,
 			 &cm_data, sizeof(cm_data));

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -316,6 +316,7 @@ static int rxm_rndv_tx_finish(struct rxm_ep *rxm_ep, struct rxm_tx_rndv_buf *tx_
 
 	RXM_LOG_STATE_TX(FI_LOG_CQ, tx_buf, RXM_RNDV_FINISH);
 	tx_buf->hdr.state = RXM_RNDV_FINISH;
+	tx_buf->conn->rndv_tx_credits++;
 
 	if (!rxm_ep->rxm_mr_local)
 		rxm_ep_msg_mr_closev(tx_buf->mr, tx_buf->count);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -943,6 +943,7 @@ rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void 
 	tx_buf->app_context = context;
 	tx_buf->flags = flags;
 	tx_buf->count = count;
+	tx_buf->conn = rxm_conn;
 
 	if (!rxm_ep->rxm_mr_local) {
 		ret = rxm_ep_msg_mr_regv(rxm_ep, iov, tx_buf->count,
@@ -1365,12 +1366,19 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 					 data, flags, tag, op);
 	} else {
 		struct rxm_tx_rndv_buf *tx_buf;
+		if (!rxm_conn->rndv_tx_credits) {
+			ret = -FI_EAGAIN;
+			goto unlock;
+		}
 
 		ret = rxm_ep_alloc_rndv_tx_res(rxm_ep, rxm_conn, context, (uint8_t)count,
 					      iov, desc, data_len, data, flags, tag, op,
 					      &tx_buf);
-		if (OFI_LIKELY(ret >= 0))
+		if (OFI_LIKELY(ret >= 0)) {
 			ret = rxm_ep_rndv_tx_send(rxm_ep, rxm_conn, tx_buf, ret);
+			if (!ret)
+				rxm_conn->rndv_tx_credits--;
+		}
 	}
 unlock:
 	ofi_ep_lock_release(&rxm_ep->util_ep);

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -532,7 +532,8 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		goto err3;
 	}
 
-	if (!strncmp(info->domain_attr->name, "hfi1", strlen("hfi1"))) {
+	if (!strncmp(info->domain_attr->name, "hfi1", strlen("hfi1")) ||
+	    !strncmp(info->domain_attr->name, "qib", strlen("qib"))) {
 		_domain->post_send = fi_ibv_post_send_track_credits;
 		_domain->poll_cq = fi_ibv_poll_cq_track_credits;
 	} else {


### PR DESCRIPTION
This PR adds patches to exchange peer RX queue size information during connection establishment and use it to limit outstanding rendezvous tx requests to limit memory usage at the peer.

Edit: added a minor patch that adds qib (psm verbs) to the list of fabric that would need tx credits monitoring.