### PR TITLE
prov/mrail: Bug fix - FI_INJECT flag incorrectly set for some message…

### DIFF
--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -370,7 +370,7 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	msg.context	= tx_buf;
 	msg.data	= data;
 
-	if (len < mrail_ep->rails[i].info->tx_attr->inject_size)
+	if (len + iov_dest[0].iov_len < mrail_ep->rails[i].info->tx_attr->inject_size)
 		flags |= FI_INJECT;
 
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting send of length: %" PRIu64
@@ -429,7 +429,7 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	msg.context	= tx_buf;
 	msg.data	= data;
 
-	if (len < mrail_ep->rails[i].info->tx_attr->inject_size)
+	if (len + iov_dest[0].iov_len < mrail_ep->rails[i].info->tx_attr->inject_size)
 		flags |= FI_INJECT;
 
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting tsend of length: %" PRIu64


### PR DESCRIPTION
… sizes

When checking if a message can be sent over the rails with FI_INJECT flag
the message header should be included in the size calculation.

This fixes the following assertion failure when using rxm as the rails:

../prov/rxm/src/rxm_ep.c:1326: rxm_ep_send_common: Assertion `(!(flags &
(1ULL << 25)) && (data_len > rxm_ep->rxm_info->tx_attr->inject_size)) ||
(data_len <= rxm_ep->rxm_info->tx_attr->inject_size)' failed.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>