### PR TITLE
prov/mrail: Bug fix - Missing completion for segmented receive

### DIFF
--- a/prov/mrail/src/mrail_cq.c
+++ b/prov/mrail/src/mrail_cq.c
@@ -70,7 +70,7 @@ int mrail_cq_process_buf_recv(struct fi_cq_tagged_entry *comp,
 
 		recv_ctx->context = recv;
 
-		ret = fi_recvmsg(recv_ctx->ep, &msg, FI_CLAIM);
+		ret = fi_recvmsg(recv_ctx->ep, &msg, FI_CLAIM | FI_COMPLETION);
 		if (ret) {
 			FI_WARN(&mrail_prov, FI_LOG_CQ,
 				"Unable to claim buffered recv\n");


### PR DESCRIPTION
Add the FI_COMPLETION flag when claiming buffered messages from the lower
layer to ensure completion generation. In general we can't assume the
lower layer will generate the completion automatically without setting
the FI_COMPLETION flag.

For example, when rxm is used as the lower layer, completions are always
generated when claiming non-segmented messages because it is handled in
a routine specific to buffered receives. This somehow hides the issue.
However, if the message is segmented, the final step that finishes the
receive won't generate a completion if the FI_COMPLETION flag is not set.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>