### PR TITLE
prov/rxm: Ensure completion generation when claiming buffered messages

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -161,7 +161,8 @@ static int rxm_finish_recv(struct rxm_rx_buf *rx_buf, size_t done_len)
 		if (ret)
 			return ret;
 	} else {
-		if (rx_buf->recv_entry->flags & FI_COMPLETION) {
+		if (rx_buf->recv_entry->flags & FI_COMPLETION ||
+		    rx_buf->ep->rxm_info->mode & FI_BUFFERED_RECV) {
 			ret = rxm_cq_write_recv_comp(
 					rx_buf, rx_buf->recv_entry->context,
 					rx_buf->recv_entry->comp_flags |


### PR DESCRIPTION
For non-segmented messages, the code path for claiming buffered receives
is different from regular receives and completions are always generated
there.  However, for segmented messages, the code to finishes the receive
is the same for buffered receives and regular receives and completion
generation depends on the FI_COMPLETION flag.

Add additional check to the finishing code so that completions are always
generated when buffered messages are claimed.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>