### PR TITLE
util: Add userfaultfd memory monitor utility functions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017-2018 Intel Corporation, Inc. All right reserved.
-# Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright (c) 2018-2019 Amazon.com, Inc. or its affiliates. All rights reserved.
 #
 # Makefile.am for libfabric
 
@@ -66,7 +66,8 @@ common_srcs =				\
 	prov/util/src/util_ns.c		\
 	prov/util/src/util_shm.c	\
 	prov/util/src/util_mem_monitor.c\
-	prov/util/src/util_mr_cache.c
+	prov/util/src/util_mr_cache.c	\
+	prov/util/src/util_uffd.c
 
 
 if MACOS
@@ -141,6 +142,7 @@ src_libfabric_la_SOURCES =			\
 	include/ofi_mr.h			\
 	include/ofi_net.h			\
 	include/ofi_perf.h			\
+	include/ofi_uffd.h                      \
 	include/fasthash.h			\
 	include/rbtree.h			\
 	include/uthash.h			\

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,6 @@
 dnl
 dnl Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+dnl Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
 dnl
 dnl Process this file with autoconf to produce a configure script.
 
@@ -304,6 +305,42 @@ if test "$with_valgrind" != "" && test "$with_valgrind" != "no"; then
 AC_CHECK_HEADER(valgrind/memcheck.h, [],
     AC_MSG_ERROR([valgrind requested but <valgrind/memcheck.h> not found.]))
 fi
+
+dnl Check for userfaultfd support
+have_userfaultfd=0
+have_userfaultfd_msg=no
+AC_CHECK_HEADERS([linux/userfaultfd.h],
+    [AC_CHECK_DECL([__NR_userfaultfd],
+        [have_userfaultfd=1 have_userfaultfd_msg=yes],
+        [],
+        [[#include <sys/syscall.h>]])])
+AC_MSG_CHECKING([for userfaultfd interface])
+AC_MSG_RESULT([$have_userfaultfd_msg])
+
+AS_IF([test $have_userfaultfd -eq 1],
+    [AC_MSG_CHECKING([for userfaultfd unmap support])
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+            #include <sys/types.h>
+            #include <linux/userfaultfd.h>
+            #include <unistd.h>
+            #include <sys/syscall.h>
+            #include <fcntl.h>
+            #include <sys/ioctl.h>
+        ]],
+        [[
+            int fd;
+            struct uffdio_api api_obj;
+            api_obj.api = UFFD_API;
+            api_obj.features = UFFD_FEATURE_EVENT_UNMAP | UFFD_FEATURE_EVENT_REMOVE | UFFD_FEATURE_EVENT_REMAP;
+            fd = syscall(__NR_userfaultfd, O_CLOEXEC | O_NONBLOCK);
+            return ioctl(fd, UFFDIO_API, &api_obj);
+        ]])
+    ],
+    [AC_MSG_RESULT([yes])],
+    [AC_MSG_RESULT([no])
+        have_userfaultfd=0])])
+AC_DEFINE_UNQUOTED([HAVE_USERFAULTFD_UNMAP], [$have_userfaultfd],
+    [Defined to 1 if platform supports compiling an application with userfaultfd unmap support])
 
 AC_CACHE_CHECK(whether ld accepts --version-script, ac_cv_version_script,
     [if test -n "`$LD --help < /dev/null 2>/dev/null | grep version-script`"; then

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation, Inc.  All rights reserved.
- * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2019 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -482,5 +482,22 @@ void ofi_pmem_init(void);
 extern uint64_t OFI_RMA_PMEM;
 extern void (*ofi_pmem_commit)(const void *addr, size_t len);
 
+static inline long get_page_size(void)
+{
+	long ret;
+
+	/* sysconf can return -1 and not change errno */
+	errno = 0;
+	ret = sysconf(_SC_PAGESIZE);
+
+	if (ret <= 0) {
+		if (errno)
+			return -errno;
+		else
+			return -FI_EOTHER;
+	}
+
+	return ret;
+}
 
 #endif /* _OFI_MEM_H_ */

--- a/include/ofi_uffd.h
+++ b/include/ofi_uffd.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _OFI_UFFD_H_
+#define _OFI_UFFD_H_
+
+int ofi_uffd_register(int uffd, void *start, size_t len);
+int ofi_uffd_unregister(int uffd, void *start, size_t len);
+void ofi_uffd_close(int uffd);
+int ofi_uffd_init(int flags, uint64_t features);
+
+#endif /* _OFI_UFFD_H_ */

--- a/prov/util/src/util_uffd.c
+++ b/prov/util/src/util_uffd.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <ofi_util.h>
+
+#ifdef HAVE_LINUX_USERFAULTFD_H
+#include <config.h>
+#include <ofi_uffd.h>
+#include <errno.h>
+#include <sys/syscall.h>
+#include <sys/ioctl.h>
+#include <linux/userfaultfd.h>
+
+#define MB(x)((size_t)(x) << 20)
+#define GB(x)((size_t)(x) << 30)
+#define ARRAY_SIZE(A) (sizeof(A)/sizeof(*A))
+
+/* See TODO in function ofi_uffd_register */
+static long page_sizes[] = {4096, MB(2), GB(1)};
+
+static inline void set_uffdio_range(struct uffdio_range *range,
+				    void *start, size_t len,
+				    long page_size)
+{
+	range->start = ((uint64_t)start / page_size) * page_size;
+	range->len = ofi_div_ceil(len, page_size) * page_size;
+}
+
+/*
+ * TODO: ioctl register needs to be passed page aligned boundaries.
+ * Need to find a more sane way of detecting a region's page size.
+ */
+int ofi_uffd_register(int uffd, void *start, size_t len)
+{
+	struct uffdio_register uffdio_register;
+	long page_size;
+	int i;
+
+	/*
+	 * Since the ioctl functions require page aligned boundaries,
+	 * we repeatedly call ioctl using different page sizes until
+	 * it succeeds or we run out of page sizes to try.
+	 */
+	for (i = 0; i < ARRAY_SIZE(page_sizes); i++) {
+		page_size = page_sizes[i];
+		set_uffdio_range(&uffdio_register.range, start, len, page_size);
+		uffdio_register.mode = UFFDIO_REGISTER_MODE_MISSING;
+
+		if (ioctl(uffd, UFFDIO_REGISTER, &uffdio_register) != -1)
+			return 0;
+
+		if (errno != EINVAL) {
+			FI_WARN(&core_prov, FI_LOG_MR, "ioctl/uffdio_register: %s\n",
+				strerror(errno));
+			break;
+		}
+	}
+
+	return -errno;
+}
+
+int ofi_uffd_unregister(int uffd, void *start, size_t len)
+{
+	struct uffdio_range uffdio_range;
+	long page_size;
+	int i;
+
+	for (i = 0; i < ARRAY_SIZE(page_sizes); i++) {
+		page_size = page_sizes[i];
+		set_uffdio_range(&uffdio_range, start, len, page_size);
+		if (ioctl(uffd, UFFDIO_UNREGISTER, &uffdio_range) != -1)
+			return 0;
+
+		if (errno != EINVAL) {
+			FI_WARN(&core_prov, FI_LOG_MR,
+				"ioctl/uffdio_unregister: %s\n",
+				strerror(errno));
+			break;
+		}
+	}
+
+	return -errno;
+}
+
+void ofi_uffd_close(int uffd)
+{
+	close(uffd);
+}
+
+int ofi_uffd_init(int flags, uint64_t features)
+{
+	struct uffdio_api uffdio_api;
+	int uffd;
+
+	page_sizes[0] = get_page_size();
+	if (page_sizes[0] < 0)
+		return page_sizes[0];
+
+	uffd = (int)syscall(__NR_userfaultfd, flags);
+	if (OFI_UNLIKELY(uffd == -1)) {
+		FI_WARN(&core_prov, FI_LOG_MR,
+			"syscall/userfaultfd: %s\n", strerror(errno));
+		return -errno;
+	}
+
+	uffdio_api.api = UFFD_API;
+	uffdio_api.features = features;
+	if (ioctl(uffd, UFFDIO_API, &uffdio_api) == -1) {
+		FI_WARN(&core_prov, FI_LOG_MR,
+			"ioctl/uffdio_api: %s\n", strerror(errno));
+		ofi_uffd_close(uffd);
+		return -errno;
+	}
+
+	if (uffdio_api.api != UFFD_API) {
+		FI_WARN(&core_prov, FI_LOG_MR,
+			"uffdio requested features not supported.\n");
+		ofi_uffd_close(uffd);
+		return -FI_ENOSYS;
+	}
+
+	return uffd;
+}
+
+#else /* !HAVE_LINUX_USERFAULTFD_H */
+
+int ofi_uffd_register(int uffd, void *start, size_t len)
+{
+	OFI_UNUSED(uffd);
+	OFI_UNUSED(start);
+	OFI_UNUSED(len);
+
+	return -FI_ENOSYS;
+}
+
+int ofi_uffd_unregister(int uffd, void *start, size_t len)
+{
+	OFI_UNUSED(uffd);
+	OFI_UNUSED(start);
+	OFI_UNUSED(len);
+
+	return -FI_ENOSYS;
+}
+
+void ofi_uffd_close(int uffd)
+{
+	OFI_UNUSED(uffd);
+}
+
+int ofi_uffd_init(int flags, uint64_t features)
+{
+	OFI_UNUSED(flags);
+	OFI_UNUSED(features);
+
+	return -FI_ENOSYS;
+}
+
+#endif /* HAVE_LINUX_USERFAULTFD_H */


### PR DESCRIPTION
Existing glibc malloc hooks prove insufficient in detecting events on a
memory region. With the current state of the memory registration cache
component, if memory is freed through, for example, munmap, the cache
relying on these hooks will preserve stale entries. This will cause
inappropriate behavior in which sends will be performed through
unregistered buffers with stale mr keys. To resolve this invalidation
error, we can instead use userfault fd event handling which does support
munmap detection. This provides better coverage of memory events for the
memory registration cache component.

This commit implements common utility functions to handle userfault fd
creation, registration, unregistration, and cleanup.

Signed-off-by: William Zhang <wilzhang@amazon.com>