### PR TITLE
[v1.7.x] revert commits that limit outstanding rndv tx ops

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -697,7 +697,6 @@ struct rxm_conn {
 	/* This is saved MSG EP fid, that hasn't been closed during
 	 * handling of CONN_RECV in RXM_CMAP_CONNREQ_SENT for passive side */
 	struct fid_ep *saved_msg_ep;
-	uint32_t rndv_tx_credits;
 };
 
 extern struct fi_provider rxm_prov;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -493,7 +493,6 @@ struct rxm_tx_rndv_buf {
 	struct rxm_rx_buf *rx_buf;
 	struct fid_mr *mr[RXM_IOV_LIMIT];
 	uint8_t count;
-	struct rxm_conn *conn;
 
 	/* Must stay at bottom */
 	struct rxm_pkt pkt;
@@ -698,9 +697,6 @@ struct rxm_conn {
 	/* This is saved MSG EP fid, that hasn't been closed during
 	 * handling of CONN_RECV in RXM_CMAP_CONNREQ_SENT for passive side */
 	struct fid_ep *saved_msg_ep;
-
-	/* Limit RNDV sends based on peer rx queue size to avoid increased
-	 * memory usage at peer */
 	uint32_t rndv_tx_credits;
 };
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1029,25 +1029,12 @@ rxm_conn_av_updated_handler(struct rxm_cmap_handle *handle)
 	}
 }
 
-static size_t rxm_conn_get_rx_size(struct rxm_ep *rxm_ep,
-                                  struct fi_info *msg_info)
-{
-       if (msg_info->ep_attr->rx_ctx_cnt == FI_SHARED_CONTEXT)
-               return MAX(MIN(16, msg_info->rx_attr->size),
-                          (msg_info->rx_attr->size /
-                           rxm_ep->util_ep.av->count));
-       else
-               return msg_info->rx_attr->size;
-}
-
 static struct rxm_cmap_handle *rxm_conn_alloc(struct rxm_cmap *cmap)
 {
-	struct rxm_ep *rxm_ep = container_of(cmap->ep, struct rxm_ep, util_ep);
 	struct rxm_conn *rxm_conn = calloc(1, sizeof(*rxm_conn));
 
 	if (OFI_UNLIKELY(!rxm_conn))
 		return NULL;
-	rxm_conn->rndv_tx_credits = rxm_conn_get_rx_size(rxm_ep, rxm_ep->msg_info);
 
 	return &rxm_conn->handle;
 }

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -311,7 +311,6 @@ static int rxm_rndv_tx_finish(struct rxm_ep *rxm_ep, struct rxm_tx_rndv_buf *tx_
 
 	RXM_LOG_STATE_TX(FI_LOG_CQ, tx_buf, RXM_RNDV_FINISH);
 	tx_buf->hdr.state = RXM_RNDV_FINISH;
-	tx_buf->conn->rndv_tx_credits++;
 
 	if (!rxm_ep->rxm_mr_local)
 		rxm_ep_msg_mr_closev(tx_buf->mr, tx_buf->count);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -967,7 +967,6 @@ rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void 
 	tx_buf->app_context = context;
 	tx_buf->flags = flags;
 	tx_buf->count = count;
-	tx_buf->conn = rxm_conn;
 
 	if (!rxm_ep->rxm_mr_local) {
 		ret = rxm_ep_msg_mr_regv(rxm_ep, iov, tx_buf->count,
@@ -1390,19 +1389,12 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 					 data, flags, tag, op);
 	} else {
 		struct rxm_tx_rndv_buf *tx_buf;
-		if (!rxm_conn->rndv_tx_credits) {
-			ret = -FI_EAGAIN;
-			goto unlock;
-		}
 
 		ret = rxm_ep_alloc_rndv_tx_res(rxm_ep, rxm_conn, context, (uint8_t)count,
 					      iov, desc, data_len, data, flags, tag, op,
 					      &tx_buf);
-		if (OFI_LIKELY(ret >= 0)) {
+		if (OFI_LIKELY(ret >= 0))
 			ret = rxm_ep_rndv_tx_send(rxm_ep, rxm_conn, tx_buf, ret);
-			if (!ret)
-				rxm_conn->rndv_tx_credits--;
-		}
 	}
 unlock:
 	ofi_ep_lock_release(&rxm_ep->util_ep);


### PR DESCRIPTION
The changes break IMB-EXT test. Reverting them for now.