### PR TITLE
prov/rxm: Handle segments ordering in buffered receive mode

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -711,6 +711,7 @@ struct rxm_conn {
 	struct dlist_entry deferred_conn_entry;
 	struct dlist_entry deferred_tx_queue;
 	struct dlist_entry sar_rx_msg_list;
+	struct dlist_entry sar_deferred_rx_msg_list;
 
 	/* This is saved MSG EP fid, that hasn't been closed during
 	 * handling of CONN_RECV in RXM_CMAP_CONNREQ_SENT for passive side */

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -221,6 +221,7 @@ static int rxm_conn_res_alloc(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn)
 	dlist_init(&rxm_conn->deferred_conn_entry);
 	dlist_init(&rxm_conn->deferred_tx_queue);
 	dlist_init(&rxm_conn->sar_rx_msg_list);
+	dlist_init(&rxm_conn->sar_deferred_rx_msg_list);
 
 	if (rxm_ep->util_ep.domain->threading != FI_THREAD_SAFE) {
 		rxm_conn->inject_pkt =


### PR DESCRIPTION
In regular receive mode, multiple segments of a single message either
go to the same matching receive entry (if already posted) or go to the
unexpected message queue, where they will all be processed when a
matching receive is posted.

In buffered receive mode, the first segment creates a completion event
and a receive entry is only created when the message is claimed. There
is no problem if the follow-up segments arrive after the message has
been claimed. However, if any of the segments arrives before the message
is claimed, it won't match any receive entry and will be treated in the
same way as the first segment, causing application error.

This patch fixes the issue associated with the buffered receive mode.
A deferred message queue is used to queue up follow-up message segments
before they can be delivered to the matching receive entry. The queue
works similarly to the unexpected message queue, but is only for the
SAR protocol under buffered receive mode.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>