### PR TITLE
prov/verbs: check and free fi_ibv_mem_notifier on provider cleanup

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -679,6 +679,8 @@ static int fi_ibv_read_params(void)
 
 static void fi_ibv_fini(void)
 {
+	if (fi_ibv_mem_notifier)
+		fi_ibv_mem_notifier_free();
 	fi_freeinfo((void *)fi_ibv_util_prov.info);
 	fi_ibv_util_prov.info = NULL;
 }

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -445,8 +445,11 @@ struct fi_ibv_monitor_entry {
 	struct iovec		iov;
 };
 
+extern struct fi_ibv_mem_notifier *fi_ibv_mem_notifier;
+
 void fi_ibv_mem_notifier_free_hook(void *ptr, const void *caller);
 void *fi_ibv_mem_notifier_realloc_hook(void *ptr, size_t size, const void *caller);
+void fi_ibv_mem_notifier_free(void);
 
 extern struct fi_ibv_mr_internal_ops fi_ibv_mr_internal_ops;
 extern struct fi_ibv_mr_internal_ops fi_ibv_mr_internal_cache_ops;


### PR DESCRIPTION
Ideally, fi_ibv_mem_notifier should be freed when all verbs domains that use it
are closed. In case this doesn't happen we have to unset the alloc, free hooks
set by fi_ibv_mem_notifier_init. Otherwise bad things would happen.