### PR TITLE
prov/rxm: extend interface for buffer repost and bugfix

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -1061,9 +1061,9 @@ rxm_rx_buf_alloc(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep, uint8_t repost)
 }
 
 static inline void
-rxm_rx_buf_release(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf)
+rxm_rx_buf_release(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf, uint8_t repost)
 {
-	if (rx_buf->repost) {
+	if (repost) {
 		dlist_insert_tail(&rx_buf->repost_entry,
 				  &rx_buf->ep->repost_ready_list);
 	} else {

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -1071,6 +1071,19 @@ rxm_rx_buf_release(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf, uint8_t rep
 	}
 }
 
+static inline int
+rxm_rx_buf_acquire(struct rxm_ep *rxm_ep, struct rxm_rx_buf **rx_buf)
+{
+	if (!dlist_empty(&rxm_ep->repost_ready_list)) {
+		dlist_pop_front(&rxm_ep->repost_ready_list, struct rxm_rx_buf,
+				*rx_buf, repost_entry);
+		return FI_SUCCESS;
+	} else {
+		*rx_buf = NULL;
+		return -FI_ENOMEM;
+	}
+}
+
 static inline struct rxm_rma_buf *rxm_rma_buf_alloc(struct rxm_ep *rxm_ep)
 {
 	return (struct rxm_rma_buf *)

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -981,7 +981,7 @@ static int rxm_conn_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
 			if (rx_buf->ep->util_ep.flags & OFI_CNTR_ENABLED)
 				rxm_cntr_incerr(rx_buf->ep->util_ep.rx_cntr);
 
-			rxm_rx_buf_release(recv_queue->rxm_ep, rx_buf);
+			rxm_rx_buf_release(recv_queue->rxm_ep, rx_buf, rx_buf->repost);
 
 			if (!(rx_buf->recv_entry->flags & FI_MULTI_RECV))
 				rxm_recv_entry_release(recv_queue,

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1356,9 +1356,7 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 	if (!slistfd_empty(&rxm_ep->msg_eq_entry_list))
 		rxm_conn_process_eq_events(rxm_ep);
 
-	while (!dlist_empty(&rxm_ep->repost_ready_list)) {
-		dlist_pop_front(&rxm_ep->repost_ready_list, struct rxm_rx_buf,
-				buf, repost_entry);
+	while (!rxm_rx_buf_acquire(rxm_ep, &buf)) {
 		ret = rxm_msg_ep_recv(buf);
 		if (ret) {
 			if (OFI_LIKELY(ret == -FI_EAGAIN))

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1357,6 +1357,13 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 		rxm_conn_process_eq_events(rxm_ep);
 
 	while (!rxm_rx_buf_acquire(rxm_ep, &buf)) {
+		// Discard rx buffer if its msg_ep was
+		// closed after eq processing.
+		if (!buf->conn->msg_ep) {
+			ofi_buf_free(&buf->hdr);
+			continue;
+		}
+
 		ret = rxm_msg_ep_recv(buf);
 		if (ret) {
 			if (OFI_LIKELY(ret == -FI_EAGAIN))

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -628,8 +628,7 @@ static int rxm_ep_discard_recv(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf,
 	RXM_DBG_ADDR_TAG(FI_LOG_EP_DATA, "Discarding message",
 			 rx_buf->unexp_msg.addr, rx_buf->unexp_msg.tag);
 
-	dlist_insert_tail(&rx_buf->repost_entry,
-			  &rx_buf->ep->repost_ready_list);
+	rxm_rx_buf_release(rx_buf->ep, rx_buf, 1);
 	return ofi_cq_write(rxm_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
 			    0, NULL, rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
 }
@@ -786,8 +785,7 @@ rxm_ep_recv_common_flags(struct rxm_ep *rxm_ep, const struct iovec *iov,
 
 		assert(flags & FI_DISCARD);
 		FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Discarding buffered receive\n");
-		dlist_insert_tail(&rx_buf->repost_entry,
-				  &rx_buf->ep->repost_ready_list);
+		rxm_rx_buf_release(rx_buf->ep, rx_buf, 1);
 		goto unlock;
 	}
 


### PR DESCRIPTION
This PR does the following things:
- Enhances interface of functions dedicated to recieve buffer posting.
- Fixes segfault while accessing closed MSG endpoint through repost buffers.