### PR TITLE
prov/tcp: op flags handling fixes.

### DIFF
--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -258,6 +258,11 @@ static ssize_t tcpx_send(struct fid_ep *ep, const void *buf, size_t len,
 	tx_entry->flags = ((tcpx_ep->util_ep.tx_op_flags & FI_COMPLETION) |
 			   FI_MSG | FI_SEND);
 
+	if (tcpx_ep->util_ep.tx_op_flags &
+	    (FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)) {
+		tx_entry->hdr.base_hdr.flags |= OFI_DELIVERY_COMPLETE;
+	}
+
 	tcpx_ep->hdr_bswap(&tx_entry->hdr.base_hdr);
 	fastlock_acquire(&tcpx_ep->lock);
 	tcpx_tx_queue_insert(tcpx_ep, tx_entry);
@@ -295,6 +300,11 @@ static ssize_t tcpx_sendv(struct fid_ep *ep, const struct iovec *iov,
 	tx_entry->rem_len = tx_entry->hdr.base_hdr.size;
 	tx_entry->flags = ((tcpx_ep->util_ep.tx_op_flags & FI_COMPLETION) |
 			   FI_MSG | FI_SEND);
+
+	if (tcpx_ep->util_ep.tx_op_flags &
+	    (FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)) {
+		tx_entry->hdr.base_hdr.flags |= OFI_DELIVERY_COMPLETE;
+	}
 
 	tcpx_ep->hdr_bswap(&tx_entry->hdr.base_hdr);
 	fastlock_acquire(&tcpx_ep->lock);
@@ -372,6 +382,11 @@ static ssize_t tcpx_senddata(struct fid_ep *ep, const void *buf, size_t len,
 	tx_entry->rem_len = tx_entry->hdr.base_hdr.size;
 	tx_entry->flags = ((tcpx_ep->util_ep.tx_op_flags & FI_COMPLETION) |
 			   FI_MSG | FI_SEND);
+
+	if (tcpx_ep->util_ep.tx_op_flags &
+	    (FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)) {
+		tx_entry->hdr.base_hdr.flags |= OFI_DELIVERY_COMPLETE;
+	}
 
 	tcpx_ep->hdr_bswap(&tx_entry->hdr.base_hdr);
 	fastlock_acquire(&tcpx_ep->lock);

--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -217,7 +217,6 @@ static ssize_t tcpx_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 
 	if (flags & (FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)) {
 		tx_entry->hdr.base_hdr.flags |= OFI_DELIVERY_COMPLETE;
-		tx_entry->flags &= ~FI_COMPLETION;
 	}
 
 	tx_entry->ep = tcpx_ep;

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -111,17 +111,15 @@ static void process_tx_entry(struct tcpx_xfer_entry *tx_entry)
 		tcpx_cq_report_error(tx_entry->ep->util_ep.tx_cq,
 				     tx_entry, ret);
 	} else {
-		tcpx_cq_report_success(tx_entry->ep->util_ep.tx_cq,
-				       tx_entry);
-
 		if (tx_entry->hdr.base_hdr.flags &
 		    (OFI_DELIVERY_COMPLETE | OFI_COMMIT_COMPLETE)) {
-			tx_entry->flags |= FI_COMPLETION;
 			slist_insert_tail(&tx_entry->entry,
 					  &tx_entry->ep->tx_rsp_pend_queue);
 			return;
 		}
+		tcpx_cq_report_success(tx_entry->ep->util_ep.tx_cq, tx_entry);
 	}
+
 	tcpx_cq = container_of(tx_entry->ep->util_ep.tx_cq,
 			       struct tcpx_cq, util_cq);
 	tcpx_xfer_entry_release(tcpx_cq, tx_entry);

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -239,12 +239,10 @@ static ssize_t tcpx_rma_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg
 			     flags | FI_RMA | FI_WRITE);
 
 	if (flags & (FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)) {
-		send_entry->flags &= ~FI_COMPLETION;
 		send_entry->hdr.base_hdr.flags |= OFI_DELIVERY_COMPLETE;
 	}
 
 	if (flags & FI_COMMIT_COMPLETE) {
-		send_entry->flags &= ~FI_COMPLETION;
 		send_entry->hdr.base_hdr.flags |= OFI_COMMIT_COMPLETE;
 	}
 


### PR DESCRIPTION
1) removed unnecessary FI_COMPLETION flag manipulation in case of transmit & delivery complete semantic
2) fix transmit and delivery complete handling for send, sendv and senddata calls. 