### PR TITLE
prov/mrail: Implement Rendezvous protocol for messaging API

### DIFF
--- a/prov/mrail/src/mrail_cq.c
+++ b/prov/mrail/src/mrail_cq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2018-2019 Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -34,6 +34,35 @@
 
 #include "mrail.h"
 
+static int mrail_cq_write_send_comp(struct util_cq *cq,
+				    struct mrail_tx_buf *tx_buf)
+{
+	int ret = 0;
+
+	ofi_ep_tx_cntr_inc(&tx_buf->ep->util_ep);
+
+	if (tx_buf->flags & FI_COMPLETION) {
+		ret = ofi_cq_write(cq, tx_buf->context,
+				   (tx_buf->flags &
+				    (FI_TAGGED | FI_MSG)) |
+				   FI_SEND, 0, NULL, 0, 0);
+		if (ret) {
+			FI_WARN(&mrail_prov, FI_LOG_CQ,
+				"Unable to write to util cq\n");
+		}
+	}
+
+	if (tx_buf->hdr.protocol == MRAIL_PROTO_RNDV &&
+	    tx_buf->rndv_hdr.cmd == MRAIL_RNDV_REQ)
+		free(tx_buf->rndv_req);
+
+	ofi_ep_lock_acquire(&tx_buf->ep->util_ep);
+	ofi_buf_free(tx_buf);
+	ofi_ep_lock_release(&tx_buf->ep->util_ep);
+
+	return ret;
+}
+
 int mrail_cq_write_recv_comp(struct mrail_ep *mrail_ep, struct mrail_hdr *hdr,
 			     struct fi_cq_tagged_entry *comp,
 			     struct mrail_recv *recv)
@@ -49,6 +78,139 @@ int mrail_cq_write_recv_comp(struct mrail_ep *mrail_ep, struct mrail_hdr *hdr,
 			   (comp->flags & FI_REMOTE_CQ_DATA),
 			   comp->len - sizeof(struct mrail_pkt),
 			   NULL, comp->data, hdr->tag);
+}
+
+static int mrail_cq_write_rndv_recv_comp(struct mrail_ep *mrail_ep,
+					 struct mrail_recv *recv)
+{
+	FI_DBG(&mrail_prov, FI_LOG_CQ, "finish rndv recv: length: %zu "
+	       "tag: 0x%" PRIx64 "\n", recv->rndv.len, recv->rndv.tag);
+	ofi_ep_rx_cntr_inc(&mrail_ep->util_ep);
+	if (!(recv->flags & FI_COMPLETION))
+		return 0;
+	return ofi_cq_write(mrail_ep->util_ep.rx_cq, recv->context,
+			   recv->comp_flags | recv->rndv.flags,
+			   recv->rndv.len, NULL, recv->rndv.data,
+			   recv->rndv.tag);
+}
+
+static void mrail_finish_rndv_recv(struct mrail_req *req,
+				   struct fi_cq_tagged_entry *comp)
+{
+	int ret;
+	struct mrail_recv *recv = req->comp.op_context;
+
+	ret = mrail_cq_write_rndv_recv_comp(req->mrail_ep, recv);
+	if (ret) {
+		FI_WARN(&mrail_prov, FI_LOG_CQ,
+			"Cannot write to recv cq\n");
+		assert(0);
+	}
+
+	do {
+		ret = mrail_send_rndv_ack(req->mrail_ep, recv->addr, (void *)recv->rndv.context);
+		if (ret && ret != -FI_EAGAIN) {
+			FI_WARN(&mrail_prov, FI_LOG_CQ,
+				"Cannot send rndv ack: %s\n", fi_strerror(-ret));
+			assert(0);
+		}
+	} while (ret == -FI_EAGAIN);
+
+	mrail_free_req(req->mrail_ep, req);
+	mrail_push_recv(recv);
+}
+
+int mrail_cq_process_rndv_req(struct fi_cq_tagged_entry *comp,
+			      struct mrail_recv *recv)
+{
+	struct fi_recv_context *recv_ctx = comp->op_context;
+	struct fi_msg msg = {
+		.context = recv_ctx,
+	};
+	struct mrail_ep *mrail_ep;
+	struct mrail_pkt *mrail_pkt;
+	struct mrail_rndv_hdr *rndv_hdr;
+	struct mrail_rndv_req *rndv_req;
+	struct fi_msg_rma rma_msg;
+	uint64_t *base_addrs;
+	size_t key_size;
+	size_t offset;
+	int ret, retv = 0;
+	int i;
+
+	mrail_ep = recv_ctx->ep->fid.context;
+	mrail_pkt = (struct mrail_pkt *)comp->buf;
+	rndv_hdr = (struct mrail_rndv_hdr *)&mrail_pkt[1];
+	rndv_req = (struct mrail_rndv_req *)&rndv_hdr[1];
+	recv->rndv.context = (void *)rndv_hdr->context;
+	recv->rndv.flags = comp->flags & FI_REMOTE_CQ_DATA;
+	recv->rndv.len = rndv_req->len;
+	recv->rndv.tag = mrail_pkt->hdr.tag;
+	recv->rndv.data = comp->data;
+
+	base_addrs = (uint64_t *)(rndv_req->rawkey + rndv_req->rawkey_size);
+	for (offset = 0, i = 0; i < rndv_req->count; i++) {
+		if (i < rndv_req->mr_count) {
+			key_size = rndv_req->rma_iov[i].key;
+			ret = fi_mr_map_raw(&mrail_ep->util_ep.domain->domain_fid,
+					    base_addrs[i],
+					    rndv_req->rawkey + offset,
+					    key_size,
+					    &rndv_req->rma_iov[i].key,
+					    0);
+			assert(!ret);
+			offset += key_size;
+		} else {
+			rndv_req->rma_iov[i].key = rndv_req->rma_iov[0].key;
+		}
+	}
+
+	rma_msg.msg_iov		= recv->iov + 1;
+	rma_msg.desc		= recv->desc + 1;
+	rma_msg.iov_count	= recv->count - 1;
+	rma_msg.addr		= recv->addr;
+	rma_msg.rma_iov		= rndv_req->rma_iov;
+	rma_msg.rma_iov_count	= rndv_req->count;
+	rma_msg.context		= recv;
+
+	ret = fi_readmsg(&mrail_ep->util_ep.ep_fid, &rma_msg,
+			 MRAIL_RNDV_FLAG | FI_COMPLETION);
+	if (ret)
+		retv = ret;
+
+	ret = fi_recvmsg(recv_ctx->ep, &msg, FI_DISCARD);
+	if (ret) {
+		FI_WARN(&mrail_prov, FI_LOG_CQ,
+			"Unable to discard buffered recv\n");
+		retv = ret;
+	}
+
+	return retv;
+}
+
+int mrail_cq_process_rndv_ack(struct fi_cq_tagged_entry *comp,
+			      struct mrail_rndv_hdr *rndv_hdr)
+{
+	struct fi_recv_context *recv_ctx = comp->op_context;
+	struct fi_msg msg = {
+		.context = recv_ctx,
+	};
+	struct mrail_tx_buf *tx_buf;
+	int ret, retv = 0;
+
+	tx_buf = (struct mrail_tx_buf *)rndv_hdr->context;
+	ret = mrail_cq_write_send_comp(tx_buf->ep->util_ep.tx_cq, tx_buf);
+	if (ret)
+		retv = ret;
+
+	ret = fi_recvmsg(recv_ctx->ep, &msg, FI_DISCARD);
+	if (ret) {
+		FI_WARN(&mrail_prov, FI_LOG_CQ,
+			"Unable to discard buffered recv\n");
+		retv = ret;
+	}
+
+	return retv;
 }
 
 int mrail_cq_process_buf_recv(struct fi_cq_tagged_entry *comp,
@@ -82,6 +244,9 @@ int mrail_cq_process_buf_recv(struct fi_cq_tagged_entry *comp,
 
 	mrail_ep = recv_ctx->ep->fid.context;
 	mrail_pkt = (struct mrail_pkt *)comp->buf;
+
+	if (mrail_pkt->hdr.protocol == MRAIL_PROTO_RNDV)
+		return mrail_cq_process_rndv_req(comp, recv);
 
 	len = comp->len - sizeof(*mrail_pkt);
 
@@ -257,6 +422,13 @@ static int mrail_handle_recv_completion(struct fi_cq_tagged_entry *comp,
 	// TODO make rxm send buffered recv amount of data for large message
 	assert(hdr->version == MRAIL_HDR_VERSION);
 
+	if (hdr->protocol == MRAIL_PROTO_RNDV) {
+		struct mrail_rndv_hdr *rndv_hdr;
+		rndv_hdr = (struct mrail_rndv_hdr *)&hdr[1];
+		if (rndv_hdr->cmd == MRAIL_RNDV_ACK)
+			return mrail_cq_process_rndv_ack(comp, rndv_hdr);
+	}
+
 	seq_no = ntohl(hdr->seq);
 	peer_info = ofi_av_get_addr(mrail_ep->util_ep.av, (int) src_addr);
 	FI_DBG(&mrail_prov, FI_LOG_CQ,
@@ -343,6 +515,11 @@ static void mrail_handle_rma_completion(struct util_cq *cq,
 	req = subreq->parent;
 
 	if (ofi_atomic_dec32(&req->expected_subcomps) == 0) {
+		if (req->comp.flags & MRAIL_RNDV_FLAG) {
+			mrail_finish_rndv_recv(req, comp);
+			return;
+		}
+
 		ret = ofi_cq_write(cq, req->comp.op_context, req->comp.flags,
 				req->comp.len, req->comp.buf, req->comp.data,
 				req->comp.tag);
@@ -382,34 +559,30 @@ void mrail_poll_cq(struct util_cq *cq)
 			FI_WARN(&mrail_prov, FI_LOG_CQ,
 				"Unable to read rail completion: %s\n",
 				fi_strerror(-ret));
-			goto err1;
+			goto err;
 		}
 		// TODO handle variable length message
 		if (comp.flags & FI_RECV) {
 			ret = mrail_cq->process_comp(&comp, src_addr);
 			if (ret)
-				goto err1;
+				goto err;
 		} else if (comp.flags & (FI_READ | FI_WRITE)) {
 			mrail_handle_rma_completion(cq, &comp);
 		} else if (comp.flags & FI_SEND) {
 			tx_buf = comp.op_context;
-
-			ofi_ep_tx_cntr_inc(&tx_buf->ep->util_ep);
-
-			if (tx_buf->flags & FI_COMPLETION) {
-				ret = ofi_cq_write(cq, tx_buf->context,
-						   (tx_buf->flags &
-						    (FI_TAGGED | FI_MSG)) |
-						   FI_SEND, 0, NULL, 0, 0);
-				if (ret) {
-					FI_WARN(&mrail_prov, FI_LOG_CQ,
-						"Unable to write to util cq\n");
-					goto err2;
+			if (tx_buf->hdr.protocol == MRAIL_PROTO_RNDV) {
+				if (tx_buf->rndv_hdr.cmd == MRAIL_RNDV_REQ) {
+					/* buf will be freed when ACK comes */
+				} else if (tx_buf->rndv_hdr.cmd == MRAIL_RNDV_ACK) {
+					ofi_ep_lock_acquire(&tx_buf->ep->util_ep);
+					ofi_buf_free(tx_buf);
+					ofi_ep_lock_release(&tx_buf->ep->util_ep);
 				}
+				continue;
 			}
-			ofi_ep_lock_acquire(&tx_buf->ep->util_ep);
-			ofi_buf_free(tx_buf);
-			ofi_ep_lock_release(&tx_buf->ep->util_ep);
+			ret = mrail_cq_write_send_comp(cq, tx_buf);
+			if (ret)
+				goto err;
 		} else {
 			/* We currently cannot support FI_REMOTE_READ and
 			 * FI_REMOTE_WRITE because RMA operations are split
@@ -424,11 +597,7 @@ void mrail_poll_cq(struct util_cq *cq)
 
 	return;
 
-err2:
-	ofi_ep_lock_acquire(&tx_buf->ep->util_ep);
-	ofi_buf_free(tx_buf);
-	ofi_ep_lock_release(&tx_buf->ep->util_ep);
-err1:
+err:
 	// TODO write error to cq
 	assert(0);
 }

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2018-2019 Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -337,6 +337,129 @@ static struct mrail_tx_buf *mrail_get_tx_buf(struct mrail_ep *mrail_ep,
 	return tx_buf;
 }
 
+/*
+ * This is an internal send that doesn't use seq_no and doesn't update
+ * the counters.
+ */
+int mrail_send_rndv_ack(struct mrail_ep *mrail_ep, fi_addr_t dest_addr,
+			void *context)
+{
+	struct iovec iov_dest;
+	struct mrail_tx_buf *tx_buf;
+	uint32_t i = mrail_get_tx_rail(mrail_ep);
+	struct fi_msg msg;
+	ssize_t ret;
+	uint64_t flags = FI_COMPLETION;
+
+	ofi_ep_lock_acquire(&mrail_ep->util_ep);
+
+	tx_buf = mrail_get_tx_buf(mrail_ep, context, 0, ofi_op_tagged, 0);
+	if (OFI_UNLIKELY(!tx_buf))
+		return -FI_ENOMEM;
+
+	tx_buf->hdr.protocol = MRAIL_PROTO_RNDV;
+	tx_buf->rndv_hdr.context = (uint64_t)context;
+	tx_buf->rndv_hdr.cmd = MRAIL_RNDV_ACK;
+
+	iov_dest.iov_base = &tx_buf->hdr;
+	iov_dest.iov_len = sizeof(tx_buf->hdr) + sizeof(tx_buf->rndv_hdr);
+
+	msg.msg_iov 	= &iov_dest;
+	msg.desc    	= NULL;
+	msg.iov_count	= 1;
+	msg.addr	= dest_addr;
+	msg.context	= tx_buf;
+
+	if (iov_dest.iov_len < mrail_ep->rails[i].info->tx_attr->inject_size)
+		flags |= FI_INJECT;
+
+	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting rdnv ack "
+	       " dest_addr: 0x%" PRIx64 " on rail: %d\n", dest_addr, i);
+
+	ret = fi_sendmsg(mrail_ep->rails[i].ep, &msg, flags);
+	if (ret) {
+		FI_WARN(&mrail_prov, FI_LOG_EP_DATA,
+			"Unable to fi_sendmsg on rail: %" PRIu32 "\n", i);
+		ofi_buf_free(tx_buf);
+	}
+	ofi_ep_lock_release(&mrail_ep->util_ep);
+	return ret;
+}
+
+static ssize_t
+mrail_prepare_rndv_req(struct mrail_ep *mrail_ep, struct mrail_tx_buf *tx_buf,
+		       const struct iovec *iov, void **desc, size_t count,
+		       size_t len, struct iovec *iov_dest)
+{
+	size_t mr_count;
+	struct fid_mr *mr;
+	uint64_t addr, *base_addrs;
+	size_t key_size, offset;
+	size_t total_key_size = 0;
+	ssize_t ret;
+	int i;
+
+	tx_buf->hdr.protocol = MRAIL_PROTO_RNDV;
+	tx_buf->rndv_hdr.context = (uint64_t)tx_buf;
+	tx_buf->rndv_hdr.cmd = MRAIL_RNDV_REQ;
+
+	if (!desc || !desc[0]) {
+		ret = fi_mr_regv(&mrail_ep->util_ep.domain->domain_fid,
+				 iov, count, FI_REMOTE_READ, 0, 0, 0, &mr, 0);
+		if (ret)
+			return ret;
+		total_key_size = 0;
+		ret = fi_mr_raw_attr(mr, &addr, NULL, &total_key_size, 0);
+		assert(ret == -FI_ETOOSMALL);
+		mr_count = 1;
+	} else {
+		total_key_size = 0;
+		for (i = 0; i < count; i++) {
+			mr = &((struct mrail_mr *)desc[i])->mr_fid;
+			key_size = 0;
+			ret = fi_mr_raw_attr(mr, &addr, NULL, &key_size, 0);
+			assert(ret == -FI_ETOOSMALL);
+			total_key_size += key_size;
+		}
+		mr_count = count;
+	}
+
+	tx_buf->rndv_req = malloc(sizeof(*tx_buf->rndv_req) + total_key_size +
+				  sizeof(*base_addrs) * mr_count);
+	if (!tx_buf->rndv_req)
+		return -FI_ENOMEM;
+
+	tx_buf->rndv_req->len = len;
+	tx_buf->rndv_req->count = count;
+	tx_buf->rndv_req->mr_count = mr_count;
+	tx_buf->rndv_req->rawkey_size = total_key_size;
+
+	base_addrs = (uint64_t *)(tx_buf->rndv_req->rawkey + total_key_size);
+	for (offset = 0, i = 0; i < count; i++) {
+		if (i < mr_count) {
+			if (mr_count > 1)
+				mr = &((struct mrail_mr *)desc[i])->mr_fid;
+			key_size = total_key_size - offset;
+			ret = fi_mr_raw_attr(mr, &base_addrs[i],
+					     tx_buf->rndv_req->rawkey + offset,
+					     &key_size, 0);
+			assert(!ret);
+			offset += key_size;
+		}
+		tx_buf->rndv_req->rma_iov[i].addr = (uint64_t)iov[i].iov_base;
+		tx_buf->rndv_req->rma_iov[i].len = iov[i].iov_len;
+		tx_buf->rndv_req->rma_iov[i].key = key_size; /* otherwise unused */
+	}
+
+	iov_dest[0].iov_base = &tx_buf->hdr;
+	iov_dest[0].iov_len = sizeof(tx_buf->hdr) + sizeof(tx_buf->rndv_hdr);
+	iov_dest[1].iov_base = tx_buf->rndv_req;
+	iov_dest[1].iov_len = sizeof(*tx_buf->rndv_req) + total_key_size +
+			      sizeof(uint64_t) * mr_count;
+
+	return 0;
+}
+
 static ssize_t
 mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		  size_t count, size_t len, fi_addr_t dest_addr, uint64_t data,
@@ -350,6 +473,7 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	uint32_t i = mrail_get_tx_rail(mrail_ep);
 	struct fi_msg msg;
 	ssize_t ret;
+	size_t total_len;
 
 	peer_info = ofi_av_get_addr(mrail_ep->util_ep.av, (int) dest_addr);
 
@@ -361,16 +485,33 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		ret = -FI_ENOMEM;
 		goto err1;
 	}
-	mrail_copy_iov_hdr(&tx_buf->hdr, iov_dest, iov, count);
 
-	msg.msg_iov 	= iov_dest;
-	msg.desc    	= desc;
-	msg.iov_count	= count + 1;
-	msg.addr	= dest_addr;
-	msg.context	= tx_buf;
-	msg.data	= data;
+	if (len <= MRAIL_RNDV_THRESHOLD) {
+		mrail_copy_iov_hdr(&tx_buf->hdr, iov_dest, iov, count);
 
-	if (len + iov_dest[0].iov_len < mrail_ep->rails[i].info->tx_attr->inject_size)
+		msg.msg_iov 	= iov_dest;
+		msg.desc    	= desc;
+		msg.iov_count	= count + 1;
+		msg.addr	= dest_addr;
+		msg.context	= tx_buf;
+		msg.data	= data;
+		total_len = len + iov_dest[0].iov_len;
+	} else {
+		ret = mrail_prepare_rndv_req(mrail_ep, tx_buf, iov, desc,
+					     count, len, iov_dest);
+		if (ret)
+			goto err2;
+
+		msg.msg_iov 	= iov_dest;
+		msg.desc    	= desc;
+		msg.iov_count	= 2;
+		msg.addr	= dest_addr;
+		msg.context	= tx_buf;
+		msg.data	= data;
+		total_len = iov_dest[0].iov_len + iov_dest[1].iov_len;
+	}
+
+	if (total_len < mrail_ep->rails[i].info->tx_attr->inject_size)
 		flags |= FI_INJECT;
 
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting send of length: %" PRIu64
@@ -408,6 +549,7 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	uint32_t i = mrail_get_tx_rail(mrail_ep);
 	struct fi_msg msg;
 	ssize_t ret;
+	size_t total_len;
 
 	peer_info = ofi_av_get_addr(mrail_ep->util_ep.av, (int) dest_addr);
 
@@ -420,16 +562,34 @@ mrail_tsend_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		goto err1;
 	}
 	tx_buf->hdr.tag = tag;
-	mrail_copy_iov_hdr(&tx_buf->hdr, iov_dest, iov, count);
 
-	msg.msg_iov 	= iov_dest;
-	msg.desc    	= desc;
-	msg.iov_count	= count + 1;
-	msg.addr	= dest_addr;
-	msg.context	= tx_buf;
-	msg.data	= data;
+	if (len <= MRAIL_RNDV_THRESHOLD) {
+		tx_buf->hdr.protocol = MRAIL_PROTO_EAGER;
+		mrail_copy_iov_hdr(&tx_buf->hdr, iov_dest, iov, count);
 
-	if (len + iov_dest[0].iov_len < mrail_ep->rails[i].info->tx_attr->inject_size)
+		msg.msg_iov 	= iov_dest;
+		msg.desc    	= desc;
+		msg.iov_count	= count + 1;
+		msg.addr	= dest_addr;
+		msg.context	= tx_buf;
+		msg.data	= data;
+		total_len = len + iov_dest[0].iov_len;
+	} else {
+		ret = mrail_prepare_rndv_req(mrail_ep, tx_buf, iov, desc,
+					     count, len, iov_dest);
+		if (ret)
+			goto err2;
+
+		msg.msg_iov 	= iov_dest;
+		msg.desc    	= desc;
+		msg.iov_count	= 2;
+		msg.addr	= dest_addr;
+		msg.context	= tx_buf;
+		msg.data	= data;
+		total_len = iov_dest[0].iov_len + iov_dest[1].iov_len;
+	}
+
+	if (total_len < mrail_ep->rails[i].info->tx_attr->inject_size)
 		flags |= FI_INJECT;
 
 	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting tsend of length: %" PRIu64


### PR DESCRIPTION
Implement a Rendezvous protocol that use RMA read to deliver large size
messages. This enables striping large messages across the rails.

Future work will add tuning knobs for the Rendezvous threshold and
minimal stripe size.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>