### PR TITLE
verbs,ofi_rxm: check hugepages when fork enabled

### DIFF
--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -73,6 +73,26 @@ static inline int ofi_free_hugepage_buf(void *memptr, size_t size)
 	return munmap(memptr, size);
 }
 
+static inline int ofi_hugepage_enabled(void)
+{
+	size_t len;
+	void *buffer;
+	int ret;
+
+	len = ofi_get_hugepage_size();
+	if (len <= 0)
+		return 0;
+
+	ret = ofi_alloc_hugepage_buf(&buffer, len);
+	if (ret)
+		return 0;
+
+	ret = ofi_free_hugepage_buf(buffer, len);
+	assert(ret == 0);
+
+	return 1;
+}
+
 size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
 
 #endif /* _LINUX_OSD_H_ */

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -90,6 +90,11 @@ static inline size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
 	return 0;
 }
 
+static inline int ofi_hugepage_enabled(void)
+{
+	return 0;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -863,6 +863,11 @@ static inline int ofi_free_hugepage_buf(void *memptr, size_t size)
 	return -FI_ENOSYS;
 }
 
+static inline int ofi_hugepage_enabled(void)
+{
+	return 0;
+}
+
 static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 	return (addr->sa_family == AF_INET &&
 		((struct sockaddr_in *)addr)->sin_addr.s_addr == ntohl(INADDR_LOOPBACK)) ||

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -95,10 +95,10 @@ and the following completion ordering:
   * RX contexts: FI_ORDER_DATA
 
 ### Fork
-Verbs provider supports the fork system call by default. See the limitations section
-for restrictions. It can be turned off by setting the FI_FORK_UNSAFE environment
-variable to "yes". This can improve the performance of memory registrations but it
-also makes the use of fork unsafe.
+Verbs provider does not provide fork safety by default. Fork safety can be requested
+by setting IBV_FORK_SAFE, or RDMAV_FORK_SAFE. If the system configuration supports
+the use of huge pages, it is recommended to set RDMAV_HUGEPAGES_SAFE.
+See ibv_fork_init(3) for additional details.
 
 ### Memory Registration Cache
 The verbs provider features a memory registration cache. This speeds up memory

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -49,7 +49,6 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.def_rx_iov_limit	= 4,
 	.def_inline_size	= 256,
 	.min_rnr_timer		= VERBS_DEFAULT_MIN_RNR_TIMER,
-	.fork_unsafe		= 0,
 	/* Disable by default. Because this feature may corrupt
 	 * data due to IBV_EXP_ACCESS_RELAXED flag. But usage
 	 * this feature w/o this flag leads to poor bandwidth */
@@ -530,8 +529,6 @@ static int fi_ibv_get_param_str(const char *param_name,
 
 static int fi_ibv_read_params(void)
 {
-	int ret;
-
 	/* Common parameters */
 	if (fi_ibv_get_param_int("tx_size", "Default maximum tx context size",
 				 &fi_ibv_gl_data.def_tx_size) ||
@@ -576,13 +573,6 @@ static int fi_ibv_read_params(void)
 	     (fi_ibv_gl_data.min_rnr_timer > 31))) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of min_rnr_timer\n");
-		return -FI_EINVAL;
-	}
-
-	ret = fi_param_get_bool(NULL, "fork_unsafe", &fi_ibv_gl_data.fork_unsafe);
-	if (ret && ret != -FI_ENODATA) {
-		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of FI_FORK_UNSAFE\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -157,7 +157,6 @@ extern struct fi_ibv_gl_data {
 	int	def_rx_iov_limit;
 	int	def_inline_size;
 	int	min_rnr_timer;
-	int	fork_unsafe;
 	int	use_odp;
 	int	cqread_bunch_size;
 	char	*iface;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1206,19 +1206,6 @@ int fi_ibv_init_info(const struct fi_info **all_infos)
 	}
 	ep_type[2] = &verbs_dgram_domain;
 
-	if (!fi_ibv_gl_data.fork_unsafe) {
-		VERBS_INFO(FI_LOG_CORE, "Enabling IB fork support\n");
-		ret = ibv_fork_init();
-		if (ret) {
-			VERBS_WARN(FI_LOG_CORE,
-				   "Enabling IB fork support failed: %s (%d)\n",
-				   strerror(ret), ret);
-			goto done;
-		}
-	} else {
-		VERBS_INFO(FI_LOG_CORE, "Not enabling IB fork support\n");
-	}
-
 	if (!fi_ibv_have_device()) {
 		VERBS_INFO(FI_LOG_FABRIC, "No RDMA devices found\n");
 		ret = -FI_ENODATA;


### PR DESCRIPTION
Memory registration can fail with libibverbs when hugepages are
available and application fork support is enabled. In multi-model
applications, libfabric cannot guarantee the correct ordering of
calls to ibv_fork_init with the correct environment settings. To
address both of these problems, the verbs provider does not set any
environment variables related to fork and hugepage safety.

Signed-off-by: James Swaro <jswaro@cray.com>

closes #4969 