### PR TITLE
prov/rxd: fix unexpected messaging and add FI_PEEK, FI_CLAIM, FI_DISCARD support

### DIFF
--- a/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
+++ b/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
@@ -15,7 +15,6 @@ poll
 cq_data
 
 # Exclude tests with unsupported capabilities
-rdm_tagged_peek
 cm_data
 trigger
 shared_ctx

--- a/include/ofi_list.h
+++ b/include/ofi_list.h
@@ -396,10 +396,12 @@ static inline int slist_empty(struct slist *list)
 
 static inline void slist_insert_head(struct slist_entry *item, struct slist *list)
 {
-	if (slist_empty(list))
+	if (slist_empty(list)) {
 		list->tail = item;
-	else
+		item->next = NULL;
+	} else {
 		item->next = list->head;
+	}
 
 	list->head = item;
 }
@@ -411,6 +413,7 @@ static inline void slist_insert_tail(struct slist_entry *item, struct slist *lis
 	else
 		list->tail->next = item;
 
+	item->next = NULL;
 	list->tail = item;
 }
 

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -74,6 +74,7 @@
 #define RXD_RX_POOL_CHUNK_CNT	1024
 #define RXD_MAX_PENDING		128
 #define RXD_MAX_PKT_RETRY	50
+#define RXD_UNEXP_ID		(~0)
 
 #define RXD_PKT_IN_USE		(1 << 0)
 #define RXD_PKT_ACKED		(1 << 1)
@@ -297,6 +298,18 @@ struct rxd_pkt_entry {
 	void *pkt;
 };
 
+struct rxd_unexp_msg {
+	struct dlist_entry entry;
+	struct rxd_pkt_entry *pkt_entry;
+	struct dlist_entry pkt_list;
+	struct rxd_base_hdr *base_hdr;
+	struct rxd_sar_hdr *sar_hdr;
+	struct rxd_tag_hdr *tag_hdr;
+	struct rxd_data_hdr *data_hdr;
+	size_t msg_size;
+	void *msg;
+};
+
 static inline int rxd_pkt_type(struct rxd_pkt_entry *pkt_entry)
 {
 	return ((struct rxd_base_hdr *) (pkt_entry->pkt))->type;
@@ -354,6 +367,7 @@ static inline void *rxd_pkt_start(struct rxd_pkt_entry *pkt_entry)
 struct rxd_match_attr {
 	fi_addr_t	peer;
 	uint64_t	tag;
+	uint64_t	ignore;
 };
 
 static inline int rxd_match_addr(fi_addr_t addr, fi_addr_t match_addr)
@@ -433,7 +447,7 @@ uint64_t rxd_get_retry_time(uint64_t start, uint8_t retry_cnt);
 ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 			       size_t iov_count, fi_addr_t addr, uint64_t tag,
 			       uint64_t ignore, void *context, uint32_t op,
-			       uint32_t rxd_flags);
+			       uint32_t rxd_flags, uint64_t flags);
 ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 			       size_t iov_count, fi_addr_t addr, uint64_t tag,
 			       uint64_t data, void *context, uint32_t op,
@@ -457,10 +471,13 @@ void rxd_progress_op(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
 		     struct rxd_rma_hdr *rma_hdr,
 		     struct rxd_atom_hdr *atom_hdr,
 		     void **msg, size_t size);
+void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
+		      struct rxd_data_pkt *pkt, size_t size);
 void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer);
 struct rxd_x_entry *rxd_progress_multi_recv(struct rxd_ep *ep,
 					    struct rxd_x_entry *rx_entry,
 					    size_t total_size);
+void rxd_ep_progress(struct util_ep *util_ep);
 
 /* CQ sub-functions */
 void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry);

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -86,7 +86,6 @@
 #define RXD_TAG_HDR		(1 << 4)
 #define RXD_INLINE		(1 << 5)
 #define RXD_MULTI_RECV		(1 << 6)
-#define RXD_CANCELLED		(1 << 7)
 
 struct rxd_env {
 	int spin_count;

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -74,7 +74,6 @@
 #define RXD_RX_POOL_CHUNK_CNT	1024
 #define RXD_MAX_PENDING		128
 #define RXD_MAX_PKT_RETRY	50
-#define RXD_UNEXP_ID		(~0)
 
 #define RXD_PKT_IN_USE		(1 << 0)
 #define RXD_PKT_ACKED		(1 << 1)
@@ -139,6 +138,7 @@ struct rxd_peer {
 	uint16_t curr_rx_id;
 	uint16_t curr_tx_id;
 
+	struct rxd_unexp_msg *curr_unexp;
 	struct dlist_entry tx_list;
 	struct dlist_entry rx_list;
 	struct dlist_entry rma_rx_list;

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -174,8 +174,8 @@ static int rxd_comp_pkt_seq_no(struct dlist_entry *item, const void *arg)
 	return new_hdr->seq_no > list_hdr->seq_no;
 }
 
-static void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
-			     struct rxd_data_pkt *pkt, size_t size)
+void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
+		      struct rxd_data_pkt *pkt, size_t size)
 {
 	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
 	uint64_t done;
@@ -196,7 +196,6 @@ static void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
 			       ep->rx_prefix_size);
 
 	x_entry->bytes_done += done;
-	ep->peers[pkt->base_hdr.peer].rx_seq_no++;
 	x_entry->next_seg_no++;
 
 	if (x_entry->next_seg_no < x_entry->num_segs) {
@@ -380,27 +379,64 @@ static int rxd_match_tmsg(struct dlist_entry *item, const void *arg)
 			     attr->tag);
 }
 
-static void rxd_check_post_unexp(struct rxd_ep *ep, struct dlist_entry *list,
-				 struct rxd_pkt_entry *pkt_entry)
+static struct rxd_unexp_msg *rxd_init_unexp(struct rxd_ep *ep,
+					    struct rxd_pkt_entry *pkt_entry,
+					    struct rxd_base_hdr *base_hdr,
+					    struct rxd_sar_hdr *sar_hdr,
+			 		    struct rxd_tag_hdr *tag_hdr,
+					    struct rxd_data_hdr *data_hdr,
+					    void *msg, size_t msg_size)
 {
-	struct rxd_pkt_entry *unexp_entry;
-	struct rxd_base_hdr *new_hdr = rxd_get_base_hdr(pkt_entry);
+	struct rxd_unexp_msg *unexp_msg;
+
+	unexp_msg = calloc(1, sizeof(*unexp_msg));
+	if (!unexp_msg)
+		return NULL;
+
+	unexp_msg->pkt_entry = pkt_entry;
+	unexp_msg->base_hdr = base_hdr;
+	unexp_msg->sar_hdr = sar_hdr;
+	unexp_msg->tag_hdr = tag_hdr;
+	unexp_msg->data_hdr = data_hdr;
+	unexp_msg->msg_size = msg_size;
+	unexp_msg->msg = msg;
+
+	dlist_init(&unexp_msg->pkt_list);
+
+	return unexp_msg;
+}
+
+static void rxd_check_post_unexp(struct rxd_ep *ep, struct dlist_entry *list,
+				 struct rxd_pkt_entry *pkt_entry,
+				 struct rxd_base_hdr *base_hdr,
+				 struct rxd_sar_hdr *sar_hdr,
+				 struct rxd_tag_hdr *tag_hdr,
+				 struct rxd_data_hdr *data_hdr,
+				 void *msg, size_t msg_size)
+{
+	struct rxd_unexp_msg *unexp_msg;
 	struct rxd_base_hdr *unexp_hdr;
 
 	if (!rxd_env.retry)
 		goto insert;
 
-	dlist_foreach_container(list, struct rxd_pkt_entry, unexp_entry, d_entry) {
-		unexp_hdr = rxd_get_base_hdr(unexp_entry);
-		if (unexp_hdr->seq_no == new_hdr->seq_no &&
-		    unexp_hdr->peer == new_hdr->peer) {
+
+	dlist_foreach_container(list, struct rxd_unexp_msg, unexp_msg, entry) {
+		unexp_hdr = rxd_get_base_hdr(unexp_msg->pkt_entry);
+		if (unexp_hdr->seq_no == base_hdr->seq_no &&
+		    unexp_hdr->peer == base_hdr->peer) {
 			rxd_release_repost_rx(ep, pkt_entry);
 			return;
 		}
 	}
 
 insert:
-	dlist_insert_tail(&pkt_entry->d_entry, list);
+	ep->peers[base_hdr->peer].rx_seq_no++;
+	ep->peers[base_hdr->peer].curr_rx_id = RXD_UNEXP_ID;
+	unexp_msg = rxd_init_unexp(ep, pkt_entry, base_hdr, sar_hdr,
+				   tag_hdr, data_hdr, msg, msg_size);
+	if (unexp_msg)
+		dlist_insert_tail(&unexp_msg->entry, list);
 }
 
 static void rxd_handle_rts(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
@@ -468,7 +504,9 @@ static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 					struct rxd_pkt_entry *pkt_entry,
 					struct rxd_base_hdr *base,
 					struct rxd_tag_hdr *tag,
-					struct rxd_sar_hdr *op, size_t msg_size)
+					struct rxd_sar_hdr *op,
+					struct rxd_data_hdr *data,
+					void *msg, size_t msg_size)
 {
 	struct rxd_x_entry *rx_entry, *dup_entry;
 	struct dlist_entry *rx_list;
@@ -494,7 +532,8 @@ static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 	}
 
 	if (!match) {
-		rxd_check_post_unexp(ep, unexp_list, pkt_entry);
+		rxd_check_post_unexp(ep, unexp_list, pkt_entry, base, op, tag, data,
+				     msg, msg_size);
 		return NULL;
 	}
 
@@ -729,7 +768,7 @@ static struct rxd_x_entry *rxd_unpack_init_rx(struct rxd_ep *ep,
 	case RXD_MSG:
 	case RXD_TAGGED:
 		return rxd_match_rx(ep, pkt_entry, base_hdr, *tag_hdr, *sar_hdr,
-				    *msg_size);
+				    *data_hdr, *msg, *msg_size);
 	case RXD_READ_REQ:
 		return rxd_rma_read_entry_init(ep, base_hdr, *sar_hdr, *rma_hdr);
 	case RXD_ATOMIC_FETCH:
@@ -799,12 +838,12 @@ void rxd_progress_op(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
 
 	if (rx_entry->flags & RXD_CANCELLED) {
 		rxd_complete_rx(ep, rx_entry);
-		ep->peers[base_hdr->peer].rx_seq_no += base_hdr->flags & RXD_INLINE ?
-				1 : sar_hdr->num_segs;
+		if (sar_hdr)
+			ep->peers[base_hdr->peer].rx_seq_no +=
+				(sar_hdr->num_segs - 1);
 		return;
 	}
 
-	ep->peers[base_hdr->peer].rx_seq_no++;
 	if (sar_hdr)
 		ep->peers[base_hdr->peer].curr_tx_id = sar_hdr->tx_id;
 
@@ -877,21 +916,28 @@ static void rxd_progress_buf_pkts(struct rxd_ep *ep, fi_addr_t peer)
 			return;
 
 		if (base_hdr->type == RXD_DATA || base_hdr->type == RXD_DATA_READ) {
-			data_pkt = (struct rxd_data_pkt *) (pkt_entry->pkt);
+			data_pkt = (struct rxd_data_pkt *) pkt_entry->pkt;
 			rx_entry = rxd_get_data_x_entry(ep, data_pkt);
 			rxd_ep_recv_data(ep, rx_entry, data_pkt, pkt_entry->pkt_size);
 		} else {
 			rx_entry = rxd_unpack_init_rx(ep, pkt_entry, base_hdr, &sar_hdr,
 					      &tag_hdr, &data_hdr, &rma_hdr, &atom_hdr,
 					      &msg, &msg_size);
-			if (!rx_entry)
+			if (!rx_entry) {
+				if (base_hdr->type == RXD_MSG ||
+				    base_hdr->type == RXD_TAGGED) {
+					ep->peers[base_hdr->peer].rx_seq_no++;
+					continue;
+				}
 				break;
+			}
 
 			rxd_progress_op(ep, rx_entry, pkt_entry, base_hdr,
 					sar_hdr, tag_hdr, data_hdr, rma_hdr,
 					atom_hdr, &msg, msg_size);
 		}
 
+		ep->peers[base_hdr->peer].rx_seq_no++;
 		dlist_remove(&pkt_entry->d_entry);
 		rxd_release_repost_rx(ep, pkt_entry);
 	}
@@ -901,14 +947,31 @@ static void rxd_handle_data(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	struct rxd_data_pkt *pkt = (struct rxd_data_pkt *) (pkt_entry->pkt);
 	struct rxd_x_entry *x_entry;
+	struct dlist_entry *unexp_list;
+	struct rxd_unexp_msg *unexp_msg;
 
 	if (pkt_entry->pkt_size < sizeof(*pkt) + ep->rx_prefix_size) {
 		FI_WARN(&rxd_prov, FI_LOG_CQ,
 			"Cannot process packet smaller than minimum header size\n");
-		return;
+		goto free;
 	}
 
 	if (pkt->base_hdr.seq_no == ep->peers[pkt->base_hdr.peer].rx_seq_no) {
+		ep->peers[pkt->base_hdr.peer].rx_seq_no++;
+		if (pkt->base_hdr.type == RXD_DATA &&
+		    ep->peers[pkt->base_hdr.peer].curr_rx_id ==
+		    (uint16_t) RXD_UNEXP_ID) {
+			unexp_list = pkt->base_hdr.flags & RXD_TAG_HDR ?
+				     &ep->unexp_tag_list : &ep->unexp_list;
+			assert(!dlist_empty(unexp_list));
+			unexp_msg = container_of(unexp_list->prev,
+						 struct rxd_unexp_msg, entry);
+			dlist_insert_tail(&pkt_entry->d_entry, &unexp_msg->pkt_list);
+			if (pkt->ext_hdr.seg_no + 1 == unexp_msg->sar_hdr->num_segs - 1)
+				rxd_ep_send_ack(ep, pkt->base_hdr.peer);
+			rxd_remove_rx_pkt(ep, pkt_entry);
+			return;
+		}
 		x_entry = rxd_get_data_x_entry(ep, pkt);
 		rxd_ep_recv_data(ep, x_entry, pkt, pkt_entry->pkt_size);
 		if (!dlist_empty(&ep->peers[pkt->base_hdr.peer].buf_pkts))
@@ -917,10 +980,13 @@ static void rxd_handle_data(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 		rxd_remove_rx_pkt(ep, pkt_entry);
 		dlist_insert_order(&ep->peers[pkt->base_hdr.peer].buf_pkts,
 				   &rxd_comp_pkt_seq_no, &pkt_entry->d_entry);
-		ep->peers[pkt->base_hdr.peer].rx_seq_no++;
+		return;
 	} else {
 		rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 	}
+free:
+	rxd_remove_rx_pkt(ep, pkt_entry);
+	rxd_release_repost_rx(ep, pkt_entry);
 }
 
 static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
@@ -940,7 +1006,6 @@ static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 			rxd_remove_rx_pkt(ep, pkt_entry);
 			dlist_insert_order(&ep->peers[base_hdr->peer].buf_pkts,
 					   &rxd_comp_pkt_seq_no, &pkt_entry->d_entry);
-			ep->peers[base_hdr->peer].rx_seq_no++;
 			return;
 		}
 
@@ -957,6 +1022,7 @@ static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 				      &msg, &msg_size);
 	if (!rx_entry) {
 		if (base_hdr->type == RXD_MSG || base_hdr->type == RXD_TAGGED) {
+			rxd_ep_send_ack(ep, base_hdr->peer);
 			rxd_remove_rx_pkt(ep, pkt_entry);
 			return;
 		}
@@ -964,6 +1030,7 @@ static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 		goto ack;
 	}
 
+	ep->peers[base_hdr->peer].rx_seq_no++;
 	ep->peers[base_hdr->peer].rx_window = rxd_env.max_unacked;
 	rxd_progress_op(ep, rx_entry, pkt_entry, base_hdr, sar_hdr, tag_hdr,
 			data_hdr, rma_hdr, atom_hdr, &msg, msg_size);
@@ -1083,7 +1150,10 @@ void rxd_handle_recv_comp(struct rxd_ep *ep, struct fi_cq_msg_entry *comp)
 	case RXD_DATA:
 	case RXD_DATA_READ:
 		rxd_handle_data(ep, pkt_entry);
-		break;
+		/* don't need to perform action below:
+		 * - remove RX packet
+		 * - release/repost RX packet */
+		return;
 	default:
 		rxd_handle_op(ep, pkt_entry);
 		/* don't need to perform action below:

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -497,11 +497,12 @@ static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 	}
 
 	if (!match) {
+		assert(!ep->peers[base->peer].curr_unexp);
 		unexp_msg = rxd_init_unexp(ep, pkt_entry, base, op,
 					   tag, data, msg, msg_size);
 		if (unexp_msg) {
-			ep->peers[base->peer].curr_rx_id = RXD_UNEXP_ID;
 			dlist_insert_tail(&unexp_msg->entry, unexp_list);
+			ep->peers[base->peer].curr_unexp = unexp_msg;
 		}
 		return NULL;
 	}
@@ -905,7 +906,6 @@ static void rxd_handle_data(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	struct rxd_data_pkt *pkt = (struct rxd_data_pkt *) (pkt_entry->pkt);
 	struct rxd_x_entry *x_entry;
-	struct dlist_entry *unexp_list;
 	struct rxd_unexp_msg *unexp_msg;
 
 	if (pkt_entry->pkt_size < sizeof(*pkt) + ep->rx_prefix_size) {
@@ -917,16 +917,13 @@ static void rxd_handle_data(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 	if (pkt->base_hdr.seq_no == ep->peers[pkt->base_hdr.peer].rx_seq_no) {
 		ep->peers[pkt->base_hdr.peer].rx_seq_no++;
 		if (pkt->base_hdr.type == RXD_DATA &&
-		    ep->peers[pkt->base_hdr.peer].curr_rx_id ==
-		    (uint16_t) RXD_UNEXP_ID) {
-			unexp_list = pkt->base_hdr.flags & RXD_TAG_HDR ?
-				     &ep->unexp_tag_list : &ep->unexp_list;
-			assert(!dlist_empty(unexp_list));
-			unexp_msg = container_of(unexp_list->prev,
-						 struct rxd_unexp_msg, entry);
+		    ep->peers[pkt->base_hdr.peer].curr_unexp) {
+			unexp_msg = ep->peers[pkt->base_hdr.peer].curr_unexp;
 			dlist_insert_tail(&pkt_entry->d_entry, &unexp_msg->pkt_list);
-			if (pkt->ext_hdr.seg_no + 1 == unexp_msg->sar_hdr->num_segs - 1)
+			if (pkt->ext_hdr.seg_no + 1 == unexp_msg->sar_hdr->num_segs - 1) {
+				ep->peers[pkt->base_hdr.peer].curr_unexp = NULL;
 				rxd_ep_send_ack(ep, pkt->base_hdr.peer);
+			}
 			rxd_remove_rx_pkt(ep, pkt_entry);
 			return;
 		}
@@ -980,8 +977,15 @@ static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 				      &msg, &msg_size);
 	if (!rx_entry) {
 		if (base_hdr->type == RXD_MSG || base_hdr->type == RXD_TAGGED) {
+			if (!ep->peers[base_hdr->peer].curr_unexp)
+				goto ack;
+
 			ep->peers[base_hdr->peer].rx_seq_no++;
 			rxd_remove_rx_pkt(ep, pkt_entry);
+
+			if (!sar_hdr)
+				ep->peers[base_hdr->peer].curr_unexp = NULL;
+
 			rxd_ep_send_ack(ep, base_hdr->peer);
 			return;
 		}

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -406,39 +406,6 @@ static struct rxd_unexp_msg *rxd_init_unexp(struct rxd_ep *ep,
 	return unexp_msg;
 }
 
-static void rxd_check_post_unexp(struct rxd_ep *ep, struct dlist_entry *list,
-				 struct rxd_pkt_entry *pkt_entry,
-				 struct rxd_base_hdr *base_hdr,
-				 struct rxd_sar_hdr *sar_hdr,
-				 struct rxd_tag_hdr *tag_hdr,
-				 struct rxd_data_hdr *data_hdr,
-				 void *msg, size_t msg_size)
-{
-	struct rxd_unexp_msg *unexp_msg;
-	struct rxd_base_hdr *unexp_hdr;
-
-	if (!rxd_env.retry)
-		goto insert;
-
-
-	dlist_foreach_container(list, struct rxd_unexp_msg, unexp_msg, entry) {
-		unexp_hdr = rxd_get_base_hdr(unexp_msg->pkt_entry);
-		if (unexp_hdr->seq_no == base_hdr->seq_no &&
-		    unexp_hdr->peer == base_hdr->peer) {
-			rxd_release_repost_rx(ep, pkt_entry);
-			return;
-		}
-	}
-
-insert:
-	ep->peers[base_hdr->peer].rx_seq_no++;
-	ep->peers[base_hdr->peer].curr_rx_id = RXD_UNEXP_ID;
-	unexp_msg = rxd_init_unexp(ep, pkt_entry, base_hdr, sar_hdr,
-				   tag_hdr, data_hdr, msg, msg_size);
-	if (unexp_msg)
-		dlist_insert_tail(&unexp_msg->entry, list);
-}
-
 static void rxd_handle_rts(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	struct rxd_av *rxd_av;
@@ -509,6 +476,7 @@ static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 					void *msg, size_t msg_size)
 {
 	struct rxd_x_entry *rx_entry, *dup_entry;
+	struct rxd_unexp_msg *unexp_msg;
 	struct dlist_entry *rx_list;
 	struct dlist_entry *unexp_list;
 	struct dlist_entry *match;
@@ -532,8 +500,12 @@ static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 	}
 
 	if (!match) {
-		rxd_check_post_unexp(ep, unexp_list, pkt_entry, base, op, tag, data,
-				     msg, msg_size);
+		unexp_msg = rxd_init_unexp(ep, pkt_entry, base, op,
+					   tag, data, msg, msg_size);
+		if (unexp_msg) {
+			ep->peers[base->peer].curr_rx_id = RXD_UNEXP_ID;
+			dlist_insert_tail(&unexp_msg->entry, unexp_list);
+		}
 		return NULL;
 	}
 
@@ -1022,8 +994,9 @@ static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 				      &msg, &msg_size);
 	if (!rx_entry) {
 		if (base_hdr->type == RXD_MSG || base_hdr->type == RXD_TAGGED) {
-			rxd_ep_send_ack(ep, base_hdr->peer);
+			ep->peers[base_hdr->peer].rx_seq_no++;
 			rxd_remove_rx_pkt(ep, pkt_entry);
+			rxd_ep_send_ack(ep, base_hdr->peer);
 			return;
 		}
 		ep->peers[base_hdr->peer].rx_window = 0;

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -119,9 +119,6 @@ static void rxd_complete_rx(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 	struct rxd_cq *rx_cq = rxd_ep_rx_cq(ep);
 	int ret;
 
-	if (rx_entry->flags & RXD_CANCELLED)
-		goto out;
-
 	if (rx_entry->bytes_done != rx_entry->cq_entry.len) {
 		memset(&err_entry, 0, sizeof(err_entry));
 		err_entry.op_context = rx_entry->cq_entry.op_context;
@@ -512,8 +509,6 @@ static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 	rx_entry = container_of(match, struct rxd_x_entry, entry);
 
 	total_size = op ? op->size : msg_size;
-	if (rx_entry->flags & RXD_CANCELLED)
-		goto out;
 
 	if (rx_entry->flags & RXD_MULTI_RECV) {
 		dup_entry = rxd_progress_multi_recv(ep, rx_entry, total_size);
@@ -807,15 +802,6 @@ void rxd_progress_op(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
 		     struct rxd_atom_hdr *atom_hdr,
 		     void **msg, size_t size)
 {
-
-	if (rx_entry->flags & RXD_CANCELLED) {
-		rxd_complete_rx(ep, rx_entry);
-		if (sar_hdr)
-			ep->peers[base_hdr->peer].rx_seq_no +=
-				(sar_hdr->num_segs - 1);
-		return;
-	}
-
 	if (sar_hdr)
 		ep->peers[base_hdr->peer].curr_tx_id = sar_hdr->tx_id;
 

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -134,7 +134,7 @@ static ssize_t rxd_ep_cancel_recv(struct rxd_ep *ep, struct dlist_entry *list,
 
 	fastlock_acquire(&ep->util_ep.lock);
 
-	entry = dlist_find_first_match(list, &rxd_match_ctx, context);
+	entry = dlist_remove_first_match(list, &rxd_match_ctx, context);
 	if (!entry)
 		goto out;
 
@@ -149,9 +149,7 @@ static ssize_t rxd_ep_cancel_recv(struct rxd_ep *ep, struct dlist_entry *list,
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not write error entry\n");
 		goto out;
 	}
-
-	rx_entry->flags |= RXD_CANCELLED;
-
+	rxd_rx_entry_free(ep, rx_entry);
 	ret = 1;
 out:
 	fastlock_release(&ep->util_ep.lock);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -241,7 +241,7 @@ struct rxd_x_entry *rxd_rx_entry_init(struct rxd_ep *ep,
 
 	rx_entry->cq_entry.op_context = context;
 	rx_entry->cq_entry.len = ofi_total_iov_len(iov, iov_count);
-	rx_entry->cq_entry.buf = iov[0].iov_base;
+	rx_entry->cq_entry.buf = iov_count ? iov[0].iov_base : NULL;
 	rx_entry->cq_entry.tag = tag;
 
 	rx_entry->cq_entry.flags = ofi_rx_cq_flags(op);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1170,7 +1170,7 @@ int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 	struct ofi_bufpool_attr entry_pool_attr = {
 		.size		= sizeof(struct rxd_x_entry),
 		.alignment	= RXD_BUF_POOL_ALIGNMENT,
-		.max_cnt	= (size_t) ((uint16_t) RXD_UNEXP_ID),
+		.max_cnt	= (size_t) ((uint16_t) (~0)),
 		.flags		= OFI_BUFPOOL_INDEXED,
 	};
 	int ret;

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -38,68 +38,86 @@
 
 static int rxd_match_unexp(struct dlist_entry *item, const void *arg)
 {
-	struct rxd_x_entry *rx_entry = (struct rxd_x_entry *) arg;
-	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_base_hdr *hdr;
+	struct rxd_match_attr *attr = (struct rxd_match_attr *) arg;
+	struct rxd_unexp_msg *unexp_msg;
 
-	pkt_entry = container_of(item, struct rxd_pkt_entry, d_entry);
-	hdr = rxd_get_base_hdr(pkt_entry);
+	unexp_msg = container_of(item, struct rxd_unexp_msg, entry);
 
-	if (!rxd_match_addr(rx_entry->peer, hdr->peer))
+	if (!rxd_match_addr(attr->peer, unexp_msg->base_hdr->peer))
 		return 0;
 
-	if (hdr->type != RXD_TAGGED)
+	if (!unexp_msg->tag_hdr)
 		return 1;
 
-	return rxd_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore,
-			     rxd_get_tag_hdr(pkt_entry)->tag);
+	return rxd_match_tag(attr->tag, attr->ignore,
+			     unexp_msg->tag_hdr->tag);
 }
 
-static int rxd_ep_check_unexp_msg_list(struct rxd_ep *ep,
-					struct dlist_entry *unexp_list,
-					struct dlist_entry *rx_list,
-					struct rxd_x_entry *rx_entry)
+static struct rxd_unexp_msg *rxd_ep_check_unexp_list(struct dlist_entry *list,
+				fi_addr_t addr, uint64_t tag, uint64_t ignore)
 {
+	struct rxd_match_attr attr;
 	struct dlist_entry *match;
-	struct rxd_x_entry *progress_entry, *dup_entry = NULL;
+
+	attr.peer = addr;
+	attr.tag = tag;
+	attr.ignore = ignore;
+
+	match = dlist_find_first_match(list, &rxd_match_unexp, &attr);
+	if (!match)
+		return NULL;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Matched to unexp msg entry\n");
+
+	return container_of(match, struct rxd_unexp_msg, entry);
+}
+
+static void rxd_progress_unexp_msg(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
+				   struct rxd_unexp_msg *unexp_msg)
+{
 	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_base_hdr *base_hdr;
-	struct rxd_sar_hdr *sar_hdr = NULL;
-	struct rxd_tag_hdr *tag_hdr = NULL;
-	struct rxd_data_hdr *data_hdr = NULL;
-	struct rxd_atom_hdr *atom_hdr = NULL;
-	struct rxd_rma_hdr *rma_hdr = NULL;
-	void *msg = NULL;
-	size_t msg_size, total_size;
+
+	rxd_progress_op(ep, rx_entry, unexp_msg->pkt_entry, unexp_msg->base_hdr,
+			unexp_msg->sar_hdr, unexp_msg->tag_hdr,
+			unexp_msg->data_hdr, NULL, NULL, &unexp_msg->msg,
+			unexp_msg->msg_size);
+
+	while (!dlist_empty(&unexp_msg->pkt_list)) {
+		dlist_pop_front(&unexp_msg->pkt_list, struct rxd_pkt_entry,
+				pkt_entry, d_entry);
+		rxd_ep_recv_data(ep, rx_entry, (struct rxd_data_pkt *)
+				 (pkt_entry->pkt), pkt_entry->pkt_size);
+		rxd_release_repost_rx(ep, pkt_entry);
+	}
+	rxd_release_repost_rx(ep, unexp_msg->pkt_entry);
+	dlist_remove(&unexp_msg->entry);
+	free(unexp_msg);
+}
+
+static int rxd_progress_unexp_list(struct rxd_ep *ep,
+				   struct dlist_entry *unexp_list,
+				   struct dlist_entry *rx_list,
+				   struct rxd_x_entry *rx_entry)
+{
+	struct rxd_x_entry *progress_entry, *dup_entry = NULL;
+	struct rxd_unexp_msg *unexp_msg;
+	size_t total_size;
 
 	while (!dlist_empty(unexp_list)) {
-		match = dlist_remove_first_match(unexp_list, &rxd_match_unexp,
-						 (void *) rx_entry);
-		if (!match)
+		unexp_msg = rxd_ep_check_unexp_list(unexp_list, rx_entry->peer,
+					rx_entry->cq_entry.tag, rx_entry->ignore);
+		if (!unexp_msg)
 			return 0;
 
-		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "progressing unexp msg entry\n");
-	
-		pkt_entry = container_of(match, struct rxd_pkt_entry, d_entry);
-		base_hdr = rxd_get_base_hdr(pkt_entry);
+		total_size = unexp_msg->sar_hdr ? unexp_msg->sar_hdr->size :
+			     unexp_msg->msg_size;
 
-		rxd_unpack_hdrs(pkt_entry->pkt_size - ep->rx_prefix_size,
-				base_hdr, &sar_hdr, &tag_hdr,
-				&data_hdr, &rma_hdr, &atom_hdr, &msg, &msg_size);
-
-		total_size = sar_hdr ? sar_hdr->size : msg_size;
 		if (rx_entry->flags & RXD_MULTI_RECV)
 			dup_entry = rxd_progress_multi_recv(ep, rx_entry, total_size);
 
 		progress_entry = dup_entry ? dup_entry : rx_entry;
-	
 		progress_entry->cq_entry.len = MIN(rx_entry->cq_entry.len, total_size);
-
-		rxd_progress_op(ep, progress_entry, pkt_entry, base_hdr, sar_hdr, tag_hdr,
-				data_hdr, rma_hdr, atom_hdr, &msg, msg_size);
-		rxd_release_repost_rx(ep, pkt_entry);
-		rxd_ep_send_ack(ep, base_hdr->peer);
-
+		rxd_progress_unexp_msg(ep, progress_entry, unexp_msg);
 		if (!dup_entry)
 			return 1;
 	}
@@ -107,31 +125,91 @@ static int rxd_ep_check_unexp_msg_list(struct rxd_ep *ep,
 	return 0;
 }
 
+static int rxd_ep_discard_recv(struct rxd_ep *rxd_ep, void *context,
+			       struct rxd_unexp_msg *unexp_msg)
+{
+	struct rxd_pkt_entry *pkt_entry;
+	uint64_t seq = unexp_msg->base_hdr->seq_no;
+	int ret;
+
+	assert(unexp_msg->tag_hdr);
+	seq += unexp_msg->sar_hdr ? unexp_msg->sar_hdr->num_segs : 1;
+
+	rxd_ep->peers[unexp_msg->base_hdr->peer].rx_seq_no =
+			MAX(seq, rxd_ep->peers[unexp_msg->base_hdr->peer].rx_seq_no);
+	rxd_ep_send_ack(rxd_ep, unexp_msg->base_hdr->peer);
+
+	ret = ofi_cq_write(rxd_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
+			   0, NULL, unexp_msg->data_hdr ?
+			   unexp_msg->data_hdr->cq_data : 0,
+			   unexp_msg->tag_hdr->tag);
+
+	while (!dlist_empty(&unexp_msg->pkt_list)) {
+		dlist_pop_front(&unexp_msg->pkt_list, struct rxd_pkt_entry,
+				pkt_entry, d_entry);
+		rxd_release_repost_rx(rxd_ep, pkt_entry);
+	}
+
+	rxd_release_repost_rx(rxd_ep, unexp_msg->pkt_entry);
+
+	dlist_remove(&unexp_msg->entry);
+	free(unexp_msg);
+
+	return ret;
+}
+
+static int rxd_peek_recv(struct rxd_ep *rxd_ep, fi_addr_t addr, uint64_t tag,
+			 uint64_t ignore, void *context, uint64_t flags,
+			 struct dlist_entry *unexp_list)
+{
+	struct rxd_unexp_msg *unexp_msg;
+
+	fastlock_release(&rxd_ep->util_ep.lock);
+	rxd_ep_progress(&rxd_ep->util_ep);
+	fastlock_acquire(&rxd_ep->util_ep.lock);
+
+	unexp_msg = rxd_ep_check_unexp_list(unexp_list, addr, tag, ignore);
+	if (!unexp_msg) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Message not found\n");
+		return ofi_cq_write_error_peek(rxd_ep->util_ep.rx_cq, tag,
+					       context);
+	}
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Message found\n");
+
+	assert(unexp_msg->tag_hdr);
+	if (flags & FI_DISCARD)
+		return rxd_ep_discard_recv(rxd_ep, context, unexp_msg);
+
+	if (flags & FI_CLAIM) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Marking message for CLAIM\n");
+		((struct fi_context *)context)->internal[0] = unexp_msg;
+		dlist_remove(&unexp_msg->entry);
+	}
+
+	return ofi_cq_write(rxd_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
+			    unexp_msg->sar_hdr ? unexp_msg->sar_hdr->size :
+			    unexp_msg->msg_size, NULL, unexp_msg->data_hdr ?
+			    unexp_msg->data_hdr->cq_data : 0,
+			    unexp_msg->tag_hdr->tag);
+}
+
 ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 			       size_t iov_count, fi_addr_t addr, uint64_t tag,
 			       uint64_t ignore, void *context, uint32_t op,
-			       uint32_t rxd_flags)
+			       uint32_t rxd_flags, uint64_t flags)
 {
 	ssize_t ret = 0;
 	struct rxd_x_entry *rx_entry;
 	struct dlist_entry *unexp_list, *rx_list;
+	struct rxd_unexp_msg *unexp_msg;
 
 	assert(iov_count <= RXD_IOV_LIMIT);
 	assert(!(rxd_flags & RXD_MULTI_RECV) || iov_count == 1);
+	assert(!(flags & FI_PEEK) || op == ofi_op_tagged);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.rx_cq->cirq)) {
-		ret = -FI_EAGAIN;
-		goto out;
-	}
-
-	rx_entry = rxd_rx_entry_init(rxd_ep, iov, iov_count, tag, ignore, context,
-				(rxd_ep->util_ep.caps & FI_DIRECTED_RECV &&
-				addr != FI_ADDR_UNSPEC) ?
-				rxd_ep_av(rxd_ep)->fi_addr_table[addr] :
-				FI_ADDR_UNSPEC, op, rxd_flags);
-	if (!rx_entry) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}
@@ -144,11 +222,38 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		rx_list = &rxd_ep->rx_list;
 	}
 
-	if (!dlist_empty(unexp_list) &&
-	    rxd_ep_check_unexp_msg_list(rxd_ep, unexp_list, rx_list, rx_entry))
+	if (flags & FI_PEEK) {
+		ret = rxd_peek_recv(rxd_ep, addr, tag, ignore, context, flags,
+				    unexp_list);
 		goto out;
+	}
 
-	dlist_insert_tail(&rx_entry->entry, rx_list);
+	if (!(flags & FI_DISCARD)) {
+		rx_entry = rxd_rx_entry_init(rxd_ep, iov, iov_count, tag, ignore, context,
+					(rxd_ep->util_ep.caps & FI_DIRECTED_RECV &&
+					addr != FI_ADDR_UNSPEC) ?
+					rxd_ep_av(rxd_ep)->fi_addr_table[addr] :
+					FI_ADDR_UNSPEC, op, rxd_flags);
+		if (!rx_entry) {
+			ret = -FI_EAGAIN;
+		} else if (flags & FI_CLAIM) {
+			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Claiming message\n");
+			unexp_msg = (struct rxd_unexp_msg *)
+				(((struct fi_context *) context)->internal[0]);
+			rxd_progress_unexp_msg(rxd_ep, rx_entry, unexp_msg);
+		} else if (!rxd_progress_unexp_list(rxd_ep, unexp_list,
+			   rx_list, rx_entry)) {
+			dlist_insert_tail(&rx_entry->entry, rx_list);
+		}
+		goto out;
+	}
+
+	assert(flags & FI_CLAIM);
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Discarding message\n");
+	unexp_msg = (struct rxd_unexp_msg *)
+			(((struct fi_context *) context)->internal[0]);
+	ret = rxd_ep_discard_recv(rxd_ep, context, unexp_msg);
+
 out:
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
@@ -163,7 +268,8 @@ static ssize_t rxd_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count,
 				      msg->addr, 0, ~0, msg->context, ofi_op_msg,
-				      rxd_rx_flags(flags | ep->util_ep.rx_msg_flags));
+				      rxd_rx_flags(flags | ep->util_ep.rx_msg_flags),
+				      flags);
 }
 
 static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
@@ -178,7 +284,7 @@ static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *d
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, 0, ~0, context,
-				      ofi_op_msg, ep->rx_flags);
+				      ofi_op_msg, ep->rx_flags, 0);
 }
 
 static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -189,7 +295,7 @@ static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr,
-				      0, ~0, context, ofi_op_msg, ep->rx_flags);
+				      0, ~0, context, ofi_op_msg, ep->rx_flags, 0);
 }
 
 ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,

--- a/prov/rxd/src/rxd_tagged.c
+++ b/prov/rxd/src/rxd_tagged.c
@@ -49,7 +49,7 @@ ssize_t rxd_ep_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, tag, ignore,
 				      context, ofi_op_tagged,
-				      ep->rx_flags | RXD_TAG_HDR);
+				      ep->rx_flags | RXD_TAG_HDR, 0);
 }
 
 ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -62,7 +62,7 @@ ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **des
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr, tag, ignore,
 				      context, ofi_op_tagged,
-				      ep->rx_flags | RXD_TAG_HDR);
+				      ep->rx_flags | RXD_TAG_HDR, 0);
 }
 
 ssize_t rxd_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
@@ -75,7 +75,7 @@ ssize_t rxd_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count, msg->addr,
 				      msg->tag, msg->ignore, msg->context,
 				      ofi_op_tagged, rxd_rx_flags(flags |
-				      ep->util_ep.rx_msg_flags) | RXD_TAG_HDR);
+				      ep->util_ep.rx_msg_flags) | RXD_TAG_HDR, flags);
 }
 
 ssize_t rxd_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,


### PR DESCRIPTION
- Add FI_PEEK, FI_CLAIM, and FI_DISCARD
- Refactor/fix unexpected message buffering/processing to support large unexpected messages and simplify code path
- Fix segfault
- Fix fi_ep_cancel
- Fix slist_insert_tail

