### PR TITLE
prov/tcp: selecting port in tcpx_init_env

### DIFF
--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -785,12 +785,6 @@ int tcpx_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	_pep->cm_ctx.type = SERVER_SOCK_ACCEPT;
 	_pep->cm_ctx.cm_data_sz = 0;
 	_pep->sock = INVALID_SOCKET;
-
-	ret = tcpx_set_port_range();
-	if (ret == -FI_EINVAL) {
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,"Invalid info\n");
-		return -FI_EINVAL;
-	}
 	
 	*pep = &_pep->util_pep.pep_fid;
 
@@ -808,24 +802,3 @@ err1:
 	free(_pep);
 	return ret;
 }
-
-int tcpx_set_port_range ()
-{
-	int  low   = port_range.low;
-	int  high  = port_range.high;
-
-	if (high > TCPX_PORT_MAX_RANGE) {
-		high = TCPX_PORT_MAX_RANGE;
-	}
-
-	if (low < 0 || high < 0 || low > high) {
-		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,"Invalid info\n");
-		return -FI_EINVAL;
-	}
-
-	port_range.high = (unsigned short)high;
-	port_range.low  = (unsigned short)low;
-
-	return FI_SUCCESS;
-}
-


### PR DESCRIPTION
Reworked the place where initing port range is.
The handling port numbers is taking place in tcpx_init_env() now.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>