### PR TITLE
prov/verbs: Minor cleanup/corrections and log severity reduction

### DIFF
--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -386,7 +386,7 @@ int fi_ibv_ep_create_tgt_qp(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn)
 	attr_ex.xrcd = domain->xrc.xrcd;
 	if (rdma_create_qp_ex(ep->tgt_id, &attr_ex)) {
 		VERBS_INFO_ERRNO(FI_LOG_EP_CTRL,
-				 "Physical XRC TGT QP, rdma_create_ep_ex()",
+				 "Physical XRC TGT QP, rdma_create_qp_ex()",
 				 errno);
 		return -errno;
 	}

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -182,7 +182,6 @@ void fi_ibv_put_shared_ini_conn(struct fi_ibv_xrc_ep *ep)
 	ep->base_ep.ibv_qp = NULL;
 	if (ep->base_ep.id)
 		ep->base_ep.id->qp = NULL;
-	ep->base_ep.id->qp = NULL;
 
 	/* Tear down physical INI/TGT when no longer being used */
 	if (!ofi_atomic_dec32(&ini_conn->ref_cnt)) {

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -623,7 +623,7 @@ static int fi_ibv_get_device_attrs(struct ibv_context *ctx,
 	}
 
 	if (port_num == device_attr.phys_port_cnt + 1) {
-		VERBS_WARN(FI_LOG_FABRIC, "There are no active ports\n");
+		VERBS_INFO(FI_LOG_FABRIC, "There are no active ports\n");
 		return -FI_ENODATA;
 	} else {
 		VERBS_INFO(FI_LOG_FABRIC,


### PR DESCRIPTION
Separate commits for minor verbs provider cleanup which do not change provider function: Log statement text, duplicate line of code, and log severity level.