### PR TITLE
prov/rxd: fix packet type declaration and printing

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -201,7 +201,6 @@ uint64_t fi_gettime_ms(void);
 uint64_t fi_gettime_us(void);
 
 #define OFI_ENUM_VAL(X) X
-#define OFI_ENUM_VAL_EX(X, VAL) X = VAL
 #define OFI_STR(X) #X
 #define OFI_STR_INT(X) OFI_STR(X)
 

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -102,7 +102,7 @@ static ssize_t rxd_atomic_writemsg(struct fid_ep *ep_fid,
 				  NULL, NULL, 0, NULL, NULL, 0, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count, msg->data,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic, rxd_tx_flags(flags |
+				  RXD_ATOMIC, rxd_tx_flags(flags |
 				  ep->util_ep.tx_msg_flags));
 }
 
@@ -122,7 +122,7 @@ static ssize_t rxd_atomic_writev(struct fid_ep *ep_fid,
 
 	return rxd_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, NULL,
 				  NULL, 0, dest_addr, &rma_iov, 1, 0, datatype,
-				  op, context, ofi_op_atomic,
+				  op, context, RXD_ATOMIC,
 				  ep->tx_flags);
 }
 
@@ -146,7 +146,7 @@ static ssize_t rxd_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t c
 
 	return rxd_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, NULL, NULL, 0,
 				  dest_addr, &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic, ep->tx_flags);
+				  RXD_ATOMIC, ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
@@ -179,7 +179,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto out;
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, &iov, 1, NULL, 0, 1, 0, 0, NULL,
-				     rxd_addr, ofi_op_atomic,
+				     rxd_addr, RXD_ATOMIC,
 				     RXD_INJECT | RXD_NO_TX_COMP);
 	if (!tx_entry)
 		goto out;
@@ -206,7 +206,7 @@ static ssize_t rxd_atomic_readwritemsg(struct fid_ep *ep_fid,
 				  result_count, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count, msg->data,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic_fetch, rxd_tx_flags(flags |
+				  RXD_ATOMIC_FETCH, rxd_tx_flags(flags |
 				  ep->util_ep.tx_msg_flags));
 }
 
@@ -229,7 +229,7 @@ static ssize_t rxd_atomic_readwritev(struct fid_ep *ep_fid,
 	return rxd_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, resultv,
 				  result_desc, result_count, dest_addr,
 				  &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic_fetch, ep->tx_flags);
+				  RXD_ATOMIC_FETCH, ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
@@ -256,7 +256,7 @@ static ssize_t rxd_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
 
 	return rxd_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, &resultv,
 				  &result_desc, 1, dest_addr, &rma_iov, 1, 0,
-				  datatype, op, context, ofi_op_atomic_fetch,
+				  datatype, op, context, RXD_ATOMIC_FETCH,
 				  ep->tx_flags);
 }
 
@@ -276,7 +276,7 @@ static ssize_t rxd_atomic_compwritemsg(struct fid_ep *ep_fid,
 				  result_count, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count, msg->data,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic_compare, rxd_tx_flags(flags |
+				  RXD_ATOMIC_COMPARE, rxd_tx_flags(flags |
 				  ep->util_ep.tx_msg_flags));
 }
 
@@ -300,7 +300,7 @@ static ssize_t rxd_atomic_compwritev(struct fid_ep *ep_fid,
 	return rxd_generic_atomic(ep, iov, desc, count, comparev, compare_desc,
 				  compare_count, resultv, result_desc,
 				  result_count, dest_addr, &rma_iov, 1, 0,
-				  datatype, op, context, ofi_op_atomic_compare,
+				  datatype, op, context, RXD_ATOMIC_COMPARE,
 				  ep->tx_flags);
 }
 
@@ -332,7 +332,7 @@ static ssize_t rxd_atomic_compwrite(struct fid_ep *ep_fid, const void *buf,
 	return rxd_generic_atomic(ep, &iov, &desc, 1, &comparev, &compare_desc,
 				  1, &resultv, &result_desc, 1, dest_addr,
 				  &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic_compare, ep->tx_flags);
+				  RXD_ATOMIC_COMPARE, ep->tx_flags);
 }
 
 int rxd_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -83,7 +83,7 @@ static int rxd_cq_write_signal(struct rxd_cq *cq,
 
 void rxd_rx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 {
-	rx_entry->op <= ofi_op_tagged ? ep->rx_msg_avail++ : ep->rx_rma_avail++;
+	rx_entry->op <= RXD_TAGGED ? ep->rx_msg_avail++ : ep->rx_rma_avail++;
 	rx_entry->op = RXD_NO_OP;
 	dlist_remove(&rx_entry->entry);
 	ofi_ibuf_free(rx_entry);
@@ -299,7 +299,7 @@ void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer)
 			if (ofi_before(tx_entry->start_seq + (tx_entry->num_segs - 1),
 			    head_seq)) {
 				if (tx_entry->op == RXD_DATA_READ) {
-					tx_entry->op = ofi_op_read_req;
+					tx_entry->op = RXD_READ_REQ;
 					rxd_complete_rx(ep, tx_entry);
 				} else {
 					rxd_complete_tx(ep, tx_entry);
@@ -576,7 +576,7 @@ static struct rxd_x_entry *rxd_rma_read_entry_init(struct rxd_ep *ep,
 		return NULL;
 
 	rx_entry->iov_count = sar_hdr->iov_count;
-	rx_entry->cq_entry.flags = ofi_rx_cq_flags(ofi_op_read_req);
+	rx_entry->cq_entry.flags = ofi_rx_cq_flags(RXD_READ_REQ);
 	rx_entry->cq_entry.len = sar_hdr->size;
 
 	dlist_insert_tail(&rx_entry->entry, &ep->peers[rx_entry->peer].tx_list);
@@ -647,7 +647,7 @@ static struct rxd_x_entry *rxd_rx_atomic_fetch(struct rxd_ep *ep,
 	if (ret)
 		return NULL;
 
-	rx_entry->cq_entry.flags = ofi_rx_cq_flags(ofi_op_atomic_fetch);
+	rx_entry->cq_entry.flags = ofi_rx_cq_flags(RXD_ATOMIC_FETCH);
 	rx_entry->cq_entry.len = sar_hdr->size;
 
 	rxd_init_data_pkt(ep, rx_entry, rx_entry->pkt);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -76,7 +76,7 @@ static struct rxd_pkt_entry *rxd_get_rx_pkt(struct rxd_ep *ep)
 struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep, uint32_t op)
 {
 	struct rxd_x_entry *tx_entry;
-	size_t *avail = op <= ofi_op_tagged ? &ep->tx_msg_avail :
+	size_t *avail = op <= RXD_TAGGED ? &ep->tx_msg_avail :
 			&ep->tx_rma_avail;
 
 	if (!(*avail)) {
@@ -97,7 +97,7 @@ struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep, uint32_t op)
 struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep, uint32_t op)
 {
 	struct rxd_x_entry *rx_entry;
-	size_t *avail = op <= ofi_op_tagged ? &ep->rx_msg_avail :
+	size_t *avail = op <= RXD_TAGGED ? &ep->rx_msg_avail :
 			&ep->rx_rma_avail;
 
 	if (!(*avail)) {
@@ -427,7 +427,7 @@ struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov
 
 void rxd_tx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 {
-	tx_entry->op <= ofi_op_tagged ? ep->tx_msg_avail++ : ep->tx_rma_avail++;
+	tx_entry->op <= RXD_TAGGED ? ep->tx_msg_avail++ : ep->tx_rma_avail++;
 	tx_entry->op = RXD_NO_OP;
 	dlist_remove(&tx_entry->entry);
 	ofi_ibuf_free(tx_entry);

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -38,8 +38,6 @@
 #include "rxd_proto.h"
 #include "rxd.h"
 
-#define RXD_OFI_STR_EX(X, VAL) OFI_STR(X)
-
 struct rxd_env rxd_env = {
 	.spin_count	= 1000,
 	.retry		= 1,
@@ -48,7 +46,7 @@ struct rxd_env rxd_env = {
 };
 
 char *rxd_pkt_type_str[] = {
-	RXD_PKT_TYPES(RXD_OFI_STR_EX, OFI_STR)
+	RXD_FOREACH_TYPE(OFI_STR)
 };
 
 static void rxd_init_env(void)

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -216,7 +216,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	assert(iov_count <= RXD_IOV_LIMIT);
 	assert(!(rxd_flags & RXD_MULTI_RECV) || iov_count == 1);
-	assert(!(flags & FI_PEEK) || op == ofi_op_tagged);
+	assert(!(flags & FI_PEEK) || op == RXD_TAGGED);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
 
@@ -225,7 +225,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		goto out;
 	}
 
-	if (op == ofi_op_tagged) {
+	if (op == RXD_TAGGED) {
 		unexp_list = &rxd_ep->unexp_tag_list;
 		rx_list = &rxd_ep->rx_tag_list;
 	} else {
@@ -278,7 +278,7 @@ static ssize_t rxd_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count,
-				      msg->addr, 0, ~0, msg->context, ofi_op_msg,
+				      msg->addr, 0, ~0, msg->context, RXD_MSG,
 				      rxd_rx_flags(flags | ep->util_ep.rx_msg_flags),
 				      flags);
 }
@@ -295,7 +295,7 @@ static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *d
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, 0, ~0, context,
-				      ofi_op_msg, ep->rx_flags, 0);
+				      RXD_MSG, ep->rx_flags, 0);
 }
 
 static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -306,7 +306,7 @@ static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr,
-				      0, ~0, context, ofi_op_msg, ep->rx_flags, 0);
+				      0, ~0, context, RXD_MSG, ep->rx_flags, 0);
 }
 
 ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
@@ -395,7 +395,7 @@ static ssize_t rxd_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	return rxd_ep_generic_sendmsg(ep, msg->msg_iov, msg->iov_count,
 				   msg->addr, 0, msg->data, msg->context,
-				   ofi_op_msg, rxd_tx_flags(flags |
+				   RXD_MSG, rxd_tx_flags(flags |
 				   ep->util_ep.tx_msg_flags));
 
 }
@@ -408,7 +408,7 @@ static ssize_t rxd_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_sendmsg(ep, iov, count, dest_addr, 0,
-				      0, context, ofi_op_msg,
+				      0, context, RXD_MSG, 
 				      ep->tx_flags);
 }
 
@@ -424,7 +424,7 @@ static ssize_t rxd_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, 0,
-				      0, context, ofi_op_msg,
+				      0, context, RXD_MSG,
 				      ep->tx_flags);
 }
 
@@ -439,7 +439,7 @@ static ssize_t rxd_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_base = (void *) buf;
 	iov.iov_len = len;
 
-	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, 0, 0, ofi_op_msg,
+	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, 0, 0, RXD_MSG,
 				     RXD_NO_TX_COMP | RXD_INJECT);
 }
 
@@ -456,7 +456,7 @@ static ssize_t rxd_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t le
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, 0, data, context,
-				      ofi_op_msg, ep->tx_flags |
+				      RXD_MSG, ep->tx_flags |
 				      RXD_REMOTE_CQ_DATA);
 }
 
@@ -471,7 +471,7 @@ static ssize_t rxd_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t 
 	iov.iov_base = (void *) buf;
 	iov.iov_len = len;
 
-	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, 0, data, ofi_op_msg,
+	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, 0, data, RXD_MSG,
 				     RXD_NO_TX_COMP | RXD_INJECT |
 				     RXD_REMOTE_CQ_DATA);
 }

--- a/prov/rxd/src/rxd_proto.h
+++ b/prov/rxd/src/rxd_proto.h
@@ -43,23 +43,27 @@
 #define RXD_IOV_LIMIT		4
 #define RXD_NAME_LENGTH		64
 
-#define RXD_PKT_TYPES(FUNC_EX, FUNC)				\
-	FUNC_EX(RXD_MSG, ofi_op_msg),				\
-	FUNC_EX(RXD_TAGGED, ofi_op_tagged),			\
-	FUNC_EX(RXD_READ_REQ, ofi_op_read_req),			\
-	FUNC_EX(RXD_WRITE, ofi_op_write),			\
-	FUNC_EX(RXD_ATOMIC, ofi_op_atomic),			\
-	FUNC_EX(RXD_ATOMIC_FETCH, ofi_op_atomic_fetch),		\
-	FUNC_EX(RXD_ATOMIC_COMPARE, ofi_op_atomic_compare),	\
-	FUNC(RXD_RTS),						\
-	FUNC(RXD_CTS),						\
-	FUNC(RXD_ACK),						\
-	FUNC(RXD_DATA),						\
-	FUNC(RXD_DATA_READ),					\
+/* Values below are part of the wire protocol
+   Reserved values are unused but defined for compatibility */
+#define RXD_FOREACH_TYPE(FUNC)		\
+	FUNC(RXD_MSG),			\
+	FUNC(RXD_TAGGED),		\
+	FUNC(RXD_READ_REQ),		\
+	FUNC(RXD_RESV_1),		\
+	FUNC(RXD_WRITE),		\
+	FUNC(RXD_RESV_2),		\
+	FUNC(RXD_ATOMIC),		\
+	FUNC(RXD_ATOMIC_FETCH),		\
+	FUNC(RXD_ATOMIC_COMPARE),	\
+	FUNC(RXD_RTS),			\
+	FUNC(RXD_CTS),			\
+	FUNC(RXD_ACK),			\
+	FUNC(RXD_DATA),			\
+	FUNC(RXD_DATA_READ),		\
 	FUNC(RXD_NO_OP)
 
 enum rxd_pkt_type {
-	RXD_PKT_TYPES(OFI_ENUM_VAL_EX, OFI_ENUM_VAL)
+	RXD_FOREACH_TYPE(OFI_ENUM_VAL)
 };
 
 extern char *rxd_pkt_type_str[];

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -140,7 +140,7 @@ ssize_t rxd_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
-			       src_addr, context, ofi_op_read_req, 0,
+			       src_addr, context, RXD_READ_REQ, 0,
 			       ep->tx_flags);
 }
 
@@ -158,7 +158,7 @@ ssize_t rxd_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, iov, count, &rma_iov, 1, desc,
-			       src_addr, context, ofi_op_read_req, 0,
+			       src_addr, context, RXD_READ_REQ, 0,
 			       ep->tx_flags);
 }
 
@@ -172,7 +172,7 @@ ssize_t rxd_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	return rxd_generic_rma(ep, msg->msg_iov, msg->iov_count,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
-			       ofi_op_read_req, msg->data, rxd_tx_flags(flags |
+			       RXD_READ_REQ, msg->data, rxd_tx_flags(flags |
 			       ep->util_ep.tx_msg_flags));
 }
 
@@ -192,7 +192,7 @@ ssize_t rxd_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
-			       dest_addr, context, ofi_op_write, 0,
+			       dest_addr, context, RXD_WRITE, 0,
 			       ep->tx_flags);
 }
 
@@ -210,7 +210,7 @@ ssize_t rxd_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, iov, count, &rma_iov, 1, desc,
-			       dest_addr, context, ofi_op_write, 0,
+			       dest_addr, context, RXD_WRITE, 0,
 			       ep->tx_flags);
 }
 
@@ -225,7 +225,7 @@ ssize_t rxd_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	return rxd_generic_rma(ep, msg->msg_iov, msg->iov_count,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
-			       ofi_op_write, msg->data, rxd_tx_flags(flags |
+			       RXD_WRITE, msg->data, rxd_tx_flags(flags |
 			       ep->util_ep.tx_msg_flags));
 }
 
@@ -246,7 +246,7 @@ ssize_t rxd_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, &iov, 1, &rma_iov, 1, &desc,
-			       dest_addr, context, ofi_op_write, data,
+			       dest_addr, context, RXD_WRITE, data,
 			       ep->tx_flags | RXD_REMOTE_CQ_DATA);
 }
 
@@ -266,7 +266,7 @@ ssize_t rxd_inject_write(struct fid_ep *ep_fid, const void *buf,
 	rma_iov.key = key;
 
 	return rxd_generic_write_inject(rxd_ep, &iov, 1, &rma_iov, 1,
-					dest_addr, NULL, ofi_op_write, 0,
+					dest_addr, NULL, RXD_WRITE, 0,
 					RXD_NO_TX_COMP | RXD_INJECT);
 }
 
@@ -287,7 +287,7 @@ ssize_t rxd_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	rma_iov.key = key;
 
 	return rxd_generic_write_inject(rxd_ep, &iov, 1, &rma_iov, 1,
-					dest_addr, NULL, ofi_op_write,
+					dest_addr, NULL, RXD_WRITE,
 					data, RXD_NO_TX_COMP | RXD_INJECT |
 					RXD_REMOTE_CQ_DATA);
 }

--- a/prov/rxd/src/rxd_tagged.c
+++ b/prov/rxd/src/rxd_tagged.c
@@ -48,7 +48,7 @@ ssize_t rxd_ep_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, tag, ignore,
-				      context, ofi_op_tagged,
+				      context, RXD_TAGGED,
 				      ep->rx_flags | RXD_TAG_HDR, 0);
 }
 
@@ -61,7 +61,7 @@ ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **des
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr, tag, ignore,
-				      context, ofi_op_tagged,
+				      context, RXD_TAGGED,
 				      ep->rx_flags | RXD_TAG_HDR, 0);
 }
 
@@ -74,7 +74,7 @@ ssize_t rxd_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count, msg->addr,
 				      msg->tag, msg->ignore, msg->context,
-				      ofi_op_tagged, rxd_rx_flags(flags |
+				      RXD_TAGGED, rxd_rx_flags(flags |
 				      ep->util_ep.rx_msg_flags) | RXD_TAG_HDR, flags);
 }
 
@@ -90,7 +90,7 @@ ssize_t rxd_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &msg_iov, 1, dest_addr, tag,
-				      0, context, ofi_op_tagged,
+				      0, context, RXD_TAGGED,
 				      ep->tx_flags | RXD_TAG_HDR);
 }
 
@@ -103,7 +103,7 @@ ssize_t rxd_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_sendmsg(ep, iov, count, dest_addr, tag,
-				      0, context, ofi_op_tagged,
+				      0, context, RXD_TAGGED,
 				      ep->tx_flags | RXD_TAG_HDR);
 }
 
@@ -116,7 +116,7 @@ ssize_t rxd_ep_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	return rxd_ep_generic_sendmsg(ep, msg->msg_iov, msg->iov_count,
 				      msg->addr, msg->tag, msg->data, msg->context,
-				      ofi_op_tagged, rxd_tx_flags(flags |
+				      RXD_TAGGED, rxd_tx_flags(flags |
 				      ep->util_ep.tx_msg_flags) | RXD_TAG_HDR);
 }
 
@@ -132,7 +132,7 @@ ssize_t rxd_ep_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, tag, 0,
-				     ofi_op_tagged, RXD_NO_TX_COMP | RXD_INJECT |
+				     RXD_TAGGED, RXD_NO_TX_COMP | RXD_INJECT |
 				     RXD_TAG_HDR);
 }
 
@@ -149,7 +149,7 @@ ssize_t rxd_ep_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, tag, data, context,
-				      ofi_op_tagged, ep->tx_flags |
+				      RXD_TAGGED, ep->tx_flags |
 				      RXD_REMOTE_CQ_DATA | RXD_TAG_HDR);
 }
 
@@ -164,7 +164,7 @@ ssize_t rxd_ep_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_base = (void *) buf;
 	iov.iov_len = len;
 
-	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, tag, data, ofi_op_tagged,
+	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, tag, data, RXD_TAGGED,
 				     RXD_NO_TX_COMP | RXD_INJECT |
 				     RXD_REMOTE_CQ_DATA | RXD_TAG_HDR);
 }


### PR DESCRIPTION
Because RxD does not use two of the ofi_op enums in ofi_proto.h and then defines RxD-specific ones after, the printing (which is based on the array index of the new defines) is off by 2 for the new RxD-specific enums.

To fix this, eliminate the connection to the ofi_proto.h enums and define completely separate RXD types but make sure to align them with the ofi_proto enums so we don't break the protocol. Add in 2 placeholder enums to line up the enums for printing

Signed-off-by: aingerson <alexia.ingerson@intel.com>