### PR TITLE
prov/rxm, verbs: fixes for cmap and EQ

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -659,6 +659,7 @@ int ofi_av_close_lightweight(struct util_av *av);
 
 int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr);
 int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr);
+fi_addr_t ofi_av_lookup_fi_addr_unsafe(struct util_av *av, const void *addr);
 fi_addr_t ofi_av_lookup_fi_addr(struct util_av *av, const void *addr);
 int ofi_av_elements_iter(struct util_av *av, ofi_av_apply_func apply, void *arg);
 int ofi_av_bind(struct fid *av_fid, struct fid *eq_fid, uint64_t flags);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -269,8 +269,7 @@ int rxm_cmap_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
 void rxm_cmap_del_handle_ts(struct rxm_cmap_handle *handle);
 void rxm_cmap_free(struct rxm_cmap *cmap);
 int rxm_cmap_alloc(struct rxm_ep *rxm_ep, struct rxm_cmap_attr *attr);
-/* Caller must hold cmap->lock */
-int rxm_cmap_move_handle_to_peer_list(struct rxm_cmap *cmap, int index);
+int rxm_cmap_remove(struct rxm_cmap *cmap, int index);
 int rxm_msg_eq_progress(struct rxm_ep *rxm_ep);
 
 static inline struct rxm_cmap_handle *

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -37,29 +37,24 @@ static int rxm_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 {
 	struct util_av *av = container_of(av_fid, struct util_av, av_fid);
 	struct rxm_ep *rxm_ep;
-	int i, ret;
+	int i, ret = 0;
 
+	fastlock_acquire(&av->lock);
 	/* This should be before ofi_ip_av_remove as we need to know
 	 * fi_addr -> addr mapping when moving handle to peer list. */
 	dlist_foreach_container(&av->ep_list, struct rxm_ep,
 				rxm_ep, util_ep.av_entry) {
+		ofi_ep_lock_acquire(&rxm_ep->util_ep);
 		for (i = 0; i < count; i++) {
-			if (!rxm_ep->cmap->handles_av[fi_addr[i]])
-				continue;
-			/* TODO this is not optimal. Replace this with something
-			 * more deterministic: delete handle if we know that peer
-			 * isn't actively communicating with us
-			 */
-			ret = rxm_cmap_move_handle_to_peer_list(rxm_ep->cmap, i);
-			if (ret) {
-				FI_WARN(&rxm_prov, FI_LOG_DOMAIN,
-					"Unable to move  handle to "
-					"peer list. Deleting it.\n");
-				rxm_cmap_del_handle_ts(rxm_ep->cmap->handles_av[i]);
-				return ret;
-			}
+			ret = rxm_cmap_remove(rxm_ep->cmap, *fi_addr + i);
+			if (ret)
+				FI_WARN(&rxm_prov, FI_LOG_AV,
+					"cmap remove failed for fi_addr: %"
+					PRIu64 "\n", *fi_addr + i);
 		}
+		ofi_ep_lock_release(&rxm_ep->util_ep);
 	}
+	fastlock_release(&av->lock);
 
 	return ofi_ip_av_remove(av_fid, fi_addr, count, flags);
 }
@@ -75,23 +70,32 @@ rxm_av_insert_cmap(struct fid_av *av_fid, const void *addr, size_t count,
 	int ret = 0;
 	const void *cur_addr;
 
+	fastlock_acquire(&av->lock);
 	dlist_foreach_container(&av->ep_list, struct rxm_ep,
 				rxm_ep, util_ep.av_entry) {
+		ofi_ep_lock_acquire(&rxm_ep->util_ep);
 		for (i = 0; i < count; i++) {
+			if (!rxm_ep->cmap)
+				break;
+
 			cur_addr = (const void *) ((char *) addr + i * av->addrlen);
 			fi_addr_tmp = (fi_addr ? fi_addr[i] :
-				       ofi_av_lookup_fi_addr(av, cur_addr));
+				       ofi_av_lookup_fi_addr_unsafe(av, cur_addr));
 			if (fi_addr_tmp == FI_ADDR_NOTAVAIL)
 				continue;
+
 			ret = rxm_cmap_update(rxm_ep->cmap, cur_addr, fi_addr_tmp);
 			if (OFI_UNLIKELY(ret)) {
 				FI_WARN(&rxm_prov, FI_LOG_AV,
-					"Unable to update CM for OFI endpoints\n");
-				return ret;
+					"cmap update failed for fi_addr: %"
+					PRIu64 "\n", fi_addr_tmp);
+				break;
 			}
 		}
+		ofi_ep_lock_release(&rxm_ep->util_ep);
 	}
-	return 0;
+	fastlock_release(&av->lock);
+	return ret;
 }
 
 static int rxm_av_insert(struct fid_av *av_fid, const void *addr, size_t count,

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -385,19 +385,27 @@ rxm_cmap_get_handle_peer(struct rxm_cmap *cmap, const void *addr)
 	return peer->handle;
 }
 
-int rxm_cmap_move_handle_to_peer_list(struct rxm_cmap *cmap, int index)
+int rxm_cmap_remove(struct rxm_cmap *cmap, int index)
 {
 	struct rxm_cmap_handle *handle;
-	int ret = 0;
+	int ret = -FI_ENOENT;
+
+	assert(cmap->ep->domain->data_progress != FI_PROGRESS_AUTO ||
+	       cmap->acquire == ofi_fastlock_acquire);
 
 	cmap->acquire(&cmap->lock);
 	handle = cmap->handles_av[index];
-	if (!handle)
+	if (!handle) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "cmap entry not found\n");
 		goto unlock;
+	}
 
 	handle->peer = calloc(1, sizeof(*handle->peer) + cmap->av->addrlen);
 	if (!handle->peer) {
 		ret = -FI_ENOMEM;
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "unable to allocate memory "
+			"for moving handle to peer list, deleting it instead\n");
+		rxm_cmap_del_handle(handle);
 		goto unlock;
 	}
 	handle->fi_addr = FI_ADDR_NOTAVAIL;
@@ -991,7 +999,6 @@ static int rxm_conn_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
 	struct fi_cq_err_entry err_entry = {0};
 	int ret, count = 0;
 
-	ofi_ep_lock_acquire(&recv_queue->rxm_ep->util_ep);
 	dlist_foreach_container_safe(&recv_queue->unexp_msg_list,
 				     struct rxm_rx_buf, rx_buf,
 				     unexp_msg.entry, tmp_entry) {
@@ -1036,8 +1043,6 @@ static int rxm_conn_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
 		}
 		count++;
 	}
-	ofi_ep_lock_release(&recv_queue->rxm_ep->util_ep);
-
 	return count;
 }
 

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1455,9 +1455,15 @@ static int rxm_conn_atomic_progress_eq_cq(struct rxm_ep *rxm_ep,
 	memset(entry, 0, RXM_MSG_EQ_ENTRY_SZ);
 
 	while(1) {
-		ofi_ep_lock_acquire(&rxm_ep->util_ep);
+		/* Comply with restricted threading levels that MSG provider
+		 * may have been configured with */
+		if (rxm_ep->msg_info->domain_attr->threading != FI_THREAD_SAFE)
+			rxm_ep->cmap->acquire(&rxm_ep->cmap->lock);
+
 		again = fi_trywait(rxm_fabric->msg_fabric, fids, 2);
-		ofi_ep_lock_release(&rxm_ep->util_ep);
+
+		if (rxm_ep->msg_info->domain_attr->threading != FI_THREAD_SAFE)
+			rxm_ep->cmap->release(&rxm_ep->cmap->lock);
 
 		if (!again) {
 			fds[0].revents = 0;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1382,7 +1382,17 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 	}
 
 	do {
+		/* Comply with restricted threading levels that MSG provider
+		 * may have been configured with. cmap->acquire would be no-op
+		 * in case rxm data progress is manual */
+		if (rxm_ep->msg_info->domain_attr->threading != FI_THREAD_SAFE)
+			rxm_ep->cmap->acquire(&rxm_ep->cmap->lock);
+
 		ret = fi_cq_read(rxm_ep->msg_cq, &comp, 1);
+
+		if (rxm_ep->msg_info->domain_attr->threading != FI_THREAD_SAFE)
+			rxm_ep->cmap->release(&rxm_ep->cmap->lock);
+
 		if (ret > 0) {
 			// We don't have enough info to write a good
 			// error entry to the CQ at this point

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2034,7 +2034,7 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep, enum fi_wait_obj wait_obj)
 
 	ret = fi_cq_open(rxm_domain->msg_domain, &cq_attr, &rxm_ep->msg_cq, NULL);
 	if (ret) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to open MSG CQ\n");
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "unable to open MSG CQ\n");
 		return ret;
 	}
 
@@ -2104,18 +2104,6 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		ret = ofi_ep_bind_av(&rxm_ep->util_ep, av);
 		if (ret)
 			return ret;
-
-		ret = fi_listen(rxm_ep->msg_pep);
-		if (ret) {
-			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-				"Unable to set msg PEP to listen state\n");
-			return ret;
-		}
-
-		ret = rxm_conn_cmap_alloc(rxm_ep);
-		if (ret)
-			return ret;
-
 		break;
 	case FI_CLASS_CQ:
 		cq = container_of(bfid, struct util_cq, cq_fid.fid);
@@ -2124,12 +2112,17 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		if (ret)
 			return ret;
 
+		/* Ensure atomics progress thread isn't started at this point.
+		 * The progress thread should be started only after CQ is bound
+		 * to keep it simple (avoids progressing only EQ first and then
+		 * progressing both EQ and CQ once CQ is bound) */
+		assert(!(rxm_ep->rxm_info->caps & FI_ATOMIC) ||
+		       !rxm_ep->cmap || !rxm_ep->cmap->cm_thread);
+
 		if (!rxm_ep->msg_cq) {
-			ofi_ep_lock_acquire(&rxm_ep->util_ep);
 			ret = rxm_ep_msg_cq_open(rxm_ep, cq->wait ||
 				rxm_needs_atomic_progress(rxm_ep->rxm_info) ?
 				FI_WAIT_FD : FI_WAIT_NONE);
-			ofi_ep_lock_release(&rxm_ep->util_ep);
 			if (ret)
 				return ret;
 		}
@@ -2148,22 +2141,18 @@ static int rxm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 			return ret;
 
 		if (!rxm_ep->msg_cq) {
-			ofi_ep_lock_acquire(&rxm_ep->util_ep);
 			ret = rxm_ep_msg_cq_open(rxm_ep, cntr->wait ||
 				rxm_needs_atomic_progress(rxm_ep->rxm_info) ?
 				FI_WAIT_FD : FI_WAIT_NONE);
-			ofi_ep_lock_release(&rxm_ep->util_ep);
 			if (ret)
 				return ret;
 		} else if (!rxm_ep->msg_cq_fd && cntr->wait) {
 			/* Reopen CQ with WAIT fd set */
-			ofi_ep_lock_acquire(&rxm_ep->util_ep);
 			ret = fi_close(&rxm_ep->msg_cq->fid);
 			if (ret)
 				FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 					"Unable to close msg CQ\n");
 			ret = rxm_ep_msg_cq_open(rxm_ep, FI_WAIT_FD);
-			ofi_ep_lock_release(&rxm_ep->util_ep);
 			if (ret)
 				return ret;
 		}
@@ -2292,7 +2281,7 @@ err:
 
 static int rxm_ep_enable_check(struct rxm_ep *rxm_ep)
 {
-	if (!rxm_ep->util_ep.av || !rxm_ep->cmap)
+	if (!rxm_ep->util_ep.av)
 		return -FI_EOPBADSTATE;
 
 	if (rxm_ep->util_ep.rx_cq)
@@ -2323,6 +2312,20 @@ static int rxm_ep_ctrl(struct fid *fid, int command, void *arg)
 	switch (command) {
 	case FI_ENABLE:
 		ret = rxm_ep_enable_check(rxm_ep);
+		if (ret)
+			return ret;
+
+		/* fi_listen should be called before cmap alloc as cmap alloc
+		 * calls fi_getname on pep which would succeed only if fi_listen
+		 * was called first */
+		ret = fi_listen(rxm_ep->msg_pep);
+		if (ret) {
+			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+				"unable to set msg PEP to listen state\n");
+			return ret;
+		}
+
+		ret = rxm_conn_cmap_alloc(rxm_ep);
 		if (ret)
 			return ret;
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1173,8 +1173,6 @@ rxm_ep_emulate_inject(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	struct rxm_tx_eager_buf *tx_buf;
 	ssize_t ret;
 
-	assert(pkt_size <= rxm_ep->rxm_info->tx_attr->inject_size);
-
 	tx_buf = (struct rxm_tx_eager_buf *)
 		  rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX);
 	if (OFI_UNLIKELY(!tx_buf)) {

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -106,10 +106,7 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 
 		if (hints->domain_attr) {
 			core_info->domain_attr->caps |= hints->domain_attr->caps;
-			if (rxm_needs_atomic_progress(hints))
-				core_info->domain_attr->threading = FI_THREAD_SAFE;
-			else
-				core_info->domain_attr->threading = hints->domain_attr->threading;
+			core_info->domain_attr->threading = hints->domain_attr->threading;
 		}
 		if (hints->tx_attr) {
 			core_info->tx_attr->msg_order = hints->tx_attr->msg_order;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -357,6 +357,13 @@ int ofi_av_bind(struct fid *av_fid, struct fid *eq_fid, uint64_t flags)
 		return -FI_EINVAL;
 	}
 
+	if (!(av->flags & FI_EVENT)) {
+		FI_WARN(av->prov, FI_LOG_AV, "cannot bind EQ to an AV that was "
+			"configured for synchronous operation: FI_EVENT flag was"
+			" not specified in fi_av_attr when AV was opened\n");
+		return -FI_EINVAL;
+	}
+
 	if (flags) {
 		FI_WARN(av->prov, FI_LOG_AV, "invalid flags\n");
 		return -FI_EINVAL;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -322,15 +322,21 @@ int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr)
 	return 0;
 }
 
-fi_addr_t ofi_av_lookup_fi_addr(struct util_av *av, const void *addr)
+fi_addr_t ofi_av_lookup_fi_addr_unsafe(struct util_av *av, const void *addr)
 {
 	struct util_av_entry *entry = NULL;
 
-	fastlock_acquire(&av->lock);
 	HASH_FIND(hh, av->hash, addr, av->addrlen, entry);
-	fastlock_release(&av->lock);
-
 	return entry ? ofi_buf_index(entry) : FI_ADDR_NOTAVAIL;
+}
+
+fi_addr_t ofi_av_lookup_fi_addr(struct util_av *av, const void *addr)
+{
+	fi_addr_t fi_addr;
+	fastlock_acquire(&av->lock);
+	fi_addr = ofi_av_lookup_fi_addr_unsafe(av, addr);
+	fastlock_release(&av->lock);
+	return fi_addr;
 }
 
 static void *

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -55,8 +55,10 @@ fi_ibv_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 {
 	struct fi_ibv_eq *_eq =
 		container_of(eq, struct fi_ibv_eq, eq_fid.fid);
+	fastlock_acquire(&_eq->lock);
 	ofi_eq_handle_err_entry(_eq->fab->util_fabric.fabric_fid.api_version,
 				flags, &_eq->err, entry);
+	fastlock_release(&_eq->lock);
 	return sizeof(*entry);
 }
 
@@ -687,7 +689,7 @@ fi_ibv_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 			goto ack;
 
 		if (flags & FI_PEEK)
-			ret = fi_ibv_eq_write_event(eq, *event, buf, len);
+			ret = fi_ibv_eq_write_event(eq, *event, buf, ret);
 ack:
 		if (!acked)
 			rdma_ack_cm_event(cma_event);


### PR DESCRIPTION
This PR refactors cmap and fixes serialization issues in verbs EQ, rxm AV and atomics progress.

@swelch please take a look at patches 4 and 5 that modifies auto-progress for atomics.