### PR TITLE
prov/rxd: Optimize rxd_ep_send_op() function.

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -309,6 +309,11 @@ struct rxd_unexp_msg {
 	void *msg;
 };
 
+struct rxd_send_op_entry {
+	struct rxd_x_entry	*tx_entry;
+	struct rxd_pkt_entry	*pkt_entry;
+};
+
 static inline int rxd_pkt_type(struct rxd_pkt_entry *pkt_entry)
 {
 	return ((struct rxd_base_hdr *) (pkt_entry->pkt))->type;
@@ -416,9 +421,10 @@ ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
 void rxd_insert_unacked(struct rxd_ep *ep, fi_addr_t peer,
 			struct rxd_pkt_entry *pkt_entry);
 ssize_t rxd_send_rts_if_needed(struct rxd_ep *rxd_ep, fi_addr_t rxd_addr);
-int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry,
-		   const struct fi_rma_iov *rma_iov, size_t rma_count,
-		   const struct iovec *comp_iov, size_t comp_count,
+int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_send_op_entry *send_op_entry);
+struct rxd_send_op_entry *rxd_ep_send_op_atomic(struct rxd_ep *rxd_ep,
+		   struct rxd_x_entry *tx_entry, const struct fi_rma_iov *rma_iov, 
+		   size_t rma_count,const struct iovec *comp_iov, size_t comp_count,
 		   enum fi_datatype datatype, enum fi_op atomic_op);
 void rxd_init_data_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 		       struct rxd_pkt_entry *pkt_entry);
@@ -427,12 +433,13 @@ void rxd_unpack_hdrs(size_t pkt_size, struct rxd_base_hdr *base_hdr,
 		     struct rxd_data_hdr **data_hdr, struct rxd_rma_hdr **rma_hdr,
 		     struct rxd_atom_hdr **atom_hdr, void **msg, size_t *msg_size);
 
+
 /* Tx/Rx entry sub-functions */
-struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov,
-				      size_t iov_count, const struct iovec *res_iov,
-				      size_t res_count, size_t rma_count,
-				      uint64_t data, uint64_t tag, void *context,
-				      fi_addr_t addr, uint32_t op, uint32_t flags);
+struct rxd_x_entry *rxd_tx_entry_init_common(struct rxd_ep *ep, 
+			const struct iovec *iov, size_t iov_count, 
+			const struct iovec *res_iov, size_t res_count,
+			uint64_t data, uint64_t tag, void *context, fi_addr_t addr,
+			uint32_t op, uint32_t flags);
 struct rxd_x_entry *rxd_rx_entry_init(struct rxd_ep *ep,
 			const struct iovec *iov, size_t iov_count, uint64_t tag,
 			uint64_t ignore, void *context, fi_addr_t addr,
@@ -441,7 +448,14 @@ void rxd_tx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
 void rxd_rx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *rx_entry);
 int rxd_get_timeout(uint8_t retry_cnt);
 uint64_t rxd_get_retry_time(uint64_t start, uint8_t retry_cnt);
-
+struct rxd_send_op_entry *rxd_tx_entry_init_msg(struct rxd_ep *ep, const struct iovec *iov,
+			      size_t rma_count, uint64_t data, struct rxd_x_entry *tx_entry);      
+struct rxd_send_op_entry *rxd_tx_entry_init_rma(struct rxd_ep *ep, const struct iovec *iov,
+			      size_t rma_count, uint64_t data, struct rxd_x_entry *tx_entry,
+			      const struct fi_rma_iov *rma_iov);
+struct rxd_x_entry  *rxd_tx_entry_init_atomic(struct rxd_ep *ep, const struct iovec *iov,
+			      size_t rma_count, uint64_t data, struct rxd_x_entry *tx_entry);
+					  
 /* Generic message functions */
 ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 			       size_t iov_count, fi_addr_t addr, uint64_t tag,

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -45,6 +45,8 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	struct rxd_x_entry *tx_entry;
 	fi_addr_t rxd_addr;
 	ssize_t ret = -FI_EAGAIN;
+	struct rxd_send_op_entry  *send_op_entry;
+	
 
 	assert(iov_count <= RXD_IOV_LIMIT && rma_count <= RXD_IOV_LIMIT);
 	assert(ofi_total_iov_len(iov, iov_count) <= rxd_ep_domain(rxd_ep)->max_inline_rma);
@@ -59,14 +61,19 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	if (ret)
 		goto out;
 
-	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count, data,
-				     0, context, rxd_addr, op, rxd_flags);
+	tx_entry = rxd_tx_entry_init_common(rxd_ep, iov, iov_count, NULL, 0, data,
+				     	    0, context, rxd_addr, op, rxd_flags);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}
 
-	ret = rxd_ep_send_op(rxd_ep, tx_entry, rma_iov, rma_count, NULL, 0, 0, 0);
+	send_op_entry = rxd_tx_entry_init_rma(rxd_ep, iov, rma_count, data,
+				              tx_entry, rma_iov);
+	if (!send_op_entry)
+		goto out;
+	
+	ret = rxd_ep_send_op(rxd_ep, send_op_entry);
 	if (ret) {
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 		goto out;
@@ -88,6 +95,7 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	uint32_t rxd_flags)
 {
 	struct rxd_x_entry *tx_entry;
+	struct rxd_send_op_entry  *send_op_entry;
 	fi_addr_t rxd_addr;
 	ssize_t ret = -FI_EAGAIN;
 
@@ -108,14 +116,18 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	if (ret)
 		goto out;
 
-	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count,
-				     data, 0, context, rxd_addr, op, rxd_flags);
+	tx_entry = rxd_tx_entry_init_common(rxd_ep, iov, iov_count, NULL, 0,
+					    data, 0, context, rxd_addr, op, rxd_flags);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}
-
-	ret = rxd_ep_send_op(rxd_ep, tx_entry, rma_iov, rma_count, NULL, 0, 0, 0);
+	send_op_entry = rxd_tx_entry_init_rma(rxd_ep, iov, rma_count,
+				     	      data, tx_entry, rma_iov);
+	if (!send_op_entry)
+		goto out;
+		
+	ret = rxd_ep_send_op(rxd_ep, send_op_entry);
 	if (ret)
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 


### PR DESCRIPTION
1) Split from rxd_ep_send_op() the handling of *_hdrs (service info)
   and max_inline values for every transmit operation into own
   functions.
2) In every function of a transmit operation added the formating a
   specefic pkt.

In conclusion, the rxd_ep_send_op() is unloaded, reducing the
instruction in it.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>