### PR TITLE
userfaultfd: Support all available huge page sizes

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -54,10 +54,24 @@
 #   define VALGRIND_MAKE_MEM_DEFINED(addr, len)
 #endif
 
+
+void ofi_mem_init(void);
+void ofi_mem_fini(void);
+
+enum {
+	OFI_PAGE_SIZE,
+	OFI_DEF_HUGEPAGE_SIZE,
+};
+
+extern size_t *page_sizes;
+extern size_t num_page_sizes;
+
 static inline long ofi_get_page_size()
 {
 	return ofi_sysconf(_SC_PAGESIZE);
 }
+ssize_t ofi_get_hugepage_size(void);
+
 
 /* We implement memdup to avoid external library dependency */
 static inline void *mem_dup(const void *src, size_t size)

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -125,8 +125,6 @@ void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
  */
 struct ofi_uffd {
 	struct ofi_mem_monitor		monitor;
-	long				page_size;
-	long				hugepage_size;
 	pthread_t			thread;
 	int				fd;
 };

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -216,7 +216,6 @@ enum ofi_mr_storage_type {
 	OFI_MR_STORAGE_DEFAULT = 0,
 	OFI_MR_STORAGE_RBT,
 	OFI_MR_STORAGE_USER,
-	OFI_MR_STORAGE_NONE,
 };
 
 struct ofi_mr_storage {

--- a/include/windows/dirent.h
+++ b/include/windows/dirent.h
@@ -2,3 +2,15 @@
 #pragma once
 
 
+
+struct dirent {
+	char	d_name[256];
+};
+
+static inline int scandir(const char *dirp, struct dirent **namelist,
+	    int (*filter)(const struct dirent *),
+	    int (*compar)(const struct dirent **, const struct dirent **))
+{
+	errno = ENOSYS;
+	return -1;
+}

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -199,6 +199,12 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 	entry_sz = (attr->size + sizeof(struct ofi_bufpool_hdr));
 	(*buf_pool)->entry_size = ofi_get_aligned_size(entry_sz, attr->alignment);
 
+	if (!attr->chunk_cnt) {
+		(*buf_pool)->attr.chunk_cnt =
+			((*buf_pool)->entry_size < page_sizes[OFI_PAGE_SIZE]) ?
+			64 : 16;
+	}
+
 	if ((*buf_pool)->attr.flags & OFI_BUFPOOL_INDEXED)
 		dlist_init(&(*buf_pool)->free_list.regions);
 	else

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -311,6 +311,10 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 	struct ofi_mr_entry *entry;
 	struct dlist_entry *tmp;
 
+	/* If we don't have a domain, initialization failed */
+	if (!cache->domain)
+		return;
+
 	FI_INFO(cache->domain->prov, FI_LOG_MR, "MR cache stats: "
 		"searches %zu, deletes %zu, hits %zu notify %zu\n",
 		cache->search_cnt, cache->delete_cnt, cache->hit_cnt,
@@ -327,12 +331,9 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 	fastlock_release(&cache->monitor->lock);
 
 	ofi_monitor_del_cache(cache);
-	if (cache->storage.type != OFI_MR_STORAGE_NONE)
-		cache->storage.destroy(&cache->storage);
-	if (cache->domain)
-		ofi_atomic_dec32(&cache->domain->ref);
-	if (cache->entry_pool)
-		ofi_bufpool_destroy(cache->entry_pool);
+	cache->storage.destroy(&cache->storage);
+	ofi_atomic_dec32(&cache->domain->ref);
+	ofi_bufpool_destroy(cache->entry_pool);
 	assert(cache->cached_cnt == 0);
 	assert(cache->cached_size == 0);
 }
@@ -417,8 +418,6 @@ static int ofi_mr_cache_init_storage(struct ofi_mr_cache *cache)
 		break;
 	}
 
-	if (ret)
-		cache->storage.type = OFI_MR_STORAGE_NONE;
 	return ret;
 }
 
@@ -437,13 +436,12 @@ int ofi_mr_cache_init(struct util_domain *domain,
 	cache->delete_cnt = 0;
 	cache->hit_cnt = 0;
 	cache->notify_cnt = 0;
+	cache->domain = domain;
+	ofi_atomic_inc32(&domain->ref);
 
 	ret = ofi_mr_cache_init_storage(cache);
 	if (ret)
-		return ret;
-
-	cache->domain = domain;
-	ofi_atomic_inc32(&domain->ref);
+		goto dec;
 
 	if (!cache->max_cached_size)
 		cache->max_cached_size = SIZE_MAX;
@@ -460,11 +458,11 @@ int ofi_mr_cache_init(struct util_domain *domain,
 
 	return 0;
 del:
-	cache->entry_pool = NULL;
 	ofi_monitor_del_cache(cache);
 destroy:
+	cache->storage.destroy(&cache->storage);
+dec:
 	ofi_atomic_dec32(&cache->domain->ref);
 	cache->domain = NULL;
-	cache->storage.destroy(&cache->storage);
 	return ret;
 }

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -450,9 +450,9 @@ int ofi_mr_cache_init(struct util_domain *domain,
 		goto destroy;
 
 	ret = ofi_bufpool_create(&cache->entry_pool,
-				   sizeof(struct ofi_mr_entry) +
-				   cache->entry_data_size,
-				   16, 0, cache->max_cached_cnt);
+				 sizeof(struct ofi_mr_entry) +
+				 cache->entry_data_size,
+				 16, cache->max_cached_cnt, 0);
 	if (ret)
 		goto del;
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -667,6 +667,7 @@ static void fi_ibv_fini(void)
 {
 #if HAVE_VERBS_DL
 	ofi_monitor_cleanup();
+	ofi_mem_fini();
 #endif
 	fi_freeinfo((void *)fi_ibv_util_prov.info);
 	fi_ibv_util_prov.info = NULL;
@@ -675,6 +676,7 @@ static void fi_ibv_fini(void)
 VERBS_INI
 {
 #if HAVE_VERBS_DL
+	ofi_mem_init();
 	ofi_monitor_init();
 #endif
 	if (fi_ibv_read_params()|| fi_ibv_init_info(&fi_ibv_util_prov.info))

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -551,6 +551,7 @@ void fi_ini(void)
 	fi_param_init();
 	fi_log_init();
 	ofi_osd_init();
+	ofi_mem_init();
 	ofi_pmem_init();
 	ofi_perf_init();
 	ofi_hook_init();
@@ -646,6 +647,7 @@ FI_DESTRUCTOR(fi_fini(void))
 
 	ofi_free_filter(&prov_filter);
 	ofi_monitor_cleanup();
+	ofi_mem_fini();
 	fi_log_fini();
 	fi_param_fini();
 	ofi_osd_fini();

--- a/src/mem.c
+++ b/src/mem.c
@@ -44,7 +44,8 @@
 #include <rdma/fabric.h>
 
 
-#define CACHE_SIZE	64
+static const int OFI_CACHE_SIZE = 64;
+
 
 uint64_t OFI_RMA_PMEM;
 void (*ofi_pmem_commit)(const void *addr, size_t len);
@@ -54,8 +55,8 @@ static void pmem_commit_clwb(const void *addr, size_t len)
 {
 	uintptr_t uptr;
 
-	for (uptr = (uintptr_t) addr & ~(CACHE_SIZE - 1);
-	     uptr < (uintptr_t) addr + len; uptr += CACHE_SIZE) {
+	for (uptr = (uintptr_t) addr & ~(OFI_CACHE_SIZE - 1);
+	     uptr < (uintptr_t) addr + len; uptr += OFI_CACHE_SIZE) {
 		ofi_clwb(uptr);
 	}
 	ofi_sfence();
@@ -65,8 +66,8 @@ static void pmem_commit_clflushopt(const void *addr, size_t len)
 {
 	uintptr_t uptr;
 
-	for (uptr = (uintptr_t) addr & ~(CACHE_SIZE - 1);
-	     uptr < (uintptr_t) addr + len; uptr += CACHE_SIZE) {
+	for (uptr = (uintptr_t) addr & ~(OFI_CACHE_SIZE - 1);
+	     uptr < (uintptr_t) addr + len; uptr += OFI_CACHE_SIZE) {
 		ofi_clflushopt(uptr);
 	}
 	ofi_sfence();
@@ -76,8 +77,8 @@ static void pmem_commit_clflush(const void *addr, size_t len)
 {
 	uintptr_t uptr;
 
-	for (uptr = (uintptr_t) addr & ~(CACHE_SIZE - 1);
-	     uptr < (uintptr_t) addr + len; uptr += CACHE_SIZE) {
+	for (uptr = (uintptr_t) addr & ~(OFI_CACHE_SIZE - 1);
+	     uptr < (uintptr_t) addr + len; uptr += OFI_CACHE_SIZE) {
 		ofi_clflush(uptr);
 	}
 }

--- a/src/mem.c
+++ b/src/mem.c
@@ -36,6 +36,7 @@
 #include <stdlib.h>
 #include <ctype.h>
 #include <inttypes.h>
+#include <dirent.h>
 
 #include <ofi_osd.h>
 #include <ofi.h>
@@ -46,10 +47,66 @@
 
 static const int OFI_CACHE_SIZE = 64;
 
+size_t *page_sizes = NULL;
+size_t num_page_sizes = 0;
+
+
+void ofi_mem_init(void)
+{
+	struct dirent **pglist = NULL;
+	size_t max_cnt;
+	ssize_t hpsize;
+	long psize;
+	int n;
+
+	psize = ofi_get_page_size();
+	if (psize < 0)
+		return;
+
+	hpsize = ofi_get_hugepage_size();
+	if (hpsize > 0) {
+		n = scandir("/sys/kernel/mm/hugepages", &pglist, NULL, NULL);
+		max_cnt = (n < 0) ? 2 : n + 1;
+	} else {
+		max_cnt = 1;
+		n = 0;
+	}
+
+	page_sizes = calloc(max_cnt, sizeof(*page_sizes));
+	if (!page_sizes)
+		goto free_list;
+
+	page_sizes[OFI_PAGE_SIZE] = psize;
+	if (hpsize > 0) {
+		page_sizes[OFI_DEF_HUGEPAGE_SIZE] = hpsize;
+		num_page_sizes = 2;
+	} else {
+		num_page_sizes = 1;
+	}
+
+	while (n--) {
+		if (sscanf(pglist[n]->d_name, "hugepages-%lukB", &hpsize) == 1) {
+			hpsize *= 1024;
+			if (hpsize != page_sizes[OFI_DEF_HUGEPAGE_SIZE])
+				page_sizes[num_page_sizes++] = hpsize;
+		}
+		free(pglist[n]);
+	}
+
+free_list:
+	while (n-- > 0)
+		free(pglist[n]);
+	free(pglist);
+}
+
+void ofi_mem_fini(void)
+{
+	free(page_sizes);
+}
+
 
 uint64_t OFI_RMA_PMEM;
 void (*ofi_pmem_commit)(const void *addr, size_t len);
-
 
 static void pmem_commit_clwb(const void *addr, size_t len)
 {


### PR DESCRIPTION
Add a global array to store the list of possible page sizes.  Fill the list by adding the standard page size, plus all available huge page sizes.  The latter is obtained by parsing the directories under /sys/kernel/mm/hugepages.