### PR TITLE
prov/rxd: restructure tx_entry + op packet initialization to reduce instructions

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -435,8 +435,6 @@ void rxd_init_atom_hdr(void **ptr, enum fi_datatype datatype,
 		       enum fi_op atomic_op);
 size_t rxd_init_msg(void **ptr, const struct iovec *iov, size_t iov_count,
 		    size_t total_len, size_t avail_len);
-size_t rxd_avail_buf(struct rxd_ep *rxd_ep, struct rxd_base_hdr *hdr,
-		     void *ptr);
 
 /* Tx/Rx entry sub-functions */
 struct rxd_x_entry *rxd_tx_entry_init_common(struct rxd_ep *ep, fi_addr_t addr,

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -61,7 +61,7 @@
 
 #define RXD_MAJOR_VERSION 	(1)
 #define RXD_MINOR_VERSION 	(0)
-#define RXD_PROTOCOL_VERSION 	(1)
+#define RXD_PROTOCOL_VERSION 	(2)
 
 #define RXD_MAX_MTU_SIZE	4096
 

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -416,23 +416,32 @@ ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
 void rxd_insert_unacked(struct rxd_ep *ep, fi_addr_t peer,
 			struct rxd_pkt_entry *pkt_entry);
 ssize_t rxd_send_rts_if_needed(struct rxd_ep *rxd_ep, fi_addr_t rxd_addr);
-int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry,
-		   const struct fi_rma_iov *rma_iov, size_t rma_count,
-		   const struct iovec *comp_iov, size_t comp_count,
-		   enum fi_datatype datatype, enum fi_op atomic_op);
+int rxd_start_xfer(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);
 void rxd_init_data_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 		       struct rxd_pkt_entry *pkt_entry);
 void rxd_unpack_hdrs(size_t pkt_size, struct rxd_base_hdr *base_hdr,
 		     struct rxd_sar_hdr **sar_hdr, struct rxd_tag_hdr **tag_hdr,
 		     struct rxd_data_hdr **data_hdr, struct rxd_rma_hdr **rma_hdr,
 		     struct rxd_atom_hdr **atom_hdr, void **msg, size_t *msg_size);
+void rxd_init_base_hdr(struct rxd_ep *rxd_ep, void **ptr,
+		       struct rxd_x_entry *tx_entry);
+void rxd_init_sar_hdr(void **ptr, struct rxd_x_entry *tx_entry,
+		      size_t iov_count);
+void rxd_init_tag_hdr(void **ptr, struct rxd_x_entry *tx_entry);
+void rxd_init_data_hdr(void **ptr, struct rxd_x_entry *tx_entry);
+void rxd_init_rma_hdr(void **ptr, const struct fi_rma_iov *rma_iov,
+		      size_t rma_count);
+void rxd_init_atom_hdr(void **ptr, enum fi_datatype datatype,
+		       enum fi_op atomic_op);
+size_t rxd_init_msg(void **ptr, const struct iovec *iov, size_t iov_count,
+		    size_t total_len, size_t avail_len);
+size_t rxd_avail_buf(struct rxd_ep *rxd_ep, struct rxd_base_hdr *hdr,
+		     void *ptr);
 
 /* Tx/Rx entry sub-functions */
-struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov,
-				      size_t iov_count, const struct iovec *res_iov,
-				      size_t res_count, size_t rma_count,
-				      uint64_t data, uint64_t tag, void *context,
-				      fi_addr_t addr, uint32_t op, uint32_t flags);
+struct rxd_x_entry *rxd_tx_entry_init_common(struct rxd_ep *ep, fi_addr_t addr,
+			uint32_t op, const struct iovec *iov, size_t iov_count,
+			uint64_t tag, uint64_t data, uint32_t flags, void *context);
 struct rxd_x_entry *rxd_rx_entry_init(struct rxd_ep *ep,
 			const struct iovec *iov, size_t iov_count, uint64_t tag,
 			uint64_t ignore, void *context, fi_addr_t addr,

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -338,14 +338,6 @@ static inline struct rxd_sar_hdr *rxd_get_sar_hdr(struct rxd_pkt_entry *pkt_entr
 		sizeof(struct rxd_base_hdr));
 }
 
-static inline struct rxd_tag_hdr *rxd_get_tag_hdr(struct rxd_pkt_entry *pkt_entry)
-{
-	struct rxd_base_hdr *hdr = rxd_get_base_hdr(pkt_entry);
-	
-	return (struct rxd_tag_hdr *) ((char *) hdr + sizeof(*hdr) +
-		(hdr->flags & RXD_INLINE ? 0 : sizeof(struct rxd_sar_hdr)));
-}
-
 static inline void rxd_set_tx_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	pkt_entry->pkt = (void *) ((char *) pkt_entry +

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -37,6 +37,66 @@
 #include "ofi_iov.h"
 #include "rxd.h"
 
+static struct rxd_x_entry *rxd_tx_entry_init_atomic(struct rxd_ep *ep, fi_addr_t addr,
+			uint32_t op, const struct iovec *iov, size_t iov_count,
+			uint64_t data, uint32_t flags, void *context,
+			const struct fi_rma_iov *rma_iov, size_t rma_count,
+			const struct iovec *res_iov, size_t res_count,
+			const struct iovec *comp_iov, size_t comp_count,
+			enum fi_datatype datatype, enum fi_op atomic_op)
+{
+	struct rxd_x_entry *tx_entry;
+	struct rxd_base_hdr *base_hdr;
+	size_t len;
+	void *ptr;
+
+	OFI_UNUSED(len);
+
+	tx_entry = rxd_tx_entry_init_common(ep, addr, op, iov, iov_count, 0,
+					    data, flags, context);
+	if (!tx_entry)
+		return NULL;
+
+	base_hdr = rxd_get_base_hdr(tx_entry->pkt);
+	ptr = (void *) base_hdr;
+
+	if (res_count) {
+		tx_entry->res_count = res_count;
+		memcpy(&tx_entry->res_iov[0], res_iov, sizeof(*res_iov) * res_count);
+	}
+
+	if (rma_count > 1 || tx_entry->cq_entry.flags & FI_READ) {
+		rxd_init_base_hdr(ep, &ptr, tx_entry);
+		rxd_init_sar_hdr(&ptr, tx_entry, rma_count);
+	} else {
+		tx_entry->flags |= RXD_INLINE;
+		tx_entry->num_segs = 1;
+		rxd_init_base_hdr(ep, &ptr, tx_entry);
+	}
+
+	if (tx_entry->flags & RXD_REMOTE_CQ_DATA)
+		rxd_init_data_hdr(&ptr, tx_entry);
+
+	rxd_init_rma_hdr(&ptr, rma_iov, rma_count);
+	rxd_init_atom_hdr(&ptr, datatype, atomic_op);
+
+	if (atomic_op != FI_ATOMIC_READ) {
+		tx_entry->bytes_done = rxd_init_msg(&ptr, tx_entry->iov,
+				tx_entry->iov_count, tx_entry->cq_entry.len,
+				rxd_avail_buf(ep, base_hdr, ptr));
+		if (tx_entry->op == RXD_ATOMIC_COMPARE) {
+			len = rxd_init_msg(&ptr, comp_iov, comp_count,
+					tx_entry->cq_entry.len,
+					rxd_avail_buf(ep, base_hdr, ptr));
+			assert(len == tx_entry->bytes_done);
+		}
+	}
+	tx_entry->pkt->pkt_size = ((char *) ptr - (char *) base_hdr) +
+				ep->tx_prefix_size;
+
+	return tx_entry;
+}
+
 static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 			const struct fi_ioc *ioc, void **desc, size_t count,
 			const struct fi_ioc *compare_ioc, void **compare_desc,
@@ -76,15 +136,14 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 	if (ret)
 		goto out;
 
-	tx_entry = rxd_tx_entry_init(rxd_ep, iov, count, res_iov, result_count, rma_count,
-				     data, 0, context, rxd_addr, op, rxd_flags);
+	tx_entry = rxd_tx_entry_init_atomic(rxd_ep, rxd_addr, op, iov, count,
+			data, rxd_flags, context, rma_iov, rma_count, res_iov,
+			result_count, comp_iov, compare_count, datatype, atomic_op);
 	if (!tx_entry)
 		goto out;
 
-	ret = rxd_ep_send_op(rxd_ep, tx_entry, rma_iov, rma_count, comp_iov,
-			     compare_count, datatype, atomic_op);
-	if (ret)
-		rxd_tx_entry_free(rxd_ep, tx_entry);
+	if (rxd_ep->peers[rxd_addr].peer_addr != FI_ADDR_UNSPEC)
+		(void) rxd_start_xfer(rxd_ep, tx_entry);
 
 out:
 	fastlock_release(&rxd_ep->util_ep.lock);
@@ -178,16 +237,16 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		goto out;
 
-	tx_entry = rxd_tx_entry_init(rxd_ep, &iov, 1, NULL, 0, 1, 0, 0, NULL,
-				     rxd_addr, RXD_ATOMIC,
-				     RXD_INJECT | RXD_NO_TX_COMP);
+	tx_entry = rxd_tx_entry_init_atomic(rxd_ep, rxd_addr, RXD_ATOMIC, &iov, 1,
+			0, RXD_INJECT | RXD_NO_TX_COMP, NULL, &rma_iov, 1, NULL,
+			0, NULL, 0, datatype, op);
 	if (!tx_entry)
 		goto out;
 
-	ret = rxd_ep_send_op(rxd_ep, tx_entry, &rma_iov, 1, NULL, 0, datatype, op);
-	if (ret)
-		rxd_tx_entry_free(rxd_ep, tx_entry);
+	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC)
+		goto out;
 
+	(void) rxd_start_xfer(rxd_ep, tx_entry);
 out:
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -242,7 +242,7 @@ static void rxd_verify_active(struct rxd_ep *ep, fi_addr_t addr, fi_addr_t peer_
 	}
 }
 
-static int rxd_start_xfer(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
+int rxd_start_xfer(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 {
 	struct rxd_base_hdr *hdr = rxd_get_base_hdr(tx_entry->pkt);
 

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -671,14 +671,6 @@ void rxd_unpack_hdrs(size_t pkt_size, struct rxd_base_hdr *base_hdr,
 	char *ptr = (char *) base_hdr + sizeof(*base_hdr);
 	uint8_t rma_count = 1;
 
-	if (!(base_hdr->flags & RXD_INLINE)) {
-		*sar_hdr = (struct rxd_sar_hdr *) ptr;
-		rma_count = (*sar_hdr)->iov_count;
-		ptr += sizeof(**sar_hdr);
-	} else {
-		*sar_hdr = NULL;
-	}
-
 	if (base_hdr->flags & RXD_TAG_HDR) {
 		*tag_hdr = (struct rxd_tag_hdr *) ptr;
 		ptr += sizeof(**tag_hdr);
@@ -691,6 +683,14 @@ void rxd_unpack_hdrs(size_t pkt_size, struct rxd_base_hdr *base_hdr,
 		ptr += sizeof(**data_hdr);
 	} else {
 		*data_hdr = NULL;
+	}
+
+	if (!(base_hdr->flags & RXD_INLINE)) {
+		*sar_hdr = (struct rxd_sar_hdr *) ptr;
+		rma_count = (*sar_hdr)->iov_count;
+		ptr += sizeof(**sar_hdr);
+	} else {
+		*sar_hdr = NULL;
 	}
 
 	if (base_hdr->type >= RXD_READ_REQ && base_hdr->type <= RXD_ATOMIC_COMPARE) {

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -411,6 +411,12 @@ static void rxd_handle_rts(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 	struct rxd_rts_pkt *pkt = (struct rxd_rts_pkt *) (pkt_entry->pkt);
 	int ret;
 
+	if (pkt->base_hdr.version != RXD_PROTOCOL_VERSION) {
+		FI_WARN(&rxd_prov, FI_LOG_CQ,
+			"ERROR: Protocol version mismatch with peer\n");
+		return;
+	}
+
 	rxd_av = rxd_ep_av(ep);
 	node = ofi_rbmap_find(&rxd_av->rbmap, pkt->source);
 
@@ -1011,6 +1017,12 @@ release:
 static void rxd_handle_cts(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	struct rxd_cts_pkt *cts = (struct rxd_cts_pkt *) (pkt_entry->pkt);
+
+	if (cts->base_hdr.version != RXD_PROTOCOL_VERSION) {
+		FI_WARN(&rxd_prov, FI_LOG_CQ,
+			"ERROR: Protocol version mismatch with peer\n");
+		return;
+	}
 
 	rxd_update_peer(ep, cts->rts_addr, cts->cts_addr);
 }

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -588,13 +588,6 @@ size_t rxd_init_msg(void **ptr, const struct iovec *iov, size_t iov_count,
 	return done;
 }
 
-size_t rxd_avail_buf(struct rxd_ep *rxd_ep, struct rxd_base_hdr *hdr,
-		     void *ptr)
-{
-	return rxd_ep_domain(rxd_ep)->max_inline_msg -
-		((uintptr_t) ptr - (uintptr_t) hdr);
-}
-
 void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer)
 {
 	struct rxd_pkt_entry *pkt_entry;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -349,19 +349,21 @@ void rxd_init_data_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 	pkt_entry->pkt_size += sizeof(*data_pkt) + ep->tx_prefix_size;
 }
 
-struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov,
-				      size_t iov_count, const struct iovec *res_iov,
-				      size_t res_count, size_t rma_count,
-				      uint64_t data, uint64_t tag, void *context,
-				      fi_addr_t addr, uint32_t op, uint32_t flags)
+struct rxd_x_entry *rxd_tx_entry_init_common(struct rxd_ep *ep, fi_addr_t addr,
+			uint32_t op, const struct iovec *iov, size_t iov_count,
+			uint64_t tag, uint64_t data, uint32_t flags, void *context)
 {
 	struct rxd_x_entry *tx_entry;
-	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
-	size_t max_inline;
 
 	tx_entry = rxd_get_tx_entry(ep, op);
 	if (!tx_entry) {
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not get tx entry\n");
+		return NULL;
+	}
+
+	tx_entry->pkt = rxd_get_tx_pkt(ep);
+	if (!tx_entry->pkt) {
+		rxd_tx_entry_free(ep, tx_entry);
 		return NULL;
 	}
 
@@ -373,54 +375,18 @@ struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov
 	tx_entry->next_seg_no = 0;
 	tx_entry->iov_count = iov_count;
 	memcpy(&tx_entry->iov[0], iov, sizeof(*iov) * iov_count);
-	if (res_count) {
-		tx_entry->res_count = res_count;
-		memcpy(&tx_entry->res_iov[0], res_iov, sizeof(*res_iov) * res_count);
-	}
 
 	tx_entry->cq_entry.op_context = context;
 	tx_entry->cq_entry.len = ofi_total_iov_len(iov, iov_count);
 	tx_entry->cq_entry.buf = iov[0].iov_base;
 	tx_entry->cq_entry.flags = ofi_tx_cq_flags(op);
 	tx_entry->cq_entry.tag = tag;
+	tx_entry->cq_entry.data = data;
 
-	tx_entry->pkt = NULL;
+	tx_entry->pkt->peer = tx_entry->peer;
 
-	max_inline = rxd_domain->max_inline_msg;
-	if (tx_entry->cq_entry.flags & FI_RMA)
-		max_inline -= sizeof(struct ofi_rma_iov) * rma_count;
-
-	if (tx_entry->flags & RXD_TAG_HDR)
-		max_inline -= sizeof(tx_entry->cq_entry.tag);
-	if (tx_entry->flags & RXD_REMOTE_CQ_DATA) {
-		max_inline -= sizeof(tx_entry->cq_entry.data);
-		tx_entry->cq_entry.data = data;
-	}
-
-	if (rma_count > 1 || tx_entry->cq_entry.flags & FI_READ ||
-	    tx_entry->cq_entry.len > max_inline)
-		max_inline -= sizeof(struct rxd_sar_hdr);
-	else
-		tx_entry->flags |= RXD_INLINE;
-
-	if (tx_entry->cq_entry.flags & FI_ATOMIC || tx_entry->cq_entry.len <= max_inline)
-		tx_entry->num_segs = 1;
-	else if (tx_entry->cq_entry.flags & FI_READ)
-		tx_entry->num_segs = ofi_div_ceil(tx_entry->cq_entry.len,
-						  rxd_domain->max_seg_sz);
-	else
-		tx_entry->num_segs = ofi_div_ceil(tx_entry->cq_entry.len - max_inline,
-						  rxd_domain->max_seg_sz) + 1;
-
-	if ((tx_entry->op == RXD_READ_REQ || tx_entry->op == RXD_ATOMIC_FETCH ||
-	     tx_entry->op == RXD_ATOMIC_COMPARE) &&
-	    ep->peers[tx_entry->peer].unacked_cnt < ep->peers[tx_entry->peer].tx_window &&
-	    ep->peers[tx_entry->peer].peer_addr != FI_ADDR_UNSPEC)
-		dlist_insert_tail(&tx_entry->entry,
-				  &ep->peers[tx_entry->peer].rma_rx_list);
-	else
-		dlist_insert_tail(&tx_entry->entry,
-				  &ep->peers[tx_entry->peer].tx_list);
+	dlist_insert_tail(&tx_entry->entry,
+			  &ep->peers[tx_entry->peer].tx_list);
 
 	return tx_entry;
 }
@@ -544,8 +510,8 @@ ssize_t rxd_send_rts_if_needed(struct rxd_ep *ep, fi_addr_t addr)
 	return 0;
 }
 
-static void rxd_init_base_hdr(struct rxd_ep *rxd_ep, void **ptr,
-			      struct rxd_x_entry *tx_entry)
+void rxd_init_base_hdr(struct rxd_ep *rxd_ep, void **ptr,
+		       struct rxd_x_entry *tx_entry)
 {
 	struct rxd_base_hdr *hdr = (struct rxd_base_hdr *) *ptr;
 
@@ -558,8 +524,8 @@ static void rxd_init_base_hdr(struct rxd_ep *rxd_ep, void **ptr,
 	*ptr = (char *) (*ptr) + sizeof(*hdr);
 }
 
-static void rxd_init_sar_hdr(void **ptr, struct rxd_x_entry *tx_entry,
-			     size_t iov_count)
+void rxd_init_sar_hdr(void **ptr, struct rxd_x_entry *tx_entry,
+		      size_t iov_count)
 {
 	struct rxd_sar_hdr *hdr = (struct rxd_sar_hdr *) *ptr;
 
@@ -571,7 +537,7 @@ static void rxd_init_sar_hdr(void **ptr, struct rxd_x_entry *tx_entry,
 	*ptr = (char *) (*ptr) + sizeof(*hdr);
 }
 
-static void rxd_init_tag_hdr(void **ptr, struct rxd_x_entry *tx_entry)
+void rxd_init_tag_hdr(void **ptr, struct rxd_x_entry *tx_entry)
 {
 	struct rxd_tag_hdr *hdr = (struct rxd_tag_hdr *) *ptr;
 
@@ -580,7 +546,7 @@ static void rxd_init_tag_hdr(void **ptr, struct rxd_x_entry *tx_entry)
 	*ptr = (char *) (*ptr) + sizeof(*hdr);
 }
 
-static void rxd_init_data_hdr(void **ptr, struct rxd_x_entry *tx_entry)
+void rxd_init_data_hdr(void **ptr, struct rxd_x_entry *tx_entry)
 {
 	struct rxd_data_hdr *hdr = (struct rxd_data_hdr *) *ptr;
 
@@ -589,8 +555,8 @@ static void rxd_init_data_hdr(void **ptr, struct rxd_x_entry *tx_entry)
 	*ptr = (char *) (*ptr) + sizeof(*hdr);
 }
 
-static void rxd_init_rma_hdr(void **ptr, const struct fi_rma_iov *rma_iov,
-			     size_t rma_count)
+void rxd_init_rma_hdr(void **ptr, const struct fi_rma_iov *rma_iov,
+		      size_t rma_count)
 {
 	struct rxd_rma_hdr *hdr = (struct rxd_rma_hdr *) *ptr;
 
@@ -599,8 +565,8 @@ static void rxd_init_rma_hdr(void **ptr, const struct fi_rma_iov *rma_iov,
 	*ptr = (char *) (*ptr) + (sizeof(*rma_iov) * rma_count);
 }
 
-static void rxd_init_atom_hdr(void **ptr, enum fi_datatype datatype,
-			      enum fi_op atomic_op)
+void rxd_init_atom_hdr(void **ptr, enum fi_datatype datatype,
+		       enum fi_op atomic_op)
 {
 	struct rxd_atom_hdr *hdr = (struct rxd_atom_hdr *) *ptr;
 
@@ -610,8 +576,8 @@ static void rxd_init_atom_hdr(void **ptr, enum fi_datatype datatype,
 	*ptr = (char *) (*ptr) + sizeof(*hdr);
 }
 
-static size_t rxd_init_msg(void **ptr, const struct iovec *iov, size_t iov_count,
-			   size_t total_len, size_t avail_len)
+size_t rxd_init_msg(void **ptr, const struct iovec *iov, size_t iov_count,
+		    size_t total_len, size_t avail_len)
 {
 	size_t done;
 
@@ -622,83 +588,11 @@ static size_t rxd_init_msg(void **ptr, const struct iovec *iov, size_t iov_count
 	return done;
 }
 
-static size_t rxd_avail_buf(struct rxd_ep *rxd_ep, struct rxd_base_hdr *hdr,
-			    void *ptr)
+size_t rxd_avail_buf(struct rxd_ep *rxd_ep, struct rxd_base_hdr *hdr,
+		     void *ptr)
 {
 	return rxd_ep_domain(rxd_ep)->max_inline_msg -
 		((uintptr_t) ptr - (uintptr_t) hdr);
-}
-
-int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry,
-		   const struct fi_rma_iov *rma_iov, size_t rma_count,
-		   const struct iovec *comp_iov, size_t comp_count,
-		   enum fi_datatype datatype, enum fi_op atomic_op)
-{
-	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_base_hdr *base_hdr;
-	int ret = 0;
-	size_t len;
-	void *ptr;
-
-	pkt_entry = rxd_get_tx_pkt(rxd_ep);
-	if (!pkt_entry)
-		return -FI_ENOMEM;
-
-	base_hdr = rxd_get_base_hdr(pkt_entry);
-	ptr = (void *) base_hdr;
-	rxd_init_base_hdr(rxd_ep, &ptr, tx_entry);
-
-	if (!(tx_entry->flags & RXD_INLINE)) {
-		rxd_init_sar_hdr(&ptr, tx_entry, rma_count);
-	}
-	if (tx_entry->flags & RXD_TAG_HDR) {
-		rxd_init_tag_hdr(&ptr, tx_entry);
-	}
-	if (tx_entry->flags & RXD_REMOTE_CQ_DATA) {
-		rxd_init_data_hdr(&ptr, tx_entry);
-	}
-	if (tx_entry->cq_entry.flags & (FI_RMA | FI_ATOMIC)) {
-		rxd_init_rma_hdr(&ptr, rma_iov, rma_count);
-		if (tx_entry->cq_entry.flags & FI_ATOMIC) {
-			rxd_init_atom_hdr(&ptr, datatype, atomic_op);
-		}
-	}
-	if (tx_entry->op != RXD_READ_REQ && atomic_op != FI_ATOMIC_READ) {
-		tx_entry->bytes_done = rxd_init_msg(&ptr, tx_entry->iov,
-						    tx_entry->iov_count,
-						    tx_entry->cq_entry.len,
-						    rxd_avail_buf(rxd_ep, base_hdr, ptr));
-		if (tx_entry->op == RXD_ATOMIC_COMPARE) {
-			len = rxd_init_msg(&ptr, comp_iov, comp_count,
-					   tx_entry->cq_entry.len,
-					   rxd_avail_buf(rxd_ep, base_hdr, ptr));
-			if (len != tx_entry->bytes_done) {
-				FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
-					"compare data length mismatch\n");
-			}
-		}
-	}
-
-	pkt_entry->peer = tx_entry->peer;
-	pkt_entry->pkt_size = ((char *) ptr - (char *) base_hdr) + rxd_ep->tx_prefix_size;
-
-	if (rxd_ep->peers[tx_entry->peer].unacked_cnt <
-	    rxd_ep->peers[tx_entry->peer].tx_window &&
-	    rxd_ep->peers[tx_entry->peer].peer_addr != FI_ADDR_UNSPEC) {
-		tx_entry->start_seq = rxd_set_pkt_seq(&rxd_ep->peers[tx_entry->peer],
-						      pkt_entry);
-		if (tx_entry->op != RXD_READ_REQ && tx_entry->num_segs > 1)
-			rxd_ep->peers[tx_entry->peer].tx_seq_no = tx_entry->start_seq +
-								  tx_entry->num_segs;
-		rxd_ep_send_pkt(rxd_ep, pkt_entry);
-		rxd_insert_unacked(rxd_ep, tx_entry->peer, pkt_entry);
-		if (tx_entry->op != RXD_READ_REQ && tx_entry->num_segs > 1)
-			ret = rxd_ep_post_data_pkts(rxd_ep, tx_entry);
-	} else {
-		tx_entry->pkt = pkt_entry;
-	}
-
-	return ret == -FI_ENOMEM ? ret : 0;
 }
 
 void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer)

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -357,7 +357,7 @@ static struct rxd_x_entry *rxd_tx_entry_init_msg(struct rxd_ep *ep, fi_addr_t ad
 	tx_entry->bytes_done = rxd_init_msg(&ptr, tx_entry->iov,
 					    tx_entry->iov_count,
 					    tx_entry->cq_entry.len,
-					    rxd_avail_buf(ep, base_hdr, ptr));
+					    max_inline);
 
 	tx_entry->pkt->pkt_size = ((char *) ptr - (char *) base_hdr) +
 				ep->tx_prefix_size;

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -309,6 +309,62 @@ static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void
 				      0, ~0, context, RXD_MSG, ep->rx_flags, 0);
 }
 
+static struct rxd_x_entry *rxd_tx_entry_init_msg(struct rxd_ep *ep, fi_addr_t addr,
+					uint32_t op, const struct iovec *iov,
+					size_t iov_count, uint64_t tag,
+					uint64_t data, uint32_t flags, void *context)
+{
+	struct rxd_x_entry *tx_entry;
+	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
+	size_t max_inline;
+	struct rxd_base_hdr *base_hdr;
+	void *ptr;
+
+	tx_entry = rxd_tx_entry_init_common(ep, addr, RXD_MSG, iov, iov_count,
+					    tag, data, flags, context);
+	if (!tx_entry)
+		return NULL;
+
+	base_hdr = rxd_get_base_hdr(tx_entry->pkt);
+	ptr = (void *) base_hdr;
+	rxd_init_base_hdr(ep, &ptr, tx_entry);
+
+	max_inline = rxd_domain->max_inline_msg;
+	if (tx_entry->flags & RXD_REMOTE_CQ_DATA)
+		max_inline -= sizeof(tx_entry->cq_entry.data);
+
+	if (tx_entry->flags & RXD_TAG_HDR)
+		max_inline -= sizeof(tx_entry->cq_entry.tag);
+
+	if (tx_entry->cq_entry.len > max_inline) {
+		max_inline -= sizeof(struct rxd_sar_hdr);
+		tx_entry->num_segs = ofi_div_ceil(tx_entry->cq_entry.len - max_inline,
+						  rxd_domain->max_seg_sz) + 1;
+		rxd_init_sar_hdr(&ptr, tx_entry, 0);
+	} else {
+		tx_entry->flags |= RXD_INLINE;
+		base_hdr->flags = tx_entry->flags;
+		tx_entry->num_segs = 1;
+	}
+
+	//TODO figure out a way to combine this with above check? (init sar, set num?)
+	if (tx_entry->flags & RXD_TAG_HDR)
+		rxd_init_tag_hdr(&ptr, tx_entry);
+
+	if (tx_entry->flags & RXD_REMOTE_CQ_DATA)
+		rxd_init_data_hdr(&ptr, tx_entry);
+
+	tx_entry->bytes_done = rxd_init_msg(&ptr, tx_entry->iov,
+					    tx_entry->iov_count,
+					    tx_entry->cq_entry.len,
+					    rxd_avail_buf(ep, base_hdr, ptr));
+
+	tx_entry->pkt->pkt_size = ((char *) ptr - (char *) base_hdr) +
+				ep->tx_prefix_size;
+
+	return tx_entry;
+}
+
 ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 			      size_t iov_count, fi_addr_t addr, uint64_t tag,
 			      uint64_t data, uint32_t op, uint32_t rxd_flags)
@@ -331,16 +387,15 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	if (ret)
 		goto out;
 
-	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, 0, data,
-				     tag, NULL, rxd_addr, op, rxd_flags);
+	tx_entry = rxd_tx_entry_init_msg(rxd_ep, rxd_addr, op, iov, iov_count,
+					 tag, data, rxd_flags, NULL);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}
 
-	ret = rxd_ep_send_op(rxd_ep, tx_entry, NULL, 0, NULL, 0, 0, 0);
-	if (ret)
-		rxd_tx_entry_free(rxd_ep, tx_entry);
+	if (rxd_ep->peers[rxd_addr].peer_addr != FI_ADDR_UNSPEC)
+		(void) rxd_start_xfer(rxd_ep, tx_entry);
 
 out:
 	fastlock_release(&rxd_ep->util_ep.lock);
@@ -372,15 +427,19 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	if (ret)
 		goto out;
 
-	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, 0,
-				     data, tag, context, rxd_addr, op, rxd_flags);
+	tx_entry = rxd_tx_entry_init_msg(rxd_ep, rxd_addr, op, iov, iov_count,
+					 tag, data, rxd_flags, context);
 	if (!tx_entry)
 		goto out;
 
-	ret = rxd_ep_send_op(rxd_ep, tx_entry, NULL, 0, NULL, 0, 0, 0);
-	if (ret)
-		rxd_tx_entry_free(rxd_ep, tx_entry);
+	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC)
+		goto out;
 
+	ret = rxd_start_xfer(rxd_ep, tx_entry);
+	if (ret && tx_entry->num_segs > 1)
+		(void) rxd_ep_post_data_pkts(rxd_ep, tx_entry);
+
+	ret = 0;
 out:
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;

--- a/prov/rxd/src/rxd_proto.h
+++ b/prov/rxd/src/rxd_proto.h
@@ -143,12 +143,12 @@ struct rxd_data_pkt {
  * The op header order is as follows:
  * base_hdr (present for all packets)
  *
- * sar_hdr: for all messages requiring more than one packet
- * 	- lack of the sar_hdr is signaled by base_hdr->flags & RXD_INLINE
  * tag_hdr: for all tagged messages
  * 	- signaled by base_hdr->flags & RXD_TAG_HDR
  * data_hdr: for messages carrying remote CQ data
  * 	- signaled by base_hdr->flags & RXD_REMOTE_CQ_DATA
+ * sar_hdr: for all messages requiring more than one packet
+ * 	- lack of the sar_hdr is signaled by base_hdr->flags & RXD_INLINE
  * rma_hdr: for FI_RMA and FI_ATOMIC operations
  * 	- signaled by base_hdr->type = RXD_READ_REQ, RXD_WRITE, RXD_ATOMIC,
  * 	  RXD_ATOMIC_FETCH, and RXD_ATOMIC_COMPARE

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -36,6 +36,63 @@
 #include <ofi_iov.h>
 #include "rxd.h"
 
+static struct rxd_x_entry *rxd_tx_entry_init_rma(struct rxd_ep *ep, fi_addr_t addr,
+				uint32_t op, const struct iovec *iov, size_t iov_count,
+				uint64_t data, uint32_t flags, void *context,
+				const struct fi_rma_iov *rma_iov, size_t rma_count)
+{
+	struct rxd_x_entry *tx_entry;
+	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
+	size_t max_inline;
+	struct rxd_base_hdr *base_hdr;
+	void *ptr;
+
+	tx_entry = rxd_tx_entry_init_common(ep, addr, op, iov, iov_count, 0,
+					    data, flags, context);
+	if (!tx_entry)
+		return NULL;
+
+	base_hdr = rxd_get_base_hdr(tx_entry->pkt);
+	ptr = (void *) base_hdr;
+
+	if (tx_entry->cq_entry.flags & FI_READ) {
+		tx_entry->num_segs = ofi_div_ceil(tx_entry->cq_entry.len,
+						  rxd_domain->max_seg_sz);
+		rxd_init_base_hdr(ep, &ptr, tx_entry);
+		rxd_init_sar_hdr(&ptr, tx_entry, rma_count);
+		rxd_init_rma_hdr(&ptr, rma_iov, rma_count);
+	} else {
+		max_inline = rxd_domain->max_inline_msg;
+		max_inline -= sizeof(struct ofi_rma_iov) * rma_count;
+		if (tx_entry->flags & RXD_REMOTE_CQ_DATA)
+			max_inline -= sizeof(tx_entry->cq_entry.data);
+
+		if (rma_count > 1 || tx_entry->cq_entry.len > max_inline) {
+			max_inline -= sizeof(struct rxd_sar_hdr);
+			tx_entry->num_segs = ofi_div_ceil(tx_entry->cq_entry.len -
+				max_inline, rxd_domain->max_seg_sz) + 1;
+			rxd_init_base_hdr(ep, &ptr, tx_entry);
+			rxd_init_sar_hdr(&ptr, tx_entry, rma_count);
+		} else {
+			tx_entry->flags |= RXD_INLINE;
+			tx_entry->num_segs = 1;
+			rxd_init_base_hdr(ep, &ptr, tx_entry);
+		}
+
+		if (tx_entry->flags & RXD_REMOTE_CQ_DATA)
+			rxd_init_data_hdr(&ptr, tx_entry);
+
+		rxd_init_rma_hdr(&ptr, rma_iov, rma_count);
+		tx_entry->bytes_done = rxd_init_msg(&ptr, tx_entry->iov,
+			tx_entry->iov_count, tx_entry->cq_entry.len,
+			rxd_avail_buf(ep, base_hdr, ptr));
+	}
+	tx_entry->pkt->pkt_size = ((char *) ptr - (char *) base_hdr) +
+				ep->tx_prefix_size;
+
+	return tx_entry;
+}
+
 static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 		const struct iovec *iov, size_t iov_count,
 		const struct fi_rma_iov *rma_iov, size_t rma_count,
@@ -59,22 +116,20 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	if (ret)
 		goto out;
 
-	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count, data,
-				     0, context, rxd_addr, op, rxd_flags);
+	tx_entry = rxd_tx_entry_init_rma(rxd_ep, rxd_addr, op, iov, iov_count,
+					 data, rxd_flags, context, rma_iov,
+					 rma_count);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}
 
-	ret = rxd_ep_send_op(rxd_ep, tx_entry, rma_iov, rma_count, NULL, 0, 0, 0);
-	if (ret) {
-		rxd_tx_entry_free(rxd_ep, tx_entry);
-		goto out;
-	}
-
-	if (tx_entry->op == RXD_READ_REQ)
+	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC)
 		goto out;
 
+	ret = rxd_start_xfer(rxd_ep, tx_entry);
+	if (ret && tx_entry->num_segs > 1)
+		(void) rxd_ep_post_data_pkts(rxd_ep, tx_entry);
 	ret = 0;
 
 out:
@@ -108,16 +163,21 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	if (ret)
 		goto out;
 
-	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, rma_count,
-				     data, 0, context, rxd_addr, op, rxd_flags);
+	tx_entry = rxd_tx_entry_init_rma(rxd_ep, rxd_addr, op, iov, iov_count,
+					 data, rxd_flags, context, rma_iov,
+					 rma_count);
 	if (!tx_entry) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}
 
-	ret = rxd_ep_send_op(rxd_ep, tx_entry, rma_iov, rma_count, NULL, 0, 0, 0);
-	if (ret)
-		rxd_tx_entry_free(rxd_ep, tx_entry);
+	if (rxd_ep->peers[rxd_addr].peer_addr == FI_ADDR_UNSPEC)
+		goto out;
+
+	ret = rxd_start_xfer(rxd_ep, tx_entry);
+	if (ret && (tx_entry->cq_entry.flags & FI_WRITE) && tx_entry->num_segs > 1)
+		(void) rxd_ep_post_data_pkts(rxd_ep, tx_entry);
+	ret = 0;
 
 out:
 	fastlock_release(&rxd_ep->util_ep.lock);

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -85,7 +85,7 @@ static struct rxd_x_entry *rxd_tx_entry_init_rma(struct rxd_ep *ep, fi_addr_t ad
 		rxd_init_rma_hdr(&ptr, rma_iov, rma_count);
 		tx_entry->bytes_done = rxd_init_msg(&ptr, tx_entry->iov,
 			tx_entry->iov_count, tx_entry->cq_entry.len,
-			rxd_avail_buf(ep, base_hdr, ptr));
+			max_inline);
 	}
 	tx_entry->pkt->pkt_size = ((char *) ptr - (char *) base_hdr) +
 				ep->tx_prefix_size;


### PR DESCRIPTION
Starting to optimize the send path (tx_entry and first packet initialization) by making them function type specific. This allows us to skip RMA and atomic-specific steps. This also lets us get rid of the send_op function by initializing straight into the tx_entry->pkt during initialization and using the existing start_xfer function.

This PR also changes the order of the op packet headers to clean the initialization process and avoid having to check for data and tags twice. Because of this change, the protocol version is incremented. A patch is included to avoid communicating with peers with different protocols.

According to the hooking provider, this PR removes 19 instructions from both the send and inject paths