### PR TITLE
prov/tcp: Support op flags set in rx attr for shared context

### DIFF
--- a/prov/tcp/src/tcpx_msg.c
+++ b/prov/tcp/src/tcpx_msg.c
@@ -106,8 +106,8 @@ static ssize_t tcpx_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	memcpy(&recv_entry->iov[0], &msg->msg_iov[0],
 	       msg->iov_count * sizeof(struct iovec));
 
-	recv_entry->flags = ((tcpx_ep->util_ep.rx_op_flags & FI_COMPLETION) |
-			     flags | FI_MSG | FI_RECV);
+	recv_entry->flags = (tcpx_ep->util_ep.rx_msg_flags | flags |
+			     FI_MSG | FI_RECV);
 	recv_entry->context = msg->context;
 
 	tcpx_queue_recv(tcpx_ep, recv_entry);

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -52,7 +52,7 @@ void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 static inline void tcpx_srx_recv_init(struct tcpx_xfer_entry *recv_entry,
 				      uint64_t base_flags, void *context)
 {
-	recv_entry->flags = base_flags | FI_MSG | FI_RECV;
+	recv_entry->flags = base_flags | FI_COMPLETION | FI_MSG | FI_RECV;
 	recv_entry->context = context;
 }
 


### PR DESCRIPTION
Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>