### PR TITLE
prov/verbs: Move MR cache controls into core

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -192,6 +192,14 @@ int ofi_mr_verify(struct ofi_mr_map *map, ssize_t len,
  * Memory registration cache
  */
 
+struct ofi_mr_cache_params {
+	size_t				max_cnt;
+	size_t				max_size;
+	int				merge_regions;
+};
+
+extern struct ofi_mr_cache_params	cache_params;
+
 struct ofi_mr_entry {
 	struct iovec			iov;
 	unsigned int			cached:1;
@@ -231,9 +239,6 @@ struct ofi_mr_cache {
 	struct util_domain		*domain;
 	struct ofi_mem_monitor		*monitor;
 	struct dlist_entry		notify_entry;
-	size_t				max_cached_cnt;
-	size_t				max_cached_size;
-	int				merge_regions;
 	size_t				entry_data_size;
 
 	struct ofi_mr_storage		storage;

--- a/man/fabric.7.md
+++ b/man/fabric.7.md
@@ -266,6 +266,19 @@ system.  Additionally, it can retrieve a list of all environment variables
 that may be used to configure libfabric and each provider.  See
 [`fi_info`(1)](fi_info.1.html) for more details.
 
+# ENVIRONMENT VARIABLE CONTROLS
+
+Core features of libfabric and its providers may be configured by an
+administrator through the use of environment variables.  Man pages
+will usually describe the most commonly accessed variables, such as those
+mentioned above.  However, libfabric defines interfaces for publishing
+and obtaining environment variables.  These are targeted for providers,
+but allow applications and users to obtain the full list of variables
+that may be set, along with a brief description of their use.
+
+A full list of variables available may be obtained by running the fi_info
+application, with the -e or --env command line option.
+
 # NOTES
 
 Because libfabric is designed to provide applications direct access to

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -607,6 +607,47 @@ Fabric errno values are defined in
 *-FI_EBADFLAGS*
 : Returned if the specified flags are not supported by the provider.
 
+# MEMORY REGISTRATION CACHE
+
+Many hardware NICs accessed by libfabric require that data buffers be
+registered with the hardware while the hardware accesses it.  This ensures
+that the virtual to physical address mappings for those buffers do not change
+while the transfer is ocurring.  The performance impact of registering
+memory regions can be significant.  As a result, some providers make use
+of a registration cache, particularly when working with applications that
+are unable to manage their own network buffers.  A registration cache avoids
+the overhead of registering and unregistering a data buffer with each
+transfer.
+
+As a general rule, if hardware requires the FI_MR_LOCAL mode bit described
+above, but this is not supported by the application, a memory registration
+cache _may_ be in use.  The following environment variables may be used to
+configure registration caches.
+
+*FI_MR_CACHE_MAX_SIZE*
+: This defines the total number of bytes for all memory regions that may
+  be tracked by the cache.  If not set, the cache has no limit on how many
+  bytes may be registered and cached.  Setting this will reduce the
+  amount of memory that is not actively being used as part of a data transfer
+  that is registered with a provider.  By default, the cache size is
+  unlimited.
+
+*FI_MR_CACHE_MAX_COUNT*
+: This defines the total number of memory regions that may be registered with
+  the cache.  If not set, a default limit is chosen.  Setting this will reduce
+  the number of regions that are registered, regardless of their size, which
+  are not actively being used as part of a data transfer.  Setting this to
+  zero will disable registration caching.
+
+*FI_MR_CACHE_MERGE_REGIONS*
+: If this variable is set to true, yes, or 1, then memory regions that are
+  adjacent or overlapping will be merged into a single larger region.  Merging
+  regions reduces the total cache size and the number of regions managed by
+  the cache.  However, merging regions can have a negative impact on
+  performance if a large number of adjacent regions are sent as separate data
+  transfers (such as sending elements of an array to peer(s)), and the larger
+  region is access infrequently.  By default merging regions is disabled.
+
 # SEE ALSO
 
 [`fi_getinfo`(3)](fi_getinfo.3.html),

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -105,12 +105,8 @@ The verbs provider features a memory registration cache. This speeds up memory
 registration calls from applications by caching registrations of frequently used
 memory regions. The user can control the maximum combined size of all cache entries
 and the maximum number of cache entries with the environment variables
-FI_VERBS_MR_MAX_CACHED_SIZE and FI_VERBS_MR_MAX_CACHED_CNT respectively. Look below
-in the environment variables section for details.
-
-Note:
-The memory registration cache framework hooks into alloc and free calls to monitor
-the memory regions. If this doesn't work as expected caching would not be optimal.
+FI_MR_CACHE_MAX_SIZE and FI_MR_CACHE_MAX_COUNT respectively. See fi_mr(3) for
+more details.
 
 # LIMITATIONS
 
@@ -197,12 +193,6 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_IFACE*
 : The prefix or the full name of the network interface associated with the verbs
   device (default: ib)
-
-*FI_VERBS_MR_MAX_CACHED_CNT*
-: Maximum number of cache entries (default: 4096)
-
-*FI_VERBS_MR_MAX_CACHED_SIZE*
-: Maximum total size of cache entries (default: 4 GB)
 
 *FI_VERBS_PREFER_XRC*
 : Prioritize XRC transport fi_info before RC transport fi_info (default: 0, RC fi_info will be before XRC fi_info)

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -46,6 +46,33 @@ void ofi_monitor_init(void)
 {
 	fastlock_init(&uffd_monitor->lock);
 	dlist_init(&uffd_monitor->list);
+
+	fi_param_define(NULL, "mr_cache_max_size", FI_PARAM_SIZE_T,
+			"Defines the total number of bytes for all memory"
+			" regions that may be tracked by the MR cache."
+			" Setting this will reduce the amount of memory"
+			" not actively in use that may be registered."
+			" (default: 0 no limit is enforced)");
+	fi_param_define(NULL, "mr_cache_max_count", FI_PARAM_SIZE_T,
+			"Defines the total number of memory regions that"
+			" may be store in the cache.  Setting this will"
+			" reduce the number of registered regions, regardless"
+			" of their size, stored in the cache.  Setting this"
+			" to zero will disable MR caching.  (default: 1024)");
+	fi_param_define(NULL, "mr_cache_merge_regions", FI_PARAM_BOOL,
+			"If set to true, overlapping or adjacent memory"
+			" regions will be combined into a single, larger"
+			" region.  Merging regions can reduce the cache"
+			" memory footprint, but can negatively impact"
+			" performance in some situations.  (default: false)");
+
+	fi_param_get_size_t(NULL, "mr_cache_max_size", &cache_params.max_size);
+	fi_param_get_size_t(NULL, "mr_cache_max_count", &cache_params.max_cnt);
+	fi_param_get_bool(NULL, "mr_cache_merge_regions",
+			  &cache_params.merge_regions);
+
+	if (!cache_params.max_size)
+		cache_params.max_size = SIZE_MAX;
 }
 
 void ofi_monitor_cleanup(void)

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -224,8 +224,9 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 		ret = ofi_monitor_subscribe(cache->monitor, iov->iov_base,
 					    iov->iov_len);
 		if (ret)
-			goto err;
-		(*entry)->subscribed = 1;
+			util_mr_uncache_entry(cache, *entry);
+		else
+			(*entry)->subscribed = 1;
 	}
 
 	return 0;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -38,6 +38,11 @@
 #include <ofi_mr.h>
 #include <ofi_list.h>
 
+
+struct ofi_mr_cache_params cache_params = {
+	.max_cnt = 1024,
+};
+
 static int util_mr_find_within(void *a, void *b)
 {
 	struct iovec *iov1 = a, *iov2 = b;
@@ -75,7 +80,7 @@ static void util_mr_free_entry(struct ofi_mr_cache *cache,
 	 * As a result, we remain subscribed.  This may result in extra
 	 * notification events, but is harmless to correct operation.
 	 */
-	if (entry->subscribed && cache->merge_regions) {
+	if (entry->subscribed && cache_params.merge_regions) {
 		ofi_monitor_unsubscribe(cache->monitor, entry->iov.iov_base,
 					entry->iov.iov_len);
 		entry->subscribed = 0;
@@ -126,7 +131,7 @@ void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr, size_t le
 	/* See comment in util_mr_free_entry.  If we're not merging address
 	 * ranges, we can only safely unsubscribe for the reported range.
 	 */
-	if (!cache->merge_regions)
+	if (!cache_params.merge_regions)
 		ofi_monitor_unsubscribe(cache->monitor, addr, len);
 }
 
@@ -205,8 +210,8 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 	}
 
 	cache->cached_size += iov->iov_len;
-	if ((++cache->cached_cnt > cache->max_cached_cnt) ||
-	    (cache->cached_size > cache->max_cached_size)) {
+	if ((++cache->cached_cnt > cache_params.max_cnt) ||
+	    (cache->cached_size > cache_params.max_size)) {
 		(*entry)->cached = 0;
 	} else {
 		if (cache->storage.insert(&cache->storage,
@@ -279,8 +284,8 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	fastlock_acquire(&cache->monitor->lock);
 	cache->search_cnt++;
 
-	while (((cache->cached_cnt >= cache->max_cached_cnt) ||
-		(cache->cached_size >= cache->max_cached_size)) &&
+	while (((cache->cached_cnt >= cache_params.max_cnt) ||
+		(cache->cached_size >= cache_params.max_size)) &&
 	       mr_cache_flush(cache))
 		;
 
@@ -385,7 +390,7 @@ static int ofi_mr_rbt_erase(struct ofi_mr_storage *storage,
 
 static int ofi_mr_cache_init_rbt(struct ofi_mr_cache *cache)
 {
-	cache->storage.storage = rbtNew(cache->merge_regions ?
+	cache->storage.storage = rbtNew(cache_params.merge_regions ?
 					   util_mr_find_overlap :
 					   util_mr_find_within);
 	if (!cache->storage.storage)
@@ -428,6 +433,8 @@ int ofi_mr_cache_init(struct util_domain *domain,
 	int ret;
 
 	assert(cache->add_region && cache->delete_region);
+	if (!cache_params.max_cnt)
+		return -FI_ENOSPC;
 
 	dlist_init(&cache->lru_list);
 	cache->cached_cnt = 0;
@@ -443,8 +450,6 @@ int ofi_mr_cache_init(struct util_domain *domain,
 	if (ret)
 		goto dec;
 
-	if (!cache->max_cached_size)
-		cache->max_cached_size = SIZE_MAX;
 	ret = ofi_monitor_add_cache(monitor, cache);
 	if (ret)
 		goto destroy;
@@ -452,7 +457,7 @@ int ofi_mr_cache_init(struct util_domain *domain,
 	ret = ofi_bufpool_create(&cache->entry_pool,
 				 sizeof(struct ofi_mr_entry) +
 				 cache->entry_data_size,
-				 16, cache->max_cached_cnt, 0);
+				 16, cache_params.max_cnt, 0);
 	if (ret)
 		goto del;
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -55,9 +55,6 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.use_odp		= 0,
 	.cqread_bunch_size	= 8,
 	.iface			= NULL,
-	.mr_max_cached_cnt	= 4096,
-	.mr_max_cached_size	= ULONG_MAX,
-	.mr_cache_merge_regions	= 0,
 	.dgram			= {
 		.use_name_server	= 1,
 		.name_server_port	= 5678,
@@ -488,25 +485,6 @@ static int fi_ibv_get_param_bool(const char *param_name,
 	return 0;
 }
 
-static int fi_ibv_get_param_size_t(const char *param_name,
-				   const char *param_str,
-				   size_t *param_default)
-{
-	int ret;
-	size_t param;
-
-	ret = fi_ibv_param_define(param_name, param_str,
-				  FI_PARAM_SIZE_T,
-				  param_default);
-	if (ret)
-		return ret;
-
-	if (!fi_param_get_size_t(&fi_ibv_prov, param_name, &param))
-		*param_default = param;
-
-	return 0;
-}
-
 static int fi_ibv_get_param_str(const char *param_name,
 				const char *param_str,
 				char **param_default)
@@ -612,29 +590,6 @@ static int fi_ibv_read_params(void)
 				 &fi_ibv_gl_data.iface)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of iface\n");
-		return -FI_EINVAL;
-	}
-	if (fi_ibv_get_param_int("mr_max_cached_cnt",
-				 "Maximum number of cache entries",
-				 &fi_ibv_gl_data.mr_max_cached_cnt) ||
-	    (fi_ibv_gl_data.mr_max_cached_cnt < 0)) {
-		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of mr_max_cached_cnt\n");
-		return -FI_EINVAL;
-	}
-	if (fi_ibv_get_param_size_t("mr_max_cached_size",
-				    "Maximum total size of cache entries",
-				    &fi_ibv_gl_data.mr_max_cached_size)) {
-		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of mr_max_cached_size\n");
-		return -FI_EINVAL;
-	}
-	if (fi_ibv_get_param_bool("mr_cache_merge_regions",
-				  "Enable the merging of MR regions for MR "
-				  "caching functionality",
-				  &fi_ibv_gl_data.mr_cache_merge_regions)) {
-		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of mr_cache_merge_regions\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -148,9 +148,6 @@ extern struct fi_ibv_gl_data {
 	int	use_odp;
 	int	cqread_bunch_size;
 	char	*iface;
-	int	mr_max_cached_cnt;
-	size_t	mr_max_cached_size;
-	int	mr_cache_merge_regions;
 
 	struct {
 		int	buffer_num;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -301,9 +301,6 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 
 	fi_ibv_domain_process_exp(_domain);
 
-	_domain->cache.max_cached_cnt = fi_ibv_gl_data.mr_max_cached_cnt;
-	_domain->cache.max_cached_size = fi_ibv_gl_data.mr_max_cached_size;
-	_domain->cache.merge_regions = fi_ibv_gl_data.mr_cache_merge_regions;
 	_domain->cache.entry_data_size = sizeof(struct fi_ibv_mem_desc);
 	_domain->cache.add_region = fi_ibv_mr_cache_entry_reg;
 	_domain->cache.delete_region = fi_ibv_mr_cache_entry_dereg;


### PR DESCRIPTION
Rather than having per provider controls for the memory
registration cache, use a single set of controls.  This
avoid duplicate values for different providers.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>