### PR TITLE
Fix check of tx_attr->op_flags and rx_attr->op_flags

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -758,7 +758,7 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 		return -FI_ENODATA;
 	}
 
-	if (prov_attr->op_flags & ~(prov_attr->op_flags)) {
+	if (user_attr->op_flags & ~(prov_attr->op_flags)) {
 		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
 		FI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
 			     FI_TYPE_OP_FLAGS);
@@ -861,7 +861,7 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 		return -FI_ENODATA;
 	}
 
-	if (prov_attr->op_flags & ~(prov_attr->op_flags)) {
+	if (user_attr->op_flags & ~(prov_attr->op_flags)) {
 		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
 		FI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
 			     FI_TYPE_OP_FLAGS);


### PR DESCRIPTION
Fix the checking of tx_attr->op_flags and rx_attr->op_flags so that the provider version and the user version are compared against each other. Current code compares the provider version against itself.

This was tested using the verbs provider with a user program that included in the tx_attr->op_flags of the hints a flag that is not supported by the verbs provider (FI_DELIVERY_COMPLETE). Without the fix, the check for the op_flags passed. With the fix, it fails (as it should).