### PR TITLE
prov/verbs: Fix the release of XRC shared connection resources

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -542,6 +542,10 @@ struct fi_ibv_xrc_ep_conn_setup {
 	struct ibv_qp			*rsvd_ini_qpn;
 	struct ibv_qp			*rsvd_tgt_qpn;
 
+	/* Temporary flags to indicate if the INI QP setup and the
+	 * TGT QP setup have completed. */
+	bool				ini_connected;
+	bool				tgt_connected;
 
 	/* Delivery of the FI_CONNECTED event is delayed until
 	 * bidirectional connectivity is established. */
@@ -580,6 +584,7 @@ struct fi_ibv_ep {
 	size_t				rx_size;
 };
 
+#define VERBS_XRC_EP_MAGIC		0x1F3D5B79
 struct fi_ibv_xrc_ep {
 	/* Must be first */
 	struct fi_ibv_ep		base_ep;
@@ -588,6 +593,7 @@ struct fi_ibv_xrc_ep {
 	struct rdma_cm_id		*tgt_id;
 	struct ibv_qp			*tgt_ibv_qp;
 	enum fi_ibv_xrc_ep_conn_state	conn_state;
+	uint32_t			magic;
 	uint32_t			srqn;
 	uint32_t			peer_srqn;
 
@@ -687,7 +693,7 @@ int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
 		       int reciprocal, void *param, size_t paramlen);
 int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
 		      void *param, size_t paramlen);
-void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep);
+void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect);
 void fi_ibv_add_pending_ini_conn(struct fi_ibv_xrc_ep *ep, int reciprocal,
 				 void *conn_param, size_t conn_paramlen);
 void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn);

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -362,6 +362,15 @@ fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 	if (ret)
 		return ret;
 
+	xrc_ep->conn_setup = calloc(1, sizeof(*xrc_ep->conn_setup));
+	if (!xrc_ep->conn_setup)
+		return -FI_ENOMEM;
+
+	fastlock_acquire(&xrc_ep->base_ep.eq->lock);
+	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
+	fi_ibv_eq_set_xrc_conn_tag(xrc_ep);
+	fastlock_release(&xrc_ep->base_ep.eq->lock);
+
 	dst_addr = rdma_get_peer_addr(_ep->id);
 	ret = fi_ibv_connect_xrc(xrc_ep, dst_addr, 0, adjusted_param, paramlen);
 	free(adjusted_param);

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -163,31 +163,44 @@ void fi_ibv_log_ep_conn(struct fi_ibv_xrc_ep *ep, char *desc)
 			  ep, ep->conn_setup->rsvd_tgt_qpn->qp_num);
 }
 
-void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep)
+void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect)
 {
 	assert(ep->conn_setup);
 
-	/* Disconnect RDMA CM IDs used for the shared XRC connections,
-	 * releasing the QP used to reserve a QP number during shared
-	 * connection setup. */
-	if (ep->conn_setup->rsvd_ini_qpn) {
+	/* Free shared connection reserved QP number resources. If
+	 * a disconnect is requested and required then initiate a
+	 * disconnect sequence (the XRC INI QP side disconnect is
+	 * initiated when the remote target disconnect is received).
+	 * If disconnecting, the QP resources will be destroyed when
+	 * the timewait state has been exited or the EP is closed. */
+	if (ep->conn_setup->rsvd_ini_qpn && !disconnect) {
 		assert(ep->base_ep.id);
-		ep->base_ep.id->qp = ep->conn_setup->rsvd_ini_qpn;
-		rdma_disconnect(ep->base_ep.id);
+		assert(!ep->base_ep.id->qp);
+
 		ibv_destroy_qp(ep->conn_setup->rsvd_ini_qpn);
+		ep->conn_setup->rsvd_ini_qpn = NULL;
 	}
+
 	if (ep->conn_setup->rsvd_tgt_qpn) {
 		assert(ep->tgt_id);
-		ep->tgt_id->qp = ep->conn_setup->rsvd_tgt_qpn;
-		rdma_disconnect(ep->tgt_id);
-		ibv_destroy_qp(ep->conn_setup->rsvd_tgt_qpn);
+		assert(!ep->tgt_id->qp);
+
+		if (disconnect && ep->conn_setup->tgt_connected) {
+			rdma_disconnect(ep->tgt_id);
+			ep->conn_setup->tgt_connected = 0;
+		} else {
+			ibv_destroy_qp(ep->conn_setup->rsvd_tgt_qpn);
+			ep->conn_setup->rsvd_tgt_qpn = NULL;
+		}
 	}
 
 	if (ep->conn_setup->conn_tag != VERBS_CONN_TAG_INVALID)
 		fi_ibv_eq_clear_xrc_conn_tag(ep);
 
-	free(ep->conn_setup);
-	ep->conn_setup = NULL;
+	if (!disconnect) {
+		free(ep->conn_setup);
+		ep->conn_setup = NULL;
+	}
 }
 
 int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
@@ -260,6 +273,7 @@ void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t peer_srqn,
 			  ep->ini_conn->tgt_qpn);
 	}
 
+	ep->conn_setup->ini_connected = 1;
 	fi_ibv_log_ep_conn(ep, "INI Connection Done");
 	fi_ibv_sched_ini_conn(ep->ini_conn);
 	fastlock_release(&domain->xrc.ini_mgmt_lock);
@@ -288,6 +302,7 @@ void fi_ibv_ep_tgt_conn_done(struct fi_ibv_xrc_ep *ep)
 		assert(ep->tgt_ibv_qp == ep->tgt_id->qp);
 		ep->tgt_id->qp = NULL;
 	}
+	ep->conn_setup->tgt_connected = 1;
 }
 
 int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -163,6 +163,7 @@ void fi_ibv_log_ep_conn(struct fi_ibv_xrc_ep *ep, char *desc)
 			  ep, ep->conn_setup->rsvd_tgt_qpn->qp_num);
 }
 
+/* Caller must hold eq:lock */
 void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect)
 {
 	assert(ep->conn_setup);
@@ -221,13 +222,6 @@ int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
 	if (peer_addr)
 		ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_FABRIC,
 				"XRC connect dest_addr", peer_addr);
-
-	if (!reciprocal) {
-		ep->conn_setup = calloc(1, sizeof(*ep->conn_setup));
-		if (!ep->conn_setup)
-			return -FI_ENOMEM;
-		ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
-	}
 
 	fastlock_acquire(&domain->xrc.ini_mgmt_lock);
 	ret = fi_ibv_get_shared_ini_conn(ep, &ep->ini_conn);

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -299,9 +299,6 @@ int fi_ibv_process_ini_conn(struct fi_ibv_xrc_ep *ep,int reciprocal,
 
 	assert(ep->base_ep.ibv_qp);
 
-	if (!reciprocal)
-		fi_ibv_eq_set_xrc_conn_tag(ep);
-
 	fi_ibv_set_xrc_cm_data(cm_data, reciprocal, ep->conn_setup->conn_tag,
 			       ep->base_ep.eq->xrc.pep_port,
 			       ep->ini_conn->tgt_qpn);

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -222,6 +222,7 @@ static int fi_ibv_close_free_ep(struct fi_ibv_ep *ep)
 	return 0;
 }
 
+/* Caller must hold eq:lock */
 static inline void fi_ibv_ep_xrc_close(struct fi_ibv_ep *ep)
 {
 	struct fi_ibv_xrc_ep *xrc_ep = container_of(ep, struct fi_ibv_xrc_ep,
@@ -242,10 +243,12 @@ static int fi_ibv_ep_close(fid_t fid)
 
 	switch (ep->util_ep.type) {
 	case FI_EP_MSG:
+		fastlock_acquire(&ep->eq->lock);
 		if (fi_ibv_is_xrc(ep->info))
 			fi_ibv_ep_xrc_close(ep);
 		else
 			rdma_destroy_ep(ep->id);
+		fastlock_release(&ep->eq->lock);
 		fi_ibv_cleanup_cq(ep);
 		break;
 	case FI_EP_DGRAM:

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -163,6 +163,7 @@ fi_ibv_alloc_init_ep(struct fi_info *info, struct fi_ibv_domain *domain,
 		xrc_ep = calloc(1, sizeof(*xrc_ep));
 		if (!xrc_ep)
 			return NULL;
+		xrc_ep->magic = VERBS_XRC_EP_MAGIC;
 		ep = &xrc_ep->base_ep;
 	} else {
 		ep = calloc(1, sizeof(*ep));
@@ -227,8 +228,9 @@ static inline void fi_ibv_ep_xrc_close(struct fi_ibv_ep *ep)
 						    base_ep);
 
 	if (xrc_ep->conn_setup)
-		fi_ibv_free_xrc_conn_setup(xrc_ep);
+		fi_ibv_free_xrc_conn_setup(xrc_ep, 0);
 	fi_ibv_ep_destroy_xrc_qp(xrc_ep);
+	xrc_ep->magic = 0;
 }
 
 static int fi_ibv_ep_close(fid_t fid)

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -62,20 +62,20 @@ fi_ibv_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 	return sizeof(*entry);
 }
 
+/* Caller must hold eq:lock */
 void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 {
 	struct fi_ibv_eq *eq = ep->base_ep.eq;
 
-	fastlock_acquire(&eq->lock);
 	assert(ep->conn_setup);
 	assert(ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID);
 	ep->conn_setup->conn_tag =
 		(uint32_t)ofi_idx2key(&eq->xrc.conn_key_idx,
 				ofi_idx_insert(eq->xrc.conn_key_map, ep));
 	ep->conn_setup->created_conn_tag = true;
-	fastlock_release(&eq->lock);
 }
 
+/* Caller must hold eq:lock */
 void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 {
 	struct fi_ibv_eq *eq = ep->base_ep.eq;
@@ -85,7 +85,6 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	if (!ep->conn_setup->created_conn_tag)
 		return;
 
-	fastlock_acquire(&eq->lock);
 	index = ofi_key2idx(&eq->xrc.conn_key_idx,
 			    (uint64_t)ep->conn_setup->conn_tag);
 	if (!ofi_idx_is_valid(eq->xrc.conn_key_map, index))
@@ -93,27 +92,24 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	else
 		ofi_idx_remove(eq->xrc.conn_key_map, index);
 	ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
-	fastlock_release(&eq->lock);
 }
 
+/* Caller must hold eq:lock */
 struct fi_ibv_xrc_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq,
 						uint32_t conn_tag)
 {
 	struct fi_ibv_xrc_ep *ep;
 	int index;
 
-	fastlock_acquire(&eq->lock);
 	index = ofi_key2idx(&eq->xrc.conn_key_idx, (uint64_t)conn_tag);
 	ep = ofi_idx_lookup(eq->xrc.conn_key_map, index);
 	if (!ep || !ep->conn_setup || (ep->conn_setup->conn_tag != conn_tag)) {
 		VERBS_WARN(FI_LOG_FABRIC,
 			   "Invalid/stale XRC connection tag\n");
-		goto err;
+		return ep;
 	}
 	ofi_idx_remove(eq->xrc.conn_key_map, index);
 	ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
-err:
-	fastlock_release(&eq->lock);
 
 	return ep;
 }
@@ -279,6 +275,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 		return FI_SUCCESS;
 	}
 
+	fastlock_acquire(&eq->lock);
 	/*
 	 * Reciprocal connections are initiated and handled internally by
 	 * the provider, get the endpoint that issued the original connection
@@ -288,8 +285,9 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 	if (!ep) {
 		VERBS_WARN(FI_LOG_FABRIC,
 			   "Reciprocal XRC connection tag not found\n");
-		return -FI_EAGAIN;
+		goto done;
 	}
+
 	ep->tgt_id = connreq->id;
 	ep->tgt_id->context = &ep->base_ep.util_ep.ep_fid.fid;
 	ep->base_ep.info->handle = entry->info->handle;
@@ -307,12 +305,17 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 			   "Reciprocal XRC Accept failed %d\n", ret);
 		goto send_reject;
 	}
+done:
+	fastlock_release(&eq->lock);
+
 	/* Event is handled internally and not passed to the application */
 	return -FI_EAGAIN;
 
 send_reject:
 	if (rdma_reject(connreq->id, *priv_data, *priv_datalen))
 		VERBS_WARN(FI_LOG_FABRIC, "rdma_reject %d\n", -errno);
+	fastlock_release(&eq->lock);
+
 	return -FI_EAGAIN;
 }
 
@@ -408,6 +411,7 @@ fi_ibv_eq_xrc_recip_conn_event(struct fi_ibv_eq *eq,
 	return sizeof(*entry) + len;
 }
 
+/* Caller must hold eq:lock */
 static int
 fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
 {
@@ -448,6 +452,7 @@ fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
 	return state == FI_IBV_XRC_ORIG_CONNECTING ? FI_SUCCESS : -FI_EAGAIN;
 }
 
+/* Caller must hold eq:lock */
 static inline int
 fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 			      struct rdma_cm_event *cma_event,
@@ -478,6 +483,7 @@ fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 	return ret;
 }
 
+/* Caller must hold eq:lock */
 static inline void
 fi_ibv_eq_xrc_timewait_event(struct fi_ibv_eq *eq,
 			     struct rdma_cm_event *cma_event, int *acked)
@@ -508,6 +514,7 @@ fi_ibv_eq_xrc_timewait_event(struct fi_ibv_eq *eq,
 		fi_ibv_free_xrc_conn_setup(ep, 0);
 }
 
+/* Caller must hold eq:lock */
 static inline void
 fi_ibv_eq_xrc_disconnect_event(struct fi_ibv_eq *eq,
 			       struct rdma_cm_event *cma_event, int *acked)
@@ -575,15 +582,21 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 				return ret;
 		}
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
-		if (fi_ibv_is_xrc(ep->info))
-			return fi_ibv_eq_xrc_connected_event(eq, cma_event,
-							     entry, len, acked);
+		if (fi_ibv_is_xrc(ep->info)) {
+			fastlock_acquire(&eq->lock);
+			ret = fi_ibv_eq_xrc_connected_event(eq, cma_event,
+							    entry, len, acked);
+			fastlock_release(&eq->lock);
+			return ret;
+		}
 		entry->info = NULL;
 		break;
 	case RDMA_CM_EVENT_DISCONNECTED:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
 		if (fi_ibv_is_xrc(ep->info)) {
+			fastlock_acquire(&eq->lock);
 			fi_ibv_eq_xrc_disconnect_event(eq, cma_event, acked);
+			fastlock_release(&eq->lock);
 			return -FI_EAGAIN;
 		}
 		*event = FI_SHUTDOWN;
@@ -591,8 +604,11 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		break;
 	case RDMA_CM_EVENT_TIMEWAIT_EXIT:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
-		if (fi_ibv_is_xrc(ep->info))
+		if (fi_ibv_is_xrc(ep->info)) {
+			fastlock_acquire(&eq->lock);
 			fi_ibv_eq_xrc_timewait_event(eq, cma_event, acked);
+			fastlock_release(&eq->lock);
+		}
 		return -FI_EAGAIN;
 	case RDMA_CM_EVENT_ADDR_ERROR:
 	case RDMA_CM_EVENT_ROUTE_ERROR:
@@ -603,7 +619,9 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 	case RDMA_CM_EVENT_REJECTED:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
 		if (fi_ibv_is_xrc(ep->info)) {
+			fastlock_acquire(&eq->lock);
 			ret = fi_ibv_eq_xrc_rej_event(eq, cma_event);
+			fastlock_release(&eq->lock);
 			if (ret == -FI_EAGAIN)
 				return ret;
 			fi_ibv_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);


### PR DESCRIPTION
Once an XRC shared connection completes setup, initiate a disconnect of the associated CM ID's. Wait until the CM timed wait state is exited for the ID before destroying the associated QP. This prevents the QP from being reused while a stale connection will be detected.

If the EP is closed prior to timewait exit (or if a disconnect was not required) the resources will be released at that point.