### PR TITLE
prov/rxm: fix serialization for RMA, atomics; fabtests: update ubertest

### DIFF
--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -227,6 +227,14 @@ provider.  Example test configurations are at /test_configs.
   values and 2 having 3 possible values, ubertest will execute 576 total
   iterations of each test.
 
+### Config file options
+
+TODO: add all supported config options
+
+- *threading*
+  Specify a list of threading levels. This is a hints only config: ubertest
+  doesn't spawn multiple threads to verify functionality.
+
 # HOW TO RUN TESTS
 
 (1) Fabtests requires that libfabric be installed on the system, and at least one provider be usable.

--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -304,7 +304,13 @@ static struct key_t keys[] = {
 		.offset = offsetof(struct ft_set, progress),
 		.val_type = VAL_NUM,
 		.val_size = sizeof(((struct ft_set *)0)->progress) / FT_MAX_PROGRESS,
-	}
+	},
+	{
+		.str = "threading",
+		.offset = offsetof(struct ft_set, threading),
+		.val_type = VAL_NUM,
+		.val_size = sizeof(((struct ft_set *)0)->threading) / FT_MAX_THREADING,
+	},
 };
 
 static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
@@ -420,6 +426,14 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_AUTO, int, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_UNSPEC, int, buf);
 		FT_ERR("Unknown progress mode");
+	} else if (!strncmp(key->str, "threading", strlen("threading"))) {
+		TEST_ENUM_SET_N_RETURN(str, len, FI_THREAD_UNSPEC, int, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_THREAD_SAFE, int, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_THREAD_FID, int, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_THREAD_DOMAIN, int, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_THREAD_COMPLETION, int, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_THREAD_ENDPOINT, int, buf);
+		FT_ERR("Unknown threading level");
 	} else if (!strncmp(key->str, "constant_caps", strlen("constant_caps"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_RMA, uint64_t, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MSG, uint64_t, buf);
@@ -707,6 +721,7 @@ void fts_start(struct ft_series *series, int index)
 	series->cur_mode = 0;
 	series->cur_class = 0;
 	series->cur_progress = 0;
+	series->cur_threading = 0;
 
 	series->test_index = 1;
 	if (index > 1) {
@@ -809,6 +824,10 @@ void fts_next(struct ft_series *series)
 		return;
 	series->cur_progress = 0;
 
+	if (set->threading[++series->cur_threading])
+		return;
+	series->cur_threading = 0;
+
 	series->cur_set++;
 }
 
@@ -837,6 +856,7 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->test_flags = set->test_flags;
 	info->test_class = set->test_class[series->cur_class];
 	info->progress = set->progress[series->cur_progress];
+	info->threading = set->threading[series->cur_threading];
 
 	if (info->test_class) {
 		info->caps = set->test_class[series->cur_class];

--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -416,9 +416,9 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FI_MR_PROV_KEY, uint64_t, buf);
 		FT_ERR("Unknown MR mode");
 	} else if (!strncmp(key->str, "progress", strlen("progress"))) {
-		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_MANUAL, uint64_t, buf);
-		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_AUTO, uint64_t, buf);
-		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_UNSPEC, uint64_t, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_MANUAL, int, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_AUTO, int, buf);
+		TEST_ENUM_SET_N_RETURN(str, len, FI_PROGRESS_UNSPEC, int, buf);
 		FT_ERR("Unknown progress mode");
 	} else if (!strncmp(key->str, "constant_caps", strlen("constant_caps"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_RMA, uint64_t, buf);
@@ -805,7 +805,7 @@ void fts_next(struct ft_series *series)
 		return;
 	series->cur_type = 0;
 
-	if (set->test_class[++series->cur_progress])
+	if (set->progress[++series->cur_progress])
 		return;
 	series->cur_progress = 0;
 

--- a/fabtests/ubertest/fabtest.h
+++ b/fabtests/ubertest/fabtest.h
@@ -148,6 +148,7 @@ enum {
 	FT_COMP_BUF_SIZE	= 256,
 	FT_MAX_FLAGS		= 64,
 	FT_MAX_PROGRESS		= 3,
+	FT_MAX_THREADING	= 6,
 };
 
 enum ft_comp_type {
@@ -244,6 +245,7 @@ struct ft_set {
 	enum fi_wait_obj	cq_wait_obj[FT_MAX_WAIT_OBJ];
 	enum fi_wait_obj	cntr_wait_obj[FT_MAX_WAIT_OBJ];
 	enum fi_progress	progress[FT_MAX_PROGRESS];
+	enum fi_threading	threading[FT_MAX_THREADING];
 	uint64_t		mode[FT_MAX_PROV_MODES];
 	uint64_t		test_class[FT_MAX_CLASS];
 	uint64_t		constant_caps[FT_MAX_CAPS];
@@ -274,6 +276,7 @@ struct ft_series {
 	int			cur_mode;
 	int			cur_class;
 	int			cur_progress;
+	int			cur_threading;
 };
 
 struct ft_info {
@@ -296,6 +299,7 @@ struct ft_info {
 	enum fi_wait_obj	cq_wait_obj;
 	enum fi_wait_obj	cntr_wait_obj;
 	enum fi_progress	progress;
+	enum fi_threading	threading;
 	uint32_t		protocol;
 	uint32_t		protocol_version;
 	char			node[FI_NAME_MAX];

--- a/fabtests/ubertest/uber.c
+++ b/fabtests/ubertest/uber.c
@@ -211,6 +211,7 @@ static void ft_show_test_info(void)
 	printf(" cntr_%s, ", ft_wait_obj_str(test_info.cq_wait_obj));
 	ft_print_comp(&test_info);
 	printf(" %s,", fi_tostr(&test_info.progress, FI_TYPE_PROGRESS));
+	printf(" %s (only hints),", fi_tostr(&test_info.threading, FI_TYPE_THREADING));
 	printf(" [%s],", fi_tostr(&test_info.mr_mode, FI_TYPE_MR_MODE));
 	printf(" [%s],", fi_tostr(&test_info.mode, FI_TYPE_MODE));
 	printf(" [%s]]\n", fi_tostr(&test_info.caps, FI_TYPE_CAPS));
@@ -247,6 +248,7 @@ static void ft_fw_convert_info(struct fi_info *info, struct ft_info *test_info)
 	info->domain_attr->mr_mode = test_info->mr_mode;
 	info->domain_attr->av_type = test_info->av_type;
 	info->domain_attr->data_progress = test_info->progress;
+	info->domain_attr->threading = test_info->threading;
 
 	info->ep_attr->type = test_info->ep_type;
 	info->ep_attr->protocol = test_info->protocol;
@@ -291,8 +293,10 @@ ft_fw_update_info(struct ft_info *test_info, struct fi_info *info, int subindex)
 		}
 	}
 
-	if (info->domain_attr)
+	if (info->domain_attr) {
 		test_info->progress = info->domain_attr->data_progress;
+		test_info->threading = info->domain_attr->threading;
+	}
 
 	test_info->mode = info->mode;
 }


### PR DESCRIPTION
This PR adds missing serialization for RMA and atomics. This change was missed in #5014 .

Also updated ubertest to accept a threading level config (tests only hints). Did a minor refactoring for rxm RMA functions to reduce indent levels and fix logging level.