### PR TITLE
prov/gni: fix a problem with not truncating recvs

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2019 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -3092,7 +3093,7 @@ DIRECT_FN STATIC int gnix_ep_setopt(fid_t fid, int level, int optname,
 		if (optlen != sizeof(size_t))
 			return -FI_EINVAL;
 		/*
-		 * see issue 1120
+		 * see https://github.com/ofi-cray/libfabric-cray/issues/1120
 		 */
 		if (*(size_t *)optval == 0UL)
 			return -FI_EINVAL;

--- a/prov/gni/test/rdm_fi_pcd_trecv_msg.c
+++ b/prov/gni/test/rdm_fi_pcd_trecv_msg.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -1811,8 +1812,6 @@ static void pdc_peek_event_present_small_buffer_provided(int len)
 	 * fetched with a peek, but the target buffer should remain untouched
 	 */
 	build_peek_message(&peek_msg, &msg);
-	peek_iov.iov_len /= 2;
-
 
 	start_test_timer();
 	do {

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -2041,6 +2041,13 @@ void do_sendrecv_buf(void *p, void *t, int send_len, int recv_len)
 	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
 	uint64_t r_e[NUMEPS] = {0};
 
+	/*
+	 * this test can't handle truncated messages so skip if recv_len
+	 * isn't big enough to receive message
+	 */
+	if (send_len > recv_len)
+		return;
+
 	rdm_sr_init_data(p, send_len, 0xab);
 	rdm_sr_init_data(t, recv_len, 0);
 


### PR DESCRIPTION
Have no idea how things were working, but the GNI provider
was incorrectly using the length of the incoming message
for transfer to recv buffers/iovecs rather than the
length of receive buffers.

Fixes #5002

Signed-off-by: Howard Pritchard <howardp@lanl.gov>