### PR TITLE
prov/rxd: Cleaned up rxd_ep_close() function

### DIFF
--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -715,22 +715,6 @@ static int rxd_ep_close(struct fid *fid)
 		ofi_buf_free(pkt_entry);
 	}
 
-	if (ep->util_ep.tx_cq) {
-		/* TODO: wait handling */
-		fid_list_remove(&ep->util_ep.tx_cq->ep_list,
-				&ep->util_ep.tx_cq->ep_list_lock,
-				&ep->util_ep.ep_fid.fid);
-	}
-
-	if (ep->util_ep.rx_cq) {
-		if (ep->util_ep.rx_cq != ep->util_ep.tx_cq) {
-			/* TODO: wait handling */
-			fid_list_remove(&ep->util_ep.rx_cq->ep_list,
-					&ep->util_ep.rx_cq->ep_list_lock,
-					&ep->util_ep.ep_fid.fid);
-		}
-	}
-
 	rxd_ep_free_res(ep);
 	ofi_endpoint_close(&ep->util_ep);
 	free(ep);


### PR DESCRIPTION
Deleted handling of fid_list_remove(). Why?
The function fid_list_remove() is called inside ofi_endpoint_close()
for tx/rx cq.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>