### PR TITLE
prov/util, verbs, rxm: fix op_flags handling

### DIFF
--- a/prov/rxd/src/rxd_attr.c
+++ b/prov/rxd/src/rxd_attr.c
@@ -37,9 +37,13 @@
 #define RXD_TX_CAPS (FI_SEND | FI_WRITE | FI_READ)
 #define RXD_RX_CAPS (FI_RECV | FI_REMOTE_READ | FI_REMOTE_WRITE)
 #define RXD_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM)
+#define RXD_TX_OP_FLAGS (FI_INJECT | FI_INJECT_COMPLETE | FI_COMPLETION	|   \
+			 FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)
+#define RXD_RX_OP_FLAGS (FI_MULTI_RECV | FI_COMPLETION)
 
 struct fi_tx_attr rxd_tx_attr = {
 	.caps = RXD_EP_CAPS | RXD_TX_CAPS,
+	.op_flags = RXD_TX_OP_FLAGS,
 	.comp_order = FI_ORDER_NONE,
 	.msg_order = FI_ORDER_SAS,
 	.inject_size = RXD_MAX_MTU_SIZE - sizeof(struct rxd_base_hdr),
@@ -50,6 +54,7 @@ struct fi_tx_attr rxd_tx_attr = {
 
 struct fi_rx_attr rxd_rx_attr = {
 	.caps = RXD_EP_CAPS | RXD_RX_CAPS,
+	.op_flags = RXD_RX_OP_FLAGS,
 	.comp_order = FI_ORDER_NONE,
 	.msg_order = FI_ORDER_SAS,
 	.total_buffered_recv = 0,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -77,6 +77,15 @@ extern size_t rxm_eager_limit;
 #define RXM_EQ_PROGRESS_SPIN_COUNT 10000
 
 #define RXM_MR_MODES	(OFI_MR_BASIC_MAP | FI_MR_LOCAL)
+
+#define RXM_PASSTHRU_TX_OP_FLAGS (FI_TRANSMIT_COMPLETE)
+
+#define RXM_PASSTHRU_RX_OP_FLAGS 0ULL
+
+#define RXM_TX_OP_FLAGS (FI_INJECT | FI_INJECT_COMPLETE | \
+			 FI_DELIVERY_COMPLETE | FI_COMPLETION)
+#define RXM_RX_OP_FLAGS (FI_MULTI_RECV | FI_COMPLETION)
+
 #define RXM_MR_VIRT_ADDR(info) ((info->domain_attr->mr_mode == FI_MR_BASIC) ||\
 				info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)
 

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -38,6 +38,8 @@
 
 #define RXM_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM)
 
+// TODO have a separate "check info" against which app hints would be checked.
+
 /* Since we are a layering provider, the attributes for which we rely on the
  * core provider are set to full capability. This ensures that ofix_getinfo
  * check hints succeeds and the core provider can accept / reject any capability
@@ -45,6 +47,7 @@
 
 struct fi_tx_attr rxm_tx_attr = {
 	.caps = RXM_EP_CAPS,
+	.op_flags = RXM_PASSTHRU_TX_OP_FLAGS | RXM_TX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
 	.size = 1024,
@@ -54,6 +57,7 @@ struct fi_tx_attr rxm_tx_attr = {
 
 struct fi_rx_attr rxm_rx_attr = {
 	.caps = RXM_EP_CAPS | FI_MULTI_RECV,
+	.op_flags = RXM_PASSTHRU_RX_OP_FLAGS | RXM_RX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
 	.size = 1024,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -109,10 +109,14 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 			core_info->domain_attr->threading = hints->domain_attr->threading;
 		}
 		if (hints->tx_attr) {
+			core_info->tx_attr->op_flags =
+				hints->tx_attr->op_flags & RXM_PASSTHRU_TX_OP_FLAGS;
 			core_info->tx_attr->msg_order = hints->tx_attr->msg_order;
 			core_info->tx_attr->comp_order = hints->tx_attr->comp_order;
 		}
 		if (hints->rx_attr) {
+			core_info->rx_attr->op_flags =
+				hints->rx_attr->op_flags & RXM_PASSTHRU_RX_OP_FLAGS;
 			core_info->rx_attr->msg_order = hints->rx_attr->msg_order;
 			core_info->rx_attr->comp_order = hints->rx_attr->comp_order;
 		}
@@ -124,7 +128,10 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 		core_info->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;
 	}
 
+	core_info->tx_attr->op_flags &= ~RXM_TX_OP_FLAGS;
 	core_info->tx_attr->size = rxm_msg_tx_size;
+
+	core_info->rx_attr->op_flags &= ~FI_MULTI_RECV;
 	core_info->rx_attr->size = rxm_msg_rx_size;
 
 	return 0;

--- a/prov/tcp/src/tcpx_attr.c
+++ b/prov/tcp/src/tcpx_attr.c
@@ -44,9 +44,15 @@
 			OFI_ORDER_WAW_SET | FI_ORDER_WAS | \
 			FI_ORDER_SAW | FI_ORDER_SAS)
 
+#define TCPX_TX_OP_FLAGS \
+	(FI_INJECT | FI_INJECT_COMPLETE | FI_TRANSMIT_COMPLETE | \
+	 FI_DELIVERY_COMPLETE | FI_COMMIT_COMPLETE | FI_COMPLETION)
+
+#define TCPX_RX_OP_FLAGS (FI_MULTI_RECV | FI_COMPLETION)
 
 static struct fi_tx_attr tcpx_tx_attr = {
 	.caps = TCPX_EP_CAPS | TCPX_TX_CAPS,
+	.op_flags = TCPX_TX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = TCPX_MSG_ORDER,
 	.inject_size = 64,
@@ -57,6 +63,7 @@ static struct fi_tx_attr tcpx_tx_attr = {
 
 static struct fi_rx_attr tcpx_rx_attr = {
 	.caps = TCPX_EP_CAPS | TCPX_RX_CAPS,
+	.op_flags = TCPX_RX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = TCPX_MSG_ORDER,
 	.total_buffered_recv = 0,

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -758,7 +758,7 @@ int ofi_check_rx_attr(const struct fi_provider *prov,
 		return -FI_ENODATA;
 	}
 
-	if (prov_attr->op_flags & ~(prov_attr->op_flags)) {
+	if (user_attr->op_flags & ~(prov_attr->op_flags)) {
 		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
 		FI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
 			     FI_TYPE_OP_FLAGS);
@@ -861,7 +861,7 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 		return -FI_ENODATA;
 	}
 
-	if (prov_attr->op_flags & ~(prov_attr->op_flags)) {
+	if (user_attr->op_flags & ~(prov_attr->op_flags)) {
 		FI_INFO(prov, FI_LOG_CORE, "op_flags not supported\n");
 		FI_INFO_CHECK(prov, prov_attr, user_attr, op_flags,
 			     FI_TYPE_OP_FLAGS);

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -51,8 +51,8 @@
 
 #define VERBS_DGRAM_RX_MODE (FI_MSG_PREFIX)
 
-#define VERBS_TX_OP_FLAGS (FI_INJECT | FI_COMPLETION | FI_TRANSMIT_COMPLETE)
-#define VERBS_TX_OP_FLAGS_IWARP (FI_INJECT | FI_COMPLETION)
+#define VERBS_TX_OP_FLAGS_IWARP (FI_INJECT | FI_INJECT_COMPLETE | FI_COMPLETION)
+#define VERBS_TX_OP_FLAGS (VERBS_TX_OP_FLAGS_IWARP | FI_TRANSMIT_COMPLETE)
 
 #define VERBS_RX_MODE (FI_RX_CQ_DATA)
 
@@ -100,6 +100,7 @@ const struct fi_ep_attr verbs_ep_attr = {
 
 const struct fi_rx_attr verbs_rx_attr = {
 	.mode			= VERBS_RX_MODE,
+	.op_flags		= FI_COMPLETION,
 	.msg_order		= VERBS_MSG_ORDER,
 	.comp_order		= FI_ORDER_STRICT | FI_ORDER_DATA,
 	.total_buffered_recv	= 0,
@@ -107,6 +108,7 @@ const struct fi_rx_attr verbs_rx_attr = {
 
 const struct fi_rx_attr verbs_dgram_rx_attr = {
 	.mode			= VERBS_DGRAM_RX_MODE | VERBS_RX_MODE,
+	.op_flags		= FI_COMPLETION,
 	.msg_order		= VERBS_MSG_ORDER,
 	.comp_order		= FI_ORDER_STRICT | FI_ORDER_DATA,
 	.total_buffered_recv	= 0,


### PR DESCRIPTION
This is a quick fix for rxm, to play well with correct op_flags handling in util code. rxm getinfo code likely needs to be refactored and fixed to avoid other potential issues (some of which is captured in #5011). I'll work on that in a follow-up PR.