### PR TITLE
contrib/cray: Use environment provided fabtest

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -99,10 +99,10 @@ pipeline {
                 stage('Functional Tests: RC') {
                     steps {
                         tee ('fabtests-rc.log') {
-                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 60'
+                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 120'
                         }
                         tee ('ubertests-rc.log') {
-                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -vvv -T 60 -t complex -u all'
+                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -vvv -T 120 -t complex -u all'
                         }
                     }
                     post {
@@ -126,10 +126,10 @@ pipeline {
                 stage('Functional Tests: XRC') {
                     steps {
                         tee ('fabtests-xrc.log') {
-                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 60 -e FI_VERBS_PREFER_XRC=1 -e FI_OFI_RXM_USE_SRX=1'
+                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -v -T 120 -e FI_VERBS_PREFER_XRC=1 -e FI_OFI_RXM_USE_SRX=1'
                         }
                         tee ('ubertests-xrc.log') {
-                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -vvv -T 60 -t complex -u all -e FI_VERBS_PREFER_XRC=1 -e FI_OFI_RXM_USE_SRX=1'
+                            sh 'srun -n 2 --ntasks-per-node=1 contrib/cray/bin/fabtest_wrapper.sh -p ${FABTEST_PATH}/bin -vvv -T 120 -t complex -u all -e FI_VERBS_PREFER_XRC=1 -e FI_OFI_RXM_USE_SRX=1'
                         }
                     }
                     post {

--- a/contrib/cray/bin/fabtest_wrapper.sh
+++ b/contrib/cray/bin/fabtest_wrapper.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-export FABTESTS_PATH=/scratch/jenkins/builds/fabtests/stable
-export PATH=${FABTESTS_PATH}/bin:$PATH
+if [[ -z ${FABTEST_PATH} ]] ; then
+	export FABTEST_PATH=/scratch/jenkins/builds/fabtests/stable
+fi
+
+export PATH=${FABTEST_PATH}/bin:$PATH
 
 if [[ -z ${FABTEST_PROVIDER} ]] ; then
     FABTEST_PROVIDER='verbs;ofi_rxm'


### PR DESCRIPTION
If provided in the environment, use the fabtest installation in the environment.
This allows us to select the correct version of fabtests when running functional
tests.

Signed-off-by: James Swaro <jswaro@cray.com>