### PR TITLE
prov/rxd: Optimized rxd_ep_post_data_pkts

### DIFF
--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -421,12 +421,6 @@ ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 		if (!pkt_entry)
 			return -FI_ENOMEM;
 
-		if (tx_entry->op == RXD_DATA_READ && !tx_entry->bytes_done) {
-			tx_entry->start_seq = ep->peers[tx_entry->peer].tx_seq_no;
-			ep->peers[tx_entry->peer].tx_seq_no = tx_entry->start_seq +
-							      tx_entry->num_segs;
-		}
-
 		rxd_init_data_pkt(ep, tx_entry, pkt_entry);
 
 		data = (struct rxd_data_pkt *) (pkt_entry->pkt);
@@ -439,7 +433,7 @@ ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 		rxd_insert_unacked(ep, tx_entry->peer, pkt_entry);
 	}
 
-	return ep->peers[tx_entry->peer].unacked_cnt <
+	return ep->peers[tx_entry->peer].unacked_cnt >=
 	       ep->peers[tx_entry->peer].tx_window;
 }
 


### PR DESCRIPTION
 The reason of getting out is don't do the checking for every
 data packet while posting the data.
 The solving is moving the checking of the flag in progress_tx_list,
 checking RXD_READ_DATA before sending packets.

 1)We had to add the check, which to make sure us that we don't
 decrement the sequence unless we incremented it.

 2)We flipped the return in rxd_ep_post_data_pkts in order to
 change the condition. if (unacked >= tx_window) it returns 1 - there
 is not space, 0 - there is more space to send. 

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>