### PR TITLE
[v1.7.x] prov/verbs: Cherry picked fixes for XRC scale and reliability

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -263,10 +263,18 @@ struct fi_ibv_eq_entry {
 
 typedef int (*fi_ibv_trywait_func)(struct fid *fid);
 
-/* The number of valid OFI indexer bits in the connection key used during
- * XRC connection establishment. Note that only the lower 32-bits of the
- * key are exchanged, so this value must be kept below 32-bits. */
-#define VERBS_TAG_INDEX_BITS	18
+/* An OFI indexer is used to maintain a unique connection request to
+ * endpoint mapping. The key is a 32-bit value (referred to as a
+ * connection tag) and is passed to the remote peer by the active side
+ * of a connection request. When the reciprocal XRC connection in the
+ * reverse direction is made, the key is passed back and used to map
+ * back to the original endpoint. A key is defined as a 32-bit value:
+ *
+ *     SSSSSSSS:SSSSSSII:IIIIIIII:IIIIIIII
+ *     |-- sequence -||--- unique key ---|
+ */
+#define VERBS_CONN_TAG_INDEX_BITS	18
+#define VERBS_CONN_TAG_INVALID		0xFFFFFFFF	/* Key is not valid */
 
 struct fi_ibv_eq {
 	struct fid_eq		eq_fid;
@@ -567,7 +575,12 @@ enum fi_ibv_xrc_ep_conn_state {
  * is established.
  */
 struct fi_ibv_xrc_ep_conn_setup {
+	/* The connection tag is used to associate the reciprocal
+	 * XRC INI/TGT QP connection request in the reverse direction
+	 * with the original request. The tag is created by the
+	 * original active side. */
 	uint32_t			conn_tag;
+	bool				created_conn_tag;
 
 	/* IB CM message stale/duplicate detection processing requires
 	 * that shared INI/TGT connections use unique QP numbers during

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -590,6 +590,10 @@ struct fi_ibv_xrc_ep_conn_setup {
 	struct ibv_qp			*rsvd_ini_qpn;
 	struct ibv_qp			*rsvd_tgt_qpn;
 
+	/* Temporary flags to indicate if the INI QP setup and the
+	 * TGT QP setup have completed. */
+	bool				ini_connected;
+	bool				tgt_connected;
 
 	/* Delivery of the FI_CONNECTED event is delayed until
 	 * bidirectional connectivity is established. */
@@ -628,6 +632,7 @@ struct fi_ibv_ep {
 	size_t				rx_size;
 };
 
+#define VERBS_XRC_EP_MAGIC		0x1F3D5B79
 struct fi_ibv_xrc_ep {
 	/* Must be first */
 	struct fi_ibv_ep		base_ep;
@@ -636,6 +641,7 @@ struct fi_ibv_xrc_ep {
 	struct rdma_cm_id		*tgt_id;
 	struct ibv_qp			*tgt_ibv_qp;
 	enum fi_ibv_xrc_ep_conn_state	conn_state;
+	uint32_t			magic;
 	uint32_t			srqn;
 	uint32_t			peer_srqn;
 
@@ -735,7 +741,7 @@ int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
 		       int reciprocal, void *param, size_t paramlen);
 int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
 		      void *param, size_t paramlen);
-void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep);
+void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect);
 void fi_ibv_add_pending_ini_conn(struct fi_ibv_xrc_ep *ep, int reciprocal,
 				 void *conn_param, size_t conn_paramlen);
 void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn);

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -362,6 +362,15 @@ fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 	if (ret)
 		return ret;
 
+	xrc_ep->conn_setup = calloc(1, sizeof(*xrc_ep->conn_setup));
+	if (!xrc_ep->conn_setup)
+		return -FI_ENOMEM;
+
+	fastlock_acquire(&xrc_ep->base_ep.eq->lock);
+	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
+	fi_ibv_eq_set_xrc_conn_tag(xrc_ep);
+	fastlock_release(&xrc_ep->base_ep.eq->lock);
+
 	dst_addr = rdma_get_peer_addr(_ep->id);
 	ret = fi_ibv_connect_xrc(xrc_ep, dst_addr, 0, adjusted_param, paramlen);
 	free(adjusted_param);

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -163,30 +163,43 @@ void fi_ibv_log_ep_conn(struct fi_ibv_xrc_ep *ep, char *desc)
 			  ep, ep->conn_setup->rsvd_tgt_qpn->qp_num);
 }
 
-void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep)
+void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect)
 {
 	assert(ep->conn_setup);
 
-	if (ep->conn_setup->rsvd_ini_qpn)
+	/* Free shared connection reserved QP number resources. If
+	 * a disconnect is requested and required then initiate a
+	 * disconnect sequence (the XRC INI QP side disconnect is
+	 * initiated when the remote target disconnect is received).
+	 * If disconnecting, the QP resources will be destroyed when
+	 * the timewait state has been exited or the EP is closed. */
+	if (ep->conn_setup->rsvd_ini_qpn && !disconnect) {
+		assert(ep->base_ep.id);
+		assert(!ep->base_ep.id->qp);
+
 		ibv_destroy_qp(ep->conn_setup->rsvd_ini_qpn);
-	if (ep->conn_setup->rsvd_tgt_qpn)
-		ibv_destroy_qp(ep->conn_setup->rsvd_tgt_qpn);
+		ep->conn_setup->rsvd_ini_qpn = NULL;
+	}
+
+	if (ep->conn_setup->rsvd_tgt_qpn) {
+		assert(ep->tgt_id);
+		assert(!ep->tgt_id->qp);
+
+		if (disconnect && ep->conn_setup->tgt_connected) {
+			rdma_disconnect(ep->tgt_id);
+			ep->conn_setup->tgt_connected = 0;
+		} else {
+			ibv_destroy_qp(ep->conn_setup->rsvd_tgt_qpn);
+			ep->conn_setup->rsvd_tgt_qpn = NULL;
+		}
+	}
 
 	if (ep->conn_setup->conn_tag != VERBS_CONN_TAG_INVALID)
 		fi_ibv_eq_clear_xrc_conn_tag(ep);
 
-	free(ep->conn_setup);
-	ep->conn_setup = NULL;
-
-	/*Free RDMA CM IDs releasing their associated resources, RDMA CM
-	 * is used for connection setup only with XRC */
-	if (ep->base_ep.id) {
-		rdma_destroy_id(ep->base_ep.id);
-		ep->base_ep.id = NULL;
-	}
-	if (ep->tgt_id) {
-		rdma_destroy_id(ep->tgt_id);
-		ep->tgt_id = NULL;
+	if (!disconnect) {
+		free(ep->conn_setup);
+		ep->conn_setup = NULL;
 	}
 }
 
@@ -260,6 +273,7 @@ void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t peer_srqn,
 			  ep->ini_conn->tgt_qpn);
 	}
 
+	ep->conn_setup->ini_connected = 1;
 	fi_ibv_log_ep_conn(ep, "INI Connection Done");
 	fi_ibv_sched_ini_conn(ep->ini_conn);
 	fastlock_release(&domain->xrc.ini_mgmt_lock);
@@ -288,6 +302,7 @@ void fi_ibv_ep_tgt_conn_done(struct fi_ibv_xrc_ep *ep)
 		assert(ep->tgt_ibv_qp == ep->tgt_id->qp);
 		ep->tgt_id->qp = NULL;
 	}
+	ep->conn_setup->tgt_connected = 1;
 }
 
 int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -163,6 +163,7 @@ void fi_ibv_log_ep_conn(struct fi_ibv_xrc_ep *ep, char *desc)
 			  ep, ep->conn_setup->rsvd_tgt_qpn->qp_num);
 }
 
+/* Caller must hold eq:lock */
 void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect)
 {
 	assert(ep->conn_setup);
@@ -221,13 +222,6 @@ int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
 	if (peer_addr)
 		ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_FABRIC,
 				"XRC connect dest_addr", peer_addr);
-
-	if (!reciprocal) {
-		ep->conn_setup = calloc(1, sizeof(*ep->conn_setup));
-		if (!ep->conn_setup)
-			return -FI_ENOMEM;
-		ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
-	}
 
 	fastlock_acquire(&domain->xrc.ini_mgmt_lock);
 	ret = fi_ibv_get_shared_ini_conn(ep, &ep->ini_conn);

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -172,6 +172,9 @@ void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep)
 	if (ep->conn_setup->rsvd_tgt_qpn)
 		ibv_destroy_qp(ep->conn_setup->rsvd_tgt_qpn);
 
+	if (ep->conn_setup->conn_tag != VERBS_CONN_TAG_INVALID)
+		fi_ibv_eq_clear_xrc_conn_tag(ep);
+
 	free(ep->conn_setup);
 	ep->conn_setup = NULL;
 
@@ -210,6 +213,7 @@ int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
 		ep->conn_setup = calloc(1, sizeof(*ep->conn_setup));
 		if (!ep->conn_setup)
 			return -FI_ENOMEM;
+		ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 	}
 
 	fastlock_acquire(&domain->xrc.ini_mgmt_lock);
@@ -326,9 +330,7 @@ int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
 	if (!ep->tgt_id->qp)
 		conn_param.qp_num = ep->conn_setup->rsvd_tgt_qpn->qp_num;
 
-	if (connreq->xrc.is_reciprocal)
-		fi_ibv_eq_clear_xrc_conn_tag(ep);
-	else
+	if (!connreq->xrc.is_reciprocal)
 		ep->conn_setup->conn_tag = connreq->xrc.conn_tag;
 
 	assert(ep->conn_state == FI_IBV_XRC_UNCONNECTED ||

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -179,7 +179,8 @@ void fi_ibv_put_shared_ini_conn(struct fi_ibv_xrc_ep *ep)
 	ini_conn = ep->ini_conn;
 	ep->ini_conn = NULL;
 	ep->base_ep.ibv_qp = NULL;
-	ep->base_ep.id->qp = NULL;
+	if (ep->base_ep.id)
+		ep->base_ep.id->qp = NULL;
 
 	/* Tear down physical INI/TGT when no longer being used */
 	if (!ofi_atomic_dec32(&ini_conn->ref_cnt)) {

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -297,9 +297,6 @@ int fi_ibv_process_ini_conn(struct fi_ibv_xrc_ep *ep,int reciprocal,
 
 	assert(ep->base_ep.ibv_qp);
 
-	if (!reciprocal)
-		fi_ibv_eq_set_xrc_conn_tag(ep);
-
 	fi_ibv_set_xrc_cm_data(cm_data, reciprocal, ep->conn_setup->conn_tag,
 			       ep->base_ep.eq->xrc.pep_port,
 			       ep->ini_conn->tgt_qpn);

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -382,7 +382,7 @@ int fi_ibv_ep_create_tgt_qp(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn)
 	attr_ex.xrcd = domain->xrc.xrcd;
 	if (rdma_create_qp_ex(ep->tgt_id, &attr_ex)) {
 		VERBS_INFO_ERRNO(FI_LOG_EP_CTRL,
-				 "Physical XRC TGT QP, rdma_create_ep_ex()",
+				 "Physical XRC TGT QP, rdma_create_qp_ex()",
 				 errno);
 		return -errno;
 	}

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -222,6 +222,7 @@ static int fi_ibv_close_free_ep(struct fi_ibv_ep *ep)
 	return 0;
 }
 
+/* Caller must hold eq:lock */
 static inline void fi_ibv_ep_xrc_close(struct fi_ibv_ep *ep)
 {
 	struct fi_ibv_xrc_ep *xrc_ep = container_of(ep, struct fi_ibv_xrc_ep,
@@ -242,10 +243,12 @@ static int fi_ibv_ep_close(fid_t fid)
 
 	switch (ep->util_ep.type) {
 	case FI_EP_MSG:
+		fastlock_acquire(&ep->eq->lock);
 		if (fi_ibv_is_xrc(ep->info))
 			fi_ibv_ep_xrc_close(ep);
 		else
 			rdma_destroy_ep(ep->id);
+		fastlock_release(&ep->eq->lock);
 		fi_ibv_cleanup_cq(ep);
 		break;
 	case FI_EP_DGRAM:

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -163,6 +163,7 @@ fi_ibv_alloc_init_ep(struct fi_info *info, struct fi_ibv_domain *domain,
 		xrc_ep = calloc(1, sizeof(*xrc_ep));
 		if (!xrc_ep)
 			return NULL;
+		xrc_ep->magic = VERBS_XRC_EP_MAGIC;
 		ep = &xrc_ep->base_ep;
 	} else {
 		ep = calloc(1, sizeof(*ep));
@@ -226,9 +227,10 @@ static inline void fi_ibv_ep_xrc_close(struct fi_ibv_ep *ep)
 	struct fi_ibv_xrc_ep *xrc_ep = container_of(ep, struct fi_ibv_xrc_ep,
 						    base_ep);
 
-	fi_ibv_ep_destroy_xrc_qp(xrc_ep);
 	if (xrc_ep->conn_setup)
-		fi_ibv_free_xrc_conn_setup(xrc_ep);
+		fi_ibv_free_xrc_conn_setup(xrc_ep, 0);
+	fi_ibv_ep_destroy_xrc_qp(xrc_ep);
+	xrc_ep->magic = 0;
 }
 
 static int fi_ibv_ep_close(fid_t fid)

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -60,20 +60,20 @@ fi_ibv_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 	return sizeof(*entry);
 }
 
+/* Caller must hold eq:lock */
 void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 {
 	struct fi_ibv_eq *eq = ep->base_ep.eq;
 
-	fastlock_acquire(&eq->lock);
 	assert(ep->conn_setup);
 	assert(ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID);
 	ep->conn_setup->conn_tag =
 		(uint32_t)ofi_idx2key(&eq->xrc.conn_key_idx,
 				ofi_idx_insert(eq->xrc.conn_key_map, ep));
 	ep->conn_setup->created_conn_tag = true;
-	fastlock_release(&eq->lock);
 }
 
+/* Caller must hold eq:lock */
 void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 {
 	struct fi_ibv_eq *eq = ep->base_ep.eq;
@@ -83,7 +83,6 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	if (!ep->conn_setup->created_conn_tag)
 		return;
 
-	fastlock_acquire(&eq->lock);
 	index = ofi_key2idx(&eq->xrc.conn_key_idx,
 			    (uint64_t)ep->conn_setup->conn_tag);
 	if (!ofi_idx_is_valid(eq->xrc.conn_key_map, index))
@@ -91,27 +90,24 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	else
 		ofi_idx_remove(eq->xrc.conn_key_map, index);
 	ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
-	fastlock_release(&eq->lock);
 }
 
+/* Caller must hold eq:lock */
 struct fi_ibv_xrc_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq,
 						uint32_t conn_tag)
 {
 	struct fi_ibv_xrc_ep *ep;
 	int index;
 
-	fastlock_acquire(&eq->lock);
 	index = ofi_key2idx(&eq->xrc.conn_key_idx, (uint64_t)conn_tag);
 	ep = ofi_idx_lookup(eq->xrc.conn_key_map, index);
 	if (!ep || !ep->conn_setup || (ep->conn_setup->conn_tag != conn_tag)) {
 		VERBS_WARN(FI_LOG_FABRIC,
 			   "Invalid/stale XRC connection tag\n");
-		goto err;
+		return ep;
 	}
 	ofi_idx_remove(eq->xrc.conn_key_map, index);
 	ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
-err:
-	fastlock_release(&eq->lock);
 
 	return ep;
 }
@@ -277,6 +273,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 		return FI_SUCCESS;
 	}
 
+	fastlock_acquire(&eq->lock);
 	/*
 	 * Reciprocal connections are initiated and handled internally by
 	 * the provider, get the endpoint that issued the original connection
@@ -286,8 +283,9 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 	if (!ep) {
 		VERBS_WARN(FI_LOG_FABRIC,
 			   "Reciprocal XRC connection tag not found\n");
-		return -FI_EAGAIN;
+		goto done;
 	}
+
 	ep->tgt_id = connreq->id;
 	ep->tgt_id->context = &ep->base_ep.util_ep.ep_fid.fid;
 	ep->base_ep.info->handle = entry->info->handle;
@@ -305,12 +303,17 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 			   "Reciprocal XRC Accept failed %d\n", ret);
 		goto send_reject;
 	}
+done:
+	fastlock_release(&eq->lock);
+
 	/* Event is handled internally and not passed to the application */
 	return -FI_EAGAIN;
 
 send_reject:
 	if (rdma_reject(connreq->id, *priv_data, *priv_datalen))
 		VERBS_WARN(FI_LOG_FABRIC, "rdma_reject %d\n", -errno);
+	fastlock_release(&eq->lock);
+
 	return -FI_EAGAIN;
 }
 
@@ -406,6 +409,7 @@ fi_ibv_eq_xrc_recip_conn_event(struct fi_ibv_eq *eq,
 	return sizeof(*entry) + len;
 }
 
+/* Caller must hold eq:lock */
 static int
 fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
 {
@@ -446,6 +450,7 @@ fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
 	return state == FI_IBV_XRC_ORIG_CONNECTING ? FI_SUCCESS : -FI_EAGAIN;
 }
 
+/* Caller must hold eq:lock */
 static inline int
 fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 			      struct rdma_cm_event *cma_event,
@@ -475,6 +480,7 @@ fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 	return ret;
 }
 
+/* Caller must hold eq:lock */
 static inline void
 fi_ibv_eq_xrc_timewait_event(struct fi_ibv_eq *eq,
 			     struct rdma_cm_event *cma_event, int *acked)
@@ -505,6 +511,7 @@ fi_ibv_eq_xrc_timewait_event(struct fi_ibv_eq *eq,
 		fi_ibv_free_xrc_conn_setup(ep, 0);
 }
 
+/* Caller must hold eq:lock */
 static inline void
 fi_ibv_eq_xrc_disconnect_event(struct fi_ibv_eq *eq,
 			       struct rdma_cm_event *cma_event, int *acked)
@@ -572,15 +579,21 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 				return ret;
 		}
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
-		if (fi_ibv_is_xrc(ep->info))
-			return fi_ibv_eq_xrc_connected_event(eq, cma_event,
-							     entry, len, acked);
+		if (fi_ibv_is_xrc(ep->info)) {
+			fastlock_acquire(&eq->lock);
+			ret = fi_ibv_eq_xrc_connected_event(eq, cma_event,
+							    entry, len, acked);
+			fastlock_release(&eq->lock);
+			return ret;
+		}
 		entry->info = NULL;
 		break;
 	case RDMA_CM_EVENT_DISCONNECTED:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
 		if (fi_ibv_is_xrc(ep->info)) {
+			fastlock_acquire(&eq->lock);
 			fi_ibv_eq_xrc_disconnect_event(eq, cma_event, acked);
+			fastlock_release(&eq->lock);
 			return -FI_EAGAIN;
 		}
 		*event = FI_SHUTDOWN;
@@ -588,8 +601,11 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		break;
 	case RDMA_CM_EVENT_TIMEWAIT_EXIT:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
-		if (fi_ibv_is_xrc(ep->info))
+		if (fi_ibv_is_xrc(ep->info)) {
+			fastlock_acquire(&eq->lock);
 			fi_ibv_eq_xrc_timewait_event(eq, cma_event, acked);
+			fastlock_release(&eq->lock);
+		}
 		return -FI_EAGAIN;
 	case RDMA_CM_EVENT_ADDR_ERROR:
 	case RDMA_CM_EVENT_ROUTE_ERROR:
@@ -600,7 +616,9 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 	case RDMA_CM_EVENT_REJECTED:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
 		if (fi_ibv_is_xrc(ep->info)) {
+			fastlock_acquire(&eq->lock);
 			ret = fi_ibv_eq_xrc_rej_event(eq, cma_event);
+			fastlock_release(&eq->lock);
 			if (ret == -FI_EAGAIN)
 				return ret;
 			fi_ibv_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -65,9 +65,12 @@ void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	struct fi_ibv_eq *eq = ep->base_ep.eq;
 
 	fastlock_acquire(&eq->lock);
+	assert(ep->conn_setup);
+	assert(ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID);
 	ep->conn_setup->conn_tag =
 		(uint32_t)ofi_idx2key(&eq->xrc.conn_key_idx,
 				ofi_idx_insert(eq->xrc.conn_key_map, ep));
+	ep->conn_setup->created_conn_tag = true;
 	fastlock_release(&eq->lock);
 }
 
@@ -76,6 +79,10 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	struct fi_ibv_eq *eq = ep->base_ep.eq;
 	int index;
 
+	assert(ep->conn_setup);
+	if (!ep->conn_setup->created_conn_tag)
+		return;
+
 	fastlock_acquire(&eq->lock);
 	index = ofi_key2idx(&eq->xrc.conn_key_idx,
 			    (uint64_t)ep->conn_setup->conn_tag);
@@ -83,7 +90,7 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	    VERBS_WARN(FI_LOG_EQ, "Invalid XRC connection connection tag\n");
 	else
 		ofi_idx_remove(eq->xrc.conn_key_map, index);
-	ep->conn_setup->conn_tag = 0;
+	ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 	fastlock_release(&eq->lock);
 }
 
@@ -96,9 +103,14 @@ struct fi_ibv_xrc_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq,
 	fastlock_acquire(&eq->lock);
 	index = ofi_key2idx(&eq->xrc.conn_key_idx, (uint64_t)conn_tag);
 	ep = ofi_idx_lookup(eq->xrc.conn_key_map, index);
-	if (!ep)
+	if (!ep || !ep->conn_setup || (ep->conn_setup->conn_tag != conn_tag)) {
 		VERBS_WARN(FI_LOG_FABRIC,
-			   "Invalid XRC connection tag\n");
+			   "Invalid/stale XRC connection tag\n");
+		goto err;
+	}
+	ofi_idx_remove(eq->xrc.conn_key_map, index);
+	ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
+err:
 	fastlock_release(&eq->lock);
 
 	return ep;
@@ -274,7 +286,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 	if (!ep) {
 		VERBS_WARN(FI_LOG_FABRIC,
 			   "Reciprocal XRC connection tag not found\n");
-		goto send_reject;
+		return -FI_EAGAIN;
 	}
 	ep->tgt_id = connreq->id;
 	ep->tgt_id->context = &ep->base_ep.util_ep.ep_fid.fid;
@@ -804,7 +816,7 @@ int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	_eq->fab = container_of(fabric, struct fi_ibv_fabric,
 				util_fabric.fabric_fid);
 
-	ofi_key_idx_init(&_eq->xrc.conn_key_idx, VERBS_TAG_INDEX_BITS);
+	ofi_key_idx_init(&_eq->xrc.conn_key_idx, VERBS_CONN_TAG_INDEX_BITS);
 	_eq->xrc.conn_key_map = calloc(1, sizeof(*_eq->xrc.conn_key_map));
 	if (!_eq->xrc.conn_key_map) {
 		ret = -ENOMEM;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -470,13 +470,57 @@ fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
 	 * ID(s) since  RDMA CM is used for connection setup only */
 	*acked = 1;
 	rdma_ack_cm_event(cma_event);
-
-	/* TODO: Ultimately we will want to initiate freeing of the connection
-	 * resources here with fi_ibv_free_xrc_conn_setup(ep); however, timewait
-	 * issues in larger fabrics need to be resolved first. The resources
-	 * will be freed at EP close if not freed here */
+	fi_ibv_free_xrc_conn_setup(ep, 1);
 
 	return ret;
+}
+
+static inline void
+fi_ibv_eq_xrc_timewait_event(struct fi_ibv_eq *eq,
+			     struct rdma_cm_event *cma_event, int *acked)
+{
+	fid_t fid = cma_event->id->context;
+	struct fi_ibv_xrc_ep *ep = container_of(fid, struct fi_ibv_xrc_ep,
+						base_ep.util_ep.ep_fid);
+	assert(ep->magic == VERBS_XRC_EP_MAGIC);
+	assert(ep->conn_setup);
+
+	if (cma_event->id == ep->tgt_id && ep->conn_setup->rsvd_tgt_qpn) {
+		*acked = 1;
+		rdma_ack_cm_event(cma_event);
+		ibv_destroy_qp(ep->conn_setup->rsvd_tgt_qpn);
+		ep->conn_setup->rsvd_tgt_qpn = NULL;
+		rdma_destroy_id(ep->tgt_id);
+		ep->tgt_id = NULL;
+	} else if (cma_event->id == ep->base_ep.id &&
+		   ep->conn_setup->rsvd_ini_qpn) {
+		*acked = 1;
+		rdma_ack_cm_event(cma_event);
+		ibv_destroy_qp(ep->conn_setup->rsvd_ini_qpn);
+		ep->conn_setup->rsvd_ini_qpn = NULL;
+		rdma_destroy_id(ep->base_ep.id);
+		ep->base_ep.id = NULL;
+	}
+	if (!ep->conn_setup->rsvd_ini_qpn && !ep->conn_setup->rsvd_tgt_qpn)
+		fi_ibv_free_xrc_conn_setup(ep, 0);
+}
+
+static inline void
+fi_ibv_eq_xrc_disconnect_event(struct fi_ibv_eq *eq,
+			       struct rdma_cm_event *cma_event, int *acked)
+{
+	fid_t fid = cma_event->id->context;
+	struct fi_ibv_xrc_ep *ep = container_of(fid, struct fi_ibv_xrc_ep,
+						base_ep.util_ep.ep_fid);
+	assert(ep->magic == VERBS_XRC_EP_MAGIC);
+
+	if (ep->conn_setup && cma_event->id == ep->base_ep.id &&
+	    ep->conn_setup->rsvd_ini_qpn) {
+		*acked = 1;
+		rdma_ack_cm_event(cma_event);
+		rdma_disconnect(ep->base_ep.id);
+		ep->conn_setup->ini_connected = 0;
+	}
 }
 
 static ssize_t
@@ -535,11 +579,18 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		break;
 	case RDMA_CM_EVENT_DISCONNECTED:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
-		if (fi_ibv_is_xrc(ep->info))
+		if (fi_ibv_is_xrc(ep->info)) {
+			fi_ibv_eq_xrc_disconnect_event(eq, cma_event, acked);
 			return -FI_EAGAIN;
+		}
 		*event = FI_SHUTDOWN;
 		entry->info = NULL;
 		break;
+	case RDMA_CM_EVENT_TIMEWAIT_EXIT:
+		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
+		if (fi_ibv_is_xrc(ep->info))
+			fi_ibv_eq_xrc_timewait_event(eq, cma_event, acked);
+		return -FI_EAGAIN;
 	case RDMA_CM_EVENT_ADDR_ERROR:
 	case RDMA_CM_EVENT_ROUTE_ERROR:
 	case RDMA_CM_EVENT_CONNECT_ERROR:


### PR DESCRIPTION
12eabf3 - Misleading log fix
52e75f8 - Remove extra unprotected line of code
15bc580 - More robust connection id mapping
31e9832 - XRC shared resource cleanup
7c0c381 - Make sure XRC EQ processing is thread-safe