### PR TITLE
[v1.7.x] prov/rxd: cherry-picked fixes

### DIFF
--- a/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
+++ b/fabtests/test_configs/ofi_rxd/ofi_rxd.exclude
@@ -13,7 +13,6 @@ poll
 cq_data
 
 # Exclude tests with unsupported capabilities
-rdm_tagged_peek
 cm_data
 trigger
 shared_ctx

--- a/fabtests/test_configs/osx.exclude
+++ b/fabtests/test_configs/osx.exclude
@@ -3,3 +3,5 @@
 # Exclude msg_epoll test as OSX doesn't have epoll system call
 msg_epoll
 msg_sockets
+
+rdm_tagged_peek

--- a/include/ofi_list.h
+++ b/include/ofi_list.h
@@ -396,10 +396,12 @@ static inline int slist_empty(struct slist *list)
 
 static inline void slist_insert_head(struct slist_entry *item, struct slist *list)
 {
-	if (slist_empty(list))
+	if (slist_empty(list)) {
 		list->tail = item;
-	else
+		item->next = NULL;
+	} else {
 		item->next = list->head;
+	}
 
 	list->head = item;
 }
@@ -411,6 +413,7 @@ static inline void slist_insert_tail(struct slist_entry *item, struct slist *lis
 	else
 		list->tail->next = item;
 
+	item->next = NULL;
 	list->tail = item;
 }
 

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -86,7 +86,6 @@
 #define RXD_TAG_HDR		(1 << 4)
 #define RXD_INLINE		(1 << 5)
 #define RXD_MULTI_RECV		(1 << 6)
-#define RXD_CANCELLED		(1 << 7)
 
 struct rxd_env {
 	int spin_count;

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -188,6 +188,8 @@ struct rxd_ep {
 	int next_retry;
 	int dg_cq_fd;
 	size_t pending_cnt;
+	uint32_t tx_flags;
+	uint32_t rx_flags;
 
 	struct util_buf_pool *tx_pkt_pool;
 	struct util_buf_pool *rx_pkt_pool;
@@ -278,9 +280,6 @@ static inline uint32_t rxd_rx_flags(uint64_t fi_flags)
 
 	return rxd_flags | RXD_NO_RX_COMP;
 }
-
-#define rxd_ep_rx_flags(rxd_ep) (rxd_rx_flags((rxd_ep)->util_ep.rx_op_flags))
-#define rxd_ep_tx_flags(rxd_ep) (rxd_tx_flags((rxd_ep)->util_ep.tx_op_flags))
 
 struct rxd_pkt_entry {
 	struct dlist_entry d_entry;

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -74,7 +74,6 @@
 #define RXD_RX_POOL_CHUNK_CNT	1024
 #define RXD_MAX_PENDING		128
 #define RXD_MAX_PKT_RETRY	50
-#define RXD_UNEXP_ID		(~0)
 
 #define RXD_PKT_IN_USE		(1 << 0)
 #define RXD_PKT_ACKED		(1 << 1)
@@ -139,6 +138,7 @@ struct rxd_peer {
 	uint16_t curr_rx_id;
 	uint16_t curr_tx_id;
 
+	struct rxd_unexp_msg *curr_unexp;
 	struct dlist_entry tx_list;
 	struct dlist_entry rx_list;
 	struct dlist_entry rma_rx_list;

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -129,8 +129,8 @@ struct rxd_peer {
 	uint64_t rx_seq_no;
 	uint64_t last_rx_ack;
 	uint64_t last_tx_ack;
-	uint16_t rx_window;//constant at MAX_UNACKED for now
-	uint16_t tx_window;//unused for now, will be used for slow start
+	uint16_t rx_window;
+	uint16_t tx_window;
 	int retry_cnt;
 
 	uint16_t unacked_cnt;
@@ -242,7 +242,6 @@ struct rxd_x_entry {
 	uint64_t next_seg_no;
 	uint64_t start_seq;
 	uint64_t offset;
-	uint16_t window;
 	uint64_t num_segs;
 	uint32_t op;
 

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -74,6 +74,7 @@
 #define RXD_RX_POOL_CHUNK_CNT	1024
 #define RXD_MAX_PENDING		128
 #define RXD_MAX_PKT_RETRY	50
+#define RXD_UNEXP_ID		(~0)
 
 #define RXD_PKT_IN_USE		(1 << 0)
 #define RXD_PKT_ACKED		(1 << 1)
@@ -297,6 +298,18 @@ struct rxd_pkt_entry {
 	void *pkt;
 };
 
+struct rxd_unexp_msg {
+	struct dlist_entry entry;
+	struct rxd_pkt_entry *pkt_entry;
+	struct dlist_entry pkt_list;
+	struct rxd_base_hdr *base_hdr;
+	struct rxd_sar_hdr *sar_hdr;
+	struct rxd_tag_hdr *tag_hdr;
+	struct rxd_data_hdr *data_hdr;
+	size_t msg_size;
+	void *msg;
+};
+
 static inline int rxd_pkt_type(struct rxd_pkt_entry *pkt_entry)
 {
 	return ((struct rxd_base_hdr *) (pkt_entry->pkt))->type;
@@ -354,6 +367,7 @@ static inline void *rxd_pkt_start(struct rxd_pkt_entry *pkt_entry)
 struct rxd_match_attr {
 	fi_addr_t	peer;
 	uint64_t	tag;
+	uint64_t	ignore;
 };
 
 static inline int rxd_match_addr(fi_addr_t addr, fi_addr_t match_addr)
@@ -436,7 +450,7 @@ uint64_t rxd_get_retry_time(uint64_t start, uint8_t retry_cnt);
 ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 			       size_t iov_count, fi_addr_t addr, uint64_t tag,
 			       uint64_t ignore, void *context, uint32_t op,
-			       uint32_t rxd_flags);
+			       uint32_t rxd_flags, uint64_t flags);
 ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 			       size_t iov_count, fi_addr_t addr, uint64_t tag,
 			       uint64_t data, void *context, uint32_t op,
@@ -460,10 +474,13 @@ void rxd_progress_op(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
 		     struct rxd_rma_hdr *rma_hdr,
 		     struct rxd_atom_hdr *atom_hdr,
 		     void **msg, size_t size);
+void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
+		      struct rxd_data_pkt *pkt, size_t size);
 void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer);
 struct rxd_x_entry *rxd_progress_multi_recv(struct rxd_ep *ep,
 					    struct rxd_x_entry *rx_entry,
 					    size_t total_size);
+void rxd_ep_progress(struct util_ep *util_ep);
 
 /* CQ sub-functions */
 void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry);

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -193,6 +193,11 @@ struct rxd_ep {
 
 	struct util_buf_pool *tx_pkt_pool;
 	struct util_buf_pool *rx_pkt_pool;
+	size_t tx_msg_avail;
+	size_t rx_msg_avail;
+	size_t tx_rma_avail;
+	size_t rx_rma_avail;
+
 	struct slist rx_pkt_list;
 
 	struct util_buf_pool *tx_entry_pool;
@@ -394,8 +399,8 @@ void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer);
 struct rxd_pkt_entry *rxd_get_tx_pkt(struct rxd_ep *ep);
 void rxd_release_rx_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt);
 void rxd_release_tx_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt);
-struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep);
-struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep);
+struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep, uint32_t op);
+struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep, uint32_t op);
 void rxd_release_rx_entry(struct rxd_ep *ep, struct rxd_x_entry *x_entry);
 int rxd_ep_retry_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry);
 ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry);

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -102,7 +102,7 @@ static ssize_t rxd_atomic_writemsg(struct fid_ep *ep_fid,
 				  NULL, NULL, 0, NULL, NULL, 0, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count, msg->data,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic, rxd_tx_flags(flags |
+				  RXD_ATOMIC, rxd_tx_flags(flags |
 				  ep->util_ep.tx_msg_flags));
 }
 
@@ -122,7 +122,7 @@ static ssize_t rxd_atomic_writev(struct fid_ep *ep_fid,
 
 	return rxd_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, NULL,
 				  NULL, 0, dest_addr, &rma_iov, 1, 0, datatype,
-				  op, context, ofi_op_atomic,
+				  op, context, RXD_ATOMIC,
 				  ep->tx_flags);
 }
 
@@ -146,7 +146,7 @@ static ssize_t rxd_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t c
 
 	return rxd_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, NULL, NULL, 0,
 				  dest_addr, &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic, ep->tx_flags);
+				  RXD_ATOMIC, ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
@@ -179,7 +179,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto out;
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, &iov, 1, NULL, 0, 1, 0, 0, NULL,
-				     rxd_addr, ofi_op_atomic,
+				     rxd_addr, RXD_ATOMIC,
 				     RXD_INJECT | RXD_NO_TX_COMP);
 	if (!tx_entry)
 		goto out;
@@ -206,7 +206,7 @@ static ssize_t rxd_atomic_readwritemsg(struct fid_ep *ep_fid,
 				  result_count, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count, msg->data,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic_fetch, rxd_tx_flags(flags |
+				  RXD_ATOMIC_FETCH, rxd_tx_flags(flags |
 				  ep->util_ep.tx_msg_flags));
 }
 
@@ -229,7 +229,7 @@ static ssize_t rxd_atomic_readwritev(struct fid_ep *ep_fid,
 	return rxd_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, resultv,
 				  result_desc, result_count, dest_addr,
 				  &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic_fetch, ep->tx_flags);
+				  RXD_ATOMIC_FETCH, ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
@@ -256,7 +256,7 @@ static ssize_t rxd_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
 
 	return rxd_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, &resultv,
 				  &result_desc, 1, dest_addr, &rma_iov, 1, 0,
-				  datatype, op, context, ofi_op_atomic_fetch,
+				  datatype, op, context, RXD_ATOMIC_FETCH,
 				  ep->tx_flags);
 }
 
@@ -276,7 +276,7 @@ static ssize_t rxd_atomic_compwritemsg(struct fid_ep *ep_fid,
 				  result_count, msg->addr,
 				  msg->rma_iov, msg->rma_iov_count, msg->data,
 				  msg->datatype, msg->op, msg->context,
-				  ofi_op_atomic_compare, rxd_tx_flags(flags |
+				  RXD_ATOMIC_COMPARE, rxd_tx_flags(flags |
 				  ep->util_ep.tx_msg_flags));
 }
 
@@ -300,7 +300,7 @@ static ssize_t rxd_atomic_compwritev(struct fid_ep *ep_fid,
 	return rxd_generic_atomic(ep, iov, desc, count, comparev, compare_desc,
 				  compare_count, resultv, result_desc,
 				  result_count, dest_addr, &rma_iov, 1, 0,
-				  datatype, op, context, ofi_op_atomic_compare,
+				  datatype, op, context, RXD_ATOMIC_COMPARE,
 				  ep->tx_flags);
 }
 
@@ -332,7 +332,7 @@ static ssize_t rxd_atomic_compwrite(struct fid_ep *ep_fid, const void *buf,
 	return rxd_generic_atomic(ep, &iov, &desc, 1, &comparev, &compare_desc,
 				  1, &resultv, &result_desc, 1, dest_addr,
 				  &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic_compare, ep->tx_flags);
+				  RXD_ATOMIC_COMPARE, ep->tx_flags);
 }
 
 int rxd_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -125,7 +125,7 @@ static ssize_t rxd_atomic_writev(struct fid_ep *ep_fid,
 	return rxd_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, NULL,
 				  NULL, 0, dest_addr, &rma_iov, 1, 0, datatype,
 				  op, context, ofi_op_atomic,
-				  rxd_ep_tx_flags(ep));
+				  ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t count,
@@ -148,7 +148,7 @@ static ssize_t rxd_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t c
 
 	return rxd_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, NULL, NULL, 0,
 				  dest_addr, &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic, rxd_ep_tx_flags(ep));
+				  ofi_op_atomic, ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
@@ -233,7 +233,7 @@ static ssize_t rxd_atomic_readwritev(struct fid_ep *ep_fid,
 	return rxd_generic_atomic(ep, iov, desc, count, NULL, NULL, 0, resultv,
 				  result_desc, result_count, dest_addr,
 				  &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic_fetch, rxd_ep_tx_flags(ep));
+				  ofi_op_atomic_fetch, ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
@@ -261,7 +261,7 @@ static ssize_t rxd_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
 	return rxd_generic_atomic(ep, &iov, &desc, 1, NULL, NULL, 0, &resultv,
 				  &result_desc, 1, dest_addr, &rma_iov, 1, 0,
 				  datatype, op, context, ofi_op_atomic_fetch,
-				  rxd_ep_tx_flags(ep));
+				  ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_compwritemsg(struct fid_ep *ep_fid,
@@ -305,7 +305,7 @@ static ssize_t rxd_atomic_compwritev(struct fid_ep *ep_fid,
 				  compare_count, resultv, result_desc,
 				  result_count, dest_addr, &rma_iov, 1, 0,
 				  datatype, op, context, ofi_op_atomic_compare,
-				  rxd_ep_tx_flags(ep));
+				  ep->tx_flags);
 }
 
 static ssize_t rxd_atomic_compwrite(struct fid_ep *ep_fid, const void *buf,
@@ -336,7 +336,7 @@ static ssize_t rxd_atomic_compwrite(struct fid_ep *ep_fid, const void *buf,
 	return rxd_generic_atomic(ep, &iov, &desc, 1, &comparev, &compare_desc,
 				  1, &resultv, &result_desc, 1, dest_addr,
 				  &rma_iov, 1, 0, datatype, op, context,
-				  ofi_op_atomic_compare, rxd_ep_tx_flags(ep));
+				  ofi_op_atomic_compare, ep->tx_flags);
 }
 
 int rxd_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -67,7 +67,6 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 	ofi_rma_ioc_to_iov(rma_ioc, rma_iov, rma_count, ofi_datatype_size(datatype));
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -88,7 +87,6 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }
@@ -171,7 +169,6 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	rma_iov.key = key;
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -192,7 +189,6 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -391,6 +391,7 @@ void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer)
 			if (ofi_before(tx_entry->start_seq + (tx_entry->num_segs - 1),
 			    head_seq)) {
 				if (tx_entry->op == RXD_DATA_READ) {
+					tx_entry->op = ofi_op_read_req;
 					fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
 					rxd_complete_rx(ep, tx_entry);
 					fastlock_release(&ep->util_ep.rx_cq->cq_lock);

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -119,9 +119,6 @@ static void rxd_complete_rx(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 	struct rxd_cq *rx_cq = rxd_ep_rx_cq(ep);
 	int ret;
 
-	if (rx_entry->flags & RXD_CANCELLED)
-		goto out;
-
 	if (rx_entry->bytes_done != rx_entry->cq_entry.len) {
 		memset(&err_entry, 0, sizeof(err_entry));
 		err_entry.op_context = rx_entry->cq_entry.op_context;
@@ -511,8 +508,6 @@ static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 	rx_entry = container_of(match, struct rxd_x_entry, entry);
 
 	total_size = op ? op->size : msg_size;
-	if (rx_entry->flags & RXD_CANCELLED)
-		goto out;
 
 	if (rx_entry->flags & RXD_MULTI_RECV) {
 		dup_entry = rxd_progress_multi_recv(ep, rx_entry, total_size);
@@ -806,15 +801,6 @@ void rxd_progress_op(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
 		     struct rxd_atom_hdr *atom_hdr,
 		     void **msg, size_t size)
 {
-
-	if (rx_entry->flags & RXD_CANCELLED) {
-		rxd_complete_rx(ep, rx_entry);
-		if (sar_hdr)
-			ep->peers[base_hdr->peer].rx_seq_no +=
-				(sar_hdr->num_segs - 1);
-		return;
-	}
-
 	if (sar_hdr)
 		ep->peers[base_hdr->peer].curr_tx_id = sar_hdr->tx_id;
 

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -64,96 +64,19 @@ static const char *rxd_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 	return str;
 }
 
-static int rxd_cq_write_ctx(struct rxd_cq *cq,
-			     struct fi_cq_tagged_entry *cq_entry)
+static int rxd_cq_write(struct rxd_cq *cq,
+			struct fi_cq_tagged_entry *cq_entry)
 {
-	struct fi_cq_tagged_entry *comp;
-
-	if (ofi_cirque_isfull(cq->util_cq.cirq))
-		return -FI_ENOSPC;
-
-	comp = ofi_cirque_tail(cq->util_cq.cirq);
-	comp->op_context = cq_entry->op_context;
-	ofi_cirque_commit(cq->util_cq.cirq);
-	return 0;
+	return ofi_cq_write(&cq->util_cq, cq_entry->op_context,
+			    cq_entry->flags, cq_entry->len,
+			    cq_entry->buf, cq_entry->data,
+			    cq_entry->tag);
 }
 
-static int rxd_cq_write_ctx_signal(struct rxd_cq *cq,
-				    struct fi_cq_tagged_entry *cq_entry)
+static int rxd_cq_write_signal(struct rxd_cq *cq,
+			       struct fi_cq_tagged_entry *cq_entry)
 {
-	int ret = rxd_cq_write_ctx(cq, cq_entry);
-	cq->util_cq.wait->signal(cq->util_cq.wait);
-	return ret;
-}
-
-static int rxd_cq_write_msg(struct rxd_cq *cq,
-			     struct fi_cq_tagged_entry *cq_entry)
-{
-	struct fi_cq_tagged_entry *comp;
-	if (ofi_cirque_isfull(cq->util_cq.cirq))
-		return -FI_ENOSPC;
-
-	comp = ofi_cirque_tail(cq->util_cq.cirq);
-	comp->op_context = cq_entry->op_context;
-	comp->flags = cq_entry->flags;
-	comp->len = cq_entry->len;
-	ofi_cirque_commit(cq->util_cq.cirq);
-	return 0;
-}
-
-static int rxd_cq_write_msg_signal(struct rxd_cq *cq,
-				    struct fi_cq_tagged_entry *cq_entry)
-{
-	int ret = rxd_cq_write_msg(cq, cq_entry);
-	cq->util_cq.wait->signal(cq->util_cq.wait);
-	return ret;
-}
-
-static int rxd_cq_write_data(struct rxd_cq *cq,
-			      struct fi_cq_tagged_entry *cq_entry)
-{
-	struct fi_cq_tagged_entry *comp;
-	if (ofi_cirque_isfull(cq->util_cq.cirq))
-		return -FI_ENOSPC;
-
-	comp = ofi_cirque_tail(cq->util_cq.cirq);
-	comp->op_context = cq_entry->op_context;
-	comp->flags = cq_entry->flags;
-	comp->len = cq_entry->len;
-	comp->buf = cq_entry->buf;
-	comp->data = cq_entry->data;
-	ofi_cirque_commit(cq->util_cq.cirq);
-	return 0;
-}
-
-static int rxd_cq_write_data_signal(struct rxd_cq *cq,
-				     struct fi_cq_tagged_entry *cq_entry)
-{
-	int ret = rxd_cq_write_data(cq, cq_entry);
-	cq->util_cq.wait->signal(cq->util_cq.wait);
-	return ret;
-}
-
-static int rxd_cq_write_tagged(struct rxd_cq *cq,
-				struct fi_cq_tagged_entry *cq_entry)
-{
-	struct fi_cq_tagged_entry *comp;
-	if (ofi_cirque_isfull(cq->util_cq.cirq))
-		return -FI_ENOSPC;
-
-	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL,
-	       "report completion: %" PRIx64 "\n", cq_entry->tag);
-
-	comp = ofi_cirque_tail(cq->util_cq.cirq);
-	*comp = *cq_entry;
-	ofi_cirque_commit(cq->util_cq.cirq);
-	return 0;
-}
-
-static int rxd_cq_write_tagged_signal(struct rxd_cq *cq,
-				       struct fi_cq_tagged_entry *cq_entry)
-{
-	int ret = rxd_cq_write_tagged(cq, cq_entry);
+	int ret = rxd_cq_write(cq, cq_entry);
 	cq->util_cq.wait->signal(cq->util_cq.wait);
 	return ret;
 }
@@ -189,26 +112,11 @@ void rxd_release_repost_rx(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 	rxd_ep_post_buf(ep);
 }
 
-void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry)
-{
-	struct fi_cq_tagged_entry cq_entry = {0};
-	struct util_cq_oflow_err_entry *entry = calloc(1, sizeof(*entry));
-	if (!entry) {
-		FI_WARN(&rxd_prov, FI_LOG_CQ,
-			"out of memory, cannot report CQ error\n");
-		return;
-	}
-
-	entry->comp = *err_entry;
-	slist_insert_tail(&entry->list_entry, &cq->util_cq.oflow_err_list);
-	cq_entry.flags = UTIL_FLAG_ERROR;
-	cq->write_fn(cq, &cq_entry);
-}
-
 static void rxd_complete_rx(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 {
 	struct fi_cq_err_entry err_entry;
 	struct rxd_cq *rx_cq = rxd_ep_rx_cq(ep);
+	int ret;
 
 	if (rx_entry->flags & RXD_CANCELLED)
 		goto out;
@@ -220,7 +128,12 @@ static void rxd_complete_rx(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 		err_entry.len = rx_entry->bytes_done;
 		err_entry.err = FI_ETRUNC;
 		err_entry.prov_errno = 0;
-		rxd_cq_report_error(rx_cq, &err_entry);
+
+		ret = ofi_cq_write_error(&rx_cq->util_cq, &err_entry);
+		if (ret) {
+			FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not write error entry\n");
+			return;
+		}
 		goto out;
 	}
 
@@ -293,15 +206,10 @@ static void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
 	}
 	rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 
-	if (x_entry->cq_entry.flags & FI_READ) {
-		fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
+	if (x_entry->cq_entry.flags & FI_READ)
 		rxd_complete_tx(ep, x_entry);
-		fastlock_release(&ep->util_ep.tx_cq->cq_lock);
-	} else {
-		fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
+	else
 		rxd_complete_rx(ep, x_entry);
-		fastlock_release(&ep->util_ep.rx_cq->cq_lock);
-	}
 }
 
 static void rxd_verify_active(struct rxd_ep *ep, fi_addr_t addr, fi_addr_t peer_addr)
@@ -392,13 +300,9 @@ void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer)
 			    head_seq)) {
 				if (tx_entry->op == RXD_DATA_READ) {
 					tx_entry->op = ofi_op_read_req;
-					fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
 					rxd_complete_rx(ep, tx_entry);
-					fastlock_release(&ep->util_ep.rx_cq->cq_lock);
 				} else {
-					fastlock_acquire(&ep->util_ep.tx_cq->cq_lock);
 					rxd_complete_tx(ep, tx_entry);
-					fastlock_release(&ep->util_ep.tx_cq->cq_lock);
 				}
 			}
 			continue;
@@ -1055,15 +959,11 @@ static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 		goto release;
 	}
 
-	fastlock_acquire(&ep->util_ep.rx_cq->cq_lock);
 	rxd_progress_op(ep, rx_entry, pkt_entry, base_hdr, sar_hdr, tag_hdr,
 			data_hdr, rma_hdr, atom_hdr, &msg, msg_size);
 
-
 	if (!dlist_empty(&ep->peers[base_hdr->peer].buf_pkts))
 		rxd_progress_buf_pkts(ep, base_hdr->peer);
-
-	fastlock_release(&ep->util_ep.rx_cq->cq_lock);
 
 ack:
 	rxd_ep_send_ack(ep, base_hdr->peer);
@@ -1305,36 +1205,12 @@ int rxd_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (ret)
 		goto free;
 
-	switch (attr->format) {
-	case FI_CQ_FORMAT_UNSPEC:
-	case FI_CQ_FORMAT_CONTEXT:
-		cq->write_fn = cq->util_cq.wait ?
-			rxd_cq_write_ctx_signal : rxd_cq_write_ctx;
-		break;
-	case FI_CQ_FORMAT_MSG:
-		cq->write_fn = cq->util_cq.wait ?
-			rxd_cq_write_msg_signal : rxd_cq_write_msg;
-		break;
-	case FI_CQ_FORMAT_DATA:
-		cq->write_fn = cq->util_cq.wait ?
-			rxd_cq_write_data_signal : rxd_cq_write_data;
-		break;
-	case FI_CQ_FORMAT_TAGGED:
-		cq->write_fn = cq->util_cq.wait ?
-			rxd_cq_write_tagged_signal : rxd_cq_write_tagged;
-		break;
-	default:
-		ret = -FI_EINVAL;
-		goto cleanup;
-	}
-
+	cq->write_fn = cq->util_cq.wait ? rxd_cq_write_signal : rxd_cq_write;
 	*cq_fid = &cq->util_cq.cq_fid;
 	(*cq_fid)->fid.ops = &rxd_cq_fi_ops;
 	(*cq_fid)->ops = &rxd_cq_ops;
 	return 0;
 
-cleanup:
-	ofi_cq_cleanup(&cq->util_cq);
 free:
 	free(cq);
 	return ret;

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -250,7 +250,8 @@ static int rxd_move_tx_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 {
 	struct rxd_base_hdr *hdr = rxd_get_base_hdr(tx_entry->pkt);
 
-	if (ep->peers[tx_entry->peer].unacked_cnt >= rxd_env.max_unacked)
+	if (ep->peers[tx_entry->peer].unacked_cnt >=
+	    ep->peers[tx_entry->peer].tx_window)
 		return 0;
 
 	tx_entry->start_seq = rxd_set_pkt_seq(&ep->peers[tx_entry->peer],
@@ -270,7 +271,8 @@ static int rxd_move_tx_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 				  &ep->peers[tx_entry->peer].rma_rx_list);
 	}
 
-	return ep->peers[tx_entry->peer].unacked_cnt < rxd_env.max_unacked;
+	return ep->peers[tx_entry->peer].unacked_cnt <
+	       ep->peers[tx_entry->peer].tx_window;
 }
 
 void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer)
@@ -957,9 +959,11 @@ static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 			rxd_remove_rx_pkt(ep, pkt_entry);
 			return;
 		}
-		goto release;
+		ep->peers[base_hdr->peer].rx_window = 0;
+		goto ack;
 	}
 
+	ep->peers[base_hdr->peer].rx_window = rxd_env.max_unacked;
 	rxd_progress_op(ep, rx_entry, pkt_entry, base_hdr, sar_hdr, tag_hdr,
 			data_hdr, rma_hdr, atom_hdr, &msg, msg_size);
 
@@ -986,6 +990,8 @@ static void rxd_handle_ack(struct rxd_ep *ep, struct rxd_pkt_entry *ack_entry)
 	struct rxd_pkt_entry *pkt_entry;
 	fi_addr_t peer = ack->base_hdr.peer;
 	struct rxd_base_hdr *hdr;
+
+	ep->peers[peer].tx_window = ack->ext_hdr.rx_id;
 
 	if (ep->peers[peer].last_rx_ack == ack->base_hdr.seq_no)
 		return;

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -83,6 +83,7 @@ static int rxd_cq_write_signal(struct rxd_cq *cq,
 
 void rxd_rx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 {
+	rx_entry->op <= ofi_op_tagged ? ep->rx_msg_avail++ : ep->rx_rma_avail++;
 	rx_entry->op = RXD_NO_OP;
 	dlist_remove(&rx_entry->entry);
 	rxd_release_rx_entry(ep, rx_entry);
@@ -440,7 +441,7 @@ struct rxd_x_entry *rxd_progress_multi_recv(struct rxd_ep *ep,
 		return NULL;
 	}
 
-	dup_entry = rxd_get_rx_entry(ep);
+	dup_entry = rxd_get_rx_entry(ep, rx_entry->op);
 	if (!dup_entry) {
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not get rx entry\n");
 		return NULL;
@@ -544,7 +545,7 @@ static struct rxd_x_entry *rxd_rma_read_entry_init(struct rxd_ep *ep,
 	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
 	int ret;
 
-	rx_entry = rxd_get_rx_entry(ep);
+	rx_entry = rxd_get_rx_entry(ep, base_hdr->type);
 	if (!rx_entry) {
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not get rx entry\n");
 		return NULL;
@@ -609,7 +610,7 @@ static struct rxd_x_entry *rxd_rx_atomic_fetch(struct rxd_ep *ep,
 	struct rxd_x_entry *rx_entry;
 	int ret;
 
-	rx_entry = rxd_get_rx_entry(ep);
+	rx_entry = rxd_get_rx_entry(ep, base_hdr->type);
 	if (!rx_entry) {
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not get tx entry\n");
 		return NULL;

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -83,7 +83,7 @@ static int rxd_cq_write_signal(struct rxd_cq *cq,
 
 void rxd_rx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *rx_entry)
 {
-	rx_entry->op <= ofi_op_tagged ? ep->rx_msg_avail++ : ep->rx_rma_avail++;
+	rx_entry->op <= RXD_TAGGED ? ep->rx_msg_avail++ : ep->rx_rma_avail++;
 	rx_entry->op = RXD_NO_OP;
 	dlist_remove(&rx_entry->entry);
 	rxd_release_rx_entry(ep, rx_entry);
@@ -298,7 +298,7 @@ void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer)
 			if (ofi_before(tx_entry->start_seq + (tx_entry->num_segs - 1),
 			    head_seq)) {
 				if (tx_entry->op == RXD_DATA_READ) {
-					tx_entry->op = ofi_op_read_req;
+					tx_entry->op = RXD_READ_REQ;
 					rxd_complete_rx(ep, tx_entry);
 				} else {
 					rxd_complete_tx(ep, tx_entry);
@@ -575,7 +575,7 @@ static struct rxd_x_entry *rxd_rma_read_entry_init(struct rxd_ep *ep,
 		return NULL;
 
 	rx_entry->iov_count = sar_hdr->iov_count;
-	rx_entry->cq_entry.flags = ofi_rx_cq_flags(ofi_op_read_req);
+	rx_entry->cq_entry.flags = ofi_rx_cq_flags(RXD_READ_REQ);
 	rx_entry->cq_entry.len = sar_hdr->size;
 
 	dlist_insert_tail(&rx_entry->entry, &ep->peers[rx_entry->peer].tx_list);
@@ -646,7 +646,7 @@ static struct rxd_x_entry *rxd_rx_atomic_fetch(struct rxd_ep *ep,
 	if (ret)
 		return NULL;
 
-	rx_entry->cq_entry.flags = ofi_rx_cq_flags(ofi_op_atomic_fetch);
+	rx_entry->cq_entry.flags = ofi_rx_cq_flags(RXD_ATOMIC_FETCH);
 	rx_entry->cq_entry.len = sar_hdr->size;
 
 	rxd_init_data_pkt(ep, rx_entry, rx_entry->pkt);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -154,7 +154,7 @@ static ssize_t rxd_ep_cancel_recv(struct rxd_ep *ep, struct dlist_entry *list,
 
 	fastlock_acquire(&ep->util_ep.lock);
 
-	entry = dlist_find_first_match(list, &rxd_match_ctx, context);
+	entry = dlist_remove_first_match(list, &rxd_match_ctx, context);
 	if (!entry)
 		goto out;
 
@@ -169,9 +169,7 @@ static ssize_t rxd_ep_cancel_recv(struct rxd_ep *ep, struct dlist_entry *list,
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not write error entry\n");
 		goto out;
 	}
-
-	rx_entry->flags |= RXD_CANCELLED;
-
+	rxd_rx_entry_free(ep, rx_entry);
 	ret = 1;
 out:
 	fastlock_release(&ep->util_ep.lock);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -294,6 +294,9 @@ static int rxd_ep_enable(struct rxd_ep *ep)
 	if (ret)
 		return ret;
 
+	ep->tx_flags = rxd_tx_flags(ep->util_ep.tx_op_flags);
+	ep->rx_flags = rxd_rx_flags(ep->util_ep.rx_op_flags);
+
 	fastlock_acquire(&ep->util_ep.lock);
 	for (i = 0; i < ep->rx_size; i++) {
 		ret = rxd_ep_post_buf(ep);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1195,7 +1195,7 @@ int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 	struct util_buf_attr entry_pool_attr = {
 		.size		= sizeof(struct rxd_x_entry),
 		.alignment	= RXD_BUF_POOL_ALIGNMENT,
-		.max_cnt	= (size_t) ((uint16_t) RXD_UNEXP_ID),
+		.max_cnt	= (size_t) ((uint16_t) (~0)),
 		.indexing	= {
 			.used 		= 1,
 			.ordered	= 1,

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -73,28 +73,44 @@ static struct rxd_pkt_entry *rxd_get_rx_pkt(struct rxd_ep *ep)
 	return pkt_entry;
 }
 
-struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep)
+struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep, uint32_t op)
 {
 	struct rxd_x_entry *tx_entry;
+	size_t *avail = op <= ofi_op_tagged ? &ep->tx_msg_avail :
+			&ep->tx_rma_avail;
+
+	if (!(*avail)) {
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "not enough space to process RX\n");
+		return NULL;
+	}
 
 	tx_entry = util_buf_indexed_alloc(ep->tx_entry_pool);
 	if (!tx_entry)
 		return NULL;
 
 	tx_entry->tx_id = util_get_buf_index(ep->tx_entry_pool, tx_entry);
+	(*avail)--;
 
 	return tx_entry;
 }
 
-struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep)
+struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep, uint32_t op)
 {
 	struct rxd_x_entry *rx_entry;
+	size_t *avail = op <= ofi_op_tagged ? &ep->rx_msg_avail :
+			&ep->rx_rma_avail;
+
+	if (!(*avail)) {
+		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "not enough space to post TX\n");
+		return NULL;
+	}
 
 	rx_entry = util_buf_indexed_alloc(ep->rx_entry_pool);
 	if (!rx_entry)
 		return NULL;
 
 	rx_entry->rx_id = util_get_buf_index(ep->rx_entry_pool, rx_entry);
+	(*avail)--;
 
 	return rx_entry;
 }
@@ -226,7 +242,7 @@ struct rxd_x_entry *rxd_rx_entry_init(struct rxd_ep *ep,
 {
 	struct rxd_x_entry *rx_entry;
 
-	rx_entry = rxd_get_rx_entry(ep);
+	rx_entry = rxd_get_rx_entry(ep, op);
 	if (!rx_entry) {
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not get rx entry\n");
 		return NULL;
@@ -365,7 +381,7 @@ struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov
 	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
 	size_t max_inline;
 
-	tx_entry = rxd_get_tx_entry(ep);
+	tx_entry = rxd_get_tx_entry(ep, op);
 	if (!tx_entry) {
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL, "could not get tx entry\n");
 		return NULL;
@@ -433,6 +449,7 @@ struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov
 
 void rxd_tx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 {
+	tx_entry->op <= ofi_op_tagged ? ep->tx_msg_avail++ : ep->tx_rma_avail++;
 	tx_entry->op = RXD_NO_OP;
 	dlist_remove(&tx_entry->entry);
 	rxd_release_tx_entry(ep, tx_entry);
@@ -1289,6 +1306,10 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 				 dg_info->ep_attr->msg_prefix_size : 0;
 	rxd_ep->rx_size = MIN(dg_info->rx_attr->size, info->rx_attr->size);
 	rxd_ep->tx_size = MIN(dg_info->tx_attr->size, info->tx_attr->size);
+	rxd_ep->tx_msg_avail = rxd_ep->tx_size;
+	rxd_ep->rx_msg_avail = rxd_ep->rx_size;
+	rxd_ep->tx_rma_avail = rxd_ep->tx_size;
+	rxd_ep->rx_rma_avail = rxd_ep->rx_size;
 	fi_freeinfo(dg_info);
 
 	rxd_ep->next_retry = -1;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -76,7 +76,7 @@ static struct rxd_pkt_entry *rxd_get_rx_pkt(struct rxd_ep *ep)
 struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep, uint32_t op)
 {
 	struct rxd_x_entry *tx_entry;
-	size_t *avail = op <= ofi_op_tagged ? &ep->tx_msg_avail :
+	size_t *avail = op <= RXD_TAGGED ? &ep->tx_msg_avail :
 			&ep->tx_rma_avail;
 
 	if (!(*avail)) {
@@ -97,7 +97,7 @@ struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep, uint32_t op)
 struct rxd_x_entry *rxd_get_rx_entry(struct rxd_ep *ep, uint32_t op)
 {
 	struct rxd_x_entry *rx_entry;
-	size_t *avail = op <= ofi_op_tagged ? &ep->rx_msg_avail :
+	size_t *avail = op <= RXD_TAGGED ? &ep->rx_msg_avail :
 			&ep->rx_rma_avail;
 
 	if (!(*avail)) {
@@ -447,7 +447,7 @@ struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov
 
 void rxd_tx_entry_free(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 {
-	tx_entry->op <= ofi_op_tagged ? ep->tx_msg_avail++ : ep->tx_rma_avail++;
+	tx_entry->op <= RXD_TAGGED ? ep->tx_msg_avail++ : ep->tx_rma_avail++;
 	tx_entry->op = RXD_NO_OP;
 	dlist_remove(&tx_entry->entry);
 	rxd_release_tx_entry(ep, tx_entry);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -253,7 +253,6 @@ struct rxd_x_entry *rxd_rx_entry_init(struct rxd_ep *ep,
 	rx_entry->bytes_done = 0;
 	rx_entry->offset = 0;
 	rx_entry->next_seg_no = 0;
-	rx_entry->window = rxd_env.max_unacked;
 	rx_entry->iov_count = iov_count;
 	rx_entry->op = op;
 	rx_entry->ignore = ignore;
@@ -436,7 +435,7 @@ struct rxd_x_entry *rxd_tx_entry_init(struct rxd_ep *ep, const struct iovec *iov
 
 	if ((tx_entry->op == RXD_READ_REQ || tx_entry->op == RXD_ATOMIC_FETCH ||
 	     tx_entry->op == RXD_ATOMIC_COMPARE) &&
-	    ep->peers[tx_entry->peer].unacked_cnt < rxd_env.max_unacked &&
+	    ep->peers[tx_entry->peer].unacked_cnt < ep->peers[tx_entry->peer].tx_window &&
 	    ep->peers[tx_entry->peer].peer_addr != FI_ADDR_UNSPEC)
 		dlist_insert_tail(&tx_entry->entry,
 				  &ep->peers[tx_entry->peer].rma_rx_list);
@@ -470,7 +469,8 @@ ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 	struct rxd_data_pkt *data;
 
 	while (tx_entry->bytes_done != tx_entry->cq_entry.len) {
-		if (ep->peers[tx_entry->peer].unacked_cnt >= rxd_env.max_unacked)
+		if (ep->peers[tx_entry->peer].unacked_cnt >=
+		    ep->peers[tx_entry->peer].tx_window)
 			return 0;
 
 		pkt_entry = rxd_get_tx_pkt(ep);
@@ -494,7 +494,8 @@ ssize_t rxd_ep_post_data_pkts(struct rxd_ep *ep, struct rxd_x_entry *tx_entry)
 		rxd_insert_unacked(ep, tx_entry->peer, pkt_entry);
 	}
 
-	return ep->peers[tx_entry->peer].unacked_cnt < rxd_env.max_unacked;
+	return ep->peers[tx_entry->peer].unacked_cnt <
+	       ep->peers[tx_entry->peer].tx_window;
 }
 
 int rxd_ep_retry_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
@@ -700,7 +701,8 @@ int rxd_ep_send_op(struct rxd_ep *rxd_ep, struct rxd_x_entry *tx_entry,
 	pkt_entry->peer = tx_entry->peer;
 	pkt_entry->pkt_size = ((char *) ptr - (char *) base_hdr) + rxd_ep->tx_prefix_size;
 
-	if (rxd_ep->peers[tx_entry->peer].unacked_cnt < rxd_env.max_unacked &&
+	if (rxd_ep->peers[tx_entry->peer].unacked_cnt <
+	    rxd_ep->peers[tx_entry->peer].tx_window &&
 	    rxd_ep->peers[tx_entry->peer].peer_addr != FI_ADDR_UNSPEC) {
 		tx_entry->start_seq = rxd_set_pkt_seq(&rxd_ep->peers[tx_entry->peer],
 						      pkt_entry);
@@ -736,8 +738,7 @@ void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer)
 	ack->base_hdr.type = RXD_ACK;
 	ack->base_hdr.peer = rxd_ep->peers[peer].peer_addr;
 	ack->base_hdr.seq_no = rxd_ep->peers[peer].rx_seq_no;
-	ack->ext_hdr.tx_id = rxd_ep->peers[peer].curr_tx_id;
-	ack->ext_hdr.rx_id = rxd_ep->peers[peer].curr_rx_id;
+	ack->ext_hdr.rx_id = rxd_ep->peers[peer].rx_window;
 	rxd_ep->peers[peer].last_tx_ack = ack->base_hdr.seq_no;
 
 	dlist_insert_tail(&pkt_entry->d_entry, &rxd_ep->ctrl_pkts);
@@ -1256,6 +1257,7 @@ static void rxd_init_peer(struct rxd_ep *ep, uint64_t rxd_addr)
 	ep->peers[rxd_addr].last_rx_ack = 0;
 	ep->peers[rxd_addr].last_tx_ack = 0;
 	ep->peers[rxd_addr].rx_window = rxd_env.max_unacked;
+	ep->peers[rxd_addr].tx_window = rxd_env.max_unacked;
 	ep->peers[rxd_addr].unacked_cnt = 0;
 	ep->peers[rxd_addr].retry_cnt = 0;
 	ep->peers[rxd_addr].active = 0;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -353,6 +353,7 @@ void rxd_init_data_pkt(struct rxd_ep *ep, struct rxd_x_entry *tx_entry,
 	data_pkt->base_hdr.type = (tx_entry->cq_entry.flags &
 				  (FI_READ | FI_REMOTE_READ)) ?
 				   RXD_DATA_READ : RXD_DATA;
+	data_pkt->base_hdr.flags = tx_entry->flags & RXD_TAG_HDR;
 
 	data_pkt->ext_hdr.rx_id = tx_entry->rx_id;
 	data_pkt->ext_hdr.tx_id = tx_entry->tx_id;
@@ -790,6 +791,24 @@ static void rxd_close_peer(struct rxd_ep *ep, struct rxd_peer *peer)
 	peer->active = 0;
 }
 
+static void rxd_cleanup_unexp_msg(struct rxd_ep *ep, struct dlist_entry *list)
+{
+	struct rxd_unexp_msg *unexp_msg;
+	struct rxd_pkt_entry *pkt_entry;
+
+	while (!dlist_empty(list)) {
+		dlist_pop_front(list, struct rxd_unexp_msg,
+				unexp_msg, entry);
+		while (!dlist_empty(&unexp_msg->pkt_list)) {
+			dlist_pop_front(&unexp_msg->pkt_list, struct rxd_pkt_entry,
+					pkt_entry, d_entry);
+			rxd_release_rx_pkt(ep, pkt_entry);
+		}
+		rxd_release_rx_pkt(ep, unexp_msg->pkt_entry);
+		free(unexp_msg);
+	}
+}
+
 static int rxd_ep_close(struct fid *fid)
 {
 	int ret;
@@ -819,17 +838,8 @@ static int rxd_ep_close(struct fid *fid)
 		rxd_release_rx_pkt(ep, pkt_entry);
 	}
 
-	while (!dlist_empty(&ep->unexp_list)) {
-		dlist_pop_front(&ep->unexp_list, struct rxd_pkt_entry,
-				pkt_entry, d_entry);
-		rxd_release_rx_pkt(ep, pkt_entry);
-	}
-
-	while (!dlist_empty(&ep->unexp_tag_list)) {
-		dlist_pop_front(&ep->unexp_tag_list, struct rxd_pkt_entry,
-				pkt_entry, d_entry);
-		rxd_release_rx_pkt(ep, pkt_entry);
-	}
+	rxd_cleanup_unexp_msg(ep, &ep->unexp_list);
+	rxd_cleanup_unexp_msg(ep, &ep->unexp_tag_list);
 
 	while (!dlist_empty(&ep->ctrl_pkts)) {
 		dlist_pop_front(&ep->ctrl_pkts, struct rxd_pkt_entry,
@@ -1111,7 +1121,7 @@ static void rxd_progress_pkt_list(struct rxd_ep *ep, struct rxd_peer *peer)
 				 MIN(ep->next_retry, peer->retry_cnt);
 }
 
-static void rxd_ep_progress(struct util_ep *util_ep)
+void rxd_ep_progress(struct util_ep *util_ep)
 {
 	struct rxd_peer *peer;
 	struct fi_cq_msg_entry cq_entry;
@@ -1187,7 +1197,7 @@ int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 	struct util_buf_attr entry_pool_attr = {
 		.size		= sizeof(struct rxd_x_entry),
 		.alignment	= RXD_BUF_POOL_ALIGNMENT,
-		.max_cnt	= 0,
+		.max_cnt	= (size_t) ((uint16_t) RXD_UNEXP_ID),
 		.indexing	= {
 			.used 		= 1,
 			.ordered	= 1,

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -42,6 +42,10 @@ struct rxd_env rxd_env = {
 	.max_unacked	= 128,
 };
 
+char *rxd_pkt_type_str[] = {
+	RXD_FOREACH_TYPE(OFI_STR)
+};
+
 static void rxd_init_env(void)
 {
 	fi_param_get_int(&rxd_prov, "spin_count", &rxd_env.spin_count);

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -216,7 +216,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	assert(iov_count <= RXD_IOV_LIMIT);
 	assert(!(rxd_flags & RXD_MULTI_RECV) || iov_count == 1);
-	assert(!(flags & FI_PEEK) || op == ofi_op_tagged);
+	assert(!(flags & FI_PEEK) || op == RXD_TAGGED);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
 
@@ -225,7 +225,7 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		goto out;
 	}
 
-	if (op == ofi_op_tagged) {
+	if (op == RXD_TAGGED) {
 		unexp_list = &rxd_ep->unexp_tag_list;
 		rx_list = &rxd_ep->rx_tag_list;
 	} else {
@@ -278,7 +278,7 @@ static ssize_t rxd_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count,
-				      msg->addr, 0, ~0, msg->context, ofi_op_msg,
+				      msg->addr, 0, ~0, msg->context, RXD_MSG,
 				      rxd_rx_flags(flags | ep->util_ep.rx_msg_flags),
 				      flags);
 }
@@ -295,7 +295,7 @@ static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *d
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, 0, ~0, context,
-				      ofi_op_msg, ep->rx_flags, 0);
+				      RXD_MSG, ep->rx_flags, 0);
 }
 
 static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -306,7 +306,7 @@ static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr,
-				      0, ~0, context, ofi_op_msg, ep->rx_flags, 0);
+				      0, ~0, context, RXD_MSG, ep->rx_flags, 0);
 }
 
 ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
@@ -395,7 +395,7 @@ static ssize_t rxd_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	return rxd_ep_generic_sendmsg(ep, msg->msg_iov, msg->iov_count,
 				   msg->addr, 0, msg->data, msg->context,
-				   ofi_op_msg, rxd_tx_flags(flags |
+				   RXD_MSG, rxd_tx_flags(flags |
 				   ep->util_ep.tx_msg_flags));
 
 }
@@ -408,7 +408,7 @@ static ssize_t rxd_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_sendmsg(ep, iov, count, dest_addr, 0,
-				      0, context, ofi_op_msg,
+				      0, context, RXD_MSG, 
 				      ep->tx_flags);
 }
 
@@ -424,7 +424,7 @@ static ssize_t rxd_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, 0,
-				      0, context, ofi_op_msg,
+				      0, context, RXD_MSG,
 				      ep->tx_flags);
 }
 
@@ -439,7 +439,7 @@ static ssize_t rxd_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_base = (void *) buf;
 	iov.iov_len = len;
 
-	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, 0, 0, ofi_op_msg,
+	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, 0, 0, RXD_MSG,
 				     RXD_NO_TX_COMP | RXD_INJECT);
 }
 
@@ -456,7 +456,7 @@ static ssize_t rxd_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t le
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, 0, data, context,
-				      ofi_op_msg, ep->tx_flags |
+				      RXD_MSG, ep->tx_flags |
 				      RXD_REMOTE_CQ_DATA);
 }
 
@@ -471,7 +471,7 @@ static ssize_t rxd_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t 
 	iov.iov_base = (void *) buf;
 	iov.iov_len = len;
 
-	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, 0, data, ofi_op_msg,
+	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, 0, data, RXD_MSG,
 				     RXD_NO_TX_COMP | RXD_INJECT |
 				     RXD_REMOTE_CQ_DATA);
 }

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -120,7 +120,6 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	assert(!(rxd_flags & RXD_MULTI_RECV) || iov_count == 1);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.rx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.rx_cq->cirq)) {
 		ret = -FI_EAGAIN;
@@ -151,7 +150,6 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	dlist_insert_tail(&rx_entry->entry, rx_list);
 out:
-	fastlock_release(&rxd_ep->util_ep.rx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }
@@ -207,7 +205,6 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	       rxd_ep_domain(rxd_ep)->max_inline_msg);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -227,7 +224,6 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }
@@ -248,7 +244,6 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 					     op, rxd_flags);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -268,7 +263,6 @@ ssize_t rxd_ep_generic_sendmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -180,7 +180,7 @@ static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *d
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, 0, ~0, context,
-				      ofi_op_msg, rxd_ep_rx_flags(ep));
+				      ofi_op_msg, ep->rx_flags);
 }
 
 static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -191,7 +191,7 @@ static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr,
-				      0, ~0, context, ofi_op_msg, rxd_ep_rx_flags(ep));
+				      0, ~0, context, ofi_op_msg, ep->rx_flags);
 }
 
 ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
@@ -296,7 +296,7 @@ static ssize_t rxd_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void
 
 	return rxd_ep_generic_sendmsg(ep, iov, count, dest_addr, 0,
 				      0, context, ofi_op_msg,
-				      rxd_ep_tx_flags(ep));
+				      ep->tx_flags);
 }
 
 static ssize_t rxd_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -312,7 +312,7 @@ static ssize_t rxd_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, 0,
 				      0, context, ofi_op_msg,
-				      rxd_ep_tx_flags(ep));
+				      ep->tx_flags);
 }
 
 static ssize_t rxd_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -343,7 +343,7 @@ static ssize_t rxd_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t le
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, 0, data, context,
-				      ofi_op_msg, rxd_ep_tx_flags(ep) |
+				      ofi_op_msg, ep->tx_flags |
 				      RXD_REMOTE_CQ_DATA);
 }
 

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -38,68 +38,86 @@
 
 static int rxd_match_unexp(struct dlist_entry *item, const void *arg)
 {
-	struct rxd_x_entry *rx_entry = (struct rxd_x_entry *) arg;
-	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_base_hdr *hdr;
+	struct rxd_match_attr *attr = (struct rxd_match_attr *) arg;
+	struct rxd_unexp_msg *unexp_msg;
 
-	pkt_entry = container_of(item, struct rxd_pkt_entry, d_entry);
-	hdr = rxd_get_base_hdr(pkt_entry);
+	unexp_msg = container_of(item, struct rxd_unexp_msg, entry);
 
-	if (!rxd_match_addr(rx_entry->peer, hdr->peer))
+	if (!rxd_match_addr(attr->peer, unexp_msg->base_hdr->peer))
 		return 0;
 
-	if (hdr->type != RXD_TAGGED)
+	if (!unexp_msg->tag_hdr)
 		return 1;
 
-	return rxd_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore,
-			     rxd_get_tag_hdr(pkt_entry)->tag);
+	return rxd_match_tag(attr->tag, attr->ignore,
+			     unexp_msg->tag_hdr->tag);
 }
 
-static int rxd_ep_check_unexp_msg_list(struct rxd_ep *ep,
-					struct dlist_entry *unexp_list,
-					struct dlist_entry *rx_list,
-					struct rxd_x_entry *rx_entry)
+static struct rxd_unexp_msg *rxd_ep_check_unexp_list(struct dlist_entry *list,
+				fi_addr_t addr, uint64_t tag, uint64_t ignore)
 {
+	struct rxd_match_attr attr;
 	struct dlist_entry *match;
-	struct rxd_x_entry *progress_entry, *dup_entry = NULL;
+
+	attr.peer = addr;
+	attr.tag = tag;
+	attr.ignore = ignore;
+
+	match = dlist_find_first_match(list, &rxd_match_unexp, &attr);
+	if (!match)
+		return NULL;
+
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Matched to unexp msg entry\n");
+
+	return container_of(match, struct rxd_unexp_msg, entry);
+}
+
+static void rxd_progress_unexp_msg(struct rxd_ep *ep, struct rxd_x_entry *rx_entry,
+				   struct rxd_unexp_msg *unexp_msg)
+{
 	struct rxd_pkt_entry *pkt_entry;
-	struct rxd_base_hdr *base_hdr;
-	struct rxd_sar_hdr *sar_hdr = NULL;
-	struct rxd_tag_hdr *tag_hdr = NULL;
-	struct rxd_data_hdr *data_hdr = NULL;
-	struct rxd_atom_hdr *atom_hdr = NULL;
-	struct rxd_rma_hdr *rma_hdr = NULL;
-	void *msg = NULL;
-	size_t msg_size, total_size;
+
+	rxd_progress_op(ep, rx_entry, unexp_msg->pkt_entry, unexp_msg->base_hdr,
+			unexp_msg->sar_hdr, unexp_msg->tag_hdr,
+			unexp_msg->data_hdr, NULL, NULL, &unexp_msg->msg,
+			unexp_msg->msg_size);
+
+	while (!dlist_empty(&unexp_msg->pkt_list)) {
+		dlist_pop_front(&unexp_msg->pkt_list, struct rxd_pkt_entry,
+				pkt_entry, d_entry);
+		rxd_ep_recv_data(ep, rx_entry, (struct rxd_data_pkt *)
+				 (pkt_entry->pkt), pkt_entry->pkt_size);
+		rxd_release_repost_rx(ep, pkt_entry);
+	}
+	rxd_release_repost_rx(ep, unexp_msg->pkt_entry);
+	dlist_remove(&unexp_msg->entry);
+	free(unexp_msg);
+}
+
+static int rxd_progress_unexp_list(struct rxd_ep *ep,
+				   struct dlist_entry *unexp_list,
+				   struct dlist_entry *rx_list,
+				   struct rxd_x_entry *rx_entry)
+{
+	struct rxd_x_entry *progress_entry, *dup_entry = NULL;
+	struct rxd_unexp_msg *unexp_msg;
+	size_t total_size;
 
 	while (!dlist_empty(unexp_list)) {
-		match = dlist_remove_first_match(unexp_list, &rxd_match_unexp,
-						 (void *) rx_entry);
-		if (!match)
+		unexp_msg = rxd_ep_check_unexp_list(unexp_list, rx_entry->peer,
+					rx_entry->cq_entry.tag, rx_entry->ignore);
+		if (!unexp_msg)
 			return 0;
 
-		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "progressing unexp msg entry\n");
-	
-		pkt_entry = container_of(match, struct rxd_pkt_entry, d_entry);
-		base_hdr = rxd_get_base_hdr(pkt_entry);
+		total_size = unexp_msg->sar_hdr ? unexp_msg->sar_hdr->size :
+			     unexp_msg->msg_size;
 
-		rxd_unpack_hdrs(pkt_entry->pkt_size - ep->rx_prefix_size,
-				base_hdr, &sar_hdr, &tag_hdr,
-				&data_hdr, &rma_hdr, &atom_hdr, &msg, &msg_size);
-
-		total_size = sar_hdr ? sar_hdr->size : msg_size;
 		if (rx_entry->flags & RXD_MULTI_RECV)
 			dup_entry = rxd_progress_multi_recv(ep, rx_entry, total_size);
 
 		progress_entry = dup_entry ? dup_entry : rx_entry;
-	
 		progress_entry->cq_entry.len = MIN(rx_entry->cq_entry.len, total_size);
-
-		rxd_progress_op(ep, progress_entry, pkt_entry, base_hdr, sar_hdr, tag_hdr,
-				data_hdr, rma_hdr, atom_hdr, &msg, msg_size);
-		rxd_release_repost_rx(ep, pkt_entry);
-		rxd_ep_send_ack(ep, base_hdr->peer);
-
+		rxd_progress_unexp_msg(ep, progress_entry, unexp_msg);
 		if (!dup_entry)
 			return 1;
 	}
@@ -107,31 +125,91 @@ static int rxd_ep_check_unexp_msg_list(struct rxd_ep *ep,
 	return 0;
 }
 
+static int rxd_ep_discard_recv(struct rxd_ep *rxd_ep, void *context,
+			       struct rxd_unexp_msg *unexp_msg)
+{
+	struct rxd_pkt_entry *pkt_entry;
+	uint64_t seq = unexp_msg->base_hdr->seq_no;
+	int ret;
+
+	assert(unexp_msg->tag_hdr);
+	seq += unexp_msg->sar_hdr ? unexp_msg->sar_hdr->num_segs : 1;
+
+	rxd_ep->peers[unexp_msg->base_hdr->peer].rx_seq_no =
+			MAX(seq, rxd_ep->peers[unexp_msg->base_hdr->peer].rx_seq_no);
+	rxd_ep_send_ack(rxd_ep, unexp_msg->base_hdr->peer);
+
+	ret = ofi_cq_write(rxd_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
+			   0, NULL, unexp_msg->data_hdr ?
+			   unexp_msg->data_hdr->cq_data : 0,
+			   unexp_msg->tag_hdr->tag);
+
+	while (!dlist_empty(&unexp_msg->pkt_list)) {
+		dlist_pop_front(&unexp_msg->pkt_list, struct rxd_pkt_entry,
+				pkt_entry, d_entry);
+		rxd_release_repost_rx(rxd_ep, pkt_entry);
+	}
+
+	rxd_release_repost_rx(rxd_ep, unexp_msg->pkt_entry);
+
+	dlist_remove(&unexp_msg->entry);
+	free(unexp_msg);
+
+	return ret;
+}
+
+static int rxd_peek_recv(struct rxd_ep *rxd_ep, fi_addr_t addr, uint64_t tag,
+			 uint64_t ignore, void *context, uint64_t flags,
+			 struct dlist_entry *unexp_list)
+{
+	struct rxd_unexp_msg *unexp_msg;
+
+	fastlock_release(&rxd_ep->util_ep.lock);
+	rxd_ep_progress(&rxd_ep->util_ep);
+	fastlock_acquire(&rxd_ep->util_ep.lock);
+
+	unexp_msg = rxd_ep_check_unexp_list(unexp_list, addr, tag, ignore);
+	if (!unexp_msg) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Message not found\n");
+		return ofi_cq_write_error_peek(rxd_ep->util_ep.rx_cq, tag,
+					       context);
+	}
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Message found\n");
+
+	assert(unexp_msg->tag_hdr);
+	if (flags & FI_DISCARD)
+		return rxd_ep_discard_recv(rxd_ep, context, unexp_msg);
+
+	if (flags & FI_CLAIM) {
+		FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Marking message for CLAIM\n");
+		((struct fi_context *)context)->internal[0] = unexp_msg;
+		dlist_remove(&unexp_msg->entry);
+	}
+
+	return ofi_cq_write(rxd_ep->util_ep.rx_cq, context, FI_TAGGED | FI_RECV,
+			    unexp_msg->sar_hdr ? unexp_msg->sar_hdr->size :
+			    unexp_msg->msg_size, NULL, unexp_msg->data_hdr ?
+			    unexp_msg->data_hdr->cq_data : 0,
+			    unexp_msg->tag_hdr->tag);
+}
+
 ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 			       size_t iov_count, fi_addr_t addr, uint64_t tag,
 			       uint64_t ignore, void *context, uint32_t op,
-			       uint32_t rxd_flags)
+			       uint32_t rxd_flags, uint64_t flags)
 {
 	ssize_t ret = 0;
 	struct rxd_x_entry *rx_entry;
 	struct dlist_entry *unexp_list, *rx_list;
+	struct rxd_unexp_msg *unexp_msg;
 
 	assert(iov_count <= RXD_IOV_LIMIT);
 	assert(!(rxd_flags & RXD_MULTI_RECV) || iov_count == 1);
+	assert(!(flags & FI_PEEK) || op == ofi_op_tagged);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.rx_cq->cirq)) {
-		ret = -FI_EAGAIN;
-		goto out;
-	}
-
-	rx_entry = rxd_rx_entry_init(rxd_ep, iov, iov_count, tag, ignore, context,
-				(rxd_ep->util_ep.caps & FI_DIRECTED_RECV &&
-				addr != FI_ADDR_UNSPEC) ?
-				rxd_ep_av(rxd_ep)->fi_addr_table[addr] :
-				FI_ADDR_UNSPEC, op, rxd_flags);
-	if (!rx_entry) {
 		ret = -FI_EAGAIN;
 		goto out;
 	}
@@ -144,11 +222,38 @@ ssize_t rxd_ep_generic_recvmsg(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		rx_list = &rxd_ep->rx_list;
 	}
 
-	if (!dlist_empty(unexp_list) &&
-	    rxd_ep_check_unexp_msg_list(rxd_ep, unexp_list, rx_list, rx_entry))
+	if (flags & FI_PEEK) {
+		ret = rxd_peek_recv(rxd_ep, addr, tag, ignore, context, flags,
+				    unexp_list);
 		goto out;
+	}
 
-	dlist_insert_tail(&rx_entry->entry, rx_list);
+	if (!(flags & FI_DISCARD)) {
+		rx_entry = rxd_rx_entry_init(rxd_ep, iov, iov_count, tag, ignore, context,
+					(rxd_ep->util_ep.caps & FI_DIRECTED_RECV &&
+					addr != FI_ADDR_UNSPEC) ?
+					rxd_ep_av(rxd_ep)->fi_addr_table[addr] :
+					FI_ADDR_UNSPEC, op, rxd_flags);
+		if (!rx_entry) {
+			ret = -FI_EAGAIN;
+		} else if (flags & FI_CLAIM) {
+			FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Claiming message\n");
+			unexp_msg = (struct rxd_unexp_msg *)
+				(((struct fi_context *) context)->internal[0]);
+			rxd_progress_unexp_msg(rxd_ep, rx_entry, unexp_msg);
+		} else if (!rxd_progress_unexp_list(rxd_ep, unexp_list,
+			   rx_list, rx_entry)) {
+			dlist_insert_tail(&rx_entry->entry, rx_list);
+		}
+		goto out;
+	}
+
+	assert(flags & FI_CLAIM);
+	FI_DBG(&rxd_prov, FI_LOG_EP_CTRL, "Discarding message\n");
+	unexp_msg = (struct rxd_unexp_msg *)
+			(((struct fi_context *) context)->internal[0]);
+	ret = rxd_ep_discard_recv(rxd_ep, context, unexp_msg);
+
 out:
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
@@ -163,7 +268,8 @@ static ssize_t rxd_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count,
 				      msg->addr, 0, ~0, msg->context, ofi_op_msg,
-				      rxd_rx_flags(flags | ep->util_ep.rx_msg_flags));
+				      rxd_rx_flags(flags | ep->util_ep.rx_msg_flags),
+				      flags);
 }
 
 static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
@@ -178,7 +284,7 @@ static ssize_t rxd_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len, void *d
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, 0, ~0, context,
-				      ofi_op_msg, ep->rx_flags);
+				      ofi_op_msg, ep->rx_flags, 0);
 }
 
 static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -189,7 +295,7 @@ static ssize_t rxd_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr,
-				      0, ~0, context, ofi_op_msg, ep->rx_flags);
+				      0, ~0, context, ofi_op_msg, ep->rx_flags, 0);
 }
 
 ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,

--- a/prov/rxd/src/rxd_msg.c
+++ b/prov/rxd/src/rxd_msg.c
@@ -216,8 +216,10 @@ ssize_t rxd_ep_generic_inject(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	tx_entry = rxd_tx_entry_init(rxd_ep, iov, iov_count, NULL, 0, 0, data,
 				     tag, NULL, rxd_addr, op, rxd_flags | RXD_INJECT);
-	if (!tx_entry)
+	if (!tx_entry) {
+		ret = -FI_EAGAIN;
 		goto out;
+	}
 
 	ret = rxd_ep_send_op(rxd_ep, tx_entry, NULL, 0, NULL, 0, 0, 0);
 	if (ret)

--- a/prov/rxd/src/rxd_proto.h
+++ b/prov/rxd/src/rxd_proto.h
@@ -43,20 +43,27 @@
 #define RXD_IOV_LIMIT		4
 #define RXD_NAME_LENGTH		64
 
+/* Values below are part of the wire protocol
+   Reserved values are unused but defined for compatibility */
+#define RXD_FOREACH_TYPE(FUNC)		\
+	FUNC(RXD_MSG),			\
+	FUNC(RXD_TAGGED),		\
+	FUNC(RXD_READ_REQ),		\
+	FUNC(RXD_RESV_1),		\
+	FUNC(RXD_WRITE),		\
+	FUNC(RXD_RESV_2),		\
+	FUNC(RXD_ATOMIC),		\
+	FUNC(RXD_ATOMIC_FETCH),		\
+	FUNC(RXD_ATOMIC_COMPARE),	\
+	FUNC(RXD_RTS),			\
+	FUNC(RXD_CTS),			\
+	FUNC(RXD_ACK),			\
+	FUNC(RXD_DATA),			\
+	FUNC(RXD_DATA_READ),		\
+	FUNC(RXD_NO_OP)
+
 enum rxd_pkt_type {
-	RXD_MSG			= ofi_op_msg,
-	RXD_TAGGED		= ofi_op_tagged,
-	RXD_READ_REQ		= ofi_op_read_req,
-	RXD_WRITE		= ofi_op_write,
-	RXD_ATOMIC		= ofi_op_atomic,
-	RXD_ATOMIC_FETCH	= ofi_op_atomic_fetch,
-	RXD_ATOMIC_COMPARE	= ofi_op_atomic_compare,
-	RXD_RTS,
-	RXD_CTS,
-	RXD_ACK,
-	RXD_DATA,
-	RXD_DATA_READ,
-	RXD_NO_OP,
+	RXD_FOREACH_TYPE(OFI_ENUM_VAL)
 };
 
 /* Base header: all packets must start with base_hdr

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -140,7 +140,7 @@ ssize_t rxd_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
-			       src_addr, context, ofi_op_read_req, 0,
+			       src_addr, context, RXD_READ_REQ, 0,
 			       ep->tx_flags);
 }
 
@@ -158,7 +158,7 @@ ssize_t rxd_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, iov, count, &rma_iov, 1, desc,
-			       src_addr, context, ofi_op_read_req, 0,
+			       src_addr, context, RXD_READ_REQ, 0,
 			       ep->tx_flags);
 }
 
@@ -172,7 +172,7 @@ ssize_t rxd_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	return rxd_generic_rma(ep, msg->msg_iov, msg->iov_count,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
-			       ofi_op_read_req, msg->data, rxd_tx_flags(flags |
+			       RXD_READ_REQ, msg->data, rxd_tx_flags(flags |
 			       ep->util_ep.tx_msg_flags));
 }
 
@@ -192,7 +192,7 @@ ssize_t rxd_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
-			       dest_addr, context, ofi_op_write, 0,
+			       dest_addr, context, RXD_WRITE, 0,
 			       ep->tx_flags);
 }
 
@@ -210,7 +210,7 @@ ssize_t rxd_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, iov, count, &rma_iov, 1, desc,
-			       dest_addr, context, ofi_op_write, 0,
+			       dest_addr, context, RXD_WRITE, 0,
 			       ep->tx_flags);
 }
 
@@ -225,7 +225,7 @@ ssize_t rxd_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	return rxd_generic_rma(ep, msg->msg_iov, msg->iov_count,
 			       msg->rma_iov, msg->rma_iov_count,
 			       msg->desc, msg->addr, msg->context,
-			       ofi_op_write, msg->data, rxd_tx_flags(flags |
+			       RXD_WRITE, msg->data, rxd_tx_flags(flags |
 			       ep->util_ep.tx_msg_flags));
 }
 
@@ -246,7 +246,7 @@ ssize_t rxd_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	rma_iov.key = key;
 
 	return rxd_generic_rma(ep, &iov, 1, &rma_iov, 1, &desc,
-			       dest_addr, context, ofi_op_write, data,
+			       dest_addr, context, RXD_WRITE, data,
 			       ep->tx_flags | RXD_REMOTE_CQ_DATA);
 }
 
@@ -266,7 +266,7 @@ ssize_t rxd_inject_write(struct fid_ep *ep_fid, const void *buf,
 	rma_iov.key = key;
 
 	return rxd_generic_write_inject(rxd_ep, &iov, 1, &rma_iov, 1,
-					dest_addr, NULL, ofi_op_write, 0,
+					dest_addr, NULL, RXD_WRITE, 0,
 					RXD_NO_TX_COMP | RXD_INJECT);
 }
 
@@ -287,7 +287,7 @@ ssize_t rxd_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	rma_iov.key = key;
 
 	return rxd_generic_write_inject(rxd_ep, &iov, 1, &rma_iov, 1,
-					dest_addr, NULL, ofi_op_write,
+					dest_addr, NULL, RXD_WRITE,
 					data, RXD_NO_TX_COMP | RXD_INJECT |
 					RXD_REMOTE_CQ_DATA);
 }

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -50,7 +50,6 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	assert(ofi_total_iov_len(iov, iov_count) <= rxd_ep_domain(rxd_ep)->max_inline_rma);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -79,7 +78,6 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 	ret = 0;
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }
@@ -101,7 +99,6 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	assert(iov_count <= RXD_IOV_LIMIT && rma_count <= RXD_IOV_LIMIT);
 
 	fastlock_acquire(&rxd_ep->util_ep.lock);
-	fastlock_acquire(&rxd_ep->util_ep.tx_cq->cq_lock);
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
@@ -123,7 +120,6 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		rxd_tx_entry_free(rxd_ep, tx_entry);
 
 out:
-	fastlock_release(&rxd_ep->util_ep.tx_cq->cq_lock);
 	fastlock_release(&rxd_ep->util_ep.lock);
 	return ret;
 }

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -145,7 +145,7 @@ ssize_t rxd_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
 			       src_addr, context, ofi_op_read_req, 0,
-			       rxd_ep_tx_flags(ep));
+			       ep->tx_flags);
 }
 
 ssize_t rxd_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -163,7 +163,7 @@ ssize_t rxd_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	return rxd_generic_rma(ep, iov, count, &rma_iov, 1, desc,
 			       src_addr, context, ofi_op_read_req, 0,
-			       rxd_ep_tx_flags(ep));
+			       ep->tx_flags);
 }
 
 ssize_t rxd_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
@@ -197,7 +197,7 @@ ssize_t rxd_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc
 
 	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
 			       dest_addr, context, ofi_op_write, 0,
-			       rxd_ep_tx_flags(ep));
+			       ep->tx_flags);
 }
 
 ssize_t rxd_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -215,7 +215,7 @@ ssize_t rxd_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 
 	return rxd_generic_rma(ep, iov, count, &rma_iov, 1, desc,
 			       dest_addr, context, ofi_op_write, 0,
-			       rxd_ep_tx_flags(ep));
+			       ep->tx_flags);
 }
 
 
@@ -251,7 +251,7 @@ ssize_t rxd_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	return rxd_generic_rma(ep, &iov, 1, &rma_iov, 1, &desc,
 			       dest_addr, context, ofi_op_write, data,
-			       rxd_ep_tx_flags(ep) | RXD_REMOTE_CQ_DATA);
+			       ep->tx_flags | RXD_REMOTE_CQ_DATA);
 }
 
 ssize_t rxd_inject_write(struct fid_ep *ep_fid, const void *buf,

--- a/prov/rxd/src/rxd_tagged.c
+++ b/prov/rxd/src/rxd_tagged.c
@@ -48,7 +48,7 @@ ssize_t rxd_ep_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, tag, ignore,
-				      context, ofi_op_tagged,
+				      context, RXD_TAGGED,
 				      ep->rx_flags | RXD_TAG_HDR, 0);
 }
 
@@ -61,7 +61,7 @@ ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **des
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr, tag, ignore,
-				      context, ofi_op_tagged,
+				      context, RXD_TAGGED,
 				      ep->rx_flags | RXD_TAG_HDR, 0);
 }
 
@@ -74,7 +74,7 @@ ssize_t rxd_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count, msg->addr,
 				      msg->tag, msg->ignore, msg->context,
-				      ofi_op_tagged, rxd_rx_flags(flags |
+				      RXD_TAGGED, rxd_rx_flags(flags |
 				      ep->util_ep.rx_msg_flags) | RXD_TAG_HDR, flags);
 }
 
@@ -90,7 +90,7 @@ ssize_t rxd_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 	msg_iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &msg_iov, 1, dest_addr, tag,
-				      0, context, ofi_op_tagged,
+				      0, context, RXD_TAGGED,
 				      ep->tx_flags | RXD_TAG_HDR);
 }
 
@@ -103,7 +103,7 @@ ssize_t rxd_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
 	ep = container_of(ep_fid, struct rxd_ep, util_ep.ep_fid.fid);
 
 	return rxd_ep_generic_sendmsg(ep, iov, count, dest_addr, tag,
-				      0, context, ofi_op_tagged,
+				      0, context, RXD_TAGGED,
 				      ep->tx_flags | RXD_TAG_HDR);
 }
 
@@ -116,7 +116,7 @@ ssize_t rxd_ep_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	return rxd_ep_generic_sendmsg(ep, msg->msg_iov, msg->iov_count,
 				      msg->addr, msg->tag, msg->data, msg->context,
-				      ofi_op_tagged, rxd_tx_flags(flags |
+				      RXD_TAGGED, rxd_tx_flags(flags |
 				      ep->util_ep.tx_msg_flags) | RXD_TAG_HDR);
 }
 
@@ -132,7 +132,7 @@ ssize_t rxd_ep_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, tag, 0,
-				     ofi_op_tagged, RXD_NO_TX_COMP | RXD_INJECT |
+				     RXD_TAGGED, RXD_NO_TX_COMP | RXD_INJECT |
 				     RXD_TAG_HDR);
 }
 
@@ -149,7 +149,7 @@ ssize_t rxd_ep_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, tag, data, context,
-				      ofi_op_tagged, ep->tx_flags |
+				      RXD_TAGGED, ep->tx_flags |
 				      RXD_REMOTE_CQ_DATA | RXD_TAG_HDR);
 }
 
@@ -164,7 +164,7 @@ ssize_t rxd_ep_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_base = (void *) buf;
 	iov.iov_len = len;
 
-	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, tag, data, ofi_op_tagged,
+	return rxd_ep_generic_inject(ep, &iov, 1, dest_addr, tag, data, RXD_TAGGED,
 				     RXD_NO_TX_COMP | RXD_INJECT |
 				     RXD_REMOTE_CQ_DATA | RXD_TAG_HDR);
 }

--- a/prov/rxd/src/rxd_tagged.c
+++ b/prov/rxd/src/rxd_tagged.c
@@ -49,7 +49,7 @@ ssize_t rxd_ep_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, tag, ignore,
 				      context, ofi_op_tagged,
-				      ep->rx_flags | RXD_TAG_HDR);
+				      ep->rx_flags | RXD_TAG_HDR, 0);
 }
 
 ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -62,7 +62,7 @@ ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **des
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr, tag, ignore,
 				      context, ofi_op_tagged,
-				      ep->rx_flags | RXD_TAG_HDR);
+				      ep->rx_flags | RXD_TAG_HDR, 0);
 }
 
 ssize_t rxd_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
@@ -75,7 +75,7 @@ ssize_t rxd_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 	return rxd_ep_generic_recvmsg(ep, msg->msg_iov, msg->iov_count, msg->addr,
 				      msg->tag, msg->ignore, msg->context,
 				      ofi_op_tagged, rxd_rx_flags(flags |
-				      ep->util_ep.rx_msg_flags) | RXD_TAG_HDR);
+				      ep->util_ep.rx_msg_flags) | RXD_TAG_HDR, flags);
 }
 
 ssize_t rxd_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,

--- a/prov/rxd/src/rxd_tagged.c
+++ b/prov/rxd/src/rxd_tagged.c
@@ -49,7 +49,7 @@ ssize_t rxd_ep_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 
 	return rxd_ep_generic_recvmsg(ep, &msg_iov, 1, src_addr, tag, ignore,
 				      context, ofi_op_tagged,
-				      rxd_ep_tx_flags(ep) | RXD_TAG_HDR);
+				      ep->rx_flags | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
@@ -62,7 +62,7 @@ ssize_t rxd_ep_trecvv(struct fid_ep *ep_fid, const struct iovec *iov, void **des
 
 	return rxd_ep_generic_recvmsg(ep, iov, count, src_addr, tag, ignore,
 				      context, ofi_op_tagged,
-				      rxd_ep_tx_flags(ep) | RXD_TAG_HDR);
+				      ep->rx_flags | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
@@ -91,7 +91,7 @@ ssize_t rxd_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	return rxd_ep_generic_sendmsg(ep, &msg_iov, 1, dest_addr, tag,
 				      0, context, ofi_op_tagged,
-				      rxd_ep_tx_flags(ep) | RXD_TAG_HDR);
+				      ep->tx_flags | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
@@ -104,7 +104,7 @@ ssize_t rxd_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	return rxd_ep_generic_sendmsg(ep, iov, count, dest_addr, tag,
 				      0, context, ofi_op_tagged,
-				      rxd_ep_tx_flags(ep) | RXD_TAG_HDR);
+				      ep->tx_flags | RXD_TAG_HDR);
 }
 
 ssize_t rxd_ep_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
@@ -149,7 +149,7 @@ ssize_t rxd_ep_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	return rxd_ep_generic_sendmsg(ep, &iov, 1, dest_addr, tag, data, context,
-				      ofi_op_tagged, rxd_ep_tx_flags(ep) |
+				      ofi_op_tagged, ep->tx_flags |
 				      RXD_REMOTE_CQ_DATA | RXD_TAG_HDR);
 }
 


### PR DESCRIPTION
Most fixes have to do with fixing the unexpected message buffering.
All of these together allow rxd to run properly with Intel MPI
