### PR TITLE
[v1.7.x] verbs, fi_tostr: cherry-picked FI_ADDR_IB_UD fixes

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -985,7 +985,6 @@ static int fi_ibv_set_info_addrs(struct fi_info *info,
 			if (ret)
 				return ret;
 		} else {
-			iter_info->addr_format = fmt;
 			if (src_addr) {
 				ret = fi_ibv_fill_addr_by_ep_name(src_addr, fmt,
 								  &iter_info->src_addr,
@@ -1000,6 +999,7 @@ static int fi_ibv_set_info_addrs(struct fi_info *info,
 				if (ret)
 					return ret;
 			}
+			iter_info->addr_format = FI_ADDR_IB_UD;
 		}
 	}
 

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -116,6 +116,7 @@ static void oofi_tostr_addr_format(char *buf, uint32_t addr_format)
 	CASEENUMSTR(FI_ADDR_BGQ);
 	CASEENUMSTR(FI_ADDR_MLX);
 	CASEENUMSTR(FI_ADDR_STR);
+	CASEENUMSTR(FI_ADDR_IB_UD);
 	default:
 		if (addr_format & FI_PROV_SPECIFIC)
 			ofi_strcatf(buf, "Provider specific");


### PR DESCRIPTION
- set addr format correctly for verbs UD
- add FI_ADDR_IB_UD format string