### PR TITLE
fabtests/test_configs/udp.exclude: move tagged_peek exclusion from UDP to OSX

### DIFF
--- a/fabtests/test_configs/osx.exclude
+++ b/fabtests/test_configs/osx.exclude
@@ -6,3 +6,4 @@ msg_epoll
 # Does not work with utility providers because of epoll limitations
 rdm_cntr_pingpong
 unexpected_msg
+rdm_tagged_peek

--- a/fabtests/test_configs/udp/udp.exclude
+++ b/fabtests/test_configs/udp/udp.exclude
@@ -10,7 +10,6 @@ inj_complete -e dgram
 cm_data
 
 # Not supported by ofi_rxd provider
-rdm_tagged_peek
 scalable_ep
 shared_ctx
 shared_av


### PR DESCRIPTION
Move rdm_tagged_peek exclusion from UDP (now supported by RxD) to OSX exclusion (not supported)