### PR TITLE
ofi: warning squashes (backport to v1.7.x)

### DIFF
--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -267,20 +267,20 @@ fi_poll_open(struct fid_domain *domain, struct fi_poll_attr *attr,
 
 static inline int
 fi_mr_reg(struct fid_domain *domain, const void *buf, size_t len,
-	  uint64_t access, uint64_t offset, uint64_t requested_key,
+	  uint64_t acs, uint64_t offset, uint64_t requested_key,
 	  uint64_t flags, struct fid_mr **mr, void *context)
 {
-	return domain->mr->reg(&domain->fid, buf, len, access, offset,
+	return domain->mr->reg(&domain->fid, buf, len, acs, offset,
 			       requested_key, flags, mr, context);
 }
 
 static inline int
 fi_mr_regv(struct fid_domain *domain, const struct iovec *iov,
-			size_t count, uint64_t access,
+			size_t count, uint64_t acs,
 			uint64_t offset, uint64_t requested_key,
 			uint64_t flags, struct fid_mr **mr, void *context)
 {
-	return domain->mr->regv(&domain->fid, iov, count, access,
+	return domain->mr->regv(&domain->fid, iov, count, acs,
 			offset, requested_key, flags, mr, context);
 }
 

--- a/include/rdma/fi_endpoint.h
+++ b/include/rdma/fi_endpoint.h
@@ -223,17 +223,17 @@ static inline int fi_ep_alias(struct fid_ep *ep, struct fid_ep **alias_ep,
 }
 
 static inline int
-fi_tx_context(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
+fi_tx_context(struct fid_ep *ep, int idx, struct fi_tx_attr *attr,
 	      struct fid_ep **tx_ep, void *context)
 {
-	return ep->ops->tx_ctx(ep, index, attr, tx_ep, context);
+	return ep->ops->tx_ctx(ep, idx, attr, tx_ep, context);
 }
 
 static inline int
-fi_rx_context(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
+fi_rx_context(struct fid_ep *ep, int idx, struct fi_rx_attr *attr,
 	      struct fid_ep **rx_ep, void *context)
 {
-	return ep->ops->rx_ctx(ep, index, attr, rx_ep, context);
+	return ep->ops->rx_ctx(ep, idx, attr, rx_ep, context);
 }
 
 static inline FI_DEPRECATED_FUNC ssize_t

--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -323,7 +323,7 @@ static int pp_ctrl_init_client(struct ct_pingpong *ct)
 	struct sockaddr_in in_addr = {0};
 	struct addrinfo *results;
 	struct addrinfo *rp;
-	int errno_save;
+	int errno_save = 0;
 	int ret;
 
 	ret = pp_getaddrinfo(ct->opts.dst_addr, ct->opts.dst_port, &results);


### PR DESCRIPTION
These warnings show up because of two reasons: (1) variable names
shadow existing global symbols or (2) some variables are
uninitialized.