### PR TITLE
[v1.7.x] prov/gni: Only generate FI_EADDRNOTAVAIL if FI_SOURCE_ERR specified

### DIFF
--- a/man/fi_gni.7.md
+++ b/man/fi_gni.7.md
@@ -323,7 +323,8 @@ The GNI provider sets the domain attribute *cq_cnt* to the CQ limit divided by 2
 The GNI provider sets the domain attribute *ep_cnt* to SIZE_MAX.
 
 Completion queue events may report unknown source address information when
-using *FI_SOURCE*. The source address information will be reported in the
+using *FI_SOURCE*. If *FI_SOURCE_ERR* is also specified, the source address
+information will be reported in the
 err_data member of the struct fi_cq_err_entry populated by fi_cq_readerr. The
 err_data member will contain the source address information in the FI_ADDR_GNI
 address format. In order to populate the remote peer's address vector

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -405,7 +405,8 @@ static int __recv_completion_src(
 	GNIX_DBG_TRACE(FI_LOG_TRACE, "\n");
 
 	if ((req->msg.recv_flags & FI_COMPLETION) && ep->recv_cq) {
-		if (src_addr == FI_ADDR_NOTAVAIL) {
+		if (src_addr == FI_ADDR_NOTAVAIL &&
+                    (req->msg.recv_flags & FI_SOURCE_ERR) != 0) {
 			buffer = malloc(GNIX_CQ_MAX_ERR_DATA_SIZE);
 			memcpy(buffer, req->vc->gnix_ep_name,
 				sizeof(struct gnix_ep_name));


### PR DESCRIPTION
When FI_SOURCE is specified, the gni provider issues a FI_EAVAIL
error with -FI_EADDRNOTAVAIL error code whenever the initiator's
address is unknown, even though FI_SOURCE_ERR is not specified.
Change this to only issue the erro when FI_SOURCE_ERR is specified.

fixes #4922
related to #4993

Signed-off-by: Kevan Rehm <krehm@cray.com>
(cherry picked from commit 0b8cabe632a3eb6db6412c4c01923fd74b7746bc)