### PR TITLE
[v1.7.x] prov/gni: fix a problem with not truncat

### DIFF
--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2019 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -3092,7 +3093,7 @@ DIRECT_FN STATIC int gnix_ep_setopt(fid_t fid, int level, int optname,
 		if (optlen != sizeof(size_t))
 			return -FI_EINVAL;
 		/*
-		 * see issue 1120
+		 * see https://github.com/ofi-cray/libfabric-cray/issues/1120
 		 */
 		if (*(size_t *)optval == 0UL)
 			return -FI_EINVAL;

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -268,7 +268,7 @@ static void __gnix_msg_copy_data_to_recv_addr(struct gnix_fab_req *req,
 	switch(req->type) {
 	case GNIX_FAB_RQ_RECV:
 		memcpy((void *)req->msg.recv_info[0].recv_addr, data,
-		       req->msg.cum_send_len);
+		       req->msg.cum_recv_len);
 		break;
 
 	case GNIX_FAB_RQ_RECVV:
@@ -276,7 +276,7 @@ static void __gnix_msg_copy_data_to_recv_addr(struct gnix_fab_req *req,
 		__gnix_msg_unpack_data_into_iov(req->msg.recv_info,
 						req->msg.recv_iov_cnt,
 						(uint64_t) data,
-						req->msg.cum_send_len);
+						req->msg.cum_recv_len);
 		break;
 
 	default:
@@ -488,29 +488,50 @@ static inline int __gnix_msg_recv_completion(struct gnix_fid_ep *ep,
 
 	len = MIN(req->msg.cum_send_len, req->msg.cum_recv_len);
 
+
 	if (OFI_UNLIKELY(req->msg.recv_flags & FI_MULTI_RECV))
 		recv_addr = (void *)req->msg.recv_info[0].recv_addr;
 
-	if (OFI_LIKELY(!(ep->caps & FI_SOURCE))) {
-		ret = __recv_completion(ep,
-					 req,
-					 flags,
-					 len,
-					 recv_addr);
+	/*
+	 * Deal with possible truncation
+	 */
+	if (OFI_LIKELY(req->msg.cum_send_len <= req->msg.cum_recv_len)) {
+
+		if (OFI_LIKELY(!(ep->caps & FI_SOURCE))) {
+			ret = __recv_completion(ep,
+						 req,
+						 flags,
+						 len,
+						 recv_addr);
+		} else {
+			src_addr = _gnix_vc_peer_fi_addr(req->vc);
+			ret = __recv_completion_src(ep,
+						     req,
+						     flags,
+						     len,
+						     recv_addr,
+						     src_addr);
+		}
+
 	} else {
-		src_addr = _gnix_vc_peer_fi_addr(req->vc);
-		ret = __recv_completion_src(ep,
-					     req,
-					     flags,
-					     len,
-					     recv_addr,
-					     src_addr);
-	}
+
+		ret = __recv_err(ep,
+				 req->user_context,
+				 flags,
+				 len,
+				 recv_addr,
+				 req->msg.imm,
+				 req->msg.tag,
+				 req->msg.cum_send_len - req->msg.cum_recv_len,
+				 FI_ETRUNC,
+				 FI_ETRUNC, NULL, 0);
+	};
 
 	/*
 	 * if i'm child of a FI_MULTI_RECV request, decrement
 	 * ref count
 	 */
+
 	if (req->msg.parent != NULL) {
 		_gnix_ref_put(req->msg.parent);
 	}
@@ -1919,6 +1940,7 @@ static inline struct gnix_fab_req *
 	 */
 
 	req->type = GNIX_FAB_RQ_RECV;
+	ofi_atomic_initialize32(&req->msg.outstanding_txds, 0);
 	req->msg.recv_flags = mrecv_req->msg.recv_flags;
 	req->msg.recv_flags |= FI_MULTI_RECV;
 	req->msg.recv_info[0].recv_addr =
@@ -2165,7 +2187,7 @@ static int __smsg_rndzv_start(void *data, void *msg)
 		req->msg.send_info[0].send_len =
 			MIN(hdr->len, req->msg.cum_recv_len);
 		req->msg.send_info[0].mem_hndl = hdr->mdh;
-		req->msg.cum_send_len = req->msg.send_info[0].send_len;
+		req->msg.cum_send_len = hdr->len;
 		req->msg.send_iov_cnt = 1;
 		req->msg.send_flags = hdr->flags;
 		req->msg.tag = hdr->msg_tag;
@@ -2700,11 +2722,6 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 				req->msg.recv_flags |= GNIX_MSG_GET_TAIL;
 			}
 
-			/* Send length is truncated to receive buffer size. */
-			req->msg.cum_send_len =
-				MIN(req->msg.cum_send_len,
-				    req->msg.recv_info[0].recv_len);
-
 			/* Initiate pull of source data. */
 			req->work_fn = req->msg.send_iov_cnt == 1 ?
 				__gnix_rndzv_req : __gnix_rndzv_iov_req_build;
@@ -2718,12 +2735,12 @@ ssize_t _gnix_recv(struct gnix_fid_ep *ep, uint64_t buf, size_t len,
 			GNIX_DEBUG(FI_LOG_EP_DATA, "Matched recv, req: %p\n",
 				  req);
 
+			req->msg.cum_send_len = req->msg.send_info[0].send_len;
+
 			/* Send length is truncated to receive buffer size. */
 			req->msg.send_info[0].send_len =
 				MIN(req->msg.send_info[0].send_len,
 				    req->msg.recv_info[0].recv_len);
-
-			req->msg.cum_send_len = req->msg.send_info[0].send_len;
 
 			/* Copy data from unexpected eager receive buffer. */
 			memcpy((void *)buf, (void *)req->msg.send_info[0].send_addr,

--- a/prov/gni/test/rdm_fi_pcd_trecv_msg.c
+++ b/prov/gni/test/rdm_fi_pcd_trecv_msg.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -1811,8 +1812,6 @@ static void pdc_peek_event_present_small_buffer_provided(int len)
 	 * fetched with a peek, but the target buffer should remain untouched
 	 */
 	build_peek_message(&peek_msg, &msg);
-	peek_iov.iov_len /= 2;
-
 
 	start_test_timer();
 	do {

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -2041,6 +2041,13 @@ void do_sendrecv_buf(void *p, void *t, int send_len, int recv_len)
 	uint64_t s[NUMEPS] = {0}, r[NUMEPS] = {0}, s_e[NUMEPS] = {0};
 	uint64_t r_e[NUMEPS] = {0};
 
+	/*
+	 * this test can't handle truncated messages so skip if recv_len
+	 * isn't big enough to receive message
+	 */
+	if (send_len > recv_len)
+		return;
+
 	rdm_sr_init_data(p, send_len, 0xab);
 	rdm_sr_init_data(t, recv_len, 0);
 


### PR DESCRIPTION
ing recvs

Have no idea how things were working, but the GNI provider
was incorrectly using the length of the incoming message
for transfer to recv buffers/iovecs rather than the
length of receive buffers.

Fixes #5002

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 50f90a4e5103e4110aa109a8526558f1363a3259)