### PR TITLE
API enhancements for collective offload support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -197,7 +197,8 @@ nodist_rdmainclude_HEADERS = \
 	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_atomic.h \
 	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_cm.h \
 	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_eq.h \
-	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_trigger.h
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_trigger.h \
+	$(top_srcdir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct_collective.h
 if FI_DIRECT_H_IN
 nodist_rdmainclude_HEADERS += $(top_builddir)/prov/$(PROVIDER_DIRECT)/include/rdma/fi_direct.h
 else

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -135,6 +135,7 @@ typedef struct fid *fid_t;
 #define FI_ATOMIC		(1ULL << 4)
 #define FI_ATOMICS		FI_ATOMIC
 #define FI_MULTICAST		(1ULL << 5)
+#define FI_COLLECTIVE		(1ULL << 6)
 
 #define FI_READ			(1ULL << 8)
 #define FI_WRITE		(1ULL << 9)

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -44,6 +44,7 @@ extern "C" {
 
 
 /* Atomic flags */
+#define FI_SCATTER		(1ULL << 57)
 #define FI_FETCH_ATOMIC		(1ULL << 58)
 #define FI_COMPARE_ATOMIC	(1ULL << 59)
 

--- a/include/rdma/fi_collective.h
+++ b/include/rdma/fi_collective.h
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2019 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FI_COLLECTIVE_H
+#define FI_COLLECTIVE_H
+
+#include <rdma/fi_atomic.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_cm.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+struct fi_ops_av_set {
+	size_t	size;
+	int	(*set_union)(struct fid_av_set *dst,
+			const struct fid_av_set *src);
+	int	(*intersect)(struct fid_av_set *dst,
+			const struct fid_av_set *src);
+	int	(*diff)(struct fid_av_set *dst, const struct fid_av_set *src);
+	int	(*insert)(struct fid_av_set *set, fi_addr_t addr);
+	int	(*remove)(struct fid_av_set *set, fi_addr_t addr);
+};
+
+struct fid_av_set {
+	struct fid		fid;
+	struct fi_ops_av_set	*ops;
+};
+
+struct fi_collective_attr {
+	struct fi_atomic_attr	datatype_attr;
+	size_t			max_members;
+	uint64_t		mode;
+};
+
+#ifdef FABRIC_DIRECT
+#include <rdma/fi_direct_collective.h>
+#endif /* FABRIC_DIRECT */
+
+#ifndef FABRIC_DIRECT_COLLECTIVE
+
+static inline int
+fi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
+	  struct fid_av_set *av_set, void * context)
+{
+	return FI_CHECK_OP(av->ops, struct fi_ops_av, av_set) ?
+		av->ops->av_set(av, attr, av_set, context) : -FI_ENOSYS;
+}
+
+static inline int
+fi_av_set_union(struct fid_av_set *dst, const struct fid_av_set *src)
+{
+	return dst->ops->set_union(dst, src);
+}
+
+static inline int
+fi_av_set_intersect(struct fid_av_set *dst, const struct fid_av_set *src)
+{
+	return dst->ops->intersect(dst, src);
+}
+
+static inline int
+fi_av_set_diff(struct fid_av_set *dst, const struct fid_av_set *src)
+{
+	return dst->ops->diff(dst, src);
+}
+
+static inline int
+fi_av_set_insert(struct fid_av_set *set, fi_addr_t addr)
+{
+	return set->ops->insert(set, addr);
+}
+
+static inline int
+fi_av_set_remove(struct fid_av_set *set, fi_addr_t addr)
+{
+	return set->ops->remove(set, addr);
+}
+
+static inline int
+fi_join_collective(struct fid_ep *ep, const struct fid_av_set *set,
+		   uint64_t flags, struct fid_mc **mc, void *context)
+{
+	return fi_join(ep, (const void *) set, flags, mc, context);
+}
+
+static inline ssize_t
+fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags, void *context)
+{
+	struct fi_msg_atomic msg;
+
+	msg.msg_iov = NULL;
+	msg.desc = NULL;
+	msg.iov_count = 0;
+	msg.addr = coll_addr;
+	msg.rma_iov = NULL;
+	msg.rma_iov_count = 0;
+	msg.datatype = FI_VOID;
+	msg.op = FI_BARRIER;
+	msg.context = context;
+	msg.data = 0;
+	return fi_atomicmsg(ep, &msg, flags | FI_COLLECTIVE);
+}
+
+static inline ssize_t
+fi_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
+	     fi_addr_t coll_addr, enum fi_datatype datatype, enum fi_op op,
+	     uint64_t flags, void *context)
+{
+	struct fi_msg_atomic msg;
+	struct fi_ioc ioc;
+
+	ioc.addr = buf;
+	ioc.count = count;
+
+	msg.addr = coll_addr;
+	msg.rma_iov = NULL;
+	msg.rma_iov_count = 0;
+	msg.datatype = datatype;
+	msg.op = FI_BROADCAST;
+	msg.context = context;
+	msg.data = 0;
+
+	if (flags & FI_SEND) {
+		msg.msg_iov = &ioc;
+		msg.desc = desc;
+		msg.iov_count = 1;
+		return fi_fetch_atomicmsg(ep, &msg, NULL, NULL, 0,
+					  flags | FI_COLLECTIVE);
+	} else {
+		msg.msg_iov = NULL;
+		msg.desc = NULL;
+		msg.iov_count = 0;
+		return fi_fetch_atomicmsg(ep, &msg, &ioc, desc, 1,
+					  flags | FI_COLLECTIVE);
+	}
+}
+
+static inline ssize_t
+fi_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+	     void *result, void *result_desc,
+	     fi_addr_t coll_addr, enum fi_datatype datatype, enum fi_op op,
+	     uint64_t flags, void *context)
+{
+	struct fi_msg_atomic msg;
+	struct fi_ioc ioc;
+
+	ioc.addr = buf;
+	ioc.count = count;
+	msg.msg_iov = &ioc;
+	msg.desc = desc;
+	msg.iov_count = 1;
+
+	msg.addr = coll_addr;
+	msg.rma_iov = NULL;
+	msg.rma_iov_count = 0;
+	msg.datatype = datatype;
+	msg.op = op;
+	msg.context = context;
+	msg.data = 0;
+
+	return fi_fetch_atomicmsg(ep, &msg, result, result_desc, 1,
+				  flags | FI_COLLECTIVE);
+}
+
+static inline ssize_t
+fi_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+		  void *result, void *result_desc,
+		  fi_addr_t coll_addr, enum fi_datatype datatype, enum fi_op op,
+		  uint64_t flags, void *context)
+{
+	struct fi_msg_atomic msg;
+	struct fi_ioc ioc;
+
+	ioc.addr = buf;
+	ioc.count = count;
+	msg.msg_iov = &ioc;
+	msg.desc = desc;
+	msg.iov_count = 1;
+
+	msg.addr = coll_addr;
+	msg.rma_iov = NULL;
+	msg.rma_iov_count = 0;
+	msg.datatype = datatype;
+	msg.op = op;
+	msg.context = context;
+	msg.data = 0;
+
+	return fi_fetch_atomicmsg(ep, &msg, result, result_desc, 1,
+				  flags | FI_COLLECTIVE | FI_SCATTER);
+}
+
+static inline ssize_t
+fi_alltoall(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+	    void *result, void *result_desc,
+	    fi_addr_t coll_addr, enum fi_datatype datatype,
+	    uint64_t flags, void *context)
+{
+	struct fi_msg_atomic msg;
+	struct fi_ioc ioc;
+
+	ioc.addr = buf;
+	ioc.count = count;
+	msg.msg_iov = &ioc;
+	msg.desc = desc;
+	msg.iov_count = 1;
+
+	msg.addr = coll_addr;
+	msg.rma_iov = NULL;
+	msg.rma_iov_count = 0;
+	msg.datatype = datatype;
+	msg.op = FI_ALLTOALL;
+	msg.context = context;
+	msg.data = 0;
+
+	return fi_fetch_atomicmsg(ep, &msg, result, result_desc, 1,
+				  flags | FI_COLLECTIVE);
+}
+
+static inline ssize_t
+fi_allgather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+	     void *result, void *result_desc,
+	     fi_addr_t coll_addr, enum fi_datatype datatype,
+	     uint64_t flags, void *context)
+{
+	struct fi_msg_atomic msg;
+	struct fi_ioc ioc;
+
+	ioc.addr = buf;
+	ioc.count = count;
+	msg.msg_iov = &ioc;
+	msg.desc = desc;
+	msg.iov_count = 1;
+
+	msg.addr = coll_addr;
+	msg.rma_iov = NULL;
+	msg.rma_iov_count = 0;
+	msg.datatype = datatype;
+	msg.op = FI_ALLGATHER;
+	msg.context = context;
+	msg.data = 0;
+
+	return fi_fetch_atomicmsg(ep, &msg, result, result_desc, 1,
+				  flags | FI_COLLECTIVE);
+}
+
+static inline int
+fi_query_collective(struct fid_domain *domain,
+		    enum fi_datatype datatype, enum fi_op op,
+		    struct fi_collective_attr *attr, uint64_t flags)
+{
+	return fi_query_atomic(domain, datatype, op, &attr->datatype_attr,
+			       flags | FI_COLLECTIVE);
+}
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FI_COLLECTIVE_H */

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -49,6 +49,7 @@ extern "C" {
 
 #define FI_SYMMETRIC		(1ULL << 59)
 #define FI_SYNC_ERR		(1ULL << 58)
+#define FI_UNIVERSE		(1ULL << 57)
 
 
 struct fi_av_attr {
@@ -60,6 +61,18 @@ struct fi_av_attr {
 	void			*map_addr;
 	uint64_t		flags;
 };
+
+struct fi_av_set_attr {
+	size_t			count;
+	fi_addr_t		start_addr;
+	fi_addr_t		end_addr;
+	uint64_t		stride;
+	size_t			comm_key_size;
+	uint8_t			*comm_key;
+	uint64_t		flags;
+};
+
+struct fid_av_set;
 
 struct fi_ops_av {
 	size_t	size;
@@ -77,6 +90,8 @@ struct fi_ops_av {
 			size_t *addrlen);
 	const char * (*straddr)(struct fid_av *av, const void *addr,
 			char *buf, size_t *len);
+	int	(*av_set)(struct fid_av *av, struct fi_av_set_attr *attr,
+			struct fid_av_set **av_set, void *context);
 };
 
 struct fid_av {
@@ -119,6 +134,8 @@ struct fi_mr_modify {
 
 #ifndef FABRIC_DIRECT_ATOMIC_DEF
 
+#define FI_COLLECTIVE_OFFSET 256
+
 enum fi_datatype {
 	FI_INT8,
 	FI_UINT8,
@@ -134,7 +151,11 @@ enum fi_datatype {
 	FI_DOUBLE_COMPLEX,
 	FI_LONG_DOUBLE,
 	FI_LONG_DOUBLE_COMPLEX,
-	FI_DATATYPE_LAST
+	/* End of point to point atomic datatypes */
+	FI_DATATYPE_LAST,
+
+	/* Collective datatypes */
+	FI_VOID = FI_COLLECTIVE_OFFSET,
 };
 
 enum fi_op {
@@ -157,7 +178,14 @@ enum fi_op {
 	FI_CSWAP_GE,
 	FI_CSWAP_GT,
 	FI_MSWAP,
-	FI_ATOMIC_OP_LAST
+	/* End of point to point atomic ops */
+	FI_ATOMIC_OP_LAST,
+
+	/* Collective only ops */
+	FI_BARRIER = FI_COLLECTIVE_OFFSET,
+	FI_BROADCAST,
+	FI_ALLTOALL,
+	FI_ALLGATHER,
 };
 
 #endif

--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -516,7 +516,9 @@ struct fi_atomic_attr {
 ```
 
 The count attribute field is as defined for the atomic valid calls.  The
-size field indicates the size in bytes of the atomic datatype.
+size field indicates the size in bytes of the atomic datatype.  The
+size field is useful for datatypes that may differ in sizes based on the
+platform or compiler, such FI_LONG_DOUBLE.
 
 ## Completions
 

--- a/man/fi_av.3.md
+++ b/man/fi_av.3.md
@@ -461,9 +461,6 @@ fabric errno on error.
 Fabric errno values are defined in
 `rdma/fi_errno.h`.
 
-# ERRORS
-
-
 # SEE ALSO
 
 [`fi_getinfo`(3)](fi_getinfo.3.html),

--- a/man/fi_av_set.3.md
+++ b/man/fi_av_set.3.md
@@ -1,0 +1,156 @@
+---
+layout: page
+title: fi_av_set(3)
+tagline: Libfabric Programmer's Manual
+---
+{% include JB/setup %}
+
+# NAME
+
+fi_av_set \- Address vector set operations
+
+fi_av_open / fi_close
+: Open or close an address vector
+
+
+# SYNOPSIS
+
+```c
+#include <rdma/fi_av_set.h>
+
+int fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+    struct fid_av **av, void *context);
+
+int fi_close(struct fid *av_set);
+```
+
+# ARGUMENTS
+
+*av*
+: Address vector
+
+*attr*
+: Address vector set attributes
+
+*context*
+: User specified context associated with the address vector set
+
+*flags*
+: Additional flags to apply to the operation.
+
+# DESCRIPTION
+
+An address vector set (AV set) represents an ordered subset of addresses of an
+address vector.  AV sets are used to identify the participants in a collective
+operation.  Endpoints use the fi_join_collective() operation to associate
+itself with an AV set.  The join collective operation provides an fi_addr that
+is used when communicating with a collective group.
+
+The creation and manipulation of an AV set is a local operation.  No fabric
+traffic is exchanged between peers.  As a result, each peer is responsible
+for creating matching AV sets as part of their collective membership definition.
+See [`fi_collective`(3)](fi_collective.3.html) for a discussion of membership
+models.
+
+## fi_av_set
+
+The fi_av_set call creates a new AV set.  The initial properties of the AV
+set are specified through the struct fi_av_set_attr parameter.  This
+structure is defined below, and allows including a subset of addresses in the
+AV set as part of AV set creation.  Addresses may be added or removed from an
+AV set using the AV set interfaces defined below.
+
+## fi_av_set_attr
+
+{% highlight c %}
+struct fi_av_set_attr {
+	size_t count;
+	fi_addr_t start_addr;
+	fi_addr_t end_addr;
+	uint64_t stride;
+	size_t comm_key_size;
+	uint8_t *comm_key;
+	uint64_t flags;
+};
+{% endhighlight %}
+
+*count*
+: Indicates the expected the number of members that will be a part of
+  the AV set.  The provider uses this to optimize resource allocations.
+
+*start_addr / end_addr*
+: The starting and ending addresses, inclusive, to
+  include as part of the AV set.  The use of start and end address require
+  that the associated AV have been created as type FI_AV_TABLE.  Valid
+  addresses in the AV which fall within the specified range and which meet other
+  requirements (such as stride) will be added as initial members to the AV set.
+  The start_addr and end_addr must be set to FI_ADDR_NOTAVAIL if creating an
+  empty AV set, a communication key is being provided, or the AV is of
+  type FI_AV_MAP.
+
+*stride*
+: The number of entries between successive addresses included in the
+  AV set.  The AV set will include all addresses from start_addr + stride x i,
+  for increasing, non-negative, integer values of i, up to end_addr.  A stride
+  of 1 indicates that all addresses between start_addr and end_addr should be
+  added to the AV set.  Stride should be set to 0 unless the start_addr and
+  end_addr fields are valid.
+
+*comm_key_size*
+: The length of the communication key in bytes.  This
+  field should be 0 if a communication key is not available.
+
+*comm_key*
+: If supported by the fabric, this represents a key
+  associated with the AV set.  The communication key is used by applications
+  that directly manage collective membership through a fabric management agent
+  or resource manager.  The key is used to convey that results of the
+  membership setup to the underlying provider.  The use and format of a
+  communication key is fabric provider specific.
+
+*flags*
+: If the flag FI_UNIVERSE is set, then the AV set will be created
+  containing all addresses stored in the AV.
+
+## fi_av_set_union
+
+The AV set union call adds all addresses in the source AV set that are not
+in the destination AV set to the destination AV set.  Where ordering matters,
+the newly inserted addresses are placed at the end of the AV set.
+
+## fi_av_set_intersect
+
+The AV set intersect call remove all addresses from the destination AV set that
+are not also members of the source AV set.  The order of the addresses in the
+destination AV set is unchanged.
+
+## fi_av_set_diff
+
+The AV set difference call removes all address from the destination AV set
+that are also members of the source AV set.  The order of the addresses in the
+destination AV set is unchanged.
+
+## fi_av_set_insert
+
+The AV set insert call appends the specified address to the end of the AV set.
+
+## fi_av_set_remove
+
+The AV set remove call removes the specified address from the given AV set.
+The order of the remaining addresses in the AV set is unchanged.
+
+# NOTES
+
+Developers who are familiar with MPI will find that AV sets are similar to
+MPI groups, and may act as a direct mapping in some, but not all, situations.
+
+# RETURN VALUES
+
+Returns 0 on success. On error, a negative value corresponding to fabric
+errno is returned. Fabric errno values are defined in
+`rdma/fi_errno.h`.
+
+# SEE ALSO
+
+[`fi_av`(3)](fi_av.3.html),
+[`fi_collective`(3)](fi_collective.3.html)

--- a/man/fi_collective.3.md
+++ b/man/fi_collective.3.md
@@ -1,0 +1,441 @@
+---
+layout: page
+title: fi_collective(3)
+tagline: Libfabric Programmer's Manual
+---
+{% include JB/setup %}
+
+# NAME
+
+fi_barrier
+: Collective operation that does not complete until all peers have entered
+  the barrier call.
+
+fi_broadcast
+: A single sender transmits data to all receiver peers.
+
+fi_allreduce
+: Collective operation where all peers broadcast an atomic operation to all
+  other peers.
+
+fi_reduce_scatter
+: Collective call where data is collected from all peers and merged (reduced).
+  The results of the reduction is distributed back to the peers, with each
+  peer receiving a slice of the results.
+
+fi_alltoall
+: Each peer distributes a slice of its local data to all peers.
+
+fi_allgather
+: Each peer sends a complete copy of its local data to all peers.
+
+fi_query_collective
+: Returns information about which collective operations are supported by a
+  provider, and limitations on the collective.
+
+# SYNOPSIS
+
+```c
+#include <rdma/fi_collective.h>
+
+int fi_join_collective(struct fid_ep *ep, const struct fid_av_set *set,
+	uint64_t flags, struct fid_mc **mc, void *context);
+
+ssize_t fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr, uint64_t flags,
+	void *context);
+
+ssize_t fi_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
+	fi_addr_t coll_addr, enum fi_datatype datatype, enum fi_op op,
+	uint64_t flags, void *context);
+
+ssize_t fi_allreduce(struct fid_ep *ep, const void *buf, size_t count,
+	void *desc, void *result, void *result_desc,
+	fi_addr_t coll_addr, enum fi_datatype datatype, enum fi_op op,
+	uint64_t flags, void *context);
+
+ssize_t fi_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count,
+	void *desc, void *result, void *result_desc,
+	fi_addr_t coll_addr, enum fi_datatype datatype, enum fi_op op,
+	uint64_t flags, void *context);
+
+ssize_t fi_alltoall(struct fid_ep *ep, const void *buf, size_t count,
+	void *desc, void *result, void *result_desc,
+	fi_addr_t coll_addr, enum fi_datatype datatype,
+	uint64_t flags, void *context);
+
+ssize_t fi_allgather(struct fid_ep *ep, const void *buf, size_t count,
+	void *desc, void *result, void *result_desc,
+	fi_addr_t coll_addr, enum fi_datatype datatype,
+	uint64_t flags, void *context);
+
+int fi_query_collective(struct fid_domain *domain,
+	enum fi_datatype datatype, enum fi_op op,
+	struct fi_collective_attr *attr, uint64_t flags);
+```
+
+# ARGUMENTS
+
+*ep*
+: Fabric endpoint on which to initiate collective operation.
+
+*set*
+: Address vector set defining the collective membership.
+
+*mc*
+: Multicast group associated with the collective.
+
+*buf*
+: Local data buffer that specifies first operand of collective operation
+
+*datatype*
+: Datatype associated with atomic operands
+
+*op*
+: Atomic operation to perform
+
+*result*
+: Local data buffer to store the result of the collective operation.
+
+*desc / result_desc*
+: Data descriptor associated with the local data buffer
+  and local result buffer, respectively.
+
+*coll_addr*
+: Address referring to the collective group of endpoints.
+
+*flags*
+: Additional flags to apply for the atomic operation
+
+*context*
+: User specified pointer to associate with the operation.  This parameter is
+  ignored if the operation will not generate a successful completion, unless
+  an op flag specifies the context parameter be used for required input.
+
+# DESCRIPTION
+
+In general collective operations can be thought of as coordinated atomic
+operations between a set of peer endpoints.  Readers should refer to the
+[`fi_atomic`(3)](fi_atomic.3.html) man page for details on the
+atomic operations and datatypes defined by libfabric.
+
+A collective operation is a group communication exchange.  It involves
+multiple peers exchanging data with other peers participating in the
+collective call.  Collective operations require close coordination by all
+participating members.  All participants must invoke the same collective call
+before any single member can complete its operation locally.  As a result,
+collective calls can strain the fabric, as well as local and remote data
+buffers.
+
+Libfabric collective interfaces target fabrics that support offloading
+portions of the collective communication into network switches, NICs, and
+other devices.  However, no implementation requirement is placed on the
+provider.
+
+The first step in using a collective call is identifying the peer endpoints
+that will participate.  Collective membership follows one of two models, both
+supported by libfabric.  In the first model, the application manages the
+membership.  This usually means that the application is performing a
+collective operation itself using point to point communication to identify
+the members who will participate.  Additionally, the application may be
+interacting with a fabric resource manager to reserve network resources
+needed to execute collective operations.  In this model, the application will
+inform libfabric that the membership has already been established.
+
+A separate model moves the membership management under libfabric and directly
+into the provider.  In this model, the application must identify which peer
+addresses will be members.  That information is conveyed to the libfabric
+provider, which is then responsible for coordinating the creation of the
+collective group.  In the provider managed model, the provider will usually
+perform the necessary collective operation to establish the communication
+group and interact with any fabric management agents.
+
+In both models, the collective membership is communicated to the provider by
+creating and configuring an address vector set (AV set).  An AV set
+represents an ordered subset of addresses in an address vector (AV).
+Details on creating and configuring an AV set are available in
+[`fi_av_set`(3)](fi_av_set.3.html).
+
+Once an AV set has been programmed with the collective membership
+information, an endpoint is joined to the set.  This uses the fi_join_collective
+operation and operates asynchronously.  This differs from how an endpoint is
+associated synchronously with an AV using the fi_ep_bind() call.  Upon
+completion of the fi_join_collective operation, an fi_addr is provided that
+is used as the target address when invoking a collective operation.
+
+For developer convenience, a set of collective APIs are defined.  However,
+these are inline wrappers around the atomic interfaces.  Collective APIs
+differ from message and RMA interfaces in that the format of the data is
+known to the provider, and the collective may perform an operation on that
+data.  This aligns collective operations closely with the atomic interfaces.
+
+## Join Collective (fi_join_collective)
+
+This call attaches an endpoint to a collective membership group.  Libfabric
+treats collective members as a multicast group, and the fi_join_collective
+call attaches the endpoint to that multicast group.  By default, the endpoint
+will join the group based on the data transfer capabilities of the endpoint.
+For example, if the endpoint has been configured to both send and receive data,
+then the endpoint will be able to initiate and receive transfers to and from
+the collective.  The fi_join flags may be used to restrict access to the
+collective group, subject to endpoint capability limitations.
+
+Join collective operations complete asynchronously, and may involve fabric
+transfers, dependent on the provider implementation.  An endpoint must be bound
+to an event queue prior to calling fi_join_collective.  The result of the join
+operation will be reported to the EQ as an FI_JOIN_COMPLETE event.  Applications
+cannot issue collective transfers until receiving notification that the join
+operation has completed.  Note that an endpoint may begin receiving
+messages from the collective group as soon as the join completes, which can
+occur prior to the FI_JOIN_COMPLETE event being generated.
+
+Applications must call fi_close on the collective group to disconnect the
+endpoint from the group.  After a join operation has completed, the
+fi_mc_addr call may be used to retrieve the address associated with the
+multicast group.  See [`fi_cm`(3)](fi_cm.3.html) for additional details on
+fi_mc_addr().
+
+## Barrier (fi_barrier)
+
+The fi_barrier operation provides a mechanism to synchronize peers.  Barrier
+does not result in any data being transferred at the application level.  A
+barrier does not complete locally until all peers have invoked the barrier
+call.  This signifies to the local application that work by peers that
+completed prior to them calling barrier has finished.
+
+## Broadcast (fi_broadcast)
+
+fi_broadcast transfers an array of data from a single sender to all other
+members of the collective group.  The sender of the broadcast data must
+specify the FI_SEND flag, while receivers use the FI_RECV flag.  The input
+buf parameter is treated as either the transmit buffer, if FI_SEND is set, or
+the receive buffer, if FI_RECV is set.  Either the FI_SEND or FI_RECV flag
+must be set.  The broadcast operation acts as an atomic write or read to a
+data array.  As a result, the format of the data in buf is specified through
+the datatype parameter.  Any non-void datatype may be broadcast.
+
+The following diagram shows an example of broadcast being used to transfer an
+array of integers to a group of peers.
+
+```
+[1]  [1]  [1]
+[5]  [5]  [5]
+[9]  [9]  [9]
+ |____^    ^
+ |_________|
+ broadcast
+```
+
+## All Reduce (fi_allreduce)
+
+fi_allreduce can be described as all peers providing input into an atomic
+operation, with the result copied back to each peer.  Conceptually, this can
+be viewed as each peer issuing a multicast atomic operation to all other
+peers, fetching the results, and combining them.  The combining of the
+results is referred to as the reduction.  The fi_allreduce() operation takes
+as input an array of data and the specified atomic operation to perform.  The
+results of the reduction are written into the result buffer.
+
+Any non-void datatype may be specified.  Valid atomic operations are listed
+below in the fi_query_collective call.  The following diagram shows an
+example of an all reduce operation involving summing an array of integers
+between three peers.
+
+```
+ [1]  [1]  [1]
+ [5]  [5]  [5]
+ [9]  [9]  [9]
+   \   |   /
+      sum
+   /   |   \
+ [3]  [3]  [3]
+[15] [15] [15]
+[27] [27] [27]
+  All Reduce
+```
+
+## All to All (fi_alltoall)
+
+The fi_alltoall collective involves distributing (or scattering) different
+portions of an array of data to peers.  It is best explained using an
+example.  Here three peers perform an all to all collective to exchange
+different entries in an integer array.
+
+```
+[1]   [2]   [3]
+[5]   [6]   [7]
+[9]  [10]  [11]
+   \   |   /
+   All to all
+   /   |   \
+[1]   [5]   [9]
+[5]   [6]   [7]
+[9]  [10]  [11]
+```
+
+All to all operations may be performed on any non-void datatype.  However,
+all to all does not perform an operation on the data itself, so no operation
+is specified.
+
+## Reduce-Scatter (fi_reduce_scatter)
+
+The fi_reduce_scatter collective is similar to an fi_allreduce operation,
+followed by all to all.  With reduce scatter, all peers provide input into an
+atomic operation, similar to all reduce.  However, rather than the full result
+being copied to each peer, each participant receives only a slice of the result.
+
+This is shown by the following example:
+
+```
+[1]  [1]  [1]
+[5]  [5]  [5]
+[9]  [9]  [9]
+  \   |   /
+     sum (reduce)
+      |
+     [3]
+    [15]
+    [27]
+      |
+   scatter
+  /   |   \
+[3] [15] [27]
+```
+
+The reduce scatter call supports the same datatype and atomic operation as
+fi_allreduce.
+
+## All Gather (fi_allgather)
+
+Conceptually, all gather can be viewed as the opposite of the scatter
+component from reduce-scatter.  All gather collects data from all peers into
+a single array, then copies that array back to each peer.
+
+```
+[1]  [5]  [9]
+  \   |   /
+ All gather
+  /   |   \
+[1]  [1]  [1]
+[5]  [5]  [5]
+[9]  [9]  [9]
+```
+
+All gather may be performed on any non-void datatype.  However, all gather
+does not perform an operation on the data itself, so no operation is
+specified.
+
+## Query Collective Attributes (fi_query_collective)
+
+The fi_query_collective call reports which collective operations are
+supported by the underlying provider, for suitably configured endpoints.
+Collective operations needed by an application that are not supported
+by the provider must be implemented by the application.  The query
+call checks whether a provider supports a specific collective operation
+for a given datatype and operation, if applicable.
+
+The datatype and operation of the collective are provided as input
+into fi_query_collective.  For operations that do not exchange
+application data, such as fi_barrier, the datatype should be set to
+FI_VOID.  The op parameter may reference one of these atomic opcodes:
+FI_MIN, FI_MAX, FI_SUM, FI_PROD, FI_LOR, FI_LAND, FI_BOR, FI_BAND,
+FI_LXOR, FI_BXOR, or a collective operation: FI_BARRIER, FI_BROADCAST,
+FI_ALLTOALL, FI_ALLGATHER.  The use of an atomic opcode will indicate
+if the provider supports the fi_allreduce() call for the given
+operation and datatype, unless the FI_SCATTER flag has been specified.  If
+FI_SCATTER has been set, query will return if the provider supports the
+fi_reduce_scatter() call for the given operation and datatype.
+Specifying a collective operation for the op parameter queries support
+for the corresponding collective.
+
+On success, fi_query_collective will provide information about
+the supported limits through the struct fi_collective_attr parameter.
+
+{% highlight c %}
+struct fi_collective_attr {
+	struct fi_atomic_attr datatype_attr;
+	size_t max_members;
+	uint64_t mode;
+};
+{% endhighlight %}
+
+For a description of struct fi_atomic_attr, see
+[`fi_atomic`(3)](fi_atomic.3.html).
+
+*datatype_attr.count*
+: The maximum number of elements that may be used with the collective.
+
+*datatype.size*
+: The size of the datatype as supported by the provider.  Applications
+  should validate the size of datatypes that differ based on the platform,
+  such as FI_LONG_DOUBLE.
+
+*max_members*
+: The maximum number of peers that may participate in a collective
+  operation.
+
+*mode*
+: This field is reserved and should be 0.
+
+If a collective operation is supported, the query call will return 0,
+along with attributes on the limits for using that collective operation
+through the provider.
+
+## Completions
+
+Collective operations map to underlying fi_atomic operations.  For a
+discussion of atomic completion semantics, see
+[`fi_atomic`(3)](fi_atomic.3.html).  The completion, ordering, and
+atomicity of collective operations match those defined for point to
+point atomic operations.
+
+# FLAGS
+
+The following flags are defined for the specified operations.
+
+*FI_SEND*
+: Applies to fi_broadcast() operations.  This indicates that the caller
+  is the transmitter of the broadcast data.  There should only be a single
+  transmitter for each broadcast collective operation.
+
+*FI_RECV*
+: Applies to fi_broadcast() operation.  This indicates that the caller
+  is the receiver of broadcase data.
+
+*FI_SCATTER*
+: Applies to fi_query_collective.  When set, requests attribute information
+  on the reduce-scatter collective operation.
+
+# RETURN VALUE
+
+Returns 0 on success. On error, a negative value corresponding to fabric
+errno is returned. Fabric errno values are defined in
+`rdma/fi_errno.h`.
+
+# ERRORS
+
+*-FI_EAGAIN*
+: See [`fi_msg`(3)](fi_msg.3.html) for a detailed description of handling
+  FI_EAGAIN.
+
+*-FI_EOPNOTSUPP*
+: The requested atomic operation is not supported on this endpoint.
+
+*-FI_EMSGSIZE*
+: The number of collective operations in a single request exceeds that
+  supported by the underlying provider.
+
+# NOTES
+
+Collective operations map to atomic operations.  As such, they follow
+most of the conventions and restrictions as peer to peer atomic operations.
+This includes data atomicity, data alignment, and message ordering
+semantics.  See [`fi_atomic`(3)](fi_atomic.3.html) for additional
+information on the datatypes and operations defined for atomic and
+collective operations.
+
+# SEE ALSO
+
+[`fi_getinfo`(3)](fi_getinfo.3.html),
+[`fi_av`(3)](fi_av.3.html),
+[`fi_atomic`(3)](fi_atomic.3.html),
+[`fi_cm`(3)](fi_cm.3.html)

--- a/man/man3/fi_av_set.3
+++ b/man/man3/fi_av_set.3
@@ -1,0 +1,1 @@
+.so man3/fi_av_set.3

--- a/man/man3/fi_collective.3
+++ b/man/man3/fi_collective.3
@@ -1,0 +1,1 @@
+.so man3/fi_collective.3

--- a/prov/bgq/include/rdma/fi_direct_collective.h
+++ b/prov/bgq/include/rdma/fi_direct_collective.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Intel Corp, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_DIRECT_COLLECTIVE_H_
+#define _FI_DIRECT_COLLECTIVE_H_
+
+/* no direct support */
+
+#endif /* _FI_DIRECT_COLLECTIVE_H_ */

--- a/prov/gni/include/rdma/fi_direct_collective.h
+++ b/prov/gni/include/rdma/fi_direct_collective.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Intel Corp, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_DIRECT_COLLECTIVE_H_
+#define _FI_DIRECT_COLLECTIVE_H_
+
+/* no direct support */
+
+#endif /* _FI_DIRECT_COLLECTIVE_H_ */

--- a/prov/psm2/include/rdma/fi_direct_collective.h
+++ b/prov/psm2/include/rdma/fi_direct_collective.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Intel Corp, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_DIRECT_COLLECTIVE_H_
+#define _FI_DIRECT_COLLECTIVE_H_
+
+/* no direct support */
+
+#endif /* _FI_DIRECT_COLLECTIVE_H_ */

--- a/prov/sockets/include/rdma/fi_direct_collective.h
+++ b/prov/sockets/include/rdma/fi_direct_collective.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Intel Corp, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FI_DIRECT_COLLECTIVE_H_
+#define _FI_DIRECT_COLLECTIVE_H_
+
+/* no direct support */
+
+#endif /* _FI_DIRECT_COLLECTIVE_H_ */

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -196,6 +196,7 @@ static void ofi_tostr_caps(char *buf, uint64_t caps)
 	IFFLAGSTR(caps, FI_TAGGED);
 	IFFLAGSTR(caps, FI_ATOMIC);
 	IFFLAGSTR(caps, FI_MULTICAST);
+	IFFLAGSTR(caps, FI_COLLECTIVE);
 
 	IFFLAGSTR(caps, FI_READ);
 	IFFLAGSTR(caps, FI_WRITE);
@@ -582,6 +583,7 @@ static void ofi_tostr_atomic_type(char *buf, enum fi_datatype type)
 	CASEENUMSTR(FI_DOUBLE_COMPLEX);
 	CASEENUMSTR(FI_LONG_DOUBLE);
 	CASEENUMSTR(FI_LONG_DOUBLE_COMPLEX);
+	CASEENUMSTR(FI_VOID);
 	default:
 		ofi_strcatf(buf, "Unknown");
 		break;
@@ -610,6 +612,10 @@ static void ofi_tostr_atomic_op(char *buf, enum fi_op op)
 	CASEENUMSTR(FI_CSWAP_GE);
 	CASEENUMSTR(FI_CSWAP_GT);
 	CASEENUMSTR(FI_MSWAP);
+	CASEENUMSTR(FI_BARRIER);
+	CASEENUMSTR(FI_BROADCAST);
+	CASEENUMSTR(FI_ALLTOALL);
+	CASEENUMSTR(FI_ALLGATHER);
 	default:
 		ofi_strcatf(buf, "Unknown");
 		break;


### PR DESCRIPTION
The following proposal is based on the OFIWG presentations for supporting switch and NIC based offload capabilities for MPI-style collective operations.  Some technical tweaks were made relative to the OFIWG presentation, but the concepts and general approach align with the final presentation.

This material targets post 1.8.x