### PR TITLE
core: Re-order provider priorities

### DIFF
--- a/man/fi_sockets.7.md
+++ b/man/fi_sockets.7.md
@@ -11,6 +11,10 @@ fi_sockets \- The Sockets Fabric Provider
 
 # OVERVIEW
 
+The sockets provider is being deprecated in favor of the tcp, udp, and
+utility providers.  Further work on the sockets provider will be minimal.
+Most applications should instead use the tcp provider instead.
+
 The sockets provider is a general purpose provider that can be used on any
 system that supports TCP sockets.  The provider is not intended to provide
 performance improvements over regular TCP sockets, but rather to allow

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -323,15 +323,15 @@ static struct ofi_prov *ofi_create_prov_entry(const char *prov_name)
 static void ofi_ordered_provs_init(void)
 {
 	char *ordered_prov_names[] = {
-		"psm2", "psm", "usnic", "mlx", "gni",
-		"bgq", "netdir", "ofi_rxm", "ofi_rxd", "verbs",
+		"psm2", "psm", "usnic", "gni", "bgq", "verbs",
+		"netdir", "ofi_rxm", "ofi_rxd", "shm", "mlx"
 		/* Initialize the socket based providers last of the
 		 * standard providers.  This will result in them being
 		 * the least preferred providers.
 		 */
 
 		/* Before you add ANYTHING here, read the comment above!!! */
-		"UDP", "sockets", "tcp", /* NOTHING GOES HERE! */
+		"UDP", "tcp", "sockets", /* NOTHING GOES HERE! */
 		/* Seriously, read it! */
 
 		/* These are hooking providers only.  Their order


### PR DESCRIPTION
Move tcp before sockets provider.  Add missing shm provider.  Move
verbs forward of utility providers.  Drop mlx near the end of the
list because of minimal support.

Update man page to indicate that sockets is being deprecated.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>