### PR TITLE
prov/verbs: addressing fixes

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -230,6 +230,9 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_NAME_SERVER_PORT*
 : The port on which Name Server thread listens incoming connections and requests (default: 5678)
 
+*FI_VERBS_GID_IDX*
+: The GID index to use (default: 0)
+
 ### Environment variables notes
 The fi_info utility would give the up-to-date information on environment variables:
 fi_info -p verbs -e

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -55,6 +55,7 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.use_odp		= 0,
 	.cqread_bunch_size	= 8,
 	.iface			= NULL,
+	.gid_idx		= 0,
 	.dgram			= {
 		.use_name_server	= 1,
 		.name_server_port	= 5678,
@@ -612,6 +613,15 @@ static int fi_ibv_read_params(void)
 	     fi_ibv_gl_data.dgram.name_server_port > 65535)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of dgram_name_server_port\n");
+		return -FI_EINVAL;
+	}
+	if (fi_ibv_get_param_int("gid_idx", "Set which gid index to use "
+				 "attribute (0 - 255)",
+				 &fi_ibv_gl_data.gid_idx) ||
+	    (fi_ibv_gl_data.gid_idx < 0 ||
+	     fi_ibv_gl_data.gid_idx > 255)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid value of gid index\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -148,6 +148,7 @@ extern struct fi_ibv_gl_data {
 	int	use_odp;
 	int	cqread_bunch_size;
 	char	*iface;
+	int	gid_idx;
 
 	struct {
 		int	buffer_num;

--- a/prov/verbs/src/verbs_dgram_av.c
+++ b/prov/verbs/src/verbs_dgram_av.c
@@ -134,7 +134,7 @@ static int fi_ibv_dgram_av_insert(struct fid_av *av_fid, const void *addr,
 	}
 
 	VERBS_DBG(FI_LOG_AV,
-		  "%"PRIu64" addresses were inserted successfully\n", count);
+		  "%d addresses were inserted successfully\n", success_cnt);
 	return success_cnt;
 }
 

--- a/prov/verbs/src/verbs_dgram_av.c
+++ b/prov/verbs/src/verbs_dgram_av.c
@@ -82,7 +82,7 @@ fi_ibv_dgram_av_insert_addr(struct fi_ibv_dgram_av *av, const void *addr,
 		ah_attr.is_global = 1;
 		ah_attr.grh.hop_limit = 64;
 		ah_attr.grh.dgid = ((struct ofi_ib_ud_ep_name *)addr)->gid;
-		ah_attr.grh.sgid_index = 0;
+		ah_attr.grh.sgid_index = fi_ibv_gl_data.gid_idx;
 	}
 
 	av_entry = calloc(1, sizeof(*av_entry));

--- a/prov/verbs/src/verbs_dgram_av.c
+++ b/prov/verbs/src/verbs_dgram_av.c
@@ -64,12 +64,6 @@ fi_ibv_dgram_av_insert_addr(struct fi_ibv_dgram_av *av, const void *addr,
 	struct fi_ibv_domain *domain =
 		container_of(av->util_av.domain, struct fi_ibv_domain, util_domain);
 
-	if (OFI_UNLIKELY(!fi_ibv_dgram_av_is_addr_valid(av, addr))) {
-		ret = -FI_EADDRNOTAVAIL;
-		VERBS_WARN(FI_LOG_AV, "Invalid address\n");
-		goto fn1;
-	}
-
 	struct ibv_ah_attr ah_attr = {
 		.is_global = 0,
 		.dlid = ((struct ofi_ib_ud_ep_name *)addr)->lid,
@@ -83,6 +77,10 @@ fi_ibv_dgram_av_insert_addr(struct fi_ibv_dgram_av *av, const void *addr,
 		ah_attr.grh.hop_limit = 64;
 		ah_attr.grh.dgid = ((struct ofi_ib_ud_ep_name *)addr)->gid;
 		ah_attr.grh.sgid_index = fi_ibv_gl_data.gid_idx;
+	} else if (OFI_UNLIKELY(!fi_ibv_dgram_av_is_addr_valid(av, addr))) {
+		ret = -FI_EADDRNOTAVAIL;
+		VERBS_WARN(FI_LOG_AV, "Invalid address\n");
+		goto fn1;
 	}
 
 	av_entry = calloc(1, sizeof(*av_entry));

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -423,7 +423,7 @@ static int fi_ibv_create_dgram_ep(struct fi_ibv_domain *domain, struct fi_ibv_ep
 		}
 	}
 
-	if (ibv_query_gid(domain->verbs, 1, 0, &gid)) {
+	if (ibv_query_gid(domain->verbs, 1, fi_ibv_gl_data.gid_idx, &gid)) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "Unable to query GID, errno = %d",
 			   errno);


### PR DESCRIPTION
- add a way to specify a gid index
- only check lid if local addressing
- print correct address insertions
