### PR TITLE
[v1.7.x] prov/gni: use ofi error values for provider

### DIFF
--- a/prov/gni/src/gnix_atomic.c
+++ b/prov/gni/src/gnix_atomic.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -54,7 +55,8 @@ static int __gnix_amo_send_err(struct gnix_fid_ep *ep,
 	if (ep->send_cq) {
 		rc = _gnix_cq_add_error(ep->send_cq, req->user_context,
 					flags, 0, 0, 0, 0, 0, error,
-					GNI_RC_TRANSACTION_ERROR, NULL, 0);
+					gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
+					NULL, 0);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_cq_add_error() failed: %d\n", rc);

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -351,7 +351,7 @@ static int __gnix_msg_recv_err(struct gnix_fid_ep *ep, struct gnix_fab_req *req)
 	return __recv_err(ep, req->user_context, flags, req->msg.cum_recv_len,
 			  (void *)req->msg.recv_info[0].recv_addr, req->msg.imm,
 			  req->msg.tag, 0, FI_ECANCELED,
-			  GNI_RC_TRANSACTION_ERROR, NULL, 0);
+			  gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR), NULL, 0);
 }
 
 static int __recv_completion(
@@ -527,7 +527,8 @@ static int __gnix_msg_send_err(struct gnix_fid_ep *ep, struct gnix_fab_req *req)
 	if (ep->send_cq) {
 		rc = _gnix_cq_add_error(ep->send_cq, req->user_context,
 					flags, 0, 0, 0, 0, 0, FI_ECANCELED,
-					GNI_RC_TRANSACTION_ERROR, NULL, 0);
+					gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
+					NULL, 0);
 		if (rc != FI_SUCCESS)  {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				   "_gnix_cq_add_error() returned %d\n",

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -64,7 +65,8 @@ static int __gnix_rma_send_err(struct gnix_fid_ep *ep,
 	if (ep->send_cq) {
 		rc = _gnix_cq_add_error(ep->send_cq, req->user_context,
 					flags, 0, 0, 0, 0, 0, error,
-					GNI_RC_TRANSACTION_ERROR, NULL, 0);
+					gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
+					NULL, 0);
 		if (rc) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_cq_add_error() failed: %d\n", rc);

--- a/prov/gni/test/rdm_atomic.c
+++ b/prov/gni/test/rdm_atomic.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,6 +50,7 @@
 #include "gnix_cm_nic.h"
 #include "gnix_hashtable.h"
 #include "gnix_atomic.h"
+#include "gnix_util.h"
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
@@ -5371,7 +5373,7 @@ Test(rdm_atomic_default, atomic_err)
 	cr_assert(err_cqe.tag == 0, "Bad error tag");
 	cr_assert(err_cqe.olen == 0, "Bad error olen");
 	cr_assert(err_cqe.err == FI_ECANCELED, "Bad error errno");
-	cr_assert(err_cqe.prov_errno == GNI_RC_TRANSACTION_ERROR,
+	cr_assert(err_cqe.prov_errno == gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
 		  "Bad prov errno");
 	cr_assert(err_cqe.err_data_size == 0);
 	cr_assert(err_cqe.err_data == NULL, "Bad error provider data");
@@ -5421,7 +5423,7 @@ Test(rdm_atomic_default, fetch_atomic_err)
 	cr_assert(err_cqe.tag == 0, "Bad error tag");
 	cr_assert(err_cqe.olen == 0, "Bad error olen");
 	cr_assert(err_cqe.err == FI_ECANCELED, "Bad error errno");
-	cr_assert(err_cqe.prov_errno == GNI_RC_TRANSACTION_ERROR,
+	cr_assert(err_cqe.prov_errno == gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
 		  "Bad prov errno");
 	cr_assert(err_cqe.err_data == NULL, "Bad error provider data");
 
@@ -5470,7 +5472,7 @@ Test(rdm_atomic_default, compare_atomic_err)
 	cr_assert(err_cqe.tag == 0, "Bad error tag");
 	cr_assert(err_cqe.olen == 0, "Bad error olen");
 	cr_assert(err_cqe.err == FI_ECANCELED, "Bad error errno");
-	cr_assert(err_cqe.prov_errno == GNI_RC_TRANSACTION_ERROR,
+	cr_assert(err_cqe.prov_errno == gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
 		  "Bad prov errno");
 	cr_assert(err_cqe.err_data == NULL, "Bad error provider data");
 

--- a/prov/gni/test/rdm_dgram_rma.c
+++ b/prov/gni/test/rdm_dgram_rma.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2018 Cray Inc. All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -2780,7 +2781,7 @@ void do_write_error(int len)
 	cr_assert(err_cqe.tag == 0, "Bad error tag");
 	cr_assert(err_cqe.olen == 0, "Bad error olen");
 	cr_assert(err_cqe.err == FI_ECANCELED, "Bad error errno");
-	cr_assert(err_cqe.prov_errno == GNI_RC_TRANSACTION_ERROR,
+	cr_assert(err_cqe.prov_errno == gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
 		  "Bad prov errno");
 	cr_assert(err_cqe.err_data == NULL, "Bad error provider data");
 
@@ -2858,7 +2859,7 @@ void do_read_error(int len)
 	cr_assert(err_cqe.tag == 0, "Bad error tag");
 	cr_assert(err_cqe.olen == 0, "Bad error olen");
 	cr_assert(err_cqe.err == FI_ECANCELED, "Bad error errno");
-	cr_assert(err_cqe.prov_errno == GNI_RC_TRANSACTION_ERROR,
+	cr_assert(err_cqe.prov_errno == gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
 		  "Bad prov errno");
 	cr_assert(err_cqe.err_data == NULL, "Bad error provider data");
 

--- a/prov/gni/test/rdm_dgram_stx.c
+++ b/prov/gni/test/rdm_dgram_stx.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2018 Cray Inc. All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -50,6 +51,7 @@
 #include "gnix_cm_nic.h"
 #include "gnix_hashtable.h"
 #include "gnix_rma.h"
+#include "gnix_util.h"
 
 #include <criterion/criterion.h>
 #include "gnix_rdma_headers.h"
@@ -2257,7 +2259,7 @@ static void do_write_error(int len)
 	cr_assert(err_cqe.tag == 0, "Bad error tag");
 	cr_assert(err_cqe.olen == 0, "Bad error olen");
 	cr_assert(err_cqe.err == FI_ECANCELED, "Bad error errno");
-	cr_assert(err_cqe.prov_errno == GNI_RC_TRANSACTION_ERROR,
+	cr_assert(err_cqe.prov_errno == gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
 		  "Bad prov errno");
 	cr_assert(err_cqe.err_data == NULL, "Bad error provider data");
 
@@ -2337,7 +2339,7 @@ static void do_read_error(int len)
 	cr_assert(err_cqe.tag == 0, "Bad error tag");
 	cr_assert(err_cqe.olen == 0, "Bad error olen");
 	cr_assert(err_cqe.err == FI_ECANCELED, "Bad error errno");
-	cr_assert(err_cqe.prov_errno == GNI_RC_TRANSACTION_ERROR,
+	cr_assert(err_cqe.prov_errno == gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
 		  "Bad prov errno");
 	cr_assert(err_cqe.err_data == NULL, "Bad error provider data");
 

--- a/prov/gni/test/rdm_sr.c
+++ b/prov/gni/test/rdm_sr.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2015-2018 Cray Inc. All rights reserved.
+ * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,6 +50,7 @@
 #include "gnix_hashtable.h"
 #include "gnix_rma.h"
 #include "gnix_mr.h"
+#include "gnix_util.h"
 #include "common.h"
 
 #include <criterion/criterion.h>
@@ -1833,7 +1835,7 @@ void do_send_err(int len)
 	cr_assert(err_cqe.tag == 0, "Bad error tag");
 	cr_assert(err_cqe.olen == 0, "Bad error olen");
 	cr_assert(err_cqe.err == FI_ECANCELED, "Bad error errno");
-	cr_assert(err_cqe.prov_errno == GNI_RC_TRANSACTION_ERROR,
+	cr_assert(err_cqe.prov_errno == gnixu_to_fi_errno(GNI_RC_TRANSACTION_ERROR),
 		  "Bad prov errno");
 	cr_assert(err_cqe.err_data == NULL, "Bad error provider data");
 


### PR DESCRIPTION
returning GNI_RC values in the CQE for error cases
confuses some users (or at least Bob C.)

Fixes #5050 

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit 77d792bddf21bccce18dc42cf3eb14a840e2120e)