### PR TITLE
prov/rxm: Modify poll mechanism for CM progress

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -150,6 +150,11 @@ The ofi_rxm provider checks for the following environment variables.
 : Defines the expected number of ranks / peers an endpoint would communicate
 with (default: 256).
 
+*FI_OFI_RXM_CM_PROGRESS_INTERVAL*
+: Defines the duration of time in microseconds between calls to RxM CM progression
+  functions when using manual progress. Higher values may provide less noise for 
+  calls to fi_cq read functions, but may increase connection setup time (default: 10000)
+
 # Tuning
 
 ## Bandwidth

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -74,8 +74,6 @@ extern size_t rxm_eager_limit;
 
 #define RXM_IOV_LIMIT 4
 
-#define RXM_EQ_PROGRESS_SPIN_COUNT 10000
-
 #define RXM_MR_MODES	(OFI_MR_BASIC_MAP | FI_MR_LOCAL)
 #define RXM_MR_VIRT_ADDR(info) ((info->domain_attr->mr_mode == FI_MR_BASIC) ||\
 				info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)
@@ -140,6 +138,7 @@ extern struct fi_ops_atomic rxm_ops_atomic;
 extern size_t rxm_msg_tx_size;
 extern size_t rxm_msg_rx_size;
 extern size_t rxm_def_univ_size;
+extern size_t rxm_cm_progress_interval;
 
 /*
  * Connection Map
@@ -657,7 +656,7 @@ struct rxm_ep {
 	struct fid_pep 		*msg_pep;
 	struct fid_eq 		*msg_eq;
 	struct fid_cq 		*msg_cq;
-	uint32_t		msg_cq_eagain_count;
+	uint64_t		msg_cq_last_poll;
 	struct fid_ep 		*srx_ctx;
 	size_t 			comp_per_progress;
 	int			msg_mr_local;

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -374,7 +374,7 @@ RXM_INI
 			"rendezvous protocol.", sizeof(struct rxm_pkt));
 
 	fi_param_define(&rxm_prov, "use_srx", FI_PARAM_BOOL,
-			"Set this enivronment variable to control the RxM "
+			"Set this environment variable to control the RxM "
 			"receive path. If this variable set to 1 (default: 0), "
 			"the RxM uses Shared Receive Context. This mode improves "
 			"memory consumption, but it may increase small message "
@@ -396,11 +396,21 @@ RXM_INI
 			"(default: 128). Setting this to 0 would get default "
 			"value defined by the MSG provider.");
 
+	fi_param_define(&rxm_prov, "cm_progress_interval", FI_PARAM_INT,
+			"Defines the number of microseconds to wait between "
+			"function calls to the connection management progression "
+			"functions during fi_cq_read calls. Higher values may "
+			"decrease noise during cq polling, but may result in "
+			"longer connection establishment times. (default: 10000).");
+
 	fi_param_get_size_t(&rxm_prov, "tx_size", &rxm_info.tx_attr->size);
 	fi_param_get_size_t(&rxm_prov, "rx_size", &rxm_info.rx_attr->size);
 	fi_param_get_size_t(&rxm_prov, "msg_tx_size", &rxm_msg_tx_size);
 	fi_param_get_size_t(&rxm_prov, "msg_rx_size", &rxm_msg_rx_size);
 	fi_param_get_size_t(NULL, "universe_size", &rxm_def_univ_size);
+	if (fi_param_get_int(&rxm_prov, "cm_progress_interval",
+				(int *) &rxm_cm_progress_interval))
+		rxm_cm_progress_interval = 10000;
 
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");


### PR DESCRIPTION
This commit changes the default behavior for progressing the
RXM connection manager. Prior to this patch, if manual progress
was requested by the application, then the CM would be progressed once
every 10000 function calls to fi_cq read functions. With this patch,
the default behavior is changed to once every 10 ms, and it is tunable
with an environment variable -- FI_OFI_RXM_POLL_FREQ_USEC. See fi_rxm(7)
for additional details on the environment variable.

Signed-off-by: James Swaro <jswaro@cray.com>

closes #5066 