### PR TITLE
src/windows: Change getifaddrs for chosing the right adapter

### DIFF
--- a/include/windows/ifaddrs.h
+++ b/include/windows/ifaddrs.h
@@ -27,6 +27,7 @@ struct ifaddrs {
 	struct sockaddr_in in_addr;
 	struct sockaddr_in in_netmask;
 	char		   ad_name[16];
+	size_t		   speed;
 };
 
 int getifaddrs(struct ifaddrs **ifap);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -882,10 +882,7 @@ static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[7] == ntohs(1));
 }
 
-static inline size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
-{
-	return 0;
-}
+size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
 
 /* complex operations implementation */
 

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -43,7 +43,6 @@
 #include "ofi_file.h"
 #include "ofi_list.h"
 #include "ofi_util.h"
-
 #include "rdma/providers/fi_log.h"
 
 extern struct ofi_common_locks common_locks;
@@ -404,65 +403,76 @@ fn_nomem:
 
 int getifaddrs(struct ifaddrs **ifap)
 {
-	DWORD i;
-	MIB_IPADDRTABLE _iptbl;
-	MIB_IPADDRTABLE *iptbl = &_iptbl;
-	ULONG ips = 1;
-	ULONG res = GetIpAddrTable(iptbl, &ips, 0);
+	ULONG subnet = 0;
+	PULONG mask = &subnet;
+	DWORD size,res, i = 0;
 	int ret = -1;
+	PIP_ADAPTER_ADDRESSES adapter_addresses, aa;
+	PIP_ADAPTER_UNICAST_ADDRESS ua;
 	struct ifaddrs *head = NULL;
+	struct sockaddr_in *pInAddr = NULL;
+	SOCKADDR *pSockAddr = NULL;
 
-	assert(ifap);
+	res = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX,
+				   NULL, NULL, &size);
+	if (res != ERROR_BUFFER_OVERFLOW)
+		return -FI_ENOMEM;
 
-	if (res == ERROR_INSUFFICIENT_BUFFER) {
-		iptbl = malloc(ips);
-		if (!iptbl)
-			goto failed_no_mem;
-		res = GetIpAddrTable(iptbl, &ips, 0);
-		if (res != NO_ERROR)
-			goto failed_get_addr;
-	} else if (res != NO_ERROR) {
-		goto failed;
-	}
+	adapter_addresses = (PIP_ADAPTER_ADDRESSES)malloc(size);
+	res = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_INCLUDE_PREFIX,
+				   NULL, adapter_addresses, &size);
+	if (res != ERROR_SUCCESS)
+		return -FI_ENOMEM;
 
-	for (i = 0; i < iptbl->dwNumEntries; i++) {
-		if (iptbl->table[i].dwAddr && iptbl->table[i].dwAddr != ntohl(INADDR_LOOPBACK)) {
+	for (aa = adapter_addresses; aa != NULL; aa = aa->Next) {
+		if (aa->OperStatus != 1)
+			continue;
+
+		for (ua = aa->FirstUnicastAddress; ua != NULL; ua = ua->Next) {
+			pSockAddr = ua->Address.lpSockaddr;
+			if (pSockAddr->sa_family != AF_INET)
+				continue;
+
+			subnet = 0;
+			mask = &subnet;
+			if (ConvertLengthToIpv4Mask(ua->OnLinkPrefixLength, mask) != NO_ERROR)
+				return -FI_ENODATA;
+
 			struct ifaddrs *fa = calloc(sizeof(*fa), 1);
 			if (!fa)
-				goto failed_cant_allocate;
+				return -FI_ENOMEM;
+
+			fa->ifa_next = head;
+			head = fa;
+
 			fa->ifa_flags = IFF_UP;
+			if (aa->IfType == IF_TYPE_SOFTWARE_LOOPBACK)
+				fa->ifa_flags |= IFF_LOOPBACK;
+
 			fa->ifa_addr = (struct sockaddr *)&fa->in_addr;
 			fa->ifa_netmask = (struct sockaddr *)&fa->in_netmask;
 			fa->ifa_name = fa->ad_name;
 
-			fa->in_addr.sin_family = fa->in_netmask.sin_family = AF_INET;
-			fa->in_addr.sin_addr.s_addr = iptbl->table[i].dwAddr;
-			fa->in_netmask.sin_addr.s_addr = iptbl->table[i].dwMask;
-			/* on Windows there is no Unix-like interface names,
-			   so, let's generate fake names */
-			sprintf_s(fa->ad_name, sizeof(fa->ad_name), "eth%d", i);
-
-			fa->ifa_next = head;
-			head = fa;
+			fa->in_addr.sin_family = fa->in_netmask.sin_family = pSockAddr->sa_family;
+			fa->in_netmask.sin_addr.S_un.S_addr = mask;
+			pInAddr = (struct sockaddr_in*)pSockAddr;
+			fa->in_addr.sin_addr = pInAddr->sin_addr;
+			fa->speed = aa->TransmitLinkSpeed;
+			sprintf_s(fa->ad_name, sizeof(fa->ad_name), "eth%d", i++);
 		}
 	}
 
-	if (iptbl != &_iptbl)
-		free(iptbl);
+	free(adapter_addresses);
 	ret = 0;
 	if (ifap)
 		*ifap = head;
-complete:
-	return ret;
 
-failed_cant_allocate:
-	if(head)
-		freeifaddrs(head);
-failed_get_addr:
-	free(iptbl);
-failed_no_mem:
-failed:
-	goto complete;
+	return ret;
+}
+
+size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
+{
+	return ifa->speed;
 }
 
 void freeifaddrs(struct ifaddrs *ifa)


### PR DESCRIPTION
Changes for geifddars():

1. Rewrote geifddars function for using new api - GetAdaptersAddresses.
Why do we use GetAdaptersAddresses?
     -get a field -> Ipv4Metric
     -add a possibility to support Ipv6 in future

2. Added an algorithm for sorting adapters under Ipv4Metric, using
IP_ADAPTER_ADDRESSES struct.

"Automatic Metric Assignment" assigns a higher metric to a slower
network interface. So, we sort the gotten metrics from the highest
to the slowest one. Then use the first IFF_UP adapter from linked list,
which we formed based on the metric and use for it as a main interface.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>