### PR TITLE
common: Work around possible long delay in getaddrinfo()

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -618,9 +618,9 @@ int ofi_str_toaddr(const char *str, uint32_t *addr_format,
 
 	switch (*addr_format) {
 	case FI_FORMAT_UNSPEC:
-		if (!ofi_hostname_toaddr(str, addr_format, addr, len))
-			return 0;
 		if (!ofi_ifname_toaddr(str, addr_format, addr, len))
+			return 0;
+		if (!ofi_hostname_toaddr(str, addr_format, addr, len))
 			return 0;
 		return -FI_EINVAL;
 	case FI_SOCKADDR_IN:


### PR DESCRIPTION
Previously, in order to convert a name into an address, the name was first
tried as a host name and if failed then tried as an interface name. However,
depending on system configuration, the function getaddrinfo() called in the
first step might incur seconds of delay if the name could not be resolved.
This could result in very slow operation when trying to convert an interface
name into address.

The workaround is to check the input name as an interface name first.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>