### PR TITLE
prov/rxd: mr mode fixes

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -117,7 +117,6 @@ struct rxd_domain {
 	ssize_t max_inline_rma;
 	ssize_t max_inline_atom;
 	ssize_t max_seg_sz;
-	int mr_mode;
 	struct ofi_mr_map mr_map;//TODO use util_domain mr_map instead
 };
 

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -135,7 +135,6 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 					sizeof(struct rxd_atom_hdr);
 	rxd_domain->max_seg_sz = rxd_domain->max_mtu_sz - sizeof(struct rxd_data_pkt) -
 				 dg_info->ep_attr->msg_prefix_size;
-	rxd_domain->mr_mode = dg_info->domain_attr->mr_mode;
 
 	ret = ofi_domain_init(fabric, info, &rxd_domain->util_domain, context);
 	if (ret) {

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1147,7 +1147,7 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err2;
 
 	memcpy(dg_info->src_addr, info->src_addr, info->src_addrlen);
-	rxd_ep->do_local_mr = (rxd_domain->mr_mode & FI_MR_LOCAL) ? 1 : 0;
+	rxd_ep->do_local_mr = ofi_mr_local(dg_info);
 
 	ret = fi_endpoint(rxd_domain->dg_domain, dg_info, &rxd_ep->dg_ep, rxd_ep);
 	if (ret)

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -57,14 +57,33 @@ static void rxd_init_env(void)
 	fi_param_get_int(&rxd_prov, "max_unacked", &rxd_env.max_unacked);
 }
 
+void rxd_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
+			       struct fi_info *core_info)
+{
+	/* We handle FI_MR_BASIC and FI_MR_SCALABLE irrespective of version */
+	if (hints && hints->domain_attr &&
+	    (hints->domain_attr->mr_mode & (FI_MR_SCALABLE | FI_MR_BASIC))) {
+		core_info->mode = FI_LOCAL_MR;
+		core_info->domain_attr->mr_mode = hints->domain_attr->mr_mode;
+	} else if (FI_VERSION_LT(version, FI_VERSION(1, 5))) {
+		core_info->mode |= FI_LOCAL_MR;
+		/* Specify FI_MR_UNSPEC (instead of FI_MR_BASIC) so that
+		 * providers that support only FI_MR_SCALABLE aren't dropped */
+		core_info->domain_attr->mr_mode = FI_MR_UNSPEC;
+	} else {
+		core_info->domain_attr->mr_mode |= FI_MR_LOCAL;
+		core_info->domain_attr->mr_mode |= OFI_MR_BASIC_MAP;
+	}
+}
+
 int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
 		     struct fi_info *core_info)
 {
+	rxd_info_to_core_mr_modes(version, rxd_info, core_info);
 	core_info->caps = FI_MSG;
 	core_info->mode = FI_LOCAL_MR | FI_CONTEXT | FI_MSG_PREFIX;
 	core_info->ep_attr->type = FI_EP_DGRAM;
 
-	core_info->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ALLOCATED;
 	return 0;
 }
 


### PR DESCRIPTION
Proper mr mode usage/passing to the core provider

This allows Open MPI to run