### PR TITLE
prov/efa : call progress function in rxr_ep_peek_trecv() to avoid hang

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -650,6 +650,7 @@ static ssize_t rxr_ep_peek_trecv(struct fid_ep *ep_fid,
 
 	fastlock_acquire(&ep->util_ep.lock);
 
+	__rxr_ep_progress(ep);
 	match_info.addr = msg->addr;
 	match_info.tag = msg->tag;
 	match_info.ignore = msg->ignore;


### PR DESCRIPTION
In MPI, when FI_PEEK was used to receive a message, the code structure
is usually like the following:

   while( !MPIDI_OFI_PEEK_FOUND ) {
      fi_trecvmsg( ..., FI_PEEK );   -> rxr_ep_peek_trecv();
      MPIDI_progress();              -> fi_cq_read();
   }

This code will hang on EFA if rxr_ep_peek_trecv() did not receive a
message at its first attemp.

The reason is:
    1. rxr_ep_peek_trecv() will write a cq error entry if no data
       was received.
    2. fi_cq_read() will not call rxr_ep_progress() if CQ is NOT empty.

Thus if rxr_ep_peek_trecv() did not receive data the first time it was
called, the code will run into an infinite loop: rxr_ep_peek_trecv()
keep writing cq error entry and fi_cq_read will keep reading them
without calling rxr_ep_progress().

This patch added a call to __rxr_ep_progress() at the beginning of
rxr_ep_peek_trecv() to fix this behavior.

Signed-off-by: Wei Zhang <wzam@amazon.com>