### PR TITLE
core/bufpool: Rework bufpool creation for huge page support

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -285,20 +285,16 @@ enum {
 
 struct ofi_bufpool_region;
 
-typedef int (*ofi_bufpool_alloc_fn)(struct ofi_bufpool_region *region);
-typedef void (*ofi_bufpool_free_fn)(struct ofi_bufpool_region *region);
-typedef void (*ofi_bufpool_init_fn)(struct ofi_bufpool_region *region, void *buf);
-
 struct ofi_bufpool_attr {
-	size_t 				size;
-	size_t 				alignment;
-	size_t	 			max_cnt;
-	size_t 				chunk_cnt;
-	ofi_bufpool_alloc_fn 		alloc_fn;
-	ofi_bufpool_free_fn 		free_fn;
-	ofi_bufpool_init_fn 		init_fn;
-	void 				*context;
-	int				flags;
+	size_t 		size;
+	size_t 		alignment;
+	size_t	 	max_cnt;
+	size_t 		chunk_cnt;
+	int		(*alloc_fn)(struct ofi_bufpool_region *region);
+	void		(*free_fn)(struct ofi_bufpool_region *region);
+	void		(*init_fn)(struct ofi_bufpool_region *region, void *buf);
+	void 		*context;
+	int		flags;
 };
 
 struct ofi_bufpool {

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -280,7 +280,7 @@ static inline void name ## _free(struct name *fs)		\
 enum {
 	OFI_BUFPOOL_INDEXED		= 1 << 1,
 	OFI_BUFPOOL_NO_TRACK		= 1 << 2,
-	OFI_BUFPOOL_MMAPPED		= 1 << 3,
+	OFI_BUFPOOL_HUGEPAGES		= 1 << 3,
 };
 
 struct ofi_bufpool_region;

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -341,14 +341,14 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 static inline int
 ofi_bufpool_create(struct ofi_bufpool **buf_pool,
 		   size_t size, size_t alignment,
-		   size_t max_cnt, size_t chunk_cnt)
+		   size_t max_cnt, size_t chunk_cnt, int flags)
 {
 	struct ofi_bufpool_attr attr = {
 		.size		= size,
 		.alignment 	= alignment,
 		.max_cnt	= max_cnt,
 		.chunk_cnt	= chunk_cnt,
-		.flags		= 0,
+		.flags		= flags,
 	};
 	return ofi_bufpool_create_attr(&attr, buf_pool);
 }

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -342,20 +342,25 @@ struct ofi_bufpool_hdr {
 int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 			    struct ofi_bufpool **buf_pool);
 
-int ofi_bufpool_create_ex(struct ofi_bufpool **buf_pool,
-			  size_t size, size_t alignment,
-			  size_t max_cnt, size_t chunk_cnt,
-			  ofi_bufpool_alloc_fn alloc_fn,
-			  ofi_bufpool_free_fn free_fn,
-			  void *pool_ctx);
-
-static inline int ofi_bufpool_create(struct ofi_bufpool **pool,
-				     size_t size, size_t alignment,
-				     size_t max_cnt, size_t chunk_cnt)
+static inline int
+ofi_bufpool_create(struct ofi_bufpool **buf_pool,
+		   size_t size, size_t alignment,
+		   size_t max_cnt, size_t chunk_cnt,
+		   ofi_bufpool_alloc_fn alloc_fn,
+		   ofi_bufpool_free_fn free_fn,
+		   void *pool_ctx)
 {
-	return ofi_bufpool_create_ex(pool, size, alignment,
-				     max_cnt, chunk_cnt,
-				     NULL, NULL, NULL);
+	struct ofi_bufpool_attr attr = {
+		.size		= size,
+		.alignment 	= alignment,
+		.max_cnt	= max_cnt,
+		.chunk_cnt	= chunk_cnt,
+		.alloc_fn	= alloc_fn,
+		.free_fn	= free_fn,
+		.context	= pool_ctx,
+		.flags		= 0,
+	};
+	return ofi_bufpool_create_attr(&attr, buf_pool);
 }
 
 void ofi_bufpool_destroy(struct ofi_bufpool *pool);

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -345,19 +345,13 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 static inline int
 ofi_bufpool_create(struct ofi_bufpool **buf_pool,
 		   size_t size, size_t alignment,
-		   size_t max_cnt, size_t chunk_cnt,
-		   ofi_bufpool_alloc_fn alloc_fn,
-		   ofi_bufpool_free_fn free_fn,
-		   void *pool_ctx)
+		   size_t max_cnt, size_t chunk_cnt)
 {
 	struct ofi_bufpool_attr attr = {
 		.size		= size,
 		.alignment 	= alignment,
 		.max_cnt	= max_cnt,
 		.chunk_cnt	= chunk_cnt,
-		.alloc_fn	= alloc_fn,
-		.free_fn	= free_fn,
-		.context	= pool_ctx,
 		.flags		= 0,
 	};
 	return ofi_bufpool_create_attr(&attr, buf_pool);

--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -514,7 +514,7 @@ int efa_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	}
 
 	ret = ofi_bufpool_create(&cq->wce_pool, sizeof(struct efa_wce), 16, 0,
-				 EFA_WCE_CNT, NULL, NULL, NULL);
+				 EFA_WCE_CNT);
 	if (ret) {
 		EFA_WARN(FI_LOG_CQ, "Failed to create wce_pool\n");
 		goto err_destroy_cq;

--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -514,7 +514,7 @@ int efa_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	}
 
 	ret = ofi_bufpool_create(&cq->wce_pool, sizeof(struct efa_wce), 16, 0,
-				 EFA_WCE_CNT);
+				 EFA_WCE_CNT, 0);
 	if (ret) {
 		EFA_WARN(FI_LOG_CQ, "Failed to create wce_pool\n");
 		goto err_destroy_cq;

--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -513,7 +513,8 @@ int efa_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		goto err_free_cq;
 	}
 
-	ret = ofi_bufpool_create(&cq->wce_pool, sizeof(struct efa_wce), 16, 0, EFA_WCE_CNT);
+	ret = ofi_bufpool_create(&cq->wce_pool, sizeof(struct efa_wce), 16, 0,
+				 EFA_WCE_CNT, NULL, NULL, NULL);
 	if (ret) {
 		EFA_WARN(FI_LOG_CQ, "Failed to create wce_pool\n");
 		goto err_destroy_cq;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2327,8 +2327,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (rxr_env.rx_copy_unexp) {
 		ret = ofi_bufpool_create(&ep->rx_unexp_pkt_pool, entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_get_rx_pool_chunk_cnt(ep),
-					 NULL, NULL, NULL);
+					 rxr_get_rx_pool_chunk_cnt(ep));
 
 		if (ret)
 			goto err_free_rx_pool;
@@ -2337,8 +2336,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (rxr_env.rx_copy_ooo) {
 		ret = ofi_bufpool_create(&ep->rx_ooo_pkt_pool, entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_env.recvwin_size,
-					 NULL, NULL, NULL);
+					 rxr_env.recvwin_size);
 
 		if (ret)
 			goto err_free_rx_unexp_pool;
@@ -2347,8 +2345,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	ret = ofi_bufpool_create(&ep->tx_entry_pool,
 				 sizeof(struct rxr_tx_entry),
 				 RXR_BUF_POOL_ALIGNMENT,
-				 ep->tx_size, ep->tx_size,
-				 NULL, NULL, NULL);
+				 ep->tx_size, ep->tx_size);
 	if (ret)
 		goto err_free_rx_ooo_pool;
 
@@ -2356,7 +2353,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 				 sizeof(struct rxr_rx_entry),
 				 RXR_BUF_POOL_ALIGNMENT,
 				 RXR_MAX_RX_QUEUE_SIZE,
-				 ep->rx_size, NULL, NULL, NULL);
+				 ep->rx_size);
 	if (ret)
 		goto err_free_tx_entry_pool;
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2297,7 +2297,7 @@ static int rxr_create_pkt_pool(struct rxr_ep *ep, size_t size,
 					rxr_buf_region_free_hndlr : NULL,
 		.init_fn	= NULL,
 		.context	= rxr_ep_domain(ep),
-		.flags		= OFI_BUFPOOL_MMAPPED,
+		.flags		= OFI_BUFPOOL_HUGEPAGES,
 	};
 
 	return ofi_bufpool_create_attr(&attr, buf_pool);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2327,7 +2327,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (rxr_env.rx_copy_unexp) {
 		ret = ofi_bufpool_create(&ep->rx_unexp_pkt_pool, entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_get_rx_pool_chunk_cnt(ep));
+					 rxr_get_rx_pool_chunk_cnt(ep), 0);
 
 		if (ret)
 			goto err_free_rx_pool;
@@ -2336,7 +2336,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (rxr_env.rx_copy_ooo) {
 		ret = ofi_bufpool_create(&ep->rx_ooo_pkt_pool, entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_env.recvwin_size);
+					 rxr_env.recvwin_size, 0);
 
 		if (ret)
 			goto err_free_rx_unexp_pool;
@@ -2345,7 +2345,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 	ret = ofi_bufpool_create(&ep->tx_entry_pool,
 				 sizeof(struct rxr_tx_entry),
 				 RXR_BUF_POOL_ALIGNMENT,
-				 ep->tx_size, ep->tx_size);
+				 ep->tx_size, ep->tx_size, 0);
 	if (ret)
 		goto err_free_rx_ooo_pool;
 
@@ -2353,7 +2353,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 				 sizeof(struct rxr_rx_entry),
 				 RXR_BUF_POOL_ALIGNMENT,
 				 RXR_MAX_RX_QUEUE_SIZE,
-				 ep->rx_size);
+				 ep->rx_size, 0);
 	if (ret)
 		goto err_free_tx_entry_pool;
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2327,7 +2327,8 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (rxr_env.rx_copy_unexp) {
 		ret = ofi_bufpool_create(&ep->rx_unexp_pkt_pool, entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_get_rx_pool_chunk_cnt(ep));
+					 rxr_get_rx_pool_chunk_cnt(ep),
+					 NULL, NULL, NULL);
 
 		if (ret)
 			goto err_free_rx_pool;
@@ -2336,7 +2337,8 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (rxr_env.rx_copy_ooo) {
 		ret = ofi_bufpool_create(&ep->rx_ooo_pkt_pool, entry_sz,
 					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_env.recvwin_size);
+					 rxr_env.recvwin_size,
+					 NULL, NULL, NULL);
 
 		if (ret)
 			goto err_free_rx_unexp_pool;
@@ -2345,7 +2347,8 @@ int rxr_ep_init(struct rxr_ep *ep)
 	ret = ofi_bufpool_create(&ep->tx_entry_pool,
 				 sizeof(struct rxr_tx_entry),
 				 RXR_BUF_POOL_ALIGNMENT,
-				 ep->tx_size, ep->tx_size);
+				 ep->tx_size, ep->tx_size,
+				 NULL, NULL, NULL);
 	if (ret)
 		goto err_free_rx_ooo_pool;
 
@@ -2353,7 +2356,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 				 sizeof(struct rxr_rx_entry),
 				 RXR_BUF_POOL_ALIGNMENT,
 				 RXR_MAX_RX_QUEUE_SIZE,
-				 ep->rx_size);
+				 ep->rx_size, NULL, NULL, NULL);
 	if (ret)
 		goto err_free_tx_entry_pool;
 

--- a/prov/mlx/src/mlx_domain.c
+++ b/prov/mlx/src/mlx_domain.c
@@ -118,7 +118,7 @@ int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	ofi_status = ofi_bufpool_create(&domain->fast_path_pool,
 					sizeof(struct mlx_request),
-					16, 0, 1024);
+					16, 0, 1024, 0);
 	if (ofi_status)
 		goto cleanup_mlx;
 

--- a/prov/mlx/src/mlx_domain.c
+++ b/prov/mlx/src/mlx_domain.c
@@ -118,7 +118,7 @@ int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	ofi_status = ofi_bufpool_create(&domain->fast_path_pool,
 					sizeof(struct mlx_request),
-					16, 0, 1024, NULL, NULL, NULL);
+					16, 0, 1024);
 	if (ofi_status)
 		goto cleanup_mlx;
 

--- a/prov/mlx/src/mlx_domain.c
+++ b/prov/mlx/src/mlx_domain.c
@@ -118,7 +118,7 @@ int mlx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 
 	ofi_status = ofi_bufpool_create(&domain->fast_path_pool,
 					sizeof(struct mlx_request),
-					16, 0, 1024);
+					16, 0, 1024, NULL, NULL, NULL);
 	if (ofi_status)
 		goto cleanup_mlx;
 

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -649,7 +649,7 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 
 	ret = ofi_bufpool_create(&mrail_ep->ooo_recv_pool,
 				 sizeof(struct mrail_ooo_recv),
-				 sizeof(void *), 0, 64);
+				 sizeof(void *), 0, 64, 0);
 	if (!mrail_ep->ooo_recv_pool)
 		goto err;
 
@@ -661,7 +661,7 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 		    (mrail_ep->num_eps * sizeof(struct mrail_subreq)));
 
 	ret = ofi_bufpool_create(&mrail_ep->req_pool, buf_size,
-				 sizeof(void *), 0, 64);
+				 sizeof(void *), 0, 64, OFI_BUFPOOL_HUGEPAGES);
 	if (ret)
 		goto err;
 	return 0;

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -649,8 +649,7 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 
 	ret = ofi_bufpool_create(&mrail_ep->ooo_recv_pool,
 				 sizeof(struct mrail_ooo_recv),
-				 sizeof(void *), 0, 64,
-				 NULL, NULL, NULL);
+				 sizeof(void *), 0, 64);
 	if (!mrail_ep->ooo_recv_pool)
 		goto err;
 
@@ -662,8 +661,7 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 		    (mrail_ep->num_eps * sizeof(struct mrail_subreq)));
 
 	ret = ofi_bufpool_create(&mrail_ep->req_pool, buf_size,
-				 sizeof(void *), 0, 64,
-				 NULL, NULL, NULL);
+				 sizeof(void *), 0, 64);
 	if (ret)
 		goto err;
 	return 0;

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -649,7 +649,8 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 
 	ret = ofi_bufpool_create(&mrail_ep->ooo_recv_pool,
 				 sizeof(struct mrail_ooo_recv),
-				 sizeof(void *), 0, 64);
+				 sizeof(void *), 0, 64,
+				 NULL, NULL, NULL);
 	if (!mrail_ep->ooo_recv_pool)
 		goto err;
 
@@ -661,7 +662,8 @@ static int mrail_ep_alloc_bufs(struct mrail_ep *mrail_ep)
 		    (mrail_ep->num_eps * sizeof(struct mrail_subreq)));
 
 	ret = ofi_bufpool_create(&mrail_ep->req_pool, buf_size,
-				 sizeof(void *), 0, 64);
+				 sizeof(void *), 0, 64,
+				 NULL, NULL, NULL);
 	if (ret)
 		goto err;
 	return 0;

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -268,7 +268,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 
 	err = ofi_bufpool_create(&trx_ctxt->am_req_pool,
 				 sizeof(struct psmx2_am_request),
-				 sizeof(void *), 0, 64);
+				 sizeof(void *), 0, 64, 0);
 	if (err) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"failed to allocate am_req_pool.\n");

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -268,7 +268,8 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 
 	err = ofi_bufpool_create(&trx_ctxt->am_req_pool,
 				 sizeof(struct psmx2_am_request),
-				 sizeof(void *), 0, 64);
+				 sizeof(void *), 0, 64,
+				 NULL, NULL, NULL);
 	if (err) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"failed to allocate am_req_pool.\n");

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -268,8 +268,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 
 	err = ofi_bufpool_create(&trx_ctxt->am_req_pool,
 				 sizeof(struct psmx2_am_request),
-				 sizeof(void *), 0, 64,
-				 NULL, NULL, NULL);
+				 sizeof(void *), 0, 64);
 	if (err) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"failed to allocate am_req_pool.\n");

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1047,6 +1047,7 @@ int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 	pkt_attr.alloc_fn = ep->do_local_mr ? rxd_buf_region_alloc_fn : NULL;
 	pkt_attr.free_fn = ep->do_local_mr ? rxd_buf_region_free_fn : NULL;
 	pkt_attr.context = rxd_domain;
+	pkt_attr.flags = OFI_BUFPOOL_HUGEPAGES;
 
 	ret = ofi_bufpool_create_attr(&pkt_attr, &ep->tx_pkt_pool);
 	if (ret)
@@ -1061,7 +1062,8 @@ int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 	entry_attr.alignment = RXD_BUF_POOL_ALIGNMENT;
 	entry_attr.max_cnt = (size_t) ((uint16_t) (~0));
 	entry_attr.chunk_cnt = ep->tx_size;
-	entry_attr.flags = OFI_BUFPOOL_INDEXED | OFI_BUFPOOL_NO_TRACK;
+	entry_attr.flags = OFI_BUFPOOL_INDEXED | OFI_BUFPOOL_NO_TRACK |
+			   OFI_BUFPOOL_HUGEPAGES;
 
 	ret = ofi_bufpool_create_attr(&entry_attr, &ep->tx_entry_pool);
 	if (ret)

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1037,40 +1037,38 @@ static void rxd_buf_region_free_fn(struct ofi_bufpool_region *region)
 int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 {
 	struct rxd_domain *rxd_domain = rxd_ep_domain(ep);
-	struct ofi_bufpool_attr entry_pool_attr = {
-		.size		= sizeof(struct rxd_x_entry),
-		.alignment	= RXD_BUF_POOL_ALIGNMENT,
-		.max_cnt	= (size_t) ((uint16_t) (~0)),
-		.flags		= OFI_BUFPOOL_INDEXED,
-	};
+	struct ofi_bufpool_attr pkt_attr = { 0 };
+	struct ofi_bufpool_attr entry_attr = { 0 };
 	int ret;
 
-	ret = ofi_bufpool_create(&ep->tx_pkt_pool,
-			rxd_domain->max_mtu_sz + sizeof(struct rxd_pkt_entry),
-			RXD_BUF_POOL_ALIGNMENT, 0, RXD_TX_POOL_CHUNK_CNT,
-			ep->do_local_mr ? rxd_buf_region_alloc_fn : NULL,
-			ep->do_local_mr ? rxd_buf_region_free_fn : NULL,
-			rxd_domain);
+	pkt_attr.size = rxd_domain->max_mtu_sz + sizeof(struct rxd_pkt_entry);
+	pkt_attr.alignment = RXD_BUF_POOL_ALIGNMENT;
+	pkt_attr.chunk_cnt = RXD_TX_POOL_CHUNK_CNT;
+	pkt_attr.alloc_fn = ep->do_local_mr ? rxd_buf_region_alloc_fn : NULL;
+	pkt_attr.free_fn = ep->do_local_mr ? rxd_buf_region_free_fn : NULL;
+	pkt_attr.context = rxd_domain;
+
+	ret = ofi_bufpool_create_attr(&pkt_attr, &ep->tx_pkt_pool);
 	if (ret)
 		return ret;
 
-	ret = ofi_bufpool_create(&ep->rx_pkt_pool,
-			rxd_domain->max_mtu_sz + sizeof (struct rxd_pkt_entry),
-			RXD_BUF_POOL_ALIGNMENT, 0, RXD_RX_POOL_CHUNK_CNT,
-			ep->do_local_mr ? rxd_buf_region_alloc_fn : NULL,
-			ep->do_local_mr ? rxd_buf_region_free_fn : NULL,
-			rxd_domain);
+	pkt_attr.chunk_cnt = RXD_RX_POOL_CHUNK_CNT;
+	ret = ofi_bufpool_create_attr(&pkt_attr, &ep->rx_pkt_pool);
 	if (ret)
 		goto err;
 
-	entry_pool_attr.flags |= OFI_BUFPOOL_NO_TRACK;
-	entry_pool_attr.chunk_cnt = ep->tx_size;
-	ret = ofi_bufpool_create_attr(&entry_pool_attr, &ep->tx_entry_pool);
+	entry_attr.size = sizeof(struct rxd_x_entry);
+	entry_attr.alignment = RXD_BUF_POOL_ALIGNMENT;
+	entry_attr.max_cnt = (size_t) ((uint16_t) (~0));
+	entry_attr.chunk_cnt = ep->tx_size;
+	entry_attr.flags = OFI_BUFPOOL_INDEXED | OFI_BUFPOOL_NO_TRACK;
+
+	ret = ofi_bufpool_create_attr(&entry_attr, &ep->tx_entry_pool);
 	if (ret)
 		goto err;
 
-	entry_pool_attr.chunk_cnt = ep->rx_size;
-	ret = ofi_bufpool_create_attr(&entry_pool_attr, &ep->rx_entry_pool);
+	entry_attr.chunk_cnt = ep->rx_size;
+	ret = ofi_bufpool_create_attr(&entry_attr, &ep->rx_entry_pool);
 	if (ret)
 		goto err;
 

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1045,7 +1045,7 @@ int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 	};
 	int ret;
 
-	ret = ofi_bufpool_create_ex(&ep->tx_pkt_pool,
+	ret = ofi_bufpool_create(&ep->tx_pkt_pool,
 			rxd_domain->max_mtu_sz + sizeof(struct rxd_pkt_entry),
 			RXD_BUF_POOL_ALIGNMENT, 0, RXD_TX_POOL_CHUNK_CNT,
 			ep->do_local_mr ? rxd_buf_region_alloc_fn : NULL,
@@ -1054,7 +1054,7 @@ int rxd_ep_init_res(struct rxd_ep *ep, struct fi_info *fi_info)
 	if (ret)
 		return ret;
 
-	ret = ofi_bufpool_create_ex(&ep->rx_pkt_pool,
+	ret = ofi_bufpool_create(&ep->rx_pkt_pool,
 			rxd_domain->max_mtu_sz + sizeof (struct rxd_pkt_entry),
 			RXD_BUF_POOL_ALIGNMENT, 0, RXD_RX_POOL_CHUNK_CNT,
 			ep->do_local_mr ? rxd_buf_region_alloc_fn : NULL,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -273,7 +273,7 @@ static int rxm_buf_pool_create(struct rxm_ep *rxm_ep,
 		.free_fn	= rxm_buf_close,
 		.init_fn	= rxm_buf_init,
 		.context	= pool,
-		.flags		= OFI_BUFPOOL_NO_TRACK,
+		.flags		= OFI_BUFPOOL_NO_TRACK | OFI_BUFPOOL_HUGEPAGES,
 	};
 
 	pool->rxm_ep = rxm_ep;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2699,14 +2699,14 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 
 	
 	ret = ofi_bufpool_create(&pe->pe_rx_pool,
-				 sizeof(struct sock_pe_entry), 16, 0, 1024);
+				 sizeof(struct sock_pe_entry), 16, 0, 1024, 0);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to create buffer pool\n");
 		goto err1;
 	}
 
 	ret = ofi_bufpool_create(&pe->atomic_rx_pool,
-				 SOCK_EP_MAX_ATOMIC_SZ, 16, 0, 32);
+				 SOCK_EP_MAX_ATOMIC_SZ, 16, 0, 32, 0);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to create atomic rx buffer pool\n");
 		goto err2;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2699,14 +2699,16 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 
 	
 	ret = ofi_bufpool_create(&pe->pe_rx_pool,
-				 sizeof(struct sock_pe_entry), 16, 0, 1024);
+				 sizeof(struct sock_pe_entry), 16, 0, 1024,
+				 NULL, NULL, NULL);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to create buffer pool\n");
 		goto err1;
 	}
 
 	ret = ofi_bufpool_create(&pe->atomic_rx_pool,
-				 SOCK_EP_MAX_ATOMIC_SZ, 16, 0, 32);
+				 SOCK_EP_MAX_ATOMIC_SZ, 16, 0, 32,
+				 NULL, NULL, NULL);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to create atomic rx buffer pool\n");
 		goto err2;

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2699,16 +2699,14 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 
 	
 	ret = ofi_bufpool_create(&pe->pe_rx_pool,
-				 sizeof(struct sock_pe_entry), 16, 0, 1024,
-				 NULL, NULL, NULL);
+				 sizeof(struct sock_pe_entry), 16, 0, 1024);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to create buffer pool\n");
 		goto err1;
 	}
 
 	ret = ofi_bufpool_create(&pe->atomic_rx_pool,
-				 SOCK_EP_MAX_ATOMIC_SZ, 16, 0, 32,
-				 NULL, NULL, NULL);
+				 SOCK_EP_MAX_ATOMIC_SZ, 16, 0, 32);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to create atomic rx buffer pool\n");
 		goto err2;

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -236,6 +236,7 @@ static int tcpx_buf_pools_create(struct tcpx_buf_pool *buf_pools)
 		.alignment = 16,
 		.chunk_cnt = 1024,
 		.init_fn = tcpx_buf_pool_init,
+		.flags = OFI_BUFPOOL_HUGEPAGES,
 	};
 
 	for (i = 0; i < TCPX_OP_CODE_MAX; i++) {

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -87,7 +87,8 @@ static int tcpx_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
 		goto err1;
 
 	ret = ofi_bufpool_create(&srx_ctx->buf_pool,
-				 sizeof(struct tcpx_xfer_entry), 16, 0, 1024);
+				 sizeof(struct tcpx_xfer_entry), 16, 0, 1024,
+				 OFI_BUFPOOL_HUGEPAGES);
 	if (ret)
 		goto err2;
 

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -87,8 +87,7 @@ static int tcpx_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
 		goto err1;
 
 	ret = ofi_bufpool_create(&srx_ctx->buf_pool,
-				 sizeof(struct tcpx_xfer_entry), 16, 0, 1024,
-				 NULL, NULL, NULL);
+				 sizeof(struct tcpx_xfer_entry), 16, 0, 1024);
 	if (ret)
 		goto err2;
 

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -87,7 +87,8 @@ static int tcpx_srx_ctx(struct fid_domain *domain, struct fi_rx_attr *attr,
 		goto err1;
 
 	ret = ofi_bufpool_create(&srx_ctx->buf_pool,
-				 sizeof(struct tcpx_xfer_entry), 16, 0, 1024);
+				 sizeof(struct tcpx_xfer_entry), 16, 0, 1024,
+				 NULL, NULL, NULL);
 	if (ret)
 		goto err2;
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -431,7 +431,8 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 		.max_cnt	= 0,
 		/* Don't use track of buffer, because user can close
 		 * the AV without prior deletion of addresses */
-		.flags		= OFI_BUFPOOL_NO_TRACK | OFI_BUFPOOL_INDEXED,
+		.flags		= OFI_BUFPOOL_NO_TRACK | OFI_BUFPOOL_INDEXED |
+				  OFI_BUFPOOL_HUGEPAGES,
 	};
 
 	/* TODO: Handle FI_READ */

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -49,11 +49,6 @@ static void ofi_bufpool_set_region_size(struct ofi_bufpool *pool)
 {
 	ssize_t hp_size;
 
-	if (pool->entry_cnt) {
-		assert(pool->alloc_size && pool->region_size);
-		return;
-	}
-
 	hp_size = ofi_get_hugepage_size();
 	if (hp_size <= 0)
 		pool->attr.flags &= ~OFI_BUFPOOL_MMAPPED;
@@ -77,7 +72,6 @@ int ofi_bufpool_grow(struct ofi_bufpool *pool)
 	if (pool->attr.max_cnt && pool->entry_cnt >= pool->attr.max_cnt)
 		return -FI_EINVAL;
 
-	ofi_bufpool_set_region_size(pool);
 	buf_region = calloc(1, sizeof(*buf_region));
 	if (!buf_region)
 		return -FI_ENOSPC;
@@ -212,6 +206,8 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 		dlist_init(&(*buf_pool)->free_list.regions);
 	else
 		slist_init(&(*buf_pool)->free_list.entries);
+
+	ofi_bufpool_set_region_size(*buf_pool);
 
 	return FI_SUCCESS;
 }

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -55,6 +55,9 @@ static void ofi_bufpool_set_region_size(struct ofi_bufpool *pool)
 	}
 
 	hp_size = ofi_get_hugepage_size();
+	if (hp_size <= 0)
+		pool->attr.flags &= ~OFI_BUFPOOL_MMAPPED;
+
 	if (pool->attr.flags & OFI_BUFPOOL_MMAPPED)
 		pool->alloc_size = ofi_get_aligned_size((pool->attr.chunk_cnt + 1) *
 							pool->entry_size, hp_size);

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -212,25 +212,6 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 	return FI_SUCCESS;
 }
 
-int ofi_bufpool_create_ex(struct ofi_bufpool **buf_pool,
-			    size_t size, size_t alignment,
-			    size_t max_cnt, size_t chunk_cnt,
-			    ofi_bufpool_alloc_fn alloc_fn,
-			    ofi_bufpool_free_fn free_fn,
-			    void *pool_ctx)
-{
-	struct ofi_bufpool_attr attr = {
-		.size		= size,
-		.alignment 	= alignment,
-		.max_cnt	= max_cnt,
-		.chunk_cnt	= chunk_cnt,
-		.alloc_fn	= alloc_fn,
-		.free_fn	= free_fn,
-		.context	= pool_ctx,
-	};
-	return ofi_bufpool_create_attr(&attr, buf_pool);
-}
-
 void ofi_bufpool_destroy(struct ofi_bufpool *pool)
 {
 	struct ofi_bufpool_region *buf_region;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -460,7 +460,7 @@ int ofi_mr_cache_init(struct util_domain *domain,
 	ret = ofi_bufpool_create(&cache->entry_pool,
 				 sizeof(struct ofi_mr_entry) +
 				 cache->entry_data_size,
-				 16, cache_params.max_cnt, 0);
+				 16, cache_params.max_cnt, 0, 0);
 	if (ret)
 		goto del;
 

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -460,8 +460,7 @@ int ofi_mr_cache_init(struct util_domain *domain,
 	ret = ofi_bufpool_create(&cache->entry_pool,
 				 sizeof(struct ofi_mr_entry) +
 				 cache->entry_data_size,
-				 16, cache_params.max_cnt, 0,
-				 NULL, NULL, NULL);
+				 16, cache_params.max_cnt, 0);
 	if (ret)
 		goto del;
 

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -460,7 +460,8 @@ int ofi_mr_cache_init(struct util_domain *domain,
 	ret = ofi_bufpool_create(&cache->entry_pool,
 				 sizeof(struct ofi_mr_entry) +
 				 cache->entry_data_size,
-				 16, cache_params.max_cnt, 0);
+				 16, cache_params.max_cnt, 0,
+				 NULL, NULL, NULL);
 	if (ret)
 		goto del;
 

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -628,7 +628,7 @@ int fi_ibv_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	}
 
 	ret = ofi_bufpool_create(&cq->wce_pool, sizeof(struct fi_ibv_wce),
-				16, 0, VERBS_WCE_CNT);
+				16, 0, VERBS_WCE_CNT, 0);
 	if (ret) {
 		VERBS_WARN(FI_LOG_CQ, "Failed to create wce_pool\n");
 		goto err5;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -628,7 +628,7 @@ int fi_ibv_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	}
 
 	ret = ofi_bufpool_create(&cq->wce_pool, sizeof(struct fi_ibv_wce),
-				16, 0, VERBS_WCE_CNT, NULL, NULL, NULL);
+				16, 0, VERBS_WCE_CNT);
 	if (ret) {
 		VERBS_WARN(FI_LOG_CQ, "Failed to create wce_pool\n");
 		goto err5;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -628,7 +628,7 @@ int fi_ibv_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	}
 
 	ret = ofi_bufpool_create(&cq->wce_pool, sizeof(struct fi_ibv_wce),
-				   16, 0, VERBS_WCE_CNT);
+				16, 0, VERBS_WCE_CNT, NULL, NULL, NULL);
 	if (ret) {
 		VERBS_WARN(FI_LOG_CQ, "Failed to create wce_pool\n");
 		goto err5;


### PR DESCRIPTION
Commit c181344092b6d43359c51173a6c9dbf18b01630f modified the buffer pool in such a way that the default behavior of supporting huge pages was removed, becoming an opt-in model.  This meant that buffer pool usage that could have made use of huge pages was switched back to normal page allocations.

This series updates the buffer pool creation calls to simplify the interface, so that huge pages can more easily be specified.  There are updates to most providers as buffer pool create calls are updated, but they should not affect the functionality of the providers.  The number of patches in this series make the changes look worse than they are.  Only about 100 lines of code change, with a net reduction of about 25 lines.