### PR TITLE
fabric.h: Check that ops exists in FI_CHECK_OP 

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -552,7 +552,7 @@ struct fid_nic {
 };
 
 #define FI_CHECK_OP(ops, opstype, op) \
-	((ops->size > offsetof(opstype, op)) && ops->op)
+	(ops && (ops->size > offsetof(opstype, op)) && ops->op)
 
 static inline int fi_close(struct fid *fid)
 {


### PR DESCRIPTION
This fixes an error where fi_pingpong will segfault if run with
verbose output.

Signed-off-by: Peter Gottesman <pgottesm@cisco.com>