### PR TITLE
/prov/tcp: fix potential deadlock due to lock ordering

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -767,6 +767,10 @@ struct util_event {
 
 int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		 struct fid_eq **eq_fid, void *context);
+int ofi_eq_init(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
+		struct fid_eq *eq_fid, void *context);
+int ofi_eq_control(struct fid *fid, int command, void *arg);
+int ofi_eq_cleanup(struct fid *fid);
 void ofi_eq_remove_fid_events(struct util_eq *eq, fid_t fid);
 void ofi_eq_handle_err_entry(uint32_t api_version, uint64_t flags,
 			     struct fi_eq_err_entry *err_entry,

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -250,6 +250,15 @@ struct tcpx_cq {
 	struct tcpx_buf_pool	buf_pools[TCPX_OP_CODE_MAX];
 };
 
+struct tcpx_eq {
+	struct util_eq		util_eq;
+	/*
+	  The following lock avoids race between ep close
+	  and connection management code.
+	 */
+	fastlock_t		close_lock;
+};
+
 int tcpx_create_fabric(struct fi_fabric_attr *attr,
 		       struct fid_fabric **fabric,
 		       void *context);
@@ -303,7 +312,6 @@ void tcpx_hdr_bswap(struct tcpx_base_hdr *hdr);
 
 int tcpx_ep_shutdown_report(struct tcpx_ep *ep, fid_t fid);
 int tcpx_cq_wait_ep_add(struct tcpx_ep *ep);
-void tcpx_cq_wait_ep_del(struct tcpx_ep *ep);
 void tcpx_tx_queue_insert(struct tcpx_ep *tcpx_ep,
 			  struct tcpx_xfer_entry *tx_entry);
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -727,20 +727,6 @@ int tcpx_cq_wait_ep_add(struct tcpx_ep *ep)
 			       NULL);
 }
 
-void tcpx_cq_wait_ep_del(struct tcpx_ep *ep)
-{
-	fastlock_acquire(&ep->lock);
-	if (ep->cm_state == TCPX_EP_CONNECTING) {
-		goto out;
-	}
-
-	if (ep->util_ep.rx_cq->wait) {
-		ofi_wait_fd_del(ep->util_ep.rx_cq->wait, ep->conn_fd);
-	}
-out:
-	fastlock_release(&ep->lock);
-}
-
 void tcpx_tx_queue_insert(struct tcpx_ep *tcpx_ep,
 			  struct tcpx_xfer_entry *tx_entry)
 {


### PR DESCRIPTION
Currently tcp provider uses eq's internal wait fd to drive connection management progress. when conn is established the ep data progress func pointer is updated to the working one, from a dummy function. It also adds the ep's socket to cq's internal wait, by taking the ep-<lock first and then taking the cq->wait->lock. lets call it PATH-1

When an app wants to block on cq wait obj, it uses fi_cq_sread call. This would check for incoming messages but does not monitor the send queue before going to blocking state. So before try function is used to check and progress if any pending sends are there. Here cq->wait->lock is taken before entering the try func and in try func tcp provider takes the ep->lock. Lets call this PATH-2.

And there is another path(PATH-3), where ep->lock and ep state is used to protect against adding ep socket to cq wait obj after ep close is called. In this case, ep->lock is taken first and cq->wait->lock next.

These paths could be exercised by competing threads based on app design. To solve this potential deadlock :

1) In PATH-1, release the ep->lock before taking the cq->wait->lock.
2) In PATH-3, remove the ep->lock
3) Above two steps removes the protections against adding ep sock to cq wait obj after ep close.
4) For this, another lock is introduced at tcpx eq level.

This fixes the order issue.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>