### PR TITLE
prov/util: Wait full timeout for EQ event in sread

### DIFF
--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -392,7 +392,7 @@ ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 			break;
 
 		if (ofi_adjust_timeout(endtime, &timeout))
-			return -FI_ETIMEDOUT;
+			return -FI_EAGAIN;
 
 		if (ofi_atomic_get32(&cq->signaled)) {
 			ofi_atomic_set32(&cq->signaled, 0);


### PR DESCRIPTION
The ofi_eq_sread() call will wait until the wait set fd is
signaled, then return any event found on the queue.  However,
it's possible that the wait set fd can be signaled without
a user event being written to the EQ.  In this case, we
need to loop until the full timeout has been reached.

This will match the semantics of the CQ and cntr blocking
read calls.

Also update the return value if CQ sread times out.  This
should be -EAGAIN, not -ETIMEDOUT, according to the man pages.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>