### PR TITLE
prov/rxm: Check for SRX use when freeing rx buf msg_ep close

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1384,7 +1384,7 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 				buf, repost_entry);
 
 		/* Discard rx buffer if its msg_ep was closed */
-		if (!buf->conn->msg_ep) {
+		if (!rxm_ep->srx_ctx && !buf->conn->msg_ep) {
 			ofi_buf_free(&buf->hdr);
 			continue;
 		}


### PR DESCRIPTION
Add check to fix SRX use with the PR5123 fixes.

@a-ilango - Let me know if this is sufficient. It enables the use of RXM SRX with the #5123 PR fixes; I was seeing a segfault where the conn was not set.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>