### PR TITLE
prov/mrail,psm2: fix a few covscan defects

### DIFF
--- a/prov/mrail/src/mrail_domain.c
+++ b/prov/mrail/src/mrail_domain.c
@@ -38,11 +38,13 @@ static int mrail_domain_close(fid_t fid)
 		container_of(fid, struct mrail_domain, util_domain.domain_fid.fid);
 	int ret, retv = 0;
 
-	ret = mrail_close_fids((struct fid **)mrail_domain->domains,
-			       mrail_domain->num_domains);
-	if (ret)
-		retv = ret;
-	free(mrail_domain->domains);
+	if (mrail_domain->domains) {
+		ret = mrail_close_fids((struct fid **)mrail_domain->domains,
+				       mrail_domain->num_domains);
+		if (ret)
+			retv = ret;
+		free(mrail_domain->domains);
+	}
 
 	ret = ofi_domain_close(&mrail_domain->util_domain);
 	if (ret)

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -357,7 +357,6 @@ int psmx2_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	uint64_t flags;
 	int err;
 
-	events = FI_CNTR_EVENTS_COMP;
 	flags = 0;
 	domain_priv = container_of(domain, struct psmx2_fid_domain,
 				   util_domain.domain_fid);

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -296,10 +296,8 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	if (err != PSM2_OK) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"psm2_ep_open returns %d, errno=%d\n", err, errno);
-		if (!should_retry) {
-			err = psmx2_errno(err);
+		if (!should_retry)
 			goto err_out_destroy_pool;
-		}
 
 		/* When round-robin fails, retry w/o explicit assignment */
 		opts.unit = -1;
@@ -308,7 +306,6 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 		if (err != PSM2_OK) {
 			FI_WARN(&psmx2_prov, FI_LOG_CORE,
 				"psm2_ep_open retry returns %d, errno=%d\n", err, errno);
-			err = psmx2_errno(err);
 			goto err_out_destroy_pool;
 		}
 	}
@@ -322,7 +319,6 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	if (err != PSM2_OK) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"psm2_mq_init returns %d, errno=%d\n", err, errno);
-		err = psmx2_errno(err);
 		goto err_out_close_ep;
 	}
 


### PR DESCRIPTION
prov/mrail: Fix potential NULL pointer dereference
prov/psm2: Remove unused assignments
