### PR TITLE
prov/rxm: fix segfault in case of enabled shared receive context

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1384,7 +1384,7 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 				buf, repost_entry);
 
 		/* Discard rx buffer if its msg_ep was closed */
-		if (!buf->conn->msg_ep) {
+		if (!buf->ep->srx_ctx && !buf->conn->msg_ep) {
 			ofi_buf_free(&buf->hdr);
 			continue;
 		}


### PR DESCRIPTION
Signed-off-by: Mikhail Khalilov <mikhail.khalilov@intel.com>