### PR TITLE
include/ofi_mem: fix smr_freestack_pop

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -223,7 +223,10 @@ static inline void* smr_freestack_pop_impl(void *fs, void *next)
 
 	local = (char **) fs + ((char **) next -
 		(char **) freestack->base_addr);
-	next = *((void **) local);
+
+	freestack->next = *((void **)local);
+	freestack_init_next(local);
+
 	return freestack_get_user_buf(local);
 }
 


### PR DESCRIPTION
smr_freestack_pop was setting next incorrectly and with no effect

Instead, set freestack->next to the next available entry after the pop.
Also add a re-initialization of the popped element->next for security (like in the normal freestack pop)

Signed-off-by: aingerson <alexia.ingerson@intel.com>