### PR TITLE
fabtests/common: only exchange addresses OOB if requested

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -1085,7 +1085,7 @@ int ft_init_av_dst_addr(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
 	size_t addrlen;
 	int ret;
 
-	if (opts.oob_port) {
+	if (opts.options & FT_OPT_OOB_ADDR_EXCH) {
 		ret = ft_exchange_addresses_oob(av_ptr, ep_ptr, remote_addr);
 		if (ret)
 			return ret;
@@ -1155,7 +1155,7 @@ int ft_init_av_addr(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
 	size_t addrlen;
 	int ret;
 
-	if (opts.oob_port)
+	if (opts.options & FT_OPT_OOB_ADDR_EXCH)
 		return ft_exchange_addresses_oob(av_ptr, ep_ptr, remote_addr);
 
 	if (opts.dst_addr) {


### PR DESCRIPTION
OOB_SYNC and OOB_ADDR_EXCH are separate options. If the oob_port was initialized, it does not necessarily mean an out of band address exchange was requested. Explicitly check this option instead of just the port.

Signed-off-by: aingerson <alexia.ingerson@intel.com>