### PR TITLE
prov/tcp: bugfix: properly check the recv completion

### DIFF
--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -167,7 +167,8 @@ int tcpx_recv_msg_data(struct tcpx_xfer_entry *rx_entry)
 		return (bytes_recvd)? -ofi_sockerr(): -FI_ENOTCONN;
 
 	ofi_consume_iov(rx_entry->iov, &rx_entry->iov_cnt, bytes_recvd);
-	return (rx_entry->iov[0].iov_len)? -FI_EAGAIN: FI_SUCCESS;
+	return (rx_entry->iov_cnt && rx_entry->iov[0].iov_len)?
+		-FI_EAGAIN: FI_SUCCESS;
 }
 
 int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf)


### PR DESCRIPTION
In case of recvs, tcp provider uses ofi_consume_iov to resize the recv buffer to the remaining msg len. ofi_consume_iov is optimized for single iov. Checking the iov[0]'s length for completion is sufficient for that case but not sufficient for multiple iov case. So added another check for iov_count along with iov[0]'s length to indicate recv completion.

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>