### PR TITLE
prov/util: enable epoll fallback in util provider

### DIFF
--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -292,12 +292,8 @@ static int util_wait_fd_control(struct fid *fid, int command, void *arg)
 	wait = container_of(fid, struct util_wait_fd, util_wait.wait_fid.fid);
 	switch (command) {
 	case FI_GETWAIT:
-#ifdef HAVE_EPOLL
 		*(int *) arg = wait->epoll_fd;
 		ret = 0;
-#else
-		ret = -FI_ENOSYS;
-#endif
 		break;
 	default:
 		FI_INFO(wait->util_wait.prov, FI_LOG_FABRIC,


### PR DESCRIPTION
Enabled epoll fallback in util provider for systems
without epoll functionality, like Windows.
For those systems, fi_epoll_ functions with poll-based
implementation from src/common.c will be used  to
wait for events (for example, in ofi_cntr_wait).

Signed-off-by: Andrey Lobanov <andrey.lobanov@intel.com>