### PR TITLE
core/mr_cache: Do not add uncached regions to cache tracking

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -242,6 +242,8 @@ struct ofi_mr_cache {
 
 	size_t				cached_cnt;
 	size_t				cached_size;
+	size_t				uncached_cnt;
+	size_t				uncached_size;
 	size_t				search_cnt;
 	size_t				delete_cnt;
 	size_t				hit_cnt;


### PR DESCRIPTION
If a memory region is not added to the cache, do not include it
as part of the cache_cnt or cache_size. This will eventually be
used to separate cacheable from non-cacheable registrations.
Plus it avoids reporting that the cache is full because an
uncached registration is active.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>