### PR TITLE
NEWS: update shm and rxd news for 1.8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,9 @@ v1.8.0, Fri Jun 28, 2019
 - Update and simplify protocol headers
 - Optimize packet initialization
 - Various improvements handling protocol messages
+- Remove pending_cnt tracking (moved to verbs provider)
+- Fix setting of mr_mode on getinfo
+- Handle error unpacking packet headers properly
 
 ## RxM
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,9 @@ v1.8.0, Fri Jun 28, 2019
 
 ## SHM
 
+- Fix possible segfault
+- Fix smr_freestack_pop to properly remove entry from stack
+
 ## TCP
 
 - Enable multi-recv support


### PR DESCRIPTION
Includes recent coverity fixes and missed mr_mode handling and pending_cnt updates