### PR TITLE
core: Add support for traffic class selection

### DIFF
--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -111,7 +111,7 @@ extern "C" {
  * name appended with the ABI version that it is compatible with.
  */
 
-#define CURRENT_ABI "FABRIC_1.2"
+#define CURRENT_ABI "FABRIC_1.3"
 
 #if  HAVE_ALIAS_ATTRIBUTE == 1
 #define DEFAULT_SYMVER_PRE(a) a##_

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -330,7 +330,6 @@ enum {
 	FI_TC_BULK_DATA,
 	FI_TC_SCAVENGER,
 	FI_TC_NETWORK_CTRL,
-	FI_TC_REALTIME_STREAM, /* TODO: pending description @shefty */
 };
 
 /* Mode bits */
@@ -382,7 +381,6 @@ struct fi_ep_attr {
 	size_t			rx_ctx_cnt;
 	size_t			auth_key_size;
 	uint8_t			*auth_key;
-	uint32_t		tclass;
 };
 
 struct fi_domain_attr {

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -316,6 +316,23 @@ enum {
 	FI_PROTO_EFA
 };
 
+#define FI_TC_PROV_SPECIFIC (1UL << 31)
+#define FI_TC_DSCP_SET(value) ((value) | FI_TC_DSCP)
+#define FI_TC_DSCP_GET(value) ((value) & ~FI_TC_DSCP)
+
+enum {
+	FI_TC_UNSPEC = 0,
+	FI_TC_DSCP = 0x100,
+	FI_TC_LABEL = 0x200,
+	FI_TC_BEST_EFFORT = FI_TC_LABEL,
+	FI_TC_LOW_LATENCY,
+	FI_TC_DEDICATED_ACCESS,
+	FI_TC_BULK_DATA,
+	FI_TC_SCAVENGER,
+	FI_TC_NETWORK_CTRL,
+	FI_TC_REALTIME_STREAM, /* TODO: pending description @shefty */
+};
+
 /* Mode bits */
 #define FI_CONTEXT		(1ULL << 59)
 #define FI_MSG_PREFIX		(1ULL << 58)
@@ -337,6 +354,7 @@ struct fi_tx_attr {
 	size_t			size;
 	size_t			iov_limit;
 	size_t			rma_iov_limit;
+	uint32_t		tclass;
 };
 
 struct fi_rx_attr {
@@ -364,6 +382,7 @@ struct fi_ep_attr {
 	size_t			rx_ctx_cnt;
 	size_t			auth_key_size;
 	uint8_t			*auth_key;
+	uint32_t		tclass;
 };
 
 struct fi_domain_attr {
@@ -393,6 +412,7 @@ struct fi_domain_attr {
 	size_t 			auth_key_size;
 	size_t			max_err_data;
 	size_t			mr_cnt;
+	uint32_t		tclass;
 };
 
 struct fi_fabric_attr {
@@ -665,7 +685,6 @@ struct fi_param {
 
 int fi_getparams(struct fi_param **params, int *count);
 void fi_freeparams(struct fi_param *params);
-
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct.h>

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -31,3 +31,10 @@ FABRIC_1.2 {
 		fi_freeinfo;
 		fi_dupinfo;
 } FABRIC_1.1;
+
+FABRIC_1.3 {
+	global:
+		fi_getinfo;
+		fi_freeinfo;
+		fi_dupinfo;
+} FABRIC_1.2;

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -513,7 +513,6 @@ The following option levels and option names and parameters are defined.
   sized renedezvous protocol message usually results in better latency for the
   overall transfer of a large message.
 
-
 ## fi_rx_size_left (DEPRECATED)
 
 This function has been deprecated and will be removed in a future version
@@ -844,6 +843,7 @@ struct fi_tx_attr {
 	size_t    size;
 	size_t    iov_limit;
 	size_t    rma_iov_limit;
+	uint32_t  tclass;
 };
 {% endhighlight %}
 
@@ -1060,6 +1060,15 @@ fi_atomic.3, for additional details.  This limit applies to both the
 number of RMA IO vectors that may be specified when initiating an
 operation from the local endpoint, as well as the maximum number of
 IO vectors that may be carried in a single request from a remote endpoint.
+
+## Traffic Class (tclass)
+
+The traffic class associated with the transmit attributes.
+
+If the traffic class type is set to FI_TC_UNSPEC, the type and value
+of the traffic class will be inherited from the domain.
+
+See fi_domain.3 for additional information.
 
 # RECEIVE CONTEXT ATTRIBUTES
 

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -122,6 +122,84 @@ struct fi_info_1_1 {
 	struct fi_fabric_attr_1_0	*fabric_attr;
 };
 
+struct fi_tx_attr_1_2 {
+        uint64_t                caps;
+        uint64_t                mode;
+        uint64_t                op_flags;
+        uint64_t                msg_order;
+        uint64_t                comp_order;
+        size_t                  inject_size;
+        size_t                  size;
+        size_t                  iov_limit;
+        size_t                  rma_iov_limit;
+        uint32_t                tclass;
+};
+
+struct fi_ep_attr_1_2 {
+        enum fi_ep_type         type;
+        uint32_t                protocol;
+        uint32_t                protocol_version;
+        size_t                  max_msg_size;
+        size_t                  msg_prefix_size;
+        size_t                  max_order_raw_size;
+        size_t                  max_order_war_size;
+        size_t                  max_order_waw_size;
+        uint64_t                mem_tag_format;
+        size_t                  tx_ctx_cnt;
+        size_t                  rx_ctx_cnt;
+        size_t                  auth_key_size;
+        uint8_t                 *auth_key;
+        uint32_t                tclass;
+};
+
+struct fi_domain_attr_1_2 {
+        struct fid_domain       *domain;
+        char                    *name;
+        enum fi_threading       threading;
+        enum fi_progress        control_progress;
+        enum fi_progress        data_progress;
+        enum fi_resource_mgmt   resource_mgmt;
+        enum fi_av_type         av_type;
+        int                     mr_mode;
+        size_t                  mr_key_size;
+        size_t                  cq_data_size;
+        size_t                  cq_cnt;
+        size_t                  ep_cnt;
+        size_t                  tx_ctx_cnt;
+        size_t                  rx_ctx_cnt;
+        size_t                  max_ep_tx_ctx;
+        size_t                  max_ep_rx_ctx;
+        size_t                  max_ep_stx_ctx;
+        size_t                  max_ep_srx_ctx;
+        size_t                  cntr_cnt;
+        size_t                  mr_iov_limit;
+        uint64_t                caps;
+        uint64_t                mode;
+        uint8_t                 *auth_key;
+        size_t                  auth_key_size;
+        size_t                  max_err_data;
+        size_t                  mr_cnt;
+        uint32_t                tclass;
+};
+
+struct fi_info_1_2 {
+        struct fi_info            *next;
+        uint64_t                  caps;
+        uint64_t                  mode;
+        uint32_t                  addr_format;
+        size_t                    src_addrlen;
+        size_t                    dest_addrlen;
+        void                      *src_addr;
+        void                      *dest_addr;
+        fid_t                     handle;
+        struct fi_tx_attr_1_2     *tx_attr;
+        struct fi_rx_attr         *rx_attr;
+        struct fi_ep_attr_1_2     *ep_attr;
+        struct fi_domain_attr_1_2 *domain_attr;
+        struct fi_fabric_attr     *fabric_attr;
+        struct fid_nic            *nic;
+};
+
 #define ofi_dup_attr(dst, src)				\
 	do {						\
 		dst = calloc(1, sizeof(*dst));		\
@@ -316,3 +394,55 @@ int fi_getinfo_1_1(uint32_t version, const char *node, const char *service,
 	return ret;
 }
 COMPAT_SYMVER(fi_getinfo_1_1, fi_getinfo, FABRIC_1.1);
+
+/*
+ * ABI 1.2
+ */
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
+void fi_freeinfo_1_2(struct fi_info_1_2 *info)
+{
+	fi_freeinfo((struct fi_info *) info);
+}
+COMPAT_SYMVER(fi_freeinfo_1_2, fi_freeinfo, FABRIC_1.2);
+
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
+struct fi_info_1_2 *fi_dupinfo_1_2(const struct fi_info_1_2 *info)
+{
+	struct fi_info *dup, *base;
+
+	if (!info)
+		return (struct fi_info_1_2 *) ofi_allocinfo_internal();
+
+	ofi_dup_attr(base, info);
+	if (base == NULL)
+		return NULL;
+
+	dup = fi_dupinfo(base);
+
+	free(base);
+	return (struct fi_info_1_2 *) dup;
+}
+COMPAT_SYMVER(fi_dupinfo_1_2, fi_dupinfo, FABRIC_1.2);
+
+__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
+int fi_getinfo_1_2(uint32_t version, const char *node, const char *service,
+		   uint64_t flags, const struct fi_info_1_2 *hints_1_2,
+		   struct fi_info_1_2 **info)
+{
+	struct fi_info *hints;
+	int ret;
+
+	if (hints_1_2) {
+		hints = (struct fi_info *) fi_dupinfo_1_2(hints_1_2);
+		if (!hints)
+			return -FI_ENOMEM;
+	} else {
+		hints = NULL;
+	}
+	ret = fi_getinfo(version, node, service, flags, hints,
+			 (struct fi_info **) info);
+	fi_freeinfo(hints);
+
+	return ret;
+}
+COMPAT_SYMVER(fi_getinfo_1_2, fi_getinfo, FABRIC_1.2);


### PR DESCRIPTION
This commit introduces the capability to select a traffic class when
creating libfabric objects with the goal to allow applications to
utilize traffic shaping mechanisms exposed to providers.

In this proposal, the fi_domain, fi_tx_attr, and fi_rx_attributes are
modified to add the new fi_traffic_class structure to the structure definition.
The fi_traffic_class structure provides a 'type' field, indicating the type of
traffic class value that is represented in the 'value' field of the structure.
Two different types of traffic class are presented with this commit; FI_TC_TYPE_LABEL,
and FI_TC_TYPE_DSCP. Libfabric defines generalized traffic classes via community
defined labels and expected behavior for those labels, which fall under the category
of FI_TC_TYPE_LABEL. Providers may also define provider specific labels utilizing the
most significant 32 bits of the value field. To provide applications with greater
control over traffic class selection, this proposal exposes the ability to specify
a specify DSCP value to be associated with libfabric objects, using the value field set
to the DSCP value, and type set to FI_TC_TYPE_DSCP.

Additionally, to simplify the traffic class selection process, this commit introduces
a heirarchal inheritance model with the fi_traffic_class structure. When an fi_domain
is created, the application can choose to select a traffic class, or allow the provider
to select a default traffic class. The traffic class associated with the domain is used
as the default for all objects created within the domain. This allows an
application to request a general traffic class for most traffic flows, while
allowing the application to finely control traffic at the granularity of the tx context
or rx context.

The original proposal to OFIWG did not include the rx context modification. However,
multi-part data transfer operations such as rendezvous messaging benefit from the differentiation of
request and response traffic shaping flows. The traffic class field in the rx attribute is
only intended to apply to these multi-part data transfer operations and does not imply any
relation with the tx attribute of a peer endpoint.

Signed-off-by: James Swaro <jswaro@cray.com>