### PR TITLE
src/windows: Change getifaddrs for chosing the right adapter

### DIFF
--- a/include/windows/ifaddrs.h
+++ b/include/windows/ifaddrs.h
@@ -27,6 +27,7 @@ struct ifaddrs {
 	struct sockaddr_in in_addr;
 	struct sockaddr_in in_netmask;
 	char		   ad_name[16];
+	size_t		   speed;
 };
 
 int getifaddrs(struct ifaddrs **ifap);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -882,10 +882,7 @@ static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[7] == ntohs(1));
 }
 
-static inline size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
-{
-	return 0;
-}
+size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
 
 /* complex operations implementation */
 


### PR DESCRIPTION
1) Rewrote geifddars function for using new api - GetAdaptersAddresses.
Why do we use GetAdaptersAddresses?
- get a field -> Ipv4Metric
- add a possibility to support Ipv6 in future

2) Added an algorithm for sorting adapters under Ipv4Metric, using
IP_ADAPTER_ADDRESSES struct.

"Automatic Metric Assignment" assigns a higher metric to a slower
network interface. So, we sort the gotten metrics from the highest
to the slowest one. Then use the first IFF_UP adapter from linked list,
which we formed based on the metric and use for it as a main interface.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>