### PR TITLE
src/windows: Added support for IPv6 in getifaddrs

### DIFF
--- a/include/windows/ifaddrs.h
+++ b/include/windows/ifaddrs.h
@@ -24,8 +24,9 @@ struct ifaddrs {
 	struct sockaddr *ifa_addr;    /* Address of interface */
 	struct sockaddr *ifa_netmask; /* Netmask of interface */
 
-	struct sockaddr_in in_addr;
-	struct sockaddr_in in_netmask;
+	struct sockaddr_storage in_addrs;
+	struct sockaddr_storage in_netmasks;
+
 	char		   ad_name[16];
 	size_t		   speed;
 };


### PR DESCRIPTION
Added the support of IPv6 mechanism in getifaddrs:
1) Changed ifaddrs struct, defining in_addrs,
   in_netmask fields as sockaddr_storage.
2) Using IP_ADAPTER_ADDRESSES struct made initilization
   for sockaddr_in6 for making the IPv6 address of the
   interface.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>