### PR TITLE
windows/osd: Fix ret = -ENOMEM to include the '='

### DIFF
--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -444,7 +444,7 @@ int getifaddrs(struct ifaddrs **ifap)
 
 			fa = calloc(sizeof(*fa), 1);
 			if (!fa) {
-				ret -FI_ENOMEM;
+				ret = -FI_ENOMEM;
 				goto out;
 			}
 


### PR DESCRIPTION
Does this even compile?  Fix obvious typo to add missing =.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>