### PR TITLE
fabtests/fi_bw: update man page/usage

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -385,6 +385,7 @@ dummy_man_pages = \
 	man/man1/fi_getinfo_test.1 \
 	man/man1/fi_mr_test.1 \
 	man/man1/fi_resource_freeing.1 \
+	man/man1/fi_bw.1 \
 	man/man1/fi_ubertest.1
 
 nroff:

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2704,6 +2704,7 @@ void ft_usage(char *name, char *desc)
 	FT_PRINT_OPTS_USAGE("", "fi_unexpected_msg");
 	FT_PRINT_OPTS_USAGE("", "fi_resmgmt_test");
 	FT_PRINT_OPTS_USAGE("", "fi_inj_complete");
+	FT_PRINT_OPTS_USAGE("", "fi_bw");
 	FT_PRINT_OPTS_USAGE("-M <mode>", "Disable mode bit from test");
 	FT_PRINT_OPTS_USAGE("", "mr_local");
 	FT_PRINT_OPTS_USAGE("-a <address vector name>", "name of address vector");

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -142,6 +142,11 @@ features of libfabric.
   buffer tries to remain the same.  This test is used to validate the
   correct behavior of memory registration caches.
 
+*fi_bw*
+: Performs a one-sided bandwidth test with an option for data verification.
+  A sleep time on the receiving side can be enabled in order to allow
+  the sender to get ahead of the receiver.
+
 # Benchmarks
 
 The client and the server exchange messages in either a ping-pong manner,

--- a/fabtests/man/man1/fi_bw.1
+++ b/fabtests/man/man1/fi_bw.1
@@ -1,0 +1,1 @@
+.so man7/fabtests.7


### PR DESCRIPTION
Add man1/fi_bw.1 to create test man page.
Update man/fabtests.7.md with fi_bw test description.
Add fi_bw (which allows for EP specification) to -e usage list.

Signed-off-by: aingerson <alexia.ingerson@intel.com>