### PR TITLE
prov/rxd: Get rid of every call to rxd_mr_desc

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -291,6 +291,7 @@ struct rxd_pkt_entry {
 	uint64_t timestamp;
 	struct fi_context context;
 	struct fid_mr *mr;
+	void *desc;
 	fi_addr_t peer;
 	void *pkt;
 };


### PR DESCRIPTION
Adding a new field 'desc' to struct rxd_pkt_entry,
we sweat out calling of rxd_mr_desc() and initialize
desc in init_fn().

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>