### PR TITLE
prov/verbs: Cleanup of MR code

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -72,9 +72,14 @@
 extern "C" {
 #endif
 
+/* EQ / CQ flags
+ * ERROR: The added entry was the result of an error completion
+ * OVERFLOW: The CQ has overflowed, and events have been lost
+ */
 #define UTIL_FLAG_ERROR		(1ULL << 60)
 #define UTIL_FLAG_OVERFLOW	(1ULL << 61)
 
+/* Indicates that an EP has been bound to a counter */
 #define OFI_CNTR_ENABLED	(1ULL << 61)
 
 #define OFI_Q_STRERROR(prov, level, subsys, q, q_str, entry, q_strerror)	\

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -178,10 +178,6 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_MIN_RNR_TIMER*
 : Set min_rnr_timer QP attribute (0 - 31) (default: 12)
 
-*FI_VERBS_USE_ODP*
-: Enable On-Demand-Paging (ODP) experimental feature. The feature is supported only
-  on Mellanox OFED (default: 0)
-
 *FI_VERBS_CQREAD_BUNCH_SIZE*
 : The number of entries to be read from the verbs completion queue at a time (default: 8).
 

--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -11,7 +11,6 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 	# Determine if we can support the verbs provider
 	verbs_ibverbs_happy=0
 	verbs_rdmacm_happy=0
-	verbs_ibverbs_exp_happy=0
 	AS_IF([test x"$enable_verbs" != x"no"],
 	      [FI_CHECK_PACKAGE([verbs_ibverbs],
 				[infiniband/verbs.h],
@@ -22,16 +21,6 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 				[$verbs_LIBDIR],
 				[FI_VERBS_DOUBLE_CHECK_LIBIBVERBS],
 				[verbs_ibverbs_happy=0])
-
-	      FI_CHECK_PACKAGE([verbs_ibverbs],
-				[infiniband/verbs_exp.h],
-				[ibverbs],
-				[ibv_open_device],
-				[],
-				[$verbs_PREFIX],
-				[$verbs_LIBDIR],
-				[verbs_ibverbs_exp_happy=1],
-				[verbs_ibverbs_exp_happy=0])
 
 	       FI_CHECK_PACKAGE([verbs_rdmacm],
 				[rdma/rdma_cma.h],
@@ -55,26 +44,8 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 
 	      ])
 
-	AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
-			   [
-			    #include <infiniband/verbs_exp.h>
-			   ],
-			   [
-			    return (IBV_EXP_DEVICE_ATTR_ODP | IBV_EXP_DEVICE_ODP);
-			   ])
-			  ],
-			  [verbs_ibverbs_exp_happy=1],
-			  [verbs_ibverbs_exp_happy=0])
-
 	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
 	       test $verbs_rdmacm_happy -eq 1], [$1], [$2])
-
-	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
-	       test $verbs_rdmacm_happy -eq 1 && \
-	       test $verbs_ibverbs_exp_happy -eq 1],
-		[AC_DEFINE([HAVE_VERBS_EXP_H], [1],
-			   [Experimental verbs features support])],
-		[])
 
 	#See if we have XRC support
 	VERBS_HAVE_XRC=0

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -49,10 +49,6 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.def_rx_iov_limit	= 4,
 	.def_inline_size	= 256,
 	.min_rnr_timer		= VERBS_DEFAULT_MIN_RNR_TIMER,
-	/* Disable by default. Because this feature may corrupt
-	 * data due to IBV_EXP_ACCESS_RELAXED flag. But usage
-	 * this feature w/o this flag leads to poor bandwidth */
-	.use_odp		= 0,
 	.cqread_bunch_size	= 8,
 	.iface			= NULL,
 	.gid_idx		= 0,
@@ -551,15 +547,6 @@ static int fi_ibv_read_params(void)
 	     (fi_ibv_gl_data.min_rnr_timer > 31))) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of min_rnr_timer\n");
-		return -FI_EINVAL;
-	}
-
-	if (fi_ibv_get_param_bool("use_odp", "Enable on-demand paging experimental feature. "
-				  "Currently this feature may corrupt data. "
-				  "Use it on your own risk.",
-				  &fi_ibv_gl_data.use_odp)) {
-		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of use_odp\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -72,11 +72,8 @@
 #include "ofi_tree.h"
 #include "ofi_indexer.h"
 
-#ifdef HAVE_VERBS_EXP_H
-#include <infiniband/verbs_exp.h>
-#endif /* HAVE_VERBS_EXP_H */
-
 #include "ofi_verbs_priv.h"
+
 
 #ifndef AF_IB
 #define AF_IB 27
@@ -145,7 +142,6 @@ extern struct fi_ibv_gl_data {
 	int	def_rx_iov_limit;
 	int	def_inline_size;
 	int	min_rnr_timer;
-	int	use_odp;
 	int	cqread_bunch_size;
 	char	*iface;
 	int	gid_idx;
@@ -332,7 +328,6 @@ struct fi_ibv_domain {
 	} xrc ;
 
 	/* MR stuff */
-	int				use_odp;
 	struct ofi_mr_cache		cache;
 	int 				(*post_send)(struct ibv_qp *qp,
 						     struct ibv_send_wr *wr,

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -224,15 +224,16 @@ static struct fi_ops fi_ibv_mr_cache_fi_ops = {
 int fi_ibv_mr_cache_add_region(struct ofi_mr_cache *cache,
 			       struct ofi_mr_entry *entry)
 {
-	int fi_ibv_access = IBV_ACCESS_LOCAL_WRITE |
-			    IBV_ACCESS_REMOTE_WRITE |
-			    IBV_ACCESS_REMOTE_ATOMIC |
-			    IBV_ACCESS_REMOTE_READ;
-	struct fi_ibv_mem_desc *md = (struct fi_ibv_mem_desc *)entry->data;
+	struct fi_ibv_mem_desc *md = (struct fi_ibv_mem_desc *) entry->data;
+
 	md->domain = container_of(cache->domain, struct fi_ibv_domain, util_domain);
 	md->mr_fid.fid.ops = &fi_ibv_mr_cache_fi_ops;
-	return fi_ibv_mr_reg_common(md, fi_ibv_access, entry->iov.iov_base,
-				    entry->iov.iov_len, NULL);
+	md->entry = entry;
+
+	return fi_ibv_mr_reg_common(md, IBV_ACCESS_LOCAL_WRITE |
+			IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_ATOMIC |
+			IBV_ACCESS_REMOTE_READ, entry->iov.iov_base,
+			entry->iov.iov_len, NULL);
 }
 
 void fi_ibv_mr_cache_delete_region(struct ofi_mr_cache *cache,
@@ -276,8 +277,6 @@ fi_ibv_mr_cache_reg(struct fid *fid, const void *buf, size_t len,
 		return ret;
 
 	md = (struct fi_ibv_mem_desc *) entry->data;
-	md->entry = entry;
-
 	*mr = &md->mr_fid;
 	return FI_SUCCESS;
 }

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -64,21 +64,7 @@ static inline struct ibv_mr *
 fi_ibv_mr_reg_wrapper(struct fi_ibv_domain *domain, void *buf,
 		      size_t len, int fi_ibv_access)
 {	
-#if defined HAVE_VERBS_EXP_H
-	struct ibv_exp_reg_mr_in in = {
-		.pd		= domain->pd,
-		.addr		= buf,
-		.length		= len,
-		.exp_access 	= fi_ibv_access,
-		.comp_mask	= 0,
-	};
-	if (domain->use_odp)
-		in.exp_access |= IBV_EXP_ACCESS_RELAXED |
-				 IBV_EXP_ACCESS_ON_DEMAND;
-	return ibv_exp_reg_mr(&in);
-#else /* HAVE_VERBS_EXP_H */
 	return ibv_reg_mr(domain->pd, buf, len, fi_ibv_access);
-#endif /* HAVE_VERBS_EXP_H */
 }
 
 static int fi_ibv_mr_close(fid_t fid)

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -159,12 +159,6 @@ fi_ibv_mr_ofi2ibv_access(uint64_t ofi_access, struct fi_ibv_domain *domain)
 	return ibv_access;
 }
 
-static inline
-void fi_ibv_common_cache_dereg(struct fi_ibv_mem_desc *md)
-{
-	ofi_mr_cache_delete(&md->domain->cache, md->entry);
-}
-
 static int
 fi_ibv_mr_reg(struct fid *fid, const void *buf, size_t len,
 	      uint64_t access, uint64_t offset, uint64_t requested_key,
@@ -201,8 +195,7 @@ static int fi_ibv_mr_cache_close(fid_t fid)
 	struct fi_ibv_mem_desc *md =
 		container_of(fid, struct fi_ibv_mem_desc, mr_fid.fid);
 	
-	fi_ibv_common_cache_dereg(md);
-
+	ofi_mr_cache_delete(&md->domain->cache, md->entry);
 	return FI_SUCCESS;
 }
 

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2017-2019 Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,44 +33,32 @@
 #include <ofi_util.h>
 #include "fi_verbs.h"
 
-#define FI_IBV_DEFINE_MR_REG_OPS(type)							\
-											\
-static int										\
-fi_ibv_mr ## type ## regv(struct fid *fid, const struct iovec *iov,			\
-			  size_t count, uint64_t access, uint64_t offset,		\
-			  uint64_t requested_key, uint64_t flags,			\
-			  struct fid_mr **mr, void *context)				\
-{											\
-	const struct fi_mr_attr attr = {						\
-		.mr_iov		= iov,							\
-		.iov_count	= count,						\
-		.access		= access,						\
-		.offset		= offset,						\
-		.requested_key	= requested_key,					\
-		.context	= context,						\
-	};										\
-	return fi_ibv_mr ## type ## regattr(fid, &attr, flags, mr);			\
-}											\
-											\
-static int										\
-fi_ibv_mr ## type ## reg(struct fid *fid, const void *buf, size_t len,			\
-			 uint64_t access, uint64_t offset, uint64_t requested_key,	\
-			 uint64_t flags, struct fid_mr **mr, void *context)		\
-{											\
-	const struct iovec iov = {							\
-		.iov_base	= (void *)buf,						\
-		.iov_len	= len,							\
-	};										\
-	return fi_ibv_mr ## type ## regv(fid, &iov, 1, access, offset,			\
-					 requested_key, flags, mr, context);		\
-}											\
-											\
-struct fi_ops_mr fi_ibv_mr ##type## ops = {						\
-	.size = sizeof(struct fi_ops_mr),						\
-	.reg = fi_ibv_mr ## type ## reg,						\
-	.regv = fi_ibv_mr ## type ## regv,						\
-	.regattr = fi_ibv_mr ## type ## regattr,					\
-};
+
+static int
+fi_ibv_mr_regv(struct fid *fid, const struct iovec *iov,
+	       size_t count, uint64_t access, uint64_t offset,
+	       uint64_t requested_key, uint64_t flags,
+	       struct fid_mr **mr, void *context)
+{
+	struct fid_domain *domain = container_of(fid, struct fid_domain, fid);
+
+	if (OFI_UNLIKELY(count > 1))
+		return -FI_EINVAL;
+
+	return count ? fi_mr_reg(domain, (const void *) iov->iov_base,
+				 iov->iov_len, access, offset, requested_key,
+				 flags, mr, context) :
+		       fi_mr_reg(domain, NULL, 0, access, offset, requested_key,
+				 flags, mr, context);
+}
+
+static int fi_ibv_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
+			     uint64_t flags, struct fid_mr **mr)
+{
+	return fi_ibv_mr_regv(fid, attr->mr_iov, attr->iov_count, attr->access,
+			      attr->offset, attr->requested_key, flags, mr,
+			      attr->context);
+}
 
 static inline struct ibv_mr *
 fi_ibv_mr_reg_wrapper(struct fi_ibv_domain *domain, void *buf,
@@ -153,24 +141,6 @@ int fi_ibv_mr_reg_common(struct fi_ibv_mem_desc *md, int fi_ibv_access,
 	return FI_SUCCESS;
 }
 
-static inline
-int fi_ibv_mr_regattr_check_args(struct fid *fid,
-				 const struct fi_mr_attr *attr,
-				 uint64_t flags)
-{
-	if (OFI_UNLIKELY(flags))
-		return -FI_EBADFLAGS;
-	if (OFI_UNLIKELY(fid->fclass != FI_CLASS_DOMAIN))
-		return -FI_EINVAL;
-	if (OFI_UNLIKELY(attr->iov_count > VERBS_MR_IOV_LIMIT)) {
-		VERBS_WARN(FI_LOG_FABRIC,
-			   "iov count > %d not supported\n",
-			   VERBS_MR_IOV_LIMIT);
-		return -FI_EINVAL;
-	}
-	return FI_SUCCESS;
-}
-
 static inline int
 fi_ibv_mr_ofi2ibv_access(uint64_t ofi_access, struct fi_ibv_domain *domain)
 {
@@ -205,7 +175,7 @@ fi_ibv_mr_ofi2ibv_access(uint64_t ofi_access, struct fi_ibv_domain *domain)
 
 static inline struct fi_ibv_mem_desc *
 fi_ibv_mr_common_cache_reg(struct fi_ibv_domain *domain,
-			 struct fi_mr_attr *attr)
+			   struct fi_mr_attr *attr)
 {
 	struct fi_ibv_mem_desc *md;
 	struct ofi_mr_entry *entry;
@@ -227,15 +197,16 @@ void fi_ibv_common_cache_dereg(struct fi_ibv_mem_desc *md)
 	ofi_mr_cache_delete(&md->domain->cache, md->entry);
 }
 
-static int fi_ibv_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
-			     uint64_t flags, struct fid_mr **mr)
+static int
+fi_ibv_mr_reg(struct fid *fid, const void *buf, size_t len,
+	      uint64_t access, uint64_t offset, uint64_t requested_key,
+	      uint64_t flags, struct fid_mr **mr, void *context)
 {
 	struct fi_ibv_mem_desc *md;
 	int ret;
 
-	ret = fi_ibv_mr_regattr_check_args(fid, attr, flags);
-	if (OFI_UNLIKELY(ret))
-		return ret;
+	if (OFI_UNLIKELY(flags))
+		return -FI_EBADFLAGS;
 
 	md = calloc(1, sizeof(*md));
 	if (OFI_UNLIKELY(!md))
@@ -245,10 +216,8 @@ static int fi_ibv_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 				  util_domain.domain_fid.fid);
 	md->mr_fid.fid.ops = &fi_ibv_mr_fi_ops;
 
-	ret = fi_ibv_mr_reg_common(md, fi_ibv_mr_ofi2ibv_access(attr->access,
-								md->domain),
-				   attr->mr_iov[0].iov_base,
-				   attr->mr_iov[0].iov_len, attr->context);
+	ret = fi_ibv_mr_reg_common(md, fi_ibv_mr_ofi2ibv_access(access, md->domain),
+				   buf, len, context);
 	if (OFI_UNLIKELY(ret))
 		goto err;
 
@@ -259,8 +228,6 @@ err:
 	return ret;
 }
 
-FI_IBV_DEFINE_MR_REG_OPS(_)
-
 static int fi_ibv_mr_cache_close(fid_t fid)
 {
 	struct fi_ibv_mem_desc *md =
@@ -270,6 +237,13 @@ static int fi_ibv_mr_cache_close(fid_t fid)
 
 	return FI_SUCCESS;
 }
+
+struct fi_ops_mr fi_ibv_mr_ops = {
+	.size = sizeof(struct fi_ops_mr),
+	.reg = fi_ibv_mr_reg,
+	.regv = fi_ibv_mr_regv,
+	.regattr = fi_ibv_mr_regattr,
+};
 
 static struct fi_ops fi_ibv_mr_cache_fi_ops = {
 	.size = sizeof(struct fi_ops),
@@ -301,25 +275,43 @@ void fi_ibv_mr_cache_delete_region(struct ofi_mr_cache *cache,
 		(void)ibv_dereg_mr(md->mr);
 }
 
-static int fi_ibv_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
-				   uint64_t flags, struct fid_mr **mr)
+static int
+fi_ibv_mr_cache_reg(struct fid *fid, const void *buf, size_t len,
+		    uint64_t access, uint64_t offset, uint64_t requested_key,
+		    uint64_t flags, struct fid_mr **mr, void *context)
 {
 	struct fi_ibv_domain *domain;
 	struct fi_ibv_mem_desc *md;
-	int ret;
+	struct fi_mr_attr attr;
+	struct iovec iov;
 
-	ret = fi_ibv_mr_regattr_check_args(fid, attr, flags);
-	if (OFI_UNLIKELY(ret))
-		return ret;
+	if (OFI_UNLIKELY(flags))
+		return -FI_EBADFLAGS;
 
 	domain = container_of(fid, struct fi_ibv_domain,
 			      util_domain.domain_fid.fid);
 
-	md = fi_ibv_mr_common_cache_reg(domain, (struct fi_mr_attr *)attr);
+	attr.access = access;
+	attr.context = context;
+	attr.iov_count = 1;
+	iov.iov_base = (void *) buf;
+	iov.iov_len = len;
+	attr.mr_iov = &iov;
+	attr.offset = offset;
+	attr.requested_key = requested_key;
+	attr.auth_key_size = 0;
+
+	md = fi_ibv_mr_common_cache_reg(domain, &attr);
 	if (OFI_UNLIKELY(!md))
-		return -FI_EAVAIL;
+		return -FI_ENOMEM;
+
 	*mr = &md->mr_fid;
 	return FI_SUCCESS;
 }
 
-FI_IBV_DEFINE_MR_REG_OPS(_cache_)
+struct fi_ops_mr fi_ibv_mr_cache_ops = {
+	.size = sizeof(struct fi_ops_mr),
+	.reg = fi_ibv_mr_cache_reg,
+	.regv = fi_ibv_mr_regv,
+	.regattr = fi_ibv_mr_regattr,
+};


### PR DESCRIPTION
See individual commits for details.  This is basically prep work for adding a flag that will allow a caller to indicate if a specific registration call should be cached or not.