### PR TITLE
prov/efa: Handle RTS credit request without breaking compat

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -64,7 +64,7 @@
 
 #define RXR_MAJOR_VERSION	(2)
 #define RXR_MINOR_VERSION	(0)
-#define RXR_PROTOCOL_VERSION	(3)
+#define RXR_PROTOCOL_VERSION	(2)
 #define RXR_FI_VERSION		FI_VERSION(1, 8)
 
 #define RXR_IOV_LIMIT		(4)
@@ -125,6 +125,7 @@ extern const uint32_t rxr_poison_value;
 #define RXR_TAGGED		BIT_ULL(0)
 #define RXR_REMOTE_CQ_DATA	BIT_ULL(1)
 #define RXR_REMOTE_SRC_ADDR	BIT_ULL(2)
+
 /*
  * TODO: In future we will send RECV_CANCEL signal to sender,
  * to stop transmitting large message, this flag is also
@@ -144,6 +145,12 @@ extern const uint32_t rxr_poison_value;
 #define RXR_WRITE		(1 << 6)
 #define RXR_READ_REQ		(1 << 7)
 #define RXR_READ_DATA		(1 << 8)
+
+/*
+ * Used to provide protocol compatibility across versions that include a
+ * credit request along with the RTS and those that do not
+ */
+#define RXR_CREDIT_REQUEST	BIT_ULL(9)
 
 /*
  * OFI flags

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -920,7 +920,11 @@ static int rxr_cq_process_rts(struct rxr_ep *ep,
 	ep->rx_pending++;
 #endif
 	rx_entry->state = RXR_RX_RECV;
-	rx_entry->credit_request = rts_hdr->credit_request;
+	if (rts_hdr->flags & RXR_CREDIT_REQUEST)
+		rx_entry->credit_request = rts_hdr->credit_request;
+	else
+		rx_entry->credit_request = rxr_env.tx_min_credits;
+
 	ret = rxr_ep_post_cts_or_queue(ep, rx_entry, bytes_left);
 	if (pkt_entry->type == RXR_PKT_ENTRY_POSTED)
 		ep->rx_bufs_to_post++;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1407,6 +1407,15 @@ void rxr_init_rts_pkt_entry(struct rxr_ep *ep,
 	rts_hdr->data_len = tx_entry->total_len;
 	rts_hdr->tx_id = tx_entry->tx_id;
 	rts_hdr->msg_id = tx_entry->msg_id;
+
+	/*
+	 * Even with protocol versions prior to v3 that did not include a
+	 * request in the RTS, the receiver can test for this flag and decide if
+	 * it should be used as a heuristic for credit calculation. If the
+	 * receiver is on <3 protocol version, the flag and the request just get
+	 * ignored.
+	 */
+	rts_hdr->flags |= RXR_CREDIT_REQUEST;
 	rts_hdr->credit_request = tx_entry->credit_request;
 
 	if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA) {


### PR DESCRIPTION
03ef12985 introduced protocol changes to support a more dynamic flow
control mechanism, and also changed the protocol version. In retrospect,
the protocol bump can be avoided and the change can be made without
breaking protocol compatibility.

With this change, if a sender is sending a request and the receiver is
on an older version, the request is just ignored and the older static
value (16) is returned with the CTS.  If a sender is running the older
protocol and fails to send a request, the receiver uses the
tx_min_credits value in the CTS window calculation.


Signed-off-by: Raghu Raja <craghun@amazon.com>