### PR TITLE
prov/rxd: Set ofi_buf_alloc to pkt_entry while rxd_ep_post_buf

### DIFF
--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -50,15 +50,6 @@ struct rxd_pkt_entry *rxd_get_tx_pkt(struct rxd_ep *ep)
 	return pkt_entry;
 }
 
-static struct rxd_pkt_entry *rxd_get_rx_pkt(struct rxd_ep *ep)
-{
-	struct rxd_pkt_entry *pkt_entry;
-
-	pkt_entry = ofi_buf_alloc(ep->rx_pkt_pool.pool);
-
-	return pkt_entry;
-}
-
 struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep, uint32_t op)
 {
 	struct rxd_x_entry *tx_entry;
@@ -237,7 +228,7 @@ int rxd_ep_post_buf(struct rxd_ep *ep)
 	struct rxd_pkt_entry *pkt_entry;
 	ssize_t ret;
 
-	pkt_entry = rxd_get_rx_pkt(ep);
+	pkt_entry = ofi_buf_alloc(ep->rx_pkt_pool.pool);
 	if (!pkt_entry)
 		return -FI_ENOMEM;
 


### PR DESCRIPTION
**Issue:**
Optimizing rxd_ep_post_buf, when we set pkt_entry attributies.

**Solution:**
Threw away calling of `rxd_get_rx_pkt()` and call `ofi_buf_alloc()` at once during `rxd_ep_post_buf()`.
It gives us the opportunity  of taking buf_data at once.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>