### PR TITLE
prov/rxd: Move the receive repost/remove to earlier in the pkt handling

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -408,7 +408,6 @@ int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
 
 /* Pkt resource functions */
 int rxd_ep_post_buf(struct rxd_ep *ep);
-void rxd_release_repost_rx(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry);
 void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer);
 struct rxd_pkt_entry *rxd_get_tx_pkt(struct rxd_ep *ep);
 struct rxd_x_entry *rxd_get_tx_entry(struct rxd_ep *ep, uint32_t op);

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -978,12 +978,6 @@ void rxd_ep_progress(struct util_ep *util_ep)
 	}
 
 out:
-	while (ep->posted_bufs < ep->rx_size) {
-		ret = rxd_ep_post_buf(ep);
-		if (ret)
-			break;
-	}
-
 	fastlock_release(&ep->util_ep.lock);
 }
 


### PR DESCRIPTION
**Issue:**
The provided changes is posting a new recive buffer right away, and don't
wait for finishing the handle of a recive complition. We post a recieve
buffer at once.

**Results:**
The changes have caused the performance part results, which were run on 
`alltoal`l test, and it shows us better results from `64Kb to 4Mb`with comparing
 'without the current changes'. But see a little regress from `1b to 64Kb`, 
the diff is about `~0.08 usec` **(not bigger)**.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>