### PR TITLE
prov/gni: CQE error posted to the wrong endpoint CQ

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -865,7 +865,7 @@ static int __gnix_rndzv_req_complete(void *arg, gni_return_t tx_status)
 		if (!GNIX_EP_DGM(req->gnix_ep->type)) {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "Dropping failed request: %p\n", req);
-			ret = __gnix_msg_send_err(req->gnix_ep,
+			ret = __gnix_msg_recv_err(req->gnix_ep,
 						  req);
 			if (ret != FI_SUCCESS)
 				GNIX_WARN(FI_LOG_EP_DATA,


### PR DESCRIPTION
A rendezvous message was to land in a multi-recv buffer.
A PostRdma() request was issued to retrieve the majority of the
message from the originator, but there was a problem with
memory permissions, and the request failed.  The code incorrectly
posted the error CQE to the endpoint's send CQ, when it should
have posted to the receive CQ.

Change the rendezvous code to post any CQE errors that occur on
a rendezvou PostRdma() request to the receive CQ, not the send CQ
since logically this is a receive operation.

fixes #5188

Signed-off-by: Kevan Rehm <krehm@cray.com>