### PR TITLE
prov/efa: Bugfix fi_nic not being copied

### DIFF
--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -147,6 +147,11 @@ static int rxr_copy_attr(const struct fi_info *info, struct fi_info *dup)
 				return -FI_ENOMEM;
 		}
 	}
+	if (info->nic) {
+		dup->nic = ofi_nic_dup(info->nic);
+		if (!dup->nic)
+			return -FI_ENOMEM;
+	}
 	return 0;
 }
 


### PR DESCRIPTION
The fi_nic structure part of the efa info object was not being properly
copied over. This caused the provider to not expose the field for its
non-dgram capabilities.

Signed-off-by: William Zhang <wilzhang@amazon.com>