### PR TITLE
prov/rxd: Delete post_bufs tracking

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -192,7 +192,6 @@ struct rxd_ep {
 	size_t tx_size;
 	size_t tx_prefix_size;
 	size_t rx_prefix_size;
-	uint32_t posted_bufs;
 	size_t min_multi_recv_size;
 	int do_local_mr;
 	int next_retry;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -242,7 +242,6 @@ int rxd_ep_post_buf(struct rxd_ep *ep)
 		return ret;
 	}
 
-	ep->posted_bufs++;
 	slist_insert_tail(&pkt_entry->s_entry, &ep->rx_pkt_list);
 
 	return 0;


### PR DESCRIPTION
Since [7f8d168](https://github.com/ofiwg/libfabric/pull/5183) when we move receive repost/remove to earlier in the pkt
handling, we don't need to track post_bufs and post them immediately.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>