### PR TITLE
prov/rxd: Make common pkt removal & reduce calls of remove_rx_pkt

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -364,10 +364,17 @@ static inline void *rxd_pkt_start(struct rxd_pkt_entry *pkt_entry)
 	return (void *) ((char *) pkt_entry + sizeof(*pkt_entry));
 }
 
+
 static inline size_t rxd_pkt_size(struct rxd_ep *ep, struct rxd_base_hdr *base_hdr,
 				   void *ptr)
 {
 	return ((char *) ptr - (char *) base_hdr) + ep->tx_prefix_size;
+}
+
+static inline void rxd_pkt_remove(struct rxd_pkt_entry *pkt_entry)
+{
+	dlist_remove(&pkt_entry->d_entry);
+	ofi_buf_free(pkt_entry);
 }
 
 struct rxd_match_attr {

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -575,10 +575,8 @@ void rxd_ep_send_ack(struct rxd_ep *rxd_ep, fi_addr_t peer)
 	rxd_ep->peers[peer].last_tx_ack = ack->base_hdr.seq_no;
 
 	dlist_insert_tail(&pkt_entry->d_entry, &rxd_ep->ctrl_pkts);
-	if (rxd_ep_send_pkt(rxd_ep, pkt_entry)) {
-		dlist_remove(&pkt_entry->d_entry);
-		ofi_buf_free(pkt_entry);
-	}
+	if (rxd_ep_send_pkt(rxd_ep, pkt_entry))
+		rxd_pkt_remove(pkt_entry);
 }
 
 static void rxd_ep_free_res(struct rxd_ep *ep)


### PR DESCRIPTION
1. Add inline rxd_pkt_remove() in order to common calls of dlist_remove() and ofi_buf_free().
2. Get rid of calls rxd_remove_rx_pkt() in recieve paths:
    Remove the item from the list right when we get recv completion

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>