### PR TITLE
contrib/cray: Remove build publishing step

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -356,65 +356,10 @@ pipeline {
                         }
                     }
                 }
-                stage("Create RPMs") {
-                    steps {
-                        sh 'make dist-bzip2'
-                        sh '''$WORKSPACE/contrib/buildrpm/buildrpmLibfabric.sh \
-                                -i verbs \
-                                -i sockets \
-                                -smv \
-                                -r '--define "_prefix /opt/cray/libfabric/$version"' \
-                                -r '--define "modulefile_path /opt/cray/modulefiles"' \
-                                $(ls libfabric-*.tar.bz2)'''
-                    }
-                    post {
-                        success {
-                            stash name: 'rpms', includes: 'rpmbuild/RPMS/**/*'
-                            stash name: 'sources',  includes: 'rpmbuild/SOURCES/*'
-                        }
-                    }
-                }
-            }
-        }
-        stage('Publish') {
-            when {
-                allOf {
-                    expression { currentBuild.result == 'SUCCESS' } ;
-                    expression { return isRelease("${env.GIT_BRANCH}") }
-                }
-            }
-            agent {
-                node {
-                    label 'utility_pod'
-                }
-            }
-            steps {
-                container('utility') {
-                    sh 'tar -cvzf /tmp/libfabric-source.tar.gz --exclude "*.log" .'
-
-                    // publishes the source RPM to DST's Artifactory instance
-                    transfer(artifactName: '/tmp/libfabric-source.tar.gz')
-
-                    // Sends event to message bus to notify other builds
-                    publishEvents(["os-networking-libfabric-verbs-publish"])
-                }
             }
         }
     }
     post {
-        success {
-            script {
-                try {
-                    unstash 'rpms'
-                    unstash 'sources'
-                    archiveArtifacts 'rpmbuild/SOURCES/*'
-                    archiveArtifacts 'rpmbuild/RPMS/**/*'
-                }
-                catch (Exception e) {
-                    echo 'No rpms to archive'
-                }
-            }
-        }
         changed {
             script {
                 // send email when the state of the pipeline changes


### PR DESCRIPTION
A separate pipeline will be used for creating and publishing builds.
This commit removes this logic from the build verification pipeline.

Signed-off-by: James Swaro <jswaro@cray.com>