### PR TITLE
Added initialization for ranks for each process.

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -341,7 +341,7 @@ ubertest_fi_ubertest_LDADD = libfabtests.la
 
 multinode_fi_multinode_SOURCES = \
 	multinode/src/harness.c \
-	multinode/src/pattern/full_mesh.c \
+	multinode/src/pattern.c \
 	multinode/include/pattern.h \
 	multinode/src/core.c \
 	multinode/include/core.h

--- a/fabtests/multinode/include/core.h
+++ b/fabtests/multinode/include/core.h
@@ -49,6 +49,7 @@ struct pm_job_info {
 	size_t		num_ranks;
 	int		sock;
 	int		*clients; //only valid for server
+	
 	struct sockaddr_storage oob_server_addr;
 	void		*names;
 	size_t		name_len;

--- a/fabtests/multinode/include/pattern.h
+++ b/fabtests/multinode/include/pattern.h
@@ -35,11 +35,13 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <errno.h>
-
 #include <rdma/fabric.h>
 
 /* Initial value for iterator position. */
 #define PATTERN_NO_CURRENT (-1)
+
+/* Number of patterns to test */
+extern const int NUM_TESTS;
 
 struct pattern_ops {
 	char *name;
@@ -47,4 +49,6 @@ struct pattern_ops {
 	int (*next_target) (int *cur);
 };
 
-extern struct pattern_ops full_mesh_ops;
+extern struct pattern_ops patterns[];
+
+

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -145,7 +145,7 @@ static int multinode_post_rx()
 			break;
 
 		ret = pattern->next_source(&state.cur_source);
-		if (ret == -ENODATA) {
+		if (ret == -FI_ENODATA) {
 			state.all_recvs_posted = true;
 			break;
 		} else if (ret < 0) {
@@ -180,7 +180,7 @@ static int multinode_post_tx()
 			break;
 
 		ret = pattern->next_target(&state.cur_target);
-		if (ret == -ENODATA) {
+		if (ret == -FI_ENODATA) {
 			state.all_sends_posted = true;
 			break;
 		} else if (ret < 0) {
@@ -277,25 +277,32 @@ static int multinode_run_test()
 
 static void pm_job_free_res()
 {
-	if (pm_job.names)
+
 		free(pm_job.names);
 
-	if (pm_job.fi_addrs)
-	free(pm_job.fi_addrs);
+		free(pm_job.fi_addrs);
 }
 
 int multinode_run_tests(int argc, char **argv)
 {
 	int ret = FI_SUCCESS;
+	int i;
 
 	ret = multinode_setup_fabric(argc, argv);
 	if (ret)
 		return ret;
 
-	pattern = &full_mesh_ops;
-
-	ret = multinode_run_test();
-
+	for (i = 0; i < NUM_TESTS && !ret; i++) {
+		printf("starting %s... ", patterns[i].name);
+		pattern = &patterns[i];
+		ret = multinode_run_test();
+		if (ret) 
+			printf("failed\n");
+		else 
+			printf("passed\n");
+		
+	}
+	
 	pm_job_free_res();
 	ft_free_res();
 	return ft_exit_code(ret);

--- a/fabtests/multinode/src/harness.c
+++ b/fabtests/multinode/src/harness.c
@@ -80,7 +80,6 @@ static inline int socket_recv(int sock, void *buf, size_t len, int flags)
 }
 
 int pm_allgather(void *my_item, void *items, int item_size)
-
 {
 	int i, ret;
 	uint8_t *offset;
@@ -128,6 +127,26 @@ void pm_barrier()
 	pm_allgather(&ch, chs, 1);
 }
 
+static int pm_init_ranks()
+{
+	int ret;
+	int i;
+	size_t send_rank;
+
+	if (pm_job.clients) {
+		for(i = 0; i < pm_job.num_ranks-1; i++) {
+			send_rank = i + 1;
+			ret = socket_send(pm_job.clients[i], &send_rank, sizeof(send_rank), 0);
+			if (ret < 0)
+				return ret;
+		}
+	} else {
+		ret = socket_recv(pm_job.sock, &(pm_job.my_rank), sizeof(pm_job.my_rank), 0);
+	}
+
+	return ret;
+}
+
 static int server_connect()
 {
 	int new_sock;
@@ -141,7 +160,7 @@ static int server_connect()
 	if (!pm_job.clients)
 		return -FI_ENOMEM;
 
-	for (i = 0; i < pm_job.num_ranks-1; i++){
+	for (i = 0; i < pm_job.num_ranks-1; i++) {
 		new_sock = accept(pm_job.sock, NULL, NULL);
 		if (new_sock < 0) {
 			FT_ERR("error during server init\n");
@@ -218,13 +237,13 @@ int pm_get_oob_server_addr()
 	struct addrinfo *res;
 	struct sockaddr_in *in;
 	struct sockaddr_in6 *in6;
-        int ret;
+	int ret;
 
-        ret = getaddrinfo(opts.src_addr, NULL, NULL, &res);
-        if (ret) {
+	ret = getaddrinfo(opts.src_addr, NULL, NULL, &res);
+	if (ret) {
 		FT_ERR( "getaddrinfo failed\n");
-                return ret;
-        }
+		return ret;
+	}
 
 	memcpy(&pm_job.oob_server_addr, res->ai_addr, res->ai_addrlen);
 
@@ -244,7 +263,7 @@ int pm_get_oob_server_addr()
 	}
 
 	freeaddrinfo(res);
-        return ret;
+	return ret;
 }
 
 int main(int argc, char **argv)
@@ -278,8 +297,16 @@ int main(int argc, char **argv)
 		goto err1;
 
 	ret = pm_conn_setup();
-	if (ret)
+	if (ret) {
+		FT_ERR("connection setup failed\n");
 		goto err1;
+	}
+	
+	ret = pm_init_ranks();
+	if (ret < 0) {
+		FT_ERR("rank initialization failed\n");
+		goto err2;
+	}
 
 	FT_DEBUG("OOB job setup done\n");
 

--- a/fabtests/multinode/src/pattern.c
+++ b/fabtests/multinode/src/pattern.c
@@ -29,24 +29,99 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 #include <pattern.h>
 #include <core.h>
+#include <shared.h>
 
-static int pattern_next(int *cur)
+static int broadcast_gather_next(int *cur)
+{
+	int next;
+	if (pm_job.my_rank) 
+		return -FI_ENODATA;
+	next = *cur + 1;
+
+	if (next >= pm_job.num_ranks)
+		return -FI_ENODATA;
+	if (next == 0)
+		next = 1;
+
+	*cur = next;
+	
+	return 0;
+}
+
+static int broadcast_gather_current(int *cur)
+{
+	int next;
+	if (!pm_job.my_rank) 
+		return -FI_ENODATA;
+	
+	next = *cur + 1;
+
+	if (next > 0)			
+		return -FI_ENODATA;
+
+	*cur = next;
+	
+	return 0; 
+}
+
+static int ring_next(int *cur)
+{
+	if ((pm_job.my_rank == 0 && pm_job.num_ranks - 1 == *cur) ||
+		(pm_job.my_rank != 0 && pm_job.my_rank - 1   == *cur))
+		return -FI_ENODATA;
+		
+	if (pm_job.my_rank == 0)
+		*cur = pm_job.num_ranks - 1;
+	else 			
+		*cur = pm_job.my_rank - 1;
+	return 0; 
+	
+}
+
+static int ring_current(int *cur)
+{
+	if ((pm_job.my_rank + 1) % pm_job.num_ranks == *cur) 
+		return -FI_ENODATA;
+	
+	*cur = (pm_job.my_rank + 1) % pm_job.num_ranks;
+	return 0; 
+	
+}
+
+static int mesh_next(int *cur)
 {
 	int next = *cur + 1;
 
 	if (next >= pm_job.num_ranks)
-		return -ENODATA;
+		return -FI_ENODATA;
 
 	*cur = next;
 	return 0;
 }
 
-
-struct pattern_ops full_mesh_ops = {
-	.name = "full_mesh",
-	.next_source = pattern_next,
-	.next_target = pattern_next,
+struct pattern_ops patterns[] = {
+	{
+		.name = "full_mesh",
+		.next_source = mesh_next,
+		.next_target = mesh_next,
+	},
+	{
+		.name = "ring",
+		.next_source = ring_next,
+		.next_target = ring_current,
+	},
+	{
+		.name = "gather",
+		.next_source = broadcast_gather_next,
+		.next_target = broadcast_gather_current,
+	},
+	{
+		.name = "broadcast",
+		.next_source = broadcast_gather_current,
+		.next_target = broadcast_gather_next,
+	},
 };
+
+ const int NUM_TESTS = ARRAY_SIZE(patterns);


### PR DESCRIPTION
For more advanced and different testing patterns, the ability for
each process to know its own rank is required.

Users also will use ranks on processes for other collective communication
patterns.

Setup is done by having the server send off a rank to each other process
in the order that they are listed in the pm_job.clients table.

Adding common hpcs testing patterns

Broadcast: host sends to each client and each client receives once
Gather: each client sends to host and host receives all sends
Ring: each process sends to the next process and receives
	  from the previous

Each pattern is run during the multinode test, in additon to the
original all to all.

Signed-off-by: Alex McKinley <alex.mckinley@intel.com>