### PR TITLE
fabtests/multinode: bugfix hints fields are accessed before allocation

### DIFF
--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -62,10 +62,6 @@ static int multinode_setup_fabric(int argc, char **argv)
 	size_t len;
 	int ret;
 
-	hints = fi_allocinfo();
-	if (!hints)
-		return EXIT_FAILURE;
-
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->caps = FI_MSG;
 	hints->mode = FI_CONTEXT;

--- a/fabtests/multinode/src/harness.c
+++ b/fabtests/multinode/src/harness.c
@@ -257,6 +257,10 @@ int main(int argc, char **argv)
 
 	pm_job.clients = NULL;
 
+	hints = fi_allocinfo();
+	if (!hints)
+		return EXIT_FAILURE;
+
 	while ((c = getopt(argc, argv, "n:h" ADDR_OPTS INFO_OPTS)) != -1) {
 		switch (c) {
 		default:


### PR DESCRIPTION

Signed-off-by: Venkata Krishna Nimmagadda <venkata.krishna.nimmagadda@intel.com>