### PR TITLE
prov/efa: Some EFA fixes for 1.8.x

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -64,7 +64,7 @@
 
 #define RXR_MAJOR_VERSION	(2)
 #define RXR_MINOR_VERSION	(0)
-#define RXR_PROTOCOL_VERSION	(3)
+#define RXR_PROTOCOL_VERSION	(2)
 #define RXR_FI_VERSION		FI_VERSION(1, 8)
 
 #define RXR_IOV_LIMIT		(4)
@@ -125,6 +125,7 @@ extern const uint32_t rxr_poison_value;
 #define RXR_TAGGED		BIT_ULL(0)
 #define RXR_REMOTE_CQ_DATA	BIT_ULL(1)
 #define RXR_REMOTE_SRC_ADDR	BIT_ULL(2)
+
 /*
  * TODO: In future we will send RECV_CANCEL signal to sender,
  * to stop transmitting large message, this flag is also
@@ -144,6 +145,12 @@ extern const uint32_t rxr_poison_value;
 #define RXR_WRITE		(1 << 6)
 #define RXR_READ_REQ		(1 << 7)
 #define RXR_READ_DATA		(1 << 8)
+
+/*
+ * Used to provide protocol compatibility across versions that include a
+ * credit request along with the RTS and those that do not
+ */
+#define RXR_CREDIT_REQUEST	BIT_ULL(9)
 
 /*
  * OFI flags

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -286,6 +286,7 @@ struct rxr_peer {
 	uint32_t next_msg_id;		/* sender's view of msg_id */
 	enum rxr_peer_state state;	/* state of CM protocol with peer */
 	unsigned int rnr_state;		/* tracks RNR backoff for peer */
+	size_t tx_pending;		/* tracks pending tx ops to this peer */
 	uint64_t rnr_ts;		/* timestamp for RNR backoff tracking */
 	int rnr_queued_pkt_cnt;		/* queued RNR packet count */
 	int timeout_interval;		/* initial RNR timeout value */
@@ -986,6 +987,28 @@ static inline int rxr_match_tag(uint64_t tag, uint64_t ignore,
 				uint64_t match_tag)
 {
 	return ((tag | ignore) == (match_tag | ignore));
+}
+
+static inline void rxr_ep_inc_tx_pending(struct rxr_ep *ep,
+					 struct rxr_peer *peer)
+{
+	ep->tx_pending++;
+	peer->tx_pending++;
+#if ENABLE_DEBUG
+	ep->sends++;
+#endif
+}
+
+static inline void rxr_ep_dec_tx_pending(struct rxr_ep *ep,
+					 struct rxr_peer *peer,
+					 int failed)
+{
+	ep->tx_pending--;
+	peer->tx_pending--;
+#if ENABLE_DEBUG
+	if (failed)
+		ep->failed_send_comps++;
+#endif
 }
 
 /*

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -64,7 +64,7 @@
 
 #define RXR_MAJOR_VERSION	(2)
 #define RXR_MINOR_VERSION	(0)
-#define RXR_PROTOCOL_VERSION	(2)
+#define RXR_PROTOCOL_VERSION	(3)
 #define RXR_FI_VERSION		FI_VERSION(1, 8)
 
 #define RXR_IOV_LIMIT		(4)
@@ -90,7 +90,12 @@ extern const uint32_t rxr_poison_value;
 /* bounds for random RNR backoff timeout */
 #define RXR_RAND_MIN_TIMEOUT		(40)
 #define RXR_RAND_MAX_TIMEOUT		(120)
-#define RXR_DEF_MAX_RX_WINDOW		(16)
+
+/* bounds for flow control */
+#define RXR_DEF_MAX_RX_WINDOW		(128)
+#define RXR_DEF_MAX_TX_CREDITS		(64)
+#define RXR_DEF_MIN_TX_CREDITS		(32)
+
 /*
  * maximum time (microseconds) we will allow available_bufs for large msgs to
  * be exhausted
@@ -166,6 +171,8 @@ extern struct util_prov rxr_util_prov;
 
 struct rxr_env {
 	int rx_window_size;
+	int tx_min_credits;
+	int tx_max_credits;
 	int tx_queue_size;
 	int enable_sas_ordering;
 	int recvwin_size;
@@ -282,11 +289,15 @@ struct rxr_av {
 };
 
 struct rxr_peer {
+	bool tx_init;			/* tracks initialization of tx state */
+	bool rx_init;			/* tracks initialization of rx state */
 	struct rxr_robuf *robuf;	/* tracks expected msg_id on rx */
 	uint32_t next_msg_id;		/* sender's view of msg_id */
 	enum rxr_peer_state state;	/* state of CM protocol with peer */
 	unsigned int rnr_state;		/* tracks RNR backoff for peer */
 	size_t tx_pending;		/* tracks pending tx ops to this peer */
+	uint16_t tx_credits;		/* available send credits */
+	uint16_t rx_credits;		/* available credits to allocate */
 	uint64_t rnr_ts;		/* timestamp for RNR backoff tracking */
 	int rnr_queued_pkt_cnt;		/* queued RNR packet count */
 	int timeout_interval;		/* initial RNR timeout value */
@@ -320,6 +331,7 @@ struct rxr_rx_entry {
 
 	uint64_t bytes_done;
 	int64_t window;
+	uint16_t credit_request;
 
 	uint64_t total_len;
 
@@ -382,6 +394,8 @@ struct rxr_tx_entry {
 	uint64_t bytes_acked;
 	uint64_t bytes_sent;
 	int64_t window;
+	uint16_t credit_request;
+	uint16_t credit_allocated;
 
 	uint64_t total_len;
 
@@ -585,15 +599,15 @@ struct rxr_rts_hdr {
 	uint8_t version;
 	uint16_t flags;
 	/* end of rxr_base_hdr */
-	/* TODO: need to add msg_id -> tx_id mapping to remove tx_id and pad */
-	uint8_t pad[2];
+	/* TODO: need to add msg_id -> tx_id mapping to remove tx_id */
+	uint16_t credit_request;
 	uint8_t addrlen;
 	uint8_t rma_iov_count;
 	uint32_t tx_id;
 	uint32_t msg_id;
 	uint64_t tag;
 	uint64_t data_len;
-}; /* 24 bytes without tx_id and padding for it */
+};
 
 #if defined(static_assert) && defined(__x86_64__)
 static_assert(sizeof(struct rxr_rts_hdr) == 32, "rxr_rts_hdr check");
@@ -761,6 +775,27 @@ static inline struct rxr_peer *rxr_ep_get_peer(struct rxr_ep *ep,
 	return &ep->peer[addr];
 }
 
+static inline void rxr_ep_peer_init(struct rxr_ep *ep, struct rxr_peer *peer)
+{
+	assert(!peer->rx_init);
+	peer->robuf = freestack_pop(ep->robuf_fs);
+	peer->robuf = ofi_recvwin_buf_alloc(peer->robuf,
+					    rxr_env.recvwin_size);
+	assert(peer->robuf);
+	dlist_insert_tail(&peer->entry, &ep->peer_list);
+	peer->rx_credits = rxr_env.rx_window_size;
+	peer->rx_init = 1;
+
+	/*
+	 * If the endpoint has never sent a message to this peer thus far,
+	 * initialize tx state as well.
+	 */
+	if (!peer->tx_init) {
+		peer->tx_credits = rxr_env.tx_max_credits;
+		peer->tx_init = 1;
+	}
+}
+
 struct rxr_rx_entry *rxr_ep_get_rx_entry(struct rxr_ep *ep,
 					 const struct iovec *iov,
 					 size_t iov_count, uint64_t tag,
@@ -776,7 +811,8 @@ struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 					  fi_addr_t addr, uint32_t op,
 					  uint64_t flags);
 
-void rxr_generic_tx_entry_init(struct rxr_tx_entry *tx_entry,
+void rxr_generic_tx_entry_init(struct rxr_ep *ep,
+			       struct rxr_tx_entry *tx_entry,
 			       const struct iovec *iov,
 			       size_t iov_count,
 			       const struct fi_rma_iov *rma_iov,
@@ -1101,12 +1137,12 @@ ssize_t rxr_ep_post_readrsp(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry
 void rxr_ep_init_connack_pkt_entry(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry,
 				   fi_addr_t addr);
-void rxr_ep_calc_cts_window_credits(struct rxr_ep *ep, uint32_t max_window,
-				    uint64_t size, int *window, int *credits);
+void rxr_ep_calc_cts_window_credits(struct rxr_ep *ep, struct rxr_peer *peer,
+				    uint64_t size, int request,
+				    int *window, int *credits);
 void rxr_ep_init_cts_pkt_entry(struct rxr_ep *ep,
 			       struct rxr_rx_entry *rx_entry,
 			       struct rxr_pkt_entry *pkt_entry,
-			       uint32_t max_window,
 			       uint64_t size,
 			       int *credits);
 void rxr_ep_init_readrsp_pkt_entry(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
@@ -1131,7 +1167,6 @@ int rxr_cq_handle_tx_error(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 int rxr_cq_handle_cq_error(struct rxr_ep *ep, ssize_t err);
 ssize_t rxr_cq_post_cts(struct rxr_ep *ep,
 			struct rxr_rx_entry *rx_entry,
-			uint32_t max_window,
 			uint64_t size);
 
 int rxr_cq_handle_rx_completion(struct rxr_ep *ep,
@@ -1288,8 +1323,7 @@ static inline int rxr_ep_post_cts_or_queue(struct rxr_ep *ep,
 	if (rx_entry->state == RXR_RX_QUEUED_CTS)
 		return 0;
 
-	ret = rxr_cq_post_cts(ep, rx_entry, rxr_env.rx_window_size,
-			      bytes_left);
+	ret = rxr_cq_post_cts(ep, rx_entry, bytes_left);
 	if (OFI_UNLIKELY(ret)) {
 		if (ret == -FI_EAGAIN) {
 			rx_entry->state = RXR_RX_QUEUED_CTS;

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -920,7 +920,11 @@ static int rxr_cq_process_rts(struct rxr_ep *ep,
 	ep->rx_pending++;
 #endif
 	rx_entry->state = RXR_RX_RECV;
-	rx_entry->credit_request = rts_hdr->credit_request;
+	if (rts_hdr->flags & RXR_CREDIT_REQUEST)
+		rx_entry->credit_request = rts_hdr->credit_request;
+	else
+		rx_entry->credit_request = rxr_env.tx_min_credits;
+
 	ret = rxr_ep_post_cts_or_queue(ep, rx_entry, bytes_left);
 	if (pkt_entry->type == RXR_PKT_ENTRY_POSTED)
 		ep->rx_bufs_to_post++;

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -497,7 +497,6 @@ static void rxr_cq_post_connack(struct rxr_ep *ep,
 
 ssize_t rxr_cq_post_cts(struct rxr_ep *ep,
 			struct rxr_rx_entry *rx_entry,
-			uint32_t max_window,
 			uint64_t size)
 {
 	ssize_t ret;
@@ -512,15 +511,13 @@ ssize_t rxr_cq_post_cts(struct rxr_ep *ep,
 	if (OFI_UNLIKELY(!pkt_entry))
 		return -FI_EAGAIN;
 
-	rxr_ep_init_cts_pkt_entry(ep, rx_entry, pkt_entry, max_window, size,
-				  &credits);
+	rxr_ep_init_cts_pkt_entry(ep, rx_entry, pkt_entry, size, &credits);
 
 	ret = rxr_ep_send_pkt(ep, pkt_entry, rx_entry->addr);
 	if (OFI_UNLIKELY(ret))
 		goto release_pkt;
 
 	rx_entry->window = rxr_get_cts_hdr(pkt_entry->pkt)->window;
-	assert(ep->available_data_bufs >= credits);
 	ep->available_data_bufs -= credits;
 
 	/*
@@ -923,6 +920,7 @@ static int rxr_cq_process_rts(struct rxr_ep *ep,
 	ep->rx_pending++;
 #endif
 	rx_entry->state = RXR_RX_RECV;
+	rx_entry->credit_request = rts_hdr->credit_request;
 	ret = rxr_ep_post_cts_or_queue(ep, rx_entry, bytes_left);
 	if (pkt_entry->type == RXR_PKT_ENTRY_POSTED)
 		ep->rx_bufs_to_post++;
@@ -941,15 +939,11 @@ static int rxr_cq_reorder_msg(struct rxr_ep *ep,
 	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
 
 	/*
-	 * TODO: Do it at the time of AV insertion w/dup detection.
+	 * TODO: Initialize peer state  at the time of AV insertion
+	 * where duplicate detection is available.
 	 */
-	if (!peer->robuf) {
-		peer->robuf = freestack_pop(ep->robuf_fs);
-		peer->robuf = ofi_recvwin_buf_alloc(peer->robuf,
-						    rxr_env.recvwin_size);
-		assert(peer->robuf);
-		dlist_insert_tail(&peer->entry, &ep->peer_list);
-	}
+	if (!peer->rx_init)
+		rxr_ep_peer_init(ep, peer);
 
 #if ENABLE_DEBUG
 	if (rts_hdr->msg_id != ofi_recvwin_next_exp_id(peer->robuf))
@@ -1135,9 +1129,12 @@ void rxr_cq_handle_pkt_with_data(struct rxr_ep *ep,
 				 char *data, size_t seg_offset,
 				 size_t seg_size)
 {
+	struct rxr_peer *peer;
 	uint64_t bytes;
 	ssize_t ret;
 
+	peer = rxr_ep_get_peer(ep, rx_entry->addr);
+	peer->rx_credits += ofi_div_ceil(seg_size, ep->max_data_payload_size);
 	rx_entry->window -= seg_size;
 
 	if (ep->available_data_bufs < rxr_get_rx_pool_chunk_cnt(ep))
@@ -1195,6 +1192,7 @@ static void rxr_cq_handle_cts(struct rxr_ep *ep,
 			      struct fi_cq_msg_entry *comp,
 			      struct rxr_pkt_entry *pkt_entry)
 {
+	struct rxr_peer *peer;
 	struct rxr_cts_hdr *cts_pkt;
 	struct rxr_tx_entry *tx_entry;
 
@@ -1206,6 +1204,12 @@ static void rxr_cq_handle_cts(struct rxr_ep *ep,
 
 	tx_entry->rx_id = cts_pkt->rx_id;
 	tx_entry->window = cts_pkt->window;
+
+	/* Return any excess tx_credits that were borrowed for the request */
+	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	tx_entry->credit_allocated = ofi_div_ceil(cts_pkt->window, ep->max_data_payload_size);
+	if (tx_entry->credit_allocated < tx_entry->credit_request)
+		peer->tx_credits += tx_entry->credit_request - tx_entry->credit_allocated;
 
 	rxr_release_rx_pkt_entry(ep, pkt_entry);
 	ep->rx_bufs_to_post++;
@@ -1420,6 +1424,8 @@ void rxr_cq_handle_pkt_send_completion(struct rxr_ep *ep, struct fi_cq_msg_entry
 					fi_strerror(-ret));
 			}
 		}
+
+		peer->tx_credits += tx_entry->credit_allocated;
 
 		if (tx_entry->cq_entry.flags & FI_READ) {
 			/*

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1407,6 +1407,15 @@ void rxr_init_rts_pkt_entry(struct rxr_ep *ep,
 	rts_hdr->data_len = tx_entry->total_len;
 	rts_hdr->tx_id = tx_entry->tx_id;
 	rts_hdr->msg_id = tx_entry->msg_id;
+
+	/*
+	 * Even with protocol versions prior to v3 that did not include a
+	 * request in the RTS, the receiver can test for this flag and decide if
+	 * it should be used as a heuristic for credit calculation. If the
+	 * receiver is on <3 protocol version, the flag and the request just get
+	 * ignored.
+	 */
+	rts_hdr->flags |= RXR_CREDIT_REQUEST;
 	rts_hdr->credit_request = tx_entry->credit_request;
 
 	if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA) {

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1081,12 +1081,8 @@ ssize_t rxr_ep_send_msg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 #endif
 	ret = fi_sendmsg(ep->rdm_ep, msg, flags);
 
-	if (OFI_LIKELY(!ret)) {
-		ep->tx_pending++;
-#if ENABLE_DEBUG
-		ep->sends++;
-#endif
-	}
+	if (OFI_LIKELY(!ret))
+		rxr_ep_inc_tx_pending(ep, peer);
 
 	return ret;
 }

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -921,9 +921,11 @@ static ssize_t rxr_ep_recvv(struct fid_ep *ep, const struct iovec *iov,
 }
 
 
-void rxr_generic_tx_entry_init(struct rxr_tx_entry *tx_entry, const struct iovec *iov, size_t iov_count,
-			       const struct fi_rma_iov *rma_iov, size_t rma_iov_count,
-			       fi_addr_t addr, uint64_t tag, uint64_t data, void *context,
+void rxr_generic_tx_entry_init(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+			       const struct iovec *iov, size_t iov_count,
+			       const struct fi_rma_iov *rma_iov,
+			       size_t rma_iov_count, fi_addr_t addr,
+			       uint64_t tag, uint64_t data, void *context,
 			       uint32_t op, uint64_t flags)
 {
 	tx_entry->type = RXR_TX_ENTRY;
@@ -1003,8 +1005,9 @@ struct rxr_tx_entry *rxr_ep_tx_entry_init(struct rxr_ep *rxr_ep, const struct io
 	dlist_insert_tail(&tx_entry->tx_entry_entry, &rxr_ep->tx_entry_list);
 #endif
 
-	rxr_generic_tx_entry_init(tx_entry, iov, iov_count, rma_iov, rma_iov_count,
-				  addr, tag, data, context, op, flags);
+	rxr_generic_tx_entry_init(rxr_ep, tx_entry, iov, iov_count, rma_iov,
+				  rma_iov_count, addr, tag, data, context,
+				  op, flags);
 
 	assert(rxr_ep->util_ep.tx_msg_flags == 0 || rxr_ep->util_ep.tx_msg_flags == FI_COMPLETION);
 	tx_op_flags = rxr_ep->util_ep.tx_op_flags;
@@ -1280,24 +1283,47 @@ ssize_t rxr_ep_post_readrsp(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	return 0;
 }
 
-void rxr_ep_calc_cts_window_credits(struct rxr_ep *ep, uint32_t max_window, uint64_t size,
+void rxr_ep_calc_cts_window_credits(struct rxr_ep *ep, struct rxr_peer *peer,
+				    uint64_t size, int request,
 				    int *window, int *credits)
 {
-	*credits = ofi_div_ceil(size, ep->max_data_payload_size);
+	struct rxr_av *av;
+	int num_peers;
+
+	/*
+	 * Adjust the peer credit pool based on the current AV size, which could
+	 * have grown since the time this peer was initialized.
+	 */
+	av = rxr_ep_av(ep);
+	num_peers = av->rdm_av_used - 1;
+	if (num_peers && ofi_div_ceil(rxr_env.rx_window_size, num_peers) < peer->rx_credits)
+		peer->rx_credits = ofi_div_ceil(peer->rx_credits, num_peers);
+
+	/*
+	 * Allocate credits for this transfer based on the request, the number
+	 * of available data buffers, and the number of outstanding peers this
+	 * endpoint is actively tracking in the AV. Also ensure that a minimum
+	 * number of credits are allocated to the transfer so the sender can
+	 * make progress.
+	 */
 	*credits = MIN(MIN(ep->available_data_bufs, ep->posted_bufs),
-		       MIN(*credits, max_window));
+		       peer->rx_credits);
+	*credits = MIN(request, *credits);
+	*credits = MAX(*credits, rxr_env.tx_min_credits);
 	*window = MIN(size, *credits * ep->max_data_payload_size);
+	if (peer->rx_credits > ofi_div_ceil(*window, ep->max_data_payload_size))
+		peer->rx_credits -= ofi_div_ceil(*window, ep->max_data_payload_size);
 }
 
 void rxr_ep_init_cts_pkt_entry(struct rxr_ep *ep,
 			       struct rxr_rx_entry *rx_entry,
 			       struct rxr_pkt_entry *pkt_entry,
-			       uint32_t max_window,
 			       uint64_t size,
 			       int *credits)
 {
 	int window = 0;
 	struct rxr_cts_hdr *cts_hdr;
+	struct rxr_peer *peer;
 
 	cts_hdr = (struct rxr_cts_hdr *)pkt_entry->pkt;
 
@@ -1311,7 +1337,9 @@ void rxr_ep_init_cts_pkt_entry(struct rxr_ep *ep,
 	cts_hdr->tx_id = rx_entry->tx_id;
 	cts_hdr->rx_id = rx_entry->rx_id;
 
-	rxr_ep_calc_cts_window_credits(ep, max_window, size, &window, credits);
+	peer = rxr_ep_get_peer(ep, rx_entry->addr);
+	rxr_ep_calc_cts_window_credits(ep, peer, size, rx_entry->credit_request,
+				       &window, credits);
 	cts_hdr->window = window;
 
 	pkt_entry->pkt_size = RXR_CTS_HDR_SIZE;
@@ -1379,6 +1407,7 @@ void rxr_init_rts_pkt_entry(struct rxr_ep *ep,
 	rts_hdr->data_len = tx_entry->total_len;
 	rts_hdr->tx_id = tx_entry->tx_id;
 	rts_hdr->msg_id = tx_entry->msg_id;
+	rts_hdr->credit_request = tx_entry->credit_request;
 
 	if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA) {
 		rts_hdr->flags = RXR_REMOTE_CQ_DATA;
@@ -1478,6 +1507,8 @@ static void rxr_inline_mr_reg(struct rxr_domain *rxr_domain,
 static size_t rxr_ep_post_rts(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 {
 	struct rxr_pkt_entry *pkt_entry;
+	struct rxr_peer *peer;
+	size_t pending = 0;
 	ssize_t ret;
 	uint64_t data_sent, offset;
 	int i;
@@ -1485,6 +1516,35 @@ static size_t rxr_ep_post_rts(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	pkt_entry = rxr_get_pkt_entry(rxr_ep, rxr_ep->tx_pkt_pool);
 
 	if (OFI_UNLIKELY(!pkt_entry))
+		return -FI_EAGAIN;
+
+	/*
+	 * Init tx state for this peer. The rx state and reorder buffers will be
+	 * initialized on the first recv so as to not allocate resources unless
+	 * necessary.
+	 */
+	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+	if (!peer->tx_init) {
+		peer->tx_credits = rxr_env.tx_max_credits;
+		peer->tx_init = 1;
+	}
+
+	/*
+	 * Divy up available credits to outstanding transfers and request the
+	 * minimum of that and the amount required to finish the current long
+	 * message.
+	 */
+	pending = peer->tx_pending + 1;
+	tx_entry->credit_request = MIN(ofi_div_ceil(peer->tx_credits, pending),
+				       ofi_div_ceil(tx_entry->total_len,
+						    rxr_ep->max_data_payload_size));
+	tx_entry->credit_request = MAX(tx_entry->credit_request,
+				       rxr_env.tx_min_credits);
+	if (peer->tx_credits >= tx_entry->credit_request)
+		peer->tx_credits -= tx_entry->credit_request;
+
+	/* Queue this RTS for later if there are too many outstanding packets */
+	if (!tx_entry->credit_request)
 		return -FI_EAGAIN;
 
 	rxr_init_rts_pkt_entry(rxr_ep, tx_entry, pkt_entry);
@@ -1625,12 +1685,13 @@ ssize_t rxr_tx(struct fid_ep *ep, const struct iovec *iov, size_t iov_count,
 			goto out;
 		}
 
-		rxr_ep_calc_cts_window_credits(rxr_ep, rxr_env.rx_window_size,
-					       tx_entry->total_len, &window,
+		rxr_ep_calc_cts_window_credits(rxr_ep, peer,
+					       tx_entry->total_len,
+					       tx_entry->credit_request,
+					       &window,
 					       &credits);
 
 		rx_entry->window = window;
-		assert(rxr_ep->available_data_bufs >= credits);
 		rxr_ep->available_data_bufs -= credits;
 
 		rx_entry->state = RXR_RX_RECV;
@@ -2614,7 +2675,6 @@ static void rxr_ep_progress_internal(struct rxr_ep *ep)
 				     rx_entry, queued_entry, tmp) {
 		if (rx_entry->state == RXR_RX_QUEUED_CTS)
 			ret = rxr_cq_post_cts(ep, rx_entry,
-					      rxr_env.rx_window_size,
 					      rx_entry->total_len -
 					      rx_entry->bytes_done);
 		else

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -770,9 +770,9 @@ static ssize_t rxr_multi_recv(struct rxr_ep *rxr_ep, const struct iovec *iov,
 			 * long msg completion. Last msg completion will free
 			 * posted rx_entry.
 			 */
-			if (ret != -FI_ENOMSG || ret != 0)
-				return ret;
-			return 0;
+			if (ret == -FI_ENOMSG)
+				return 0;
+			return ret;
 		}
 
 		if (ret == -FI_ENOMSG) {

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -41,6 +41,8 @@ struct fi_provider *lower_efa_prov;
 
 struct rxr_env rxr_env = {
 	.rx_window_size	= RXR_DEF_MAX_RX_WINDOW,
+	.tx_max_credits = RXR_DEF_MAX_TX_CREDITS,
+	.tx_min_credits = RXR_DEF_MIN_TX_CREDITS,
 	.tx_queue_size = 0,
 	.enable_sas_ordering = 1,
 	.recvwin_size = RXR_RECVWIN_SIZE,
@@ -60,6 +62,8 @@ struct rxr_env rxr_env = {
 static void rxr_init_env(void)
 {
 	fi_param_get_int(&rxr_prov, "rx_window_size", &rxr_env.rx_window_size);
+	fi_param_get_int(&rxr_prov, "tx_max_credits", &rxr_env.tx_max_credits);
+	fi_param_get_int(&rxr_prov, "tx_min_credits", &rxr_env.tx_min_credits);
 	fi_param_get_int(&rxr_prov, "tx_queue_size", &rxr_env.tx_queue_size);
 	fi_param_get_int(&rxr_prov, "enable_sas_ordering", &rxr_env.enable_sas_ordering);
 	fi_param_get_int(&rxr_prov, "recvwin_size", &rxr_env.recvwin_size);
@@ -424,7 +428,11 @@ struct fi_provider rxr_prov = {
 EFA_INI
 {
 	fi_param_define(&rxr_prov, "rx_window_size", FI_PARAM_INT,
-			"Defines the maximum window size that a receiver will return for matched large messages. Defaults to the number of available posted receive buffers when the clear to send message is sent (Default: 16).");
+			"Defines the maximum window size that a receiver will return for matched large messages. (Default: 128).");
+	fi_param_define(&rxr_prov, "tx_max_credits", FI_PARAM_INT,
+			"Defines the maximum number of credits a sender requests from a receiver (Default: 64).");
+	fi_param_define(&rxr_prov, "tx_min_credits", FI_PARAM_INT,
+			"Defines the minimum number of credits a sender requests from a receiver (Default: 32).");
 	fi_param_define(&rxr_prov, "tx_queue_size", FI_PARAM_INT,
 			"Defines the maximum number of unacknowledged sends with the NIC.");
 	fi_param_define(&rxr_prov, "enable_sas_ordering", FI_PARAM_INT,

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -147,6 +147,11 @@ static int rxr_copy_attr(const struct fi_info *info, struct fi_info *dup)
 				return -FI_ENOMEM;
 		}
 	}
+	if (info->nic) {
+		dup->nic = ofi_nic_dup(info->nic);
+		if (!dup->nic)
+			return -FI_ENOMEM;
+	}
 	return 0;
 }
 

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -88,9 +88,9 @@ struct rxr_tx_entry *rxr_readrsp_tx_entry_init(struct rxr_ep *rxr_ep,
 	 * this tx_entry works similar to a send tx_entry thus its op was
 	 * set to ofi_op_msg. Note this tx_entry will not write a completion
 	 */
-	rxr_generic_tx_entry_init(tx_entry, rx_entry->iov, rx_entry->iov_count,
-				  NULL, 0, rx_entry->addr, 0, 0, NULL,
-				  ofi_op_msg, 0);
+	rxr_generic_tx_entry_init(rxr_ep, tx_entry, rx_entry->iov,
+				  rx_entry->iov_count, NULL, 0, rx_entry->addr,
+				  0, 0, NULL, ofi_op_msg, 0);
 
 	tx_entry->cq_entry.flags |= FI_READ;
 	/* rma_loc_rx_id is for later retrieve of rx_entry


### PR DESCRIPTION
Some critical fixes that need to be backported to the release branch. The flowcontrol changes were also fixed with `0da8130` so that it does not break protocol compatibility and is safe to be backported.