### PR TITLE
prov/psm2: Always enable the lock accessed by the disconnection thread

### DIFF
--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -375,7 +375,6 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			domain_priv->av_lock_fn = psmx2_lock_disabled;
 			domain_priv->trx_ctxt_lock_fn = psmx2_lock_disabled;
 			domain_priv->trigger_queue_lock_fn = psmx2_lock_disabled;
-			domain_priv->peer_lock_fn = psmx2_lock_disabled;
 			domain_priv->sep_lock_fn = psmx2_lock_disabled;
 			domain_priv->trigger_lock_fn = psmx2_lock_disabled;
 			domain_priv->cq_lock_fn = psmx2_lock_disabled;
@@ -386,13 +385,16 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			domain_priv->av_unlock_fn = psmx2_lock_disabled;
 			domain_priv->trx_ctxt_unlock_fn = psmx2_lock_disabled;
 			domain_priv->trigger_queue_unlock_fn = psmx2_lock_disabled;
-			domain_priv->peer_unlock_fn = psmx2_lock_disabled;
 			domain_priv->sep_unlock_fn = psmx2_lock_disabled;
 			domain_priv->trigger_unlock_fn = psmx2_lock_disabled;
 			domain_priv->cq_unlock_fn = psmx2_lock_disabled;
 			domain_priv->mr_unlock_fn = psmx2_lock_disabled;
 			domain_priv->context_unlock_fn = psmx2_lock_disabled;
 			domain_priv->poll_unlock_fn = psmx2_lock_disabled;
+
+			/* Enable lock accessed by the disconnection thread */
+			domain_priv->peer_lock_fn = psmx2_lock_enabled;
+			domain_priv->peer_unlock_fn = psmx2_unlock_enabled;
 
 			/*
 			 * If FI_RMA or FI_ATOMIC caps are enabled, then locks are


### PR DESCRIPTION
Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>