### PR TITLE
Use address length when doing an address vector lookup

### DIFF
--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -78,7 +78,10 @@ rxm_av_insert_cmap(struct fid_av *av_fid, const void *addr, size_t count,
 			if (!rxm_ep->cmap)
 				break;
 
-			cur_addr = (const void *) ((char *) addr + i * av->addrlen);
+			size_t addrlen = ((struct sockaddr *) addr)->sa_family == AF_INET ?
+				sizeof(struct sockaddr_in) :
+				sizeof(struct sockaddr_in6);
+			cur_addr = (const void *) ((char *) addr + i * MIN(addrlen, av->addrlen));
 			fi_addr_tmp = (fi_addr ? fi_addr[i] :
 				       ofi_av_lookup_fi_addr_unsafe(av, cur_addr));
 			if (fi_addr_tmp == FI_ADDR_NOTAVAIL)

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -157,7 +157,11 @@ static int rxm_cmap_match_peer(struct dlist_entry *entry, const void *addr)
 	struct rxm_cmap_peer *peer;
 
 	peer = container_of(entry, struct rxm_cmap_peer, entry);
-	return !memcmp(peer->addr, addr, peer->handle->cmap->av->addrlen);
+
+	size_t addrlen = ((struct sockaddr *) addr)->sa_family == AF_INET ?
+		sizeof(struct sockaddr_in) :
+		sizeof(struct sockaddr_in6);
+	return !memcmp(peer->addr, addr, MIN(addrlen, peer->handle->cmap->av->addrlen));
 }
 
 static int rxm_cmap_del_handle(struct rxm_cmap_handle *handle)


### PR DESCRIPTION
If the domain address format is set to FI_SOCKADDR then address vector will be initialized for ipv6 addresses.  If ipv4 addresses are inserted into the address vector this will cause lookup misses and duplicate entries which may create duplicate connections.  The address length needs to be taken into account with HASH_ADD and HASH_FIND instead of relying on the length of the address vector. Also zero out the extra bits when inserting an ipv4 address as a precautionary measure.

Signed-off-by: Matt Wycklendt <wycklendt@google.com>