### PR TITLE
prov/rxm: Fix connection handle shutdown/CQ processing race

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -448,7 +448,6 @@ void rxm_cmap_process_shutdown(struct rxm_cmap *cmap,
 			"Invalid handle on shutdown event\n");
 	} else if (handle->state != RXM_CMAP_SHUTDOWN) {
 		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Got remote shutdown\n");
-		rxm_cmap_del_handle(handle);
 	} else {
 		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Got local shutdown\n");
 	}


### PR DESCRIPTION
When an RDMA CM disconnect event is received do not
immediately create a FI_SHUTDOWN event. Instead wait until
the timewait event is received before reporting the shutdown.
In larger fabrics we were seeing the FI_SHUTDOWN event delivered
prior to the QP fully draining and CQ entries processed.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>