### PR TITLE
prov/gni: fix memory leak in multi-recv buffer handling

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -2012,7 +2012,6 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 	struct gnix_tag_storage *unexp_queue;
 	struct gnix_tag_storage *posted_queue;
 	int tagged;
-	bool multi_recv = false;
 
 	GNIX_DBG_TRACE(FI_LOG_EP_DATA, "\n");
 
@@ -2033,7 +2032,6 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 			if (req == NULL) {
 				return -FI_ENOMEM;
 			}
-			multi_recv = true;
 		}
 
 		req->addr = vc->peer_addr;
@@ -2057,14 +2055,10 @@ static int __smsg_eager_msg_w_data(void *data, void *msg)
 		GNIX_DEBUG(FI_LOG_EP_DATA, "Freeing req: %p\n", req);
 
 		/*
-		 * Dequeue and free the request if not
-		 * matching a FI_MULTI_RECV buffer.
+		 * Dequeue and free the request.
 		 */
-		if (multi_recv == false) {
-			_gnix_remove_tag(posted_queue, req);
-			_gnix_fr_free(ep, req);
-		}
-
+		_gnix_remove_tag(posted_queue, req);
+		_gnix_fr_free(ep, req);
 	} else {
 		/* Add new unexpected receive request. */
 		req = _gnix_fr_alloc(ep);
@@ -2178,7 +2172,6 @@ static int __smsg_rndzv_start(void *data, void *msg)
 	struct gnix_tag_storage *unexp_queue;
 	struct gnix_tag_storage *posted_queue;
 	int tagged;
-	bool multi_recv = false;
 
 	GNIX_DBG_TRACE(FI_LOG_EP_DATA, "\n");
 
@@ -2198,7 +2191,6 @@ static int __smsg_rndzv_start(void *data, void *msg)
 			if (req == NULL) {
 				return -FI_ENOMEM;
 			}
-			multi_recv = true;
 		}
 
 		req->addr = vc->peer_addr;
@@ -2246,8 +2238,7 @@ static int __smsg_rndzv_start(void *data, void *msg)
 			  req, req->msg.recv_info[0].recv_addr,
 			  req->msg.send_info[0].send_len);
 
-		if (multi_recv == false)
-			_gnix_remove_tag(posted_queue, req);
+		_gnix_remove_tag(posted_queue, req);
 
 		/* Queue request to initiate pull of source data. */
 		ret = _gnix_vc_queue_work_req(req);


### PR DESCRIPTION
Routine __handle_mrecv_req() checks if a buffer is a multi-recv
buffer, and if so, it allocates a separate gnix_fab_req struct to
use for the message about to be landed in that buffer.  However,
code in __smsg_eager_msg_w_data() and __smsg_rndzv_start() would
interpret that returned req pointer as a pointer to the multi-recv
buffer, and would not free the 'req' after completing the message
transfer.  The result was the leaking of one gnix_fab_req struct
for each message landing in a multi-recv buffer.

This PR removes the 'multi_recv' variable handling in those two
routines so that the gnix_fab_req struct that gets allocated by
__handle_mrecv_req gets properly freed in the same way that a
non-multi-recv gnix_fab_req would be freed.

fixes #5232

Signed-off-by: Kevan Rehm krehm@cray.com