### PR TITLE
prov/efa: fix alloc handler to use correct pointer and size

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2399,8 +2399,8 @@ static int rxr_buf_region_alloc_hndlr(struct ofi_bufpool_region *region)
 	struct fid_mr *mr;
 	struct rxr_domain *domain = region->pool->attr.context;
 
-	ret = fi_mr_reg(domain->rdm_domain, region->mem_region,
-			region->pool->region_size,
+	ret = fi_mr_reg(domain->rdm_domain, region->alloc_region,
+			region->pool->alloc_size,
 			FI_SEND | FI_RECV, 0, 0, 0, &mr, NULL);
 
 	region->context = mr;


### PR DESCRIPTION
The alloc handler was using the pointer and size for the buf pool
allocation area without the buf pool headers. Instead, it should use the
pointer that is returned by mmap/posix_memalign to avoid page alignment
issues.

Signed-off-by: Robert Wespetal <wesper@amazon.com>