### PR TITLE
core/mr_cache: Limit cache size by default

### DIFF
--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -72,6 +72,8 @@ static inline long ofi_get_page_size()
 }
 ssize_t ofi_get_hugepage_size(void);
 
+size_t ofi_get_mem_size(void);
+
 
 /* We implement memdup to avoid external library dependency */
 static inline void *mem_dup(const void *src, size_t size)

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -213,9 +213,6 @@ extern "C" {
 #define SHUT_RDWR	SD_BOTH
 #endif
 
-#ifndef _SC_PAGESIZE
-#define _SC_PAGESIZE	0
-#endif
 
 #define FI_DESTRUCTOR(func) void func
 
@@ -831,15 +828,33 @@ static inline char * strndup(char const *src, size_t n)
 	return dst;
 }
 
+#ifndef _SC_PAGESIZE
+#define _SC_PAGESIZE	0
+#endif
+
+#ifndef _SC_NPROCESSORS_ONLN
+#define _SC_NPROCESSORS_ONLN 1
+#endif
+
+#ifndef _SC_PHYS_PAGES
+#define _SC_PHYS_PAGES 2
+#endif
+
 static inline long ofi_sysconf(int name)
 {
 	SYSTEM_INFO si;
+	ULONGLONG mem_size = 0;
 
 	GetSystemInfo(&si);
 
 	switch (name) {
 	case _SC_PAGESIZE:
 		return si.dwPageSize;
+	case _SC_NPROCESSORS_ONLN:
+		return si.dwNumberOfProcessors;
+	case _SC_PHYS_PAGES:
+		GetPhysicallyInstalledSystemMemory(&mem_size);
+		return mem_size / si.dwPageSize;
 	default:
 		errno = EINVAL;
 		return -1;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -213,8 +213,8 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 		}
 	}
 
-	if ((cache->cached_cnt > cache_params.max_cnt) ||
-	    (cache->cached_size > cache_params.max_size)) {
+	if ((cache->cached_cnt >= cache_params.max_cnt) ||
+	    (cache->cached_size >= cache_params.max_size)) {
 		(*entry)->cached = 0;
 		cache->uncached_cnt++;
 		cache->uncached_size += iov->iov_len;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -445,7 +445,7 @@ int ofi_mr_cache_init(struct util_domain *domain,
 	int ret;
 
 	assert(cache->add_region && cache->delete_region);
-	if (!cache_params.max_cnt)
+	if (!cache_params.max_cnt || !cache_params.max_size)
 		return -FI_ENOSPC;
 
 	dlist_init(&cache->lru_list);

--- a/src/mem.c
+++ b/src/mem.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018, Intel Corporation
+ * Copyright 2014-2019, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,6 +102,24 @@ free_list:
 void ofi_mem_fini(void)
 {
 	free(page_sizes);
+}
+
+size_t ofi_get_mem_size(void)
+{
+	long page_cnt, page_size;
+	size_t mem_size;
+
+	page_cnt = ofi_sysconf(_SC_PHYS_PAGES);
+	page_size = ofi_get_page_size();
+
+	if (page_cnt <= 0 || page_size <= 0)
+		return 0;
+
+	mem_size = (size_t) page_cnt * (size_t) page_size;
+	if (mem_size < page_cnt || mem_size < page_size)
+		return 0;
+
+	return mem_size;
 }
 
 


### PR DESCRIPTION
The MR cache is currently unlimited in how much memory may be
registered by the cache.  At scale, this causes application
crashes when the system runs out of memory.  Change the default
to limit the cache size to:

total memory / # of cpus / 2

Assuming 1 process per core, this will limit the total amount
of system memory that will be maintained by the collective
caches to half of system memory.

Disable the cache if cache size is set to 0.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>