### PR TITLE
prov/gni: memcpy() of SMSG data to buffer using incorrect length

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -265,20 +265,22 @@ fn_exit:
 static void __gnix_msg_copy_data_to_recv_addr(struct gnix_fab_req *req,
 					      void *data)
 {
+	size_t	len;
+
 	GNIX_DBG_TRACE(FI_LOG_EP_DATA, "\n");
+
+	len = MIN(req->msg.cum_send_len, req->msg.cum_recv_len);
 
 	switch(req->type) {
 	case GNIX_FAB_RQ_RECV:
-		memcpy((void *)req->msg.recv_info[0].recv_addr, data,
-		       req->msg.cum_recv_len);
+		memcpy((void *)req->msg.recv_info[0].recv_addr, data, len);
 		break;
 
 	case GNIX_FAB_RQ_RECVV:
 	case GNIX_FAB_RQ_TRECVV:
 		__gnix_msg_unpack_data_into_iov(req->msg.recv_info,
 						req->msg.recv_iov_cnt,
-						(uint64_t) data,
-						req->msg.cum_recv_len);
+						(uint64_t) data, len);
 		break;
 
 	default:


### PR DESCRIPTION
Routine __gnix_msg_copy_data_to_recv_addr() was recently changed because
an incoming message larger than the matched recv or multi-recv buffer
would result in buffer overflow. The reverse problem is now occurring,
the recv buffer's req->msg.cum_recv_len is now being used for the length
of the memcpy(), when the incoming SMSG is only a hundred bytes long.

The memcpy() is now called with the minimum of the cum_recv_len and
cum_send_len.

fixes ofiwg#5166
related to #1567

Signed-off-by: Kevan Rehm <krehm@cray.com>
(cherry picked from commit 177042c9b196be21f98ac364af1291b082779193)