### PR TITLE
prov/gni: fix an edge error case

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -3284,7 +3284,7 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	ret = _gnix_vc_queue_tx_req(req);
 	connected = (vc->conn_state == GNIX_VC_CONNECTED);
 
-	COND_RELEASE(vc->ep->requires_lock, &vc->ep->vc_lock);
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 
 	/*
 	 * If a new VC was allocated, progress CM before returning.
@@ -3300,7 +3300,7 @@ ssize_t _gnix_send(struct gnix_fid_ep *ep, uint64_t loc_addr, size_t len,
 	return ret;
 
 err_get_vc:
-	COND_RELEASE(vc->ep->requires_lock, &vc->ep->vc_lock);
+	COND_RELEASE(ep->requires_lock, &ep->vc_lock);
 	_gnix_fr_free(ep, req);
 	if (flags & FI_LOCAL_MR)
 		fi_close(&auto_mr->fid);


### PR DESCRIPTION
which could lead to a segfault rather than return an error.

related to #5186

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit a486274720e7c08fc376acdac2686eefe6c4fb06)