### PR TITLE
prov/gni: fix a breakage from previous commit

### DIFF
--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -409,7 +409,7 @@ static int __recv_completion_src(
 
 	if ((req->msg.recv_flags & FI_COMPLETION) && ep->recv_cq) {
 		if ((src_addr == FI_ADDR_NOTAVAIL) &&
-                    (req->msg.recv_flags & FI_SOURCE_ERR) != 0) {
+                    (ep->caps & FI_SOURCE_ERR) != 0) {
 			if (ep->domain->addr_format == FI_ADDR_STR) {
 				buffer = malloc(GNIX_FI_ADDR_STR_LEN);
 				rc = _gnix_ep_name_to_str(req->vc->gnix_ep_name, (char **)&buffer);


### PR DESCRIPTION
This commit

fixes #5191
related to #5218

Signed-off-by: Howard Pritchard <howardp@lanl.gov>
(cherry picked from commit ce3375a6dd20db2c0fed8c9cb7c94e4f05d57829)