### PR TITLE
include/fabric, domain: add HMEM API changes

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -162,6 +162,7 @@ typedef struct fid *fid_t;
 #define FI_COMMIT_COMPLETE	(1ULL << 30)
 #define FI_MATCH_COMPLETE	(1ULL << 31)
 
+#define FI_HMEM			(1ULL << 47)
 #define FI_VARIABLE_MSG		(1ULL << 48)
 #define FI_RMA_PMEM		(1ULL << 49)
 #define FI_SOURCE_ERR		(1ULL << 50)
@@ -231,6 +232,7 @@ enum fi_mr_mode {
 #define FI_MR_MMU_NOTIFY	(1 << 7)
 #define FI_MR_RMA_EVENT		(1 << 8)
 #define FI_MR_ENDPOINT		(1 << 9)
+#define FI_MR_HMEM		(1 << 10)
 
 enum fi_progress {
 	FI_PROGRESS_UNSPEC,

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -112,6 +112,11 @@ struct fid_mr {
 	uint64_t		key;
 };
 
+enum fi_hmem_iface {
+	FI_HMEM_SYSTEM	= 0,
+	FI_HMEM_CUDA,
+};
+
 struct fi_mr_attr {
 	const struct iovec	*mr_iov;
 	size_t			iov_count;
@@ -121,6 +126,11 @@ struct fi_mr_attr {
 	void			*context;
 	size_t			auth_key_size;
 	uint8_t			*auth_key;
+	enum fi_hmem_iface	iface;
+	union {
+		uint64_t	reserved;
+		int		cuda;
+	} device;
 };
 
 struct fi_mr_modify {

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -420,6 +420,10 @@ additional optimizations.
   are any messages larger than an endpoint configurable size.  This
   flag requires that FI_MSG and/or FI_TAGGED be set.
 
+*FI_HMEM*
+: Specifies that the endpoint should support transfers to and from
+  device memory. 
+
 Capabilities may be grouped into two general categories: primary and
 secondary.  Primary capabilities must explicitly be requested by an
 application, and a provider must enable support for only those primary
@@ -431,7 +435,7 @@ would not compromise performance or security.
 
 Primary capabilities: FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_MULTICAST,
 FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_READ, FI_WRITE, FI_RECV, FI_SEND,
-FI_REMOTE_READ, FI_REMOTE_WRITE, and FI_VARIABLE_MSG.
+FI_REMOTE_READ, FI_REMOTE_WRITE, FI_VARIABLE_MSG, FI_HMEM.
 
 Secondary capabilities: FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_SHARED_AV,
 FI_TRIGGER, FI_FENCE, FI_LOCAL_COMM, FI_REMOTE_COMM, FI_SOURCE_ERR, FI_RMA_PMEM.


### PR DESCRIPTION
Add API changes for GPU aware applications:

- Add FI_HMEM capability for applications to request device support
- Add FI_MR_HMEM mr_mode for providers to set if they require the
  application to register device memory
- Add fi_mr_attr::iface to pass the hmem interface to the provider
  when registering device memory
- Add fi_mr_attr union to pass interface-specific device
  identifier to specify on which device the memory resides

This allows providers to easily know what buffers are on which device
without having to query the device.

Signed-off-by: aingerson <alexia.ingerson@intel.com>