### PR TITLE
prov/verbs: Add XRC support for updated rdma-core librdmacm

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -58,6 +58,17 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 	AC_DEFINE_UNQUOTED([VERBS_HAVE_XRC],[$VERBS_HAVE_XRC],
 		[Whether infiniband/verbs.h has XRC support or not])
 
+	#See if we have rdma-core rdma_establish support
+	VERBS_HAVE_RDMA_ESTABLISH=0
+	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
+	       test $verbs_rdmacm_ex_happy -eq 1],[
+		AC_CHECK_DECL([rdma_establish],
+			[VERBS_HAVE_RDMA_ESTABLISH=1],[],
+			[#include <rdma/rdma_cma.h>])
+		])
+	AC_DEFINE_UNQUOTED([VERBS_HAVE_RDMA_ESTABLISH],[$VERBS_HAVE_RDMA_ESTABLISH],
+		[Whether rdma/rdma_cma.h has rdma_establish() support or not])
+
 	# Technically, verbs_ibverbs_CPPFLAGS and
 	# verbs_rdmacm_CPPFLAGS could be different, but it is highly
 	# unlikely that they ever will be.  So only list

--- a/prov/verbs/src/ofi_verbs_priv.h
+++ b/prov/verbs/src/ofi_verbs_priv.h
@@ -60,4 +60,9 @@
 #define FI_VERBS_XRC_ONLY
 #endif /* VERBS_HAVE_XRC */
 
+#if !VERBS_HAVE_RDMA_ESTABLISH
+/* If older rdma-core this function does not exist/is not needed */
+#define rdma_establish(id) do { } while (0)
+#endif
+
 #endif /* OFI_VERBS_PRIV_H */


### PR DESCRIPTION
The rdma-core librdmacm has been extended to implement the
RDMA_CM_EVENT_CONNECT_RESPONSE event to notify the
active side of a connection if the QP is not managed
by the RDMA CM (i.e. id->qp == NULL). Allowing additional
connection initialization to take place if required.

This patch adds XRC support for these updates if the
librdmacm supports the required new call, rdma_establish().

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>