### PR TITLE
prov/sockets: memset realloced new memroy to 0

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -160,6 +160,7 @@ static int sock_resize_av_table(struct sock_av *av)
 		new_addr = realloc(av->table_hdr, table_sz);
 		if (!new_addr)
 			return -1;
+		memset((char *) new_addr + old_sz, 0, table_sz - old_sz);
 	}
 
 	av->table_hdr = new_addr;


### PR DESCRIPTION
set new memory obtained through realloc to 0.

Signed-off-by: Yulu Jia <yulu.jia@intel.com>