### PR TITLE
convert ofi_mem_monitor spinlock to pthread mutex

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -102,7 +102,7 @@ static inline uint64_t ofi_mr_get_prov_mode(uint32_t version,
 struct ofi_mr_cache;
 
 struct ofi_mem_monitor {
-	fastlock_t			lock;
+	pthread_mutex_t 		lock;
 	struct dlist_entry		list;
 
 	int (*subscribe)(struct ofi_mem_monitor *notifier,

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -252,12 +252,12 @@ static void *ofi_intercept_dlopen(const char *filename, int flag)
 	if (!handle)
 		return NULL;
 
-	fastlock_acquire(&memhooks_monitor->lock);
+	pthread_mutex_lock(&memhooks_monitor->lock);
 	dlist_foreach_container(&memhooks.intercept_list, struct ofi_intercept,
 		intercept, entry) {
 		dl_iterate_phdr(ofi_intercept_phdr_handler, intercept);
 	}
-	fastlock_release(&memhooks_monitor->lock);
+	pthread_mutex_unlock(&memhooks_monitor->lock);
 	return handle;
 }
 
@@ -356,9 +356,9 @@ static int ofi_intercept_symbol(struct ofi_intercept *intercept, void **real_fun
 
 void ofi_intercept_handler(const void *addr, size_t len)
 {
-	fastlock_acquire(&memhooks_monitor->lock);
+	pthread_mutex_lock(&memhooks_monitor->lock);
 	ofi_monitor_notify(memhooks_monitor, addr, len);
-	fastlock_release(&memhooks_monitor->lock);
+	pthread_mutex_unlock(&memhooks_monitor->lock);
 }
 
 static void *ofi_intercept_mmap(void *start, size_t length,


### PR DESCRIPTION
Bug fix: some of the critical paths in util_mr_cache may yield while holding the
monitor lock.  If the monitor lock is a spinlock, then starvation can happen
if all available cores spin trying to acquire the lock while the thread holding
the lock is suspended.

fixes #5244 