### PR TITLE
core/mr_cache: Ensure that we remove the correct entry from storage

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -223,7 +223,7 @@ extern struct ofi_mr_cache_params	cache_params;
 
 struct ofi_mr_entry {
 	struct ofi_mr_info		info;
-	unsigned int			cached:1;
+	void				*storage_context;
 	unsigned int			subscribed:1;
 	int				use_cnt;
 	struct dlist_entry		lru_entry;


### PR DESCRIPTION
When we want to remove an cached mr entry from the underlying
rbtree, we use the entry as input into the rbtree find routine.
However, it's possible that we could match some other node
in the tree, depending on which find routine is used.  For
example, find_overlap() can match nodes that refer to an
overlapping memory region.

To avoid possible issues, extend the mr_entry structure to record
the rbtree node pointer.  This will allow us to remove the node
directly without needing to perform a new search.

The new 'storage_context' replaces the 'cached' entry, as it
implies the same state.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>