### PR TITLE
core: Fix setting loopback addresses

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -229,12 +229,12 @@ static inline long ofi_sysconf(int name)
 
 static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 	return (addr->sa_family == AF_INET &&
-		((struct sockaddr_in *)addr)->sin_addr.s_addr == ntohl(INADDR_LOOPBACK)) ||
+		((struct sockaddr_in *)addr)->sin_addr.s_addr == htonl(INADDR_LOOPBACK)) ||
 		(addr->sa_family == AF_INET6 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[0] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[1] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[2] == 0 &&
-		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[3] == ntohl(1));
+		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[3] == htonl(1));
 }
 
 

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -885,7 +885,7 @@ static inline int ofi_hugepage_enabled(void)
 
 static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 	return (addr->sa_family == AF_INET &&
-		((struct sockaddr_in *)addr)->sin_addr.s_addr == ntohl(INADDR_LOOPBACK)) ||
+		((struct sockaddr_in *)addr)->sin_addr.s_addr == htonl(INADDR_LOOPBACK)) ||
 		(addr->sa_family == AF_INET6 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[0] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[1] == 0 &&
@@ -894,7 +894,7 @@ static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[4] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[5] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[6] == 0 &&
-		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[7] == ntohs(1));
+		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[7] == htons(1));
 }
 
 static inline size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)

--- a/src/common.c
+++ b/src/common.c
@@ -1087,7 +1087,7 @@ void ofi_insert_loopback_addr(struct fi_provider *prov, struct slist *addr_list)
 		return;
 
 	addr_entry->ipaddr.sin.sin_family = AF_INET;
-	addr_entry->ipaddr.sin.sin_addr.s_addr = INADDR_LOOPBACK;
+	addr_entry->ipaddr.sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	ofi_straddr_log(prov, FI_LOG_INFO, FI_LOG_CORE,
 			"available addr: ", &addr_entry->ipaddr);
 
@@ -1246,7 +1246,7 @@ void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
 
 	for (i = 0; i < iptbl->dwNumEntries; i++) {
 		if (iptbl->table[i].dwAddr &&
-		    (iptbl->table[i].dwAddr != ntohl(INADDR_LOOPBACK))) {
+		    (iptbl->table[i].dwAddr != htonl(INADDR_LOOPBACK))) {
 			addr_entry = calloc(1, sizeof(*addr_entry));
 			if (!addr_entry)
 				break;


### PR DESCRIPTION
The loopback addresses are being set using host order, rather
than network order.  As a result, the returned src_addr from
fi_info calls does not include the loopback addresses, but
rather something like this: 1.0.0.127.

Update calls from ntoh to hton to better reflect reality when
accessing the loopack address.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>