### PR TITLE
core: Fix setting loopback addresses

### DIFF
--- a/fabtests/test_configs/tcp/quick.test
+++ b/fabtests/test_configs/tcp/quick.test
@@ -1,0 +1,60 @@
+#: "Suite of tests for the tcp provider"
+{
+	prov_name: tcp,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT
+	],
+	class_function: [
+		FT_FUNC_SEND,
+		FT_FUNC_SENDV,
+		FT_FUNC_SENDMSG,
+		FT_FUNC_INJECT,
+		FT_FUNC_INJECTDATA,
+		FT_FUNC_SENDDATA,
+	],
+	ep_type: [
+		FI_EP_MSG,
+	],
+	comp_type: [
+		FT_COMP_QUEUE
+	],
+	mode: [
+		FT_MODE_NONE
+	],
+	test_class: [
+		FT_CAP_MSG,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: tcp,
+	test_type: [
+		FT_TEST_LATENCY,
+		FT_TEST_BANDWIDTH,
+		FT_TEST_UNIT
+	],
+	class_function: [
+		FT_FUNC_READ,
+		FT_FUNC_READV,
+		FT_FUNC_READMSG,
+		FT_FUNC_WRITE,
+		FT_FUNC_WRITEV,
+		FT_FUNC_WRITEMSG,
+		FT_FUNC_WRITEDATA
+	],
+	ep_type: [
+		FI_EP_MSG,
+	],
+	comp_type: [
+		FT_COMP_QUEUE
+	],
+	mode: [
+		FT_MODE_NONE
+	],
+	test_class: [
+		FT_CAP_RMA,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+}

--- a/fabtests/ubertest/uber.c
+++ b/fabtests/ubertest/uber.c
@@ -370,7 +370,7 @@ static int ft_skip_info(struct fi_info *hints, struct fi_info *info)
 
 	//check needed to skip utility providers, unless requested
 	skip = (!ft_util_name(hints->fabric_attr->prov_name, &len) &&
-		strcmp(hints->fabric_attr->prov_name,
+		strcasecmp(hints->fabric_attr->prov_name,
 		info->fabric_attr->prov_name));
 
 	ret = ft_exchange_uint32(skip, &remote_skip);

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -229,12 +229,12 @@ static inline long ofi_sysconf(int name)
 
 static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 	return (addr->sa_family == AF_INET &&
-		((struct sockaddr_in *)addr)->sin_addr.s_addr == ntohl(INADDR_LOOPBACK)) ||
+		((struct sockaddr_in *)addr)->sin_addr.s_addr == htonl(INADDR_LOOPBACK)) ||
 		(addr->sa_family == AF_INET6 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[0] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[1] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[2] == 0 &&
-		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[3] == ntohl(1));
+		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[3] == htonl(1));
 }
 
 

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -885,7 +885,7 @@ static inline int ofi_hugepage_enabled(void)
 
 static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 	return (addr->sa_family == AF_INET &&
-		((struct sockaddr_in *)addr)->sin_addr.s_addr == ntohl(INADDR_LOOPBACK)) ||
+		((struct sockaddr_in *)addr)->sin_addr.s_addr == htonl(INADDR_LOOPBACK)) ||
 		(addr->sa_family == AF_INET6 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[0] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[1] == 0 &&
@@ -894,7 +894,7 @@ static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[4] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[5] == 0 &&
 		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[6] == 0 &&
-		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[7] == ntohs(1));
+		((struct sockaddr_in6 *)addr)->sin6_addr.u.Word[7] == htons(1));
 }
 
 size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);

--- a/src/common.c
+++ b/src/common.c
@@ -1087,7 +1087,7 @@ void ofi_insert_loopback_addr(struct fi_provider *prov, struct slist *addr_list)
 		return;
 
 	addr_entry->ipaddr.sin.sin_family = AF_INET;
-	addr_entry->ipaddr.sin.sin_addr.s_addr = INADDR_LOOPBACK;
+	addr_entry->ipaddr.sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	ofi_straddr_log(prov, FI_LOG_INFO, FI_LOG_CORE,
 			"available addr: ", &addr_entry->ipaddr);
 
@@ -1246,7 +1246,7 @@ void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
 
 	for (i = 0; i < iptbl->dwNumEntries; i++) {
 		if (iptbl->table[i].dwAddr &&
-		    (iptbl->table[i].dwAddr != ntohl(INADDR_LOOPBACK))) {
+		    (iptbl->table[i].dwAddr != htonl(INADDR_LOOPBACK))) {
 			addr_entry = calloc(1, sizeof(*addr_entry));
 			if (!addr_entry)
 				break;


### PR DESCRIPTION
The loopback addresses are being set using host order, rather
than network order.  As a result, the returned src_addr from
fi_info calls does not include the loopback addresses, but
rather something like this: 1.0.0.127.

Update calls from ntoh to hton to better reflect reality when
accessing the loopack address.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>