### PR TITLE
windows/osd: fixed netmask in getifaddrs function

### DIFF
--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -465,7 +465,7 @@ int getifaddrs(struct ifaddrs **ifap)
 								&fa->in_netmasks;
 				netmask4->sin_family = pSockAddr->sa_family;
 				addr4->sin_family = pSockAddr->sa_family;
-				netmask4->sin_addr.S_un.S_addr = mask;
+				netmask4->sin_addr.S_un.S_addr = *mask;
 				pInAddr = (struct sockaddr_in *) pSockAddr;
 				addr4->sin_addr = pInAddr->sin_addr;
 			} else {


### PR DESCRIPTION
Fixed netmask value in getifaddrs implementation on Windows.
The bug does not break core functionality, but leads to wrong
IPv4 addresses in fi_info output.

Signed-off-by: Andrey Lobanov <andrey.lobanov@intel.com>