### PR TITLE
verbs: Allow passing of OFI_MR_NOCACHE flag

### DIFF
--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -159,7 +159,7 @@ fi_ibv_mr_reg(struct fid *fid, const void *buf, size_t len,
 	struct fi_ibv_mem_desc *md;
 	int ret;
 
-	if (OFI_UNLIKELY(flags))
+	if (OFI_UNLIKELY(flags & ~OFI_MR_NOCACHE))
 		return -FI_EBADFLAGS;
 
 	md = calloc(1, sizeof(*md));


### PR DESCRIPTION
RXM now passes the OFI_MR_NOCACHE flag on a MR registration.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>