### PR TITLE
core/mr_cache: Ensure that we remove the correct entry + ubertest updates

### DIFF
--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -221,7 +221,7 @@ result, a full ubertest run can take a significant amount of time.  Because
 ubertest iterates over input variables, it relies on a test configuration
 file for control, rather than extensive command line options that are used
 by other fabtests.  A configuration file must be constructured for each
-provider.  Example test configurations are at /test_configs.
+provider.  Example test configurations are at test_configs.
 
 *fi_ubertest*
 : This test takes a configure file as input.  The file contains a list of
@@ -234,11 +234,94 @@ provider.  Example test configurations are at /test_configs.
 
 ### Config file options
 
-TODO: add all supported config options
+The following keys and respective key values may be used in the config file.
 
-- *threading*
-  Specify a list of threading levels. This is a hints only config: ubertest
-  doesn't spawn multiple threads to verify functionality.
+*prov_name*
+: Identify the provider(s) to test.  E.g. udp, tcp, verbs,
+  ofi_rxm;verbs; ofi_rxd;udp.
+
+*test_type*
+: FT_TEST_LATENCY, FT_TEST_BANDWIDTH, FT_TEST_UNIT
+
+*test_class*
+: FT_CAP_MSG, FT_CAP_TAGGED, FT_CAP_RMA, FT_CAP_ATOMIC
+
+*class_function*
+: For FT_CAP_MSG and FT_CAP_TAGGED: FT_FUNC_SEND, FT_FUNC_SENDV, FT_FUNC_SENDMSG,
+  FT_FUNC_INJECT, FT_FUNC_INJECTDATA, FT_FUNC_SENDDATA
+
+  For FT_CAP_RMA: FT_FUNC_WRITE, FT_FUNC_WRITEV, FT_FUNC_WRITEMSG,
+  FT_FUNC_WRITEDATA, FT_FUNC_INJECT_WRITE, FT_FUNC_INJECT_WRITEDATA
+  FT_FUNC_READ, FT_FUNC_READV, FT_FUNC_READMSG
+
+  For FT_CAP_ATOMIC: FT_FUNC_ATOMIC, FT_FUNC_ATOMICV, FT_FUNC_ATOMICMSG,
+  FT_FUNC_INJECT_ATOMIC, FT_FUNC_FETCH_ATOMIC, FT_FUNC_FETCH_ATOMICV,
+  FT_FUNC_FETCH_ATOMICMSG, FT_FUNC_COMPARE_ATOMIC, FT_FUNC_COMPARE_ATOMICV,
+  FT_FUNC_COMPARE_ATOMICMSG
+
+*constant_caps - values OR'ed together*
+: FI_RMA, FI_MSG, FI_SEND, FI_RECV, FI_READ,
+  FI_WRITE, FI_REMOTE_READ, FI_REMOTE_WRITE, FI_TAGGED, FI_DIRECTED_RECV
+
+*mode - values OR'ed together*
+: FI_CONTEXT, FI_RX_CQ_DATA
+
+*ep_type*
+: FI_EP_MSG, FI_EP_DGRAM, FI_EP_RDM
+
+*comp_type*
+: FT_COMP_QUEUE, FT_COMP_CNTR, FT_COMP_ALL
+
+*av_type*
+: FI_AV_MAP, FI_AV_TABLE
+
+*eq_wait_obj*
+: FI_WAIT_NONE, FI_WAIT_UNSPEC, FI_WAIT_FD, FI_WAIT_MUTEX_COND
+
+*cq_wait_obj*
+: FI_WAIT_NONE, FI_WAIT_UNSPEC, FI_WAIT_FD, FI_WAIT_MUTEX_COND
+
+*cntr_wait_obj*
+: FI_WAIT_NONE, FI_WAIT_UNSPEC, FI_WAIT_FD, FI_WAIT_MUTEX_COND
+
+*threading*
+: FI_THREAD_UNSPEC, FI_THREAD_SAFE, FI_THREAD_FID, FI_THREAD_DOMAIN,
+  FI_THREAD_COMPLETION, FI_THREAD_ENDPOINT
+
+*progress*
+: FI_PROGRESS_MANUAL, FI_PROGRESS_AUTO, FI_PROGRESS_UNSPEC
+
+*mr_mode*
+: (Values OR'ed together) FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED,
+  FI_MR_PROV_KEY
+
+*op*
+: For FT_CAP_ATOMIC: FI_MIN, FI_MAX, FI_SUM, FI_PROD, FI_LOR, FI_LAND, FI_BOR,
+  FI_BAND, FI_LXOR, FI_BXOR, FI_ATOMIC_READ, FI_ATOMIC_WRITE, FI_CSWAP,
+  FI_CSWAP_NE, FI_CSWAP_LE, FI_CSWAP_LT, FI_CSWAP_GE, FI_CSWAP_GT, FI_MSWAP
+
+*datatype*
+: For FT_CAP_ATOMIC: FI_INT8, FI_UINT8, FI_INT16, FI_UINT16, FI_INT32,
+  FI_UINT32, FI_INT64, FI_UINT64, FI_FLOAT, FI_DOUBLE, FI_FLOAT_COMPLEX,
+  FI_DOUBLE_COMPLEX, FI_LONG_DOUBLE, FI_LONG_DOUBLE_COMPLE
+
+*msg_flags - values OR'ed together*
+: For FT_FUNC_XXXMSG: FI_REMOTE_CQ_DATA, FI_COMPLETION
+
+*rx_cq_bind_flags - values OR'ed together*
+: FI_SELECTIVE_COMPLETION
+
+*tx_cq_bind_flags - values OR'ed together*
+: FI_SELECTIVE_COMPLETION
+
+*rx_op_flags - values OR'ed together*
+: FI_COMPLETION
+
+*tx_op_flags - values OR'ed together*
+: FI_COMPLETION
+
+*test_flags - values OR'ed together*
+: FT_FLAG_QUICKTEST
 
 # HOW TO RUN TESTS
 

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -446,6 +446,7 @@ function cs_test {
 function complex_test {
 	local test=$1
 	local config=$2
+	local path=${PROV/;/\/}
 	local test_exe="${test}"
 	local s_ret=0
 	local c_ret=0
@@ -468,7 +469,7 @@ function complex_test {
 	s_pid=$!
 	sleep 1
 
-	c_cmd="${BIN_PATH}${test_exe} -p \"${PROV}\" -t $config $S_INTERFACE $opts"
+	c_cmd="${BIN_PATH}${test_exe} -u "test_configs/${path}/${config}.test" $S_INTERFACE $opts"
 	FI_LOG_LEVEL=error ${CLIENT_CMD} "${EXPORT_ENV} $c_cmd" &> $c_outp &
 	c_pid=$!
 

--- a/fabtests/test_configs/eq_cq.test
+++ b/fabtests/test_configs/eq_cq.test
@@ -1,6 +1,6 @@
-#: "Tests different wait objects for EQ and CQ across sockets and verbs providers"
+#: "Tests different wait objects for EQ and CQ across tcp and verbs providers"
 {
-	prov_name: sockets,
+	prov_name: tcp,
 	test_type: [
 		FT_TEST_LATENCY,
 	],
@@ -34,7 +34,7 @@
 	test_flags: FT_FLAG_QUICKTEST
 },
 {
-	prov_name: sockets,
+	prov_name: tcp,
 	test_type: [
 		FT_TEST_LATENCY,
 		FT_TEST_BANDWIDTH,

--- a/fabtests/test_configs/lat_bw.test
+++ b/fabtests/test_configs/lat_bw.test
@@ -1,6 +1,6 @@
-#: "Latency and bandwidth tests for all providers"
+#: "Latency and bandwidth tests"
 {
-	prov_name: sockets,
+	prov_name: tcp,
 	test_type: [
 		FT_TEST_LATENCY,
 		FT_TEST_BANDWIDTH,

--- a/fabtests/test_configs/ofi_rxd/udp.test
+++ b/fabtests/test_configs/ofi_rxd/udp.test
@@ -16,9 +16,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,

--- a/fabtests/test_configs/psm/all.test
+++ b/fabtests/test_configs/psm/all.test
@@ -20,7 +20,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -53,7 +53,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_RMA,

--- a/fabtests/test_configs/psm2/all.test
+++ b/fabtests/test_configs/psm2/all.test
@@ -21,7 +21,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -50,7 +50,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -84,7 +84,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_RMA,

--- a/fabtests/test_configs/psm2/verify.test
+++ b/fabtests/test_configs/psm2/verify.test
@@ -19,7 +19,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -46,7 +46,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -78,7 +78,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_RMA,
@@ -138,7 +138,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -185,7 +185,7 @@
 		FT_COMP_CNTR,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -237,7 +237,7 @@
 		FT_COMP_QUEUE,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,

--- a/fabtests/test_configs/shm/all.test
+++ b/fabtests/test_configs/shm/all.test
@@ -15,9 +15,6 @@
 	ep_type: [
 		FI_EP_RDM,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -40,9 +37,6 @@
 	],
 	ep_type: [
 		FI_EP_RDM,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -74,9 +68,6 @@
 	ep_type: [
 		FI_EP_RDM,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -103,9 +94,6 @@
 	],
 	ep_type: [
 		FI_EP_RDM,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -141,9 +129,6 @@
 	],
 	ep_type: [
 		FI_EP_RDM,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_RMA,
@@ -175,9 +160,6 @@
 	],
 	ep_type: [
 		FI_EP_RDM,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_RMA,
@@ -218,9 +200,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -259,9 +238,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -302,9 +278,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -347,9 +320,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -381,9 +351,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -422,9 +389,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,

--- a/fabtests/test_configs/shm/quick.test
+++ b/fabtests/test_configs/shm/quick.test
@@ -15,9 +15,6 @@
 	ep_type: [
 		FI_EP_RDM,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -42,9 +39,6 @@
 	],
 	ep_type: [
 		FI_EP_RDM,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -77,9 +71,6 @@
 	ep_type: [
 		FI_EP_RDM,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -107,9 +98,6 @@
 	],
 	ep_type: [
 		FI_EP_RDM,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -146,9 +134,6 @@
 	],
 	ep_type: [
 		FI_EP_RDM,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_RMA,
@@ -181,9 +166,6 @@
 	],
 	ep_type: [
 		FI_EP_RDM,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_RMA,
@@ -227,9 +209,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -269,9 +248,6 @@
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -313,9 +289,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -359,9 +332,6 @@
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -394,9 +364,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -436,9 +403,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,

--- a/fabtests/test_configs/shm/verify.test
+++ b/fabtests/test_configs/shm/verify.test
@@ -14,9 +14,6 @@
 	ep_type: [
 		FI_EP_RDM,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -48,9 +45,6 @@
 	ep_type: [
 		FI_EP_RDM,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_RMA,
 	],
@@ -81,9 +75,6 @@
 	ep_type: [
 		FI_EP_RDM,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_RMA,
 	],
@@ -141,9 +132,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -186,9 +174,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -238,9 +223,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -299,9 +281,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -341,9 +320,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -390,9 +366,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,

--- a/fabtests/test_configs/tcp/quick.test
+++ b/fabtests/test_configs/tcp/quick.test
@@ -20,9 +20,6 @@
 	comp_type: [
 		FT_COMP_QUEUE
 	],
-	mode: [
-		FT_MODE_NONE
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],
@@ -49,9 +46,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE
-	],
-	mode: [
-		FT_MODE_NONE
 	],
 	test_class: [
 		FT_CAP_RMA,

--- a/fabtests/test_configs/udp/all.test
+++ b/fabtests/test_configs/udp/all.test
@@ -31,9 +31,6 @@
 		FI_WAIT_UNSPEC,
 		FI_WAIT_FD,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],

--- a/fabtests/test_configs/udp/functional.test
+++ b/fabtests/test_configs/udp/functional.test
@@ -22,9 +22,6 @@
 	cq_wait_obj: [
 		FI_WAIT_NONE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],

--- a/fabtests/test_configs/udp/lat_bw.test
+++ b/fabtests/test_configs/udp/lat_bw.test
@@ -17,9 +17,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],

--- a/fabtests/test_configs/udp/quick.test
+++ b/fabtests/test_configs/udp/quick.test
@@ -31,9 +31,6 @@
 		FI_WAIT_UNSPEC,
 		FI_WAIT_FD,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],

--- a/fabtests/test_configs/usnic/all.test
+++ b/fabtests/test_configs/usnic/all.test
@@ -32,7 +32,7 @@
 		FI_WAIT_UNSPEC,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT, FI_RX_CQ_DATA,
 	],
 	test_class: [
 		FT_CAP_MSG,

--- a/fabtests/test_configs/usnic/quick.test
+++ b/fabtests/test_configs/usnic/quick.test
@@ -32,7 +32,7 @@
 		FI_WAIT_UNSPEC,
 	],
 	mode: [
-		FT_MODE_ALL,
+		FI_CONTEXT, FI_RX_CQ_DATA,
 	],
 	test_class: [
 		FT_CAP_MSG,

--- a/fabtests/test_configs/verbs/all.test
+++ b/fabtests/test_configs/verbs/all.test
@@ -25,6 +25,7 @@
 	test_class: [
 		FT_CAP_MSG,
 	],
+	mode: [FI_CONTEXT, FI_RX_CQ_DATA],
 	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
 },
 {
@@ -45,6 +46,7 @@
 	test_class: [
 		FT_CAP_MSG,
 	],
+	mode: [FI_CONTEXT, FI_RX_CQ_DATA],
 	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
 	msg_flags: FI_REMOTE_CQ_DATA,
 },
@@ -71,6 +73,7 @@
 	test_class: [
 		FT_CAP_RMA,
 	],
+	mode: [FI_CONTEXT, FI_RX_CQ_DATA],
 	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
 },
 {
@@ -91,6 +94,7 @@
 	test_class: [
 		FT_CAP_RMA,
 	],
+	mode: [FI_CONTEXT, FI_RX_CQ_DATA],
 	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
 	msg_flags: FI_REMOTE_CQ_DATA,
 },
@@ -119,6 +123,7 @@
 	test_class: [
 		FT_CAP_MSG,
 	],
+	mode: [FI_CONTEXT, FI_RX_CQ_DATA],
 	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
 },
 {
@@ -147,5 +152,6 @@
 	test_class: [
 		FT_CAP_MSG,
 	],
+	mode: [FI_CONTEXT, FI_RX_CQ_DATA],
 	mr_mode: [FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY],
 },

--- a/fabtests/test_configs/verbs/quick.test
+++ b/fabtests/test_configs/verbs/quick.test
@@ -18,9 +18,8 @@
 	comp_type: [
 		FT_COMP_QUEUE
 	],
-	mode: [
-		FT_MODE_ALL
-	],
+	mr_mode: [ FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY ],
+	mode: [ FI_CONTEXT, FI_RX_CQ_DATA ],
 	test_class: [
 		FT_CAP_MSG,
 	],
@@ -48,9 +47,8 @@
 	cq_wait_obj: [
 		FI_WAIT_NONE
 	],
-	mode: [
-		FT_MODE_ALL
-	],
+	mr_mode: [ FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY ],
+	mode: [ FI_CONTEXT, FI_RX_CQ_DATA ],
 	test_class: [
 		FT_CAP_MSG,
 	],
@@ -79,9 +77,8 @@
 		FI_WAIT_UNSPEC,
 		FI_WAIT_FD,
 	],
-	mode: [
-		FT_MODE_ALL
-	],
+	mr_mode: [ FI_MR_LOCAL, FI_MR_VIRT_ADDR, FI_MR_ALLOCATED, FI_MR_PROV_KEY ],
+	mode: [ FI_CONTEXT, FI_RX_CQ_DATA ],
 	test_class: [
 		FT_CAP_MSG,
 	],

--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -458,10 +458,12 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 	} else if (!strncmp(key->str, "tx_op_flags", strlen("tx_op_flags"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FI_COMPLETION, uint64_t, buf);
 		FT_ERR("Unknown tx_op_flags");
-	} else {
+	} else if (!strncmp(key->str, "comp_type", strlen("comp_type"))) {
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_QUEUE, enum ft_comp_type, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_CNTR, enum ft_comp_type, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_COMP_ALL, enum ft_comp_type, buf);
+		FT_ERR("Unknown comp_type");
+	} else {
 		TEST_SET_N_RETURN(str, len, "FT_MODE_ALL", FT_MODE_ALL, uint64_t, buf);
 		TEST_SET_N_RETURN(str, len, "FT_MODE_NONE", FT_MODE_NONE, uint64_t, buf);
 		TEST_SET_N_RETURN(str, len, "FT_FLAG_QUICKTEST", FT_FLAG_QUICKTEST, uint64_t, buf);

--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -46,68 +46,6 @@ struct key_t {
 	int val_size;
 };
 
-static struct ft_set test_sets_default[] = {
-	{
-		.prov_name = "sockets",
-		.test_type = {
-			FT_TEST_LATENCY,
-			FT_TEST_BANDWIDTH
-		},
-		.class_function = {
-			FT_FUNC_SEND,
-			FT_FUNC_SENDV,
-			FT_FUNC_SENDMSG
-		},
-		.ep_type = {
-			FI_EP_MSG,
-			FI_EP_DGRAM,
-			FI_EP_RDM
-		},
-		.av_type = {
-			FI_AV_TABLE,
-			FI_AV_MAP
-		},
-		.comp_type = {
-			FT_COMP_QUEUE
-		},
-		.mode = {
-			FT_MODE_ALL
-		},
-		.test_class = {
-			FT_CAP_MSG,
-			FT_CAP_TAGGED,
-//			FT_CAP_RMA,
-//			FT_CAP_ATOMIC
-		},
-		.test_flags = FT_FLAG_QUICKTEST
-	},
-	{
-		.prov_name = "verbs",
-		.test_type = {
-			FT_TEST_LATENCY,
-			FT_TEST_BANDWIDTH
-		},
-		.class_function = {
-			FT_FUNC_SEND,
-			FT_FUNC_SENDV,
-			FT_FUNC_SENDMSG
-		},
-		.ep_type = {
-			FI_EP_MSG,
-		},
-		.comp_type = {
-			FT_COMP_QUEUE
-		},
-		.mode = {
-			FT_MODE_ALL
-		},
-		.test_class = {
-			FT_CAP_MSG,
-		},
-		.test_flags = FT_FLAG_QUICKTEST
-	},
-};
-
 static struct ft_series test_series;
 
 size_t sm_size_array[] = {
@@ -684,9 +622,8 @@ struct ft_series *fts_load(char *filename)
 		free(config);
 		fclose(fp);
 	} else {
-		printf("No config file given. Using default tests.\n");
-		test_series.sets = test_sets_default;
-		test_series.nsets = sizeof(test_sets_default) / sizeof(test_sets_default[0]);
+		printf("Test config file required.\n");
+		exit(1);
 	}
 
 	for (fts_start(&test_series, 0); !fts_end(&test_series, 0);
@@ -706,8 +643,7 @@ err1:
 
 void fts_close(struct ft_series *series)
 {
-	if (series->sets != test_sets_default)
-		free(series->sets);
+	free(series->sets);
 }
 
 void fts_start(struct ft_series *series, int index)

--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -403,9 +403,10 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FI_CONTEXT, uint64_t, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FI_RX_CQ_DATA, uint64_t, buf);
 		FT_ERR("Unsupported mode bit");
-	} else {
+	} else if (!strncmp(key->str, "test_flags", strlen("test_flags"))) {
 		TEST_SET_N_RETURN(str, len, "FT_FLAG_QUICKTEST", FT_FLAG_QUICKTEST, uint64_t, buf);
-		FT_ERR("Unknown stand-alone value");
+	} else {
+		FT_ERR("Unknown test configuration key");
 	}
 
 	return -1;

--- a/fabtests/ubertest/uber.c
+++ b/fabtests/ubertest/uber.c
@@ -68,8 +68,6 @@ enum {
 
 static int results[FT_MAX_RESULT];
 static char *filename = NULL;
-static char *provname = NULL;
-static char *testname = NULL;
 
 
 static int ft_nullstr(char *str)
@@ -769,17 +767,14 @@ static void ft_fw_usage(char *program)
 {
 	fprintf(stderr, "Usage:\n");
 	fprintf(stderr, "  %s [OPTIONS] \t\t\tstart server\n", program);
-	fprintf(stderr, "  %s [OPTIONS] <server_node> \tconnect to server\n", program);
+	fprintf(stderr, "  %s [OPTIONS] -u config_file <server_node> \tconnect to server\n", program);
 	fprintf(stderr, "\nOptions:\n");
 	FT_PRINT_OPTS_USAGE("-q <service_port>", "Management port for test");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
 	fprintf(stderr, "\nServer only options:\n");
 	FT_PRINT_OPTS_USAGE("-x", "exit after test run");
 	fprintf(stderr, "\nClient only options:\n");
-	FT_PRINT_OPTS_USAGE("-u <test_config_file>", "test configuration file "
-		"(Either config file or both provider and test name are required)");
-	FT_PRINT_OPTS_USAGE("-p <provider_name>", " provider name");
-	FT_PRINT_OPTS_USAGE("-t <test_name>", "test name");
+	FT_PRINT_OPTS_USAGE("-u <test_config_file>", "test configuration file ");
 	FT_PRINT_OPTS_USAGE("-y <start_test_index>", "");
 	FT_PRINT_OPTS_USAGE("-z <end_test_index>", "");
 	FT_PRINT_OPTS_USAGE("-s <address>", "source address");
@@ -792,77 +787,6 @@ void ft_free()
 {
 	if (filename)
 		free(filename);
-	if (testname)
-		free(testname);
-	if (provname)
-		free(provname);
-}
-
-static int ft_get_config_file(char *provname, char *testname, char **filename)
-{
-	char **prov_vec, **path_vec, *str;
-	size_t i, prov_count, path_count, len;
-	int ret = -FI_ENOMEM;
-
-	// TODO use macro for ";"
-	prov_vec = ft_split_and_alloc(provname, ";", &prov_count);
-	if (!prov_vec) {
-		FT_ERR("Unable to split provname\n");
-		return -FI_EINVAL;
-	}
-
-	/* prov_count + count_of(CONFIG_PATH, "test_configs", "testname", ".test") */
-	path_count = prov_count + 4;
-	path_vec = calloc(path_count, sizeof(*path_vec));
-	if (!path_vec)
-		goto err1;
-
-	path_vec[0] = CONFIG_PATH;
-	path_vec[1] = "test_configs";
-
-	/* Path for "prov1;prov2;prov3;..." is ".../prov3/prov2/prov1" */
-	for (i = 0; i < prov_count; i++)
-		path_vec[i + 2] = prov_vec[prov_count - i - 1];
-
-	path_vec[prov_count + 2] = testname;
-	path_vec[prov_count + 3] = "test";
-
-	for (i = 0, len = 0; i < path_count; i++)
-		len += strlen(path_vec[i]) + 1;
-
-	// NULL char at the end
-	len++;
-
-	*filename = calloc(1, len);
-	if (!*filename)
-		goto err2;
-
-	for (i = 0, str = *filename; i < path_count; i++) {
-		if (i < path_count - 1)
-			ret = snprintf(str, len, "/%s", path_vec[i]);
-		else
-			ret = snprintf(str, len, ".%s", path_vec[i]);
-		if (ret < 0)
-			goto err3;
-
-		if (ret >= (int)len) {
-			ret = -FI_ETRUNC;
-			goto err3;
-		}
-		str += ret;
-		len -= ret;
-	}
-	free(path_vec);
-	ft_free_string_array(prov_vec);
-	return 0;
-err3:
-	free(*filename);
-	*filename = NULL;
-err2:
-	free(path_vec);
-err1:
-	ft_free_string_array(prov_vec);
-	return ret;
 }
 
 int main(int argc, char **argv)
@@ -871,16 +795,10 @@ int main(int argc, char **argv)
 	opts = INIT_OPTS;
 	int ret, op;
 
-	while ((op = getopt(argc, argv, "p:u:t:q:xy:z:hf" ADDR_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "u:q:xy:z:hf" ADDR_OPTS)) != -1) {
 		switch (op) {
 		case 'u':
 			filename = strdup(optarg);
-			break;
-		case 'p':
-			provname = strdup(optarg);
-			break;
-		case 't':
-			testname = strdup(optarg);
 			break;
 		case 'q':
 			service = optarg;
@@ -919,21 +837,9 @@ int main(int argc, char **argv)
 		if (!opts.dst_port)
 			opts.dst_port = default_port;
 		if (!filename) {
-			if (!testname || !provname) {
-				ft_fw_usage(argv[0]);
-				ft_free();
-				exit(1);
-			} else {
-				ret = ft_get_config_file(provname, testname,
-							 &filename);
-				if (ret < 0) {
-					ft_free();
-					exit(1);
-				}
-			}
-		} else {
-			testname = NULL;
-			provname = NULL;
+			ft_fw_usage(argv[0]);
+			ft_free();
+			exit(1);
 		}
 		series = fts_load(filename);
 		if (!series) {

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -223,7 +223,7 @@ extern struct ofi_mr_cache_params	cache_params;
 
 struct ofi_mr_entry {
 	struct ofi_mr_info		info;
-	unsigned int			cached:1;
+	void				*storage_context;
 	unsigned int			subscribed:1;
 	int				use_cnt;
 	struct dlist_entry		lru_entry;

--- a/include/ofi_tree.h
+++ b/include/ofi_tree.h
@@ -87,6 +87,7 @@ struct ofi_rbnode *ofi_rbmap_search(struct ofi_rbmap *map, void *key,
 int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
 		struct ofi_rbnode **node);
 void ofi_rbmap_delete(struct ofi_rbmap *map, struct ofi_rbnode *node);
+int ofi_rbmap_find_delete(struct ofi_rbmap *map, void *key);
 int ofi_rbmap_empty(struct ofi_rbmap *map);
 
 

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -255,7 +255,6 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 	fi_addr_t rxd_addr;
 	struct rxd_av *av;
 	uint8_t addr[RXD_NAME_LENGTH];
-	struct ofi_rbnode *node;
 
 	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
 	fastlock_acquire(&av->util_av.lock);
@@ -268,11 +267,9 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 		if (ret)
 			goto err;
 		
-		node = ofi_rbmap_find(&av->rbmap, (void *) addr);
-		if (!node)
+		ret = ofi_rbmap_find_delete(&av->rbmap, (void *) addr);
+		if (ret)
 			goto err;
-
-		ofi_rbmap_delete(&av->rbmap, node);
 
 		ret = fi_av_remove(av->dg_av, &av->rxd_addr_table[rxd_addr].dg_addr,
 				   1, flags);

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -174,7 +174,6 @@ void fi_ibv_put_shared_ini_conn(struct fi_ibv_xrc_ep *ep)
 	struct fi_ibv_domain *domain = fi_ibv_ep_to_domain(&ep->base_ep);
 	struct fi_ibv_ini_shared_conn *ini_conn;
 	struct fi_ibv_ini_conn_key key;
-	struct ofi_rbnode *node;
 
 	if (!ep->ini_conn)
 		return;
@@ -206,9 +205,7 @@ void fi_ibv_put_shared_ini_conn(struct fi_ibv_xrc_ep *ep)
 
 		assert(dlist_empty(&ini_conn->pending_list));
 		fi_ibv_set_ini_conn_key(ep, &key);
-		node = ofi_rbmap_find(domain->xrc.ini_conn_rbmap, &key);
-		assert(node);
-		ofi_rbmap_delete(domain->xrc.ini_conn_rbmap, node);
+		ofi_rbmap_find_delete(domain->xrc.ini_conn_rbmap, &key);
 		free(ini_conn->peer_addr);
 		free(ini_conn);
 	} else {

--- a/src/tree.c
+++ b/src/tree.c
@@ -345,6 +345,18 @@ struct ofi_rbnode *ofi_rbmap_find(struct ofi_rbmap *map, void *key)
 	return NULL;
 }
 
+int ofi_rbmap_find_delete(struct ofi_rbmap *map, void *key)
+{
+	struct ofi_rbnode *node;
+
+	node = ofi_rbmap_find(map, key);
+	if (!node)
+		return -FI_ENODATA;
+
+	ofi_rbmap_delete(map, node);
+	return 0;
+}
+
 struct ofi_rbnode *ofi_rbmap_search(struct ofi_rbmap *map, void *key,
 		int (*compare)(struct ofi_rbmap *map, void *key, void *data))
 {


### PR DESCRIPTION
Includes a batch of updates to ubertest which were useful in debugging the issue.  The main patch here is the following change (2nd patch in series).  I believe the described problem can actually occur (my original PR resulted in the problem being hit repeatedly), so the updated patch is marked for v1.8.x

The rbtree delete call takes as input a node to remove from the
tree.  As an optimization, that node may be left in place in the
tree, with only the data it references replaced.  Instead, another
node in the tree (the node that is logically immediately to the
right of the given node) may be delete.  But the data values
of the two nodes are swapped.

This can lead to a possible use after free issue.

The issue results from the rbtree insert call returning a
pointer to the node where new data was inserted.  If that node
pointer is saved but later accessed, it could have been freed.
The freeing of that node is separate from the data originally
associated with the node being removed from the tree because
of the above optimization.

The typically 'fix' for this is that an rbtree delete call must
be preceded by a find call to locate the node currently
associated with the data/key to remove.  This works fine for
cases where simple key values are used, such as an integer or
an address, where comparison operators use >, <, memcmp, etc.

However, for more complex keys, such as those used by the MR
cache, this presents an issue.  The MR cache uses a comparison
function that involves comparing addresses and length fields
from an iovec.  And to make a long story short, this can result
in the find call matching different nodes, depending on the
state of the tree, even when no entries have been removed
from it.

Because the node->data stored by the rbtree corresponds to a
specific mr_entry allocated by the cache, when we free an
mr_entry, we need to match the specific node where the
node->data == mr_entry.  However, because of the complexity
of the comparison function, that is no longer guaranteed.
This can show up when: merging regions is disabled, we have
overlapping regions in the cache, and we have a third region
that falls within both overlapping regions.  In this case, the
third region can match either region, depending on the order
of their insertion.

To avoid this issue, we need to store the node that was
allocated for a new key inserted into the rbtree.  That exact
same node must be deleted when removing the key.  This allows
us to have a 1:1 relationship between an mr_entry and a node
in the tree.

The insert call already returns the node to the caller.  However
we need to update the delete call to free that node, because
we can't rely on calling find prior to deleting the key.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>
