### PR TITLE
prov/sockets: add lock to protect av table access

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -377,6 +377,7 @@ struct sock_av {
 	int    shared;
 	struct dlist_entry ep_list;
 	fastlock_t list_lock;
+	fastlock_t table_lock;
 };
 
 struct sock_fid_list {


### PR DESCRIPTION
add a lock to make av table access thread-safe

Signed-off-by: Yulu Jia <yulu.jia@intel.com>