### PR TITLE
prov/sockets: protect av table access continued

### DIFF
--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -501,7 +501,9 @@ int sock_ep_connect(struct sock_ep_attr *ep_attr, fi_addr_t index,
 		addr = *ep_attr->dest_addr;
 		ofi_addr_set_port(&addr.sa, ep_attr->msg_dest_port);
 	} else {
+		fastlock_acquire(&ep_attr->av->table_lock);
 		addr = ep_attr->av->table[index].addr;
+		fastlock_release(&ep_attr->av->table_lock);
 	}
 
 do_connect:

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1861,8 +1861,11 @@ int sock_ep_get_conn(struct sock_ep_attr *attr, struct sock_tx_ctx *tx_ctx,
 
 	if (attr->ep_type == FI_EP_MSG)
 		addr = attr->dest_addr;
-	else
+	else {
+		fastlock_acquire(&attr->av->table_lock);
 		addr = &attr->av->table[av_index].addr;
+		fastlock_release(&attr->av->table_lock);
+	}
 
 	fastlock_acquire(&attr->cmap.lock);
 	conn = sock_ep_lookup_conn(attr, av_index, addr);


### PR DESCRIPTION
protect av table access in a few more places in addition to PR-5300

Signed-off-by: Yulu Jia <yulu.jia@intel.com>