### PR TITLE
cherry picked fixes to sockets AV and MR cache

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -98,7 +98,7 @@ static inline uint64_t ofi_mr_get_prov_mode(uint32_t version,
 struct ofi_mr_cache;
 
 struct ofi_mem_monitor {
-	fastlock_t			lock;
+	pthread_mutex_t 		lock;
 	struct dlist_entry		list;
 
 	int (*subscribe)(struct ofi_mem_monitor *notifier,

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -202,7 +202,7 @@ extern struct ofi_mr_cache_params	cache_params;
 
 struct ofi_mr_entry {
 	struct iovec			iov;
-	unsigned int			cached:1;
+	void				*storage_context;
 	unsigned int			subscribed:1;
 	int				use_cnt;
 	struct dlist_entry		lru_entry;

--- a/include/ofi_tree.h
+++ b/include/ofi_tree.h
@@ -84,7 +84,8 @@ void ofi_rbmap_cleanup(struct ofi_rbmap *map);
 struct ofi_rbnode *ofi_rbmap_find(struct ofi_rbmap *map, void *key);
 struct ofi_rbnode *ofi_rbmap_search(struct ofi_rbmap *map, void *key,
 		int (*compare)(struct ofi_rbmap *map, void *key, void *data));
-int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data);
+int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
+		struct ofi_rbnode **node);
 void ofi_rbmap_delete(struct ofi_rbmap *map, struct ofi_rbnode *node);
 int ofi_rbmap_empty(struct ofi_rbmap *map);
 

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -158,8 +158,10 @@ int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
 
 	*rxd_addr = rxd_set_rxd_addr(av, dg_addr);
 
-	ret = ofi_rbmap_insert(&av->rbmap, (void *) addr, (void *) (*rxd_addr));
-	if (ret && ret != -FI_EALREADY) {
+	ret = ofi_rbmap_insert(&av->rbmap, (void *) addr, (void *) (*rxd_addr),
+			       NULL);
+	if (ret) {
+		assert(ret != -FI_EALREADY);
 		fi_av_remove(av->dg_av, &dg_addr, 1, flags);
 		return ret;
 	}

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -501,7 +501,9 @@ int sock_ep_connect(struct sock_ep_attr *ep_attr, fi_addr_t index,
 		addr = *ep_attr->dest_addr;
 		ofi_addr_set_port(&addr.sa, ep_attr->msg_dest_port);
 	} else {
+		fastlock_acquire(&ep_attr->av->table_lock);
 		addr = ep_attr->av->table[index].addr;
+		fastlock_release(&ep_attr->av->table_lock);
 	}
 
 do_connect:

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1861,8 +1861,11 @@ int sock_ep_get_conn(struct sock_ep_attr *attr, struct sock_tx_ctx *tx_ctx,
 
 	if (attr->ep_type == FI_EP_MSG)
 		addr = attr->dest_addr;
-	else
+	else {
+		fastlock_acquire(&attr->av->table_lock);
 		addr = &attr->av->table[av_index].addr;
+		fastlock_release(&attr->av->table_lock);
+	}
 
 	fastlock_acquire(&attr->cmap.lock);
 	conn = sock_ep_lookup_conn(attr, av_index, addr);

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -379,8 +379,8 @@ static int ofi_mr_rbt_insert(struct ofi_mr_storage *storage,
 			     struct iovec *key,
 			     struct ofi_mr_entry *entry)
 {
-	return ofi_rbmap_insert(storage->storage, (void *) &entry->iov,
-			        (void *) entry);
+	return ofi_rbmap_insert(storage->storage, (void *) key, (void *) entry,
+				NULL);
 }
 
 static int ofi_mr_rbt_erase(struct ofi_mr_storage *storage,

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -76,7 +76,7 @@ static void util_mr_free_entry(struct ofi_mr_cache *cache,
 	FI_DBG(cache->domain->prov, FI_LOG_MR, "free %p (len: %" PRIu64 ")\n",
 	       entry->iov.iov_base, entry->iov.iov_len);
 
-	assert(!entry->cached);
+	assert(!entry->storage_context);
 	/* If regions are not being merged, then we can't safely
 	 * unsubscribe this region from the monitor.  Otherwise, we
 	 * might unsubscribe an address range in use by another region.
@@ -95,9 +95,7 @@ static void util_mr_free_entry(struct ofi_mr_cache *cache,
 static void util_mr_uncache_entry_storage(struct ofi_mr_cache *cache,
 					  struct ofi_mr_entry *entry)
 {
-	assert(entry->cached);
 	cache->storage.erase(&cache->storage, entry);
-	entry->cached = 0;
 	cache->cached_cnt--;
 	cache->cached_size -= entry->iov.iov_len;
 }
@@ -174,7 +172,7 @@ void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
 	cache->delete_cnt++;
 
 	if (--entry->use_cnt == 0) {
-		if (entry->cached) {
+		if (entry->storage_context) {
 			dlist_insert_tail(&entry->lru_entry, &cache->lru_list);
 		} else {
 			cache->uncached_cnt--;
@@ -198,6 +196,7 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 	if (OFI_UNLIKELY(!*entry))
 		return -FI_ENOMEM;
 
+	(*entry)->storage_context = NULL;
 	(*entry)->iov = *iov;
 	(*entry)->use_cnt = 1;
 
@@ -215,7 +214,6 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 
 	if ((cache->cached_cnt >= cache_params.max_cnt) ||
 	    (cache->cached_size >= cache_params.max_size)) {
-		(*entry)->cached = 0;
 		cache->uncached_cnt++;
 		cache->uncached_size += iov->iov_len;
 	} else {
@@ -224,7 +222,6 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 			ret = -FI_ENOMEM;
 			goto err;
 		}
-		(*entry)->cached = 1;
 		cache->cached_cnt++;
 		cache->cached_size += iov->iov_len;
 
@@ -379,18 +376,18 @@ static int ofi_mr_rbt_insert(struct ofi_mr_storage *storage,
 			     struct iovec *key,
 			     struct ofi_mr_entry *entry)
 {
+	assert(!entry->storage_context);
 	return ofi_rbmap_insert(storage->storage, (void *) key, (void *) entry,
-				NULL);
+				(struct ofi_rbnode **) &entry->storage_context);
 }
 
 static int ofi_mr_rbt_erase(struct ofi_mr_storage *storage,
 			    struct ofi_mr_entry *entry)
 {
-	struct ofi_rbnode *node;
-
-	node = ofi_rbmap_find(storage->storage, &entry->iov);
-	assert(node);
-	ofi_rbmap_delete(storage->storage, node);
+	assert(entry->storage_context);
+	ofi_rbmap_delete(storage->storage,
+			 (struct ofi_rbnode *) entry->storage_context);
+	entry->storage_context = NULL;
 	return 0;
 }
 

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -159,9 +159,9 @@ bool ofi_mr_cache_flush(struct ofi_mr_cache *cache)
 {
 	bool empty;
 
-	fastlock_acquire(&cache->monitor->lock);
+	pthread_mutex_lock(&cache->monitor->lock);
 	empty = mr_cache_flush(cache);
-	fastlock_release(&cache->monitor->lock);
+	pthread_mutex_unlock(&cache->monitor->lock);
 	return empty;
 }
 
@@ -170,7 +170,7 @@ void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
 	FI_DBG(cache->domain->prov, FI_LOG_MR, "delete %p (len: %" PRIu64 ")\n",
 	       entry->iov.iov_base, entry->iov.iov_len);
 
-	fastlock_acquire(&cache->monitor->lock);
+	pthread_mutex_lock(&cache->monitor->lock);
 	cache->delete_cnt++;
 
 	if (--entry->use_cnt == 0) {
@@ -182,7 +182,7 @@ void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
 			util_mr_free_entry(cache, entry);
 		}
 	}
-	fastlock_release(&cache->monitor->lock);
+	pthread_mutex_unlock(&cache->monitor->lock);
 }
 
 static int
@@ -283,7 +283,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	FI_DBG(cache->domain->prov, FI_LOG_MR, "search %p (len: %" PRIu64 ")\n",
 	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
 
-	fastlock_acquire(&cache->monitor->lock);
+	pthread_mutex_lock(&cache->monitor->lock);
 	cache->search_cnt++;
 
 	while (((cache->cached_cnt >= cache_params.max_cnt) ||
@@ -309,7 +309,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 		dlist_remove_init(&(*entry)->lru_entry);
 
 unlock:
-	fastlock_release(&cache->monitor->lock);
+	pthread_mutex_unlock(&cache->monitor->lock);
 	return ret;
 }
 
@@ -327,13 +327,13 @@ void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 		cache->search_cnt, cache->delete_cnt, cache->hit_cnt,
 		cache->notify_cnt);
 
-	fastlock_acquire(&cache->monitor->lock);
+	pthread_mutex_lock(&cache->monitor->lock);
 	dlist_foreach_container_safe(&cache->lru_list, struct ofi_mr_entry,
 				     entry, lru_entry, tmp) {
 		assert(entry->use_cnt == 0);
 		util_mr_uncache_entry(cache, entry);
 	}
-	fastlock_release(&cache->monitor->lock);
+	pthread_mutex_unlock(&cache->monitor->lock);
 
 	ofi_monitor_del_cache(cache);
 	cache->storage.destroy(&cache->storage);

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -76,7 +76,7 @@ int ofi_mr_map_insert(struct ofi_mr_map *map, const struct fi_mr_attr *attr,
 		item->requested_key = map->key++;
 	}
 
-	ofi_rbmap_insert(map->rbtree, &item->requested_key, item);
+	ofi_rbmap_insert(map->rbtree, &item->requested_key, item, NULL);
 	*key = item->requested_key;
 	item->context = context;
 

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -147,7 +147,7 @@ int fi_ibv_get_shared_ini_conn(struct fi_ibv_xrc_ep *ep,
 	ofi_atomic_initialize32(&conn->ref_cnt, 1);
 
 	ret = ofi_rbmap_insert(domain->xrc.ini_conn_rbmap,
-			       (void *) &key, (void *) conn);
+			       (void *) &key, (void *) conn, NULL);
 	assert(ret != -FI_EALREADY);
 	if (ret) {
 		VERBS_WARN(FI_LOG_EP_CTRL, "INI QP RBTree insert failed %d\n",

--- a/src/tree.c
+++ b/src/tree.c
@@ -192,7 +192,8 @@ ofi_insert_rebalance(struct ofi_rbmap *map, struct ofi_rbnode *x)
 	map->root->color = BLACK;
 }
 
-int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data)
+int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
+		     struct ofi_rbnode **ret_node)
 {
 	struct ofi_rbnode *current, *parent, *node;
 	int ret;
@@ -229,6 +230,8 @@ int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data)
 	}
 
 	ofi_insert_rebalance(map, node);
+	if (ret_node)
+		*ret_node = node;
 	return 0;
 }
 


### PR DESCRIPTION
Some modifications were needed to resolve conflicts, but this pulls in the MR cache locking change (to a mutex) and MR cache entry deletion adjustments.