### PR TITLE
man/mr: Tweak wording on FI_MR_HMEM and desc use

### DIFF
--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -130,7 +130,7 @@ int fi_query_atomic(struct fid_domain *domain,
 
 *desc / compare_desc / result_desc*
 : Data descriptor associated with the local data buffer, local compare
-  buffer, and local result buffer, respectively.
+  buffer, and local result buffer, respectively.  See [`fi_mr`(3)](fi_mr.3.html).
 
 *dest_addr*
 : Destination address for connectionless atomic operations.  Ignored for

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -164,11 +164,13 @@ The following apply to memory registration.
 *FI_MR_LOCAL*
 : When the FI_MR_LOCAL mode bit is set, applications must register all
   data buffers that will be accessed by the local hardware and provide
-  a valid mem_desc parameter into applicable data transfer operations.
+  a valid desc parameter into applicable data transfer operations.
   When FI_MR_LOCAL is zero, applications are not required to register
   data buffers before using them for local operations (e.g. send and
-  receive data buffers), and the mem_desc parameter into data transfer
-  operations is ignored.
+  receive data buffers).  The desc parameter into data transfer
+  operations will be ignored in this case, unless otherwise required
+  (e.g. se  FI_MR_HMEM).  It is recommended that applications pass in
+  NULL for desc when not required.
 
   A provider may hide local registration requirements from applications
   by making use of an internal registration cache or similar mechanisms.
@@ -246,18 +248,19 @@ The following apply to memory registration.
   enable the memory region, the application must call fi_mr_enable().
 
 *FI_MR_HMEM*
-: If FI_MR_HMEM is set, the application must register buffers that
+: This mode bit is associated with the FI_HMEM capability.
+  If FI_MR_HMEM is set, the application must register buffers that
   were allocated using a device call and provide a valid desc
   parameter into applicable data transfer operations even if they are
   only used for local operations (e.g. send and receive data buffers).
+  Device memory must be registered using the fi_mr_regattr call, with
+  the iface and device fields filled out.
 
   If FI_MR_HMEM is set, but FI_MR_LOCAL is unset, only device buffers
-  should be registered - when input addresses reference (un-registered)
-  local, non-device memory buffers, the desc parameter must be NULL.
-  Similarly if FI_MR_LOCAL is set but FI_MR_HMEM is unset, only local,
-  non-device memory buffers should be registered - when input addresses
-  reference (un-registered) device memory buffers, the desc paramter
-  must be NULL.
+  must be registered when used locally.  In this case, the desc parameter
+  passed into data transfer operations must either be valid or NULL.
+  Similarly, if FI_MR_LOCAL is set, but FI_MR_HMEM is not, the desc
+  parameter must either be valid or NULL.
 
 *Basic Memory Registration*
 : Basic memory registration is indicated by the FI_MR_BASIC mr_mode bit.

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -68,7 +68,7 @@ ssize_t fi_injectdata(struct fid_ep *ep, const void *buf, size_t len,
 : Count of vectored data entries.
 
 *desc*
-: Descriptor associated with the data buffer
+: Descriptor associated with the data buffer.  See [`fi_mr`(3)](fi_mr.3.html).
 
 *data*
 : Remote CQ data to transfer with the sent message.

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -82,6 +82,7 @@ ssize_t fi_inject_writedata(struct fid_ep *ep, const void *buf, size_t len,
 
 *desc*
 : Descriptor associated with the local data buffer
+  See [`fi_mr`(3)](fi_mr.3.html).
 
 *data*
 : Remote CQ data to transfer with the operation.

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -75,7 +75,8 @@ ssize_t fi_tinjectdata(struct fid_ep *ep, const void *buf, size_t len,
 : Mask of bits to ignore applied to the tag for receive operations.
 
 *desc*
-: Memory descriptor associated with the data buffer
+: Memory descriptor associated with the data buffer.
+  See [`fi_mr`(3)](fi_mr.3.html).
 
 *data*
 : Remote CQ data to transfer with the sent data.


### PR DESCRIPTION
Only updates to the wording to clarify use and point
developers to the fi_mr man page.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>