### PR TITLE
prov/efa: Fix failure in rxr_av when av type is FI_AV_UNSPEC

### DIFF
--- a/prov/efa/src/rxr/rxr_av.c
+++ b/prov/efa/src/rxr/rxr_av.c
@@ -298,6 +298,12 @@ int rxr_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 
 	util_attr.addrlen = sizeof(fi_addr_t);
 	util_attr.flags = 0;
+	if (attr->type == FI_AV_UNSPEC){
+		if (domain->util_domain.av_type != FI_AV_UNSPEC)
+			attr->type = domain->util_domain.av_type;
+		else
+			attr->type = FI_AV_TABLE;
+	}
 	ret = ofi_av_init(&domain->util_domain, attr, &util_attr,
 			  &av->util_av, context);
 	if (ret)


### PR DESCRIPTION
When the attr->type is FI_AV_UNSPEC, failure occurs in
util_verify_av_attr. util_verify_av_attr also does a check to ensure
that attr->type and domain->util_domain.av_type match. The following
change has been done: Set the attr->type to FI_AV_TABLE if the
domain->util_domain.av_type is FI_AV_UNSPEC. Otherwise, attr->type
should be equal to domain->util_domain.av_type.

@rajachan, could you please check?

Signed-off-by: Dipti Kothari <dkothar@amazon.com>