### PR TITLE
prov/rxm: Remove atomic response buffer allocation limitation

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -656,6 +656,7 @@ struct rxm_ep {
 	uint64_t		msg_cq_last_poll;
 	struct fid_ep 		*srx_ctx;
 	size_t 			comp_per_progress;
+	ofi_atomic32_t		atomic_tx_credits;
 	int			msg_mr_local;
 	int			rxm_mr_local;
 	size_t			min_multi_recv_size;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1082,6 +1082,9 @@ static inline ssize_t rxm_handle_atomic_resp(struct rxm_ep *rxm_ep,
 err:
 	rxm_rx_buf_finish(rx_buf);
 	ofi_buf_free(tx_buf);
+	ofi_atomic_inc32(&rxm_ep->atomic_tx_credits);
+	assert(ofi_atomic_get32(&rxm_ep->atomic_tx_credits) <=
+				rxm_ep->rxm_info->tx_attr->size);
 
 	return ret;
 }

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -390,8 +390,9 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 			continue;
 
 		ret = rxm_buf_pool_create(rxm_ep, entry_sizes[i],
-					  (i == RXM_BUF_POOL_RX ? 0 :
-					   rxm_ep->rxm_info->tx_attr->size),
+					  (i == RXM_BUF_POOL_RX ||
+					   i == RXM_BUF_POOL_TX_ATOMIC) ? 0 :
+					  rxm_ep->rxm_info->tx_attr->size,
 					  queue_sizes[i],
 					  &rxm_ep->buf_pools[i], i);
 		if (ret)
@@ -2155,6 +2156,8 @@ static void rxm_ep_settings_init(struct rxm_ep *rxm_ep)
 			   rxm_ep->msg_info->rx_attr->size) / 2;
 	rxm_ep->comp_per_progress = (rxm_ep->comp_per_progress > max_prog_val) ?
 				    max_prog_val : rxm_ep->comp_per_progress;
+	ofi_atomic_initialize32(&rxm_ep->atomic_tx_credits,
+				rxm_ep->rxm_info->tx_attr->size);
 
 	rxm_ep->msg_mr_local = ofi_mr_local(rxm_ep->msg_info);
 	rxm_ep->rxm_mr_local = ofi_mr_local(rxm_ep->rxm_info);


### PR DESCRIPTION
Change the RXM atomic protocol TX buffer pool to be unbounded,
but use a credit scheme that limits the number of atomic requests
initiated by the application that can be outstanding (RXM tx_attr->size).
This allows the RXM atomic protocol CQ processing to allocate an atomic
response TX buffer as needed independent of the application usage.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>