### PR TITLE
fabric/collectives: Assign an address to an AV set

### DIFF
--- a/include/rdma/fi_collective.h
+++ b/include/rdma/fi_collective.h
@@ -52,6 +52,7 @@ struct fi_ops_av_set {
 	int	(*diff)(struct fid_av_set *dst, const struct fid_av_set *src);
 	int	(*insert)(struct fid_av_set *set, fi_addr_t addr);
 	int	(*remove)(struct fid_av_set *set, fi_addr_t addr);
+	int	(*addr)(struct fid_av_set *set, fi_addr_t *coll_addr);
 };
 
 struct fid_av_set {
@@ -105,10 +106,10 @@ struct fi_ops_collective {
 
 static inline int
 fi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
-	  struct fid_av_set **av_set, void * context)
+	  struct fid_av_set **set, void * context)
 {
 	return FI_CHECK_OP(av->ops, struct fi_ops_av, av_set) ?
-		av->ops->av_set(av, attr, av_set, context) : -FI_ENOSYS;
+		av->ops->av_set(av, attr, set, context) : -FI_ENOSYS;
 }
 
 static inline int
@@ -139,6 +140,12 @@ static inline int
 fi_av_set_remove(struct fid_av_set *set, fi_addr_t addr)
 {
 	return set->ops->remove(set, addr);
+}
+
+static inline int
+fi_av_set_addr(struct fid_av_set *set, fi_addr_t *coll_addr)
+{
+	return set->ops->addr(set, coll_addr);
 }
 
 static inline int

--- a/man/fi_av_set.3.md
+++ b/man/fi_av_set.3.md
@@ -9,17 +9,47 @@ tagline: Libfabric Programmer's Manual
 
 fi_av_set \- Address vector set operations
 
-fi_av_open / fi_close
-: Open or close an address vector
+fi_av_set / fi_close
+: Open or close an address vector set
+
+fi_av_set_union
+: Perform a set union operation on two AV sets
+
+fi_av_set_intersect
+: Perform a set intersect operation on two AV sets
+
+fi_av_set_diff
+: Perform a set difference operation on two AV sets
+
+fi_av_set_insert
+: Add an address to an AV set
+
+fi_av_set_remove
+: Remove an address from an AV set
+
+fi_av_set_addr
+: Obtain a collective address for current addresses in an AV set
 
 
 # SYNOPSIS
 
 ```c
-#include <rdma/fi_av_set.h>
+#include <rdma/fi_collective.h>
 
-int fi_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
-    struct fid_av **av, void *context);
+int fi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
+	  struct fid_av_set **set, void * context);
+
+int fi_av_set_union(struct fid_av_set *dst,	const struct fid_av_set *src);
+
+int fi_av_set_intersect(struct fid_av_set *dst, const struct fid_av_set *src);
+
+int fi_av_set_diff(struct fid_av_set *dst, const struct fid_av_set *src);
+
+int fi_av_set_insert(struct fid_av_set *set, fi_addr_t addr);
+
+int fi_av_set_remove(struct fid_av_set *set, fi_addr_t addr);
+
+int fi_av_set_addr(struct fid_av_set *set, fi_addr_t *coll_addr);
 
 int fi_close(struct fid *av_set);
 ```
@@ -29,6 +59,15 @@ int fi_close(struct fid *av_set);
 *av*
 : Address vector
 
+*set*
+: Address vector set
+
+*dst*
+: Address vector set updated by set operation
+
+*src*
+: Address vector set providing input to a set operation
+
 *attr*
 : Address vector set attributes
 
@@ -37,6 +76,12 @@ int fi_close(struct fid *av_set);
 
 *flags*
 : Additional flags to apply to the operation.
+
+*addr*
+: Destination address to insert to remove from AV set.
+
+*coll_addr*
+: Address identifying collective group.
 
 # DESCRIPTION
 
@@ -138,6 +183,15 @@ The AV set insert call appends the specified address to the end of the AV set.
 
 The AV set remove call removes the specified address from the given AV set.
 The order of the remaining addresses in the AV set is unchanged.
+
+## fi_av_set_addr
+
+Returns an address that may be used to communicate with all current members
+of an AV set.  This is a local operation only that does not involve network
+communication.  The returned address may be used as input into
+fi_join_collective.  Note that attempting to use the address returned from
+fi_av_set_addr (e.g. passing it to fi_join_collective) while simultaneously
+modifying the addresses stored in an AV set results in undefined behavior.
 
 # NOTES
 

--- a/man/fi_collective.3.md
+++ b/man/fi_collective.3.md
@@ -198,12 +198,12 @@ will report that the join has completed.  Application managed collective
 memberships are an exception.  With application managed memberships, the
 fi_join_collective call may be completed locally without fabric communication.
 For provider managed memberships, the join collective call requires as
-input a coll_addr that refers to an existing collective group.  The
-fi_join_collective call will create a new collective subgroup.  If there is
-no existing collective group (e.g. this is the first group being created),
-or if application managed memberships are used, coll_addr should be set to
-FI_ADDR_UNAVAIL.  For provider managed memberships, this will result in
-using all entries in the associated AV as the base.
+input a coll_addr that refers to either an address associated with an
+AV set (see fi_av_set_addr) or an existing collective group (obtained through
+a previous call to fi_join_collective).  The
+fi_join_collective call will create a new collective subgroup.
+If application managed memberships are used, coll_addr should be set to
+FI_ADDR_UNAVAIL.
 
 Applications must call fi_close on the collective group to disconnect the
 endpoint from the group.  After a join operation has completed, the


### PR DESCRIPTION
fi_join_collective() performs a collective operation itself with
the endpoints identified via the coll_addr parameter.  This
works well for all join operations except the first.  In the case
of the first join, the user passes in ADDR_UNSPEC.  This indicates
that all endpoints that are part of the associated AV are
participarint in the collective.

From the viewpoint of the app, this is restrictive and a little
unusual.

Instead of creating a special case to handle the first join
call, associate an fi_addr with an AV set.  Applications can
create an AV set, populate it with peer addresses, then obtain
an fi_addr for that set of peers.  The fi_addr returned by the
AV set is a local operation only.

By creating an AV set that contains all addresses in an AV,
we maintain the existing support.  But, we also provide a
optimal mechanism for creating collective groups without
needing all endpoints in an AV to participate in the join.
(MPI may not take advantage of this, but other apps might).

Update man pages with new definition, plus include other
missing documentation.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>