### PR TITLE
prov/verbs: Remove XRC shared INI QP management lock

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -325,8 +325,9 @@ struct fi_ibv_domain {
 
 		/* The domain maintains a RBTree for mapping an endpoint
 		 * destination addresses to physical XRC INI QP connected
-		 * to that host. */
-		fastlock_t		ini_mgmt_lock;
+		 * to that host. The map is protected using the EQ lock
+		 * bound to the domain to avoid the need for additional
+		 * locking. */
 		struct ofi_rbmap	*ini_conn_rbmap;
 	} xrc ;
 
@@ -463,7 +464,7 @@ enum fi_ibv_ini_qp_state {
  * An XRC transport INI QP connection can be shared within a process to
  * communicate with all the ranks on the same remote node. This structure is
  * only accessed during connection setup and tear down and should be
- * done while holding the domain:xrc:ini_mgmt_lock.
+ * done while holding the domain:eq:lock.
  */
 struct fi_ibv_ini_shared_conn {
 	/* To share, EP must have same remote peer host addr and TX CQ */

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -622,7 +622,6 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		container_of(fid, struct fi_ibv_pep, pep_fid);
 	struct fi_ibv_ep *ep;
 	struct fi_ibv_xrc_ep *xrc_ep;
-	struct fi_ibv_domain *domain;
 
 	switch (cma_event->event) {
 	case RDMA_CM_EVENT_ROUTE_RESOLVED:
@@ -635,10 +634,7 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 			if (fi_ibv_is_xrc(ep->info)) {
 				xrc_ep = container_of(fid, struct fi_ibv_xrc_ep,
 						      base_ep.util_ep.ep_fid);
-				domain = fi_ibv_ep_to_domain(ep);
-				fastlock_acquire(&domain->xrc.ini_mgmt_lock);
 				fi_ibv_put_shared_ini_conn(xrc_ep);
-				fastlock_release(&domain->xrc.ini_mgmt_lock);
 			}
 		} else {
 			ret = -FI_EAGAIN;


### PR DESCRIPTION
With the evolution of the EQ lock to make connection
processing thread-safe, the INI QP management lock
is no longer needed, the structure is protected by
the EQ lock.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>