### PR TITLE
prov/shm: save completion address properly

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -107,7 +107,7 @@ struct smr_ep_entry {
 
 struct smr_ep;
 typedef int (*smr_rx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, void *addr,
+		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err);
 typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, uint64_t err);
@@ -227,19 +227,19 @@ int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
 int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, uint64_t err);
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, void *addr,
+		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err);
 int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, void *addr,
+		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err);
 int smr_rx_src_comp(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, void *addr,
+		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err);
 int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, void *addr,
+		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err);
 int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, void *addr,
+		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err);
 
 uint64_t smr_rx_cq_flags(uint32_t op, uint16_t op_flags);

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -89,7 +89,7 @@ int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 }
 
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op, uint16_t flags,
-		    size_t len, void *buf, void *addr, uint64_t tag, uint64_t data,
+		    size_t len, void *buf, fi_addr_t addr, uint64_t tag, uint64_t data,
 		    uint64_t err)
 {
 	ofi_ep_rx_cntr_inc_func(&ep->util_ep, op);
@@ -102,7 +102,7 @@ int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op, uint16_t flag
 }
 
 int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, void *addr,
+		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err)
 {
 	struct fi_cq_tagged_entry *comp;
@@ -133,17 +133,16 @@ int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
 }
 
 int smr_rx_src_comp(struct smr_ep *ep, void *context, uint32_t op,
-		    uint16_t flags, size_t len, void *buf, void *addr,
+		    uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		    uint64_t tag, uint64_t data, uint64_t err)
 {
-	ep->util_ep.rx_cq->src[ofi_cirque_windex(ep->util_ep.rx_cq->cirq)] =
-		(uint32_t) (uintptr_t) addr;
+	ep->util_ep.rx_cq->src[ofi_cirque_windex(ep->util_ep.rx_cq->cirq)] = addr;
 	return smr_rx_comp(ep, context, op, flags, len, buf, addr, tag,
 			   data, err);
 }
 
 int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		       uint16_t flags, size_t len, void *buf, void *addr,
+		       uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		       uint64_t tag, uint64_t data, uint64_t err)
 {
 	int ret;
@@ -156,7 +155,7 @@ int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 }
 
 int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-			   uint16_t flags, size_t len, void *buf, void *addr,
+			   uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 			   uint64_t tag, uint64_t data, uint64_t err)
 {
 	int ret;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -138,7 +138,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 		recv_entry = container_of(entry, struct smr_ep_entry, entry);
 		ret = smr_complete_rx(ep, (void *) recv_entry->context, ofi_op_msg,
 				  recv_entry->flags, 0,
-				  NULL, (void *) recv_entry->addr,
+				  NULL, recv_entry->addr,
 				  recv_entry->tag, 0, FI_ECANCELED);
 		freestack_push(ep->recv_fs, recv_entry);
 		ret = ret ? ret : 1;


### PR DESCRIPTION
The previous implementation was not saving the source address
properly if requested, either improperly casting the fi_addr_t
to a pointer or not passing in the correct address.

Change the completion function to take in a fi_addr_t instead of
void * and make sure it's passing in the correct value.

Signed-off-by: aingerson <alexia.ingerson@intel.com>