### PR TITLE
core: Add support for traffic class selection

### DIFF
--- a/include/ofi_abi.h
+++ b/include/ofi_abi.h
@@ -111,7 +111,7 @@ extern "C" {
  * name appended with the ABI version that it is compatible with.
  */
 
-#define CURRENT_ABI "FABRIC_1.2"
+#define CURRENT_ABI "FABRIC_1.3"
 
 #if  HAVE_ALIAS_ATTRIBUTE == 1
 #define DEFAULT_SYMVER_PRE(a) a##_

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -318,6 +318,28 @@ enum {
 	FI_PROTO_EFA
 };
 
+enum {
+	FI_TC_UNSPEC = 0,
+	FI_TC_DSCP = 0x100,
+	FI_TC_LABEL = 0x200,
+	FI_TC_BEST_EFFORT = FI_TC_LABEL,
+	FI_TC_LOW_LATENCY,
+	FI_TC_DEDICATED_ACCESS,
+	FI_TC_BULK_DATA,
+	FI_TC_SCAVENGER,
+	FI_TC_NETWORK_CTRL,
+};
+
+static inline uint32_t fi_tc_dscp_set(uint8_t dscp)
+{
+	return ((uint32_t) dscp) | FI_TC_DSCP;
+}
+
+static inline uint8_t fi_tc_dscp_get(uint32_t tclass)
+{
+	return tclass & FI_TC_DSCP ? (uint8_t) tclass : 0;
+}
+
 /* Mode bits */
 #define FI_CONTEXT		(1ULL << 59)
 #define FI_MSG_PREFIX		(1ULL << 58)
@@ -339,6 +361,7 @@ struct fi_tx_attr {
 	size_t			size;
 	size_t			iov_limit;
 	size_t			rma_iov_limit;
+	uint32_t		tclass;
 };
 
 struct fi_rx_attr {
@@ -395,6 +418,7 @@ struct fi_domain_attr {
 	size_t 			auth_key_size;
 	size_t			max_err_data;
 	size_t			mr_cnt;
+	uint32_t		tclass;
 };
 
 struct fi_fabric_attr {
@@ -668,7 +692,6 @@ struct fi_param {
 
 int fi_getparams(struct fi_param **params, int *count);
 void fi_freeparams(struct fi_param *params);
-
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct.h>

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -31,3 +31,10 @@ FABRIC_1.2 {
 		fi_freeinfo;
 		fi_dupinfo;
 } FABRIC_1.1;
+
+FABRIC_1.3 {
+	global:
+		fi_getinfo;
+		fi_freeinfo;
+		fi_dupinfo;
+} FABRIC_1.2;

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -134,6 +134,7 @@ struct fi_domain_attr {
 	size_t                auth_key_size;
 	size_t                max_err_data;
 	size_t                mr_cnt;
+	uint32_t              tclass;
 };
 ```
 
@@ -665,6 +666,12 @@ attributes of the domain, such as the supported memory registration modes.
 Applications can set the mr_cnt on input to fi_getinfo, in order to
 indicate their memory registration requirements.  Doing so may allow the
 provider to optimize any memory registration cache or lookup tables.
+
+## Traffic Class (tclass)
+
+This specifies the default traffic class that will be associated any endpoints
+created within the domain.  See [`fi_endpoint`(3)](fi_endpoint.3.html
+for additional information.
 
 # RETURN VALUE
 


### PR DESCRIPTION
From PR #5148

Changes:
Move tclass documentation from fi_domain to fi_endpoint man page
Changed fi_tc_dscp_get/set macros into functions.  Added to man pages
Fixed ABI compatibility issues (tclass field should not be in ABI 1.2 structs)
Removed FI_TC_PROV_SPECIFIC, FI_PROV_SPECIFIC define already exists for this purpose
Remove lengthy and unneeded examples from tclass documentation