### PR TITLE
prov/psm2: Add fi_nic support and use device name for domain name

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -827,9 +827,6 @@ struct psmx2_env {
 	int	prog_interval;
 	char	*prog_affinity;
 	int	multi_ep;
-	int	max_trx_ctxt;
-	int	free_trx_ctxt;
-	int	num_devunits;
 	int	inject_size;
 	int	lock_level;
 	int	lazy_conn;
@@ -837,6 +834,19 @@ struct psmx2_env {
 #if (PSMX2_TAG_LAYOUT == PSMX2_TAG_LAYOUT_RUNTIME)
 	char	*tag_layout;
 #endif
+};
+
+#define PSMX2_MAX_UNITS	4
+struct psmx2_hfi_info {
+	int max_trx_ctxt;
+	int free_trx_ctxt;
+	int num_units;
+	int num_active_units;
+	int active_units[PSMX2_MAX_UNITS];
+	int unit_is_active[PSMX2_MAX_UNITS];
+	int unit_nctxts[PSMX2_MAX_UNITS];
+	int unit_nfreectxts[PSMX2_MAX_UNITS];
+	char default_domain_name[PSMX2_MAX_UNITS * 8]; /* hfi1_0;hfi1_1;...;hfi1_n */
 };
 
 extern struct fi_ops_mr		psmx2_mr_ops;
@@ -863,6 +873,7 @@ extern struct fi_ops_msg	psmx2_msg2_ops;
 extern struct fi_ops_rma	psmx2_rma_ops;
 extern struct fi_ops_atomic	psmx2_atomic_ops;
 extern struct psmx2_env		psmx2_env;
+extern struct psmx2_hfi_info	psmx2_hfi_info;
 extern struct psmx2_fid_fabric	*psmx2_active_fabric;
 
 /*

--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -1036,7 +1036,7 @@ int psmx2_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (av_type == FI_AV_MAP)
 		conn_size = 0;
 	else
-		conn_size = psmx2_env.max_trx_ctxt * sizeof(struct psmx2_av_conn);
+		conn_size = psmx2_hfi_info.max_trx_ctxt * sizeof(struct psmx2_av_conn);
 
 	av_priv = (struct psmx2_fid_av *) calloc(1, sizeof(*av_priv) + conn_size);
 	if (!av_priv)
@@ -1099,7 +1099,7 @@ init_lock:
 	av_priv->count = count;
 	av_priv->flags = flags;
 	av_priv->rx_ctx_bits = rx_ctx_bits;
-	av_priv->max_trx_ctxt = psmx2_env.max_trx_ctxt;
+	av_priv->max_trx_ctxt = psmx2_hfi_info.max_trx_ctxt;
 	av_priv->addr_format = domain_priv->addr_format;
 	av_priv->type = av_type;
 

--- a/prov/psm2/src/psmx2_cntr.c
+++ b/prov/psm2/src/psmx2_cntr.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -309,7 +309,7 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 				   util_fabric.fabric_fid);
 
 	if (!info->domain_attr->name ||
-	    strcmp(info->domain_attr->name, PSMX2_DOMAIN_NAME)) {
+	    strncmp(info->domain_attr->name, PSMX2_DOMAIN_NAME, strlen(PSMX2_DOMAIN_NAME))) {
 		err = -FI_EINVAL;
 		goto err_out;
 	}

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -949,18 +949,18 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 		goto errout;
 
 	if (info && info->ep_attr) {
-		if (info->ep_attr->tx_ctx_cnt > psmx2_env.max_trx_ctxt) {
+		if (info->ep_attr->tx_ctx_cnt > psmx2_hfi_info.max_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"tx_ctx_cnt %"PRIu64" exceed limit %d.\n",
 				info->ep_attr->tx_ctx_cnt,
-				psmx2_env.max_trx_ctxt);
+				psmx2_hfi_info.max_trx_ctxt);
 			goto errout;
 		}
-		if (info->ep_attr->rx_ctx_cnt > psmx2_env.max_trx_ctxt) {
+		if (info->ep_attr->rx_ctx_cnt > psmx2_hfi_info.max_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"rx_ctx_cnt %"PRIu64" exceed limit %d.\n",
 				info->ep_attr->rx_ctx_cnt,
-				psmx2_env.max_trx_ctxt);
+				psmx2_hfi_info.max_trx_ctxt);
 			goto errout;
 		}
 		ctxt_cnt = info->ep_attr->tx_ctx_cnt;

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/psm2/src/psmx2_rma.c
+++ b/prov/psm2/src/psmx2_rma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/psm2/src/psmx2_tagged.c
+++ b/prov/psm2/src/psmx2_tagged.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -258,10 +258,10 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 		domain->trx_ctxt_unlock_fn(&domain->trx_ctxt_lock, 1);
 	}
 
-	if (psmx2_trx_ctxt_cnt >= psmx2_env.max_trx_ctxt) {
+	if (psmx2_trx_ctxt_cnt >= psmx2_hfi_info.max_trx_ctxt) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
 			"number of Tx/Rx contexts exceeds limit (%d).\n",
-			psmx2_env.max_trx_ctxt);
+			psmx2_hfi_info.max_trx_ctxt);
 		return NULL;
 	}
 

--- a/prov/psm2/src/psmx2_wait.c
+++ b/prov/psm2/src/psmx2_wait.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/psm2/src/version.h
+++ b/prov/psm2/src/version.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2013-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -47,7 +47,7 @@
 #endif
 
 #define PSMX2_PROV_NAME		"psm2"
-#define PSMX2_DOMAIN_NAME	"psm2"
+#define PSMX2_DOMAIN_NAME	"hfi1"
 #define PSMX2_FABRIC_NAME	"psm2"
 
 #define PSMX2_DEFAULT_UUID	"00FF00FF-0000-0000-0000-00FF00FF00FF"


### PR DESCRIPTION
By default, PSM2 uses all active HFI devices. In order to report fi_nic
information a domain must be associated to a specific HFI device. This
is done by converting a single fi_info structure with default device
selection (-1) into a list of fi_info structures with specific device
settings. Only the PCI bus attributes of the fi_nic information are
populated. The original fi_info structure is kept intact if there are
more than one active devices.

Set the domain name to be the name of the selected HFI device(s).

Update the year in the copyright headers.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>