### PR TITLE
prov/efa: Rework function signatures of generic tx functions

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -929,26 +929,20 @@ struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 
 void rxr_generic_tx_entry_init(struct rxr_ep *ep,
 			       struct rxr_tx_entry *tx_entry,
-			       const struct iovec *iov,
-			       size_t iov_count,
+			       const struct fi_msg *msg, uint64_t tag,
 			       const struct fi_rma_iov *rma_iov,
 			       size_t rma_iov_count,
-			       fi_addr_t addr, uint64_t tag,
-			       uint64_t data, void *context,
 			       uint32_t op, uint64_t flags);
 
 struct rxr_tx_entry *rxr_ep_tx_entry_init(struct rxr_ep *rxr_ep,
-					  const struct iovec *iov,
-					  size_t iov_count,
+					  const struct fi_msg *msg,
+					  uint64_t tag,
 					  const struct fi_rma_iov *rma_iov,
 					  size_t rma_iov_count,
-					  fi_addr_t addr, uint64_t tag,
-					  uint64_t data, void *context,
 					  uint32_t op, uint64_t flags);
 
-ssize_t rxr_tx(struct fid_ep *ep, const struct iovec *iov, size_t iov_count,
+ssize_t rxr_tx(struct fid_ep *ep, const struct fi_msg *msg, uint64_t tag,
 	       const struct fi_rma_iov *rma_iov, size_t rma_iov_count,
-	       fi_addr_t addr, uint64_t tag, uint64_t data, void *context,
 	       uint32_t op, uint64_t flags);
 
 static inline void

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -72,6 +72,7 @@ struct rxr_tx_entry *rxr_readrsp_tx_entry_init(struct rxr_ep *rxr_ep,
 					       struct rxr_rx_entry *rx_entry)
 {
 	struct rxr_tx_entry *tx_entry;
+	struct fi_msg msg;
 
 	tx_entry = ofi_buf_alloc(rxr_ep->readrsp_tx_entry_pool);
 	if (OFI_UNLIKELY(!tx_entry)) {
@@ -84,13 +85,16 @@ struct rxr_tx_entry *rxr_readrsp_tx_entry_init(struct rxr_ep *rxr_ep,
 	dlist_insert_tail(&tx_entry->tx_entry_entry, &rxr_ep->tx_entry_list);
 #endif
 
+	msg.msg_iov = rx_entry->iov;
+	msg.iov_count = rx_entry->iov_count;
+	msg.addr = rx_entry->addr;
+
 	/*
 	 * this tx_entry works similar to a send tx_entry thus its op was
 	 * set to ofi_op_msg. Note this tx_entry will not write a completion
 	 */
-	rxr_generic_tx_entry_init(rxr_ep, tx_entry, rx_entry->iov,
-				  rx_entry->iov_count, NULL, 0, rx_entry->addr,
-				  0, 0, NULL, ofi_op_msg, 0);
+	rxr_generic_tx_entry_init(rxr_ep, tx_entry, &msg, 0, NULL, 0,
+				  ofi_op_msg, 0);
 
 	tx_entry->cq_entry.flags |= FI_READ;
 	/* rma_loc_rx_id is for later retrieve of rx_entry
@@ -109,17 +113,23 @@ struct rxr_tx_entry *rxr_readrsp_tx_entry_init(struct rxr_ep *rxr_ep,
 	return tx_entry;
 }
 
-ssize_t rxr_generic_rma(struct fid_ep *ep,
-			const struct iovec *iov, size_t iov_count,
-			const struct fi_rma_iov *rma_iov, size_t rma_iov_count,
-			fi_addr_t addr, uint64_t data, void *context, uint32_t op,
-			uint64_t flags)
+ssize_t rxr_generic_rma(struct fid_ep *ep, const struct fi_msg_rma *rma_msg,
+			uint32_t op, uint64_t flags)
 {
-	assert(iov_count <= RXR_IOV_LIMIT && rma_iov_count <= RXR_IOV_LIMIT);
-	int tag = 0; // RMA is not tagged
+	struct fi_msg msg;
 
-	return rxr_tx(ep, iov, iov_count, rma_iov, rma_iov_count, addr,
-		      tag, data, context, op, flags);
+	msg.msg_iov = rma_msg->msg_iov;
+	msg.desc = rma_msg->desc;
+	msg.iov_count = rma_msg->iov_count;
+	msg.addr = rma_msg->addr;
+	msg.context = rma_msg->context;
+	msg.data = rma_msg->data;
+
+	assert(rma_msg->iov_count <= RXR_IOV_LIMIT &&
+	       rma_msg->rma_iov_count <= RXR_IOV_LIMIT);
+
+	return rxr_tx(ep, &msg, 0, rma_msg->rma_iov, rma_msg->rma_iov_count,
+		      op, flags);
 }
 
 ssize_t rxr_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
@@ -158,10 +168,7 @@ ssize_t rxr_readv(struct fid_ep *ep, const struct iovec *iov, void **desc,
 
 ssize_t rxr_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_t flags)
 {
-	return rxr_generic_rma(ep, msg->msg_iov, msg->iov_count,
-			       msg->rma_iov, msg->rma_iov_count,
-			       msg->addr, msg->data, msg->context,
-			       ofi_op_read_req, flags);
+	return rxr_generic_rma(ep, msg, ofi_op_read_req, flags);
 }
 
 ssize_t rxr_write(struct fid_ep *ep, const void *buf, size_t len, void *desc,
@@ -201,21 +208,9 @@ ssize_t rxr_writev(struct fid_ep *ep, const struct iovec *iov, void **desc,
 ssize_t rxr_writemsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 		     uint64_t flags)
 {
-	ssize_t ret = 0;
 
-	if (msg->data == 0) {
-		ret = rxr_generic_rma(ep, msg->msg_iov, msg->iov_count,
-				      msg->rma_iov, msg->rma_iov_count,
-				      msg->addr, 0, NULL, ofi_op_write, 0);
-	} else {
-		ret = rxr_generic_rma(ep, msg->msg_iov, msg->iov_count,
-				      msg->rma_iov, msg->rma_iov_count,
-				      msg->addr, msg->data,
-				      msg->context, ofi_op_write,
-				      FI_REMOTE_CQ_DATA);
-	}
-
-	return ret;
+	return rxr_generic_rma(ep, msg, ofi_op_write,
+			      (msg->data == 0) ? 0 : FI_REMOTE_CQ_DATA);
 }
 
 ssize_t rxr_writedata(struct fid_ep *ep, const void *buf, size_t len,
@@ -248,6 +243,7 @@ ssize_t rxr_writedata(struct fid_ep *ep, const void *buf, size_t len,
 ssize_t rxr_inject(struct fid_ep *ep, const void *buf, size_t len,
 		   fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
+	struct fi_msg_rma msg;
 	struct iovec iov;
 	struct fi_rma_iov rma_iov;
 
@@ -256,8 +252,15 @@ ssize_t rxr_inject(struct fid_ep *ep, const void *buf, size_t len,
 	rma_iov.addr = addr;
 	rma_iov.len  = len;
 	rma_iov.key = key;
-	return rxr_generic_rma(ep, &iov, 1, &rma_iov, 1, dest_addr,
-			       0, NULL, ofi_op_write, FI_INJECT |
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.iov_count = 1;
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+	msg.addr = dest_addr;
+
+	return rxr_generic_rma(ep, &msg, ofi_op_write, FI_INJECT |
 			       RXR_NO_COMPLETION);
 }
 
@@ -265,6 +268,7 @@ ssize_t rxr_inject_data(struct fid_ep *ep, const void *buf, size_t len,
 			uint64_t data, fi_addr_t dest_addr, uint64_t addr,
 			uint64_t key)
 {
+	struct fi_msg_rma msg;
 	struct iovec iov;
 	struct fi_rma_iov rma_iov;
 
@@ -273,8 +277,16 @@ ssize_t rxr_inject_data(struct fid_ep *ep, const void *buf, size_t len,
 	rma_iov.addr = addr;
 	rma_iov.len  = len;
 	rma_iov.key = key;
-	return rxr_generic_rma(ep, &iov, 1, &rma_iov, 1, dest_addr,
-			       data, NULL, ofi_op_write, FI_INJECT |
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_iov = &iov;
+	msg.iov_count = 1;
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+	msg.addr = dest_addr;
+	msg.data = data;
+
+	return rxr_generic_rma(ep, &msg, ofi_op_write, FI_INJECT |
 			       RXR_NO_COMPLETION | FI_REMOTE_CQ_DATA);
 }
 


### PR DESCRIPTION
This commit changes the rather messy function signatures of
rxr_ep_tx_entry_init(), rxr_generic_tx_entry_init(), rxr_tx(), and
rxr_generic_rma() to use `struct fi_msg` or `struct fi_msg_rma` as
applicable. The send descriptor was also getting dropped in some paths,
which is now fixed by using the msg structures.

Signed-off-by: Raghu Raja <craghun@amazon.com>