### PR TITLE
prov/util: rework collective implementation

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -58,7 +58,8 @@ bin_PROGRAMS = \
 	unit/fi_getinfo_test \
 	unit/fi_resource_freeing \
 	ubertest/fi_ubertest	\
-	multinode/fi_multinode
+	multinode/fi_multinode	\
+	multinode/fi_multinode_coll
 
 dist_bin_SCRIPTS = \
 	scripts/runfabtests.sh \
@@ -351,6 +352,17 @@ multinode_fi_multinode_SOURCES = \
 multinode_fi_multinode_LDADD = 	libfabtests.la
 
 multinode_fi_multinode_CFLAGS = \
+	$(AM_CFLAGS) \
+	-I$(srcdir)/multinode/include
+
+multinode_fi_multinode_coll_SOURCES = \
+	multinode/src/harness.c \
+	multinode/src/core_coll.c \
+	multinode/include/core.h
+
+multinode_fi_multinode_coll_LDADD = 	libfabtests.la
+
+multinode_fi_multinode_coll_CFLAGS = \
 	$(AM_CFLAGS) \
 	-I$(srcdir)/multinode/include
 

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -46,6 +46,7 @@
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_atomic.h>
+#include <rdma/fi_collective.h>
 
 #include <shared.h>
 
@@ -426,7 +427,7 @@ static int ft_alloc_msgs(void)
 	} else {
 		ft_set_tx_rx_sizes(&tx_size, &rx_size);
 		tx_mr_size = 0;
-		rx_mr_size = 0;		
+		rx_mr_size = 0;
 		buf_size = MAX(tx_size, FT_MAX_CTRL_MSG) + MAX(rx_size, FT_MAX_CTRL_MSG);
 	}
 
@@ -995,7 +996,8 @@ int ft_enable_ep(struct fid_ep *ep, struct fid_eq *eq, struct fid_av *av,
 	uint64_t flags;
 	int ret;
 
-	if (fi->ep_attr->type == FI_EP_MSG || fi->caps & FI_MULTICAST)
+	if (fi->ep_attr->type == FI_EP_MSG || fi->caps & FI_MULTICAST ||
+	    fi->caps & FI_COLLECTIVE)
 		FT_EP_BIND(ep, eq, 0);
 
 	FT_EP_BIND(ep, av, 0);
@@ -1143,7 +1145,7 @@ int ft_exchange_addresses_oob(struct fid_av *av_ptr, struct fid_ep *ep_ptr,
 
 	ret = ft_av_insert(av_ptr, buf, 1, remote_addr, 0, NULL);
 	if (ret)
-		return ret;	
+		return ret;
 
 	return 0;
 }
@@ -1855,7 +1857,7 @@ ssize_t ft_post_rma_inject(enum ft_rma_opcodes op, struct fid_ep *ep, size_t siz
 	switch (op) {
 	case FT_RMA_WRITE:
 		FT_POST(fi_inject_write, ft_progress, txcq, tx_seq, &tx_cq_cntr,
-			"fi_inject_write", ep, tx_buf, opts.transfer_size, 
+			"fi_inject_write", ep, tx_buf, opts.transfer_size,
 			remote_fi_addr, remote->addr, remote->key);
 		break;
 	case FT_RMA_WRITEDATA:

--- a/fabtests/multinode/include/coll_test.h
+++ b/fabtests/multinode/include/coll_test.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2019 Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2019 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -29,56 +29,17 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 #pragma once
 
-#include <stdlib.h>
-#include <stdbool.h>
 
-#include <rdma/fabric.h>
-#include <rdma/fi_trigger.h>
-#include <sys/uio.h>
-#include <sys/socket.h>
 
-#include "pattern.h"
+typedef int (*coll_test_setup_t)();
+typedef int (*coll_test_run_t)();
+typedef void (*coll_test_teardown_t)();
 
-#define PM_DEFAULT_OOB_PORT (8228)
-
-struct pm_job_info {
-	size_t		my_rank;
-	size_t		num_ranks;
-	int		sock;
-	int		*clients; //only valid for server
-
-	struct sockaddr_storage oob_server_addr;
-	size_t 		server_addr_len;
-	void		*names;
-	size_t		name_len;
-	fi_addr_t	*fi_addrs;
+struct coll_test {
+        char *name;
+        coll_test_setup_t setup;
+        coll_test_run_t run;
+        coll_test_teardown_t teardown;
 };
-
-
-struct multinode_xfer_state {
-	int 			iteration;
-	size_t			recvs_posted;
-	size_t			sends_posted;
-
-	size_t			tx_window;
-	size_t			rx_window;
-
-	/* pattern iterator state */
-	int			cur_source;
-	int			cur_target;
-
-	bool			all_recvs_posted;
-	bool			all_sends_posted;
-	bool			all_completions_done;
-
-	uint64_t		tx_flags;
-	uint64_t		rx_flags;
-};
-
-extern struct pm_job_info pm_job;
-int multinode_run_tests(int argc, char **argv);
-int pm_allgather(void *my_item, void *items, int item_size);
-void pm_barrier();

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -298,12 +298,12 @@ int multinode_run_tests(int argc, char **argv)
 		printf("starting %s... ", patterns[i].name);
 		pattern = &patterns[i];
 		ret = multinode_run_test();
-		if (ret) 
+		if (ret)
 			printf("failed\n");
-		else 
+		else
 			printf("passed\n");
 	}
-	
+
 	pm_job_free_res();
 	ft_free_res();
 	return ft_exit_code(ret);

--- a/fabtests/multinode/src/core_coll.c
+++ b/fabtests/multinode/src/core_coll.c
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2017-2019 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHWARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. const NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER const AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS const THE
+ * SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <limits.h>
+#include <stdarg.h>
+
+#include <rdma/fi_errno.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_trigger.h>
+#include <rdma/fi_collective.h>
+
+#include <core.h>
+#include <coll_test.h>
+#include <shared.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <assert.h>
+
+struct fid_av_set *av_set;
+struct fid_mc *mc;
+
+int no_setup()
+{
+	return FI_SUCCESS;
+}
+
+int no_run()
+{
+	return FI_SUCCESS;
+}
+
+void no_teardown()
+{
+}
+
+int coll_setup()
+{
+	int err;
+	struct fi_av_set_attr av_set_attr;
+
+	av_set_attr.count = pm_job.num_ranks;
+	av_set_attr.start_addr = 0;
+	av_set_attr.end_addr = pm_job.num_ranks-1;
+	av_set_attr.stride = 1;
+
+	err = fi_av_set(av, &av_set_attr, &av_set, NULL);
+	if (err) {
+		FT_DEBUG("av_set creation failed ret = %d\n", err);
+	}
+
+	return err;
+}
+
+void coll_teardown()
+{
+	fi->dest_addr = NULL;
+}
+
+int join_test_run()
+{
+	int ret;
+	uint32_t event;
+	struct fi_cq_err_entry comp;
+	fi_addr_t world_addr;
+
+	ret = fi_av_set_addr(av_set, &world_addr);
+	if (ret) {
+		FT_DEBUG("failed to get collective addr = %d\n", ret);
+		return ret;
+	}
+
+	ret = fi_join_collective(ep, world_addr, av_set, 0, &mc, NULL);
+	if (ret) {
+		FT_DEBUG("collective join failed ret = %d\n", ret);
+		return ret;
+	}
+
+	while (1) {
+		ret = fi_eq_read(eq, &event, NULL, 0, 0);
+		if (ret >= 0) {
+			FT_DEBUG("found eq entry ret %d\n", event);
+			if (event == FI_JOIN_COMPLETE) {
+				return FI_SUCCESS;
+			}
+		} else if(ret != -EAGAIN) {
+			return ret;
+		}
+
+		ret = fi_cq_read(rxcq, (void *) &comp, 1);
+		if(ret < 0 && ret != -EAGAIN) {
+			return ret;
+		}
+
+		ret = fi_cq_read(txcq, (void *) &comp, 1);
+		if(ret < 0 && ret != -EAGAIN) {
+			return ret;
+		}
+	}
+}
+
+int barrier_test_run()
+{
+	int ret;
+	uint32_t event;
+	struct fi_cq_err_entry comp = {0};
+	uint64_t barrier = 0x0ba221e20150600d;
+	fi_addr_t world_addr;
+	fi_addr_t barrier_addr;
+
+	ret = fi_av_set_addr(av_set, &world_addr);
+	if (ret) {
+		FT_DEBUG("failed to get collective addr = %d\n", ret);
+		return ret;
+	}
+
+	ret = fi_join_collective(ep, world_addr, av_set, 0, &mc, NULL);
+	if (ret) {
+		FT_DEBUG("collective join failed ret = %d\n", ret);
+		return ret;
+	}
+
+	while (1) {
+		ret = fi_eq_read(eq, &event, NULL, 0, 0);
+		if (ret >= 0) {
+			FT_DEBUG("found eq entry ret %d\n", event);
+			if (event == FI_JOIN_COMPLETE) {
+				barrier_addr = fi_mc_addr(mc);
+				ret = fi_barrier(ep, barrier_addr, &barrier);
+				if (ret) {
+					FT_DEBUG("collective barrier failed ret = %d\n", ret);
+					return ret;
+				}
+			}
+		} else if(ret != -EAGAIN) {
+			return ret;
+		}
+
+		ret = fi_cq_read(rxcq, (void *) &comp, 1);
+		if(ret < 0 && ret != -EAGAIN) {
+			return ret;
+		}
+
+		if(comp.op_context && (*((uint64_t*)comp.op_context) == barrier)) {
+			return FI_SUCCESS;
+		}
+
+		ret = fi_cq_read(txcq, (void *) &comp, 1);
+		if(ret < 0 && ret != -EAGAIN) {
+			return ret;
+		}
+
+		if(comp.op_context && (*((uint64_t*)comp.op_context) == barrier)) {
+			return FI_SUCCESS;
+		}
+	}
+}
+
+struct coll_test tests[] = {
+	{
+		.name = "join_test",
+		.setup = coll_setup,
+		.run = join_test_run,
+		.teardown = coll_teardown
+	},
+	{
+		.name = "barrier_test",
+		.setup = coll_setup,
+		.run = barrier_test_run,
+		.teardown = coll_teardown
+	},
+};
+
+const int NUM_TESTS = ARRAY_SIZE(tests);
+
+static inline
+int setup_hints()
+{
+	hints->ep_attr->type			= FI_EP_RDM;
+	hints->caps				= FI_MSG | FI_COLLECTIVE;
+	hints->mode				= FI_CONTEXT;
+	hints->domain_attr->control_progress	= FI_PROGRESS_MANUAL;
+	hints->domain_attr->data_progress	= FI_PROGRESS_MANUAL;
+	hints->fabric_attr->prov_name		= strdup("tcp");
+	return FI_SUCCESS;
+}
+
+static int multinode_setup_fabric(int argc, char **argv)
+{
+	char my_name[FT_MAX_CTRL_MSG];
+	size_t len;
+	int ret;
+
+	setup_hints();
+
+	ret = ft_getinfo(hints, &fi);
+	if (ret)
+		return ret;
+
+	ret = ft_open_fabric_res();
+	if (ret)
+		return ret;
+
+	opts.av_size = pm_job.num_ranks;
+
+	av_attr.type = FI_AV_TABLE;
+	ret = ft_alloc_active_res(fi);
+	if (ret)
+		return ret;
+
+	ret = ft_enable_ep(ep, eq, av, txcq, rxcq, txcntr, rxcntr);
+	if (ret)
+		return ret;
+
+	len = FT_MAX_CTRL_MSG;
+	ret = fi_getname(&ep->fid, (void *) my_name, &len);
+	if (ret) {
+		FT_PRINTERR("error determining local endpoint name\n", ret);
+		goto err;
+	}
+
+	pm_job.name_len = len;
+	pm_job.names = malloc(len * pm_job.num_ranks);
+	if (!pm_job.names) {
+		FT_ERR("error allocating memory for address exchange\n");
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	ret = pm_allgather(my_name, pm_job.names, pm_job.name_len);
+	if (ret) {
+		FT_PRINTERR("error exchanging addresses\n", ret);
+		goto err;
+	}
+
+	pm_job.fi_addrs = calloc(pm_job.num_ranks, sizeof(*pm_job.fi_addrs));
+	if (!pm_job.fi_addrs) {
+		FT_ERR("error allocating memory for av fi addrs\n");
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	ret = fi_av_insert(av, pm_job.names, pm_job.num_ranks,
+			   pm_job.fi_addrs, 0, NULL);
+	if (ret != pm_job.num_ranks) {
+		FT_ERR("unable to insert all addresses into AV table\n");
+		ret = -1;
+		goto err;
+	}
+	return 0;
+err:
+	ft_free_res();
+	return ft_exit_code(ret);
+}
+
+static void pm_job_free_res()
+{
+
+	free(pm_job.names);
+
+	free(pm_job.fi_addrs);
+}
+
+int multinode_run_tests(int argc, char **argv)
+{
+	int ret = FI_SUCCESS;
+	int i;
+
+	ret = multinode_setup_fabric(argc, argv);
+	if (ret)
+		return ret;
+
+	for (i = 0; i < NUM_TESTS && !ret; i++) {
+		FT_DEBUG("Running Test: %s \n", tests[i].name);
+
+		ret = tests[i].setup();
+		FT_DEBUG("Setup Complete...\n");
+		if (ret)
+			goto out;
+
+		ret = tests[i].run();
+		tests[i].teardown();
+		FT_DEBUG("Run Complete...\n");
+		if (ret)
+			goto out;
+
+
+		pm_barrier();
+		FT_DEBUG("Test Complete: %s \n", tests[i].name);
+	}
+
+out:
+	if (ret)
+		printf("failed\n");
+	else
+		printf("passed\n");
+
+	pm_job_free_res();
+	ft_free_res();
+	return ft_exit_code(ret);
+}

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -201,6 +201,7 @@ complex_tests=(
 
 multinode_tests=(
 	"fi_multinode"
+	"fi_multinode_coll"
 )
 
 function errcho {

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -205,6 +205,12 @@ static inline uint64_t roundup_power_of_two(uint64_t n)
 	return n;
 }
 
+static inline uint64_t rounddown_power_of_two(uint64_t n)
+{
+	uint64_t pof2 = roundup_power_of_two(n);
+	return (pof2 > n) ? (pof2 >> 1) : pof2;
+}
+
 static inline size_t ofi_get_aligned_size(size_t size, size_t alignment)
 {
 	return ((size % alignment) == 0) ?

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -35,8 +35,12 @@
 
 #include <rdma/fi_collective.h>
 
+#include <ofi_list.h>
+#include <ofi_atom.h>
+
 #define OFI_WORLD_CONTEXT_ID 0
 #define OFI_CONTEXT_ID_SIZE 4
+#define OFI_COLL_TAG_FLAG (1ULL << 63)
 
 enum barrier_type {
 	NO_BARRIER,
@@ -70,6 +74,7 @@ enum coll_work_type {
 
 struct util_coll_hdr {
 	struct slist_entry	entry;
+	struct slist_entry	barrier_entry;
 	enum coll_work_type	type;
 	/* only valid for xfer_item*/
 	uint64_t		tag;
@@ -104,33 +109,36 @@ struct util_coll_reduce_item {
 	enum fi_op		op;
 };
 
-struct util_coll_comp_item;
-
-typedef void (*util_coll_comp_t)(struct util_coll_mc *coll_mc,
-				 struct util_coll_comp_item *comp);
-
-struct util_coll_join_comp_data {
-	uint64_t		cid_buf[OFI_CONTEXT_ID_SIZE];
-	uint64_t		tmp_cid_buf[OFI_CONTEXT_ID_SIZE];
-};
-
-struct util_coll_comp_item {
-	struct util_coll_hdr	hdr;
-	enum util_coll_op_type	op_type;
-	void			*data;
-	util_coll_comp_t	comp_fn;
-};
-
 struct util_coll_mc {
 	struct fid_mc		mc_fid;
 	struct fid_ep		*ep;
-	struct util_av_set 	*av_set;
+	struct util_av_set	*av_set;
 	struct slist		barrier_list;
 	struct slist		deferred_list;
-	int 			my_rank;
+	struct slist		pending_xfer_list;
+	int			my_rank;
 	uint16_t		cid;
-	uint16_t		tag_seq;
+	uint16_t		seq;
 	ofi_atomic32_t		ref;
+};
+
+struct util_coll_state;
+
+typedef void (*util_coll_comp_fn_t)(struct util_coll_state *state);
+
+struct util_coll_cid_data {
+	uint64_t	cid_buf[OFI_CONTEXT_ID_SIZE];
+	uint64_t	tmp_cid_buf[OFI_CONTEXT_ID_SIZE];
+};
+
+struct util_coll_state {
+	struct util_coll_hdr	hdr;
+	struct dlist_entry	entry;
+	enum util_coll_op_type	type;
+	void			*context;
+	struct util_coll_mc	*mc;
+	struct util_coll_cid_data data;
+	util_coll_comp_fn_t	comp_fn;
 };
 
 int ofi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
@@ -138,18 +146,15 @@ int ofi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 			struct fid_mc **mc, void *context);
 
 int ofi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
-	       struct fid_av_set **av_set_fid, void * context);
+	       struct fid_av_set **av_set_fid, void *context);
 
 ssize_t ofi_ep_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context);
 
-ssize_t ofi_ep_writeread(struct fid_ep *ep, const void *buf, size_t count,
-		     void *desc, void *result, void *result_desc,
-		     fi_addr_t coll_addr, enum fi_datatype datatype,
-		     enum fi_op op, uint64_t flags, void *context);
+int ofi_coll_process_pending(struct fid_ep *ep);
 
-ssize_t ofi_ep_writereadmsg(struct fid_ep *ep, const struct fi_msg_collective *msg,
-			struct fi_ioc *resultv, void **result_desc,
-			size_t result_count, uint64_t flags);
+int ofi_coll_ep_progress(struct fid_ep *ep);
+
+void ofi_coll_handle_comp(uint64_t tag, void *ctx);
 
 
 #endif // _OFI_COLL_H_

--- a/include/ofi_enosys.h
+++ b/include/ofi_enosys.h
@@ -43,6 +43,7 @@
 #include <rdma/fi_eq.h>
 #include <rdma/fi_rma.h>
 #include <rdma/fi_tagged.h>
+#include <rdma/fi_collective.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -453,6 +454,55 @@ int fi_no_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt,
 			uint64_t flags, void *context);
 int fi_no_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 			uint64_t flags);
+
+/*
+static struct fi_ops_collective X = {
+	.size = sizeof(struct fi_ops_collective),
+	.barrier = fi_coll_no_barrier,
+	.broadcast = fi_coll_no_broadcast,
+	.alltoall = fi_coll_no_alltoall,
+	.allreduce = fi_coll_no_allreduce,
+	.allgather = fi_coll_no_allgather,
+	.reduce_scatter = fi_coll_no_reduce_scatter,
+	.reduce = fi_coll_no_reduce,
+	.scatter = fi_coll_no_scatter,
+	.gather = fi_coll_no_gather,
+	.msg = fi_coll_no_msg,
+};
+*/
+ssize_t fi_coll_no_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context);
+ssize_t fi_coll_no_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
+			     fi_addr_t coll_addr, fi_addr_t root_addr,
+			     enum fi_datatype datatype, uint64_t flags, void *context);
+ssize_t fi_coll_no_alltoall(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			    void *result, void *result_desc, fi_addr_t coll_addr,
+			    enum fi_datatype datatype, uint64_t flags, void *context);
+ssize_t fi_coll_no_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			     void *result, void *result_desc, fi_addr_t coll_addr,
+			     enum fi_datatype datatype, enum fi_op op, uint64_t flags,
+			     void *context);
+ssize_t fi_coll_no_allgather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			     void *result, void *result_desc, fi_addr_t coll_addr,
+			     enum fi_datatype datatype, uint64_t flags, void *context);
+ssize_t fi_coll_no_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count,
+				  void *desc, void *result, void *result_desc,
+				  fi_addr_t coll_addr, enum fi_datatype datatype,
+				  enum fi_op op, uint64_t flags, void *context);
+ssize_t fi_coll_no_reduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			  void *result, void *result_desc, fi_addr_t coll_addr,
+			  fi_addr_t root_addr, enum fi_datatype datatype, enum fi_op op,
+			  uint64_t flags, void *context);
+ssize_t fi_coll_no_scatter(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			   void *result, void *result_desc, fi_addr_t coll_addr,
+			   fi_addr_t root_addr, enum fi_datatype datatype, uint64_t flags,
+			   void *context);
+ssize_t fi_coll_no_gather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			  void *result, void *result_desc, fi_addr_t coll_addr,
+			  fi_addr_t root_addr, enum fi_datatype datatype, uint64_t flags,
+			  void *context);
+ssize_t fi_coll_no_msg(struct fid_ep *ep, const struct fi_msg_collective *msg,
+		       struct fi_ioc *resultv, void **result_desc, size_t result_count,
+		       uint64_t flags);
 
 #ifdef __cplusplus
 }

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -294,6 +294,9 @@ struct util_ep {
 	fastlock_t		lock;
 	ofi_fastlock_acquire_t	lock_acquire;
 	ofi_fastlock_release_t	lock_release;
+
+	struct dlist_entry	coll_state_list;
+	fastlock_t		coll_state_lock;
 };
 
 int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av);
@@ -804,7 +807,7 @@ const char *ofi_eq_strerror(struct fid_eq *eq_fid, int prov_errno,
 #define FI_PRIMARY_CAPS	(FI_MSG | FI_RMA | FI_TAGGED | FI_ATOMICS | FI_MULTICAST | \
 			 FI_NAMED_RX_CTX | FI_DIRECTED_RECV | \
 			 FI_READ | FI_WRITE | FI_RECV | FI_SEND | \
-			 FI_REMOTE_READ | FI_REMOTE_WRITE)
+			 FI_REMOTE_READ | FI_REMOTE_WRITE | FI_COLLECTIVE)
 
 #define FI_SECONDARY_CAPS (FI_MULTI_RECV | FI_SOURCE | FI_RMA_EVENT | \
 			   FI_SHARED_AV | FI_TRIGGER | FI_FENCE | \

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -103,7 +103,7 @@ struct fi_fabric_attr rxm_fabric_attr = {
 };
 
 struct fi_info rxm_info = {
-	.caps = RXM_EP_CAPS | RXM_DOMAIN_CAPS | FI_MULTI_RECV,
+	.caps = RXM_EP_CAPS | RXM_DOMAIN_CAPS | FI_MULTI_RECV | FI_COLLECTIVE,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxm_tx_attr,
 	.rx_attr = &rxm_rx_attr,

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -30,6 +30,8 @@
  * SOFTWARE.
  */
 
+#include <ofi_coll.h>
+
 #include "rxm.h"
 
 static int rxm_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
@@ -190,6 +192,7 @@ static struct fi_ops_av rxm_av_ops = {
 	.remove = rxm_av_remove,
 	.lookup = rxm_av_lookup,
 	.straddr = rxm_av_straddr,
+	.av_set = ofi_av_set
 };
 
 int rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1366,7 +1366,7 @@ static int rxm_conn_atomic_progress_eq_cq(struct rxm_ep *rxm_ep,
 				goto exit;
 		}
 		if (again || fds[1].revents & POLLIN)
-			rxm_ep_progress(&rxm_ep->util_ep);
+			rxm_ep->util_ep.progress(&rxm_ep->util_ep);
 	}
 exit:
 	return -1;

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -240,6 +240,8 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 		ep->lock_acquire = ofi_fastlock_acquire;
 		ep->lock_release = ofi_fastlock_release;
 	}
+	dlist_init(&ep->coll_state_list);
+	fastlock_init(&ep->coll_state_lock);
 	return 0;
 }
 

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -588,3 +588,67 @@ int fi_no_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 {
 	return -FI_ENOSYS;
 }
+
+ssize_t fi_coll_no_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
+			     fi_addr_t coll_addr, fi_addr_t root_addr,
+			     enum fi_datatype datatype, uint64_t flags, void *context)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_alltoall(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			    void *result, void *result_desc, fi_addr_t coll_addr,
+			    enum fi_datatype datatype, uint64_t flags, void *context)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			     void *result, void *result_desc, fi_addr_t coll_addr,
+			     enum fi_datatype datatype, enum fi_op op, uint64_t flags,
+			     void *context)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_allgather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			     void *result, void *result_desc, fi_addr_t coll_addr,
+			     enum fi_datatype datatype, uint64_t flags, void *context)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count,
+				  void *desc, void *result, void *result_desc,
+				  fi_addr_t coll_addr, enum fi_datatype datatype,
+				  enum fi_op op, uint64_t flags, void *context)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_reduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			  void *result, void *result_desc, fi_addr_t coll_addr,
+			  fi_addr_t root_addr, enum fi_datatype datatype, enum fi_op op,
+			  uint64_t flags, void *context)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_scatter(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			   void *result, void *result_desc, fi_addr_t coll_addr,
+			   fi_addr_t root_addr, enum fi_datatype datatype, uint64_t flags,
+			   void *context)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_gather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+			  void *result, void *result_desc, fi_addr_t coll_addr,
+			  fi_addr_t root_addr, enum fi_datatype datatype, uint64_t flags,
+			  void *context)
+{
+	return -FI_ENOSYS;
+}
+ssize_t fi_coll_no_msg(struct fid_ep *ep, const struct fi_msg_collective *msg,
+		       struct fi_ioc *resultv, void **result_desc, size_t result_count,
+		       uint64_t flags)
+{
+	return -FI_ENOSYS;
+}


### PR DESCRIPTION
This PR makes several improvements over the initial collective implementation and integrates join and barrier collectives with prov/rxm

- when handling collective transfers during the ep->progress flow, additional transfers
  could be generated for the collective operations.  If these collective messages are generated
  during ep->progress, we will hit a deadlock when the collective handling tries to send its
  messages.  To work around this, we've moved the collective transfers to a pending queue,
  which will need to be progressed by providers using the util/coll implementation

- Refactor collective state structures so that there is a single structure
  to describe in-progress collective calls

- Reserve the most significant bit of the collective message tags to identify a collective
  transfer when collective support is requested

- Re-use atomic function implementations