### PR TITLE
collectives: Rework collective APIs to add gather / reduce support

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -576,12 +576,12 @@ function main {
 	set_excludes
 
 	if [[ $1 == "quick" ]]; then
-		local -r tests="unit functional short multinode"
+		local -r tests="unit functional short"
 	elif [[ $1 == "verify" ]]; then
 		local -r tests="complex"
 		complex_cfg=$1
 	else
-		local -r tests=$(echo $1 | sed 's/all/unit,functional,standard,complex,multinode/g' | tr ',' ' ')
+		local -r tests=$(echo $1 | sed 's/all/unit,functional,standard,complex/g' | tr ',' ' ')
 		if [[ $1 == "all" ]]; then
 			complex_cfg=$1
 		fi

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -672,6 +672,7 @@ enum fi_type {
 	FI_TYPE_MR_MODE,
 	FI_TYPE_OP_TYPE,
 	FI_TYPE_FID,
+	FI_TYPE_COLLECTIVE_OP,
 };
 
 char *fi_tostr(const void *data, enum fi_type datatype);

--- a/include/rdma/fi_atomic.h
+++ b/include/rdma/fi_atomic.h
@@ -44,7 +44,6 @@ extern "C" {
 
 
 /* Atomic flags */
-#define FI_SCATTER		(1ULL << 57)
 #define FI_FETCH_ATOMIC		(1ULL << 58)
 #define FI_COMPARE_ATOMIC	(1ULL << 59)
 

--- a/include/rdma/fi_collective.h
+++ b/include/rdma/fi_collective.h
@@ -42,6 +42,26 @@
 extern "C" {
 #endif
 
+#ifdef FABRIC_DIRECT
+#include <rdma/fi_direct_collective_def.h>
+#endif /* FABRIC_DIRECT */
+
+#ifndef FABRIC_DIRECT_COLLECTIVE_DEF
+
+enum fi_collective_op {
+	FI_BARRIER,
+	FI_BROADCAST,
+	FI_ALLTOALL,
+	FI_ALLREDUCE,
+	FI_ALLGATHER,
+	FI_REDUCE_SCATTER,
+	FI_REDUCE,
+	FI_SCATTER,
+	FI_GATHER,
+};
+
+#endif
+
 
 struct fi_ops_av_set {
 	size_t	size;
@@ -65,6 +85,7 @@ struct fi_collective_attr {
 	struct fi_atomic_attr	datatype_attr;
 	size_t			max_members;
 	uint64_t		mode;
+	enum fi_collective_op	coll;
 };
 
 struct fi_collective_addr {
@@ -77,6 +98,8 @@ struct fi_msg_collective {
 	void			**desc;
 	size_t			iov_count;
 	fi_addr_t		coll_addr;
+	fi_addr_t		root_addr;
+	enum fi_collective_op	coll;
 	enum fi_datatype	datatype;
 	enum fi_op		op;
 	void			*context;
@@ -84,14 +107,47 @@ struct fi_msg_collective {
 
 struct fi_ops_collective {
 	size_t	size;
+
 	ssize_t	(*barrier)(struct fid_ep *ep, fi_addr_t coll_addr,
 			void *context);
-	ssize_t	(*writeread)(struct fid_ep *ep,
+	ssize_t	(*broadcast)(struct fid_ep *ep,
+			void *buf, size_t count, void *desc,
+			fi_addr_t coll_addr, fi_addr_t root_addr,
+			enum fi_datatype datatype, uint64_t flags, void *context);
+	ssize_t	(*alltoall)(struct fid_ep *ep,
+			const void *buf, size_t count, void *desc,
+			void *result, void *result_desc, fi_addr_t coll_addr,
+			enum fi_datatype datatype, uint64_t flags, void *context);
+	ssize_t	(*allreduce)(struct fid_ep *ep,
 			const void *buf, size_t count, void *desc,
 			void *result, void *result_desc, fi_addr_t coll_addr,
 			enum fi_datatype datatype, enum fi_op op,
 			uint64_t flags, void *context);
-	ssize_t	(*writereadmsg)(struct fid_ep *ep,
+	ssize_t	(*allgather)(struct fid_ep *ep,
+			const void *buf, size_t count, void *desc,
+			void *result, void *result_desc, fi_addr_t coll_addr,
+			enum fi_datatype datatype, uint64_t flags, void *context);
+	ssize_t	(*reduce_scatter)(struct fid_ep *ep,
+			const void *buf, size_t count, void *desc,
+			void *result, void *result_desc, fi_addr_t coll_addr,
+			enum fi_datatype datatype, enum fi_op op,
+			uint64_t flags, void *context);
+	ssize_t	(*reduce)(struct fid_ep *ep,
+			const void *buf, size_t count, void *desc,
+			void *result, void *result_desc, fi_addr_t coll_addr,
+			fi_addr_t root_addr, enum fi_datatype datatype, enum fi_op op,
+			uint64_t flags, void *context);
+	ssize_t	(*scatter)(struct fid_ep *ep,
+			const void *buf, size_t count, void *desc,
+			void *result, void *result_desc,
+			fi_addr_t coll_addr, fi_addr_t root_addr,
+			enum fi_datatype datatype, uint64_t flags, void *context);
+	ssize_t	(*gather)(struct fid_ep *ep,
+			const void *buf, size_t count, void *desc,
+			void *result, void *result_desc,
+			fi_addr_t coll_addr, fi_addr_t root_addr,
+			enum fi_datatype datatype, uint64_t flags, void *context);
+	ssize_t	(*msg)(struct fid_ep *ep,
 			const struct fi_msg_collective *msg,
 			struct fi_ioc *resultv, void **result_desc,
 			size_t result_count, uint64_t flags);
@@ -168,37 +224,11 @@ fi_barrier(struct fid_ep *ep, fi_addr_t coll_addr, void *context)
 
 static inline ssize_t
 fi_broadcast(struct fid_ep *ep, void *buf, size_t count, void *desc,
-	     fi_addr_t coll_addr, enum fi_datatype datatype,
-	     enum fi_op op, uint64_t flags, void *context)
+	     fi_addr_t coll_addr, fi_addr_t root_addr,
+	     enum fi_datatype datatype, uint64_t flags, void *context)
 {
-	if (flags & FI_SEND) {
-		return ep->collective->writeread(ep, buf, count, desc,
-			NULL, NULL, coll_addr, datatype, op, flags, context);
-	} else {
-		return ep->collective->writeread(ep, NULL, count, NULL,
-			buf, desc, coll_addr, datatype, op, flags, context);
-	}
-}
-
-static inline ssize_t
-fi_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-	     void *result, void *result_desc, fi_addr_t coll_addr,
-	     enum fi_datatype datatype, enum fi_op op,
-	     uint64_t flags, void *context)
-{
-	return ep->collective->writeread(ep, buf, count, desc,
-		result, result_desc, coll_addr, datatype, op, flags, context);
-}
-
-static inline ssize_t
-fi_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-		  void *result, void *result_desc,
-		  fi_addr_t coll_addr, enum fi_datatype datatype, enum fi_op op,
-		  uint64_t flags, void *context)
-{
-	return ep->collective->writeread(ep, buf, count, desc,
-		result, result_desc, coll_addr, datatype, op,
-		flags | FI_SCATTER, context);
+	return ep->collective->broadcast(ep, buf, count, desc,
+		coll_addr, root_addr, datatype, flags, context);
 }
 
 static inline ssize_t
@@ -207,26 +237,74 @@ fi_alltoall(struct fid_ep *ep, const void *buf, size_t count, void *desc,
 	    fi_addr_t coll_addr, enum fi_datatype datatype,
 	    uint64_t flags, void *context)
 {
-	return ep->collective->writeread(ep, buf, count, desc,
-		result, result_desc, coll_addr, datatype, FI_ALLTOALL,
-		flags, context);
+	return ep->collective->alltoall(ep, buf, count, desc,
+		result, result_desc, coll_addr, datatype, flags, context);
+}
+
+static inline ssize_t
+fi_allreduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+	     void *result, void *result_desc, fi_addr_t coll_addr,
+	     enum fi_datatype datatype, enum fi_op op,
+	     uint64_t flags, void *context)
+{
+	return ep->collective->allreduce(ep, buf, count, desc,
+		result, result_desc, coll_addr, datatype, op, flags, context);
 }
 
 static inline ssize_t
 fi_allgather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
-	     void *result, void *result_desc,
-	     fi_addr_t coll_addr, enum fi_datatype datatype,
-	     uint64_t flags, void *context)
+	     void *result, void *result_desc, fi_addr_t coll_addr,
+	     enum fi_datatype datatype, uint64_t flags, void *context)
 {
-	return ep->collective->writeread(ep, buf, count, desc,
-		result, result_desc, coll_addr, datatype, FI_ALLGATHER,
-		flags, context);
+	return ep->collective->allgather(ep, buf, count, desc,
+		result, result_desc, coll_addr, datatype, flags, context);
+}
+
+static inline ssize_t
+fi_reduce_scatter(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+		  void *result, void *result_desc, fi_addr_t coll_addr,
+		  enum fi_datatype datatype, enum fi_op op,
+		  uint64_t flags, void *context)
+{
+	return ep->collective->reduce_scatter(ep, buf, count, desc,
+		result, result_desc, coll_addr, datatype, op, flags, context);
+}
+
+static inline ssize_t
+fi_reduce(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+	  void *result, void *result_desc, fi_addr_t coll_addr,
+	  fi_addr_t root_addr, enum fi_datatype datatype, enum fi_op op,
+	  uint64_t flags, void *context)
+{
+	return ep->collective->reduce(ep, buf, count, desc, result, result_desc,
+		coll_addr, root_addr, datatype, op, flags, context);
+}
+
+
+static inline ssize_t
+fi_scatter(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+	   void *result, void *result_desc, fi_addr_t coll_addr,
+	   fi_addr_t root_addr, enum fi_datatype datatype,
+	   uint64_t flags, void *context)
+{
+	return ep->collective->scatter(ep, buf, count, desc, result, result_desc,
+		coll_addr, root_addr, datatype, flags, context);
+}
+
+
+static inline ssize_t
+fi_gather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
+	  void *result, void *result_desc, fi_addr_t coll_addr,
+	  fi_addr_t root_addr, enum fi_datatype datatype,
+	  uint64_t flags, void *context)
+{
+	return ep->collective->gather(ep, buf, count, desc, result, result_desc,
+		coll_addr, root_addr, datatype, flags, context);
 }
 
 static inline int
-fi_query_collective(struct fid_domain *domain,
-		    enum fi_datatype datatype, enum fi_op op,
-		    struct fi_collective_attr *attr, uint64_t flags)
+fi_query_collective(struct fid_domain *domain, struct fi_collective_attr *attr,
+		    enum fi_datatype datatype, enum fi_op op, uint64_t flags)
 {
 	return fi_query_atomic(domain, datatype, op, &attr->datatype_attr,
 			       flags | FI_COLLECTIVE);

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -145,7 +145,7 @@ struct fi_mr_modify {
 
 #ifndef FABRIC_DIRECT_ATOMIC_DEF
 
-#define FI_COLLECTIVE_OFFSET 256
+//#define FI_COLLECTIVE_OFFSET 256
 
 enum fi_datatype {
 	FI_INT8,
@@ -166,7 +166,7 @@ enum fi_datatype {
 	FI_DATATYPE_LAST,
 
 	/* Collective datatypes */
-	FI_VOID = FI_COLLECTIVE_OFFSET,
+//	FI_VOID = FI_COLLECTIVE_OFFSET,
 };
 
 enum fi_op {
@@ -191,12 +191,6 @@ enum fi_op {
 	FI_MSWAP,
 	/* End of point to point atomic ops */
 	FI_ATOMIC_OP_LAST,
-
-	/* Collective only ops */
-	FI_BARRIER = FI_COLLECTIVE_OFFSET,
-	FI_BROADCAST,
-	FI_ALLTOALL,
-	FI_ALLGATHER,
 };
 
 #endif

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -651,10 +651,6 @@ static int util_coll_proc_reduce_item(struct util_coll_mc *coll_mc,
 	case FI_CSWAP_GT:
 	case FI_MSWAP:
 	case FI_ATOMIC_OP_LAST:
-	case FI_BARRIER:
-	case FI_BROADCAST:
-	case FI_ALLTOALL:
-	case FI_ALLGATHER:
 	default:
 		return -FI_ENOSYS;
 	};

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -47,6 +47,8 @@
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_trigger.h>
+#include <rdma/fi_collective.h>
+
 
 /* Print fi_info and related structs, enums, OR_able flags, addresses.
  *
@@ -585,7 +587,6 @@ static void ofi_tostr_atomic_type(char *buf, enum fi_datatype type)
 	CASEENUMSTR(FI_DOUBLE_COMPLEX);
 	CASEENUMSTR(FI_LONG_DOUBLE);
 	CASEENUMSTR(FI_LONG_DOUBLE_COMPLEX);
-	CASEENUMSTR(FI_VOID);
 	default:
 		ofi_strcatf(buf, "Unknown");
 		break;
@@ -614,10 +615,24 @@ static void ofi_tostr_atomic_op(char *buf, enum fi_op op)
 	CASEENUMSTR(FI_CSWAP_GE);
 	CASEENUMSTR(FI_CSWAP_GT);
 	CASEENUMSTR(FI_MSWAP);
+	default:
+		ofi_strcatf(buf, "Unknown");
+		break;
+	}
+}
+
+static void ofi_tostr_collective_op(char *buf, enum fi_collective_op op)
+{
+	switch (op) {
 	CASEENUMSTR(FI_BARRIER);
 	CASEENUMSTR(FI_BROADCAST);
 	CASEENUMSTR(FI_ALLTOALL);
+	CASEENUMSTR(FI_ALLREDUCE);
 	CASEENUMSTR(FI_ALLGATHER);
+	CASEENUMSTR(FI_REDUCE_SCATTER);
+	CASEENUMSTR(FI_REDUCE);
+	CASEENUMSTR(FI_SCATTER);
+	CASEENUMSTR(FI_GATHER);
 	default:
 		ofi_strcatf(buf, "Unknown");
 		break;
@@ -760,6 +775,9 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 		break;
 	case FI_TYPE_FID:
 		ofi_tostr_fid("fid: ", buf, data);
+		break;
+	case FI_TYPE_COLLECTIVE_OP:
+		ofi_tostr_collective_op(buf, *enumval);
 		break;
 	default:
 		ofi_strcatf(buf, "Unknown type");


### PR DESCRIPTION
Update the collective APIs to support gather and reduce
operations.  These were missing from the initial collective
calls.  Adding these exposed an issue with the existing calls
providing the 'root' of broadcast calls, which are also
needed for gather and reduce.

To support the new calls, and make it easier to extend support
for other collective ops, modify the calls into the provider.
Instead of using a single writeread() atomic style call, define
separate entry points for each collective.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>