### PR TITLE
Revert "prov/verbs: Attempt at providing IB async events"

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -264,7 +264,6 @@ struct fi_ibv_eq {
 	struct fid_eq		eq_fid;
 	struct fi_ibv_fabric	*fab;
 	fastlock_t		lock;
-	ofi_atomic32_t		ref;
 	struct dlistfd_head	list_head;
 	struct rdma_event_channel *channel;
 	uint64_t		flags;
@@ -738,9 +737,6 @@ int fi_ibv_cq_signal(struct fid_cq *cq);
 
 ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
 		const void *buf, size_t len);
-
-int fi_ibv_eq_attach_domain(struct fi_ibv_eq *eq, struct fi_ibv_domain *domain);
-int fi_ibv_eq_detach_domain(struct fi_ibv_domain *domain);
 
 int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -42,7 +42,6 @@ static int fi_ibv_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
 	struct fi_ibv_domain *domain;
 	struct fi_ibv_eq *eq;
-	int ret;
 
 	domain = container_of(fid, struct fi_ibv_domain,
 			      util_domain.domain_fid.fid);
@@ -52,10 +51,7 @@ static int fi_ibv_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		switch (domain->ep_type) {
 		case FI_EP_MSG:
 			eq = container_of(bfid, struct fi_ibv_eq, eq_fid);
-			ret = fi_ibv_eq_attach_domain(eq, domain);
-			if (ret)
-				return ret;
-
+			domain->eq = eq;
 			domain->eq_flags = flags;
 			break;
 		case FI_EP_DGRAM:
@@ -107,11 +103,6 @@ static int fi_ibv_domain_close(fid_t fid)
 	}
 
 	ofi_mr_cache_cleanup(&domain->cache);
-
-	if (domain->eq) {
-		ret = fi_ibv_eq_detach_domain(domain);
-		assert(ret == 0);
-	}
 
 	if (domain->pd) {
 		ret = ibv_dealloc_pd(domain->pd);


### PR DESCRIPTION
This reverts commit df435c92dfb1233680d69be8881b533a885218ed.

This patch is an attempt to provide an initial support of async
events into the Verbs provider. Async event are particularly
interesting to report events such as a network device removal or
CQ overrun into the Event Queue (EQ).

PS: only MSG and RDM endpoints are supported as for now.

Two separate issues have been reported.  Multi-threaded apps with
auto-progress without FI_ATOMIC is failing.  Also, ubertest is
experiencing hangs during shutdown waiting for the async thread
to exit.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>
Signed-off-by: Sean Hefty <sean.hefty@intel.com>