### PR TITLE
prov/efa: Use application's registration when available

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -469,6 +469,9 @@ struct rxr_tx_entry {
 	size_t rma_iov_count;
 	struct fi_rma_iov rma_iov[RXR_IOV_LIMIT];
 
+	/* App-provided reg descriptor */
+	void *desc[RXR_IOV_LIMIT];
+
 	/* Only used with mr threshold switch from memcpy */
 	size_t iov_mr_start;
 	struct fid_mr *mr[RXR_IOV_LIMIT];


### PR DESCRIPTION
With this commit, the inline registration path allows for reuse of
application descriptors when provided, avoiding the need for the bounce
buffers for the data packets.

Signed-off-by: Raghu Raja <craghun@amazon.com>