### PR TITLE
mr/cache: Tweaks to unsubscribe paths

### DIFF
--- a/fabtests/ubertest/uber.c
+++ b/fabtests/ubertest/uber.c
@@ -596,6 +596,15 @@ static int ft_server_child()
 	if (ret && ret != -FI_ENODATA) {
 		FT_PRINTERR("fi_getinfo", ret);
 	} else {
+		/* Temporary fix to run one set of tests, rather than
+		 * iterating over all interfaces / addresses.
+		 * TODO: Remove iteration from ft_fw_process_list_server.
+		 */
+		if (info->next) {
+			fi_freeinfo(info->next);
+			info->next = NULL;
+		}
+
 		ret = ft_fw_process_list_server(hints, info);
 		if (ret != -FI_ENODATA)
 			fi_freeinfo(info);
@@ -680,8 +689,16 @@ static int ft_client_child(void)
 
 		result = fi_getinfo(FT_FIVERSION, ft_strptr(test_info.node),
 				 ft_strptr(test_info.service), 0, hints, &info);
-		if (result) {
+		if (result)
 			FT_PRINTERR("fi_getinfo", result);
+
+		/* Temporary fix to run one set of tests, rather than
+		 * iterating over all interfaces / addresses.
+		 * TODO: Remove iteration from ft_fw_process_list_client.
+		 */
+		if (info && info->next) {
+			fi_freeinfo(info->next);
+			info->next = NULL;
 		}
 
 		ret = ft_fw_process_list_client(hints, info);

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -247,6 +247,11 @@ static void *ofi_uffd_handler(void *arg)
 
 		switch (msg.event) {
 		case UFFD_EVENT_REMOVE:
+			ofi_monitor_unsubscribe(&uffd.monitor,
+				(void *) (uintptr_t) msg.arg.remove.start,
+				(size_t) (msg.arg.remove.end -
+					  msg.arg.remove.start));
+			/* fall through */
 		case UFFD_EVENT_UNMAP:
 			ofi_monitor_notify(&uffd.monitor,
 				(void *) (uintptr_t) msg.arg.remove.start,

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -128,12 +128,6 @@ void ofi_mr_cache_notify(struct ofi_mr_cache *cache, const void *addr, size_t le
 	for (entry = cache->storage.overlap(&cache->storage, &iov); entry;
 	     entry = cache->storage.overlap(&cache->storage, &iov))
 		util_mr_uncache_entry(cache, entry);
-
-	/* See comment in util_mr_free_entry.  If we're not merging address
-	 * ranges, we can only safely unsubscribe for the reported range.
-	 */
-	if (!cache_params.merge_regions)
-		ofi_monitor_unsubscribe(cache->monitor, addr, len);
 }
 
 static bool mr_cache_flush(struct ofi_mr_cache *cache)

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -78,6 +78,13 @@ static void util_mr_free_entry(struct ofi_mr_cache *cache,
 	       entry->info.iov.iov_base, entry->info.iov.iov_len);
 
 	assert(!entry->storage_context);
+	cache->delete_region(cache, entry);
+	ofi_buf_free(entry);
+}
+
+static void util_mr_uncache_entry_storage(struct ofi_mr_cache *cache,
+					  struct ofi_mr_entry *entry)
+{
 	/* If regions are not being merged, then we can't safely
 	 * unsubscribe this region from the monitor.  Otherwise, we
 	 * might unsubscribe an address range in use by another region.
@@ -89,13 +96,7 @@ static void util_mr_free_entry(struct ofi_mr_cache *cache,
 					entry->info.iov.iov_len);
 		entry->subscribed = 0;
 	}
-	cache->delete_region(cache, entry);
-	ofi_buf_free(entry);
-}
 
-static void util_mr_uncache_entry_storage(struct ofi_mr_cache *cache,
-					  struct ofi_mr_entry *entry)
-{
 	cache->storage.erase(&cache->storage, entry);
 	cache->cached_cnt--;
 	cache->cached_size -= entry->info.iov.iov_len;


### PR DESCRIPTION
First commit adds auto-unsubscribe for the REMOVE event, to align it with UNMAP.

The second commit moves unsubscribe from the MR free path to the uncache path.  Note that the resulting changes actually show that other lines moved because of the structure of the code.  But the code that moved is the call to ofi_monitor_unsubscribe() and related if statement and comment.

This is a slight improvement over the existing code, but an additional cleanup could be added to better handle entries for which we've received a notification.