### PR TITLE
contrib/cray: Added Excluded result to parser

### DIFF
--- a/contrib/cray/python/parse_results.py
+++ b/contrib/cray/python/parse_results.py
@@ -86,6 +86,8 @@ def fabtests_testcase_parser(log, classname_prefix):
                 result = 'pass'
             elif data[1] == 'Notrun':
                 result = 'skip'
+            elif data[1] == 'Excluded':
+                result = 'skip'
             else:
                 result = 'fail'
         elif line.startswith('  time:'):


### PR DESCRIPTION
Adds Excluded result to parser. Without the change, the script assumes
the test has failed.

Signed-off-by: James Swaro <jswaro@cray.com>