### PR TITLE
prov/efa: Change efa mr cache defaults

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -72,7 +72,7 @@
 
 #define EFA_NO_DEFAULT -1
 
-#define EFA_DEF_MR_CACHE_ENABLE 0
+#define EFA_DEF_MR_CACHE_ENABLE 1
 #define EFA_DEF_MR_CACHE_MERGE_REGIONS 1
 
 int efa_mr_cache_enable		= EFA_DEF_MR_CACHE_ENABLE;


### PR DESCRIPTION
MR cache issues have been diagnosed, details in issue #5347 . We have
decided to enable it by default.

Signed-off-by: William Zhang <wilzhang@amazon.com>