### PR TITLE
scripts/runfabtests.sh: Fix multinode test running on OSX devices

### DIFF
--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -212,6 +212,15 @@ testing scope is limited.
 *fi_resource_freeing*
 : Allocates and closes fabric resources to check for proper cleanup.
 
+# Multinode
+
+This test runs a series of tests over multiple formats and patterns to help
+validate at scale. The patterns are an all to all, one to all, all to one and
+a ring. The tests also run accross multiple capabilites, such as messages, rma,
+atomics, and tagged messages. Currently, there is no option to run these 
+capabilities and patterns independently, however the test is short enough to be
+all run at once.   
+
 # Ubertest
 
 This is a comprehensive latency, bandwidth, and functionality test that can
@@ -356,6 +365,14 @@ This will run "fi_rdm_atomic" for all atomic operations with
 	- 1000 iterations
 	- 1024 bytes message size
 	- server node as 123.168.0.123
+
+## Run multinode tests
+
+	server and clients are invoked with the same command: 
+		fi_multinode -n <number of processes> -s <server_addr> 
+	
+	a process on the server must be started before any of the clients can be started 
+	succesfully. 
 
 ## Run fi_ubertest
 

--- a/fabtests/man/man1/fi_multinode.1
+++ b/fabtests/man/man1/fi_multinode.1
@@ -1,0 +1,1 @@
+.so man7/fabtests.7

--- a/fabtests/man/man7/fabtests.7
+++ b/fabtests/man/man7/fabtests.7
@@ -304,7 +304,7 @@ Tests memory registration.
 .RE
 .TP
 .B \f[I]fi_resource_freeing\f[]
-Allocates and closes fabric resources to check for proper cleanup. 
+Allocates and closes fabric resources to check for proper cleanup.
 .RS
 .RE
 .SH Ubertest

--- a/fabtests/man/man7/fabtests.7
+++ b/fabtests/man/man7/fabtests.7
@@ -304,7 +304,7 @@ Tests memory registration.
 .RE
 .TP
 .B \f[I]fi_resource_freeing\f[]
-Allocates and closes fabric resources to check for proper cleanup.
+Allocates and closes fabric resources to check for proper cleanup. 
 .RS
 .RE
 .SH Ubertest

--- a/fabtests/multinode/src/harness.c
+++ b/fabtests/multinode/src/harness.c
@@ -184,7 +184,7 @@ static int pm_conn_setup()
 	int sock,  ret;
 	int optval = 1;
 
-	sock = socket(AF_INET, SOCK_STREAM, 0);
+	sock = socket(pm_job.oob_server_addr.ss_family, SOCK_STREAM, 0);
 	if (sock < 0)
 		return -1;
 

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -542,6 +542,11 @@ function multinode_test {
 		c_pid_arr+=($!)
 	done
 
+	for pid in ${c_pid_arr[*]}; do
+		wait $pid
+	done
+	
+
 	[[ c_ret -ne 0 ]] && kill -9 $s_pid 2> /dev/null
 
 	wait $s_pid


### PR DESCRIPTION
The issue of the OSX tests timing out was likely caused by not waiting for client processes to finish executing before killing the server. The bash script now waits for all of those clients to finish. 