### PR TITLE
contrib/cray: Change paths to only use stable

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -408,8 +408,8 @@ pipeline {
         ROOT_BUILD_PATH = "/scratch/jenkins/builds"
         FABTEST_PATH = "${WORKSPACE + '/installs/fabtests'}"
         LIBFABRIC_BUILD_PATH = "${ROOT_BUILD_PATH + '/libfabric'}"
-        OMB_BUILD_PATH = "${ROOT_BUILD_PATH + '/osu-micro-benchmarks/5.4.2/libexec/osu-micro-benchmarks/mpi'}"
-        MPICH_PATH = "${ROOT_BUILD_PATH + '/mpich/3.3b3'}"
+        OMB_BUILD_PATH = "${ROOT_BUILD_PATH + '/osu-micro-benchmarks/stable/libexec/osu-micro-benchmarks/mpi'}"
+        MPICH_PATH = "${ROOT_BUILD_PATH + '/mpich/stable'}"
         SFT_INSTALL_PATH = "${ROOT_BUILD_PATH + '/libfabric-sft/stable'}"
         BATS_INSTALL_PATH = "${ROOT_BUILD_PATH + '/bats/stable/bin'}"
     }


### PR DESCRIPTION
When testing libfabric, only use builds of OMB and MPICH
that have been deemed stable by the development team.

Signed-off-by: James Swaro <jswaro@cray.com>