### PR TITLE
prov/util: Refactor queuing of collective work items

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -127,6 +127,7 @@ src_libfabric_la_SOURCES =			\
 	include/ofi_indexer.h			\
 	include/ofi_iov.h			\
 	include/ofi_list.h			\
+	include/ofi_bitmask.h			\
 	include/shared/ofi_str.h		\
 	include/ofi_lock.h			\
 	include/ofi_mem.h			\

--- a/include/ofi_bitmask.h
+++ b/include/ofi_bitmask.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2019-2019 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _OFI_BITMASK_H_
+#define _OFI_BITMASK_H_
+
+#include <rdma/fi_errno.h>
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+
+struct bitmask {
+	size_t size;
+	uint8_t *bytes;
+};
+
+static inline int ofi_bitmask_create(struct bitmask *mask, size_t size)
+{
+	size_t byte_size = size / 8;
+	if (byte_size % 8)
+		byte_size++;
+
+	mask->bytes = calloc(byte_size, 1);
+	if (!mask->bytes)
+		return -FI_ENOMEM;
+
+	mask->size = size;
+
+	return FI_SUCCESS;
+};
+
+static inline void ofi_bitmask_free(struct bitmask *mask)
+{
+	free(mask->bytes);
+	mask->bytes = NULL;
+};
+
+static inline void ofi_bitmask_unset(struct bitmask *mask, size_t idx)
+{
+	assert(idx <= mask->size);
+	mask->bytes[idx / 8] &= ~(0x01 << (idx % 8));
+};
+
+static inline void ofi_bitmask_set(struct bitmask *mask, size_t idx)
+{
+	assert(idx <= mask->size);
+	mask->bytes[idx / 8] |= (0x01 << (idx % 8));
+};
+
+static inline void ofi_bitmask_set_all(struct bitmask *mask)
+{
+	int byte_size = mask->size / 8;
+	memset(mask->bytes, 0xff, byte_size);
+};
+
+static inline size_t ofi_bitmask_get_lsbset(struct bitmask mask)
+{
+	int cur;
+	uint8_t tmp;
+	size_t ret = 0;
+
+	for (cur = 0; cur < (mask.size/8); cur++) {
+		if (mask.bytes[cur]) {
+			tmp = mask.bytes[cur];
+			while (!(tmp & 0x1)) {
+				tmp >>= 1;
+				ret++;
+			}
+			break;
+		} else {
+			ret += 8;
+		}
+	}
+
+	assert(ret <= (mask.size));
+	return ret;
+};
+
+#endif

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -37,9 +37,10 @@
 
 #include <ofi_list.h>
 #include <ofi_atom.h>
+#include <ofi_bitmask.h>
 
-#define OFI_WORLD_CONTEXT_ID 0
-#define OFI_CONTEXT_ID_SIZE 4
+#define OFI_WORLD_GROUP_ID 0
+#define OFI_MAX_GROUP_ID 256
 #define OFI_COLL_TAG_FLAG (1ULL << 63)
 
 enum barrier_type {
@@ -117,7 +118,7 @@ struct util_coll_mc {
 	struct slist		deferred_list;
 	struct slist		pending_xfer_list;
 	int			my_rank;
-	uint16_t		cid;
+	uint16_t		group_id;
 	uint16_t		seq;
 	ofi_atomic32_t		ref;
 };
@@ -126,18 +127,15 @@ struct util_coll_state;
 
 typedef void (*util_coll_comp_fn_t)(struct util_coll_state *state);
 
-struct util_coll_cid_data {
-	uint64_t	cid_buf[OFI_CONTEXT_ID_SIZE];
-	uint64_t	tmp_cid_buf[OFI_CONTEXT_ID_SIZE];
-};
-
 struct util_coll_state {
 	struct util_coll_hdr	hdr;
 	struct dlist_entry	entry;
 	enum util_coll_op_type	type;
 	void			*context;
 	struct util_coll_mc	*mc;
-	struct util_coll_cid_data data;
+	struct slist		work_queue;
+	void			*comp_data;
+	size_t			comp_data_size;
 	util_coll_comp_fn_t	comp_fn;
 };
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -297,8 +297,7 @@ struct util_ep {
 	ofi_fastlock_release_t	lock_release;
 
 	struct bitmask		*coll_cid_mask;
-	struct dlist_entry	coll_state_list;
-	fastlock_t		coll_state_lock;
+	struct slist		coll_ready_queue;
 };
 
 int ofi_ep_bind_av(struct util_ep *util_ep, struct util_av *av);

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -64,6 +64,7 @@
 #include <ofi_indexer.h>
 #include <ofi_epoll.h>
 #include <ofi_proto.h>
+#include <ofi_bitmask.h>
 
 #include "rbtree.h"
 #include "uthash.h"
@@ -295,6 +296,7 @@ struct util_ep {
 	ofi_fastlock_acquire_t	lock_acquire;
 	ofi_fastlock_release_t	lock_release;
 
+	struct bitmask		*coll_cid_mask;
 	struct dlist_entry	coll_state_list;
 	fastlock_t		coll_state_lock;
 };

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -616,6 +616,7 @@
     <ClInclude Include="include\rdma\fi_rma.h" />
     <ClInclude Include="include\rdma\fi_tagged.h" />
     <ClInclude Include="include\rdma\fi_trigger.h" />
+    <ClInclude Include="include\rdma\fi_collective.h" />
     <ClInclude Include="include\rdma\providers\fi_log.h" />
     <ClInclude Include="include\rdma\providers\fi_prov.h" />
     <ClInclude Include="include\uthash.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -557,6 +557,9 @@
     <ClInclude Include="include\rdma\fi_trigger.h">
       <Filter>Header Files\rdma</Filter>
     </ClInclude>
+    <ClInclude Include="include\rdma\fi_collective.h">
+      <Filter>Header Files\rdma</Filter>
+    </ClInclude>
     <ClInclude Include="include\windows\osd.h">
       <Filter>Header Files\windows</Filter>
     </ClInclude>

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -612,7 +612,7 @@ ssize_t rxm_cq_handle_coll_eager(struct rxm_rx_buf *rx_buf)
 					    0, rx_buf->pkt.data,
 					    rx_buf->pkt.hdr.size);
 	if(rx_buf->pkt.hdr.tag & OFI_COLL_TAG_FLAG) {
-		ofi_coll_handle_comp(rx_buf->pkt.hdr.tag,
+		ofi_coll_handle_xfer_comp(rx_buf->pkt.hdr.tag,
 				rx_buf->recv_entry->context);
 		rxm_recv_entry_release(rx_buf->recv_entry->recv_queue,
 				rx_buf->recv_entry);
@@ -1110,7 +1110,7 @@ int rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *t
 	int ret;
 
 	if (tx_eager_buf->pkt.hdr.tag & OFI_COLL_TAG_FLAG) {
-		ofi_coll_handle_comp(tx_eager_buf->pkt.hdr.tag,
+		ofi_coll_handle_xfer_comp(tx_eager_buf->pkt.hdr.tag,
 				tx_eager_buf->app_context);
 		ret = FI_SUCCESS;
 	} else {
@@ -1475,10 +1475,9 @@ void rxm_ep_progress_coll(struct util_ep *util_ep)
 {
 	ofi_ep_lock_acquire(util_ep);
 	rxm_ep_do_progress(util_ep);
-	ofi_coll_ep_progress(&util_ep->ep_fid);
 	ofi_ep_lock_release(util_ep);
 
-	ofi_coll_process_pending(&util_ep->ep_fid);
+	ofi_coll_ep_progress(&util_ep->ep_fid);
 }
 
 static int rxm_cq_close(struct fid *fid)

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -263,8 +263,7 @@ int ofi_endpoint_init(struct fid_domain *domain, const struct util_prov *util_pr
 	} else {
 		ep->coll_cid_mask = NULL;
 	}
-	dlist_init(&ep->coll_state_list);
-	fastlock_init(&ep->coll_state_lock);
+	slist_init(&ep->coll_ready_queue);
 	return 0;
 }
 


### PR DESCRIPTION
This PR aims to clean up some of the confusing and extraneous queuing and locking of collective work items.  We reduce to 1 queue of all ready-to-go items across all collectives in flight and structures to track collectives and their work items that are waiting to be processed.

The PR also offers a few other minor clean up items, such as some clarification to the context id mask, the addition of some missing file listings in the vsxproj, and some minor collective multinode fabtest clean up.