### PR TITLE
rdma/fabric.h: Change windows version to 1.9.1a1

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -77,7 +77,7 @@ extern "C" {
 #endif
 
 #define FI_MAJOR_VERSION 1
-#define FI_MINOR_VERSION 8
+#define FI_MINOR_VERSION 9
 
 enum {
 	FI_PATH_MAX		= 256,


### PR DESCRIPTION
There is some difference between how we set linux version
and how we do it for windows version. For windows
it is set by FI_MINOR_VERSION*.
*- check include/windows/config.h:198

That's why we should change FI_MINOR_VERSION to 9
in order to see 1.9.1a1 instead of 1.8.1a1 for WinOS.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>