### PR TITLE
ubertest/psm2: Remove SENDV bandwidth testing

### DIFF
--- a/fabtests/test_configs/psm2/all.test
+++ b/fabtests/test_configs/psm2/all.test
@@ -2,12 +2,39 @@
 	prov_name: psm2,
 	test_type: [
 		FT_TEST_LATENCY,
-		FT_TEST_BANDWIDTH,
 	],
 	class_function: [
 		FT_FUNC_SEND,
 		FT_FUNC_SENDV,
 		FT_FUNC_SENDMSG,
+		FT_FUNC_INJECT,
+	],
+	ep_type: [
+		FI_EP_RDM
+	],
+	av_type: [
+		FI_AV_TABLE
+		FI_AV_MAP,
+	],
+	comp_type: [
+		FT_COMP_QUEUE,
+	],
+	mode: [
+		FI_CONTEXT,
+	],
+	test_class: [
+		FT_CAP_MSG,
+		FT_CAP_TAGGED,
+	],
+	test_flags: FT_FLAG_QUICKTEST
+},
+{
+	prov_name: psm2,
+	test_type: [
+		FT_TEST_BANDWIDTH,
+	],
+	class_function: [
+		FT_FUNC_SEND,
 		FT_FUNC_INJECT,
 	],
 	ep_type: [


### PR DESCRIPTION
Ubertest re-uses the same data buffer for all sends and receives.
This exposed an issue in the psm2 provider.  The provider posts
the start of the data buffer in order to receive the underlying
protocol header.  After parsing the header, it posts the buffer
to receive the rest of the data.

With bandwidth tests, a stream of messages are received.  When
a single buffer is posted to receive the messages, the received
header is overwritten.  This results in the test hanging.

Since it's highly unlikely that a real application is going to
reuse the same buffer to receive all messages, the simplest
solution is to remove this specific test for the psm2
provider.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>