### PR TITLE
prov/efa: Fix the missing shm env. variable check

### DIFF
--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -1009,7 +1009,7 @@ static int rxr_cq_process_rts(struct rxr_ep *ep,
 		return ret;
 	}
 
-	if (is_local) {
+	if (rxr_env.enable_shm_transfer && is_local) {
 		rxr_release_rx_pkt_entry(ep, pkt_entry);
 		return ret;
 	}
@@ -1179,7 +1179,7 @@ static void rxr_cq_handle_rts(struct rxr_ep *ep,
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 	assert(peer);
 
-	if (peer->is_local) {
+	if (rxr_env.enable_shm_transfer && peer->is_local) {
 		/* no need to reorder msg for shm_ep
 		 * rxr_cq_process_rts will write error cq entry if needed
 		 */
@@ -1486,7 +1486,7 @@ void rxr_cq_handle_pkt_recv_completion(struct rxr_ep *ep,
 
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
 
-	if (peer->is_local)
+	if (rxr_env.enable_shm_transfer && peer->is_local)
 		ep->posted_bufs_shm--;
 	else
 		ep->posted_bufs_efa--;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1115,7 +1115,7 @@ ssize_t rxr_ep_send_msg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	rxr_ep_print_pkt("Sent", ep, (struct rxr_base_hdr *)pkt_entry->pkt);
 #endif
 #endif
-	if (peer->is_local) {
+	if (rxr_env.enable_shm_transfer && peer->is_local) {
 		ret = fi_sendmsg(ep->shm_ep, msg, flags);
 	} else {
 		ret = fi_sendmsg(ep->rdm_ep, msg, flags);
@@ -2935,7 +2935,8 @@ static inline int rxr_ep_send_queued_pkts(struct rxr_ep *ep,
 
 	dlist_foreach_container_safe(pkts, struct rxr_pkt_entry,
 				     pkt_entry, entry, tmp) {
-		if (rxr_ep_get_peer(ep, pkt_entry->addr)->is_local) {
+		if (rxr_env.enable_shm_transfer &&
+				rxr_ep_get_peer(ep, pkt_entry->addr)->is_local) {
 			dlist_remove(&pkt_entry->entry);
 			continue;
 		}


### PR DESCRIPTION
There were a few places where we were missing the check for shm environment
variable (rxr_env.enable_shm_transfer). Although the code path won't be
affected, fix them to make the code more readable.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>