### PR TITLE
prov/efa : turn on inline memory registration for emulated read

### DIFF
--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -88,7 +88,7 @@ struct rxr_tx_entry *rxr_readrsp_tx_entry_init(struct rxr_ep *rxr_ep,
 	msg.msg_iov = rx_entry->iov;
 	msg.iov_count = rx_entry->iov_count;
 	msg.addr = rx_entry->addr;
-
+	msg.desc = NULL;
 	/*
 	 * this tx_entry works similar to a send tx_entry thus its op was
 	 * set to ofi_op_msg. Note this tx_entry will not write a completion


### PR DESCRIPTION
If MR cache is turned on, EFA provider will try to send data inline
(not using bounce buffer), which require inline memory regitration.

For send/receive, this happens in rxr_ep_handle_rts_sent() on sending
EP. Emulated read does not send a RTS on the sending EP, thus did
not turn on memory registration.

This patch do inline memory registration for emulated read path
after readrsp packet was sent.

Signed-off-by: Wei Zhang <wzam@amazon.com>