### PR TITLE
prov/efa : fix a bug in rxr_ep_rx_entry_init()

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -221,10 +221,10 @@ struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 		rx_entry->cq_entry.flags = (FI_RECV | FI_MSG);
 		break;
 	case ofi_op_read_rsp:
-		rx_entry->cq_entry.flags = (FI_REMOTE_READ | FI_MSG);
+		rx_entry->cq_entry.flags = (FI_REMOTE_READ | FI_RMA);
 		break;
 	case ofi_op_write_async:
-		rx_entry->cq_entry.flags = (FI_REMOTE_WRITE | FI_MSG);
+		rx_entry->cq_entry.flags = (FI_REMOTE_WRITE | FI_RMA);
 		break;
 	default:
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,


### PR DESCRIPTION
rxr_ep_rx_entry_init() is not setting rx_entry->cq_entry.flags for
ofi_op_read_rsp and ofi_op_write correctly.

For these operations, it should set the FI_RMA flag, but is
setting the FI_MSG flag. This patch fix this issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>