### PR TITLE
prov/sockets: postive value returned on error

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -398,7 +398,7 @@ static int sock_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt
 					err_code = ret;
 			} else {
 				SOCK_LOG_ERROR("Node/service value is not valid\n");
-				err_code = FI_ETOOSMALL;
+				err_code = -FI_ETOOSMALL;
 			}
 		}
 	}


### PR DESCRIPTION
sock_av_insertsym() may return postive FI_ETOOSMALL on
error. Fix nit (#5387) before fixing #5386.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>