### PR TITLE
Fix gcc-9.2.1 stringop warnings

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -379,8 +379,9 @@ static int sock_av_insertsym(struct fid_av *av, const char *node, size_t nodecnt
 	else
 		fmt = offset;
 
-	assert((hostlen-offset) < FI_NAME_MAX);
-	strncpy(base_host, node, hostlen - (offset));
+	if (hostlen - offset >= FI_NAME_MAX)
+		return -FI_ETOOSMALL;
+	memcpy(base_host, node, hostlen - offset);
 	var_port = atoi(service);
 	var_host = atoi(node + hostlen - offset);
 

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -197,7 +197,7 @@ void smr_map_to_endpoint(struct smr_region *region, int index)
 	local_peers = smr_peer_addr(region);
 
 	strncpy(smr_peer_addr(region)[index].name,
-		region->map->peers[index].peer.name, SMR_NAME_SIZE);
+		region->map->peers[index].peer.name, SMR_NAME_SIZE - 1);
 	smr_peer_addr(region)[index].name[SMR_NAME_SIZE - 1] = '\0';
 	if (region->map->peers[index].peer.addr == FI_ADDR_UNSPEC)
 		return;


### PR DESCRIPTION
Fixes issue #5386. gcc 9 adds compiler warnings for strncpy
overflows and NUL termination. This fixes the two warnings
that occurred when compiling the existing code. The change
in util_shm.c just suppresses the warning; the existing code
was correct. The change in sock_av.c does fix a possible
overflow in the non-debug case.

Signed-off-by: John Byrne <john.l.byrne@hpe.com>