### PR TITLE
contrib/cray: Remove tag fetching from pipeline

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -30,7 +30,6 @@ pipeline {
             steps {
                 // creating git short hash
                 script {
-		    sh("git fetch --tags")
                     GIT_DESCRIPTION = sh(returnStdout: true, script: "git describe --tags").trim()
                     LIBFABRIC_INSTALL = pwd tmp: true
                 }


### PR DESCRIPTION
Tags can be fetched through the pipeline configuration.
This commit removes the tag fetching from the pipeline.

Signed-off-by: James Swaro <jswaro@cray.com>