### PR TITLE
prov/efa: prov/efa: Initialize global objects for DSO builds

### DIFF
--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -552,6 +552,11 @@ static void rxr_fini(void)
 		if (shm_info)
 			fi_freeinfo(shm_info);
 	}
+
+#if HAVE_EFA_DL
+	ofi_monitor_cleanup();
+	ofi_mem_fini();
+#endif
 }
 
 struct fi_provider rxr_prov = {
@@ -618,6 +623,11 @@ EFA_INI
 	fi_param_define(&rxr_prov, "shm_cq_read_size", FI_PARAM_SIZE_T,
 			"Set the number of SHM completion entries to read for one loop for one iteration of the progress engine. (Default: 50)");
 	rxr_init_env();
+
+#if HAVE_EFA_DL
+	ofi_mem_init();
+	ofi_monitor_init();
+#endif
 
 	lower_efa_prov = init_lower_efa_prov();
 	if (!lower_efa_prov)


### PR DESCRIPTION
76a9f40ffe added logic to mark pinned memory with MADV_DONTFORK to
prevent the copy-on-write semantics in the face of a fork. Given the
pinned memory could be backed by regular or huge pages, efa_madvise()
relied on the global page_sizes array to try marking the region with all
known sizes. When the provider is built as a DSO library, the global
page_sizes array is uninitialized causing the function to fail and
return an erroneous errno. This commit fixes it by calling
`ofi_mem_ini()` explicitly when initializing the EFA provider in a DSO
build.

Likewise, the MR cache code in EFA relies on the global monitor which
needs to be initialized inside a DSO build.

Signed-off-by: Raghu Raja <craghun@amazon.com>