### PR TITLE
src/common, prov/shm: addressing fixes

### DIFF
--- a/man/fi_shm.7.md
+++ b/man/fi_shm.7.md
@@ -74,7 +74,7 @@ of operations.
   provided (and in the case of setting the src address without FI_SOURCE and
   no hints), the process ID will be used as a default address.
   On endpoint creation, if the src_addr has the "fi_shm://" prefix, the provider
-  will append ":[dom_idx]:[ep_idx]" as a unique endpoint name (essentially,
+  will append ":[uid]:[dom_idx]:[ep_idx]" as a unique endpoint name (essentially,
   in place of a service).  In the case of the "fi_ns://" prefix (or any other
   prefix if one was provided by the application), no supplemental information
   is required to make it unique and it will remain with only the

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -430,7 +430,7 @@ static int smr_endpoint_name(char *name, char *addr, size_t addrlen,
 
 	start = smr_no_prefix((const char *) addr);
 	if (strstr(addr, SMR_PREFIX) || dom_idx || ep_idx)
-		snprintf(name, SMR_NAME_SIZE, "%s:%d:%d", start, dom_idx,
+		snprintf(name, SMR_NAME_SIZE, "%s:%d:%d:%d", start, getuid(), dom_idx,
 			 ep_idx);
 	else
 		snprintf(name, SMR_NAME_SIZE, "%s", start);

--- a/src/common.c
+++ b/src/common.c
@@ -756,6 +756,8 @@ int ofi_is_wildcard_listen_addr(const char *node, const char *service,
 	/* else it's okay to call getaddrinfo, proceed with processing */
 
 	if (node) {
+		if (!(flags & FI_SOURCE))
+			return 0;
 		ret = getaddrinfo(node, service, NULL, &res);
 		if (ret) {
 			FI_WARN(&core_prov, FI_LOG_CORE,

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -872,9 +872,13 @@ static int ofi_layering_ok(const struct fi_provider *provider,
 			FI_INFO(&core_prov, FI_LOG_CORE,
 				"Sockets requested, skipping util layering\n");
 			return 0;
-		} else {
-			return 1;
 		}
+		if (!strcasecmp(prov_vec[0], "shm")) {
+			FI_INFO(&core_prov, FI_LOG_CORE,
+				"Shm requested, skipping util layering\n");
+			return 0;
+		}
+		return 1;
 	}
 
 	if ((count == 2) && ofi_has_util_prefix(prov_vec[0]) &&


### PR DESCRIPTION
3 addressing fixes:
- avoid unnecessary getaddrinfo calls
- skip utility provider layering if shm was specifically requested since it cannot be layered
- add user ID to shm address to avoid user permission/duplicate errors
