### PR TITLE
prov/shm: Register custom signal handlers

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -154,6 +154,14 @@ struct smr_addr {
 	fi_addr_t	addr;
 };
 
+
+struct smr_ep_name {
+	char name[NAME_MAX];
+	struct dlist_entry entry;
+};
+
+struct dlist_entry ep_name_list;
+
 struct smr_region;
 
 struct smr_peer {

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -149,9 +149,8 @@ struct smr_cmd {
 #define SMR_INJECT_SIZE		4096
 #define SMR_COMP_INJECT_SIZE	(SMR_INJECT_SIZE / 2)
 
-#define SMR_NAME_SIZE	NAME_MAX
 struct smr_addr {
-	char		name[SMR_NAME_SIZE];
+	char		name[NAME_MAX];
 	fi_addr_t	addr;
 };
 

--- a/prov/shm/Makefile.include
+++ b/prov/shm/Makefile.include
@@ -13,6 +13,7 @@ _shm_files = \
 	prov/shm/src/smr_fabric.c	\
 	prov/shm/src/smr_init.c		\
 	prov/shm/src/smr_av.c		\
+	prov/shm/src/smr_signal.h	\
 	prov/shm/src/smr.h
 
 if HAVE_SHM_DL

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -212,7 +212,7 @@ int smr_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (!smr_av)
 		return -FI_ENOMEM;
 
-	util_attr.addrlen = SMR_NAME_SIZE;
+	util_attr.addrlen = NAME_MAX;
 	util_attr.flags = 0;
 	if (attr->count > SMR_MAX_PEERS) {
 		ret = -FI_ENOSYS;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -70,7 +70,7 @@ int smr_getname(fid_t fid, void *addr, size_t *addrlen)
 	if (!addr || *addrlen == 0 ||
 	    snprintf(addr, *addrlen, "%s", ep->name) >= *addrlen)
 		ret = -FI_ETOOSMALL;
-	*addrlen = NAME_MAX;
+	*addrlen = strlen(ep->name);
 	return ret;
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -70,7 +70,7 @@ int smr_getname(fid_t fid, void *addr, size_t *addrlen)
 	if (!addr || *addrlen == 0 ||
 	    snprintf(addr, *addrlen, "%s", ep->name) >= *addrlen)
 		ret = -FI_ETOOSMALL;
-	*addrlen = SMR_NAME_SIZE;
+	*addrlen = NAME_MAX;
 	return ret;
 }
 
@@ -424,16 +424,16 @@ static int smr_endpoint_name(char *name, char *addr, size_t addrlen,
 			     int dom_idx, int ep_idx)
 {
 	const char *start;
-	memset(name, 0, SMR_NAME_SIZE);
-	if (!addr || addrlen > SMR_NAME_SIZE)
+	memset(name, 0, NAME_MAX);
+	if (!addr || addrlen > NAME_MAX)
 		return -FI_EINVAL;
 
 	start = smr_no_prefix((const char *) addr);
 	if (strstr(addr, SMR_PREFIX) || dom_idx || ep_idx)
-		snprintf(name, SMR_NAME_SIZE, "%s:%d:%d:%d", start, getuid(), dom_idx,
+		snprintf(name, NAME_MAX, "%s:%d:%d:%d", start, getuid(), dom_idx,
 			 ep_idx);
 	else
-		snprintf(name, SMR_NAME_SIZE, "%s", start);
+		snprintf(name, NAME_MAX, "%s", start);
 
 	return 0;
 }
@@ -444,7 +444,7 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct smr_ep *ep;
 	struct smr_domain *smr_domain;
 	int ret, ep_idx;
-	char name[SMR_NAME_SIZE];
+	char name[NAME_MAX];
 
 	ep = calloc(1, sizeof(*ep));
 	if (!ep)
@@ -460,7 +460,7 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err2;
 
-	ret = smr_setname(&ep->util_ep.ep_fid.fid, name, SMR_NAME_SIZE);
+	ret = smr_setname(&ep->util_ep.ep_fid.fid, name, NAME_MAX);
 	if (ret)
 		goto err2;
 

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -135,7 +135,13 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 
 static void smr_fini(void)
 {
-	/* yawn */
+	struct smr_ep_name *ep_name;
+	struct dlist_entry *tmp;
+
+	dlist_foreach_container_safe(&ep_name_list, struct smr_ep_name,
+				     ep_name, entry, tmp) {
+		free(ep_name);
+	}
 }
 
 struct fi_provider smr_prov = {
@@ -155,6 +161,8 @@ struct util_prov smr_util_prov = {
 
 SHM_INI
 {
+	dlist_init(&ep_name_list);
+
 	/* Signal handlers to cleanup tmpfs files on an unclean shutdown */
 	smr_reg_sig_hander(SIGBUS);
 	smr_reg_sig_hander(SIGSEGV);

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -39,21 +39,21 @@
 static void smr_resolve_addr(const char *node, const char *service,
 			     char **addr, size_t *addrlen)
 {
-	char temp_name[SMR_NAME_SIZE];
+	char temp_name[NAME_MAX];
 
 	if (service) {
 		if (node)
-			snprintf(temp_name, SMR_NAME_SIZE, "%s%s:%s",
+			snprintf(temp_name, NAME_MAX, "%s%s:%s",
 				 SMR_PREFIX_NS, node, service);
 		else
-			snprintf(temp_name, SMR_NAME_SIZE, "%s%s",
+			snprintf(temp_name, NAME_MAX, "%s%s",
 				 SMR_PREFIX_NS, service);
 	} else {
 		if (node)
-			snprintf(temp_name, SMR_NAME_SIZE, "%s%s",
+			snprintf(temp_name, NAME_MAX, "%s%s",
 				 SMR_PREFIX, node);
 		else
-			snprintf(temp_name, SMR_NAME_SIZE, "%s%d",
+			snprintf(temp_name, NAME_MAX, "%s%d",
 				 SMR_PREFIX, getpid());
 	}
 

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -34,6 +34,7 @@
 
 #include <ofi_prov.h>
 #include "smr.h"
+#include "smr_signal.h"
 
 
 static void smr_resolve_addr(const char *node, const char *service,
@@ -154,5 +155,11 @@ struct util_prov smr_util_prov = {
 
 SHM_INI
 {
+	/* Signal handlers to cleanup tmpfs files on an unclean shutdown */
+	smr_reg_sig_hander(SIGBUS);
+	smr_reg_sig_hander(SIGSEGV);
+	smr_reg_sig_hander(SIGTERM);
+	smr_reg_sig_hander(SIGINT);
+
 	return &smr_prov;
 }

--- a/prov/shm/src/smr_signal.h
+++ b/prov/shm/src/smr_signal.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2019 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _SMR_SIGNAL_H_
+#define _SMR_SIGNAL_H_
+#include <signal.h>
+#include <ofi_shm.h>
+
+struct sigaction old_action;
+
+static void smr_handle_signal(int signum, siginfo_t *info, void *ucontext)
+{
+	int ret;
+
+	/* Register the original signum handler, SIG_DFL or otherwise */
+	ret = sigaction(signum, &old_action, NULL);
+	if (ret)
+		return;
+
+	/* Raise signum to execute the original handler */
+	raise(signum);
+}
+
+static void smr_reg_sig_hander(int signum)
+{
+	struct sigaction action;
+	int ret;
+
+	memset(&action, 0, sizeof(action));
+	action.sa_sigaction = smr_handle_signal;
+	action.sa_flags |= SA_SIGINFO;
+
+	ret = sigaction(signum, &action, &old_action);
+	if (ret)
+		FI_WARN(&smr_prov, FI_LOG_FABRIC,
+			"Unable to register handler for sig %d\n", signum);
+}
+
+#endif /* _SMR_SIGNAL_H_ */

--- a/prov/shm/src/smr_signal.h
+++ b/prov/shm/src/smr_signal.h
@@ -40,7 +40,13 @@ struct sigaction old_action;
 
 static void smr_handle_signal(int signum, siginfo_t *info, void *ucontext)
 {
+	struct smr_ep_name *ep_name;
 	int ret;
+
+	dlist_foreach_container(&ep_name_list, struct smr_ep_name,
+				ep_name, entry) {
+		shm_unlink(ep_name->name);
+	}
 
 	/* Register the original signum handler, SIG_DFL or otherwise */
 	ret = sigaction(signum, &old_action, NULL);

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -53,6 +53,7 @@ static void smr_peer_addr_init(struct smr_addr *peer)
 int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	       const struct smr_attr *attr, struct smr_region **smr)
 {
+	struct smr_ep_name *ep_name;
 	size_t total_size, cmd_queue_offset, peer_addr_offset;
 	size_t resp_queue_offset, inject_pool_offset, name_offset;
 	int fd, ret, i;
@@ -78,6 +79,14 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 		FI_WARN(prov, FI_LOG_EP_CTRL, "shm_open error\n");
 		goto err1;
 	}
+
+	ep_name = calloc(1, sizeof(*ep_name));
+	if (!ep_name) {
+		FI_WARN(prov, FI_LOG_EP_CTRL, "calloc error\n");
+		return -FI_ENOMEM;
+	}
+	strncpy(ep_name->name, (char *)attr->name, NAME_MAX);
+	dlist_insert_tail(&ep_name->entry, &ep_name_list);
 
 	ret = ftruncate(fd, total_size);
 	if (ret < 0) {

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -45,7 +45,7 @@
 
 static void smr_peer_addr_init(struct smr_addr *peer)
 {
-	memset(peer->name, 0, SMR_NAME_SIZE);
+	memset(peer->name, 0, NAME_MAX);
 	peer->addr = FI_ADDR_UNSPEC;
 }
 
@@ -201,8 +201,8 @@ void smr_map_to_endpoint(struct smr_region *region, int index)
 	local_peers = smr_peer_addr(region);
 
 	strncpy(smr_peer_addr(region)[index].name,
-		region->map->peers[index].peer.name, SMR_NAME_SIZE - 1);
-	smr_peer_addr(region)[index].name[SMR_NAME_SIZE - 1] = '\0';
+		region->map->peers[index].peer.name, NAME_MAX - 1);
+	smr_peer_addr(region)[index].name[NAME_MAX - 1] = '\0';
 	if (region->map->peers[index].peer.addr == FI_ADDR_UNSPEC)
 		return;
 
@@ -211,7 +211,7 @@ void smr_map_to_endpoint(struct smr_region *region, int index)
 
 	for (peer_index = 0; peer_index < SMR_MAX_PEERS; peer_index++) {
 		if (!strncmp(smr_name(region),
-		    peer_peers[peer_index].name, SMR_NAME_SIZE))
+		    peer_peers[peer_index].name, NAME_MAX))
 			break;
 	}
 	if (peer_index != SMR_MAX_PEERS) {
@@ -228,7 +228,7 @@ void smr_unmap_from_endpoint(struct smr_region *region, int index)
 
 	local_peers = smr_peer_addr(region);
 
-	memset(local_peers[index].name, 0, SMR_NAME_SIZE);
+	memset(local_peers[index].name, 0, NAME_MAX);
 	peer_index = region->map->peers[index].peer.addr;
 	if (peer_index == FI_ADDR_UNSPEC)
 		return;
@@ -252,8 +252,8 @@ int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
 	int ret = 0;
 
 	fastlock_acquire(&map->lock);
-	strncpy(map->peers[id].peer.name, name, SMR_NAME_SIZE);
-	map->peers[id].peer.name[SMR_NAME_SIZE - 1] = '\0';
+	strncpy(map->peers[id].peer.name, name, NAME_MAX);
+	map->peers[id].peer.name[NAME_MAX - 1] = '\0';
 	ret = smr_map_to_region(prov, &map->peers[id]);
 	if (!ret)
 		map->peers[id].peer.addr = id;


### PR DESCRIPTION
Four commits:
e2edcc7a9 prov/shm: Cleanup tmpfs cruft after an unclean shutdown
aa71fb16a prov/shm: Register custom signal handlers
1692a4765 prov/shm: Return the correct addrlen on a fi_getname()
076168a4e prov/shm: Replace SMR_NAME_SIZE with NAME_MAX