### PR TITLE
fabtests/getinfo_test: Add test to verify progress

### DIFF
--- a/fabtests/unit/getinfo_test.c
+++ b/fabtests/unit/getinfo_test.c
@@ -491,6 +491,58 @@ out:
 
 
 /*
+ * Progress checks
+ */
+static int init_data_manual(struct fi_info *hints)
+{
+	hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+	return 0;
+}
+
+static int init_data_auto(struct fi_info *hints)
+{
+	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
+	return 0;
+}
+
+static int init_ctrl_manual(struct fi_info *hints)
+{
+	hints->domain_attr->control_progress = FI_PROGRESS_MANUAL;
+	return 0;
+}
+
+static int init_ctrl_auto(struct fi_info *hints)
+{
+	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
+	return 0;
+}
+
+static int check_data_manual(struct fi_info *info)
+{
+	return (info->domain_attr->data_progress != FI_PROGRESS_MANUAL) ?
+		EXIT_FAILURE : 0;
+}
+
+static int check_data_auto(struct fi_info *info)
+{
+	return (info->domain_attr->data_progress != FI_PROGRESS_AUTO) ?
+		EXIT_FAILURE : 0;
+}
+
+static int check_ctrl_manual(struct fi_info *info)
+{
+	return (info->domain_attr->control_progress != FI_PROGRESS_MANUAL) ?
+		EXIT_FAILURE : 0;
+}
+
+static int check_ctrl_auto(struct fi_info *info)
+{
+	return (info->domain_attr->control_progress != FI_PROGRESS_AUTO) ?
+		EXIT_FAILURE : 0;
+}
+
+
+/*
  * getinfo test
  */
 static int getinfo_unit_test(char *node, char *service, uint64_t flags,
@@ -661,6 +713,16 @@ getinfo_test(mr_mode, 5, "Test FI_MR_SCALABLE (v1.0)", NULL, NULL, 0,
 getinfo_test(mr_mode, 6, "Test mr_mode bits", NULL, NULL, 0,
 	     hints, NULL, test_mr_modes, NULL, 0)
 
+/* Progress tests */
+getinfo_test(progress, 1, "Test data manual progress", NULL, NULL, 0,
+	     hints, init_data_manual, NULL, check_data_manual, 0)
+getinfo_test(progress, 2, "Test data auto progress", NULL, NULL, 0,
+	     hints, init_data_auto, NULL, check_data_auto, 0)
+getinfo_test(progress, 3, "Test ctrl manual progress", NULL, NULL, 0,
+	     hints, init_ctrl_manual, NULL, check_ctrl_manual, 0)
+getinfo_test(progress, 4, "Test ctrl auto progress", NULL, NULL, 0,
+	     hints, init_ctrl_auto, NULL, check_ctrl_auto, 0)
+
 
 static void usage(void)
 {
@@ -734,6 +796,10 @@ int main(int argc, char **argv)
 		TEST_ENTRY_GETINFO(mr_mode4),
 		TEST_ENTRY_GETINFO(mr_mode5),
 		TEST_ENTRY_GETINFO(mr_mode6),
+		TEST_ENTRY_GETINFO(progress1),
+		TEST_ENTRY_GETINFO(progress2),
+		TEST_ENTRY_GETINFO(progress3),
+		TEST_ENTRY_GETINFO(progress4),
 		{ NULL, "" }
 	};
 


### PR DESCRIPTION
Expand the unit test to request and verify that providers
return the correct progress settings (manual vs auto for
both data and control).

Signed-off-by: Sean Hefty <sean.hefty@intel.com>