### PR TITLE
prov/verbs: Enable ODP support for filesystem DAX support

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -47,6 +47,16 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 	AS_IF([test $verbs_ibverbs_happy -eq 1 && \
 	       test $verbs_rdmacm_happy -eq 1], [$1], [$2])
 
+	#See if we have extended verbs calls
+	VERBS_HAVE_QUERY_EX=0
+	AS_IF([test $verbs_ibverbs_happy -eq 1],[
+		AC_CHECK_DECL([ibv_query_device_ex],
+			[VERBS_HAVE_QUERY_EX=1],[],
+			[#include <infiniband/verbs.h>])
+		])
+	AC_DEFINE_UNQUOTED([VERBS_HAVE_QUERY_EX],[$VERBS_HAVE_QUERY_EX],
+		[Whether infiniband/verbs.h has ibv_query_device_ex() support or not])
+
 	#See if we have XRC support
 	VERBS_HAVE_XRC=0
 	AS_IF([test $verbs_ibverbs_happy -eq 1 && \

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -49,6 +49,7 @@ struct fi_ibv_gl_data fi_ibv_gl_data = {
 	.def_rx_iov_limit	= 4,
 	.def_inline_size	= 256,
 	.min_rnr_timer		= VERBS_DEFAULT_MIN_RNR_TIMER,
+	.use_odp		= 0,
 	.cqread_bunch_size	= 8,
 	.iface			= NULL,
 	.gid_idx		= 0,
@@ -559,6 +560,14 @@ static int fi_ibv_read_params(void)
 	     (fi_ibv_gl_data.min_rnr_timer > 31))) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of min_rnr_timer\n");
+		return -FI_EINVAL;
+	}
+
+	if (fi_ibv_get_param_bool("use_odp", "Enable on-demand paging memory "
+	    "registrations, if supported.  This is currently required to "
+	    "register DAX file system mmapped memory.", &fi_ibv_gl_data.use_odp)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid value of use_odp\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -310,6 +310,10 @@ struct fi_ibv_pep {
 
 struct fi_ops_cm *fi_ibv_pep_ops_cm(struct fi_ibv_pep *pep);
 
+enum {
+	VRB_USE_XRC = BIT(0),
+};
+
 struct fi_ibv_domain {
 	struct util_domain		util_domain;
 	struct ibv_context		*verbs;
@@ -323,7 +327,7 @@ struct fi_ibv_domain {
 
 	/* Indicates that MSG endpoints should use the XRC transport.
 	 * TODO: Move selection of XRC/RC to endpoint info from domain */
-	int				use_xrc;
+	int				flags;
 	struct {
 		int			xrcd_fd;
 		struct ibv_xrcd		*xrcd;
@@ -444,8 +448,8 @@ int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 
 static inline int fi_ibv_is_xrc(struct fi_info *info)
 {
-	return  (FI_IBV_EP_TYPE(info) == FI_EP_MSG) &&
-		(FI_IBV_EP_PROTO(info) == FI_PROTO_RDMA_CM_IB_XRC);
+	return (FI_IBV_EP_TYPE(info) == FI_EP_MSG) &&
+	       (FI_IBV_EP_PROTO(info) == FI_PROTO_RDMA_CM_IB_XRC);
 }
 
 static inline int fi_ibv_is_xrc_send_qp(enum ibv_qp_type qp_type)

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -146,6 +146,7 @@ extern struct fi_ibv_gl_data {
 	int	def_inline_size;
 	int	min_rnr_timer;
 	int	cqread_bunch_size;
+	int	use_odp;
 	char	*iface;
 	int	gid_idx;
 
@@ -310,8 +311,16 @@ struct fi_ibv_pep {
 
 struct fi_ops_cm *fi_ibv_pep_ops_cm(struct fi_ibv_pep *pep);
 
+
+#if VERBS_HAVE_QUERY_EX
+#define VRB_ACCESS_ON_DEMAND IBV_ACCESS_ON_DEMAND
+#else
+#define VRB_ACCESS_ON_DEMAND 0
+#endif
+
 enum {
 	VRB_USE_XRC = BIT(0),
+	VRB_USE_ODP = BIT(1),
 };
 
 struct fi_ibv_domain {

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -323,13 +323,13 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		goto err4;
 	}
 
-	if (!strncmp(info->domain_attr->name, "hfi1", strlen("hfi1")) ||
-	    !strncmp(info->domain_attr->name, "qib", strlen("qib"))) {
-		_domain->post_send = fi_ibv_post_send_track_credits;
-		_domain->poll_cq = fi_ibv_poll_cq_track_credits;
-	} else {
+	if (fi->nic && fi->nic->device_attr &&
+	    !strncmp(fi->nic->device_attr->vendor_id, "0x02c9", 6)) {
 		_domain->post_send = ibv_post_send;
 		_domain->poll_cq = ibv_poll_cq;
+	} else {
+		_domain->post_send = fi_ibv_post_send_track_credits;
+		_domain->poll_cq = fi_ibv_poll_cq_track_credits;
 	}
 
 	*domain = &_domain->util_domain.domain_fid;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -90,7 +90,7 @@ static int fi_ibv_domain_close(fid_t fid)
 			ofi_ns_stop_server(&fab->name_server);
 		break;
 	case FI_EP_MSG:
-		if (domain->use_xrc) {
+		if (domain->flags & VRB_USE_XRC) {
 			ret = fi_ibv_domain_xrc_cleanup(domain);
 			if (ret)
 				return ret;
@@ -136,7 +136,7 @@ static int fi_ibv_open_device_by_name(struct fi_ibv_domain *domain, const char *
 		const char *rdma_name = ibv_get_device_name(dev_list[i]->device);
 		switch (domain->ep_type) {
 		case FI_EP_MSG:
-			ret = domain->use_xrc ?
+			ret = domain->flags & VRB_USE_XRC ?
 				fi_ibv_cmp_xrc_domain_name(name, rdma_name) :
 				strcmp(name, rdma_name);
 			break;
@@ -263,7 +263,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		goto err2;
 
 	_domain->ep_type = FI_IBV_EP_TYPE(info);
-	_domain->use_xrc = fi_ibv_is_xrc(info);
+	_domain->flags |= fi_ibv_is_xrc(info) ? VRB_USE_XRC : 0;
 
 	ret = fi_ibv_open_device_by_name(_domain, info->domain_attr->name);
 	if (ret)
@@ -309,7 +309,7 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		_domain->util_domain.domain_fid.ops = &fi_ibv_dgram_domain_ops;
 		break;
 	case FI_EP_MSG:
-		if (_domain->use_xrc) {
+		if (_domain->flags & VRB_USE_XRC) {
 			ret = fi_ibv_domain_xrc_init(_domain);
 			if (ret)
 				goto err4;

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -545,7 +545,7 @@ int fi_ibv_domain_xrc_init(struct fi_ibv_domain *domain)
 		goto rbmap_err;
 	}
 
-	domain->use_xrc = 1;
+	domain->flags |= VRB_USE_XRC;
 	return FI_SUCCESS;
 
 rbmap_err:

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -91,6 +91,9 @@ int fi_ibv_mr_reg_common(struct fi_ibv_mem_desc *md, int fi_ibv_access,
 	md->mr_fid.fid.fclass = FI_CLASS_MR;
 	md->mr_fid.fid.context = context;
 
+	if (md->domain->flags & VRB_USE_ODP)
+		fi_ibv_access |= VRB_ACCESS_ON_DEMAND;
+
 	md->mr = ibv_reg_mr(md->domain->pd, (void *) buf, len, fi_ibv_access);
 	if (!md->mr) {
 		if (len)


### PR DESCRIPTION
Experimental verbs API were removed previously.  This adds ODP support through the main verbs API.