### PR TITLE
prov/efa : fix a bug in rxr_ep_tsend()

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1998,8 +1998,7 @@ ssize_t rxr_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	msg_iov.iov_base = (void *)buf;
 	msg_iov.iov_len = len;
-
-	return rxr_ep_tsendv(ep_fid, &msg_iov, desc, 1, dest_addr, tag,
+	return rxr_ep_tsendv(ep_fid, &msg_iov, &desc, 1, dest_addr, tag,
 			     context);
 }
 


### PR DESCRIPTION
While calling rxr_ep_tsendv(), rxr_ep_tsend() should use pointer
to desc, but it is use desc itself currently.

This patch fix this issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>