### PR TITLE
fabtests/ubertest: fixes and updates

### DIFF
--- a/fabtests/test_configs/eq_cq.test
+++ b/fabtests/test_configs/eq_cq.test
@@ -25,9 +25,6 @@
 	cq_wait_obj: [
 		FI_WAIT_NONE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],
@@ -61,9 +58,6 @@
 		FI_WAIT_FD,
 		FI_WAIT_MUTEX_COND,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],
@@ -90,9 +84,6 @@
 	],
 	cq_wait_obj: [
 		FI_WAIT_NONE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -121,9 +112,6 @@
 		FI_WAIT_NONE,
 		FI_WAIT_UNSPEC,
 		FI_WAIT_FD,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,

--- a/fabtests/test_configs/lat_bw.test
+++ b/fabtests/test_configs/lat_bw.test
@@ -19,9 +19,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -42,9 +39,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -68,9 +62,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,

--- a/fabtests/test_configs/sockets/all.test
+++ b/fabtests/test_configs/sockets/all.test
@@ -24,9 +24,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -57,9 +54,6 @@
 	],
 	cq_wait_obj: [
 		FI_WAIT_NONE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -92,9 +86,6 @@
 		FI_WAIT_UNSPEC,
 		FI_WAIT_FD,
 		FI_WAIT_MUTEX_COND,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,

--- a/fabtests/test_configs/sockets/all.test
+++ b/fabtests/test_configs/sockets/all.test
@@ -14,7 +14,6 @@
 	],
 	ep_type: [
 		FI_EP_MSG,
-		FI_EP_DGRAM,
 		FI_EP_RDM,
 	],
 	av_type: [
@@ -70,7 +69,6 @@
 	],
 	ep_type: [
 		FI_EP_MSG,
-		FI_EP_DGRAM,
 	],
 	av_type: [
 		FI_AV_TABLE,

--- a/fabtests/test_configs/sockets/complete.test
+++ b/fabtests/test_configs/sockets/complete.test
@@ -15,7 +15,6 @@
 	],
 	ep_type: [
 		FI_EP_MSG,
-		FI_EP_DGRAM,
 		FI_EP_RDM,
 	],
 	av_type: [
@@ -72,7 +71,6 @@
 	],
 	ep_type: [
 		FI_EP_MSG,
-		FI_EP_DGRAM,
 	],
 	av_type: [
 		FI_AV_TABLE,
@@ -105,7 +103,6 @@
 	],
 	ep_type: [
 		FI_EP_MSG,
-		FI_EP_DGRAM,
 	],
 	av_type: [
 		FI_AV_TABLE,

--- a/fabtests/test_configs/sockets/complete.test
+++ b/fabtests/test_configs/sockets/complete.test
@@ -26,10 +26,6 @@
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
 	],
-	mode: [
-		FT_MODE_ALL,
-		FT_MODE_NONE,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -59,10 +55,6 @@
 		FI_WAIT_UNSPEC,
 		FI_WAIT_FD,
 		FI_WAIT_MUTEX_COND,
-	],
-	mode: [
-		FT_MODE_ALL,
-		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -97,10 +89,6 @@
 		FI_WAIT_FD,
 		FI_WAIT_MUTEX_COND,
 	],
-	mode: [
-		FT_MODE_ALL,
-		FT_MODE_NONE,
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],
@@ -134,10 +122,6 @@
 		FI_WAIT_FD,
 		FI_WAIT_MUTEX_COND,
 	],
-	mode: [
-		FT_MODE_ALL,
-		FT_MODE_NONE,
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],
@@ -170,10 +154,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
-	],
-	mode: [
-		FT_MODE_ALL,
-		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_RMA,
@@ -235,10 +215,6 @@
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
 	],
-	mode: [
-		FT_MODE_ALL,
-		FT_MODE_NONE,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -284,10 +260,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
-	],
-	mode: [
-		FT_MODE_ALL,
-		FT_MODE_NONE,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -341,10 +313,6 @@
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
 	],
-	mode: [
-		FT_MODE_ALL,
-		FT_MODE_NONE,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -367,9 +335,6 @@
 	],
 	comp_type: [
 		FT_COMP_CNTR,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -403,9 +368,6 @@
 	],
 	comp_type: [
 		FT_COMP_CNTR,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -441,9 +403,6 @@
 	comp_type: [
 		FT_COMP_CNTR,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -475,9 +434,6 @@
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -508,9 +464,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 		FT_COMP_CNTR,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,

--- a/fabtests/test_configs/sockets/quick.test
+++ b/fabtests/test_configs/sockets/quick.test
@@ -15,7 +15,6 @@
 	],
 	ep_type: [
 		FI_EP_MSG,
-		FI_EP_DGRAM,
 		FI_EP_RDM,
 	],
 	av_type: [
@@ -73,7 +72,6 @@
 	],
 	ep_type: [
 		FI_EP_MSG,
-		FI_EP_DGRAM,
 	],
 	av_type: [
 		FI_AV_TABLE,

--- a/fabtests/test_configs/sockets/quick.test
+++ b/fabtests/test_configs/sockets/quick.test
@@ -25,9 +25,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -59,9 +56,6 @@
 	],
 	cq_wait_obj: [
 		FI_WAIT_NONE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -96,9 +90,6 @@
 		FI_WAIT_FD,
 		FI_WAIT_MUTEX_COND,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 	],
@@ -130,9 +121,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_RMA,
@@ -171,9 +159,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -206,9 +191,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -240,9 +222,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,

--- a/fabtests/test_configs/sockets/verify.test
+++ b/fabtests/test_configs/sockets/verify.test
@@ -20,9 +20,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_MSG,
 		FT_CAP_TAGGED,
@@ -53,9 +50,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_RMA,
@@ -114,9 +108,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -159,9 +150,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_ATOMIC,
@@ -212,9 +200,6 @@
 	comp_type: [
 		FT_COMP_QUEUE,
 	],
-	mode: [
-		FT_MODE_ALL,
-	],
 	test_class: [
 		FT_CAP_ATOMIC,
 	],
@@ -238,9 +223,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_MSG,
@@ -267,9 +249,6 @@
 	],
 	comp_type: [
 		FT_COMP_QUEUE,
-	],
-	mode: [
-		FT_MODE_ALL,
 	],
 	test_class: [
 		FT_CAP_RMA,

--- a/fabtests/ubertest/ofi_atomic.c
+++ b/fabtests/ubertest/ofi_atomic.c
@@ -55,12 +55,12 @@
 #define OFI_OP_READ(type,dst,src)  /* src unused, dst is written to result */
 #define OFI_OP_WRITE(type,dst,src) (dst) = (src)
 
-#define OFI_OP_CSWAP_EQ(type,dst,src,cmp) if ((dst) == (cmp)) (dst) = (src)
-#define OFI_OP_CSWAP_NE(type,dst,src,cmp) if ((dst) != (cmp)) (dst) = (src)
-#define OFI_OP_CSWAP_LE(type,dst,src,cmp) if ((dst) <= (cmp)) (dst) = (src)
-#define OFI_OP_CSWAP_LT(type,dst,src,cmp) if ((dst) <  (cmp)) (dst) = (src)
-#define OFI_OP_CSWAP_GE(type,dst,src,cmp) if ((dst) >= (cmp)) (dst) = (src)
-#define OFI_OP_CSWAP_GT(type,dst,src,cmp) if ((dst) >  (cmp)) (dst) = (src)
+#define OFI_OP_CSWAP_EQ(type,dst,src,cmp) if ((cmp) == (dst)) (dst) = (src)
+#define OFI_OP_CSWAP_NE(type,dst,src,cmp) if ((cmp) != (dst)) (dst) = (src)
+#define OFI_OP_CSWAP_LE(type,dst,src,cmp) if ((cmp) <= (dst)) (dst) = (src)
+#define OFI_OP_CSWAP_LT(type,dst,src,cmp) if ((cmp) <  (dst)) (dst) = (src)
+#define OFI_OP_CSWAP_GE(type,dst,src,cmp) if ((cmp) >= (dst)) (dst) = (src)
+#define OFI_OP_CSWAP_GT(type,dst,src,cmp) if ((cmp) >  (dst)) (dst) = (src)
 #define OFI_OP_MSWAP(type,dst,src,cmp)    (dst) = (((src) & (cmp)) | \
 						   ((dst) & ~(cmp)))
 

--- a/fabtests/ubertest/uber.c
+++ b/fabtests/ubertest/uber.c
@@ -600,7 +600,7 @@ static int ft_server_child()
 		 * iterating over all interfaces / addresses.
 		 * TODO: Remove iteration from ft_fw_process_list_server.
 		 */
-		if (info->next) {
+		if (info && info->next) {
 			fi_freeinfo(info->next);
 			info->next = NULL;
 		}


### PR DESCRIPTION
- Update atomic swap calls to match libfabric
- Check for info on server ENODATA
- Remove old FT_MODE_* configs
- Remove sockets FI_EP_DGRAM tests (broken, times out, out of sync)