### PR TITLE
prov/rxm: delete cmap handles when processing client shutdowns

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -698,6 +698,19 @@ free:
 	return ret;
 }
 
+int ft_accept_next_client() {
+	int ret;
+
+	if (!ft_check_opts(FT_OPT_SKIP_MSG_ALLOC) && (fi->caps & (FI_MSG | FI_TAGGED))) {
+		/* Initial receive will get remote address for unconnected EPs */
+		ret = ft_post_rx(ep, MAX(rx_size, FT_MAX_CTRL_MSG), &rx_ctx);
+		if (ret)
+			return ret;
+	}
+
+	return ft_init_av();
+}
+
 int ft_getinfo(struct fi_info *hints, struct fi_info **info)
 {
 	char *node, *service;
@@ -2680,6 +2693,8 @@ void ft_addr_usage()
 			"synchronization over the, optional, port");
 	FT_PRINT_OPTS_USAGE("-E[=<oob_port>]", "enable out-of-band address exchange only "
 			"over the, optional, port");
+	FT_PRINT_OPTS_USAGE("-C <number>", "number of connections to accept before "
+			"cleaning up a server");
 }
 
 void ft_usage(char *name, char *desc)
@@ -2826,6 +2841,9 @@ void ft_parse_addr_opts(int op, char *optarg, struct ft_opts *opts)
 		else
 			opts->oob_port = default_oob_port;
 		break;
+	case 'C':
+		opts->options |= FT_OPT_SERVER_PERSIST;
+		opts->num_connections = atoi(optarg);
 	default:
 		/* let getopt handle unknown opts*/
 		break;

--- a/fabtests/functional/rdm.c
+++ b/fabtests/functional/rdm.c
@@ -34,15 +34,28 @@
 
 #include <shared.h>
 
+
 static int run(void)
 {
 	int ret;
+	int nconn = 1;
 
 	ret = ft_init_fabric();
 	if (ret)
 		return ret;
 
-	return ft_send_recv_greeting(ep);
+	if ((opts.options & FT_OPT_SERVER_PERSIST) && !opts.dst_addr)
+		nconn = opts.num_connections;
+
+	while (nconn && !ret) {
+		ret = ft_send_recv_greeting(ep);
+
+		if (--nconn && !ret) {
+			ret = ft_accept_next_client();
+		}
+	}
+
+	return ret;
 }
 
 int main(int argc, char **argv)

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -112,6 +112,7 @@ enum {
 	FT_OPT_SKIP_REG_MR	= 1 << 13,
 	FT_OPT_OOB_ADDR_EXCH	= 1 << 14,
 	FT_OPT_ALLOC_MULT_MR	= 1 << 15,
+	FT_OPT_SERVER_PERSIST	= 1 << 16,
 	FT_OPT_OOB_CTRL		= FT_OPT_OOB_SYNC | FT_OPT_OOB_ADDR_EXCH,
 };
 
@@ -163,6 +164,7 @@ struct ft_opts {
 	enum ft_rma_opcodes rma_op;
 	char *oob_port;
 	int argc;
+	int num_connections;
 
 	uint64_t mr_mode;
 	/* Fail if the selected provider does not support FI_MSG_PREFIX.  */
@@ -236,7 +238,7 @@ extern int ft_parent_proc;
 extern int ft_socket_pair[2];
 extern int sock;
 extern int listen_sock;
-#define ADDR_OPTS "B:P:s:a:b::E::"
+#define ADDR_OPTS "B:P:s:a:b::E::C:"
 #define FAB_OPTS "f:d:p:"
 #define INFO_OPTS FAB_OPTS "e:M:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
@@ -478,6 +480,8 @@ void show_perf_mr(size_t tsize, int iters, struct timespec *start,
 int ft_send_recv_greeting(struct fid_ep *ep);
 int ft_send_greeting(struct fid_ep *ep);
 int ft_recv_greeting(struct fid_ep *ep);
+
+int ft_accept_next_client();
 
 int check_recv_msg(const char *message);
 uint64_t ft_info_to_mr_access(struct fi_info *info);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -731,6 +731,9 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 int rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep);
 void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 			void *op_context, int err);
+void rxm_cq_write_error_all(struct rxm_ep *rxm_ep, int err);
+void rxm_cq_read_write_error(struct rxm_ep *rxm_ep);
+ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp);
 void rxm_ep_progress(struct util_ep *util_ep);
 void rxm_ep_progress_coll(struct util_ep *util_ep);
 void rxm_ep_do_progress(struct util_ep *util_ep);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -433,6 +433,7 @@ void rxm_cmap_process_shutdown(struct rxm_cmap *cmap,
 			"Invalid handle on shutdown event\n");
 	} else if (handle->state != RXM_CMAP_SHUTDOWN) {
 		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Got remote shutdown\n");
+		rxm_cmap_del_handle(handle);
 	} else {
 		FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Got local shutdown\n");
 	}
@@ -1077,18 +1078,51 @@ err1:
 	return ret;
 }
 
+static void rxm_flush_msg_cq(struct rxm_ep *rxm_ep)
+{
+	struct fi_cq_data_entry comp;
+	int ret;
+	do {
+		ret = fi_cq_read(rxm_ep->msg_cq, &comp, 1);
+		if (ret > 0) {
+			ret = rxm_cq_handle_comp(rxm_ep, &comp);
+			if (OFI_UNLIKELY(ret)) {
+				rxm_cq_write_error_all(rxm_ep, ret);
+			} else {
+				ret = 1;
+			}
+		} else if (ret == -FI_EAVAIL) {
+			rxm_cq_read_write_error(rxm_ep);
+			ret = 1;
+		} else if (ret < 0 && ret != -FI_EAGAIN) {
+			rxm_cq_write_error_all(rxm_ep, ret);
+		}
+	} while (ret > 0);
+}
+
 static int rxm_conn_handle_notify(struct fi_eq_entry *eq_entry)
 {
 	struct rxm_cmap *cmap;
 	struct rxm_cmap_handle *handle;
+	struct rxm_ep *rxm_ep;
 
-	assert((enum rxm_cmap_signal)eq_entry->data);
+	assert((enum rxm_cmap_signal) eq_entry->data);
 
-	if ((enum rxm_cmap_signal)eq_entry->data == RXM_CMAP_FREE) {
+	if ((enum rxm_cmap_signal) eq_entry->data == RXM_CMAP_FREE) {
 		handle = eq_entry->context;
 		assert(handle->state == RXM_CMAP_SHUTDOWN);
 		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "freeing handle: %p\n", handle);
 		cmap = handle->cmap;
+		rxm_ep = container_of(cmap->ep, struct rxm_ep, util_ep);
+
+		rxm_conn_close(handle);
+
+		// after closing the connection, we need to flush any dangling references to the
+		// handle from msg_cq entries that have not been cleaned up yet, otherwise we
+		// could run into problems during CQ cleanup.  these entries will be errored so
+		// keep reading through EAVAIL.
+		rxm_flush_msg_cq(rxm_ep);
+
 		if (handle->peer) {
 			dlist_remove(&handle->peer->entry);
 			free(handle->peer);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1120,8 +1120,7 @@ int rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *t
 	return ret;
 };
 
-static ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep,
-				  struct fi_cq_data_entry *comp)
+ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 {
 	ssize_t ret;
 	struct rxm_rx_buf *rx_buf;
@@ -1228,7 +1227,7 @@ void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 	}
 }
 
-static void rxm_cq_write_error_all(struct rxm_ep *rxm_ep, int err)
+void rxm_cq_write_error_all(struct rxm_ep *rxm_ep, int err)
 {
 	struct fi_cq_err_entry err_entry = {0};
 	ssize_t ret = 0;
@@ -1269,7 +1268,7 @@ static void rxm_cq_write_error_all(struct rxm_ep *rxm_ep, int err)
 	 (state == RXM_TX) ||		\
 	 (state == RXM_RNDV_TX))
 
-static void rxm_cq_read_write_error(struct rxm_ep *rxm_ep)
+void rxm_cq_read_write_error(struct rxm_ep *rxm_ep)
 {
 	struct rxm_tx_eager_buf *eager_buf;
 	struct rxm_tx_sar_buf *sar_buf;


### PR DESCRIPTION
when multiple 'clients' are connecting and disconnecting from a single 'server'
the structures tracking the connection state were not being cleaned up, which
could quickly balloon memory depending on the application use case