### PR TITLE
core: Increase the size of the indexer to 1M

### DIFF
--- a/include/ofi_indexer.h
+++ b/include/ofi_indexer.h
@@ -60,7 +60,7 @@ struct ofi_idx_entry {
 	int   next;
 };
 
-#define OFI_IDX_INDEX_BITS 16
+#define OFI_IDX_INDEX_BITS 20
 #define OFI_IDX_ENTRY_BITS 10
 #define OFI_IDX_ENTRY_SIZE (1 << OFI_IDX_ENTRY_BITS)
 #define OFI_IDX_ARRAY_SIZE (1 << (OFI_IDX_INDEX_BITS - OFI_IDX_ENTRY_BITS))


### PR DESCRIPTION
When running more than 64K application ranks, the indexer
hits a hard limit as defined in the header file. This commit
increases the number of bits in the indexer from 16 to 22,
increasing the size from (64K - 1) entries, to (1M - 1) entries.

Signed-off-by: James Swaro <jswaro@cray.com>

Fixes #5429 