### PR TITLE
common: fixed epoll_wait implementation

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -970,6 +970,7 @@ static void fi_epoll_process_work_item_list(struct fi_epoll *ep)
 		case EPOLL_CTL_ADD:
 			ep->fds[ep->nfds].fd = item->fd;
 			ep->fds[ep->nfds].events = item->events;
+			ep->fds[ep->nfds].revents = 0;
 			ep->context[ep->nfds] = item->context;
 			ep->nfds++;
 			break;


### PR DESCRIPTION
explicitly set revents field to zero for the new fds during add operation.
Otherwise we might use incorrect (related to deleted fds) revents during
contexts filling if fd set modified just after poll(). This can be easily
reproduced with tcp/rxm on Windows when endpoint connects to itself.

Signed-off-by: Andrey Lobanov <andrey.lobanov@intel.com>