### PR TITLE
fabric: provide basic implementation of fi_query_collective

### DIFF
--- a/fabtests/multinode/src/core_coll.c
+++ b/fabtests/multinode/src/core_coll.c
@@ -147,6 +147,16 @@ int barrier_test_run()
 	fi_addr_t world_addr;
 	fi_addr_t barrier_addr;
 	struct fid_mc *coll_mc;
+	struct fi_collective_attr attr;
+
+	attr.op = FI_VOID;
+	attr.datatype = FI_VOID;
+	attr.mode = 0;
+	ret = fi_query_collective(domain, FI_BARRIER, &attr, 0);
+	if (ret) {
+		FT_DEBUG("barrier collective not supported: %d (%s)\n", ret, fi_strerror(ret));
+		return ret;
+	}
 
 	ret = fi_av_set_addr(av_set, &world_addr);
 	if (ret) {
@@ -212,6 +222,16 @@ int sum_all_reduce_test_run()
 	uint64_t data = pm_job.my_rank;
 	size_t count = 1;
 	uint64_t i;
+	struct fi_collective_attr attr;
+
+	attr.op = FI_SUM;
+	attr.datatype = FI_UINT64;
+	attr.mode = 0;
+	ret = fi_query_collective(domain, FI_ALLREDUCE, &attr, 0);
+	if (ret) {
+		FT_DEBUG("SUM AllReduce collective not supported: %d (%s)\n", ret, fi_strerror(ret));
+		return ret;
+	}
 
 	for(i = 0; i < pm_job.num_ranks; i++) {
 		expect_result += i;

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -153,6 +153,9 @@ struct util_coll_operation {
 	util_coll_comp_fn_t		comp_fn;
 };
 
+int ofi_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
+			 struct fi_collective_attr *attr, uint64_t flags);
+
 int ofi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 			const struct fid_av_set *set, uint64_t flags,
 			struct fid_mc **mc, void *context);

--- a/include/ofi_enosys.h
+++ b/include/ofi_enosys.h
@@ -191,6 +191,7 @@ static struct fi_ops_domain X = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = fi_no_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 */
 int fi_no_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
@@ -211,7 +212,8 @@ int fi_no_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		struct fid_ep **rx_ep, void *context);
 int fi_no_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 		enum fi_op op, struct fi_atomic_attr *attr, uint64_t flags);
-
+int fi_no_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
+			   struct fi_collective_attr *attr, uint64_t flags);
 
 /*
 static struct fi_ops_mr X = {

--- a/include/ofi_hook.h
+++ b/include/ofi_hook.h
@@ -37,6 +37,7 @@
 
 #include <rdma/fabric.h>
 #include <rdma/fi_atomic.h>
+#include <rdma/fi_collective.h>
 #include <rdma/fi_cm.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>

--- a/include/rdma/fi_collective.h
+++ b/include/rdma/fi_collective.h
@@ -80,12 +80,12 @@ struct fid_av_set {
 	struct fi_ops_av_set	*ops;
 };
 
-
 struct fi_collective_attr {
-	struct fi_atomic_attr	datatype_attr;
-	size_t			max_members;
-	uint64_t		mode;
-	enum fi_collective_op	coll;
+	enum fi_op 		op;
+	enum fi_datatype 	datatype;
+	struct fi_atomic_attr 	datatype_attr;
+	size_t 			max_members;
+	uint64_t 		mode;
 };
 
 struct fi_collective_addr {
@@ -302,12 +302,13 @@ fi_gather(struct fid_ep *ep, const void *buf, size_t count, void *desc,
 		coll_addr, root_addr, datatype, flags, context);
 }
 
-static inline int
-fi_query_collective(struct fid_domain *domain, struct fi_collective_attr *attr,
-		    enum fi_datatype datatype, enum fi_op op, uint64_t flags)
+static inline
+int fi_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
+			struct fi_collective_attr *attr, uint64_t flags)
 {
-	return fi_query_atomic(domain, datatype, op, &attr->datatype_attr,
-			       flags | FI_COLLECTIVE);
+	return FI_CHECK_OP(domain->ops, struct fi_ops_domain, query_collective) ?
+		       domain->ops->query_collective(domain, coll, attr, flags) :
+		       -FI_ENOSYS;
 }
 
 #endif

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -145,7 +145,7 @@ struct fi_mr_modify {
 
 #ifndef FABRIC_DIRECT_ATOMIC_DEF
 
-//#define FI_COLLECTIVE_OFFSET 256
+#define FI_COLLECTIVE_OFFSET 256
 
 enum fi_datatype {
 	FI_INT8,
@@ -166,7 +166,7 @@ enum fi_datatype {
 	FI_DATATYPE_LAST,
 
 	/* Collective datatypes */
-//	FI_VOID = FI_COLLECTIVE_OFFSET,
+	FI_VOID = FI_COLLECTIVE_OFFSET,
 };
 
 enum fi_op {
@@ -199,6 +199,8 @@ enum fi_op {
 struct fi_atomic_attr;
 struct fi_cq_attr;
 struct fi_cntr_attr;
+struct fi_collective_attr;
+enum   fi_collective_op;
 
 struct fi_ops_domain {
 	size_t	size;
@@ -223,6 +225,8 @@ struct fi_ops_domain {
 	int	(*query_atomic)(struct fid_domain *domain,
 			enum fi_datatype datatype, enum fi_op op,
 			struct fi_atomic_attr *attr, uint64_t flags);
+	int (*query_collective)(struct fid_domain *domain, enum fi_collective_op coll,
+				struct fi_collective_attr *attr, uint64_t flags);
 };
 
 /* Memory registration flags */

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -116,6 +116,7 @@ static struct fi_ops_domain efa_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = fi_no_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -53,6 +53,7 @@ static struct fi_ops_domain rxr_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = fi_no_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 static int rxr_domain_close(fid_t fid)

--- a/prov/hook/src/hook_domain.c
+++ b/prov/hook/src/hook_domain.c
@@ -108,6 +108,14 @@ int hook_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 	return fi_query_atomic(dom->hdomain, datatype, op, attr, flags);
 }
 
+static int hook_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
+				 struct fi_collective_attr *attr, uint64_t flags)
+{
+	struct hook_domain *dom = container_of(domain, struct hook_domain, domain);
+
+	return fi_query_collective(dom->hdomain, coll, attr, flags);
+}
+
 struct fi_ops_domain hook_domain_ops = {
 	.size = sizeof(struct fi_ops_domain),
 	.av_open = hook_av_open,
@@ -119,6 +127,7 @@ struct fi_ops_domain hook_domain_ops = {
 	.stx_ctx = hook_stx_ctx,
 	.srx_ctx = hook_srx_ctx,
 	.query_atomic = hook_query_atomic,
+	.query_collective = hook_query_collective,
 };
 
 

--- a/prov/mrail/src/mrail_domain.c
+++ b/prov/mrail/src/mrail_domain.c
@@ -355,6 +355,7 @@ static struct fi_ops_domain mrail_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = fi_no_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 int mrail_domain_open(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -246,6 +246,7 @@ static struct fi_ops_domain psmx_domain_ops = {
 	.stx_ctx = psmx_stx_ctx,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = psmx_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 static int psmx_key_compare(void *key1, void *key2)

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -246,6 +246,7 @@ static struct fi_ops_domain psmx2_domain_ops = {
 	.stx_ctx = psmx2_stx_ctx,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = psmx2_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 static int psmx2_key_compare(void *key1, void *key2)

--- a/prov/rstream/src/rstream_domain.c
+++ b/prov/rstream/src/rstream_domain.c
@@ -79,6 +79,7 @@ static struct fi_ops_domain rstream_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = fi_no_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 int rstream_domain_open(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -48,6 +48,7 @@ static struct fi_ops_domain rxd_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = rxd_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 static int rxd_domain_close(fid_t fid)

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -35,6 +35,7 @@
 #include <unistd.h>
 
 #include <ofi_util.h>
+#include <ofi_coll.h>
 #include "rxm.h"
 
 int rxm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
@@ -71,6 +72,7 @@ static struct fi_ops_domain rxm_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = rxm_ep_query_atomic,
+	.query_collective = ofi_query_collective,
 };
 
 static void rxm_mr_remove_map_entry(struct rxm_mr *mr)

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -46,6 +46,7 @@ static struct fi_ops_domain smr_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = smr_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 static int smr_domain_close(fid_t fid)

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -272,6 +272,7 @@ static struct fi_ops_domain sock_dom_ops = {
 	.stx_ctx = sock_stx_ctx,
 	.srx_ctx = sock_srx_ctx,
 	.query_atomic = sock_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 int sock_domain(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -115,6 +115,7 @@ static struct fi_ops_domain tcpx_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = tcpx_srx_ctx,
 	.query_atomic = fi_no_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 static int tcpx_domain_close(fid_t fid)

--- a/prov/udp/src/udpx_domain.c
+++ b/prov/udp/src/udpx_domain.c
@@ -47,6 +47,7 @@ static struct fi_ops_domain udpx_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = fi_no_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 static int udpx_domain_close(fid_t fid)

--- a/prov/usnic/src/usdf_domain.c
+++ b/prov/usnic/src/usdf_domain.c
@@ -146,6 +146,7 @@ static struct fi_ops_domain usdf_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = usdf_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 int

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -204,6 +204,7 @@ static struct fi_ops_domain fi_ibv_msg_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_ibv_srq_context,
 	.query_atomic = fi_ibv_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 static struct fi_ops_domain fi_ibv_dgram_domain_ops = {
@@ -216,6 +217,7 @@ static struct fi_ops_domain fi_ibv_dgram_domain_ops = {
 	.stx_ctx = fi_no_stx_context,
 	.srx_ctx = fi_no_srx_context,
 	.query_atomic = fi_no_query_atomic,
+	.query_collective = fi_no_query_collective,
 };
 
 static int

--- a/src/enosys.c
+++ b/src/enosys.c
@@ -270,6 +270,11 @@ int fi_no_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 {
 	return -FI_ENOSYS;
 }
+int fi_no_query_collective(struct fid_domain *domain, enum fi_collective_op coll,
+			   struct fi_collective_attr *attr, uint64_t flags)
+{
+	return -FI_ENOSYS;
+}
 
 /*
  * struct fi_ops_mr


### PR DESCRIPTION
this commit implements the framework for fi_query_collective and provides
basic implementation for util and rxm providers suitable for all currently
implemented collective operations

Signed-off-by: Stephen Oost <stephen.oost@intel.com>