### PR TITLE
man: set a correct value for SAR_LIMIT in doc

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -133,7 +133,7 @@ The ofi_rxm provider checks for the following environment variables.
 
 *FI_OFI_RXM_SAR_LIMIT*
 : Set this environment variable to control the RxM SAR (Segmentation And Reassembly)
-  protocol. Messages of size greater than this (default: 256 Kb) would be transmitted
+  protocol. Messages of size greater than this (default: 128 Kb) would be transmitted
   via rendezvous protocol.
 
 *FI_OFI_RXM_USE_SRX*

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -377,7 +377,7 @@ RXM_INI
 	fi_param_define(&rxm_prov, "sar_limit", FI_PARAM_SIZE_T,
 			"Set this environment variable to enable and control "
 			"RxM SAR (Segmentation And Reassembly) protocol "
-			"(default: 256 KB). This value should be set greater than "
+			"(default: 128 KB). This value should be set greater than "
 			" eager limit (FI_OFI_RXM_BUFFER_SIZE - RxM protocol "
 			"header size (%zu B)) for SAR to take effect. Messages "
 			"of size greater than this would be transmitted via "


### PR DESCRIPTION
fixed value to 128 Kb refer to #define RXM_SAR_LIMIT

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>