### PR TITLE
util/coll: apply negotiated group id to new mc during collective join

### DIFF
--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -122,6 +122,7 @@ struct util_coll_mc {
 };
 
 struct join_data {
+	struct util_coll_mc *new_mc;
 	struct bitmask data;
 	struct bitmask tmp;
 };

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -555,10 +555,10 @@ void util_coll_join_comp(struct util_coll_operation *coll_op)
 	struct fi_eq_err_entry entry;
 	struct util_ep *ep = container_of(coll_op->mc->ep, struct util_ep, ep_fid);
 
-	coll_op->mc->seq = 0;
-	coll_op->mc->group_id = ofi_bitmask_get_lsbset(coll_op->data.join.data);
+	coll_op->data.join.new_mc->seq = 0;
+	coll_op->data.join.new_mc->group_id = ofi_bitmask_get_lsbset(coll_op->data.join.data);
 	// mark the local mask bit
-	ofi_bitmask_unset(ep->coll_cid_mask, coll_op->mc->group_id);
+	ofi_bitmask_unset(ep->coll_cid_mask, coll_op->data.join.new_mc->group_id);
 
 	/* write to the eq  */
 	memset(&entry, 0, sizeof(entry));
@@ -740,6 +740,8 @@ int ofi_join_collective(struct fid_ep *ep, fi_addr_t coll_addr,
 				util_coll_join_comp);
 	if (ret)
 		goto err1;
+
+	join_op->data.join.new_mc = new_coll_mc;
 
 	if (new_coll_mc->local_rank != FI_ADDR_NOTAVAIL) {
 		ret = ofi_bitmask_create(&join_op->data.join.data, OFI_MAX_GROUP_ID);


### PR DESCRIPTION
The initial implementation of the join collective was updating the group id
of the initial mc group rather than the new mc group created during the join

in simple tests, the previous appeared to work if you're using the same set of
ranks for all collectives, but would be incorrect for multiple and varying
groups