### PR TITLE
headers: fix forward-declaration of enum fi_collective_op with C++

### DIFF
--- a/include/rdma/fi_collective.h
+++ b/include/rdma/fi_collective.h
@@ -46,22 +46,6 @@ extern "C" {
 #include <rdma/fi_direct_collective_def.h>
 #endif /* FABRIC_DIRECT */
 
-#ifndef FABRIC_DIRECT_COLLECTIVE_DEF
-
-enum fi_collective_op {
-	FI_BARRIER,
-	FI_BROADCAST,
-	FI_ALLTOALL,
-	FI_ALLREDUCE,
-	FI_ALLGATHER,
-	FI_REDUCE_SCATTER,
-	FI_REDUCE,
-	FI_SCATTER,
-	FI_GATHER,
-};
-
-#endif
-
 
 struct fi_ops_av_set {
 	size_t	size;

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -198,12 +198,27 @@ enum fi_op {
 
 #endif
 
+#ifndef FABRIC_DIRECT_COLLECTIVE_DEF
+
+enum fi_collective_op {
+	FI_BARRIER,
+	FI_BROADCAST,
+	FI_ALLTOALL,
+	FI_ALLREDUCE,
+	FI_ALLGATHER,
+	FI_REDUCE_SCATTER,
+	FI_REDUCE,
+	FI_SCATTER,
+	FI_GATHER,
+};
+
+#endif
+
 
 struct fi_atomic_attr;
 struct fi_cq_attr;
 struct fi_cntr_attr;
 struct fi_collective_attr;
-enum   fi_collective_op;
 
 struct fi_ops_domain {
 	size_t	size;


### PR DESCRIPTION
Compiling the `fi_domain.h` header with C++ compiler ends up to the following error:

```
include/rdma/fi_domain.h:206:8: error: use of enum 'fi_collective_op'
without previous declaration  enum fi_collective_op;
```
In C++, the storage required for the enum variables is determined by the compiler, whilst it is always an integer with C.

As a consequence, C++ doesn't allow to forward-declare an enum without specifying its actual size.

The suggested fix is to move the declaration of the `enum fi_collective_op` to `fi_domain.h`. It should be fine as `fi_collective.h` does include `fi_domain.h` anyway.

IMPORTANT: I haven't tested my patch with collective operations since the code I compile doesn't need this support. Can someone please confirm that I'm not breaking this support?