### PR TITLE
prov/verbs: Remove possible deadlock in XRC error path logic

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -753,6 +753,8 @@ static inline int fi_ibv_cmp_xrc_domain_name(const char *domain_name,
 
 int fi_ibv_cq_signal(struct fid_cq *cq);
 
+struct fi_ibv_eq_entry *fi_ibv_eq_alloc_entry(uint32_t event,
+					      const void *buf, size_t len);
 ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
 		const void *buf, size_t len);
 

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -225,14 +225,17 @@ void fi_ibv_add_pending_ini_conn(struct fi_ibv_xrc_ep *ep, int reciprocal,
 	dlist_insert_tail(&ep->ini_conn_entry, &ep->ini_conn->pending_list);
 }
 
+/* Caller must hold domain:eq:lock */
 static void fi_ibv_create_shutdown_event(struct fi_ibv_xrc_ep *ep)
 {
 	struct fi_eq_cm_entry entry = {
 		.fid = &ep->base_ep.util_ep.ep_fid.fid,
 	};
+	struct fi_ibv_eq_entry *eq_entry;
 
-	fi_ibv_eq_write_event(ep->base_ep.eq, FI_SHUTDOWN,
-			      &entry, sizeof(entry));
+	eq_entry = fi_ibv_eq_alloc_entry(FI_SHUTDOWN, &entry, sizeof(entry));
+	if (eq_entry)
+		dlistfd_insert_tail(&eq_entry->item, &ep->base_ep.eq->list_head);
 }
 
 /* Caller must hold domain:eq:lock */

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -806,20 +806,32 @@ void fi_ibv_eq_remove_events(struct fi_ibv_eq *eq, struct fid *fid)
 	}
 }
 
-ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
-			      const void *buf, size_t len)
+struct fi_ibv_eq_entry  *
+fi_ibv_eq_alloc_entry(uint32_t event, const void *buf, size_t len)
 {
 	struct fi_ibv_eq_entry *entry;
 
 	entry = calloc(1, sizeof(struct fi_ibv_eq_entry) + len);
 	if (!entry) {
 		VERBS_WARN(FI_LOG_EP_CTRL, "Unable to allocate EQ entry\n");
-		return -FI_ENOMEM;
+		return NULL;
 	}
 
 	entry->event = event;
 	entry->len = len;
 	memcpy(entry->entry, buf, len);
+
+	return entry;
+}
+
+ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
+			      const void *buf, size_t len)
+{
+	struct fi_ibv_eq_entry *entry;
+
+	entry = fi_ibv_eq_alloc_entry(event, buf, len);
+	if (!entry)
+		return -FI_ENOMEM;
 
 	fastlock_acquire(&eq->lock);
 	dlistfd_insert_tail(&entry->item, &eq->list_head);


### PR DESCRIPTION
Adds the capability to write an EQ entry while already holding the EQ lock. This
has not been seen in practice, but could occur in the XRC error path if an asynchronous
call into rdma_resolve_route() returned an error.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>