### PR TITLE
prov/util, shm: add generic util cntr and cq spin wait, use in shm provider

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -497,7 +497,13 @@ ssize_t ofi_cq_sread(struct fid_cq *cq_fid, void *buf, size_t count,
 		const void *cond, int timeout);
 ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		fi_addr_t *src_addr, const void *cond, int timeout);
+ssize_t ofi_cq_spin_sread(struct fid_cq *cq_fid, void *buf, size_t count,
+		const void *cond, int timeout);
+ssize_t ofi_cq_spin_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
+		fi_addr_t *src_addr, const void *cond, int timeout);
 int ofi_cq_signal(struct fid_cq *cq_fid);
+const char *util_cq_strerror(struct fid_cq *cq, int prov_errno,
+			     const void *err_data, char *buf, size_t len);
 
 int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags, size_t len,
 			  void *buf, uint64_t data, uint64_t tag, fi_addr_t src);

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -630,6 +630,16 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 		  struct fi_cntr_attr *attr, struct util_cntr *cntr,
 		  ofi_cntr_progress_func progress, void *context);
 int ofi_cntr_cleanup(struct util_cntr *cntr);
+uint64_t ofi_cntr_read(struct fid_cntr *cntr_fid);
+uint64_t ofi_cntr_readerr(struct fid_cntr *cntr_fid);
+int ofi_cntr_add(struct fid_cntr *cntr_fid, uint64_t value);
+int ofi_cntr_adderr(struct fid_cntr *cntr_fid, uint64_t value);
+int ofi_cntr_set(struct fid_cntr *cntr_fid, uint64_t value);
+int ofi_cntr_seterr(struct fid_cntr *cntr_fid, uint64_t value);
+int ofi_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int timeout);
+int ofi_cntr_spin_wait(struct fid_cntr *cntr_fid, uint64_t threshold,
+		       int timeout);
+
 static inline void util_cntr_signal(struct util_cntr *cntr)
 {
 	assert(cntr->wait);

--- a/prov/shm/src/smr_cq.c
+++ b/prov/shm/src/smr_cq.c
@@ -64,7 +64,8 @@ int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (!util_cq)
 		return -FI_ENOMEM;
 
-	ret = ofi_cq_init(&smr_prov, domain, attr, util_cq, ofi_cq_progress, context);
+	ret = ofi_cq_init(&smr_prov, domain, attr, util_cq,
+			  &ofi_cq_progress, context);
 	if (ret)
 		goto free;
 


### PR DESCRIPTION
Adds generic util_cntr and util_cq spin blocking functions for generic support.
Adds support in shm provider for calling fi_cntr_wait and fi_cq_sread without a wait object to wait on.

Also includes a small bug fix.