### PR TITLE
Handle message ID wraparound in EFA and ofi_recvwin header

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -98,6 +98,27 @@ extern "C" {
 
 #define ofi_div_ceil(a, b) ((a + b - 1) / b)
 
+static inline int ofi_val64_gt(uint64_t x, uint64_t y) {
+	return ((int64_t) (x - y)) > 0;
+}
+static inline int ofi_val64_ge(uint64_t x, uint64_t y) {
+	return ((int64_t) (x - y)) >= 0;
+}
+#define ofi_val64_lt(x, y) ofi_val64_gt(y, x)
+
+static inline int ofi_val32_gt(uint32_t x, uint32_t y) {
+	return ((int32_t) (x - y)) > 0;
+}
+static inline int ofi_val32_ge(uint32_t x, uint32_t y) {
+	return ((int32_t) (x - y)) >= 0;
+}
+#define ofi_val32_lt(x, y) ofi_val32_gt(y, x)
+
+#define ofi_val32_inrange(start, length, value) \
+    ofi_val32_ge(value, start) && ofi_val32_lt(value, start + length)
+#define ofi_val64_inrange(start, length, value) \
+    ofi_val64_ge(value, start) && ofi_val64_lt(value, start + length)
+
 #define OFI_MAGIC_64 (0x0F1C0DE0F1C0DE64)
 
 #ifndef BIT

--- a/include/ofi_recvwin.h
+++ b/include/ofi_recvwin.h
@@ -49,11 +49,11 @@
 #include <ofi.h>
 #include <ofi_rbuf.h>
 
-#define OFI_DECL_RECVWIN_BUF(entrytype, name)				\
+#define OFI_DECL_RECVWIN_BUF(entrytype, name, id_type)			\
 OFI_DECLARE_CIRQUE(entrytype, recvwin_cirq);				\
 struct name {								\
-	uint64_t exp_msg_id;						\
-	unsigned int win_size;						\
+	id_type exp_msg_id;						\
+	id_type win_size;						\
 	struct recvwin_cirq *pending;					\
 };									\
 									\
@@ -74,9 +74,9 @@ ofi_recvwin_free(struct name *recvq)					\
 }									\
 									\
 static inline int							\
-ofi_recvwin_queue_msg(struct name *recvq, entrytype * msg, uint64_t id)	\
+ofi_recvwin_queue_msg(struct name *recvq, entrytype * msg, id_type id)	\
 {									\
-	int write_idx;							\
+	size_t write_idx;						\
 									\
 	assert(ofi_recvwin_is_allowed(recvq, id));			\
 	write_idx = (ofi_cirque_rindex(recvq->pending)			\
@@ -88,9 +88,9 @@ ofi_recvwin_queue_msg(struct name *recvq, entrytype * msg, uint64_t id)	\
 }									\
 				                                        \
 static inline entrytype *						\
-ofi_recvwin_get_msg(struct name *recvq, uint64_t id)	   		\
+ofi_recvwin_get_msg(struct name *recvq, id_type id)			\
 {		                                           		\
-	int read_idx;							\
+	size_t read_idx;						\
 									\
 	assert(ofi_recvwin_is_allowed(recvq, id));			\
 	read_idx = (ofi_cirque_rindex(recvq->pending)			\

--- a/include/ofi_recvwin.h
+++ b/include/ofi_recvwin.h
@@ -74,11 +74,17 @@ ofi_recvwin_free(struct name *recvq)					\
 }									\
 									\
 static inline int							\
+ofi_recvwin_id_valid(struct name *recvq, id_type id)			\
+{									\
+	return ofi_recvwin_id_valid_ ## id_type (recvq, id);		\
+}									\
+									\
+static inline int							\
 ofi_recvwin_queue_msg(struct name *recvq, entrytype * msg, id_type id)	\
 {									\
 	size_t write_idx;						\
 									\
-	assert(ofi_recvwin_is_allowed(recvq, id));			\
+	assert(ofi_recvwin_id_valid(recvq, id));			\
 	write_idx = (ofi_cirque_rindex(recvq->pending)			\
 		    + (id - recvq->exp_msg_id))				\
 		    & recvq->pending->size_mask;			\
@@ -92,7 +98,7 @@ ofi_recvwin_get_msg(struct name *recvq, id_type id)			\
 {		                                           		\
 	size_t read_idx;						\
 									\
-	assert(ofi_recvwin_is_allowed(recvq, id));			\
+	assert(ofi_recvwin_id_valid(recvq, id));			\
 	read_idx = (ofi_cirque_rindex(recvq->pending)			\
 		    + (id - recvq->exp_msg_id))				\
 		    & recvq->pending->size_mask;			\
@@ -123,8 +129,14 @@ ofi_recvwin_slide(struct name *recvq)					\
 #define ofi_recvwin_exp_inc(rq)		((rq)->exp_msg_id++)
 #define ofi_recvwin_is_exp(rq, id)	((rq)->exp_msg_id == id)
 #define ofi_recvwin_next_exp_id(rq)	((rq)->exp_msg_id)
-#define ofi_recvwin_is_delayed(rq, id)	((rq)->exp_msg_id > id)
-#define ofi_recvwin_is_allowed(rq, id)	(id >= rq->exp_msg_id \
-					&& id < (rq->win_size + rq->exp_msg_id))
+/*
+ * When exp_msg_id on the receiver has not wrapped around but the sender ID has
+ * we need to allow the IDs starting from 0 that are valid. These macros use
+ * the overflow of exp_msg_id to validate that.
+ */
+#define ofi_recvwin_id_valid_uint32_t(rq, id) \
+	ofi_val32_inrange(rq->exp_msg_id, rq->win_size, id)
+#define ofi_recvwin_id_valid_uint64_t(rq, id) \
+	ofi_val64_inrange(rq->exp_msg_id, rq->win_size, id)
 
 #endif /* FI_RECVWIN_H */

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -1014,7 +1014,6 @@ static inline void rxr_release_tx_entry(struct rxr_ep *ep,
 			      sizeof(struct rxr_tx_entry));
 #endif
 	tx_entry->state = RXR_TX_FREE;
-	tx_entry->msg_id = ~0;
 	ofi_buf_free(tx_entry);
 }
 
@@ -1030,7 +1029,6 @@ static inline void rxr_release_rx_entry(struct rxr_ep *ep,
 			      sizeof(struct rxr_rx_entry));
 #endif
 	rx_entry->state = RXR_RX_FREE;
-	rx_entry->msg_id = ~0;
 	ofi_buf_free(rx_entry);
 }
 

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -845,7 +845,7 @@ static_assert(sizeof(struct rxr_pkt_entry) == 64, "rxr_pkt_entry check");
 #endif
 #endif
 
-OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf);
+OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf, uint32_t);
 DECLARE_FREESTACK(struct rxr_robuf, rxr_robuf_fs);
 
 #define RXR_CTRL_HDR_SIZE		(sizeof(struct rxr_ctrl_cq_hdr))

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -894,7 +894,7 @@ static int rxr_cq_reorder_msg(struct rxr_ep *ep,
 #endif
 	if (ofi_recvwin_is_exp(peer->robuf, rts_hdr->msg_id))
 		return 0;
-	else if (ofi_recvwin_is_delayed(peer->robuf, rts_hdr->msg_id))
+	else if (!ofi_recvwin_id_valid(peer->robuf, rts_hdr->msg_id))
 		return -FI_EALREADY;
 
 	if (OFI_LIKELY(rxr_env.rx_copy_ooo)) {
@@ -1037,7 +1037,7 @@ static void rxr_cq_handle_rts(struct rxr_ep *ep,
 			return;
 		} else if (OFI_UNLIKELY(ret == -FI_EALREADY)) {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
-				"Duplicate RTS packet msg_id: %" PRIu32
+				"Invalid msg_id: %" PRIu32
 				" robuf->exp_msg_id: %" PRIu32 "\n",
 			       rts_hdr->msg_id, peer->robuf->exp_msg_id);
 			if (!rts_hdr->addrlen)

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -889,7 +889,7 @@ static int rxr_cq_reorder_msg(struct rxr_ep *ep,
 	if (rts_hdr->msg_id != ofi_recvwin_next_exp_id(peer->robuf))
 		FI_DBG(&rxr_prov, FI_LOG_EP_CTRL,
 		       "msg OOO rts_hdr->msg_id: %" PRIu32 " expected: %"
-		       PRIu64 "\n", rts_hdr->msg_id,
+		       PRIu32 "\n", rts_hdr->msg_id,
 		       ofi_recvwin_next_exp_id(peer->robuf));
 #endif
 	if (ofi_recvwin_is_exp(peer->robuf, rts_hdr->msg_id))
@@ -1038,7 +1038,7 @@ static void rxr_cq_handle_rts(struct rxr_ep *ep,
 		} else if (OFI_UNLIKELY(ret == -FI_EALREADY)) {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
 				"Duplicate RTS packet msg_id: %" PRIu32
-				" robuf->exp_msg_id: %" PRIu64 "\n",
+				" robuf->exp_msg_id: %" PRIu32 "\n",
 			       rts_hdr->msg_id, peer->robuf->exp_msg_id);
 			if (!rts_hdr->addrlen)
 				rxr_eq_write_error(ep, FI_EIO, ret);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -958,7 +958,7 @@ void rxr_tx_entry_init(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	tx_entry->iov_index = 0;
 	tx_entry->iov_mr_start = 0;
 	tx_entry->iov_offset = 0;
-	tx_entry->msg_id = ~0;
+	tx_entry->msg_id = 0;
 	dlist_init(&tx_entry->queued_pkts);
 
 	memcpy(&tx_entry->iov[0], msg->msg_iov, sizeof(struct iovec) * msg->iov_count);
@@ -1774,8 +1774,7 @@ ssize_t rxr_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 
 	if (!(rxr_env.enable_shm_transfer && peer->is_local) &&
 	    rxr_need_sas_ordering(rxr_ep))
-		tx_entry->msg_id = (peer->next_msg_id != ~0) ?
-				    peer->next_msg_id++ : ++peer->next_msg_id;
+		tx_entry->msg_id = peer->next_msg_id++;
 
 	err = rxr_ep_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry, RXR_RTS_PKT, 0);
 	if (OFI_UNLIKELY(err)) {

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -520,8 +520,8 @@ ssize_t rxr_rma_post_efa_read(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	 */
 	tx_entry->rma_loc_rx_id = rx_entry->rx_id;
 	tx_entry->rma_window = rx_entry->window;
-	tx_entry->msg_id = (peer->next_msg_id != ~0) ?
-			    peer->next_msg_id++ : ++peer->next_msg_id;
+
+	tx_entry->msg_id = peer->next_msg_id++;
 
 	err = rxr_ep_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_RTS_PKT, 0);
 	if (OFI_UNLIKELY(err)) {
@@ -654,8 +654,7 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 			goto out;
 		}
 
-		tx_entry->msg_id = (peer->next_msg_id != ~0) ?
-				    peer->next_msg_id++ : ++peer->next_msg_id;
+		tx_entry->msg_id = peer->next_msg_id++;
 
 		err = rxr_ep_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry, RXR_RTS_PKT, 0);
 		if (OFI_UNLIKELY(err)) {


### PR DESCRIPTION
The EFA provider and ofi_recvwin.h were not handling the case where message ID wraps around. This patch series fixes this issue.