### PR TITLE
1.8.x fixes for efa

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -95,6 +95,27 @@ extern "C" {
 
 #define ofi_div_ceil(a, b) ((a + b - 1) / b)
 
+static inline int ofi_val64_gt(uint64_t x, uint64_t y) {
+	return ((int64_t) (x - y)) > 0;
+}
+static inline int ofi_val64_ge(uint64_t x, uint64_t y) {
+	return ((int64_t) (x - y)) >= 0;
+}
+#define ofi_val64_lt(x, y) ofi_val64_gt(y, x)
+
+static inline int ofi_val32_gt(uint32_t x, uint32_t y) {
+	return ((int32_t) (x - y)) > 0;
+}
+static inline int ofi_val32_ge(uint32_t x, uint32_t y) {
+	return ((int32_t) (x - y)) >= 0;
+}
+#define ofi_val32_lt(x, y) ofi_val32_gt(y, x)
+
+#define ofi_val32_inrange(start, length, value) \
+    ofi_val32_ge(value, start) && ofi_val32_lt(value, start + length)
+#define ofi_val64_inrange(start, length, value) \
+    ofi_val64_ge(value, start) && ofi_val64_lt(value, start + length)
+
 #define OFI_MAGIC_64 (0x0F1C0DE0F1C0DE64)
 
 #ifndef BIT

--- a/include/ofi_recvwin.h
+++ b/include/ofi_recvwin.h
@@ -74,11 +74,17 @@ ofi_recvwin_free(struct name *recvq)					\
 }									\
 									\
 static inline int							\
+ofi_recvwin_id_valid(struct name *recvq, id_type id)			\
+{									\
+	return ofi_recvwin_id_valid_ ## id_type (recvq, id);		\
+}									\
+									\
+static inline int							\
 ofi_recvwin_queue_msg(struct name *recvq, entrytype * msg, id_type id)	\
 {									\
 	size_t write_idx;						\
 									\
-	assert(ofi_recvwin_is_allowed(recvq, id));			\
+	assert(ofi_recvwin_id_valid(recvq, id));			\
 	write_idx = (ofi_cirque_rindex(recvq->pending)			\
 		    + (id - recvq->exp_msg_id))				\
 		    & recvq->pending->size_mask;			\
@@ -111,8 +117,14 @@ ofi_recvwin_slide(struct name *recvq)					\
 #define ofi_recvwin_exp_inc(rq)		((rq)->exp_msg_id++)
 #define ofi_recvwin_is_exp(rq, id)	((rq)->exp_msg_id == id)
 #define ofi_recvwin_next_exp_id(rq)	((rq)->exp_msg_id)
-#define ofi_recvwin_is_delayed(rq, id)	((rq)->exp_msg_id > id)
-#define ofi_recvwin_is_allowed(rq, id)	(id >= rq->exp_msg_id \
-					&& id < (rq->win_size + rq->exp_msg_id))
+/*
+ * When exp_msg_id on the receiver has not wrapped around but the sender ID has
+ * we need to allow the IDs starting from 0 that are valid. These macros use
+ * the overflow of exp_msg_id to validate that.
+ */
+#define ofi_recvwin_id_valid_uint32_t(rq, id) \
+	ofi_val32_inrange(rq->exp_msg_id, rq->win_size, id)
+#define ofi_recvwin_id_valid_uint64_t(rq, id) \
+	ofi_val64_inrange(rq->exp_msg_id, rq->win_size, id)
 
 #endif /* FI_RECVWIN_H */

--- a/include/ofi_recvwin.h
+++ b/include/ofi_recvwin.h
@@ -49,11 +49,11 @@
 #include <ofi.h>
 #include <ofi_rbuf.h>
 
-#define OFI_DECL_RECVWIN_BUF(entrytype, name)				\
+#define OFI_DECL_RECVWIN_BUF(entrytype, name, id_type)			\
 OFI_DECLARE_CIRQUE(entrytype, recvwin_cirq);				\
 struct name {								\
-	uint64_t exp_msg_id;						\
-	unsigned int win_size;						\
+	id_type exp_msg_id;						\
+	id_type win_size;						\
 	struct recvwin_cirq *pending;					\
 };									\
 									\
@@ -74,9 +74,9 @@ ofi_recvwin_free(struct name *recvq)					\
 }									\
 									\
 static inline int							\
-ofi_recvwin_queue_msg(struct name *recvq, entrytype * msg, uint64_t id)	\
+ofi_recvwin_queue_msg(struct name *recvq, entrytype * msg, id_type id)	\
 {									\
-	int write_idx;							\
+	size_t write_idx;						\
 									\
 	assert(ofi_recvwin_is_allowed(recvq, id));			\
 	write_idx = (ofi_cirque_rindex(recvq->pending)			\

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -956,7 +956,6 @@ static inline void rxr_release_tx_entry(struct rxr_ep *ep,
 			      sizeof(struct rxr_tx_entry));
 #endif
 	tx_entry->state = RXR_TX_FREE;
-	tx_entry->msg_id = ~0;
 	ofi_buf_free(tx_entry);
 }
 
@@ -972,7 +971,6 @@ static inline void rxr_release_rx_entry(struct rxr_ep *ep,
 			      sizeof(struct rxr_rx_entry));
 #endif
 	rx_entry->state = RXR_RX_FREE;
-	rx_entry->msg_id = ~0;
 	ofi_buf_free(rx_entry);
 }
 

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -761,7 +761,7 @@ static_assert(sizeof(struct rxr_pkt_entry) == 64, "rxr_pkt_entry check");
 #endif
 #endif
 
-OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf);
+OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf, uint32_t);
 DECLARE_FREESTACK(struct rxr_robuf, rxr_robuf_fs);
 
 #define RXR_CTRL_HDR_SIZE		(sizeof(struct rxr_ctrl_cq_hdr))

--- a/prov/efa/src/rxr/rxr_attr.c
+++ b/prov/efa/src/rxr/rxr_attr.c
@@ -40,7 +40,7 @@ const uint32_t rxr_poison_value = 0xdeadbeef;
 #define RXR_EP_CAPS (FI_MSG | FI_TAGGED | FI_RECV | FI_SEND | FI_READ \
 		     | FI_WRITE | FI_REMOTE_READ | FI_REMOTE_WRITE \
 		     | FI_DIRECTED_RECV | FI_SOURCE | FI_MULTI_RECV \
-		     | FI_RMA)
+		     | FI_RMA | FI_LOCAL_COMM | FI_REMOTE_COMM)
 
 /* TODO: Add support for true FI_DELIVERY_COMPLETE */
 #define RXR_TX_OP_FLAGS (FI_INJECT | FI_COMPLETION | FI_TRANSMIT_COMPLETE | \
@@ -94,7 +94,8 @@ struct fi_domain_attr rxr_domain_attr = {
 	.rx_ctx_cnt = 1,
 	.max_ep_tx_ctx = 1,
 	.max_ep_rx_ctx = 1,
-	.cq_data_size = RXR_CQ_DATA_SIZE
+	.cq_data_size = RXR_CQ_DATA_SIZE,
+	.caps = FI_LOCAL_COMM | FI_REMOTE_COMM
 };
 
 struct fi_fabric_attr rxr_fabric_attr = {

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -953,7 +953,7 @@ static int rxr_cq_reorder_msg(struct rxr_ep *ep,
 	if (rts_hdr->msg_id != ofi_recvwin_next_exp_id(peer->robuf))
 		FI_DBG(&rxr_prov, FI_LOG_EP_CTRL,
 		       "msg OOO rts_hdr->msg_id: %" PRIu32 " expected: %"
-		       PRIu64 "\n", rts_hdr->msg_id,
+		       PRIu32 "\n", rts_hdr->msg_id,
 		       ofi_recvwin_next_exp_id(peer->robuf));
 #endif
 	if (ofi_recvwin_is_exp(peer->robuf, rts_hdr->msg_id))

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -958,7 +958,7 @@ static int rxr_cq_reorder_msg(struct rxr_ep *ep,
 #endif
 	if (ofi_recvwin_is_exp(peer->robuf, rts_hdr->msg_id))
 		return 0;
-	else if (ofi_recvwin_is_delayed(peer->robuf, rts_hdr->msg_id))
+	else if (!ofi_recvwin_id_valid(peer->robuf, rts_hdr->msg_id))
 		return -FI_EALREADY;
 
 	if (OFI_LIKELY(rxr_env.rx_copy_ooo)) {
@@ -1078,7 +1078,7 @@ static void rxr_cq_handle_rts(struct rxr_ep *ep,
 			return;
 		} else if (OFI_UNLIKELY(ret == -FI_EALREADY)) {
 			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
-				"Duplicate RTS packet msg_id: %" PRIu32
+				"Invalid msg_id: %" PRIu32
 				" next_msg_id: %" PRIu32 "\n",
 			       rts_hdr->msg_id, peer->next_msg_id);
 			if (!rts_hdr->addrlen)

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -943,7 +943,7 @@ void rxr_generic_tx_entry_init(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	tx_entry->iov_index = 0;
 	tx_entry->iov_mr_start = 0;
 	tx_entry->iov_offset = 0;
-	tx_entry->msg_id = ~0;
+	tx_entry->msg_id = 0;
 	dlist_init(&tx_entry->queued_pkts);
 
 	memcpy(&tx_entry->iov[0], iov, sizeof(*iov) * iov_count);
@@ -1639,8 +1639,7 @@ ssize_t rxr_tx(struct fid_ep *ep, const struct iovec *iov, size_t iov_count,
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, addr);
-	tx_entry->msg_id = (peer->next_msg_id != ~0) ?
-			    peer->next_msg_id++ : ++peer->next_msg_id;
+	tx_entry->msg_id = peer->next_msg_id++;
 
 	if (op == ofi_op_read_req) {
 		int ignore = ~0;


### PR DESCRIPTION
Pull in the `FI_LOCAL_COMM | FI_REMOTE_COMM` and message ID fixes for EFA for the next 1.8.x release.