### PR TITLE
prov/util, shm: add FI_WAIT_YIELD

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -201,6 +201,10 @@ static void ft_cq_set_wait_attr(void)
 		cq_attr.wait_obj = FI_WAIT_FD;
 		cq_attr.wait_cond = FI_CQ_COND_NONE;
 		break;
+	case FT_COMP_YIELD:
+		cq_attr.wait_obj = FI_WAIT_YIELD;
+		cq_attr.wait_cond = FI_CQ_COND_NONE;
+		break;
 	default:
 		cq_attr.wait_obj = FI_WAIT_NONE;
 		break;
@@ -219,6 +223,9 @@ static void ft_cntr_set_wait_attr(void)
 		break;
 	case FT_COMP_WAIT_FD:
 		cntr_attr.wait_obj = FI_WAIT_FD;
+		break;
+	case FT_COMP_YIELD:
+		cntr_attr.wait_obj = FI_WAIT_YIELD;
 		break;
 	default:
 		cntr_attr.wait_obj = FI_WAIT_NONE;
@@ -2155,6 +2162,7 @@ static int ft_get_cq_comp(struct fid_cq *cq, uint64_t *cur,
 
 	switch (opts.comp_method) {
 	case FT_COMP_SREAD:
+	case FT_COMP_YIELD:
 		ret = ft_wait_for_comp(cq, cur, total, timeout);
 		break;
 	case FT_COMP_WAIT_FD:
@@ -2222,6 +2230,7 @@ static int ft_get_cntr_comp(struct fid_cntr *cntr, uint64_t total, int timeout)
 	case FT_COMP_SREAD:
 	case FT_COMP_WAITSET:
 	case FT_COMP_WAIT_FD:
+	case FT_COMP_YIELD:
 		ret = ft_wait_for_cntr(cntr, total, timeout);
 		break;
 	default:
@@ -2760,7 +2769,7 @@ void ft_csusage(char *name, char *desc)
 	FT_PRINT_OPTS_USAGE("-l", "align transmit and receive buffers to page size");
 	FT_PRINT_OPTS_USAGE("-m", "machine readable output");
 	FT_PRINT_OPTS_USAGE("-t <type>", "completion type [queue, counter]");
-	FT_PRINT_OPTS_USAGE("-c <method>", "completion method [spin, sread, fd]");
+	FT_PRINT_OPTS_USAGE("-c <method>", "completion method [spin, sread, fd, yield]");
 	FT_PRINT_OPTS_USAGE("-h", "display this help output");
 
 	return;
@@ -2875,6 +2884,8 @@ void ft_parsecsopts(int op, char *optarg, struct ft_opts *opts)
 			opts->comp_method = FT_COMP_SREAD;
 		else if (!strncasecmp("fd", optarg, 2))
 			opts->comp_method = FT_COMP_WAIT_FD;
+		else if (!strncasecmp("yield", optarg, 5))
+			opts->comp_method = FT_COMP_YIELD;
 		break;
 	case 't':
 		if (!strncasecmp("counter", optarg, 7)) {

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -92,7 +92,8 @@ enum ft_comp_method {
 	FT_COMP_SPIN = 0,
 	FT_COMP_SREAD,
 	FT_COMP_WAITSET,
-	FT_COMP_WAIT_FD
+	FT_COMP_WAIT_FD,
+	FT_COMP_YIELD,
 };
 
 enum {

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -420,12 +420,12 @@ struct util_wait_fd {
 	fastlock_t		lock;
 };
 
-typedef int (*ofi_wait_fd_try_func)(void *arg);
+typedef int (*ofi_wait_try_func)(void *arg);
 
 struct ofi_wait_fd_entry {
 	struct dlist_entry	entry;
 	int 			fd;
-	ofi_wait_fd_try_func	wait_try;
+	ofi_wait_try_func	wait_try;
 	void			*arg;
 	ofi_atomic32_t		ref;
 };
@@ -433,8 +433,29 @@ struct ofi_wait_fd_entry {
 int ofi_wait_fd_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		struct fid_wait **waitset);
 int ofi_wait_fd_add(struct util_wait *wait, int fd, uint32_t events,
-		    ofi_wait_fd_try_func wait_try, void *arg, void *context);
+		    ofi_wait_try_func wait_try, void *arg, void *context);
 int ofi_wait_fd_del(struct util_wait *wait, int fd);
+
+struct util_wait_yield {
+	struct util_wait	util_wait;
+	int			signal;
+	struct dlist_entry	fid_list;
+	fastlock_t		wait_lock;
+	fastlock_t		signal_lock;
+};
+
+struct ofi_wait_fid_entry {
+	struct dlist_entry	entry;
+	ofi_wait_try_func	wait_try;
+	void			*fid;
+	ofi_atomic32_t		ref;
+};
+
+int ofi_wait_yield_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
+			struct fid_wait **waitset);
+int ofi_wait_fid_add(struct util_wait *wait, ofi_wait_try_func wait_try,
+		       void *arg);
+int ofi_wait_fid_del(struct util_wait *wait, void *fid);
 
 /*
  * Completion queue

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -408,8 +408,8 @@ struct util_wait {
 	fi_wait_try_func	wait_try;
 };
 
-int fi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
-		 struct util_wait *wait);
+int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
+		  struct util_wait *wait);
 int fi_wait_cleanup(struct util_wait *wait);
 
 struct util_wait_fd {

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -58,7 +58,8 @@ enum fi_wait_obj {
 	FI_WAIT_UNSPEC,
 	FI_WAIT_SET,
 	FI_WAIT_FD,
-	FI_WAIT_MUTEX_COND	/* pthread mutex & cond */
+	FI_WAIT_MUTEX_COND,	/* pthread mutex & cond */
+	FI_WAIT_YIELD,
 };
 
 struct fi_wait_attr {

--- a/include/windows/pthread.h
+++ b/include/windows/pthread.h
@@ -138,6 +138,12 @@ static inline pthread_t pthread_self(void)
 	return (pthread_t) ENOSYS;
 }
 
+static inline int pthread_yield(void)
+{
+	(void) SwitchToThread();
+	return 0;
+}
+
 /*
  * TODO: temporary solution
  * Need to re-implement

--- a/man/fi_cntr.3.md
+++ b/man/fi_cntr.3.md
@@ -131,8 +131,8 @@ struct fi_cntr_attr {
   object associated with a counter, in order to use it in other system
   calls.  The following values may be used to specify the type of wait
   object associated with a counter: FI_WAIT_NONE, FI_WAIT_UNSPEC,
-  FI_WAIT_SET, FI_WAIT_FD, and FI_WAIT_MUTEX_COND.  The default is
-  FI_WAIT_NONE.
+  FI_WAIT_SET, FI_WAIT_FD, FI_WAIT_MUTEX_COND, and FI_WAIT_YIELD. 
+  The default is FI_WAIT_NONE.
 
 - *FI_WAIT_NONE*
 : Used to indicate that the user will not block (wait) for events on
@@ -160,6 +160,10 @@ struct fi_cntr_attr {
 - *FI_WAIT_MUTEX_COND*
 : Specifies that the counter should use a pthread mutex and cond
   variable as a wait object.
+
+- *FI_WAIT_YIELD*
+: Indicates that the counter will wait without a wait object but instead
+  yield on every wait. Allows usage of fi_cntr_wait through a spin.
 
 *wait_set*
 : If wait_obj is FI_WAIT_SET, this field references a wait object to

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -252,10 +252,6 @@ struct fi_cq_tagged_entry {
 : Specifies that the CQ should use a pthread mutex and cond variable
   as a wait object.
 
-- *FI_WAIT_CRITSEC_COND*
-: Windows specific.  Specifies that the CQ should use a critical
-  section and condition variable as a wait object.
-
 *signaling_vector*
 : If the FI_AFFINITY flag is set, this indicates the logical cpu number
   (0..max cpu - 1) that interrupts associated with the CQ should target.

--- a/man/fi_cq.3.md
+++ b/man/fi_cq.3.md
@@ -221,8 +221,8 @@ struct fi_cq_tagged_entry {
   fi_control to retrieve the underlying wait object associated with a
   CQ, in order to use it in other system calls.  The following values
   may be used to specify the type of wait object associated with a
-  CQ: FI_WAIT_NONE, FI_WAIT_UNSPEC, FI_WAIT_SET, FI_WAIT_FD, and
-  FI_WAIT_MUTEX_COND.  The default is FI_WAIT_NONE.
+  CQ: FI_WAIT_NONE, FI_WAIT_UNSPEC, FI_WAIT_SET, FI_WAIT_FD,
+  FI_WAIT_MUTEX_COND, and FI_WAIT_YIELD.  The default is FI_WAIT_NONE.
 
 - *FI_WAIT_NONE*
 : Used to indicate that the user will not block (wait) for completions
@@ -251,6 +251,11 @@ struct fi_cq_tagged_entry {
 - *FI_WAIT_MUTEX_COND*
 : Specifies that the CQ should use a pthread mutex and cond variable
   as a wait object.
+
+- *FI_WAIT_YIELD*
+: Indicates that the CQ will wait without a wait object but instead
+  yield on every wait. Allows usage of fi_cq_sread and fi_cq_sreadfrom
+  through a spin.
 
 *signaling_vector*
 : If the FI_AFFINITY flag is set, this indicates the logical cpu number

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -176,6 +176,10 @@ struct fi_eq_attr {
 : Specifies that the EQ should use a pthread mutex and cond variable
   as a wait object.
 
+- *FI_WAIT_YIELD*
+: Indicates that the EQ will wait without a wait object but instead
+  yield on every wait. Allows usage of fi_eq_sread through a spin.
+
 *signaling_vector*
 : If the FI_AFFINITY flag is set, this indicates the logical cpu number
   (0..max cpu - 1) that interrupts associated with the EQ should target.

--- a/man/fi_eq.3.md
+++ b/man/fi_eq.3.md
@@ -176,10 +176,6 @@ struct fi_eq_attr {
 : Specifies that the EQ should use a pthread mutex and cond variable
   as a wait object.
 
-- *FI_WAIT_CRITSEC_COND*
-: Windows specific.  Specifies that the EQ should use a critical
-  section and condition variable as a wait object.
-
 *signaling_vector*
 : If the FI_AFFINITY flag is set, this indicates the logical cpu number
   (0..max cpu - 1) that interrupts associated with the EQ should target.

--- a/man/fi_poll.3.md
+++ b/man/fi_poll.3.md
@@ -174,7 +174,8 @@ struct fi_wait_attr {
   allow applications to block until the wait object is signaled,
   indicating that an event is available to be read.  The following
   values may be used to specify the type of wait object associated
-  with a wait set: FI_WAIT_UNSPEC, FI_WAIT_FD, and FI_WAIT_MUTEX_COND.
+  with a wait set: FI_WAIT_UNSPEC, FI_WAIT_FD, FI_WAIT_MUTEX_COND,
+  and FI_WAIT_YIELD.
 
 - *FI_WAIT_UNSPEC*
 : Specifies that the user will only wait on the wait set using
@@ -196,6 +197,10 @@ struct fi_wait_attr {
 - *FI_WAIT_MUTEX_COND*
 : Specifies that the wait set should use a pthread mutex and cond
   variable as a wait object.
+
+- *FI_WAIT_YIELD*
+: Indicates that the wait set will wait without a wait object but instead
+  yield on every wait.
 
 *flags*
 : Flags that set the default operation of the wait set.  The use of

--- a/man/fi_poll.3.md
+++ b/man/fi_poll.3.md
@@ -197,10 +197,6 @@ struct fi_wait_attr {
 : Specifies that the wait set should use a pthread mutex and cond
   variable as a wait object.
 
-- *FI_WAIT_CRITSEC_COND*
-: Windows specific.  Specifies that the EQ should use a critical
-  section and condition variable as a wait object.
-
 *flags*
 : Flags that set the default operation of the wait set.  The use of
   this field is reserved and must be set to 0 by the caller.

--- a/prov/shm/src/smr_cntr.c
+++ b/prov/shm/src/smr_cntr.c
@@ -38,8 +38,15 @@ int smr_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 	int ret;
 	struct util_cntr *cntr;
 
-	if (attr->wait_obj != FI_WAIT_NONE) {
-		FI_INFO(&smr_prov, FI_LOG_CNTR, "cntr wait not yet supported\n");
+	switch (attr->wait_obj) {
+	case FI_WAIT_UNSPEC:
+		attr->wait_obj = FI_WAIT_YIELD;
+		/* fall through */
+	case FI_WAIT_NONE:
+	case FI_WAIT_YIELD:
+		break;
+	default:
+		FI_INFO(&smr_prov, FI_LOG_CQ, "cntr wait not yet supported\n");
 		return -FI_ENOSYS;
 	}
 

--- a/prov/shm/src/smr_cq.c
+++ b/prov/shm/src/smr_cq.c
@@ -41,7 +41,14 @@ int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	struct util_cq *util_cq;
 	int ret;
 
-	if (attr->wait_obj != FI_WAIT_NONE) {
+	switch (attr->wait_obj) {
+	case FI_WAIT_UNSPEC:
+		attr->wait_obj = FI_WAIT_YIELD;
+		/* fall through */
+	case FI_WAIT_NONE:
+	case FI_WAIT_YIELD:
+		break;
+	default:
 		FI_INFO(&smr_prov, FI_LOG_CQ, "CQ wait not yet supported\n");
 		return -FI_ENOSYS;
 	}

--- a/prov/shm/src/smr_fabric.c
+++ b/prov/shm/src/smr_fabric.c
@@ -41,7 +41,7 @@ static struct fi_ops_fabric smr_fabric_ops = {
 	.domain = smr_domain_open,
 	.passive_ep = fi_no_passive_ep,
 	.eq_open = ofi_eq_create,
-	.wait_open = ofi_wait_fd_open,
+	.wait_open = ofi_wait_yield_open,
 	.trywait = ofi_trywait
 };
 

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -49,6 +49,7 @@ static int ofi_check_cntr_attr(const struct fi_provider *prov,
 
 	switch (attr->wait_obj) {
 	case FI_WAIT_NONE:
+	case FI_WAIT_YIELD:
 		break;
 	case FI_WAIT_SET:
 		if (!attr->wait_set) {
@@ -290,6 +291,7 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
 	case FI_WAIT_MUTEX_COND:
+	case FI_WAIT_YIELD:
 		memset(&wait_attr, 0, sizeof wait_attr);
 		wait_attr.wait_obj = attr->wait_obj;
 		cntr->internal_wait = 1;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -142,6 +142,7 @@ int ofi_check_cq_attr(const struct fi_provider *prov,
 
 	switch (attr->wait_obj) {
 	case FI_WAIT_NONE:
+	case FI_WAIT_YIELD:
 		break;
 	case FI_WAIT_SET:
 		if (!attr->wait_set) {
@@ -537,6 +538,7 @@ static int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
 	case FI_WAIT_MUTEX_COND:
+	case FI_WAIT_YIELD:
 		memset(&wait_attr, 0, sizeof wait_attr);
 		wait_attr.wait_obj = attr->wait_obj;
 		cq->internal_wait = 1;

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -290,6 +290,7 @@ static int util_eq_init(struct fid_fabric *fabric, struct util_eq *eq,
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
 	case FI_WAIT_MUTEX_COND:
+	case FI_WAIT_YIELD:
 		memset(&wait_attr, 0, sizeof wait_attr);
 		wait_attr.wait_obj = attr->wait_obj;
 		eq->internal_wait = 1;
@@ -363,6 +364,7 @@ static int util_verify_eq_attr(const struct fi_provider *prov,
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
 	case FI_WAIT_MUTEX_COND:
+	case FI_WAIT_YIELD:
 		break;
 	case FI_WAIT_SET:
 		if (!attr->wait_set) {

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -81,6 +81,7 @@ int ofi_check_wait_attr(const struct fi_provider *prov,
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
 	case FI_WAIT_MUTEX_COND:
+	case FI_WAIT_YIELD:
 		break;
 	default:
 		FI_WARN(prov, FI_LOG_FABRIC, "invalid wait object type\n");
@@ -128,6 +129,9 @@ int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
 		break;
 	case FI_WAIT_MUTEX_COND:
 		wait->wait_obj = FI_WAIT_MUTEX_COND;
+		break;
+	case FI_WAIT_YIELD:
+		wait->wait_obj = FI_WAIT_YIELD;
 		break;
 	default:
 		assert(0);
@@ -182,7 +186,7 @@ out:
 }
 
 int ofi_wait_fd_add(struct util_wait *wait, int fd, uint32_t events,
-		    ofi_wait_fd_try_func wait_try, void *arg, void *context)
+		    ofi_wait_try_func wait_try, void *arg, void *context)
 {
 	struct ofi_wait_fd_entry *fd_entry;
 	struct dlist_entry *entry;
@@ -422,5 +426,211 @@ err2:
 	fi_wait_cleanup(&wait->util_wait);
 err1:
 	free(wait);
+	return ret;
+}
+
+static void util_wait_yield_signal(struct util_wait *util_wait)
+{
+	struct util_wait_yield *wait_yield;
+
+	wait_yield = container_of(util_wait, struct util_wait_yield, util_wait);
+
+	fastlock_acquire(&wait_yield->signal_lock);
+	wait_yield->signal = 1;
+	fastlock_release(&wait_yield->signal_lock);
+}
+
+static int util_wait_yield_run(struct fid_wait *wait_fid, int timeout)
+{
+	struct util_wait_yield *wait = container_of(wait_fid,
+			struct util_wait_yield, util_wait.wait_fid);
+	struct ofi_wait_fid_entry *fid_entry;
+	int ret = 0;
+
+	while (!wait->signal) {
+		fastlock_acquire(&wait->wait_lock);
+		dlist_foreach_container(&wait->fid_list,
+					struct ofi_wait_fid_entry,
+					fid_entry, entry) {
+			ret = fid_entry->wait_try(fid_entry->fid);
+			if (ret)
+				return ret;
+		}
+		fastlock_release(&wait->wait_lock);
+		pthread_yield();
+	}
+
+	fastlock_acquire(&wait->signal_lock);
+	wait->signal = 0;
+	fastlock_release(&wait->signal_lock);
+
+	return FI_SUCCESS;
+}
+
+static int util_wait_yield_close(struct fid *fid)
+{
+	struct util_wait_yield *wait;
+	struct ofi_wait_fid_entry *fid_entry;
+	int ret;
+
+	wait = container_of(fid, struct util_wait_yield, util_wait.wait_fid.fid);
+	ret = fi_wait_cleanup(&wait->util_wait);
+	if (ret)
+		return ret;
+
+	while (!dlist_empty(&wait->fid_list)) {
+		dlist_pop_front(&wait->fid_list, struct ofi_wait_fid_entry,
+				fid_entry, entry);
+		free(fid_entry);
+	}
+
+	fastlock_destroy(&wait->wait_lock);
+	fastlock_destroy(&wait->signal_lock);
+	free(wait);
+	return 0;
+}
+
+static struct fi_ops_wait util_wait_yield_ops = {
+	.size = sizeof(struct fi_ops_wait),
+	.wait = util_wait_yield_run,
+};
+
+static struct fi_ops util_wait_yield_fi_ops = {
+	.size = sizeof(struct fi_ops),
+	.close = util_wait_yield_close,
+	.bind = fi_no_bind,
+	.control = fi_no_control,
+	.ops_open = fi_no_ops_open,
+};
+
+static int util_verify_wait_yield_attr(const struct fi_provider *prov,
+				       const struct fi_wait_attr *attr)
+{
+	int ret;
+
+	ret = ofi_check_wait_attr(prov, attr);
+	if (ret)
+		return ret;
+
+	switch (attr->wait_obj) {
+	case FI_WAIT_UNSPEC:
+	case FI_WAIT_YIELD:
+		break;
+	default:
+		FI_WARN(prov, FI_LOG_FABRIC, "unsupported wait object\n");
+		return -FI_EINVAL;
+	}
+
+	return 0;
+}
+
+int ofi_wait_yield_open(struct fid_fabric *fabric_fid, struct fi_wait_attr *attr,
+			struct fid_wait **waitset)
+{
+	struct util_fabric *fabric;
+	struct util_wait_yield *wait;
+	int ret;
+
+	fabric = container_of(fabric_fid, struct util_fabric, fabric_fid);
+	ret = util_verify_wait_yield_attr(fabric->prov, attr);
+	if (ret)
+		return ret;
+
+	attr->wait_obj = FI_WAIT_YIELD;
+	wait = calloc(1, sizeof(*wait));
+	if (!wait)
+		return -FI_ENOMEM;
+
+	ret = ofi_wait_init(fabric, attr, &wait->util_wait);
+	if (ret) {
+		free(wait);
+		return ret;
+	}
+
+	wait->util_wait.signal = util_wait_yield_signal;
+	wait->signal = 0;
+
+	wait->util_wait.wait_fid.fid.ops = &util_wait_yield_fi_ops;
+	wait->util_wait.wait_fid.ops = &util_wait_yield_ops;
+
+	fastlock_init(&wait->wait_lock);
+	fastlock_init(&wait->signal_lock);
+	dlist_init(&wait->fid_list);
+
+	*waitset = &wait->util_wait.wait_fid;
+
+	return 0;
+}
+
+static int ofi_wait_fid_match(struct dlist_entry *item, const void *arg)
+{
+	struct ofi_wait_fid_entry *fid_entry;
+
+	fid_entry = container_of(item, struct ofi_wait_fid_entry, entry);
+	return fid_entry->fid == arg;
+}
+
+int ofi_wait_fid_del(struct util_wait *wait, void *fid)
+{
+	int ret = 0;
+	struct ofi_wait_fid_entry *fid_entry;
+	struct dlist_entry *entry;
+	struct util_wait_yield *wait_yield = container_of(wait,
+						struct util_wait_yield,
+						util_wait);
+
+	fastlock_acquire(&wait_yield->wait_lock);
+	entry = dlist_find_first_match(&wait_yield->fid_list, ofi_wait_fid_match,
+				       fid);
+	if (!entry) {
+		FI_INFO(wait->prov, FI_LOG_FABRIC,
+			"Given fid (%p) not found in wait list - %p\n",
+			fid, wait_yield);
+		ret = -FI_EINVAL;
+		goto out;
+	}
+	fid_entry = container_of(entry, struct ofi_wait_fid_entry, entry);
+	if (ofi_atomic_dec32(&fid_entry->ref))
+		goto out;
+	dlist_remove(&fid_entry->entry);
+	free(fid_entry);
+out:
+	fastlock_release(&wait_yield->wait_lock);
+	return ret;
+}
+
+int ofi_wait_fid_add(struct util_wait *wait, ofi_wait_try_func wait_try,
+		     void *fid)
+{
+	struct ofi_wait_fid_entry *fid_entry;
+	struct dlist_entry *entry;
+	struct util_wait_yield *wait_yield = container_of(wait,
+					struct util_wait_yield, util_wait);
+	int ret = 0;
+
+	fastlock_acquire(&wait_yield->wait_lock);
+	entry = dlist_find_first_match(&wait_yield->fid_list, ofi_wait_fid_match,
+				       fid);
+	if (entry) {
+		FI_DBG(wait->prov, FI_LOG_EP_CTRL,
+		       "Given fid (%p) already added to wait list - %p \n",
+		       fid, wait_yield);
+		fid_entry = container_of(entry, struct ofi_wait_fid_entry, entry);
+		ofi_atomic_inc32(&fid_entry->ref);
+		goto out;
+	}
+
+	fid_entry = calloc(1, sizeof *fid_entry);
+	if (!fid_entry) {
+		ret = -FI_ENOMEM;
+		goto out;
+	}
+
+	fid_entry->fid = fid;
+	fid_entry->wait_try = wait_try;
+	ofi_atomic_initialize32(&fid_entry->ref, 1);
+	dlist_insert_tail(&fid_entry->entry, &wait_yield->fid_list);
+out:
+	fastlock_release(&wait_yield->wait_lock);
 	return ret;
 }

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -110,8 +110,8 @@ int fi_wait_cleanup(struct util_wait *wait)
 	return 0;
 }
 
-int fi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
-		 struct util_wait *wait)
+int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
+		  struct util_wait *wait)
 {
 	struct fid_poll *poll_fid;
 	struct fi_poll_attr poll_attr;
@@ -386,7 +386,7 @@ int ofi_wait_fd_open(struct fid_fabric *fabric_fid, struct fi_wait_attr *attr,
 	if (!wait)
 		return -FI_ENOMEM;
 
-	ret = fi_wait_init(fabric, attr, &wait->util_wait);
+	ret = ofi_wait_init(fabric, attr, &wait->util_wait);
 	if (ret)
 		goto err1;
 


### PR DESCRIPTION
- Add definition of new wait object type FI_WAIT_YIELD to allow for waiting without an underlying wait object.
- Add support of FI_WAIT_YIELD in utility code
- Add FI_WAIT_YIELD as the default (and only) waiting method for the shm provider
- Add testing option of FI_WAIT_YIELD
