### PR TITLE
[v1.9.x] prov/shm: fix pointer passed into ofi_cq_init

### DIFF
--- a/prov/shm/src/smr_cq.c
+++ b/prov/shm/src/smr_cq.c
@@ -50,7 +50,8 @@ int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (!util_cq)
 		return -FI_ENOMEM;
 
-	ret = ofi_cq_init(&smr_prov, domain, attr, util_cq, ofi_cq_progress, context);
+	ret = ofi_cq_init(&smr_prov, domain, attr, util_cq,
+			  &ofi_cq_progress, context);
 	if (ret)
 		goto free;
 


### PR DESCRIPTION
Cherry-picked from commit dcb9c6dbf5e9bebefec5fc00ea1d6133a701f4e6

Signed-off-by: aingerson <alexia.ingerson@intel.com>