### PR TITLE
prov/verbs: Code restructuring in prep of fixing SQ overflow

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -351,12 +351,6 @@ struct fi_ibv_domain {
 
 	/* MR stuff */
 	struct ofi_mr_cache		cache;
-	int 				(*post_send)(struct ibv_qp *qp,
-						     struct ibv_send_wr *wr,
-						     struct ibv_send_wr **bad_wr);
-	int				(*poll_cq)(struct ibv_cq *cq,
-						   int num_entries,
-						   struct ibv_wc *wc);
 };
 
 struct fi_ibv_cq;
@@ -808,18 +802,18 @@ fi_ibv_process_wc(struct fi_ibv_cq *cq, struct ibv_wc *wc)
 	return (wc->wr_id == VERBS_NO_COMP_FLAG) ? 0 : 1;
 }
 
+int fi_ibv_poll_cq_track_credits(struct ibv_cq *cq, int num_entries,
+				 struct ibv_wc *wc);
+
 /* Returns 0 and tries read new completions if it processes
  * WR entry for which user doesn't request the completion */
 static inline int
 fi_ibv_process_wc_poll_new(struct fi_ibv_cq *cq, struct ibv_wc *wc)
 {
-	struct fi_ibv_domain *domain = container_of(cq->util_cq.domain,
-						    struct fi_ibv_domain,
-						    util_domain);
 	if (wc->wr_id == VERBS_NO_COMP_FLAG) {
 		int ret;
 
-		while ((ret = domain->poll_cq(cq->cq, 1, wc)) > 0) {
+		while ((ret = fi_ibv_poll_cq_track_credits(cq->cq, 1, wc)) > 0) {
 			if (wc->wr_id != VERBS_NO_COMP_FLAG)
 				return 1;
 		}
@@ -902,13 +896,10 @@ static inline int fi_ibv_poll_reap_unsig_cq(struct fi_ibv_ep *ep)
 	int ret, i;
 	struct fi_ibv_cq *cq =
 		container_of(ep->util_ep.tx_cq, struct fi_ibv_cq, util_cq);
-	struct fi_ibv_domain *domain = container_of(cq->util_cq.domain,
-						    struct fi_ibv_domain,
-						    util_domain);
 
 	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
 	while (1) {
-		ret = domain->poll_cq(cq->cq, 10, wc);
+		ret = fi_ibv_poll_cq_track_credits(cq->cq, 10, wc);
 		if (ret <= 0)
 			break;
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -923,29 +923,7 @@ static inline int fi_ibv_poll_reap_unsig_cq(struct fi_ibv_ep *ep)
 	return ret;
 }
 
-/* WR must be filled out by now except for context */
-static inline ssize_t
-fi_ibv_send_poll_cq_if_needed(struct fi_ibv_ep *ep, struct ibv_send_wr *wr)
-{
-	struct ibv_send_wr *bad_wr;
-	struct fi_ibv_domain *domain =
-		container_of(ep->util_ep.domain, struct fi_ibv_domain, util_domain);
-	int ret;
-
-	ret = domain->post_send(ep->ibv_qp, wr, &bad_wr);
-	if (OFI_UNLIKELY(ret)) {
-		ret = vrb_convert_ret(ret);
-		if (OFI_LIKELY(ret == -FI_EAGAIN)) {
-			ret = fi_ibv_poll_reap_unsig_cq(ep);
-			if (OFI_UNLIKELY(ret))
-				return -FI_EAGAIN;
-			/* Try again and return control to a caller */
-			ret = vrb_convert_ret(
-				domain->post_send(ep->ibv_qp, wr, &bad_wr));
-		}
-	}
-	return ret;
-}
+ssize_t vrb_post_send(struct fi_ibv_ep *ep, struct ibv_send_wr *wr);
 
 static inline ssize_t
 fi_ibv_send_buf(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
@@ -958,7 +936,7 @@ fi_ibv_send_buf(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
 	wr->sg_list = &sge;
 	wr->num_sge = 1;
 
-	return fi_ibv_send_poll_cq_if_needed(ep, wr);
+	return vrb_post_send(ep, wr);
 }
 
 static inline ssize_t
@@ -972,7 +950,7 @@ fi_ibv_send_buf_inline(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
 	wr->sg_list = &sge;
 	wr->num_sge = 1;
 
-	return fi_ibv_send_poll_cq_if_needed(ep, wr);
+	return vrb_post_send(ep, wr);
 }
 
 static inline ssize_t
@@ -994,7 +972,7 @@ fi_ibv_send_iov_flags(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
 	if (flags & FI_FENCE)
 		wr->send_flags |= IBV_SEND_FENCE;
 
-	return fi_ibv_send_poll_cq_if_needed(ep, wr);
+	return vrb_post_send(ep, wr);
 }
 
 int fi_ibv_get_rai_id(const char *node, const char *service, uint64_t flags,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -788,22 +788,16 @@ fi_ibv_dgram_av_lookup_av_entry(fi_addr_t fi_addr)
  * Deal with non-compliant libibverbs drivers which set errno
  * instead of directly returning the error value
  */
-static inline ssize_t fi_ibv_handle_post(int ret)
+static inline ssize_t vrb_convert_ret(int ret)
 {
-	switch (ret) {
-		case -ENOMEM:
-		case ENOMEM:
-			ret = -FI_EAGAIN;
-			break;
-		case -1:
-			ret = (errno == ENOMEM) ? -FI_EAGAIN :
-						  -errno;
-			break;
-		default:
-			ret = -abs(ret);
-			break;
-	}
-	return ret;
+	if (!ret)
+		return 0;
+	else if (ret == -ENOMEM || ret == ENOMEM)
+		return -FI_EAGAIN;
+	else if (ret == -1)
+		return (errno == ENOMEM) ? -FI_EAGAIN : -errno;
+	else
+		return -abs(ret);
 }
 
 /* Returns 0 if it processes WR entry for which user
@@ -940,13 +934,13 @@ fi_ibv_send_poll_cq_if_needed(struct fi_ibv_ep *ep, struct ibv_send_wr *wr)
 
 	ret = domain->post_send(ep->ibv_qp, wr, &bad_wr);
 	if (OFI_UNLIKELY(ret)) {
-		ret = fi_ibv_handle_post(ret);
+		ret = vrb_convert_ret(ret);
 		if (OFI_LIKELY(ret == -FI_EAGAIN)) {
 			ret = fi_ibv_poll_reap_unsig_cq(ep);
 			if (OFI_UNLIKELY(ret))
 				return -FI_EAGAIN;
 			/* Try again and return control to a caller */
-			ret = fi_ibv_handle_post(
+			ret = vrb_convert_ret(
 				domain->post_send(ep->ibv_qp, wr, &bad_wr));
 		}
 	}

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -238,14 +238,11 @@ static void fi_ibv_cq_read_data_entry(struct ibv_wc *wc, void *buf)
 static inline int fi_ibv_poll_outstanding_cq(struct fi_ibv_ep *ep,
 					     struct fi_ibv_cq *cq)
 {
-	struct fi_ibv_domain *domain = container_of(cq->util_cq.domain,
-						    struct fi_ibv_domain,
-						    util_domain);
 	struct fi_ibv_wce *wce;
 	struct ibv_wc wc;
 	ssize_t ret;
 
-	ret = domain->poll_cq(cq->cq, 1, &wc);
+	ret = fi_ibv_poll_cq_track_credits(cq->cq, 1, &wc);
 	if (ret <= 0)
 		return ret;
 
@@ -296,12 +293,9 @@ void fi_ibv_cleanup_cq(struct fi_ibv_ep *ep)
 static inline
 ssize_t fi_ibv_poll_cq_process_wc(struct fi_ibv_cq *cq, struct ibv_wc *wc)
 {
-	struct fi_ibv_domain *domain = container_of(cq->util_cq.domain,
-						    struct fi_ibv_domain,
-						    util_domain);
 	ssize_t ret;
 
-	ret = domain->poll_cq(cq->cq, 1, wc);
+	ret = fi_ibv_poll_cq_track_credits(cq->cq, 1, wc);
 	if (ret <= 0)
 		return ret;
 

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -210,7 +210,7 @@ fi_ibv_dgram_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t l
 	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &ep->wrs->msg_wr))
 		return -FI_ENOENT;
 
-	ret = fi_ibv_send_poll_cq_if_needed(ep, &ep->wrs->msg_wr);
+	ret = vrb_post_send(ep, &ep->wrs->msg_wr);
 	ep->wrs->msg_wr.opcode = IBV_WR_SEND;
 	return ret;
 }
@@ -246,7 +246,7 @@ fi_ibv_dgram_ep_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &ep->wrs->msg_wr))
 		return -FI_ENOENT;
 
-	return fi_ibv_send_poll_cq_if_needed(ep, &ep->wrs->msg_wr);
+	return vrb_post_send(ep, &ep->wrs->msg_wr);
 }
 
 const struct fi_ops_msg fi_ibv_dgram_msg_ops = {

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -64,7 +64,7 @@ fi_ibv_dgram_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 
 	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
-	return fi_ibv_handle_post(ibv_post_recv(ep->ibv_qp, &wr, &bad_wr));
+	return vrb_convert_ret(ibv_post_recv(ep->ibv_qp, &wr, &bad_wr));
 }
 
 static inline ssize_t

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -36,6 +36,30 @@
 
 static struct fi_ops_msg fi_ibv_srq_msg_ops;
 
+
+/* WR must be filled out by now except for context */
+ssize_t vrb_post_send(struct fi_ibv_ep *ep, struct ibv_send_wr *wr)
+{
+	struct ibv_send_wr *bad_wr;
+	struct fi_ibv_domain *domain;
+	int ret;
+
+	domain = container_of(ep->util_ep.domain, struct fi_ibv_domain, util_domain);
+	ret = domain->post_send(ep->ibv_qp, wr, &bad_wr);
+	if (!ret)
+		return 0;
+
+	ret = vrb_convert_ret(ret);
+	if (ret != -FI_EAGAIN)
+		return ret;
+
+	ret = fi_ibv_poll_reap_unsig_cq(ep);
+	if (ret)
+		return -FI_EAGAIN;
+
+	return vrb_convert_ret(domain->post_send(ep->ibv_qp, wr, &bad_wr));
+}
+
 static inline int fi_ibv_msg_ep_cmdata_size(fid_t fid)
 {
 	struct fi_ibv_pep *pep;

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1171,7 +1171,7 @@ fi_ibv_srq_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t 
 
 	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
-	return fi_ibv_handle_post(ibv_post_srq_recv(ep->srq, &wr, &bad_wr));
+	return vrb_convert_ret(ibv_post_srq_recv(ep->srq, &wr, &bad_wr));
 }
 
 static ssize_t
@@ -1189,7 +1189,7 @@ fi_ibv_srq_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	};
 	struct ibv_recv_wr *bad_wr;
 
-	return fi_ibv_handle_post(ibv_post_srq_recv(ep->srq, &wr, &bad_wr));
+	return vrb_convert_ret(ibv_post_srq_recv(ep->srq, &wr, &bad_wr));
 }
 
 static ssize_t
@@ -1242,7 +1242,7 @@ fi_ibv_xrc_srq_ep_prepost_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 	 * receive message function is swapped out. */
 	if (ep->srq) {
 		fastlock_release(&ep->xrc.prepost_lock);
-		return fi_ibv_handle_post(fi_recv(ep_fid, buf, len, desc,
+		return vrb_convert_ret(fi_recv(ep_fid, buf, len, desc,
 						 src_addr, context));
 	}
 

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -37,27 +37,32 @@
 static struct fi_ops_msg fi_ibv_srq_msg_ops;
 
 
-/* WR must be filled out by now except for context */
 ssize_t vrb_post_send(struct fi_ibv_ep *ep, struct ibv_send_wr *wr)
 {
+	struct fi_ibv_cq *cq;
 	struct ibv_send_wr *bad_wr;
-	struct fi_ibv_domain *domain;
-	int ret;
+	int ret, retry = 1;
 
-	domain = container_of(ep->util_ep.domain, struct fi_ibv_domain, util_domain);
-	ret = domain->post_send(ep->ibv_qp, wr, &bad_wr);
-	if (!ret)
-		return 0;
+	cq = container_of(ep->util_ep.tx_cq, struct fi_ibv_cq, util_cq);
+retry:
+	if (ofi_atomic_dec32(&cq->credits) < 0)
+		goto try_polling;
 
-	ret = vrb_convert_ret(ret);
-	if (ret != -FI_EAGAIN)
-		return ret;
+	ret = ibv_post_send(ep->ibv_qp, wr, &bad_wr);
+	if (ret) {
+		ofi_atomic_inc32(&cq->credits);
+		goto try_polling;
+	}
+	return 0;
 
-	ret = fi_ibv_poll_reap_unsig_cq(ep);
-	if (ret)
-		return -FI_EAGAIN;
-
-	return vrb_convert_ret(domain->post_send(ep->ibv_qp, wr, &bad_wr));
+try_polling:
+	if (retry) {
+		retry = 0;
+		ret = fi_ibv_poll_reap_unsig_cq(ep);
+		if (!ret)
+			goto retry;
+	}
+	return -FI_EAGAIN;
 }
 
 static inline int fi_ibv_msg_ep_cmdata_size(fid_t fid)

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -51,7 +51,7 @@ fi_ibv_msg_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t 
 
 	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
-	return fi_ibv_handle_post(ibv_post_recv(ep->ibv_qp, &wr, &bad_wr));
+	return vrb_convert_ret(ibv_post_recv(ep->ibv_qp, &wr, &bad_wr));
 }
 
 static ssize_t
@@ -71,7 +71,7 @@ fi_ibv_msg_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 
 	assert(ep->util_ep.rx_cq);
 
-	return fi_ibv_handle_post(ibv_post_recv(ep->ibv_qp, &wr, &bad_wr));
+	return vrb_convert_ret(ibv_post_recv(ep->ibv_qp, &wr, &bad_wr));
 }
 
 static ssize_t

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -192,7 +192,7 @@ fi_ibv_msg_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	return fi_ibv_send_poll_cq_if_needed(ep, &ep->wrs->msg_wr);
+	return vrb_post_send(ep, &ep->wrs->msg_wr);
 }
 
 static ssize_t fi_ibv_msg_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -208,7 +208,7 @@ static ssize_t fi_ibv_msg_ep_injectdata_fast(struct fid_ep *ep_fid, const void *
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	ret = fi_ibv_send_poll_cq_if_needed(ep, &ep->wrs->msg_wr);
+	ret = vrb_post_send(ep, &ep->wrs->msg_wr);
 	ep->wrs->msg_wr.opcode = IBV_WR_SEND;
 	return ret;
 }

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -134,7 +134,7 @@ fi_ibv_msg_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **d
 
 	fi_ibv_set_sge_iov(wr.sg_list, iov, count, desc);
 
-	return fi_ibv_send_poll_cq_if_needed(ep, &wr);
+	return vrb_post_send(ep, &wr);
 }
 
 static ssize_t
@@ -153,7 +153,7 @@ fi_ibv_msg_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 
 	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
-	return fi_ibv_send_poll_cq_if_needed(ep, &wr);
+	return vrb_post_send(ep, &wr);
 }
 
 static ssize_t
@@ -206,7 +206,7 @@ fi_ibv_rma_write_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	return fi_ibv_send_poll_cq_if_needed(ep, &ep->wrs->rma_wr);
+	return vrb_post_send(ep, &ep->wrs->rma_wr);
 }
 
 static ssize_t
@@ -245,7 +245,7 @@ fi_ibv_msg_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid, const void *buf, 
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	ret = fi_ibv_send_poll_cq_if_needed(ep, &ep->wrs->rma_wr);
+	ret = vrb_post_send(ep, &ep->wrs->rma_wr);
 	ep->wrs->rma_wr.opcode = IBV_WR_RDMA_WRITE;
 	return ret;
 }
@@ -377,7 +377,7 @@ fi_ibv_msg_xrc_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	fi_ibv_set_sge_iov(wr.sg_list, iov, count, desc);
 
-	return fi_ibv_send_poll_cq_if_needed(&ep->base_ep, &wr);
+	return vrb_post_send(&ep->base_ep, &wr);
 }
 
 static ssize_t
@@ -399,7 +399,7 @@ fi_ibv_msg_xrc_ep_rma_readmsg(struct fid_ep *ep_fid,
 
 	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
-	return fi_ibv_send_poll_cq_if_needed(&ep->base_ep, &wr);
+	return vrb_post_send(&ep->base_ep, &wr);
 }
 
 static ssize_t
@@ -456,8 +456,7 @@ fi_ibv_xrc_rma_write_fast(struct fid_ep *ep_fid, const void *buf,
 	ep->base_ep.wrs->sge.addr = (uintptr_t) buf;
 	ep->base_ep.wrs->sge.length = (uint32_t) len;
 
-	return fi_ibv_send_poll_cq_if_needed(&ep->base_ep,
-					     &ep->base_ep.wrs->rma_wr);
+	return vrb_post_send(&ep->base_ep, &ep->base_ep.wrs->rma_wr);
 }
 
 static ssize_t
@@ -500,8 +499,7 @@ fi_ibv_msg_xrc_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid,
 	ep->base_ep.wrs->sge.addr = (uintptr_t) buf;
 	ep->base_ep.wrs->sge.length = (uint32_t) len;
 
-	ret = fi_ibv_send_poll_cq_if_needed(&ep->base_ep,
-					    &ep->base_ep.wrs->rma_wr);
+	ret = vrb_post_send(&ep->base_ep, &ep->base_ep.wrs->rma_wr);
 	ep->base_ep.wrs->rma_wr.opcode = IBV_WR_RDMA_WRITE;
 	return ret;
 }


### PR DESCRIPTION
If the underlying verbs device does not check for SQ overflow, we need to handle it in the OFI provider.  This is a small set of patches that simplifies the send path to make it a little more readable and maintainable in preparation of re-working the credit checks.