### PR TITLE
prov/rxm, tcp: Mostly code restructuring in pursuit of identifying cause of crash

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -89,9 +89,9 @@ extern "C" {
 #define OFI_Q_STRERROR(prov, level, subsys, q, q_str, entry, q_strerror)	\
 	FI_LOG(prov, level, subsys, "fi_" q_str "_readerr: err: %s (%d), "	\
 	       "prov_err: %s (%d)\n", strerror((entry)->err), (entry)->err,	\
-	       q_strerror((q), -(entry)->prov_errno,				\
+	       q_strerror((q), (entry)->prov_errno,				\
 			  (entry)->err_data, NULL, 0),				\
-	       -(entry)->prov_errno)
+	       (entry)->prov_errno)
 
 #define OFI_CQ_STRERROR(prov, level, subsys, cq, entry) \
 	OFI_Q_STRERROR(prov, level, subsys, cq, "cq", entry, fi_cq_strerror)

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -662,12 +662,12 @@ struct rxm_ep {
 	struct fid_ep 		*srx_ctx;
 	size_t 			comp_per_progress;
 	ofi_atomic32_t		atomic_tx_credits;
-	int			msg_mr_local;
-	int			rxm_mr_local;
+	bool			msg_mr_local;
+	bool			rdm_mr_local;
+
 	size_t			min_multi_recv_size;
 	size_t			buffered_min;
 	size_t			buffered_limit;
-
 	size_t			inject_limit;
 	size_t			eager_limit;
 	size_t			sar_limit;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1199,11 +1199,10 @@ rxm_conn_handle_event(struct rxm_ep *rxm_ep, struct rxm_msg_eq_entry *entry)
 	if (entry->rd == -FI_ECONNREFUSED)
 		return rxm_conn_handle_reject(rxm_ep, entry);
 
-	switch(entry->event) {
+	switch (entry->event) {
 	case FI_NOTIFY:
-		if (rxm_conn_handle_notify((struct fi_eq_entry *) &entry->cm_entry))
-			return -FI_EOTHER;
-		break;
+		return rxm_conn_handle_notify((struct fi_eq_entry *)
+					      &entry->cm_entry);
 	case FI_CONNREQ:
 		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "Got new connection\n");
 		if ((size_t)entry->rd != RXM_CM_ENTRY_SZ) {

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -656,7 +656,8 @@ static int rxm_cmap_cm_thread_close(struct rxm_cmap *cmap)
 {
 	int ret;
 
-	if (cmap->ep->domain->data_progress != FI_PROGRESS_AUTO)
+	FI_INFO(&rxm_prov, FI_LOG_EP_CTRL, "stopping CM thread\n");
+	if (!cmap->cm_thread)
 		return 0;
 
 	ret = rxm_conn_signal(cmap->ep, NULL, RXM_CMAP_EXIT);
@@ -680,9 +681,9 @@ void rxm_cmap_free(struct rxm_cmap *cmap)
 	struct dlist_entry *entry;
 	size_t i;
 
+	FI_INFO(cmap->av->prov, FI_LOG_EP_CTRL, "Closing cmap\n");
 	rxm_cmap_cm_thread_close(cmap);
 
-	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Closing cmap\n");
 	for (i = 0; i < cmap->num_allocated; i++) {
 		if (cmap->handles_av[i]) {
 			rxm_cmap_clear_key(cmap->handles_av[i]);
@@ -690,6 +691,7 @@ void rxm_cmap_free(struct rxm_cmap *cmap)
 			cmap->handles_av[i] = 0;
 		}
 	}
+
 	while(!dlist_empty(&cmap->peer_list)) {
 		entry = cmap->peer_list.next;
 		peer = container_of(entry, struct rxm_cmap_peer, entry);
@@ -1136,7 +1138,8 @@ static int rxm_conn_handle_notify(struct fi_eq_entry *eq_entry)
 		rxm_conn_free(handle);
 		return 0;
 	} else {
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "unknown cmap signal\n");
+		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "unhandled cmap state %" PRIu64 "\n",
+			eq_entry->data);
 		assert(0);
 		return -FI_EOTHER;
 	}

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1288,10 +1288,7 @@ void rxm_cq_read_write_error(struct rxm_ep *rxm_ep)
 		return;
 	}
 
-	if (err_entry.err == FI_ECANCELED)
-		OFI_CQ_STRERROR(&rxm_prov, FI_LOG_DEBUG, FI_LOG_CQ,
-				rxm_ep->msg_cq, &err_entry);
-	else
+	if (err_entry.err != FI_ECANCELED)
 		OFI_CQ_STRERROR(&rxm_prov, FI_LOG_WARN, FI_LOG_CQ,
 				rxm_ep->msg_cq, &err_entry);
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -277,7 +277,7 @@ static inline int rxm_finish_rma(struct rxm_ep *rxm_ep, struct rxm_rma_buf *rma_
 	else
 		ofi_ep_rd_cntr_inc(&rxm_ep->util_ep);
 
-	if (!(rma_buf->flags & FI_INJECT) && !rxm_ep->rxm_mr_local &&
+	if (!(rma_buf->flags & FI_INJECT) && !rxm_ep->rdm_mr_local &&
 	    rxm_ep->msg_mr_local) {
 		rxm_msg_mr_closev(rma_buf->mr.mr, rma_buf->mr.count);
 	}
@@ -334,7 +334,7 @@ static inline int rxm_finish_send_rndv_ack(struct rxm_rx_buf *rx_buf)
 		rx_buf->recv_entry->rndv.tx_buf = NULL;
 	}
 
-	if (!rx_buf->ep->rxm_mr_local)
+	if (!rx_buf->ep->rdm_mr_local)
 		rxm_msg_mr_closev(rx_buf->mr, rx_buf->recv_entry->rxm_iov.count);
 
 	return rxm_finish_recv(rx_buf, rx_buf->recv_entry->total_len);
@@ -346,7 +346,7 @@ static int rxm_rndv_tx_finish(struct rxm_ep *rxm_ep, struct rxm_tx_rndv_buf *tx_
 
 	RXM_UPDATE_STATE(FI_LOG_CQ, tx_buf, RXM_RNDV_FINISH);
 
-	if (!rxm_ep->rxm_mr_local)
+	if (!rxm_ep->rdm_mr_local)
 		rxm_msg_mr_closev(tx_buf->mr, tx_buf->count);
 
 	ret = rxm_cq_tx_comp_write(rxm_ep, ofi_tx_cq_flags(tx_buf->pkt.hdr.op),
@@ -528,7 +528,7 @@ ssize_t rxm_cq_handle_rndv(struct rxm_rx_buf *rx_buf)
 	rx_buf->rndv_hdr = (struct rxm_rndv_hdr *)rx_buf->pkt.data;
 	rx_buf->rndv_rma_index = 0;
 
-	if (!rx_buf->ep->rxm_mr_local) {
+	if (!rx_buf->ep->rdm_mr_local) {
 		total_recv_len = MIN(rx_buf->recv_entry->total_len,
 				     rx_buf->pkt.hdr.size);
 		ret = rxm_msg_mr_regv(rx_buf->ep,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -956,7 +956,7 @@ rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void 
 	tx_buf->flags = flags;
 	tx_buf->count = count;
 
-	if (!rxm_ep->rxm_mr_local) {
+	if (!rxm_ep->rdm_mr_local) {
 		ret = rxm_msg_mr_regv(rxm_ep, iov, tx_buf->count, data_len,
 				      FI_REMOTE_READ, tx_buf->mr);
 		if (ret)
@@ -1008,7 +1008,7 @@ rxm_ep_rndv_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 err:
 	FI_DBG(&rxm_prov, FI_LOG_EP_DATA,
 	       "Transmit for MSG provider failed\n");
-	if (!rxm_ep->rxm_mr_local)
+	if (!rxm_ep->rdm_mr_local)
 		rxm_msg_mr_closev(tx_buf->mr, tx_buf->count);
 	ofi_buf_free(tx_buf);
 	return ret;
@@ -2193,7 +2193,7 @@ static void rxm_ep_settings_init(struct rxm_ep *rxm_ep)
 				rxm_ep->rxm_info->tx_attr->size);
 
 	rxm_ep->msg_mr_local = ofi_mr_local(rxm_ep->msg_info);
-	rxm_ep->rxm_mr_local = ofi_mr_local(rxm_ep->rxm_info);
+	rxm_ep->rdm_mr_local = ofi_mr_local(rxm_ep->rxm_info);
 
 	rxm_ep->inject_limit = rxm_ep->msg_info->tx_attr->inject_size;
 
@@ -2225,7 +2225,7 @@ static void rxm_ep_settings_init(struct rxm_ep *rxm_ep)
 	        "\t\t rxm inject size: %zu\n"
 		"\t\t Protocol limits: Eager: %zu, "
 				      "SAR: %zu\n",
-		rxm_ep->msg_mr_local, rxm_ep->rxm_mr_local,
+		rxm_ep->msg_mr_local, rxm_ep->rdm_mr_local,
 		rxm_ep->comp_per_progress, rxm_ep->buffered_min,
 		rxm_ep->min_multi_recv_size, rxm_ep->inject_limit,
 		rxm_ep->rxm_info->tx_attr->inject_size,

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -45,7 +45,7 @@ rxm_ep_rma_reg_iov(struct rxm_ep *rxm_ep, const struct iovec *msg_iov,
 	if (!rxm_ep->msg_mr_local)
 		return FI_SUCCESS;
 
-	if (!rxm_ep->rxm_mr_local) {
+	if (!rxm_ep->rdm_mr_local) {
 		ret = rxm_msg_mr_regv(rxm_ep, msg_iov, iov_count, SIZE_MAX,
 				      comp_flags, rma_buf->mr.mr);
 		if (OFI_UNLIKELY(ret))
@@ -101,7 +101,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg, uint64_t 
 	if (OFI_LIKELY(!ret))
 		goto unlock;
 
-	if ((rxm_ep->msg_mr_local) && (!rxm_ep->rxm_mr_local))
+	if ((rxm_ep->msg_mr_local) && (!rxm_ep->rdm_mr_local))
 		rxm_msg_mr_closev(rma_buf->mr.mr, rma_buf->mr.count);
 release:
 	ofi_buf_free(rma_buf);

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -225,7 +225,7 @@ err:
 	free(cm_ctx);
 
 	/* `err_entry.err_data` must live until it is passed to user */
-	ret = fi_eq_write(&ep->util_ep.eq->eq_fid, FI_NOTIFY,
+	ret = fi_eq_write(&ep->util_ep.eq->eq_fid, FI_SHUTDOWN,
 			  &err_entry, sizeof(err_entry), UTIL_FLAG_ERROR);
 	if (ret < 0)
 		free(err_entry.err_data);
@@ -274,7 +274,7 @@ err:
 	err_entry.err = -ret;
 
 	free(cm_ctx);
-	fi_eq_write(&ep->util_ep.eq->eq_fid, FI_NOTIFY,
+	fi_eq_write(&ep->util_ep.eq->eq_fid, FI_SHUTDOWN,
 		    &err_entry, sizeof(err_entry), UTIL_FLAG_ERROR);
 }
 
@@ -385,7 +385,7 @@ err:
 	err_entry.err = -ret;
 
 	free(cm_ctx);
-	fi_eq_write(&ep->util_ep.eq->eq_fid, FI_NOTIFY,
+	fi_eq_write(&ep->util_ep.eq->eq_fid, FI_SHUTDOWN,
 		    &err_entry, sizeof(err_entry), UTIL_FLAG_ERROR);
 }
 

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -39,43 +39,56 @@
 #include <ofi_util.h>
 
 
-static int read_cm_data(SOCKET fd, struct tcpx_cm_context *cm_ctx,
-			struct ofi_ctrl_hdr *hdr)
-{
-	size_t data_sz;
-	ssize_t ret;
-
-	cm_ctx->cm_data_sz = ntohs(hdr->seg_size);
-	if (cm_ctx->cm_data_sz) {
-		data_sz = MIN(cm_ctx->cm_data_sz, TCPX_MAX_CM_DATA_SIZE);
-		ret = ofi_recv_socket(fd, cm_ctx->cm_data, data_sz, MSG_WAITALL);
-		if ((size_t) ret != data_sz)
-			return -FI_EIO;
-
-		cm_ctx->cm_data_sz = data_sz;
-
-		if (OFI_UNLIKELY(cm_ctx->cm_data_sz > TCPX_MAX_CM_DATA_SIZE))
-			ofi_discard_socket(fd, cm_ctx->cm_data_sz -
-					   TCPX_MAX_CM_DATA_SIZE);
-	}
-	return FI_SUCCESS;
-}
-
 static int rx_cm_data(SOCKET fd, struct ofi_ctrl_hdr *hdr,
 		      int type, struct tcpx_cm_context *cm_ctx)
 {
+	size_t data_size = 0;
 	ssize_t ret;
 
 	ret = ofi_recv_socket(fd, hdr, sizeof(*hdr), MSG_WAITALL);
-	if (ret != sizeof(*hdr))
-		return -FI_EIO;
+	if (ret != sizeof(*hdr)) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"Failed to read cm header\n");
+		ret = ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
+		goto out;
+	}
 
-	if (hdr->version != TCPX_CTRL_HDR_VERSION)
-		return -FI_ENOPROTOOPT;
+	if (hdr->version != TCPX_CTRL_HDR_VERSION) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"cm protocol version mismatch\n");
+		ret = -FI_ENOPROTOOPT;
+		goto out;
+	}
 
-	ret = read_cm_data(fd, cm_ctx, hdr);
-	if (hdr->type != type)
+	if (hdr->type != type) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"unexpected cm message type\n");
 		ret = -FI_ECONNREFUSED;
+		goto out;
+	}
+
+	data_size = MIN(ntohs(hdr->seg_size), TCPX_MAX_CM_DATA_SIZE);
+	if (data_size) {
+		ret = ofi_recv_socket(fd, cm_ctx->cm_data, data_size,
+				      MSG_WAITALL);
+		if ((size_t) ret != data_size) {
+			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+				"Failed to read cm data\n");
+			ret = ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
+			data_size = 0;
+			goto out;
+		}
+
+		if (ntohs(hdr->seg_size) > TCPX_MAX_CM_DATA_SIZE) {
+			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+				"Discarding unexpected cm data\n");
+			ofi_discard_socket(fd, ntohs(hdr->seg_size) -
+					   TCPX_MAX_CM_DATA_SIZE);
+		}
+	}
+	ret = 0;
+out:
+	cm_ctx->cm_data_sz = data_size;
 	return ret;
 }
 
@@ -92,13 +105,13 @@ static int tx_cm_data(SOCKET fd, uint8_t type, struct tcpx_cm_context *cm_ctx)
 
 	ret = ofi_send_socket(fd, &hdr, sizeof(hdr), MSG_NOSIGNAL);
 	if (ret != sizeof(hdr))
-		return -FI_EIO;
+		return ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
 
 	if (cm_ctx->cm_data_sz) {
 		ret = ofi_send_socket(fd, cm_ctx->cm_data,
 				      cm_ctx->cm_data_sz, MSG_NOSIGNAL);
 		if ((size_t) ret != cm_ctx->cm_data_sz)
-			return -FI_EIO;
+			return ofi_sockerr() ? -ofi_sockerr() : -FI_EIO;
 	}
 	return FI_SUCCESS;
 }
@@ -110,12 +123,16 @@ static int tcpx_ep_msg_xfer_enable(struct tcpx_ep *ep)
 	fastlock_acquire(&ep->lock);
 	if (ep->cm_state != TCPX_EP_CONNECTING) {
 		fastlock_release(&ep->lock);
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"ep is in invalid state\n");
 		return -FI_EINVAL;
 	}
 	ep->progress_func = tcpx_ep_progress;
 	ret = fi_fd_nonblock(ep->conn_fd);
 	if (ret) {
 		fastlock_release(&ep->lock);
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"failed to set socket to nonblocking\n");
 		return ret;
 	}
 	ep->cm_state = TCPX_EP_CONNECTED;
@@ -133,8 +150,11 @@ static int proc_conn_resp(struct tcpx_cm_context *cm_ctx,
 	int ret = FI_SUCCESS;
 
 	ret = rx_cm_data(ep->conn_fd, &conn_resp, ofi_ctrl_connresp, cm_ctx);
-	if (ret)
+	if (ret) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"Failed to receive connect response\n");
 		return ret;
+	}
 
 	cm_entry = calloc(1, sizeof(*cm_entry) + cm_ctx->cm_data_sz);
 	if (!cm_entry)
@@ -152,10 +172,9 @@ static int proc_conn_resp(struct tcpx_cm_context *cm_ctx,
 
 	len = fi_eq_write(&ep->util_ep.eq->eq_fid, FI_CONNECTED, cm_entry,
 			  sizeof(*cm_entry) + cm_ctx->cm_data_sz, 0);
-	if (len < 0) {
+	if (len < 0)
 		ret = (int) len;
-		goto err;
-	}
+
 err:
 	free(cm_entry);
 	return ret;
@@ -169,10 +188,11 @@ int tcpx_eq_wait_try_func(void *arg)
 static void client_recv_connresp(struct util_wait *wait,
 				 struct tcpx_cm_context *cm_ctx)
 {
-	struct fi_eq_err_entry err_entry = { 0 };
+	struct fi_eq_err_entry err_entry;
 	struct tcpx_ep *ep;
 	ssize_t ret;
 
+	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Handling accept from server\n");
 	assert(cm_ctx->fid->fclass == FI_CLASS_EP);
 	ep = container_of(cm_ctx->fid, struct tcpx_ep, util_ep.ep_fid.fid);
 
@@ -187,29 +207,27 @@ static void client_recv_connresp(struct util_wait *wait,
 	if (ret)
 		goto err;
 
-	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Received Accept from server\n");
 	free(cm_ctx);
 	return;
 err:
+	memset(&err_entry, 0, sizeof err_entry);
 	err_entry.fid = cm_ctx->fid;
 	err_entry.context = cm_ctx->fid->context;
 	err_entry.err = -ret;
 	if (cm_ctx->cm_data_sz) {
 		err_entry.err_data = calloc(1, cm_ctx->cm_data_sz);
-		if (OFI_LIKELY(err_entry.err_data != NULL)) {
+		if (err_entry.err_data) {
 			memcpy(err_entry.err_data, cm_ctx->cm_data,
 			       cm_ctx->cm_data_sz);
 			err_entry.err_data_size = cm_ctx->cm_data_sz;
 		}
 	}
-	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL,
-	       "fi_eq_write the conn refused %"PRId64"\n", ret);
 	free(cm_ctx);
 
 	/* `err_entry.err_data` must live until it is passed to user */
 	ret = fi_eq_write(&ep->util_ep.eq->eq_fid, FI_NOTIFY,
 			  &err_entry, sizeof(err_entry), UTIL_FLAG_ERROR);
-	if (OFI_UNLIKELY(ret < 0))
+	if (ret < 0)
 		free(err_entry.err_data);
 }
 
@@ -224,6 +242,7 @@ static void server_send_cm_accept(struct util_wait *wait,
 	assert(cm_ctx->fid->fclass == FI_CLASS_EP);
 	ep = container_of(cm_ctx->fid, struct tcpx_ep, util_ep.ep_fid.fid);
 
+	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Send connect (accept) response\n");
 	ret = tx_cm_data(ep->conn_fd, ofi_ctrl_connresp, cm_ctx);
 	if (ret)
 		goto err;
@@ -271,6 +290,7 @@ static void server_recv_connreq(struct util_wait *wait,
 	assert(cm_ctx->fid->fclass == FI_CLASS_CONNREQ);
 	handle  = container_of(cm_ctx->fid, struct tcpx_conn_handle, handle);
 
+	FI_DBG(&tcpx_prov, FI_LOG_EP_CTRL, "Server receive connect request\n");
 	ret = rx_cm_data(handle->conn_fd, &conn_req, ofi_ctrl_connreq, cm_ctx);
 	if (ret)
 		goto err1;

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -68,7 +68,7 @@ static void tcpx_report_error(struct tcpx_ep *tcpx_ep, int err)
 	err_entry.context = tcpx_ep->util_ep.ep_fid.fid.context;
 	err_entry.err = -err;
 
-	fi_eq_write(&tcpx_ep->util_ep.eq->eq_fid, FI_NOTIFY,
+	fi_eq_write(&tcpx_ep->util_ep.eq->eq_fid, FI_SHUTDOWN,
 		    &err_entry, sizeof(err_entry), UTIL_FLAG_ERROR);
 }
 


### PR DESCRIPTION
The cause of the crash still isn't known, but this is a series of cleanups and minor fixes to the rxm and tcp providers.  The crash appears to be a use after free bug somewhere in the cmap handling, so work is being done to simplify that code path, including the progress threads.