### PR TITLE
Changed to using Jenkins environment variable job name instead of branch name in build path 

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -212,8 +212,8 @@ pipeline {
   post {
     cleanup {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-            sh "rm -rf '/mpibuilddir/mpich-build-dir/${env.BRANCH_NAME}/${env.BUILD_NUMBER}'"
-            sh "rm -rf '/mpibuilddir/ompi-build-dir/${env.BRANCH_NAME}/${env.BUILD_NUMBER}'"
+            sh "rm -rf '/mpibuilddir/mpich-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
+            sh "rm -rf '/mpibuilddir/ompi-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
             dir("${env.WORKSPACE}"){
                 deleteDir()
             }

--- a/contrib/intel/jenkins/Jenkinsfile.daily
+++ b/contrib/intel/jenkins/Jenkinsfile.daily
@@ -479,8 +479,8 @@ pipeline {
             }
     cleanup {
         withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:$PYTHONPATH']) {
-            sh "rm -rf '/mpibuilddir/mpich-build-dir/${env.BRANCH_NAME}/${env.BUILD_NUMBER}'"
-            sh "rm -rf '/mpibuilddir/ompi-build-dir/${env.BRANCH_NAME}/${env.BUILD_NUMBER}'"
+            sh "rm -rf '/mpibuilddir/mpich-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
+            sh "rm -rf '/mpibuilddir/ompi-build-dir/${env.JOB_NAME}/${env.BUILD_NUMBER}'"
             dir("${env.WORKSPACE}"){
                 deleteDir()
             }

--- a/contrib/intel/jenkins/build.py
+++ b/contrib/intel/jenkins/build.py
@@ -123,7 +123,7 @@ def build_uh(shmem_dir):
 
 def build_mpi(mpi, mpisrc, mpi_install_path, libfab_install_path,  ofi_build_mode):
    
-    build_mpi_path ="/mpibuilddir/{}-build-dir/{}/{}/{}".format(mpi, branchname, buildno, ofi_build_mode)
+    build_mpi_path ="/mpibuilddir/{}-build-dir/{}/{}/{}".format(mpi, jobname, buildno, ofi_build_mode)
     if (os.path.exists(build_mpi_path) == False):
         os.makedirs(build_mpi_path)
 
@@ -197,8 +197,11 @@ def build_osu_bm(mpi, mpi_install_path, libfab_install_path):
 
 
 if __name__ == "__main__":
-#read environment variables
-    branchname = os.environ['BRANCH_NAME']
+#read Jenkins environment variables
+    # In Jenkins,  JOB_NAME  = 'ofi_libfabric/master' vs BRANCH_NAME = 'master' 
+    # job name is better to use to distinguish between builds of different
+    # jobs but with same branch name.
+    jobname = os.environ['JOB_NAME']
     buildno = os.environ['BUILD_NUMBER']
     workspace = os.environ['WORKSPACE']
 
@@ -221,9 +224,9 @@ if __name__ == "__main__":
 
 
 
-    install_path = "{installdir}/{brname}/{bno}/{bmode}" \
+    install_path = "{installdir}/{jbname}/{bno}/{bmode}" \
                      .format(installdir=ci_site_config.install_dir,
-                            brname=branchname, bno=buildno,bmode=ofi_build_mode)
+                            jbname=jobname, bno=buildno,bmode=ofi_build_mode)
 
     p = re.compile('mpi*')
 

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -8,15 +8,19 @@ import common
 sys.path.append(os.environ['CI_SITE_CONFIG'])
 import ci_site_config
 
+# read Jenkins environment variables
+# In Jenkins, JOB_NAME = 'ofi_libfabric/master' vs BRANCH_NAME = 'master'
+# job name is better to use to distinguish between builds of different
+# jobs but with the same branch name.
 fab = os.environ['FABRIC']#args.fabric
-brname = os.environ['BRANCH_NAME']#args.branchname
+jbname = os.environ['JOB_NAME']#args.jobname
 bno = os.environ['BUILD_NUMBER']#args.buildno
 
 
 #run fi_info test
 def fi_info_test(core, hosts, mode,util=None):
     
-    fi_info_test = tests.FiInfoTest(branchname=brname,buildno=bno,\
+    fi_info_test = tests.FiInfoTest(jobname=jbname,buildno=bno,\
                     testname="fi_info", core_prov=core, fabric=fab,\
                          hosts=hosts, ofi_build_mode=mode, util_prov=util)
     print("running fi_info test for {}-{}-{}".format(core, util, fab))
@@ -26,7 +30,7 @@ def fi_info_test(core, hosts, mode,util=None):
 #runfabtests
 def fabtests(core, hosts, mode, util=None):
        
-    runfabtest = tests.Fabtest(branchname=brname,buildno=bno,\
+    runfabtest = tests.Fabtest(jobname=jbname,buildno=bno,\
                  testname="runfabtests", core_prov=core, fabric=fab,\
                  hosts=hosts, ofi_build_mode=mode, util_prov=util)
 
@@ -39,7 +43,7 @@ def fabtests(core, hosts, mode, util=None):
     print("----------------------------------------------------------------------------------------\n")
     
 def shmemtest(core, hosts, mode, util=None):
-    runshmemtest = tests.ShmemTest(branchname=brname,buildno=bno,\
+    runshmemtest = tests.ShmemTest(jobname=jbname,buildno=bno,\
                  testname="shmem test", core_prov=core, fabric=fab,\
                  hosts=hosts, ofi_build_mode=mode, util_prov=util)
     if (runshmemtest.execute_condn):
@@ -60,7 +64,7 @@ def shmemtest(core, hosts, mode, util=None):
 #imb-tests
 def intel_mpi_benchmark(core, hosts, mpi, mode, util=None):
 
-    imb_test = tests.MpiTestIMB(branchname=brname,buildno=bno,\
+    imb_test = tests.MpiTestIMB(jobname=jbname,buildno=bno,\
                testname="IntelMPIbenchmark",core_prov=core, fabric=fab,\
                hosts=hosts, mpitype=mpi, ofi_build_mode=mode, util_prov=util)
     
@@ -75,7 +79,7 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, util=None):
 #mpi_stress benchmark tests
 def mpistress_benchmark(core, hosts, mpi, mode, util=None):
 
-    stress_test = tests.MpiTestStress(branchname=brname,buildno=bno,\
+    stress_test = tests.MpiTestStress(jobname=jbname,buildno=bno,\
                   testname="stress",core_prov=core, fabric=fab, mpitype=mpi,\
                   hosts=hosts, ofi_build_mode=mode, util_prov=util)
  
@@ -90,7 +94,7 @@ def mpistress_benchmark(core, hosts, mpi, mode, util=None):
 #osu benchmark tests    
 def osu_benchmark(core, hosts, mpi, mode, util=None):
 
-    osu_test = tests.MpiTestOSU(branchname=brname, buildno=bno, \
+    osu_test = tests.MpiTestOSU(jobname=jbname, buildno=bno, \
                testname="osu-benchmarks",core_prov=core, fabric=fab, mpitype=mpi, \
                hosts=hosts, ofi_build_mode=mode, util_prov=util)
     

--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -10,10 +10,12 @@ import ci_site_config
 import common
 import shlex
 
+# A Jenkins env variable for job name is composed of the name of the jenkins job and the branch name
+# it is building for. for e.g. in our case jobname = 'ofi_libfabric/master'
 class Test:
-    def __init__ (self, branchname, buildno, testname, core_prov, fabric,
+    def __init__ (self, jobname, buildno, testname, core_prov, fabric,
                   hosts, ofi_build_mode, util_prov=None):
-        self.branchname = branchname
+        self.jobname = jobname
         self.buildno = buildno
         self.testname = testname
         self.core_prov = core_prov
@@ -27,16 +29,16 @@ class Test:
        
         self.nw_interface = ci_site_config.interface_map[self.fabric]
         self.libfab_installpath = "{}/{}/{}/{}".format(ci_site_config.install_dir,
-                                  self.branchname, self.buildno, self.ofi_build_mode)
+                                  self.jobname, self.buildno, self.ofi_build_mode)
  
         self.env = [("FI_VERBS_MR_CACHE_ENABLE", "1"),\
                     ("FI_VERBS_INLINE_SIZE", "256")] \
                     if self.core_prov == "verbs" else []
 class FiInfoTest(Test):
-    def __init__(self, branchname, buildno, testname, core_prov, fabric,
+    def __init__(self, jobname, buildno, testname, core_prov, fabric,
                  hosts, ofi_build_mode, util_prov=None):
 
-        super().__init__(branchname, buildno, testname, core_prov, fabric,
+        super().__init__(jobname, buildno, testname, core_prov, fabric,
                      hosts, ofi_build_mode, util_prov)
      
         self.fi_info_testpath =  "{}/bin".format(self.libfab_installpath) 
@@ -62,10 +64,10 @@ class FiInfoTest(Test):
 
 class Fabtest(Test):
     
-    def __init__(self, branchname, buildno, testname, core_prov, fabric,
+    def __init__(self, jobname, buildno, testname, core_prov, fabric,
                  hosts, ofi_build_mode, util_prov=None):
         
-        super().__init__(branchname, buildno, testname, core_prov, fabric,
+        super().__init__(jobname, buildno, testname, core_prov, fabric,
                          hosts, ofi_build_mode, util_prov)
         self.fabtestpath = "{}/bin".format(self.libfab_installpath) 
         self.fabtestconfigpath = "{}/share/fabtests".format(self.libfab_installpath)
@@ -151,10 +153,10 @@ class Fabtest(Test):
         os.chdir(curdir)
 
 class ShmemTest(Test):
-    def __init__(self, branchname, buildno, testname, core_prov, fabric,
+    def __init__(self, jobname, buildno, testname, core_prov, fabric,
                  hosts, ofi_build_mode, util_prov=None):
         
-        super().__init__(branchname, buildno, testname, core_prov, fabric,
+        super().__init__(jobname, buildno, testname, core_prov, fabric,
                          hosts, ofi_build_mode, util_prov)
      
         #self.n - number of hosts * number of processes per host
@@ -197,10 +199,10 @@ class ShmemTest(Test):
     
 
 class MpiTests(Test):
-    def __init__(self, branchname, buildno, testname, core_prov, fabric,
+    def __init__(self, jobname, buildno, testname, core_prov, fabric,
                  mpitype, hosts, ofi_build_mode, util_prov=None):
        
-        super().__init__(branchname, buildno, testname, core_prov, 
+        super().__init__(jobname, buildno, testname, core_prov, 
                          fabric, hosts, ofi_build_mode, util_prov)
         self.mpi = mpitype
 
@@ -273,9 +275,9 @@ class MpiTests(Test):
 
 class MpiTestIMB(MpiTests):
 
-    def __init__(self, branchname, buildno, testname, core_prov, fabric,
+    def __init__(self, jobname, buildno, testname, core_prov, fabric,
                  mpitype, hosts, ofi_build_mode, util_prov=None):
-        super().__init__(branchname, buildno, testname, core_prov, fabric,
+        super().__init__(jobname, buildno, testname, core_prov, fabric,
                          mpitype, hosts, ofi_build_mode, util_prov)
         self.additional_tests = [ 
                                    "Biband",
@@ -305,9 +307,9 @@ class MpiTestIMB(MpiTests):
         
 class MpiTestStress(MpiTests):
      
-    def __init__(self, branchname, buildno, testname, core_prov, fabric, 
+    def __init__(self, jobname, buildno, testname, core_prov, fabric, 
                  mpitype, hosts, ofi_build_mode, util_prov=None):
-        super().__init__(branchname, buildno, testname, core_prov, fabric, 
+        super().__init__(jobname, buildno, testname, core_prov, fabric, 
                          mpitype,  hosts, ofi_build_mode, util_prov)
         
          
@@ -342,9 +344,9 @@ class MpiTestStress(MpiTests):
       
 class MpiTestOSU(MpiTests):
 
-    def __init__(self, branchname, buildno, testname, core_prov, fabric,
+    def __init__(self, jobname, buildno, testname, core_prov, fabric,
                  mpitype, hosts, ofi_build_mode, util_prov=None):
-        super().__init__(branchname, buildno, testname, core_prov, fabric,
+        super().__init__(jobname, buildno, testname, core_prov, fabric,
                          mpitype, hosts, ofi_build_mode, util_prov)
         
         self.n = 4 


### PR DESCRIPTION
Job name includes both the name of the job and name of the branch.
Using Job name helps differentiate the same branch being built by
two different jobs. Moreover, it prevents two builds for the same 
branch overwriting the same build path. 

changes made to build.py and run.py: replace BRANCH_NAME,
brname and branchname to JOB_NAME, jobname and jbname.

