### PR TITLE
prov/shm: address name fixes

### DIFF
--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -57,7 +57,6 @@ static int smr_av_close(struct fid *fid)
 static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			 fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
-	struct smr_addr *smr_names = (void *)addr;
 	struct util_av *util_av;
 	struct util_ep *util_ep;
 	struct smr_av *smr_av;
@@ -71,8 +70,8 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 	util_av = container_of(av_fid, struct util_av, av_fid);
 	smr_av = container_of(util_av, struct smr_av, util_av);
 
-	for (i = 0; i < count; i++) {
-		ep_name = smr_no_prefix((const char *) smr_names[i].name);
+	for (i = 0; i < count; i++, addr = (char *) addr + strlen(addr) + 1) {
+		ep_name = smr_no_prefix(addr);
 		ret = ofi_av_insert_addr(util_av, ep_name, &index);
 		if (ret) {
 			if (util_av->eq)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -70,7 +70,12 @@ int smr_getname(fid_t fid, void *addr, size_t *addrlen)
 	if (!addr || *addrlen == 0 ||
 	    snprintf(addr, *addrlen, "%s", ep->name) >= *addrlen)
 		ret = -FI_ETOOSMALL;
-	*addrlen = strlen(ep->name);
+
+	*addrlen = strlen(ep->name) + 1;
+
+	if (!ret)
+		((char *) addr)[*addrlen - 1] = '\0';
+
 	return ret;
 }
 

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -44,22 +44,23 @@ static void smr_resolve_addr(const char *node, const char *service,
 
 	if (service) {
 		if (node)
-			snprintf(temp_name, NAME_MAX, "%s%s:%s",
+			snprintf(temp_name, NAME_MAX - 1, "%s%s:%s",
 				 SMR_PREFIX_NS, node, service);
 		else
-			snprintf(temp_name, NAME_MAX, "%s%s",
+			snprintf(temp_name, NAME_MAX - 1, "%s%s",
 				 SMR_PREFIX_NS, service);
 	} else {
 		if (node)
-			snprintf(temp_name, NAME_MAX, "%s%s",
+			snprintf(temp_name, NAME_MAX - 1, "%s%s",
 				 SMR_PREFIX, node);
 		else
-			snprintf(temp_name, NAME_MAX, "%s%d",
+			snprintf(temp_name, NAME_MAX - 1, "%s%d",
 				 SMR_PREFIX, getpid());
 	}
 
 	*addr = strdup(temp_name);
-	*addrlen = strlen(*addr);
+	*addrlen = strlen(*addr) + 1;
+	(*addr)[*addrlen - 1]  = '\0';
 }
 
 static int smr_get_ptrace_scope(void)


### PR DESCRIPTION
2 address name fixes:
- include NULL terminator in addrlen to make sure to duplicate/use it
- cast address correctly in fi_av_insert