### PR TITLE
Added timeout

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -1,7 +1,10 @@
 
 pipeline {
     agent any
-    options {timestamps()}
+    options {
+        timestamps()
+        timeout(activity: true, time: 4, unit: 'HOURS')    
+    }
 
     stages {
         stage ('fetch-opa-psm2')  {


### PR DESCRIPTION
added timeout to abort the build after 4
hours of inactivity (on the logs) of a pull request build. 
 
Jenkinsfile: added timeout under options. 

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>