### PR TITLE
prov/verbs: Use RDMA CM SIDR message exchanges for shared XRC QP connections

### DIFF
--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -206,7 +206,8 @@ err1:
 	return ret;
 }
 
-int fi_ibv_create_ep(const struct fi_info *hints, struct rdma_cm_id **id)
+int fi_ibv_create_ep(const struct fi_info *hints, enum rdma_port_space ps,
+		     struct rdma_cm_id **id)
 {
 	struct rdma_addrinfo *rai = NULL;
 	int ret;
@@ -216,7 +217,7 @@ int fi_ibv_create_ep(const struct fi_info *hints, struct rdma_cm_id **id)
 		return ret;
 	}
 
-	if (rdma_create_id(NULL, id, NULL, RDMA_PS_TCP)) {
+	if (rdma_create_id(NULL, id, NULL, ps)) {
 		ret = -errno;
 		FI_WARN(&fi_ibv_prov, FI_LOG_FABRIC, "rdma_create_id failed: "
 			"%s (%d)\n", strerror(-ret), -ret);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -303,6 +303,12 @@ struct fi_ibv_pep {
 	struct fid_pep		pep_fid;
 	struct fi_ibv_eq	*eq;
 	struct rdma_cm_id	*id;
+
+	/* XRC uses SIDR based RDMA CM exchanges for setting up
+	 * shared QP connections. This ID is bound to the same
+	 * port number as "id", but the RDMA_PS_UDP port space. */
+	struct rdma_cm_id	*xrc_ps_udp_id;
+
 	int			backlog;
 	int			bound;
 	size_t			src_addrlen;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -613,7 +613,8 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		   struct fid_ep **ep, void *context);
 int fi_ibv_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		      struct fid_pep **pep, void *context);
-int fi_ibv_create_ep(const struct fi_info *hints, struct rdma_cm_id **id);
+int fi_ibv_create_ep(const struct fi_info *hints, enum rdma_port_space ps,
+		     struct rdma_cm_id **id);
 int fi_ibv_dgram_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 			 struct fid_av **av_fid, void *context);
 static inline

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -533,7 +533,7 @@ struct fi_ibv_xrc_ep_conn_setup {
 	 * with the original request. The tag is created by the
 	 * original active side. */
 	uint32_t			conn_tag;
-	bool				created_conn_tag;
+	uint32_t			remote_conn_tag;
 
 	/* Temporary flags to indicate if the INI QP setup and the
 	 * TGT QP setup have completed. */

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -535,14 +535,6 @@ struct fi_ibv_xrc_ep_conn_setup {
 	uint32_t			conn_tag;
 	bool				created_conn_tag;
 
-	/* IB CM message stale/duplicate detection processing requires
-	 * that shared INI/TGT connections use unique QP numbers during
-	 * RDMA CM connection setup. To avoid conflicts with actual HCA
-	 * QP number space, we allocate minimal QP that are left in the
-	 * reset state and closed once the setup process completes. */
-	struct ibv_qp			*rsvd_ini_qpn;
-	struct ibv_qp			*rsvd_tgt_qpn;
-
 	/* Temporary flags to indicate if the INI QP setup and the
 	 * TGT QP setup have completed. */
 	bool				ini_connected;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -535,11 +535,6 @@ struct fi_ibv_xrc_ep_conn_setup {
 	uint32_t			conn_tag;
 	uint32_t			remote_conn_tag;
 
-	/* Temporary flags to indicate if the INI QP setup and the
-	 * TGT QP setup have completed. */
-	bool				ini_connected;
-	bool				tgt_connected;
-
 	/* Delivery of the FI_CONNECTED event is delayed until
 	 * bidirectional connectivity is established. */
 	size_t				event_len;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -588,6 +588,7 @@ struct fi_ibv_xrc_ep {
 	struct rdma_cm_id		*tgt_id;
 	struct ibv_qp			*tgt_ibv_qp;
 	enum fi_ibv_xrc_ep_conn_state	conn_state;
+	bool				recip_req_received;
 	uint32_t			magic;
 	uint32_t			srqn;
 	uint32_t			peer_srqn;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -634,13 +634,14 @@ struct fi_ops_rma fi_ibv_msg_ep_rma_ops;
 struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops_ts;
 struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops;
 
-#define FI_IBV_XRC_VERSION	1
+#define FI_IBV_XRC_VERSION	2
 
 struct fi_ibv_xrc_cm_data {
 	uint8_t		version;
 	uint8_t		reciprocal;
 	uint16_t	port;
-	uint32_t	param;
+	uint32_t	tgt_qpn;
+	uint32_t	srqn;
 	uint32_t	conn_tag;
 };
 
@@ -648,7 +649,8 @@ struct fi_ibv_xrc_conn_info {
 	uint32_t		conn_tag;
 	uint32_t		is_reciprocal;
 	uint32_t		ini_qpn;
-	uint32_t		conn_data;
+	uint32_t		tgt_qpn;
+	uint32_t		peer_srqn;
 	uint16_t		port;
 	struct rdma_conn_param	conn_param;
 };
@@ -680,7 +682,8 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep);
 struct fi_ibv_xrc_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq,
 						uint32_t conn_tag);
 void fi_ibv_set_xrc_cm_data(struct fi_ibv_xrc_cm_data *local, int reciprocal,
-			    uint32_t conn_tag, uint16_t port, uint32_t param);
+			    uint32_t conn_tag, uint16_t port, uint32_t tgt_qpn,
+			    uint32_t srqn);
 int fi_ibv_verify_xrc_cm_data(struct fi_ibv_xrc_cm_data *remote,
 			      int private_data_len);
 int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
@@ -700,8 +703,7 @@ void fi_ibv_save_priv_data(struct fi_ibv_xrc_ep *ep, const void *data,
 			   size_t len);
 int fi_ibv_ep_create_ini_qp(struct fi_ibv_xrc_ep *ep, void *dst_addr,
 			    uint32_t *peer_tgt_qpn);
-void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t peer_srqn,
-			    uint32_t peer_tgt_qpn);
+void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t peer_tgt_qpn);
 void fi_ibv_ep_ini_conn_rejected(struct fi_ibv_xrc_ep *ep);
 int fi_ibv_ep_create_tgt_qp(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn);
 void fi_ibv_ep_tgt_conn_done(struct fi_ibv_xrc_ep *qp);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -118,6 +118,7 @@
 				 sizeof(struct fi_ibv_cm_data_hdr))
 
 #define FI_IBV_CM_REJ_CONSUMER_DEFINED	28
+#define FI_IBV_CM_REJ_SIDR_CONSUMER_DEFINED	2
 
 #define VERBS_DGRAM_MSG_PREFIX_SIZE	(40)
 

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -374,10 +374,9 @@ fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 		free(cm_hdr);
 		return -FI_ENOMEM;
 	}
+	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 
 	fastlock_acquire(&xrc_ep->base_ep.eq->lock);
-	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
-	fi_ibv_eq_set_xrc_conn_tag(xrc_ep);
 	ret = fi_ibv_connect_xrc(xrc_ep, NULL, 0, adjusted_param, paramlen);
 	fastlock_release(&xrc_ep->base_ep.eq->lock);
 

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -254,7 +254,7 @@ fi_ibv_msg_xrc_ep_reject(struct fi_ibv_connreq *connreq,
 		return ret;
 
 	fi_ibv_set_xrc_cm_data(cm_data, connreq->xrc.is_reciprocal,
-			       connreq->xrc.conn_tag, connreq->xrc.port, 0);
+			       connreq->xrc.conn_tag, connreq->xrc.port, 0, 0);
 	ret = rdma_reject(connreq->id, cm_data,
 			  (uint8_t) paramlen) ? -errno : 0;
 	free(cm_data);

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -78,7 +78,7 @@ static int fi_ibv_msg_ep_setname(fid_t ep_fid, void *addr, size_t addrlen)
 
 	memcpy(ep->info->src_addr, addr, ep->info->src_addrlen);
 
-	ret = fi_ibv_create_ep(ep->info, &id);
+	ret = fi_ibv_create_ep(ep->info, RDMA_PS_TCP, &id);
 	if (ret)
 		goto err2;
 

--- a/prov/verbs/src/verbs_cm.c
+++ b/prov/verbs/src/verbs_cm.c
@@ -341,7 +341,6 @@ static int
 fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 		   const void *param, size_t paramlen)
 {
-	struct sockaddr *dst_addr;
 	void *adjusted_param;
 	struct fi_ibv_ep *_ep = container_of(ep, struct fi_ibv_ep,
 					     util_ep.ep_fid);
@@ -379,8 +378,7 @@ fi_ibv_msg_xrc_ep_connect(struct fid_ep *ep, const void *addr,
 	fastlock_acquire(&xrc_ep->base_ep.eq->lock);
 	xrc_ep->conn_setup->conn_tag = VERBS_CONN_TAG_INVALID;
 	fi_ibv_eq_set_xrc_conn_tag(xrc_ep);
-	dst_addr = rdma_get_peer_addr(_ep->id);
-	ret = fi_ibv_connect_xrc(xrc_ep, dst_addr, 0, adjusted_param, paramlen);
+	ret = fi_ibv_connect_xrc(xrc_ep, NULL, 0, adjusted_param, paramlen);
 	fastlock_release(&xrc_ep->base_ep.eq->lock);
 
 	free(adjusted_param);

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -333,17 +333,17 @@ int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
 
 	/* The passive side of the initial shared connection using
 	 * SIDR is complete, initiate reciprocal connection */
-	if (ep->tgt_id->ps == RDMA_PS_UDP &&
-	    ep->conn_state == FI_IBV_XRC_ORIG_CONNECTING) {
+	if (ep->tgt_id->ps == RDMA_PS_UDP && !reciprocal) {
 		fi_ibv_next_xrc_conn_state(ep);
 		fi_ibv_ep_tgt_conn_done(ep);
 		ret = fi_ibv_connect_xrc(ep, NULL, FI_IBV_RECIP_CONN,
 					 &connect_cm_data,
 					 sizeof(connect_cm_data));
 		if (ret) {
+			VERBS_WARN(FI_LOG_EP_CTRL,
+				   "XRC reciprocal connect error %d\n", ret);
 			fi_ibv_prev_xrc_conn_state(ep);
 			ep->tgt_id->qp = NULL;
-			rdma_disconnect(ep->tgt_id);
 		}
 	}
 

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -180,14 +180,11 @@ void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect)
 		assert(ep->tgt_id);
 		assert(!ep->tgt_id->qp);
 
-		if (ep->conn_setup->tgt_connected) {
-			if (ep->tgt_id->ps == RDMA_PS_UDP) {
-				rdma_destroy_id(ep->tgt_id);
-				ep->tgt_id = NULL;
-			} else {
-				rdma_disconnect(ep->tgt_id);
-			}
-			ep->conn_setup->tgt_connected = 0;
+		if (ep->tgt_id->ps == RDMA_PS_UDP) {
+			rdma_destroy_id(ep->tgt_id);
+			ep->tgt_id = NULL;
+		} else {
+			rdma_disconnect(ep->tgt_id);
 		}
 
 		if (ep->base_ep.id->ps == RDMA_PS_UDP) {
@@ -251,7 +248,6 @@ void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn)
 			  ep->ini_conn->tgt_qpn);
 	}
 
-	ep->conn_setup->ini_connected = 1;
 	fi_ibv_log_ep_conn(ep, "INI Connection Done");
 	fi_ibv_sched_ini_conn(ep->ini_conn);
 }
@@ -274,7 +270,6 @@ void fi_ibv_ep_tgt_conn_done(struct fi_ibv_xrc_ep *ep)
 		assert(ep->tgt_ibv_qp == ep->tgt_id->qp);
 		ep->tgt_id->qp = NULL;
 	}
-	ep->conn_setup->tgt_connected = 1;
 }
 
 /* Caller must hold the eq:lock */

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -344,7 +344,7 @@ int fi_ibv_process_ini_conn(struct fi_ibv_xrc_ep *ep,int reciprocal,
 			       ep->conn_setup->remote_conn_tag :
 			       ep->conn_setup->conn_tag,
 			       ep->base_ep.eq->xrc.pep_port,
-			       ep->ini_conn->tgt_qpn);
+			       ep->ini_conn->tgt_qpn, ep->srqn);
 
 	ep->base_ep.conn_param.private_data = cm_data;
 	ep->base_ep.conn_param.private_data_len = paramlen;

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -340,9 +340,12 @@ int fi_ibv_process_ini_conn(struct fi_ibv_xrc_ep *ep,int reciprocal,
 
 	assert(ep->base_ep.ibv_qp);
 
-	fi_ibv_set_xrc_cm_data(cm_data, reciprocal, ep->conn_setup->conn_tag,
+	fi_ibv_set_xrc_cm_data(cm_data, reciprocal, reciprocal ?
+			       ep->conn_setup->remote_conn_tag :
+			       ep->conn_setup->conn_tag,
 			       ep->base_ep.eq->xrc.pep_port,
 			       ep->ini_conn->tgt_qpn);
+
 	ep->base_ep.conn_param.private_data = cm_data;
 	ep->base_ep.conn_param.private_data_len = paramlen;
 	ep->base_ep.conn_param.responder_resources = RDMA_MAX_RESP_RES;

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -458,9 +458,8 @@ static int fi_ibv_put_tgt_qp(struct fi_ibv_xrc_ep *ep)
 /* Caller must hold eq:lock */
 int fi_ibv_ep_destroy_xrc_qp(struct fi_ibv_xrc_ep *ep)
 {
-	if (ep->base_ep.ibv_qp) {
-		fi_ibv_put_shared_ini_conn(ep);
-	}
+	fi_ibv_put_shared_ini_conn(ep);
+
 	if (ep->base_ep.id) {
 		rdma_destroy_id(ep->base_ep.id);
 		ep->base_ep.id = NULL;

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -262,7 +262,8 @@ void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn)
 		last_state = ep->ini_conn->state;
 
 		/* TODO: Select RDMA_PS_TCP/UDP based on last_state (i.e. physical) */
-		ret = fi_ibv_create_ep(ep->base_ep.info, &ep->base_ep.id);
+		ret = fi_ibv_create_ep(ep->base_ep.info, RDMA_PS_TCP,
+				       &ep->base_ep.id);
 		if (ret) {
 			VERBS_WARN(FI_LOG_EP_CTRL,
 				   "Failed to create active CM ID %d\n",

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -229,6 +229,9 @@ static inline void fi_ibv_ep_xrc_close(struct fi_ibv_ep *ep)
 
 	if (xrc_ep->conn_setup)
 		fi_ibv_free_xrc_conn_setup(xrc_ep, 0);
+
+	if (xrc_ep->conn_map_node)
+		fi_ibv_eq_remove_sidr_conn(xrc_ep);
 	fi_ibv_ep_destroy_xrc_qp(xrc_ep);
 	xrc_ep->magic = 0;
 }

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -879,7 +879,8 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		if (!info->handle) {
 			/* Only RC, XRC active RDMA CM ID is created at connect */
 			if (!(dom->flags & VRB_USE_XRC)) {
-				ret = fi_ibv_create_ep(info, &ep->id);
+				ret = fi_ibv_create_ep(info, RDMA_PS_TCP,
+						       &ep->id);
 				if (ret)
 					goto err1;
 				ep->id->context = &ep->util_ep.ep_fid.fid;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -144,7 +144,8 @@ static int fi_ibv_eq_set_xrc_info(struct rdma_cm_event *event,
 	info->is_reciprocal = remote->reciprocal;
 	info->conn_tag = ntohl(remote->conn_tag);
 	info->port = ntohs(remote->port);
-	info->conn_data = ntohl(remote->param);
+	info->tgt_qpn = ntohl(remote->tgt_qpn);
+	info->peer_srqn = ntohl(remote->srqn);
 	info->conn_param = event->param.conn;
 	info->conn_param.private_data = NULL;
 	info->conn_param.private_data_len = 0;
@@ -429,11 +430,10 @@ fi_ibv_eq_xrc_conn_event(struct fi_ibv_xrc_ep *ep,
 			rdma_disconnect(ep->base_ep.id);
 			goto err;
 		}
-		ep->peer_srqn = xrc_info.conn_data;
+		ep->peer_srqn = xrc_info.peer_srqn;
 		fi_ibv_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
 		fi_ibv_save_priv_data(ep, priv_data, priv_datalen);
-		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_data,
-					xrc_info.conn_param.qp_num);
+		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_param.qp_num);
 		fi_ibv_eq_xrc_establish(cma_event);
 
 		/* If we have received the reciprocal connect request,
@@ -485,9 +485,8 @@ fi_ibv_eq_xrc_recip_conn_event(struct fi_ibv_eq *eq,
 			return -FI_EAVAIL;
 		}
 
-		ep->peer_srqn = xrc_info.conn_data;
-		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_data,
-					xrc_info.conn_param.qp_num);
+		ep->peer_srqn = xrc_info.peer_srqn;
+		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_param.qp_num);
 		fi_ibv_eq_xrc_establish(cma_event);
 	} else {
 		fi_ibv_ep_tgt_conn_done(ep);

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -78,7 +78,6 @@ void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	ep->conn_setup->conn_tag =
 		(uint32_t)ofi_idx2key(&eq->xrc.conn_key_idx,
 				ofi_idx_insert(eq->xrc.conn_key_map, ep));
-	ep->conn_setup->created_conn_tag = true;
 }
 
 /* Caller must hold eq:lock */
@@ -88,7 +87,7 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 	int index;
 
 	assert(ep->conn_setup);
-	if (!ep->conn_setup->created_conn_tag)
+	if (ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID)
 		return;
 
 	index = ofi_key2idx(&eq->xrc.conn_key_idx,

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -658,7 +658,6 @@ fi_ibv_eq_xrc_disconnect_event(struct fi_ibv_eq *eq,
 		*acked = 1;
 		rdma_ack_cm_event(cma_event);
 		rdma_disconnect(ep->base_ep.id);
-		ep->conn_setup->ini_connected = 0;
 	}
 }
 

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -627,6 +627,11 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 	struct fi_ibv_ep *ep;
 	struct fi_ibv_xrc_ep *xrc_ep;
 
+	if (cma_event->id->ps == RDMA_PS_UDP) {
+		VERBS_DBG(FI_LOG_EQ, "PS_UDP not supported\n");
+		return -FI_EAGAIN;
+	}
+
 	switch (cma_event->event) {
 	case RDMA_CM_EVENT_ROUTE_RESOLVED:
 		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);


### PR DESCRIPTION
This is a series of patches that implement using RDMA CM SIDR message exchanges to setup virtual/shared XRC QP connections. This avoids the necessity of creating temporary hardware resources when setting up the shared connections. With these changes XRC connection setup becomes faster than RC when the PPN count is greater than 4 PPN, and has up to a 70% improvement in connection setup time over the existing XRC connection setup implementation.