### PR TITLE
Reformatted printing of test commands in the logs

### DIFF
--- a/contrib/intel/jenkins/common.py
+++ b/contrib/intel/jenkins/common.py
@@ -8,7 +8,7 @@ def get_node_name(host, interface):
    return "%s-%s" % (host, interface)
 
 def run_command(command):
-    print(command)
+    print(" ".join(command))
     p = subprocess.Popen(command, stdout=subprocess.PIPE, text=True)
     print(p.returncode)
     while True:


### PR DESCRIPTION
reformatted printing of exeuted commands as a string instead of a list
This saves time for developers when testing failed tests commands manually
common.py: added " ".join to the print statement in run_command

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>