### PR TITLE
prov/shm:  Detect the availability of CMA system call directly

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -38,6 +38,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <sys/wait.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_atomic.h>


### PR DESCRIPTION
Detect the availability of CMA system calls by directly
calling process_vm_writev.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>