### PR TITLE
Add RMA mode to the multinode tests

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -379,7 +379,7 @@ static int ft_alloc_ctx_array(struct ft_context **mr_array, char ***mr_bufs,
 	for (i = 0; i < opts.window_size; i++) {
 		context = &(*mr_array)[i];
 		if (!(opts.options & FT_OPT_ALLOC_MULT_MR)) {
-			context->buf = default_buf;
+			context->buf = default_buf + mr_size * i;
 			continue;
 		}
 		(*mr_bufs)[i] = calloc(1, mr_size);
@@ -435,7 +435,8 @@ static int ft_alloc_msgs(void)
 		ft_set_tx_rx_sizes(&tx_size, &rx_size);
 		tx_mr_size = 0;
 		rx_mr_size = 0;
-		buf_size = MAX(tx_size, FT_MAX_CTRL_MSG) + MAX(rx_size, FT_MAX_CTRL_MSG);
+		buf_size = MAX(tx_size, FT_MAX_CTRL_MSG) * opts.window_size + 
+			   MAX(rx_size, FT_MAX_CTRL_MSG) * opts.window_size;
 	}
 
 	if (opts.options & FT_OPT_ALIGN) {
@@ -459,9 +460,11 @@ static int ft_alloc_msgs(void)
 	}
 	memset(buf, 0, buf_size);
 	rx_buf = buf;
-	tx_buf = (char *) buf + MAX(rx_size, FT_MAX_CTRL_MSG);
-	tx_buf = (void *) (((uintptr_t) tx_buf + alignment - 1) &
-			   ~(alignment - 1));
+
+	if (opts.options & FT_OPT_ALLOC_MULT_MR)
+		tx_buf = (char *) buf + MAX(rx_size, FT_MAX_CTRL_MSG);
+	else
+		tx_buf = (char *) buf + MAX(rx_size, FT_MAX_CTRL_MSG) * opts.window_size;
 
 	remote_cq_data = ft_init_cq_data(fi);
 

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -454,11 +454,12 @@ This will run "fi_rdm_atomic" for all atomic operations with
 
 ## Run multinode tests
 
-	server and clients are invoked with the same command: 
-		fi_multinode -n <number of processes> -s <server_addr> 
+	Server and clients are invoked with the same command: 
+		fi_multinode -n <number of processes> -s <server_addr> -C <mode>
 	
-	a process on the server must be started before any of the clients can be started 
-	succesfully. 
+	A process on the server must be started before any of the clients can be started 
+	succesfully. -C lists the mode that the tests will run in. Currently the options are
+  for rma and msg. If not provided, the test will default to msg. 
 
 ## Run fi_ubertest
 

--- a/fabtests/multinode/include/core.h
+++ b/fabtests/multinode/include/core.h
@@ -44,6 +44,17 @@
 
 #define PM_DEFAULT_OOB_PORT (8228)
 
+enum multi_xfer{
+	multi_msg,
+};
+
+struct multi_xfer_method {
+	char* name;
+	int (*send)();
+	int (*recv)();
+	int (*wait)();
+};
+
 struct pm_job_info {
 	size_t		my_rank;
 	size_t		num_ranks;
@@ -55,8 +66,8 @@ struct pm_job_info {
 	void		*names;
 	size_t		name_len;
 	fi_addr_t	*fi_addrs;
+	enum multi_xfer transfer_method;
 };
-
 
 struct multinode_xfer_state {
 	int 			iteration;
@@ -82,3 +93,6 @@ extern struct pm_job_info pm_job;
 int multinode_run_tests(int argc, char **argv);
 int pm_allgather(void *my_item, void *items, int item_size);
 void pm_barrier();
+int multi_msg_send();
+int multi_msg_recv();
+int multi_msg_wait();

--- a/fabtests/multinode/include/core.h
+++ b/fabtests/multinode/include/core.h
@@ -46,6 +46,7 @@
 
 enum multi_xfer{
 	multi_msg,
+	multi_rma,
 };
 
 struct multi_xfer_method {
@@ -60,6 +61,7 @@ struct pm_job_info {
 	size_t		num_ranks;
 	int		sock;
 	int		*clients; //only valid for server
+	struct fi_rma_iov 	*multi_iovs;
 
 	struct sockaddr_storage oob_server_addr;
 	size_t 		server_addr_len;
@@ -96,3 +98,6 @@ void pm_barrier();
 int multi_msg_send();
 int multi_msg_recv();
 int multi_msg_wait();
+int multi_rma_write();
+int multi_rma_recv();
+int multi_rma_wait();

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -62,6 +62,12 @@ struct multi_xfer_method multi_xfer_methods[] = {
 		.send = multi_msg_send,
 		.recv = multi_msg_recv,
 		.wait = multi_msg_wait,
+	},
+	{
+		.name = "rma",
+		.send = multi_rma_write,
+		.recv = multi_rma_recv,
+		.wait = multi_rma_wait,
 	}
 };
 
@@ -69,20 +75,23 @@ static int multi_setup_fabric(int argc, char **argv)
 {
 	char my_name[FT_MAX_CTRL_MSG];
 	size_t len;
-	int ret;
+	int i, ret;
+	struct fi_rma_iov *remote = malloc(sizeof(*remote));
+
+	hints->ep_attr->type = FI_EP_RDM;
+	hints->mode = FI_CONTEXT;
+	hints->domain_attr->mr_mode = opts.mr_mode;
 
 	if (pm_job.transfer_method == multi_msg) {
 		hints->caps = FI_MSG;
+	} else if (pm_job.transfer_method == multi_rma) {
+		hints->caps = FI_MSG | FI_RMA;
 	} else {
 		printf("Not a valid cabability\n");
 		return -FI_ENODATA;
 	}
 
 	method = multi_xfer_methods[pm_job.transfer_method];
-
-	hints->ep_attr->type = FI_EP_RDM;
-	hints->mode = FI_CONTEXT;
-	hints->domain_attr->mr_mode = opts.mr_mode;
 
 	tx_seq = 0;
 	rx_seq = 0;
@@ -147,10 +156,55 @@ static int multi_setup_fabric(int argc, char **argv)
 		ret = -1;
 		goto err;
 	}
+
+	pm_job.multi_iovs = malloc(sizeof(*(pm_job.multi_iovs)) * pm_job.num_ranks);
+	if (!pm_job.multi_iovs) {
+		FT_ERR("error allocation memory for rma_iovs\n");
+		goto err;
+	}
+
+	if (fi->domain_attr->mr_mode & FI_MR_VIRT_ADDR) 
+		remote->addr = (uintptr_t) rx_buf;
+	else
+		remote->addr = 0;
+
+	remote->key = fi_mr_key(mr);
+	remote->len = rx_size;
+
+	ret = pm_allgather(remote, pm_job.multi_iovs, sizeof(*remote));
+	if (ret) {
+		FT_ERR("error exchanging rma_iovs\n");
+		goto err;
+	}
+	for (i = 0; i < pm_job.num_ranks; i++) {
+		pm_job.multi_iovs[i].addr += (tx_size * pm_job.my_rank);
+	}
+
 	return 0;
 err:
 	ft_free_res();
 	return ft_exit_code(ret);
+}
+
+static int ft_progress(struct fid_cq *cq, uint64_t total, uint64_t *cq_cntr)
+{
+	struct fi_cq_err_entry comp;
+	int ret;
+
+	ret = fi_cq_read(cq, &comp, 1);
+	if (ret > 0)
+		(*cq_cntr)++;
+
+	if (ret >= 0 || ret == -FI_EAGAIN)
+		return 0;
+
+	if (ret == -FI_EAVAIL) {
+		ret = ft_cq_readerr(cq);
+		(*cq_cntr)++;
+	} else {
+		FT_PRINTERR("fi_cq_read/sread", ret);
+	}
+	return ret;
 }
 
 int multi_msg_recv()
@@ -158,10 +212,7 @@ int multi_msg_recv()
 	int ret, offset;
 
 	/* post receives */
-	while (!state.all_recvs_posted) {
-
-		if (state.rx_window == 0)
-			break;
+	while (!state.all_recvs_posted && state.rx_window) {
 
 		ret = pattern->next_source(&state.cur_source);
 		if (ret == -FI_ENODATA) {
@@ -184,7 +235,7 @@ int multi_msg_recv()
 		rx_ctx_arr[offset].state = OP_PENDING;
 		state.recvs_posted++;
 		state.rx_window--;
-	};
+	}
 	return 0;
 }
 
@@ -193,10 +244,7 @@ int multi_msg_send()
 	int ret, offset;
 	fi_addr_t dest;
 
-	while (!state.all_sends_posted) {
-
-		if (state.tx_window == 0)
-			break;
+	while (!state.all_sends_posted && state.tx_window) {
 
 		ret = pattern->next_target(&state.cur_target);
 		if (ret == -FI_ENODATA) {
@@ -242,6 +290,78 @@ int multi_msg_wait()
 		rx_ctx_arr[i].state = OP_DONE;
 		tx_ctx_arr[i].state = OP_DONE;
 	}
+
+	state.rx_window = opts.window_size;
+	state.tx_window = opts.window_size;
+
+	if (state.all_recvs_posted && state.all_sends_posted)
+		state.all_completions_done = true;
+
+	return 0;
+}
+
+int multi_rma_write()
+{
+	int ret, rc;
+
+	while (!state.all_sends_posted && state.tx_window) {
+
+		ret = pattern->next_target(&state.cur_target);
+		if (ret == -FI_ENODATA) {
+			state.all_sends_posted = true;
+			break;
+		} else if (ret < 0) {
+			return ret;
+		}
+
+		snprintf((char*) tx_buf + tx_size * state.cur_target, tx_size,
+		        "Hello World! from %zu to %i on the %zuth iteration, %s test",
+		        pm_job.my_rank, state.cur_target, 
+		        (size_t) tx_seq, pattern->name);
+
+		while (1) {
+			ret = fi_write(ep, 
+				tx_buf + tx_size * state.cur_target,
+				opts.transfer_size, mr_desc, 
+				pm_job.fi_addrs[state.cur_target], 
+				pm_job.multi_iovs[state.cur_target].addr,
+				pm_job.multi_iovs[state.cur_target].key, 
+				&tx_ctx_arr[state.tx_window].context);
+			if (!ret)
+				break;
+		
+			if (ret != -FI_EAGAIN) {
+				printf("RMA write failed");
+				return ret;
+			}
+
+			rc = ft_progress(txcq, tx_seq, &tx_cq_cntr);
+			if (rc && rc != -FI_EAGAIN) {
+				printf("Failed to get rma completion");
+				return rc;
+			}
+		}
+		tx_seq++;
+	
+		state.sends_posted++;
+		state.tx_window--;
+	}
+	return 0;
+}
+
+int multi_rma_recv()
+{
+	state.all_recvs_posted = true;
+	return 0;
+}
+
+int multi_rma_wait()
+{
+	int ret;
+
+	ret = ft_get_tx_comp(tx_seq);
+	if (ret)
+		return ret;
 
 	state.rx_window = opts.window_size;
 	state.tx_window = opts.window_size;
@@ -300,6 +420,7 @@ static void pm_job_free_res()
 	free(pm_job.names);
 
 	free(pm_job.fi_addrs);
+	free(pm_job.multi_iovs);
 }
 
 int multinode_run_tests(int argc, char **argv)

--- a/fabtests/multinode/src/harness.c
+++ b/fabtests/multinode/src/harness.c
@@ -45,6 +45,16 @@
 #include <core.h>
 struct pm_job_info pm_job;
 
+static int parse_caps(char* caps)
+{
+	if (strcmp(caps, "msg") == 0) {
+		return multi_msg;
+	} else {
+		printf("Warn: Invalid capability, defaulting to msg\n");
+		return multi_msg;
+	}
+}
+
 static inline ssize_t socket_send(int sock, void *buf, size_t len, int flags)
 {
 	ssize_t ret;
@@ -281,7 +291,7 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((c = getopt(argc, argv, "n:h" CS_OPTS INFO_OPTS)) != -1) {
+	while ((c = getopt(argc, argv, "n:C:h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (c) {
 		default:
 			ft_parse_addr_opts(c, optarg, &opts);
@@ -290,6 +300,9 @@ int main(int argc, char **argv)
 			break;
 		case 'n':
 			pm_job.num_ranks = atoi(optarg);
+			break;
+		case 'C':
+			pm_job.transfer_method = parse_caps(optarg);
 			break;
 		case '?':
 		case 'h':

--- a/fabtests/multinode/src/harness.c
+++ b/fabtests/multinode/src/harness.c
@@ -49,6 +49,8 @@ static int parse_caps(char* caps)
 {
 	if (strcmp(caps, "msg") == 0) {
 		return multi_msg;
+	} else if (strcmp(caps, "rma") == 0) {
+		return multi_rma;
 	} else {
 		printf("Warn: Invalid capability, defaulting to msg\n");
 		return multi_msg;
@@ -283,7 +285,7 @@ int main(int argc, char **argv)
 	int c, ret;
 
 	opts = INIT_OPTS;
-	opts.options |= (FT_OPT_SIZE | FT_OPT_ALLOC_MULT_MR);
+	opts.options |= FT_OPT_SIZE;
 
 	pm_job.clients = NULL;
 

--- a/fabtests/multinode/src/pattern.c
+++ b/fabtests/multinode/src/pattern.c
@@ -102,11 +102,6 @@ static int mesh_next(int *cur)
 
 struct pattern_ops patterns[] = {
 	{
-		.name = "full_mesh",
-		.next_source = mesh_next,
-		.next_target = mesh_next,
-	},
-	{
 		.name = "ring",
 		.next_source = ring_next,
 		.next_target = ring_current,
@@ -120,6 +115,11 @@ struct pattern_ops patterns[] = {
 		.name = "broadcast",
 		.next_source = broadcast_gather_current,
 		.next_target = broadcast_gather_next,
+	},
+	{
+		.name = "full_mesh",
+		.next_source = mesh_next,
+		.next_target = mesh_next,
 	},
 };
 

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -201,7 +201,8 @@ complex_tests=(
 )
 
 multinode_tests=(
-	"fi_multinode"
+	"fi_multinode -C msg"
+	"fi_multinode -C rma"
 	"fi_multinode_coll"
 )
 
@@ -567,20 +568,21 @@ function complex_test {
 }
 
 function multinode_test {
-	local test=$1
+	local test="$1"
 	local s_ret=0
 	local c_ret=0
+	local c_out_arr=()
 	local num_procs=$2
 	local test_exe="${test} -n $num_procs -p \"${PROV}\"" 	
+	local c_out
 	local start_time
 	local end_time
 	local test_time
 
-
 	is_excluded "$test" && return
 
 	start_time=$(date '+%s')
-
+	
 	s_cmd="${BIN_PATH}${test_exe} ${S_ARGS} -s ${S_INTERFACE}"
 	${SERVER_CMD} "${EXPORT_ENV} $s_cmd" &> $s_outp &
 	s_pid=$!
@@ -589,36 +591,58 @@ function multinode_test {
 	c_pid_arr=()	
 	for ((i=1; i<num_procs; i++))
 	do
+		local c_out=$(mktemp fabtests.c_outp${i}.XXXXXX)
 		c_cmd="${BIN_PATH}${test_exe} ${S_ARGS} -s ${S_INTERFACE}"
-		${CLIENT_CMD} "${EXPORT_ENV} $c_cmd" &> $c_outp & 
+		${CLIENT_CMD} "${EXPORT_ENV} $c_cmd" &> $c_out & 
 		c_pid_arr+=($!)
+		c_out_arr+=($c_out)
 	done
 
 	for pid in ${c_pid_arr[*]}; do
 		wait $pid
+		c_ret=($?)||$c_ret
 	done
 	
-
 	[[ c_ret -ne 0 ]] && kill -9 $s_pid 2> /dev/null
 
 	wait $s_pid
 	s_ret=$?
+	echo "server finished"
 	
 	end_time=$(date '+%s')
 	test_time=$(compute_duration "$start_time" "$end_time")
-
+	
+	pe=1
 	if [[ $STRICT_MODE -eq 0 && $s_ret -eq $FI_ENODATA && $c_ret -eq $FI_ENODATA ]] ||
 	   [[ $STRICT_MODE -eq 0 && $s_ret -eq $FI_ENOSYS && $c_ret -eq $FI_ENOSYS ]]; then
-		print_results "$test_exe" "Notrun" "$test_time" "$s_outp" "$s_cmd" "$c_outp" "$c_cmd"
+		print_results "$test_exe" "Notrun" "$test_time" "$s_outp" "$s_cmd" "" "$c_cmd"
+		for c_out in "${c_out_arr[@]}" 
+		do
+			printf -- "  client_stdout $pe: |\n"
+			sed -e 's/^/    /' < $c_out
+			pe=$((pe+1))
+		done
 		skip_count+=1
 	elif [ $s_ret -ne 0 -o $c_ret -ne 0 ]; then
-		print_results "$test_exe" "Fail" "$test_time" "$s_outp" "$s_cmd" "$c_outp" "$c_cmd"
+		print_results "$test_exe" "Fail" "$test_time" "$s_outp" "$s_cmd" "" "$c_cmd"
+		for c_out in "${c_out_arr[@]}" 
+		do
+			printf -- "  client_stdout $pe: |\n"
+			sed -e 's/^/    /' < $c_out
+			pe=$((pe+1))
+		done
 		if [ $s_ret -eq 124 -o $c_ret -eq 124 ]; then
 			cleanup
 		fi
 		fail_count+=1
 	else
-		print_results "$test_exe" "Pass" "$test_time" "$s_outp" "$s_cmd" "$c_outp" "$c_cmd"
+		print_results "$test_exe" "Pass" "$test_time" "$s_outp" "$s_cmd" "" "$c_cmd"
+		for c_out in "${c_out_arr[@]}" 
+		do
+			printf -- "  client_stdout $pe: |\n"
+			sed -e 's/^/    /' < $c_out
+			pe=$((pe+1))
+		done
 		pass_count+=1
 	fi
 }
@@ -644,6 +668,7 @@ function main {
 
 	set_core_util
 	set_excludes
+	
 
 	if [[ $1 == "quick" ]]; then
 		local -r tests="unit functional short"
@@ -651,7 +676,7 @@ function main {
 		local -r tests="complex"
 		complex_type=$1
 	else
-		local -r tests=$(echo $1 | sed 's/all/unit,functional,standard,complex/g' | tr ',' ' ')
+		local -r tests=$(echo $1 | sed 's/all/unit,functional,standard,complex,multinode/g' | tr ',' ' ')
 		if [[ $1 == "all" || $1 == "complex" ]]; then
 			complex_type="all"
 		fi
@@ -693,12 +718,11 @@ function main {
 		complex)
 			for test in "${complex_tests[@]}"; do
 				complex_test $test $complex_type
-
 			done
 		;;
 		multinode)
 			for test in "${multinode_tests[@]}"; do
-					multinode_test $test 3
+					multinode_test "$test" 3
 			done
 		;;
 		*)

--- a/fabtests/test_configs/sockets/sockets.exclude
+++ b/fabtests/test_configs/sockets/sockets.exclude
@@ -2,4 +2,3 @@
 
 -e dgram
 dgram
-multinode


### PR DESCRIPTION
By specifying rma with a -C flag, the multinode tests will run all of the normal patterns over RMA instead of MSG. msg can also be specified through the -C flag, but is the default. There are a few changes to shared.c to help with the memory registration and key exchange. By having one large buffer that is divided up for each process to read and write from, fewer keys need to be exchanged to set up the RMA exchanges. 