### PR TITLE
v1.8: pingpong: selectively AV insert local address

### DIFF
--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -1786,13 +1786,16 @@ static int pp_init_fabric(struct ct_pingpong *ct)
 				   NULL);
 		if (ret)
 			return ret;
-		ret = pp_av_insert(ct->av, ct->local_name, 1, &(ct->local_fi_addr), 0,
-				   NULL);
+		if (ct->fi->domain_attr->caps & FI_LOCAL_COMM)
+			ret = pp_av_insert(ct->av, ct->local_name, 1,
+					&(ct->local_fi_addr), 0, NULL);
 	} else {
-		ret = pp_av_insert(ct->av, ct->local_name, 1, &(ct->local_fi_addr), 0,
-				   NULL);
-		if (ret)
-			return ret;
+		if (ct->fi->domain_attr->caps & FI_LOCAL_COMM) {
+			ret = pp_av_insert(ct->av, ct->local_name, 1,
+					&(ct->local_fi_addr), 0, NULL);
+			if (ret)
+				return ret;
+		}
 		ret = pp_av_insert(ct->av, ct->rem_name, 1, &(ct->remote_fi_addr), 0,
 				   NULL);
 	}


### PR DESCRIPTION
Only insert the local address into the AV if the provider supports
FI_LOCAL_COMM.  This fixes usnic with fi_pingpong.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>
(cherry picked from commit 3bf9513f284a89ae834dc58680634a9f817bc49c)

Refs #5497