### PR TITLE
prov/efa : remove EFA device name check

### DIFF
--- a/prov/efa/src/efa_verbs/efa_init.c
+++ b/prov/efa/src/efa_verbs/efa_init.c
@@ -186,9 +186,6 @@ static int efa_find_sysfs_devs(struct ibv_sysfs_dev **sysfs_dev_list)
 
 		sysfs_dev->ibdev_name[sizeof(sysfs_dev->ibdev_name) - 1] = '\0';
 
-		if (strncmp(sysfs_dev->ibdev_name, "efa_", 4) != 0)
-			continue;
-
 		if (!check_snprintf(sysfs_dev->ibdev_path,
 				    sizeof(sysfs_dev->ibdev_path),
 				    "%s/class/infiniband/%s", sysfs_path,


### PR DESCRIPTION
Currently, efa_find_sysfs_devs() which check ibdev name, and will skip
a device whose name does not start with efa_. This name check is
unnecessary, because driver_init() already checks for vendor ID and
device ID, which is sufficient.

The name check will also cause problem on CentOS7 platform, when rdma-core
v27 is used. Under that case, rdma-core will rename EFA device name to
rdmap0s6.

This patch address the issue by removing the name check.

Signed-off-by: Wei Zhang <wzam@amazon.com>