### PR TITLE
prov/efa: Detect CMA systemcall directly

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -62,6 +62,8 @@
 #include <ofi_recvwin.h>
 #include <ofi_perf.h>
 
+#include <sys/wait.h>
+
 #define RXR_MAJOR_VERSION	(2)
 #define RXR_MINOR_VERSION	(0)
 #define RXR_PROTOCOL_VERSION	(3)


### PR DESCRIPTION
Detect the availability of CMA system calls by directly
calling process_vm_writev during EFA initialization.

Earlier, we were trying to put it in the getinfo function
of SHM provider. But there are two issues with that.
1. getinfo could be invoked anytime during the lifetime of
   the application. Therefore, copy-on-write could silently
   corrupt the application data if those buffers are pinned.
2. Not all providers support fork, e.g., verbs.

So we decide to move this detection in EFA_INI, as it will
be invoked once before any memory registration or libfabric
object allocation. Copy-on-write will not be a problem.

We are also working on the large message segmentation. Once
it is landed, we can delay the CMA detection till the real
communication phase between local peers. If CMA is not
available, communication will fallback to segmentation logic.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>