### PR TITLE
[1.9.x] prov/efa: Detect CMA systemcall directly

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -62,6 +62,8 @@
 #include <ofi_recvwin.h>
 #include <ofi_perf.h>
 
+#include <sys/wait.h>
+
 #define RXR_MAJOR_VERSION	(2)
 #define RXR_MINOR_VERSION	(0)
 #define RXR_PROTOCOL_VERSION	(3)


### PR DESCRIPTION
Cherry-picking 0fc2e9955072d5cc348818131259492cda3d7b6e from master into 1.9.x, where shared-memory support was enabled by default in the EFA provider.