### PR TITLE
prov/shm : Let non-tagged recv also progress unexpected queue

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -186,7 +186,8 @@ struct smr_ep {
 	struct smr_queue	trecv_queue;
 	struct smr_unexp_fs	*unexp_fs;
 	struct smr_pend_fs	*pend_fs;
-	struct smr_queue	unexp_queue;
+	struct smr_queue	unexp_msg_queue;
+	struct smr_queue	unexp_tagged_queue;
 };
 
 #define smr_ep_rx_flags(smr_ep) ((smr_ep)->util_ep.rx_op_flags)
@@ -245,6 +246,9 @@ int smr_rx_src_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 uint64_t smr_rx_cq_flags(uint32_t op, uint16_t op_flags);
 
 void smr_ep_progress(struct util_ep *util_ep);
-int smr_progress_unexp(struct smr_ep *ep, struct smr_ep_entry *entry);
+
+int smr_progress_unexp(struct smr_ep *ep,
+		       struct smr_ep_entry *entry,
+		       struct smr_queue *unexp_queue);
 
 #endif

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -209,12 +209,26 @@ static int smr_match_tagged(struct dlist_entry *item, const void *args)
 	       smr_match_tag(recv_entry->tag, recv_entry->ignore, attr->tag); 
 } 
 
-static int smr_match_unexp(struct dlist_entry *item, const void *args)
+static int smr_match_unexp_msg(struct dlist_entry *item, const void *args)
 {
 	struct smr_match_attr *attr = (struct smr_match_attr *)args;
 	struct smr_unexp_msg *unexp_msg;
 
 	unexp_msg = container_of(item, struct smr_unexp_msg, entry);
+	assert(unexp_msg->cmd.msg.hdr.op == ofi_op_msg);
+	return smr_match_addr(unexp_msg->cmd.msg.hdr.addr, attr->addr);
+}
+
+static int smr_match_unexp_tagged(struct dlist_entry *item, const void *args)
+{
+	struct smr_match_attr *attr = (struct smr_match_attr *)args;
+	struct smr_unexp_msg *unexp_msg;
+
+	unexp_msg = container_of(item, struct smr_unexp_msg, entry);
+	if (unexp_msg->cmd.msg.hdr.op == ofi_op_msg)
+		return smr_match_addr(unexp_msg->cmd.msg.hdr.addr, attr->addr);
+
+	assert(unexp_msg->cmd.msg.hdr.op == ofi_op_tagged);
 	return smr_match_addr(unexp_msg->cmd.msg.hdr.addr, attr->addr) &&
 	       smr_match_tag(unexp_msg->cmd.msg.hdr.tag, attr->ignore,
 			     attr->tag);
@@ -480,7 +494,8 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ep->pend_fs = smr_pend_fs_create(info->tx_attr->size, NULL, NULL);
 	smr_init_queue(&ep->recv_queue, smr_match_msg);
 	smr_init_queue(&ep->trecv_queue, smr_match_tagged);
-	smr_init_queue(&ep->unexp_queue, smr_match_unexp);
+	smr_init_queue(&ep->unexp_msg_queue, smr_match_unexp_msg);
+	smr_init_queue(&ep->unexp_tagged_queue, smr_match_unexp_tagged);
 
 	ep->min_multi_recv_size = SMR_INJECT_SIZE;
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -353,7 +353,13 @@ static int smr_progress_cmd_msg(struct smr_ep *ep, struct smr_cmd *cmd)
 		unexp = freestack_pop(ep->unexp_fs);
 		memcpy(&unexp->cmd, cmd, sizeof(*cmd));
 		ofi_cirque_discard(smr_cmd_queue(ep->region));
-		dlist_insert_tail(&unexp->entry, &ep->unexp_queue.list);
+		if (cmd->msg.hdr.op == ofi_op_msg) {
+			dlist_insert_tail(&unexp->entry, &ep->unexp_msg_queue.list);
+		} else {
+			assert(cmd->msg.hdr.op == ofi_op_tagged);
+			dlist_insert_tail(&unexp->entry, &ep->unexp_tagged_queue.list);
+		}
+
 		return ret;
 	}
 	entry = container_of(dlist_entry, struct smr_ep_entry, entry);
@@ -596,7 +602,9 @@ void smr_ep_progress(struct util_ep *util_ep)
 	smr_progress_cmd(ep);
 }
 
-int smr_progress_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
+int smr_progress_unexp(struct smr_ep *ep,
+		       struct smr_ep_entry *entry,
+		       struct smr_queue *unexp_queue)
 {
 	struct smr_match_attr match_attr;
 	struct smr_unexp_msg *unexp_msg;
@@ -615,8 +623,8 @@ int smr_progress_unexp(struct smr_ep *ep, struct smr_ep_entry *entry)
 	match_attr.addr = entry->addr;
 	match_attr.ignore = entry->ignore;
 	match_attr.tag = entry->tag;
-	dlist_entry = dlist_remove_first_match(&ep->unexp_queue.list,
-					       ep->unexp_queue.match_func,
+	dlist_entry = dlist_remove_first_match(&unexp_queue->list,
+					       unexp_queue->match_func,
 					       &match_attr);
 	if (!dlist_entry) {
 		ret = -FI_ENOMSG;


### PR DESCRIPTION
A recent commit:

        371456d910cf8435fa8f5f606c4207c9a5cba47d

titled

"prov/shm: fix unexpected message on empty recv queue"

has put unexpected command into unexpected msg queue.

Because untagged recv functions (smr_recv(), smr_recvv() and
smr_recvmsg()) will not process unexpected msg queue, dead
lock can sometimes happen.

This patch fix the issue by letting untagged recv functions
progress unexpected msg queue before put smr_entry into
ep->recv_list.

Signed-off-by: Wei Zhang <wzam@amazon.com>