### PR TITLE
core: Fix locking around fabric list

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -904,7 +904,6 @@ void fid_list_remove(struct dlist_entry *fid_list, fastlock_t *lock,
 		     struct fid *fid);
 
 void ofi_fabric_insert(struct util_fabric *fabric);
-struct util_fabric *ofi_fabric_find(struct util_fabric_info *fabric_info);
 void ofi_fabric_remove(struct util_fabric *fabric);
 
 /*

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -146,6 +146,10 @@ fi_getinfo, if no domain was specified, but the user has an opened
 instance of the named domain, this will reference the first opened
 instance.  If no instance has been opened, this field will be NULL.
 
+The domain instance returned by fi_getinfo should only be considered
+valid if the application does not close any domain instances from
+another thread while fi_getinfo is being processed.
+
 ## Name
 
 The name of the access domain.

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -176,6 +176,10 @@ fi_getinfo, if no fabric was specified, but the user has an opened
 instance of the named fabric, this will reference the first opened
 instance.  If no instance has been opened, this field will be NULL.
 
+The fabric instance returned by fi_getinfo should only be considered
+valid if the application does not close any fabric instances from
+another thread while fi_getinfo is being processed.
+
 ## name
 
 A fabric identifier.


### PR DESCRIPTION
ofi_find_fabric locks around the fabric list, but once the
lock is released, the fabric could be destroyed by the
app.  Hold the lock around accessing the fabric object.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

Fixes #5530 