### PR TITLE
prov/verbs: Fix null dereference in fi_ibv_eq_entry

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -245,9 +245,9 @@ struct fi_ibv_eq_entry {
 	uint32_t		event;
 	size_t			len;
 	union {
-		char 			entry[0];
 		struct fi_eq_entry 	*eq_entry;
 		struct fi_eq_cm_entry	*cm_entry;
+		uint8_t 		data[0];
 	};
 };
 


### PR DESCRIPTION
fi_ibv_eq_remove_events() will remove all events from the EQ
that reference a specific CQ or EQ.  However, the CQ and EQ
fields in fi_ibv_eq_entry belong to a union.  There's no
guarantee that either has been set.  When the event data is
used instead (or no event data is present), then attempting to
access the eq/cq field can result in dereferencing a null
pointer.

Check the event type before dereferencing the union
members.  Rename the entry member to data, to indicate that
it is only storing data associated with the event.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>