### PR TITLE
Fix compilation with -fno-common

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -160,7 +160,7 @@ struct smr_ep_name {
 	struct dlist_entry entry;
 };
 
-struct dlist_entry ep_name_list;
+extern struct dlist_entry ep_name_list;
 
 struct smr_region;
 

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -126,8 +126,8 @@ struct efa_domain {
 	struct ofi_mr_cache	cache;
 };
 
-struct fi_ops_mr efa_domain_mr_ops;
-struct fi_ops_mr efa_domain_mr_cache_ops;
+extern struct fi_ops_mr efa_domain_mr_ops;
+extern struct fi_ops_mr efa_domain_mr_cache_ops;
 int efa_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 			   struct ofi_mr_entry *entry);
 void efa_mr_cache_entry_dereg(struct ofi_mr_cache *cache,
@@ -385,8 +385,8 @@ static inline uint32_t align_up_queue_size(uint32_t req)
 extern const struct efa_ep_domain efa_rdm_domain;
 extern const struct efa_ep_domain efa_dgrm_domain;
 
-struct fi_ops_cm efa_ep_cm_ops;
-struct fi_ops_msg efa_ep_msg_ops;
+extern struct fi_ops_cm efa_ep_cm_ops;
+extern struct fi_ops_msg efa_ep_msg_ops;
 
 const struct fi_info *efa_get_efa_info(const char *domain_name);
 int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -42,6 +42,7 @@
 
 #include <ofi_shm.h>
 
+struct dlist_entry ep_name_list;
 
 static void smr_peer_addr_init(struct smr_addr *peer)
 {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -617,21 +617,21 @@ struct fi_ibv_domain *fi_ibv_ep_to_domain(struct fi_ibv_ep *ep)
 			    util_domain);
 }
 
-struct fi_ops_atomic fi_ibv_msg_ep_atomic_ops;
-struct fi_ops_atomic fi_ibv_msg_xrc_ep_atomic_ops;
-struct fi_ops_cm fi_ibv_msg_ep_cm_ops;
-struct fi_ops_cm fi_ibv_msg_xrc_ep_cm_ops;
-const struct fi_ops_msg fi_ibv_msg_ep_msg_ops_ts;
-const struct fi_ops_msg fi_ibv_msg_ep_msg_ops;
-const struct fi_ops_msg fi_ibv_dgram_msg_ops_ts;
-const struct fi_ops_msg fi_ibv_dgram_msg_ops;
-const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops;
-const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops_ts;
-const struct fi_ops_msg fi_ibv_msg_srq_xrc_ep_msg_ops;
-struct fi_ops_rma fi_ibv_msg_ep_rma_ops_ts;
-struct fi_ops_rma fi_ibv_msg_ep_rma_ops;
-struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops_ts;
-struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops;
+extern struct fi_ops_atomic fi_ibv_msg_ep_atomic_ops;
+extern struct fi_ops_atomic fi_ibv_msg_xrc_ep_atomic_ops;
+extern struct fi_ops_cm fi_ibv_msg_ep_cm_ops;
+extern struct fi_ops_cm fi_ibv_msg_xrc_ep_cm_ops;
+extern const struct fi_ops_msg fi_ibv_msg_ep_msg_ops_ts;
+extern const struct fi_ops_msg fi_ibv_msg_ep_msg_ops;
+extern const struct fi_ops_msg fi_ibv_dgram_msg_ops_ts;
+extern const struct fi_ops_msg fi_ibv_dgram_msg_ops;
+extern const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops;
+extern const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops_ts;
+extern const struct fi_ops_msg fi_ibv_msg_srq_xrc_ep_msg_ops;
+extern struct fi_ops_rma fi_ibv_msg_ep_rma_ops_ts;
+extern struct fi_ops_rma fi_ibv_msg_ep_rma_ops;
+extern struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops_ts;
+extern struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops;
 
 #define FI_IBV_XRC_VERSION	1
 


### PR DESCRIPTION
Starting from the upcoming GCC release 10, the default of -fcommon option will change to -fno-common:
In C, global variables with multiple tentative definitions will result in linker errors.
Global variable accesses are also more efficient on various targets.

This patches adds missing extern keywords to global variables in headers and declarations outside of headers when needed.

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>