### PR TITLE
prov/shm: move ep_name_list initialization/cleanup

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -257,6 +257,7 @@ struct smr_attr {
 	size_t		tx_count;
 };
 
+void	smr_cleanup(void);
 int	smr_map_create(const struct fi_provider *prov, int peer_count,
 		       struct smr_map **map);
 int	smr_map_to_region(const struct fi_provider *prov,

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -884,6 +884,9 @@ static void fi_efa_fini(void)
 		efa_dealloc_ctx(ctx_list[i]);
 	efa_device_free_context_list(ctx_list);
 	efa_device_free();
+#if HAVE_EFA_DL
+	smr_cleanup();
+#endif 
 }
 
 struct fi_provider efa_prov = {

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -136,13 +136,7 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 
 static void smr_fini(void)
 {
-	struct smr_ep_name *ep_name;
-	struct dlist_entry *tmp;
-
-	dlist_foreach_container_safe(&ep_name_list, struct smr_ep_name,
-				     ep_name, entry, tmp) {
-		free(ep_name);
-	}
+	smr_cleanup();
 }
 
 struct fi_provider smr_prov = {
@@ -162,7 +156,6 @@ struct util_prov smr_util_prov = {
 
 SHM_INI
 {
-	dlist_init(&ep_name_list);
 
 	/* Signal handlers to cleanup tmpfs files on an unclean shutdown */
 	smr_reg_sig_hander(SIGBUS);

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -44,6 +44,18 @@
 
 struct dlist_entry ep_name_list;
 
+DEFINE_LIST(ep_name_list);
+
+void smr_cleanup(void)
+{
+	struct smr_ep_name *ep_name;
+	struct dlist_entry *tmp;
+
+	dlist_foreach_container_safe(&ep_name_list, struct smr_ep_name,
+				     ep_name, entry, tmp)
+		free(ep_name);
+}
+
 static void smr_peer_addr_init(struct smr_addr *peer)
 {
 	memset(peer->name, 0, NAME_MAX);


### PR DESCRIPTION
DL builds do not call ini/fini and will not properly
initialize or cleanup the ep_name_list.

Move the initialization out of ini and use DEFINE_LIST
to initialize.

Move the cleanup out of fini and into a cleanup function
to be called by any provider using the utility shm code.
Call this function on shm fabric cleanup.

Signed-off-by: aingerson <alexia.ingerson@intel.com>