### PR TITLE
prov/verbs: Replace fi_ibv_ prefix with vrb_

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -88,11 +88,11 @@
 #define VERBS_PROV_NAME "verbs"
 #define VERBS_PROV_VERS FI_VERSION(1,0)
 
-#define VERBS_DBG(subsys, ...) FI_DBG(&fi_ibv_prov, subsys, __VA_ARGS__)
-#define VERBS_INFO(subsys, ...) FI_INFO(&fi_ibv_prov, subsys, __VA_ARGS__)
+#define VERBS_DBG(subsys, ...) FI_DBG(&vrb_prov, subsys, __VA_ARGS__)
+#define VERBS_INFO(subsys, ...) FI_INFO(&vrb_prov, subsys, __VA_ARGS__)
 #define VERBS_INFO_ERRNO(subsys, fn, errno) VERBS_INFO(subsys, fn ": %s(%d)\n",	\
 		strerror(errno), errno)
-#define VERBS_WARN(subsys, ...) FI_WARN(&fi_ibv_prov, subsys, __VA_ARGS__)
+#define VERBS_WARN(subsys, ...) FI_WARN(&vrb_prov, subsys, __VA_ARGS__)
 
 
 #define VERBS_INJECT_FLAGS(ep, len, flags) ((((flags) & FI_INJECT) || \
@@ -113,33 +113,33 @@
 
 #define VERBS_NO_COMP_FLAG	((uint64_t)-1)
 
-#define FI_IBV_CM_DATA_SIZE	(56)
-#define VERBS_CM_DATA_SIZE	(FI_IBV_CM_DATA_SIZE -		\
-				 sizeof(struct fi_ibv_cm_data_hdr))
+#define VRB_CM_DATA_SIZE	(56)
+#define VERBS_CM_DATA_SIZE	(VRB_CM_DATA_SIZE -		\
+				 sizeof(struct vrb_cm_data_hdr))
 
-#define FI_IBV_CM_REJ_CONSUMER_DEFINED	28
-#define FI_IBV_CM_REJ_SIDR_CONSUMER_DEFINED	2
+#define VRB_CM_REJ_CONSUMER_DEFINED	28
+#define VRB_CM_REJ_SIDR_CONSUMER_DEFINED	2
 
 #define VERBS_DGRAM_MSG_PREFIX_SIZE	(40)
 
-#define FI_IBV_EP_TYPE(info)						\
+#define VRB_EP_TYPE(info)						\
 	((info && info->ep_attr) ? info->ep_attr->type : FI_EP_MSG)
-#define FI_IBV_EP_PROTO(info)						\
+#define VRB_EP_PROTO(info)						\
 	(((info) && (info)->ep_attr) ? (info)->ep_attr->protocol :	\
 					FI_PROTO_UNSPEC)
 
-#define FI_IBV_MEM_ALIGNMENT (64)
-#define FI_IBV_BUF_ALIGNMENT (4096) /* TODO: Page or MTU size */
-#define FI_IBV_POOL_BUF_CNT (100)
+#define VRB_MEM_ALIGNMENT (64)
+#define VRB_BUF_ALIGNMENT (4096) /* TODO: Page or MTU size */
+#define VRB_POOL_BUF_CNT (100)
 
 #define VERBS_ANY_DOMAIN "verbs_any_domain"
 #define VERBS_ANY_FABRIC "verbs_any_fabric"
 
-extern struct fi_provider fi_ibv_prov;
-extern struct util_prov fi_ibv_util_prov;
+extern struct fi_provider vrb_prov;
+extern struct util_prov vrb_util_prov;
 extern struct dlist_entry verbs_devs;
 
-extern struct fi_ibv_gl_data {
+extern struct vrb_gl_data {
 	int	def_tx_size;
 	int	def_rx_size;
 	int	def_tx_iov_limit;
@@ -169,7 +169,7 @@ extern struct fi_ibv_gl_data {
 		int	prefer_xrc;
 		char	*xrcd_filename;
 	} msg;
-} fi_ibv_gl_data;
+} vrb_gl_data;
 
 struct verbs_addr {
 	struct dlist_entry entry;
@@ -207,18 +207,18 @@ struct ofi_ib_ud_ep_name {
 #define VERBS_IB_UD_NS_ANY_SERVICE	0
 
 static inline
-int fi_ibv_dgram_ns_is_service_wildcard(void *svc)
+int vrb_dgram_ns_is_service_wildcard(void *svc)
 {
 	return (*(int *)svc == VERBS_IB_UD_NS_ANY_SERVICE);
 }
 
 static inline
-int fi_ibv_dgram_ns_service_cmp(void *svc1, void *svc2)
+int vrb_dgram_ns_service_cmp(void *svc1, void *svc2)
 {
 	int service1 = *(int *)svc1, service2 = *(int *)svc2;
 
-	if (fi_ibv_dgram_ns_is_service_wildcard(svc1) ||
-	    fi_ibv_dgram_ns_is_service_wildcard(svc2))
+	if (vrb_dgram_ns_is_service_wildcard(svc1) ||
+	    vrb_dgram_ns_is_service_wildcard(svc2))
 		return 0;
 	return (service1 < service2) ? -1 : (service1 > service2);
 }
@@ -230,17 +230,17 @@ struct verbs_dev_info {
 };
 
 
-struct fi_ibv_fabric {
+struct vrb_fabric {
 	struct util_fabric	util_fabric;
 	const struct fi_info	*info;
 	struct util_ns		name_server;
 };
 
-int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
+int vrb_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		  void *context);
-int fi_ibv_find_fabric(const struct fi_fabric_attr *attr);
+int vrb_find_fabric(const struct fi_fabric_attr *attr);
 
-struct fi_ibv_eq_entry {
+struct vrb_eq_entry {
 	struct dlist_entry	item;
 	uint32_t		event;
 	size_t			len;
@@ -251,7 +251,7 @@ struct fi_ibv_eq_entry {
 	};
 };
 
-typedef int (*fi_ibv_trywait_func)(struct fid *fid);
+typedef int (*vrb_trywait_func)(struct fid *fid);
 
 /* An OFI indexer is used to maintain a unique connection request to
  * endpoint mapping. The key is a 32-bit value (referred to as a
@@ -266,9 +266,9 @@ typedef int (*fi_ibv_trywait_func)(struct fid *fid);
 #define VERBS_CONN_TAG_INDEX_BITS	18
 #define VERBS_CONN_TAG_INVALID		0xFFFFFFFF	/* Key is not valid */
 
-struct fi_ibv_eq {
+struct vrb_eq {
 	struct fid_eq		eq_fid;
-	struct fi_ibv_fabric	*fab;
+	struct vrb_fabric	*fab;
 	fastlock_t		lock;
 	struct dlistfd_head	list_head;
 	struct rdma_event_channel *channel;
@@ -300,17 +300,17 @@ struct fi_ibv_eq {
 	} xrc;
 };
 
-int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		   struct fid_eq **eq, void *context);
-int fi_ibv_eq_trywait(struct fi_ibv_eq *eq);
-void fi_ibv_eq_remove_events(struct fi_ibv_eq *eq, struct fid *fid);
+int vrb_eq_trywait(struct vrb_eq *eq);
+void vrb_eq_remove_events(struct vrb_eq *eq, struct fid *fid);
 
-int fi_ibv_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
+int vrb_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 		   struct fid_av **av, void *context);
 
-struct fi_ibv_pep {
+struct vrb_pep {
 	struct fid_pep		pep_fid;
-	struct fi_ibv_eq	*eq;
+	struct vrb_eq	*eq;
 	struct rdma_cm_id	*id;
 
 	/* XRC uses SIDR based RDMA CM exchanges for setting up
@@ -324,7 +324,7 @@ struct fi_ibv_pep {
 	struct fi_info		*info;
 };
 
-struct fi_ops_cm *fi_ibv_pep_ops_cm(struct fi_ibv_pep *pep);
+struct fi_ops_cm *vrb_pep_ops_cm(struct vrb_pep *pep);
 
 
 #if VERBS_HAVE_QUERY_EX
@@ -338,7 +338,7 @@ enum {
 	VRB_USE_ODP = BIT(1),
 };
 
-struct fi_ibv_domain {
+struct vrb_domain {
 	struct util_domain		util_domain;
 	struct ibv_context		*verbs;
 	struct ibv_pd			*pd;
@@ -346,7 +346,7 @@ struct fi_ibv_domain {
 	enum fi_ep_type			ep_type;
 	struct fi_info			*info;
 	/* The EQ is utilized by verbs/MSG */
-	struct fi_ibv_eq		*eq;
+	struct vrb_eq		*eq;
 	uint64_t			eq_flags;
 
 	/* Indicates that MSG endpoints should use the XRC transport.
@@ -368,16 +368,16 @@ struct fi_ibv_domain {
 	struct ofi_mr_cache		cache;
 };
 
-struct fi_ibv_cq;
-typedef void (*fi_ibv_cq_read_entry)(struct ibv_wc *wc, void *buf);
+struct vrb_cq;
+typedef void (*vrb_cq_read_entry)(struct ibv_wc *wc, void *buf);
 
 struct vrb_wc_entry {
 	struct slist_entry	entry;
 	struct ibv_wc		wc;
 };
 
-struct fi_ibv_srq_ep;
-struct fi_ibv_cq {
+struct vrb_srq_ep;
+struct vrb_cq {
 	struct util_cq		util_cq;
 	struct ibv_comp_channel	*channel;
 	struct ibv_cq		*cq;
@@ -386,7 +386,7 @@ struct fi_ibv_cq {
 	enum fi_cq_wait_cond	wait_cond;
 	struct ibv_wc		wc;
 	int			signal_fd[2];
-	fi_ibv_cq_read_entry	read_entry;
+	vrb_cq_read_entry	read_entry;
 	struct slist		saved_wc_list;
 	ofi_atomic32_t		nevents;
 	struct ofi_bufpool	*wce_pool;
@@ -404,25 +404,25 @@ struct fi_ibv_cq {
 	struct ofi_bufpool	*ctx_pool;
 };
 
-int fi_ibv_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
+int vrb_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		   struct fid_cq **cq, void *context);
-int fi_ibv_cq_trywait(struct fi_ibv_cq *cq);
+int vrb_cq_trywait(struct vrb_cq *cq);
 
-struct fi_ibv_mem_desc {
+struct vrb_mem_desc {
 	struct fid_mr		mr_fid;
 	struct ibv_mr		*mr;
-	struct fi_ibv_domain	*domain;
+	struct vrb_domain	*domain;
 	size_t			len;
 	/* this field is used only by MR cache operations */
 	struct ofi_mr_entry	*entry;
 };
 
-extern struct fi_ops_mr fi_ibv_mr_ops;
-extern struct fi_ops_mr fi_ibv_mr_cache_ops;
+extern struct fi_ops_mr vrb_mr_ops;
+extern struct fi_ops_mr vrb_mr_cache_ops;
 
-int fi_ibv_mr_cache_add_region(struct ofi_mr_cache *cache,
+int vrb_mr_cache_add_region(struct ofi_mr_cache *cache,
 			       struct ofi_mr_entry *entry);
-void fi_ibv_mr_cache_delete_region(struct ofi_mr_cache *cache,
+void vrb_mr_cache_delete_region(struct ofi_mr_cache *cache,
 				   struct ofi_mr_entry *entry);
 
 /*
@@ -430,7 +430,7 @@ void fi_ibv_mr_cache_delete_region(struct ofi_mr_cache *cache,
  * maintain a list of validated pre-posted receives to post once
  * the SRQ is created.
  */
-struct fi_ibv_xrc_srx_prepost {
+struct vrb_xrc_srx_prepost {
 	struct slist_entry	prepost_entry;
 	void			*buf;
 	void			*desc;
@@ -439,10 +439,10 @@ struct fi_ibv_xrc_srx_prepost {
 	fi_addr_t		src_addr;
 };
 
-struct fi_ibv_srq_ep {
+struct vrb_srq_ep {
 	struct fid_ep		ep_fid;
 	struct ibv_srq		*srq;
-	struct fi_ibv_domain	*domain;
+	struct vrb_domain	*domain;
 
 	/* For XRC SRQ only */
 	struct {
@@ -456,33 +456,33 @@ struct fi_ibv_srq_ep {
 		/* The RX CQ associated with this XRC SRQ. This field
 		 * and the srq_entry should only be modified while holding
 		 * the associted cq::xrc.srq_list_lock. */
-		struct fi_ibv_cq	*cq;
+		struct vrb_cq	*cq;
 
 		/* The CQ maintains a list of XRC SRQ associated with it */
 		struct dlist_entry	srq_entry;
 	} xrc;
 };
 
-int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
+int vrb_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		       struct fid_ep **rx_ep, void *context);
 
-static inline int fi_ibv_is_xrc(struct fi_info *info)
+static inline int vrb_is_xrc(struct fi_info *info)
 {
-	return (FI_IBV_EP_TYPE(info) == FI_EP_MSG) &&
-	       (FI_IBV_EP_PROTO(info) == FI_PROTO_RDMA_CM_IB_XRC);
+	return (VRB_EP_TYPE(info) == FI_EP_MSG) &&
+	       (VRB_EP_PROTO(info) == FI_PROTO_RDMA_CM_IB_XRC);
 }
 
-int fi_ibv_domain_xrc_init(struct fi_ibv_domain *domain);
-int fi_ibv_domain_xrc_cleanup(struct fi_ibv_domain *domain);
+int vrb_domain_xrc_init(struct vrb_domain *domain);
+int vrb_domain_xrc_cleanup(struct vrb_domain *domain);
 
-enum fi_ibv_ini_qp_state {
-	FI_IBV_INI_QP_UNCONNECTED,
-	FI_IBV_INI_QP_CONNECTING,
-	FI_IBV_INI_QP_CONNECTED
+enum vrb_ini_qp_state {
+	VRB_INI_QP_UNCONNECTED,
+	VRB_INI_QP_CONNECTING,
+	VRB_INI_QP_CONNECTED
 };
 
-#define FI_IBV_NO_INI_TGT_QPNUM 0
-#define FI_IBV_RECIP_CONN	1
+#define VRB_NO_INI_TGT_QPNUM 0
+#define VRB_RECIP_CONN	1
 
 /*
  * An XRC transport INI QP connection can be shared within a process to
@@ -490,17 +490,17 @@ enum fi_ibv_ini_qp_state {
  * only accessed during connection setup and tear down and should be
  * done while holding the domain:eq:lock.
  */
-struct fi_ibv_ini_shared_conn {
+struct vrb_ini_shared_conn {
 	/* To share, EP must have same remote peer host addr and TX CQ */
 	struct sockaddr			*peer_addr;
-	struct fi_ibv_cq		*tx_cq;
+	struct vrb_cq		*tx_cq;
 
 	/* The physical INI/TGT QPN connection. Virtual connections to the
 	 * same remote peer and TGT QPN will share this connection, with
 	 * the remote end opening the specified XRC TGT QPN for sharing
 	 * During the physical connection setup, phys_conn_id identifies
 	 * the RDMA CM ID (and MSG_EP) associated with the operation. */
-	enum fi_ibv_ini_qp_state	state;
+	enum vrb_ini_qp_state	state;
 	struct rdma_cm_id		*phys_conn_id;
 	struct ibv_qp			*ini_qp;
 	uint32_t			tgt_qpn;
@@ -512,13 +512,13 @@ struct fi_ibv_ini_shared_conn {
 	ofi_atomic32_t			ref_cnt;
 };
 
-enum fi_ibv_xrc_ep_conn_state {
-	FI_IBV_XRC_UNCONNECTED,
-	FI_IBV_XRC_ORIG_CONNECTING,
-	FI_IBV_XRC_ORIG_CONNECTED,
-	FI_IBV_XRC_RECIP_CONNECTING,
-	FI_IBV_XRC_CONNECTED,
-	FI_IBV_XRC_ERROR
+enum vrb_xrc_ep_conn_state {
+	VRB_XRC_UNCONNECTED,
+	VRB_XRC_ORIG_CONNECTING,
+	VRB_XRC_ORIG_CONNECTED,
+	VRB_XRC_RECIP_CONNECTING,
+	VRB_XRC_CONNECTED,
+	VRB_XRC_ERROR
 };
 
 /*
@@ -526,7 +526,7 @@ enum fi_ibv_xrc_ep_conn_state {
  * establishment and can be freed once bidirectional connectivity
  * is established.
  */
-struct fi_ibv_xrc_ep_conn_setup {
+struct vrb_xrc_ep_conn_setup {
 	/* The connection tag is used to associate the reciprocal
 	 * XRC INI/TGT QP connection request in the reverse direction
 	 * with the original request. The tag is created by the
@@ -537,16 +537,16 @@ struct fi_ibv_xrc_ep_conn_setup {
 	/* Delivery of the FI_CONNECTED event is delayed until
 	 * bidirectional connectivity is established. */
 	size_t				event_len;
-	uint8_t				event_data[FI_IBV_CM_DATA_SIZE];
+	uint8_t				event_data[VRB_CM_DATA_SIZE];
 
 	/* Connection request may have to queue waiting for the
 	 * physical XRC INI/TGT QP connection to complete. */
 	int				pending_recip;
 	size_t				pending_paramlen;
-	uint8_t				pending_param[FI_IBV_CM_DATA_SIZE];
+	uint8_t				pending_param[VRB_CM_DATA_SIZE];
 };
 
-struct fi_ibv_ep {
+struct vrb_ep {
 	struct util_ep			util_ep;
 	struct ibv_qp			*ibv_qp;
 
@@ -563,8 +563,8 @@ struct fi_ibv_ep {
 
 	size_t				inject_limit;
 
-	struct fi_ibv_eq		*eq;
-	struct fi_ibv_srq_ep		*srq_ep;
+	struct vrb_eq		*eq;
+	struct vrb_srq_ep		*srq_ep;
 	struct fi_info			*info;
 
 	struct {
@@ -574,26 +574,26 @@ struct fi_ibv_ep {
 	} *wrs;
 	size_t				rx_cq_size;
 	struct rdma_conn_param		conn_param;
-	struct fi_ibv_cm_data_hdr	*cm_hdr;
+	struct vrb_cm_data_hdr	*cm_hdr;
 };
 
 
 /* Must be cast-able to struct fi_context */
 struct vrb_context {
-	struct fi_ibv_ep		*ep;
+	struct vrb_ep		*ep;
 	void				*user_ctx;
 };
 
 
 #define VERBS_XRC_EP_MAGIC		0x1F3D5B79
-struct fi_ibv_xrc_ep {
+struct vrb_xrc_ep {
 	/* Must be first */
-	struct fi_ibv_ep		base_ep;
+	struct vrb_ep		base_ep;
 
 	/* XRC only fields */
 	struct rdma_cm_id		*tgt_id;
 	struct ibv_qp			*tgt_ibv_qp;
-	enum fi_ibv_xrc_ep_conn_state	conn_state;
+	enum vrb_xrc_ep_conn_state	conn_state;
 	bool				recip_req_received;
 	uint32_t			magic;
 	uint32_t			srqn;
@@ -601,7 +601,7 @@ struct fi_ibv_xrc_ep {
 
 	/* A reference is held to a shared physical XRC INI/TGT QP connecting
 	 * to the destination node. */
-	struct fi_ibv_ini_shared_conn	*ini_conn;
+	struct vrb_ini_shared_conn	*ini_conn;
 	struct dlist_entry		ini_conn_entry;
 
 	/* The following is used for resending lost SIDR accept response
@@ -614,43 +614,43 @@ struct fi_ibv_xrc_ep {
 
 	/* The following state is allocated during XRC bidirectional setup and
 	 * freed once the connection is established. */
-	struct fi_ibv_xrc_ep_conn_setup	*conn_setup;
+	struct vrb_xrc_ep_conn_setup	*conn_setup;
 };
 
-int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
+int vrb_open_ep(struct fid_domain *domain, struct fi_info *info,
 		   struct fid_ep **ep, void *context);
-int fi_ibv_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
+int vrb_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		      struct fid_pep **pep, void *context);
-int fi_ibv_create_ep(const struct fi_info *hints, enum rdma_port_space ps,
+int vrb_create_ep(const struct fi_info *hints, enum rdma_port_space ps,
 		     struct rdma_cm_id **id);
-int fi_ibv_dgram_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
+int vrb_dgram_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 			 struct fid_av **av_fid, void *context);
 static inline
-struct fi_ibv_domain *fi_ibv_ep_to_domain(struct fi_ibv_ep *ep)
+struct vrb_domain *vrb_ep_to_domain(struct vrb_ep *ep)
 {
-	return container_of(ep->util_ep.domain, struct fi_ibv_domain,
+	return container_of(ep->util_ep.domain, struct vrb_domain,
 			    util_domain);
 }
 
-extern struct fi_ops_atomic fi_ibv_msg_ep_atomic_ops;
-extern struct fi_ops_atomic fi_ibv_msg_xrc_ep_atomic_ops;
-extern struct fi_ops_cm fi_ibv_msg_ep_cm_ops;
-extern struct fi_ops_cm fi_ibv_msg_xrc_ep_cm_ops;
-extern const struct fi_ops_msg fi_ibv_msg_ep_msg_ops_ts;
-extern const struct fi_ops_msg fi_ibv_msg_ep_msg_ops;
-extern const struct fi_ops_msg fi_ibv_dgram_msg_ops_ts;
-extern const struct fi_ops_msg fi_ibv_dgram_msg_ops;
-extern const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops;
-extern const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops_ts;
-extern const struct fi_ops_msg fi_ibv_msg_srq_xrc_ep_msg_ops;
-extern struct fi_ops_rma fi_ibv_msg_ep_rma_ops_ts;
-extern struct fi_ops_rma fi_ibv_msg_ep_rma_ops;
-extern struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops_ts;
-extern struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops;
+extern struct fi_ops_atomic vrb_msg_ep_atomic_ops;
+extern struct fi_ops_atomic vrb_msg_xrc_ep_atomic_ops;
+extern struct fi_ops_cm vrb_msg_ep_cm_ops;
+extern struct fi_ops_cm vrb_msg_xrc_ep_cm_ops;
+extern const struct fi_ops_msg vrb_msg_ep_msg_ops_ts;
+extern const struct fi_ops_msg vrb_msg_ep_msg_ops;
+extern const struct fi_ops_msg vrb_dgram_msg_ops_ts;
+extern const struct fi_ops_msg vrb_dgram_msg_ops;
+extern const struct fi_ops_msg vrb_msg_xrc_ep_msg_ops;
+extern const struct fi_ops_msg vrb_msg_xrc_ep_msg_ops_ts;
+extern const struct fi_ops_msg vrb_msg_srq_xrc_ep_msg_ops;
+extern struct fi_ops_rma vrb_msg_ep_rma_ops_ts;
+extern struct fi_ops_rma vrb_msg_ep_rma_ops;
+extern struct fi_ops_rma vrb_msg_xrc_ep_rma_ops_ts;
+extern struct fi_ops_rma vrb_msg_xrc_ep_rma_ops;
 
-#define FI_IBV_XRC_VERSION	2
+#define VRB_XRC_VERSION	2
 
-struct fi_ibv_xrc_cm_data {
+struct vrb_xrc_cm_data {
 	uint8_t		version;
 	uint8_t		reciprocal;
 	uint16_t	port;
@@ -659,7 +659,7 @@ struct fi_ibv_xrc_cm_data {
 	uint32_t	conn_tag;
 };
 
-struct fi_ibv_xrc_conn_info {
+struct vrb_xrc_conn_info {
 	uint32_t		conn_tag;
 	uint32_t		is_reciprocal;
 	uint32_t		ini_qpn;
@@ -669,88 +669,88 @@ struct fi_ibv_xrc_conn_info {
 	struct rdma_conn_param	conn_param;
 };
 
-struct fi_ibv_connreq {
+struct vrb_connreq {
 	struct fid			handle;
 	struct rdma_cm_id		*id;
 
 	/* Support for XRC bidirectional connections, and
 	 * non-RDMA CM managed QP. */
 	int				is_xrc;
-	struct fi_ibv_xrc_conn_info	xrc;
+	struct vrb_xrc_conn_info	xrc;
 };
 
-struct fi_ibv_cm_data_hdr {
+struct vrb_cm_data_hdr {
 	uint8_t	size;
 	char	data[];
 };
 
-int fi_ibv_eq_add_sidr_conn(struct fi_ibv_xrc_ep *ep,
+int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 			    void *param_data, size_t param_len);
-void fi_ibv_eq_remove_sidr_conn(struct fi_ibv_xrc_ep *ep);
-struct fi_ibv_xrc_ep *fi_ibv_eq_get_sidr_conn(struct fi_ibv_eq *eq,
+void vrb_eq_remove_sidr_conn(struct vrb_xrc_ep *ep);
+struct vrb_xrc_ep *vrb_eq_get_sidr_conn(struct vrb_eq *eq,
 					      struct sockaddr *peer,
 					      uint16_t pep_port, bool recip);
 
-void fi_ibv_msg_ep_get_qp_attr(struct fi_ibv_ep *ep,
+void vrb_msg_ep_get_qp_attr(struct vrb_ep *ep,
 			       struct ibv_qp_init_attr *attr);
-int fi_ibv_process_xrc_connreq(struct fi_ibv_ep *ep,
-			       struct fi_ibv_connreq *connreq);
+int vrb_process_xrc_connreq(struct vrb_ep *ep,
+			       struct vrb_connreq *connreq);
 
-void fi_ibv_next_xrc_conn_state(struct fi_ibv_xrc_ep *ep);
-void fi_ibv_prev_xrc_conn_state(struct fi_ibv_xrc_ep *ep);
-void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_xrc_ep *ep);
-void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep);
-struct fi_ibv_xrc_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq,
+void vrb_next_xrc_conn_state(struct vrb_xrc_ep *ep);
+void vrb_prev_xrc_conn_state(struct vrb_xrc_ep *ep);
+void vrb_eq_set_xrc_conn_tag(struct vrb_xrc_ep *ep);
+void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep);
+struct vrb_xrc_ep *vrb_eq_xrc_conn_tag2ep(struct vrb_eq *eq,
 						uint32_t conn_tag);
-void fi_ibv_set_xrc_cm_data(struct fi_ibv_xrc_cm_data *local, int reciprocal,
+void vrb_set_xrc_cm_data(struct vrb_xrc_cm_data *local, int reciprocal,
 			    uint32_t conn_tag, uint16_t port, uint32_t tgt_qpn,
 			    uint32_t srqn);
-int fi_ibv_verify_xrc_cm_data(struct fi_ibv_xrc_cm_data *remote,
+int vrb_verify_xrc_cm_data(struct vrb_xrc_cm_data *remote,
 			      int private_data_len);
-int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
+int vrb_connect_xrc(struct vrb_xrc_ep *ep, struct sockaddr *addr,
 		       int reciprocal, void *param, size_t paramlen);
-int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
+int vrb_accept_xrc(struct vrb_xrc_ep *ep, int reciprocal,
 		      void *param, size_t paramlen);
-int fi_ibv_resend_shared_accept_xrc(struct fi_ibv_xrc_ep *ep,
-				    struct fi_ibv_connreq *connreq,
+int vrb_resend_shared_accept_xrc(struct vrb_xrc_ep *ep,
+				    struct vrb_connreq *connreq,
 				    struct rdma_cm_id *id);
-void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect);
-void fi_ibv_add_pending_ini_conn(struct fi_ibv_xrc_ep *ep, int reciprocal,
+void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect);
+void vrb_add_pending_ini_conn(struct vrb_xrc_ep *ep, int reciprocal,
 				 void *conn_param, size_t conn_paramlen);
-void fi_ibv_sched_ini_conn(struct fi_ibv_ini_shared_conn *ini_conn);
-int fi_ibv_get_shared_ini_conn(struct fi_ibv_xrc_ep *ep,
-			       struct fi_ibv_ini_shared_conn **ini_conn);
-void fi_ibv_put_shared_ini_conn(struct fi_ibv_xrc_ep *ep);
-int fi_ibv_reserve_qpn(struct fi_ibv_xrc_ep *ep, struct ibv_qp **qp);
+void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn);
+int vrb_get_shared_ini_conn(struct vrb_xrc_ep *ep,
+			       struct vrb_ini_shared_conn **ini_conn);
+void vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep);
+int vrb_reserve_qpn(struct vrb_xrc_ep *ep, struct ibv_qp **qp);
 
-void fi_ibv_save_priv_data(struct fi_ibv_xrc_ep *ep, const void *data,
+void vrb_save_priv_data(struct vrb_xrc_ep *ep, const void *data,
 			   size_t len);
-int fi_ibv_ep_create_ini_qp(struct fi_ibv_xrc_ep *ep, void *dst_addr,
+int vrb_ep_create_ini_qp(struct vrb_xrc_ep *ep, void *dst_addr,
 			    uint32_t *peer_tgt_qpn);
-void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t peer_tgt_qpn);
-void fi_ibv_ep_ini_conn_rejected(struct fi_ibv_xrc_ep *ep);
-int fi_ibv_ep_create_tgt_qp(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn);
-void fi_ibv_ep_tgt_conn_done(struct fi_ibv_xrc_ep *qp);
-int fi_ibv_ep_destroy_xrc_qp(struct fi_ibv_xrc_ep *ep);
+void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t peer_tgt_qpn);
+void vrb_ep_ini_conn_rejected(struct vrb_xrc_ep *ep);
+int vrb_ep_create_tgt_qp(struct vrb_xrc_ep *ep, uint32_t tgt_qpn);
+void vrb_ep_tgt_conn_done(struct vrb_xrc_ep *qp);
+int vrb_ep_destroy_xrc_qp(struct vrb_xrc_ep *ep);
 
-int fi_ibv_xrc_close_srq(struct fi_ibv_srq_ep *srq_ep);
-int fi_ibv_sockaddr_len(struct sockaddr *addr);
+int vrb_xrc_close_srq(struct vrb_srq_ep *srq_ep);
+int vrb_sockaddr_len(struct sockaddr *addr);
 
 
-int fi_ibv_init_info(const struct fi_info **all_infos);
-int fi_ibv_getinfo(uint32_t version, const char *node, const char *service,
+int vrb_init_info(const struct fi_info **all_infos);
+int vrb_getinfo(uint32_t version, const char *node, const char *service,
 		   uint64_t flags, const struct fi_info *hints,
 		   struct fi_info **info);
-const struct fi_info *fi_ibv_get_verbs_info(const struct fi_info *ilist,
+const struct fi_info *vrb_get_verbs_info(const struct fi_info *ilist,
 					    const char *domain_name);
-int fi_ibv_fi_to_rai(const struct fi_info *fi, uint64_t flags,
+int vrb_fi_to_rai(const struct fi_info *fi, uint64_t flags,
 		     struct rdma_addrinfo *rai);
-int fi_ibv_get_rdma_rai(const char *node, const char *service, uint64_t flags,
+int vrb_get_rdma_rai(const char *node, const char *service, uint64_t flags,
 			const struct fi_info *hints, struct rdma_addrinfo **rai);
-int fi_ibv_get_matching_info(uint32_t version, const struct fi_info *hints,
+int vrb_get_matching_info(uint32_t version, const struct fi_info *hints,
 			     struct fi_info **info, const struct fi_info *verbs_info,
 			     uint8_t passive);
-void fi_ibv_alter_info(const struct fi_info *hints, struct fi_info *info);
+void vrb_alter_info(const struct fi_info *hints, struct fi_info *info);
 
 struct verbs_ep_domain {
 	char			*suffix;
@@ -762,13 +762,13 @@ struct verbs_ep_domain {
 extern const struct verbs_ep_domain verbs_dgram_domain;
 extern const struct verbs_ep_domain verbs_msg_xrc_domain;
 
-int fi_ibv_check_ep_attr(const struct fi_info *hints,
+int vrb_check_ep_attr(const struct fi_info *hints,
 			 const struct fi_info *info);
-int fi_ibv_check_rx_attr(const struct fi_rx_attr *attr,
+int vrb_check_rx_attr(const struct fi_rx_attr *attr,
 			 const struct fi_info *hints,
 			 const struct fi_info *info);
 
-static inline int fi_ibv_cmp_xrc_domain_name(const char *domain_name,
+static inline int vrb_cmp_xrc_domain_name(const char *domain_name,
 					     const char *rdma_name)
 {
 	size_t domain_len = strlen(domain_name);
@@ -778,36 +778,36 @@ static inline int fi_ibv_cmp_xrc_domain_name(const char *domain_name,
 						 domain_len - suffix_len) : -1;
 }
 
-int fi_ibv_cq_signal(struct fid_cq *cq);
+int vrb_cq_signal(struct fid_cq *cq);
 
-struct fi_ibv_eq_entry *fi_ibv_eq_alloc_entry(uint32_t event,
+struct vrb_eq_entry *vrb_eq_alloc_entry(uint32_t event,
 					      const void *buf, size_t len);
-ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
+ssize_t vrb_eq_write_event(struct vrb_eq *eq, uint32_t event,
 		const void *buf, size_t len);
 
-int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
+int vrb_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,
 			uint64_t flags);
-int fi_ibv_set_rnr_timer(struct ibv_qp *qp);
-void fi_ibv_cleanup_cq(struct fi_ibv_ep *cur_ep);
-int fi_ibv_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
+int vrb_set_rnr_timer(struct ibv_qp *qp);
+void vrb_cleanup_cq(struct vrb_ep *cur_ep);
+int vrb_find_max_inline(struct ibv_pd *pd, struct ibv_context *context,
 			   enum ibv_qp_type qp_type);
 
-struct fi_ibv_dgram_av {
+struct vrb_dgram_av {
 	struct util_av util_av;
 	struct dlist_entry av_entry_list;
 };
 
-struct fi_ibv_dgram_av_entry {
+struct vrb_dgram_av_entry {
 	struct dlist_entry list_entry;
 	struct ofi_ib_ud_ep_name addr;
 	struct ibv_ah *ah;
 };
 
-static inline struct fi_ibv_dgram_av_entry*
-fi_ibv_dgram_av_lookup_av_entry(fi_addr_t fi_addr)
+static inline struct vrb_dgram_av_entry*
+vrb_dgram_av_lookup_av_entry(fi_addr_t fi_addr)
 {
-	return (struct fi_ibv_dgram_av_entry *) (uintptr_t) fi_addr;
+	return (struct vrb_dgram_av_entry *) (uintptr_t) fi_addr;
 }
 
 /* NOTE:
@@ -828,32 +828,32 @@ static inline ssize_t vrb_convert_ret(int ret)
 }
 
 
-int vrb_poll_cq(struct fi_ibv_cq *cq, struct ibv_wc *wc);
-int vrb_save_wc(struct fi_ibv_cq *cq, struct ibv_wc *wc);
+int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc);
+int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc);
 
-#define fi_ibv_init_sge(buf, len, desc) (struct ibv_sge)		\
+#define vrb_init_sge(buf, len, desc) (struct ibv_sge)		\
 	{ .addr = (uintptr_t)buf,					\
 	  .length = (uint32_t)len,					\
 	  .lkey = (uint32_t)(uintptr_t)desc }
 
-#define fi_ibv_set_sge_iov(sg_list, iov, count, desc)	\
+#define vrb_set_sge_iov(sg_list, iov, count, desc)	\
 ({							\
 	size_t i;					\
 	sg_list = alloca(sizeof(*sg_list) * count);	\
 	for (i = 0; i < count; i++) {			\
-		sg_list[i] = fi_ibv_init_sge(		\
+		sg_list[i] = vrb_init_sge(		\
 				iov[i].iov_base,	\
 				iov[i].iov_len,		\
 				desc[i]);		\
 	}						\
 })
 
-#define fi_ibv_set_sge_iov_count_len(sg_list, iov, count, desc, len)	\
+#define vrb_set_sge_iov_count_len(sg_list, iov, count, desc, len)	\
 ({									\
 	size_t i;							\
 	sg_list = alloca(sizeof(*sg_list) * count);			\
 	for (i = 0; i < count; i++) {					\
-		sg_list[i] = fi_ibv_init_sge(				\
+		sg_list[i] = vrb_init_sge(				\
 				iov[i].iov_base,			\
 				iov[i].iov_len,				\
 				desc[i]);				\
@@ -861,37 +861,37 @@ int vrb_save_wc(struct fi_ibv_cq *cq, struct ibv_wc *wc);
 	}								\
 })
 
-#define fi_ibv_init_sge_inline(buf, len) fi_ibv_init_sge(buf, len, NULL)
+#define vrb_init_sge_inline(buf, len) vrb_init_sge(buf, len, NULL)
 
-#define fi_ibv_set_sge_iov_inline(sg_list, iov, count, len)	\
+#define vrb_set_sge_iov_inline(sg_list, iov, count, len)	\
 ({								\
 	size_t i;						\
 	sg_list = alloca(sizeof(*sg_list) * count);		\
 	for (i = 0; i < count; i++) {				\
-		sg_list[i] = fi_ibv_init_sge_inline(		\
+		sg_list[i] = vrb_init_sge_inline(		\
 					iov[i].iov_base,	\
 					iov[i].iov_len);	\
 		len += iov[i].iov_len;				\
 	}							\
 })
 
-#define fi_ibv_send_iov(ep, wr, iov, desc, count)		\
-	fi_ibv_send_iov_flags(ep, wr, iov, desc, count,		\
+#define vrb_send_iov(ep, wr, iov, desc, count)		\
+	vrb_send_iov_flags(ep, wr, iov, desc, count,		\
 			      (ep)->info->tx_attr->op_flags)
 
-#define fi_ibv_send_msg(ep, wr, msg, flags)				\
-	fi_ibv_send_iov_flags(ep, wr, (msg)->msg_iov, (msg)->desc,	\
+#define vrb_send_msg(ep, wr, msg, flags)				\
+	vrb_send_iov_flags(ep, wr, (msg)->msg_iov, (msg)->desc,	\
 			      (msg)->iov_count, flags)
 
 
-ssize_t vrb_post_send(struct fi_ibv_ep *ep, struct ibv_send_wr *wr);
-ssize_t vrb_post_recv(struct fi_ibv_ep *ep, struct ibv_recv_wr *wr);
+ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr);
+ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr);
 
 static inline ssize_t
-fi_ibv_send_buf(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
+vrb_send_buf(struct vrb_ep *ep, struct ibv_send_wr *wr,
 		const void *buf, size_t len, void *desc)
 {
-	struct ibv_sge sge = fi_ibv_init_sge(buf, len, desc);
+	struct ibv_sge sge = vrb_init_sge(buf, len, desc);
 
 	assert(wr->wr_id != VERBS_NO_COMP_FLAG);
 
@@ -902,10 +902,10 @@ fi_ibv_send_buf(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
 }
 
 static inline ssize_t
-fi_ibv_send_buf_inline(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
+vrb_send_buf_inline(struct vrb_ep *ep, struct ibv_send_wr *wr,
 		       const void *buf, size_t len)
 {
-	struct ibv_sge sge = fi_ibv_init_sge_inline(buf, len);
+	struct ibv_sge sge = vrb_init_sge_inline(buf, len);
 
 	assert(wr->wr_id == VERBS_NO_COMP_FLAG);
 
@@ -916,16 +916,16 @@ fi_ibv_send_buf_inline(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
 }
 
 static inline ssize_t
-fi_ibv_send_iov_flags(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
+vrb_send_iov_flags(struct vrb_ep *ep, struct ibv_send_wr *wr,
 		      const struct iovec *iov, void **desc, int count,
 		      uint64_t flags)
 {
 	size_t len = 0;
 
 	if (!desc)
-		fi_ibv_set_sge_iov_inline(wr->sg_list, iov, count, len);
+		vrb_set_sge_iov_inline(wr->sg_list, iov, count, len);
 	else
-		fi_ibv_set_sge_iov_count_len(wr->sg_list, iov, count, desc, len);
+		vrb_set_sge_iov_count_len(wr->sg_list, iov, count, desc, len);
 
 	wr->num_sge = count;
 	wr->send_flags = VERBS_INJECT_FLAGS(ep, len, flags);
@@ -937,7 +937,7 @@ fi_ibv_send_iov_flags(struct fi_ibv_ep *ep, struct ibv_send_wr *wr,
 	return vrb_post_send(ep, wr);
 }
 
-int fi_ibv_get_rai_id(const char *node, const char *service, uint64_t flags,
+int vrb_get_rai_id(const char *node, const char *service, uint64_t flags,
 		      const struct fi_info *hints, struct rdma_addrinfo **rai,
 		      struct rdma_cm_id **id);
 

--- a/prov/verbs/src/ofi_verbs_priv.h
+++ b/prov/verbs/src/ofi_verbs_priv.h
@@ -45,14 +45,14 @@
 #define IBV_SRQ_INIT_ATTR_CQ 3ull
 
 #define IBV_SRQT_XRC 1ull
-#define FI_IBV_SET_REMOTE_SRQN(var, val) do { } while (0)
+#define VRB_SET_REMOTE_SRQN(var, val) do { } while (0)
 #define FI_VERBS_XRC_ONLY __attribute__((unused))
 
 #define ibv_get_srq_num(srq, srqn) do { } while (0)
 #define ibv_create_srq_ex(context, attr) (NULL)
 #else /* !VERBS_HAVE_XRC */
 
-#define FI_IBV_SET_REMOTE_SRQN(var, val) \
+#define VRB_SET_REMOTE_SRQN(var, val) \
 	do { \
 		(var).qp_type.xrc.remote_srqn = (val); \
 	} while (0)

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -33,23 +33,23 @@
 #include "config.h"
 #include "fi_verbs.h"
 
-void fi_ibv_next_xrc_conn_state(struct fi_ibv_xrc_ep *ep)
+void vrb_next_xrc_conn_state(struct vrb_xrc_ep *ep)
 {
 	switch (ep->conn_state) {
-	case FI_IBV_XRC_UNCONNECTED:
-		ep->conn_state = FI_IBV_XRC_ORIG_CONNECTING;
+	case VRB_XRC_UNCONNECTED:
+		ep->conn_state = VRB_XRC_ORIG_CONNECTING;
 		break;
-	case FI_IBV_XRC_ORIG_CONNECTING:
-		ep->conn_state = FI_IBV_XRC_ORIG_CONNECTED;
+	case VRB_XRC_ORIG_CONNECTING:
+		ep->conn_state = VRB_XRC_ORIG_CONNECTED;
 		break;
-	case FI_IBV_XRC_ORIG_CONNECTED:
-		ep->conn_state = FI_IBV_XRC_RECIP_CONNECTING;
+	case VRB_XRC_ORIG_CONNECTED:
+		ep->conn_state = VRB_XRC_RECIP_CONNECTING;
 		break;
-	case FI_IBV_XRC_RECIP_CONNECTING:
-		ep->conn_state = FI_IBV_XRC_CONNECTED;
+	case VRB_XRC_RECIP_CONNECTING:
+		ep->conn_state = VRB_XRC_CONNECTED;
 		break;
-	case FI_IBV_XRC_CONNECTED:
-	case FI_IBV_XRC_ERROR:
+	case VRB_XRC_CONNECTED:
+	case VRB_XRC_ERROR:
 		break;
 	default:
 		assert(0);
@@ -58,24 +58,24 @@ void fi_ibv_next_xrc_conn_state(struct fi_ibv_xrc_ep *ep)
 	}
 }
 
-void fi_ibv_prev_xrc_conn_state(struct fi_ibv_xrc_ep *ep)
+void vrb_prev_xrc_conn_state(struct vrb_xrc_ep *ep)
 {
 	switch (ep->conn_state) {
-	case FI_IBV_XRC_UNCONNECTED:
+	case VRB_XRC_UNCONNECTED:
 		break;
-	case FI_IBV_XRC_ORIG_CONNECTING:
-		ep->conn_state = FI_IBV_XRC_UNCONNECTED;
+	case VRB_XRC_ORIG_CONNECTING:
+		ep->conn_state = VRB_XRC_UNCONNECTED;
 		break;
-	case FI_IBV_XRC_ORIG_CONNECTED:
-		ep->conn_state = FI_IBV_XRC_ORIG_CONNECTING;
+	case VRB_XRC_ORIG_CONNECTED:
+		ep->conn_state = VRB_XRC_ORIG_CONNECTING;
 		break;
-	case FI_IBV_XRC_RECIP_CONNECTING:
-		ep->conn_state = FI_IBV_XRC_ORIG_CONNECTED;
+	case VRB_XRC_RECIP_CONNECTING:
+		ep->conn_state = VRB_XRC_ORIG_CONNECTED;
 		break;
-	case FI_IBV_XRC_CONNECTED:
-		ep->conn_state = FI_IBV_XRC_RECIP_CONNECTING;
+	case VRB_XRC_CONNECTED:
+		ep->conn_state = VRB_XRC_RECIP_CONNECTING;
 		break;
-	case FI_IBV_XRC_ERROR:
+	case VRB_XRC_ERROR:
 		break;
 	default:
 		assert(0);
@@ -84,7 +84,7 @@ void fi_ibv_prev_xrc_conn_state(struct fi_ibv_xrc_ep *ep)
 	}
 }
 
-void fi_ibv_save_priv_data(struct fi_ibv_xrc_ep *ep, const void *data,
+void vrb_save_priv_data(struct vrb_xrc_ep *ep, const void *data,
 			   size_t len)
 {
 	ep->conn_setup->event_len = MIN(sizeof(ep->conn_setup->event_data),
@@ -92,11 +92,11 @@ void fi_ibv_save_priv_data(struct fi_ibv_xrc_ep *ep, const void *data,
 	memcpy(ep->conn_setup->event_data, data, ep->conn_setup->event_len);
 }
 
-void fi_ibv_set_xrc_cm_data(struct fi_ibv_xrc_cm_data *local, int reciprocal,
+void vrb_set_xrc_cm_data(struct vrb_xrc_cm_data *local, int reciprocal,
 			    uint32_t conn_tag, uint16_t port, uint32_t tgt_qpn,
 			    uint32_t srqn)
 {
-	local->version = FI_IBV_XRC_VERSION;
+	local->version = VRB_XRC_VERSION;
 	local->reciprocal = reciprocal ? 1 : 0;
 	local->port = htons(port);
 	local->conn_tag = htonl(conn_tag);
@@ -104,7 +104,7 @@ void fi_ibv_set_xrc_cm_data(struct fi_ibv_xrc_cm_data *local, int reciprocal,
 	local->srqn = htonl(srqn);
 }
 
-int fi_ibv_verify_xrc_cm_data(struct fi_ibv_xrc_cm_data *remote,
+int vrb_verify_xrc_cm_data(struct vrb_xrc_cm_data *remote,
 			      int private_data_len)
 {
 	if (sizeof(*remote) > private_data_len) {
@@ -113,23 +113,23 @@ int fi_ibv_verify_xrc_cm_data(struct fi_ibv_xrc_cm_data *remote,
 		return -FI_EINVAL;
 	}
 
-	if (remote->version != FI_IBV_XRC_VERSION) {
+	if (remote->version != VRB_XRC_VERSION) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "XRC MSG EP connection protocol mismatch "
 			   "(local %"PRIu8", remote %"PRIu8")\n",
-			   FI_IBV_XRC_VERSION, remote->version);
+			   VRB_XRC_VERSION, remote->version);
 		return -FI_EINVAL;
 	}
 	return FI_SUCCESS;
 }
 
-void fi_ibv_log_ep_conn(struct fi_ibv_xrc_ep *ep, char *desc)
+void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 {
 	struct sockaddr *addr;
 	char buf[OFI_ADDRSTRLEN];
 	size_t len = sizeof(buf);
 
-	if (!fi_log_enabled(&fi_ibv_prov, FI_LOG_INFO, FI_LOG_EP_CTRL))
+	if (!fi_log_enabled(&vrb_prov, FI_LOG_INFO, FI_LOG_EP_CTRL))
 		return;
 
 	VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, %s\n", ep, desc);
@@ -168,7 +168,7 @@ void fi_ibv_log_ep_conn(struct fi_ibv_xrc_ep *ep, char *desc)
 }
 
 /* Caller must hold eq:lock */
-void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect)
+void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect)
 {
 	assert(ep->conn_setup);
 
@@ -193,7 +193,7 @@ void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect)
 		}
 	}
 
-	fi_ibv_eq_clear_xrc_conn_tag(ep);
+	vrb_eq_clear_xrc_conn_tag(ep);
 	if (!disconnect) {
 		free(ep->conn_setup);
 		ep->conn_setup = NULL;
@@ -201,14 +201,14 @@ void fi_ibv_free_xrc_conn_setup(struct fi_ibv_xrc_ep *ep, int disconnect)
 }
 
 /* Caller must hold the eq:lock */
-int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
+int vrb_connect_xrc(struct vrb_xrc_ep *ep, struct sockaddr *addr,
 		       int reciprocal, void *param, size_t paramlen)
 {
 	int ret;
 
 	assert(!ep->base_ep.id && !ep->base_ep.ibv_qp && !ep->ini_conn);
 
-	ret = fi_ibv_get_shared_ini_conn(ep, &ep->ini_conn);
+	ret = vrb_get_shared_ini_conn(ep, &ep->ini_conn);
 	if (ret) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "Get of shared XRC INI connection failed %d\n", ret);
@@ -219,27 +219,27 @@ int fi_ibv_connect_xrc(struct fi_ibv_xrc_ep *ep, struct sockaddr *addr,
 		return ret;
 	}
 
-	fi_ibv_eq_set_xrc_conn_tag(ep);
-	fi_ibv_add_pending_ini_conn(ep, reciprocal, param, paramlen);
-	fi_ibv_sched_ini_conn(ep->ini_conn);
+	vrb_eq_set_xrc_conn_tag(ep);
+	vrb_add_pending_ini_conn(ep, reciprocal, param, paramlen);
+	vrb_sched_ini_conn(ep->ini_conn);
 
 	return FI_SUCCESS;
 }
 
 /* Caller must hold the eq:lock */
-void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn)
+void vrb_ep_ini_conn_done(struct vrb_xrc_ep *ep, uint32_t tgt_qpn)
 {
 	assert(ep->base_ep.id && ep->ini_conn);
 
-	assert(ep->ini_conn->state == FI_IBV_INI_QP_CONNECTING ||
-	       ep->ini_conn->state == FI_IBV_INI_QP_CONNECTED);
+	assert(ep->ini_conn->state == VRB_INI_QP_CONNECTING ||
+	       ep->ini_conn->state == VRB_INI_QP_CONNECTED);
 
 	/* If this was a physical INI/TGT QP connection, remove the QP
 	 * from control of the RDMA CM. We don't want the shared INI QP
 	 * to be destroyed if this endpoint closes. */
 	if (ep->base_ep.id == ep->ini_conn->phys_conn_id) {
 		ep->ini_conn->phys_conn_id = NULL;
-		ep->ini_conn->state = FI_IBV_INI_QP_CONNECTED;
+		ep->ini_conn->state = VRB_INI_QP_CONNECTED;
 		ep->ini_conn->tgt_qpn = tgt_qpn;
 		ep->base_ep.id->qp = NULL;
 		VERBS_DBG(FI_LOG_EP_CTRL,
@@ -248,23 +248,23 @@ void fi_ibv_ep_ini_conn_done(struct fi_ibv_xrc_ep *ep, uint32_t tgt_qpn)
 			  ep->ini_conn->tgt_qpn);
 	}
 
-	fi_ibv_log_ep_conn(ep, "INI Connection Done");
-	fi_ibv_sched_ini_conn(ep->ini_conn);
+	vrb_log_ep_conn(ep, "INI Connection Done");
+	vrb_sched_ini_conn(ep->ini_conn);
 }
 
 /* Caller must hold the eq:lock */
-void fi_ibv_ep_ini_conn_rejected(struct fi_ibv_xrc_ep *ep)
+void vrb_ep_ini_conn_rejected(struct vrb_xrc_ep *ep)
 {
 	assert(ep->base_ep.id && ep->ini_conn);
 
-	fi_ibv_log_ep_conn(ep, "INI Connection Rejected");
-	fi_ibv_put_shared_ini_conn(ep);
-	ep->conn_state = FI_IBV_XRC_ERROR;
+	vrb_log_ep_conn(ep, "INI Connection Rejected");
+	vrb_put_shared_ini_conn(ep);
+	ep->conn_state = VRB_XRC_ERROR;
 }
 
-void fi_ibv_ep_tgt_conn_done(struct fi_ibv_xrc_ep *ep)
+void vrb_ep_tgt_conn_done(struct vrb_xrc_ep *ep)
 {
-	fi_ibv_log_ep_conn(ep, "TGT Connection Done\n");
+	vrb_log_ep_conn(ep, "TGT Connection Done\n");
 
 	if (ep->tgt_id->qp) {
 		assert(ep->tgt_ibv_qp == ep->tgt_id->qp);
@@ -273,18 +273,18 @@ void fi_ibv_ep_tgt_conn_done(struct fi_ibv_xrc_ep *ep)
 }
 
 /* Caller must hold the eq:lock */
-int fi_ibv_resend_shared_accept_xrc(struct fi_ibv_xrc_ep *ep,
-				    struct fi_ibv_connreq *connreq,
+int vrb_resend_shared_accept_xrc(struct vrb_xrc_ep *ep,
+				    struct vrb_connreq *connreq,
 				    struct rdma_cm_id *id)
 {
 	struct rdma_conn_param conn_param = { 0 };
-	struct fi_ibv_xrc_cm_data *cm_data = ep->accept_param_data;
+	struct vrb_xrc_cm_data *cm_data = ep->accept_param_data;
 
 	assert(cm_data && ep->tgt_ibv_qp);
 	assert(ep->tgt_ibv_qp->qp_num == connreq->xrc.tgt_qpn);
 	assert(ep->peer_srqn == connreq->xrc.peer_srqn);
 
-	fi_ibv_set_xrc_cm_data(cm_data, connreq->xrc.is_reciprocal,
+	vrb_set_xrc_cm_data(cm_data, connreq->xrc.is_reciprocal,
 			       connreq->xrc.conn_tag, connreq->xrc.port,
 			       0, ep->srqn);
 	conn_param.private_data = cm_data;
@@ -302,34 +302,34 @@ int fi_ibv_resend_shared_accept_xrc(struct fi_ibv_xrc_ep *ep,
 }
 
 /* Caller must hold the eq:lock */
-int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
+int vrb_accept_xrc(struct vrb_xrc_ep *ep, int reciprocal,
 		      void *param, size_t paramlen)
 {
 	struct sockaddr *addr;
-	struct fi_ibv_connreq *connreq;
+	struct vrb_connreq *connreq;
 	struct rdma_conn_param conn_param = { 0 };
-	struct fi_ibv_xrc_cm_data *cm_data = param;
-	struct fi_ibv_xrc_cm_data connect_cm_data;
+	struct vrb_xrc_cm_data *cm_data = param;
+	struct vrb_xrc_cm_data connect_cm_data;
 	int ret;
 
 	addr = rdma_get_local_addr(ep->tgt_id);
 	if (addr)
-		ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_CORE, "src_addr", addr);
+		ofi_straddr_dbg(&vrb_prov, FI_LOG_CORE, "src_addr", addr);
 
 	addr = rdma_get_peer_addr(ep->tgt_id);
 	if (addr)
-		ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_CORE, "dest_addr", addr);
+		ofi_straddr_dbg(&vrb_prov, FI_LOG_CORE, "dest_addr", addr);
 
 	connreq = container_of(ep->base_ep.info->handle,
-			       struct fi_ibv_connreq, handle);
-	ret = fi_ibv_ep_create_tgt_qp(ep, connreq->xrc.tgt_qpn);
+			       struct vrb_connreq, handle);
+	ret = vrb_ep_create_tgt_qp(ep, connreq->xrc.tgt_qpn);
 	if (ret)
 		return ret;
 
 	ep->peer_srqn = connreq->xrc.peer_srqn;
 	ep->remote_pep_port = connreq->xrc.port;
 	ep->recip_accept = connreq->xrc.is_reciprocal;
-	fi_ibv_set_xrc_cm_data(cm_data, connreq->xrc.is_reciprocal,
+	vrb_set_xrc_cm_data(cm_data, connreq->xrc.is_reciprocal,
 			       connreq->xrc.conn_tag, connreq->xrc.port,
 			       0, ep->srqn);
 	conn_param.private_data = cm_data;
@@ -346,37 +346,37 @@ int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
 
 	ep->conn_setup->remote_conn_tag = connreq->xrc.conn_tag;
 
-	assert(ep->conn_state == FI_IBV_XRC_UNCONNECTED ||
-	       ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED);
-	fi_ibv_next_xrc_conn_state(ep);
+	assert(ep->conn_state == VRB_XRC_UNCONNECTED ||
+	       ep->conn_state == VRB_XRC_ORIG_CONNECTED);
+	vrb_next_xrc_conn_state(ep);
 
 	ret = rdma_accept(ep->tgt_id, &conn_param);
 	if (OFI_UNLIKELY(ret)) {
 		ret = -errno;
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "XRC TGT, rdma_accept error %d\n", ret);
-		fi_ibv_prev_xrc_conn_state(ep);
+		vrb_prev_xrc_conn_state(ep);
 		return ret;
 	}
 	free(connreq);
 
 	if (ep->tgt_id->ps == RDMA_PS_UDP &&
-	    fi_ibv_eq_add_sidr_conn(ep, cm_data, paramlen))
+	    vrb_eq_add_sidr_conn(ep, cm_data, paramlen))
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "SIDR connection accept not added to map\n");
 
 	/* The passive side of the initial shared connection using
 	 * SIDR is complete, initiate reciprocal connection */
 	if (ep->tgt_id->ps == RDMA_PS_UDP && !reciprocal) {
-		fi_ibv_next_xrc_conn_state(ep);
-		fi_ibv_ep_tgt_conn_done(ep);
-		ret = fi_ibv_connect_xrc(ep, NULL, FI_IBV_RECIP_CONN,
+		vrb_next_xrc_conn_state(ep);
+		vrb_ep_tgt_conn_done(ep);
+		ret = vrb_connect_xrc(ep, NULL, VRB_RECIP_CONN,
 					 &connect_cm_data,
 					 sizeof(connect_cm_data));
 		if (ret) {
 			VERBS_WARN(FI_LOG_EP_CTRL,
 				   "XRC reciprocal connect error %d\n", ret);
-			fi_ibv_prev_xrc_conn_state(ep);
+			vrb_prev_xrc_conn_state(ep);
 			ep->tgt_id->qp = NULL;
 		}
 	}
@@ -384,10 +384,10 @@ int fi_ibv_accept_xrc(struct fi_ibv_xrc_ep *ep, int reciprocal,
 	return ret;
 }
 
-int fi_ibv_process_xrc_connreq(struct fi_ibv_ep *ep,
-			       struct fi_ibv_connreq *connreq)
+int vrb_process_xrc_connreq(struct vrb_ep *ep,
+			       struct vrb_connreq *connreq)
 {
-	struct fi_ibv_xrc_ep *xrc_ep = container_of(ep, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *xrc_ep = container_of(ep, struct vrb_xrc_ep,
 						    base_ep);
 
 	assert(ep->info->src_addr);

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -33,11 +33,11 @@
 #include "fi_verbs.h"
 
 static inline int
-fi_ibv_dgram_ep_set_addr(struct fi_ibv_ep *ep, fi_addr_t addr,
+vrb_dgram_ep_set_addr(struct vrb_ep *ep, fi_addr_t addr,
 			 struct ibv_send_wr *wr)
 {
-	struct fi_ibv_dgram_av_entry *av_entry =
-			fi_ibv_dgram_av_lookup_av_entry(addr);
+	struct vrb_dgram_av_entry *av_entry =
+			vrb_dgram_av_lookup_av_entry(addr);
 	if (OFI_UNLIKELY(!av_entry))
 		return -FI_ENOENT;
 	wr->wr.ud.ah = av_entry->ah;
@@ -48,23 +48,23 @@ fi_ibv_dgram_ep_set_addr(struct fi_ibv_ep *ep, fi_addr_t addr,
 }
 
 static inline ssize_t
-fi_ibv_dgram_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+vrb_dgram_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 			uint64_t flags)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_recv_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
 		.num_sge = msg->iov_count,
 		.next = NULL,
 	};
 
-	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
+	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 	return vrb_post_recv(ep, &wr);
 }
 
 static inline ssize_t
-fi_ibv_dgram_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+vrb_dgram_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		      size_t count, fi_addr_t src_addr, void *context)
 {
 	struct fi_msg msg = {
@@ -75,11 +75,11 @@ fi_ibv_dgram_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **des
 		.context	= context,
 	};
 
-	return fi_ibv_dgram_ep_recvmsg(ep_fid, &msg, 0);
+	return vrb_dgram_ep_recvmsg(ep_fid, &msg, 0);
 }
 
 static inline ssize_t
-fi_ibv_dgram_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
+vrb_dgram_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 		     void *desc, fi_addr_t src_addr, void *context)
 {
 	struct iovec iov = {
@@ -87,16 +87,16 @@ fi_ibv_dgram_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 		.iov_len	= len,
 	};
 
-	return fi_ibv_dgram_ep_recvv(ep_fid, &iov, &desc,
+	return vrb_dgram_ep_recvv(ep_fid, &iov, &desc,
 				     1, src_addr, context);
 }
 
 static ssize_t
-fi_ibv_dgram_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
+vrb_dgram_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 			uint64_t flags)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
 	};
@@ -108,55 +108,55 @@ fi_ibv_dgram_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		wr.opcode = IBV_WR_SEND;
 	}
 
-	if (fi_ibv_dgram_ep_set_addr(ep, msg->addr, &wr))
+	if (vrb_dgram_ep_set_addr(ep, msg->addr, &wr))
 		return -FI_ENOENT;
 
-	return fi_ibv_send_msg(ep, &wr, msg, flags);
+	return vrb_send_msg(ep, &wr, msg, flags);
 }
 
 static inline ssize_t
-fi_ibv_dgram_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
+vrb_dgram_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 		      void **desc, size_t count, fi_addr_t dest_addr,
 		      void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)context,
 		.opcode = IBV_WR_SEND,
 	};
 
-	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &wr))
+	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
 
-	return fi_ibv_send_iov(ep, &wr, iov, desc, count);
+	return vrb_send_iov(ep, &wr, iov, desc, count);
 }
 
 static ssize_t
-fi_ibv_dgram_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_dgram_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 		     void *desc, fi_addr_t dest_addr, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
 		.send_flags = VERBS_INJECT(ep, len),
 	};
 
-	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &wr))
+	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
 
-	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
+	return vrb_send_buf(ep, &wr, buf, len, desc);
 }
 
 static inline ssize_t
-fi_ibv_dgram_ep_senddata(struct fid_ep *ep_fid, const void *buf,
+vrb_dgram_ep_senddata(struct fid_ep *ep_fid, const void *buf,
 			 size_t len, void *desc, uint64_t data,
 			 fi_addr_t dest_addr, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
@@ -164,18 +164,18 @@ fi_ibv_dgram_ep_senddata(struct fid_ep *ep_fid, const void *buf,
 		.send_flags = VERBS_INJECT(ep, len),
 	};
 
-	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &wr))
+	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
 
-	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
+	return vrb_send_buf(ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_dgram_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_dgram_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 			   uint64_t data, fi_addr_t dest_addr)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND_WITH_IMM,
@@ -183,19 +183,19 @@ fi_ibv_dgram_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &wr))
+	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
 
-	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf_inline(ep, &wr, buf, len);
 }
 
 static ssize_t
-fi_ibv_dgram_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_dgram_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 				uint64_t data, fi_addr_t dest_addr)
 {
 	ssize_t ret;
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	ep->wrs->msg_wr.imm_data = htonl((uint32_t)data);
 	ep->wrs->msg_wr.opcode = IBV_WR_SEND_WITH_IMM;
@@ -203,7 +203,7 @@ fi_ibv_dgram_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t l
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &ep->wrs->msg_wr))
+	if (vrb_dgram_ep_set_addr(ep, dest_addr, &ep->wrs->msg_wr))
 		return -FI_ENOENT;
 
 	ret = vrb_post_send(ep, &ep->wrs->msg_wr);
@@ -212,61 +212,61 @@ fi_ibv_dgram_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t l
 }
 
 static ssize_t
-fi_ibv_dgram_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_dgram_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 		       fi_addr_t dest_addr)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND,
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &wr))
+	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
 
-	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf_inline(ep, &wr, buf, len);
 }
 
 static ssize_t
-fi_ibv_dgram_ep_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_dgram_ep_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 			    fi_addr_t dest_addr)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	if (fi_ibv_dgram_ep_set_addr(ep, dest_addr, &ep->wrs->msg_wr))
+	if (vrb_dgram_ep_set_addr(ep, dest_addr, &ep->wrs->msg_wr))
 		return -FI_ENOENT;
 
 	return vrb_post_send(ep, &ep->wrs->msg_wr);
 }
 
-const struct fi_ops_msg fi_ibv_dgram_msg_ops = {
-	.size		= sizeof(fi_ibv_dgram_msg_ops),
-	.recv		= fi_ibv_dgram_ep_recv,
-	.recvv		= fi_ibv_dgram_ep_recvv,
-	.recvmsg	= fi_ibv_dgram_ep_recvmsg,
-	.send		= fi_ibv_dgram_ep_send,
-	.sendv		= fi_ibv_dgram_ep_sendv,
-	.sendmsg	= fi_ibv_dgram_ep_sendmsg,
-	.inject		= fi_ibv_dgram_ep_inject_fast,
-	.senddata	= fi_ibv_dgram_ep_senddata,
-	.injectdata	= fi_ibv_dgram_ep_injectdata_fast,
+const struct fi_ops_msg vrb_dgram_msg_ops = {
+	.size		= sizeof(vrb_dgram_msg_ops),
+	.recv		= vrb_dgram_ep_recv,
+	.recvv		= vrb_dgram_ep_recvv,
+	.recvmsg	= vrb_dgram_ep_recvmsg,
+	.send		= vrb_dgram_ep_send,
+	.sendv		= vrb_dgram_ep_sendv,
+	.sendmsg	= vrb_dgram_ep_sendmsg,
+	.inject		= vrb_dgram_ep_inject_fast,
+	.senddata	= vrb_dgram_ep_senddata,
+	.injectdata	= vrb_dgram_ep_injectdata_fast,
 };
 
-const struct fi_ops_msg fi_ibv_dgram_msg_ops_ts = {
-	.size		= sizeof(fi_ibv_dgram_msg_ops),
-	.recv		= fi_ibv_dgram_ep_recv,
-	.recvv		= fi_ibv_dgram_ep_recvv,
-	.recvmsg	= fi_ibv_dgram_ep_recvmsg,
-	.send		= fi_ibv_dgram_ep_send,
-	.sendv		= fi_ibv_dgram_ep_sendv,
-	.sendmsg	= fi_ibv_dgram_ep_sendmsg,
-	.inject		= fi_ibv_dgram_ep_inject,
-	.senddata	= fi_ibv_dgram_ep_senddata,
-	.injectdata	= fi_ibv_dgram_ep_injectdata,
+const struct fi_ops_msg vrb_dgram_msg_ops_ts = {
+	.size		= sizeof(vrb_dgram_msg_ops),
+	.recv		= vrb_dgram_ep_recv,
+	.recvv		= vrb_dgram_ep_recvv,
+	.recvmsg	= vrb_dgram_ep_recvmsg,
+	.send		= vrb_dgram_ep_send,
+	.sendv		= vrb_dgram_ep_sendv,
+	.sendmsg	= vrb_dgram_ep_sendmsg,
+	.inject		= vrb_dgram_ep_inject,
+	.senddata	= vrb_dgram_ep_senddata,
+	.injectdata	= vrb_dgram_ep_injectdata,
 };

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -39,13 +39,13 @@
 
 
 #if VERBS_HAVE_QUERY_EX
-static int fi_ibv_odp_flag(struct ibv_context *verbs)
+static int vrb_odp_flag(struct ibv_context *verbs)
 {
 	struct ibv_query_device_ex_input input = {0};
 	struct ibv_device_attr_ex attr;
 	int ret;
 
-	if (!fi_ibv_gl_data.use_odp)
+	if (!vrb_gl_data.use_odp)
 		return 0;
 
 	ret = ibv_query_device_ex(verbs, &input, &attr);
@@ -56,26 +56,26 @@ static int fi_ibv_odp_flag(struct ibv_context *verbs)
 	       VRB_USE_ODP : 0;
 }
 #else
-static int fi_ibv_odp_flag(struct ibv_context *verbs)
+static int vrb_odp_flag(struct ibv_context *verbs)
 {
 	return 0;
 }
 #endif /* VERBS_HAVE_QUERY_EX */
 
 
-static int fi_ibv_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+static int vrb_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
-	struct fi_ibv_domain *domain;
-	struct fi_ibv_eq *eq;
+	struct vrb_domain *domain;
+	struct vrb_eq *eq;
 
-	domain = container_of(fid, struct fi_ibv_domain,
+	domain = container_of(fid, struct vrb_domain,
 			      util_domain.domain_fid.fid);
 
 	switch (bfid->fclass) {
 	case FI_CLASS_EQ:
 		switch (domain->ep_type) {
 		case FI_EP_MSG:
-			eq = container_of(bfid, struct fi_ibv_eq, eq_fid);
+			eq = container_of(bfid, struct vrb_eq, eq_fid);
 			domain->eq = eq;
 			domain->eq_flags = flags;
 			break;
@@ -95,28 +95,28 @@ static int fi_ibv_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	return 0;
 }
 
-static int fi_ibv_domain_close(fid_t fid)
+static int vrb_domain_close(fid_t fid)
 {
 	int ret;
-	struct fi_ibv_fabric *fab;
-	struct fi_ibv_domain *domain =
-		container_of(fid, struct fi_ibv_domain,
+	struct vrb_fabric *fab;
+	struct vrb_domain *domain =
+		container_of(fid, struct vrb_domain,
 			     util_domain.domain_fid.fid);
 
 	switch (domain->ep_type) {
 	case FI_EP_DGRAM:
 		fab = container_of(&domain->util_domain.fabric->fabric_fid,
-				   struct fi_ibv_fabric,
+				   struct vrb_fabric,
 				   util_fabric.fabric_fid.fid);
 		/* Even if it's invoked not for the first time
 		 * (e.g. multiple domains per fabric), it's safe
 		 */
-		if (fi_ibv_gl_data.dgram.use_name_server)
+		if (vrb_gl_data.dgram.use_name_server)
 			ofi_ns_stop_server(&fab->name_server);
 		break;
 	case FI_EP_MSG:
 		if (domain->flags & VRB_USE_XRC) {
-			ret = fi_ibv_domain_xrc_cleanup(domain);
+			ret = vrb_domain_xrc_cleanup(domain);
 			if (ret)
 				return ret;
 		}
@@ -145,7 +145,7 @@ static int fi_ibv_domain_close(fid_t fid)
 	return 0;
 }
 
-static int fi_ibv_open_device_by_name(struct fi_ibv_domain *domain, const char *name)
+static int vrb_open_device_by_name(struct vrb_domain *domain, const char *name)
 {
 	struct ibv_context **dev_list;
 	int i, ret = -FI_ENODEV;
@@ -162,7 +162,7 @@ static int fi_ibv_open_device_by_name(struct fi_ibv_domain *domain, const char *
 		switch (domain->ep_type) {
 		case FI_EP_MSG:
 			ret = domain->flags & VRB_USE_XRC ?
-				fi_ibv_cmp_xrc_domain_name(name, rdma_name) :
+				vrb_cmp_xrc_domain_name(name, rdma_name) :
 				strcmp(name, rdma_name);
 			break;
 		case FI_EP_DGRAM:
@@ -185,33 +185,33 @@ static int fi_ibv_open_device_by_name(struct fi_ibv_domain *domain, const char *
 	return ret;
 }
 
-static struct fi_ops fi_ibv_fid_ops = {
+static struct fi_ops vrb_fid_ops = {
 	.size = sizeof(struct fi_ops),
-	.close = fi_ibv_domain_close,
-	.bind = fi_ibv_domain_bind,
+	.close = vrb_domain_close,
+	.bind = vrb_domain_bind,
 	.control = fi_no_control,
 	.ops_open = fi_no_ops_open,
 };
 
-static struct fi_ops_domain fi_ibv_msg_domain_ops = {
+static struct fi_ops_domain vrb_msg_domain_ops = {
 	.size = sizeof(struct fi_ops_domain),
 	.av_open = fi_no_av_open,
-	.cq_open = fi_ibv_cq_open,
-	.endpoint = fi_ibv_open_ep,
+	.cq_open = vrb_cq_open,
+	.endpoint = vrb_open_ep,
 	.scalable_ep = fi_no_scalable_ep,
 	.cntr_open = fi_no_cntr_open,
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = fi_no_stx_context,
-	.srx_ctx = fi_ibv_srq_context,
-	.query_atomic = fi_ibv_query_atomic,
+	.srx_ctx = vrb_srq_context,
+	.query_atomic = vrb_query_atomic,
 	.query_collective = fi_no_query_collective,
 };
 
-static struct fi_ops_domain fi_ibv_dgram_domain_ops = {
+static struct fi_ops_domain vrb_dgram_domain_ops = {
 	.size = sizeof(struct fi_ops_domain),
-	.av_open = fi_ibv_dgram_av_open,
-	.cq_open = fi_ibv_cq_open,
-	.endpoint = fi_ibv_open_ep,
+	.av_open = vrb_dgram_av_open,
+	.cq_open = vrb_cq_open,
+	.endpoint = vrb_open_ep,
 	.scalable_ep = fi_no_scalable_ep,
 	.poll_open = fi_no_poll_open,
 	.stx_ctx = fi_no_stx_context,
@@ -222,20 +222,20 @@ static struct fi_ops_domain fi_ibv_dgram_domain_ops = {
 
 
 static int
-fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
+vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	      struct fid_domain **domain, void *context)
 {
-	struct fi_ibv_domain *_domain;
+	struct vrb_domain *_domain;
 	int ret;
-	struct fi_ibv_fabric *fab =
-		 container_of(fabric, struct fi_ibv_fabric,
+	struct vrb_fabric *fab =
+		 container_of(fabric, struct vrb_fabric,
 			      util_fabric.fabric_fid);
-	const struct fi_info *fi = fi_ibv_get_verbs_info(fi_ibv_util_prov.info,
+	const struct fi_info *fi = vrb_get_verbs_info(vrb_util_prov.info,
 							 info->domain_attr->name);
 	if (!fi)
 		return -FI_EINVAL;
 
-	ret = ofi_check_domain_attr(&fi_ibv_prov, fabric->api_version,
+	ret = ofi_check_domain_attr(&vrb_prov, fabric->api_version,
 				    fi->domain_attr, info);
 	if (ret)
 		return ret;
@@ -252,10 +252,10 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 	if (!_domain->info)
 		goto err2;
 
-	_domain->ep_type = FI_IBV_EP_TYPE(info);
-	_domain->flags |= fi_ibv_is_xrc(info) ? VRB_USE_XRC : 0;
+	_domain->ep_type = VRB_EP_TYPE(info);
+	_domain->flags |= vrb_is_xrc(info) ? VRB_USE_XRC : 0;
 
-	ret = fi_ibv_open_device_by_name(_domain, info->domain_attr->name);
+	ret = vrb_open_device_by_name(_domain, info->domain_attr->name);
 	if (ret)
 		goto err3;
 
@@ -265,47 +265,47 @@ fi_ibv_domain(struct fid_fabric *fabric, struct fi_info *info,
 		goto err3;
 	}
 
-	_domain->flags |= fi_ibv_odp_flag(_domain->verbs);
+	_domain->flags |= vrb_odp_flag(_domain->verbs);
 	_domain->util_domain.domain_fid.fid.fclass = FI_CLASS_DOMAIN;
 	_domain->util_domain.domain_fid.fid.context = context;
-	_domain->util_domain.domain_fid.fid.ops = &fi_ibv_fid_ops;
+	_domain->util_domain.domain_fid.fid.ops = &vrb_fid_ops;
 
-	_domain->cache.entry_data_size = sizeof(struct fi_ibv_mem_desc);
-	_domain->cache.add_region = fi_ibv_mr_cache_add_region;
-	_domain->cache.delete_region = fi_ibv_mr_cache_delete_region;
+	_domain->cache.entry_data_size = sizeof(struct vrb_mem_desc);
+	_domain->cache.add_region = vrb_mr_cache_add_region;
+	_domain->cache.delete_region = vrb_mr_cache_delete_region;
 	ret = ofi_mr_cache_init(&_domain->util_domain, default_monitor,
 				&_domain->cache);
 	if (!ret)
-		_domain->util_domain.domain_fid.mr = &fi_ibv_mr_cache_ops;
+		_domain->util_domain.domain_fid.mr = &vrb_mr_cache_ops;
 	else
-		_domain->util_domain.domain_fid.mr = &fi_ibv_mr_ops;
+		_domain->util_domain.domain_fid.mr = &vrb_mr_ops;
 
 	switch (_domain->ep_type) {
 	case FI_EP_DGRAM:
-		if (fi_ibv_gl_data.dgram.use_name_server) {
+		if (vrb_gl_data.dgram.use_name_server) {
 			/* Even if it's invoked not for the first time
 			 * (e.g. multiple domains per fabric), it's safe
 			 */
 			fab->name_server.port =
-					fi_ibv_gl_data.dgram.name_server_port;
+					vrb_gl_data.dgram.name_server_port;
 			fab->name_server.name_len = sizeof(struct ofi_ib_ud_ep_name);
 			fab->name_server.service_len = sizeof(int);
-			fab->name_server.service_cmp = fi_ibv_dgram_ns_service_cmp;
+			fab->name_server.service_cmp = vrb_dgram_ns_service_cmp;
 			fab->name_server.is_service_wildcard =
-					fi_ibv_dgram_ns_is_service_wildcard;
+					vrb_dgram_ns_is_service_wildcard;
 
 			ofi_ns_init(&fab->name_server);
 			ofi_ns_start_server(&fab->name_server);
 		}
-		_domain->util_domain.domain_fid.ops = &fi_ibv_dgram_domain_ops;
+		_domain->util_domain.domain_fid.ops = &vrb_dgram_domain_ops;
 		break;
 	case FI_EP_MSG:
 		if (_domain->flags & VRB_USE_XRC) {
-			ret = fi_ibv_domain_xrc_init(_domain);
+			ret = vrb_domain_xrc_init(_domain);
 			if (ret)
 				goto err4;
 		}
-		_domain->util_domain.domain_fid.ops = &fi_ibv_msg_domain_ops;
+		_domain->util_domain.domain_fid.ops = &vrb_msg_domain_ops;
 		break;
 	default:
 		VERBS_INFO(FI_LOG_DOMAIN, "Ivalid EP type is provided, "
@@ -332,23 +332,23 @@ err1:
 	return ret;
 }
 
-static int fi_ibv_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
+static int vrb_trywait(struct fid_fabric *fabric, struct fid **fids, int count)
 {
-	struct fi_ibv_cq *cq;
-	struct fi_ibv_eq *eq;
+	struct vrb_cq *cq;
+	struct vrb_eq *eq;
 	int ret, i;
 
 	for (i = 0; i < count; i++) {
 		switch (fids[i]->fclass) {
 		case FI_CLASS_CQ:
-			cq = container_of(fids[i], struct fi_ibv_cq, util_cq.cq_fid.fid);
-			ret = fi_ibv_cq_trywait(cq);
+			cq = container_of(fids[i], struct vrb_cq, util_cq.cq_fid.fid);
+			ret = vrb_cq_trywait(cq);
 			if (ret)
 				return ret;
 			break;
 		case FI_CLASS_EQ:
-			eq = container_of(fids[i], struct fi_ibv_eq, eq_fid.fid);
-			ret = fi_ibv_eq_trywait(eq);
+			eq = container_of(fids[i], struct vrb_eq, eq_fid.fid);
+			ret = vrb_eq_trywait(eq);
 			if (ret)
 				return ret;
 			break;
@@ -363,12 +363,12 @@ static int fi_ibv_trywait(struct fid_fabric *fabric, struct fid **fids, int coun
 	return FI_SUCCESS;
 }
 
-static int fi_ibv_fabric_close(fid_t fid)
+static int vrb_fabric_close(fid_t fid)
 {
-	struct fi_ibv_fabric *fab;
+	struct vrb_fabric *fab;
 	int ret;
 
-	fab = container_of(fid, struct fi_ibv_fabric, util_fabric.fabric_fid.fid);
+	fab = container_of(fid, struct vrb_fabric, util_fabric.fabric_fid.fid);
 	ret = ofi_fabric_close(&fab->util_fabric);
 	if (ret)
 		return ret;
@@ -377,28 +377,28 @@ static int fi_ibv_fabric_close(fid_t fid)
 	return 0;
 }
 
-static struct fi_ops fi_ibv_fi_ops = {
+static struct fi_ops vrb_fi_ops = {
 	.size = sizeof(struct fi_ops),
-	.close = fi_ibv_fabric_close,
+	.close = vrb_fabric_close,
 	.bind = fi_no_bind,
 	.control = fi_no_control,
 	.ops_open = fi_no_ops_open,
 };
 
-static struct fi_ops_fabric fi_ibv_ops_fabric = {
+static struct fi_ops_fabric vrb_ops_fabric = {
 	.size = sizeof(struct fi_ops_fabric),
-	.domain = fi_ibv_domain,
-	.passive_ep = fi_ibv_passive_ep,
-	.eq_open = fi_ibv_eq_open,
+	.domain = vrb_domain,
+	.passive_ep = vrb_passive_ep,
+	.eq_open = vrb_eq_open,
 	.wait_open = fi_no_wait_open,
-	.trywait = fi_ibv_trywait
+	.trywait = vrb_trywait
 };
 
-int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
+int vrb_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		  void *context)
 {
-	struct fi_ibv_fabric *fab;
-	const struct fi_info *cur, *info = fi_ibv_util_prov.info;
+	struct vrb_fabric *fab;
+	const struct fi_info *cur, *info = vrb_util_prov.info;
 	int ret = FI_SUCCESS;
 
 	fab = calloc(1, sizeof(*fab));
@@ -406,7 +406,7 @@ int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 		return -FI_ENOMEM;
 
 	for (cur = info; cur; cur = info->next) {
-		ret = ofi_fabric_init(&fi_ibv_prov, cur->fabric_attr, attr,
+		ret = ofi_fabric_init(&vrb_prov, cur->fabric_attr, attr,
 				      &fab->util_fabric, context);
 		if (ret != -FI_ENODATA)
 			break;
@@ -420,8 +420,8 @@ int fi_ibv_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 
 	*fabric = &fab->util_fabric.fabric_fid;
 	(*fabric)->fid.fclass = FI_CLASS_FABRIC;
-	(*fabric)->fid.ops = &fi_ibv_fi_ops;
-	(*fabric)->ops = &fi_ibv_ops_fabric;
+	(*fabric)->fid.ops = &vrb_fi_ops;
+	(*fabric)->ops = &vrb_ops_fabric;
 
 	return 0;
 }

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -34,11 +34,11 @@
 
 #include "fi_verbs.h"
 
-static struct fi_ops_msg fi_ibv_srq_msg_ops;
+static struct fi_ops_msg vrb_srq_msg_ops;
 
 
 /* Receive CQ credits are pre-allocated */
-ssize_t vrb_post_recv(struct fi_ibv_ep *ep, struct ibv_recv_wr *wr)
+ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr)
 {
 	struct ibv_recv_wr *bad_wr;
 	int ret;
@@ -48,15 +48,15 @@ ssize_t vrb_post_recv(struct fi_ibv_ep *ep, struct ibv_recv_wr *wr)
 	return vrb_convert_ret(ret);
 }
 
-ssize_t vrb_post_send(struct fi_ibv_ep *ep, struct ibv_send_wr *wr)
+ssize_t vrb_post_send(struct vrb_ep *ep, struct ibv_send_wr *wr)
 {
 	struct vrb_context *ctx;
-	struct fi_ibv_cq *cq;
+	struct vrb_cq *cq;
 	struct ibv_send_wr *bad_wr;
 	struct ibv_wc wc;
 	int ret;
 
-	cq = container_of(ep->util_ep.tx_cq, struct fi_ibv_cq, util_cq);
+	cq = container_of(ep->util_ep.tx_cq, struct vrb_cq, util_cq);
 	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
 	ctx = ofi_buf_alloc(cq->ctx_pool);
 	if (!ctx)
@@ -99,31 +99,31 @@ unlock:
 	return -FI_EAGAIN;
 }
 
-static inline int fi_ibv_msg_ep_cmdata_size(fid_t fid)
+static inline int vrb_msg_ep_cmdata_size(fid_t fid)
 {
-	struct fi_ibv_pep *pep;
-	struct fi_ibv_ep *ep;
+	struct vrb_pep *pep;
+	struct vrb_ep *ep;
 	struct fi_info *info;
 
 	switch (fid->fclass) {
 	case FI_CLASS_PEP:
-		pep = container_of(fid, struct fi_ibv_pep, pep_fid.fid);
+		pep = container_of(fid, struct vrb_pep, pep_fid.fid);
 		info = pep->info;
 		break;
 	case FI_CLASS_EP:
-		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid.fid);
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid.fid);
 		info = ep->info;
 		break;
 	default:
 		info = NULL;
 	};
-	if (fi_ibv_is_xrc(info))
-		return VERBS_CM_DATA_SIZE - sizeof(struct fi_ibv_xrc_cm_data);
+	if (vrb_is_xrc(info))
+		return VERBS_CM_DATA_SIZE - sizeof(struct vrb_xrc_cm_data);
 	else
 		return VERBS_CM_DATA_SIZE;
 }
 
-static int fi_ibv_ep_getopt(fid_t fid, int level, int optname,
+static int vrb_ep_getopt(fid_t fid, int level, int optname,
 			    void *optval, size_t *optlen)
 {
 	switch (level) {
@@ -132,7 +132,7 @@ static int fi_ibv_ep_getopt(fid_t fid, int level, int optname,
 		case FI_OPT_CM_DATA_SIZE:
 			if (*optlen < sizeof(size_t))
 				return -FI_ETOOSMALL;
-			*((size_t *) optval) = fi_ibv_msg_ep_cmdata_size(fid);
+			*((size_t *) optval) = vrb_msg_ep_cmdata_size(fid);
 			*optlen = sizeof(size_t);
 			return 0;
 		default:
@@ -144,7 +144,7 @@ static int fi_ibv_ep_getopt(fid_t fid, int level, int optname,
 	return 0;
 }
 
-static int fi_ibv_ep_setopt(fid_t fid, int level, int optname,
+static int vrb_ep_setopt(fid_t fid, int level, int optname,
 			    const void *optval, size_t optlen)
 {
 	switch (level) {
@@ -156,18 +156,18 @@ static int fi_ibv_ep_setopt(fid_t fid, int level, int optname,
 	return 0;
 }
 
-static struct fi_ops_ep fi_ibv_ep_base_ops = {
+static struct fi_ops_ep vrb_ep_base_ops = {
 	.size = sizeof(struct fi_ops_ep),
 	.cancel = fi_no_cancel,
-	.getopt = fi_ibv_ep_getopt,
-	.setopt = fi_ibv_ep_setopt,
+	.getopt = vrb_ep_getopt,
+	.setopt = vrb_ep_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
 	.rx_size_left = fi_no_rx_size_left,
 	.tx_size_left = fi_no_tx_size_left,
 };
 
-static struct fi_ops_rma fi_ibv_dgram_rma_ops = {
+static struct fi_ops_rma vrb_dgram_rma_ops = {
 	.size = sizeof(struct fi_ops_rma),
 	.read = fi_no_rma_read,
 	.readv = fi_no_rma_readv,
@@ -180,7 +180,7 @@ static struct fi_ops_rma fi_ibv_dgram_rma_ops = {
 	.injectdata = fi_no_rma_injectdata,
 };
 
-static int fi_ibv_alloc_wrs(struct fi_ibv_ep *ep)
+static int vrb_alloc_wrs(struct vrb_ep *ep)
 {
 	ep->wrs = calloc(1, sizeof(*ep->wrs));
 	if (!ep->wrs)
@@ -201,26 +201,26 @@ static int fi_ibv_alloc_wrs(struct fi_ibv_ep *ep)
 	return FI_SUCCESS;
 }
 
-static void fi_ibv_free_wrs(struct fi_ibv_ep *ep)
+static void vrb_free_wrs(struct vrb_ep *ep)
 {
 	free(ep->wrs);
 }
 
-static void fi_ibv_util_ep_progress_noop(struct util_ep *util_ep)
+static void vrb_util_ep_progress_noop(struct util_ep *util_ep)
 {
 	/* This routine shouldn't be called */
 	assert(0);
 }
 
-static struct fi_ibv_ep *
-fi_ibv_alloc_init_ep(struct fi_info *info, struct fi_ibv_domain *domain,
+static struct vrb_ep *
+vrb_alloc_init_ep(struct fi_info *info, struct vrb_domain *domain,
 		     void *context)
 {
-	struct fi_ibv_ep *ep;
-	struct fi_ibv_xrc_ep *xrc_ep;
+	struct vrb_ep *ep;
+	struct vrb_xrc_ep *xrc_ep;
 	int ret;
 
-	if (fi_ibv_is_xrc(info)) {
+	if (vrb_is_xrc(info)) {
 		xrc_ep = calloc(1, sizeof(*xrc_ep));
 		if (!xrc_ep)
 			return NULL;
@@ -237,12 +237,12 @@ fi_ibv_alloc_init_ep(struct fi_info *info, struct fi_ibv_domain *domain,
 		goto err1;
 
 	if (domain->util_domain.threading != FI_THREAD_SAFE) {
-		if (fi_ibv_alloc_wrs(ep))
+		if (vrb_alloc_wrs(ep))
 			goto err2;
 	}
 
-	ret = ofi_endpoint_init(&domain->util_domain.domain_fid, &fi_ibv_util_prov, info,
-				&ep->util_ep, context, fi_ibv_util_ep_progress_noop);
+	ret = ofi_endpoint_init(&domain->util_domain.domain_fid, &vrb_util_prov, info,
+				&ep->util_ep, context, vrb_util_ep_progress_noop);
 	if (ret) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "Unable to initialize EP, error - %d\n", ret);
@@ -257,7 +257,7 @@ fi_ibv_alloc_init_ep(struct fi_info *info, struct fi_ibv_domain *domain,
 err4:
 	(void) ofi_endpoint_close(&ep->util_ep);
 err3:
-	fi_ibv_free_wrs(ep);
+	vrb_free_wrs(ep);
 err2:
 	fi_freeinfo(ep->info);
 err1:
@@ -265,9 +265,9 @@ err1:
 	return NULL;
 }
 
-static int fi_ibv_close_free_ep(struct fi_ibv_ep *ep)
+static int vrb_close_free_ep(struct vrb_ep *ep)
 {
-	struct fi_ibv_cq *cq;
+	struct vrb_cq *cq;
 	int ret;
 
 	free(ep->util_ep.ep_fid.msg);
@@ -275,7 +275,7 @@ static int fi_ibv_close_free_ep(struct fi_ibv_ep *ep)
 	free(ep->cm_hdr);
 
 	if (ep->util_ep.rx_cq) {
-		cq = container_of(ep->util_ep.rx_cq, struct fi_ibv_cq, util_cq);
+		cq = container_of(ep->util_ep.rx_cq, struct vrb_cq, util_cq);
 		cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
 		cq->credits += ep->rx_cq_size;
 		cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
@@ -284,7 +284,7 @@ static int fi_ibv_close_free_ep(struct fi_ibv_ep *ep)
 	if (ret)
 		return ret;
 
-	fi_ibv_free_wrs(ep);
+	vrb_free_wrs(ep);
 	fi_freeinfo(ep->info);
 	free(ep);
 
@@ -292,26 +292,26 @@ static int fi_ibv_close_free_ep(struct fi_ibv_ep *ep)
 }
 
 /* Caller must hold eq:lock */
-static inline void fi_ibv_ep_xrc_close(struct fi_ibv_ep *ep)
+static inline void vrb_ep_xrc_close(struct vrb_ep *ep)
 {
-	struct fi_ibv_xrc_ep *xrc_ep = container_of(ep, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *xrc_ep = container_of(ep, struct vrb_xrc_ep,
 						    base_ep);
 
 	if (xrc_ep->conn_setup)
-		fi_ibv_free_xrc_conn_setup(xrc_ep, 0);
+		vrb_free_xrc_conn_setup(xrc_ep, 0);
 
 	if (xrc_ep->conn_map_node)
-		fi_ibv_eq_remove_sidr_conn(xrc_ep);
-	fi_ibv_ep_destroy_xrc_qp(xrc_ep);
+		vrb_eq_remove_sidr_conn(xrc_ep);
+	vrb_ep_destroy_xrc_qp(xrc_ep);
 	xrc_ep->magic = 0;
 }
 
-static int fi_ibv_ep_close(fid_t fid)
+static int vrb_ep_close(fid_t fid)
 {
 	int ret;
-	struct fi_ibv_fabric *fab;
-	struct fi_ibv_ep *ep =
-		container_of(fid, struct fi_ibv_ep, util_ep.ep_fid.fid);
+	struct vrb_fabric *fab;
+	struct vrb_ep *ep =
+		container_of(fid, struct vrb_ep, util_ep.ep_fid.fid);
 
 	switch (ep->util_ep.type) {
 	case FI_EP_MSG:
@@ -326,21 +326,21 @@ static int fi_ibv_ep_close(fid_t fid)
 				ep->eq->err.err = 0;
 				ep->eq->err.prov_errno = 0;
 			}
-			fi_ibv_eq_remove_events(ep->eq, fid);
+			vrb_eq_remove_events(ep->eq, fid);
 		}
 
-		if (fi_ibv_is_xrc(ep->info))
-			fi_ibv_ep_xrc_close(ep);
+		if (vrb_is_xrc(ep->info))
+			vrb_ep_xrc_close(ep);
 		else
 			rdma_destroy_ep(ep->id);
 
 		if (ep->eq)
 			fastlock_release(&ep->eq->lock);
-		fi_ibv_cleanup_cq(ep);
+		vrb_cleanup_cq(ep);
 		break;
 	case FI_EP_DGRAM:
 		fab = container_of(&ep->util_ep.domain->fabric->fabric_fid,
-				   struct fi_ibv_fabric, util_fabric.fabric_fid.fid);
+				   struct vrb_fabric, util_fabric.fabric_fid.fid);
 		ofi_ns_del_local_name(&fab->name_server,
 				      &ep->service, &ep->ep_name);
 		ret = ibv_destroy_qp(ep->ibv_qp);
@@ -349,7 +349,7 @@ static int fi_ibv_ep_close(fid_t fid)
 				   "Unable to destroy QP (errno = %d)\n", errno);
 			return -errno;
 		}
-		fi_ibv_cleanup_cq(ep);
+		vrb_cleanup_cq(ep);
 		break;
 	default:
 		VERBS_INFO(FI_LOG_DOMAIN, "Unknown EP type\n");
@@ -359,7 +359,7 @@ static int fi_ibv_ep_close(fid_t fid)
 
 	VERBS_INFO(FI_LOG_DOMAIN, "EP %p is being closed\n", ep);
 
-	ret = fi_ibv_close_free_ep(ep);
+	ret = vrb_close_free_ep(ep);
 	if (ret) {
 		VERBS_WARN(FI_LOG_DOMAIN,
 			   "Unable to close EP (%p), error - %d\n", ep, ret);
@@ -369,9 +369,9 @@ static int fi_ibv_ep_close(fid_t fid)
 	return 0;
 }
 
-static inline int fi_ibv_ep_xrc_set_tgt_chan(struct fi_ibv_ep *ep)
+static inline int vrb_ep_xrc_set_tgt_chan(struct vrb_ep *ep)
 {
-	struct fi_ibv_xrc_ep *xrc_ep = container_of(ep, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *xrc_ep = container_of(ep, struct vrb_xrc_ep,
 						    base_ep);
 	if (xrc_ep->tgt_id)
 		return rdma_migrate_id(xrc_ep->tgt_id, ep->eq->channel);
@@ -379,16 +379,16 @@ static inline int fi_ibv_ep_xrc_set_tgt_chan(struct fi_ibv_ep *ep)
 	return FI_SUCCESS;
 }
 
-static int fi_ibv_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+static int vrb_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
-	struct fi_ibv_ep *ep;
-	struct fi_ibv_cq *cq =
-		container_of(bfid, struct fi_ibv_cq, util_cq.cq_fid.fid);
-	struct fi_ibv_dgram_av *av;
+	struct vrb_ep *ep;
+	struct vrb_cq *cq =
+		container_of(bfid, struct vrb_cq, util_cq.cq_fid.fid);
+	struct vrb_dgram_av *av;
 	int ret;
 
-	ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid.fid);
-	ret = ofi_ep_bind_valid(&fi_ibv_prov, bfid, flags);
+	ep = container_of(fid, struct vrb_ep, util_ep.ep_fid.fid);
+	ret = ofi_ep_bind_valid(&vrb_prov, bfid, flags);
 	if (ret)
 		return ret;
 
@@ -418,12 +418,12 @@ static int fi_ibv_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		if (ep->util_ep.type != FI_EP_MSG)
 			return -FI_EINVAL;
 
-		ep->eq = container_of(bfid, struct fi_ibv_eq, eq_fid.fid);
+		ep->eq = container_of(bfid, struct vrb_eq, eq_fid.fid);
 
 		/* Make sure EQ channel is not polled during migrate */
 		fastlock_acquire(&ep->eq->lock);
-		if (fi_ibv_is_xrc(ep->info))
-			ret = fi_ibv_ep_xrc_set_tgt_chan(ep);
+		if (vrb_is_xrc(ep->info))
+			ret = vrb_ep_xrc_set_tgt_chan(ep);
 		else
 			ret = rdma_migrate_id(ep->id, ep->eq->channel);
 		fastlock_release(&ep->eq->lock);
@@ -435,13 +435,13 @@ static int fi_ibv_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		if (ep->util_ep.type != FI_EP_MSG)
 			return -FI_EINVAL;
 
-		ep->srq_ep = container_of(bfid, struct fi_ibv_srq_ep, ep_fid.fid);
+		ep->srq_ep = container_of(bfid, struct vrb_srq_ep, ep_fid.fid);
 		break;
 	case FI_CLASS_AV:
 		if (ep->util_ep.type != FI_EP_DGRAM)
 			return -FI_EINVAL;
 
-		av = container_of(bfid, struct fi_ibv_dgram_av,
+		av = container_of(bfid, struct vrb_dgram_av,
 				  util_av.av_fid.fid);
 		return ofi_ep_bind_av(&ep->util_ep, &av->util_av);
 	default:
@@ -451,10 +451,10 @@ static int fi_ibv_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	return 0;
 }
 
-static int fi_ibv_create_dgram_ep(struct fi_ibv_domain *domain, struct fi_ibv_ep *ep,
+static int vrb_create_dgram_ep(struct vrb_domain *domain, struct vrb_ep *ep,
 				  struct ibv_qp_init_attr *init_attr)
 {
-	struct fi_ibv_fabric *fab;
+	struct vrb_fabric *fab;
 	struct ibv_qp_attr attr = {
 		.qp_state = IBV_QPS_INIT,
 		.pkey_index = 0,
@@ -510,7 +510,7 @@ static int fi_ibv_create_dgram_ep(struct fi_ibv_domain *domain, struct fi_ibv_ep
 		}
 	}
 
-	if (ibv_query_gid(domain->verbs, 1, fi_ibv_gl_data.gid_idx, &gid)) {
+	if (ibv_query_gid(domain->verbs, 1, vrb_gl_data.gid_idx, &gid)) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "Unable to query GID, errno = %d",
 			   errno);
@@ -538,7 +538,7 @@ static int fi_ibv_create_dgram_ep(struct fi_ibv_domain *domain, struct fi_ibv_ep
 	ep->ep_name.pkey = p_key;
 
 	fab = container_of(ep->util_ep.domain->fabric,
-			   struct fi_ibv_fabric, util_fabric);
+			   struct vrb_fabric, util_fabric);
 
 	ofi_ns_add_local_name(&fab->name_server,
 			      &ep->service, &ep->ep_name);
@@ -546,11 +546,11 @@ static int fi_ibv_create_dgram_ep(struct fi_ibv_domain *domain, struct fi_ibv_ep
 	return 0;
 }
 
-/* fi_ibv_srq_ep::xrc.prepost_lock must be held */
+/* vrb_srq_ep::xrc.prepost_lock must be held */
 FI_VERBS_XRC_ONLY
-static int fi_ibv_process_xrc_preposted(struct fi_ibv_srq_ep *srq_ep)
+static int vrb_process_xrc_preposted(struct vrb_srq_ep *srq_ep)
 {
-	struct fi_ibv_xrc_srx_prepost *recv;
+	struct vrb_xrc_srx_prepost *recv;
 	struct slist_entry *entry;
 	int ret;
 
@@ -558,7 +558,7 @@ static int fi_ibv_process_xrc_preposted(struct fi_ibv_srq_ep *srq_ep)
 	 * posting here results in adding the RX entries to the SRQ */
 	while (!slist_empty(&srq_ep->xrc.prepost_list)) {
 		entry = slist_remove_head(&srq_ep->xrc.prepost_list);
-		recv = container_of(entry, struct fi_ibv_xrc_srx_prepost,
+		recv = container_of(entry, struct vrb_xrc_srx_prepost,
 				    prepost_entry);
 		ret = fi_recv(&srq_ep->ep_fid, recv->buf, recv->len,
 			      recv->desc, recv->src_addr, recv->context);
@@ -571,22 +571,22 @@ static int fi_ibv_process_xrc_preposted(struct fi_ibv_srq_ep *srq_ep)
 	return FI_SUCCESS;
 }
 
-static int fi_ibv_ep_enable_xrc(struct fi_ibv_ep *ep)
+static int vrb_ep_enable_xrc(struct vrb_ep *ep)
 {
 #if VERBS_HAVE_XRC
-	struct fi_ibv_xrc_ep *xrc_ep = container_of(ep, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *xrc_ep = container_of(ep, struct vrb_xrc_ep,
 						    base_ep);
-	struct fi_ibv_srq_ep *srq_ep = ep->srq_ep;
-	struct fi_ibv_domain *domain = container_of(ep->util_ep.rx_cq->domain,
-					    struct fi_ibv_domain, util_domain);
-	struct fi_ibv_cq *cq = container_of(ep->util_ep.rx_cq,
-					    struct fi_ibv_cq, util_cq);
+	struct vrb_srq_ep *srq_ep = ep->srq_ep;
+	struct vrb_domain *domain = container_of(ep->util_ep.rx_cq->domain,
+					    struct vrb_domain, util_domain);
+	struct vrb_cq *cq = container_of(ep->util_ep.rx_cq,
+					    struct vrb_cq, util_cq);
 	struct ibv_srq_init_attr_ex attr;
 	ssize_t ret;
 
 	/* XRC EP additional initialization */
 	dlist_init(&xrc_ep->ini_conn_entry);
-	xrc_ep->conn_state = FI_IBV_XRC_UNCONNECTED;
+	xrc_ep->conn_state = VRB_XRC_UNCONNECTED;
 
 	fastlock_acquire(&srq_ep->xrc.prepost_lock);
 	if (srq_ep->srq) {
@@ -630,8 +630,8 @@ static int fi_ibv_ep_enable_xrc(struct fi_ibv_ep *ep)
 	ibv_get_srq_num(srq_ep->srq, &xrc_ep->srqn);
 
 	/* Swap functions since locking is no longer required */
-	srq_ep->ep_fid.msg = &fi_ibv_srq_msg_ops;
-	ret = fi_ibv_process_xrc_preposted(srq_ep);
+	srq_ep->ep_fid.msg = &vrb_srq_msg_ops;
+	ret = vrb_process_xrc_preposted(srq_ep);
 done:
 	fastlock_release(&srq_ep->xrc.prepost_lock);
 
@@ -641,35 +641,35 @@ done:
 #endif /* !VERBS_HAVE_XRC */
 }
 
-void fi_ibv_msg_ep_get_qp_attr(struct fi_ibv_ep *ep,
+void vrb_msg_ep_get_qp_attr(struct vrb_ep *ep,
 			       struct ibv_qp_init_attr *attr)
 {
 	attr->qp_context = ep;
 
 	if (ep->util_ep.tx_cq) {
-		struct fi_ibv_cq *cq = container_of(ep->util_ep.tx_cq,
-						    struct fi_ibv_cq, util_cq);
+		struct vrb_cq *cq = container_of(ep->util_ep.tx_cq,
+						    struct vrb_cq, util_cq);
 
 		attr->cap.max_send_wr = ep->info->tx_attr->size;
 		attr->cap.max_send_sge = ep->info->tx_attr->iov_limit;
 		attr->send_cq = cq->cq;
 	} else {
-		struct fi_ibv_cq *cq =
-			container_of(ep->util_ep.rx_cq, struct fi_ibv_cq, util_cq);
+		struct vrb_cq *cq =
+			container_of(ep->util_ep.rx_cq, struct vrb_cq, util_cq);
 
 		attr->send_cq = cq->cq;
 	}
 
 	if (ep->util_ep.rx_cq) {
-		struct fi_ibv_cq *cq =
-			container_of(ep->util_ep.rx_cq, struct fi_ibv_cq, util_cq);
+		struct vrb_cq *cq =
+			container_of(ep->util_ep.rx_cq, struct vrb_cq, util_cq);
 
 		attr->cap.max_recv_wr = ep->info->rx_attr->size;
 		attr->cap.max_recv_sge = ep->info->rx_attr->iov_limit;
 		attr->recv_cq = cq->cq;
 	} else {
-		struct fi_ibv_cq *cq =
-			container_of(ep->util_ep.tx_cq, struct fi_ibv_cq, util_cq);
+		struct vrb_cq *cq =
+			container_of(ep->util_ep.tx_cq, struct vrb_cq, util_cq);
 
 		attr->recv_cq = cq->cq;
 	}
@@ -685,12 +685,12 @@ void fi_ibv_msg_ep_get_qp_attr(struct fi_ibv_ep *ep,
 }
 
 
-static int fi_ibv_ep_enable(struct fid_ep *ep_fid)
+static int vrb_ep_enable(struct fid_ep *ep_fid)
 {
 	struct ibv_qp_init_attr attr = { 0 };
-	struct fi_ibv_ep *ep = container_of(ep_fid, struct fi_ibv_ep,
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep,
 					    util_ep.ep_fid);
-	struct fi_ibv_domain *domain = fi_ibv_ep_to_domain(ep);
+	struct vrb_domain *domain = vrb_ep_to_domain(ep);
 	int ret;
 
 	if (!ep->eq && (ep->util_ep.type == FI_EP_MSG)) {
@@ -719,7 +719,7 @@ static int fi_ibv_ep_enable(struct fid_ep *ep_fid)
 			   "capabilities enabled. (FI_RECV)\n");
 		return -FI_ENOCQ;
 	}
-	fi_ibv_msg_ep_get_qp_attr(ep, &attr);
+	vrb_msg_ep_get_qp_attr(ep, &attr);
 
 	switch (ep->util_ep.type) {
 	case FI_EP_MSG:
@@ -727,8 +727,8 @@ static int fi_ibv_ep_enable(struct fid_ep *ep_fid)
 			/* Override receive function pointers to prevent the user from
 			 * posting Receive WRs to a QP where a SRQ is attached to it */
 			if (domain->flags & VRB_USE_XRC) {
-				*ep->util_ep.ep_fid.msg = fi_ibv_msg_srq_xrc_ep_msg_ops;
-				return fi_ibv_ep_enable_xrc(ep);
+				*ep->util_ep.ep_fid.msg = vrb_msg_srq_xrc_ep_msg_ops;
+				return vrb_ep_enable_xrc(ep);
 			} else {
 				ep->util_ep.ep_fid.msg->recv = fi_no_msg_recv;
 				ep->util_ep.ep_fid.msg->recvv = fi_no_msg_recvv;
@@ -756,7 +756,7 @@ static int fi_ibv_ep_enable(struct fid_ep *ep_fid)
 	case FI_EP_DGRAM:
 		assert(domain);
 		attr.sq_sig_all = 1;
-		ret = fi_ibv_create_dgram_ep(domain, ep, &attr);
+		ret = vrb_create_dgram_ep(domain, ep, &attr);
 		if (ret) {
 			VERBS_WARN(FI_LOG_EP_CTRL, "Unable to create dgram EP: %s (%d)\n",
 				   fi_strerror(-ret), -ret);
@@ -771,7 +771,7 @@ static int fi_ibv_ep_enable(struct fid_ep *ep_fid)
 	return 0;
 }
 
-static int fi_ibv_ep_control(struct fid *fid, int command, void *arg)
+static int vrb_ep_control(struct fid *fid, int command, void *arg)
 {
 	struct fid_ep *ep;
 
@@ -780,7 +780,7 @@ static int fi_ibv_ep_control(struct fid *fid, int command, void *arg)
 		ep = container_of(fid, struct fid_ep, fid);
 		switch (command) {
 		case FI_ENABLE:
-			return fi_ibv_ep_enable(ep);
+			return vrb_ep_enable(ep);
 			break;
 		default:
 			return -FI_ENOSYS;
@@ -791,13 +791,13 @@ static int fi_ibv_ep_control(struct fid *fid, int command, void *arg)
 	}
 }
 
-static int fi_ibv_dgram_ep_setname(fid_t ep_fid, void *addr, size_t addrlen)
+static int vrb_dgram_ep_setname(fid_t ep_fid, void *addr, size_t addrlen)
 {
-	struct fi_ibv_ep *ep;
+	struct vrb_ep *ep;
 	void *save_addr;
 	int ret = FI_SUCCESS;
 
-	ep = container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid.fid);
+	ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid.fid);
 	if (addrlen < ep->info->src_addrlen) {
 		VERBS_INFO(FI_LOG_EP_CTRL,
 			   "addrlen expected: %zu, got: %zu\n",
@@ -825,11 +825,11 @@ err:
 	return ret;
 }
 
-static int fi_ibv_dgram_ep_getname(fid_t ep_fid, void *addr, size_t *addrlen)
+static int vrb_dgram_ep_getname(fid_t ep_fid, void *addr, size_t *addrlen)
 {
-	struct fi_ibv_ep *ep;
+	struct vrb_ep *ep;
 
-	ep = container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid.fid);
+	ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid.fid);
 	if (*addrlen < sizeof(ep->ep_name)) {
 		*addrlen = sizeof(ep->ep_name);
 		VERBS_INFO(FI_LOG_EP_CTRL,
@@ -845,18 +845,18 @@ static int fi_ibv_dgram_ep_getname(fid_t ep_fid, void *addr, size_t *addrlen)
 	return FI_SUCCESS;
 }
 
-static struct fi_ops fi_ibv_ep_ops = {
+static struct fi_ops vrb_ep_ops = {
 	.size = sizeof(struct fi_ops),
-	.close = fi_ibv_ep_close,
-	.bind = fi_ibv_ep_bind,
-	.control = fi_ibv_ep_control,
+	.close = vrb_ep_close,
+	.bind = vrb_ep_bind,
+	.control = vrb_ep_control,
 	.ops_open = fi_no_ops_open,
 };
 
-static struct fi_ops_cm fi_ibv_dgram_cm_ops = {
-	.size = sizeof(fi_ibv_dgram_cm_ops),
-	.setname = fi_ibv_dgram_ep_setname,
-	.getname = fi_ibv_dgram_ep_getname,
+static struct fi_ops_cm vrb_dgram_cm_ops = {
+	.size = sizeof(vrb_dgram_cm_ops),
+	.setname = vrb_dgram_ep_setname,
+	.getname = vrb_dgram_ep_getname,
 	.getpeer = fi_no_getpeer,
 	.connect = fi_no_connect,
 	.listen = fi_no_listen,
@@ -866,24 +866,24 @@ static struct fi_ops_cm fi_ibv_dgram_cm_ops = {
 	.join = fi_no_join,
 };
 
-int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
+int vrb_open_ep(struct fid_domain *domain, struct fi_info *info,
 		   struct fid_ep **ep_fid, void *context)
 {
-	struct fi_ibv_domain *dom;
-	struct fi_ibv_ep *ep;
-	struct fi_ibv_connreq *connreq;
-	struct fi_ibv_pep *pep;
+	struct vrb_domain *dom;
+	struct vrb_ep *ep;
+	struct vrb_connreq *connreq;
+	struct vrb_pep *pep;
 	struct fi_info *fi;
 	int ret;
 
 	if (info->src_addr)
-		ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_FABRIC,
+		ofi_straddr_dbg(&vrb_prov, FI_LOG_FABRIC,
 				"open_ep src addr", info->src_addr);
 	if (info->dest_addr)
-		ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_FABRIC,
+		ofi_straddr_dbg(&vrb_prov, FI_LOG_FABRIC,
 				"open_ep dest addr", info->dest_addr);
 
-	dom = container_of(domain, struct fi_ibv_domain,
+	dom = container_of(domain, struct vrb_domain,
 			   util_domain.domain_fid);
 	/* strncmp is used here, because the function is used
 	 * to allocate DGRAM (has prefix <dev_name>-dgram) and MSG EPs */
@@ -898,25 +898,25 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 	fi = dom->info;
 
 	if (info->ep_attr) {
-		ret = fi_ibv_check_ep_attr(info, fi);
+		ret = vrb_check_ep_attr(info, fi);
 		if (ret)
 			return ret;
 	}
 
 	if (info->tx_attr) {
-		ret = ofi_check_tx_attr(&fi_ibv_prov, fi->tx_attr,
+		ret = ofi_check_tx_attr(&vrb_prov, fi->tx_attr,
 					info->tx_attr, info->mode);
 		if (ret)
 			return ret;
 	}
 
 	if (info->rx_attr) {
-		ret = fi_ibv_check_rx_attr(info->rx_attr, info, fi);
+		ret = vrb_check_rx_attr(info->rx_attr, info, fi);
 		if (ret)
 			return ret;
 	}
 
-	ep = fi_ibv_alloc_init_ep(info, dom, context);
+	ep = vrb_alloc_init_ep(info, dom, context);
 	if (!ep) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "Unable to allocate/init EP memory\n");
@@ -929,30 +929,30 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 	case FI_EP_MSG:
 		if (dom->flags & VRB_USE_XRC) {
 			if (dom->util_domain.threading == FI_THREAD_SAFE) {
-				*ep->util_ep.ep_fid.msg = fi_ibv_msg_xrc_ep_msg_ops_ts;
-				ep->util_ep.ep_fid.rma = &fi_ibv_msg_xrc_ep_rma_ops_ts;
+				*ep->util_ep.ep_fid.msg = vrb_msg_xrc_ep_msg_ops_ts;
+				ep->util_ep.ep_fid.rma = &vrb_msg_xrc_ep_rma_ops_ts;
 			} else {
-				*ep->util_ep.ep_fid.msg = fi_ibv_msg_xrc_ep_msg_ops;
-				ep->util_ep.ep_fid.rma = &fi_ibv_msg_xrc_ep_rma_ops;
+				*ep->util_ep.ep_fid.msg = vrb_msg_xrc_ep_msg_ops;
+				ep->util_ep.ep_fid.rma = &vrb_msg_xrc_ep_rma_ops;
 			}
-			ep->util_ep.ep_fid.cm = &fi_ibv_msg_xrc_ep_cm_ops;
-			ep->util_ep.ep_fid.atomic = &fi_ibv_msg_xrc_ep_atomic_ops;
+			ep->util_ep.ep_fid.cm = &vrb_msg_xrc_ep_cm_ops;
+			ep->util_ep.ep_fid.atomic = &vrb_msg_xrc_ep_atomic_ops;
 		} else {
 			if (dom->util_domain.threading == FI_THREAD_SAFE) {
-				*ep->util_ep.ep_fid.msg = fi_ibv_msg_ep_msg_ops_ts;
-				ep->util_ep.ep_fid.rma = &fi_ibv_msg_ep_rma_ops_ts;
+				*ep->util_ep.ep_fid.msg = vrb_msg_ep_msg_ops_ts;
+				ep->util_ep.ep_fid.rma = &vrb_msg_ep_rma_ops_ts;
 			} else {
-				*ep->util_ep.ep_fid.msg = fi_ibv_msg_ep_msg_ops;
-				ep->util_ep.ep_fid.rma = &fi_ibv_msg_ep_rma_ops;
+				*ep->util_ep.ep_fid.msg = vrb_msg_ep_msg_ops;
+				ep->util_ep.ep_fid.rma = &vrb_msg_ep_rma_ops;
 			}
-			ep->util_ep.ep_fid.cm = &fi_ibv_msg_ep_cm_ops;
-			ep->util_ep.ep_fid.atomic = &fi_ibv_msg_ep_atomic_ops;
+			ep->util_ep.ep_fid.cm = &vrb_msg_ep_cm_ops;
+			ep->util_ep.ep_fid.atomic = &vrb_msg_ep_atomic_ops;
 		}
 
 		if (!info->handle) {
 			/* Only RC, XRC active RDMA CM ID is created at connect */
 			if (!(dom->flags & VRB_USE_XRC)) {
-				ret = fi_ibv_create_ep(info, RDMA_PS_TCP,
+				ret = vrb_create_ep(info, RDMA_PS_TCP,
 						       &ep->id);
 				if (ret)
 					goto err1;
@@ -960,12 +960,12 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 			}
 		} else if (info->handle->fclass == FI_CLASS_CONNREQ) {
 			connreq = container_of(info->handle,
-					       struct fi_ibv_connreq, handle);
+					       struct vrb_connreq, handle);
 			if (dom->flags & VRB_USE_XRC) {
 				assert(connreq->is_xrc);
 
 				if (!connreq->xrc.is_reciprocal) {
-					ret = fi_ibv_process_xrc_connreq(ep,
+					ret = vrb_process_xrc_connreq(ep,
 								connreq);
 					if (ret)
 						goto err1;
@@ -976,7 +976,7 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 				ep->id->context = &ep->util_ep.ep_fid.fid;
 			}
 		} else if (info->handle->fclass == FI_CLASS_PEP) {
-			pep = container_of(info->handle, struct fi_ibv_pep, pep_fid.fid);
+			pep = container_of(info->handle, struct vrb_pep, pep_fid.fid);
 			ep->id = pep->id;
 			ep->ibv_qp = ep->id->qp;
 			pep->id = NULL;
@@ -999,12 +999,12 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 			(((getpid() & 0x7FFF) << 16) + ((uintptr_t)ep & 0xFFFF));
 
 		if (dom->util_domain.threading == FI_THREAD_SAFE) {
-			*ep->util_ep.ep_fid.msg = fi_ibv_dgram_msg_ops_ts;
+			*ep->util_ep.ep_fid.msg = vrb_dgram_msg_ops_ts;
 		} else {
-			*ep->util_ep.ep_fid.msg = fi_ibv_dgram_msg_ops;
+			*ep->util_ep.ep_fid.msg = vrb_dgram_msg_ops;
 		}
-		ep->util_ep.ep_fid.rma = &fi_ibv_dgram_rma_ops;
-		ep->util_ep.ep_fid.cm = &fi_ibv_dgram_cm_ops;
+		ep->util_ep.ep_fid.rma = &vrb_dgram_rma_ops;
+		ep->util_ep.ep_fid.cm = &vrb_dgram_cm_ops;
 		break;
 	default:
 		VERBS_INFO(FI_LOG_DOMAIN, "Unknown EP type\n");
@@ -1022,8 +1022,8 @@ int fi_ibv_open_ep(struct fid_domain *domain, struct fi_info *info,
 		ep->tx_credits = info->tx_attr->size;
 
 	*ep_fid = &ep->util_ep.ep_fid;
-	ep->util_ep.ep_fid.fid.ops = &fi_ibv_ep_ops;
-	ep->util_ep.ep_fid.ops = &fi_ibv_ep_base_ops;
+	ep->util_ep.ep_fid.fid.ops = &vrb_ep_ops;
+	ep->util_ep.ep_fid.ops = &vrb_ep_base_ops;
 
 	return FI_SUCCESS;
 err2:
@@ -1031,20 +1031,20 @@ err2:
 	if (ep->id)
 		rdma_destroy_ep(ep->id);
 err1:
-	fi_ibv_close_free_ep(ep);
+	vrb_close_free_ep(ep);
 	return ret;
 }
 
-static int fi_ibv_pep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
+static int vrb_pep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 {
-	struct fi_ibv_pep *pep;
+	struct vrb_pep *pep;
 	int ret;
 
-	pep = container_of(fid, struct fi_ibv_pep, pep_fid.fid);
+	pep = container_of(fid, struct vrb_pep, pep_fid.fid);
 	if (bfid->fclass != FI_CLASS_EQ)
 		return -FI_EINVAL;
 
-	pep->eq = container_of(bfid, struct fi_ibv_eq, eq_fid.fid);
+	pep->eq = container_of(bfid, struct vrb_eq, eq_fid.fid);
 	/*
 	 * This is a restrictive solution that enables an XRC EP to
 	 * inform it's peer the port that should be used in making the
@@ -1052,7 +1052,7 @@ static int fi_ibv_pep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	 * it limits an EQ to a single passive endpoint. TODO: implement
 	 * a more general solution.
 	 */
-	if (fi_ibv_is_xrc(pep->info)) {
+	if (vrb_is_xrc(pep->info)) {
 	       if (pep->eq->xrc.pep_port) {
 			VERBS_WARN(FI_LOG_EP_CTRL,
 				   "XRC limits EQ binding to a single PEP\n");
@@ -1065,7 +1065,7 @@ static int fi_ibv_pep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	if (ret)
 		return -errno;
 
-	if (fi_ibv_is_xrc(pep->info)) {
+	if (vrb_is_xrc(pep->info)) {
 		ret = rdma_migrate_id(pep->xrc_ps_udp_id, pep->eq->channel);
 		if (ret)
 			return -errno;
@@ -1073,14 +1073,14 @@ static int fi_ibv_pep_bind(fid_t fid, struct fid *bfid, uint64_t flags)
 	return FI_SUCCESS;
 }
 
-static int fi_ibv_pep_control(struct fid *fid, int command, void *arg)
+static int vrb_pep_control(struct fid *fid, int command, void *arg)
 {
-	struct fi_ibv_pep *pep;
+	struct vrb_pep *pep;
 	int ret = 0;
 
 	switch (fid->fclass) {
 	case FI_CLASS_PEP:
-		pep = container_of(fid, struct fi_ibv_pep, pep_fid.fid);
+		pep = container_of(fid, struct vrb_pep, pep_fid.fid);
 		switch (command) {
 		case FI_BACKLOG:
 			if (!arg)
@@ -1100,11 +1100,11 @@ static int fi_ibv_pep_control(struct fid *fid, int command, void *arg)
 	return ret;
 }
 
-static int fi_ibv_pep_close(fid_t fid)
+static int vrb_pep_close(fid_t fid)
 {
-	struct fi_ibv_pep *pep;
+	struct vrb_pep *pep;
 
-	pep = container_of(fid, struct fi_ibv_pep, pep_fid.fid);
+	pep = container_of(fid, struct vrb_pep, pep_fid.fid);
 	if (pep->id)
 		rdma_destroy_ep(pep->id);
 	if (pep->xrc_ps_udp_id)
@@ -1115,17 +1115,17 @@ static int fi_ibv_pep_close(fid_t fid)
 	return 0;
 }
 
-static struct fi_ops fi_ibv_pep_fi_ops = {
+static struct fi_ops vrb_pep_fi_ops = {
 	.size = sizeof(struct fi_ops),
-	.close = fi_ibv_pep_close,
-	.bind = fi_ibv_pep_bind,
-	.control = fi_ibv_pep_control,
+	.close = vrb_pep_close,
+	.bind = vrb_pep_bind,
+	.control = vrb_pep_control,
 	.ops_open = fi_no_ops_open,
 };
 
-static struct fi_ops_ep fi_ibv_pep_ops = {
+static struct fi_ops_ep vrb_pep_ops = {
 	.size = sizeof(struct fi_ops_ep),
-	.getopt = fi_ibv_ep_getopt,
+	.getopt = vrb_ep_getopt,
 	.setopt = fi_no_setopt,
 	.tx_ctx = fi_no_tx_ctx,
 	.rx_ctx = fi_no_rx_ctx,
@@ -1133,10 +1133,10 @@ static struct fi_ops_ep fi_ibv_pep_ops = {
 	.tx_size_left = fi_no_tx_size_left,
 };
 
-int fi_ibv_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
+int vrb_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 		      struct fid_pep **pep, void *context)
 {
-	struct fi_ibv_pep *_pep;
+	struct vrb_pep *_pep;
 	int ret;
 
 	_pep = calloc(1, sizeof *_pep);
@@ -1170,7 +1170,7 @@ int fi_ibv_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	}
 
 	/* XRC listens on both RDMA_PS_TCP and RDMA_PS_UDP */
-	if (fi_ibv_is_xrc(info)) {
+	if (vrb_is_xrc(info)) {
 		ret = rdma_create_id(NULL, &_pep->xrc_ps_udp_id,
 				     &_pep->pep_fid.fid, RDMA_PS_UDP);
 		if (ret) {
@@ -1192,9 +1192,9 @@ int fi_ibv_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 
 	_pep->pep_fid.fid.fclass = FI_CLASS_PEP;
 	_pep->pep_fid.fid.context = context;
-	_pep->pep_fid.fid.ops = &fi_ibv_pep_fi_ops;
-	_pep->pep_fid.ops = &fi_ibv_pep_ops;
-	_pep->pep_fid.cm = fi_ibv_pep_ops_cm(_pep);
+	_pep->pep_fid.fid.ops = &vrb_pep_fi_ops;
+	_pep->pep_fid.ops = &vrb_pep_ops;
+	_pep->pep_fid.cm = vrb_pep_ops_cm(_pep);
 
 	_pep->src_addrlen = info->src_addrlen;
 
@@ -1213,7 +1213,7 @@ err1:
 	return ret;
 }
 
-static struct fi_ops_ep fi_ibv_srq_ep_base_ops = {
+static struct fi_ops_ep vrb_srq_ep_base_ops = {
 	.size = sizeof(struct fi_ops_ep),
 	.cancel = fi_no_cancel,
 	.getopt = fi_no_getopt,
@@ -1224,7 +1224,7 @@ static struct fi_ops_ep fi_ibv_srq_ep_base_ops = {
 	.tx_size_left = fi_no_tx_size_left,
 };
 
-static struct fi_ops_cm fi_ibv_srq_cm_ops = {
+static struct fi_ops_cm vrb_srq_cm_ops = {
 	.size = sizeof(struct fi_ops_cm),
 	.setname = fi_no_setname,
 	.getname = fi_no_getname,
@@ -1237,7 +1237,7 @@ static struct fi_ops_cm fi_ibv_srq_cm_ops = {
 	.join = fi_no_join,
 };
 
-static struct fi_ops_rma fi_ibv_srq_rma_ops = {
+static struct fi_ops_rma vrb_srq_rma_ops = {
 	.size = sizeof(struct fi_ops_rma),
 	.read = fi_no_rma_read,
 	.readv = fi_no_rma_readv,
@@ -1250,7 +1250,7 @@ static struct fi_ops_rma fi_ibv_srq_rma_ops = {
 	.injectdata = fi_no_rma_injectdata,
 };
 
-static struct fi_ops_atomic fi_ibv_srq_atomic_ops = {
+static struct fi_ops_atomic vrb_srq_atomic_ops = {
 	.size = sizeof(struct fi_ops_atomic),
 	.write = fi_no_atomic_write,
 	.writev = fi_no_atomic_writev,
@@ -1268,10 +1268,10 @@ static struct fi_ops_atomic fi_ibv_srq_atomic_ops = {
 };
 
 static inline ssize_t
-fi_ibv_srq_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
+vrb_srq_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 {
-	struct fi_ibv_srq_ep *ep =
-		container_of(ep_fid, struct fi_ibv_srq_ep, ep_fid);
+	struct vrb_srq_ep *ep =
+		container_of(ep_fid, struct vrb_srq_ep, ep_fid);
 	struct ibv_recv_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
 		.num_sge = msg->iov_count,
@@ -1281,18 +1281,18 @@ fi_ibv_srq_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t 
 
 	assert(ep->srq);
 
-	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
+	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
 	return vrb_convert_ret(ibv_post_srq_recv(ep->srq, &wr, &bad_wr));
 }
 
 static ssize_t
-fi_ibv_srq_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
+vrb_srq_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 		void *desc, fi_addr_t src_addr, void *context)
 {
-	struct fi_ibv_srq_ep *ep =
-		container_of(ep_fid, struct fi_ibv_srq_ep, ep_fid);
-	struct ibv_sge sge = fi_ibv_init_sge(buf, len, desc);
+	struct vrb_srq_ep *ep =
+		container_of(ep_fid, struct vrb_srq_ep, ep_fid);
+	struct ibv_sge sge = vrb_init_sge(buf, len, desc);
 	struct ibv_recv_wr wr = {
 		.wr_id = (uintptr_t)context,
 		.num_sge = 1,
@@ -1305,7 +1305,7 @@ fi_ibv_srq_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 }
 
 static ssize_t
-fi_ibv_srq_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+vrb_srq_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		    size_t count, fi_addr_t src_addr, void *context)
 {
 	struct fi_msg msg = {
@@ -1316,14 +1316,14 @@ fi_ibv_srq_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		.context = context,
 	};
 
-	return fi_ibv_srq_ep_recvmsg(ep_fid, &msg, 0);
+	return vrb_srq_ep_recvmsg(ep_fid, &msg, 0);
 }
 
-static struct fi_ops_msg fi_ibv_srq_msg_ops = {
+static struct fi_ops_msg vrb_srq_msg_ops = {
 	.size = sizeof(struct fi_ops_msg),
-	.recv = fi_ibv_srq_ep_recv,
-	.recvv = fi_ibv_srq_ep_recvv,
-	.recvmsg = fi_ibv_srq_ep_recvmsg,
+	.recv = vrb_srq_ep_recv,
+	.recvv = vrb_srq_ep_recvv,
+	.recvmsg = vrb_srq_ep_recvmsg,
 	.send = fi_no_msg_send,
 	.sendv = fi_no_msg_sendv,
 	.sendmsg = fi_no_msg_sendmsg,
@@ -1340,12 +1340,12 @@ static struct fi_ops_msg fi_ibv_srq_msg_ops = {
  * to the shared receive context is enabled.
  */
 static ssize_t
-fi_ibv_xrc_srq_ep_prepost_recv(struct fid_ep *ep_fid, void *buf, size_t len,
+vrb_xrc_srq_ep_prepost_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 			void *desc, fi_addr_t src_addr, void *context)
 {
-	struct fi_ibv_srq_ep *ep =
-		container_of(ep_fid, struct fi_ibv_srq_ep, ep_fid);
-	struct fi_ibv_xrc_srx_prepost *recv;
+	struct vrb_srq_ep *ep =
+		container_of(ep_fid, struct vrb_srq_ep, ep_fid);
+	struct vrb_xrc_srx_prepost *recv;
 	ssize_t ret;
 
 	fastlock_acquire(&ep->xrc.prepost_lock);
@@ -1383,9 +1383,9 @@ done:
 	return ret;
 }
 
-static struct fi_ops_msg fi_ibv_xrc_srq_msg_ops = {
+static struct fi_ops_msg vrb_xrc_srq_msg_ops = {
 	.size = sizeof(struct fi_ops_msg),
-	.recv = fi_ibv_xrc_srq_ep_prepost_recv,
+	.recv = vrb_xrc_srq_ep_prepost_recv,
 	.recvv = fi_no_msg_recvv,		/* Not used by RXM */
 	.recvmsg = fi_no_msg_recvmsg,		/* Not used by RXM */
 	.send = fi_no_msg_send,
@@ -1396,21 +1396,21 @@ static struct fi_ops_msg fi_ibv_xrc_srq_msg_ops = {
 	.injectdata = fi_no_msg_injectdata,
 };
 
-static void fi_ibv_cleanup_prepost_bufs(struct fi_ibv_srq_ep *srq_ep)
+static void vrb_cleanup_prepost_bufs(struct vrb_srq_ep *srq_ep)
 {
-	struct fi_ibv_xrc_srx_prepost *recv;
+	struct vrb_xrc_srx_prepost *recv;
 	struct slist_entry *entry;
 
 	while (!slist_empty(&srq_ep->xrc.prepost_list)) {
 		entry = slist_remove_head(&srq_ep->xrc.prepost_list);
-		recv = container_of(entry, struct fi_ibv_xrc_srx_prepost,
+		recv = container_of(entry, struct vrb_xrc_srx_prepost,
 				    prepost_entry);
 		free(recv);
 	}
 }
 
 /* Must hold the associated CQ lock cq::xrc.srq_list_lock */
-int fi_ibv_xrc_close_srq(struct fi_ibv_srq_ep *srq_ep)
+int vrb_xrc_close_srq(struct vrb_srq_ep *srq_ep)
 {
 	int ret;
 
@@ -1426,21 +1426,21 @@ int fi_ibv_xrc_close_srq(struct fi_ibv_srq_ep *srq_ep)
 	srq_ep->srq = NULL;
 	srq_ep->xrc.cq = NULL;
 	dlist_remove(&srq_ep->xrc.srq_entry);
-	fi_ibv_cleanup_prepost_bufs(srq_ep);
+	vrb_cleanup_prepost_bufs(srq_ep);
 
 	return FI_SUCCESS;
 }
 
-static int fi_ibv_srq_close(fid_t fid)
+static int vrb_srq_close(fid_t fid)
 {
-	struct fi_ibv_srq_ep *srq_ep = container_of(fid, struct fi_ibv_srq_ep,
+	struct vrb_srq_ep *srq_ep = container_of(fid, struct vrb_srq_ep,
 						    ep_fid.fid);
 	int ret;
 
 	if (srq_ep->domain->flags & VRB_USE_XRC) {
 		if (srq_ep->xrc.cq) {
 			fastlock_acquire(&srq_ep->xrc.cq->xrc.srq_list_lock);
-			ret = fi_ibv_xrc_close_srq(srq_ep);
+			ret = vrb_xrc_close_srq(srq_ep);
 			fastlock_release(&srq_ep->xrc.cq->xrc.srq_list_lock);
 			if (ret)
 				goto err;
@@ -1459,20 +1459,20 @@ err:
 	return ret;
 }
 
-static struct fi_ops fi_ibv_srq_ep_ops = {
+static struct fi_ops vrb_srq_ep_ops = {
 	.size = sizeof(struct fi_ops),
-	.close = fi_ibv_srq_close,
+	.close = vrb_srq_close,
 	.bind = fi_no_bind,
 	.control = fi_no_control,
 	.ops_open = fi_no_ops_open,
 };
 
-int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
+int vrb_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		       struct fid_ep **srq_ep_fid, void *context)
 {
 	struct ibv_srq_init_attr srq_init_attr = { 0 };
-	struct fi_ibv_domain *dom;
-	struct fi_ibv_srq_ep *srq_ep;
+	struct vrb_domain *dom;
+	struct vrb_srq_ep *srq_ep;
 	int ret;
 
 	if (!domain)
@@ -1484,16 +1484,16 @@ int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		goto err1;
 	}
 
-	dom = container_of(domain, struct fi_ibv_domain,
+	dom = container_of(domain, struct vrb_domain,
 			   util_domain.domain_fid);
 
 	srq_ep->ep_fid.fid.fclass = FI_CLASS_SRX_CTX;
 	srq_ep->ep_fid.fid.context = context;
-	srq_ep->ep_fid.fid.ops = &fi_ibv_srq_ep_ops;
-	srq_ep->ep_fid.ops = &fi_ibv_srq_ep_base_ops;
-	srq_ep->ep_fid.cm = &fi_ibv_srq_cm_ops;
-	srq_ep->ep_fid.rma = &fi_ibv_srq_rma_ops;
-	srq_ep->ep_fid.atomic = &fi_ibv_srq_atomic_ops;
+	srq_ep->ep_fid.fid.ops = &vrb_srq_ep_ops;
+	srq_ep->ep_fid.ops = &vrb_srq_ep_base_ops;
+	srq_ep->ep_fid.cm = &vrb_srq_cm_ops;
+	srq_ep->ep_fid.rma = &vrb_srq_rma_ops;
+	srq_ep->ep_fid.atomic = &vrb_srq_atomic_ops;
 	srq_ep->domain = dom;
 
 	/* XRC SRQ creation is delayed until the first endpoint it is bound
@@ -1504,11 +1504,11 @@ int fi_ibv_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 		dlist_init(&srq_ep->xrc.srq_entry);
 		srq_ep->xrc.max_recv_wr = attr->size;
 		srq_ep->xrc.max_sge = attr->iov_limit;
-		srq_ep->ep_fid.msg = &fi_ibv_xrc_srq_msg_ops;
+		srq_ep->ep_fid.msg = &vrb_xrc_srq_msg_ops;
 		goto done;
 	}
 
-	srq_ep->ep_fid.msg = &fi_ibv_srq_msg_ops;
+	srq_ep->ep_fid.msg = &vrb_srq_msg_ops;
 	srq_init_attr.attr.max_wr = attr->size;
 	srq_init_attr.attr.max_sge = attr->iov_limit;
 
@@ -1532,33 +1532,33 @@ err1:
 }
 
 
-#define fi_ibv_atomicvalid(name, flags)					\
-static int fi_ibv_msg_ep_atomic_ ## name(struct fid_ep *ep_fid,		\
+#define vrb_atomicvalid(name, flags)					\
+static int vrb_msg_ep_atomic_ ## name(struct fid_ep *ep_fid,		\
 					 enum fi_datatype datatype,	\
 					 enum fi_op op, size_t *count)	\
 {									\
-	struct fi_ibv_ep *ep = container_of(ep_fid, struct fi_ibv_ep,	\
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep,	\
 					    util_ep.ep_fid);		\
 	struct fi_atomic_attr attr;					\
 	int ret;							\
 									\
-	ret = fi_ibv_query_atomic(&ep->util_ep.domain->domain_fid,	\
+	ret = vrb_query_atomic(&ep->util_ep.domain->domain_fid,	\
 				  datatype, op, &attr, flags);		\
 	if (!ret)							\
 		*count = attr.count;					\
 	return ret;							\
 }
 
-fi_ibv_atomicvalid(writevalid, 0);
-fi_ibv_atomicvalid(readwritevalid, FI_FETCH_ATOMIC);
-fi_ibv_atomicvalid(compwritevalid, FI_COMPARE_ATOMIC);
+vrb_atomicvalid(writevalid, 0);
+vrb_atomicvalid(readwritevalid, FI_FETCH_ATOMIC);
+vrb_atomicvalid(compwritevalid, FI_COMPARE_ATOMIC);
 
-int fi_ibv_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
+int vrb_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,
 			uint64_t flags)
 {
-	struct fi_ibv_domain *domain = container_of(domain_fid,
-						    struct fi_ibv_domain,
+	struct vrb_domain *domain = container_of(domain_fid,
+						    struct vrb_domain,
 						    util_domain.domain_fid);
 	char *log_str_fetch = "fi_fetch_atomic with FI_SUM op";
 	char *log_str_comp = "fi_compare_atomic";
@@ -1623,12 +1623,12 @@ check_datatype:
 }
 
 static ssize_t
-fi_ibv_msg_ep_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t count,
+vrb_msg_ep_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t count,
 			void *desc, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_RDMA_WRITE,
@@ -1648,15 +1648,15 @@ fi_ibv_msg_ep_atomic_write(struct fid_ep *ep_fid, const void *buf, size_t count,
 
 	count_copy = count;
 
-	ret = fi_ibv_msg_ep_atomic_writevalid(ep_fid, datatype, op, &count_copy);
+	ret = vrb_msg_ep_atomic_writevalid(ep_fid, datatype, op, &count_copy);
 	if (ret)
 		return ret;
 
-	return fi_ibv_send_buf(ep, &wr, buf, sizeof(uint64_t), desc);
+	return vrb_send_buf(ep, &wr, buf, sizeof(uint64_t), desc);
 }
 
 static ssize_t
-fi_ibv_msg_ep_atomic_writev(struct fid_ep *ep,
+vrb_msg_ep_atomic_writev(struct fid_ep *ep,
 			const struct fi_ioc *iov, void **desc, size_t count,
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype, enum fi_op op, void *context)
@@ -1664,16 +1664,16 @@ fi_ibv_msg_ep_atomic_writev(struct fid_ep *ep,
 	if (OFI_UNLIKELY(iov->count != 1))
 		return -FI_E2BIG;
 
-	return fi_ibv_msg_ep_atomic_write(ep, iov->addr, count, desc[0],
+	return vrb_msg_ep_atomic_write(ep, iov->addr, count, desc[0],
 			dest_addr, addr, key, datatype, op, context);
 }
 
 static ssize_t
-fi_ibv_msg_ep_atomic_writemsg(struct fid_ep *ep_fid,
+vrb_msg_ep_atomic_writemsg(struct fid_ep *ep_fid,
 			const struct fi_msg_atomic *msg, uint64_t flags)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_FLAGS(ep, flags, (uintptr_t)msg->context),
 		.wr.rdma.remote_addr = msg->rma_iov->addr,
@@ -1692,7 +1692,7 @@ fi_ibv_msg_ep_atomic_writemsg(struct fid_ep *ep_fid,
 
 	count_copy = msg->iov_count;
 
-	ret = fi_ibv_msg_ep_atomic_writevalid(ep_fid, msg->datatype, msg->op,
+	ret = vrb_msg_ep_atomic_writevalid(ep_fid, msg->datatype, msg->op,
 			&count_copy);
 	if (ret)
 		return ret;
@@ -1704,19 +1704,19 @@ fi_ibv_msg_ep_atomic_writemsg(struct fid_ep *ep_fid,
 		wr.opcode = IBV_WR_RDMA_WRITE;
 	}
 
-	return fi_ibv_send_buf(ep, &wr, msg->msg_iov->addr, sizeof(uint64_t),
+	return vrb_send_buf(ep, &wr, msg->msg_iov->addr, sizeof(uint64_t),
 			       msg->desc[0]);
 }
 
 static ssize_t
-fi_ibv_msg_ep_atomic_readwrite(struct fid_ep *ep_fid, const void *buf, size_t count,
+vrb_msg_ep_atomic_readwrite(struct fid_ep *ep_fid, const void *buf, size_t count,
 			void *desc, void *result, void *result_desc,
 			fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 			enum fi_datatype datatype,
 			enum fi_op op, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.send_flags = IBV_SEND_FENCE,
@@ -1729,7 +1729,7 @@ fi_ibv_msg_ep_atomic_readwrite(struct fid_ep *ep_fid, const void *buf, size_t co
 
 	count_copy = count;
 
-	ret = fi_ibv_msg_ep_atomic_readwritevalid(ep_fid, datatype, op,
+	ret = vrb_msg_ep_atomic_readwritevalid(ep_fid, datatype, op,
 			&count_copy);
 	if (ret)
 		return ret;
@@ -1751,11 +1751,11 @@ fi_ibv_msg_ep_atomic_readwrite(struct fid_ep *ep_fid, const void *buf, size_t co
 		return -FI_ENOSYS;
 	}
 
-	return fi_ibv_send_buf(ep, &wr, result, sizeof(uint64_t), result_desc);
+	return vrb_send_buf(ep, &wr, result, sizeof(uint64_t), result_desc);
 }
 
 static ssize_t
-fi_ibv_msg_ep_atomic_readwritev(struct fid_ep *ep, const struct fi_ioc *iov,
+vrb_msg_ep_atomic_readwritev(struct fid_ep *ep, const struct fi_ioc *iov,
 			void **desc, size_t count,
 			struct fi_ioc *resultv, void **result_desc,
 			size_t result_count, fi_addr_t dest_addr, uint64_t addr,
@@ -1765,19 +1765,19 @@ fi_ibv_msg_ep_atomic_readwritev(struct fid_ep *ep, const struct fi_ioc *iov,
 	if (OFI_UNLIKELY(iov->count != 1))
 		return -FI_E2BIG;
 
-	return fi_ibv_msg_ep_atomic_readwrite(ep, iov->addr, count,
+	return vrb_msg_ep_atomic_readwrite(ep, iov->addr, count,
 			desc[0], resultv->addr, result_desc[0],
 			dest_addr, addr, key, datatype, op, context);
 }
 
 static ssize_t
-fi_ibv_msg_ep_atomic_readwritemsg(struct fid_ep *ep_fid,
+vrb_msg_ep_atomic_readwritemsg(struct fid_ep *ep_fid,
 				const struct fi_msg_atomic *msg,
 				struct fi_ioc *resultv, void **result_desc,
 				size_t result_count, uint64_t flags)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_FLAGS(ep, flags, (uintptr_t)msg->context),
 		.send_flags = IBV_SEND_FENCE,
@@ -1790,7 +1790,7 @@ fi_ibv_msg_ep_atomic_readwritemsg(struct fid_ep *ep_fid,
 
 	count_copy = msg->iov_count;
 
-	ret = fi_ibv_msg_ep_atomic_readwritevalid(ep_fid, msg->datatype, msg->op,
+	ret = vrb_msg_ep_atomic_readwritevalid(ep_fid, msg->datatype, msg->op,
 		       &count_copy);
 	if (ret)
 		return ret;
@@ -1815,12 +1815,12 @@ fi_ibv_msg_ep_atomic_readwritemsg(struct fid_ep *ep_fid,
 	if (flags & FI_REMOTE_CQ_DATA)
 		wr.imm_data = htonl((uint32_t) msg->data);
 
-	return fi_ibv_send_buf(ep, &wr, resultv->addr,
+	return vrb_send_buf(ep, &wr, resultv->addr,
 			       sizeof(uint64_t), result_desc[0]);
 }
 
 static ssize_t
-fi_ibv_msg_ep_atomic_compwrite(struct fid_ep *ep_fid, const void *buf, size_t count,
+vrb_msg_ep_atomic_compwrite(struct fid_ep *ep_fid, const void *buf, size_t count,
 			void *desc, const void *compare,
 			void *compare_desc, void *result,
 			void *result_desc,
@@ -1828,8 +1828,8 @@ fi_ibv_msg_ep_atomic_compwrite(struct fid_ep *ep_fid, const void *buf, size_t co
 			enum fi_datatype datatype,
 			enum fi_op op, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_ATOMIC_CMP_AND_SWP,
@@ -1847,15 +1847,15 @@ fi_ibv_msg_ep_atomic_compwrite(struct fid_ep *ep_fid, const void *buf, size_t co
 
 	count_copy = count;
 
-	ret = fi_ibv_msg_ep_atomic_compwritevalid(ep_fid, datatype, op, &count_copy);
+	ret = vrb_msg_ep_atomic_compwritevalid(ep_fid, datatype, op, &count_copy);
 	if (ret)
 		return ret;
 
-	return fi_ibv_send_buf(ep, &wr, result, sizeof(uint64_t), result_desc);
+	return vrb_send_buf(ep, &wr, result, sizeof(uint64_t), result_desc);
 }
 
 static ssize_t
-fi_ibv_msg_ep_atomic_compwritev(struct fid_ep *ep, const struct fi_ioc *iov,
+vrb_msg_ep_atomic_compwritev(struct fid_ep *ep, const struct fi_ioc *iov,
 				void **desc, size_t count,
 				const struct fi_ioc *comparev,
 				void **compare_desc, size_t compare_count,
@@ -1868,14 +1868,14 @@ fi_ibv_msg_ep_atomic_compwritev(struct fid_ep *ep, const struct fi_ioc *iov,
 	if (OFI_UNLIKELY(iov->count != 1))
 		return -FI_E2BIG;
 
-	return fi_ibv_msg_ep_atomic_compwrite(ep, iov->addr, count, desc[0],
+	return vrb_msg_ep_atomic_compwrite(ep, iov->addr, count, desc[0],
 				comparev->addr, compare_desc[0], resultv->addr,
 				result_desc[0], dest_addr, addr, key,
 				datatype, op, context);
 }
 
 static ssize_t
-fi_ibv_msg_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
+vrb_msg_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 				const struct fi_msg_atomic *msg,
 				const struct fi_ioc *comparev,
 				void **compare_desc, size_t compare_count,
@@ -1883,8 +1883,8 @@ fi_ibv_msg_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 				void **result_desc, size_t result_count,
 				uint64_t flags)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_FLAGS(ep, flags, (uintptr_t)msg->context),
 		.opcode = IBV_WR_ATOMIC_CMP_AND_SWP,
@@ -1902,7 +1902,7 @@ fi_ibv_msg_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 
 	count_copy = msg->iov_count;
 
-	ret = fi_ibv_msg_ep_atomic_compwritevalid(ep_fid, msg->datatype, msg->op,
+	ret = vrb_msg_ep_atomic_compwritevalid(ep_fid, msg->datatype, msg->op,
 		       &count_copy);
 	if (ret)
 		return ret;
@@ -1910,34 +1910,34 @@ fi_ibv_msg_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 	if (flags & FI_REMOTE_CQ_DATA)
 		wr.imm_data = htonl((uint32_t) msg->data);
 
-	return fi_ibv_send_buf(ep, &wr, resultv->addr, sizeof(uint64_t),
+	return vrb_send_buf(ep, &wr, resultv->addr, sizeof(uint64_t),
 			result_desc[0]);
 }
 
-struct fi_ops_atomic fi_ibv_msg_ep_atomic_ops = {
+struct fi_ops_atomic vrb_msg_ep_atomic_ops = {
 	.size		= sizeof(struct fi_ops_atomic),
-	.write		= fi_ibv_msg_ep_atomic_write,
-	.writev		= fi_ibv_msg_ep_atomic_writev,
-	.writemsg	= fi_ibv_msg_ep_atomic_writemsg,
+	.write		= vrb_msg_ep_atomic_write,
+	.writev		= vrb_msg_ep_atomic_writev,
+	.writemsg	= vrb_msg_ep_atomic_writemsg,
 	.inject		= fi_no_atomic_inject,
-	.readwrite	= fi_ibv_msg_ep_atomic_readwrite,
-	.readwritev	= fi_ibv_msg_ep_atomic_readwritev,
-	.readwritemsg	= fi_ibv_msg_ep_atomic_readwritemsg,
-	.compwrite	= fi_ibv_msg_ep_atomic_compwrite,
-	.compwritev	= fi_ibv_msg_ep_atomic_compwritev,
-	.compwritemsg	= fi_ibv_msg_ep_atomic_compwritemsg,
-	.writevalid	= fi_ibv_msg_ep_atomic_writevalid,
-	.readwritevalid	= fi_ibv_msg_ep_atomic_readwritevalid,
-	.compwritevalid = fi_ibv_msg_ep_atomic_compwritevalid
+	.readwrite	= vrb_msg_ep_atomic_readwrite,
+	.readwritev	= vrb_msg_ep_atomic_readwritev,
+	.readwritemsg	= vrb_msg_ep_atomic_readwritemsg,
+	.compwrite	= vrb_msg_ep_atomic_compwrite,
+	.compwritev	= vrb_msg_ep_atomic_compwritev,
+	.compwritemsg	= vrb_msg_ep_atomic_compwritemsg,
+	.writevalid	= vrb_msg_ep_atomic_writevalid,
+	.readwritevalid	= vrb_msg_ep_atomic_readwritevalid,
+	.compwritevalid = vrb_msg_ep_atomic_compwritevalid
 };
 
 static ssize_t
-fi_ibv_msg_xrc_ep_atomic_write(struct fid_ep *ep_fid, const void *buf,
+vrb_msg_xrc_ep_atomic_write(struct fid_ep *ep_fid, const void *buf,
 		size_t count, void *desc, fi_addr_t dest_addr, uint64_t addr,
 		uint64_t key, enum fi_datatype datatype, enum fi_op op,
 		void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
@@ -1956,22 +1956,22 @@ fi_ibv_msg_xrc_ep_atomic_write(struct fid_ep *ep_fid, const void *buf,
 	if (OFI_UNLIKELY(op != FI_ATOMIC_WRITE))
 		return -FI_ENOSYS;
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
 	count_copy = count;
 
-	ret = fi_ibv_msg_ep_atomic_writevalid(ep_fid, datatype, op, &count_copy);
+	ret = vrb_msg_ep_atomic_writevalid(ep_fid, datatype, op, &count_copy);
 	if (ret)
 		return ret;
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, sizeof(uint64_t), desc);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, sizeof(uint64_t), desc);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_atomic_writemsg(struct fid_ep *ep_fid,
+vrb_msg_xrc_ep_atomic_writemsg(struct fid_ep *ep_fid,
 			const struct fi_msg_atomic *msg, uint64_t flags)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_FLAGS(&ep->base_ep, flags,
@@ -1990,10 +1990,10 @@ fi_ibv_msg_xrc_ep_atomic_writemsg(struct fid_ep *ep_fid,
 	if (OFI_UNLIKELY(msg->op != FI_ATOMIC_WRITE))
 		return -FI_ENOSYS;
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 	count_copy = msg->iov_count;
 
-	ret = fi_ibv_msg_ep_atomic_writevalid(ep_fid, msg->datatype, msg->op,
+	ret = vrb_msg_ep_atomic_writevalid(ep_fid, msg->datatype, msg->op,
 			&count_copy);
 	if (ret)
 		return ret;
@@ -2005,17 +2005,17 @@ fi_ibv_msg_xrc_ep_atomic_writemsg(struct fid_ep *ep_fid,
 		wr.opcode = IBV_WR_RDMA_WRITE;
 	}
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, msg->msg_iov->addr,
+	return vrb_send_buf(&ep->base_ep, &wr, msg->msg_iov->addr,
 			       sizeof(uint64_t), msg->desc[0]);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
+vrb_msg_xrc_ep_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
 		size_t count, void *desc, void *result, void *result_desc,
 		fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 		enum fi_datatype datatype, enum fi_op op, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
@@ -2027,10 +2027,10 @@ fi_ibv_msg_xrc_ep_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
 	if (OFI_UNLIKELY(count != 1))
 		return -FI_E2BIG;
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 	count_copy = count;
 
-	ret = fi_ibv_msg_ep_atomic_readwritevalid(ep_fid, datatype, op,
+	ret = vrb_msg_ep_atomic_readwritevalid(ep_fid, datatype, op,
 			&count_copy);
 	if (ret)
 		return ret;
@@ -2052,17 +2052,17 @@ fi_ibv_msg_xrc_ep_atomic_readwrite(struct fid_ep *ep_fid, const void *buf,
 		return -FI_ENOSYS;
 	}
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, result,
+	return vrb_send_buf(&ep->base_ep, &wr, result,
 			       sizeof(uint64_t), result_desc);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_atomic_readwritemsg(struct fid_ep *ep_fid,
+vrb_msg_xrc_ep_atomic_readwritemsg(struct fid_ep *ep_fid,
 			const struct fi_msg_atomic *msg,
 			struct fi_ioc *resultv, void **result_desc,
 			size_t result_count, uint64_t flags)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_FLAGS(&ep->base_ep, flags,
@@ -2075,10 +2075,10 @@ fi_ibv_msg_xrc_ep_atomic_readwritemsg(struct fid_ep *ep_fid,
 	if (OFI_UNLIKELY(msg->iov_count != 1 || msg->msg_iov->count != 1))
 		return -FI_E2BIG;
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 	count_copy = msg->iov_count;
 
-	ret = fi_ibv_msg_ep_atomic_readwritevalid(ep_fid, msg->datatype, msg->op,
+	ret = vrb_msg_ep_atomic_readwritevalid(ep_fid, msg->datatype, msg->op,
 		       &count_copy);
 	if (ret)
 		return ret;
@@ -2103,12 +2103,12 @@ fi_ibv_msg_xrc_ep_atomic_readwritemsg(struct fid_ep *ep_fid,
 	if (flags & FI_REMOTE_CQ_DATA)
 		wr.imm_data = htonl((uint32_t) msg->data);
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, resultv->addr,
+	return vrb_send_buf(&ep->base_ep, &wr, resultv->addr,
 			       sizeof(uint64_t), result_desc[0]);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_atomic_compwrite(struct fid_ep *ep_fid, const void *buf, size_t count,
+vrb_msg_xrc_ep_atomic_compwrite(struct fid_ep *ep_fid, const void *buf, size_t count,
 			void *desc, const void *compare,
 			void *compare_desc, void *result,
 			void *result_desc,
@@ -2116,7 +2116,7 @@ fi_ibv_msg_xrc_ep_atomic_compwrite(struct fid_ep *ep_fid, const void *buf, size_
 			enum fi_datatype datatype,
 			enum fi_op op, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
@@ -2133,19 +2133,19 @@ fi_ibv_msg_xrc_ep_atomic_compwrite(struct fid_ep *ep_fid, const void *buf, size_
 	if (OFI_UNLIKELY(count != 1))
 		return -FI_E2BIG;
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 	count_copy = count;
 
-	ret = fi_ibv_msg_ep_atomic_compwritevalid(ep_fid, datatype, op, &count_copy);
+	ret = vrb_msg_ep_atomic_compwritevalid(ep_fid, datatype, op, &count_copy);
 	if (ret)
 		return ret;
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, result,
+	return vrb_send_buf(&ep->base_ep, &wr, result,
 			       sizeof(uint64_t), result_desc);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
+vrb_msg_xrc_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 				const struct fi_msg_atomic *msg,
 				const struct fi_ioc *comparev,
 				void **compare_desc, size_t compare_count,
@@ -2153,7 +2153,7 @@ fi_ibv_msg_xrc_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 				void **result_desc, size_t result_count,
 				uint64_t flags)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_FLAGS(&ep->base_ep, flags,
@@ -2171,10 +2171,10 @@ fi_ibv_msg_xrc_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 	if (OFI_UNLIKELY(msg->iov_count != 1 || msg->msg_iov->count != 1))
 		return -FI_E2BIG;
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 	count_copy = msg->iov_count;
 
-	ret = fi_ibv_msg_ep_atomic_compwritevalid(ep_fid, msg->datatype, msg->op,
+	ret = vrb_msg_ep_atomic_compwritevalid(ep_fid, msg->datatype, msg->op,
 		       &count_copy);
 	if (ret)
 		return ret;
@@ -2182,23 +2182,23 @@ fi_ibv_msg_xrc_ep_atomic_compwritemsg(struct fid_ep *ep_fid,
 	if (flags & FI_REMOTE_CQ_DATA)
 		wr.imm_data = htonl((uint32_t) msg->data);
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, resultv->addr,
+	return vrb_send_buf(&ep->base_ep, &wr, resultv->addr,
 			       sizeof(uint64_t), result_desc[0]);
 }
 
-struct fi_ops_atomic fi_ibv_msg_xrc_ep_atomic_ops = {
+struct fi_ops_atomic vrb_msg_xrc_ep_atomic_ops = {
 	.size		= sizeof(struct fi_ops_atomic),
-	.write		= fi_ibv_msg_xrc_ep_atomic_write,
-	.writev		= fi_ibv_msg_ep_atomic_writev,
-	.writemsg	= fi_ibv_msg_xrc_ep_atomic_writemsg,
+	.write		= vrb_msg_xrc_ep_atomic_write,
+	.writev		= vrb_msg_ep_atomic_writev,
+	.writemsg	= vrb_msg_xrc_ep_atomic_writemsg,
 	.inject		= fi_no_atomic_inject,
-	.readwrite	= fi_ibv_msg_xrc_ep_atomic_readwrite,
-	.readwritev	= fi_ibv_msg_ep_atomic_readwritev,
-	.readwritemsg	= fi_ibv_msg_xrc_ep_atomic_readwritemsg,
-	.compwrite	= fi_ibv_msg_xrc_ep_atomic_compwrite,
-	.compwritev	= fi_ibv_msg_ep_atomic_compwritev,
-	.compwritemsg	= fi_ibv_msg_xrc_ep_atomic_compwritemsg,
-	.writevalid	= fi_ibv_msg_ep_atomic_writevalid,
-	.readwritevalid	= fi_ibv_msg_ep_atomic_readwritevalid,
-	.compwritevalid = fi_ibv_msg_ep_atomic_compwritevalid
+	.readwrite	= vrb_msg_xrc_ep_atomic_readwrite,
+	.readwritev	= vrb_msg_ep_atomic_readwritev,
+	.readwritemsg	= vrb_msg_xrc_ep_atomic_readwritemsg,
+	.compwrite	= vrb_msg_xrc_ep_atomic_compwrite,
+	.compwritev	= vrb_msg_ep_atomic_compwritev,
+	.compwritemsg	= vrb_msg_xrc_ep_atomic_compwritemsg,
+	.writevalid	= vrb_msg_ep_atomic_writevalid,
+	.readwritevalid	= vrb_msg_ep_atomic_readwritevalid,
+	.compwritevalid = vrb_msg_ep_atomic_compwritevalid
 };

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -37,14 +37,14 @@
 #include "fi_verbs.h"
 
 /* XRC SIDR connection map RBTree key */
-struct fi_ibv_sidr_conn_key {
+struct vrb_sidr_conn_key {
 	struct sockaddr		*addr;
 	uint16_t		pep_port;
 	bool			recip;
 };
 
 const struct fi_info *
-fi_ibv_get_verbs_info(const struct fi_info *ilist, const char *domain_name)
+vrb_get_verbs_info(const struct fi_info *ilist, const char *domain_name)
 {
 	const struct fi_info *fi;
 
@@ -57,11 +57,11 @@ fi_ibv_get_verbs_info(const struct fi_info *ilist, const char *domain_name)
 }
 
 static ssize_t
-fi_ibv_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
+vrb_eq_readerr(struct fid_eq *eq, struct fi_eq_err_entry *entry,
 		  uint64_t flags)
 {
-	struct fi_ibv_eq *_eq =
-		container_of(eq, struct fi_ibv_eq, eq_fid.fid);
+	struct vrb_eq *_eq =
+		container_of(eq, struct vrb_eq, eq_fid.fid);
 	ssize_t rd = -FI_EAGAIN;
 	fastlock_acquire(&_eq->lock);
 	if (!_eq->err.err)
@@ -76,9 +76,9 @@ unlock:
 }
 
 /* Caller must hold eq:lock */
-void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
+void vrb_eq_set_xrc_conn_tag(struct vrb_xrc_ep *ep)
 {
-	struct fi_ibv_eq *eq = ep->base_ep.eq;
+	struct vrb_eq *eq = ep->base_ep.eq;
 
 	assert(ep->conn_setup);
 	assert(ep->conn_setup->conn_tag == VERBS_CONN_TAG_INVALID);
@@ -88,9 +88,9 @@ void fi_ibv_eq_set_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 }
 
 /* Caller must hold eq:lock */
-void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
+void vrb_eq_clear_xrc_conn_tag(struct vrb_xrc_ep *ep)
 {
-	struct fi_ibv_eq *eq = ep->base_ep.eq;
+	struct vrb_eq *eq = ep->base_ep.eq;
 	int index;
 
 	assert(ep->conn_setup);
@@ -108,10 +108,10 @@ void fi_ibv_eq_clear_xrc_conn_tag(struct fi_ibv_xrc_ep *ep)
 }
 
 /* Caller must hold eq:lock */
-struct fi_ibv_xrc_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq,
+struct vrb_xrc_ep *vrb_eq_xrc_conn_tag2ep(struct vrb_eq *eq,
 						uint32_t conn_tag)
 {
-	struct fi_ibv_xrc_ep *ep;
+	struct vrb_xrc_ep *ep;
 	int index;
 
 	index = ofi_key2idx(&eq->xrc.conn_key_idx, (uint64_t)conn_tag);
@@ -136,14 +136,14 @@ struct fi_ibv_xrc_ep *fi_ibv_eq_xrc_conn_tag2ep(struct fi_ibv_eq *eq,
 	return ep;
 }
 
-static int fi_ibv_eq_set_xrc_info(struct rdma_cm_event *event,
-				  struct fi_ibv_xrc_conn_info *info)
+static int vrb_eq_set_xrc_info(struct rdma_cm_event *event,
+				  struct vrb_xrc_conn_info *info)
 {
-	struct fi_ibv_xrc_cm_data *remote = (struct fi_ibv_xrc_cm_data *)
+	struct vrb_xrc_cm_data *remote = (struct vrb_xrc_cm_data *)
 						event->param.conn.private_data;
 	int ret;
 
-	ret = fi_ibv_verify_xrc_cm_data(remote,
+	ret = vrb_verify_xrc_cm_data(remote,
 					event->param.conn.private_data_len);
 	if (ret)
 		return ret;
@@ -161,12 +161,12 @@ static int fi_ibv_eq_set_xrc_info(struct rdma_cm_event *event,
 }
 
 static int
-fi_ibv_pep_dev_domain_match(struct fi_info *hints, const char *devname)
+vrb_pep_dev_domain_match(struct fi_info *hints, const char *devname)
 {
 	int ret;
 
-	if ((FI_IBV_EP_PROTO(hints)) == FI_PROTO_RDMA_CM_IB_XRC)
-		ret = fi_ibv_cmp_xrc_domain_name(hints->domain_attr->name,
+	if ((VRB_EP_PROTO(hints)) == FI_PROTO_RDMA_CM_IB_XRC)
+		ret = vrb_cmp_xrc_domain_name(hints->domain_attr->name,
 						 devname);
 	else
 		ret = strcmp(hints->domain_attr->name, devname);
@@ -175,11 +175,11 @@ fi_ibv_pep_dev_domain_match(struct fi_info *hints, const char *devname)
 }
 
 static int
-fi_ibv_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
+vrb_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 		     struct fi_info **info)
 {
 	struct fi_info *hints;
-	struct fi_ibv_connreq *connreq;
+	struct vrb_connreq *connreq;
 	const char *devname = ibv_get_device_name(event->id->verbs->device);
 	int ret = -FI_ENOMEM;
 
@@ -198,7 +198,7 @@ fi_ibv_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 		if (!(hints->domain_attr->name = strdup(devname)))
 			goto err1;
 	} else {
-		if (fi_ibv_pep_dev_domain_match(hints, devname)) {
+		if (vrb_pep_dev_domain_match(hints, devname)) {
 			VERBS_WARN(FI_LOG_EQ, "passive endpoint domain: %s does"
 				   " not match device: %s where we got a "
 				   "connection request\n",
@@ -213,30 +213,30 @@ fi_ibv_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 		hints->fabric_attr->name = NULL;
 	}
 
-	ret = fi_ibv_get_matching_info(hints->fabric_attr->api_version, hints,
-				       info, fi_ibv_util_prov.info, 0);
+	ret = vrb_get_matching_info(hints->fabric_attr->api_version, hints,
+				       info, vrb_util_prov.info, 0);
 	if (ret)
 		goto err1;
 
 	assert(!(*info)->dest_addr);
 
 	ofi_alter_info(*info, hints, hints->fabric_attr->api_version);
-	fi_ibv_alter_info(hints, *info);
+	vrb_alter_info(hints, *info);
 
 	free((*info)->src_addr);
 
-	(*info)->src_addrlen = fi_ibv_sockaddr_len(rdma_get_local_addr(event->id));
+	(*info)->src_addrlen = vrb_sockaddr_len(rdma_get_local_addr(event->id));
 	if (!((*info)->src_addr = malloc((*info)->src_addrlen)))
 		goto err2;
 	memcpy((*info)->src_addr, rdma_get_local_addr(event->id), (*info)->src_addrlen);
 
-	(*info)->dest_addrlen = fi_ibv_sockaddr_len(rdma_get_peer_addr(event->id));
+	(*info)->dest_addrlen = vrb_sockaddr_len(rdma_get_peer_addr(event->id));
 	if (!((*info)->dest_addr = malloc((*info)->dest_addrlen)))
 		goto err2;
 	memcpy((*info)->dest_addr, rdma_get_peer_addr(event->id), (*info)->dest_addrlen);
 
-	ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_EQ, "src", (*info)->src_addr);
-	ofi_straddr_dbg(&fi_ibv_prov, FI_LOG_EQ, "dst", (*info)->dest_addr);
+	ofi_straddr_dbg(&vrb_prov, FI_LOG_EQ, "src", (*info)->src_addr);
+	ofi_straddr_dbg(&vrb_prov, FI_LOG_EQ, "dst", (*info)->dest_addr);
 
 	connreq = calloc(1, sizeof *connreq);
 	if (!connreq) {
@@ -248,9 +248,9 @@ fi_ibv_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 	connreq->handle.fclass = FI_CLASS_CONNREQ;
 	connreq->id = event->id;
 
-	if (fi_ibv_is_xrc(*info)) {
+	if (vrb_is_xrc(*info)) {
 		connreq->is_xrc = 1;
-		ret = fi_ibv_eq_set_xrc_info(event, &connreq->xrc);
+		ret = vrb_eq_set_xrc_info(event, &connreq->xrc);
 		if (ret)
 			goto err3;
 	}
@@ -268,11 +268,11 @@ err1:
 	return ret;
 }
 
-static inline int fi_ibv_eq_copy_event_data(struct fi_eq_cm_entry *entry,
+static inline int vrb_eq_copy_event_data(struct fi_eq_cm_entry *entry,
 				size_t max_dest_len, const void *priv_data,
 				size_t priv_datalen)
 {
-	const struct fi_ibv_cm_data_hdr *cm_hdr = priv_data;
+	const struct vrb_cm_data_hdr *cm_hdr = priv_data;
 
 	size_t datalen = MIN(max_dest_len - sizeof(*entry), cm_hdr->size);
 	if (datalen)
@@ -281,10 +281,10 @@ static inline int fi_ibv_eq_copy_event_data(struct fi_eq_cm_entry *entry,
 	return datalen;
 }
 
-static void fi_ibv_eq_skip_xrc_cm_data(const void **priv_data,
+static void vrb_eq_skip_xrc_cm_data(const void **priv_data,
 				       size_t *priv_data_len)
 {
-	const struct fi_ibv_xrc_cm_data *cm_data = *priv_data;
+	const struct vrb_xrc_cm_data *cm_data = *priv_data;
 
 	if (*priv_data_len > sizeof(*cm_data)) {
 		*priv_data = (cm_data + 1);
@@ -292,20 +292,20 @@ static void fi_ibv_eq_skip_xrc_cm_data(const void **priv_data,
 	}
 }
 
-static inline void fi_ibv_set_sidr_conn_key(struct sockaddr *addr,
+static inline void vrb_set_sidr_conn_key(struct sockaddr *addr,
 					    uint16_t pep_port, bool recip,
-					    struct fi_ibv_sidr_conn_key *key)
+					    struct vrb_sidr_conn_key *key)
 {
 	key->addr = addr;
 	key->pep_port = pep_port;
 	key->recip = recip;
 }
 
-static int fi_ibv_sidr_conn_compare(struct ofi_rbmap *map,
+static int vrb_sidr_conn_compare(struct ofi_rbmap *map,
 				    void *key, void *data)
 {
-	struct fi_ibv_sidr_conn_key *_key = key;
-	struct fi_ibv_xrc_ep *ep = data;
+	struct vrb_sidr_conn_key *_key = key;
+	struct vrb_xrc_ep *ep = data;
 	int ret;
 
 	assert(_key->addr->sa_family ==
@@ -341,33 +341,33 @@ static int fi_ibv_sidr_conn_compare(struct ofi_rbmap *map,
 }
 
 /* Caller must hold eq:lock */
-struct fi_ibv_xrc_ep *fi_ibv_eq_get_sidr_conn(struct fi_ibv_eq *eq,
+struct vrb_xrc_ep *vrb_eq_get_sidr_conn(struct vrb_eq *eq,
 					      struct sockaddr *peer,
 					      uint16_t pep_port, bool recip)
 {
 	struct ofi_rbnode *node;
-	struct fi_ibv_sidr_conn_key key;
+	struct vrb_sidr_conn_key key;
 
-	fi_ibv_set_sidr_conn_key(peer, pep_port, recip, &key);
+	vrb_set_sidr_conn_key(peer, pep_port, recip, &key);
 	node = ofi_rbmap_find(&eq->xrc.sidr_conn_rbmap, &key);
 	if (OFI_LIKELY(!node))
 		return NULL;
 
-	return (struct fi_ibv_xrc_ep *) node->data;
+	return (struct vrb_xrc_ep *) node->data;
 }
 
 /* Caller must hold eq:lock */
-int fi_ibv_eq_add_sidr_conn(struct fi_ibv_xrc_ep *ep,
+int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 			    void *param_data, size_t param_len)
 {
 	int ret;
-	struct fi_ibv_sidr_conn_key key;
+	struct vrb_sidr_conn_key key;
 
 	assert(!ep->accept_param_data);
 	assert(param_len);
 	assert(ep->tgt_id && ep->tgt_id->ps == RDMA_PS_UDP);
 
-	fi_ibv_set_sidr_conn_key(ep->base_ep.info->dest_addr,
+	vrb_set_sidr_conn_key(ep->base_ep.info->dest_addr,
 				 ep->remote_pep_port, ep->recip_accept, &key);
 	ep->accept_param_data = calloc(1, param_len);
 	if (!ep->accept_param_data) {
@@ -393,7 +393,7 @@ int fi_ibv_eq_add_sidr_conn(struct fi_ibv_xrc_ep *ep,
 }
 
 /* Caller must hold eq:lock */
-void fi_ibv_eq_remove_sidr_conn(struct fi_ibv_xrc_ep *ep)
+void vrb_eq_remove_sidr_conn(struct vrb_xrc_ep *ep)
 {
 	assert(ep->conn_map_node);
 
@@ -405,17 +405,17 @@ void fi_ibv_eq_remove_sidr_conn(struct fi_ibv_xrc_ep *ep)
 }
 
 static int
-fi_ibv_eq_accept_recip_conn(struct fi_ibv_xrc_ep *ep,
+vrb_eq_accept_recip_conn(struct vrb_xrc_ep *ep,
 			    struct fi_eq_cm_entry *entry, size_t len,
 			    uint32_t *event, struct rdma_cm_event *cma_event,
 			    int *acked)
 {
-	struct fi_ibv_xrc_cm_data cm_data;
+	struct vrb_xrc_cm_data cm_data;
 	int ret;
 
-	assert(ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED);
+	assert(ep->conn_state == VRB_XRC_ORIG_CONNECTED);
 
-	ret = fi_ibv_accept_xrc(ep, FI_IBV_RECIP_CONN, &cm_data,
+	ret = vrb_accept_xrc(ep, VRB_RECIP_CONN, &cm_data,
 				sizeof(cm_data));
 	if (ret) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
@@ -426,16 +426,16 @@ fi_ibv_eq_accept_recip_conn(struct fi_ibv_xrc_ep *ep,
 	/* SIDR based shared reciprocal connections are complete at
 	 * this point, generate the connection established event. */
 	if (ep->tgt_id->ps == RDMA_PS_UDP) {
-		fi_ibv_next_xrc_conn_state(ep);
-		fi_ibv_ep_tgt_conn_done(ep);
+		vrb_next_xrc_conn_state(ep);
+		vrb_ep_tgt_conn_done(ep);
 		entry->fid = &ep->base_ep.util_ep.ep_fid.fid;
 		*event = FI_CONNECTED;
-		len = fi_ibv_eq_copy_event_data(entry, len,
+		len = vrb_eq_copy_event_data(entry, len,
 						ep->conn_setup->event_data,
 						ep->conn_setup->event_len);
 		*acked = 1;
 		rdma_ack_cm_event(cma_event);
-		fi_ibv_free_xrc_conn_setup(ep, 1);
+		vrb_free_xrc_conn_setup(ep, 1);
 
 		return sizeof(*entry) + len;
 	}
@@ -445,14 +445,14 @@ fi_ibv_eq_accept_recip_conn(struct fi_ibv_xrc_ep *ep,
 }
 
 static int
-fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
+vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
 			    size_t len, uint32_t *event,
 			    struct rdma_cm_event *cma_event, int *acked,
 			    const void **priv_data, size_t *priv_datalen)
 {
-	struct fi_ibv_connreq *connreq = container_of(entry->info->handle,
-						struct fi_ibv_connreq, handle);
-	struct fi_ibv_xrc_ep *ep;
+	struct vrb_connreq *connreq = container_of(entry->info->handle,
+						struct vrb_connreq, handle);
+	struct vrb_xrc_ep *ep;
 	int ret;
 
 	/*
@@ -463,7 +463,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 	 */
 	assert(entry->info->dest_addr);
 	if (cma_event->id->ps == RDMA_PS_UDP) {
-		ep = fi_ibv_eq_get_sidr_conn(eq, entry->info->dest_addr,
+		ep = vrb_eq_get_sidr_conn(eq, entry->info->dest_addr,
 					     connreq->xrc.port,
 					     connreq->xrc.is_reciprocal);
 		if (ep) {
@@ -471,7 +471,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 				  "SIDR %s request retry received\n",
 				  connreq->xrc.is_reciprocal ?
 				  "reciprocal" : "original");
-			ret = fi_ibv_resend_shared_accept_xrc(ep, connreq,
+			ret = vrb_resend_shared_accept_xrc(ep, connreq,
 							      cma_event->id);
 			if (ret)
 				VERBS_WARN(FI_LOG_EP_CTRL,
@@ -483,7 +483,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 	}
 
 	if (!connreq->xrc.is_reciprocal) {
-		fi_ibv_eq_skip_xrc_cm_data(priv_data, priv_datalen);
+		vrb_eq_skip_xrc_cm_data(priv_data, priv_datalen);
 		return FI_SUCCESS;
 	}
 
@@ -492,7 +492,7 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 	 * the provider, get the endpoint that issued the original connection
 	 * request.
 	 */
-	ep = fi_ibv_eq_xrc_conn_tag2ep(eq, connreq->xrc.conn_tag);
+	ep = vrb_eq_xrc_conn_tag2ep(eq, connreq->xrc.conn_tag);
 	if (!ep) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "Reciprocal XRC connection tag 0x%x not found\n",
@@ -501,8 +501,8 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 	}
 	ep->recip_req_received = 1;
 
-	assert(ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED ||
-	       ep->conn_state == FI_IBV_XRC_ORIG_CONNECTING);
+	assert(ep->conn_state == VRB_XRC_ORIG_CONNECTED ||
+	       ep->conn_state == VRB_XRC_ORIG_CONNECTING);
 
 	ep->tgt_id = connreq->id;
 	ep->tgt_id->context = &ep->base_ep.util_ep.ep_fid.fid;
@@ -516,8 +516,8 @@ fi_ibv_eq_xrc_connreq_event(struct fi_ibv_eq *eq, struct fi_eq_cm_entry *entry,
 
 	/* If the initial connection has completed proceed with accepting
 	 * the reciprocal; otherwise wait until it has before proceeding */
-	if (ep->conn_state == FI_IBV_XRC_ORIG_CONNECTED)
-		return fi_ibv_eq_accept_recip_conn(ep, entry, len, event,
+	if (ep->conn_state == VRB_XRC_ORIG_CONNECTED)
+		return vrb_eq_accept_recip_conn(ep, entry, len, event,
 						   cma_event, acked);
 
 	return -FI_EAGAIN;
@@ -530,7 +530,7 @@ send_reject:
 }
 
 static void
-fi_ibv_eq_xrc_establish(struct rdma_cm_event *cma_event)
+vrb_eq_xrc_establish(struct rdma_cm_event *cma_event)
 {
 	/* For newer rdma-core, active side  must complete the
 	 * connect if rdma_cm is not managing the QP */
@@ -540,20 +540,20 @@ fi_ibv_eq_xrc_establish(struct rdma_cm_event *cma_event)
 }
 
 static int
-fi_ibv_eq_xrc_conn_event(struct fi_ibv_xrc_ep *ep,
+vrb_eq_xrc_conn_event(struct vrb_xrc_ep *ep,
 			 struct rdma_cm_event *cma_event, int *acked,
 			 struct fi_eq_cm_entry *entry, size_t len,
 			 uint32_t *event)
 {
-	struct fi_ibv_xrc_conn_info xrc_info;
-	struct fi_ibv_xrc_cm_data cm_data;
+	struct vrb_xrc_conn_info xrc_info;
+	struct vrb_xrc_cm_data cm_data;
 	const void *priv_data = cma_event->param.conn.private_data;
 	size_t priv_datalen = cma_event->param.conn.private_data_len;
 	int ret;
 
 	VERBS_DBG(FI_LOG_EP_CTRL, "EP %p INITIAL CONNECTION DONE state %d, ps %d\n",
 		  ep, ep->conn_state, cma_event->id->ps);
-	fi_ibv_next_xrc_conn_state(ep);
+	vrb_next_xrc_conn_state(ep);
 
 	/*
 	 * Original application initiated connect is done, if the passive
@@ -561,30 +561,30 @@ fi_ibv_eq_xrc_conn_event(struct fi_ibv_xrc_ep *ep,
 	 * to create bidirectional connectivity.
 	 */
 	if (priv_data) {
-		ret = fi_ibv_eq_set_xrc_info(cma_event, &xrc_info);
+		ret = vrb_eq_set_xrc_info(cma_event, &xrc_info);
 		if (ret) {
-			fi_ibv_prev_xrc_conn_state(ep);
+			vrb_prev_xrc_conn_state(ep);
 			rdma_disconnect(ep->base_ep.id);
 			goto err;
 		}
 		ep->peer_srqn = xrc_info.peer_srqn;
-		fi_ibv_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
-		fi_ibv_save_priv_data(ep, priv_data, priv_datalen);
-		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_param.qp_num);
-		fi_ibv_eq_xrc_establish(cma_event);
+		vrb_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
+		vrb_save_priv_data(ep, priv_data, priv_datalen);
+		vrb_ep_ini_conn_done(ep, xrc_info.conn_param.qp_num);
+		vrb_eq_xrc_establish(cma_event);
 
 		/* If we have received the reciprocal connect request,
 		 * process it now */
 		if (ep->recip_req_received)
-			return fi_ibv_eq_accept_recip_conn(ep, entry,
+			return vrb_eq_accept_recip_conn(ep, entry,
 							   len, event,
 							   cma_event, acked);
 	} else {
-		fi_ibv_ep_tgt_conn_done(ep);
-		ret = fi_ibv_connect_xrc(ep, NULL, FI_IBV_RECIP_CONN, &cm_data,
+		vrb_ep_tgt_conn_done(ep);
+		ret = vrb_connect_xrc(ep, NULL, VRB_RECIP_CONN, &cm_data,
 					 sizeof(cm_data));
 		if (ret) {
-			fi_ibv_prev_xrc_conn_state(ep);
+			vrb_prev_xrc_conn_state(ep);
 			ep->tgt_id->qp = NULL;
 			rdma_disconnect(ep->tgt_id);
 			goto err;
@@ -597,22 +597,22 @@ err:
 }
 
 static size_t
-fi_ibv_eq_xrc_recip_conn_event(struct fi_ibv_eq *eq,
-			       struct fi_ibv_xrc_ep *ep,
+vrb_eq_xrc_recip_conn_event(struct vrb_eq *eq,
+			       struct vrb_xrc_ep *ep,
 			       struct rdma_cm_event *cma_event,
 			       struct fi_eq_cm_entry *entry, size_t len)
 {
 	fid_t fid = cma_event->id->context;
-	struct fi_ibv_xrc_conn_info xrc_info;
+	struct vrb_xrc_conn_info xrc_info;
 	int ret;
 
-	fi_ibv_next_xrc_conn_state(ep);
+	vrb_next_xrc_conn_state(ep);
 	VERBS_DBG(FI_LOG_EP_CTRL, "EP %p RECIPROCAL CONNECTION DONE state %d\n",
 		  ep, ep->conn_state);
 
 	/* If this is the reciprocal active side notification */
 	if (cma_event->param.conn.private_data) {
-		ret = fi_ibv_eq_set_xrc_info(cma_event, &xrc_info);
+		ret = vrb_eq_set_xrc_info(cma_event, &xrc_info);
 		if (ret) {
 			VERBS_WARN(FI_LOG_EP_CTRL,
 				   "Reciprocal connection protocol mismatch\n");
@@ -623,17 +623,17 @@ fi_ibv_eq_xrc_recip_conn_event(struct fi_ibv_eq *eq,
 		}
 
 		ep->peer_srqn = xrc_info.peer_srqn;
-		fi_ibv_ep_ini_conn_done(ep, xrc_info.conn_param.qp_num);
-		fi_ibv_eq_xrc_establish(cma_event);
+		vrb_ep_ini_conn_done(ep, xrc_info.conn_param.qp_num);
+		vrb_eq_xrc_establish(cma_event);
 	} else {
-		fi_ibv_ep_tgt_conn_done(ep);
+		vrb_ep_tgt_conn_done(ep);
 	}
 
 	/* The internal reciprocal XRC connection has completed. Return the
 	 * CONNECTED event application data associated with the original
 	 * connection. */
 	entry->fid = fid;
-	len = fi_ibv_eq_copy_event_data(entry, len,
+	len = vrb_eq_copy_event_data(entry, len,
 					ep->conn_setup->event_data,
 					ep->conn_setup->event_len);
 	entry->info = NULL;
@@ -642,14 +642,14 @@ fi_ibv_eq_xrc_recip_conn_event(struct fi_ibv_eq *eq,
 
 /* Caller must hold eq:lock */
 static int
-fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
+vrb_eq_xrc_rej_event(struct vrb_eq *eq, struct rdma_cm_event *cma_event)
 {
-	struct fi_ibv_xrc_ep *ep;
+	struct vrb_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
-	struct fi_ibv_xrc_conn_info xrc_info;
-	enum fi_ibv_xrc_ep_conn_state state;
+	struct vrb_xrc_conn_info xrc_info;
+	enum vrb_xrc_ep_conn_state state;
 
-	ep = container_of(fid, struct fi_ibv_xrc_ep, base_ep.util_ep.ep_fid);
+	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "CM ID context not valid\n");
@@ -658,24 +658,24 @@ fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
 
 	state = ep->conn_state;
 	if (ep->base_ep.id != cma_event->id ||
-	    (state != FI_IBV_XRC_ORIG_CONNECTING &&
-	     state != FI_IBV_XRC_RECIP_CONNECTING)) {
+	    (state != VRB_XRC_ORIG_CONNECTING &&
+	     state != VRB_XRC_RECIP_CONNECTING)) {
 		VERBS_WARN(FI_LOG_EP_CTRL,
 			   "Stale/invalid CM reject %d received\n", cma_event->status);
 		return -FI_EAGAIN;
 	}
 
 	/* If reject comes from remote provider peer */
-	if (cma_event->status == FI_IBV_CM_REJ_CONSUMER_DEFINED ||
-	    cma_event->status == FI_IBV_CM_REJ_SIDR_CONSUMER_DEFINED) {
+	if (cma_event->status == VRB_CM_REJ_CONSUMER_DEFINED ||
+	    cma_event->status == VRB_CM_REJ_SIDR_CONSUMER_DEFINED) {
 		if (cma_event->param.conn.private_data_len &&
-		    fi_ibv_eq_set_xrc_info(cma_event, &xrc_info)) {
+		    vrb_eq_set_xrc_info(cma_event, &xrc_info)) {
 			VERBS_WARN(FI_LOG_EP_CTRL,
 				   "CM REJ private data not valid\n");
 			return -FI_EAGAIN;
 		}
 
-		fi_ibv_ep_ini_conn_rejected(ep);
+		vrb_ep_ini_conn_rejected(ep);
 		return FI_SUCCESS;
 	}
 
@@ -684,20 +684,20 @@ fi_ibv_eq_xrc_rej_event(struct fi_ibv_eq *eq, struct rdma_cm_event *cma_event)
 	if (cma_event->param.conn.private_data_len)
 		VERBS_WARN(FI_LOG_EP_CTRL, "Unexpected CM Reject priv_data\n");
 
-	fi_ibv_ep_ini_conn_rejected(ep);
+	vrb_ep_ini_conn_rejected(ep);
 
-	return state == FI_IBV_XRC_ORIG_CONNECTING ? FI_SUCCESS : -FI_EAGAIN;
+	return state == VRB_XRC_ORIG_CONNECTING ? FI_SUCCESS : -FI_EAGAIN;
 }
 
 /* Caller must hold eq:lock */
 static inline int
-fi_ibv_eq_xrc_cm_err_event(struct fi_ibv_eq *eq,
+vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
                            struct rdma_cm_event *cma_event)
 {
-	struct fi_ibv_xrc_ep *ep;
+	struct vrb_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
 
-	ep = container_of(fid, struct fi_ibv_xrc_ep, base_ep.util_ep.ep_fid);
+	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 	if (ep->magic != VERBS_XRC_EP_MAGIC) {
 		VERBS_WARN(FI_LOG_EP_CTRL, "CM ID context invalid\n");
 		return -FI_EAGAIN;
@@ -715,53 +715,53 @@ fi_ibv_eq_xrc_cm_err_event(struct fi_ibv_eq *eq,
 	VERBS_WARN(FI_LOG_EP_CTRL, "CM error event %s, status %d\n",
 		   rdma_event_str(cma_event->event), cma_event->status);
 	if (ep->base_ep.info->src_addr)
-		ofi_straddr_log(&fi_ibv_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
+		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
 				"Src ", ep->base_ep.info->src_addr);
 	if (ep->base_ep.info->dest_addr)
-		ofi_straddr_log(&fi_ibv_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
+		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
 				"Dest ", ep->base_ep.info->dest_addr);
-        ep->conn_state = FI_IBV_XRC_ERROR;
+        ep->conn_state = VRB_XRC_ERROR;
         return FI_SUCCESS;
 }
 
 /* Caller must hold eq:lock */
 static inline int
-fi_ibv_eq_xrc_connected_event(struct fi_ibv_eq *eq,
+vrb_eq_xrc_connected_event(struct vrb_eq *eq,
 			      struct rdma_cm_event *cma_event, int *acked,
 			      struct fi_eq_cm_entry *entry, size_t len,
 			      uint32_t *event)
 {
-	struct fi_ibv_xrc_ep *ep;
+	struct vrb_xrc_ep *ep;
 	fid_t fid = cma_event->id->context;
 	int ret;
 
-	ep = container_of(fid, struct fi_ibv_xrc_ep, base_ep.util_ep.ep_fid);
+	ep = container_of(fid, struct vrb_xrc_ep, base_ep.util_ep.ep_fid);
 
-	assert(ep->conn_state == FI_IBV_XRC_ORIG_CONNECTING ||
-	       ep->conn_state == FI_IBV_XRC_RECIP_CONNECTING);
+	assert(ep->conn_state == VRB_XRC_ORIG_CONNECTING ||
+	       ep->conn_state == VRB_XRC_RECIP_CONNECTING);
 
-	if (ep->conn_state == FI_IBV_XRC_ORIG_CONNECTING)
-		return fi_ibv_eq_xrc_conn_event(ep, cma_event, acked,
+	if (ep->conn_state == VRB_XRC_ORIG_CONNECTING)
+		return vrb_eq_xrc_conn_event(ep, cma_event, acked,
 						entry, len, event);
 
-	ret = fi_ibv_eq_xrc_recip_conn_event(eq, ep, cma_event, entry, len);
+	ret = vrb_eq_xrc_recip_conn_event(eq, ep, cma_event, entry, len);
 
 	/* Bidirectional connection setup is complete, release RDMA CM ID
 	 * resources. */
 	*acked = 1;
 	rdma_ack_cm_event(cma_event);
-	fi_ibv_free_xrc_conn_setup(ep, 1);
+	vrb_free_xrc_conn_setup(ep, 1);
 
 	return ret;
 }
 
 /* Caller must hold eq:lock */
 static inline void
-fi_ibv_eq_xrc_timewait_event(struct fi_ibv_eq *eq,
+vrb_eq_xrc_timewait_event(struct vrb_eq *eq,
 			     struct rdma_cm_event *cma_event, int *acked)
 {
 	fid_t fid = cma_event->id->context;
-	struct fi_ibv_xrc_ep *ep = container_of(fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	assert(ep->magic == VERBS_XRC_EP_MAGIC);
 	assert(ep->conn_setup);
@@ -778,16 +778,16 @@ fi_ibv_eq_xrc_timewait_event(struct fi_ibv_eq *eq,
 		ep->base_ep.id = NULL;
 	}
 	if (!ep->base_ep.id && !ep->tgt_id)
-		fi_ibv_free_xrc_conn_setup(ep, 0);
+		vrb_free_xrc_conn_setup(ep, 0);
 }
 
 /* Caller must hold eq:lock */
 static inline void
-fi_ibv_eq_xrc_disconnect_event(struct fi_ibv_eq *eq,
+vrb_eq_xrc_disconnect_event(struct vrb_eq *eq,
 			       struct rdma_cm_event *cma_event, int *acked)
 {
 	fid_t fid = cma_event->id->context;
-	struct fi_ibv_xrc_ep *ep = container_of(fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	assert(ep->magic == VERBS_XRC_EP_MAGIC);
 
@@ -799,33 +799,33 @@ fi_ibv_eq_xrc_disconnect_event(struct fi_ibv_eq *eq,
 }
 
 static ssize_t
-fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
+vrb_eq_cm_process_event(struct vrb_eq *eq,
 	struct rdma_cm_event *cma_event, uint32_t *event,
 	struct fi_eq_cm_entry *entry, size_t len)
 {
-	const struct fi_ibv_cm_data_hdr *cm_hdr;
+	const struct vrb_cm_data_hdr *cm_hdr;
 	size_t datalen = 0;
 	size_t priv_datalen = cma_event->param.conn.private_data_len;
 	const void *priv_data = cma_event->param.conn.private_data;
 	int ret, acked = 0;;
 	fid_t fid = cma_event->id->context;
-	struct fi_ibv_pep *pep =
-		container_of(fid, struct fi_ibv_pep, pep_fid);
-	struct fi_ibv_ep *ep;
-	struct fi_ibv_xrc_ep *xrc_ep;
+	struct vrb_pep *pep =
+		container_of(fid, struct vrb_pep, pep_fid);
+	struct vrb_ep *ep;
+	struct vrb_xrc_ep *xrc_ep;
 
 	switch (cma_event->event) {
 	case RDMA_CM_EVENT_ROUTE_RESOLVED:
-		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
 		if (rdma_connect(ep->id, &ep->conn_param)) {
 			ret = -errno;
-			FI_WARN(&fi_ibv_prov, FI_LOG_EP_CTRL,
+			FI_WARN(&vrb_prov, FI_LOG_EP_CTRL,
 				"rdma_connect failed: %s (%d)\n",
 				strerror(-ret), -ret);
-			if (fi_ibv_is_xrc(ep->info)) {
-				xrc_ep = container_of(fid, struct fi_ibv_xrc_ep,
+			if (vrb_is_xrc(ep->info)) {
+				xrc_ep = container_of(fid, struct vrb_xrc_ep,
 						      base_ep.util_ep.ep_fid);
-				fi_ibv_put_shared_ini_conn(xrc_ep);
+				vrb_put_shared_ini_conn(xrc_ep);
 			}
 		} else {
 			ret = -FI_EAGAIN;
@@ -834,7 +834,7 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 	case RDMA_CM_EVENT_CONNECT_REQUEST:
 		*event = FI_CONNREQ;
 
-		ret = fi_ibv_eq_cm_getinfo(cma_event, pep->info, &entry->info);
+		ret = vrb_eq_cm_getinfo(cma_event, pep->info, &entry->info);
 		if (ret) {
 			VERBS_WARN(FI_LOG_EP_CTRL,
 				   "CM getinfo error %d\n", ret);
@@ -844,8 +844,8 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 			goto err;
 		}
 
-		if (fi_ibv_is_xrc(entry->info)) {
-			ret = fi_ibv_eq_xrc_connreq_event(eq, entry, len, event,
+		if (vrb_is_xrc(entry->info)) {
+			ret = vrb_eq_xrc_connreq_event(eq, entry, len, event,
 							  cma_event, &acked,
 							  &priv_data, &priv_datalen);
 			if (ret == -FI_EAGAIN || *event == FI_CONNECTED)
@@ -859,13 +859,13 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		if (cma_event->id->qp &&
 		    cma_event->id->qp->context->device->transport_type !=
 		    IBV_TRANSPORT_IWARP) {
-			ret = fi_ibv_set_rnr_timer(cma_event->id->qp);
+			ret = vrb_set_rnr_timer(cma_event->id->qp);
 			if (ret)
 				goto ack;
 		}
-		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
-		if (fi_ibv_is_xrc(ep->info)) {
-			ret = fi_ibv_eq_xrc_connected_event(eq, cma_event,
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		if (vrb_is_xrc(ep->info)) {
+			ret = vrb_eq_xrc_connected_event(eq, cma_event,
 							    &acked, entry, len,
 							    event);
 			goto ack;
@@ -873,9 +873,9 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		entry->info = NULL;
 		break;
 	case RDMA_CM_EVENT_DISCONNECTED:
-		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
-		if (fi_ibv_is_xrc(ep->info)) {
-			fi_ibv_eq_xrc_disconnect_event(eq, cma_event, &acked);
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		if (vrb_is_xrc(ep->info)) {
+			vrb_eq_xrc_disconnect_event(eq, cma_event, &acked);
 			ret = -FI_EAGAIN;
 			goto ack;
 		}
@@ -883,24 +883,24 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		entry->info = NULL;
 		break;
 	case RDMA_CM_EVENT_TIMEWAIT_EXIT:
-		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
-		if (fi_ibv_is_xrc(ep->info))
-			fi_ibv_eq_xrc_timewait_event(eq, cma_event, &acked);
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		if (vrb_is_xrc(ep->info))
+			vrb_eq_xrc_timewait_event(eq, cma_event, &acked);
 		ret = -FI_EAGAIN;
 		goto ack;
 	case RDMA_CM_EVENT_ADDR_ERROR:
 	case RDMA_CM_EVENT_ROUTE_ERROR:
 	case RDMA_CM_EVENT_CONNECT_ERROR:
 	case RDMA_CM_EVENT_UNREACHABLE:
-		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
 		assert(ep->info);
-		if (fi_ibv_is_xrc(ep->info)) {
+		if (vrb_is_xrc(ep->info)) {
 			/* SIDR Reject is reported as UNREACHABLE */
 			if (cma_event->id->ps == RDMA_PS_UDP &&
 			    cma_event->event == RDMA_CM_EVENT_UNREACHABLE)
 				goto xrc_shared_reject;
 
-			ret = fi_ibv_eq_xrc_cm_err_event(eq, cma_event);
+			ret = vrb_eq_xrc_cm_err_event(eq, cma_event);
 			if (ret == -FI_EAGAIN)
 				goto ack;
 		}
@@ -913,13 +913,13 @@ fi_ibv_eq_cm_process_event(struct fi_ibv_eq *eq,
 		}
 		goto err;
 	case RDMA_CM_EVENT_REJECTED:
-		ep = container_of(fid, struct fi_ibv_ep, util_ep.ep_fid);
-		if (fi_ibv_is_xrc(ep->info)) {
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		if (vrb_is_xrc(ep->info)) {
 xrc_shared_reject:
-			ret = fi_ibv_eq_xrc_rej_event(eq, cma_event);
+			ret = vrb_eq_xrc_rej_event(eq, cma_event);
 			if (ret == -FI_EAGAIN)
 				goto ack;
-			fi_ibv_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
+			vrb_eq_skip_xrc_cm_data(&priv_data, &priv_datalen);
 		}
 		eq->err.err = ECONNREFUSED;
 		eq->err.prov_errno = -cma_event->status;
@@ -954,7 +954,7 @@ xrc_shared_reject:
 
 	/* rdmacm has no way to track how much data is sent by peer */
 	if (priv_datalen)
-		datalen = fi_ibv_eq_copy_event_data(entry, len, priv_data,
+		datalen = vrb_eq_copy_event_data(entry, len, priv_data,
 						    priv_datalen);
 	if (!acked)
 		rdma_ack_cm_event(cma_event);
@@ -968,7 +968,7 @@ ack:
 	return ret;
 }
 
-int fi_ibv_eq_trywait(struct fi_ibv_eq *eq)
+int vrb_eq_trywait(struct vrb_eq *eq)
 {
 	int ret;
 	fastlock_acquire(&eq->lock);
@@ -977,12 +977,12 @@ int fi_ibv_eq_trywait(struct fi_ibv_eq *eq)
 	return ret ? 0 : -FI_EAGAIN;
 }
 
-int fi_ibv_eq_match_event(struct dlist_entry *item, const void *arg)
+int vrb_eq_match_event(struct dlist_entry *item, const void *arg)
 {
-	struct fi_ibv_eq_entry *entry;
+	struct vrb_eq_entry *entry;
 	const struct fid *fid = arg;
 
-	entry = container_of(item, struct fi_ibv_eq_entry, item);
+	entry = container_of(item, struct vrb_eq_entry, item);
 	switch (entry->event) {
 	case FI_CONNREQ:
 	case FI_CONNECTED:
@@ -998,27 +998,27 @@ int fi_ibv_eq_match_event(struct dlist_entry *item, const void *arg)
 }
 
 /* Caller must hold eq->lock */
-void fi_ibv_eq_remove_events(struct fi_ibv_eq *eq, struct fid *fid)
+void vrb_eq_remove_events(struct vrb_eq *eq, struct fid *fid)
 {
 	struct dlist_entry *item;
-	struct fi_ibv_eq_entry *entry;
+	struct vrb_eq_entry *entry;
 
 	while ((item =
 		dlistfd_remove_first_match(&eq->list_head,
-					   fi_ibv_eq_match_event, fid))) {
-		entry = container_of(item, struct fi_ibv_eq_entry, item);
+					   vrb_eq_match_event, fid))) {
+		entry = container_of(item, struct vrb_eq_entry, item);
 		if (entry->event == FI_CONNREQ)
 			fi_freeinfo(entry->cm_entry->info);
 		free(entry);
 	}
 }
 
-struct fi_ibv_eq_entry  *
-fi_ibv_eq_alloc_entry(uint32_t event, const void *buf, size_t len)
+struct vrb_eq_entry  *
+vrb_eq_alloc_entry(uint32_t event, const void *buf, size_t len)
 {
-	struct fi_ibv_eq_entry *entry;
+	struct vrb_eq_entry *entry;
 
-	entry = calloc(1, sizeof(struct fi_ibv_eq_entry) + len);
+	entry = calloc(1, sizeof(struct vrb_eq_entry) + len);
 	if (!entry)
 		return NULL;
 
@@ -1029,12 +1029,12 @@ fi_ibv_eq_alloc_entry(uint32_t event, const void *buf, size_t len)
 	return entry;
 }
 
-ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
+ssize_t vrb_eq_write_event(struct vrb_eq *eq, uint32_t event,
 			      const void *buf, size_t len)
 {
-	struct fi_ibv_eq_entry *entry;
+	struct vrb_eq_entry *entry;
 
-	entry = fi_ibv_eq_alloc_entry(event, buf, len);
+	entry = vrb_eq_alloc_entry(event, buf, len);
 	if (!entry)
 		return -FI_ENOMEM;
 
@@ -1045,22 +1045,22 @@ ssize_t fi_ibv_eq_write_event(struct fi_ibv_eq *eq, uint32_t event,
 	return len;
 }
 
-static ssize_t fi_ibv_eq_write(struct fid_eq *eq_fid, uint32_t event,
+static ssize_t vrb_eq_write(struct fid_eq *eq_fid, uint32_t event,
 			       const void *buf, size_t len, uint64_t flags)
 {
-	struct fi_ibv_eq *eq;
+	struct vrb_eq *eq;
 
-	eq = container_of(eq_fid, struct fi_ibv_eq, eq_fid.fid);
+	eq = container_of(eq_fid, struct vrb_eq, eq_fid.fid);
 	if (!(eq->flags & FI_WRITE))
 		return -FI_EINVAL;
 
-	return fi_ibv_eq_write_event(eq, event, buf, len);
+	return vrb_eq_write_event(eq, event, buf, len);
 }
 
-static size_t fi_ibv_eq_read_event(struct fi_ibv_eq *eq, uint32_t *event,
+static size_t vrb_eq_read_event(struct vrb_eq *eq, uint32_t *event,
 		void *buf, size_t len, uint64_t flags)
 {
-	struct fi_ibv_eq_entry *entry;
+	struct vrb_eq_entry *entry;
 	ssize_t ret = 0;
 
 	fastlock_acquire(&eq->lock);
@@ -1073,7 +1073,7 @@ static size_t fi_ibv_eq_read_event(struct fi_ibv_eq *eq, uint32_t *event,
 	if (dlistfd_empty(&eq->list_head))
 		goto out;
 
-	entry = container_of(eq->list_head.list.next, struct fi_ibv_eq_entry, item);
+	entry = container_of(eq->list_head.list.next, struct vrb_eq_entry, item);
 	if (entry->len > len) {
 		ret = -FI_ETOOSMALL;
 		goto out;
@@ -1094,19 +1094,19 @@ out:
 }
 
 static ssize_t
-fi_ibv_eq_read(struct fid_eq *eq_fid, uint32_t *event,
+vrb_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 	       void *buf, size_t len, uint64_t flags)
 {
-	struct fi_ibv_eq *eq;
+	struct vrb_eq *eq;
 	struct rdma_cm_event *cma_event;
 	ssize_t ret = 0;
 
 	if (len < sizeof(struct fi_eq_cm_entry))
 		return -FI_ETOOSMALL;
 
-	eq = container_of(eq_fid, struct fi_ibv_eq, eq_fid.fid);
+	eq = container_of(eq_fid, struct vrb_eq, eq_fid.fid);
 
-	if ((ret = fi_ibv_eq_read_event(eq, event, buf, len, flags)))
+	if ((ret = vrb_eq_read_event(eq, event, buf, len, flags)))
 		return ret;
 
 	if (eq->channel) {
@@ -1118,7 +1118,7 @@ next_event:
 			return -errno;
 		}
 
-		ret = fi_ibv_eq_cm_process_event(eq, cma_event, event,
+		ret = vrb_eq_cm_process_event(eq, cma_event, event,
 						 (struct fi_eq_cm_entry *)buf,
 						 len);
 		fastlock_release(&eq->lock);
@@ -1128,7 +1128,7 @@ next_event:
 			goto next_event;
 
 		if (flags & FI_PEEK)
-			ret = fi_ibv_eq_write_event(eq, *event, buf, ret);
+			ret = vrb_eq_write_event(eq, *event, buf, ret);
 
 		return ret;
 	}
@@ -1137,17 +1137,17 @@ next_event:
 }
 
 static ssize_t
-fi_ibv_eq_sread(struct fid_eq *eq_fid, uint32_t *event,
+vrb_eq_sread(struct fid_eq *eq_fid, uint32_t *event,
 		void *buf, size_t len, int timeout, uint64_t flags)
 {
-	struct fi_ibv_eq *eq;
+	struct vrb_eq *eq;
 	struct epoll_event events[2];
 	ssize_t ret;
 
-	eq = container_of(eq_fid, struct fi_ibv_eq, eq_fid.fid);
+	eq = container_of(eq_fid, struct vrb_eq, eq_fid.fid);
 
 	while (1) {
-		ret = fi_ibv_eq_read(eq_fid, event, buf, len, flags);
+		ret = vrb_eq_read(eq_fid, event, buf, len, flags);
 		if (ret && (ret != -FI_EAGAIN))
 			return ret;
 
@@ -1160,7 +1160,7 @@ fi_ibv_eq_sread(struct fid_eq *eq_fid, uint32_t *event,
 }
 
 static const char *
-fi_ibv_eq_strerror(struct fid_eq *eq, int prov_errno, const void *err_data,
+vrb_eq_strerror(struct fid_eq *eq, int prov_errno, const void *err_data,
 		   char *buf, size_t len)
 {
 	if (buf && len)
@@ -1168,21 +1168,21 @@ fi_ibv_eq_strerror(struct fid_eq *eq, int prov_errno, const void *err_data,
 	return strerror(prov_errno);
 }
 
-static struct fi_ops_eq fi_ibv_eq_ops = {
+static struct fi_ops_eq vrb_eq_ops = {
 	.size = sizeof(struct fi_ops_eq),
-	.read = fi_ibv_eq_read,
-	.readerr = fi_ibv_eq_readerr,
-	.write = fi_ibv_eq_write,
-	.sread = fi_ibv_eq_sread,
-	.strerror = fi_ibv_eq_strerror
+	.read = vrb_eq_read,
+	.readerr = vrb_eq_readerr,
+	.write = vrb_eq_write,
+	.sread = vrb_eq_sread,
+	.strerror = vrb_eq_strerror
 };
 
-static int fi_ibv_eq_control(fid_t fid, int command, void *arg)
+static int vrb_eq_control(fid_t fid, int command, void *arg)
 {
-	struct fi_ibv_eq *eq;
+	struct vrb_eq *eq;
 	int ret = 0;
 
-	eq = container_of(fid, struct fi_ibv_eq, eq_fid.fid);
+	eq = container_of(fid, struct vrb_eq, eq_fid.fid);
 	switch (command) {
 	case FI_GETWAIT:
 		if (!eq->epfd) {
@@ -1199,12 +1199,12 @@ static int fi_ibv_eq_control(fid_t fid, int command, void *arg)
 	return ret;
 }
 
-static int fi_ibv_eq_close(fid_t fid)
+static int vrb_eq_close(fid_t fid)
 {
-	struct fi_ibv_eq *eq;
-	struct fi_ibv_eq_entry *entry;
+	struct vrb_eq *eq;
+	struct vrb_eq_entry *entry;
 
-	eq = container_of(fid, struct fi_ibv_eq, eq_fid.fid);
+	eq = container_of(fid, struct vrb_eq, eq_fid.fid);
 	/* TODO: use util code, if possible, and add ref counting */
 
 	if (!ofi_rbmap_empty(&eq->xrc.sidr_conn_rbmap))
@@ -1219,7 +1219,7 @@ static int fi_ibv_eq_close(fid_t fid)
 
 	while (!dlistfd_empty(&eq->list_head)) {
 		entry = container_of(eq->list_head.list.next,
-				     struct fi_ibv_eq_entry, item);
+				     struct vrb_eq_entry, item);
 		dlistfd_remove(eq->list_head.list.next, &eq->list_head);
 		free(entry);
 	}
@@ -1235,18 +1235,18 @@ static int fi_ibv_eq_close(fid_t fid)
 	return 0;
 }
 
-static struct fi_ops fi_ibv_eq_fi_ops = {
+static struct fi_ops vrb_eq_fi_ops = {
 	.size = sizeof(struct fi_ops),
-	.close = fi_ibv_eq_close,
+	.close = vrb_eq_close,
 	.bind = fi_no_bind,
-	.control = fi_ibv_eq_control,
+	.control = vrb_eq_control,
 	.ops_open = fi_no_ops_open,
 };
 
-int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		   struct fid_eq **eq, void *context)
 {
-	struct fi_ibv_eq *_eq;
+	struct vrb_eq *_eq;
 	struct epoll_event event;
 	int ret;
 
@@ -1254,7 +1254,7 @@ int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	if (!_eq)
 		return -ENOMEM;
 
-	_eq->fab = container_of(fabric, struct fi_ibv_fabric,
+	_eq->fab = container_of(fabric, struct vrb_fabric,
 				util_fabric.fabric_fid);
 
 	ofi_key_idx_init(&_eq->xrc.conn_key_idx, VERBS_CONN_TAG_INDEX_BITS);
@@ -1263,7 +1263,7 @@ int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		ret = -ENOMEM;
 		goto err0;
 	}
-	ofi_rbmap_init(&_eq->xrc.sidr_conn_rbmap, fi_ibv_sidr_conn_compare);
+	ofi_rbmap_init(&_eq->xrc.sidr_conn_rbmap, vrb_sidr_conn_compare);
 
 	fastlock_init(&_eq->lock);
 	ret = dlistfd_head_init(&_eq->list_head);
@@ -1315,8 +1315,8 @@ int fi_ibv_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	_eq->flags = attr->flags;
 	_eq->eq_fid.fid.fclass = FI_CLASS_EQ;
 	_eq->eq_fid.fid.context = context;
-	_eq->eq_fid.fid.ops = &fi_ibv_eq_fi_ops;
-	_eq->eq_fid.ops = &fi_ibv_eq_ops;
+	_eq->eq_fid.fid.ops = &vrb_eq_fi_ops;
+	_eq->eq_fid.ops = &vrb_eq_ops;
 
 	*eq = &_eq->eq_fid;
 	return 0;

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -36,27 +36,27 @@
 
 
 static inline ssize_t
-fi_ibv_msg_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
+vrb_msg_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_recv_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
 		.num_sge = msg->iov_count,
 		.next = NULL,
 	};
 
-	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
+	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 	return vrb_post_recv(ep, &wr);
 }
 
 static ssize_t
-fi_ibv_msg_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
+vrb_msg_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 		void *desc, fi_addr_t src_addr, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
-	struct ibv_sge sge = fi_ibv_init_sge(buf, len, desc);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	struct ibv_sge sge = vrb_init_sge(buf, len, desc);
 	struct ibv_recv_wr wr = {
 		.wr_id = (uintptr_t)context,
 		.num_sge = 1,
@@ -68,7 +68,7 @@ fi_ibv_msg_ep_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 }
 
 static ssize_t
-fi_ibv_msg_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+vrb_msg_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
                  size_t count, fi_addr_t src_addr, void *context)
 {
 	struct fi_msg msg = {
@@ -79,14 +79,14 @@ fi_ibv_msg_ep_recvv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		.context = context,
 	};
 
-	return fi_ibv_msg_ep_recvmsg(ep_fid, &msg, 0);
+	return vrb_msg_ep_recvmsg(ep_fid, &msg, 0);
 }
 
 static ssize_t
-fi_ibv_msg_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
+vrb_msg_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
 	};
@@ -98,30 +98,30 @@ fi_ibv_msg_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t 
 		wr.opcode = IBV_WR_SEND;
 	}
 
-	return fi_ibv_send_msg(ep, &wr, msg, flags);
+	return vrb_send_msg(ep, &wr, msg, flags);
 }
 
 static ssize_t
-fi_ibv_msg_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 		void *desc, fi_addr_t dest_addr, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
 		.send_flags = VERBS_INJECT(ep, len),
 	};
 
-	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
+	return vrb_send_buf(ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		       void *desc, uint64_t data, fi_addr_t dest_addr, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
@@ -129,42 +129,42 @@ fi_ibv_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.send_flags = VERBS_INJECT(ep, len),
 	};
 
-	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
+	return vrb_send_buf(ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+vrb_msg_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		    size_t count, fi_addr_t dest_addr, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)context,
 		.opcode = IBV_WR_SEND,
 	};
 
-	return fi_ibv_send_iov(ep, &wr, iov, desc, count);
+	return vrb_send_iov(ep, &wr, iov, desc, count);
 }
 
-static ssize_t fi_ibv_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
+static ssize_t vrb_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 		fi_addr_t dest_addr)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND,
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf_inline(ep, &wr, buf, len);
 }
 
-static ssize_t fi_ibv_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
+static ssize_t vrb_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		    uint64_t data, fi_addr_t dest_addr)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_SEND_WITH_IMM,
@@ -172,15 +172,15 @@ static ssize_t fi_ibv_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, 
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf_inline(ep, &wr, buf, len);
 }
 
 static ssize_t
-fi_ibv_msg_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 		       fi_addr_t dest_addr)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
@@ -188,12 +188,12 @@ fi_ibv_msg_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 	return vrb_post_send(ep, &ep->wrs->msg_wr);
 }
 
-static ssize_t fi_ibv_msg_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
+static ssize_t vrb_msg_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 					     uint64_t data, fi_addr_t dest_addr)
 {
 	ssize_t ret;
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	ep->wrs->msg_wr.imm_data = htonl((uint32_t)data);
 	ep->wrs->msg_wr.opcode = IBV_WR_SEND_WITH_IMM;
@@ -206,42 +206,42 @@ static ssize_t fi_ibv_msg_ep_injectdata_fast(struct fid_ep *ep_fid, const void *
 	return ret;
 }
 
-const struct fi_ops_msg fi_ibv_msg_ep_msg_ops_ts = {
+const struct fi_ops_msg vrb_msg_ep_msg_ops_ts = {
 	.size = sizeof(struct fi_ops_msg),
-	.recv = fi_ibv_msg_ep_recv,
-	.recvv = fi_ibv_msg_ep_recvv,
-	.recvmsg = fi_ibv_msg_ep_recvmsg,
-	.send = fi_ibv_msg_ep_send,
-	.sendv = fi_ibv_msg_ep_sendv,
-	.sendmsg = fi_ibv_msg_ep_sendmsg,
-	.inject = fi_ibv_msg_ep_inject,
-	.senddata = fi_ibv_msg_ep_senddata,
-	.injectdata = fi_ibv_msg_ep_injectdata,
+	.recv = vrb_msg_ep_recv,
+	.recvv = vrb_msg_ep_recvv,
+	.recvmsg = vrb_msg_ep_recvmsg,
+	.send = vrb_msg_ep_send,
+	.sendv = vrb_msg_ep_sendv,
+	.sendmsg = vrb_msg_ep_sendmsg,
+	.inject = vrb_msg_ep_inject,
+	.senddata = vrb_msg_ep_senddata,
+	.injectdata = vrb_msg_ep_injectdata,
 };
 
-const struct fi_ops_msg fi_ibv_msg_ep_msg_ops = {
+const struct fi_ops_msg vrb_msg_ep_msg_ops = {
 	.size = sizeof(struct fi_ops_msg),
-	.recv = fi_ibv_msg_ep_recv,
-	.recvv = fi_ibv_msg_ep_recvv,
-	.recvmsg = fi_ibv_msg_ep_recvmsg,
-	.send = fi_ibv_msg_ep_send,
-	.sendv = fi_ibv_msg_ep_sendv,
-	.sendmsg = fi_ibv_msg_ep_sendmsg,
-	.inject = fi_ibv_msg_inject_fast,
-	.senddata = fi_ibv_msg_ep_senddata,
-	.injectdata = fi_ibv_msg_ep_injectdata_fast,
+	.recv = vrb_msg_ep_recv,
+	.recvv = vrb_msg_ep_recvv,
+	.recvmsg = vrb_msg_ep_recvmsg,
+	.send = vrb_msg_ep_send,
+	.sendv = vrb_msg_ep_sendv,
+	.sendmsg = vrb_msg_ep_sendmsg,
+	.inject = vrb_msg_inject_fast,
+	.senddata = vrb_msg_ep_senddata,
+	.injectdata = vrb_msg_ep_injectdata_fast,
 };
 
 static ssize_t
-fi_ibv_msg_xrc_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
+vrb_msg_xrc_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
 	if (flags & FI_REMOTE_CQ_DATA) {
 		wr.opcode = IBV_WR_SEND_WITH_IMM;
@@ -250,14 +250,14 @@ fi_ibv_msg_xrc_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint6
 		wr.opcode = IBV_WR_SEND;
 	}
 
-	return fi_ibv_send_msg(&ep->base_ep, &wr, msg, flags);
+	return vrb_send_msg(&ep->base_ep, &wr, msg, flags);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_xrc_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 		void *desc, fi_addr_t dest_addr, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
@@ -265,16 +265,16 @@ fi_ibv_msg_xrc_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.send_flags = VERBS_INJECT(&ep->base_ep, len),
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_xrc_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		       void *desc, uint64_t data, fi_addr_t dest_addr, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
@@ -283,31 +283,31 @@ fi_ibv_msg_xrc_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.send_flags = VERBS_INJECT(&ep->base_ep, len),
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+vrb_msg_xrc_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		    size_t count, fi_addr_t dest_addr, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)context,
 		.opcode = IBV_WR_SEND,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_iov(&ep->base_ep, &wr, iov, desc, count);
+	return vrb_send_iov(&ep->base_ep, &wr, iov, desc, count);
 }
 
-static ssize_t fi_ibv_msg_xrc_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
+static ssize_t vrb_msg_xrc_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 		fi_addr_t dest_addr)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
@@ -315,15 +315,15 @@ static ssize_t fi_ibv_msg_xrc_ep_inject(struct fid_ep *ep_fid, const void *buf, 
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_buf_inline(&ep->base_ep, &wr, buf, len);
+	return vrb_send_buf_inline(&ep->base_ep, &wr, buf, len);
 }
 
-static ssize_t fi_ibv_msg_xrc_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
+static ssize_t vrb_msg_xrc_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		    uint64_t data, fi_addr_t dest_addr)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
@@ -332,13 +332,13 @@ static ssize_t fi_ibv_msg_xrc_ep_injectdata(struct fid_ep *ep_fid, const void *b
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_buf_inline(&ep->base_ep, &wr, buf, len);
+	return vrb_send_buf_inline(&ep->base_ep, &wr, buf, len);
 }
 
 /* NOTE: Initially the XRC endpoint must be used with a SRQ. */
-const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops_ts = {
+const struct fi_ops_msg vrb_msg_xrc_ep_msg_ops_ts = {
 	.size = sizeof(struct fi_ops_msg),
 	.recv = fi_no_msg_recv,
 	.recvv = fi_no_msg_recvv,
@@ -351,7 +351,7 @@ const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops_ts = {
 	.injectdata = fi_no_msg_injectdata,
 };
 
-const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops = {
+const struct fi_ops_msg vrb_msg_xrc_ep_msg_ops = {
 	.size = sizeof(struct fi_ops_msg),
 	.recv = fi_no_msg_recv,
 	.recvv = fi_no_msg_recvv,
@@ -364,15 +364,15 @@ const struct fi_ops_msg fi_ibv_msg_xrc_ep_msg_ops = {
 	.injectdata = fi_no_msg_injectdata,
 };
 
-const struct fi_ops_msg fi_ibv_msg_srq_xrc_ep_msg_ops = {
+const struct fi_ops_msg vrb_msg_srq_xrc_ep_msg_ops = {
 	.size = sizeof(struct fi_ops_msg),
 	.recv = fi_no_msg_recv,
 	.recvv = fi_no_msg_recvv,
 	.recvmsg = fi_no_msg_recvmsg,
-	.send = fi_ibv_msg_xrc_ep_send,
-	.sendv = fi_ibv_msg_xrc_ep_sendv,
-	.sendmsg = fi_ibv_msg_xrc_ep_sendmsg,
-	.inject = fi_ibv_msg_xrc_ep_inject,
-	.senddata = fi_ibv_msg_xrc_ep_senddata,
-	.injectdata = fi_ibv_msg_xrc_ep_injectdata,
+	.send = vrb_msg_xrc_ep_send,
+	.sendv = vrb_msg_xrc_ep_sendv,
+	.sendmsg = vrb_msg_xrc_ep_sendmsg,
+	.inject = vrb_msg_xrc_ep_inject,
+	.senddata = vrb_msg_xrc_ep_senddata,
+	.injectdata = vrb_msg_xrc_ep_injectdata,
 };

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -44,12 +44,12 @@
 	VERBS_COMP_READ_FLAGS(ep, 0, context)
 
 static ssize_t
-fi_ibv_msg_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 		     void *desc, fi_addr_t dest_addr,
 		     uint64_t addr, uint64_t key, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_RDMA_WRITE,
@@ -58,16 +58,16 @@ fi_ibv_msg_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.send_flags = VERBS_INJECT(ep, len),
 	};
 
-	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
+	return vrb_send_buf(ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+vrb_msg_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		      size_t count, fi_addr_t dest_addr,
 		      uint64_t addr, uint64_t key, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)context,
 		.opcode = IBV_WR_RDMA_WRITE,
@@ -75,15 +75,15 @@ fi_ibv_msg_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **
 		.wr.rdma.rkey = (uint32_t)key,
 	};
 
-	return fi_ibv_send_iov(ep, &wr, iov, desc, count);
+	return vrb_send_iov(ep, &wr, iov, desc, count);
 }
 
 static ssize_t
-fi_ibv_msg_ep_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
+vrb_msg_ep_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 			uint64_t flags)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
 		.wr.rdma.remote_addr = msg->rma_iov->addr,
@@ -97,16 +97,16 @@ fi_ibv_msg_ep_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		wr.opcode = IBV_WR_RDMA_WRITE;
 	}
 
-	return fi_ibv_send_msg(ep, &wr, msg, flags);
+	return vrb_send_msg(ep, &wr, msg, flags);
 }
 
 static ssize_t
-fi_ibv_msg_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
+vrb_msg_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
 		    void *desc, fi_addr_t src_addr,
 		    uint64_t addr, uint64_t key, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_READ(ep, (uintptr_t)context),
 		.opcode = IBV_WR_RDMA_READ,
@@ -114,16 +114,16 @@ fi_ibv_msg_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
 		.wr.rdma.rkey = (uint32_t)key,
 	};
 
-	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
+	return vrb_send_buf(ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+vrb_msg_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		     size_t count, fi_addr_t src_addr,
 		     uint64_t addr, uint64_t key, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_READ(ep, (uintptr_t)context),
 		.opcode = IBV_WR_RDMA_READ,
@@ -132,17 +132,17 @@ fi_ibv_msg_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **d
 		.num_sge = count,
 	};
 
-	fi_ibv_set_sge_iov(wr.sg_list, iov, count, desc);
+	vrb_set_sge_iov(wr.sg_list, iov, count, desc);
 
 	return vrb_post_send(ep, &wr);
 }
 
 static ssize_t
-fi_ibv_msg_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
+vrb_msg_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 			uint64_t flags)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_READ_FLAGS(ep, flags, (uintptr_t)msg->context),
 		.opcode = IBV_WR_RDMA_READ,
@@ -151,18 +151,18 @@ fi_ibv_msg_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		.num_sge = msg->iov_count,
 	};
 
-	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
+	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
 	return vrb_post_send(ep, &wr);
 }
 
 static ssize_t
-fi_ibv_msg_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 			void *desc, uint64_t data, fi_addr_t dest_addr,
 			uint64_t addr, uint64_t key, void *context)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_RDMA_WRITE_WITH_IMM,
@@ -172,15 +172,15 @@ fi_ibv_msg_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.send_flags = VERBS_INJECT(ep, len),
 	};
 
-	return fi_ibv_send_buf(ep, &wr, buf, len, desc);
+	return vrb_send_buf(ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 		     fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_RDMA_WRITE,
@@ -189,16 +189,16 @@ fi_ibv_msg_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf, size_t le
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf_inline(ep, &wr, buf, len);
 }
 
 static ssize_t
-fi_ibv_rma_write_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_rma_write_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 		      fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
-	struct fi_ibv_ep *ep;
+	struct vrb_ep *ep;
 
-	ep = container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	ep->wrs->rma_wr.wr.rdma.remote_addr = addr;
 	ep->wrs->rma_wr.wr.rdma.rkey = (uint32_t) key;
@@ -210,12 +210,12 @@ fi_ibv_rma_write_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 }
 
 static ssize_t
-fi_ibv_msg_ep_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_ep_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 			uint64_t data, fi_addr_t dest_addr, uint64_t addr,
 			uint64_t key)
 {
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
 		.opcode = IBV_WR_RDMA_WRITE_WITH_IMM,
@@ -225,17 +225,17 @@ fi_ibv_msg_ep_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	return fi_ibv_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf_inline(ep, &wr, buf, len);
 }
 
 static ssize_t
-fi_ibv_msg_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
+vrb_msg_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 					uint64_t data, fi_addr_t dest_addr, uint64_t addr,
 					uint64_t key)
 {
 	ssize_t ret;
-	struct fi_ibv_ep *ep =
-		container_of(ep_fid, struct fi_ibv_ep, util_ep.ep_fid);
+	struct vrb_ep *ep =
+		container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 	ep->wrs->rma_wr.wr.rdma.remote_addr = addr;
 	ep->wrs->rma_wr.wr.rdma.rkey = (uint32_t) key;
 
@@ -250,38 +250,38 @@ fi_ibv_msg_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid, const void *buf, 
 	return ret;
 }
 
-struct fi_ops_rma fi_ibv_msg_ep_rma_ops_ts = {
+struct fi_ops_rma vrb_msg_ep_rma_ops_ts = {
 	.size = sizeof(struct fi_ops_rma),
-	.read = fi_ibv_msg_ep_rma_read,
-	.readv = fi_ibv_msg_ep_rma_readv,
-	.readmsg = fi_ibv_msg_ep_rma_readmsg,
-	.write = fi_ibv_msg_ep_rma_write,
-	.writev = fi_ibv_msg_ep_rma_writev,
-	.writemsg = fi_ibv_msg_ep_rma_writemsg,
-	.inject = fi_ibv_msg_ep_rma_inject_write,
-	.writedata = fi_ibv_msg_ep_rma_writedata,
-	.injectdata = fi_ibv_msg_ep_rma_inject_writedata,
+	.read = vrb_msg_ep_rma_read,
+	.readv = vrb_msg_ep_rma_readv,
+	.readmsg = vrb_msg_ep_rma_readmsg,
+	.write = vrb_msg_ep_rma_write,
+	.writev = vrb_msg_ep_rma_writev,
+	.writemsg = vrb_msg_ep_rma_writemsg,
+	.inject = vrb_msg_ep_rma_inject_write,
+	.writedata = vrb_msg_ep_rma_writedata,
+	.injectdata = vrb_msg_ep_rma_inject_writedata,
 };
 
-struct fi_ops_rma fi_ibv_msg_ep_rma_ops = {
+struct fi_ops_rma vrb_msg_ep_rma_ops = {
 	.size = sizeof(struct fi_ops_rma),
-	.read = fi_ibv_msg_ep_rma_read,
-	.readv = fi_ibv_msg_ep_rma_readv,
-	.readmsg = fi_ibv_msg_ep_rma_readmsg,
-	.write = fi_ibv_msg_ep_rma_write,
-	.writev = fi_ibv_msg_ep_rma_writev,
-	.writemsg = fi_ibv_msg_ep_rma_writemsg,
-	.inject = fi_ibv_rma_write_fast,
-	.writedata = fi_ibv_msg_ep_rma_writedata,
-	.injectdata = fi_ibv_msg_ep_rma_inject_writedata_fast,
+	.read = vrb_msg_ep_rma_read,
+	.readv = vrb_msg_ep_rma_readv,
+	.readmsg = vrb_msg_ep_rma_readmsg,
+	.write = vrb_msg_ep_rma_write,
+	.writev = vrb_msg_ep_rma_writev,
+	.writemsg = vrb_msg_ep_rma_writemsg,
+	.inject = vrb_rma_write_fast,
+	.writedata = vrb_msg_ep_rma_writedata,
+	.injectdata = vrb_msg_ep_rma_inject_writedata_fast,
 };
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_write(struct fid_ep *ep_fid, const void *buf,
+vrb_msg_xrc_ep_rma_write(struct fid_ep *ep_fid, const void *buf,
 		size_t len, void *desc, fi_addr_t dest_addr,
 		uint64_t addr, uint64_t key, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
@@ -291,17 +291,17 @@ fi_ibv_msg_xrc_ep_rma_write(struct fid_ep *ep_fid, const void *buf,
 		.send_flags = VERBS_INJECT(&ep->base_ep, len),
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov,
+vrb_msg_xrc_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov,
 		void **desc, size_t count, fi_addr_t dest_addr,
 		uint64_t addr, uint64_t key, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)context,
@@ -310,16 +310,16 @@ fi_ibv_msg_xrc_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov,
 		.wr.rdma.rkey = (uint32_t)key,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_iov(&ep->base_ep, &wr, iov, desc, count);
+	return vrb_send_iov(&ep->base_ep, &wr, iov, desc, count);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_writemsg(struct fid_ep *ep_fid,
+vrb_msg_xrc_ep_rma_writemsg(struct fid_ep *ep_fid,
 			const struct fi_msg_rma *msg, uint64_t flags)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = (uintptr_t)msg->context,
@@ -327,7 +327,7 @@ fi_ibv_msg_xrc_ep_rma_writemsg(struct fid_ep *ep_fid,
 		.wr.rdma.rkey = (uint32_t)msg->rma_iov->key,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
 	if (flags & FI_REMOTE_CQ_DATA) {
 		wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
@@ -336,15 +336,15 @@ fi_ibv_msg_xrc_ep_rma_writemsg(struct fid_ep *ep_fid,
 		wr.opcode = IBV_WR_RDMA_WRITE;
 	}
 
-	return fi_ibv_send_msg(&ep->base_ep, &wr, msg, flags);
+	return vrb_send_msg(&ep->base_ep, &wr, msg, flags);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
+vrb_msg_xrc_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
 		void *desc, fi_addr_t src_addr, uint64_t addr,
 		uint64_t key, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_READ(&ep->base_ep, (uintptr_t)context),
@@ -353,17 +353,17 @@ fi_ibv_msg_xrc_ep_rma_read(struct fid_ep *ep_fid, void *buf, size_t len,
 		.wr.rdma.rkey = (uint32_t)key,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov,
+vrb_msg_xrc_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov,
 		void **desc, size_t count, fi_addr_t src_addr,
 		uint64_t addr, uint64_t key, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_READ(&ep->base_ep, (uintptr_t)context),
@@ -373,18 +373,18 @@ fi_ibv_msg_xrc_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov,
 		.num_sge = count,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	fi_ibv_set_sge_iov(wr.sg_list, iov, count, desc);
+	vrb_set_sge_iov(wr.sg_list, iov, count, desc);
 
 	return vrb_post_send(&ep->base_ep, &wr);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_readmsg(struct fid_ep *ep_fid,
+vrb_msg_xrc_ep_rma_readmsg(struct fid_ep *ep_fid,
 		const struct fi_msg_rma *msg, uint64_t flags)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP_READ_FLAGS(&ep->base_ep, flags,
@@ -395,19 +395,19 @@ fi_ibv_msg_xrc_ep_rma_readmsg(struct fid_ep *ep_fid,
 		.num_sge = msg->iov_count,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	fi_ibv_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
+	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
 	return vrb_post_send(&ep->base_ep, &wr);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf,
+vrb_msg_xrc_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf,
 		size_t len, void *desc, uint64_t data, fi_addr_t dest_addr,
 		uint64_t addr, uint64_t key, void *context)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
@@ -418,17 +418,17 @@ fi_ibv_msg_xrc_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf,
 		.send_flags = VERBS_INJECT(&ep->base_ep, len),
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_buf(&ep->base_ep, &wr, buf, len, desc);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, len, desc);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf,
+vrb_msg_xrc_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf,
 		size_t len, fi_addr_t dest_addr, uint64_t addr,
 		uint64_t key)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_NO_COMP_FLAG,
@@ -438,21 +438,21 @@ fi_ibv_msg_xrc_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf,
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_buf_inline(&ep->base_ep, &wr, buf, len);
+	return vrb_send_buf_inline(&ep->base_ep, &wr, buf, len);
 }
 
 static ssize_t
-fi_ibv_xrc_rma_write_fast(struct fid_ep *ep_fid, const void *buf,
+vrb_xrc_rma_write_fast(struct fid_ep *ep_fid, const void *buf,
 	  size_t len, fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 
 	ep->base_ep.wrs->rma_wr.wr.rdma.remote_addr = addr;
 	ep->base_ep.wrs->rma_wr.wr.rdma.rkey = (uint32_t) key;
-	FI_IBV_SET_REMOTE_SRQN(ep->base_ep.wrs->rma_wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(ep->base_ep.wrs->rma_wr, ep->peer_srqn);
 	ep->base_ep.wrs->sge.addr = (uintptr_t) buf;
 	ep->base_ep.wrs->sge.length = (uint32_t) len;
 
@@ -460,11 +460,11 @@ fi_ibv_xrc_rma_write_fast(struct fid_ep *ep_fid, const void *buf,
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_inject_writedata(struct fid_ep *ep_fid,
+vrb_msg_xrc_ep_rma_inject_writedata(struct fid_ep *ep_fid,
 		const void *buf, size_t len, uint64_t data,
 		fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 
 	struct ibv_send_wr wr = {
@@ -476,22 +476,22 @@ fi_ibv_msg_xrc_ep_rma_inject_writedata(struct fid_ep *ep_fid,
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	FI_IBV_SET_REMOTE_SRQN(wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return fi_ibv_send_buf_inline(&ep->base_ep, &wr, buf, len);
+	return vrb_send_buf_inline(&ep->base_ep, &wr, buf, len);
 }
 
 static ssize_t
-fi_ibv_msg_xrc_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid,
+vrb_msg_xrc_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid,
 		const void *buf, size_t len, uint64_t data,
 		fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
 	ssize_t ret;
-	struct fi_ibv_xrc_ep *ep = container_of(ep_fid, struct fi_ibv_xrc_ep,
+	struct vrb_xrc_ep *ep = container_of(ep_fid, struct vrb_xrc_ep,
 						base_ep.util_ep.ep_fid);
 	ep->base_ep.wrs->rma_wr.wr.rdma.remote_addr = addr;
 	ep->base_ep.wrs->rma_wr.wr.rdma.rkey = (uint32_t) key;
-	FI_IBV_SET_REMOTE_SRQN(ep->base_ep.wrs->rma_wr, ep->peer_srqn);
+	VRB_SET_REMOTE_SRQN(ep->base_ep.wrs->rma_wr, ep->peer_srqn);
 
 	ep->base_ep.wrs->rma_wr.imm_data = htonl((uint32_t) data);
 	ep->base_ep.wrs->rma_wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
@@ -504,28 +504,28 @@ fi_ibv_msg_xrc_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid,
 	return ret;
 }
 
-struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops_ts = {
+struct fi_ops_rma vrb_msg_xrc_ep_rma_ops_ts = {
 	.size = sizeof(struct fi_ops_rma),
-	.read = fi_ibv_msg_xrc_ep_rma_read,
-	.readv = fi_ibv_msg_xrc_ep_rma_readv,
-	.readmsg = fi_ibv_msg_xrc_ep_rma_readmsg,
-	.write = fi_ibv_msg_xrc_ep_rma_write,
-	.writev = fi_ibv_msg_xrc_ep_rma_writev,
-	.writemsg = fi_ibv_msg_xrc_ep_rma_writemsg,
-	.inject = fi_ibv_msg_xrc_ep_rma_inject_write,
-	.writedata = fi_ibv_msg_xrc_ep_rma_writedata,
-	.injectdata = fi_ibv_msg_xrc_ep_rma_inject_writedata,
+	.read = vrb_msg_xrc_ep_rma_read,
+	.readv = vrb_msg_xrc_ep_rma_readv,
+	.readmsg = vrb_msg_xrc_ep_rma_readmsg,
+	.write = vrb_msg_xrc_ep_rma_write,
+	.writev = vrb_msg_xrc_ep_rma_writev,
+	.writemsg = vrb_msg_xrc_ep_rma_writemsg,
+	.inject = vrb_msg_xrc_ep_rma_inject_write,
+	.writedata = vrb_msg_xrc_ep_rma_writedata,
+	.injectdata = vrb_msg_xrc_ep_rma_inject_writedata,
 };
 
-struct fi_ops_rma fi_ibv_msg_xrc_ep_rma_ops = {
+struct fi_ops_rma vrb_msg_xrc_ep_rma_ops = {
 	.size = sizeof(struct fi_ops_rma),
-	.read = fi_ibv_msg_xrc_ep_rma_read,
-	.readv = fi_ibv_msg_xrc_ep_rma_readv,
-	.readmsg = fi_ibv_msg_xrc_ep_rma_readmsg,
-	.write = fi_ibv_msg_xrc_ep_rma_write,
-	.writev = fi_ibv_msg_xrc_ep_rma_writev,
-	.writemsg = fi_ibv_msg_xrc_ep_rma_writemsg,
-	.inject = fi_ibv_xrc_rma_write_fast,
-	.writedata = fi_ibv_msg_xrc_ep_rma_writedata,
-	.injectdata = fi_ibv_msg_xrc_ep_rma_inject_writedata_fast,
+	.read = vrb_msg_xrc_ep_rma_read,
+	.readv = vrb_msg_xrc_ep_rma_readv,
+	.readmsg = vrb_msg_xrc_ep_rma_readmsg,
+	.write = vrb_msg_xrc_ep_rma_write,
+	.writev = vrb_msg_xrc_ep_rma_writev,
+	.writemsg = vrb_msg_xrc_ep_rma_writemsg,
+	.inject = vrb_xrc_rma_write_fast,
+	.writedata = vrb_msg_xrc_ep_rma_writedata,
+	.injectdata = vrb_msg_xrc_ep_rma_inject_writedata_fast,
 };


### PR DESCRIPTION
The fi_ prefix is intended for external facing APIs and
data structures only.  Use a shorter prefix to improve
code readability.

This is a simple find-replace change that updates the
verbs provider in one shot.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>