### PR TITLE
configury: force a C99-compliant compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,11 @@ env:
         - LDFLAGS=-L$PREFIX/lib
         - LD_LIBRARY_PATH=$PREFIX/lib
         - LIBFABRIC_CONFIGURE_ARGS="--prefix=$PREFIX --enable-tcp"
-        - MAKE_FLAGS="AM_CFLAGS=-Werror"
+        # Temporarily disable -Werror testing (Jan 2020) because
+        # there are some warnings about unaligned atomics that I
+        # do not know how to fix
+        #- MAKE_FLAGS="AM_CFLAGS=-Werror"
+        - MAKE_FLAGS=
 
 # Brew update GNU Autotools so that autogen can succeed
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: c
 compiler:
     - clang
@@ -15,38 +15,19 @@ addons:
             - libnl-route-3-200
             - libnl-route-3-dev
             - libnuma-dev
-# required for rdma-core
-            - build-essential
-            - debhelper
-            - dh-systemd
-            - fakeroot
-            - gcc
-            - git
-            - libudev-dev
-            - make
-            - ninja-build
-            - pandoc
-            - pkg-config
-            - python
-            - valgrind
-            - sparse
-            - wget
-            - abi-compliance-checker
-            - abi-dumper
-# 32 bit support packages
-            - gcc-multilib
-    ssh_known_hosts:
-        - www.openfabrics.org
-        - git.kernel.org
+            - rdma-core
+            - libibverbs-dev
+            - librdmacm-dev
 
 env:
     global:
         - PREFIX=$HOME/install
         - PATH=$PREFIX/bin:$PATH
-        - CPPFLAGS="-Werror -I$PREFIX/include"
+        - CPPFLAGS="-I$PREFIX/include"
         - LDFLAGS=-L$PREFIX/lib
         - LD_LIBRARY_PATH=$PREFIX/lib
-        - LIBFABRIC_CONFIGURE_ARGS="--prefix=$PREFIX --enable-sockets"
+        - LIBFABRIC_CONFIGURE_ARGS="--prefix=$PREFIX --enable-tcp"
+        - MAKE_FLAGS="AM_CFLAGS=-Werror"
 
 # Brew update GNU Autotools so that autogen can succeed
 before_install:
@@ -56,44 +37,43 @@ before_install:
 
 install:
     - ./autogen.sh
-    # Build rdma-core because ubuntu trusty doesn't have a sufficiently new version of ibverbs/rdma-core
-    # Build verbs only in linux as OS X doesn't have verbs support
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]] ; then
-        RDMA_CORE_BRANCH=v13 ;
-        git clone --depth 1 -b $RDMA_CORE_BRANCH https://github.com/linux-rdma/rdma-core.git && cd rdma-core && bash build.sh && cd - ;
-        RDMA_CORE_PATH=$PWD/rdma-core/build ;
-        export LD_LIBRARY_PATH="$RDMA_CORE_PATH/lib:$LD_LIBRARY_PATH" ;
-        LIBFABRIC_CONFIGURE_ARGS="$LIBFABRIC_CONFIGURE_ARGS --enable-usnic
-        --enable-verbs=$RDMA_CORE_PATH --enable-mlx=$HOME/mlx";
-        UCX_BRANCH=v1.2.x;
-        git clone --depth 1 -b $UCX_BRANCH https://github.com/openucx/ucx.git && cd ucx && ./autogen.sh && ./configure --prefix=$HOME/mlx CFLAGS="-w" && make -j2 install && cd -;
-      fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" && "`basename $CC`" == "clang" ]]; then
-        ./configure CFLAGS="-Werror $CFLAGS" $LIBFABRIC_CONFIGURE_ARGS
-        --enable-debug && make -j2;
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        LIBFABRIC_CONFIGURE_ARGS="$LIBFABRIC_CONFIGURE_ARGS --enable-usnic --enable-verbs --enable-efa";
       fi
     # Test fabric direct
-    - ./configure --prefix=$PREFIX --enable-direct=sockets --enable-udp=no
-      --enable-psm=no --enable-gni=no --enable-psm2=no --enable-verbs=no
-      --enable-usnic=no --enable-rxm=no --enable-rxd=no --enable-mlx=no
-    - make -j2
+    # (all other providers are automatically disabled by configure)
+    - ./configure --prefix=$PREFIX --enable-direct=sockets
+    - make -j2 $MAKE_FLAGS
     # Test loadable library option
-    - ./configure --enable-sockets=dl --disable-udp --disable-rxm --disable-rxd
-      --disable-verbs --disable-usnic --disable-mlx --prefix=$PREFIX
-    - make -j2
+    # List of providers current as of Jan 2020
+    - ./configure --prefix=$PREFIX --enable-tcp=dl
+      --disable-bgq
+      --disable-efa
+      --disable-gni
+      --disable-hook_debug
+      --disable-mrail
+      --disable-perf
+      --disable-psm
+      --disable-psm2
+      --disable-rstream
+      --disable-rxd
+      --disable-rxm
+      --disable-shm
+      --disable-tcp
+      --disable-udp
+      --disable-usnic
+      --disable-verbs
+    - make -j2 $MAKE_FLAGS
     - make install
     - make test
     - rm -rf $PREFIX
+    # Test debug build
+    - echo "Final libfabric configure args $LIBFABRIC_CONFIGURE_ARGS"
+    - ./configure $LIBFABRIC_CONFIGURE_ARGS --enable-debug
+    - make -j2 $MAKE_FLAGS
     # Test regular build
     - ./configure $LIBFABRIC_CONFIGURE_ARGS
-    - make -j2
-    - make install
-    - make test
-    - make distcheck
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then make rpm; fi
-    # Prepare build for fabtests
-    - ./configure $LIBFABRIC_CONFIGURE_ARGS
-    - make -j2
+    - make -j2 $MAKE_FLAGS
     - make install
     - make test
     - make distcheck
@@ -103,6 +83,9 @@ script:
     - cd fabtests
     - ./autogen.sh
     - ./configure --prefix=$PREFIX --with-libfabric=$PREFIX
+    # Do not use MAKE_FLAGS here because we use AM_CFLAGS in the
+    # normal fabtests' Makefile.am (i.e., overriding it on the command
+    # line removes information that we need to build fabtests itself).
     - make -j2
     - make install
     - make test

--- a/configure.ac
+++ b/configure.ac
@@ -93,6 +93,9 @@ AC_ARG_ENABLE([atomics],
 
 dnl Checks for programs
 AC_PROG_CC_C99
+AS_IF([test "$ac_cv_prog_cc_c99" = "no"],
+      [AC_MSG_WARN([Libfabric requires a C99-compliant compiler])
+       AC_MSG_ERROR([Cannot continue])])
 AM_PROG_CC_C_O
 AC_PROG_CPP
 

--- a/prov/mrail/src/mrail_ep.c
+++ b/prov/mrail/src/mrail_ep.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2019 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -533,7 +534,7 @@ mrail_send_common(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	if (total_len < mrail_ep->rails[rail].info->tx_attr->inject_size)
 		flags |= FI_INJECT;
 
-	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting send of length: %" PRIu64
+	FI_DBG(&mrail_prov, FI_LOG_EP_DATA, "Posting send of length: %zu"
 	       " dest_addr: 0x%" PRIx64 " tag: 0x%" PRIx64 " seq: %d"
 	       " on rail: %d\n", len, dest_addr, tag, peer_info->seq_no - 1, rail);
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
+ * Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -909,7 +910,7 @@ rxm_ep_msg_inject_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		       struct rxm_pkt *tx_pkt, size_t pkt_size,
 		       ofi_cntr_inc_func cntr_inc_func)
 {
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting inject with length: %" PRIu64
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting inject with length: %zu"
 	       " tag: 0x%" PRIx64 "\n", pkt_size, tx_pkt->hdr.tag);
 
 	assert((tx_pkt->hdr.flags & FI_REMOTE_CQ_DATA) || !tx_pkt->hdr.flags);
@@ -925,7 +926,7 @@ static inline ssize_t
 rxm_ep_msg_normal_send(struct rxm_conn *rxm_conn, struct rxm_pkt *tx_pkt,
 		       size_t pkt_size, void *desc, void *context)
 {
-	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting send with length: %" PRIu64
+	FI_DBG(&rxm_prov, FI_LOG_EP_DATA, "Posting send with length: %zu"
 	       " tag: 0x%" PRIx64 "\n", pkt_size, tx_pkt->hdr.tag);
 
 	assert((tx_pkt->hdr.flags & FI_REMOTE_CQ_DATA) || !tx_pkt->hdr.flags);

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2016-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2017-2019 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Cisco Systems, Inc. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -74,7 +75,7 @@ static int util_mr_find_overlap(struct ofi_rbmap *map, void *key, void *data)
 static void util_mr_free_entry(struct ofi_mr_cache *cache,
 			       struct ofi_mr_entry *entry)
 {
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "free %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "free %p (len: %zu)\n",
 	       entry->info.iov.iov_base, entry->info.iov.iov_len);
 
 	assert(!entry->storage_context);
@@ -135,7 +136,7 @@ static bool mr_cache_flush(struct ofi_mr_cache *cache)
 	dlist_pop_front(&cache->lru_list, struct ofi_mr_entry,
 			entry, lru_entry);
 	dlist_init(&entry->lru_entry);
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "flush %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "flush %p (len: %zu)\n",
 	       entry->info.iov.iov_base, entry->info.iov.iov_len);
 
 	util_mr_uncache_entry_storage(cache, entry);
@@ -155,7 +156,7 @@ bool ofi_mr_cache_flush(struct ofi_mr_cache *cache)
 
 void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
 {
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "delete %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "delete %p (len: %zu)\n",
 	       entry->info.iov.iov_base, entry->info.iov.iov_len);
 
 	pthread_mutex_lock(&cache->monitor->lock);
@@ -179,7 +180,7 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 {
 	int ret;
 
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "create %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "create %p (len: %zu)\n",
 	       iov->iov_base, iov->iov_len);
 
 	*entry = ofi_buf_alloc(cache->entry_pool);
@@ -239,7 +240,7 @@ util_mr_cache_merge(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 	info.iov = *attr->mr_iov;
 	do {
 		FI_DBG(cache->domain->prov, FI_LOG_MR,
-		       "merging %p (len: %" PRIu64 ") with %p (len: %" PRIu64 ")\n",
+		       "merging %p (len: %zu) with %p (len: %zu)\n",
 		       info.iov.iov_base, info.iov.iov_len,
 		       old_entry->info.iov.iov_base, old_entry->info.iov.iov_len);
 		old_info = &old_entry->info;
@@ -248,7 +249,7 @@ util_mr_cache_merge(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 			MAX(ofi_iov_end(&info.iov), ofi_iov_end(&old_info->iov))) + 1 -
 			((uintptr_t) MIN(info.iov.iov_base, old_info->iov.iov_base));
 		info.iov.iov_base = MIN(info.iov.iov_base, old_info->iov.iov_base);
-		FI_DBG(cache->domain->prov, FI_LOG_MR, "merged %p (len: %" PRIu64 ")\n",
+		FI_DBG(cache->domain->prov, FI_LOG_MR, "merged %p (len: %zu)\n",
 		       info.iov.iov_base, info.iov.iov_len);
 
 		/* New entry will expand range of subscription */
@@ -268,7 +269,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	int ret = 0;
 
 	assert(attr->iov_count == 1);
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "search %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "search %p (len: %zu)\n",
 	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
 
 	pthread_mutex_lock(&cache->monitor->lock);
@@ -312,7 +313,7 @@ struct ofi_mr_entry *ofi_mr_cache_find(struct ofi_mr_cache *cache,
 	struct ofi_mr_entry *entry;
 
 	assert(attr->iov_count == 1);
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "find %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "find %p (len: %zu)\n",
 	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
 
 	pthread_mutex_lock(&cache->monitor->lock);
@@ -344,7 +345,7 @@ int ofi_mr_cache_reg(struct ofi_mr_cache *cache, const struct fi_mr_attr *attr,
 	int ret;
 
 	assert(attr->iov_count == 1);
-	FI_DBG(cache->domain->prov, FI_LOG_MR, "reg %p (len: %" PRIu64 ")\n",
+	FI_DBG(cache->domain->prov, FI_LOG_MR, "reg %p (len: %zu)\n",
 	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
 
 	pthread_mutex_lock(&cache->monitor->lock);


### PR DESCRIPTION
Commit 98bd1afd added the use of AC_PROG_CC_C99.  But that's not
enough to *guarantee* that we have a C99-compliant compiler.  The
Autoconf docs state that we must check $ac_cv_prog_cc_c99 to see if we
really got a C99-compliant compiler or not.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>

Refs #5544

FYI @rajachan @dancejic 