### PR TITLE
fabtests/cq_test: limit max CQs to test

### DIFF
--- a/fabtests/unit/cq_test.c
+++ b/fabtests/unit/cq_test.c
@@ -41,6 +41,7 @@
 #include "unit_common.h"
 #include "shared.h"
 
+static int test_max = 1 << 15;
 static char err_buf[512];
 
 static int
@@ -70,7 +71,7 @@ static int cq_open_close_simultaneous(void)
 	int testret = FAIL;
 	struct fid_cq **cq_array;
 
-	count = fi->domain_attr->cq_cnt;
+	count = MIN(fi->domain_attr->cq_cnt, test_max);
 	FT_DEBUG("testing creation of up to %zu simultaneous CQs\n", count);
 
 	cq_array = calloc(count, sizeof(*cq_array));
@@ -217,6 +218,7 @@ struct test_entry test_array[] = {
 static void usage(void)
 {
 	ft_unit_usage("cq_test", "Unit test for Completion Queue (CQ)");
+	FT_PRINT_OPTS_USAGE("-L <int>", "Limit of CQs to open. Default: 32k");
 }
 
 int main(int argc, char **argv)
@@ -228,8 +230,11 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, FAB_OPTS "h")) != -1) {
+	while ((op = getopt(argc, argv, FAB_OPTS "hL:")) != -1) {
 		switch (op) {
+		case 'L':
+			test_max = atoi(optarg);
+			break;
 		default:
 			ft_parseinfo(op, optarg, hints, &opts);
 			break;


### PR DESCRIPTION
A Mellanox bug is causing this test to take too long and
resulting in memory issues/leaks when we try to open too
many CQs (around ~65k). Add a test max to not run into
system memory issues.

Signed-off-by: aingerson <alexia.ingerson@intel.com>