### PR TITLE
prov/efa: change MR cache count and size limits

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -89,7 +89,11 @@
 #define EFA_MR_IOV_LIMIT 1
 #define EFA_MR_SUPPORTED_PERMISSIONS (FI_SEND | FI_RECV)
 
-#define EFA_DEF_NUM_MR_CACHE 36
+/*
+ * Multiplier to give some room in the device memory registration limits
+ * to allow processes added to a running job to bootstrap.
+ */
+#define EFA_MR_CACHE_LIMIT_MULT (.9)
 
 extern int efa_mr_cache_enable;
 extern size_t efa_mr_max_cached_count;

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -176,11 +176,11 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 
 	if (efa_mr_cache_enable) {
 		if (!efa_mr_max_cached_count)
-			efa_mr_max_cached_count = info->domain_attr->mr_cnt /
-						  EFA_DEF_NUM_MR_CACHE;
+			efa_mr_max_cached_count = info->domain_attr->mr_cnt *
+			                          EFA_MR_CACHE_LIMIT_MULT;
 		if (!efa_mr_max_cached_size)
-			efa_mr_max_cached_size = domain->ctx->max_mr_size /
-						 EFA_DEF_NUM_MR_CACHE;
+			efa_mr_max_cached_size = domain->ctx->max_mr_size *
+			                         EFA_MR_CACHE_LIMIT_MULT;
 		cache_params.max_cnt = efa_mr_max_cached_count;
 		cache_params.max_size = efa_mr_max_cached_size;
 		cache_params.merge_regions = efa_mr_cache_merge_regions;
@@ -191,6 +191,9 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 					&domain->cache);
 		if (!ret) {
 			domain->util_domain.domain_fid.mr = &efa_domain_mr_cache_ops;
+			EFA_INFO(FI_LOG_DOMAIN, "EFA MR cache enabled, max_cnt: %zu max_size: %zu merge_regions: %d\n",
+			         cache_params.max_cnt, cache_params.max_size,
+			         cache_params.merge_regions);
 			return 0;
 		}
 	}


### PR DESCRIPTION
The EFA MR cache limits are currently set based on a fully subscribed
c5n.18xlarge EC2 instance. However, users may not utilize all ranks when
running jobs with frameworks like OpenMP, or may use a different
instance type with more cores. In these situations performance is poor
due to cache thrashing despite the fact that the hardware will allow
additional registrations.

Instead, set limits that are near the device limits. This is safe to do
since the MR cache will attempt to evict registrations when the device
returns an error and if the cache cannot evict registrations the
segmentation code will fallback to use bounce buffers. We leave some
overhead here for bootstraping if processes are added to a job.

Users that wish to enforce memory lock limits should do so via ulimits
or the FI_EFA_MR_MAX_CACHED_COUNT and FI_EFA_MR_MAX_CACHED_SIZE
variables.

Signed-off-by: Robert Wespetal <wesper@amazon.com>