### PR TITLE
prov/efa: use OFI_GETINFO_HIDDEN flag when querying for shm

### DIFF
--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -522,7 +522,8 @@ dgram_info:
 		shm_info = fi_allocinfo();
 		shm_hints = fi_allocinfo();
 		rxr_set_shm_hints(shm_hints);
-		ret = fi_getinfo(FI_VERSION(1, 8), NULL, NULL, 0, shm_hints, &shm_info);
+		ret = fi_getinfo(FI_VERSION(1, 8), NULL, NULL,
+		                 OFI_GETINFO_HIDDEN, shm_hints, &shm_info);
 		fi_freeinfo(shm_hints);
 		if (ret) {
 			FI_WARN(&rxr_prov, FI_LOG_CORE, "Disabling EFA shared memory support; failed to get shm provider's info: %s\n",


### PR DESCRIPTION
Users may set FI_PROVIDER=efa which will hide the shm provider. Use the hidden
flag when querying for shm so that we can still use the shm provider in this
case.

Signed-off-by: Robert Wespetal <wesper@amazon.com>