### PR TITLE
util/mr_cache: Series of changes to avoid calling malloc/free while holding monitor lock

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -260,6 +260,7 @@ struct ofi_mr_cache {
 
 	struct ofi_mr_storage		storage;
 	struct dlist_entry		lru_list;
+	pthread_mutex_t 		lock;
 
 	size_t				cached_cnt;
 	size_t				cached_size;

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -226,7 +226,7 @@ struct ofi_mr_entry {
 	void				*storage_context;
 	unsigned int			subscribed:1;
 	int				use_cnt;
-	struct dlist_entry		lru_entry;
+	struct dlist_entry		list_entry;
 	uint8_t				data[];
 };
 
@@ -260,6 +260,7 @@ struct ofi_mr_cache {
 
 	struct ofi_mr_storage		storage;
 	struct dlist_entry		lru_list;
+	struct dlist_entry		flush_list;
 	pthread_mutex_t 		lock;
 
 	size_t				cached_cnt;

--- a/include/ofi_tree.h
+++ b/include/ofi_tree.h
@@ -64,6 +64,7 @@ struct ofi_rbnode {
 struct ofi_rbmap {
 	struct ofi_rbnode	*root;
 	struct ofi_rbnode	sentinel;
+	struct ofi_rbnode	*free_list;
 
 	/* compare()
 	 *	= 0: a == b

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -238,10 +238,13 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 
 		ret = ofi_monitor_subscribe(cache->monitor, iov->iov_base,
 					    iov->iov_len);
-		if (ret)
-			util_mr_uncache_entry(cache, *entry);
-		else
+		if (ret) {
+			util_mr_uncache_entry_storage(cache, *entry);
+			cache->uncached_cnt++;
+			cache->uncached_size += (*entry)->info.iov.iov_len;
+		} else {
 			(*entry)->subscribed = 1;
+		}
 	}
 
 	return 0;

--- a/src/tree.c
+++ b/src/tree.c
@@ -51,6 +51,24 @@
 #include <rdma/fi_errno.h>
 
 
+static struct ofi_rbnode *ofi_rbnode_alloc(struct ofi_rbmap *map)
+{
+	struct ofi_rbnode *node;
+
+	if (!map->free_list)
+		return malloc(sizeof(*node));
+
+	node = map->free_list;
+	map->free_list = node->right;
+	return node;
+}
+
+static void ofi_rbnode_free(struct ofi_rbmap *map, struct ofi_rbnode *node)
+{
+	node->right = map->free_list ? map->free_list : NULL;
+	map->free_list = node;
+}
+
 void ofi_rbmap_init(struct ofi_rbmap *map,
 		int (*compare)(struct ofi_rbmap *map, void *key, void *data))
 {
@@ -211,7 +229,7 @@ int ofi_rbmap_insert(struct ofi_rbmap *map, void *key, void *data,
 		current = (ret < 0) ? current->left : current->right;
 	}
 
-	node = malloc(sizeof(*node));
+	node = ofi_rbnode_alloc(map);
 	if (!node)
 		return -FI_ENOMEM;
 
@@ -350,7 +368,7 @@ void ofi_rbmap_delete(struct ofi_rbmap *map, struct ofi_rbnode *node)
 
 	/* swap y in for node, so we can free node */
 	ofi_rbmap_replace_node_ptr(map, node, y);
-	free(node);
+	ofi_rbnode_free(map, node);
 }
 
 struct ofi_rbnode *ofi_rbmap_find(struct ofi_rbmap *map, void *key)


### PR DESCRIPTION
Not tested.

This series restructures the mr_cache, so that ofi_mr_cache_flush() will cleanup stale entries without holding the monitor lock.  Specifically, we cannot hold the monitor lock while calling util_mr_free_entry().

However, there are still code paths that call util_mr_free_entry() while holding the monitor lock.  For example, notify, merge, cleanup, and create still call uncache_entry, which calls free_entry.  The intent is for additional patches to update uncache_entry to move the stale entries to a flush_list, and have ofi_mr_cache_flush() cleanup those entries when called.