### PR TITLE
prov/util: destroy fastlock in poll_close

### DIFF
--- a/prov/util/src/util_poll.c
+++ b/prov/util/src/util_poll.c
@@ -141,6 +141,9 @@ static int util_poll_close(struct fid *fid)
 
 	if (pollset->domain)
 		ofi_atomic_dec32(&pollset->domain->ref);
+
+	fastlock_destroy(&pollset->lock);
+
 	free(pollset);
 	return 0;
 }


### PR DESCRIPTION
Signed-off-by: Andrey Lobanov <andrey.lobanov@intel.com>