### PR TITLE
core: Adding CUDA IOV copy helpers

### DIFF
--- a/config/fi_provider.m4
+++ b/config/fi_provider.m4
@@ -9,8 +9,6 @@ AC_DEFUN([FI_PROVIDER_INIT],[
 	PROVIDERS_DL=
 	PROVIDERS_STATIC=
 	PROVIDERS_COUNT=
-
-	m4_include(config/fi_check_package.m4)
 ])
 
 dnl

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl
 dnl Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2019 Intel, Inc.  All rights reserved.
-dnl Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+dnl Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
 dnl
 dnl Process this file with autoconf to produce a configure script.
 
@@ -13,6 +13,7 @@ AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)
 AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects parallel-tests tar-ustar])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+m4_include(config/fi_check_package.m4)
 
 AC_CANONICAL_HOST
 
@@ -467,6 +468,27 @@ AC_SEARCH_LIBS([clock_gettime],[rt],
 AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
        [Define to 1 if clock_gettime is available.])
 AM_CONDITIONAL(HAVE_CLOCK_GETTIME, [test $have_clock_gettime -eq 1])
+
+dnl Check for CUDA runtime libraries.
+AC_ARG_WITH([cuda],
+	    [AC_HELP_STRING([--with-cuda=DIR],
+			    [Provide path to where the CUDA development
+			    and runtime libraries are installed.])],
+	    [], [])
+
+FI_CHECK_PACKAGE([cuda],
+		 [cuda_runtime.h],
+		 [cudart],
+		 [cudaMemcpy],
+		 [-lcuda],
+		 [$with_cuda],
+		 [],
+		 [AC_DEFINE([HAVE_LIBCUDA], [1],[CUDA support])],
+		 [], [])
+
+CPPFLAGS="$CPPFLAGS $cuda_CPPFLAGS"
+LDFLAGS="$LD_FLAGS $cuda_LDFLAGS"
+LIBS="$LIBS $cuda_LIBS"
 
 dnl Provider-specific checks
 FI_PROVIDER_INIT

--- a/include/ofi_cuda.h
+++ b/include/ofi_cuda.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#ifndef _OFI_CUDA_H_
+#define _OFI_CUDA_H_
+#ifdef HAVE_LIBCUDA
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+static uint64_t
+ofi_copy_cuda_iov_buf(const struct iovec *iov, size_t iov_count,
+		      uint64_t iov_offset, void *buf,
+		      uint64_t bufsize, int dir)
+{
+	uint64_t done = 0, len;
+	char *iov_buf;
+	size_t i;
+
+	for (i = 0; i < iov_count && bufsize; i++) {
+		len = iov[i].iov_len;
+
+		if (iov_offset > len) {
+			iov_offset -= len;
+			continue;
+		}
+
+		iov_buf = (char *)iov[i].iov_base + iov_offset;
+		len -= iov_offset;
+
+		len = MIN(len, bufsize);
+		if (dir == OFI_COPY_BUF_TO_IOV)
+			cudaMemcpy(iov_buf, (char *) buf + done, len, cudaMemcpyHostToDevice);
+		else if (dir == OFI_COPY_IOV_TO_BUF)
+			cudaMemcpy((char *) buf + done, iov_buf, len, cudaMemcpyDeviceToHost);
+
+		iov_offset = 0;
+		bufsize -= len;
+		done += len;
+	}
+	return done;
+}
+
+static inline uint64_t
+ofi_copy_from_cuda_iov(void *buf, uint64_t bufsize,
+		       const struct iovec *iov, size_t iov_count, uint64_t iov_offset)
+{
+	if (iov_count == 1) {
+		uint64_t size = ((iov_offset > iov[0].iov_len) ?
+				 0 : MIN(bufsize, iov[0].iov_len - iov_offset));
+
+		cudaMemcpy(buf, (char *) iov[0].iov_base + iov_offset,
+			   size, cudaMemcpyDeviceToHost);
+		return size;
+	} else {
+		return ofi_copy_cuda_iov_buf(iov, iov_count, iov_offset, buf,
+					     bufsize, OFI_COPY_IOV_TO_BUF);
+	}
+}
+
+static inline uint64_t
+ofi_copy_to_cuda_iov(const struct iovec *iov, size_t iov_count, uint64_t iov_offset,
+		     void *buf, uint64_t bufsize)
+{
+	if (iov_count == 1) {
+		uint64_t size = ((iov_offset > iov[0].iov_len) ?
+				 0 : MIN(bufsize, iov[0].iov_len - iov_offset));
+		cudaMemcpy((char *) iov[0].iov_base + iov_offset,
+			   buf, size, cudaMemcpyHostToDevice);
+		return size;
+	} else {
+		return ofi_copy_cuda_iov_buf(iov, iov_count, iov_offset, buf,
+					     bufsize, OFI_COPY_BUF_TO_IOV);
+	}
+}
+
+#endif /* HAVE_LIBCUDA */
+#endif /* _OFI_CUDA_H_ */


### PR DESCRIPTION
~~This PR is built on https://github.com/ofiwg/libfabric/pull/5561, so ignore the rdma-core related commits and just look at the two top commits in this branch. Github doesn't handle parent-child PR relationships well across forks.~~ (The latest version has the right commits.)

@shefty @j-xiong I have added the copy functions to EFA in this case, but I see no reason why they can not be general enough and live in a ofi_cuda.h. I know we have talked about a generic peer software interface for providers that support `FI_HMEM` in the past, so until that gets defined I did not want to push this to core. Let me know what you think.

I have more changes to support `FI_HMEM` in the EFA provider lined up, but they depend on these helpers (and the parent PR), so I'll wait for these two to get merged before cutting more PRs.