### PR TITLE
prov/efa: Post inlined send if FI_INJECT is set

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -506,16 +506,19 @@ static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 
 	info->tx_attr->iov_limit = efadv_attr.max_sq_sge;
 	info->tx_attr->size = align_down_to_power_of_2(efadv_attr.max_sq_wr);
+	info->tx_attr->inject_size = efadv_attr.inline_buf_size;
 	info->rx_attr->iov_limit = efadv_attr.max_rq_sge;
 	info->rx_attr->size = align_down_to_power_of_2(efadv_attr.max_rq_wr / info->rx_attr->iov_limit);
 
 	EFA_DBG(FI_LOG_DOMAIN, "Tx/Rx attribute :\n"
 				"\t info->tx_attr->iov_limit		= %zu\n"
 				"\t info->tx_attr->size			= %zu\n"
+				"\t info->tx_attr->inject_size		= %zu\n"
 				"\t info->rx_attr->iov_limit		= %zu\n"
 				"\t info->rx_attr->size			= %zu\n",
 				info->tx_attr->iov_limit,
 				info->tx_attr->size,
+				info->tx_attr->inject_size,
 				info->rx_attr->iov_limit,
 				info->rx_attr->size);
 

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -309,6 +309,9 @@ static ssize_t efa_post_send(struct efa_ep *ep, const struct fi_msg *msg, uint64
 
 	efa_post_send_sgl(ep, msg, ewr);
 
+	if (flags & FI_INJECT)
+		wr->send_flags |= IBV_SEND_INLINE;
+
 	wr->opcode = IBV_WR_SEND;
 	wr->wr_id = (uintptr_t)msg->context;
 	wr->wr.ud.ah = conn->ah.ibv_ah;


### PR DESCRIPTION
`efadv_query_device()` fetches the `inline_buf_size` of the EFA device.
If a send is within this limit and if the OFI application requests
FI_INJECT, set IBV_SEND_INLINE.

Signed-off-by: Raghu Raja <craghun@amazon.com>