### PR TITLE
fi_info: Add filter option when displaying environment vars

### DIFF
--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -828,6 +828,8 @@ static inline char * strndup(char const *src, size_t n)
 	return dst;
 }
 
+char *strcasestr(const char *haystack, const char *needle);
+
 #ifndef _SC_PAGESIZE
 #define _SC_PAGESIZE	0
 #endif

--- a/info.vcxproj
+++ b/info.vcxproj
@@ -238,6 +238,7 @@
       <C99Support Condition="'$(Configuration)|$(Platform)'=='Release-ICC|x64'">true</C99Support>
     </ClCompile>
     <ClCompile Include="util\windows\getopt\getopt.cpp" />
+    <ClCompile Include="src\shared\ofi_str.c" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="libfabric.vcxproj">

--- a/info.vcxproj.filters
+++ b/info.vcxproj.filters
@@ -18,6 +18,9 @@
     <ClCompile Include="util\info.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\shared\ofi_str.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="util\windows\getopt\getopt.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/man/fi_info.1.md
+++ b/man/fi_info.1.md
@@ -70,8 +70,12 @@ providers, see the `--list` option.
 ## Discovery
 
 *-e, --env*
-: List libfabric related environment levels which can be used to enable extra
+: List libfabric related environment variables which can be used to enable extra
 configuration or tuning.
+
+*-g [filter]
+: Same as -e option, with output limited to environment variables containing
+filter as a substring.
 
 *-l, --list*
 : List available libfabric providers.

--- a/src/shared/ofi_str.c
+++ b/src/shared/ofi_str.c
@@ -62,6 +62,35 @@ static inline char* strsep(char **stringp, const char *delim)
 
 	return ptr;
 }
+
+char *strcasestr(const char *haystack, const char *needle)
+{
+	char *uneedle, *uhaystack, *pos = NULL;
+	int i;
+
+	uneedle = malloc(strlen(needle) + 1);
+	uhaystack = malloc(strlen(haystack) + 1);
+	if (!uneedle || !uhaystack)
+		goto out;
+
+	for (i = 0; i < strlen(needle); i++)
+		uneedle[i] = toupper(needle[i]);
+	uneedle[i] = '\0';
+
+	for (i = 0; i < strlen(haystack); i++)
+		uhaystack[i] = toupper(haystack[i]);
+	uhaystack[i] = '\0';
+
+	pos = strstr(uhaystack, uneedle);
+	if (pos)
+		pos = (char *) ((uintptr_t) haystack + (uintptr_t) pos -
+				(uintptr_t) uhaystack);
+out:
+	free(uneedle);
+	free(uhaystack);
+	return pos;
+}
+
 #endif
 
 /* String utility functions */


### PR DESCRIPTION
The number of environment variables can be fairly long.
Using grep on the output can help search for a variable
containing a specific string, but in doing so, it loses
the vars description.  Allow passing in a string to use
as a filter.  Only variables containing that string will
be displayed.

This removes the need for the variable prefix hack to
filter based on provider name.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>