### PR TITLE
prov/efa : fix a bug in efa_mr_cache_entry_dereg()

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -87,6 +87,9 @@ void efa_mr_cache_entry_dereg(struct ofi_mr_cache *cache,
 			      struct ofi_mr_entry *entry)
 {
 	struct efa_mem_desc *md = (struct efa_mem_desc *)entry->data;
+	if (!md->mr)
+		return;
+
 	int ret = -ibv_dereg_mr(md->mr);
 	if (ret)
 		EFA_WARN(FI_LOG_MR, "Unable to dereg mr: %d\n", ret);


### PR DESCRIPTION
efa_mr_cache_entry_dereg() call ibv_dereg_mr() with mem_desc->mr
to deregister a memory region, if mem_desc-mr is NULL, this will
cause segmentaion fault.

This patch fix the issue by checking if mem_desc->mr is NULL,
and does not call ibv_dereg_mr() on the NULL pointer.

Signed-off-by: Wei Zhang <wzam@amazon.com>