### PR TITLE
common: Using clock_gettime() instead of gettitmeofday()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -457,6 +457,17 @@ AC_DEFINE_UNQUOTED([HAVE_UFFD_UNMAP], [$have_uffd],
 dnl Check support to intercept syscalls
 AC_CHECK_HEADERS_ONCE(elf.h sys/auxv.h)
 
+dnl Check support to clock_gettime
+have_clock_gettime=0
+
+AC_SEARCH_LIBS([clock_gettime],[rt],
+         [have_clock_gettime=1],
+         [])
+
+AC_DEFINE_UNQUOTED(HAVE_CLOCK_GETTIME, [$have_clock_gettime],
+       [Define to 1 if clock_gettime is available.])
+AM_CONDITIONAL(HAVE_CLOCK_GETTIME, [test $have_clock_gettime -eq 1])
+
 dnl Provider-specific checks
 FI_PROVIDER_INIT
 FI_PROVIDER_SETUP([psm])

--- a/docs/providers
+++ b/docs/providers
@@ -106,6 +106,7 @@ fi_poll_fd() - call poll() on an fd
 fi_wait_cond() - wait on a mutex
 fi_datatype_size() - return size of an atomic datatype
 fi_[capability]_allowed() - routines to check caps bits
-fi_gettime_ms() - return current time in milliseconds
-fi_gettime_us() - return current time in microseconds
+ofi_gettime_ns() - return current time in nanoseconds
+ofi_gettime_us() - return current time in microseconds
+ofi_gettime_ms() - return current time in milliseconds
 fi_fd_nonblock() - set fd to nonblocking

--- a/docs/providers
+++ b/docs/providers
@@ -107,4 +107,5 @@ fi_wait_cond() - wait on a mutex
 fi_datatype_size() - return size of an atomic datatype
 fi_[capability]_allowed() - routines to check caps bits
 fi_gettime_ms() - return current time in milliseconds
+fi_gettime_us() - return current time in microseconds
 fi_fd_nonblock() - set fd to nonblocking

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -275,8 +275,9 @@ int ofi_ep_bind_valid(const struct fi_provider *prov, struct fid *bfid,
 		      uint64_t flags);
 int ofi_check_rx_mode(const struct fi_info *info, uint64_t flags);
 
-uint64_t fi_gettime_ms(void);
+uint64_t fi_gettime_ns(void);
 uint64_t fi_gettime_us(void);
+uint64_t fi_gettime_ms(void);
 
 static inline uint64_t ofi_timeout_time(int timeout)
 {

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -275,19 +275,19 @@ int ofi_ep_bind_valid(const struct fi_provider *prov, struct fid *bfid,
 		      uint64_t flags);
 int ofi_check_rx_mode(const struct fi_info *info, uint64_t flags);
 
-uint64_t fi_gettime_ns(void);
-uint64_t fi_gettime_us(void);
-uint64_t fi_gettime_ms(void);
+uint64_t ofi_gettime_ns(void);
+uint64_t ofi_gettime_us(void);
+uint64_t ofi_gettime_ms(void);
 
 static inline uint64_t ofi_timeout_time(int timeout)
 {
-	return (timeout >= 0) ? fi_gettime_ms() + timeout : 0;
+	return (timeout >= 0) ? ofi_gettime_ms() + timeout : 0;
 }
 
 static inline int ofi_adjust_timeout(uint64_t timeout_time, int *timeout)
 {
 	if (*timeout >= 0) {
-		*timeout = (int) (timeout_time - fi_gettime_ms());
+		*timeout = (int) (timeout_time - ofi_gettime_ms());
 		return (*timeout <= 0) ? -FI_ETIMEDOUT : 0;
 	}
 	return 0;

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -237,6 +237,17 @@ static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 		((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[3] == htonl(1));
 }
 
+#if !HAVE_CLOCK_GETTIME
+
+#define CLOCK_REALTIME 0
+#define CLOCK_REALTIME_COARSE 0
+#define CLOCK_MONOTONIC 0
+
+typedef int clockid_t;
+
+int clock_gettime(clockid_t clk_id, struct timespec *tp);
+
+#endif /* !HAVE_CLOCK_GETTIME */
 
 /* complex operations implementation */
 

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -32,6 +32,7 @@
 #include "pthread.h"
 
 #include <sys/uio.h>
+#include <time.h>
 
 #include <rdma/fi_errno.h>
 #include <rdma/fabric.h>
@@ -898,6 +899,25 @@ static inline int ofi_is_loopback_addr(struct sockaddr *addr) {
 }
 
 size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
+
+#define file2unix_time	10000000i64
+#define win2unix_epoch	116444736000000000i64
+#define CLOCK_MONOTONIC 1
+
+/* Own implementation of clock_gettime*/
+static inline
+int clock_gettime(int which_clock, struct timespec *spec)
+{
+	__int64 wintime;
+
+	GetSystemTimeAsFileTime((FILETIME*)&wintime);
+	wintime -= win2unix_epoch;
+
+	spec->tv_sec = wintime / file2unix_time;
+	spec->tv_nsec = wintime % file2unix_time * 100;
+
+	return 0;
+}
 
 /* complex operations implementation */
 

--- a/prov/efa/src/rxr/rxr_cntr.c
+++ b/prov/efa/src/rxr/rxr_cntr.c
@@ -48,7 +48,7 @@ static int rxr_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 	cntr = container_of(cntr_fid, struct util_cntr, cntr_fid);
 	assert(cntr->wait);
 	errcnt = ofi_atomic_get64(&cntr->err);
-	start = (timeout >= 0) ? fi_gettime_ms() : 0;
+	start = (timeout >= 0) ? ofi_gettime_ms() : 0;
 
 	for (tryid = 0; tryid < numtry; ++tryid) {
 		cntr->progress(cntr);
@@ -59,7 +59,7 @@ static int rxr_cntr_wait(struct fid_cntr *cntr_fid, uint64_t threshold, int time
 			return -FI_EAVAIL;
 
 		if (timeout >= 0) {
-			timeout -= (int)(fi_gettime_ms() - start);
+			timeout -= (int)(ofi_gettime_ms() - start);
 			if (timeout <= 0)
 				return -FI_ETIMEDOUT;
 		}

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -255,7 +255,7 @@ static inline void rxr_cq_queue_pkt(struct rxr_ep *ep,
 	 * a retransmitted packet is received while waiting for the timer to
 	 * expire.
 	 */
-	peer->rnr_ts = fi_gettime_us();
+	peer->rnr_ts = ofi_gettime_us();
 	if (peer->rnr_state & RXR_PEER_IN_BACKOFF)
 		goto queue_pkt;
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -889,7 +889,7 @@ void rxr_ep_handle_cts_sent(struct rxr_ep *ep,
 	 * to replenish the credits.
 	 */
 	if (OFI_UNLIKELY(ep->available_data_bufs == 0))
-		ep->available_data_bufs_ts = fi_gettime_us();
+		ep->available_data_bufs_ts = ofi_gettime_us();
 }
 
 void rxr_ep_init_connack_pkt_entry(struct rxr_ep *ep,
@@ -1981,7 +1981,7 @@ static inline void rxr_ep_check_available_data_bufs_timer(struct rxr_ep *ep)
 	if (OFI_LIKELY(ep->available_data_bufs != 0))
 		return;
 
-	if (fi_gettime_us() - ep->available_data_bufs_ts >=
+	if (ofi_gettime_us() - ep->available_data_bufs_ts >=
 	    RXR_AVAILABLE_DATA_BUFS_TIMEOUT) {
 		ep->available_data_bufs = rxr_get_rx_pool_chunk_cnt(ep);
 		ep->available_data_bufs_ts = 0;
@@ -2001,7 +2001,7 @@ static inline void rxr_ep_check_peer_backoff_timer(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->peer_backoff_list, struct rxr_peer,
 				     peer, rnr_entry, tmp) {
 		peer->rnr_state &= ~RXR_PEER_BACKED_OFF;
-		if (!rxr_peer_timeout_expired(ep, peer, fi_gettime_us()))
+		if (!rxr_peer_timeout_expired(ep, peer, ofi_gettime_us()))
 			continue;
 		peer->rnr_state = 0;
 		dlist_remove(&peer->rnr_entry);

--- a/prov/netdir/src/netdir.h
+++ b/prov/netdir/src/netdir.h
@@ -181,9 +181,9 @@ static inline int ofi_nd_hresult_2_fierror(HRESULT hr)
 
 #define OFI_ND_TIMEOUT_INIT(timeout)				\
 	uint64_t sfinish = ((timeout) >= 0) ?			\
-		(fi_gettime_ms() + (timeout) * 10000) : -1;
+		(ofi_gettime_ms() + (timeout) * 10000) : -1;
 
-#define OFI_ND_TIMEDOUT() ((sfinish > 0) ? fi_gettime_ms() >= sfinish : 0)
+#define OFI_ND_TIMEDOUT() ((sfinish > 0) ? ofi_gettime_ms() >= sfinish : 0)
 
 #ifdef ENABLE_DEBUG  
 # define NODEFAULT	assert(0)  

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -415,7 +415,7 @@ int rxd_ep_send_pkt(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 {
 	int ret;
 
-	pkt_entry->timestamp = fi_gettime_ms();
+	pkt_entry->timestamp = ofi_gettime_ms();
 
 	ret = fi_send(ep->dg_ep, (const void *) rxd_pkt_start(pkt_entry),
 		      pkt_entry->pkt_size, pkt_entry->desc,
@@ -915,7 +915,7 @@ static void rxd_progress_pkt_list(struct rxd_ep *ep, struct rxd_peer *peer)
 	uint64_t current;
 	int ret, retry = 0;
 
-	current = fi_gettime_ms();
+	current = ofi_gettime_ms();
 	if (peer->retry_cnt > RXD_MAX_PKT_RETRY) {
 		rxd_peer_timeout(ep, peer);
 		return;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1444,7 +1444,7 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 			else
 				rxm_cq_write_error_all(rxm_ep, ret);
 		} else {
-			timestamp = fi_gettime_us();
+			timestamp = ofi_gettime_us();
 			if (timestamp - rxm_ep->msg_cq_last_poll >
 				rxm_cm_progress_interval) {
 				rxm_ep->msg_cq_last_poll = timestamp;

--- a/prov/sockets/src/sock_cntr.c
+++ b/prov/sockets/src/sock_cntr.c
@@ -325,7 +325,7 @@ static int sock_cntr_wait(struct fid_cntr *fid_cntr, uint64_t threshold,
 	ofi_atomic_inc32(&cntr->num_waiting);
 
 	if (timeout >= 0) {
-		start_ms = fi_gettime_ms();
+		start_ms = ofi_gettime_ms();
 		end_ms = start_ms + timeout;
 	}
 
@@ -341,7 +341,7 @@ static int sock_cntr_wait(struct fid_cntr *fid_cntr, uint64_t threshold,
 			ret = fi_wait_cond(&cntr->cond, &cntr->mut, remaining_ms);
 		}
 
-		uint64_t curr_ms = fi_gettime_ms();
+		uint64_t curr_ms = ofi_gettime_ms();
 		if (timeout >= 0) {
 			if (curr_ms >= end_ms) {
 				ret = -FI_ETIMEDOUT;

--- a/prov/sockets/src/sock_cq.c
+++ b/prov/sockets/src/sock_cq.c
@@ -349,7 +349,7 @@ static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 	else
 		threshold = count;
 
-	start_ms = (timeout >= 0) ? fi_gettime_ms() : 0;
+	start_ms = (timeout >= 0) ? ofi_gettime_ms() : 0;
 
 	if (sock_cq->domain->progress_mode == FI_PROGRESS_MANUAL) {
 		while (1) {
@@ -366,7 +366,7 @@ static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 				return ret;
 
 			if (timeout >= 0) {
-				timeout -= (int) (fi_gettime_ms() - start_ms);
+				timeout -= (int) (ofi_gettime_ms() - start_ms);
 				if (timeout <= 0)
 					return -FI_EAGAIN;
 			}
@@ -393,7 +393,7 @@ static ssize_t sock_cq_sreadfrom(struct fid_cq *cq, void *buf, size_t count,
 				return ret;
 
 			if (timeout >= 0) {
-				timeout -= (int) (fi_gettime_ms() - start_ms);
+				timeout -= (int) (ofi_gettime_ms() - start_ms);
 				if (timeout <= 0)
 					return -FI_EAGAIN;
 			}

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2538,7 +2538,7 @@ static int sock_pe_wait_ok(struct sock_pe *pe)
 	struct sock_tx_ctx *tx_ctx;
 	struct sock_rx_ctx *rx_ctx;
 
-	if (pe->waittime && ((fi_gettime_ms() - pe->waittime) < (uint64_t)sock_pe_waittime))
+	if (pe->waittime && ((ofi_gettime_ms() - pe->waittime) < (uint64_t)sock_pe_waittime))
 		return 0;
 
 	if (dlist_empty(&pe->tx_list) && dlist_empty(&pe->rx_list))
@@ -2589,7 +2589,7 @@ static void sock_pe_wait(struct sock_pe *pe)
 			SOCK_LOG_ERROR("Invalid signal\n");
 	}
 	fastlock_release(&pe->signal_lock);
-	pe->waittime = fi_gettime_ms();
+	pe->waittime = ofi_gettime_ms();
 }
 
 static void sock_pe_set_affinity(void)

--- a/prov/sockets/src/sock_wait.c
+++ b/prov/sockets/src/sock_wait.c
@@ -127,7 +127,7 @@ static int sock_wait_wait(struct fid_wait *wait_fid, int timeout)
 
 	wait = container_of(wait_fid, struct sock_wait, wait_fid);
 	if (timeout > 0)
-		start_ms = fi_gettime_ms();
+		start_ms = ofi_gettime_ms();
 
 	head = &wait->fid_list;
 	for (p = head->next; p != head; p = p->next) {
@@ -149,7 +149,7 @@ static int sock_wait_wait(struct fid_wait *wait_fid, int timeout)
 		}
 	}
 	if (timeout > 0) {
-		end_ms = fi_gettime_ms();
+		end_ms = ofi_gettime_ms();
 		timeout -=  (int) (end_ms - start_ms);
 		timeout = timeout < 0 ? 0 : timeout;
 	}

--- a/src/common.c
+++ b/src/common.c
@@ -218,20 +218,22 @@ int ofi_check_rx_mode(const struct fi_info *info, uint64_t flags)
 	return (info->mode & flags) ? 1 : 0;
 }
 
-uint64_t fi_gettime_ms(void)
+uint64_t fi_gettime_ns(void)
 {
-	struct timeval now;
+	struct timespec now;
 
-	gettimeofday(&now, NULL);
-	return now.tv_sec * 1000 + now.tv_usec / 1000;
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	return now.tv_sec * 1000000000 + now.tv_nsec;
 }
 
 uint64_t fi_gettime_us(void)
 {
-	struct timeval now;
+	return fi_gettime_ns() / 1000000;
+}
 
-	gettimeofday(&now, NULL);
-	return now.tv_sec * 1000000 + now.tv_usec;
+uint64_t fi_gettime_ms(void)
+{
+	return fi_gettime_ns() / 1000;
 }
 
 uint16_t ofi_get_sa_family(const struct fi_info *info)

--- a/src/common.c
+++ b/src/common.c
@@ -218,7 +218,7 @@ int ofi_check_rx_mode(const struct fi_info *info, uint64_t flags)
 	return (info->mode & flags) ? 1 : 0;
 }
 
-uint64_t fi_gettime_ns(void)
+uint64_t ofi_gettime_ns(void)
 {
 	struct timespec now;
 
@@ -226,14 +226,14 @@ uint64_t fi_gettime_ns(void)
 	return now.tv_sec * 1000000000 + now.tv_nsec;
 }
 
-uint64_t fi_gettime_us(void)
+uint64_t ofi_gettime_us(void)
 {
-	return fi_gettime_ns() / 1000000;
+	return ofi_gettime_ns() / 1000000;
 }
 
-uint64_t fi_gettime_ms(void)
+uint64_t ofi_gettime_ms(void)
 {
-	return fi_gettime_ns() / 1000;
+	return ofi_gettime_ns() / 1000;
 }
 
 uint16_t ofi_get_sa_family(const struct fi_info *info)
@@ -1010,7 +1010,7 @@ int fi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
 {
 	int i, ret;
 	int found = 0;
-	uint64_t start = (timeout >= 0) ? fi_gettime_ms() : 0;
+	uint64_t start = (timeout >= 0) ? ofi_gettime_ms() : 0;
 
 	do {
 		ret = poll(ep->fds, ep->nfds, timeout);
@@ -1042,7 +1042,7 @@ int fi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
 		}
 
 		if (timeout > 0)
-			timeout -= (int) (fi_gettime_ms() - start);
+			timeout -= (int) (ofi_gettime_ms() - start);
 
 	} while (timeout > 0 && !found);
 

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -99,7 +99,7 @@ int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
 	if (timeout_ms < 0)
 		return pthread_cond_wait(cond, mut);
 
-	t = fi_gettime_ms() + timeout_ms;
+	t = ofi_gettime_ms() + timeout_ms;
 	ts.tv_sec = t / 1000;
 	ts.tv_nsec = (t % 1000) * 1000000;
 	return pthread_cond_timedwait(cond, mut, &ts);

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -62,6 +62,20 @@ typedef cpuset_t ofi_cpu_set_t;
 typedef cpu_set_t ofi_cpu_set_t;
 #endif
 
+#if !HAVE_CLOCK_GETTIME
+int clock_gettime(clockid_t clk_id, struct timespec *tp) {
+	int retval;
+	struct timeval tv;
+
+	retval = gettimeofday(&tv, NULL);
+
+	tp->tv_sec = tv.tv_sec;
+	tp->tv_nsec = tv.tv_usec * 1000;
+
+	return retval;
+}
+#endif /* !HAVE_CLOCK_GETTIME */
+
 int fi_fd_nonblock(int fd)
 {
 	long flags = 0;


### PR DESCRIPTION
1)clock_gettime() works about 33% faster than gettimeofday().

2)Added fi_gettime_ns - it will give an oppurtunity to call to
clock_gettime() in a single function and easy to modify in
the future if it requires.

3)Added check for clock_gettime() in configure.ac and added a fallback
function on gettimeofday() for UnixOS. For WinOS, provided own
implementation.

4)common: Refactored fi to ofi prefix -- fi_gettime_xxx to ofi_gettime_xxx

5)docs/prov: changed prefix fi to ofi, add gettime_ns\us

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>