### PR TITLE
prov/efa : re-organize packet related functions into 3 parts

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -48,14 +48,23 @@ _efa_files = \
 	prov/efa/src/rxr/rxr_ep.c	\
 	prov/efa/src/rxr/rxr_cntr.c	\
 	prov/efa/src/rxr/rxr_rma.c	\
-	prov/efa/src/rxr/rxr_msg.c
+	prov/efa/src/rxr/rxr_msg.c	\
+	prov/efa/src/rxr/rxr_pkt_entry.c \
+	prov/efa/src/rxr/rxr_pkt_type_rts.c \
+	prov/efa/src/rxr/rxr_pkt_type_data.c \
+	prov/efa/src/rxr/rxr_pkt_type_misc.c \
+	prov/efa/src/rxr/rxr_pkt_cmd.c
 
 _efa_headers = \
 	prov/efa/src/efa.h \
 	prov/efa/src/rxr/rxr.h \
 	prov/efa/src/rxr/rxr_cntr.h \
 	prov/efa/src/rxr/rxr_rma.h \
-	prov/efa/src/rxr/rxr_msg.h
+	prov/efa/src/rxr/rxr_msg.h \
+	prov/efa/src/rxr/rxr_pkt.h \
+	prov/efa/src/rxr/rxr_pkt_type.h \
+	prov/efa/src/rxr/rxr_pkt_entry.h \
+	prov/efa/src/rxr/rxr_pkt_cmd.h
 
 efa_CPPFLAGS += \
 	-I$(top_srcdir)/prov/efa/src/ \

--- a/prov/efa/src/rxr/rxr_msg.h
+++ b/prov/efa/src/rxr/rxr_msg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/prov/efa/src/rxr/rxr_pkt.h
+++ b/prov/efa/src/rxr/rxr_pkt.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -30,41 +30,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#if HAVE_CONFIG_H
-#include <config.h>
-#endif /* HAVE_CONFIG_H */
 
-#ifndef _RXR_RMA_H_
-#define _RXR_RMA_H_
+#include "rxr_pkt_entry.h"
+#include "rxr_pkt_type.h"
+#include "rxr_pkt_cmd.h"
 
-#include <rdma/fi_rma.h>
-
-int rxr_rma_verified_copy_iov(struct rxr_ep *ep, struct fi_rma_iov *rma,
-			      size_t count, uint32_t flags, struct iovec *iov);
-
-/* read response related functions */
-struct rxr_tx_entry *
-rxr_rma_alloc_readrsp_tx_entry(struct rxr_ep *rxr_ep,
-			       struct rxr_rx_entry *rx_entry);
-
-int rxr_rma_init_readrsp_pkt(struct rxr_ep *ep,
-			     struct rxr_tx_entry *tx_entry,
-			     struct rxr_pkt_entry *pkt_entry);
-
-void rxr_rma_handle_readrsp_sent(struct rxr_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry);
-
-/* EOR related functions */
-int rxr_rma_init_eor_pkt(struct rxr_ep *ep,
-			 struct rxr_rx_entry *rx_entry,
-			 struct rxr_pkt_entry *pkt_entry);
-
-void rxr_rma_handle_eor_sent(struct rxr_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry);
-
-size_t rxr_rma_post_shm_rma(struct rxr_ep *rxr_ep,
-			    struct rxr_tx_entry *tx_entry);
-
-extern struct fi_ops_rma rxr_ops_rma;
-
-#endif

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -1,0 +1,617 @@
+/*
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa.h"
+#include "rxr.h"
+#include "rxr_cntr.h"
+
+/* This file implements 4 actions that can be applied to a packet:
+ *          posting,
+ *          handling send completion and,
+ *          handing recv completion.
+ *          dump (for debug only)
+ */
+
+/*
+ *  Functions used to post a packet
+ */
+ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep,
+			  struct rxr_tx_entry *tx_entry)
+{
+	struct rxr_pkt_entry *pkt_entry;
+	struct rxr_data_pkt *data_pkt;
+	ssize_t ret;
+
+	pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_efa_pool);
+
+	if (OFI_UNLIKELY(!pkt_entry))
+		return -FI_ENOMEM;
+
+	pkt_entry->x_entry = (void *)tx_entry;
+	pkt_entry->addr = tx_entry->addr;
+
+	data_pkt = (struct rxr_data_pkt *)pkt_entry->pkt;
+
+	data_pkt->hdr.type = RXR_DATA_PKT;
+	data_pkt->hdr.version = RXR_PROTOCOL_VERSION;
+	data_pkt->hdr.flags = 0;
+
+	data_pkt->hdr.rx_id = tx_entry->rx_id;
+
+	/*
+	 * Data packets are sent in order so using bytes_sent is okay here.
+	 */
+	data_pkt->hdr.seg_offset = tx_entry->bytes_sent;
+
+	if (efa_mr_cache_enable)
+		ret = rxr_pkt_send_data_mr_cache(rxr_ep, tx_entry, pkt_entry);
+	else
+		ret = rxr_pkt_send_data(rxr_ep, tx_entry, pkt_entry);
+
+	if (OFI_UNLIKELY(ret)) {
+		rxr_pkt_entry_release_tx(rxr_ep, pkt_entry);
+		return ret;
+	}
+
+	data_pkt = rxr_get_data_pkt(pkt_entry->pkt);
+	tx_entry->bytes_sent += data_pkt->hdr.seg_size;
+	tx_entry->window -= data_pkt->hdr.seg_size;
+	return ret;
+}
+
+/*
+ *   rxr_pkt_init_ctrl() uses init functions declared in rxr_pkt_type.h
+ */
+static
+int rxr_pkt_init_ctrl(struct rxr_ep *rxr_ep, int entry_type, void *x_entry,
+		      int ctrl_type, struct rxr_pkt_entry *pkt_entry)
+{
+	int ret = 0;
+
+	switch (ctrl_type) {
+	case RXR_RTS_PKT:
+		ret = rxr_pkt_init_rts(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		break;
+	case RXR_READRSP_PKT:
+		ret = rxr_pkt_init_readrsp(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		break;
+	case RXR_CTS_PKT:
+		ret = rxr_pkt_init_cts(rxr_ep, (struct rxr_rx_entry *)x_entry, pkt_entry);
+		break;
+	case RXR_EOR_PKT:
+		ret = rxr_pkt_init_eor(rxr_ep, (struct rxr_rx_entry *)x_entry, pkt_entry);
+		break;
+	default:
+		ret = -FI_EINVAL;
+		assert(0 && "unknown pkt type to init");
+		break;
+	}
+
+	return ret;
+}
+
+/*
+ *   rxr_pkt_handle_ctrl_sent() uses handle_sent() functions declared in rxr_pkt_type.h
+ */
+void rxr_pkt_handle_ctrl_sent(struct rxr_ep *rxr_ep, struct rxr_pkt_entry *pkt_entry)
+{
+	int ctrl_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+
+	switch (ctrl_type) {
+	case RXR_RTS_PKT:
+		rxr_pkt_handle_rts_sent(rxr_ep, pkt_entry);
+		break;
+	case RXR_READRSP_PKT:
+		rxr_pkt_handle_readrsp_sent(rxr_ep, pkt_entry);
+		break;
+	case RXR_CTS_PKT:
+		rxr_pkt_handle_cts_sent(rxr_ep, pkt_entry);
+		break;
+	case RXR_EOR_PKT:
+		rxr_pkt_handle_eor_sent(rxr_ep, pkt_entry);
+		break;
+	default:
+		assert(0 && "Unknown packet type to handle sent");
+		break;
+	}
+}
+
+ssize_t rxr_pkt_post_ctrl(struct rxr_ep *rxr_ep, int entry_type, void *x_entry,
+			  int ctrl_type, bool inject)
+{
+	struct rxr_pkt_entry *pkt_entry;
+	struct rxr_tx_entry *tx_entry;
+	struct rxr_rx_entry *rx_entry;
+	struct rxr_peer *peer;
+	ssize_t err;
+	fi_addr_t addr;
+
+	if (entry_type == RXR_TX_ENTRY) {
+		tx_entry = (struct rxr_tx_entry *)x_entry;
+		addr = tx_entry->addr;
+	} else {
+		rx_entry = (struct rxr_rx_entry *)x_entry;
+		addr = rx_entry->addr;
+	}
+
+	peer = rxr_ep_get_peer(rxr_ep, addr);
+	if (peer->is_local)
+		pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_shm_pool);
+	else
+		pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_efa_pool);
+
+	if (!pkt_entry)
+		return -FI_EAGAIN;
+
+	err = rxr_pkt_init_ctrl(rxr_ep, entry_type, x_entry, ctrl_type, pkt_entry);
+	if (OFI_UNLIKELY(err)) {
+		rxr_pkt_entry_release_tx(rxr_ep, pkt_entry);
+		return err;
+	}
+
+	/* if send, tx_pkt_entry will be released while handle completion
+	 * if inject, there will not be completion, therefore tx_pkt_entry has to be
+	 * released here
+	 */
+	if (inject)
+		err = rxr_pkt_entry_inject(rxr_ep, pkt_entry, addr);
+	else
+		err = rxr_pkt_entry_send(rxr_ep, pkt_entry, addr);
+
+	if (OFI_UNLIKELY(err)) {
+		rxr_pkt_entry_release_tx(rxr_ep, pkt_entry);
+		return err;
+	}
+
+	rxr_pkt_handle_ctrl_sent(rxr_ep, pkt_entry);
+
+	if (inject)
+		rxr_pkt_entry_release_tx(rxr_ep, pkt_entry);
+
+	return 0;
+}
+
+ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry, int ctrl_type, bool inject)
+{
+	ssize_t err;
+	struct rxr_tx_entry *tx_entry;
+	struct rxr_rx_entry *rx_entry;
+
+	err = rxr_pkt_post_ctrl(ep, entry_type, x_entry, ctrl_type, inject);
+	if (err == -FI_EAGAIN) {
+		if (entry_type == RXR_TX_ENTRY) {
+			tx_entry = (struct rxr_tx_entry *)x_entry;
+			tx_entry->state = RXR_TX_QUEUED_CTRL;
+			tx_entry->queued_ctrl.type = ctrl_type;
+			dlist_insert_tail(&tx_entry->queued_entry,
+					  &ep->tx_entry_queued_list);
+		} else {
+			assert(entry_type == RXR_RX_ENTRY);
+			rx_entry = (struct rxr_rx_entry *)x_entry;
+			rx_entry->state = RXR_RX_QUEUED_CTRL;
+			rx_entry->queued_ctrl.type = ctrl_type;
+			rx_entry->queued_ctrl.inject = inject;
+			dlist_insert_tail(&rx_entry->queued_entry,
+					  &ep->rx_entry_queued_list);
+		}
+
+		err = 0;
+	}
+
+	return err;
+}
+
+/*
+ *   Functions used to handle packet send completion
+ */
+static
+int rxr_send_completion_mr_dereg(struct rxr_tx_entry *tx_entry)
+{
+	int i, ret = 0;
+
+	for (i = tx_entry->iov_mr_start; i < tx_entry->iov_count; i++) {
+		if (tx_entry->mr[i]) {
+			ret = fi_close((struct fid *)tx_entry->mr[i]);
+			if (OFI_UNLIKELY(ret))
+				return ret;
+		}
+	}
+	return ret;
+}
+
+void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *comp)
+{
+	struct rxr_pkt_entry *pkt_entry;
+	struct rxr_tx_entry *tx_entry = NULL;
+	struct rxr_peer *peer;
+	struct rxr_rts_hdr *rts_hdr = NULL;
+	struct rxr_readrsp_hdr *readrsp_hdr = NULL;
+	uint32_t tx_id;
+	int ret;
+
+	pkt_entry = (struct rxr_pkt_entry *)comp->op_context;
+	assert(rxr_get_base_hdr(pkt_entry->pkt)->version ==
+	       RXR_PROTOCOL_VERSION);
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+
+	switch (rxr_get_base_hdr(pkt_entry->pkt)->type) {
+	case RXR_RTS_PKT:
+		/*
+		 * for FI_READ, it is possible (though does not happen very offen) that at the point
+		 * tx_entry has been released. The reason is, for FI_READ:
+		 *     1. only the initator side will send a RTS.
+		 *     2. the initator side will receive data packet. When all data was received,
+		 *        it will release the tx_entry
+		 * Therefore, if it so happens that all data was received before we got the send
+		 * completion notice, we will have a released tx_entry at this point.
+		 * Nonetheless, because for FI_READ tx_entry will be release in rxr_handle_rx_completion,
+		 * we will ignore it here.
+		 *
+		 * For shm provider, we will write completion for small & medium  message, as data has
+		 * been sent in the RTS packet; for large message, will wait for the EOR packet
+		 */
+		rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+		if (!(rts_hdr->flags & RXR_READ_REQ)) {
+			tx_id = rts_hdr->tx_id;
+			tx_entry = ofi_bufpool_get_ibuf(ep->tx_entry_pool, tx_id);
+			tx_entry->bytes_acked += rxr_get_rts_data_size(ep, rts_hdr);
+		}
+		break;
+	case RXR_CONNACK_PKT:
+		break;
+	case RXR_CTS_PKT:
+		break;
+	case RXR_DATA_PKT:
+		tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+		tx_entry->bytes_acked +=
+			rxr_get_data_pkt(pkt_entry->pkt)->hdr.seg_size;
+		break;
+	case RXR_READRSP_PKT:
+		readrsp_hdr = rxr_get_readrsp_hdr(pkt_entry->pkt);
+		tx_id = readrsp_hdr->tx_id;
+		tx_entry = ofi_bufpool_get_ibuf(ep->readrsp_tx_entry_pool, tx_id);
+		assert(tx_entry->cq_entry.flags & FI_READ);
+		tx_entry->bytes_acked += readrsp_hdr->seg_size;
+		break;
+	case RXR_RMA_CONTEXT_PKT:
+		rxr_pkt_handle_rma_context_send_completion(ep, pkt_entry);
+		return;
+	default:
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"invalid control pkt type %d\n",
+			rxr_get_base_hdr(pkt_entry->pkt)->type);
+		assert(0 && "invalid control pkt type");
+		rxr_cq_handle_cq_error(ep, -FI_EIO);
+		return;
+	}
+
+	if (tx_entry && tx_entry->total_len == tx_entry->bytes_acked) {
+		if (tx_entry->state == RXR_TX_SEND)
+			dlist_remove(&tx_entry->entry);
+		if (tx_entry->state == RXR_TX_SEND &&
+		    efa_mr_cache_enable && rxr_ep_mr_local(ep)) {
+			ret = rxr_send_completion_mr_dereg(tx_entry);
+			if (OFI_UNLIKELY(ret)) {
+				FI_WARN(&rxr_prov, FI_LOG_MR,
+					"In-line memory deregistration failed with error: %s.\n",
+					fi_strerror(-ret));
+			}
+		}
+
+		peer->tx_credits += tx_entry->credit_allocated;
+
+		if (tx_entry->cq_entry.flags & FI_READ) {
+			/*
+			 * this must be on remote side
+			 * see explaination on rxr_cq_handle_rx_completion
+			 */
+			struct rxr_rx_entry *rx_entry = NULL;
+
+			rx_entry = ofi_bufpool_get_ibuf(ep->rx_entry_pool, tx_entry->rma_loc_rx_id);
+			assert(rx_entry);
+			assert(rx_entry->state == RXR_RX_WAIT_READ_FINISH);
+
+			if (ep->util_ep.caps & FI_RMA_EVENT) {
+				rx_entry->cq_entry.len = rx_entry->total_len;
+				rx_entry->bytes_done = rx_entry->total_len;
+				efa_cntr_report_rx_completion(&ep->util_ep, rx_entry->cq_entry.flags);
+			}
+
+			rxr_release_rx_entry(ep, rx_entry);
+			/* just release tx, do not write completion */
+			rxr_release_tx_entry(ep, tx_entry);
+		} else if (tx_entry->cq_entry.flags & FI_WRITE) {
+			if (tx_entry->fi_flags & FI_COMPLETION) {
+				rxr_cq_write_tx_completion(ep, tx_entry);
+			} else {
+				efa_cntr_report_tx_completion(&ep->util_ep, tx_entry->cq_entry.flags);
+				rxr_release_tx_entry(ep, tx_entry);
+			}
+		} else {
+			assert(tx_entry->cq_entry.flags & FI_SEND);
+			rxr_cq_write_tx_completion(ep, tx_entry);
+		}
+	}
+
+	rxr_pkt_entry_release_tx(ep, pkt_entry);
+	if (!peer->is_local)
+		rxr_ep_dec_tx_pending(ep, peer, 0);
+}
+
+/*
+ *  Functions used to handle packet receive completion
+ */
+static
+fi_addr_t rxr_pkt_insert_addr_from_rts(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+	int i, ret;
+	void *raw_address;
+	fi_addr_t rdm_addr;
+	struct rxr_rts_hdr *rts_hdr;
+	struct efa_ep *efa_ep;
+
+	assert(rxr_get_base_hdr(pkt_entry->pkt)->type == RXR_RTS_PKT);
+
+	efa_ep = container_of(ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+	assert(rts_hdr->flags & RXR_REMOTE_SRC_ADDR);
+	assert(rts_hdr->addrlen > 0);
+	if (rxr_get_base_hdr(pkt_entry->pkt)->version !=
+	    RXR_PROTOCOL_VERSION) {
+		char buffer[ep->core_addrlen * 3];
+		int length = 0;
+
+		for (i = 0; i < ep->core_addrlen; i++)
+			length += sprintf(&buffer[length], "%02x ",
+					  ep->core_addr[i]);
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"Host %s:Invalid protocol version %d. Expected protocol version %d.\n",
+			buffer,
+			rxr_get_base_hdr(pkt_entry->pkt)->version,
+			RXR_PROTOCOL_VERSION);
+		efa_eq_write_error(&ep->util_ep, FI_EIO, -FI_EINVAL);
+		fprintf(stderr, "Invalid protocol version %d. Expected protocol version %d. %s:%d\n",
+			rxr_get_base_hdr(pkt_entry->pkt)->version,
+			RXR_PROTOCOL_VERSION, __FILE__, __LINE__);
+		abort();
+	}
+
+	raw_address = (rts_hdr->flags & RXR_REMOTE_CQ_DATA) ?
+		      rxr_get_ctrl_cq_pkt(rts_hdr)->data
+		      : rxr_get_ctrl_pkt(rts_hdr)->data;
+
+	ret = efa_av_insert_addr(efa_ep->av, (struct efa_ep_addr *)raw_address,
+				 &rdm_addr, 0, NULL);
+	if (OFI_UNLIKELY(ret != 0)) {
+		efa_eq_write_error(&ep->util_ep, FI_EINVAL, ret);
+		return -1;
+	}
+
+	return rdm_addr;
+}
+
+void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
+				    struct fi_cq_data_entry *cq_entry,
+				    fi_addr_t src_addr)
+{
+	struct rxr_peer *peer;
+	struct rxr_pkt_entry *pkt_entry;
+
+	pkt_entry = (struct rxr_pkt_entry *)cq_entry->op_context;
+
+#if ENABLE_DEBUG
+	dlist_remove(&pkt_entry->dbg_entry);
+	dlist_insert_tail(&pkt_entry->dbg_entry, &ep->rx_pkt_list);
+#ifdef ENABLE_RXR_PKT_DUMP
+	rxr_ep_print_pkt("Received", ep, (struct rxr_base_hdr *)pkt_entry->pkt);
+#endif
+#endif
+	if (OFI_UNLIKELY(src_addr == FI_ADDR_NOTAVAIL))
+		pkt_entry->addr = rxr_pkt_insert_addr_from_rts(ep, pkt_entry);
+	else
+		pkt_entry->addr = src_addr;
+
+	assert(rxr_get_base_hdr(pkt_entry->pkt)->version ==
+	       RXR_PROTOCOL_VERSION);
+
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+
+	if (rxr_env.enable_shm_transfer && peer->is_local)
+		ep->posted_bufs_shm--;
+	else
+		ep->posted_bufs_efa--;
+
+	switch (rxr_get_base_hdr(pkt_entry->pkt)->type) {
+	case RXR_RTS_PKT:
+		rxr_pkt_handle_rts_recv(ep, pkt_entry);
+		return;
+	case RXR_EOR_PKT:
+		rxr_pkt_handle_eor_recv(ep, pkt_entry);
+		return;
+	case RXR_CONNACK_PKT:
+		rxr_pkt_handle_connack_recv(ep, cq_entry, pkt_entry, src_addr);
+		return;
+	case RXR_CTS_PKT:
+		rxr_pkt_handle_cts_recv(ep, cq_entry, pkt_entry);
+		return;
+	case RXR_DATA_PKT:
+		rxr_pkt_handle_data_recv(ep, pkt_entry);
+		return;
+	case RXR_READRSP_PKT:
+		rxr_pkt_handle_readrsp_recv(ep, cq_entry, pkt_entry);
+		return;
+	default:
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"invalid control pkt type %d\n",
+			rxr_get_base_hdr(pkt_entry->pkt)->type);
+		assert(0 && "invalid control pkt type");
+		rxr_cq_handle_cq_error(ep, -FI_EIO);
+		return;
+	}
+}
+
+#if ENABLE_DEBUG
+
+/*
+ *  Functions used to dump packets
+ */
+
+#define RXR_PKT_DUMP_DATA_LEN 64
+
+static
+void rxr_pkt_print_rts(struct rxr_ep *ep,
+		       char *prefix, struct rxr_rts_hdr *rts_hdr)
+{
+	char str[RXR_PKT_DUMP_DATA_LEN * 4];
+	size_t str_len = RXR_PKT_DUMP_DATA_LEN * 4, l;
+	uint8_t *src;
+	uint8_t *data;
+	int i;
+
+	str[str_len - 1] = '\0';
+
+	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
+	       "%s RxR RTS packet - version: %"	PRIu8
+	       " flags: %"	PRIu16
+	       " tx_id: %"	PRIu32
+	       " msg_id: %"	PRIu32
+	       " tag: %lx data_len: %"	PRIu64 "\n",
+	       prefix, rts_hdr->version, rts_hdr->flags, rts_hdr->tx_id,
+	       rts_hdr->msg_id, rts_hdr->tag, rts_hdr->data_len);
+
+	if ((rts_hdr->flags & RXR_REMOTE_CQ_DATA) &&
+	    (rts_hdr->flags & RXR_REMOTE_SRC_ADDR)) {
+		src = (uint8_t *)((struct rxr_ctrl_cq_pkt *)rts_hdr)->data;
+		data = src + rts_hdr->addrlen;
+	} else if (!(rts_hdr->flags & RXR_REMOTE_CQ_DATA) &&
+		   (rts_hdr->flags & RXR_REMOTE_SRC_ADDR)) {
+		src = (uint8_t *)((struct rxr_ctrl_pkt *)rts_hdr)->data;
+		data = src + rts_hdr->addrlen;
+	} else if ((rts_hdr->flags & RXR_REMOTE_CQ_DATA) &&
+		   !(rts_hdr->flags & RXR_REMOTE_SRC_ADDR)) {
+		data = (uint8_t *)((struct rxr_ctrl_cq_pkt *)rts_hdr)->data;
+	} else {
+		data = (uint8_t *)((struct rxr_ctrl_pkt *)rts_hdr)->data;
+	}
+
+	if (rts_hdr->flags & RXR_REMOTE_CQ_DATA)
+		FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
+		       "\tcq_data: %08lx\n",
+		       ((struct rxr_ctrl_cq_hdr *)rts_hdr)->cq_data);
+
+	if (rts_hdr->flags & RXR_REMOTE_SRC_ADDR) {
+		l = snprintf(str, str_len, "\tsrc_addr: ");
+		for (i = 0; i < rts_hdr->addrlen; i++)
+			l += snprintf(str + l, str_len - l, "%02x ", src[i]);
+		FI_DBG(&rxr_prov, FI_LOG_EP_DATA, "%s\n", str);
+	}
+
+	l = snprintf(str, str_len, ("\tdata:    "));
+	for (i = 0; i < MIN(rxr_get_rts_data_size(ep, rts_hdr),
+			    RXR_PKT_DUMP_DATA_LEN); i++)
+		l += snprintf(str + l, str_len - l, "%02x ", data[i]);
+	FI_DBG(&rxr_prov, FI_LOG_EP_DATA, "%s\n", str);
+}
+
+static
+void rxr_pkt_print_connack(char *prefix,
+			   struct rxr_connack_hdr *connack_hdr)
+{
+	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
+	       "%s RxR CONNACK packet - version: %" PRIu8
+	       " flags: %x\n", prefix, connack_hdr->version,
+	       connack_hdr->flags);
+}
+
+static
+void rxr_pkt_print_cts(char *prefix, struct rxr_cts_hdr *cts_hdr)
+{
+	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
+	       "%s RxR CTS packet - version: %"	PRIu8
+	       " flags: %x tx_id: %" PRIu32
+	       " rx_id: %"	   PRIu32
+	       " window: %"	   PRIu64
+	       "\n", prefix, cts_hdr->version, cts_hdr->flags,
+	       cts_hdr->tx_id, cts_hdr->rx_id, cts_hdr->window);
+}
+
+static
+void rxr_pkt_print_data(char *prefix, struct rxr_data_pkt *data_pkt)
+{
+	char str[RXR_PKT_DUMP_DATA_LEN * 4];
+	size_t str_len = RXR_PKT_DUMP_DATA_LEN * 4, l;
+	int i;
+
+	str[str_len - 1] = '\0';
+
+	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
+	       "%s RxR DATA packet -  version: %" PRIu8
+	       " flags: %x rx_id: %" PRIu32
+	       " seg_size: %"	     PRIu64
+	       " seg_offset: %"	     PRIu64
+	       "\n", prefix, data_pkt->hdr.version, data_pkt->hdr.flags,
+	       data_pkt->hdr.rx_id, data_pkt->hdr.seg_size,
+	       data_pkt->hdr.seg_offset);
+
+	l = snprintf(str, str_len, ("\tdata:    "));
+	for (i = 0; i < MIN(data_pkt->hdr.seg_size, RXR_PKT_DUMP_DATA_LEN);
+	     i++)
+		l += snprintf(str + l, str_len - l, "%02x ",
+			      ((uint8_t *)data_pkt->data)[i]);
+	FI_DBG(&rxr_prov, FI_LOG_EP_DATA, "%s\n", str);
+}
+
+void rxr_pkt_print(char *prefix, struct rxr_ep *ep, struct rxr_base_hdr *hdr)
+{
+	switch (hdr->type) {
+	case RXR_RTS_PKT:
+		rxr_pkt_print_rts(ep, prefix, (struct rxr_rts_hdr *)hdr);
+		break;
+	case RXR_CONNACK_PKT:
+		rxr_pkt_print_connack(prefix, (struct rxr_connack_hdr *)hdr);
+		break;
+	case RXR_CTS_PKT:
+		rxr_pkt_print_cts(prefix, (struct rxr_cts_hdr *)hdr);
+		break;
+	case RXR_DATA_PKT:
+		rxr_pkt_print_data(prefix, (struct rxr_data_pkt *)hdr);
+		break;
+	default:
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "invalid ctl pkt type %d\n",
+			rxr_get_base_hdr(hdr)->type);
+		assert(0);
+		return;
+	}
+}
+#endif
+

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -30,41 +30,36 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#if HAVE_CONFIG_H
-#include <config.h>
-#endif /* HAVE_CONFIG_H */
 
-#ifndef _RXR_RMA_H_
-#define _RXR_RMA_H_
+#ifndef _RXR_PKT_CMD_H
+#define _RXR_PKT_CMD_H
 
-#include <rdma/fi_rma.h>
+struct rxr_ep;
 
-int rxr_rma_verified_copy_iov(struct rxr_ep *ep, struct fi_rma_iov *rma,
-			      size_t count, uint32_t flags, struct iovec *iov);
+struct rxr_tx_entry;
 
-/* read response related functions */
-struct rxr_tx_entry *
-rxr_rma_alloc_readrsp_tx_entry(struct rxr_ep *rxr_ep,
-			       struct rxr_rx_entry *rx_entry);
+ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry);
 
-int rxr_rma_init_readrsp_pkt(struct rxr_ep *ep,
-			     struct rxr_tx_entry *tx_entry,
-			     struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_post_ctrl(struct rxr_ep *ep, int entry_type, void *x_entry,
+			  int ctrl_type, bool inject);
 
-void rxr_rma_handle_readrsp_sent(struct rxr_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry,
+				   int ctrl_type, bool inject);
 
-/* EOR related functions */
-int rxr_rma_init_eor_pkt(struct rxr_ep *ep,
-			 struct rxr_rx_entry *rx_entry,
-			 struct rxr_pkt_entry *pkt_entry);
+void rxr_pkt_handle_send_completion(struct rxr_ep *ep,
+				    struct fi_cq_data_entry *cq_entry);
 
-void rxr_rma_handle_eor_sent(struct rxr_ep *ep,
-			     struct rxr_pkt_entry *pkt_entry);
+void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
+				    struct fi_cq_data_entry *cq_entry,
+				    fi_addr_t src_addr);
 
-size_t rxr_rma_post_shm_rma(struct rxr_ep *rxr_ep,
-			    struct rxr_tx_entry *tx_entry);
+#if ENABLE_DEBUG
+struct rxr_base_hdr;
 
-extern struct fi_ops_rma rxr_ops_rma;
+void rxr_pkt_print(char *prefix,
+		   struct rxr_ep *ep,
+		   struct rxr_base_hdr *hdr);
+#endif
 
 #endif
+

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <inttypes.h>
+#include <stdlib.h>
+#include <string.h>
+#include "ofi.h"
+#include <ofi_util.h>
+#include <ofi_iov.h>
+
+#include "rxr.h"
+#include "efa.h"
+#include "rxr_msg.h"
+#include "rxr_rma.h"
+
+/*
+ *   General purpose utility functions
+ */
+struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep,
+					  struct ofi_bufpool *pkt_pool)
+{
+	struct rxr_pkt_entry *pkt_entry;
+	void *mr = NULL;
+
+	pkt_entry = ofi_buf_alloc_ex(pkt_pool, &mr);
+	if (!pkt_entry)
+		return NULL;
+#ifdef ENABLE_EFA_POISONING
+	memset(pkt_entry, 0, sizeof(*pkt_entry));
+#endif
+	dlist_init(&pkt_entry->entry);
+#if ENABLE_DEBUG
+	dlist_init(&pkt_entry->dbg_entry);
+#endif
+	pkt_entry->mr = (struct fid_mr *)mr;
+	pkt_entry->pkt = (struct rxr_pkt *)((char *)pkt_entry +
+			  sizeof(*pkt_entry));
+#ifdef ENABLE_EFA_POISONING
+	memset(pkt_entry->pkt, 0, ep->mtu_size);
+#endif
+	pkt_entry->state = RXR_PKT_ENTRY_IN_USE;
+
+	return pkt_entry;
+}
+
+void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt)
+{
+	struct rxr_peer *peer;
+
+#if ENABLE_DEBUG
+	dlist_remove(&pkt->dbg_entry);
+#endif
+	/*
+	 * Decrement rnr_queued_pkts counter and reset backoff for this peer if
+	 * we get a send completion for a retransmitted packet.
+	 */
+	if (OFI_UNLIKELY(pkt->state == RXR_PKT_ENTRY_RNR_RETRANSMIT)) {
+		peer = rxr_ep_get_peer(ep, pkt->addr);
+		peer->rnr_queued_pkt_cnt--;
+		peer->timeout_interval = 0;
+		peer->rnr_timeout_exp = 0;
+		if (peer->rnr_state & RXR_PEER_IN_BACKOFF)
+			dlist_remove(&peer->rnr_entry);
+		peer->rnr_state = 0;
+		FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
+		       "reset backoff timer for peer: %" PRIu64 "\n",
+		       pkt->addr);
+	}
+#ifdef ENABLE_EFA_POISONING
+	rxr_poison_mem_region((uint32_t *)pkt, ep->tx_pkt_pool_entry_sz);
+#endif
+	pkt->state = RXR_PKT_ENTRY_FREE;
+	ofi_buf_free(pkt);
+}
+
+void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt_entry)
+{
+	if (pkt_entry->type == RXR_PKT_ENTRY_POSTED) {
+		struct rxr_peer *peer;
+
+		peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+		assert(peer);
+		if (peer->is_local)
+			ep->rx_bufs_shm_to_post++;
+		else
+			ep->rx_bufs_efa_to_post++;
+	}
+#if ENABLE_DEBUG
+	dlist_remove(&pkt_entry->dbg_entry);
+#endif
+#ifdef ENABLE_EFA_POISONING
+	/* the same pool size is used for all types of rx pkt_entries */
+	rxr_poison_mem_region((uint32_t *)pkt_entry, ep->rx_pkt_pool_entry_sz);
+#endif
+	pkt_entry->state = RXR_PKT_ENTRY_FREE;
+	ofi_buf_free(pkt_entry);
+}
+
+void rxr_pkt_entry_copy(struct rxr_ep *ep,
+			struct rxr_pkt_entry *dest,
+			struct rxr_pkt_entry *src,
+			enum rxr_pkt_entry_type type)
+{
+	FI_DBG(&rxr_prov, FI_LOG_EP_CTRL,
+	       "Copying packet (type %d) out of posted buffer\n", type);
+	assert(src->type == RXR_PKT_ENTRY_POSTED);
+	memcpy(dest, src, sizeof(struct rxr_pkt_entry));
+	dest->pkt = (struct rxr_pkt *)((char *)dest + sizeof(*dest));
+	memcpy(dest->pkt, src->pkt, ep->mtu_size);
+	dest->type = type;
+	dlist_init(&dest->entry);
+#if ENABLE_DEBUG
+	dlist_init(&dest->dbg_entry);
+#endif
+	dest->state = RXR_PKT_ENTRY_IN_USE;
+}
+
+/*
+ *   Utility functions used to send pkt over wire
+ */
+static inline
+ssize_t rxr_pkt_entry_sendmsg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
+			      const struct fi_msg *msg, uint64_t flags)
+{
+	struct rxr_peer *peer;
+	size_t ret;
+
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(ep->tx_pending <= ep->max_outstanding_tx);
+
+	if (ep->tx_pending == ep->max_outstanding_tx)
+		return -FI_EAGAIN;
+
+	if (peer->rnr_state & RXR_PEER_IN_BACKOFF)
+		return -FI_EAGAIN;
+
+#if ENABLE_DEBUG
+	dlist_insert_tail(&pkt_entry->dbg_entry, &ep->tx_pkt_list);
+#ifdef ENABLE_RXR_PKT_DUMP
+	rxr_pkt_print("Sent", ep, (struct rxr_base_hdr *)pkt_entry->pkt);
+#endif
+#endif
+	if (rxr_env.enable_shm_transfer && peer->is_local) {
+		ret = fi_sendmsg(ep->shm_ep, msg, flags);
+	} else {
+		ret = fi_sendmsg(ep->rdm_ep, msg, flags);
+		if (OFI_LIKELY(!ret))
+			rxr_ep_inc_tx_pending(ep, peer);
+	}
+
+	return ret;
+}
+
+ssize_t rxr_pkt_entry_sendv(struct rxr_ep *ep,
+			    struct rxr_pkt_entry *pkt_entry,
+			    fi_addr_t addr, const struct iovec *iov,
+			    void **desc, size_t count, uint64_t flags)
+{
+	struct fi_msg msg;
+	struct rxr_peer *peer;
+
+	msg.msg_iov = iov;
+	msg.desc = desc;
+	msg.iov_count = count;
+	peer = rxr_ep_get_peer(ep, addr);
+	msg.addr = peer->is_local ? peer->shm_fiaddr : addr;
+	msg.context = pkt_entry;
+	msg.data = 0;
+
+	return rxr_pkt_entry_sendmsg(ep, pkt_entry, &msg, flags);
+}
+
+/* rxr_pkt_start currently expects data pkt right after pkt hdr */
+ssize_t rxr_pkt_entry_send_with_flags(struct rxr_ep *ep,
+				      struct rxr_pkt_entry *pkt_entry,
+				      fi_addr_t addr, uint64_t flags)
+{
+	struct iovec iov;
+	void *desc;
+
+	iov.iov_base = rxr_pkt_start(pkt_entry);
+	iov.iov_len = pkt_entry->pkt_size;
+
+	if (rxr_ep_get_peer(ep, addr)->is_local)
+		desc = NULL;
+	else
+		desc = rxr_ep_mr_local(ep) ? fi_mr_desc(pkt_entry->mr) : NULL;
+
+	return rxr_pkt_entry_sendv(ep, pkt_entry, addr, &iov, &desc, 1, flags);
+}
+
+ssize_t rxr_pkt_entry_send(struct rxr_ep *ep,
+			   struct rxr_pkt_entry *pkt_entry,
+			   fi_addr_t addr)
+{
+	return rxr_pkt_entry_send_with_flags(ep, pkt_entry, addr, 0);
+}
+
+ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry,
+			     fi_addr_t addr)
+{
+	struct rxr_peer *peer;
+
+	/* currently only EOR packet is injected using shm ep */
+	peer = rxr_ep_get_peer(ep, addr);
+	assert(peer);
+	assert(rxr_env.enable_shm_transfer && peer->is_local);
+	return fi_inject(ep->shm_ep, rxr_pkt_start(pkt_entry), pkt_entry->pkt_size,
+			 peer->shm_fiaddr);
+}

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _RXR_PKT_ENTRY_H
+#define _RXR_PKT_ENTRY_H
+
+#include <ofi_list.h>
+
+/* pkt_entry state for retransmit tracking */
+enum rxr_pkt_entry_state {
+	RXR_PKT_ENTRY_FREE = 0,
+	RXR_PKT_ENTRY_IN_USE,
+	RXR_PKT_ENTRY_RNR_RETRANSMIT,
+};
+
+/* pkt_entry types for rx pkts */
+enum rxr_pkt_entry_type {
+	RXR_PKT_ENTRY_POSTED = 1,   /* entries that are posted to the core */
+	RXR_PKT_ENTRY_UNEXP,        /* entries used to stage unexpected msgs */
+	RXR_PKT_ENTRY_OOO	    /* entries used to stage out-of-order RTS */
+};
+
+struct rxr_pkt_entry {
+	/* for rx/tx_entry queued_pkts list */
+	struct dlist_entry entry;
+#if ENABLE_DEBUG
+	/* for tx/rx debug list or posted buf list */
+	struct dlist_entry dbg_entry;
+#endif
+	void *x_entry; /* pointer to rxr rx/tx entry */
+	size_t pkt_size;
+	struct fid_mr *mr;
+	fi_addr_t addr;
+	void *pkt; /* rxr_ctrl_*_pkt, or rxr_data_pkt */
+	enum rxr_pkt_entry_type type;
+	enum rxr_pkt_entry_state state;
+#if ENABLE_DEBUG
+/* pad to cache line size of 64 bytes */
+	uint8_t pad[48];
+#endif
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+#if ENABLE_DEBUG
+static_assert(sizeof(struct rxr_pkt_entry) == 128, "rxr_pkt_entry check");
+#else
+static_assert(sizeof(struct rxr_pkt_entry) == 64, "rxr_pkt_entry check");
+#endif
+#endif
+
+OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf, uint32_t);
+DECLARE_FREESTACK(struct rxr_robuf, rxr_robuf_fs);
+
+struct rxr_ep;
+
+struct rxr_tx_entry;
+
+struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep,
+					  struct ofi_bufpool *pkt_pool);
+
+void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_entry_copy(struct rxr_ep *ep,
+			struct rxr_pkt_entry *dest,
+			struct rxr_pkt_entry *src,
+			enum rxr_pkt_entry_type type);
+
+ssize_t rxr_pkt_entry_send_with_flags(struct rxr_ep *ep,
+				      struct rxr_pkt_entry *pkt_entry,
+				      fi_addr_t addr, uint64_t flags);
+
+ssize_t rxr_pkt_entry_sendv(struct rxr_ep *ep,
+			    struct rxr_pkt_entry *pkt_entry,
+			    fi_addr_t addr, const struct iovec *iov,
+			    void **desc, size_t count, uint64_t flags);
+
+ssize_t rxr_pkt_entry_send(struct rxr_ep *ep,
+			   struct rxr_pkt_entry *pkt_entry,
+			   fi_addr_t addr);
+
+ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry,
+			     fi_addr_t addr);
+
+#endif
+

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -1,0 +1,346 @@
+/*
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _RXR_PKT_TYPE_H
+#define _RXR_PKT_TYPE_H
+
+/* This header file contain the ID of all RxR packet types, and
+ * the necessary data structures and functions for each packet type
+ *
+ * RxR packet types can be classified into 3 categories:
+ *     data packet, control packet and context packet
+ *
+ * For each packet type, the following items are needed:
+ *
+ *   First, each packet type need to define a struct for its header,
+ *       and the header must be start with ```struct rxr_base_hdr```.
+ *
+ *   Second, each control packet type need to define an init()
+ *       function and a handle_sent() function. These functions
+ *       are called by rxr_pkt_post_ctrl_or_queue().
+ *
+ *   Finally, each packet type (except context packet) need to
+ *     define a handle_recv() functions which is called by
+ *     rxr_pkt_handle_recv_completion().
+ */
+
+enum rxr_pkt_type {
+	RXR_RTS_PKT = 1,
+	RXR_CONNACK_PKT,
+	RXR_CTS_PKT,
+	RXR_DATA_PKT,
+	RXR_READRSP_PKT,
+	RXR_RMA_CONTEXT_PKT,
+	RXR_EOR_PKT,
+};
+
+/*
+ *  Packet fields common to all rxr packets. The other packet headers below must
+ *  be changed if this is updated.
+ */
+struct rxr_base_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_base_hdr) == 4, "rxr_base_hdr check");
+#endif
+
+static inline struct rxr_base_hdr *rxr_get_base_hdr(void *pkt)
+{
+	return (struct rxr_base_hdr *)pkt;
+}
+
+struct rxr_ep;
+struct rxr_peer;
+struct rxr_tx_entry;
+struct rxr_rx_entry;
+
+/*
+ *  RTS packet data structures and functions. the implementation of
+ *  these functions are in rxr_pkt_type_rts.c
+ */
+struct rxr_rts_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	/* TODO: need to add msg_id -> tx_id mapping to remove tx_id */
+	uint16_t credit_request;
+	uint8_t addrlen;
+	uint8_t rma_iov_count;
+	uint32_t tx_id;
+	uint32_t msg_id;
+	uint64_t tag;
+	uint64_t data_len;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_rts_hdr) == 32, "rxr_rts_hdr check");
+#endif
+
+static inline
+struct rxr_rts_hdr *rxr_get_rts_hdr(void *pkt)
+{
+	return (struct rxr_rts_hdr *)pkt;
+}
+
+uint64_t rxr_get_rts_data_size(struct rxr_ep *ep,
+			       struct rxr_rts_hdr *rts_hdr);
+
+ssize_t rxr_pkt_init_rts(struct rxr_ep *ep,
+			 struct rxr_tx_entry *tx_entry,
+			 struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_rts_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+ssize_t rxr_pkt_post_shm_read(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry);
+
+ssize_t rxr_pkt_proc_matched_msg_rts(struct rxr_ep *ep,
+				     struct rxr_rx_entry *rx_entry,
+				     struct rxr_pkt_entry *pkt_entry);
+
+ssize_t rxr_pkt_proc_rts(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_rts_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  CONNACK packet header and functions
+ *  implementation of the functions are in rxr_pkt_type_misc.c
+ */
+struct rxr_connack_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_connack_hdr) == 4, "rxr_connack_hdr check");
+#endif
+
+static inline
+struct rxr_connack_hdr *rxr_get_connack_hdr(void *pkt)
+{
+	return (struct rxr_connack_hdr *)pkt;
+}
+
+ssize_t rxr_pkt_init_connack(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry,
+			     fi_addr_t addr);
+
+void rxr_pkt_post_connack(struct rxr_ep *ep,
+			  struct rxr_peer *peer,
+			  fi_addr_t addr);
+
+void rxr_pkt_handle_connack_recv(struct rxr_ep *ep,
+				 struct fi_cq_data_entry *comp,
+				 struct rxr_pkt_entry *pkt_entry,
+				 fi_addr_t addr);
+/*
+ *  CTS packet data structures and functions.
+ *  Definition of the functions is in rxr_pkt_type_misc.c
+ */
+struct rxr_cts_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint8_t pad[4];
+	/* TODO: need to add msg_id -> tx_id/rx_id mapping */
+	uint32_t tx_id;
+	uint32_t rx_id;
+	uint64_t window;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_cts_hdr) == 24, "rxr_cts_hdr check");
+#endif
+
+static inline
+struct rxr_cts_hdr *rxr_get_cts_hdr(void *pkt)
+{
+	return (struct rxr_cts_hdr *)pkt;
+}
+
+ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
+			 struct rxr_rx_entry *rx_entry,
+			 struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_cts_sent(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_cts_recv(struct rxr_ep *ep,
+			     struct fi_cq_data_entry *comp,
+			     struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  DATA packet data structures and functions
+ *  Definition of the functions is in rxr_pkt_data.c
+ */
+struct rxr_data_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	/* TODO: need to add msg_id -> tx_id/rx_id mapping */
+	uint32_t rx_id;
+	uint64_t seg_size;
+	uint64_t seg_offset;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_data_hdr) == 24, "rxr_data_hdr check");
+#endif
+
+struct rxr_data_pkt {
+	struct rxr_data_hdr hdr;
+	char data[];
+};
+
+static inline
+struct rxr_data_pkt *rxr_get_data_pkt(void *pkt)
+{
+	return (struct rxr_data_pkt *)pkt;
+}
+
+ssize_t rxr_pkt_send_data(struct rxr_ep *ep,
+			  struct rxr_tx_entry *tx_entry,
+			  struct rxr_pkt_entry *pkt_entry);
+
+ssize_t rxr_pkt_send_data_mr_cache(struct rxr_ep *ep,
+				   struct rxr_tx_entry *tx_entry,
+				   struct rxr_pkt_entry *pkt_entry);
+
+int rxr_pkt_handle_data(struct rxr_ep *ep,
+			struct rxr_rx_entry *rx_entry,
+			struct rxr_pkt_entry *pkt_entry,
+			char *data, size_t seg_offset,
+			size_t seg_size);
+
+void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  READRSP packet data structures and functions
+ *  The definition of functions are in rxr_pkt_type_misc.c
+ */
+struct rxr_readrsp_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint8_t pad[4];
+	uint32_t rx_id;
+	uint32_t tx_id;
+	uint64_t seg_size;
+};
+
+static inline struct rxr_readrsp_hdr *rxr_get_readrsp_hdr(void *pkt)
+{
+	return (struct rxr_readrsp_hdr *)pkt;
+}
+
+#define RXR_READRSP_HDR_SIZE	(sizeof(struct rxr_readrsp_hdr))
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_readrsp_hdr) == sizeof(struct rxr_data_hdr), "rxr_readrsp_hdr check");
+#endif
+
+struct rxr_readrsp_pkt {
+	struct rxr_readrsp_hdr hdr;
+	char data[];
+};
+
+int rxr_pkt_init_readrsp(struct rxr_ep *ep,
+			 struct rxr_tx_entry *tx_entry,
+			 struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep,
+				 struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_readrsp_recv(struct rxr_ep *ep,
+				 struct fi_cq_data_entry *comp,
+				 struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  RMA context packet, used to differentiate the normal RMA read, normal RMA
+ *  write, and the RMA read in two-sided large message transfer
+ *  Implementation of the function is in rxr_pkt_type_misc.c
+ */
+struct rxr_rma_context_pkt {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t tx_id;
+	uint8_t rma_context_type;
+};
+
+void rxr_pkt_handle_rma_context_send_completion(struct rxr_ep *ep,
+						struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  EOR packet, used to acknowledge the sender that large message
+ *  copy has been finished.
+ *  Implementaion of the functions are in rxr_pkt_misc.c
+ */
+struct rxr_eor_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t tx_id;
+	uint32_t rx_id;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_eor_hdr) == 12, "rxr_eor_hdr check");
+#endif
+
+int rxr_pkt_init_eor(struct rxr_ep *ep,
+		     struct rxr_rx_entry *rx_entry,
+		     struct rxr_pkt_entry *pkt_entry);
+
+static inline
+void rxr_pkt_handle_eor_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+}
+
+void rxr_pkt_handle_eor_recv(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry);
+
+#endif
+

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -1,0 +1,301 @@
+/*
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "rxr.h"
+#include "rxr_msg.h"
+
+/*
+ * This function contains data packet related functions
+ * Data packet is used by long message protocol.
+ */
+
+/*
+ * Functions to send data packet, including
+ */
+
+ssize_t rxr_pkt_send_data(struct rxr_ep *ep,
+			  struct rxr_tx_entry *tx_entry,
+			  struct rxr_pkt_entry *pkt_entry)
+{
+	uint64_t payload_size;
+	struct rxr_data_pkt *data_pkt;
+
+	pkt_entry->x_entry = (void *)tx_entry;
+	pkt_entry->addr = tx_entry->addr;
+
+	payload_size = MIN(tx_entry->total_len - tx_entry->bytes_sent,
+			   ep->max_data_payload_size);
+	payload_size = MIN(payload_size, tx_entry->window);
+
+	data_pkt = (struct rxr_data_pkt *)pkt_entry->pkt;
+	data_pkt->hdr.seg_size = payload_size;
+
+	pkt_entry->pkt_size = ofi_copy_from_iov(data_pkt->data,
+						payload_size,
+						tx_entry->iov,
+						tx_entry->iov_count,
+						tx_entry->bytes_sent);
+	assert(pkt_entry->pkt_size == payload_size);
+
+	pkt_entry->pkt_size += RXR_DATA_HDR_SIZE;
+	pkt_entry->addr = tx_entry->addr;
+
+	return rxr_pkt_entry_send_with_flags(ep, pkt_entry, pkt_entry->addr,
+					     tx_entry->send_flags);
+}
+
+/*
+ * Copies all consecutive small iov's into one buffer. If the function reaches
+ * an iov greater than the max memcpy size, it will end, only copying up to
+ * that iov.
+ */
+static size_t rxr_copy_from_iov(void *buf, uint64_t remaining_len,
+				struct rxr_tx_entry *tx_entry)
+{
+	struct iovec *tx_iov = tx_entry->iov;
+	uint64_t done = 0, len;
+
+	while (tx_entry->iov_index < tx_entry->iov_count &&
+	       done < remaining_len) {
+		len = tx_iov[tx_entry->iov_index].iov_len;
+		if (tx_entry->mr[tx_entry->iov_index])
+			break;
+
+		len -= tx_entry->iov_offset;
+
+		/*
+		 * If the amount to be written surpasses the remaining length,
+		 * copy up to the remaining length and return, else copy the
+		 * entire iov and continue.
+		 */
+		if (done + len > remaining_len) {
+			len = remaining_len - done;
+			memcpy((char *)buf + done,
+			       (char *)tx_iov[tx_entry->iov_index].iov_base +
+			       tx_entry->iov_offset, len);
+			tx_entry->iov_offset += len;
+			done += len;
+			break;
+		}
+		memcpy((char *)buf + done,
+		       (char *)tx_iov[tx_entry->iov_index].iov_base +
+		       tx_entry->iov_offset, len);
+		tx_entry->iov_index++;
+		tx_entry->iov_offset = 0;
+		done += len;
+	}
+	return done;
+}
+
+ssize_t rxr_pkt_send_data_mr_cache(struct rxr_ep *ep,
+				   struct rxr_tx_entry *tx_entry,
+				   struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_data_pkt *data_pkt;
+	/* The user's iov */
+	struct iovec *tx_iov = tx_entry->iov;
+	/* The constructed iov to be passed to sendv
+	 * and corresponding fid_mrs
+	 */
+	struct iovec iov[ep->core_iov_limit];
+	void *desc[ep->core_iov_limit];
+	/* Constructed iov's total size */
+	uint64_t payload_size = 0;
+	/* pkt_entry offset to write data into */
+	uint64_t pkt_used = 0;
+	/* Remaining size that can fit in the constructed iov */
+	uint64_t remaining_len = MIN(tx_entry->window,
+				     ep->max_data_payload_size);
+	/* The constructed iov's index */
+	size_t i = 0;
+	size_t len = 0;
+
+	ssize_t ret;
+
+	data_pkt = (struct rxr_data_pkt *)pkt_entry->pkt;
+	/* Assign packet header in constructed iov */
+	iov[i].iov_base = rxr_pkt_start(pkt_entry);
+	iov[i].iov_len = RXR_DATA_HDR_SIZE;
+	desc[i] = rxr_ep_mr_local(ep) ? fi_mr_desc(pkt_entry->mr) : NULL;
+	i++;
+
+	/*
+	 * Loops until payload size is at max, all user iovs are sent, the
+	 * constructed iov count is greater than the core iov limit, or the tx
+	 * entry window is exhausted.  Each iteration fills one entry of the
+	 * iov to be sent.
+	 */
+	while (tx_entry->iov_index < tx_entry->iov_count &&
+	       remaining_len > 0 && i < ep->core_iov_limit) {
+		if (!rxr_ep_mr_local(ep) ||
+		    /* from the inline registration post-RTS */
+		    tx_entry->mr[tx_entry->iov_index] ||
+		    /* from application-provided descriptor */
+		    tx_entry->desc[tx_entry->iov_index]) {
+			iov[i].iov_base =
+				(char *)tx_iov[tx_entry->iov_index].iov_base +
+				tx_entry->iov_offset;
+			if (rxr_ep_mr_local(ep))
+				desc[i] = tx_entry->desc[tx_entry->iov_index] ?
+					  tx_entry->desc[tx_entry->iov_index] :
+					  fi_mr_desc(tx_entry->mr[tx_entry->iov_index]);
+
+			len = tx_iov[tx_entry->iov_index].iov_len
+			      - tx_entry->iov_offset;
+			if (len > remaining_len) {
+				len = remaining_len;
+				tx_entry->iov_offset += len;
+			} else {
+				tx_entry->iov_index++;
+				tx_entry->iov_offset = 0;
+			}
+			iov[i].iov_len = len;
+		} else {
+			/*
+			 * Copies any consecutive small iov's, returning size
+			 * written while updating iov index and offset
+			 */
+			len = rxr_copy_from_iov((char *)data_pkt->data +
+						 pkt_used,
+						 remaining_len,
+						 tx_entry);
+
+			iov[i].iov_base = (char *)data_pkt->data + pkt_used;
+			iov[i].iov_len = len;
+			desc[i] = fi_mr_desc(pkt_entry->mr);
+			pkt_used += len;
+		}
+		payload_size += len;
+		remaining_len -= len;
+		i++;
+	}
+	data_pkt->hdr.seg_size = (uint16_t)payload_size;
+	pkt_entry->pkt_size = payload_size + RXR_DATA_HDR_SIZE;
+	pkt_entry->addr = tx_entry->addr;
+
+	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
+	       "Sending an iov count, %zu with payload size: %lu.\n",
+	       i, payload_size);
+	ret = rxr_pkt_entry_sendv(ep, pkt_entry, tx_entry->addr,
+				  (const struct iovec *)iov,
+				  desc, i, tx_entry->send_flags);
+	return ret;
+}
+
+/*
+ *  rxr_pkt_handle_data_recv() and related functions
+ */
+int rxr_pkt_handle_data(struct rxr_ep *ep,
+			struct rxr_rx_entry *rx_entry,
+			struct rxr_pkt_entry *pkt_entry,
+			char *data, size_t seg_offset,
+			size_t seg_size)
+{
+	struct rxr_peer *peer;
+	int64_t bytes_left, bytes_copied;
+	ssize_t ret = 0;
+
+#if ENABLE_DEBUG
+	int pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+
+	assert(pkt_type == RXR_DATA_PKT || pkt_type == RXR_READRSP_PKT);
+#endif
+	/* we are sinking message for CANCEL/DISCARD entry */
+	if (OFI_LIKELY(!(rx_entry->rxr_flags & RXR_RECV_CANCEL)) &&
+	    rx_entry->cq_entry.len > seg_offset) {
+		bytes_copied = ofi_copy_to_iov(rx_entry->iov, rx_entry->iov_count,
+					       seg_offset, data, seg_size);
+		if (bytes_copied != MIN(seg_size, rx_entry->cq_entry.len - seg_offset)) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ, "wrong size! bytes_copied: %ld\n",
+				bytes_copied);
+			if (rxr_cq_handle_rx_error(ep, rx_entry, -FI_EINVAL))
+				assert(0 && "error writing error cq entry for EOR\n");
+		}
+	}
+
+	rx_entry->bytes_done += seg_size;
+
+	peer = rxr_ep_get_peer(ep, rx_entry->addr);
+	peer->rx_credits += ofi_div_ceil(seg_size, ep->max_data_payload_size);
+
+	rx_entry->window -= seg_size;
+	if (ep->available_data_bufs < rxr_get_rx_pool_chunk_cnt(ep))
+		ep->available_data_bufs++;
+
+	/* bytes_done is total bytes sent/received, which could be larger than
+	 * to bytes copied to recv buffer (for truncated messages).
+	 * rx_entry->total_len is from rts_hdr and is the size of send buffer,
+	 * thus we always have:
+	 *             rx_entry->total >= rx_entry->bytes_done
+	 */
+	bytes_left = rx_entry->total_len - rx_entry->bytes_done;
+	assert(bytes_left >= 0);
+	if (!bytes_left) {
+#if ENABLE_DEBUG
+		dlist_remove(&rx_entry->rx_pending_entry);
+		ep->rx_pending--;
+#endif
+		rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
+
+		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
+		rxr_release_rx_entry(ep, rx_entry);
+		return 0;
+	}
+
+	if (!rx_entry->window) {
+		assert(rx_entry->state == RXR_RX_RECV);
+		ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
+	}
+
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	return ret;
+}
+
+void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_data_pkt *data_pkt;
+	struct rxr_rx_entry *rx_entry;
+
+	data_pkt = (struct rxr_data_pkt *)pkt_entry->pkt;
+
+	rx_entry = ofi_bufpool_get_ibuf(ep->rx_entry_pool,
+					data_pkt->hdr.rx_id);
+
+	rxr_pkt_handle_data(ep, rx_entry,
+			    pkt_entry,
+			    data_pkt->data,
+			    data_pkt->hdr.seg_offset,
+			    data_pkt->hdr.seg_size);
+}
+

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa.h"
+#include "rxr.h"
+#include "rxr_msg.h"
+#include "rxr_cntr.h"
+
+/* This file define functons for the following packet type:
+ *       CONNACK
+ *       CTS
+ *       READRSP
+ *       RMA_CONTEXT
+ *       EOR
+ */
+
+/*  CONNACK packet related functions */
+ssize_t rxr_pkt_init_connack(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry,
+			     fi_addr_t addr)
+{
+	struct rxr_connack_hdr *connack_hdr;
+
+	connack_hdr = (struct rxr_connack_hdr *)pkt_entry->pkt;
+
+	connack_hdr->type = RXR_CONNACK_PKT;
+	connack_hdr->version = RXR_PROTOCOL_VERSION;
+	connack_hdr->flags = 0;
+
+	pkt_entry->pkt_size = RXR_CONNACK_HDR_SIZE;
+	pkt_entry->addr = addr;
+	return 0;
+}
+
+void rxr_pkt_post_connack(struct rxr_ep *ep,
+			  struct rxr_peer *peer,
+			  fi_addr_t addr)
+{
+	struct rxr_pkt_entry *pkt_entry;
+	ssize_t ret;
+
+	if (peer->state == RXR_PEER_ACKED)
+		return;
+
+	pkt_entry = rxr_pkt_entry_alloc(ep, ep->tx_pkt_efa_pool);
+	if (OFI_UNLIKELY(!pkt_entry))
+		return;
+
+	rxr_pkt_init_connack(ep, pkt_entry, addr);
+
+	/*
+	 * TODO: Once we start using a core's selective completion capability,
+	 * post the CONNACK packets without FI_COMPLETION.
+	 */
+	ret = rxr_pkt_entry_send(ep, pkt_entry, addr);
+
+	/*
+	 * Skip sending this connack on error and try again when processing the
+	 * next RTS from this peer containing the source information
+	 */
+	if (OFI_UNLIKELY(ret)) {
+		rxr_pkt_entry_release_tx(ep, pkt_entry);
+		if (ret == -FI_EAGAIN)
+			return;
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"Failed to send a CONNACK packet: ret %zd\n", ret);
+	} else {
+		peer->state = RXR_PEER_ACKED;
+	}
+}
+
+void rxr_pkt_handle_connack_recv(struct rxr_ep *ep,
+				 struct fi_cq_data_entry *comp,
+				 struct rxr_pkt_entry *pkt_entry,
+				 fi_addr_t src_addr)
+{
+	struct rxr_peer *peer;
+
+	/*
+	 * We don't really need any information from the actual connack packet
+	 * itself, just the src_addr from the CQE
+	 */
+	assert(src_addr != FI_ADDR_NOTAVAIL);
+	peer = rxr_ep_get_peer(ep, src_addr);
+	peer->state = RXR_PEER_ACKED;
+	FI_DBG(&rxr_prov, FI_LOG_CQ,
+	       "CONNACK received from %" PRIu64 "\n", src_addr);
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+}
+
+/*  CTS packet related functions */
+void rxr_ep_calc_cts_window_credits(struct rxr_ep *ep, struct rxr_peer *peer,
+				    uint64_t size, int request,
+				    int *window, int *credits)
+{
+	struct efa_av *av;
+	int num_peers;
+
+	/*
+	 * Adjust the peer credit pool based on the current AV size, which could
+	 * have grown since the time this peer was initialized.
+	 */
+	av = rxr_ep_av(ep);
+	num_peers = av->used - 1;
+	if (num_peers && ofi_div_ceil(rxr_env.rx_window_size, num_peers) < peer->rx_credits)
+		peer->rx_credits = ofi_div_ceil(peer->rx_credits, num_peers);
+
+	/*
+	 * Allocate credits for this transfer based on the request, the number
+	 * of available data buffers, and the number of outstanding peers this
+	 * endpoint is actively tracking in the AV. Also ensure that a minimum
+	 * number of credits are allocated to the transfer so the sender can
+	 * make progress.
+	 */
+	*credits = MIN(MIN(ep->available_data_bufs, ep->posted_bufs_efa),
+		       peer->rx_credits);
+	*credits = MIN(request, *credits);
+	*credits = MAX(*credits, rxr_env.tx_min_credits);
+	*window = MIN(size, *credits * ep->max_data_payload_size);
+	if (peer->rx_credits > ofi_div_ceil(*window, ep->max_data_payload_size))
+		peer->rx_credits -= ofi_div_ceil(*window, ep->max_data_payload_size);
+}
+
+ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
+			 struct rxr_rx_entry *rx_entry,
+			 struct rxr_pkt_entry *pkt_entry)
+{
+	int window = 0;
+	struct rxr_cts_hdr *cts_hdr;
+	struct rxr_peer *peer;
+	size_t bytes_left;
+
+	cts_hdr = (struct rxr_cts_hdr *)pkt_entry->pkt;
+	cts_hdr->type = RXR_CTS_PKT;
+	cts_hdr->version = RXR_PROTOCOL_VERSION;
+	cts_hdr->flags = 0;
+
+	if (rx_entry->cq_entry.flags & FI_READ)
+		cts_hdr->flags |= RXR_READ_REQ;
+
+	cts_hdr->tx_id = rx_entry->tx_id;
+	cts_hdr->rx_id = rx_entry->rx_id;
+
+	bytes_left = rx_entry->total_len - rx_entry->bytes_done;
+	peer = rxr_ep_get_peer(ep, rx_entry->addr);
+	rxr_ep_calc_cts_window_credits(ep, peer, bytes_left,
+				       rx_entry->credit_request,
+				       &window, &rx_entry->credit_cts);
+	cts_hdr->window = window;
+	pkt_entry->pkt_size = RXR_CTS_HDR_SIZE;
+	pkt_entry->addr = rx_entry->addr;
+	pkt_entry->x_entry = (void *)rx_entry;
+	return 0;
+}
+
+void rxr_pkt_handle_cts_sent(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rx_entry *rx_entry;
+
+	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
+	rx_entry->window = rxr_get_cts_hdr(pkt_entry->pkt)->window;
+	ep->available_data_bufs -= rx_entry->credit_cts;
+
+	/*
+	 * Set a timer if available_bufs is exhausted. We may encounter a
+	 * scenario where a peer has stopped responding so we need a fallback
+	 * to replenish the credits.
+	 */
+	if (OFI_UNLIKELY(ep->available_data_bufs == 0))
+		ep->available_data_bufs_ts = ofi_gettime_us();
+}
+
+void rxr_pkt_handle_cts_recv(struct rxr_ep *ep,
+			     struct fi_cq_data_entry *comp,
+			     struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_peer *peer;
+	struct rxr_cts_hdr *cts_pkt;
+	struct rxr_tx_entry *tx_entry;
+
+	cts_pkt = (struct rxr_cts_hdr *)pkt_entry->pkt;
+	if (cts_pkt->flags & RXR_READ_REQ)
+		tx_entry = ofi_bufpool_get_ibuf(ep->readrsp_tx_entry_pool, cts_pkt->tx_id);
+	else
+		tx_entry = ofi_bufpool_get_ibuf(ep->tx_entry_pool, cts_pkt->tx_id);
+
+	tx_entry->rx_id = cts_pkt->rx_id;
+	tx_entry->window = cts_pkt->window;
+
+	/* Return any excess tx_credits that were borrowed for the request */
+	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	tx_entry->credit_allocated = ofi_div_ceil(cts_pkt->window, ep->max_data_payload_size);
+	if (tx_entry->credit_allocated < tx_entry->credit_request)
+		peer->tx_credits += tx_entry->credit_request - tx_entry->credit_allocated;
+
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+
+	if (tx_entry->state != RXR_TX_SEND) {
+		tx_entry->state = RXR_TX_SEND;
+		dlist_insert_tail(&tx_entry->entry, &ep->tx_pending_list);
+	}
+}
+
+/*  READRSP pakcet functions */
+int rxr_pkt_init_readrsp(struct rxr_ep *ep,
+			 struct rxr_tx_entry *tx_entry,
+			 struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_readrsp_pkt *readrsp_pkt;
+	struct rxr_readrsp_hdr *readrsp_hdr;
+	size_t mtu = ep->mtu_size;
+
+	readrsp_pkt = (struct rxr_readrsp_pkt *)pkt_entry->pkt;
+	readrsp_hdr = &readrsp_pkt->hdr;
+	readrsp_hdr->type = RXR_READRSP_PKT;
+	readrsp_hdr->version = RXR_PROTOCOL_VERSION;
+	readrsp_hdr->flags = 0;
+	readrsp_hdr->tx_id = tx_entry->tx_id;
+	readrsp_hdr->rx_id = tx_entry->rx_id;
+	readrsp_hdr->seg_size = ofi_copy_from_iov(readrsp_pkt->data,
+						  mtu - RXR_READRSP_HDR_SIZE,
+						  tx_entry->iov,
+						  tx_entry->iov_count, 0);
+	pkt_entry->pkt_size = RXR_READRSP_HDR_SIZE + readrsp_hdr->seg_size;
+	pkt_entry->addr = tx_entry->addr;
+	pkt_entry->x_entry = tx_entry;
+	return 0;
+}
+
+void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_tx_entry *tx_entry;
+	size_t data_len;
+
+	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	data_len = rxr_get_readrsp_hdr(pkt_entry->pkt)->seg_size;
+	tx_entry->state = RXR_TX_SENT_READRSP;
+	tx_entry->bytes_sent += data_len;
+	tx_entry->window -= data_len;
+	assert(tx_entry->window >= 0);
+	if (tx_entry->bytes_sent < tx_entry->total_len) {
+		if (efa_mr_cache_enable && rxr_ep_mr_local(ep))
+			rxr_inline_mr_reg(rxr_ep_domain(ep), tx_entry);
+
+		tx_entry->state = RXR_TX_SEND;
+		dlist_insert_tail(&tx_entry->entry,
+				  &ep->tx_pending_list);
+	}
+}
+
+void rxr_pkt_handle_readrsp_recv(struct rxr_ep *ep,
+				 struct fi_cq_data_entry *comp,
+				 struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_readrsp_pkt *readrsp_pkt = NULL;
+	struct rxr_readrsp_hdr *readrsp_hdr = NULL;
+	struct rxr_rx_entry *rx_entry = NULL;
+
+	readrsp_pkt = (struct rxr_readrsp_pkt *)pkt_entry->pkt;
+	readrsp_hdr = &readrsp_pkt->hdr;
+	rx_entry = ofi_bufpool_get_ibuf(ep->rx_entry_pool, readrsp_hdr->rx_id);
+	assert(rx_entry->cq_entry.flags & FI_READ);
+	rx_entry->tx_id = readrsp_hdr->tx_id;
+	rxr_pkt_handle_data(ep, rx_entry, pkt_entry,
+			    readrsp_pkt->data,
+			    0, readrsp_hdr->seg_size);
+}
+
+/*  RMA_CONTEXT packet functions */
+void rxr_pkt_handle_rma_context_send_completion(struct rxr_ep *ep,
+						struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_tx_entry *tx_entry = NULL;
+	struct rxr_rx_entry *rx_entry = NULL;
+	struct rxr_rma_context_pkt *rma_context_pkt;
+	int ret;
+
+	assert(rxr_get_base_hdr(pkt_entry->pkt)->version == RXR_PROTOCOL_VERSION);
+
+	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->pkt;
+
+	switch (rma_context_pkt->rma_context_type) {
+	case RXR_SHM_RMA_READ:
+	case RXR_SHM_RMA_WRITE:
+		/* Completion of RMA READ/WRTITE operations that apps call */
+		tx_entry = pkt_entry->x_entry;
+
+		if (tx_entry->fi_flags & FI_COMPLETION) {
+			rxr_cq_write_tx_completion(ep, tx_entry);
+		} else {
+			efa_cntr_report_tx_completion(&ep->util_ep, tx_entry->cq_entry.flags);
+			rxr_release_tx_entry(ep, tx_entry);
+		}
+		rxr_pkt_entry_release_tx(ep, pkt_entry);
+		break;
+	case RXR_SHM_LARGE_READ:
+		/*
+		 * This must be on the receiver (remote) side of two-sided message
+		 * transfer, which is also the initiator of RMA READ.
+		 * We get RMA READ completion for previously issued
+		 * fi_read operation over shm provider, which means
+		 * receiver side has received all data from sender
+		 */
+		rx_entry = pkt_entry->x_entry;
+		rx_entry->cq_entry.len = rx_entry->total_len;
+		rx_entry->bytes_done = rx_entry->total_len;
+
+		ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, rx_entry, RXR_EOR_PKT, 1);
+		if (ret) {
+			if (rxr_cq_handle_rx_error(ep, rx_entry, ret))
+				assert(0 && "error writing error cq entry for EOR\n");
+		}
+
+		if (rx_entry->fi_flags & FI_MULTI_RECV)
+			rxr_msg_multi_recv_handle_completion(ep, rx_entry);
+		rxr_cq_write_rx_completion(ep, rx_entry);
+		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
+		if (OFI_LIKELY(!ret))
+			rxr_release_rx_entry(ep, rx_entry);
+		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		break;
+	default:
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "invalid rma_context_type in RXR_RMA_CONTEXT_PKT %d\n",
+			rma_context_pkt->rma_context_type);
+		assert(0 && "invalid RXR_RMA_CONTEXT_PKT rma_context_type\n");
+	}
+}
+
+/*  EOR packet related functions */
+int rxr_pkt_init_eor(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry, struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_eor_hdr *eor_hdr;
+
+	eor_hdr = (struct rxr_eor_hdr *)pkt_entry->pkt;
+	eor_hdr->type = RXR_EOR_PKT;
+	eor_hdr->version = RXR_PROTOCOL_VERSION;
+	eor_hdr->flags = 0;
+	eor_hdr->tx_id = rx_entry->tx_id;
+	eor_hdr->rx_id = rx_entry->rx_id;
+	pkt_entry->pkt_size = sizeof(struct rxr_eor_hdr);
+	pkt_entry->addr = rx_entry->addr;
+	pkt_entry->x_entry = rx_entry;
+	return 0;
+}
+
+/*
+ *   Sender handles the acknowledgment (RXR_EOR_PKT) from receiver on the completion
+ *   of the large message copy via fi_readmsg operation
+ */
+void rxr_pkt_handle_eor_recv(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_eor_hdr *shm_eor;
+	struct rxr_tx_entry *tx_entry;
+
+	shm_eor = (struct rxr_eor_hdr *)pkt_entry->pkt;
+
+	/* pre-post buf used here, so can NOT track back to tx_entry with x_entry */
+	tx_entry = ofi_bufpool_get_ibuf(ep->tx_entry_pool, shm_eor->tx_id);
+	rxr_cq_write_tx_completion(ep, tx_entry);
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+}
+

--- a/prov/efa/src/rxr/rxr_pkt_type_rts.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_rts.c
@@ -1,0 +1,802 @@
+/*
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "efa.h"
+#include "rxr.h"
+#include "rxr_msg.h"
+#include "rxr_rma.h"
+
+/* This file contains RTS packet related functions.
+ * RTS is used to post send, emulated read and emualted
+ * write requests.
+ */
+
+/*
+ *  Utility struct and functions
+ */
+struct rxr_pkt_rts_read_hdr {
+	uint64_t rma_initiator_rx_id;
+	uint64_t window;
+};
+
+/*
+ *   Helper function to compute the maximum payload of the RTS header based on
+ *   the RTS header flags. The header may have a length greater than the possible
+ *   RTS payload size if it is a large message.
+ */
+uint64_t rxr_get_rts_data_size(struct rxr_ep *ep,
+			       struct rxr_rts_hdr *rts_hdr)
+{
+	/*
+	 * read RTS contain no data, because data is on remote EP.
+	 */
+	if (rts_hdr->flags & RXR_READ_REQ)
+		return 0;
+
+	if (rts_hdr->flags & RXR_SHM_HDR)
+		return (rts_hdr->flags & RXR_SHM_HDR_DATA) ? rts_hdr->data_len : 0;
+
+	size_t max_payload_size;
+
+	if (rts_hdr->flags & RXR_REMOTE_CQ_DATA)
+		max_payload_size = ep->mtu_size - RXR_CTRL_HDR_SIZE;
+	else
+		max_payload_size = ep->mtu_size - RXR_CTRL_HDR_SIZE_NO_CQ;
+
+	if (rts_hdr->flags & RXR_REMOTE_SRC_ADDR)
+		max_payload_size -= rts_hdr->addrlen;
+
+	if (rts_hdr->flags & RXR_WRITE)
+		max_payload_size -= rts_hdr->rma_iov_count *
+					sizeof(struct fi_rma_iov);
+
+	return (rts_hdr->data_len > max_payload_size)
+		? max_payload_size : rts_hdr->data_len;
+}
+
+/*
+ *  rxr_pkt_init_rts() and related functions.
+ */
+static
+char *rxr_pkt_init_rts_base_hdr(struct rxr_ep *ep,
+				struct rxr_tx_entry *tx_entry,
+				struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rts_hdr *rts_hdr;
+	struct rxr_peer *peer;
+	char *src;
+
+	rts_hdr = (struct rxr_rts_hdr *)pkt_entry->pkt;
+	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+
+	rts_hdr->type = RXR_RTS_PKT;
+	rts_hdr->version = RXR_PROTOCOL_VERSION;
+	rts_hdr->tag = tx_entry->tag;
+
+	rts_hdr->data_len = tx_entry->total_len;
+	rts_hdr->tx_id = tx_entry->tx_id;
+	rts_hdr->msg_id = tx_entry->msg_id;
+	/*
+	 * Even with protocol versions prior to v3 that did not include a
+	 * request in the RTS, the receiver can test for this flag and decide if
+	 * it should be used as a heuristic for credit calculation. If the
+	 * receiver is on <3 protocol version, the flag and the request just get
+	 * ignored.
+	 */
+	rts_hdr->flags |= RXR_CREDIT_REQUEST;
+	rts_hdr->credit_request = tx_entry->credit_request;
+
+	if (tx_entry->fi_flags & FI_REMOTE_CQ_DATA) {
+		rts_hdr->flags = RXR_REMOTE_CQ_DATA;
+		pkt_entry->pkt_size = RXR_CTRL_HDR_SIZE;
+		rxr_get_ctrl_cq_pkt(rts_hdr)->hdr.cq_data =
+			tx_entry->cq_entry.data;
+		src = rxr_get_ctrl_cq_pkt(rts_hdr)->data;
+	} else {
+		rts_hdr->flags = 0;
+		pkt_entry->pkt_size = RXR_CTRL_HDR_SIZE_NO_CQ;
+		src = rxr_get_ctrl_pkt(rts_hdr)->data;
+	}
+
+	if (tx_entry->cq_entry.flags & FI_TAGGED)
+		rts_hdr->flags |= RXR_TAGGED;
+
+	rts_hdr->addrlen = 0;
+	if (OFI_UNLIKELY(peer->state != RXR_PEER_ACKED)) {
+		/*
+		 * This is the first communication with this peer on this
+		 * endpoint, so send the core's address for this EP in the RTS
+		 * so the remote side can insert it into its address vector.
+		 */
+		rts_hdr->addrlen = ep->core_addrlen;
+		rts_hdr->flags |= RXR_REMOTE_SRC_ADDR;
+		memcpy(src, ep->core_addr, rts_hdr->addrlen);
+		src += rts_hdr->addrlen;
+		pkt_entry->pkt_size += rts_hdr->addrlen;
+	}
+
+	return src;
+}
+
+static
+char *rxr_pkt_init_rts_rma_hdr(struct rxr_ep *ep,
+			       struct rxr_tx_entry *tx_entry,
+			       struct rxr_pkt_entry *pkt_entry,
+			       char *hdr)
+{
+	int rmalen;
+	struct rxr_rts_hdr *rts_hdr;
+
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+	rts_hdr->rma_iov_count = 0;
+	assert(tx_entry->cq_entry.flags & FI_RMA);
+	if (tx_entry->op == ofi_op_write) {
+		rts_hdr->flags |= RXR_WRITE;
+	} else {
+		assert(tx_entry->op == ofi_op_read_req);
+		rts_hdr->flags |= RXR_READ_REQ;
+	}
+
+	rmalen = tx_entry->rma_iov_count * sizeof(struct fi_rma_iov);
+	rts_hdr->rma_iov_count = tx_entry->rma_iov_count;
+	memcpy(hdr, tx_entry->rma_iov, rmalen);
+	hdr += rmalen;
+	pkt_entry->pkt_size += rmalen;
+
+	return hdr;
+}
+
+static
+int rxr_pkt_init_read_rts(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+			  struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_pkt_rts_read_hdr *read_hdr;
+	char *hdr;
+
+	hdr = rxr_pkt_init_rts_base_hdr(ep, tx_entry, pkt_entry);
+	hdr = rxr_pkt_init_rts_rma_hdr(ep, tx_entry, pkt_entry, hdr);
+
+	/* no data to send, but need to send rx_id and window */
+	read_hdr = (struct rxr_pkt_rts_read_hdr *)hdr;
+	read_hdr->rma_initiator_rx_id = tx_entry->rma_loc_rx_id;
+	read_hdr->window = tx_entry->rma_window;
+	hdr += sizeof(struct rxr_pkt_rts_read_hdr);
+	pkt_entry->pkt_size += sizeof(struct rxr_pkt_rts_read_hdr);
+
+	assert(pkt_entry->pkt_size <= ep->mtu_size);
+	pkt_entry->addr = tx_entry->addr;
+	pkt_entry->x_entry = (void *)tx_entry;
+	return 0;
+}
+
+ssize_t rxr_pkt_init_rts(struct rxr_ep *ep,
+			 struct rxr_tx_entry *tx_entry,
+			 struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_peer *peer;
+	struct rxr_rts_hdr *rts_hdr;
+	char *data, *src;
+	uint64_t data_len;
+	size_t mtu = ep->mtu_size;
+
+	if (tx_entry->op == ofi_op_read_req)
+		return rxr_pkt_init_read_rts(ep, tx_entry, pkt_entry);
+
+	src = rxr_pkt_init_rts_base_hdr(ep, tx_entry, pkt_entry);
+	if (tx_entry->op == ofi_op_write)
+		src = rxr_pkt_init_rts_rma_hdr(ep, tx_entry, pkt_entry, src);
+
+	peer = rxr_ep_get_peer(ep, tx_entry->addr);
+	assert(peer);
+	data = src;
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+	if (rxr_env.enable_shm_transfer && peer->is_local) {
+		rts_hdr->flags |= RXR_SHM_HDR;
+		/* will be sent over shm provider */
+		if (tx_entry->total_len <= rxr_env.shm_max_medium_size) {
+			data_len = ofi_copy_from_iov(data, rxr_env.shm_max_medium_size,
+						     tx_entry->iov, tx_entry->iov_count, 0);
+			assert(data_len == tx_entry->total_len);
+			rts_hdr->flags |= RXR_SHM_HDR_DATA;
+			pkt_entry->pkt_size += data_len;
+		} else {
+			/* rendezvous protocol
+			 * place iov_count first, then local iov
+			 */
+			memcpy(data, &tx_entry->iov_count, sizeof(size_t));
+			data += sizeof(size_t);
+			pkt_entry->pkt_size += sizeof(size_t);
+			memcpy(data, tx_entry->iov, sizeof(struct iovec) * tx_entry->iov_count);
+			pkt_entry->pkt_size += sizeof(struct iovec) * tx_entry->iov_count;
+		}
+	} else {
+		/* will be sent over efa provider */
+		data_len = ofi_copy_from_iov(data, mtu - pkt_entry->pkt_size,
+					     tx_entry->iov, tx_entry->iov_count, 0);
+		assert(data_len == rxr_get_rts_data_size(ep, rts_hdr));
+		pkt_entry->pkt_size += data_len;
+	}
+
+	assert(pkt_entry->pkt_size <= mtu);
+	pkt_entry->addr = tx_entry->addr;
+	pkt_entry->x_entry = (void *)tx_entry;
+	return 0;
+}
+
+/*
+ *  rxr_pkt_handle_rts_sent() and related functions
+ */
+void rxr_pkt_handle_rts_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_peer *peer;
+	struct rxr_tx_entry *tx_entry;
+	size_t data_sent;
+
+	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
+	if (tx_entry->op == ofi_op_read_req) {
+		tx_entry->bytes_sent = 0;
+		tx_entry->state = RXR_TX_WAIT_READ_FINISH;
+		return;
+	}
+
+	data_sent = rxr_get_rts_data_size(ep, rxr_get_rts_hdr(pkt_entry->pkt));
+
+	tx_entry->bytes_sent += data_sent;
+
+	if ((rxr_env.enable_shm_transfer && peer->is_local) ||
+	    !(efa_mr_cache_enable && tx_entry->total_len > data_sent))
+		return;
+
+	/*
+	 * Register the data buffers inline only if the application did not
+	 * provide a descriptor with the tx op
+	 */
+	if (rxr_ep_mr_local(ep) && !tx_entry->desc[0])
+		rxr_inline_mr_reg(rxr_ep_domain(ep), tx_entry);
+}
+
+/*
+ *  rxr_pkt_handle_rts_recv() and related functions
+ */
+static
+char *rxr_pkt_read_rts_base_hdr(struct rxr_ep *ep,
+				struct rxr_rx_entry *rx_entry,
+				struct rxr_pkt_entry *pkt_entry)
+{
+	char *data;
+	struct rxr_rts_hdr *rts_hdr = NULL;
+	/*
+	 * Use the correct header and grab CQ data and data, but ignore the
+	 * source_address since that has been fetched and processed already
+	 */
+
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+
+	rx_entry->addr = pkt_entry->addr;
+	rx_entry->tx_id = rts_hdr->tx_id;
+	rx_entry->msg_id = rts_hdr->msg_id;
+	rx_entry->total_len = rts_hdr->data_len;
+	rx_entry->cq_entry.tag = rts_hdr->tag;
+
+	if (rts_hdr->flags & RXR_REMOTE_CQ_DATA) {
+		rx_entry->cq_entry.flags |= FI_REMOTE_CQ_DATA;
+		data = rxr_get_ctrl_cq_pkt(rts_hdr)->data + rts_hdr->addrlen;
+		rx_entry->cq_entry.data =
+				rxr_get_ctrl_cq_pkt(rts_hdr)->hdr.cq_data;
+	} else {
+		rx_entry->cq_entry.data = 0;
+		data = rxr_get_ctrl_pkt(rts_hdr)->data + rts_hdr->addrlen;
+	}
+
+	return data;
+}
+
+static
+char *rxr_pkt_read_rts_rma_hdr(struct rxr_ep *ep,
+			       struct rxr_rx_entry *rx_entry,
+			       struct rxr_pkt_entry *pkt_entry,
+			       char *rma_hdr)
+{
+	uint32_t rma_access;
+	struct fi_rma_iov *rma_iov = NULL;
+	struct rxr_rts_hdr *rts_hdr;
+	int ret;
+
+	rma_iov = (struct fi_rma_iov *)rma_hdr;
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+	if (rts_hdr->flags & RXR_READ_REQ) {
+		rma_access = FI_SEND;
+		rx_entry->cq_entry.flags |= (FI_RMA | FI_READ);
+	} else {
+		assert(rts_hdr->flags & RXR_WRITE);
+		rma_access = FI_RECV;
+		rx_entry->cq_entry.flags |= (FI_RMA | FI_WRITE);
+	}
+
+	assert(rx_entry->iov_count == 0);
+
+	rx_entry->iov_count = rts_hdr->rma_iov_count;
+	ret = rxr_rma_verified_copy_iov(ep, rma_iov, rts_hdr->rma_iov_count,
+					rma_access, rx_entry->iov);
+	if (ret) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "RMA address verify failed!\n");
+		rxr_cq_handle_cq_error(ep, -FI_EIO);
+	}
+
+	rx_entry->cq_entry.len = ofi_total_iov_len(&rx_entry->iov[0],
+						   rx_entry->iov_count);
+	rx_entry->cq_entry.buf = rx_entry->iov[0].iov_base;
+	return rma_hdr + rts_hdr->rma_iov_count * sizeof(struct fi_rma_iov);
+}
+
+static
+int rxr_cq_match_recv(struct dlist_entry *item, const void *arg)
+{
+	const struct rxr_pkt_entry *pkt_entry = arg;
+	struct rxr_rx_entry *rx_entry;
+
+	rx_entry = container_of(item, struct rxr_rx_entry, entry);
+
+	return rxr_match_addr(rx_entry->addr, pkt_entry->addr);
+}
+
+static
+int rxr_cq_match_trecv(struct dlist_entry *item, const void *arg)
+{
+	struct rxr_pkt_entry *pkt_entry = (struct rxr_pkt_entry *)arg;
+	struct rxr_rx_entry *rx_entry;
+	uint64_t match_tag;
+
+	rx_entry = container_of(item, struct rxr_rx_entry, entry);
+
+	match_tag = rxr_get_rts_hdr(pkt_entry->pkt)->tag;
+
+	return rxr_match_addr(rx_entry->addr, pkt_entry->addr) &&
+	       rxr_match_tag(rx_entry->cq_entry.tag, rx_entry->ignore,
+			     match_tag);
+}
+
+int rxr_cq_handle_rts_with_data(struct rxr_ep *ep,
+				struct rxr_rx_entry *rx_entry,
+				struct rxr_pkt_entry *pkt_entry,
+				char *data, size_t data_size)
+{
+	struct rxr_rts_hdr *rts_hdr;
+	int64_t bytes_left, bytes_copied;
+	ssize_t ret;
+
+	/* rx_entry->cq_entry.len is total recv buffer size.
+	 * rx_entry->total_len is from rts_hdr and is total send buffer size.
+	 * if send buffer size < recv buffer size, we adjust value of rx_entry->cq_entry.len.
+	 * if send buffer size > recv buffer size, we have a truncated message.
+	 */
+	if (rx_entry->cq_entry.len > rx_entry->total_len)
+		rx_entry->cq_entry.len = rx_entry->total_len;
+
+	bytes_copied = ofi_copy_to_iov(rx_entry->iov, rx_entry->iov_count,
+				       0, data, data_size);
+
+	if (OFI_UNLIKELY(bytes_copied < data_size)) {
+		/* recv buffer is not big enough to hold rts, this must be a truncated message */
+		assert(bytes_copied == rx_entry->cq_entry.len &&
+		       rx_entry->cq_entry.len < rx_entry->total_len);
+		rx_entry->bytes_done = bytes_copied;
+		bytes_left = 0;
+	} else {
+		assert(bytes_copied == data_size);
+		rx_entry->bytes_done = data_size;
+		bytes_left = rx_entry->total_len - data_size;
+	}
+
+	assert(bytes_left >= 0);
+	if (!bytes_left) {
+		/* rxr_cq_handle_rx_completion() releases pkt_entry, thus
+		 * we do not release it here.
+		 */
+		rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
+		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
+		rxr_release_rx_entry(ep, rx_entry);
+		return 0;
+	}
+
+#if ENABLE_DEBUG
+	dlist_insert_tail(&rx_entry->rx_pending_entry, &ep->rx_pending_list);
+	ep->rx_pending++;
+#endif
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+	rx_entry->state = RXR_RX_RECV;
+	if (rts_hdr->flags & RXR_CREDIT_REQUEST)
+		rx_entry->credit_request = rts_hdr->credit_request;
+	else
+		rx_entry->credit_request = rxr_env.tx_min_credits;
+	ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	return ret;
+}
+
+ssize_t rxr_pkt_post_shm_read(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry)
+{
+	struct rxr_pkt_entry *pkt_entry;
+	struct rxr_rma_context_pkt *rma_context_pkt;
+	struct fi_msg_rma msg;
+	struct iovec msg_iov[RXR_IOV_LIMIT];
+	struct fi_rma_iov rma_iov[RXR_IOV_LIMIT];
+	fi_addr_t src_shm_fiaddr;
+	uint64_t remain_len;
+	struct rxr_peer *peer;
+	int ret, i;
+
+	if (rx_entry->state == RXR_RX_QUEUED_SHM_LARGE_READ)
+		return 0;
+
+	pkt_entry = rxr_pkt_entry_alloc(ep, ep->tx_pkt_shm_pool);
+	assert(pkt_entry);
+
+	pkt_entry->x_entry = (void *)rx_entry;
+	pkt_entry->addr = rx_entry->addr;
+	rma_context_pkt = (struct rxr_rma_context_pkt *)pkt_entry->pkt;
+	rma_context_pkt->type = RXR_RMA_CONTEXT_PKT;
+	rma_context_pkt->version = RXR_PROTOCOL_VERSION;
+	rma_context_pkt->rma_context_type = RXR_SHM_LARGE_READ;
+	rma_context_pkt->tx_id = rx_entry->tx_id;
+
+	peer = rxr_ep_get_peer(ep, rx_entry->addr);
+	src_shm_fiaddr = peer->shm_fiaddr;
+
+	memset(&msg, 0, sizeof(msg));
+
+	remain_len = rx_entry->total_len;
+
+	for (i = 0; i < rx_entry->rma_iov_count; i++) {
+		rma_iov[i].addr = rx_entry->rma_iov[i].addr;
+		rma_iov[i].len = rx_entry->rma_iov[i].len;
+		rma_iov[i].key = 0;
+	}
+
+	/*
+	 * shm provider will compare #bytes CMA copied with total length of recv buffer
+	 * (msg_iov here). If they are not equal, an error is returned when reading shm
+	 * provider's cq. So shrink the total length of recv buffer if applicable
+	 */
+	for (i = 0; i < rx_entry->iov_count; i++) {
+		msg_iov[i].iov_base = (void *)rx_entry->iov[i].iov_base;
+		msg_iov[i].iov_len = (remain_len < rx_entry->iov[i].iov_len) ?
+					remain_len : rx_entry->iov[i].iov_len;
+		remain_len -= msg_iov[i].iov_len;
+		if (remain_len == 0)
+			break;
+	}
+
+	msg.msg_iov = msg_iov;
+	msg.iov_count = rx_entry->iov_count;
+	msg.desc = NULL;
+	msg.addr = src_shm_fiaddr;
+	msg.context = pkt_entry;
+	msg.rma_iov = rma_iov;
+	msg.rma_iov_count = rx_entry->rma_iov_count;
+
+	ret = fi_readmsg(ep->shm_ep, &msg, 0);
+
+	return ret;
+}
+
+void rxr_pkt_proc_shm_long_msg_rts(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+				   struct rxr_rts_hdr *rts_hdr, char *data)
+{
+	struct iovec *iovec_ptr;
+	int ret, i;
+
+	/*
+	 * rx_entry->cq_entry.len is the buffer size, rx_entry->total_len
+	 * is incoming data size.
+	 */
+	if (rx_entry->cq_entry.len > rx_entry->total_len)
+		rx_entry->cq_entry.len = rx_entry->total_len;
+
+	/* get iov_count of sender first */
+	memcpy(&rx_entry->rma_iov_count, data, sizeof(size_t));
+	data += sizeof(size_t);
+
+	iovec_ptr = (struct iovec *)data;
+	for (i = 0; i < rx_entry->rma_iov_count; i++) {
+		iovec_ptr = iovec_ptr + i;
+		rx_entry->rma_iov[i].addr = (intptr_t)iovec_ptr->iov_base;
+		rx_entry->rma_iov[i].len = iovec_ptr->iov_len;
+		rx_entry->rma_iov[i].key = 0;
+	}
+
+	ret = rxr_pkt_post_shm_read(ep, rx_entry);
+
+	if (OFI_UNLIKELY(ret)) {
+		if (ret == -FI_EAGAIN) {
+			rx_entry->state = RXR_RX_QUEUED_SHM_LARGE_READ;
+			dlist_insert_tail(&rx_entry->queued_entry,  &ep->rx_entry_queued_list);
+			return;
+		}
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"A large message RMA READ failed over shm provider.\n");
+		if (rxr_cq_handle_rx_error(ep, rx_entry, ret))
+			assert(0 && "failed to write err cq entry");
+	}
+}
+
+ssize_t rxr_pkt_proc_matched_msg_rts(struct rxr_ep *ep,
+				     struct rxr_rx_entry *rx_entry,
+				     struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_peer *peer;
+	struct rxr_rts_hdr *rts_hdr;
+	char *data;
+	size_t data_size;
+
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
+
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+	data = rxr_pkt_read_rts_base_hdr(ep, rx_entry, pkt_entry);
+	if (peer->is_local && !(rts_hdr->flags & RXR_SHM_HDR_DATA)) {
+		rxr_pkt_proc_shm_long_msg_rts(ep, rx_entry, rts_hdr, data);
+		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		return 0;
+	}
+
+	data_size = rxr_get_rts_data_size(ep, rts_hdr);
+	return rxr_cq_handle_rts_with_data(ep, rx_entry,
+					   pkt_entry, data,
+					   data_size);
+}
+
+static
+int rxr_pkt_proc_msg_rts(struct rxr_ep *ep,
+			 struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rts_hdr *rts_hdr;
+	struct dlist_entry *match;
+	struct rxr_rx_entry *rx_entry;
+
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+
+	if (rts_hdr->flags & RXR_TAGGED) {
+		match = dlist_find_first_match(&ep->rx_tagged_list,
+					       &rxr_cq_match_trecv,
+					       (void *)pkt_entry);
+	} else {
+		match = dlist_find_first_match(&ep->rx_list,
+					       &rxr_cq_match_recv,
+					       (void *)pkt_entry);
+	}
+
+	if (OFI_UNLIKELY(!match)) {
+		rx_entry = rxr_ep_get_new_unexp_rx_entry(ep, pkt_entry);
+		if (!rx_entry) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+				"RX entries exhausted.\n");
+			efa_eq_write_error(&ep->util_ep, FI_ENOBUFS, -FI_ENOBUFS);
+			return -FI_ENOBUFS;
+		}
+
+		/* we are not releasing pkt_entry here because it will be
+		 * processed later
+		 */
+		pkt_entry = rx_entry->unexp_rts_pkt;
+		rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+		rxr_pkt_read_rts_base_hdr(ep, rx_entry, pkt_entry);
+		return 0;
+	}
+
+	rx_entry = container_of(match, struct rxr_rx_entry, entry);
+	if (rx_entry->rxr_flags & RXR_MULTI_RECV_POSTED) {
+		rx_entry = rxr_ep_split_rx_entry(ep, rx_entry,
+						 NULL, pkt_entry);
+		if (OFI_UNLIKELY(!rx_entry)) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+				"RX entries exhausted.\n");
+			efa_eq_write_error(&ep->util_ep, FI_ENOBUFS, -FI_ENOBUFS);
+			return -FI_ENOBUFS;
+		}
+	}
+
+	rx_entry->state = RXR_RX_MATCHED;
+
+	if (!(rx_entry->fi_flags & FI_MULTI_RECV) ||
+	    !rxr_msg_multi_recv_buffer_available(ep, rx_entry->master_entry))
+		dlist_remove(match);
+
+	return rxr_pkt_proc_matched_msg_rts(ep, rx_entry, pkt_entry);
+}
+
+static
+int rxr_pkt_proc_write_rts(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rx_entry *rx_entry;
+	struct rxr_rts_hdr *rts_hdr;
+	uint64_t tag = ~0;
+	char *rma_hdr;
+	char *data;
+	size_t data_size;
+
+	/*
+	 * rma is one sided operation, match is not expected
+	 * we need to create a rx entry upon receiving a rts
+	 */
+	rx_entry = rxr_ep_get_rx_entry(ep, NULL, 0, tag, 0, NULL, pkt_entry->addr, ofi_op_write, 0);
+	if (OFI_UNLIKELY(!rx_entry)) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"RX entries exhausted.\n");
+		efa_eq_write_error(&ep->util_ep, FI_ENOBUFS, -FI_ENOBUFS);
+		return -FI_ENOBUFS;
+	}
+
+	rx_entry->bytes_done = 0;
+
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+	rma_hdr = rxr_pkt_read_rts_base_hdr(ep, rx_entry, pkt_entry);
+	data = rxr_pkt_read_rts_rma_hdr(ep, rx_entry, pkt_entry, rma_hdr);
+	data_size = rxr_get_rts_data_size(ep, rts_hdr);
+	return rxr_cq_handle_rts_with_data(ep, rx_entry,
+					   pkt_entry, data,
+					   data_size);
+}
+
+static
+int rxr_pkt_proc_read_rts(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rx_entry *rx_entry;
+	struct rxr_tx_entry *tx_entry;
+	uint64_t tag = ~0;
+	int err = 0;
+	char *hdr;
+	struct rxr_pkt_rts_read_hdr *read_info;
+	/*
+	 * rma is one sided operation, match is not expected
+	 * we need to create a rx entry upon receiving a rts
+	 */
+	rx_entry = rxr_ep_get_rx_entry(ep, NULL, 0, tag, 0, NULL, pkt_entry->addr, ofi_op_read_rsp, 0);
+	if (OFI_UNLIKELY(!rx_entry)) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"RX entries exhausted.\n");
+		efa_eq_write_error(&ep->util_ep, FI_ENOBUFS, -FI_ENOBUFS);
+		return -FI_ENOBUFS;
+	}
+
+	rx_entry->bytes_done = 0;
+
+	hdr = (char *)rxr_pkt_read_rts_base_hdr(ep, rx_entry, pkt_entry);
+	hdr = (char *)rxr_pkt_read_rts_rma_hdr(ep, rx_entry, pkt_entry, hdr);
+	read_info = (struct rxr_pkt_rts_read_hdr *)hdr;
+
+	rx_entry->rma_initiator_rx_id = read_info->rma_initiator_rx_id;
+	rx_entry->window = read_info->window;
+	assert(rx_entry->window > 0);
+
+	tx_entry = rxr_rma_alloc_readrsp_tx_entry(ep, rx_entry);
+	assert(tx_entry);
+	/* the only difference between a read response packet and
+	 * a data packet is that read response packet has remote EP tx_id
+	 * which initiator EP rx_entry need to send CTS back
+	 */
+	err = rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_READRSP_PKT, 0);
+	if (OFI_UNLIKELY(err)) {
+		if (rxr_cq_handle_tx_error(ep, tx_entry, err))
+			assert(0 && "failed to write err cq entry");
+		rxr_release_tx_entry(ep, tx_entry);
+		rxr_release_rx_entry(ep, rx_entry);
+	} else {
+		rx_entry->state = RXR_RX_WAIT_READ_FINISH;
+	}
+
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	return err;
+}
+
+ssize_t rxr_pkt_proc_rts(struct rxr_ep *ep,
+			 struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rts_hdr *rts_hdr;
+
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+
+	if (rts_hdr->flags & RXR_READ_REQ)
+		return rxr_pkt_proc_read_rts(ep, pkt_entry);
+
+	if (rts_hdr->flags & RXR_WRITE)
+		return rxr_pkt_proc_write_rts(ep, pkt_entry);
+
+	return rxr_pkt_proc_msg_rts(ep, pkt_entry);
+}
+
+void rxr_pkt_handle_rts_recv(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rts_hdr *rts_hdr;
+	struct rxr_peer *peer;
+	int ret;
+
+	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
+	assert(peer);
+
+	if (rxr_env.enable_shm_transfer && peer->is_local) {
+		/* no need to reorder msg for shm_ep
+		 * rxr_pkt_proc_rts will write error cq entry if needed
+		 */
+		rxr_pkt_proc_rts(ep, pkt_entry);
+		return;
+	}
+
+	rts_hdr = rxr_get_rts_hdr(pkt_entry->pkt);
+
+	if (ep->core_caps & FI_SOURCE)
+		rxr_pkt_post_connack(ep, peer, pkt_entry->addr);
+
+	if (rxr_need_sas_ordering(ep)) {
+		ret = rxr_cq_reorder_msg(ep, peer, pkt_entry);
+		if (ret == 1) {
+			/* Packet was queued */
+			return;
+		} else if (OFI_UNLIKELY(ret == -FI_EALREADY)) {
+			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+				"Invalid msg_id: %" PRIu32
+				" robuf->exp_msg_id: %" PRIu32 "\n",
+			       rts_hdr->msg_id, peer->robuf->exp_msg_id);
+			if (!rts_hdr->addrlen)
+				efa_eq_write_error(&ep->util_ep, FI_EIO, ret);
+			rxr_pkt_entry_release_rx(ep, pkt_entry);
+			return;
+		} else if (OFI_UNLIKELY(ret == -FI_ENOMEM)) {
+			efa_eq_write_error(&ep->util_ep, FI_ENOBUFS, -FI_ENOBUFS);
+			return;
+		} else if (OFI_UNLIKELY(ret < 0)) {
+			FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+				"Unknown error %d processing RTS packet msg_id: %"
+				PRIu32 "\n", ret, rts_hdr->msg_id);
+			efa_eq_write_error(&ep->util_ep, FI_EIO, ret);
+			return;
+		}
+
+		/* processing the expected packet */
+		ofi_recvwin_slide(peer->robuf);
+	}
+
+	/* rxr_pkt_proc_rts will write error cq entry if needed */
+	ret = rxr_pkt_proc_rts(ep, pkt_entry);
+	if (OFI_UNLIKELY(ret))
+		return;
+
+	/* process pending items in reorder buff */
+	if (rxr_need_sas_ordering(ep))
+		rxr_cq_proc_pending_items_in_recvwin(ep, peer);
+}
+


### PR DESCRIPTION
Packet handling is the central part of the EFA provider and
currently the related functions are in rxr_ep.c and rxr_cq.c,
both of which are too long.

This patch extract packet related functions from rxr_ep.c
and rxr_cq.c, and re-organize them into 3 parts:

 rxr_pkt_entry: contain struct rxr_pkt_entry and utility
                functions to allocate, relese, copy
                and send a packet

 rxr_pkt_type: contain type ID and functions for each
               packet type.
               RTS and DATA packets are so complicated
               that their implementation was put into
               two separate source files:
               rxr_pkt_type_rts.c and rxr_pkt_type_data.c,
               the rest of packet types are put in
               rxr_pkt_type_misc.c

 rxr_pkt_cmd: contain functions to post, handle send
              completion and handle receive completion
              by type ID.

Function names in these files have been adjusted to
add a rxr_pkt_ prefix

Signed-off-by: Wei Zhang <wzam@amazon.com>