### PR TITLE
util/mr_cache : remove an unused variable in ofi_mr_cache_cleanup()

### DIFF
--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -423,8 +423,6 @@ buf_free:
 
 void ofi_mr_cache_cleanup(struct ofi_mr_cache *cache)
 {
-	struct ofi_mr_entry *entry;
-
 	/* If we don't have a domain, initialization failed */
 	if (!cache->domain)
 		return;


### PR DESCRIPTION
There is an unused variable entry of type "struct ofi_mr_entry *",
which is causing compiler warnings. This patch removes it.

Signed-off-by: Wei Zhang <wzam@amazon.com>