### PR TITLE
core/getinfo: Set current info list to NULL when calling providers

### DIFF
--- a/src/fabric.c
+++ b/src/fabric.c
@@ -952,6 +952,7 @@ int DEFAULT_SYMVER_PRE(fi_getinfo)(uint32_t version, const char *node,
 			continue;
 		}
 
+		cur = NULL;
 		ret = prov->provider->getinfo(version, node, service, flags,
 					      hints, &cur);
 		if (ret) {


### PR DESCRIPTION
To protect against a provider modifying the fi_info structure from
another provider, set the cur list pointer to NULL before calling
the provider's getinfo call.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>