### PR TITLE
prov/efa: Disable MR cache

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -118,7 +118,7 @@ These OFI runtime parameters apply only to the RDM endpoint.
 
 *FI_EFA_MR_CACHE_ENABLE*
 : Enables using the mr cache and in-line registration instead of a bounce
-  buffer for iov's larger than max_memcpy_size. Defaults to true. When
+  buffer for iov's larger than max_memcpy_size. Defaults to false. When
   disabled, only uses a bounce buffer
 
 *FI_EFA_MR_CACHE_MERGE_REGIONS*

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -71,7 +71,7 @@
 
 #define EFA_NO_DEFAULT -1
 
-#define EFA_DEF_MR_CACHE_ENABLE 1
+#define EFA_DEF_MR_CACHE_ENABLE 0
 #define EFA_DEF_MR_CACHE_MERGE_REGIONS 1
 
 int efa_mr_cache_enable		= EFA_DEF_MR_CACHE_ENABLE;

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -637,7 +637,7 @@ EFA_INI
 	fi_param_define(&rxr_prov, "cq_size", FI_PARAM_INT,
 			"Define the size of completion queue. (Default: 8192)");
 	fi_param_define(&rxr_prov, "mr_cache_enable", FI_PARAM_BOOL,
-			"Enables using the mr cache and in-line registration instead of a bounce buffer for iov's larger than max_memcpy_size. Defaults to true. When disabled, only uses a bounce buffer.");
+			"Enables using the mr cache and in-line registration instead of a bounce buffer for iov's larger than max_memcpy_size. Defaults to false. When disabled, only uses a bounce buffer.");
 	fi_param_define(&rxr_prov, "mr_cache_merge_regions", FI_PARAM_BOOL,
 			"Enables merging overlapping and adjacent memory registration regions. Defaults to true.");
 	fi_param_define(&rxr_prov, "mr_max_cached_count", FI_PARAM_SIZE_T,


### PR DESCRIPTION
We are starting to see performance issues with the MR cache thrashing
with larger message sizes. This commit disables the cache for EFA until
we have a better handle on the issue with an acceptable solution.

Signed-off-by: Raghu Raja <craghun@amazon.com>