### PR TITLE
prov/util,rxm: Alter RxM domain MR mode attribute

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -980,6 +980,9 @@ int ofi_ns_del_local_name(struct util_ns *ns, void *service, void *name);
 void *ofi_ns_resolve_name(struct util_ns *ns, const char *server,
 			  void *service);
 
+void ofi_alter_mr_mode(int *mr_mode, int hints_mr_mode, uint64_t info_caps,
+		       uint32_t api_version);
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -183,6 +183,9 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 			return -FI_ENOMEM;
 	}
 
+	ofi_alter_mr_mode(&info->domain_attr->mr_mode,
+			  core_info->domain_attr->mr_mode, info->caps, version);
+
 	return 0;
 }
 


### PR DESCRIPTION
The RxM provider was not altering the MR mode attribute based on API
version if the fi_getinfo() hints argument was NULL. Define
ofi_alter_domain_mr_mode_attr() to alter the MR mode attribute and have
RxM call it accordingly.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>