### PR TITLE
man: Define Tx and Rx capabilities

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -870,8 +870,20 @@ struct fi_tx_attr {
 The requested capabilities of the context.  The capabilities must be
 a subset of those requested of the associated endpoint.  See the
 CAPABILITIES section of fi_getinfo(3) for capability details.  If
-the caps field is 0 on input to fi_getinfo(3), the caps value from the
-fi_info structure will be used.
+the caps field is 0 on input to fi_getinfo(3), the applicable
+capability bits from the fi_info structure will be used.
+
+The following capabilities apply to the transmit attributes: FI_MSG,
+FI_RMA, FI_TAGGED, FI_ATOMIC, FI_READ, FI_WRITE, FI_SEND, FI_HMEM,
+FI_TRIGGER, FI_FENCE, FI_MULTICAST, FI_RMA_PMEM, and FI_NAMED_RX_CTX.
+
+Many applications will be able to ignore this field and rely solely
+on the fi_info::caps field.  Use of this field provides fine grained
+control over the transmit capabilities associated with an endpoint.
+It is useful when handling scalable endpoints, with multiple transmit
+contexts, for example, and allows configuring a specific transmit
+context with fewer capabilities than that supported by the endpoint
+or other transmit contexts.
 
 ## mode
 
@@ -1153,8 +1165,21 @@ struct fi_rx_attr {
 The requested capabilities of the context.  The capabilities must be
 a subset of those requested of the associated endpoint.  See the
 CAPABILITIES section if fi_getinfo(3) for capability details.  If
-the caps field is 0 on input to fi_getinfo(3), the caps value from the
-fi_info structure will be used.
+the caps field is 0 on input to fi_getinfo(3), the applicable
+capability bits from the fi_info structure will be used.
+
+The following capabilities apply to the receive attributes: FI_MSG,
+FI_RMA, FI_TAGGED, FI_ATOMIC, FI_REMOTE_READ, FI_REMOTE_WRITE, FI_RECV,
+FI_HMEM, FI_TRIGGER, FI_RMA_PMEM, FI_DIRECTED_RECV, FI_VARIABLE_MSG,
+FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, and FI_SOURCE_ERROR.
+
+Many applications will be able to ignore this field and rely solely
+on the fi_info::caps field.  Use of this field provides fine grained
+control over the receive capabilities associated with an endpoint.
+It is useful when handling scalable endpoints, with multiple receive
+contexts, for example, and allows configuring a specific receive
+context with fewer capabilities than that supported by the endpoint
+or other receive contexts.
 
 ## mode
 

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -296,8 +296,8 @@ additional optimizations.
 
 *FI_MULTICAST*
 : Indicates that the endpoint support multicast data transfers.  This
-  capability must be paired with at least one other data transfer capability,
-  (e.g. FI_MSG, FI_SEND, FI_RECV, ...).
+  capability must be paired with FI_MSG.  Aplications can use FI_SEND
+  and FI_RECV to optimize multicast as send-only or receive-only.
 
 *FI_NAMED_RX_CTX*
 : Requests that endpoints which support multiple receive contexts
@@ -424,18 +424,26 @@ additional optimizations.
 : Specifies that the endpoint should support transfers to and from
   device memory. 
 
-Capabilities may be grouped into two general categories: primary and
-secondary.  Primary capabilities must explicitly be requested by an
-application, and a provider must enable support for only those primary
-capabilities which were selected.  Secondary capabilities may optionally
-be requested by an application.  If requested, a provider must support
-the capability or fail the fi_getinfo request (FI_ENODATA).  A provider
+Capabilities may be grouped into three general categories: primary,
+secondary, and primary modifiers.  Primary capabilities must explicitly
+be requested by an application, and a provider must enable support for
+only those primary capabilities which were selected.  Primary modifiers
+are used to limit a primary capability, such as restricting an endpoint
+to being send-only.  If no modifiers are specified for an applicable
+capability, all relevant modifiers are assumed.  See above definitions
+for details.
+
+Secondary capabilities may optionally be requested by an application.
+If requested, a provider must support the capability or fail the
+fi_getinfo request (FI_ENODATA).  A provider
 may optionally report non-selected secondary capabilities if doing so
 would not compromise performance or security.
 
 Primary capabilities: FI_MSG, FI_RMA, FI_TAGGED, FI_ATOMIC, FI_MULTICAST,
-FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_READ, FI_WRITE, FI_RECV, FI_SEND,
-FI_REMOTE_READ, FI_REMOTE_WRITE, FI_VARIABLE_MSG, FI_HMEM.
+FI_NAMED_RX_CTX, FI_DIRECTED_RECV, FI_VARIABLE_MSG, FI_HMEM
+
+Primary modifiers: FI_READ, FI_WRITE, FI_RECV, FI_SEND,
+FI_REMOTE_READ, FI_REMOTE_WRITE
 
 Secondary capabilities: FI_MULTI_RECV, FI_SOURCE, FI_RMA_EVENT, FI_SHARED_AV,
 FI_TRIGGER, FI_FENCE, FI_LOCAL_COMM, FI_REMOTE_COMM, FI_SOURCE_ERR, FI_RMA_PMEM.


### PR DESCRIPTION
The man pages do not clearly identify which capability bits are
tx vs rx attributes.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>