### PR TITLE
prov/shm: refactor ptrace_scope to use globally

### DIFF
--- a/man/fi_shm.7.md
+++ b/man/fi_shm.7.md
@@ -108,8 +108,14 @@ EPs must be bound to both RX and TX CQs.
 No support for counters.
 
 # RUNTIME PARAMETERS
-
-No runtime parameters are currently defined.
+*FI_SHM_DISABLE_CMA*
+: Force disable use of CMA (Cross Memory Attach) in shm environment. CMA is a
+  Linux feature for copying data directly between two processes without the use
+  of intermediate buffering. This requires the processes to have full access to
+  the peer's address space (the same permissions required to perform a ptrace).
+  CMA is enabled by default but checked for availability during run-time.
+  For more information see the CMA [`man pages`]
+  (https://linux.die.net/man/2/process_vm_writev)
 
 # SEE ALSO
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -67,6 +67,11 @@
 #define SMR_MAJOR_VERSION 1
 #define SMR_MINOR_VERSION 1
 
+struct smr_env {
+	int disable_cma;
+};
+
+extern struct smr_env smr_env;
 extern struct fi_provider smr_prov;
 extern struct fi_info smr_info;
 extern struct util_prov smr_util_prov;
@@ -169,7 +174,8 @@ static inline const char *smr_no_prefix(const char *addr)
 #define SMR_RMA_ORDER (OFI_ORDER_RAR_SET | OFI_ORDER_RAW_SET | FI_ORDER_RAS |	\
 		       OFI_ORDER_WAR_SET | OFI_ORDER_WAW_SET | FI_ORDER_WAS |	\
 		       FI_ORDER_SAR | FI_ORDER_SAW)
-#define smr_fast_rma_enabled(mode, order) ((mode & FI_MR_VIRT_ADDR) && \
+#define smr_fast_rma_enabled(mode, order) (!smr_env.disable_cma && \
+			(mode & FI_MR_VIRT_ADDR) && \
 			!(order & SMR_RMA_ORDER))
 
 struct smr_ep {

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -36,6 +36,14 @@
 #include "smr.h"
 #include "smr_signal.h"
 
+struct smr_env smr_env = {
+	.disable_cma	= 0,
+};
+
+static void smr_init_env(void)
+{
+	fi_param_get_bool(&smr_prov, "disable_cma", &smr_env.disable_cma);
+}
 
 static void smr_resolve_addr(const char *node, const char *service,
 			     char **addr, size_t *addrlen)
@@ -63,10 +71,14 @@ static void smr_resolve_addr(const char *node, const char *service,
 	(*addr)[*addrlen - 1]  = '\0';
 }
 
-static int smr_get_ptrace_scope(void)
+static void smr_check_ptrace_scope(void)
 {
+	static bool init = 0;
 	FILE *file;
 	int scope, ret;
+
+	if (smr_env.disable_cma || init)
+		return;
 
 	scope = 0;
 	file = fopen("/proc/sys/kernel/yama/ptrace_scope", "r");
@@ -75,16 +87,21 @@ static int smr_get_ptrace_scope(void)
 		if (ret != 1) {
 			FI_WARN(&smr_prov, FI_LOG_CORE,
 				"Error getting value from ptrace_scope\n");
-			return -FI_EINVAL;
+			scope = 1;
+			goto out;
 		}
 		ret = fclose(file);
 		if (ret) {
 			FI_WARN(&smr_prov, FI_LOG_CORE,
 				"Error closing ptrace_scope file\n");
-			return -FI_EINVAL;
+			scope = 1;
+			goto out;
 		}
 	}
-	return scope;
+
+out:
+	smr_env.disable_cma = scope;
+	init = 1;
 }
 
 static int smr_getinfo(uint32_t version, const char *node, const char *service,
@@ -94,19 +111,18 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 	struct fi_info *cur;
 	uint64_t mr_mode, msg_order;
 	int fast_rma;
-	int ptrace_scope, ret;
+	int ret;
 
 	mr_mode = hints && hints->domain_attr ? hints->domain_attr->mr_mode :
 						FI_MR_VIRT_ADDR;
 	msg_order = hints && hints->tx_attr ? hints->tx_attr->msg_order : 0;
+	smr_check_ptrace_scope();
 	fast_rma = smr_fast_rma_enabled(mr_mode, msg_order);
 
 	ret = util_getinfo(&smr_util_prov, version, node, service, flags,
 			   hints, info);
 	if (ret)
 		return ret;
-
-	ptrace_scope = smr_get_ptrace_scope();
 
 	for (cur = *info; cur; cur = cur->next) {
 		if (!(flags & FI_SOURCE) && !cur->dest_addr)
@@ -128,7 +144,7 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 			cur->ep_attr->max_order_waw_size = 0;
 			cur->ep_attr->max_order_war_size = 0;
 		}
-		if (ptrace_scope != 0)
+		if (smr_env.disable_cma)
 			cur->ep_attr->max_msg_size = SMR_INJECT_SIZE;
 	}
 	return 0;
@@ -156,6 +172,10 @@ struct util_prov smr_util_prov = {
 
 SHM_INI
 {
+	fi_param_define(&smr_prov, "disable_cma", FI_PARAM_BOOL,
+			"Disable use of CMA (Cross Memory Attach) for \
+			copying data directly between processes (default: no)");
+	smr_init_env();
 
 	/* Signal handlers to cleanup tmpfs files on an unclean shutdown */
 	smr_reg_sig_hander(SIGBUS);


### PR DESCRIPTION
The availability of CMA/ptrace_scope needs to be
known throughout shm and not just on getinfo since
it is needed to determine whether to use the fast
RMA path or not. Add an environment variable to
access this throughout shm. This also allows
applications to toggle to turn off CMA if desired.

Signed-off-by: aingerson <alexia.ingerson@intel.com>