### PR TITLE
fabtests: Check for FI_INJECT flag

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.c
+++ b/fabtests/benchmarks/benchmark_shared.c
@@ -82,8 +82,7 @@ int pingpong(void)
 		for (i = 0; i < opts.iterations + opts.warmup_iterations; i++) {
 			if (i == opts.warmup_iterations)
 				ft_start();
-
-			if (opts.transfer_size < fi->tx_attr->inject_size)
+			if ((opts.transfer_size < fi->tx_attr->inject_size) && (fi->tx_attr->op_flags & FI_INJECT))
 				ret = ft_inject(ep, remote_fi_addr, opts.transfer_size);
 			else
 				ret = ft_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);
@@ -103,7 +102,7 @@ int pingpong(void)
 			if (ret)
 				return ret;
 
-			if (opts.transfer_size < fi->tx_attr->inject_size)
+			if ((opts.transfer_size < fi->tx_attr->inject_size) && (fi->tx_attr->op_flags & FI_INJECT))
 				ret = ft_inject(ep, remote_fi_addr, opts.transfer_size);
 			else
 				ret = ft_tx(ep, remote_fi_addr, opts.transfer_size, &tx_ctx);


### PR DESCRIPTION
Before calling fi_inject, also check if FI_INJECT flag is supported by
the provider.

Signed-off-by: Dipti Kothari <dkothar@amazon.com>