### PR TITLE
prov/efa: Fix compilation warning in DSO build

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -52,6 +52,9 @@
 #include <ofi_util.h>
 
 #include "efa.h"
+#if HAVE_EFA_DL
+#include <ofi_shm.h>
+#endif
 
 #define EFA_FABRIC_PREFIX "EFA-"
 


### PR DESCRIPTION
In DSO build, ofi_shm.h should be included to
declare function smr_cleanup().

Signed-off-by: Jie Zhang <zhngaj@amazon.com>