### PR TITLE
man: Sort flags into alphabetical order

### DIFF
--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -163,17 +163,31 @@ accessed by multiple threads.  Applications which can guarantee
 serialization in their access of provider allocated resources and
 interfaces enables a provider to eliminate lower-level locks.
 
-*FI_THREAD_UNSPEC*
-: This value indicates that no threading model has been defined.  It
-  may be used on input hints to the fi_getinfo call.  When specified,
-  providers will return a threading model that allows for the greatest
-  level of parallelism.
+*FI_THREAD_COMPLETION*
+: The completion threading model is intended for providers that make use
+  of manual progress.  Applications must serialize access to all objects
+  that are associated through the use of having a shared completion
+  structure.  This includes endpoint, transmit context, receive context,
+  completion queue, counter, wait set, and poll set objects.
 
-*FI_THREAD_SAFE*
-: A thread safe serialization model allows a multi-threaded
-  application to access any allocated resources through any interface
-  without restriction.  All providers are required to support
-  FI_THREAD_SAFE.
+  For example, threads must serialize access to an endpoint and its
+  bound completion queue(s) and/or counters.  Access to endpoints that
+  share the same completion queue must also be serialized.
+
+  The use of FI_THREAD_COMPLETION can increase parallelism over
+  FI_THREAD_SAFE, but requires the use of isolated resources.
+
+*FI_THREAD_DOMAIN*
+: A domain serialization model requires applications to serialize
+  access to all objects belonging to a domain.
+
+*FI_THREAD_ENDPOINT*
+: The endpoint threading model is similar to FI_THREAD_FID, but with
+  the added restriction that serialization is required when accessing
+  the same endpoint, even if multiple transmit and receive contexts are
+  used.  Conceptually, FI_THREAD_ENDPOINT maps well to providers that
+  implement fabric services in hardware but use a single command
+  queue to access different data flows.
 
 *FI_THREAD_FID*
 : A fabric descriptor (FID) serialization model requires applications
@@ -199,31 +213,17 @@ interfaces enables a provider to eliminate lower-level locks.
   fabric services in hardware and provide separate command queues to
   different data flows.
 
-*FI_THREAD_ENDPOINT*
-: The endpoint threading model is similar to FI_THREAD_FID, but with
-  the added restriction that serialization is required when accessing
-  the same endpoint, even if multiple transmit and receive contexts are
-  used.  Conceptually, FI_THREAD_ENDPOINT maps well to providers that
-  implement fabric services in hardware but use a single command
-  queue to access different data flows.
+*FI_THREAD_SAFE*
+: A thread safe serialization model allows a multi-threaded
+  application to access any allocated resources through any interface
+  without restriction.  All providers are required to support
+  FI_THREAD_SAFE.
 
-*FI_THREAD_COMPLETION*
-: The completion threading model is intended for providers that make use
-  of manual progress.  Applications must serialize access to all objects
-  that are associated through the use of having a shared completion
-  structure.  This includes endpoint, transmit context, receive context,
-  completion queue, counter, wait set, and poll set objects.
-
-  For example, threads must serialize access to an endpoint and its
-  bound completion queue(s) and/or counters.  Access to endpoints that
-  share the same completion queue must also be serialized.
-
-  The use of FI_THREAD_COMPLETION can increase parallelism over
-  FI_THREAD_SAFE, but requires the use of isolated resources.
-
-*FI_THREAD_DOMAIN*
-: A domain serialization model requires applications to serialize
-  access to all objects belonging to a domain.
+*FI_THREAD_UNSPEC*
+: This value indicates that no threading model has been defined.  It
+  may be used on input hints to the fi_getinfo call.  When specified,
+  providers will return a threading model that allows for the greatest
+  level of parallelism.
 
 ## Progress Models (control_progress / data_progress)
 
@@ -253,10 +253,6 @@ reliable transfers, as a result of retry and acknowledgement processing.
 
 To balance between performance and ease of use, two progress models
 are defined.
-
-*FI_PROGRESS_UNSPEC*
-: This value indicates that no progress model has been defined.  It
-  may be used on input hints to the fi_getinfo call.
 
 *FI_PROGRESS_AUTO*
 : This progress model indicates that the provider will make forward
@@ -293,6 +289,10 @@ are defined.
   manual progress may still need application assistance to process
   received operations.
 
+*FI_PROGRESS_UNSPEC*
+: This value indicates that no progress model has been defined.  It
+  may be used on input hints to the fi_getinfo call.
+
 ## Resource Management (resource_mgmt)
 
 Resource management (RM) is provider and protocol support to protect
@@ -314,10 +314,6 @@ provider implementation and protocol may still provide some level of
 protection against overruns.  However, such protection is not guaranteed.
 The following values for resource management are defined.
 
-*FI_RM_UNSPEC*
-: This value indicates that no resource management model has been defined.
-  It may be used on input hints to the fi_getinfo call.
-
 *FI_RM_DISABLED*
 : The provider is free to select an implementation and protocol that does
   not protect against resource overruns.  The application is responsible
@@ -325,6 +321,10 @@ The following values for resource management are defined.
 
 *FI_RM_ENABLED*
 : Resource management is enabled for this provider domain.
+
+*FI_RM_UNSPEC*
+: This value indicates that no resource management model has been defined.
+  It may be used on input hints to the fi_getinfo call.
 
 The behavior of the various resource management options depends on whether
 the endpoint is reliable or unreliable, as well as provider and protocol
@@ -427,14 +427,14 @@ Specifies the type of address vectors that are usable with this domain.
 For additional details on AV type, see [`fi_av`(3)](fi_av.3.html).
 The following values may be specified.
 
-*FI_AV_UNSPEC*
-: Any address vector format is requested and supported.
-
 *FI_AV_MAP*
 : Only address vectors of type AV map are requested or supported.
 
 *FI_AV_TABLE*
 : Only address vectors of type AV index are requested or supported.
+
+*FI_AV_UNSPEC*
+: Any address vector format is requested and supported.
 
 Address vectors are only used by connectionless endpoints.  Applications
 that require the use of a specific type of address vector should set the
@@ -450,6 +450,13 @@ Defines memory registration specific mode bits used with this domain.
 Full details on MR mode options are available in [`fi_mr`(3)](fi_mr.3.html).
 The following values may be specified.
 
+*FI_MR_ALLOCATED*
+: Indicates that memory registration occurs on allocated data buffers, and
+  physical pages must back all virtual addresses being registered.
+
+*FI_MR_ENDPOINT*
+: Memory registration occurs at the endpoint level, rather than domain.
+
 *FI_MR_LOCAL*
 : The provider is optimized around having applications register memory
   for locally accessed data buffers.  Data buffers used in send and
@@ -457,38 +464,31 @@ The following values may be specified.
   operations must be registered by the application for access domains
   opened with this capability.
 
-*FI_MR_RAW*
-: The provider requires additional setup as part of their memory registration
-  process.  This mode is required by providers that use a memory key
-  that is larger than 64-bits.
-
-*FI_MR_VIRT_ADDR*
-: Registered memory regions are referenced by peers using the virtual address
-  of the registered memory region, rather than a 0-based offset.
-
-*FI_MR_ALLOCATED*
-: Indicates that memory registration occurs on allocated data buffers, and
-  physical pages must back all virtual addresses being registered.
-
-*FI_MR_PROV_KEY*
-: Memory registration keys are selected and returned by the provider.
-
 *FI_MR_MMU_NOTIFY*
 : Indicates that the application is responsible for notifying the provider
   when the page tables referencing a registered memory region may have been
   updated.
 
+*FI_MR_PROV_KEY*
+: Memory registration keys are selected and returned by the provider.
+
+*FI_MR_RAW*
+: The provider requires additional setup as part of their memory registration
+  process.  This mode is required by providers that use a memory key
+  that is larger than 64-bits.
+
 *FI_MR_RMA_EVENT*
 : Indicates that the memory regions associated with completion counters
   must be explicitly enabled after being bound to any counter.
-
-*FI_MR_ENDPOINT*
-: Memory registration occurs at the endpoint level, rather than domain.
 
 *FI_MR_UNSPEC*
 : Defined for compatibility -- library versions 1.4 and earlier.  Setting
   mr_mode to 0 indicates that FI_MR_BASIC or FI_MR_SCALABLE are requested
   and supported.
+
+*FI_MR_VIRT_ADDR*
+: Registered memory regions are referenced by peers using the virtual address
+  of the registered memory region, rather than a 0-based offset.
 
 *FI_MR_BASIC*
 : Defined for compatibility -- library versions 1.4 and earlier.  Only


### PR DESCRIPTION
Although it's been commented that the current ordering of flags is
'spicy', it makes it hard to find flags.  Re-order them.

This changes no existing text, only the order.  However, some missing
text has been added where needed.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>