### PR TITLE
Reduce warnings when -Wextra is enabled

### DIFF
--- a/include/ofi_bitmask.h
+++ b/include/ofi_bitmask.h
@@ -58,43 +58,42 @@ static inline int ofi_bitmask_create(struct bitmask *mask, size_t size)
 	mask->size = size;
 
 	return FI_SUCCESS;
-};
+}
 
 static inline void ofi_bitmask_free(struct bitmask *mask)
 {
 	free(mask->bytes);
 	mask->bytes = NULL;
-};
+}
 
 static inline size_t ofi_bitmask_bytesize(struct bitmask *mask)
 {
 	return (mask->size % 8) ? (mask->size / 8 + 1) : (mask->size / 8);
-};
+}
 
 static inline void ofi_bitmask_unset(struct bitmask *mask, size_t idx)
 {
 	assert(idx <= mask->size);
 	mask->bytes[idx / 8] &= ~(0x01 << (idx % 8));
-};
+}
 
 static inline void ofi_bitmask_set(struct bitmask *mask, size_t idx)
 {
 	assert(idx <= mask->size);
 	mask->bytes[idx / 8] |= (0x01 << (idx % 8));
-};
+}
 
 static inline void ofi_bitmask_set_all(struct bitmask *mask)
 {
 	memset(mask->bytes, 0xff, ofi_bitmask_bytesize(mask));
-};
+}
 
 static inline size_t ofi_bitmask_get_lsbset(struct bitmask mask)
 {
-	int cur;
 	uint8_t tmp;
 	size_t ret = 0;
 
-	for (cur = 0; cur < (mask.size/8); cur++) {
+	for (size_t cur = 0; cur < (mask.size/8); cur++) {
 		if (mask.bytes[cur]) {
 			tmp = mask.bytes[cur];
 			while (!(tmp & 0x1)) {
@@ -109,6 +108,6 @@ static inline size_t ofi_bitmask_get_lsbset(struct bitmask mask)
 
 	assert(ret <= (mask.size));
 	return ret;
-};
+}
 
 #endif

--- a/include/ofi_recvwin.h
+++ b/include/ofi_recvwin.h
@@ -50,7 +50,7 @@
 #include <ofi_rbuf.h>
 
 #define OFI_DECL_RECVWIN_BUF(entrytype, name, id_type)			\
-OFI_DECLARE_CIRQUE(entrytype, recvwin_cirq);				\
+OFI_DECLARE_CIRQUE(entrytype, recvwin_cirq)				\
 struct name {								\
 	id_type exp_msg_id;						\
 	id_type win_size;						\

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -80,7 +80,7 @@ enum {
 #define SMR_RX_COMPLETION	(1 << 3)
 #define SMR_MULTI_RECV		(1 << 4)
 
-/* 
+/*
  * Unique smr_op_hdr for smr message protocol:
  * 	addr - local fi_addr of peer sending msg (for shm lookup)
  * 	op - type of op (ex. ofi_op_msg, defined in ofi_proto.h)
@@ -217,9 +217,9 @@ struct smr_inject_buf {
 	};
 };
 
-OFI_DECLARE_CIRQUE(struct smr_cmd, smr_cmd_queue);
-OFI_DECLARE_CIRQUE(struct smr_resp, smr_resp_queue);
-DECLARE_SMR_FREESTACK(struct smr_inject_buf, smr_inject_pool);
+OFI_DECLARE_CIRQUE(struct smr_cmd, smr_cmd_queue)
+OFI_DECLARE_CIRQUE(struct smr_resp, smr_resp_queue)
+DECLARE_SMR_FREESTACK(struct smr_inject_buf, smr_inject_pool)
 
 static inline struct smr_region *smr_peer_region(struct smr_region *smr, int i)
 {
@@ -239,7 +239,7 @@ static inline struct smr_inject_pool *smr_inject_pool(struct smr_region *smr)
 }
 static inline struct smr_addr *smr_peer_addr(struct smr_region *smr)
 {
-	return (struct smr_addr *) ((char *) smr + smr->peer_addr_offset); 
+	return (struct smr_addr *) ((char *) smr + smr->peer_addr_offset);
 }
 static inline const char *smr_name(struct smr_region *smr)
 {

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -476,7 +476,7 @@ struct util_cq_oflow_err_entry {
 	struct slist_entry		list_entry;
 };
 
-OFI_DECLARE_CIRQUE(struct fi_cq_tagged_entry, util_comp_cirq);
+OFI_DECLARE_CIRQUE(struct fi_cq_tagged_entry, util_comp_cirq)
 
 typedef void (*ofi_cq_progress_func)(struct util_cq *cq);
 
@@ -674,7 +674,7 @@ static inline void ofi_cntr_inc(struct util_cntr *cntr)
 struct util_av_entry {
 	ofi_atomic32_t	use_cnt;
 	UT_hash_handle	hh;
-	char		addr[0];
+	char		addr[];
 };
 
 struct util_av {
@@ -796,7 +796,7 @@ struct util_event {
 	int			size;
 	int			event;
 	int			err;
-	uint8_t			data[0];
+	uint8_t			data[];
 };
 
 int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -97,7 +97,7 @@ fi_addr_t efa_ahn_qpn_to_addr(struct efa_av *av, uint16_t ahn, uint16_t qpn)
 
 static inline int efa_av_is_valid_address(struct efa_ep_addr *addr)
 {
-	struct efa_ep_addr all_zeros = {};
+	struct efa_ep_addr all_zeros = {0};
 
 	return memcmp(addr->raw, all_zeros.raw, sizeof(addr->raw));
 }
@@ -226,7 +226,7 @@ static int efa_av_insert_ah(struct efa_av *av, struct efa_ep_addr *addr,
 	}
 
 	EFA_INFO(FI_LOG_AV, "av successfully inserted conn[%p] fi_addr[%" PRIu64 "]\n",
-		 conn, *fi_addr);
+		 (void *)conn, *fi_addr);
 
 	av->used++;
 	return FI_SUCCESS;
@@ -480,7 +480,7 @@ static int efa_av_remove_ah(struct fid_av *av_fid, fi_addr_t *fi_addr,
 
 	memset(str, 0, sizeof(str));
 	inet_ntop(AF_INET6, conn->ep_addr.raw, str, INET6_ADDRSTRLEN);
-	EFA_INFO(FI_LOG_AV, "av_remove conn[%p] with GID[%s] QP[%u]\n", conn,
+	EFA_INFO(FI_LOG_AV, "av_remove conn[%p] with GID[%s] QP[%u]\n", (void *)conn,
 			str, conn->ep_addr.qpn);
 	av->used--;
 

--- a/prov/efa/src/efa_cm.c
+++ b/prov/efa/src/efa_cm.c
@@ -48,7 +48,7 @@ static int efa_ep_getname(fid_t ep_fid, void *addr, size_t *addrlen)
 {
 	struct efa_ep_addr *ep_addr;
 	struct efa_ep *ep;
-	char str[INET6_ADDRSTRLEN] = {};
+	char str[INET6_ADDRSTRLEN] = {0};
 
 	ep = container_of(ep_fid, struct efa_ep, util_ep.ep_fid);
 

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -828,8 +828,8 @@ static_assert(sizeof(struct rxr_pkt_entry) == 64, "rxr_pkt_entry check");
 #endif
 #endif
 
-OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf, uint32_t);
-DECLARE_FREESTACK(struct rxr_robuf, rxr_robuf_fs);
+OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf, uint32_t)
+DECLARE_FREESTACK(struct rxr_robuf, rxr_robuf_fs)
 
 #define RXR_CTRL_HDR_SIZE		(sizeof(struct rxr_ctrl_cq_hdr))
 

--- a/prov/hook/hook_debug/src/hook_debug.c
+++ b/prov/hook/hook_debug/src/hook_debug.c
@@ -89,14 +89,14 @@ static void hook_debug_trace_exit(struct fid *fid, struct fid *hfid,
 
 	if (ret > 0) {
 		FI_TRACE(hook_to_hprov(fid), subsys, "%s (fid: %p) returned: "
-			 "%zd\n", fn, hfid, ret);
+			 "%zd\n", fn, (void *)hfid, ret);
 		goto out;
 	}
 
 	if (ret != -FI_EAGAIN || !eagain_count ||
 	    !((*eagain_count)++ % HOOK_DEBUG_EAGAIN_LOG))
 		FI_TRACE(hook_to_hprov(fid), subsys, "%s (fid: %p) returned: "
-			 "%zd (%s)\n", fn, hfid, ret, fi_strerror(-ret));
+			 "%zd (%s)\n", fn, (void *)hfid, ret, fi_strerror(-ret));
 out:
 	if (eagain_count && ret != -FI_EAGAIN)
 		*eagain_count = 0;
@@ -105,7 +105,7 @@ out:
 static void
 hook_debug_trace_exit_eq(struct hook_debug_eq *eq, const char *fn, ssize_t ret)
 {
-	return hook_debug_trace_exit(&eq->hook_eq.eq.fid, &eq->hook_eq.heq->fid,
+	hook_debug_trace_exit(&eq->hook_eq.eq.fid, &eq->hook_eq.heq->fid,
 				     FI_LOG_EQ, fn, ret, &eq->eagain_count);
 }
 
@@ -143,7 +143,7 @@ static void hook_debug_rx_end(struct hook_debug_ep *ep, char *fn,
 			ep->rx_outs++;
 			FI_TRACE(hook_to_hprov(&ep->hook_ep.ep.fid),
 				 FI_LOG_EP_DATA, "ep: %p rx_outs: %zu\n",
-				 ep->hook_ep.hep, ep->rx_outs);
+				 (void *)ep->hook_ep.hep, ep->rx_outs);
 		} else {
 			rx_entry = mycontext;
 			ofi_buf_free(rx_entry);
@@ -238,7 +238,7 @@ static void hook_debug_tx_end(struct hook_debug_ep *ep, char *fn,
 			ep->tx_outs++;
 			FI_TRACE(hook_to_hprov(&ep->hook_ep.ep.fid),
 				 FI_LOG_EP_DATA, "ep: %p tx_outs: %zu\n",
-				 ep->hook_ep.hep, ep->tx_outs);
+				 (void *)ep->hook_ep.hep, ep->tx_outs);
 		} else {
 			tx_entry = mycontext;
 			ofi_buf_free(tx_entry);
@@ -522,7 +522,7 @@ static void hook_debug_cq_process_entry(struct hook_debug_cq *mycq,
 				rx_entry->ep->rx_outs--;
 				FI_TRACE(hook_to_hprov(&mycq->hook_cq.cq.fid),
 					 FI_LOG_CQ, "ep: %p rx_outs: %zu\n",
-					 rx_entry->ep->hook_ep.hep,
+					 (void *)rx_entry->ep->hook_ep.hep,
 					 rx_entry->ep->rx_outs);
 				ofi_buf_free(rx_entry);
 			}
@@ -535,7 +535,7 @@ static void hook_debug_cq_process_entry(struct hook_debug_cq *mycq,
 			tx_entry->ep->tx_outs--;
 			FI_TRACE(hook_to_hprov(&mycq->hook_cq.cq.fid),
 				 FI_LOG_CQ, "ep: %p tx_outs: %zu\n",
-				 tx_entry->ep->hook_ep.hep,
+				 (void *)tx_entry->ep->hook_ep.hep,
 				 tx_entry->ep->tx_outs);
 			ofi_buf_free(tx_entry);
 		}
@@ -601,7 +601,8 @@ static void hook_debug_cq_attr_log(struct hook_domain *dom,
 	HOOK_DEBUG_TRACE(dom->fabric, FI_LOG_CQ, "\tsignaling_vector: %d\n",
 			 attr->signaling_vector);
 	HOOK_DEBUG_TRACE(dom->fabric, FI_LOG_CQ, "\twait_cond: %s\n", "TBD");
-	HOOK_DEBUG_TRACE(dom->fabric, FI_LOG_CQ, "\twait_set: %p\n", attr->wait_set);
+	HOOK_DEBUG_TRACE(dom->fabric, FI_LOG_CQ, "\twait_set: %p\n",
+             (void *)attr->wait_set);
 }
 
 int hook_debug_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
@@ -633,7 +634,7 @@ int hook_debug_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		goto err;
 
 	FI_TRACE(hook_fabric_to_hprov(mycq->hook_cq.domain->fabric), FI_LOG_CQ,
-		 "cq opened, fid: %p\n", &mycq->hook_cq.hcq->fid);
+		 "cq opened, fid: %p\n", (void *)&mycq->hook_cq.hcq->fid);
 
 	mycq->hook_cq.cq.fid.ops = &hook_debug_cq_fid_ops;
 	mycq->hook_cq.cq.ops = &hook_debug_cq_ops;
@@ -682,13 +683,13 @@ int hook_debug_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	case FI_CLASS_CQ:
 		cq = container_of(bfid, struct hook_cq, cq.fid);
 		HOOK_DEBUG_TRACE(cq->domain->fabric, FI_LOG_EP_CTRL,
-				 "cq: %p bind flags: %s\n", cq->hcq,
+				 "cq: %p bind flags: %s\n", (void *)cq->hcq,
 				 fi_tostr(&flags, FI_TYPE_CAPS));
 		break;
 	case FI_CLASS_CNTR:
 		cntr = container_of(bfid, struct hook_cntr, cntr.fid);
 		HOOK_DEBUG_TRACE(cntr->domain->fabric, FI_LOG_EP_CTRL,
-				 "cntr: %p bind flags: %s\n", cntr->hcntr,
+				 "cntr: %p bind flags: %s\n", (void *)cntr->hcntr,
 				 fi_tostr(&flags, FI_TYPE_CAPS));
 		break;
 	}
@@ -779,7 +780,7 @@ int hook_debug_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err;
 
 	FI_TRACE(hook_to_hprov(&myep->hook_ep.ep.fid), FI_LOG_EP_CTRL,
-		 "endpoint opened, fid: %p\n", &myep->hook_ep.hep->fid);
+		 "endpoint opened, fid: %p\n", (void *)&myep->hook_ep.hep->fid);
 
 	myep->hook_ep.ep.fid.ops = &hook_debug_ep_fid_ops;
 	myep->hook_ep.ep.msg = &hook_debug_msg_ops;
@@ -930,7 +931,7 @@ static int hook_debug_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int t
 
 	HOOK_DEBUG_TRACE(mycntr->domain->fabric, FI_LOG_CNTR,
 			 "cntr: %p, threshold: %" PRIu64 ", timeout: %d\n",
-			 mycntr->hcntr, threshold, timeout);
+			 (void *)mycntr->hcntr, threshold, timeout);
 
 	ret = fi_cntr_wait(mycntr->hcntr, threshold, timeout);
 
@@ -944,7 +945,7 @@ int hook_debug_cntr_init(struct fid *fid)
 {
 	struct hook_cntr *mycntr = container_of(fid, struct hook_cntr, cntr.fid);
 	HOOK_DEBUG_TRACE(mycntr->domain->fabric, FI_LOG_CNTR,
-			 "fi_cntr_open: %p\n", mycntr->hcntr);
+			 "fi_cntr_open: %p\n", (void *)mycntr->hcntr);
 	mycntr->cntr.ops = &hook_debug_cntr_ops;
 	return 0;
 }

--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -218,7 +218,7 @@ struct mrail_recv {
 	uint64_t 		ignore;
 	struct mrail_rndv_recv	rndv;
 };
-DECLARE_FREESTACK(struct mrail_recv, mrail_recv_fs);
+DECLARE_FREESTACK(struct mrail_recv, mrail_recv_fs)
 
 int mrail_cq_process_buf_recv(struct fi_cq_tagged_entry *comp,
 			      struct mrail_recv *recv);

--- a/prov/mrail/src/mrail_cq.c
+++ b/prov/mrail/src/mrail_cq.c
@@ -436,7 +436,7 @@ static int mrail_handle_recv_completion(struct fi_cq_tagged_entry *comp,
 	peer_info = ofi_av_get_addr(mrail_ep->util_ep.av, (int) src_addr);
 	FI_DBG(&mrail_prov, FI_LOG_CQ,
 			"ep=%p peer=%d received seq=%d, expected=%d\n",
-			mrail_ep, (int)peer_info->addr, seq_no,
+			(void *)mrail_ep, (int)peer_info->addr, seq_no,
 			peer_info->expected_seq_no);
 	ofi_ep_lock_acquire(&mrail_ep->util_ep);
 	if (seq_no == peer_info->expected_seq_no) {

--- a/prov/mrail/src/mrail_rma.c
+++ b/prov/mrail/src/mrail_rma.c
@@ -183,7 +183,7 @@ void mrail_progress_deferred_reqs(struct mrail_ep *mrail_ep)
 static ssize_t mrail_prepare_rma_subreqs(struct mrail_ep *mrail_ep,
 		const struct fi_msg_rma *msg, struct mrail_req *req)
 {
-	ssize_t ret;
+	ssize_t ret = 0;
 	struct mrail_subreq *subreq;
 	size_t subreq_count;
 	size_t total_len;
@@ -200,7 +200,7 @@ static ssize_t mrail_prepare_rma_subreqs(struct mrail_ep *mrail_ep,
 	 */
 	subreq_count = mrail_ep->num_eps;
 
-	total_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count); 
+	total_len = ofi_total_iov_len(msg->msg_iov, msg->iov_count);
 	chunk_len = total_len / subreq_count;
 
 	/* The first chunk is the longest */

--- a/prov/rstream/src/rstream.h
+++ b/prov/rstream/src/rstream.h
@@ -142,7 +142,7 @@ struct rstream_ctx_data {
 	size_t len;
 };
 
-DECLARE_FREESTACK(struct rstream_ctx_data, rstream_tx_ctx_fs);
+DECLARE_FREESTACK(struct rstream_ctx_data, rstream_tx_ctx_fs)
 
 struct rstream_tx_ctx {
 	struct rstream_ctx_data *tx_ctxs;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -165,7 +165,7 @@ extern char *rxm_cm_state_str[];
 #define RXM_CM_UPDATE_STATE(handle, new_state)				\
 	do {								\
 		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "[CM] handle: "	\
-		       "%p %s -> %s\n",	handle,				\
+		       "%p %s -> %s\n",	(void *)handle,				\
 		       rxm_cm_state_str[handle->state],			\
 		       rxm_cm_state_str[new_state]);			\
 		handle->state = new_state;				\
@@ -600,7 +600,7 @@ struct rxm_recv_entry {
 		struct rxm_tx_base_buf *tx_buf;
 	} rndv;
 };
-DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
+DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs)
 
 enum rxm_recv_queue_type {
 	RXM_RECV_QUEUE_UNSPEC,

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -156,7 +156,7 @@ static int rxm_cmap_del_handle(struct rxm_cmap_handle *handle)
 	int ret;
 
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
-	       "marking connection handle: %p for deletion\n", handle);
+	       "marking connection handle: %p for deletion\n", (void *)handle);
 	rxm_cmap_clear_key(handle);
 
 	RXM_CM_UPDATE_STATE(handle, RXM_CMAP_SHUTDOWN);
@@ -298,7 +298,7 @@ static int rxm_cmap_alloc_handle(struct rxm_cmap *cmap, fi_addr_t fi_addr,
 		return -FI_ENOMEM;
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
 	       "Allocated handle: %p for fi_addr: %" PRIu64 "\n",
-	       *handle, fi_addr);
+	       (void *)*handle, fi_addr);
 	ret = rxm_cmap_check_and_realloc_handles_table(cmap, fi_addr);
 	if (OFI_UNLIKELY(ret)) {
 		rxm_conn_free(*handle);
@@ -325,7 +325,7 @@ static int rxm_cmap_alloc_handle_peer(struct rxm_cmap *cmap, void *addr,
 	}
 	ofi_straddr_dbg(cmap->av->prov, FI_LOG_AV, "Allocated handle for addr",
 			addr);
-	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "handle: %p\n", *handle);
+	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "handle: %p\n", (void *)*handle);
 	rxm_cmap_init_handle(*handle, cmap, state, FI_ADDR_NOTAVAIL, peer);
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Adding handle to peer list\n");
 	peer->handle = *handle;
@@ -426,7 +426,7 @@ void rxm_cmap_process_shutdown(struct rxm_cmap *cmap,
 			       struct rxm_cmap_handle *handle)
 {
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
-		"Processing shutdown for handle: %p\n", handle);
+		"Processing shutdown for handle: %p\n", (void *)handle);
 	if (handle->state > RXM_CMAP_SHUTDOWN) {
 		FI_WARN(cmap->av->prov, FI_LOG_EP_CTRL,
 			"Invalid handle on shutdown event\n");
@@ -445,7 +445,7 @@ void rxm_cmap_process_connect(struct rxm_cmap *cmap,
 	struct rxm_conn *rxm_conn = container_of(handle, struct rxm_conn, handle);
 
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
-	       "processing FI_CONNECTED event for handle: %p\n", handle);
+	       "processing FI_CONNECTED event for handle: %p\n", (void *)handle);
 	if (cm_data) {
 		assert(handle->state == RXM_CMAP_CONNREQ_SENT);
 		handle->remote_key = cm_data->accept.server_conn_id;
@@ -469,7 +469,7 @@ void rxm_cmap_process_reject(struct rxm_cmap *cmap,
 			     enum rxm_cmap_reject_reason reject_reason)
 {
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
-		"Processing reject for handle: %p\n", handle);
+		"Processing reject for handle: %p\n", (void *)handle);
 	switch (handle->state) {
 	case RXM_CMAP_CONNREQ_RECV:
 	case RXM_CMAP_CONNECTED:
@@ -549,7 +549,7 @@ int rxm_cmap_process_connreq(struct rxm_cmap *cmap, void *addr,
 		} else if (cmp > 0) {
 			FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
 				"Re-using handle: %p to accept remote "
-				"connection\n", handle);
+				"connection\n", (void *)handle);
 			*reject_reason = RXM_CMAP_REJECT_GENUINE;
 			rxm_conn_close(handle);
 		} else {
@@ -573,7 +573,7 @@ int rxm_cmap_process_connreq(struct rxm_cmap *cmap, void *addr,
 		break;
 	case RXM_CMAP_SHUTDOWN:
 		FI_WARN(cmap->av->prov, FI_LOG_EP_CTRL, "handle :%p marked for "
-			"deletion / shutdown, reject connection\n", handle);
+			"deletion / shutdown, reject connection\n", (void *)handle);
 		*reject_reason = RXM_CMAP_REJECT_GENUINE;
 		ret = -FI_EOPBADSTATE;
 		break;
@@ -1100,7 +1100,7 @@ static int rxm_conn_handle_notify(struct fi_eq_entry *eq_entry)
 
 	handle = eq_entry->context;
 	assert(handle->state == RXM_CMAP_SHUTDOWN);
-	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "freeing handle: %p\n", handle);
+	FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "freeing handle: %p\n", (void *)handle);
 	cmap = handle->cmap;
 
 	rxm_conn_close(handle);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -677,7 +677,7 @@ ssize_t rxm_sar_handle_segment(struct rxm_rx_buf *rx_buf)
 		return -FI_EOTHER;
 	FI_DBG(&rxm_prov, FI_LOG_CQ,
 	       "Got incoming recv with msg_id: 0x%" PRIx64 "for conn - %p\n",
-	       rx_buf->pkt.ctrl_hdr.msg_id, rx_buf->conn);
+	       rx_buf->pkt.ctrl_hdr.msg_id, (void *)rx_buf->conn);
 	sar_entry = dlist_find_first_match(&rx_buf->conn->sar_rx_msg_list,
 					   rxm_sar_match_msg_id,
 					   &rx_buf->pkt.ctrl_hdr.msg_id);
@@ -1061,7 +1061,7 @@ int rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *t
 	}
 
 	return ret;
-};
+}
 
 ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 {

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -135,9 +135,9 @@ struct smr_unexp_msg {
 	struct smr_cmd cmd;
 };
 
-DECLARE_FREESTACK(struct smr_ep_entry, smr_recv_fs);
-DECLARE_FREESTACK(struct smr_unexp_msg, smr_unexp_fs);
-DECLARE_FREESTACK(struct smr_cmd, smr_pend_fs);
+DECLARE_FREESTACK(struct smr_ep_entry, smr_recv_fs)
+DECLARE_FREESTACK(struct smr_unexp_msg, smr_unexp_fs)
+DECLARE_FREESTACK(struct smr_cmd, smr_pend_fs)
 
 struct smr_queue {
 	struct dlist_entry list;

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -481,7 +481,7 @@ struct sock_eq_entry {
 	size_t len;
 	uint64_t flags;
 	struct dlist_entry entry;
-	char event[0];
+	char event[];
 };
 
 struct sock_eq_err_data_entry {
@@ -888,7 +888,7 @@ struct sock_cq_overflow_entry_t {
 	size_t len;
 	fi_addr_t addr;
 	struct dlist_entry entry;
-	char cq_entry[0];
+	char cq_entry[];
 };
 
 struct sock_cq {
@@ -928,7 +928,7 @@ struct sock_conn_req {
 	struct sock_conn_hdr hdr;
 	union ofi_sock_ip src_addr;
 	uint64_t caps;
-	char cm_data[0];
+	char cm_data[];
 };
 
 enum {

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -66,7 +66,7 @@ ssize_t sock_conn_send_src_addr(struct sock_ep_attr *ep_attr, struct sock_tx_ctx
 	struct sock_op tx_op = { 0 };
 
 	tx_op.op = SOCK_OP_CONN_MSG;
-	SOCK_LOG_DBG("New conn msg on TX: %p using conn: %p\n", tx_ctx, conn);
+	SOCK_LOG_DBG("New conn msg on TX: %p using conn: %p\n", (void *)tx_ctx, (void *)conn);
 
 	total_len = 0;
 	tx_op.src_iov_len = sizeof(union ofi_sock_ip);

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -1137,7 +1137,7 @@ static void *sock_pep_listener_thread(void *data)
 	int ret = 0, conn_fd;
 	char tmp = 0;
 
-	SOCK_LOG_DBG("Starting listener thread for PEP: %p\n", pep);
+	SOCK_LOG_DBG("Starting listener thread for PEP: %p\n", (void *)pep);
 	poll_fds[0].fd = pep->cm.sock;
 	poll_fds[1].fd = pep->cm.signal_fds[1];
 	poll_fds[0].events = poll_fds[1].events = POLLIN;

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -132,7 +132,7 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		rx_entry->total_len += rx_entry->iov[i].iov.len;
 	}
 
-	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", rx_entry, rx_ctx);
+	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", (void *)rx_entry, (void *)rx_ctx);
 	fastlock_acquire(&rx_ctx->lock);
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_entry_list);
 	fastlock_release(&rx_ctx->lock);
@@ -221,7 +221,7 @@ ssize_t sock_ep_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 		return ret;
 
 	SOCK_LOG_DBG("New sendmsg on TX: %p using conn: %p\n",
-		      tx_ctx, conn);
+		      (void *)tx_ctx, (void *)conn);
 
 	SOCK_EP_SET_TX_OP_FLAGS(flags);
 	if (flags & SOCK_USE_OP_FLAGS)
@@ -477,7 +477,7 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 	}
 
 	fastlock_acquire(&rx_ctx->lock);
-	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", rx_entry, rx_ctx);
+	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", (void *)rx_entry, (void *)rx_ctx);
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_entry_list);
 	fastlock_release(&rx_ctx->lock);
 	return 0;
@@ -755,4 +755,3 @@ struct fi_ops_tagged sock_ep_tagged = {
 	.senddata = sock_ep_tsenddata,
 	.injectdata = sock_ep_tinjectdata,
 };
-

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -132,7 +132,7 @@ static inline void sock_pe_discard_field(struct sock_pe_entry *pe_entry)
 	if (!pe_entry->rem)
 		goto out;
 
-	SOCK_LOG_DBG("Remaining for %p: %" PRId64 "\n", pe_entry, pe_entry->rem);
+	SOCK_LOG_DBG("Remaining for %p: %" PRId64 "\n", (void *)pe_entry, pe_entry->rem);
 	ret = sock_comm_discard(pe_entry, pe_entry->rem);
 	SOCK_LOG_DBG("Discarded %ld\n", ret);
 
@@ -142,7 +142,7 @@ static inline void sock_pe_discard_field(struct sock_pe_entry *pe_entry)
 
  out:
 	if (pe_entry->done_len == pe_entry->total_len && !pe_entry->rem) {
-		SOCK_LOG_DBG("Discard complete for %p\n", pe_entry);
+		SOCK_LOG_DBG("Discard complete for %p\n", (void *)pe_entry);
 		pe_entry->is_complete = 1;
 	}
 }
@@ -196,7 +196,7 @@ static void sock_pe_release_entry(struct sock_pe *pe,
 
 	dlist_remove(&pe_entry->entry);
 	dlist_insert_head(&pe_entry->entry, &pe->free_list);
-	SOCK_LOG_DBG("progress entry %p released\n", pe_entry);
+	SOCK_LOG_DBG("progress entry %p released\n", (void *)pe_entry);
 }
 
 static struct sock_pe_entry *sock_pe_acquire_entry(struct sock_pe *pe)
@@ -223,7 +223,7 @@ static struct sock_pe_entry *sock_pe_acquire_entry(struct sock_pe *pe)
 		assert(ofi_rbempty(&pe_entry->comm_buf));
 		dlist_remove(&pe_entry->entry);
 		dlist_insert_tail(&pe_entry->entry, &pe->busy_list);
-		SOCK_LOG_DBG("progress entry %p acquired : %lu\n", pe_entry,
+		SOCK_LOG_DBG("progress entry %p acquired : %lu\n", (void *)pe_entry,
 			     PE_INDEX(pe, pe_entry));
 	}
 	return pe_entry;
@@ -242,7 +242,7 @@ static void sock_pe_report_send_cq_completion(struct sock_pe_entry *pe_entry)
 
 	if (ret < 0) {
 		SOCK_LOG_ERROR("Failed to report completion %p\n",
-			       pe_entry);
+			       (void *)pe_entry);
 		if (pe_entry->comp->eq) {
 			sock_eq_report_error(
 				pe_entry->comp->eq,
@@ -282,7 +282,7 @@ static void sock_pe_report_recv_cq_completion(struct sock_pe_entry *pe_entry)
 			pe_entry);
 
 	if (ret < 0) {
-		SOCK_LOG_ERROR("Failed to report completion %p\n", pe_entry);
+		SOCK_LOG_ERROR("Failed to report completion %p\n", (void *)pe_entry);
 		if (pe_entry->comp->eq) {
 			sock_eq_report_error(
 				pe_entry->comp->eq,
@@ -470,12 +470,12 @@ static void sock_pe_progress_pending_ack(struct sock_pe *pe,
 
 	if (conn->tx_pe_entry != NULL && conn->tx_pe_entry != pe_entry) {
 		SOCK_LOG_DBG("Cannot progress %p as conn %p is being used by %p\n",
-			      pe_entry, conn, conn->tx_pe_entry);
+			      (void *)pe_entry, (void *)conn, (void *)conn->tx_pe_entry);
 		return;
 	}
 
 	if (conn->tx_pe_entry == NULL) {
-		SOCK_LOG_DBG("Connection %p grabbed by %p\n", conn, pe_entry);
+		SOCK_LOG_DBG("Connection %p grabbed by %p\n", (void *)conn, (void *)pe_entry);
 		conn->tx_pe_entry = pe_entry;
 	}
 
@@ -580,7 +580,7 @@ static int sock_pe_handle_ack(struct sock_pe *pe,
 	assert(response->pe_entry_id <= SOCK_PE_MAX_ENTRIES);
 	waiting_entry = &pe->pe_table[response->pe_entry_id];
 	SOCK_LOG_DBG("Received ack for PE entry %p (index: %d)\n",
-		      waiting_entry, response->pe_entry_id);
+		      (void *)waiting_entry, response->pe_entry_id);
 
 	assert(waiting_entry->type == SOCK_PE_TX);
 	sock_pe_report_send_completion(waiting_entry);
@@ -602,7 +602,7 @@ static int sock_pe_handle_error(struct sock_pe *pe,
 	assert(response->pe_entry_id <= SOCK_PE_MAX_ENTRIES);
 	waiting_entry = &pe->pe_table[response->pe_entry_id];
 	SOCK_LOG_ERROR("Received error for PE entry %p (index: %d)\n",
-		      waiting_entry, response->pe_entry_id);
+		      (void *)waiting_entry, response->pe_entry_id);
 
 	assert(waiting_entry->type == SOCK_PE_TX);
 
@@ -638,7 +638,7 @@ static int sock_pe_handle_read_complete(struct sock_pe *pe,
 	assert(response->pe_entry_id <= SOCK_PE_MAX_ENTRIES);
 	waiting_entry = &pe->pe_table[response->pe_entry_id];
 	SOCK_LOG_DBG("Received read complete for PE entry %p (index: %d)\n",
-		      waiting_entry, response->pe_entry_id);
+		      (void *)waiting_entry, response->pe_entry_id);
 
 	waiting_entry = &pe->pe_table[response->pe_entry_id];
 	assert(waiting_entry->type == SOCK_PE_TX);
@@ -672,7 +672,7 @@ static int sock_pe_handle_write_complete(struct sock_pe *pe,
 	assert(response->pe_entry_id <= SOCK_PE_MAX_ENTRIES);
 	waiting_entry = &pe->pe_table[response->pe_entry_id];
 	SOCK_LOG_DBG("Received ack for PE entry %p (index: %d)\n",
-		      waiting_entry, response->pe_entry_id);
+		      (void *)waiting_entry, response->pe_entry_id);
 
 	assert(waiting_entry->type == SOCK_PE_TX);
 	sock_pe_report_write_completion(waiting_entry);
@@ -696,7 +696,7 @@ static int sock_pe_handle_atomic_complete(struct sock_pe *pe,
 	assert(response->pe_entry_id <= SOCK_PE_MAX_ENTRIES);
 	waiting_entry = &pe->pe_table[response->pe_entry_id];
 	SOCK_LOG_DBG("Received atomic complete for PE entry %p (index: %d)\n",
-		      waiting_entry, response->pe_entry_id);
+		      (void *)waiting_entry, response->pe_entry_id);
 
 	waiting_entry = &pe->pe_table[response->pe_entry_id];
 	assert(waiting_entry->type == SOCK_PE_TX);
@@ -1205,9 +1205,9 @@ static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx)
 			continue;
 
 		SOCK_LOG_DBG("Consuming buffered entry: %p, ctx: %p\n",
-			      rx_buffered, rx_ctx);
+			      (void *)rx_buffered, (void *)rx_ctx);
 		SOCK_LOG_DBG("Consuming posted entry: %p, ctx: %p\n",
-			      rx_posted, rx_ctx);
+			      (void *)rx_posted, (void *)rx_ctx);
 
 		datatype_sz = (rx_buffered->flags & FI_ATOMIC) ?
 			ofi_datatype_size(rx_buffered->rx_op.atomic.datatype) : 0;
@@ -1329,11 +1329,11 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 
 		rx_entry = sock_rx_get_entry(rx_ctx, pe_entry->addr, pe_entry->tag,
 					     pe_entry->msg_hdr.op_type == SOCK_OP_TSEND ? 1 : 0);
-		SOCK_LOG_DBG("Consuming posted entry: %p\n", rx_entry);
+		SOCK_LOG_DBG("Consuming posted entry: %p\n", (void *)rx_entry);
 
 		if (!rx_entry) {
 			SOCK_LOG_DBG("%p: No matching recv, buffering recv (len = %llu)\n",
-				      pe_entry, (long long unsigned int)data_len);
+				      (void *)pe_entry, (long long unsigned int)data_len);
 
 			rx_entry = sock_rx_new_buffered_entry(rx_ctx, data_len);
 			if (!rx_entry) {
@@ -1942,12 +1942,12 @@ static int sock_pe_progress_tx_entry(struct sock_pe *pe,
 
 	if (conn->tx_pe_entry != NULL && conn->tx_pe_entry != pe_entry) {
 		SOCK_LOG_DBG("Cannot progress %p as conn %p is being used by %p\n",
-			      pe_entry, conn, conn->tx_pe_entry);
+			      (void *)pe_entry, (void *)conn, (void *)conn->tx_pe_entry);
 		goto out;
 	}
 
 	if (conn->tx_pe_entry == NULL) {
-		SOCK_LOG_DBG("Connection %p grabbed by %p\n", conn, pe_entry);
+		SOCK_LOG_DBG("Connection %p grabbed by %p\n", (void *)conn, (void *)pe_entry);
 		conn->tx_pe_entry = pe_entry;
 	}
 
@@ -1990,7 +1990,7 @@ static int sock_pe_progress_tx_entry(struct sock_pe *pe,
 out:
 	if (pe_entry->is_complete) {
 		sock_pe_release_entry(pe, pe_entry);
-		SOCK_LOG_DBG("[%p] TX done\n", pe_entry);
+		SOCK_LOG_DBG("[%p] TX done\n", (void *)pe_entry);
 	}
 	return ret;
 }
@@ -2044,7 +2044,7 @@ out:
 
 	if (pe_entry->is_complete && !pe_entry->pe.rx.pending_send) {
 		sock_pe_release_entry(pe, pe_entry);
-		SOCK_LOG_DBG("[%p] RX done\n", pe_entry);
+		SOCK_LOG_DBG("[%p] RX done\n", (void *)pe_entry);
 	}
 	return 0;
 }
@@ -2077,10 +2077,10 @@ static void sock_pe_new_rx_entry(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 		pe_entry->comp = &rx_ctx->comp;
 
 	SOCK_LOG_DBG("New RX on PE entry %p (%ld)\n",
-		      pe_entry, PE_INDEX(pe, pe_entry));
+		      (void *)pe_entry, PE_INDEX(pe, pe_entry));
 
 	SOCK_LOG_DBG("Inserting rx_entry to PE entry %p, conn: %p\n",
-		      pe_entry, pe_entry->conn);
+		      (void *)pe_entry, (void *)pe_entry->conn);
 
 	dlist_insert_tail(&pe_entry->ctx_entry, &rx_ctx->pe_entry_list);
 }
@@ -2112,7 +2112,7 @@ static int sock_pe_new_tx_entry(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx)
 
 	msg_hdr->pe_entry_id = PE_INDEX(pe, pe_entry);
 	SOCK_LOG_DBG("New TX on PE entry %p (%d)\n",
-		      pe_entry, msg_hdr->pe_entry_id);
+		      (void *)pe_entry, msg_hdr->pe_entry_id);
 
 	sock_tx_ctx_read_op_send(tx_ctx, &pe_entry->pe.tx.tx_op,
 			&pe_entry->flags, &pe_entry->context, &pe_entry->addr,
@@ -2236,7 +2236,7 @@ static int sock_pe_new_tx_entry(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx)
 		return -FI_EINVAL;
 	}
 	SOCK_LOG_DBG("Inserting TX-entry to PE entry %p, conn: %p\n",
-		      pe_entry, pe_entry->conn);
+		      (void *)pe_entry, (void *)pe_entry->conn);
 
 	/* prepare message header */
 	msg_hdr->version = SOCK_WIRE_PROTO_VERSION;
@@ -2511,7 +2511,7 @@ int sock_pe_progress_tx_ctx(struct sock_pe *pe, struct sock_tx_ctx *tx_ctx)
 
 		ret = sock_pe_progress_tx_entry(pe, tx_ctx, pe_entry);
 		if (ret < 0) {
-			SOCK_LOG_ERROR("Error in progressing %p\n", pe_entry);
+			SOCK_LOG_ERROR("Error in progressing %p\n", (void *)pe_entry);
 			goto out;
 		}
 	}
@@ -2697,7 +2697,7 @@ struct sock_pe *sock_pe_init(struct sock_domain *domain)
 	pthread_mutex_init(&pe->list_lock, NULL);
 	pe->domain = domain;
 
-	
+
 	ret = ofi_bufpool_create(&pe->pe_rx_pool,
 				 sizeof(struct sock_pe_entry), 16, 0, 1024, 0);
 	if (ret) {

--- a/prov/sockets/src/sock_rx_entry.c
+++ b/prov/sockets/src/sock_rx_entry.c
@@ -79,7 +79,7 @@ struct sock_rx_entry *sock_rx_new_entry(struct sock_rx_ctx *rx_ctx)
 	}
 
 	rx_entry->is_tagged = 0;
-	SOCK_LOG_DBG("New rx_entry: %p, ctx: %p\n", rx_entry, rx_ctx);
+	SOCK_LOG_DBG("New rx_entry: %p, ctx: %p\n", (void *)rx_entry, (void *)rx_ctx);
 	dlist_init(&rx_entry->entry);
 	rx_ctx->num_left--;
 	return rx_entry;
@@ -88,7 +88,7 @@ struct sock_rx_entry *sock_rx_new_entry(struct sock_rx_ctx *rx_ctx)
 void sock_rx_release_entry(struct sock_rx_entry *rx_entry)
 {
 	struct sock_rx_ctx *rx_ctx;
-	SOCK_LOG_DBG("Releasing rx_entry: %p\n", rx_entry);
+	SOCK_LOG_DBG("Releasing rx_entry: %p\n", (void *)rx_entry);
 	if (rx_entry->is_pool_entry) {
 		rx_ctx = rx_entry->rx_ctx;
 		memset(rx_entry, 0, sizeof(*rx_entry));
@@ -113,7 +113,7 @@ struct sock_rx_entry *sock_rx_new_buffered_entry(struct sock_rx_ctx *rx_ctx,
 		return NULL;
 
 	SOCK_LOG_DBG("New buffered entry:%p len: %lu, ctx: %p\n",
-		       rx_entry, len, rx_ctx);
+		       (void *)rx_entry, len, (void *)rx_ctx);
 
 	rx_entry->is_busy = 1;
 	rx_entry->is_buffered = 1;

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -92,7 +92,7 @@ struct udpx_ep_entry {
 	uint8_t			resv[sizeof(size_t) - 2];
 };
 
-OFI_DECLARE_CIRQUE(struct udpx_ep_entry, udpx_rx_cirq);
+OFI_DECLARE_CIRQUE(struct udpx_ep_entry, udpx_rx_cirq)
 
 struct udpx_ep;
 typedef void (*udpx_rx_comp_func)(struct udpx_ep *ep, void *context,

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -245,7 +245,7 @@ static inline void util_coll_op_log_work(struct util_coll_operation *coll_op)
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
 			       "\t%ld: { %p [%s] SEND TO: 0x%02x FROM: 0x%02lx "
 			       "cnt: %d typesize: %ld tag: 0x%02lx }\n",
-			       count, cur_item, log_util_coll_state[cur_item->state],
+			       count, (void *)cur_item, log_util_coll_state[cur_item->state],
 			       xfer_item->remote_rank, coll_op->mc->local_rank,
 			       xfer_item->count, ofi_datatype_size(xfer_item->datatype),
 			       xfer_item->tag);
@@ -256,7 +256,7 @@ static inline void util_coll_op_log_work(struct util_coll_operation *coll_op)
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
 			       "\t%ld: { %p [%s] RECV FROM: 0x%02x TO: 0x%02lx "
 			       "cnt: %d typesize: %ld tag: 0x%02lx }\n",
-			       count, cur_item, log_util_coll_state[cur_item->state],
+			       count, (void *)cur_item, log_util_coll_state[cur_item->state],
 			       xfer_item->remote_rank, coll_op->mc->local_rank,
 			       xfer_item->count, ofi_datatype_size(xfer_item->datatype),
 			       xfer_item->tag);
@@ -264,22 +264,22 @@ static inline void util_coll_op_log_work(struct util_coll_operation *coll_op)
 		case UTIL_COLL_REDUCE:
 			//reduce_item = container_of(cur_item, struct util_coll_reduce_item, hdr);
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
-			       "\t%ld: { %p [%s] REDUCTION }\n", count, cur_item,
+			       "\t%ld: { %p [%s] REDUCTION }\n", count, (void *)cur_item,
 			       log_util_coll_state[cur_item->state]);
 			break;
 		case UTIL_COLL_COPY:
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
-			       "\t%ld: { %p [%s] COPY }\n", count, cur_item,
+			       "\t%ld: { %p [%s] COPY }\n", count, (void *)cur_item,
 			       log_util_coll_state[cur_item->state]);
 			break;
 		case UTIL_COLL_COMP:
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
-			       "\t%ld: { %p [%s] COMPLETION }\n", count, cur_item,
+			       "\t%ld: { %p [%s] COMPLETION }\n", count, (void *)cur_item,
 			       log_util_coll_state[cur_item->state]);
 			break;
 		default:
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
-			       "\t%ld: { %p [%s] UNKNOWN }\n", count, cur_item,
+			       "\t%ld: { %p [%s] UNKNOWN }\n", count, (void *)cur_item,
 			       log_util_coll_state[cur_item->state]);
 			break;
 		}
@@ -314,7 +314,7 @@ static inline void util_coll_op_progress_work(struct util_ep *util_ep,
 				continue;
 
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
-			       "Removing Completed Work item: %p \n", cur_item);
+			       "Removing Completed Work item: %p \n", (void *)cur_item);
 			dlist_remove(&cur_item->waiting_entry);
 			free(cur_item);
 
@@ -329,20 +329,20 @@ static inline void util_coll_op_progress_work(struct util_ep *util_ep,
 		// we can't progress if prior work is fencing
 		if (!previous_is_head && prev_item && prev_item->fence) {
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
-			       "%p fenced by: %p \n", cur_item, prev_item);
+			       "%p fenced by: %p \n", (void *)cur_item, (void *)prev_item);
 			return;
 		}
 
 		// if the current item isn't waiting, it's not the next ready item
 		if (cur_item->state != UTIL_COLL_WAITING) {
 			FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ,
-			       "Work item not waiting: %p [%s]\n", cur_item,
+			       "Work item not waiting: %p [%s]\n", (void *)cur_item,
 			       log_util_coll_state[cur_item->state]);
 			continue;
 		}
 
 		FI_DBG(coll_op->mc->av_set->av->prov, FI_LOG_CQ, "Ready item: %p \n",
-		       cur_item);
+		       (void *)cur_item);
 		next_ready = cur_item;
 		break;
 	}
@@ -889,7 +889,7 @@ int util_coll_process_xfer_item(struct util_coll_xfer_item *item) {
 		ret = fi_tsendmsg(mc->ep, &msg, FI_COLLECTIVE);
 		if (!ret)
 			FI_DBG(mc->av_set->av->prov, FI_LOG_CQ,
-			       "%p SEND [0x%02lx] -> [0x%02x] cnt: %d sz: %ld\n", item,
+			       "%p SEND [0x%02lx] -> [0x%02x] cnt: %d sz: %ld\n", (void *)item,
 			       item->hdr.coll_op->mc->local_rank, item->remote_rank,
 			       item->count,
 			       item->count * ofi_datatype_size(item->datatype));
@@ -898,7 +898,7 @@ int util_coll_process_xfer_item(struct util_coll_xfer_item *item) {
 		ret = fi_trecvmsg(mc->ep, &msg, FI_COLLECTIVE);
 		if (!ret)
 			FI_DBG(mc->av_set->av->prov, FI_LOG_CQ,
-			       "%p RECV [0x%02lx] <- [0x%02x] cnt: %d sz: %ld\n", item,
+			       "%p RECV [0x%02lx] <- [0x%02x] cnt: %d sz: %ld\n", (void *)item,
 			       item->hdr.coll_op->mc->local_rank, item->remote_rank,
 			       item->count,
 			       item->count * ofi_datatype_size(item->datatype));
@@ -1382,7 +1382,7 @@ void ofi_coll_handle_xfer_comp(uint64_t tag, void *ctx)
 
 	FI_DBG(xfer_item->hdr.coll_op->mc->av_set->av->prov, FI_LOG_CQ,
 	       "\tXfer complete: { %p %s Remote: 0x%02x Local: 0x%02lx cnt: %d typesize: %ld }\n",
-	       xfer_item, xfer_item->hdr.type == UTIL_COLL_SEND ? "SEND" : "RECV",
+	       (void *)xfer_item, xfer_item->hdr.type == UTIL_COLL_SEND ? "SEND" : "RECV",
 	       xfer_item->remote_rank, xfer_item->hdr.coll_op->mc->local_rank,
 	       xfer_item->count, ofi_datatype_size(xfer_item->datatype));
 	util_ep = container_of(xfer_item->hdr.coll_op->mc->ep, struct util_ep, ep_fid);

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -170,7 +170,7 @@ int ofi_wait_fd_del(struct util_wait *wait, int fd)
 	if (!entry) {
 		FI_INFO(wait->prov, FI_LOG_FABRIC,
 			"Given fd (%d) not found in wait list - %p\n",
-			fd, wait_fd);
+			fd, (void *)wait_fd);
 		ret = -FI_EINVAL;
 		goto out;
 	}
@@ -199,7 +199,7 @@ int ofi_wait_fd_add(struct util_wait *wait, int fd, uint32_t events,
 	if (entry) {
 		FI_DBG(wait->prov, FI_LOG_EP_CTRL,
 		       "Given fd (%d) already added to wait list - %p \n",
-		       fd, wait_fd);
+		       fd, (void *)wait_fd);
 		fd_entry = container_of(entry, struct ofi_wait_fd_entry, entry);
 		ofi_atomic_inc32(&fd_entry->ref);
 		goto out;
@@ -585,7 +585,7 @@ int ofi_wait_fid_del(struct util_wait *wait, void *fid)
 	if (!entry) {
 		FI_INFO(wait->prov, FI_LOG_FABRIC,
 			"Given fid (%p) not found in wait list - %p\n",
-			fid, wait_yield);
+			fid, (void *)wait_yield);
 		ret = -FI_EINVAL;
 		goto out;
 	}
@@ -614,7 +614,7 @@ int ofi_wait_fid_add(struct util_wait *wait, ofi_wait_try_func wait_try,
 	if (entry) {
 		FI_DBG(wait->prov, FI_LOG_EP_CTRL,
 		       "Given fid (%p) already added to wait list - %p \n",
-		       fid, wait_yield);
+		       fid, (void *)wait_yield);
 		fid_entry = container_of(entry, struct ofi_wait_fid_entry, entry);
 		ofi_atomic_inc32(&fid_entry->ref);
 		goto out;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -585,7 +585,7 @@ static void ofi_ini_dir(const char *dir)
 		}
 		free(lib);
 
-		inif = dlsym(dlhandle, "fi_prov_ini");
+		*(void **) &inif = dlsym(dlhandle, "fi_prov_ini");
 		if (inif == NULL) {
 			FI_WARN(&core_prov, FI_LOG_CORE, "dlsym: %s\n", dlerror());
 			dlclose(dlhandle);

--- a/src/linux/osd.c
+++ b/src/linux/osd.c
@@ -59,7 +59,7 @@ ssize_t ofi_get_hugepage_size(void)
 		return -errno;
 
 	while (getline(&line, &len, fd) != -1)
-		if (sscanf(line, "Hugepagesize: %zu kB", &val) == 1)
+		if (sscanf(line, "Hugepagesize: %zd kB", &val) == 1)
 			break;
 
 	free(line);

--- a/src/mem.c
+++ b/src/mem.c
@@ -85,7 +85,7 @@ void ofi_mem_init(void)
 	}
 
 	while (n-- > 0) {
-		if (sscanf(pglist[n]->d_name, "hugepages-%zukB", &hpsize) == 1) {
+		if (sscanf(pglist[n]->d_name, "hugepages-%zdkB", &hpsize) == 1) {
 			hpsize *= 1024;
 			if (hpsize != page_sizes[OFI_DEF_HUGEPAGE_SIZE])
 				page_sizes[num_page_sizes++] = hpsize;

--- a/util/pingpong.c
+++ b/util/pingpong.c
@@ -1655,7 +1655,7 @@ static int pp_server_connect(struct ct_pingpong *ct)
 
 	if (event != FI_CONNECTED || entry.fid != &(ct->ep->fid)) {
 		fprintf(stderr, "Unexpected CM event %d fid %p (ep %p)\n",
-			event, entry.fid, ct->ep);
+			event, (void *)entry.fid, (void *)ct->ep);
 		ret = -FI_EOTHER;
 		goto err;
 	}
@@ -1707,7 +1707,7 @@ static int pp_client_connect(struct ct_pingpong *ct)
 
 	if (event != FI_CONNECTED || entry.fid != &(ct->ep->fid)) {
 		fprintf(stderr, "Unexpected CM event %d fid %p (ep %p)\n",
-			event, entry.fid, ct->ep);
+			event, (void *)entry.fid, (void *)ct->ep);
 		ret = -FI_EOTHER;
 		return ret;
 	}
@@ -1829,7 +1829,7 @@ static void pp_free_res(struct ct_pingpong *ct)
 
 	free(ct->rem_name);
 	free(ct->local_name);
-	
+
 	if (ct->buf) {
 		ofi_freealign(ct->buf);
 		ct->buf = ct->rx_buf = ct->tx_buf = NULL;


### PR DESCRIPTION
It would be likeable to have libfabric compiled with -Wextra enabled
(instead of just -Wall).  This patch fixes a lot of warnings that appear
when -Wextra is enabled:

- Fix some maybe-uninitialized warnings
- Avoid comparison between signed and unsigned integers
- Remove extra semi-colons (not ISO C compliant)
- Use flexible-length arrays instead of GNU C's zero-length arrays
- In format strings, cast %p arguments to (void *)

Since I'm new to libfabric, I couldn't fix them all (especially the
maybe-uninitialized ones).

Signed-off-by: Hubert Hirtz <hubert.hirtz@laposte.net>