### PR TITLE
[v1.9.x] prov/psm2: Clean up AV table entries that have been removed

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -700,6 +700,7 @@ struct psmx2_av_addr {
 	psm2_epid_t		epid;
 	uint8_t			type;
 	uint8_t			sep_id;
+	uint8_t			valid;
 };
 
 struct psmx2_av_sep {
@@ -1052,7 +1053,7 @@ psm2_epaddr_t psmx2_av_translate_addr(struct psmx2_fid_av *av,
 	av->domain->av_lock_fn(&av->lock, 1);
 
 	idx = PSMX2_ADDR_IDX(addr);
-	assert(idx < av->hdr->last);
+	assert(idx < av->hdr->last && av->table[idx].valid);
 
 	if (OFI_UNLIKELY(av->table[idx].type == PSMX2_EP_SCALABLE)) {
 		if (OFI_UNLIKELY(!av->sep_info[idx].epids)) {


### PR DESCRIPTION
Previously the AV remove operation focused on cleaning up connection
states so that the same process could talk to different peers that
might reuse hardware context. Some information were left intact in
the AV table which worked fine in most cases.

However, some applications rely on the FI_EADDRNOTAVAIL event to do
special handling for connection management. The leftover information
in the AV table may prevent the event from being generated. Fix by
cleaning up the removed entries and marking them as invalid.

Cherry-picked from commit 7b6b34cb6a1402c7928802bf2800f7d952bff343.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>