### PR TITLE
tcp: Rework progress functionality

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -184,10 +184,19 @@ fi
 AC_DEFINE_UNQUOTED([PT_LOCK_SPIN], [$have_spinlock],
 	[Define to 1 if pthread_spin_init is available.])
 
-AC_CHECK_FUNCS([epoll_create])
-if test "$ac_cv_func_epoll_create" = yes; then
-  AC_DEFINE([HAVE_EPOLL], [1], [Define if you have epoll support.])
-fi
+AC_ARG_ENABLE([epoll],
+    [AS_HELP_STRING([--disable-epoll],
+        [Disable epoll if available@<:@default=no@:>@])],
+    [],
+    [enable_epoll=auto]
+)
+
+AS_IF([test x"$enable_epoll" != x"no"],
+    [AC_CHECK_FUNCS([epoll_create])
+     if test "$ac_cv_func_epoll_create" = yes; then
+        AC_DEFINE([HAVE_EPOLL], [1], [Define if you have epoll support.])
+     fi]
+)
 
 AC_CHECK_HEADER([linux/perf_event.h],
     [AC_CHECK_DECL([__builtin_ia32_rdpmc],

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -46,18 +46,18 @@
 #ifdef HAVE_EPOLL
 #include <sys/epoll.h>
 
-#define FI_EPOLL_IN  EPOLLIN
-#define FI_EPOLL_OUT EPOLLOUT
+#define OFI_EPOLL_IN  EPOLLIN
+#define OFI_EPOLL_OUT EPOLLOUT
 
-typedef int fi_epoll_t;
+typedef int ofi_epoll_t;
 
-static inline int fi_epoll_create(int *ep)
+static inline int ofi_epoll_create(int *ep)
 {
 	*ep = epoll_create(4);
 	return *ep < 0 ? -ofi_syserr() : 0;
 }
 
-static inline int fi_epoll_add(int ep, int fd, uint32_t events, void *context)
+static inline int ofi_epoll_add(int ep, int fd, uint32_t events, void *context)
 {
 	struct epoll_event event;
 	int ret;
@@ -70,7 +70,7 @@ static inline int fi_epoll_add(int ep, int fd, uint32_t events, void *context)
 	return 0;
 }
 
-static inline int fi_epoll_mod(int ep, int fd, uint32_t events, void *context)
+static inline int ofi_epoll_mod(int ep, int fd, uint32_t events, void *context)
 {
 	struct epoll_event event;
 
@@ -79,12 +79,12 @@ static inline int fi_epoll_mod(int ep, int fd, uint32_t events, void *context)
 	return epoll_ctl(ep, EPOLL_CTL_MOD, fd, &event) ? -ofi_syserr() : 0;
 }
 
-static inline int fi_epoll_del(int ep, int fd)
+static inline int ofi_epoll_del(int ep, int fd)
 {
 	return epoll_ctl(ep, EPOLL_CTL_DEL, fd, NULL) ? -ofi_syserr() : 0;
 }
 
-static inline int fi_epoll_wait(int ep, void **contexts, int max_contexts,
+static inline int ofi_epoll_wait(int ep, void **contexts, int max_contexts,
                                 int timeout)
 {
 	struct epoll_event events[max_contexts];
@@ -100,7 +100,7 @@ static inline int fi_epoll_wait(int ep, void **contexts, int max_contexts,
 	return ret;
 }
 
-static inline void fi_epoll_close(int ep)
+static inline void ofi_epoll_close(int ep)
 {
 	close(ep);
 }
@@ -108,20 +108,20 @@ static inline void fi_epoll_close(int ep)
 #else
 #include <poll.h>
 
-#define FI_EPOLL_IN  POLLIN
-#define FI_EPOLL_OUT POLLOUT
+#define OFI_EPOLL_IN  POLLIN
+#define OFI_EPOLL_OUT POLLOUT
 
-enum fi_epoll_ctl {
+enum ofi_epoll_ctl {
 	EPOLL_CTL_ADD,
 	EPOLL_CTL_DEL,
 	EPOLL_CTL_MOD,
 };
 
-struct fi_epoll_work_item {
+struct ofi_epoll_work_item {
 	int		fd;
 	uint32_t	events;
 	void		*context;
-	enum fi_epoll_ctl type;
+	enum ofi_epoll_ctl type;
 	struct slist_entry entry;
 };
 
@@ -134,15 +134,15 @@ typedef struct fi_epoll {
 	struct fd_signal signal;
 	struct slist	work_item_list;
 	fastlock_t	lock;
-} *fi_epoll_t;
+} *ofi_epoll_t;
 
-int fi_epoll_create(struct fi_epoll **ep);
-int fi_epoll_add(struct fi_epoll *ep, int fd, uint32_t events, void *context);
-int fi_epoll_mod(struct fi_epoll *ep, int fd, uint32_t events, void *context);
-int fi_epoll_del(struct fi_epoll *ep, int fd);
-int fi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
+int ofi_epoll_create(struct fi_epoll **ep);
+int ofi_epoll_add(struct fi_epoll *ep, int fd, uint32_t events, void *context);
+int ofi_epoll_mod(struct fi_epoll *ep, int fd, uint32_t events, void *context);
+int ofi_epoll_del(struct fi_epoll *ep, int fd);
+int ofi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
                   int timeout);
-void fi_epoll_close(struct fi_epoll *ep);
+void ofi_epoll_close(struct fi_epoll *ep);
 
 #endif /* HAVE_EPOLL */
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -415,7 +415,7 @@ int fi_wait_cleanup(struct util_wait *wait);
 struct util_wait_fd {
 	struct util_wait	util_wait;
 	struct fd_signal	signal;
-	fi_epoll_t		epoll_fd;
+	ofi_epoll_t		epoll_fd;
 	struct dlist_entry	fd_list;
 	fastlock_t		lock;
 };

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -709,7 +709,7 @@ static int rxd_ep_trywait(void *arg)
 
 static int rxd_ep_wait_fd_add(struct rxd_ep *rxd_ep, struct util_wait *wait)
 {
-	return ofi_wait_fd_add(wait, rxd_ep->dg_cq_fd, FI_EPOLL_IN,
+	return ofi_wait_fd_add(wait, rxd_ep->dg_cq_fd, OFI_EPOLL_IN,
 			       rxd_ep_trywait, rxd_ep,
 			       &rxd_ep->util_ep.ep_fid.fid);
 }

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2271,7 +2271,7 @@ static int rxm_ep_wait_fd_add(struct rxm_ep *rxm_ep, struct util_wait *wait)
 		return ret;
 	}
 
-	ret = ofi_wait_fd_add(wait, msg_cq_fd, FI_EPOLL_IN,
+	ret = ofi_wait_fd_add(wait, msg_cq_fd, OFI_EPOLL_IN,
 			      rxm_ep_trywait_cq, rxm_ep,
 			      &rxm_ep->util_ep.ep_fid.fid);
 	if (ret)
@@ -2288,7 +2288,7 @@ static int rxm_ep_wait_fd_add(struct rxm_ep *rxm_ep, struct util_wait *wait)
 		return ret;
 	}
 
-	return ofi_wait_fd_add(wait, msg_eq_fd, FI_EPOLL_IN, rxm_ep_trywait_eq,
+	return ofi_wait_fd_add(wait, msg_eq_fd, OFI_EPOLL_IN, rxm_ep_trywait_eq,
 			       rxm_ep, &rxm_ep->util_ep.ep_fid.fid);
 }
 

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -212,7 +212,7 @@ struct sock_conn {
 
 struct sock_conn_map {
 	struct sock_conn *table;
-	fi_epoll_t epoll_set;
+	ofi_epoll_t epoll_set;
 	void **epoll_ctxs;
 	int epoll_ctxs_sz;
 	int used;
@@ -221,7 +221,7 @@ struct sock_conn_map {
 };
 
 struct sock_conn_listener {
-	fi_epoll_t emap;
+	ofi_epoll_t emap;
 	struct fd_signal signal;
 	fastlock_t signal_lock; /* acquire before map lock */
 	pthread_t listener_thread;
@@ -229,7 +229,7 @@ struct sock_conn_listener {
 };
 
 struct sock_ep_cm_head {
-	fi_epoll_t emap;
+	ofi_epoll_t emap;
 	struct fd_signal signal;
 	fastlock_t signal_lock;
 	pthread_t listener_thread;
@@ -878,7 +878,7 @@ struct sock_pe {
 	pthread_t progress_thread;
 	volatile int do_progress;
 	struct sock_pe_entry *pe_atomic;
-	fi_epoll_t epoll_set;
+	ofi_epoll_t epoll_set;
 };
 
 typedef int (*sock_cq_report_fn) (struct sock_cq *cq, fi_addr_t addr,

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -705,7 +705,7 @@ static int sock_ep_close(struct fid *fid)
 
 	if (sock_ep->attr->conn_handle.do_listen) {
 		fastlock_acquire(&sock_ep->attr->domain->conn_listener.signal_lock);
-		fi_epoll_del(sock_ep->attr->domain->conn_listener.emap,
+		ofi_epoll_del(sock_ep->attr->domain->conn_listener.emap,
 		             sock_ep->attr->conn_handle.sock);
 		fastlock_release(&sock_ep->attr->domain->conn_listener.signal_lock);
 		ofi_close_socket(sock_ep->attr->conn_handle.sock);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -209,7 +209,7 @@ struct tcpx_ep {
 	void (*hdr_bswap)(struct tcpx_base_hdr *hdr);
 	struct stage_buf	stage_buf;
 	size_t			min_multi_recv_size;
-	bool			send_ready_monitor;
+	bool			epoll_out_set;
 };
 
 struct tcpx_fabric {

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -121,7 +121,7 @@ struct tcpx_port_range {
 struct tcpx_conn_handle {
 	struct fid		handle;
 	struct tcpx_pep		*pep;
-	SOCKET			conn_fd;
+	SOCKET			sock;
 	bool			endian_match;
 };
 
@@ -191,7 +191,7 @@ struct stage_buf {
 
 struct tcpx_ep {
 	struct util_ep		util_ep;
-	SOCKET			conn_fd;
+	SOCKET			sock;
 	struct tcpx_cur_rx_msg	cur_rx_msg;
 	struct tcpx_xfer_entry	*cur_rx_entry;
 	tcpx_rx_process_fn_t 	cur_rx_proc_fn;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 201-2020 Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -179,7 +179,6 @@ struct tcpx_rx_ctx {
 };
 
 typedef int (*tcpx_rx_process_fn_t)(struct tcpx_xfer_entry *rx_entry);
-typedef void (*tcpx_ep_progress_func_t)(struct tcpx_ep *ep);
 typedef int (*tcpx_get_rx_func_t)(struct tcpx_ep *ep);
 
 struct stage_buf {
@@ -204,7 +203,6 @@ struct tcpx_ep {
 	enum tcpx_cm_state	cm_state;
 	/* lock for protecting tx/rx queues,rma list,cm_state*/
 	fastlock_t		lock;
-	tcpx_ep_progress_func_t progress_func;
 	tcpx_get_rx_func_t	get_rx_entry[ofi_op_write + 1];
 	void (*hdr_bswap)(struct tcpx_base_hdr *hdr);
 	struct stage_buf	stage_buf;
@@ -300,8 +298,8 @@ struct tcpx_xfer_entry *
 tcpx_srx_next_xfer_entry(struct tcpx_rx_ctx *srx_ctx,
 			struct tcpx_ep *ep, size_t entry_size);
 
-void tcpx_progress(struct util_ep *util_ep);
-void tcpx_ep_progress(struct tcpx_ep *ep);
+void tcpx_progress_tx(struct tcpx_ep *ep);
+void tcpx_progress_rx(struct tcpx_ep *ep);
 int tcpx_try_func(void *util_ep);
 
 void tcpx_hdr_none(struct tcpx_base_hdr *hdr);

--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -45,8 +45,7 @@ int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry)
 	msg.msg_iov = tx_entry->iov;
 	msg.msg_iovlen = tx_entry->iov_cnt;
 
-	bytes_sent = ofi_sendmsg_tcp(tx_entry->ep->conn_fd,
-	                             &msg, MSG_NOSIGNAL);
+	bytes_sent = ofi_sendmsg_tcp(tx_entry->ep->sock, &msg, MSG_NOSIGNAL);
 	if (bytes_sent < 0)
 		return ofi_sockerr() == EPIPE ? -FI_ENOTCONN : -ofi_sockerr();
 
@@ -154,7 +153,7 @@ int tcpx_recv_msg_data(struct tcpx_xfer_entry *rx_entry)
 						     rx_entry->iov,
 						     rx_entry->iov_cnt);
 	else
-		bytes_recvd = ofi_readv_socket(rx_entry->ep->conn_fd,
+		bytes_recvd = ofi_readv_socket(rx_entry->ep->sock,
 					       rx_entry->iov,
 					       rx_entry->iov_cnt);
 	if (bytes_recvd <= 0)

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -142,7 +142,7 @@ static int tcpx_ep_enable_xfers(struct tcpx_ep *ep)
 
 	if (ep->util_ep.rx_cq->wait) {
 		ret = ofi_wait_fd_add(ep->util_ep.rx_cq->wait,
-				      ep->conn_fd, FI_EPOLL_IN,
+				      ep->conn_fd, OFI_EPOLL_IN,
 				      tcpx_try_func, (void *) &ep->util_ep,
 				      NULL);
 	}
@@ -382,7 +382,7 @@ static void client_send_connreq(struct util_wait *wait,
 		goto err;
 
 	cm_ctx->type = CLIENT_RECV_CONNRESP;
-	ret = ofi_wait_fd_add(wait, ep->conn_fd, FI_EPOLL_IN,
+	ret = ofi_wait_fd_add(wait, ep->conn_fd, OFI_EPOLL_IN,
 			      tcpx_eq_wait_try_func, NULL, cm_ctx);
 	if (ret)
 		goto err;
@@ -437,7 +437,7 @@ static void server_sock_accept(struct util_wait *wait,
 	rx_req_cm_ctx->fid = &handle->handle;
 	rx_req_cm_ctx->type = SERVER_RECV_CONNREQ;
 
-	ret = ofi_wait_fd_add(wait, sock, FI_EPOLL_IN,
+	ret = ofi_wait_fd_add(wait, sock, OFI_EPOLL_IN,
 			      tcpx_eq_wait_try_func,
 			      NULL, (void *) rx_req_cm_ctx);
 	if (ret)
@@ -491,7 +491,7 @@ void tcpx_conn_mgr_run(struct util_eq *eq)
 
 	tcpx_eq = container_of(eq, struct tcpx_eq, util_eq);
 	fastlock_acquire(&tcpx_eq->close_lock);
-	num_fds = fi_epoll_wait(wait_fd->epoll_fd, wait_contexts,
+	num_fds = ofi_epoll_wait(wait_fd->epoll_fd, wait_contexts,
 				MAX_EPOLL_EVENTS, 0);
 	if (num_fds < 0) {
 		fastlock_release(&tcpx_eq->close_lock);

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -242,8 +242,9 @@ err:
 int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 		 struct fid_cq **cq_fid, void *context)
 {
-	int ret;
 	struct tcpx_cq *tcpx_cq;
+	struct fi_cq_attr cq_attr;
+	int ret;
 
 	tcpx_cq = calloc(1, sizeof(*tcpx_cq));
 	if (!tcpx_cq)
@@ -255,6 +256,12 @@ int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	ret = tcpx_buf_pools_create(tcpx_cq->buf_pools);
 	if (ret)
 		goto free_cq;
+
+	if (attr->wait_obj == FI_WAIT_NONE) {
+		cq_attr = *attr;
+		cq_attr.wait_obj = FI_WAIT_FD;
+		attr = &cq_attr;
+	}
 
 	ret = ofi_cq_init(&tcpx_prov, domain, attr, &tcpx_cq->util_cq,
 			  &ofi_cq_progress, context);

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2017-2020 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -36,6 +36,49 @@
 #include "tcpx.h"
 
 #define TCPX_DEF_CQ_SIZE (1024)
+
+
+void tcpx_cq_progress(struct util_cq *cq)
+{
+	void *wait_contexts[MAX_EPOLL_EVENTS];
+	struct fid_list_entry *fid_entry;
+	struct util_wait_fd *fdwait;
+	struct dlist_entry *item;
+	struct tcpx_ep *ep;
+	struct fid *fid;
+	int nfds, i;
+
+	fdwait = container_of(cq->wait, struct util_wait_fd, util_wait);
+
+	cq->cq_fastlock_acquire(&cq->ep_list_lock);
+	dlist_foreach(&cq->ep_list, item) {
+		fid_entry = container_of(item, struct fid_list_entry, entry);
+		ep = container_of(fid_entry->fid, struct tcpx_ep,
+				  util_ep.ep_fid.fid);
+		tcpx_try_func(&ep->util_ep);
+		tcpx_progress_tx(ep);
+		if (ep->stage_buf.off != ep->stage_buf.len)
+			tcpx_progress_rx(ep);
+	}
+
+	nfds = ofi_epoll_wait(fdwait->epoll_fd, wait_contexts,
+			      MAX_EPOLL_EVENTS, 0);
+	if (nfds <= 0)
+		goto unlock;
+
+	for (i = 0; i < nfds; i++) {
+		fid = wait_contexts[i];
+		if (fid->fclass != FI_CLASS_EP) {
+			fd_signal_reset(&fdwait->signal);
+			continue;
+		}
+
+		ep = container_of(fid, struct tcpx_ep, util_ep.ep_fid.fid);
+		tcpx_progress_rx(ep);
+	}
+unlock:
+	cq->cq_fastlock_release(&cq->ep_list_lock);
+}
 
 static void tcpx_buf_pools_destroy(struct tcpx_buf_pool *buf_pools)
 {
@@ -264,7 +307,7 @@ int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	}
 
 	ret = ofi_cq_init(&tcpx_prov, domain, attr, &tcpx_cq->util_cq,
-			  &ofi_cq_progress, context);
+			  &tcpx_cq_progress, context);
 	if (ret)
 		goto destroy_pool;
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -97,7 +97,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	struct tcpx_cm_context *cm_ctx;
 	int ret;
 
-	if (!addr || !tcpx_ep->conn_fd || paramlen > TCPX_MAX_CM_DATA_SIZE)
+	if (!addr || !tcpx_ep->sock || paramlen > TCPX_MAX_CM_DATA_SIZE)
 		return -FI_EINVAL;
 
 	cm_ctx = calloc(1, sizeof(*cm_ctx));
@@ -107,7 +107,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 		return -FI_ENOMEM;
 	}
 
-	ret = connect(tcpx_ep->conn_fd, (struct sockaddr *) addr,
+	ret = connect(tcpx_ep->sock, (struct sockaddr *) addr,
 		      (socklen_t) ofi_sizeofaddr(addr));
 	if (ret && ofi_sockerr() != FI_EINPROGRESS) {
 		ret =  -ofi_sockerr();
@@ -122,7 +122,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 		memcpy(cm_ctx->cm_data, param, paramlen);
 	}
 
-	ret = ofi_wait_fd_add(tcpx_ep->util_ep.eq->wait, tcpx_ep->conn_fd,
+	ret = ofi_wait_fd_add(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
 			      OFI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL,cm_ctx);
 	if (ret)
 		goto err;
@@ -140,7 +140,7 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	struct tcpx_cm_context *cm_ctx;
 	int ret;
 
-	if (tcpx_ep->conn_fd == INVALID_SOCKET)
+	if (tcpx_ep->sock == INVALID_SOCKET)
 		return -FI_EINVAL;
 
 	cm_ctx = calloc(1, sizeof(*cm_ctx));
@@ -157,7 +157,7 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 		memcpy(cm_ctx->cm_data, param, paramlen);
 	}
 
-	ret = ofi_wait_fd_add(tcpx_ep->util_ep.eq->wait, tcpx_ep->conn_fd,
+	ret = ofi_wait_fd_add(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
 			      OFI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL, cm_ctx);
 	if (ret) {
 		free(cm_ctx);
@@ -174,7 +174,7 @@ static int tcpx_ep_shutdown(struct fid_ep *ep, uint64_t flags)
 
 	tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
 
-	ret = ofi_shutdown(tcpx_ep->conn_fd, SHUT_RDWR);
+	ret = ofi_shutdown(tcpx_ep->sock, SHUT_RDWR);
 	if (ret && ofi_sockerr() != ENOTCONN) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_DATA, "ep shutdown unsuccessful\n");
 	}
@@ -269,7 +269,7 @@ static int tcpx_ep_getname(fid_t fid, void *addr, size_t *addrlen)
 	int ret;
 
 	tcpx_ep = container_of(fid, struct tcpx_ep, util_ep.ep_fid);
-	ret = ofi_getsockname(tcpx_ep->conn_fd, addr, (socklen_t *)addrlen);
+	ret = ofi_getsockname(tcpx_ep->sock, addr, (socklen_t *)addrlen);
 	if (ret)
 		return -ofi_sockerr();
 
@@ -283,7 +283,7 @@ static int tcpx_ep_getpeer(struct fid_ep *ep, void *addr, size_t *addrlen)
 	int ret;
 
 	tcpx_ep = container_of(ep, struct tcpx_ep, util_ep.ep_fid);
-	ret = ofi_getpeername(tcpx_ep->conn_fd, addr, (socklen_t *)addrlen);
+	ret = ofi_getpeername(tcpx_ep->sock, addr, (socklen_t *)addrlen);
 	if (ret)
 		return -ofi_sockerr();
 
@@ -361,14 +361,14 @@ static int tcpx_ep_close(struct fid *fid)
 	/* eq->close_lock protects from processing stale connection events */
 	fastlock_acquire(&eq->close_lock);
 	if (ep->util_ep.rx_cq->wait)
-		ofi_wait_fd_del(ep->util_ep.rx_cq->wait, ep->conn_fd);
+		ofi_wait_fd_del(ep->util_ep.rx_cq->wait, ep->sock);
 
 	if (ep->util_ep.eq->wait)
-		ofi_wait_fd_del(ep->util_ep.eq->wait, ep->conn_fd);
+		ofi_wait_fd_del(ep->util_ep.eq->wait, ep->sock);
 
 	fastlock_release(&eq->close_lock);
 	ofi_eq_remove_fid_events(ep->util_ep.eq, &ep->util_ep.ep_fid.fid);
-	ofi_close_socket(ep->conn_fd);
+	ofi_close_socket(ep->sock);
 	ofi_endpoint_close(&ep->util_ep);
 	fastlock_destroy(&ep->lock);
 
@@ -507,28 +507,28 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 			pep = container_of(info->handle, struct tcpx_pep,
 					   util_pep.pep_fid.fid);
 
-			ep->conn_fd = pep->sock;
+			ep->sock = pep->sock;
 			pep->sock = INVALID_SOCKET;
 		} else {
 			handle = container_of(info->handle,
 					      struct tcpx_conn_handle, handle);
-			ep->conn_fd = handle->conn_fd;
+			ep->sock = handle->sock;
 			ep->hdr_bswap = handle->endian_match ?
 					tcpx_hdr_none : tcpx_hdr_bswap;
 			free(handle);
 
-			ret = tcpx_setup_socket(ep->conn_fd);
+			ret = tcpx_setup_socket(ep->sock);
 			if (ret)
 				goto err3;
 		}
 	} else {
-		ep->conn_fd = ofi_socket(ofi_get_sa_family(info), SOCK_STREAM, 0);
-		if (ep->conn_fd == INVALID_SOCKET) {
+		ep->sock = ofi_socket(ofi_get_sa_family(info), SOCK_STREAM, 0);
+		if (ep->sock == INVALID_SOCKET) {
 			ret = -ofi_sockerr();
 			goto err2;
 		}
 
-		ret = tcpx_setup_socket(ep->conn_fd);
+		ret = tcpx_setup_socket(ep->sock);
 		if (ret)
 			goto err3;
 	}
@@ -566,7 +566,7 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ep->get_rx_entry[ofi_op_write] = tcpx_get_rx_entry_op_write;
 	return 0;
 err3:
-	ofi_close_socket(ep->conn_fd);
+	ofi_close_socket(ep->sock);
 err2:
 	ofi_endpoint_close(&ep->util_ep);
 err1:
@@ -692,15 +692,15 @@ static int tcpx_pep_reject(struct fid_pep *pep, fid_t handle,
 	hdr.type = ofi_ctrl_nack;
 	hdr.seg_size = htons((uint16_t) paramlen);
 
-	ret = ofi_send_socket(tcpx_handle->conn_fd, &hdr,
+	ret = ofi_send_socket(tcpx_handle->sock, &hdr,
 			      sizeof(hdr), MSG_NOSIGNAL);
 
 	if ((ret == sizeof(hdr)) && paramlen)
-		(void) ofi_send_socket(tcpx_handle->conn_fd, param,
+		(void) ofi_send_socket(tcpx_handle->sock, param,
 				       paramlen, MSG_NOSIGNAL);
 
-	ofi_shutdown(tcpx_handle->conn_fd, SHUT_RDWR);
-	ret = ofi_close_socket(tcpx_handle->conn_fd);
+	ofi_shutdown(tcpx_handle->sock, SHUT_RDWR);
+	ret = ofi_close_socket(tcpx_handle->sock);
 	if (ret)
 		return ret;
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -123,7 +123,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	}
 
 	ret = ofi_wait_fd_add(tcpx_ep->util_ep.eq->wait, tcpx_ep->conn_fd,
-			      FI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL,cm_ctx);
+			      OFI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL,cm_ctx);
 	if (ret)
 		goto err;
 
@@ -158,7 +158,7 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	}
 
 	ret = ofi_wait_fd_add(tcpx_ep->util_ep.eq->wait, tcpx_ep->conn_fd,
-			      FI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL, cm_ctx);
+			      OFI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL, cm_ctx);
 	if (ret) {
 		free(cm_ctx);
 		return ret;
@@ -671,7 +671,7 @@ static int tcpx_pep_listen(struct fid_pep *pep)
 	}
 
 	ret = ofi_wait_fd_add(tcpx_pep->util_pep.eq->wait, tcpx_pep->sock,
-			      FI_EPOLL_IN, tcpx_eq_wait_try_func,
+			      OFI_EPOLL_IN, tcpx_eq_wait_try_func,
 			      NULL, &tcpx_pep->cm_ctx);
 
 	tcpx_pep->util_pep.eq->wait->signal(tcpx_pep->util_pep.eq->wait);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -668,18 +668,18 @@ int tcpx_try_func(void *util_ep)
 	fastlock_acquire(&ep->lock);
 	if (!slist_empty(&ep->tx_queue) && !ep->send_ready_monitor) {
 		ep->send_ready_monitor = true;
-		events = FI_EPOLL_IN | FI_EPOLL_OUT;
+		events = OFI_EPOLL_IN | OFI_EPOLL_OUT;
 		goto epoll_mod;
 	} else if (slist_empty(&ep->tx_queue) && ep->send_ready_monitor) {
 		ep->send_ready_monitor = false;
-		events = FI_EPOLL_IN;
+		events = OFI_EPOLL_IN;
 		goto epoll_mod;
 	}
 	fastlock_release(&ep->lock);
 	return FI_SUCCESS;
 
 epoll_mod:
-	ret = fi_epoll_mod(wait_fd->epoll_fd, ep->conn_fd, events, NULL);
+	ret = ofi_epoll_mod(wait_fd->epoll_fd, ep->conn_fd, events, NULL);
 	if (ret)
 		FI_WARN(&tcpx_prov, FI_LOG_EP_DATA,
 			"invalid op type\n");

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -666,12 +666,12 @@ int tcpx_try_func(void *util_ep)
 			       struct util_wait_fd, util_wait);
 
 	fastlock_acquire(&ep->lock);
-	if (!slist_empty(&ep->tx_queue) && !ep->send_ready_monitor) {
-		ep->send_ready_monitor = true;
+	if (!slist_empty(&ep->tx_queue) && !ep->epoll_out_set) {
+		ep->epoll_out_set = true;
 		events = OFI_EPOLL_IN | OFI_EPOLL_OUT;
 		goto epoll_mod;
-	} else if (slist_empty(&ep->tx_queue) && ep->send_ready_monitor) {
-		ep->send_ready_monitor = false;
+	} else if (slist_empty(&ep->tx_queue) && ep->epoll_out_set) {
+		ep->epoll_out_set = false;
 		events = OFI_EPOLL_IN;
 		goto epoll_mod;
 	}

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -585,7 +585,7 @@ static inline int tcpx_get_next_rx_hdr(struct tcpx_ep *ep)
 	if (ep->cur_rx_msg.hdr_len == ep->cur_rx_msg.done_len)
 		return FI_SUCCESS;
 
-	ret = tcpx_comm_recv_hdr(ep->conn_fd, &ep->stage_buf, &ep->cur_rx_msg);
+	ret = tcpx_comm_recv_hdr(ep->sock, &ep->stage_buf, &ep->cur_rx_msg);
 	if (ret)
 		return ret;
 
@@ -598,7 +598,7 @@ static void tcpx_process_rx_msg(struct tcpx_ep *ep)
 	int ret;
 
 	if (!ep->cur_rx_entry && (ep->stage_buf.len == ep->stage_buf.off)) {
-		ret = tcpx_read_to_buffer(ep->conn_fd, &ep->stage_buf);
+		ret = tcpx_read_to_buffer(ep->sock, &ep->stage_buf);
 		if (ret)
 			goto err;
 	}
@@ -679,7 +679,7 @@ int tcpx_try_func(void *util_ep)
 	return FI_SUCCESS;
 
 epoll_mod:
-	ret = ofi_epoll_mod(wait_fd->epoll_fd, ep->conn_fd, events, NULL);
+	ret = ofi_epoll_mod(wait_fd->epoll_fd, ep->sock, events, NULL);
 	if (ret)
 		FI_WARN(&tcpx_prov, FI_LOG_EP_DATA,
 			"invalid op type\n");

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -561,7 +561,7 @@ static int udpx_ep_close(struct fid *fid)
 		if (ep->util_ep.rx_cq->wait) {
 			wait = container_of(ep->util_ep.rx_cq->wait,
 					    struct util_wait_fd, util_wait);
-			fi_epoll_del(wait->epoll_fd, (int)ep->sock);
+			ofi_epoll_del(wait->epoll_fd, (int)ep->sock);
 		}
 		fid_list_remove(&ep->util_ep.rx_cq->ep_list,
 				&ep->util_ep.rx_cq->ep_list_lock,
@@ -604,8 +604,8 @@ static int udpx_ep_bind_cq(struct udpx_ep *ep, struct util_cq *cq,
 
 			wait = container_of(cq->wait,
 					    struct util_wait_fd, util_wait);
-			ret = fi_epoll_add(wait->epoll_fd, (int)ep->sock,
-					   FI_EPOLL_IN, &ep->util_ep.ep_fid.fid);
+			ret = ofi_epoll_add(wait->epoll_fd, (int)ep->sock,
+					   OFI_EPOLL_IN, &ep->util_ep.ep_fid.fid);
 			if (ret)
 				return ret;
 		} else {

--- a/prov/util/src/util_ep.c
+++ b/prov/util/src/util_ep.c
@@ -174,18 +174,18 @@ int ofi_ep_bind(struct util_ep *util_ep, struct fid *fid, uint64_t flags)
 		return ret;
 
 	switch (fid->fclass) {
-		case FI_CLASS_CQ:
-			cq = container_of(fid, struct util_cq, cq_fid.fid);
-			return ofi_ep_bind_cq(util_ep, cq, flags);
-		case FI_CLASS_EQ:
-			eq = container_of(fid, struct util_eq, eq_fid.fid);
-			return ofi_ep_bind_eq(util_ep, eq);
-		case FI_CLASS_AV:
-			av = container_of(fid, struct util_av, av_fid.fid);
-			return ofi_ep_bind_av(util_ep, av);
-		case FI_CLASS_CNTR:
-			cntr = container_of(fid, struct util_cntr, cntr_fid.fid);
-			return ofi_ep_bind_cntr(util_ep, cntr, flags);
+	case FI_CLASS_CQ:
+		cq = container_of(fid, struct util_cq, cq_fid.fid);
+		return ofi_ep_bind_cq(util_ep, cq, flags);
+	case FI_CLASS_EQ:
+		eq = container_of(fid, struct util_eq, eq_fid.fid);
+		return ofi_ep_bind_eq(util_ep, eq);
+	case FI_CLASS_AV:
+		av = container_of(fid, struct util_av, av_fid.fid);
+		return ofi_ep_bind_av(util_ep, av);
+	case FI_CLASS_CNTR:
+		cntr = container_of(fid, struct util_cntr, cntr_fid.fid);
+		return ofi_ep_bind_cntr(util_ep, cntr, flags);
 	}
 
 	return -FI_EINVAL;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -48,7 +48,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <pthread.h>
-#include <sys/epoll.h>
+#include <ofi_epoll.h>
 
 #include <infiniband/ib.h>
 #include <infiniband/verbs.h>
@@ -274,7 +274,7 @@ struct vrb_eq {
 	struct rdma_event_channel *channel;
 	uint64_t		flags;
 	struct fi_eq_err_entry	err;
-	int			epfd;
+	ofi_epoll_t		epollfd;
 
 	struct {
 		/* The connection key map is used during the XRC connection

--- a/src/common.c
+++ b/src/common.c
@@ -987,10 +987,9 @@ static void ofi_epoll_process_work_item_list(struct fi_epoll *ep)
 		case EPOLL_CTL_MOD:
 			for (i = 0; i < ep->nfds; i++) {
 				if (ep->fds[i].fd == item->fd) {
-
 					ep->fds[i].events = item->events;
 					ep->fds[i].revents &= item->events;
-					ep->context = item->context;
+					ep->context[i] = item->context;
 					break;
 				}
 			}
@@ -1028,6 +1027,7 @@ int ofi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
 
 		fastlock_release(&ep->lock);
 
+		/* Index 0 is the internal signaling fd, skip it */
 		for (i = ep->index; i < ep->nfds && found < max_contexts; i++) {
 			if (ep->fds[i].revents && i) {
 				contexts[found++] = ep->context[i];

--- a/src/common.c
+++ b/src/common.c
@@ -846,7 +846,7 @@ int ofi_discard_socket(SOCKET sock, size_t len)
 
 #ifndef HAVE_EPOLL
 
-int fi_epoll_create(struct fi_epoll **ep)
+int ofi_epoll_create(struct fi_epoll **ep)
 {
 	int ret;
 
@@ -868,7 +868,7 @@ int fi_epoll_create(struct fi_epoll **ep)
 		goto err2;
 
 	(*ep)->fds[(*ep)->nfds].fd = (*ep)->signal.fd[FI_READ_FD];
-	(*ep)->fds[(*ep)->nfds].events = FI_EPOLL_IN;
+	(*ep)->fds[(*ep)->nfds].events = OFI_EPOLL_IN;
 	(*ep)->context[(*ep)->nfds++] = NULL;
 	slist_init(&(*ep)->work_item_list);
 	fastlock_init(&(*ep)->lock);
@@ -881,10 +881,10 @@ err1:
 }
 
 
-static int fi_epoll_ctl(struct fi_epoll *ep, enum fi_epoll_ctl op,
+static int ofi_epoll_ctl(struct fi_epoll *ep, enum ofi_epoll_ctl op,
 			int fd, uint32_t events, void *context)
 {
-	struct fi_epoll_work_item *item;
+	struct ofi_epoll_work_item *item;
 
 	item = calloc(1,sizeof(*item));
 	if (!item)
@@ -901,22 +901,22 @@ static int fi_epoll_ctl(struct fi_epoll *ep, enum fi_epoll_ctl op,
 	return 0;
 }
 
-int fi_epoll_add(struct fi_epoll *ep, int fd, uint32_t events, void *context)
+int ofi_epoll_add(struct fi_epoll *ep, int fd, uint32_t events, void *context)
 {
-	return fi_epoll_ctl(ep, EPOLL_CTL_ADD, fd, events, context);
+	return ofi_epoll_ctl(ep, EPOLL_CTL_ADD, fd, events, context);
 }
 
-int fi_epoll_mod(struct fi_epoll *ep, int fd, uint32_t events, void *context)
+int ofi_epoll_mod(struct fi_epoll *ep, int fd, uint32_t events, void *context)
 {
-	return fi_epoll_ctl(ep, EPOLL_CTL_MOD, fd, events, context);
+	return ofi_epoll_ctl(ep, EPOLL_CTL_MOD, fd, events, context);
 }
 
-int fi_epoll_del(struct fi_epoll *ep, int fd)
+int ofi_epoll_del(struct fi_epoll *ep, int fd)
 {
-	return fi_epoll_ctl(ep, EPOLL_CTL_DEL, fd, 0, NULL);
+	return ofi_epoll_ctl(ep, EPOLL_CTL_DEL, fd, 0, NULL);
 }
 
-static int fi_epoll_fd_array_grow(struct fi_epoll *ep)
+static int ofi_epoll_fd_array_grow(struct fi_epoll *ep)
 {
 	struct pollfd *fds;
 	void *contexts;
@@ -937,7 +937,7 @@ static int fi_epoll_fd_array_grow(struct fi_epoll *ep)
 	return FI_SUCCESS;
 }
 
-static void fi_epoll_cleanup_array(struct fi_epoll *ep)
+static void ofi_epoll_cleanup_array(struct fi_epoll *ep)
 {
 	int i;
 
@@ -954,19 +954,19 @@ static void fi_epoll_cleanup_array(struct fi_epoll *ep)
 	}
 }
 
-static void fi_epoll_process_work_item_list(struct fi_epoll *ep)
+static void ofi_epoll_process_work_item_list(struct fi_epoll *ep)
 {
 	struct slist_entry *entry;
-	struct fi_epoll_work_item *item;
+	struct ofi_epoll_work_item *item;
 	int i;
 
 	while (!slist_empty(&ep->work_item_list)) {
 		if ((ep->nfds == ep->size) &&
-		    fi_epoll_fd_array_grow(ep))
+		    ofi_epoll_fd_array_grow(ep))
 			continue;
 
 		entry = slist_remove_head(&ep->work_item_list);
-		item = container_of(entry, struct fi_epoll_work_item, entry);
+		item = container_of(entry, struct ofi_epoll_work_item, entry);
 
 		switch (item->type) {
 		case EPOLL_CTL_ADD:
@@ -1002,10 +1002,10 @@ static void fi_epoll_process_work_item_list(struct fi_epoll *ep)
 		free(item);
 	}
 out:
-	fi_epoll_cleanup_array(ep);
+	ofi_epoll_cleanup_array(ep);
 }
 
-int fi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
+int ofi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
                   int timeout)
 {
 	int i, ret;
@@ -1024,7 +1024,7 @@ int fi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
 
 		fastlock_acquire(&ep->lock);
 		if (!slist_empty(&ep->work_item_list))
-			fi_epoll_process_work_item_list(ep);
+			ofi_epoll_process_work_item_list(ep);
 
 		fastlock_release(&ep->lock);
 
@@ -1049,15 +1049,15 @@ int fi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
 	return found;
 }
 
-void fi_epoll_close(struct fi_epoll *ep)
+void ofi_epoll_close(struct fi_epoll *ep)
 {
-	struct fi_epoll_work_item *item;
+	struct ofi_epoll_work_item *item;
 	struct slist_entry *entry;
 	if (ep) {
 		while (!slist_empty(&ep->work_item_list)) {
 			entry = slist_remove_head(&ep->work_item_list);
 			item = container_of(entry,
-					    struct fi_epoll_work_item,
+					    struct ofi_epoll_work_item,
 					    entry);
 			free(item);
 		}

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -104,7 +104,7 @@ static void ofi_tostr_opflags(char *buf, uint64_t flags)
 	ofi_remove_comma(buf);
 }
 
-static void oofi_tostr_addr_format(char *buf, uint32_t addr_format)
+static void ofi_tostr_addr_format(char *buf, uint32_t addr_format)
 {
 	switch (addr_format) {
 	CASEENUMSTR(FI_FORMAT_UNSPEC);
@@ -551,7 +551,7 @@ static void ofi_tostr_info(char *buf, const struct fi_info *info)
 	ofi_strcatf(buf, " ]\n");
 
 	ofi_strcatf(buf, "%saddr_format: ", TAB);
-	oofi_tostr_addr_format(buf, info->addr_format);
+	ofi_tostr_addr_format(buf, info->addr_format);
 	ofi_strcatf(buf, "\n");
 
 	ofi_strcatf(buf, "%ssrc_addrlen: %zu\n", TAB, info->src_addrlen);
@@ -718,7 +718,7 @@ char *DEFAULT_SYMVER_PRE(fi_tostr)(const void *data, enum fi_type datatype)
 		ofi_tostr_opflags(buf, *val64);
 		break;
 	case FI_TYPE_ADDR_FORMAT:
-		oofi_tostr_addr_format(buf, *val32);
+		ofi_tostr_addr_format(buf, *val32);
 		break;
 	case FI_TYPE_TX_ATTR:
 		ofi_tostr_tx_attr(buf, data, "");


### PR DESCRIPTION
Progress over tcp currently requires iterating over all open endpoints seeing if there is data available  This maps to reading each open socket.  At scale, this results in a large number of 'no-op' read calls to the kernel.  Replace the progress model with epoll, and only read sockets that have data available.