### PR TITLE
[v1.9.x] prov/efa: fix a bug in rxr_ep_poll_cq()

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -329,6 +329,7 @@ struct rxr_av {
 	struct util_av util_av;
 	struct fid_av *rdm_av;
 	struct fid_av *shm_rdm_av;
+	fi_addr_t shm_rdm_addr_map[RXR_SHM_MAX_AV_COUNT];
 	struct rxr_av_entry *av_map;
 
 	int rdm_av_used;

--- a/prov/efa/src/rxr/rxr_av.c
+++ b/prov/efa/src/rxr/rxr_av.c
@@ -126,6 +126,8 @@ int rxr_av_insert_rdm_addr(struct rxr_av *av, const void *addr,
 			" shm_rdm_fiaddr = %" PRIu64 "\n", smr_name, *(uint64_t *)addr, *rdm_fiaddr, shm_fiaddr);
 		av_entry->local_mapping = 1;
 		av_entry->shm_rdm_addr = shm_fiaddr;
+		assert(av_entry->shm_rdm_addr < RXR_SHM_MAX_AV_COUNT);
+		av->shm_rdm_addr_map[shm_fiaddr] = av_entry->rdm_addr;
 
 		/*
 		 * Walk through all the EPs that bound to the AV,
@@ -259,6 +261,9 @@ static int rxr_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 			ret = fi_av_remove(av->shm_rdm_av, &av_entry->shm_rdm_addr, 1, flags);
 			if (ret)
 				break;
+
+			assert(av_entry->shm_rdm_addr < RXR_SHM_MAX_AV_COUNT);
+			av->shm_rdm_addr_map[av_entry->shm_rdm_addr] = FI_ADDR_UNSPEC;
 		}
 
 		if (av_entry) {

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -2902,6 +2902,12 @@ static inline void rxr_ep_poll_cq(struct rxr_ep *ep,
 		if (OFI_UNLIKELY(ret == 0))
 			return;
 
+		if (is_shm_cq && src_addr != FI_ADDR_UNSPEC) {
+			/* convert SHM address to EFA address */
+			assert(src_addr < RXR_SHM_MAX_AV_COUNT);
+			src_addr = rxr_ep_av(ep)->shm_rdm_addr_map[src_addr];
+		}
+
 		if (is_shm_cq && (cq_entry.flags & FI_REMOTE_CQ_DATA)) {
 			rxr_cq_handle_shm_rma_write_data(ep, &cq_entry, src_addr);
 		} else if (cq_entry.flags & (FI_SEND | FI_READ | FI_WRITE)) {


### PR DESCRIPTION
The function rxr_ep_poll_cq() call fi_cq_readfrom() on both efa_cq
and shm_cq, and get the src_addr back. For shm_cq, src_addr returned
is shm address, which is used in rxr_ep_poll_cq() as EFA address.

This patch fix the issue by introducing a shm_rdm_addr_map to efa_av,
which is filled in efa_av_insert_addr() and used in rxr_ep_poll_cq()
to convert shm address to EFA address.

Signed-off-by: Wei Zhang <wzam@amazon.com>