### PR TITLE
Add FI_WARN_ONCE macro

### DIFF
--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -100,6 +100,15 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 	do {} while (0)
 #endif
 
+#define FI_WARN_ONCE(prov, subsystem, ...) ({				\
+	static int warned;						\
+	if (!warned && fi_log_enabled(prov, FI_LOG_WARN, subsystem)) {	\
+		fi_log(prov, FI_LOG_WARN, subsystem,			\
+			__func__, __LINE__, __VA_ARGS__);		\
+		warned = 1;						\
+	}								\
+})
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -185,7 +185,7 @@ int smr_map_to_region(const struct fi_provider *prov, struct smr_peer *peer_buf)
 
 	fd = shm_open(peer_buf->peer.name, O_RDWR, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
-		FI_WARN(prov, FI_LOG_AV, "shm_open error\n");
+		FI_WARN_ONCE(prov, FI_LOG_AV, "shm_open error\n");
 		return -errno;
 	}
 


### PR DESCRIPTION
1. Add FI_WARN_ONCE marco 
2. Only print out warning message once if failing with shm_open