### PR TITLE
prov/efa: move definition of packet types to a separate header file

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -57,7 +57,8 @@ _efa_headers = \
 	prov/efa/src/rxr/rxr_cntr.h \
 	prov/efa/src/rxr/rxr_rma.h \
 	prov/efa/src/rxr/rxr_msg.h \
-	prov/efa/src/rxr/rxr_pkt_entry.h
+	prov/efa/src/rxr/rxr_pkt_entry.h \
+	prov/efa/src/rxr/rxr_pkt_type.h
 
 efa_CPPFLAGS += \
 	-I$(top_srcdir)/prov/efa/src/ \

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _RXR_PKT_TYPE_H
+#define _RXR_PKT_TYPE_H
+
+/* This header file contain the ID of all RxR packet types, and
+ * the necessary data structures and functions for each packet type
+ *
+ * RxR packet types can be classified into 3 categories:
+ *     data packet, control packet and context packet
+ *
+ * For each packet type, the following items are needed:
+ *
+ *   First, each packet type need to define a struct for its header,
+ *       and the header must be start with ```struct rxr_base_hdr```.
+ *
+ *   Second, each control packet type need to define an init()
+ *       function and a handle_sent() function. These functions
+ *       are called by rxr_pkt_post_ctrl_or_queue().
+ *
+ *   Finally, each packet type (except context packet) need to
+ *     define a handle_recv() functions which is called by
+ *     rxr_pkt_handle_recv_completion().
+ */
+
+enum rxr_pkt_type {
+	RXR_RTS_PKT = 1,
+	RXR_CONNACK_PKT,
+	RXR_CTS_PKT,
+	RXR_DATA_PKT,
+	RXR_READRSP_PKT,
+	RXR_RMA_CONTEXT_PKT,
+	RXR_EOR_PKT,
+};
+
+/*
+ *  Packet fields common to all rxr packets. The other packet headers below must
+ *  be changed if this is updated.
+ */
+struct rxr_base_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_base_hdr) == 4, "rxr_base_hdr check");
+#endif
+
+static inline struct rxr_base_hdr *rxr_get_base_hdr(void *pkt)
+{
+	return (struct rxr_base_hdr *)pkt;
+}
+
+struct rxr_ep;
+struct rxr_peer;
+struct rxr_tx_entry;
+struct rxr_rx_entry;
+
+/*
+ *  RTS packet data structures and functions. the implementation of
+ *  these functions are in rxr_pkt_type_rts.c
+ */
+struct rxr_rts_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	/* TODO: need to add msg_id -> tx_id mapping to remove tx_id */
+	uint16_t credit_request;
+	uint8_t addrlen;
+	uint8_t rma_iov_count;
+	uint32_t tx_id;
+	uint32_t msg_id;
+	uint64_t tag;
+	uint64_t data_len;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_rts_hdr) == 32, "rxr_rts_hdr check");
+#endif
+
+static inline
+struct rxr_rts_hdr *rxr_get_rts_hdr(void *pkt)
+{
+	return (struct rxr_rts_hdr *)pkt;
+}
+
+uint64_t rxr_get_rts_data_size(struct rxr_ep *ep,
+			       struct rxr_rts_hdr *rts_hdr);
+
+ssize_t rxr_pkt_init_rts(struct rxr_ep *ep,
+			 struct rxr_tx_entry *tx_entry,
+			 struct rxr_pkt_entry *pkt_entry);
+
+char *rxr_pkt_init_rts_base_hdr(struct rxr_ep *ep,
+				struct rxr_tx_entry *tx_entry,
+				struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_rts_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+ssize_t rxr_pkt_post_shm_read(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry);
+
+ssize_t rxr_pkt_proc_matched_msg_rts(struct rxr_ep *ep,
+				     struct rxr_rx_entry *rx_entry,
+				     struct rxr_pkt_entry *pkt_entry);
+
+ssize_t rxr_pkt_proc_rts(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_rts_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  CONNACK packet header and functions
+ *  implementation of the functions are in rxr_pkt_type_misc.c
+ */
+struct rxr_connack_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_connack_hdr) == 4, "rxr_connack_hdr check");
+#endif
+
+#define RXR_CONNACK_HDR_SIZE		(sizeof(struct rxr_connack_hdr))
+
+static inline
+struct rxr_connack_hdr *rxr_get_connack_hdr(void *pkt)
+{
+	return (struct rxr_connack_hdr *)pkt;
+}
+
+ssize_t rxr_pkt_init_connack(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry,
+			     fi_addr_t addr);
+
+void rxr_pkt_post_connack(struct rxr_ep *ep,
+			  struct rxr_peer *peer,
+			  fi_addr_t addr);
+
+void rxr_pkt_handle_connack_recv(struct rxr_ep *ep,
+				 struct fi_cq_data_entry *comp,
+				 struct rxr_pkt_entry *pkt_entry,
+				 fi_addr_t addr);
+/*
+ *  CTS packet data structures and functions.
+ *  Definition of the functions is in rxr_pkt_type_misc.c
+ */
+struct rxr_cts_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint8_t pad[4];
+	/* TODO: need to add msg_id -> tx_id/rx_id mapping */
+	uint32_t tx_id;
+	uint32_t rx_id;
+	uint64_t window;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_cts_hdr) == 24, "rxr_cts_hdr check");
+#endif
+
+#define RXR_CTS_HDR_SIZE		(sizeof(struct rxr_cts_hdr))
+
+static inline
+struct rxr_cts_hdr *rxr_get_cts_hdr(void *pkt)
+{
+	return (struct rxr_cts_hdr *)pkt;
+}
+
+ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
+			 struct rxr_rx_entry *rx_entry,
+			 struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_cts_sent(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_cts_recv(struct rxr_ep *ep,
+			     struct fi_cq_data_entry *comp,
+			     struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  DATA packet data structures and functions
+ *  Definition of the functions is in rxr_pkt_data.c
+ */
+struct rxr_data_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	/* TODO: need to add msg_id -> tx_id/rx_id mapping */
+	uint32_t rx_id;
+	uint64_t seg_size;
+	uint64_t seg_offset;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_data_hdr) == 24, "rxr_data_hdr check");
+#endif
+
+#define RXR_DATA_HDR_SIZE		(sizeof(struct rxr_data_hdr))
+
+struct rxr_data_pkt {
+	struct rxr_data_hdr hdr;
+	char data[];
+};
+
+static inline
+struct rxr_data_pkt *rxr_get_data_pkt(void *pkt)
+{
+	return (struct rxr_data_pkt *)pkt;
+}
+
+ssize_t rxr_pkt_send_data(struct rxr_ep *ep,
+			  struct rxr_tx_entry *tx_entry,
+			  struct rxr_pkt_entry *pkt_entry);
+
+ssize_t rxr_pkt_send_data_mr_cache(struct rxr_ep *ep,
+				   struct rxr_tx_entry *tx_entry,
+				   struct rxr_pkt_entry *pkt_entry);
+
+int rxr_pkt_handle_data(struct rxr_ep *ep,
+			struct rxr_rx_entry *rx_entry,
+			struct rxr_pkt_entry *pkt_entry,
+			char *data, size_t seg_offset,
+			size_t seg_size);
+
+void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  READRSP packet data structures and functions
+ *  The definition of functions are in rxr_pkt_type_misc.c
+ */
+struct rxr_readrsp_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint8_t pad[4];
+	uint32_t rx_id;
+	uint32_t tx_id;
+	uint64_t seg_size;
+};
+
+static inline struct rxr_readrsp_hdr *rxr_get_readrsp_hdr(void *pkt)
+{
+	return (struct rxr_readrsp_hdr *)pkt;
+}
+
+#define RXR_READRSP_HDR_SIZE	(sizeof(struct rxr_readrsp_hdr))
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_readrsp_hdr) == sizeof(struct rxr_data_hdr), "rxr_readrsp_hdr check");
+#endif
+
+struct rxr_readrsp_pkt {
+	struct rxr_readrsp_hdr hdr;
+	char data[];
+};
+
+int rxr_pkt_init_readrsp(struct rxr_ep *ep,
+			 struct rxr_tx_entry *tx_entry,
+			 struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep,
+				 struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_readrsp_recv(struct rxr_ep *ep,
+				 struct fi_cq_data_entry *comp,
+				 struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  RMA context packet, used to differentiate the normal RMA read, normal RMA
+ *  write, and the RMA read in two-sided large message transfer
+ *  Implementation of the function is in rxr_pkt_type_misc.c
+ */
+struct rxr_rma_context_pkt {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t tx_id;
+	uint8_t rma_context_type;
+};
+
+void rxr_pkt_handle_rma_context_send_completion(struct rxr_ep *ep,
+						struct rxr_pkt_entry *pkt_entry);
+
+/*
+ *  EOR packet, used to acknowledge the sender that large message
+ *  copy has been finished.
+ *  Implementaion of the functions are in rxr_pkt_misc.c
+ */
+struct rxr_eor_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t tx_id;
+	uint32_t rx_id;
+};
+
+#if defined(static_assert) && defined(__x86_64__)
+static_assert(sizeof(struct rxr_eor_hdr) == 12, "rxr_eor_hdr check");
+#endif
+
+int rxr_pkt_init_eor(struct rxr_ep *ep,
+		     struct rxr_rx_entry *rx_entry,
+		     struct rxr_pkt_entry *pkt_entry);
+
+static inline
+void rxr_pkt_handle_eor_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+}
+
+void rxr_pkt_handle_eor_recv(struct rxr_ep *ep,
+			     struct rxr_pkt_entry *pkt_entry);
+
+/*
+ * Control header without completion data. We will send more data with the RTS
+ * packet if RXR_REMOTE_CQ_DATA is not set.
+ */
+struct rxr_ctrl_hdr {
+	union {
+		struct rxr_base_hdr base_hdr;
+		struct rxr_rts_hdr rts_hdr;
+		struct rxr_connack_hdr connack_hdr;
+		struct rxr_cts_hdr cts_hdr;
+	};
+};
+
+#define RXR_CTRL_HDR_SIZE              (sizeof(struct rxr_ctrl_cq_hdr))
+
+struct rxr_ctrl_pkt {
+	struct rxr_ctrl_hdr hdr;
+	char data[];
+};
+
+/*
+ * Control header with completion data. CQ data length is static.
+ */
+#define RXR_CQ_DATA_SIZE (8)
+struct rxr_ctrl_cq_hdr {
+	union {
+		struct rxr_base_hdr base_hdr;
+		struct rxr_rts_hdr rts_hdr;
+		struct rxr_connack_hdr connack_hdr;
+		struct rxr_cts_hdr cts_hdr;
+	};
+	uint64_t cq_data;
+};
+
+#define RXR_CTRL_HDR_SIZE_NO_CQ                (sizeof(struct rxr_ctrl_hdr))
+
+struct rxr_ctrl_cq_pkt {
+	struct rxr_ctrl_cq_hdr hdr;
+	char data[];
+};
+
+#endif
+

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -39,10 +39,10 @@
 #include "rxr.h"
 #include "rxr_rma.h"
 
-char *rxr_rma_init_rts_hdr(struct rxr_ep *ep,
-			   struct rxr_tx_entry *tx_entry,
-			   struct rxr_pkt_entry *pkt_entry,
-			   char *hdr)
+char *rxr_pkt_init_rts_rma_hdr(struct rxr_ep *ep,
+			       struct rxr_tx_entry *tx_entry,
+			       struct rxr_pkt_entry *pkt_entry,
+			       char *hdr)
 {
 	int rmalen;
 	struct rxr_rts_hdr *rts_hdr;
@@ -168,8 +168,8 @@ int rxr_rma_init_read_rts(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	struct rxr_rma_read_info *read_info;
 	char *hdr;
 
-	hdr = rxr_ep_init_rts_hdr(ep, tx_entry, pkt_entry);
-	hdr = rxr_rma_init_rts_hdr(ep, tx_entry, pkt_entry, hdr);
+	hdr = rxr_pkt_init_rts_base_hdr(ep, tx_entry, pkt_entry);
+	hdr = rxr_pkt_init_rts_rma_hdr(ep, tx_entry, pkt_entry, hdr);
 
 	/* no data to send, but need to send rx_id and window */
 	read_info = (struct rxr_rma_read_info *)hdr;
@@ -285,9 +285,9 @@ rxr_rma_alloc_readrsp_tx_entry(struct rxr_ep *rxr_ep,
 	return tx_entry;
 }
 
-int rxr_rma_init_readrsp_pkt(struct rxr_ep *ep,
-			     struct rxr_tx_entry *tx_entry,
-			     struct rxr_pkt_entry *pkt_entry)
+int rxr_pkt_init_readrsp(struct rxr_ep *ep,
+			 struct rxr_tx_entry *tx_entry,
+			 struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_readrsp_pkt *readrsp_pkt;
 	struct rxr_readrsp_hdr *readrsp_hdr;
@@ -310,7 +310,7 @@ int rxr_rma_init_readrsp_pkt(struct rxr_ep *ep,
 	return 0;
 }
 
-void rxr_rma_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_tx_entry *tx_entry;
 	size_t data_len;
@@ -332,7 +332,7 @@ void rxr_rma_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 }
 
 /* EOR packet functions */
-int rxr_rma_init_eor_pkt(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry, struct rxr_pkt_entry *pkt_entry)
+int rxr_pkt_init_eor(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry, struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_eor_hdr *eor_hdr;
 
@@ -346,10 +346,6 @@ int rxr_rma_init_eor_pkt(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry, struc
 	pkt_entry->addr = rx_entry->addr;
 	pkt_entry->x_entry = rx_entry;
 	return 0;
-}
-
-void rxr_rma_handle_eor_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
-{
 }
 
 struct rxr_tx_entry *

--- a/prov/efa/src/rxr/rxr_rma.h
+++ b/prov/efa/src/rxr/rxr_rma.h
@@ -39,33 +39,6 @@
 
 #include <rdma/fi_rma.h>
 
-struct rxr_readrsp_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	uint8_t pad[4];
-	uint32_t rx_id;
-	uint32_t tx_id;
-	uint64_t seg_size;
-};
-
-struct rxr_readrsp_pkt {
-	struct rxr_readrsp_hdr hdr;
-	char data[];
-};
-
-static inline struct rxr_readrsp_hdr *rxr_get_readrsp_hdr(void *pkt)
-{
-	return (struct rxr_readrsp_hdr *)pkt;
-}
-
-#define RXR_READRSP_HDR_SIZE	(sizeof(struct rxr_readrsp_hdr))
-
-#if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_readrsp_hdr) == sizeof(struct rxr_data_hdr), "rxr_readrsp_hdr check");
-#endif
-
 struct rxr_rma_read_info {
 	uint64_t rma_initiator_rx_id;
 	uint64_t window;
@@ -75,10 +48,10 @@ struct rxr_rma_read_info {
 static_assert(sizeof(struct rxr_rma_read_info) == 16, "rxr_rma_read_hdr check");
 #endif
 
-char *rxr_rma_init_rts_hdr(struct rxr_ep *ep,
-			   struct rxr_tx_entry *tx_entry,
-			   struct rxr_pkt_entry *pkt_entry,
-			   char *hdr);
+char *rxr_pkt_init_rts_rma_hdr(struct rxr_ep *ep,
+			       struct rxr_tx_entry *tx_entry,
+			       struct rxr_pkt_entry *pkt_entry,
+			       char *hdr);
 
 int rxr_rma_verified_copy_iov(struct rxr_ep *ep, struct fi_rma_iov *rma,
 			      size_t count, uint32_t flags, struct iovec *iov);
@@ -100,19 +73,19 @@ struct rxr_tx_entry *
 rxr_rma_alloc_readrsp_tx_entry(struct rxr_ep *rxr_ep,
 			       struct rxr_rx_entry *rx_entry);
 
-int rxr_rma_init_readrsp_pkt(struct rxr_ep *ep,
-			     struct rxr_tx_entry *tx_entry,
-			     struct rxr_pkt_entry *pkt_entry);
+int rxr_pkt_init_readrsp(struct rxr_ep *ep,
+			 struct rxr_tx_entry *tx_entry,
+			 struct rxr_pkt_entry *pkt_entry);
 
-void rxr_rma_handle_readrsp_sent(struct rxr_ep *ep,
+void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry);
 
 /* EOR related functions */
-int rxr_rma_init_eor_pkt(struct rxr_ep *ep,
-			 struct rxr_rx_entry *rx_entry,
-			 struct rxr_pkt_entry *pkt_entry);
+int rxr_pkt_init_eor(struct rxr_ep *ep,
+		     struct rxr_rx_entry *rx_entry,
+		     struct rxr_pkt_entry *pkt_entry);
 
-void rxr_rma_handle_eor_sent(struct rxr_ep *ep,
+void rxr_pkt_handle_eor_sent(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry);
 
 size_t rxr_rma_post_shm_rma(struct rxr_ep *rxr_ep,


### PR DESCRIPTION
Each packet type need to define a header struct and some functions,
this patch move these definitions into a separate header file
       rxr_pkt_type.h,

also rename the functions included in the header files to add
a rxr_pkt prefix

Signed-off-by: Wei Zhang <wzam@amazon.com>