### PR TITLE
prov/psm,psm2: Minor code cleanups

### DIFF
--- a/prov/psm/src/psmx_am.c
+++ b/prov/psm/src/psmx_am.c
@@ -127,8 +127,6 @@ int psmx_am_init(struct psmx_fid_domain *domain)
 	size_t size;
 	int err = 0;
 
-	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
-
 	psmx_atomic_init();
 
 	if (!psmx_am_handlers_initialized) {

--- a/prov/psm/src/psmx_domain.c
+++ b/prov/psm/src/psmx_domain.c
@@ -106,8 +106,6 @@ static void *psmx_progress_func(void *args)
 	int sleep_usec;
 	struct timespec ts;
 
-	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
-
 	affinity_set = psmx_progress_set_affinity(psmx_env.prog_affinity);
 
 	/* Negative sleep time means let the system choose the default.
@@ -361,8 +359,6 @@ int psmx_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct psmx_fid_fabric *fabric_priv;
 	struct psmx_fid_domain *domain_priv;
 	int err;
-
-	FI_INFO(&psmx_prov, FI_LOG_DOMAIN, "\n");
 
 	fabric_priv = container_of(fabric, struct psmx_fid_fabric,
 				   util_fabric.fabric_fid);

--- a/prov/psm/src/psmx_ep.c
+++ b/prov/psm/src/psmx_ep.c
@@ -531,8 +531,6 @@ int psmx_stx_ctx(struct fid_domain *domain, struct fi_tx_attr *attr,
 	struct psmx_fid_domain *domain_priv;
 	struct psmx_fid_stx *stx_priv;
 
-	FI_INFO(&psmx_prov, FI_LOG_EP_DATA, "\n");
-
 	domain_priv = container_of(domain, struct psmx_fid_domain,
 				   util_domain.domain_fid.fid);
 

--- a/prov/psm/src/psmx_fabric.c
+++ b/prov/psm/src/psmx_fabric.c
@@ -88,8 +88,6 @@ int psmx_fabric(struct fi_fabric_attr *attr,
 	struct psmx_fid_fabric *fabric_priv;
 	int ret;
 
-	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
-
 	if (strcmp(attr->name, PSMX_FABRIC_NAME))
 		return -FI_ENODATA;
 

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -674,8 +674,6 @@ err_out:
 
 static void psmx_fini(void)
 {
-	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
-
 	if (! --psmx_init_count && psmx_lib_initialized) {
 		/* This function is called from a library destructor, which is called
 		 * automatically when exit() is called. The call to psm_finalize()
@@ -705,8 +703,6 @@ struct fi_provider psmx_prov = {
 
 PROVIDER_INI
 {
-	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
-
 	fi_param_define(&psmx_prov, "name_server", FI_PARAM_BOOL,
 			"Whether to turn on the name server or not "
 			"(default: yes)");

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -107,8 +107,6 @@ static void *psmx2_progress_func(void *args)
 	int sleep_usec;
 	struct timespec ts;
 
-	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
-
 	affinity_set = psmx2_progress_set_affinity(psmx2_env.prog_affinity);
 
 	/* Negative sleep time means let the system choose the default.
@@ -303,8 +301,6 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	struct psmx2_ep_name *src_addr = info->src_addr;
 	int mr_mode = (info->domain_attr->mr_mode & FI_MR_BASIC) ? FI_MR_BASIC : 0;
 	int err, tmp;
-
-	FI_INFO(&psmx2_prov, FI_LOG_DOMAIN, "\n");
 
 	fabric_priv = container_of(fabric, struct psmx2_fid_fabric,
 				   util_fabric.fabric_fid);

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -87,8 +87,6 @@ int psmx2_fabric(struct fi_fabric_attr *attr,
 	struct psmx2_fid_fabric *fabric_priv;
 	int ret;
 
-	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
-
 	if (strcmp(attr->name, PSMX2_FABRIC_NAME))
 		return -FI_ENODATA;
 

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -629,8 +629,6 @@ err_out:
 
 static void psmx2_fini(void)
 {
-	FI_INFO(&psmx2_prov, FI_LOG_CORE, "\n");
-
 	if (! --psmx2_init_count && psmx2_lib_initialized) {
 		/* This function is called from a library destructor, which is called
 		 * automatically when exit() is called. The call to psm2_finalize()


### PR DESCRIPTION
There are some `FI_INFO` outputs with `"\n"`. Removed them.
Do we really need them or can remove? 

Thanks.