### PR TITLE
Revert "prov/efa: Disable MR cache"

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -118,7 +118,7 @@ These OFI runtime parameters apply only to the RDM endpoint.
 
 *FI_EFA_MR_CACHE_ENABLE*
 : Enables using the mr cache and in-line registration instead of a bounce
-  buffer for iov's larger than max_memcpy_size. Defaults to false. When
+  buffer for iov's larger than max_memcpy_size. Defaults to true. When
   disabled, only uses a bounce buffer
 
 *FI_EFA_MR_CACHE_MERGE_REGIONS*

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -74,7 +74,7 @@
 
 #define EFA_NO_DEFAULT -1
 
-#define EFA_DEF_MR_CACHE_ENABLE 0
+#define EFA_DEF_MR_CACHE_ENABLE 1
 #define EFA_DEF_MR_CACHE_MERGE_REGIONS 1
 
 int efa_mr_cache_enable		= EFA_DEF_MR_CACHE_ENABLE;

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -637,7 +637,7 @@ EFA_INI
 	fi_param_define(&rxr_prov, "cq_size", FI_PARAM_INT,
 			"Define the size of completion queue. (Default: 8192)");
 	fi_param_define(&rxr_prov, "mr_cache_enable", FI_PARAM_BOOL,
-			"Enables using the mr cache and in-line registration instead of a bounce buffer for iov's larger than max_memcpy_size. Defaults to false. When disabled, only uses a bounce buffer.");
+			"Enables using the mr cache and in-line registration instead of a bounce buffer for iov's larger than max_memcpy_size. Defaults to true. When disabled, only uses a bounce buffer.");
 	fi_param_define(&rxr_prov, "mr_cache_merge_regions", FI_PARAM_BOOL,
 			"Enables merging overlapping and adjacent memory registration regions. Defaults to true.");
 	fi_param_define(&rxr_prov, "mr_max_cached_count", FI_PARAM_SIZE_T,


### PR DESCRIPTION
This commit re-enables the MR cache in EFA. The thrashing is affecting
large-scale large-message alltoall patterns in synthetic benchmarks, but
we don't see this impacting real applications, which otherwise
benefit from the cache. The EFA device will also be increasing the
memory registration limits, which will mitigate this issue.

This reverts commit 8e7a674df51d5411d9ff5deffb23a671c925ff7a.