### PR TITLE
prov/efa: Provide explicit warning when rdma-core v27 is not available

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -49,7 +49,10 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 				[$efa_PREFIX],
 				[$efa_LIBDIR],
 				[efa_happy=1],
-				[efa_happy=0])
+				[
+					efa_happy=0
+					AC_MSG_WARN([The EFA provider requires rdma-core v27 or newer.])
+				])
 	      ])
 
 	AS_IF([test x"$enable_efa" != x"no"],


### PR DESCRIPTION
The current behavior does not make it obvious why configure failed when
the necessary direct verbs are not available, and needed digging in the
config.log. This commit it makes it explicit for users. The check itself
is fine as it is, given we are checking for the functionality needed and
not for a specific version.

Signed-off-by: Raghu Raja <craghun@amazon.com>