### PR TITLE
prov/rxm: Fix locking in rxm_ep_trecvmsg

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1844,9 +1844,9 @@ static ssize_t rxm_ep_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged
 
 	if (!(flags & (FI_CLAIM | FI_PEEK)) &&
 	    !(rxm_ep->rxm_info->mode & FI_BUFFERED_RECV)) {
-		return rxm_ep_post_trecv(rxm_ep, msg->msg_iov, msg->desc,
-					 msg->iov_count, msg->addr,
-					 msg->tag, msg->ignore, context, flags);
+		return rxm_ep_trecv_common(rxm_ep, msg->msg_iov, msg->desc,
+					   msg->iov_count, msg->addr,
+					   msg->tag, msg->ignore, context, flags);
 	}
 
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -580,6 +580,7 @@ struct fi_ibv_ep {
 struct vrb_context {
 	struct fi_ibv_ep		*ep;
 	void				*user_ctx;
+	uint64_t			flags;
 };
 
 

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -234,13 +234,22 @@ int vrb_poll_cq(struct fi_ibv_cq *cq, struct ibv_wc *wc)
 
 	do {
 		ret = ibv_poll_cq(cq->cq, 1, wc);
-		if (ret <= 0 || (wc->opcode & IBV_WC_RECV))
+		if (ret <= 0)
 			break;
 
 		ctx = (struct vrb_context *) (uintptr_t) wc->wr_id;
-		cq->credits++;
-		ctx->ep->tx_credits++;
 		wc->wr_id = (uintptr_t) ctx->user_ctx;
+		if (ctx->flags & FI_TRANSMIT) {
+			cq->credits++;
+			ctx->ep->tx_credits++;
+		}
+
+		if (wc->status) {
+			if (ctx->flags & FI_RECV)
+				wc->opcode |= IBV_WC_RECV;
+			else
+				wc->opcode &= ~IBV_WC_RECV;
+		}
 		ofi_buf_free(ctx);
 
 	} while (wc->wr_id == VERBS_NO_COMP_FLAG);
@@ -640,8 +649,7 @@ int fi_ibv_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 	}
 
 	ret = ofi_bufpool_create(&cq->ctx_pool, sizeof(struct fi_context),
-				 16, size, fi_ibv_gl_data.def_tx_size,
-				 OFI_BUFPOOL_NO_TRACK);
+				 16, size, 0, OFI_BUFPOOL_NO_TRACK);
 	if (ret)
 		goto err6;
 


### PR DESCRIPTION
rxm_ep_post_trecv requires that we hold the ep lock.  Replace call with
rxm_ep_trecv_common, which acquires the locks.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>