### PR TITLE
prov/util: Fix setting of mr_mode

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1089,6 +1089,10 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 				FI_MR_BASIC : FI_MR_SCALABLE;
 	} else {
 		if ((hints_mr_mode & attr->mr_mode) != attr->mr_mode) {
+			if (attr->mr_mode & FI_MR_BASIC) {
+				attr->mr_mode &= ~FI_MR_BASIC;
+				attr->mr_mode |= FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR;
+			}
 			attr->mr_mode = ofi_cap_mr_mode(info_caps,
 						attr->mr_mode & hints_mr_mode);
 		}


### PR DESCRIPTION
If the app passes FI_MR_VIRT_ADDR as hints, and provider
supports FI_MR_BASIC, then FI_MR_VIRT_ADDR will be removed
when calling function fi_alter_domain_attr. Therefore, the created
ofi_mr_map won't be able to support FI_MR_VIRT_ADDR.

Fix such issue by substituting FI_MR_BASIC with FI_MR_VIRT_ADDR,
FI_MR_ALLOCATED, and FI_MR_PROV_KEY.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>