### PR TITLE
mrcache: Set memhooks as the default caching mechanism

### DIFF
--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -692,6 +692,17 @@ configure registration caches.
   transfers (such as sending elements of an array to peer(s)), and the larger
   region is access infrequently.  By default merging regions is disabled.
 
+*FI_MR_CACHE_MONITOR*
+: The cache monitor is responsible for detecting changes made between the
+  virtual addresses used by an application and the underlying physical pages.
+  Valid monitor options are: userfaultfd, memhooks, and disabled.  Selecting
+  disabled will turn off the registration cache.  Userfaultfd is a Linux
+  kernel feature used to report virtual to physical address mapping changes
+  to user space.  Memhooks operates by intercepting relevant memory
+  allocation and deallocation calls which may result in the mappings changing,
+  such as malloc, mmap, free, etc.  Note that memhooks operates at the elf
+  linker layer, and does not use glibc memory hooks.
+
 # SEE ALSO
 
 [`fi_getinfo`(3)](fi_getinfo.3.html),

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -68,10 +68,10 @@ void ofi_monitor_init(void)
 	pthread_mutex_init(&memhooks_monitor->lock, NULL);
 	dlist_init(&memhooks_monitor->list);
 
-#if HAVE_UFFD_UNMAP
-        default_monitor = uffd_monitor;
-#elif defined(HAVE_ELF_H) && defined(HAVE_SYS_AUXV_H)
+#if defined(HAVE_ELF_H) && defined(HAVE_SYS_AUXV_H)
         default_monitor = memhooks_monitor;
+#elif HAVE_UFFD_UNMAP
+        default_monitor = uffd_monitor;
 #else
         default_monitor = NULL;
 #endif


### PR DESCRIPTION
There are reports of userfaultfd caching causing failures.  See
issue #5662.  Until those are resolved, set memhooks as the
default cache monitor.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>