### PR TITLE
core: Changed FI_INFO to FI_DBG  for core level

### DIFF
--- a/prov/mrail/src/mrail_init.c
+++ b/prov/mrail/src/mrail_init.c
@@ -112,8 +112,8 @@ static int mrail_parse_env_vars(void)
 	if (ret)
 		ret = fi_param_get_str(&mrail_prov, "addr_strc", &addr_strc);
 	if (ret) {
-		FI_INFO(&mrail_prov, FI_LOG_CORE, "unable to read "
-			"FI_OFI_MRAIL_ADDR env variable\n");
+		FI_DBG(&mrail_prov, FI_LOG_CORE, "unable to read "
+		       "FI_OFI_MRAIL_ADDR env variable\n");
 		return ret;
 	}
 	mrail_addr_strv = mrail_split_addr_strc(addr_strc);

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -705,7 +705,7 @@ struct fi_provider psmx_prov = {
 
 PROVIDER_INI
 {
-	FI_INFO(&psmx_prov, FI_LOG_CORE, "\n");
+	FI_DBG(&psmx_prov, FI_LOG_CORE, "\n");
 
 	fi_param_define(&psmx_prov, "name_server", FI_PARAM_BOOL,
 			"Whether to turn on the name server or not "

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -660,7 +660,7 @@ struct fi_provider psmx2_prov = {
 
 PROVIDER_INI
 {
-	FI_INFO(&psmx2_prov, FI_LOG_CORE, "build options: HAVE_PSM2_SRC=%d, "
+	FI_DBG(&psmx2_prov, FI_LOG_CORE, "build options: HAVE_PSM2_SRC=%d, "
 			"HAVE_PSM2_AM_REGISTER_HANDLERS_2=%d, "
 			"HAVE_PSM2_MQ_FP_MSG=%d, "
 			"PSMX2_USE_REQ_CONTEXT=%d\n", HAVE_PSM2_SRC,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -433,9 +433,9 @@ RXM_INI
 	fi_param_get_bool(&rxm_prov, "data_auto_progress", &force_auto_progress);
 
 	if (force_auto_progress)
-		FI_INFO(&rxm_prov, FI_LOG_CORE, "auto-progress for data requested "
-			"(FI_OFI_RXM_DATA_AUTO_PROGRESS = 1), domain threading "
-			"level would be set to FI_THREAD_SAFE\n");
+		FI_DBG(&rxm_prov, FI_LOG_CORE, "auto-progress for data requested "
+		       "(FI_OFI_RXM_DATA_AUTO_PROGRESS = 1), domain threading "
+		       "level would be set to FI_THREAD_SAFE\n");
 
 	if (rxm_init_info()) {
 		FI_WARN(&rxm_prov, FI_LOG_CORE, "Unable to initialize rxm_info\n");

--- a/src/var.c
+++ b/src/var.c
@@ -276,8 +276,8 @@ int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 
 	str_value = getenv(param->env_var_name);
 	if (!str_value) {
-		FI_INFO(provider, FI_LOG_CORE,
-			"variable %s=<not set>\n", param_name);
+		FI_DBG(provider, FI_LOG_CORE,
+		       "variable %s=<not set>\n", param_name);
 		ret = -FI_ENODATA;
 		goto out;
 	}
@@ -285,25 +285,25 @@ int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 	switch (param->type) {
 	case FI_PARAM_STRING:
 		* ((char **) value) = str_value;
-		FI_INFO(provider, FI_LOG_CORE,
-			"read string var %s=%s\n", param_name, *(char **) value);
+		FI_DBG(provider, FI_LOG_CORE,
+		       "read string var %s=%s\n", param_name, *(char **) value);
 		break;
 	case FI_PARAM_INT:
 		* ((int *) value) = strtol(str_value, NULL, 0);
-		FI_INFO(provider, FI_LOG_CORE,
-			"read int var %s=%d\n", param_name, *(int *) value);
+		FI_DBG(provider, FI_LOG_CORE,
+		       "read int var %s=%d\n", param_name, *(int *) value);
 		break;
 	case FI_PARAM_BOOL:
 		* ((int *) value) = fi_parse_bool(str_value);
-		FI_INFO(provider, FI_LOG_CORE,
-			"read bool var %s=%d\n", param_name, *(int *) value);
+		FI_DBG(provider, FI_LOG_CORE,
+		       "read bool var %s=%d\n", param_name, *(int *) value);
 		if (*(int *) value == -1)
 			ret = -FI_EINVAL;
 		break;
 	case FI_PARAM_SIZE_T:
 		* ((size_t *) value) = strtol(str_value, NULL, 0);
-		FI_INFO(provider, FI_LOG_CORE,
-			"read long var %s=%zu\n", param_name, *(size_t *) value);
+		FI_DBG(provider, FI_LOG_CORE,
+		       "read long var %s=%zu\n", param_name, *(size_t *) value);
 		break;
 	}
 


### PR DESCRIPTION
**What did:**

Implemented some corrections of setting 
`FI_LOG_SUBSYS=core FI_LOG_PROV=core FI_LOG_LEVEL=debug` for output under specific level

**Issue:**

_before:_
when an user sets `FI_LOG_SUBSYS=core FI_LOG_PROV=core FI_LOG_LEVEL=debug`, it outputted not only core level information, but also provided in information of specific provider, which is inappropriate	for the set level.

_Now:_
User can only see the output of a core level, and there is not any additional information from init providers.

**How:**

Changed level from FI_INFO to FI_DBG of fi_param_get function, which printed information of the current provider.
Changed level from FI_INFO to FI_DBG of providers in *_INI function, there is a main issue of the change:

When ofi_register_provider is called, although it is printing output on the core level, but as the first arg we give *_INIT in ofi_register_provider, where FI_INFO takes `struct fi_provide` of the current provider,	that's why we get extra output.