### PR TITLE
fabtest: Update test_info's mr_mode

### DIFF
--- a/fabtests/ubertest/uber.c
+++ b/fabtests/ubertest/uber.c
@@ -291,6 +291,7 @@ static void ft_fw_update_info(struct ft_info *test_info, struct fi_info *info)
 	if (info->domain_attr) {
 		test_info->progress = info->domain_attr->data_progress;
 		test_info->threading = info->domain_attr->threading;
+		test_info->mr_mode = info->domain_attr->mr_mode;
 	}
 
 	test_info->mode = info->mode;


### PR DESCRIPTION
Update test_info's mr_mode in ubertest with the one returned
from the provider.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>