### PR TITLE
fabtests/rdm_atomic: call ft_init_oob() from init_fabric()

### DIFF
--- a/fabtests/functional/rdm_atomic.c
+++ b/fabtests/functional/rdm_atomic.c
@@ -435,6 +435,10 @@ static int init_fabric(void)
 {
 	int ret;
 
+	ret  = ft_init_oob();
+	if (ret)
+		return ret;
+
 	ret = ft_getinfo(hints, &fi);
 	if (ret)
 		return ret;


### PR DESCRIPTION
This patch added a call of ft_init_oob() to rdm_atomic's init_fabric()
function to enable out of band address exchange for that test.

Signed-off-by: Wei Zhang <wzam@amazon.com>