### PR TITLE
prov/verbs: add environment variable to select specific verbs device by name

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -181,12 +181,17 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_CQREAD_BUNCH_SIZE*
 : The number of entries to be read from the verbs completion queue at a time (default: 8).
 
+*FI_VERBS_PREFER_XRC*
+: Prioritize XRC transport fi_info before RC transport fi_info (default: 0, RC fi_info will be before XRC fi_info)
+
+*FI_VERBS_GID_IDX*
+: The GID index to use (default: 0)
+
+### Variables specific to MSG endpoints
+
 *FI_VERBS_IFACE*
 : The prefix or the full name of the network interface associated with the verbs
   device (default: ib)
-
-*FI_VERBS_PREFER_XRC*
-: Prioritize XRC transport fi_info before RC transport fi_info (default: 0, RC fi_info will be before XRC fi_info)
 
 ### Variables specific to DGRAM endpoints
 
@@ -197,9 +202,6 @@ The verbs provider checks for the following environment variables.
 
 *FI_VERBS_NAME_SERVER_PORT*
 : The port on which Name Server thread listens incoming connections and requests (default: 5678)
-
-*FI_VERBS_GID_IDX*
-: The GID index to use (default: 0)
 
 ### Environment variables notes
 The fi_info utility would give the up-to-date information on environment variables:

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -187,6 +187,9 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_GID_IDX*
 : The GID index to use (default: 0)
 
+*FI_VERBS_DEVICE_NAME*
+: Specify a specific verbs device to use by name
+
 ### Variables specific to MSG endpoints
 
 *FI_VERBS_IFACE*

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -595,6 +595,17 @@ static int vrb_read_params(void)
 			   "Invalid value of cqread_bunch_size\n");
 		return -FI_EINVAL;
 	}
+	if (vrb_get_param_int("gid_idx", "Set which gid index to use "
+				 "attribute (0 - 255)",
+				 &vrb_gl_data.gid_idx) ||
+	    (vrb_gl_data.gid_idx < 0 ||
+	     vrb_gl_data.gid_idx > 255)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid value of gid index\n");
+		return -FI_EINVAL;
+	}
+
+	/* MSG-specific parameter */
 	if (vrb_get_param_str("iface", "The prefix or the full name of the "
 				 "network interface associated with the verbs device",
 				 &vrb_gl_data.iface)) {
@@ -622,15 +633,6 @@ static int vrb_read_params(void)
 	     vrb_gl_data.dgram.name_server_port > 65535)) {
 		VERBS_WARN(FI_LOG_CORE,
 			   "Invalid value of dgram_name_server_port\n");
-		return -FI_EINVAL;
-	}
-	if (vrb_get_param_int("gid_idx", "Set which gid index to use "
-				 "attribute (0 - 255)",
-				 &vrb_gl_data.gid_idx) ||
-	    (vrb_gl_data.gid_idx < 0 ||
-	     vrb_gl_data.gid_idx > 255)) {
-		VERBS_WARN(FI_LOG_CORE,
-			   "Invalid value of gid index\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -605,6 +605,14 @@ static int vrb_read_params(void)
 		return -FI_EINVAL;
 	}
 
+	if (vrb_get_param_str("device_name", "The prefix or the full name of the "
+			      "verbs device to use",
+			      &vrb_gl_data.device_name)) {
+		VERBS_WARN(FI_LOG_CORE,
+			   "Invalid value of device_name\n");
+		return -FI_EINVAL;
+	}
+
 	/* MSG-specific parameter */
 	if (vrb_get_param_str("iface", "The prefix or the full name of the "
 				 "network interface associated with the verbs device",

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -150,6 +150,7 @@ extern struct vrb_gl_data {
 	int	use_odp;
 	char	*iface;
 	int	gid_idx;
+	char	*device_name;
 
 	struct {
 		int	buffer_num;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1299,6 +1299,11 @@ int vrb_init_info(const struct fi_info **all_infos)
 					ctx_list[i]->device->name);
 				continue;
 			}
+			if (vrb_gl_data.device_name &&
+			    strncasecmp(ctx_list[i]->device->name,
+					vrb_gl_data.device_name,
+					strlen(vrb_gl_data.device_name)))
+				continue;
 
 			ret = vrb_alloc_info(ctx_list[i], &fi, ep_type[j]);
 			if (!ret) {


### PR DESCRIPTION
This also reorganizes the definitions of parameters both in the code and the man pages to clarify which parameters are for both msg and dgram eps or only one.