### PR TITLE
prov/efa: refactor rxr_pkt_handle_send_completion()

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -839,6 +839,9 @@ void rxr_cq_handle_rx_completion(struct rxr_ep *ep,
 void rxr_cq_write_tx_completion(struct rxr_ep *ep,
 				struct rxr_tx_entry *tx_entry);
 
+void rxr_cq_handle_tx_completion(struct rxr_ep *ep,
+				 struct rxr_tx_entry *tx_entry);
+
 int rxr_cq_reorder_msg(struct rxr_ep *ep,
 		       struct rxr_peer *peer,
 		       struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -130,6 +130,9 @@ ssize_t rxr_pkt_proc_matched_msg_rts(struct rxr_ep *ep,
 				     struct rxr_rx_entry *rx_entry,
 				     struct rxr_pkt_entry *pkt_entry);
 
+void rxr_pkt_handle_rts_send_completion(struct rxr_ep *ep,
+					struct rxr_pkt_entry *pkt_entry);
+
 ssize_t rxr_pkt_post_shm_rndzv_read(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry);
 
 ssize_t rxr_pkt_proc_rts(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
@@ -259,6 +262,10 @@ int rxr_pkt_proc_data(struct rxr_ep *ep,
 		      char *data, size_t seg_offset,
 		      size_t seg_size);
 
+void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
+					 struct rxr_pkt_entry *pkt_entry);
+
+
 void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);
 
@@ -299,6 +306,9 @@ int rxr_pkt_init_readrsp(struct rxr_ep *ep,
 
 void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_readrsp_send_completion(struct rxr_ep *ep,
+					    struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_readrsp_recv(struct rxr_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -213,6 +213,18 @@ ssize_t rxr_pkt_send_data_mr_cache(struct rxr_ep *ep,
 	return ret;
 }
 
+void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
+					 struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_tx_entry *tx_entry;
+
+	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	tx_entry->bytes_acked +=
+		rxr_get_data_pkt(pkt_entry->pkt)->hdr.seg_size;
+	if (tx_entry->total_len == tx_entry->bytes_acked)
+		rxr_cq_handle_tx_completion(ep, tx_entry);
+}
+
 /*
  *  rxr_pkt_handle_data_recv() and related functions
  */

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -278,6 +278,22 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 	}
 }
 
+void rxr_pkt_handle_readrsp_send_completion(struct rxr_ep *ep,
+					    struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_tx_entry *tx_entry;
+	struct rxr_readrsp_hdr *readrsp_hdr;
+
+	readrsp_hdr = (struct rxr_readrsp_hdr *)pkt_entry->pkt;
+
+	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
+	assert(tx_entry->cq_entry.flags & FI_READ);
+
+	tx_entry->bytes_acked += readrsp_hdr->seg_size;
+	if (tx_entry->total_len == tx_entry->bytes_acked)
+		rxr_cq_handle_tx_completion(ep, tx_entry);
+}
+
 void rxr_pkt_handle_readrsp_recv(struct rxr_ep *ep,
 				 struct rxr_pkt_entry *pkt_entry)
 {


### PR DESCRIPTION
This patch refactor the function rxr_pkt_handle_send_completion:

1. Extract the section handle tx_entry into a separate function
        rxr_cq_handle_tx_completion().

2. Extract the handling of RTS, DATA and READRSP packet into 3
   separate functions:
        rxr_pkt_handle_rts_send_completion(),
        rxr_pkt_handle_data_send_completion() and
        rxr_pkt_handle_readrsp_send_completion().

   All these functions call rxr_cq_handle_tx_completion().

Signed-off-by: Wei Zhang <wzam@amazon.com>