### PR TITLE
Add mmap-based fallback solution if CMA is not available

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -72,6 +72,7 @@ enum {
 	smr_src_inline,	/* command data */
 	smr_src_inject,	/* inject buffers */
 	smr_src_iov,	/* reference iovec via CMA */
+	smr_src_mmap,	/* mmap-based fallback protocol */
 };
 
 #define SMR_REMOTE_CQ_DATA	(1 << 0)

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -80,6 +80,13 @@ enum {
 #define SMR_RX_COMPLETION	(1 << 3)
 #define SMR_MULTI_RECV		(1 << 4)
 
+/* CMA capability */
+enum {
+	SMR_CMA_CAP_NA,
+	SMR_CMA_CAP_ON,
+	SMR_CMA_CAP_OFF,
+};
+
 /* 
  * Unique smr_op_hdr for smr message protocol:
  * 	addr - local fi_addr of peer sending msg (for shm lookup)
@@ -181,6 +188,8 @@ struct smr_region {
 	uint8_t		resv;
 	uint16_t	flags;
 	int		pid;
+	uint8_t		cma_cap;
+	void		*base_addr;
 	fastlock_t	lock; /* lock for shm access
 				 Must hold smr->lock before tx/rx cq locks
 				 in order to progress or post recv */
@@ -257,6 +266,7 @@ struct smr_attr {
 	size_t		tx_count;
 };
 
+void	smr_cma_check(struct smr_region *region, struct smr_region *peer_region);
 void	smr_cleanup(void);
 int	smr_map_create(const struct fi_provider *prov, int peer_count,
 		       struct smr_map **map);

--- a/man/fi_shm.7.md
+++ b/man/fi_shm.7.md
@@ -107,16 +107,6 @@ EPs must be bound to both RX and TX CQs.
 
 No support for counters.
 
-# RUNTIME PARAMETERS
-*FI_SHM_DISABLE_CMA*
-: Force disable use of CMA (Cross Memory Attach) in shm environment. CMA is a
-  Linux feature for copying data directly between two processes without the use
-  of intermediate buffering. This requires the processes to have full access to
-  the peer's address space (the same permissions required to perform a ptrace).
-  CMA is enabled by default but checked for availability during run-time.
-  For more information see the CMA [`man pages`]
-  (https://linux.die.net/man/2/process_vm_writev)
-
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -38,6 +38,23 @@
 #include "rxr_atomic.h"
 #include "rxr_pkt_cmd.h"
 
+static void rxr_atomic_copy_shm_msg(struct fi_msg_atomic *shm_msg,
+				    const struct fi_msg_atomic *msg,
+				    struct fi_rma_ioc *rma_iov)
+{
+	int i;
+
+	assert(msg->rma_iov_count <= RXR_IOV_LIMIT);
+	memcpy(shm_msg, msg, sizeof(*msg));
+	if (!(shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)) {
+		memcpy(rma_iov, msg->rma_iov,
+		       sizeof(*msg->rma_iov) * msg->rma_iov_count);
+		for (i = 0; i < msg->rma_iov_count; i++)
+			rma_iov[i].addr = 0;
+		shm_msg->rma_iov = rma_iov;
+	}
+}
+
 static
 struct rxr_tx_entry *
 rxr_atomic_alloc_tx_entry(struct rxr_ep *rxr_ep,
@@ -153,9 +170,12 @@ rxr_atomic_inject(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, dest_addr);
-	if (rxr_env.enable_shm_transfer && peer->is_local)
+	if (rxr_env.enable_shm_transfer && peer->is_local) {
+		if (!(shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR))
+			remote_addr = 0;
 		return fi_inject_atomic(rxr_ep->shm_ep, buf, count, peer->shm_fiaddr,
 					remote_addr, remote_key, datatype, op);
+	}
 
 	iov.addr = (void *)buf;
 	iov.count = count;
@@ -187,6 +207,7 @@ rxr_atomic_writemsg(struct fid_ep *ep,
 	struct fi_msg_atomic shm_msg;
 	struct rxr_ep *rxr_ep;
 	struct rxr_peer *peer;
+	struct fi_rma_ioc rma_iov[RXR_IOV_LIMIT];
 
 	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
 	       "%s: iov_len: %lu flags: %lx\n",
@@ -195,7 +216,7 @@ rxr_atomic_writemsg(struct fid_ep *ep,
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	if (rxr_env.enable_shm_transfer && peer->is_local) {
-		memcpy(&shm_msg, msg, sizeof(struct fi_msg_atomic));
+		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_atomicmsg(rxr_ep->shm_ep, &shm_msg, flags);
 	}
@@ -257,6 +278,7 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 	struct rxr_ep *rxr_ep;
 	struct rxr_peer *peer;
 	struct fi_msg_atomic shm_msg;
+	struct fi_rma_ioc rma_iov[RXR_IOV_LIMIT];
 	struct rxr_atomic_ex atomic_ex;
 	size_t datatype_size = ofi_datatype_size(msg->datatype);
 
@@ -266,7 +288,7 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	if (rxr_env.enable_shm_transfer && peer->is_local) {
-		memcpy(&shm_msg, msg, sizeof(struct fi_msg_atomic));
+		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_fetch_atomicmsg(rxr_ep->shm_ep, &shm_msg,
 					  resultv, result_desc, result_count,
@@ -336,6 +358,7 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 	struct rxr_ep *rxr_ep;
 	struct rxr_peer *peer;
 	struct fi_msg_atomic shm_msg;
+	struct fi_rma_ioc rma_iov[RXR_IOV_LIMIT];
 	struct rxr_atomic_ex atomic_ex;
 	size_t datatype_size = ofi_datatype_size(msg->datatype);
 
@@ -346,7 +369,7 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 	if (rxr_env.enable_shm_transfer && peer->is_local) {
-		memcpy(&shm_msg, msg, sizeof(struct fi_msg_atomic));
+		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_compare_atomicmsg(rxr_ep->shm_ep, &shm_msg,
 					    comparev, compare_desc, compare_count,

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -149,7 +149,7 @@ int rxr_ep_efa_addr_to_str(const void *addr, char *smr_name)
 	}
 	qpn = ((struct efa_ep_addr *)addr)->qpn;
 
-	ret = snprintf(smr_name, NAME_MAX, "/%ld_%s_%d", (size_t) getuid(), gid, qpn);
+	ret = snprintf(smr_name, NAME_MAX, "%ld_%s_%d", (size_t) getuid(), gid, qpn);
 
 	return (ret <= 0) ? ret : FI_SUCCESS;
 }

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -596,11 +596,10 @@ static void rxr_check_cma_capability(void)
 		// parent waits child to exit, and check flag bit
 		wait(NULL);
 		if (flag == 0) {
-			fprintf(stderr, "SHM transfer will be disabled because of ptrace protection.\n"
-				"To enable SHM transfer, please refer to the man page fi_efa.7 for more information.\n"
-				"Also note that turning off ptrace protection has security implications. If you cannot\n"
-				"turn it off, you can suppress this message by setting FI_EFA_ENABLE_SHM_TRANSFER=0\n");
-			rxr_env.enable_shm_transfer = 0;
+			fprintf(stderr, "shm transfer will fallback to mmap-based solution as CMA\n"
+				"is not available, which could lead to performance degradation.\n"
+				"To enable CMA-based shm transfer, you can turn off ptrace protection.\n"
+				"Please note that turning off ptrace protection has security implications.\n");
 		}
 	}
 }

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -498,25 +498,20 @@ void rxr_pkt_handle_eor_recv(struct rxr_ep *ep,
 {
 	struct rxr_eor_hdr *shm_eor;
 	struct rxr_tx_entry *tx_entry;
-	struct rxr_peer *peer;
 	ssize_t err;
 
 	shm_eor = (struct rxr_eor_hdr *)pkt_entry->pkt;
 
 	/* pre-post buf used here, so can NOT track back to tx_entry with x_entry */
-	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
-	assert(peer);
+	tx_entry = ofi_bufpool_get_ibuf(ep->tx_entry_pool, eor_hdr->tx_id);
 
-	tx_entry = ofi_bufpool_get_ibuf(ep->tx_entry_pool, shm_eor->tx_id);
-	if (!peer->is_local) {
-		err = rxr_tx_entry_mr_dereg(tx_entry);
-		if (OFI_UNLIKELY(err)) {
-			if (rxr_cq_handle_tx_error(ep, tx_entry, err))
-				assert(0 && "failed to write err cq entry");
-			rxr_release_tx_entry(ep, tx_entry);
-			rxr_pkt_entry_release_rx(ep, pkt_entry);
-			return;
-		}
+	err = rxr_tx_entry_mr_dereg(tx_entry);
+	if (OFI_UNLIKELY(err)) {
+		if (rxr_cq_handle_tx_error(ep, tx_entry, err))
+			assert(0 && "failed to write err cq entry");
+		rxr_release_tx_entry(ep, tx_entry);
+		rxr_pkt_entry_release_rx(ep, pkt_entry);
+		return;
 	}
 
 	rxr_cq_write_tx_completion(ep, tx_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -496,11 +496,11 @@ void rxr_pkt_handle_eor_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_eor_recv(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry)
 {
-	struct rxr_eor_hdr *shm_eor;
+	struct rxr_eor_hdr *eor_hdr;
 	struct rxr_tx_entry *tx_entry;
 	ssize_t err;
 
-	shm_eor = (struct rxr_eor_hdr *)pkt_entry->pkt;
+	eor_hdr = (struct rxr_eor_hdr *)pkt_entry->pkt;
 
 	/* pre-post buf used here, so can NOT track back to tx_entry with x_entry */
 	tx_entry = ofi_bufpool_get_ibuf(ep->tx_entry_pool, eor_hdr->tx_id);

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -156,6 +156,11 @@ struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, int entry_type, v
 	} else {
 		assert(lower_ep_type == SHM_EP);
 		memset(read_entry->mr, 0, read_entry->iov_count * sizeof(struct fid_mr *));
+		/* FI_MR_VIRT_ADDR is not being set, use 0-based offset instead. */
+		if (!(shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)) {
+			for (i = 0; i < read_entry->rma_iov_count; ++i)
+				read_entry->rma_iov[i].addr = 0;
+		}
 	}
 
 	read_entry->lower_ep_type = lower_ep_type;

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -227,21 +227,15 @@ int rxr_read_init_iov(struct rxr_ep *ep,
 {
 	int i, err;
 	struct fid_mr *mr;
-	struct rxr_peer *peer;
 
-	peer = rxr_ep_get_peer(ep, tx_entry->addr);
-	if (peer->is_local) {
-		for (i = 0; i < tx_entry->iov_count; ++i) {
-			assert(!tx_entry->mr[i]);
-			read_iov[i].addr = (uint64_t)tx_entry->iov[i].iov_base;
-			read_iov[i].len = tx_entry->iov[i].iov_len;
-			read_iov[i].key = 0;
-		}
-	} else if (tx_entry->desc[0]) {
+	for (i = 0; i < tx_entry->iov_count; ++i) {
+		read_iov[i].addr = (uint64_t)tx_entry->iov[i].iov_base;
+		read_iov[i].len = tx_entry->iov[i].iov_len;
+	}
+
+	if (tx_entry->desc[0]) {
 		for (i = 0; i < tx_entry->iov_count; ++i) {
 			mr = (struct fid_mr *)tx_entry->desc[i];
-			read_iov[i].addr = (uint64_t)tx_entry->iov[i].iov_base;
-			read_iov[i].len = tx_entry->iov[i].iov_len;
 			read_iov[i].key = fi_mr_key(mr);
 		}
 	} else {
@@ -264,8 +258,6 @@ int rxr_read_init_iov(struct rxr_ep *ep,
 
 		for (i = 0; i < tx_entry->iov_count; ++i) {
 			assert(tx_entry->mr[i]);
-			read_iov[i].addr = (uint64_t)tx_entry->iov[i].iov_base;
-			read_iov[i].len = tx_entry->iov[i].iov_len;
 			read_iov[i].key = fi_mr_key(tx_entry->mr[i]);
 		}
 	}

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -159,6 +159,7 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	struct rxr_pkt_entry *pkt_entry;
 	struct fi_msg_rma msg;
 	struct rxr_peer *peer;
+	int i;
 
 	assert(tx_entry->op == ofi_op_write);
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
@@ -168,6 +169,11 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 
 	rxr_pkt_init_write_context(tx_entry, pkt_entry);
 
+	/* If no FI_MR_VIRT_ADDR being set, have to use 0-based offset */
+	if (!(shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR)) {
+		for (i = 0; i < tx_entry->iov_count; i++)
+			tx_entry->rma_iov[i].addr = 0;
+	}
 	msg.msg_iov = tx_entry->iov;
 	msg.iov_count = tx_entry->iov_count;
 	msg.addr = peer->shm_fiaddr;

--- a/prov/efa/src/rxr/rxr_rma.h
+++ b/prov/efa/src/rxr/rxr_rma.h
@@ -47,9 +47,6 @@ struct rxr_tx_entry *
 rxr_rma_alloc_readrsp_tx_entry(struct rxr_ep *rxr_ep,
 			       struct rxr_rx_entry *rx_entry);
 
-size_t rxr_rma_post_shm_rma(struct rxr_ep *rxr_ep,
-			    struct rxr_tx_entry *tx_entry);
-
 extern struct fi_ops_rma rxr_ops_rma;
 
 #endif

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -116,6 +116,7 @@ struct smr_tx_entry {
 	void		*context;
 	struct iovec	iov[SMR_IOV_LIMIT];
 	uint32_t	iov_count;
+	struct smr_ep_name *map_name;
 };
 
 struct smr_ep;
@@ -194,6 +195,7 @@ struct smr_ep {
 	size_t			rx_size;
 	size_t			min_multi_recv_size;
 	const char		*name;
+	uint64_t		msg_id;
 	struct smr_region	*region;
 	struct smr_recv_fs	*recv_fs; /* protected by rx_cq lock */
 	struct smr_queue	recv_queue;
@@ -206,6 +208,13 @@ struct smr_ep {
 
 #define smr_ep_rx_flags(smr_ep) ((smr_ep)->util_ep.rx_op_flags)
 #define smr_ep_tx_flags(smr_ep) ((smr_ep)->util_ep.tx_op_flags)
+
+static inline int smr_mmap_name(char *shm_name, const char *ep_name,
+				uint64_t msg_id)
+{
+	return snprintf(shm_name, NAME_MAX - 1, "%s_%ld",
+			ep_name, msg_id);
+}
 
 int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 		  struct fid_ep **ep, void *context);
@@ -231,6 +240,9 @@ void smr_format_inject(struct smr_cmd *cmd, const struct iovec *iov,
 void smr_format_iov(struct smr_cmd *cmd, const struct iovec *iov, size_t count,
 		    size_t total_len, struct smr_region *smr,
 		    struct smr_resp *resp);
+int smr_format_mmap(struct smr_ep *ep, struct smr_cmd *cmd,
+		    const struct iovec *iov, size_t count, size_t total_len,
+		    struct smr_tx_entry *pend, struct smr_resp *resp);
 
 int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, uint64_t err);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -116,6 +116,7 @@ struct smr_tx_entry {
 	void		*context;
 	struct iovec	iov[SMR_IOV_LIMIT];
 	uint32_t	iov_count;
+	void		*map_ptr;
 	struct smr_ep_name *map_name;
 };
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -67,11 +67,7 @@
 #define SMR_MAJOR_VERSION 1
 #define SMR_MINOR_VERSION 1
 
-struct smr_env {
-	int disable_cma;
-};
 
-extern struct smr_env smr_env;
 extern struct fi_provider smr_prov;
 extern struct fi_info smr_info;
 extern struct util_prov smr_util_prov;
@@ -184,8 +180,7 @@ static inline const char *smr_no_prefix(const char *addr)
 #define SMR_RMA_ORDER (OFI_ORDER_RAR_SET | OFI_ORDER_RAW_SET | FI_ORDER_RAS |	\
 		       OFI_ORDER_WAR_SET | OFI_ORDER_WAW_SET | FI_ORDER_WAS |	\
 		       FI_ORDER_SAR | FI_ORDER_SAW)
-#define smr_fast_rma_enabled(mode, order) (!smr_env.disable_cma && \
-			(mode & FI_MR_VIRT_ADDR) && \
+#define smr_fast_rma_enabled(mode, order) ((mode & FI_MR_VIRT_ADDR) && \
 			!(order & SMR_RMA_ORDER))
 
 #define smr_get_offset(base, addr) ((uintptr_t) ((char *) addr - (char *) base))

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -188,6 +188,9 @@ static inline const char *smr_no_prefix(const char *addr)
 			(mode & FI_MR_VIRT_ADDR) && \
 			!(order & SMR_RMA_ORDER))
 
+#define smr_get_offset(base, addr) ((uintptr_t) ((char *) addr - (char *) base))
+#define smr_get_addr(base, offset) ((char *) base + (uintptr_t) offset)
+
 struct smr_ep {
 	struct util_ep		util_ep;
 	smr_rx_comp_func	rx_comp;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -91,7 +91,7 @@ static void smr_format_inject_atomic(struct smr_cmd *cmd,
 	size_t comp_size;
 
 	cmd->msg.hdr.op_src = smr_src_inject;
-	cmd->msg.hdr.src_data = (char **) tx_buf - (char **) smr;
+	cmd->msg.hdr.src_data = smr_get_offset(smr, tx_buf);
 
 	switch (cmd->msg.hdr.op) {
 	case ofi_op_atomic:
@@ -214,8 +214,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 			pend = freestack_pop(ep->pend_fs);
 			smr_format_pend_resp(pend, cmd, context, result_iov,
 					     result_count, id, resp);
-			cmd->msg.hdr.data = (uintptr_t) ((char **) resp -
-						(char **) ep->region);
+			cmd->msg.hdr.data = smr_get_offset(ep->region, resp);
 			ofi_cirque_commit(smr_resp_queue(ep->region));
 		}
 	} else {

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -283,7 +283,7 @@ void smr_format_inject(struct smr_cmd *cmd, const struct iovec *iov,
 		       struct smr_inject_buf *tx_buf)
 {
 	cmd->msg.hdr.op_src = smr_src_inject;
-	cmd->msg.hdr.src_data = (char **) tx_buf - (char **) smr;
+	cmd->msg.hdr.src_data = smr_get_offset(smr, tx_buf);
 	cmd->msg.hdr.size = ofi_copy_from_iov(tx_buf->data, SMR_INJECT_SIZE,
 					      iov, count, 0);
 }
@@ -293,7 +293,7 @@ void smr_format_iov(struct smr_cmd *cmd, const struct iovec *iov, size_t count,
 		    struct smr_resp *resp)
 {
 	cmd->msg.hdr.op_src = smr_src_iov;
-	cmd->msg.hdr.src_data = (uintptr_t) ((char **) resp - (char **) smr);
+	cmd->msg.hdr.src_data = smr_get_offset(smr, resp);
 	cmd->msg.data.iov_count = count;
 	cmd->msg.hdr.size = total_len;
 	memcpy(cmd->msg.data.iov, iov, sizeof(*iov) * count);
@@ -357,7 +357,7 @@ int smr_format_mmap(struct smr_ep *ep, struct smr_cmd *cmd,
 
 	cmd->msg.hdr.op_src = smr_src_mmap;
 	cmd->msg.hdr.msg_id = msg_id;
-	cmd->msg.hdr.src_data = (uintptr_t) ((char *) resp - (char *) ep->region);
+	cmd->msg.hdr.src_data = smr_get_offset(ep->region, resp);
 	cmd->msg.hdr.size = total_len;
 	pend->map_name = map_name;
 

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -146,8 +146,6 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 			cur->ep_attr->max_order_waw_size = 0;
 			cur->ep_attr->max_order_war_size = 0;
 		}
-		if (smr_env.disable_cma)
-			cur->ep_attr->max_msg_size = SMR_INJECT_SIZE;
 	}
 	return 0;
 }

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -73,8 +73,8 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_tx_entry *pendi
 		goto out;
 	case smr_src_inject:
 		inj_offset = (size_t) pending->cmd.msg.hdr.src_data;
-		tx_buf = (struct smr_inject_buf *) ((char **) peer_smr +
-						    inj_offset);
+		tx_buf = (struct smr_inject_buf *) smr_get_addr(peer_smr, inj_offset);
+
 		if (*ret)
 			goto push;
 
@@ -156,8 +156,8 @@ static int smr_progress_inject(struct smr_cmd *cmd, struct iovec *iov,
 	size_t inj_offset;
 
 	inj_offset = (size_t) cmd->msg.hdr.src_data;
-	tx_buf = (struct smr_inject_buf *) ((char **) ep->region +
-					    inj_offset);
+	tx_buf = (struct smr_inject_buf *) smr_get_addr(ep->region, inj_offset);
+
 	if (err) {
 		smr_freestack_push(smr_inject_pool(ep->region), tx_buf);
 		return err;
@@ -191,8 +191,7 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct iovec *iov,
 
 	peer_id = (int) cmd->msg.hdr.addr;
 	peer_smr = smr_peer_region(ep->region, peer_id);
-	resp = (struct smr_resp *) ((char **) peer_smr +
-				    (size_t) cmd->msg.hdr.src_data);
+	resp = (struct smr_resp *) smr_get_addr(peer_smr, cmd->msg.hdr.src_data);
 
 	if (err) {
 		ret = -err;
@@ -301,8 +300,7 @@ static int smr_progress_mmap(struct smr_cmd *cmd, struct iovec *iov,
 
 	peer_id = (int) cmd->msg.hdr.addr;
 	peer_smr = smr_peer_region(ep->region, peer_id);
-	resp = (struct smr_resp *) ((char *) peer_smr +
-				    (uintptr_t) cmd->msg.hdr.src_data);
+	resp = (struct smr_resp *) smr_get_addr(peer_smr, cmd->msg.hdr.src_data);
 
 	ret = smr_mmap_peer_copy(ep, cmd, iov, iov_count, total_len);
 
@@ -391,8 +389,7 @@ static int smr_progress_inject_atomic(struct smr_cmd *cmd, struct fi_ioc *ioc,
 	int i;
 
 	inj_offset = (size_t) cmd->msg.hdr.src_data;
-	tx_buf = (struct smr_inject_buf *) ((char **) ep->region +
-					    inj_offset);
+	tx_buf = (struct smr_inject_buf *) smr_get_addr(ep->region, inj_offset);
 	if (err)
 		goto out;
 
@@ -593,8 +590,7 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 
 	if (cmd->msg.hdr.op == ofi_op_read_req && cmd->msg.hdr.data) {
 		peer_smr = smr_peer_region(ep->region, cmd->msg.hdr.addr);
-		resp = (struct smr_resp *) ((char **) peer_smr +
-			    (size_t) cmd->msg.hdr.data);
+		resp = (struct smr_resp *) smr_get_addr(peer_smr, cmd->msg.hdr.data);
 		resp->status = -err;
 	} else {
 		ep->region->cmd_cnt++;
@@ -664,8 +660,7 @@ static int smr_progress_cmd_atomic(struct smr_ep *ep, struct smr_cmd *cmd)
 	}
 	if (cmd->msg.hdr.data) {
 		peer_smr = smr_peer_region(ep->region, cmd->msg.hdr.addr);
-		resp = (struct smr_resp *) ((char **) peer_smr +
-			    (size_t) cmd->msg.hdr.data);
+		resp = (struct smr_resp *) smr_get_addr(peer_smr, cmd->msg.hdr.data);
 		resp->status = -err;
 	} else {
 		ep->region->cmd_cnt++;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -168,7 +168,8 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		smr_format_pend_resp(pend, cmd, context, iov, iov_count, id, resp);
 		ofi_cirque_commit(smr_resp_queue(ep->region));
 		comp = 0;
-	} else if (total_len > SMR_MSG_DATA_LEN || smr_env.disable_cma) {
+	} else if (total_len > SMR_MSG_DATA_LEN ||
+		   (smr_env.disable_cma && op == ofi_op_read_req)) {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
 		smr_format_inject(cmd, iov, iov_count, peer_smr, tx_buf);
 		if (op == ofi_op_read_req) {

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -128,7 +128,8 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 
 	cmds = 1 + !(domain->fast_rma && !(op_flags &
 		    (FI_REMOTE_CQ_DATA | FI_DELIVERY_COMPLETE)) &&
-		     rma_count == 1);
+		     rma_count == 1 &&
+		     ep->region->cma_cap == SMR_CMA_CAP_ON);
 
 	peer_smr = smr_peer_region(ep->region, id);
 	fastlock_acquire(&peer_smr->lock);
@@ -156,20 +157,33 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	total_len = ofi_total_iov_len(iov, iov_count);
 
 	smr_generic_format(cmd, peer_id, op, 0, data, op_flags);
-	if (!smr_env.disable_cma && (total_len > SMR_INJECT_SIZE ||
-	    op != ofi_op_write || op_flags & FI_DELIVERY_COMPLETE)) {
+	if (total_len > SMR_INJECT_SIZE || (!smr_env.disable_cma &&
+	    (op != ofi_op_write || op_flags & FI_DELIVERY_COMPLETE))) {
 		if (ofi_cirque_isfull(smr_resp_queue(ep->region))) {
 			ret = -FI_EAGAIN;
 			goto unlock_cq;
 		}
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 		pend = freestack_pop(ep->pend_fs);
-		smr_format_iov(cmd, iov, iov_count, total_len, ep->region, resp);
+		if (ep->region->cma_cap == SMR_CMA_CAP_ON) {
+			smr_format_iov(cmd, iov, iov_count, total_len, ep->region, resp);
+		} else {
+			/*
+			 * TODO: Add a threshold for switching from SAR to mmap
+			 * once SAR protocol gets merged
+			 */
+			ret = smr_format_mmap(ep, cmd, iov, iov_count, total_len,
+					      pend, resp);
+			if (ret) {
+				freestack_push(ep->pend_fs, pend);
+				ret = -FI_EAGAIN;
+				goto unlock_cq;
+			}
+		}
 		smr_format_pend_resp(pend, cmd, context, iov, iov_count, id, resp);
 		ofi_cirque_commit(smr_resp_queue(ep->region));
 		comp = 0;
-	} else if (total_len > SMR_MSG_DATA_LEN ||
-		   (smr_env.disable_cma && op == ofi_op_read_req)) {
+	} else if (total_len > SMR_MSG_DATA_LEN || op == ofi_op_read_req) {
 		tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
 		smr_format_inject(cmd, iov, iov_count, peer_smr, tx_buf);
 		if (op == ofi_op_read_req) {
@@ -348,7 +362,8 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	if (ret)
 		return ret;
 
-	cmds = 1 + !(domain->fast_rma && !(flags & FI_REMOTE_CQ_DATA));
+	cmds = 1 + !(domain->fast_rma && !(flags & FI_REMOTE_CQ_DATA) &&
+		     ep->region->cma_cap == SMR_CMA_CAP_ON);
 
 	peer_smr = smr_peer_region(ep->region, id);
 	fastlock_acquire(&peer_smr->lock);


### PR DESCRIPTION
This series of commit includes two parts
1. Added mmap-based fallback solution in shm provider if CMA is not available
2. Made corresponding change in efa provider

Note:
1. This work can be rebased onto PR #5664, once it's merged. 
2. Open this PR first for community review.
3. The fabtests for shm provider (especially fi_ubertest) takes longer time. We might need to increase the timeout value (`-N 1200` works fine on my end).