### PR TITLE
tcp provider: Early remove ep from polling after shutdown

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -208,6 +208,9 @@ struct tcpx_ep {
 	struct stage_buf	stage_buf;
 	size_t			min_multi_recv_size;
 	bool			epoll_out_set;
+
+	/* optimization to reduce poll delete calls */
+	bool			poll_released;
 };
 
 struct tcpx_fabric {
@@ -288,6 +291,8 @@ int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf);
 
 struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq,
 					      enum tcpx_xfer_op_codes type);
+
+void tcpx_ep_wait_fd_del(struct tcpx_ep *ep);
 void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
 			     struct tcpx_xfer_entry *xfer_entry);
 void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -641,6 +641,18 @@ void tcpx_progress_tx(struct tcpx_ep *ep)
 		tx_entry = container_of(entry, struct tcpx_xfer_entry, entry);
 		process_tx_entry(tx_entry);
 	}
+	bool is_shutdown = false;
+
+	if (ep->cm_state == TCPX_EP_SHUTDOWN && !ep->poll_released)
+		is_shutdown = true; /* let it progress once more */
+
+
+	if (is_shutdown)
+	{
+		tcpx_ep_wait_fd_del(ep);
+		ep->poll_released = true; /* just an optimization */
+	}
+
 }
 
 int tcpx_try_func(void *util_ep)


### PR DESCRIPTION
I noticed that the polling thread in our applicatioon
is spinning for some time after calling fi_shutdown().
Reason is that we only call fi_close() after all references
to our internal connection handling are dropped and that
can be much later than the call of fi_close() and the
FI_SHUTDOWN event handling. Our polling thread then
started to spin without ever going to sleep.
The solution here is to remove the endpoint from polling
after the TCPX_EP_SHUTDOWN flag is set and only after
another round of polling in tcpx_progress() - similar to
what the socket provider does.

Signed-off-by: Bernd Schubert <bschubert@ddn.com>