### PR TITLE
prov/ip-based: Add reporting of network and interface names to getinfo

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -149,7 +149,7 @@ int ofi_getifaddrs(struct ifaddrs **ifap);
 
 void ofi_set_netmask_str(char *netstr, size_t len, struct ifaddrs *ifa);
 
-void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
+void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 			  struct slist *addr_list);
 void ofi_free_list_of_addr(struct slist *addr_list);
 

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -125,6 +125,8 @@ int ofi_discard_socket(SOCKET sock, size_t len);
 #define AF_IB 27
 #endif
 
+#define OFI_ADDRSTRLEN (INET6_ADDRSTRLEN + 50)
+
 union ofi_sock_ip {
 	struct sockaddr		sa;
 	struct sockaddr_in	sin;
@@ -133,15 +135,20 @@ union ofi_sock_ip {
 };
 
 struct ofi_addr_list_entry {
-	char ipstr[INET6_ADDRSTRLEN];
-	union ofi_sock_ip ipaddr;
-	size_t speed;
-	struct slist_entry entry;
+	struct slist_entry	entry;
+	char			ipstr[INET6_ADDRSTRLEN];
+	union ofi_sock_ip	ipaddr;
+	size_t			speed;
+	char			net_name[OFI_ADDRSTRLEN];
+	char			ifa_name[OFI_ADDRSTRLEN];
 };
 
 int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,
 		const struct sockaddr *sa2);
 int ofi_getifaddrs(struct ifaddrs **ifap);
+
+void ofi_set_netmask_str(char *netstr, size_t len, struct ifaddrs *ifa);
+
 void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
 			  struct slist *addr_list);
 void ofi_free_list_of_addr(struct slist *addr_list);
@@ -153,7 +160,6 @@ void ofi_free_list_of_addr(struct slist *addr_list);
 #define ofi_sin6_addr(addr) (((struct sockaddr_in6 *)(addr))->sin6_addr)
 #define ofi_sin6_port(addr) (((struct sockaddr_in6 *)(addr))->sin6_port)
 
-#define OFI_ADDRSTRLEN (INET6_ADDRSTRLEN + 50)
 
 static inline size_t ofi_sizeofaddr(const struct sockaddr *addr)
 {

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -891,6 +891,9 @@ struct fi_info *ofi_allocinfo_internal(void);
 int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		 const char *node, const char *service, uint64_t flags,
 		 const struct fi_info *hints, struct fi_info **info);
+int ofi_ip_getinfo(const struct util_prov *prov, uint32_t version,
+		   const char *node, const char *service, uint64_t flags,
+		   const struct fi_info *hints, struct fi_info **info);
 
 
 struct fid_list_entry {

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -151,12 +151,10 @@ enum {
 
 #define SOCK_WIRE_PROTO_VERSION (2)
 
-extern struct fi_info sock_msg_info;
-extern struct fi_info sock_rdm_info;
 extern struct fi_info sock_dgram_info;
-extern struct util_prov sock_msg_util_prov;
-extern struct util_prov sock_rdm_util_prov;
-extern struct util_prov sock_dgram_util_prov;
+extern struct fi_info sock_msg_info;
+
+extern struct util_prov sock_util_prov;
 extern struct fi_domain_attr sock_domain_attr;
 extern struct fi_fabric_attr sock_fabric_attr;
 extern struct fi_tx_attr sock_msg_tx_attr;
@@ -989,20 +987,7 @@ union sock_tx_op {
 };
 #define SOCK_EP_TX_ENTRY_SZ (sizeof(union sock_tx_op))
 
-int sock_verify_info(uint32_t version, const struct fi_info *hints);
-int sock_verify_fabric_attr(const struct fi_fabric_attr *attr);
-int sock_verify_domain_attr(uint32_t version, const struct fi_info *info);
-
 size_t sock_get_tx_size(size_t size);
-int sock_rdm_verify_ep_attr(const struct fi_ep_attr *ep_attr,
-			    const struct fi_tx_attr *tx_attr,
-			    const struct fi_rx_attr *rx_attr);
-int sock_dgram_verify_ep_attr(const struct fi_ep_attr *ep_attr,
-			      const struct fi_tx_attr *tx_attr,
-			      const struct fi_rx_attr *rx_attr);
-int sock_msg_verify_ep_attr(const struct fi_ep_attr *ep_attr,
-			    const struct fi_tx_attr *tx_attr,
-			    const struct fi_rx_attr *rx_attr);
 int sock_get_src_addr(union ofi_sock_ip *dest_addr,
 		      union ofi_sock_ip *src_addr);
 int sock_get_src_addr_from_hostname(union ofi_sock_ip *src_addr,

--- a/prov/sockets/src/sock_attr.c
+++ b/prov/sockets/src/sock_attr.c
@@ -230,6 +230,7 @@ struct fi_info sock_msg_info = {
 };
 
 struct fi_info sock_rdm_info = {
+	.next = &sock_msg_info,
 	.caps = SOCK_RDM_TX_CAPS | SOCK_RDM_RX_CAPS | SOCK_DOMAIN_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &sock_rdm_tx_attr,
@@ -240,6 +241,7 @@ struct fi_info sock_rdm_info = {
 };
 
 struct fi_info sock_dgram_info = {
+	.next = &sock_rdm_info,
 	.caps = SOCK_DGRAM_TX_CAPS | SOCK_DGRAM_RX_CAPS | SOCK_DOMAIN_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &sock_dgram_tx_attr,

--- a/prov/sockets/src/sock_dom.c
+++ b/prov/sockets/src/sock_dom.c
@@ -46,109 +46,6 @@
 
 extern struct fi_ops_mr sock_dom_mr_ops;
 
-int sock_verify_domain_attr(uint32_t version, const struct fi_info *info)
-{
-	const struct fi_domain_attr *attr = info->domain_attr;
-
-	if (!attr)
-		return 0;
-
-	switch (attr->threading) {
-	case FI_THREAD_UNSPEC:
-	case FI_THREAD_SAFE:
-	case FI_THREAD_FID:
-	case FI_THREAD_DOMAIN:
-	case FI_THREAD_COMPLETION:
-	case FI_THREAD_ENDPOINT:
-		break;
-	default:
-		SOCK_LOG_DBG("Invalid threading model!\n");
-		return -FI_ENODATA;
-	}
-
-	switch (attr->control_progress) {
-	case FI_PROGRESS_UNSPEC:
-	case FI_PROGRESS_AUTO:
-	case FI_PROGRESS_MANUAL:
-		break;
-
-	default:
-		SOCK_LOG_DBG("Control progress mode not supported!\n");
-		return -FI_ENODATA;
-	}
-
-	switch (attr->data_progress) {
-	case FI_PROGRESS_UNSPEC:
-	case FI_PROGRESS_AUTO:
-	case FI_PROGRESS_MANUAL:
-		break;
-
-	default:
-		SOCK_LOG_DBG("Data progress mode not supported!\n");
-		return -FI_ENODATA;
-	}
-
-	switch (attr->resource_mgmt) {
-	case FI_RM_UNSPEC:
-	case FI_RM_DISABLED:
-	case FI_RM_ENABLED:
-		break;
-
-	default:
-		SOCK_LOG_DBG("Resource mgmt not supported!\n");
-		return -FI_ENODATA;
-	}
-
-	switch (attr->av_type) {
-	case FI_AV_UNSPEC:
-	case FI_AV_MAP:
-	case FI_AV_TABLE:
-		break;
-
-	default:
-		SOCK_LOG_DBG("AV type not supported!\n");
-		return -FI_ENODATA;
-	}
-
-	if (ofi_check_mr_mode(&sock_prov, version,
-			      sock_domain_attr.mr_mode, info)) {
-		FI_INFO(&sock_prov, FI_LOG_CORE,
-			"Invalid memory registration mode\n");
-		return -FI_ENODATA;
-	}
-
-	if (attr->mr_key_size > sock_domain_attr.mr_key_size)
-		return -FI_ENODATA;
-
-	if (attr->cq_data_size > sock_domain_attr.cq_data_size)
-		return -FI_ENODATA;
-
-	if (attr->cq_cnt > sock_domain_attr.cq_cnt)
-		return -FI_ENODATA;
-
-	if (attr->ep_cnt > sock_domain_attr.ep_cnt)
-		return -FI_ENODATA;
-
-	if (attr->max_ep_tx_ctx > sock_domain_attr.max_ep_tx_ctx)
-		return -FI_ENODATA;
-
-	if (attr->max_ep_rx_ctx > sock_domain_attr.max_ep_rx_ctx)
-		return -FI_ENODATA;
-
-	if (attr->cntr_cnt > sock_domain_attr.cntr_cnt)
-		return -FI_ENODATA;
-
-	if (attr->mr_iov_limit > sock_domain_attr.mr_iov_limit)
-		return -FI_ENODATA;
-
-	if (attr->max_err_data > sock_domain_attr.max_err_data)
-		return -FI_ENODATA;
-
-	if (attr->mr_cnt > sock_domain_attr.mr_cnt)
-		return -FI_ENODATA;
-
-	return 0;
-}
 
 static int sock_dom_close(struct fid *fid)
 {
@@ -258,12 +155,8 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 	struct sock_fabric *fab;
 	int ret;
 
+	assert(info && info->domain_attr);
 	fab = container_of(fabric, struct sock_fabric, fab_fid);
-	if (info && info->domain_attr) {
-		ret = sock_verify_domain_attr(fabric->api_version, info);
-		if (ret)
-			return -FI_EINVAL;
-	}
 
 	sock_domain = calloc(1, sizeof(*sock_domain));
 	if (!sock_domain)
@@ -272,12 +165,8 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 	fastlock_init(&sock_domain->lock);
 	ofi_atomic_initialize32(&sock_domain->ref, 0);
 
-	if (info) {
-		sock_domain->info = *info;
-	} else {
-		SOCK_LOG_ERROR("invalid fi_info\n");
-		goto err1;
-	}
+	sock_domain->info = *info;
+	sock_domain->info.domain_attr = NULL;
 
 	sock_domain->dom_fid.fid.fclass = FI_CLASS_DOMAIN;
 	sock_domain->dom_fid.fid.context = context;
@@ -285,8 +174,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 	sock_domain->dom_fid.ops = &sock_dom_ops;
 	sock_domain->dom_fid.mr = &sock_dom_mr_ops;
 
-	if (!info->domain_attr ||
-	    info->domain_attr->data_progress == FI_PROGRESS_UNSPEC)
+	if (info->domain_attr->data_progress == FI_PROGRESS_UNSPEC)
 		sock_domain->progress_mode = FI_PROGRESS_AUTO;
 	else
 		sock_domain->progress_mode = info->domain_attr->data_progress;
@@ -300,10 +188,7 @@ int sock_domain(struct fid_fabric *fabric, struct fi_info *info,
 	sock_domain->fab = fab;
 	*dom = &sock_domain->dom_fid;
 
-	if (info->domain_attr)
-		sock_domain->attr = *(info->domain_attr);
-	else
-		sock_domain->attr = sock_domain_attr;
+	sock_domain->attr = *(info->domain_attr);
 
 	ret = ofi_mr_map_init(&sock_prov, sock_domain->attr.mr_mode,
 			      &sock_domain->mr_map);

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -59,113 +59,6 @@
 #define SOCK_LOG_DBG(...) _SOCK_LOG_DBG(FI_LOG_EP_CTRL, __VA_ARGS__)
 #define SOCK_LOG_ERROR(...) _SOCK_LOG_ERROR(FI_LOG_EP_CTRL, __VA_ARGS__)
 
-static int sock_msg_verify_rx_attr(const struct fi_rx_attr *attr)
-{
-	if (!attr)
-		return 0;
-
-	if ((attr->caps | sock_msg_rx_attr.caps) != sock_msg_rx_attr.caps)
-		return -FI_ENODATA;
-
-	if ((attr->msg_order | SOCK_EP_MSG_ORDER) != SOCK_EP_MSG_ORDER)
-		return -FI_ENODATA;
-
-	if ((attr->comp_order | SOCK_EP_COMP_ORDER) != SOCK_EP_COMP_ORDER)
-		return -FI_ENODATA;
-
-	if (attr->total_buffered_recv > sock_msg_rx_attr.total_buffered_recv)
-		return -FI_ENODATA;
-
-	if (sock_get_tx_size(attr->size) >
-	     sock_get_tx_size(sock_msg_rx_attr.size))
-		return -FI_ENODATA;
-
-	if (attr->iov_limit > sock_msg_rx_attr.iov_limit)
-		return -FI_ENODATA;
-
-	return 0;
-}
-
-static int sock_msg_verify_tx_attr(const struct fi_tx_attr *attr)
-{
-	if (!attr)
-		return 0;
-
-	if ((attr->caps | sock_msg_tx_attr.caps) != sock_msg_tx_attr.caps)
-		return -FI_ENODATA;
-
-	if ((attr->msg_order | SOCK_EP_MSG_ORDER) != SOCK_EP_MSG_ORDER)
-		return -FI_ENODATA;
-
-	if (attr->inject_size > sock_msg_tx_attr.inject_size)
-		return -FI_ENODATA;
-
-	if (sock_get_tx_size(attr->size) >
-	     sock_get_tx_size(sock_msg_tx_attr.size))
-		return -FI_ENODATA;
-
-	if (attr->iov_limit > sock_msg_tx_attr.iov_limit)
-		return -FI_ENODATA;
-
-	if (attr->rma_iov_limit > sock_msg_tx_attr.rma_iov_limit)
-		return -FI_ENODATA;
-
-	return 0;
-}
-
-int sock_msg_verify_ep_attr(const struct fi_ep_attr *ep_attr,
-			    const struct fi_tx_attr *tx_attr,
-			    const struct fi_rx_attr *rx_attr)
-{
-	if (ep_attr) {
-		switch (ep_attr->protocol) {
-		case FI_PROTO_UNSPEC:
-		case FI_PROTO_SOCK_TCP:
-			break;
-		default:
-			return -FI_ENODATA;
-		}
-
-		if (ep_attr->protocol_version &&
-		    (ep_attr->protocol_version != sock_msg_ep_attr.protocol_version))
-			return -FI_ENODATA;
-
-		if (ep_attr->max_msg_size > sock_msg_ep_attr.max_msg_size)
-			return -FI_ENODATA;
-
-		if (ep_attr->msg_prefix_size > sock_msg_ep_attr.msg_prefix_size)
-			return -FI_ENODATA;
-
-		if (ep_attr->max_order_raw_size >
-		   sock_msg_ep_attr.max_order_raw_size)
-			return -FI_ENODATA;
-
-		if (ep_attr->max_order_war_size >
-		   sock_msg_ep_attr.max_order_war_size)
-			return -FI_ENODATA;
-
-		if (ep_attr->max_order_waw_size >
-		   sock_msg_ep_attr.max_order_waw_size)
-			return -FI_ENODATA;
-
-		if ((ep_attr->tx_ctx_cnt > SOCK_EP_MAX_TX_CNT) &&
-		    ep_attr->tx_ctx_cnt != FI_SHARED_CONTEXT)
-			return -FI_ENODATA;
-
-		if ((ep_attr->rx_ctx_cnt > SOCK_EP_MAX_RX_CNT) &&
-		    ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
-			return -FI_ENODATA;
-
-		if (ep_attr->auth_key_size &&
-		    (ep_attr->auth_key_size != sock_msg_ep_attr.auth_key_size))
-			return -FI_ENODATA;
-	}
-
-	if (sock_msg_verify_tx_attr(tx_attr) || sock_msg_verify_rx_attr(rx_attr))
-		return -FI_ENODATA;
-
-	return 0;
-}
 
 static int sock_ep_cm_getname(fid_t fid, void *addr, size_t *addrlen)
 {
@@ -741,64 +634,21 @@ struct fi_ops_cm sock_ep_cm_ops = {
 	.join = fi_no_join,
 };
 
-static int sock_msg_endpoint(struct fid_domain *domain, struct fi_info *info,
-		struct sock_ep **ep, void *context, size_t fclass)
+int sock_msg_ep(struct fid_domain *domain, struct fi_info *info,
+		struct fid_ep **ep, void *context)
 {
-	int ret;
+	struct sock_ep *endpoint;
 	struct sock_pep *pep;
+	int ret;
 
-	if (info) {
-		if (info->ep_attr) {
-			ret = sock_msg_verify_ep_attr(info->ep_attr,
-						      info->tx_attr,
-						      info->rx_attr);
-			if (ret)
-				return -FI_EINVAL;
-		}
-
-		if (info->tx_attr) {
-			ret = sock_msg_verify_tx_attr(info->tx_attr);
-			if (ret)
-				return -FI_EINVAL;
-		}
-
-		if (info->rx_attr) {
-			ret = sock_msg_verify_rx_attr(info->rx_attr);
-			if (ret)
-				return -FI_EINVAL;
-		}
-	}
-
-	ret = sock_alloc_endpoint(domain, info, ep, context, fclass);
+	ret = sock_alloc_endpoint(domain, info, &endpoint, context, FI_CLASS_EP);
 	if (ret)
 		return ret;
 
 	if (info && info->handle && info->handle->fclass == FI_CLASS_PEP) {
 		pep = container_of(info->handle, struct sock_pep, pep.fid);
-		memcpy((*ep)->attr->src_addr, &pep->src_addr, sizeof *(*ep)->attr->src_addr);
+		*endpoint->attr->src_addr = pep->src_addr;
 	}
-
-	if (!info || !info->ep_attr)
-		(*ep)->attr->ep_attr = sock_msg_ep_attr;
-
-	if (!info || !info->tx_attr)
-		(*ep)->tx_attr = sock_msg_tx_attr;
-
-	if (!info || !info->rx_attr)
-		(*ep)->rx_attr = sock_msg_rx_attr;
-
-	return 0;
-}
-
-int sock_msg_ep(struct fid_domain *domain, struct fi_info *info,
-		struct fid_ep **ep, void *context)
-{
-	int ret;
-	struct sock_ep *endpoint;
-
-	ret = sock_msg_endpoint(domain, info, &endpoint, context, FI_CLASS_EP);
-	if (ret)
-		return ret;
 
 	*ep = &endpoint->ep;
 	return 0;
@@ -1202,7 +1052,7 @@ int sock_msg_sep(struct fid_domain *domain, struct fi_info *info,
 	int ret;
 	struct sock_ep *endpoint;
 
-	ret = sock_msg_endpoint(domain, info, &endpoint, context, FI_CLASS_SEP);
+	ret = sock_alloc_endpoint(domain, info, &endpoint, context, FI_CLASS_SEP);
 	if (ret)
 		return ret;
 
@@ -1217,52 +1067,40 @@ int sock_msg_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	struct sock_pep *_pep;
 	struct addrinfo hints, *result;
 
-	if (info) {
-		ret = sock_verify_info(fabric->api_version, info);
-		if (ret) {
-			SOCK_LOG_DBG("Cannot support requested options!\n");
-			return ret;
-		}
-	}
-
+	assert(info);
 	_pep = calloc(1, sizeof(*_pep));
 	if (!_pep)
 		return -FI_ENOMEM;
 
-	if (info) {
-		if (info->src_addr) {
-			memcpy(&_pep->src_addr, info->src_addr,
-				info->src_addrlen);
-		} else {
-			memset(&hints, 0, sizeof(hints));
-			hints.ai_socktype = SOCK_STREAM;
-			hints.ai_family = ofi_get_sa_family(info);
-			if (!hints.ai_family)
-				hints.ai_family = AF_INET;
-
-			if (hints.ai_family == AF_INET) {
-				ret = getaddrinfo("127.0.0.1", NULL, &hints,
-						  &result);
-			} else if (hints.ai_family == AF_INET6) {
-				ret = getaddrinfo("::1", NULL, &hints, &result);
-			} else {
-				ret = getaddrinfo("localhost", NULL, &hints,
-						  &result);
-			}
-			if (ret) {
-				ret = -FI_EINVAL;
-				SOCK_LOG_DBG("getaddrinfo failed!\n");
-				goto err;
-			}
-			memcpy(&_pep->src_addr, result->ai_addr,
-				result->ai_addrlen);
-			freeaddrinfo(result);
-		}
-		_pep->info = *info;
+	if (info->src_addr) {
+		memcpy(&_pep->src_addr, info->src_addr,
+			info->src_addrlen);
 	} else {
-		SOCK_LOG_ERROR("invalid fi_info\n");
-		goto err;
+		memset(&hints, 0, sizeof(hints));
+		hints.ai_socktype = SOCK_STREAM;
+		hints.ai_family = ofi_get_sa_family(info);
+		if (!hints.ai_family)
+			hints.ai_family = AF_INET;
+
+		if (hints.ai_family == AF_INET) {
+			ret = getaddrinfo("127.0.0.1", NULL, &hints,
+						&result);
+		} else if (hints.ai_family == AF_INET6) {
+			ret = getaddrinfo("::1", NULL, &hints, &result);
+		} else {
+			ret = getaddrinfo("localhost", NULL, &hints,
+						&result);
+		}
+		if (ret) {
+			ret = -FI_EINVAL;
+			SOCK_LOG_DBG("getaddrinfo failed!\n");
+			goto err;
+		}
+		memcpy(&_pep->src_addr, result->ai_addr,
+			result->ai_addrlen);
+		freeaddrinfo(result);
 	}
+	_pep->info = *info;
 
 	ret = socketpair(AF_UNIX, SOCK_STREAM, 0, _pep->cm.signal_fds);
 	if (ret) {

--- a/prov/sockets/src/sock_ep_rdm.c
+++ b/prov/sockets/src/sock_ep_rdm.c
@@ -57,196 +57,6 @@
 #define SOCK_LOG_DBG(...) _SOCK_LOG_DBG(FI_LOG_EP_CTRL, __VA_ARGS__)
 #define SOCK_LOG_ERROR(...) _SOCK_LOG_ERROR(FI_LOG_EP_CTRL, __VA_ARGS__)
 
-static int sock_rdm_verify_rx_attr(const struct fi_rx_attr *attr)
-{
-	if (!attr)
-		return 0;
-
-	if ((attr->caps | sock_rdm_rx_attr.caps) != sock_rdm_rx_attr.caps) {
-		SOCK_LOG_DBG("Unsupported RDM rx caps\n");
-		return -FI_ENODATA;
-	}
-
-	if ((attr->msg_order | SOCK_EP_MSG_ORDER) != SOCK_EP_MSG_ORDER) {
-		SOCK_LOG_DBG("Unsuported rx message order\n");
-		return -FI_ENODATA;
-	}
-
-	if ((attr->comp_order | SOCK_EP_COMP_ORDER) != SOCK_EP_COMP_ORDER) {
-		SOCK_LOG_DBG("Unsuported rx completion order\n");
-		return -FI_ENODATA;
-	}
-
-	if (attr->total_buffered_recv > sock_rdm_rx_attr.total_buffered_recv) {
-		SOCK_LOG_DBG("Buffered receive size too large\n");
-		return -FI_ENODATA;
-	}
-
-	if (sock_get_tx_size(attr->size) >
-	     sock_get_tx_size(sock_rdm_rx_attr.size)) {
-		SOCK_LOG_DBG("Rx size too large\n");
-		return -FI_ENODATA;
-	}
-
-	if (attr->iov_limit > sock_rdm_rx_attr.iov_limit) {
-		SOCK_LOG_DBG("Rx iov limit too large\n");
-		return -FI_ENODATA;
-	}
-
-	return 0;
-}
-
-static int sock_rdm_verify_tx_attr(const struct fi_tx_attr *attr)
-{
-	if (!attr)
-		return 0;
-
-	if ((attr->caps | sock_rdm_tx_attr.caps) != sock_rdm_tx_attr.caps) {
-		SOCK_LOG_DBG("Unsupported RDM tx caps\n");
-		return -FI_ENODATA;
-	}
-
-	if ((attr->msg_order | SOCK_EP_MSG_ORDER) != SOCK_EP_MSG_ORDER) {
-		SOCK_LOG_DBG("Unsupported tx message order\n");
-		return -FI_ENODATA;
-	}
-
-	if (attr->inject_size > sock_rdm_tx_attr.inject_size) {
-		SOCK_LOG_DBG("Inject size too large\n");
-		return -FI_ENODATA;
-	}
-
-	if (sock_get_tx_size(attr->size) >
-	     sock_get_tx_size(sock_rdm_tx_attr.size)) {
-		SOCK_LOG_DBG("Tx size too large\n");
-		return -FI_ENODATA;
-	}
-
-	if (attr->iov_limit > sock_rdm_tx_attr.iov_limit) {
-		SOCK_LOG_DBG("Tx iov limit too large\n");
-		return -FI_ENODATA;
-	}
-
-	if (attr->rma_iov_limit > sock_rdm_tx_attr.rma_iov_limit) {
-		SOCK_LOG_DBG("RMA iov limit too large\n");
-		return -FI_ENODATA;
-	}
-
-	return 0;
-}
-
-int sock_rdm_verify_ep_attr(const struct fi_ep_attr *ep_attr,
-			    const struct fi_tx_attr *tx_attr,
-			    const struct fi_rx_attr *rx_attr)
-{
-	int ret;
-
-	if (ep_attr) {
-		switch (ep_attr->protocol) {
-		case FI_PROTO_UNSPEC:
-		case FI_PROTO_SOCK_TCP:
-			break;
-		default:
-			SOCK_LOG_DBG("Unsupported protocol\n");
-			return -FI_ENODATA;
-		}
-
-		if (ep_attr->protocol_version &&
-		    (ep_attr->protocol_version != sock_rdm_ep_attr.protocol_version)) {
-			SOCK_LOG_DBG("Invalid protocol version\n");
-			return -FI_ENODATA;
-		}
-
-		if (ep_attr->max_msg_size > sock_rdm_ep_attr.max_msg_size) {
-			SOCK_LOG_DBG("Message size too large\n");
-			return -FI_ENODATA;
-		}
-
-		if (ep_attr->msg_prefix_size > sock_rdm_ep_attr.msg_prefix_size) {
-			SOCK_LOG_DBG("Msg prefix size not supported\n");
-			return -FI_ENODATA;
-		}
-
-		if (ep_attr->max_order_raw_size >
-		   sock_rdm_ep_attr.max_order_raw_size) {
-			SOCK_LOG_DBG("RAW order size too large\n");
-			return -FI_ENODATA;
-		}
-
-		if (ep_attr->max_order_war_size >
-		   sock_rdm_ep_attr.max_order_war_size) {
-			SOCK_LOG_DBG("WAR order size too large\n");
-			return -FI_ENODATA;
-		}
-
-		if (ep_attr->max_order_waw_size >
-		   sock_rdm_ep_attr.max_order_waw_size) {
-			SOCK_LOG_DBG("WAW order size too large\n");
-			return -FI_ENODATA;
-		}
-
-		if ((ep_attr->tx_ctx_cnt > SOCK_EP_MAX_TX_CNT) &&
-		    ep_attr->tx_ctx_cnt != FI_SHARED_CONTEXT)
-			return -FI_ENODATA;
-
-		if ((ep_attr->rx_ctx_cnt > SOCK_EP_MAX_RX_CNT) &&
-		    ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
-			return -FI_ENODATA;
-	}
-
-	ret = sock_rdm_verify_tx_attr(tx_attr);
-	if (ret)
-		return ret;
-
-	ret = sock_rdm_verify_rx_attr(rx_attr);
-	if (ret)
-		return ret;
-
-	return 0;
-}
-
-static int sock_rdm_endpoint(struct fid_domain *domain, struct fi_info *info,
-		struct sock_ep **ep, void *context, size_t fclass)
-{
-	int ret;
-
-	if (info) {
-		if (info->ep_attr) {
-			ret = sock_rdm_verify_ep_attr(info->ep_attr,
-						      info->tx_attr,
-						      info->rx_attr);
-			if (ret)
-				return -FI_EINVAL;
-		}
-
-		if (info->tx_attr) {
-			ret = sock_rdm_verify_tx_attr(info->tx_attr);
-			if (ret)
-				return -FI_EINVAL;
-		}
-
-		if (info->rx_attr) {
-			ret = sock_rdm_verify_rx_attr(info->rx_attr);
-			if (ret)
-				return -FI_EINVAL;
-		}
-	}
-
-	ret = sock_alloc_endpoint(domain, info, ep, context, fclass);
-	if (ret)
-		return ret;
-
-	if (!info || !info->ep_attr)
-		(*ep)->attr->ep_attr = sock_rdm_ep_attr;
-
-	if (!info || !info->tx_attr)
-		(*ep)->tx_attr = sock_rdm_tx_attr;
-
-	if (!info || !info->rx_attr)
-		(*ep)->rx_attr = sock_rdm_rx_attr;
-
-	return 0;
-}
 
 int sock_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 		struct fid_ep **ep, void *context)
@@ -254,7 +64,7 @@ int sock_rdm_ep(struct fid_domain *domain, struct fi_info *info,
 	int ret;
 	struct sock_ep *endpoint;
 
-	ret = sock_rdm_endpoint(domain, info, &endpoint, context, FI_CLASS_EP);
+	ret = sock_alloc_endpoint(domain, info, &endpoint, context, FI_CLASS_EP);
 	if (ret)
 		return ret;
 
@@ -268,11 +78,10 @@ int sock_rdm_sep(struct fid_domain *domain, struct fi_info *info,
 	int ret;
 	struct sock_ep *endpoint;
 
-	ret = sock_rdm_endpoint(domain, info, &endpoint, context, FI_CLASS_SEP);
+	ret = sock_alloc_endpoint(domain, info, &endpoint, context, FI_CLASS_SEP);
 	if (ret)
 		return ret;
 
 	*sep = &endpoint->ep;
 	return 0;
 }
-

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -36,88 +36,15 @@
 #include "tcpx.h"
 
 #include <sys/types.h>
-#include <ifaddrs.h>
-#include <net/if.h>
 #include <ofi_util.h>
 #include <stdlib.h>
-
-#if HAVE_GETIFADDRS
-static void tcpx_getinfo_ifs(struct fi_info **info)
-{
-	struct fi_info *head = NULL, *tail = NULL, *cur;
-	struct slist addr_list;
-	size_t addrlen;
-	uint32_t addr_format;
-	struct slist_entry *entry, *prev;
-	struct ofi_addr_list_entry *addr_entry;
-
-	slist_init(&addr_list);
-
-	ofi_get_list_of_addr(&tcpx_prov, "iface", &addr_list);
-
-	(void) prev; /* Makes compiler happy */
-	slist_foreach(&addr_list, entry, prev) {
-		addr_entry = container_of(entry, struct ofi_addr_list_entry, entry);
-
-		cur = fi_dupinfo(*info);
-		if (!cur)
-			break;
-
-		if (!head) {
-			head = cur;
-			FI_INFO(&tcpx_prov, FI_LOG_CORE, "Chosen addr for using: %s,"
-				" speed %zu\n", addr_entry->ipstr, addr_entry->speed);
-		}
-		else
-			tail->next = cur;
-		tail = cur;
-
-		switch (addr_entry->ipaddr.sin.sin_family) {
-		case AF_INET:
-			addrlen = sizeof(struct sockaddr_in);
-			addr_format = FI_SOCKADDR_IN;
-			break;
-		case AF_INET6:
-			addrlen = sizeof(struct sockaddr_in6);
-			addr_format = FI_SOCKADDR_IN6;
-			break;
-		default:
-			continue;
-		}
-
-		cur->src_addr = mem_dup(&addr_entry->ipaddr, addrlen);
-		if (cur->src_addr) {
-			cur->src_addrlen = addrlen;
-			cur->addr_format = addr_format;
-		}
-		/* TODO: rework util code
-		util_set_fabric_domain(&tcpx_prov, cur);
-		*/
-	}
-
-	ofi_free_list_of_addr(&addr_list);
-	fi_freeinfo(*info);
-	*info = head;
-}
-#else
-#define tcpx_getinfo_ifs(info) do{ } while(0)
-#endif
 
 static int tcpx_getinfo(uint32_t version, const char *node, const char *service,
 			uint64_t flags, const struct fi_info *hints,
 			struct fi_info **info)
 {
-	int ret;
-
-	ret = util_getinfo(&tcpx_util_prov, version, node, service, flags,
-			   hints, info);
-	if (ret)
-		return ret;
-
-	if (!(*info)->src_addr && !(*info)->dest_addr)
-		tcpx_getinfo_ifs(info);
-
-	return 0;
+	return ofi_ip_getinfo(&tcpx_util_prov, version, node, service, flags,
+			      hints, info);
 }
 
 struct tcpx_port_range port_range = {

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -902,7 +902,7 @@ int ofi_check_tx_attr(const struct fi_provider *prov,
 	return 0;
 }
 
-/* if there are multiple fi_info in the provider:
+/* Use if there are multiple fi_info in the provider:
  * check provider's info */
 int ofi_prov_check_info(const struct util_prov *util_prov,
 			uint32_t api_version,
@@ -925,7 +925,7 @@ int ofi_prov_check_info(const struct util_prov *util_prov,
 	return (!success_info ? -FI_ENODATA : FI_SUCCESS);
 }
 
-/* if there are multiple fi_info in the provider:
+/* Use if there are multiple fi_info in the provider:
  * check and duplicate provider's info */
 int ofi_prov_check_dup_info(const struct util_prov *util_prov,
 			    uint32_t api_version,
@@ -958,7 +958,7 @@ int ofi_prov_check_dup_info(const struct util_prov *util_prov,
 		tail = fi;
 	}
 
-	return (!*info ? -FI_ENODATA : FI_SUCCESS);
+	return !*info ? -FI_ENODATA : FI_SUCCESS;
 err:
 	fi_freeinfo(*info);
 	FI_INFO(prov, FI_LOG_CORE,
@@ -966,7 +966,7 @@ err:
 	return ret;
 }
 
-/* if there is only single fi_info in the provider */
+/* Use if there is only single fi_info in the provider */
 int ofi_check_info(const struct util_prov *util_prov,
 		   const struct fi_info *prov_info, uint32_t api_version,
 		   const struct fi_info *user_info)

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -520,13 +520,6 @@ int ofi_check_domain_attr(const struct fi_provider *prov, uint32_t api_version,
 {
 	const struct fi_domain_attr *user_attr = user_info->domain_attr;
 
-	if (prov_attr->name && user_attr->name &&
-	    strcasecmp(user_attr->name, prov_attr->name)) {
-		FI_INFO(prov, FI_LOG_CORE, "Unknown domain name\n");
-		FI_INFO_NAME(prov, prov_attr, user_attr);
-		return -FI_ENODATA;
-	}
-
 	if (fi_thread_level(user_attr->threading) <
 	    fi_thread_level(prov_attr->threading)) {
 		FI_INFO(prov, FI_LOG_CORE, "Invalid threading model\n");

--- a/prov/util/src/util_main.c
+++ b/prov/util/src/util_main.c
@@ -127,6 +127,11 @@ static int util_find_domain(struct dlist_entry *item, const void *arg)
 		 ((info->domain_attr->mr_mode & domain->mr_mode) == domain->mr_mode);
 }
 
+/*
+ * Produces 1 fi_info output for each fi_info entry in the provider's base
+ * list (stored with util_prov), subject to the base fi_info meeting the
+ * user's hints.
+ */
 int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 		 const char *node, const char *service, uint64_t flags,
 		 const struct fi_info *hints, struct fi_info **info)
@@ -253,4 +258,126 @@ int util_getinfo(const struct util_prov *util_prov, uint32_t version,
 err:
 	fi_freeinfo(*info);
 	return ret;
+}
+
+static void util_set_netif_names(struct fi_info *info,
+				 struct ofi_addr_list_entry *addr_entry)
+{
+	char *name;
+
+	name = strdup(addr_entry->net_name);
+	if (name) {
+		free(info->fabric_attr->name);
+		info->fabric_attr->name = name;
+	}
+
+	name = strdup(addr_entry->ifa_name);
+	if (name) {
+		free(info->domain_attr->name);
+		info->domain_attr->name = name;
+	}
+}
+
+/*
+ * Produces 1 fi_info output for each usable IP address in the system for the
+ * given fi_info input.
+ */
+#if HAVE_GETIFADDRS
+static void util_getinfo_ifs(const struct util_prov *prov, struct fi_info *src_info,
+			     struct fi_info **head, struct fi_info **tail)
+{
+	struct fi_info *cur;
+	struct slist addr_list;
+	size_t addrlen;
+	uint32_t addr_format;
+	struct slist_entry *entry, *prev;
+	struct ofi_addr_list_entry *addr_entry;
+
+	*head = *tail = NULL;
+	slist_init(&addr_list);
+
+	ofi_get_list_of_addr(prov->prov, "iface", &addr_list);
+
+	(void) prev; /* Makes compiler happy */
+	slist_foreach(&addr_list, entry, prev) {
+		addr_entry = container_of(entry, struct ofi_addr_list_entry, entry);
+
+		cur = fi_dupinfo(src_info);
+		if (!cur)
+			break;
+
+		if (!*head) {
+			*head = cur;
+			FI_INFO(prov->prov, FI_LOG_CORE, "Chosen addr for using: %s,"
+				" speed %zu\n", addr_entry->ipstr, addr_entry->speed);
+		} else {
+			(*tail)->next = cur;
+		}
+		*tail = cur;
+
+		switch (addr_entry->ipaddr.sin.sin_family) {
+		case AF_INET:
+			addrlen = sizeof(struct sockaddr_in);
+			addr_format = FI_SOCKADDR_IN;
+			break;
+		case AF_INET6:
+			addrlen = sizeof(struct sockaddr_in6);
+			addr_format = FI_SOCKADDR_IN6;
+			break;
+		default:
+			continue;
+		}
+
+		cur->src_addr = mem_dup(&addr_entry->ipaddr, addrlen);
+		if (cur->src_addr) {
+			cur->src_addrlen = addrlen;
+			cur->addr_format = addr_format;
+		}
+		util_set_netif_names(cur, addr_entry);
+	}
+
+	ofi_free_list_of_addr(&addr_list);
+	if (!*head) {
+		*head = src_info;
+		*tail = src_info;
+	}
+}
+#else
+static void util_getinfo_ifs(const struct util_prov *prov, struct fi_info *src_info,
+			     struct fi_info **head, struct fi_info **tail)
+{
+	*head = src_info;
+	*tail = src_info;
+}
+#endif
+
+int ofi_ip_getinfo(const struct util_prov *prov, uint32_t version,
+		   const char *node, const char *service, uint64_t flags,
+		   const struct fi_info *hints, struct fi_info **info)
+{
+	struct fi_info *head, *tail, *cur, **prev;
+	int ret;
+
+	ret = util_getinfo(prov, version, node, service, flags,
+			   hints, info);
+	if (ret)
+		return ret;
+
+	prev = info;
+	for (cur = *info; cur; cur = cur->next) {
+		if (!cur->src_addr && !cur->dest_addr) {
+			util_getinfo_ifs(prov, cur, &head, &tail);
+			if (head != cur) {
+				tail->next = (*prev)->next;
+				*prev = head;
+
+				cur->next = NULL;
+				fi_freeinfo(cur);
+				cur = tail;
+			}
+		}
+		prev = &cur->next;
+	}
+
+	return 0;
 }

--- a/src/common.c
+++ b/src/common.c
@@ -1083,7 +1083,7 @@ void ofi_free_list_of_addr(struct slist *addr_list)
 }
 
 static inline
-void ofi_insert_loopback_addr(struct fi_provider *prov, struct slist *addr_list)
+void ofi_insert_loopback_addr(const struct fi_provider *prov, struct slist *addr_list)
 {
 	struct ofi_addr_list_entry *addr_entry;
 
@@ -1184,7 +1184,7 @@ void ofi_set_netmask_str(char *netstr, size_t len, struct ifaddrs *ifa)
 	netstr[len - 1] = '\0';
 }
 
-void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
+void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 			  struct slist *addr_list)
 {
 	int ret;
@@ -1192,7 +1192,7 @@ void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
 	struct ofi_addr_list_entry *addr_entry;
 	struct ifaddrs *ifaddrs, *ifa;
 
-	fi_param_get_str(prov, env_name, &iface);
+	fi_param_get_str((struct fi_provider *) prov, env_name, &iface);
 
 	ret = ofi_getifaddrs(&ifaddrs);
 	if (ret)
@@ -1264,7 +1264,7 @@ insert_lo:
 
 #elif defined HAVE_MIB_IPADDRTABLE
 
-void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
+void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 			  struct slist *addr_list)
 {
 	struct ofi_addr_list_entry *addr_entry;
@@ -1313,7 +1313,7 @@ out:
 
 #else /* !HAVE_MIB_IPADDRTABLE && !HAVE_MIB_IPADDRTABLE */
 
-void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
+void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 			  struct slist *addr_list)
 {
 	ofi_insert_loopback_addr(prov, addr_list);

--- a/src/common.c
+++ b/src/common.c
@@ -1097,6 +1097,8 @@ void ofi_insert_loopback_addr(struct fi_provider *prov, struct slist *addr_list)
 			"available addr: ", &addr_entry->ipaddr);
 
 	strncpy(addr_entry->ipstr, "127.0.0.1", sizeof(addr_entry->ipstr));
+	strncpy(addr_entry->net_name, "127.0.0.1/32", sizeof(addr_entry->net_name));
+	strncpy(addr_entry->ifa_name, "lo", sizeof(addr_entry->ifa_name));
 	slist_insert_tail(&addr_entry->entry, addr_list);
 
 	addr_entry = calloc(1, sizeof(struct ofi_addr_list_entry));
@@ -1109,6 +1111,8 @@ void ofi_insert_loopback_addr(struct fi_provider *prov, struct slist *addr_list)
 			"available addr: ", &addr_entry->ipaddr);
 
 	strncpy(addr_entry->ipstr, "::1", sizeof(addr_entry->ipstr));
+	strncpy(addr_entry->net_name, "::1/128", sizeof(addr_entry->net_name));
+	strncpy(addr_entry->ifa_name, "lo", sizeof(addr_entry->ifa_name));
 	slist_insert_tail(&addr_entry->entry, addr_list);
 }
 
@@ -1154,6 +1158,32 @@ ofi_addr_list_entry_comp_speed(struct slist_entry *cur, const void *insert)
 	return (cur_addr->speed < insert_addr->speed);
 }
 
+void ofi_set_netmask_str(char *netstr, size_t len, struct ifaddrs *ifa)
+{
+	union ofi_sock_ip addr;
+	size_t prefix_len;
+
+	netstr[0] = '\0';
+	prefix_len = ofi_mask_addr(&addr.sa, ifa->ifa_addr, ifa->ifa_netmask);
+
+	switch (addr.sa.sa_family) {
+	case AF_INET:
+		inet_ntop(AF_INET, &addr.sin.sin_addr, netstr, len);
+		break;
+	case AF_INET6:
+		inet_ntop(AF_INET6, &addr.sin6.sin6_addr, netstr, len);
+		break;
+	default:
+		snprintf(netstr, len, "%s", "<unknown>");
+		netstr[len - 1] = '\0';
+		break;
+	}
+
+	snprintf(netstr + strlen(netstr), len - strlen(netstr),
+		 "%s%d", "/", (int) prefix_len);
+	netstr[len - 1] = '\0';
+}
+
 void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
 			  struct slist *addr_list)
 {
@@ -1165,63 +1195,69 @@ void ofi_get_list_of_addr(struct fi_provider *prov, const char *env_name,
 	fi_param_get_str(prov, env_name, &iface);
 
 	ret = ofi_getifaddrs(&ifaddrs);
-	if (!ret) {
-		if (iface) {
-			for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
-				if (strncmp(iface, ifa->ifa_name,
-					    strlen(iface)) == 0) {
-					break;
-				}
-			}
-			if (ifa == NULL) {
-				FI_INFO(prov, FI_LOG_CORE,
-					"Can't set filter to unknown interface: (%s)\n",
-					iface);
-				iface = NULL;
-			}
-		}
+	if (ret)
+		goto insert_lo;
+
+	if (iface) {
 		for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
-			if (ifa->ifa_addr == NULL ||
-			    !(ifa->ifa_flags & IFF_UP) ||
-			    (ifa->ifa_flags & IFF_LOOPBACK) ||
-			    ((ifa->ifa_addr->sa_family != AF_INET) &&
-			     (ifa->ifa_addr->sa_family != AF_INET6)))
-				continue;
-			if (iface && strncmp(iface, ifa->ifa_name, strlen(iface)) != 0) {
-				FI_DBG(prov, FI_LOG_CORE,
-				       "Skip (%s) interface\n", ifa->ifa_name);
-				continue;
+			if (strncmp(iface, ifa->ifa_name,
+					strlen(iface)) == 0) {
+				break;
 			}
-
-			addr_entry = calloc(1, sizeof(struct ofi_addr_list_entry));
-			if (!addr_entry)
-				continue;
-
-			memcpy(&addr_entry->ipaddr, ifa->ifa_addr,
-			       ofi_sizeofaddr(ifa->ifa_addr));
-			
-			if (!inet_ntop(ifa->ifa_addr->sa_family,
-					ofi_get_ipaddr(ifa->ifa_addr),
-					addr_entry->ipstr,
-					sizeof(addr_entry->ipstr))) {
-				FI_DBG(prov, FI_LOG_CORE,
-				       "inet_ntop failed: %d\n", errno);
-				free(addr_entry);
-				continue;
-			}
-
-			addr_entry->speed = ofi_ifaddr_get_speed(ifa);
-			FI_INFO(prov, FI_LOG_CORE, "Available addr: %s, "
-				"iface name: %s, speed: %zu\n",
-				addr_entry->ipstr, ifa->ifa_name, addr_entry->speed);
-
-			slist_insert_before_first_match(addr_list, ofi_addr_list_entry_comp_speed,
-							&addr_entry->entry);
+		}
+		if (ifa == NULL) {
+			FI_INFO(prov, FI_LOG_CORE,
+				"Can't set filter to unknown interface: (%s)\n",
+				iface);
+			iface = NULL;
+		}
+	}
+	for (ifa = ifaddrs; ifa != NULL; ifa = ifa->ifa_next) {
+		if (ifa->ifa_addr == NULL ||
+			!(ifa->ifa_flags & IFF_UP) ||
+			(ifa->ifa_flags & IFF_LOOPBACK) ||
+			((ifa->ifa_addr->sa_family != AF_INET) &&
+			(ifa->ifa_addr->sa_family != AF_INET6)))
+			continue;
+		if (iface && strncmp(iface, ifa->ifa_name, strlen(iface)) != 0) {
+			FI_DBG(prov, FI_LOG_CORE,
+				"Skip (%s) interface\n", ifa->ifa_name);
+			continue;
 		}
 
-		freeifaddrs(ifaddrs);
+		addr_entry = calloc(1, sizeof(*addr_entry));
+		if (!addr_entry)
+			continue;
+
+		memcpy(&addr_entry->ipaddr, ifa->ifa_addr,
+			ofi_sizeofaddr(ifa->ifa_addr));
+		strncpy(addr_entry->ifa_name, ifa->ifa_name,
+			sizeof(addr_entry->ifa_name));
+		ofi_set_netmask_str(addr_entry->net_name,
+				    sizeof(addr_entry->net_name), ifa);
+
+		if (!inet_ntop(ifa->ifa_addr->sa_family,
+				ofi_get_ipaddr(ifa->ifa_addr),
+				addr_entry->ipstr,
+				sizeof(addr_entry->ipstr))) {
+			FI_DBG(prov, FI_LOG_CORE,
+				"inet_ntop failed: %d\n", errno);
+			free(addr_entry);
+			continue;
+		}
+
+		addr_entry->speed = ofi_ifaddr_get_speed(ifa);
+		FI_INFO(prov, FI_LOG_CORE, "Available addr: %s, "
+			"iface name: %s, speed: %zu\n",
+			addr_entry->ipstr, ifa->ifa_name, addr_entry->speed);
+
+		slist_insert_before_first_match(addr_list, ofi_addr_list_entry_comp_speed,
+						&addr_entry->entry);
 	}
 
+	freeifaddrs(ifaddrs);
+
+insert_lo:
 	/* Always add loopback address at the end */
 	ofi_insert_loopback_addr(prov, addr_list);
 }


### PR DESCRIPTION
Update the udp, tcp, and sockets providers to report the network and interface names.  This fixes a regression with the sockets provider.  Convert the sockets provider to use the util calls for handling fi_getinfo.

Patches are not quite ready, but posting for early evaluation in response to bug report.