### PR TITLE
src/tree.c: Fixed the memory leak of map->free_list

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -111,6 +111,7 @@ void ofi_rbmap_cleanup(struct ofi_rbmap *map)
 void ofi_rbmap_destroy(struct ofi_rbmap *map)
 {
 	ofi_rbmap_cleanup(map);
+	free(map->free_list);
 	free(map);
 }
 


### PR DESCRIPTION
Added a free() call for map->free_list, which is can be allocated by
malloc(), on destroy phase.

Added OFI_UNLIKELY for !map->free_list branch.

Signed-off-by: Nikita Gusev <nikita.gusev@intel.com>