### PR TITLE
[v1.9.x] core/tree: Fix memory leak in free_list

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -110,7 +110,14 @@ void ofi_rbmap_cleanup(struct ofi_rbmap *map)
 
 void ofi_rbmap_destroy(struct ofi_rbmap *map)
 {
+	struct ofi_rbnode *node;
+
 	ofi_rbmap_cleanup(map);
+	while (map->free_list) {
+		node = map->free_list;
+		map->free_list = node->right;
+		free(node);
+	}
 	free(map);
 }
 


### PR DESCRIPTION
We need to cleanup the free_list when destroying the rbmap to avoid
a memory leak.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>