### PR TITLE
include/ofi_iov.h : add function ofi_total_rma_iov_len()

### DIFF
--- a/include/ofi_iov.h
+++ b/include/ofi_iov.h
@@ -61,6 +61,16 @@ static inline size_t ofi_total_ioc_cnt(const struct fi_ioc *ioc, size_t ioc_coun
 	return cnt;
 }
 
+static inline size_t ofi_total_rma_iov_len(const struct fi_rma_iov *rma_iov,
+					   size_t iov_count)
+{
+	size_t i, len = 0;
+
+	for (i = 0; i < iov_count; i++)
+		len += rma_iov[i].len;
+	return len;
+}
+
 static inline size_t ofi_total_rma_ioc_cnt(const struct fi_rma_ioc *rma_ioc,
 					   size_t ioc_count)
 {


### PR DESCRIPTION
This patch implement function ofi_total_rma_iov_len()

Signed-off-by: Wei Zhang <wzam@amazon.com>