### PR TITLE
core/iov: add ofi_consume_iov_desc() and ofi_consume_rma_iov()

### DIFF
--- a/include/ofi_iov.h
+++ b/include/ofi_iov.h
@@ -171,6 +171,12 @@ ofi_iov_within(const struct iovec *iov1, const struct iovec *iov2)
 
 void ofi_consume_iov(struct iovec *iovec, size_t *iovec_count, size_t offset);
 
+void ofi_consume_iov_desc(struct iovec *iovec, void **desc,
+			  size_t *iovec_count, size_t offset);
+
+void ofi_consume_rma_iov(struct fi_rma_iov *rma_iov, size_t *rma_iov_count,
+			 size_t length);
+
 int ofi_truncate_iov(struct iovec *iov, size_t *iov_count, size_t new_size);
 
 /* Copy 'len' bytes worth of src iovec to dst */


### PR DESCRIPTION
This patch introduce the following two functions:

ofi_consume_iov_desc(): some provider advertise FI_MR_LOCAL mode,
which require caller to provider mem_desc together with iov. In
which case, desc should be consumed together with iov.

ofi_consume_rma_iov(): as the name suggested, this function consume
rma iov.

Signed-off-by: Wei Zhang <wzam@amazon.com>