### PR TITLE
Jenkins-CI: Timeout For Daily builds

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile.daily
+++ b/contrib/intel/jenkins/Jenkinsfile.daily
@@ -1,7 +1,10 @@
 
 pipeline {
     agent any
-    options {timestamps()}
+    options {
+    timestamps()             
+    timeout(activity: true, time: 4, unit: 'HOURS')
+    }
     
     stages {
         stage ('fetch-opa-psm2')  {


### PR DESCRIPTION
Jenkinsfile.daily: Added timeout for daily builds.
This ensures that if a daily build hangs it will
abort itself after 4 hours of inactivity and release
resources for other builds.

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>