### PR TITLE
prov/efa: include efa_prefix/include when checking struct efadv_struct

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -67,12 +67,15 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 				[efa_happy=0])
 	      ])
 
+	save_CPPFLAGS=$CPPFLAGS
+	CPPFLAGS=-I$efa_PREFIX/include
 	AS_IF([test x"$enable_efa" != x"no"],
 	      [AC_CHECK_MEMBER(struct efadv_device_attr.max_rdma_size,
 			      [AC_DEFINE([HAVE_RDMA_SIZE], [1], [efadv_device_attr has max_rdma_size])],
 			      [],
 			      [[#include <infiniband/efadv.h>]])
 	      ])
+	CPPFLAGS=$save_CPPFLAGS
 
 	AS_IF([test $efa_happy -eq 1 ], [$1], [$2])
 


### PR DESCRIPTION
Currently we check the existence of max_rdma_size in
struct efadv_attr using AC_CHECK_MEMBER, which rely on CPPFLAGS.
If rdma-core is not installed in standard path, this check will
always fail.

This patch address issue by setting CPPFLAGS to include efa_prefix/include
before AC_CHECK_MEMBER(), and set it back to original value afterwards.

Signed-off-by: Wei Zhang <wzam@amazon.com>

cr https://code.amazon.com/reviews/CR-21303694