### PR TITLE
prov/efa: handle multiple sge in efa_rma_post_read()

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -158,7 +158,7 @@ const struct fi_tx_attr efa_rdm_tx_attr = {
 	.msg_order		= EFA_MSG_ORDER,
 	.comp_order		= FI_ORDER_NONE,
 	.inject_size		= 0,
-	.rma_iov_limit		= 0,
+	.rma_iov_limit		= 1,
 };
 
 const struct efa_ep_domain efa_rdm_domain = {


### PR DESCRIPTION
Currently efa_rma_post_read() assumes iov_count and
rma_iov_count to be 1. This patch addresses the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>