### PR TITLE
mr_cache: Do not hold monitor lock when allocating or registering memory

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -215,7 +215,6 @@ int ofi_mr_verify(struct ofi_mr_map *map, ssize_t len,
 struct ofi_mr_cache_params {
 	size_t				max_cnt;
 	size_t				max_size;
-	int				merge_regions;
 	char *				monitor;
 };
 

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -121,10 +121,6 @@ These OFI runtime parameters apply only to the RDM endpoint.
   buffer for iov's larger than max_memcpy_size. Defaults to true. When
   disabled, only uses a bounce buffer
 
-*FI_EFA_MR_CACHE_MERGE_REGIONS*
-: Enables merging overlapping and adjacent memory registration regions.
-  Defaults to true.
-
 *FI_EFA_MR_MAX_CACHED_COUNT*
 : Sets the maximum number of memory registrations that can be cached at
   any time.

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -683,15 +683,6 @@ configure registration caches.
   are not actively being used as part of a data transfer.  Setting this to
   zero will disable registration caching.
 
-*FI_MR_CACHE_MERGE_REGIONS*
-: If this variable is set to true, yes, or 1, then memory regions that are
-  adjacent or overlapping will be merged into a single larger region.  Merging
-  regions reduces the total cache size and the number of regions managed by
-  the cache.  However, merging regions can have a negative impact on
-  performance if a large number of adjacent regions are sent as separate data
-  transfers (such as sending elements of an array to peer(s)), and the larger
-  region is access infrequently.  By default merging regions is disabled.
-
 *FI_MR_CACHE_MONITOR*
 : The cache monitor is responsible for detecting changes made between the
   virtual addresses used by an application and the underlying physical pages.

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -109,7 +109,6 @@
 extern int efa_mr_cache_enable;
 extern size_t efa_mr_max_cached_count;
 extern size_t efa_mr_max_cached_size;
-extern int efa_mr_cache_merge_regions;
 
 extern struct fi_provider efa_prov;
 extern struct util_prov efa_util_prov;

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -201,7 +201,6 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 			                         EFA_MR_CACHE_LIMIT_MULT;
 		cache_params.max_cnt = efa_mr_max_cached_count;
 		cache_params.max_size = efa_mr_max_cached_size;
-		cache_params.merge_regions = efa_mr_cache_merge_regions;
 		domain->cache.entry_data_size = sizeof(struct efa_mr);
 		domain->cache.add_region = efa_mr_cache_entry_reg;
 		domain->cache.delete_region = efa_mr_cache_entry_dereg;
@@ -209,9 +208,8 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 					&domain->cache);
 		if (!ret) {
 			domain->util_domain.domain_fid.mr = &efa_domain_mr_cache_ops;
-			EFA_INFO(FI_LOG_DOMAIN, "EFA MR cache enabled, max_cnt: %zu max_size: %zu merge_regions: %d\n",
-			         cache_params.max_cnt, cache_params.max_size,
-			         cache_params.merge_regions);
+			EFA_INFO(FI_LOG_DOMAIN, "EFA MR cache enabled, max_cnt: %zu max_size: %zu\n",
+			         cache_params.max_cnt, cache_params.max_size);
 			return 0;
 		}
 	}

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -79,10 +79,8 @@
 #define EFA_NO_DEFAULT -1
 
 #define EFA_DEF_MR_CACHE_ENABLE 1
-#define EFA_DEF_MR_CACHE_MERGE_REGIONS 1
 
 int efa_mr_cache_enable		= EFA_DEF_MR_CACHE_ENABLE;
-int efa_mr_cache_merge_regions	= EFA_DEF_MR_CACHE_MERGE_REGIONS;
 size_t efa_mr_max_cached_count;
 size_t efa_mr_max_cached_size;
 

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -88,8 +88,6 @@ static void rxr_init_env(void)
 			    &rxr_env.max_memcpy_size);
 	fi_param_get_bool(&rxr_prov, "mr_cache_enable",
 			  &efa_mr_cache_enable);
-	fi_param_get_bool(&rxr_prov, "mr_cache_merge_regions",
-			  &efa_mr_cache_merge_regions);
 	fi_param_get_size_t(&rxr_prov, "mr_max_cached_count",
 			    &efa_mr_max_cached_count);
 	fi_param_get_size_t(&rxr_prov, "mr_max_cached_size",
@@ -650,8 +648,6 @@ EFA_INI
 			"Define the size of completion queue. (Default: 8192)");
 	fi_param_define(&rxr_prov, "mr_cache_enable", FI_PARAM_BOOL,
 			"Enables using the mr cache and in-line registration instead of a bounce buffer for iov's larger than max_memcpy_size. Defaults to true. When disabled, only uses a bounce buffer.");
-	fi_param_define(&rxr_prov, "mr_cache_merge_regions", FI_PARAM_BOOL,
-			"Enables merging overlapping and adjacent memory registration regions. Defaults to true.");
 	fi_param_define(&rxr_prov, "mr_max_cached_count", FI_PARAM_SIZE_T,
 			"Sets the maximum number of memory registrations that can be cached at any time.");
 	fi_param_define(&rxr_prov, "mr_max_cached_size", FI_PARAM_SIZE_T,

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -88,12 +88,6 @@ void ofi_monitor_init(void)
 			" reduce the number of registered regions, regardless"
 			" of their size, stored in the cache.  Setting this"
 			" to zero will disable MR caching.  (default: 1024)");
-	fi_param_define(NULL, "mr_cache_merge_regions", FI_PARAM_BOOL,
-			"If set to true, overlapping or adjacent memory"
-			" regions will be combined into a single, larger"
-			" region.  Merging regions can reduce the cache"
-			" memory footprint, but can negatively impact"
-			" performance in some situations.  (default: false)");
 	fi_param_define(NULL, "mr_cache_monitor", FI_PARAM_STRING,
 			"Define a default memory registration monitor."
 			" The monitor checks for virtual to physical memory"
@@ -106,8 +100,6 @@ void ofi_monitor_init(void)
 
 	fi_param_get_size_t(NULL, "mr_cache_max_size", &cache_params.max_size);
 	fi_param_get_size_t(NULL, "mr_cache_max_count", &cache_params.max_cnt);
-	fi_param_get_bool(NULL, "mr_cache_merge_regions",
-			  &cache_params.merge_regions);
 	fi_param_get_str(NULL, "mr_cache_monitor", &cache_params.monitor);
 
 	if (!cache_params.max_size)

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -213,42 +213,60 @@ void ofi_mr_cache_delete(struct ofi_mr_cache *cache, struct ofi_mr_entry *entry)
 	pthread_mutex_unlock(&cache->monitor->lock);
 }
 
+/*
+ * We cannot hold the monitor lock when allocating and registering the
+ * mr_entry without creating a potential deadlock situation with the
+ * memory monitor needing to acquire the same lock.  The underlying
+ * calls may allocate memory, which can result in the monitor needing
+ * to handle address mapping changes.  To handle this, we build the
+ * new entry, then check under lock that a conflict with another thread
+ * hasn't occurred.  If a conflict occurred, we return -EAGAIN and
+ * restart the entire operation.
+ */
 static int
-util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
-		     uint64_t access, struct ofi_mr_entry **entry)
+util_mr_cache_create(struct ofi_mr_cache *cache, const struct ofi_mr_info *info,
+		     struct ofi_mr_entry **entry)
 {
+	struct ofi_mr_entry *cur;
 	int ret;
 
 	FI_DBG(cache->domain->prov, FI_LOG_MR, "create %p (len: %zu)\n",
-	       iov->iov_base, iov->iov_len);
+	       info->iov.iov_base, info->iov.iov_len);
 
 	*entry = util_mr_entry_alloc(cache);
 	if (!*entry)
 		return -FI_ENOMEM;
 
 	(*entry)->storage_context = NULL;
-	(*entry)->info.iov = *iov;
+	(*entry)->info = *info;
 	(*entry)->use_cnt = 1;
 
 	ret = cache->add_region(cache, *entry);
 	if (ret)
-		goto err;
+		goto free;
+
+	pthread_mutex_lock(&cache->monitor->lock);
+	cur = cache->storage.find(&cache->storage, info);
+	if (cur) {
+		ret = -FI_EAGAIN;
+		goto unlock;
+	}
 
 	if ((cache->cached_cnt >= cache_params.max_cnt) ||
 	    (cache->cached_size >= cache_params.max_size)) {
 		cache->uncached_cnt++;
-		cache->uncached_size += iov->iov_len;
+		cache->uncached_size += info->iov.iov_len;
 	} else {
 		if (cache->storage.insert(&cache->storage,
 					  &(*entry)->info, *entry)) {
 			ret = -FI_ENOMEM;
-			goto err;
+			goto unlock;
 		}
 		cache->cached_cnt++;
-		cache->cached_size += iov->iov_len;
+		cache->cached_size += info->iov.iov_len;
 
-		ret = ofi_monitor_subscribe(cache->monitor, iov->iov_base,
-					    iov->iov_len);
+		ret = ofi_monitor_subscribe(cache->monitor, info->iov.iov_base,
+					    info->iov.iov_len);
 		if (ret) {
 			util_mr_uncache_entry_storage(cache, *entry);
 			cache->uncached_cnt++;
@@ -257,10 +275,12 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct iovec *iov,
 			(*entry)->subscribed = 1;
 		}
 	}
-
+	pthread_mutex_unlock(&cache->monitor->lock);
 	return 0;
 
-err:
+unlock:
+	pthread_mutex_unlock(&cache->monitor->lock);
+free:
 	util_mr_free_entry(cache, *entry);
 	return ret;
 }
@@ -269,62 +289,53 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 			struct ofi_mr_entry **entry)
 {
 	struct ofi_mr_info info;
-	int ret = 0;
+	int ret;
 
 	assert(attr->iov_count == 1);
 	FI_DBG(cache->domain->prov, FI_LOG_MR, "search %p (len: %zu)\n",
 	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
 
-	pthread_mutex_lock(&cache->monitor->lock);
-	cache->search_cnt++;
-
-	if ((cache->cached_cnt >= cache_params.max_cnt) ||
-	    (cache->cached_size >= cache_params.max_size)) {
-		pthread_mutex_unlock(&cache->monitor->lock);
-		ofi_mr_cache_flush(cache);
-		pthread_mutex_lock(&cache->monitor->lock);
-	}
-
 	info.iov = *attr->mr_iov;
-retry:
-	*entry = cache->storage.find(&cache->storage, &info);
-	if (!*entry) {
-		ret = util_mr_cache_create(cache, attr->mr_iov,
-					   attr->access, entry);
-		if (ret) {
+
+	do {
+		pthread_mutex_lock(&cache->monitor->lock);
+
+		if ((cache->cached_cnt >= cache_params.max_cnt) ||
+		    (cache->cached_size >= cache_params.max_size)) {
 			pthread_mutex_unlock(&cache->monitor->lock);
-			if (!ofi_mr_cache_flush(cache))
-				return ret;
-
+			ofi_mr_cache_flush(cache);
 			pthread_mutex_lock(&cache->monitor->lock);
-			goto retry;
 		}
-		goto unlock;
-	}
 
-	/* This branch may be taken even if the new region encloses a previously
-	 * cached smaller region.  In this case, we need to see if other smaller
-	 * regions may also be enclosed and release them all.
-	 */
-	if (!ofi_iov_within(attr->mr_iov, &(*entry)->info.iov)) {
-		do {
+		cache->search_cnt++;
+		*entry = cache->storage.find(&cache->storage, &info);
+		if (*entry && ofi_iov_within(attr->mr_iov, &(*entry)->info.iov))
+			goto hit;
+
+		/* Purge regions that overlap with new region */
+		while (*entry) {
 			/* New entry will expand range of subscription */
 			(*entry)->subscribed = 0;
 			util_mr_uncache_entry(cache, *entry);
-		} while ((*entry = cache->storage.find(&cache->storage, &info)));
+			*entry = cache->storage.find(&cache->storage, &info);
+		}
+		pthread_mutex_unlock(&cache->monitor->lock);
 
-		ret = util_mr_cache_create(cache, attr->mr_iov,
-					   attr->access, entry);
-		goto unlock;
-	}
+		ret = util_mr_cache_create(cache, &info, entry);
+		if (ret && ret != -FI_EAGAIN) {
+			if (ofi_mr_cache_flush(cache))
+				ret = -FI_EAGAIN;
+		}
+	} while (ret == -FI_EAGAIN);
 
+	return ret;
+
+hit:
 	cache->hit_cnt++;
 	if ((*entry)->use_cnt++ == 0)
 		dlist_remove_init(&(*entry)->list_entry);
-
-unlock:
 	pthread_mutex_unlock(&cache->monitor->lock);
-	return ret;
+	return 0;
 }
 
 struct ofi_mr_entry *ofi_mr_cache_find(struct ofi_mr_cache *cache,


### PR DESCRIPTION
PR is untested.

See #5687 - MR cache use results in a deadlock when using the memhooks option.

We cannot hold the monitor lock when performing any operation which may invoke the monitor notification callback.  This is true for both the memhooks and userfaultfd monitors.  This series restructures the code holding the lock when allocating memory or registering memory (which may allocate memory).  Because the lock is necessary to serialize access to the cache, the code is modified to perform a secondary check after registering a new region, and rollback in case of a conflict.