### PR TITLE
prov/efa: MR descriptor updates

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -358,6 +358,9 @@ struct rxr_rx_entry {
 	size_t iov_count;
 	struct iovec iov[RXR_IOV_LIMIT];
 
+	/* App-provided reg descriptor */
+	void *desc[RXR_IOV_LIMIT];
+
 	/* iov_count on sender side, used for large message READ over shm */
 	size_t rma_iov_count;
 	struct fi_rma_iov rma_iov[RXR_IOV_LIMIT];
@@ -674,18 +677,18 @@ static inline void rxr_ep_peer_init(struct rxr_ep *ep, struct rxr_peer *peer)
 }
 
 struct rxr_rx_entry *rxr_ep_get_rx_entry(struct rxr_ep *ep,
-					 const struct iovec *iov,
-					 size_t iov_count, uint64_t tag,
-					 uint64_t ignore, void *context,
-					 fi_addr_t addr, uint32_t op,
+					 const struct fi_msg *msg,
+					 uint64_t tag,
+					 uint64_t ignore,
+					 uint32_t op,
 					 uint64_t flags);
 
 struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 					  struct rxr_rx_entry *rx_entry,
-					  const struct iovec *iov,
-					  size_t iov_count, uint64_t tag,
-					  uint64_t ignore, void *context,
-					  fi_addr_t addr, uint32_t op,
+					  const struct fi_msg *msg,
+					  uint64_t tag,
+					  uint64_t ignore,
+					  uint32_t op,
 					  uint64_t flags);
 
 void rxr_tx_entry_init(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry,

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -822,8 +822,8 @@ int rxr_ep_post_buf(struct rxr_ep *ep, uint64_t flags, enum rxr_lower_ep_type lo
 int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep,
 				 struct rxr_tx_entry *tx_entry);
 
-void rxr_inline_mr_reg(struct rxr_domain *rxr_domain,
-		       struct rxr_tx_entry *tx_entry);
+void rxr_prepare_mr_send(struct rxr_domain *rxr_domain,
+			 struct rxr_tx_entry *tx_entry);
 
 struct rxr_rx_entry *rxr_ep_lookup_mediumrtm_rx_entry(struct rxr_ep *ep,
 						      struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -438,8 +438,8 @@ struct rxr_tx_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
 	return tx_entry;
 }
 
-void rxr_inline_mr_reg(struct rxr_domain *rxr_domain,
-		       struct rxr_tx_entry *tx_entry)
+void rxr_prepare_mr_send(struct rxr_domain *rxr_domain,
+			 struct rxr_tx_entry *tx_entry)
 {
 	ssize_t ret;
 	size_t offset;
@@ -459,7 +459,8 @@ void rxr_inline_mr_reg(struct rxr_domain *rxr_domain,
 
 	tx_entry->iov_mr_start = index;
 	while (index < tx_entry->iov_count) {
-		if (tx_entry->iov[index].iov_len > rxr_env.max_memcpy_size) {
+		if (!tx_entry->desc[index]
+		    && tx_entry->iov[index].iov_len > rxr_env.max_memcpy_size) {
 			ret = fi_mr_reg(rxr_domain->rdm_domain,
 					tx_entry->iov[index].iov_base,
 					tx_entry->iov[index].iov_len,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -48,20 +48,20 @@
 
 struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 					  struct rxr_rx_entry *rx_entry,
-					  const struct iovec *iov,
-					  size_t iov_count, uint64_t tag,
-					  uint64_t ignore, void *context,
-					  fi_addr_t addr, uint32_t op,
+					  const struct fi_msg *msg,
+					  uint64_t tag,
+					  uint64_t ignore,
+					  uint32_t op,
 					  uint64_t flags)
 {
 	rx_entry->type = RXR_RX_ENTRY;
 	rx_entry->rx_id = ofi_buf_index(rx_entry);
-	rx_entry->addr = addr;
+	rx_entry->addr = msg->addr;
 	rx_entry->fi_flags = flags;
 	rx_entry->rxr_flags = 0;
 	rx_entry->bytes_done = 0;
 	rx_entry->window = 0;
-	rx_entry->iov_count = iov_count;
+	rx_entry->iov_count = msg->iov_count;
 	rx_entry->tag = tag;
 	rx_entry->op = op;
 	rx_entry->ignore = ignore;
@@ -72,13 +72,16 @@ struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 	memset(&rx_entry->cq_entry, 0, sizeof(rx_entry->cq_entry));
 
 	/* Handle case where we're allocating an unexpected rx_entry */
-	if (iov) {
-		memcpy(rx_entry->iov, iov, sizeof(*rx_entry->iov) * iov_count);
-		rx_entry->cq_entry.len = ofi_total_iov_len(iov, iov_count);
-		rx_entry->cq_entry.buf = iov[0].iov_base;
+	if (msg->msg_iov) {
+		memcpy(rx_entry->iov, msg->msg_iov, sizeof(*rx_entry->iov) * msg->iov_count);
+		rx_entry->cq_entry.len = ofi_total_iov_len(msg->msg_iov, msg->iov_count);
+		rx_entry->cq_entry.buf = msg->msg_iov[0].iov_base;
 	}
 
-	rx_entry->cq_entry.op_context = context;
+	if (msg->desc)
+		memcpy(&rx_entry->desc[0], msg->desc, sizeof(*msg->desc) * msg->iov_count);
+
+	rx_entry->cq_entry.op_context = msg->context;
 	rx_entry->cq_entry.tag = 0;
 	rx_entry->ignore = ~0;
 
@@ -114,10 +117,10 @@ struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 }
 
 struct rxr_rx_entry *rxr_ep_get_rx_entry(struct rxr_ep *ep,
-					 const struct iovec *iov,
-					 size_t iov_count, uint64_t tag,
-					 uint64_t ignore, void *context,
-					 fi_addr_t addr, uint32_t op,
+					 const struct fi_msg *msg,
+					 uint64_t tag,
+					 uint64_t ignore,
+					 uint32_t op,
 					 uint64_t flags)
 {
 	struct rxr_rx_entry *rx_entry;
@@ -131,8 +134,7 @@ struct rxr_rx_entry *rxr_ep_get_rx_entry(struct rxr_ep *ep,
 #if ENABLE_DEBUG
 	dlist_insert_tail(&rx_entry->rx_entry_entry, &ep->rx_entry_list);
 #endif
-	rx_entry = rxr_ep_rx_entry_init(ep, rx_entry, iov, iov_count, tag,
-					ignore, context, addr, op, flags);
+	rx_entry = rxr_ep_rx_entry_init(ep, rx_entry, msg, tag, ignore, op, flags);
 	rx_entry->state = RXR_RX_INIT;
 	rx_entry->op = op;
 	return rx_entry;
@@ -143,6 +145,7 @@ struct rxr_rx_entry *rxr_ep_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 {
 	struct rxr_rx_entry *rx_entry;
 	struct rxr_pkt_entry *unexp_pkt_entry;
+	struct fi_msg msg = {0};
 
 	unexp_pkt_entry = rxr_pkt_get_unexp(ep, pkt_entry_ptr);
 	if (OFI_UNLIKELY(!unexp_pkt_entry)) {
@@ -150,8 +153,8 @@ struct rxr_rx_entry *rxr_ep_alloc_unexp_rx_entry_for_msgrtm(struct rxr_ep *ep,
 		return NULL;
 	}
 
-	rx_entry = rxr_ep_get_rx_entry(ep, NULL, 0, 0, ~0, NULL,
-				       unexp_pkt_entry->addr, ofi_op_msg, 0);
+	msg.addr = unexp_pkt_entry->addr;
+	rx_entry = rxr_ep_get_rx_entry(ep, &msg, 0, ~0, ofi_op_msg, 0);
 	if (OFI_UNLIKELY(!rx_entry)) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "RX entries exhausted.\n");
 		return NULL;
@@ -171,6 +174,7 @@ struct rxr_rx_entry *rxr_ep_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 	uint64_t tag;
 	struct rxr_rx_entry *rx_entry;
 	struct rxr_pkt_entry *unexp_pkt_entry;
+	struct fi_msg msg = {0};
 
 	unexp_pkt_entry = rxr_pkt_get_unexp(ep, pkt_entry_ptr);
 	if (OFI_UNLIKELY(!unexp_pkt_entry)) {
@@ -179,8 +183,8 @@ struct rxr_rx_entry *rxr_ep_alloc_unexp_rx_entry_for_tagrtm(struct rxr_ep *ep,
 	}
 
 	tag = rxr_pkt_rtm_tag(unexp_pkt_entry);
-	rx_entry = rxr_ep_get_rx_entry(ep, NULL, 0, tag, ~0, NULL,
-				       unexp_pkt_entry->addr, ofi_op_tagged, 0);
+	msg.addr = unexp_pkt_entry->addr;
+	rx_entry = rxr_ep_get_rx_entry(ep, &msg, tag, ~0, ofi_op_tagged, 0);
 	if (OFI_UNLIKELY(!rx_entry)) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "RX entries exhausted.\n");
 		return NULL;
@@ -202,14 +206,16 @@ struct rxr_rx_entry *rxr_ep_split_rx_entry(struct rxr_ep *ep,
 	struct rxr_rx_entry *rx_entry;
 	size_t buf_len, consumed_len, data_len;
 	uint64_t tag;
+	struct fi_msg msg = {0};
 
 	assert(rxr_get_base_hdr(pkt_entry->pkt)->type >= RXR_REQ_PKT_BEGIN);
 	tag = 0;
 
 	if (!consumer_entry) {
-		rx_entry = rxr_ep_get_rx_entry(ep, posted_entry->iov,
-					       posted_entry->iov_count, tag,
-					       0, NULL, pkt_entry->addr, ofi_op_msg,
+		msg.msg_iov = posted_entry->iov;
+		msg.iov_count = posted_entry->iov_count;
+		msg.addr = pkt_entry->addr;
+		rx_entry = rxr_ep_get_rx_entry(ep, &msg, tag, 0, ofi_op_msg,
 					       posted_entry->fi_flags);
 		if (OFI_UNLIKELY(!rx_entry))
 			return NULL;
@@ -358,12 +364,10 @@ void rxr_tx_entry_init(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	dlist_init(&tx_entry->queued_pkts);
 
 	memcpy(&tx_entry->iov[0], msg->msg_iov, sizeof(struct iovec) * msg->iov_count);
+	memset(tx_entry->mr, 0, sizeof(*tx_entry->mr) * msg->iov_count);
 	if (msg->desc)
 		memcpy(&tx_entry->desc[0], msg->desc, sizeof(*msg->desc) * msg->iov_count);
-	else
-		memset(&tx_entry->desc[0], 0, sizeof(*msg->desc) * msg->iov_count);
 
-	memset(tx_entry->mr, 0, sizeof(*tx_entry->mr) * msg->iov_count);
 	/* set flags */
 	assert(ep->util_ep.tx_msg_flags == 0 ||
 	       ep->util_ep.tx_msg_flags == FI_COMPLETION);

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -520,12 +520,8 @@ int rxr_msg_handle_unexp_match(struct rxr_ep *ep,
  *    Returns 0 if the message is processed, -FI_ENOMSG if no match is found.
  */
 static
-int rxr_msg_proc_unexp_msg_list(struct rxr_ep *ep,
-				const struct iovec *iov,
-				size_t iov_count, uint64_t tag,
-				uint64_t ignore, void *context,
-				fi_addr_t addr, uint32_t op,
-				uint64_t flags,
+int rxr_msg_proc_unexp_msg_list(struct rxr_ep *ep, const struct fi_msg *msg,
+				uint64_t tag, uint64_t ignore, uint32_t op, uint64_t flags,
 				struct rxr_rx_entry *posted_entry)
 {
 	struct rxr_match_info match_info;
@@ -534,14 +530,14 @@ int rxr_msg_proc_unexp_msg_list(struct rxr_ep *ep,
 	int ret;
 
 	if (op == ofi_op_tagged) {
-		match_info.addr = addr;
+		match_info.addr = msg->addr;
 		match_info.tag = tag;
 		match_info.ignore = ignore;
 		match = dlist_remove_first_match(&ep->rx_unexp_tagged_list,
 						 &rxr_msg_match_unexp_tagged,
 						 (void *)&match_info);
 	} else {
-		match_info.addr = addr;
+		match_info.addr = msg->addr;
 		match = dlist_remove_first_match(&ep->rx_unexp_list,
 						 &rxr_msg_match_unexp,
 						 (void *)&match_info);
@@ -568,8 +564,8 @@ int rxr_msg_proc_unexp_msg_list(struct rxr_ep *ep,
 			return -FI_ENOBUFS;
 		}
 	} else {
-		memcpy(rx_entry->iov, iov, sizeof(*rx_entry->iov) * iov_count);
-		rx_entry->iov_count = iov_count;
+		memcpy(rx_entry->iov, msg->msg_iov, sizeof(*rx_entry->iov) * msg->iov_count);
+		rx_entry->iov_count = msg->iov_count;
 	}
 
 	FI_DBG(&rxr_prov, FI_LOG_EP_CTRL,
@@ -578,7 +574,7 @@ int rxr_msg_proc_unexp_msg_list(struct rxr_ep *ep,
 	       rx_entry->msg_id, rx_entry->total_len, rx_entry->tag);
 
 	ret = rxr_msg_handle_unexp_match(ep, rx_entry, tag, ignore,
-					 context, addr, op, flags);
+					 msg->context, msg->addr, op, flags);
 	return ret;
 }
 
@@ -614,15 +610,13 @@ void rxr_msg_multi_recv_free_posted_entry(struct rxr_ep *ep,
 }
 
 static
-ssize_t rxr_msg_multi_recv(struct rxr_ep *rxr_ep, const struct iovec *iov,
-			   size_t iov_count, fi_addr_t addr, uint64_t tag,
-			   uint64_t ignore, void *context, uint32_t op,
-			   uint64_t flags)
+ssize_t rxr_msg_multi_recv(struct rxr_ep *rxr_ep, const struct fi_msg *msg,
+			   uint64_t tag, uint64_t ignore, uint32_t op, uint64_t flags)
 {
 	struct rxr_rx_entry *rx_entry;
 	int ret = 0;
 
-	if ((ofi_total_iov_len(iov, iov_count)
+	if ((ofi_total_iov_len(msg->msg_iov, msg->iov_count)
 	     < rxr_ep->min_multi_recv_size) || op != ofi_op_msg)
 		return -FI_EINVAL;
 
@@ -632,11 +626,7 @@ ssize_t rxr_msg_multi_recv(struct rxr_ep *rxr_ep, const struct iovec *iov,
 	 * messages but will be used for tracking the application's buffer and
 	 * when to write the completion to release the buffer.
 	 */
-	rx_entry = rxr_ep_get_rx_entry(rxr_ep, iov, iov_count, tag,
-				       ignore, context,
-				       (rxr_ep->util_ep.caps &
-					FI_DIRECTED_RECV) ? addr :
-				       FI_ADDR_UNSPEC, op, flags);
+	rx_entry = rxr_ep_get_rx_entry(rxr_ep, msg, tag, ignore, op, flags);
 	if (OFI_UNLIKELY(!rx_entry)) {
 		rxr_ep_progress_internal(rxr_ep);
 		return -FI_EAGAIN;
@@ -647,12 +637,8 @@ ssize_t rxr_msg_multi_recv(struct rxr_ep *rxr_ep, const struct iovec *iov,
 	dlist_init(&rx_entry->multi_recv_entry);
 
 	while (!dlist_empty(&rxr_ep->rx_unexp_list)) {
-		ret = rxr_msg_proc_unexp_msg_list(rxr_ep, NULL, 0, tag,
-						  ignore, context,
-						  (rxr_ep->util_ep.caps
-						   & FI_DIRECTED_RECV) ?
-						   addr : FI_ADDR_UNSPEC,
-						  op, flags, rx_entry);
+		ret = rxr_msg_proc_unexp_msg_list(rxr_ep, msg, tag,
+						  ignore, op, flags, rx_entry);
 
 		if (!rxr_msg_multi_recv_buffer_available(rxr_ep, rx_entry)) {
 			/*
@@ -713,9 +699,8 @@ void rxr_msg_multi_recv_handle_completion(struct rxr_ep *ep,
  *     else add to posted recv list
  */
 static
-ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct iovec *iov,
-			     size_t iov_count, fi_addr_t addr, uint64_t tag,
-			     uint64_t ignore, void *context, uint32_t op,
+ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct fi_msg *msg,
+			     uint64_t tag, uint64_t ignore, uint32_t op,
 			     uint64_t flags)
 {
 	ssize_t ret = 0;
@@ -726,12 +711,12 @@ ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct iovec *iov,
 
 	FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
 	       "%s: iov_len: %lu tag: %lx ignore: %lx op: %x flags: %lx\n",
-	       __func__, ofi_total_iov_len(iov, iov_count), tag, ignore,
+	       __func__, ofi_total_iov_len(msg->msg_iov, msg->iov_count), tag, ignore,
 	       op, flags);
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 
-	assert(iov_count <= rxr_ep->rx_iov_limit);
+	assert(msg->iov_count <= rxr_ep->rx_iov_limit);
 
 	rxr_perfset_start(rxr_ep, perf_rxr_recv);
 
@@ -748,8 +733,7 @@ ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct iovec *iov,
 	}
 
 	if (flags & FI_MULTI_RECV) {
-		ret = rxr_msg_multi_recv(rxr_ep, iov, iov_count, addr, tag, ignore,
-					 context, op, flags);
+		ret = rxr_msg_multi_recv(rxr_ep, msg, tag, ignore, op, flags);
 		goto out;
 	}
 
@@ -757,23 +741,16 @@ ssize_t rxr_msg_generic_recv(struct fid_ep *ep, const struct iovec *iov,
 		     &rxr_ep->rx_unexp_list;
 
 	if (!dlist_empty(unexp_list)) {
-		ret = rxr_msg_proc_unexp_msg_list(rxr_ep, iov, iov_count, tag,
-						  ignore, context,
-						  (rxr_ep->util_ep.caps
-						   & FI_DIRECTED_RECV) ?
-						   addr : FI_ADDR_UNSPEC,
-						  op, flags, NULL);
+		ret = rxr_msg_proc_unexp_msg_list(rxr_ep, msg, tag,
+						  ignore, op, flags, NULL);
 
 		if (ret != -FI_ENOMSG)
 			goto out;
 		ret = 0;
 	}
 
-	rx_entry = rxr_ep_get_rx_entry(rxr_ep, iov, iov_count, tag,
-				       ignore, context,
-				       (rxr_ep->util_ep.caps &
-					FI_DIRECTED_RECV) ? addr :
-				       FI_ADDR_UNSPEC, op, flags);
+	rx_entry = rxr_ep_get_rx_entry(rxr_ep, msg, tag,
+				       ignore, op, flags);
 
 	if (OFI_UNLIKELY(!rx_entry)) {
 		ret = -FI_EAGAIN;
@@ -942,8 +919,7 @@ static
 ssize_t rxr_msg_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 			uint64_t flags)
 {
-	return rxr_msg_generic_recv(ep_fid, msg->msg_iov, msg->iov_count, msg->addr,
-				    0, 0, msg->context, ofi_op_msg, flags);
+	return rxr_msg_generic_recv(ep_fid, msg, 0, 0, ofi_op_msg, flags);
 }
 
 static
@@ -993,13 +969,19 @@ ssize_t rxr_msg_trecv(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 		      fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
 		      void *context)
 {
+	struct fi_msg msg;
 	struct iovec msg_iov;
 
 	msg_iov.iov_base = (void *)buf;
 	msg_iov.iov_len = len;
 
-	return rxr_msg_generic_recv(ep_fid, &msg_iov, 1, src_addr, tag, ignore,
-				    context, ofi_op_tagged, 0);
+	msg.msg_iov = &msg_iov;
+	msg.iov_count = 1;
+	msg.addr = src_addr;
+	msg.context = context;
+	msg.desc = &desc;
+
+	return rxr_msg_generic_recv(ep_fid, &msg, tag, ignore, ofi_op_tagged, 0);
 }
 
 static
@@ -1007,26 +989,39 @@ ssize_t rxr_msg_trecvv(struct fid_ep *ep_fid, const struct iovec *iov,
 		       void **desc, size_t count, fi_addr_t src_addr,
 		       uint64_t tag, uint64_t ignore, void *context)
 {
-	return rxr_msg_generic_recv(ep_fid, iov, count, src_addr, tag, ignore,
-				    context, ofi_op_tagged, 0);
+	struct fi_msg msg;
+
+	msg.msg_iov = iov;
+	msg.iov_count = count;
+	msg.addr = src_addr;
+	msg.desc = desc;
+	msg.context = context;
+
+	return rxr_msg_generic_recv(ep_fid, &msg, tag, ignore, ofi_op_tagged, 0);
 }
 
 static
-ssize_t rxr_msg_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
+ssize_t rxr_msg_trecvmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *tagmsg,
 			 uint64_t flags)
 {
 	ssize_t ret;
+	struct fi_msg msg;
 
 	if (flags & FI_PEEK) {
-		ret = rxr_msg_peek_trecv(ep_fid, msg, flags);
+		ret = rxr_msg_peek_trecv(ep_fid, tagmsg, flags);
 		goto out;
 	} else if (flags & FI_CLAIM) {
-		ret = rxr_msg_claim_trecv(ep_fid, msg, flags);
+		ret = rxr_msg_claim_trecv(ep_fid, tagmsg, flags);
 		goto out;
 	}
 
-	ret = rxr_msg_generic_recv(ep_fid, msg->msg_iov, msg->iov_count, msg->addr,
-				   msg->tag, msg->ignore, msg->context,
+	msg.msg_iov = tagmsg->msg_iov;
+	msg.iov_count = tagmsg->iov_count;
+	msg.addr = tagmsg->addr;
+	msg.desc = tagmsg->desc;
+	msg.context = tagmsg->context;
+
+	ret = rxr_msg_generic_recv(ep_fid, &msg, tagmsg->tag, tagmsg->ignore,
 				   ofi_op_tagged, flags);
 
 out:

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -186,6 +186,7 @@ ssize_t rxr_pkt_send_data_mr_cache(struct rxr_ep *ep,
 			 * Copies any consecutive small iov's, returning size
 			 * written while updating iov index and offset
 			 */
+
 			len = rxr_copy_from_iov((char *)data_pkt->data +
 						 pkt_used,
 						 remaining_len,

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -271,7 +271,7 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 	assert(tx_entry->window >= 0);
 	if (tx_entry->bytes_sent < tx_entry->total_len) {
 		if (efa_mr_cache_enable && rxr_ep_mr_local(ep))
-			rxr_inline_mr_reg(rxr_ep_domain(ep), tx_entry);
+			rxr_prepare_mr_send(rxr_ep_domain(ep), tx_entry);
 
 		tx_entry->state = RXR_TX_SEND;
 		dlist_insert_tail(&tx_entry->entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -421,8 +421,8 @@ void rxr_pkt_handle_long_rtm_sent(struct rxr_ep *ep,
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 
-	if (efa_mr_cache_enable && !tx_entry->desc[0])
-		rxr_inline_mr_reg(rxr_ep_domain(ep), tx_entry);
+	if (efa_mr_cache_enable)
+		rxr_prepare_mr_send(rxr_ep_domain(ep), tx_entry);
 }
 
 /*
@@ -1010,8 +1010,8 @@ void rxr_pkt_handle_long_rtw_sent(struct rxr_ep *ep,
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 
-	if (efa_mr_cache_enable && !tx_entry->desc[0])
-		rxr_inline_mr_reg(rxr_ep_domain(ep), tx_entry);
+	if (efa_mr_cache_enable)
+		rxr_prepare_mr_send(rxr_ep_domain(ep), tx_entry);
 }
 
 /*

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1048,9 +1048,10 @@ struct rxr_rx_entry *rxr_pkt_alloc_rtw_rx_entry(struct rxr_ep *ep,
 {
 	struct rxr_rx_entry *rx_entry;
 	struct rxr_base_hdr *base_hdr;
-	uint64_t tag = 0; /* RMA is not tagged */
+	struct fi_msg msg = {0};
 
-	rx_entry = rxr_ep_get_rx_entry(ep, NULL, 0, tag, 0, NULL, pkt_entry->addr, ofi_op_write, 0);
+	msg.addr = pkt_entry->addr;
+	rx_entry = rxr_ep_get_rx_entry(ep, &msg, 0, ~0, ofi_op_write, 0);
 	if (OFI_UNLIKELY(!rx_entry))
 		return NULL;
 
@@ -1322,13 +1323,14 @@ void rxr_pkt_handle_rtr_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	struct rxr_rx_entry *rx_entry;
 	struct rxr_tx_entry *tx_entry;
 	ssize_t err;
-	uint64_t tag = 0; /* RMA is not tagged */
+	struct fi_msg msg = {0};
 
 	if (ep->core_caps & FI_SOURCE)
 		rxr_pkt_post_connack(ep, rxr_ep_get_peer(ep, pkt_entry->addr),
 				     pkt_entry->addr);
 
-	rx_entry = rxr_ep_get_rx_entry(ep, NULL, 0, tag, 0, NULL, pkt_entry->addr, ofi_op_read_rsp, 0);
+	msg.addr = pkt_entry->addr;
+	rx_entry = rxr_ep_get_rx_entry(ep, &msg, 0, ~0, ofi_op_read_rsp, 0);
 	if (OFI_UNLIKELY(!rx_entry)) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"RX entries exhausted.\n");
@@ -1492,8 +1494,10 @@ struct rxr_rx_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pk
 {
 	struct rxr_rx_entry *rx_entry;
 	struct rxr_rta_hdr *rta_hdr;
+	struct fi_msg msg = {0};
 
-	rx_entry = rxr_ep_get_rx_entry(ep, NULL, 0, 0, 0, NULL, pkt_entry->addr, op, 0);
+	msg.addr = pkt_entry->addr;
+	rx_entry = rxr_ep_get_rx_entry(ep, &msg, 0, ~0, op, 0);
 	if (OFI_UNLIKELY(!rx_entry)) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"RX entries exhausted.\n");

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -184,15 +184,16 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 	int err, window, credits;
 	struct rxr_peer *peer;
 	struct rxr_rx_entry *rx_entry;
+	struct fi_msg msg = {0};
 
 	/* create a rx_entry to receve data
 	 * use ofi_op_msg for its op.
 	 * it does not write a rx completion.
 	 */
-	rx_entry = rxr_ep_get_rx_entry(ep, tx_entry->iov,
-				       tx_entry->iov_count,
-				       0, ~0, NULL,
-				       tx_entry->addr, ofi_op_msg, 0);
+	msg.msg_iov = tx_entry->iov;
+	msg.iov_count = tx_entry->iov_count;
+	msg.addr = tx_entry->addr;
+	rx_entry = rxr_ep_get_rx_entry(ep, &msg, 0, ~0, ofi_op_msg, 0);
 	if (!rx_entry) {
 		rxr_release_tx_entry(ep, tx_entry);
 		FI_WARN(&rxr_prov, FI_LOG_CQ,


### PR DESCRIPTION
Two commits in prep for FI_MR_HMEM.
```
commit d8c3b6c7395c310919244efda6517e791b343336 (HEAD -> mr-desc-updates, origin/recv-desc)
Author: Raghu Raja <craghun@amazon.com>
Date:   Mon Mar 9 17:35:05 2020 -0700

    prov/efa: Make rxr_inline_mr_reg() usable beyond the MR cache path

    The original rxr_inline_mr_reg() was written with the MR cache usage in
    mind and a world where the EFA provider did not require memory
    registrations, with the upper layer use pre-registered bounce buffers.
    In preparation for FI_MR_HMEM, this commit extends the function to be
    more useful beyond the inline registration. It can still walk the iov to
    register buffers inline, but will now do it only when a descriptor is
    not provided.

    Signed-off-by: Raghu Raja <craghun@amazon.com>
    Signed-off-by: Wei Zhang <wzam@amazon.com>

commit 16553728729d19bea599afd28a8deec03d6a8097
Author: Raghu Raja <craghun@amazon.com>
Date:   Mon Mar 9 17:37:21 2020 -0700

    prov/efa: Rework RX function signatures to propagate desc

    1e91d22 reworked the send-side function paths so that the registration
    descriptor did not get lost. This commit does the same for the
    receive-side, making sure an application-provided descriptor is used
    when available instead of falling back to bounce-buffers.

    Signed-off-by: Raghu Raja <craghun@amazon.com>
```