### PR TITLE
prov/efa: set random seed in init_lower_efa_prov()

### DIFF
--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -121,7 +121,6 @@ static int efa_ep_create_qp_ex(struct efa_ep *ep,
 	}
 
 	qp->ibv_qp_ex = ibv_qp_to_qp_ex(qp->ibv_qp);
-	srandom(time(NULL));
 	qp->qkey = random() & 0x7fffffff;
 	err = efa_ep_modify_qp_rst2rts(qp);
 	if (err)

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -39,6 +39,8 @@
 
 #include <netdb.h>
 #include <inttypes.h>
+#include <sys/time.h>
+#include <stdlib.h>
 
 #include <infiniband/efadv.h>
 
@@ -1014,8 +1016,19 @@ static int efa_init_info(const struct fi_info **all_infos)
 
 struct fi_provider *init_lower_efa_prov()
 {
+	int err;
+	struct timeval tv;
+	struct timezone tz;
+
 	if (efa_init_info(&efa_util_prov.info))
 		return NULL;
 
+	err = gettimeofday(&tv, &tz);
+	if (err) {
+		EFA_WARN(FI_LOG_FABRIC, "Unable to get time, which is used as random seed.\n");
+		return NULL;
+	}
+
+	srandom(tv.tv_usec);
 	return &efa_prov;
 }


### PR DESCRIPTION
We call random() to generate qkey. Currently we set random seed
before calling random(), and use time() as seed, which lead to
same seed if two QP was generated at same second.

This patch address the issue by moving srandom() to
init_lower_efa_prov() and use tv_usec from gettimeofday() to
avoid getting same seed.

Signed-off-by: Wei Zhang <wzam@amazon.com>