### PR TITLE
prov/efa: introduce function efa_generate_qkey()

### DIFF
--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -32,11 +32,33 @@
  */
 
 #include "config.h"
-
 #include "efa.h"
 
+#include <sys/time.h>
 #include <infiniband/efadv.h>
 #define EFA_CQ_PROGRESS_ENTRIES 500
+
+static int efa_generate_qkey()
+{
+	struct timeval tv;
+	struct timezone tz;
+	uint32_t val;
+	int err;
+
+	err = gettimeofday(&tv, &tz);
+	if (err) {
+		EFA_WARN(FI_LOG_EP_CTRL, "Cannot gettimeofday, err=%d.\n", err);
+		return 0;
+	}
+
+	/* tv_usec is in range [0,1,000,000), shift it by 12 to [0,4,096,000,000 */
+	val = (tv.tv_usec << 12) + tv.tv_sec;
+
+	/* 0x80000000 and up is privileged Q Key range. */
+	val &= 0x7fffffff;
+
+	return val;
+}
 
 static int efa_ep_destroy_qp(struct efa_qp *qp)
 {
@@ -121,8 +143,7 @@ static int efa_ep_create_qp_ex(struct efa_ep *ep,
 	}
 
 	qp->ibv_qp_ex = ibv_qp_to_qp_ex(qp->ibv_qp);
-	srandom(time(NULL));
-	qp->qkey = random() & 0x7fffffff;
+	qp->qkey = efa_generate_qkey();
 	err = efa_ep_modify_qp_rst2rts(qp);
 	if (err)
 		goto err_destroy_qp;


### PR DESCRIPTION
Currently Q Key is generated by calling srandom(time(NULL)) then
calling random(). However, it has been pointed out by @sydidelot
that calling srandom() might in some case change application behavior:

     https://github.com/ofiwg/libfabric/pull/5744
     https://github.com/open-mpi/ompi/issues/1877
     https://github.com/pmodels/mpich/pull/2997

This patch address the issue by generating Q Key using gettimeofday
result, which set qkey to

       (tv.tv_usec << 12) + tv.tv_sec

and do not call srandom()

Signed-off-by: Wei Zhang <wzam@amazon.com>