### PR TITLE
prov/verbs: Add check against domain name

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -252,6 +252,13 @@ static int fi_ibv_check_hints(uint32_t version, const struct fi_info *hints,
 	}
 
 	if (hints->domain_attr) {
+		if (hints->domain_attr->name &&
+		    strcasecmp(hints->domain_attr->name, info->domain_attr->name)) {
+			VERBS_INFO(FI_LOG_CORE, "skipping device %s (want %s)\n",
+				   info->domain_attr->name, hints->domain_attr->name);
+			return -FI_ENODATA;
+		}
+
 		ret = ofi_check_domain_attr(&fi_ibv_prov, version,
 					    info->domain_attr,
 					    hints);


### PR DESCRIPTION
Commit 77b79ae removed the domain name check from the util
code in order to handle dynamically named domains (e.g. tcp
and udp providers).  However, verbs needs this check when
multiple devices are present, or we can match with the
incorrect device.  (Verbs forms a list of all valid domains
during initialization).  Add back in the check but directly
in the verbs code when it's searching its saved fi_info domain
list.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>