### PR TITLE
prov/efa: Handling CUDA buffers in send/recv paths (new)

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -100,8 +100,11 @@ const struct fi_domain_attr efa_domain_attr = {
 	.control_progress	= FI_PROGRESS_AUTO,
 	.data_progress		= FI_PROGRESS_AUTO,
 	.resource_mgmt		= FI_RM_DISABLED,
-
+#ifdef HAVE_LIBCUDA
+	.mr_mode		= OFI_MR_BASIC_MAP | FI_MR_LOCAL | FI_MR_BASIC | FI_MR_HMEM,
+#else
 	.mr_mode		= OFI_MR_BASIC_MAP | FI_MR_LOCAL | FI_MR_BASIC,
+#endif
 	.mr_key_size		= sizeof_field(struct ibv_sge, lkey),
 	.cq_data_size		= 0,
 	.tx_ctx_cnt		= 1024,

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -267,7 +267,7 @@ static int efa_mr_reg_impl(struct efa_mr *efa_mr, uint64_t flags, void *attr)
 		return -errno;
 	}
 
-	efa_mr->mr_fid.mem_desc = efa_mr->ibv_mr;
+	efa_mr->mr_fid.mem_desc = efa_mr;
 	efa_mr->mr_fid.key = efa_mr->ibv_mr->rkey;
 	efa_mr->peer.iface = mr_attr->iface;
 	if (mr_attr->iface == FI_HMEM_CUDA)

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -125,7 +125,7 @@ static ssize_t efa_post_recv_validate(struct efa_ep *ep, const struct fi_msg *ms
 
 static ssize_t efa_post_recv(struct efa_ep *ep, const struct fi_msg *msg, uint64_t flags)
 {
-	struct ibv_mr *ibv_mr;
+	struct efa_mr *efa_mr;
 	struct efa_qp *qp = ep->qp;
 	struct ibv_recv_wr *bad_wr;
 	struct efa_recv_wr *ewr;
@@ -158,8 +158,8 @@ static ssize_t efa_post_recv(struct efa_ep *ep, const struct fi_msg *msg, uint64
 		/* Set RX buffer desc from SGE */
 		wr->sg_list[i].length = msg->msg_iov[i].iov_len;
 		assert(msg->desc[i]);
-		ibv_mr = (struct ibv_mr *)msg->desc[i];
-		wr->sg_list[i].lkey = ibv_mr->lkey;
+		efa_mr = (struct efa_mr *)msg->desc[i];
+		wr->sg_list[i].lkey = efa_mr->ibv_mr->lkey;
 		wr->sg_list[i].addr = addr;
 	}
 
@@ -251,7 +251,7 @@ static ssize_t efa_post_send_validate(struct efa_ep *ep, const struct fi_msg *ms
 static void efa_post_send_sgl(struct efa_ep *ep, const struct fi_msg *msg,
 			      struct efa_send_wr *ewr)
 {
-	struct ibv_mr *ibv_mr;
+	struct efa_mr *efa_mr;
 	struct ibv_send_wr *wr = &ewr->wr;
 	struct ibv_sge *sge;
 	size_t sgl_idx = 0;
@@ -280,8 +280,8 @@ static void efa_post_send_sgl(struct efa_ep *ep, const struct fi_msg *msg,
 		/* Set TX buffer desc from SGE */
 		sge->length = length;
 		assert (msg->desc && msg->desc[i]);
-		ibv_mr = (struct ibv_mr *)msg->desc[i];
-		sge->lkey = ibv_mr->lkey;
+		efa_mr = (struct efa_mr *)msg->desc[i];
+		sge->lkey = efa_mr->ibv_mr->lkey;
 		sge->addr = addr;
 		sgl_idx++;
 	}

--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -41,7 +41,7 @@ static
 ssize_t efa_rma_post_read(struct efa_ep *ep, const struct fi_msg_rma *msg, uint64_t flags)
 {
 	struct efa_qp *qp;
-	struct ibv_mr *ibv_mr;
+	struct efa_mr *efa_mr;
 	struct efa_conn *conn;
 	struct ibv_sge sge_list[msg->iov_count];
 	int i;
@@ -75,8 +75,8 @@ ssize_t efa_rma_post_read(struct efa_ep *ep, const struct fi_msg_rma *msg, uint6
 		sge_list[i].addr = (uint64_t)msg->msg_iov[i].iov_base;
 		sge_list[i].length = msg->msg_iov[i].iov_len;
 		assert(msg->desc[i]);
-		ibv_mr = (struct ibv_mr *)msg->desc[i];
-		sge_list[i].lkey = ibv_mr->lkey;
+		efa_mr = (struct efa_mr *)msg->desc[i];
+		sge_list[i].lkey = efa_mr->ibv_mr->lkey;
 	}
 
 	ibv_wr_set_sge_list(qp->ibv_qp_ex, msg->iov_count, sge_list);

--- a/prov/efa/src/rxr/efa_cuda.h
+++ b/prov/efa/src/rxr/efa_cuda.h
@@ -83,4 +83,27 @@ size_t rxr_copy_from_tx(void *buf, size_t tocopy,
 	return data_size;
 }
 
+static inline
+size_t rxr_copy_to_rx(void *data, size_t tocopy, struct rxr_rx_entry *rx_entry, size_t offset)
+{
+	size_t data_size;
+#ifdef HAVE_LIBCUDA
+	if (rxr_ep_is_cuda_mr(rx_entry->desc[0]))
+		data_size = ofi_copy_to_cuda_iov(rx_entry->iov,
+						 rx_entry->iov_count,
+						 offset,
+						 data,
+						 tocopy);
+	else
+#endif
+		data_size = ofi_copy_to_iov(rx_entry->iov,
+					    rx_entry->iov_count,
+					    offset,
+					    data,
+					    tocopy);
+
+	return data_size;
+}
+
+
 #endif /* _EFA_CUDA_H_ */

--- a/prov/efa/src/rxr/efa_cuda.h
+++ b/prov/efa/src/rxr/efa_cuda.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#ifndef _EFA_CUDA_H_
+#define _EFA_CUDA_H_
+
+#include "efa.h"
+#include "rxr.h"
+
+#ifdef HAVE_LIBCUDA
+
+#include <ofi_cuda.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+static inline bool rxr_ep_is_cuda_mr(struct efa_mr *efa_mr)
+{
+	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA): false;
+}
+
+#else
+
+static inline bool rxr_ep_is_cuda_mr(struct efa_mr *efa_mr)
+{
+	return false;
+}
+
+#endif /* HAVE_LIBCUDA */
+
+static inline
+size_t rxr_copy_from_tx(void *buf, size_t tocopy,
+			struct rxr_tx_entry *tx_entry, size_t offset)
+{
+	size_t data_size;
+
+#ifdef HAVE_LIBCUDA
+	if (rxr_ep_is_cuda_mr(tx_entry->desc[0]))
+		data_size = ofi_copy_from_cuda_iov(buf,
+						   tocopy,
+						   tx_entry->iov,
+						   tx_entry->iov_count,
+						   offset);
+       else
+#endif
+		data_size = ofi_copy_from_iov(buf,
+					      tocopy,
+					      tx_entry->iov,
+					      tx_entry->iov_count,
+					      offset);
+	return data_size;
+}
+
+#endif /* _EFA_CUDA_H_ */

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -843,10 +843,12 @@ int rxr_ep_post_buf(struct rxr_ep *ep, uint64_t flags, enum rxr_lower_ep_type lo
 int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep,
 				 struct rxr_tx_entry *tx_entry);
 
-int rxr_ep_tx_init_mr_desc(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+int rxr_ep_tx_init_mr_desc(struct rxr_domain *rxr_domain,
+			   struct rxr_tx_entry *tx_entry,
 			   int mr_iov_start, uint64_t access);
 
-void rxr_prepare_mr_send(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry);
+void rxr_prepare_desc_send(struct rxr_domain *rxr_domain,
+			   struct rxr_tx_entry *tx_entry);
 
 struct rxr_rx_entry *rxr_ep_lookup_mediumrtm_rx_entry(struct rxr_ep *ep,
 						      struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_attr.c
+++ b/prov/efa/src/rxr/rxr_attr.c
@@ -37,9 +37,16 @@
 const uint32_t rxr_poison_value = 0xdeadbeef;
 #endif
 
-#define RXR_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | FI_ATOMIC)
+#ifdef HAVE_LIBCUDA
+#define EFA_HMEM_CAP FI_HMEM
+#else
+#define EFA_HMEM_CAP 0
+#endif
+#define RXR_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | \
+		     FI_ATOMIC | EFA_HMEM_CAP)
 #define RXR_RX_CAPS (OFI_RX_MSG_CAPS | FI_TAGGED | OFI_RX_RMA_CAPS | \
-		     FI_SOURCE | FI_MULTI_RECV | FI_DIRECTED_RECV | FI_ATOMIC)
+		     FI_SOURCE | FI_MULTI_RECV | FI_DIRECTED_RECV | \
+		     FI_ATOMIC | EFA_HMEM_CAP)
 #define RXR_DOM_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM)
 
 /* TODO: Add support for true FI_DELIVERY_COMPLETE */

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -107,6 +107,9 @@ int rxr_mr_regattr(struct fid *domain_fid, const struct fi_mr_attr *attr,
 	rxr_domain = container_of(domain_fid, struct rxr_domain,
 				  util_domain.domain_fid.fid);
 
+	if (attr->iface == FI_HMEM_CUDA)
+		flags |= OFI_MR_NOCACHE;
+
 	ret = fi_mr_regattr(rxr_domain->rdm_domain, attr, flags, mr);
 	if (ret) {
 		FI_WARN(&rxr_prov, FI_LOG_MR,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -80,6 +80,8 @@ struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 
 	if (msg->desc)
 		memcpy(&rx_entry->desc[0], msg->desc, sizeof(*msg->desc) * msg->iov_count);
+	else
+		memset(&rx_entry->desc[0], 0, sizeof(rx_entry->desc));
 
 	rx_entry->cq_entry.op_context = msg->context;
 	rx_entry->cq_entry.tag = 0;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -440,7 +440,8 @@ struct rxr_tx_entry *rxr_ep_alloc_tx_entry(struct rxr_ep *rxr_ep,
 	return tx_entry;
 }
 
-int rxr_ep_tx_init_mr_desc(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+int rxr_ep_tx_init_mr_desc(struct rxr_domain *rxr_domain,
+			   struct rxr_tx_entry *tx_entry,
 			   int mr_iov_start, uint64_t access)
 {
 	int i, err, ret;
@@ -457,7 +458,7 @@ int rxr_ep_tx_init_mr_desc(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 			continue;
 		}
 
-		err = fi_mr_reg(rxr_ep_domain(ep)->rdm_domain,
+		err = fi_mr_reg(rxr_domain->rdm_domain,
 				tx_entry->iov[i].iov_base,
 				tx_entry->iov[i].iov_len,
 				access, 0, 0, 0,
@@ -478,7 +479,8 @@ int rxr_ep_tx_init_mr_desc(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	return ret;
 }
 
-void rxr_prepare_mr_send(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
+void rxr_prepare_desc_send(struct rxr_domain *rxr_domain,
+			   struct rxr_tx_entry *tx_entry)
 {
 	size_t offset;
 	int index;
@@ -500,7 +502,7 @@ void rxr_prepare_mr_send(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	 * because the long message protocol would work with or without
 	 * memory registration and descriptor.
 	 */
-	rxr_ep_tx_init_mr_desc(ep, tx_entry, index, FI_SEND);
+	rxr_ep_tx_init_mr_desc(rxr_domain, tx_entry, index, FI_SEND);
 }
 
 /* Generic send */

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -101,7 +101,8 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 * because medium message works even if MR registration failed
 		 */
 		if (efa_mr_cache_enable)
-			rxr_ep_tx_init_mr_desc(rxr_ep, tx_entry, 0, FI_SEND);
+			rxr_ep_tx_init_mr_desc(rxr_ep_domain(rxr_ep),
+					       tx_entry, 0, FI_SEND);
 		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
 						  RXR_MEDIUM_MSGRTM_PKT + tagged, 0);
 	}

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -597,6 +597,9 @@ int rxr_msg_proc_unexp_msg_list(struct rxr_ep *ep, const struct fi_msg *msg,
 		rx_entry->iov_count = msg->iov_count;
 	}
 
+	if (msg->desc)
+		memcpy(rx_entry->desc, msg->desc, sizeof(void*) * msg->iov_count);
+
 	FI_DBG(&rxr_prov, FI_LOG_EP_CTRL,
 	       "Match found in unexp list for a posted recv msg_id: %" PRIu32
 	       " total_len: %" PRIu64 " tag: %lx\n",

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -34,6 +34,7 @@
 #include "efa.h"
 #include "rxr.h"
 #include "rxr_cntr.h"
+#include "efa_cuda.h"
 
 /* This file implements 4 actions that can be applied to a packet:
  *          posting,
@@ -72,8 +73,15 @@ ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep,
 	 */
 	data_pkt->hdr.seg_offset = tx_entry->bytes_sent;
 
-	if (efa_mr_cache_enable)
-		ret = rxr_pkt_send_data_mr_cache(rxr_ep, tx_entry, pkt_entry);
+	/*
+	 * TODO: Check to see if underlying device can support CUDA
+	 * registrations and fallback to rxr_ep_send_data_pkt_entry() if it does
+	 * not. This should be done at init time with a CUDA reg-and-fail flag.
+	 * For now, always send CUDA buffers through
+	 * rxr_pkt_send_data_desc().
+	 */
+	if (efa_mr_cache_enable || rxr_ep_is_cuda_mr(tx_entry->desc[0]))
+		ret = rxr_pkt_send_data_desc(rxr_ep, tx_entry, pkt_entry);
 	else
 		ret = rxr_pkt_send_data(rxr_ep, tx_entry, pkt_entry);
 

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -230,9 +230,9 @@ ssize_t rxr_pkt_send_data(struct rxr_ep *ep,
 			  struct rxr_tx_entry *tx_entry,
 			  struct rxr_pkt_entry *pkt_entry);
 
-ssize_t rxr_pkt_send_data_mr_cache(struct rxr_ep *ep,
-				   struct rxr_tx_entry *tx_entry,
-				   struct rxr_pkt_entry *pkt_entry);
+ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
+			       struct rxr_tx_entry *tx_entry,
+			       struct rxr_pkt_entry *pkt_entry);
 
 int rxr_pkt_proc_data(struct rxr_ep *ep,
 		      struct rxr_rx_entry *rx_entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -242,8 +242,8 @@ int rxr_pkt_proc_data(struct rxr_ep *ep,
 	/* we are sinking message for CANCEL/DISCARD entry */
 	if (OFI_LIKELY(!(rx_entry->rxr_flags & RXR_RECV_CANCEL)) &&
 	    rx_entry->cq_entry.len > seg_offset) {
-		bytes_copied = ofi_copy_to_iov(rx_entry->iov, rx_entry->iov_count,
-					       seg_offset, data, seg_size);
+		bytes_copied = rxr_copy_to_rx(data, seg_size, rx_entry, seg_offset);
+
 		if (bytes_copied != MIN(seg_size, rx_entry->cq_entry.len - seg_offset)) {
 			FI_WARN(&rxr_prov, FI_LOG_CQ, "wrong size! bytes_copied: %ld\n",
 				bytes_copied);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -32,6 +32,7 @@
  */
 
 #include "efa.h"
+#include "efa_cuda.h"
 #include "rxr.h"
 #include "rxr_msg.h"
 #include "rxr_cntr.h"
@@ -278,8 +279,9 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 	tx_entry->window -= data_len;
 	assert(tx_entry->window >= 0);
 	if (tx_entry->bytes_sent < tx_entry->total_len) {
+		assert(!rxr_ep_is_cuda_mr(tx_entry->desc[0]));
 		if (efa_mr_cache_enable && rxr_ep_mr_local(ep))
-			rxr_prepare_mr_send(ep, tx_entry);
+			rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 
 		tx_entry->state = RXR_TX_SEND;
 		dlist_insert_tail(&tx_entry->entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -38,6 +38,7 @@
 #include "rxr_msg.h"
 #include "rxr_pkt_cmd.h"
 #include "rxr_read.h"
+#include "efa_cuda.h"
 
 /*
  * Utility constants and funnctions shared by all REQ packe
@@ -274,9 +275,7 @@ void rxr_pkt_data_from_tx(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry,
 	assert(pkt_entry->hdr_size > 0);
 	if (!tx_entry->desc[tx_iov_index]) {
 		data = (char *)pkt_entry->pkt + pkt_entry->hdr_size;
-		data_size = ofi_copy_from_iov(data, data_size, tx_entry->iov,
-					      tx_entry->iov_count, data_offset);
-
+		data_size = rxr_copy_from_tx(data, data_size, tx_entry, data_offset);
 		pkt_entry->iov_count = 0;
 		pkt_entry->pkt_size = pkt_entry->hdr_size + data_size;
 		return;
@@ -477,8 +476,8 @@ void rxr_pkt_handle_long_rtm_sent(struct rxr_ep *ep,
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 
-	if (efa_mr_cache_enable)
-		rxr_prepare_mr_send(ep, tx_entry);
+	if (efa_mr_cache_enable || rxr_ep_is_cuda_mr(tx_entry->desc[0]))
+		rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 }
 
 /*
@@ -1130,9 +1129,8 @@ void rxr_pkt_handle_long_rtw_sent(struct rxr_ep *ep,
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
-
-	if (efa_mr_cache_enable)
-		rxr_prepare_mr_send(ep, tx_entry);
+	if (efa_mr_cache_enable || rxr_ep_is_cuda_mr(tx_entry->desc[0]))
+		rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 }
 
 /*

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -225,8 +225,7 @@ size_t rxr_pkt_req_copy_data(struct rxr_rx_entry *rx_entry,
 	size_t bytes_copied;
 	int bytes_left;
 
-	bytes_copied = ofi_copy_to_iov(rx_entry->iov, rx_entry->iov_count,
-				       0, data, data_size);
+	bytes_copied = rxr_copy_to_rx(data, data_size, rx_entry, 0);
 
 	if (OFI_UNLIKELY(bytes_copied < data_size)) {
 		/* recv buffer is not big enough to hold req, this must be a truncated message */
@@ -751,7 +750,7 @@ ssize_t rxr_pkt_proc_matched_medium_rtm(struct rxr_ep *ep,
 		data = (char *)cur->pkt + cur->hdr_size;
 		offset = rxr_get_medium_rtm_base_hdr(cur->pkt)->offset;
 		data_size = cur->pkt_size - cur->hdr_size;
-		ofi_copy_to_iov(rx_entry->iov, rx_entry->iov_count, offset, data, data_size);
+		rxr_copy_to_rx(data, data_size, rx_entry, offset);
 		rx_entry->bytes_done += data_size;
 		cur = cur->next;
 	}

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -129,7 +129,7 @@ struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, int entry_type, v
 		read_entry->rma_iov_count = rx_entry->rma_iov_count;
 		read_entry->rma_iov = rx_entry->rma_iov;
 
-		mr_desc = NULL;
+		mr_desc = rx_entry->desc;
 		total_iov_len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
 		total_rma_iov_len = ofi_total_rma_iov_len(rx_entry->rma_iov, rx_entry->rma_iov_count);
 		read_entry->total_len = MIN(total_iov_len, total_rma_iov_len);


### PR DESCRIPTION
This is the update of 

https://github.com/ofiwg/libfabric/pull/5742

What I did is address the comments from myself and Robert:

1. Introduced helper function rxr_copy_from_tx() and rxr_copy_to_rx() to wrap rxr_cuda_copy_iov.

2. rename rxr_pkt_send_data_mr_cache to rxr_pkt_send_data_desc() and rxr_prepare_mr_send to rxr_prepare_desc_send() .