### PR TITLE
prov/efa: Use the default cache monitor

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -204,7 +204,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		domain->cache.entry_data_size = sizeof(struct efa_mr);
 		domain->cache.add_region = efa_mr_cache_entry_reg;
 		domain->cache.delete_region = efa_mr_cache_entry_dereg;
-		ret = ofi_mr_cache_init(&domain->util_domain, uffd_monitor,
+		ret = ofi_mr_cache_init(&domain->util_domain, default_monitor,
 					&domain->cache);
 		if (!ret) {
 			domain->util_domain.domain_fid.mr = &efa_domain_mr_cache_ops;


### PR DESCRIPTION
We have seen MR cache initialization failure in container,
because userfaultfd syscall is blocked by default.
Switch to the default cache monitor (memhooks), so that
MR cache can still be enabled in container.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>