### PR TITLE
prov/efa: call rxr_pkt_insert_addr() if REQ packet contain raw address

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -181,6 +181,8 @@ void rxr_pkt_proc_req_common_hdr(struct rxr_pkt_entry *pkt_entry)
 		raw_addr_hdr = (struct rxr_req_opt_raw_addr_hdr *)opt_hdr;
 		pkt_entry->raw_addr = raw_addr_hdr->raw_addr;
 		opt_hdr += sizeof(*raw_addr_hdr) + raw_addr_hdr->addr_len;
+	} else {
+		pkt_entry->raw_addr = NULL;
 	}
 
 	if (base_hdr->flags & RXR_REQ_OPT_CQ_DATA_HDR) {


### PR DESCRIPTION
Currently rxr_pkt_insert_addr() is called only when the source address
is FI_ADDR_UNAVAIL, this behavior will cause problem when the packet
is from a newly created EP with the same GID and QP of a previous one.

This patch address the issue by calling rxr_pkt_insert_addr() as long
as incoming REQ packet contains raw address in the header.

Signed-off-by: Wei Zhang <wzam@amazon.com>