### PR TITLE
prov/efa: fix a bug in rxr_cq_handle_cq_error()

### DIFF
--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -326,7 +326,7 @@ int rxr_cq_handle_cq_error(struct rxr_ep *ep, ssize_t err)
 	}
 
 	ret = fi_cq_readerr(ep->rdm_cq, &err_entry, 0);
-	if (ret != sizeof(err_entry)) {
+	if (ret != 1) {
 		if (ret < 0) {
 			FI_WARN(&rxr_prov, FI_LOG_CQ, "fi_cq_readerr: %s\n",
 				fi_strerror(-ret));


### PR DESCRIPTION
Currently rxr_cq_handle_cq_error() is checking the return of
fi_cq_readerr() against sizeof(fi_cq_err_entry), which is wrong
because fi_cq_readerr() should return either a negative error
code or number of entries it retrived.

This patch fix the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>