### PR TITLE
man/index: Add links to missing man pages in v1.9.x

### DIFF
--- a/v1.9.0/man/index.md
+++ b/v1.9.0/man/index.md
@@ -18,9 +18,11 @@ v1.9.0](https://github.com/ofiwg/libfabric/releases/tag/v1.9.0).
 * API documentation
   * [fi_atomic(3)](fi_atomic.3.html)
   * [fi_av(3)](fi_av.3.html)
+  * [fi_av_set(3)](fi_av_set.3.html)
   * [fi_cm(3)](fi_cm.3.html)
-  * [fi_control(3)](fi_control.3.html)
   * [fi_cntr(3)](fi_cntr.3.html)
+  * [fi_collective(3)](fi_collective.3.html)
+  * [fi_control(3)](fi_control.3.html)
   * [fi_cq(3)](fi_cq.3.html)
   * [fi_domain(3)](fi_domain.3.html)
   * [fi_endpoint(3)](fi_endpoint.3.html)

--- a/v1.9.1/man/index.md
+++ b/v1.9.1/man/index.md
@@ -18,9 +18,11 @@ v1.9.1](https://github.com/ofiwg/libfabric/releases/tag/v1.9.1).
 * API documentation
   * [fi_atomic(3)](fi_atomic.3.html)
   * [fi_av(3)](fi_av.3.html)
+  * [fi_av_set(3)](fi_av_set.3.html)
   * [fi_cm(3)](fi_cm.3.html)
-  * [fi_control(3)](fi_control.3.html)
   * [fi_cntr(3)](fi_cntr.3.html)
+  * [fi_collective(3)](fi_collective.3.html)
+  * [fi_control(3)](fi_control.3.html)
   * [fi_cq(3)](fi_cq.3.html)
   * [fi_domain(3)](fi_domain.3.html)
   * [fi_endpoint(3)](fi_endpoint.3.html)


### PR DESCRIPTION
Signed-off-by: Sean Hefty <sean.hefty@intel.com>