### PR TITLE
core: Ignore invalid caps in ofi_check_attr_subset

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -81,6 +81,15 @@ extern "C" {
 #define OFI_ORDER_WAW_SET	(FI_ORDER_WAW | FI_ORDER_RMA_WAW | \
 				 FI_ORDER_ATOMIC_WAW)
 
+#define OFI_IGNORED_TX_CAPS /* older Rx caps not applicable to Tx */ \
+	(FI_REMOTE_READ | FI_REMOTE_WRITE | FI_RECV | FI_DIRECTED_RECV | \
+	 FI_VARIABLE_MSG | FI_MULTI_RECV | FI_SOURCE | FI_RMA_EVENT | \
+	 FI_SOURCE_ERR)
+#define OFI_IGNORED_RX_CAPS /* Older Tx caps not applicable to Rx */ \
+	(FI_READ | FI_WRITE | FI_SEND | FI_FENCE | FI_MULTICAST | \
+	 FI_NAMED_RX_CTX)
+
+
 #define sizeof_field(type, field) sizeof(((type *)0)->field)
 
 #ifndef MIN

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -1121,9 +1121,11 @@ static int sock_ep_tx_ctx(struct fid_ep *ep, int index, struct fi_tx_attr *attr,
 	if (attr) {
 		if (ofi_check_tx_attr(&sock_prov, sock_ep->attr->info.tx_attr,
 				      attr, 0) ||
-			ofi_check_attr_subset(&sock_prov,
-				sock_ep->attr->info.tx_attr->caps, attr->caps))
+		    ofi_check_attr_subset(&sock_prov,
+					  sock_ep->attr->info.tx_attr->caps,
+					  attr->caps & ~OFI_IGNORED_TX_CAPS)) {
 			return -FI_ENODATA;
+		}
 		tx_ctx = sock_tx_ctx_alloc(attr, context, 0);
 	} else {
 		tx_ctx = sock_tx_ctx_alloc(&sock_ep->tx_attr, context, 0);
@@ -1166,9 +1168,10 @@ static int sock_ep_rx_ctx(struct fid_ep *ep, int index, struct fi_rx_attr *attr,
 
 	if (attr) {
 		if (ofi_check_rx_attr(&sock_prov, &sock_ep->attr->info, attr, 0) ||
-			ofi_check_attr_subset(&sock_prov, sock_ep->attr->info.rx_attr->caps,
-				attr->caps))
+		    ofi_check_attr_subset(&sock_prov, sock_ep->attr->info.rx_attr->caps,
+					  attr->caps & ~OFI_IGNORED_RX_CAPS)) {
 			return -FI_ENODATA;
+		}
 		rx_ctx = sock_rx_ctx_alloc(attr, context, 0);
 	} else {
 		rx_ctx = sock_rx_ctx_alloc(&sock_ep->rx_attr, context, 0);

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -40,14 +40,6 @@
 #define OFI_RMA_DIRECTION_CAPS	(FI_READ | FI_WRITE | \
 				 FI_REMOTE_READ | FI_REMOTE_WRITE)
 
-#define OFI_IGNORED_TX_CAPS /* older Rx caps not applicable to Tx */ \
-	(FI_REMOTE_READ | FI_REMOTE_WRITE | FI_RECV | FI_DIRECTED_RECV | \
-	 FI_VARIABLE_MSG | FI_MULTI_RECV | FI_SOURCE | FI_RMA_EVENT | \
-	 FI_SOURCE_ERR)
-#define OFI_IGNORED_RX_CAPS /* Older Tx caps not applicable to Rx */ \
-	(FI_READ | FI_WRITE | FI_SEND | FI_FENCE | FI_MULTICAST | \
-	 FI_NAMED_RX_CTX)
-
 static int fi_valid_addr_format(uint32_t prov_format, uint32_t user_format)
 {
 	if (user_format == FI_FORMAT_UNSPEC || prov_format == FI_FORMAT_UNSPEC)


### PR DESCRIPTION
If the wrong tx/rx caps have been set (rx-only as a tx cap, and
vice versa), we ignore them in getinfo.  Add the same ignore logic
when performing the subset checks.

This fixes a regression with MPICH.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>