### PR TITLE
prov/shm: fix recent av lookup bug fix

### DIFF
--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -155,7 +155,7 @@ static int smr_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 
 	strncpy((char *)addr, smr_name(peer_smr), *addrlen);
 	((char *) addr)[MIN(*addrlen - 1, strlen(smr_name(peer_smr)))] = '\0';
-	*addrlen = strlen(smr_name(addr) + 1);
+	*addrlen = strlen(smr_name(peer_smr) + 1);
 	return 0;
 }
 


### PR DESCRIPTION
smr_name() should take a peer_region, not the addr

Signed-off-by: aingerson <alexia.ingerson@intel.com>