### PR TITLE
[v1.9.x] prov/shm: fix potential data ordering issue in atomic fetch path

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -53,7 +53,7 @@ static int smr_progress_fetch(struct smr_ep *ep, struct smr_cmd *pending,
 	tx_buf = (struct smr_inject_buf *) ((char **) peer_smr +
 					    inj_offset);
 
-	if (*ret)
+	if (*ret || !(pending->msg.hdr.op_flags & SMR_RMA_REQ))
 		goto out;
 
 	src = pending->msg.hdr.op == ofi_op_atomic_compare ?


### PR DESCRIPTION
Remove an optimization that allows for some atomic
fetch operations to remotely fetch the data from the
peer using CMA before the peer actually processes the
incoming request. To be completely correct, this would
have to have a message ordering check around it to make
sure the application does not require atomic write after
read ordering. However, it is a rare use case that makes
the code more complicated so this is getting removed
rather than getting fixed to check the ordering.

This patch removes the optimization, making all atomic
fetch operations use the SMR_RMA_REQ path and also cleans
up and simplifies the code to make it more readable.

Note that applications using previous versions may be
broken if data ordering for atomic fetches is needed.

Cherry-picked from commit 6d4e7b86d80b04f8a53046f556a631a9a6b47100

Signed-off-by: aingerson <alexia.ingerson@intel.com>