### PR TITLE
core/epoll: Enables the epoll over poll abstraction for all builds

### DIFF
--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -50,6 +50,7 @@
 #define OFI_EPOLL_OUT EPOLLOUT
 
 typedef int ofi_epoll_t;
+#define OFI_EPOLL_INVALID -1
 
 static inline int ofi_epoll_create(int *ep)
 {
@@ -110,6 +111,8 @@ static inline void ofi_epoll_close(int ep)
 
 #define OFI_EPOLL_IN  POLLIN
 #define OFI_EPOLL_OUT POLLOUT
+
+#define OFI_EPOLL_INVALID NULL
 
 enum ofi_epoll_ctl {
 	EPOLL_CTL_ADD,

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -114,17 +114,17 @@ static inline void ofi_epoll_close(int ep)
 
 #define OFI_EPOLL_INVALID NULL
 
-enum ofi_epoll_ctl {
-	EPOLL_CTL_ADD,
-	EPOLL_CTL_DEL,
-	EPOLL_CTL_MOD,
+enum ofi_pollfds_ctl {
+	POLLFDS_CTL_ADD,
+	POLLFDS_CTL_DEL,
+	POLLFDS_CTL_MOD,
 };
 
-struct ofi_epoll_work_item {
+struct ofi_pollfds_work_item {
 	int		fd;
 	uint32_t	events;
 	void		*context;
-	enum ofi_epoll_ctl type;
+	enum ofi_pollfds_ctl type;
 	struct slist_entry entry;
 };
 
@@ -139,15 +139,26 @@ typedef struct ofi_pollfds {
 	fastlock_t	lock;
 } *ofi_epoll_t;
 
-int ofi_epoll_create(struct ofi_pollfds **pfds);
-int ofi_epoll_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
+int ofi_pollfds_create(struct ofi_pollfds **pfds);
+int ofi_pollfds_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		  void *context);
-int ofi_epoll_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+int ofi_pollfds_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
 		  void *context);
-int ofi_epoll_del(struct ofi_pollfds *pfds, int fd);
-int ofi_epoll_wait(struct ofi_pollfds *pfds, void **contexts,
+int ofi_pollfds_del(struct ofi_pollfds *pfds, int fd);
+int ofi_pollfds_wait(struct ofi_pollfds *pfds, void **contexts,
 		   int max_contexts, int timeout);
-void ofi_epoll_close(struct ofi_pollfds *pfds);
+void ofi_pollfds_close(struct ofi_pollfds *pfds);
+
+#define ofi_epoll_create ofi_pollfds_create
+#define ofi_epoll_add ofi_pollfds_add
+#define ofi_epoll_mod ofi_pollfds_mod
+#define ofi_epoll_del ofi_pollfds_del
+#define ofi_epoll_wait ofi_pollfds_wait
+#define ofi_epoll_close ofi_pollfds_close
+
+#define EPOLL_CTL_ADD POLLFDS_CTL_ADD
+#define EPOLL_CTL_DEL POLLFDS_CTL_DEL
+#define EPOLL_CTL_MOD POLLFDS_CTL_MOD
 
 #endif /* HAVE_EPOLL */
 

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -128,7 +128,7 @@ struct ofi_epoll_work_item {
 	struct slist_entry entry;
 };
 
-typedef struct fi_epoll {
+typedef struct ofi_pollfds {
 	int		size;
 	int		nfds;
 	struct pollfd	*fds;
@@ -139,13 +139,15 @@ typedef struct fi_epoll {
 	fastlock_t	lock;
 } *ofi_epoll_t;
 
-int ofi_epoll_create(struct fi_epoll **ep);
-int ofi_epoll_add(struct fi_epoll *ep, int fd, uint32_t events, void *context);
-int ofi_epoll_mod(struct fi_epoll *ep, int fd, uint32_t events, void *context);
-int ofi_epoll_del(struct fi_epoll *ep, int fd);
-int ofi_epoll_wait(struct fi_epoll *ep, void **contexts, int max_contexts,
-                  int timeout);
-void ofi_epoll_close(struct fi_epoll *ep);
+int ofi_epoll_create(struct ofi_pollfds **pfds);
+int ofi_epoll_add(struct ofi_pollfds *pfds, int fd, uint32_t events,
+		  void *context);
+int ofi_epoll_mod(struct ofi_pollfds *pfds, int fd, uint32_t events,
+		  void *context);
+int ofi_epoll_del(struct ofi_pollfds *pfds, int fd);
+int ofi_epoll_wait(struct ofi_pollfds *pfds, void **contexts,
+		   int max_contexts, int timeout);
+void ofi_epoll_close(struct ofi_pollfds *pfds);
 
 #endif /* HAVE_EPOLL */
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -415,9 +415,14 @@ int fi_wait_cleanup(struct util_wait *wait);
 struct util_wait_fd {
 	struct util_wait	util_wait;
 	struct fd_signal	signal;
-	ofi_epoll_t		epoll_fd;
 	struct dlist_entry	fd_list;
 	fastlock_t		lock;
+
+	union {
+		ofi_epoll_t		epoll_fd;
+		struct ofi_pollfds	*pollfds;
+	};
+	uint64_t		change_index;
 };
 
 typedef int (*ofi_wait_try_func)(void *arg);

--- a/include/rdma/fi_eq.h
+++ b/include/rdma/fi_eq.h
@@ -33,6 +33,8 @@
 #ifndef FI_EQ_H
 #define FI_EQ_H
 
+#include <poll.h>
+
 #ifndef _WIN32
 #include <pthread.h>
 #endif /* _WIN32 */
@@ -60,6 +62,7 @@ enum fi_wait_obj {
 	FI_WAIT_FD,
 	FI_WAIT_MUTEX_COND,	/* pthread mutex & cond */
 	FI_WAIT_YIELD,
+	FI_WAIT_POLLFD,
 };
 
 struct fi_wait_attr {
@@ -84,6 +87,11 @@ struct fi_mutex_cond {
 };
 #endif /* _WIN32 */
 
+struct fi_wait_pollfd {
+	uint64_t		change_index;
+	size_t			nfds;
+	struct pollfd		*fd;
+};
 
 /*
  * Poll Set

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -707,13 +707,6 @@ static int rxd_ep_trywait(void *arg)
 	return fi_trywait(rxd_fabric->dg_fabric, fids, 1);
 }
 
-static int rxd_ep_wait_fd_add(struct rxd_ep *rxd_ep, struct util_wait *wait)
-{
-	return ofi_wait_fd_add(wait, rxd_ep->dg_cq_fd, OFI_EPOLL_IN,
-			       rxd_ep_trywait, rxd_ep,
-			       &rxd_ep->util_ep.ep_fid.fid);
-}
-
 static int rxd_dg_cq_open(struct rxd_ep *rxd_ep, enum fi_wait_obj wait_obj)
 {
 	struct rxd_domain *rxd_domain;
@@ -784,7 +777,9 @@ static int rxd_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		}
 
 		if (cq->wait)
-			ret = rxd_ep_wait_fd_add(ep, cq->wait);
+			ret = ofi_wait_fd_add(cq->wait, ep->dg_cq_fd, OFI_EPOLL_IN,
+					      rxd_ep_trywait, ep,
+					      &ep->util_ep.ep_fid.fid);
 		break;
 	case FI_CLASS_EQ:
 		break;
@@ -814,7 +809,9 @@ static int rxd_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 			return ret;
 
 		if (cntr->wait)
-			ret = rxd_ep_wait_fd_add(ep, cntr->wait);
+			ret = ofi_wait_fd_add(cntr->wait, ep->dg_cq_fd,
+					      OFI_EPOLL_IN, rxd_ep_trywait, ep,
+					      &ep->util_ep.ep_fid.fid);
 		break;
 	default:
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -72,7 +72,7 @@
 #define TCPX_IOV_LIMIT		(4)
 #define TCPX_MAX_INJECT_SZ	(64)
 
-#define MAX_EPOLL_EVENTS	100
+#define MAX_POLL_EVENTS		100
 #define STAGE_BUF_SIZE		512
 
 #define TCPX_MIN_MULTI_RECV	16384
@@ -208,7 +208,7 @@ struct tcpx_ep {
 	void (*hdr_bswap)(struct tcpx_base_hdr *hdr);
 	struct stage_buf	stage_buf;
 	size_t			min_multi_recv_size;
-	bool			epoll_out_set;
+	bool			pollout_set;
 };
 
 struct tcpx_fabric {

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -40,15 +40,15 @@
 
 void tcpx_cq_progress(struct util_cq *cq)
 {
-	void *wait_contexts[MAX_EPOLL_EVENTS];
+	void *wait_contexts[MAX_POLL_EVENTS];
 	struct fid_list_entry *fid_entry;
-	struct util_wait_fd *fdwait;
+	struct util_wait_fd *wait_fd;
 	struct dlist_entry *item;
 	struct tcpx_ep *ep;
 	struct fid *fid;
 	int nfds, i;
 
-	fdwait = container_of(cq->wait, struct util_wait_fd, util_wait);
+	wait_fd = container_of(cq->wait, struct util_wait_fd, util_wait);
 
 	cq->cq_fastlock_acquire(&cq->ep_list_lock);
 	dlist_foreach(&cq->ep_list, item) {
@@ -61,15 +61,18 @@ void tcpx_cq_progress(struct util_cq *cq)
 			tcpx_progress_rx(ep);
 	}
 
-	nfds = ofi_epoll_wait(fdwait->epoll_fd, wait_contexts,
-			      MAX_EPOLL_EVENTS, 0);
+	nfds = (wait_fd->util_wait.wait_obj == FI_WAIT_FD) ?
+	       ofi_epoll_wait(wait_fd->epoll_fd, wait_contexts,
+			      MAX_POLL_EVENTS, 0) :
+	       ofi_pollfds_wait(wait_fd->pollfds, wait_contexts,
+				MAX_POLL_EVENTS, 0);
 	if (nfds <= 0)
 		goto unlock;
 
 	for (i = 0; i < nfds; i++) {
 		fid = wait_contexts[i];
 		if (fid->fclass != FI_CLASS_EP) {
-			fd_signal_reset(&fdwait->signal);
+			fd_signal_reset(&wait_fd->signal);
 			continue;
 		}
 
@@ -300,9 +303,10 @@ int tcpx_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (ret)
 		goto free_cq;
 
-	if (attr->wait_obj == FI_WAIT_NONE) {
+	if (attr->wait_obj == FI_WAIT_NONE ||
+	    attr->wait_obj == FI_WAIT_UNSPEC) {
 		cq_attr = *attr;
-		cq_attr.wait_obj = FI_WAIT_FD;
+		cq_attr.wait_obj = FI_WAIT_POLLFD;
 		attr = &cq_attr;
 	}
 

--- a/prov/tcp/src/tcpx_eq.c
+++ b/prov/tcp/src/tcpx_eq.c
@@ -108,7 +108,7 @@ int tcpx_eq_create(struct fid_fabric *fabric_fid, struct fi_eq_attr *attr,
 
 	if (!eq->util_eq.wait) {
 		memset(&wait_attr, 0, sizeof wait_attr);
-		wait_attr.wait_obj = FI_WAIT_FD;
+		wait_attr.wait_obj = FI_WAIT_POLLFD;
 		ret = fi_wait_open(fabric_fid, &wait_attr, &wait);
 		if (ret) {
 			FI_WARN(&tcpx_prov, FI_LOG_EQ,

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -40,6 +40,7 @@
 #include <pthread.h>
 
 #include <rdma/providers/fi_log.h>
+#include <ofi_epoll.h>
 
 #include "usdf_progress.h"
 #include "usd.h"
@@ -120,7 +121,7 @@ struct usdf_fabric {
 	/* progression */
 	pthread_t fab_thread;
 	int fab_exit;
-	int fab_epollfd;
+	ofi_epoll_t fab_epollfd;
 	int fab_eventfd;
 	struct usdf_poll_item fab_poll_item;
 

--- a/prov/usnic/src/usdf_cm.c
+++ b/prov/usnic/src/usdf_cm.c
@@ -45,7 +45,7 @@
 #include <netinet/ip.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/epoll.h>
+#include <ofi_epoll.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_cm.h>

--- a/prov/usnic/src/usdf_endpoint.c
+++ b/prov/usnic/src/usdf_endpoint.c
@@ -41,7 +41,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/in.h>
-#include <sys/epoll.h>
+#include <ofi_epoll.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/prov/usnic/src/usdf_pep.c
+++ b/prov/usnic/src/usdf_pep.c
@@ -43,7 +43,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
-#include <sys/epoll.h>
+#include <ofi_epoll.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -142,8 +142,8 @@ usdf_pep_creq_epoll_del(struct usdf_connreq *crp)
 	pep = crp->cr_pep;
 
 	if (crp->cr_pollitem.pi_rtn != NULL) {
-		ret = epoll_ctl(pep->pep_fabric->fab_epollfd, EPOLL_CTL_DEL,
-				crp->cr_sockfd, NULL);
+		ret = ofi_epoll_del(pep->pep_fabric->fab_epollfd,
+				    crp->cr_sockfd);
 		crp->cr_pollitem.pi_rtn = NULL;
 		if (ret != 0) {
 			ret = -errno;
@@ -230,7 +230,6 @@ usdf_pep_listen_cb(void *v)
 	struct usdf_pep *pep;
 	struct sockaddr_in sin;
 	struct usdf_connreq *crp;
-	struct epoll_event ev;
 	socklen_t socklen;
 	int ret;
 	int s;
@@ -266,13 +265,11 @@ usdf_pep_listen_cb(void *v)
 
 	crp->cr_pollitem.pi_rtn = usdf_pep_read_connreq;
 	crp->cr_pollitem.pi_context = crp;
-	ev.events = EPOLLIN;
-	ev.data.ptr = &crp->cr_pollitem;
 
-	ret = epoll_ctl(pep->pep_fabric->fab_epollfd, EPOLL_CTL_ADD,
-			crp->cr_sockfd, &ev);
-	if (ret == -1) {
-		usdf_cm_report_failure(crp, -errno, false);
+	ret = ofi_epoll_add(pep->pep_fabric->fab_epollfd, crp->cr_sockfd,
+			    OFI_EPOLL_IN, &crp->cr_pollitem);
+	if (ret) {
+		usdf_cm_report_failure(crp, ret, false);
 		return 0;
 	}
 
@@ -285,7 +282,6 @@ static int
 usdf_pep_listen(struct fid_pep *fpep)
 {
 	struct usdf_pep *pep;
-	struct epoll_event ev;
 	struct usdf_fabric *fp;
 	struct sockaddr_in *sin;
 	socklen_t socklen;
@@ -359,10 +355,10 @@ usdf_pep_listen(struct fid_pep *fpep)
 
 	pep->pep_pollitem.pi_rtn = usdf_pep_listen_cb;
 	pep->pep_pollitem.pi_context = pep;
-	ev.events = EPOLLIN;
-	ev.data.ptr = &pep->pep_pollitem;
-	ret = epoll_ctl(fp->fab_epollfd, EPOLL_CTL_ADD, pep->pep_sock, &ev);
-	if (ret == -1) {
+	ret = ofi_epoll_add(fp->fab_epollfd, pep->pep_sock, OFI_EPOLL_IN,
+			    &pep->pep_pollitem);
+	if (ret) {
+		errno = -ret;
 		goto fail;
 	}
 
@@ -408,7 +404,6 @@ static int usdf_pep_reject(struct fid_pep *fpep, fid_t handle, const void *param
 {
 	struct usdf_pep *pep;
 	struct usdf_connreq *crp;
-	struct epoll_event event;
 	struct usdf_connreq_msg *reqp;
 	int ret;
 
@@ -452,16 +447,9 @@ static int usdf_pep_reject(struct fid_pep *fpep, fid_t handle, const void *param
 	crp->cr_pollitem.pi_rtn = usdf_pep_reject_async;
 	crp->cr_pollitem.pi_context = crp;
 
-	event.events = EPOLLOUT;
-	event.data.ptr = &crp->cr_pollitem;
-
-	ret = epoll_ctl(pep->pep_fabric->fab_epollfd, EPOLL_CTL_ADD,
-			crp->cr_sockfd, &event);
-
-	if (ret)
-		return -errno;
-
-	return FI_SUCCESS;
+	ret = ofi_epoll_add(pep->pep_fabric->fab_epollfd, crp->cr_sockfd,
+			    OFI_EPOLL_OUT, &crp->cr_pollitem);
+	return ret;
 }
 
 static void

--- a/prov/usnic/src/usdf_socket.c
+++ b/prov/usnic/src/usdf_socket.c
@@ -39,7 +39,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <sys/socket.h>
-#include <sys/epoll.h>
+#include <ofi_epoll.h>
 
 #include <rdma/fi_errno.h>
 

--- a/prov/usnic/src/usdf_wait.h
+++ b/prov/usnic/src/usdf_wait.h
@@ -45,7 +45,7 @@ struct usdf_wait {
 
 	enum fi_wait_obj	wait_obj;
 	union {
-		int epfd;
+		ofi_epoll_t epfd;
 		struct fi_mutex_cond mutex_cond;
 	} object;
 

--- a/prov/util/src/util_cntr.c
+++ b/prov/util/src/util_cntr.c
@@ -59,6 +59,7 @@ static int ofi_check_cntr_attr(const struct fi_provider *prov,
 		/* fall through */
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
+	case FI_WAIT_POLLFD:
 		break;
 	default:
 		FI_WARN(prov, FI_LOG_CNTR, "unsupported wait object\n");
@@ -290,6 +291,7 @@ int ofi_cntr_init(const struct fi_provider *prov, struct fid_domain *domain,
 		break;
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
+	case FI_WAIT_POLLFD:
 	case FI_WAIT_MUTEX_COND:
 	case FI_WAIT_YIELD:
 		memset(&wait_attr, 0, sizeof wait_attr);

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -152,6 +152,7 @@ int ofi_check_cq_attr(const struct fi_provider *prov,
 		/* fall through */
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
+	case FI_WAIT_POLLFD:
 		switch (attr->wait_cond) {
 		case FI_CQ_COND_NONE:
 		case FI_CQ_COND_THRESHOLD:
@@ -537,6 +538,7 @@ static int fi_cq_init(struct fid_domain *domain, struct fi_cq_attr *attr,
 		break;
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
+	case FI_WAIT_POLLFD:
 	case FI_WAIT_MUTEX_COND:
 	case FI_WAIT_YIELD:
 		memset(&wait_attr, 0, sizeof wait_attr);

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -289,6 +289,7 @@ static int util_eq_init(struct fid_fabric *fabric, struct util_eq *eq,
 		break;
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
+	case FI_WAIT_POLLFD:
 	case FI_WAIT_MUTEX_COND:
 	case FI_WAIT_YIELD:
 		memset(&wait_attr, 0, sizeof wait_attr);
@@ -363,6 +364,7 @@ static int util_verify_eq_attr(const struct fi_provider *prov,
 	case FI_WAIT_NONE:
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
+	case FI_WAIT_POLLFD:
 	case FI_WAIT_MUTEX_COND:
 	case FI_WAIT_YIELD:
 		break;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -275,7 +275,9 @@ struct vrb_eq {
 	struct rdma_event_channel *channel;
 	uint64_t		flags;
 	struct fi_eq_err_entry	err;
+
 	ofi_epoll_t		epollfd;
+	enum fi_wait_obj	wait_obj;
 
 	struct {
 		/* The connection key map is used during the XRC connection
@@ -384,6 +386,7 @@ struct vrb_cq {
 	struct ibv_cq		*cq;
 	size_t			entry_size;
 	uint64_t		flags;
+	enum fi_wait_obj	wait_obj;
 	enum fi_cq_wait_cond	wait_cond;
 	struct ibv_wc		wc;
 	int			signal_fd[2];

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -1179,17 +1179,32 @@ static struct fi_ops_eq vrb_eq_ops = {
 
 static int vrb_eq_control(fid_t fid, int command, void *arg)
 {
+	struct fi_wait_pollfd *pollfd;
 	struct vrb_eq *eq;
 	int ret;
 
 	eq = container_of(fid, struct vrb_eq, eq_fid.fid);
 	switch (command) {
 	case FI_GETWAIT:
-#ifdef HAVE_EPOLL
-		*(int *) arg = eq->epollfd;
-		ret = 0;
+#ifndef HAVE_EPOLL
+		/* We expect verbs to only run on systems with epoll */
+		return -FI_ENOSYS;
 #else
-		ret = -FI_ENOSYS;
+		if (eq->wait_obj == FI_WAIT_FD) {
+			*(int *) arg = eq->epollfd;
+			return 0;
+		}
+
+		pollfd = arg;
+		if (pollfd->nfds >= 1) {
+			pollfd->fd[0].fd = eq->epollfd;
+			pollfd->fd[0].events = POLLIN;
+			ret = 0;
+		} else {
+			ret = -FI_ETOOSMALL;
+		}
+		pollfd->change_index = 1;
+		pollfd->nfds = 1;
 #endif
 		break;
 	default:
@@ -1286,26 +1301,29 @@ int vrb_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	case FI_WAIT_NONE:
 	case FI_WAIT_UNSPEC:
 	case FI_WAIT_FD:
-		_eq->channel = rdma_create_event_channel();
-		if (!_eq->channel) {
-			ret = -errno;
-			goto err3;
-		}
-
-		ret = fi_fd_nonblock(_eq->channel->fd);
-		if (ret)
-			goto err4;
-
-		if (ofi_epoll_add(_eq->epollfd, _eq->channel->fd, OFI_EPOLL_IN,
-				  NULL)) {
-			ret = -errno;
-			goto err4;
-		}
-
+		_eq->wait_obj = FI_WAIT_FD;
+		break;
+	case FI_WAIT_POLLFD:
+		_eq->wait_obj = FI_WAIT_POLLFD;
 		break;
 	default:
 		ret = -FI_ENOSYS;
 		goto err1;
+	}
+
+	_eq->channel = rdma_create_event_channel();
+	if (!_eq->channel) {
+		ret = -errno;
+		goto err3;
+	}
+
+	ret = fi_fd_nonblock(_eq->channel->fd);
+	if (ret)
+		goto err4;
+
+	if (ofi_epoll_add(_eq->epollfd, _eq->channel->fd, OFI_EPOLL_IN, NULL)) {
+		ret = -errno;
+		goto err4;
 	}
 
 	_eq->flags = attr->flags;

--- a/src/common.c
+++ b/src/common.c
@@ -845,8 +845,6 @@ int ofi_discard_socket(SOCKET sock, size_t len)
 }
 
 
-#ifndef HAVE_EPOLL
-
 int ofi_pollfds_create(struct ofi_pollfds **pfds)
 {
 	int ret;
@@ -869,7 +867,7 @@ int ofi_pollfds_create(struct ofi_pollfds **pfds)
 		goto err2;
 
 	(*pfds)->fds[(*pfds)->nfds].fd = (*pfds)->signal.fd[FI_READ_FD];
-	(*pfds)->fds[(*pfds)->nfds].events = OFI_EPOLL_IN;
+	(*pfds)->fds[(*pfds)->nfds].events = POLLIN;
 	(*pfds)->context[(*pfds)->nfds++] = NULL;
 	slist_init(&(*pfds)->work_item_list);
 	fastlock_init(&(*pfds)->lock);
@@ -1070,8 +1068,6 @@ void ofi_pollfds_close(struct ofi_pollfds *pfds)
 		free(pfds);
 	}
 }
-
-#endif
 
 
 void ofi_free_list_of_addr(struct slist *addr_list)


### PR DESCRIPTION
The purpose behind this series is to provide the ofi_epoll semantics over the poll() implementation directly to providers.  In scale-up testing, poll significantly outperforms epoll (by multiple factors).  So the epoll over poll implementation is exposed as a separate option that is directly callable, under a new name (ofi_pollfds).  The behavior of ofi_epoll remains the same, based on whether epoll is available or not.

Additional changes are still in the works to adapt the tcp provider to use the new ofi_pollfds.  Posting these changes for review, particularly since it updates the usnic provider to use the epoll abstraction.