### PR TITLE
prov/efa: add environmental variable efa_max_long_msg_size

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -213,8 +213,9 @@ struct rxr_env {
 	size_t efa_cq_read_size;
 	size_t shm_cq_read_size;
 	size_t efa_max_medium_msg_size;
+	size_t efa_max_long_msg_size;
 	size_t efa_max_emulated_read_size;
-	size_t efa_max_emulated_write_size;
+	size_t efa_max_long_write_size;
 	size_t efa_read_segment_size;
 };
 

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -67,9 +67,10 @@ struct rxr_env rxr_env = {
 	.timeout_interval = 0, /* 0 is random timeout */
 	.efa_cq_read_size = 50,
 	.shm_cq_read_size = 50,
-	.efa_max_medium_msg_size = 131072,
+	.efa_max_medium_msg_size = 65536,
+	.efa_max_long_msg_size = 131072,
 	.efa_max_emulated_read_size = 0,
-	.efa_max_emulated_write_size = 65536,
+	.efa_max_long_write_size = 65536,
 	.efa_read_segment_size = 1073741824,
 };
 
@@ -112,10 +113,12 @@ static void rxr_init_env(void)
 			 &rxr_env.shm_cq_read_size);
 	fi_param_get_size_t(&rxr_prov, "inter_max_medium_message_size",
 			    &rxr_env.efa_max_medium_msg_size);
+	fi_param_get_size_t(&rxr_prov, "inter_max_long_message_size",
+			    &rxr_env.efa_max_long_msg_size);
 	fi_param_get_size_t(&rxr_prov, "inter_max_emulated_read_size",
 			    &rxr_env.efa_max_emulated_read_size);
-	fi_param_get_size_t(&rxr_prov, "inter_max_emulated_write_size",
-			    &rxr_env.efa_max_emulated_write_size);
+	fi_param_get_size_t(&rxr_prov, "inter_max_long_write_size",
+			    &rxr_env.efa_max_long_write_size);
 	fi_param_get_size_t(&rxr_prov, "read_segment_size",
 			    &rxr_env.efa_read_segment_size);
 }
@@ -690,10 +693,12 @@ EFA_INI
 	fi_param_define(&rxr_prov, "shm_cq_read_size", FI_PARAM_SIZE_T,
 			"Set the number of SHM completion entries to read for one loop for one iteration of the progress engine. (Default: 50)");
 	fi_param_define(&rxr_prov, "inter_max_medium_message_size", FI_PARAM_INT,
-			"The maximal message size for inter EFA medium message protocol, messages whose size is larger than this value will be sent either by read message protocol (depend on firmware support), or long message protocol (Default 131072).");
+			"The maximum message size for inter EFA medium message protocol, messages whose size is larger than this value will be sent either by read message protocol (depend on firmware support), or long message protocol (Default 65536).");
+	fi_param_define(&rxr_prov, "inter_max_long_message_size", FI_PARAM_INT,
+			"The maximum message size for inter EFA long message protocol, messages whose size is larger than this value will be sent either by read message protocol (if firmware support) (Default 131072).");
 	fi_param_define(&rxr_prov, "inter_max_emulated_read_size", FI_PARAM_INT,
 			"The maximum message size for inter EFA emulated read protocol. Read requests whose size is larger than this value will be implemented via RDMA read (if firmware support), (Default 0 [RDMA read is always used]).");
-	fi_param_define(&rxr_prov, "inter_max_emulated_write_size", FI_PARAM_INT,
+	fi_param_define(&rxr_prov, "inter_max_long_write_size", FI_PARAM_INT,
 			"The maximum message size for inter EFA emulated write protocol. Write requests whose size is larger than this value will be implemented via read write protocol (write by read).");
 	fi_param_define(&rxr_prov, "efa_read_segment_size", FI_PARAM_INT,
 			"Calls to RDMA read is segmented using this value.");

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -100,7 +100,8 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
 						  RXR_MEDIUM_MSGRTM_PKT + tagged, 0);
 
-	if (efa_ep_support_rdma_read(rxr_ep->rdm_ep) && rxr_peer_support_rdma_read(peer)) {
+	if (efa_ep_support_rdma_read(rxr_ep->rdm_ep) && rxr_peer_support_rdma_read(peer) &&
+	    tx_entry->total_len > rxr_env.efa_max_long_msg_size) {
 		/* use read message protocol */
 		err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
 						 RXR_READ_MSGRTM_PKT + tagged, 0);

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -381,7 +381,7 @@ ssize_t rxr_rma_post_rtw(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 	if (tx_entry->total_len < rxr_pkt_req_max_data_size(ep, tx_entry->addr, RXR_EAGER_RTW_PKT))
 		return rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_EAGER_RTW_PKT, 0);
 
-	if (tx_entry->total_len >= rxr_env.efa_max_emulated_write_size &&
+	if (tx_entry->total_len >= rxr_env.efa_max_long_write_size &&
 	    efa_ep_support_rdma_read(ep->rdm_ep) && rxr_peer_support_rdma_read(peer)) {
 		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_READ_RTW_PKT, 0);
 		if (err != -FI_ENOMEM)


### PR DESCRIPTION
This environmental variable is used as the upper limit of
the long messge protocol. Messages whose size is larger than
this value will be using read message protocol (with firmware
support.)

Signed-off-by: Wei Zhang <wzam@amazon.com>