### PR TITLE
prov/rxm: Fixed uninitialised value

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -688,7 +688,14 @@ ssize_t rxm_sar_handle_segment(struct rxm_rx_buf *rx_buf)
 
 static ssize_t rxm_rndv_send_ack_inject(struct rxm_rx_buf *rx_buf)
 {
-	struct rxm_pkt pkt;
+	struct rxm_pkt pkt = {
+		.hdr.op = ofi_op_msg,
+		.hdr.version = OFI_OP_VERSION,
+		.ctrl_hdr.version = RXM_CTRL_VERSION,
+		.ctrl_hdr.type = rxm_ctrl_rndv_ack,
+		.ctrl_hdr.conn_id = rx_buf->conn->handle.remote_key,
+		.ctrl_hdr.msg_id = rx_buf->pkt.ctrl_hdr.msg_id
+	};
 	struct iovec iov = {
 		.iov_base = &pkt,
 		.iov_len = sizeof(pkt),
@@ -698,15 +705,6 @@ static ssize_t rxm_rndv_send_ack_inject(struct rxm_rx_buf *rx_buf)
 		.iov_count = 1,
 		.context = rx_buf,
 	};
-
-	assert(rx_buf->conn);
-
-	pkt.hdr.op		= ofi_op_msg;
-	pkt.hdr.version		= OFI_OP_VERSION;
-	pkt.ctrl_hdr.version	= RXM_CTRL_VERSION;
-	pkt.ctrl_hdr.type	= rxm_ctrl_rndv_ack;
-	pkt.ctrl_hdr.conn_id 	= rx_buf->conn->handle.remote_key;
-	pkt.ctrl_hdr.msg_id 	= rx_buf->pkt.ctrl_hdr.msg_id;
 
 	return fi_sendmsg(rx_buf->conn->msg_ep, &msg, FI_INJECT);
 }


### PR DESCRIPTION
**commit 1, valgrind issue:**

```
==206074==  Address 0x7cbce7a is 378 bytes inside a block of size 360,800 alloc'd
==206074==    at 0x4C2C3C8: memalign (vg_replace_malloc.c:898)
==206074==    by 0x4C2C4C9: posix_memalign (vg_replace_malloc.c:1062)
==206074==    by 0x50F12AF: ofi_memalign (osd.h:91)
==206074==    by 0x50F1685: ofi_bufpool_grow (util_buf.c:81)
==206074==    by 0x50C18A9: ofi_buf_alloc (ofi_mem.h:449)
==206074==    by 0x50C1FD4: tcpx_xfer_entry_alloc (tcpx_cq.c:113)
==206074==    by 0x50BDC86: tcpx_alloc_send_entry (tcpx_msg.c:74)
==206074==    by 0x50BE2FB: tcpx_send (tcpx_msg.c:238)
==206074==    by 0x4E458C8: fi_send (fi_endpoint.h:291)
==206074==    by 0x4E495DF: rxm_ep_msg_normal_send (rxm_ep.c:1030)
==206074==    by 0x4E4A352: rxm_ep_emulate_inject (rxm_ep.c:1296)
==206074==    by 0x4E4A4B6: rxm_ep_inject_send_fast (rxm_ep.c:1322)
==206074==  Uninitialised value was created by a stack allocation
==206074==    at 0x4E51ACA: rxm_rndv_send_ack_inject (rxm_cq.c:690)
```
