### PR TITLE
prov/shm: Bugfix the id for accessing peer region

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -112,6 +112,7 @@ struct smr_rx_entry {
 
 struct smr_tx_entry {
 	struct smr_cmd	cmd;
+	fi_addr_t	addr;
 	void		*context;
 	struct iovec	iov[SMR_IOV_LIMIT];
 	uint32_t	iov_count;
@@ -218,7 +219,8 @@ int smr_verify_peer(struct smr_ep *ep, int peer_id);
 
 void smr_format_pend_resp(struct smr_tx_entry *pend, struct smr_cmd *cmd,
 			  void *context, const struct iovec *iov,
-			  uint32_t iov_count, struct smr_resp *resp);
+			  uint32_t iov_count, fi_addr_t id,
+			  struct smr_resp *resp);
 void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id, uint32_t op,
 			uint64_t tag, uint64_t data, uint64_t op_flags);
 void smr_format_inline(struct smr_cmd *cmd, const struct iovec *iov,

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -213,7 +213,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 			resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 			pend = freestack_pop(ep->pend_fs);
 			smr_format_pend_resp(pend, cmd, context, result_iov,
-					     result_count, resp);
+					     result_count, id, resp);
 			cmd->msg.hdr.data = (uintptr_t) ((char **) resp -
 						(char **) ep->region);
 			ofi_cirque_commit(smr_resp_queue(ep->region));

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -243,12 +243,13 @@ static void smr_init_queue(struct smr_queue *queue,
 
 void smr_format_pend_resp(struct smr_tx_entry *pend, struct smr_cmd *cmd,
 			  void *context, const struct iovec *iov,
-			  uint32_t iov_count, struct smr_resp *resp)
+			  uint32_t iov_count, fi_addr_t id, struct smr_resp *resp)
 {
 	pend->cmd = *cmd;
 	pend->context = context;
 	memcpy(pend->iov, iov, sizeof(*iov) * iov_count);
 	pend->iov_count = iov_count;
+	pend->addr = id;
 
 	resp->msg_id = (uint64_t) (uintptr_t) pend;
 	resp->status = FI_EBUSY;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -195,7 +195,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 		pend = freestack_pop(ep->pend_fs);
 		smr_format_iov(cmd, iov, iov_count, total_len, ep->region, resp);
-		smr_format_pend_resp(pend, cmd, context, iov, iov_count, resp);
+		smr_format_pend_resp(pend, cmd, context, iov, iov_count, id, resp);
 		ofi_cirque_commit(smr_resp_queue(ep->region));
 		goto commit;
 	} else if (total_len > SMR_MSG_DATA_LEN) {

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -45,7 +45,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_tx_entry *pendi
 	struct smr_inject_buf *tx_buf;
 	uint8_t *src;
 
-	peer_smr = smr_peer_region(ep->region, pending->cmd.msg.hdr.addr);
+	peer_smr = smr_peer_region(ep->region, pending->addr);
 	if (fastlock_tryacquire(&peer_smr->lock))
 		return -FI_EAGAIN;
 

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -165,7 +165,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 		pend = freestack_pop(ep->pend_fs);
 		smr_format_iov(cmd, iov, iov_count, total_len, ep->region, resp);
-		smr_format_pend_resp(pend, cmd, context, iov, iov_count, resp);
+		smr_format_pend_resp(pend, cmd, context, iov, iov_count, id, resp);
 		ofi_cirque_commit(smr_resp_queue(ep->region));
 		comp = 0;
 	} else if (total_len > SMR_MSG_DATA_LEN || smr_env.disable_cma) {
@@ -181,7 +181,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 			resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 			pend = freestack_pop(ep->pend_fs);
 			smr_format_pend_resp(pend, cmd, context, iov,
-					     iov_count, resp);
+					     iov_count, id, resp);
 			cmd->msg.hdr.data = (uintptr_t) ((char **) resp -
 						(char **) ep->region);
 			ofi_cirque_commit(smr_resp_queue(ep->region));


### PR DESCRIPTION
Use id (peer's addr) instead of peer id (its own addr
in peer's av) to access the peer's shm region when
progressing response entry.

To do so, struct smr_tx_entry is extended to include
the peer's addr.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>