### PR TITLE
prov/efa: let medium message protcol use memory desc

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -843,8 +843,10 @@ int rxr_ep_post_buf(struct rxr_ep *ep, uint64_t flags, enum rxr_lower_ep_type lo
 int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep,
 				 struct rxr_tx_entry *tx_entry);
 
-void rxr_prepare_mr_send(struct rxr_domain *rxr_domain,
-			 struct rxr_tx_entry *tx_entry);
+int rxr_ep_tx_init_mr_desc(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
+			   int mr_iov_start, uint64_t access);
+
+void rxr_prepare_mr_send(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry);
 
 struct rxr_rx_entry *rxr_ep_lookup_mediumrtm_rx_entry(struct rxr_ep *ep,
 						      struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -802,8 +802,7 @@ void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entr
 	if (tx_entry->state == RXR_TX_SEND)
 		dlist_remove(&tx_entry->entry);
 
-	if (tx_entry->state == RXR_TX_SEND &&
-	    efa_mr_cache_enable && rxr_ep_mr_local(ep)) {
+	if (efa_mr_cache_enable && rxr_ep_mr_local(ep)) {
 		ret = rxr_tx_entry_mr_dereg(tx_entry);
 		if (OFI_UNLIKELY(ret)) {
 			FI_WARN(&rxr_prov, FI_LOG_MR,

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -269,6 +269,10 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 	 */
 	if (inject)
 		err = rxr_pkt_entry_inject(rxr_ep, pkt_entry, addr);
+	else if (pkt_entry->iov_count > 0)
+		err = rxr_pkt_entry_sendv(rxr_ep, pkt_entry, addr,
+					  pkt_entry->iov, pkt_entry->desc,
+					  pkt_entry->iov_count, 0);
 	else
 		err = rxr_pkt_entry_send(rxr_ep, pkt_entry, addr);
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -65,6 +65,16 @@ struct rxr_pkt_entry {
 	void *raw_addr;
 	uint64_t cq_data;
 
+	/* Because core EP current only support 2 iov,
+	 * and for the sake of code simplicity, we use 2 iov.
+	 * One for header, and the other for data.
+	 * iov_count here is used as an indication
+	 * of whether iov is used, it is either 0 or 2.
+	 */
+	int iov_count;
+	struct iovec iov[2];
+	void *desc[2];
+
 	struct fid_mr *mr;
 	fi_addr_t addr;
 	void *pkt; /* rxr_ctrl_*_pkt, or rxr_data_pkt */
@@ -73,9 +83,9 @@ struct rxr_pkt_entry {
 	struct rxr_pkt_entry *next;
 #if ENABLE_DEBUG
 /* pad to cache line size of 64 bytes */
-	uint8_t pad[8];
+	uint8_t pad[16];
 #else
-	uint8_t pad[24];
+	uint8_t pad[32];
 #endif
 };
 
@@ -85,7 +95,7 @@ static inline void *rxr_pkt_start(struct rxr_pkt_entry *pkt_entry)
 }
 
 #if defined(static_assert) && defined(__x86_64__)
-static_assert(sizeof(struct rxr_pkt_entry) == 128, "rxr_pkt_entry check");
+static_assert(sizeof(struct rxr_pkt_entry) == 192, "rxr_pkt_entry check");
 #endif
 
 OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf, uint32_t);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -279,7 +279,7 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 	assert(tx_entry->window >= 0);
 	if (tx_entry->bytes_sent < tx_entry->total_len) {
 		if (efa_mr_cache_enable && rxr_ep_mr_local(ep))
-			rxr_prepare_mr_send(rxr_ep_domain(ep), tx_entry);
+			rxr_prepare_mr_send(ep, tx_entry);
 
 		tx_entry->state = RXR_TX_SEND;
 		dlist_insert_tail(&tx_entry->entry,

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -79,6 +79,9 @@ struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, int entry_type, v
 void rxr_read_release_entry(struct rxr_ep *ep, struct rxr_read_entry *read_entry);
 
 /* used by read message protocol and read write protocol */
+int rxr_locate_iov_pos(struct iovec *iov, int iov_count, size_t offset,
+		       int *iov_idx, size_t *iov_offset);
+
 int rxr_read_init_iov(struct rxr_ep *ep,
 		      struct rxr_tx_entry *tx_entry,
 		      struct fi_rma_iov *read_iov);


### PR DESCRIPTION
This patch let medium message protocol us descriptor if
it is available.

It includes the following changes:

1. The memory registration part of rxr_prepare_mr_send()
   was extracted into a function rxr_ep_init_tx_mr_desc().
   If MR cache is turned on, rxr_pkt_post_rtm() will call
   it before posting medium RTM to setup descriptor.

2. The following member was added to rxr_pkt_entry:
       int iov_count;
       struct iovect iov[2];
       void *desc[2];
   Note for code simplicity, we use 2 iov: one the header,
   the other for data.

3. A function rxr_pkt_data_from_tx() was added that will
   set RTM packet iov_count,iov and desc if tx_entry->desc
   is available

4. rxr_pkt_post_ctrl_once() was modified such that it will
   call rxr_pkt_entry_sendv() if pkt_entry->iov_count > 0.

Signed-off-by: Wei Zhang <wzam@amazon.com>