### PR TITLE
[v1.9.x] prov/shm: fix peer_smr address

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -210,7 +210,7 @@ int smr_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 int smr_verify_peer(struct smr_ep *ep, int peer_id);
 
 void smr_post_pend_resp(struct smr_cmd *cmd, struct smr_cmd *pend,
-			struct smr_resp *resp);
+			struct smr_resp *resp, fi_addr_t id);
 void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id,
 		uint32_t op, uint64_t tag, uint8_t datatype, uint8_t atomic_op,
 		uint64_t data, uint64_t op_flags);
@@ -221,7 +221,7 @@ void smr_format_inject(struct smr_cmd *cmd, fi_addr_t peer_id,
 		const struct iovec *iov, size_t count,
 		uint32_t op, uint64_t tag, uint64_t data, uint64_t op_flags,
 		struct smr_region *smr, struct smr_inject_buf *tx_buf);
-void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
+void smr_format_iov(struct smr_cmd *cmd, fi_addr_t my_id, fi_addr_t peer_id,
 		const struct iovec *iov, size_t count, size_t total_len,
 		uint32_t op, uint64_t tag, uint64_t data, uint64_t op_flags,
 		void *context, struct smr_region *smr, struct smr_resp *resp,

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -120,8 +120,8 @@ static void smr_format_inject_atomic(struct smr_cmd *cmd, fi_addr_t peer_id,
 }
 
 static void smr_post_fetch_resp(struct smr_ep *ep, struct smr_cmd *cmd,
-				const struct iovec *result_iov, size_t count,
-				uint16_t flags)
+				fi_addr_t id, const struct iovec *result_iov,
+				size_t count, uint16_t flags)
 {
 	struct smr_cmd *pend;
 	struct smr_resp *resp;
@@ -133,7 +133,7 @@ static void smr_post_fetch_resp(struct smr_ep *ep, struct smr_cmd *cmd,
 			    (char **) ep->region);
 
 	pend = freestack_pop(ep->pend_fs);
-	smr_post_pend_resp(cmd, pend, resp);
+	smr_post_pend_resp(cmd, pend, resp, id);
 	memcpy(pend->msg.data.iov, result_iov,
 	       sizeof(*result_iov) * count);
 	pend->msg.data.iov_count = count;
@@ -226,7 +226,8 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 					 compare_iov, compare_count, op, datatype,
 					 atomic_op, peer_smr, tx_buf, op_flags);
 		if (flags & SMR_RMA_REQ || op_flags & FI_DELIVERY_COMPLETE)
-			smr_post_fetch_resp(ep, cmd, result_iov, result_count, flags);
+			smr_post_fetch_resp(ep, cmd, peer_id, result_iov,
+					    result_count, flags);
 	} else {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"message too large\n");

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -120,7 +120,8 @@ static void smr_format_inject_atomic(struct smr_cmd *cmd, fi_addr_t peer_id,
 }
 
 static void smr_post_fetch_resp(struct smr_ep *ep, struct smr_cmd *cmd,
-				const struct iovec *result_iov, size_t count)
+				const struct iovec *result_iov, size_t count,
+				uint16_t flags)
 {
 	struct smr_cmd *pend;
 	struct smr_resp *resp;
@@ -136,6 +137,7 @@ static void smr_post_fetch_resp(struct smr_ep *ep, struct smr_cmd *cmd,
 	memcpy(pend->msg.data.iov, result_iov,
 	       sizeof(*result_iov) * count);
 	pend->msg.data.iov_count = count;
+	pend->msg.hdr.op_flags |= flags;
 
 	ofi_cirque_commit(smr_resp_queue(ep->region));
 }
@@ -224,7 +226,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 					 compare_iov, compare_count, op, datatype,
 					 atomic_op, peer_smr, tx_buf, op_flags);
 		if (flags & SMR_RMA_REQ || op_flags & FI_DELIVERY_COMPLETE)
-			smr_post_fetch_resp(ep, cmd, result_iov, result_count);
+			smr_post_fetch_resp(ep, cmd, result_iov, result_count, flags);
 	} else {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"message too large\n");

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -243,9 +243,10 @@ static void smr_init_queue(struct smr_queue *queue,
 }
 
 void smr_post_pend_resp(struct smr_cmd *cmd, struct smr_cmd *pend,
-			struct smr_resp *resp)
+			struct smr_resp *resp, fi_addr_t id)
 {
 	*pend = *cmd;
+	pend->msg.hdr.addr = id;
 	resp->msg_id = (uint64_t) (uintptr_t) pend;
 	resp->status = FI_EBUSY;
 }
@@ -299,7 +300,7 @@ void smr_format_inject(struct smr_cmd *cmd, fi_addr_t peer_id,
 					      iov, count, 0);
 }
 
-void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
+void smr_format_iov(struct smr_cmd *cmd, fi_addr_t my_id, fi_addr_t peer_id,
 		    const struct iovec *iov, size_t count, size_t total_len,
 		    uint32_t op, uint64_t tag, uint64_t data, uint64_t op_flags,
 		    void *context, struct smr_region *smr,
@@ -313,7 +314,7 @@ void smr_format_iov(struct smr_cmd *cmd, fi_addr_t peer_id,
 	cmd->msg.hdr.msg_id = (uint64_t) (uintptr_t) context;
 	memcpy(cmd->msg.data.iov, iov, sizeof(*iov) * count);
 
-	smr_post_pend_resp(cmd, pend_cmd, resp);
+	smr_post_pend_resp(cmd, pend_cmd, resp, my_id);
 }
 
 static int smr_ep_close(struct fid *fid)

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -220,8 +220,8 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 		}
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 		pend = freestack_pop(ep->pend_fs);
-		smr_format_iov(cmd, smr_peer_addr(ep->region)[peer_id].addr, iov,
-			       iov_count, total_len, op, tag, data, op_flags,
+		smr_format_iov(cmd, peer_id, smr_peer_addr(ep->region)[peer_id].addr,
+			       iov, iov_count, total_len, op, tag, data, op_flags,
 			       context, ep->region, resp, pend);
 		ofi_cirque_commit(smr_resp_queue(ep->region));
 		goto commit;

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -167,7 +167,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		}
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 		pend = freestack_pop(ep->pend_fs);
-		smr_format_iov(cmd, smr_peer_addr(ep->region)[peer_id].addr,
+		smr_format_iov(cmd, peer_id, smr_peer_addr(ep->region)[peer_id].addr,
 			       iov, iov_count, total_len, op, 0, data,
 			       op_flags, context, ep->region, resp, pend);
 		ofi_cirque_commit(smr_resp_queue(ep->region));


### PR DESCRIPTION
Use local peer address instead of remote address
stored in cmd to get the correct peer_smr.

To do this, modify the pending->cmd after it is
copied to have the correct address.

Modified from commit ff35c6322f97feb394f01decb8fa6482b15b7f1f
By Jie Zhang zhngaj@amazon.com

Signed-off-by: aingerson <alexia.ingerson@intel.com>