### PR TITLE
prov/efa: Fix shm file name

### DIFF
--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -133,7 +133,7 @@ int rxr_ep_efa_addr_to_str(const void *addr, char *smr_name)
 	}
 	qpn = ((struct efa_ep_addr *)addr)->qpn;
 
-	ret = snprintf(smr_name, NAME_MAX, "/%ld_%s_%d", (size_t) getuid(), gid, qpn);
+	ret = snprintf(smr_name, NAME_MAX, "%ld_%s_%d", (size_t) getuid(), gid, qpn);
 
 	return (ret <= 0) ? ret : FI_SUCCESS;
 }


### PR DESCRIPTION
Remove "/" from the shm file name.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>