### PR TITLE
prov/tcp: Fix missing ep-lock / list corruption

### DIFF
--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -56,9 +56,11 @@ void tcpx_cq_progress(struct util_cq *cq)
 		ep = container_of(fid_entry->fid, struct tcpx_ep,
 				  util_ep.ep_fid.fid);
 		tcpx_try_func(&ep->util_ep);
+		fastlock_acquire(&ep->lock);
 		tcpx_progress_tx(ep);
 		if (ep->stage_buf.off != ep->stage_buf.len)
 			tcpx_progress_rx(ep);
+		fastlock_release(&ep->lock);
 	}
 
 	nfds = ofi_epoll_wait(fdwait->epoll_fd, wait_contexts,
@@ -74,7 +76,9 @@ void tcpx_cq_progress(struct util_cq *cq)
 		}
 
 		ep = container_of(fid, struct tcpx_ep, util_ep.ep_fid.fid);
+		fastlock_acquire(&ep->lock);
 		tcpx_progress_rx(ep);
+		fastlock_release(&ep->lock);
 	}
 unlock:
 	cq->cq_fastlock_release(&cq->ep_list_lock);


### PR DESCRIPTION
tcpx_cq_progress() was taking cq->ep_list_lock, but was
then calling functions that required holding ep->lock.
This ended up in bad list corruption of tx_queue (and likely
also of rx queue).