### PR TITLE
prov/efa: fix a bug in rxr_pkt_entry_alloc()

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -69,6 +69,7 @@ struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep,
 	memset(pkt_entry->pkt, 0, ep->mtu_size);
 #endif
 	pkt_entry->state = RXR_PKT_ENTRY_IN_USE;
+	pkt_entry->iov_count = 0;
 	pkt_entry->next = NULL;
 	return pkt_entry;
 }


### PR DESCRIPTION
This patch fix a bug in rxr_pkt_entry_alloc(), it should
initialize pkt_entry->iov_count to 0. Not initializing the
variable cause pkt_entry to send as iov.

Signed-off-by: Wei Zhang <wzam@amazon.com>