### PR TITLE
util/wait: Trickling of patches aimed at improve tcp performance

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -437,9 +437,9 @@ struct ofi_wait_fd_entry {
 
 int ofi_wait_fd_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		struct fid_wait **waitset);
-int ofi_wait_fd_add(struct util_wait *wait, int fd, uint32_t events,
+int ofi_wait_add_fd(struct util_wait *wait, int fd, uint32_t events,
 		    ofi_wait_try_func wait_try, void *arg, void *context);
-int ofi_wait_fd_del(struct util_wait *wait, int fd);
+int ofi_wait_del_fd(struct util_wait *wait, int fd);
 
 struct util_wait_yield {
 	struct util_wait	util_wait;
@@ -458,9 +458,9 @@ struct ofi_wait_fid_entry {
 
 int ofi_wait_yield_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 			struct fid_wait **waitset);
-int ofi_wait_fid_add(struct util_wait *wait, ofi_wait_try_func wait_try,
+int ofi_wait_add_fid(struct util_wait *wait, ofi_wait_try_func wait_try,
 		       void *arg);
-int ofi_wait_fid_del(struct util_wait *wait, void *fid);
+int ofi_wait_del_fid(struct util_wait *wait, void *fid);
 
 /*
  * Completion queue

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -406,6 +406,9 @@ struct util_wait {
 	enum fi_wait_obj	wait_obj;
 	fi_wait_signal_func	signal;
 	fi_wait_try_func	wait_try;
+
+	struct dlist_entry	fid_list;
+	fastlock_t		lock;
 };
 
 int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
@@ -416,7 +419,6 @@ struct util_wait_fd {
 	struct util_wait	util_wait;
 	struct fd_signal	signal;
 	struct dlist_entry	fd_list;
-	fastlock_t		lock;
 
 	union {
 		ofi_epoll_t		epoll_fd;
@@ -454,8 +456,6 @@ int ofi_wait_del_fid(struct util_wait *wait, fid_t fid);
 struct util_wait_yield {
 	struct util_wait	util_wait;
 	int			signal;
-	struct dlist_entry	fid_list;
-	fastlock_t		wait_lock;
 	fastlock_t		signal_lock;
 };
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -435,11 +435,21 @@ struct ofi_wait_fd_entry {
 	ofi_atomic32_t		ref;
 };
 
+struct ofi_wait_fid_entry {
+	struct dlist_entry	entry;
+	ofi_wait_try_func	wait_try;
+	fid_t			fid;
+	ofi_atomic32_t		ref;
+};
+
 int ofi_wait_fd_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 		struct fid_wait **waitset);
 int ofi_wait_add_fd(struct util_wait *wait, int fd, uint32_t events,
 		    ofi_wait_try_func wait_try, void *arg, void *context);
 int ofi_wait_del_fd(struct util_wait *wait, int fd);
+int ofi_wait_add_fid(struct util_wait *wat, fid_t fid, uint32_t events,
+		     ofi_wait_try_func wait_try);
+int ofi_wait_del_fid(struct util_wait *wait, fid_t fid);
 
 struct util_wait_yield {
 	struct util_wait	util_wait;
@@ -449,18 +459,8 @@ struct util_wait_yield {
 	fastlock_t		signal_lock;
 };
 
-struct ofi_wait_fid_entry {
-	struct dlist_entry	entry;
-	ofi_wait_try_func	wait_try;
-	void			*fid;
-	ofi_atomic32_t		ref;
-};
-
 int ofi_wait_yield_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 			struct fid_wait **waitset);
-int ofi_wait_add_fid(struct util_wait *wait, ofi_wait_try_func wait_try,
-		       void *arg);
-int ofi_wait_del_fid(struct util_wait *wait, void *fid);
 
 /*
  * Completion queue

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -777,7 +777,7 @@ static int rxd_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		}
 
 		if (cq->wait)
-			ret = ofi_wait_fd_add(cq->wait, ep->dg_cq_fd, OFI_EPOLL_IN,
+			ret = ofi_wait_add_fd(cq->wait, ep->dg_cq_fd, OFI_EPOLL_IN,
 					      rxd_ep_trywait, ep,
 					      &ep->util_ep.ep_fid.fid);
 		break;
@@ -809,7 +809,7 @@ static int rxd_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 			return ret;
 
 		if (cntr->wait)
-			ret = ofi_wait_fd_add(cntr->wait, ep->dg_cq_fd,
+			ret = ofi_wait_add_fd(cntr->wait, ep->dg_cq_fd,
 					      OFI_EPOLL_IN, rxd_ep_trywait, ep,
 					      &ep->util_ep.ep_fid.fid);
 		break;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2271,7 +2271,7 @@ static int rxm_ep_wait_fd_add(struct rxm_ep *rxm_ep, struct util_wait *wait)
 		return ret;
 	}
 
-	ret = ofi_wait_fd_add(wait, msg_cq_fd, OFI_EPOLL_IN,
+	ret = ofi_wait_add_fd(wait, msg_cq_fd, OFI_EPOLL_IN,
 			      rxm_ep_trywait_cq, rxm_ep,
 			      &rxm_ep->util_ep.ep_fid.fid);
 	if (ret)
@@ -2288,7 +2288,7 @@ static int rxm_ep_wait_fd_add(struct rxm_ep *rxm_ep, struct util_wait *wait)
 		return ret;
 	}
 
-	return ofi_wait_fd_add(wait, msg_eq_fd, OFI_EPOLL_IN, rxm_ep_trywait_eq,
+	return ofi_wait_add_fd(wait, msg_eq_fd, OFI_EPOLL_IN, rxm_ep_trywait_eq,
 			       rxm_ep, &rxm_ep->util_ep.ep_fid.fid);
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -368,7 +368,7 @@ static int smr_ep_bind_cq(struct smr_ep *ep, struct util_cq *cq, uint64_t flags)
 	}
 
 	if (cq->wait) {
-		ret = ofi_wait_fid_add(cq->wait, smr_ep_trywait,
+		ret = ofi_wait_add_fid(cq->wait, smr_ep_trywait,
 				       &ep->util_ep.ep_fid.fid);
 		if (ret)
 			return ret;
@@ -390,7 +390,7 @@ static int smr_ep_bind_cntr(struct smr_ep *ep, struct util_cntr *cntr, uint64_t 
 		return ret;
 
 	if (cntr->wait) {	
-		ret = ofi_wait_fid_add(cntr->wait, smr_ep_trywait,
+		ret = ofi_wait_add_fid(cntr->wait, smr_ep_trywait,
 				       &ep->util_ep.ep_fid.fid);
 		if (ret)
 			return ret;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -368,8 +368,8 @@ static int smr_ep_bind_cq(struct smr_ep *ep, struct util_cq *cq, uint64_t flags)
 	}
 
 	if (cq->wait) {
-		ret = ofi_wait_add_fid(cq->wait, smr_ep_trywait,
-				       &ep->util_ep.ep_fid.fid);
+		ret = ofi_wait_add_fid(cq->wait, &ep->util_ep.ep_fid.fid, 0,
+				       smr_ep_trywait);
 		if (ret)
 			return ret;
 	}
@@ -390,8 +390,8 @@ static int smr_ep_bind_cntr(struct smr_ep *ep, struct util_cntr *cntr, uint64_t 
 		return ret;
 
 	if (cntr->wait) {	
-		ret = ofi_wait_add_fid(cntr->wait, smr_ep_trywait,
-				       &ep->util_ep.ep_fid.fid);
+		ret = ofi_wait_add_fid(cntr->wait, &ep->util_ep.ep_fid.fid, 0,
+				       smr_ep_trywait);
 		if (ret)
 			return ret;
 	}

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -141,14 +141,14 @@ static int tcpx_ep_enable_xfers(struct tcpx_ep *ep)
 	fastlock_release(&ep->lock);
 
 	if (ep->util_ep.rx_cq) {
-		ret = ofi_wait_fd_add(ep->util_ep.rx_cq->wait,
+		ret = ofi_wait_add_fd(ep->util_ep.rx_cq->wait,
 				      ep->sock, OFI_EPOLL_IN, tcpx_try_func,
 				      (void *) &ep->util_ep,
 				      &ep->util_ep.ep_fid.fid);
 	}
 
 	if (ep->util_ep.tx_cq) {
-		ret = ofi_wait_fd_add(ep->util_ep.tx_cq->wait,
+		ret = ofi_wait_add_fd(ep->util_ep.tx_cq->wait,
 				      ep->sock, OFI_EPOLL_IN, tcpx_try_func,
 				      (void *) &ep->util_ep,
 				      &ep->util_ep.ep_fid.fid);
@@ -215,7 +215,7 @@ static void client_recv_connresp(struct util_wait *wait,
 	assert(cm_ctx->fid->fclass == FI_CLASS_EP);
 	ep = container_of(cm_ctx->fid, struct tcpx_ep, util_ep.ep_fid.fid);
 
-	ret = ofi_wait_fd_del(wait, ep->sock);
+	ret = ofi_wait_del_fd(wait, ep->sock);
 	if (ret) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"Could not remove fd from wait\n");
@@ -272,7 +272,7 @@ static void server_send_cm_accept(struct util_wait *wait,
 	if (ret < 0)
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
 
-	ret = ofi_wait_fd_del(wait, ep->sock);
+	ret = ofi_wait_del_fd(wait, ep->sock);
 	if (ret) {
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"Could not remove fd from wait\n");
@@ -342,7 +342,7 @@ static void server_recv_connreq(struct util_wait *wait,
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL, "Error writing to EQ\n");
 		goto err3;
 	}
-	ret = ofi_wait_fd_del(wait, handle->sock);
+	ret = ofi_wait_del_fd(wait, handle->sock);
 	if (ret)
 		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 			"fd deletion from ofi_wait failed\n");
@@ -354,7 +354,7 @@ err3:
 err2:
 	free(cm_entry);
 err1:
-	ofi_wait_fd_del(wait, handle->sock);
+	ofi_wait_del_fd(wait, handle->sock);
 	ofi_close_socket(handle->sock);
 	free(cm_ctx);
 	free(handle);
@@ -385,12 +385,12 @@ static void client_send_connreq(struct util_wait *wait,
 	if (ret)
 		goto err;
 
-	ret = ofi_wait_fd_del(wait, ep->sock);
+	ret = ofi_wait_del_fd(wait, ep->sock);
 	if (ret)
 		goto err;
 
 	cm_ctx->type = CLIENT_RECV_CONNRESP;
-	ret = ofi_wait_fd_add(wait, ep->sock, OFI_EPOLL_IN,
+	ret = ofi_wait_add_fd(wait, ep->sock, OFI_EPOLL_IN,
 			      tcpx_eq_wait_try_func, NULL, cm_ctx);
 	if (ret)
 		goto err;
@@ -445,7 +445,7 @@ static void server_sock_accept(struct util_wait *wait,
 	rx_req_cm_ctx->fid = &handle->handle;
 	rx_req_cm_ctx->type = SERVER_RECV_CONNREQ;
 
-	ret = ofi_wait_fd_add(wait, sock, OFI_EPOLL_IN,
+	ret = ofi_wait_add_fd(wait, sock, OFI_EPOLL_IN,
 			      tcpx_eq_wait_try_func,
 			      NULL, (void *) rx_req_cm_ctx);
 	if (ret)

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -122,7 +122,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 		memcpy(cm_ctx->cm_data, param, paramlen);
 	}
 
-	ret = ofi_wait_fd_add(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
+	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
 			      OFI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL,cm_ctx);
 	if (ret)
 		goto err;
@@ -157,7 +157,7 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 		memcpy(cm_ctx->cm_data, param, paramlen);
 	}
 
-	ret = ofi_wait_fd_add(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
+	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
 			      OFI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL, cm_ctx);
 	if (ret) {
 		free(cm_ctx);
@@ -362,13 +362,13 @@ void tcpx_ep_wait_fd_del(struct tcpx_ep *ep)
 	/* eq->close_lock protects from processing stale connection events */
 	fastlock_acquire(&eq->close_lock);
 	if (ep->util_ep.rx_cq)
-		ofi_wait_fd_del(ep->util_ep.rx_cq->wait, ep->sock);
+		ofi_wait_del_fd(ep->util_ep.rx_cq->wait, ep->sock);
 
 	if (ep->util_ep.tx_cq)
-		ofi_wait_fd_del(ep->util_ep.tx_cq->wait, ep->sock);
+		ofi_wait_del_fd(ep->util_ep.tx_cq->wait, ep->sock);
 
 	if (ep->util_ep.eq->wait)
-		ofi_wait_fd_del(ep->util_ep.eq->wait, ep->sock);
+		ofi_wait_del_fd(ep->util_ep.eq->wait, ep->sock);
 
 	fastlock_release(&eq->close_lock);
 }
@@ -589,7 +589,7 @@ static int tcpx_pep_fi_close(struct fid *fid)
 
 	pep = container_of(fid, struct tcpx_pep, util_pep.pep_fid.fid);
 	if (pep->util_pep.eq)
-		ofi_wait_fd_del(pep->util_pep.eq->wait, pep->sock);
+		ofi_wait_del_fd(pep->util_pep.eq->wait, pep->sock);
 
 	ofi_close_socket(pep->sock);
 	ofi_pep_close(&pep->util_pep);
@@ -679,7 +679,7 @@ static int tcpx_pep_listen(struct fid_pep *pep)
 		return -ofi_sockerr();
 	}
 
-	ret = ofi_wait_fd_add(tcpx_pep->util_pep.eq->wait, tcpx_pep->sock,
+	ret = ofi_wait_add_fd(tcpx_pep->util_pep.eq->wait, tcpx_pep->sock,
 			      OFI_EPOLL_IN, tcpx_eq_wait_try_func,
 			      NULL, &tcpx_pep->cm_ctx);
 

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -150,7 +150,7 @@ int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
 	return 0;
 }
 
-static int ofi_wait_fd_match(struct dlist_entry *item, const void *arg)
+static int ofi_wait_match_fd(struct dlist_entry *item, const void *arg)
 {
 	struct ofi_wait_fd_entry *fd_entry;
 
@@ -158,7 +158,7 @@ static int ofi_wait_fd_match(struct dlist_entry *item, const void *arg)
 	return fd_entry->fd == *(int *) arg;
 }
 
-int ofi_wait_fd_del(struct util_wait *wait, int fd)
+int ofi_wait_del_fd(struct util_wait *wait, int fd)
 {
 	struct ofi_wait_fd_entry *fd_entry;
 	struct dlist_entry *entry;
@@ -167,7 +167,7 @@ int ofi_wait_fd_del(struct util_wait *wait, int fd)
 
 	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
 	fastlock_acquire(&wait_fd->lock);
-	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_fd_match, &fd);
+	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_match_fd, &fd);
 	if (!entry) {
 		FI_INFO(wait->prov, FI_LOG_FABRIC,
 			"Given fd (%d) not found in wait list - %p\n",
@@ -193,7 +193,7 @@ out:
 	return ret;
 }
 
-int ofi_wait_fd_add(struct util_wait *wait, int fd, uint32_t events,
+int ofi_wait_add_fd(struct util_wait *wait, int fd, uint32_t events,
 		    ofi_wait_try_func wait_try, void *arg, void *context)
 {
 	struct ofi_wait_fd_entry *fd_entry;
@@ -203,7 +203,7 @@ int ofi_wait_fd_add(struct util_wait *wait, int fd, uint32_t events,
 
 	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
 	fastlock_acquire(&wait_fd->lock);
-	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_fd_match, &fd);
+	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_match_fd, &fd);
 	if (entry) {
 		FI_DBG(wait->prov, FI_LOG_EP_CTRL,
 		       "Given fd (%d) already added to wait list - %p \n",
@@ -611,7 +611,7 @@ int ofi_wait_yield_open(struct fid_fabric *fabric_fid, struct fi_wait_attr *attr
 	return 0;
 }
 
-static int ofi_wait_fid_match(struct dlist_entry *item, const void *arg)
+static int ofi_wait_match_fid(struct dlist_entry *item, const void *arg)
 {
 	struct ofi_wait_fid_entry *fid_entry;
 
@@ -619,7 +619,7 @@ static int ofi_wait_fid_match(struct dlist_entry *item, const void *arg)
 	return fid_entry->fid == arg;
 }
 
-int ofi_wait_fid_del(struct util_wait *wait, void *fid)
+int ofi_wait_del_fid(struct util_wait *wait, void *fid)
 {
 	int ret = 0;
 	struct ofi_wait_fid_entry *fid_entry;
@@ -629,7 +629,7 @@ int ofi_wait_fid_del(struct util_wait *wait, void *fid)
 						util_wait);
 
 	fastlock_acquire(&wait_yield->wait_lock);
-	entry = dlist_find_first_match(&wait_yield->fid_list, ofi_wait_fid_match,
+	entry = dlist_find_first_match(&wait_yield->fid_list, ofi_wait_match_fid,
 				       fid);
 	if (!entry) {
 		FI_INFO(wait->prov, FI_LOG_FABRIC,
@@ -648,7 +648,7 @@ out:
 	return ret;
 }
 
-int ofi_wait_fid_add(struct util_wait *wait, ofi_wait_try_func wait_try,
+int ofi_wait_add_fid(struct util_wait *wait, ofi_wait_try_func wait_try,
 		     void *fid)
 {
 	struct ofi_wait_fid_entry *fid_entry;
@@ -658,7 +658,7 @@ int ofi_wait_fid_add(struct util_wait *wait, ofi_wait_try_func wait_try,
 	int ret = 0;
 
 	fastlock_acquire(&wait_yield->wait_lock);
-	entry = dlist_find_first_match(&wait_yield->fid_list, ofi_wait_fid_match,
+	entry = dlist_find_first_match(&wait_yield->fid_list, ofi_wait_match_fid,
 				       fid);
 	if (entry) {
 		FI_DBG(wait->prov, FI_LOG_EP_CTRL,

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -100,6 +100,7 @@ int ofi_check_wait_attr(const struct fi_provider *prov,
 
 int fi_wait_cleanup(struct util_wait *wait)
 {
+	struct ofi_wait_fid_entry *fid_entry;
 	int ret;
 
 	if (ofi_atomic_get32(&wait->ref))
@@ -109,6 +110,13 @@ int fi_wait_cleanup(struct util_wait *wait)
 	if (ret)
 		return ret;
 
+	while (!dlist_empty(&wait->fid_list)) {
+		dlist_pop_front(&wait->fid_list, struct ofi_wait_fid_entry,
+				fid_entry, entry);
+		free(fid_entry);
+	}
+
+	fastlock_destroy(&wait->lock);
 	ofi_atomic_dec32(&wait->fabric->ref);
 	return 0;
 }
@@ -145,6 +153,8 @@ int ofi_wait_init(struct util_fabric *fabric, struct fi_wait_attr *attr,
 		return ret;
 
 	wait->pollset = container_of(poll_fid, struct util_poll, poll_fid);
+	fastlock_init(&wait->lock);
+	dlist_init(&wait->fid_list);
 	wait->fabric = fabric;
 	ofi_atomic_inc32(&fabric->ref);
 	return 0;
@@ -166,7 +176,7 @@ int ofi_wait_del_fd(struct util_wait *wait, int fd)
 	int ret = 0;
 
 	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
-	fastlock_acquire(&wait_fd->lock);
+	fastlock_acquire(&wait->lock);
 	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_match_fd, &fd);
 	if (!entry) {
 		FI_INFO(wait->prov, FI_LOG_FABRIC,
@@ -189,7 +199,7 @@ int ofi_wait_del_fd(struct util_wait *wait, int fd)
 	free(fd_entry);
 	wait_fd->change_index++;
 out:
-	fastlock_release(&wait_fd->lock);
+	fastlock_release(&wait->lock);
 	return ret;
 }
 
@@ -202,7 +212,7 @@ int ofi_wait_add_fd(struct util_wait *wait, int fd, uint32_t events,
 	int ret = 0;
 
 	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
-	fastlock_acquire(&wait_fd->lock);
+	fastlock_acquire(&wait->lock);
 	entry = dlist_find_first_match(&wait_fd->fd_list, ofi_wait_match_fd, &fd);
 	if (entry) {
 		FI_DBG(wait->prov, FI_LOG_EP_CTRL,
@@ -239,7 +249,7 @@ int ofi_wait_add_fd(struct util_wait *wait, int fd, uint32_t events,
 	dlist_insert_tail(&fd_entry->entry, &wait_fd->fd_list);
 	wait_fd->change_index++;
 out:
-	fastlock_release(&wait_fd->lock);
+	fastlock_release(&wait->lock);
 	return ret;
 }
 
@@ -259,16 +269,16 @@ static int util_wait_fd_try(struct util_wait *wait)
 
 	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
 	fd_signal_reset(&wait_fd->signal);
-	fastlock_acquire(&wait_fd->lock);
+	fastlock_acquire(&wait->lock);
 	dlist_foreach_container(&wait_fd->fd_list, struct ofi_wait_fd_entry,
 				fd_entry, entry) {
 		ret = fd_entry->wait_try(fd_entry->arg);
 		if (ret != FI_SUCCESS) {
-			fastlock_release(&wait_fd->lock);
+			fastlock_release(&wait->lock);
 			return ret;
 		}
 	}
-	fastlock_release(&wait_fd->lock);
+	fastlock_release(&wait->lock);
 	ret = fi_poll(&wait->pollset->poll_fid, &context, 1);
 	return (ret > 0) ? -FI_EAGAIN : (ret == -FI_EAGAIN) ? FI_SUCCESS : ret;
 }
@@ -324,7 +334,7 @@ static int util_wait_fd_control(struct fid *fid, int command, void *arg)
 		}
 
 		pollfd = arg;
-		fastlock_acquire(&wait->lock);
+		fastlock_acquire(&wait->util_wait.lock);
 		if (pollfd->nfds >= wait->pollfds->nfds) {
 			memcpy(pollfd->fd, &wait->pollfds->fds[0],
 			       wait->pollfds->nfds * sizeof(*wait->pollfds->fds));
@@ -334,7 +344,7 @@ static int util_wait_fd_control(struct fid *fid, int command, void *arg)
 		}
 		pollfd->change_index = wait->change_index;
 		pollfd->nfds = wait->pollfds->nfds;
-		fastlock_release(&wait->lock);
+		fastlock_release(&wait->util_wait.lock);
 		break;
 	default:
 		FI_INFO(wait->util_wait.prov, FI_LOG_FABRIC,
@@ -352,11 +362,8 @@ static int util_wait_fd_close(struct fid *fid)
 	int ret;
 
 	wait = container_of(fid, struct util_wait_fd, util_wait.wait_fid.fid);
-	ret = fi_wait_cleanup(&wait->util_wait);
-	if (ret)
-		return ret;
 
-	fastlock_acquire(&wait->lock);
+	fastlock_acquire(&wait->util_wait.lock);
 	while (!dlist_empty(&wait->fd_list)) {
 		dlist_pop_front(&wait->fd_list, struct ofi_wait_fd_entry,
 				fd_entry, entry);
@@ -366,7 +373,11 @@ static int util_wait_fd_close(struct fid *fid)
 			ofi_pollfds_del(wait->pollfds, fd_entry->fd);
 		free(fd_entry);
 	}
-	fastlock_release(&wait->lock);
+	fastlock_release(&wait->util_wait.lock);
+
+	ret = fi_wait_cleanup(&wait->util_wait);
+	if (ret)
+		return ret;
 
 	ofi_epoll_del(wait->epoll_fd, wait->signal.fd[FI_READ_FD]);
 	fd_signal_free(&wait->signal);
@@ -375,7 +386,6 @@ static int util_wait_fd_close(struct fid *fid)
 		ofi_epoll_close(wait->epoll_fd);
 	else
 		ofi_epoll_close(wait->epoll_fd);
-	fastlock_destroy(&wait->lock);
 	free(wait);
 	return 0;
 }
@@ -459,7 +469,6 @@ int ofi_wait_fd_open(struct fid_fabric *fabric_fid, struct fi_wait_attr *attr,
 	wait->util_wait.wait_fid.ops = &util_wait_fd_ops;
 
 	dlist_init(&wait->fd_list);
-	fastlock_init(&wait->lock);
 
 	*waitset = &wait->util_wait.wait_fid;
 	return 0;
@@ -491,21 +500,21 @@ static void util_wait_yield_signal(struct util_wait *util_wait)
 
 static int util_wait_yield_run(struct fid_wait *wait_fid, int timeout)
 {
-	struct util_wait_yield *wait = container_of(wait_fid,
-			struct util_wait_yield, util_wait.wait_fid);
+	struct util_wait_yield *wait;
 	struct ofi_wait_fid_entry *fid_entry;
 	int ret = 0;
 
+	wait = container_of(wait_fid, struct util_wait_yield, util_wait.wait_fid);
 	while (!wait->signal) {
-		fastlock_acquire(&wait->wait_lock);
-		dlist_foreach_container(&wait->fid_list,
+		fastlock_acquire(&wait->util_wait.lock);
+		dlist_foreach_container(&wait->util_wait.fid_list,
 					struct ofi_wait_fid_entry,
 					fid_entry, entry) {
 			ret = fid_entry->wait_try(fid_entry->fid);
 			if (ret)
 				return ret;
 		}
-		fastlock_release(&wait->wait_lock);
+		fastlock_release(&wait->util_wait.lock);
 		pthread_yield();
 	}
 
@@ -519,7 +528,6 @@ static int util_wait_yield_run(struct fid_wait *wait_fid, int timeout)
 static int util_wait_yield_close(struct fid *fid)
 {
 	struct util_wait_yield *wait;
-	struct ofi_wait_fid_entry *fid_entry;
 	int ret;
 
 	wait = container_of(fid, struct util_wait_yield, util_wait.wait_fid.fid);
@@ -527,13 +535,6 @@ static int util_wait_yield_close(struct fid *fid)
 	if (ret)
 		return ret;
 
-	while (!dlist_empty(&wait->fid_list)) {
-		dlist_pop_front(&wait->fid_list, struct ofi_wait_fid_entry,
-				fid_entry, entry);
-		free(fid_entry);
-	}
-
-	fastlock_destroy(&wait->wait_lock);
 	fastlock_destroy(&wait->signal_lock);
 	free(wait);
 	return 0;
@@ -602,9 +603,7 @@ int ofi_wait_yield_open(struct fid_fabric *fabric_fid, struct fi_wait_attr *attr
 	wait->util_wait.wait_fid.fid.ops = &util_wait_yield_fi_ops;
 	wait->util_wait.wait_fid.ops = &util_wait_yield_ops;
 
-	fastlock_init(&wait->wait_lock);
 	fastlock_init(&wait->signal_lock);
-	dlist_init(&wait->fid_list);
 
 	*waitset = &wait->util_wait.wait_fid;
 
@@ -623,17 +622,15 @@ int ofi_wait_del_fid(struct util_wait *wait, fid_t fid)
 {
 	struct ofi_wait_fid_entry *fid_entry;
 	struct dlist_entry *entry;
-	struct util_wait_yield *wait_yield;
 	int ret = 0;
 
-	wait_yield = container_of(wait, struct util_wait_yield, util_wait);
-	fastlock_acquire(&wait_yield->wait_lock);
-	entry = dlist_find_first_match(&wait_yield->fid_list,
+	fastlock_acquire(&wait->lock);
+	entry = dlist_find_first_match(&wait->fid_list,
 				       ofi_wait_match_fid, fid);
 	if (!entry) {
 		FI_INFO(wait->prov, FI_LOG_FABRIC,
 			"Given fid (%p) not found in wait list - %p\n",
-			fid, wait_yield);
+			fid, wait);
 		ret = -FI_EINVAL;
 		goto out;
 	}
@@ -645,7 +642,7 @@ int ofi_wait_del_fid(struct util_wait *wait, fid_t fid)
 	dlist_remove(&fid_entry->entry);
 	free(fid_entry);
 out:
-	fastlock_release(&wait_yield->wait_lock);
+	fastlock_release(&wait->lock);
 	return ret;
 }
 
@@ -654,17 +651,15 @@ int ofi_wait_add_fid(struct util_wait *wait, fid_t fid, uint32_t events,
 {
 	struct ofi_wait_fid_entry *fid_entry;
 	struct dlist_entry *entry;
-	struct util_wait_yield *wait_yield;
 	int ret = 0;
 
-	wait_yield = container_of(wait, struct util_wait_yield, util_wait);
-	fastlock_acquire(&wait_yield->wait_lock);
-	entry = dlist_find_first_match(&wait_yield->fid_list,
+	fastlock_acquire(&wait->lock);
+	entry = dlist_find_first_match(&wait->fid_list,
 				       ofi_wait_match_fid, fid);
 	if (entry) {
 		FI_DBG(wait->prov, FI_LOG_EP_CTRL,
 		       "Given fid (%p) already added to wait list - %p \n",
-		       fid, wait_yield);
+		       fid, wait);
 		fid_entry = container_of(entry, struct ofi_wait_fid_entry, entry);
 		ofi_atomic_inc32(&fid_entry->ref);
 		goto out;
@@ -679,8 +674,8 @@ int ofi_wait_add_fid(struct util_wait *wait, fid_t fid, uint32_t events,
 	fid_entry->fid = fid;
 	fid_entry->wait_try = wait_try;
 	ofi_atomic_initialize32(&fid_entry->ref, 1);
-	dlist_insert_tail(&fid_entry->entry, &wait_yield->fid_list);
+	dlist_insert_tail(&fid_entry->entry, &wait->fid_list);
 out:
-	fastlock_release(&wait_yield->wait_lock);
+	fastlock_release(&wait->lock);
 	return ret;
 }


### PR DESCRIPTION
The long term goal here is for an rxm level wait set to monitor all wait objects (sockets in this case) used by the tcp level wait set *without* needing to use epoll, because epoll performance is the suck.

This continues a set of changes to the util wait code.  The changes are aimed at allowing a fid to be directly associated with a wait set.  The shm provider and yield based wait set supports this today.  These changes make this more generic, so that the underlying fid can be associated with one or more fd's as its wait object.