### PR TITLE
util/wait: Fix locking issue in util_wait_yield_run

### DIFF
--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -511,8 +511,10 @@ static int util_wait_yield_run(struct fid_wait *wait_fid, int timeout)
 					struct ofi_wait_fid_entry,
 					fid_entry, entry) {
 			ret = fid_entry->wait_try(fid_entry->fid);
-			if (ret)
+			if (ret) {
+				fastlock_release(&wait->util_wait.lock);
 				return ret;
+			}
 		}
 		fastlock_release(&wait->util_wait.lock);
 		pthread_yield();


### PR DESCRIPTION
Release the spinlock before returning.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>