### PR TITLE
util/wait: More changes to support poll() as a wait call

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -441,6 +441,7 @@ struct ofi_wait_fid_entry {
 	struct dlist_entry	entry;
 	ofi_wait_try_func	wait_try;
 	fid_t			fid;
+	uint32_t		events;
 	ofi_atomic32_t		ref;
 };
 

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -625,6 +625,7 @@ enum {
 	FI_FLUSH_WORK,		/* NULL */
 	FI_REFRESH,		/* mr: fi_mr_modify */
 	FI_DUP,			/* struct fid ** */
+	FI_GETWAITOBJ,		/*enum fi_wait_obj * */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -777,7 +777,7 @@ static int rxd_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 		}
 
 		if (cq->wait)
-			ret = ofi_wait_add_fd(cq->wait, ep->dg_cq_fd, OFI_EPOLL_IN,
+			ret = ofi_wait_add_fd(cq->wait, ep->dg_cq_fd, POLLIN,
 					      rxd_ep_trywait, ep,
 					      &ep->util_ep.ep_fid.fid);
 		break;
@@ -810,7 +810,7 @@ static int rxd_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 
 		if (cntr->wait)
 			ret = ofi_wait_add_fd(cntr->wait, ep->dg_cq_fd,
-					      OFI_EPOLL_IN, rxd_ep_trywait, ep,
+					      POLLIN, rxd_ep_trywait, ep,
 					      &ep->util_ep.ep_fid.fid);
 		break;
 	default:

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2266,14 +2266,14 @@ static int rxm_ep_wait_fd_add(struct rxm_ep *rxm_ep, struct util_wait *wait)
 {
 	int ret;
 
-	ret = ofi_wait_add_fid(wait, &rxm_ep->msg_cq->fid, OFI_EPOLL_IN,
+	ret = ofi_wait_add_fid(wait, &rxm_ep->msg_cq->fid, POLLIN,
 			       rxm_ep_trywait_cq);
 
 	if (ret || (rxm_ep->util_ep.domain->data_progress == FI_PROGRESS_AUTO &&
 	    !(rxm_ep->util_ep.caps & FI_ATOMIC)))
 		return ret;
 
-	return ofi_wait_add_fid(wait, &rxm_ep->msg_eq->fid, OFI_EPOLL_IN,
+	return ofi_wait_add_fid(wait, &rxm_ep->msg_eq->fid, POLLIN,
 				rxm_ep_trywait_eq);
 }
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2237,8 +2237,9 @@ static int rxm_ep_close(struct fid *fid)
 static int rxm_ep_trywait_cq(void *arg)
 {
 	struct rxm_fabric *rxm_fabric;
-	struct rxm_ep *rxm_ep = (struct rxm_ep *)arg;
-	struct fid *fids[1] = {&rxm_ep->msg_cq->fid};
+	fid_t fid = arg;
+	struct rxm_ep *rxm_ep = fid->context;
+	struct fid *fids[1] = { &rxm_ep->msg_cq->fid };
 	int ret;
 
 	rxm_fabric = container_of(rxm_ep->util_ep.domain->fabric,
@@ -2252,8 +2253,9 @@ static int rxm_ep_trywait_cq(void *arg)
 static int rxm_ep_trywait_eq(void *arg)
 {
 	struct rxm_fabric *rxm_fabric;
-	struct rxm_ep *rxm_ep = (struct rxm_ep *)arg;
-	struct fid *fids[1] = {&rxm_ep->msg_eq->fid};
+	fid_t fid = arg;
+	struct rxm_ep *rxm_ep = fid->context;
+	struct fid *fids[1] = { &rxm_ep->msg_eq->fid };
 
 	rxm_fabric = container_of(rxm_ep->util_ep.domain->fabric,
 				  struct rxm_fabric, util_fabric);
@@ -2262,34 +2264,17 @@ static int rxm_ep_trywait_eq(void *arg)
 
 static int rxm_ep_wait_fd_add(struct rxm_ep *rxm_ep, struct util_wait *wait)
 {
-	int msg_eq_fd, msg_cq_fd, ret;
+	int ret;
 
-	ret = fi_control(&rxm_ep->msg_cq->fid, FI_GETWAIT, &msg_cq_fd);
-	if (ret) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-			"unable to get MSG CQ wait fd %d\n", ret);
-		return ret;
-	}
+	ret = ofi_wait_add_fid(wait, &rxm_ep->msg_cq->fid, OFI_EPOLL_IN,
+			       rxm_ep_trywait_cq);
 
-	ret = ofi_wait_add_fd(wait, msg_cq_fd, OFI_EPOLL_IN,
-			      rxm_ep_trywait_cq, rxm_ep,
-			      &rxm_ep->util_ep.ep_fid.fid);
-	if (ret)
+	if (ret || (rxm_ep->util_ep.domain->data_progress == FI_PROGRESS_AUTO &&
+	    !(rxm_ep->util_ep.caps & FI_ATOMIC)))
 		return ret;
 
-	if (rxm_ep->util_ep.domain->data_progress == FI_PROGRESS_AUTO &&
-	    !(rxm_ep->util_ep.caps & FI_ATOMIC))
-		return 0;
-
-	ret = fi_control(&rxm_ep->msg_eq->fid, FI_GETWAIT, &msg_eq_fd);
-	if (ret) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-			"unable to get MSG EQ wait fd %d\n", ret);
-		return ret;
-	}
-
-	return ofi_wait_add_fd(wait, msg_eq_fd, OFI_EPOLL_IN, rxm_ep_trywait_eq,
-			       rxm_ep, &rxm_ep->util_ep.ep_fid.fid);
+	return ofi_wait_add_fid(wait, &rxm_ep->msg_eq->fid, OFI_EPOLL_IN,
+				rxm_ep_trywait_eq);
 }
 
 static int rxm_msg_cq_fd_needed(struct rxm_ep *rxm_ep)
@@ -2329,9 +2314,11 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep)
 	cq_attr.wait_obj = (rxm_msg_cq_fd_needed(rxm_ep) ?
 			    FI_WAIT_FD : FI_WAIT_NONE);
 
-	rxm_domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain, util_domain);
+	rxm_domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain,
+				  util_domain);
 
-	ret = fi_cq_open(rxm_domain->msg_domain, &cq_attr, &rxm_ep->msg_cq, NULL);
+	ret = fi_cq_open(rxm_domain->msg_domain, &cq_attr, &rxm_ep->msg_cq,
+			 rxm_ep);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "unable to open MSG CQ\n");
 		return ret;
@@ -2568,12 +2555,13 @@ static int rxm_listener_open(struct rxm_ep *rxm_ep)
 		.wait_obj = FI_WAIT_UNSPEC,
 		.flags = FI_WRITE,
 	};
+	struct rxm_fabric *rxm_fabric;
 	int ret;
-	struct rxm_fabric *rxm_fabric =
-		container_of(rxm_ep->util_ep.domain->fabric,
-			     struct rxm_fabric, util_fabric);
 
-	ret = fi_eq_open(rxm_fabric->msg_fabric, &eq_attr, &rxm_ep->msg_eq, NULL);
+	rxm_fabric = container_of(rxm_ep->util_ep.domain->fabric,
+				  struct rxm_fabric, util_fabric);
+	ret = fi_eq_open(rxm_fabric->msg_fabric, &eq_attr, &rxm_ep->msg_eq,
+			 rxm_ep);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, "Unable to open msg EQ\n");
 		return ret;

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -142,14 +142,14 @@ static int tcpx_ep_enable_xfers(struct tcpx_ep *ep)
 
 	if (ep->util_ep.rx_cq) {
 		ret = ofi_wait_add_fd(ep->util_ep.rx_cq->wait,
-				      ep->sock, OFI_EPOLL_IN, tcpx_try_func,
+				      ep->sock, POLLIN, tcpx_try_func,
 				      (void *) &ep->util_ep,
 				      &ep->util_ep.ep_fid.fid);
 	}
 
 	if (ep->util_ep.tx_cq) {
 		ret = ofi_wait_add_fd(ep->util_ep.tx_cq->wait,
-				      ep->sock, OFI_EPOLL_IN, tcpx_try_func,
+				      ep->sock, POLLIN, tcpx_try_func,
 				      (void *) &ep->util_ep,
 				      &ep->util_ep.ep_fid.fid);
 	}
@@ -390,7 +390,7 @@ static void client_send_connreq(struct util_wait *wait,
 		goto err;
 
 	cm_ctx->type = CLIENT_RECV_CONNRESP;
-	ret = ofi_wait_add_fd(wait, ep->sock, OFI_EPOLL_IN,
+	ret = ofi_wait_add_fd(wait, ep->sock, POLLIN,
 			      tcpx_eq_wait_try_func, NULL, cm_ctx);
 	if (ret)
 		goto err;
@@ -445,7 +445,7 @@ static void server_sock_accept(struct util_wait *wait,
 	rx_req_cm_ctx->fid = &handle->handle;
 	rx_req_cm_ctx->type = SERVER_RECV_CONNREQ;
 
-	ret = ofi_wait_add_fd(wait, sock, OFI_EPOLL_IN,
+	ret = ofi_wait_add_fd(wait, sock, POLLIN,
 			      tcpx_eq_wait_try_func,
 			      NULL, (void *) rx_req_cm_ctx);
 	if (ret)

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -205,11 +205,11 @@ static int tcpx_cq_control(struct fid *fid, int command, void *arg)
 
 	switch(command) {
 	case FI_GETWAIT:
+	case FI_GETWAITOBJ:
 		if (!cq->wait)
-			return -FI_ENOSYS;
+			return -FI_ENODATA;
 
-		ret = fi_control(&cq->wait->wait_fid.fid,
-				 command, arg);
+		ret = fi_control(&cq->wait->wait_fid.fid, command, arg);
 		break;
 	default:
 		return -FI_ENOSYS;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -123,7 +123,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	}
 
 	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
-			      OFI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL,cm_ctx);
+			      POLLOUT, tcpx_eq_wait_try_func, NULL,cm_ctx);
 	if (ret)
 		goto err;
 
@@ -158,7 +158,7 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 	}
 
 	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
-			      OFI_EPOLL_OUT, tcpx_eq_wait_try_func, NULL, cm_ctx);
+			      POLLOUT, tcpx_eq_wait_try_func, NULL, cm_ctx);
 	if (ret) {
 		free(cm_ctx);
 		return ret;
@@ -680,7 +680,7 @@ static int tcpx_pep_listen(struct fid_pep *pep)
 	}
 
 	ret = ofi_wait_add_fd(tcpx_pep->util_pep.eq->wait, tcpx_pep->sock,
-			      OFI_EPOLL_IN, tcpx_eq_wait_try_func,
+			      POLLIN, tcpx_eq_wait_try_func,
 			      NULL, &tcpx_pep->cm_ctx);
 
 	tcpx_pep->util_pep.eq->wait->signal(tcpx_pep->util_pep.eq->wait);

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -473,9 +473,10 @@ int ofi_cq_control(struct fid *fid, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
+	case FI_GETWAITOBJ:
 		if (!cq->wait)
 			return -FI_ENODATA;
-		return fi_control(&cq->wait->wait_fid.fid, FI_GETWAIT, arg);
+		return fi_control(&cq->wait->wait_fid.fid, command, arg);
 	default:
 		FI_INFO(cq->wait->prov, FI_LOG_CQ, "Unsupported command\n");
 		return -FI_ENOSYS;

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -202,6 +202,7 @@ int ofi_eq_control(struct fid *fid, int command, void *arg)
 
 	switch (command) {
 	case FI_GETWAIT:
+	case FI_GETWAITOBJ:
 		ret = fi_control(&eq->wait->wait_fid.fid, command, arg);
 		break;
 	default:

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -262,6 +262,7 @@ static void util_wait_fd_signal(struct util_wait *util_wait)
 
 static int util_wait_fd_try(struct util_wait *wait)
 {
+	struct ofi_wait_fid_entry *fid_entry;
 	struct ofi_wait_fd_entry *fd_entry;
 	struct util_wait_fd *wait_fd;
 	void *context;
@@ -278,6 +279,16 @@ static int util_wait_fd_try(struct util_wait *wait)
 			return ret;
 		}
 	}
+
+	dlist_foreach_container(&wait->fid_list,
+				struct ofi_wait_fid_entry, fid_entry, entry) {
+		ret = fid_entry->wait_try(fid_entry->fid);
+		if (ret != FI_SUCCESS) {
+			fastlock_release(&wait->lock);
+			return ret;
+		}
+	}
+
 	fastlock_release(&wait->lock);
 	ret = fi_poll(&wait->pollset->poll_fid, &context, 1);
 	return (ret > 0) ? -FI_EAGAIN : (ret == -FI_EAGAIN) ? FI_SUCCESS : ret;
@@ -620,6 +631,28 @@ static int ofi_wait_match_fid(struct dlist_entry *item, const void *arg)
 	return fid_entry->fid == arg;
 }
 
+static int ofi_wait_del_fds(struct util_wait *wait,
+			    struct ofi_wait_fid_entry *fid_entry)
+{
+	struct util_wait_fd *wait_fd;
+	int fd, ret;
+
+	/* TODO: support fid being a pollfd wait set */
+	ret = fi_control(fid_entry->fid, FI_GETWAIT, &fd);
+	if (ret) {
+		FI_WARN(wait->prov, FI_LOG_EP_CTRL,
+			"unable to get wait fd %d\n", ret);
+		return ret;
+	}
+
+	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
+	ret = (wait->wait_obj == FI_WAIT_FD) ?
+	      ofi_epoll_del(wait_fd->epoll_fd, fd) :
+	      ofi_pollfds_del(wait_fd->pollfds, fd);
+
+	return ret;
+}
+
 int ofi_wait_del_fid(struct util_wait *wait, fid_t fid)
 {
 	struct ofi_wait_fid_entry *fid_entry;
@@ -630,7 +663,7 @@ int ofi_wait_del_fid(struct util_wait *wait, fid_t fid)
 	entry = dlist_find_first_match(&wait->fid_list,
 				       ofi_wait_match_fid, fid);
 	if (!entry) {
-		FI_INFO(wait->prov, FI_LOG_FABRIC,
+		FI_INFO(wait->prov, FI_LOG_EP_CTRL,
 			"Given fid (%p) not found in wait list - %p\n",
 			fid, wait);
 		ret = -FI_EINVAL;
@@ -641,10 +674,47 @@ int ofi_wait_del_fid(struct util_wait *wait, fid_t fid)
 	if (ofi_atomic_dec32(&fid_entry->ref))
 		goto out;
 
+	if (wait->wait_obj == FI_WAIT_FD || wait->wait_obj == FI_WAIT_POLLFD) {
+		ret = ofi_wait_del_fds(wait, fid_entry);
+		if (ret) {
+			FI_WARN(wait->prov, FI_LOG_EP_CTRL,
+				"Failed to delete fd's\n");
+			ofi_atomic_inc32(&fid_entry->ref);
+			goto out;
+		}
+	}
+
 	dlist_remove(&fid_entry->entry);
 	free(fid_entry);
 out:
 	fastlock_release(&wait->lock);
+	return ret;
+}
+
+static int ofi_wait_add_fds(struct util_wait *wait,
+			    struct ofi_wait_fid_entry *fid_entry)
+{
+	struct util_wait_fd *wait_fd;
+	int fd, ret;
+
+	/* TODO: support fid being a pollfd wait set */
+	ret = fi_control(fid_entry->fid, FI_GETWAIT, &fd);
+	if (ret) {
+		FI_WARN(wait->prov, FI_LOG_EP_CTRL,
+			"unable to get wait fd %d\n", ret);
+		return ret;
+	}
+
+	wait_fd = container_of(wait, struct util_wait_fd, util_wait);
+	if (wait->wait_obj == FI_WAIT_FD) {
+		ret = ofi_epoll_add(wait_fd->epoll_fd, fd,
+				    fid_entry->events, fid_entry->fid->context);
+	} else {
+		ret = ofi_pollfds_add(wait_fd->pollfds, fd,
+				      fid_entry->events,
+				      fid_entry->fid->context);
+	}
+
 	return ret;
 }
 
@@ -675,7 +745,16 @@ int ofi_wait_add_fid(struct util_wait *wait, fid_t fid, uint32_t events,
 
 	fid_entry->fid = fid;
 	fid_entry->wait_try = wait_try;
+	fid_entry->events = events;
 	ofi_atomic_initialize32(&fid_entry->ref, 1);
+
+	if (wait->wait_obj == FI_WAIT_FD || wait->wait_obj == FI_WAIT_POLLFD) {
+		ret = ofi_wait_add_fds(wait, fid_entry);
+		if (ret) {
+			free(fid_entry);
+			goto out;
+		}
+	}
 	dlist_insert_tail(&fid_entry->entry, &wait->fid_list);
 out:
 	fastlock_release(&wait->lock);

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -340,7 +340,7 @@ static int util_wait_fd_control(struct fid *fid, int command, void *arg)
 			*(int *) arg = wait->epoll_fd;
 			return 0;
 #else
-			return -FI_ENOSYS;
+			return -FI_ENODATA;
 #endif
 		}
 
@@ -356,6 +356,10 @@ static int util_wait_fd_control(struct fid *fid, int command, void *arg)
 		pollfd->change_index = wait->change_index;
 		pollfd->nfds = wait->pollfds->nfds;
 		fastlock_release(&wait->util_wait.lock);
+		break;
+	case FI_GETWAITOBJ:
+		*(enum fi_wait_obj *) arg = wait->util_wait.wait_obj;
+		ret = 0;
 		break;
 	default:
 		FI_INFO(wait->util_wait.prov, FI_LOG_FABRIC,

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -471,6 +471,10 @@ static int vrb_cq_control(fid_t fid, int command, void *arg)
 		}
 		pollfd->nfds = 1;
 		break;
+	case FI_GETWAITOBJ:
+		*(enum fi_wait_obj *) arg = cq->wait_obj;
+		ret = 0;
+		break;
 	default:
 		ret = -FI_ENOSYS;
 		break;

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -1244,6 +1244,10 @@ static int vrb_eq_control(fid_t fid, int command, void *arg)
 		pollfd->nfds = 1;
 #endif
 		break;
+	case FI_GETWAITOBJ:
+		*(enum fi_wait_obj *) arg = eq->wait_obj;
+		ret = 0;
+		break;
 	default:
 		ret = -FI_ENOSYS;
 		break;


### PR DESCRIPTION
Updates to util wait code and callers to allow direct use of struct pollfd array as a wait object type.