### PR TITLE
prov/efa: Remove CMA check during efa initialization

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -62,7 +62,6 @@
 #include <ofi_recvwin.h>
 #include <ofi_perf.h>
 
-#include <sys/wait.h>
 #include "rxr_pkt_entry.h"
 #include "rxr_pkt_type.h"
 


### PR DESCRIPTION
Since peer-peer cma check has been added recently in shm
provider, we do not need this check any more.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>