### PR TITLE
prov/efa: handle the case an EP want to use RDMA read on itself

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -364,6 +364,24 @@ bool efa_ep_support_rdma_read(struct fid_ep *ep_fid)
 }
 
 static inline
+bool efa_peer_support_rdma_read(struct rxr_peer *peer)
+{
+	/* RDMA READ is an extra feature defined in version 4 (the base version).
+	 * Because it is an extra feature, an EP will assume the peer does not support
+	 * it before a handshake packet was received.
+	 */
+	return (peer->flags & RXR_PEER_HANDSHAKE_RECEIVED) &&
+	       (peer->features[0] & RXR_REQ_FEATURE_RDMA_READ);
+}
+
+static inline
+bool efa_both_support_rdma_read(struct rxr_ep *ep, struct rxr_peer *peer)
+{
+	return efa_ep_support_rdma_read(ep->rdm_ep) &&
+	       (peer->is_self || efa_peer_support_rdma_read(peer));
+}
+
+static inline
 size_t efa_max_rdma_size(struct fid_ep *ep_fid)
 {
 	struct efa_ep *efa_ep;

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -283,6 +283,7 @@ struct rxr_fabric {
 struct rxr_peer {
 	bool tx_init;			/* tracks initialization of tx state */
 	bool rx_init;			/* tracks initialization of rx state */
+	bool is_self;			/* self flag */
 	bool is_local;			/* local/remote peer flag */
 	fi_addr_t shm_fiaddr;		/* fi_addr_t addr from shm provider */
 	struct rxr_robuf *robuf;	/* tracks expected msg_id on rx */
@@ -300,17 +301,6 @@ struct rxr_peer {
 	struct dlist_entry rnr_entry;	/* linked to rxr_ep peer_backoff_list */
 	struct dlist_entry entry;	/* linked to rxr_ep peer_list */
 };
-
-static inline
-bool rxr_peer_support_rdma_read(struct rxr_peer *peer)
-{
-	/* RDMA READ is an extra feature defined in version 4 (the base version).
-	 * Because it is an extra feature, an EP will assume the peer does not support
-	 * it before a handshake packet was received.
-	 */
-	return (peer->flags & RXR_PEER_HANDSHAKE_RECEIVED) &&
-	       (peer->features[0] & RXR_REQ_FEATURE_RDMA_READ);
-}
 
 struct rxr_queued_ctrl_info {
 	int type;

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -107,7 +107,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 						  RXR_MEDIUM_MSGRTM_PKT + tagged, 0);
 	}
 
-	if (efa_ep_support_rdma_read(rxr_ep->rdm_ep) && rxr_peer_support_rdma_read(peer) &&
+	if (efa_both_support_rdma_read(rxr_ep, peer) &&
 	    tx_entry->total_len > rxr_env.efa_max_long_msg_size) {
 		/* use read message protocol */
 		err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -308,8 +308,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	use_lower_ep_read = false;
 	if (rxr_env.enable_shm_transfer && peer->is_local) {
 		use_lower_ep_read = true;
-	} else if (efa_ep_support_rdma_read(rxr_ep->rdm_ep) &&
-		   rxr_peer_support_rdma_read(peer) &&
+	} else if (efa_both_support_rdma_read(rxr_ep, peer) &&
 		   tx_entry->total_len >= rxr_env.efa_max_emulated_read_size) {
 		use_lower_ep_read = true;
 	}
@@ -388,7 +387,7 @@ ssize_t rxr_rma_post_rtw(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 		return rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_EAGER_RTW_PKT, 0);
 
 	if (tx_entry->total_len >= rxr_env.efa_max_long_write_size &&
-	    efa_ep_support_rdma_read(ep->rdm_ep) && rxr_peer_support_rdma_read(peer)) {
+	    efa_both_support_rdma_read(ep, peer)) {
 		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_READ_RTW_PKT, 0);
 		if (err != -FI_ENOMEM)
 			return err;


### PR DESCRIPTION
Currently, an EP will use RDMA read on a peer only if both the EP
and the peer support RDMA read. The peer's information was received
via a handshake packet.

In the case an EP want to use RDMA read on itself, it does not
need to wait for a handshake packet. If should use RDMA as long
as it supports RDMA.

This patch introduced a flag is_self to struct rxr_peer, which
was set at efa_av_insert_addr(), and was used to determine whether
RDMA read should be used.

Signed-off-by: Wei Zhang <wzam@amazon.com>