### PR TITLE
prov/efa: Fix addr_format handling for RDM endpoints

### DIFF
--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -170,9 +170,12 @@ void rxr_info_to_core_mr_modes(uint32_t version,
 			FI_MR_LOCAL | FI_MR_ALLOCATED;
 		if (!hints)
 			core_info->domain_attr->mr_mode |= OFI_MR_BASIC_MAP;
-		else if (hints->domain_attr)
-			core_info->domain_attr->mr_mode |=
-				hints->domain_attr->mr_mode & OFI_MR_BASIC_MAP;
+		else {
+			if (hints->domain_attr)
+				core_info->domain_attr->mr_mode |=
+					hints->domain_attr->mr_mode & OFI_MR_BASIC_MAP;
+			core_info->addr_format = hints->addr_format;
+		}
 #ifdef HAVE_LIBCUDA
 		core_info->domain_attr->mr_mode |= FI_MR_HMEM;
 #endif
@@ -231,8 +234,6 @@ static int rxr_info_to_core(uint32_t version, const struct fi_info *rxr_info,
 	(*core_info)->caps = FI_MSG;
 	(*core_info)->ep_attr->type = FI_EP_RDM;
 	(*core_info)->tx_attr->op_flags = FI_TRANSMIT_COMPLETE;
-
-	(*core_info)->addr_format = FI_ADDR_EFA;
 
 	/*
 	 * Skip copying address, domain, fabric info.


### PR DESCRIPTION
The emulation layer for RDM endpoints in the EFA provider was
overwriting the addr_format field of the caller's hints without
verifying the contents.  This would result in endpoints being
returned with address formats other than the one requested (for
example, requesting FI_ADDR_STR would result in an endpoint with
FI_ADDR_EFA address format).

This patch removes that munging.  The core efa provider already
has a check that the addr_format is either EFA or UNSPEC, so the
end result of this patch is that efa endpoints will not be
returned if the addr_format in hints is not EFA or UNSPEC.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>