### PR TITLE
prov/shm: allow building of shm provider on older kernels

### DIFF
--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -95,4 +95,34 @@ static inline int ofi_hugepage_enabled(void)
 
 size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa);
 
+#ifndef __NR_process_vm_readv
+# define __NR_process_vm_readv 310
+#endif
+
+#ifndef __NR_process_vm_writev
+# define __NR_process_vm_writev 311
+#endif
+
+static inline ssize_t ofi_process_vm_readv(pid_t pid,
+			const struct iovec *local_iov,
+			unsigned long liovcnt,
+			const struct iovec *remote_iov,
+			unsigned long riovcnt,
+			unsigned long flags)
+{
+	return syscall(__NR_process_vm_readv, pid, local_iov, liovcnt,
+		       remote_iov, riovcnt, flags);
+}
+
+static inline size_t ofi_process_vm_writev(pid_t pid,
+			 const struct iovec *local_iov,
+			 unsigned long liovcnt,
+			 const struct iovec *remote_iov,
+			 unsigned long riovcnt,
+			 unsigned long flags)
+{
+	return syscall(__NR_process_vm_writev, pid, local_iov, liovcnt,
+		       remote_iov, riovcnt, flags);
+}
+
 #endif /* _LINUX_OSD_H_ */

--- a/prov/psm2/configure.m4
+++ b/prov/psm2/configure.m4
@@ -9,7 +9,7 @@ dnl $2: action if not configured successfully
 dnl
 AC_DEFUN([FI_PSM2_CONFIGURE],[
 	 # Determine if we can support the psm2 provider
-	 psm2_ARCH=`uname -m | sed -e 's,\(i[456]86\|athlon$$\),i386,'`
+	 psm2_ARCH=$host_cpu
 	 AM_CONDITIONAL([HAVE_PSM2_X86_64], [test x$psm2_ARCH = xx86_64])
 	 AC_SUBST([HAVE_PSM2_X86_64])
 	 AC_SUBST([psm2_ARCH])

--- a/prov/shm/configure.m4
+++ b/prov/shm/configure.m4
@@ -14,9 +14,12 @@ AC_DEFUN([FI_SHM_CONFIGURE],[
 	AS_IF([test x"$enable_shm" != x"no"],
 	      [
 	       # check if CMA support are present
-	       AC_CHECK_FUNC([process_vm_readv],
-			     [cma_happy=1],
-			     [cma_happy=0])
+	       AS_IF([test x$linux = x1 && test x$host_cpu = xx86_64],
+		     [cma_happy=1],
+		     [AC_CHECK_FUNC([process_vm_readv],
+				    [cma_happy=1],
+				    [cma_happy=0])]
+	       )
 
 	       # check if SHM support are present
 	       AC_CHECK_FUNC([shm_open],

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -199,13 +199,13 @@ static int smr_progress_iov(struct smr_cmd *cmd, struct iovec *iov,
 	}
 
 	if (cmd->msg.hdr.op == ofi_op_read_req) {
-		ret = process_vm_writev(peer_smr->pid, iov, iov_count,
-					cmd->msg.data.iov,
-					cmd->msg.data.iov_count, 0);
+		ret = ofi_process_vm_writev(peer_smr->pid, iov, iov_count,
+					    cmd->msg.data.iov,
+					    cmd->msg.data.iov_count, 0);
 	} else {
-		ret = process_vm_readv(peer_smr->pid, iov, iov_count,
-				       cmd->msg.data.iov,
-				       cmd->msg.data.iov_count, 0);
+		ret = ofi_process_vm_readv(peer_smr->pid, iov, iov_count,
+					   cmd->msg.data.iov,
+					   cmd->msg.data.iov_count, 0);
 	}
 
 	if (ret != cmd->msg.hdr.size) {

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -71,11 +71,11 @@ ssize_t smr_rma_fast(struct smr_region *peer_smr, struct smr_cmd *cmd,
 	total_len = ofi_total_iov_len(iov, iov_count);
 
 	if (op == ofi_op_write) {
-		ret = process_vm_writev(peer_smr->pid, iov, iov_count,
-					rma_iovec, rma_count, 0);
+		ret = ofi_process_vm_writev(peer_smr->pid, iov, iov_count,
+					    rma_iovec, rma_count, 0);
 	} else {
-		ret = process_vm_readv(peer_smr->pid, iov, iov_count,
-				       rma_iovec, rma_count, 0);
+		ret = ofi_process_vm_readv(peer_smr->pid, iov, iov_count,
+					   rma_iovec, rma_count, 0);
 	}
 
 	if (ret != total_len) {

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -76,8 +76,8 @@ void smr_cma_check(struct smr_region *smr, struct smr_region *peer_smr)
 	remote_iov.iov_base = (char *)peer_smr->base_addr +
 			      ((char *)&peer_smr->cma_cap - (char *)peer_smr);
 	remote_iov.iov_len = sizeof(peer_smr->cma_cap);
-	ret = process_vm_writev(peer_smr->pid, &local_iov, 1,
-				&remote_iov, 1, 0);
+	ret = ofi_process_vm_writev(peer_smr->pid, &local_iov, 1,
+				    &remote_iov, 1, 0);
 	smr->cma_cap = (ret == -1) ? SMR_CMA_CAP_OFF : SMR_CMA_CAP_ON;
 	peer_smr->cma_cap = smr->cma_cap;
 }


### PR DESCRIPTION
When building on an older kernel without CMA for use on
systems with CMA, shm will not get built and will be disabled.

To bypass this for x86 systems, skip the configure check and
provide a wrappers for the CMA calls which call the syscall
directly.

The newly added runtime checks for CMA calls and the alternate
large message protocol for use without CMA will allow the shm
provider to run with or without CMA.

Signed-off-by: aingerson <alexia.ingerson@intel.com>