### PR TITLE
core: Define generic provider version mechanism

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -67,6 +67,10 @@ extern "C" {
 
 /* For in-tree providers */
 #define OFI_VERSION_LATEST	FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION)
+/* The lower minor digit is reserved for custom libfabric builds */
+#define OFI_VERSION_DEF_PROV \
+	FI_VERSION(FI_MAJOR_VERSION * 100 + FI_MINOR_VERSION, \
+		   FI_REVISION_VERSION * 10)
 
 #define OFI_GETINFO_INTERNAL	(1ULL << 58)
 #define OFI_CORE_PROV_ONLY	(1ULL << 59)

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -78,6 +78,7 @@ extern "C" {
 
 #define FI_MAJOR_VERSION 1
 #define FI_MINOR_VERSION 10
+#define FI_REVISION_VERSION 0
 
 enum {
 	FI_PATH_MAX		= 256,
@@ -85,7 +86,7 @@ enum {
 	FI_VERSION_MAX		= 64
 };
 
-#define FI_VERSION(major, minor) ((major << 16) | (minor))
+#define FI_VERSION(major, minor) (((major) << 16) | (minor))
 #define FI_MAJOR(version)	(version >> 16)
 #define FI_MINOR(version)	(version & 0xFFFF)
 #define FI_VERSION_GE(v1, v2)   ((FI_MAJOR(v1) > FI_MAJOR(v2)) || \

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -67,7 +67,6 @@
 
 #include "rxr.h"
 #define EFA_PROV_NAME "efa"
-#define EFA_PROV_VERS FI_VERSION(3, 0)
 
 #define EFA_WARN(subsys, ...) FI_WARN(&efa_prov, subsys, __VA_ARGS__)
 #define EFA_TRACE(subsys, ...) FI_TRACE(&efa_prov, subsys, __VA_ARGS__)

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -91,7 +91,7 @@ const struct fi_fabric_attr efa_fabric_attr = {
 	.fabric		= NULL,
 	.name		= NULL,
 	.prov_name	= NULL,
-	.prov_version	= EFA_PROV_VERS,
+	.prov_version	= OFI_VERSION_DEF_PROV,
 };
 
 const struct fi_domain_attr efa_domain_attr = {
@@ -960,7 +960,7 @@ static void fi_efa_fini(void)
 
 struct fi_provider efa_prov = {
 	.name = EFA_PROV_NAME,
-	.version = EFA_PROV_VERS,
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = efa_getinfo,
 	.fabric = efa_fabric,

--- a/prov/hook/hook_debug/src/hook_debug.c
+++ b/prov/hook/hook_debug/src/hook_debug.c
@@ -902,9 +902,9 @@ static int hook_debug_fabric(struct fi_fabric_attr *attr,
 
 struct hook_prov_ctx hook_debug_prov_ctx = {
 	.prov = {
-		.version = FI_VERSION(1,0),
+		.version = OFI_VERSION_DEF_PROV,
 		/* We're a pass-through provider, so the fi_version is always the latest */
-		.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+		.fi_version = OFI_VERSION_LATEST,
 		.name = "ofi_hook_debug",
 		.getinfo = NULL,
 		.fabric = hook_debug_fabric,

--- a/prov/hook/perf/src/hook_perf.c
+++ b/prov/hook/perf/src/hook_perf.c
@@ -898,9 +898,9 @@ static int hook_perf_fabric(struct fi_fabric_attr *attr,
 
 struct hook_prov_ctx hook_perf_ctx = {
 	.prov = {
-		.version = FI_VERSION(1,0),
+		.version = OFI_VERSION_DEF_PROV,
 		/* We're a pass-through provider, so the fi_version is always the latest */
-		.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+		.fi_version = OFI_VERSION_LATEST,
 		.name = "ofi_hook_perf",
 		.getinfo = NULL,
 		.fabric = hook_perf_fabric,

--- a/prov/hook/src/hook.c
+++ b/prov/hook/src/hook.c
@@ -267,9 +267,9 @@ static int hook_noop_fabric(struct fi_fabric_attr *attr,
 
 struct hook_prov_ctx hook_noop_ctx = {
 	.prov = {
-		.version = FI_VERSION(1,0),
+		.version = OFI_VERSION_DEF_PROV,
 		/* We're a pass-through provider, so the fi_version is always the latest */
-		.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION),
+		.fi_version = OFI_VERSION_LATEST,
 		.name = "ofi_hook_noop",
 		.getinfo = NULL,
 		.fabric = hook_noop_fabric,

--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -54,9 +54,6 @@
 #include <ofi_prov.h>
 #include <ofi_enosys.h>
 
-#define MRAIL_MAJOR_VERSION 1
-#define MRAIL_MINOR_VERSION 0
-
 #define MRAIL_MAX_INFO 100
 
 #define MRAIL_PASSTHRU_TX_OP_FLAGS	(FI_INJECT_COMPLETE | \

--- a/prov/mrail/src/mrail_attr.c
+++ b/prov/mrail/src/mrail_attr.c
@@ -94,7 +94,7 @@ struct fi_domain_attr mrail_domain_attr = {
 };
 
 struct fi_fabric_attr mrail_fabric_attr = {
-	.prov_version = FI_VERSION(MRAIL_MAJOR_VERSION, MRAIL_MINOR_VERSION),
+	.prov_version = OFI_VERSION_DEF_PROV,
 	.name = "ofi_mrail_fabric",
 };
 

--- a/prov/mrail/src/mrail_init.c
+++ b/prov/mrail/src/mrail_init.c
@@ -426,8 +426,7 @@ static struct fi_info *mrail_get_prefix_info(struct fi_info *core_info, int id)
 
 	fi->ep_attr->protocol		= mrail_info.ep_attr->protocol;
 	fi->ep_attr->protocol_version	= mrail_info.ep_attr->protocol_version;
-	fi->fabric_attr->prov_version	= FI_VERSION(MRAIL_MAJOR_VERSION,
-						     MRAIL_MINOR_VERSION);
+	fi->fabric_attr->prov_version	= OFI_VERSION_DEF_PROV;
 	fi->domain_attr->mr_key_size	= (num_rails *
 					   sizeof(struct mrail_addr_key));
 	fi->domain_attr->mr_mode	|= FI_MR_RAW;
@@ -525,7 +524,7 @@ static void mrail_fini(void)
 
 struct fi_provider mrail_prov = {
 	.name = OFI_UTIL_PREFIX "mrail",
-	.version = FI_VERSION(MRAIL_MAJOR_VERSION, MRAIL_MINOR_VERSION),
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = mrail_getinfo,
 	.fabric = mrail_fabric_open,

--- a/prov/netdir/src/netdir.h
+++ b/prov/netdir/src/netdir.h
@@ -48,8 +48,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#define OFI_ND_MAJOR_VERSION 1
-#define OFI_ND_MINOR_VERSION 0
 
 #define ND_MSG_IOV_LIMIT		(256)
 #define ND_MSG_INTERNAL_IOV_LIMIT	(512)

--- a/prov/netdir/src/netdir_init.c
+++ b/prov/netdir/src/netdir_init.c
@@ -47,7 +47,7 @@ const char ofi_nd_prov_name[] = "netdir";
 
 struct fi_provider ofi_nd_prov = {
 	.name = ofi_nd_prov_name,
-	.version = FI_VERSION(OFI_ND_MAJOR_VERSION, OFI_ND_MINOR_VERSION),
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = ofi_nd_getinfo,
 	.fabric = ofi_nd_fabric,
@@ -138,7 +138,7 @@ static int ofi_nd_adapter_cb(const ND2_ADAPTER_INFO *adapter, const char *name)
 	info->domain_attr->mr_cnt = OFI_ND_MAX_MR_CNT;
 
 	info->fabric_attr->name = strdup(ofi_nd_prov_name);
-	info->fabric_attr->prov_version = FI_VERSION(OFI_ND_MAJOR_VERSION, OFI_ND_MINOR_VERSION);
+	info->fabric_attr->prov_version = OFI_VERSION_DEF_PROV;
 
 	info->caps = OFI_ND_EP_CAPS | OFI_ND_DOMAIN_CAPS;
 	info->addr_format = FI_SOCKADDR;

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -76,7 +76,6 @@ extern struct fi_provider psmx_prov;
 
 extern int psmx_am_compat_mode;
 
-#define PSMX_VERSION	(OFI_VERSION_LATEST)
 
 #define PSMX_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \

--- a/prov/psm/src/psmx_fabric.c
+++ b/prov/psm/src/psmx_fabric.c
@@ -79,7 +79,7 @@ static struct fi_ops_fabric psmx_fabric_ops = {
 
 static struct fi_fabric_attr psmx_fabric_attr = {
 	.name = PSMX_FABRIC_NAME,
-	.prov_version = PSMX_VERSION,
+	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
 int psmx_fabric(struct fi_fabric_attr *attr,

--- a/prov/psm/src/psmx_init.c
+++ b/prov/psm/src/psmx_init.c
@@ -639,7 +639,7 @@ static int psmx_getinfo(uint32_t version, const char *node, const char *service,
 	psmx_info->dest_addrlen = sizeof(*dest_addr);
 	psmx_info->fabric_attr->name = strdup(PSMX_FABRIC_NAME);
 	psmx_info->fabric_attr->prov_name = NULL;
-	psmx_info->fabric_attr->prov_version = PSMX_VERSION;
+	psmx_info->fabric_attr->prov_version = OFI_VERSION_DEF_PROV;
 
 	psmx_info->tx_attr->caps = psmx_info->caps;
 	psmx_info->tx_attr->mode = psmx_info->mode;
@@ -696,8 +696,8 @@ static void psmx_fini(void)
 
 struct fi_provider psmx_prov = {
 	.name = PSMX_PROV_NAME,
-	.version = PSMX_VERSION,
-	.fi_version = PSMX_VERSION,
+	.version = OFI_VERSION_DEF_PROV,
+	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = psmx_getinfo,
 	.fabric = psmx_fabric,
 	.cleanup = psmx_fini

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -83,7 +83,6 @@ extern "C" {
 
 extern struct fi_provider psmx2_prov;
 
-#define PSMX2_VERSION	(OFI_VERSION_LATEST)
 
 #define PSMX2_OP_FLAGS	(FI_INJECT | FI_MULTI_RECV | FI_COMPLETION | \
 			 FI_TRIGGER | FI_INJECT_COMPLETE | \

--- a/prov/psm2/src/psmx2_attr.c
+++ b/prov/psm2/src/psmx2_attr.c
@@ -115,7 +115,7 @@ static struct fi_domain_attr psmx2_domain_attr = {
 
 static struct fi_fabric_attr psmx2_fabric_attr = {
 	.name			= PSMX2_FABRIC_NAME,
-	.prov_version		= PSMX2_VERSION,
+	.prov_version		= OFI_VERSION_DEF_PROV,
 };
 
 static struct fi_info psmx2_prov_info = {

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -78,7 +78,7 @@ static struct fi_ops_fabric psmx2_fabric_ops = {
 
 static struct fi_fabric_attr psmx2_fabric_attr = {
 	.name = PSMX2_FABRIC_NAME,
-	.prov_version = PSMX2_VERSION,
+	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
 int psmx2_fabric(struct fi_fabric_attr *attr,

--- a/prov/psm2/src/psmx2_init.c
+++ b/prov/psm2/src/psmx2_init.c
@@ -651,7 +651,7 @@ static void psmx2_fini(void)
 
 struct fi_provider psmx2_prov = {
 	.name = PSMX2_PROV_NAME,
-	.version = PSMX2_VERSION,
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = psmx2_getinfo,
 	.fabric = psmx2_fabric,

--- a/prov/rstream/src/rstream_init.c
+++ b/prov/rstream/src/rstream_init.c
@@ -162,7 +162,7 @@ static void rstream_fini(void)
 
 struct fi_provider rstream_prov = {
 	.name = OFI_UTIL_PREFIX "rstream",
-	.version = FI_VERSION(1 ,0),
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = rstream_getinfo,
 	.fabric = rstream_fabric_open,

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -59,8 +59,6 @@
 #ifndef _RXD_H_
 #define _RXD_H_
 
-#define RXD_MAJOR_VERSION 	(1)
-#define RXD_MINOR_VERSION 	(0)
 #define RXD_PROTOCOL_VERSION 	(2)
 
 #define RXD_MAX_MTU_SIZE	4096

--- a/prov/rxd/src/rxd_attr.c
+++ b/prov/rxd/src/rxd_attr.c
@@ -93,7 +93,7 @@ struct fi_domain_attr rxd_domain_attr = {
 };
 
 struct fi_fabric_attr rxd_fabric_attr = {
-	.prov_version = FI_VERSION(RXD_MAJOR_VERSION, RXD_MINOR_VERSION),
+	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
 struct fi_info rxd_info = {

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -130,7 +130,7 @@ static void rxd_fini(void)
 
 struct fi_provider rxd_prov = {
 	.name = OFI_UTIL_PREFIX "rxd",
-	.version = FI_VERSION(RXD_MAJOR_VERSION, RXD_MINOR_VERSION),
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = rxd_getinfo,
 	.fabric = rxd_fabric,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -57,10 +57,6 @@
 #ifndef _RXM_H_
 #define _RXM_H_
 
-#endif
-
-#define RXM_MAJOR_VERSION 1
-#define RXM_MINOR_VERSION 0
 
 #define RXM_CM_DATA_VERSION	1
 #define RXM_OP_VERSION		3
@@ -954,3 +950,5 @@ static inline int rxm_cq_write_recv_comp(struct rxm_rx_buf *rx_buf,
 				    flags, len, buf, rx_buf->pkt.hdr.data,
 				    rx_buf->pkt.hdr.tag);
 }
+
+#endif

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -99,7 +99,7 @@ struct fi_domain_attr rxm_domain_attr = {
 };
 
 struct fi_fabric_attr rxm_fabric_attr = {
-	.prov_version = FI_VERSION(RXM_MAJOR_VERSION, RXM_MINOR_VERSION),
+	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
 struct fi_info rxm_info = {

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -353,7 +353,7 @@ static void rxm_fini(void)
 
 struct fi_provider rxm_prov = {
 	.name = OFI_UTIL_PREFIX "rxm",
-	.version = FI_VERSION(RXM_MAJOR_VERSION, RXM_MINOR_VERSION),
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = rxm_getinfo,
 	.fabric = rxm_fabric,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -64,10 +64,6 @@
 #define _SMR_H_
 
 
-#define SMR_MAJOR_VERSION 1
-#define SMR_MINOR_VERSION 1
-
-
 extern struct fi_provider smr_prov;
 extern struct fi_info smr_info;
 extern struct util_prov smr_util_prov;

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -95,7 +95,7 @@ struct fi_domain_attr smr_domain_attr = {
 
 struct fi_fabric_attr smr_fabric_attr = {
 	.name = "shm",
-	.prov_version = FI_VERSION(SMR_MAJOR_VERSION, SMR_MINOR_VERSION)
+	.prov_version = OFI_VERSION_DEF_PROV
 };
 
 struct fi_info smr_info = {

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -116,7 +116,7 @@ static void smr_fini(void)
 
 struct fi_provider smr_prov = {
 	.name = "shm",
-	.version = FI_VERSION(SMR_MAJOR_VERSION, SMR_MINOR_VERSION),
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = smr_getinfo,
 	.fabric = smr_fabric,

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -146,9 +146,6 @@ enum {
 	SOCK_OPTS_KEEPALIVE = 1<<1
 };
 
-#define SOCK_MAJOR_VERSION 2
-#define SOCK_MINOR_VERSION 0
-
 #define SOCK_WIRE_PROTO_VERSION (2)
 
 extern struct fi_info sock_dgram_info;

--- a/prov/sockets/src/sock_attr.c
+++ b/prov/sockets/src/sock_attr.c
@@ -216,7 +216,7 @@ struct fi_domain_attr sock_domain_attr = {
 
 struct fi_fabric_attr sock_fabric_attr = {
 	.name = "sockets",
-	.prov_version = FI_VERSION(SOCK_MAJOR_VERSION, SOCK_MINOR_VERSION),
+	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
 struct fi_info sock_msg_info = {

--- a/prov/sockets/src/sock_fabric.c
+++ b/prov/sockets/src/sock_fabric.c
@@ -323,7 +323,7 @@ static void fi_sockets_fini(void)
 
 struct fi_provider sock_prov = {
 	.name = sock_prov_name,
-	.version = FI_VERSION(SOCK_MAJOR_VERSION, SOCK_MINOR_VERSION),
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = sock_getinfo,
 	.fabric = sock_fabric,

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -62,9 +62,6 @@
 #ifndef _TCP_H_
 #define _TCP_H_
 
-#define TCPX_MAJOR_VERSION 	1
-#define TCPX_MINOR_VERSION 	0
-
 #define TCPX_HDR_VERSION	3
 #define TCPX_CTRL_HDR_VERSION	3
 

--- a/prov/tcp/src/tcpx_attr.c
+++ b/prov/tcp/src/tcpx_attr.c
@@ -104,7 +104,7 @@ static struct fi_domain_attr tcpx_domain_attr = {
 
 static struct fi_fabric_attr tcpx_fabric_attr = {
 	.name = "TCP-IP",
-	.prov_version = FI_VERSION(TCPX_MAJOR_VERSION, TCPX_MINOR_VERSION),
+	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
 struct fi_info tcpx_info = {

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -78,7 +78,7 @@ static void fi_tcp_fini(void)
 
 struct fi_provider tcpx_prov = {
 	.name = "tcp",
-	.version = FI_VERSION(TCPX_MAJOR_VERSION,TCPX_MINOR_VERSION),
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = tcpx_getinfo,
 	.fabric = tcpx_create_fabric,

--- a/prov/udp/src/udpx.h
+++ b/prov/udp/src/udpx.h
@@ -64,10 +64,6 @@
 #define _UDPX_H_
 
 
-#define UDPX_MAJOR_VERSION 1
-#define UDPX_MINOR_VERSION 1
-
-
 extern struct fi_provider udpx_prov;
 extern struct util_prov udpx_util_prov;
 extern struct fi_info udpx_info;

--- a/prov/udp/src/udpx_attr.c
+++ b/prov/udp/src/udpx_attr.c
@@ -81,7 +81,7 @@ struct fi_domain_attr udpx_domain_attr = {
 
 struct fi_fabric_attr udpx_fabric_attr = {
 	.name = "UDP-IP",
-	.prov_version = FI_VERSION(UDPX_MAJOR_VERSION, UDPX_MINOR_VERSION)
+	.prov_version = OFI_VERSION_DEF_PROV
 };
 
 struct fi_info udpx_info = {

--- a/prov/udp/src/udpx_init.c
+++ b/prov/udp/src/udpx_init.c
@@ -53,7 +53,7 @@ static void udpx_fini(void)
 
 struct fi_provider udpx_prov = {
 	.name = "UDP",
-	.version = FI_VERSION(UDPX_MAJOR_VERSION, UDPX_MINOR_VERSION),
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = udpx_getinfo,
 	.fabric = udpx_fabric,

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -78,7 +78,7 @@ struct vrb_dev_preset {
 
 struct fi_provider vrb_prov = {
 	.name = VERBS_PROV_NAME,
-	.version = VERBS_PROV_VERS,
+	.version = OFI_VERSION_DEF_PROV,
 	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = vrb_getinfo,
 	.fabric = vrb_fabric,

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -86,7 +86,6 @@
 #define VERBS_RESOLVE_TIMEOUT 2000	// ms
 
 #define VERBS_PROV_NAME "verbs"
-#define VERBS_PROV_VERS FI_VERSION(1,0)
 
 #define VERBS_DBG(subsys, ...) FI_DBG(&vrb_prov, subsys, __VA_ARGS__)
 #define VERBS_INFO(subsys, ...) FI_INFO(&vrb_prov, subsys, __VA_ARGS__)

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -70,7 +70,7 @@
 		   (ib_ud_addr)->lid, (ib_ud_addr)->service)
 
 const struct fi_fabric_attr verbs_fabric_attr = {
-	.prov_version		= VERBS_PROV_VERS,
+	.prov_version		= OFI_VERSION_DEF_PROV,
 };
 
 const struct fi_domain_attr verbs_domain_attr = {

--- a/src/common.c
+++ b/src/common.c
@@ -70,8 +70,8 @@
 
 struct fi_provider core_prov = {
 	.name = "core",
-	.version = 1,
-	.fi_version = FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION)
+	.version = OFI_VERSION_DEF_PROV,
+	.fi_version = OFI_VERSION_LATEST
 };
 
 struct ofi_common_locks common_locks = {


### PR DESCRIPTION
Provider versions are not getting updated as new libfabric versions are
being released.  To fix this moving forward, the following changes are
being proposed:

A new FI_REVISION_VERSION value is added to fabric.h.  This value will
align with the last number in the version release.  That is, for version
vX.Y.Z, it will correspond to the Z value.

By default, provider versions will be set to a value that corresponds with
Y.Z as their version.  The provider major value will be the minor value for
libfabric, and the provider minor value will be the stable release
revision.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>