### PR TITLE
prov/efa: Add tentative shm space size check

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -61,6 +61,7 @@
 #include <uthash.h>
 #include <ofi_recvwin.h>
 #include <ofi_perf.h>
+#include <sys/statvfs.h>
 
 #include "rxr_pkt_entry.h"
 #include "rxr_pkt_type.h"
@@ -175,6 +176,14 @@ static inline void rxr_poison_mem_region(uint32_t *ptr, size_t size)
 
 #define RXR_MTU_MAX_LIMIT	BIT_ULL(15)
 
+/*
+ * Tentatively estimated shm space limit, 64GB
+ * If available shm space is less than this limit,
+ * shm transfer will be disabled
+ * Once shm segmentation protocol merges, we can
+ * have a better calculated limit
+ */
+#define RXR_SHM_FS_LIMIT	(64 * 1024UL * 1024UL * 1024UL)
 
 
 extern struct fi_info *shm_info;


### PR DESCRIPTION
The mmap protocol could potentially take a lot space
from /dev/shm, as mmap shm file is created separately
under /dev/shm. Once segmentation protocol comes in,
we can have a good calculation of the upper limit of
shm space that we need internally.

Add a tentative estimation shm space size limit. If the
available space of /dev/shm is less than 64GB, we
disable shm transfer.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>