### PR TITLE
prov/efa: add missing header file to Makefile.include

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -60,12 +60,14 @@ _efa_files = \
 
 _efa_headers = \
 	prov/efa/src/efa.h \
+	prov/efa/src/rxr/efa_cuda.h \
 	prov/efa/src/rxr/rxr.h \
 	prov/efa/src/rxr/rxr_cntr.h \
 	prov/efa/src/rxr/rxr_rma.h \
 	prov/efa/src/rxr/rxr_msg.h \
 	prov/efa/src/rxr/rxr_pkt_entry.h \
 	prov/efa/src/rxr/rxr_pkt_type.h \
+	prov/efa/src/rxr/rxr_pkt_type_req.h \
 	prov/efa/src/rxr/rxr_pkt_cmd.h \
 	prov/efa/src/rxr/rxr_read.h \
 	prov/efa/src/rxr/rxr_atomic.h


### PR DESCRIPTION
rxr_pkt_type_req.h and efa_cuda.h was missing in the
_efa_headers section in file Makefile.include, this
patch fixes it.

Signed-off-by: Wei Zhang <wzam@amazon.com>