### PR TITLE
mrcache: Introduce CUDA buffer invalidation checks

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -226,6 +226,9 @@ struct ofi_mr_entry {
 	unsigned int			subscribed:1;
 	int				use_cnt;
 	struct dlist_entry		list_entry;
+#ifdef HAVE_LIBCUDA
+	uint64_t			cuda_buf_id;
+#endif
 	uint8_t				data[];
 };
 

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -107,9 +107,6 @@ int rxr_mr_regattr(struct fid *domain_fid, const struct fi_mr_attr *attr,
 	rxr_domain = container_of(domain_fid, struct rxr_domain,
 				  util_domain.domain_fid.fid);
 
-	if (attr->iface == FI_HMEM_CUDA)
-		flags |= OFI_MR_NOCACHE;
-
 	ret = fi_mr_regattr(rxr_domain->rdm_domain, attr, flags, mr);
 	if (ret) {
 		FI_WARN(&rxr_prov, FI_LOG_MR,


### PR DESCRIPTION

I do not intend to get this merged, this is just a proof-of-concept patch.

---
    This commit extendes the cached entry validation in
    ofi_mr_cache_search/find() to include a CUDA buffer ID check, which
    helps catch deallocations by the application. In order to do this, the
    original registration also includes a query to CUDA to get the base ID
    for an allocation, when creating an entry in util_mr_cache_create().

    Proof-of-concept change to help discussion in:
    https://github.com/ofiwg/libfabric/issues/5789

    Signed-off-by: Raghu Raja <craghun@amazon.com>