### PR TITLE
prov/rxm: Implement support for credit based flow control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ fabtests/ubertest/fi_ubertest
 fabtests/benchmarks/fi_*
 fabtests/functional/fi_*
 fabtests/unit/fi_*
+fabtests/multinode/fi_*
 pingpong/fi_*

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -992,6 +992,26 @@ int ofi_ns_del_local_name(struct util_ns *ns, void *service, void *name);
 void *ofi_ns_resolve_name(struct util_ns *ns, const char *server,
 			  void *service);
 
+
+/* Setup coordination for credit based flow control between core and util.
+ * threshold - When number of available RQ credits > threshold, the send
+ *     handler will be invoked
+ * add_credits - Increments the number of peer RQ credits available
+ * send_handler - Called to have util code send credit message.  If the
+ *     credit message cannot be sent, the credits should be returned to
+ *     the core by calling add_credits.
+ */
+#define OFI_OPS_FLOW_CTRL "ofix_flow_ctrl_v1"
+
+struct ofi_ops_flow_ctrl {
+	size_t	size;
+	void	(*set_threshold)(struct fid_domain *domain, uint64_t threshold);
+	void	(*add_credits)(struct fid_ep *ep, uint64_t credits);
+	void	(*set_send_handler)(struct fid_domain *domain,
+			ssize_t (*send_handler)(struct fid_ep *ep, uint64_t credits));
+};
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -152,6 +152,7 @@ typedef struct fid *fid_t;
 #define FI_PEEK			(1ULL << 19)
 #define FI_TRIGGER		(1ULL << 20)
 #define FI_FENCE		(1ULL << 21)
+#define FI_PRIORITY		(1ULL << 22)
 
 #define FI_COMPLETION		(1ULL << 24)
 #define FI_EVENT		FI_COMPLETION

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -332,6 +332,7 @@ struct rxm_atomic_resp_hdr {
 	FUNC(RXM_RMA),			\
 	FUNC(RXM_RX),			\
 	FUNC(RXM_SAR_TX),		\
+	FUNC(RXM_CREDIT_TX),		\
 	FUNC(RXM_RNDV_TX),		\
 	FUNC(RXM_RNDV_ACK_WAIT),	\
 	FUNC(RXM_RNDV_READ),		\
@@ -354,6 +355,7 @@ enum {
 	rxm_ctrl_rndv_ack,
 	rxm_ctrl_atomic,
 	rxm_ctrl_atomic_resp,
+	rxm_ctrl_credit
 };
 
 struct rxm_pkt {
@@ -413,6 +415,7 @@ enum rxm_buf_pool_type {
 	RXM_BUF_POOL_TX_ACK,
 	RXM_BUF_POOL_TX_RNDV,
 	RXM_BUF_POOL_TX_ATOMIC,
+	RXM_BUF_POOL_TX_CREDIT,
 	RXM_BUF_POOL_TX_SAR,
 	RXM_BUF_POOL_TX_END	= RXM_BUF_POOL_TX_SAR,
 	RXM_BUF_POOL_RMA,
@@ -530,6 +533,7 @@ enum rxm_deferred_tx_entry_type {
 	RXM_DEFERRED_TX_RNDV_READ,
 	RXM_DEFERRED_TX_SAR_SEG,
 	RXM_DEFERRED_TX_ATOMIC_RESP,
+	RXM_DEFERRED_TX_CREDIT_SEND,
 };
 
 struct rxm_deferred_tx_entry {
@@ -569,6 +573,9 @@ struct rxm_deferred_tx_entry {
 			struct rxm_tx_atomic_buf *tx_buf;
 			ssize_t len;
 		} atomic_resp;
+		struct {
+			struct rxm_tx_base_buf *tx_buf;
+		} credit_msg;
 	};
 };
 
@@ -676,7 +683,8 @@ struct rxm_ep {
 	struct rxm_recv_queue	recv_queue;
 	struct rxm_recv_queue	trecv_queue;
 
-	struct rxm_handle_txrx_ops *txrx_ops;
+	struct rxm_handle_txrx_ops	*txrx_ops;
+	struct ofi_ops_flow_ctrl	*flow_ctrl_ops;
 };
 
 struct rxm_conn {
@@ -883,6 +891,7 @@ rxm_tx_buf_alloc(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
 	       (type == RXM_BUF_POOL_TX_ACK) ||
 	       (type == RXM_BUF_POOL_TX_RNDV) ||
 	       (type == RXM_BUF_POOL_TX_ATOMIC) ||
+	       (type == RXM_BUF_POOL_TX_CREDIT) ||
 	       (type == RXM_BUF_POOL_TX_SAR));
 	return ofi_buf_alloc(rxm_ep->buf_pools[type].pool);
 }

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -786,20 +786,106 @@ err1:
 	return ret;
 }
 
+static ssize_t rxm_send_credits(struct fid_ep *ep, size_t credits)
+{
+	struct rxm_conn *rxm_conn =
+		container_of(ep->fid.context, struct rxm_conn, handle);
+	struct rxm_ep *rxm_ep = rxm_conn->handle.cmap->ep;
+	struct rxm_deferred_tx_entry *def_tx_entry;
+	struct rxm_tx_base_buf *tx_buf;
+	struct iovec iov;
+	struct fi_msg msg;
+	ssize_t ret;
+
+	tx_buf = (struct rxm_tx_base_buf *) rxm_tx_buf_alloc(
+		rxm_ep, RXM_BUF_POOL_TX_CREDIT);
+	if (!tx_buf) {
+		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
+			"Ran out of buffers from TX credit buffer pool.\n");
+		return -FI_ENOMEM;
+	}
+
+	rxm_ep_format_tx_buf_pkt(rxm_conn, 0, rxm_ctrl_credit, 0, 0, FI_SEND,
+				 &tx_buf->pkt);
+	tx_buf->pkt.ctrl_hdr.type = rxm_ctrl_credit;
+	tx_buf->pkt.ctrl_hdr.msg_id = ofi_buf_index(tx_buf);
+	tx_buf->pkt.ctrl_hdr.ctrl_data = credits;
+
+	if (rxm_conn->handle.state != RXM_CMAP_CONNECTED)
+		goto defer;
+
+	iov.iov_base = &tx_buf->pkt;
+	iov.iov_len = sizeof(struct rxm_pkt);
+	msg.msg_iov = &iov;
+	msg.iov_count = 1;
+	msg.context = tx_buf;
+	msg.desc = &tx_buf->hdr.desc;
+
+	ret = fi_sendmsg(ep, &msg, FI_PRIORITY);
+	if (!ret)
+		return FI_SUCCESS;
+
+defer:
+	def_tx_entry = rxm_ep_alloc_deferred_tx_entry(
+		rxm_ep, rxm_conn, RXM_DEFERRED_TX_CREDIT_SEND);
+	if (!def_tx_entry) {
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+			"unable to allocate TX entry for deferred CREDIT mxg\n");
+		ofi_buf_free(tx_buf);
+		return -FI_ENOMEM;
+	}
+
+	def_tx_entry->credit_msg.tx_buf = tx_buf;
+	rxm_ep_enqueue_deferred_tx_queue(def_tx_entry);
+	return FI_SUCCESS;
+}
+
+static void rxm_no_set_threshold(struct fid_domain *domain_fid, size_t threshold)
+{ }
+
+static void rxm_no_add_credits(struct fid_ep *ep_fid, size_t credits)
+{ }
+
+static void rxm_no_credit_handler(struct fid_domain *domain_fid,
+		ssize_t (*credit_handler)(struct fid_ep *ep, size_t credits))
+{ }
+
+struct ofi_ops_flow_ctrl rxm_no_ops_flow_ctrl = {
+	.size = sizeof(struct ofi_ops_flow_ctrl),
+	.set_threshold = rxm_no_set_threshold,
+	.add_credits = rxm_no_add_credits,
+	.set_send_handler = rxm_no_credit_handler,
+};
+
 static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 			   struct rxm_conn *rxm_conn, void *context)
 {
 	struct rxm_domain *rxm_domain;
 	struct fid_ep *msg_ep;
+	struct ofi_ops_flow_ctrl *flow_ctrl_ops;
 	int ret;
 
 	rxm_domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain,
 			util_domain);
+
 	ret = fi_endpoint(rxm_domain->msg_domain, msg_info, &msg_ep, context);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 			"unable to create msg_ep: %d\n", ret);
 		return ret;
+	}
+
+	ret = fi_open_ops(&msg_ep->fid, OFI_OPS_FLOW_CTRL, 0, (void **) &flow_ctrl_ops, NULL);
+	if (!ret && flow_ctrl_ops) {
+		rxm_ep->flow_ctrl_ops = flow_ctrl_ops;
+		rxm_ep->flow_ctrl_ops->set_threshold(rxm_domain->msg_domain,
+						     rxm_ep->msg_info->rx_attr->size / 2);
+		rxm_ep->flow_ctrl_ops->set_send_handler(rxm_domain->msg_domain,
+							rxm_send_credits);
+	} else if (ret == -FI_ENOSYS) {
+		rxm_ep->flow_ctrl_ops = &rxm_no_ops_flow_ctrl;
+	} else {
+		goto err;
 	}
 
 	ret = fi_ep_bind(msg_ep, &rxm_ep->msg_eq->fid, 0);
@@ -833,13 +919,13 @@ static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 		goto err;
 	}
 
+	rxm_conn->msg_ep = msg_ep;
+
 	if (!rxm_ep->srx_ctx) {
 		ret = rxm_msg_ep_prepost_recv(rxm_ep, msg_ep);
 		if (ret)
 			goto err;
 	}
-
-	rxm_conn->msg_ep = msg_ep;
 	return 0;
 err:
 	fi_close(&msg_ep->fid);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1430,7 +1430,7 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 		}
 	} while ((ret > 0) && (++comp_read < rxm_ep->comp_per_progress));
 
-	if (OFI_UNLIKELY(!dlist_empty(&rxm_ep->deferred_tx_conn_queue))) {
+	if (!dlist_empty(&rxm_ep->deferred_tx_conn_queue)) {
 		dlist_foreach_container_safe(&rxm_ep->deferred_tx_conn_queue,
 					     struct rxm_conn, rxm_conn,
 					     deferred_conn_entry, conn_entry_tmp)

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1526,6 +1526,9 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 	struct rxm_deferred_tx_entry *def_tx_entry;
 	ssize_t ret = 0;
 
+	if (rxm_conn->handle.state != RXM_CMAP_CONNECTED)
+		return;
+
 	while (!dlist_empty(&rxm_conn->deferred_tx_queue) && !ret) {
 		def_tx_entry = container_of(rxm_conn->deferred_tx_queue.next,
 					    struct rxm_deferred_tx_entry, entry);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -116,10 +116,10 @@
 #define VERBS_CM_DATA_SIZE	(VRB_CM_DATA_SIZE -		\
 				 sizeof(struct vrb_cm_data_hdr))
 
-#define VRB_CM_REJ_CONSUMER_DEFINED	28
+#define VRB_CM_REJ_CONSUMER_DEFINED		28
 #define VRB_CM_REJ_SIDR_CONSUMER_DEFINED	2
 
-#define VERBS_DGRAM_MSG_PREFIX_SIZE	(40)
+#define VERBS_DGRAM_MSG_PREFIX_SIZE		(40)
 
 #define VRB_EP_TYPE(info)						\
 	((info && info->ep_attr) ? info->ep_attr->type : FI_EP_MSG)
@@ -209,17 +209,18 @@ struct ofi_ib_ud_ep_name {
 static inline
 int vrb_dgram_ns_is_service_wildcard(void *svc)
 {
-	return (*(int *)svc == VERBS_IB_UD_NS_ANY_SERVICE);
+	return (*(int *) svc == VERBS_IB_UD_NS_ANY_SERVICE);
 }
 
 static inline
 int vrb_dgram_ns_service_cmp(void *svc1, void *svc2)
 {
-	int service1 = *(int *)svc1, service2 = *(int *)svc2;
+	int service1 = *(int *) svc1, service2 = *(int *) svc2;
 
 	if (vrb_dgram_ns_is_service_wildcard(svc1) ||
 	    vrb_dgram_ns_is_service_wildcard(svc2))
 		return 0;
+
 	return (service1 < service2) ? -1 : (service1 > service2);
 }
 
@@ -312,7 +313,7 @@ int vrb_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 
 struct vrb_pep {
 	struct fid_pep		pep_fid;
-	struct vrb_eq	*eq;
+	struct vrb_eq		*eq;
 	struct rdma_cm_id	*id;
 
 	/* XRC uses SIDR based RDMA CM exchanges for setting up
@@ -348,7 +349,7 @@ struct vrb_domain {
 	enum fi_ep_type			ep_type;
 	struct fi_info			*info;
 	/* The EQ is utilized by verbs/MSG */
-	struct vrb_eq		*eq;
+	struct vrb_eq			*eq;
 	uint64_t			eq_flags;
 
 	/* Indicates that MSG endpoints should use the XRC transport.
@@ -498,14 +499,14 @@ enum vrb_ini_qp_state {
 struct vrb_ini_shared_conn {
 	/* To share, EP must have same remote peer host addr and TX CQ */
 	struct sockaddr			*peer_addr;
-	struct vrb_cq		*tx_cq;
+	struct vrb_cq			*tx_cq;
 
 	/* The physical INI/TGT QPN connection. Virtual connections to the
 	 * same remote peer and TGT QPN will share this connection, with
 	 * the remote end opening the specified XRC TGT QPN for sharing
 	 * During the physical connection setup, phys_conn_id identifies
 	 * the RDMA CM ID (and MSG_EP) associated with the operation. */
-	enum vrb_ini_qp_state	state;
+	enum vrb_ini_qp_state		state;
 	struct rdma_cm_id		*phys_conn_id;
 	struct ibv_qp			*ini_qp;
 	uint32_t			tgt_qpn;
@@ -563,7 +564,7 @@ struct vrb_ep {
 	size_t				tx_credits;
 
 	union {
-		struct rdma_cm_id		*id;
+		struct rdma_cm_id	*id;
 		struct {
 			struct ofi_ib_ud_ep_name	ep_name;
 			int				service;
@@ -572,7 +573,7 @@ struct vrb_ep {
 
 	size_t				inject_limit;
 
-	struct vrb_eq		*eq;
+	struct vrb_eq			*eq;
 	struct vrb_srq_ep		*srq_ep;
 	struct fi_info			*info;
 
@@ -583,7 +584,7 @@ struct vrb_ep {
 	} *wrs;
 	size_t				rx_cq_size;
 	struct rdma_conn_param		conn_param;
-	struct vrb_cm_data_hdr	*cm_hdr;
+	struct vrb_cm_data_hdr		*cm_hdr;
 };
 
 
@@ -599,7 +600,7 @@ struct vrb_context {
 #define VERBS_XRC_EP_MAGIC		0x1F3D5B79
 struct vrb_xrc_ep {
 	/* Must be first */
-	struct vrb_ep		base_ep;
+	struct vrb_ep			base_ep;
 
 	/* XRC only fields */
 	struct rdma_cm_id		*tgt_id;
@@ -841,10 +842,10 @@ static inline ssize_t vrb_convert_ret(int ret)
 int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc);
 int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc);
 
-#define vrb_init_sge(buf, len, desc) (struct ibv_sge)		\
-	{ .addr = (uintptr_t)buf,					\
-	  .length = (uint32_t)len,					\
-	  .lkey = (uint32_t)(uintptr_t)desc }
+#define vrb_init_sge(buf, len, desc) (struct ibv_sge)	\
+	{ .addr = (uintptr_t) buf,			\
+	  .length = (uint32_t) len,			\
+	  .lkey = (uint32_t) (uintptr_t) desc }
 
 #define vrb_set_sge_iov(sg_list, iov, count, desc)	\
 ({							\

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -561,7 +561,7 @@ struct vrb_ep {
 	struct ibv_qp			*ibv_qp;
 
 	/* Protected by send CQ lock */
-	size_t				tx_credits;
+	uint64_t			sq_credits;
 
 	union {
 		struct rdma_cm_id	*id;

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -241,7 +241,7 @@ int vrb_poll_cq(struct vrb_cq *cq, struct ibv_wc *wc)
 		wc->wr_id = (uintptr_t) ctx->user_ctx;
 		if (ctx->flags & FI_TRANSMIT) {
 			cq->credits++;
-			ctx->ep->tx_credits++;
+			ctx->ep->sq_credits++;
 		}
 
 		if (wc->status) {

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -206,7 +206,7 @@ vrb_dgram_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &ep->wrs->msg_wr))
 		return -FI_ENOENT;
 
-	ret = vrb_post_send(ep, &ep->wrs->msg_wr);
+	ret = vrb_post_send(ep, &ep->wrs->msg_wr, 0);
 	ep->wrs->msg_wr.opcode = IBV_WR_SEND;
 	return ret;
 }
@@ -242,7 +242,7 @@ vrb_dgram_ep_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &ep->wrs->msg_wr))
 		return -FI_ENOENT;
 
-	return vrb_post_send(ep, &ep->wrs->msg_wr);
+	return vrb_post_send(ep, &ep->wrs->msg_wr, 0);
 }
 
 const struct fi_ops_msg vrb_dgram_msg_ops = {

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -38,6 +38,52 @@
 #include <malloc.h>
 
 
+
+static void vrb_set_threshold(struct fid_domain *domain_fid, size_t threshold)
+{
+	struct vrb_domain *domain;
+
+	domain = container_of(domain_fid, struct vrb_domain,
+			      util_domain.domain_fid.fid);
+	domain->threshold = threshold;
+}
+
+static void vrb_set_credit_handler(struct fid_domain *domain_fid,
+		ssize_t (*credit_handler)(struct fid_ep *ep, size_t credits))
+{
+	struct vrb_domain *domain;
+
+	domain = container_of(domain_fid, struct vrb_domain,
+			      util_domain.domain_fid.fid);
+	domain->send_credits = credit_handler;
+}
+
+struct ofi_ops_flow_ctrl vrb_ops_flow_ctrl = {
+	.size = sizeof(struct ofi_ops_flow_ctrl),
+	.set_threshold = vrb_set_threshold,
+	.add_credits = vrb_add_credits,
+	.set_send_handler = vrb_set_credit_handler,
+};
+
+static int
+vrb_domain_ops_open(struct fid *fid, const char *name, uint64_t flags,
+		    void **ops, void *context)
+{
+	struct vrb_ep *ep;
+	if (flags)
+		return -FI_EBADFLAGS;
+
+	if (!strcasecmp(name, OFI_OPS_FLOW_CTRL)) {
+		*ops = &vrb_ops_flow_ctrl;
+		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		ep->peer_rq_credits = 1;
+		return 0;
+	}
+
+	return -FI_ENOSYS;
+}
+
+
 #if VERBS_HAVE_QUERY_EX
 static int vrb_odp_flag(struct ibv_context *verbs)
 {
@@ -190,7 +236,7 @@ static struct fi_ops vrb_fid_ops = {
 	.close = vrb_domain_close,
 	.bind = vrb_domain_bind,
 	.control = fi_no_control,
-	.ops_open = fi_no_ops_open,
+	.ops_open = vrb_domain_ops_open,
 };
 
 static struct fi_ops_domain vrb_msg_domain_ops = {
@@ -254,6 +300,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 
 	_domain->ep_type = VRB_EP_TYPE(info);
 	_domain->flags |= vrb_is_xrc(info) ? VRB_USE_XRC : 0;
+	_domain->threshold = UINT64_MAX; /* disables RQ flow control */
 
 	ret = vrb_open_device_by_name(_domain, info->domain_attr->name);
 	if (ret)

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -185,7 +185,7 @@ vrb_msg_inject_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	return vrb_post_send(ep, &ep->wrs->msg_wr);
+	return vrb_post_send(ep, &ep->wrs->msg_wr, 0);
 }
 
 static ssize_t vrb_msg_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -201,7 +201,7 @@ static ssize_t vrb_msg_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	ret = vrb_post_send(ep, &ep->wrs->msg_wr);
+	ret = vrb_post_send(ep, &ep->wrs->msg_wr, 0);
 	ep->wrs->msg_wr.opcode = IBV_WR_SEND;
 	return ret;
 }

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -134,7 +134,7 @@ vrb_msg_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc
 
 	vrb_set_sge_iov(wr.sg_list, iov, count, desc);
 
-	return vrb_post_send(ep, &wr);
+	return vrb_post_send(ep, &wr, 0);
 }
 
 static ssize_t
@@ -153,7 +153,7 @@ vrb_msg_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 
 	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
-	return vrb_post_send(ep, &wr);
+	return vrb_post_send(ep, &wr, 0);
 }
 
 static ssize_t
@@ -206,7 +206,7 @@ vrb_rma_write_fast(struct fid_ep *ep_fid, const void *buf, size_t len,
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	return vrb_post_send(ep, &ep->wrs->rma_wr);
+	return vrb_post_send(ep, &ep->wrs->rma_wr, 0);
 }
 
 static ssize_t
@@ -245,7 +245,7 @@ vrb_msg_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid, const void *buf, siz
 	ep->wrs->sge.addr = (uintptr_t) buf;
 	ep->wrs->sge.length = (uint32_t) len;
 
-	ret = vrb_post_send(ep, &ep->wrs->rma_wr);
+	ret = vrb_post_send(ep, &ep->wrs->rma_wr, 0);
 	ep->wrs->rma_wr.opcode = IBV_WR_RDMA_WRITE;
 	return ret;
 }
@@ -377,7 +377,7 @@ vrb_msg_xrc_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	vrb_set_sge_iov(wr.sg_list, iov, count, desc);
 
-	return vrb_post_send(&ep->base_ep, &wr);
+	return vrb_post_send(&ep->base_ep, &wr, 0);
 }
 
 static ssize_t
@@ -399,7 +399,7 @@ vrb_msg_xrc_ep_rma_readmsg(struct fid_ep *ep_fid,
 
 	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
 
-	return vrb_post_send(&ep->base_ep, &wr);
+	return vrb_post_send(&ep->base_ep, &wr, flags);
 }
 
 static ssize_t
@@ -456,7 +456,7 @@ vrb_xrc_rma_write_fast(struct fid_ep *ep_fid, const void *buf,
 	ep->base_ep.wrs->sge.addr = (uintptr_t) buf;
 	ep->base_ep.wrs->sge.length = (uint32_t) len;
 
-	return vrb_post_send(&ep->base_ep, &ep->base_ep.wrs->rma_wr);
+	return vrb_post_send(&ep->base_ep, &ep->base_ep.wrs->rma_wr, 0);
 }
 
 static ssize_t
@@ -499,7 +499,7 @@ vrb_msg_xrc_ep_rma_inject_writedata_fast(struct fid_ep *ep_fid,
 	ep->base_ep.wrs->sge.addr = (uintptr_t) buf;
 	ep->base_ep.wrs->sge.length = (uint32_t) len;
 
-	ret = vrb_post_send(&ep->base_ep, &ep->base_ep.wrs->rma_wr);
+	ret = vrb_post_send(&ep->base_ep, &ep->base_ep.wrs->rma_wr, 0);
 	ep->base_ep.wrs->rma_wr.opcode = IBV_WR_RDMA_WRITE;
 	return ret;
 }


### PR DESCRIPTION
To mitigate some performance issues caused by packet loss due to CQ overrun, this set of changes implements an optional flow control mechanism in RxM. Utility providers that want to take advantage of this flow control should implement the new ofi_ops_flow_ctrl structure and return this struct from ops_open.  Currently, only verbs implements this interface and all other utility providers will not user credit based flow control by default.
