### PR TITLE
prov/efa: fix a bug of rxr_read_init_iov()

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -155,6 +155,9 @@ int efa_mr_cache_entry_reg(struct ofi_mr_cache *cache,
 void efa_mr_cache_entry_dereg(struct ofi_mr_cache *cache,
 			      struct ofi_mr_entry *entry);
 
+int efa_mr_reg_shm(struct fid_domain *domain_fid, struct iovec *iov,
+		   uint64_t access, struct fid_mr **mr_fid);
+
 struct efa_wc {
 	struct ibv_wc		ibv_wc;
 	/* Source address */


### PR DESCRIPTION
rxr_read_init_iov() prepare the iov for read message
protocol by registering send buffers.
    
Currently, even when the send buffer was intended to local peer
it will still register the buffer for a remote peer by calling
ibv_reg_mr(), which caused performance issue.
    
This patch introduced a function efa_mr_reg_shm() and let
rxr_read_init_iov() to use it to register memory for local peer.

Signed-off-by: Wei Zhang <wzam@amazon.com>