### PR TITLE
prov/verbs: Fix fi_info memory leak for XRC reciprocal connections

### DIFF
--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -881,7 +881,12 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 			ret = vrb_eq_xrc_connreq_event(eq, entry, len, event,
 							  cma_event, &acked,
 							  &priv_data, &priv_datalen);
-			if (ret == -FI_EAGAIN || *event == FI_CONNECTED)
+			if (ret == -FI_EAGAIN) {
+				fi_freeinfo(entry->info);
+				entry->info = NULL;
+				goto ack;
+			}
+			if (*event == FI_CONNECTED)
 				goto ack;
 		}
 		break;


### PR DESCRIPTION
Need to free the connection request duplicated fi_info for a
XRC reciprocal connection request handled internally by the Verbs
provider.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>