### PR TITLE
prov/verbs: Fix XRC SIDR request reject/retry identification

### DIFF
--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -928,9 +928,11 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
 		assert(ep->info);
 		if (vrb_is_xrc(ep->info)) {
-			/* SIDR Reject is reported as UNREACHABLE */
+			/* SIDR Reject is reported as UNREACHABLE unless
+			 * status is negative */
 			if (cma_event->id->ps == RDMA_PS_UDP &&
-			    cma_event->event == RDMA_CM_EVENT_UNREACHABLE)
+			    (cma_event->event == RDMA_CM_EVENT_UNREACHABLE &&
+			     cma_event->status >= 0))
 				goto xrc_shared_reject;
 
 			ret = vrb_eq_xrc_cm_err_event(eq, cma_event, &acked);


### PR DESCRIPTION
For SIDR Requests, the RDMA CM event status determines if
RDMA_CM_EVENT_UNREACHABLE event is reporting a reject of
the SIDR request or a error/timeout.

This prevented a Verbs retry of a SIDR connection request if
IB CM SIDR Request retries are exhausted.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>