### PR TITLE
prov/efa: Error handling when shm av is exhausted

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -256,6 +256,7 @@ struct efa_av {
 	struct efa_ep           *ep;
 	size_t			used;
 	size_t			next;
+	size_t			shm_used;
 	enum fi_av_type		type;
 	efa_addr_to_conn_func	addr_to_conn;
 	struct efa_reverse_av	*reverse_av;

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -336,7 +336,7 @@ int efa_av_insert_addr(struct efa_av *av, struct efa_ep_addr *addr,
 			" rdm_fiaddr = %" PRIu64 " shm_rdm_fiaddr = %" PRIu64
 			"\n", smr_name, *(uint64_t *)addr, *fi_addr, shm_fiaddr);
 
-		assert(shm_fiaddr < EFA_SHM_MAX_AV_COUNT);
+		assert(shm_fiaddr < rxr_env.shm_av_size);
 		av->shm_used++;
 		av_entry->local_mapping = 1;
 		av_entry->shm_rdm_addr = shm_fiaddr;
@@ -552,7 +552,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 					goto err_free_av_entry;
 
 				av->shm_used--;
-				assert(av_entry->shm_rdm_addr < EFA_SHM_MAX_AV_COUNT);
+				assert(av_entry->shm_rdm_addr < rxr_env.shm_av_size);
 				av->shm_rdm_addr_map[av_entry->shm_rdm_addr] = FI_ADDR_UNSPEC;
 			}
 			HASH_DEL(av->av_map, av_entry);

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -310,6 +310,13 @@ int efa_av_insert_addr(struct efa_av *av, struct efa_ep_addr *addr,
 
 	/* If peer is local, insert the address into shm provider's av */
 	if (rxr_env.enable_shm_transfer && efa_is_local_peer(av, addr)) {
+		if (av->shm_used >= rxr_env.shm_av_size) {
+			ret = -FI_ENOMEM;
+			EFA_WARN(FI_LOG_AV,
+				 "Max number of shm AV entry %d has been reached.\n",
+				 rxr_env.shm_av_size);
+			goto err_free_av_entry;
+		}
 		ret = rxr_ep_efa_addr_to_str(addr, smr_name);
 		if (ret != FI_SUCCESS)
 			goto err_free_av_entry;
@@ -330,6 +337,7 @@ int efa_av_insert_addr(struct efa_av *av, struct efa_ep_addr *addr,
 			"\n", smr_name, *(uint64_t *)addr, *fi_addr, shm_fiaddr);
 
 		assert(shm_fiaddr < EFA_SHM_MAX_AV_COUNT);
+		av->shm_used++;
 		av_entry->local_mapping = 1;
 		av_entry->shm_rdm_addr = shm_fiaddr;
 		av->shm_rdm_addr_map[shm_fiaddr] = av_entry->rdm_addr;
@@ -543,6 +551,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 				if (ret)
 					goto err_free_av_entry;
 
+				av->shm_used--;
 				assert(av_entry->shm_rdm_addr < EFA_SHM_MAX_AV_COUNT);
 				av->shm_rdm_addr_map[av_entry->shm_rdm_addr] = FI_ADDR_UNSPEC;
 			}
@@ -732,6 +741,7 @@ int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	av->type = attr->type;
 	av->used = 0;
 	av->next = 0;
+	av->shm_used = 0;
 
 	if (av->type == FI_AV_TABLE && av->util_av.count > 0) {
 		av->conn_table = calloc(av->util_av.count, sizeof(*av->conn_table));


### PR DESCRIPTION
In EFA, there's a variable shm_av_size, which can
be dynamically changed to cater for future instance
types that might have high #core. Currently the
default size is 128. There's another macro
EFA_SHM_MAX_AV_COUNT, which tracks the hard limit
SMR_MAX_PEERS in shm provider, and the current
value is 256. In any cases, shm_av_size cannot
be large than EFA_SHM_MAX_AV_COUNT.

Since we use shm_av_size when opening shm's av,
the returned shm fi_addr should not exceed
shm_av_size. And the assertion should check
against shm_av_size as well.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>