### PR TITLE
prov/efa: fix memory leak in rxr_rma_post_shm_write()

### DIFF
--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -159,7 +159,7 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	struct rxr_pkt_entry *pkt_entry;
 	struct fi_msg_rma msg;
 	struct rxr_peer *peer;
-	int i;
+	int i, err;
 
 	assert(tx_entry->op == ofi_op_write);
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
@@ -174,6 +174,7 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 		for (i = 0; i < tx_entry->iov_count; i++)
 			tx_entry->rma_iov[i].addr = 0;
 	}
+
 	msg.msg_iov = tx_entry->iov;
 	msg.iov_count = tx_entry->iov_count;
 	msg.addr = peer->shm_fiaddr;
@@ -181,7 +182,12 @@ size_t rxr_rma_post_shm_write(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	msg.rma_iov_count = tx_entry->rma_iov_count;
 	msg.context = pkt_entry;
 	msg.data = tx_entry->cq_entry.data;
-	return fi_writemsg(rxr_ep->shm_ep, &msg, tx_entry->fi_flags);
+
+	err = fi_writemsg(rxr_ep->shm_ep, &msg, tx_entry->fi_flags);
+	if (err)
+		rxr_pkt_entry_release_tx(rxr_ep, pkt_entry);
+
+	return err;
 }
 
 /* rma_read functions */
@@ -372,7 +378,7 @@ ssize_t rxr_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
 }
 
 /* rma_write functions */
-ssize_t rxr_rma_post_rtw(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
+ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 {
 	ssize_t err;
 	struct rxr_peer *peer;
@@ -430,7 +436,7 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 		goto out;
 	}
 
-	err = rxr_rma_post_rtw(rxr_ep, tx_entry);
+	err = rxr_rma_post_write(rxr_ep, tx_entry);
 	if (OFI_UNLIKELY(err))
 		rxr_release_tx_entry(rxr_ep, tx_entry);
 out:


### PR DESCRIPTION
rxr_rma_post_shm_write() allocate pkt_entry and use it
as context to call fi_writemsg() on shm_ep. In the
case that fi_writemsg() failed, it did not release the
pkt_entry, causing a memory leak.

This patch address the issue by release pkt_entry in
case fi_writemsg() return an error.

It also do a little refactoring: the function name

       rxr_rma_port_rtw()

is not correct, because it not only post rtw, but also
call rxr_rma_post_shm_write(). This patch rename it to

       rxr_rma_post_write().

Signed-off-by: Wei Zhang <wzam@amazon.com>