### PR TITLE
prov/efa: fallback to segmented protocol under certain condition

### DIFF
--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -108,7 +108,8 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	}
 
 	if (efa_both_support_rdma_read(rxr_ep, peer) &&
-	    tx_entry->total_len > rxr_env.efa_max_long_msg_size) {
+	    tx_entry->total_len > rxr_env.efa_max_long_msg_size &&
+	    (tx_entry->desc[0] || efa_mr_cache_enable)) {
 		/* use read message protocol */
 		err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
 						 RXR_READ_MSGRTM_PKT + tagged, 0);

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -387,7 +387,8 @@ ssize_t rxr_rma_post_rtw(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 		return rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_EAGER_RTW_PKT, 0);
 
 	if (tx_entry->total_len >= rxr_env.efa_max_long_write_size &&
-	    efa_both_support_rdma_read(ep, peer)) {
+	    efa_both_support_rdma_read(ep, peer) &&
+	    (tx_entry->desc[0] || efa_mr_cache_enable)) {
 		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_READ_RTW_PKT, 0);
 		if (err != -FI_ENOMEM)
 			return err;


### PR DESCRIPTION
Currently, read based message protocol is used for messages whose
size is large than

	rxr_env.efa_max_long_message_size.

However, we have noticed that read message protocol is slower than
segmented message protocol if application does not provide memory
descriptor and MR cache is not enabled.

This patch make rxr_msg_post_rtm() fallback to use segmented
protocol under such condition (no descriptor and no MR cache).

This patch also make rxr_rma_post_rtw() to fallback
to segmented write protocol under same condition.

Signed-off-by: Wei Zhang <wzam@amazon.com>