### PR TITLE
util/util_attr: fix ofi_cap_mr_mode to not drop FI_MR_HMEM

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -449,7 +449,7 @@ static int fi_resource_mgmt_level(enum fi_resource_mgmt rm_model)
 static int ofi_cap_mr_mode(uint64_t info_caps, int mr_mode)
 {
 	if (!ofi_rma_target_allowed(info_caps)) {
-		if (!(mr_mode & FI_MR_LOCAL))
+		if (!(mr_mode & (FI_MR_LOCAL | FI_MR_HMEM)))
 			return 0;
 
 		mr_mode &= ~OFI_MR_MODE_RMA_TARGET;


### PR DESCRIPTION
FI_MR_HMEM is similar to FI_MR_LOCAL, in that it specifies that device buffers
must be registered. However, it is valid for a provider to require FI_MR_HMEM
support but not FI_MR_LOCAL.

Change ofi_cap_mr_mode to not drop FI_MR_HMEM so this mr mode bit is still set
in this case.

Signed-off-by: Robert Wespetal <wesper@amazon.com>