### PR TITLE
rxm/util: A couple fixes and updates to support pollfd wait sets

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -441,8 +441,10 @@ struct ofi_wait_fid_entry {
 	struct dlist_entry	entry;
 	ofi_wait_try_func	wait_try;
 	fid_t			fid;
+	enum fi_wait_obj	wait_obj;
 	uint32_t		events;
 	ofi_atomic32_t		ref;
+	struct fi_wait_pollfd	pollfds;
 };
 
 int ofi_wait_fd_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -129,6 +129,7 @@ extern size_t rxm_msg_rx_size;
 extern size_t rxm_def_univ_size;
 extern size_t rxm_cm_progress_interval;
 extern int force_auto_progress;
+extern enum fi_wait_obj def_wait_obj;
 
 struct rxm_ep;
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2311,7 +2311,7 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep)
 			rxm_ep->msg_info->rx_attr->size) * rxm_def_univ_size;
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = (rxm_msg_cq_fd_needed(rxm_ep) ?
-			    FI_WAIT_FD : FI_WAIT_NONE);
+			    def_wait_obj : FI_WAIT_NONE);
 
 	rxm_domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain,
 				  util_domain);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2345,6 +2345,7 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep)
 	return 0;
 err:
 	fi_close(&rxm_ep->msg_cq->fid);
+	rxm_ep->msg_cq = NULL;
 	return ret;
 }
 
@@ -2624,8 +2625,10 @@ static int rxm_ep_msg_res_open(struct rxm_ep *rxm_ep)
 
 	return 0;
 err2:
-	if (rxm_ep->srx_ctx)
+	if (rxm_ep->srx_ctx) {
 		fi_close(&rxm_ep->srx_ctx->fid);
+		rxm_ep->srx_ctx = NULL;
+	}
 err1:
 	fi_freeinfo(rxm_ep->msg_info);
 	return ret;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2163,19 +2163,18 @@ static struct fi_ops_collective rxm_ops_collective_none = {
 
 static int rxm_ep_msg_res_close(struct rxm_ep *rxm_ep)
 {
-	int ret, retv = 0;
+	int ret = 0;
 
 	if (rxm_ep->srx_ctx) {
 		ret = fi_close(&rxm_ep->srx_ctx->fid);
 		if (ret) {
 			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL, \
 				"Unable to close msg shared ctx\n");
-			retv = ret;
 		}
 	}
 
 	fi_freeinfo(rxm_ep->msg_info);
-	return retv;
+	return ret;
 }
 
 static int rxm_listener_close(struct rxm_ep *rxm_ep)

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -395,7 +395,6 @@ static void client_send_connreq(struct util_wait *wait,
 	if (ret)
 		goto err;
 
-	wait->signal(wait);
 	return;
 err:
 	memset(&err_entry, 0, sizeof err_entry);
@@ -450,7 +449,7 @@ static void server_sock_accept(struct util_wait *wait,
 			      NULL, (void *) rx_req_cm_ctx);
 	if (ret)
 		goto err3;
-	wait->signal(wait);
+
 	return;
 err3:
 	free(rx_req_cm_ctx);

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -127,7 +127,6 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	if (ret)
 		goto err;
 
-	tcpx_ep->util_ep.eq->wait->signal(tcpx_ep->util_ep.eq->wait);
 	return 0;
 err:
 	free(cm_ctx);
@@ -159,12 +158,10 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 
 	ret = ofi_wait_add_fd(tcpx_ep->util_ep.eq->wait, tcpx_ep->sock,
 			      POLLOUT, tcpx_eq_wait_try_func, NULL, cm_ctx);
-	if (ret) {
+	if (ret)
 		free(cm_ctx);
-		return ret;
-	}
-	tcpx_ep->util_ep.eq->wait->signal(tcpx_ep->util_ep.eq->wait);
-	return 0;
+
+	return ret;
 }
 
 static int tcpx_ep_shutdown(struct fid_ep *ep, uint64_t flags)
@@ -683,7 +680,6 @@ static int tcpx_pep_listen(struct fid_pep *pep)
 			      POLLIN, tcpx_eq_wait_try_func,
 			      NULL, &tcpx_pep->cm_ctx);
 
-	tcpx_pep->util_pep.eq->wait->signal(tcpx_pep->util_pep.eq->wait);
 	return ret;
 }
 

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -398,7 +398,7 @@ ssize_t ofi_cq_sreadfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 
 		if (ofi_atomic_get32(&cq->signaled)) {
 			ofi_atomic_set32(&cq->signaled, 0);
-			return -FI_ECANCELED;
+			return -FI_EAGAIN;
 		}
 
 		ret = fi_wait(&cq->wait->wait_fid, timeout);


### PR DESCRIPTION
This allows rxm to use pollfd based wait sets, with a control to switch from epoll to pollfd via an environment variable.  The pollfd changes the timing in such a way that some additional bugs were exposed.  Include fixes uncovered through testing.