### PR TITLE
util/coll: Create collective address for an av_set correctly

### DIFF
--- a/fabtests/multinode/src/core_coll.c
+++ b/fabtests/multinode/src/core_coll.c
@@ -153,7 +153,7 @@ static int coll_setup()
 static void coll_teardown()
 {
 	fi_close(&coll_mc->fid);
-	free(av_set);
+	fi_close(&av_set->fid);
 }
 
 static int join_test_run()

--- a/include/ofi_coll.h
+++ b/include/ofi_coll.h
@@ -61,12 +61,23 @@ static const char * const log_util_coll_op_type[] = {
 	[UTIL_COLL_SCATTER_OP] = "COLL_SCATTER"
 };
 
+struct util_coll_mc {
+	struct fid_mc		mc_fid;
+	struct fid_ep		*ep;
+	struct util_av_set	*av_set;
+	uint64_t		local_rank;
+	uint16_t		group_id;
+	uint16_t		seq;
+	ofi_atomic32_t		ref;
+};
+
 struct util_av_set {
 	struct fid_av_set	av_set_fid;
 	struct util_av		*av;
 	fi_addr_t		*fi_addr_array;
 	size_t			fi_addr_count;
 	uint64_t		flags;
+	struct util_coll_mc     coll_mc;
 	ofi_atomic32_t		ref;
 	fastlock_t		lock;
 };
@@ -126,16 +137,6 @@ struct util_coll_reduce_item {
 	int				count;
 	enum fi_datatype		datatype;
 	enum fi_op			op;
-};
-
-struct util_coll_mc {
-	struct fid_mc		mc_fid;
-	struct fid_ep		*ep;
-	struct util_av_set	*av_set;
-	uint64_t		local_rank;
-	uint16_t		group_id;
-	uint16_t		seq;
-	ofi_atomic32_t		ref;
 };
 
 struct join_data {


### PR DESCRIPTION
ofi_av_set_addr creates a new collective address for an av_set
by building a new coll_mc with only the group members, instead
of using the av_set's AV address.

Signed-off-by: Gengbin Zheng <gengbin.zheng@intel.com>

fixes https://github.com/ofiwg/libfabric/issues/5809