### PR TITLE
prov/shm: shm space check and error handling to avoid more than SMR_MAX_PEERS insert

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -297,6 +297,10 @@ struct smr_attr {
 	size_t		tx_count;
 };
 
+size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
+				  size_t *cmd_offset, size_t *resp_offset,
+				  size_t *inject_offset, size_t *sar_offset,
+				  size_t *peer_offset, size_t *name_offset);
 void	smr_cma_check(struct smr_region *region, struct smr_region *peer_region);
 void	smr_cleanup(void);
 int	smr_map_create(const struct fi_provider *prov, int peer_count,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -35,6 +35,7 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <sys/types.h>
+#include <sys/statvfs.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <stddef.h>

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -78,6 +78,7 @@ int smr_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 struct smr_av {
 	struct util_av		util_av;
 	struct smr_map		*smr_map;
+	size_t			used;
 };
 
 int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,


### PR DESCRIPTION
1. Add error handling to avoid inserting more than SMR_MAX_PEERS
addresses into shm av.

2. Add shm space size check to ensure we have enough shm space to create the basic shm structures, this is to deal with the case where users run libfabric in small shm space environment, e.g., Docker container (64M /dev/shm space by default).
