### PR TITLE
fabtests: Fix parameter passed to fi_eq_strerror/fi_cq_strerror

### DIFF
--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -301,17 +301,17 @@ static inline int ft_use_size(int index, int enable_flags)
 #define FT_DEBUG(fmt, ...)
 #endif
 
-#define FT_EQ_ERR(eq, entry, buf, len) \
-	FT_ERR("eq_readerr (Provider errno: %d) : %s",		 \
-		entry.prov_errno, fi_eq_strerror(eq, entry.err,	 \
-						 entry.err_data, \
-						 buf, len))	 \
+#define FT_EQ_ERR(eq, entry, buf, len)				\
+	FT_ERR("eq_readerr (Provider errno: %d) : %s",			\
+		entry.prov_errno, fi_eq_strerror(eq, entry.prov_errno,	\
+						 entry.err_data,	\
+						 buf, len))		\
 
-#define FT_CQ_ERR(cq, entry, buf, len) \
-	FT_ERR("cq_readerr (Provider errno: %d) : %s",		 \
-		entry.prov_errno, fi_cq_strerror(cq, entry.err,	 \
-						 entry.err_data, \
-						 buf, len))	 \
+#define FT_CQ_ERR(cq, entry, buf, len)				\
+	FT_ERR("cq_readerr (Provider errno: %d) : %s",			\
+		entry.prov_errno, fi_cq_strerror(cq, entry.prov_errno,	\
+						 entry.err_data,	\
+						 buf, len))		\
 
 #define FT_CLOSE_FID(fd)						\
 	do {								\


### PR DESCRIPTION
entry.prov_errno should be passed to fi_eq_strerror/fi_cq_strerror
function call instead of entry.err

Signed-off-by: Dipti Kothari <dkothar@amazon.com>