### PR TITLE
man: Fix spelling errors and formatting throughout man pages

### DIFF
--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -499,8 +499,8 @@ The following option levels and option names and parameters are defined.
   to discard or claim a buffered receive or when to claim a buffered receive
   on getting a buffered receive completion. The value is typically used by a
   provider when sending a rendezvous protocol request where it would send
-  atleast FI_OPT_BUFFERED_MIN bytes of application data along with it. A smaller
-  sized renedezvous protocol message usually results in better latency for the
+  at least FI_OPT_BUFFERED_MIN bytes of application data along with it. A smaller
+  sized rendezvous protocol message usually results in better latency for the
   overall transfer of a large message.
 
 - *FI_OPT_CM_DATA_SIZE - size_t*

--- a/man/fi_getinfo.3.md
+++ b/man/fi_getinfo.3.md
@@ -305,7 +305,7 @@ additional optimizations.
 
 *FI_MULTICAST*
 : Indicates that the endpoint support multicast data transfers.  This
-  capability must be paired with FI_MSG.  Aplications can use FI_SEND
+  capability must be paired with FI_MSG.  Applications can use FI_SEND
   and FI_RECV to optimize multicast as send-only or receive-only.
 
 *FI_MULTI_RECV*

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -471,10 +471,10 @@ struct fi_mr_attr {
 	void               *context;
 	size_t             auth_key_size;
 	uint8_t            *auth_key;
-	enum fi_hmem_iface  iface;
+	enum fi_hmem_iface iface;
 	union {
-		uint64_t	reserved;
-		int		cuda;
+		uint64_t         reserved;
+		int              cuda;
 	} device;
 };
 ```
@@ -656,7 +656,7 @@ Fabric errno values are defined in
 Many hardware NICs accessed by libfabric require that data buffers be
 registered with the hardware while the hardware accesses it.  This ensures
 that the virtual to physical address mappings for those buffers do not change
-while the transfer is ocurring.  The performance impact of registering
+while the transfer is occurring.  The performance impact of registering
 memory regions can be significant.  As a result, some providers make use
 of a registration cache, particularly when working with applications that
 are unable to manage their own network buffers.  A registration cache avoids

--- a/man/fi_mrail.7.md
+++ b/man/fi_mrail.7.md
@@ -13,7 +13,7 @@ fi_mrail \- The Multi-Rail Utility Provider
 
 The mrail provider (ofi_mrail) is an utility provider that layers over an underlying
 provider to enable the use of multiple network ports (rails). This increases
-the total available bandwidth of an underlying proivder. The current status of
+the total available bandwidth of an underlying provider. The current status of
 mrail provider is experimental - not all libfabric features are supported and
 performance is not guaranteed.
 

--- a/man/fi_nic.3.md
+++ b/man/fi_nic.3.md
@@ -140,7 +140,7 @@ into the fabric.
 
 Provider attributes reference provider specific details of the device.
 These attributes are both provider and device specific.  The attributes
-can be interpretted by [`fi_tostr`(3)](fi_tostr.3.html).  Applications
+can be interpreted by [`fi_tostr`(3)](fi_tostr.3.html).  Applications
 may also use the other attribute fields, such as related fi_fabric_attr:
 prov_name field, to determine an appropriate structure to cast the
 attributes.  The format and definition of this field is outside the

--- a/man/fi_poll.3.md
+++ b/man/fi_poll.3.md
@@ -375,7 +375,7 @@ struct fi_wait_pollfd {
 
 The change_index is updated only when the file descriptors associated with
 the pollfd file set has changed.  Checking the change_index is an additional
-step needed when working with FI_WAIT_POLLFD wait ojects directly.  The use
+step needed when working with FI_WAIT_POLLFD wait objects directly.  The use
 of the fi_trywait() function is still required if accessing wait objects
 directly.
 

--- a/man/fi_rstream.7.md
+++ b/man/fi_rstream.7.md
@@ -42,8 +42,8 @@ supported: *fi_msg*.
 : The provider supports FI_THREAD_SAFE
 
 *Verbs-iWarp*
-: The provider has added features to enable iWarp. To use this feature, the ep protocol
- IWARP must be requested in a getinfo call.
+: The provider has added features to enable iWarp. To use this feature, the
+  ep protocol iWarp must be requested in an fi_getinfo call.
 
 # LIMITATIONS
 
@@ -53,8 +53,6 @@ The rstream provider is experimental and lacks performance validation and
  hooks into the core provider verbs. It is not interoperable with the previous rsockets(v1)
  protocol. There are default settings that limit the message stream (provider
  memory region size and CQ size). These can be modified by fi_setopt.
-
-
 
 # SETTINGS
 
@@ -76,8 +74,8 @@ The *rstream* provider settings can be modified via fi_setopt on the
 # OFI EXTENSIONS
 
 The rstream provider has extended the current OFI API set in order to enable a
- user implemenation of Poll. Specifically sendmsg(FI_PEEK) is supported which replicates
- the behavior of the recvmsg(FI_PEEK) feature.
+ user implementation of Poll. Specifically sendmsg(FI_PEEK) is supported
+ which replicates the behavior of the recvmsg(FI_PEEK) feature.
 
 # SEE ALSO
 

--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -196,7 +196,6 @@ of memory. The workaround is to use shared receive contexts for the MSG provider
 (FI_OFI_RXM_USE_SRX=1) or reduce eager message size (FI_OFI_RXM_BUFFER_SIZE) and
 MSG provider TX/RX queue sizes (FI_OFI_RXM_MSG_TX_SIZE / FI_OFI_RXM_MSG_RX_SIZE).
 
-
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -368,7 +368,7 @@ receiving endpoint.
 
 For discussion purposes, the completion queue is assumed to be configured
 for FI_CQ_FORMAT_TAGGED.  The op_context field will point to a struct
-fi_recv_contex.
+fi_recv_context.
 
 {% highlight c %}
 struct fi_recv_context {

--- a/man/fi_tcp.7.md
+++ b/man/fi_tcp.7.md
@@ -23,10 +23,11 @@ The following features are supported
 
 *Endpoint types*
 : *FI_EP_MSG* is the only supported endpoint type. Reliable
-datagram endpoint over TCP sockets can be achieved by layering RxM over
-tcp provider.
+  datagram endpoint over TCP sockets can be achieved by layering RxM over
+  tcp provider.
 
-: *FI_EP_RDM* is supported by layering ofi_rxm provider on top of the tcp provider.
+: *FI_EP_RDM* is supported by layering ofi_rxm provider on top of the
+  tcp provider.
 
 *Endpoint capabilities*
 : The tcp provider currently supports *FI_MSG*, *FI_RMA*
@@ -40,7 +41,6 @@ tcp provider.
 *Multi recv buffers*
 : The tcp provider supports multi recv buffers
 
-
 # RUNTIME PARAMETERS
 
 The tcp provider check for the following enviroment variables -
@@ -49,14 +49,16 @@ The tcp provider check for the following enviroment variables -
 : A specific can be requested with this variable
 
 *FI_TCP_PORT_LOW_RANGE/FI_TCP_PORT_HIGH_RANGE*
-: These variables are used to set the range of ports to be used by the tcp provider for its passive endpoint creation. This is useful where only a range of ports are allowed by firewall for tcp connections.
-
+: These variables are used to set the range of ports to be used by the
+  tcp provider for its passive endpoint creation. This is useful where
+  only a range of ports are allowed by firewall for tcp connections.
 
 # LIMITATIONS
 
-tcp provider is implemented over TCP sockets to emulate libfabric API. Hence
-the performance is lower than what an application might see implementing to
-sockets directly.
+The tcp provider is implemented over TCP sockets to emulate libfabric API.
+Hence the performance may be lower than what an application might see
+implementing to sockets directly, depending on the types of data transfers
+the application is trying to achieve.
 
 # SEE ALSO
 

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -167,22 +167,27 @@ The verbs provider checks for the following environment variables.
 :  Default maximum rx context size (default: 384)
 
 *FI_VERBS_TX_IOV_LIMIT*
-: Default maximum tx iov_limit (default: 4). Note: RDM (internal - deprecated) EP type supports only 1
+: Default maximum tx iov_limit (default: 4). Note: RDM (internal -
+  deprecated) EP type supports only 1
 
 *FI_VERBS_RX_IOV_LIMIT*
-: Default maximum rx iov_limit (default: 4). Note: RDM (internal - deprecated) EP type supports only 1
+: Default maximum rx iov_limit (default: 4). Note: RDM (internal -
+  deprecated) EP type supports only 1
 
 *FI_VERBS_INLINE_SIZE*
-:  Default maximum inline size. Actual inject size returned in fi_info may be greater (default: 64)
+: Default maximum inline size. Actual inject size returned in fi_info
+  may be greater (default: 64)
 
 *FI_VERBS_MIN_RNR_TIMER*
 : Set min_rnr_timer QP attribute (0 - 31) (default: 12)
 
 *FI_VERBS_CQREAD_BUNCH_SIZE*
-: The number of entries to be read from the verbs completion queue at a time (default: 8).
+: The number of entries to be read from the verbs completion queue
+  at a time (default: 8).
 
 *FI_VERBS_PREFER_XRC*
-: Prioritize XRC transport fi_info before RC transport fi_info (default: 0, RC fi_info will be before XRC fi_info)
+: Prioritize XRC transport fi_info before RC transport fi_info (default:
+  0, RC fi_info will be before XRC fi_info)
 
 *FI_VERBS_GID_IDX*
 : The GID index to use (default: 0)
@@ -199,12 +204,13 @@ The verbs provider checks for the following environment variables.
 ### Variables specific to DGRAM endpoints
 
 *FI_VERBS_DGRAM_USE_NAME_SERVER*
-: The option that enables/disables OFI Name Server thread. The NS thread is used to
-  resolve IP-addresses to provider specific addresses (default: 1, if "OMPI_COMM_WORLD_RANK"
-  and "PMI_RANK" environment variables aren't defined)
+: The option that enables/disables OFI Name Server thread. The NS thread is
+  used to resolve IP-addresses to provider specific addresses (default: 1,
+  if "OMPI_COMM_WORLD_RANK" and "PMI_RANK" environment variables aren't defined)
 
 *FI_VERBS_NAME_SERVER_PORT*
-: The port on which Name Server thread listens incoming connections and requests (default: 5678)
+: The port on which Name Server thread listens incoming connections and
+  requests (default: 5678)
 
 ### Environment variables notes
 The fi_info utility would give the up-to-date information on environment variables:
@@ -217,7 +223,7 @@ fi_info -p verbs -e
 - Set FI_LOG_LEVEL=info or FI_LOG_LEVEL=debug (if debug build of libfabric is
   available) and check if there any errors because of incorrect input parameters
   to fi_getinfo.
-- Check if "fi_info -p verbs" is successful. If that fails the following chkecklist
+- Check if "fi_info -p verbs" is successful. If that fails the following checklist
   may help in ensuring that the RDMA verbs stack is functional:
   - If libfabric was compiled, check if verbs provider was built. Building verbs
    provider would be skipped if its dependencies (listed in requirements) aren't


### PR DESCRIPTION
Signed-off-by: Sean Hefty <sean.hefty@intel.com>