### PR TITLE
prov/rxm: Add EQ progression fairness to progress routine

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -161,6 +161,11 @@ with (default: 256).
   functions when using manual progress. Higher values may provide less noise for 
   calls to fi_cq read functions, but may increase connection setup time (default: 10000)
 
+*FI_OFI_RXM_CQ_EQ_FAIRNESS*
+: Defines the maximum number of message provider CQ entries that can be
+  consecutively read across progress calls without checking to see if the
+  CM progress interval has been reached (default: 128)
+
 # Tuning
 
 ## Bandwidth

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -128,6 +128,7 @@ extern size_t rxm_msg_tx_size;
 extern size_t rxm_msg_rx_size;
 extern size_t rxm_def_univ_size;
 extern size_t rxm_cm_progress_interval;
+extern size_t rxm_cq_eq_fairness;
 extern int force_auto_progress;
 extern enum fi_wait_obj def_wait_obj;
 
@@ -656,6 +657,7 @@ struct rxm_ep {
 	struct fid_ep 		*srx_ctx;
 	size_t 			comp_per_progress;
 	ofi_atomic32_t		atomic_tx_credits;
+	int			cq_eq_fairness;
 
 	bool			msg_mr_local;
 	bool			rdm_mr_local;

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -428,6 +428,12 @@ RXM_INI
 			"decrease noise during cq polling, but may result in "
 			"longer connection establishment times. (default: 10000).");
 
+	fi_param_define(&rxm_prov, "cq_eq_fairness", FI_PARAM_INT,
+			"Defines the maximum number of message provider CQ entries"
+			" that can be consecutively read across progress calls "
+			"without checking to see if the CM progress interval has "
+			"been reached. (default: 128).");
+
 	fi_param_define(&rxm_prov, "data_auto_progress", FI_PARAM_BOOL,
 			"Force auto-progress for data transfers even if app "
 			"requested manual progress (default: false/no).");
@@ -445,6 +451,9 @@ RXM_INI
 	if (fi_param_get_int(&rxm_prov, "cm_progress_interval",
 				(int *) &rxm_cm_progress_interval))
 		rxm_cm_progress_interval = 10000;
+	if (fi_param_get_int(&rxm_prov, "cq_eq_fairness",
+				(int *) &rxm_cq_eq_fairness))
+		rxm_cq_eq_fairness = 128;
 	fi_param_get_bool(&rxm_prov, "data_auto_progress", &force_auto_progress);
 	rxm_param_get_def_wait();
 


### PR DESCRIPTION
In cases where a RXM endpoint is performing extensive operations
that create completion entries, it is possible for the EQ to
get starved from making progress. This change adds a check
so that after some number of consecutive CQ entries being
reaped (across many progress calls), the EQ CM progress interval
will be checked and if it has elapsed EQ progress will be made.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>