### PR TITLE
prov/rxm: Do not log -FI_EAGAIN warning within rxm_eq_readerr

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -69,8 +69,9 @@ static inline ssize_t rxm_eq_readerr(struct rxm_ep *rxm_ep,
 
 	ret = fi_eq_readerr(rxm_ep->msg_eq, &entry->err_entry, 0);
 	if (ret != sizeof(entry->err_entry)) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
-			"unable to fi_eq_readerr: %zd\n", ret);
+		if (ret != -FI_EAGAIN)
+			FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
+				"unable to fi_eq_readerr: %zd\n", ret);
 		return ret < 0 ? ret : -FI_EINVAL;
 	}
 


### PR DESCRIPTION
Since RXM does not offer protection between the reading
the message provider EQ and subsequent reading of an
available error, do not log a warning if an error is
not available. The return value is still passed to the
caller so this does not change behavior.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>