### PR TITLE
sockets: Convert to mutexes.  bufpool: Hugepage fallback.  core: Add universe variable

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -280,6 +280,8 @@ uint64_t ofi_tag_format(uint64_t max_tag);
 uint8_t ofi_msb(uint64_t num);
 uint8_t ofi_lsb(uint64_t num);
 
+extern size_t ofi_universe_size;
+
 int ofi_send_allowed(uint64_t caps);
 int ofi_recv_allowed(uint64_t caps);
 int ofi_rma_initiate_allowed(uint64_t caps);

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -326,6 +326,7 @@ struct ofi_bufpool_region {
 	size_t				index;
 	void 				*context;
 	struct ofi_bufpool 		*pool;
+	int				flags;
 #ifndef NDEBUG
 	size_t 				use_cnt;
 #endif

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -126,7 +126,6 @@ extern struct fi_ops_atomic rxm_ops_atomic;
 
 extern size_t rxm_msg_tx_size;
 extern size_t rxm_msg_rx_size;
-extern size_t rxm_def_univ_size;
 extern size_t rxm_cm_progress_interval;
 extern size_t rxm_cq_eq_fairness;
 extern int force_auto_progress;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2308,7 +2308,7 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep)
 	int i, ret;
 
 	cq_attr.size = (rxm_ep->msg_info->tx_attr->size +
-			rxm_ep->msg_info->rx_attr->size) * rxm_def_univ_size;
+			rxm_ep->msg_info->rx_attr->size) * ofi_universe_size;
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = (rxm_msg_cq_fd_needed(rxm_ep) ?
 			    def_wait_obj : FI_WAIT_NONE);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -50,7 +50,6 @@
 
 size_t rxm_msg_tx_size		= 128;
 size_t rxm_msg_rx_size		= 128;
-size_t rxm_def_univ_size	= 256;
 size_t rxm_eager_limit		= RXM_BUF_SIZE - sizeof(struct rxm_pkt);
 int force_auto_progress		= 0;
 enum fi_wait_obj def_wait_obj	= FI_WAIT_FD;
@@ -447,7 +446,6 @@ RXM_INI
 	fi_param_get_size_t(&rxm_prov, "rx_size", &rxm_info.rx_attr->size);
 	fi_param_get_size_t(&rxm_prov, "msg_tx_size", &rxm_msg_tx_size);
 	fi_param_get_size_t(&rxm_prov, "msg_rx_size", &rxm_msg_rx_size);
-	fi_param_get_size_t(NULL, "universe_size", &rxm_def_univ_size);
 	if (fi_param_get_int(&rxm_prov, "cm_progress_interval",
 				(int *) &rxm_cm_progress_interval))
 		rxm_cm_progress_interval = 10000;

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -886,8 +886,8 @@ struct sock_cq {
 	struct ofi_ringbuffd cq_rbfd;
 	struct ofi_ringbuf cqerr_rb;
 	struct dlist_entry overflow_list;
-	fastlock_t lock;
-	fastlock_t list_lock;
+	pthread_mutex_t lock;
+	pthread_mutex_t list_lock;
 
 	struct fid_wait *waitset;
 	int signal;

--- a/prov/sockets/src/sock_poll.c
+++ b/prov/sockets/src/sock_poll.c
@@ -129,12 +129,12 @@ static int sock_poll_poll(struct fid_poll *pollset, void **context, int count)
 			cq = container_of(list_item->fid, struct sock_cq,
 						cq_fid);
 			sock_cq_progress(cq);
-			fastlock_acquire(&cq->lock);
+			pthread_mutex_lock(&cq->lock);
 			if (ofi_rbfdused(&cq->cq_rbfd) || ofi_rbused(&cq->cqerr_rb)) {
 				*context++ = cq->cq_fid.fid.context;
 				ret_count++;
 			}
-			fastlock_release(&cq->lock);
+			pthread_mutex_unlock(&cq->lock);
 			break;
 
 		case FI_CLASS_CNTR:

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -53,7 +53,6 @@
 
 enum {
 	UTIL_NO_ENTRY = -1,
-	UTIL_DEFAULT_AV_SIZE = 1024,
 };
 
 static int fi_get_src_sockaddr(const struct sockaddr *dest_addr, size_t dest_addrlen,
@@ -442,16 +441,8 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 	if (ret)
 		return ret;
 
-	if (attr->count) {
-		max_count = attr->count;
-	} else {
-		if (fi_param_get_size_t(NULL, "universe_size", &max_count))
-			max_count = UTIL_DEFAULT_AV_SIZE;
-	}
-
-	av->count = roundup_power_of_two(max_count ?
-					 max_count :
-					 UTIL_DEFAULT_AV_SIZE);
+	max_count = attr->count ? attr->count : ofi_universe_size;
+	av->count = roundup_power_of_two(max_count);
 	FI_INFO(av->prov, FI_LOG_AV, "AV size %zu\n", av->count);
 
 	av->addrlen = util_attr->addrlen;

--- a/src/common.c
+++ b/src/common.c
@@ -79,6 +79,8 @@ struct ofi_common_locks common_locks = {
 	.util_fabric_lock = PTHREAD_MUTEX_INITIALIZER,
 };
 
+size_t ofi_universe_size = 1024;
+
 int fi_poll_fd(int fd, int timeout)
 {
 	struct pollfd fds;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -621,7 +621,8 @@ void fi_ini(void)
 			"Defines the maximum number of processes that will be"
 			" used by distribute OFI application. The provider uses"
 			" this to optimize resource allocations"
-			" (default: OFI service specific)");
+			" (default: provider specific)");
+	fi_param_get_size_t(NULL, "universe_size", &ofi_universe_size);
 	fi_param_get_str(NULL, "provider", &param_val);
 	ofi_create_filter(&prov_filter, param_val);
 


### PR DESCRIPTION
prov/sockets: Convert spinlocks to mutexes.

bufpool: Fallback to normal allocations any time hugepage allocations fails.

core/rxm/av: Use a single, consistent universe size variable