### PR TITLE
prov/rxm: fix fi_getinfo handling of FI_COLLECTIVE

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -931,6 +931,7 @@ static inline int ofi_has_util_prefix(const char *str)
 }
 
 typedef int (*ofi_alter_info_t)(uint32_t version, const struct fi_info *src_info,
+				const struct fi_info *base_info,
 				struct fi_info *dest_info);
 
 int ofi_get_core_info(uint32_t version, const char *node, const char *service,

--- a/prov/rstream/src/rstream.h
+++ b/prov/rstream/src/rstream.h
@@ -207,9 +207,9 @@ extern ssize_t rstream_post_cq_data_recv(struct rstream_ep *ep,
 	const struct fi_cq_data_entry *cq_entry);
 
 extern int rstream_info_to_rstream(uint32_t version, const struct fi_info *core_info,
-	struct fi_info *info);
+	const struct fi_info *base_info, struct fi_info *info);
 extern int rstream_info_to_core(uint32_t version, const struct fi_info *rstream_info,
-	struct fi_info *core_info);
+	const struct fi_info *base_info, struct fi_info *core_info);
 extern void rstream_set_info(struct fi_info *info);
 extern struct fi_ops_cm rstream_ops_cm;
 extern struct fi_ops_cm rstream_ops_pep_cm;
@@ -227,6 +227,6 @@ int rstream_ep_open(struct fid_domain *domain, struct fi_info *info,
 int rstream_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 	struct fid_eq **eq, void *context);
 int rstream_info_to_core(uint32_t version, const struct fi_info *rstream_info,
-	struct fi_info *core_info);
+	const struct fi_info *base_info, struct fi_info *core_info);
 
 #endif /* _RSTREAM_H_ */

--- a/prov/rstream/src/rstream_ep.c
+++ b/prov/rstream/src/rstream_ep.c
@@ -250,7 +250,7 @@ int rstream_ep_open(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err1;
 
-	rstream_info_to_core(FI_VERSION(1, 8), NULL, info);
+	rstream_info_to_core(FI_VERSION(1, 8), NULL, NULL, info);
 
 	if (info->handle && info->handle->fclass == FI_CLASS_PEP) {
 		rstream_pep = container_of(info->handle,
@@ -378,7 +378,7 @@ int rstream_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	if (!rstream_pep)
 		return -FI_ENOMEM;
 
-	rstream_info_to_core(FI_VERSION(1, 8), NULL, info);
+	rstream_info_to_core(FI_VERSION(1, 8), NULL, NULL, info);
 
 	ret = fi_passive_ep(rstream_fabric->msg_fabric, info,
 		&rstream_pep->pep_fd, NULL);

--- a/prov/rstream/src/rstream_init.c
+++ b/prov/rstream/src/rstream_init.c
@@ -51,7 +51,7 @@ static void rstream_default_settings(struct fi_info *core_info)
 }
 
 int rstream_info_to_core(uint32_t version, const struct fi_info *irstream_info,
-	struct fi_info *core_info)
+	const struct fi_info *base_info, struct fi_info *core_info)
 {
 	core_info->ep_attr->type = FI_EP_MSG;
 	core_info->ep_attr->protocol = FI_PROTO_UNSPEC;
@@ -90,7 +90,7 @@ static void update_rstream_info(const struct fi_info *core_info)
 }
 
 int rstream_info_to_rstream(uint32_t version, const struct fi_info *core_info,
-	struct fi_info *info)
+	const struct fi_info *base_info, struct fi_info *info)
 {
 	info->caps = RSTREAM_CAPS;
 	info->mode = 0;

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -397,9 +397,9 @@ static inline int rxd_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_ta
 }
 
 int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
-		     struct fi_info *core_info);
+		     const struct fi_info *base_info, struct fi_info *core_info);
 int rxd_info_to_rxd(uint32_t version, const struct fi_info *core_info,
-		    struct fi_info *info);
+		    const struct fi_info *base_info, struct fi_info *info);
 
 int rxd_fabric(struct fi_fabric_attr *attr,
 	       struct fid_fabric **fabric, void *context);
@@ -449,7 +449,7 @@ size_t rxd_init_msg(void **ptr, const struct iovec *iov, size_t iov_count,
 		    size_t total_len, size_t avail_len);
 static inline void rxd_check_init_cq_data(void **ptr, struct rxd_x_entry *tx_entry,
 			      		  size_t *max_inline)
-{	
+{
 	if (tx_entry->flags & RXD_REMOTE_CQ_DATA) {
 		rxd_init_data_hdr(ptr, tx_entry);
 		*max_inline -= sizeof(tx_entry->cq_entry.data);

--- a/prov/rxd/src/rxd_init.c
+++ b/prov/rxd/src/rxd_init.c
@@ -77,7 +77,7 @@ void rxd_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
 }
 
 int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
-		     struct fi_info *core_info)
+		     const struct fi_info *base_info, struct fi_info *core_info)
 {
 	rxd_info_to_core_mr_modes(version, rxd_info, core_info);
 	core_info->caps = FI_MSG;
@@ -88,7 +88,7 @@ int rxd_info_to_core(uint32_t version, const struct fi_info *rxd_info,
 }
 
 int rxd_info_to_rxd(uint32_t version, const struct fi_info *core_info,
-		    struct fi_info *info)
+		    const struct fi_info *base_info, struct fi_info *info)
 {
 	info->caps = ofi_pick_core_flags(rxd_info.caps, core_info->caps,
 					 FI_LOCAL_COMM | FI_REMOTE_COMM);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -718,9 +718,9 @@ extern struct fi_rx_attr rxm_rx_attr;
 int rxm_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric,
 			void *context);
 int rxm_info_to_core(uint32_t version, const struct fi_info *rxm_info,
-		     struct fi_info *core_info);
+		     const struct fi_info *base_info, struct fi_info *core_info);
 int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
-		    struct fi_info *info);
+		     const struct fi_info *base_info, struct fi_info *info);
 int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			     struct fid_domain **dom, void *context);
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -710,6 +710,7 @@ struct rxm_conn {
 
 extern struct fi_provider rxm_prov;
 extern struct fi_info rxm_info;
+extern struct fi_info rxm_info_coll;
 extern struct fi_fabric_attr rxm_fabric_attr;
 extern struct fi_domain_attr rxm_domain_attr;
 extern struct fi_tx_attr rxm_tx_attr;

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -77,6 +77,19 @@ struct fi_ep_attr rxm_ep_attr = {
 	.mem_tag_format = FI_TAG_GENERIC,
 };
 
+struct fi_ep_attr rxm_ep_attr_coll = {
+	.type = FI_EP_RDM,
+	.protocol = FI_PROTO_RXM,
+	.protocol_version = 1,
+	.max_msg_size = SIZE_MAX,
+	.tx_ctx_cnt = 1,
+	.rx_ctx_cnt = 1,
+	.max_order_raw_size = SIZE_MAX,
+	.max_order_war_size = SIZE_MAX,
+	.max_order_waw_size = SIZE_MAX,
+	.mem_tag_format = FI_TAG_GENERIC >> 1,
+};
+
 struct fi_domain_attr rxm_domain_attr = {
 	.caps = RXM_DOMAIN_CAPS,
 	.threading = FI_THREAD_SAFE,
@@ -102,14 +115,25 @@ struct fi_fabric_attr rxm_fabric_attr = {
 	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
-struct fi_info rxm_info = {
+struct fi_info rxm_info_coll = {
 	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS | FI_COLLECTIVE,
+	.addr_format = FI_SOCKADDR,
+	.tx_attr = &rxm_tx_attr,
+	.rx_attr = &rxm_rx_attr,
+	.ep_attr = &rxm_ep_attr_coll,
+	.domain_attr = &rxm_domain_attr,
+	.fabric_attr = &rxm_fabric_attr
+};
+
+struct fi_info rxm_info = {
+	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxm_tx_attr,
 	.rx_attr = &rxm_rx_attr,
 	.ep_attr = &rxm_ep_attr,
 	.domain_attr = &rxm_domain_attr,
-	.fabric_attr = &rxm_fabric_attr
+	.fabric_attr = &rxm_fabric_attr,
+	.next = &rxm_info_coll,
 };
 
 struct util_prov rxm_util_prov = {

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -89,7 +89,7 @@ void rxm_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
 }
 
 int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
-		     struct fi_info *core_info)
+		     const struct fi_info *base_info, struct fi_info *core_info)
 {
 	int use_srx = 0;
 
@@ -140,7 +140,7 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 }
 
 int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
-		    struct fi_info *info)
+		    const struct fi_info *base_info, struct fi_info *info)
 {
 	info->caps = rxm_info.caps;
 	// TODO find which other modes should be filtered

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -37,6 +37,7 @@
 
 #include <ofi_prov.h>
 #include "rxm.h"
+#include "ofi_coll.h"
 
 #define RXM_ATOMIC_UNSUPPORTED_MSG_ORDER (FI_ORDER_RAW | FI_ORDER_ATOMIC_RAW | \
 					  FI_ORDER_RAR | FI_ORDER_ATOMIC_RAR | \
@@ -142,39 +143,39 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 		    const struct fi_info *base_info, struct fi_info *info)
 {
-	info->caps = rxm_info.caps;
+	info->caps = base_info->caps;
 	// TODO find which other modes should be filtered
-	info->mode = (core_info->mode & ~FI_RX_CQ_DATA) | rxm_info.mode;
+	info->mode = (core_info->mode & ~FI_RX_CQ_DATA) | base_info->mode;
 
-	info->tx_attr->caps		= rxm_info.tx_attr->caps;
+	info->tx_attr->caps		= base_info->tx_attr->caps;
 	info->tx_attr->mode		= info->mode;
 	info->tx_attr->msg_order 	= core_info->tx_attr->msg_order;
-	info->tx_attr->comp_order 	= rxm_info.tx_attr->comp_order;
-	info->tx_attr->inject_size	= rxm_info.tx_attr->inject_size;
-	info->tx_attr->size 		= rxm_info.tx_attr->size;
-	info->tx_attr->iov_limit 	= MIN(rxm_info.tx_attr->iov_limit,
+	info->tx_attr->comp_order 	= base_info->tx_attr->comp_order;
+	info->tx_attr->inject_size	= base_info->tx_attr->inject_size;
+	info->tx_attr->size 		= base_info->tx_attr->size;
+	info->tx_attr->iov_limit 	= MIN(base_info->tx_attr->iov_limit,
 					      core_info->tx_attr->iov_limit);
-	info->tx_attr->rma_iov_limit	= MIN(rxm_info.tx_attr->rma_iov_limit,
+	info->tx_attr->rma_iov_limit	= MIN(base_info->tx_attr->rma_iov_limit,
 					      core_info->tx_attr->rma_iov_limit);
 
-	info->rx_attr->caps		= rxm_info.rx_attr->caps;
+	info->rx_attr->caps		= base_info->rx_attr->caps;
 	info->rx_attr->mode		= info->rx_attr->mode & ~FI_RX_CQ_DATA;
 	info->rx_attr->msg_order 	= core_info->rx_attr->msg_order;
-	info->rx_attr->comp_order 	= rxm_info.rx_attr->comp_order;
-	info->rx_attr->size 		= rxm_info.rx_attr->size;
-	info->rx_attr->iov_limit 	= MIN(rxm_info.rx_attr->iov_limit,
+	info->rx_attr->comp_order 	= base_info->rx_attr->comp_order;
+	info->rx_attr->size 		= base_info->rx_attr->size;
+	info->rx_attr->iov_limit 	= MIN(base_info->rx_attr->iov_limit,
 					      core_info->rx_attr->iov_limit);
 
-	*info->ep_attr = *rxm_info.ep_attr;
+	*info->ep_attr = *base_info->ep_attr;
 	info->ep_attr->max_msg_size = core_info->ep_attr->max_msg_size;
 	info->ep_attr->max_order_raw_size = core_info->ep_attr->max_order_raw_size;
 	info->ep_attr->max_order_war_size = core_info->ep_attr->max_order_war_size;
 	info->ep_attr->max_order_waw_size = core_info->ep_attr->max_order_waw_size;
 
-	*info->domain_attr = *rxm_info.domain_attr;
+	*info->domain_attr = *base_info->domain_attr;
 	info->domain_attr->mr_mode |= core_info->domain_attr->mr_mode;
 	info->domain_attr->cq_data_size = MIN(core_info->domain_attr->cq_data_size,
-					      rxm_info.domain_attr->cq_data_size);
+					      base_info->domain_attr->cq_data_size);
 	info->domain_attr->mr_key_size = core_info->domain_attr->mr_key_size;
 
 	if (core_info->nic) {
@@ -200,6 +201,7 @@ static int rxm_init_info(void)
 		rxm_eager_limit = param - sizeof(struct rxm_pkt);
 	}
 	rxm_info.tx_attr->inject_size = rxm_eager_limit;
+	rxm_info_coll.tx_attr->inject_size = rxm_eager_limit;
 	rxm_util_prov.info = &rxm_info;
 	return 0;
 }
@@ -263,7 +265,7 @@ static void rxm_alter_info(const struct fi_info *hints, struct fi_info *info)
 				cur->domain_attr->data_progress = FI_PROGRESS_MANUAL;
 
 			if (hints->ep_attr && hints->ep_attr->mem_tag_format &&
-			    (info->caps & FI_TAGGED)) {
+			    (info->caps & (FI_TAGGED | FI_COLLECTIVE))) {
 				FI_INFO(&rxm_prov, FI_LOG_CORE,
 					"mem_tag_format requested: 0x%" PRIx64
 					" (note: provider doesn't optimize "
@@ -273,6 +275,7 @@ static void rxm_alter_info(const struct fi_info *hints, struct fi_info *info)
 					hints->ep_attr->mem_tag_format;
 			}
 		}
+
 		if (cur->domain_attr->data_progress == FI_PROGRESS_AUTO ||
 		    force_auto_progress)
 			cur->domain_attr->threading = FI_THREAD_SAFE;

--- a/util/info.c
+++ b/util/info.c
@@ -119,6 +119,7 @@ static int str2cap(char *inputstr, uint64_t *value)
 	ORCASE(FI_TAGGED);
 	ORCASE(FI_ATOMIC);
 	ORCASE(FI_MULTICAST);
+	ORCASE(FI_COLLECTIVE);
 
 	ORCASE(FI_READ);
 	ORCASE(FI_WRITE);


### PR DESCRIPTION
This change modifies rxm_getinfo to return an additional set of info describing
rxm with and without FI_COLLECTIVE support.  This is necessary to enable apps
that want to use collective support without breaking apps that do not use the
mem_tag_format negotiation.