### PR TITLE
configure.ac: use "pax" tar format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)
-AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects parallel-tests tar-ustar])
+AM_INIT_AUTOMAKE([1.11 dist-bzip2 foreign -Wall -Werror subdir-objects parallel-tests tar-pax])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 m4_include(config/fi_check_package.m4)
 


### PR DESCRIPTION
The "ustar" tar format (POSIX.1-1988) imposes a restriction that the UID/GID is at most 2097151. Unfortunately, the configure step will *not fail* if this condition is not met - from the GNU Automake documentation:

> configure knows several ways to construct these formats. It will not abort if it cannot find a tool up to the task (so that the package can still be built), but 'make dist' will fail.

The "pax" tar format (POSIX.1-2001) supports "unlimited" UID/GID value and also supports unlimited filename lengths and an unlimited file size. The "ustar" tar format has the UID/GID restriction, but also has a maximum 8GB file size and a 256 character maximum filename length.