### PR TITLE
prov/shm: add environment variable to control tx and rx size

### DIFF
--- a/man/fi_shm.7.md
+++ b/man/fi_shm.7.md
@@ -116,6 +116,12 @@ The *shm* provider checks for the following environment variables:
   to mmap (only valid when CMA is not available). Default: SIZE_MAX
   (18446744073709551615)
 
+*FI_SHM_TX_SIZE*
+: Maximum number of outstanding tx operations. Default 1024
+
+*FI_SHM_RX_SIZE*
+: Maximum number of outstanding rx operations. Default 1024
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -44,6 +44,8 @@ struct smr_env smr_env = {
 static void smr_init_env(void)
 {
 	fi_param_get_size_t(&smr_prov, "sar_threshold", &smr_env.sar_threshold);
+	fi_param_get_size_t(&smr_prov, "tx_size", &smr_info.tx_attr->size);
+	fi_param_get_size_t(&smr_prov, "rx_size", &smr_info.rx_attr->size);
 }
 
 static void smr_resolve_addr(const char *node, const char *service,
@@ -189,6 +191,12 @@ SHM_INI
 			"Max size to use for alternate SAR protocol if CMA \
 			 is not available before switching to mmap protocol \
 			 Default: SIZE_MAX (18446744073709551615)");
+	fi_param_define(&smr_prov, "tx_size", FI_PARAM_SIZE_T,
+			"Max number of outstanding tx operations \
+			 Default: 1024");
+	fi_param_define(&smr_prov, "rx_size", FI_PARAM_SIZE_T,
+			"Max number of outstanding rx operations \
+			 Default: 1024");
 
 	smr_init_env();
 


### PR DESCRIPTION
The shm provider defaults to a rx and tx size of 1024 to minimize
resources in the shared memory region.

Add environment variables to allow the app to toggle these sizes
if needed.

Signed-off-by: aingerson <alexia.ingerson@intel.com>