### PR TITLE
mrcache: Free lock when cache is not initalized

### DIFF
--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -565,6 +565,7 @@ destroy:
 	cache->storage.destroy(&cache->storage);
 dec:
 	ofi_atomic_dec32(&cache->domain->ref);
+	pthread_mutex_destroy(&cache->lock);
 	cache->domain = NULL;
 	return ret;
 }


### PR DESCRIPTION
If ofi_mr_cache_init_storage() fails for some reason, destroy the lock
before letting the caller free the domain resources.

Signed-off-by: Raghu Raja <craghun@amazon.com>