### PR TITLE
prov/efa: fix a bug in rxr_reset_rx_tx_to_core()

### DIFF
--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -274,9 +274,6 @@ void rxr_reset_rx_tx_to_core(const struct fi_info *user_info,
 	core_info->rx_attr->size =
 		user_info->rx_attr->size < core_info->rx_attr->size ?
 		user_info->rx_attr->size : core_info->rx_attr->size;
-	core_info->rx_attr->iov_limit =
-		user_info->rx_attr->iov_limit < core_info->rx_attr->iov_limit ?
-		user_info->rx_attr->iov_limit : core_info->rx_attr->iov_limit;
 	/* tx attr */
 	core_info->tx_attr->inject_size =
 		user_info->tx_attr->inject_size < core_info->tx_attr->inject_size ?
@@ -284,9 +281,6 @@ void rxr_reset_rx_tx_to_core(const struct fi_info *user_info,
 	core_info->tx_attr->size =
 		user_info->tx_attr->size < core_info->tx_attr->size ?
 		user_info->tx_attr->size : core_info->tx_attr->size;
-	core_info->tx_attr->iov_limit =
-		user_info->tx_attr->iov_limit < core_info->tx_attr->iov_limit ?
-		user_info->tx_attr->iov_limit : core_info->tx_attr->iov_limit;
 }
 
 void rxr_set_rx_tx_size(struct fi_info *info,


### PR DESCRIPTION
rxr_reset_rx_tx_to_core() adjust core_info->tx/rx_attr->iov_limit according
to application provided info, which is not right because device
supported iov_limit is not related to application input.
Especailly, it would cause problem when application specify
tx_attr->iov_limit to 1, in this case core_info->tx_attr->iov_limit
would be set to 1, but the upper layer need at least 2 iov to do
MR cached send.

This patch remove the adjustment of core_inof->tx/rx_attr->iov_limit
from the function.

Signed-off-by: Wei Zhang <wzam@amazon.com>