### PR TITLE
prov/psm2: Improve source address translation for scalable endpoints

### DIFF
--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -1032,6 +1032,8 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 				   ((uintptr_t)sep_priv & 0xFFFF);
 
 	sep_priv->id = ofi_atomic_inc32(&domain_priv->sep_cnt);
+	for (i = 0; i < ctxt_cnt; i++)
+		sep_priv->ctxts[i].ep->sep_id = sep_priv->id;
 
 	domain_priv->sep_lock_fn(&domain_priv->sep_lock, 1);
 	dlist_insert_before(&sep_priv->entry, &domain_priv->sep_list);

--- a/prov/psm2/src/psmx2_msg.c
+++ b/prov/psm2/src/psmx2_msg.c
@@ -211,7 +211,10 @@ ssize_t psmx2_send_generic(struct fid_ep *ep, const void *buf, size_t len,
 	assert(av);
 	psm2_epaddr = psmx2_av_translate_addr(av, ep_priv->tx, dest_addr, av->type);
 
-	PSMX2_SET_TAG(psm2_tag, 0, data, PSMX2_TYPE_MSG | PSMX2_IMM_BIT_SET(have_data));
+	if (have_data)
+		PSMX2_SET_TAG(psm2_tag, 0, data, PSMX2_TYPE_MSG | PSMX2_IMM_BIT);
+	else
+		PSMX2_SET_TAG(psm2_tag, 0, ep_priv->sep_id, PSMX2_TYPE_MSG);
 
 	if ((flags & PSMX2_NO_COMPLETION) ||
 	    (ep_priv->send_selective_completion && !(flags & FI_COMPLETION)))
@@ -353,10 +356,12 @@ ssize_t psmx2_sendv_generic(struct fid_ep *ep, const struct iovec *iov,
 	assert(av);
 	psm2_epaddr = psmx2_av_translate_addr(av, ep_priv->tx, dest_addr, av->type);
 
-	if (flags & FI_REMOTE_CQ_DATA)
+	if (flags & FI_REMOTE_CQ_DATA) {
 		msg_flags |= PSMX2_IMM_BIT;
-
-	PSMX2_SET_TAG(psm2_tag, 0ULL, data, msg_flags);
+		PSMX2_SET_TAG(psm2_tag, 0ULL, data, msg_flags);
+	} else {
+		PSMX2_SET_TAG(psm2_tag, 0ULL, ep_priv->sep_id, msg_flags);
+	}
 
 	if ((flags & PSMX2_NO_COMPLETION) ||
 	    (ep_priv->send_selective_completion && !(flags & FI_COMPLETION)))


### PR DESCRIPTION
The 'source' address information of a message received from the PSM2
layer contains only the PSM2 endpoint address. The information itself
is insufficient to tell whether the source is a scalable endpoint. If
source has already been inserted into the address vector, the provider
can retrieve the right fi_addr by looking into the addresses of each
SEP context. However, if the source has not been inserted into the
address vector, the generated FI_EADDRNOTAVAIL event have to assume the
address is a regular endpoint. This works fine if the address is then
inserted into the address vector and used as-is for later communication,
but can cause error if the application takes advantage of prior
knowledge and tries to use the resulting fi_addr as scalable endpoint
address.

This is improved by overloading the remote CQ data with sep_id. When
remote CQ data is unused, the space can be used to pass the sep_id of
the sender to the receiver. The receiver can now construct correct
source address for scalable endpoints. It falls back to the old way if
the remote CQ data is in use.

This feature is used by the RPC framework Mercury, which conveniently
does not need remote CQ data.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>