### PR TITLE
prov/efa: remove ordering bits from rxr_env

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -192,8 +192,6 @@ struct rxr_env {
 	int tx_min_credits;
 	int tx_max_credits;
 	int tx_queue_size;
-	int enable_sas_ordering;
-	int enable_atomic_ordering;
 	int enable_shm_transfer;
 	int shm_av_size;
 	int shm_max_medium_size;
@@ -787,25 +785,7 @@ static inline size_t rxr_get_tx_pool_chunk_cnt(struct rxr_ep *ep)
 
 static inline int rxr_need_sas_ordering(struct rxr_ep *ep)
 {
-	/*
-	 * RxR needs to reorder RTM packets for send-after-send guarantees
-	 * only if the application requested it and the core provider does not
-	 * support it.
-	 */
-	return ((ep->msg_order & FI_ORDER_SAS) &&
-		!(ep->core_msg_order & FI_ORDER_SAS) &&
-		rxr_env.enable_sas_ordering);
-}
-
-static inline int rxr_need_atomic_ordering(struct rxr_ep *ep)
-{
-	uint64_t atomic_ordering;
-
-	atomic_ordering = FI_ORDER_ATOMIC_RAR | FI_ORDER_ATOMIC_RAW |
-			  FI_ORDER_ATOMIC_WAR | FI_ORDER_ATOMIC_WAW;
-
-	return ((ep->msg_order & atomic_ordering) &&
-		rxr_env.enable_atomic_ordering);
+	return ep->msg_order & FI_ORDER_SAS;
 }
 
 /* Initialization functions */

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -967,7 +967,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
 		base_hdr = (struct rxr_base_hdr *)pkt_entry->pkt;
 		if ((base_hdr->flags & RXR_REQ_MSG) && rxr_need_sas_ordering(ep))
 			need_ordering = true;
-		else if ((base_hdr->flags & RXR_REQ_ATOMIC) && rxr_need_atomic_ordering(ep))
+		else if (base_hdr->flags & RXR_REQ_ATOMIC)
 			need_ordering = true;
 	}
 


### PR DESCRIPTION
This patch remove enable_sas_ordering and enable_atomic_ordering
from rxr_env, because ordering should be solely determining by
EP's attribute. Having an environmental variable to control
ordering is dangerous, and can cause error.

While in there, this patch also remove the check for

   !(ep->core_msg_order & FI_ORDER_SAS)

from rxr_need_sas_ordering(), because we know for sure
that core EP does not support FI_ORDER_SAS.

Signed-off-by: Wei Zhang <wzam@amazon.com>