### PR TITLE
prov/rxm: Fix rxm_buffer_size param checking

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -192,13 +192,13 @@ static int rxm_init_info(void)
 	size_t param;
 
 	if (!fi_param_get_size_t(&rxm_prov, "buffer_size", &param)) {
-		if (param > sizeof(struct rxm_pkt)) {
-			rxm_eager_limit = param - sizeof(struct rxm_pkt);
-		} else {
+		if (param < sizeof(struct rxm_pkt) + sizeof(struct rxm_rndv_hdr)) {
 			FI_WARN(&rxm_prov, FI_LOG_CORE,
 				"Requested buffer size too small\n");
 			return -FI_EINVAL;
 		}
+
+		rxm_eager_limit = param - sizeof(struct rxm_pkt);
 	}
 	rxm_info.tx_attr->inject_size = rxm_eager_limit;
 	rxm_util_prov.info = &rxm_info;


### PR DESCRIPTION
If rxm_buffer_size and rxm_sar_limit size are set significantly low such
that most small message operations are issued using the rendezvous
protocol, the target receive buffer may be too small to hold the
incoming rendezvous control message. This results in the core provider
raising a CQ error which causes RxM to crash on an assert. To fix this
issue, always ensure that the rxm_buffer size is greater than the
rendezvous control message.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>