### PR TITLE
prov/rxm: Return EOPNOTSUPP for zero count AMO op

### DIFF
--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -508,6 +508,9 @@ int rxm_ep_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 	attr->size = ofi_datatype_size(datatype);
 	attr->count = tot_size / attr->size;
 
+	if (attr->count == 0)
+		return -FI_EOPNOTSUPP;
+
 	return FI_SUCCESS;
 }
 


### PR DESCRIPTION
If the rxm_buffer_size is significantly small, the number of elements
RxM can support for a given AMO operation may be zero. For these cases,
when the user checks to see if an AMO operation is valid, return
-FI_EOPNOSUPP instead of returning FI_SUCCESS with a zero count.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>