### PR TITLE
prov/efa: Allow eager req packets to utilize MR cache.

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -821,6 +821,9 @@ int rxr_ep_tx_init_mr_desc(struct rxr_domain *rxr_domain,
 			   struct rxr_tx_entry *tx_entry,
 			   int mr_iov_start, uint64_t access);
 
+void rxr_ep_init_tx_mr_desc_by_find(struct rxr_ep *ep,
+				    struct rxr_tx_entry *tx_entry);
+
 void rxr_prepare_desc_send(struct rxr_domain *rxr_domain,
 			   struct rxr_tx_entry *tx_entry);
 

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -32,6 +32,7 @@
  */
 
 #include <ofi_atomic.h>
+#include "efa.h"
 #include "rxr.h"
 #include "rxr_rma.h"
 #include "rxr_cntr.h"
@@ -139,6 +140,9 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 
 	tx_entry->msg_id = (peer->next_msg_id != ~0) ?
 			    peer->next_msg_id++ : ++peer->next_msg_id;
+
+	if (efa_mr_cache_enable)
+		rxr_ep_init_tx_mr_desc_by_find(rxr_ep, tx_entry);
 
 	err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY,
 					tx_entry, req_pkt_type_list[op],

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -92,9 +92,12 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	}
 
 	/* inter instance message */
-	if (tx_entry->total_len <= max_rtm_data_size)
+	if (tx_entry->total_len <= max_rtm_data_size) {
+		if (efa_mr_cache_enable)
+			rxr_ep_init_tx_mr_desc_by_find(rxr_ep, tx_entry);
 		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
 						  RXR_EAGER_MSGRTM_PKT + tagged, 0);
+	}
 
 	if (tx_entry->total_len <= rxr_env.efa_max_medium_msg_size) {
 		/* we do not check the return value of rxr_ep_init_mr_desc()

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -584,6 +584,8 @@ void rxr_pkt_handle_atomrsp_recv(struct rxr_ep *ep,
 			0, atomrsp_pkt->data,
 			atomrsp_hdr->seg_size);
 
+	rxr_tx_entry_mr_dereg(tx_entry);
+
 	if (tx_entry->fi_flags & FI_COMPLETION) {
 		/* Note write_tx_completion() will release tx_entry */
 		rxr_cq_write_tx_completion(ep, tx_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1031,7 +1031,6 @@ void rxr_pkt_init_rtw_data(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry,
 			   struct fi_rma_iov *rma_iov)
 {
-	char *data;
 	size_t data_size;
 	int i;
 
@@ -1041,10 +1040,9 @@ void rxr_pkt_init_rtw_data(struct rxr_ep *ep,
 		rma_iov[i].key = tx_entry->rma_iov[i].key;
 	}
 
-	data = (char *)pkt_entry->pkt + pkt_entry->hdr_size;
-	data_size = ofi_copy_from_iov(data, ep->mtu_size - pkt_entry->hdr_size,
-				      tx_entry->iov, tx_entry->iov_count, 0);
-
+	data_size = MIN(tx_entry->total_len,
+			ep->mtu_size - pkt_entry->hdr_size);
+	rxr_pkt_data_from_tx(ep, pkt_entry, tx_entry, 0, data_size);
 	pkt_entry->pkt_size = pkt_entry->hdr_size + data_size;
 	pkt_entry->x_entry = tx_entry;
 }
@@ -1503,7 +1501,6 @@ ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 {
 	struct fi_rma_iov *rma_iov;
 	struct rxr_rta_hdr *rta_hdr;
-	char *data;
 	size_t data_size;
 	int i;
 
@@ -1522,9 +1519,9 @@ ssize_t rxr_pkt_init_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 		rma_iov[i].key = tx_entry->rma_iov[i].key;
 	}
 
-	data = (char *)pkt_entry->pkt + pkt_entry->hdr_size;
-	data_size = ofi_copy_from_iov(data, ep->mtu_size - pkt_entry->hdr_size,
-				      tx_entry->iov, tx_entry->iov_count, 0);
+	data_size = MIN(tx_entry->total_len,
+			ep->mtu_size - pkt_entry->hdr_size);
+	rxr_pkt_data_from_tx(ep, pkt_entry, tx_entry, 0, data_size);
 
 	pkt_entry->pkt_size = pkt_entry->hdr_size + data_size;
 	pkt_entry->x_entry = tx_entry;

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -391,8 +391,11 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 		return rxr_rma_post_shm_write(ep, tx_entry);
 
 	/* Inter instance */
-	if (tx_entry->total_len < rxr_pkt_req_max_data_size(ep, tx_entry->addr, RXR_EAGER_RTW_PKT))
+	if (tx_entry->total_len < rxr_pkt_req_max_data_size(ep, tx_entry->addr, RXR_EAGER_RTW_PKT)) {
+		if (efa_mr_cache_enable)
+			rxr_ep_init_tx_mr_desc_by_find(ep, tx_entry);
 		return rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_EAGER_RTW_PKT, 0);
+	}
 
 	if (tx_entry->total_len >= rxr_env.efa_min_read_write_size &&
 	    efa_both_support_rdma_read(ep, peer) &&


### PR DESCRIPTION
Currently, when we are sending eager req packets, we need to copy the data from the `iov` of `tx_entry` to the bounce buffer. However, sometimes the iovs of are already registered in the MR cache. This patch allows us to avoid memory copy in this case.

It includes the following changes:

A function `rxr_ep_init_tx_mr_desc_by_find()` was added that will loop through the `tx_entry->iov` and call `ofi_mr_cache_find()` on each to find registered MRs and set the corresponding `tx_entry->mr` and `tx_entry->desc`.

When we initialize these types of packets: `RXR_EAGER_MSGRTM_PKT`,`RXR_EAGER_TAGRTM_PKT`,`RXR_EAGER_RTW_PKT`,`RXR_WRITE_RTA_PKT`,`RXR_FETCH_RTA_PKT`,`RXR_COMPARE_RTA_PKT`. We call `rxr_ep_init_tx_mr_desc_by_find()` to set `tx_entry->desc` before we call `rxr_pkt_post_ctrl_or_queue()`

Signed-off-by: Ao Li <aolia@amazon.com>