### PR TITLE
verbs: cleanup + memory leak fix, tcp: cleanup, windows: handle socket API diffs

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -70,7 +70,6 @@
 #define TCPX_MAX_INJECT_SZ	(64)
 
 #define MAX_POLL_EVENTS		100
-#define STAGE_BUF_SIZE		512
 
 #define TCPX_MIN_MULTI_RECV	16384
 
@@ -179,11 +178,14 @@ struct tcpx_rx_ctx {
 typedef int (*tcpx_rx_process_fn_t)(struct tcpx_xfer_entry *rx_entry);
 typedef int (*tcpx_get_rx_func_t)(struct tcpx_ep *ep);
 
+enum {
+	STAGE_BUF_SIZE = 512
+};
+
 struct stage_buf {
 	uint8_t			buf[STAGE_BUF_SIZE];
-	size_t			size;
-	size_t			len;
-	size_t			off;
+	size_t			bytes_avail;
+	size_t			cur_pos;
 };
 
 struct tcpx_ep {
@@ -280,7 +282,7 @@ void tcpx_cq_report_error(struct util_cq *cq,
 
 int tcpx_recv_msg_data(struct tcpx_xfer_entry *recv_entry);
 int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry);
-int tcpx_comm_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
+int tcpx_comm_recv_hdr(SOCKET sock, struct stage_buf *stage_buf,
 		        struct tcpx_cur_rx_msg *cur_rx_msg);
 int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf);
 

--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -57,22 +57,21 @@ int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry)
 	return FI_SUCCESS;
 }
 
-static ssize_t tcpx_read_from_buffer(struct stage_buf *sbuf,
+static ssize_t tcpx_read_from_buffer(struct stage_buf *stage_buf,
 				     uint8_t *buf, size_t len)
 {
 	size_t rem_size;
 	ssize_t ret;
 
-	assert(sbuf->len >= sbuf->off);
-	rem_size = sbuf->len - sbuf->off;
-	assert(rem_size);
+	assert(stage_buf->cur_pos < stage_buf->bytes_avail);
+	rem_size = stage_buf->bytes_avail - stage_buf->cur_pos;
 	ret = (rem_size >= len) ? len : rem_size;
-	memcpy(buf, &sbuf->buf[sbuf->off], ret);
-	sbuf->off += ret;
+	memcpy(buf, &stage_buf->buf[stage_buf->cur_pos], ret);
+	stage_buf->cur_pos += ret;
 	return ret;
 }
 
-static int tcpx_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
+static int tcpx_recv_hdr(SOCKET sock, struct stage_buf *stage_buf,
 			  struct tcpx_cur_rx_msg *cur_rx_msg)
 {
 	void *rem_buf;
@@ -82,8 +81,8 @@ static int tcpx_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
 	rem_buf = (uint8_t *) &cur_rx_msg->hdr + cur_rx_msg->done_len;
 	rem_len = cur_rx_msg->hdr_len - cur_rx_msg->done_len;
 
-	if (sbuf->len != sbuf->off)
-		bytes_recvd = tcpx_read_from_buffer(sbuf, rem_buf, rem_len);
+	if (stage_buf->cur_pos < stage_buf->bytes_avail)
+		bytes_recvd = tcpx_read_from_buffer(stage_buf, rem_buf, rem_len);
 	else
 		bytes_recvd = ofi_recv_socket(sock, rem_buf, rem_len, 0);
 	if (bytes_recvd <= 0)
@@ -92,11 +91,11 @@ static int tcpx_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
 	return bytes_recvd;
 }
 
-int tcpx_comm_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
+int tcpx_comm_recv_hdr(SOCKET sock, struct stage_buf *stage_buf,
 		        struct tcpx_cur_rx_msg *cur_rx_msg)
 {
 	ssize_t bytes_recvd;
-	bytes_recvd = tcpx_recv_hdr(sock, sbuf, cur_rx_msg);
+	bytes_recvd = tcpx_recv_hdr(sock, stage_buf, cur_rx_msg);
 	if (bytes_recvd < 0)
 		return bytes_recvd;
 	cur_rx_msg->done_len += bytes_recvd;
@@ -105,7 +104,7 @@ int tcpx_comm_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
 		cur_rx_msg->hdr_len = (size_t) cur_rx_msg->hdr.base_hdr.payload_off;
 
 		if (cur_rx_msg->hdr_len > cur_rx_msg->done_len) {
-			bytes_recvd = tcpx_recv_hdr(sock, sbuf, cur_rx_msg);
+			bytes_recvd = tcpx_recv_hdr(sock, stage_buf, cur_rx_msg);
 			if (bytes_recvd < 0)
 				return bytes_recvd;
 			cur_rx_msg->done_len += bytes_recvd;
@@ -118,7 +117,7 @@ int tcpx_comm_recv_hdr(SOCKET sock, struct stage_buf *sbuf,
 		FI_SUCCESS : -FI_EAGAIN;
 }
 
-static ssize_t tcpx_readv_from_buffer(struct stage_buf *sbuf,
+static ssize_t tcpx_readv_from_buffer(struct stage_buf *stage_buf,
 				      struct iovec *iov,
 				      int iov_cnt)
 {
@@ -127,15 +126,15 @@ static ssize_t tcpx_readv_from_buffer(struct stage_buf *sbuf,
 	int i;
 
 	if (iov_cnt == 1)
-		return tcpx_read_from_buffer(sbuf, iov[0].iov_base,
+		return tcpx_read_from_buffer(stage_buf, iov[0].iov_base,
 					     iov[0].iov_len);
 
 	for (i = 0; i < iov_cnt; i++) {
-		bytes_read = tcpx_read_from_buffer(sbuf, iov[i].iov_base,
+		bytes_read = tcpx_read_from_buffer(stage_buf, iov[i].iov_base,
 						   iov[i].iov_len);
 		ret += bytes_read;
 		if ((bytes_read < iov[i].iov_len) ||
-		    !(sbuf->len - sbuf->off))
+		    !(stage_buf->bytes_avail - stage_buf->cur_pos))
 			break;
 	}
 	return ret;
@@ -148,7 +147,7 @@ int tcpx_recv_msg_data(struct tcpx_xfer_entry *rx_entry)
 	if (!rx_entry->iov_cnt || !rx_entry->iov[0].iov_len)
 		return FI_SUCCESS;
 
-	if (rx_entry->ep->stage_buf.len != rx_entry->ep->stage_buf.off)
+	if (rx_entry->ep->stage_buf.cur_pos < rx_entry->ep->stage_buf.bytes_avail)
 		bytes_recvd = tcpx_readv_from_buffer(&rx_entry->ep->stage_buf,
 						     rx_entry->iov,
 						     rx_entry->iov_cnt);
@@ -169,11 +168,11 @@ int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf)
 	int bytes_recvd;
 
 	bytes_recvd = ofi_recv_socket(sock, stage_buf->buf,
-				      stage_buf->size, 0);
+				      sizeof(stage_buf->buf), 0);
 	if (bytes_recvd <= 0)
 		return (bytes_recvd) ? -ofi_sockerr(): -FI_ENOTCONN;
 
-	stage_buf->len = bytes_recvd;
-	stage_buf->off = 0;
+	stage_buf->bytes_avail = bytes_recvd;
+	stage_buf->cur_pos = 0;
 	return FI_SUCCESS;
 }

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -58,7 +58,7 @@ void tcpx_cq_progress(struct util_cq *cq)
 		tcpx_try_func(&ep->util_ep);
 		fastlock_acquire(&ep->lock);
 		tcpx_progress_tx(ep);
-		if (ep->stage_buf.off != ep->stage_buf.len)
+		if (ep->stage_buf.cur_pos < ep->stage_buf.bytes_avail)
 			tcpx_progress_rx(ep);
 		fastlock_release(&ep->lock);
 	}

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -545,10 +545,6 @@ int tcpx_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err3;
 
-	ep->stage_buf.size = STAGE_BUF_SIZE;
-	ep->stage_buf.len = 0;
-	ep->stage_buf.off = 0;
-
 	slist_init(&ep->rx_queue);
 	slist_init(&ep->tx_queue);
 	slist_init(&ep->rma_read_queue);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -599,7 +599,7 @@ void tcpx_progress_rx(struct tcpx_ep *ep)
 {
 	int ret;
 
-	if (!ep->cur_rx_entry && (ep->stage_buf.len == ep->stage_buf.off)) {
+	if (!ep->cur_rx_entry && (ep->stage_buf.cur_pos == ep->stage_buf.bytes_avail)) {
 		ret = tcpx_read_to_buffer(ep->sock, &ep->stage_buf);
 		if (ret)
 			goto err;
@@ -618,7 +618,7 @@ void tcpx_progress_rx(struct tcpx_ep *ep)
 		assert(ep->cur_rx_proc_fn != NULL);
 		ep->cur_rx_proc_fn(ep->cur_rx_entry);
 
-	} while (ep->stage_buf.len != ep->stage_buf.off);
+	} while (ep->stage_buf.cur_pos < ep->stage_buf.bytes_avail);
 
 	return;
 err:

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -101,8 +101,9 @@ int vrb_sockaddr_len(struct sockaddr *addr)
 		return ofi_sizeofaddr(addr);
 }
 
-int vrb_get_rdma_rai(const char *node, const char *service, uint64_t flags,
-		   const struct fi_info *hints, struct rdma_addrinfo **rai)
+static int
+vrb_get_rdma_rai(const char *node, const char *service, uint64_t flags,
+		 const struct fi_info *hints, struct rdma_addrinfo **rai)
 {
 	struct rdma_addrinfo rai_hints, *_rai;
 	struct rdma_addrinfo **rai_current;

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -240,7 +240,9 @@ int vrb_create_ep(const struct fi_info *hints, enum rdma_port_space ps,
 				"dst addr", rai->ai_dst_addr);
 		goto err2;
 	}
+	rdma_freeaddrinfo(rai);
 	return 0;
+
 err2:
 	rdma_destroy_id(*id);
 err1:

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -763,8 +763,6 @@ const struct fi_info *vrb_get_verbs_info(const struct fi_info *ilist,
 					    const char *domain_name);
 int vrb_fi_to_rai(const struct fi_info *fi, uint64_t flags,
 		     struct rdma_addrinfo *rai);
-int vrb_get_rdma_rai(const char *node, const char *service, uint64_t flags,
-			const struct fi_info *hints, struct rdma_addrinfo **rai);
 int vrb_get_matching_info(uint32_t version, const struct fi_info *hints,
 			     struct fi_info **info, const struct fi_info *verbs_info,
 			     uint8_t passive);

--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -509,11 +509,14 @@ ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags
 	ssize_t size = 0;
 	int ret, i;
 
-	if (iov_cnt == 1)
-		return send(fd, iovec[0].iov_base, iovec[0].iov_len, flags);
+	if (iov_cnt == 1) {
+		return ofi_send_socket(fd, iovec[0].iov_base,
+				       iovec[0].iov_len, flags);
+	}
 
 	for (i = 0; i < iov_cnt; i++) {
-		ret = send(fd, iovec[i].iov_base, iovec[i].iov_len, flags);
+		ret = ofi_send_socket(fd, iovec[i].iov_base,
+				      iovec[i].iov_len, flags);
 		if (ret >= 0) {
 			size += ret;
 			if (ret != iovec[i].iov_len)
@@ -531,11 +534,14 @@ ofi_recvv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags
 	ssize_t size = 0;
 	int ret, i;
 
-	if (iov_cnt == 1)
-		return recv(fd, iovec[0].iov_base, iovec[0].iov_len, flags);
+	if (iov_cnt == 1) {
+		return ofi_recv_socket(fd, iovec[0].iov_base,
+				       iovec[0].iov_len, flags);
+	}
 
 	for (i = 0; i < iov_cnt; i++) {
-		ret = recv(fd, iovec[i].iov_base, iovec[i].iov_len, flags);
+		ret = ofi_recv_socket(fd, iovec[i].iov_base,
+				      iovec[i].iov_len, flags);
 		if (ret >= 0) {
 			size += ret;
 			if (ret != iovec[i].iov_len)


### PR DESCRIPTION
verbs: Fix a minor memory leak in the verbs provider, along with updates to the surrounding code.

tcp: cleanup and renaming of struct stage_buf

windows: Handle mapping of linux socket calls to windows socket API.  The latter use 'int' for data transfers sizes, rather than size_t.