### PR TITLE
prov/util: Alter provider info with NULL hints

### DIFF
--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1091,6 +1091,8 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 		attr->mr_mode = (attr->mr_mode && attr->mr_mode != FI_MR_SCALABLE) ?
 				FI_MR_BASIC : FI_MR_SCALABLE;
 	} else {
+		attr->mr_mode &= ~(FI_MR_BASIC | FI_MR_SCALABLE);
+
 		if ((hints_mr_mode & attr->mr_mode) != attr->mr_mode) {
 			attr->mr_mode = ofi_cap_mr_mode(info_caps,
 						attr->mr_mode & hints_mr_mode);

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -1093,7 +1093,8 @@ static void fi_alter_domain_attr(struct fi_domain_attr *attr,
 	} else {
 		attr->mr_mode &= ~(FI_MR_BASIC | FI_MR_SCALABLE);
 
-		if ((hints_mr_mode & attr->mr_mode) != attr->mr_mode) {
+		if (hints &&
+		    ((hints_mr_mode & attr->mr_mode) != attr->mr_mode)) {
 			attr->mr_mode = ofi_cap_mr_mode(info_caps,
 						attr->mr_mode & hints_mr_mode);
 		}
@@ -1176,7 +1177,8 @@ static uint64_t ofi_get_info_caps(const struct fi_info *prov_info,
 	int prov_mode, user_mode;
 	uint64_t caps;
 
-	assert(user_info);
+	if (!user_info)
+		return prov_info->caps;
 
 	caps = ofi_get_caps(prov_info->caps, user_info->caps, prov_info->caps);
 
@@ -1210,9 +1212,6 @@ trim_caps:
 void ofi_alter_info(struct fi_info *info, const struct fi_info *hints,
 		    uint32_t api_version)
 {
-	if (!hints)
-		return;
-
 	for (; info; info = info->next) {
 		/* This should stay before call to fi_alter_domain_attr as
 		 * the checks depend on unmodified provider mr_mode attr */
@@ -1224,12 +1223,17 @@ void ofi_alter_info(struct fi_info *info, const struct fi_info *hints,
 		      (hints->domain_attr->mr_mode & (FI_MR_BASIC | FI_MR_SCALABLE)))))
 			info->mode |= FI_LOCAL_MR;
 
-		info->handle = hints->handle;
+		if (hints)
+			info->handle = hints->handle;
 
-		fi_alter_domain_attr(info->domain_attr, hints->domain_attr,
+		fi_alter_domain_attr(info->domain_attr,
+				     hints ? hints->domain_attr : NULL,
 				     info->caps, api_version);
-		fi_alter_ep_attr(info->ep_attr, hints->ep_attr, info->caps);
-		fi_alter_rx_attr(info->rx_attr, hints->rx_attr, info->caps);
-		fi_alter_tx_attr(info->tx_attr, hints->tx_attr, info->caps);
+		fi_alter_ep_attr(info->ep_attr, hints ? hints->ep_attr : NULL,
+				 info->caps);
+		fi_alter_rx_attr(info->rx_attr, hints ? hints->rx_attr : NULL,
+				 info->caps);
+		fi_alter_tx_attr(info->tx_attr, hints ? hints->tx_attr : NULL,
+				 info->caps);
 	}
 }


### PR DESCRIPTION
The RxM provider was not altering the MR mode attribute based on API
version if the fi_getinfo() hints argument was NULL. Define
ofi_alter_mr_mode() to alter the MR mode attribute and have RxM call
it accordingly.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>

Resolves https://github.com/ofiwg/libfabric/issues/5607