### PR TITLE
Verbs;RxM HMEM Support

### DIFF
--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -120,8 +120,9 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			       datatype_sz);
 		buf_len = ofi_total_iov_len(buf_iov, msg->iov_count);
 
-		buf_iface = rxm_mr_desc_to_hmem_iface(msg->desc,
-						      msg->iov_count);
+		buf_iface = rxm_init_hmem_iface(rxm_ep, buf_iov, msg->desc,
+						msg->iov_count,
+						!!(flags & FI_INJECT));
 	}
 
 	if (op == ofi_op_atomic_compare) {
@@ -131,8 +132,9 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		cmp_len = ofi_total_iov_len(cmp_iov, compare_iov_count);
 		assert(buf_len == cmp_len);
 
-		cmp_iface = rxm_mr_desc_to_hmem_iface(compare_desc,
-						      compare_iov_count);
+		cmp_iface = rxm_init_hmem_iface(rxm_ep, cmp_iov, compare_desc,
+						compare_iov_count,
+						!!(flags & FI_INJECT));
 	}
 
 	tot_len = buf_len + cmp_len + sizeof(struct rxm_atomic_hdr) +

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -32,10 +33,11 @@
 
 #include "rxm.h"
 
-#define RXM_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | FI_ATOMICS)
+#define RXM_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | \
+		     FI_ATOMICS | FI_HMEM)
 #define RXM_RX_CAPS (FI_SOURCE | OFI_RX_MSG_CAPS | FI_TAGGED | \
 		     OFI_RX_RMA_CAPS | FI_ATOMICS | FI_DIRECTED_RECV | \
-		     FI_MULTI_RECV)
+		     FI_MULTI_RECV | FI_HMEM)
 #define RXM_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM)
 
 // TODO have a separate "check info" against which app hints would be checked.

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -2,6 +2,7 @@
  * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
  * Copyright (c) 2018 Cray Inc. All rights reserved.
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -486,7 +487,7 @@ ssize_t rxm_cq_handle_rndv(struct rxm_rx_buf *rx_buf)
 	} else {
 		for (i = 0; i < rx_buf->recv_entry->rxm_iov.count; i++)
 			rx_buf->recv_entry->rxm_iov.desc[i] =
-				fi_mr_desc(rx_buf->recv_entry->rxm_iov.desc[i]);
+				fi_mr_desc(((struct rxm_mr *)rx_buf->recv_entry->rxm_iov.desc[i])->msg_mr);
 		total_recv_len = MIN(rx_buf->recv_entry->total_len,
 				     rx_buf->pkt.hdr.size);
 	}

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -339,8 +339,9 @@ ssize_t rxm_cq_copy_seg_data(struct rxm_rx_buf *rx_buf, int *done)
 	enum fi_hmem_iface iface;
 	ssize_t done_len;
 
-	iface = rxm_mr_desc_to_hmem_iface(rx_buf->recv_entry->rxm_iov.desc,
-					  rx_buf->recv_entry->rxm_iov.count);
+	iface = rxm_init_hmem_iface(rx_buf->ep, rx_buf->recv_entry->rxm_iov.iov,
+				    rx_buf->recv_entry->rxm_iov.desc,
+				    rx_buf->recv_entry->rxm_iov.count, false);
 
 	done_len = ofi_copy_to_hmem_iov(rx_buf->recv_entry->rxm_iov.iov, iface,
 					rx_buf->recv_entry->rxm_iov.count,
@@ -453,6 +454,7 @@ ssize_t rxm_cq_handle_rndv(struct rxm_rx_buf *rx_buf)
 	size_t i, index = 0, offset = 0, count, total_recv_len;
 	struct iovec iov[RXM_IOV_LIMIT];
 	void *desc[RXM_IOV_LIMIT];
+	enum fi_hmem_iface iface;
 	struct rxm_rx_buf *new_rx_buf;
 	int ret = 0;
 
@@ -482,11 +484,15 @@ ssize_t rxm_cq_handle_rndv(struct rxm_rx_buf *rx_buf)
 	rx_buf->rndv_hdr = (struct rxm_rndv_hdr *)rx_buf->pkt.data;
 	rx_buf->rndv_rma_index = 0;
 
+	iface = rxm_init_hmem_iface(rx_buf->ep, rx_buf->recv_entry->rxm_iov.iov,
+				    rx_buf->recv_entry->rxm_iov.desc,
+				    rx_buf->recv_entry->rxm_iov.count, false);
+
 	if (!rx_buf->ep->rdm_mr_local) {
 		total_recv_len = MIN(rx_buf->recv_entry->total_len,
 				     rx_buf->pkt.hdr.size);
 		ret = rxm_msg_mr_regv(rx_buf->ep,
-				      rx_buf->recv_entry->rxm_iov.iov,
+				      rx_buf->recv_entry->rxm_iov.iov, iface,
 				      rx_buf->recv_entry->rxm_iov.count,
 				      total_recv_len, FI_READ, rx_buf->mr);
 		if (OFI_UNLIKELY(ret))
@@ -555,8 +561,9 @@ ssize_t rxm_cq_handle_eager(struct rxm_rx_buf *rx_buf)
 	enum fi_hmem_iface iface;
 	ssize_t done_len;
 
-	iface = rxm_mr_desc_to_hmem_iface(rx_buf->recv_entry->rxm_iov.desc,
-					  rx_buf->recv_entry->rxm_iov.count);
+	iface = rxm_init_hmem_iface(rx_buf->ep, rx_buf->recv_entry->rxm_iov.iov,
+				    rx_buf->recv_entry->rxm_iov.desc,
+				    rx_buf->recv_entry->rxm_iov.count, false);
 
 	done_len = ofi_copy_to_hmem_iov(rx_buf->recv_entry->rxm_iov.iov, iface,
 					rx_buf->recv_entry->rxm_iov.count,
@@ -579,8 +586,9 @@ ssize_t rxm_cq_handle_coll_eager(struct rxm_rx_buf *rx_buf)
 	enum fi_hmem_iface iface;
 	ssize_t done_len;
 
-	iface = rxm_mr_desc_to_hmem_iface(rx_buf->recv_entry->rxm_iov.desc,
-					  rx_buf->recv_entry->rxm_iov.count);
+	iface = rxm_init_hmem_iface(rx_buf->ep, rx_buf->recv_entry->rxm_iov.iov,
+				    rx_buf->recv_entry->rxm_iov.desc,
+				    rx_buf->recv_entry->rxm_iov.count, false);
 
 	done_len = ofi_copy_to_hmem_iov(rx_buf->recv_entry->rxm_iov.iov, iface,
 					rx_buf->recv_entry->rxm_iov.count,
@@ -1132,8 +1140,9 @@ static inline ssize_t rxm_handle_atomic_resp(struct rxm_ep *rxm_ep,
 	       " msg_id: 0x%" PRIx64 "\n", rx_buf->pkt.hdr.op,
 	       rx_buf->pkt.ctrl_hdr.msg_id);
 
-	iface = rxm_mr_desc_to_hmem_iface(tx_buf->rxm_iov.desc,
-					  tx_buf->rxm_iov.count);
+	iface = rxm_init_hmem_iface(rxm_ep, tx_buf->rxm_iov.iov,
+				    tx_buf->rxm_iov.desc, tx_buf->rxm_iov.count,
+				    false);
 
 	assert(!(rx_buf->comp_flags & ~(FI_RECV | FI_REMOTE_CQ_DATA)));
 

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -233,10 +234,7 @@ static void rxm_mr_init(struct rxm_mr *rxm_mr, struct rxm_domain *domain,
 	rxm_mr->mr_fid.fid.fclass = FI_CLASS_MR;
 	rxm_mr->mr_fid.fid.context = context;
 	rxm_mr->mr_fid.fid.ops = &rxm_mr_ops;
-	/* Store msg_mr as rxm_mr descriptor so that we can get its key when
-	 * the app passes msg_mr as the descriptor in fi_send and friends.
-	 * The key would be used in large message transfer protocol and RMA. */
-	rxm_mr->mr_fid.mem_desc = rxm_mr->msg_mr;
+	rxm_mr->mr_fid.mem_desc = rxm_mr;
 	rxm_mr->mr_fid.key = fi_mr_key(rxm_mr->msg_mr);
 	rxm_mr->domain = domain;
 	ofi_atomic_inc32(&domain->util_domain.ref);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013-2016 Intel Corporation. All rights reserved.
  * Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -1045,8 +1046,10 @@ rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void 
 			uint64_t data, uint64_t flags, uint64_t tag, uint8_t op,
 			struct rxm_tx_rndv_buf **tx_rndv_buf)
 {
+	struct fid_mr *rxm_mr_msg_mr[RXM_IOV_LIMIT];
 	struct fid_mr **mr_iov;
 	ssize_t ret;
+	int i;
 	struct rxm_tx_rndv_buf *tx_buf = (struct rxm_tx_rndv_buf *)
 			rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX_RNDV);
 
@@ -1069,8 +1072,10 @@ rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void 
 			goto err;
 		mr_iov = tx_buf->mr;
 	} else {
-		/* desc is msg fid_mr * array */
-		mr_iov = (struct fid_mr **)desc;
+		for (i = 0; i < count; i++)
+			rxm_mr_msg_mr[i] = ((struct rxm_mr *)desc[i])->msg_mr;
+
+		mr_iov = rxm_mr_msg_mr;
 	}
 
 	rxm_rndv_hdr_init(rxm_ep, &tx_buf->pkt.data, iov, tx_buf->count, mr_iov);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -275,6 +275,11 @@ static void rxm_alter_info(const struct fi_info *hints, struct fi_info *info)
 				cur->tx_attr->mode &= ~FI_LOCAL_MR;
 				cur->rx_attr->mode &= ~FI_LOCAL_MR;
 				cur->domain_attr->mr_mode &= ~FI_MR_LOCAL;
+
+				/* If MR local was not requested, FI_MR_HMEM is
+				 * always disabled.
+				 */
+				cur->domain_attr->mr_mode &= ~FI_MR_HMEM;
 			}
 
 			if (!hints->domain_attr ||

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Intel Corporation. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -56,7 +57,8 @@ rxm_ep_rma_reg_iov(struct rxm_ep *rxm_ep, const struct iovec *msg_iov,
 		rma_buf->mr.count = iov_count;
 	} else {
 		for (i = 0; i < iov_count; i++)
-			desc_storage[i] = fi_mr_desc(desc[i]);
+			desc_storage[i] =
+				fi_mr_desc(((struct rxm_mr *)desc[i])->msg_mr);
 	}
 	return FI_SUCCESS;
 }

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013-2018 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -373,6 +374,7 @@ struct vrb_domain {
 
 	/* MR stuff */
 	struct ofi_mr_cache		cache;
+	bool				cache_enabled;
 };
 
 struct vrb_cq;
@@ -423,10 +425,10 @@ struct vrb_mem_desc {
 	size_t			len;
 	/* this field is used only by MR cache operations */
 	struct ofi_mr_entry	*entry;
+	enum fi_hmem_iface	iface;
 };
 
 extern struct fi_ops_mr vrb_mr_ops;
-extern struct fi_ops_mr vrb_mr_cache_ops;
 
 int vrb_mr_cache_add_region(struct ofi_mr_cache *cache,
 			       struct ofi_mr_entry *entry);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -379,6 +379,11 @@ struct vrb_domain {
 	/* MR stuff */
 	struct ofi_mr_cache		cache;
 	bool				cache_enabled;
+
+#ifdef HAVE_LIBCUDA
+	struct ofi_mr_cache		cuda_cache;
+	bool				cuda_cache_enabled;
+#endif
 };
 
 struct vrb_cq;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015 Intel Corporation, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -316,6 +317,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	_domain->util_domain.domain_fid.fid.fclass = FI_CLASS_DOMAIN;
 	_domain->util_domain.domain_fid.fid.context = context;
 	_domain->util_domain.domain_fid.fid.ops = &vrb_fid_ops;
+	_domain->util_domain.domain_fid.mr = &vrb_mr_ops;
 
 	_domain->cache.entry_data_size = sizeof(struct vrb_mem_desc);
 	_domain->cache.add_region = vrb_mr_cache_add_region;
@@ -323,9 +325,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	ret = ofi_mr_cache_init(&_domain->util_domain, default_monitor,
 				&_domain->cache);
 	if (!ret)
-		_domain->util_domain.domain_fid.mr = &vrb_mr_cache_ops;
-	else
-		_domain->util_domain.domain_fid.mr = &vrb_mr_ops;
+		_domain->cache_enabled = true;
 
 	switch (_domain->ep_type) {
 	case FI_EP_DGRAM:

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -180,6 +180,10 @@ struct ofi_mr_cache *vrb_mr_get_cache(struct vrb_domain *domain,
 {
 	if (iface == FI_HMEM_SYSTEM)
 		return &domain->cache;
+#ifdef HAVE_LIBCUDA
+	else if (iface == FI_HMEM_CUDA)
+		return &domain->cuda_cache;
+#endif
 	return NULL;
 }
 
@@ -274,6 +278,10 @@ bool vrb_mr_iface_cache_enabled(struct vrb_domain *domain,
 {
 	if (iface == FI_HMEM_SYSTEM)
 		return domain->cache_enabled;
+#ifdef HAVE_LIBCUDA
+	else if (iface == FI_HMEM_CUDA)
+		return domain->cuda_cache_enabled;
+#endif
 	return false;
 }
 

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -66,7 +66,7 @@ int vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access,
 	md->mr_fid.fid.fclass = FI_CLASS_MR;
 	md->mr_fid.fid.context = context;
 
-	if (md->domain->flags & VRB_USE_ODP)
+	if (md->domain->flags & VRB_USE_ODP && iface == FI_HMEM_SYSTEM)
 		vrb_access |= VRB_ACCESS_ON_DEMAND;
 
 	md->mr = ibv_reg_mr(md->domain->pd, (void *) buf, len, vrb_access);
@@ -77,9 +77,11 @@ int vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access,
 			/* Ignore failure for zero length memory registration */
 			assert(errno == FI_EINVAL);
 	} else {
-		md->mr_fid.mem_desc = (void *)(uintptr_t)md->mr->lkey;
+		md->mr_fid.mem_desc = (void *)md;
 		md->mr_fid.key = md->mr->rkey;
 	}
+
+	md->iface = iface;
 
 	if (md->domain->eq_flags & FI_REG_MR) {
 		struct fi_eq_entry entry = {

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2018 Intel Corporation, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -110,7 +111,7 @@ vrb_msg_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT_DESC(ep, len, desc),
 	};
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
@@ -126,7 +127,7 @@ vrb_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT_DESC(ep, len, desc),
 	};
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
@@ -262,7 +263,7 @@ vrb_msg_xrc_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
-		.send_flags = VERBS_INJECT(&ep->base_ep, len),
+		.send_flags = VERBS_INJECT_DESC(&ep->base_ep, len, desc),
 	};
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
@@ -280,7 +281,7 @@ vrb_msg_xrc_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
-		.send_flags = VERBS_INJECT(&ep->base_ep, len),
+		.send_flags = VERBS_INJECT_DESC(&ep->base_ep, len, desc),
 	};
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2018 Intel Corporation, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -55,7 +56,7 @@ vrb_msg_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.opcode = IBV_WR_RDMA_WRITE,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT_DESC(ep, len, desc),
 	};
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
@@ -169,7 +170,7 @@ vrb_msg_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.imm_data = htonl((uint32_t)data),
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT_DESC(ep, len, desc),
 	};
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
@@ -288,7 +289,7 @@ vrb_msg_xrc_ep_rma_write(struct fid_ep *ep_fid, const void *buf,
 		.opcode = IBV_WR_RDMA_WRITE,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.send_flags = VERBS_INJECT(&ep->base_ep, len),
+		.send_flags = VERBS_INJECT_DESC(&ep->base_ep, len, desc),
 	};
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
@@ -415,7 +416,7 @@ vrb_msg_xrc_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf,
 		.imm_data = htonl((uint32_t)data),
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.send_flags = VERBS_INJECT(&ep->base_ep, len),
+		.send_flags = VERBS_INJECT_DESC(&ep->base_ep, len, desc),
 	};
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);


### PR DESCRIPTION
Enabled FI_HMEM support for verbs and rxm. For verbs, FI_MR_HMEM is required. For rxm, FI_MR_HMEM is set by default. But, if the user does not request FI_MR_HMEM in hints, rxm can run without it. This will result in a buffer query for each data transfer operation.

Couple things to point out:
1. The CUDA memory monitor implementation I had completed before the discussions in https://github.com/ofiwg/libfabric/issues/5789. I thought that embracing the memory monitor approach made sense. In addition, it would be easy to replace this memory monitor with a CUDA memhooks implementation in the future (just change the pointer). Having said that, if storing the buffer ID in the MR entry is preferred, I can change to that approach. Note that I think the memory monitor approach should be used for AMD buffers. I can open up a draft PR for this implementation.

Since a CUDA memory monitor was used and an MR cache cannot support multiple monitors per cache, I had to use multiple caches for the different fi_hmem_iface types. One area for improvement is to allow a MR cache to subscribed to multiple memory monitors.

2. Since the requirement was to support rxm without FI_MR_HMEM set, it became messy quickly on how to support the different combinations of FI_MR_HMEM and FI_MR_LOCAL. The end result would have been having to query the buffer pointer type unless both FI_MR_HMEM and FI_MR_LOCAL are set. Thus, I limited rxm to operate with either both FI_MR_HMEM and FI_MR_LOCAL or neither.

This resolves most of https://github.com/ofiwg/libfabric/issues/5849 except for the AMD GPU requirement.