### PR TITLE
prov/rxm: fix flow control ops_open

### DIFF
--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -876,11 +876,13 @@ static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 		return ret;
 	}
 
-	ret = fi_open_ops(&msg_ep->fid, OFI_OPS_FLOW_CTRL, 0, (void **) &flow_ctrl_ops, NULL);
+	ret = fi_open_ops(&rxm_domain->msg_domain->fid, OFI_OPS_FLOW_CTRL, 0,
+			  (void **) &flow_ctrl_ops, &msg_ep->fid);
 	if (!ret && flow_ctrl_ops) {
 		rxm_ep->flow_ctrl_ops = flow_ctrl_ops;
-		rxm_ep->flow_ctrl_ops->set_threshold(rxm_domain->msg_domain,
-						     rxm_ep->msg_info->rx_attr->size / 2);
+		rxm_ep->flow_ctrl_ops->set_threshold(
+			rxm_domain->msg_domain,
+			rxm_ep->msg_info->rx_attr->size / 2);
 		rxm_ep->flow_ctrl_ops->set_send_handler(rxm_domain->msg_domain,
 							rxm_send_credits);
 	} else if (ret == -FI_ENOSYS) {

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1048,7 +1048,6 @@ err:
 static inline ssize_t rxm_handle_credit(struct rxm_ep *rxm_ep,
 					struct rxm_rx_buf *rx_buf)
 {
-	assert(rx_buf->comp_flags == FI_RECV);
 	rxm_ep->flow_ctrl_ops->add_credits(rx_buf->msg_ep,
 					   rx_buf->pkt.ctrl_hdr.ctrl_data);
 	rxm_rx_buf_free(rx_buf);

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -75,7 +75,7 @@ vrb_domain_ops_open(struct fid *fid, const char *name, uint64_t flags,
 
 	if (!strcasecmp(name, OFI_OPS_FLOW_CTRL)) {
 		*ops = &vrb_ops_flow_ctrl;
-		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
+		ep = container_of(context, struct vrb_ep, util_ep.ep_fid);
 		ep->peer_rq_credits = 1;
 		return 0;
 	}


### PR DESCRIPTION
the fi_open_ops query should be on the domain rather than the ep
and should supply the ep as context