### PR TITLE
prov/sockets: shallow progress in matching rx_buffered_list

### DIFF
--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -654,6 +654,8 @@ struct sock_rx_ctx {
 	struct dlist_entry ep_list;
 	fastlock_t lock;
 
+	struct dlist_entry *progress_start;
+
 	struct fi_rx_attr attr;
 	struct sock_rx_entry *rx_entry_pool;
 	struct slist pool_list;

--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -57,6 +57,8 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr,
 	dlist_init(&rx_ctx->rx_buffered_list);
 	dlist_init(&rx_ctx->ep_list);
 
+	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
+
 	fastlock_init(&rx_ctx->lock);
 
 	rx_ctx->ctx.fid.fclass = FI_CLASS_RX_CTX;

--- a/prov/sockets/src/sock_msg.c
+++ b/prov/sockets/src/sock_msg.c
@@ -135,6 +135,7 @@ ssize_t sock_ep_recvmsg(struct fid_ep *ep, const struct fi_msg *msg,
 	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", rx_entry, rx_ctx);
 	fastlock_acquire(&rx_ctx->lock);
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_entry_list);
+	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
 	fastlock_release(&rx_ctx->lock);
 	return 0;
 }
@@ -479,6 +480,7 @@ ssize_t sock_ep_trecvmsg(struct fid_ep *ep,
 	fastlock_acquire(&rx_ctx->lock);
 	SOCK_LOG_DBG("New rx_entry: %p (ctx: %p)\n", rx_entry, rx_ctx);
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_entry_list);
+	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
 	fastlock_release(&rx_ctx->lock);
 	return 0;
 }

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -68,8 +68,9 @@
 		(((uint64_t)_addr) >> (64 - _bits)))
 
 
-static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx);
-
+#define SOCK_EP_MAX_PROGRESS_CNT 10
+static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx,
+					bool shallow);
 
 static inline int sock_pe_is_data_msg(int msg_id)
 {
@@ -1059,7 +1060,7 @@ sock_pe_process_rx_tatomic(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx,
 
 	pe_entry->pe.rx.rx_entry = rx_entry;
 
-	sock_pe_progress_buffered_rx(rx_ctx);
+	sock_pe_progress_buffered_rx(rx_ctx, true);
 	fastlock_release(&rx_ctx->lock);
 
 	pe_entry->is_complete = 1;
@@ -1177,21 +1178,36 @@ ssize_t sock_rx_claim_recv(struct sock_rx_ctx *rx_ctx, void *context,
 	return ret;
 }
 
-static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx)
+/* Check buffered msg list against posted list. If shallow is true,
+ * we only check SOCK_EP_MAX_PROGRESS_CNT messages to prevent progress
+ * test taking too long */
+static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx,
+					bool shallow)
 {
 	struct dlist_entry *entry;
 	struct sock_pe_entry pe_entry;
 	struct sock_rx_entry *rx_buffered, *rx_posted;
 	size_t i, rem = 0, offset, len, used_len, dst_offset, datatype_sz;
+	size_t max_cnt;
 	char *src, *dst;
 
 	if (dlist_empty(&rx_ctx->rx_entry_list) ||
 	    dlist_empty(&rx_ctx->rx_buffered_list))
 		return 0;
 
-	for (entry = rx_ctx->rx_buffered_list.next;
-	     entry != &rx_ctx->rx_buffered_list;) {
-
+	if (!shallow) {
+		/* ignoring rx_ctx->progress_start */
+		entry = rx_ctx->rx_buffered_list.next;
+		max_cnt = SIZE_MAX;
+	} else {
+		/* continue where last time left off */
+		entry = rx_ctx->progress_start;
+		if (entry == &rx_ctx->rx_buffered_list) {
+			entry = entry->next;
+		}
+		max_cnt = SOCK_EP_MAX_PROGRESS_CNT;
+	}
+	for (i = 0; i < max_cnt && entry != &rx_ctx->rx_buffered_list; i++) {
 		rx_buffered = container_of(entry, struct sock_rx_entry, entry);
 		entry = entry->next;
 
@@ -1294,6 +1310,8 @@ static int sock_pe_progress_buffered_rx(struct sock_rx_ctx *rx_ctx)
 			rx_ctx->num_left++;
 		}
 	}
+	/* remember where we left off for next shallow progress */
+	rx_ctx->progress_start = entry;
 	return 0;
 }
 
@@ -1325,7 +1343,8 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 	data_len = pe_entry->msg_hdr.msg_len - len;
 	if (pe_entry->done_len == len && !pe_entry->pe.rx.rx_entry) {
 		fastlock_acquire(&rx_ctx->lock);
-		sock_pe_progress_buffered_rx(rx_ctx);
+		rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
+		sock_pe_progress_buffered_rx(rx_ctx, false);
 
 		rx_entry = sock_rx_get_entry(rx_ctx, pe_entry->addr, pe_entry->tag,
 					     pe_entry->msg_hdr.op_type == SOCK_OP_TSEND ? 1 : 0);
@@ -2400,7 +2419,7 @@ int sock_pe_progress_rx_ctx(struct sock_pe *pe, struct sock_rx_ctx *rx_ctx)
 	fastlock_acquire(&pe->lock);
 
 	fastlock_acquire(&rx_ctx->lock);
-	sock_pe_progress_buffered_rx(rx_ctx);
+	sock_pe_progress_buffered_rx(rx_ctx, true);
 	fastlock_release(&rx_ctx->lock);
 
 	/* check for incoming data */

--- a/prov/sockets/src/sock_rx_entry.c
+++ b/prov/sockets/src/sock_rx_entry.c
@@ -124,6 +124,7 @@ struct sock_rx_entry *sock_rx_new_buffered_entry(struct sock_rx_ctx *rx_ctx,
 
 	rx_ctx->buffered_len += len;
 	dlist_insert_tail(&rx_entry->entry, &rx_ctx->rx_buffered_list);
+	rx_ctx->progress_start = &rx_ctx->rx_buffered_list;
 
 	return rx_entry;
 }


### PR DESCRIPTION
MPICH currently tests against sockets provider and we run into performance issue when message queue gets too long, say above 10k. We run progress test repeatedly in a progress wait loop. Most of these progress test will make no progress as relevant operations haven't been posted yet. When message queue is large, current sockets provider traverses entire queue in every progress test causing latency which in turn delays posting operations, exacerbates the bad performance.

## Discussion
This PR implements a shallow mechanism so each time progress only try match a limited number of entries and pick up where it left off in the next progress. 

However, it appears a more appropriate fix is not to try to match the entire message queue against the entire posted queue at all in progress. Rather, if we simply try the match each time a new message arrives and each time a new recv posted, then we can skip the match during progress as it is known that they won't match anyway.  So maybe this would be a better fix for the issue.

## Questions

Do we have similar issues in other providers, such as `psm2`?

## commit message
When rx_buffered_list get long, such as more than 10k entries, each
progress loop will take significant time just to iterate through all the
entries, even when no progress can be made. For example, we may
accumulate significant unexpected messages while the local process
could not keep up the rate of posting recv -- due exactly to the
progress loop being slugish.

This patch let the progress only check a limited number of entries and
have a progress pointer to pickup where it left off each round. This
significantly expedites the progress loops.

To prevent matching out-of-order, we reset progress_start when new recv posted
or when new buffered_list entry inserted.