### PR TITLE
prov/efa: add type field to efa_domain and rxr_domain

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -134,14 +134,24 @@ struct efa_conn {
 	struct efa_ep_addr	ep_addr;
 };
 
+/*
+ * Common fields for the beginning of the efa_domain and rxr_domain structures.
+ * This structure must be kept in sync with rxr_domain and efa_domain. This
+ * will be removed when the rxr and efa domain structures are combined.
+ */
+struct efa_domain_base {
+	struct util_domain	util_domain;
+	enum efa_domain_type	type;
+};
+
 struct efa_domain {
 	struct util_domain	util_domain;
+	enum efa_domain_type	type;
 	struct fid_domain	*shm_domain;
 	struct efa_context	*ctx;
 	struct ibv_pd		*ibv_pd;
 	struct fi_info		*info;
 	struct efa_fabric	*fab;
-	int			rdm;
 	struct ofi_mr_cache	cache;
 	struct efa_qp		**qp_table;
 	size_t			qp_table_sz_m1;

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -81,7 +81,7 @@ static int efa_open_device_by_name(struct efa_domain *domain, const char *name)
 	if (!ctx_list)
 		return -errno;
 
-	if (domain->rdm)
+	if (domain->type == EFA_DOMAIN_RDM)
 		name_len = strlen(name) - strlen(efa_rdm_domain.suffix);
 	else
 		name_len = strlen(name) - strlen(efa_dgrm_domain.suffix);
@@ -163,7 +163,10 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		goto err_close_domain;
 	}
 
-	domain->rdm = EFA_EP_TYPE_IS_RDM(info);
+	if (EFA_EP_TYPE_IS_RDM(info))
+		domain->type = EFA_DOMAIN_RDM;
+	else
+		domain->type = EFA_DOMAIN_DGRAM;
 
 	ret = efa_open_device_by_name(domain, info->domain_attr->name);
 	if (ret)

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -420,7 +420,7 @@ static int efa_ep_enable(struct fid_ep *ep_fid)
 
 	attr_ex.cap.max_inline_data = ep->domain->ctx->inline_buf_size;
 
-	if (ep->domain->rdm) {
+	if (ep->domain->type == EFA_DOMAIN_RDM) {
 		attr_ex.qp_type = IBV_QPT_DRIVER;
 		attr_ex.comp_mask = IBV_QP_INIT_ATTR_PD | IBV_QP_INIT_ATTR_SEND_OPS_FLAGS;
 		attr_ex.send_ops_flags = IBV_QP_EX_WITH_SEND;

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -476,8 +476,14 @@ struct rxr_tx_entry {
 	(*((enum rxr_x_entry_type *)	\
 	 ((unsigned char *)((pkt_entry)->x_entry))))
 
+enum efa_domain_type {
+	EFA_DOMAIN_DGRAM = 0,
+	EFA_DOMAIN_RDM,
+};
+
 struct rxr_domain {
 	struct util_domain util_domain;
+	enum efa_domain_type type;
 	struct fid_domain *rdm_domain;
 	size_t mtu_size;
 	size_t addrlen;

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -190,6 +190,8 @@ int rxr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!rxr_domain)
 		return -FI_ENOMEM;
 
+	rxr_domain->type = EFA_DOMAIN_RDM;
+
 	ret = rxr_get_lower_rdm_info(fabric->api_version, NULL, NULL, 0,
 				     &rxr_util_prov, info, &rdm_info);
 	if (ret)


### PR DESCRIPTION
Add a field to identify the endpoint type for the domain. Using the
domain name to identify the type does not work with the new RDMA
device naming conventions.

In addition, remove the rdm field from efa_domain since this type field
can be used instead.

Signed-off-by: Robert Wespetal <wesper@amazon.com>