### PR TITLE
prov/rxm: credit flow control fixes

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -74,7 +74,7 @@ static int rxm_finish_buf_recv(struct rxm_rx_buf *rx_buf)
 
 	if ((rx_buf->pkt.ctrl_hdr.type == rxm_ctrl_seg) &&
 	    rxm_sar_get_seg_type(&rx_buf->pkt.ctrl_hdr) != RXM_SAR_SEG_FIRST) {
-
+		rx_buf->repost = 0;
 		dlist_insert_tail(&rx_buf->unexp_msg.entry,
 				  &rx_buf->conn->sar_deferred_rx_msg_list);
 		rx_buf = rxm_rx_buf_alloc(rx_buf->ep, rx_buf->msg_ep, 1);


### PR DESCRIPTION
This set of changes addresses a few things

1. Makes sure deferred messages are cleaned up during connection shutdown.  Lingering deferred messages were sometimes being sent to the peer if there was a duplicate connection to the same peer, which happens when two peers try to connect to eachother at the same time

2. Make sure that only messages marked for repost are actually added to the repost queue

3. make sure that the credit avail counter is protected by the rx cq during verbs send