### PR TITLE
ofi_signal Add a lock to protect wcnt and rcnt

### DIFF
--- a/include/ofi_signal.h
+++ b/include/ofi_signal.h
@@ -39,11 +39,13 @@
 #include <unistd.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <stdbool.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 
 #include <ofi_file.h>
 #include <ofi_osd.h>
+#include <ofi_atom.h>
 #include <rdma/fi_errno.h>
 
 
@@ -52,10 +54,20 @@ enum {
 	FI_WRITE_FD
 };
 
+enum ofi_signal_state {
+	OFI_SIGNAL_UNSET,
+	OFI_SIGNAL_WRITE_PREPARE,
+	OFI_SIGNAL_SET,
+	OFI_SIGNAL_READ_PREPARE,
+};
+
 struct fd_signal {
-	int		rcnt;
-	int		wcnt;
+	ofi_atomic32_t	state;
 	int		fd[2];
+
+#if ENABLE_DEBUG
+	ofi_atomic32_t debug_cnt;
+#endif
 };
 
 static inline int fd_signal_init(struct fd_signal *signal)
@@ -70,6 +82,11 @@ static inline int fd_signal_init(struct fd_signal *signal)
 	if (ret)
 		goto err;
 
+	ofi_atomic_initialize32(&signal->state, OFI_SIGNAL_UNSET);
+
+#if ENABLE_DEBUG
+	ofi_atomic_initialize32(&signal->debug_cnt, 0);
+#endif
 	return 0;
 
 err:
@@ -87,19 +104,73 @@ static inline void fd_signal_free(struct fd_signal *signal)
 static inline void fd_signal_set(struct fd_signal *signal)
 {
 	char c = 0;
-	if (signal->wcnt == signal->rcnt) {
-		if (ofi_write_socket(signal->fd[FI_WRITE_FD], &c, sizeof c) == sizeof c)
-			signal->wcnt++;
+	bool cas; /* cas result */
+	int write_rc;
+
+	cas = ofi_atomic_cas_bool_strong32(&signal->state,
+					   OFI_SIGNAL_UNSET,
+					   OFI_SIGNAL_WRITE_PREPARE);
+	if (cas) {
+		write_rc = ofi_write_socket(signal->fd[FI_WRITE_FD], &c,
+					    sizeof c);
+		if (write_rc == sizeof c) {
+#if ENABLE_DEBUG
+			assert(ofi_atomic_inc32(&signal->debug_cnt) == 1);
+#endif
+			ofi_atomic_set32(&signal->state, OFI_SIGNAL_SET);
+		} else {
+			/* XXX: Setting the signal failed, a polling thread
+			 * will not be woken up now and the system might
+			 * get stuck.
+			 * Also, typically this will be totally
+			 * untested code path, as it basically will never
+			 * come up.
+			 */
+			ofi_atomic_set32(&signal->state, OFI_SIGNAL_UNSET);
+		}
 	}
 }
 
 static inline void fd_signal_reset(struct fd_signal *signal)
 {
 	char c;
-	if (signal->rcnt != signal->wcnt) {
-		if (ofi_read_socket(signal->fd[FI_READ_FD], &c, sizeof c) == sizeof c)
-			signal->rcnt++;
-	}
+	bool cas; /* cas result */
+	enum ofi_signal_state state;
+	int read_rc;
+
+	do {
+		cas = ofi_atomic_cas_bool_weak32(&signal->state,
+						 OFI_SIGNAL_SET,
+						 OFI_SIGNAL_READ_PREPARE);
+		if (cas) {
+			read_rc = ofi_read_socket(signal->fd[FI_READ_FD], &c,
+						  sizeof c);
+			if (read_rc == sizeof c) {
+#if ENABLE_DEBUG
+				assert(ofi_atomic_dec32(&signal->debug_cnt) == 0);
+#endif
+				ofi_atomic_set32(&signal->state,
+						 OFI_SIGNAL_UNSET);
+				break;
+			} else {
+				ofi_atomic_set32(&signal->state, OFI_SIGNAL_SET);
+
+				/* Avoid spinning forever in this highly
+				 * unlikely code path.
+				 */
+				break;
+			}
+		}
+
+		state = ofi_atomic_get32(&signal->state);
+
+		/* note that this loop also needs to include
+		 * OFI_SIGNAL_WRITE_PREPARE, as the writing thread sets
+		 * the signal to the socket in _WRITE_PREPARE state. The reading
+		 * thread might then race with the writing thread and then
+		 * end up here before the state was switched to OFI_SIGNAL_SET.
+		 */
+	} while (state == OFI_SIGNAL_WRITE_PREPARE || state == OFI_SIGNAL_SET);
 }
 
 static inline int fd_signal_poll(struct fd_signal *signal, int timeout)

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -296,6 +296,8 @@ OFI_DEF_COMPLEX_OPS(long_double)
 #ifdef HAVE_BUILTIN_ATOMICS
 #define ofi_atomic_add_and_fetch(radix, ptr, val) __sync_add_and_fetch((ptr), (val))
 #define ofi_atomic_sub_and_fetch(radix, ptr, val) __sync_sub_and_fetch((ptr), (val))
+#define ofi_atomic_cas_bool(radix, ptr, expected, desired) 	\
+	__sync_bool_compare_and_swap((ptr), (expected), (desired))
 #endif /* HAVE_BUILTIN_ATOMICS */
 
 int ofi_set_thread_affinity(const char *s);

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -1000,11 +1000,15 @@ OFI_DEF_COMPLEX(long_double)
 /* atomics primitives */
 #ifdef HAVE_BUILTIN_ATOMICS
 #define InterlockedAdd32 InterlockedAdd
+#define InterlockedCompareExchange32 InterlockedCompareExchange
 typedef LONG ofi_atomic_int_32_t;
 typedef LONGLONG ofi_atomic_int_64_t;
 
 #define ofi_atomic_add_and_fetch(radix, ptr, val) InterlockedAdd##radix((ofi_atomic_int_##radix##_t *)(ptr), (ofi_atomic_int_##radix##_t)(val))
 #define ofi_atomic_sub_and_fetch(radix, ptr, val) InterlockedAdd##radix((ofi_atomic_int_##radix##_t *)(ptr), -(ofi_atomic_int_##radix##_t)(val))
+#define ofi_atomic_cas_bool(radix, ptr, expected, desired)					\
+	(InterlockedCompareExchange##radix(ptr, desired, expected) == expected)
+
 #endif /* HAVE_BUILTIN_ATOMICS */
 
 static inline int ofi_set_thread_affinity(const char *s)


### PR DESCRIPTION
fd_signal_set() and fd_signal_reset() have an optimization
to avoid writing more than needed to the signal socket.
Now this optimization is done with counters (wcnt and rcnt)
and if the user of fd_signal (for example prov/tcp) does
not protect the call chain with its own locks a
write leak might come up filling up the socket.

Prov/tcp uses struct fd_signal through util_wait, but it
is also not easily possible to use the util_wait_fd
lock to protect struct fd_signal counters, as a lock ordering
issue comes up

    Thread 14 (Thread 0x7fbaae42a700 (LWP 2623488)):

    ==> tries to aquire ep->lock
    tcpx_try_func           at prov/tcp/src/tcpx_progress.c:657

    ==> holds wait_fd->lock
    in util_wait_fd_try     at prov/util/src/util_wait.c:249
    ofi_trywait             at prov/util/src/util_wait.c:70
    fi_trywait              at include/rdma/fi_eq.h:314


    Thread 73 (Thread 0x7fbcf6ec6700 (LWP 2623413)):

    ==> Tries to acquire wait_fd->lock
    util_wait_fd_signal     at prov/util/src/util_wait.c:232
    util_cq_signal          at include/ofi_util.h:508
    cq_signal               at prov/util/src/util_cq.c:418
    tcpx_cq_report_success  at prov/tcp/src/tcpx_cq.c:168
    process_tx_entry        at prov/tcp/src/tcpx_progress.c:121
    tcpx_tx_queue_insert    at prov/tcp/src/tcpx_progress.c:692
    tcpx_send               at prov/tcp/src/tcpx_msg.c:263


    ==> holds ep->lock
    fi_send at include/rdma/fi_endpoint.h:291


Simplest solution is therefore to add a lock to fd_signal.


Signed-off-by: Bernd Schubert <bschubert@ddn.com>