### PR TITLE
[v1.10.x] include/freebsd: add CMA wrappers

### DIFF
--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -75,6 +75,26 @@ static inline size_t ofi_ifaddr_get_speed(struct ifaddrs *ifa)
 	return 0;
 }
 
+static inline ssize_t ofi_process_vm_readv(pid_t pid,
+			const struct iovec *local_iov,
+			unsigned long liovcnt,
+			const struct iovec *remote_iov,
+			unsigned long riovcnt,
+			unsigned long flags)
+{
+	return -FI_ENOSYS;
+}
+
+static inline size_t ofi_process_vm_writev(pid_t pid,
+			 const struct iovec *local_iov,
+			 unsigned long liovcnt,
+			 const struct iovec *remote_iov,
+			 unsigned long riovcnt,
+			 unsigned long flags)
+{
+	return -FI_ENOSYS;
+}
+
 #endif /* _FREEBSD_OSD_H_ */
 
 


### PR DESCRIPTION
Add missing wrappers for CMA calls for BSD

Cherry-picked from commit 40868d289040a7629e9557fac987c79cde53ca8f

Signed-off-by: aingerson <alexia.ingerson@intel.com>