### PR TITLE
prov/util: Fix to allow forcing userfaultfd memory monitor

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -106,13 +106,17 @@ void ofi_monitor_init(void)
 		cache_params.max_size = ofi_default_cache_size();
 
 	if (cache_params.monitor != NULL) {
-		if (!strcmp(cache_params.monitor, "userfaultfd") &&
-		    default_monitor == uffd_monitor)
+		if (!strcmp(cache_params.monitor, "userfaultfd")) {
+#if HAVE_UFFD_UNMAP
 			default_monitor = uffd_monitor;
-		else if (!strcmp(cache_params.monitor, "memhooks"))
+#else
+			FI_WARN(&core_prov, FI_LOG_MR, "userfaultfd monitor not available\n");
+#endif
+		} else if (!strcmp(cache_params.monitor, "memhooks")) {
 			default_monitor = memhooks_monitor;
-		else if (!strcmp(cache_params.monitor, "disabled"))
+		} else if (!strcmp(cache_params.monitor, "disabled")) {
 			default_monitor = NULL;
+		}
 	}
 }
 


### PR DESCRIPTION
Current memory monitor initialization does not allow the selection
of userfaultfd over default memhooks using FI_MR_CACHE_MONITOR.
Also log warning if requested and not available. This is a proposed 
fix for issue #5908

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>