### PR TITLE
build: Set libtool version correctly for 1.10.1 release

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -175,7 +175,7 @@ src_libfabric_la_LIBADD =
 src_libfabric_la_DEPENDENCIES = libfabric.map
 
 if !EMBEDDED
-src_libfabric_la_LDFLAGS += -version-info 13:0:12
+src_libfabric_la_LDFLAGS += -version-info 14:1:13
 endif
 src_libfabric_la_LDFLAGS += -export-dynamic \
 			   $(libfabric_version_script)


### PR DESCRIPTION
The libtool versioning data was incorrectly set for the 1.10 release and
ended up matching the 1.9 release.  Fix this for 1.10.1.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>