### PR TITLE
prov/rxm: allow core providers to decide if flow control should be enabled

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1006,8 +1006,9 @@ void *ofi_ns_resolve_name(struct util_ns *ns, const char *server,
 
 struct ofi_ops_flow_ctrl {
 	size_t	size;
-	void	(*set_threshold)(struct fid_domain *domain, uint64_t threshold);
+	void	(*set_threshold)(struct fid_ep *ep, uint64_t threshold);
 	void	(*add_credits)(struct fid_ep *ep, uint64_t credits);
+	int	(*enable)(struct fid_ep *ep);
 	void	(*set_send_handler)(struct fid_domain *domain,
 			ssize_t (*send_handler)(struct fid_ep *ep, uint64_t credits));
 };

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -277,6 +277,7 @@ struct rxm_domain {
 	size_t max_atomic_size;
 	uint64_t mr_key;
 	uint8_t mr_local;
+	struct ofi_ops_flow_ctrl *flow_ctrl_ops;
 };
 
 int rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
@@ -685,7 +686,6 @@ struct rxm_ep {
 	struct rxm_recv_queue	trecv_queue;
 
 	struct rxm_handle_txrx_ops	*txrx_ops;
-	struct ofi_ops_flow_ctrl	*flow_ctrl_ops;
 };
 
 struct rxm_conn {

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -808,82 +808,11 @@ err1:
 	return ret;
 }
 
-static ssize_t rxm_send_credits(struct fid_ep *ep, size_t credits)
-{
-	struct rxm_conn *rxm_conn =
-		container_of(ep->fid.context, struct rxm_conn, handle);
-	struct rxm_ep *rxm_ep = rxm_conn->handle.cmap->ep;
-	struct rxm_deferred_tx_entry *def_tx_entry;
-	struct rxm_tx_base_buf *tx_buf;
-	struct iovec iov;
-	struct fi_msg msg;
-	ssize_t ret;
-
-	tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX_CREDIT);
-	if (!tx_buf) {
-		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
-			"Ran out of buffers from TX credit buffer pool.\n");
-		return -FI_ENOMEM;
-	}
-
-	rxm_ep_format_tx_buf_pkt(rxm_conn, 0, rxm_ctrl_credit, 0, 0, FI_SEND,
-				 &tx_buf->pkt);
-	tx_buf->pkt.ctrl_hdr.type = rxm_ctrl_credit;
-	tx_buf->pkt.ctrl_hdr.msg_id = ofi_buf_index(tx_buf);
-	tx_buf->pkt.ctrl_hdr.ctrl_data = credits;
-
-	if (rxm_conn->handle.state != RXM_CMAP_CONNECTED)
-		goto defer;
-
-	iov.iov_base = &tx_buf->pkt;
-	iov.iov_len = sizeof(struct rxm_pkt);
-	msg.msg_iov = &iov;
-	msg.iov_count = 1;
-	msg.context = tx_buf;
-	msg.desc = &tx_buf->hdr.desc;
-
-	ret = fi_sendmsg(ep, &msg, FI_PRIORITY);
-	if (!ret)
-		return FI_SUCCESS;
-
-defer:
-	def_tx_entry = rxm_ep_alloc_deferred_tx_entry(
-		rxm_ep, rxm_conn, RXM_DEFERRED_TX_CREDIT_SEND);
-	if (!def_tx_entry) {
-		FI_WARN(&rxm_prov, FI_LOG_CQ,
-			"unable to allocate TX entry for deferred CREDIT mxg\n");
-		ofi_buf_free(tx_buf);
-		return -FI_ENOMEM;
-	}
-
-	def_tx_entry->credit_msg.tx_buf = tx_buf;
-	rxm_ep_enqueue_deferred_tx_queue(def_tx_entry);
-	return FI_SUCCESS;
-}
-
-static void rxm_no_set_threshold(struct fid_domain *domain_fid, size_t threshold)
-{ }
-
-static void rxm_no_add_credits(struct fid_ep *ep_fid, size_t credits)
-{ }
-
-static void rxm_no_credit_handler(struct fid_domain *domain_fid,
-		ssize_t (*credit_handler)(struct fid_ep *ep, size_t credits))
-{ }
-
-struct ofi_ops_flow_ctrl rxm_no_ops_flow_ctrl = {
-	.size = sizeof(struct ofi_ops_flow_ctrl),
-	.set_threshold = rxm_no_set_threshold,
-	.add_credits = rxm_no_add_credits,
-	.set_send_handler = rxm_no_credit_handler,
-};
-
 static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 			   struct rxm_conn *rxm_conn, void *context)
 {
 	struct rxm_domain *rxm_domain;
 	struct fid_ep *msg_ep;
-	struct ofi_ops_flow_ctrl *flow_ctrl_ops;
 	int ret;
 
 	rxm_domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain,
@@ -894,21 +823,6 @@ static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 			"unable to create msg_ep: %d\n", ret);
 		return ret;
-	}
-
-	ret = fi_open_ops(&rxm_domain->msg_domain->fid, OFI_OPS_FLOW_CTRL, 0,
-			  (void **) &flow_ctrl_ops, &msg_ep->fid);
-	if (!ret && flow_ctrl_ops) {
-		rxm_ep->flow_ctrl_ops = flow_ctrl_ops;
-		rxm_ep->flow_ctrl_ops->set_threshold(
-			rxm_domain->msg_domain,
-			rxm_ep->msg_info->rx_attr->size / 2);
-		rxm_ep->flow_ctrl_ops->set_send_handler(rxm_domain->msg_domain,
-							rxm_send_credits);
-	} else if (ret == -FI_ENOSYS) {
-		rxm_ep->flow_ctrl_ops = &rxm_no_ops_flow_ctrl;
-	} else {
-		goto err;
 	}
 
 	ret = fi_ep_bind(msg_ep, &rxm_ep->msg_eq->fid, 0);
@@ -940,6 +854,12 @@ static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 		FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,
 			"unable to enable msg_ep: %d\n", ret);
 		goto err;
+	}
+
+	ret = rxm_domain->flow_ctrl_ops->enable(msg_ep);
+	if (!ret) {
+		rxm_domain->flow_ctrl_ops->set_threshold(
+			msg_ep, rxm_ep->msg_info->rx_attr->size / 2);
 	}
 
 	rxm_conn->msg_ep = msg_ep;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1065,10 +1065,12 @@ free:
 	return ret;
 }
 
-static ssize_t rxm_handle_credit(struct rxm_ep *rxm_ep,
-				 struct rxm_rx_buf *rx_buf)
+static ssize_t rxm_handle_credit(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf)
 {
-	rxm_ep->flow_ctrl_ops->add_credits(rx_buf->msg_ep,
+	struct rxm_domain *domain = container_of(rxm_ep->util_ep.domain,
+						 struct rxm_domain, util_domain);
+
+	domain->flow_ctrl_ops->add_credits(rx_buf->msg_ep,
 					   rx_buf->pkt.ctrl_hdr.ctrl_data);
 	rxm_rx_buf_free(rx_buf);
 	return FI_SUCCESS;

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -353,7 +353,6 @@ struct vrb_domain {
 	struct vrb_eq			*eq;
 	uint64_t			eq_flags;
 
-	uint64_t	threshold;
 	ssize_t		(*send_credits)(struct fid_ep *ep, uint64_t credits);
 
 	/* Indicates that MSG endpoints should use the XRC transport.
@@ -569,6 +568,7 @@ struct vrb_ep {
 	uint64_t			peer_rq_credits;
 	/* Protected by recv CQ lock */
 	uint64_t			rq_credits_avail;
+	uint64_t			threshold;
 
 	union {
 		struct rdma_cm_id	*id;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -55,11 +55,16 @@ static void vrb_set_credit_handler(struct fid_domain *domain_fid,
 	domain->send_credits = credit_handler;
 }
 
-static ssize_t vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid)
+static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid)
 {
 	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
-	ep->peer_rq_credits = 1;
-	return FI_SUCCESS;
+	// only enable if we are not using SRQ
+	if (!ep->srq_ep && ep->ibv_qp && ep->ibv_qp->qp_type == IBV_QPT_RC) {
+		ep->peer_rq_credits = 1;
+		return FI_SUCCESS;
+	}
+
+	return -FI_ENOSYS;
 }
 
 struct ofi_ops_flow_ctrl vrb_ops_flow_ctrl = {

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -39,13 +39,10 @@
 
 
 
-static void vrb_set_threshold(struct fid_domain *domain_fid, size_t threshold)
+static void vrb_set_threshold(struct fid_ep *ep_fid, size_t threshold)
 {
-	struct vrb_domain *domain;
-
-	domain = container_of(domain_fid, struct vrb_domain,
-			      util_domain.domain_fid.fid);
-	domain->threshold = threshold;
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	ep->threshold = threshold;
 }
 
 static void vrb_set_credit_handler(struct fid_domain *domain_fid,
@@ -58,10 +55,18 @@ static void vrb_set_credit_handler(struct fid_domain *domain_fid,
 	domain->send_credits = credit_handler;
 }
 
+static ssize_t vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid)
+{
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
+	ep->peer_rq_credits = 1;
+	return FI_SUCCESS;
+}
+
 struct ofi_ops_flow_ctrl vrb_ops_flow_ctrl = {
 	.size = sizeof(struct ofi_ops_flow_ctrl),
 	.set_threshold = vrb_set_threshold,
 	.add_credits = vrb_add_credits,
+	.enable = vrb_enable_ep_flow_ctrl,
 	.set_send_handler = vrb_set_credit_handler,
 };
 
@@ -69,14 +74,11 @@ static int
 vrb_domain_ops_open(struct fid *fid, const char *name, uint64_t flags,
 		    void **ops, void *context)
 {
-	struct vrb_ep *ep;
 	if (flags)
 		return -FI_EBADFLAGS;
 
 	if (!strcasecmp(name, OFI_OPS_FLOW_CTRL)) {
 		*ops = &vrb_ops_flow_ctrl;
-		ep = container_of(context, struct vrb_ep, util_ep.ep_fid);
-		ep->peer_rq_credits = 1;
 		return 0;
 	}
 
@@ -300,7 +302,6 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 
 	_domain->ep_type = VRB_EP_TYPE(info);
 	_domain->flags |= vrb_is_xrc(info) ? VRB_USE_XRC : 0;
-	_domain->threshold = UINT64_MAX; /* disables RQ flow control */
 
 	ret = vrb_open_device_by_name(_domain, info->domain_attr->name);
 	if (ret)

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -78,7 +78,7 @@ ssize_t vrb_post_recv(struct vrb_ep *ep, struct ibv_recv_wr *wr)
 	if (ret)
 		goto freebuf;
 
-	if (++ep->rq_credits_avail >= domain->threshold) {
+	if (++ep->rq_credits_avail >= ep->threshold) {
 		credits_to_give = ep->rq_credits_avail;
 		ep->rq_credits_avail = 0;
 	} else {
@@ -167,7 +167,7 @@ unlock:
 	cq->util_cq.cq_fastlock_release(&cq->util_cq.cq_lock);
 	cq_rx = container_of(ep->util_ep.rx_cq, struct vrb_cq, util_cq);
 	cq_rx->util_cq.cq_fastlock_acquire(&cq_rx->util_cq.cq_lock);
-	if (ep->rq_credits_avail >= domain->threshold) {
+	if (ep->rq_credits_avail >= ep->threshold) {
 		credits_to_give = ep->rq_credits_avail;
 		ep->rq_credits_avail = 0;
 	}
@@ -1007,6 +1007,7 @@ int vrb_open_ep(struct fid_domain *domain, struct fi_info *info,
 
 	ep->inject_limit = ep->info->tx_attr->inject_size;
 	ep->peer_rq_credits = UINT64_MAX;
+	ep->threshold = UINT64_MAX; /* disables RQ flow control */
 
 	switch (info->ep_attr->type) {
 	case FI_EP_MSG:


### PR DESCRIPTION
This set of changes is a proposal to address #5907 and enables core providers to decide if credit based flow control should be enabled.  

With this implementation, verbs will disable flow control if shared receive queue is used.