### PR TITLE
[v1.9.x] prov/rxd: Corrected the use of dest_addr in rxd_atomic_inject.

### DIFF
--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -235,7 +235,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
 
-	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
+	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[dest_addr];
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
 	if (ret)
 		goto out;


### PR DESCRIPTION
rxd_atomic.c : In the rxd_atomic_inject function, the 'addr'
argument which corresponds to the remote memory address was
incorrectly used in place of dest_addr when fetching rxd_addr
from fi_addr_table. This is now corrected.

cherrypicked from f4588e5

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>