### PR TITLE
[v1.10.x] prov/efa: allow end point to choose shm usage

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -349,9 +349,11 @@ int efa_av_insert_addr(struct efa_av *av, struct efa_ep_addr *addr,
 		dlist_foreach(&av->util_av.ep_list, ep_list_entry) {
 			util_ep = container_of(ep_list_entry, struct util_ep, av_entry);
 			rxr_ep = container_of(util_ep, struct rxr_ep, util_ep);
-			peer = rxr_ep_get_peer(rxr_ep, *fi_addr);
-			peer->shm_fiaddr = shm_fiaddr;
-			peer->is_local = 1;
+			if (rxr_ep->use_shm) {
+				peer = rxr_ep_get_peer(rxr_ep, *fi_addr);
+				peer->shm_fiaddr = shm_fiaddr;
+				peer->is_local = 1;
+			}
 		}
 	}
 	HASH_ADD(hh, av->av_map, ep_addr,

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -514,6 +514,7 @@ struct rxr_ep {
 	struct fid_cq *rdm_cq;
 
 	/* shm provider fid */
+	bool use_shm;
 	struct fid_ep *shm_ep;
 	struct fid_cq *shm_cq;
 

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -170,7 +170,8 @@ rxr_atomic_inject(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, dest_addr);
-	if (rxr_env.enable_shm_transfer && peer->is_local) {
+	if (peer->is_local) {
+		assert(rxr_ep->use_shm);
 		if (!(shm_info->domain_attr->mr_mode & FI_MR_VIRT_ADDR))
 			remote_addr = 0;
 		return fi_inject_atomic(rxr_ep->shm_ep, buf, count, peer->shm_fiaddr,
@@ -215,7 +216,8 @@ rxr_atomic_writemsg(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
-	if (rxr_env.enable_shm_transfer && peer->is_local) {
+	if (peer->is_local) {
+		assert(rxr_ep->use_shm);
 		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_atomicmsg(rxr_ep->shm_ep, &shm_msg, flags);
@@ -287,7 +289,8 @@ rxr_atomic_readwritemsg(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
-	if (rxr_env.enable_shm_transfer && peer->is_local) {
+	if (peer->is_local) {
+		assert(rxr_ep->use_shm);
 		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_fetch_atomicmsg(rxr_ep->shm_ep, &shm_msg,
@@ -368,7 +371,8 @@ rxr_atomic_compwritemsg(struct fid_ep *ep,
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
-	if (rxr_env.enable_shm_transfer && peer->is_local) {
+	if (peer->is_local) {
+		assert(rxr_ep->use_shm);
 		rxr_atomic_copy_shm_msg(&shm_msg, msg, rma_iov);
 		shm_msg.addr = peer->shm_fiaddr;
 		return fi_compare_atomicmsg(rxr_ep->shm_ep, &shm_msg,

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -538,20 +538,6 @@ static int rxr_getinfo(uint32_t version, const char *node,
 	if (hints && hints->ep_attr && hints->ep_attr->type == FI_EP_DGRAM)
 		goto dgram_info;
 
-	/*
-	 * Using the shm provider comes with some overheads, particularly in the
-	 * progress engine when polling an empty completion queue, so avoid
-	 * initializing the provider if the app provides a hint that it does not
-	 * require node-local communication. We can still loopback over the EFA
-	 * device in cases where the app violates the hint and continues
-	 * communicating with node-local peers.
-	 */
-	if (hints
-	    /* If the app requires explicitly remote communication */
-	    && (hints->caps & FI_REMOTE_COMM)
-	    /* but not local communication */
-	    && !(hints->caps & FI_LOCAL_COMM))
-		rxr_env.enable_shm_transfer = 0;
 
 	ret = rxr_get_lower_rdm_info(version, node, service, flags,
 				     &rxr_util_prov, hints, &core_info);
@@ -578,6 +564,15 @@ static int rxr_getinfo(uint32_t version, const char *node,
 			goto free_info;
 
 		ofi_alter_info(util_info, hints, version);
+
+		/* If application asked for FI_REMOTE_COMM but not FI_LOCAL_COMM, it
+		 * does not want to use shm. In this case, we honor the request by
+		 * unsetting the FI_LOCAL_COMM flag in info. This way rxr_endpoint()
+		 * should disable shm transfer for the endpoint
+		 */
+		if (hints && hints->caps & FI_REMOTE_COMM && !(hints->caps & FI_LOCAL_COMM))
+			util_info->caps &= ~FI_LOCAL_COMM;
+
 		if (!*info)
 			*info = util_info;
 		else

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -83,7 +83,9 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 						      RXR_EAGER_MSGRTM_PKT + tagged);
 
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
+
 	if (peer->is_local) {
+		assert(rxr_ep->use_shm);
 		/* intra instance message */
 		int rtm_type = (tx_entry->total_len <= max_rtm_data_size) ? RXR_EAGER_MSGRTM_PKT
 									  : RXR_READ_MSGRTM_PKT;

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -257,10 +257,12 @@ ssize_t rxr_pkt_post_ctrl_once(struct rxr_ep *rxr_ep, int entry_type, void *x_en
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, addr);
-	if (peer->is_local)
+	if (peer->is_local) {
+		assert(rxr_ep->use_shm);
 		pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_shm_pool);
-	else
+	} else {
 		pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_efa_pool);
+	}
 
 	if (!pkt_entry)
 		return -FI_EAGAIN;
@@ -530,10 +532,12 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 	if (!(peer->flags & RXR_PEER_HANDSHAKE_SENT))
 		rxr_pkt_post_handshake(ep, peer, pkt_entry->addr);
 
-	if (rxr_env.enable_shm_transfer && peer->is_local)
+	if (peer->is_local) {
+		assert(ep->use_shm);
 		ep->posted_bufs_shm--;
-	else
+	} else {
 		ep->posted_bufs_efa--;
+	}
 
 	switch (base_hdr->type) {
 	case RXR_RETIRED_RTS_PKT:

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -284,7 +284,8 @@ ssize_t rxr_pkt_entry_sendmsg(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry
 	rxr_pkt_print("Sent", ep, (struct rxr_base_hdr *)pkt_entry->pkt);
 #endif
 #endif
-	if (rxr_env.enable_shm_transfer && peer->is_local) {
+	if (peer->is_local) {
+		assert(ep->use_shm);
 		ret = fi_sendmsg(ep->shm_ep, msg, flags);
 	} else {
 		ret = fi_sendmsg(ep->rdm_ep, msg, flags);
@@ -307,7 +308,7 @@ ssize_t rxr_pkt_entry_sendv(struct rxr_ep *ep,
 	msg.desc = desc;
 	msg.iov_count = count;
 	peer = rxr_ep_get_peer(ep, addr);
-	msg.addr = peer->is_local ? peer->shm_fiaddr : addr;
+	msg.addr = (peer->is_local) ? peer->shm_fiaddr : addr;
 	msg.context = pkt_entry;
 	msg.data = 0;
 
@@ -325,10 +326,12 @@ ssize_t rxr_pkt_entry_send_with_flags(struct rxr_ep *ep,
 	iov.iov_base = rxr_pkt_start(pkt_entry);
 	iov.iov_len = pkt_entry->pkt_size;
 
-	if (rxr_ep_get_peer(ep, addr)->is_local)
+	if (rxr_ep_get_peer(ep, addr)->is_local) {
+		assert(ep->use_shm);
 		desc = NULL;
-	else
+	} else {
 		desc = rxr_ep_mr_local(ep) ? fi_mr_desc(pkt_entry->mr) : NULL;
+	}
 
 	return rxr_pkt_entry_sendv(ep, pkt_entry, addr, &iov, &desc, 1, flags);
 }
@@ -349,7 +352,7 @@ ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 	/* currently only EOR packet is injected using shm ep */
 	peer = rxr_ep_get_peer(ep, addr);
 	assert(peer);
-	assert(rxr_env.enable_shm_transfer && peer->is_local);
+	assert(ep->use_shm && peer->is_local);
 	return fi_inject(ep->shm_ep, rxr_pkt_start(pkt_entry), pkt_entry->pkt_size,
 			 peer->shm_fiaddr);
 }

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -204,8 +204,10 @@ size_t rxr_pkt_req_max_data_size(struct rxr_ep *ep, fi_addr_t addr, int pkt_type
 	peer = rxr_ep_get_peer(ep, addr);
 	assert(peer);
 
-	if (rxr_env.enable_shm_transfer && peer->is_local)
+	if (peer->is_local) {
+		assert(ep->use_shm);
 		return rxr_env.shm_max_medium_size;
+	}
 
 	int max_hdr_size = REQ_INF_LIST[pkt_type].base_hdr_size
 		+ sizeof(struct rxr_req_opt_raw_addr_hdr)

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -312,7 +312,8 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	assert(peer);
 
 	use_lower_ep_read = false;
-	if (rxr_env.enable_shm_transfer && peer->is_local) {
+	if (peer->is_local) {
+		assert(rxr_ep->use_shm);
 		use_lower_ep_read = true;
 	} else if (efa_both_support_rdma_read(rxr_ep, peer)) {
 		/* efa_both_support_rdma_read also check rxr_env.use_device_rdma,


### PR DESCRIPTION
Currently, whether to use shm was controlled by a global variable
    rxr_env.enable_shm_transfer
, which means all end points behavior the same on shm usage.
However, some applications want to be able to choose shm usage when
it is enabled.

This patch allow application to do that by setting hints->caps
with FI_REMOTE_COMM and without FI_LOCAL_COMM off.

The following change has been made to the code to acheive that:

1. a flag use_shm has been added to struct rxr_ep, which will be
   set in rxr_endpoint()

2. only set peer->is_local flag when ep->use_shm is true.

3. In data transmission code path, change the condtion check:

        if (rxr_env.enable_shm_transfer && peer->is_local)

   to
        if (peer->is_local) with assert(ep->use_shm)

Signed-off-by: Wei Zhang <wzam@amazon.com>