### PR TITLE
hmem: Generalized HMEM copy interface

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,7 @@
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017-2018 Intel Corporation, Inc. All right reserved.
 # Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
+# (C) Copyright 2020 Hewlett Packard Enterprise Development LP
 #
 # Makefile.am for libfabric
 
@@ -39,6 +40,8 @@ rdmainclude_HEADERS =
 
 # internal utility functions shared by in-tree providers:
 common_srcs =				\
+	src/hmem.c			\
+	src/hmem_cuda.c			\
 	src/common.c			\
 	src/enosys.c			\
 	src/rbtree.c			\
@@ -118,6 +121,7 @@ util_fi_pingpong_LDADD = $(linkback)
 
 nodist_src_libfabric_la_SOURCES =
 src_libfabric_la_SOURCES =			\
+	include/ofi_hmem.h			\
 	include/ofi.h				\
 	include/ofi_abi.h			\
 	include/ofi_atom.h			\

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -1,0 +1,57 @@
+/*
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _OFI_HMEM_H_
+#define _OFI_HMEM_H_
+
+#include <rdma/fi_domain.h>
+
+int cuda_copy_to_dev(void *dev, const void *host, size_t size);
+int cuda_copy_from_dev(void *host, const void *dev, size_t size);
+
+static inline int ofi_memcpy(void *dest, const void *src, size_t size)
+{
+	memcpy(dest, src, size);
+	return FI_SUCCESS;
+}
+
+ssize_t ofi_copy_from_hmem_iov(void *dest, size_t size,
+			       const struct iovec *hmem_iov,
+			       enum fi_hmem_iface hmem_iface,
+			       size_t hmem_iov_count, uint64_t hmem_iov_offset);
+
+ssize_t ofi_copy_to_hmem_iov(const struct iovec *hmem_iov,
+			     enum fi_hmem_iface hmem_iface,
+			     size_t hmem_iov_count, uint64_t hmem_iov_offset,
+			     void *src, size_t size);
+
+#endif /* _OFI_HMEM_H_ */

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -576,6 +576,8 @@
     <ClCompile Include="src\fabric.c" />
     <ClCompile Include="src\fasthash.c" />
     <ClCompile Include="src\fi_tostr.c" />
+    <ClCompile Include="src\hmem.c" />
+    <ClCompile Include="src\hmem_cuda.c" />
     <ClCompile Include="src\indexer.c" />
     <ClCompile Include="src\iov.c" />
     <ClCompile Include="src\shared\ofi_str.c" />
@@ -593,6 +595,7 @@
     <ClInclude Include="include\ofi_abi.h" />
     <ClInclude Include="include\ofi_atom.h" />
     <ClInclude Include="include\ofi_atomic.h" />
+    <ClInclude Include="include\ofi_hmem.h" />
     <ClInclude Include="include\ofi_hook.h" />
     <ClInclude Include="include\ofi_mr.h" />
     <ClInclude Include="include\ofi_net.h" />

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -138,6 +138,12 @@
     <ClCompile Include="src\mem.c">
       <Filter>Source Files\src</Filter>
     </ClCompile>
+    <ClCompile Include="src\hmem.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
+    <ClCompile Include="src\hmem_cuda.c">
+      <Filter>Source Files\src</Filter>
+    </ClCompile>
     <ClCompile Include="src\rbtree.c">
       <Filter>Source Files\src</Filter>
     </ClCompile>
@@ -501,6 +507,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\ofi_enosys.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\ofi_hmem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\ofi_indexer.h">

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -451,6 +451,9 @@ static int fi_resource_mgmt_level(enum fi_resource_mgmt rm_model)
  */
 static int ofi_cap_mr_mode(uint64_t info_caps, int mr_mode)
 {
+	if (!(info_caps & FI_HMEM))
+		mr_mode &= ~FI_MR_HMEM;
+
 	if (!ofi_rma_target_allowed(info_caps)) {
 		if (!(mr_mode & (FI_MR_LOCAL | FI_MR_HMEM)))
 			return 0;

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -1,0 +1,128 @@
+/*
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "ofi_hmem.h"
+#include "ofi.h"
+#include "ofi_iov.h"
+
+struct ofi_hmem_ops {
+	int (*copy_to_hmem)(void *dest, const void *src, size_t size);
+	int (*copy_from_hmem)(void *dest, const void *src, size_t size);
+};
+
+static struct ofi_hmem_ops hmem_ops[] = {
+	[FI_HMEM_SYSTEM] = {
+		.copy_to_hmem = ofi_memcpy,
+		.copy_from_hmem = ofi_memcpy,
+	},
+	[FI_HMEM_CUDA] = {
+		.copy_to_hmem = cuda_copy_to_dev,
+		.copy_from_hmem = cuda_copy_from_dev,
+	},
+};
+
+static inline int ofi_copy_to_hmem(void *dest, const void *src, size_t size,
+				   enum fi_hmem_iface iface)
+{
+	return hmem_ops[iface].copy_to_hmem(dest, src, size);
+}
+
+static inline int ofi_copy_from_hmem(void *dest, const void *src, size_t size,
+				     enum fi_hmem_iface iface)
+{
+	return hmem_ops[iface].copy_from_hmem(dest, src, size);
+}
+
+static ssize_t ofi_copy_hmem_iov_buf(const struct iovec *hmem_iov,
+				     enum fi_hmem_iface hmem_iface,
+				     size_t hmem_iov_count,
+				     uint64_t hmem_iov_offset, void *buf,
+				     size_t size, int dir)
+{
+	uint64_t done = 0, len;
+	char *hmem_buf;
+	size_t i;
+	int ret;
+
+	for (i = 0; i < hmem_iov_count && size; i++) {
+		len = hmem_iov[i].iov_len;
+
+		if (hmem_iov_offset > len) {
+			hmem_iov_offset -= len;
+			continue;
+		}
+
+		hmem_buf = (char *)hmem_iov[i].iov_base + hmem_iov_offset;
+		len -= hmem_iov_offset;
+
+		len = MIN(len, size);
+		if (dir == OFI_COPY_BUF_TO_IOV)
+			ret = ofi_copy_to_hmem(hmem_buf, (char *)buf + done,
+					       len, hmem_iface);
+		else
+			ret = ofi_copy_from_hmem((char *)buf + done, hmem_buf,
+						 len, hmem_iface);
+
+		if (ret)
+			return ret;
+
+		hmem_iov_offset = 0;
+		size -= len;
+		done += len;
+	}
+	return done;
+}
+
+ssize_t ofi_copy_from_hmem_iov(void *dest, size_t size,
+				const struct iovec *hmem_iov,
+				enum fi_hmem_iface hmem_iface,
+				size_t hmem_iov_count,
+				uint64_t hmem_iov_offset)
+{
+	return ofi_copy_hmem_iov_buf(hmem_iov, hmem_iface, hmem_iov_count,
+				     hmem_iov_offset, dest, size,
+				     OFI_COPY_IOV_TO_BUF);
+}
+
+ssize_t ofi_copy_to_hmem_iov(const struct iovec *hmem_iov,
+			      enum fi_hmem_iface hmem_iface,
+			      size_t hmem_iov_count, uint64_t hmem_iov_offset,
+			      void *src, size_t size)
+{
+	return ofi_copy_hmem_iov_buf(hmem_iov, hmem_iface, hmem_iov_count,
+				     hmem_iov_offset, src, size,
+				     OFI_COPY_BUF_TO_IOV);
+}

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -1,0 +1,87 @@
+/*
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "ofi_hmem.h"
+#include "ofi.h"
+
+#ifdef HAVE_LIBCUDA
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+int cuda_copy_to_dev(void *dev, const void *host, size_t size)
+{
+	cudaError_t cuda_ret;
+
+	cuda_ret = cudaMemcpy(dev, host, size, cudaMemcpyHostToDevice);
+	if (cuda_ret == cudaSuccess)
+		return 0;
+
+	FI_WARN(&core_prov, FI_LOG_CORE,
+		"Failed to perform cudaMemcpy: %s:%s\n",
+		cudaGetErrorName(cuda_ret), cudaGetErrorString(cuda_ret));
+
+	return -FI_EIO;
+}
+
+int cuda_copy_from_dev(void *host, const void *dev, size_t size)
+{
+	cudaError_t cuda_ret;
+
+	cuda_ret = cudaMemcpy(host, dev, size, cudaMemcpyDeviceToHost);
+	if (cuda_ret == cudaSuccess)
+		return 0;
+
+	FI_WARN(&core_prov, FI_LOG_CORE,
+		"Failed to perform cudaMemcpy: %s:%s\n",
+		cudaGetErrorName(cuda_ret), cudaGetErrorString(cuda_ret));
+
+	return -FI_EIO;
+}
+
+#else
+
+int cuda_copy_to_dev(void *dev, const void *host, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int cuda_copy_from_dev(void *host, const void *dev, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+#endif /* HAVE_LIBCUDA */


### PR DESCRIPTION
The generalized HMEM interface allows providers to perform operations
with all supported HMEM interfaces without calling HMEM specific calls.
FI_HMEM_SYSTEM and FI_HMEM_CUDA are currently supported.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>