### PR TITLE
prov/sockets: using SOMAXCONN as listen()'s parameter

### DIFF
--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -451,7 +451,7 @@ int sock_conn_listen(struct sock_ep_attr *ep_attr)
 
 	ofi_straddr_dbg(&sock_prov, FI_LOG_EP_CTRL, "listening at addr: ",
 			&addr.sa);
-	ret = listen(listen_fd, sock_cm_def_map_sz);
+	ret = listen(listen_fd, SOMAXCONN);
 	if (ret) {
 		SOCK_LOG_ERROR("failed to listen socket: %s\n",
 			       strerror(ofi_sockerr()));

--- a/prov/sockets/src/sock_ep_msg.c
+++ b/prov/sockets/src/sock_ep_msg.c
@@ -122,7 +122,7 @@ static int sock_pep_create_listener(struct sock_pep *pep)
 		goto err;
 	}
 
-	if (listen(pep->cm.sock, sock_cm_def_map_sz)) {
+	if (listen(pep->cm.sock, SOMAXCONN)) {
 		SOCK_LOG_ERROR("failed to listen socket: %s\n",
 			       strerror(ofi_sockerr()));
 		ret = -ofi_sockerr();


### PR DESCRIPTION
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>