### PR TITLE
Add compatibility with SUSE packaging

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -20,6 +20,9 @@ License: GPLv2 or BSD
 Url: http://www.github.com/ofiwg/libfabric
 Source: http://www.github.org/ofiwg/%{name}/releases/download/v{%version}/%{name}-%{version}.tar.bz2
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+%if 0%{?suse_version} >= 1
+Provides: libfabric1 = %{version}-%{release}
+%endif
 
 %description
 libfabric provides a user-space API to access high-performance fabric


### PR DESCRIPTION
Since SUSE packages libraries separately from tools and binaries in a
<library><version> format, when building on SUSE platforms, add a
Provides: to maintain compatibility with the SUSE packaged libfabric.

This allows this packaging to be compatible with other packages on a
SUSE system that might have a "Requires: libfabric1 >= ..." in them.

Signed-off-by: ￼Brian J. Murrell <brian.murrell@intel.com>