### PR TITLE
core/mr_cache: Rework MR cache locking

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -96,6 +96,9 @@ static inline uint64_t ofi_mr_get_prov_mode(uint32_t version,
 }
 
 
+/* Single lock used by all memory monitors and MR caches. */
+extern pthread_mutex_t mm_lock;
+
 /*
  * Memory notifier - Report memory mapping changes to address ranges
  */
@@ -103,7 +106,6 @@ static inline uint64_t ofi_mr_get_prov_mode(uint32_t version,
 struct ofi_mr_cache;
 
 struct ofi_mem_monitor {
-	pthread_mutex_t 		lock;
 	struct dlist_entry		list;
 
 	void (*init)(struct ofi_mem_monitor *monitor);

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -256,12 +256,12 @@ static void *ofi_intercept_dlopen(const char *filename, int flag)
 	if (!handle)
 		return NULL;
 
-	pthread_mutex_lock(&memhooks_monitor->lock);
+	pthread_mutex_lock(&mm_lock);
 	dlist_foreach_container(&memhooks.intercept_list, struct ofi_intercept,
 		intercept, entry) {
 		dl_iterate_phdr(ofi_intercept_phdr_handler, intercept);
 	}
-	pthread_mutex_unlock(&memhooks_monitor->lock);
+	pthread_mutex_unlock(&mm_lock);
 	return handle;
 }
 
@@ -360,9 +360,9 @@ static int ofi_intercept_symbol(struct ofi_intercept *intercept, void **real_fun
 
 void ofi_intercept_handler(const void *addr, size_t len)
 {
-	pthread_mutex_lock(&memhooks_monitor->lock);
+	pthread_mutex_lock(&mm_lock);
 	ofi_monitor_notify(memhooks_monitor, addr, len);
-	pthread_mutex_unlock(&memhooks_monitor->lock);
+	pthread_mutex_unlock(&mm_lock);
 }
 
 static void *ofi_intercept_mmap(void *start, size_t length,


### PR DESCRIPTION
~~Instead of serializing on the memory monitor's lock, serialize MR cache
accesses using the MR cache lock. This will allow the MR cache to
subscribe to multiple memory monitor's and still maintain the correct
locking.~~

Instead of having a lock per memory monitor, have a single, global lock
which all memory monitors and MR caches will use. This change enables a
future change to have an MR cache subscribe to multiple memory monitors,
one per HMEM iface type.


Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>