### PR TITLE
Tweak mem monitor init, cleanup, start, stop routines

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -136,6 +136,8 @@ struct ofi_uffd {
 	int				fd;
 };
 
+void ofi_uffd_init(void);
+void ofi_uffd_cleanup(void);
 int ofi_uffd_start(void);
 void ofi_uffd_stop(void);
 
@@ -149,6 +151,8 @@ struct ofi_memhooks {
 	struct dlist_entry		intercept_list;
 };
 
+void ofi_memhooks_init(void);
+void ofi_memhooks_cleanup(void);
 int ofi_memhooks_start(void);
 void ofi_memhooks_stop(void);
 

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -112,8 +112,8 @@ struct ofi_mem_monitor {
 			    const void *addr, size_t len);
 };
 
-void ofi_monitor_init(void);
-void ofi_monitor_cleanup(void);
+void ofi_monitors_init(void);
+void ofi_monitors_cleanup(void);
 int ofi_monitor_add_cache(struct ofi_mem_monitor *monitor,
 			   struct ofi_mr_cache *cache);
 void ofi_monitor_del_cache(struct ofi_mr_cache *cache);

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -106,12 +106,16 @@ struct ofi_mem_monitor {
 	pthread_mutex_t 		lock;
 	struct dlist_entry		list;
 
+	void (*init)(struct ofi_mem_monitor *monitor);
+	void (*cleanup)(struct ofi_mem_monitor *monitor);
 	int (*subscribe)(struct ofi_mem_monitor *notifier,
 			 const void *addr, size_t len);
 	void (*unsubscribe)(struct ofi_mem_monitor *notifier,
 			    const void *addr, size_t len);
 };
 
+void ofi_monitor_init(struct ofi_mem_monitor *monitor);
+void ofi_monitor_cleanup(struct ofi_mem_monitor *monitor);
 void ofi_monitors_init(void);
 void ofi_monitors_cleanup(void);
 int ofi_monitor_add_cache(struct ofi_mem_monitor *monitor,
@@ -136,8 +140,6 @@ struct ofi_uffd {
 	int				fd;
 };
 
-void ofi_uffd_init(void);
-void ofi_uffd_cleanup(void);
 int ofi_uffd_start(void);
 void ofi_uffd_stop(void);
 
@@ -151,8 +153,6 @@ struct ofi_memhooks {
 	struct dlist_entry		intercept_list;
 };
 
-void ofi_memhooks_init(void);
-void ofi_memhooks_cleanup(void);
 int ofi_memhooks_start(void);
 void ofi_memhooks_stop(void);
 

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -136,8 +136,8 @@ struct ofi_uffd {
 	int				fd;
 };
 
-int ofi_uffd_init(void);
-void ofi_uffd_cleanup(void);
+int ofi_uffd_start(void);
+void ofi_uffd_stop(void);
 
 extern struct ofi_mem_monitor *uffd_monitor;
 
@@ -149,8 +149,8 @@ struct ofi_memhooks {
 	struct dlist_entry		intercept_list;
 };
 
-int ofi_memhooks_init(void);
-void ofi_memhooks_cleanup(void);
+int ofi_memhooks_start(void);
+void ofi_memhooks_stop(void);
 
 extern struct ofi_mem_monitor *memhooks_monitor;
 

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -640,7 +640,7 @@ static void rxr_fini(void)
 	}
 
 #if HAVE_EFA_DL
-	ofi_monitor_cleanup();
+	ofi_monitors_cleanup();
 	ofi_mem_fini();
 #endif
 }
@@ -716,7 +716,7 @@ EFA_INI
 
 #if HAVE_EFA_DL
 	ofi_mem_init();
-	ofi_monitor_init();
+	ofi_monitors_init();
 #endif
 
 	lower_efa_prov = init_lower_efa_prov();

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -468,7 +468,7 @@ static void ofi_memhooks_unsubscribe(struct ofi_mem_monitor *monitor,
 	/* no-op */
 }
 
-int ofi_memhooks_init(void)
+int ofi_memhooks_start(void)
 {
 	int i, ret;
 
@@ -549,7 +549,7 @@ int ofi_memhooks_init(void)
 	return 0;
 }
 
-void ofi_memhooks_cleanup(void)
+void ofi_memhooks_stop(void)
 {
 	ofi_restore_intercepts();
 	memhooks_monitor->subscribe = NULL;
@@ -558,12 +558,12 @@ void ofi_memhooks_cleanup(void)
 
 #else
 
-int ofi_memhooks_init(void)
+int ofi_memhooks_start(void)
 {
 	return -FI_ENOSYS;
 }
 
-void ofi_memhooks_cleanup(void)
+void ofi_memhooks_stop(void)
 {
 }
 

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -42,7 +42,10 @@
 
 #include <ofi_mr.h>
 
-struct ofi_memhooks memhooks;
+struct ofi_memhooks memhooks = {
+	.monitor.init = ofi_monitor_init,
+	.monitor.cleanup = ofi_monitor_cleanup
+};
 struct ofi_mem_monitor *memhooks_monitor = &memhooks.monitor;
 
 
@@ -569,15 +572,3 @@ void ofi_memhooks_stop(void)
 }
 
 #endif /* memhook support checks */
-
-void ofi_memhooks_init(void)
-{
-	pthread_mutex_init(&memhooks_monitor->lock, NULL);
-	dlist_init(&memhooks_monitor->list);
-}
-
-void ofi_memhooks_cleanup(void)
-{
-	assert(dlist_empty(&memhooks_monitor->list));
-	pthread_mutex_destroy(&memhooks_monitor->lock);
-}

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -46,6 +46,7 @@ struct ofi_memhooks memhooks;
 struct ofi_mem_monitor *memhooks_monitor = &memhooks.monitor;
 
 
+/* memhook support checks */
 #if defined(__linux__) && defined(HAVE_ELF_H) && defined(HAVE_SYS_AUXV_H)
 
 #include <elf.h>
@@ -567,4 +568,16 @@ void ofi_memhooks_stop(void)
 {
 }
 
-#endif
+#endif /* memhook support checks */
+
+void ofi_memhooks_init(void)
+{
+	pthread_mutex_init(&memhooks_monitor->lock, NULL);
+	dlist_init(&memhooks_monitor->list);
+}
+
+void ofi_memhooks_cleanup(void)
+{
+	assert(dlist_empty(&memhooks_monitor->list));
+	pthread_mutex_destroy(&memhooks_monitor->lock);
+}

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -140,9 +140,9 @@ int ofi_monitor_add_cache(struct ofi_mem_monitor *monitor,
 	pthread_mutex_lock(&monitor->lock);
 	if (dlist_empty(&monitor->list)) {
 		if (monitor == uffd_monitor)
-			ret = ofi_uffd_init();
+			ret = ofi_uffd_start();
 		else if (monitor == memhooks_monitor)
-			ret = ofi_memhooks_init();
+			ret = ofi_memhooks_start();
 		else
 			ret = -FI_ENOSYS;
 
@@ -166,9 +166,9 @@ void ofi_monitor_del_cache(struct ofi_mr_cache *cache)
 
 	if (dlist_empty(&monitor->list)) {
 		if (monitor == uffd_monitor)
-			ofi_uffd_cleanup();
+			ofi_uffd_stop();
 		else if (monitor == memhooks_monitor)
-			ofi_memhooks_cleanup();
+			ofi_memhooks_stop();
 	}
 
 	pthread_mutex_unlock(&monitor->lock);
@@ -334,7 +334,7 @@ static void ofi_uffd_unsubscribe(struct ofi_mem_monitor *monitor,
 	}
 }
 
-int ofi_uffd_init(void)
+int ofi_uffd_start(void)
 {
 	struct uffdio_api api;
 	int ret;
@@ -383,7 +383,7 @@ closefd:
 	return ret;
 }
 
-void ofi_uffd_cleanup(void)
+void ofi_uffd_stop(void)
 {
 	pthread_cancel(uffd.thread);
 	pthread_join(uffd.thread, NULL);
@@ -392,12 +392,12 @@ void ofi_uffd_cleanup(void)
 
 #else /* HAVE_UFFD_UNMAP */
 
-int ofi_uffd_init(void)
+int ofi_uffd_start(void)
 {
 	return -FI_ENOSYS;
 }
 
-void ofi_uffd_cleanup(void)
+void ofi_uffd_stop(void)
 {
 }
 

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -62,11 +62,8 @@ static size_t ofi_default_cache_size(void)
  */
 void ofi_monitor_init(void)
 {
-	pthread_mutex_init(&uffd_monitor->lock, NULL);
-	dlist_init(&uffd_monitor->list);
-
-	pthread_mutex_init(&memhooks_monitor->lock, NULL);
-	dlist_init(&memhooks_monitor->list);
+	ofi_uffd_init();
+	ofi_memhooks_init();
 
 #if defined(HAVE_ELF_H) && defined(HAVE_SYS_AUXV_H)
         default_monitor = memhooks_monitor;
@@ -122,11 +119,8 @@ void ofi_monitor_init(void)
 
 void ofi_monitor_cleanup(void)
 {
-	assert(dlist_empty(&uffd_monitor->list));
-	pthread_mutex_destroy(&uffd_monitor->lock);
-
-	assert(dlist_empty(&memhooks_monitor->list));
-	pthread_mutex_destroy(&memhooks_monitor->lock);
+	ofi_uffd_cleanup();
+	ofi_memhooks_cleanup();
 }
 
 int ofi_monitor_add_cache(struct ofi_mem_monitor *monitor,
@@ -402,3 +396,15 @@ void ofi_uffd_stop(void)
 }
 
 #endif /* HAVE_UFFD_UNMAP */
+
+void ofi_uffd_init(void)
+{
+	pthread_mutex_init(&uffd_monitor->lock, NULL);
+	dlist_init(&uffd_monitor->list);
+}
+
+void ofi_uffd_cleanup(void)
+{
+	assert(dlist_empty(&uffd_monitor->list));
+	pthread_mutex_destroy(&uffd_monitor->lock);
+}

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -60,7 +60,7 @@ static size_t ofi_default_cache_size(void)
 /*
  * Initialize all available memory monitors
  */
-void ofi_monitor_init(void)
+void ofi_monitors_init(void)
 {
 	ofi_uffd_init();
 	ofi_memhooks_init();
@@ -117,7 +117,7 @@ void ofi_monitor_init(void)
 	}
 }
 
-void ofi_monitor_cleanup(void)
+void ofi_monitors_cleanup(void)
 {
 	ofi_uffd_cleanup();
 	ofi_memhooks_cleanup();

--- a/prov/verbs/src/fi_verbs.c
+++ b/prov/verbs/src/fi_verbs.c
@@ -108,7 +108,7 @@ vrb_get_rdma_rai(const char *node, const char *service, uint64_t flags,
 	struct rdma_addrinfo rai_hints, *_rai;
 	struct rdma_addrinfo **cur, *next;
 	int ret;
-	
+
 	ret = vrb_fi_to_rai(hints, flags, &rai_hints);
 	if (ret)
 		goto out;
@@ -666,7 +666,7 @@ static void verbs_devs_free(void)
 static void vrb_fini(void)
 {
 #if HAVE_VERBS_DL
-	ofi_monitor_cleanup();
+	ofi_monitors_cleanup();
 	ofi_mem_fini();
 #endif
 	fi_freeinfo((void *)vrb_util_prov.info);
@@ -678,7 +678,7 @@ VERBS_INI
 {
 #if HAVE_VERBS_DL
 	ofi_mem_init();
-	ofi_monitor_init();
+	ofi_monitors_init();
 #endif
 	if (vrb_read_params()|| vrb_init_info(&vrb_util_prov.info))
 		return NULL;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -586,7 +586,7 @@ static void ofi_ini_dir(const char *dir)
 			goto libdl_done;
 		}
 		ofi_reg_dl_prov(lib);
-	
+
 		free(liblist[n]);
 		free(lib);
 	}
@@ -611,9 +611,9 @@ static void ofi_find_prov_libs(void)
 
 		if (!prov->prov_name)
 			continue;
-		
+
 		if (ofi_has_util_prefix(prov->prov_name)) {
-			short_prov_name = prov->prov_name + strlen(OFI_UTIL_PREFIX);		
+			short_prov_name = prov->prov_name + strlen(OFI_UTIL_PREFIX);
 		} else {
 			short_prov_name = prov->prov_name;
 		}
@@ -627,7 +627,7 @@ static void ofi_find_prov_libs(void)
 
 		ofi_reg_dl_prov(lib);
 		free(lib);
-	}   
+	}
 }
 #endif
 
@@ -648,7 +648,7 @@ void fi_ini(void)
 	ofi_pmem_init();
 	ofi_perf_init();
 	ofi_hook_init();
-	ofi_monitor_init();
+	ofi_monitors_init();
 
 	fi_param_define(NULL, "provider", FI_PARAM_STRING,
 			"Only use specified provider (default: all available)");
@@ -741,7 +741,7 @@ FI_DESTRUCTOR(fi_fini(void))
 	}
 
 	ofi_free_filter(&prov_filter);
-	ofi_monitor_cleanup();
+	ofi_monitors_cleanup();
 	ofi_mem_fini();
 	fi_log_fini();
 	fi_param_fini();


### PR DESCRIPTION
This renames the existing memory monitor init/cleanup routines to start/stop, and moves the real init/cleanup functionality out of the generic monitor call into dedicated calls.  PR has not been tested yet.