### PR TITLE
prov/rxd: Changing from a static to a dynamic av Implementation

### DIFF
--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -34,23 +34,6 @@
 #include <inttypes.h>
 
 
-static int rxd_tree_compare(struct ofi_rbmap *map, void *key, void *data)
-{
-	struct rxd_av *av;
-	uint8_t addr[RXD_NAME_LENGTH];
-	size_t len = RXD_NAME_LENGTH;
-	int ret;
-
-	memset(addr, 0, len);
-	av = container_of(map, struct rxd_av, rbmap);
-	ret = fi_av_lookup(av->dg_av, av->rxd_addr_table[(fi_addr_t) data].dg_addr,
-			   addr, &len);
-	if (ret)
-		return -1;
-
-	return memcmp(key, addr, len);
-}
-
 /*
  * The RXD code is agnostic wrt the datagram address format, but we need
  * to know the size of the address in order to iterate over them.  Because
@@ -103,107 +86,91 @@ close:
 	return ret;
 }
 
-static fi_addr_t rxd_av_dg_addr(struct rxd_av *av, fi_addr_t fi_addr)
-{
-	fi_addr_t rxd_addr = av->fi_addr_table[fi_addr];
-
-	return rxd_addr == FI_ADDR_UNSPEC ? rxd_addr :
-		av->rxd_addr_table[rxd_addr].dg_addr;
-}
-
-static fi_addr_t rxd_set_rxd_addr(struct rxd_av *av, fi_addr_t dg_addr)
-{
-	int tries = 0;
-
-	while (av->rxd_addr_table[av->rxd_addr_idx].dg_addr != FI_ADDR_UNSPEC &&
-	       tries < av->util_av.count) {
-		if (++av->rxd_addr_idx == av->util_av.count)
-			av->rxd_addr_idx = 0;
-		tries++;
-	}
-	assert(av->rxd_addr_idx < av->util_av.count && tries < av->util_av.count);
-	av->rxd_addr_table[av->rxd_addr_idx].dg_addr = dg_addr;
-
-	return av->rxd_addr_idx;
-}
-
-static fi_addr_t rxd_set_fi_addr(struct rxd_av *av, fi_addr_t rxd_addr)
-{
-	int tries = 0;
-
-	while (av->fi_addr_table[av->fi_addr_idx] != FI_ADDR_UNSPEC &&
-	       tries < av->util_av.count) {
-		if (++av->fi_addr_idx == av->util_av.count)
-			av->fi_addr_idx = 0;
-		tries++;
-	}
-	assert(av->fi_addr_idx < av->util_av.count && tries < av->util_av.count);
-	av->fi_addr_table[av->fi_addr_idx] = rxd_addr;
-	av->rxd_addr_table[rxd_addr].fi_addr = av->fi_addr_idx;
-
-	return av->fi_addr_idx;
-}
-
 int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
-			  fi_addr_t *rxd_addr, uint64_t flags,
-			  void *context)
+			fi_addr_t *dg_addr, uint64_t flags,
+			void *context, size_t addrlen)
 {
-	fi_addr_t dg_addr;
 	int ret;
+	struct rxd_dgaddr_entry *entry = NULL;
+	uint8_t tmp_addr[RXD_NAME_LENGTH];
 
-	ret = fi_av_insert(av->dg_av, addr, 1, &dg_addr,
-			     flags, context);
-	if (ret != 1)
-		return -FI_EINVAL;
+	memset(tmp_addr, 0, RXD_NAME_LENGTH);
+	memcpy(tmp_addr, addr, addrlen);
 
-	*rxd_addr = rxd_set_rxd_addr(av, dg_addr);
-
-	ret = ofi_rbmap_insert(&av->rbmap, (void *) addr, (void *) (*rxd_addr),
-			       NULL);
-	if (ret) {
-		assert(ret != -FI_EALREADY);
-		fi_av_remove(av->dg_av, &dg_addr, 1, flags);
+	HASH_FIND(hh, av->ep_dgaddr_hash, tmp_addr, RXD_NAME_LENGTH, entry);
+	if (entry) {
+		*dg_addr = entry->dg_addr;
+		return 0;
 	}
+	ret = fi_av_insert(av->dg_av, tmp_addr, 1, dg_addr,
+				flags, context);
+	if (ret != 1) {
+		FI_WARN(&rxd_prov, FI_LOG_AV, "failed to insert in dg AV");
+		return -FI_EINVAL;
+	}
+	entry = calloc(1, sizeof(*entry));
+	entry->dg_addr = *dg_addr;
+	memcpy(entry->addr, tmp_addr, RXD_NAME_LENGTH);
+	HASH_ADD(hh, av->ep_dgaddr_hash, addr, RXD_NAME_LENGTH, entry);
+	return 0;
+}
 
-	return ret;
+static int rxd_av_delete_dgaddr(struct rxd_av *av, const void *addr,
+			uint64_t flags, size_t addrlen)
+{
+	struct rxd_dgaddr_entry *entry = NULL;
+	uint8_t tmp_addr[RXD_NAME_LENGTH];
+
+	memset(tmp_addr, 0, RXD_NAME_LENGTH);
+	memcpy(tmp_addr, addr, addrlen);
+
+	HASH_FIND(hh, av->ep_dgaddr_hash, (void*)tmp_addr, RXD_NAME_LENGTH, entry);
+	if (!entry){
+		fi_av_remove(av->dg_av, &entry->dg_addr, 1, flags);
+		HASH_DELETE(hh, av->ep_dgaddr_hash, entry);
+		free(entry);
+	}
+	return 0;
 }
 
 static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			fi_addr_t *fi_addr, uint64_t flags, void *context)
 {
 	struct rxd_av *av;
+	struct rxd_ep *rxd_ep;	
+	struct dlist_entry *av_entry;
 	int i = 0, ret = 0, success_cnt = 0;
-	fi_addr_t rxd_addr, util_addr;
-	struct ofi_rbnode *node;
+	fi_addr_t util_addr, dg_addr;
 
 	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
 	fastlock_acquire(&av->util_av.lock);
+
 	if (!av->dg_addrlen) {
 		ret = rxd_av_set_addrlen(av, addr);
 		if (ret)
 			goto out;
 	}
 
-	for (; i < count; i++, addr = (uint8_t *) addr + av->dg_addrlen) {
-		node = ofi_rbmap_find(&av->rbmap, (void *) addr);
-		if (node) {
-			rxd_addr = (fi_addr_t) node->data;
-		} else {
-			ret = rxd_av_insert_dg_addr(av, addr, &rxd_addr,
-						    flags, context);
-			if (ret)
-				break;
+	for (; i < count; i++, addr = (uint8_t *) addr + av->dg_addrlen) {		
+		ret = rxd_av_insert_dg_addr(av, addr, &dg_addr, flags, context,
+					    av->dg_addrlen);
+		if (ret)
+			break;
+		ret = ofi_av_insert_addr(&av->util_av, &dg_addr, &util_addr);
+		if (ret) {
+			rxd_av_delete_dgaddr(av, addr, flags, av->dg_addrlen);
+			break;
 		}
-
-		util_addr = av->rxd_addr_table[rxd_addr].fi_addr == FI_ADDR_UNSPEC ?
-			    rxd_set_fi_addr(av, rxd_addr) :
-			    av->rxd_addr_table[rxd_addr].fi_addr;
+		dlist_foreach(&av->util_av.ep_list, av_entry) {
+			rxd_ep = container_of(av_entry, struct rxd_ep,
+					      util_ep.av_entry);
+			rxd_map_av_to_ep(&av->util_av, &dg_addr, util_addr,
+					 rxd_ep);
+		}
 		if (fi_addr)
 			fi_addr[i] = util_addr;
-
 		success_cnt++;
 	}
-
 	if (ret) {
 		FI_WARN(&rxd_prov, FI_LOG_AV,
 			"failed to insert address %d: %d (%s)\n",
@@ -224,7 +191,6 @@ out:
 		if (fi_addr)
 			fi_addr[i] = FI_ADDR_NOTAVAIL;
 	}
-
 	if (av->util_av.eq) {
 		ofi_av_write_event(&av->util_av, success_cnt, 0, context);
 		return 0;
@@ -251,35 +217,34 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 			uint64_t flags)
 {
 	int ret = 0;
-	size_t i, addrlen;
+	size_t i;
 	fi_addr_t rxd_addr;
 	struct rxd_av *av;
-	uint8_t addr[RXD_NAME_LENGTH];
+	struct rxd_ep *rxd_ep;
+	struct dlist_entry *av_entry;
+	struct rxd_peer *peer_entry;
+	struct rxd_fiaddr_entry *entry;
 
 	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
 	fastlock_acquire(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
-		rxd_addr = av->fi_addr_table[fi_addr[i]];
-
-		addrlen = RXD_NAME_LENGTH;
-		ret = fi_av_lookup(av->dg_av, av->rxd_addr_table[rxd_addr].dg_addr,
-				   addr, &addrlen);
+		ret = ofi_av_remove_addr(&av->util_av, fi_addr[i]);
 		if (ret)
 			goto err;
-		
-		ret = ofi_rbmap_find_delete(&av->rbmap, (void *) addr);
-		if (ret)
-			goto err;
-
-		ret = fi_av_remove(av->dg_av, &av->rxd_addr_table[rxd_addr].dg_addr,
-				   1, flags);
-		if (ret)
-			goto err;
-
-		av->fi_addr_table[fi_addr[i]] = FI_ADDR_UNSPEC;
-		av->rxd_addr_table[rxd_addr].fi_addr = FI_ADDR_UNSPEC;
-		av->rxd_addr_table[rxd_addr].dg_addr = FI_ADDR_UNSPEC;
-		av->dg_av_used--;
+		dlist_foreach(&av->util_av.ep_list, av_entry) {
+			rxd_ep =  container_of(av_entry, struct rxd_ep, util_ep.av_entry); 
+			HASH_FIND(hh, rxd_ep->fi_rxdaddr_hash, (void*)(&fi_addr[i]), 
+					sizeof(*fi_addr), entry);
+			if(!entry) {
+				FI_WARN(&rxd_prov, FI_LOG_AV, "Unable to remove addr from EP\n");
+				continue;
+			}
+			rxd_addr = entry->rxd_addr;
+			peer_entry = ofi_bufpool_get_ibuf(rxd_ep->peer_pool.pool, rxd_addr);
+			peer_entry->fi_addr = FI_ADDR_UNSPEC;
+			HASH_DELETE(hh, rxd_ep->fi_rxdaddr_hash, entry);
+			free(entry);
+		}
 	}
 
 err:
@@ -302,14 +267,12 @@ static int rxd_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 			 size_t *addrlen)
 {
 	struct rxd_av *rxd_av;
-	fi_addr_t dg_fiaddr;
+	fi_addr_t *dg_fiaddr;
 
 	rxd_av = container_of(av, struct rxd_av, util_av.av_fid);
-	dg_fiaddr = rxd_av_dg_addr(rxd_av, fi_addr);
-	if (dg_fiaddr == FI_ADDR_UNSPEC)
-		return -FI_ENODATA;
+	dg_fiaddr = (fi_addr_t*) ofi_av_get_addr(&(rxd_av->util_av), fi_addr);
 
-	return fi_av_lookup(rxd_av->dg_av, dg_fiaddr, addr, addrlen);
+	return fi_av_lookup(rxd_av->dg_av, *dg_fiaddr, addr, addrlen);
 }
 
 static struct fi_ops_av rxd_av_ops = {
@@ -322,6 +285,25 @@ static struct fi_ops_av rxd_av_ops = {
 	.straddr = rxd_av_straddr,
 };
 
+static void rxd_av_delete_hashtable(struct rxd_av *av)
+{
+	struct rxd_dgaddr_entry *dg_entry, *dg_tmp;
+	struct rxd_fiaddr_entry *fi_entry, *fi_tmp;
+	struct dlist_entry *av_entry;
+	struct rxd_ep *ep;
+
+	dlist_foreach(&av->util_av.ep_list, av_entry) {
+		ep =  container_of(av_entry, struct rxd_ep, util_ep.av_entry);
+		HASH_ITER(hh, ep->fi_rxdaddr_hash, fi_entry, fi_tmp) {
+			HASH_DEL(ep->fi_rxdaddr_hash, fi_entry);
+			free(fi_entry);
+		}
+	}
+	HASH_ITER(hh, av->ep_dgaddr_hash, dg_entry, dg_tmp) {
+		HASH_DEL(av->ep_dgaddr_hash, dg_entry);
+		free(dg_entry);
+	}
+}
 static int rxd_av_close(struct fid *fid)
 {
 	struct rxd_av *av;
@@ -332,13 +314,11 @@ static int rxd_av_close(struct fid *fid)
 	if (ret)
 		return ret;
 
-	ofi_rbmap_cleanup(&av->rbmap);
+	rxd_av_delete_hashtable(av);
 	ret = ofi_av_close(&av->util_av);
 	if (ret)
 		return ret;
 
-	free(av->fi_addr_table);
-	free(av->rxd_addr_table);
 	free(av);
 	return 0;
 }
@@ -359,7 +339,7 @@ static struct fi_ops rxd_av_fi_ops = {
 int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		   struct fid_av **av_fid, void *context)
 {
-	int ret, i;
+	int ret;
 	struct rxd_av *av;
 	struct rxd_domain *domain;
 	struct util_av_attr util_attr;
@@ -371,20 +351,10 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	if (attr->name)
 		return -FI_ENOSYS;
 
-	//TODO implement dynamic AV sizing
-	attr->count = roundup_power_of_two(attr->count ?
-					   attr->count : rxd_env.max_peers);
 	domain = container_of(domain_fid, struct rxd_domain, util_domain.domain_fid);
 	av = calloc(1, sizeof(*av));
 	if (!av)
 		return -FI_ENOMEM;
-	av->fi_addr_table = calloc(1, attr->count * sizeof(fi_addr_t));
-	av->rxd_addr_table = calloc(1, rxd_env.max_peers * sizeof(struct rxd_addr));
-	if (!av->fi_addr_table || !av->rxd_addr_table) {
-		ret = -FI_ENOMEM;
-		goto err1;
-	}
-
 
 	util_attr.addrlen = sizeof(fi_addr_t);
 	util_attr.flags = 0;
@@ -394,19 +364,12 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	ret = ofi_av_init(&domain->util_domain, attr, &util_attr,
 			 &av->util_av, context);
 	if (ret)
-		goto err1;
-
-	ofi_rbmap_init(&av->rbmap, rxd_tree_compare);
-	for (i = 0; i < attr->count; av->fi_addr_table[i++] = FI_ADDR_UNSPEC)
-		;
-	for (i = 0; i < rxd_env.max_peers; i++) {
-		av->rxd_addr_table[i].fi_addr = FI_ADDR_UNSPEC;
-		av->rxd_addr_table[i].dg_addr = FI_ADDR_UNSPEC;
-	}
+		goto err1;	
 
 	av_attr = *attr;
 	av_attr.count = 0;
 	av_attr.flags = 0;
+
 	ret = fi_av_open(domain->dg_domain, &av_attr, &av->dg_av, context);
 	if (ret)
 		goto err2;
@@ -414,13 +377,12 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	av->util_av.av_fid.fid.ops = &rxd_av_fi_ops;
 	av->util_av.av_fid.ops = &rxd_av_ops;
 	*av_fid = &av->util_av.av_fid;
+
 	return 0;
 
 err2:
 	ofi_av_close(&av->util_av);
 err1:
-	free(av->fi_addr_table);
-	free(av->rxd_addr_table);
 	free(av);
 	return ret;
 }


### PR DESCRIPTION
The current implementation of rxd av is dependent on FI_OFI_RXD_MAX_PEERS
environment variable which must be specified to determine the maximum
number of peers that it can support.This also restricts the possibility of
any new peers more than the intially specified count to join the communication
at run time.
This patch removes the dependence of the number of peers which can communicate
via rxd on the environment variables by allowing expansion of the address vector
and the peers stored per endpoint dynamically.

As the peer list can grow dynamically upon an RTS event or an address insertion
the endpoint needs to maintain its unique peer list indexed by a rxd_addr.
Each endpoint also maintains a mapping between the fi_addr and the rxd_addr
in order to access a peer during a send/inject operation. This is needed
since the dg_addr/fi_addr in the AV may be shared across endpoints but
each endpoint will have its own unique rxd_addr for a peer.

data structures added:

- rxd_ep->fi_rxdaddr_hash: Used to map fi_addr to a unique rxd_addr per endpoint.
- rxd_ep->ep_rxdaddr_hash: To ensure that a peer endpoint is created only once
  for a peer_list.
- rxd_ep->peer_pool	 : The peer list is implemented using bufpool.
- rxd_av->ep_dgaddr_hash : A hash table to ensure unique entries into the dg_av.
- rxd_av->util_av	 : To store the fi_addr-->dg_addr mapping

Signed-off-by: Nikhil Nanal <nihkil.nanal@intel.com>