### PR TITLE
prov/efa: adjust struct rxr_pkt_entry

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -63,13 +63,10 @@ struct rxr_pkt_entry *rxr_pkt_entry_alloc(struct rxr_ep *ep,
 	dlist_init(&pkt_entry->dbg_entry);
 #endif
 	pkt_entry->mr = (struct fid_mr *)mr;
-	pkt_entry->pkt = (struct rxr_pkt *)((char *)pkt_entry +
-			  sizeof(*pkt_entry));
 #ifdef ENABLE_EFA_POISONING
 	memset(pkt_entry->pkt, 0, ep->mtu_size);
 #endif
 	pkt_entry->state = RXR_PKT_ENTRY_IN_USE;
-	pkt_entry->iov_count = 0;
 	pkt_entry->next = NULL;
 	return pkt_entry;
 }
@@ -165,7 +162,6 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
 	       "Copying packet out of posted buffer\n");
 	assert(src->type == RXR_PKT_ENTRY_POSTED);
 	memcpy(dest, src, sizeof(struct rxr_pkt_entry));
-	dest->pkt = (struct rxr_pkt *)((char *)dest + sizeof(*dest));
 	memcpy(dest->pkt, src->pkt, ep->mtu_size);
 	dlist_init(&dest->entry);
 #if ENABLE_DEBUG

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -86,7 +86,11 @@ struct rxr_req_opt_cq_data_hdr {
 	int64_t cq_data;
 };
 
-void rxr_pkt_proc_req_common_hdr(struct rxr_pkt_entry *pkt_entry);
+void *rxr_pkt_req_raw_addr(struct rxr_pkt_entry *pkt_entry);
+
+int64_t rxr_pkt_req_cq_data(struct rxr_pkt_entry *pkt_entry);
+
+size_t rxr_pkt_req_hdr_size(struct rxr_pkt_entry *pkt_entry);
 
 size_t rxr_pkt_req_base_hdr_size(struct rxr_pkt_entry *pkt_entry);
 


### PR DESCRIPTION
Some recent commits added data members to struct rxr_pkt_entry and
increase its size from 64 bytes to 192 bytes. This has caused
increased cache misses and degraded bandwidth.

This patch remove data members from struct rxr_pkt_entry and make
it 64 bytes again. The removed data members include:

1. hdr_size, raw_addr, cq_data. They are used in processing
   REQ packet types, we introduced the following functions:
           rxr_pkt_req_hdr_size()
           rxr_pkt_req_raw_addr()
	   rxr_pkt_req_cq_data()
   to retrieve on the fly.

2. iov_count, iov and desc. They are used in sending packets and
   only used inside rxr_pkt_post_ctrl_once().
   We added a new struct rxr_pkt_sendv, rxr_pkt_post_ctrl_once()
   will declare a rxr_pkt_sendv, rxr_pkt_init_ctrl() will initialize
   it.

Signed-off-by: Wei Zhang <wzam@amazon.com>