### PR TITLE
prov/sockets: do sock_ep_remove_conn() when detects disconnect

### DIFF
--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -441,10 +441,12 @@ static int sock_av_remove(struct fid_av *av, fi_addr_t *fi_addr, size_t count,
 	}
 	fastlock_release(&_av->list_lock);
 
+	fastlock_acquire(&_av->table_lock);
 	for (i = 0; i < count; i++) {
 		av_addr = &_av->table[fi_addr[i]];
 		av_addr->valid = 0;
 	}
+	fastlock_release(&_av->table_lock);
 
 	return 0;
 }

--- a/prov/sockets/src/sock_conn.c
+++ b/prov/sockets/src/sock_conn.c
@@ -167,8 +167,9 @@ void sock_conn_release_entry(struct sock_conn_map *map, struct sock_conn *conn)
 	ofi_close_socket(conn->sock_fd);
 
 	conn->address_published = 0;
-        conn->connected = 0;
-        conn->sock_fd = -1;
+	conn->av_index = FI_ADDR_NOTAVAIL;
+	conn->connected = 0;
+	conn->sock_fd = -1;
 }
 
 static int sock_conn_get_next_index(struct sock_conn_map *map)
@@ -581,6 +582,8 @@ retry:
 
 	SOCK_LOG_ERROR("Connect error, retrying - %s - %d\n",
 		       strerror(ofi_sockerr()), conn_fd);
+	ofi_straddr_log(&sock_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
+			"Retry connect to peer ", &addr.sa);
         goto do_connect;
 
 out:

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1942,13 +1942,12 @@ static int sock_pe_progress_tx_entry(struct sock_pe *pe,
 		goto out;
 
 	if (sock_comm_is_disconnected(pe_entry)) {
-		SOCK_LOG_DBG("conn disconnected: removing fd from pollset\n");
-		if (pe_entry->ep_attr->cmap.used > 0 &&
-		     pe_entry->conn->sock_fd != -1) {
-			fastlock_acquire(&pe_entry->ep_attr->cmap.lock);
-			sock_ep_remove_conn(pe_entry->ep_attr, pe_entry->conn);
-			fastlock_release(&pe_entry->ep_attr->cmap.lock);
-		}
+		ofi_straddr_log(&sock_prov, FI_LOG_WARN, FI_LOG_EP_DATA,
+				"Peer disconnected: removing fd from pollset",
+				&pe_entry->conn->addr.sa);
+		fastlock_acquire(&pe_entry->ep_attr->cmap.lock);
+		sock_ep_remove_conn(pe_entry->ep_attr, pe_entry->conn);
+		fastlock_release(&pe_entry->ep_attr->cmap.lock);
 
 		sock_pe_report_tx_error(pe_entry, 0, FI_EIO);
 		pe_entry->is_complete = 1;
@@ -2021,13 +2020,12 @@ static int sock_pe_progress_rx_pe_entry(struct sock_pe *pe,
 	int ret;
 
 	if (sock_comm_is_disconnected(pe_entry)) {
-		SOCK_LOG_DBG("conn disconnected: removing fd from pollset\n");
-		if (pe_entry->ep_attr->cmap.used > 0 &&
-		     pe_entry->conn->sock_fd != -1) {
-			fastlock_acquire(&pe_entry->ep_attr->cmap.lock);
-			sock_ep_remove_conn(pe_entry->ep_attr, pe_entry->conn);
-			fastlock_release(&pe_entry->ep_attr->cmap.lock);
-		}
+		ofi_straddr_log(&sock_prov, FI_LOG_WARN, FI_LOG_EP_DATA,
+				"Peer disconnected: removing fd from pollset",
+				&pe_entry->conn->addr.sa);
+		fastlock_acquire(&pe_entry->ep_attr->cmap.lock);
+		sock_ep_remove_conn(pe_entry->ep_attr, pe_entry->conn);
+		fastlock_release(&pe_entry->ep_attr->cmap.lock);
 
 		if (pe_entry->pe.rx.header_read)
 			sock_pe_report_rx_error(pe_entry, 0, FI_EIO);


### PR DESCRIPTION
1. When detects peer disconnected, call sock_ep_remove_conn() to remove
   the connection.
2. Fixes a case using 16bits av index that possibly be overflowed.
3. Takes av->table_lock in sock_av_remove().
4. Adds a few more verbose debug msg.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>