### PR TITLE
[v1.10.x] prov/shm: fix memory leaks

### DIFF
--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -467,6 +467,8 @@ static int smr_ep_close(struct fid *fid)
 	smr_recv_fs_free(ep->recv_fs);
 	smr_unexp_fs_free(ep->unexp_fs);
 	smr_pend_fs_free(ep->pend_fs);
+	smr_sar_fs_free(ep->sar_fs);
+	free((void *)ep->name);
 	free(ep);
 	return 0;
 }


### PR DESCRIPTION
Current code did not release sar_fs and ep_name in smr_ep_close().
This patch address the issue.

Signed-off-by: Wei Zhang <wzam@amazon.com>