### PR TITLE
fabtests/getinfo_test : fix memory leak in validate_bit_combos()

### DIFF
--- a/fabtests/unit/getinfo_test.c
+++ b/fabtests/unit/getinfo_test.c
@@ -148,6 +148,9 @@ static int validate_bit_combos(char *node, char *service, uint64_t flags,
 		}
 		if (ret)
 			fail++;
+
+		fi_freeinfo(*info);
+		*info = NULL;
 	}
 	ret = 0;
 	printf("(passed)(skipped) (%d)(%d)/%d combinations\n",


### PR DESCRIPTION
Currently validate_bit_combos() call fi_getinfo() in a loop, and
did not release the memory allocated by it.

This patch added call to free the info object, and only return
the last one.

Signed-off-by: Wei Zhang <wzam@amazon.com>