### PR TITLE
[v1.9.x] prov/shm: fix a memory leak

### DIFF
--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -331,6 +331,7 @@ static int smr_ep_close(struct fid *fid)
 	smr_recv_fs_free(ep->recv_fs);
 	smr_unexp_fs_free(ep->unexp_fs);
 	smr_pend_fs_free(ep->pend_fs);
+	free((void *)ep->name);
 	free(ep);
 	return 0;
 }


### PR DESCRIPTION
This patch release smr_ep->ep_name in smr_ep_close()

Signed-off-by: Wei Zhang <wzam@amazon.com>