### PR TITLE
prov/efa: Advertise the correct inject_size

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -535,7 +535,6 @@ struct rxr_ep {
 	/* rx/tx queue size of core provider */
 	size_t core_rx_size;
 	size_t max_outstanding_tx;
-	size_t core_inject_size;
 	size_t max_data_payload_size;
 
 	/* Resource management flag */

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1668,7 +1668,6 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	assert(info->tx_attr->msg_order == info->rx_attr->msg_order);
 	rxr_ep->msg_order = info->rx_attr->msg_order;
 	rxr_ep->core_msg_order = rdm_info->rx_attr->msg_order;
-	rxr_ep->core_inject_size = rdm_info->tx_attr->inject_size;
 	rxr_ep->mtu_size = rdm_info->ep_attr->max_msg_size;
 	if (rxr_env.mtu_size > 0 && rxr_env.mtu_size < rxr_ep->mtu_size)
 		rxr_ep->mtu_size = rxr_env.mtu_size;

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -263,8 +263,6 @@ ssize_t rxr_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
 	msg.addr = dest_addr;
 
 	rxr_ep = container_of(ep, struct rxr_ep, util_ep.ep_fid.fid);
-	assert(len <= rxr_ep->core_inject_size - sizeof(struct rxr_eager_msgrtm_hdr));
-
 	return rxr_msg_generic_send(ep, &msg, 0, ofi_op_msg,
 				    rxr_tx_flags(rxr_ep) | RXR_NO_COMPLETION | FI_INJECT);
 }
@@ -293,7 +291,6 @@ ssize_t rxr_msg_injectdata(struct fid_ep *ep, const void *buf,
 	 * source address. This means that we may end up not using the core
 	 * providers inject for this send.
 	 */
-	assert(len <= rxr_ep->core_inject_size - sizeof(struct rxr_eager_msgrtm_hdr));
 	return rxr_msg_generic_send(ep, &msg, 0, ofi_op_msg,
 				    rxr_tx_flags(rxr_ep) | RXR_NO_COMPLETION |
 				    FI_REMOTE_CQ_DATA | FI_INJECT);
@@ -391,8 +388,6 @@ ssize_t rxr_msg_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	msg.addr = dest_addr;
 
 	rxr_ep = container_of(ep_fid, struct rxr_ep, util_ep.ep_fid.fid);
-	assert(len <= rxr_ep->core_inject_size - sizeof(struct rxr_eager_tagrtm_hdr));
-
 	return rxr_msg_generic_send(ep_fid, &msg, tag, ofi_op_tagged,
 				    rxr_tx_flags(rxr_ep) | RXR_NO_COMPLETION | FI_INJECT);
 }
@@ -420,8 +415,6 @@ ssize_t rxr_msg_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	 * source address. This means that we may end up not using the core
 	 * providers inject for this send.
 	 */
-	assert(len <= rxr_ep->core_inject_size - sizeof(struct rxr_eager_tagrtm_hdr));
-
 	return rxr_msg_generic_send(ep_fid, &msg, tag, ofi_op_tagged,
 				    rxr_tx_flags(rxr_ep) | RXR_NO_COMPLETION |
 				    FI_REMOTE_CQ_DATA | FI_INJECT);


### PR DESCRIPTION
Commit 717f14b4db retired the RTS packet and set the inject_size to zero.
Commmit 5aa0faede started inlining sends based on the inline_buf_size we get
from efadv_query_device(). With the completions already squashed for
fi_(t)inject(), we can advertise the correct size based on the capabilities
requested and the corresponding largest header type for eager messages.

Signed-off-by: Raghu Raja <craghun@amazon.com>