### PR TITLE
Move vrb_speed to src/common.c and use it in EFA provider

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -366,6 +366,7 @@ static inline uint32_t ofi_xorshift_random(uint32_t val)
 	return val;
 }
 
+size_t ofi_vrb_speed(uint8_t speed, uint8_t width);
 
 #ifdef __cplusplus
 }

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -429,7 +429,8 @@ static int efa_alloc_fid_nic(struct fi_info *fi, struct efa_context *ctx,
 
 	link_attr->mtu = port_attr->max_msg_sz;
 
-	link_attr->speed = 0;
+	link_attr->speed = ofi_vrb_speed(port_attr->active_speed,
+	                                 port_attr->active_width);
 
 	switch (port_attr->state) {
 	case IBV_PORT_DOWN:

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -534,55 +534,6 @@ static const char *vrb_link_layer_str(uint8_t link_layer)
 	}
 }
 
-static size_t vrb_speed(uint8_t speed, uint8_t width)
-{
-	const size_t gbit_2_bit_coef = 1024 * 1024;
-	size_t width_val, speed_val;
-
-	switch (speed) {
-	case 1:
-		speed_val = (size_t) (2.5 * (float) gbit_2_bit_coef);
-		break;
-	case 2:
-		speed_val = 5 * gbit_2_bit_coef;
-		break;
-	case 4:
-	case 8:
-		speed_val = 8 * gbit_2_bit_coef;
-		break;
-	case 16:
-		speed_val = 14 * gbit_2_bit_coef;
-		break;
-	case 32:
-		speed_val = 25 * gbit_2_bit_coef;
-		break;
-	default:
-		speed_val = 0;
-		break;
-	}
-
-	switch (width) {
-	case 1:
-		width_val = 1;
-		break;
-	case 2:
-		width_val = 4;
-		break;
-	case 4:
-		width_val = 8;
-		break;
-	case 8:
-		width_val = 12;
-		break;
-	default:
-		width_val = 0;
-		break;
-	}
-
-	return width_val * speed_val;
-}
-
-
 static int vrb_get_device_attrs(struct ibv_context *ctx,
 				   struct fi_info *info, uint32_t protocol)
 {
@@ -717,8 +668,8 @@ static int vrb_get_device_attrs(struct ibv_context *ctx,
 
 	mtu_size = vrb_mtu_type_to_len(port_attr.active_mtu);
 	info->nic->link_attr->mtu = (size_t) (mtu_size > 0 ? mtu_size : 0);
-	info->nic->link_attr->speed = vrb_speed(port_attr.active_speed,
-						   port_attr.active_width);
+	info->nic->link_attr->speed = ofi_vrb_speed(port_attr.active_speed,
+						    port_attr.active_width);
 	info->nic->link_attr->state =
 		vrb_pstate_2_lstate(port_attr.state);
 	info->nic->link_attr->network_type =

--- a/src/common.c
+++ b/src/common.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2006-2017 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013-2018 Intel Corp., Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos Nat. Security, LLC. All rights reserved.
+ * Copyright (c) 2020 Amazon.com, Inc. or its affiliates.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -1603,4 +1604,55 @@ struct fid_nic *ofi_nic_dup(const struct fid_nic *nic)
 fail:
 	ofi_nic_close(&dup_nic->fid);
 	return NULL;
+}
+
+/*
+ * Calculate bits per second based on verbs port active_speed and active_width.
+ */
+size_t ofi_vrb_speed(uint8_t speed, uint8_t width)
+{
+	const size_t gbit_2_bit_coef = 1000 * 1000 * 1000;
+	size_t width_val, speed_val;
+
+	switch (speed) {
+	case 1:
+		speed_val = (size_t) (2.5 * (float) gbit_2_bit_coef);
+		break;
+	case 2:
+		speed_val = 5 * gbit_2_bit_coef;
+		break;
+	case 4:
+	case 8:
+		speed_val = 8 * gbit_2_bit_coef;
+		break;
+	case 16:
+		speed_val = 14 * gbit_2_bit_coef;
+		break;
+	case 32:
+		speed_val = 25 * gbit_2_bit_coef;
+		break;
+	default:
+		speed_val = 0;
+		break;
+	}
+
+	switch (width) {
+	case 1:
+		width_val = 1;
+		break;
+	case 2:
+		width_val = 4;
+		break;
+	case 4:
+		width_val = 8;
+		break;
+	case 8:
+		width_val = 12;
+		break;
+	default:
+		width_val = 0;
+		break;
+	}
+
+	return width_val * speed_val;
 }


### PR DESCRIPTION
Move the vrb_speed() function to a common function and fix the units so that it reports bits per second. Use that function in the EFA provider to populate the fid_nic speed field.