### PR TITLE
prov/rxm: Simplification of rxm_handle_txrx_ops

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -644,10 +644,10 @@ struct rxm_msg_eq_entry {
 #define RXM_CM_ENTRY_SZ (sizeof(struct fi_eq_cm_entry) + \
 			 sizeof(union rxm_cm_data))
 
-struct rxm_handle_txrx_ops {
-	int (*comp_eager_tx)(struct rxm_ep *rxm_ep,
-				    struct rxm_tx_eager_buf *tx_eager_buf);
-	ssize_t (*handle_eager_rx)(struct rxm_rx_buf *rx_buf);
+struct rxm_eager_ops {
+	int (*comp_tx)(struct rxm_ep *rxm_ep,
+		       struct rxm_tx_eager_buf *tx_eager_buf);
+	ssize_t (*handle_rx)(struct rxm_rx_buf *rx_buf);
 };
 
 struct rxm_ep {
@@ -683,7 +683,7 @@ struct rxm_ep {
 	struct rxm_recv_queue	recv_queue;
 	struct rxm_recv_queue	trecv_queue;
 
-	struct rxm_handle_txrx_ops	*txrx_ops;
+	struct rxm_eager_ops	*eager_ops;
 };
 
 struct rxm_conn {

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -648,7 +648,6 @@ struct rxm_handle_txrx_ops {
 	int (*comp_eager_tx)(struct rxm_ep *rxm_ep,
 				    struct rxm_tx_eager_buf *tx_eager_buf);
 	ssize_t (*handle_eager_rx)(struct rxm_rx_buf *rx_buf);
-	ssize_t (*handle_rndv_rx)(struct rxm_rx_buf *rx_buf);
 };
 
 struct rxm_ep {
@@ -742,7 +741,6 @@ void rxm_ep_do_progress(struct util_ep *util_ep);
 
 ssize_t rxm_cq_handle_eager(struct rxm_rx_buf *rx_buf);
 ssize_t rxm_cq_handle_coll_eager(struct rxm_rx_buf *rx_buf);
-ssize_t rxm_cq_handle_rndv(struct rxm_rx_buf *rx_buf);
 int rxm_finish_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *tx_eager_buf);
 int rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *tx_eager_buf);
 

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -649,7 +649,6 @@ struct rxm_handle_txrx_ops {
 				    struct rxm_tx_eager_buf *tx_eager_buf);
 	ssize_t (*handle_eager_rx)(struct rxm_rx_buf *rx_buf);
 	ssize_t (*handle_rndv_rx)(struct rxm_rx_buf *rx_buf);
-	ssize_t (*handle_seg_data_rx)(struct rxm_rx_buf *rx_buf);
 };
 
 struct rxm_ep {
@@ -744,7 +743,6 @@ void rxm_ep_do_progress(struct util_ep *util_ep);
 ssize_t rxm_cq_handle_eager(struct rxm_rx_buf *rx_buf);
 ssize_t rxm_cq_handle_coll_eager(struct rxm_rx_buf *rx_buf);
 ssize_t rxm_cq_handle_rndv(struct rxm_rx_buf *rx_buf);
-ssize_t rxm_cq_handle_seg_data(struct rxm_rx_buf *rx_buf);
 int rxm_finish_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *tx_eager_buf);
 int rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *tx_eager_buf);
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -592,7 +592,7 @@ ssize_t rxm_cq_handle_rx_buf(struct rxm_rx_buf *rx_buf)
 {
 	switch (rx_buf->pkt.ctrl_hdr.type) {
 	case rxm_ctrl_eager:
-		return rx_buf->ep->txrx_ops->handle_eager_rx(rx_buf);
+		return rx_buf->ep->eager_ops->handle_rx(rx_buf);
 	case rxm_ctrl_rndv:
 		return rxm_handle_rndv(rx_buf);
 	case rxm_ctrl_seg:
@@ -1099,7 +1099,7 @@ ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 	switch (RXM_GET_PROTO_STATE(comp->op_context)) {
 	case RXM_TX:
 		tx_eager_buf = comp->op_context;
-		ret = rxm_ep->txrx_ops->comp_eager_tx(rxm_ep, tx_eager_buf);
+		ret = rxm_ep->eager_ops->comp_tx(rxm_ep, tx_eager_buf);
 		ofi_buf_free(tx_eager_buf);
 		return ret;
 	case RXM_CREDIT_TX:

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -457,7 +457,7 @@ int rxm_rx_repost_new(struct rxm_rx_buf *rx_buf)
 	return FI_SUCCESS;
 }
 
-ssize_t rxm_cq_handle_rndv(struct rxm_rx_buf *rx_buf)
+static ssize_t rxm_handle_rndv(struct rxm_rx_buf *rx_buf)
 {
 	size_t i, index = 0, offset = 0, count, total_recv_len;
 	struct iovec iov[RXM_IOV_LIMIT];
@@ -594,7 +594,7 @@ ssize_t rxm_cq_handle_rx_buf(struct rxm_rx_buf *rx_buf)
 	case rxm_ctrl_eager:
 		return rx_buf->ep->txrx_ops->handle_eager_rx(rx_buf);
 	case rxm_ctrl_rndv:
-		return rx_buf->ep->txrx_ops->handle_rndv_rx(rx_buf);
+		return rxm_handle_rndv(rx_buf);
 	case rxm_ctrl_seg:
 		return rxm_handle_seg_data(rx_buf);
 	default:

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -382,7 +382,7 @@ static ssize_t rxm_cq_copy_seg_data(struct rxm_rx_buf *rx_buf, int *done)
 	return ret;
 }
 
-ssize_t rxm_cq_handle_seg_data(struct rxm_rx_buf *rx_buf)
+static ssize_t rxm_handle_seg_data(struct rxm_rx_buf *rx_buf)
 {
 	struct rxm_recv_entry *recv_entry;
 	struct rxm_conn *conn;
@@ -596,7 +596,7 @@ ssize_t rxm_cq_handle_rx_buf(struct rxm_rx_buf *rx_buf)
 	case rxm_ctrl_rndv:
 		return rx_buf->ep->txrx_ops->handle_rndv_rx(rx_buf);
 	case rxm_ctrl_seg:
-		return rx_buf->ep->txrx_ops->handle_seg_data_rx(rx_buf);
+		return rxm_handle_seg_data(rx_buf);
 	default:
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unknown message type\n");
 		assert(0);
@@ -696,7 +696,7 @@ static ssize_t rxm_sar_handle_segment(struct rxm_rx_buf *rx_buf)
 
 	rx_buf->recv_entry = container_of(sar_entry, struct rxm_recv_entry,
 					  sar.entry);
-	return rx_buf->ep->txrx_ops->handle_seg_data_rx(rx_buf);
+	return rxm_handle_seg_data(rx_buf);
 }
 
 static ssize_t rxm_rndv_send_ack_inject(struct rxm_rx_buf *rx_buf)

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -500,14 +500,12 @@ static struct rxm_handle_txrx_ops rxm_rx_ops = {
 	.comp_eager_tx = rxm_finish_eager_send,
 	.handle_eager_rx = rxm_cq_handle_eager,
 	.handle_rndv_rx = rxm_cq_handle_rndv,
-	.handle_seg_data_rx = rxm_cq_handle_seg_data,
 };
 
 static struct rxm_handle_txrx_ops rxm_coll_rx_ops = {
 	.comp_eager_tx = rxm_finish_coll_eager_send,
 	.handle_eager_rx = rxm_cq_handle_coll_eager,
 	.handle_rndv_rx = rxm_cq_handle_rndv,
-	.handle_seg_data_rx = rxm_cq_handle_seg_data,
 };
 
 static int rxm_ep_cancel_recv(struct rxm_ep *rxm_ep,
@@ -1056,7 +1054,7 @@ rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	struct fid_mr **mr_iov;
 	ssize_t ret;
 	struct rxm_tx_rndv_buf *tx_buf;
-	
+
 	tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX_RNDV);
 	if (!tx_buf) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
@@ -1144,7 +1142,7 @@ rxm_ep_sar_tx_prepare_segment(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			      enum rxm_sar_seg_type seg_type, uint64_t *msg_id)
 {
 	struct rxm_tx_sar_buf *tx_buf;
-	
+
 	tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX_SAR);
 	if (!tx_buf) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
@@ -1460,7 +1458,7 @@ rxm_ep_alloc_deferred_tx_entry(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			       enum rxm_deferred_tx_entry_type type)
 {
 	struct rxm_deferred_tx_entry *def_tx_entry;
-	
+
 	def_tx_entry = calloc(1, sizeof(*def_tx_entry));
 	if (!def_tx_entry)
 		return NULL;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -499,13 +499,11 @@ static struct fi_ops_cm rxm_ops_cm = {
 static struct rxm_handle_txrx_ops rxm_rx_ops = {
 	.comp_eager_tx = rxm_finish_eager_send,
 	.handle_eager_rx = rxm_cq_handle_eager,
-	.handle_rndv_rx = rxm_cq_handle_rndv,
 };
 
 static struct rxm_handle_txrx_ops rxm_coll_rx_ops = {
 	.comp_eager_tx = rxm_finish_coll_eager_send,
 	.handle_eager_rx = rxm_cq_handle_coll_eager,
-	.handle_rndv_rx = rxm_cq_handle_rndv,
 };
 
 static int rxm_ep_cancel_recv(struct rxm_ep *rxm_ep,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -496,14 +496,14 @@ static struct fi_ops_cm rxm_ops_cm = {
 	.join = rxm_join_coll,
 };
 
-static struct rxm_handle_txrx_ops rxm_rx_ops = {
-	.comp_eager_tx = rxm_finish_eager_send,
-	.handle_eager_rx = rxm_cq_handle_eager,
+static struct rxm_eager_ops def_eager_ops = {
+	.comp_tx = rxm_finish_eager_send,
+	.handle_rx = rxm_cq_handle_eager,
 };
 
-static struct rxm_handle_txrx_ops rxm_coll_rx_ops = {
-	.comp_eager_tx = rxm_finish_coll_eager_send,
-	.handle_eager_rx = rxm_cq_handle_coll_eager,
+static struct rxm_eager_ops coll_eager_ops = {
+	.comp_tx = rxm_finish_coll_eager_send,
+	.handle_rx = rxm_cq_handle_coll_eager,
 };
 
 static int rxm_ep_cancel_recv(struct rxm_ep *rxm_ep,
@@ -2752,10 +2752,10 @@ int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	if(rxm_ep->rxm_info->caps & FI_COLLECTIVE) {
 		(*ep_fid)->collective = &rxm_ops_collective;
-		rxm_ep->txrx_ops = &rxm_coll_rx_ops;
+		rxm_ep->eager_ops = &coll_eager_ops;
 	} else {
 		(*ep_fid)->collective = &rxm_ops_collective_none;
-		rxm_ep->txrx_ops = &rxm_rx_ops;
+		rxm_ep->eager_ops = &def_eager_ops;
 	}
 
 	if (rxm_ep->util_ep.domain->threading != FI_THREAD_SAFE) {


### PR DESCRIPTION
Some minor cleanups to make the code easier to follow.