### PR TITLE
prov/rxm: Rename several functions in rxm_cq

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -724,7 +724,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 			     struct fid_domain **dom, void *context);
 int rxm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 			 struct fid_cq **cq_fid, void *context);
-ssize_t rxm_cq_handle_rx_buf(struct rxm_rx_buf *rx_buf);
+ssize_t rxm_handle_rx_buf(struct rxm_rx_buf *rx_buf);
 
 int rxm_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  struct fid_ep **ep, void *context);
@@ -733,14 +733,14 @@ int rxm_conn_cmap_alloc(struct rxm_ep *rxm_ep);
 void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 			void *op_context, int err);
 void rxm_cq_write_error_all(struct rxm_ep *rxm_ep, int err);
-void rxm_cq_read_write_error(struct rxm_ep *rxm_ep);
-ssize_t rxm_cq_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp);
+void rxm_handle_comp_error(struct rxm_ep *rxm_ep);
+ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp);
 void rxm_ep_progress(struct util_ep *util_ep);
 void rxm_ep_progress_coll(struct util_ep *util_ep);
 void rxm_ep_do_progress(struct util_ep *util_ep);
 
-ssize_t rxm_cq_handle_eager(struct rxm_rx_buf *rx_buf);
-ssize_t rxm_cq_handle_coll_eager(struct rxm_rx_buf *rx_buf);
+ssize_t rxm_handle_eager(struct rxm_rx_buf *rx_buf);
+ssize_t rxm_handle_coll_eager(struct rxm_rx_buf *rx_buf);
 int rxm_finish_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *tx_eager_buf);
 int rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *tx_eager_buf);
 
@@ -749,7 +749,6 @@ int rxm_msg_ep_prepost_recv(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
 int rxm_ep_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,
 			uint64_t flags);
-int rxm_rx_repost_new(struct rxm_rx_buf *rx_buf);
 
 static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
 {

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -905,7 +905,7 @@ static int rxm_conn_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
 		rx_buf->recv_entry = container_of(entry, struct rxm_recv_entry,
 						  entry);
 
-		ret = rxm_cq_handle_rx_buf(rx_buf);
+		ret = rxm_handle_rx_buf(rx_buf);
 		if (ret) {
 			err_entry.op_context = rx_buf;
 			err_entry.flags = rx_buf->recv_entry->comp_flags;
@@ -1100,14 +1100,14 @@ static void rxm_flush_msg_cq(struct rxm_ep *rxm_ep)
 	do {
 		ret = fi_cq_read(rxm_ep->msg_cq, &comp, 1);
 		if (ret > 0) {
-			ret = rxm_cq_handle_comp(rxm_ep, &comp);
+			ret = rxm_handle_comp(rxm_ep, &comp);
 			if (OFI_UNLIKELY(ret)) {
 				rxm_cq_write_error_all(rxm_ep, ret);
 			} else {
 				ret = 1;
 			}
 		} else if (ret == -FI_EAVAIL) {
-			rxm_cq_read_write_error(rxm_ep);
+			rxm_handle_comp_error(rxm_ep);
 			ret = 1;
 		} else if (ret < 0 && ret != -FI_EAGAIN) {
 			rxm_cq_write_error_all(rxm_ep, ret);


### PR DESCRIPTION
There are several rxm function with the prefix rxm_cq_, which have nothing
to do with the cq.  Remove the 'cq' from the prefix to make it clearer that
these are not cq related functions, and are merely handling received data.

Rename other calls to follow the more common format of 'verb-object' used
throughout the code.  The provider has a mix of function names, making it
difficult to figure out what action is being taken on what object.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>