### PR TITLE
travis: Send Coverity scan reports to the maintainer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ addons:
       project:
         name: "ofiwg/libfabric"
         description: "Libfabric project coverity scans"
+      notification_email: sean.hefty@intel.com
       build_command_prepend: "./autogen.sh; ./configure"
       build_command: "make -j2"
       # It might be overkill to run a full scan across the compiler test matrix


### PR DESCRIPTION
Sending notifications to Sean, per discussion in
https://github.com/ofiwg/libfabric/pull/5954. If the builds work after
this, we can think about setting up a generic list with OFA.

Signed-off-by: Raghu Raja <craghun@amazon.com>