### PR TITLE
Jenkins-CI: enabled spawn tests

### DIFF
--- a/contrib/intel/jenkins/Jenkinsfile
+++ b/contrib/intel/jenkins/Jenkinsfile
@@ -44,40 +44,17 @@ pipeline {
         
         stage ('build-shmem') {
             steps {
-              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
                 sh """
                 python3.7  contrib/intel/jenkins/build.py 'shmem' --ofi_build_mode='dbg'
                 echo 'shmem benchmarks built successfully'
                 """
-                }
               }
-          }
-  
-        stage ('build OMPI_bm') {
-              steps {
-              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
-                  sh """
-                  python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks' --ofi_build_mode='dbg'
-                  echo 'mpi benchmarks with ompi - built successfully'
-                 """
-                }
-              }
-          }
-    
-    stage('build IMPI_bm') {
-        steps {
-          withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
-                sh """
-                python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dbg'
-                echo 'mpi benchmarks with impi - built successfully'
-                """
             }
-          }
-      }  
-    
-    stage('build MPICH_bm') {
-        steps {
-          withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']) {
+        }
+        stage('build MPICH_bm') {
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
                 sh """
                 python3.7 contrib/intel/jenkins/build.py 'mpich_benchmarks' --ofi_build_mode='dbg'
                 echo "mpi benchmarks with mpich - built successfully"
@@ -85,7 +62,29 @@ pipeline {
               }
             }
         }
-   stage('parallel-tests') {
+        stage('build IMPI_bm') {
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
+                sh """
+                python3.7 contrib/intel/jenkins/build.py 'impi_benchmarks' --ofi_build_mode='dbg'
+                echo 'mpi benchmarks with impi - built successfully'
+                """
+              }
+            }
+        }  
+
+        stage ('build OMPI_bm') {
+            steps {
+              withEnv(['PATH+EXTRA=/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin']){
+                sh """
+                python3.7 contrib/intel/jenkins/build.py 'ompi_benchmarks' --ofi_build_mode='dbg'
+                echo 'mpi benchmarks with ompi - built successfully'
+                """
+              }
+            }
+        }
+    
+        stage('parallel-tests') {
             parallel { 
                  stage('eth-tcp-dbg') {
                     agent {node {label 'eth'}}

--- a/contrib/intel/jenkins/run.py
+++ b/contrib/intel/jenkins/run.py
@@ -75,7 +75,19 @@ def intel_mpi_benchmark(core, hosts, mpi, mode, util=None):
         print("skipping {} as execute condition fails"\
                     .format(imb_test.testname))
     print("----------------------------------------------------------------------------------------\n")
-    
+
+#mpich_test_suite
+def mpich_test_suite(core, hosts, mpi, mode, util=None):
+    mpich_tests = tests.MpichTestSuite(jobname=jbname,buildno=bno,\
+                  testname="MpichTestSuite",core_prov=core, fabric=fab,\
+                  mpitype=mpi, hosts=hosts, ofi_build_mode=mode, \
+                  util_prov=util)
+    if (mpich_tests.execute_condn == True and \
+        mpich_tests.mpi_gen_execute_condn == True):
+        print("Running mpich test suite: Spawn coll, comm, dt Tests for {}-{}-{}-{}".format(core, util, fab, mpi))
+        os.environ["MPITEST_RETURN_WITH_CODE"] = "1"
+        mpich_tests.execute_cmd("spawn")
+ 
 #mpi_stress benchmark tests
 def mpistress_benchmark(core, hosts, mpi, mode, util=None):
 

--- a/contrib/intel/jenkins/runtests.py
+++ b/contrib/intel/jenkins/runtests.py
@@ -50,6 +50,7 @@ if(args_core):
         run.fabtests(args_core, hosts, ofi_build_mode)
         run.shmemtest(args_core, hosts, ofi_build_mode)
         for mpi in mpilist:
+            run.mpich_test_suite(args_core, hosts, mpi, ofi_build_mode)
             run.intel_mpi_benchmark(args_core, hosts, mpi, ofi_build_mode)   
             run.mpistress_benchmark(args_core, hosts, mpi, ofi_build_mode)
             run.osu_benchmark(args_core, hosts, mpi, ofi_build_mode)  
@@ -58,10 +59,13 @@ if(args_core):
         run.fabtests(args_core, hosts, ofi_build_mode, util=args_util)
         run.shmemtest(args_core, hosts, ofi_build_mode, util=args_util)
         for mpi in mpilist:
+            run.mpich_test_suite(args_core, hosts, mpi, ofi_build_mode, \
+                                 util=args_util)
+
             run.intel_mpi_benchmark(args_core, hosts, mpi, ofi_build_mode, \
-                                        util=args_util,)
+                                    util=args_util)
             run.mpistress_benchmark(args_core, hosts, mpi, ofi_build_mode, \
-                                            util=args_util)
+                                    util=args_util)
             run.osu_benchmark(args_core, hosts, mpi, ofi_build_mode, \
                                              util=args_util)
 else:


### PR DESCRIPTION
build.py: added code to build mpich_test_suite.
tests.py: added class for mpich_suite.
runtests.py: added calls to run the spawn tests.
Note: Currently not enabled for psm2 provider due to errors.

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>