### PR TITLE
prov/rxm: Allow setting tcp defaults separate from verbs

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -129,7 +129,7 @@ extern size_t rxm_msg_rx_size;
 extern size_t rxm_cm_progress_interval;
 extern size_t rxm_cq_eq_fairness;
 extern int force_auto_progress;
-extern enum fi_wait_obj def_wait_obj;
+extern enum fi_wait_obj def_wait_obj, def_tcp_wait_obj;
 
 struct rxm_ep;
 

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -372,6 +372,19 @@ static void rxm_param_get_def_wait(void)
 		def_wait_obj = FI_WAIT_POLLFD;
 }
 
+static void rxm_init_infos(void)
+{
+	struct fi_info *info;
+
+	for (info = (struct fi_info *) rxm_util_prov.info; info;
+	     info = info->next) {
+		fi_param_get_size_t(&rxm_prov, "tx_size",
+				    &rxm_info.tx_attr->size);
+		fi_param_get_size_t(&rxm_prov, "rx_size",
+				    &rxm_info.rx_attr->size);
+	}
+}
+
 RXM_INI
 {
 	fi_param_define(&rxm_prov, "buffer_size", FI_PARAM_SIZE_T,
@@ -445,8 +458,7 @@ RXM_INI
 			"operations (e.g. fi_cq_sread).  Supported values "
 			"are: fd and pollfd (default: fd).");
 
-	fi_param_get_size_t(&rxm_prov, "tx_size", &rxm_info.tx_attr->size);
-	fi_param_get_size_t(&rxm_prov, "rx_size", &rxm_info.rx_attr->size);
+	rxm_init_infos();
 	fi_param_get_size_t(&rxm_prov, "msg_tx_size", &rxm_msg_tx_size);
 	fi_param_get_size_t(&rxm_prov, "msg_rx_size", &rxm_msg_rx_size);
 	if (fi_param_get_int(&rxm_prov, "cm_progress_interval",


### PR DESCRIPTION
This allows optimizing rxm over tcp separately from optimizing over verbs.