### PR TITLE
prov/verbs,rxm: Fix possible XRC SRQ close segfault and simplify code

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2286,6 +2286,9 @@ static int rxm_ep_close(struct fid *fid)
 		retv = ret;
 
 	rxm_ep_txrx_res_close(rxm_ep);
+	ret = rxm_ep_msg_res_close(rxm_ep);
+	if (ret)
+		retv = ret;
 
 	if (rxm_ep->msg_cq) {
 		ret = fi_close(&rxm_ep->msg_cq->fid);
@@ -2294,10 +2297,6 @@ static int rxm_ep_close(struct fid *fid)
 			retv = ret;
 		}
 	}
-
-	ret = rxm_ep_msg_res_close(rxm_ep);
-	if (ret)
-		retv = ret;
 
 	ofi_endpoint_close(&rxm_ep->util_ep);
 	fi_freeinfo(rxm_ep->rxm_info);

--- a/prov/verbs/src/verbs_cq.c
+++ b/prov/verbs/src/verbs_cq.c
@@ -490,25 +490,18 @@ static int vrb_cq_close(fid_t fid)
 	int ret;
 	struct vrb_cq *cq =
 		container_of(fid, struct vrb_cq, util_cq.cq_fid);
-	struct vrb_srq_ep *srq_ep;
-	struct dlist_entry *srq_ep_temp;
+
+	/* XRC SRQ directly reference the associated CQ,
+	 * make sure the SRQ is closed first. */
+	fastlock_acquire(&cq->xrc.srq_list_lock);
+	if (!dlist_empty(&cq->xrc.srq_list)) {
+		fastlock_release(&cq->xrc.srq_list_lock);
+		return -FI_EBUSY;
+	}
+	fastlock_release(&cq->xrc.srq_list_lock);
 
 	if (ofi_atomic_get32(&cq->nevents))
 		ibv_ack_cq_events(cq->cq, ofi_atomic_get32(&cq->nevents));
-
-	/* Since an RX CQ and SRX context can be destroyed in any order,
-	 * and the XRC SRQ references the RX CQ, we must destroy any
-	 * XRC SRQ using this CQ before destroying the CQ. */
-	fastlock_acquire(&cq->xrc.srq_list_lock);
-	dlist_foreach_container_safe(&cq->xrc.srq_list, struct vrb_srq_ep,
-				     srq_ep, xrc.srq_entry, srq_ep_temp) {
-		ret = vrb_xrc_close_srq(srq_ep);
-		if (ret) {
-			fastlock_release(&cq->xrc.srq_list_lock);
-			return -ret;
-		}
-	}
-	fastlock_release(&cq->xrc.srq_list_lock);
 
 	cq->util_cq.cq_fastlock_acquire(&cq->util_cq.cq_lock);
 	while (!slist_empty(&cq->saved_wc_list)) {

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1524,8 +1524,6 @@ int vrb_xrc_close_srq(struct vrb_srq_ep *srq_ep)
 	int ret;
 
 	assert(srq_ep->domain->flags & VRB_USE_XRC);
-	if (!srq_ep->xrc.cq || !srq_ep->srq)
-		return FI_SUCCESS;
 
 	ret = ibv_destroy_srq(srq_ep->srq);
 	if (ret) {
@@ -1533,7 +1531,6 @@ int vrb_xrc_close_srq(struct vrb_srq_ep *srq_ep)
 		return -ret;
 	}
 	srq_ep->srq = NULL;
-	srq_ep->xrc.cq = NULL;
 	dlist_remove(&srq_ep->xrc.srq_entry);
 	vrb_cleanup_prepost_bufs(srq_ep);
 
@@ -1544,17 +1541,14 @@ static int vrb_srq_close(fid_t fid)
 {
 	struct vrb_srq_ep *srq_ep = container_of(fid, struct vrb_srq_ep,
 						 ep_fid.fid);
-	struct vrb_cq *cq = srq_ep->xrc.cq;
 	int ret;
 
 	if (srq_ep->domain->flags & VRB_USE_XRC) {
-		if (cq) {
-			fastlock_acquire(&cq->xrc.srq_list_lock);
-			ret = vrb_xrc_close_srq(srq_ep);
-			fastlock_release(&cq->xrc.srq_list_lock);
-			if (ret)
-				goto err;
-		}
+		fastlock_acquire(&srq_ep->xrc.cq->xrc.srq_list_lock);
+		ret = vrb_xrc_close_srq(srq_ep);
+		fastlock_release(&srq_ep->xrc.cq->xrc.srq_list_lock);
+		if (ret)
+			goto err;
 		fastlock_destroy(&srq_ep->xrc.prepost_lock);
 	} else {
 		ret = ibv_destroy_srq(srq_ep->srq);

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1544,13 +1544,14 @@ static int vrb_srq_close(fid_t fid)
 {
 	struct vrb_srq_ep *srq_ep = container_of(fid, struct vrb_srq_ep,
 						 ep_fid.fid);
+	struct vrb_cq *cq = srq_ep->xrc.cq;
 	int ret;
 
 	if (srq_ep->domain->flags & VRB_USE_XRC) {
-		if (srq_ep->xrc.cq) {
-			fastlock_acquire(&srq_ep->xrc.cq->xrc.srq_list_lock);
+		if (cq) {
+			fastlock_acquire(&cq->xrc.srq_list_lock);
 			ret = vrb_xrc_close_srq(srq_ep);
-			fastlock_release(&srq_ep->xrc.cq->xrc.srq_list_lock);
+			fastlock_release(&cq->xrc.srq_list_lock);
 			if (ret)
 				goto err;
 		}


### PR DESCRIPTION
The XRC SRQ and associated CQ can be closed in any order.
If the SRQ were to be closed first, then a temporary
variable is needed to release the CQ SRQ list lock.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>