### PR TITLE
prov/rxd: fi_add_table expansion

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -199,7 +199,7 @@ struct rxd_ep {
 	size_t tx_msg_avail;
 	size_t rx_msg_avail;
 	size_t tx_rma_avail;
-	size_t rx_rma_avail;
+	size_t rx_rma_avail;	
 
 	struct rxd_buf_pool tx_pkt_pool;
 	struct rxd_buf_pool rx_pkt_pool;
@@ -216,7 +216,8 @@ struct rxd_ep {
 	struct dlist_entry rts_sent_list;
 	struct dlist_entry ctrl_pkts;
 
-	struct rxd_peer peers[];
+	size_t max_peers;
+	struct rxd_peer *peers;
 };
 
 static inline struct rxd_domain *rxd_ep_domain(struct rxd_ep *ep)
@@ -420,6 +421,8 @@ int rxd_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
 			  fi_addr_t *dg_fiaddr, uint64_t flags,
 			  void *context);
+/* EP sub functions*/
+void rxd_ep_peers_grow(struct rxd_ep *ep, fi_addr_t rxd_addr);
 
 /* Pkt resource functions */
 int rxd_ep_post_buf(struct rxd_ep *ep);

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -156,7 +156,7 @@ struct rxd_av {
 
 	int dg_av_used;
 	size_t dg_addrlen;
-
+	size_t max_peers;
 	fi_addr_t *fi_addr_table;
 	struct rxd_addr *rxd_addr_table;
 };

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -167,6 +167,8 @@ int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
 			  fi_addr_t *rxd_addr, uint64_t flags,
 			  void *context)
 {
+	struct dlist_entry *av_entry;
+	struct rxd_ep *rxd_ep;
 	fi_addr_t dg_addr;
 	int ret;
 
@@ -176,7 +178,11 @@ int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
 		return -FI_EINVAL;
 
 	*rxd_addr = rxd_set_rxd_addr(av, dg_addr);
-
+	dlist_foreach(&av->util_av.ep_list, av_entry) {
+		rxd_ep =  container_of(av_entry, struct rxd_ep,
+				       util_ep.av_entry);
+		rxd_ep_peers_grow(rxd_ep, *rxd_addr);
+	}
 	ret = ofi_rbmap_insert(&av->rbmap, (void *) addr, (void *) (*rxd_addr),
 			       NULL);
 	if (ret) {

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -437,7 +437,7 @@ static void rxd_handle_rts(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 		if (ret)
 			return;
 	}
-
+	
 	if (rxd_send_cts(ep, pkt, rxd_addr)) {
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
 			"error posting CTS\n");


### PR DESCRIPTION
rxd_av.c: modifed rxd_set_fiaddr function code to dynamically
double the size of the fi_addr_table whenever the
current limit is reached.

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>