### PR TITLE
hmem: Support CUDA cuPointerGetAttribute

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -49,6 +49,8 @@ cudaError_t ofi_cudaMemcpy(void* dst, const void* src, size_t count,
 			   enum cudaMemcpyKind kind);
 const char *ofi_cudaGetErrorName(cudaError_t error);
 const char *ofi_cudaGetErrorString(cudaError_t error);
+CUresult ofi_cuPointerGetAttribute(void *data, CUpointer_attribute attribute,
+				   CUdeviceptr ptr);
 
 #endif /* HAVE_LIBCUDA */
 


### PR DESCRIPTION
cuPointerGetAttribute is required for a CUDA MR cache implementation.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>