### PR TITLE
hmem: Support querying HMEM iface type

### DIFF
--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -38,6 +38,7 @@
 #endif
 
 #include <rdma/fi_domain.h>
+#include <stdbool.h>
 
 #ifdef HAVE_LIBCUDA
 
@@ -87,5 +88,6 @@ ssize_t ofi_copy_to_hmem_iov(const struct iovec *hmem_iov,
 
 void ofi_hmem_init(void);
 void ofi_hmem_cleanup(void);
+enum fi_hmem_iface ofi_get_hmem_iface(const void *addr);
 
 #endif /* _OFI_HMEM_H_ */

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -59,6 +59,7 @@ int cuda_copy_to_dev(void *dev, const void *host, size_t size);
 int cuda_copy_from_dev(void *host, const void *dev, size_t size);
 int cuda_hmem_init(void);
 int cuda_hmem_cleanup(void);
+bool cuda_is_addr_valid(const void *addr);
 
 static inline int ofi_memcpy(void *dest, const void *src, size_t size)
 {

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -61,6 +61,7 @@ static struct ofi_hmem_ops hmem_ops[] = {
 		.cleanup = cuda_hmem_cleanup,
 		.copy_to_hmem = cuda_copy_to_dev,
 		.copy_from_hmem = cuda_copy_from_dev,
+		.is_addr_valid = cuda_is_addr_valid,
 	},
 };
 

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -44,6 +44,7 @@ struct ofi_hmem_ops {
 	int (*cleanup)(void);
 	int (*copy_to_hmem)(void *dest, const void *src, size_t size);
 	int (*copy_from_hmem)(void *dest, const void *src, size_t size);
+	bool (*is_addr_valid)(const void *addr);
 };
 
 static struct ofi_hmem_ops hmem_ops[] = {
@@ -160,4 +161,22 @@ void ofi_hmem_cleanup(void)
 		if (hmem_ops[iface].initialized)
 			hmem_ops[iface].cleanup();
 	}
+}
+
+enum fi_hmem_iface ofi_get_hmem_iface(const void *addr)
+{
+	enum fi_hmem_iface iface;
+
+	/* Since a is_addr_valid function is not implemented for FI_HMEM_SYSTEM,
+	 * HMEM iface is skipped. In addition, if no other HMEM ifaces claim the
+	 * address as valid, it is assumed the address is FI_HMEM_SYSTEM.
+	 */
+	for (iface = ARRAY_SIZE(hmem_ops) - 1; iface > FI_HMEM_SYSTEM;
+	     iface--) {
+		if (hmem_ops[iface].initialized &&
+		    hmem_ops[iface].is_addr_valid(addr))
+			return iface;
+	}
+
+	return FI_HMEM_SYSTEM;
 }


### PR DESCRIPTION
ofi_get_hmem_iface() will return the fi_hmem_iface type of an address.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>

Needs https://github.com/ofiwg/libfabric/pull/5976