### PR TITLE
Cuda mr cache

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,6 +71,7 @@ common_srcs =				\
 	prov/util/src/util_mem_monitor.c\
 	prov/util/src/util_mem_hooks.c	\
 	prov/util/src/util_mr_cache.c	\
+	prov/util/src/cuda_mem_monitor.c \
 	prov/util/src/util_coll.c
 
 

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -155,6 +155,7 @@ void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
 			     union ofi_mr_hmem_info *hmem_info);
 
 extern struct ofi_mem_monitor *default_monitor;
+extern struct ofi_mem_monitor *default_cuda_monitor;
 
 /*
  * Userfault fd memory monitor
@@ -240,6 +241,7 @@ struct ofi_mr_cache_params {
 	size_t				max_cnt;
 	size_t				max_size;
 	char *				monitor;
+	int				cuda_monitor_enabled;
 };
 
 extern struct ofi_mr_cache_params	cache_params;

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -108,6 +108,10 @@ extern pthread_mutex_t mm_lock;
 
 struct ofi_mr_cache;
 
+union ofi_mr_hmem_info {
+	uint64_t reserved;
+};
+
 struct ofi_mem_monitor {
 	struct dlist_entry		list;
 	enum fi_hmem_iface		iface;
@@ -117,9 +121,11 @@ struct ofi_mem_monitor {
 	int (*start)(struct ofi_mem_monitor *monitor);
 	void (*stop)(struct ofi_mem_monitor *monitor);
 	int (*subscribe)(struct ofi_mem_monitor *notifier,
-			 const void *addr, size_t len);
+			 const void *addr, size_t len,
+			 union ofi_mr_hmem_info *hmem_info);
 	void (*unsubscribe)(struct ofi_mem_monitor *notifier,
-			    const void *addr, size_t len);
+			    const void *addr, size_t len,
+			    union ofi_mr_hmem_info *hmem_info);
 };
 
 void ofi_monitor_init(struct ofi_mem_monitor *monitor);
@@ -133,9 +139,11 @@ void ofi_monitor_notify(struct ofi_mem_monitor *monitor,
 			const void *addr, size_t len);
 
 int ofi_monitor_subscribe(struct ofi_mem_monitor *monitor,
-			  const void *addr, size_t len);
+			  const void *addr, size_t len,
+			  union ofi_mr_hmem_info *hmem_info);
 void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
-			     const void *addr, size_t len);
+			     const void *addr, size_t len,
+			     union ofi_mr_hmem_info *hmem_info);
 
 extern struct ofi_mem_monitor *default_monitor;
 
@@ -232,6 +240,7 @@ struct ofi_mr_entry {
 	unsigned int			subscribed:1;
 	int				use_cnt;
 	struct dlist_entry		list_entry;
+	union ofi_mr_hmem_info		hmem_info;
 	uint8_t				data[];
 };
 

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -109,7 +109,7 @@ extern pthread_mutex_t mm_lock;
 struct ofi_mr_cache;
 
 union ofi_mr_hmem_info {
-	uint64_t reserved;
+	uint64_t cuda_id;
 };
 
 struct ofi_mem_monitor {
@@ -177,6 +177,7 @@ struct ofi_memhooks {
 
 extern struct ofi_mem_monitor *memhooks_monitor;
 
+extern struct ofi_mem_monitor *cuda_monitor;
 
 /*
  * Used to store registered memory regions into a lookup map.  This

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -126,6 +126,15 @@ struct ofi_mem_monitor {
 	void (*unsubscribe)(struct ofi_mem_monitor *notifier,
 			    const void *addr, size_t len,
 			    union ofi_mr_hmem_info *hmem_info);
+
+	/* Valid is a memory monitor operation used to query a memory monitor to
+	 * see if the memory monitor's view of the buffer is still valid. If the
+	 * memory monitor's view of the buffer is no longer valid (e.g. the
+	 * pages behind a given virtual address have changed), the buffer needs
+	 * to be re-registered.
+	 */
+	bool (*valid)(struct ofi_mem_monitor *notifier, const void *addr,
+		      size_t len, union ofi_mr_hmem_info *hmem_info);
 };
 
 void ofi_monitor_init(struct ofi_mem_monitor *monitor);

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -568,6 +568,7 @@
     <ClCompile Include="prov\util\src\util_mem_monitor.c" />
     <ClCompile Include="prov\util\src\util_mem_hooks.c" />
     <ClCompile Include="prov\util\src\util_mr_cache.c" />
+    <ClCompile Include="prov\util\src\cuda_mem_monitor.c" />
     <ClCompile Include="src\common.c" />
     <ClCompile Include="src\enosys.c">
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug-ICC|x64'">4127;869</DisableSpecificWarnings>

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -192,6 +192,9 @@
     <ClCompile Include="prov\util\src\util_mr_cache.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
+    <ClCompile Include="prov\util\src\cuda_mem_monitor.c">
+      <Filter>Source Files\prov\util</Filter>
+    </ClCompile>
     <ClCompile Include="src\windows\osd.c">
       <Filter>Source Files\src\windows</Filter>
     </ClCompile>

--- a/prov/util/src/cuda_mem_monitor.c
+++ b/prov/util/src/cuda_mem_monitor.c
@@ -1,0 +1,151 @@
+/*
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "ofi_mr.h"
+
+#ifdef HAVE_LIBCUDA
+
+#include "ofi_hmem.h"
+
+static int cuda_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
+			     size_t len, union ofi_mr_hmem_info *hmem_info)
+{
+	CUresult ret;
+
+	ret = ofi_cuPointerGetAttribute(&hmem_info->cuda_id,
+					CU_POINTER_ATTRIBUTE_BUFFER_ID,
+					(CUdeviceptr)addr);
+	if (ret == CUDA_SUCCESS) {
+		FI_DBG(&core_prov, FI_LOG_MR,
+		       "Assigned CUDA buffer ID %lu to buffer %p\n",
+		       hmem_info->cuda_id, addr);
+		return FI_SUCCESS;
+	}
+
+	FI_WARN(&core_prov, FI_LOG_MR,
+		"Failed to get CUDA buffer ID for buffer %p len %lu\n"
+		"cuPointerGetAttribute() failed: %s:%s\n", addr, len,
+		ofi_cudaGetErrorName(ret), ofi_cudaGetErrorString(ret));
+
+	return -FI_EFAULT;
+}
+
+static void cuda_mm_unsubscribe(struct ofi_mem_monitor *monitor,
+				const void *addr, size_t len,
+				union ofi_mr_hmem_info *hmem_info)
+{
+	/* no-op */
+}
+
+static bool cuda_mm_valid(struct ofi_mem_monitor *monitor,
+			  const void *addr, size_t len,
+			  union ofi_mr_hmem_info *hmem_info)
+{
+	uint64_t id;
+	CUresult ret;
+
+	/* CUDA buffer IDs are associated for each CUDA monitor entry. If the
+	 * device pages backing the device virtual address change, a different
+	 * buffer ID is associated with this mapping.
+	 */
+	ret = ofi_cuPointerGetAttribute(&id, CU_POINTER_ATTRIBUTE_BUFFER_ID,
+					(CUdeviceptr)addr);
+	if (ret == CUDA_SUCCESS && hmem_info->cuda_id == id) {
+		FI_DBG(&core_prov, FI_LOG_MR,
+		       "CUDA buffer ID %lu still valid for buffer %p\n",
+		       hmem_info->cuda_id, addr);
+		return true;
+	} else if (ret == CUDA_SUCCESS && hmem_info->cuda_id != id) {
+		FI_DBG(&core_prov, FI_LOG_MR,
+		       "CUDA buffer ID %lu invalid for buffer %p\n",
+		       hmem_info->cuda_id, addr);
+	} else {
+		FI_WARN(&core_prov, FI_LOG_MR,
+			"Failed to get CUDA buffer ID for buffer %p len %lu\n"
+			"cuPointerGetAttribute() failed: %s:%s\n", addr, len,
+			ofi_cudaGetErrorName(ret), ofi_cudaGetErrorString(ret));
+	}
+
+	return false;
+}
+
+static int cuda_monitor_start(struct ofi_mem_monitor *monitor)
+{
+	/* no-op */
+	return FI_SUCCESS;
+}
+
+#else
+
+static int cuda_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
+			     size_t len, union ofi_mr_hmem_info *hmem_info)
+{
+	return -FI_ENOSYS;
+}
+
+static void cuda_mm_unsubscribe(struct ofi_mem_monitor *monitor,
+				const void *addr, size_t len,
+				union ofi_mr_hmem_info *hmem_info)
+{
+}
+
+static bool cuda_mm_valid(struct ofi_mem_monitor *monitor,
+			  const void *addr, size_t len,
+			  union ofi_mr_hmem_info *hmem_info)
+{
+	return false;
+}
+
+static int cuda_monitor_start(struct ofi_mem_monitor *monitor)
+{
+	return -FI_ENOSYS;
+}
+
+#endif /* HAVE_LIBCUDA */
+
+void cuda_monitor_stop(struct ofi_mem_monitor *monitor)
+{
+	/* no-op */
+}
+
+static struct ofi_mem_monitor cuda_mm = {
+	.iface = FI_HMEM_CUDA,
+	.init = ofi_monitor_init,
+	.cleanup = ofi_monitor_cleanup,
+	.start = cuda_monitor_start,
+	.stop = cuda_monitor_stop,
+	.subscribe = cuda_mm_subscribe,
+	.unsubscribe = cuda_mm_unsubscribe,
+	.valid = cuda_mm_valid,
+};
+
+struct ofi_mem_monitor *cuda_monitor = &cuda_mm;

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -466,14 +466,16 @@ static int ofi_intercept_brk(const void *brkaddr)
 }
 
 static int ofi_memhooks_subscribe(struct ofi_mem_monitor *monitor,
-				 const void *addr, size_t len)
+				  const void *addr, size_t len,
+				  union ofi_mr_hmem_info *hmem_info)
 {
 	/* no-op */
 	return FI_SUCCESS;
 }
 
 static void ofi_memhooks_unsubscribe(struct ofi_mem_monitor *monitor,
-				    const void *addr, size_t len)
+				     const void *addr, size_t len,
+				     union ofi_mr_hmem_info *hmem_info)
 {
 	/* no-op */
 }

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -480,6 +480,14 @@ static void ofi_memhooks_unsubscribe(struct ofi_mem_monitor *monitor,
 	/* no-op */
 }
 
+static bool ofi_memhooks_valid(struct ofi_mem_monitor *monitor,
+			       const void *addr, size_t len,
+			       union ofi_mr_hmem_info *hmem_info)
+{
+	/* no-op */
+	return true;
+}
+
 static int ofi_memhooks_start(struct ofi_mem_monitor *monitor)
 {
 	int i, ret;
@@ -489,6 +497,7 @@ static int ofi_memhooks_start(struct ofi_mem_monitor *monitor)
 
 	memhooks_monitor->subscribe = ofi_memhooks_subscribe;
 	memhooks_monitor->unsubscribe = ofi_memhooks_unsubscribe;
+	memhooks_monitor->valid = ofi_memhooks_valid;
 	dlist_init(&memhooks.intercept_list);
 
 	for (i = 0; i < OFI_INTERCEPT_MAX; ++i)

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -231,14 +231,15 @@ void ofi_monitor_notify(struct ofi_mem_monitor *monitor,
 }
 
 int ofi_monitor_subscribe(struct ofi_mem_monitor *monitor,
-			  const void *addr, size_t len)
+			  const void *addr, size_t len,
+			  union ofi_mr_hmem_info *hmem_info)
 {
 	int ret;
 
 	FI_DBG(&core_prov, FI_LOG_MR,
 	       "subscribing addr=%p len=%zu\n", addr, len);
 
-	ret = monitor->subscribe(monitor, addr, len);
+	ret = monitor->subscribe(monitor, addr, len, hmem_info);
 	if (OFI_UNLIKELY(ret)) {
 		FI_WARN(&core_prov, FI_LOG_MR,
 			"Failed (ret = %d) to monitor addr=%p len=%zu\n",
@@ -248,11 +249,12 @@ int ofi_monitor_subscribe(struct ofi_mem_monitor *monitor,
 }
 
 void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
-			     const void *addr, size_t len)
+			     const void *addr, size_t len,
+			     union ofi_mr_hmem_info *hmem_info)
 {
 	FI_DBG(&core_prov, FI_LOG_MR,
 	       "unsubscribing addr=%p len=%zu\n", addr, len);
-	monitor->unsubscribe(monitor, addr, len);
+	monitor->unsubscribe(monitor, addr, len, hmem_info);
 }
 
 #if HAVE_UFFD_MONITOR
@@ -290,7 +292,7 @@ static void *ofi_uffd_handler(void *arg)
 			ofi_monitor_unsubscribe(&uffd.monitor,
 				(void *) (uintptr_t) msg.arg.remove.start,
 				(size_t) (msg.arg.remove.end -
-					  msg.arg.remove.start));
+					  msg.arg.remove.start), NULL);
 			/* fall through */
 		case UFFD_EVENT_UNMAP:
 			ofi_monitor_notify(&uffd.monitor,
@@ -334,7 +336,8 @@ static int ofi_uffd_register(const void *addr, size_t len, size_t page_size)
 }
 
 static int ofi_uffd_subscribe(struct ofi_mem_monitor *monitor,
-			      const void *addr, size_t len)
+			      const void *addr, size_t len,
+			      union ofi_mr_hmem_info *hmem_info)
 {
 	int i;
 
@@ -367,7 +370,8 @@ static int ofi_uffd_unregister(const void *addr, size_t len, size_t page_size)
 
 /* May be called from mr cache notifier callback */
 static void ofi_uffd_unsubscribe(struct ofi_mem_monitor *monitor,
-				 const void *addr, size_t len)
+				 const void *addr, size_t len,
+				 union ofi_mr_hmem_info *hmem_info)
 {
 	int i;
 

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -51,6 +51,7 @@ static struct ofi_uffd uffd = {
 struct ofi_mem_monitor *uffd_monitor = &uffd.monitor;
 
 struct ofi_mem_monitor *default_monitor;
+struct ofi_mem_monitor *default_cuda_monitor;
 
 static size_t ofi_default_cache_size(void)
 {
@@ -86,6 +87,7 @@ void ofi_monitors_init(void)
 {
 	uffd_monitor->init(uffd_monitor);
 	memhooks_monitor->init(memhooks_monitor);
+	cuda_monitor->init(cuda_monitor);
 
 #if HAVE_MEMHOOKS_MONITOR
         default_monitor = memhooks_monitor;
@@ -116,10 +118,15 @@ void ofi_monitors_init(void)
 			" and free calls.  Userfaultfd is the default if"
 			" available on the system. 'disabled' option disables"
 			" memory caching.");
+	fi_param_define(NULL, "mr_cuda_cache_monitor_enabled", FI_PARAM_BOOL,
+			"Enable or disable the CUDA cache memory monitor."
+			"Monitor is enabled by default.");
 
 	fi_param_get_size_t(NULL, "mr_cache_max_size", &cache_params.max_size);
 	fi_param_get_size_t(NULL, "mr_cache_max_count", &cache_params.max_cnt);
 	fi_param_get_str(NULL, "mr_cache_monitor", &cache_params.monitor);
+	fi_param_get_bool(NULL, "mr_cuda_cache_monitor_enabled",
+			  &cache_params.cuda_monitor_enabled);
 
 	if (!cache_params.max_size)
 		cache_params.max_size = ofi_default_cache_size();
@@ -143,12 +150,18 @@ void ofi_monitors_init(void)
 			default_monitor = NULL;
 		}
 	}
+
+	if (cache_params.cuda_monitor_enabled)
+		default_cuda_monitor = cuda_monitor;
+	else
+		default_cuda_monitor = NULL;
 }
 
 void ofi_monitors_cleanup(void)
 {
 	uffd_monitor->cleanup(uffd_monitor);
 	memhooks_monitor->cleanup(memhooks_monitor);
+	cuda_monitor->cleanup(cuda_monitor);
 }
 
 /* Monitors array must be of size OFI_HMEM_MAX. */

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -382,6 +382,13 @@ static void ofi_uffd_unsubscribe(struct ofi_mem_monitor *monitor,
 	}
 }
 
+static bool ofi_uffd_valid(struct ofi_mem_monitor *monitor, const void *addr,
+			   size_t len, union ofi_mr_hmem_info *hmem_info)
+{
+	/* no-op */
+	return true;
+}
+
 static int ofi_uffd_start(struct ofi_mem_monitor *monitor)
 {
 	struct uffdio_api api;
@@ -389,6 +396,7 @@ static int ofi_uffd_start(struct ofi_mem_monitor *monitor)
 
 	uffd.monitor.subscribe = ofi_uffd_subscribe;
 	uffd.monitor.unsubscribe = ofi_uffd_unsubscribe;
+	uffd.monitor.valid = ofi_uffd_valid;
 
 	if (!num_page_sizes)
 		return -FI_ENODATA;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -45,6 +45,7 @@
 
 struct ofi_mr_cache_params cache_params = {
 	.max_cnt = 1024,
+	.cuda_monitor_enabled = true,
 };
 
 static int util_mr_find_within(struct ofi_rbmap *map, void *key, void *data)

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -323,7 +323,13 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 
 		cache->search_cnt++;
 		*entry = cache->storage.find(&cache->storage, &info);
-		if (*entry && ofi_iov_within(attr->mr_iov, &(*entry)->info.iov))
+
+		if (*entry &&
+		    ofi_iov_within(attr->mr_iov, &(*entry)->info.iov) &&
+		    monitor->valid(monitor,
+				   (const void *)(*entry)->info.iov.iov_base,
+				   (*entry)->info.iov.iov_len,
+				   &(*entry)->hmem_info))
 			goto hit;
 
 		/* Purge regions that overlap with new region */

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -270,7 +270,8 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct ofi_mr_info *info,
 		cache->cached_size += info->iov.iov_len;
 
 		ret = ofi_monitor_subscribe(monitor, info->iov.iov_base,
-					    info->iov.iov_len);
+					    info->iov.iov_len,
+					    &(*entry)->hmem_info);
 		if (ret) {
 			util_mr_uncache_entry_storage(cache, *entry);
 			cache->uncached_cnt++;


### PR DESCRIPTION
PR to enable CUDA MR cache. Consists of two components:
~~1. Update MR cache to support multiple monitors.~~
2. Define CUDA memory monitor.

Needs ~~https://github.com/ofiwg/libfabric/pull/5976~~, https://github.com/ofiwg/libfabric/pull/6001