### PR TITLE
core / rxm: Pass base fi_info to getinfo callbacks to adjust core hints

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -936,7 +936,9 @@ typedef int (*ofi_alter_info_t)(uint32_t version, const struct fi_info *src_info
 
 int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 		      uint64_t flags, const struct util_prov *util_prov,
-		      const struct fi_info *util_hints, ofi_alter_info_t info_to_core,
+		      const struct fi_info *util_hints,
+		      const struct fi_info *base_attr,
+		      ofi_alter_info_t info_to_core,
 		      struct fi_info **core_info);
 int ofix_getinfo(uint32_t version, const char *node, const char *service,
 		 uint64_t flags, const struct util_prov *util_prov,

--- a/prov/rstream/src/rstream_domain.c
+++ b/prov/rstream/src/rstream_domain.c
@@ -98,7 +98,7 @@ int rstream_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		util_fabric.fabric_fid);
 
 	ret = ofi_get_core_info(FI_VERSION(1, 8), NULL, NULL, 0,
-		&rstream_util_prov, info, rstream_info_to_core, &cinfo);
+		&rstream_util_prov, info, NULL, rstream_info_to_core, &cinfo);
 	if (ret)
 		goto err1;
 

--- a/prov/rxd/src/rxd_domain.c
+++ b/prov/rxd/src/rxd_domain.c
@@ -114,7 +114,7 @@ int rxd_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		return -FI_ENOMEM;
 
 	ret = ofi_get_core_info(fabric->api_version, NULL, NULL,
-				0, &rxd_util_prov, info,
+				0, &rxd_util_prov, info, NULL,
 				rxd_info_to_core, &dg_info);
 	if (ret)
 		goto err1;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1177,7 +1177,7 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err1;
 
 	ret = ofi_get_core_info(rxd_domain->util_domain.fabric->fabric_fid.api_version,
-				NULL, NULL, 0, &rxd_util_prov, info,
+				NULL, NULL, 0, &rxd_util_prov, info, NULL,
 				rxd_info_to_core, &dg_info);
 	if (ret)
 		goto err2;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -707,8 +707,6 @@ struct rxm_conn {
 };
 
 extern struct fi_provider rxm_prov;
-extern struct fi_info rxm_info;
-extern struct fi_info rxm_info_coll;
 extern struct fi_fabric_attr rxm_fabric_attr;
 extern struct fi_domain_attr rxm_domain_attr;
 extern struct fi_tx_attr rxm_tx_attr;

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -38,7 +38,6 @@
 		     FI_MULTI_RECV)
 #define RXM_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM)
 
-// TODO have a separate "check info" against which app hints would be checked.
 
 /* Since we are a layering provider, the attributes for which we rely on the
  * core provider are set to full capability. This ensures that ofix_getinfo
@@ -99,7 +98,8 @@ struct fi_domain_attr rxm_domain_attr = {
 	.av_type = FI_AV_UNSPEC,
 	/* Advertise support for FI_MR_BASIC so that ofi_check_info call
 	 * doesn't fail at RxM level. If an app requires FI_MR_BASIC, it
-	 * would be passed down to core provider. */
+	 * would be passed down to core provider.
+	 */
 	.mr_mode = FI_MR_BASIC | FI_MR_SCALABLE,
 	.cq_data_size = sizeof_field(struct ofi_op_hdr, data),
 	.cq_cnt = (1 << 16),
@@ -115,7 +115,17 @@ struct fi_fabric_attr rxm_fabric_attr = {
 	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
-struct fi_info rxm_info_coll = {
+struct fi_fabric_attr rxm_verbs_fabric_attr = {
+	.prov_version = OFI_VERSION_DEF_PROV,
+	.prov_name = "verbs",
+};
+
+struct fi_fabric_attr rxm_tcp_fabric_attr = {
+	.prov_version = OFI_VERSION_DEF_PROV,
+	.prov_name = "tcp",
+};
+
+struct fi_info rxm_coll_info = {
 	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS | FI_COLLECTIVE,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxm_tx_attr,
@@ -125,7 +135,7 @@ struct fi_info rxm_info_coll = {
 	.fabric_attr = &rxm_fabric_attr
 };
 
-struct fi_info rxm_info = {
+struct fi_info rxm_base_info = {
 	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxm_tx_attr,
@@ -133,10 +143,33 @@ struct fi_info rxm_info = {
 	.ep_attr = &rxm_ep_attr,
 	.domain_attr = &rxm_domain_attr,
 	.fabric_attr = &rxm_fabric_attr,
-	.next = &rxm_info_coll,
+	.next = &rxm_coll_info,
+};
+
+struct fi_info rxm_tcp_info = {
+	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS,
+	.addr_format = FI_SOCKADDR,
+	.tx_attr = &rxm_tx_attr,
+	.rx_attr = &rxm_rx_attr,
+	.ep_attr = &rxm_ep_attr,
+	.domain_attr = &rxm_domain_attr,
+	.fabric_attr = &rxm_tcp_fabric_attr,
+	.next = &rxm_base_info,
+};
+
+struct fi_info rxm_verbs_info = {
+	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS,
+	.addr_format = FI_SOCKADDR,
+	.tx_attr = &rxm_tx_attr,
+	.rx_attr = &rxm_rx_attr,
+	.ep_attr = &rxm_ep_attr,
+	.domain_attr = &rxm_domain_attr,
+	.fabric_attr = &rxm_verbs_fabric_attr,
+	.next = &rxm_tcp_info,
 };
 
 struct util_prov rxm_util_prov = {
 	.prov = &rxm_prov,
+	.info = &rxm_verbs_info,
 	.flags = 0,
 };

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -447,7 +447,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	rxm_fabric = container_of(fabric, struct rxm_fabric, util_fabric.fabric_fid);
 
 	ret = ofi_get_core_info(fabric->api_version, NULL, NULL, 0, &rxm_util_prov,
-				info, rxm_info_to_core, &msg_info);
+				info, NULL, rxm_info_to_core, &msg_info);
 	if (ret)
 		goto err1;
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2680,7 +2680,7 @@ static int rxm_ep_msg_res_open(struct rxm_ep *rxm_ep)
 				  util_domain);
  	ret = ofi_get_core_info(rxm_ep->util_ep.domain->fabric->fabric_fid.api_version,
 				NULL, NULL, 0, &rxm_util_prov, rxm_ep->rxm_info,
-				rxm_info_to_core, &rxm_ep->msg_info);
+				NULL, rxm_info_to_core, &rxm_ep->msg_info);
 	if (ret)
 		return ret;
 

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -126,7 +126,10 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 	}
 
 	core_info->ep_attr->type = FI_EP_MSG;
-	if (!fi_param_get_bool(&rxm_prov, "use_srx", &use_srx) && use_srx) {
+
+	fi_param_get_bool(&rxm_prov, "use_srx", &use_srx);
+	if (use_srx || (base_info && base_info->fabric_attr->prov_name &&
+	    !strcmp(base_info->fabric_attr->prov_name, "tcp"))) {
 		FI_DBG(&rxm_prov, FI_LOG_FABRIC,
 		       "Requesting shared receive context from core provider\n");
 		core_info->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -309,8 +309,11 @@ int ofix_getinfo(uint32_t version, const char *node, const char *service,
 		ret = ofi_get_core_info(version, node, service, flags,
 					util_prov, hints, base_info,
 					info_to_core, &core_info);
-		if (ret)
-			return ret;
+		if (ret) {
+			if (ret == -FI_ENODATA)
+				continue;
+			break;
+		}
 
 		for (cur = core_info; cur; cur = cur->next) {
 			ret = ofi_info_to_util(version, util_prov->prov, cur,

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -151,6 +151,27 @@ static int ofi_dup_addr(const struct fi_info *info, struct fi_info *dup)
 	return 0;
 }
 
+static int ofi_set_prov_name(const struct fi_provider *prov,
+			     const struct fi_fabric_attr *util_hints,
+			     const struct fi_info *base_attr,
+			     struct fi_fabric_attr *core_hints)
+{
+	if (util_hints->prov_name) {
+		core_hints->prov_name = strdup(util_hints->prov_name);
+		if (!core_hints->prov_name)
+			return -FI_ENOMEM;
+	} else if (base_attr && base_attr->fabric_attr &&
+		   base_attr->fabric_attr->prov_name) {
+		core_hints->prov_name = strdup(base_attr->fabric_attr->
+					       prov_name);
+		if (!core_hints->prov_name)
+			return -FI_ENOMEM;
+	}
+
+	return core_hints->prov_name ?
+	       ofi_exclude_prov_name(&core_hints->prov_name, prov->name) : 0;
+}
+
 static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 			    const struct fi_info *util_hints,
 			    const struct fi_info *base_attr,
@@ -182,20 +203,10 @@ static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 			}
 		}
 
-		if (util_hints->fabric_attr->prov_name) {
-			(*core_hints)->fabric_attr->prov_name =
-				strdup(util_hints->fabric_attr->prov_name);
-			if (!(*core_hints)->fabric_attr->prov_name) {
-				FI_WARN(prov, FI_LOG_FABRIC,
-					"Unable to alloc prov name\n");
-				goto err;
-			}
-			ret = ofi_exclude_prov_name(
-					&(*core_hints)->fabric_attr->prov_name,
-					prov->name);
-			if (ret)
-				goto err;
-		}
+		ret = ofi_set_prov_name(prov, util_hints->fabric_attr,
+					base_attr, (*core_hints)->fabric_attr);
+		if (ret)
+			goto err;
 	}
 
 	if (util_hints->domain_attr && util_hints->domain_attr->name) {
@@ -380,7 +391,18 @@ int ofi_check_fabric_attr(const struct fi_provider *prov,
 			  const struct fi_fabric_attr *prov_attr,
 			  const struct fi_fabric_attr *user_attr)
 {
-	/* Provider names are checked by the framework */
+	/* Provider names are properly checked by the framework.
+	 * Here we only apply a simple filter.  If the util provider has
+	 * supplied a core provider name, verify that it is also in the
+	 * user's hints, if one is specified.
+	 */
+	if (prov_attr->prov_name && user_attr->prov_name &&
+	    !strcasestr(user_attr->prov_name, prov_attr->prov_name)) {
+		FI_INFO(prov, FI_LOG_CORE,
+			"Requesting provider %s, skipping %s\n",
+			prov_attr->prov_name, user_attr->prov_name);
+		return -FI_ENODATA;
+	}
 
 	if (user_attr->prov_version > prov_attr->prov_version) {
 		FI_INFO(prov, FI_LOG_CORE, "Unsupported provider version\n");

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -152,7 +152,7 @@ static int ofi_dup_addr(const struct fi_info *info, struct fi_info *dup)
 }
 
 static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
-			    const struct fi_info *util_info,
+			    const struct fi_info *util_hints,
 			    ofi_alter_info_t info_to_core,
 			    struct fi_info **core_hints)
 {
@@ -161,19 +161,19 @@ static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 	if (!(*core_hints = fi_allocinfo()))
 		return -FI_ENOMEM;
 
-	if (info_to_core(version, util_info, NULL, *core_hints))
+	if (info_to_core(version, util_hints, NULL, *core_hints))
 		goto err;
 
-	if (!util_info)
+	if (!util_hints)
 		return 0;
 
-	if (ofi_dup_addr(util_info, *core_hints))
+	if (ofi_dup_addr(util_hints, *core_hints))
 		goto err;
 
-	if (util_info->fabric_attr) {
-		if (util_info->fabric_attr->name) {
+	if (util_hints->fabric_attr) {
+		if (util_hints->fabric_attr->name) {
 			(*core_hints)->fabric_attr->name =
-				strdup(util_info->fabric_attr->name);
+				strdup(util_hints->fabric_attr->name);
 			if (!(*core_hints)->fabric_attr->name) {
 				FI_WARN(prov, FI_LOG_FABRIC,
 					"Unable to allocate fabric name\n");
@@ -181,9 +181,9 @@ static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 			}
 		}
 
-		if (util_info->fabric_attr->prov_name) {
+		if (util_hints->fabric_attr->prov_name) {
 			(*core_hints)->fabric_attr->prov_name =
-				strdup(util_info->fabric_attr->prov_name);
+				strdup(util_hints->fabric_attr->prov_name);
 			if (!(*core_hints)->fabric_attr->prov_name) {
 				FI_WARN(prov, FI_LOG_FABRIC,
 					"Unable to alloc prov name\n");
@@ -197,9 +197,9 @@ static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 		}
 	}
 
-	if (util_info->domain_attr && util_info->domain_attr->name) {
+	if (util_hints->domain_attr && util_hints->domain_attr->name) {
 		(*core_hints)->domain_attr->name =
-			strdup(util_info->domain_attr->name);
+			strdup(util_hints->domain_attr->name);
 		if (!(*core_hints)->domain_attr->name) {
 			FI_WARN(prov, FI_LOG_FABRIC,
 				"Unable to allocate domain name\n");

--- a/prov/util/src/util_attr.c
+++ b/prov/util/src/util_attr.c
@@ -153,6 +153,7 @@ static int ofi_dup_addr(const struct fi_info *info, struct fi_info *dup)
 
 static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 			    const struct fi_info *util_hints,
+			    const struct fi_info *base_attr,
 			    ofi_alter_info_t info_to_core,
 			    struct fi_info **core_hints)
 {
@@ -161,7 +162,7 @@ static int ofi_info_to_core(uint32_t version, const struct fi_provider *prov,
 	if (!(*core_hints = fi_allocinfo()))
 		return -FI_ENOMEM;
 
-	if (info_to_core(version, util_hints, NULL, *core_hints))
+	if (info_to_core(version, util_hints, base_attr, *core_hints))
 		goto err;
 
 	if (!util_hints)
@@ -268,14 +269,15 @@ err:
 
 int ofi_get_core_info(uint32_t version, const char *node, const char *service,
 		      uint64_t flags, const struct util_prov *util_prov,
-		      const struct fi_info *util_hints, ofi_alter_info_t info_to_core,
-		      struct fi_info **core_info)
+		      const struct fi_info *util_hints,
+		      const struct fi_info *base_attr,
+		      ofi_alter_info_t info_to_core, struct fi_info **core_info)
 {
 	struct fi_info *core_hints = NULL;
 	int ret;
 
-	ret = ofi_info_to_core(version, util_prov->prov, util_hints, info_to_core,
-			       &core_hints);
+	ret = ofi_info_to_core(version, util_prov->prov, util_hints, base_attr,
+			       info_to_core, &core_hints);
 	if (ret)
 		return ret;
 
@@ -304,8 +306,9 @@ int ofix_getinfo(uint32_t version, const char *node, const char *service,
 		if (ofi_check_info(util_prov, base_info, version, hints))
 			continue;
 
-		ret = ofi_get_core_info(version, node, service, flags, util_prov,
-					hints, info_to_core, &core_info);
+		ret = ofi_get_core_info(version, node, service, flags,
+					util_prov, hints, base_info,
+					info_to_core, &core_info);
 		if (ret)
 			return ret;
 


### PR DESCRIPTION
The overall objective of this series is to allow rxm to optimize differently when running over tcp versus verbs.  To support this, we need to pass the base fi_info's (supplied by the providers) into the getinfo callbacks.  Previous work by @ooststep added this for the core_to_util callback.  This expands that functionality to support the info_to_core callback.

The rxm provider is updated with verbs and tcp specific fi_info structures (in order to maintain priority of using verbs first).  When the tcp base info is detected, shared receive contexts are requested.  This greatly improves the scalability of the tcp provider.  The verbs provider still adjusted based on an environment variable.