### PR TITLE
prov/rxm: Update message CQ size calculation to consider SRX context

### DIFF
--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2392,8 +2392,10 @@ static int rxm_ep_msg_cq_open(struct rxm_ep *rxm_ep)
 	};
 	int i, ret;
 
-	cq_attr.size = (rxm_ep->msg_info->tx_attr->size +
-			rxm_ep->msg_info->rx_attr->size) * ofi_universe_size;
+	cq_attr.size = rxm_ep->msg_info->rx_attr->size;
+	if (rxm_ep->msg_info->ep_attr->rx_ctx_cnt != FI_SHARED_CONTEXT)
+		cq_attr.size *= ofi_universe_size;
+	cq_attr.size += rxm_ep->msg_info->tx_attr->size * ofi_universe_size;
 	cq_attr.format = FI_CQ_FORMAT_DATA;
 	cq_attr.wait_obj = rxm_get_wait_obj(rxm_ep);
 


### PR DESCRIPTION
When using shared RX contexts the required message CQ size
calculated is inflated. Change so for shared RX contexts,
only the required RX CQ entries are added. The universe size
can be used to size the CQ as needed for TX.

This change has no impact on non-shared RX context usage.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>