### PR TITLE
fi_log.h: save and restore the errno in FI_LOG

### DIFF
--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -74,9 +74,12 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 
 #define FI_LOG(prov, level, subsystem, ...)				\
 	do {								\
-		if (fi_log_enabled(prov, level, subsystem))		\
+		if (fi_log_enabled(prov, level, subsystem)) {		\
+			int saved_errno = errno;			\
 			fi_log(prov, level, subsystem,			\
 				__func__, __LINE__, __VA_ARGS__);	\
+			errno = saved_errno;				\
+		}							\
 	} while (0)
 
 #define FI_WARN(prov, subsystem, ...)					\
@@ -103,9 +106,11 @@ void fi_log(const struct fi_provider *prov, enum fi_log_level level,
 #define FI_WARN_ONCE(prov, subsystem, ...) ({				\
 	static int warned;						\
 	if (!warned && fi_log_enabled(prov, FI_LOG_WARN, subsystem)) {	\
+		int saved_errno = errno;				\
 		fi_log(prov, FI_LOG_WARN, subsystem,			\
 			__func__, __LINE__, __VA_ARGS__);		\
 		warned = 1;						\
+		errno = saved_errno;					\
 	}								\
 })
 


### PR DESCRIPTION
Subject: [PATCH] fi_log.h: save and restore the errno in FI_LOG

There are multiple occurances of something like

func()
{
   ret = somefunction();
   if (ret) {
      FI_LOG();
      return -errno
   }
}

At least stated by opengroup, printf functions might
set errno on their own and the returned or used errno
might then be the wrong value from a printf function.

In the chosen solution errno is saved in the FI_LOG()
macro and not in fi_log(), in order to also exclude errno
overwrite by a possible function argument of FI_LOG, like

FI_WARN(..., "result:", function_overwriting_errno());

I.e., errno is saved before arguments are evaluated.


Signed-off-by: Bernd Schubert <bschubert@ddn.com>