### PR TITLE
Revert "prov/verbs: Simplify XRC SRQ/CQ close code"

### DIFF
--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1533,6 +1533,8 @@ int vrb_xrc_close_srq(struct vrb_srq_ep *srq_ep)
 	int ret;
 
 	assert(srq_ep->domain->flags & VRB_USE_XRC);
+	if (!srq_ep->xrc.cq || !srq_ep->srq)
+		return FI_SUCCESS;
 
 	ret = ibv_destroy_srq(srq_ep->srq);
 	if (ret) {
@@ -1541,6 +1543,7 @@ int vrb_xrc_close_srq(struct vrb_srq_ep *srq_ep)
 	}
 	srq_ep->xrc.cq->credits += srq_ep->xrc.max_recv_wr;
 	srq_ep->srq = NULL;
+	srq_ep->xrc.cq = NULL;
 	dlist_remove(&srq_ep->xrc.srq_entry);
 	vrb_cleanup_prepost_bufs(srq_ep);
 
@@ -1551,14 +1554,17 @@ static int vrb_srq_close(fid_t fid)
 {
 	struct vrb_srq_ep *srq_ep = container_of(fid, struct vrb_srq_ep,
 						 ep_fid.fid);
+	struct vrb_cq *cq = srq_ep->xrc.cq;
 	int ret;
 
 	if (srq_ep->domain->flags & VRB_USE_XRC) {
-		fastlock_acquire(&srq_ep->xrc.cq->xrc.srq_list_lock);
-		ret = vrb_xrc_close_srq(srq_ep);
-		fastlock_release(&srq_ep->xrc.cq->xrc.srq_list_lock);
-		if (ret)
-			goto err;
+		if (cq) {
+			fastlock_acquire(&cq->xrc.srq_list_lock);
+			ret = vrb_xrc_close_srq(srq_ep);
+			fastlock_release(&cq->xrc.srq_list_lock);
+			if (ret)
+				goto err;
+		}
 		fastlock_destroy(&srq_ep->xrc.prepost_lock);
 	} else {
 		ret = ibv_destroy_srq(srq_ep->srq);


### PR DESCRIPTION
This reverts commit 07b53c39cb974c3715a2c72d753f7d32c0a46005.

I am seeing some failures in osu_allreduce with this commit and need to understand why before keeping this simplification.