### PR TITLE
Support multiple memory monitors per cache

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -112,6 +112,8 @@ struct ofi_mem_monitor {
 
 	void (*init)(struct ofi_mem_monitor *monitor);
 	void (*cleanup)(struct ofi_mem_monitor *monitor);
+	int (*start)(struct ofi_mem_monitor *monitor);
+	void (*stop)(struct ofi_mem_monitor *monitor);
 	int (*subscribe)(struct ofi_mem_monitor *notifier,
 			 const void *addr, size_t len);
 	void (*unsubscribe)(struct ofi_mem_monitor *notifier,
@@ -144,9 +146,6 @@ struct ofi_uffd {
 	int				fd;
 };
 
-int ofi_uffd_start(void);
-void ofi_uffd_stop(void);
-
 extern struct ofi_mem_monitor *uffd_monitor;
 
 /*
@@ -156,9 +155,6 @@ struct ofi_memhooks {
 	struct ofi_mem_monitor          monitor;
 	struct dlist_entry		intercept_list;
 };
-
-int ofi_memhooks_start(void);
-void ofi_memhooks_stop(void);
 
 extern struct ofi_mem_monitor *memhooks_monitor;
 

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017-2019 Intel Corporation, Inc. All rights reserved.
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -49,6 +50,7 @@
 
 struct ofi_mr_info {
 	struct iovec iov;
+	enum fi_hmem_iface iface;
 };
 
 

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -663,6 +663,11 @@ are unable to manage their own network buffers.  A registration cache avoids
 the overhead of registering and unregistering a data buffer with each
 transfer.
 
+If a registration cache is going to be used for host and device memory, the
+device must support unified virtual addressing. If the device does not
+support unified virtual addressing, either an additional registration cache
+is required to track this device memory, or device memory cannot be cached.
+
 As a general rule, if hardware requires the FI_MR_LOCAL mode bit described
 above, but this is not supported by the application, a memory registration
 cache _may_ be in use.  The following environment variables may be used to

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -166,6 +166,9 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	const struct fi_info *fi;
 	size_t qp_table_size;
 	int ret;
+	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
+		[FI_HMEM_SYSTEM] = uffd_monitor,
+	};
 
 	fi = efa_get_efa_info(info->domain_attr->name);
 	if (!fi)
@@ -239,7 +242,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 		domain->cache.entry_data_size = sizeof(struct efa_mr);
 		domain->cache.add_region = efa_mr_cache_entry_reg;
 		domain->cache.delete_region = efa_mr_cache_entry_dereg;
-		ret = ofi_mr_cache_init(&domain->util_domain, uffd_monitor,
+		ret = ofi_mr_cache_init(&domain->util_domain, memory_monitors,
 					&domain->cache);
 		if (!ret) {
 			domain->util_domain.domain_fid.mr = &efa_domain_mr_cache_ops;

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -42,9 +42,14 @@
 
 #include <ofi_mr.h>
 
+static int ofi_memhooks_start(struct ofi_mem_monitor *monitor);
+static void ofi_memhooks_stop(struct ofi_mem_monitor *monitor);
+
 struct ofi_memhooks memhooks = {
 	.monitor.init = ofi_monitor_init,
-	.monitor.cleanup = ofi_monitor_cleanup
+	.monitor.cleanup = ofi_monitor_cleanup,
+	.monitor.start = ofi_memhooks_start,
+	.monitor.stop = ofi_memhooks_stop,
 };
 struct ofi_mem_monitor *memhooks_monitor = &memhooks.monitor;
 
@@ -472,7 +477,7 @@ static void ofi_memhooks_unsubscribe(struct ofi_mem_monitor *monitor,
 	/* no-op */
 }
 
-int ofi_memhooks_start(void)
+static int ofi_memhooks_start(struct ofi_mem_monitor *monitor)
 {
 	int i, ret;
 
@@ -553,7 +558,7 @@ int ofi_memhooks_start(void)
 	return 0;
 }
 
-void ofi_memhooks_stop(void)
+static void ofi_memhooks_stop(struct ofi_mem_monitor *monitor)
 {
 	ofi_restore_intercepts();
 	memhooks_monitor->subscribe = NULL;
@@ -562,12 +567,12 @@ void ofi_memhooks_stop(void)
 
 #else
 
-int ofi_memhooks_start(void)
+static int ofi_memhooks_start(struct ofi_mem_monitor *monitor)
 {
 	return -FI_ENOSYS;
 }
 
-void ofi_memhooks_stop(void)
+static void ofi_memhooks_stop(struct ofi_mem_monitor *monitor)
 {
 }
 

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -46,6 +46,7 @@ static int ofi_memhooks_start(struct ofi_mem_monitor *monitor);
 static void ofi_memhooks_stop(struct ofi_mem_monitor *monitor);
 
 struct ofi_memhooks memhooks = {
+	.monitor.iface = FI_HMEM_SYSTEM,
 	.monitor.init = ofi_monitor_init,
 	.monitor.cleanup = ofi_monitor_cleanup,
 	.monitor.start = ofi_memhooks_start,

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2017-2019 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
  * Copyright (c) 2020 Cisco Systems, Inc. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -296,6 +297,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	       attr->mr_iov->iov_base, attr->mr_iov->iov_len);
 
 	info.iov = *attr->mr_iov;
+	info.iface = attr->iface;
 
 	do {
 		pthread_mutex_lock(&mm_lock);

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -278,6 +278,9 @@ static int
 vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	      struct fid_domain **domain, void *context)
 {
+	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
+		[FI_HMEM_SYSTEM] = default_monitor,
+	};
 	struct vrb_domain *_domain;
 	int ret;
 	struct vrb_fabric *fab =
@@ -326,7 +329,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	_domain->cache.entry_data_size = sizeof(struct vrb_mem_desc);
 	_domain->cache.add_region = vrb_mr_cache_add_region;
 	_domain->cache.delete_region = vrb_mr_cache_delete_region;
-	ret = ofi_mr_cache_init(&_domain->util_domain, default_monitor,
+	ret = ofi_mr_cache_init(&_domain->util_domain, memory_monitors,
 				&_domain->cache);
 	if (!ret)
 		_domain->util_domain.domain_fid.mr = &vrb_mr_cache_ops;

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -189,7 +189,7 @@ static int vrb_mr_cache_close(fid_t fid)
 {
 	struct vrb_mem_desc *md =
 		container_of(fid, struct vrb_mem_desc, mr_fid.fid);
-	
+
 	ofi_mr_cache_delete(&md->domain->cache, md->entry);
 	return FI_SUCCESS;
 }
@@ -259,6 +259,7 @@ vrb_mr_cache_reg(struct fid *fid, const void *buf, size_t len,
 	attr.offset = offset;
 	attr.requested_key = requested_key;
 	attr.auth_key_size = 0;
+	attr.iface = FI_HMEM_SYSTEM;
 
 	ret = (flags & OFI_MR_NOCACHE) ?
 	      ofi_mr_cache_reg(&domain->cache, &attr, &entry) :


### PR DESCRIPTION
This enables support for multiple memory monitors, (one per HMEM iface) per cache.