### PR TITLE
prov/psm2: Add missing return status checking for PSM2 AM calls

### DIFF
--- a/prov/psm2/src/psmx2_atomic.c
+++ b/prov/psm2/src/psmx2_atomic.c
@@ -808,6 +808,7 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	psm2_epid_t psm2_epid;
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size, len;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -873,9 +874,15 @@ ssize_t psmx2_atomic_write_generic(struct fid_ep *ep,
 	args[3].u64 = key;
 	args[4].u32w0 = datatype;
 	args[4].u32w1 = op;
-	psm2_am_request_short(psm2_epaddr,
-			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
-			      (void *)buf, len, am_flags, NULL, NULL);
+	err = psm2_am_request_short(psm2_epaddr,
+				    PSMX2_AM_ATOMIC_HANDLER, args, 5,
+				    (void *)buf, len, am_flags, NULL, NULL);
+	if (err) {
+		free(req->tmpbuf);
+		psmx2_am_request_free(ep_priv->tx, req);
+		return psmx2_errno(err);
+	}
+
 	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
@@ -982,9 +989,15 @@ ssize_t psmx2_atomic_writev_generic(struct fid_ep *ep,
 	args[3].u64 = key;
 	args[4].u32w0 = datatype;
 	args[4].u32w1 = op;
-	psm2_am_request_short(psm2_epaddr,
-			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
-			      (void *)buf, len, am_flags, NULL, NULL);
+	err = psm2_am_request_short(psm2_epaddr,
+				    PSMX2_AM_ATOMIC_HANDLER, args, 5,
+				    (void *)buf, len, am_flags, NULL, NULL);
+	if (err) {
+		free(req->tmpbuf);
+		psmx2_am_request_free(ep_priv->tx, req);
+		return psmx2_errno(err);
+	}
+
 	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
@@ -1097,6 +1110,7 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 	psm2_epid_t psm2_epid;
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size, len;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1168,9 +1182,16 @@ ssize_t psmx2_atomic_readwrite_generic(struct fid_ep *ep,
 	args[3].u64 = key;
 	args[4].u32w0 = datatype;
 	args[4].u32w1 = op;
-	psm2_am_request_short(psm2_epaddr,
-			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
-			      (void *)buf, (buf?len:0), am_flags, NULL, NULL);
+	err = psm2_am_request_short(psm2_epaddr,
+				    PSMX2_AM_ATOMIC_HANDLER, args, 5,
+				    (void *)buf, (buf?len:0), am_flags, NULL,
+				    NULL);
+	if (err) {
+		free(req->tmpbuf);
+		psmx2_am_request_free(ep_priv->tx, req);
+		return psmx2_errno(err);
+	}
+
 	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
@@ -1341,9 +1362,16 @@ ssize_t psmx2_atomic_readwritev_generic(struct fid_ep *ep,
 	args[3].u64 = key;
 	args[4].u32w0 = datatype;
 	args[4].u32w1 = op;
-	psm2_am_request_short(psm2_epaddr,
-			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
-			      (void *)buf, (buf?len:0), am_flags, NULL, NULL);
+	err = psm2_am_request_short(psm2_epaddr,
+				    PSMX2_AM_ATOMIC_HANDLER, args, 5,
+				    (void *)buf, (buf?len:0), am_flags, NULL,
+				    NULL);
+	if (err) {
+		free(req->tmpbuf);
+		psmx2_am_request_free(ep_priv->tx, req);
+		return psmx2_errno(err);
+	}
+
 	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
@@ -1476,6 +1504,7 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 	psm2_epid_t psm2_epid;
 	int am_flags = PSM2_AM_FLAG_ASYNC;
 	int chunk_size, len;
+	int err;
 
 	ep_priv = container_of(ep, struct psmx2_fid_ep, ep);
 
@@ -1548,10 +1577,16 @@ ssize_t psmx2_atomic_compwrite_generic(struct fid_ep *ep,
 	args[3].u64 = key;
 	args[4].u32w0 = datatype;
 	args[4].u32w1 = op;
-	psm2_am_request_short(psm2_epaddr,
-			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
-			      (void *)buf, len * 2, am_flags,
-			      NULL, NULL);
+	err = psm2_am_request_short(psm2_epaddr,
+				    PSMX2_AM_ATOMIC_HANDLER, args, 5,
+				    (void *)buf, len * 2, am_flags,
+				    NULL, NULL);
+	if (err) {
+		free(req->tmpbuf);
+		psmx2_am_request_free(ep_priv->tx, req);
+		return psmx2_errno(err);
+	}
+
 	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }
@@ -1745,9 +1780,15 @@ ssize_t psmx2_atomic_compwritev_generic(struct fid_ep *ep,
 	args[3].u64 = key;
 	args[4].u32w0 = datatype;
 	args[4].u32w1 = op;
-	psm2_am_request_short(psm2_epaddr,
-			      PSMX2_AM_ATOMIC_HANDLER, args, 5,
-			      buf, len * 2, am_flags, NULL, NULL);
+	err = psm2_am_request_short(psm2_epaddr,
+				    PSMX2_AM_ATOMIC_HANDLER, args, 5,
+				    buf, len * 2, am_flags, NULL, NULL);
+	if (err) {
+		free(req->tmpbuf);
+		psmx2_am_request_free(ep_priv->tx, req);
+		return psmx2_errno(err);
+	}
+
 	psmx2_am_poll(ep_priv->tx);
 	return 0;
 }

--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -350,9 +350,12 @@ int psmx2_av_query_sep(struct psmx2_fid_av *av,
 	args[0].u32w1 = av->table[idx].sep_id;
 	args[1].u64 = (uint64_t)(uintptr_t)&av->sep_info[idx];
 	args[2].u64 = (uint64_t)(uintptr_t)&status;
-	psm2_am_request_short(av->conn_info[trx_ctxt->id].epaddrs[idx],
-			      PSMX2_AM_SEP_HANDLER, args, 3, NULL,
-			      0, 0, NULL, NULL);
+	error = psm2_am_request_short(av->conn_info[trx_ctxt->id].epaddrs[idx],
+				      PSMX2_AM_SEP_HANDLER, args, 3, NULL,
+				      0, 0, NULL, NULL);
+
+	if (error)
+		return error;
 
 	/*
 	 * make sure AM is progressed promptly. don't call

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -128,6 +128,7 @@ void psmx2_trx_ctxt_disconnect_peers(struct psmx2_trx_ctxt *trx_ctxt)
 	struct psmx2_epaddr_context *peer;
 	struct dlist_entry peer_list;
 	psm2_amarg_t arg;
+	int err;
 
 	arg.u32w0 = PSMX2_AM_REQ_TRX_CTXT_DISCONNECT;
 
@@ -144,8 +145,14 @@ void psmx2_trx_ctxt_disconnect_peers(struct psmx2_trx_ctxt *trx_ctxt)
 		peer = container_of(item, struct psmx2_epaddr_context, entry);
 		if (psmx2_env.disconnect) {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE, "epaddr: %p\n", peer->epaddr);
-			psm2_am_request_short(peer->epaddr, PSMX2_AM_TRX_CTXT_HANDLER,
-					      &arg, 1, NULL, 0, 0, NULL, NULL);
+			err = psm2_am_request_short(peer->epaddr,
+						    PSMX2_AM_TRX_CTXT_HANDLER,
+						    &arg, 1, NULL, 0, 0, NULL,
+						    NULL);
+			if (err)
+				FI_INFO(&psmx2_prov, FI_LOG_CORE,
+					"failed to send disconnect, err %d\n",
+					err);
 		}
 		psm2_epaddr_setctxt(peer->epaddr, NULL);
 		free(peer);


### PR DESCRIPTION
PSM2 Active Message calls are used for RMA and atomic operations.
Previously the return results of some of the calls were unchecked,
which may lead to application hanging on waiting for completions
when the connection is broken.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>

This partly addresses #5997, but a complete fix also depends on 
PSM2 calls being able to return error upon remote disconnection. 