### PR TITLE
Jenkins-CI : remove spawn tests for sockets provider

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -405,7 +405,8 @@ class MpichTestSuite(MpiTests):
 
     @property
     def execute_condn(self):
-        return True if (self.mpi == 'impi' and  self.core_prov != 'psm2') else False
+        return True if (self.mpi == 'impi' and  self.core_prov != 'psm2' \
+                        and self.core_prov != 'sockets') else False
  
     def execute_cmd(self, testgroupname):
         print("Running Tests: " + testgroupname)


### PR DESCRIPTION
Removed spawn tests for sockets provider.
Sockets provider is throwing errors causing the
nightly builds to abort with a timeout and holding
up builds for long duration.

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>