### PR TITLE
prov/rxm: Allow disabling SRX from tcp provider

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -137,8 +137,10 @@ The ofi_rxm provider checks for the following environment variables.
   via rendezvous protocol.
 
 *FI_OFI_RXM_USE_SRX*
-: Set this to 1 to use shared receive context from MSG provider. This reduces
-  overall memory usage but there may be a slight increase in latency (default: 0).
+: Set this to 1 to use shared receive context from MSG provider, or 0 to
+  disable using shared receive context. Shared receive contexts reduce overall
+  memory usage, but may increase in message latency.  If not set, verbs will
+  not use shared receive contexts by default, but the tcp provider will.
 
 *FI_OFI_RXM_TX_SIZE*
 : Defines default TX context size (default: 1024)
@@ -158,7 +160,7 @@ with (default: 256).
 
 *FI_OFI_RXM_CM_PROGRESS_INTERVAL*
 : Defines the duration of time in microseconds between calls to RxM CM progression
-  functions when using manual progress. Higher values may provide less noise for 
+  functions when using manual progress. Higher values may provide less noise for
   calls to fi_cq read functions, but may increase connection setup time (default: 10000)
 
 *FI_OFI_RXM_CQ_EQ_FAIRNESS*

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -92,7 +92,7 @@ void rxm_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
 int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 		     const struct fi_info *base_info, struct fi_info *core_info)
 {
-	int use_srx = 0;
+	int ret, use_srx = 0;
 
 	rxm_info_to_core_mr_modes(version, hints, core_info);
 
@@ -127,8 +127,9 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 
 	core_info->ep_attr->type = FI_EP_MSG;
 
-	fi_param_get_bool(&rxm_prov, "use_srx", &use_srx);
-	if (use_srx || (base_info && base_info->fabric_attr->prov_name &&
+	ret = fi_param_get_bool(&rxm_prov, "use_srx", &use_srx);
+	if (use_srx || ((ret == -FI_ENODATA) && base_info &&
+	    base_info->fabric_attr->prov_name &&
 	    !strcmp(base_info->fabric_attr->prov_name, "tcp"))) {
 		FI_DBG(&rxm_prov, FI_LOG_FABRIC,
 		       "Requesting shared receive context from core provider\n");


### PR DESCRIPTION
The tcp provider will use SRX by default.  Override this default
if the user explicitly disables SRX through the environment
variable.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>