### PR TITLE
prov/shm: mark smr_region as volatile

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -320,7 +320,7 @@ void	smr_map_free(struct smr_map *map);
 struct smr_region *smr_map_get(struct smr_map *map, int id);
 
 int	smr_create(const struct fi_provider *prov, struct smr_map *map,
-		   const struct smr_attr *attr, struct smr_region **smr);
+		   const struct smr_attr *attr, struct smr_region *volatile *smr);
 void	smr_free(struct smr_region *smr);
 
 #ifdef __cplusplus

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -217,7 +217,7 @@ struct smr_ep {
 	size_t			min_multi_recv_size;
 	const char		*name;
 	uint64_t		msg_id;
-	struct smr_region	*region;
+	struct smr_region	*volatile region;
 	struct smr_recv_fs	*recv_fs; /* protected by rx_cq lock */
 	struct smr_queue	recv_queue;
 	struct smr_queue	trecv_queue;

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -133,7 +133,7 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 
 /* TODO: Determine if aligning SMR data helps performance */
 int smr_create(const struct fi_provider *prov, struct smr_map *map,
-	       const struct smr_attr *attr, struct smr_region **smr)
+	       const struct smr_attr *attr, struct smr_region *volatile *smr)
 {
 	struct smr_ep_name *ep_name;
 	size_t total_size, cmd_queue_offset, peer_data_offset;


### PR DESCRIPTION
On non-debug builds, the compiler optimizes shared memory
queues out causing performance issues for the shm provider
in non-debug builds.

Declare the entire EP's region as volatile to resolve
performance issues.

Signed-off-by: aingerson <alexia.ingerson@intel.com>