### PR TITLE
prov/efa: Replace rxr_ep_print_pkt by rxr_pkt_print

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -34,6 +34,7 @@
 #include "efa.h"
 #include "rxr.h"
 #include "rxr_cntr.h"
+#include "rxr_pkt_cmd.h"
 
 /* This file implements 4 actions that can be applied to a packet:
  *          posting,
@@ -531,7 +532,7 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 	dlist_remove(&pkt_entry->dbg_entry);
 	dlist_insert_tail(&pkt_entry->dbg_entry, &ep->rx_pkt_list);
 #ifdef ENABLE_RXR_PKT_DUMP
-	rxr_ep_print_pkt("Received", ep, (struct rxr_base_hdr *)pkt_entry->pkt);
+	rxr_pkt_print("Received", ep, (struct rxr_base_hdr *)pkt_entry->pkt);
 #endif
 #endif
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -42,6 +42,7 @@
 #include "efa.h"
 #include "rxr_msg.h"
 #include "rxr_rma.h"
+#include "rxr_pkt_cmd.h"
 
 /*
  *   General purpose utility functions


### PR DESCRIPTION
When building libfabric with CFLAGS=-DENABLE_RXR_PKT_DUMP, it
returns an error, as rxr_ep_print_pkt function has been renamed
and replaced by rxr_pkt_print.

Signed-off-by: Dipti Kothari <dkothar@amazon.com>