### PR TITLE
Revert "test_configs/efa: exclude multi_recv test"

### DIFF
--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -61,9 +61,8 @@ trigger
 #rdm_cntr_pingpong
 
 
-# These tests require ENA IPs for the OOB sync
+# This test requires ENA IPs for the OOB sync
 av_xfer
-multi_recv
 
 # Connection manager isn't supported
 cm_data


### PR DESCRIPTION
This reverts commit 99e83f1bde60b9838a8888d6e66dfb65f9750b10.

This commit excluded multi_recv test for efa because the EFA CI
did not support OOB address sync at that time.

Now the CI support OOB address sync. This patch re-enable
the test.