### PR TITLE
prov/util: Add av_entry_size field to struct util_av_attr

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -682,7 +682,13 @@ static inline void ofi_cntr_inc(struct util_cntr *cntr)
 struct util_av_entry {
 	ofi_atomic32_t	use_cnt;
 	UT_hash_handle	hh;
-	char		addr[0];
+	/*
+	 * data includes 'addr' and any other additional fields
+	 * associated with av_entry. 'addr' must be the first
+	 * field in 'data' and addr length should be a multiple
+	 * of 8 bytes to ensure alignment of additional fields
+	 */
+	char		data[0];
 };
 
 struct util_av {
@@ -706,7 +712,13 @@ struct util_av {
 };
 
 struct util_av_attr {
+	/* Must be a multiple of 8 bytes */
 	size_t	addrlen;
+	/*
+	 * Specify the length of additional fields to be added
+	 * to av_entry other than struct util_av_entry and addr
+	 */
+	size_t  context_len;
 	int	flags;
 };
 

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -708,6 +708,7 @@ int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 			attr->count = MAX(attr->count, universe_size);
 
 		util_attr.addrlen = EFA_EP_ADDR_LEN;
+		util_attr.context_len = 0;
 		util_attr.flags = 0;
 		ret = ofi_av_init(&efa_domain->util_domain, attr, &util_attr,
 					&av->util_av, context);

--- a/prov/mrail/src/mrail_av.c
+++ b/prov/mrail/src/mrail_av.c
@@ -195,6 +195,7 @@ int mrail_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	util_attr.addrlen = sizeof(struct mrail_peer_info);
 	/* We just need a table to store the mapping */
 	util_attr.flags = 0;
+	util_attr.context_len = 0;
 
 	if (attr->type == FI_AV_UNSPEC)
 		attr->type = FI_AV_TABLE;

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -387,6 +387,7 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 
 
 	util_attr.addrlen = sizeof(fi_addr_t);
+	util_attr.context_len = 0;
 	util_attr.flags = 0;
 	attr->type = domain->util_domain.av_type != FI_AV_UNSPEC ?
 		     domain->util_domain.av_type : FI_AV_TABLE;

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -220,7 +220,8 @@ int smr_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (!smr_av)
 		return -FI_ENOMEM;
 
-	util_attr.addrlen = NAME_MAX;
+	util_attr.addrlen = NAME_MAX + 1;
+	util_attr.context_len = 0;
 	util_attr.flags = 0;
 	if (attr->count > SMR_MAX_PEERS) {
 		ret = -FI_ENOSYS;


### PR DESCRIPTION
To allow custom av entry size, add an additional field
i.e. av_entry_size to struct util_av_attr

Signed-off-by: Dipti Kothari <dkothar@amazon.com>