### PR TITLE
prov/util: Add config options to disable monitors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -495,6 +495,42 @@ FI_CHECK_PACKAGE([cuda],
 		 [AC_DEFINE([HAVE_LIBCUDA], [1],[CUDA support])],
 		 [], [])
 
+
+enable_memhooks=1
+AC_ARG_ENABLE([memhooks-monitor],
+              [AC_HELP_STRING([--disable-memhooks-monitor],
+                              [Determine whether memhooks memory monitor is disabled.])],
+              [enable_memhooks=0],
+              [])
+
+AC_DEFINE_UNQUOTED(ENABLE_MEMHOOKS_MONITOR, [$enable_memhooks],
+	[Define to 1 to enable memhooks memory monitor])
+
+enable_uffd=1
+AC_ARG_ENABLE([uffd-monitor],
+              [AC_HELP_STRING([--disable-uffd-monitor],
+                              [Determine whether uffd memory monitor is disabled.])],
+              [enable_uffd=0],
+              [])
+
+AC_DEFINE_UNQUOTED(ENABLE_UFFD_MONITOR, [$enable_uffd],
+	[Define to 1 to enable uffd memory monitor])
+
+
+AH_BOTTOM([
+#if defined(__linux__) && defined(HAVE_ELF_H) && defined(HAVE_SYS_AUXV_H) && ENABLE_MEMHOOKS_MONITOR
+#define HAVE_MEMHOOKS_MONITOR 1
+#else
+#define HAVE_MEMHOOKS_MONITOR 0
+#endif
+
+#if HAVE_UFFD_UNMAP && ENABLE_UFFD_MONITOR
+#define HAVE_UFFD_MONITOR 1
+#else
+#define HAVE_UFFD_MONITOR 0
+#endif
+])
+
 CPPFLAGS="$CPPFLAGS $cuda_CPPFLAGS"
 LDFLAGS="$LDFLAGS $cuda_LDFLAGS"
 LIBS="$LIBS $cuda_LIBS"

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -46,7 +46,8 @@ struct ofi_memhooks memhooks;
 struct ofi_mem_monitor *memhooks_monitor = &memhooks.monitor;
 
 
-#if defined(__linux__) && defined(HAVE_ELF_H) && defined(HAVE_SYS_AUXV_H)
+/* memhook support checks */
+#if HAVE_MEMHOOKS_MONITOR
 
 #include <elf.h>
 #include <sys/auxv.h>


### PR DESCRIPTION
This commit introduces two new configure options for controlling
how memory monitors are used with applications by default:

  --disable-uffd-monitor
  --disable-memhooks-monitor

When a monitor is disabled, it cannot be selected as the default monitor
at init, or when the environment variables are read in. If a user selects a
monitor with FI_MR_CACHE_MONITOR, then the following behavior is expected:
  - if the monitor is available, it becomes the default.
  - otherwise, no monitor is chosen as the default monitor and caching is disabled

The behavior choice was made so that users will experience a predictable behavior
when the monitor of choice is not available.

The behavior for default cache selection has been modified. If an available monitor is
disabled, the next monitor in order (memhooks, uffd, none) is selected if enabled.
If none of the enabled monitors are available, it defaults to none.
This change maintains the current preference order of monitors.

Signed-off-by: James Swaro <james.swaro@hpe.com>