### PR TITLE
log function and stream overload capability

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -36,6 +36,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 
@@ -716,6 +717,16 @@ struct fi_recv_context {
 	struct fid_ep		*ep;
 	void			*context;
 };
+
+/* XXX should be in rdma/providers/fi_log.h, but header file is not shipped in
+ * distro and would also need to be striped of its current requires
+ * (config.h, ...)
+ */
+void fi_log_set_stream_warn(FILE *log_stream);
+void fi_log_set_stream_trace(FILE *log_stream);
+void fi_log_set_stream_info(FILE *log_stream);
+void fi_log_set_stream_debug(FILE *log_stream);
+void fi_log_set_func(int (*log_func)(FILE *stream, const char *format, ...));
 
 #ifdef __cplusplus
 }

--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -722,11 +722,16 @@ struct fi_recv_context {
  * distro and would also need to be striped of its current requires
  * (config.h, ...)
  */
-void fi_log_set_stream_warn(FILE *log_stream);
-void fi_log_set_stream_trace(FILE *log_stream);
-void fi_log_set_stream_info(FILE *log_stream);
-void fi_log_set_stream_debug(FILE *log_stream);
+void fi_log_set_stream(FILE *log_stream, int level);
 void fi_log_set_func(int (*log_func)(FILE *stream, const char *format, ...));
+
+enum fi_log_level {
+        FI_LOG_WARN,
+        FI_LOG_TRACE,
+        FI_LOG_INFO,
+        FI_LOG_DEBUG,
+        FI_LOG_MAX
+};
 
 #ifdef __cplusplus
 }

--- a/include/rdma/providers/fi_log.h
+++ b/include/rdma/providers/fi_log.h
@@ -58,14 +58,6 @@ enum fi_log_subsys {
 	FI_LOG_SUBSYS_MAX
 };
 
-enum fi_log_level {
-	FI_LOG_WARN,
-	FI_LOG_TRACE,
-	FI_LOG_INFO,
-	FI_LOG_DEBUG,
-	FI_LOG_MAX
-};
-
 int fi_log_enabled(const struct fi_provider *prov, enum fi_log_level level,
 		   enum fi_log_subsys subsys);
 void fi_log(const struct fi_provider *prov, enum fi_log_level level,

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -7,11 +7,6 @@ FABRIC_1.0 {
 		fi_version;
 		fi_strerror;
 		fi_tostr;
-		fi_log_set_stream_warn;
-		fi_log_set_stream_trace;
-		fi_log_set_stream_info;
-		fi_log_set_stream_debug;
-		fi_log_set_func;
 		fi_log_enabled;
 		fi_log;
 		fi_param_define;
@@ -43,3 +38,9 @@ FABRIC_1.3 {
 		fi_freeinfo;
 		fi_dupinfo;
 } FABRIC_1.2;
+
+FABRIC_1.4 {
+	global:
+		fi_log_set_stream;
+		fi_log_set_func;
+} FABRIC_1.3;

--- a/libfabric.map.in
+++ b/libfabric.map.in
@@ -7,6 +7,11 @@ FABRIC_1.0 {
 		fi_version;
 		fi_strerror;
 		fi_tostr;
+		fi_log_set_stream_warn;
+		fi_log_set_stream_trace;
+		fi_log_set_stream_info;
+		fi_log_set_stream_debug;
+		fi_log_set_func;
 		fi_log_enabled;
 		fi_log;
 		fi_param_define;

--- a/src/log.c
+++ b/src/log.c
@@ -83,6 +83,9 @@ struct fi_filter prov_log_filter;
 
 static pid_t pid;
 
+/* one stream per OFI log level */
+static FILE *fi_log_streams[FI_LOG_MAX];
+
 static int fi_convert_log_str(const char *value)
 {
 	int i;
@@ -125,6 +128,8 @@ void fi_log_init(void)
 	}
 	ofi_free_filter(&subsys_filter);
 	pid = getpid();
+	for (i = 0; i < FI_LOG_MAX; i++)
+		fi_log_streams[i] = stderr;
 }
 
 void fi_log_fini(void)
@@ -145,39 +150,13 @@ int DEFAULT_SYMVER_PRE(fi_log_enabled)(const struct fi_provider *prov,
 }
 DEFAULT_SYMVER(fi_log_enabled_, fi_log_enabled, FABRIC_1.0);
 
-/* one stream per OFI log level */
-static FILE *fi_log_stream_warn = NULL;
-static FILE *fi_log_stream_trace = NULL;
-static FILE *fi_log_stream_info = NULL;
-static FILE *fi_log_stream_debug = NULL;
-
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
-void DEFAULT_SYMVER_PRE(fi_log_set_stream_warn)(FILE *log_stream)
+void DEFAULT_SYMVER_PRE(fi_log_set_stream)(FILE *log_stream, int level)
 {
-    fi_log_stream_warn = log_stream;
+	if (level < FI_LOG_MAX)
+		fi_log_streams[level] = log_stream;
 }
-DEFAULT_SYMVER(fi_log_set_stream_warn_, fi_log_set_stream_warn, FABRIC_1.0);
-
-__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
-void DEFAULT_SYMVER_PRE(fi_log_set_stream_trace)(FILE *log_stream)
-{
-    fi_log_stream_trace = log_stream;
-}
-DEFAULT_SYMVER(fi_log_set_stream_trace_, fi_log_set_stream_trace, FABRIC_1.0);
-
-__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
-void DEFAULT_SYMVER_PRE(fi_log_set_stream_info)(FILE *log_stream)
-{
-    fi_log_stream_info = log_stream;
-}
-DEFAULT_SYMVER(fi_log_set_stream_info_, fi_log_set_stream_info, FABRIC_1.0);
-
-__attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
-void DEFAULT_SYMVER_PRE(fi_log_set_stream_debug)(FILE *log_stream)
-{
-    fi_log_stream_debug = log_stream;
-}
-DEFAULT_SYMVER(fi_log_set_stream_debug_, fi_log_set_stream_debug, FABRIC_1.0);
+DEFAULT_SYMVER(fi_log_set_stream_, fi_log_set_stream, FABRIC_1.4);
 
 static int (*fi_log_func)(FILE *stream, const char *format, ...) = fprintf;
 
@@ -186,7 +165,7 @@ void DEFAULT_SYMVER_PRE(fi_log_set_func)(int (*log_func)(FILE *stream, const cha
 {
     fi_log_func = log_func;
 }
-DEFAULT_SYMVER(fi_log_set_func_, fi_log_set_func, FABRIC_1.0);
+DEFAULT_SYMVER(fi_log_set_func_, fi_log_set_func, FABRIC_1.4);
 
 __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_level level,
@@ -195,7 +174,6 @@ void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_leve
 {
 	char buf[1024];
 	int size;
-	FILE *stream = stderr;
 
 	va_list vargs;
 
@@ -207,20 +185,6 @@ void DEFAULT_SYMVER_PRE(fi_log)(const struct fi_provider *prov, enum fi_log_leve
 	vsnprintf(buf + size, sizeof(buf) - size, fmt, vargs);
 	va_end(vargs);
 
-	switch (level) {
-	case FI_LOG_WARN:
-		stream = fi_log_stream_warn != NULL ? fi_log_stream_warn : stderr;
-		break;
-	case FI_LOG_TRACE:
-		stream = fi_log_stream_trace != NULL ? fi_log_stream_trace : stderr;
-		break;
-	case FI_LOG_INFO:
-		stream = fi_log_stream_info != NULL ? fi_log_stream_info : stderr;
-		break;
-	case FI_LOG_DEBUG:
-		stream = fi_log_stream_debug != NULL ? fi_log_stream_debug : stderr;
-		break;
-	}
-	fi_log_func(stream , "%s", buf);
+	fi_log_func(fi_log_streams[level] , "%s", buf);
 }
 DEFAULT_SYMVER(fi_log_, fi_log, FABRIC_1.0);


### PR DESCRIPTION
API: log function and stream overload capability

allow to enhance and redirect OFI/libfabric logs.
these new ABIs will permit to enhance current libfabric msgs
with more details/infos, like timestamp, thread-id, ...
and also to redirect each level's msgs to a separate stream
being managed by the application.
this will be particularly helpful in order to prevent garbling
application's stderr with OFI/libfabric debug/info msgs, and
also to merge them with applications's log msgs.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>