### PR TITLE
prov/efa: adjust timing of rx completion for read message protocol

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -341,6 +341,12 @@ struct rxr_eor_hdr {
 static_assert(sizeof(struct rxr_eor_hdr) == 12, "rxr_eor_hdr check");
 #endif
 
+static inline
+struct rxr_eor_hdr *rxr_get_eor_hdr(void *pkt)
+{
+	return (struct rxr_eor_hdr *)pkt;
+}
+
 int rxr_pkt_init_eor(struct rxr_ep *ep,
 		     struct rxr_rx_entry *rx_entry,
 		     struct rxr_pkt_entry *pkt_entry);


### PR DESCRIPTION
Currently, for read message protocol, the rx completion was wrote
after the sending of EOR packet was completed, which is too late
because the receive has completed when read is finished and impact
performance.

This patch fix that by writing rx completion when read is finished.

Signed-off-by: Wei Zhang <wzam@amazon.com>