### PR TITLE
prov/util: Add context_offset to struct util_av

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -707,6 +707,11 @@ struct util_av {
 	uint64_t		flags;
 	size_t			count;
 	size_t			addrlen;
+	/*
+	 * context_offset is addrlen + offset (required for alignment),
+	 * if addrlen is a multiple of 8 bytes offset will be 0.
+	 */
+	size_t			context_offset;
 	struct dlist_entry	ep_list;
 	fastlock_t		ep_list_lock;
 };

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -220,7 +220,7 @@ int smr_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (!smr_av)
 		return -FI_ENOMEM;
 
-	util_attr.addrlen = NAME_MAX + 1;
+	util_attr.addrlen = NAME_MAX;
 	util_attr.context_len = 0;
 	util_attr.flags = 0;
 	if (attr->count > SMR_MAX_PEERS) {

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -423,10 +423,14 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 {
 	int ret = 0;
 	size_t max_count;
+	size_t offset;
 
-	assert(util_attr->addrlen % 8 == 0);
+	/* offset calculated on a 8-byte boundary */
+	offset = util_attr->addrlen % 8;
+	if (offset != 0)
+		offset = 8 - offset;
 	struct ofi_bufpool_attr pool_attr = {
-		.size		= util_attr->addrlen +
+		.size		= util_attr->addrlen + offset +
 				  util_attr->context_len +
 				  sizeof(struct util_av_entry),
 		.alignment	= 16,
@@ -449,6 +453,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 	FI_INFO(av->prov, FI_LOG_AV, "AV size %zu\n", av->count);
 
 	av->addrlen = util_attr->addrlen;
+	av->context_offset = offset + av->addrlen;
 	av->flags = util_attr->flags | attr->flags;
 	av->hash = NULL;
 


### PR DESCRIPTION
If addrlen is not a multiple of 8 bytes, add an offset to
align context. The offset + addrlen is stored as an additional
field, context_offset in struct util_av
Also set util_attr.addrlen back to NAME_MAX for shm

Signed-off-by: Dipti Kothari <dkothar@amazon.com>