### PR TITLE
prov/shm: redefine shm addrlen to not use NAME_MAX

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -162,8 +162,10 @@ struct smr_cmd {
 #define SMR_COMP_INJECT_SIZE	(SMR_INJECT_SIZE / 2)
 #define SMR_SAR_SIZE		16384
 
+#define SMR_NAME_MAX		256
+
 struct smr_addr {
-	char		name[NAME_MAX];
+	char		name[SMR_NAME_MAX];
 	fi_addr_t	addr;
 };
 
@@ -178,7 +180,7 @@ extern pthread_mutex_t ep_list_lock;
 struct smr_region;
 
 struct smr_ep_name {
-	char name[NAME_MAX];
+	char name[SMR_NAME_MAX];
 	struct smr_region *region;
 	struct dlist_entry entry;
 };

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -235,7 +235,7 @@ struct smr_ep {
 static inline int smr_mmap_name(char *shm_name, const char *ep_name,
 				uint64_t msg_id)
 {
-	return snprintf(shm_name, NAME_MAX - 1, "%s_%ld",
+	return snprintf(shm_name, SMR_NAME_MAX - 1, "%s_%ld",
 			ep_name, msg_id);
 }
 

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -220,7 +220,7 @@ int smr_av_open(struct fid_domain *domain, struct fi_av_attr *attr,
 	if (!smr_av)
 		return -FI_ENOMEM;
 
-	util_attr.addrlen = NAME_MAX;
+	util_attr.addrlen = SMR_NAME_MAX;
 	util_attr.context_len = 0;
 	util_attr.flags = 0;
 	if (attr->count > SMR_MAX_PEERS) {

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -618,16 +618,16 @@ static int smr_endpoint_name(char *name, char *addr, size_t addrlen,
 			     int dom_idx, int ep_idx)
 {
 	const char *start;
-	memset(name, 0, NAME_MAX);
-	if (!addr || addrlen > NAME_MAX)
+	memset(name, 0, SMR_NAME_MAX);
+	if (!addr || addrlen > SMR_NAME_MAX)
 		return -FI_EINVAL;
 
 	start = smr_no_prefix((const char *) addr);
 	if (strstr(addr, SMR_PREFIX) || dom_idx || ep_idx)
-		snprintf(name, NAME_MAX - 1, "%s:%d:%d:%d", start, getuid(), dom_idx,
-			 ep_idx);
+		snprintf(name, SMR_NAME_MAX - 1, "%s:%d:%d:%d", start, getuid(),
+			 dom_idx, ep_idx);
 	else
-		snprintf(name, NAME_MAX - 1, "%s", start);
+		snprintf(name, SMR_NAME_MAX - 1, "%s", start);
 
 	return 0;
 }
@@ -638,7 +638,7 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct smr_ep *ep;
 	struct smr_domain *smr_domain;
 	int ret, ep_idx;
-	char name[NAME_MAX];
+	char name[SMR_NAME_MAX];
 
 	ep = calloc(1, sizeof(*ep));
 	if (!ep)
@@ -654,7 +654,7 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err2;
 
-	ret = smr_setname(&ep->util_ep.ep_fid.fid, name, NAME_MAX);
+	ret = smr_setname(&ep->util_ep.ep_fid.fid, name, SMR_NAME_MAX);
 	if (ret)
 		goto err2;
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -624,10 +624,10 @@ static int smr_endpoint_name(char *name, char *addr, size_t addrlen,
 
 	start = smr_no_prefix((const char *) addr);
 	if (strstr(addr, SMR_PREFIX) || dom_idx || ep_idx)
-		snprintf(name, NAME_MAX, "%s:%d:%d:%d", start, getuid(), dom_idx,
+		snprintf(name, NAME_MAX - 1, "%s:%d:%d:%d", start, getuid(), dom_idx,
 			 ep_idx);
 	else
-		snprintf(name, NAME_MAX, "%s", start);
+		snprintf(name, NAME_MAX - 1, "%s", start);
 
 	return 0;
 }

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -51,21 +51,21 @@ static void smr_init_env(void)
 static void smr_resolve_addr(const char *node, const char *service,
 			     char **addr, size_t *addrlen)
 {
-	char temp_name[NAME_MAX];
+	char temp_name[SMR_NAME_MAX];
 
 	if (service) {
 		if (node)
-			snprintf(temp_name, NAME_MAX - 1, "%s%s:%s",
+			snprintf(temp_name, SMR_NAME_MAX - 1, "%s%s:%s",
 				 SMR_PREFIX_NS, node, service);
 		else
-			snprintf(temp_name, NAME_MAX - 1, "%s%s",
+			snprintf(temp_name, SMR_NAME_MAX - 1, "%s%s",
 				 SMR_PREFIX_NS, service);
 	} else {
 		if (node)
-			snprintf(temp_name, NAME_MAX - 1, "%s%s",
+			snprintf(temp_name, SMR_NAME_MAX - 1, "%s%s",
 				 SMR_PREFIX, node);
 		else
-			snprintf(temp_name, NAME_MAX - 1, "%s%d",
+			snprintf(temp_name, SMR_NAME_MAX - 1, "%s%d",
 				 SMR_PREFIX, getpid());
 	}
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -292,7 +292,7 @@ static int smr_mmap_peer_copy(struct smr_ep *ep, struct smr_cmd *cmd,
 				 struct iovec *iov, size_t iov_count,
 				 size_t *total_len)
 {
-	char shm_name[NAME_MAX];
+	char shm_name[SMR_NAME_MAX];
 	void *mapped_ptr;
 	int peer_id, fd, num;
 	int ret = 0;

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -60,7 +60,7 @@ void smr_cleanup(void)
 
 static void smr_peer_addr_init(struct smr_addr *peer)
 {
-	memset(peer->name, 0, NAME_MAX);
+	memset(peer->name, 0, SMR_NAME_MAX);
 	peer->addr = FI_ADDR_UNSPEC;
 }
 
@@ -120,7 +120,7 @@ size_t smr_calculate_size_offsets(size_t tx_count, size_t rx_count,
 	if (name_offset)
 		*name_offset = ep_name_offset;
 
-	total_size = ep_name_offset + NAME_MAX;
+	total_size = ep_name_offset + SMR_NAME_MAX;
 
 	/* 
  	 * Revisit later to see if we really need the size adjustment, or
@@ -161,8 +161,8 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 		FI_WARN(prov, FI_LOG_EP_CTRL, "calloc error\n");
 		return -FI_ENOMEM;
 	}
-	strncpy(ep_name->name, (char *)attr->name, NAME_MAX - 1);
-	ep_name->name[NAME_MAX - 1] = '\0';
+	strncpy(ep_name->name, (char *)attr->name, SMR_NAME_MAX - 1);
+	ep_name->name[SMR_NAME_MAX - 1] = '\0';
 
 	pthread_mutex_lock(&ep_list_lock);
 	dlist_insert_tail(&ep_name->entry, &ep_name_list);
@@ -319,8 +319,8 @@ void smr_map_to_endpoint(struct smr_region *region, int index)
 	local_peers = smr_peer_data(region);
 
 	strncpy(smr_peer_data(region)[index].addr.name,
-		region->map->peers[index].peer.name, NAME_MAX - 1);
-	smr_peer_data(region)[index].addr.name[NAME_MAX - 1] = '\0';
+		region->map->peers[index].peer.name, SMR_NAME_MAX - 1);
+	smr_peer_data(region)[index].addr.name[SMR_NAME_MAX - 1] = '\0';
 	if (region->map->peers[index].peer.addr == FI_ADDR_UNSPEC)
 		return;
 
@@ -332,7 +332,7 @@ void smr_map_to_endpoint(struct smr_region *region, int index)
 
 	for (peer_index = 0; peer_index < SMR_MAX_PEERS; peer_index++) {
 		if (!strncmp(smr_name(region),
-		    peer_peers[peer_index].addr.name, NAME_MAX))
+		    peer_peers[peer_index].addr.name, SMR_NAME_MAX))
 			break;
 	}
 	if (peer_index != SMR_MAX_PEERS) {
@@ -349,7 +349,7 @@ void smr_unmap_from_endpoint(struct smr_region *region, int index)
 
 	local_peers = smr_peer_data(region);
 
-	memset(local_peers[index].addr.name, 0, NAME_MAX);
+	memset(local_peers[index].addr.name, 0, SMR_NAME_MAX);
 	peer_index = region->map->peers[index].peer.addr;
 	if (peer_index == FI_ADDR_UNSPEC)
 		return;
@@ -373,8 +373,8 @@ int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
 	int ret = 0;
 
 	fastlock_acquire(&map->lock);
-	strncpy(map->peers[id].peer.name, name, NAME_MAX);
-	map->peers[id].peer.name[NAME_MAX - 1] = '\0';
+	strncpy(map->peers[id].peer.name, name, SMR_NAME_MAX);
+	map->peers[id].peer.name[SMR_NAME_MAX - 1] = '\0';
 	ret = smr_map_to_region(prov, &map->peers[id]);
 	if (!ret)
 		map->peers[id].peer.addr = id;


### PR DESCRIPTION
NAME_MAX (256) is defined as not including the terminating
null character in a string.

While the shm provider does use this for strings, its
max length and addrlen refer to data size not string length
and must include the terminating character. Therefore,
NAME_MAX is not fully comparable to how shm uses it.

To fix this, define SMR_NAME_MAX as 256 and use this instead
to avoid confusion with the terms.

Signed-off-by: aingerson <alexia.ingerson@intel.com>