### PR TITLE
Fix leak of dev_name when it is a duplicate

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -897,8 +897,10 @@ static int verbs_devs_add(struct dlist_entry *verbs_devs, char *dev_name,
 	addr->rai = rai;
 
 	dlist_foreach_container(verbs_devs, struct verbs_dev_info, dev, entry)
-		if (!strcmp(dev_name, dev->name))
+		if (!strcmp(dev_name, dev->name)) {
+			free(dev_name);
 			goto add_rai;
+		}
 
 	if (!(dev = malloc(sizeof(*dev))))
 		goto err1;


### PR DESCRIPTION
When interface entries have duplicated names, the later names are simply
dropped, leaking memory.

