### PR TITLE
Jenkins-CI: Removed shm daily builds

### DIFF
--- a/contrib/intel/jenkins/tests.py
+++ b/contrib/intel/jenkins/tests.py
@@ -141,7 +141,8 @@ class Fabtest(Test):
    
     @property
     def execute_condn(self):     
-        return True
+        return True if (self.core_prov != 'shm' or \
+                        self.ofi_build_mode == 'dbg') else False
 
     def execute_cmd(self):
         curdir = os.getcwd()


### PR DESCRIPTION
Removed shm from dl/reg builds, to investigate
fabtest failures.

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>