### PR TITLE
Proposal: HMEM override operations

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013-2017 Intel Corporation. All rights reserved.
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -38,6 +39,7 @@
 #include <stddef.h>
 #include <sys/types.h>
 #include <sys/uio.h>
+#include <rdma/fi_errno.h>
 
 #ifdef __GNUC__
 #define FI_DEPRECATED_FUNC __attribute__((deprecated))
@@ -531,6 +533,8 @@ struct fi_ops {
 	int	(*ops_open)(struct fid *fid, const char *name,
 			    uint64_t flags, void **ops, void *context);
 	int	(*tostr)(const struct fid *fid, char *buf, size_t len);
+	int	(*ops_set)(struct fid *fid, const char *name, uint64_t flags,
+			   void *ops, void *context);
 };
 
 /* All fabric interface descriptors must start with this structure */
@@ -648,6 +652,14 @@ fi_open_ops(struct fid *fid, const char *name, uint64_t flags,
 	    void **ops, void *context)
 {
 	return fid->ops->ops_open(fid, name, flags, ops, context);
+}
+
+static inline int
+fi_set_ops(struct fid *fid, const char *name, uint64_t flags,
+	   void *ops, void *context)
+{
+	return FI_CHECK_OP(fid->ops, struct fi_ops, ops_set) ?
+		fid->ops->ops_set(fid, name, flags, ops, context) : -FI_ENOSYS;
 }
 
 enum fi_type {

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -140,6 +140,23 @@ struct fi_mr_modify {
 	struct fi_mr_attr	attr;
 };
 
+#define FI_SET_OPS_HMEM_OVERRIDE "hmem_override_ops"
+
+struct fi_hmem_override_ops {
+	size_t	size;
+
+	ssize_t	(*copy_from_hmem_iov)(void *dest, size_t size,
+				      const struct iovec *hmem_iov,
+				      enum fi_hmem_iface hmem_iface,
+				      size_t hmem_iov_count,
+				      uint64_t hmem_iov_offset);
+
+	ssize_t (*copy_to_hmem_iov)(const struct iovec *hmem_iov,
+				    enum fi_hmem_iface hmem_iface,
+				    size_t hmem_iov_count,
+				    uint64_t hmem_iov_offset, const void *src,
+				    size_t size);
+};
 
 #ifdef FABRIC_DIRECT
 #include <rdma/fi_direct_atomic_def.h>


### PR DESCRIPTION
The following PR is a proposal for overriding the HMEM data movement operations a provider may used. Users defined a ```struct fi_hmem_override_ops``` structure and register the structure with a fid via ```fi_set_ops()``` with the ```FI_SET_OPS_HMEM_OVERRIDE``` string.

At this point, I am looking for feedback. I can provide a concrete example of the verbs;ofi_rxm provider using this. But, I need verbs;ofi_rxm HMEM support first https://github.com/ofiwg/libfabric/pull/5885.