### PR TITLE
Free any remaining buffered entries in sock_rx_ctx_free

### DIFF
--- a/prov/sockets/src/sock_ctx.c
+++ b/prov/sockets/src/sock_ctx.c
@@ -71,6 +71,15 @@ struct sock_rx_ctx *sock_rx_ctx_alloc(const struct fi_rx_attr *attr,
 
 void sock_rx_ctx_free(struct sock_rx_ctx *rx_ctx)
 {
+	struct sock_rx_entry *rx_buffered;
+
+	/* free any remaining buffered entries */
+	while (!dlist_empty(&rx_ctx->rx_buffered_list)) {
+		dlist_pop_front(&rx_ctx->rx_buffered_list,
+		                struct sock_rx_entry, rx_buffered, entry);
+		free(rx_buffered);
+	}
+
 	fastlock_destroy(&rx_ctx->lock);
 	free(rx_ctx->rx_entry_pool);
 	free(rx_ctx);


### PR DESCRIPTION
This happens when there is unclaimed messages at finalize. Free them to prevent leaking memory.

It is debatable that whether this is user error since users failed to post matching receive. We encountered this in a test of dynamic connection. When connection attempt fails (timeout) and we report as recoverable error to user, there seems no easy way to clean up the unexpected messages.

Potentially other lists also need cleanup.