### PR TITLE
prov/tcp Do not alter rand() pseudo random sequence

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -371,6 +371,8 @@ static inline uint32_t ofi_xorshift_random_r(uint32_t *seed)
 	return *seed = ofi_xorshift_random(*seed);
 }
 
+uint32_t ofi_generate_seed(void);
+
 size_t ofi_vrb_speed(uint8_t speed, uint8_t width);
 
 #ifdef __cplusplus

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -366,6 +366,11 @@ static inline uint32_t ofi_xorshift_random(uint32_t val)
 	return val;
 }
 
+static inline uint32_t ofi_xorshift_random_r(uint32_t *seed)
+{
+	return *seed = ofi_xorshift_random(*seed);
+}
+
 size_t ofi_vrb_speed(uint8_t speed, uint8_t width);
 
 #ifdef __cplusplus

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -188,9 +188,12 @@ static int tcpx_ep_shutdown(struct fid_ep *ep, uint64_t flags)
 static int tcpx_bind_to_port_range(SOCKET sock, void* src_addr, size_t addrlen)
 {
 	int ret, i, rand_port_number;
+	static uint32_t seed;
+	if (!seed)
+		seed = ofi_generate_seed();
 
-	rand_port_number = rand() % (port_range.high + 1 - port_range.low) +
-			   port_range.low;
+	rand_port_number = ofi_xorshift_random_r(&seed) %
+			   (port_range.high + 1 - port_range.low) + port_range.low;
 
 	for (i = port_range.low; i <= port_range.high; i++, rand_port_number++) {
 		if (rand_port_number > port_range.high)

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -54,8 +54,6 @@ struct tcpx_port_range port_range = {
 
 static void tcpx_init_env(void)
 {
-	srand(getpid());
-
 	fi_param_get_int(&tcpx_prov, "port_high_range", &port_range.high);
 	fi_param_get_int(&tcpx_prov, "port_low_range", &port_range.low);
 

--- a/src/common.c
+++ b/src/common.c
@@ -221,6 +221,20 @@ int ofi_check_rx_mode(const struct fi_info *info, uint64_t flags)
 	return (info->mode & flags) ? 1 : 0;
 }
 
+uint32_t ofi_generate_seed(void)
+{
+	/* Time returns long; keep the lower and most significant 32 bits */
+	uint32_t rand_seed;
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
+	rand_seed = ((getpid() & 0xffffffff) << 16);
+
+	/* Mix the PID into the upper bits */
+	rand_seed |= (uint32_t) tv.tv_usec;
+
+	return rand_seed;
+}
+
 uint64_t ofi_gettime_ns(void)
 {
 	struct timespec now;


### PR DESCRIPTION
Context: Some applications such as IOR (with random pattern) depend
on having same initial seed across all MPI processes. Other
applications may also rely on a given pseudo random sequence.
   
The TCP provider calls:
    - srand(getpid()): initializing a different seed per process
    - rand(): changes the pseudo random sequence from the application
      standpoint.
    
This patch serie prevents the TCP provider from interfering with the
rand() pseudo random sequence.