### PR TITLE
prov/efa: introduce efa_min_read_msg_size to rxr_env

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -212,6 +212,7 @@ struct rxr_env {
 	size_t efa_cq_read_size;
 	size_t shm_cq_read_size;
 	size_t efa_max_medium_msg_size;
+	size_t efa_min_read_msg_size;
 	size_t efa_min_read_write_size;
 	size_t efa_read_segment_size;
 };

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -68,6 +68,7 @@ struct rxr_env rxr_env = {
 	.efa_cq_read_size = 50,
 	.shm_cq_read_size = 50,
 	.efa_max_medium_msg_size = 65536,
+	.efa_min_read_msg_size = 1048576,
 	.efa_min_read_write_size = 65536,
 	.efa_read_segment_size = 1073741824,
 };
@@ -111,6 +112,8 @@ static void rxr_init_env(void)
 			 &rxr_env.shm_cq_read_size);
 	fi_param_get_size_t(&rxr_prov, "inter_max_medium_message_size",
 			    &rxr_env.efa_max_medium_msg_size);
+	fi_param_get_size_t(&rxr_prov, "inter_min_read_message_size",
+			    &rxr_env.efa_min_read_msg_size);
 	fi_param_get_size_t(&rxr_prov, "inter_min_read_write_size",
 			    &rxr_env.efa_min_read_write_size);
 	fi_param_get_size_t(&rxr_prov, "inter_read_segment_size",
@@ -704,7 +707,10 @@ EFA_INI
 	fi_param_define(&rxr_prov, "shm_cq_read_size", FI_PARAM_SIZE_T,
 			"Set the number of SHM completion entries to read for one loop for one iteration of the progress engine. (Default: 50)");
 	fi_param_define(&rxr_prov, "inter_max_medium_message_size", FI_PARAM_INT,
-			"The maximum message size for inter EFA medium message protocol, messages whose size is larger than this value will be sent either by read message protocol (depend on firmware support), or long message protocol (Default 65536).");
+			"The maximum message size for inter EFA medium message protocol (Default 65536).");
+	fi_param_define(&rxr_prov, "inter_min_read_message_size", FI_PARAM_INT,
+			"The minimum message size for inter EFA read message protocol. If instance support RDMA read, messages whose size is larger than this value will be sent by read message protocol (Default 1048576).");
+
 	fi_param_define(&rxr_prov, "inter_min_read_write_size", FI_PARAM_INT,
 			"The mimimum message size for inter EFA write to use read write protocol. If firmware support RDMA read, and FI_EFA_USE_DEVICE_RDMA is 1, write requests whose size is larger than this value will use the read write protocol (Default 65536).");
 	fi_param_define(&rxr_prov, "inter_read_segment_size", FI_PARAM_INT,

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -109,7 +109,8 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 						  RXR_MEDIUM_MSGRTM_PKT + tagged, 0);
 	}
 
-	if (efa_both_support_rdma_read(rxr_ep, peer) &&
+	if (tx_entry->total_len >= rxr_env.efa_min_read_msg_size &&
+	    efa_both_support_rdma_read(rxr_ep, peer) &&
 	    (tx_entry->desc[0] || efa_mr_cache_enable)) {
 		/* use read message protocol */
 		err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,


### PR DESCRIPTION
This patch introduce efa_min_read_msg_size to rxr_env. This value
is used to limit the usage of the read message protocols.

Before this patch, messages whose size is larger than
rxr_env.max_medium_msg_size will be sent using read message
protocol (if both end points support RDMA read).

After this patch, messages whose size is larger than
rxrenv.efa_min_read_msg_size will be sent using read message
protocol. Messages whose size is between rxr_env.max_medium_msg_size
and rxr_env.efa_min_read_msg_size will be sent using the CTS
base long message protocol.

By default efa_min_read_msg_size is set to 1M. It can be changed
by setting the environmental variable:

	FI_EFA_INTER_MIN_READ_MESSAGE_SIZE

Signed-off-by: Wei Zhang <wzam@amazon.com>