### PR TITLE
Fabtests: Replace python in runfabtests.sh with python3 or python2

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -74,12 +74,19 @@ declare -i pass_count=0
 declare -i fail_count=0
 declare -i total_failures=0
 
-if [[ "$(uname)" == "FreeBSD" ]]; then
-    declare -ri FI_ENODATA=$(python -c 'import errno; print(errno.ENOMSG)')
-else
-    declare -ri FI_ENODATA=$(python -c 'import errno; print(errno.ENODATA)')
+python=$(which python3 2>/dev/null) || python=$(which python2 2>/dev/null)
+
+if [ $? -ne 0 ]; then
+	echo "Unable to find python dependency, exiting..."
+	exit 1
 fi
-declare -ri FI_ENOSYS=$(python -c 'import errno; print(errno.ENOSYS)')
+
+if [[ "$(uname)" == "FreeBSD" ]]; then
+    declare -ri FI_ENODATA=$($python -c 'import errno; print(errno.ENOMSG)')
+else
+    declare -ri FI_ENODATA=$($python -c 'import errno; print(errno.ENODATA)')
+fi
+declare -ri FI_ENOSYS=$($python -c 'import errno; print(errno.ENOSYS)')
 
 neg_unit_tests=(
 	"fi_dgram g00n13s"


### PR DESCRIPTION
In RHEL8, python is no longer linked to python 2. Instead, it is
preferred that the user specifies python2 or python3 (rather than
symlinking or setting alternatives). Since our scripts look to be
compatible with either version, we check for both and use python3 by
default.

This also exits the runfabtests script if python is not detected rather
than proceeding on (I have seen some unusual bugs when continuing without
python).

Signed-off-by: William Zhang <wilzhang@amazon.com>