### PR TITLE
Fabtests: Add check for python in runfabtests.sh

### DIFF
--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -74,7 +74,7 @@ declare -i pass_count=0
 declare -i fail_count=0
 declare -i total_failures=0
 
-python=$(which python3 2>/dev/null) || python=$(which python2 2>/dev/null)
+python=$(which python3 2>/dev/null) || python=$(which python2 2>/dev/null) || python=$(which python 2>/dev/null)
 
 if [ $? -ne 0 ]; then
 	echo "Unable to find python dependency, exiting..."


### PR DESCRIPTION
In order to prevent some possible issues with older systems, add a check
for python in addition to python3 and python2. This should ensure
that we're backward compatible.

Signed-off-by: William Zhang <wilzhang@amazon.com>