### PR TITLE
cleanups in response to coverity report

### DIFF
--- a/prov/hook/hook_debug/src/hook_debug.c
+++ b/prov/hook/hook_debug/src/hook_debug.c
@@ -863,8 +863,10 @@ int hook_debug_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
 		return -FI_ENOMEM;
 
 	ret = hook_eq_init(fabric, attr, eq, context, &myeq->hook_eq);
-	if (ret)
+	if (ret) {
 		free(myeq);
+		return ret;
+	}
 
 	myeq->hook_eq.eq.ops = &hook_debug_eq_ops;
 	myeq->hook_eq.eq.fid.ops = &hook_debug_eq_fid_ops;

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -484,7 +484,7 @@ static int util_wait_fd_close(struct fid *fid)
 	if (wait->util_wait.wait_obj == FI_WAIT_FD)
 		ofi_epoll_close(wait->epoll_fd);
 	else
-		ofi_epoll_close(wait->epoll_fd);
+		ofi_pollfds_close(wait->pollfds);
 	free(wait);
 	return 0;
 }


### PR DESCRIPTION
possible use after free in error handling (hooking provider)
and fd memory leak resulting from calling wrong cleanup function