### PR TITLE
prov/efa: FI_DELIVERY_COMPLETE Support for Eager Messages

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -395,6 +395,17 @@ bool efa_peer_support_rdma_read(struct rxr_peer *peer)
 }
 
 static inline
+bool rxr_peer_support_delivery_complete(struct rxr_peer *peer)
+{
+	/* FI_DELIVERY_COMPLETE is an extra feature defined in version 4 (the base version).
+	 * Because it is an extra feature, an EP will assume the peer does not support
+	 * it before a handshake packet was received.
+	 */
+	return (peer->flags & RXR_PEER_HANDSHAKE_RECEIVED) &&
+	       (peer->features[0] & RXR_REQ_FEATURE_DELIVERY_COMPLETE);
+}
+
+static inline
 bool efa_both_support_rdma_read(struct rxr_ep *ep, struct rxr_peer *peer)
 {
 	if (!rxr_env.use_device_rdma)

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -167,7 +167,7 @@ static inline void rxr_poison_mem_region(uint32_t *ptr, size_t size)
  * 60 - 63      provider specific
  */
 #define RXR_NO_COMPLETION	BIT_ULL(60)
-
+#define RXR_NO_COUNTER  	BIT_ULL(61)
 /*
  * RM flags
  */

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -858,7 +858,8 @@ void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entr
 		if (tx_entry->fi_flags & FI_COMPLETION) {
 			rxr_cq_write_tx_completion(ep, tx_entry);
 		} else {
-			efa_cntr_report_tx_completion(&ep->util_ep, tx_entry->cq_entry.flags);
+			if (!(tx_entry->fi_flags & RXR_NO_COUNTER))
+				efa_cntr_report_tx_completion(&ep->util_ep, tx_entry->cq_entry.flags);
 			rxr_release_tx_entry(ep, tx_entry);
 		}
 	} else {

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -829,6 +829,8 @@ void rxr_ep_set_features(struct rxr_ep *ep)
 	/* RDMA read is an extra feature defined in protocol version 4 (the base version) */
 	if (efa_ep_support_rdma_read(ep->rdm_ep))
 		ep->features[0] |= RXR_REQ_FEATURE_RDMA_READ;
+
+	ep->features[0] |= RXR_REQ_FEATURE_DELIVERY_COMPLETE;
 }
 
 static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -69,10 +69,14 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	assert(RXR_LONG_MSGRTM_PKT + 1 == RXR_LONG_TAGRTM_PKT);
 	assert(RXR_MEDIUM_MSGRTM_PKT + 1 == RXR_MEDIUM_TAGRTM_PKT);
 
+	assert(RXR_DC_EAGER_MSGRTM_PKT + 1 == RXR_DC_EAGER_TAGRTM_PKT);
+
 	int tagged;
 	size_t max_rtm_data_size;
 	ssize_t err;
 	struct rxr_peer *peer;
+	ssize_t delivery_complete_requested;
+	int ctrl_type;
 
 	assert(tx_entry->op == ofi_op_msg || tx_entry->op == ofi_op_tagged);
 	tagged = (tx_entry->op == ofi_op_tagged);
@@ -82,6 +86,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 						      tx_entry->addr,
 						      RXR_EAGER_MSGRTM_PKT + tagged);
 
+	delivery_complete_requested = rxr_ep->util_ep.tx_op_flags & FI_DELIVERY_COMPLETE;
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
 
 	if (peer->is_local) {
@@ -93,10 +98,41 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry, rtm_type + tagged, 0);
 	}
 
+	if (delivery_complete_requested && !(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)) {
+		/*
+		 * Because delivery complete is defined as an extra
+		 * feature, the receiver might not support it.
+		 *
+		 * The sender cannot send with FI_DELIVERY_COMPLETE
+		 * if the peer is not able to handle it.
+		 *
+		 * If the sender does not know whether the peer
+		 * can handle it, it needs to wait for
+		 * a handshake packet from the peer.
+		 *
+		 * The handshake packet contains
+		 * the information whether the peer
+		 * support it or not.
+		 */
+		err = rxr_pkt_wait_handshake(rxr_ep, tx_entry->addr, peer);
+		if (OFI_UNLIKELY(err))
+			return err;
+
+		assert(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED);
+	}
+
+	if (delivery_complete_requested &&
+	    peer->flags & RXR_PEER_HANDSHAKE_RECEIVED &&
+		!rxr_peer_support_delivery_complete(peer))
+		return -FI_EOPNOTSUPP;
+
 	/* inter instance message */
-	if (tx_entry->total_len <= max_rtm_data_size)
+	if (tx_entry->total_len <= max_rtm_data_size) {
+		ctrl_type = (delivery_complete_requested) ?
+			RXR_DC_EAGER_MSGRTM_PKT : RXR_EAGER_MSGRTM_PKT;
 		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
-						  RXR_EAGER_MSGRTM_PKT + tagged, 0);
+						  ctrl_type + tagged, 0);
+	}
 
 	if (tx_entry->total_len <= rxr_env.efa_max_medium_msg_size) {
 		/* we do not check the return value of rxr_ep_init_mr_desc()

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -36,6 +36,9 @@
 #include "rxr_cntr.h"
 #include "rxr_pkt_cmd.h"
 
+/* Handshake wait timeout in microseconds */
+#define RXR_HANDSHAKE_WAIT_TIMEOUT 1000000
+
 /* This file implements 4 actions that can be applied to a packet:
  *          posting,
  *          handling send completion and,
@@ -120,6 +123,9 @@ int rxr_pkt_init_ctrl(struct rxr_ep *rxr_ep, int entry_type, void *x_entry,
 	case RXR_ATOMRSP_PKT:
 		ret = rxr_pkt_init_atomrsp(rxr_ep, (struct rxr_rx_entry *)x_entry, pkt_entry);
 		break;
+	case RXR_RECEIPT_PKT:
+		ret = rxr_pkt_init_receipt(rxr_ep, (struct rxr_rx_entry *)x_entry, pkt_entry);
+		break;
 	case RXR_EAGER_MSGRTM_PKT:
 		ret = rxr_pkt_init_eager_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
 		break;
@@ -168,6 +174,12 @@ int rxr_pkt_init_ctrl(struct rxr_ep *rxr_ep, int entry_type, void *x_entry,
 	case RXR_COMPARE_RTA_PKT:
 		ret = rxr_pkt_init_compare_rta(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
 		break;
+	case RXR_DC_EAGER_MSGRTM_PKT:
+		ret = rxr_pkt_init_dc_eager_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		break;
+	case RXR_DC_EAGER_TAGRTM_PKT:
+		ret = rxr_pkt_init_dc_eager_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
+		break;
 	default:
 		ret = -FI_EINVAL;
 		assert(0 && "unknown pkt type to init");
@@ -197,6 +209,9 @@ void rxr_pkt_handle_ctrl_sent(struct rxr_ep *rxr_ep, struct rxr_pkt_entry *pkt_e
 		break;
 	case RXR_ATOMRSP_PKT:
 		rxr_pkt_handle_atomrsp_sent(rxr_ep, pkt_entry);
+		break;
+	case RXR_RECEIPT_PKT:
+		rxr_pkt_handle_receipt_sent(rxr_ep, pkt_entry);
 		break;
 	case RXR_EAGER_MSGRTM_PKT:
 	case RXR_EAGER_TAGRTM_PKT:
@@ -231,6 +246,10 @@ void rxr_pkt_handle_ctrl_sent(struct rxr_ep *rxr_ep, struct rxr_pkt_entry *pkt_e
 	case RXR_FETCH_RTA_PKT:
 	case RXR_COMPARE_RTA_PKT:
 		rxr_pkt_handle_rta_sent(rxr_ep, pkt_entry);
+		break;
+	case RXR_DC_EAGER_MSGRTM_PKT:
+	case RXR_DC_EAGER_TAGRTM_PKT:
+		/* no action to be taken here */
 		break;
 	default:
 		assert(0 && "Unknown packet type to handle sent");
@@ -362,6 +381,86 @@ ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_en
 }
 
 /*
+ * This function is used for any extra feature that does not have an alternative,
+ * for example FI_DELIVERY_COMPLETE
+ *
+ * This function will send a eager rtw packet with no data. Then keep calling
+ * rxr_ep_progress_internal() until rxr_peer->flags has the HANDSHAKE_RECEIVED flag.
+ * Upon receiving the eager RTW, the receiver will post a handshake,
+ * which will be processed in sender's rxr_ep_progress_internal().
+ *
+ * ep: The endpoint on which the packet for triggering handshake will be sent.
+ * peer: The peer from which the sender receives handshake.
+ * addr: The address of the peer.
+ *
+ * This function will return 0 if sender successfully receives / have already
+ * received the handshake from the peer
+ *
+ * This function will return FI_EAGAIN if it fails to allocate or send the trigger packet or
+ * it fails to receive handshake packet within a certain period of time.
+ */
+
+ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rxr_peer *peer)
+{
+	struct rxr_tx_entry *tx_entry;
+	ssize_t err;
+
+	uint64_t start, endwait;
+
+	if (peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)
+		return 0;
+
+	tx_entry = ofi_buf_alloc(ep->tx_entry_pool);
+	if (OFI_UNLIKELY(!tx_entry)) {
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "TX entries exhausted.\n");
+		return -FI_EAGAIN;
+	}
+
+	tx_entry->total_len = 0;
+	tx_entry->addr = addr;
+	tx_entry->msg_id = -1;
+	tx_entry->cq_entry.flags = FI_RMA | FI_WRITE;
+	tx_entry->cq_entry.buf = NULL;
+	dlist_init(&tx_entry->queued_pkts);
+
+	tx_entry->type = RXR_TX_ENTRY;
+	tx_entry->op = ofi_op_write;
+	tx_entry->state = RXR_TX_REQ;
+
+	tx_entry->send_flags = 0;
+	tx_entry->bytes_acked = 0;
+	tx_entry->bytes_sent = 0;
+	tx_entry->window = 0;
+	tx_entry->rma_iov_count = 0;
+	tx_entry->iov_count = 0;
+	tx_entry->iov_index = 0;
+	tx_entry->iov_mr_start = 0;
+	tx_entry->iov_offset = 0;
+	tx_entry->fi_flags = RXR_NO_COMPLETION | RXR_NO_COUNTER;
+
+#if ENABLE_DEBUG
+	dlist_insert_tail(&tx_entry->tx_entry_entry, &ep->tx_entry_list);
+#endif
+
+	err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_EAGER_RTW_PKT, 0);
+
+	if (OFI_UNLIKELY(err))
+		return err;
+
+	start = ofi_gettime_us();
+	endwait = start + RXR_HANDSHAKE_WAIT_TIMEOUT;
+	while (start < endwait && !(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)) {
+		rxr_ep_progress_internal(ep);
+		start = ofi_gettime_us();
+	}
+
+	if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED))
+		return FI_ETIMEDOUT;
+
+	return 0;
+}
+
+/*
  *   Functions used to handle packet send completion
  */
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *comp)
@@ -390,6 +489,9 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *
 		return;
 	case RXR_ATOMRSP_PKT:
 		rxr_pkt_handle_atomrsp_send_completion(ep, pkt_entry);
+		break;
+	case RXR_RECEIPT_PKT:
+		rxr_pkt_handle_receipt_send_completion(ep, pkt_entry);
 		break;
 	case RXR_EAGER_MSGRTM_PKT:
 	case RXR_EAGER_TAGRTM_PKT:
@@ -427,6 +529,12 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *
 		/* no action to be taken here */
 		break;
 	case RXR_COMPARE_RTA_PKT:
+		/* no action to be taken here */
+		break;
+	case RXR_DC_EAGER_MSGRTM_PKT:
+		/* no action to be taken here */
+		break;
+	case RXR_DC_EAGER_TAGRTM_PKT:
 		/* no action to be taken here */
 		break;
 	default:
@@ -577,6 +685,9 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 	case RXR_ATOMRSP_PKT:
 		rxr_pkt_handle_atomrsp_recv(ep, pkt_entry);
 		return;
+	case RXR_RECEIPT_PKT:
+		rxr_pkt_handle_receipt_recv(ep, pkt_entry);
+		return;
 	case RXR_EAGER_MSGRTM_PKT:
 	case RXR_EAGER_TAGRTM_PKT:
 	case RXR_MEDIUM_MSGRTM_PKT:
@@ -588,6 +699,8 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 	case RXR_WRITE_RTA_PKT:
 	case RXR_FETCH_RTA_PKT:
 	case RXR_COMPARE_RTA_PKT:
+	case RXR_DC_EAGER_MSGRTM_PKT:
+	case RXR_DC_EAGER_TAGRTM_PKT:
 		rxr_pkt_handle_rtm_rta_recv(ep, pkt_entry);
 		return;
 	case RXR_EAGER_RTW_PKT:

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -51,6 +51,8 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 				    struct fi_cq_data_entry *cq_entry,
 				    fi_addr_t src_addr);
 
+ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rxr_peer *peer);
+
 #if ENABLE_DEBUG
 void rxr_pkt_print(char *prefix,
 		   struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -67,6 +67,7 @@
 #define RXR_EOR_PKT		7
 #define RXR_ATOMRSP_PKT         8
 #define RXR_HANDSHAKE_PKT	9
+#define RXR_RECEIPT_PKT 10
 
 #define RXR_REQ_PKT_BEGIN		64
 #define RXR_BASELINE_REQ_PKT_BEGIN	64
@@ -90,7 +91,10 @@
 #define RXR_READ_TAGRTM_PKT		129
 #define RXR_READ_RTW_PKT		130
 #define RXR_READ_RTR_PKT		131
-#define RXR_EXTRA_REQ_PKT_END		132
+
+#define RXR_DC_EAGER_MSGRTM_PKT 	132
+#define RXR_DC_EAGER_TAGRTM_PKT 	133
+#define RXR_EXTRA_REQ_PKT_END		134
 
 /*
  *  Packet fields common to all rxr packets. The other packet headers below must
@@ -389,6 +393,35 @@ static inline struct rxr_atomrsp_hdr *rxr_get_atomrsp_hdr(void *pkt)
 {
 	return (struct rxr_atomrsp_hdr *)pkt;
 }
+
+/* receipt packet headers */
+struct rxr_receipt_hdr {
+	uint8_t type;
+	uint8_t version;
+	uint16_t flags;
+	/* end of rxr_base_hdr */
+	uint32_t tx_id;
+	uint32_t msg_id;
+	int32_t ret_code;
+	int32_t padding;
+};
+
+static inline
+struct rxr_receipt_hdr *rxr_get_receipt_hdr(void *pkt)
+{
+	return (struct rxr_receipt_hdr *)pkt;
+}
+
+/* receipt packet functions: init, handle_sent, handle_send_completion, recv*/
+int rxr_pkt_init_receipt(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
+			 struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_receipt_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_receipt_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
+				 struct rxr_pkt_entry *pkt_entry);
 
 /* atomrsp functions: init, handle_sent, handle_send_completion, recv */
 int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -70,6 +70,8 @@ struct rxr_req_inf REQ_INF_LIST[] = {
 	[RXR_LONG_TAGRTM_PKT] = {4, sizeof(struct rxr_long_tagrtm_hdr), 0},
 	[RXR_READ_MSGRTM_PKT] = {4, sizeof(struct rxr_read_msgrtm_hdr), RXR_REQ_FEATURE_RDMA_READ},
 	[RXR_READ_TAGRTM_PKT] = {4, sizeof(struct rxr_read_tagrtm_hdr), RXR_REQ_FEATURE_RDMA_READ},
+	[RXR_DC_EAGER_MSGRTM_PKT] = {4, sizeof(struct rxr_dc_eager_msgrtm_hdr), 0},
+	[RXR_DC_EAGER_TAGRTM_PKT] = {4, sizeof(struct rxr_dc_eager_tagrtm_hdr), 0},
 	/* rtw header */
 	[RXR_EAGER_RTW_PKT] = {4, sizeof(struct rxr_eager_rtw_hdr), 0},
 	[RXR_LONG_RTW_PKT] = {4, sizeof(struct rxr_long_rtw_hdr), 0},
@@ -384,6 +386,19 @@ ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
 	return 0;
 }
 
+ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
+				     struct rxr_tx_entry *tx_entry,
+				     struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_dc_eager_msgrtm_hdr *dc_eager_msgrtm_hdr;
+
+	rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_MSGRTM_PKT, 0, pkt_entry);
+	dc_eager_msgrtm_hdr = rxr_get_dc_eager_msgrtm_hdr(pkt_entry->pkt);
+	dc_eager_msgrtm_hdr->hdr.flags |= RXR_REQ_WAIT_RECEIPT;
+	dc_eager_msgrtm_hdr->tx_id = tx_entry->tx_id;
+	return 0;
+}
+
 ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
 				  struct rxr_tx_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry)
@@ -395,6 +410,24 @@ ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
 	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
 	base_hdr->flags |= RXR_REQ_TAGGED;
 	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
+	return 0;
+}
+
+ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
+				     struct rxr_tx_entry *tx_entry,
+				     struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_base_hdr *base_hdr;
+	struct rxr_dc_eager_tagrtm_hdr *dc_eager_tagrtm_hdr;
+
+	rxr_pkt_init_rtm(ep, tx_entry, RXR_DC_EAGER_TAGRTM_PKT, 0, pkt_entry);
+	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	base_hdr->flags |= RXR_REQ_TAGGED;
+	base_hdr->flags |= RXR_REQ_WAIT_RECEIPT;
+	rxr_pkt_rtm_settag(pkt_entry, tx_entry->tag);
+
+	dc_eager_tagrtm_hdr = rxr_get_dc_eager_tagrtm_hdr(pkt_entry->pkt);
+	dc_eager_tagrtm_hdr->tx_id = tx_entry->tx_id;
 	return 0;
 }
 
@@ -591,6 +624,8 @@ size_t rxr_pkt_rtm_total_len(struct rxr_pkt_entry *pkt_entry)
 	switch (base_hdr->type) {
 	case RXR_EAGER_MSGRTM_PKT:
 	case RXR_EAGER_TAGRTM_PKT:
+	case RXR_DC_EAGER_MSGRTM_PKT:
+	case RXR_DC_EAGER_TAGRTM_PKT:
 		return rxr_pkt_req_data_size(pkt_entry);
 	case RXR_MEDIUM_MSGRTM_PKT:
 	case RXR_MEDIUM_TAGRTM_PKT:
@@ -853,6 +888,7 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	char *data;
 	size_t hdr_size, data_size, bytes_left;
 	ssize_t ret;
+	struct rxr_base_hdr *base_hdr;
 
 	assert(rx_entry->state == RXR_RX_MATCHED);
 
@@ -866,7 +902,8 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 	if (rx_entry->cq_entry.len > rx_entry->total_len)
 		rx_entry->cq_entry.len = rx_entry->total_len;
 
-	pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+	base_hdr = rxr_get_base_hdr(pkt_entry->pkt);
+	pkt_type = base_hdr->type;
 	if (pkt_type == RXR_READ_MSGRTM_PKT || pkt_type == RXR_READ_TAGRTM_PKT)
 		return rxr_pkt_proc_matched_read_rtm(ep, rx_entry, pkt_entry);
 
@@ -883,10 +920,19 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 		 * rxr_cq_handle_rx_completion() releases pkt_entry, thus
 		 * we do not release it here.
 		 */
-		rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
-		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
-		rxr_release_rx_entry(ep, rx_entry);
-		ret = 0;
+		if (base_hdr->flags & RXR_REQ_WAIT_RECEIPT) {
+			rx_entry->tx_id = rxr_get_dc_rtm_base_hdr(pkt_entry->pkt)->tx_id;
+			rx_entry->msg_id = rxr_get_rtm_base_hdr(pkt_entry->pkt)->msg_id;
+			rx_entry->addr = pkt_entry->addr;
+			ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_RECEIPT_PKT, 0);
+			rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
+			rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
+		} else {
+			rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
+			rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
+			rxr_release_rx_entry(ep, rx_entry);
+			ret = 0;
+		}
 	} else {
 		/*
 		 * long message protocol
@@ -980,11 +1026,13 @@ ssize_t rxr_pkt_proc_rtm_rta(struct rxr_ep *ep,
 	case RXR_MEDIUM_MSGRTM_PKT:
 	case RXR_LONG_MSGRTM_PKT:
 	case RXR_READ_MSGRTM_PKT:
+	case RXR_DC_EAGER_MSGRTM_PKT:
 		return rxr_pkt_proc_msgrtm(ep, pkt_entry);
 	case RXR_EAGER_TAGRTM_PKT:
 	case RXR_MEDIUM_TAGRTM_PKT:
 	case RXR_LONG_TAGRTM_PKT:
 	case RXR_READ_TAGRTM_PKT:
+	case RXR_DC_EAGER_TAGRTM_PKT:
 		return rxr_pkt_proc_tagrtm(ep, pkt_entry);
 	case RXR_WRITE_RTA_PKT:
 		return rxr_pkt_proc_write_rta(ep, pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -67,11 +67,13 @@
 #define RXR_REQ_TAGGED			BIT_ULL(3)
 #define RXR_REQ_RMA			BIT_ULL(4)
 #define RXR_REQ_ATOMIC			BIT_ULL(5)
+#define RXR_REQ_WAIT_RECEIPT		BIT_ULL(6)
 
 /*
  *     Extra Feature Flags
  */
 #define RXR_REQ_FEATURE_RDMA_READ	BIT_ULL(0)
+#define RXR_REQ_FEATURE_DELIVERY_COMPLETE BIT_ULL(1)
 
 /*
  *     Utility struct and functions for
@@ -126,6 +128,18 @@ struct rxr_rtm_base_hdr *rxr_get_rtm_base_hdr(void *pkt)
 	return (struct rxr_rtm_base_hdr *)pkt;
 }
 
+struct rxr_dc_rtm_base_hdr {
+	struct rxr_rtm_base_hdr hdr;
+	uint32_t tx_id;
+	uint32_t padding;
+};
+
+static inline
+struct rxr_dc_rtm_base_hdr *rxr_get_dc_rtm_base_hdr(void *pkt)
+{
+	return (struct rxr_dc_rtm_base_hdr *)pkt;
+}
+
 static inline
 uint32_t rxr_pkt_msg_id(struct rxr_pkt_entry *pkt_entry)
 {
@@ -178,6 +192,31 @@ struct rxr_eager_tagrtm_hdr {
 	struct rxr_rtm_base_hdr hdr;
 	uint64_t tag;
 };
+
+struct rxr_dc_eager_msgrtm_hdr {
+	struct rxr_rtm_base_hdr hdr;
+	uint32_t tx_id;
+	uint32_t padding;
+};
+
+static inline
+struct rxr_dc_eager_msgrtm_hdr *rxr_get_dc_eager_msgrtm_hdr(void *pkt)
+{
+	return (struct rxr_dc_eager_msgrtm_hdr *)pkt;
+}
+
+struct rxr_dc_eager_tagrtm_hdr {
+	struct rxr_rtm_base_hdr hdr;
+	uint32_t tx_id;
+	uint32_t padding;
+	uint64_t tag;
+};
+
+static inline
+struct rxr_dc_eager_tagrtm_hdr *rxr_get_dc_eager_tagrtm_hdr(void *pkt)
+{
+	return (struct rxr_dc_eager_tagrtm_hdr *)pkt;
+}
 
 struct rxr_medium_rtm_base_hdr {
 	struct rxr_rtm_base_hdr hdr;
@@ -259,6 +298,10 @@ ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
 				  struct rxr_tx_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
+ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
+				     struct rxr_tx_entry *tx_entry,
+				     struct rxr_pkt_entry *pkt_entry);
+
 ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
 				  struct rxr_tx_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
@@ -266,6 +309,10 @@ ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
 ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
 				   struct rxr_tx_entry *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry);
+
+ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
+				     struct rxr_tx_entry *tx_entry,
+				     struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
 				   struct rxr_tx_entry *tx_entry,


### PR DESCRIPTION
This patch is created to add support for FI_DELIVERY_COMPLETE
with packets of RXR_EAGER_MSGRTM_PKT and RXR_EAGER_TAGRTM type.

Signed-off-by: Ao Li <aolia@amazon.com>