### PR TITLE
Initial verbs provider HMEM support

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -430,6 +430,7 @@ struct vrb_mem_desc {
 	/* this field is used only by MR cache operations */
 	struct ofi_mr_entry	*entry;
 	struct ofi_mr_info	info;
+	uint32_t		lkey;
 };
 
 extern struct fi_ops_mr vrb_mr_ops;
@@ -886,7 +887,7 @@ int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc);
 #define vrb_init_sge(buf, len, desc) (struct ibv_sge)	\
 	{ .addr = (uintptr_t) buf,			\
 	  .length = (uint32_t) len,			\
-	  .lkey = (uint32_t) (uintptr_t) desc }
+	  .lkey = (desc) ? ((struct vrb_mem_desc *) (desc))->lkey : 0 }
 
 #define vrb_set_sge_iov(sg_list, iov, count, desc)	\
 do {							\

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2016 Cisco Systems, Inc. All rights reserved.
  * Copyright (c) 2018-2019 Cray Inc. All rights reserved.
  * Copyright (c) 2018-2019 System Fabric Works, Inc. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -431,7 +432,6 @@ struct vrb_mem_desc {
 };
 
 extern struct fi_ops_mr vrb_mr_ops;
-extern struct fi_ops_mr vrb_mr_cache_ops;
 
 int vrb_mr_cache_add_region(struct ofi_mr_cache *cache,
 			       struct ofi_mr_entry *entry);

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -429,6 +429,7 @@ struct vrb_mem_desc {
 	size_t			len;
 	/* this field is used only by MR cache operations */
 	struct ofi_mr_entry	*entry;
+	struct ofi_mr_info	info;
 };
 
 extern struct fi_ops_mr vrb_mr_ops;

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -141,7 +141,7 @@ vrb_dgram_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT(ep, len, desc),
 	};
 
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
@@ -161,7 +161,7 @@ vrb_dgram_ep_senddata(struct fid_ep *ep_fid, const void *buf,
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT(ep, len, desc),
 	};
 
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -282,6 +282,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
 		[FI_HMEM_SYSTEM] = default_monitor,
 		[FI_HMEM_CUDA] = default_cuda_monitor,
+		[FI_HMEM_ROCR] = default_rocr_monitor,
 	};
 	enum fi_hmem_iface iface;
 	struct vrb_domain *_domain;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -281,6 +281,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 {
 	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
 		[FI_HMEM_SYSTEM] = default_monitor,
+		[FI_HMEM_CUDA] = default_cuda_monitor,
 	};
 	enum fi_hmem_iface iface;
 	struct vrb_domain *_domain;

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017-2019 Intel Corporation, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -33,33 +34,6 @@
 #include <ofi_util.h>
 #include "fi_verbs.h"
 
-
-static int
-vrb_mr_regv(struct fid *fid, const struct iovec *iov,
-	       size_t count, uint64_t access, uint64_t offset,
-	       uint64_t requested_key, uint64_t flags,
-	       struct fid_mr **mr, void *context)
-{
-	struct fid_domain *domain = container_of(fid, struct fid_domain, fid);
-
-	if (OFI_UNLIKELY(count > 1))
-		return -FI_EINVAL;
-
-	return count ? fi_mr_reg(domain, (const void *) iov->iov_base,
-				 iov->iov_len, access, offset, requested_key,
-				 flags, mr, context) :
-		       fi_mr_reg(domain, NULL, 0, access, offset, requested_key,
-				 flags, mr, context);
-}
-
-static int vrb_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
-			     uint64_t flags, struct fid_mr **mr)
-{
-	return vrb_mr_regv(fid, attr->mr_iov, attr->iov_count, attr->access,
-			      attr->offset, attr->requested_key, flags, mr,
-			      attr->context);
-}
-
 static int vrb_mr_close(fid_t fid)
 {
 	struct vrb_mem_desc *mr;
@@ -84,8 +58,8 @@ static struct fi_ops vrb_mr_fi_ops = {
 };
 
 static inline
-int vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access,
-			 const void *buf, size_t len, void *context)
+int vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access, const void *buf,
+		      size_t len, void *context)
 {
 	/* ops should be set in special functions */
 	md->mr_fid.fid.fclass = FI_CLASS_MR;
@@ -113,7 +87,7 @@ int vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access,
 		};
 		if (md->domain->eq)
 			vrb_eq_write_event(md->domain->eq, FI_MR_COMPLETE,
-				 	      &entry, sizeof(entry));
+					   &entry, sizeof(entry));
 		else if (md->domain->util_domain.eq)
 			 /* This branch is taken for the verbs/DGRAM */
 			fi_eq_write(&md->domain->util_domain.eq->eq_fid,
@@ -155,9 +129,9 @@ vrb_mr_ofi2ibv_access(uint64_t ofi_access, struct vrb_domain *domain)
 }
 
 static int
-vrb_mr_reg(struct fid *fid, const void *buf, size_t len,
-	      uint64_t access, uint64_t offset, uint64_t requested_key,
-	      uint64_t flags, struct fid_mr **mr, void *context)
+vrb_mr_nocache_reg(struct vrb_domain *domain, const void *buf, size_t len,
+		   uint64_t access, uint64_t offset, uint64_t requested_key,
+		   uint64_t flags, struct fid_mr **mr, void *context)
 {
 	struct vrb_mem_desc *md;
 	int ret;
@@ -169,12 +143,11 @@ vrb_mr_reg(struct fid *fid, const void *buf, size_t len,
 	if (OFI_UNLIKELY(!md))
 		return -FI_ENOMEM;
 
-	md->domain = container_of(fid, struct vrb_domain,
-				  util_domain.domain_fid.fid);
+	md->domain = domain;
 	md->mr_fid.fid.ops = &vrb_mr_fi_ops;
 
 	ret = vrb_mr_reg_common(md, vrb_mr_ofi2ibv_access(access, md->domain),
-				   buf, len, context);
+				buf, len, context);
 	if (OFI_UNLIKELY(ret))
 		goto err;
 
@@ -189,17 +162,9 @@ static int vrb_mr_cache_close(fid_t fid)
 {
 	struct vrb_mem_desc *md =
 		container_of(fid, struct vrb_mem_desc, mr_fid.fid);
-
 	ofi_mr_cache_delete(&md->domain->cache, md->entry);
 	return FI_SUCCESS;
 }
-
-struct fi_ops_mr vrb_mr_ops = {
-	.size = sizeof(struct fi_ops_mr),
-	.reg = vrb_mr_reg,
-	.regv = vrb_mr_regv,
-	.regattr = vrb_mr_regattr,
-};
 
 static struct fi_ops vrb_mr_cache_fi_ops = {
 	.size = sizeof(struct fi_ops),
@@ -233,11 +198,10 @@ void vrb_mr_cache_delete_region(struct ofi_mr_cache *cache,
 }
 
 static int
-vrb_mr_cache_reg(struct fid *fid, const void *buf, size_t len,
-		    uint64_t access, uint64_t offset, uint64_t requested_key,
-		    uint64_t flags, struct fid_mr **mr, void *context)
+vrb_mr_cache_reg(struct vrb_domain *domain, const void *buf, size_t len,
+		 uint64_t access, uint64_t offset, uint64_t requested_key,
+		 uint64_t flags, struct fid_mr **mr, void *context)
 {
-	struct vrb_domain *domain;
 	struct vrb_mem_desc *md;
 	struct ofi_mr_entry *entry;
 	struct fi_mr_attr attr;
@@ -246,9 +210,6 @@ vrb_mr_cache_reg(struct fid *fid, const void *buf, size_t len,
 
 	if (flags & ~OFI_MR_NOCACHE)
 		return -FI_EBADFLAGS;
-
-	domain = container_of(fid, struct vrb_domain,
-			      util_domain.domain_fid.fid);
 
 	attr.access = access;
 	attr.context = context;
@@ -272,9 +233,50 @@ vrb_mr_cache_reg(struct fid *fid, const void *buf, size_t len,
 	return FI_SUCCESS;
 }
 
-struct fi_ops_mr vrb_mr_cache_ops = {
+static int
+vrb_mr_reg(struct fid *fid, const void *buf, size_t len, uint64_t access,
+	   uint64_t offset, uint64_t requested_key, uint64_t flags,
+	   struct fid_mr **mr, void *context)
+{
+	struct vrb_domain *domain;
+
+	domain = container_of(fid, struct vrb_domain,
+			      util_domain.domain_fid.fid);
+
+	if (domain->cache.monitors[FI_HMEM_SYSTEM])
+		return vrb_mr_cache_reg(domain, buf, len, access, offset,
+					requested_key, flags, mr, context);
+	else
+		return vrb_mr_nocache_reg(domain, buf, len, access, offset,
+					  requested_key, flags, mr, context);
+}
+
+static int
+vrb_mr_regv(struct fid *fid, const struct iovec *iov, size_t count,
+	    uint64_t access, uint64_t offset, uint64_t requested_key,
+	    uint64_t flags, struct fid_mr **mr, void *context)
+{
+	const void *addr = count ? iov->iov_base: NULL;
+	size_t len = count ? iov->iov_len : 0;
+
+	if (OFI_UNLIKELY(count > 1))
+		return -FI_EINVAL;
+
+	return vrb_mr_reg(fid, addr, len, access, offset, requested_key, flags,
+			  mr, context);
+}
+
+static int vrb_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
+			  uint64_t flags, struct fid_mr **mr)
+{
+	return vrb_mr_regv(fid, attr->mr_iov, attr->iov_count, attr->access,
+			   attr->offset, attr->requested_key, flags, mr,
+			   attr->context);
+}
+
+struct fi_ops_mr vrb_mr_ops = {
 	.size = sizeof(struct fi_ops_mr),
-	.reg = vrb_mr_cache_reg,
+	.reg = vrb_mr_reg,
 	.regv = vrb_mr_regv,
 	.regattr = vrb_mr_regattr,
 };

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -301,10 +301,22 @@ vrb_mr_regv(struct fid *fid, const struct iovec *iov, size_t count,
 static int vrb_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 			  uint64_t flags, struct fid_mr **mr)
 {
-	return vrb_mr_regv_iface(fid, attr->mr_iov, attr->iov_count,
-				 attr->access, attr->offset,
-				 attr->requested_key, flags, mr, attr->context,
-				 attr->iface, attr->device.reserved);
+	struct vrb_domain *domain;
+	struct fi_mr_attr cur_abi_attr;
+
+	domain = container_of(fid, struct vrb_domain,
+			      util_domain.domain_fid.fid);
+
+	ofi_mr_update_attr(domain->util_domain.fabric->fabric_fid.api_version,
+			   domain->util_domain.info_domain_caps, attr,
+			   &cur_abi_attr);
+
+	return vrb_mr_regv_iface(fid, cur_abi_attr.mr_iov,
+				 cur_abi_attr.iov_count, cur_abi_attr.access,
+				 cur_abi_attr.offset,
+				 cur_abi_attr.requested_key, flags, mr,
+				 cur_abi_attr.context, cur_abi_attr.iface,
+				 cur_abi_attr.device.reserved);
 }
 
 struct fi_ops_mr vrb_mr_ops = {

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -81,8 +81,9 @@ int vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access, const void *buf,
 			/* Ignore failure for zero length memory registration */
 			assert(errno == FI_EINVAL);
 	} else {
-		md->mr_fid.mem_desc = (void *)(uintptr_t)md->mr->lkey;
+		md->mr_fid.mem_desc = md;
 		md->mr_fid.key = md->mr->rkey;
+		md->lkey = md->mr->lkey;
 	}
 
 	if (md->domain->eq_flags & FI_REG_MR) {

--- a/prov/verbs/src/verbs_mr.c
+++ b/prov/verbs/src/verbs_mr.c
@@ -70,7 +70,7 @@ int vrb_mr_reg_common(struct vrb_mem_desc *md, int vrb_access, const void *buf,
 	md->info.iov.iov_base = (void *) buf;
 	md->info.iov.iov_len = len;
 
-	if (md->domain->flags & VRB_USE_ODP)
+	if (md->domain->flags & VRB_USE_ODP && iface == FI_HMEM_SYSTEM)
 		vrb_access |= VRB_ACCESS_ON_DEMAND;
 
 	md->mr = ibv_reg_mr(md->domain->pd, (void *) buf, len, vrb_access);

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2018 Intel Corporation, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -110,7 +111,7 @@ vrb_msg_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT(ep, len, desc),
 	};
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
@@ -126,7 +127,7 @@ vrb_msg_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.wr_id = VERBS_COMP(ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT(ep, len, desc),
 	};
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
@@ -262,7 +263,7 @@ vrb_msg_xrc_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 	struct ibv_send_wr wr = {
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND,
-		.send_flags = VERBS_INJECT(&ep->base_ep, len),
+		.send_flags = VERBS_INJECT(&ep->base_ep, len, desc),
 	};
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
@@ -280,7 +281,7 @@ vrb_msg_xrc_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.wr_id = VERBS_COMP(&ep->base_ep, (uintptr_t)context),
 		.opcode = IBV_WR_SEND_WITH_IMM,
 		.imm_data = htonl((uint32_t)data),
-		.send_flags = VERBS_INJECT(&ep->base_ep, len),
+		.send_flags = VERBS_INJECT(&ep->base_ep, len, desc),
 	};
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2018 Intel Corporation, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -55,7 +56,7 @@ vrb_msg_ep_rma_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.opcode = IBV_WR_RDMA_WRITE,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT(ep, len, desc),
 	};
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
@@ -169,7 +170,7 @@ vrb_msg_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.imm_data = htonl((uint32_t)data),
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.send_flags = VERBS_INJECT(ep, len),
+		.send_flags = VERBS_INJECT(ep, len, desc),
 	};
 
 	return vrb_send_buf(ep, &wr, buf, len, desc);
@@ -288,7 +289,7 @@ vrb_msg_xrc_ep_rma_write(struct fid_ep *ep_fid, const void *buf,
 		.opcode = IBV_WR_RDMA_WRITE,
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.send_flags = VERBS_INJECT(&ep->base_ep, len),
+		.send_flags = VERBS_INJECT(&ep->base_ep, len, desc),
 	};
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
@@ -415,7 +416,7 @@ vrb_msg_xrc_ep_rma_writedata(struct fid_ep *ep_fid, const void *buf,
 		.imm_data = htonl((uint32_t)data),
 		.wr.rdma.remote_addr = addr,
 		.wr.rdma.rkey = (uint32_t)key,
-		.send_flags = VERBS_INJECT(&ep->base_ep, len),
+		.send_flags = VERBS_INJECT(&ep->base_ep, len, desc),
 	};
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);


### PR DESCRIPTION
HMEM support is only enabled for systems running Mellanox OFED and for Mellanox mlx4 and mlx5 devices. MR caching is only supported for FI_HMEM_SYSTEM and FI_HMEM_CUDA memory.