### PR TITLE
sockets: Try find addr again when it is -1

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1322,6 +1322,11 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 	struct sock_rx_entry *rx_entry;
 	uint64_t len, rem, offset, data_len, done_data, used;
 
+	if (pe_entry->addr == FI_ADDR_NOTAVAIL) {
+		pe_entry->addr = sock_av_get_addr_index(pe_entry->ep_attr->av,
+							&pe_entry->conn->addr);
+	}
+
 	offset = 0;
 	len = sizeof(struct sock_msg_hdr);
 

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2383,7 +2383,7 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe,
 	}
 
 	num_fds = ofi_epoll_wait(map->epoll_set, map->epoll_ctxs,
-	                        MIN(map->used, map->epoll_ctxs_sz), 0);
+	                         1, 0);
 	if (num_fds < 0 || num_fds == 0) {
 		if (num_fds < 0)
 			SOCK_LOG_ERROR("epoll failed: %d\n", num_fds);

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -2357,6 +2357,24 @@ void sock_pe_remove_rx_ctx(struct sock_rx_ctx *rx_ctx)
 	pthread_mutex_unlock(&rx_ctx->domain->pe->list_lock);
 }
 
+static int sock_pe_progress_pe_entry_list(struct sock_pe *pe,
+					  struct sock_rx_ctx *rx_ctx)
+{
+	int ret = 0;
+	struct dlist_entry *entry;
+	struct sock_pe_entry *pe_entry;
+
+	for (entry = rx_ctx->pe_entry_list.next;
+	     entry != &rx_ctx->pe_entry_list;) {
+		pe_entry = container_of(entry, struct sock_pe_entry, ctx_entry);
+		entry = entry->next;
+		ret = sock_pe_progress_rx_pe_entry(pe, pe_entry, rx_ctx);
+		if (ret < 0)
+			break;
+	}
+	return ret;
+}
+
 static int sock_pe_progress_rx_ep(struct sock_pe *pe,
 				  struct sock_ep_attr *ep_attr,
 				  struct sock_rx_ctx *rx_ctx)
@@ -2390,8 +2408,8 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe,
 		return num_fds;
 	}
 
-	fastlock_acquire(&map->lock);
 	for (i = 0; i < num_fds; i++) {
+		fastlock_acquire(&map->lock);
 		conn = map->epoll_ctxs[i];
 		if (!conn)
 			SOCK_LOG_ERROR("ofi_idm_lookup failed\n");
@@ -2400,8 +2418,9 @@ static int sock_pe_progress_rx_ep(struct sock_pe *pe,
 			continue;
 
 		sock_pe_new_rx_entry(pe, rx_ctx, ep_attr, conn);
+		fastlock_release(&map->lock);
+		sock_pe_progress_pe_entry_list(pe, rx_ctx);
 	}
-	fastlock_release(&map->lock);
 
 	return 0;
 }

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1322,11 +1322,6 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 	struct sock_rx_entry *rx_entry;
 	uint64_t len, rem, offset, data_len, done_data, used;
 
-	if (pe_entry->addr == FI_ADDR_NOTAVAIL) {
-		pe_entry->addr = sock_av_get_addr_index(pe_entry->ep_attr->av,
-							&pe_entry->conn->addr);
-	}
-
 	offset = 0;
 	len = sizeof(struct sock_msg_hdr);
 


### PR DESCRIPTION
When the first couple messages are received in a single poll, the last a few
messages' addr field may be set to FI_ADDR_NOTAVAIL since the
connection table has not been established yet -- the connection message is in
the same batch yet to be processed. Message with FI_ADDR_NOTAVAIL will
have trouble matching as it skips the checking of source, resulting in
message mismatch.

This patch trys to look up the addr_index again in the case of addr was
FI_ADDR_NOTAVAIL.

We found this issue when testing on FreeBSD. It must have something to do with how the kernel accumulates messages between the poll.
