### PR TITLE
prov/rxd: Runtime allocation of peers.

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -216,12 +216,12 @@ struct rxd_ep {
 	struct dlist_entry rts_sent_list;
 	struct dlist_entry ctrl_pkts;
 
-	struct rxd_peer peers[];
+	struct rxd_peer **peers;
 };
 
 static inline struct rxd_peer *rxd_peer(struct rxd_ep *ep, fi_addr_t rxd_addr)
 {
-	return &ep->peers[rxd_addr];
+	return ep->peers[rxd_addr];
 }
 static inline struct rxd_domain *rxd_ep_domain(struct rxd_ep *ep)
 {
@@ -514,5 +514,8 @@ void rxd_cleanup_unexp_msg(struct rxd_unexp_msg *unexp_msg);
 /* CQ sub-functions */
 void rxd_cq_report_error(struct rxd_cq *cq, struct fi_cq_err_entry *err_entry);
 void rxd_cq_report_tx_comp(struct rxd_cq *cq, struct rxd_x_entry *tx_entry);
+
+
+int rxd_create_peer(struct rxd_ep *ep, uint64_t rxd_addr);
 
 #endif

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -439,6 +439,11 @@ static void rxd_handle_rts(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 			return;
 	}
 
+	if (!rxd_peer(ep, rxd_addr)) {
+		if (rxd_create_peer(ep, rxd_addr) < 0)
+			return;
+	}
+
 	if (rxd_send_cts(ep, pkt, rxd_addr)) {
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
 			"error posting CTS\n");


### PR DESCRIPTION
replaced static array implementation of peers array
with an array of pointers to struct rxd_peer and the peers are
initialized during first rts sent(rxd_send_rts_if_needed) or when the first rts (rxd_handle_rts) is
received.

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>