### PR TITLE
fabtests: add device support infrastructure

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -110,7 +110,9 @@ noinst_LTLIBRARIES = libfabtests.la
 libfabtests_la_SOURCES = \
 	common/shared.c \
 	common/jsmn.c \
+	common/hmem.c \
 	include/shared.h \
+	include/hmem.h \
 	include/jsmn.h \
 	include/unix/osd.h \
 	include/ft_osd.h

--- a/fabtests/Makefile.win
+++ b/fabtests/Makefile.win
@@ -27,8 +27,8 @@ outdir = $(output_root)$(arch)\release-v141
 CFLAGS = $(CFLAGS) /O2 /MT
 !endif
 
-basedeps = common\shared.c common\jsmn.c common\windows\getopt.c \
-	common\windows\osd.c
+basedeps = common\hmem.c common\shared.c common\jsmn.c \
+	common\windows\getopt.c common\windows\osd.c
 
 includes = /Iinclude /Iinclude\windows /I..\include /FIft_osd.h \
 	/Iinclude\windows\getopt

--- a/fabtests/common/hmem.c
+++ b/fabtests/common/hmem.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ */
+
+#if HAVE_CONFIG_H
+	#include <config.h>
+#endif
+
+#include <inttypes.h>
+#include "hmem.h"
+
+struct ft_hmem_ops {
+	int (*init)(void);
+	int (*cleanup)(void);
+	int (*alloc)(uint64_t device, void **buf, size_t size);
+	int (*free)(void *buf);
+	int (*memset)(uint64_t device, void *buf, int value, size_t size);
+	int (*copy_to_hmem)(uint64_t device, void *dst, const void *src,
+			    size_t size);
+	int (*copy_from_hmem)(uint64_t device, void *dst, const void *src,
+			      size_t size);
+};
+
+static struct ft_hmem_ops hmem_ops[] = {
+	[FI_HMEM_SYSTEM] = {
+		.init = ft_host_init,
+		.cleanup = ft_host_cleanup,
+		.alloc = ft_host_alloc,
+		.free = ft_host_free,
+		.memset = ft_host_memset,
+		.copy_to_hmem = ft_host_memcpy,
+		.copy_from_hmem = ft_host_memcpy,
+	},
+};
+
+int ft_hmem_init(enum fi_hmem_iface iface)
+{
+	return hmem_ops[iface].init();
+}
+
+int ft_hmem_cleanup(enum fi_hmem_iface iface)
+{
+	return hmem_ops[iface].cleanup();
+}
+
+int ft_hmem_alloc(enum fi_hmem_iface iface, uint64_t device, void **buf,
+		  size_t size)
+{
+	return hmem_ops[iface].alloc(device, buf, size);
+}
+
+int ft_hmem_free(enum fi_hmem_iface iface, void *buf)
+{
+	return hmem_ops[iface].free(buf);
+}
+
+int ft_hmem_memset(enum fi_hmem_iface iface, uint64_t device, void *buf,
+		   int value, size_t size)
+{
+	return hmem_ops[iface].memset(device, buf, value, size);
+}
+
+int ft_hmem_copy_to(enum fi_hmem_iface iface, uint64_t device, void *dst,
+		    const void *src, size_t size)
+{
+	return hmem_ops[iface].copy_to_hmem(device, dst, src, size);
+}
+
+int ft_hmem_copy_from(enum fi_hmem_iface iface, uint64_t device, void *dst,
+		      const void *src, size_t size)
+{
+	return hmem_ops[iface].copy_from_hmem(device, dst, src, size);
+}

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -380,6 +380,8 @@ static int ft_alloc_ctx_array(struct ft_context **mr_array, char ***mr_bufs,
 		context = &(*mr_array)[i];
 		if (!(opts.options & FT_OPT_ALLOC_MULT_MR)) {
 			context->buf = default_buf + mr_size * i;
+			context->mr = mr;
+			context->desc = mr_desc;
 			continue;
 		}
 		(*mr_bufs)[i] = calloc(1, mr_size);

--- a/fabtests/fabtests.vcxproj
+++ b/fabtests/fabtests.vcxproj
@@ -108,6 +108,7 @@
     <ClCompile Include="benchmarks\rdm_tagged_pingpong.c" />
     <ClCompile Include="benchmarks\rma_bw.c" />
     <ClCompile Include="common\jsmn.c" />
+    <ClCompile Include="common\hmem.c" />
     <ClCompile Include="common\shared.c" />
     <ClCompile Include="common\windows\getopt.c" />
     <ClCompile Include="common\windows\osd.c" />
@@ -150,6 +151,7 @@
     <ClInclude Include="ubertest\fabtest.h" />
     <ClInclude Include="include\ft_osd.h" />
     <ClInclude Include="include\jsmn.h" />
+    <ClInclude Include="include\hmem.h" />
     <ClInclude Include="include\shared.h" />
     <ClInclude Include="include\unit_common.h" />
     <ClInclude Include="include\windows\getopt\getopt.h" />

--- a/fabtests/fabtests.vcxproj.filters
+++ b/fabtests/fabtests.vcxproj.filters
@@ -48,6 +48,9 @@
     <ClCompile Include="common\jsmn.c">
       <Filter>Source Files\common</Filter>
     </ClCompile>
+    <ClCompile Include="common\hmem.c">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
     <ClCompile Include="common\shared.c">
       <Filter>Source Files\common</Filter>
     </ClCompile>
@@ -183,6 +186,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\jsmn.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="include\hmem.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="include\shared.h">

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2020 Intel Corporation.  All rights reserved.
+ *
+ * This software is available to you under the BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ */
+
+#ifndef _HMEM_H_
+#define _HMEM_H_
+#if HAVE_CONFIG_H
+	#include <config.h>
+#endif /* HAVE_CONFIG_H */
+
+#include <stdlib.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_errno.h>
+
+static inline int ft_host_init()
+{
+	return FI_SUCCESS;
+}
+
+static inline int ft_host_cleanup()
+{
+	return FI_SUCCESS;
+}
+
+static inline int ft_host_alloc(uint64_t device, void **buffer, size_t size)
+{
+	*buffer = malloc(size);
+	return !buffer ? -FI_ENOMEM : FI_SUCCESS;
+}
+
+static inline int ft_host_free(void *buf)
+{
+	free(buf);
+	return FI_SUCCESS;
+}
+
+static inline int ft_host_memset(uint64_t device, void *buf, int value,
+				 size_t size)
+{
+	memset(buf, value, size);
+	return FI_SUCCESS;
+}
+
+static inline int ft_host_memcpy(uint64_t device, void *dst, const void *src,
+				 size_t size)
+{
+	memcpy(dst, src, size);
+	return FI_SUCCESS;
+}
+
+int ft_hmem_init(enum fi_hmem_iface iface);
+int ft_hmem_cleanup(enum fi_hmem_iface iface);
+int ft_hmem_alloc(enum fi_hmem_iface iface, uint64_t device, void **buf,
+		  size_t size);
+int ft_hmem_free(enum fi_hmem_iface iface, void *buf);
+int ft_hmem_memset(enum fi_hmem_iface iface, uint64_t device, void *buf,
+		   int value, size_t size);
+int ft_hmem_copy_to(enum fi_hmem_iface iface, uint64_t device, void *dst,
+		    const void *src, size_t size);
+int ft_hmem_copy_from(enum fi_hmem_iface iface, uint64_t device, void *dst,
+		      const void *src, size_t size);
+
+#endif /* _HMEM_H_ */

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -111,6 +111,8 @@ enum {
 	FT_OPT_OOB_ADDR_EXCH	= 1 << 14,
 	FT_OPT_ALLOC_MULT_MR	= 1 << 15,
 	FT_OPT_SERVER_PERSIST	= 1 << 16,
+	FT_OPT_ENABLE_HMEM	= 1 << 17,
+	FT_OPT_USE_DEVICE	= 1 << 18,
 	FT_OPT_OOB_CTRL		= FT_OPT_OOB_SYNC | FT_OPT_OOB_ADDR_EXCH,
 };
 
@@ -167,6 +169,9 @@ struct ft_opts {
 	uint64_t mr_mode;
 	/* Fail if the selected provider does not support FI_MSG_PREFIX.  */
 	int force_prefix;
+	enum fi_hmem_iface iface;
+	uint64_t device;
+	
 	char **argv;
 };
 
@@ -237,7 +242,7 @@ extern int ft_socket_pair[2];
 extern int sock;
 extern int listen_sock;
 #define ADDR_OPTS "B:P:s:a:b::E::C:"
-#define FAB_OPTS "f:d:p:"
+#define FAB_OPTS "f:d:p:D:i:H"
 #define INFO_OPTS FAB_OPTS "e:M:"
 #define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
 #define NO_CQ_DATA 0
@@ -258,6 +263,8 @@ extern char default_port[8];
 		.rma_op = FT_RMA_WRITE, \
 		.oob_port = NULL, \
 		.mr_mode = FI_MR_LOCAL | OFI_MR_BASIC_MAP, \
+		.iface = FI_HMEM_SYSTEM, \
+		.device = 0, \
 		.argc = argc, .argv = argv \
 	}
 


### PR DESCRIPTION
Initial device support for fabtests with L0 support

Changes:
- use fi_mr_regattr to register device memory
- general hmem_ops infrastructure mimicking libfabric structure
- add L0 configure check
- add L0 hmem ops for ZE testing