### PR TITLE
Initial ROCR Memory Monitor

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -73,6 +73,7 @@ common_srcs =				\
 	prov/util/src/util_mem_hooks.c	\
 	prov/util/src/util_mr_cache.c	\
 	prov/util/src/cuda_mem_monitor.c \
+	prov/util/src/rocr_mem_monitor.c \
 	prov/util/src/util_coll.c
 
 

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -72,6 +72,12 @@ hsa_status_t ofi_hsa_status_string(hsa_status_t status,
 				   const char **status_string);
 const char *ofi_hsa_status_to_string(hsa_status_t status);
 
+hsa_status_t ofi_hsa_amd_dereg_dealloc_cb(void *ptr,
+					  hsa_amd_deallocation_callback_t cb);
+hsa_status_t ofi_hsa_amd_reg_dealloc_cb(void *ptr,
+					hsa_amd_deallocation_callback_t cb,
+					void *user_data);
+
 #endif /* HAVE_ROCR */
 
 int rocr_memcpy(void *dest, const void *src, size_t size);

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -156,6 +156,7 @@ void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
 
 extern struct ofi_mem_monitor *default_monitor;
 extern struct ofi_mem_monitor *default_cuda_monitor;
+extern struct ofi_mem_monitor *default_rocr_monitor;
 
 /*
  * Userfault fd memory monitor
@@ -179,6 +180,8 @@ struct ofi_memhooks {
 extern struct ofi_mem_monitor *memhooks_monitor;
 
 extern struct ofi_mem_monitor *cuda_monitor;
+
+extern struct ofi_mem_monitor *rocr_monitor;
 
 /*
  * Used to store registered memory regions into a lookup map.  This
@@ -242,6 +245,7 @@ struct ofi_mr_cache_params {
 	size_t				max_size;
 	char *				monitor;
 	int				cuda_monitor_enabled;
+	int				rocr_monitor_enabled;
 };
 
 extern struct ofi_mr_cache_params	cache_params;

--- a/include/ofi_tree.h
+++ b/include/ofi_tree.h
@@ -82,6 +82,7 @@ void ofi_rbmap_init(struct ofi_rbmap *map,
 		int (*compare)(struct ofi_rbmap *map, void *key, void *data));
 void ofi_rbmap_cleanup(struct ofi_rbmap *map);
 
+struct ofi_rbnode *ofi_rbmap_get_root(struct ofi_rbmap *map);
 struct ofi_rbnode *ofi_rbmap_find(struct ofi_rbmap *map, void *key);
 struct ofi_rbnode *ofi_rbmap_search(struct ofi_rbmap *map, void *key,
 		int (*compare)(struct ofi_rbmap *map, void *key, void *data));

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -569,6 +569,7 @@
     <ClCompile Include="prov\util\src\util_mem_hooks.c" />
     <ClCompile Include="prov\util\src\util_mr_cache.c" />
     <ClCompile Include="prov\util\src\cuda_mem_monitor.c" />
+    <ClCompile Include="prov\util\src\rocr_mem_monitor.c" />
     <ClCompile Include="src\common.c" />
     <ClCompile Include="src\enosys.c">
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug-ICC|x64'">4127;869</DisableSpecificWarnings>

--- a/libfabric.vcxproj.filters
+++ b/libfabric.vcxproj.filters
@@ -198,6 +198,9 @@
     <ClCompile Include="prov\util\src\cuda_mem_monitor.c">
       <Filter>Source Files\prov\util</Filter>
     </ClCompile>
+    <ClCompile Include="prov\util\src\rocr_mem_monitor.c">
+      <Filter>Source Files\prov\util</Filter>
+    </ClCompile>
     <ClCompile Include="src\windows\osd.c">
       <Filter>Source Files\src\windows</Filter>
     </ClCompile>

--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) 2020 Hewlett Packard Enterprise Development LP
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "ofi_mr.h"
+
+#ifdef HAVE_ROCR
+
+#include "ofi_tree.h"
+#include "ofi_iov.h"
+
+#include <hsa/hsa_ext_amd.h>
+
+struct rocr_mm_entry {
+	struct iovec iov;
+	struct ofi_rbnode *node;
+};
+
+struct rocr_mm {
+	struct ofi_mem_monitor mm;
+	struct ofi_rbmap *dev_region_tree;
+};
+
+static int rocr_mm_start(struct ofi_mem_monitor *monitor);
+static void rocr_mm_stop(struct ofi_mem_monitor *monitor);
+static int rocr_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
+			     size_t len, union ofi_mr_hmem_info *hmem_info);
+static void rocr_mm_unsubscribe(struct ofi_mem_monitor *monitor,
+				const void *addr, size_t len,
+				union ofi_mr_hmem_info *hmem_info);
+static bool rocr_mm_valid(struct ofi_mem_monitor *monitor, const void *addr,
+			  size_t len, union ofi_mr_hmem_info *hmem_info);
+
+static struct rocr_mm rocr_mm = {
+	.mm = {
+		.iface = FI_HMEM_ROCR,
+		.init = ofi_monitor_init,
+		.cleanup = ofi_monitor_cleanup,
+		.start = rocr_mm_start,
+		.stop = rocr_mm_stop,
+		.subscribe = rocr_mm_subscribe,
+		.unsubscribe = rocr_mm_unsubscribe,
+		.valid = rocr_mm_valid,
+	},
+};
+
+struct ofi_mem_monitor *rocr_monitor = &rocr_mm.mm;
+
+static int rocr_rbmap_compare(struct ofi_rbmap *map, void *key, void *data)
+{
+	struct rocr_mm_entry *entry = data;
+	struct iovec *iov = key;
+
+	if (ofi_iov_left(&entry->iov, iov))
+		return -1;
+	else if (ofi_iov_right(&entry->iov, iov))
+		return 1;
+
+	/* If this fails, the ROCR memory monitor failed to have a single ROCR
+	 * memory monitor entry per user allocated ROCR memory region.
+	 */
+	assert(ofi_iov_within(iov, &entry->iov));
+
+	return 0;
+}
+
+static struct rocr_mm_entry *rocr_mm_entry_get_root(void)
+{
+	struct ofi_rbnode *node;
+
+	node = ofi_rbmap_get_root(rocr_mm.dev_region_tree);
+	if (node)
+		return node->data;
+	return NULL;
+}
+
+/* ROCR memory monitor entry find works by finding the node within the device
+ * region tree which contains the address within an entry's monitored range.
+ * Thus, we only need an address instead of an address and length when
+ * searching.
+ */
+static struct rocr_mm_entry *rocr_mm_entry_find(const void *addr)
+{
+	struct ofi_rbnode *node;
+	struct iovec iov = {
+		.iov_base = (void *) addr,
+		.iov_len = 1,
+	};
+
+	node = ofi_rbmap_find(rocr_mm.dev_region_tree, (void *) &iov);
+	if (node)
+		return node->data;
+	return NULL;
+}
+
+/* Pointer to ROCR memory monitor entry can never be returned as user data. This
+ * could lead to use-after-free. Instead, address and length is always returned.
+ * Unsubscribe will attempt to lookup the corresponding ROCR memory monitor
+ * entry and will free the entry if found.
+ */
+static void rocr_mm_dealloc_cb(void *addr, void *user_data)
+{
+	size_t len = (size_t) user_data;
+
+	pthread_mutex_lock(&mm_lock);
+	ofi_monitor_unsubscribe(rocr_monitor, addr, len, NULL);
+	pthread_mutex_unlock(&mm_lock);
+}
+
+static void *rocr_mm_entry_end_addr(struct rocr_mm_entry *entry)
+{
+	return (void *) ((uintptr_t) entry->iov.iov_base + entry->iov.iov_len);
+}
+
+static void rocr_mm_entry_free(struct rocr_mm_entry *entry)
+{
+	hsa_status_t hsa_ret __attribute__((unused));
+
+	FI_DBG(&core_prov, FI_LOG_MR,
+	       "ROCR buffer address %p length %lu monitor entry freed\n",
+	       entry->iov.iov_base, entry->iov.iov_len);
+
+	/* Two return codes are expected. HSA_STATUS_SUCCESS is returned if the
+	 * deallocation callback was not triggered and the entry is freed.
+	 * HSA_STATUS_ERROR_INVALID_ARGUMENT is returned if the deallocation
+	 * callback was triggered and the entry is freed. Any other return code
+	 * puts the monitor in an unknown state and is fatal.
+	 */
+	hsa_ret = ofi_hsa_amd_dereg_dealloc_cb(entry->iov.iov_base,
+					       rocr_mm_dealloc_cb);
+	assert(hsa_ret == HSA_STATUS_SUCCESS ||
+	       hsa_ret == HSA_STATUS_ERROR_INVALID_ARGUMENT);
+
+	ofi_rbmap_delete(rocr_mm.dev_region_tree, entry->node);
+	free(entry);
+}
+
+/* Each ROCR memory monitor entry is sized to the entire user-allocated ROCR
+ * memory region. A single deallocation callback is registered for the memory
+ * region. This callback is called when the user frees the ROCR memory region.
+ */
+static int rocr_mm_entry_alloc(const void *addr, struct rocr_mm_entry **entry)
+{
+	hsa_amd_pointer_info_t hsa_info = {
+		.size = sizeof(hsa_info),
+	};
+	hsa_status_t hsa_ret;
+	int ret;
+
+	*entry = malloc(sizeof(**entry));
+	if (!*entry) {
+		ret = -FI_ENOMEM;
+		goto err;
+	}
+
+	/* Determine full ROCR memory region size. */
+	hsa_ret = ofi_hsa_amd_pointer_info((void *) addr, &hsa_info, NULL, NULL,
+					   NULL);
+	if (hsa_ret != HSA_STATUS_SUCCESS) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to perform hsa_amd_pointer_info: %s\n",
+			ofi_hsa_status_to_string(hsa_ret));
+		ret = -FI_EIO;
+		goto err_free_entry;
+	}
+
+	if (hsa_info.type != HSA_EXT_POINTER_TYPE_HSA) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Cannot monitor non-HSA allocated memory\n");
+		ret = -FI_EINVAL;
+		goto err_free_entry;
+	}
+
+	(*entry)->iov.iov_base = hsa_info.agentBaseAddress;
+	(*entry)->iov.iov_len = hsa_info.sizeInBytes;
+
+	ret = ofi_rbmap_insert(rocr_mm.dev_region_tree,
+			       (void *) &(*entry)->iov,
+			       (void *) *entry, &(*entry)->node);
+	if (ret) {
+		FI_WARN(&core_prov, FI_LOG_MR,
+			"Failed to insert into RB tree: %s\n", strerror(ret));
+		goto err_free_entry;
+	}
+
+	/* Register a deallocation callback for this ROCR memory region. */
+	hsa_ret = ofi_hsa_amd_reg_dealloc_cb(hsa_info.agentBaseAddress,
+					     rocr_mm_dealloc_cb,
+					     (void *) hsa_info.sizeInBytes);
+	if (hsa_ret != HSA_STATUS_SUCCESS) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Failed to perform hsa_amd_register_deallocation_callback: %s\n",
+			ofi_hsa_status_to_string(hsa_ret));
+
+		ret = -FI_EIO;
+		goto err_rbmap_delete_entry;
+	}
+
+	FI_DBG(&core_prov, FI_LOG_MR,
+	       "ROCR buffer address %p length %lu monitor entry allocated\n",
+	       hsa_info.agentBaseAddress, hsa_info.sizeInBytes);
+
+	return FI_SUCCESS;
+
+err_rbmap_delete_entry:
+	ofi_rbmap_delete(rocr_mm.dev_region_tree, (*entry)->node);
+err_free_entry:
+	free(*entry);
+err:
+	*entry = NULL;
+	return ret;
+}
+
+static int rocr_mm_start(struct ofi_mem_monitor *monitor)
+{
+	rocr_mm.dev_region_tree = ofi_rbmap_create(rocr_rbmap_compare);
+	if (!rocr_mm.dev_region_tree)
+		return -FI_ENOMEM;
+	return FI_SUCCESS;
+}
+
+static void rocr_mm_stop(struct ofi_mem_monitor *monitor)
+{
+	struct rocr_mm_entry *entry;
+
+	while ((entry = rocr_mm_entry_get_root()))
+		rocr_mm_entry_free(entry);
+
+	assert(ofi_rbmap_empty(rocr_mm.dev_region_tree));
+
+	ofi_rbmap_destroy(rocr_mm.dev_region_tree);
+}
+
+static void rocr_mm_unsubscribe(struct ofi_mem_monitor *monitor,
+				const void *addr, size_t len,
+				union ofi_mr_hmem_info *hmem_info)
+{
+	struct rocr_mm_entry *entry;
+	size_t cur_len = len;
+	void *cur_addr = (void *) addr;
+
+	/* The user unsubscribe region may span multiple ROCR memory regions.
+	 * Each ROCR memory region needs to be freed and MR caches notified.
+	 */
+	while (cur_len) {
+		entry = rocr_mm_entry_find(addr);
+		if (!entry)
+			break;
+
+		cur_len -= MIN((uintptr_t) rocr_mm_entry_end_addr(entry) -
+			       (uintptr_t) cur_addr, cur_len);
+		cur_addr = rocr_mm_entry_end_addr(entry);
+
+		ofi_monitor_notify(rocr_monitor, entry->iov.iov_base,
+				   entry->iov.iov_len);
+
+		FI_DBG(&core_prov, FI_LOG_MR,
+		       "ROCR buffer address %p length %lu unsubscribed\n",
+		       entry->iov.iov_base, entry->iov.iov_len);
+
+		rocr_mm_entry_free(entry);
+	}
+
+	if (cur_len)
+		FI_WARN(&core_prov, FI_LOG_MR,
+			"Failed to completely unsubscribe from address %p length %lu\n",
+			addr, len);
+}
+
+/* Subscribe is designed to monitor entire ROCR memory regions even if the user
+ * subscribe region is smaller. All ROCR memory regions are inserted into an RB
+ * tree for tracking. Future subscriptions will always reuse RB tree entries if
+ * possible.
+ *
+ * RB tree entries can be removed in two different ways:
+ * 1. An unsubscribe against the memory region occurs. This will occur when ROCR
+ *    invokes the deregistration callback.
+ * 2. The ROCR memory monitor is stopped.
+ *
+ * Note: The ROCR memory monitor does not impose a limit on the number of ROCR
+ * memory regions which can be monitored.
+ */
+static int rocr_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
+			     size_t len, union ofi_mr_hmem_info *hmem_info)
+{
+	struct rocr_mm_entry *entry;
+	int ret = FI_SUCCESS;
+	size_t cur_len = len;
+	void *cur_addr = (void *) addr;
+
+	/* The user subscribe region may span multiple ROCR memory regions. For
+	 * this case, each ROCR memory region needs to be monitored. This
+	 * requires allocating a ROCR memory monitor entry for each ROCR memory
+	 * region.
+	 */
+	while (cur_len) {
+		entry = rocr_mm_entry_find(cur_addr);
+		if (entry) {
+			FI_DBG(&core_prov, FI_LOG_MR,
+			"Reusing monitored ROCR buffer address %p length %lu\n",
+			entry->iov.iov_base, entry->iov.iov_len);
+		} else {
+			/* On error, previous allocated entries are not cleaned
+			 * up. This is harmless since these entries will either
+			 * be cleaned up when the user frees the ROCR memory
+			 * region or the memory monitor is stopped.
+			 */
+			ret = rocr_mm_entry_alloc(cur_addr, &entry);
+			if (ret != FI_SUCCESS)
+				break;
+		}
+
+		cur_len -= MIN((uintptr_t) rocr_mm_entry_end_addr(entry) -
+			       (uintptr_t) cur_addr, cur_len);
+		cur_addr = rocr_mm_entry_end_addr(entry);
+	}
+
+	FI_LOG(&core_prov, ret ? FI_LOG_WARN : FI_LOG_DEBUG, FI_LOG_MR,
+	       "ROCR buffer address %p length %lu subscribe status: %s\n", addr,
+	       len, fi_strerror(-ret));
+
+	return ret;
+}
+
+static bool rocr_mm_valid(struct ofi_mem_monitor *monitor, const void *addr,
+			  size_t len, union ofi_mr_hmem_info *hmem_info)
+{
+	/* no-op */
+	return true;
+}
+
+#else
+
+static int rocr_mm_start(struct ofi_mem_monitor *monitor)
+{
+	return -FI_ENOSYS;
+}
+
+static void rocr_mm_stop(struct ofi_mem_monitor *monitor)
+{
+}
+
+static int rocr_mm_subscribe(struct ofi_mem_monitor *monitor, const void *addr,
+			     size_t len, union ofi_mr_hmem_info *hmem_info)
+{
+	return -FI_ENOSYS;
+}
+
+static void rocr_mm_unsubscribe(struct ofi_mem_monitor *monitor,
+				const void *addr, size_t len,
+				union ofi_mr_hmem_info *hmem_info)
+{
+}
+
+static bool rocr_mm_valid(struct ofi_mem_monitor *monitor, const void *addr,
+			  size_t len, union ofi_mr_hmem_info *hmem_info)
+{
+	return false;
+}
+
+static struct ofi_mem_monitor rocr_mm = {
+	.iface = FI_HMEM_ROCR,
+	.init = ofi_monitor_init,
+	.cleanup = ofi_monitor_cleanup,
+	.start = rocr_mm_start,
+	.stop = rocr_mm_stop,
+	.subscribe = rocr_mm_subscribe,
+	.unsubscribe = rocr_mm_unsubscribe,
+	.valid = rocr_mm_valid,
+};
+
+struct ofi_mem_monitor *rocr_monitor = &rocr_mm;
+
+#endif /* HAVE_ROCR */

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -52,6 +52,7 @@ struct ofi_mem_monitor *uffd_monitor = &uffd.monitor;
 
 struct ofi_mem_monitor *default_monitor;
 struct ofi_mem_monitor *default_cuda_monitor;
+struct ofi_mem_monitor *default_rocr_monitor;
 
 static size_t ofi_default_cache_size(void)
 {
@@ -88,6 +89,7 @@ void ofi_monitors_init(void)
 	uffd_monitor->init(uffd_monitor);
 	memhooks_monitor->init(memhooks_monitor);
 	cuda_monitor->init(cuda_monitor);
+	rocr_monitor->init(rocr_monitor);
 
 #if HAVE_MEMHOOKS_MONITOR
         default_monitor = memhooks_monitor;
@@ -121,12 +123,17 @@ void ofi_monitors_init(void)
 	fi_param_define(NULL, "mr_cuda_cache_monitor_enabled", FI_PARAM_BOOL,
 			"Enable or disable the CUDA cache memory monitor."
 			"Monitor is enabled by default.");
+	fi_param_define(NULL, "mr_rocr_cache_monitor_enabled", FI_PARAM_BOOL,
+			"Enable or disable the ROCR cache memory monitor. "
+			"Monitor is enabled by default.");
 
 	fi_param_get_size_t(NULL, "mr_cache_max_size", &cache_params.max_size);
 	fi_param_get_size_t(NULL, "mr_cache_max_count", &cache_params.max_cnt);
 	fi_param_get_str(NULL, "mr_cache_monitor", &cache_params.monitor);
 	fi_param_get_bool(NULL, "mr_cuda_cache_monitor_enabled",
 			  &cache_params.cuda_monitor_enabled);
+	fi_param_get_bool(NULL, "mr_rocr_cache_monitor_enabled",
+			  &cache_params.rocr_monitor_enabled);
 
 	if (!cache_params.max_size)
 		cache_params.max_size = ofi_default_cache_size();
@@ -155,6 +162,11 @@ void ofi_monitors_init(void)
 		default_cuda_monitor = cuda_monitor;
 	else
 		default_cuda_monitor = NULL;
+
+	if (cache_params.rocr_monitor_enabled)
+		default_rocr_monitor = rocr_monitor;
+	else
+		default_rocr_monitor = NULL;
 }
 
 void ofi_monitors_cleanup(void)
@@ -162,6 +174,7 @@ void ofi_monitors_cleanup(void)
 	uffd_monitor->cleanup(uffd_monitor);
 	memhooks_monitor->cleanup(memhooks_monitor);
 	cuda_monitor->cleanup(cuda_monitor);
+	rocr_monitor->cleanup(rocr_monitor);
 }
 
 /* Monitors array must be of size OFI_HMEM_MAX. */

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -46,6 +46,7 @@
 struct ofi_mr_cache_params cache_params = {
 	.max_cnt = 1024,
 	.cuda_monitor_enabled = true,
+	.rocr_monitor_enabled = true,
 };
 
 static int util_mr_find_within(struct ofi_rbmap *map, void *key, void *data)

--- a/src/tree.c
+++ b/src/tree.c
@@ -378,6 +378,13 @@ void ofi_rbmap_delete(struct ofi_rbmap *map, struct ofi_rbnode *node)
 	ofi_rbnode_free(map, node);
 }
 
+struct ofi_rbnode *ofi_rbmap_get_root(struct ofi_rbmap *map)
+{
+	if (ofi_rbmap_empty(map))
+		return NULL;
+	return map->root;
+}
+
 struct ofi_rbnode *ofi_rbmap_find(struct ofi_rbmap *map, void *key)
 {
 	struct ofi_rbnode *node;


### PR DESCRIPTION
The ROCR memory monitor allows for the caching of AMD GPU buffers. The monitor works by registering a deallocation callback for subscribed GPU buffers. To prevent the registration of multiple deallocation callbacks for addresses within the same GPU memory region (design decision), the user provided GPU address is expanded to GPU memory region size, and the entire region is tracked in a RB tree. Tracked regions are cleaned up when the GPU memory region is freed or the ROCR memory monitor is stopped.

The reason I went the RB tree route instead of storing a context pointer in a MR's ofi_mr_hmem_info is since ofi_monitor_unsubscribe() is not called when a MR is freed, the list of subscribed callbacks would be continuously growing (one for each MR). These would then only be cleaned up if the GPU memory region was freed or the ROCR memory monitor is stopped.