### PR TITLE
fabtests: Fix fi_mr_cache_evict usage

### DIFF
--- a/fabtests/unit/mr_cache_evict.c
+++ b/fabtests/unit/mr_cache_evict.c
@@ -581,7 +581,7 @@ struct test_entry test_array[] = {
 
 static void usage(void)
 {
-	ft_unit_usage("mr_cache",
+	ft_unit_usage("fi_mr_cache_evict",
 		"Test a provider's ability to evict MR cache entries.\n"
 		"Evictions are verified using MMAP, BRK, and SBRK allocations.\n"
 		"Users should set the FI_MR_CACHE_MONITOR env variable to \n"


### PR DESCRIPTION
The binary name was called mr_cache in the usage info instead of
fi_mr_cache_evict. Fix this.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>