### PR TITLE
prov/efa: let rxr_rma_readmsg() use device rdma read if peer is self

### DIFF
--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -315,6 +315,12 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	if (peer->is_local) {
 		assert(rxr_ep->use_shm);
 		use_lower_ep_read = true;
+	} else if (peer->is_self) {
+		/*
+		 * when peer is myself, I want to use rdma read as long as
+		 * device support it (disregard rxr_env.use_device_rdma).
+		 */
+		use_lower_ep_read = efa_ep_support_rdma_read(rxr_ep->rdm_ep);
 	} else if (efa_both_support_rdma_read(rxr_ep, peer)) {
 		/* efa_both_support_rdma_read also check rxr_env.use_device_rdma,
 		 * so we do not check it here


### PR DESCRIPTION
Currently, if rxr_env.use_device_rdma is 0, rxr_rma_readmsg() will
not use device RDMA read even if device support it. This patch make
the exception in that case of peer->is_self and device support RDMA
read. This would allow some caller to do a flush.

Signed-off-by: Wei Zhang <wzam@amazon.com>