### PR TITLE
RXM HMEM Support

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -1002,4 +1002,6 @@ static inline int rxm_cq_write_recv_comp(struct rxm_rx_buf *rx_buf,
 				    rx_buf->pkt.hdr.tag);
 }
 
+struct rxm_mr *rxm_mr_get_map_entry(struct rxm_domain *domain, uint64_t key);
+
 #endif

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -2,6 +2,7 @@
 /*
  * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -53,6 +54,7 @@
 #include <ofi_list.h>
 #include <ofi_proto.h>
 #include <ofi_iov.h>
+#include <ofi_hmem.h>
 
 #ifndef _RXM_H_
 #define _RXM_H_

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -546,8 +546,7 @@ struct rxm_tx_atomic_buf {
 
 	void *app_context;
 	uint64_t flags;
-	struct iovec result_iov[RXM_IOV_LIMIT];
-	uint8_t result_iov_count;
+	struct rxm_iov result_iov;
 
 	/* Must stay at bottom */
 	struct rxm_pkt pkt;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -280,6 +280,8 @@ struct rxm_domain {
 	uint64_t mr_key;
 	uint8_t mr_local;
 	struct ofi_ops_flow_ctrl *flow_ctrl_ops;
+	struct ofi_bufpool *amo_bufpool;
+	fastlock_t amo_bufpool_lock;
 };
 
 int rxm_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -289,7 +289,22 @@ struct rxm_mr {
 	struct fid_mr mr_fid;
 	struct fid_mr *msg_mr;
 	struct rxm_domain *domain;
+	enum fi_hmem_iface iface;
+	uint64_t device;
+	fastlock_t amo_lock;
 };
+
+static inline enum fi_hmem_iface
+rxm_mr_desc_to_hmem_iface_dev(void **desc, size_t count, uint64_t *device)
+{
+	if (!count || !desc || !desc[0]) {
+		*device = 0;
+		return FI_HMEM_SYSTEM;
+	}
+
+	*device = ((struct rxm_mr *) desc[0])->device;
+	return ((struct rxm_mr *) desc[0])->iface;
+}
 
 struct rxm_rndv_hdr {
 	struct ofi_rma_iov iov[RXM_IOV_LIMIT];
@@ -603,6 +618,8 @@ struct rxm_deferred_tx_entry {
 			uint64_t msg_id;
 			void *app_context;
 			uint64_t flags;
+			enum fi_hmem_iface iface;
+			uint64_t device;
 		} sar_seg;
 		struct {
 			struct rxm_tx_atomic_buf *tx_buf;

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -103,6 +103,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	size_t cmp_len = 0;
 	size_t tot_len;
 	ssize_t ret;
+	int i;
 
 	assert(msg->iov_count <= RXM_IOV_LIMIT &&
 	       msg->rma_iov_count <= RXM_IOV_LIMIT);
@@ -169,10 +170,16 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		assert(ret == cmp_len);
 	}
 
-	tx_buf->result_iov_count = result_iov_count;
-	if (resultv)
-		ofi_ioc_to_iov(resultv, tx_buf->result_iov, result_iov_count,
-			       datatype_sz);
+	tx_buf->result_iov.count = result_iov_count;
+	if (resultv) {
+		ofi_ioc_to_iov(resultv, tx_buf->result_iov.iov,
+			       result_iov_count, datatype_sz);
+
+		if (result_desc) {
+			for (i = 0; i < result_iov_count; i++)
+				tx_buf->result_iov.desc[i] = result_desc[i];
+		}
+	}
 
 	ret = rxm_ep_send_atomic_req(rxm_ep, rxm_conn, tx_buf, tot_len);
 	if (OFI_LIKELY(!ret))

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018 Cray Inc. All rights reserved.
  * Copyright (c) 2018 System Fabric Works, Inc. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -157,11 +158,16 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	atomic_hdr = (struct rxm_atomic_hdr *) tx_buf->pkt.data;
 
-	ofi_copy_from_iov(atomic_hdr->data, buf_len, buf_iov,
-			  msg->iov_count, 0);
-	if (cmp_len)
-		ofi_copy_from_iov(atomic_hdr->data + buf_len, cmp_len,
-				  cmp_iov, compare_iov_count, 0);
+	ret = ofi_copy_from_hmem_iov(atomic_hdr->data, buf_len, FI_HMEM_SYSTEM,
+				     0, buf_iov, msg->iov_count, 0);
+	assert(ret == buf_len);
+
+	if (cmp_len) {
+		ret = ofi_copy_from_hmem_iov(atomic_hdr->data + buf_len,
+					     cmp_len, FI_HMEM_SYSTEM, 0,
+					     cmp_iov, compare_iov_count, 0);
+		assert(ret == cmp_len);
+	}
 
 	tx_buf->result_iov_count = result_iov_count;
 	if (resultv)

--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015-2016 Intel Corporation. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -32,10 +33,15 @@
 
 #include "rxm.h"
 
-#define RXM_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | FI_ATOMICS)
+#define RXM_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | \
+		     FI_ATOMICS)
+#define RXM_TX_HMEM_CAPS (RXM_TX_CAPS | FI_HMEM)
+
 #define RXM_RX_CAPS (FI_SOURCE | OFI_RX_MSG_CAPS | FI_TAGGED | \
 		     OFI_RX_RMA_CAPS | FI_ATOMICS | FI_DIRECTED_RECV | \
 		     FI_MULTI_RECV)
+#define RXM_RX_HMEM_CAPS (RXM_RX_CAPS | FI_HMEM)
+
 #define RXM_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM)
 
 
@@ -45,7 +51,7 @@
  * requested by the app. */
 
 struct fi_tx_attr rxm_tx_attr = {
-	.caps = RXM_TX_CAPS,
+	.caps = RXM_TX_HMEM_CAPS,
 	.op_flags = RXM_PASSTHRU_TX_OP_FLAGS | RXM_TX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
@@ -55,7 +61,7 @@ struct fi_tx_attr rxm_tx_attr = {
 };
 
 struct fi_rx_attr rxm_rx_attr = {
-	.caps = RXM_RX_CAPS,
+	.caps = RXM_RX_HMEM_CAPS,
 	.op_flags = RXM_PASSTHRU_RX_OP_FLAGS | RXM_RX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
@@ -155,7 +161,7 @@ struct fi_info rxm_coll_info = {
 };
 
 struct fi_info rxm_base_info = {
-	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS,
+	.caps = RXM_TX_HMEM_CAPS | RXM_RX_HMEM_CAPS | RXM_DOMAIN_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxm_tx_attr,
 	.rx_attr = &rxm_rx_attr,
@@ -177,7 +183,7 @@ struct fi_info rxm_tcp_info = {
 };
 
 struct fi_info rxm_verbs_info = {
-	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS,
+	.caps = RXM_TX_HMEM_CAPS | RXM_RX_HMEM_CAPS | RXM_DOMAIN_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxm_tx_attr,
 	.rx_attr = &rxm_rx_attr,

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2018 Cray Inc. All rights reserved.
  * Copyright (c) 2018 System Fabric Works, Inc. All rights reserved.
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -622,10 +623,12 @@ static ssize_t rxm_handle_rndv(struct rxm_rx_buf *rx_buf)
 						fi_mr_desc(rx_buf->mr[i]);
 		}
 	} else {
+		struct rxm_mr *mr;
+
 		for (i = 0; i < rx_buf->recv_entry->rxm_iov.count; i++) {
-			rx_buf->mr[i] = rx_buf->recv_entry->rxm_iov.desc[i];
+			mr = rx_buf->recv_entry->rxm_iov.desc[i];
 			rx_buf->recv_entry->rxm_iov.desc[i] =
-				fi_mr_desc(rx_buf->mr[i]);
+				fi_mr_desc(mr->msg_mr);
 		}
 	}
 

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1308,11 +1308,12 @@ static ssize_t rxm_handle_atomic_resp(struct rxm_ep *rxm_ep,
 		goto free;
 	}
 
-	len = ofi_total_iov_len(tx_buf->result_iov, tx_buf->result_iov_count);
+	len = ofi_total_iov_len(tx_buf->result_iov.iov,
+				tx_buf->result_iov.count);
 	assert(ntohl(resp_hdr->result_len) == len);
 
-	ret = ofi_copy_to_hmem_iov(FI_HMEM_SYSTEM, 0, tx_buf->result_iov,
-				   tx_buf->result_iov_count, 0, resp_hdr->data,
+	ret = ofi_copy_to_hmem_iov(FI_HMEM_SYSTEM, 0, tx_buf->result_iov.iov,
+				   tx_buf->result_iov.count, 0, resp_hdr->data,
 				   len);
 	assert(ret == len);
 

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -107,6 +107,17 @@ static int rxm_mr_add_map_entry(struct util_domain *domain,
 	return ret;
 }
 
+struct rxm_mr *rxm_mr_get_map_entry(struct rxm_domain *domain, uint64_t key)
+{
+	struct rxm_mr *mr;
+
+	fastlock_acquire(&domain->util_domain.lock);
+	mr = ofi_mr_map_get(&domain->util_domain.mr_map, key);
+	fastlock_release(&domain->util_domain.lock);
+
+	return mr;
+}
+
 static int rxm_domain_close(fid_t fid)
 {
 	struct rxm_domain *rxm_domain;

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -266,6 +266,10 @@ static int rxm_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	if (!rxm_mr)
 		return -FI_ENOMEM;
 
+	ofi_mr_update_attr(rxm_domain->util_domain.fabric->fabric_fid.api_version,
+			   rxm_domain->util_domain.info_domain_caps, attr,
+			   &msg_attr);
+
 	msg_attr.access = rxm_mr_get_msg_access(rxm_domain, attr->access);
 
 	ret = fi_mr_regattr(rxm_domain->msg_domain, &msg_attr,
@@ -277,6 +281,7 @@ static int rxm_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	rxm_mr_init(rxm_mr, rxm_domain, attr->context);
 	fastlock_init(&rxm_mr->amo_lock);
 	rxm_mr->iface = msg_attr.iface;
+	rxm_mr->device = msg_attr.device.reserved;
 	*mr = &rxm_mr->mr_fid;
 
 	if (rxm_domain->util_domain.info_domain_caps & FI_ATOMIC) {

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Intel Corporation, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -233,10 +234,7 @@ static void rxm_mr_init(struct rxm_mr *rxm_mr, struct rxm_domain *domain,
 	rxm_mr->mr_fid.fid.fclass = FI_CLASS_MR;
 	rxm_mr->mr_fid.fid.context = context;
 	rxm_mr->mr_fid.fid.ops = &rxm_mr_ops;
-	/* Store msg_mr as rxm_mr descriptor so that we can get its key when
-	 * the app passes msg_mr as the descriptor in fi_send and friends.
-	 * The key would be used in large message transfer protocol and RMA. */
-	rxm_mr->mr_fid.mem_desc = rxm_mr->msg_mr;
+	rxm_mr->mr_fid.mem_desc = rxm_mr;
 	rxm_mr->mr_fid.key = fi_mr_key(rxm_mr->msg_mr);
 	rxm_mr->domain = domain;
 	ofi_atomic_inc32(&domain->util_domain.ref);

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -275,6 +275,8 @@ static int rxm_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		goto err;
 	}
 	rxm_mr_init(rxm_mr, rxm_domain, attr->context);
+	fastlock_init(&rxm_mr->amo_lock);
+	rxm_mr->iface = msg_attr.iface;
 	*mr = &rxm_mr->mr_fid;
 
 	if (rxm_domain->util_domain.info_domain_caps & FI_ATOMIC) {

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2013-2020 Intel Corporation. All rights reserved.
  * Copyright (c) 2020 Cisco Systems, Inc.  All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -1071,6 +1072,7 @@ rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			 uint64_t flags, uint64_t tag, uint8_t op,
 			 struct rxm_tx_rndv_buf **tx_rndv_buf)
 {
+	struct fid_mr *rxm_mr_msg_mr[RXM_IOV_LIMIT];
 	struct fid_mr **mr_iov;
 	ssize_t ret;
 	struct rxm_tx_rndv_buf *tx_buf;
@@ -1097,8 +1099,10 @@ rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 			goto err;
 		mr_iov = tx_buf->mr;
 	} else {
-		/* desc is msg fid_mr * array */
-		mr_iov = (struct fid_mr **)desc;
+		for (i = 0; i < count; i++)
+			rxm_mr_msg_mr[i] = ((struct rxm_mr *) desc[i])->msg_mr;
+
+		mr_iov = rxm_mr_msg_mr;
 	}
 
 	if (rxm_ep->rndv_ops == &rxm_rndv_ops_write) {

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1066,11 +1066,11 @@ rxm_ep_msg_normal_send(struct rxm_conn *rxm_conn, struct rxm_pkt *tx_pkt,
 }
 
 static ssize_t
-rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
-			 void *context, uint8_t count, const struct iovec *iov,
-			 void **desc, size_t data_len, uint64_t data,
-			 uint64_t flags, uint64_t tag, uint8_t op,
-			 struct rxm_tx_rndv_buf **tx_rndv_buf)
+rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn, void *context,
+			uint8_t count, const struct iovec *iov, void **desc, size_t data_len,
+			uint64_t data, uint64_t flags, uint64_t tag, uint8_t op,
+			struct rxm_tx_rndv_buf **tx_rndv_buf,
+			enum fi_hmem_iface iface, uint64_t device)
 {
 	struct fid_mr *rxm_mr_msg_mr[RXM_IOV_LIMIT];
 	struct fid_mr **mr_iov;
@@ -1121,8 +1121,8 @@ rxm_ep_alloc_rndv_tx_res(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	if (rxm_ep->rxm_info->mode & FI_BUFFERED_RECV) {
 		ret = ofi_copy_from_hmem_iov(rxm_pkt_rndv_data(&tx_buf->pkt),
-					     rxm_ep->buffered_min,
-					     FI_HMEM_SYSTEM, 0, iov, count, 0);
+					     rxm_ep->buffered_min, iface,
+					     device, iov, count, 0);
 		assert(ret == rxm_ep->buffered_min);
 
 		len += rxm_ep->buffered_min;
@@ -1227,7 +1227,8 @@ rxm_ep_sar_tx_prepare_and_send_segment(struct rxm_ep *rxm_ep,
 		size_t seg_no, size_t segs_cnt, uint64_t data, uint64_t flags,
 		uint64_t tag, uint8_t op, const struct iovec *iov,
 		uint8_t count, size_t *iov_offset,
-		struct rxm_tx_sar_buf **out_tx_buf)
+		struct rxm_tx_sar_buf **out_tx_buf,
+		enum fi_hmem_iface iface, uint64_t device)
 {
 	struct rxm_tx_sar_buf *tx_buf;
 	enum rxm_sar_seg_type seg_type = RXM_SAR_SEG_MIDDLE;
@@ -1247,8 +1248,8 @@ rxm_ep_sar_tx_prepare_and_send_segment(struct rxm_ep *rxm_ep,
 		return -FI_EAGAIN;
 	}
 
-	ret = ofi_copy_from_hmem_iov(tx_buf->pkt.data, seg_len, FI_HMEM_SYSTEM,
-				     0, iov, count, *iov_offset);
+	ret = ofi_copy_from_hmem_iov(tx_buf->pkt.data, seg_len, iface, device,
+				     iov, count, *iov_offset);
 	assert(ret == seg_len);
 
 	*iov_offset += seg_len;
@@ -1263,7 +1264,8 @@ static ssize_t
 rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		   void *context, uint8_t count, const struct iovec *iov,
 		   size_t data_len, size_t segs_cnt, uint64_t data,
-		   uint64_t flags, uint64_t tag, uint8_t op)
+		   uint64_t flags, uint64_t tag, uint8_t op,
+		   enum fi_hmem_iface iface, uint64_t device)
 {
 	struct rxm_tx_sar_buf *tx_buf, *first_tx_buf;
 	size_t i, iov_offset = 0, remain_len = data_len;
@@ -1281,7 +1283,7 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		return -FI_EAGAIN;
 
 	ret = ofi_copy_from_hmem_iov(first_tx_buf->pkt.data, rxm_eager_limit,
-				     FI_HMEM_SYSTEM, 0, iov, count, iov_offset);
+				     iface, device, iov, count, iov_offset);
 	assert(ret == rxm_eager_limit);
 
 	iov_offset += rxm_eager_limit;
@@ -1299,11 +1301,11 @@ rxm_ep_sar_tx_send(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	remain_len -= rxm_eager_limit;
 
 	for (i = 1; i < segs_cnt; i++) {
-		ret = rxm_ep_sar_tx_prepare_and_send_segment(rxm_ep, rxm_conn,
-				context, data_len, remain_len,
-				msg_id, rxm_eager_limit, i, segs_cnt,
-				data, flags, tag, op, iov, count,
-				&iov_offset, &tx_buf);
+		ret = rxm_ep_sar_tx_prepare_and_send_segment(
+					rxm_ep, rxm_conn, context, data_len, remain_len,
+					msg_id, rxm_eager_limit, i, segs_cnt, data,
+					flags, tag, op, iov, count, &iov_offset, &tx_buf,
+					iface, device);
 		if (ret) {
 			if (ret == -FI_EAGAIN)
 				goto defer;
@@ -1340,6 +1342,8 @@ defer:
 	def_tx->sar_seg.total_len = data_len;
 	def_tx->sar_seg.remain_len = remain_len;
 	def_tx->sar_seg.msg_id = msg_id;
+	def_tx->sar_seg.iface = iface;
+	def_tx->sar_seg.device = device;
 	rxm_ep_enqueue_deferred_tx_queue(def_tx);
 	return 0;
 }
@@ -1352,6 +1356,7 @@ rxm_ep_emulate_inject(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 {
 	struct rxm_tx_eager_buf *tx_buf;
 	ssize_t ret;
+	enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
 	const struct iovec iov = {
 		.iov_base = (void *)buf,
 		.iov_len = len,
@@ -1368,8 +1373,8 @@ rxm_ep_emulate_inject(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	rxm_ep_format_tx_buf_pkt(rxm_conn, len, op, data, tag, flags, &tx_buf->pkt);
 
-	ret = ofi_copy_from_hmem_iov(tx_buf->pkt.data, len, FI_HMEM_SYSTEM, 0,
-				     &iov, 1, 0);
+	ret = ofi_copy_from_hmem_iov(tx_buf->pkt.data, len, iface, 0, &iov, 1,
+				     0);
 	assert(ret == len);
 
 	tx_buf->flags = flags;
@@ -1393,8 +1398,7 @@ rxm_ep_inject_send_fast(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 
 	assert(len <= rxm_ep->rxm_info->tx_attr->inject_size);
 
-	if (pkt_size <= rxm_ep->inject_limit &&
-	    !rxm_ep->util_ep.tx_cntr) {
+	if (pkt_size <= rxm_ep->inject_limit && !rxm_ep->util_ep.tx_cntr) {
 		inject_pkt->hdr.size = len;
 		memcpy(inject_pkt->data, buf, len);
 		ret = rxm_ep_msg_inject_send(rxm_ep, rxm_conn, inject_pkt,
@@ -1457,11 +1461,15 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	size_t data_len = ofi_total_iov_len(iov, count);
 	size_t total_len = sizeof(struct rxm_pkt) + data_len;
 	ssize_t ret;
+	enum fi_hmem_iface iface;
+	uint64_t device;
 
 	assert(count <= rxm_ep->rxm_info->tx_attr->iov_limit);
 	assert((!(flags & FI_INJECT) &&
 		(data_len > rxm_ep->rxm_info->tx_attr->inject_size)) ||
 	       (data_len <= rxm_ep->rxm_info->tx_attr->inject_size));
+
+	iface = rxm_mr_desc_to_hmem_iface_dev(desc, count, &device);
 
 	if (data_len <= rxm_eager_limit) {
 		tx_buf = rxm_tx_buf_alloc(rxm_ep, RXM_BUF_POOL_TX);
@@ -1476,8 +1484,8 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 					 flags, &tx_buf->pkt);
 
 		ret = ofi_copy_from_hmem_iov(tx_buf->pkt.data,
-					     tx_buf->pkt.hdr.size,
-					     FI_HMEM_SYSTEM, 0, iov, count, 0);
+					     tx_buf->pkt.hdr.size, iface,
+					     device, iov, count, 0);
 		assert(ret == tx_buf->pkt.hdr.size);
 
 		tx_buf->app_context = context;
@@ -1497,14 +1505,13 @@ rxm_ep_send_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 		ret = rxm_ep_sar_tx_send(rxm_ep, rxm_conn, context,
 					 count, iov, data_len,
 					 rxm_ep_sar_calc_segs_cnt(rxm_ep, data_len),
-					 data, flags, tag, op);
+					 data, flags, tag, op, iface, device);
 	} else {
 		struct rxm_tx_rndv_buf *tx_buf;
 
-		ret = rxm_ep_alloc_rndv_tx_res(rxm_ep, rxm_conn, context,
-					       (uint8_t) count, iov, desc,
-					       data_len, data, flags, tag, op,
-					       &tx_buf);
+		ret = rxm_ep_alloc_rndv_tx_res(rxm_ep, rxm_conn, context, (uint8_t)count,
+					      iov, desc, data_len, data, flags, tag, op,
+					      &tx_buf, iface, device);
 		if (ret >= 0)
 			ret = rxm_ep_rndv_tx_send(rxm_ep, rxm_conn, tx_buf, ret);
 	}
@@ -1589,7 +1596,9 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 				def_tx_entry->sar_seg.payload.iov,
 				def_tx_entry->sar_seg.payload.count,
 				&def_tx_entry->sar_seg.payload.cur_iov_offset,
-				&def_tx_entry->sar_seg.cur_seg_tx_buf);
+				&def_tx_entry->sar_seg.cur_seg_tx_buf,
+				def_tx_entry->sar_seg.iface,
+				def_tx_entry->sar_seg.device);
 		if (ret) {
 			if (ret != -FI_EAGAIN) {
 				rxm_ep_sar_handle_segment_failure(def_tx_entry, ret);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2016 Intel Corporation. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -45,7 +46,7 @@
 
 #define RXM_PASSTHRU_CAPS (FI_MSG | FI_RMA | FI_SEND | FI_RECV |	\
 			   FI_READ | FI_WRITE | FI_REMOTE_READ |	\
-			   FI_REMOTE_WRITE)
+			   FI_REMOTE_WRITE | FI_HMEM)
 
 size_t rxm_msg_tx_size		= 128;
 size_t rxm_msg_rx_size		= 128;
@@ -85,6 +86,12 @@ void rxm_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
 			core_info->domain_attr->mr_mode |=
 				hints->domain_attr->mr_mode;
 	}
+
+	/* RxM is setup to support FI_HMEM with the core provider requiring
+	 * FI_MR_HMEM. Always set this MR mode bit.
+	 */
+	if (hints && hints->caps & FI_HMEM)
+		core_info->domain_attr->mr_mode |= FI_MR_HMEM;
 }
 
 int rxm_info_to_core(uint32_t version, const struct fi_info *hints,

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -184,13 +184,18 @@ rxm_ep_format_rma_msg(struct rxm_rma_buf *rma_buf, const struct fi_msg_rma *orig
 		      struct iovec *rxm_iov, struct fi_msg_rma *rxm_msg)
 {
 	ssize_t ret __attribute__((unused));
+	enum fi_hmem_iface iface;
+	uint64_t device;
+
+	iface = rxm_mr_desc_to_hmem_iface_dev(orig_msg->desc,
+					      orig_msg->iov_count, &device);
 
 	rxm_msg->context = rma_buf;
 	rxm_msg->addr = orig_msg->addr;
 	rxm_msg->data = orig_msg->data;
 
 	ret = ofi_copy_from_hmem_iov(rma_buf->pkt.data, rma_buf->pkt.hdr.size,
-				     FI_HMEM_SYSTEM, 0, orig_msg->msg_iov,
+				     iface, device, orig_msg->msg_iov,
 				     orig_msg->iov_count, 0);
 	assert(ret == rma_buf->pkt.hdr.size);
 

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -183,12 +183,17 @@ static void
 rxm_ep_format_rma_msg(struct rxm_rma_buf *rma_buf, const struct fi_msg_rma *orig_msg,
 		      struct iovec *rxm_iov, struct fi_msg_rma *rxm_msg)
 {
+	ssize_t ret __attribute__((unused));
+
 	rxm_msg->context = rma_buf;
 	rxm_msg->addr = orig_msg->addr;
 	rxm_msg->data = orig_msg->data;
 
-	ofi_copy_from_iov(rma_buf->pkt.data, rma_buf->pkt.hdr.size,
-			  orig_msg->msg_iov, orig_msg->iov_count, 0);
+	ret = ofi_copy_from_hmem_iov(rma_buf->pkt.data, rma_buf->pkt.hdr.size,
+				     FI_HMEM_SYSTEM, 0, orig_msg->msg_iov,
+				     orig_msg->iov_count, 0);
+	assert(ret == rma_buf->pkt.hdr.size);
+
 	rxm_iov->iov_base = &rma_buf->pkt.data;
 	rxm_iov->iov_len = rma_buf->pkt.hdr.size;
 	rxm_msg->msg_iov = rxm_iov;

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017-2020 Intel Corporation. All rights reserved.
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -54,7 +55,8 @@ rxm_ep_rma_reg_iov(struct rxm_ep *rxm_ep, const struct iovec *msg_iov,
 		rma_buf->mr.count = iov_count;
 	} else {
 		for (i = 0; i < iov_count; i++)
-			desc_storage[i] = fi_mr_desc(desc[i]);
+			desc_storage[i] =
+				fi_mr_desc(((struct rxm_mr *) desc[i])->msg_mr);
 	}
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
For RXM support to be enabled, the core provider must support FI_HMEM and FI_MR_HMEM. To support a core provider that does not require FI_MR_HMEM to be would require rework to RXM core provider discovery.

If RXM FI_HMEM is enabled, FI_COLLECTIVE is always disabled due to the collective util layer not supporting device buffers. With this implementation, FI_HMEM takes precedence over FI_COLLECTIVE. This results in the user having to explicitly request FI_COLLECTIVE. I'm not sure if we want it the other way around or not.

RXM has the capability to operate with and without FI_MR_LOCAL. This functionality has been extended to FI_MR_HMEM. Currently, I have it setup such that the only supported combinations of FI_MR_LOCAL and FI_MR_HMEM is either none or FI_MR_LOCAL | FI_MR_HMEM. Not sure if we want the other two combinations.