### PR TITLE
prov/verbs: Fix non-debug enabled unused variable compiler warning

### DIFF
--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -243,7 +243,6 @@ void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn)
 {
 	struct vrb_xrc_ep *ep;
 	enum vrb_ini_qp_state last_state;
-	struct sockaddr *addr;
 	int ret;
 
 	/* Continue to schedule shared connections if the physical connection
@@ -306,12 +305,10 @@ void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn)
 			goto err;
 		}
 
-		addr = rdma_get_local_addr(ep->base_ep.id);
-		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL,
-				"XRC connect src_addr", addr);
-		addr = rdma_get_peer_addr(ep->base_ep.id);
-		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL,
-				"XRC connect dest_addr", addr);
+		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL, "XRC connect src_addr",
+				rdma_get_local_addr(ep->base_ep.id));
+		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL, "XRC connect dest_addr",
+				rdma_get_peer_addr(ep->base_ep.id));
 
 		ep->base_ep.ibv_qp = ep->ini_conn->ini_qp;
 		ret = vrb_process_ini_conn(ep, ep->conn_setup->pending_recip,


### PR DESCRIPTION
Signed-off-by: Steve Welch <swelch@systemfabricworks.com>