### PR TITLE
core/mr_cache: Fix initialization of multiple MMs

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -171,6 +171,7 @@ int ofi_monitors_add_cache(struct ofi_mem_monitor **monitors,
 	int ret = 0;
 	enum fi_hmem_iface iface;
 	struct ofi_mem_monitor *monitor;
+	unsigned int success_count = 0;
 
 	if (!monitors) {
 		for (iface = FI_HMEM_SYSTEM; iface < OFI_HMEM_MAX; iface++)
@@ -179,32 +180,40 @@ int ofi_monitors_add_cache(struct ofi_mem_monitor **monitors,
 	}
 
 	pthread_mutex_lock(&mm_lock);
-
 	for (iface = FI_HMEM_SYSTEM; iface < OFI_HMEM_MAX; iface++) {
+		cache->monitors[iface] = NULL;
+
 		monitor = monitors[iface];
 		if (!monitor) {
 			FI_DBG(&core_prov, FI_LOG_MR,
 			       "MR cache disabled for %s memory\n",
 			       fi_tostr(&iface, FI_TYPE_HMEM_IFACE));
-			cache->monitors[iface] = NULL;
 			continue;
 		}
 
 		if (dlist_empty(&monitor->list)) {
 			ret = monitor->start(monitor);
-			if (ret) {
-				cache->monitors[iface] = NULL;
-				goto out;
-			}
+			if (ret == -FI_ENOSYS)
+				continue;
+			else if (ret)
+				goto err;
 		}
 
+		success_count++;
 		cache->monitors[iface] = monitor;
 		dlist_insert_tail(&cache->notify_entries[iface],
 				  &monitor->list);
 	}
-
-out:
 	pthread_mutex_unlock(&mm_lock);
+	return success_count ? FI_SUCCESS : -FI_ENOSYS;
+
+err:
+	pthread_mutex_unlock(&mm_lock);
+	FI_WARN(&core_prov, FI_LOG_MR,
+		"Failed to start %s memory monitor: %s\n",
+		fi_tostr(&iface, FI_TYPE_HMEM_IFACE), fi_strerror(-ret));
+	ofi_monitors_del_cache(cache);
+
 	return ret;
 }
 


### PR DESCRIPTION
If libfabric is not configured with a memory monitor, the memory monitor
start operation returns -FI_ENOSYS. This should be treated as a memory
monitor not being supported instead of a start error.

Prior to this commit, ofi_monitors_add_cache() would fail when
-FI_ENOSYS is encountered. Instead, treat -FI_ENOSYS as a NULL memory
monitor and continue processing the array of memory monitors. If all
memory monitors assigned to a MR cache are NULL,
ofi_monitors_add_cache() will now return an error.

The end result is a MR cache having different combinations of valid
memory monitors based on HMEM interface type. If a memory monitor is
NULL for a given HMEM interface type, the MR cache does not support the
caching of the given HMEM interface type.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>