### PR TITLE
prov/efa: turn off FI_HMEM support when RDMA is not available

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -374,6 +374,8 @@ ssize_t efa_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count, fi_addr_
 
 ssize_t efa_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *entry, uint64_t flags);
 
+bool efa_device_support_rdma_read(void);
+
 static inline
 bool efa_ep_support_rdma_read(struct fid_ep *ep_fid)
 {

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -130,6 +130,26 @@ err_free_dev_list:
 	return ret;
 }
 
+bool efa_device_support_rdma_read(void)
+{
+#ifdef HAVE_RDMA_SIZE
+	int err;
+	struct efadv_device_attr efadv_attr;
+
+	if (dev_cnt <=0)
+		return false;
+
+	assert(dev_cnt > 0);
+	err = efadv_query_device(ctx_list[0]->ibv_ctx, &efadv_attr, sizeof(efadv_attr));
+	if (err)
+		return false;
+
+	return efadv_attr.device_caps & EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
+#else
+	return false;
+#endif
+}
+
 void efa_device_free(void)
 {
 	int i;

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -385,6 +385,20 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 		 * which means FI_MR_HMEM implies FI_MR_LOCAL for cuda buffer
 		 */
 		if (hints->caps & FI_HMEM) {
+
+			if (!efa_device_support_rdma_read()) {
+				FI_INFO(&rxr_prov, FI_LOG_CORE,
+				        "FI_HMEM capability requires RDMA, which this device does not support.\n");
+				return -FI_ENODATA;
+
+			}
+
+			if (!rxr_env.use_device_rdma) {
+				FI_INFO(&rxr_prov, FI_LOG_CORE,
+				        "FI_HMEM capability requires RDMA, which is turned off. You can turn it on by set environment variable FI_EFA_USE_DEVICE_RDMA to 1.\n");
+				return -FI_ENODATA;
+			}
+
 			if (hints->domain_attr &&
 			    !(hints->domain_attr->mr_mode & FI_MR_HMEM)) {
 				FI_INFO(&rxr_prov, FI_LOG_CORE,


### PR DESCRIPTION
This patch with turn off FI_HMEM support when RDMA capability
is not available, either because device does not support or
rxr_env.use_device_rdma is 0.

Signed-off-by: Wei Zhang <wzam@amazon.com>