### PR TITLE
prov/efa: fix a typo in rxr_pkt_handle_send_completion()

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -397,7 +397,7 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *
 		break;
 	case RXR_MEDIUM_MSGRTM_PKT:
 	case RXR_MEDIUM_TAGRTM_PKT:
-		rxr_pkt_handle_long_rtm_send_completion(ep, pkt_entry);
+		rxr_pkt_handle_medium_rtm_send_completion(ep, pkt_entry);
 		break;
 	case RXR_LONG_MSGRTM_PKT:
 	case RXR_LONG_TAGRTM_PKT:


### PR DESCRIPTION
Currently in rxr_pkt_handle_send_completion(), RXR_MEDIUM_MSGRTM
and RXR_MEDIUM_TAGRTM was handle by calling
rxr_pkt_handle_long_rtm_send_completion(), which is typo. It should
be rxr_pkt_handle_medium_rtm_send_completion(). The reason this typo
did not cause problem is because the two functions have exactly same
implementation.

This function fix this issue by calling correct function.

Signed-off-by: Wei Zhang <wzam@amazon.com>