### PR TITLE
prov/tcp: Read from socket if staging buffer is empty

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -279,8 +279,8 @@ void tcpx_cq_report_error(struct util_cq *cq,
 			  int err);
 
 
-int tcpx_recv_hdr(SOCKET sock, struct stage_buf *stage_buf,
-		  struct tcpx_cur_rx_msg *cur_rx_msg);
+ssize_t tcpx_recv_hdr(SOCKET sock, struct stage_buf *stage_buf,
+		      struct tcpx_cur_rx_msg *cur_rx_msg);
 int tcpx_recv_msg_data(struct tcpx_xfer_entry *recv_entry);
 int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry);
 int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf);

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -575,11 +575,11 @@ int tcpx_op_read_rsp(struct tcpx_ep *tcpx_ep)
 
 static int tcpx_get_next_rx_hdr(struct tcpx_ep *ep)
 {
-	int ret;
+	ssize_t ret;
 
 	ret = tcpx_recv_hdr(ep->sock, &ep->stage_buf, &ep->cur_rx_msg);
 	if (ret < 0)
-		return ret;
+		return (int) ret;
 
 	ep->cur_rx_msg.done_len += ret;
 	if (ep->cur_rx_msg.done_len >= sizeof(ep->cur_rx_msg.hdr.base_hdr)) {
@@ -590,7 +590,7 @@ static int tcpx_get_next_rx_hdr(struct tcpx_ep *ep)
 			ret = tcpx_recv_hdr(ep->sock, &ep->stage_buf,
 					    &ep->cur_rx_msg);
 			if (ret < 0)
-				return ret;
+				return (int) ret;
 
 			ep->cur_rx_msg.done_len += ret;
 		}


### PR DESCRIPTION
In tcpx_recv_hdr and tcpx_recv_msg_data, we either read from the
staging buffer if data is available, or from the socket if it is
empty.  If we empty the staging buffer, it's likely that data is
available to be read from the socket.  However, we require looping
back through the progress loop (usually returning to the app)
before checking the socket.

Update the code to immediately try reading from the socket once
the staging buffer is empty.

As part of this change, convert tcpx_recv_hdr to return ssize_t,
rather than int, since it returns the number of bytes read in the
success case.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>