### PR TITLE
util/memhooks: Fix printf compilation warning

### DIFF
--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -475,7 +475,7 @@ static void *ofi_intercept_sbrk(intptr_t increment)
 	void *old_brk;
 
 	FI_DBG(&core_prov, FI_LOG_MR,
-		   "intercepted sbrk increment %d\n", increment);
+		   "intercepted sbrk increment %ld\n", increment);
 
 	old_brk = real_calls.sbrk(increment);
 


### PR DESCRIPTION
Use correctly sized specifier for intptr_t.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>