### PR TITLE
prov/rxd: replacing statically allocated arrays with ofi index_map and ofi indexer.

### DIFF
--- a/include/ofi_indexer.h
+++ b/include/ofi_indexer.h
@@ -80,6 +80,7 @@ struct indexer
 
 int ofi_idx_insert(struct indexer *idx, void *item);
 void *ofi_idx_remove(struct indexer *idx, int index);
+void *ofi_idx_remove_ordered(struct indexer *idx, int index);
 void ofi_idx_replace(struct indexer *idx, int index, void *item);
 void ofi_idx_reset(struct indexer *idx);
 

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -216,12 +216,15 @@ struct rxd_ep {
 	struct dlist_entry rts_sent_list;
 	struct dlist_entry ctrl_pkts;
 
-	struct rxd_peer **peers;
+	struct index_map peers_idm;
 };
 
 static inline struct rxd_peer *rxd_peer(struct rxd_ep *ep, fi_addr_t rxd_addr)
 {
-	return ep->peers[rxd_addr];
+	fastlock_tryacquire(&ep->util_ep.lock);
+	return ofi_idm_lookup(&ep->peers_idm, rxd_addr);
+	fastlock_release(&ep->util_ep.lock);
+
 }
 static inline struct rxd_domain *rxd_ep_domain(struct rxd_ep *ep)
 {

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -72,6 +72,7 @@
 #define RXD_RX_POOL_CHUNK_CNT	1024
 #define RXD_MAX_PENDING		128
 #define RXD_MAX_PKT_RETRY	50
+#define RXD_ADDR_INVALID	0
 
 #define RXD_PKT_IN_USE		(1 << 0)
 #define RXD_PKT_ACKED		(1 << 1)
@@ -154,13 +155,12 @@ struct rxd_av {
 	struct util_av util_av;
 	struct fid_av *dg_av;
 	struct ofi_rbmap rbmap;
-	
-	int rxd_addr_idx;
 
 	int dg_av_used;
 	size_t dg_addrlen;
 	struct indexer fi_addr_idx;	
-	struct rxd_addr *rxd_addr_table;
+	struct indexer rxdaddr_dg_idx;
+	struct index_map rxdaddr_fi_idm;
 };
 
 struct rxd_cq;
@@ -397,7 +397,7 @@ struct rxd_match_attr {
 
 static inline int rxd_match_addr(fi_addr_t addr, fi_addr_t match_addr)
 {
-	return (addr == FI_ADDR_UNSPEC || addr == match_addr);
+	return (addr == RXD_ADDR_INVALID || addr == match_addr);
 }
 
 static inline int rxd_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_tag)

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -54,6 +54,7 @@
 #include <ofi_util.h>
 #include <ofi_tree.h>
 #include <ofi_atomic.h>
+#include <ofi_indexer.h>
 #include "rxd_proto.h"
 
 #ifndef _RXD_H_
@@ -82,6 +83,8 @@
 #define RXD_TAG_HDR		(1 << 4)
 #define RXD_INLINE		(1 << 5)
 #define RXD_MULTI_RECV		(1 << 6)
+
+#define RXD_IDX_OFFSET(x)	(x + 1)	
 
 struct rxd_env {
 	int spin_count;
@@ -151,13 +154,12 @@ struct rxd_av {
 	struct util_av util_av;
 	struct fid_av *dg_av;
 	struct ofi_rbmap rbmap;
-	int fi_addr_idx;
+	
 	int rxd_addr_idx;
 
 	int dg_av_used;
 	size_t dg_addrlen;
-
-	fi_addr_t *fi_addr_table;
+	struct indexer fi_addr_idx;	
 	struct rxd_addr *rxd_addr_table;
 };
 

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -148,7 +148,7 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 	if (!tx_entry)
 		goto out;
 
-	if (rxd_peer(rxd_ep, rxd_addr)->peer_addr != FI_ADDR_UNSPEC)
+	if (rxd_peer(rxd_ep, rxd_addr)->peer_addr != RXD_ADDR_INVALID)
 		(void) rxd_start_xfer(rxd_ep, tx_entry);
 
 out:
@@ -252,7 +252,7 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	if (!tx_entry)
 		goto out;
 
-	if (rxd_peer(rxd_ep, rxd_addr)->peer_addr == FI_ADDR_UNSPEC)
+	if (rxd_peer(rxd_ep, rxd_addr)->peer_addr == RXD_ADDR_INVALID)
 		goto out;
 
 	(void) rxd_start_xfer(rxd_ep, tx_entry);

--- a/prov/rxd/src/rxd_atomic.c
+++ b/prov/rxd/src/rxd_atomic.c
@@ -133,8 +133,11 @@ static ssize_t rxd_generic_atomic(struct rxd_ep *rxd_ep,
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
-
-	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
+	
+	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
+					     RXD_IDX_OFFSET(addr));
+	if (!rxd_addr)
+		goto out;
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
 	if (ret)
 		goto out;
@@ -234,8 +237,11 @@ static ssize_t rxd_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
+	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx), 
+					     RXD_IDX_OFFSET(addr));
+	if (!rxd_addr)
+		goto out;
 
-	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[dest_addr];
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
 	if (ret)
 		goto out;

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -40,11 +40,14 @@ static int rxd_tree_compare(struct ofi_rbmap *map, void *key, void *data)
 	uint8_t addr[RXD_NAME_LENGTH];
 	size_t len = RXD_NAME_LENGTH;
 	int ret;
+	fi_addr_t dg_addr;
 
 	memset(addr, 0, len);
 	av = container_of(map, struct rxd_av, rbmap);
-	ret = fi_av_lookup(av->dg_av, av->rxd_addr_table[(fi_addr_t) data].dg_addr,
-			   addr, &len);
+	dg_addr = (intptr_t)ofi_idx_lookup(&av->rxdaddr_dg_idx, 
+					   (fi_addr_t) data);
+
+	ret = fi_av_lookup(av->dg_av, dg_addr,addr, &len);
 	if (ret)
 		return -1;
 
@@ -105,37 +108,53 @@ close:
 
 static fi_addr_t rxd_av_dg_addr(struct rxd_av *av, fi_addr_t fi_addr)
 {
+	fi_addr_t dg_addr;
 	fi_addr_t rxd_addr = (intptr_t) ofi_idx_lookup(&av->fi_addr_idx, 
 					     RXD_IDX_OFFSET(fi_addr));
+	if (!rxd_addr)
+		goto err;
+	dg_addr = (intptr_t) ofi_idx_lookup(&av->rxdaddr_dg_idx, rxd_addr);
+	if (!dg_addr)
+		goto err;
 
-	return rxd_addr == 0 ? FI_ADDR_UNSPEC :
-		av->rxd_addr_table[rxd_addr].dg_addr;
+	return dg_addr;
+err:
+	return FI_ADDR_UNSPEC;
 }
 
-static fi_addr_t rxd_set_rxd_addr(struct rxd_av *av, fi_addr_t dg_addr)
+static int rxd_set_rxd_addr(struct rxd_av *av, fi_addr_t dg_addr, fi_addr_t *addr)
 {
-	int tries = 0;
+	int rxdaddr;
+	rxdaddr = ofi_idx_insert(&(av->rxdaddr_dg_idx), (void*)(uintptr_t)dg_addr);
+	if (rxdaddr < 0)
+		return -FI_ENOMEM;
+	*addr = rxdaddr;
+	return 0;
 
-	while (av->rxd_addr_table[av->rxd_addr_idx].dg_addr != FI_ADDR_UNSPEC &&
-	       tries < av->util_av.count) {
-		if (++av->rxd_addr_idx == av->util_av.count)
-			av->rxd_addr_idx = 0;
-		tries++;
-	}
-	assert(av->rxd_addr_idx < av->util_av.count && tries < av->util_av.count);
-	av->rxd_addr_table[av->rxd_addr_idx].dg_addr = dg_addr;
-
-	return av->rxd_addr_idx;
 }
 
 static fi_addr_t rxd_set_fi_addr(struct rxd_av *av, fi_addr_t rxd_addr)
 {
-	int index;
-	index = ofi_idx_insert(&(av->fi_addr_idx), (void*)(uintptr_t)rxd_addr);
-	if (index < 0)
-		return FI_ADDR_UNSPEC;
-	av->rxd_addr_table[rxd_addr].fi_addr = index - 1;
-	return (index - 1);
+	int fi_addr;
+	fi_addr_t dg_addr;
+	fi_addr = ofi_idx_insert(&(av->fi_addr_idx), (void*)(uintptr_t)rxd_addr);
+	if (fi_addr < 0)
+		goto nomem1;
+	
+	if (ofi_idm_set(&(av->rxdaddr_fi_idm), rxd_addr, 
+		        (void*)(uintptr_t) fi_addr) < 0)
+		goto nomem2;
+
+	return fi_addr;
+
+nomem2:
+	ofi_idx_remove_ordered(&(av->fi_addr_idx), fi_addr);
+nomem1:
+	dg_addr = (intptr_t) ofi_idx_remove_ordered(&(av->rxdaddr_dg_idx), 
+						    rxd_addr);
+	fi_av_remove(av->dg_av, &dg_addr, 1, 0);
+
+	return -FI_ENOMEM;
 }
 
 int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
@@ -150,16 +169,24 @@ int rxd_av_insert_dg_addr(struct rxd_av *av, const void *addr,
 	if (ret != 1)
 		return -FI_EINVAL;
 
-	*rxd_addr = rxd_set_rxd_addr(av, dg_addr);
+	ret = rxd_set_rxd_addr(av, dg_addr, rxd_addr);
+	if (ret < 0) {
+		goto nomem;
+	}
 
-	ret = ofi_rbmap_insert(&av->rbmap, (void *) addr, (void *) (*rxd_addr),
+	ret = ofi_rbmap_insert(&av->rbmap, (void *)addr, (void *)(*rxd_addr),
 			       NULL);
 	if (ret) {
 		assert(ret != -FI_EALREADY);
-		fi_av_remove(av->dg_av, &dg_addr, 1, flags);
+		ofi_idx_remove_ordered(&(av->rxdaddr_dg_idx), *rxd_addr);
+		goto nomem;
 	}
 
 	return ret;
+nomem:
+	fi_av_remove(av->dg_av, &dg_addr, 1, flags);
+	return ret;
+
 }
 
 static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
@@ -167,7 +194,8 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 {
 	struct rxd_av *av;
 	int i = 0, ret = 0, success_cnt = 0;
-	fi_addr_t rxd_addr, util_addr;
+	fi_addr_t rxd_addr;
+	int util_addr;
 	struct ofi_rbnode *node;
 
 	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
@@ -189,11 +217,18 @@ static int rxd_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 				break;
 		}
 
-		util_addr = av->rxd_addr_table[rxd_addr].fi_addr == FI_ADDR_UNSPEC ?
-			    rxd_set_fi_addr(av, rxd_addr) :
-			    av->rxd_addr_table[rxd_addr].fi_addr;
+		util_addr = (intptr_t)ofi_idm_lookup(&av->rxdaddr_fi_idm, 
+						     rxd_addr);
+
+		if (!util_addr) {
+			util_addr = rxd_set_fi_addr(av, rxd_addr);
+			if (util_addr < 0) {
+				ret = util_addr;
+				break;	
+			}
+		}
 		if (fi_addr)
-			fi_addr[i] = util_addr;
+			fi_addr[i] = (util_addr - 1);
 
 		success_cnt++;
 	}
@@ -247,20 +282,23 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 	int ret = 0;
 	size_t i, addrlen;
 	fi_addr_t rxd_addr;
+	fi_addr_t dg_addr;
 	struct rxd_av *av;
 	uint8_t addr[RXD_NAME_LENGTH];
 
 	av = container_of(av_fid, struct rxd_av, util_av.av_fid);
 	fastlock_acquire(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
-		rxd_addr = (intptr_t) ofi_idx_remove_ordered(&(av->fi_addr_idx), 
-						  RXD_IDX_OFFSET(fi_addr[i]));
-		if (!rxd_addr)
-			goto err;
 
 		addrlen = RXD_NAME_LENGTH;
-		ret = fi_av_lookup(av->dg_av, av->rxd_addr_table[rxd_addr].dg_addr,
-				   addr, &addrlen);
+		rxd_addr = (intptr_t)ofi_idx_lookup(&av->fi_addr_idx,
+						    RXD_IDX_OFFSET(fi_addr[i]));
+		if (!rxd_addr)
+			goto err;
+		
+		dg_addr = (intptr_t)ofi_idx_lookup(&av->rxdaddr_dg_idx, rxd_addr);
+
+		ret = fi_av_lookup(av->dg_av, dg_addr, addr, &addrlen);
 		if (ret)
 			goto err;
 		
@@ -268,13 +306,15 @@ static int rxd_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr, size_t count
 		if (ret)
 			goto err;
 
-		ret = fi_av_remove(av->dg_av, &av->rxd_addr_table[rxd_addr].dg_addr,
-				   1, flags);
+		ret = fi_av_remove(av->dg_av, &dg_addr, 1, flags);
+
 		if (ret)
 			goto err;
-
-		av->rxd_addr_table[rxd_addr].fi_addr = FI_ADDR_UNSPEC;
-		av->rxd_addr_table[rxd_addr].dg_addr = FI_ADDR_UNSPEC;
+		
+		ofi_idx_remove_ordered(&(av->fi_addr_idx), 
+				       RXD_IDX_OFFSET(fi_addr[i]));
+		ofi_idx_remove_ordered(&(av->rxdaddr_dg_idx), rxd_addr);
+		ofi_idm_clear(&(av->rxdaddr_fi_idm), rxd_addr);
 		av->dg_av_used--;
 	}
 
@@ -335,7 +375,9 @@ static int rxd_av_close(struct fid *fid)
 		return ret;
 
 	ofi_idx_reset(&(av->fi_addr_idx)); 
-	free(av->rxd_addr_table);
+	ofi_idx_reset(&(av->rxdaddr_dg_idx));
+	ofi_idm_reset(&(av->rxdaddr_fi_idm));
+
 	free(av);
 	return 0;
 }
@@ -356,7 +398,7 @@ static struct fi_ops rxd_av_fi_ops = {
 int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		   struct fid_av **av_fid, void *context)
 {
-	int ret, i;
+	int ret;
 	struct rxd_av *av;
 	struct rxd_domain *domain;
 	struct util_av_attr util_attr;
@@ -376,12 +418,8 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	if (!av)
 		return -FI_ENOMEM;
 	memset(&(av->fi_addr_idx), 0, sizeof(av->fi_addr_idx));
-	av->rxd_addr_table = calloc(1, rxd_env.max_peers * sizeof(struct rxd_addr));
-	if (!av->rxd_addr_table) {
-		ret = -FI_ENOMEM;
-		goto err1;
-	}
-
+	memset(&(av->rxdaddr_dg_idx), 0, sizeof(av->rxdaddr_dg_idx));
+	memset(&(av->rxdaddr_fi_idm), 0, sizeof(av->rxdaddr_fi_idm));
 
 	util_attr.addrlen = sizeof(fi_addr_t);
 	util_attr.context_len = 0;
@@ -396,11 +434,6 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 
 	ofi_rbmap_init(&av->rbmap, rxd_tree_compare);
 	
-	for (i = 0; i < rxd_env.max_peers; i++) {
-		av->rxd_addr_table[i].fi_addr = FI_ADDR_UNSPEC;
-		av->rxd_addr_table[i].dg_addr = FI_ADDR_UNSPEC;
-	}
-
 	av_attr = *attr;
 	av_attr.count = 0;
 	av_attr.flags = 0;
@@ -415,8 +448,7 @@ int rxd_av_create(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 
 err2:
 	ofi_av_close(&av->util_av);
-err1:
-	free(av->rxd_addr_table);
+err1:	
 	free(av);
 	return ret;
 }

--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -207,7 +207,7 @@ static void rxd_verify_active(struct rxd_ep *ep, fi_addr_t addr, fi_addr_t peer_
 {
 	struct rxd_pkt_entry *pkt_entry;
 
-	if (rxd_peer(ep, addr)->peer_addr != FI_ADDR_UNSPEC &&
+	if (rxd_peer(ep, addr)->peer_addr != RXD_ADDR_INVALID &&
 	    rxd_peer(ep, addr)->peer_addr != peer_addr)
 		FI_WARN(&rxd_prov, FI_LOG_EP_CTRL,
 			"overwriting active peer - unexpected behavior\n");
@@ -280,7 +280,7 @@ void rxd_progress_tx_list(struct rxd_ep *ep, struct rxd_peer *peer)
 					    struct rxd_pkt_entry, d_entry))->seq_no;
 	}
 
-	if (peer->peer_addr == FI_ADDR_UNSPEC)
+	if (peer->peer_addr == RXD_ADDR_INVALID)
 		return;
 
 	dlist_foreach_container_safe(&peer->tx_list, struct rxd_x_entry,
@@ -529,7 +529,6 @@ static struct rxd_x_entry *rxd_match_rx(struct rxd_ep *ep,
 	}
 
 	rx_entry = container_of(match, struct rxd_x_entry, entry);
-
 	total_size = op ? op->size : msg_size;
 
 	if (rx_entry->flags & RXD_MULTI_RECV) {
@@ -996,7 +995,7 @@ static void rxd_handle_data(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 				   &rxd_comp_pkt_seq_no, &pkt_entry->d_entry);
 		return;
 	} else if (rxd_peer(ep, pkt->base_hdr.peer)->peer_addr != 
-		   FI_ADDR_UNSPEC) {
+		   RXD_ADDR_INVALID) {
 		rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 	}
 free:
@@ -1023,12 +1022,12 @@ static void rxd_handle_op(struct rxd_ep *ep, struct rxd_pkt_entry *pkt_entry)
 			return;
 		}
 
-		if (rxd_peer(ep, base_hdr->peer)->peer_addr != FI_ADDR_UNSPEC)
+		if (rxd_peer(ep, base_hdr->peer)->peer_addr != RXD_ADDR_INVALID)
 			goto ack;
 		goto release;
 	}
 
-	if (rxd_peer(ep, base_hdr->peer)->peer_addr == FI_ADDR_UNSPEC)
+	if (rxd_peer(ep, base_hdr->peer)->peer_addr == RXD_ADDR_INVALID)
 		goto release;
 
 	ret = rxd_unpack_init_rx(ep, &rx_entry, pkt_entry, base_hdr, &sar_hdr,

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -100,8 +100,11 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
-
-	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
+	
+	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
+					      RXD_IDX_OFFSET(addr));
+	if (!rxd_addr)
+		goto out;
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
 	if (ret)
 		goto out;
@@ -147,8 +150,11 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
+	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
+					     RXD_IDX_OFFSET(addr));
+	if (!rxd_addr)
+		goto out;
 
-	rxd_addr = rxd_ep_av(rxd_ep)->fi_addr_table[addr];
 	ret = rxd_send_rts_if_needed(rxd_ep, rxd_addr);
 	if (ret)
 		goto out;

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -117,7 +117,7 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 		goto out;
 	}
 
-	if (rxd_peer(rxd_ep, rxd_addr)->peer_addr == FI_ADDR_UNSPEC)
+	if (rxd_peer(rxd_ep, rxd_addr)->peer_addr == RXD_ADDR_INVALID)
 		goto out;
 
 	ret = rxd_start_xfer(rxd_ep, tx_entry);
@@ -167,7 +167,7 @@ ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 		goto out;
 	}
 
-	if (rxd_peer(rxd_ep, rxd_addr)->peer_addr == FI_ADDR_UNSPEC)
+	if (rxd_peer(rxd_ep, rxd_addr)->peer_addr == RXD_ADDR_INVALID)
 		goto out;
 
 	ret = rxd_start_xfer(rxd_ep, tx_entry);

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -122,7 +122,6 @@ void *ofi_idx_remove_ordered(struct indexer *idx, int index)
 
 	entry = idx->array[ofi_idx_array_index(index)];
 	item = entry[entry_index].item;
-	assert(item != NULL);
 	entry[entry_index].item = NULL;	
 	if (ofi_idx_free_list_empty(idx) || index < idx->free_list) {
 		entry[entry_index].next = idx->free_list;


### PR DESCRIPTION
 - replaced peers array in rxd_ep to an index_map based implementation. 
- replaced fi_addr_table in rxd_av to an indexer based implementation. 