### PR TITLE
Minor unrelated fixes

### DIFF
--- a/docs/policy
+++ b/docs/policy
@@ -4,7 +4,13 @@ This document describes the general policies and procedures that
 are followed by the libfabric development community.  It is best
 viewed as a guideline, and is not a formal or legal document.
 
-Code contributions
+
+DEVELOPER GUIDELINES
+====================
+The following guidelines are helpful for developers new to the
+libfabric community and open source development.
+
+Code Contributions
 ------------------
 Any developers wishing to contribute to libfabric may do so,
 provided that they adhere to the CONTRIBUTORS agreement in the root
@@ -12,6 +18,82 @@ of the source tree.  There are no separate membership requirements
 or documents that must be signed prior to submitting code.  Developers
 need the rights to submit the code being introduced, and the code
 must meet the license requirements of the project.
+
+Patch Submission
+----------------
+Patches should be submitted directly to github as part of a pull request.
+For patches that touch the external API or introduce or modify core
+functionality significantly, an email should be sent to the ofiwg mail
+list with a link to the pull request.
+
+Patches should include a clear description of the problem that the patch
+is addressing, and how it does so.  One or two line descriptions are
+almost never sufficient, except for the most trivial code changes.
+The description should stand on its own, and provide enough context
+for someone to determine what the patch does, without needing to read
+the accompanying code changes.  Often times, the purpose of a patch is
+made clearer as part of a review discussion.  When this occurs, the
+portion of the discussion clarifying the purpose of a change should be
+folded into the patch description.
+
+Each patch should address a single problem.  When a patch description
+indicates that a patch does A, B, and C, that's usually the indication
+that the patch should have been split into three separate patches.
+An exception may be made if an unrelated change occurs in the code that
+surrounds the patch, provided that the change is trivial.  For example,
+white space cleanup or fixing typos in comments may be allowed to slip
+through the review process, even though those changes are unrelated to
+the patch.
+
+No single patch should ever break the build or result in incorrect operation.
+That is, arbitrarily breaking up a patch into two or more pieces, which all
+need to be applied to bring the repository back into a stable state is not
+allowed.
+
+One of the most common reasons that a patch is rejected is that it is
+trying to change too many things at once.  The standard argument back is
+that developer viewed the entire set of changes as one entity.  The
+best chance of having code accepted with minimal changes requested is
+to keep patches small.  If a large set of changes requires restructuring
+the existing code, then separate out the restructuring into its own set
+of patches.  It's okay for a patch to do nothing significant other than
+prepare the code for a follow on patch.  In fact, it's often preferred,
+as that can help identify alternatives that weren't considered.
+
+For help on how to write a good patch and patch description, search the
+web.  There are plenty of helpful tutorials out there.
+
+Pull Requests
+-------------
+A number of continuous integration tests run against all pull requests.
+Some CI testing involves access to special hardware, so is hosted
+directly by various vendors.  Pull requests should not be merged until
+after all CI completes.  In some cases, CI may fail, either because of
+known issues, CI test node problems, or as a result of race conditions.
+For CI failures that are unrelated to the pull request, the failures
+may be ignored, and the pull request merged.  It is the responsibility
+of the person committing the request to the repo to confirm that any
+CI failures are unrelated to the changes in the pull request.
+
+Core Changes
+------------
+Updates to the libfabric core should be reviewed by at least one other
+developer.  Changes to the API should be brought to the attention of
+the OFIWG mailing list, with significant changes discussed prior to
+being implemented.
+
+API Changes
+-----------
+All files under the include/rdma subdirectory are maintained as part of
+the stable libfabric API.  Any changes to those files will receive a
+strongly scrutinized review, as changes there have a much broader impact
+across not just the project, but the entire libfabric software ecosystem.
+For additional details, see include/ofi_abi.h before deciding that you
+really don't need that API change. :)
+
+
+PROJECT ADMINISTRATION
+======================
 
 Git Repository Admin
 --------------------
@@ -30,32 +112,6 @@ commit changes to the subdirectory that corresponds with the provider
 that they are maintaining.  Changes made to other providers or the
 libfabric core must be approved prior by the relevant owners prior to
 being merged.
-
-Core Changes
-------------
-Updates to the libfabric core should be reviewed by at least one other
-developer.  Changes to the API should be brought to the attention of
-the OFIWG mailing list, with significant changes discussed prior to
-being implemented.
-
-Patch Submission
-----------------
-Patches should be submitted directly to github as part of a pull request.
-For patches that touch the external API or introduce or modify core
-functionality significantly, an email should be sent to the ofiwg mail
-list with a link to the pull request.
-
-Pull Requests
--------------
-A number of continuous integration tests run against all pull requests.
-Some CI testing involves access to special hardware, so is hosted
-directly by various vendors.  Pull requests should not be merged until
-after all CI completes.  In some cases, CI may fail, either because of
-known issues, CI test node problems, or as a result of race conditions.
-For CI failures that are unrelated to the pull request, the failures
-may be ignored, and the pull request merged.  It is the responsibility
-of the person committing the request to the repo to confirm that any
-CI failures are unrelated to the changes in the pull request.
 
 Releases
 --------

--- a/prov/udp/Makefile.include
+++ b/prov/udp/Makefile.include
@@ -11,12 +11,11 @@ _udp_files = \
 if HAVE_UDP_DL
 pkglib_LTLIBRARIES += libudp-fi.la
 libudp_fi_la_SOURCES = $(_udp_files) $(common_srcs)
-libudp_fi_la_LIBADD = $(linkback) $(udp_shm_LIBS)
+libudp_fi_la_LIBADD = $(linkback)
 libudp_fi_la_LDFLAGS = -module -avoid-version -shared -export-dynamic
 libudp_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_UDP_DL
 src_libfabric_la_SOURCES += $(_udp_files)
-src_libfabric_la_LIBADD += $(udp_shm_LIBS)
 endif !HAVE_UDP_DL
 
 prov_install_man_pages += man/man7/fi_udp.7

--- a/prov/udp/libfabric-udp.spec.in
+++ b/prov/udp/libfabric-udp.spec.in
@@ -1,11 +1,12 @@
 %{!?configopts: %global configopts LDFLAGS=-Wl,--build-id}
-%{!?provider: %define provider usnic}
-%{!?provider_formal: %define provider_formal usNIC}
+%{!?provider: %define provider udp}
+%{!?provider_formal: %define provider_formal udp}
 
 Name: libfabric-%{provider}
 Version: @VERSION@
 Release: 1%{?dist}
 Summary: Dynamic %{provider_formal} provider for user-space Open Fabric Interfaces
+
 Group: System Environment/Libraries
 License: GPLv2 or BSD
 Url: http://www.github.com/ofiwg/libfabric

--- a/util/info.c
+++ b/util/info.c
@@ -80,7 +80,7 @@ static const char *help_strings[][2] = {
 	{"FMT", "\t\tspecify accepted address format: FI_FORMAT_UNSPEC, FI_SOCKADDR..."},
 	{"PROV", "\t\tspecify provider explicitly"},
 	{"", "\t\tprint libfabric environment variables"},
-	{"", "\t\tprint libfabric environment variables with substr"},
+	{"SUBSTR", "\t\tprint libfabric environment variables with substr"},
 	{"", "\t\tlist available libfabric providers"},
 	{"", "\t\tverbose output"},
 	{"", "\t\tprint version info and exit"},


### PR DESCRIPTION
docs: Improve developer guideline documentation on patch submission
udp: Fix incorrect name in spec.in file
udp: Remove unused udp_shm_libs from makefile.include
fi_info: Fix help text for -g --getenv option