### PR TITLE
core/mr_cache: Remove entry subscribed field

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -249,7 +249,6 @@ extern struct ofi_mr_cache_params	cache_params;
 struct ofi_mr_entry {
 	struct ofi_mr_info		info;
 	void				*storage_context;
-	unsigned int			subscribed:1;
 	int				use_cnt;
 	struct dlist_entry		list_entry;
 	union ofi_mr_hmem_info		hmem_info;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -277,8 +277,6 @@ util_mr_cache_create(struct ofi_mr_cache *cache, const struct ofi_mr_info *info,
 			util_mr_uncache_entry_storage(cache, *entry);
 			cache->uncached_cnt++;
 			cache->uncached_size += (*entry)->info.iov.iov_len;
-		} else {
-			(*entry)->subscribed = 1;
 		}
 	}
 	pthread_mutex_unlock(&mm_lock);
@@ -335,8 +333,6 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 
 		/* Purge regions that overlap with new region */
 		while (*entry) {
-			/* New entry will expand range of subscription */
-			(*entry)->subscribed = 0;
 			util_mr_uncache_entry(cache, *entry);
 			*entry = cache->storage.find(&cache->storage, &info);
 		}


### PR DESCRIPTION
This field is no longer used, as subscriptions made from the cache
are always kept.  It used to be used to know when to unsubscribe.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>