### PR TITLE
[v1.10.x] prov/efa: fix a bug in rxr_rma_readmsg()

### DIFF
--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -299,13 +299,16 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	rxr_perfset_start(rxr_ep, perf_rxr_tx);
 	fastlock_acquire(&rxr_ep->util_ep.lock);
 
-	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep)))
-		return -FI_EAGAIN;
+	if (OFI_UNLIKELY(is_tx_res_full(rxr_ep))) {
+		err = -FI_EAGAIN;
+		goto out;
+	}
 
 	tx_entry = rxr_rma_alloc_tx_entry(rxr_ep, msg, ofi_op_read_req, flags);
 	if (OFI_UNLIKELY(!tx_entry)) {
 		rxr_ep_progress_internal(rxr_ep);
-		return -FI_EAGAIN;
+		err = -FI_EAGAIN;
+		goto out;
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);


### PR DESCRIPTION
Currently in rxr_rma_readmsg(), when error was encountered,
the function return immediately. This is wrong because a lock
on rxr_ep->util_ep.lock has been acquired at the beginning
of the function and was not released.

This patch fix the issue by set err then "goto out", so that
the lock will be released.

Signed-off-by: Wei Zhang <wzam@amazon.com>