### PR TITLE
rocr_memory_monitor: Update to use common IOV code

### DIFF
--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -271,7 +271,7 @@ static void rocr_mm_unsubscribe(struct ofi_mem_monitor *monitor,
 	 * Each ROCR memory region needs to be freed and MR caches notified.
 	 */
 	while (cur_len) {
-		entry = rocr_mm_entry_find(addr);
+		entry = rocr_mm_entry_find(cur_addr);
 		if (!entry)
 			break;
 


### PR DESCRIPTION
Use ofi_iov_end() in place of rocr_mm_entry_end_addr() for determining
the next ROCR address.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>