### PR TITLE
Move symver check out of main() in configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -363,8 +363,8 @@ AS_IF([test "$icc_symver_hack"],
 	[AC_MSG_RESULT(disabled)],
 [
 
-AC_TRY_LINK([],
-	[__asm__(".symver main_, main@ABIVER_1.0");],
+AC_TRY_LINK([__asm__(".symver main_, main@ABIVER_1.0");],
+	[],
 	[
 		AC_MSG_RESULT(yes)
 		ac_asm_symver_support=1


### PR DESCRIPTION
On xlc, asm statements outside of function bodies are not supported. This causes a compilation error first seen with the CURRENT_SYMVER macros in `src/fabric.c`. However, the configure check for symver support uses AC_TRY_LINK and places the asm statement in the main() loop, so the configure check passes on xlc. This PR moves the asm statement into the 'include' argument of the AC_TRY_LINK macro. The build now succeeds using xlc, and symver support detection is unchanged on gcc (i haven't tested other compilers.) 