### PR TITLE
fabtests/hmem_ze: add L0 fabtests support

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -113,6 +113,7 @@ libfabtests_la_SOURCES = \
 	common/hmem.c \
 	common/hmem_cuda.c \
 	common/hmem_rocr.c \
+	common/hmem_ze.c \
 	include/shared.h \
 	include/hmem.h \
 	include/jsmn.h \

--- a/fabtests/Makefile.win
+++ b/fabtests/Makefile.win
@@ -29,7 +29,7 @@ CFLAGS = $(CFLAGS) /O2 /MT
 
 basedeps = common\hmem.c common\shared.c common\jsmn.c \
 	common\windows\getopt.c common\windows\osd.c \
-	common\hmem_cuda.c common\hmem_rocr.c
+	common\hmem_cuda.c common\hmem_rocr.c common\hmem_ze.c
 
 includes = /Iinclude /Iinclude\windows /I..\include /FIft_osd.h \
 	/Iinclude\windows\getopt

--- a/fabtests/common/hmem.c
+++ b/fabtests/common/hmem.c
@@ -72,6 +72,15 @@ static struct ft_hmem_ops hmem_ops[] = {
 		.copy_to_hmem = ft_rocr_memcpy,
 		.copy_from_hmem = ft_rocr_memcpy,
 	},
+	[FI_HMEM_ZE] = {
+		.init = ft_ze_init,
+		.cleanup = ft_ze_cleanup,
+		.alloc = ft_ze_alloc,
+		.free = ft_ze_free,
+		.memset = ft_ze_memset,
+		.copy_to_hmem = ft_ze_copy,
+		.copy_from_hmem = ft_ze_copy,
+	},
 };
 
 int ft_hmem_init(enum fi_hmem_iface iface)

--- a/fabtests/common/hmem_ze.c
+++ b/fabtests/common/hmem_ze.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2020 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "hmem.h"
+
+#ifdef HAVE_LIBZE
+
+#include <level_zero/ze_api.h>
+
+#define ZE_MAX_DEVICES 4
+
+static ze_driver_handle_t driver;
+static ze_device_handle_t devices[ZE_MAX_DEVICES];
+static ze_command_queue_handle_t cmd_queue[ZE_MAX_DEVICES];
+static int num_devices = 0;
+
+static inline int _ze_cmd_queue_create(ze_device_handle_t device,
+				       ze_command_queue_handle_t *cmd_queue)
+{
+	ze_command_queue_desc_t desc = {
+		.version	= ZE_COMMAND_QUEUE_DESC_VERSION_CURRENT,
+		.flags		= ZE_COMMAND_QUEUE_FLAG_NONE,
+		.mode		= ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS,
+		.priority	= ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
+		.ordinal	= 0,
+	};
+
+	return zeCommandQueueCreate(device, &desc, cmd_queue);
+}
+
+static inline int _ze_cmd_list_create(ze_device_handle_t device,
+				      ze_command_list_handle_t *cmd_list)
+{
+	ze_command_list_desc_t desc = {
+		.version	= ZE_COMMAND_LIST_DESC_VERSION_CURRENT,
+		.flags		= ZE_COMMAND_LIST_FLAG_NONE,
+	};
+	return zeCommandListCreate(device, &desc, cmd_list);
+}
+
+int ft_ze_init(void)
+{
+	ze_result_t ze_ret;
+	uint32_t count;
+
+	ze_ret = zeInit(ZE_INIT_FLAG_NONE);
+	if (ze_ret)
+		return -FI_EIO;
+
+	count = 1;
+	ze_ret = zeDriverGet(&count, &driver);
+	if (ze_ret)
+		return -FI_EIO;
+
+	count = 0;
+	ze_ret = zeDeviceGet(driver, &count, NULL);
+	if (ze_ret || count > ZE_MAX_DEVICES)
+		return -FI_EIO;
+
+	ze_ret = zeDeviceGet(driver, &count, devices);
+	if (ze_ret)
+		return -FI_EIO;
+
+	for (num_devices = 0; num_devices < count; num_devices++) {
+		ze_ret = _ze_cmd_queue_create(devices[num_devices],
+					      &cmd_queue[num_devices]);
+		if (ze_ret) {
+			(void) ft_ze_cleanup();
+			return -FI_EIO;
+		}
+	}
+
+	return FI_SUCCESS;
+}
+
+int ft_ze_cleanup(void)
+{
+	int i, ret = FI_SUCCESS;
+
+	for (i = 0; i < num_devices; i++) {
+		if (cmd_queue[i] && zeCommandQueueDestroy(cmd_queue[i]))
+			ret = -FI_EINVAL;
+	}
+
+	return ret;
+}
+
+int ft_ze_alloc(uint64_t device, void **buf, size_t size)
+{
+	ze_device_mem_alloc_desc_t device_desc;
+	ze_host_mem_alloc_desc_t host_desc;
+	ze_result_t ze_ret;
+
+	device_desc.version = ZE_DEVICE_MEM_ALLOC_DESC_VERSION_CURRENT;
+	device_desc.ordinal = 0;
+	device_desc.flags = ZE_DEVICE_MEM_ALLOC_FLAG_DEFAULT;
+
+	host_desc.version = ZE_HOST_MEM_ALLOC_DESC_VERSION_CURRENT;
+	host_desc.flags = ZE_HOST_MEM_ALLOC_FLAG_DEFAULT;
+
+	ze_ret = zeDriverAllocSharedMem(driver, &device_desc, &host_desc,
+					size, 16, devices[device], buf);
+	return !ze_ret ? ze_ret : -FI_EINVAL;
+}
+
+int ft_ze_free(void *buf)
+{
+	return zeDriverFreeMem(driver, buf) ? -FI_EINVAL : FI_SUCCESS;
+}
+
+int ft_ze_memset(uint64_t device, void *buf, int value, size_t size)
+{
+	ze_command_list_handle_t cmd_list;
+	ze_result_t ze_ret;
+
+	ze_ret = _ze_cmd_list_create(devices[device], &cmd_list);
+	if (ze_ret)
+		return -FI_EIO;
+
+	ze_ret = zeCommandListAppendMemoryFill(cmd_list, buf, &value,
+					       sizeof(value), size, NULL);
+	if (ze_ret)
+		goto free;
+
+	ze_ret = zeCommandListClose(cmd_list);
+	if (ze_ret)
+		goto free;
+
+	ze_ret = zeCommandQueueExecuteCommandLists(cmd_queue[device], 1,
+						   &cmd_list, NULL);
+
+free:
+	if (!zeCommandListDestroy(cmd_list) && !ze_ret)
+		return FI_SUCCESS;
+
+	return -FI_EINVAL;
+}
+
+int ft_ze_copy(uint64_t device, void *dst, const void *src, size_t size)
+{
+	ze_command_list_handle_t cmd_list;
+	ze_result_t ze_ret;
+
+	ze_ret = _ze_cmd_list_create(devices[device], &cmd_list);
+	if (ze_ret)
+		return -FI_EIO;
+
+	ze_ret = zeCommandListAppendMemoryCopy(cmd_list, dst, src, size, NULL);
+	if (ze_ret)
+		goto free;
+
+	ze_ret = zeCommandListClose(cmd_list);
+	if (ze_ret)
+		goto free;
+
+	ze_ret = zeCommandQueueExecuteCommandLists(cmd_queue[device], 1,
+						   &cmd_list, NULL);
+
+free:
+	if (!zeCommandListDestroy(cmd_list) && !ze_ret)
+		return FI_SUCCESS;
+
+	return -FI_EINVAL;
+}
+
+#else
+
+int ft_ze_init(void)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_ze_cleanup(void)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_ze_alloc(uint64_t device, void **buf, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_ze_free(void *buf)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_ze_memset(uint64_t device, void *buf, int value, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_ze_copy(uint64_t device, void *dst, const void *src, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+
+#endif /* HAVE_LIBZE */

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -383,6 +383,14 @@ static int ft_reg_mr(void *buf, size_t size, uint64_t access,
 	attr.context = NULL;
 	attr.iface = opts.iface;
 
+	switch (opts.iface) {
+	case FI_HMEM_ZE:
+		attr.device.ze = opts.device;
+		break;
+	default:
+		break;
+	}
+
 	ret = fi_mr_regattr(domain, &attr, 0, mr);
 	if (ret)
 		return ret;
@@ -2816,7 +2824,7 @@ void ft_mcusage(char *name, char *desc)
 	FT_PRINT_OPTS_USAGE("-p <provider>", "specific provider name eg sockets, verbs");
 	FT_PRINT_OPTS_USAGE("-d <domain>", "domain name");
 	FT_PRINT_OPTS_USAGE("-p <provider>", "specific provider name eg sockets, verbs");
-	FT_PRINT_OPTS_USAGE("-D <device_iface>", "Specify device interface (default: None). "
+	FT_PRINT_OPTS_USAGE("-D <device_iface>", "Specify device interface: eg ze (default: None). "
 			     "Automatically enables FI_HMEM (-H)");
 	FT_PRINT_OPTS_USAGE("-i <device_id>", "Specify which device to use (default: 0)");
 	FT_PRINT_OPTS_USAGE("-H", "Enable provider FI_HMEM support");
@@ -2887,6 +2895,10 @@ void ft_parseinfo(int op, char *optarg, struct fi_info *hints,
 			opts->mr_mode &= ~FI_MR_LOCAL;
 		break;
 	case 'D':
+		if (!strncasecmp("ze", optarg, 2))
+			opts->iface = FI_HMEM_ZE;
+		else
+			printf("Unsupported interface\n");
 		opts->options |= FT_OPT_ENABLE_HMEM | FT_OPT_USE_DEVICE;
 		break;
 	case 'i':

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -135,6 +135,18 @@ AC_HEADER_STDC
 AC_CHECK_HEADER([rdma/fabric.h], [],
     [AC_MSG_ERROR([<rdma/fabric.h> not found.  fabtests requires libfabric.])])
 
+AC_ARG_WITH([ze],
+            AC_HELP_STRING([--with-ze], [Use non-default ZE location - default NO]),
+            [CPPFLAGS="-I$withval/include $CPPFLAGS"
+             LDFLAGS="-L$withval/$lib $LDFLAGS"],
+            [])
+
+dnl Checks for ZE libraries
+AC_CHECK_LIB([ze_loader], zeInit,
+	     AC_CHECK_HEADER([level_zero/ze_api.h],
+			     AC_DEFINE([HAVE_LIBZE], 1, [ZE support])),
+	     [])
+
 AC_MSG_CHECKING([for fi_trywait support])
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <rdma/fi_eq.h>]],
 	       [[fi_trywait(NULL, NULL, 0);]])],

--- a/fabtests/fabtests.vcxproj
+++ b/fabtests/fabtests.vcxproj
@@ -111,6 +111,7 @@
     <ClCompile Include="common\hmem.c" />
     <ClCompile Include="common\hmem_cuda.c" />
     <ClCompile Include="common\hmem_rocr.c" />
+    <ClCompile Include="common\hmem_ze.c" />
     <ClCompile Include="common\shared.c" />
     <ClCompile Include="common\windows\getopt.c" />
     <ClCompile Include="common\windows\osd.c" />

--- a/fabtests/fabtests.vcxproj.filters
+++ b/fabtests/fabtests.vcxproj.filters
@@ -57,6 +57,9 @@
     <ClCompile Include="common\hmem_rocr.c">
       <Filter>Source Files\common</Filter>
     </ClCompile>
+    <ClCompile Include="common\hmem_ze.c">
+      <Filter>Source Files\common</Filter>
+    </ClCompile>
     <ClCompile Include="common\shared.c">
       <Filter>Source Files\common</Filter>
     </ClCompile>

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -35,6 +35,13 @@
 #include <rdma/fi_domain.h>
 #include <rdma/fi_errno.h>
 
+int ft_ze_init(void);
+int ft_ze_cleanup(void);
+int ft_ze_alloc(uint64_t device, void **buf, size_t size);
+int ft_ze_free(void *buf);
+int ft_ze_memset(uint64_t device, void *buf, int value, size_t size);
+int ft_ze_copy(uint64_t device, void *dst, const void *src, size_t size);
+
 static inline int ft_host_init()
 {
 	return FI_SUCCESS;


### PR DESCRIPTION
- add L0 configure option for non default location and ZE library/header check for compilation
- add L0 hmem_ops and command line option for enabling testing