### PR TITLE
rdma/fi_domain, src/hmem_ze: L0 support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ common_srcs =				\
 	src/hmem.c			\
 	src/hmem_rocr.c			\
 	src/hmem_cuda.c			\
+	src/hmem_ze.c			\
 	src/common.c			\
 	src/enosys.c			\
 	src/rbtree.c			\

--- a/configure.ac
+++ b/configure.ac
@@ -509,6 +509,24 @@ FI_CHECK_PACKAGE([cuda],
 		 [AC_DEFINE([HAVE_LIBCUDA], [1],[CUDA support])],
 		 [], [])
 
+AC_ARG_WITH([ze],
+	AC_HELP_STRING([--with-ze=DIR], [Provide path to where the ZE
+					 libraries and headers are installed.]),
+	[], [])
+
+FI_CHECK_PACKAGE([ze],
+	[level_zero/ze_api.h],
+	[ze_loader],
+	[zeInit],
+	[],
+	[$with_ze],
+	[],
+	[AC_DEFINE([HAVE_LIBZE], [1],[ZE support])],
+	[], [])
+
+CPPFLAGS="$CPPFLAGS $ze_CPPFLAGS"
+LDFLAGS="$LDFLAGS $ze_LDFLAGS"
+LIBS="$LIBS $ze_LIBS"
 
 enable_memhooks=1
 AC_ARG_ENABLE([memhooks-monitor],

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -91,6 +91,14 @@ int cuda_hmem_init(void);
 int cuda_hmem_cleanup(void);
 bool cuda_is_addr_valid(const void *addr);
 
+int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size);
+int ze_hmem_init(void);
+int ze_hmem_cleanup(void);
+bool ze_is_addr_valid(const void *addr);
+int ze_hmem_get_handle(void *dev_buf, void **handle);
+int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr);
+int ze_hmem_close_handle(void *ipc_ptr);
+
 static inline int ofi_memcpy(uint64_t device, void *dest, const void *src,
 			     size_t size)
 {

--- a/include/rdma/fi_domain.h
+++ b/include/rdma/fi_domain.h
@@ -117,6 +117,7 @@ enum fi_hmem_iface {
 	FI_HMEM_SYSTEM	= 0,
 	FI_HMEM_CUDA,
 	FI_HMEM_ROCR,
+	FI_HMEM_ZE,
 };
 
 struct fi_mr_attr {
@@ -132,6 +133,7 @@ struct fi_mr_attr {
 	union {
 		uint64_t	reserved;
 		int		cuda;
+		int		ze;
 	} device;
 };
 

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -581,6 +581,7 @@
     <ClCompile Include="src\hmem.c" />
     <ClCompile Include="src\hmem_cuda.c" />
     <ClCompile Include="src\hmem_rocr.c" />
+    <ClCompile Include="src\hmem_ze.c" />
     <ClCompile Include="src\indexer.c" />
     <ClCompile Include="src\iov.c" />
     <ClCompile Include="src\shared\ofi_str.c" />

--- a/man/fi_mr.3.md
+++ b/man/fi_mr.3.md
@@ -475,6 +475,7 @@ struct fi_mr_attr {
 	union {
 		uint64_t         reserved;
 		int              cuda;
+		int		 ze
 	} device;
 };
 ```
@@ -584,12 +585,19 @@ requested the FI_HMEM capability.
 *FI_HMEM_ROCR*
 : Uses AMD ROCR interfaces such as hsa_memory_allocate and hsa_memory_free.
 
+*FI_HMEM_ZE*
+: Uses Intel L0 ZE interfaces such as zeDriverAllocSharedMem,
+  zeDriverFreeMem. 
+
 ## device
 Reserved 64 bits for device identifier if using non-standard HMEM interface.
 This field is ignore unless the iface field is valid.
 
 *cuda*
 : For FI_HMEM_CUDA, this is equivalent to CUdevice (int).
+
+*ze*
+: For FI_HMEM_ZE, this is equivalent to the ze_device_handle_t index (int).
 
 # NOTES
 

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -85,6 +85,17 @@ static struct ofi_hmem_ops hmem_ops[] = {
 		.open_handle = ofi_hmem_no_open_handle,
 		.close_handle = ofi_hmem_no_close_handle,
 	},
+	[FI_HMEM_ZE] = {
+		.initialized = false,
+		.init = ze_hmem_init,
+		.cleanup = ze_hmem_cleanup,
+		.copy_to_hmem = ze_hmem_copy,
+		.copy_from_hmem = ze_hmem_copy,
+		.is_addr_valid = ze_is_addr_valid,
+		.get_handle = ze_hmem_get_handle,
+		.open_handle = ze_hmem_open_handle,
+		.close_handle = ze_hmem_close_handle,
+	},
 };
 
 static inline int ofi_copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2020 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "ofi_hmem.h"
+#include "ofi.h"
+
+#ifdef HAVE_LIBZE
+
+#include <level_zero/ze_api.h>
+
+#define ZE_MAX_DEVICES 4
+
+static ze_driver_handle_t driver;
+static ze_device_handle_t devices[ZE_MAX_DEVICES];
+static ze_command_queue_handle_t cmd_queue[ZE_MAX_DEVICES];
+static int num_devices = 0;
+
+static const ze_command_queue_desc_t cq_desc = {
+	.version	= ZE_COMMAND_QUEUE_DESC_VERSION_CURRENT,
+	.flags		= ZE_COMMAND_QUEUE_FLAG_NONE,
+	.mode		= ZE_COMMAND_QUEUE_MODE_SYNCHRONOUS,
+	.priority	= ZE_COMMAND_QUEUE_PRIORITY_NORMAL,
+	.ordinal	= 0,
+};
+
+static const ze_command_list_desc_t cl_desc = {
+	.version	= ZE_COMMAND_LIST_DESC_VERSION_CURRENT,
+	.flags		= ZE_COMMAND_LIST_FLAG_NONE,
+};
+
+int ze_hmem_init(void)
+{
+	ze_result_t ze_ret;
+	uint32_t count;
+
+	ze_ret = zeInit(ZE_INIT_FLAG_NONE);
+	if (ze_ret)
+		goto err;
+
+	count = 1;
+	ze_ret = zeDriverGet(&count, &driver);
+	if (ze_ret)
+		goto err;
+
+	count = 0;
+	ze_ret = zeDeviceGet(driver, &count, NULL);
+	if (ze_ret || count > ZE_MAX_DEVICES)
+		goto err;
+
+	ze_ret = zeDeviceGet(driver, &count, devices);
+	if (ze_ret)
+		goto err;
+
+	for (num_devices = 0; num_devices < count; num_devices++) {
+		ze_ret = zeCommandQueueCreate(devices[num_devices], &cq_desc,
+					      &cmd_queue[num_devices]);
+		if (ze_ret)
+			goto free;
+	}
+
+	return FI_SUCCESS;
+
+free:
+	(void) ze_hmem_cleanup();
+
+err:
+	FI_WARN(&core_prov, FI_LOG_CORE,
+		"Failed to initialize ZE driver resources\n");
+
+	return -FI_EIO;
+}
+
+int ze_hmem_cleanup(void)
+{
+	int i, ret = FI_SUCCESS;
+
+	for (i = 0; i < num_devices; i++) {
+		if (cmd_queue[i] && zeCommandQueueDestroy(cmd_queue[i])) {
+			FI_WARN(&core_prov, FI_LOG_CORE,
+				"Failed to destroy ZE cmd_queue\n");
+			ret = -FI_EINVAL;
+		}
+	}
+
+	return ret;
+}
+
+int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size)
+{
+	ze_command_list_handle_t cmd_list;
+	ze_result_t ze_ret;
+	int dev_id = (int) device;
+
+	ze_ret = zeCommandListCreate(devices[dev_id], &cl_desc, &cmd_list);
+	if (ze_ret)
+		goto err;
+
+	ze_ret = zeCommandListAppendMemoryCopy(cmd_list, dst, src, size, NULL);
+	if (ze_ret)
+		goto free;
+
+	ze_ret = zeCommandListClose(cmd_list);
+	if (ze_ret)
+		goto free;
+
+	ze_ret = zeCommandQueueExecuteCommandLists(cmd_queue[dev_id], 1,
+						   &cmd_list, NULL);
+
+free:
+	if (!zeCommandListDestroy(cmd_list) && !ze_ret)
+		return FI_SUCCESS;
+err:
+	FI_WARN(&core_prov, FI_LOG_CORE,
+		"Failed to perform ze copy (%d)\n", ze_ret);
+
+	return -FI_EIO;
+}
+
+bool ze_is_addr_valid(const void *addr)
+{
+	ze_result_t ze_ret;
+	ze_memory_allocation_properties_t mem_prop;
+	int i;
+
+	for (i = 0; i < num_devices; i++) {
+		ze_ret = zeDriverGetMemAllocProperties(driver, addr, &mem_prop,
+						       &devices[i]);
+		if (!ze_ret && mem_prop.type == ZE_MEMORY_TYPE_DEVICE)
+			return true;
+	}
+	return false;
+}
+
+int ze_hmem_get_handle(void *dev_buf, void **handle)
+{
+	ze_result_t ze_ret;
+
+	ze_ret = zeDriverGetMemIpcHandle(driver, dev_buf,
+                                 (ze_ipc_mem_handle_t *) handle);
+	if (ze_ret) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Unable to get handle\n");
+		return -FI_EINVAL;
+	}
+
+	return FI_SUCCESS;
+}
+
+int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+{
+	ze_result_t ze_ret;
+
+	ze_ret = zeDriverOpenMemIpcHandle(driver, devices[device],
+					  *((ze_ipc_mem_handle_t *) handle),
+					  ZE_IPC_MEMORY_FLAG_NONE, ipc_ptr);
+	if (ze_ret) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Unable to open memory handle\n");
+		return -FI_EINVAL;
+	}
+
+	return FI_SUCCESS;
+}
+
+int ze_hmem_close_handle(void *ipc_ptr)
+{
+	ze_result_t ze_ret;
+
+	ze_ret = zeDriverCloseMemIpcHandle(driver, ipc_ptr);
+	if (ze_ret) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Unable to close memory handle\n");
+		return -FI_EINVAL;
+	}
+
+	return FI_SUCCESS;
+}
+
+#else
+
+int ze_hmem_init(void)
+{
+	return -FI_ENOSYS;
+}
+
+int ze_hmem_cleanup(void)
+{
+	return -FI_ENOSYS;
+}
+
+int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size)
+{
+	return -FI_ENOSYS;
+}
+
+bool ze_is_addr_valid(const void *addr)
+{
+	return false;
+}
+
+int ze_hmem_get_handle(void *dev_buf, void **handle)
+{
+	return -FI_ENOSYS;
+}
+
+int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr)
+{
+	return -FI_ENOSYS;
+}
+
+int ze_hmem_close_handle(void *ipc_ptr)
+{
+	return -FI_ENOSYS;
+}
+
+#endif /* HAVE_LIBZE */


### PR DESCRIPTION
- Add FI_HMEM_ZE to libfabric API
- Add ZE library and header configure check and option for non-default installation location
- Add ZE hmem_ops