### PR TITLE
Revert "prov/efa: Add True Support for FI_DELIVERY_COMPLETE"

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -397,17 +397,6 @@ bool efa_peer_support_rdma_read(struct rxr_peer *peer)
 }
 
 static inline
-bool rxr_peer_support_delivery_complete(struct rxr_peer *peer)
-{
-	/* FI_DELIVERY_COMPLETE is an extra feature defined in version 4 (the base version).
-	 * Because it is an extra feature, an EP will assume the peer does not support
-	 * it before a handshake packet was received.
-	 */
-	return (peer->flags & RXR_PEER_HANDSHAKE_RECEIVED) &&
-	       (peer->features[0] & RXR_REQ_FEATURE_DELIVERY_COMPLETE);
-}
-
-static inline
 bool efa_both_support_rdma_read(struct rxr_ep *ep, struct rxr_peer *peer)
 {
 	if (!rxr_env.use_device_rdma)

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -167,7 +167,7 @@ static inline void rxr_poison_mem_region(uint32_t *ptr, size_t size)
  * 60 - 63      provider specific
  */
 #define RXR_NO_COMPLETION	BIT_ULL(60)
-#define RXR_NO_COUNTER  	BIT_ULL(61)
+
 /*
  * RM flags
  */
@@ -353,8 +353,6 @@ struct rxr_rx_entry {
 	uint16_t credit_request;
 	int credit_cts;
 
-	bool delivery_complete_requested;
-
 	uint64_t total_len;
 
 	enum rxr_rx_comm_type state;
@@ -429,8 +427,6 @@ struct rxr_tx_entry {
 	int64_t window;
 	uint16_t credit_request;
 	uint16_t credit_allocated;
-
-	bool delivery_complete_requested;
 
 	uint64_t total_len;
 

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -32,7 +32,6 @@
  */
 
 #include <ofi_atomic.h>
-#include "efa.h"
 #include "rxr.h"
 #include "rxr_rma.h"
 #include "rxr_cntr.h"
@@ -113,7 +112,7 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 {
 	struct rxr_tx_entry *tx_entry;
 	struct rxr_peer *peer;
-	ssize_t delivery_complete_requested, err;
+	ssize_t err;
 	static int req_pkt_type_list[] = {
 		[ofi_op_atomic] = RXR_WRITE_RTA_PKT,
 		[ofi_op_atomic_fetch] = RXR_FETCH_RTA_PKT,
@@ -138,48 +137,12 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 		goto out;
 	}
 
-	delivery_complete_requested = rxr_ep->util_ep.tx_op_flags & FI_DELIVERY_COMPLETE;
-	tx_entry->delivery_complete_requested = delivery_complete_requested;
-	if (delivery_complete_requested) {
-		/*
-		 * Because delivery complete is defined as an extra
-		 * feature, the receiver might not support it.
-		 *
-		 * The sender cannot send with FI_DELIVERY_COMPLETE
-		 * if the peer is not able to handle it.
-		 *
-		 * If the sender does not know whether the peer
-		 * can handle it, it needs to wait for
-		 * a handshake packet from the peer.
-		 *
-		 * The handshake packet contains
-		 * the information whether the peer
-		 * support it or not.
-		 */
-		err = rxr_pkt_wait_handshake(rxr_ep, tx_entry->addr, peer);
-		if (OFI_UNLIKELY(err))
-			goto out;
-
-		assert(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED);
-		if (!rxr_peer_support_delivery_complete(peer)) {
-			err = -FI_EOPNOTSUPP;
-			goto out;
-		}
-	}
-
 	tx_entry->msg_id = (peer->next_msg_id != ~0) ?
 			    peer->next_msg_id++ : ++peer->next_msg_id;
 
-	if (delivery_complete_requested && op == ofi_op_atomic) {
-		/* Fetch atomic and compare atomic support DELIVERY_COMPLETE by nature */
-		err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY,
-						 tx_entry, RXR_DC_WRITE_RTA_PKT,
-						 0);
-	} else {
-		err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY,
-						 tx_entry, req_pkt_type_list[op],
-						 0);
-	}
+	err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY,
+					tx_entry, req_pkt_type_list[op],
+					0);
 
 	if (OFI_UNLIKELY(err)) {
 		rxr_release_tx_entry(rxr_ep, tx_entry);

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -633,9 +633,7 @@ int rxr_cq_reorder_msg(struct rxr_ep *ep,
 	cur_ooo_entry = *ofi_recvwin_get_msg(peer->robuf, msg_id);
 	if (cur_ooo_entry) {
 		assert(rxr_get_base_hdr(cur_ooo_entry->pkt)->type == RXR_MEDIUM_MSGRTM_PKT ||
-		       rxr_get_base_hdr(cur_ooo_entry->pkt)->type == RXR_MEDIUM_TAGRTM_PKT ||
-		       rxr_get_base_hdr(cur_ooo_entry->pkt)->type == RXR_DC_MEDIUM_MSGRTM_PKT ||
-		       rxr_get_base_hdr(cur_ooo_entry->pkt)->type == RXR_DC_MEDIUM_TAGRTM_PKT);
+		       rxr_get_base_hdr(cur_ooo_entry->pkt)->type == RXR_MEDIUM_TAGRTM_PKT);
 		assert(rxr_pkt_msg_id(cur_ooo_entry) == msg_id);
 		assert(rxr_pkt_rtm_total_len(cur_ooo_entry) == rxr_pkt_rtm_total_len(ooo_entry));
 		rxr_pkt_entry_append(cur_ooo_entry, ooo_entry);
@@ -860,8 +858,7 @@ void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entr
 		if (tx_entry->fi_flags & FI_COMPLETION) {
 			rxr_cq_write_tx_completion(ep, tx_entry);
 		} else {
-			if (!(tx_entry->fi_flags & RXR_NO_COUNTER))
-				efa_cntr_report_tx_completion(&ep->util_ep, tx_entry->cq_entry.flags);
+			efa_cntr_report_tx_completion(&ep->util_ep, tx_entry->cq_entry.flags);
 			rxr_release_tx_entry(ep, tx_entry);
 		}
 	} else {

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -57,7 +57,6 @@ struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 	rx_entry->type = RXR_RX_ENTRY;
 	rx_entry->rx_id = ofi_buf_index(rx_entry);
 	rx_entry->addr = msg->addr;
-	rx_entry->delivery_complete_requested = 0;
 	rx_entry->fi_flags = flags;
 	rx_entry->rxr_flags = 0;
 	rx_entry->bytes_done = 0;
@@ -353,8 +352,6 @@ void rxr_tx_entry_init(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry,
 	tx_entry->tx_id = ofi_buf_index(tx_entry);
 	tx_entry->state = RXR_TX_REQ;
 	tx_entry->addr = msg->addr;
-
-	tx_entry->delivery_complete_requested = 0;
 
 	tx_entry->send_flags = 0;
 	tx_entry->bytes_acked = 0;
@@ -832,8 +829,6 @@ void rxr_ep_set_features(struct rxr_ep *ep)
 	/* RDMA read is an extra feature defined in protocol version 4 (the base version) */
 	if (efa_ep_support_rdma_read(ep->rdm_ep))
 		ep->features[0] |= RXR_REQ_FEATURE_RDMA_READ;
-
-	ep->features[0] |= RXR_REQ_FEATURE_DELIVERY_COMPLETE;
 }
 
 static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -36,9 +36,6 @@
 #include "rxr_cntr.h"
 #include "rxr_pkt_cmd.h"
 
-/* Handshake wait timeout in microseconds */
-#define RXR_HANDSHAKE_WAIT_TIMEOUT 1000000
-
 /* This file implements 4 actions that can be applied to a packet:
  *          posting,
  *          handling send completion and,
@@ -123,9 +120,6 @@ int rxr_pkt_init_ctrl(struct rxr_ep *rxr_ep, int entry_type, void *x_entry,
 	case RXR_ATOMRSP_PKT:
 		ret = rxr_pkt_init_atomrsp(rxr_ep, (struct rxr_rx_entry *)x_entry, pkt_entry);
 		break;
-	case RXR_RECEIPT_PKT:
-		ret = rxr_pkt_init_receipt(rxr_ep, (struct rxr_rx_entry *)x_entry, pkt_entry);
-		break;
 	case RXR_EAGER_MSGRTM_PKT:
 		ret = rxr_pkt_init_eager_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
 		break;
@@ -174,33 +168,6 @@ int rxr_pkt_init_ctrl(struct rxr_ep *rxr_ep, int entry_type, void *x_entry,
 	case RXR_COMPARE_RTA_PKT:
 		ret = rxr_pkt_init_compare_rta(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
 		break;
-	case RXR_DC_EAGER_MSGRTM_PKT:
-		ret = rxr_pkt_init_dc_eager_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
-		break;
-	case RXR_DC_EAGER_TAGRTM_PKT:
-		ret = rxr_pkt_init_dc_eager_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
-		break;
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
-		ret = rxr_pkt_init_dc_medium_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
-		break;
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
-		ret = rxr_pkt_init_dc_medium_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
-		break;
-	case RXR_DC_LONG_MSGRTM_PKT:
-		ret = rxr_pkt_init_dc_long_msgrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
-		break;
-	case RXR_DC_LONG_TAGRTM_PKT:
-		ret = rxr_pkt_init_dc_long_tagrtm(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
-		break;
-	case RXR_DC_EAGER_RTW_PKT:
-		ret = rxr_pkt_init_dc_eager_rtw(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
-		break;
-	case RXR_DC_LONG_RTW_PKT:
-		ret = rxr_pkt_init_dc_long_rtw(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
-		break;
-	case RXR_DC_WRITE_RTA_PKT:
-		ret = rxr_pkt_init_dc_write_rta(rxr_ep, (struct rxr_tx_entry *)x_entry, pkt_entry);
-		break;
 	default:
 		ret = -FI_EINVAL;
 		assert(0 && "unknown pkt type to init");
@@ -231,23 +198,16 @@ void rxr_pkt_handle_ctrl_sent(struct rxr_ep *rxr_ep, struct rxr_pkt_entry *pkt_e
 	case RXR_ATOMRSP_PKT:
 		rxr_pkt_handle_atomrsp_sent(rxr_ep, pkt_entry);
 		break;
-	case RXR_RECEIPT_PKT:
-		rxr_pkt_handle_receipt_sent(rxr_ep, pkt_entry);
-		break;
 	case RXR_EAGER_MSGRTM_PKT:
 	case RXR_EAGER_TAGRTM_PKT:
 		rxr_pkt_handle_eager_rtm_sent(rxr_ep, pkt_entry);
 		break;
 	case RXR_MEDIUM_MSGRTM_PKT:
 	case RXR_MEDIUM_TAGRTM_PKT:
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
 		rxr_pkt_handle_medium_rtm_sent(rxr_ep, pkt_entry);
 		break;
 	case RXR_LONG_MSGRTM_PKT:
-	case RXR_DC_LONG_MSGRTM_PKT:
 	case RXR_LONG_TAGRTM_PKT:
-	case RXR_DC_LONG_TAGRTM_PKT:
 		rxr_pkt_handle_long_rtm_sent(rxr_ep, pkt_entry);
 		break;
 	case RXR_READ_MSGRTM_PKT:
@@ -258,7 +218,6 @@ void rxr_pkt_handle_ctrl_sent(struct rxr_ep *rxr_ep, struct rxr_pkt_entry *pkt_e
 		rxr_pkt_handle_eager_rtw_sent(rxr_ep, pkt_entry);
 		break;
 	case RXR_LONG_RTW_PKT:
-	case RXR_DC_LONG_RTW_PKT:
 		rxr_pkt_handle_long_rtw_sent(rxr_ep, pkt_entry);
 		break;
 	case RXR_READ_RTW_PKT:
@@ -269,15 +228,9 @@ void rxr_pkt_handle_ctrl_sent(struct rxr_ep *rxr_ep, struct rxr_pkt_entry *pkt_e
 		rxr_pkt_handle_rtr_sent(rxr_ep, pkt_entry);
 		break;
 	case RXR_WRITE_RTA_PKT:
-	case RXR_DC_WRITE_RTA_PKT:
 	case RXR_FETCH_RTA_PKT:
 	case RXR_COMPARE_RTA_PKT:
 		rxr_pkt_handle_rta_sent(rxr_ep, pkt_entry);
-		break;
-	case RXR_DC_EAGER_MSGRTM_PKT:
-	case RXR_DC_EAGER_TAGRTM_PKT:
-	case RXR_DC_EAGER_RTW_PKT:
-		/* no action to be taken here */
 		break;
 	default:
 		assert(0 && "Unknown packet type to handle sent");
@@ -360,10 +313,7 @@ ssize_t rxr_pkt_post_ctrl(struct rxr_ep *ep, int entry_type, void *x_entry,
 	ssize_t err;
 	struct rxr_tx_entry *tx_entry;
 
-	if (ctrl_type == RXR_MEDIUM_TAGRTM_PKT ||
-	    ctrl_type == RXR_MEDIUM_MSGRTM_PKT ||
-	    ctrl_type == RXR_DC_MEDIUM_MSGRTM_PKT ||
-	    ctrl_type == RXR_DC_MEDIUM_TAGRTM_PKT) {
+	if (ctrl_type == RXR_MEDIUM_TAGRTM_PKT || ctrl_type == RXR_MEDIUM_MSGRTM_PKT) {
 		assert(entry_type == RXR_TX_ENTRY);
 		assert(!inject);
 
@@ -412,86 +362,6 @@ ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_en
 }
 
 /*
- * This function is used for any extra feature that does not have an alternative,
- * for example FI_DELIVERY_COMPLETE
- *
- * This function will send a eager rtw packet with no data. Then keep calling
- * rxr_ep_progress_internal() until rxr_peer->flags has the HANDSHAKE_RECEIVED flag.
- * Upon receiving the eager RTW, the receiver will post a handshake,
- * which will be processed in sender's rxr_ep_progress_internal().
- *
- * ep: The endpoint on which the packet for triggering handshake will be sent.
- * peer: The peer from which the sender receives handshake.
- * addr: The address of the peer.
- *
- * This function will return 0 if sender successfully receives / have already
- * received the handshake from the peer
- *
- * This function will return FI_EAGAIN if it fails to allocate or send the trigger packet or
- * it fails to receive handshake packet within a certain period of time.
- */
-
-ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rxr_peer *peer)
-{
-	struct rxr_tx_entry *tx_entry;
-	ssize_t err;
-
-	uint64_t start, endwait;
-
-	if (peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)
-		return 0;
-
-	tx_entry = ofi_buf_alloc(ep->tx_entry_pool);
-	if (OFI_UNLIKELY(!tx_entry)) {
-		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "TX entries exhausted.\n");
-		return -FI_EAGAIN;
-	}
-
-	tx_entry->total_len = 0;
-	tx_entry->addr = addr;
-	tx_entry->msg_id = -1;
-	tx_entry->cq_entry.flags = FI_RMA | FI_WRITE;
-	tx_entry->cq_entry.buf = NULL;
-	dlist_init(&tx_entry->queued_pkts);
-
-	tx_entry->type = RXR_TX_ENTRY;
-	tx_entry->op = ofi_op_write;
-	tx_entry->state = RXR_TX_REQ;
-
-	tx_entry->send_flags = 0;
-	tx_entry->bytes_acked = 0;
-	tx_entry->bytes_sent = 0;
-	tx_entry->window = 0;
-	tx_entry->rma_iov_count = 0;
-	tx_entry->iov_count = 0;
-	tx_entry->iov_index = 0;
-	tx_entry->iov_mr_start = 0;
-	tx_entry->iov_offset = 0;
-	tx_entry->fi_flags = RXR_NO_COMPLETION | RXR_NO_COUNTER;
-
-#if ENABLE_DEBUG
-	dlist_insert_tail(&tx_entry->tx_entry_entry, &ep->tx_entry_list);
-#endif
-
-	err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_EAGER_RTW_PKT, 0);
-
-	if (OFI_UNLIKELY(err))
-		return err;
-
-	start = ofi_gettime_us();
-	endwait = start + RXR_HANDSHAKE_WAIT_TIMEOUT;
-	while (start < endwait && !(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)) {
-		rxr_ep_progress_internal(ep);
-		start = ofi_gettime_us();
-	}
-
-	if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED))
-		return FI_ETIMEDOUT;
-
-	return 0;
-}
-
-/*
  *   Functions used to handle packet send completion
  */
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *comp)
@@ -520,9 +390,6 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *
 		return;
 	case RXR_ATOMRSP_PKT:
 		rxr_pkt_handle_atomrsp_send_completion(ep, pkt_entry);
-		break;
-	case RXR_RECEIPT_PKT:
-		rxr_pkt_handle_receipt_send_completion(ep, pkt_entry);
 		break;
 	case RXR_EAGER_MSGRTM_PKT:
 	case RXR_EAGER_TAGRTM_PKT:
@@ -560,29 +427,6 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *
 		/* no action to be taken here */
 		break;
 	case RXR_COMPARE_RTA_PKT:
-		/* no action to be taken here */
-		break;
-	case RXR_DC_EAGER_MSGRTM_PKT:
-		/* completion will be written upon receving the receipt packet, thus no action to be taken here */
-		break;
-	case RXR_DC_EAGER_TAGRTM_PKT:
-		/* completion will be written upon receving the receipt packet, thus no action to be taken her */
-		break;
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
-		rxr_pkt_handle_dc_medium_rtm_send_completion(ep, pkt_entry);
-		break;
-	case RXR_DC_LONG_MSGRTM_PKT:
-	case RXR_DC_LONG_TAGRTM_PKT:
-		rxr_pkt_handle_dc_long_rtm_send_completion(ep, pkt_entry);
-		break;
-	case RXR_DC_EAGER_RTW_PKT:
-		/* no action to be taken here */
-		break;
-	case RXR_DC_LONG_RTW_PKT:
-		rxr_pkt_handle_dc_long_rtw_send_completion(ep, pkt_entry);
-		break;
-	case RXR_DC_WRITE_RTA_PKT:
 		/* no action to be taken here */
 		break;
 	default:
@@ -733,34 +577,23 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 	case RXR_ATOMRSP_PKT:
 		rxr_pkt_handle_atomrsp_recv(ep, pkt_entry);
 		return;
-	case RXR_RECEIPT_PKT:
-		rxr_pkt_handle_receipt_recv(ep, pkt_entry);
-		return;
 	case RXR_EAGER_MSGRTM_PKT:
 	case RXR_EAGER_TAGRTM_PKT:
 	case RXR_MEDIUM_MSGRTM_PKT:
 	case RXR_MEDIUM_TAGRTM_PKT:
-	case RXR_DC_MEDIUM_MSGRTM_PKT:
-	case RXR_DC_MEDIUM_TAGRTM_PKT:
 	case RXR_LONG_MSGRTM_PKT:
 	case RXR_LONG_TAGRTM_PKT:
-	case RXR_DC_LONG_MSGRTM_PKT:
-	case RXR_DC_LONG_TAGRTM_PKT:
 	case RXR_READ_MSGRTM_PKT:
 	case RXR_READ_TAGRTM_PKT:
 	case RXR_WRITE_RTA_PKT:
-	case RXR_DC_WRITE_RTA_PKT:
 	case RXR_FETCH_RTA_PKT:
 	case RXR_COMPARE_RTA_PKT:
-	case RXR_DC_EAGER_MSGRTM_PKT:
-	case RXR_DC_EAGER_TAGRTM_PKT:
 		rxr_pkt_handle_rtm_rta_recv(ep, pkt_entry);
 		return;
 	case RXR_EAGER_RTW_PKT:
 		rxr_pkt_handle_eager_rtw_recv(ep, pkt_entry);
 		return;
 	case RXR_LONG_RTW_PKT:
-	case RXR_DC_LONG_RTW_PKT:
 		rxr_pkt_handle_long_rtw_recv(ep, pkt_entry);
 		return;
 	case RXR_READ_RTW_PKT:
@@ -769,9 +602,6 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 	case RXR_SHORT_RTR_PKT:
 	case RXR_LONG_RTR_PKT:
 		rxr_pkt_handle_rtr_recv(ep, pkt_entry);
-		return;
-	case RXR_DC_EAGER_RTW_PKT:
-		rxr_pkt_handle_dc_eager_rtw_recv(ep, pkt_entry);
 		return;
 	default:
 		FI_WARN(&rxr_prov, FI_LOG_CQ,

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -51,8 +51,6 @@ void rxr_pkt_handle_recv_completion(struct rxr_ep *ep,
 				    struct fi_cq_data_entry *cq_entry,
 				    fi_addr_t src_addr);
 
-ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rxr_peer *peer);
-
 #if ENABLE_DEBUG
 void rxr_pkt_print(char *prefix,
 		   struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -67,7 +67,6 @@
 #define RXR_EOR_PKT		7
 #define RXR_ATOMRSP_PKT         8
 #define RXR_HANDSHAKE_PKT	9
-#define RXR_RECEIPT_PKT 10
 
 #define RXR_REQ_PKT_BEGIN		64
 #define RXR_BASELINE_REQ_PKT_BEGIN	64
@@ -91,17 +90,7 @@
 #define RXR_READ_TAGRTM_PKT		129
 #define RXR_READ_RTW_PKT		130
 #define RXR_READ_RTR_PKT		131
-
-#define RXR_DC_EAGER_MSGRTM_PKT 	132
-#define RXR_DC_EAGER_TAGRTM_PKT 	133
-#define RXR_DC_MEDIUM_MSGRTM_PKT 	134
-#define RXR_DC_MEDIUM_TAGRTM_PKT 	135
-#define RXR_DC_LONG_MSGRTM_PKT  	136
-#define RXR_DC_LONG_TAGRTM_PKT  	137
-#define RXR_DC_EAGER_RTW_PKT    	138
-#define RXR_DC_LONG_RTW_PKT     	139
-#define RXR_DC_WRITE_RTA_PKT    	140
-#define RXR_EXTRA_REQ_PKT_END   	141
+#define RXR_EXTRA_REQ_PKT_END		132
 
 /*
  *  Packet fields common to all rxr packets. The other packet headers below must
@@ -400,35 +389,6 @@ static inline struct rxr_atomrsp_hdr *rxr_get_atomrsp_hdr(void *pkt)
 {
 	return (struct rxr_atomrsp_hdr *)pkt;
 }
-
-/* receipt packet headers */
-struct rxr_receipt_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	uint32_t tx_id;
-	uint32_t msg_id;
-	int32_t ret_code;
-	int32_t padding;
-};
-
-static inline
-struct rxr_receipt_hdr *rxr_get_receipt_hdr(void *pkt)
-{
-	return (struct rxr_receipt_hdr *)pkt;
-}
-
-/* receipt packet functions: init, handle_sent, handle_send_completion, recv*/
-int rxr_pkt_init_receipt(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
-			 struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_receipt_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_receipt_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry);
 
 /* atomrsp functions: init, handle_sent, handle_send_completion, recv */
 int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -234,8 +234,7 @@ void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 	tx_entry->bytes_acked +=
 		rxr_get_data_pkt(pkt_entry->pkt)->hdr.seg_size;
 
-	/* If FI_DELIVERY_COMPLETE requested, rx_cq_handle_tx_completion() will be called upon receiving RECEIPT */
-	if (tx_entry->total_len == tx_entry->bytes_acked && !tx_entry->delivery_complete_requested)
+	if (tx_entry->total_len == tx_entry->bytes_acked)
 		rxr_cq_handle_tx_completion(ep, tx_entry);
 }
 
@@ -295,25 +294,15 @@ int rxr_pkt_proc_data(struct rxr_ep *ep,
 	bytes_left = rx_entry->total_len - rx_entry->bytes_done;
 	assert(bytes_left >= 0);
 	if (!bytes_left) {
-		rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
-		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 #if ENABLE_DEBUG
 		dlist_remove(&rx_entry->rx_pending_entry);
 		ep->rx_pending--;
 #endif
-		if (rx_entry->delivery_complete_requested) {
-			ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_RECEIPT_PKT, 0);
-			if (OFI_UNLIKELY(ret)) {
-				FI_WARN(&rxr_prov, FI_LOG_CQ, "Posting of receipt packet failed! err=%ld\n", ret);
-				efa_eq_write_error(&ep->util_ep, FI_EIO, ret);
-				rxr_release_rx_entry(ep, rx_entry);
-				return ret;
-			}
-			return 0;
-		}
+		rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
 
+		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 		rxr_release_rx_entry(ep, rx_entry);
-		return ret;
+		return 0;
 	}
 
 	if (!rx_entry->window) {

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -506,38 +506,6 @@ void rxr_pkt_handle_eor_recv(struct rxr_ep *ep,
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 }
 
-/* receipt packet related functions */
-int rxr_pkt_init_receipt(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
-			 struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_receipt_hdr *receipt_hdr;
-
-	receipt_hdr = rxr_get_receipt_hdr(pkt_entry->pkt);
-	receipt_hdr->type = RXR_RECEIPT_PKT;
-	receipt_hdr->version = RXR_BASE_PROTOCOL_VERSION;
-	receipt_hdr->flags = 0;
-	receipt_hdr->ret_code = 0;
-	receipt_hdr->tx_id = rx_entry->tx_id;
-	receipt_hdr->msg_id = rx_entry->msg_id;
-
-	pkt_entry->pkt_size = sizeof(struct rxr_receipt_hdr);
-	pkt_entry->addr = rx_entry->addr;
-	pkt_entry->x_entry = rx_entry;
-
-	return 0;
-}
-
-void rxr_pkt_handle_receipt_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
-{
-}
-
-void rxr_pkt_handle_receipt_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_rx_entry *rx_entry;
-
-	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
-	rxr_release_rx_entry(ep, rx_entry);
-}
 
 /* atomrsp packet related functions: init, handle_sent, handle_send_completion and recv
  *
@@ -610,21 +578,6 @@ void rxr_pkt_handle_atomrsp_recv(struct rxr_ep *ep,
 		rxr_release_tx_entry(ep, tx_entry);
 	}
 
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
-}
-
-void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
-				 struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_tx_entry *tx_entry = NULL;
-	struct rxr_receipt_hdr *receipt_hdr;
-
-	receipt_hdr = rxr_get_receipt_hdr(pkt_entry->pkt);
-	/* Retrive the tx_entry that will be written into TX CQ*/
-	tx_entry = ofi_bufpool_get_ibuf(ep->tx_entry_pool,
-					receipt_hdr->tx_id);
-
-	rxr_cq_handle_tx_completion(ep, tx_entry);
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -67,13 +67,11 @@
 #define RXR_REQ_TAGGED			BIT_ULL(3)
 #define RXR_REQ_RMA			BIT_ULL(4)
 #define RXR_REQ_ATOMIC			BIT_ULL(5)
-#define RXR_REQ_WAIT_RECEIPT		BIT_ULL(6)
 
 /*
  *     Extra Feature Flags
  */
 #define RXR_REQ_FEATURE_RDMA_READ	BIT_ULL(0)
-#define RXR_REQ_FEATURE_DELIVERY_COMPLETE BIT_ULL(1)
 
 /*
  *     Utility struct and functions for
@@ -126,18 +124,6 @@ static inline
 struct rxr_rtm_base_hdr *rxr_get_rtm_base_hdr(void *pkt)
 {
 	return (struct rxr_rtm_base_hdr *)pkt;
-}
-
-struct rxr_dc_rtm_base_hdr {
-	struct rxr_rtm_base_hdr hdr;
-	uint32_t tx_id;
-	uint32_t padding;
-};
-
-static inline
-struct rxr_dc_rtm_base_hdr *rxr_get_dc_rtm_base_hdr(void *pkt)
-{
-	return (struct rxr_dc_rtm_base_hdr *)pkt;
 }
 
 static inline
@@ -193,51 +179,14 @@ struct rxr_eager_tagrtm_hdr {
 	uint64_t tag;
 };
 
-struct rxr_dc_eager_msgrtm_hdr {
-	struct rxr_rtm_base_hdr hdr;
-	uint32_t tx_id;
-	uint32_t padding;
-};
-
-static inline
-struct rxr_dc_eager_msgrtm_hdr *rxr_get_dc_eager_msgrtm_hdr(void *pkt)
-{
-	return (struct rxr_dc_eager_msgrtm_hdr *)pkt;
-}
-
-struct rxr_dc_eager_tagrtm_hdr {
-	struct rxr_rtm_base_hdr hdr;
-	uint32_t tx_id;
-	uint32_t padding;
-	uint64_t tag;
-};
-
-static inline
-struct rxr_dc_eager_tagrtm_hdr *rxr_get_dc_eager_tagrtm_hdr(void *pkt)
-{
-	return (struct rxr_dc_eager_tagrtm_hdr *)pkt;
-}
-
 struct rxr_medium_rtm_base_hdr {
 	struct rxr_rtm_base_hdr hdr;
 	uint64_t data_len;
 	uint64_t offset;
 };
 
-struct rxr_dc_medium_rtm_base_hdr {
-	struct rxr_rtm_base_hdr hdr;
-	uint64_t data_len;
-	uint64_t offset;
-	uint32_t tx_id;
-	uint32_t padding;
-};
-
 struct rxr_medium_msgrtm_hdr {
 	struct rxr_medium_rtm_base_hdr hdr;
-};
-
-struct rxr_dc_medium_msgrtm_hdr {
-	struct rxr_dc_medium_rtm_base_hdr hdr;
 };
 
 struct rxr_medium_tagrtm_hdr {
@@ -245,33 +194,10 @@ struct rxr_medium_tagrtm_hdr {
 	uint64_t tag;
 };
 
-struct rxr_dc_medium_tagrtm_hdr {
-	struct rxr_dc_medium_rtm_base_hdr hdr;
-	uint64_t tag;
-};
-
 static inline
 struct rxr_medium_rtm_base_hdr *rxr_get_medium_rtm_base_hdr(void *pkt)
 {
 	return (struct rxr_medium_rtm_base_hdr *)pkt;
-}
-
-static inline
-struct rxr_dc_medium_rtm_base_hdr *rxr_get_dc_medium_rtm_base_hdr(void *pkt)
-{
-	return (struct rxr_dc_medium_rtm_base_hdr *)pkt;
-}
-
-static inline
-struct rxr_dc_medium_msgrtm_hdr *rxr_get_dc_medium_msgrtm_hdr(void *pkt)
-{
-	return (struct rxr_dc_medium_msgrtm_hdr *)pkt;
-}
-
-static inline
-struct rxr_dc_medium_tagrtm_hdr *rxr_get_dc_medium_tagrtm_hdr(void *pkt)
-{
-	return (struct rxr_dc_medium_tagrtm_hdr *)pkt;
 }
 
 struct rxr_long_rtm_base_hdr {
@@ -333,10 +259,6 @@ ssize_t rxr_pkt_init_eager_msgrtm(struct rxr_ep *ep,
 				  struct rxr_tx_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
 
-ssize_t rxr_pkt_init_dc_eager_msgrtm(struct rxr_ep *ep,
-				     struct rxr_tx_entry *tx_entry,
-				     struct rxr_pkt_entry *pkt_entry);
-
 ssize_t rxr_pkt_init_eager_tagrtm(struct rxr_ep *ep,
 				  struct rxr_tx_entry *tx_entry,
 				  struct rxr_pkt_entry *pkt_entry);
@@ -345,37 +267,17 @@ ssize_t rxr_pkt_init_medium_msgrtm(struct rxr_ep *ep,
 				   struct rxr_tx_entry *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry);
 
-ssize_t rxr_pkt_init_dc_eager_tagrtm(struct rxr_ep *ep,
-				     struct rxr_tx_entry *tx_entry,
-				     struct rxr_pkt_entry *pkt_entry);
-
-ssize_t rxr_pkt_init_dc_medium_msgrtm(struct rxr_ep *ep,
-				      struct rxr_tx_entry *tx_entry,
-				      struct rxr_pkt_entry *pkt_entry);
-
 ssize_t rxr_pkt_init_medium_tagrtm(struct rxr_ep *ep,
 				   struct rxr_tx_entry *tx_entry,
 				   struct rxr_pkt_entry *pkt_entry);
-
-ssize_t rxr_pkt_init_dc_medium_tagrtm(struct rxr_ep *ep,
-				      struct rxr_tx_entry *tx_entry,
-				      struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_long_msgrtm(struct rxr_ep *ep,
 				 struct rxr_tx_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
 
-ssize_t rxr_pkt_init_dc_long_msgrtm(struct rxr_ep *ep,
-				    struct rxr_tx_entry *tx_entry,
-				    struct rxr_pkt_entry *pkt_entry);
-
 ssize_t rxr_pkt_init_long_tagrtm(struct rxr_ep *ep,
 				 struct rxr_tx_entry *tx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
-
-ssize_t rxr_pkt_init_dc_long_tagrtm(struct rxr_ep *ep,
-				    struct rxr_tx_entry *tx_entry,
-				    struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_read_msgrtm(struct rxr_ep *ep,
 				 struct rxr_tx_entry *tx_entry,
@@ -419,11 +321,6 @@ void rxr_pkt_handle_medium_rtm_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_long_rtm_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry);
 
-void rxr_pkt_handle_dc_medium_rtm_send_completion(struct rxr_ep *ep,
-						  struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_dc_long_rtm_send_completion(struct rxr_ep *ep,
-                                                struct rxr_pkt_entry *pkt_entry);
 static inline
 void rxr_pkt_handle_read_rtm_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry)
@@ -487,24 +384,6 @@ struct rxr_eager_rtw_hdr {
 	struct fi_rma_iov rma_iov[0];
 };
 
-struct rxr_dc_eager_rtw_hdr {
-	uint8_t type;
-	uint8_t version;
-	uint16_t flags;
-	/* end of rxr_base_hdr */
-	uint32_t rma_iov_count;
-	/* end of rxr_rtw_base_hdr */
-	uint32_t tx_id;
-	uint32_t padding;
-	struct fi_rma_iov rma_iov[0];
-};
-
-static inline
-struct rxr_dc_eager_rtw_hdr *rxr_get_dc_eager_rtw_hdr(void *pkt)
-{
-	return (struct rxr_dc_eager_rtw_hdr *)pkt;
-}
-
 struct rxr_long_rtw_hdr {
 	uint8_t type;
 	uint8_t version;
@@ -543,15 +422,6 @@ ssize_t rxr_pkt_init_long_rtw(struct rxr_ep *ep,
 ssize_t rxr_pkt_init_read_rtw(struct rxr_ep *ep,
 			      struct rxr_tx_entry *tx_entry,
 			      struct rxr_pkt_entry *pkt_entry);
-
-ssize_t rxr_pkt_init_dc_eager_rtw(struct rxr_ep *ep,
-				  struct rxr_tx_entry *tx_entry,
-				  struct rxr_pkt_entry *pkt_entry);
-
-ssize_t rxr_pkt_init_dc_long_rtw(struct rxr_ep *ep,
-				 struct rxr_tx_entry *tx_entry,
-				 struct rxr_pkt_entry *pkt_entry);
-
 /*
  *     handle_sent() functions
  */
@@ -581,9 +451,6 @@ void rxr_pkt_handle_eager_rtw_send_completion(struct rxr_ep *ep,
 void rxr_pkt_handle_long_rtw_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry);
 
-void rxr_pkt_handle_dc_long_rtw_send_completion(struct rxr_ep *ep,
-						struct rxr_pkt_entry *pkt_entry);
-
 static inline
 void rxr_pkt_handle_read_rtw_send_completion(struct rxr_ep *ep,
 					     struct rxr_pkt_entry *pkt_entry)
@@ -595,9 +462,6 @@ void rxr_pkt_handle_read_rtw_send_completion(struct rxr_ep *ep,
  */
 void rxr_pkt_handle_eager_rtw_recv(struct rxr_ep *ep,
 				   struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_dc_eager_rtw_recv(struct rxr_ep *ep,
-				      struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_long_rtw_recv(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry);
@@ -689,8 +553,6 @@ struct rxr_rta_hdr *rxr_get_rta_hdr(void *pkt)
 
 ssize_t rxr_pkt_init_write_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
 
-ssize_t rxr_pkt_init_dc_write_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
-
 ssize_t rxr_pkt_init_fetch_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_init_compare_rta(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry, struct rxr_pkt_entry *pkt_entry);
@@ -710,9 +572,6 @@ void rxr_pkt_handle_write_rta_send_completion(struct rxr_ep *ep,
 
 int rxr_pkt_proc_write_rta(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry);
-
-int rxr_pkt_proc_dc_write_rta(struct rxr_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry);
 
 int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry);


### PR DESCRIPTION
This is the revert for the pull request
https://github.com/ofiwg/libfabric/pull/6092.

This pull request will result in failure
in running openfoam with intel mpi U7
on 32 nodes and 128 nodes

Signed-off-by: Ao Li <aolia@amazon.com>