### PR TITLE
prov/efa: Bugfix for prov version

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -66,9 +66,6 @@
 #include "rxr_pkt_entry.h"
 #include "rxr_pkt_type.h"
 
-#define RXR_MAJOR_VERSION	(2)
-#define RXR_MINOR_VERSION	(0)
-
 /*
  * EFA support interoperability between protocol version 4 and above,
  * and version 4 is considered the base version.

--- a/prov/efa/src/rxr/rxr_attr.c
+++ b/prov/efa/src/rxr/rxr_attr.c
@@ -110,7 +110,7 @@ struct fi_domain_attr rxr_domain_attr = {
 };
 
 struct fi_fabric_attr rxr_fabric_attr = {
-	.prov_version = FI_VERSION(RXR_MAJOR_VERSION, RXR_MINOR_VERSION),
+	.prov_version = OFI_VERSION_DEF_PROV,
 };
 
 struct fi_info rxr_info = {

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -657,8 +657,8 @@ static void rxr_fini(void)
 
 struct fi_provider rxr_prov = {
 	.name = "efa",
-	.version = FI_VERSION(RXR_MAJOR_VERSION, RXR_MINOR_VERSION),
-	.fi_version = RXR_FI_VERSION,
+	.version = OFI_VERSION_DEF_PROV,
+	.fi_version = OFI_VERSION_LATEST,
 	.getinfo = rxr_getinfo,
 	.fabric = rxr_fabric,
 	.cleanup = rxr_fini


### PR DESCRIPTION
The provider version between different endpoint types in EFA differred.
This fix synchronizes the version numbers.

Signed-off-by: William Zhang <wilzhang@amazon.com>