### PR TITLE
shm: fix signal handler function calling the original handler

### DIFF
--- a/prov/shm/src/smr_signal.h
+++ b/prov/shm/src/smr_signal.h
@@ -53,8 +53,15 @@ static void smr_handle_signal(int signum, siginfo_t *info, void *ucontext)
 	if (ret)
 		return;
 
-	/* Raise signum to execute the original handler */
-	raise(signum);
+	/* call the original handler */
+	if (old_action[signum].sa_flags & SA_SIGINFO)
+		old_action[signum].sa_sigaction(signum, info, ucontext);
+	else if (old_action[signum].sa_handler == SIG_DFL ||
+		 old_action[signum].sa_handler == SIG_IGN)
+		return;
+	else
+		old_action[signum].sa_handler(signum);
+
 }
 
 static void smr_reg_sig_hander(int signum)


### PR DESCRIPTION
The shm signal handler should call the original handler inline with the same siginfo_t info object, instead of raising a new signal.
This is to fix an issue found with level zero which also register a page fault signal handle for SIGSEGV on DG1.