### PR TITLE
smr: Fix compile warnings, util/sockets: Handle fi_mr_attr compatibility

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -225,6 +225,9 @@ struct ofi_mr {
 	uint64_t device;
 };
 
+void ofi_mr_update_attr(uint32_t user_version, uint64_t caps,
+			const struct fi_mr_attr *user_attr,
+			struct fi_mr_attr *cur_abi_attr);
 int ofi_mr_close(struct fid *fid);
 int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		   uint64_t flags, struct fid_mr **mr_fid);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -164,8 +164,10 @@ static inline int smr_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_ta
 static inline enum fi_hmem_iface smr_get_mr_hmem_iface(struct util_domain *domain,
 				void **desc, uint64_t *device)
 {
-	if (!(domain->mr_mode & FI_MR_HMEM) || !desc || !*desc)
+	if (!(domain->mr_mode & FI_MR_HMEM) || !desc || !*desc) {
+		*device = 0;
 		return FI_HMEM_SYSTEM;
+	}
 
 	*device = ((struct ofi_mr *) *desc)->device;
 	return ((struct ofi_mr *) *desc)->iface;

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -669,8 +669,8 @@ static int smr_progress_cmd_rma(struct smr_ep *ep, struct smr_cmd *cmd)
 	size_t total_len = 0;
 	int err = 0, ret = 0;
 	struct ofi_mr *mr;
-	enum fi_hmem_iface iface;
-	uint64_t device;
+	enum fi_hmem_iface iface = FI_HMEM_SYSTEM;
+	uint64_t device = 0;
 
 	domain = container_of(ep->util_ep.domain, struct smr_domain,
 			      util_domain);

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -219,10 +219,39 @@ static struct fi_ops ofi_mr_fi_ops = {
 	.ops_open = fi_no_ops_open
 };
 
+void ofi_mr_update_attr(uint32_t user_version, uint64_t caps,
+			const struct fi_mr_attr *user_attr,
+			struct fi_mr_attr *cur_abi_attr)
+{
+	cur_abi_attr->mr_iov = (struct iovec *) user_attr->mr_iov;
+	cur_abi_attr->iov_count = user_attr->iov_count;
+	cur_abi_attr->access = user_attr->access;
+	cur_abi_attr->offset = user_attr->offset;
+	cur_abi_attr->requested_key = user_attr->requested_key;
+	cur_abi_attr->context = user_attr->context;
+
+	if (FI_VERSION_GE(user_version, FI_VERSION(1, 5))) {
+		cur_abi_attr->auth_key_size = user_attr->auth_key_size;
+		cur_abi_attr->auth_key = user_attr->auth_key;
+	} else {
+		cur_abi_attr->auth_key_size = 0;
+		cur_abi_attr->auth_key = NULL;
+	}
+
+	if (caps & FI_HMEM) {
+		cur_abi_attr->iface = user_attr->iface;
+		cur_abi_attr->device = user_attr->device;
+	} else {
+		cur_abi_attr->iface = FI_HMEM_SYSTEM;
+		cur_abi_attr->device.reserved = 0;
+	}
+}
+
 int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 		   uint64_t flags, struct fid_mr **mr_fid)
 {
 	struct util_domain *domain;
+	struct fi_mr_attr cur_abi_attr;
 	struct ofi_mr *mr;
 	uint64_t key;
 	int ret = 0;
@@ -235,6 +264,8 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	if (!mr)
 		return -FI_ENOMEM;
 
+	ofi_mr_update_attr(domain->fabric->fabric_fid.api_version,
+			   domain->info_domain_caps, attr, &cur_abi_attr);
 	fastlock_acquire(&domain->lock);
 
 	mr->mr_fid.fid.fclass = FI_CLASS_MR;
@@ -242,15 +273,10 @@ int ofi_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	mr->mr_fid.fid.ops = &ofi_mr_fi_ops;
 	mr->domain = domain;
 	mr->flags = flags;
+	mr->iface = cur_abi_attr.iface;
+	mr->device = cur_abi_attr.device.reserved;
 
-	if (domain->mr_mode & FI_MR_HMEM) {
-		mr->iface = attr->iface;
-		mr->device = attr->device.reserved;
-	} else {
-		mr->iface = FI_HMEM_SYSTEM;
-	}
-
-	ret = ofi_mr_map_insert(&domain->mr_map, attr, &key, mr);
+	ret = ofi_mr_map_insert(&domain->mr_map, &cur_abi_attr, &key, mr);
 	if (ret) {
 		free(mr);
 		goto out;


### PR DESCRIPTION
Fixes compile warnings in smr provider

Updates util and sockets providers to handle fi_mr_attr backwards compatibility.  Specifically, do not access new HMEM related fields unless FI_HMEM capability has been requested by the app.  And do not access auth fields unless API version is 1.5 or greater.