### PR TITLE
prov/efa: Add the missing op_flag FI_MULTI_RECV

### DIFF
--- a/prov/efa/src/rxr/rxr_attr.c
+++ b/prov/efa/src/rxr/rxr_attr.c
@@ -52,7 +52,7 @@ const uint32_t rxr_poison_value = 0xdeadbeef;
 /* TODO: Add support for true FI_DELIVERY_COMPLETE */
 #define RXR_TX_OP_FLAGS (FI_INJECT | FI_COMPLETION | FI_TRANSMIT_COMPLETE | \
 			 FI_DELIVERY_COMPLETE)
-#define RXR_RX_OP_FLAGS (FI_COMPLETION)
+#define RXR_RX_OP_FLAGS (FI_COMPLETION | FI_MULTI_RECV)
 
 struct fi_tx_attr rxr_tx_attr = {
 	.caps = RXR_TX_CAPS,


### PR DESCRIPTION
The EFA provider is missing op_flag 'FI_MULTI_RECV' in rx_attr, which is
required by fabtest fi_multi_recv, so adding it back.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>