### PR TITLE
core/mr_cache: Store HMEM device in MR entry info

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -52,6 +52,7 @@
 struct ofi_mr_info {
 	struct iovec iov;
 	enum fi_hmem_iface iface;
+	uint64_t device;
 };
 
 

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -310,6 +310,7 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 
 	info.iov = *attr->mr_iov;
 	info.iface = attr->iface;
+	info.device = attr->device.reserved;
 
 	do {
 		pthread_mutex_lock(&mm_lock);


### PR DESCRIPTION
By storing the device in ofi_mr_info, providers can store the device
with the MR when the MR cache allocates a new MR.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>