### PR TITLE
prov/efa: rxr_pkt_wait_handshake() to return -FI_EAGAIN when timeout

### DIFF
--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -439,8 +439,12 @@ ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rxr_pee
 		current = ofi_gettime_us();
 	}
 
-	if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED))
-		return FI_ETIMEDOUT;
+	if (!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED)) {
+		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL,
+			"did not get handshake back in %f second(s). returning -FI_EAGAIN!\n",
+			RXR_HANDSHAKE_WAIT_TIMEOUT*1e-6);
+		return -FI_EAGAIN;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Currently, rxr_pkt_wait_handshake() would post a EAGER RTW, and
wait for 1 second for handshake to arrive. If the handshake packet
did not arrive in time, rxr_pkt_wait_handshake() will return FI_ETIMDOUT

Because receiver can only send a handshake back when the the progress
engine was called. The time for sender to get handshake is arbitrary, and
it is normal that sender did not receive handshake in time.

This patch made a change that if the sender did not receive handshake
in time, rxr_pkt_wait_handshake() would print a warning and return
-FI_EAGAIN. The application will then retry the send later.

Signed-off-by: Wei Zhang <wzam@amazon.com>