### PR TITLE
prov/efa: Fix FI_HMEM backwards compat

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -537,8 +537,13 @@ static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 	info->domain_attr->mr_cnt		= base_attr->max_mr;
 
 #ifdef HAVE_LIBCUDA
-	if (efa_get_gdr_support(ctx->ibv_ctx->device->name) == 1)
+	if (info->ep_attr->type == FI_EP_RDM &&
+	    efa_get_gdr_support(ctx->ibv_ctx->device->name) == 1) {
+		info->caps			|= FI_HMEM;
+		info->tx_attr->caps		|= FI_HMEM;
+		info->rx_attr->caps		|= FI_HMEM;
 		info->domain_attr->mr_mode	|= FI_MR_HMEM;
+	}
 #endif
 
 	EFA_DBG(FI_LOG_DOMAIN, "Domain attribute :\n"

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -220,6 +220,9 @@ static int rxr_copy_attr(const struct fi_info *info, struct fi_info *dup)
 		if (!dup->nic)
 			return -FI_ENOMEM;
 	}
+	if (info->caps & FI_HMEM)
+		dup->caps |= FI_HMEM;
+
 	return 0;
 }
 


### PR DESCRIPTION
Two commits here, one to fix the capability bits internally so that we can look at the values in util_domain and another to fix the actual issue.