### PR TITLE
prov/psm2: Always generate log message for fatal errors

### DIFF
--- a/prov/psm2/src/psmx2_av.c
+++ b/prov/psm2/src/psmx2_av.c
@@ -226,7 +226,8 @@ void psmx2_epid_to_epaddr(struct psmx2_trx_ctxt *trx_ctxt,
 		return;
 	}
 
-	FI_WARN(&psmx2_prov, FI_LOG_AV,
+	/* call fi_log() directly to always generate the output */
+	fi_log(&psmx2_prov, FI_LOG_WARN, FI_LOG_AV, __func__, __LINE__,
 		"psm2_ep_connect retured error %s, remote epid=%lx."
 		"If it is a timeout error, try setting FI_PSM2_CONN_TIMEOUT "
 		"to a larger value (current: %d seconds).\n",


### PR DESCRIPTION
Use fi_log() directly so that the message explaining the fatal error
is always generated. This can save debugging time.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>