### PR TITLE
fabtests: Improve ROCR memset execution time

### DIFF
--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -56,6 +56,10 @@ extern "C" {
 #define OFI_UTIL_PREFIX "ofi_"
 #define OFI_NAME_DELIM ';'
 
+#define ALIGN_MASK(x, mask) (((x) + (mask)) & ~(mask))
+#define ALIGN(x, a) ALIGN_MASK(x, (typeof(x))(a) - 1)
+#define ALIGN_DOWN(x, a) ALIGN((x) - ((a) - 1), (a))
+
 #define OFI_MR_BASIC_MAP (FI_MR_ALLOCATED | FI_MR_PROV_KEY | FI_MR_VIRT_ADDR)
 
 /* exit codes must be 0-255 */


### PR DESCRIPTION
ROCR memset has been updated to use hsa_amd_memory_fill(). Since
hsa_amd_memory_fill() requires 4-byte alignment, any unaligned data
which needs to be memset is done with ROCR memcpy.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>