### PR TITLE
fabtests: Skip HMEM cleanup if not initialized

### DIFF
--- a/fabtests/common/hmem.c
+++ b/fabtests/common/hmem.c
@@ -30,7 +30,10 @@
 #endif
 
 #include <inttypes.h>
+#include <stdbool.h>
 #include "hmem.h"
+
+static bool hmem_initialized = false;
 
 struct ft_hmem_ops {
 	int (*init)(void);
@@ -85,12 +88,26 @@ static struct ft_hmem_ops hmem_ops[] = {
 
 int ft_hmem_init(enum fi_hmem_iface iface)
 {
-	return hmem_ops[iface].init();
+	int ret;
+
+	ret = hmem_ops[iface].init();
+	if (ret == FI_SUCCESS)
+		hmem_initialized = true;
+
+	return ret;
 }
 
 int ft_hmem_cleanup(enum fi_hmem_iface iface)
 {
-	return hmem_ops[iface].cleanup();
+	int ret = FI_SUCCESS;
+
+	if (hmem_initialized) {
+		ret = hmem_ops[iface].cleanup();
+		if (ret == FI_SUCCESS)
+			hmem_initialized = false;
+	}
+
+	return ret;
 }
 
 int ft_hmem_alloc(enum fi_hmem_iface iface, uint64_t device, void **buf,


### PR DESCRIPTION
If ft_hmem_init() failed, various fabtests would still call
ft_hmem_cleanup() as a part of cleanup. This can lead to segfault
issues especially if the HMEM library was dlopened. To prevent this,
only run the HMEM iface specific cleanup routine if ft_hmem_init() was
successful.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>