### PR TITLE
core/net: Mark if addresses support local/remote communication

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -163,6 +163,7 @@ struct ofi_addr_list_entry {
 	size_t			speed;
 	char			net_name[OFI_ADDRSTRLEN];
 	char			ifa_name[OFI_ADDRSTRLEN];
+	uint64_t		comm_caps;
 };
 
 int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,

--- a/src/common.c
+++ b/src/common.c
@@ -1212,10 +1212,11 @@ void ofi_insert_loopback_addr(const struct fi_provider *prov, struct slist *addr
 {
 	struct ofi_addr_list_entry *addr_entry;
 
-	addr_entry = calloc(1, sizeof(struct ofi_addr_list_entry));
+	addr_entry = calloc(1, sizeof(*addr_entry));
 	if (!addr_entry)
 		return;
 
+	addr_entry->comm_caps = FI_LOCAL_COMM;
 	addr_entry->ipaddr.sin.sin_family = AF_INET;
 	addr_entry->ipaddr.sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	ofi_straddr_log(prov, FI_LOG_INFO, FI_LOG_CORE,
@@ -1226,10 +1227,11 @@ void ofi_insert_loopback_addr(const struct fi_provider *prov, struct slist *addr
 	strncpy(addr_entry->ifa_name, "lo", sizeof(addr_entry->ifa_name));
 	slist_insert_tail(&addr_entry->entry, addr_list);
 
-	addr_entry = calloc(1, sizeof(struct ofi_addr_list_entry));
+	addr_entry = calloc(1, sizeof(*addr_entry));
 	if (!addr_entry)
 		return;
 
+	addr_entry->comm_caps = FI_LOCAL_COMM;
 	addr_entry->ipaddr.sin6.sin6_family = AF_INET6;
 	addr_entry->ipaddr.sin6.sin6_addr = in6addr_loopback;
 	ofi_straddr_log(prov, FI_LOG_INFO, FI_LOG_CORE,
@@ -1354,6 +1356,7 @@ void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 		if (!addr_entry)
 			continue;
 
+		addr_entry->comm_caps = FI_LOCAL_COMM | FI_REMOTE_COMM;
 		memcpy(&addr_entry->ipaddr, ifa->ifa_addr,
 			ofi_sizeofaddr(ifa->ifa_addr));
 		strncpy(addr_entry->ifa_name, ifa->ifa_name,
@@ -1418,6 +1421,7 @@ void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 			if (!addr_entry)
 				break;
 
+			addr_entry->comm_caps = FI_LOCAL_COMM | FI_REMOTE_COMM;
 			addr_entry->ipaddr.sin.sin_family = AF_INET;
 			addr_entry->ipaddr.sin.sin_addr.s_addr =
 						iptbl->table[i].dwAddr;


### PR DESCRIPTION
When collecting the list of addresses available in the system, also
record if the address supports local and/or remote communication.

When fi_getinfo is called, a list of fi_info structures is created
based on the provider's base fi_info list.  That list may be expanded
in order to report all addresses that are usable to the app.  For
example, see udpx_getinfo -> ofi_ip_getinfo -> util_getinfo_ifs.

The list of available addresses in the system is created for each
provider through ofi_get_list_of_addr.  When constructing that list,
the loopback addresses are appended to the end of the list.

Currently, regardless of the application request, one fi_info
is created for each address and returned to the user.  This can
result in returnin a loopback address to the app even though it
requests FI_REMOTE_COMM.

Expand the address entry (ofi_addr_list_entry) to record if the
address supports FI_REMOTE_COMM / FI_LOCAL_COMM.  Use that to
verify if the address is usable prior to returning it to the user,
and update the COMM flags as needed.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>