### PR TITLE
util/shm: replace lock with PID setting

### DIFF
--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -190,12 +190,10 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 
 	*smr = mapped_addr;
 	fastlock_init(&(*smr)->lock);
-	fastlock_acquire(&(*smr)->lock);
 
 	(*smr)->map = map;
 	(*smr)->version = SMR_VERSION;
 	(*smr)->flags = SMR_FLAG_ATOMIC | SMR_FLAG_DEBUG;
-	(*smr)->pid = getpid();
 	(*smr)->cma_cap = SMR_CMA_CAP_NA;
 	(*smr)->base_addr = *smr;
 
@@ -220,8 +218,9 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	}
 
 	strncpy((char *) smr_name(*smr), attr->name, total_size - name_offset);
-	fastlock_release(&(*smr)->lock);
 
+	/* Must be set last to signal full initialization to peers */
+	(*smr)->pid = getpid();
 	return 0;
 
 remove:


### PR DESCRIPTION
Acquiring the lock right after initialization
provides no protection. It was originally placed
there to protect peers from accessing the shared
memory region before all resources were initialized.

Use PID instead. ftruncate will set the shared memory
to 0 (including the PID). Move the setting of the PID
last to protect the initialization of resources.

The peer mapping (map_to_region) already checks for
!PID and does not finish mapping until the PID has
been set.

Signed-off-by: aingerson <alexia.ingerson@intel.com>