### PR TITLE
prov/rxd: remove redundant calls to fastlock_tryacquire.

### DIFF
--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -220,12 +220,10 @@ struct rxd_ep {
 
 	struct index_map peers_idm;
 };
-
+/* ensure ep lock is held before this function is called */
 static inline struct rxd_peer *rxd_peer(struct rxd_ep *ep, fi_addr_t rxd_addr)
 {
-	fastlock_tryacquire(&ep->util_ep.lock);
 	return ofi_idm_lookup(&ep->peers_idm, rxd_addr);
-	fastlock_release(&ep->util_ep.lock);
 
 }
 static inline struct rxd_domain *rxd_ep_domain(struct rxd_ep *ep)

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1167,15 +1167,12 @@ int rxd_create_peer(struct rxd_ep *ep, uint64_t rxd_addr)
 	dlist_init(&(peer->rx_list));
 	dlist_init(&(peer->rma_rx_list));
 	dlist_init(&(peer->buf_pkts));
-	
-	fastlock_tryacquire(&ep->util_ep.lock);
+		
 	if (ofi_idm_set(&(ep->peers_idm), rxd_addr, peer) < 0)
 		goto err;
-	fastlock_release(&ep->util_ep.lock);
 	
 	return 0;
 err:	
-	fastlock_release(&ep->util_ep.lock);
 	free(peer);
 	return -FI_ENOMEM;
 }


### PR DESCRIPTION
removed the fastlock_tryacquire for ep lock in the rxd_peer and
rxd_create_peer functions since all code paths calling these functions
already hold the ep lock.

Signed-off-by: Nikhil Nanal <nikhil.nanal@intel.com>