### PR TITLE
prov/verbs: Fix XRC transport shared INI QP locking

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -364,11 +364,15 @@ struct vrb_domain {
 		int			xrcd_fd;
 		struct ibv_xrcd		*xrcd;
 
-		/* The domain maintains a RBTree for mapping an endpoint
-		 * destination addresses to physical XRC INI QP connected
-		 * to that host. The map is protected using the EQ lock
-		 * bound to the domain to avoid the need for additional
-		 * locking. */
+		/* XRC INI QP connections can be shared between endpoint
+		 * within the same domain. The domain maintains an RBTree
+		 * for mapping endpoint destination addresses to the
+		 * physical XRC INI connection to the associated node. The
+		 * map and XRC INI connection object state information are
+		 * protected via the ini_lock. */
+		fastlock_t		ini_lock;
+		ofi_fastlock_acquire_t	lock_acquire;
+		ofi_fastlock_release_t	lock_release;
 		struct ofi_rbmap	*ini_conn_rbmap;
 	} xrc;
 


### PR DESCRIPTION
XRC INI QP connection state is maintained in a RBTree
at the XRC domain. Connections can be shared among
all endpoint created using that domain; the destination
address maps to the shared XRC INI QP connection object.

This commit fixes the XRC INI QP connection object locking
to handle the case where message EP are not all bound to
the same EQ (and hence EQ locking is insufficient).
For example, when there are multiple RxM EP created using
the same RxM/Verbs domain.

This fix is rather course grain and will be subsequently
improved with finer grain locking to improve performance.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>