### PR TITLE
prov/verbs: account for off-by-one credit initialization

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -569,7 +569,7 @@ struct vrb_ep {
 	uint64_t			sq_credits;
 	uint64_t			peer_rq_credits;
 	/* Protected by recv CQ lock */
-	uint64_t			rq_credits_avail;
+	int64_t				rq_credits_avail;
 	uint64_t			threshold;
 
 	union {

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -315,6 +315,12 @@ vrb_alloc_init_ep(struct fi_info *info, struct vrb_domain *domain,
 			return NULL;
 	}
 
+	// When we are enabling flow control, we artificially inject
+	// a credit so that the credit messaging itself is not blocked
+	// by a lack of credits.  To counter this, we will adjust the number
+	// of credit we send the first time by initializing to -1.
+	ep->rq_credits_avail = -1;
+
 	ep->info = fi_dupinfo(info);
 	if (!ep->info)
 		goto err1;


### PR DESCRIPTION
When we are enabling flow control, we artificially inject
a credit so that the credit messaging itself is not blocked
by a lack of credits.  To counter this, we will adjust the number
of credits we send the first time by initializing to -1.