### PR TITLE
prov/sockets: Retry address lookup if not set

### DIFF
--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1325,6 +1325,10 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 	offset = 0;
 	len = sizeof(struct sock_msg_hdr);
 
+	if (pe_entry->addr == FI_ADDR_NOTAVAIL &&
+	    pe_entry->ep_attr->ep_type == FI_EP_RDM && pe_entry->ep_attr->av)
+		pe_entry->addr = pe_entry->conn->av_index;
+
 	if (pe_entry->msg_hdr.op_type == SOCK_OP_TSEND) {
 		if (sock_pe_recv_field(pe_entry, &pe_entry->tag,
 				       SOCK_TAG_SIZE, len))


### PR DESCRIPTION
If several messages are received immediately after a connection has been
established, the AV index for the connection may not be set when new
Rx process entries are initialized.  The result is that those messages may
be associated with the wrong data buffer due to the address being set to
FI_ADDR_UNAVAIL.

To handle this case, see if the pe_entry address has been set when handling
the receive.  This allows the first message to be processed completely, which
can set the av_index.  Other received messages will then have the av_index
set correctly.

This problem has shown up on BSD systems.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>