### PR TITLE
prov/efa: use local read to copy data to gpu memory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ common_srcs =				\
 	src/hmem.c			\
 	src/hmem_rocr.c			\
 	src/hmem_cuda.c			\
+	src/hmem_cuda_gdrcopy.c		\
 	src/hmem_ze.c			\
 	src/common.c			\
 	src/enosys.c			\

--- a/configure.ac
+++ b/configure.ac
@@ -569,6 +569,41 @@ LDFLAGS="$LDFLAGS $cuda_LDFLAGS"
 
 AS_IF([test x"$enable_cuda_dlopen" != x"yes"], [LIBS="$LIBS $cuda_LIBS"])
 
+#gdrcopy related configs
+AC_ARG_WITH([gdrcopy],
+	    [AC_HELP_STRING([--with-gdrcopy=DIR],
+			    [Provide path to where the gdrcopy development
+			    and runtime libraries are installed.])],
+	    [], [])
+
+FI_CHECK_PACKAGE([gdrcopy],
+		 [gdrapi.h],
+		 [gdrapi],
+		 [gdr_open],
+		 [-lgdrapi],
+		 [$with_gdrcopy],
+		 [],
+		 [AC_DEFINE([HAVE_GDRCOPY], [1],[gdrcopy support])],
+		 [], [])
+
+AC_ARG_ENABLE([gdrcopy-dlopen],
+    [AS_HELP_STRING([--enable-gdrcopy-dlopen],
+        [Enable dlopen of gdrcopy libraries @<:@default=no@:>@])
+    ],
+    [
+        AS_IF([test "$freebsd" == "0"], [
+            AC_CHECK_LIB(dl, dlopen, [],
+                [AC_MSG_ERROR([dlopen not found.  libfabric requires libdl.])])
+        ])
+        AC_DEFINE([ENABLE_GDRCOPY_DLOPEN], [1], [dlopen CUDA libraries])
+    ],
+    [enable_gdrcopy_dlopen=no])
+
+CPPFLAGS="$CPPFLAGS $gdrcopy_CPPFLAGS"
+LDFLAGS="$LDFLAGS $gdrcopy_LDFLAGS"
+AS_IF([test x"$enable_gdrcopy_dlopen" != x"yes"], [LIBS="$LIBS $gdrcopy_LIBS"])
+#end gdrcopy configures
+
 dnl Check for ROCR runtime libraries.
 AC_ARG_WITH([rocr],
 	    [AC_HELP_STRING([--with-rocr=DIR],

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -81,6 +81,22 @@ hsa_status_t ofi_hsa_amd_reg_dealloc_cb(void *ptr,
 
 #endif /* HAVE_ROCR */
 
+#ifdef HAVE_GDRCOPY
+#include <gdrapi.h>
+
+struct ofi_gdrcopy_handle {
+	gdr_mh_t mh; /* memory handler */
+	void *cuda_ptr; /* page aligned gpu pointer */
+	void *user_ptr; /* user space ptr mapped to GPU memory */
+	size_t length; /* page aligned length */
+};
+
+gdr_t ofi_gdrcopy_open();
+int ofi_gdrcopy_close(gdr_t gdr);
+ssize_t ofi_gdrcopy_reg(void *addr, size_t len, gdr_t gdr, struct ofi_gdrcopy_handle *gdrcopy);
+ssize_t ofi_gdrcopy_dereg(gdr_t gdr, struct ofi_gdrcopy_handle *gdrcopy);
+#endif
+
 int rocr_memcpy(uint64_t device, void *dest, const void *src, size_t size);
 int rocr_hmem_init(void);
 int rocr_hmem_cleanup(void);
@@ -99,6 +115,11 @@ bool ze_is_addr_valid(const void *addr);
 int ze_hmem_get_handle(void *dev_buf, void **handle);
 int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr);
 int ze_hmem_close_handle(void *ipc_ptr);
+
+int cuda_gdrcopy_to_dev(uint64_t device, void *dev, const void *host, size_t size);
+int cuda_gdrcopy_from_dev(uint64_t device, void *host, const void *dev, size_t size);
+int cuda_gdrcopy_hmem_init(void);
+int cuda_gdrcopy_hmem_cleanup(void);
 
 static inline int ofi_memcpy(uint64_t device, void *dest, const void *src,
 			     size_t size)

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -154,6 +154,9 @@ struct efa_domain {
 	struct ofi_mr_cache	cache;
 	struct efa_qp		**qp_table;
 	size_t			qp_table_sz_m1;
+#ifdef HAVE_GDRCOPY
+	gdr_t			gdr;
+#endif
 };
 
 extern struct fi_ops_mr efa_domain_mr_ops;
@@ -223,6 +226,9 @@ struct efa_mr_peer {
 		uint64_t        reserved;
 		int             cuda;
 	} device;
+#ifdef HAVE_GDRCOPY
+	struct ofi_gdrcopy_handle gdrcopy;
+#endif
 };
 
 struct efa_mr {

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -53,10 +53,11 @@ static int efa_domain_close(fid_t fid)
 		ofi_mr_cache_cleanup(&domain->cache);
 
 #ifdef HAVE_GDRCOPY
-	assert(domain->gdr);
-	ret = ofi_gdrcopy_close(domain->gdr);
-	if (ret) {
-		EFA_WARN(FI_LOG_DOMAIN, "gdr_close failed!\n");
+	if (domain->gdr) {
+		ret = ofi_gdrcopy_close(domain->gdr);
+		if (ret) {
+			EFA_WARN(FI_LOG_DOMAIN, "gdrcopy_close failed!\n");
+		}
 	}
 #endif
 
@@ -241,9 +242,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 #ifdef HAVE_GDRCOPY
 	domain->gdr = ofi_gdrcopy_open();
 	if (!domain->gdr) {
-		EFA_WARN(FI_LOG_DOMAIN, "gdr_open failed!\n");
-		ret = -FI_ENOMEM;
-		goto err_free_info;
+		EFA_WARN(FI_LOG_DOMAIN, "gdrcopy_open failed! The EFA provider will use local read as fallback\n");
 	}
 #endif
 

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -215,6 +215,7 @@ struct rxr_env {
 	size_t efa_min_read_msg_size;
 	size_t efa_min_read_write_size;
 	size_t efa_read_segment_size;
+	size_t efa_max_gdrcopy_size;
 };
 
 enum rxr_lower_ep_type {
@@ -520,6 +521,9 @@ struct rxr_ep {
 	/* core provider fid */
 	struct fid_ep *rdm_ep;
 	struct fid_cq *rdm_cq;
+
+	/* address of myself in my AV, used to post read to my self */
+	fi_addr_t rdm_self_addr;
 
 	/* shm provider fid */
 	bool use_shm;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1651,7 +1651,6 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	rxr_ep = calloc(1, sizeof(*rxr_ep));
 	if (!rxr_ep)
 		return -FI_ENOMEM;
-
 	rxr_domain = container_of(domain, struct rxr_domain,
 				  util_domain.domain_fid);
 	memset(&cq_attr, 0, sizeof(cq_attr));
@@ -1675,6 +1674,8 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  &rxr_ep->rdm_ep, rxr_ep);
 	if (ret)
 		goto err_free_rdm_info;
+
+	rxr_ep->rdm_self_addr = FI_ADDR_NOTAVAIL;
 
 	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
 				  util_domain.domain_fid);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1151,18 +1151,16 @@ int rxr_ep_init(struct rxr_ep *ep)
 		goto err_free_tx_pool;
 
 	if (rxr_env.rx_copy_unexp) {
-		ret = ofi_bufpool_create(&ep->rx_unexp_pkt_pool, entry_sz,
-					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_get_rx_pool_chunk_cnt(ep), 0);
+		ret = rxr_create_pkt_pool(ep, entry_sz, rxr_get_rx_pool_chunk_cnt(ep),
+					  &ep->rx_unexp_pkt_pool);
 
 		if (ret)
 			goto err_free_rx_pool;
 	}
 
 	if (rxr_env.rx_copy_ooo) {
-		ret = ofi_bufpool_create(&ep->rx_ooo_pkt_pool, entry_sz,
-					 RXR_BUF_POOL_ALIGNMENT, 0,
-					 rxr_env.recvwin_size, 0);
+		ret = rxr_create_pkt_pool(ep, entry_sz, rxr_get_rx_pool_chunk_cnt(ep),
+					  &ep->rx_ooo_pkt_pool);
 
 		if (ret)
 			goto err_free_rx_unexp_pool;

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -73,6 +73,7 @@ struct rxr_env rxr_env = {
 	.efa_min_read_msg_size = 1048576,
 	.efa_min_read_write_size = 65536,
 	.efa_read_segment_size = 1073741824,
+	.efa_max_gdrcopy_size = 8192,
 };
 
 static void rxr_init_env(void)
@@ -122,6 +123,8 @@ static void rxr_init_env(void)
 			    &rxr_env.efa_min_read_write_size);
 	fi_param_get_size_t(&rxr_prov, "inter_read_segment_size",
 			    &rxr_env.efa_read_segment_size);
+	fi_param_get_size_t(&rxr_prov, "inter_max_gdrcopy_size",
+			    &rxr_env.efa_max_gdrcopy_size);
 }
 
 /*
@@ -768,6 +771,8 @@ EFA_INI
 			"The mimimum message size for inter EFA write to use read write protocol. If firmware support RDMA read, and FI_EFA_USE_DEVICE_RDMA is 1, write requests whose size is larger than this value will use the read write protocol (Default 65536).");
 	fi_param_define(&rxr_prov, "inter_read_segment_size", FI_PARAM_INT,
 			"Calls to RDMA read is segmented using this value.");
+	fi_param_define(&rxr_prov, "inter_max_gdrcopy_size", FI_PARAM_INT,
+			"The maximum size to use gdrcopy to copy data from bounce buffer to target GPU memory (Default 8192)");
 	rxr_init_env();
 
 #if HAVE_EFA_DL

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -38,6 +38,12 @@
 
 ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry);
 
+ssize_t rxr_pkt_post_read_to_copy_data(struct rxr_ep *rxr_ep,
+				       struct rxr_pkt_entry *pkt_entry,
+				       char *data, size_t data_size,
+				       struct rxr_rx_entry *rx_entry,
+				       size_t data_offset);
+
 ssize_t rxr_pkt_post_ctrl(struct rxr_ep *ep, int entry_type, void *x_entry,
 			  int ctrl_type, bool inject);
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -201,16 +201,20 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
 			int new_entry_type)
 {
 	FI_DBG(&rxr_prov, FI_LOG_EP_CTRL,
-	       "Copying packet out of posted buffer\n");
+	       "Copying packet out of posted buffer! new_entry_type: %d\n",
+		new_entry_type);
 	assert(src->type == RXR_PKT_ENTRY_POSTED);
-	memcpy(dest, src, sizeof(struct rxr_pkt_entry));
-	memcpy(dest->pkt, src->pkt, ep->mtu_size);
 	dlist_init(&dest->entry);
 #if ENABLE_DEBUG
 	dlist_init(&dest->dbg_entry);
 #endif
-	dest->state = RXR_PKT_ENTRY_IN_USE;
+	dest->x_entry = src->x_entry;
+	dest->pkt_size = src->pkt_size;
+	dest->addr = src->addr;
 	dest->type = new_entry_type;
+	dest->state = RXR_PKT_ENTRY_IN_USE;
+	dest->next = NULL;
+	memcpy(dest->pkt, src->pkt, ep->mtu_size);
 }
 
 /*

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -154,10 +154,14 @@ void rxr_pkt_entry_release_tx(struct rxr_ep *ep,
 	}
 }
 
-static
-void rxr_pkt_entry_release_single_rx(struct rxr_ep *ep,
-				     struct rxr_pkt_entry *pkt_entry)
+void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
+			      struct rxr_pkt_entry *pkt_entry)
 {
+	assert(pkt_entry->next == NULL);
+
+	if (ep->use_zcpy_rx && pkt_entry->type == RXR_PKT_ENTRY_USER)
+		return;
+
 	if (pkt_entry->type == RXR_PKT_ENTRY_POSTED) {
 		struct rxr_peer *peer;
 
@@ -179,22 +183,6 @@ void rxr_pkt_entry_release_single_rx(struct rxr_ep *ep,
 	ofi_buf_free(pkt_entry);
 }
 
-void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
-			      struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_pkt_entry *next;
-
-	if (ep->use_zcpy_rx && pkt_entry->type == RXR_PKT_ENTRY_USER)
-		return;
-
-	while (pkt_entry) {
-		next = pkt_entry->next;
-		rxr_pkt_entry_release_single_rx(ep, pkt_entry);
-		pkt_entry = next;
-	}
-}
-
-static
 void rxr_pkt_entry_copy(struct rxr_ep *ep,
 			struct rxr_pkt_entry *dest,
 			struct rxr_pkt_entry *src,

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -41,6 +41,8 @@ enum rxr_pkt_entry_state {
 	RXR_PKT_ENTRY_FREE = 0,
 	RXR_PKT_ENTRY_IN_USE,
 	RXR_PKT_ENTRY_RNR_RETRANSMIT,
+	RXR_PKT_ENTRY_COPY_BY_READ, /* the pkt entry contains data. A RDMA read has been issued to copy 
+				       data to GPU receivingbuffer */
 };
 
 /* pkt_entry types for rx pkts */
@@ -129,6 +131,11 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 
 void rxr_pkt_entry_append(struct rxr_pkt_entry *dst,
 			  struct rxr_pkt_entry *src);
+
+void rxr_pkt_entry_copy(struct rxr_ep *ep,
+			struct rxr_pkt_entry *dest,
+			struct rxr_pkt_entry *src,
+			int new_entry_type);
 
 struct rxr_pkt_entry *rxr_pkt_entry_clone(struct rxr_ep *ep,
 					  struct ofi_bufpool *pkt_pool,

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -234,15 +234,17 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 			       struct rxr_tx_entry *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry);
 
-int rxr_pkt_proc_data(struct rxr_ep *ep,
-		      struct rxr_rx_entry *rx_entry,
-		      struct rxr_pkt_entry *pkt_entry,
-		      char *data, size_t seg_offset,
-		      size_t seg_size);
+void rxr_pkt_proc_data(struct rxr_ep *ep,
+		       struct rxr_rx_entry *rx_entry,
+		       struct rxr_pkt_entry *pkt_entry,
+		       char *data, size_t seg_offset,
+		       size_t seg_size);
 
 void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 					 struct rxr_pkt_entry *pkt_entry);
 
+void rxr_data_pkt_handle_data_copied(struct rxr_ep *ep,
+				     struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);
@@ -399,6 +401,10 @@ void rxr_pkt_handle_atomrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 void rxr_pkt_handle_atomrsp_send_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_atomrsp_recv(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+struct efa_mr;
+
+bool rxr_pkt_use_read_copy(struct efa_mr *recv_mr, size_t data_size);
 
 #endif
 

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -242,41 +242,20 @@ void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 /*
  *  rxr_pkt_handle_data_recv() and related functions
  */
-int rxr_pkt_proc_data(struct rxr_ep *ep,
-		      struct rxr_rx_entry *rx_entry,
-		      struct rxr_pkt_entry *pkt_entry,
-		      char *data, size_t seg_offset,
-		      size_t seg_size)
+void rxr_data_pkt_handle_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 {
+	struct rxr_rx_entry *rx_entry;
 	struct rxr_peer *peer;
-	struct efa_mr *desc;
-	int64_t bytes_left, bytes_copied;
-	ssize_t ret = 0;
+	ssize_t err, seg_size, bytes_left;
+	int pkt_type;
 
-#if ENABLE_DEBUG
-	int pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
+	assert(rx_entry);
 
+	pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
 	assert(pkt_type == RXR_DATA_PKT || pkt_type == RXR_READRSP_PKT);
-#endif
-	/* we are sinking message for CANCEL/DISCARD entry */
-	if (OFI_LIKELY(!(rx_entry->rxr_flags & RXR_RECV_CANCEL)) &&
-	    rx_entry->cq_entry.len > seg_offset) {
-		desc = rx_entry->desc[0];
-		bytes_copied = ofi_copy_to_hmem_iov(desc ? desc->peer.iface : FI_HMEM_SYSTEM,
-						    desc ? desc->peer.device.reserved : 0,
-						    rx_entry->iov,
-						    rx_entry->iov_count,
-						    seg_offset,
-						    data,
-						    seg_size);
-
-		if (bytes_copied != MIN(seg_size, rx_entry->cq_entry.len - seg_offset)) {
-			FI_WARN(&rxr_prov, FI_LOG_CQ, "wrong size! bytes_copied: %ld\n",
-				bytes_copied);
-			if (rxr_cq_handle_rx_error(ep, rx_entry, -FI_EINVAL))
-				assert(0 && "error writing error cq entry for EOR\n");
-		}
-	}
+	seg_size = (pkt_type == RXR_DATA_PKT) ? rxr_get_data_pkt(pkt_entry->pkt)->hdr.seg_size
+					      : rxr_get_readrsp_hdr(pkt_entry->pkt)->seg_size;
 
 	rx_entry->bytes_done += seg_size;
 
@@ -304,16 +283,75 @@ int rxr_pkt_proc_data(struct rxr_ep *ep,
 
 		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 		rxr_release_rx_entry(ep, rx_entry);
-		return 0;
+		return;
 	}
 
 	if (!rx_entry->window) {
 		assert(rx_entry->state == RXR_RX_RECV);
-		ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
+		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
+		if (OFI_UNLIKELY(err)) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ, "Cannot post CTS packet\n");
+			rxr_cq_handle_rx_error(ep, rx_entry, err);
+			rxr_release_rx_entry(ep, rx_entry);
+		}
 	}
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
-	return ret;
+}
+
+void rxr_pkt_proc_data(struct rxr_ep *ep,
+		       struct rxr_rx_entry *rx_entry,
+		       struct rxr_pkt_entry *pkt_entry,
+		       char *data, size_t seg_offset,
+		       size_t seg_size)
+{
+#if ENABLE_DEBUG
+	int pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+
+	assert(pkt_type == RXR_DATA_PKT || pkt_type == RXR_READRSP_PKT);
+#endif
+	ssize_t err;
+	size_t bytes_copied;
+	struct efa_mr *desc;
+	struct rxr_data_pkt *data_pkt;
+
+	pkt_entry->x_entry = rx_entry;
+
+	data_pkt = (struct rxr_data_pkt *)pkt_entry->pkt;
+	seg_size = data_pkt->hdr.seg_size;
+	seg_offset = data_pkt->hdr.seg_offset;
+
+	/*
+	 * we are sinking message for CANCEL/DISCARD entry,
+	 */
+	if (OFI_UNLIKELY(rx_entry->rxr_flags & RXR_RECV_CANCEL) ||
+	    seg_offset >= rx_entry->cq_entry.len) {
+		rxr_data_pkt_handle_data_copied(ep, pkt_entry);
+		return;
+	}
+
+	desc = rx_entry->desc[0];
+	if (rxr_pkt_use_read_copy(desc, seg_size)) {
+		err = rxr_pkt_post_read_to_copy_data(ep, pkt_entry, data, seg_size, rx_entry, seg_offset);
+		if (OFI_UNLIKELY(err)) {
+			if (rxr_cq_handle_rx_error(ep, rx_entry, -FI_EINVAL))
+				assert(0 && "error writing error cq entry\n");
+		}
+	} else {
+		bytes_copied = ofi_copy_to_hmem_iov(desc ? desc->peer.iface : FI_HMEM_SYSTEM,
+						    desc ? desc->peer.device.reserved : 0,
+						    rx_entry->iov, rx_entry->iov_count, seg_offset,
+						    data, seg_size);
+		if (bytes_copied != MIN(seg_size, rx_entry->cq_entry.len - seg_offset)) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ, "wrong size! bytes_copied: %ld\n",
+				bytes_copied);
+			if (rxr_cq_handle_rx_error(ep, rx_entry, -FI_EINVAL))
+				assert(0 && "error writing error cq entry\n");
+			return;
+		}
+
+		rxr_data_pkt_handle_data_copied(ep, pkt_entry);
+	}
 }
 
 void rxr_pkt_handle_data_recv(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -339,6 +339,15 @@ void rxr_pkt_rtm_init_rx_entry(struct rxr_pkt_entry *pkt_entry,
  *            rxr_pkt_handle_rtm_recv() and
  *            rxr_msg_handle_unexp_match()
  */
+void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep,
+					  struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_medium_rtm_data_copied(struct rxr_ep *ep,
+					   struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_long_rtm_data_copied(struct rxr_ep *ep,
+					 struct rxr_pkt_entry *pkt_entry);
+
 ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 				 struct rxr_rx_entry *rx_entry,
 				 struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -44,6 +44,9 @@ enum rxr_read_entry_state {
 	RXR_RDMA_ENTRY_PENDING
 };
 
+int rxr_locate_iov_pos(struct iovec *iov, int iov_count, size_t offset,
+		       int *iov_idx, size_t *iov_offset);
+
 /* rxr_read_entry was arranged as a packet
  * and was put in a rxr_pkt_entry. Because rxr_pkt_entry is used
  * as context.

--- a/src/hmem_cuda_gdrcopy.c
+++ b/src/hmem_cuda_gdrcopy.c
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2020 Amazon.com, Inc. or its affiliates.
+ * All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#if HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include "ofi_hmem.h"
+#include "ofi.h"
+
+#ifdef HAVE_GDRCOPY
+
+#include <gdrapi.h>
+
+struct gdrcopy_ops {
+
+	gdr_t (*gdr_open)();
+
+	int (*gdr_close)(gdr_t g);
+
+	int (*gdr_pin_buffer)(gdr_t g, unsigned long addr, size_t size,
+			      uint64_t p2p_token, uint32_t va_space,
+			      gdr_mh_t *handle);
+
+	int (*gdr_unpin_buffer)(gdr_t g, gdr_mh_t handle);
+
+	int (*gdr_map)(gdr_t g, gdr_mh_t handle, void **va, size_t size);
+
+	int (*gdr_unmap)(gdr_t g, gdr_mh_t handle, void *va, size_t size);
+
+	int (*gdr_copy_to_mapping)(gdr_mh_t handle, void *map_d_ptr,
+				   const void *h_ptr, size_t size);
+
+	int (*gdr_copy_from_mapping)(gdr_mh_t handle, void *map_d_ptr,
+				     const void *h_ptr, size_t size);
+};
+
+#ifdef ENABLE_GDRCOPY_DLOPEN
+
+#include <dlfcn.h>
+
+static void *gdrapi_handle;
+static struct gdrcopy_ops gdrcopy_ops;
+
+#else
+
+static struct gdrcopy_ops gdrcopy_ops = {
+	.gdr_open = gdr_open,
+	.gdr_close = gdr_close,
+	.gdr_pin_buffer = gdr_pin_buffer,
+	.gdr_unpin_buffer = gdr_unpin_buffer,
+	.gdr_map = gdr_map,
+	.gdr_unmap = gdr_unmap,
+	.gdr_copy_to_mapping = gdr_copy_to_mapping,
+	.gdr_copy_from_mapping = gdr_copy_from_mapping
+};
+
+#endif /* ENABLE_CUDA_DLOPEN */
+
+gdr_t ofi_gdrcopy_open()
+{
+	if (!gdrcopy_ops.gdr_open)
+		return NULL;
+
+	return gdrcopy_ops.gdr_open();
+}
+
+int ofi_gdrcopy_close(gdr_t gdr)
+{
+	if (!gdrcopy_ops.gdr_close)
+		return -FI_ENOSYS;
+
+	return gdrcopy_ops.gdr_close(gdr);
+}
+
+ssize_t ofi_gdrcopy_reg(void *addr, size_t len, gdr_t gdr, struct ofi_gdrcopy_handle *gdrcopy)
+{
+	ssize_t err;
+	uintptr_t regbgn = (uintptr_t)addr;
+	uintptr_t regend = (uintptr_t)addr + len;
+	size_t reglen;
+
+	assert(gdr);
+	assert(gdrcopy_ops.gdr_pin_buffer);
+	assert(gdrcopy_ops.gdr_map);
+
+	regbgn = regbgn & GPU_PAGE_MASK;
+	regend = (regend & GPU_PAGE_MASK) + GPU_PAGE_SIZE;
+	reglen = regend - regbgn;
+
+	assert(gdr);
+	err = gdrcopy_ops.gdr_pin_buffer(gdr, regbgn,
+					 reglen, 0, 0, &gdrcopy->mh);
+	if (err) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "gdr_pin_buffer failed! error: %s",
+			strerror(err));
+		return err;
+	}
+
+	gdrcopy->cuda_ptr = (void *)regbgn;
+	gdrcopy->length = reglen;
+
+	err = gdrcopy_ops.gdr_map(gdr, gdrcopy->mh, &gdrcopy->user_ptr, gdrcopy->length);
+	if (err) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "gdr_map failed! error: %s\n",
+			strerror(err));
+		gdrcopy_ops.gdr_unpin_buffer(gdr, gdrcopy->mh);
+		return err;
+	}
+
+	return 0;
+}
+
+ssize_t ofi_gdrcopy_dereg(gdr_t gdr, struct ofi_gdrcopy_handle *gdrcopy)
+{
+	ssize_t err;
+
+	assert(gdr);
+	assert(gdrcopy);
+	assert(gdrcopy_ops.gdr_unmap);
+	assert(gdrcopy_ops.gdr_unpin_buffer);
+	err = gdrcopy_ops.gdr_unmap(gdr, gdrcopy->mh, gdrcopy->user_ptr, gdrcopy->length);
+	if (err) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "gdr_unmap failed! error: %s\n",
+			strerror(err));
+		return err;
+	}
+
+	err = gdrcopy_ops.gdr_unpin_buffer(gdr, gdrcopy->mh);
+	if (err) {
+		FI_WARN(&core_prov, FI_LOG_MR, "gdr_unmap failed! error: %s\n",
+			strerror(err));
+		return err;
+	}
+
+	return 0;
+}
+
+/*
+ * The following 4 functions
+ *
+ *     cuda_gdrcopy_hmem_init()
+ *     cuda_gdrcopy_hmem_cleanup()
+ *     cuda_gdrcopy_to_dev()
+ *     cuda_gdrcopy_from_dev()
+ *
+ * are called by the corresponding cuda_hmem functions.
+ */
+
+int cuda_gdrcopy_hmem_init(void)
+{
+#ifdef ENABLE_GDRCOPY_DLOPEN
+	gdrapi_handle = dlopen("libgdrapi.so", RTLD_NOW);
+	if (!gdrapi_handle) {
+		FI_INFO(&core_prov, FI_LOG_CORE,
+			"Failed to dlopen libgdrapi.so\n");
+		return -FI_ENOSYS;
+	}
+
+	gdrcopy_ops.gdr_open = dlsym(gdrapi_handle, "gdr_open");
+	if (!gdrcopy_ops.gdr_open) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find gdr_open\n");
+		goto err_dlclose_gdrapi;
+	}
+
+	gdrcopy_ops.gdr_close = dlsym(gdrapi_handle, "gdr_close");
+	if (!gdrcopy_ops.gdr_close) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find gdr_close\n");
+		goto err_dlclose_gdrapi;
+	}
+
+	gdrcopy_ops.gdr_pin_buffer = dlsym(gdrapi_handle, "gdr_pin_buffer");
+	if (!gdrcopy_ops.gdr_pin_buffer) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find gdr_pin_buffer\n");
+		goto err_dlclose_gdrapi;
+	}
+
+	gdrcopy_ops.gdr_unpin_buffer = dlsym(gdrapi_handle, "gdr_unpin_buffer");
+	if (!gdrcopy_ops.gdr_unpin_buffer) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find gdr_unpin_buffer\n");
+		goto err_dlclose_gdrapi;
+	}
+
+	gdrcopy_ops.gdr_map = dlsym(gdrapi_handle, "gdr_map");
+	if (!gdrcopy_ops.gdr_map) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find gdr_map\n");
+		goto err_dlclose_gdrapi;
+	}
+
+	gdrcopy_ops.gdr_unmap = dlsym(gdrapi_handle, "gdr_unmap");
+	if (!gdrcopy_ops.gdr_unmap) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find gdr_unmap\n");
+		goto err_dlclose_gdrapi;
+	}
+
+	gdrcopy_ops.gdr_copy_to_mapping = dlsym(gdrapi_handle, "gdr_copy_to_mapping");
+	if (!gdrcopy_ops.gdr_copy_to_mapping) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find gdr_copy_to_mapping\n");
+		goto err_dlclose_gdrapi;
+	}
+
+	gdrcopy_ops.gdr_copy_from_mapping = dlsym(gdrapi_handle, "gdr_copy_from_mapping");
+	if (!gdrcopy_ops.gdr_copy_from_mapping) {
+		FI_WARN(&core_prov, FI_LOG_CORE, "Failed to find gdr_copy_from_mapping\n");
+		goto err_dlclose_gdrapi;
+	}
+
+	return FI_SUCCESS;
+
+err_dlclose_gdrapi:
+	memset(&gdrcopy_ops, 0, sizeof(gdrcopy_ops));
+	dlclose(gdrapi_handle);
+	return -FI_ENODATA;
+#else /* ENABLE_GDRCOPY_DLOPEN */
+	return FI_SUCCESS;
+#endif /* ENABLE_GDRCOPY_DLOPEN */
+}
+
+int cuda_gdrcopy_hmem_cleanup(void)
+{
+#ifdef ENABLE_GDRCOPY_DLOPEN
+	dlclose(gdrapi_handle);
+#endif
+	return FI_SUCCESS;
+}
+
+int cuda_gdrcopy_to_dev(uint64_t devhandle, void *devptr, const void *hostptr, size_t len)
+{
+	ssize_t off;
+	struct ofi_gdrcopy_handle *gdrcopy;
+	void *gdrcopy_user_ptr;
+
+	if (!gdrcopy_ops.gdr_copy_to_mapping)
+		return -FI_ENOSYS;
+
+	gdrcopy = (struct ofi_gdrcopy_handle *)devhandle;
+	off = (char *)devptr - (char *)gdrcopy->cuda_ptr;
+	assert(off >= 0 && off + len <= gdrcopy->length);
+	gdrcopy_user_ptr = (char *)gdrcopy->user_ptr + off;
+	gdrcopy_ops.gdr_copy_to_mapping(gdrcopy->mh, gdrcopy_user_ptr, hostptr, len);
+	return 0;
+}
+
+int cuda_gdrcopy_from_dev(uint64_t devhandle, void *hostptr, const void *devptr, size_t len)
+{
+	ssize_t off;
+	struct ofi_gdrcopy_handle *gdrcopy;
+	void *gdrcopy_user_ptr;
+
+	if (!gdrcopy_ops.gdr_copy_from_mapping)
+		return -FI_ENOSYS;
+
+	gdrcopy = (struct ofi_gdrcopy_handle *)devhandle;
+
+	off = (char *)devptr - (char *)gdrcopy->cuda_ptr;
+	assert(off >= 0 && off + len <= gdrcopy->length);
+	gdrcopy_user_ptr = (char *)gdrcopy->user_ptr + off;
+	gdrcopy_ops.gdr_copy_from_mapping(gdrcopy->mh, gdrcopy_user_ptr, hostptr, len);
+	return 0;
+}
+
+#endif /* HAVE_GDRCOPY */


### PR DESCRIPTION
This PR contain 3 patches that implement local read as the fallback solution to copy data to gpu memory.