### PR TITLE
fabtests, prov/shm: fabtests and shm provider fixes to support very large transfers

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -427,7 +427,6 @@ static int ft_alloc_ctx_array(struct ft_context **mr_array, char ***mr_bufs,
 			context->desc = mr_desc;
 			continue;
 		}
-		(*mr_bufs)[i] = calloc(1, mr_size);
 		ret = ft_hmem_alloc(opts.iface, opts.device,
 				    (void **) &((*mr_bufs)[i]), mr_size);
 		if (ret)

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2971,7 +2971,7 @@ void ft_parsecsopts(int op, char *optarg, struct ft_opts *opts)
 			opts->sizes_enabled = FT_ENABLE_ALL;
 		} else {
 			opts->options |= FT_OPT_SIZE;
-			opts->transfer_size = atoi(optarg);
+			opts->transfer_size = atol(optarg);
 		}
 		break;
 	case 'm':

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -55,7 +55,7 @@ static inline int ft_host_cleanup()
 static inline int ft_host_alloc(uint64_t device, void **buffer, size_t size)
 {
 	*buffer = malloc(size);
-	return !buffer ? -FI_ENOMEM : FI_SUCCESS;
+	return !*buffer ? -FI_ENOMEM : FI_SUCCESS;
 }
 
 static inline int ft_host_free(void *buf)


### PR DESCRIPTION
Fabtests:
- remove extra allocation
- check host allocation properly
- parse size option correctly

Shm:
- Loop CMA calls for large transfers to avoid CMA copy limit