### PR TITLE
prov/verbs: Fix disablement of RQ flow control

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -574,7 +574,7 @@ struct vrb_ep {
 	uint64_t			peer_rq_credits;
 	/* Protected by recv CQ lock */
 	int64_t				rq_credits_avail;
-	uint64_t			threshold;
+	int64_t				threshold;
 
 	union {
 		struct rdma_cm_id	*id;

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1023,7 +1023,7 @@ int vrb_open_ep(struct fid_domain *domain, struct fi_info *info,
 
 	ep->inject_limit = ep->info->tx_attr->inject_size;
 	ep->peer_rq_credits = UINT64_MAX;
-	ep->threshold = UINT64_MAX; /* disables RQ flow control */
+	ep->threshold = INT64_MAX; /* disables RQ flow control */
 
 	switch (info->ep_attr->type) {
 	case FI_EP_MSG:


### PR DESCRIPTION
I was seeing an osu_bw segfault that appeared with commit 220af33. I modified to avoid making an int64_t (-1) and uint64_t (UINT64_MAX) comparison it introduced. When flow control is not enabled when using SRQ, vrb_post_send() could still send credits due to this comparison.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>