### PR TITLE
Fix warnings generated in the include file

### DIFF
--- a/include/ofi_bitmask.h
+++ b/include/ofi_bitmask.h
@@ -90,7 +90,7 @@ static inline void ofi_bitmask_set_all(struct bitmask *mask)
 
 static inline size_t ofi_bitmask_get_lsbset(struct bitmask mask)
 {
-	int cur;
+	size_t cur;
 	uint8_t tmp;
 	size_t ret = 0;
 

--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -162,7 +162,7 @@ static inline void ofi_fastlock_acquire_noop(fastlock_t *lock)
 	assert(!lock->in_use);
 	lock->in_use = 1;
 #else
-    (void)lock;
+	(void) lock;
 #endif
 }
 static inline void ofi_fastlock_release_noop(fastlock_t *lock)
@@ -171,7 +171,7 @@ static inline void ofi_fastlock_release_noop(fastlock_t *lock)
 	assert(lock->in_use);
 	lock->in_use = 0;
 #else
-    (void)lock;
+	(void) lock;
 #endif
 }
 

--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -161,6 +161,8 @@ static inline void ofi_fastlock_acquire_noop(fastlock_t *lock)
 	/* These non-op routines must be used only by a single-threaded code*/
 	assert(!lock->in_use);
 	lock->in_use = 1;
+#else
+    (void)lock;
 #endif
 }
 static inline void ofi_fastlock_release_noop(fastlock_t *lock)
@@ -168,6 +170,8 @@ static inline void ofi_fastlock_release_noop(fastlock_t *lock)
 #if ENABLE_DEBUG
 	assert(lock->in_use);
 	lock->in_use = 0;
+#else
+    (void)lock;
 #endif
 }
 


### PR DESCRIPTION
Small changes to eliminate warnings that are generated under certain versions of gcc.

Changing cur to a size_t avoids a compare mismatch with mask.size

Adding (void)lock to avoid generating warnings about unused parameters when ENABLE_DEBUG is not set.