### PR TITLE
contrib/cray: Fix variable spelling error

### DIFF
--- a/contrib/cray/Jenkinsfile.verbs
+++ b/contrib/cray/Jenkinsfile.verbs
@@ -457,9 +457,9 @@ pipeline {
             steps {
                 script {
                     if ( isInternalBuild &&
-                        (( evn.BRANCH_NAME == 'master' ) || buildingTag())) {
+                        (( env.BRANCH_NAME == 'master' ) || buildingTag())) {
                         BUILD_LIBFABRIC = true
-                    } else if ( isOfiwgBuild() && ( evn.BRANCH_NAME == 'master' )) {
+                    } else if ( isOfiwgBuild() && ( env.BRANCH_NAME == 'master' )) {
                         LIBFABRIC_INSTALL_PATH="${LIBFABRIC_BUILD_PATH + '/' + 'OFIWG_' + GIT_DESCRIPTION}"
                         BUILD_LIBFABRIC = true
                     }


### PR DESCRIPTION
In Jenkinsfile.verbs, evn should be env.

Signed-off-by: Ian Ziemba <ian.ziemba@hpe.com>