### PR TITLE
fabtests/common: fix large transfer data validation

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3036,12 +3036,12 @@ int ft_parse_rma_opts(int op, char *optarg, struct fi_info *hints,
 	return 0;
 }
 
-void ft_fill_buf(void *buf, int size)
+void ft_fill_buf(void *buf, size_t size)
 {
 	char *msg_buf;
 	int msg_index;
 	static unsigned int iter = 0;
-	int i;
+	size_t i;
 
 	msg_index = ((iter++)*INTEG_SEED) % integ_alphabet_length;
 	msg_buf = (char *)buf;
@@ -3052,13 +3052,13 @@ void ft_fill_buf(void *buf, int size)
 	}
 }
 
-int ft_check_buf(void *buf, int size)
+int ft_check_buf(void *buf, size_t size)
 {
 	char *recv_data;
 	char c;
 	static unsigned int iter = 0;
 	int msg_index;
-	int i;
+	size_t i;
 
 	msg_index = ((iter++)*INTEG_SEED) % integ_alphabet_length;
 	recv_data = (char *)buf;
@@ -3071,7 +3071,7 @@ int ft_check_buf(void *buf, int size)
 			break;
 	}
 	if (i != size) {
-		printf("Error at iteration=%d size=%d byte=%d\n",
+		printf("Error at iteration=%d size=%zu byte=%zu\n",
 			iter, size, i);
 		return 1;
 	}

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -229,8 +229,8 @@ void ft_usage(char *name, char *desc);
 void ft_mcusage(char *name, char *desc);
 void ft_csusage(char *name, char *desc);
 
-void ft_fill_buf(void *buf, int size);
-int ft_check_buf(void *buf, int size);
+void ft_fill_buf(void *buf, size_t size);
+int ft_check_buf(void *buf, size_t size);
 int ft_check_opts(uint64_t flags);
 uint64_t ft_init_cq_data(struct fi_info *info);
 int ft_sock_listen(char *node, char *service);


### PR DESCRIPTION
Change fill_buf and check_buf to use size_t instead of ints
for filling buffers larger than 2GB

Signed-off-by: aingerson <alexia.ingerson@intel.com>