### PR TITLE
prov/efa: fix signature of function to avoid compilation warning

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -717,11 +717,11 @@ static inline void rxr_ep_peer_init_tx(struct rxr_peer *peer)
 
 struct efa_ep_addr *rxr_ep_raw_addr(struct rxr_ep *ep);
 
-char *rxr_ep_raw_addr_str(struct rxr_ep *ep, char *buf, size_t *buflen);
+const char *rxr_ep_raw_addr_str(struct rxr_ep *ep, char *buf, size_t *buflen);
 
 struct efa_ep_addr *rxr_peer_raw_addr(struct rxr_ep *ep, fi_addr_t addr);
 
-char *rxr_peer_raw_addr_str(struct rxr_ep *ep, fi_addr_t addr, char *buf, size_t *buflen);
+const char *rxr_peer_raw_addr_str(struct rxr_ep *ep, fi_addr_t addr, char *buf, size_t *buflen);
 
 struct rxr_rx_entry *rxr_ep_get_rx_entry(struct rxr_ep *ep,
 					 const struct fi_msg *msg,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -51,7 +51,7 @@ struct efa_ep_addr *rxr_ep_raw_addr(struct rxr_ep *ep)
 	return (struct efa_ep_addr *)ep->core_addr;
 }
 
-char *rxr_ep_raw_addr_str(struct rxr_ep *ep, char *buf, size_t *buflen)
+const char *rxr_ep_raw_addr_str(struct rxr_ep *ep, char *buf, size_t *buflen)
 {
 	return ofi_straddr(buf, buflen, FI_ADDR_EFA, rxr_ep_raw_addr(ep));
 }
@@ -69,7 +69,7 @@ struct efa_ep_addr *rxr_peer_raw_addr(struct rxr_ep *ep, fi_addr_t addr)
 	return &efa_conn->ep_addr;
 }
 
-char *rxr_peer_raw_addr_str(struct rxr_ep *ep, fi_addr_t addr, char *buf, size_t *buflen)
+const char *rxr_peer_raw_addr_str(struct rxr_ep *ep, fi_addr_t addr, char *buf, size_t *buflen)
 {
 	return ofi_straddr(buf, buflen, FI_ADDR_EFA, rxr_peer_raw_addr(ep, addr));
 }


### PR DESCRIPTION
The functions:

	rxr_ep_raw_addr_str() and rxr_ep_peer_addr_str()

return types are "char *", which is causing compilation warning.

This patch change the return type to "const char *" to fix it.

Signed-off-by: Wei Zhang <wzam@amazon.com>