### PR TITLE
prov/efa: use fi_read to copy data to gpu buffer

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -521,6 +521,9 @@ struct rxr_ep {
 	struct fid_ep *rdm_ep;
 	struct fid_cq *rdm_cq;
 
+	/* address of myself in my AV, used to post read to my self */
+	fi_addr_t rdm_self_addr;
+
 	/* shm provider fid */
 	bool use_shm;
 	struct fid_ep *shm_ep;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -890,6 +890,7 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 	ssize_t ret;
 	size_t i;
 	struct rxr_ep *ep;
+	struct efa_ep *efa_ep;
 	uint64_t flags = FI_MORE;
 	size_t rx_size, shm_rx_size;
 	char shm_ep_name[NAME_MAX];
@@ -962,6 +963,17 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 				if (ret)
 					goto out;
 			}
+		}
+
+		/*
+		 * insert EP's own address to AV and save the address as
+		 * ep->rdm_self_addr. It is used when copy data to GPU memory by local read
+		 */
+		efa_ep = container_of(ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
+		ret = efa_av_insert_addr(efa_ep->av, (struct efa_ep_addr *)ep->core_addr,
+					 &ep->rdm_self_addr, 0, NULL);
+		if (OFI_UNLIKELY(ret)) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ, "insert EP's own address failed!\n");
 		}
 
 out:
@@ -1703,6 +1715,8 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  &rxr_ep->rdm_ep, rxr_ep);
 	if (ret)
 		goto err_free_rdm_info;
+
+	rxr_ep->rdm_self_addr = FI_ADDR_NOTAVAIL;
 
 	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
 				  util_domain.domain_fid);

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -34,13 +34,15 @@
 #include "efa.h"
 #include "rxr.h"
 #include "rxr_cntr.h"
+#include "rxr_read.h"
 #include "rxr_pkt_cmd.h"
 
 /* Handshake wait timeout in microseconds */
 #define RXR_HANDSHAKE_WAIT_TIMEOUT 1000000
 
-/* This file implements 4 actions that can be applied to a packet:
+/* This file implements 5 actions that can be applied to a packet:
  *          posting,
+ *          processing data,
  *          handling send completion and,
  *          handing recv completion.
  *          dump (for debug only)
@@ -100,6 +102,7 @@ ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep,
 	assert(tx_entry->window >= 0);
 	return ret;
 }
+
 
 /*
  *   rxr_pkt_init_ctrl() uses init functions declared in rxr_pkt_type.h
@@ -450,7 +453,140 @@ ssize_t rxr_pkt_wait_handshake(struct rxr_ep *ep, fi_addr_t addr, struct rxr_pee
 }
 
 /*
- *   Functions used to handle packet send completion
+ * Functions to copy data to receiving buffer in a packet entry.
+ *
+ * Each packet type that may contain data will implement
+ * a handler function to handle data copied event.
+ *
+ * Data can be copied either directly or by a read request.
+ *
+ * If data is copied directly, the event handler will be called
+ * immediately.
+ *
+ * If data is copied by read. The progress engine will call the
+ * event handler.
+ */
+static inline
+ssize_t rxr_pkt_post_read_to_copy_data(struct rxr_ep *rxr_ep,
+				       struct rxr_pkt_entry *pkt_entry,
+				       char *data, size_t data_size,
+				       struct rxr_rx_entry *rx_entry,
+				       size_t data_offset)
+{
+	ssize_t err;
+	int iov_idx;
+	size_t iov_offset;
+	void *dest_buf;
+
+	assert(pkt_entry->x_entry == rx_entry);
+
+	err = rxr_locate_iov_pos(rx_entry->iov, rx_entry->iov_count, data_offset,
+				 &iov_idx, &iov_offset);
+
+	if (err) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"data_offset %ld out of range\n",
+			data_offset);
+		return err;
+	}
+
+	assert(iov_idx >=0 && iov_idx < rx_entry->iov_count);
+	assert(efa_ep_is_cuda_mr(rx_entry->desc[iov_idx]));
+	assert(iov_offset + data_size <= rx_entry->iov[iov_idx].iov_len);
+
+	dest_buf = (char *)rx_entry->iov[iov_idx].iov_base + iov_offset;
+
+	pkt_entry->state = RXR_PKT_ENTRY_COPY_BY_READ;
+	assert(pkt_entry->mr);
+	assert(rxr_ep->rdm_self_addr != FI_ADDR_NOTAVAIL);
+
+	err = fi_read(rxr_ep->rdm_ep,
+		      dest_buf, data_size, rx_entry->desc[iov_idx],
+		      rxr_ep->rdm_self_addr,
+		      (uint64_t)data, fi_mr_key(pkt_entry->mr),
+		      pkt_entry);
+
+	if (OFI_UNLIKELY(err)) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "Failed to post read to copy data\n");
+		return err;
+	}
+
+	return 0;
+}
+
+static inline
+void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
+				struct rxr_pkt_entry *pkt_entry)
+{
+	int pkt_type;
+
+	pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
+
+	switch(pkt_type) {
+	case RXR_DATA_PKT:
+	case RXR_READRSP_PKT:
+		rxr_data_pkt_handle_data_copied(ep, pkt_entry);
+		break;
+	case RXR_EAGER_MSGRTM_PKT:
+	case RXR_EAGER_TAGRTM_PKT:
+		rxr_pkt_handle_eager_rtm_data_copied(ep, pkt_entry);
+		break;
+	case RXR_MEDIUM_MSGRTM_PKT:
+	case RXR_MEDIUM_TAGRTM_PKT:
+		rxr_pkt_handle_medium_rtm_data_copied(ep, pkt_entry);
+		break;
+	case RXR_LONG_MSGRTM_PKT:
+	case RXR_LONG_TAGRTM_PKT:
+		rxr_pkt_handle_long_rtm_data_copied(ep, pkt_entry);
+		break;
+	case RXR_EAGER_RTW_PKT:
+		rxr_pkt_handle_eager_rtw_data_copied(ep, pkt_entry);
+		break;
+	case RXR_LONG_RTW_PKT:
+		rxr_pkt_handle_long_rtw_data_copied(ep, pkt_entry);
+		break;
+	default:
+		FI_WARN(&rxr_prov, FI_LOG_CQ,
+			"invalid control pkt type %d\n",
+			rxr_get_base_hdr(pkt_entry->pkt)->type);
+		assert(0 && "invalid control pkt type");
+		rxr_cq_handle_cq_error(ep, -FI_EIO);
+	}
+}
+
+void rxr_pkt_proc_data(struct rxr_ep *ep,
+		       struct rxr_rx_entry *rx_entry,
+		       size_t data_offset,
+		       struct rxr_pkt_entry *pkt_entry,
+		       char *data, size_t data_size)
+{
+	ssize_t err;
+
+	pkt_entry->x_entry = rx_entry;
+
+	if (OFI_UNLIKELY(rx_entry->rxr_flags & RXR_RECV_CANCEL) ||
+	    data_offset >= rx_entry->cq_entry.len) {
+		rxr_pkt_handle_data_copied(ep, pkt_entry);
+		return;
+	}
+
+	if (efa_ep_is_cuda_mr(rx_entry->desc[0])) {
+		err = rxr_pkt_post_read_to_copy_data(ep, pkt_entry, data,
+						     data_size, rx_entry,
+						     data_offset);
+		if (OFI_UNLIKELY(err)) {
+			if (rxr_cq_handle_rx_error(ep, rx_entry, -FI_EINVAL))
+				assert(0 && "error writing error cq entry\n");
+		}
+	} else {
+		ofi_copy_to_iov(rx_entry->iov, rx_entry->iov_count,
+				data_offset, data, data_size);
+		rxr_pkt_handle_data_copied(ep, pkt_entry);
+	}
+}
+
+/*
+ * Functions handle send completions
  */
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *comp)
 {
@@ -458,6 +594,10 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *
 	struct rxr_peer *peer;
 
 	pkt_entry = (struct rxr_pkt_entry *)comp->op_context;
+	if (pkt_entry->state == RXR_PKT_ENTRY_COPY_BY_READ) {
+		rxr_pkt_handle_data_copied(ep, pkt_entry);
+		return;
+	}
 
 	switch (rxr_get_base_hdr(pkt_entry->pkt)->type) {
 	case RXR_HANDSHAKE_PKT:

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -44,6 +44,10 @@ ssize_t rxr_pkt_post_ctrl(struct rxr_ep *ep, int entry_type, void *x_entry,
 ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry,
 				   int ctrl_type, bool inject);
 
+void rxr_pkt_proc_data(struct rxr_ep *rxr_ep, struct rxr_rx_entry *rx_entry,
+		       size_t data_offset, struct rxr_pkt_entry *pkt_eentry,
+		       char *data, size_t data_size);
+
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep,
 				    struct fi_cq_data_entry *cq_entry);
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -41,6 +41,9 @@ enum rxr_pkt_entry_state {
 	RXR_PKT_ENTRY_FREE = 0,
 	RXR_PKT_ENTRY_IN_USE,
 	RXR_PKT_ENTRY_RNR_RETRANSMIT,
+	RXR_PKT_ENTRY_COPY_BY_READ, /* entries contain data. A read request has been posted to copy
+				     * to receiving buffer
+				     */
 };
 
 /* pkt_entry types for rx pkts */

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -234,15 +234,11 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 			       struct rxr_tx_entry *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry);
 
-int rxr_pkt_proc_data(struct rxr_ep *ep,
-		      struct rxr_rx_entry *rx_entry,
-		      struct rxr_pkt_entry *pkt_entry,
-		      char *data, size_t seg_offset,
-		      size_t seg_size);
-
 void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 					 struct rxr_pkt_entry *pkt_entry);
 
+void rxr_data_pkt_handle_data_copied(struct rxr_ep *ep,
+				     struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -316,9 +316,10 @@ void rxr_pkt_handle_readrsp_recv(struct rxr_ep *ep,
 	rx_entry = ofi_bufpool_get_ibuf(ep->rx_entry_pool, readrsp_hdr->rx_id);
 	assert(rx_entry->cq_entry.flags & FI_READ);
 	rx_entry->tx_id = readrsp_hdr->tx_id;
-	rxr_pkt_proc_data(ep, rx_entry, pkt_entry,
+	rxr_pkt_proc_data(ep, rx_entry, 0,
+			  pkt_entry,
 			  readrsp_pkt->data,
-			  0, readrsp_hdr->seg_size);
+			  readrsp_hdr->seg_size);
 }
 
 /*  RMA_CONTEXT packet functions

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -268,40 +268,6 @@ size_t rxr_pkt_req_max_data_size(struct rxr_ep *ep, fi_addr_t addr, int pkt_type
 	return ep->mtu_size - rxr_pkt_req_max_header_size(pkt_type);
 }
 
-static
-size_t rxr_pkt_req_copy_data(struct rxr_rx_entry *rx_entry,
-			     struct rxr_pkt_entry *pkt_entry,
-			     char *data, size_t data_size)
-{
-	struct efa_mr *desc;
-	size_t bytes_copied;
-	int bytes_left;
-
-	desc = rx_entry->desc[0];
-	bytes_copied = ofi_copy_to_hmem_iov(desc ? desc->peer.iface : FI_HMEM_SYSTEM,
-					    desc ? desc->peer.device.reserved : 0,
-					    rx_entry->iov,
-					    rx_entry->iov_count,
-					    0,
-					    data,
-					    data_size);
-
-	if (OFI_UNLIKELY(bytes_copied < data_size)) {
-		/* recv buffer is not big enough to hold req, this must be a truncated message */
-		assert(bytes_copied == rx_entry->cq_entry.len &&
-		       rx_entry->cq_entry.len < rx_entry->total_len);
-		rx_entry->bytes_done = bytes_copied;
-		bytes_left = 0;
-	} else {
-		assert(bytes_copied == data_size);
-		rx_entry->bytes_done = data_size;
-		bytes_left = rx_entry->total_len - rx_entry->bytes_done;
-	}
-
-	assert(bytes_left >= 0);
-	return bytes_left;
-}
-
 /*
  * REQ packet type functions
  *
@@ -799,6 +765,134 @@ struct rxr_rx_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 	return rx_entry;
 }
 
+/*
+ * handle_data_copied() functions for RTM packets
+ */
+void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rx_entry *rx_entry;
+
+	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
+	assert(rx_entry);
+
+	/* rxr_cq_handle_rx_completion release pkt_entry */
+	rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
+	rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
+	rxr_release_rx_entry(ep, rx_entry);
+}
+
+void rxr_pkt_handle_medium_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rx_entry *rx_entry;
+	size_t data_size;
+
+	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
+	assert(rx_entry);
+	data_size = pkt_entry->pkt_size - rxr_pkt_req_hdr_size(pkt_entry);
+
+	rx_entry->bytes_done += data_size;
+
+	if (rx_entry->bytes_done == rx_entry->total_len) {
+		rxr_pkt_rx_map_remove(ep, pkt_entry, rx_entry);
+
+		/* rxr_cq_handle_rx_completion release pkt_entry */
+		rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
+		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
+		rxr_release_rx_entry(ep, rx_entry);
+	} else {
+		rxr_pkt_entry_release_rx(ep, pkt_entry);
+	}
+}
+
+void rxr_pkt_handle_long_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rx_entry *rx_entry;
+	size_t data_size;
+	int err;
+
+	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
+	assert(rx_entry);
+	data_size = pkt_entry->pkt_size - rxr_pkt_req_hdr_size(pkt_entry);
+
+#if ENABLE_DEBUG
+	dlist_insert_tail(&rx_entry->rx_pending_entry, &ep->rx_pending_list);
+	ep->rx_pending++;
+#endif
+	rx_entry->bytes_done = data_size;
+	rx_entry->state = RXR_RX_RECV;
+	rx_entry->tx_id = rxr_get_long_rtm_base_hdr(pkt_entry->pkt)->tx_id;
+	/* we have noticed using the default value achieve better bandwidth */
+	rx_entry->credit_request = rxr_env.tx_min_credits;
+	err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
+	if (err) {
+		rxr_cq_handle_rx_error(ep, rx_entry, err);
+		rxr_release_rx_entry(ep, rx_entry);
+	}
+
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+}
+
+/*
+ * proc() functions for RTM packets
+ */
+static inline
+ssize_t rxr_pkt_proc_matched_eager_rtm(struct rxr_ep *ep,
+				       struct rxr_rx_entry *rx_entry,
+				       struct rxr_pkt_entry *pkt_entry)
+{
+	size_t hdr_size, data_size;
+	char * data;
+
+	hdr_size = rxr_pkt_req_hdr_size(pkt_entry);
+	data = (char *)pkt_entry->pkt + hdr_size;
+	data_size = pkt_entry->pkt_size - hdr_size;
+
+	rxr_pkt_proc_data(ep, rx_entry, 0, pkt_entry, data, data_size);
+	return 0;
+}
+
+ssize_t rxr_pkt_proc_matched_medium_rtm(struct rxr_ep *ep,
+					struct rxr_rx_entry *rx_entry,
+					struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_pkt_entry *cur, *nxt;
+	char *data;
+	size_t offset, hdr_size, data_size;
+
+	cur = pkt_entry;
+	while (cur) {
+		cur->x_entry = rx_entry;
+		hdr_size = rxr_pkt_req_hdr_size(cur);
+		data = (char *)cur->pkt + hdr_size;
+		offset = rxr_get_medium_rtm_base_hdr(cur->pkt)->offset;
+		data_size = cur->pkt_size - hdr_size;
+
+		nxt = cur->next;
+		cur->next = NULL;
+		rxr_pkt_proc_data(ep, rx_entry, offset, cur, data, data_size);
+		cur = nxt;
+	}
+
+	return 0;
+}
+
+static inline
+size_t rxr_pkt_proc_matched_long_rtm(struct rxr_ep *ep,
+				     struct rxr_rx_entry *rx_entry,
+				     struct rxr_pkt_entry *pkt_entry)
+{
+	size_t hdr_size, data_size;
+	char *data;
+
+	hdr_size = rxr_pkt_req_hdr_size(pkt_entry);
+	data = (char *)pkt_entry->pkt + hdr_size;
+	data_size = pkt_entry->pkt_size - hdr_size;
+	assert(data_size < rx_entry->total_len);
+
+	rxr_pkt_proc_data(ep, rx_entry, 0, pkt_entry, data, data_size);
+	return 0;
+}
+
 ssize_t rxr_pkt_proc_matched_read_rtm(struct rxr_ep *ep,
 				      struct rxr_rx_entry *rx_entry,
 				      struct rxr_pkt_entry *pkt_entry)
@@ -823,63 +917,14 @@ ssize_t rxr_pkt_proc_matched_read_rtm(struct rxr_ep *ep,
 	return rxr_read_post_or_queue(ep, RXR_RX_ENTRY, rx_entry);
 }
 
-ssize_t rxr_pkt_proc_matched_medium_rtm(struct rxr_ep *ep,
-					struct rxr_rx_entry *rx_entry,
-					struct rxr_pkt_entry *pkt_entry)
-{
-	struct rxr_pkt_entry *cur, *nxt;
-	struct efa_mr *desc;
-	char *data;
-	size_t offset, hdr_size, data_size;
-
-	cur = pkt_entry;
-	while (cur) {
-		hdr_size = rxr_pkt_req_hdr_size(cur);
-		data = (char *)cur->pkt + hdr_size;
-		offset = rxr_get_medium_rtm_base_hdr(cur->pkt)->offset;
-		data_size = cur->pkt_size - hdr_size;
-		desc = rx_entry->desc[0];
-
-		ofi_copy_to_hmem_iov(desc ? desc->peer.iface : FI_HMEM_SYSTEM,
-				     desc ? desc->peer.device.reserved : 0,
-				     rx_entry->iov,
-				     rx_entry->iov_count,
-				     offset,
-				     data,
-				     data_size);
-		rx_entry->bytes_done += data_size;
-
-		nxt = cur->next;
-		cur->next = NULL;
-		if (rx_entry->total_len == rx_entry->bytes_done) {
-			rxr_pkt_rx_map_remove(ep, cur, rx_entry);
-			/*
-			 * rxr_cq_handle_rx_completion() releases pkt_entry, thus
-			 * we do not release it here.
-			 */
-			rxr_cq_handle_rx_completion(ep, cur, rx_entry);
-			rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
-			rxr_release_rx_entry(ep, rx_entry);
-		} else {
-			rxr_pkt_entry_release_rx(ep, cur);
-		}
-
-		cur = nxt;
-	}
-
-	return 0;
-}
-
 ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 				 struct rxr_rx_entry *rx_entry,
 				 struct rxr_pkt_entry *pkt_entry)
 {
 	int pkt_type;
-	char *data;
-	size_t hdr_size, data_size, bytes_left;
-	ssize_t ret;
 
 	assert(rx_entry->state == RXR_RX_MATCHED);
+	pkt_entry->x_entry = rx_entry;
 
 	/* Adjust rx_entry->cq_entry.len as needed.
 	 * Initialy rx_entry->cq_entry.len is total recv buffer size.
@@ -892,43 +937,25 @@ ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 		rx_entry->cq_entry.len = rx_entry->total_len;
 
 	pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
-	if (pkt_type == RXR_READ_MSGRTM_PKT || pkt_type == RXR_READ_TAGRTM_PKT)
-		return rxr_pkt_proc_matched_read_rtm(ep, rx_entry, pkt_entry);
-
-	if (pkt_type == RXR_MEDIUM_MSGRTM_PKT || pkt_type == RXR_MEDIUM_TAGRTM_PKT)
+	switch (pkt_type) {
+	case RXR_EAGER_MSGRTM_PKT:
+	case RXR_EAGER_TAGRTM_PKT:
+		return rxr_pkt_proc_matched_eager_rtm(ep, rx_entry, pkt_entry);
+	case RXR_MEDIUM_MSGRTM_PKT:
+	case RXR_MEDIUM_TAGRTM_PKT:
 		return rxr_pkt_proc_matched_medium_rtm(ep, rx_entry, pkt_entry);
-
-	hdr_size = rxr_pkt_req_hdr_size(pkt_entry);
-	data = (char *)pkt_entry->pkt + hdr_size;
-	data_size = pkt_entry->pkt_size - hdr_size;
-	bytes_left = rxr_pkt_req_copy_data(rx_entry, pkt_entry,
-					   data, data_size);
-	if (!bytes_left) {
-		/*
-		 * rxr_cq_handle_rx_completion() releases pkt_entry, thus
-		 * we do not release it here.
-		 */
-		rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
-		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
-		rxr_release_rx_entry(ep, rx_entry);
-		ret = 0;
-	} else {
-		/*
-		 * long message protocol
-		 */
-#if ENABLE_DEBUG
-		dlist_insert_tail(&rx_entry->rx_pending_entry, &ep->rx_pending_list);
-		ep->rx_pending++;
-#endif
-		rx_entry->state = RXR_RX_RECV;
-		rx_entry->tx_id = rxr_get_long_rtm_base_hdr(pkt_entry->pkt)->tx_id;
-		/* we have noticed using the default value achieve better bandwidth */
-		rx_entry->credit_request = rxr_env.tx_min_credits;
-		ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
-		rxr_pkt_entry_release_rx(ep, pkt_entry);
+	case RXR_LONG_MSGRTM_PKT:
+	case RXR_LONG_TAGRTM_PKT:
+		return rxr_pkt_proc_matched_long_rtm(ep, rx_entry, pkt_entry);
+	case RXR_READ_MSGRTM_PKT:
+	case RXR_READ_TAGRTM_PKT:
+		return rxr_pkt_proc_matched_read_rtm(ep, rx_entry, pkt_entry);
+	default:
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "invalid pkt type: %d\n", pkt_type);
+		assert(0 && "invalid pkt type");
 	}
 
-	return ret;
+	return 0;
 }
 
 ssize_t rxr_pkt_proc_msgrtm(struct rxr_ep *ep,
@@ -988,10 +1015,6 @@ ssize_t rxr_pkt_proc_tagrtm(struct rxr_ep *ep,
 
 	return 0;
 }
-
-/*
- * proc() functions called by rxr_pkt_handle_recv_completion()
- */
 ssize_t rxr_pkt_proc_rtm_rta(struct rxr_ep *ep,
 			     struct rxr_pkt_entry *pkt_entry)
 {
@@ -1306,6 +1329,48 @@ void rxr_pkt_handle_long_rtw_send_completion(struct rxr_ep *ep,
 }
 
 /*
+ *     handle_data_copied() functions for RTW packets
+ */
+void rxr_pkt_handle_eager_rtw_data_copied(struct rxr_ep *ep,
+					  struct rxr_pkt_entry *pkt_entry)
+{
+	struct rxr_rx_entry *rx_entry;
+
+	rx_entry = pkt_entry->x_entry;
+
+	if (rx_entry->cq_entry.flags & FI_REMOTE_CQ_DATA)
+		rxr_cq_write_rx_completion(ep, rx_entry);
+
+	rxr_release_rx_entry(ep, rx_entry);
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+}
+
+void rxr_pkt_handle_long_rtw_data_copied(struct rxr_ep *ep,
+					 struct rxr_pkt_entry *pkt_entry)
+{
+	int err;
+	size_t data_size;
+	struct rxr_rx_entry *rx_entry;
+
+	rx_entry = pkt_entry->x_entry;
+	assert(rx_entry);
+	data_size = pkt_entry->pkt_size - rxr_pkt_req_hdr_size(pkt_entry);
+
+	rx_entry->bytes_done += data_size;
+#if ENABLE_DEBUG
+	dlist_insert_tail(&rx_entry->rx_pending_entry, &ep->rx_pending_list);
+	ep->rx_pending++;
+#endif
+	err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
+	if (OFI_UNLIKELY(err)) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "Cannot post CTS packet\n");
+		rxr_cq_handle_rx_error(ep, rx_entry, err);
+		rxr_release_rx_entry(ep, rx_entry);
+	}
+	rxr_pkt_entry_release_rx(ep, pkt_entry);
+}
+
+/*
  *     handle_recv() functions
  */
 
@@ -1341,7 +1406,7 @@ void rxr_pkt_handle_eager_rtw_recv(struct rxr_ep *ep,
 	struct rxr_eager_rtw_hdr *rtw_hdr;
 	char *data;
 	size_t data_size, hdr_size;
-	ssize_t err, bytes_left;
+	ssize_t err;
 
 	rx_entry = rxr_pkt_alloc_rtw_rx_entry(ep, pkt_entry);
 	if (!rx_entry) {
@@ -1372,10 +1437,9 @@ void rxr_pkt_handle_eager_rtw_recv(struct rxr_ep *ep,
 	hdr_size = rxr_pkt_req_hdr_size(pkt_entry);
 	data = (char *)pkt_entry->pkt + hdr_size;
 	data_size = pkt_entry->pkt_size - hdr_size;
-	bytes_left = rxr_pkt_req_copy_data(rx_entry, pkt_entry, data, data_size);
-	if (bytes_left != 0) {
-		FI_WARN(&rxr_prov, FI_LOG_CQ, "Eager RTM bytes_left is %ld, which should be 0.",
-			bytes_left);
+	if (data_size != rx_entry->total_len) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "Eager RTM data_size is %ld, total len is %ld.",
+			data_size, rx_entry->total_len);
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "target buffer: %p length: %ld", rx_entry->iov[0].iov_base,
 			rx_entry->iov[0].iov_len);
 		efa_eq_write_error(&ep->util_ep, FI_EINVAL, -FI_EINVAL);
@@ -1384,11 +1448,7 @@ void rxr_pkt_handle_eager_rtw_recv(struct rxr_ep *ep,
 		return;
 	}
 
-	if (rx_entry->cq_entry.flags & FI_REMOTE_CQ_DATA)
-		rxr_cq_write_rx_completion(ep, rx_entry);
-
-	rxr_release_rx_entry(ep, rx_entry);
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	rxr_pkt_proc_data(ep, rx_entry, 0, pkt_entry, data, data_size);
 }
 
 void rxr_pkt_handle_long_rtw_recv(struct rxr_ep *ep,
@@ -1398,7 +1458,7 @@ void rxr_pkt_handle_long_rtw_recv(struct rxr_ep *ep,
 	struct rxr_long_rtw_hdr *rtw_hdr;
 	char *data;
 	size_t hdr_size, data_size;
-	ssize_t err, bytes_left;
+	ssize_t err;
 
 	rx_entry = rxr_pkt_alloc_rtw_rx_entry(ep, pkt_entry);
 	if (!rx_entry) {
@@ -1429,10 +1489,9 @@ void rxr_pkt_handle_long_rtw_recv(struct rxr_ep *ep,
 	hdr_size = rxr_pkt_req_hdr_size(pkt_entry);
 	data = (char *)pkt_entry->pkt + hdr_size;
 	data_size = pkt_entry->pkt_size - hdr_size;
-	bytes_left = rxr_pkt_req_copy_data(rx_entry, pkt_entry, data, data_size);
-	if (OFI_UNLIKELY(bytes_left <= 0)) {
-		FI_WARN(&rxr_prov, FI_LOG_CQ, "Long RTM bytes_left is %ld, which should be > 0.",
-			bytes_left);
+	if (data_size >= rx_entry->total_len) {
+		FI_WARN(&rxr_prov, FI_LOG_CQ, "Long RTM data size is %ld, which is larger than total len %ld",
+			data_size, rx_entry->total_len);
 		FI_WARN(&rxr_prov, FI_LOG_CQ, "target buffer: %p length: %ld", rx_entry->iov[0].iov_base,
 			rx_entry->iov[0].iov_len);
 		efa_eq_write_error(&ep->util_ep, FI_EINVAL, -FI_EINVAL);
@@ -1441,20 +1500,11 @@ void rxr_pkt_handle_long_rtw_recv(struct rxr_ep *ep,
 		return;
 	}
 
-#if ENABLE_DEBUG
-	dlist_insert_tail(&rx_entry->rx_pending_entry, &ep->rx_pending_list);
-	ep->rx_pending++;
-#endif
 	rx_entry->state = RXR_RX_RECV;
 	rx_entry->tx_id = rtw_hdr->tx_id;
 	rx_entry->credit_request = rxr_env.tx_min_credits;
-	err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
-	if (OFI_UNLIKELY(err)) {
-		FI_WARN(&rxr_prov, FI_LOG_CQ, "Cannot post CTS packet\n");
-		rxr_cq_handle_rx_error(ep, rx_entry, err);
-		rxr_release_rx_entry(ep, rx_entry);
-	}
-	rxr_pkt_entry_release_rx(ep, pkt_entry);
+
+	rxr_pkt_proc_data(ep, rx_entry, 0, pkt_entry, data, data_size);
 }
 
 void rxr_pkt_handle_read_rtw_recv(struct rxr_ep *ep,
@@ -1739,7 +1789,7 @@ int rxr_pkt_proc_write_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	op = rta_hdr->atomic_op;
 	dt = rta_hdr->atomic_datatype;
 	dtsize = ofi_datatype_size(dt);
-	
+
 	hdr_size = rxr_pkt_req_hdr_size(pkt_entry);
 	data = (char *)pkt_entry->pkt + hdr_size;
 	iov_count = rta_hdr->rma_iov_count;
@@ -1817,7 +1867,7 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	}
 
 	op = rx_entry->atomic_hdr.atomic_op;
- 	dt = rx_entry->atomic_hdr.datatype;	
+  	dt = rx_entry->atomic_hdr.datatype;
 	dtsize = ofi_datatype_size(rx_entry->atomic_hdr.datatype);
 
 	data = (char *)pkt_entry->pkt + rxr_pkt_req_hdr_size(pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -330,6 +330,16 @@ void rxr_pkt_handle_read_rtm_send_completion(struct rxr_ep *ep,
 }
 
 /*
+ * handle_data_copied() functions for RTM packet types.
+ * Note: read rtm does not contain data, so does not have such a handler.
+ */
+void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+
+/*
  *   proc() functions for RTM packet types
  */
 void rxr_pkt_rtm_init_rx_entry(struct rxr_pkt_entry *pkt_entry,
@@ -339,6 +349,15 @@ void rxr_pkt_rtm_init_rx_entry(struct rxr_pkt_entry *pkt_entry,
  *            rxr_pkt_handle_rtm_recv() and
  *            rxr_msg_handle_unexp_match()
  */
+void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep,
+					  struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_medium_rtm_data_copied(struct rxr_ep *ep,
+					   struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_long_rtm_data_copied(struct rxr_ep *ep,
+					 struct rxr_pkt_entry *pkt_entry);
+
 ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 				 struct rxr_rx_entry *rx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
@@ -464,6 +483,14 @@ void rxr_pkt_handle_read_rtw_send_completion(struct rxr_ep *ep,
 {
 }
 
+/*
+ *     handle_data_copied() functions for RTW packets
+ */
+void rxr_pkt_handle_eager_rtw_data_copied(struct rxr_ep *ep,
+					  struct rxr_pkt_entry *pkt_entry);
+
+void rxr_pkt_handle_long_rtw_data_copied(struct rxr_ep *ep,
+					 struct rxr_pkt_entry *pkt_entry);
 /*
  *     handle_recv() functions
  */

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -44,6 +44,9 @@ enum rxr_read_entry_state {
 	RXR_RDMA_ENTRY_PENDING
 };
 
+int rxr_locate_iov_pos(struct iovec *iov, int iov_count, size_t offset,
+		       int *iov_idx, size_t *iov_offset);
+
 /* rxr_read_entry was arranged as a packet
  * and was put in a rxr_pkt_entry. Because rxr_pkt_entry is used
  * as context.


### PR DESCRIPTION
This patch use fi_read instead of cudaMemcpy() to copy data to gpu buffer. This change is because cudaMemcpy()
can cause deadlock, when the EFA provider is used by a NCCL plugin.

Related GitHub issue:
   https://github.com/ofiwg/libfabric/issues/6124

The core change is to extend the function rxr_pkt_proc_data(), which will copy data to recieving buffer for all packets that
may contain data.

Each packet type implements a handler function to handle data copied event.

If recieving buffer is on host memory, rxr_pkt_proc_data() will copy data then call the handler fucntions.

If receiving buffer is on GPU memory, rxr_pkt_proc_data() will post a read, and the progress engine will call the handler functions.

Signed-off-by: Wei Zhang <wzam@amazon.com>