### PR TITLE
Extend gnix_smsg_rma_data_hdr to fully support FI_REMOTE_CQ_DATA.

### DIFF
--- a/prov/gni/include/gnix_nic.h
+++ b/prov/gni/include/gnix_nic.h
@@ -299,11 +299,13 @@ struct gnix_smsg_rndzv_fin_hdr {
  * @var flags       control flags
  * @var user_flags  remote CQ user flags
  * @var user_data   remote CQ user immediate data
+ * @var user_addr   remote CQ user buf address
  */
 struct gnix_smsg_rma_data_hdr {
 	uint64_t flags;
 	uint64_t user_flags;
 	uint64_t user_data;
+  	uint64_t user_addr;
 };
 
 /**

--- a/prov/gni/src/gnix_rma.c
+++ b/prov/gni/src/gnix_rma.c
@@ -270,8 +270,8 @@ int __smsg_rma_data(void *data, void *msg)
 
 	if (GNIX_ALLOW_FI_REMOTE_CQ_DATA(hdr->flags, ep->caps) && ep->recv_cq) {
 		ret = _gnix_cq_add_event(ep->recv_cq, ep, NULL, hdr->user_flags,
-					 0, 0, hdr->user_data, 0,
-					 FI_ADDR_NOTAVAIL);
+					 0, (void*)hdr->user_addr,
+					 hdr->user_data, 0, FI_ADDR_NOTAVAIL);
 		if (ret != FI_SUCCESS)  {
 			GNIX_WARN(FI_LOG_EP_DATA,
 				  "_gnix_cq_add_event returned %d\n",
@@ -362,6 +362,7 @@ static int __gnix_rma_send_data_req(void *arg)
 			txd->rma_data_hdr.user_flags |= FI_REMOTE_READ;
 		}
 		txd->rma_data_hdr.user_data = req->rma.imm;
+		txd->rma_data_hdr.user_addr = req->rma.rem_addr;
 	}
 
 	if (req->vc->peer_caps & FI_RMA_EVENT) {


### PR DESCRIPTION
This attempts to resolve #6237.

Remote `fi_cq_data_entry` structures resulting from `fi_writemsg` with
`FI_REMOTE_CQ_DATA` should provide both the immediate value as well as the
remote target address. The GNI provider implements remote CQ data with
`GNI_SmsgSendWTag` using a message type of `gnix_smsg_rma_data_hdr`, but this
type does not have space to send the remote address, thus the remote
`fi_cq_data_entry` is returned to the user with a NULL `.buf`.

This extends the `gnix_smsg_rma_data_hdr` with a single `user_addr` field that
is set with the remote address, which can then be extracted and injected into
the remote CQ event.