### PR TITLE
util_mem_monitor: Add flag to indicate whether to defer free

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -156,6 +156,7 @@ int ofi_monitors_add_cache(struct ofi_mem_monitor **monitors,
 void ofi_monitors_del_cache(struct ofi_mr_cache *cache);
 void ofi_monitor_notify(struct ofi_mem_monitor *monitor,
 			const void *addr, size_t len);
+void ofi_monitor_flush(struct ofi_mem_monitor *monitor);
 
 int ofi_monitor_subscribe(struct ofi_mem_monitor *monitor,
 			  const void *addr, size_t len,

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2017-2019 Intel Corporation, Inc. All rights reserved.
- * Copyright (c) 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates.
+ *                         All rights reserved.
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
  *
  * This software is available to you under a choice of one of two
@@ -102,6 +103,14 @@ static inline uint64_t ofi_mr_get_prov_mode(uint32_t version,
 
 /* Single lock used by all memory monitors and MR caches. */
 extern pthread_mutex_t mm_lock;
+/* The read-write lock is an additional lock used to protect the dlist_entry
+ * list of ofi_mem_monitor. Due to the necessity of releasing the mm_lock
+ * while walking the dlist in ofi_monitor_notify, we need a separate lock to
+ * ensure thread safety. This must be a read-write lock because
+ * ofi_monitor_notify may be recursive and cannot block multiple walks from
+ * occurring at the same time.
+ */
+extern pthread_rwlock_t mm_list_rwlock;
 
 /*
  * Memory notifier - Report memory mapping changes to address ranges

--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -276,7 +276,7 @@ static void rocr_mm_unsubscribe(struct ofi_mem_monitor *monitor,
 
 		ofi_monitor_notify(rocr_monitor, entry->iov.iov_base,
 				   entry->iov.iov_len);
-
+		ofi_monitor_flush(rocr_monitor);
 		FI_DBG(&core_prov, FI_LOG_MR,
 		       "ROCR buffer address %p length %lu unsubscribed\n",
 		       entry->iov.iov_base, entry->iov.iov_len);

--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Hewlett Packard Enterprise Development LP
+ * Copyright (c) 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -130,9 +131,11 @@ static void rocr_mm_dealloc_cb(void *addr, void *user_data)
 {
 	size_t len = (size_t) user_data;
 
+	pthread_rwlock_rdlock(&mm_list_rwlock);
 	pthread_mutex_lock(&mm_lock);
 	ofi_monitor_unsubscribe(rocr_monitor, addr, len, NULL);
 	pthread_mutex_unlock(&mm_lock);
+	pthread_rwlock_unlock(&mm_list_rwlock);
 }
 
 static void rocr_mm_entry_free(struct rocr_mm_entry *entry)

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -375,6 +375,7 @@ void ofi_intercept_handler(const void *addr, size_t len)
 	pthread_rwlock_rdlock(&mm_list_rwlock);
 	pthread_mutex_lock(&mm_lock);
 	ofi_monitor_notify(memhooks_monitor, addr, len);
+	ofi_monitor_flush(memhooks_monitor);
 	pthread_mutex_unlock(&mm_lock);
 	pthread_rwlock_unlock(&mm_list_rwlock);
 }

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -372,9 +372,11 @@ static int ofi_intercept_symbol(struct ofi_intercept *intercept)
 
 void ofi_intercept_handler(const void *addr, size_t len)
 {
+	pthread_rwlock_rdlock(&mm_list_rwlock);
 	pthread_mutex_lock(&mm_lock);
 	ofi_monitor_notify(memhooks_monitor, addr, len);
 	pthread_mutex_unlock(&mm_lock);
+	pthread_rwlock_unlock(&mm_list_rwlock);
 }
 
 static void *ofi_intercept_mmap(void *start, size_t length,

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -347,7 +347,15 @@ void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
 #include <sys/ioctl.h>
 #include <linux/userfaultfd.h>
 
-
+/* The userfault fd monitor requires for events that could
+ * trigger it to be handled outside of the monitor functions
+ * itself. When a fault occurs on a monitored region, the
+ * faulting thread is put to sleep until the event is read
+ * via the userfault file descriptor. If this fault occurs
+ * within the userfault handling thread, no threads will
+ * read this event and our threads cannot progress, resulting
+ * in a hang.
+ */
 static void *ofi_uffd_handler(void *arg)
 {
 	struct uffd_msg msg;


### PR DESCRIPTION
Depending on monitor behavior, some monitors require calls that may
result in a free operation (for example memory deregistration), to be
deferred until outside of the monitor. This patch adds a flag and only
requests free deferral if necessary.

Signed-off-by: William Zhang <wilzhang@amazon.com>