### PR TITLE
prov/efa: bugfixes for local read

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -225,6 +225,7 @@ enum rxr_lower_ep_type {
 enum rxr_x_entry_type {
 	RXR_TX_ENTRY = 1,
 	RXR_RX_ENTRY,
+	RXR_LOCAL_READ_ENTRY,
 };
 
 enum rxr_tx_comm_type {
@@ -599,6 +600,8 @@ struct rxr_ep {
 	struct ofi_bufpool *readrsp_tx_entry_pool;
 	/* data structure to maintain read */
 	struct ofi_bufpool *read_entry_pool;
+	/* data structure to maintain local read */
+	struct ofi_bufpool *local_read_entry_pool;
 	/* data structure to maintain pkt rx map */
 	struct ofi_bufpool *map_entry_pool;
 	/* rxr medium message pkt_entry to rx_entry map */
@@ -623,6 +626,8 @@ struct rxr_ep {
 	struct dlist_entry tx_pending_list;
 	/* read entries with data to be read */
 	struct dlist_entry read_pending_list;
+	/* local read entries with data to be read */
+	struct dlist_entry local_read_pending_list;
 	/* rxr_peer entries that are in backoff due to RNR */
 	struct dlist_entry peer_backoff_list;
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1198,18 +1198,19 @@ int rxr_ep_init(struct rxr_ep *ep)
 		goto err_free_tx_pool;
 
 	if (rxr_env.rx_copy_unexp) {
-		ret = rxr_create_pkt_pool(ep, entry_sz,
-					  0, rxr_get_rx_pool_chunk_cnt(ep),
-					  0, &ep->rx_unexp_pkt_pool);
+		ret = ofi_bufpool_create(&ep->rx_unexp_pkt_pool, entry_sz,
+					 RXR_BUF_POOL_ALIGNMENT,
+					 0, rxr_get_rx_pool_chunk_cnt(ep),
+					 0);
 		if (ret)
 			goto err_free_rx_pool;
 	}
 
 	if (rxr_env.rx_copy_ooo) {
-		ret = rxr_create_pkt_pool(ep, entry_sz,
-					  0, rxr_env.recvwin_size,
-					  0, &ep->rx_ooo_pkt_pool);
-
+		ret = ofi_bufpool_create(&ep->rx_ooo_pkt_pool, entry_sz,
+					 RXR_BUF_POOL_ALIGNMENT,
+					 0, rxr_env.recvwin_size,
+					 0);
 		if (ret)
 			goto err_free_rx_unexp_pool;
 	}

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -477,6 +477,7 @@ ssize_t rxr_pkt_post_read_to_copy_data(struct rxr_ep *rxr_ep,
 	int iov_idx;
 	size_t iov_offset, pkt_offset;
 	void *dest_buf;
+	struct rxr_peer *peer;
 	struct rxr_pkt_entry *pkt_entry_copy;
 
 	assert(pkt_entry->x_entry == rx_entry);
@@ -533,6 +534,8 @@ ssize_t rxr_pkt_post_read_to_copy_data(struct rxr_ep *rxr_ep,
 		return err;
 	}
 
+	peer = rxr_ep_get_peer(rxr_ep, rxr_ep->rdm_self_addr);
+	rxr_ep_inc_tx_pending(rxr_ep, peer);
 	return 0;
 }
 
@@ -618,6 +621,8 @@ void rxr_pkt_handle_send_completion(struct rxr_ep *ep, struct fi_cq_data_entry *
 	pkt_entry = (struct rxr_pkt_entry *)comp->op_context;
 	if (pkt_entry->state == RXR_PKT_ENTRY_READING) {
 		rxr_pkt_handle_data_copied(ep, pkt_entry);
+		peer = rxr_ep_get_peer(ep, ep->rdm_self_addr);
+		rxr_ep_dec_tx_pending(ep, peer, 0);
 		return;
 	}
 

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -35,14 +35,18 @@
 #define _RXR_PKT_CMD_H
 
 #include "rxr.h"
+#include "rxr_read.h"
 
 ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry);
 
 ssize_t rxr_pkt_post_ctrl(struct rxr_ep *ep, int entry_type, void *x_entry,
 			  int ctrl_type, bool inject);
 
+
 ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry,
 				   int ctrl_type, bool inject);
+
+ssize_t rxr_pkt_post_local_read(struct rxr_ep *ep, struct rxr_local_read_entry *local_read_entry);
 
 void rxr_pkt_proc_data(struct rxr_ep *rxr_ep, struct rxr_rx_entry *rx_entry,
 		       size_t data_offset, struct rxr_pkt_entry *pkt_eentry,

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -199,9 +199,8 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
 			int new_entry_type)
 {
 	FI_DBG(&rxr_prov, FI_LOG_EP_CTRL,
-	       "Copying packet out of posted buffer! new_entry_type: %d\n",
-		new_entry_type);
-	assert(src->type == RXR_PKT_ENTRY_POSTED);
+	       "copy pkt entry! old_entry_type: %d new_entry_type: %d\n",
+		src->type, new_entry_type);
 	dlist_init(&dest->entry);
 #if ENABLE_DEBUG
 	dlist_init(&dest->dbg_entry);
@@ -271,7 +270,8 @@ struct rxr_pkt_entry *rxr_pkt_entry_clone(struct rxr_ep *ep,
 
 	assert(src);
 	assert(new_entry_type == RXR_PKT_ENTRY_OOO ||
-	       new_entry_type == RXR_PKT_ENTRY_UNEXP);
+	       new_entry_type == RXR_PKT_ENTRY_UNEXP ||
+	       new_entry_type == RXR_PKT_ENTRY_READ_COPY);
 
 	dst = rxr_pkt_entry_alloc(ep, pkt_pool);
 	if (!dst)

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -41,9 +41,9 @@ enum rxr_pkt_entry_state {
 	RXR_PKT_ENTRY_FREE = 0,
 	RXR_PKT_ENTRY_IN_USE,
 	RXR_PKT_ENTRY_RNR_RETRANSMIT,
-	RXR_PKT_ENTRY_COPY_BY_READ, /* entries contain data. A read request has been posted to copy
-				     * to receiving buffer
-				     */
+	RXR_PKT_ENTRY_READING, /* entries contain data. A read request has been posted to copy
+				* to receiving buffer
+				*/
 };
 
 /* pkt_entry types for rx pkts */
@@ -51,7 +51,8 @@ enum rxr_pkt_entry_type {
 	RXR_PKT_ENTRY_POSTED = 1,   /* entries that are posted to the device from the RX bufpool */
 	RXR_PKT_ENTRY_UNEXP,        /* entries used to stage unexpected msgs */
 	RXR_PKT_ENTRY_OOO,	    /* entries used to stage out-of-order RTM or RTA */
-	RXR_PKT_ENTRY_USER	    /* entries backed by user-provided msg prefix (FI_MSG_PREFIX)*/
+	RXR_PKT_ENTRY_USER,	    /* entries backed by user-provided msg prefix (FI_MSG_PREFIX)*/
+	RXR_PKT_ENTRY_READ_COPY,    /* entries used to stage copy by read */
 };
 
 struct rxr_pkt_sendv {

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -238,7 +238,8 @@ void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 					 struct rxr_pkt_entry *pkt_entry);
 
 void rxr_data_pkt_handle_data_copied(struct rxr_ep *ep,
-				     struct rxr_pkt_entry *pkt_entry);
+				     struct rxr_pkt_entry *pkt_entry,
+				     struct rxr_rx_entry *rx_entry);
 
 void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -239,15 +239,13 @@ void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 		rxr_cq_handle_tx_completion(ep, tx_entry);
 }
 
-void rxr_data_pkt_handle_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+void rxr_data_pkt_handle_data_copied(struct rxr_ep *ep,
+				     struct rxr_pkt_entry *pkt_entry,
+				     struct rxr_rx_entry *rx_entry)
 {
 	int pkt_type;
-	struct rxr_rx_entry *rx_entry;
 	struct rxr_peer *peer;
 	ssize_t err, seg_size, bytes_left;
-
-	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
-	assert(rx_entry);
 
 	pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
 	assert(pkt_type == RXR_DATA_PKT || pkt_type == RXR_READRSP_PKT);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -768,11 +768,10 @@ struct rxr_rx_entry *rxr_pkt_get_tagrtm_rx_entry(struct rxr_ep *ep,
 /*
  * handle_data_copied() functions for RTM packets
  */
-void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep,
+					  struct rxr_pkt_entry *pkt_entry,
+					  struct rxr_rx_entry *rx_entry)
 {
-	struct rxr_rx_entry *rx_entry;
-
-	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
 	assert(rx_entry);
 
 	/* rxr_cq_handle_rx_completion release pkt_entry */
@@ -781,12 +780,12 @@ void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entr
 	rxr_release_rx_entry(ep, rx_entry);
 }
 
-void rxr_pkt_handle_medium_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+void rxr_pkt_handle_medium_rtm_data_copied(struct rxr_ep *ep,
+					   struct rxr_pkt_entry *pkt_entry,
+					   struct rxr_rx_entry *rx_entry)
 {
-	struct rxr_rx_entry *rx_entry;
 	size_t data_size;
 
-	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
 	assert(rx_entry);
 	data_size = pkt_entry->pkt_size - rxr_pkt_req_hdr_size(pkt_entry);
 
@@ -804,13 +803,13 @@ void rxr_pkt_handle_medium_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_ent
 	}
 }
 
-void rxr_pkt_handle_long_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+void rxr_pkt_handle_long_rtm_data_copied(struct rxr_ep *ep,
+					 struct rxr_pkt_entry *pkt_entry,
+					 struct rxr_rx_entry *rx_entry)
 {
-	struct rxr_rx_entry *rx_entry;
 	size_t data_size;
 	int err;
 
-	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
 	assert(rx_entry);
 	data_size = pkt_entry->pkt_size - rxr_pkt_req_hdr_size(pkt_entry);
 
@@ -1332,12 +1331,9 @@ void rxr_pkt_handle_long_rtw_send_completion(struct rxr_ep *ep,
  *     handle_data_copied() functions for RTW packets
  */
 void rxr_pkt_handle_eager_rtw_data_copied(struct rxr_ep *ep,
-					  struct rxr_pkt_entry *pkt_entry)
+					  struct rxr_pkt_entry *pkt_entry,
+					  struct rxr_rx_entry *rx_entry)
 {
-	struct rxr_rx_entry *rx_entry;
-
-	rx_entry = pkt_entry->x_entry;
-
 	if (rx_entry->cq_entry.flags & FI_REMOTE_CQ_DATA)
 		rxr_cq_write_rx_completion(ep, rx_entry);
 
@@ -1346,13 +1342,12 @@ void rxr_pkt_handle_eager_rtw_data_copied(struct rxr_ep *ep,
 }
 
 void rxr_pkt_handle_long_rtw_data_copied(struct rxr_ep *ep,
-					 struct rxr_pkt_entry *pkt_entry)
+					 struct rxr_pkt_entry *pkt_entry,
+					 struct rxr_rx_entry *rx_entry)
 {
 	int err;
 	size_t data_size;
-	struct rxr_rx_entry *rx_entry;
 
-	rx_entry = pkt_entry->x_entry;
 	assert(rx_entry);
 	data_size = pkt_entry->pkt_size - rxr_pkt_req_hdr_size(pkt_entry);
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -333,30 +333,23 @@ void rxr_pkt_handle_read_rtm_send_completion(struct rxr_ep *ep,
  * handle_data_copied() functions for RTM packet types.
  * Note: read rtm does not contain data, so does not have such a handler.
  */
-void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep,
+					  struct rxr_pkt_entry *pkt_entry,
+					  struct rxr_rx_entry *rx_entry);
 
-void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void rxr_pkt_handle_medium_rtm_data_copied(struct rxr_ep *ep,
+					  struct rxr_pkt_entry *pkt_entry,
+					  struct rxr_rx_entry *rx_entry);
 
-void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
+void rxr_pkt_handle_long_rtm_data_copied(struct rxr_ep *ep,
+					 struct rxr_pkt_entry *pkt_entry,
+					 struct rxr_rx_entry *rx_entry);
 
 /*
  *   proc() functions for RTM packet types
  */
 void rxr_pkt_rtm_init_rx_entry(struct rxr_pkt_entry *pkt_entry,
 			       struct rxr_rx_entry *rx_entry);
-
-/*         This function is called by both
- *            rxr_pkt_handle_rtm_recv() and
- *            rxr_msg_handle_unexp_match()
- */
-void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep,
-					  struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_medium_rtm_data_copied(struct rxr_ep *ep,
-					   struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_long_rtm_data_copied(struct rxr_ep *ep,
-					 struct rxr_pkt_entry *pkt_entry);
 
 ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 				 struct rxr_rx_entry *rx_entry,
@@ -487,10 +480,12 @@ void rxr_pkt_handle_read_rtw_send_completion(struct rxr_ep *ep,
  *     handle_data_copied() functions for RTW packets
  */
 void rxr_pkt_handle_eager_rtw_data_copied(struct rxr_ep *ep,
-					  struct rxr_pkt_entry *pkt_entry);
+					  struct rxr_pkt_entry *pkt_entry,
+					  struct rxr_rx_entry *rx_entry);
 
 void rxr_pkt_handle_long_rtw_data_copied(struct rxr_ep *ep,
-					 struct rxr_pkt_entry *pkt_entry);
+					 struct rxr_pkt_entry *pkt_entry,
+					 struct rxr_rx_entry *rx_entry);
 /*
  *     handle_recv() functions
  */

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -97,5 +97,17 @@ void rxr_read_handle_read_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pk
 
 int rxr_read_handle_error(struct rxr_ep *ep, struct rxr_read_entry *read_entry, int ret);
 
+struct rxr_local_read_entry {
+	enum rxr_x_entry_type x_entry_type;
+	struct rxr_pkt_entry *pkt_entry;
+	char *data;
+	size_t data_size;
+
+	struct rxr_rx_entry *rx_entry;
+	size_t data_offset;
+
+	struct dlist_entry pending_entry;
+};
+
 #endif
 


### PR DESCRIPTION
This PR contain 3 patches for the local read:

1. use separate pool to support local read

2. adjust tx pending counter for local read.

3. queue local read when EAGIN happened.

Signed-off-by: Wei Zhang <wzam@amazon.com>