### PR TITLE
prov/rxm: Revert HMEM changes to capability bits

### DIFF
--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -35,12 +35,10 @@
 
 #define RXM_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | \
 		     FI_ATOMICS)
-#define RXM_TX_HMEM_CAPS (RXM_TX_CAPS | FI_HMEM)
 
 #define RXM_RX_CAPS (FI_SOURCE | OFI_RX_MSG_CAPS | FI_TAGGED | \
 		     OFI_RX_RMA_CAPS | FI_ATOMICS | FI_DIRECTED_RECV | \
 		     FI_MULTI_RECV)
-#define RXM_RX_HMEM_CAPS (RXM_RX_CAPS | FI_HMEM)
 
 #define RXM_DOMAIN_CAPS (FI_LOCAL_COMM | FI_REMOTE_COMM)
 
@@ -51,7 +49,7 @@
  * requested by the app. */
 
 struct fi_tx_attr rxm_tx_attr = {
-	.caps = RXM_TX_HMEM_CAPS,
+	.caps = RXM_TX_CAPS,
 	.op_flags = RXM_PASSTHRU_TX_OP_FLAGS | RXM_TX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
@@ -61,7 +59,7 @@ struct fi_tx_attr rxm_tx_attr = {
 };
 
 struct fi_rx_attr rxm_rx_attr = {
-	.caps = RXM_RX_HMEM_CAPS,
+	.caps = RXM_RX_CAPS,
 	.op_flags = RXM_PASSTHRU_RX_OP_FLAGS | RXM_RX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
@@ -161,7 +159,7 @@ struct fi_info rxm_coll_info = {
 };
 
 struct fi_info rxm_base_info = {
-	.caps = RXM_TX_HMEM_CAPS | RXM_RX_HMEM_CAPS | RXM_DOMAIN_CAPS,
+	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxm_tx_attr,
 	.rx_attr = &rxm_rx_attr,
@@ -183,7 +181,7 @@ struct fi_info rxm_tcp_info = {
 };
 
 struct fi_info rxm_verbs_info = {
-	.caps = RXM_TX_HMEM_CAPS | RXM_RX_HMEM_CAPS | RXM_DOMAIN_CAPS,
+	.caps = RXM_TX_CAPS | RXM_RX_CAPS | RXM_DOMAIN_CAPS,
 	.addr_format = FI_SOCKADDR,
 	.tx_attr = &rxm_tx_attr,
 	.rx_attr = &rxm_rx_attr,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -85,13 +85,13 @@ void rxm_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
 		else
 			core_info->domain_attr->mr_mode |=
 				hints->domain_attr->mr_mode;
-	}
 
-	/* RxM is setup to support FI_HMEM with the core provider requiring
-	 * FI_MR_HMEM. Always set this MR mode bit.
-	 */
-	if (hints && hints->caps & FI_HMEM)
-		core_info->domain_attr->mr_mode |= FI_MR_HMEM;
+		/* RxM is setup to support FI_HMEM with the core provider requiring
+		 * FI_MR_HMEM. Always set this MR mode bit.
+		 */
+		if (hints && hints->caps & FI_HMEM)
+			core_info->domain_attr->mr_mode |= FI_MR_HMEM;
+	}
 }
 
 int rxm_info_to_core(uint32_t version, const struct fi_info *hints,


### PR DESCRIPTION
Disable FI_HMEM support from rxm by removing the capability bits.
This fixes a regression where rxm over verbs fails CI validation.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>