### PR TITLE
prov/shm: register signals with SA_ONSTACK

### DIFF
--- a/prov/shm/src/smr_signal.h
+++ b/prov/shm/src/smr_signal.h
@@ -71,7 +71,7 @@ static void smr_reg_sig_hander(int signum)
 
 	memset(&action, 0, sizeof(action));
 	action.sa_sigaction = smr_handle_signal;
-	action.sa_flags |= SA_SIGINFO;
+	action.sa_flags |= SA_SIGINFO | SA_ONSTACK;
 
 	ret = sigaction(signum, &action, &old_action[signum]);
 	if (ret)


### PR DESCRIPTION
Because of signal stack limitations for languages such
as Go that might create alternate stacks, use the flag
SA_ONSTACK to use the signal stack

Signed-off-by: aingerson <alexia.ingerson@intel.com>