### PR TITLE
prov/efa: Revert 2 commits

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -521,9 +521,6 @@ struct rxr_ep {
 	struct fid_ep *rdm_ep;
 	struct fid_cq *rdm_cq;
 
-	/* address of myself in my AV, used to post read to my self */
-	fi_addr_t rdm_self_addr;
-
 	/* shm provider fid */
 	bool use_shm;
 	struct fid_ep *shm_ep;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -890,7 +890,6 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 	ssize_t ret;
 	size_t i;
 	struct rxr_ep *ep;
-	struct efa_ep *efa_ep;
 	uint64_t flags = FI_MORE;
 	size_t rx_size, shm_rx_size;
 	char shm_ep_name[NAME_MAX];
@@ -963,17 +962,6 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 				if (ret)
 					goto out;
 			}
-		}
-
-		/*
-		 * insert EP's own address to AV and save the address as
-		 * ep->rdm_self_addr. It is used when copy data to GPU memory by local read
-		 */
-		efa_ep = container_of(ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
-		ret = efa_av_insert_addr(efa_ep->av, (struct efa_ep_addr *)ep->core_addr,
-					 &ep->rdm_self_addr, 0, NULL);
-		if (OFI_UNLIKELY(ret)) {
-			FI_WARN(&rxr_prov, FI_LOG_CQ, "insert EP's own address failed!\n");
 		}
 
 out:
@@ -1723,8 +1711,6 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  &rxr_ep->rdm_ep, rxr_ep);
 	if (ret)
 		goto err_free_rdm_info;
-
-	rxr_ep->rdm_self_addr = FI_ADDR_NOTAVAIL;
 
 	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
 				  util_domain.domain_fid);

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -44,10 +44,6 @@ ssize_t rxr_pkt_post_ctrl(struct rxr_ep *ep, int entry_type, void *x_entry,
 ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry,
 				   int ctrl_type, bool inject);
 
-void rxr_pkt_proc_data(struct rxr_ep *rxr_ep, struct rxr_rx_entry *rx_entry,
-		       size_t data_offset, struct rxr_pkt_entry *pkt_eentry,
-		       char *data, size_t data_size);
-
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep,
 				    struct fi_cq_data_entry *cq_entry);
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -41,9 +41,6 @@ enum rxr_pkt_entry_state {
 	RXR_PKT_ENTRY_FREE = 0,
 	RXR_PKT_ENTRY_IN_USE,
 	RXR_PKT_ENTRY_RNR_RETRANSMIT,
-	RXR_PKT_ENTRY_COPY_BY_READ, /* entries contain data. A read request has been posted to copy
-				     * to receiving buffer
-				     */
 };
 
 /* pkt_entry types for rx pkts */

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -234,11 +234,15 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 			       struct rxr_tx_entry *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry);
 
+int rxr_pkt_proc_data(struct rxr_ep *ep,
+		      struct rxr_rx_entry *rx_entry,
+		      struct rxr_pkt_entry *pkt_entry,
+		      char *data, size_t seg_offset,
+		      size_t seg_size);
+
 void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 					 struct rxr_pkt_entry *pkt_entry);
 
-void rxr_data_pkt_handle_data_copied(struct rxr_ep *ep,
-				     struct rxr_pkt_entry *pkt_entry);
 
 void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
 			      struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -239,20 +239,44 @@ void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 		rxr_cq_handle_tx_completion(ep, tx_entry);
 }
 
-void rxr_data_pkt_handle_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
+/*
+ *  rxr_pkt_handle_data_recv() and related functions
+ */
+int rxr_pkt_proc_data(struct rxr_ep *ep,
+		      struct rxr_rx_entry *rx_entry,
+		      struct rxr_pkt_entry *pkt_entry,
+		      char *data, size_t seg_offset,
+		      size_t seg_size)
 {
-	int pkt_type;
-	struct rxr_rx_entry *rx_entry;
 	struct rxr_peer *peer;
-	ssize_t err, seg_size, bytes_left;
+	struct efa_mr *desc;
+	int64_t bytes_left, bytes_copied;
+	ssize_t ret = 0;
 
-	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
-	assert(rx_entry);
+#if ENABLE_DEBUG
+	int pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
 
-	pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
 	assert(pkt_type == RXR_DATA_PKT || pkt_type == RXR_READRSP_PKT);
-	seg_size = (pkt_type == RXR_DATA_PKT) ? rxr_get_data_pkt(pkt_entry->pkt)->hdr.seg_size
-					      : rxr_get_readrsp_hdr(pkt_entry->pkt)->seg_size;
+#endif
+	/* we are sinking message for CANCEL/DISCARD entry */
+	if (OFI_LIKELY(!(rx_entry->rxr_flags & RXR_RECV_CANCEL)) &&
+	    rx_entry->cq_entry.len > seg_offset) {
+		desc = rx_entry->desc[0];
+		bytes_copied = ofi_copy_to_hmem_iov(desc ? desc->peer.iface : FI_HMEM_SYSTEM,
+						    desc ? desc->peer.device.reserved : 0,
+						    rx_entry->iov,
+						    rx_entry->iov_count,
+						    seg_offset,
+						    data,
+						    seg_size);
+
+		if (bytes_copied != MIN(seg_size, rx_entry->cq_entry.len - seg_offset)) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ, "wrong size! bytes_copied: %ld\n",
+				bytes_copied);
+			if (rxr_cq_handle_rx_error(ep, rx_entry, -FI_EINVAL))
+				assert(0 && "error writing error cq entry for EOR\n");
+		}
+	}
 
 	rx_entry->bytes_done += seg_size;
 
@@ -280,20 +304,16 @@ void rxr_data_pkt_handle_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pk
 
 		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 		rxr_release_rx_entry(ep, rx_entry);
-		return;
+		return 0;
 	}
 
 	if (!rx_entry->window) {
 		assert(rx_entry->state == RXR_RX_RECV);
-		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
-		if (OFI_UNLIKELY(err)) {
-			FI_WARN(&rxr_prov, FI_LOG_CQ, "Cannot post CTS packet\n");
-			rxr_cq_handle_rx_error(ep, rx_entry, err);
-			rxr_release_rx_entry(ep, rx_entry);
-		}
+		ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
 	}
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
+	return ret;
 }
 
 void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
@@ -308,9 +328,9 @@ void rxr_pkt_handle_data_recv(struct rxr_ep *ep,
 					data_pkt->hdr.rx_id);
 
 	rxr_pkt_proc_data(ep, rx_entry,
-			  data_pkt->hdr.seg_offset,
 			  pkt_entry,
 			  data_pkt->data,
+			  data_pkt->hdr.seg_offset,
 			  data_pkt->hdr.seg_size);
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -316,10 +316,9 @@ void rxr_pkt_handle_readrsp_recv(struct rxr_ep *ep,
 	rx_entry = ofi_bufpool_get_ibuf(ep->rx_entry_pool, readrsp_hdr->rx_id);
 	assert(rx_entry->cq_entry.flags & FI_READ);
 	rx_entry->tx_id = readrsp_hdr->tx_id;
-	rxr_pkt_proc_data(ep, rx_entry, 0,
-			  pkt_entry,
+	rxr_pkt_proc_data(ep, rx_entry, pkt_entry,
 			  readrsp_pkt->data,
-			  readrsp_hdr->seg_size);
+			  0, readrsp_hdr->seg_size);
 }
 
 /*  RMA_CONTEXT packet functions

--- a/prov/efa/src/rxr/rxr_pkt_type_req.h
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.h
@@ -330,16 +330,6 @@ void rxr_pkt_handle_read_rtm_send_completion(struct rxr_ep *ep,
 }
 
 /*
- * handle_data_copied() functions for RTM packet types.
- * Note: read rtm does not contain data, so does not have such a handler.
- */
-void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
-
-/*
  *   proc() functions for RTM packet types
  */
 void rxr_pkt_rtm_init_rx_entry(struct rxr_pkt_entry *pkt_entry,
@@ -349,15 +339,6 @@ void rxr_pkt_rtm_init_rx_entry(struct rxr_pkt_entry *pkt_entry,
  *            rxr_pkt_handle_rtm_recv() and
  *            rxr_msg_handle_unexp_match()
  */
-void rxr_pkt_handle_eager_rtm_data_copied(struct rxr_ep *ep,
-					  struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_medium_rtm_data_copied(struct rxr_ep *ep,
-					   struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_long_rtm_data_copied(struct rxr_ep *ep,
-					 struct rxr_pkt_entry *pkt_entry);
-
 ssize_t rxr_pkt_proc_matched_rtm(struct rxr_ep *ep,
 				 struct rxr_rx_entry *rx_entry,
 				 struct rxr_pkt_entry *pkt_entry);
@@ -483,14 +464,6 @@ void rxr_pkt_handle_read_rtw_send_completion(struct rxr_ep *ep,
 {
 }
 
-/*
- *     handle_data_copied() functions for RTW packets
- */
-void rxr_pkt_handle_eager_rtw_data_copied(struct rxr_ep *ep,
-					  struct rxr_pkt_entry *pkt_entry);
-
-void rxr_pkt_handle_long_rtw_data_copied(struct rxr_ep *ep,
-					 struct rxr_pkt_entry *pkt_entry);
 /*
  *     handle_recv() functions
  */

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -44,9 +44,6 @@ enum rxr_read_entry_state {
 	RXR_RDMA_ENTRY_PENDING
 };
 
-int rxr_locate_iov_pos(struct iovec *iov, int iov_count, size_t offset,
-		       int *iov_idx, size_t *iov_offset);
-
 /* rxr_read_entry was arranged as a packet
  * and was put in a rxr_pkt_entry. Because rxr_pkt_entry is used
  * as context.


### PR DESCRIPTION
This PR revert two recent commits:

76b77fb: register memory of rx_ooo_pkt_pool and rx_unexp_pkt_pool
We noticed registration of rx_ooo_pkt_pool can fail when running some test

f8fb944: use fi_read to copy data to gpu buffer
This commit depend on 76b77fb