### PR TITLE
contrib/cray: Updating batsgenerator.sh script

### DIFF
--- a/contrib/cray/bats/batsgenerator.sh
+++ b/contrib/cray/bats/batsgenerator.sh
@@ -7,6 +7,7 @@
 
 # Insert shebang and load test helper
 shebang="#!/usr/bin/env bats\n\n"
+fi_env="export XRC_FI_ENV=\"FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_\$\$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1\"\n\n"
 
 # Command line input: test suite
 # E.g. IMB-EXT
@@ -32,18 +33,20 @@ shift
 # E.g. imb.bats
 bats_file=$1
 
-# Add test to .bats file
-if [ -f "${bats_file}" ]; then
-        sed -e "s/@TEST_SUITE@/${test_suite}/g" \
-        -e "s/@BENCHMARK@/${benchmark}/g" \
-        -e "s/@RANKS@/${num_ranks}/g" \
-        -e "s/@RPN@/${num_rpn}/g" \
-        benchmark.template >> ${bats_file}
+shift
+if [[ $# -gt 0 ]] ; then
+       iter_flag=" -iter $1"
 else
-        printf "${shebang}load test_helper\n\n" >> ${bats_file}
-        sed -e "s/@TEST_SUITE@/${test_suite}/g" \
-        -e "s/@BENCHMARK@/${benchmark}/g" \
-        -e "s/@RANKS@/${num_ranks}/g" \
-        -e "s/@RPN@/${num_rpn}/g" \
-        benchmark.template >> ${bats_file}
+       iter_flag=""
 fi
+
+if [ ! -f "${bats_file}" ]; then
+        printf "${shebang}load test_helper\n\n${fi_env}" >> ${bats_file}
+fi
+
+sed -e "s/@TEST_SUITE@/${test_suite}/g" \
+    -e "s/@BENCHMARK@/${benchmark}/g" \
+    -e "s/@RANKS@/${num_ranks}/g" \
+    -e "s/@RPN@/${num_rpn}/g" \
+    -e "s/@ITER_FLAG@/${iter_flag}/g" \
+    benchmark.template >> ${bats_file}

--- a/contrib/cray/bats/benchmark.template
+++ b/contrib/cray/bats/benchmark.template
@@ -1,13 +1,14 @@
-# RC                                                                                                                                     
+# RC
 @test "@TEST_SUITE@ @BENCHMARK@ @RANKS@ ranks, @RPN@ ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher @RANKS@ @RPN@) timeout 300 "$IMB_BUILD_PATH/@TEST_SUITE@ -npmin @RANKS@ -iter 100 -time 10 -mem 2 -msglog 2:18 @BENCHMARK@"
+                $(batch_launcher @RANKS@ @RPN@) timeout 300 "$IMB_BUILD_PATH/@TEST_SUITE@ -npmin @RANKS@@ITER_FLAG@ -time 10 -mem 2 -msglog 2:18 @BENCHMARK@"
         [ "$status" -eq 0 ]
 }
 
 # XRC
 @test "@TEST_SUITE@ @BENCHMARK@ @RANKS@ ranks, @RPN@ ranks per node using XRC verbs" {
-        FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
-                $(batch_launcher @RANKS@ @RPN@) timeout 300 "$IMB_BUILD_PATH/@TEST_SUITE@ -npmin @RANKS@ -iter 100 -time 10 -mem 2 -msglog 2:18 @BENCHMARK@"
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+                $(batch_launcher @RANKS@ @RPN@) timeout 300 "$IMB_BUILD_PATH/@TEST_SUITE@ -npmin @RANKS@@ITER_FLAG@ -time 10 -mem 2 -msglog 2:18 @BENCHMARK@"
         [ "$status" -eq 0 ]
 }

--- a/contrib/cray/bats/imb.bats
+++ b/contrib/cray/bats/imb.bats
@@ -2,7 +2,9 @@
 
 load test_helper
 
-# RC                                                                                                                                     
+export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1"
+
+# RC
 @test "IMB-P2P unirandom 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 unirandom"
@@ -11,11 +13,12 @@ load test_helper
 
 # XRC
 @test "IMB-P2P unirandom 2 ranks, 1 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 unirandom"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-P2P birandom 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 birandom"
@@ -24,11 +27,12 @@ load test_helper
 
 # XRC
 @test "IMB-P2P birandom 2 ranks, 1 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 birandom"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-P2P corandom 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 corandom"
@@ -37,11 +41,12 @@ load test_helper
 
 # XRC
 @test "IMB-P2P corandom 2 ranks, 1 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 corandom"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-RMA bidir_get 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_get"
@@ -50,11 +55,12 @@ load test_helper
 
 # XRC
 @test "IMB-RMA bidir_get 2 ranks, 1 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_get"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-RMA bidir_put 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_put"
@@ -63,11 +69,12 @@ load test_helper
 
 # XRC
 @test "IMB-RMA bidir_put 2 ranks, 1 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_put"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-RMA unidir_get 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_get"
@@ -76,11 +83,12 @@ load test_helper
 
 # XRC
 @test "IMB-RMA unidir_get 2 ranks, 1 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_get"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-RMA unidir_put 2 ranks, 1 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_put"
@@ -89,11 +97,12 @@ load test_helper
 
 # XRC
 @test "IMB-RMA unidir_put 2 ranks, 1 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_put"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-EXT window 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 window"
@@ -102,11 +111,12 @@ load test_helper
 
 # XRC
 @test "IMB-EXT window 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 window"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-EXT accumulate 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 accumulate"
@@ -115,11 +125,12 @@ load test_helper
 
 # XRC
 @test "IMB-EXT accumulate 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 accumulate"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ialltoall 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall"
@@ -128,11 +139,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ialltoall 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ialltoall_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall_pure"
@@ -141,11 +153,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ialltoall_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ialltoallv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv"
@@ -154,11 +167,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ialltoallv 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ialltoallv_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv_pure"
@@ -167,11 +181,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ialltoallv_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iallgather 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather"
@@ -180,11 +195,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iallgather 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iallgather_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather_pure"
@@ -193,11 +209,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iallgather_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iallgatherv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv"
@@ -206,11 +223,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iallgatherv 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iallgatherv_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv_pure"
@@ -219,11 +237,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iallgatherv_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iallreduce 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce"
@@ -232,11 +251,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iallreduce 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iallreduce_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce_pure"
@@ -245,11 +265,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iallreduce_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ibarrier 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier"
@@ -258,11 +279,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ibarrier 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ibarrier_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier_pure"
@@ -271,11 +293,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ibarrier_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ibcast 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast"
@@ -284,11 +307,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ibcast 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ibcast_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast_pure"
@@ -297,11 +321,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ibcast_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC igather 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather"
@@ -310,11 +335,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC igather 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC igather_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather_pure"
@@ -323,11 +349,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC igather_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC igatherv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv"
@@ -336,11 +363,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC igatherv 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC igatherv_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv_pure"
@@ -349,11 +377,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC igatherv_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ireduce 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce"
@@ -362,11 +391,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ireduce 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ireduce_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_pure"
@@ -375,11 +405,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ireduce_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC ireduce_scatter 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_scatter"
@@ -388,11 +419,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC ireduce_scatter 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_scatter"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iscatter 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter"
@@ -401,11 +433,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iscatter 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iscatter_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter_pure"
@@ -414,11 +447,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iscatter_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iscatterv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv"
@@ -427,11 +461,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iscatterv 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-NBC iscatterv_pure 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv_pure"
@@ -440,11 +475,12 @@ load test_helper
 
 # XRC
 @test "IMB-NBC iscatterv_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv_pure"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 reduce 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce"
@@ -453,11 +489,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 reduce 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 reduce_scatter 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter"
@@ -466,11 +503,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 reduce_scatter 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 reduce_scatter_block 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter_block"
@@ -479,11 +517,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 reduce_scatter_block 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter_block"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 allreduce 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allreduce"
@@ -492,11 +531,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 allreduce 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allreduce"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 allgather 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgather"
@@ -505,11 +545,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 allgather 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgather"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 allgatherv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgatherv"
@@ -518,11 +559,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 allgatherv 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgatherv"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 scatter 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatter"
@@ -531,11 +573,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 scatter 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatter"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 scatterv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatterv"
@@ -544,11 +587,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 scatterv 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatterv"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 gather 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gather"
@@ -557,11 +601,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 gather 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gather"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 gatherv 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gatherv"
@@ -570,11 +615,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 gatherv 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gatherv"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 alltoall 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 alltoall"
@@ -583,11 +629,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 alltoall 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 alltoall"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 bcast 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 bcast"
@@ -596,11 +643,12 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 bcast 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 bcast"
         [ "$status" -eq 0 ]
 }
-# RC                                                                                                                                     
+# RC
 @test "IMB-MPI1 barrier 20 ranks, 5 ranks per node using RC verbs" {
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 barrier"
@@ -609,7 +657,8 @@ load test_helper
 
 # XRC
 @test "IMB-MPI1 barrier 20 ranks, 5 ranks per node using XRC verbs" {
-        FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1 run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
+        ${XRC_FI_ENV} \
+        run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 barrier"
         [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
The bats generator scrip will now pass the FI_ environment variables as one unit:
A level of indirection has been added for the FI_* environment variables to
facilitate simpler and more accurate modifications in the future.  Additionally,
the '-iter' flag option has been added as an optional parameter to the script
since it is not used in every test:
./batsgenerator.sh <TEST_SUITE> <BENCHMARK> <NUM_RANKS> <RANKS_PER_NODE> <BATS_FILE> [-iter count]

Signed-off-by: Patrick Bueb <patrick.bueb@hpe.com>