### PR TITLE
prov/shm: change shm index references to int64_t

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -97,7 +97,7 @@ enum {
 
 /* 
  * Unique smr_op_hdr for smr message protocol:
- * 	addr - local fi_addr of peer sending msg (for shm lookup)
+ * 	addr - local shm_id of peer sending msg (for shm lookup)
  * 	op - type of op (ex. ofi_op_msg, defined in ofi_proto.h)
  * 	op_src - msg src (ex. smr_src_inline, defined above)
  * 	op_flags - operation flags (ex. SMR_REMOTE_CQ_DATA, defined above)
@@ -106,7 +106,7 @@ enum {
  */
 struct smr_msg_hdr {
 	uint64_t		msg_id;
-	fi_addr_t		addr;
+	int64_t			addr;
 	uint32_t		op;
 	uint16_t		op_src;
 	uint16_t		op_flags;
@@ -182,7 +182,7 @@ struct smr_cmd {
 
 struct smr_addr {
 	char		name[SMR_NAME_MAX];
-	fi_addr_t	addr;
+	int64_t		id;
 };
 
 struct smr_peer_data {
@@ -204,6 +204,7 @@ struct smr_ep_name {
 
 struct smr_peer {
 	struct smr_addr		peer;
+	fi_addr_t		fiaddr;
 	struct smr_region	*region;
 };
 
@@ -211,7 +212,7 @@ struct smr_peer {
 
 struct smr_map {
 	fastlock_t		lock;
-	int			cur_idx;
+	int64_t			cur_idx;
 	struct ofi_rbmap	rbmap;
 	struct smr_peer		peers[SMR_MAX_PEERS];
 };
@@ -330,15 +331,15 @@ int	smr_map_create(const struct fi_provider *prov, int peer_count,
 		       struct smr_map **map);
 int	smr_map_to_region(const struct fi_provider *prov,
 			  struct smr_peer *peer_buf);
-void	smr_map_to_endpoint(struct smr_region *region, int index);
-void	smr_unmap_from_endpoint(struct smr_region *region, int index);
+void	smr_map_to_endpoint(struct smr_region *region, int64_t index);
+void	smr_unmap_from_endpoint(struct smr_region *region, int64_t index);
 void	smr_exchange_all_peers(struct smr_region *region);
 int	smr_map_add(const struct fi_provider *prov,
-		    struct smr_map *map, const char *name, fi_addr_t *id);
-void	smr_map_del(struct smr_map *map, int id);
+		    struct smr_map *map, const char *name, int64_t *id);
+void	smr_map_del(struct smr_map *map, int64_t id);
 void	smr_map_free(struct smr_map *map);
 
-struct smr_region *smr_map_get(struct smr_map *map, int id);
+struct smr_region *smr_map_get(struct smr_map *map, int64_t id);
 
 int	smr_create(const struct fi_provider *prov, struct smr_map *map,
 		   const struct smr_attr *attr, struct smr_region *volatile *smr);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -105,7 +105,7 @@ int smr_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 struct smr_rx_entry {
 	struct dlist_entry	entry;
 	void			*context;
-	fi_addr_t		addr;
+	int64_t			addr;
 	uint64_t		tag;
 	uint64_t		ignore;
 	struct iovec		iov[SMR_IOV_LIMIT];
@@ -118,7 +118,7 @@ struct smr_rx_entry {
 
 struct smr_tx_entry {
 	struct smr_cmd	cmd;
-	fi_addr_t	addr;
+	int64_t		addr;
 	void		*context;
 	struct iovec	iov[SMR_IOV_LIMIT];
 	uint32_t	iov_count;
@@ -151,15 +151,14 @@ typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
 
 
 struct smr_match_attr {
-	fi_addr_t	addr;
+	int64_t		addr;
 	uint64_t	tag;
 	uint64_t	ignore;
 };
 
-static inline int smr_match_addr(fi_addr_t addr, fi_addr_t match_addr)
+static inline int smr_match_addr(int64_t addr, int64_t match_addr)
 {
-	return (addr == FI_ADDR_UNSPEC) || (match_addr == FI_ADDR_UNSPEC) ||
-		(addr == match_addr);
+	return (addr == -1) || (match_addr == -1) || (addr == match_addr);
 }
 
 static inline int smr_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_tag)
@@ -271,13 +270,13 @@ int smr_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 int smr_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 		  struct fid_cntr **cntr_fid, void *context);
 
-fi_addr_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr);
+int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr);
 
 void smr_format_pend_resp(struct smr_tx_entry *pend, struct smr_cmd *cmd,
 			  void *context, enum fi_hmem_iface iface, uint64_t device,
 			  const struct iovec *iov, uint32_t iov_count,
-			  fi_addr_t id, struct smr_resp *resp);
-void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id, uint32_t op,
+			  int64_t id, struct smr_resp *resp);
+void smr_generic_format(struct smr_cmd *cmd, int64_t peer_id, uint32_t op,
 			uint64_t tag, uint64_t data, uint64_t op_flags);
 void smr_format_inline(struct smr_cmd *cmd, enum fi_hmem_iface iface,
 		       uint64_t device, const struct iovec *iov, size_t count);
@@ -311,7 +310,7 @@ int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
 int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, uint64_t err);
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
+		uint16_t flags, size_t len, void *buf, int64_t id,
 		uint64_t tag, uint64_t data, uint64_t err);
 int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, size_t len, void *buf, fi_addr_t addr,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -83,6 +83,11 @@ struct smr_av {
 	size_t			used;
 };
 
+static inline int64_t smr_addr_lookup(struct util_av *av, fi_addr_t fiaddr)
+{
+	return *((int64_t *) ofi_av_get_addr(av, fiaddr));
+}
+
 int smr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		struct fid_domain **dom, void *context);
 

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -143,7 +143,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	struct iovec result_iov[SMR_IOV_LIMIT];
 	enum fi_hmem_iface iface;
 	uint64_t device;
-	fi_addr_t id, peer_id;
+	int64_t id, peer_id;
 	int err = 0;
 	uint16_t flags = 0;
 	ssize_t ret = 0;
@@ -155,10 +155,10 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 	assert(rma_count <= SMR_IOV_LIMIT);
 
 	id = smr_verify_peer(ep, addr);
-	if (id == FI_ADDR_UNSPEC)
+	if (id < 0)
 		return -FI_EAGAIN;
 
-	peer_id = smr_peer_data(ep->region)[id].addr.addr;
+	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
 	fastlock_acquire(&peer_smr->lock);
@@ -325,7 +325,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	struct smr_cmd *cmd;
 	struct iovec iov;
 	struct fi_rma_ioc rma_ioc;
-	fi_addr_t id, peer_id;
+	int64_t id, peer_id;
 	ssize_t ret = 0;
 	size_t total_len;
 
@@ -334,10 +334,10 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 	ep = container_of(ep_fid, struct smr_ep, util_ep.ep_fid.fid);
 
 	id = smr_verify_peer(ep, dest_addr);
-	if (id == FI_ADDR_UNSPEC)
+	if (id < 0)
 		return -FI_EAGAIN;
 
-	peer_id = smr_peer_data(ep->region)[id].addr.addr;
+	peer_id = smr_peer_data(ep->region)[id].addr.id;
 	peer_smr = smr_peer_region(ep->region, id);
 
 	fastlock_acquire(&peer_smr->lock);

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -162,7 +162,7 @@ static int smr_av_lookup(struct fid_av *av, fi_addr_t fi_addr, void *addr,
 	peer_smr = smr_map_get(smr_av->smr_map, peer_id);
 
 	if (!peer_smr)
-		return -FI_ADDR_NOTAVAIL;
+		return -FI_ENODATA;
 
 	strncpy((char *)addr, smr_name(peer_smr), *addrlen);
 	((char *) addr)[MIN(*addrlen - 1, strlen(smr_name(peer_smr)))] = '\0';

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -89,16 +89,22 @@ int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 }
 
 int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op, uint16_t flags,
-		    size_t len, void *buf, fi_addr_t addr, uint64_t tag, uint64_t data,
+		    size_t len, void *buf, int64_t id, uint64_t tag, uint64_t data,
 		    uint64_t err)
 {
+	fi_addr_t fiaddr = FI_ADDR_UNSPEC;
+
 	ofi_ep_rx_cntr_inc_func(&ep->util_ep, op);
 
 	if (!err && !(flags & (SMR_REMOTE_CQ_DATA | SMR_RX_COMPLETION)))
 		return 0;
 
+	//TODO I was here
+	if (ep->util_ep.domain->info_domain_caps & FI_SOURCE)
+		fiaddr = ep->region->map->peers[id].fiaddr;
+
 	return ep->rx_comp(ep, context, op, flags, len, buf,
-			   addr, tag, data, err);
+			   fiaddr, tag, data, err);
 }
 
 int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -179,7 +179,7 @@ static struct fi_ops_ep smr_ep_ops = {
 	.tx_size_left = fi_no_tx_size_left,
 };
 
-static void smr_send_name(struct smr_ep *ep, fi_addr_t id)
+static void smr_send_name(struct smr_ep *ep, int64_t id)
 {
 	struct smr_region *peer_smr;
 	struct smr_cmd *cmd;
@@ -211,27 +211,27 @@ out:
 	fastlock_release(&peer_smr->lock);
 }
 
-fi_addr_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)
+int64_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)
 {
-	fi_addr_t id;
+	int64_t id;
 	int ret;
 
 	id = smr_addr_lookup(ep->util_ep.av, fi_addr);
 	assert(id < SMR_MAX_PEERS);
 
-	if (smr_peer_data(ep->region)[id].addr.addr != FI_ADDR_UNSPEC)
+	if (smr_peer_data(ep->region)[id].addr.id >= 0)
 		return id;
 
-	if (ep->region->map->peers[id].peer.addr == FI_ADDR_UNSPEC) {
+	if (ep->region->map->peers[id].peer.id < 0) {
 		ret = smr_map_to_region(&smr_prov, &ep->region->map->peers[id]);
 		if (ret == -ENOENT)
-			return FI_ADDR_UNSPEC;
+			return -1;
 
 	}
 
 	smr_send_name(ep, id);
 
-	return FI_ADDR_UNSPEC;
+	return -1;
 }
 
 static int smr_match_msg(struct dlist_entry *item, const void *args)
@@ -288,7 +288,7 @@ static void smr_init_queue(struct smr_queue *queue,
 void smr_format_pend_resp(struct smr_tx_entry *pend, struct smr_cmd *cmd,
 			  void *context, enum fi_hmem_iface iface, uint64_t device,
 			  const struct iovec *iov, uint32_t iov_count,
-			  fi_addr_t id, struct smr_resp *resp)
+			  int64_t id, struct smr_resp *resp)
 {
 	pend->cmd = *cmd;
 	pend->context = context;
@@ -305,7 +305,7 @@ void smr_format_pend_resp(struct smr_tx_entry *pend, struct smr_cmd *cmd,
 	resp->status = FI_EBUSY;
 }
 
-void smr_generic_format(struct smr_cmd *cmd, fi_addr_t peer_id, uint32_t op,
+void smr_generic_format(struct smr_cmd *cmd, int64_t peer_id, uint32_t op,
 			uint64_t tag, uint64_t data, uint64_t op_flags)
 {
 	cmd->msg.hdr.op = op;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -216,7 +216,7 @@ fi_addr_t smr_verify_peer(struct smr_ep *ep, fi_addr_t fi_addr)
 	fi_addr_t id;
 	int ret;
 
-	id = *((fi_addr_t *) ofi_av_get_addr(ep->util_ep.av, fi_addr));
+	id = smr_addr_lookup(ep->util_ep.av, fi_addr);
 	assert(id < SMR_MAX_PEERS);
 
 	if (smr_peer_data(ep->region)[id].addr.addr != FI_ADDR_UNSPEC)


### PR DESCRIPTION
To completely separate shm index from fi_addr (which are no longer interchangeable), change all definitions and usages of shm indeces to int64_t from fi_addr or ints.

Various bug fixes included because of the clarification