### PR TITLE
prov/shm: renaming addr/id/index for clarity

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -106,7 +106,7 @@ enum {
  */
 struct smr_msg_hdr {
 	uint64_t		msg_id;
-	int64_t			addr;
+	int64_t			id;
 	uint32_t		op;
 	uint16_t		op_src;
 	uint16_t		op_flags;
@@ -212,7 +212,7 @@ struct smr_peer {
 
 struct smr_map {
 	fastlock_t		lock;
-	int64_t			cur_idx;
+	int64_t			cur_id;
 	struct ofi_rbmap	rbmap;
 	struct smr_peer		peers[SMR_MAX_PEERS];
 };
@@ -331,8 +331,8 @@ int	smr_map_create(const struct fi_provider *prov, int peer_count,
 		       struct smr_map **map);
 int	smr_map_to_region(const struct fi_provider *prov,
 			  struct smr_peer *peer_buf);
-void	smr_map_to_endpoint(struct smr_region *region, int64_t index);
-void	smr_unmap_from_endpoint(struct smr_region *region, int64_t index);
+void	smr_map_to_endpoint(struct smr_region *region, int64_t id);
+void	smr_unmap_from_endpoint(struct smr_region *region, int64_t id);
 void	smr_exchange_all_peers(struct smr_region *region);
 int	smr_map_add(const struct fi_provider *prov,
 		    struct smr_map *map, const char *name, int64_t *id);

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -105,7 +105,7 @@ int smr_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 struct smr_rx_entry {
 	struct dlist_entry	entry;
 	void			*context;
-	int64_t			addr;
+	int64_t			peer_id;
 	uint64_t		tag;
 	uint64_t		ignore;
 	struct iovec		iov[SMR_IOV_LIMIT];
@@ -118,7 +118,7 @@ struct smr_rx_entry {
 
 struct smr_tx_entry {
 	struct smr_cmd	cmd;
-	int64_t		addr;
+	int64_t		peer_id;
 	void		*context;
 	struct iovec	iov[SMR_IOV_LIMIT];
 	uint32_t	iov_count;
@@ -151,14 +151,14 @@ typedef int (*smr_tx_comp_func)(struct smr_ep *ep, void *context, uint32_t op,
 
 
 struct smr_match_attr {
-	int64_t		addr;
+	int64_t		id;
 	uint64_t	tag;
 	uint64_t	ignore;
 };
 
-static inline int smr_match_addr(int64_t addr, int64_t match_addr)
+static inline int smr_match_id(int64_t id, int64_t match_id)
 {
-	return (addr == -1) || (match_addr == -1) || (addr == match_addr);
+	return (id == -1) || (match_id == -1) || (id == match_id);
 }
 
 static inline int smr_match_tag(uint64_t tag, uint64_t ignore, uint64_t match_tag)

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -143,7 +143,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 		recv_entry = container_of(entry, struct smr_rx_entry, entry);
 		ret = smr_complete_rx(ep, (void *) recv_entry->context, ofi_op_msg,
 				  recv_entry->flags, 0,
-				  NULL, recv_entry->addr,
+				  NULL, recv_entry->peer_id,
 				  recv_entry->tag, 0, FI_ECANCELED);
 		freestack_push(ep->recv_fs, recv_entry);
 		ret = ret ? ret : 1;
@@ -195,7 +195,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 
 	cmd->msg.hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
-	cmd->msg.hdr.addr = id;
+	cmd->msg.hdr.id = id;
 
 	tx_buf = smr_freestack_pop(smr_inject_pool(peer_smr));
 	cmd->msg.hdr.src_data = smr_get_offset(peer_smr, tx_buf);
@@ -240,7 +240,7 @@ static int smr_match_msg(struct dlist_entry *item, const void *args)
 	struct smr_rx_entry *recv_entry;
 
 	recv_entry = container_of(item, struct smr_rx_entry, entry);
-	return smr_match_addr(recv_entry->addr, attr->addr);
+	return smr_match_id(recv_entry->peer_id, attr->id);
 }
 
 static int smr_match_tagged(struct dlist_entry *item, const void *args)
@@ -249,7 +249,7 @@ static int smr_match_tagged(struct dlist_entry *item, const void *args)
 	struct smr_rx_entry *recv_entry;
 
 	recv_entry = container_of(item, struct smr_rx_entry, entry);
-	return smr_match_addr(recv_entry->addr, attr->addr) &&
+	return smr_match_id(recv_entry->peer_id, attr->id) &&
 	       smr_match_tag(recv_entry->tag, recv_entry->ignore, attr->tag); 
 } 
 
@@ -260,7 +260,7 @@ static int smr_match_unexp_msg(struct dlist_entry *item, const void *args)
 
 	unexp_msg = container_of(item, struct smr_unexp_msg, entry);
 	assert(unexp_msg->cmd.msg.hdr.op == ofi_op_msg);
-	return smr_match_addr(unexp_msg->cmd.msg.hdr.addr, attr->addr);
+	return smr_match_id(unexp_msg->cmd.msg.hdr.id, attr->id);
 }
 
 static int smr_match_unexp_tagged(struct dlist_entry *item, const void *args)
@@ -270,10 +270,10 @@ static int smr_match_unexp_tagged(struct dlist_entry *item, const void *args)
 
 	unexp_msg = container_of(item, struct smr_unexp_msg, entry);
 	if (unexp_msg->cmd.msg.hdr.op == ofi_op_msg)
-		return smr_match_addr(unexp_msg->cmd.msg.hdr.addr, attr->addr);
+		return smr_match_id(unexp_msg->cmd.msg.hdr.id, attr->id);
 
 	assert(unexp_msg->cmd.msg.hdr.op == ofi_op_tagged);
-	return smr_match_addr(unexp_msg->cmd.msg.hdr.addr, attr->addr) &&
+	return smr_match_id(unexp_msg->cmd.msg.hdr.id, attr->id) &&
 	       smr_match_tag(unexp_msg->cmd.msg.hdr.tag, attr->ignore,
 			     attr->tag);
 }
@@ -294,7 +294,7 @@ void smr_format_pend_resp(struct smr_tx_entry *pend, struct smr_cmd *cmd,
 	pend->context = context;
 	memcpy(pend->iov, iov, sizeof(*iov) * iov_count);
 	pend->iov_count = iov_count;
-	pend->addr = id;
+	pend->peer_id = id;
 	if (cmd->msg.hdr.op_src != smr_src_sar)
 		pend->bytes_done = 0;
 
@@ -311,7 +311,7 @@ void smr_generic_format(struct smr_cmd *cmd, int64_t peer_id, uint32_t op,
 	cmd->msg.hdr.op = op;
 	cmd->msg.hdr.op_flags = 0;
 	cmd->msg.hdr.tag = tag;
-	cmd->msg.hdr.addr = peer_id;
+	cmd->msg.hdr.id = peer_id;
 	cmd->msg.hdr.data = data;
 
 	if (op_flags & FI_REMOTE_CQ_DATA)

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -70,7 +70,7 @@ static struct smr_rx_entry *smr_get_recv_entry(struct smr_ep *ep,
 	entry->context = context;
 	entry->err = 0;
 	entry->flags = smr_convert_rx_flags(flags);
-	entry->addr = ep->util_ep.caps & FI_DIRECTED_RECV &&
+	entry->peer_id = ep->util_ep.caps & FI_DIRECTED_RECV &&
 				addr != FI_ADDR_UNSPEC ?
 				smr_addr_lookup(ep->util_ep.av, addr) : -1;
 	entry->tag = tag;

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -329,44 +329,44 @@ out:
 	return ret;
 }
 
-void smr_map_to_endpoint(struct smr_region *region, int64_t index)
+void smr_map_to_endpoint(struct smr_region *region, int64_t id)
 {
 	struct smr_region *peer_smr;
 	struct smr_peer_data *local_peers;
 
-	if (region->map->peers[index].peer.id < 0)
+	if (region->map->peers[id].peer.id < 0)
 		return;
 
 	local_peers = smr_peer_data(region);
 
-	strncpy(local_peers[index].addr.name,
-		region->map->peers[index].peer.name, SMR_NAME_MAX - 1);
-	local_peers[index].addr.name[SMR_NAME_MAX - 1] = '\0';
+	strncpy(local_peers[id].addr.name,
+		region->map->peers[id].peer.name, SMR_NAME_MAX - 1);
+	local_peers[id].addr.name[SMR_NAME_MAX - 1] = '\0';
 
-	peer_smr = smr_peer_region(region, index);
+	peer_smr = smr_peer_region(region, id);
 
 	if (region->cma_cap == SMR_CMA_CAP_NA && region != peer_smr)
 		smr_cma_check(region, peer_smr);
 }
 
-void smr_unmap_from_endpoint(struct smr_region *region, int64_t index)
+void smr_unmap_from_endpoint(struct smr_region *region, int64_t id)
 {
 	struct smr_region *peer_smr;
 	struct smr_peer_data *local_peers, *peer_peers;
-	int64_t peer_index;
+	int64_t peer_id;
 
 	local_peers = smr_peer_data(region);
 
-	memset(local_peers[index].addr.name, 0, SMR_NAME_MAX);
-	peer_index = region->map->peers[index].peer.id;
-	if (peer_index < 0)
+	memset(local_peers[id].addr.name, 0, SMR_NAME_MAX);
+	peer_id = region->map->peers[id].peer.id;
+	if (peer_id < 0)
 		return;
 
-	peer_smr = smr_peer_region(region, index);
+	peer_smr = smr_peer_region(region, id);
 	peer_peers = smr_peer_data(peer_smr);
 
-	peer_peers[peer_index].addr.id = -1;
-	peer_peers[peer_index].name_sent = 0;
+	peer_peers[peer_id].addr.id = -1;
+	peer_peers[peer_id].name_sent = 0;
 }
 
 void smr_exchange_all_peers(struct smr_region *region)
@@ -391,15 +391,15 @@ int smr_map_add(const struct fi_provider *prov, struct smr_map *map,
 		return 0;
 	}
 
-	while (map->peers[map->cur_idx].peer.id != -1 &&
+	while (map->peers[map->cur_id].peer.id != -1 &&
 	       tries < SMR_MAX_PEERS) {
-		if (++map->cur_idx == SMR_MAX_PEERS)
-			map->cur_idx = 0;
+		if (++map->cur_id == SMR_MAX_PEERS)
+			map->cur_id = 0;
 		tries++;
 	}
 
-	assert(map->cur_idx < SMR_MAX_PEERS && tries < SMR_MAX_PEERS);
-	*id = map->cur_idx;
+	assert(map->cur_id < SMR_MAX_PEERS && tries < SMR_MAX_PEERS);
+	*id = map->cur_id;
 	node->data = (void *) *id;
 	strncpy(map->peers[*id].peer.name, name, SMR_NAME_MAX);
 	map->peers[*id].peer.name[SMR_NAME_MAX - 1] = '\0';


### PR DESCRIPTION
Rename all uses of shm indices/addrs to ids to
avoid confusion with fiaddrs

Fix one bug where smr_map_to_endpoint was getting
called with "index" which was an fiaddr, not id

Signed-off-by: aingerson <alexia.ingerson@intel.com>