### PR TITLE
[v1.11.x] fabtests, prov/shm, common: cherry picks 

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -427,7 +427,6 @@ static int ft_alloc_ctx_array(struct ft_context **mr_array, char ***mr_bufs,
 			context->desc = mr_desc;
 			continue;
 		}
-		(*mr_bufs)[i] = calloc(1, mr_size);
 		ret = ft_hmem_alloc(opts.iface, opts.device,
 				    (void **) &((*mr_bufs)[i]), mr_size);
 		if (ret)

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -686,7 +686,7 @@ static int ft_init(void)
 	//If using device memory for transfers, require OOB address
 	//exchange because extra steps are involved when passing
 	//device buffers into fi_av_insert
-	if (opts.options & FT_OPT_USE_DEVICE)
+	if (opts.options & FT_OPT_ENABLE_HMEM)
 		opts.options |= FT_OPT_OOB_ADDR_EXCH;
 
 	return ft_hmem_init(opts.iface);

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -55,7 +55,7 @@ static inline int ft_host_cleanup()
 static inline int ft_host_alloc(uint64_t device, void **buffer, size_t size)
 {
 	*buffer = malloc(size);
-	return !buffer ? -FI_ENOMEM : FI_SUCCESS;
+	return !*buffer ? -FI_ENOMEM : FI_SUCCESS;
 }
 
 static inline int ft_host_free(void *buf)

--- a/prov/shm/src/smr_attr.c
+++ b/prov/shm/src/smr_attr.c
@@ -32,11 +32,10 @@
 
 #include "smr.h"
 
-#define SMR_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | FI_ATOMICS | \
-		     FI_HMEM)
+#define SMR_TX_CAPS (OFI_TX_MSG_CAPS | FI_TAGGED | OFI_TX_RMA_CAPS | FI_ATOMICS)
 #define SMR_RX_CAPS (FI_SOURCE | FI_RMA_EVENT | OFI_RX_MSG_CAPS | FI_TAGGED | \
 		     OFI_RX_RMA_CAPS | FI_ATOMICS | FI_DIRECTED_RECV | \
-		     FI_MULTI_RECV | FI_HMEM)
+		     FI_MULTI_RECV)
 #define SMR_TX_OP_FLAGS (FI_COMPLETION | FI_INJECT_COMPLETE | \
 			 FI_TRANSMIT_COMPLETE | FI_DELIVERY_COMPLETE)
 #define SMR_RX_OP_FLAGS (FI_COMPLETION | FI_MULTI_RECV)
@@ -54,6 +53,26 @@ struct fi_tx_attr smr_tx_attr = {
 
 struct fi_rx_attr smr_rx_attr = {
 	.caps = SMR_RX_CAPS,
+	.op_flags = SMR_RX_OP_FLAGS,
+	.comp_order = FI_ORDER_STRICT,
+	.msg_order = SMR_RMA_ORDER | FI_ORDER_SAS,
+	.size = 1024,
+	.iov_limit = SMR_IOV_LIMIT
+};
+
+struct fi_tx_attr smr_hmem_tx_attr = {
+	.caps = SMR_TX_CAPS | FI_HMEM,
+	.op_flags = SMR_TX_OP_FLAGS,
+	.comp_order = FI_ORDER_NONE,
+	.msg_order = SMR_RMA_ORDER | FI_ORDER_SAS,
+	.inject_size = 0,
+	.size = 1024,
+	.iov_limit = SMR_IOV_LIMIT,
+	.rma_iov_limit = SMR_IOV_LIMIT
+};
+
+struct fi_rx_attr smr_hmem_rx_attr = {
+	.caps = SMR_RX_CAPS | FI_HMEM,
 	.op_flags = SMR_RX_OP_FLAGS,
 	.comp_order = FI_ORDER_STRICT,
 	.msg_order = SMR_RMA_ORDER | FI_ORDER_SAS,
@@ -99,6 +118,16 @@ struct fi_fabric_attr smr_fabric_attr = {
 	.prov_version = OFI_VERSION_DEF_PROV
 };
 
+struct fi_info smr_hmem_info = {
+	.caps = SMR_TX_CAPS | SMR_RX_CAPS | FI_HMEM | FI_MULTI_RECV,
+	.addr_format = FI_ADDR_STR,
+	.tx_attr = &smr_hmem_tx_attr,
+	.rx_attr = &smr_hmem_rx_attr,
+	.ep_attr = &smr_ep_attr,
+	.domain_attr = &smr_domain_attr,
+	.fabric_attr = &smr_fabric_attr
+};
+
 struct fi_info smr_info = {
 	.caps = SMR_TX_CAPS | SMR_RX_CAPS | FI_MULTI_RECV,
 	.addr_format = FI_ADDR_STR,
@@ -106,5 +135,6 @@ struct fi_info smr_info = {
 	.rx_attr = &smr_rx_attr,
 	.ep_attr = &smr_ep_attr,
 	.domain_attr = &smr_domain_attr,
-	.fabric_attr = &smr_fabric_attr
+	.fabric_attr = &smr_fabric_attr,
+	.next = &smr_hmem_info,
 };

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -167,7 +167,6 @@ static int smr_getinfo(uint32_t version, const char *node, const char *service,
 				return -FI_ENODATA;
 			}
 			cur->domain_attr->mr_mode |= FI_MR_HMEM;
-			cur->tx_attr->inject_size = 0;
 			ofi_hmem_init();
 		} else {
 			cur->domain_attr->mr_mode &= ~FI_MR_HMEM;

--- a/src/common.c
+++ b/src/common.c
@@ -954,9 +954,13 @@ void ofi_straddr_log_internal(const char *func, int line,
 	size_t len = sizeof(buf);
 
 	if (fi_log_enabled(prov, level, subsys)) {
-		addr_format = ofi_translate_addr_format(ofi_sa_family(addr));
-		fi_log(prov, level, subsys, func, line, "%s: %s\n", log_str,
-		       ofi_straddr(buf, &len, addr_format, addr));
+		if (addr) {
+			addr_format = ofi_translate_addr_format(ofi_sa_family(addr));
+			fi_log(prov, level, subsys, func, line, "%s: %s\n", log_str,
+			       ofi_straddr(buf, &len, addr_format, addr));
+		} else {
+			fi_log(prov, level, subsys, func, line, "%s: (null)\n", log_str);
+		}
 	}
 }
 


### PR DESCRIPTION
fabtests FI_HMEM bugs:
- double memory allocation with ft_hmem_alloc
- fix malloc error checking/return
- fix OOB enabling for device->host transfers
shm:
- duplicate fi_infos for FI_HMEM, FI_MR_HMEM support
common:
- fix address print segfault