### PR TITLE
prov/efa: use local read to copy data to GPU buffer

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -522,6 +522,9 @@ struct rxr_ep {
 	struct fid_ep *rdm_ep;
 	struct fid_cq *rdm_cq;
 
+	/* address of myself in my AV, used to post read to my self */
+	fi_addr_t rdm_self_addr;
+
 	/* shm provider fid */
 	bool use_shm;
 	struct fid_ep *shm_ep;

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -353,7 +353,8 @@ struct rxr_rx_entry {
 	uint64_t tag;
 	uint64_t ignore;
 
-	uint64_t bytes_done;
+	uint64_t bytes_received;
+	uint64_t bytes_copied;
 	int64_t window;
 	uint16_t credit_request;
 	int credit_cts;

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -198,6 +198,7 @@ struct rxr_env {
 	int shm_av_size;
 	int shm_max_medium_size;
 	int recvwin_size;
+	int readcopy_pool_size;
 	int cq_size;
 	size_t max_memcpy_size;
 	size_t mtu_size;
@@ -587,6 +588,11 @@ struct rxr_ep {
 	/* staging area for unexpected and out-of-order packets */
 	struct ofi_bufpool *rx_unexp_pkt_pool;
 	struct ofi_bufpool *rx_ooo_pkt_pool;
+
+	/* staging area for read copy */
+	struct ofi_bufpool *rx_readcopy_pkt_pool;
+	int rx_readcopy_pkt_pool_used;
+	int rx_readcopy_pkt_pool_max_used;
 
 #ifdef ENABLE_EFA_POISONING
 	size_t tx_pkt_pool_entry_sz;

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -847,7 +847,7 @@ void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entr
 
 		if (ep->util_ep.caps & FI_RMA_EVENT) {
 			rx_entry->cq_entry.len = rx_entry->total_len;
-			rx_entry->bytes_done = rx_entry->total_len;
+			rx_entry->bytes_copied = rx_entry->total_len;
 			efa_cntr_report_rx_completion(&ep->util_ep, rx_entry->cq_entry.flags);
 		}
 

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -87,7 +87,8 @@ struct rxr_rx_entry *rxr_ep_rx_entry_init(struct rxr_ep *ep,
 	rx_entry->addr = msg->addr;
 	rx_entry->fi_flags = flags;
 	rx_entry->rxr_flags = 0;
-	rx_entry->bytes_done = 0;
+	rx_entry->bytes_received = 0;
+	rx_entry->bytes_copied = 0;
 	rx_entry->window = 0;
 	rx_entry->iov_count = msg->iov_count;
 	rx_entry->tag = tag;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -709,8 +709,14 @@ static void rxr_ep_free_res(struct rxr_ep *rxr_ep)
 	if (rxr_ep->readrsp_tx_entry_pool)
 		ofi_bufpool_destroy(rxr_ep->readrsp_tx_entry_pool);
 
-	if (rxr_ep->rx_readcopy_pkt_pool)
+	if (rxr_ep->rx_readcopy_pkt_pool) {
+		FI_INFO(&rxr_prov, FI_LOG_EP_CTRL, "current usage of read copy packet pool is %d\n",
+			rxr_ep->rx_readcopy_pkt_pool_used);
+		FI_INFO(&rxr_prov, FI_LOG_EP_CTRL, "maximum usage of read copy packet pool is %d\n",
+			rxr_ep->rx_readcopy_pkt_pool_max_used);
+		assert(!rxr_ep->rx_readcopy_pkt_pool_used);
 		ofi_bufpool_destroy(rxr_ep->rx_readcopy_pkt_pool);
+	}
 
 	if (rxr_ep->rx_ooo_pkt_pool)
 		ofi_bufpool_destroy(rxr_ep->rx_ooo_pkt_pool);

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -56,6 +56,7 @@ struct rxr_env rxr_env = {
 	.shm_av_size = 128,
 	.shm_max_medium_size = 4096,
 	.recvwin_size = RXR_RECVWIN_SIZE,
+	.readcopy_pool_size = 256,
 	.cq_size = RXR_DEF_CQ_SIZE,
 	.max_memcpy_size = 4096,
 	.mtu_size = 0,
@@ -88,6 +89,7 @@ static void rxr_init_env(void)
 	fi_param_get_int(&rxr_prov, "shm_av_size", &rxr_env.shm_av_size);
 	fi_param_get_int(&rxr_prov, "shm_max_medium_size", &rxr_env.shm_max_medium_size);
 	fi_param_get_int(&rxr_prov, "recvwin_size", &rxr_env.recvwin_size);
+	fi_param_get_int(&rxr_prov, "readcopy_pool_size", &rxr_env.readcopy_pool_size);
 	fi_param_get_int(&rxr_prov, "cq_size", &rxr_env.cq_size);
 	fi_param_get_size_t(&rxr_prov, "max_memcpy_size",
 			    &rxr_env.max_memcpy_size);
@@ -727,6 +729,8 @@ EFA_INI
 			"Defines the switch point between small/medium message and large message. The message larger than this switch point will be transferred with large message protocol (Default 4096).");
 	fi_param_define(&rxr_prov, "recvwin_size", FI_PARAM_INT,
 			"Defines the size of sliding receive window. (Default: 16384)");
+	fi_param_define(&rxr_prov, "readcopy_pool_size", FI_PARAM_INT,
+			"Defines the size of readcopy packet pool size. (Default: 256)");
 	fi_param_define(&rxr_prov, "cq_size", FI_PARAM_INT,
 			"Define the size of completion queue. (Default: 8192)");
 	fi_param_define(&rxr_prov, "mr_cache_enable", FI_PARAM_BOOL,

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -487,9 +487,9 @@ ssize_t rxr_pkt_copy_to_rx(struct rxr_ep *ep,
 		}
 	}
 
-	rx_entry->bytes_done += data_size;
+	rx_entry->bytes_copied += data_size;
 
-	if (rx_entry->total_len == rx_entry->bytes_done) {
+	if (rx_entry->total_len == rx_entry->bytes_copied) {
 		rxr_cq_handle_rx_completion(ep, pkt_entry, rx_entry);
 		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 		rxr_release_rx_entry(ep, rx_entry);

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -44,6 +44,8 @@ ssize_t rxr_pkt_post_ctrl(struct rxr_ep *ep, int entry_type, void *x_entry,
 ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry,
 				   int ctrl_type, bool inject);
 
+size_t rxr_pkt_data_size(struct rxr_pkt_entry *pkt_entry);
+
 ssize_t rxr_pkt_copy_to_rx(struct rxr_ep *ep,
 			   struct rxr_rx_entry *rx_entry,
 			   size_t data_offset,

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -52,6 +52,10 @@ ssize_t rxr_pkt_copy_to_rx(struct rxr_ep *ep,
 			   struct rxr_pkt_entry *pkt_entry,
 			   char *data, size_t data_size);
 
+void rxr_pkt_handle_data_copied(struct rxr_ep *ep,
+				struct rxr_pkt_entry *pkt_entry,
+				size_t data_size);
+
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep,
 				    struct fi_cq_data_entry *cq_entry);
 

--- a/prov/efa/src/rxr/rxr_pkt_cmd.h
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.h
@@ -44,6 +44,12 @@ ssize_t rxr_pkt_post_ctrl(struct rxr_ep *ep, int entry_type, void *x_entry,
 ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry,
 				   int ctrl_type, bool inject);
 
+ssize_t rxr_pkt_copy_to_rx(struct rxr_ep *ep,
+			   struct rxr_rx_entry *rx_entry,
+			   size_t data_offset,
+			   struct rxr_pkt_entry *pkt_entry,
+			   char *data, size_t data_size);
+
 void rxr_pkt_handle_send_completion(struct rxr_ep *ep,
 				    struct fi_cq_data_entry *cq_entry);
 

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -205,9 +205,8 @@ void rxr_pkt_entry_copy(struct rxr_ep *ep,
 			int new_entry_type)
 {
 	FI_DBG(&rxr_prov, FI_LOG_EP_CTRL,
-	       "Copying packet out of posted buffer! new_entry_type: %d\n",
-		new_entry_type);
-	assert(src->type == RXR_PKT_ENTRY_POSTED);
+	       "Copying packet out of posted buffer! src_entry_type: %d new_entry_type: %d\n",
+		src->type, new_entry_type);
 	dlist_init(&dest->entry);
 #if ENABLE_DEBUG
 	dlist_init(&dest->dbg_entry);
@@ -277,7 +276,8 @@ struct rxr_pkt_entry *rxr_pkt_entry_clone(struct rxr_ep *ep,
 
 	assert(src);
 	assert(new_entry_type == RXR_PKT_ENTRY_OOO ||
-	       new_entry_type == RXR_PKT_ENTRY_UNEXP);
+	       new_entry_type == RXR_PKT_ENTRY_UNEXP ||
+	       new_entry_type == RXR_PKT_ENTRY_READ_COPY);
 
 	dst = rxr_pkt_entry_alloc(ep, pkt_pool);
 	if (!dst)

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -48,7 +48,8 @@ enum rxr_pkt_entry_type {
 	RXR_PKT_ENTRY_POSTED = 1,   /* entries that are posted to the device from the RX bufpool */
 	RXR_PKT_ENTRY_UNEXP,        /* entries used to stage unexpected msgs */
 	RXR_PKT_ENTRY_OOO,	    /* entries used to stage out-of-order RTM or RTA */
-	RXR_PKT_ENTRY_USER	    /* entries backed by user-provided msg prefix (FI_MSG_PREFIX)*/
+	RXR_PKT_ENTRY_USER,	    /* entries backed by user-provided msg prefix (FI_MSG_PREFIX)*/
+	RXR_PKT_ENTRY_READ_COPY,    /* entries used to stage copy by read */
 };
 
 struct rxr_pkt_sendv {

--- a/prov/efa/src/rxr/rxr_pkt_type.h
+++ b/prov/efa/src/rxr/rxr_pkt_type.h
@@ -234,11 +234,11 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 			       struct rxr_tx_entry *tx_entry,
 			       struct rxr_pkt_entry *pkt_entry);
 
-int rxr_pkt_proc_data(struct rxr_ep *ep,
-		      struct rxr_rx_entry *rx_entry,
-		      struct rxr_pkt_entry *pkt_entry,
-		      char *data, size_t seg_offset,
-		      size_t seg_size);
+void rxr_pkt_proc_data(struct rxr_ep *ep,
+		       struct rxr_rx_entry *rx_entry,
+		       struct rxr_pkt_entry *pkt_entry,
+		       char *data, size_t seg_offset,
+		       size_t seg_size);
 
 void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 					 struct rxr_pkt_entry *pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -242,16 +242,21 @@ void rxr_pkt_handle_data_send_completion(struct rxr_ep *ep,
 /*
  *  rxr_pkt_handle_data_recv() and related functions
  */
-int rxr_pkt_proc_data(struct rxr_ep *ep,
-		      struct rxr_rx_entry *rx_entry,
-		      struct rxr_pkt_entry *pkt_entry,
-		      char *data, size_t seg_offset,
-		      size_t seg_size)
+
+/*
+ * rxr_pkt_proc_data() processes data in a DATA/READRSP
+ * pakcet entry.
+ */
+void rxr_pkt_proc_data(struct rxr_ep *ep,
+		       struct rxr_rx_entry *rx_entry,
+		       struct rxr_pkt_entry *pkt_entry,
+		       char *data, size_t seg_offset,
+		       size_t seg_size)
 {
 	struct rxr_peer *peer;
 	struct efa_mr *desc;
 	int64_t bytes_left, bytes_copied;
-	ssize_t ret = 0;
+	ssize_t err;
 
 #if ENABLE_DEBUG
 	int pkt_type = rxr_get_base_hdr(pkt_entry->pkt)->type;
@@ -304,16 +309,19 @@ int rxr_pkt_proc_data(struct rxr_ep *ep,
 
 		rxr_msg_multi_recv_free_posted_entry(ep, rx_entry);
 		rxr_release_rx_entry(ep, rx_entry);
-		return 0;
+		return;
 	}
 
 	if (!rx_entry->window) {
 		assert(rx_entry->state == RXR_RX_RECV);
-		ret = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
+		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_CTS_PKT, 0);
+		if (err) {
+			FI_WARN(&rxr_prov, FI_LOG_CQ, "post CTS packet failed!\n");
+			rxr_cq_handle_rx_error(ep, rx_entry, err);
+		}
 	}
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
-	return ret;
 }
 
 void rxr_pkt_handle_data_recv(struct rxr_ep *ep,

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -381,12 +381,13 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 	assert(read_entry->bytes_finished <= read_entry->total_len);
 
 	if (read_entry->bytes_finished == read_entry->total_len) {
-		if (read_entry->x_entry_type == RXR_TX_ENTRY) {
-			tx_entry = ofi_bufpool_get_ibuf(ep->tx_entry_pool, read_entry->x_entry_id);
+		if (read_entry->context_type == RXR_READ_CONTEXT_TX_ENTRY) {
+			tx_entry = read_entry->context;
 			assert(tx_entry && tx_entry->cq_entry.flags & FI_READ);
 			rxr_cq_write_tx_completion(ep, tx_entry);
 		} else {
-			rx_entry = ofi_bufpool_get_ibuf(ep->rx_entry_pool, read_entry->x_entry_id);
+			assert(read_entry->context_type == RXR_READ_CONTEXT_RX_ENTRY);
+			rx_entry = read_entry->context;
 			if (rx_entry->op == ofi_op_msg || rx_entry->op == ofi_op_tagged) {
 				rxr_cq_write_rx_completion(ep, rx_entry);
 			} else {

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -180,7 +180,7 @@ ssize_t rxr_pkt_init_cts(struct rxr_ep *ep,
 	cts_hdr->tx_id = rx_entry->tx_id;
 	cts_hdr->rx_id = rx_entry->rx_id;
 
-	bytes_left = rx_entry->total_len - rx_entry->bytes_done;
+	bytes_left = rx_entry->total_len - rx_entry->bytes_received;
 	peer = rxr_ep_get_peer(ep, rx_entry->addr);
 	rxr_pkt_calc_cts_window_credits(ep, peer, bytes_left,
 					rx_entry->credit_request,

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -366,10 +366,12 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 {
 	struct rxr_tx_entry *tx_entry;
 	struct rxr_rx_entry *rx_entry;
+	struct rxr_pkt_entry *pkt_entry;
 	struct rxr_read_entry *read_entry;
 	struct rxr_rma_context_pkt *rma_context_pkt;
 	struct rxr_peer *peer;
 	int inject;
+	size_t data_size;
 	ssize_t ret;
 
 	rma_context_pkt = (struct rxr_rma_context_pkt *)context_pkt_entry->pkt;
@@ -385,8 +387,7 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 			tx_entry = read_entry->context;
 			assert(tx_entry && tx_entry->cq_entry.flags & FI_READ);
 			rxr_cq_write_tx_completion(ep, tx_entry);
-		} else {
-			assert(read_entry->context_type == RXR_READ_CONTEXT_RX_ENTRY);
+		} else if (read_entry->context_type == RXR_READ_CONTEXT_RX_ENTRY) {
 			rx_entry = read_entry->context;
 			if (rx_entry->op == ofi_op_msg || rx_entry->op == ofi_op_tagged) {
 				rxr_cq_write_rx_completion(ep, rx_entry);
@@ -403,6 +404,12 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 					assert(0 && "failed to write err cq entry");
 				rxr_release_rx_entry(ep, rx_entry);
 			}
+		} else {
+			assert(read_entry->context_type == RXR_READ_CONTEXT_PKT_ENTRY);
+			pkt_entry = read_entry->context;
+			data_size = rxr_pkt_data_size(pkt_entry);
+			assert(data_size > 0);
+			rxr_pkt_handle_data_copied(ep, pkt_entry, data_size);
 		}
 
 		rxr_read_release_entry(ep, read_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -786,7 +786,7 @@ ssize_t rxr_pkt_proc_matched_read_rtm(struct rxr_ep *ep,
 	 * need to do memory registration for the receiving buffer.
 	 */
 	ofi_truncate_iov(rx_entry->iov, &rx_entry->iov_count, rx_entry->total_len);
-	return rxr_read_post_or_queue(ep, RXR_RX_ENTRY, rx_entry);
+	return rxr_read_post_remote_read_or_queue(ep, RXR_RX_ENTRY, rx_entry);
 }
 
 ssize_t rxr_pkt_proc_matched_medium_rtm(struct rxr_ep *ep,
@@ -1467,7 +1467,7 @@ void rxr_pkt_handle_read_rtw_recv(struct rxr_ep *ep,
 	       rx_entry->rma_iov_count * sizeof(struct fi_rma_iov));
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);
-	err = rxr_read_post_or_queue(ep, RXR_RX_ENTRY, rx_entry);
+	err = rxr_read_post_remote_read_or_queue(ep, RXR_RX_ENTRY, rx_entry);
 	if (OFI_UNLIKELY(err)) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
 			"RDMA post read or queue failed.\n");

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -162,10 +162,12 @@ struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, int entry_type, v
 		read_entry->addr = tx_entry->addr;
 
 		read_entry->iov_count = tx_entry->iov_count;
-		read_entry->iov = tx_entry->iov;
+		memcpy(read_entry->iov, tx_entry->iov,
+		       tx_entry->iov_count * sizeof(struct iovec));
 
 		read_entry->rma_iov_count = tx_entry->rma_iov_count;
-		read_entry->rma_iov = tx_entry->rma_iov;
+		memcpy(read_entry->rma_iov, tx_entry->rma_iov,
+		       tx_entry->rma_iov_count * sizeof(struct fi_rma_iov));
 
 		total_iov_len = ofi_total_iov_len(tx_entry->iov, tx_entry->iov_count);
 		total_rma_iov_len = ofi_total_rma_iov_len(tx_entry->rma_iov, tx_entry->rma_iov_count);
@@ -186,10 +188,12 @@ struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, int entry_type, v
 		read_entry->addr = rx_entry->addr;
 
 		read_entry->iov_count = rx_entry->iov_count;
-		read_entry->iov = rx_entry->iov;
+		memcpy(read_entry->iov, rx_entry->iov,
+		       rx_entry->iov_count * sizeof(struct iovec));
 
 		read_entry->rma_iov_count = rx_entry->rma_iov_count;
-		read_entry->rma_iov = rx_entry->rma_iov;
+		memcpy(read_entry->rma_iov, rx_entry->rma_iov,
+		       rx_entry->rma_iov_count * sizeof(struct fi_rma_iov));
 
 		total_iov_len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
 		total_rma_iov_len = ofi_total_rma_iov_len(rx_entry->rma_iov, rx_entry->rma_iov_count);

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -379,6 +379,10 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 	assert(read_entry->total_len == MIN(total_iov_len, total_rma_iov_len));
 
 	while (read_entry->bytes_submitted < read_entry->total_len) {
+
+		if (ep->tx_pending == ep->max_outstanding_tx)
+			return -FI_EAGAIN;
+
 		assert(iov_idx < read_entry->iov_count);
 		assert(iov_offset < read_entry->iov[iov_idx].iov_len);
 		assert(rma_iov_idx < read_entry->rma_iov_count);

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -79,12 +79,12 @@ struct rxr_read_entry {
 
 	fi_addr_t addr;
 
-	struct iovec *iov;
+	struct iovec iov[RXR_IOV_LIMIT];
 	size_t iov_count;
 	struct fid_mr *mr[RXR_IOV_LIMIT];
 	void *mr_desc[RXR_IOV_LIMIT];
 
-	struct fi_rma_iov *rma_iov;
+	struct fi_rma_iov rma_iov[RXR_IOV_LIMIT];
 	size_t rma_iov_count;
 
 	size_t total_len;

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -46,10 +46,15 @@
  * 2. read message protocol is being used, receiver is going
  *    to post a read requst.
  *
+ * 3. a packet entry with data has been received, and the
+ *    receiving buffer is on GPU memroy. A read request is
+ *    being posted to copy data to receiving buffer.
+ *
  * To distinguish them, we use a pointer as context.
  *
  * For 1, the tx_entry is used as context
  * For 2, the rx_entry is used as context
+ * For 3, the pkt_entry is used as context
  *
  * We also store rxr_read_context_type in read_entry to specify
  * context type.
@@ -57,6 +62,7 @@
 enum rxr_read_context_type {
 	RXR_READ_CONTEXT_TX_ENTRY,
 	RXR_READ_CONTEXT_RX_ENTRY,
+	RXR_READ_CONTEXT_PKT_ENTRY,
 };
 
 enum rxr_read_entry_state {
@@ -109,7 +115,13 @@ int rxr_read_init_iov(struct rxr_ep *ep,
 
 int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry);
 
-int rxr_read_post_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry);
+int rxr_read_post_remote_read_or_queue(struct rxr_ep *ep, int entry_type, void *x_entry);
+
+int rxr_read_post_local_read_or_queue(struct rxr_ep *ep,
+				      struct rxr_rx_entry *rx_entry,
+				      size_t data_offset,
+				      struct rxr_pkt_entry *pkt_entry,
+				      char *data, size_t data_size);
 
 void rxr_read_handle_read_completion(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry);
 

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -38,22 +38,43 @@
 #ifndef _RXR_RDMA_H_
 #define _RXR_RDMA_H_
 
+/*
+ * read can used in 2 scenarios:
+ *
+ * 1. application posted a read request.
+ *
+ * 2. read message protocol is being used, receiver is going
+ *    to post a read requst.
+ *
+ * To distinguish them, we use a pointer as context.
+ *
+ * For 1, the tx_entry is used as context
+ * For 2, the rx_entry is used as context
+ *
+ * We also store rxr_read_context_type in read_entry to specify
+ * context type.
+ */
+enum rxr_read_context_type {
+	RXR_READ_CONTEXT_TX_ENTRY,
+	RXR_READ_CONTEXT_RX_ENTRY,
+};
+
 enum rxr_read_entry_state {
 	RXR_RDMA_ENTRY_FREE = 0,
 	RXR_RDMA_ENTRY_CREATED,
 	RXR_RDMA_ENTRY_PENDING
 };
 
-/* rxr_read_entry was arranged as a packet
- * and was put in a rxr_pkt_entry. Because rxr_pkt_entry is used
- * as context.
+/*
+ * rxr_read_entry contains the information of a read request
  */
 struct rxr_read_entry {
 	int read_id;
 	enum rxr_lower_ep_type lower_ep_type;
 
-	enum rxr_x_entry_type x_entry_type;
-	int x_entry_id;
+	void *context;
+	enum rxr_read_context_type context_type;
+
 	enum rxr_read_entry_state state;
 
 	fi_addr_t addr;

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -326,7 +326,7 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	}
 
 	if (use_lower_ep_read) {
-		err = rxr_read_post_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry);
+		err = rxr_read_post_remote_read_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry);
 		if (OFI_UNLIKELY(err == -FI_ENOBUFS)) {
 			rxr_release_tx_entry(rxr_ep, tx_entry);
 			err = -FI_EAGAIN;


### PR DESCRIPTION
This PR contain 12 commits that implements using local read to copy data to GPU buffer.

The first 7 commits are refactors.

The next 5 commits implements the local read.