### PR TITLE
prov/efa: Switch to memhooks monitor

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -167,7 +167,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	size_t qp_table_size;
 	int ret;
 	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
-		[FI_HMEM_SYSTEM] = uffd_monitor,
+		[FI_HMEM_SYSTEM] = memhooks_monitor,
 	};
 
 	fi = efa_get_efa_info(info->domain_attr->name);


### PR DESCRIPTION
The uffd monitor we are using currently defers the de-registration
until after the free, which is erroneous according to the rdma-core
interface. (e.g., it causes the RBTree in rdma-core update incorrectly
if fork support is enabled).

Switch to memhooks monitor to avoid the deferring.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>