### PR TITLE
V1.11.x - first set of cherry picked fixes

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2970,7 +2970,7 @@ void ft_parsecsopts(int op, char *optarg, struct ft_opts *opts)
 			opts->sizes_enabled = FT_ENABLE_ALL;
 		} else {
 			opts->options |= FT_OPT_SIZE;
-			opts->transfer_size = atoi(optarg);
+			opts->transfer_size = atol(optarg);
 		}
 		break;
 	case 'm':

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3036,12 +3036,12 @@ int ft_parse_rma_opts(int op, char *optarg, struct fi_info *hints,
 	return 0;
 }
 
-void ft_fill_buf(void *buf, int size)
+void ft_fill_buf(void *buf, size_t size)
 {
 	char *msg_buf;
 	int msg_index;
 	static unsigned int iter = 0;
-	int i;
+	size_t i;
 
 	msg_index = ((iter++)*INTEG_SEED) % integ_alphabet_length;
 	msg_buf = (char *)buf;
@@ -3052,13 +3052,13 @@ void ft_fill_buf(void *buf, int size)
 	}
 }
 
-int ft_check_buf(void *buf, int size)
+int ft_check_buf(void *buf, size_t size)
 {
 	char *recv_data;
 	char c;
 	static unsigned int iter = 0;
 	int msg_index;
-	int i;
+	size_t i;
 
 	msg_index = ((iter++)*INTEG_SEED) % integ_alphabet_length;
 	recv_data = (char *)buf;
@@ -3071,7 +3071,7 @@ int ft_check_buf(void *buf, int size)
 			break;
 	}
 	if (i != size) {
-		printf("Error at iteration=%d size=%d byte=%d\n",
+		printf("Error at iteration=%d size=%zu byte=%zu\n",
 			iter, size, i);
 		return 1;
 	}

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -225,8 +225,8 @@ void ft_usage(char *name, char *desc);
 void ft_mcusage(char *name, char *desc);
 void ft_csusage(char *name, char *desc);
 
-void ft_fill_buf(void *buf, int size);
-int ft_check_buf(void *buf, int size);
+void ft_fill_buf(void *buf, size_t size);
+int ft_check_buf(void *buf, size_t size);
 int ft_check_opts(uint64_t flags);
 uint64_t ft_init_cq_data(struct fi_info *info);
 int ft_sock_listen(char *node, char *service);

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -194,6 +194,7 @@ enum ofi_prov_type {
 struct fi_prov_context {
 	enum ofi_prov_type type;
 	int disable_logging;
+	int disable_layering;
 };
 
 struct fi_filter {

--- a/include/ofi_bitmask.h
+++ b/include/ofi_bitmask.h
@@ -90,7 +90,7 @@ static inline void ofi_bitmask_set_all(struct bitmask *mask)
 
 static inline size_t ofi_bitmask_get_lsbset(struct bitmask mask)
 {
-	int cur;
+	size_t cur;
 	uint8_t tmp;
 	size_t ret = 0;
 

--- a/include/ofi_lock.h
+++ b/include/ofi_lock.h
@@ -161,6 +161,8 @@ static inline void ofi_fastlock_acquire_noop(fastlock_t *lock)
 	/* These non-op routines must be used only by a single-threaded code*/
 	assert(!lock->in_use);
 	lock->in_use = 1;
+#else
+    (void)lock;
 #endif
 }
 static inline void ofi_fastlock_release_noop(fastlock_t *lock)
@@ -168,6 +170,8 @@ static inline void ofi_fastlock_release_noop(fastlock_t *lock)
 #if ENABLE_DEBUG
 	assert(lock->in_use);
 	lock->in_use = 0;
+#else
+    (void)lock;
 #endif
 }
 

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -163,6 +163,7 @@ struct ofi_addr_list_entry {
 	size_t			speed;
 	char			net_name[OFI_ADDRSTRLEN];
 	char			ifa_name[OFI_ADDRSTRLEN];
+	uint64_t		comm_caps;
 };
 
 int ofi_addr_cmp(const struct fi_provider *prov, const struct sockaddr *sa1,

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -452,9 +452,11 @@ int ofi_wait_fd_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 int ofi_wait_add_fd(struct util_wait *wait, int fd, uint32_t events,
 		    ofi_wait_try_func wait_try, void *arg, void *context);
 int ofi_wait_del_fd(struct util_wait *wait, int fd);
+int ofi_wait_fdset_del(struct util_wait_fd *wait_fd, int fd);
 int ofi_wait_add_fid(struct util_wait *wat, fid_t fid, uint32_t events,
 		     ofi_wait_try_func wait_try);
 int ofi_wait_del_fid(struct util_wait *wait, fid_t fid);
+
 
 struct util_wait_yield {
 	struct util_wait	util_wait;

--- a/prov/rxd/src/rxd.h
+++ b/prov/rxd/src/rxd.h
@@ -220,12 +220,10 @@ struct rxd_ep {
 
 	struct index_map peers_idm;
 };
-
+/* ensure ep lock is held before this function is called */
 static inline struct rxd_peer *rxd_peer(struct rxd_ep *ep, fi_addr_t rxd_addr)
 {
-	fastlock_tryacquire(&ep->util_ep.lock);
 	return ofi_idm_lookup(&ep->peers_idm, rxd_addr);
-	fastlock_release(&ep->util_ep.lock);
 
 }
 static inline struct rxd_domain *rxd_ep_domain(struct rxd_ep *ep)

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -1167,15 +1167,12 @@ int rxd_create_peer(struct rxd_ep *ep, uint64_t rxd_addr)
 	dlist_init(&(peer->rx_list));
 	dlist_init(&(peer->rma_rx_list));
 	dlist_init(&(peer->buf_pkts));
-	
-	fastlock_tryacquire(&ep->util_ep.lock);
+		
 	if (ofi_idm_set(&(ep->peers_idm), rxd_addr, peer) < 0)
 		goto err;
-	fastlock_release(&ep->util_ep.lock);
 	
 	return 0;
 err:	
-	fastlock_release(&ep->util_ep.lock);
 	free(peer);
 	return -FI_ENOMEM;
 }

--- a/prov/sockets/src/sock_progress.c
+++ b/prov/sockets/src/sock_progress.c
@@ -1325,6 +1325,10 @@ static int sock_pe_process_rx_send(struct sock_pe *pe,
 	offset = 0;
 	len = sizeof(struct sock_msg_hdr);
 
+	if (pe_entry->addr == FI_ADDR_NOTAVAIL &&
+	    pe_entry->ep_attr->ep_type == FI_EP_RDM && pe_entry->ep_attr->av)
+		pe_entry->addr = pe_entry->conn->av_index;
+
 	if (pe_entry->msg_hdr.op_type == SOCK_OP_TSEND) {
 		if (sock_pe_recv_field(pe_entry, &pe_entry->tag,
 				       SOCK_TAG_SIZE, len))

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -42,54 +42,6 @@
 #include <ofi_util.h>
 #include <ofi_iov.h>
 
-static void tcpx_ep_flush_pending_xfers(struct tcpx_ep *ep)
-{
-	struct slist_entry *entry;
-	struct tcpx_xfer_entry *tx_entry;
-	struct tcpx_cq *cq;
-
-	while (!slist_empty(&ep->tx_rsp_pend_queue)) {
-		entry = slist_remove_head(&ep->tx_rsp_pend_queue);
-		tx_entry = container_of(entry, struct tcpx_xfer_entry, entry);
-		tcpx_cq_report_error(ep->util_ep.tx_cq, tx_entry, FI_ENOTCONN);
-
-		cq = container_of(ep->util_ep.tx_cq, struct tcpx_cq, util_cq);
-		tcpx_xfer_entry_release(cq, tx_entry);
-	}
-}
-
-/**
- * Shutdown is done in two phases, phase1 writes the FI_SHUTDOWN event, which
- * a polling thread still needs to handle, phase2 removes the fd
- * of the ep from polling, so that a polling thread won't spin
- * if it does not close the connection immediately after it handled
- * FI_SHUTDOWN
- */
-int tcpx_ep_shutdown_report(struct tcpx_ep *ep, fid_t fid)
-{
-	struct fi_eq_cm_entry cm_entry = {0};
-	ssize_t len;
-
-	switch (ep->cm_state) {
-	case TCPX_EP_POLL_REMOVED:
-		break;
-	case TCPX_EP_SHUTDOWN:
-		tcpx_ep_wait_fd_del(ep);
-		ep->cm_state = TCPX_EP_POLL_REMOVED;
-		break;
-	default:
-		tcpx_ep_flush_pending_xfers(ep);
-		ep->cm_state = TCPX_EP_SHUTDOWN;
-		cm_entry.fid = fid;
-		len =  fi_eq_write(&ep->util_ep.eq->eq_fid, FI_SHUTDOWN,
-				   &cm_entry, sizeof(cm_entry), 0);
-		if (len < 0)
-			return (int) len;
-		break;
-	}
-
-	return FI_SUCCESS;
-}
 
 static void process_tx_entry(struct tcpx_xfer_entry *tx_entry)
 {
@@ -106,8 +58,7 @@ static void process_tx_entry(struct tcpx_xfer_entry *tx_entry)
 
 	if (ret) {
 		FI_WARN(&tcpx_prov, FI_LOG_DOMAIN, "msg send failed\n");
-		tcpx_ep_shutdown_report(tx_entry->ep,
-					&tx_entry->ep->util_ep.ep_fid.fid);
+		tcpx_ep_disable(tx_entry->ep, 0);
 		tcpx_cq_report_error(tx_entry->ep->util_ep.tx_cq,
 				     tx_entry, -ret);
 	} else {
@@ -171,8 +122,7 @@ static int process_rx_entry(struct tcpx_xfer_entry *rx_entry)
 		FI_WARN(&tcpx_prov, FI_LOG_EP_DATA,
 			"msg recv Failed ret = %d\n", ret);
 
-		tcpx_ep_shutdown_report(rx_entry->ep,
-					&rx_entry->ep->util_ep.ep_fid.fid);
+		tcpx_ep_disable(rx_entry->ep, 0);
 		tcpx_cq_report_error(rx_entry->ep->util_ep.rx_cq, rx_entry, -ret);
 		tcpx_rx_msg_release(rx_entry);
 	} else if (rx_entry->hdr.base_hdr.flags & OFI_DELIVERY_COMPLETE) {
@@ -258,8 +208,7 @@ static int process_remote_write(struct tcpx_xfer_entry *rx_entry)
 			"remote write Failed ret = %d\n",
 			ret);
 
-		tcpx_ep_shutdown_report(rx_entry->ep,
-					&rx_entry->ep->util_ep.ep_fid.fid);
+		tcpx_ep_disable(rx_entry->ep, 0);
 		tcpx_cq_report_error(rx_entry->ep->util_ep.rx_cq, rx_entry, -ret);
 		tcpx_cq = container_of(rx_entry->ep->util_ep.rx_cq,
 				       struct tcpx_cq, util_cq);
@@ -294,8 +243,7 @@ static int process_remote_read(struct tcpx_xfer_entry *rx_entry)
 	if (ret) {
 		FI_WARN(&tcpx_prov, FI_LOG_DOMAIN,
 			"msg recv Failed ret = %d\n", ret);
-		tcpx_ep_shutdown_report(rx_entry->ep,
-					&rx_entry->ep->util_ep.ep_fid.fid);
+		tcpx_ep_disable(rx_entry->ep, 0);
 		tcpx_cq_report_error(rx_entry->ep->util_ep.tx_cq, rx_entry, -ret);
 	} else {
 		tcpx_cq_report_success(rx_entry->ep->util_ep.tx_cq, rx_entry);
@@ -649,7 +597,7 @@ err:
 		return;
 
 	if (ret == -FI_ENOTCONN)
-		tcpx_ep_shutdown_report(ep, &ep->util_ep.ep_fid.fid);
+		tcpx_ep_disable(ep, 0);
 }
 
 /* Must hold ep lock */

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -190,12 +190,10 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 
 	*smr = mapped_addr;
 	fastlock_init(&(*smr)->lock);
-	fastlock_acquire(&(*smr)->lock);
 
 	(*smr)->map = map;
 	(*smr)->version = SMR_VERSION;
 	(*smr)->flags = SMR_FLAG_ATOMIC | SMR_FLAG_DEBUG;
-	(*smr)->pid = getpid();
 	(*smr)->cma_cap = SMR_CMA_CAP_NA;
 	(*smr)->base_addr = *smr;
 
@@ -220,8 +218,9 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 	}
 
 	strncpy((char *) smr_name(*smr), attr->name, total_size - name_offset);
-	fastlock_release(&(*smr)->lock);
 
+	/* Must be set last to signal full initialization to peers */
+	(*smr)->pid = getpid();
 	return 0;
 
 remove:

--- a/prov/util/src/util_wait.c
+++ b/prov/util/src/util_wait.c
@@ -180,7 +180,7 @@ static int ofi_wait_match_fd(struct dlist_entry *item, const void *arg)
 	return fd_entry->fd == *(int *) arg;
 }
 
-static int ofi_wait_fdset_del(struct util_wait_fd *wait_fd, int fd)
+int ofi_wait_fdset_del(struct util_wait_fd *wait_fd, int fd)
 {
 	wait_fd->change_index++;
 
@@ -190,7 +190,7 @@ static int ofi_wait_fdset_del(struct util_wait_fd *wait_fd, int fd)
 }
 
 static int ofi_wait_fdset_add(struct util_wait_fd *wait_fd, int fd,
-			       uint32_t events, void *context)
+			      uint32_t events, void *context)
 {
 	int ret;
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -573,7 +573,7 @@ struct vrb_ep {
 	uint64_t			sq_credits;
 	uint64_t			peer_rq_credits;
 	/* Protected by recv CQ lock */
-	uint64_t			rq_credits_avail;
+	int64_t				rq_credits_avail;
 	uint64_t			threshold;
 
 	union {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -364,11 +364,15 @@ struct vrb_domain {
 		int			xrcd_fd;
 		struct ibv_xrcd		*xrcd;
 
-		/* The domain maintains a RBTree for mapping an endpoint
-		 * destination addresses to physical XRC INI QP connected
-		 * to that host. The map is protected using the EQ lock
-		 * bound to the domain to avoid the need for additional
-		 * locking. */
+		/* XRC INI QP connections can be shared between endpoint
+		 * within the same domain. The domain maintains an RBTree
+		 * for mapping endpoint destination addresses to the
+		 * physical XRC INI connection to the associated node. The
+		 * map and XRC INI connection object state information are
+		 * protected via the ini_lock. */
+		fastlock_t		ini_lock;
+		ofi_fastlock_acquire_t	lock_acquire;
+		ofi_fastlock_release_t	lock_release;
 		struct ofi_rbmap	*ini_conn_rbmap;
 	} xrc;
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -574,7 +574,7 @@ struct vrb_ep {
 	uint64_t			peer_rq_credits;
 	/* Protected by recv CQ lock */
 	int64_t				rq_credits_avail;
-	uint64_t			threshold;
+	int64_t				threshold;
 
 	union {
 		struct rdma_cm_id	*id;

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -142,12 +142,12 @@ void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 	if (ep->base_ep.id) {
 		addr = rdma_get_local_addr(ep->base_ep.id);
 		len = sizeof(buf);
-		ofi_straddr(buf, &len, ep->base_ep.info->addr_format, addr);
+		ofi_straddr(buf, &len, ep->base_ep.info_attr.addr_format, addr);
 		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p src_addr: %s\n", ep, buf);
 
 		addr = rdma_get_peer_addr(ep->base_ep.id);
 		len = sizeof(buf);
-		ofi_straddr(buf, &len, ep->base_ep.info->addr_format, addr);
+		ofi_straddr(buf, &len, ep->base_ep.info_attr.addr_format, addr);
 		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p dst_addr: %s\n", ep, buf);
 	}
 
@@ -192,6 +192,9 @@ void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect)
 	if (!disconnect) {
 		free(ep->conn_setup);
 		ep->conn_setup = NULL;
+		free(ep->base_ep.info_attr.src_addr);
+		ep->base_ep.info_attr.src_addr = NULL;
+		ep->base_ep.info_attr.src_addrlen = 0;
 	}
 }
 
@@ -323,7 +326,7 @@ int vrb_accept_xrc(struct vrb_xrc_ep *ep, int reciprocal,
 	if (addr)
 		ofi_straddr_dbg(&vrb_prov, FI_LOG_CORE, "dest_addr", addr);
 
-	connreq = container_of(ep->base_ep.info->handle,
+	connreq = container_of(ep->base_ep.info_attr.handle,
 			       struct vrb_connreq, handle);
 	ret = vrb_ep_create_tgt_qp(ep, connreq->xrc.tgt_qpn);
 	if (ret)
@@ -393,8 +396,8 @@ int vrb_process_xrc_connreq(struct vrb_ep *ep,
 	struct vrb_xrc_ep *xrc_ep = container_of(ep, struct vrb_xrc_ep,
 						    base_ep);
 
-	assert(ep->info->src_addr);
-	assert(ep->info->dest_addr);
+	assert(ep->info_attr.src_addr);
+	assert(ep->info_attr.dest_addr);
 
 	xrc_ep->conn_setup = calloc(1, sizeof(*xrc_ep->conn_setup));
 	if (!xrc_ep->conn_setup) {
@@ -407,8 +410,8 @@ int vrb_process_xrc_connreq(struct vrb_ep *ep,
 	/* This endpoint was created on the passive side of a connection
 	 * request. The reciprocal connection request will go back to the
 	 * passive port indicated by the active side */
-	ofi_addr_set_port(ep->info->src_addr, 0);
-	ofi_addr_set_port(ep->info->dest_addr, connreq->xrc.port);
+	ofi_addr_set_port(ep->info_attr.src_addr, 0);
+	ofi_addr_set_port(ep->info_attr.dest_addr, connreq->xrc.port);
 	xrc_ep->tgt_id = connreq->id;
 	xrc_ep->tgt_id->context = &ep->util_ep.ep_fid.fid;
 

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -309,7 +309,7 @@ vrb_domain(struct fid_fabric *fabric, struct fi_info *info,
 		goto err2;
 
 	_domain->ep_type = VRB_EP_TYPE(info);
-	_domain->flags |= vrb_is_xrc(info) ? VRB_USE_XRC : 0;
+	_domain->flags |= vrb_is_xrc_info(info) ? VRB_USE_XRC : 0;
 
 	ret = vrb_open_device_by_name(_domain, info->domain_attr->name);
 	if (ret)

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -107,7 +107,7 @@ static int vrb_create_ini_qp(struct vrb_xrc_ep *ep)
 static inline void vrb_set_ini_conn_key(struct vrb_xrc_ep *ep,
 					   struct vrb_ini_conn_key *key)
 {
-	key->addr = ep->base_ep.info->dest_addr;
+	key->addr = ep->base_ep.info_attr.dest_addr;
 	key->tx_cq = container_of(ep->base_ep.util_ep.tx_cq,
 				  struct vrb_cq, util_cq);
 }
@@ -270,7 +270,7 @@ void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn)
 				  &ep->ini_conn->active_list);
 		last_state = ep->ini_conn->state;
 
-		ret = vrb_create_ep(ep->base_ep.info,
+		ret = vrb_create_ep(&ep->base_ep,
 				       last_state == VRB_INI_QP_UNCONNECTED ?
 				       RDMA_PS_TCP : RDMA_PS_UDP,
 				       &ep->base_ep.id);

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -315,6 +315,12 @@ vrb_alloc_init_ep(struct fi_info *info, struct vrb_domain *domain,
 			return NULL;
 	}
 
+	// When we are enabling flow control, we artificially inject
+	// a credit so that the credit messaging itself is not blocked
+	// by a lack of credits.  To counter this, we will adjust the number
+	// of credit we send the first time by initializing to -1.
+	ep->rq_credits_avail = -1;
+
 	ep->info = fi_dupinfo(info);
 	if (!ep->info)
 		goto err1;

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1023,7 +1023,7 @@ int vrb_open_ep(struct fid_domain *domain, struct fi_info *info,
 
 	ep->inject_limit = ep->info->tx_attr->inject_size;
 	ep->peer_rq_credits = UINT64_MAX;
-	ep->threshold = UINT64_MAX; /* disables RQ flow control */
+	ep->threshold = INT64_MAX; /* disables RQ flow control */
 
 	switch (info->ep_attr->type) {
 	case FI_EP_MSG:

--- a/prov/verbs/src/verbs_eq.c
+++ b/prov/verbs/src/verbs_eq.c
@@ -251,7 +251,7 @@ vrb_eq_cm_getinfo(struct rdma_cm_event *event, struct fi_info *pep_info,
 	connreq->handle.fclass = FI_CLASS_CONNREQ;
 	connreq->id = event->id;
 
-	if (vrb_is_xrc(*info)) {
+	if (vrb_is_xrc_info(*info)) {
 		connreq->is_xrc = 1;
 		ret = vrb_eq_set_xrc_info(event, &connreq->xrc);
 		if (ret)
@@ -323,19 +323,19 @@ static int vrb_sidr_conn_compare(struct ofi_rbmap *map,
 	int ret;
 
 	assert(_key->addr->sa_family ==
-	       ofi_sa_family(ep->base_ep.info->dest_addr));
+	       ofi_sa_family(ep->base_ep.info_attr.dest_addr));
 
 	/* The interface address and the passive endpoint port define
 	 * the unique connection to a peer */
 	switch(_key->addr->sa_family) {
 	case AF_INET:
 		ret = memcmp(&ofi_sin_addr(_key->addr),
-			     &ofi_sin_addr(ep->base_ep.info->dest_addr),
+			     &ofi_sin_addr(ep->base_ep.info_attr.dest_addr),
 			     sizeof(ofi_sin_addr(_key->addr)));
 		break;
 	case AF_INET6:
 		ret = memcmp(&ofi_sin6_addr(_key->addr),
-			     &ofi_sin6_addr(ep->base_ep.info->dest_addr),
+			     &ofi_sin6_addr(ep->base_ep.info_attr.dest_addr),
 			     sizeof(ofi_sin6_addr(_key->addr)));
 		break;
 	default:
@@ -381,7 +381,7 @@ int vrb_eq_add_sidr_conn(struct vrb_xrc_ep *ep,
 	assert(param_len);
 	assert(ep->tgt_id && ep->tgt_id->ps == RDMA_PS_UDP);
 
-	vrb_set_sidr_conn_key(ep->base_ep.info->dest_addr,
+	vrb_set_sidr_conn_key(ep->base_ep.info_attr.dest_addr,
 				 ep->remote_pep_port, ep->recip_accept, &key);
 	ep->accept_param_data = calloc(1, param_len);
 	if (!ep->accept_param_data) {
@@ -520,7 +520,7 @@ vrb_eq_xrc_connreq_event(struct vrb_eq *eq, struct fi_eq_cm_entry *entry,
 
 	ep->tgt_id = connreq->id;
 	ep->tgt_id->context = &ep->base_ep.util_ep.ep_fid.fid;
-	ep->base_ep.info->handle = entry->info->handle;
+	ep->base_ep.info_attr.handle = entry->info->handle;
 
 	ret = rdma_migrate_id(ep->tgt_id, ep->base_ep.eq->channel);
 	if (ret) {
@@ -708,14 +708,14 @@ static inline int
 vrb_eq_xrc_connect_retry(struct vrb_xrc_ep *ep,
 			 struct rdma_cm_event *cma_event, int *acked)
 {
-	if (ep->base_ep.info->src_addr)
+	if (ep->base_ep.info_attr.src_addr)
 		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL,
 				"Connect retry src ",
-				ep->base_ep.info->src_addr);
-	if (ep->base_ep.info->dest_addr)
+				ep->base_ep.info_attr.src_addr);
+	if (ep->base_ep.info_attr.dest_addr)
 		ofi_straddr_dbg(&vrb_prov, FI_LOG_EP_CTRL,
 				"Connect retry dest ",
-				ep->base_ep.info->dest_addr);
+				ep->base_ep.info_attr.dest_addr);
 
 	*acked = 1;
 	rdma_ack_cm_event(cma_event);
@@ -766,12 +766,12 @@ vrb_eq_xrc_cm_err_event(struct vrb_eq *eq,
 
 	VERBS_WARN(FI_LOG_EP_CTRL, "CM error event %s, status %d\n",
 		   rdma_event_str(cma_event->event), cma_event->status);
-	if (ep->base_ep.info->src_addr)
+	if (ep->base_ep.info_attr.src_addr)
 		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
-				"Src ", ep->base_ep.info->src_addr);
-	if (ep->base_ep.info->dest_addr)
+				"Src ", ep->base_ep.info_attr.src_addr);
+	if (ep->base_ep.info_attr.dest_addr)
 		ofi_straddr_log(&vrb_prov, FI_LOG_WARN, FI_LOG_EP_CTRL,
-				"Dest ", ep->base_ep.info->dest_addr);
+				"Dest ", ep->base_ep.info_attr.dest_addr);
         ep->conn_state = VRB_XRC_ERROR;
         return FI_SUCCESS;
 }
@@ -874,7 +874,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 			FI_WARN(&vrb_prov, FI_LOG_EP_CTRL,
 				"rdma_connect failed: %s (%d)\n",
 				strerror(-ret), -ret);
-			if (vrb_is_xrc(ep->info)) {
+			if (vrb_is_xrc_ep(ep)) {
 				xrc_ep = container_of(fid, struct vrb_xrc_ep,
 						      base_ep.util_ep.ep_fid);
 				vrb_put_shared_ini_conn(xrc_ep);
@@ -896,7 +896,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 			goto err;
 		}
 
-		if (vrb_is_xrc(entry->info)) {
+		if (vrb_is_xrc_info(entry->info)) {
 			ret = vrb_eq_xrc_connreq_event(eq, entry, len, event,
 							  cma_event, &acked,
 							  &priv_data, &priv_datalen);
@@ -923,7 +923,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 				goto ack;
 		}
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		if (vrb_is_xrc(ep->info)) {
+		if (vrb_is_xrc_ep(ep)) {
 			ret = vrb_eq_xrc_connected_event(eq, cma_event,
 							    &acked, entry, len,
 							    event);
@@ -933,7 +933,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 		break;
 	case RDMA_CM_EVENT_DISCONNECTED:
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		if (vrb_is_xrc(ep->info)) {
+		if (vrb_is_xrc_ep(ep)) {
 			vrb_eq_xrc_disconnect_event(eq, cma_event, &acked);
 			ret = -FI_EAGAIN;
 			goto ack;
@@ -943,7 +943,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 		break;
 	case RDMA_CM_EVENT_TIMEWAIT_EXIT:
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		if (vrb_is_xrc(ep->info))
+		if (vrb_is_xrc_ep(ep))
 			vrb_eq_xrc_timewait_event(eq, cma_event, &acked);
 		ret = -FI_EAGAIN;
 		goto ack;
@@ -952,8 +952,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 	case RDMA_CM_EVENT_CONNECT_ERROR:
 	case RDMA_CM_EVENT_UNREACHABLE:
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		assert(ep->info);
-		if (vrb_is_xrc(ep->info)) {
+		if (vrb_is_xrc_ep(ep)) {
 			/* SIDR Reject is reported as UNREACHABLE unless
 			 * status is negative */
 			if (cma_event->id->ps == RDMA_PS_UDP &&
@@ -979,7 +978,7 @@ vrb_eq_cm_process_event(struct vrb_eq *eq,
 		goto err;
 	case RDMA_CM_EVENT_REJECTED:
 		ep = container_of(fid, struct vrb_ep, util_ep.ep_fid);
-		if (vrb_is_xrc(ep->info)) {
+		if (vrb_is_xrc_ep(ep)) {
 xrc_shared_reject:
 			ret = vrb_eq_xrc_rej_event(eq, cma_event);
 			if (ret == -FI_EAGAIN)

--- a/src/common.c
+++ b/src/common.c
@@ -1216,10 +1216,11 @@ void ofi_insert_loopback_addr(const struct fi_provider *prov, struct slist *addr
 {
 	struct ofi_addr_list_entry *addr_entry;
 
-	addr_entry = calloc(1, sizeof(struct ofi_addr_list_entry));
+	addr_entry = calloc(1, sizeof(*addr_entry));
 	if (!addr_entry)
 		return;
 
+	addr_entry->comm_caps = FI_LOCAL_COMM;
 	addr_entry->ipaddr.sin.sin_family = AF_INET;
 	addr_entry->ipaddr.sin.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
 	ofi_straddr_log(prov, FI_LOG_INFO, FI_LOG_CORE,
@@ -1230,10 +1231,11 @@ void ofi_insert_loopback_addr(const struct fi_provider *prov, struct slist *addr
 	strncpy(addr_entry->ifa_name, "lo", sizeof(addr_entry->ifa_name));
 	slist_insert_tail(&addr_entry->entry, addr_list);
 
-	addr_entry = calloc(1, sizeof(struct ofi_addr_list_entry));
+	addr_entry = calloc(1, sizeof(*addr_entry));
 	if (!addr_entry)
 		return;
 
+	addr_entry->comm_caps = FI_LOCAL_COMM;
 	addr_entry->ipaddr.sin6.sin6_family = AF_INET6;
 	addr_entry->ipaddr.sin6.sin6_addr = in6addr_loopback;
 	ofi_straddr_log(prov, FI_LOG_INFO, FI_LOG_CORE,
@@ -1358,6 +1360,7 @@ void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 		if (!addr_entry)
 			continue;
 
+		addr_entry->comm_caps = FI_LOCAL_COMM | FI_REMOTE_COMM;
 		memcpy(&addr_entry->ipaddr, ifa->ifa_addr,
 			ofi_sizeofaddr(ifa->ifa_addr));
 		strncpy(addr_entry->ifa_name, ifa->ifa_name,
@@ -1422,6 +1425,7 @@ void ofi_get_list_of_addr(const struct fi_provider *prov, const char *env_name,
 			if (!addr_entry)
 				break;
 
+			addr_entry->comm_caps = FI_LOCAL_COMM | FI_REMOTE_COMM;
 			addr_entry->ipaddr.sin.sin_family = AF_INET;
 			addr_entry->ipaddr.sin.sin_addr.s_addr =
 						iptbl->table[i].dwAddr;

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -271,7 +271,7 @@ static struct ofi_prov *ofi_getprov(const char *prov_name, size_t len)
 
 	for (prov = prov_head; prov; prov = prov->next) {
 		if ((strlen(prov->prov_name) == len) &&
-		    !strncmp(prov->prov_name, prov_name, len))
+		    !strncasecmp(prov->prov_name, prov_name, len))
 			return prov;
 	}
 

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -450,7 +450,7 @@ static void ofi_register_provider(struct fi_provider *provider, void *dlhandle)
 	 */
 	if (!strcasecmp(provider->name, "sockets") ||
 	    !strcasecmp(provider->name, "shm") ||
-	    ofi_is_util_prov(provider))
+	    !strcasecmp(provider->name, "efa") || ofi_is_util_prov(provider))
 		ctx->disable_layering = 1;
 
 	prov = ofi_getprov(provider->name, strlen(provider->name));

--- a/src/fabric.c
+++ b/src/fabric.c
@@ -138,6 +138,13 @@ static enum ofi_prov_type ofi_prov_type(const struct fi_provider *provider)
 	return ctx->type;
 }
 
+static int ofi_disable_util_layering(const struct fi_provider *provider) {
+	const struct fi_prov_context *ctx;
+
+	ctx = (const struct fi_prov_context *) &provider->context;
+	return ctx->disable_layering;
+}
+
 static int ofi_is_util_prov(const struct fi_provider *provider)
 {
 	return ofi_prov_type(provider) == OFI_PROV_UTIL;
@@ -436,6 +443,15 @@ static void ofi_register_provider(struct fi_provider *provider, void *dlhandle)
 
 	if (ofi_apply_filter(&prov_log_filter, provider->name))
 		ctx->disable_logging = 1;
+
+	/*
+	 * Prevent utility providers from layering on these core providers
+	 * unless explicitly requested.
+	 */
+	if (!strcasecmp(provider->name, "sockets") ||
+	    !strcasecmp(provider->name, "shm") ||
+	    ofi_is_util_prov(provider))
+		ctx->disable_layering = 1;
 
 	prov = ofi_getprov(provider->name, strlen(provider->name));
 	if (prov) {
@@ -860,8 +876,9 @@ static void ofi_set_prov_attr(struct fi_fabric_attr *attr,
  *    1b. If a utility provider is specified, return it over any* core provider.
  *    1c. If a core provider is specified, return any utility provider that can
  *        layer over it, plus the core provider itself, if possible.
- *    1d. A utility provider will not layer over the sockets provider unless the
- *        user explicitly requests that combination.
+ *    1d. A utility provider will not layer over a provider that has disabled
+ *        utility provider layering unless the user explicitly requests that
+ *        combination.
  *    1e. OFI_CORE_PROV_ONLY flag prevents utility providers layering over other
  *        utility providers.
  * 2. If both the providers are utility providers or if more than two providers
@@ -875,6 +892,7 @@ static int ofi_layering_ok(const struct fi_provider *provider,
 			   uint64_t flags)
 {
 	char *prov_name;
+	struct ofi_prov *core_ofi_prov;
 	int i;
 
 	/* Excluded providers must be at the end */
@@ -896,9 +914,9 @@ static int ofi_layering_ok(const struct fi_provider *provider,
 			return 0;
 		}
 
-		if ((count == 0) && !strcasecmp(provider->name, "sockets")) {
+		if ((count == 0) && ofi_disable_util_layering(provider)) {
 			FI_INFO(&core_prov, FI_LOG_CORE,
-				"Skipping util;sockets layering\n");
+				"Skipping util;%s layering\n", provider->name);
 			return 0;
 		}
 	}
@@ -913,14 +931,12 @@ static int ofi_layering_ok(const struct fi_provider *provider,
 
 	if ((count == 1) && ofi_is_util_prov(provider) &&
 	    !ofi_has_util_prefix(prov_vec[0])) {
-		if (!strcasecmp(prov_vec[0], "sockets")) {
+		core_ofi_prov = ofi_getprov(prov_vec[0], strlen(prov_vec[0]));
+		if (core_ofi_prov && core_ofi_prov->provider &&
+		    ofi_disable_util_layering(core_ofi_prov->provider)) {
 			FI_INFO(&core_prov, FI_LOG_CORE,
-				"Sockets requested, skipping util layering\n");
-			return 0;
-		}
-		if (!strcasecmp(prov_vec[0], "shm")) {
-			FI_INFO(&core_prov, FI_LOG_CORE,
-				"Shm requested, skipping util layering\n");
+				"Skipping %s;%s layering\n", prov_vec[0],
+				provider->name);
 			return 0;
 		}
 		return 1;


### PR DESCRIPTION
Pulls in these fixes from master:

commit edd3691dbd3b67d42bf9a30dc62d8f1cd6a157e7
    fabtests/recv_cancel: repost cancelled recv
commit 2751e7287da36c72d9cf50b25e9172d49f12fc9c
    fabtests/common: fix large transfer data validation
commit b5357c4f63da0adab2060ac820753d0c674d1f03
    core: Get rid of unused parameters warning
commit 245c4b23b73df50adee0fad46b74903a43cc2a50
    core: Get rid of type mismatch warning
commit 1e82728dc08495819e94c234199aae35ae768892
    Reduce overall memory footprint in a fully connected fabric
commit 3a63d76698aac8ed2a4be0f84c03ae29eca51108
    prov/verbs: Fix disablement of RQ flow control
commit 8018cd1791da7966ba91251f787d8fe0c6e3c792
    prov/verbs: account for off-by-one credit initialization
commit 82b073e84ef43ce33ac788ac9d5a54fd82a2d4e3
    prov/shm: support CMA copies larger than 2GB
commit 230693192b4a3806f3d2c9b070691fa08be9ee44
    fabtests/common: fix transfer_size op parsing
commit 4bb94d56e02b61b1f32f61d93fb9a75e741324d6
    core: change ofi_getprov() to ignore case when comparing prov names
commit ce9bef0a1c6c2097804e8c64a038e778837c1ea3
    core: add efa to list to prevent utility provider layering
commit f978d7a1d48c802529a03d49c4cb7c7a4fb34231
    core: add disable_layering flag to fi_prov_context
commit 03b9dcc4b1694b1a8ba87eeca80188a33b3eedcb
    prov/sockets: Retry address lookup if not set
commit 8018cd1791da7966ba91251f787d8fe0c6e3c792
    prov/verbs: account for off-by-one credit initialization
commit 07d37649f5ddc11604cb210b8fc3b5f78afb3734
    prov/verbs: Fix XRC transport shared INI QP locking
commit 30b93ae025fcfe88f0441f155d487957d1c8978a
    prov/tcp: Rework CM state machine to fix lock inversion
commit be01ebd9b9b5f7e6bd9f413424c1858409cc1c1c
    prov/tcp: Rename cq_report_xfer_fail -> ep_flush_pending_xfers
commit b107fee5094cdcb7ee77f518f6b83c2c3208cf07
    util/wait: Expose ofi_wait_fdset_del for direct access
commit f3d208bd9da93908bcb5279193ae44915c479862
    prov/rxd: remove redundant calls to fastlock_tryacquire.
commit ccb955a3f98d5cb0719b757afb9a551fc9497944
    prov/tcp: Fix deadlock due to AB-BA lock ordering
commit a970f3b35cdef7d2c3d209fcee61daeb3af606e5
    util/shm: replace lock with PID setting
commit ac55a43dc5c37beac918fcd84fb78c795762bd66
    core/net: Mark if addresses support local/remote communication

There are additional fixes to pull in, but I started hitting conflicts and need to figure out the prerequisite patches to also pull in, unless of course the fixes are the result of the pre-reqs.