### PR TITLE
prov/psm2: Allow per-endpoint UUID assignment

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -115,6 +115,12 @@ The *psm2* provider checks for the following environment variables:
 
   The default UUID is 00FF00FF-0000-0000-0000-00FF0F0F00FF.
 
+  It is possible to create endpoints with UUID different from the one
+  set here. To achieve that, set 'info->ep_attr->auth_key' to the uuid
+  value and 'info->ep_attr->auth_key_size' to its size (16 bytes) when
+  calling fi_endpoint() or fi_scalable_ep(). It is still true that an
+  endpoint can only communicate with endpoints with the same UUID.
+
 *FI_PSM2_NAME_SERVER*
 : The *psm2* provider has a simple built-in name server that can be used
   to resolve an IP address or host name into a transport address needed

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -528,6 +528,8 @@ struct psmx2_trx_ctxt {
 	ofi_atomic32_t		poll_refcnt;
 	int			poll_active;
 
+	psm2_uuid_t		uuid;
+
 	struct dlist_entry	entry;
 };
 
@@ -989,7 +991,8 @@ int	psmx2_domain_enable_ep(struct psmx2_fid_domain *domain, struct psmx2_fid_ep 
 void	psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt, int usage_flags);
 struct	psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 					     struct psmx2_ep_name *src_addr,
-					     int sep_ctxt_idx, int usage_flags);
+					     int sep_ctxt_idx, int usage_flags,
+					     uint8_t *uuid);
 
 static inline
 int	psmx2_ns_service_cmp(void *svc1, void *svc2)

--- a/prov/psm2/src/psmx2_ep.c
+++ b/prov/psm2/src/psmx2_ep.c
@@ -526,24 +526,6 @@ int psmx2_ep_open_internal(struct psmx2_fid_domain *domain_priv,
 	else
 		ep_cap = FI_TAGGED;
 
-	if (info && info->ep_attr && info->ep_attr->auth_key) {
-		if (info->ep_attr->auth_key_size != sizeof(psm2_uuid_t)) {
-			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
-				"Invalid auth_key_len %"PRIu64
-				", should be %"PRIu64".\n",
-				info->ep_attr->auth_key_size,
-				sizeof(psm2_uuid_t));
-			goto errout;
-		}
-		if (memcmp(domain_priv->fabric->uuid, info->ep_attr->auth_key,
-			   sizeof(psm2_uuid_t))) {
-			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
-				"Invalid auth_key: %s\n",
-				psmx2_uuid_to_string((void *)info->ep_attr->auth_key));
-			goto errout;
-		}
-	}
-
 	ep_priv = (struct psmx2_fid_ep *) calloc(1, sizeof *ep_priv);
 	if (!ep_priv) {
 		err = -FI_ENOMEM;
@@ -625,6 +607,7 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 	struct psmx2_trx_ctxt *trx_ctxt = NULL;
 	int err = -FI_EINVAL;
 	int usage_flags = PSMX2_TX_RX;
+	uint8_t *uuid = NULL;
 
 	domain_priv = container_of(domain, struct psmx2_fid_domain,
 				   util_domain.domain_fid.fid);
@@ -655,9 +638,21 @@ int psmx2_ep_open(struct fid_domain *domain, struct fi_info *info,
 			src_addr = info->src_addr;
 	}
 
+	if (info && info->ep_attr && info->ep_attr->auth_key) {
+		if (info->ep_attr->auth_key_size != sizeof(psm2_uuid_t)) {
+			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
+				"Invalid auth_key_len %"PRIu64
+				", should be %"PRIu64".\n",
+				info->ep_attr->auth_key_size,
+				sizeof(psm2_uuid_t));
+			goto errout;
+		}
+		uuid = info->ep_attr->auth_key;
+	}
+
 	if (usage_flags) {
 		trx_ctxt = psmx2_trx_ctxt_alloc(domain_priv, src_addr, -1,
-						usage_flags);
+						usage_flags, uuid);
 		if (!trx_ctxt)
 			goto errout;
 	} else {
@@ -758,7 +753,9 @@ int psmx2_stx_ctx(struct fid_domain *domain, struct fi_tx_attr *attr,
 		goto errout;
 	}
 
-	trx_ctxt = psmx2_trx_ctxt_alloc(domain_priv, NULL, -1, PSMX2_TX);
+	/* no auth_key is provided, use NULL to pick the default uuid */
+	trx_ctxt = psmx2_trx_ctxt_alloc(domain_priv, NULL, -1, PSMX2_TX,
+					NULL);
 	if (!trx_ctxt) {
 		err = -FI_ENOMEM;
 		goto errout_free_stx;
@@ -941,6 +938,7 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 	size_t ctxt_cnt = 1;
 	size_t ctxt_size;
 	int err = -FI_EINVAL;
+	uint8_t *uuid = NULL;
 	int i;
 
 	domain_priv = container_of(domain, struct psmx2_fid_domain,
@@ -949,6 +947,16 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 		goto errout;
 
 	if (info && info->ep_attr) {
+		if (info->ep_attr->auth_key_size != sizeof(psm2_uuid_t)) {
+			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
+				"Invalid auth_key_len %"PRIu64
+				", should be %"PRIu64".\n",
+				info->ep_attr->auth_key_size,
+				sizeof(psm2_uuid_t));
+			goto errout;
+		}
+		uuid = info->ep_attr->auth_key;
+
 		if (info->ep_attr->tx_ctx_cnt > psmx2_hfi_info.max_trx_ctxt) {
 			FI_WARN(&psmx2_prov, FI_LOG_EP_CTRL,
 				"tx_ctx_cnt %"PRIu64" exceed limit %d.\n",
@@ -1000,7 +1008,7 @@ int psmx2_sep_open(struct fid_domain *domain, struct fi_info *info,
 	for (i = 0; i < ctxt_cnt; i++) {
 		trx_ctxt = psmx2_trx_ctxt_alloc(domain_priv, src_addr,
 						(ctxt_cnt > 1) ? i : -1,
-						PSMX2_TX_RX);
+						PSMX2_TX_RX, uuid);
 		if (!trx_ctxt) {
 			err = -FI_ENOMEM;
 			goto errout_free_ctxt;

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -236,7 +236,8 @@ void psmx2_trx_ctxt_free(struct psmx2_trx_ctxt *trx_ctxt, int usage_flags)
 struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 					    struct psmx2_ep_name *src_addr,
 					    int sep_ctxt_idx,
-					    int usage_flags)
+					    int usage_flags,
+					    uint8_t *uuid)
 {
 	struct psmx2_trx_ctxt *trx_ctxt;
 	struct psm2_ep_open_opts opts;
@@ -246,12 +247,16 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	int asked_flags = usage_flags & PSMX2_TX_RX;
 	int compatible_flags = ~asked_flags & PSMX2_TX_RX;
 
+	if (!uuid)
+		uuid = domain->fabric->uuid;
+
 	/* Check existing allocations first if only Tx or Rx is needed */
 	if (compatible_flags) {
 		domain->trx_ctxt_lock_fn(&domain->trx_ctxt_lock, 1);
 		dlist_foreach(&domain->trx_ctxt_list, item) {
 			trx_ctxt = container_of(item, struct psmx2_trx_ctxt, entry);
-			if (compatible_flags == trx_ctxt->usage_flags) {
+			if (compatible_flags == trx_ctxt->usage_flags &&
+			    !memcmp(uuid, trx_ctxt->uuid, sizeof(psm2_uuid_t))) {
 				trx_ctxt->usage_flags |= asked_flags;
 				domain->trx_ctxt_unlock_fn(&domain->trx_ctxt_lock, 1);
 				FI_INFO(&psmx2_prov, FI_LOG_CORE,
@@ -288,8 +293,9 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	}
 
 	psm2_ep_open_opts_get_defaults(&opts);
+	memcpy(trx_ctxt->uuid, uuid, sizeof(psm2_uuid_t));
 	FI_INFO(&psmx2_prov, FI_LOG_CORE,
-		"uuid: %s\n", psmx2_uuid_to_string(domain->fabric->uuid));
+		"uuid: %s\n", psmx2_uuid_to_string(uuid));
 
 	opts.unit = src_addr ? src_addr->unit : PSMX2_DEFAULT_UNIT;
 	opts.port = src_addr ? src_addr->port : PSMX2_DEFAULT_PORT;
@@ -303,7 +309,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 			"sep %d: ep_open_opts: unit=%d\n", sep_ctxt_idx, opts.unit);
 	}
 
-	err = psm2_ep_open(domain->fabric->uuid, &opts,
+	err = psm2_ep_open(uuid, &opts,
 			   &trx_ctxt->psm2_ep, &trx_ctxt->psm2_epid);
 	if (err != PSM2_OK) {
 		FI_WARN(&psmx2_prov, FI_LOG_CORE,
@@ -313,7 +319,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 
 		/* When round-robin fails, retry w/o explicit assignment */
 		opts.unit = -1;
-		err = psm2_ep_open(domain->fabric->uuid, &opts,
+		err = psm2_ep_open(uuid, &opts,
 				   &trx_ctxt->psm2_ep, &trx_ctxt->psm2_epid);
 		if (err != PSM2_OK) {
 			FI_WARN(&psmx2_prov, FI_LOG_CORE,


### PR DESCRIPTION
In addition to the existing job-wide UUID setting by the environment
variable FI_PSM2_UUID, applications now can set different UUIDs for
individual endpoint via 'info->ep_attr->auth_key'.

Update the man page accordingly.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>