### PR TITLE
prov/rxd: fix bug preventing segmentation acks

### DIFF
--- a/prov/rxd/src/rxd_cq.c
+++ b/prov/rxd/src/rxd_cq.c
@@ -190,8 +190,8 @@ void rxd_ep_recv_data(struct rxd_ep *ep, struct rxd_x_entry *x_entry,
 	x_entry->next_seg_no++;
 
 	if (x_entry->next_seg_no < x_entry->num_segs) {
-		if (!(rxd_peer(ep, pkt->base_hdr.peer)->rx_seq_no) %
-		    (rxd_peer(ep, pkt->base_hdr.peer)->rx_window))
+		if (!(rxd_peer(ep, pkt->base_hdr.peer)->rx_seq_no %
+		    rxd_peer(ep, pkt->base_hdr.peer)->rx_window))
 			rxd_ep_send_ack(ep, pkt->base_hdr.peer);
 		return;
 	}


### PR DESCRIPTION
Data packets that are at the end of a window should
trigger an ACK to the sender to drive progress on
the sender. However, due to incorrect parentheses, the
ACK was always getting skipped, requiring a resend in
order for an ACK to get sent. Fixing this significantly
improves performance at larger messages.

Signed-off-by: aingerson <alexia.ingerson@intel.com>