### PR TITLE
prov/shm: always use CMA when sending to self

### DIFF
--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -329,6 +329,13 @@ uint64_t smr_rx_cq_flags(uint32_t op, uint16_t op_flags);
 
 void smr_ep_progress(struct util_ep *util_ep);
 
+static inline bool smr_cma_enabled(struct smr_ep *ep,
+				   struct smr_region *peer_smr)
+{
+	return ep->region->cma_cap == SMR_CMA_CAP_ON ||
+	       ep->region == peer_smr;
+}
+
 static inline int smr_cma_loop(pid_t pid, struct iovec *local,
 			unsigned long local_cnt, struct iovec *remote,
 			unsigned long remote_cnt, unsigned long flags,

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -209,8 +209,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 		}
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
 		pend = freestack_pop(ep->pend_fs);
-		if (ep->region->cma_cap == SMR_CMA_CAP_ON &&
-		    iface == FI_HMEM_SYSTEM) {
+		if (smr_cma_enabled(ep, peer_smr) && iface == FI_HMEM_SYSTEM) {
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
 				       resp);
 		} else {


### PR DESCRIPTION
CMA is always allowed to the same thread so use CMA when sending to self. This fixes a hang when a SHM endpoint has no peers but tries to communicate with itself.

Test description: ran fabtests and the failing test (Intel MPI osu_alltoall -n 37 -ppn 36) with and without restricted ptrace.