### PR TITLE
contrib/cray: Updating run_libfabric_pipeline and imb.bats

### DIFF
--- a/contrib/cray/bats/batsgenerator.sh
+++ b/contrib/cray/bats/batsgenerator.sh
@@ -7,7 +7,7 @@
 
 # Insert shebang and load test helper
 shebang="#!/usr/bin/env bats\n\n"
-fi_env="export XRC_FI_ENV=\"FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_\$\$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1\"\n\n"
+fi_env="XRC_FI_ENV=\"FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_\$\$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1\"\n\n"
 
 # Command line input: test suite
 # E.g. IMB-EXT

--- a/contrib/cray/bats/benchmark.template
+++ b/contrib/cray/bats/benchmark.template
@@ -7,7 +7,7 @@
 
 # XRC
 @test "@TEST_SUITE@ @BENCHMARK@ @RANKS@ ranks, @RPN@ ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher @RANKS@ @RPN@) timeout 300 "$IMB_BUILD_PATH/@TEST_SUITE@ -npmin @RANKS@@ITER_FLAG@ -time 10 -mem 2 -msglog 2:18 @BENCHMARK@"
         [ "$status" -eq 0 ]

--- a/contrib/cray/bats/imb.bats
+++ b/contrib/cray/bats/imb.bats
@@ -2,7 +2,7 @@
 
 load test_helper
 
-export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1"
+XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 FI_VERBS_PREFER_XRC=1"
 
 # RC
 @test "IMB-P2P unirandom 2 ranks, 1 ranks per node using RC verbs" {
@@ -13,7 +13,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-P2P unirandom 2 ranks, 1 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 unirandom"
         [ "$status" -eq 0 ]
@@ -27,7 +27,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-P2P birandom 2 ranks, 1 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 birandom"
         [ "$status" -eq 0 ]
@@ -41,7 +41,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-P2P corandom 2 ranks, 1 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-P2P -npmin 2 -time 10 -mem 2 -msglog 2:18 corandom"
         [ "$status" -eq 0 ]
@@ -55,7 +55,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-RMA bidir_get 2 ranks, 1 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_get"
         [ "$status" -eq 0 ]
@@ -69,7 +69,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-RMA bidir_put 2 ranks, 1 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 bidir_put"
         [ "$status" -eq 0 ]
@@ -83,7 +83,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-RMA unidir_get 2 ranks, 1 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_get"
         [ "$status" -eq 0 ]
@@ -97,7 +97,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-RMA unidir_put 2 ranks, 1 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 2 1) timeout 300 "$IMB_BUILD_PATH/IMB-RMA -npmin 2 -time 10 -mem 2 -msglog 2:18 unidir_put"
         [ "$status" -eq 0 ]
@@ -111,7 +111,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-EXT window 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 window"
         [ "$status" -eq 0 ]
@@ -125,7 +125,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-EXT accumulate 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-EXT -npmin 20 -time 10 -mem 2 -msglog 2:18 accumulate"
         [ "$status" -eq 0 ]
@@ -139,7 +139,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ialltoall 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall"
         [ "$status" -eq 0 ]
@@ -153,7 +153,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ialltoall_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoall_pure"
         [ "$status" -eq 0 ]
@@ -167,7 +167,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ialltoallv 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv"
         [ "$status" -eq 0 ]
@@ -181,7 +181,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ialltoallv_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ialltoallv_pure"
         [ "$status" -eq 0 ]
@@ -195,7 +195,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iallgather 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather"
         [ "$status" -eq 0 ]
@@ -209,7 +209,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iallgather_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgather_pure"
         [ "$status" -eq 0 ]
@@ -223,7 +223,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iallgatherv 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv"
         [ "$status" -eq 0 ]
@@ -237,7 +237,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iallgatherv_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallgatherv_pure"
         [ "$status" -eq 0 ]
@@ -251,7 +251,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iallreduce 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce"
         [ "$status" -eq 0 ]
@@ -265,7 +265,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iallreduce_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iallreduce_pure"
         [ "$status" -eq 0 ]
@@ -279,7 +279,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ibarrier 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier"
         [ "$status" -eq 0 ]
@@ -293,7 +293,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ibarrier_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibarrier_pure"
         [ "$status" -eq 0 ]
@@ -307,7 +307,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ibcast 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast"
         [ "$status" -eq 0 ]
@@ -321,7 +321,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ibcast_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ibcast_pure"
         [ "$status" -eq 0 ]
@@ -335,7 +335,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC igather 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather"
         [ "$status" -eq 0 ]
@@ -349,7 +349,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC igather_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igather_pure"
         [ "$status" -eq 0 ]
@@ -363,7 +363,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC igatherv 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv"
         [ "$status" -eq 0 ]
@@ -377,7 +377,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC igatherv_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 igatherv_pure"
         [ "$status" -eq 0 ]
@@ -391,7 +391,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ireduce 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce"
         [ "$status" -eq 0 ]
@@ -405,7 +405,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ireduce_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_pure"
         [ "$status" -eq 0 ]
@@ -419,7 +419,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC ireduce_scatter 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 ireduce_scatter"
         [ "$status" -eq 0 ]
@@ -433,7 +433,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iscatter 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter"
         [ "$status" -eq 0 ]
@@ -447,7 +447,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iscatter_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatter_pure"
         [ "$status" -eq 0 ]
@@ -461,7 +461,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iscatterv 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv"
         [ "$status" -eq 0 ]
@@ -475,7 +475,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-NBC iscatterv_pure 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-NBC -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 iscatterv_pure"
         [ "$status" -eq 0 ]
@@ -489,7 +489,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 reduce 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce"
         [ "$status" -eq 0 ]
@@ -503,7 +503,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 reduce_scatter 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter"
         [ "$status" -eq 0 ]
@@ -517,7 +517,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 reduce_scatter_block 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 reduce_scatter_block"
         [ "$status" -eq 0 ]
@@ -531,7 +531,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 allreduce 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allreduce"
         [ "$status" -eq 0 ]
@@ -545,7 +545,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 allgather 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgather"
         [ "$status" -eq 0 ]
@@ -559,7 +559,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 allgatherv 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 allgatherv"
         [ "$status" -eq 0 ]
@@ -573,7 +573,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 scatter 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatter"
         [ "$status" -eq 0 ]
@@ -587,7 +587,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 scatterv 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 scatterv"
         [ "$status" -eq 0 ]
@@ -601,7 +601,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 gather 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gather"
         [ "$status" -eq 0 ]
@@ -615,7 +615,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 gatherv 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 gatherv"
         [ "$status" -eq 0 ]
@@ -629,7 +629,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 alltoall 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 alltoall"
         [ "$status" -eq 0 ]
@@ -643,7 +643,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 bcast 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 bcast"
         [ "$status" -eq 0 ]
@@ -657,7 +657,7 @@ export XRC_FI_ENV="FI_VERBS_XRCD_FILENAME=/tmp/xrc_imb_$$ FI_OFI_RXM_USE_SRX=1 F
 
 # XRC
 @test "IMB-MPI1 barrier 20 ranks, 5 ranks per node using XRC verbs" {
-        ${XRC_FI_ENV} \
+        eval ${XRC_FI_ENV} \
         run $CONTRIB_BIN/logwrap -w ${BATS_TEST_LOGFILE} -- \
                 $(batch_launcher 20 5) timeout 300 "$IMB_BUILD_PATH/IMB-MPI1 -npmin 20 -iter 100 -time 10 -mem 2 -msglog 2:18 barrier"
         [ "$status" -eq 0 ]

--- a/contrib/cray/bin/run_libfabric_pipeline
+++ b/contrib/cray/bin/run_libfabric_pipeline
@@ -21,9 +21,10 @@ BUILD=true
 TEST=true
 UNITTEST=true
 SMOKETEST=true
+IMBTEST=true
+OMBTEST=true
 FABTEST=true
 SFT=true
-MPI=true
 
 function usage {
     echo \
@@ -38,15 +39,16 @@ function set_sections_to_run {
     TEST=false
     UNITTEST=false
     SMOKETEST=false
+    IMBTEST=false
+    OMBTEST=false
     FABTEST=false
     SFT=false
-    MPI=false
 
     sections=$(echo $@ | tr ',' ' ')
     for section in $sections ; do
         section_name=$(echo $section | awk '{print toupper($0)}')
         case $section_name in
-            'UNITTEST'|'SMOKETEST'|'FABTEST'|'SFT'|'MPI')
+            'UNITTEST'|'SMOKETEST'|'IMBTEST'|'OMBTEST'|'FABTEST'|'SFT')
                 TEST=true
                 eval ${section_name}=true
                 ;;
@@ -55,17 +57,19 @@ function set_sections_to_run {
                 TEST=true
                 UNITTEST=true
                 SMOKETEST=true
+                IMBTEST=true
+                OMBTEST=true
                 FABTEST=true
                 SFT=true
-                MPI=true
                 ;;
             'TEST')
                 TEST=true
                 UNITTEST=true
                 SMOKETEST=true
+                IMBTEST=true
+                OMBTEST=true
                 FABTEST=true
                 SFT=true
-                MPI=true
                 ;;
              'BUILD')
                 BUILD=true
@@ -75,7 +79,7 @@ function set_sections_to_run {
         esac
     done
 
-    for each in BUILD TEST UNITTEST SMOKETEST SFT MPI ; do
+    for each in BUILD TEST UNITTEST SMOKETEST IMBTEST OMBTEST SFT ; do
         if $DEBUG ; then echo ${each} = $(eval echo \$$each) ; fi
     done
 }
@@ -127,7 +131,7 @@ verbose "CLEAN:     $CLEAN"
 verbose "SECTIONS:  $SECTIONS"
 verbose "WORKSPACE: $WORKSPACE"
 
-for each in BUILD TEST UNITTEST SMOKETEST FABTEST MPI SFT ; do
+for each in BUILD TEST UNITTEST SMOKETEST IMBTEST OMBTEST FABTEST SFT ; do
     verbose "$each: $(eval echo \$$each)"
 done
 
@@ -172,6 +176,7 @@ export MPICH_PATH="${ROOT_BUILD_PATH}/mpich/stable"
 export SFT_INSTALL_PATH="${ROOT_BUILD_PATH}/libfabric-sft/stable"
 export BATS_INSTALL_PATH="${ROOT_BUILD_PATH}/bats/stable/bin"
 export BATS_LOG_DIRECTORY="$WORKSPACE/logs"
+export IMB_BUILD_PATH="${ROOT_BUILD_PATH}/imb/v2019.6"
 # End pipeline variables
 
 # Start Prologue
@@ -226,6 +231,22 @@ section_start 'smoke tests'
 $BATS_INSTALL_PATH/bats $@ -t contrib/cray/bats/smoketests.bats | tee smoketests.tap
 ## End Smoke Tests
 section_end 'smoke tests'
+fi
+
+if $IMBTEST ; then
+section_start 'imb tests'
+## Start IMB Tests
+$BATS_INSTALL_PATH/bats $@ -t contrib/cray/bats/imb.bats | tee imb.tap
+## End IMB Tests
+section_end 'imb tests'
+fi
+
+if $OMBTEST ; then
+section_start 'omb tests'
+## Start OMB Tests
+$BATS_INSTALL_PATH/bats $@ -t contrib/cray/bats/omb.bats | tee omb.tap
+## End OMB Tests
+section_end 'omb tests'
 fi
 
 if $FABTEST ; then
@@ -286,8 +307,8 @@ timeout 900 ./ci-all.sh \
     --results-file ${SFT_TEST_RESULTS_DIR}/${SFT_TEST_RESULTS_CI}
 popd
 
-cp  ./${SFT_BASELINE_DIR}/${SFT_BASELINE_RESULTS_FILE} ${SFT_TEST_RESULTS_DIR}/ \
-    ${SFT_TEST_RESULTS_EXPECTED}${SFT_BASELINE_RESULTS_FILE}
+cp  ./${SFT_BASELINE_DIR}/${SFT_BASELINE_RESULTS_FILE} \
+    ${SFT_TEST_RESULTS_DIR}/${SFT_TEST_RESULTS_EXPECTED}${SFT_BASELINE_RESULTS_FILE}
 ${SFT_BIN}/sft_parse_test_results.pm \
     -b ${SFT_TEST_RESULTS_EXPECTED}${SFT_BASELINE_RESULTS_FILE} \
     -d ${SFT_TEST_RESULTS_DIR} \
@@ -302,14 +323,6 @@ cp -r ${SFT_TEST_RESULTS_DIR} .
 rm -rf ${SFT_TEST_RESULTS_DIR} || true
 ## End SFT
 section_end 'sft'
-fi
-
-if $MPI ; then
-section_start 'mpi'
-## Start MPI Tests
-$BATS_INSTALL_PATH/bats -t contrib/cray/bats/mpi.bats | tee mpi.tap
-## End MPI Tests
-section_end 'mpi'
 fi
 
 fi


### PR DESCRIPTION
IMB and OMB tests have been added to run_libfabric_pipline. Additionally
a fix is included for a test bug in IMB.

Signed-off-by: patrickbueb <70724661+patrickbueb@users.noreply.github.com>