### PR TITLE
prov/shm: always call SAR progress function

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -947,8 +947,7 @@ void smr_ep_progress(struct util_ep *util_ep)
 	smr_progress_resp(ep);
 	smr_progress_cmd(ep);
 
-	if (ep->region->cma_cap == SMR_CMA_CAP_OFF)
-		smr_progress_sar_list(ep);
+	smr_progress_sar_list(ep);
 }
 
 int smr_progress_unexp_queue(struct smr_ep *ep, struct smr_rx_entry *entry,


### PR DESCRIPTION
SAR can be used before the CMA check occurs and is also used for device
transfers. Call this function regardless whether CMA is available.

Signed-off-by: Robert Wespetal <wesper@amazon.com>