### PR TITLE
prov/shm: fix incorrect id for sar protocol

### DIFF
--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -225,7 +225,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 						       ep->region, peer_smr, sar,
 						       pend, resp);
 					peer_smr->sar_cnt--;
-					smr_peer_data(ep->region)[peer_id].sar_status = 1;
+					smr_peer_data(ep->region)[id].sar_status = 1;
 				}
 			} else {
 				ret = smr_format_mmap(ep, cmd, iov, iov_count,


### PR DESCRIPTION
Use id, not peer_id for setting sar_status since
we are using the local smr data. The peer id is used
for remote smr data

Signed-off-by: aingerson <alexia.ingerson@intel.com>