### PR TITLE
v1.11.x: core/cache: Fix incorrect unlocking in uffd_handler

### DIFF
--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -374,6 +374,7 @@ static void *ofi_uffd_handler(void *arg)
 		ret = read(uffd.fd, &msg, sizeof(msg));
 		if (ret != sizeof(msg)) {
 			pthread_mutex_unlock(&mm_lock);
+			pthread_rwlock_unlock(&mm_list_rwlock);
 			if (errno != EAGAIN)
 				break;
 			continue;


### PR DESCRIPTION
Problem reported by coverity.  The new mm_list_rwlock is not
released if read fails to return sizeof(msg).

Signed-off-by: Sean Hefty <sean.hefty@intel.com>