### PR TITLE
prov/rxm: Allow reconnecting to peers and retrying connection requests

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -255,7 +255,6 @@ void rxm_cmap_process_shutdown(struct rxm_cmap *cmap,
 			       struct rxm_cmap_handle *handle);
 int rxm_cmap_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
 		     struct rxm_cmap_handle *handle);
-void rxm_cmap_del_handle_ts(struct rxm_cmap_handle *handle);
 void rxm_cmap_free(struct rxm_cmap *cmap);
 int rxm_cmap_alloc(struct rxm_ep *rxm_ep, struct rxm_cmap_attr *attr);
 int rxm_cmap_remove(struct rxm_cmap *cmap, int index);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -245,6 +245,9 @@ union rxm_cm_data {
 	} reject;
 };
 
+int rxm_cmap_alloc_handle(struct rxm_cmap *cmap, fi_addr_t fi_addr,
+			  enum rxm_cmap_state state,
+			  struct rxm_cmap_handle **handle);
 struct rxm_cmap_handle *rxm_cmap_key2handle(struct rxm_cmap *cmap, uint64_t key);
 int rxm_cmap_update(struct rxm_cmap *cmap, const void *addr, fi_addr_t fi_addr);
 
@@ -913,31 +916,8 @@ static inline void rxm_cq_log_comp(uint64_t flags)
 #endif
 }
 
-static inline ssize_t
-rxm_ep_prepare_tx(struct rxm_ep *rxm_ep, fi_addr_t dest_addr,
-		  struct rxm_conn **rxm_conn)
-{
-	ssize_t ret;
-
-	assert(rxm_ep->util_ep.tx_cq);
-	*rxm_conn = (struct rxm_conn *)rxm_cmap_acquire_handle(rxm_ep->cmap,
-							       dest_addr);
-	if (OFI_UNLIKELY(!*rxm_conn))
-		return -FI_EHOSTUNREACH;
-
-	if (OFI_UNLIKELY((*rxm_conn)->handle.state != RXM_CMAP_CONNECTED)) {
-		ret = rxm_cmap_connect(rxm_ep, dest_addr, &(*rxm_conn)->handle);
-		if (ret)
-			return ret;
-	}
-
-	if (OFI_UNLIKELY(!dlist_empty(&(*rxm_conn)->deferred_tx_queue))) {
-		rxm_ep_do_progress(&rxm_ep->util_ep);
-		if (!dlist_empty(&(*rxm_conn)->deferred_tx_queue))
-			return -FI_EAGAIN;
-	}
-	return 0;
-}
+ssize_t rxm_get_conn(struct rxm_ep *rxm_ep, fi_addr_t addr,
+		     struct rxm_conn **rxm_conn);
 
 static inline void
 rxm_ep_format_tx_buf_pkt(struct rxm_conn *rxm_conn, size_t len, uint8_t op,
@@ -951,7 +931,6 @@ rxm_ep_format_tx_buf_pkt(struct rxm_conn *rxm_conn, size_t len, uint8_t op,
 	pkt->hdr.flags = (flags & FI_REMOTE_CQ_DATA);
 	pkt->hdr.data = data;
 }
-
 
 static inline void *
 rxm_tx_buf_alloc(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
@@ -967,7 +946,6 @@ rxm_tx_buf_alloc(struct rxm_ep *rxm_ep, enum rxm_buf_pool_type type)
 	       (type == RXM_BUF_POOL_TX_SAR));
 	return ofi_buf_alloc(rxm_ep->buf_pools[type].pool);
 }
-
 
 static inline struct rxm_rx_buf *
 rxm_rx_buf_alloc(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep, uint8_t repost)

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -207,13 +207,12 @@ static ssize_t
 rxm_ep_generic_atomic_writemsg(struct rxm_ep *rxm_ep, const struct fi_msg_atomic *msg,
 			       uint64_t flags)
 {
-	int ret;
 	struct rxm_conn *rxm_conn;
+	ssize_t ret;
 
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-
-	ret = rxm_ep_prepare_tx(rxm_ep, msg->addr, &rxm_conn);
-	if (OFI_UNLIKELY(ret))
+	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
+	if (ret)
 		goto unlock;
 
 	ret = rxm_ep_atomic_common(rxm_ep, rxm_conn, msg, NULL, NULL, 0,
@@ -318,13 +317,12 @@ rxm_ep_generic_atomic_readwritemsg(struct rxm_ep *rxm_ep,
 				   struct fi_ioc *resultv, void **result_desc,
 				   size_t result_count, uint64_t flags)
 {
-	int ret;
 	struct rxm_conn *rxm_conn;
+	ssize_t ret;
 
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-
-	ret = rxm_ep_prepare_tx(rxm_ep, msg->addr, &rxm_conn);
-	if (OFI_UNLIKELY(ret))
+	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
+	if (ret)
 		goto unlock;
 
 	ret = rxm_ep_atomic_common(rxm_ep, rxm_conn, msg, NULL, NULL, 0,
@@ -412,13 +410,12 @@ rxm_ep_generic_atomic_compwritemsg(struct rxm_ep *rxm_ep,
 				   void **result_desc, size_t result_count,
 				   uint64_t flags)
 {
-	int ret;
 	struct rxm_conn *rxm_conn;
+	ssize_t ret;
 
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-
-	ret = rxm_ep_prepare_tx(rxm_ep, msg->addr, &rxm_conn);
-	if (OFI_UNLIKELY(ret))
+	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
+	if (ret)
 		goto unlock;
 
 	ret = rxm_ep_atomic_common(rxm_ep, rxm_conn, msg, comparev,

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -175,6 +175,37 @@ static int rxm_cmap_del_handle(struct rxm_cmap_handle *handle)
 	return 0;
 }
 
+ssize_t rxm_get_conn(struct rxm_ep *rxm_ep, fi_addr_t addr,
+		     struct rxm_conn **rxm_conn)
+{
+	struct rxm_cmap_handle *handle;
+	ssize_t ret;
+
+	assert(rxm_ep->util_ep.tx_cq);
+	handle = rxm_cmap_acquire_handle(rxm_ep->cmap, addr);
+	if (!handle) {
+		ret = rxm_cmap_alloc_handle(rxm_ep->cmap, addr,
+					    RXM_CMAP_IDLE, &handle);
+		if (ret)
+			return ret;
+	}
+
+	*rxm_conn = container_of(handle, struct rxm_conn, handle);
+
+	if (handle->state != RXM_CMAP_CONNECTED) {
+		ret = rxm_cmap_connect(rxm_ep, addr, handle);
+		if (ret)
+			return ret;
+	}
+
+	if (!dlist_empty(&(*rxm_conn)->deferred_tx_queue)) {
+		rxm_ep_do_progress(&rxm_ep->util_ep);
+		if (!dlist_empty(&(*rxm_conn)->deferred_tx_queue))
+			return -FI_EAGAIN;
+	}
+	return 0;
+}
+
 static inline int
 rxm_cmap_check_and_realloc_handles_table(struct rxm_cmap *cmap,
 					 fi_addr_t fi_addr)
@@ -309,23 +340,26 @@ static void rxm_conn_free(struct rxm_cmap_handle *handle)
 	free(rxm_conn);
 }
 
-static int rxm_cmap_alloc_handle(struct rxm_cmap *cmap, fi_addr_t fi_addr,
-				 enum rxm_cmap_state state,
-				 struct rxm_cmap_handle **handle)
+int rxm_cmap_alloc_handle(struct rxm_cmap *cmap, fi_addr_t fi_addr,
+			  enum rxm_cmap_state state,
+			  struct rxm_cmap_handle **handle)
 {
 	int ret;
 
 	*handle = rxm_conn_alloc(cmap);
-	if (OFI_UNLIKELY(!*handle))
+	if (!*handle)
 		return -FI_ENOMEM;
+
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL,
 	       "Allocated handle: %p for fi_addr: %" PRIu64 "\n",
 	       *handle, fi_addr);
+
 	ret = rxm_cmap_check_and_realloc_handles_table(cmap, fi_addr);
-	if (OFI_UNLIKELY(ret)) {
+	if (ret) {
 		rxm_conn_free(*handle);
 		return ret;
 	}
+
 	rxm_cmap_init_handle(*handle, cmap, state, fi_addr, NULL);
 	cmap->handles_av[fi_addr] = *handle;
 	return 0;
@@ -340,14 +374,17 @@ static int rxm_cmap_alloc_handle_peer(struct rxm_cmap *cmap, void *addr,
 	peer = calloc(1, sizeof(*peer) + cmap->av->addrlen);
 	if (!peer)
 		return -FI_ENOMEM;
+
 	*handle = rxm_conn_alloc(cmap);
 	if (!*handle) {
 		free(peer);
 		return -FI_ENOMEM;
 	}
-	ofi_straddr_dbg(cmap->av->prov, FI_LOG_AV, "Allocated handle for addr",
-			addr);
+
+	ofi_straddr_dbg(cmap->av->prov, FI_LOG_AV,
+			"Allocated handle for addr", addr);
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "handle: %p\n", *handle);
+
 	rxm_cmap_init_handle(*handle, cmap, state, FI_ADDR_NOTAVAIL, peer);
 	FI_DBG(cmap->av->prov, FI_LOG_EP_CTRL, "Adding handle to peer list\n");
 	peer->handle = *handle;
@@ -366,6 +403,7 @@ rxm_cmap_get_handle_peer(struct rxm_cmap *cmap, const void *addr)
 				       addr);
 	if (!entry)
 		return NULL;
+
 	ofi_straddr_dbg(cmap->av->prov, FI_LOG_AV,
 			"handle found in peer list for addr", addr);
 	peer = container_of(entry, struct rxm_cmap_peer, entry);
@@ -649,6 +687,9 @@ int rxm_cmap_connect(struct rxm_ep *rxm_ep, fi_addr_t fi_addr,
 		ret = rxm_conn_connect(rxm_ep, handle,
 				       ofi_av_get_addr(rxm_ep->cmap->av, fi_addr));
 		if (ret) {
+			if (ret == -FI_ECONNREFUSED)
+				return -FI_EAGAIN;
+
 			rxm_cmap_del_handle(handle);
 		} else {
 			RXM_CM_UPDATE_STATE(handle, RXM_CMAP_CONNREQ_SENT);
@@ -946,9 +987,10 @@ rxm_conn_av_updated_handler(struct rxm_cmap_handle *handle)
 
 static struct rxm_cmap_handle *rxm_conn_alloc(struct rxm_cmap *cmap)
 {
-	struct rxm_conn *rxm_conn = calloc(1, sizeof(*rxm_conn));
+	struct rxm_conn *rxm_conn;
 
-	if (OFI_UNLIKELY(!rxm_conn))
+	rxm_conn = calloc(1, sizeof(*rxm_conn));
+	if (!rxm_conn)
 		return NULL;
 
 	if (rxm_conn_res_alloc(cmap->ep, rxm_conn)) {

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1143,7 +1143,7 @@ static int rxm_conn_handle_notify(struct fi_eq_entry *eq_entry)
 		free(handle->peer);
 		handle->peer = NULL;
 	} else {
-		cmap->handles_av[handle->fi_addr] = 0;
+		cmap->handles_av[handle->fi_addr] = NULL;
 	}
 	rxm_conn_free(handle);
 	return 0;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -709,11 +709,10 @@ void rxm_cmap_free(struct rxm_cmap *cmap)
 		if (cmap->handles_av[i]) {
 			rxm_cmap_clear_key(cmap->handles_av[i]);
 			rxm_conn_free(cmap->handles_av[i]);
-			cmap->handles_av[i] = 0;
 		}
 	}
 
-	while(!dlist_empty(&cmap->peer_list)) {
+	while (!dlist_empty(&cmap->peer_list)) {
 		entry = cmap->peer_list.next;
 		peer = container_of(entry, struct rxm_cmap_peer, entry);
 		dlist_remove(&peer->entry);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1792,7 +1792,7 @@ rxm_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t flags)
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, msg->addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -1819,7 +1819,7 @@ static ssize_t rxm_ep_send(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -1841,7 +1841,7 @@ static ssize_t rxm_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -1862,7 +1862,7 @@ static ssize_t rxm_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -1882,7 +1882,7 @@ static ssize_t rxm_ep_inject_fast(struct fid_ep *ep_fid, const void *buf,
 	ssize_t ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		return ret;
 
@@ -1904,7 +1904,7 @@ static ssize_t rxm_ep_senddata(struct fid_ep *ep_fid, const void *buf, size_t le
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -1925,7 +1925,7 @@ static ssize_t rxm_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t 
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -1945,7 +1945,7 @@ static ssize_t rxm_ep_injectdata_fast(struct fid_ep *ep_fid, const void *buf, si
 	ssize_t ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		return ret;
 
@@ -2144,7 +2144,7 @@ rxm_ep_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *msg,
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, msg->addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -2172,7 +2172,7 @@ static ssize_t rxm_ep_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -2194,7 +2194,7 @@ static ssize_t rxm_ep_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -2215,7 +2215,7 @@ static ssize_t rxm_ep_tinject(struct fid_ep *ep_fid, const void *buf, size_t len
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -2235,7 +2235,7 @@ static ssize_t rxm_ep_tinject_fast(struct fid_ep *ep_fid, const void *buf, size_
 	ssize_t ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		return ret;
 
@@ -2259,7 +2259,7 @@ static ssize_t rxm_ep_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t l
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -2280,7 +2280,7 @@ static ssize_t rxm_ep_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		goto unlock;
 
@@ -2300,7 +2300,7 @@ static ssize_t rxm_ep_tinjectdata_fast(struct fid_ep *ep_fid, const void *buf, s
 	ssize_t ret;
 
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (ret)
 		return ret;
 

--- a/prov/rxm/src/rxm_rma.c
+++ b/prov/rxm/src/rxm_rma.c
@@ -77,7 +77,7 @@ rxm_ep_rma_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 
-	ret = rxm_ep_prepare_tx(rxm_ep, msg->addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		goto unlock;
 
@@ -282,7 +282,7 @@ rxm_ep_rma_inject_common(struct rxm_ep *rxm_ep, const struct fi_msg_rma *msg,
 
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 
-	ret = rxm_ep_prepare_tx(rxm_ep, msg->addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, msg->addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		goto unlock;
 
@@ -440,7 +440,7 @@ static ssize_t rxm_ep_inject_write(struct fid_ep *ep_fid, const void *buf,
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		goto unlock;
 
@@ -475,7 +475,7 @@ static ssize_t rxm_ep_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 	rxm_ep = container_of(ep_fid, struct rxm_ep, util_ep.ep_fid.fid);
 	ofi_ep_lock_acquire(&rxm_ep->util_ep);
 
-	ret = rxm_ep_prepare_tx(rxm_ep, dest_addr, &rxm_conn);
+	ret = rxm_get_conn(rxm_ep, dest_addr, &rxm_conn);
 	if (OFI_UNLIKELY(ret))
 		goto unlock;
 


### PR DESCRIPTION
    If we fail to establish a connection to a peer, or if after a
    connection has been established, the peer shuts down, the
    connection map entry that corresponds with the peer's address
    in the AV is cleared.  The result is that any attempts to
    send to the same address will fail with -EHOSTUNAVAIL.
    
    In the case where a connection to the peer fails, this can
    be the result of starting a client process prior to the
    server process being started.  (The server will be using a
    well-known address).  This problem occurs running DAOS
    tests.
    
    A similar problem can occur if a peer is re-started.  The
    client's connection to the server can be shutdown.  Once
    the server is restarted, the client should be able to
    communicate again.  However, since the server address is the
    same, all future attempts to send to the server will fail.
    
    To fix this, we allocate a new cmap handle if one is not
    available.  This resets the connection state, allowing the
    formation of a new connection to the server, so that further
    transfers are possible.  Additionally, if the connect request
    fails immediate with ECONNREFUSED, we return EAGAIN, so that
    the application will retry the request.  ECONNREFUSED can
    occur when using the loopback address.
    
    Includes some adjacent minor code cleanups to improve
    readability.
    
    Signed-off-by: Sean Hefty <sean.hefty@intel.com>