### PR TITLE
configure: Rework FI_CHECK_PACKAGE[(cuda)] logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -486,6 +486,25 @@ AC_ARG_WITH([cuda],
 			    and runtime libraries are installed.])],
 	    [], [])
 
+have_libcuda=0
+AS_IF([test x"$with_cuda" != x"no"],
+	    [FI_CHECK_PACKAGE([cuda],
+			      [cuda_runtime.h],
+			      [cudart],
+			      [cudaMemcpy],
+			      [-lcuda],
+			      [$with_cuda],
+			      [],
+			      [have_libcuda=1],
+			      [],
+			      [])],
+	    [])
+
+AS_IF([test "$with_cuda" = "yes" && test "$have_libcuda" = "0" ],
+	[AC_MSG_ERROR([CUDA support requested but CUDA runtime not available.])],
+	[])
+AC_DEFINE_UNQUOTED([HAVE_LIBCUDA], [$have_libcuda], [Whether we have CUDA runtime or not])
+
 AC_ARG_ENABLE([cuda-dlopen],
     [AS_HELP_STRING([--enable-cuda-dlopen],
         [Enable dlopen of CUDA libraries @<:@default=no@:>@])
@@ -498,16 +517,6 @@ AC_ARG_ENABLE([cuda-dlopen],
         AC_DEFINE([ENABLE_CUDA_DLOPEN], [1], [dlopen CUDA libraries])
     ],
     [enable_cuda_dlopen=no])
-
-FI_CHECK_PACKAGE([cuda],
-		 [cuda_runtime.h],
-		 [cudart],
-		 [cudaMemcpy],
-		 [-lcuda],
-		 [$with_cuda],
-		 [],
-		 [AC_DEFINE([HAVE_LIBCUDA], [1],[CUDA support])],
-		 [], [])
 
 AC_ARG_WITH([ze],
 	AC_HELP_STRING([--with-ze=DIR], [Provide path to where the ZE

--- a/include/ofi_cuda.h
+++ b/include/ofi_cuda.h
@@ -36,7 +36,7 @@
 
 #ifndef _OFI_CUDA_H_
 #define _OFI_CUDA_H_
-#ifdef HAVE_LIBCUDA
+#if HAVE_LIBCUDA
 
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -40,7 +40,7 @@
 #include <rdma/fi_domain.h>
 #include <stdbool.h>
 
-#ifdef HAVE_LIBCUDA
+#if HAVE_LIBCUDA
 
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -466,7 +466,7 @@ err_free_nic:
 	return ret;
 }
 
-#ifdef HAVE_LIBCUDA
+#if HAVE_LIBCUDA
 static int efa_get_gdr_support(char *device_name)
 {
 	char *gdr_path = NULL;
@@ -536,7 +536,7 @@ static int efa_get_device_attrs(struct efa_context *ctx, struct fi_info *info)
 	info->domain_attr->resource_mgmt	= FI_RM_DISABLED;
 	info->domain_attr->mr_cnt		= base_attr->max_mr;
 
-#ifdef HAVE_LIBCUDA
+#if HAVE_LIBCUDA
 	if (info->ep_attr->type == FI_EP_RDM &&
 	    efa_get_gdr_support(ctx->ibv_ctx->device->name) == 1) {
 		info->caps			|= FI_HMEM;

--- a/prov/efa/src/rxr/rxr_attr.c
+++ b/prov/efa/src/rxr/rxr_attr.c
@@ -37,7 +37,7 @@
 const uint32_t rxr_poison_value = 0xdeadbeef;
 #endif
 
-#ifdef HAVE_LIBCUDA
+#if HAVE_LIBCUDA
 #define EFA_HMEM_CAP FI_HMEM
 #else
 #define EFA_HMEM_CAP 0

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -179,7 +179,7 @@ void rxr_info_to_core_mr_modes(uint32_t version,
 					hints->domain_attr->mr_mode & OFI_MR_BASIC_MAP;
 			core_info->addr_format = hints->addr_format;
 		}
-#ifdef HAVE_LIBCUDA
+#if HAVE_LIBCUDA
 		core_info->domain_attr->mr_mode |= FI_MR_HMEM;
 #endif
 	}
@@ -385,7 +385,7 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 		if (!hints->domain_attr || hints->domain_attr->av_type == FI_AV_UNSPEC)
 			info->domain_attr->av_type = FI_AV_TABLE;
 
-#ifdef HAVE_LIBCUDA
+#if HAVE_LIBCUDA
 		/* If the application requires HMEM support, we will add FI_MR_HMEM
 		 * to mr_mode, because we need application to provide descriptor
 		 * for cuda buffer.

--- a/prov/util/src/cuda_mem_monitor.c
+++ b/prov/util/src/cuda_mem_monitor.c
@@ -32,7 +32,7 @@
 
 #include "ofi_mr.h"
 
-#ifdef HAVE_LIBCUDA
+#if HAVE_LIBCUDA
 
 #include "ofi_hmem.h"
 

--- a/src/hmem_cuda.c
+++ b/src/hmem_cuda.c
@@ -37,7 +37,7 @@
 #include "ofi_hmem.h"
 #include "ofi.h"
 
-#ifdef HAVE_LIBCUDA
+#if HAVE_LIBCUDA
 
 #include <cuda.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
    The current logic was silently ignoring a failure to find the CUDA
    runtime libraries. We would want the configure to abort if an explicit
    request to build with CUDA fails to find the headers/libs in the
    provided dir-path (or they are absent in the standard system paths
    when no path is provided). When `--with-cuda` is not provided, we
    still check to see if the runtime is available and define HAVE_LIBCUDA
    if it is.
