### PR TITLE
man: Clarify write/read/send operations apply to RDM EPs

### DIFF
--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -12,7 +12,7 @@ fi_msg - Message data transfer operations
 fi_recv / fi_recvv / fi_recvmsg
 :   Post a buffer to receive an incoming message
 
-fi_send / fi_sendv / fi_sendmsg  
+fi_send / fi_sendv / fi_sendmsg
 fi_inject / fi_senddata
 :   Initiate an operation to send a message
 
@@ -127,11 +127,7 @@ event details.
 
 The call fi_send transfers the data contained in the user-specified
 data buffer to a remote endpoint, with message boundaries being
-maintained.  For connection based endpoints (FI_EP_MSG) the local
-endpoint must be connected to a remote endpoint or destination before
-fi_send is called.  Unless the endpoint has been configured
-differently, the data buffer passed into fi_send must not be touched
-by the application until the fi_send call completes asynchronously.
+maintained.
 
 ## fi_sendv
 
@@ -276,7 +272,7 @@ fi_sendmsg.
 *FI_INJECT_COMPLETE*
 : Applies to fi_sendmsg.  Indicates that a completion should be
   generated when the source buffer(s) may be reused.
-  
+
 *FI_TRANSMIT_COMPLETE*
 : Applies to fi_sendmsg.  Indicates that a completion should not be
   generated until the operation has been successfully transmitted and
@@ -293,7 +289,7 @@ fi_sendmsg.
   targeting the same peer endpoint have completed.  Operations posted
   after the fencing will see and/or replace the results of any
   operations initiated prior to the fenced operation.
-  
+
   The ordering of operations starting at the posting of the fenced
   operation (inclusive) to the posting of a subsequent fenced operation
   (exclusive) is controlled by the endpoint's ordering semantics.

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -12,7 +12,7 @@ fi_rma - Remote memory access operations
 fi_read / fi_readv / fi_readmsg
 :   Initiates a read from remote memory
 
-fi_write / fi_writev / fi_writemsg    
+fi_write / fi_writev / fi_writemsg
 fi_inject_write / fi_writedata
 :   Initiate a write to remote memory
 
@@ -141,11 +141,7 @@ may be delivered.
 ## fi_write
 
 The call fi_write transfers the data contained in the user-specified
-data buffer to a remote memory region.  The local endpoint must be
-connected to a remote endpoint or destination before fi_write is
-called.  Unless the endpoint has been configured differently, the data
-buffer passed into fi_write must not be touched by the application
-until the fi_write call completes asynchronously.
+data buffer to a remote memory region.
 
 ## fi_writev
 
@@ -199,9 +195,7 @@ transfer.
 ## fi_read
 
 The fi_read call requests that the remote endpoint transfer data from
-the remote memory region into the local data buffer.  The local
-endpoint must be connected to a remote endpoint or destination before
-fi_read is called.
+the remote memory region into the local data buffer.
 
 ## fi_readv
 
@@ -254,7 +248,7 @@ fi_writemsg.
 *FI_INJECT_COMPLETE*
 : Applies to fi_writemsg.  Indicates that a completion should be
   generated when the source buffer(s) may be reused.
-  
+
 *FI_TRANSMIT_COMPLETE*
 : Applies to fi_writemsg.  Indicates that a completion should not be
   generated until the operation has been successfully transmitted and
@@ -276,7 +270,7 @@ fi_writemsg.
   targeting the same peer endpoint have completed.  Operations posted
   after the fencing will see and/or replace the results of any
   operations initiated prior to the fenced operation.
-  
+
   The ordering of operations starting at the posting of the fenced
   operation (inclusive) to the posting of a subsequent fenced operation
   (exclusive) is controlled by the endpoint's ordering semantics.


### PR DESCRIPTION
Address a long outstanding man page issue, and clarify that
these operations are not restricted to connected EPs.

Fixes #2683

Signed-off-by: Sean Hefty <sean.hefty@intel.com>