### PR TITLE
prov/verbs: Skip SIB addresses if a network iface is set

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1332,8 +1332,8 @@ int vrb_init_info(const struct fi_info **all_infos)
 	}
 
 	vrb_getifaddrs(&verbs_devs);
-
-	vrb_get_sib(&verbs_devs);
+	if (!vrb_gl_data.iface)
+		vrb_get_sib(&verbs_devs);
 
 	if (dlist_empty(&verbs_devs))
 		FI_WARN(&vrb_prov, FI_LOG_FABRIC,


### PR DESCRIPTION
If the user has set FI_VERBS_IFACE, they are looking for
addresses which correspond to a specific network interface,
such as ib0.  In this case, skip adding sockaddr_ib native
IB addresses to the getinfo list.

This fixes a regression with Intel MPI.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>