### PR TITLE
prov/efa: Turn off the MR Cache if FI_MR_LOCAL is set, set FI_REMOTE_READ for internal SHM MRs

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -230,6 +230,14 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 
 	*domain_fid = &domain->util_domain.domain_fid;
 
+	/*
+	 * If FI_MR_LOCAL is set, we do not want to use the
+	 * MR cache
+	 */
+	if (info->domain_attr && info->domain_attr->mr_mode & FI_MR_LOCAL) {
+		efa_mr_cache_enable = 0;
+	}
+
 	if (efa_mr_cache_enable) {
 		if (!efa_mr_max_cached_count)
 			efa_mr_max_cached_count = info->domain_attr->mr_cnt *


### PR DESCRIPTION
To allow better optimization, we turn off the memory registration cache
if the user attempts to open a domain with FI_MR_LOCAL bit set.

Signed-off-by: William Zhang <wilzhang@amazon.com>