### PR TITLE
Revert "util: Flush caches after notifying for memhooks and rocr"

### DIFF
--- a/prov/util/src/rocr_mem_monitor.c
+++ b/prov/util/src/rocr_mem_monitor.c
@@ -276,7 +276,7 @@ static void rocr_mm_unsubscribe(struct ofi_mem_monitor *monitor,
 
 		ofi_monitor_notify(rocr_monitor, entry->iov.iov_base,
 				   entry->iov.iov_len);
-		ofi_monitor_flush(rocr_monitor);
+
 		FI_DBG(&core_prov, FI_LOG_MR,
 		       "ROCR buffer address %p length %lu unsubscribed\n",
 		       entry->iov.iov_base, entry->iov.iov_len);

--- a/prov/util/src/util_mem_hooks.c
+++ b/prov/util/src/util_mem_hooks.c
@@ -375,7 +375,6 @@ void ofi_intercept_handler(const void *addr, size_t len)
 	pthread_rwlock_rdlock(&mm_list_rwlock);
 	pthread_mutex_lock(&mm_lock);
 	ofi_monitor_notify(memhooks_monitor, addr, len);
-	ofi_monitor_flush(memhooks_monitor);
 	pthread_mutex_unlock(&mm_lock);
 	pthread_rwlock_unlock(&mm_list_rwlock);
 }

--- a/prov/util/src/util_mem_monitor.c
+++ b/prov/util/src/util_mem_monitor.c
@@ -347,15 +347,7 @@ void ofi_monitor_unsubscribe(struct ofi_mem_monitor *monitor,
 #include <sys/ioctl.h>
 #include <linux/userfaultfd.h>
 
-/* The userfault fd monitor requires for events that could
- * trigger it to be handled outside of the monitor functions
- * itself. When a fault occurs on a monitored region, the
- * faulting thread is put to sleep until the event is read
- * via the userfault file descriptor. If this fault occurs
- * within the userfault handling thread, no threads will
- * read this event and our threads cannot progress, resulting
- * in a hang.
- */
+
 static void *ofi_uffd_handler(void *arg)
 {
 	struct uffd_msg msg;


### PR DESCRIPTION
Calling malloc (which happens in rdma-core during deregistration if fork
support is enabled) causes a deadlock if called in the sbrk memhook.
glibc acquires a mutex in _int_free that is also acquired in
__libc_malloc.

See #6244

This reverts commit 4dbf0c964010a1a7b76ae4270d812a0ca61132c2.