### PR TITLE
prov/efa: remove protection domain use_cnt assert

### DIFF
--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -154,10 +154,8 @@ void efa_device_free(void)
 {
 	int i;
 
-	for (i = 0; i < dev_cnt; i++) {
-		assert(pd_list[i].use_cnt == 0);
+	for (i = 0; i < dev_cnt; i++)
 		efa_device_close(ctx_list[i]);
-	}
 
 	free(pd_list);
 	free(ctx_list);


### PR DESCRIPTION
There is currently a case where closing the protection domain may fail.
Remove the assert here as the resources will be cleaned up by the
driver.

Signed-off-by: Robert Wespetal <wesper@amazon.com>