### PR TITLE
prov/efa: Bugfix, only disable the cache per domain when checking for FI_MR_LOCAL.

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -469,4 +469,9 @@ static inline bool efa_ep_is_cuda_mr(struct efa_mr *efa_mr)
 	return efa_mr ? (efa_mr->peer.iface == FI_HMEM_CUDA): false;
 }
 
+static inline bool efa_is_cache_available(struct efa_domain *efa_domain)
+{
+	return efa_domain->cache;
+}
+
 #endif /* EFA_H */

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -151,7 +151,7 @@ struct efa_domain {
 	struct ibv_pd		*ibv_pd;
 	struct fi_info		*info;
 	struct efa_fabric	*fab;
-	struct ofi_mr_cache	cache;
+	struct ofi_mr_cache	*cache;
 	struct efa_qp		**qp_table;
 	size_t			qp_table_sz_m1;
 };

--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -44,7 +44,7 @@ static int efa_mr_cache_close(fid_t fid)
 	struct efa_mr *efa_mr = container_of(fid, struct efa_mr,
 					       mr_fid.fid);
 
-	ofi_mr_cache_delete(&efa_mr->domain->cache, efa_mr->entry);
+	ofi_mr_cache_delete(efa_mr->domain->cache, efa_mr->entry);
 
 	return 0;
 }
@@ -167,11 +167,11 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	domain = container_of(fid, struct efa_domain,
 			      util_domain.domain_fid.fid);
 
-	if (domain->cache.cached_cnt > 0 && domain->cache.cached_cnt % EFA_MR_CACHE_FLUSH_CHECK==0) {
-		ofi_mr_cache_flush(&domain->cache, false);
+	if (domain->cache->cached_cnt > 0 && domain->cache->cached_cnt % EFA_MR_CACHE_FLUSH_CHECK==0) {
+		ofi_mr_cache_flush(domain->cache, false);
 	}
 
-	ret = ofi_mr_cache_search(&domain->cache, attr, &entry);
+	ret = ofi_mr_cache_search(domain->cache, attr, &entry);
 	if (OFI_UNLIKELY(ret))
 		return ret;
 

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -498,6 +498,7 @@ struct rxr_domain {
 	size_t mtu_size;
 	size_t addrlen;
 	uint8_t mr_local;
+	uint8_t rxr_mr_local;
 	uint64_t rdm_mode;
 	int do_progress;
 	size_t cq_size;

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -818,11 +818,16 @@ void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entr
 {
 	int ret;
 	struct rxr_peer *peer;
+	struct efa_domain *efa_domain;
+	struct rxr_domain *rxr_domain = rxr_ep_domain(ep);
+
+	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
+				  util_domain.domain_fid);
 
 	if (tx_entry->state == RXR_TX_SEND)
 		dlist_remove(&tx_entry->entry);
 
-	if (efa_mr_cache_enable && rxr_ep_mr_local(ep)) {
+	if (efa_is_cache_available(efa_domain) && rxr_ep_mr_local(ep)) {
 		ret = rxr_tx_entry_mr_dereg(tx_entry);
 		if (OFI_UNLIKELY(ret)) {
 			FI_WARN(&rxr_prov, FI_LOG_MR,

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -180,6 +180,7 @@ int rxr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (!rxr_domain)
 		return -FI_ENOMEM;
 
+	rxr_domain->rxr_mr_local = ofi_mr_local(info);
 	rxr_domain->type = EFA_DOMAIN_RDM;
 
 	ret = rxr_get_lower_rdm_info(fabric->api_version, NULL, NULL, 0,

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -57,6 +57,12 @@ ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep,
 	struct rxr_pkt_entry *pkt_entry;
 	struct rxr_data_pkt *data_pkt;
 	ssize_t ret;
+	struct efa_domain *efa_domain;
+	struct rxr_domain *rxr_domain = rxr_ep_domain(rxr_ep);
+
+	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
+				  util_domain.domain_fid);
+
 
 	pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_efa_pool);
 	if (OFI_UNLIKELY(!pkt_entry))
@@ -85,7 +91,7 @@ ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep,
 	 * For now, always send CUDA buffers through
 	 * rxr_pkt_send_data_desc().
 	 */
-	if (efa_mr_cache_enable || efa_ep_is_cuda_mr(tx_entry->desc[0]))
+	if (efa_is_cache_available(efa_domain) || efa_ep_is_cuda_mr(tx_entry->desc[0]))
 		ret = rxr_pkt_send_data_desc(rxr_ep, tx_entry, pkt_entry);
 	else
 		ret = rxr_pkt_send_data(rxr_ep, tx_entry, pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -270,6 +270,11 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 {
 	struct rxr_tx_entry *tx_entry;
 	size_t data_len;
+	struct efa_domain *efa_domain;
+	struct rxr_domain *rxr_domain = rxr_ep_domain(ep);
+
+	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
+				  util_domain.domain_fid);
 
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	data_len = rxr_get_readrsp_hdr(pkt_entry->pkt)->seg_size;
@@ -279,7 +284,7 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 	assert(tx_entry->window >= 0);
 	if (tx_entry->bytes_sent < tx_entry->total_len) {
 		assert(!efa_ep_is_cuda_mr(tx_entry->desc[0]));
-		if (efa_mr_cache_enable && rxr_ep_mr_local(ep))
+		if (efa_is_cache_available(efa_domain) && rxr_ep_mr_local(ep))
 			rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 
 		tx_entry->state = RXR_TX_SEND;

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -522,12 +522,17 @@ void rxr_pkt_handle_long_rtm_sent(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_tx_entry *tx_entry;
+	struct efa_domain *efa_domain;
+	struct rxr_domain *rxr_domain = rxr_ep_domain(ep);
+
+	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
+				  util_domain.domain_fid);
 
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 
-	if (efa_mr_cache_enable || efa_ep_is_cuda_mr(tx_entry->desc[0]))
+	if (efa_is_cache_available(efa_domain) || efa_ep_is_cuda_mr(tx_entry->desc[0]))
 		rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 }
 
@@ -1232,11 +1237,16 @@ void rxr_pkt_handle_long_rtw_sent(struct rxr_ep *ep,
 				  struct rxr_pkt_entry *pkt_entry)
 {
 	struct rxr_tx_entry *tx_entry;
+	struct efa_domain *efa_domain;
+	struct rxr_domain *rxr_domain = rxr_ep_domain(ep);
+
+	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
+				  util_domain.domain_fid);
 
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
-	if (efa_mr_cache_enable || efa_ep_is_cuda_mr(tx_entry->desc[0]))
+	if (efa_is_cache_available(efa_domain) || efa_ep_is_cuda_mr(tx_entry->desc[0]))
 		rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 }
 

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -388,6 +388,11 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 {
 	ssize_t err;
 	struct rxr_peer *peer;
+	struct efa_domain *efa_domain;
+	struct rxr_domain *rxr_domain = rxr_ep_domain(ep);
+
+	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
+				  util_domain.domain_fid);
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
 	assert(peer);
@@ -400,7 +405,7 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 
 	if (tx_entry->total_len >= rxr_env.efa_min_read_write_size &&
 	    efa_both_support_rdma_read(ep, peer) &&
-	    (tx_entry->desc[0] || efa_mr_cache_enable)) {
+	    (tx_entry->desc[0] || efa_is_cache_available(efa_domain))) {
 		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_READ_RTW_PKT, 0);
 		if (err != -FI_ENOMEM)
 			return err;


### PR DESCRIPTION
Due to efa_mr_cache_enable being a global variable, it is checked for
every domain. The check for FI_MR_LOCAL to disable efa_mr_cache_enable
caused a bug where domains with different mr_mode settings would cause
the domains with caches to not cleanup their cache. Due to needing a
domain specific check, we now check if the cache was malloc'd or not and
do not change efa_mr_cache_enable.