### PR TITLE
core/mr_cache: Remove unused user storage complexity

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -275,15 +275,8 @@ struct ofi_mr_entry {
 	uint8_t				data[];
 };
 
-enum ofi_mr_storage_type {
-	OFI_MR_STORAGE_DEFAULT = 0,
-	OFI_MR_STORAGE_RBT,
-	OFI_MR_STORAGE_USER,
-};
-
 struct ofi_mr_storage {
-	enum ofi_mr_storage_type	type;
-	void				*storage;
+	struct ofi_rbmap		tree;
 
 	struct ofi_mr_entry *		(*find)(struct ofi_mr_storage *storage,
 						const struct ofi_mr_info *key);

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -275,21 +275,6 @@ struct ofi_mr_entry {
 	uint8_t				data[];
 };
 
-struct ofi_mr_storage {
-	struct ofi_rbmap		tree;
-
-	struct ofi_mr_entry *		(*find)(struct ofi_mr_storage *storage,
-						const struct ofi_mr_info *key);
-	struct ofi_mr_entry *		(*overlap)(struct ofi_mr_storage *storage,
-						const struct iovec *key);
-	int				(*insert)(struct ofi_mr_storage *storage,
-						struct ofi_mr_info *key,
-						struct ofi_mr_entry *entry);
-	int				(*erase)(struct ofi_mr_storage *storage,
-						struct ofi_mr_entry *entry);
-	void				(*destroy)(struct ofi_mr_storage *storage);
-};
-
 #define OFI_HMEM_MAX 4
 
 struct ofi_mr_cache {
@@ -298,7 +283,7 @@ struct ofi_mr_cache {
 	struct dlist_entry		notify_entries[OFI_HMEM_MAX];
 	size_t				entry_data_size;
 
-	struct ofi_mr_storage		storage;
+	struct ofi_rbmap		tree;
 	struct dlist_entry		lru_list;
 	struct dlist_entry		flush_list;
 	pthread_mutex_t 		lock;

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -268,7 +268,7 @@ extern struct ofi_mr_cache_params	cache_params;
 
 struct ofi_mr_entry {
 	struct ofi_mr_info		info;
-	void				*storage_context;
+	struct ofi_rbnode		*node;
 	int				use_cnt;
 	struct dlist_entry		list_entry;
 	union ofi_mr_hmem_info		hmem_info;

--- a/src/tree.c
+++ b/src/tree.c
@@ -105,19 +105,19 @@ static void ofi_delete_tree(struct ofi_rbmap *map, struct ofi_rbnode *node)
 
 void ofi_rbmap_cleanup(struct ofi_rbmap *map)
 {
-	ofi_delete_tree(map, map->root);
-}
-
-void ofi_rbmap_destroy(struct ofi_rbmap *map)
-{
 	struct ofi_rbnode *node;
 
-	ofi_rbmap_cleanup(map);
+	ofi_delete_tree(map, map->root);
 	while (map->free_list) {
 		node = map->free_list;
 		map->free_list = node->right;
 		free(node);
 	}
+}
+
+void ofi_rbmap_destroy(struct ofi_rbmap *map)
+{
+	ofi_rbmap_cleanup(map);
 	free(map);
 }
 


### PR DESCRIPTION
The upstream MR cache only uses a rbtree to track registrations.  However, extra complexity and indirection is added to the code to support an alternative storage option which isn't actually used.  Simplify the code to remove the function indirection and call the  rbtree code directly.  This makes the code easier to manage and read.