### PR TITLE
common: move fork check to EFA provider

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -465,8 +465,6 @@ AS_IF([test $have_uffd -eq 1],
 AC_DEFINE_UNQUOTED([HAVE_UFFD_UNMAP], [$have_uffd],
 	[Define to 1 if platform supports userfault fd unmap])
 
-AC_CHECK_HEADERS_ONCE(infiniband/verbs.h)
-
 dnl Check support to intercept syscalls
 AC_CHECK_HEADERS_ONCE(elf.h sys/auxv.h)
 

--- a/include/ofi.h
+++ b/include/ofi.h
@@ -374,8 +374,6 @@ static inline uint32_t ofi_xorshift_random_r(uint32_t *seed)
 
 uint32_t ofi_generate_seed(void);
 
-int ofi_vrb_check_fork_enabled(struct fid_domain *domain_fid);
-
 size_t ofi_vrb_speed(uint8_t speed, uint8_t width);
 
 #ifdef __cplusplus


### PR DESCRIPTION
The autoconf was done incorrectly causing builds to fail. Move the fork
check function into the EFA provider for now.

Fixes #6327

Signed-off-by: Robert Wespetal <wesper@amazon.com>