### PR TITLE
Revert "prov/efa: Turn off the MR Cache if FI_MR_LOCAL is set"

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -273,14 +273,6 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 
 	*domain_fid = &domain->util_domain.domain_fid;
 
-	/*
-	 * If FI_MR_LOCAL is set, we do not want to use the
-	 * MR cache
-	 */
-	if (info->domain_attr && info->domain_attr->mr_mode & FI_MR_LOCAL) {
-		efa_mr_cache_enable = 0;
-	}
-
 	if (efa_mr_cache_enable && efa_check_fork_enabled(*domain_fid)) {
 		fprintf(stderr,
 		         "\nEnabling the memory registration cache and libibverbs "


### PR DESCRIPTION
This check is causing the MR cache to be disabled for MPI applications
causing performance impacts for our nightly testing.

This reverts commit 0cb254460a63c3718e1141f848a1945f2ae55e21.

Signed-off-by: Robert Wespetal <wesper@amazon.com>