### PR TITLE
[v1.11.x] EFA fixes for 1.11.x

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -338,6 +338,9 @@ extern struct fi_ops_cm efa_ep_cm_ops;
 extern struct fi_ops_msg efa_ep_msg_ops;
 extern struct fi_ops_rma efa_ep_rma_ops;
 
+ssize_t efa_rma_post_read(struct efa_ep *ep, const struct fi_msg_rma *msg,
+			  uint64_t flags, bool self_comm);
+
 extern fastlock_t pd_list_lock;
 // This list has the same indicies as ctx_list.
 extern struct efa_pd *pd_list;

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -251,6 +251,7 @@ struct efa_ep {
 	struct ibv_recv_wr	*recv_more_wr_tail;
 	struct ofi_bufpool	*send_wr_pool;
 	struct ofi_bufpool	*recv_wr_pool;
+	struct ibv_ah		*self_ah;
 };
 
 struct efa_send_wr {

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -154,10 +154,8 @@ void efa_device_free(void)
 {
 	int i;
 
-	for (i = 0; i < dev_cnt; i++) {
-		assert(pd_list[i].use_cnt == 0);
+	for (i = 0; i < dev_cnt; i++)
 		efa_device_close(ctx_list[i]);
-	}
 
 	free(pd_list);
 	free(ctx_list);

--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -37,8 +37,24 @@
 #include <ofi_iov.h>
 #include "efa.h"
 
-static
-ssize_t efa_rma_post_read(struct efa_ep *ep, const struct fi_msg_rma *msg, uint64_t flags)
+
+/*
+ * efa_rma_post_read() will post a read request.
+ *
+ * Input:
+ *     ep: endpoint
+ *     msg: read operation information
+ *     flags: currently no flags is taken
+ *     self_comm: indicate whether the read is toward
+ *                the end point itself. If self_comm is true,
+ *                caller must set msg->addr to FI_ADDR_NOTAVAIL.
+ *                
+ * On success return 0,
+ * If read iov and rma_iov count out of device limit, return -FI_EINVAL
+ * If read failed, return the error of read operation
+ */
+ssize_t efa_rma_post_read(struct efa_ep *ep, const struct fi_msg_rma *msg,
+			  uint64_t flags, bool self_comm)
 {
 	struct efa_qp *qp;
 	struct efa_mr *efa_mr;
@@ -80,8 +96,16 @@ ssize_t efa_rma_post_read(struct efa_ep *ep, const struct fi_msg_rma *msg, uint6
 	}
 
 	ibv_wr_set_sge_list(qp->ibv_qp_ex, msg->iov_count, sge_list);
-	conn = ep->av->addr_to_conn(ep->av, msg->addr);
-	ibv_wr_set_ud_addr(qp->ibv_qp_ex, conn->ah.ibv_ah, conn->ep_addr.qpn, conn->ep_addr.qkey);
+	if (self_comm) {
+		assert(msg->addr == FI_ADDR_NOTAVAIL);
+		ibv_wr_set_ud_addr(qp->ibv_qp_ex, ep->self_ah,
+				   qp->qp_num, qp->qkey);
+	} else {
+		conn = ep->av->addr_to_conn(ep->av, msg->addr);
+		ibv_wr_set_ud_addr(qp->ibv_qp_ex, conn->ah.ibv_ah,
+				   conn->ep_addr.qpn, conn->ep_addr.qkey);
+	}
+
 	return ibv_wr_complete(qp->ibv_qp_ex);
 }
 
@@ -90,7 +114,7 @@ ssize_t efa_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg, uin
 {
 	struct efa_ep *ep = container_of(ep_fid, struct efa_ep, util_ep.ep_fid);
 
-	return efa_rma_post_read(ep, msg, flags);
+	return efa_rma_post_read(ep, msg, flags, false);
 }
 
 static

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -523,9 +523,6 @@ struct rxr_ep {
 	struct fid_ep *rdm_ep;
 	struct fid_cq *rdm_cq;
 
-	/* address of myself in my AV, used to post read to my self */
-	fi_addr_t rdm_self_addr;
-
 	/* shm provider fid */
 	bool use_shm;
 	struct fid_ep *shm_ep;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -872,7 +872,6 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 	ssize_t ret;
 	size_t i;
 	struct rxr_ep *ep;
-	struct efa_ep *efa_ep;
 	uint64_t flags = FI_MORE;
 	size_t rx_size, shm_rx_size;
 	char shm_ep_name[NAME_MAX];
@@ -946,16 +945,6 @@ static int rxr_ep_ctrl(struct fid *fid, int command, void *arg)
 					goto out;
 			}
 		}
-
-		/*
-		 * insert EP's own address to AV and save the address as
-		 * ep->rdm_self_addr. It is used when copy data to GPU memory by local read
-		 */
-		efa_ep = container_of(ep->rdm_ep, struct efa_ep, util_ep.ep_fid);
-		ret = efa_av_insert_addr(efa_ep->av, (struct efa_ep_addr *)ep->core_addr,
-					 &ep->rdm_self_addr, 0, NULL);
-		if (OFI_UNLIKELY(ret))
-			FI_WARN(&rxr_prov, FI_LOG_CQ, "insert EP's own address failed!\n");
 
 out:
 		fastlock_release(&ep->util_ep.lock);
@@ -1737,8 +1726,6 @@ int rxr_endpoint(struct fid_domain *domain, struct fi_info *info,
 			  &rxr_ep->rdm_ep, rxr_ep);
 	if (ret)
 		goto err_free_rdm_info;
-
-	rxr_ep->rdm_self_addr = FI_ADDR_NOTAVAIL;
 
 	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
 				  util_domain.domain_fid);

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -415,9 +415,14 @@ void rxr_pkt_handle_rma_read_completion(struct rxr_ep *ep,
 		rxr_read_release_entry(ep, read_entry);
 	}
 
-	peer = rxr_ep_get_peer(ep, context_pkt_entry->addr);
-	if (!peer->is_local)
-		rxr_ep_dec_tx_pending(ep, peer, 0);
+	if (read_entry->context_type == RXR_READ_CONTEXT_PKT_ENTRY) {
+		assert(context_pkt_entry->addr == FI_ADDR_NOTAVAIL);
+		ep->tx_pending--;
+	} else {
+		peer = rxr_ep_get_peer(ep, context_pkt_entry->addr);
+		if (!peer->is_local)
+			rxr_ep_dec_tx_pending(ep, peer, 0);
+	}
 }
 
 void rxr_pkt_handle_rma_completion(struct rxr_ep *ep,


### PR DESCRIPTION
This doesn't include the fork support checks and remaining MR cache PR that's in progress but picks the EFA commits in master that are ready to go.

```
a9cc492a5 prov/efa: fix a bug in efa_get_gdr_support()
f20ea2dd6 prov/efa: Add FI_REMOTE_READ access to shm registrations
57f708282 prov/efa: remove protection domain use_cnt assert
106b59951 prov/efa: fix a bug by removing address insertion during initialization
8b8fcc557 prov/efa: add argument self_comm to efa_rma_post_read()
1cb1342dd prov/efa: create an AH for EP's own address
```