### PR TITLE
prov/efa: update fork support check and change to abort

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -971,9 +971,11 @@ void efa_atfork_callback()
 		"other system errors.\n"
 		"\n"
 		"For the libfabric EFA provider to work safely when fork()\n"
-		"is called, you will need to set the following environment\n"
+		"is called, the application must handle memory registrations\n"
+		"(FI_MR_LOCAL) and you will need to set the following environment\n"
 		"variables:\n"
-		"          RDMAV_FORK_SAFE=1 FI_EFA_MR_CACHE_ENABLE=0 \n"
+		"          RDMAV_FORK_SAFE=1\n"
+		"MPI applications do not support this mode.\n"
 		"\n"
 		"However, this setting can result in signficant performance\n"
 		"impact to your application due to increased cost of memory\n"
@@ -982,6 +984,9 @@ void efa_atfork_callback()
 		"You may want to check with your application vendor to see\n"
 		"if an application-level alternative (of not using fork)\n"
 		"exists.\n"
+		"\n"
+		"Please refer to https://github.com/ofiwg/libfabric/issues/6332\n"
+		"for more information.\n"
 		"\n"
 		"Your job will now abort.\n");
 	abort();


### PR DESCRIPTION
Update the fork support check so that it fails unless FI_MR_LOCAL is
set. We will only be supporting libibverbs fork support when memory
registrations are handled by the application.

Also change the fork support check to abort instead of returning an
error. Open MPI will continue if fi_domain fails and setup another
component for communication.

Signed-off-by: Robert Wespetal <wesper@amazon.com>

Test description: Verified with Open MPI that ring_c crashes when fork support is enabled but proceeds if fork support is not enabled. Called fork in ring_c and it aborted. Verified that the cache is enabled with Open MPI and the cache is disabled when the app specifies FI_MR_LOCAL (via fabtests).