### PR TITLE
common/rbmap: Fix leak by moving free_list cleanup

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -105,19 +105,19 @@ static void ofi_delete_tree(struct ofi_rbmap *map, struct ofi_rbnode *node)
 
 void ofi_rbmap_cleanup(struct ofi_rbmap *map)
 {
-	ofi_delete_tree(map, map->root);
-}
-
-void ofi_rbmap_destroy(struct ofi_rbmap *map)
-{
 	struct ofi_rbnode *node;
 
-	ofi_rbmap_cleanup(map);
+	ofi_delete_tree(map, map->root);
 	while (map->free_list) {
 		node = map->free_list;
 		map->free_list = node->right;
 		free(node);
 	}
+}
+
+void ofi_rbmap_destroy(struct ofi_rbmap *map)
+{
+	ofi_rbmap_cleanup(map);
 	free(map);
 }
 


### PR DESCRIPTION
The free_list is cleaned up as part of ofi_rbmap_destroy.
However, ofi_rbmap_destroy pairs with ofi_rbmap_create.
For users that allocate the rbmap as part of another
structure, they use ofi_rbmap_init / ofi_rbmap_cleanup.
In this use case, the free_list will leak memory for
allocated nodes.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>