### PR TITLE
util/av: Replace use of av->count with new ofi_av_size()

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -707,7 +707,6 @@ struct util_av {
 	struct util_coll_mc	*coll_mc;
 	void			*context;
 	uint64_t		flags;
-	size_t			count;
 	size_t			addrlen;
 	/*
 	 * context_offset is addrlen + offset (required for alignment),

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -740,6 +740,7 @@ int ofi_av_init_lightweight(struct util_domain *domain, const struct fi_av_attr 
 int ofi_av_close(struct util_av *av);
 int ofi_av_close_lightweight(struct util_av *av);
 
+size_t ofi_av_size(struct util_av *av);
 int ofi_av_insert_addr(struct util_av *av, const void *addr, fi_addr_t *fi_addr);
 int ofi_av_remove_addr(struct util_av *av, fi_addr_t fi_addr);
 fi_addr_t ofi_av_lookup_fi_addr_unsafe(struct util_av *av, const void *addr);

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -280,6 +280,7 @@ struct efa_av {
 	efa_addr_to_conn_func	addr_to_conn;
 	struct efa_reverse_av	*reverse_av;
 	struct util_av		util_av;
+	size_t			count;
 	enum fi_ep_type         ep_type;
 	/* Used only for FI_AV_TABLE */
 	struct efa_conn         **conn_table;

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -216,7 +216,7 @@ rxm_cmap_check_and_realloc_handles_table(struct rxm_cmap *cmap,
 	if (OFI_LIKELY(fi_addr < cmap->num_allocated))
 		return 0;
 
-	grow_size = MAX(cmap->av->count, fi_addr - cmap->num_allocated + 1);
+	grow_size = MAX(ofi_av_size(cmap->av), fi_addr - cmap->num_allocated + 1);
 
 	new_handles = realloc(cmap->handles_av,
 			      (grow_size + cmap->num_allocated) *
@@ -796,12 +796,12 @@ int rxm_cmap_alloc(struct rxm_ep *rxm_ep, struct rxm_cmap_attr *attr)
 	cmap->ep = rxm_ep;
 	cmap->av = ep->av;
 
-	cmap->handles_av = calloc(cmap->av->count, sizeof(*cmap->handles_av));
+	cmap->handles_av = calloc(ofi_av_size(ep->av), sizeof(*cmap->handles_av));
 	if (!cmap->handles_av) {
 		ret = -FI_ENOMEM;
 		goto err1;
 	}
-	cmap->num_allocated = ep->av->count;
+	cmap->num_allocated = ofi_av_size(ep->av);
 
 	cmap->attr = *attr;
 	cmap->attr.name = mem_dup(attr->name, ep->av->addrlen);
@@ -1055,7 +1055,7 @@ static size_t rxm_conn_get_rx_size(struct rxm_ep *rxm_ep,
 	if (msg_info->ep_attr->rx_ctx_cnt == FI_SHARED_CONTEXT)
 		return MAX(MIN(16, msg_info->rx_attr->size),
 			   (msg_info->rx_attr->size /
-			    rxm_ep->util_ep.av->count));
+			    ofi_av_size(rxm_ep->util_ep.av)));
 	else
 		return msg_info->rx_attr->size;
 }

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -431,7 +431,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 			const struct util_av_attr *util_attr)
 {
 	int ret = 0;
-	size_t max_count;
+	size_t orig_size;
 	size_t offset;
 
 	/* offset calculated on a 8-byte boundary */
@@ -457,16 +457,16 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 	if (ret)
 		return ret;
 
-	max_count = attr->count ? attr->count : ofi_universe_size;
-	av->count = roundup_power_of_two(max_count);
-	FI_INFO(av->prov, FI_LOG_AV, "AV size %zu\n", av->count);
+	orig_size = attr->count ? attr->count : ofi_universe_size;
+	orig_size = roundup_power_of_two(orig_size);
+	FI_INFO(av->prov, FI_LOG_AV, "AV size %zu\n", orig_size);
 
 	av->addrlen = util_attr->addrlen;
 	av->context_offset = offset + av->addrlen;
 	av->flags = util_attr->flags | attr->flags;
 	av->hash = NULL;
 
-	pool_attr.chunk_cnt = av->count;
+	pool_attr.chunk_cnt = orig_size;
 	return ofi_bufpool_create_attr(&pool_attr, &av->av_entry_pool);
 }
 

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -411,6 +411,11 @@ int ofi_av_close(struct util_av *av)
 	return 0;
 }
 
+size_t ofi_av_size(struct util_av *av)
+{
+	return av->av_entry_pool->entry_cnt;
+}
+
 static int util_verify_av_util_attr(struct util_domain *domain,
 				    const struct util_av_attr *util_attr)
 {

--- a/prov/util/src/util_coll.c
+++ b/prov/util/src/util_coll.c
@@ -1145,8 +1145,8 @@ static int util_coll_av_init(struct util_av *av)
 	if (ret)
 		goto err3;
 
-	coll_mc->av_set->fi_addr_array =
-		calloc(av->count, sizeof(*coll_mc->av_set->fi_addr_array));
+	coll_mc->av_set->fi_addr_array = calloc(ofi_av_size(av),
+					 sizeof(*coll_mc->av_set->fi_addr_array));
 	if (!coll_mc->av_set->fi_addr_array) {
 		ret = -FI_ENOMEM;
 		goto err2;
@@ -1194,7 +1194,8 @@ int ofi_av_set(struct fid_av *av, struct fi_av_set_attr *attr,
 	if (ret)
 		goto err1;
 
-	av_set->fi_addr_array = calloc(util_av->count, sizeof(*av_set->fi_addr_array));
+	av_set->fi_addr_array = calloc(ofi_av_size(util_av),
+				       sizeof(*av_set->fi_addr_array));
 	if (!av_set->fi_addr_array)
 		goto err2;
 


### PR DESCRIPTION
The AV count field does not reflect the current size of the AV.  Add a function to retrieve that value and update calling sites to use it.  This fixes an issue where AV sets are created smaller than the number of addresses being stored in the associated AV.