### PR TITLE
man: Use connectionless term consistently

### DIFF
--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -38,7 +38,7 @@ These tests are a mix of very basic functionality tests that show major
 features of libfabric.
 
 *fi_av_xfer*
-: Tests communication for unconnected endpoints, as addresses
+: Tests communication for connectionless endpoints, as addresses
   are inserted and removed from the local address vector.
 
 *fi_cm_data*

--- a/man/fi_atomic.3.md
+++ b/man/fi_atomic.3.md
@@ -382,7 +382,7 @@ and type of parameters that they accept as input.  Otherwise, they
 perform the same general function.
 
 The call fi_atomic transfers the data contained in the user-specified
-data buffer to a remote node.  For unconnected endpoints, the destination
+data buffer to a remote node.  For connectionless endpoints, the destination
 endpoint is specified through the dest_addr parameter.  Unless
 the endpoint has been configured differently, the data buffer passed
 into fi_atomic must not be touched by the application until the
@@ -405,7 +405,7 @@ discussion below for more details. The requested message size that
 can be used with fi_inject_atomic is limited by inject_size.
 
 The fi_atomicmsg call supports atomic functions over both connected
-and unconnected endpoints, with the ability to control the atomic
+and connectionless endpoints, with the ability to control the atomic
 operation per call through the use of flags.  The fi_atomicmsg
 function takes a struct fi_msg_atomic as input.
 
@@ -600,7 +600,7 @@ with atomic message calls.
   targeting the same peer endpoint have completed.  Operations posted
   after the fencing will see and/or replace the results of any
   operations initiated prior to the fenced operation.
-  
+
   The ordering of operations starting at the posting of the fenced
   operation (inclusive) to the posting of a subsequent fenced operation
   (exclusive) is controlled by the endpoint's ordering semantics.

--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -471,7 +471,7 @@ transfer operation.
 
 When a resource management error occurs on an endpoint, the endpoint is
 transitioned into a disabled state.  Any operations which have not
-already completed will fail and be discarded.  For unconnected endpoints,
+already completed will fail and be discarded.  For connectionless endpoints,
 the endpoint must be re-enabled before it will accept new data transfer
 operations.  For connected endpoints, the connection is torn down and
 must be re-established.

--- a/man/fi_endpoint.3.md
+++ b/man/fi_endpoint.3.md
@@ -198,7 +198,7 @@ Additionally, endpoints that use manual progress must be associated
 with relevant completion queues or event queues in order to drive
 progress.  For endpoints that are only used as the target of RMA or
 atomic operations, this means binding the endpoint to a completion
-queue associated with receive processing.  Unconnected endpoints must
+queue associated with receive processing.  Connectionless endpoints must
 be bound to an address vector.
 
 Once an endpoint has been activated, it may be associated with an address
@@ -594,7 +594,7 @@ desired.  Supported types are:
   flow control that maintains message boundaries.
 
 *FI_EP_RDM*
-: Reliable datagram message.  Provides a reliable, unconnected data
+: Reliable datagram message.  Provides a reliable, connectionless data
   transfer service with flow control that maintains message
   boundaries.
 
@@ -1038,7 +1038,7 @@ message order.  Relaxed completion order may enable faster reporting of
 completed transfers, allow acknowledgments to be sent over different
 fabric paths, and support more sophisticated retry mechanisms.
 This can result in lower-latency completions, particularly when
-using unconnected endpoints.  Strict completion ordering may require
+using connectionless endpoints.  Strict completion ordering may require
 that providers queue completed operations or limit available optimizations.
 
 For transmit requests, completion ordering depends on the endpoint

--- a/man/fi_msg.3.md
+++ b/man/fi_msg.3.md
@@ -139,7 +139,7 @@ message.
 ## fi_sendmsg
 
 The fi_sendmsg call supports data transfers over both connected and
-unconnected endpoints, with the ability to control the send operation
+connectionless endpoints, with the ability to control the send operation
 per call through the use of flags.  The fi_sendmsg function takes a
 `struct fi_msg` as input.
 
@@ -188,7 +188,7 @@ corresponding endpoint.  Posted receives are searched in the order in
 which they were posted in order to match sends.
 Message boundaries are maintained.  The order in which
 the receives complete is dependent on
-the endpoint type and protocol.  For unconnected endpoints, the
+the endpoint type and protocol.  For connectionless endpoints, the
 src_addr parameter can be used to indicate that a buffer should be
 posted to receive incoming data from a specific remote endpoint.
 
@@ -201,7 +201,7 @@ parameter to a receive incoming data.
 ## fi_recvmsg
 
 The fi_recvmsg call supports posting buffers over both connected and
-unconnected endpoints, with the ability to control the receive
+connectionless endpoints, with the ability to control the receive
 operation per call through the use of flags.  The fi_recvmsg function
 takes a struct fi_msg as input.
 

--- a/man/fi_rma.3.md
+++ b/man/fi_rma.3.md
@@ -152,7 +152,7 @@ referenced by the iov parameter to the remote memory region.
 ## fi_writemsg
 
 The fi_writemsg call supports data transfers over both connected and
-unconnected endpoints, with the ability to control the write operation
+connectionless endpoints, with the ability to control the write operation
 per call through the use of flags.  The fi_writemsg function takes a
 struct fi_msg_rma as input.
 
@@ -206,7 +206,7 @@ the set of data buffers referenced by the iov parameter.
 ## fi_readmsg
 
 The fi_readmsg call supports data transfers over both connected and
-unconnected endpoints, with the ability to control the read operation
+connectionless endpoints, with the ability to control the read operation
 per call through the use of flags.  The fi_readmsg function takes a
 struct fi_msg_rma as input.
 

--- a/man/fi_tagged.3.md
+++ b/man/fi_tagged.3.md
@@ -165,7 +165,7 @@ message.
 ## fi_tsendmsg
 
 The fi_tsendmsg call supports data transfers over both connected and
-unconnected endpoints, with the ability to control the send operation
+connectionless endpoints, with the ability to control the send operation
 per call through the use of flags.  The fi_tsendmsg function takes a
 struct fi_msg_tagged as input.
 
@@ -216,7 +216,7 @@ parameter to a receive incoming data.
 ## fi_trecvmsg
 
 The fi_trecvmsg call supports posting buffers over both connected and
-unconnected endpoints, with the ability to control the receive
+connectionless endpoints, with the ability to control the receive
 operation per call through the use of flags.  The fi_trecvmsg function
 takes a struct fi_msg_tagged as input.
 
@@ -258,7 +258,7 @@ and/or fi_tsendmsg.
 *FI_INJECT_COMPLETE*
 : Applies to fi_tsendmsg.  Indicates that a completion should be
   generated when the source buffer(s) may be reused.
-  
+
 *FI_TRANSMIT_COMPLETE*
 : Applies to fi_tsendmsg.  Indicates that a completion should not be
   generated until the operation has been successfully transmitted and
@@ -276,7 +276,7 @@ and/or fi_tsendmsg.
   targeting the same peer endpoint have completed.  Operations posted
   after the fencing will see and/or replace the results of any
   operations initiated prior to the fenced operation.
-  
+
   The ordering of operations starting at the posting of the fenced
   operation (inclusive) to the posting of a subsequent fenced operation
   (exclusive) is controlled by the endpoint's ordering semantics.
@@ -289,7 +289,7 @@ The following flags may be used with fi_trecvmsg.
   allocated buffering enabled (see fi_rx_attr total_buffered_recv).
   Unlike standard receive operations, a receive operation with the FI_PEEK
   flag set does not remain queued with the provider after the peek completes
-  successfully. The peek operation operates asynchronously, and the results 
+  successfully. The peek operation operates asynchronously, and the results
   of the peek operation are available in the completion queue associated with
   the endpoint. If no message is found matching the tags specified in the peek
   request, then a completion queue error entry with err field set to FI_ENOMSG


### PR DESCRIPTION
Connectionless and unconnected endpoints are used inter-
changeably in the man pages.  Use the term connectionless
instead.  Unconnected could refer to the state of a
connection-oriented endpoint.  This makes the documentation
consistent.

Fixes: 6346

Signed-off-by: Sean Hefty <sean.hefty@intel.com>