### PR TITLE
tcp/util: Add support to bind EQ to domain, along with test

### DIFF
--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -117,6 +117,7 @@ enum {
 	FT_OPT_SERVER_PERSIST	= 1 << 16,
 	FT_OPT_ENABLE_HMEM	= 1 << 17,
 	FT_OPT_USE_DEVICE	= 1 << 18,
+	FT_OPT_DOMAIN_EQ	= 1 << 19,
 	FT_OPT_OOB_CTRL		= FT_OPT_OOB_SYNC | FT_OPT_OOB_ADDR_EXCH,
 };
 
@@ -249,7 +250,7 @@ extern int listen_sock;
 #define ADDR_OPTS "B:P:s:a:b::E::C:F:"
 #define FAB_OPTS "f:d:p:D:i:H"
 #define INFO_OPTS FAB_OPTS "e:M:"
-#define CS_OPTS ADDR_OPTS "I:S:mc:t:w:l"
+#define CS_OPTS ADDR_OPTS "I:QS:mc:t:w:l"
 #define NO_CQ_DATA 0
 
 extern char default_port[8];

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -399,6 +399,9 @@ the list available for that test.
 *-I <number>*
 : Number of data transfer iterations.
 
+*-Q*
+: Associated any EQ with the domain, rather than directly with the EP.
+
 *-w <number>*
 : Number of warm-up data transfer iterations.
 

--- a/fabtests/man/fabtests.7.md
+++ b/fabtests/man/fabtests.7.md
@@ -366,6 +366,10 @@ the list available for that test.
 : Use the specified endpoint type for the test.  Valid options are msg,
   dgram, and rdm.  The default endpoint type is rdm.
 
+*-D <device_name>*
+: Allocate data buffers on the specified device, rather than in host
+  memory.  Valid options are ze.
+
 *-a <address vector name>*
 : The name of a shared address vector.  This option only applies to tests
   that support shared address vectors.

--- a/fabtests/multinode/src/core.c
+++ b/fabtests/multinode/src/core.c
@@ -52,6 +52,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <assert.h>
+#include <hmem.h>
 
 char *tx_barrier;
 char *rx_barrier;
@@ -174,7 +175,7 @@ static int multi_setup_fabric(int argc, char **argv)
 		goto err;
 	}
 
-	if (fi->domain_attr->mr_mode & FI_MR_VIRT_ADDR) 
+	if (fi->domain_attr->mr_mode & FI_MR_VIRT_ADDR)
 		remote->addr = (uintptr_t) rx_buf;
 	else
 		remote->addr = 0;
@@ -326,20 +327,20 @@ int multi_rma_write()
 
 		snprintf((char*) tx_buf + tx_size * state.cur_target, tx_size,
 		        "Hello World! from %zu to %i on the %zuth iteration, %s test",
-		        pm_job.my_rank, state.cur_target, 
+		        pm_job.my_rank, state.cur_target,
 		        (size_t) tx_seq, pattern->name);
 
 		while (1) {
-			ret = fi_write(ep, 
+			ret = fi_write(ep,
 				tx_buf + tx_size * state.cur_target,
-				opts.transfer_size, mr_desc, 
-				pm_job.fi_addrs[state.cur_target], 
+				opts.transfer_size, mr_desc,
+				pm_job.fi_addrs[state.cur_target],
 				pm_job.multi_iovs[state.cur_target].addr,
-				pm_job.multi_iovs[state.cur_target].key, 
+				pm_job.multi_iovs[state.cur_target].key,
 				&tx_ctx_arr[state.tx_window].context);
 			if (!ret)
 				break;
-		
+
 			if (ret != -FI_EAGAIN) {
 				printf("RMA write failed");
 				return ret;
@@ -352,7 +353,7 @@ int multi_rma_write()
 			}
 		}
 		tx_seq++;
-	
+
 		state.sends_posted++;
 		state.tx_window--;
 	}
@@ -396,7 +397,7 @@ int send_recv_barrier(int sync)
 	}
 
 	for (i = 0; i < pm_job.num_ranks; i++) {
-		ret = ft_post_tx_buf(ep, pm_job.fi_addrs[i], 0, 
+		ret = ft_post_tx_buf(ep, pm_job.fi_addrs[i], 0,
 				     NO_CQ_DATA, &barrier_tx_ctx[i],
 		                     tx_buf, mr_desc, 0);
 		if (ret)
@@ -407,7 +408,7 @@ int send_recv_barrier(int sync)
 	if (ret)
 		return ret;
 
-	ret = ft_get_rx_comp(rx_seq);	
+	ret = ft_get_rx_comp(rx_seq);
 
 	return ret;
 }
@@ -485,7 +486,7 @@ int multinode_run_tests(int argc, char **argv)
 	ret = multi_setup_fabric(argc, argv);
 	if (ret)
 		return ret;
-	
+
 
 	for (i = 0; i < NUM_TESTS && !ret; i++) {
 		printf("starting %s... ", patterns[i].name);

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -209,7 +209,7 @@ struct util_domain {
 
 int ofi_domain_init(struct fid_fabric *fabric_fid, const struct fi_info *info,
 		     struct util_domain *domain, void *context);
-int ofi_domain_bind_eq(struct util_domain *domain, struct util_eq *eq);
+int ofi_domain_bind(struct fid *fid, struct fid *bfid, uint64_t flags);
 int ofi_domain_close(struct util_domain *domain);
 
 static const uint64_t ofi_rx_mr_flags[] = {

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -137,7 +137,7 @@ static int tcpx_domain_close(fid_t fid)
 static struct fi_ops tcpx_domain_fi_ops = {
 	.size = sizeof(struct fi_ops),
 	.close = tcpx_domain_close,
-	.bind = fi_no_bind,
+	.bind = ofi_domain_bind,
 	.control = fi_no_control,
 	.ops_open = fi_no_ops_open,
 };


### PR DESCRIPTION
1. Fix build warning in multinode test
2. Document -D option in fabtests
3. Add fabtest option to bind the EQ to the domain, rather than the EP
4. Add domain bind support to the util_domain
5. Update tcp to use the new util domain bind function