### PR TITLE
Remove (some) warnings when building with --enable-picky

### DIFF
--- a/include/ofi_bitmask.h
+++ b/include/ofi_bitmask.h
@@ -58,35 +58,35 @@ static inline int ofi_bitmask_create(struct bitmask *mask, size_t size)
 	mask->size = size;
 
 	return FI_SUCCESS;
-};
+}
 
 static inline void ofi_bitmask_free(struct bitmask *mask)
 {
 	free(mask->bytes);
 	mask->bytes = NULL;
-};
+}
 
 static inline size_t ofi_bitmask_bytesize(struct bitmask *mask)
 {
 	return (mask->size % 8) ? (mask->size / 8 + 1) : (mask->size / 8);
-};
+}
 
 static inline void ofi_bitmask_unset(struct bitmask *mask, size_t idx)
 {
 	assert(idx <= mask->size);
 	mask->bytes[idx / 8] &= ~(0x01 << (idx % 8));
-};
+}
 
 static inline void ofi_bitmask_set(struct bitmask *mask, size_t idx)
 {
 	assert(idx <= mask->size);
 	mask->bytes[idx / 8] |= (0x01 << (idx % 8));
-};
+}
 
 static inline void ofi_bitmask_set_all(struct bitmask *mask)
 {
 	memset(mask->bytes, 0xff, ofi_bitmask_bytesize(mask));
-};
+}
 
 static inline size_t ofi_bitmask_get_lsbset(struct bitmask mask)
 {
@@ -109,6 +109,6 @@ static inline size_t ofi_bitmask_get_lsbset(struct bitmask mask)
 
 	assert(ret <= (mask.size));
 	return ret;
-};
+}
 
 #endif

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -191,7 +191,9 @@ static inline int name ## _index(struct name *fs,		\
 static inline void name ## _free(struct name *fs)		\
 {								\
 	free(fs);						\
-}
+}								\
+void dummy ## name (void) /* work-around global ; scope */
+
 
 /*
  * Buffer pool (free stack) template for shared memory regions
@@ -275,7 +277,8 @@ static inline int name ## _index(struct name *fs,		\
 static inline void name ## _free(struct name *fs)		\
 {								\
 	free(fs);						\
-}
+}								\
+void dummy ## name (void) /* work-around global ; scope */
 
 
 /*

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -66,7 +66,7 @@ enum {
 extern size_t *page_sizes;
 extern size_t num_page_sizes;
 
-static inline long ofi_get_page_size()
+static inline long ofi_get_page_size(void)
 {
 	return ofi_sysconf(_SC_PAGESIZE);
 }

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -100,50 +100,50 @@ static inline int ofi_str_dup(const char *src, char **dst)
 /*
  * Buffer pool (free stack) template
  */
-#define FREESTACK_EMPTY	NULL
+#define OFI_FREESTACK_EMPTY	NULL
 
-#define freestack_get_next(user_buf)	((char *)user_buf - sizeof(void *))
-#define freestack_get_user_buf(entry)	((char *)entry + sizeof(void *))
+#define ofi_freestack_get_next(user_buf) ((char *)user_buf - sizeof(void *))
+#define ofi_freestack_get_user_buf(entry) ((char *)entry + sizeof(void *))
 
 #if ENABLE_DEBUG
-#define freestack_init_next(entry)	*((void **)entry) = NULL
-#define freestack_check_next(entry)	assert(*((void **)entry) == NULL)
+#define ofi_freestack_init_next(entry)	*((void **)entry) = NULL
+#define ofi_freestack_check_next(entry)	assert(*((void **)entry) == NULL)
 #else
-#define freestack_init_next(entry)
-#define freestack_check_next(entry)
+#define ofi_freestack_init_next(entry)
+#define ofi_freestack_check_next(entry)
 #endif
 
-#define FREESTACK_HEADER 					\
+#define OFI_FREESTACK_HEADER 					\
 	size_t		size;					\
 	void		*next;					\
 
-#define freestack_isempty(fs)	((fs)->next == FREESTACK_EMPTY)
-#define freestack_push(fs, p)					\
+#define ofi_freestack_isempty(fs) ((fs)->next == OFI_FREESTACK_EMPTY)
+#define ofi_freestack_push(fs, p)				\
 do {								\
-	freestack_check_next(freestack_get_next(p));		\
-	*(void **) (freestack_get_next(p)) = (fs)->next;	\
-	(fs)->next = (freestack_get_next(p));			\
+	ofi_freestack_check_next(ofi_freestack_get_next(p));	\
+	*(void **) (ofi_freestack_get_next(p)) = (fs)->next;	\
+	(fs)->next = (ofi_freestack_get_next(p));		\
 } while (0)
-#define freestack_pop(fs) freestack_pop_impl(fs, (fs)->next)
+#define ofi_freestack_pop(fs) ofi_freestack_pop_impl(fs, (fs)->next)
 
-static inline void* freestack_pop_impl(void *fs, void *fs_next)
+static inline void* ofi_freestack_pop_impl(void *fs, void *fs_next)
 {
 	struct _freestack {
-		FREESTACK_HEADER
+		OFI_FREESTACK_HEADER
 	} *freestack = (struct _freestack *)fs;
-	assert(!freestack_isempty(freestack));
+	assert(!ofi_freestack_isempty(freestack));
 	freestack->next = *((void **)fs_next);
-	freestack_init_next(fs_next);
-	return freestack_get_user_buf(fs_next);
+	ofi_freestack_init_next(fs_next);
+	return ofi_freestack_get_user_buf(fs_next);
 }
 
-#define DECLARE_FREESTACK(entrytype, name)			\
+#define OFI_DECLARE_FREESTACK(entrytype, name)			\
 struct name ## _entry {						\
 	void		*next;					\
 	entrytype	buf;					\
 };								\
 struct name {							\
-	FREESTACK_HEADER					\
+	OFI_FREESTACK_HEADER					\
 	struct name ## _entry	entry[];			\
 };								\
 								\
@@ -158,11 +158,11 @@ name ## _init(struct name *fs, size_t size,			\
 	assert(size == roundup_power_of_two(size));		\
 	assert(sizeof(fs->entry[0].buf) >= sizeof(void *));	\
 	fs->size = size;					\
-	fs->next = FREESTACK_EMPTY;				\
+	fs->next = OFI_FREESTACK_EMPTY;				\
 	for (i = size - 1; i >= 0; i--) {			\
 		if (init)					\
 			init(&fs->entry[i].buf, arg);		\
-		freestack_push(fs, &fs->entry[i].buf);		\
+		ofi_freestack_push(fs, &fs->entry[i].buf);	\
 	}							\
 }								\
 								\
@@ -184,7 +184,7 @@ static inline int name ## _index(struct name *fs,		\
 				 entrytype *entry)		\
 {								\
 	return (int)((struct name ## _entry *)			\
-			(freestack_get_next(entry))		\
+			(ofi_freestack_get_next(entry))		\
 			- (struct name ## _entry *)fs->entry);	\
 }								\
 								\
@@ -207,9 +207,9 @@ static inline void name ## _free(struct name *fs)		\
 #define smr_freestack_push(fs, local_p)				\
 do {								\
 	void *p = (char **) fs->base_addr +			\
-	    ((char **) freestack_get_next(local_p) -		\
+	    ((char **) ofi_freestack_get_next(local_p) -	\
 		(char **) fs);					\
-	*(void **) freestack_get_next(local_p) = (fs)->next;	\
+	*(void **) ofi_freestack_get_next(local_p) = (fs)->next;\
 	(fs)->next = p;						\
 } while (0)
 #define smr_freestack_pop(fs) smr_freestack_pop_impl(fs, fs->next)
@@ -227,9 +227,9 @@ static inline void* smr_freestack_pop_impl(void *fs, void *next)
 		(char **) freestack->base_addr);
 
 	freestack->next = *((void **)local);
-	freestack_init_next(local);
+	ofi_freestack_init_next(local);
 
-	return freestack_get_user_buf(local);
+	return ofi_freestack_get_user_buf(local);
 }
 
 #define DECLARE_SMR_FREESTACK(entrytype, name)			\
@@ -268,7 +268,7 @@ static inline int name ## _index(struct name *fs,		\
 		entrytype *entry)				\
 {								\
 	return (int)((struct name ## _entry *)			\
-			(freestack_get_next(entry))		\
+			(ofi_freestack_get_next(entry))		\
 			- (struct name ## _entry *)fs->entry);	\
 }								\
 								\

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -232,7 +232,7 @@ static inline void* smr_freestack_pop_impl(void *fs, void *next)
 	return ofi_freestack_get_user_buf(local);
 }
 
-#define DECLARE_SMR_FREESTACK(entrytype, name)			\
+#define SMR_DECLARE_FREESTACK(entrytype, name)			\
 struct name ## _entry {						\
 	void		*next;					\
 	entrytype	buf;					\

--- a/include/ofi_rbuf.h
+++ b/include/ofi_rbuf.h
@@ -82,7 +82,8 @@ static inline struct name * name ## _create(size_t size)	\
 static inline void name ## _free(struct name *cq)		\
 {								\
 	free(cq);						\
-}
+}								\
+void dummy ## name (void) /* work-around global ; scope */
 
 #define ofi_cirque_isempty(cq)		((cq)->wcnt == (cq)->rcnt)
 #define ofi_cirque_usedcnt(cq)		((cq)->wcnt - (cq)->rcnt)

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -80,7 +80,7 @@ enum {
 
 //reserves 0-255 for defined ops and room for new ops
 //256 and beyond reserved for ctrl ops
-#define SMR_OP_MAX (1 << 8) 
+#define SMR_OP_MAX (1 << 8)
 
 #define SMR_REMOTE_CQ_DATA	(1 << 0)
 #define SMR_RMA_REQ		(1 << 1)
@@ -95,7 +95,7 @@ enum {
 	SMR_CMA_CAP_OFF,
 };
 
-/* 
+/*
  * Unique smr_op_hdr for smr message protocol:
  * 	addr - local shm_id of peer sending msg (for shm lookup)
  * 	op - type of op (ex. ofi_op_msg, defined in ofi_proto.h)
@@ -278,8 +278,8 @@ struct smr_sar_msg {
 
 OFI_DECLARE_CIRQUE(struct smr_cmd, smr_cmd_queue);
 OFI_DECLARE_CIRQUE(struct smr_resp, smr_resp_queue);
-DECLARE_SMR_FREESTACK(struct smr_inject_buf, smr_inject_pool);
-DECLARE_SMR_FREESTACK(struct smr_sar_msg, smr_sar_pool);
+SMR_DECLARE_FREESTACK(struct smr_inject_buf, smr_inject_pool);
+SMR_DECLARE_FREESTACK(struct smr_sar_msg, smr_sar_pool);
 
 static inline struct smr_region *smr_peer_region(struct smr_region *smr, int i)
 {
@@ -299,11 +299,11 @@ static inline struct smr_inject_pool *smr_inject_pool(struct smr_region *smr)
 }
 static inline struct smr_peer_data *smr_peer_data(struct smr_region *smr)
 {
-	return (struct smr_peer_data *) ((char *) smr + smr->peer_data_offset); 
+	return (struct smr_peer_data *) ((char *) smr + smr->peer_data_offset);
 }
 static inline struct smr_sar_pool *smr_sar_pool(struct smr_region *smr)
 {
-	return (struct smr_sar_pool *) ((char *) smr + smr->sar_pool_offset); 
+	return (struct smr_sar_pool *) ((char *) smr + smr->sar_pool_offset);
 }
 static inline const char *smr_name(struct smr_region *smr)
 {

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -690,7 +690,7 @@ struct util_av_entry {
 	 * field in 'data' and addr length should be a multiple
 	 * of 8 bytes to ensure alignment of additional fields
 	 */
-	char		data[0];
+	char		data[];
 };
 
 struct util_av {
@@ -823,7 +823,7 @@ struct util_event {
 	ssize_t			size;
 	int			event;
 	int			err;
-	uint8_t			data[0]; /* offset should be 8-byte aligned */
+	uint8_t			data[]; /* offset should be 8-byte aligned */
 };
 
 int ofi_eq_create(struct fid_fabric *fabric, struct fi_eq_attr *attr,

--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -256,12 +256,12 @@ struct efa_ep {
 
 struct efa_send_wr {
 	struct ibv_send_wr wr;
-	struct ibv_sge sge[0];
+	struct ibv_sge sge[];
 };
 
 struct efa_recv_wr {
 	struct ibv_recv_wr wr;
-	struct ibv_sge sge[0];
+	struct ibv_sge sge[];
 };
 
 typedef struct efa_conn *

--- a/prov/efa/src/rxr/rxr_pkt_entry.h
+++ b/prov/efa/src/rxr/rxr_pkt_entry.h
@@ -109,7 +109,7 @@ static_assert(sizeof(struct rxr_pkt_entry) == 64, "rxr_pkt_entry check");
 #endif
 
 OFI_DECL_RECVWIN_BUF(struct rxr_pkt_entry*, rxr_robuf, uint32_t);
-DECLARE_FREESTACK(struct rxr_robuf, rxr_robuf_fs);
+OFI_DECLARE_FREESTACK(struct rxr_robuf, rxr_robuf_fs);
 
 struct rxr_ep;
 

--- a/prov/hook/hook_debug/src/hook_debug.c
+++ b/prov/hook/hook_debug/src/hook_debug.c
@@ -89,14 +89,14 @@ static void hook_debug_trace_exit(struct fid *fid, struct fid *hfid,
 
 	if (ret > 0) {
 		FI_TRACE(hook_to_hprov(fid), subsys, "%s (fid: %p) returned: "
-			 "%zd\n", fn, hfid, ret);
+			 "%zd\n", fn, (void *) hfid, ret);
 		goto out;
 	}
 
 	if (ret != -FI_EAGAIN || !eagain_count ||
 	    !((*eagain_count)++ % HOOK_DEBUG_EAGAIN_LOG))
 		FI_TRACE(hook_to_hprov(fid), subsys, "%s (fid: %p) returned: "
-			 "%zd (%s)\n", fn, hfid, ret, fi_strerror(-ret));
+			 "%zd (%s)\n", fn, (void *) hfid, ret, fi_strerror(-ret));
 out:
 	if (eagain_count && ret != -FI_EAGAIN)
 		*eagain_count = 0;
@@ -105,8 +105,8 @@ out:
 static void
 hook_debug_trace_exit_eq(struct hook_debug_eq *eq, const char *fn, ssize_t ret)
 {
-	return hook_debug_trace_exit(&eq->hook_eq.eq.fid, &eq->hook_eq.heq->fid,
-				     FI_LOG_EQ, fn, ret, &eq->eagain_count);
+	hook_debug_trace_exit(&eq->hook_eq.eq.fid, &eq->hook_eq.heq->fid,
+			      FI_LOG_EQ, fn, ret, &eq->eagain_count);
 }
 
 static void
@@ -143,7 +143,7 @@ static void hook_debug_rx_end(struct hook_debug_ep *ep, char *fn,
 			ep->rx_outs++;
 			FI_TRACE(hook_to_hprov(&ep->hook_ep.ep.fid),
 				 FI_LOG_EP_DATA, "ep: %p rx_outs: %zu\n",
-				 ep->hook_ep.hep, ep->rx_outs);
+				 (void *) ep->hook_ep.hep, ep->rx_outs);
 		} else {
 			rx_entry = mycontext;
 			ofi_buf_free(rx_entry);
@@ -238,7 +238,7 @@ static void hook_debug_tx_end(struct hook_debug_ep *ep, char *fn,
 			ep->tx_outs++;
 			FI_TRACE(hook_to_hprov(&ep->hook_ep.ep.fid),
 				 FI_LOG_EP_DATA, "ep: %p tx_outs: %zu\n",
-				 ep->hook_ep.hep, ep->tx_outs);
+				 (void *) ep->hook_ep.hep, ep->tx_outs);
 		} else {
 			tx_entry = mycontext;
 			ofi_buf_free(tx_entry);
@@ -522,7 +522,7 @@ static void hook_debug_cq_process_entry(struct hook_debug_cq *mycq,
 				rx_entry->ep->rx_outs--;
 				FI_TRACE(hook_to_hprov(&mycq->hook_cq.cq.fid),
 					 FI_LOG_CQ, "ep: %p rx_outs: %zu\n",
-					 rx_entry->ep->hook_ep.hep,
+					 (void *) rx_entry->ep->hook_ep.hep,
 					 rx_entry->ep->rx_outs);
 				ofi_buf_free(rx_entry);
 			}
@@ -535,7 +535,7 @@ static void hook_debug_cq_process_entry(struct hook_debug_cq *mycq,
 			tx_entry->ep->tx_outs--;
 			FI_TRACE(hook_to_hprov(&mycq->hook_cq.cq.fid),
 				 FI_LOG_CQ, "ep: %p tx_outs: %zu\n",
-				 tx_entry->ep->hook_ep.hep,
+				 (void *) tx_entry->ep->hook_ep.hep,
 				 tx_entry->ep->tx_outs);
 			ofi_buf_free(tx_entry);
 		}
@@ -565,7 +565,7 @@ static ssize_t hook_debug_cq_readfrom(struct fid_cq *cq, void *buf, size_t count
 	return ret;
 }
 
-int hook_debug_cq_close(struct fid *fid)
+static int hook_debug_cq_close(struct fid *fid)
 {
 	struct hook_debug_cq *mycq =
 		container_of(fid, struct hook_debug_cq, hook_cq.cq.fid);
@@ -601,11 +601,13 @@ static void hook_debug_cq_attr_log(struct hook_domain *dom,
 	HOOK_DEBUG_TRACE(dom->fabric, FI_LOG_CQ, "\tsignaling_vector: %d\n",
 			 attr->signaling_vector);
 	HOOK_DEBUG_TRACE(dom->fabric, FI_LOG_CQ, "\twait_cond: %s\n", "TBD");
-	HOOK_DEBUG_TRACE(dom->fabric, FI_LOG_CQ, "\twait_set: %p\n", attr->wait_set);
+	HOOK_DEBUG_TRACE(dom->fabric, FI_LOG_CQ, "\twait_set: %p\n",
+			 (void *) attr->wait_set);
 }
 
-int hook_debug_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
-		       struct fid_cq **cq, void *context)
+static int
+hook_debug_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
+		   struct fid_cq **cq, void *context)
 {
 	struct hook_domain *domain = container_of(domain_fid, struct hook_domain,
 						  domain);
@@ -633,7 +635,7 @@ int hook_debug_cq_open(struct fid_domain *domain_fid, struct fi_cq_attr *attr,
 		goto err;
 
 	FI_TRACE(hook_fabric_to_hprov(mycq->hook_cq.domain->fabric), FI_LOG_CQ,
-		 "cq opened, fid: %p\n", &mycq->hook_cq.hcq->fid);
+		 "cq opened, fid: %p\n", (void *) &mycq->hook_cq.hcq->fid);
 
 	mycq->hook_cq.cq.fid.ops = &hook_debug_cq_fid_ops;
 	mycq->hook_cq.cq.ops = &hook_debug_cq_ops;
@@ -667,7 +669,7 @@ static int hook_debug_ep_close(struct fid *fid)
 	return ret;
 }
 
-int hook_debug_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
+static int hook_debug_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
 	struct fid *hfid, *hbfid;
 	struct hook_cntr *cntr;
@@ -682,13 +684,14 @@ int hook_debug_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 	case FI_CLASS_CQ:
 		cq = container_of(bfid, struct hook_cq, cq.fid);
 		HOOK_DEBUG_TRACE(cq->domain->fabric, FI_LOG_EP_CTRL,
-				 "cq: %p bind flags: %s\n", cq->hcq,
+				 "cq: %p bind flags: %s\n", (void *) cq->hcq,
 				 fi_tostr(&flags, FI_TYPE_CAPS));
 		break;
 	case FI_CLASS_CNTR:
 		cntr = container_of(bfid, struct hook_cntr, cntr.fid);
 		HOOK_DEBUG_TRACE(cntr->domain->fabric, FI_LOG_EP_CTRL,
-				 "cntr: %p bind flags: %s\n", cntr->hcntr,
+				 "cntr: %p bind flags: %s\n",
+				 (void *) cntr->hcntr,
 				 fi_tostr(&flags, FI_TYPE_CAPS));
 		break;
 	}
@@ -729,8 +732,9 @@ struct fi_ops_tagged hook_debug_tagged_ops = {
 	.injectdata	= hook_debug_tinjectdata,
 };
 
-int hook_debug_endpoint(struct fid_domain *domain, struct fi_info *info,
-			struct fid_ep **ep, void *context)
+static int
+hook_debug_endpoint(struct fid_domain *domain, struct fi_info *info,
+		    struct fid_ep **ep, void *context)
 {
 	struct hook_debug_ep *myep;
 	struct ofi_bufpool_attr bufpool_attr = {
@@ -779,7 +783,7 @@ int hook_debug_endpoint(struct fid_domain *domain, struct fi_info *info,
 		goto err;
 
 	FI_TRACE(hook_to_hprov(&myep->hook_ep.ep.fid), FI_LOG_EP_CTRL,
-		 "endpoint opened, fid: %p\n", &myep->hook_ep.hep->fid);
+		 "endpoint opened, fid: %p\n", (void *) &myep->hook_ep.hep->fid);
 
 	myep->hook_ep.ep.fid.ops = &hook_debug_ep_fid_ops;
 	myep->hook_ep.ep.msg = &hook_debug_msg_ops;
@@ -852,8 +856,9 @@ static int hook_debug_eq_close(struct fid *fid)
 static struct fi_ops_eq hook_debug_eq_ops;
 static struct fi_ops hook_debug_eq_fid_ops;
 
-int hook_debug_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
-		 struct fid_eq **eq, void *context)
+static int
+hook_debug_eq_open(struct fid_fabric *fabric, struct fi_eq_attr *attr,
+		   struct fid_eq **eq, void *context)
 {
 	struct hook_debug_eq *myeq;
 	int i, ret;
@@ -932,7 +937,7 @@ static int hook_debug_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int t
 
 	HOOK_DEBUG_TRACE(mycntr->domain->fabric, FI_LOG_CNTR,
 			 "cntr: %p, threshold: %" PRIu64 ", timeout: %d\n",
-			 mycntr->hcntr, threshold, timeout);
+			 (void *) mycntr->hcntr, threshold, timeout);
 
 	ret = fi_cntr_wait(mycntr->hcntr, threshold, timeout);
 
@@ -942,18 +947,18 @@ static int hook_debug_cntr_wait(struct fid_cntr *cntr, uint64_t threshold, int t
 
 static struct fi_ops_cntr hook_debug_cntr_ops;
 
-int hook_debug_cntr_init(struct fid *fid)
+static int hook_debug_cntr_init(struct fid *fid)
 {
 	struct hook_cntr *mycntr = container_of(fid, struct hook_cntr, cntr.fid);
 	HOOK_DEBUG_TRACE(mycntr->domain->fabric, FI_LOG_CNTR,
-			 "fi_cntr_open: %p\n", mycntr->hcntr);
+			 "fi_cntr_open: %p\n", (void *) mycntr->hcntr);
 	mycntr->cntr.ops = &hook_debug_cntr_ops;
 	return 0;
 }
 
 static struct fi_ops_domain hook_debug_domain_ops;
 
-int hook_debug_domain_init(struct fid *fid)
+static int hook_debug_domain_init(struct fid *fid)
 {
 	struct fid_domain *domain = container_of(fid, struct fid_domain, fid);
 	domain->ops = &hook_debug_domain_ops;

--- a/prov/mrail/src/mrail.h
+++ b/prov/mrail/src/mrail.h
@@ -215,7 +215,7 @@ struct mrail_recv {
 	uint64_t 		ignore;
 	struct mrail_rndv_recv	rndv;
 };
-DECLARE_FREESTACK(struct mrail_recv, mrail_recv_fs);
+OFI_DECLARE_FREESTACK(struct mrail_recv, mrail_recv_fs);
 
 int mrail_cq_process_buf_recv(struct fi_cq_tagged_entry *comp,
 			      struct mrail_recv *recv);
@@ -316,8 +316,8 @@ mrail_pop_recv(struct mrail_ep *mrail_ep)
 {
 	struct mrail_recv *recv;
 	ofi_ep_lock_acquire(&mrail_ep->util_ep);
-	recv = freestack_isempty(mrail_ep->recv_fs) ? NULL :
-		freestack_pop(mrail_ep->recv_fs);
+	recv = ofi_freestack_isempty(mrail_ep->recv_fs) ? NULL :
+		ofi_freestack_pop(mrail_ep->recv_fs);
 	ofi_ep_lock_release(&mrail_ep->util_ep);
 	return recv;
 }
@@ -326,7 +326,7 @@ static inline void
 mrail_push_recv(struct mrail_recv *recv)
 {
 	ofi_ep_lock_acquire(&recv->ep->util_ep);
-	freestack_push(recv->ep->recv_fs, recv);
+	ofi_freestack_push(recv->ep->recv_fs, recv);
 	ofi_ep_lock_release(&recv->ep->util_ep);
 }
 

--- a/prov/psm/src/psmx.h
+++ b/prov/psm/src/psmx.h
@@ -287,7 +287,7 @@ struct psmx_fid_domain {
 	 * purpose. The tag-matching functions automatically treat these bits
 	 * as 0. This field is a bit mask, with reserved bits valued as "1".
 	 */
-	uint64_t		reserved_tag_bits; 
+	uint64_t		reserved_tag_bits;
 
 	/* lock to prevent the sequence of psm_mq_ipeek and psm_mq_test be
 	 * interleaved in a multithreaded environment.
@@ -534,7 +534,7 @@ struct psmx_fid_mr {
 	uint64_t		flags;
 	uint64_t		offset;
 	size_t			iov_count;
-	struct iovec		iov[0];	/* must be the last field */
+	struct iovec		iov[];	/* must be the last field */
 };
 
 struct psmx_epaddr_context {

--- a/prov/rstream/src/rstream.h
+++ b/prov/rstream/src/rstream.h
@@ -142,7 +142,7 @@ struct rstream_ctx_data {
 	size_t len;
 };
 
-DECLARE_FREESTACK(struct rstream_ctx_data, rstream_tx_ctx_fs);
+OFI_DECLARE_FREESTACK(struct rstream_ctx_data, rstream_tx_ctx_fs);
 
 struct rstream_tx_ctx {
 	struct rstream_ctx_data *tx_ctxs;

--- a/prov/rstream/src/rstream_msg.c
+++ b/prov/rstream/src/rstream_msg.c
@@ -118,7 +118,7 @@ static struct fi_context *rstream_get_rx_ctx(struct rstream_ep *ep)
 static struct fi_context *rstream_get_tx_ctx(struct rstream_ep *ep, int len)
 {
 	struct rstream_tx_ctx_fs *fs = ep->tx_ctxs;
-	struct rstream_ctx_data *rtn_ctx = freestack_pop(fs);
+	struct rstream_ctx_data *rtn_ctx = ofi_freestack_pop(fs);
 
 	if (!rtn_ctx)
 		return NULL;
@@ -135,7 +135,7 @@ static int rstream_return_tx_ctx(struct fi_context *ctx_ptr,
 
 	struct rstream_ctx_data *ctx_data = (struct rstream_ctx_data *)ctx_ptr;
 	len = ctx_data->len;
-	freestack_push(fs, ctx_data);
+	ofi_freestack_push(fs, ctx_data);
 
 	return len;
 }

--- a/prov/rxd/src/rxd_rma.c
+++ b/prov/rxd/src/rxd_rma.c
@@ -100,7 +100,7 @@ static ssize_t rxd_generic_write_inject(struct rxd_ep *rxd_ep,
 
 	if (ofi_cirque_isfull(rxd_ep->util_ep.tx_cq->cirq))
 		goto out;
-	
+
 	rxd_addr = (intptr_t) ofi_idx_lookup(&(rxd_ep_av(rxd_ep)->fi_addr_idx),
 					      RXD_IDX_OFFSET(addr));
 	if (!rxd_addr)
@@ -130,7 +130,8 @@ out:
 	return ret;
 }
 
-ssize_t rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
+static ssize_t
+rxd_generic_rma(struct rxd_ep *rxd_ep, const struct iovec *iov,
 	size_t iov_count, const struct fi_rma_iov *rma_iov, size_t rma_count,
 	void **desc, fi_addr_t addr, void *context, uint32_t op, uint64_t data,
 	uint32_t rxd_flags)
@@ -180,7 +181,8 @@ out:
 	return ret;
 }
 
-ssize_t rxd_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
+static ssize_t
+rxd_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	fi_addr_t src_addr, uint64_t addr, uint64_t key, void *context)
 {
 	struct rxd_ep *ep;
@@ -195,12 +197,13 @@ ssize_t rxd_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	rma_iov.len = len;
 	rma_iov.key = key;
 
-	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
+	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc,
 			       src_addr, context, RXD_READ_REQ, 0,
 			       ep->tx_flags);
 }
 
-ssize_t rxd_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+static ssize_t
+rxd_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 	size_t count, fi_addr_t src_addr, uint64_t addr, uint64_t key,
 	void *context)
 {
@@ -218,7 +221,8 @@ ssize_t rxd_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 			       ep->tx_flags);
 }
 
-ssize_t rxd_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
+static ssize_t
+rxd_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	uint64_t flags)
 {
 	struct rxd_ep *ep;
@@ -232,7 +236,8 @@ ssize_t rxd_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 			       ep->util_ep.tx_msg_flags));
 }
 
-ssize_t rxd_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
+static ssize_t
+rxd_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc,
 	fi_addr_t dest_addr, uint64_t addr, uint64_t key, void *context)
 {
 	struct rxd_ep *ep;
@@ -247,12 +252,13 @@ ssize_t rxd_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc
 	rma_iov.len = len;
 	rma_iov.key = key;
 
-	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
+	return rxd_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc,
 			       dest_addr, context, RXD_WRITE, 0,
 			       ep->tx_flags);
 }
 
-ssize_t rxd_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
+static ssize_t
+rxd_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		size_t count, fi_addr_t dest_addr, uint64_t addr, uint64_t key,
 		void *context)
 {
@@ -270,8 +276,8 @@ ssize_t rxd_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 			       ep->tx_flags);
 }
 
-
-ssize_t rxd_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
+static ssize_t
+rxd_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 	uint64_t flags)
 {
 	struct rxd_ep *ep;
@@ -285,7 +291,8 @@ ssize_t rxd_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 			       ep->util_ep.tx_msg_flags));
 }
 
-ssize_t rxd_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
+static ssize_t
+rxd_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 		      void *desc, uint64_t data, fi_addr_t dest_addr,
 		      uint64_t addr, uint64_t key, void *context)
 {
@@ -306,7 +313,8 @@ ssize_t rxd_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
 			       ep->tx_flags | RXD_REMOTE_CQ_DATA);
 }
 
-ssize_t rxd_inject_write(struct fid_ep *ep_fid, const void *buf,
+static ssize_t
+rxd_inject_write(struct fid_ep *ep_fid, const void *buf,
 	size_t len, fi_addr_t dest_addr, uint64_t addr, uint64_t key)
 {
 	struct rxd_ep *rxd_ep;
@@ -326,9 +334,10 @@ ssize_t rxd_inject_write(struct fid_ep *ep_fid, const void *buf,
 					RXD_NO_TX_COMP | RXD_INJECT);
 }
 
-ssize_t rxd_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
-			     uint64_t data, fi_addr_t dest_addr, uint64_t addr,
-			     uint64_t key)
+static ssize_t
+rxd_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t len,
+		     uint64_t data, fi_addr_t dest_addr, uint64_t addr,
+		     uint64_t key)
 {
 	struct rxd_ep *rxd_ep;
 	struct iovec iov;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -660,7 +660,7 @@ struct rxm_recv_entry {
 		struct rxm_tx_base_buf *tx_buf;
 	} rndv;
 };
-DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
+OFI_DECLARE_FREESTACK(struct rxm_recv_entry, rxm_recv_fs);
 
 enum rxm_recv_queue_type {
 	RXM_RECV_QUEUE_UNSPEC,
@@ -980,7 +980,7 @@ static inline void
 rxm_recv_entry_release(struct rxm_recv_queue *queue, struct rxm_recv_entry *entry)
 {
 	entry->total_len = 0;
-	freestack_push(queue->fs, entry);
+	ofi_freestack_push(queue->fs, entry);
 }
 
 static inline int rxm_cq_write_recv_comp(struct rxm_rx_buf *rx_buf,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -824,10 +824,10 @@ rxm_recv_entry_get(struct rxm_ep *rxm_ep, const struct iovec *iov,
 	struct rxm_recv_entry *recv_entry;
 	size_t i;
 
-	if (freestack_isempty(recv_queue->fs))
+	if (ofi_freestack_isempty(recv_queue->fs))
 		return NULL;
 
-	recv_entry = freestack_pop(recv_queue->fs);
+	recv_entry = ofi_freestack_pop(recv_queue->fs);
 	assert(!recv_entry->rndv.tx_buf);
 
 	recv_entry->rxm_iov.count = (uint8_t) count;

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -183,10 +183,10 @@ struct smr_unexp_msg {
 	struct smr_cmd cmd;
 };
 
-DECLARE_FREESTACK(struct smr_rx_entry, smr_recv_fs);
-DECLARE_FREESTACK(struct smr_unexp_msg, smr_unexp_fs);
-DECLARE_FREESTACK(struct smr_tx_entry, smr_pend_fs);
-DECLARE_FREESTACK(struct smr_sar_entry, smr_sar_fs);
+OFI_DECLARE_FREESTACK(struct smr_rx_entry, smr_recv_fs);
+OFI_DECLARE_FREESTACK(struct smr_unexp_msg, smr_unexp_fs);
+OFI_DECLARE_FREESTACK(struct smr_tx_entry, smr_pend_fs);
+OFI_DECLARE_FREESTACK(struct smr_sar_entry, smr_sar_fs);
 
 struct smr_queue {
 	struct dlist_entry list;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -175,7 +175,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 	total_len = ofi_datatype_size(datatype) * ofi_total_ioc_cnt(ioc, count);
-	
+
 	switch (op) {
 	case ofi_op_atomic_compare:
 		assert(compare_ioc);
@@ -222,7 +222,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 				goto unlock_cq;
 			}
 			resp = ofi_cirque_tail(smr_resp_queue(ep->region));
-			pend = freestack_pop(ep->pend_fs);
+			pend = ofi_freestack_pop(ep->pend_fs);
 			smr_format_pend_resp(pend, cmd, context, iface, device, result_iov,
 					     result_count, id, resp);
 			cmd->msg.hdr.data = smr_get_offset(ep->region, resp);
@@ -348,7 +348,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
 	total_len = count * ofi_datatype_size(datatype);
-	
+
 	iov.iov_base = (void *) buf;
 	iov.iov_len = total_len;
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -145,7 +145,7 @@ static int smr_ep_cancel_recv(struct smr_ep *ep, struct smr_queue *queue,
 				  recv_entry->flags, 0,
 				  NULL, recv_entry->peer_id,
 				  recv_entry->tag, 0, FI_ECANCELED);
-		freestack_push(ep->recv_fs, recv_entry);
+		ofi_freestack_push(ep->recv_fs, recv_entry);
 		ret = ret ? ret : 1;
 	}
 
@@ -250,8 +250,8 @@ static int smr_match_tagged(struct dlist_entry *item, const void *args)
 
 	recv_entry = container_of(item, struct smr_rx_entry, entry);
 	return smr_match_id(recv_entry->peer_id, attr->id) &&
-	       smr_match_tag(recv_entry->tag, recv_entry->ignore, attr->tag); 
-} 
+	       smr_match_tag(recv_entry->tag, recv_entry->ignore, attr->tag);
+}
 
 static int smr_match_unexp_msg(struct dlist_entry *item, const void *args)
 {
@@ -585,7 +585,7 @@ static int smr_ep_bind_cntr(struct smr_ep *ep, struct util_cntr *cntr, uint64_t 
 	if (ret)
 		return ret;
 
-	if (cntr->wait) {	
+	if (cntr->wait) {
 		ret = ofi_wait_add_fid(cntr->wait, &ep->util_ep.ep_fid.fid, 0,
 				       smr_ep_trywait);
 		if (ret)

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -57,13 +57,13 @@ static struct smr_rx_entry *smr_get_recv_entry(struct smr_ep *ep,
 	struct smr_rx_entry *entry;
 
 	if (ofi_cirque_isfull(ep->util_ep.rx_cq->cirq) ||
-	    freestack_isempty(ep->recv_fs)) {
+	    ofi_freestack_isempty(ep->recv_fs)) {
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
 			"not enough space to post recv\n");
 		return NULL;
 	}
 
-	entry = freestack_pop(ep->recv_fs);
+	entry = ofi_freestack_pop(ep->recv_fs);
 
 	memcpy(&entry->iov, iov, sizeof(*iov) * count);
 	entry->iov_count = count;
@@ -208,7 +208,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 			goto unlock_cq;
 		}
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
-		pend = freestack_pop(ep->pend_fs);
+		pend = ofi_freestack_pop(ep->pend_fs);
 		if (smr_cma_enabled(ep, peer_smr) && iface == FI_HMEM_SYSTEM) {
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
 				       resp);
@@ -231,7 +231,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 						      total_len, pend, resp);
 			}
 			if (ret) {
-				freestack_push(ep->pend_fs, pend);
+				ofi_freestack_push(ep->pend_fs, pend);
 				ret = -FI_EAGAIN;
 				goto unlock_cq;
 			}

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -163,7 +163,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 			}
 			cmd->msg.hdr.op_flags |= SMR_RMA_REQ;
 			resp = ofi_cirque_tail(smr_resp_queue(ep->region));
-			pend = freestack_pop(ep->pend_fs);
+			pend = ofi_freestack_pop(ep->pend_fs);
 			smr_format_pend_resp(pend, cmd, context, iface, device, iov,
 					     iov_count, id, resp);
 			cmd->msg.hdr.data = smr_get_offset(ep->region, resp);
@@ -176,7 +176,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 			goto unlock_cq;
 		}
 		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
-		pend = freestack_pop(ep->pend_fs);
+		pend = ofi_freestack_pop(ep->pend_fs);
 		if (smr_cma_enabled(ep, peer_smr) && iface == FI_HMEM_SYSTEM) {
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
 				       resp);
@@ -199,7 +199,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 						      total_len, pend, resp);
 			}
 			if (ret) {
-				freestack_push(ep->pend_fs, pend);
+				ofi_freestack_push(ep->pend_fs, pend);
 				ret = -FI_EAGAIN;
 				goto unlock_cq;
 			}
@@ -251,7 +251,7 @@ ssize_t smr_read(struct fid_ep *ep_fid, void *buf, size_t len, void *desc,
 	rma_iov.len = len;
 	rma_iov.key = key;
 
-	return smr_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
+	return smr_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc,
 			       src_addr, context, ofi_op_read_req, 0,
 			       smr_ep_tx_flags(ep));
 }
@@ -303,7 +303,7 @@ ssize_t smr_write(struct fid_ep *ep_fid, const void *buf, size_t len, void *desc
 	rma_iov.len = len;
 	rma_iov.key = key;
 
-	return smr_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc, 
+	return smr_generic_rma(ep, &msg_iov, 1, &rma_iov, 1, &desc,
 			       dest_addr, context, ofi_op_write, 0,
 			       smr_ep_tx_flags(ep));
 }

--- a/prov/sockets/include/sock.h
+++ b/prov/sockets/include/sock.h
@@ -467,7 +467,7 @@ struct sock_eq_entry {
 	size_t len;
 	uint64_t flags;
 	struct dlist_entry entry;
-	char event[0];
+	char event[];
 };
 
 struct sock_eq_err_data_entry {
@@ -876,7 +876,7 @@ struct sock_cq_overflow_entry_t {
 	size_t len;
 	fi_addr_t addr;
 	struct dlist_entry entry;
-	char cq_entry[0];
+	char cq_entry[];
 };
 
 struct sock_cq {
@@ -916,7 +916,7 @@ struct sock_conn_req {
 	struct sock_conn_hdr hdr;
 	union ofi_sock_ip src_addr;
 	uint64_t caps;
-	char cm_data[0];
+	char cm_data[];
 };
 
 enum {

--- a/prov/usnic/src/usdf.h
+++ b/prov/usnic/src/usdf.h
@@ -425,7 +425,7 @@ enum {
 struct usdf_err_data_entry {
 	struct slist_entry entry;
 	uint8_t seen;
-	uint8_t err_data[0];
+	uint8_t err_data[];
 };
 
 struct usdf_event {

--- a/prov/usnic/src/usdf_cm.h
+++ b/prov/usnic/src/usdf_cm.h
@@ -51,7 +51,7 @@ struct usdf_connreq_msg {
 	uint32_t creq_result;
 	uint32_t creq_reason;
 	uint32_t creq_datalen;
-	uint8_t creq_data[0];
+	uint8_t creq_data[];
 } __attribute__((packed));
 
 struct usdf_connreq {
@@ -67,7 +67,7 @@ struct usdf_connreq {
 	size_t cr_resid;
 
 	size_t cr_datalen;
-	uint8_t cr_data[0];
+	uint8_t cr_data[];
 };
 
 void usdf_cm_report_failure(struct usdf_connreq *crp, int error,

--- a/prov/usnic/src/usnic_direct/vnic_devcmd.h
+++ b/prov/usnic/src/usnic_direct/vnic_devcmd.h
@@ -820,7 +820,7 @@ struct vnic_devcmd_notify {
 struct vnic_devcmd_provinfo {
 	u8 oui[3];
 	u8 type;
-	u8 data[0];
+	u8 data[];
 };
 
 /*
@@ -1038,7 +1038,7 @@ enum {
 struct filter_tlv {
 	u_int32_t type;
 	u_int32_t length;
-	u_int32_t val[0];
+	u_int32_t val[];
 };
 
 /* Data for CMD_ADD_FILTER is 2 TLV and filter + action structs */
@@ -1379,9 +1379,9 @@ typedef enum {
  *
  * in:  (u32) a0 = RDMA_SUBCMD_GET_STATS
  *
- * out: (u64) a0 = IG packet count 
+ * out: (u64) a0 = IG packet count
  *      (u64) a1 = IG byte count
- *      (u64) a2 = EG packet count 
+ *      (u64) a2 = EG packet count
  *      (u64) a3 = EG byte count
  */
 #define RDMA_SUBCMD_GET_STATS             7

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -888,7 +888,7 @@ int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc);
 	  .lkey = (uint32_t) (uintptr_t) desc }
 
 #define vrb_set_sge_iov(sg_list, iov, count, desc)	\
-({							\
+do {							\
 	size_t i;					\
 	sg_list = alloca(sizeof(*sg_list) * count);	\
 	for (i = 0; i < count; i++) {			\
@@ -897,10 +897,10 @@ int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc);
 				iov[i].iov_len,		\
 				desc[i]);		\
 	}						\
-})
+} while (0)
 
 #define vrb_set_sge_iov_count_len(sg_list, iov, count, desc, len)	\
-({									\
+do {									\
 	size_t i;							\
 	sg_list = alloca(sizeof(*sg_list) * count);			\
 	for (i = 0; i < count; i++) {					\
@@ -910,12 +910,12 @@ int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc);
 				desc[i]);				\
 		len += iov[i].iov_len;					\
 	}								\
-})
+} while (0)
 
 #define vrb_init_sge_inline(buf, len) vrb_init_sge(buf, len, NULL)
 
 #define vrb_set_sge_iov_inline(sg_list, iov, count, len)	\
-({								\
+do {								\
 	size_t i;						\
 	sg_list = alloca(sizeof(*sg_list) * count);		\
 	for (i = 0; i < count; i++) {				\
@@ -924,7 +924,7 @@ int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc);
 					iov[i].iov_len);	\
 		len += iov[i].iov_len;				\
 	}							\
-})
+} while (0)
 
 #define vrb_send_iov(ep, wr, iov, desc, count)		\
 	vrb_send_iov_flags(ep, wr, iov, desc, count,		\

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -124,7 +124,7 @@ int vrb_verify_xrc_cm_data(struct vrb_xrc_cm_data *remote,
 	return FI_SUCCESS;
 }
 
-void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
+static void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 {
 	struct sockaddr *addr;
 	char buf[OFI_ADDRSTRLEN];
@@ -133,33 +133,36 @@ void vrb_log_ep_conn(struct vrb_xrc_ep *ep, char *desc)
 	if (!fi_log_enabled(&vrb_prov, FI_LOG_INFO, FI_LOG_EP_CTRL))
 		return;
 
-	VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, %s\n", ep, desc);
+	VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, %s\n", (void *) ep, desc);
 	VERBS_INFO(FI_LOG_EP_CTRL,
 		  "EP %p, CM ID %p, TGT CM ID %p, SRQN %d Peer SRQN %d\n",
-		  ep, ep->base_ep.id, ep->tgt_id, ep->srqn, ep->peer_srqn);
+		  (void*) ep, (void *) ep->base_ep.id, (void *) ep->tgt_id,
+		  ep->srqn, ep->peer_srqn);
 
 
 	if (ep->base_ep.id) {
 		addr = rdma_get_local_addr(ep->base_ep.id);
 		len = sizeof(buf);
 		ofi_straddr(buf, &len, ep->base_ep.info_attr.addr_format, addr);
-		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p src_addr: %s\n", ep, buf);
+		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p src_addr: %s\n",
+			   (void *) ep, buf);
 
 		addr = rdma_get_peer_addr(ep->base_ep.id);
 		len = sizeof(buf);
 		ofi_straddr(buf, &len, ep->base_ep.info_attr.addr_format, addr);
-		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p dst_addr: %s\n", ep, buf);
+		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p dst_addr: %s\n",
+			   (void *) ep, buf);
 	}
 
 	if (ep->base_ep.ibv_qp) {
 		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, INI QP Num %d\n",
-			  ep, ep->base_ep.ibv_qp->qp_num);
-		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, Remote TGT QP Num %d\n", ep,
-			  ep->ini_conn->tgt_qpn);
+			   (void *) ep, ep->base_ep.ibv_qp->qp_num);
+		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, Remote TGT QP Num %d\n",
+			   (void *) ep, ep->ini_conn->tgt_qpn);
 	}
 	if (ep->tgt_ibv_qp)
 		VERBS_INFO(FI_LOG_EP_CTRL, "EP %p, TGT QP Num %d\n",
-			  ep, ep->tgt_ibv_qp->qp_num);
+			   (void *) ep, ep->tgt_ibv_qp->qp_num);
 }
 
 /* Caller must hold eq:lock */

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1695,26 +1695,26 @@ free_ep:
 }
 
 
-#define vrb_atomicvalid(name, flags)					\
+#define VRB_DEF_ATOMICVALID(name, flags)				\
 static int vrb_msg_ep_atomic_ ## name(struct fid_ep *ep_fid,		\
 					 enum fi_datatype datatype,	\
 					 enum fi_op op, size_t *count)	\
 {									\
-	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep,	\
+	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep,		\
 					    util_ep.ep_fid);		\
 	struct fi_atomic_attr attr;					\
 	int ret;							\
 									\
-	ret = vrb_query_atomic(&ep->util_ep.domain->domain_fid,	\
+	ret = vrb_query_atomic(&ep->util_ep.domain->domain_fid,		\
 				  datatype, op, &attr, flags);		\
 	if (!ret)							\
 		*count = attr.count;					\
 	return ret;							\
 }
 
-vrb_atomicvalid(writevalid, 0);
-vrb_atomicvalid(readwritevalid, FI_FETCH_ATOMIC);
-vrb_atomicvalid(compwritevalid, FI_COMPARE_ATOMIC);
+VRB_DEF_ATOMICVALID(writevalid, 0)
+VRB_DEF_ATOMICVALID(readwritevalid, FI_FETCH_ATOMIC)
+VRB_DEF_ATOMICVALID(compwritevalid, FI_COMPARE_ATOMIC)
 
 int vrb_query_atomic(struct fid_domain *domain_fid, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,


### PR DESCRIPTION
First set of patches to cleanup build warnings when pedantic is enabled.  These cleanups touch a variety of places in the code.  See individual commits for details.  None of the changes are fix any functionality.

These changes do not address all build warnings.  There are plenty to go.  But this is a start at removing some of them.