### PR TITLE
fi_tostr: Add ability to convert an binary address to a string

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -662,6 +662,12 @@ fi_set_ops(struct fid *fid, const char *name, uint64_t flags,
 		fid->ops->ops_set(fid, name, flags, ops, context) : -FI_ENOSYS;
 }
 
+struct fi_ep_addr {
+	void			*addr;
+	size_t			len;
+	uint32_t		format;
+};
+
 enum fi_type {
 	FI_TYPE_INFO,
 	FI_TYPE_EP_TYPE,
@@ -689,6 +695,7 @@ enum fi_type {
 	FI_TYPE_FID,
 	FI_TYPE_COLLECTIVE_OP,
 	FI_TYPE_HMEM_IFACE,
+	FI_TYPE_EP_ADDR,
 };
 
 char *fi_tostr(const void *data, enum fi_type datatype);

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -12,7 +12,7 @@ fi_fabric \- Fabric domain operations
 fi_fabric / fi_close
 : Open / close a fabric domain
 
-fi_tostr
+fi_tostr / fi_tostr_r
 : Convert fabric attributes, flags, and capabilities to printable string
 
 # SYNOPSIS
@@ -26,6 +26,9 @@ int fi_fabric(struct fi_fabric_attr *attr,
 int fi_close(struct fid *fabric);
 
 char * fi_tostr(const void *data, enum fi_type datatype);
+
+char * fi_tostr(char *buf, size_t len, const void *data,
+    enum fi_type datatype);
 ```
 
 # ARGUMENTS
@@ -39,6 +42,19 @@ char * fi_tostr(const void *data, enum fi_type datatype);
 *context*
 : User specified context associated with the opened object.  This
   context is returned as part of any associated asynchronous event.
+
+*buf*
+: Output buffer to write string.
+
+*len*
+: Size in bytes of memory referenced by buf.
+
+*data*
+: Input data to convert into a string.  The format of data is determined
+  by the datatype parameter.
+
+*datatype*
+: Indicates the data to convert to a printable string.
 
 # DESCRIPTION
 
@@ -60,7 +76,7 @@ The fi_close call is used to release all resources associated with a
 fabric domain or interface.  All items associated with the opened
 fabric must be released prior to calling fi_close.
 
-## fi_tostr
+## fi_tostr / fi_tostr_r
 
 Converts fabric interface attributes, capabilities, flags, and enum
 values into a printable string.  The data parameter accepts a pointer
@@ -150,6 +166,10 @@ datatype or field value.
 fi_tostr() will return a pointer to an internal libfabric buffer that
 should not be modified, and will be overwritten the next time
 fi_tostr() is invoked.  fi_tostr() is not thread safe.
+
+The fi_tostr_r() function is a re-entrant and thread safe version of
+fi_tostr().  It writes the string into a buffer provided by the caller.
+fi_tostr_r() returns the start of the caller's buffer.
 
 # NOTES
 

--- a/man/fi_fabric.3.md
+++ b/man/fi_fabric.3.md
@@ -163,6 +163,9 @@ datatype or field value.
 *FI_TYPE_HMEM_IFACE*
 : enum fi_hmem_iface *
 
+*FI_TYPE_EP_ADDR*
+: struct fi_ep_addr *
+
 fi_tostr() will return a pointer to an internal libfabric buffer that
 should not be modified, and will be overwritten the next time
 fi_tostr() is invoked.  fi_tostr() is not thread safe.

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -741,6 +741,7 @@ __attribute__((visibility ("default"),EXTERNALLY_VISIBLE))
 char *DEFAULT_SYMVER_PRE(fi_tostr_r)(char *buf, size_t len,
 				     const void *data, enum fi_type datatype)
 {
+	struct fi_ep_addr *ep_addr;
 	const uint64_t *val64;
 	const uint32_t *val32;
 	const int *enumval;
@@ -833,6 +834,10 @@ char *DEFAULT_SYMVER_PRE(fi_tostr_r)(char *buf, size_t len,
 		break;
 	case FI_TYPE_HMEM_IFACE:
 		ofi_tostr_hmem_iface(buf, len, *enumval);
+		break;
+	case FI_TYPE_EP_ADDR:
+		ep_addr = (void *) data;
+		ofi_tostr_addr(buf, len, ep_addr->format, ep_addr->addr);
 		break;
 	default:
 		ofi_strncatf(buf, len, "Unknown type");


### PR DESCRIPTION
Introduce a new struct fi_ep_addr, which can be passed into fi_tostr() and used to convert a binary endpoint address into a string.  Some services used to setup communication between peers only allow exchanging strings.