### PR TITLE
configure: Improve __alias__ attribute check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -386,7 +386,7 @@ AC_TRY_LINK(
 		int foo(int arg) { return arg + 3; };
 		int foo2(int arg) __attribute__ (( __alias__("foo")));
 	],
-	[ /* empty main */ ],
+	[ foo2(1); ],
 	[
 		AC_MSG_RESULT(yes)
 		ac_prog_cc_alias_symbols=1


### PR DESCRIPTION
Attempt to use the function alias, since some compilers only warn that
aliases are not supported when defined. Usage is a stronger
check. Fixes build with Intel compilers on macOS.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>