### PR TITLE
fabtest: Fix MR cache evict test on FreeBSD

### DIFF
--- a/fabtests/include/freebsd/malloc.h
+++ b/fabtests/include/freebsd/malloc.h
@@ -1,0 +1,44 @@
+/*
+ * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef _FABTESTS_FREEBSD_MALLOC_H_
+#define _FABTESTS_FREEBSD_MALLOC_H_
+
+#define M_MMAP_THRESHOLD    -3
+
+int mallopt(int param, int value)
+{
+	/* Not supported. */
+	return 0;
+}
+
+#endif /* _FABTESTS_FREEBSD_MALLOC_H_ */


### PR DESCRIPTION
Use same workaround as macOS to enable building MR cache evict test on
FreeBSD platforms, where mallopt is not supported.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>