### PR TITLE
prov/efa: EFA send path/MR fixes

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -497,7 +497,6 @@ struct rxr_domain {
 	struct fid_domain *rdm_domain;
 	size_t mtu_size;
 	size_t addrlen;
-	uint8_t mr_local;
 	uint8_t rxr_mr_local;
 	uint64_t rdm_mode;
 	int do_progress;
@@ -967,14 +966,6 @@ static inline void efa_eq_write_error(struct util_ep *ep, ssize_t err,
 static inline struct rxr_domain *rxr_ep_domain(struct rxr_ep *ep)
 {
 	return container_of(ep->util_ep.domain, struct rxr_domain, util_domain);
-}
-
-static inline uint8_t rxr_ep_mr_local(struct rxr_ep *ep)
-{
-	struct rxr_domain *domain = container_of(ep->util_ep.domain,
-						 struct rxr_domain,
-						 util_domain);
-	return domain->mr_local;
 }
 
 /*

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -827,7 +827,7 @@ void rxr_cq_handle_tx_completion(struct rxr_ep *ep, struct rxr_tx_entry *tx_entr
 	if (tx_entry->state == RXR_TX_SEND)
 		dlist_remove(&tx_entry->entry);
 
-	if (efa_is_cache_available(efa_domain) && rxr_ep_mr_local(ep)) {
+	if (efa_is_cache_available(efa_domain)) {
 		ret = rxr_tx_entry_mr_dereg(tx_entry);
 		if (OFI_UNLIKELY(ret)) {
 			FI_WARN(&rxr_prov, FI_LOG_MR,

--- a/prov/efa/src/rxr/rxr_domain.c
+++ b/prov/efa/src/rxr/rxr_domain.c
@@ -211,7 +211,6 @@ int rxr_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 				info->src_addrlen : info->dest_addrlen;
 	rxr_domain->cq_size = MAX(info->rx_attr->size + info->tx_attr->size,
 				  rxr_env.cq_size);
-	rxr_domain->mr_local = ofi_mr_local(rdm_info);
 	rxr_domain->resource_mgmt = rdm_info->domain_attr->resource_mgmt;
 
 	ret = ofi_domain_init(fabric, info, &rxr_domain->util_domain, context);

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -349,7 +349,7 @@ int rxr_ep_post_buf(struct rxr_ep *ep, const struct fi_msg *posted_recv, uint64_
 			dlist_insert_tail(&rx_pkt_entry->dbg_entry,
 					  &ep->rx_posted_buf_list);
 #endif
-		desc = rxr_ep_mr_local(ep) ? fi_mr_desc(rx_pkt_entry->mr) : NULL;
+		desc = fi_mr_desc(rx_pkt_entry->mr);
 		msg.desc = &desc;
 		/*
 		 * Use the actual receive sizes from the application
@@ -1168,10 +1168,8 @@ static int rxr_create_pkt_pool(struct rxr_ep *ep, size_t size,
 		.alignment	= RXR_BUF_POOL_ALIGNMENT,
 		.max_cnt	= chunk_count,
 		.chunk_cnt	= chunk_count,
-		.alloc_fn	= rxr_ep_mr_local(ep) ?
-					rxr_buf_region_alloc_hndlr : NULL,
-		.free_fn	= rxr_ep_mr_local(ep) ?
-					rxr_buf_region_free_hndlr : NULL,
+		.alloc_fn	= rxr_buf_region_alloc_hndlr,
+		.free_fn	= rxr_buf_region_free_hndlr,
 		.init_fn	= NULL,
 		.context	= rxr_ep_domain(ep),
 		.flags		= flags,

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -166,7 +166,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		/* we do not check the return value of rxr_ep_init_mr_desc()
 		 * because medium message works even if MR registration failed
 		 */
-		if (efa_is_cache_available(efa_domain))
+		if (tx_entry->desc[0] || efa_is_cache_available(efa_domain))
 			rxr_ep_tx_init_mr_desc(rxr_domain, tx_entry, 0, FI_SEND);
 		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
 						  RXR_MEDIUM_MSGRTM_PKT + tagged, 0);

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -57,12 +57,6 @@ ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep,
 	struct rxr_pkt_entry *pkt_entry;
 	struct rxr_data_pkt *data_pkt;
 	ssize_t ret;
-	struct efa_domain *efa_domain;
-	struct rxr_domain *rxr_domain = rxr_ep_domain(rxr_ep);
-
-	efa_domain = container_of(rxr_domain->rdm_domain, struct efa_domain,
-				  util_domain.domain_fid);
-
 
 	pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_efa_pool);
 	if (OFI_UNLIKELY(!pkt_entry))
@@ -84,14 +78,7 @@ ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep,
 	 */
 	data_pkt->hdr.seg_offset = tx_entry->bytes_sent;
 
-	/*
-	 * TODO: Check to see if underlying device can support CUDA
-	 * registrations and fallback to rxr_ep_send_data_pkt_entry() if it does
-	 * not. This should be done at init time with a CUDA reg-and-fail flag.
-	 * For now, always send CUDA buffers through
-	 * rxr_pkt_send_data_desc().
-	 */
-	if (efa_is_cache_available(efa_domain) || efa_ep_is_cuda_mr(tx_entry->desc[0]))
+	if (tx_entry->desc[0])
 		ret = rxr_pkt_send_data_desc(rxr_ep, tx_entry, pkt_entry);
 	else
 		ret = rxr_pkt_send_data(rxr_ep, tx_entry, pkt_entry);

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -387,7 +387,7 @@ ssize_t rxr_pkt_entry_send_with_flags(struct rxr_ep *ep,
 		assert(ep->use_shm);
 		desc = NULL;
 	} else {
-		desc = rxr_ep_mr_local(ep) ? fi_mr_desc(pkt_entry->mr) : NULL;
+		desc = fi_mr_desc(pkt_entry->mr);
 	}
 
 	return rxr_pkt_entry_sendv(ep, pkt_entry, addr, &iov, &desc, 1, flags);

--- a/prov/efa/src/rxr/rxr_pkt_type_data.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_data.c
@@ -157,7 +157,7 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 	/* Assign packet header in constructed iov */
 	iov[i].iov_base = rxr_pkt_start(pkt_entry);
 	iov[i].iov_len = sizeof(struct rxr_data_hdr);
-	desc[i] = rxr_ep_mr_local(ep) ? fi_mr_desc(pkt_entry->mr) : NULL;
+	desc[i] = fi_mr_desc(pkt_entry->mr);
 	i++;
 
 	/*
@@ -168,12 +168,11 @@ ssize_t rxr_pkt_send_data_desc(struct rxr_ep *ep,
 	 */
 	while (tx_entry->iov_index < tx_entry->iov_count &&
 	       remaining_len > 0 && i < ep->core_iov_limit) {
-		if (!rxr_ep_mr_local(ep) || tx_entry->desc[tx_entry->iov_index]) {
+		if (tx_entry->desc[tx_entry->iov_index]) {
 			iov[i].iov_base =
 				(char *)tx_iov[tx_entry->iov_index].iov_base +
 				tx_entry->iov_offset;
-			if (rxr_ep_mr_local(ep))
-				desc[i] = tx_entry->desc[tx_entry->iov_index];
+			desc[i] = tx_entry->desc[tx_entry->iov_index];
 
 			len = tx_iov[tx_entry->iov_index].iov_len
 			      - tx_entry->iov_offset;

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -284,7 +284,7 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 	assert(tx_entry->window >= 0);
 	if (tx_entry->bytes_sent < tx_entry->total_len) {
 		assert(!efa_ep_is_cuda_mr(tx_entry->desc[0]));
-		if (efa_is_cache_available(efa_domain))
+		if (tx_entry->desc[0] || efa_is_cache_available(efa_domain))
 			rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 
 		tx_entry->state = RXR_TX_SEND;

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -284,7 +284,7 @@ void rxr_pkt_handle_readrsp_sent(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_en
 	assert(tx_entry->window >= 0);
 	if (tx_entry->bytes_sent < tx_entry->total_len) {
 		assert(!efa_ep_is_cuda_mr(tx_entry->desc[0]));
-		if (efa_is_cache_available(efa_domain) && rxr_ep_mr_local(ep))
+		if (efa_is_cache_available(efa_domain))
 			rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 
 		tx_entry->state = RXR_TX_SEND;

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -532,7 +532,7 @@ void rxr_pkt_handle_long_rtm_sent(struct rxr_ep *ep,
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
 
-	if (efa_is_cache_available(efa_domain) || efa_ep_is_cuda_mr(tx_entry->desc[0]))
+	if (tx_entry->desc[0] || efa_is_cache_available(efa_domain))
 		rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 }
 
@@ -1246,7 +1246,7 @@ void rxr_pkt_handle_long_rtw_sent(struct rxr_ep *ep,
 	tx_entry = (struct rxr_tx_entry *)pkt_entry->x_entry;
 	tx_entry->bytes_sent += rxr_pkt_req_data_size(pkt_entry);
 	assert(tx_entry->bytes_sent < tx_entry->total_len);
-	if (efa_is_cache_available(efa_domain) || efa_ep_is_cuda_mr(tx_entry->desc[0]))
+	if (tx_entry->desc[0] || efa_is_cache_available(efa_domain))
 		rxr_prepare_desc_send(rxr_ep_domain(ep), tx_entry);
 }
 


### PR DESCRIPTION
There is a bug in the EFA provider that causes the memory descriptor to be skipped when specified by the app, causing an unneeded memory copy in the send path. Do some other cleanup while we're here. There is more to do but this at least fixes the issue for now.

Test description: Added some prints and ran `fi_rdm_tagged_pingpong`/`fi_rma_bw -o write` to verify the descriptor is being used for the various protocols. Did some testing with MPI (latency, bw, message rate, alltoall) as well and verified inline registration is still functional.