### PR TITLE
Add support for FI_SYNC_ERR to IP based AVs

### DIFF
--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -231,43 +231,43 @@ static inline int ofi_translate_addr_format(int family)
 
 uint16_t ofi_get_sa_family(const struct fi_info *info);
 
-static inline int ofi_sin_is_any_addr(const struct sockaddr *sa)
+static inline bool ofi_sin_is_any_addr(const struct sockaddr *sa)
 {
 	struct in_addr ia_any = {
 		.s_addr = INADDR_ANY,
 	};
 
 	if (!sa)
-		return 0;
+		return false;
 
 	return !memcmp(&ofi_sin_addr(sa).s_addr, &ia_any, sizeof(ia_any));
 
 }
 
-static inline int ofi_sin6_is_any_addr(const struct sockaddr *sa)
+static inline bool ofi_sin6_is_any_addr(const struct sockaddr *sa)
 {
 	struct in6_addr ia6_any = IN6ADDR_ANY_INIT;
 
 	if (!sa)
-		return 0;
+		return false;
 
 	return !memcmp(&ofi_sin6_addr(sa), &ia6_any, sizeof(ia6_any));
 }
 
-static inline int ofi_sib_is_any_addr(const struct sockaddr *sa)
+static inline bool ofi_sib_is_any_addr(const struct sockaddr *sa)
 {
 	struct in6_addr ia6_any = IN6ADDR_ANY_INIT;
 
 	if (!sa)
-		return 0;
+		return false;
 
 	return !memcmp(&ofi_sib_addr(sa), &ia6_any, sizeof(ia6_any));
 }
 
-static inline int ofi_is_any_addr(const struct sockaddr *sa)
+static inline bool ofi_is_any_addr(const struct sockaddr *sa)
 {
 	if (!sa)
-		return 0;
+		return false;
 
 	switch(sa->sa_family) {
 	case AF_INET:
@@ -278,7 +278,7 @@ static inline int ofi_is_any_addr(const struct sockaddr *sa)
 		return ofi_sib_is_any_addr(sa);
 	default:
 		FI_WARN(&core_prov, FI_LOG_CORE, "Unknown address format!\n");
-		return 0;
+		return false;
 	}
 }
 
@@ -336,16 +336,16 @@ static inline void * ofi_get_ipaddr(const struct sockaddr *addr)
 	}
 }
 
-static inline int ofi_valid_dest_ipaddr(const struct sockaddr *addr)
+static inline bool ofi_valid_dest_ipaddr(const struct sockaddr *addr)
 {
 	return ofi_addr_get_port(addr) && !ofi_is_any_addr(addr);
 }
 
-static inline int ofi_equals_ipaddr(const struct sockaddr *addr1,
+static inline bool ofi_equals_ipaddr(const struct sockaddr *addr1,
 				    const struct sockaddr *addr2)
 {
 	if (addr1->sa_family != addr2->sa_family)
-		return 0;
+		return false;
 
 	switch (addr1->sa_family) {
 	case AF_INET:
@@ -358,19 +358,19 @@ static inline int ofi_equals_ipaddr(const struct sockaddr *addr1,
 	        return !memcmp(&ofi_sib_addr(addr1), &ofi_sib_addr(addr2),
 				sizeof(ofi_sib_addr(addr1)));
 	default:
-		return 0;
+		return false;
 	}
 }
 
-static inline int ofi_equals_sockaddr(const struct sockaddr *addr1,
-				      const struct sockaddr *addr2)
+static inline bool ofi_equals_sockaddr(const struct sockaddr *addr1,
+				       const struct sockaddr *addr2)
 {
         return (ofi_addr_get_port(addr1) == ofi_addr_get_port(addr2)) &&
 		ofi_equals_ipaddr(addr1, addr2);
 }
 
-int ofi_is_wildcard_listen_addr(const char *node, const char *service,
-				uint64_t flags, const struct fi_info *hints);
+bool ofi_is_wildcard_listen_addr(const char *node, const char *service,
+				 uint64_t flags, const struct fi_info *hints);
 
 size_t ofi_mask_addr(struct sockaddr *maskaddr, const struct sockaddr *srcaddr,
 		     const struct sockaddr *netmask);

--- a/include/ofi_net.h
+++ b/include/ofi_net.h
@@ -231,7 +231,7 @@ static inline int ofi_translate_addr_format(int family)
 
 uint16_t ofi_get_sa_family(const struct fi_info *info);
 
-static inline int ofi_sin_is_any_addr(struct sockaddr *sa)
+static inline int ofi_sin_is_any_addr(const struct sockaddr *sa)
 {
 	struct in_addr ia_any = {
 		.s_addr = INADDR_ANY,
@@ -244,7 +244,7 @@ static inline int ofi_sin_is_any_addr(struct sockaddr *sa)
 
 }
 
-static inline int ofi_sin6_is_any_addr(struct sockaddr *sa)
+static inline int ofi_sin6_is_any_addr(const struct sockaddr *sa)
 {
 	struct in6_addr ia6_any = IN6ADDR_ANY_INIT;
 
@@ -254,7 +254,7 @@ static inline int ofi_sin6_is_any_addr(struct sockaddr *sa)
 	return !memcmp(&ofi_sin6_addr(sa), &ia6_any, sizeof(ia6_any));
 }
 
-static inline int ofi_sib_is_any_addr(struct sockaddr *sa)
+static inline int ofi_sib_is_any_addr(const struct sockaddr *sa)
 {
 	struct in6_addr ia6_any = IN6ADDR_ANY_INIT;
 
@@ -264,7 +264,7 @@ static inline int ofi_sib_is_any_addr(struct sockaddr *sa)
 	return !memcmp(&ofi_sib_addr(sa), &ia6_any, sizeof(ia6_any));
 }
 
-static inline int ofi_is_any_addr(struct sockaddr *sa)
+static inline int ofi_is_any_addr(const struct sockaddr *sa)
 {
 	if (!sa)
 		return 0;
@@ -296,7 +296,6 @@ static inline uint16_t ofi_addr_get_port(const struct sockaddr *addr)
 		return (uint16_t)ntohll(((const struct ofi_sockaddr_ib *)addr)->sib_sid);
 	default:
 		FI_WARN(&core_prov, FI_LOG_FABRIC, "Unknown address format\n");
-		assert(0);
 		return 0;
 	}
 }
@@ -335,6 +334,11 @@ static inline void * ofi_get_ipaddr(const struct sockaddr *addr)
 	default:
 		return NULL;
 	}
+}
+
+static inline int ofi_valid_dest_ipaddr(const struct sockaddr *addr)
+{
+	return ofi_addr_get_port(addr) && !ofi_is_any_addr(addr);
 }
 
 static inline int ofi_equals_ipaddr(const struct sockaddr *addr1,

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -767,9 +767,10 @@ int ofi_get_src_addr(uint32_t addr_format,
 void ofi_getnodename(uint16_t sa_family, char *buf, int buflen);
 int ofi_av_get_index(struct util_av *av, const void *addr);
 
-int ofi_verify_av_insert(struct util_av *av, uint64_t flags);
+int ofi_verify_av_insert(struct util_av *av, uint64_t flags, void *context);
 int ofi_ip_av_insertv(struct util_av *av, const void *addr, size_t addrlen,
-		      size_t count, fi_addr_t *fi_addr, void *context);
+		      size_t count, fi_addr_t *fi_addr, uint64_t flags,
+		      void *context);
 /* Caller should free *addr */
 int ofi_ip_av_sym_getaddr(struct util_av *av, const char *node,
 			  size_t nodecnt, const char *service,

--- a/prov/rxm/src/rxm_av.c
+++ b/prov/rxm/src/rxm_av.c
@@ -137,7 +137,7 @@ static int rxm_av_insertsym(struct fid_av *av_fid, const char *node,
 	size_t addrlen, count = nodecnt * svccnt;
 	int ret, retv;
 
-	ret = ofi_verify_av_insert(av, flags);
+	ret = ofi_verify_av_insert(av, flags, context);
 	if (ret)
 		return ret;
 
@@ -148,7 +148,8 @@ static int rxm_av_insertsym(struct fid_av *av_fid, const char *node,
 
 	assert(ret == count);
 
-	ret = ofi_ip_av_insertv(av, addr, addrlen, count, fi_addr, context);
+	ret = ofi_ip_av_insertv(av, addr, addrlen, count, fi_addr, flags,
+				context);
 	if (!av->eq && ret < count) {
 		count = ret;
 	}

--- a/prov/sockets/src/sock_av.c
+++ b/prov/sockets/src/sock_av.c
@@ -140,11 +140,6 @@ static void sock_av_report_error(struct sock_av *av, fi_addr_t *fi_addr,
 			     context, index, err, -err, NULL, 0);
 }
 
-static int sock_av_is_valid_address(const struct sockaddr *addr)
-{
-	return ofi_sizeofaddr(addr);
-}
-
 static void sock_update_av_table(struct sock_av *_av, size_t count)
 {
 	_av->table = (struct sock_av_addr *)
@@ -211,7 +206,7 @@ static int sock_check_table_in(struct sock_av *_av, const struct sockaddr *addr,
 		for (i = 0; i < count; i++) {
 			for (j = 0; j < _av->table_hdr->size; j++) {
 				if (_av->table[j].valid &&
-				    !sock_av_is_valid_address(&addr[i])) {
+				    !ofi_valid_dest_ipaddr(&addr[i])) {
 					sock_av_report_error(_av, fi_addr,
 							context, i, FI_EINVAL);
 					continue;
@@ -232,7 +227,7 @@ static int sock_check_table_in(struct sock_av *_av, const struct sockaddr *addr,
 	}
 
 	for (i = 0, ret = 0; i < count; i++) {
-		if (!sock_av_is_valid_address(&addr[i])) {
+		if (!ofi_valid_dest_ipaddr(&addr[i])) {
 			sock_av_report_error(_av, fi_addr, context, i, FI_EINVAL);
 			continue;
 		}

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -256,7 +256,7 @@ int ofi_verify_av_insert(struct util_av *av, uint64_t flags)
 
 	if (flags & ~(FI_MORE)) {
 		FI_WARN(av->prov, FI_LOG_AV, "unsupported flags\n");
-		return -FI_ENOEQ;
+		return -FI_EBADFLAGS;
 	}
 
 	return 0;

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -592,28 +592,12 @@ fi_addr_t ofi_ip_av_get_fi_addr(struct util_av *av, const void *addr)
 	return ofi_av_lookup_fi_addr(av, addr);
 }
 
-static int ip_av_valid_addr(struct util_av *av, const void *addr)
-{
-	const struct sockaddr_in *sin = addr;
-	const struct sockaddr_in6 *sin6 = addr;
-
-	switch (sin->sin_family) {
-	case AF_INET:
-		return sin->sin_port && sin->sin_addr.s_addr;
-	case AF_INET6:
-		return sin6->sin6_port &&
-		      memcmp(&in6addr_any, &sin6->sin6_addr, sizeof(in6addr_any));
-	default:
-		return 0;
-	}
-}
-
 static int ip_av_insert_addr(struct util_av *av, const void *addr,
 			     fi_addr_t *fi_addr, void *context)
 {
 	int ret;
 
-	if (ip_av_valid_addr(av, addr)) {
+	if (ofi_valid_dest_ipaddr(addr)) {
 		fastlock_acquire(&av->lock);
 		ret = ofi_av_insert_addr(av, addr, fi_addr);
 		fastlock_release(&av->lock);

--- a/src/common.c
+++ b/src/common.c
@@ -870,8 +870,8 @@ static int ofi_is_any_addr_port(struct sockaddr *addr)
 	}
 }
 
-int ofi_is_wildcard_listen_addr(const char *node, const char *service,
-				uint64_t flags, const struct fi_info *hints)
+bool ofi_is_wildcard_listen_addr(const char *node, const char *service,
+				 uint64_t flags, const struct fi_info *hints)
 {
 	struct addrinfo *res = NULL;
 	int ret;
@@ -880,30 +880,30 @@ int ofi_is_wildcard_listen_addr(const char *node, const char *service,
 	    hints->addr_format != FI_SOCKADDR &&
 	    hints->addr_format != FI_SOCKADDR_IN &&
 	    hints->addr_format != FI_SOCKADDR_IN6)
-		return 0;
+		return false;
 
 	/* else it's okay to call getaddrinfo, proceed with processing */
 
 	if (node) {
 		if (!(flags & FI_SOURCE))
-			return 0;
+			return false;
 		ret = getaddrinfo(node, service, NULL, &res);
 		if (ret) {
 			FI_WARN(&core_prov, FI_LOG_CORE,
 				"getaddrinfo failed!\n");
-			return 0;
+			return false;
 		}
 		if (ofi_is_any_addr_port(res->ai_addr)) {
 			freeaddrinfo(res);
 			goto out;
 		}
 		freeaddrinfo(res);
-		return 0;
+		return false;
 	}
 
 	if (hints) {
 		if (hints->dest_addr)
-			return 0;
+			return false;
 
 		if (!hints->src_addr)
 			goto out;
@@ -911,7 +911,7 @@ int ofi_is_wildcard_listen_addr(const char *node, const char *service,
 		return ofi_is_any_addr_port(hints->src_addr);
 	}
 out:
-	return ((flags & FI_SOURCE) && service) ? 1 : 0;
+	return ((flags & FI_SOURCE) && service);
 }
 
 size_t ofi_mask_addr(struct sockaddr *maskaddr, const struct sockaddr *srcaddr,


### PR DESCRIPTION
Fix a bug returning an incorrect (misleading) errno from the util AV code.

Add support for FI_SYNC_ERR to the IP AV code.  This allows rxm and rxd to support the flag.

Add a new test to the AV unit test to verify correct operation of FI_SYNC_ERR.

Fixes #6357