### PR TITLE
fabtest: Include FreeBSD specific headers

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -9,6 +9,7 @@ endif
 
 if FREEBSD
 os_excludes = -f ./test_configs/freebsd.exclude
+AM_CFLAGS += -I$(srcdir)/include/freebsd
 endif
 
 bin_PROGRAMS = \


### PR DESCRIPTION
Follow up to incomplete fix in
[f37705916a07bebfcb5814a7af16fd572bc55f60]. Modify AM_CFLAGS so the
dummy malloc.h file gets included.

Signed-off-by: Ken Raffenetti <raffenet@mcs.anl.gov>