### PR TITLE
prov/util: Fix a bug in ofi_get_page_end

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -257,7 +257,8 @@ static inline void *ofi_get_page_start(const void *addr, size_t page_size)
 
 static inline void *ofi_get_page_end(const void *addr, size_t page_size)
 {
-	return ofi_get_page_start((const char *) addr + page_size -1, page_size);
+	return (void *)((uintptr_t)ofi_get_page_start((const char *)addr
+			+ page_size, page_size) - 1);
 }
 
 static inline size_t


### PR DESCRIPTION
If addr is already page algined,
ofi_get_page_start(const void *addr, size_t page_size) and
ofi_get_page_end(const void *addr, size_t page_size) return the
same address.

If mem-hooks monitor is used, ofi_write_patch() will have both base
and bound pointing to the same address, and length will be 0.
Therefore, we can not set the memory protection correctly, which
causes the following memcpy failed with segfault.

Fix the issue by returning the ending address of the page.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>