### PR TITLE
prov/verbs: Reformat GID type output

### DIFF
--- a/prov/verbs/configure.m4
+++ b/prov/verbs/configure.m4
@@ -57,6 +57,20 @@ AC_DEFUN([FI_VERBS_CONFIGURE],[
 	AC_DEFINE_UNQUOTED([VERBS_HAVE_QUERY_EX],[$VERBS_HAVE_QUERY_EX],
 		[Whether infiniband/verbs.h has ibv_query_device_ex() support or not])
 
+	#See if we can query by GID type
+	VERBS_HAVE_IBV_QUERY_GID_TYPE=0
+	AS_IF([test $verbs_ibverbs_happy -eq 1], [
+		AC_CHECK_LIB([ibverbs], [ibv_query_gid_type],[],[],[])
+		AC_CHECK_FUNCS([ibv_query_gid_type],[],[],
+			[[#include <infiniband/drivers.h>]])
+		AC_CHECK_DECL([ibv_query_gid_type],
+			[VERBS_HAVE_IBV_QUERY_GID_TYPE=1],[],
+			[[#include <infiniband/drivers.h>]])
+		])
+	AC_DEFINE_UNQUOTED([VERBS_HAVE_IBV_QUERY_GID_TYPE],
+		[$VERBS_HAVE_IBV_QUERY_GID_TYPE],
+		[Whether verbs have ibv_query_gid_type() support or not])
+
 	#See if we have XRC support
 	VERBS_HAVE_XRC=0
 	AS_IF([test $verbs_ibverbs_happy -eq 1 && \

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -484,6 +484,18 @@ int vrb_srq_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 int vrb_domain_xrc_init(struct vrb_domain *domain);
 int vrb_domain_xrc_cleanup(struct vrb_domain *domain);
 
+#if !VERBS_HAVE_IBV_QUERY_GID_TYPE
+enum ibv_gid_type {
+	IBV_GID_TYPE_IB,
+	IBV_GID_TYPE_ROCE_V1,
+	IBV_GID_TYPE_ROCE_V2,
+};
+
+	extern int *ibv_query_gid_type(struct ibv_context *context,
+					uint8_t port_num, unsigned int index,
+					enum ibv_gid_type *gid_type);
+#endif
+
 enum vrb_ini_qp_state {
 	VRB_INI_QP_UNCONNECTED,
 	VRB_INI_QP_CONNECTING,


### PR DESCRIPTION
The Verbs provider defines a fabric name based on the GID subnet prefix returned from ibv_query_gid(), which is currently hardcoded to 0 and therefore only returns the subnet prefix for GID[0] . This results in fi_info only returning only "IB-0xfe80000000000000" as the fabric attribute output, regardless of which device it queries. This implies that all devices queried reside on the same fabric, and may result in applications using the wrong endpoints during communication.

With multiple interfaces going to multiple fabrics, the subnet prefixes should be set differently than default. Modifications to the verbs_info.c file replace the hardcoded 0 with vrb_gl_data.gid_idx and introduce a switch case to add a RoCEv1 or v2 prefix where appropriate. The fi_info fabric attribute output for RoCE devices is now more easily differentiated:

    fabric: RoCEv1-fe80000000000000 (RoCEv1 w/IPv6)
    fabric: RoCEv2-fe80000000000000 (RoCEv2 w/IPv6)
    fabric: RoCEv1-0 (RoCEv1 w/IPv4)
    fabric: RoCEv2-0 (RoCEv2 w/IPv4)

Signed-off-by: Leena Radeke <leena.radeke@hpe.com>