### PR TITLE
fabtests: add option -X (window type) to bandwidth test

### DIFF
--- a/fabtests/benchmarks/benchmark_shared.h
+++ b/fabtests/benchmarks/benchmark_shared.h
@@ -40,7 +40,7 @@ extern "C" {
 
 #include <rdma/fi_rma.h>
 
-#define BENCHMARK_OPTS "vkj:W:"
+#define BENCHMARK_OPTS "vkj:W:X:"
 #define FT_BENCHMARK_MAX_MSG_SIZE (test_size[TEST_CNT - 1].size)
 
 void ft_parse_benchmark_opts(int op, char *optarg);

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -140,6 +140,15 @@ enum op_state {
 	OP_PENDING
 };
 
+enum ft_window_type {
+	WAIT_ALL_WINDOW,/* New opertaion can be submitted only after
+			 * all operations in a window have finished
+			 */
+	WAIT_ANY_WINDOW,/* New operation can be submitted when there
+			 * is an operation finished.
+			 */
+};
+
 struct ft_context {
 	char *buf;
 	void *desc;
@@ -153,6 +162,7 @@ struct ft_opts {
 	int warmup_iterations;
 	size_t transfer_size;
 	int window_size;
+	enum ft_window_type window_type;
 	int av_size;
 	int verbose;
 	int tx_cq_size;
@@ -261,6 +271,7 @@ extern char default_port[8];
 		.warmup_iterations = 10, \
 		.transfer_size = 1024, \
 		.window_size = 64, \
+		.window_type = WAIT_ALL_WINDOW, \
 		.av_size = 1, \
 		.tx_cq_size = 0, \
 		.rx_cq_size = 0, \
@@ -474,7 +485,9 @@ int check_compare_atomic_op(struct fid_ep *endpoint, enum fi_op op,
 
 int ft_cq_readerr(struct fid_cq *cq);
 int ft_get_rx_comp(uint64_t total);
+int ft_get_rx_comp_any(struct fi_cq_err_entry *comp);
 int ft_get_tx_comp(uint64_t total);
+int ft_get_tx_comp_any(struct fi_cq_err_entry *comp);
 int ft_recvmsg(struct fid_ep *ep, fi_addr_t fi_addr,
 		size_t size, void *ctx, int flags);
 int ft_sendmsg(struct fid_ep *ep, fi_addr_t fi_addr,


### PR DESCRIPTION
Currently, when measuring bandwidth, fabtests uses a wait all
window: e.g. a new TX/RX operation can be submitted only after
all the operations in the current window have completed. This
is also how some MPI level benchmark measure bandwidth.

Meanwhile, there are other benchmarks/applications use a wait
any window: a new TX/RX operation can be submitted when any
outstanding TX/RX operation completed. The maximum number
of outstanding operations remain the same at any given time.
For exmaple, this is how perftest and NCCL works.

By nature, using wait any window would result in higher
bandwidth than using wait all window.

To address this issue, this patch added a new option -X
to bandwidth test. This option can be used to select
window type: wait_all/wait_any.

The core change is the addtion of the following utility
functions:

    ft_get_tx_comp_any()
    ft_get_rx_comp_any()
    bw_tx_comp_any()
    bw_rx_comp_any()

which will wait for 1 TX/RX completion.

Signed-off-by: Wei Zhang <wzam@amazon.com>