### PR TITLE
prov/verbs: GID_IDX support

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -791,7 +791,7 @@ static int vrb_alloc_info(struct ibv_context *ctx, struct fi_info **info,
 
 	switch (ctx->device->transport_type) {
 	case IBV_TRANSPORT_IB:
-		if (ibv_query_gid(ctx, 1, 0, &gid)) {
+		if (ibv_query_gid(ctx, 1, vrb_gl_data.gid_idx, &gid)) {
 			VERBS_INFO_ERRNO(FI_LOG_FABRIC,
 					 "ibv_query_gid", errno);
 			ret = -errno;


### PR DESCRIPTION
Patch to modify Verbs provider ibv_query_gid() call to use FI_VERBS_GID_IDX to obtain the device's GID index, rather than being hardcoded to GID index 0.

Signed-off-by: Leena Radeke <leena.radeke@hpe.com>