### PR TITLE
prov/psm2: Add domain level parameter setting ops

### DIFF
--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -262,6 +262,29 @@ The *psm2* provider checks for the following environment variables:
   to 1 (means *tag60*) or 2 (means *tag64*), the choice is fixed at compile time
   and this runtime option will be disabled.
 
+# PSM2 EXTENSIONS
+
+The *psm2* provider supports limited low level parameter setting through domain
+level *fi_open_ops* interface. The extension is named *FI_PSM2_DOMAIN_OPS_1*.
+To get access to the extension, *fi_open_ops* is called on the domain fid to
+retrieve a pointer that points to *struct fi_psm2_ops_domain*. 
+
+```c
+struct fi_psm2_ops_domain {
+	int (*set_val)(struct fid *fid, int var, void *val);
+	int (*get_val)(struct fid *fid, int var, void *val);
+};
+```
+
+The value of the parameters can be set or retrieved via the *set_val* and *get_val*
+method, respectively. Currently the following parameters are supported:
+
+* FI_PSM2_DISCONNECT *
+: Overwite the global runtime parameter *FI_PSM2_DISCONNECT* for this domain. See
+  the *RUNTIME PARAMETERS* section for details.
+
+These definitions are in the header file *rdma/fi_ext_psm2.h*.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/psm2/Makefile.include
+++ b/prov/psm2/Makefile.include
@@ -22,6 +22,9 @@ _psm2_files = \
 	prov/psm2/src/psmx2_wait.c \
 	prov/psm2/src/psmx2_util.c
 
+_psm2_cppflags = \
+	-I$(top_srcdir)/prov/psm2/include
+
 if HAVE_PSM2_SRC
 _psm2_files += \
 	prov/psm2/src/psm2_revision.c
@@ -97,7 +100,7 @@ _psm2_nodist_files += \
 	prov/psm2/src/psm2/opa/opa_dwordcpy-x86_64-fast.S
 endif
 
-_psm2_cppflags = \
+_psm2_cppflags += \
 	-I$(top_srcdir)/prov/psm2/src/psm2 \
 	-I$(top_srcdir)/prov/psm2/src/psm2/include \
 	-I$(top_srcdir)/prov/psm2/src/psm2/include/linux-i386 \
@@ -132,6 +135,7 @@ src_libfabric_la_LIBADD += libpsmx2.la
 src_libfabric_la_DEPENDENCIES += libpsmx2.la
 endif !HAVE_PSM2_DL
 
+rdmainclude_HEADERS += prov/psm2/include/fi_ext_psm2.h
 prov_install_man_pages += man/man7/fi_psm2.7
 
 endif HAVE_PSM2

--- a/prov/psm2/include/fi_ext_psm2.h
+++ b/prov/psm2/include/fi_ext_psm2.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FI_EXT_PSM2_H
+#define FI_EXT_PSM2_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define FI_PSM2_DOMAIN_OPS_1 "fi psm2 domain ops 1"
+
+enum {
+	FI_PSM2_DISCONNECT
+};
+
+struct fi_psm2_ops_domain {
+	int (*set_val)(struct fid *fid, int var, void *val);
+	int (*get_val)(struct fid *fid, int var, void *val);
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FI_EXT_PSM2_H */

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -72,6 +72,7 @@ extern "C" {
 #include "ofi_mem.h"
 #include "rbtree.h"
 #include "version.h"
+#include "fi_ext_psm2.h"
 
 #ifdef FABRIC_DIRECT_ENABLED
 #define DIRECT_FN __attribute__((visibility ("default")))
@@ -589,6 +590,11 @@ struct psmx2_fid_domain {
 	psmx2_unlock_fn_t	context_unlock_fn;
 	psmx2_trylock_fn_t	poll_trylock_fn;
 	psmx2_unlock_fn_t	poll_unlock_fn;
+
+	/* parameters that can be set via domain_ops */
+	struct {
+		int		disconnect;
+	} params;
 };
 
 #define PSMX2_EP_REGULAR	0

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -143,7 +143,7 @@ void psmx2_trx_ctxt_disconnect_peers(struct psmx2_trx_ctxt *trx_ctxt)
 
 	dlist_foreach_safe(&peer_list, item, tmp) {
 		peer = container_of(item, struct psmx2_epaddr_context, entry);
-		if (psmx2_env.disconnect) {
+		if (trx_ctxt->domain->params.disconnect) {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE, "epaddr: %p\n", peer->epaddr);
 			err = psm2_am_request_short(peer->epaddr,
 						    PSMX2_AM_TRX_CTXT_HANDLER,


### PR DESCRIPTION
Support fi_open_ops() for domain object and thus allow per-domain parameter
setting. Currently a single parameter 'FI_PSM2_DISCONNECT' is defined, but
this can be easily expanded in the future.

Update the man page accordingly.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>