### PR TITLE
Add fi_get_val() and fi_set_val()

### DIFF
--- a/include/rdma/fabric.h
+++ b/include/rdma/fabric.h
@@ -598,6 +598,11 @@ struct fi_alias {
 	uint64_t		flags;
 };
 
+struct fi_fid_var {
+	int		name;
+	void		*val;
+};
+
 struct fi_mr_raw_attr {
 	uint64_t	flags;
 	uint64_t	*base_addr;
@@ -632,6 +637,8 @@ enum {
 	FI_REFRESH,		/* mr: fi_mr_modify */
 	FI_DUP,			/* struct fid ** */
 	FI_GETWAITOBJ,		/*enum fi_wait_obj * */
+	FI_GET_VAL,		/* struct fi_fid_var */
+	FI_SET_VAL,		/* struct fi_fid_var */
 };
 
 static inline int fi_control(struct fid *fid, int command, void *arg)
@@ -645,6 +652,28 @@ static inline int fi_alias(struct fid *fid, struct fid **alias_fid, uint64_t fla
 	alias.fid = alias_fid;
 	alias.flags = flags;
 	return fi_control(fid, FI_ALIAS, &alias);
+}
+
+/* fid value names */
+/*
+ * Currently no common name is defined. Provider specific names should
+ * have the FI_PROV_SPECIFIC bit set.
+ */
+
+static inline int fi_get_val(struct fid *fid, int name, void *val)
+{
+	struct fi_fid_var var;
+	var.name = name;
+	var.val = val;
+	return fi_control(fid, FI_GET_VAL, &var);
+}
+
+static inline int fi_set_val(struct fid *fid, int name, void *val)
+{
+	struct fi_fid_var var;
+	var.name = name;
+	var.val = val;
+	return fi_control(fid, FI_SET_VAL, &var);
 }
 
 static inline int

--- a/man/fi_control.3.md
+++ b/man/fi_control.3.md
@@ -15,6 +15,9 @@ fi_control \- Perform an operation on a fabric resource.
 #include <rdma/fabric.h>
 
 int fi_control(struct fid *fid, int command, void *arg);
+int fi_alias(struct fid *fid, struct fid **alias_fid, uint64_t flags);
+int fi_get_val(struct fid *fid, int name, void *val);
+int fi_set_val(struct fid *fid, int name, void *val);
 ```
 
 
@@ -37,6 +40,15 @@ routine.  The exact behavior of using fi_control depends on the fabric
 resource being operated on, the specified command, and any provided
 arguments for the command.  For specific details, see the fabric resource
 specific help pages noted below.
+
+fi_alias, fi_get_val, and fi_set_val are wrappers for fi_control with
+commands FI_ALIAS, FI_GET_VAL, FI_SET_VAL, respectively. fi_alias creates
+an alias of the specified fabric resource. fi_get_val reads the value of
+the named parameter associated with the fabric resource, while fi_set_val
+updates that value. Available parameter names depend on the type of the
+fabric resource and the provider in use. Providers may define provider
+specific names in the provider extension header files ('rdma/fi_ext_*.h').
+Please refer to the provider man pages for details. 
 
 # SEE ALSO
 

--- a/man/fi_psm2.7.md
+++ b/man/fi_psm2.7.md
@@ -262,6 +262,18 @@ The *psm2* provider checks for the following environment variables:
   to 1 (means *tag60*) or 2 (means *tag64*), the choice is fixed at compile time
   and this runtime option will be disabled.
 
+# PSM2 EXTENSIONS
+
+The *psm2* provider supports limited low level parameter setting through the
+fi_set_val() and fi_get_val() functions. Currently the following parameters
+can be set via the domain fid:
+
+* FI_PSM2_DISCONNECT *
+: Overwite the global runtime parameter *FI_PSM2_DISCONNECT* for this domain.
+  See the *RUNTIME PARAMETERS* section for details.
+
+Valid parameter names are defined in the header file *rdma/fi_ext_psm2.h*.
+
 # SEE ALSO
 
 [`fabric`(7)](fabric.7.html),

--- a/prov/psm2/Makefile.include
+++ b/prov/psm2/Makefile.include
@@ -22,6 +22,9 @@ _psm2_files = \
 	prov/psm2/src/psmx2_wait.c \
 	prov/psm2/src/psmx2_util.c
 
+_psm2_cppflags = \
+	-I$(top_srcdir)/prov/psm2/include
+
 if HAVE_PSM2_SRC
 _psm2_files += \
 	prov/psm2/src/psm2_revision.c
@@ -97,7 +100,7 @@ _psm2_nodist_files += \
 	prov/psm2/src/psm2/opa/opa_dwordcpy-x86_64-fast.S
 endif
 
-_psm2_cppflags = \
+_psm2_cppflags += \
 	-I$(top_srcdir)/prov/psm2/src/psm2 \
 	-I$(top_srcdir)/prov/psm2/src/psm2/include \
 	-I$(top_srcdir)/prov/psm2/src/psm2/include/linux-i386 \
@@ -132,6 +135,7 @@ src_libfabric_la_LIBADD += libpsmx2.la
 src_libfabric_la_DEPENDENCIES += libpsmx2.la
 endif !HAVE_PSM2_DL
 
+rdmainclude_HEADERS += prov/psm2/include/fi_ext_psm2.h
 prov_install_man_pages += man/man7/fi_psm2.7
 
 endif HAVE_PSM2

--- a/prov/psm2/include/fi_ext_psm2.h
+++ b/prov/psm2/include/fi_ext_psm2.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 Intel Corporation. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef FI_EXT_PSM2_H
+#define FI_EXT_PSM2_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Provider specific name for fi_set_val() / fi_get_val() */
+#define	FI_PSM2_DISCONNECT	(1U | FI_PROV_SPECIFIC)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FI_EXT_PSM2_H */

--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -72,6 +72,7 @@ extern "C" {
 #include "ofi_mem.h"
 #include "rbtree.h"
 #include "version.h"
+#include "fi_ext_psm2.h"
 
 #ifdef FABRIC_DIRECT_ENABLED
 #define DIRECT_FN __attribute__((visibility ("default")))
@@ -589,6 +590,11 @@ struct psmx2_fid_domain {
 	psmx2_unlock_fn_t	context_unlock_fn;
 	psmx2_trylock_fn_t	poll_trylock_fn;
 	psmx2_unlock_fn_t	poll_unlock_fn;
+
+	/* parameters that can be set via domain_ops */
+	struct {
+		int		disconnect;
+	} params;
 };
 
 #define PSMX2_EP_REGULAR	0

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -203,10 +203,51 @@ static int psmx2_domain_close(fid_t fid)
 	return 0;
 }
 
+static int psmx2_domain_get_val(struct fid *fid, int var, void *val)
+{
+	struct psmx2_fid_domain *domain;
+ 
+	if (!val)
+		return -FI_EINVAL;
+
+	domain = container_of(fid, struct psmx2_fid_domain,
+			      util_domain.domain_fid.fid);
+ 
+	switch (var) {
+	case FI_PSM2_DISCONNECT:
+		*(uint32_t *)val = domain->params.disconnect;
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+	return 0;
+}
+
+static int psmx2_domain_set_val(struct fid *fid, int var, void *val)
+{
+	struct psmx2_fid_domain *domain;
+ 
+	if (!val)
+		return -FI_EINVAL;
+
+	domain = container_of(fid, struct psmx2_fid_domain,
+			      util_domain.domain_fid.fid);
+ 
+	switch (var) {
+	case FI_PSM2_DISCONNECT:
+		domain->params.disconnect = *(uint32_t *)val;
+		break;
+	default:
+		return -FI_EINVAL;
+	}
+	return 0;
+}
+
 DIRECT_FN
 STATIC int psmx2_domain_control(fid_t fid, int command, void *arg)
 {
 	struct fi_mr_map_raw *map;
+	struct fi_fid_var *var;
 
 	switch (command) {
 	case FI_MAP_RAW_MR:
@@ -219,6 +260,14 @@ STATIC int psmx2_domain_control(fid_t fid, int command, void *arg)
 	case FI_UNMAP_KEY:
 		/* Nothing to do here */
 		break;
+
+	case FI_GET_VAL:
+		var = arg;
+		return psmx2_domain_get_val(fid, var->name, var->val);
+
+	case FI_SET_VAL:
+		var = arg;
+		return psmx2_domain_set_val(fid, var->name, var->val);
 
 	default:
 		return -FI_ENOSYS;
@@ -336,6 +385,7 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	domain_priv->progress_thread_enabled =
 		(info->domain_attr->data_progress == FI_PROGRESS_AUTO);
 	domain_priv->addr_format = info->addr_format;
+	domain_priv->params.disconnect = psmx2_env.disconnect;
 
 	if (info->addr_format == FI_ADDR_STR)
 		src_addr = psmx2_string_to_ep_name(info->src_addr);

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -143,7 +143,7 @@ void psmx2_trx_ctxt_disconnect_peers(struct psmx2_trx_ctxt *trx_ctxt)
 
 	dlist_foreach_safe(&peer_list, item, tmp) {
 		peer = container_of(item, struct psmx2_epaddr_context, entry);
-		if (psmx2_env.disconnect) {
+		if (trx_ctxt->domain->params.disconnect) {
 			FI_INFO(&psmx2_prov, FI_LOG_CORE, "epaddr: %p\n", peer->epaddr);
 			err = psm2_am_request_short(peer->epaddr,
 						    PSMX2_AM_TRX_CTXT_HANDLER,


### PR DESCRIPTION
Define new fi_control() commands for accessing fid specific values.
Use the new interface to add domain level parameter setting for psm2 provider.