### PR TITLE
macOS: Handle socket API size limitations

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,7 @@ common_srcs =				\
 
 
 if MACOS
+common_srcs += src/osx/osd.c
 common_srcs += src/unix/osd.c
 common_srcs += include/osx/osd.h
 common_srcs += include/unix/osd.h

--- a/include/freebsd/osd.h
+++ b/include/freebsd/osd.h
@@ -95,6 +95,62 @@ static inline size_t ofi_process_vm_writev(pid_t pid,
 	return -FI_ENOSYS;
 }
 
+static inline ssize_t ofi_read_socket(SOCKET fd, void *buf, size_t count)
+{
+	return read(fd, buf, count);
+}
+
+static inline ssize_t ofi_write_socket(SOCKET fd, const void *buf, size_t count)
+{
+	return write(fd, buf, count);
+}
+
+static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
+				      int flags)
+{
+	return recv(fd, buf, count, flags);
+}
+
+static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
+					  struct sockaddr *from, socklen_t *fromlen)
+{
+	return recvfrom(fd, buf, count, flags, from, fromlen);
+}
+
+static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
+				      int flags)
+{
+	return send(fd, buf, count, flags);
+}
+
+static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
+					const struct sockaddr *to, socklen_t tolen)
+{
+	return sendto(fd, buf, count, flags, to, tolen);
+}
+
+static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov, size_t iov_cnt)
+{
+	return writev(fd, iov, iov_cnt);
+}
+
+static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov, int iov_cnt)
+{
+	return readv(fd, iov, iov_cnt);
+}
+
+static inline ssize_t
+ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags)
+{
+	return sendmsg(fd, msg, flags);
+}
+
+static inline ssize_t
+ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
+{
+	return recvmsg(fd, msg, flags);
+}
+
 #endif /* _FREEBSD_OSD_H_ */
 
 

--- a/include/linux/osd.h
+++ b/include/linux/osd.h
@@ -125,4 +125,60 @@ static inline size_t ofi_process_vm_writev(pid_t pid,
 		       remote_iov, riovcnt, flags);
 }
 
+static inline ssize_t ofi_read_socket(SOCKET fd, void *buf, size_t count)
+{
+	return read(fd, buf, count);
+}
+
+static inline ssize_t ofi_write_socket(SOCKET fd, const void *buf, size_t count)
+{
+	return write(fd, buf, count);
+}
+
+static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
+				      int flags)
+{
+	return recv(fd, buf, count, flags);
+}
+
+static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
+					  struct sockaddr *from, socklen_t *fromlen)
+{
+	return recvfrom(fd, buf, count, flags, from, fromlen);
+}
+
+static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
+				      int flags)
+{
+	return send(fd, buf, count, flags);
+}
+
+static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
+					const struct sockaddr *to, socklen_t tolen)
+{
+	return sendto(fd, buf, count, flags, to, tolen);
+}
+
+static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov, size_t iov_cnt)
+{
+	return writev(fd, iov, iov_cnt);
+}
+
+static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov, int iov_cnt)
+{
+	return readv(fd, iov, iov_cnt);
+}
+
+static inline ssize_t
+ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags)
+{
+	return sendmsg(fd, msg, flags);
+}
+
+static inline ssize_t
+ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
+{
+	return recvmsg(fd, msg, flags);
+}
+
 #endif /* _LINUX_OSD_H_ */

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -47,6 +47,8 @@
 
 #include <ifaddrs.h>
 
+#include <limits.h>
+
 #include "unix/osd.h"
 #include "rdma/fi_errno.h"
 #include "config.h"
@@ -115,61 +117,50 @@ static inline size_t ofi_process_vm_writev(pid_t pid,
 	return -FI_ENOSYS;
 }
 
+static inline ssize_t
+ofi_recv_socket(SOCKET fd, void *buf, size_t count, int flags)
+{
+	size_t len = count > INT_MAX ? INT_MAX : count;
+	return recv(fd, buf, len, flags);
+}
+
+static inline ssize_t
+ofi_send_socket(SOCKET fd, const void *buf, size_t count, int flags)
+{
+	size_t len = count > INT_MAX ? INT_MAX : count;
+	return send(fd, buf, len, flags);
+}
+
 static inline ssize_t ofi_read_socket(SOCKET fd, void *buf, size_t count)
 {
-	return read(fd, buf, count);
+	return ofi_recv_socket(fd, buf, count, 0);
 }
 
 static inline ssize_t ofi_write_socket(SOCKET fd, const void *buf, size_t count)
 {
-	return write(fd, buf, count);
-}
-
-static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
-				      int flags)
-{
-	return recv(fd, buf, count, flags);
-}
-
-static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
-					  struct sockaddr *from, socklen_t *fromlen)
-{
-	return recvfrom(fd, buf, count, flags, from, fromlen);
-}
-
-static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
-				      int flags)
-{
-	return send(fd, buf, count, flags);
-}
-
-static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
-					const struct sockaddr *to, socklen_t tolen)
-{
-	return sendto(fd, buf, count, flags, to, tolen);
-}
-
-static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov, size_t iov_cnt)
-{
-    return writev(fd, iov, iov_cnt);
-}
-
-static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov, int iov_cnt)
-{
-    return readv(fd, iov, iov_cnt);
+	return ofi_send_socket(fd, buf, count, 0);
 }
 
 static inline ssize_t
-ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags)
+ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
+		    struct sockaddr *from, socklen_t *fromlen)
 {
-    return sendmsg(fd, msg, flags);
+	size_t len = count > INT_MAX ? INT_MAX : count;
+	return recvfrom(fd, buf, len, flags, from, fromlen);
 }
 
 static inline ssize_t
-ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
+ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
+		  const struct sockaddr *to, socklen_t tolen)
 {
-    return recvmsg(fd, msg, flags);
+	size_t len = count > INT_MAX ? INT_MAX : count;
+	return sendto(fd, buf, len, flags, to, tolen);
 }
+
+ssize_t ofi_writev_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
+ssize_t ofi_readv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt);
+ssize_t ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags);
+ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags);
 
 #ifdef __cplusplus
 }

--- a/include/osx/osd.h
+++ b/include/osx/osd.h
@@ -115,6 +115,62 @@ static inline size_t ofi_process_vm_writev(pid_t pid,
 	return -FI_ENOSYS;
 }
 
+static inline ssize_t ofi_read_socket(SOCKET fd, void *buf, size_t count)
+{
+	return read(fd, buf, count);
+}
+
+static inline ssize_t ofi_write_socket(SOCKET fd, const void *buf, size_t count)
+{
+	return write(fd, buf, count);
+}
+
+static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
+				      int flags)
+{
+	return recv(fd, buf, count, flags);
+}
+
+static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
+					  struct sockaddr *from, socklen_t *fromlen)
+{
+	return recvfrom(fd, buf, count, flags, from, fromlen);
+}
+
+static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
+				      int flags)
+{
+	return send(fd, buf, count, flags);
+}
+
+static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
+					const struct sockaddr *to, socklen_t tolen)
+{
+	return sendto(fd, buf, count, flags, to, tolen);
+}
+
+static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov, size_t iov_cnt)
+{
+    return writev(fd, iov, iov_cnt);
+}
+
+static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov, int iov_cnt)
+{
+    return readv(fd, iov, iov_cnt);
+}
+
+static inline ssize_t
+ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags)
+{
+    return sendmsg(fd, msg, flags);
+}
+
+static inline ssize_t
+ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
+{
+    return recvmsg(fd, msg, flags);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -119,66 +119,10 @@ static inline SOCKET ofi_socket(int domain, int type, int protocol)
 	return socket(domain, type, protocol);
 }
 
-static inline ssize_t ofi_read_socket(SOCKET fd, void *buf, size_t count)
-{
-	return read(fd, buf, count);
-}
-
-static inline ssize_t ofi_write_socket(SOCKET fd, const void *buf, size_t count)
-{
-	return write(fd, buf, count);
-}
-
-static inline ssize_t ofi_recv_socket(SOCKET fd, void *buf, size_t count,
-				      int flags)
-{
-	return recv(fd, buf, count, flags);
-}
-
-static inline ssize_t ofi_recvfrom_socket(SOCKET fd, void *buf, size_t count, int flags,
-					  struct sockaddr *from, socklen_t *fromlen)
-{
-	return recvfrom(fd, buf, count, flags, from, fromlen);
-}
-
-static inline ssize_t ofi_send_socket(SOCKET fd, const void *buf, size_t count,
-				      int flags)
-{
-	return send(fd, buf, count, flags);
-}
-
-static inline ssize_t ofi_sendto_socket(SOCKET fd, const void *buf, size_t count, int flags,
-					const struct sockaddr *to, socklen_t tolen)
-{
-	return sendto(fd, buf, count, flags, to, tolen);
-}
-
-static inline ssize_t ofi_writev_socket(SOCKET fd, struct iovec *iov, size_t iov_cnt)
-{
-	return writev(fd, iov, iov_cnt);
-}
-
-static inline ssize_t ofi_readv_socket(SOCKET fd, struct iovec *iov, int iov_cnt)
-{
-	return readv(fd, iov, iov_cnt);
-}
-
-static inline ssize_t
-ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags)
-{
-	return sendmsg(fd, msg, flags);
-}
-
 static inline ssize_t
 ofi_sendmsg_udp(SOCKET fd, const struct msghdr *msg, int flags)
 {
 	return sendmsg(fd, msg, flags);
-}
-
-static inline ssize_t
-ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
-{
-	return recvmsg(fd, msg, flags);
 }
 
 static inline ssize_t

--- a/src/osx/osd.c
+++ b/src/osx/osd.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 by Argonne National Laboratory.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "ofi.h"
+#include "ofi_osd.h"
+
+static ssize_t
+ofi_sendv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags)
+{
+	ssize_t size = 0;
+	int ret, i;
+
+	if (iov_cnt == 1) {
+		return ofi_send_socket(fd, iovec[0].iov_base,
+				       iovec[0].iov_len, flags);
+	}
+
+	for (i = 0; i < iov_cnt; i++) {
+		ret = ofi_send_socket(fd, iovec[i].iov_base,
+				      iovec[i].iov_len, flags);
+		if (ret >= 0) {
+			size += ret;
+			if (ret != iovec[i].iov_len)
+				return size;
+		} else {
+			return size ? size : ret;
+		}
+	}
+	return size;
+}
+
+static ssize_t
+ofi_recvv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt, int flags)
+{
+	ssize_t size = 0;
+	int ret, i;
+
+	if (iov_cnt == 1) {
+		return ofi_recv_socket(fd, iovec[0].iov_base,
+				       iovec[0].iov_len, flags);
+	}
+
+	for (i = 0; i < iov_cnt; i++) {
+		ret = ofi_recv_socket(fd, iovec[i].iov_base,
+				      iovec[i].iov_len, flags);
+		if (ret >= 0) {
+			size += ret;
+			if (ret != iovec[i].iov_len)
+				return size;
+		} else {
+			return size ? size : ret;
+		}
+	}
+	return size;
+}
+
+ssize_t ofi_writev_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt)
+{
+	return ofi_sendv_socket(fd, iovec, iov_cnt, 0);
+}
+
+ssize_t ofi_readv_socket(SOCKET fd, const struct iovec *iovec, size_t iov_cnt)
+{
+	return ofi_recvv_socket(fd, iovec, iov_cnt, 0);
+}
+
+ssize_t ofi_sendmsg_tcp(SOCKET fd, const struct msghdr *msg, int flags)
+{
+	return ofi_sendv_socket(fd, msg->msg_iov, msg->msg_iovlen, flags);
+}
+
+ssize_t ofi_recvmsg_tcp(SOCKET fd, struct msghdr *msg, int flags)
+{
+	return ofi_recvv_socket(fd, msg->msg_iov, msg->msg_iovlen, flags);
+}


### PR DESCRIPTION
In practice, macOS returns an error (Invalid argument) with socket
operations > 2GB. Lower the limit to avoid infinite retry loops.