### PR TITLE
[v1.11.x] core/pmem: Fix pmem instruction checks

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -172,13 +172,15 @@ static inline int ofi_val32_ge(uint32_t x, uint32_t y) {
 /*
  * CPU specific features
  */
+
+/* X86_64 */
 enum {
-	OFI_CLWB_REG		= 2,
+	OFI_CLWB_REG		= 1,
 	OFI_CLWB_BIT		= (1 << 24),
 	OFI_CLFLUSHOPT_REG	= 1,
-	OFI_CLFLUSHOPT_BIT	= (1 << 24),
+	OFI_CLFLUSHOPT_BIT	= (1 << 23),
 	OFI_CLFLUSH_REG		= 3,
-	OFI_CLFLUSH_BIT		= (1 << 23),
+	OFI_CLFLUSH_BIT		= (1 << 19),
 };
 
 int ofi_cpu_supports(unsigned func, unsigned reg, unsigned bit);


### PR DESCRIPTION
Update the checks for CLWB, CLFLUSH, and CLFLUSHOPT to
match the latest code from the pmem/pmdk/libpmem2 source.
The CLWB register was incorrect, and the CLFLUSH/CLFLUSHOPT
bits have changed since the original code was provided.

Fixes #6391

Signed-off-by: Sean Hefty <sean.hefty@intel.com>