### PR TITLE
rxm/tcp: Eliminate bounce buffers for medium message transfers

### DIFF
--- a/fabtests/benchmarks/dgram_pingpong.c
+++ b/fabtests/benchmarks/dgram_pingpong.c
@@ -118,6 +118,7 @@ int main(int argc, char **argv)
 	hints->mode |= FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 
 	ret = run();
 

--- a/fabtests/benchmarks/msg_bw.c
+++ b/fabtests/benchmarks/msg_bw.c
@@ -108,6 +108,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->addr_format = opts.address_format;
+	hints->tx_attr->tclass = FI_TC_BULK_DATA;
 
 	ret = run();
 

--- a/fabtests/benchmarks/msg_pingpong.c
+++ b/fabtests/benchmarks/msg_pingpong.c
@@ -108,6 +108,7 @@ int main(int argc, char **argv)
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 	hints->addr_format = opts.address_format;
+	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rdm_cntr_pingpong.c
+++ b/fabtests/benchmarks/rdm_cntr_pingpong.c
@@ -100,6 +100,7 @@ int main(int argc, char **argv)
 	hints->caps = FI_MSG;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rdm_pingpong.c
+++ b/fabtests/benchmarks/rdm_pingpong.c
@@ -101,6 +101,7 @@ int main(int argc, char **argv)
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rdm_tagged_bw.c
+++ b/fabtests/benchmarks/rdm_tagged_bw.c
@@ -104,6 +104,7 @@ int main(int argc, char **argv)
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	hints->tx_attr->tclass = FI_TC_BULK_DATA;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rdm_tagged_pingpong.c
+++ b/fabtests/benchmarks/rdm_tagged_pingpong.c
@@ -102,6 +102,7 @@ int main(int argc, char **argv)
 	hints->mode = FI_CONTEXT;
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 
 	ret = run();
 

--- a/fabtests/benchmarks/rma_bw.c
+++ b/fabtests/benchmarks/rma_bw.c
@@ -127,6 +127,7 @@ int main(int argc, char **argv)
 		opts.dst_addr = argv[optind];
 
 	hints->domain_attr->mr_mode = opts.mr_mode;
+	hints->tx_attr->tclass = FI_TC_BULK_DATA;
 
 	ret = run();
 

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1036,6 +1036,15 @@ struct ofi_ops_flow_ctrl {
 };
 
 
+/* Dynamic receive buffering support. */
+#define OFI_OPS_DYNAMIC_RBUF "ofix_dynamic_rbuf"
+
+struct ofi_ops_dynamic_rbuf {
+	size_t	size;
+	ssize_t	(*get_rbuf)(struct fi_cq_data_entry *entry, struct iovec *iov,
+			    size_t *count);
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -131,6 +131,13 @@ The ofi_rxm provider checks for the following environment variables.
 : Defines the maximum number of MSG provider CQ entries (default: 1) that would
   be read per progress (RxM CQ read).
 
+*FI_OFI_RXM_ENABLE_DYN_RBUF*
+: Enables support for dynamic receive buffering, if available by the message
+  endpoint provider.  This feature allows direct placement of received
+  message data into application buffers, bypassing RxM bounce buffers.
+  This feature targets providers that provide internal network buffering,
+  such as the tcp provider.  (default: true)
+
 *FI_OFI_RXM_SAR_LIMIT*
 : Set this environment variable to control the RxM SAR (Segmentation And Reassembly)
   protocol. Messages of size greater than this (default: 128 Kb) would be transmitted

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -834,10 +834,7 @@ static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
 {
 	size_t overhead = sizeof(struct rxm_atomic_hdr) +
 			  sizeof(struct rxm_pkt);
-
-	/* Must be set to eager size or less */
-	return (info->tx_attr && info->tx_attr->inject_size > overhead) ?
-		info->tx_attr->inject_size - overhead : 0;
+	return rxm_eager_limit > overhead ? rxm_eager_limit - overhead : 0;
 }
 
 static inline ssize_t

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -279,8 +279,10 @@ struct rxm_domain {
 	struct util_domain util_domain;
 	struct fid_domain *msg_domain;
 	size_t max_atomic_size;
+	size_t rx_buf_post_size;
 	uint64_t mr_key;
 	bool mr_local;
+	bool dyn_rbuf;
 	struct ofi_ops_flow_ctrl *flow_ctrl_ops;
 	struct ofi_bufpool *amo_bufpool;
 	fastlock_t amo_bufpool_lock;
@@ -472,7 +474,8 @@ struct rxm_rx_buf {
 	/* MSG EP / shared context to which bufs would be posted to */
 	struct fid_ep *msg_ep;
 	struct dlist_entry repost_entry;
-	struct rxm_conn *conn;
+	struct rxm_conn *conn;		/* msg ep data was received on */
+	/* if recv_entry is set, then we matched dyn rbuf */
 	struct rxm_recv_entry *recv_entry;
 	struct rxm_unexp_msg unexp_msg;
 	uint64_t comp_flags;
@@ -667,13 +670,14 @@ enum rxm_recv_queue_type {
 };
 
 struct rxm_recv_queue {
-	struct rxm_ep *rxm_ep;
+	struct rxm_ep		*rxm_ep;
 	enum rxm_recv_queue_type type;
-	struct rxm_recv_fs *fs;
-	struct dlist_entry recv_list;
-	struct dlist_entry unexp_msg_list;
-	dlist_func_t *match_recv;
-	dlist_func_t *match_unexp;
+	struct rxm_recv_fs	*fs;
+	struct dlist_entry	recv_list;
+	struct dlist_entry	unexp_msg_list;
+	size_t			dyn_rbuf_unexp_cnt;
+	dlist_func_t		*match_recv;
+	dlist_func_t		*match_unexp;
 };
 
 struct rxm_buf_pool {
@@ -696,6 +700,9 @@ struct rxm_msg_eq_entry {
 			     sizeof(union rxm_cm_data))
 #define RXM_CM_ENTRY_SZ (sizeof(struct fi_eq_cm_entry) + \
 			 sizeof(union rxm_cm_data))
+
+ssize_t rxm_get_dyn_rbuf(struct fi_cq_data_entry *entry, struct iovec *iov,
+			 size_t *count);
 
 struct rxm_eager_ops {
 	int (*comp_tx)(struct rxm_ep *rxm_ep,

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -1071,7 +1071,7 @@ rxm_msg_process_connreq(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 			.endianness = ofi_detect_endianness(),
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
-			.eager_size = rxm_ep->rxm_info->tx_attr->inject_size,
+			.eager_size = rxm_eager_limit,
 		},
 	};
 	union rxm_cm_data reject_cm_data = {
@@ -1493,13 +1493,12 @@ rxm_conn_connect(struct rxm_ep *ep, struct rxm_cmap_handle *handle,
 			.ctrl_version = RXM_CTRL_VERSION,
 			.op_version = RXM_OP_VERSION,
 			.endianness = ofi_detect_endianness(),
-			.eager_size = ep->rxm_info->tx_attr->inject_size,
+			.eager_size = rxm_eager_limit,
 		},
 	};
 
 	assert(sizeof(uint32_t) == sizeof(cm_data.connect.eager_size));
 	assert(sizeof(uint32_t) == sizeof(cm_data.connect.rx_size));
-	assert(ep->rxm_info->tx_attr->inject_size <= (uint32_t) -1);
 	assert(ep->msg_info->rx_attr->size <= (uint32_t) -1);
 
 	free(ep->msg_info->dest_addr);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1731,16 +1731,16 @@ void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 
 	/* Application receive related error */
 	case RXM_RX:
-		/* Silently drop any MSG CQ error entries for canceled receive
+		/* Silently drop any MSG CQ error entries for any failed receive
 		 * operations as these are internal to RxM. This situation can
 		 * happen when the MSG EP receives a reject / shutdown and CM
-		 * thread hasn't handled the event yet. */
-		if (err_entry.err == FI_ECANCELED) {
-			/* No need to re-post these buffers. Free directly */
-			ofi_buf_free((struct rxm_rx_buf *)err_entry.op_context);
-			return;
-		}
-		/* fall through */
+		 * thread hasn't handled the event yet.
+		 *
+		 * There are no application posted receives associated with the
+		 * message endpoint receive at this point.
+		 */
+		ofi_buf_free((struct rxm_rx_buf *)err_entry.op_context);
+		return;
 	case RXM_RNDV_READ_DONE_SENT:
 	case RXM_RNDV_WRITE_DATA_SENT:
 		/* fall through */

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -735,9 +735,20 @@ ssize_t rxm_handle_rx_buf(struct rxm_rx_buf *rx_buf)
 static ssize_t
 rxm_match_rx_buf(struct rxm_rx_buf *rx_buf,
 		 struct rxm_recv_queue *recv_queue,
-		    struct rxm_recv_match_attr *match_attr)
+		 struct rxm_recv_match_attr *match_attr)
 {
 	struct dlist_entry *entry;
+
+	/* Dynamic receive buffers may have already matched */
+	if (rx_buf->recv_entry) {
+		if (rx_buf->pkt.ctrl_hdr.type == rxm_ctrl_rndv_req)
+			return rxm_handle_rndv(rx_buf);
+		else
+			return rxm_finish_recv(rx_buf, rx_buf->pkt.hdr.size);
+	}
+
+	if (recv_queue->dyn_rbuf_unexp_cnt)
+		recv_queue->dyn_rbuf_unexp_cnt--;
 
 	entry = dlist_remove_first_match(&recv_queue->recv_list,
 					 recv_queue->match_recv, match_attr);
@@ -755,8 +766,9 @@ rxm_match_rx_buf(struct rxm_rx_buf *rx_buf,
 	dlist_insert_tail(&rx_buf->unexp_msg.entry,
 			  &recv_queue->unexp_msg_list);
 
-	// repost a new buffer now since we don't know when the unexpected
-	// buffer will be consumed
+	/* post a new buffer since we don't know when the unexpected buffer
+	 * will be consumed
+	 */
 	return rxm_repost_new_rx(rx_buf);
 }
 
@@ -952,7 +964,6 @@ err:
 	ofi_buf_free(rx_buf->recv_entry->rndv.tx_buf);
 	return ret;
 }
-
 
 static ssize_t rxm_rndv_send_wr_done_inject(struct rxm_tx_rndv_buf *tx_buf)
 {
@@ -1609,6 +1620,146 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 	}
 }
 
+static int rxm_get_recv_entry(struct rxm_rx_buf *rx_buf)
+{
+	struct rxm_recv_match_attr match_attr;
+	struct rxm_recv_queue *recv_queue;
+	struct dlist_entry *entry;
+
+	assert(!rx_buf->recv_entry);
+	if (rx_buf->ep->rxm_info->caps & (FI_SOURCE | FI_DIRECTED_RECV)) {
+		if (rx_buf->ep->srx_ctx)
+			rx_buf->conn = rxm_key2conn(rx_buf->ep, rx_buf->
+						    pkt.ctrl_hdr.conn_id);
+		if (!rx_buf->conn)
+			return -FI_EOTHER;
+		match_attr.addr = rx_buf->conn->handle.fi_addr;
+	} else {
+		match_attr.addr = FI_ADDR_UNSPEC;
+	}
+
+	if (rx_buf->pkt.hdr.op == ofi_op_msg) {
+		match_attr.tag = 0;
+		recv_queue = &rx_buf->ep->recv_queue;
+	} else {
+		assert(rx_buf->pkt.hdr.op == ofi_op_tagged);
+		match_attr.tag = rx_buf->pkt.hdr.tag;
+		recv_queue = &rx_buf->ep->trecv_queue;
+	}
+
+	/* See comment with rxm_get_dyn_rbuf */
+	if (recv_queue->dyn_rbuf_unexp_cnt == 0) {
+		entry = dlist_remove_first_match(&recv_queue->recv_list,
+						 recv_queue->match_recv,
+						 &match_attr);
+		if (entry) {
+			rx_buf->recv_entry = container_of(entry,
+						struct rxm_recv_entry, entry);
+		} else {
+			recv_queue->dyn_rbuf_unexp_cnt++;
+		}
+	} else {
+		recv_queue->dyn_rbuf_unexp_cnt++;
+	}
+
+	return 0;
+}
+
+/*
+ * Dynamic receive buffer callback from fi_cq_read(msg cq).
+ * We're holding the ep lock.
+ *
+ * There's a subtle race condition handling unexpected messages. If we cannot
+ * find a matching receive, the message will be marked as unexpected.
+ * However, we can't queue it on the unexpected list until is has been fully
+ * received and returned through fi_cq_read().  It's possible for the
+ * application to post the matching buffer prior to that occurring.  That is,
+ * the matching buffer is posted after we checked for a match, but before the
+ * message endpoint is finishes receiving the unexpected data.
+ *
+ * Once the unexpected message has been received, it's completion may be
+ * written to the CQ.  If the message provider continues processing messages
+ * it could invoke a callback for a second message.  If we allow the second
+ * message to match the posted receive buffer, then the second message would
+ * match out of order from the first message.
+ *
+ * To handle this, we need to track the number of unexpected messages queued
+ * within the message provider, so that they can check for matching
+ * receives in order.  If there are any unexpected messages outstanding, we
+ * need to fail all matches until they have been read from the CQ.
+ */
+ssize_t rxm_get_dyn_rbuf(struct fi_cq_data_entry *entry, struct iovec *iov,
+			 size_t *count)
+{
+	struct rxm_rx_buf *rx_buf;
+	int ret;
+
+	rx_buf = entry->op_context;
+	assert((rx_buf->pkt.hdr.version == OFI_OP_VERSION) &&
+		(rx_buf->pkt.ctrl_hdr.version == RXM_CTRL_VERSION));
+	assert(!(rx_buf->ep->rxm_info->mode & FI_BUFFERED_RECV));
+
+	switch (rx_buf->pkt.ctrl_hdr.type) {
+	case rxm_ctrl_eager:
+		ret = rxm_get_recv_entry(rx_buf);
+		if (ret)
+			return ret;
+
+		if (rx_buf->recv_entry) {
+			*count = rx_buf->recv_entry->rxm_iov.count;
+			memcpy(iov, rx_buf->recv_entry->rxm_iov.iov, *count *
+			       sizeof(*iov));
+		} else {
+			*count = 1;
+			iov[0].iov_base = &rx_buf->pkt + 1;
+			iov[0].iov_len = rxm_eager_limit;
+		}
+		break;
+	case rxm_ctrl_rndv_req:
+		/* find matching receive to maintain message ordering, but we
+		 * only need to receive rendezvous header to complete message
+		 */
+		ret = rxm_get_recv_entry(rx_buf);
+		if (ret)
+			return ret;
+
+		*count = 1;
+		iov[0].iov_base = &rx_buf->pkt + 1;
+		iov[0].iov_len = sizeof(struct rxm_rndv_hdr);
+		break;
+	case rxm_ctrl_atomic:
+		*count = 1;
+		iov[0].iov_base = &rx_buf->pkt + 1;
+		iov[0].iov_len = sizeof(struct rxm_atomic_hdr);
+		break;
+	case rxm_ctrl_atomic_resp:
+		*count = 1;
+		iov[0].iov_base = &rx_buf->pkt + 1;
+		iov[0].iov_len = sizeof(struct rxm_atomic_resp_hdr);
+		break;
+	case rxm_ctrl_rndv_wr_data:
+		*count = 1;
+		iov[0].iov_base = &rx_buf->pkt + 1;
+		iov[0].iov_len = sizeof(struct rxm_rndv_hdr);
+		break;
+	case rxm_ctrl_rndv_wr_done:
+	case rxm_ctrl_rndv_rd_done:
+	case rxm_ctrl_credit:
+		*count = 0;
+		iov[0].iov_base = NULL;
+		iov[0].iov_len = 0;
+		break;
+	case rxm_ctrl_seg:
+	default:
+		FI_WARN(&rxm_prov, FI_LOG_CQ,
+			"Unexpected request for dynamic rbuf\n");
+		*count = 0;
+		break;
+	}
+
+	return 0;
+}
+
 void rxm_cq_write_error(struct util_cq *cq, struct util_cntr *cntr,
 			void *op_context, int err)
 {
@@ -1729,21 +1880,22 @@ void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 		err_entry.flags = ofi_tx_cq_flags(rndv_buf->pkt.hdr.op);
 		break;
 
-	/* Application receive related error */
+	/* Incoming application data error */
 	case RXM_RX:
-		/* Silently drop any MSG CQ error entries for any failed receive
-		 * operations as these are internal to RxM. This situation can
-		 * happen when the MSG EP receives a reject / shutdown and CM
-		 * thread hasn't handled the event yet.
-		 *
-		 * There are no application posted receives associated with the
-		 * message endpoint receive at this point.
+		/* Silently drop MSG CQ error entries for internal receive
+		 * operations not associated with an application posted
+		 * receive. This situation can happen when the MSG EP
+		 * receives a reject / shutdown and CM thread hasn't handled
+		 * the event yet.
 		 */
-		ofi_buf_free((struct rxm_rx_buf *)err_entry.op_context);
-		return;
+		rx_buf = (struct rxm_rx_buf *) err_entry.op_context;
+		if (!rx_buf->recv_entry) {
+			ofi_buf_free((struct rxm_rx_buf *)err_entry.op_context);
+			return;
+		}
+		/* fall through */
 	case RXM_RNDV_READ_DONE_SENT:
 	case RXM_RNDV_WRITE_DATA_SENT:
-		/* fall through */
 	case RXM_RNDV_READ:
 		rx_buf = (struct rxm_rx_buf *) err_entry.op_context;
 		assert(rx_buf->recv_entry);
@@ -1772,15 +1924,19 @@ void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 
 static int rxm_msg_ep_recv(struct rxm_rx_buf *rx_buf)
 {
+	struct rxm_domain *domain;
 	int ret, level;
 
 	if (rx_buf->ep->srx_ctx)
 		rx_buf->conn = NULL;
 	rx_buf->hdr.state = RXM_RX;
+	rx_buf->recv_entry = NULL;
 
+	domain = container_of(rx_buf->ep->util_ep.domain,
+			      struct rxm_domain, util_domain);
 	ret = (int) fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
-			    rxm_eager_limit + sizeof(struct rxm_pkt),
-			    rx_buf->hdr.desc, FI_ADDR_UNSPEC, rx_buf);
+			    domain->rx_buf_post_size, rx_buf->hdr.desc,
+			    FI_ADDR_UNSPEC, rx_buf);
 	if (!ret)
 		return 0;
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2567,7 +2567,17 @@ err:
 
 static void rxm_ep_sar_init(struct rxm_ep *rxm_ep)
 {
+	struct rxm_domain *domain;
 	size_t param;
+
+	domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain,
+			      util_domain);
+	if (domain->dyn_rbuf) {
+		FI_INFO(&rxm_prov, FI_LOG_CORE, "Dynamic receive buffer "
+			"enabled, disabling SAR protocol\n");
+		rxm_ep->sar_limit = rxm_eager_limit;
+		return;
+	}
 
 	if (!fi_param_get_size_t(&rxm_prov, "sar_limit", &param)) {
 		if (param <= rxm_eager_limit) {

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -51,6 +51,7 @@
 size_t rxm_msg_tx_size		= 128;
 size_t rxm_msg_rx_size		= 128;
 size_t rxm_eager_limit		= RXM_BUF_SIZE - sizeof(struct rxm_pkt);
+size_t rxm_rx_buf_post_size	= RXM_BUF_SIZE;
 int force_auto_progress		= 0;
 enum fi_wait_obj def_wait_obj = FI_WAIT_FD, def_tcp_wait_obj = FI_WAIT_UNSPEC;
 
@@ -468,8 +469,8 @@ RXM_INI
 			"longer connection establishment times. (default: 10000).");
 
 	fi_param_define(&rxm_prov, "cq_eq_fairness", FI_PARAM_INT,
-			"Defines the maximum number of message provider CQ entries"
-			" that can be consecutively read across progress calls "
+			"Defines the maximum number of message provider CQ entries "
+			"that can be consecutively read across progress calls "
 			"without checking to see if the CM progress interval has "
 			"been reached. (default: 128).");
 
@@ -482,6 +483,14 @@ RXM_INI
 			"RxM Rendezvous protocol.  If set (1), RxM will use "
 			"RMA writes rather than RMA reads during Rendezvous "
 			"transactions. (default: 0).");
+
+	fi_param_define(&rxm_prov, "enable_dyn_rbuf", FI_PARAM_BOOL,
+			"Enable support for dynamic receive buffering, if "
+			"available by the message endpoint provider. "
+			"This allows direct placement of received messages "
+			"into application buffers, bypassing RxM bounce "
+			"buffers.  This feature targets using tcp sockets "
+			"for the message transport.  (default: true)");
 
 	rxm_init_infos();
 	fi_param_get_size_t(&rxm_prov, "msg_tx_size", &rxm_msg_tx_size);

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -155,14 +155,24 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 		    const struct fi_info *base_info, struct fi_info *info)
 {
 	info->caps = base_info->caps;
-	// TODO find which other modes should be filtered
 	info->mode = (core_info->mode & ~FI_RX_CQ_DATA) | base_info->mode;
 
 	info->tx_attr->caps		= base_info->tx_attr->caps;
 	info->tx_attr->mode		= info->mode;
 	info->tx_attr->msg_order 	= core_info->tx_attr->msg_order;
 	info->tx_attr->comp_order 	= base_info->tx_attr->comp_order;
-	info->tx_attr->inject_size	= base_info->tx_attr->inject_size;
+
+	/* If the core provider requires registering send buffers, it's
+	 * usually faster to copy small transfer through bounce buffers
+	 * than requiring the user to register the buffers.  Bump the
+	 * inject size up to the rxm limit (eager buffer size) in this
+	 * case.  If registration is not required, use the core provider's
+	 * limit, which avoids potential extra data copies.
+	 */
+	info->tx_attr->inject_size = ofi_mr_local(info) ?
+				     base_info->tx_attr->inject_size :
+				     core_info->tx_attr->inject_size;
+
 	info->tx_attr->size 		= base_info->tx_attr->size;
 	info->tx_attr->iov_limit 	= MIN(base_info->tx_attr->iov_limit,
 					      core_info->tx_attr->iov_limit);
@@ -234,12 +244,6 @@ static void rxm_alter_info(const struct fi_info *hints, struct fi_info *info)
 	struct fi_info *cur;
 
 	for (cur = info; cur; cur = cur->next) {
-		/* RxM can support higher inject size without any big
-		 * performance penalty even if app had requested lower value
-		 * in hints. App is still free to reduce this when opening an
-		 * endpoint. This overrides setting by ofi_alter_info */
-		cur->tx_attr->inject_size = rxm_eager_limit;
-
 		/* Remove the following caps if they are not requested as they
 		 * may affect performance in fast-path */
 		if (!hints) {

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -213,6 +213,8 @@ static void rxm_init_infos(void)
 		}
 
 		rxm_eager_limit = buf_size - sizeof(struct rxm_pkt);
+		if (rxm_eager_limit > UINT32_MAX)
+			rxm_eager_limit = UINT32_MAX;
 	}
 
 	fi_param_get_size_t(&rxm_prov, "tx_size", &tx_size);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -232,8 +232,18 @@ struct tcpx_xfer_entry {
 };
 
 struct tcpx_domain {
-	struct util_domain	util_domain;
+	struct util_domain		util_domain;
+	struct ofi_ops_dynamic_rbuf	*dynamic_rbuf;
 };
+
+static inline struct ofi_ops_dynamic_rbuf *tcpx_dynamic_rbuf(struct tcpx_ep *ep)
+{
+	struct tcpx_domain *domain;
+
+	domain = container_of(ep->util_ep.domain, struct tcpx_domain,
+			      util_domain);
+	return domain->dynamic_rbuf;
+}
 
 struct tcpx_buf_pool {
 	struct ofi_bufpool	*pool;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -79,6 +79,7 @@ extern struct fi_provider	tcpx_prov;
 extern struct util_prov		tcpx_util_prov;
 extern struct fi_info		tcpx_info;
 extern struct tcpx_port_range	port_range;
+extern int			tcpx_nodelay;
 struct tcpx_xfer_entry;
 struct tcpx_ep;
 

--- a/prov/tcp/src/tcpx_domain.c
+++ b/prov/tcp/src/tcpx_domain.c
@@ -118,6 +118,29 @@ static struct fi_ops_domain tcpx_domain_ops = {
 	.query_collective = fi_no_query_collective,
 };
 
+static int tcpx_set_ops(struct fid *fid, const char *name,
+			uint64_t flags, void *ops, void *context)
+{
+	struct tcpx_domain *domain;
+
+	domain = container_of(fid, struct tcpx_domain,
+			      util_domain.domain_fid.fid);
+	if (flags)
+		return -FI_EBADFLAGS;
+
+	if (!strcasecmp(name, OFI_OPS_DYNAMIC_RBUF)) {
+		domain->dynamic_rbuf = ops;
+		if (domain->dynamic_rbuf->size != sizeof(*domain->dynamic_rbuf)) {
+			domain->dynamic_rbuf = NULL;
+			return -FI_ENOSYS;
+		}
+
+		return 0;
+	}
+
+	return -FI_ENOSYS;
+}
+
 static int tcpx_domain_close(fid_t fid)
 {
 	struct tcpx_domain *tcpx_domain;
@@ -140,6 +163,8 @@ static struct fi_ops tcpx_domain_fi_ops = {
 	.bind = ofi_domain_bind,
 	.control = fi_no_control,
 	.ops_open = fi_no_ops_open,
+	.tostr = NULL,
+	.ops_set = tcpx_set_ops,
 };
 
 static struct fi_ops_mr tcpx_domain_fi_ops_mr = {

--- a/prov/tcp/src/tcpx_init.c
+++ b/prov/tcp/src/tcpx_init.c
@@ -52,8 +52,24 @@ struct tcpx_port_range port_range = {
 	.high = 0,
 };
 
+int tcpx_nodelay = -1;
+
+
 static void tcpx_init_env(void)
 {
+	fi_param_define(&tcpx_prov, "iface", FI_PARAM_STRING,
+			"Specify interface name");
+
+	fi_param_define(&tcpx_prov,"port_low_range", FI_PARAM_INT,
+			"define port low range");
+
+	fi_param_define(&tcpx_prov,"port_high_range", FI_PARAM_INT,
+			"define port high range");
+
+	fi_param_define(&tcpx_prov, "nodelay", FI_PARAM_BOOL,
+			"overrides default TCP_NODELAY socket setting");
+	fi_param_get_bool(&tcpx_prov, "nodelay", &tcpx_nodelay);
+
 	fi_param_get_int(&tcpx_prov, "port_high_range", &port_range.high);
 	fi_param_get_int(&tcpx_prov, "port_low_range", &port_range.low);
 
@@ -88,15 +104,6 @@ TCP_INI
 #if HAVE_TCP_DL
 	ofi_pmem_init();
 #endif
-	fi_param_define(&tcpx_prov, "iface", FI_PARAM_STRING,
-			"Specify interface name");
-
-	fi_param_define(&tcpx_prov,"port_low_range", FI_PARAM_INT,
-			"define port low range");
-
-	fi_param_define(&tcpx_prov,"port_high_range", FI_PARAM_INT,
-			"define port high range");
-
 	tcpx_init_env();
 	return &tcpx_prov;
 }


### PR DESCRIPTION
This series introduces a concept I named dynamic receive buffers.  The purpose is to eliminate the need for the tcp provider to copy data through rxm bounce buffers on the receive side.

Rxm must still allocate and post receive buffers.  However, the buffers are only posted to receive the size of the rxm packet (64 bytes).  Once tcp receives that header, it invokes a callback into rxm to retrieve the rest of the receive buffer.  This allows rxm to process the packet headers, identify the application buffer that the receive targets, and return that to tcp.  The tcp provider then continues reading from the socket, placing the data directly into the application's buffer, rather than staging it through an rxm bounce buffer.

Bounce buffers are still required to handle unexpected messages.  When dynamic receive buffers are enabled, the SAR protocol is disabled.  The patches currently enable this feature by default, but that's for CI purposes.  A follow on patch will disable it by default until a full set of performance data can be analyzed to determine if or when it should be enabled, and what adjustments may be needed to other settings, such as the default eager message size.

This feature avoids receive side data copies for transfers up to the eager message size.  Beyond that size, the rendezvous protocol is used.  Because SAR is disabled, the eager message size should be increased when this is enabled to better align with the behavior of the current implementation.

There are 2 additional optimizations that are possible beyond these changes.  Because we need to handle unexpected messages, all rx buffers are the size of the eager buffer size.  However, we only post the first 64-bytes of each buffer as a receive.  If unexpected buffers are rare, we can reduce the memory footprint by dynamically allocating unexpected message buffers as needed.  Second is to avoid copying through the bounce buffers on the send side.