### PR TITLE
prov/gni: clean up compiler warnings

### DIFF
--- a/prov/gni/include/gnix_cm.h
+++ b/prov/gni/include/gnix_cm.h
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2016 Cray Inc. All rights reserved.
  * Copyright (c) 2017 Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2019-2020 Triad National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -117,7 +118,7 @@ _gnix_resolve_gni_ep_name(const char *ep_name, int idx,
 	int ret = FI_SUCCESS;
 	static size_t addr_size = sizeof(struct gnix_ep_name);
 
-	GNIX_TRACE(FI_LOG_TRACE, "\n");
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	/*TODO (optimization): Just return offset into ep_name */
 	memcpy(addr, &ep_name[addr_size * idx], addr_size);
@@ -138,7 +139,7 @@ _gnix_resolve_str_ep_name(const char *ep_name, int idx,
 	int ret = FI_SUCCESS;
 	static size_t addr_size = GNIX_FI_ADDR_STR_LEN;
 
-	GNIX_TRACE(FI_LOG_TRACE, "\n");
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	ret = _gnix_ep_name_from_str(&ep_name[addr_size * idx], addr);
 	return ret;

--- a/prov/gni/include/gnix_freelist.h
+++ b/prov/gni/include/gnix_freelist.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2016 Cray Inc.  All rights reserved.
  * Copyright (c) 2015 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2020 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -128,7 +129,7 @@ static inline int _gnix_fl_alloc(struct dlist_entry **e, struct gnix_freelist *f
         if (fl->refill_size == 0) {
                 ret = -FI_ECANCELED;
 
-                GNIX_DEBUG(FI_LOG_DEBUG, "Freelist not growable (refill "
+                GNIX_DEBUG(FI_LOG_EP_CTRL, "Freelist not growable (refill "
                                    "size is 0\n");
 
                 goto err;

--- a/prov/gni/src/gnix_av.c
+++ b/prov/gni/src/gnix_av.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2015-2017 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2019      Triad National Security, LLC.
+ * Copyright (c) 2019-2020 Triad National Security, LLC.
  *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
@@ -361,7 +361,7 @@ static int map_insert(struct gnix_fid_av *av_priv, const void *addr,
 					ret_cnt = -FI_EINVAL;
 					continue;
 				}
-				GNIX_DEBUG(FI_LOG_DEBUG, "ep_name doesn't fit "
+				GNIX_DEBUG(FI_LOG_AV, "ep_name doesn't fit "
 					"into the av context bits\n");
 				return -FI_EINVAL; /* TODO: should try to do
 						      cleanup */
@@ -745,7 +745,7 @@ DIRECT_FN const char *gnix_av_straddr(struct fid_av *av,
 	struct gnix_fid_av *av_priv;
 
 	if (!av || !addr || !buf || !len) {
-		GNIX_DEBUG(FI_LOG_DEBUG, "NULL parameter in gnix_av_straddr\n");
+		GNIX_DEBUG(FI_LOG_AV, "NULL parameter in gnix_av_straddr\n");
 		return NULL;
 	}
 

--- a/prov/gni/src/gnix_cm.c
+++ b/prov/gni/src/gnix_cm.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2015-2017 Cray Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Los Alamos National Security, LLC. All rights reserved.
+ * Copyright (c) 2020 Triad National Security, LLC. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -55,7 +56,7 @@ int _gnix_ep_name_to_str(struct gnix_ep_name *ep_name, char **out_buf)
 	char *str;
 	size_t len = GNIX_FI_ADDR_STR_LEN;
 
-	GNIX_TRACE(FI_LOG_TRACE, "\n");
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	if (*out_buf == NULL) {
 		str = calloc(len, sizeof(char));
@@ -90,10 +91,10 @@ int _gnix_ep_name_from_str(const char *addr,
 	long tok_val;
 	char *dup_addr;
 
-	GNIX_TRACE(FI_LOG_TRACE, "\n");
+	GNIX_TRACE(FI_LOG_EP_CTRL, "\n");
 
 	if (!addr || !resolved_addr) {
-		GNIX_WARN(FI_LOG_WARN, "NULL parameter in "
+		GNIX_WARN(FI_LOG_EP_CTRL, "NULL parameter in "
 			"__gnix_resolved_name_from_str");
 		return -FI_EINVAL;
 	}
@@ -105,34 +106,34 @@ int _gnix_ep_name_from_str(const char *addr,
 
 	tok = strtok(dup_addr, ";");
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		return -FI_EINVAL;
 	}
 
 	ret = memcmp(tok, "gni", 3);
 	if (ret) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
 
 	tok = strtok(NULL, ";");/*node*/
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
 
 	tok = strtok(NULL, ";");/*service*/
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
 
 	tok = strtok(NULL, ";");/*GNIX_AV_STR_ADDR_VERSION*/
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
@@ -140,13 +141,13 @@ int _gnix_ep_name_from_str(const char *addr,
 	/*device_addr*/
 	tok = strtok(NULL, ";");
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
 	tok_val = strtol(tok, &endptr, 16);
 	if (*endptr) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid device_addr.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid device_addr.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
@@ -155,13 +156,13 @@ int _gnix_ep_name_from_str(const char *addr,
 	/*cdm_id*/
 	tok = strtok(NULL, ";");
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
 	tok_val = strtol(tok, &endptr, 16);
 	if (*endptr) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid cdm_id.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid cdm_id.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
@@ -170,13 +171,13 @@ int _gnix_ep_name_from_str(const char *addr,
 	/*name_type*/
 	tok = strtok(NULL, ";");
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
 	tok_val = strtol(tok, &endptr, 10);
 	if (*endptr) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid name_type.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid name_type.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
@@ -185,13 +186,13 @@ int _gnix_ep_name_from_str(const char *addr,
 	/*cm_nic_cdm_id*/
 	tok = strtok(NULL, ";");
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
 	tok_val = strtol(tok, &endptr, 16);
 	if (*endptr) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid cm_nic_cdm_id.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid cm_nic_cdm_id.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
@@ -200,13 +201,13 @@ int _gnix_ep_name_from_str(const char *addr,
 	/*cookie*/
 	tok = strtok(NULL, ";");
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
 	tok_val = strtol(tok, &endptr, 16);
 	if (*endptr) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid cookie.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid cookie.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
@@ -215,13 +216,13 @@ int _gnix_ep_name_from_str(const char *addr,
 	/*rx_ctx_cnt*/
 	tok = strtok(NULL, ";");
 	if (!tok) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid address.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid address.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}
 	tok_val = strtol(tok, &endptr, 10);
 	if (*endptr) {
-		GNIX_WARN(FI_LOG_WARN, "Invalid rx_ctx_cnt.\n");
+		GNIX_WARN(FI_LOG_EP_CTRL, "Invalid rx_ctx_cnt.\n");
 		free(dup_addr);
 		return -FI_EINVAL;
 	}

--- a/prov/gni/src/gnix_ep.c
+++ b/prov/gni/src/gnix_ep.c
@@ -2,7 +2,8 @@
  * Copyright (c) 2015-2019 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2019-2020 Triad National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -2350,7 +2351,7 @@ DIRECT_FN int gnix_ep_open(struct fid_domain *domain, struct fi_info *info,
 	ep_priv->info = fi_dupinfo(info);
 	ep_priv->info->addr_format = info->addr_format;
 
-	GNIX_DEBUG(FI_LOG_DEBUG, "ep(%p) is using addr_format(%s)\n", ep_priv,
+	GNIX_DEBUG(FI_LOG_EP_CTRL, "ep(%p) is using addr_format(%s)\n", ep_priv,
 		  ep_priv->info->addr_format == FI_ADDR_STR ? "FI_ADDR_STR" :
 		  "FI_ADDR_GNI");
 

--- a/prov/gni/src/gnix_msg.c
+++ b/prov/gni/src/gnix_msg.c
@@ -2,7 +2,8 @@
  * Copyright (c) 2015-2019 Cray Inc. All rights reserved.
  * Copyright (c) 2015-2018 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
+ * Copyright (c) 2019-2020 Triad National Security, LLC.
+ *                         All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -407,7 +408,7 @@ static int __recv_completion_src(
 	char *buffer;
 	size_t buf_len;
 
-	GNIX_DBG_TRACE(FI_LOG_TRACE, "\n");
+	GNIX_DBG_TRACE(FI_LOG_EP_DATA, "\n");
 
 	if ((req->msg.recv_flags & FI_COMPLETION) && ep->recv_cq) {
 		if ((src_addr == FI_ADDR_NOTAVAIL) &&

--- a/prov/gni/test/api.c
+++ b/prov/gni/test/api.c
@@ -79,7 +79,6 @@ static fi_addr_t gni_addr[NUMEPS];
 static struct fid_cq *msg_cq[NUMEPS];
 static struct fi_info *fi[NUMEPS];
 static struct fi_cq_attr cq_attr;
-static const char *api_cdm_id[NUMEPS] = { "5000", "5001" };
 static struct fi_info *hints[NUMEPS];
 
 #define BUF_SZ (1<<20)

--- a/prov/gni/test/rdm_tagged_sr.c
+++ b/prov/gni/test/rdm_tagged_sr.c
@@ -84,7 +84,7 @@ static struct fi_cq_attr cq_attr;
 static char *target, *target_base;
 static char *source, *source_base;
 static struct iovec *src_iov, *dest_iov;
-static char *iov_src_buf, *iov_dest_buf, *iov_src_buf_base, *iov_dest_buf_base;
+static char *iov_src_buf, *iov_dest_buf;
 static struct fid_mr *rem_mr, *loc_mr;
 static uint64_t mr_key;
 

--- a/prov/gni/test/vc.c
+++ b/prov/gni/test/vc.c
@@ -76,7 +76,6 @@ static struct fid_ep *ep3;
 static struct fid_av *av3;
 static struct fid_cq *cq3;
 static void *ep_name3;
-static fi_addr_t gni_addr3;
 
 /* Register a target buffer with both domains for pings. */
 static void *target_buf, *target_buf_base;


### PR DESCRIPTION
when using newer >8 gcc and with --enable-debug configure option.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>