### PR TITLE
prov/rxm: Fix check for FI_COLLECTIVE enabled

### DIFF
--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -485,7 +485,7 @@ static void rxm_config_dyn_rbuf(struct rxm_domain *domain, struct fi_info *info)
 	 * messages, collective support is mostly for development purposes.
 	 * So, fallback to bounce buffers when enabled.
 	 */
-	if (info->caps | FI_COLLECTIVE)
+	if (info->caps & FI_COLLECTIVE)
 		return;
 
 	fi_param_get_bool(&rxm_prov, "enable_dyn_rbuf", &ret);


### PR DESCRIPTION
Dynamic receive buffers are disabled if FI_COLLECTIVE support
is enabled, however the check for collectives being enabled is
incorrect (always true).  Use '&' instead of '|' to check if the
flag is set.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>