### PR TITLE
prov/rxm: fixed rxm provider init when built as dynamic library

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -522,5 +522,9 @@ RXM_INI
 			"(FI_OFI_RXM_DATA_AUTO_PROGRESS = 1), domain threading "
 			"level would be set to FI_THREAD_SAFE\n");
 
+#ifdef HAVE_RXM_DL
+	ofi_mem_init();
+#endif
+
 	return &rxm_prov;
 }


### PR DESCRIPTION
Providers built as dynamic libraries need to call ofi_mem_init()
to create buf pools.

Signed-off-by: Andrey Lobanov <andrey.lobanov@intel.com>