### PR TITLE
spec: Abstract version with symbolic link

### DIFF
--- a/contrib/buildrpm/buildrpmLibfabric.sh
+++ b/contrib/buildrpm/buildrpmLibfabric.sh
@@ -105,7 +105,7 @@ error()
 # usage information
 ###################
 usage="Usage: $0 [-i provider_name] [-e provider_name]
-       [-n] [-o] [-m] [-d] [-s] [-c] [-r] [-v] [-h] tarball
+       [-n] [-o] [-l] [-m] [-d] [-s] [-c] [-r] [-v] [-h] tarball
 
  Provider options:
 
@@ -120,6 +120,9 @@ usage="Usage: $0 [-i provider_name] [-e provider_name]
 
   -o         install under /opt/libfabric/_VERSION_
                {default: install under /usr/ }
+
+  -l         create symbolic link 'default' to _VERSION_ (requires -o option) 
+              {default: link not create}
 
   -m         install modulefile
               {default: don't install modulefile}
@@ -160,7 +163,7 @@ usage="Usage: $0 [-i provider_name] [-e provider_name]
 # parse args
 ############
 export arguments="$@"
-while getopts DP:M:V:nomi:e:dc:r:svh flag; do
+while getopts DP:M:V:nolmi:e:dc:r:svh flag; do
     case "$flag" in
       n) noop="true"
          ;;
@@ -190,6 +193,8 @@ while getopts DP:M:V:nomi:e:dc:r:svh flag; do
       s) unpack_spec="true"
          ;;
       v) verbose="true"
+         ;;
+      l) version_symbolic_link="true"
          ;;
       h) echo "$usage"
          exit 0
@@ -260,6 +265,9 @@ verbose "Version: $version"
 if [[ -n "$install_in_opt" ]]; then
   if [[ -z "$prefix" ]] ; then
     prefix=$default_opt_prefix
+  fi
+  if [[ -n "$version_symbolic_link" ]]; then
+    rpmbuild_options="$rpmbuild_options --define '_version_symbolic_link $prefix/libfabric/default'"
   fi
   prefix="$prefix/libfabric/$version"
 

--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -81,6 +81,9 @@ EOF
 %makeinstall installdirs
 # remove unpackaged files from the buildroot
 rm -f %{buildroot}%{_libdir}/*.la
+%if 0%{?_version_symbolic_link:1}
+%{__ln_s} %{version} %{buildroot}/%{_version_symbolic_link}
+%endif
 
 %clean
 rm -rf %{buildroot}
@@ -94,6 +97,9 @@ rm -rf %{buildroot}
 %{_bindir}/fi_info
 %{_bindir}/fi_strerror
 %{_bindir}/fi_pingpong
+%if 0%{?_version_symbolic_link:1}
+%{_version_symbolic_link}
+%endif
 %dir %{_libdir}/libfabric/
 %doc AUTHORS COPYING README
 


### PR DESCRIPTION
Create a symbolic link to abstract the version named directory. This will
assist the automated test process.

Signed-off-by: Patrick Bueb <patrick.bueb@hpe.com>