### PR TITLE
at this point a bunch of fixes everywhere

### DIFF
--- a/fabtests/functional/multi_recv.c
+++ b/fabtests/functional/multi_recv.c
@@ -210,6 +210,11 @@ static int alloc_ep_res(struct fi_info *fi)
 		return ret;
 	}
 
+	/* We only ues the common code to send messages, so
+	 * set mr_desc to the tx buffer's region.
+	 */
+	mr_desc = fi_mr_desc(mr);
+
 	//Each multi recv buffer will be able to hold at least 2 and
 	//up to 64 messages, allowing proper testing of multi recv
 	//completions and reposting

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -479,8 +479,8 @@ int ofi_wait_yield_open(struct fid_fabric *fabric, struct fi_wait_attr *attr,
 
 typedef void (*fi_cq_read_func)(void **dst, void *src);
 
-struct util_cq_oflow_err_entry {
-	struct fi_cq_tagged_entry	*parent_comp;
+struct util_cq_aux_entry {
+	struct fi_cq_tagged_entry	*cq_slot;
 	struct fi_cq_err_entry		comp;
 	fi_addr_t			src;
 	struct slist_entry		list_entry;

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -504,7 +504,7 @@ struct util_cq {
 	struct util_comp_cirq	*cirq;
 	fi_addr_t		*src;
 
-	struct slist		oflow_err_list;
+	struct slist		aux_queue;
 	fi_cq_read_func		read_entry;
 	int			internal_wait;
 	ofi_atomic32_t		signaled;

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -472,7 +472,7 @@ struct rxm_rx_buf {
 
 	struct rxm_ep *ep;
 	/* MSG EP / shared context to which bufs would be posted to */
-	struct fid_ep *msg_ep;
+	struct fid_ep *rx_ep;
 	struct dlist_entry repost_entry;
 	struct rxm_conn *conn;		/* msg ep data was received on */
 	/* if recv_entry is set, then we matched dyn rbuf */
@@ -819,7 +819,7 @@ ssize_t rxm_handle_coll_eager(struct rxm_rx_buf *rx_buf);
 int rxm_finish_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *tx_eager_buf);
 int rxm_finish_coll_eager_send(struct rxm_ep *rxm_ep, struct rxm_tx_eager_buf *tx_eager_buf);
 
-int rxm_msg_ep_prepost_recv(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep);
+int rxm_prepost_recv(struct rxm_ep *rxm_ep, struct fid_ep *rx_ep);
 
 int rxm_ep_query_atomic(struct fid_domain *domain, enum fi_datatype datatype,
 			enum fi_op op, struct fi_atomic_attr *attr,

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -904,13 +904,13 @@ static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 			msg_ep, rxm_ep->msg_info->rx_attr->size / 2);
 	}
 
-	rxm_conn->msg_ep = msg_ep;
-
 	if (!rxm_ep->srx_ctx) {
 		ret = rxm_msg_ep_prepost_recv(rxm_ep, msg_ep);
 		if (ret)
 			goto err;
 	}
+
+	rxm_conn->msg_ep = msg_ep;
 	return 0;
 err:
 	fi_close(&msg_ep->fid);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -905,7 +905,7 @@ static int rxm_msg_ep_open(struct rxm_ep *rxm_ep, struct fi_info *msg_info,
 	}
 
 	if (!rxm_ep->srx_ctx) {
-		ret = rxm_msg_ep_prepost_recv(rxm_ep, msg_ep);
+		ret = rxm_prepost_recv(rxm_ep, msg_ep);
 		if (ret)
 			goto err;
 	}

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1465,9 +1465,11 @@ free:
 
 static ssize_t rxm_handle_credit(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_buf)
 {
-	struct rxm_domain *domain = container_of(rxm_ep->util_ep.domain,
-						 struct rxm_domain, util_domain);
+	struct rxm_domain *domain;
 
+	assert(rx_buf->rx_ep->fid.fclass == FI_CLASS_EP);
+	domain = container_of(rxm_ep->util_ep.domain, struct rxm_domain,
+			      util_domain);
 	domain->flow_ctrl_ops->add_credits(rx_buf->rx_ep,
 					   rx_buf->pkt.ctrl_hdr.ctrl_data);
 	rxm_rx_buf_free(rx_buf);

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -64,7 +64,7 @@ rxm_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
 }
 
 static struct rxm_rx_buf *
-rxm_rx_buf_alloc(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep, bool repost)
+rxm_rx_buf_alloc(struct rxm_ep *rxm_ep, struct fid_ep *rx_ep, bool repost)
 {
 	struct rxm_rx_buf *rx_buf;
 
@@ -74,12 +74,14 @@ rxm_rx_buf_alloc(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep, bool repost)
 
 	assert(rx_buf->ep == rxm_ep);
 	rx_buf->hdr.state = RXM_RX;
-	rx_buf->msg_ep = msg_ep;
+	rx_buf->rx_ep = rx_ep;
 	rx_buf->repost = repost;
 
-	if (!rxm_ep->srx_ctx)
-		rx_buf->conn = container_of(msg_ep->fid.context,
+	if (!rxm_ep->srx_ctx) {
+		rx_buf->conn = container_of(rx_ep->fid.context,
 					    struct rxm_conn, handle);
+	}
+
 	return rx_buf;
 }
 
@@ -88,7 +90,7 @@ static int rxm_repost_new_rx(struct rxm_rx_buf *rx_buf)
 	struct rxm_rx_buf *new_rx_buf;
 	if (rx_buf->repost) {
 		rx_buf->repost = false;
-		new_rx_buf = rxm_rx_buf_alloc(rx_buf->ep, rx_buf->msg_ep, true);
+		new_rx_buf = rxm_rx_buf_alloc(rx_buf->ep, rx_buf->rx_ep, true);
 		if (!new_rx_buf)
 			return -FI_ENOMEM;
 
@@ -1466,7 +1468,7 @@ static ssize_t rxm_handle_credit(struct rxm_ep *rxm_ep, struct rxm_rx_buf *rx_bu
 	struct rxm_domain *domain = container_of(rxm_ep->util_ep.domain,
 						 struct rxm_domain, util_domain);
 
-	domain->flow_ctrl_ops->add_credits(rx_buf->msg_ep,
+	domain->flow_ctrl_ops->add_credits(rx_buf->rx_ep,
 					   rx_buf->pkt.ctrl_hdr.ctrl_data);
 	rxm_rx_buf_free(rx_buf);
 	return FI_SUCCESS;
@@ -1922,7 +1924,7 @@ void rxm_handle_comp_error(struct rxm_ep *rxm_ep)
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Unable to ofi_cq_write_error\n");
 }
 
-static int rxm_msg_ep_recv(struct rxm_rx_buf *rx_buf)
+static int rxm_post_recv(struct rxm_rx_buf *rx_buf)
 {
 	struct rxm_domain *domain;
 	int ret, level;
@@ -1934,7 +1936,7 @@ static int rxm_msg_ep_recv(struct rxm_rx_buf *rx_buf)
 
 	domain = container_of(rx_buf->ep->util_ep.domain,
 			      struct rxm_domain, util_domain);
-	ret = (int) fi_recv(rx_buf->msg_ep, &rx_buf->pkt,
+	ret = (int) fi_recv(rx_buf->rx_ep, &rx_buf->pkt,
 			    domain->rx_buf_post_size, rx_buf->hdr.desc,
 			    FI_ADDR_UNSPEC, rx_buf);
 	if (!ret)
@@ -1949,18 +1951,18 @@ static int rxm_msg_ep_recv(struct rxm_rx_buf *rx_buf)
 	return ret;
 }
 
-int rxm_msg_ep_prepost_recv(struct rxm_ep *rxm_ep, struct fid_ep *msg_ep)
+int rxm_prepost_recv(struct rxm_ep *rxm_ep, struct fid_ep *rx_ep)
 {
 	struct rxm_rx_buf *rx_buf;
 	int ret;
 	size_t i;
 
 	for (i = 0; i < rxm_ep->msg_info->rx_attr->size; i++) {
-		rx_buf = rxm_rx_buf_alloc(rxm_ep, msg_ep, true);
+		rx_buf = rxm_rx_buf_alloc(rxm_ep, rx_ep, true);
 		if (!rx_buf)
 			return -FI_ENOMEM;
 
-		ret = rxm_msg_ep_recv(rx_buf);
+		ret = rxm_post_recv(rx_buf);
 		if (ret) {
 			ofi_buf_free(&rx_buf->hdr);
 			return ret;
@@ -1990,7 +1992,7 @@ void rxm_ep_do_progress(struct util_ep *util_ep)
 			continue;
 		}
 
-		ret = rxm_msg_ep_recv(buf);
+		ret = rxm_post_recv(buf);
 		if (ret) {
 			if (ret == -FI_EAGAIN)
 				ofi_buf_free(&buf->hdr);

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -2784,7 +2784,7 @@ static int rxm_ep_ctrl(struct fid *fid, int command, void *arg)
 			return ret;
 
 		if (rxm_ep->srx_ctx) {
-			ret = rxm_msg_ep_prepost_recv(rxm_ep, rxm_ep->srx_ctx);
+			ret = rxm_prepost_recv(rxm_ep, rxm_ep->srx_ctx);
 			if (ret) {
 				rxm_cmap_free(rxm_ep->cmap);
 				FI_WARN(&rxm_prov, FI_LOG_EP_CTRL,

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -94,12 +94,25 @@ void rxm_info_to_core_mr_modes(uint32_t version, const struct fi_info *hints,
 			core_info->domain_attr->mr_mode |= FI_MR_HMEM;
 	}
 }
+static bool rxm_use_srx(const struct fi_info *hints,
+			const struct fi_info *base_info)
+{
+	const struct fi_info *info;
+	int ret, use_srx = 0;
+
+	ret = fi_param_get_bool(&rxm_prov, "use_srx", &use_srx);
+	if (ret != -FI_ENODATA)
+		return use_srx;
+
+	info = base_info ? base_info : hints;
+
+	return info && info->fabric_attr && info->fabric_attr->prov_name &&
+	       !strncasecmp(info->fabric_attr->prov_name, "tcp", 3);
+}
 
 int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 		     const struct fi_info *base_info, struct fi_info *core_info)
 {
-	int ret, use_srx = 0;
-
 	rxm_info_to_core_mr_modes(version, hints, core_info);
 
 	core_info->mode |= FI_RX_CQ_DATA | FI_CONTEXT;
@@ -110,12 +123,15 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 			core_info->caps |= FI_MSG | FI_SEND | FI_RECV;
 
 		/* FI_RMA cap is needed for large message transfer protocol */
-		if (core_info->caps & FI_MSG)
-			core_info->caps |= FI_RMA | FI_READ | FI_REMOTE_READ | FI_REMOTE_WRITE;
+		if (core_info->caps & FI_MSG) {
+			core_info->caps |= FI_RMA | FI_READ |
+					   FI_REMOTE_READ | FI_REMOTE_WRITE;
+		}
 
 		if (hints->domain_attr) {
 			core_info->domain_attr->caps |= hints->domain_attr->caps;
-			core_info->domain_attr->threading = hints->domain_attr->threading;
+			core_info->domain_attr->threading =
+				hints->domain_attr->threading;
 		}
 		if (hints->tx_attr) {
 			core_info->tx_attr->op_flags =
@@ -133,10 +149,7 @@ int rxm_info_to_core(uint32_t version, const struct fi_info *hints,
 
 	core_info->ep_attr->type = FI_EP_MSG;
 
-	ret = fi_param_get_bool(&rxm_prov, "use_srx", &use_srx);
-	if (use_srx || ((ret == -FI_ENODATA) && base_info &&
-	    base_info->fabric_attr->prov_name &&
-	    !strcmp(base_info->fabric_attr->prov_name, "tcp"))) {
+	if (rxm_use_srx(hints, base_info)) {
 		FI_DBG(&rxm_prov, FI_LOG_FABRIC,
 		       "Requesting shared receive context from core provider\n");
 		core_info->ep_attr->rx_ctx_cnt = FI_SHARED_CONTEXT;

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -52,7 +52,7 @@ int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, uint64_t err)
 {
 	struct fi_cq_tagged_entry *comp;
-	struct util_cq_oflow_err_entry *entry;
+	struct util_cq_aux_entry *entry;
 
 	comp = ofi_cirque_tail(ep->util_ep.tx_cq->cirq);
 	if (err) {
@@ -112,7 +112,7 @@ int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
 		uint64_t tag, uint64_t data, uint64_t err)
 {
 	struct fi_cq_tagged_entry *comp;
-	struct util_cq_oflow_err_entry *entry;
+	struct util_cq_aux_entry *entry;
 
 	if (ofi_cirque_isfull(ep->util_ep.rx_cq->cirq))
 		return ofi_cq_write_overflow(ep->util_ep.rx_cq, context,

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -63,7 +63,7 @@ int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
 		entry->comp.err = err;
 		entry->comp.prov_errno = -err;
 		slist_insert_tail(&entry->list_entry,
-				  &ep->util_ep.tx_cq->oflow_err_list);
+				  &ep->util_ep.tx_cq->aux_queue);
 		comp->flags = UTIL_FLAG_ERROR;
 	} else {
 		comp->op_context = context;
@@ -129,7 +129,7 @@ int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
 		entry->comp.err = err;
 		entry->comp.prov_errno = -err;
 		slist_insert_tail(&entry->list_entry,
-				  &ep->util_ep.rx_cq->oflow_err_list);
+				  &ep->util_ep.rx_cq->aux_queue);
 		comp->flags = UTIL_FLAG_ERROR;
 	} else {
 		comp->op_context = context;

--- a/prov/shm/src/smr_comp.c
+++ b/prov/shm/src/smr_comp.c
@@ -48,36 +48,67 @@ int smr_complete_tx(struct smr_ep *ep, void *context, uint32_t op,
 	return ep->tx_comp(ep, context, op, flags, err);
 }
 
+static int
+smr_write_err_comp(struct util_cq *cq, void *context,
+		   uint64_t flags, uint64_t tag, uint64_t err)
+{
+	struct fi_cq_err_entry err_entry;
+
+	memset(&err_entry, 0, sizeof err_entry);
+	err_entry.op_context = context;
+	err_entry.flags = flags;
+	err_entry.tag = tag;
+	err_entry.err = err;
+	err_entry.prov_errno = -err;
+	return ofi_cq_insert_error(cq, &err_entry);
+}
+
+static int
+smr_write_comp(struct util_cq *cq, void *context,
+	       uint64_t flags, size_t len, void *buf,
+	       uint64_t tag, uint64_t data, uint64_t err)
+{
+	if (err)
+		return smr_write_err_comp(cq, context, flags, tag, err);
+
+	if (ofi_cirque_freecnt(cq->cirq) > 1) {
+		ofi_cq_write_entry(cq, context, flags, len,
+				   buf, data, tag);
+		return 0;
+	} else {
+		return ofi_cq_write_overflow(cq, context, flags,
+					     len, buf, data, tag,
+					     FI_ADDR_NOTAVAIL);
+	}
+}
+
+static int
+smr_write_src_comp(struct util_cq *cq, void *context,
+		   uint64_t flags, size_t len, void *buf, fi_addr_t addr,
+		   uint64_t tag, uint64_t data, uint64_t err)
+{
+	if (err)
+		return smr_write_err_comp(cq, context, flags, tag, err);
+
+	if (ofi_cirque_freecnt(cq->cirq) > 1) {
+		ofi_cq_write_src_entry(cq, context, flags, len,
+				       buf, data, tag, addr);
+		return 0;
+	} else {
+		return ofi_cq_write_overflow(cq, context, flags,
+					     len, buf, data, tag, addr);
+	}
+}
+
 int smr_tx_comp(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, uint64_t err)
 {
-	struct fi_cq_tagged_entry *comp;
-	struct util_cq_aux_entry *entry;
-
-	comp = ofi_cirque_tail(ep->util_ep.tx_cq->cirq);
-	if (err) {
-		if (!(entry = calloc(1, sizeof(*entry))))
-			return -FI_ENOMEM;
-		entry->comp.op_context = context;
-		entry->comp.flags = ofi_tx_cq_flags(op);
-		entry->comp.err = err;
-		entry->comp.prov_errno = -err;
-		slist_insert_tail(&entry->list_entry,
-				  &ep->util_ep.tx_cq->aux_queue);
-		comp->flags = UTIL_FLAG_ERROR;
-	} else {
-		comp->op_context = context;
-		comp->flags = ofi_tx_cq_flags(op);
-		comp->len = 0;
-		comp->buf = NULL;
-		comp->data = 0;
-	}
-	ofi_cirque_commit(ep->util_ep.tx_cq->cirq);
-	return 0;
+	return smr_write_comp(ep->util_ep.tx_cq, context,
+			      ofi_tx_cq_flags(op), 0, NULL, 0, 0, err);
 }
 
 int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
-		uint16_t flags, uint64_t err)
+		       uint16_t flags, uint64_t err)
 {
 	int ret;
 
@@ -88,9 +119,9 @@ int smr_tx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 	return 0;
 }
 
-int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op, uint16_t flags,
-		    size_t len, void *buf, int64_t id, uint64_t tag, uint64_t data,
-		    uint64_t err)
+int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op,
+		    uint16_t flags, size_t len, void *buf, int64_t id,
+		    uint64_t tag, uint64_t data, uint64_t err)
 {
 	fi_addr_t fiaddr = FI_ADDR_UNSPEC;
 
@@ -99,7 +130,6 @@ int smr_complete_rx(struct smr_ep *ep, void *context, uint32_t op, uint16_t flag
 	if (!err && !(flags & (SMR_REMOTE_CQ_DATA | SMR_RX_COMPLETION)))
 		return 0;
 
-	//TODO I was here
 	if (ep->util_ep.domain->info_domain_caps & FI_SOURCE)
 		fiaddr = ep->region->map->peers[id].fiaddr;
 
@@ -111,45 +141,18 @@ int smr_rx_comp(struct smr_ep *ep, void *context, uint32_t op,
 		uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		uint64_t tag, uint64_t data, uint64_t err)
 {
-	struct fi_cq_tagged_entry *comp;
-	struct util_cq_aux_entry *entry;
-
-	if (ofi_cirque_isfull(ep->util_ep.rx_cq->cirq))
-		return ofi_cq_write_overflow(ep->util_ep.rx_cq, context,
-					     smr_rx_cq_flags(op, flags),
-					     len, buf, data, tag, addr);
-
-	comp = ofi_cirque_tail(ep->util_ep.rx_cq->cirq);
-	if (err) {
-		if (!(entry = calloc(1, sizeof(*entry))))
-			return -FI_ENOMEM;
-		entry->comp.op_context = context;
-		entry->comp.flags = smr_rx_cq_flags(op, flags);
-		entry->comp.tag = tag;
-		entry->comp.err = err;
-		entry->comp.prov_errno = -err;
-		slist_insert_tail(&entry->list_entry,
-				  &ep->util_ep.rx_cq->aux_queue);
-		comp->flags = UTIL_FLAG_ERROR;
-	} else {
-		comp->op_context = context;
-		comp->flags = smr_rx_cq_flags(op, flags);
-		comp->len = len;
-		comp->buf = buf;
-		comp->data = data;
-		comp->tag = tag;
-	}
-	ofi_cirque_commit(ep->util_ep.rx_cq->cirq);
-	return 0;
+	return smr_write_comp(ep->util_ep.rx_cq, context,
+			      smr_rx_cq_flags(op, flags), len, buf,
+			      tag, data, err);
 }
 
 int smr_rx_src_comp(struct smr_ep *ep, void *context, uint32_t op,
 		    uint16_t flags, size_t len, void *buf, fi_addr_t addr,
 		    uint64_t tag, uint64_t data, uint64_t err)
 {
-	ep->util_ep.rx_cq->src[ofi_cirque_windex(ep->util_ep.rx_cq->cirq)] = addr;
-	return smr_rx_comp(ep, context, op, flags, len, buf, addr, tag,
-			   data, err);
+	return smr_write_src_comp(ep->util_ep.rx_cq, context,
+				  smr_rx_cq_flags(op, flags), len, buf, addr,
+				  tag, data, err);
 }
 
 int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
@@ -158,7 +161,8 @@ int smr_rx_comp_signal(struct smr_ep *ep, void *context, uint32_t op,
 {
 	int ret;
 
-	ret = smr_rx_comp(ep, context, op, flags, len, buf, addr, tag, data, err);
+	ret = smr_rx_comp(ep, context, op, flags, len, buf, addr, tag,
+			  data, err);
 	if (ret)
 		return ret;
 	ep->util_ep.rx_cq->wait->signal(ep->util_ep.rx_cq->wait);

--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -425,7 +425,9 @@ int ofi_av_close(struct util_av *av)
 
 size_t ofi_av_size(struct util_av *av)
 {
-	return av->av_entry_pool->entry_cnt;
+	return av->av_entry_pool->entry_cnt ?
+	       av->av_entry_pool->entry_cnt :
+	       av->av_entry_pool->attr.chunk_cnt;
 }
 
 static int util_verify_av_util_attr(struct util_domain *domain,

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -38,19 +38,33 @@
 
 #define UTIL_DEF_CQ_SIZE (1024)
 
-/* Caller must hold `cq_lock` */
-int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags, size_t len,
-			  void *buf, uint64_t data, uint64_t tag, fi_addr_t src)
+
+/* While the CQ is full, we continue to add new entries to the auxiliary
+ * queue.
+ */
+static void ofi_cq_insert_aux(struct util_cq *cq,
+			      struct util_cq_aux_entry *entry)
+{
+	entry->cq_slot = ofi_cirque_tail(cq->cirq);
+	entry->cq_slot->flags = UTIL_FLAG_AUX;
+	slist_insert_tail(&entry->list_entry, &cq->aux_queue);
+
+	if (!ofi_cirque_isfull(cq->cirq))
+		ofi_cirque_commit(cq->cirq);
+}
+
+/* Caller must hold 'cq lock' */
+int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags,
+			  size_t len, void *buf, uint64_t data, uint64_t tag,
+			  fi_addr_t src)
 {
 	struct util_cq_aux_entry *entry;
 
-	assert(ofi_cirque_isfull(cq->cirq));
+	FI_DBG(cq->domain->prov, FI_LOG_CQ, "writing to CQ overflow list\n");
+	assert(ofi_cirque_freecnt(cq->cirq) <= 1);
 
 	if (!(entry = calloc(1, sizeof(*entry))))
 		return -FI_ENOMEM;
-
-	entry->cq_slot = ofi_cirque_tail(cq->cirq);
-	entry->cq_slot->flags |= UTIL_FLAG_OVERFLOW;
 
 	entry->comp.op_context = context;
 	entry->comp.flags = flags;
@@ -58,38 +72,35 @@ int ofi_cq_write_overflow(struct util_cq *cq, void *context, uint64_t flags, siz
 	entry->comp.buf = buf;
 	entry->comp.data = data;
 	entry->comp.tag = tag;
-
+	entry->comp.err = 0;
 	entry->src = src;
-	slist_insert_tail(&entry->list_entry, &cq->aux_queue);
 
+	ofi_cq_insert_aux(cq, entry);
+	return 0;
+}
+
+/* Caller must hold 'cq lock' */
+int ofi_cq_insert_error(struct util_cq *cq,
+			const struct fi_cq_err_entry *err_entry)
+{
+	struct util_cq_aux_entry *entry;
+
+	assert(err_entry->err);
+	if (!(entry = calloc(1, sizeof(*entry))))
+		return -FI_ENOMEM;
+
+	entry->comp = *err_entry;
+	ofi_cq_insert_aux(cq, entry);
 	return 0;
 }
 
 int ofi_cq_write_error(struct util_cq *cq,
 		       const struct fi_cq_err_entry *err_entry)
 {
-	struct util_cq_aux_entry *entry;
-	struct fi_cq_tagged_entry *comp;
-
-	assert(err_entry->err);
-
-	if (!(entry = calloc(1, sizeof(*entry))))
-		return -FI_ENOMEM;
-
-	entry->comp = *err_entry;
 	cq->cq_fastlock_acquire(&cq->cq_lock);
-	slist_insert_tail(&entry->list_entry, &cq->aux_queue);
-
-	if (OFI_UNLIKELY(ofi_cirque_isfull(cq->cirq))) {
-		comp = ofi_cirque_tail(cq->cirq);
-		comp->flags |= (UTIL_FLAG_ERROR | UTIL_FLAG_OVERFLOW);
-		entry->cq_slot = ofi_cirque_tail(cq->cirq);
-	} else {
-		comp = ofi_cirque_tail(cq->cirq);
-		comp->flags = UTIL_FLAG_ERROR;
-		ofi_cirque_commit(cq->cirq);
-	}
+	ofi_cq_insert_error(cq, err_entry);
 	cq->cq_fastlock_release(&cq->cq_lock);
+
 	if (cq->wait)
 		cq->wait->signal(cq->wait);
 	return 0;
@@ -203,41 +214,12 @@ static void util_cq_read_tagged(void **dst, void *src)
 	*(char **)dst += sizeof(struct fi_cq_tagged_entry);
 }
 
-static inline
-void util_cq_read_aux_entry(struct util_cq *cq,
-			    struct util_cq_aux_entry *aux_entry,
-			    struct fi_cq_tagged_entry *cirq_entry,
-			    void **buf, fi_addr_t *src_addr, ssize_t i)
-{
-	if (src_addr && cq->src) {
-		src_addr[i] = cq->src[ofi_cirque_rindex(cq->cirq)];
-		cq->src[ofi_cirque_rindex(cq->cirq)] = aux_entry->src;
-	}
-	cq->read_entry(buf, cirq_entry);
-	cirq_entry->op_context = aux_entry->comp.op_context;
-	cirq_entry->flags = aux_entry->comp.flags;
-	cirq_entry->len = aux_entry->comp.len;
-	cirq_entry->buf = aux_entry->comp.buf;
-	cirq_entry->data = aux_entry->comp.data;
-	cirq_entry->tag = aux_entry->comp.tag;
-}
-
-static inline
-void util_cq_read_entry(struct util_cq *cq, struct fi_cq_tagged_entry *entry,
-			void **buf, fi_addr_t *src_addr, ssize_t i)
-{
-	if (src_addr && cq->src)
-		src_addr[i] = cq->src[ofi_cirque_rindex(cq->cirq)];
-	cq->read_entry(buf, entry);
-	ofi_cirque_discard(cq->cirq);
-}
-
 ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 			fi_addr_t *src_addr)
 {
-	struct util_cq *cq;
 	struct fi_cq_tagged_entry *entry;
 	struct util_cq_aux_entry *aux_entry;
+	struct util_cq *cq;
 	ssize_t i;
 
 	cq = container_of(cq_fid, struct util_cq, cq_fid);
@@ -256,53 +238,40 @@ ssize_t ofi_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 	if (count > ofi_cirque_usedcnt(cq->cirq))
 		count = ofi_cirque_usedcnt(cq->cirq);
 
-	for (i = 0; i < (ssize_t)count; i++) {
+	for (i = 0; i < (ssize_t) count; i++) {
 		entry = ofi_cirque_head(cq->cirq);
-		if (OFI_UNLIKELY(entry->flags & (UTIL_FLAG_ERROR |
-						 UTIL_FLAG_OVERFLOW))) {
-			if (entry->flags & UTIL_FLAG_ERROR) {
-				struct util_cq_aux_entry *aux_entry =
-						container_of(cq->aux_queue.head,
-							     struct util_cq_aux_entry,
-							     list_entry);
-				if (aux_entry->comp.err) {
-					/* This handles case when the head of aux_queue is
-					 * an error entry.
-					 *
-					 * NOTE: if this isn't an error entry, we have to handle
-					 * overflow entries and then the error entries to ensure
-					 * ordering. */
-					if (!i)
-						i = -FI_EAVAIL;
-					break;
-				}
+		if (!(entry->flags & UTIL_FLAG_AUX)) {
+			if (src_addr && cq->src)
+				src_addr[i] = cq->src[ofi_cirque_rindex(cq->cirq)];
+			cq->read_entry(&buf, entry);
+			ofi_cirque_discard(cq->cirq);
+		} else {
+			assert(!slist_empty(&cq->aux_queue));
+			aux_entry = container_of(cq->aux_queue.head,
+						 struct util_cq_aux_entry,
+						 list_entry);
+			assert(aux_entry->cq_slot == entry);
+			if (aux_entry->comp.err) {
+				if (!i)
+					i = -FI_EAVAIL;
+				break;
 			}
-			if (entry->flags & UTIL_FLAG_OVERFLOW) {
-				assert(!slist_empty(&cq->aux_queue));
-				aux_entry = container_of(cq->aux_queue.head,
-							 struct util_cq_aux_entry,
-							 list_entry);
-				if (aux_entry->cq_slot != entry) {
-					/* Handle case when all overflow/error CQ entries were read
-					 * for particular CIRQ entry */
-					entry->flags &= ~(UTIL_FLAG_OVERFLOW | UTIL_FLAG_ERROR);
-				} else {
-					uint64_t service_flags =
-						(entry->flags & (UTIL_FLAG_OVERFLOW | UTIL_FLAG_ERROR));
-					slist_remove_head(&cq->aux_queue);
 
-					entry->flags &= ~(service_flags);
-					util_cq_read_aux_entry(cq, aux_entry, entry,
-							       &buf, src_addr, i);
-					/* To ensure checking of overflow CQ entries once again */
-					if (!slist_empty(&cq->aux_queue))
-						entry->flags |= service_flags;
-					free(aux_entry);
-					continue;
-				}
+			if (src_addr && cq->src)
+				src_addr[i] = aux_entry->src;
+			cq->read_entry(&buf, &aux_entry->comp);
+			slist_remove_head(&cq->aux_queue);
+
+			if (slist_empty(&cq->aux_queue)) {
+				ofi_cirque_discard(cq->cirq);
+			} else {
+				aux_entry = container_of(cq->aux_queue.head,
+							struct util_cq_aux_entry,
+							list_entry);
+				if (aux_entry->cq_slot != ofi_cirque_head(cq->cirq))
+					ofi_cirque_discard(cq->cirq);
 			}
 		}
-		util_cq_read_entry(cq, entry, &buf, src_addr, i);
 	}
 out:
 	cq->cq_fastlock_release(&cq->cq_lock);
@@ -317,10 +286,8 @@ ssize_t ofi_cq_read(struct fid_cq *cq_fid, void *buf, size_t count)
 ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 		       uint64_t flags)
 {
+	struct util_cq_aux_entry *aux_entry;
 	struct util_cq *cq;
-	struct util_cq_aux_entry *err;
-	struct slist_entry *entry;
-	struct fi_cq_tagged_entry *cirq_entry;
 	char *err_buf_save;
 	size_t err_data_size;
 	uint32_t api_version;
@@ -331,47 +298,48 @@ ssize_t ofi_cq_readerr(struct fid_cq *cq_fid, struct fi_cq_err_entry *buf,
 
 	cq->cq_fastlock_acquire(&cq->cq_lock);
 	if (ofi_cirque_isempty(cq->cirq) ||
-	    !(ofi_cirque_head(cq->cirq)->flags & UTIL_FLAG_ERROR)) {
+	    !(ofi_cirque_head(cq->cirq)->flags & UTIL_FLAG_AUX)) {
 		ret = -FI_EAGAIN;
 		goto unlock;
 	}
 
-	entry = slist_remove_head(&cq->aux_queue);
-	err = container_of(entry, struct util_cq_aux_entry, list_entry);
-	if ((FI_VERSION_GE(api_version, FI_VERSION(1, 5))) && buf->err_data_size) {
-		err_data_size = MIN(buf->err_data_size, err->comp.err_data_size);
-		memcpy(buf->err_data, err->comp.err_data, err_data_size);
+	assert(!slist_empty(&cq->aux_queue));
+	aux_entry = container_of(cq->aux_queue.head,
+				 struct util_cq_aux_entry, list_entry);
+	assert(aux_entry->cq_slot == ofi_cirque_head(cq->cirq));
+
+	if (!aux_entry->comp.err) {
+		ret = -FI_EAGAIN;
+		goto unlock;
+	}
+
+	if ((FI_VERSION_GE(api_version, FI_VERSION(1, 5))) &&
+	    buf->err_data_size) {
 		err_buf_save = buf->err_data;
-		*buf = err->comp;
+		err_data_size = MIN(buf->err_data_size,
+				    aux_entry->comp.err_data_size);
+
+		*buf = aux_entry->comp;
+		memcpy(err_buf_save, aux_entry->comp.err_data, err_data_size);
 		buf->err_data = err_buf_save;
 		buf->err_data_size = err_data_size;
 	} else {
-		memcpy(buf, &err->comp, sizeof(struct fi_cq_err_entry_1_0));
+		memcpy(buf, &aux_entry->comp,
+		       sizeof(struct fi_cq_err_entry_1_0));
 	}
 
-	cirq_entry = ofi_cirque_head(cq->cirq);
-	if (!(cirq_entry->flags & UTIL_FLAG_OVERFLOW)) {
+	slist_remove_head(&cq->aux_queue);
+	free(aux_entry);
+	if (slist_empty(&cq->aux_queue)) {
 		ofi_cirque_discard(cq->cirq);
-	} else if (!slist_empty(&cq->aux_queue)) {
-		struct util_cq_aux_entry *oflow_entry =
-			container_of(cq->aux_queue.head,
-				     struct util_cq_aux_entry,
-				     list_entry);
-		if (oflow_entry->cq_slot != cirq_entry) {
-			/* The normal CQ entry were used to report error due to
-			 * out of space in the circular queue. We have to unset
-			 * UTIL_FLAG_ERROR and UTIL_FLAG_OVERFLOW flags */
-			cirq_entry->flags &= ~(UTIL_FLAG_ERROR | UTIL_FLAG_OVERFLOW);
-		}
-		/* If the next entry in the aux_queue use the same entry from CIRQ to
-		 * report error/overflow, don't unset UTIL_FLAG_ERRO and UTIL_FLAG_OVERFLOW
-		 * flags to ensure the next round of handling overflow/error entries */
 	} else {
-		cirq_entry->flags &= ~(UTIL_FLAG_ERROR | UTIL_FLAG_OVERFLOW);
+		aux_entry = container_of(cq->aux_queue.head,
+					 struct util_cq_aux_entry, list_entry);
+		if (aux_entry->cq_slot != ofi_cirque_head(cq->cirq))
+			ofi_cirque_discard(cq->cirq);
 	}
 
 	ret = 1;
-	free(err);
 unlock:
 	cq->cq_fastlock_release(&cq->cq_lock);
 	return ret;

--- a/prov/util/src/util_eq.c
+++ b/prov/util/src/util_eq.c
@@ -68,6 +68,11 @@ void ofi_eq_handle_err_entry(uint32_t api_version, uint64_t flags,
 	}
 }
 
+/*
+ * fi_eq_read and fi_eq_readerr share this common code path.
+ * If flags contains UTIL_FLAG_ERROR, then we are processing
+ * fi_eq_readerr.
+ */
 ssize_t ofi_eq_read(struct fid_eq *eq_fid, uint32_t *event,
 		    void *buf, size_t len, uint64_t flags)
 {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -955,75 +955,9 @@ vrb_send_buf(struct vrb_ep *ep, struct ibv_send_wr *wr,
 	return vrb_post_send(ep, wr, 0);
 }
 
-static inline ssize_t
-vrb_send_iov_flags(struct vrb_ep *ep, struct ibv_send_wr *wr,
-		      const struct iovec *iov, void **desc, int count,
-		      uint64_t flags)
-{
-	size_t len = 0;
-	enum fi_hmem_iface iface;
-	uint64_t device;
-	void *bounce_buf;
-	void *send_desc;
-	ssize_t ret;
-
-	if (ep->hmem_enabled) {
-		if (!desc) {
-			vrb_set_sge_iov_inline(wr->sg_list, iov, count, len);
-			iface = FI_HMEM_SYSTEM;
-			device = 0;
-			send_desc = NULL;
-		} else {
-			vrb_set_sge_iov_count_len(wr->sg_list, iov, count, desc,
-						  len);
-			iface = ((struct vrb_mem_desc *) desc[0])->info.iface;
-			device = ((struct vrb_mem_desc *) desc[0])->info.device;
-			send_desc = desc[0];
-		}
-
-		wr->send_flags = VERBS_INJECT_FLAGS(ep, len, flags, send_desc);
-
-		if (wr->send_flags & IBV_SEND_INLINE &&
-		    iface != FI_HMEM_SYSTEM) {
-			bounce_buf = alloca(len);
-
-			ret = ofi_copy_from_hmem_iov(bounce_buf, len, iface,
-						     device, iov, count, 0);
-			if (ret != len) {
-				if (ret >= 0) {
-					VERBS_WARN(FI_LOG_EP_DATA,
-						   "Unexpected short copy");
-					ret = -FI_EIO;
-				}
-
-				goto out;
-			}
-
-			wr->sg_list[0] = vrb_init_sge(bounce_buf, len, NULL);
-			count = 1;
-		}
-	} else {
-		if (!desc)
-			vrb_set_sge_iov_inline(wr->sg_list, iov, count, len);
-		else
-			vrb_set_sge_iov_count_len(wr->sg_list, iov, count, desc,
-						  len);
-
-		if (flags & FI_INJECT || len < ep->info_attr.inject_size)
-			wr->send_flags = IBV_SEND_INLINE;
-	}
-
-	wr->num_sge = count;
-	wr->wr_id = VERBS_COMP_FLAGS(ep, flags, wr->wr_id);
-
-	if (flags & FI_FENCE)
-		wr->send_flags |= IBV_SEND_FENCE;
-
-	ret = vrb_post_send(ep, wr, flags);
-
-out:
-	return ret;
-}
+ssize_t vrb_send_iov(struct vrb_ep *ep, struct ibv_send_wr *wr,
+		     const struct iovec *iov, void **desc, int count,
+		     uint64_t flags);
 
 void vrb_add_credits(struct fid_ep *ep, size_t credits);
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -936,10 +936,6 @@ do {								\
 	}							\
 } while (0)
 
-#define vrb_send_msg(ep, wr, msg, flags)			\
-	vrb_send_iov_flags(ep, wr, (msg)->msg_iov, (msg)->desc,	\
-			      (msg)->iov_count, flags)
-
 #define vrb_wr_consumes_recv(wr)						\
 	( wr->opcode == IBV_WR_SEND || wr->opcode == IBV_WR_SEND_WITH_IMM	\
 	|| wr->opcode == IBV_WR_RDMA_WRITE_WITH_IMM )

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -100,11 +100,9 @@
 
 
 #define VERBS_INJECT_FLAGS(ep, len, flags, desc) \
-	((flags) & FI_INJECT || \
-	 ((!(desc) || \
-	  ((struct vrb_mem_desc *) (desc))->info.iface == FI_HMEM_SYSTEM) && \
-	 (len) <= (ep)->info_attr.inject_size)) ? \
-	IBV_SEND_INLINE : 0
+	(((flags) & FI_INJECT) || !(desc) || \
+	 ((((struct vrb_mem_desc *) (desc))->info.iface == FI_HMEM_SYSTEM) && \
+	  ((len) <= (ep)->info_attr.inject_size))) ? IBV_SEND_INLINE : 0
 #define VERBS_INJECT(ep, len, desc) \
 	VERBS_INJECT_FLAGS(ep, len, (ep)->util_ep.tx_op_flags, desc)
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -923,25 +923,20 @@ do {									\
 	}								\
 } while (0)
 
-#define vrb_init_sge_inline(buf, len) vrb_init_sge(buf, len, NULL)
-
 #define vrb_set_sge_iov_inline(sg_list, iov, count, len)	\
 do {								\
 	size_t i;						\
 	sg_list = alloca(sizeof(*sg_list) * count);		\
 	for (i = 0; i < count; i++) {				\
-		sg_list[i] = vrb_init_sge_inline(		\
+		sg_list[i] = vrb_init_sge(			\
 					iov[i].iov_base,	\
-					iov[i].iov_len);	\
+					iov[i].iov_len,		\
+					NULL);			\
 		len += iov[i].iov_len;				\
 	}							\
 } while (0)
 
-#define vrb_send_iov(ep, wr, iov, desc, count)		\
-	vrb_send_iov_flags(ep, wr, iov, desc, count,		\
-			      (ep)->util_ep.tx_op_flags)
-
-#define vrb_send_msg(ep, wr, msg, flags)				\
+#define vrb_send_msg(ep, wr, msg, flags)			\
 	vrb_send_iov_flags(ep, wr, (msg)->msg_iov, (msg)->desc,	\
 			      (msg)->iov_count, flags)
 
@@ -970,7 +965,7 @@ static inline ssize_t
 vrb_send_buf_inline(struct vrb_ep *ep, struct ibv_send_wr *wr,
 		       const void *buf, size_t len)
 {
-	struct ibv_sge sge = vrb_init_sge_inline(buf, len);
+	struct ibv_sge sge = vrb_init_sge(buf, len, NULL);
 
 	assert(wr->wr_id == VERBS_NO_COMP_FLAG);
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -906,32 +906,6 @@ do {								\
 	}							\
 } while (0)
 
-#define vrb_set_sge_iov_count_len(sg_list, iov, count, desc, len)	\
-do {									\
-	size_t i;							\
-	sg_list = alloca(sizeof(*sg_list) * count);			\
-	for (i = 0; i < count; i++) {					\
-		sg_list[i] = vrb_init_sge(				\
-				iov[i].iov_base,			\
-				iov[i].iov_len,				\
-				desc[i]);				\
-		len += iov[i].iov_len;					\
-	}								\
-} while (0)
-
-#define vrb_set_sge_iov_inline(sg_list, iov, count, len)	\
-do {								\
-	size_t i;						\
-	sg_list = alloca(sizeof(*sg_list) * count);		\
-	for (i = 0; i < count; i++) {				\
-		sg_list[i] = vrb_init_sge(			\
-					iov[i].iov_base,	\
-					iov[i].iov_len,		\
-					NULL);			\
-		len += iov[i].iov_len;				\
-	}							\
-} while (0)
-
 #define vrb_wr_consumes_recv(wr)						\
 	( wr->opcode == IBV_WR_SEND || wr->opcode == IBV_WR_SEND_WITH_IMM	\
 	|| wr->opcode == IBV_WR_RDMA_WRITE_WITH_IMM )

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -949,22 +949,6 @@ vrb_send_buf(struct vrb_ep *ep, struct ibv_send_wr *wr,
 {
 	struct ibv_sge sge = vrb_init_sge(buf, len, desc);
 
-	assert(wr->wr_id != VERBS_NO_COMP_FLAG);
-
-	wr->sg_list = &sge;
-	wr->num_sge = 1;
-
-	return vrb_post_send(ep, wr, 0);
-}
-
-static inline ssize_t
-vrb_send_buf_inline(struct vrb_ep *ep, struct ibv_send_wr *wr,
-		       const void *buf, size_t len)
-{
-	struct ibv_sge sge = vrb_init_sge(buf, len, NULL);
-
-	assert(wr->wr_id == VERBS_NO_COMP_FLAG);
-
 	wr->sg_list = &sge;
 	wr->num_sge = 1;
 

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -898,16 +898,14 @@ int vrb_save_wc(struct vrb_cq *cq, struct ibv_wc *wc);
 	  .length = (uint32_t) len,			\
 	  .lkey = (desc) ? ((struct vrb_mem_desc *) (desc))->lkey : 0 }
 
-#define vrb_set_sge_iov(sg_list, iov, count, desc)	\
-do {							\
-	size_t i;					\
-	sg_list = alloca(sizeof(*sg_list) * count);	\
-	for (i = 0; i < count; i++) {			\
-		sg_list[i] = vrb_init_sge(		\
-				iov[i].iov_base,	\
-				iov[i].iov_len,		\
-				desc[i]);		\
-	}						\
+#define vrb_iov_dupa(dst, iov, desc, count)			\
+do {								\
+	size_t i;						\
+	dst = alloca(sizeof(*dst) * count);			\
+	for (i = 0; i < count; i++) {				\
+		dst[i] = vrb_init_sge(iov[i].iov_base,		\
+				      iov[i].iov_len, desc[i]);	\
+	}							\
 } while (0)
 
 #define vrb_set_sge_iov_count_len(sg_list, iov, count, desc, len)	\

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -188,7 +188,7 @@ vrb_dgram_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
 
-	return vrb_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf(ep, &wr, buf, len, NULL);
 }
 
 static ssize_t
@@ -228,7 +228,7 @@ vrb_dgram_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
 
-	return vrb_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf(ep, &wr, buf, len, NULL);
 }
 
 static ssize_t

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -111,8 +111,8 @@ vrb_dgram_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	if (vrb_dgram_ep_set_addr(ep, msg->addr, &wr))
 		return -FI_ENOENT;
 
-	return vrb_send_iov_flags(ep, &wr, msg->msg_iov, msg->desc,
-				  msg->iov_count, flags);
+	return vrb_send_iov(ep, &wr, msg->msg_iov, msg->desc,
+			    msg->iov_count, flags);
 }
 
 static inline ssize_t
@@ -130,8 +130,8 @@ vrb_dgram_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
 
-	return vrb_send_iov_flags(ep, &wr, iov, desc, count,
-				  ep->util_ep.tx_op_flags);
+	return vrb_send_iov(ep, &wr, iov, desc, count,
+			    ep->util_ep.tx_op_flags);
 }
 
 static ssize_t

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -111,7 +111,8 @@ vrb_dgram_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 	if (vrb_dgram_ep_set_addr(ep, msg->addr, &wr))
 		return -FI_ENOENT;
 
-	return vrb_send_msg(ep, &wr, msg, flags);
+	return vrb_send_iov_flags(ep, &wr, msg->msg_iov, msg->desc,
+				  msg->iov_count, flags);
 }
 
 static inline ssize_t

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -129,7 +129,8 @@ vrb_dgram_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov,
 	if (vrb_dgram_ep_set_addr(ep, dest_addr, &wr))
 		return -FI_ENOENT;
 
-	return vrb_send_iov(ep, &wr, iov, desc, count);
+	return vrb_send_iov_flags(ep, &wr, iov, desc, count,
+				  ep->util_ep.tx_op_flags);
 }
 
 static ssize_t

--- a/prov/verbs/src/verbs_dgram_ep_msg.c
+++ b/prov/verbs/src/verbs_dgram_ep_msg.c
@@ -59,7 +59,7 @@ vrb_dgram_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		.next = NULL,
 	};
 
-	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
+	vrb_iov_dupa(wr.sg_list, msg->msg_iov, msg->desc, msg->iov_count);
 	return vrb_post_recv(ep, &wr);
 }
 

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -1508,7 +1508,7 @@ vrb_srq_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t fla
 		.next = NULL,
 	};
 
-	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
+	vrb_iov_dupa(wr.sg_list, msg->msg_iov, msg->desc, msg->iov_count);
 	return vrb_post_srq(ep, &wr);
 }
 

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -182,6 +182,75 @@ unlock:
 	return -FI_EAGAIN;
 }
 
+ssize_t vrb_send_iov(struct vrb_ep *ep, struct ibv_send_wr *wr,
+		     const struct iovec *iov, void **desc, int count,
+		     uint64_t flags)
+{
+	size_t len = 0;
+	enum fi_hmem_iface iface;
+	uint64_t device;
+	void *bounce_buf;
+	void *send_desc;
+	ssize_t ret;
+
+	if (ep->hmem_enabled) {
+		if (!desc) {
+			vrb_set_sge_iov_inline(wr->sg_list, iov, count, len);
+			iface = FI_HMEM_SYSTEM;
+			device = 0;
+			send_desc = NULL;
+		} else {
+			vrb_set_sge_iov_count_len(wr->sg_list, iov, count, desc,
+						  len);
+			iface = ((struct vrb_mem_desc *) desc[0])->info.iface;
+			device = ((struct vrb_mem_desc *) desc[0])->info.device;
+			send_desc = desc[0];
+		}
+
+		wr->send_flags = VERBS_INJECT_FLAGS(ep, len, flags, send_desc);
+
+		if (wr->send_flags & IBV_SEND_INLINE &&
+		    iface != FI_HMEM_SYSTEM) {
+			bounce_buf = alloca(len);
+
+			ret = ofi_copy_from_hmem_iov(bounce_buf, len, iface,
+						     device, iov, count, 0);
+			if (ret != len) {
+				if (ret >= 0) {
+					VERBS_WARN(FI_LOG_EP_DATA,
+						   "Unexpected short copy");
+					ret = -FI_EIO;
+				}
+
+				goto out;
+			}
+
+			wr->sg_list[0] = vrb_init_sge(bounce_buf, len, NULL);
+			count = 1;
+		}
+	} else {
+		if (!desc)
+			vrb_set_sge_iov_inline(wr->sg_list, iov, count, len);
+		else
+			vrb_set_sge_iov_count_len(wr->sg_list, iov, count, desc,
+						  len);
+
+		if (flags & FI_INJECT || len < ep->info_attr.inject_size)
+			wr->send_flags = IBV_SEND_INLINE;
+	}
+
+	wr->num_sge = count;
+	wr->wr_id = VERBS_COMP_FLAGS(ep, flags, wr->wr_id);
+
+	if (flags & FI_FENCE)
+		wr->send_flags |= IBV_SEND_FENCE;
+
+	ret = vrb_post_send(ep, wr, flags);
+
+out:
+	return ret;
+}
+
 static inline int vrb_msg_ep_cmdata_size(fid_t fid)
 {
 	struct vrb_pep *pep;

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -47,7 +47,7 @@ vrb_msg_ep_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t fla
 		.next = NULL,
 	};
 
-	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
+	vrb_iov_dupa(wr.sg_list, msg->msg_iov, msg->desc, msg->iov_count);
 	return vrb_post_recv(ep, &wr);
 }
 

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -160,7 +160,7 @@ static ssize_t vrb_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t 
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	return vrb_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf(ep, &wr, buf, len, NULL);
 }
 
 static ssize_t vrb_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -175,7 +175,7 @@ static ssize_t vrb_msg_ep_injectdata(struct fid_ep *ep_fid, const void *buf, siz
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	return vrb_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf(ep, &wr, buf, len, NULL);
 }
 
 static ssize_t
@@ -322,7 +322,7 @@ static ssize_t vrb_msg_xrc_ep_inject(struct fid_ep *ep_fid, const void *buf, siz
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return vrb_send_buf_inline(&ep->base_ep, &wr, buf, len);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, len, NULL);
 }
 
 static ssize_t vrb_msg_xrc_ep_injectdata(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -339,7 +339,7 @@ static ssize_t vrb_msg_xrc_ep_injectdata(struct fid_ep *ep_fid, const void *buf,
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return vrb_send_buf_inline(&ep->base_ep, &wr, buf, len);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, len, NULL);
 }
 
 /* NOTE: Initially the XRC endpoint must be used with a SRQ. */

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -99,7 +99,8 @@ vrb_msg_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t fla
 		wr.opcode = IBV_WR_SEND;
 	}
 
-	return vrb_send_msg(ep, &wr, msg, flags);
+	return vrb_send_iov_flags(ep, &wr, msg->msg_iov, msg->desc,
+				  msg->iov_count, flags);
 }
 
 static ssize_t
@@ -252,7 +253,8 @@ vrb_msg_xrc_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t
 		wr.opcode = IBV_WR_SEND;
 	}
 
-	return vrb_send_msg(&ep->base_ep, &wr, msg, flags);
+	return vrb_send_iov_flags(&ep->base_ep, &wr, msg->msg_iov, msg->desc,
+				  msg->iov_count, flags);
 }
 
 static ssize_t

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -144,7 +144,8 @@ vrb_msg_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		.opcode = IBV_WR_SEND,
 	};
 
-	return vrb_send_iov(ep, &wr, iov, desc, count);
+	return vrb_send_iov_flags(ep, &wr, iov, desc, count,
+				  ep->util_ep.tx_op_flags);
 }
 
 static ssize_t vrb_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -302,7 +303,8 @@ vrb_msg_xrc_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return vrb_send_iov(&ep->base_ep, &wr, iov, desc, count);
+	return vrb_send_iov_flags(&ep->base_ep, &wr, iov, desc, count,
+				  ep->base_ep.util_ep.tx_op_flags);
 }
 
 static ssize_t vrb_msg_xrc_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,

--- a/prov/verbs/src/verbs_msg.c
+++ b/prov/verbs/src/verbs_msg.c
@@ -99,8 +99,8 @@ vrb_msg_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t fla
 		wr.opcode = IBV_WR_SEND;
 	}
 
-	return vrb_send_iov_flags(ep, &wr, msg->msg_iov, msg->desc,
-				  msg->iov_count, flags);
+	return vrb_send_iov(ep, &wr, msg->msg_iov, msg->desc,
+			    msg->iov_count, flags);
 }
 
 static ssize_t
@@ -145,8 +145,8 @@ vrb_msg_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc,
 		.opcode = IBV_WR_SEND,
 	};
 
-	return vrb_send_iov_flags(ep, &wr, iov, desc, count,
-				  ep->util_ep.tx_op_flags);
+	return vrb_send_iov(ep, &wr, iov, desc, count,
+			    ep->util_ep.tx_op_flags);
 }
 
 static ssize_t vrb_msg_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,
@@ -253,8 +253,8 @@ vrb_msg_xrc_ep_sendmsg(struct fid_ep *ep_fid, const struct fi_msg *msg, uint64_t
 		wr.opcode = IBV_WR_SEND;
 	}
 
-	return vrb_send_iov_flags(&ep->base_ep, &wr, msg->msg_iov, msg->desc,
-				  msg->iov_count, flags);
+	return vrb_send_iov(&ep->base_ep, &wr, msg->msg_iov, msg->desc,
+			    msg->iov_count, flags);
 }
 
 static ssize_t
@@ -305,8 +305,8 @@ vrb_msg_xrc_ep_sendv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return vrb_send_iov_flags(&ep->base_ep, &wr, iov, desc, count,
-				  ep->base_ep.util_ep.tx_op_flags);
+	return vrb_send_iov(&ep->base_ep, &wr, iov, desc, count,
+			    ep->base_ep.util_ep.tx_op_flags);
 }
 
 static ssize_t vrb_msg_xrc_ep_inject(struct fid_ep *ep_fid, const void *buf, size_t len,

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -76,7 +76,8 @@ vrb_msg_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **des
 		.wr.rdma.rkey = (uint32_t)key,
 	};
 
-	return vrb_send_iov(ep, &wr, iov, desc, count);
+	return vrb_send_iov_flags(ep, &wr, iov, desc, count,
+				  ep->util_ep.tx_op_flags);
 }
 
 static ssize_t
@@ -313,7 +314,8 @@ vrb_msg_xrc_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return vrb_send_iov(&ep->base_ep, &wr, iov, desc, count);
+	return vrb_send_iov_flags(&ep->base_ep, &wr, iov, desc, count,
+				  ep->base_ep.util_ep.tx_op_flags);
 }
 
 static ssize_t

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -192,7 +192,7 @@ vrb_msg_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	return vrb_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf(ep, &wr, buf, len, NULL);
 }
 
 static ssize_t
@@ -228,7 +228,7 @@ vrb_msg_ep_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf, size_t l
 		.send_flags = IBV_SEND_INLINE,
 	};
 
-	return vrb_send_buf_inline(ep, &wr, buf, len);
+	return vrb_send_buf(ep, &wr, buf, len, NULL);
 }
 
 static ssize_t
@@ -445,7 +445,7 @@ vrb_msg_xrc_ep_rma_inject_write(struct fid_ep *ep_fid, const void *buf,
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return vrb_send_buf_inline(&ep->base_ep, &wr, buf, len);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, len, NULL);
 }
 
 static ssize_t
@@ -483,7 +483,7 @@ vrb_msg_xrc_ep_rma_inject_writedata(struct fid_ep *ep_fid,
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return vrb_send_buf_inline(&ep->base_ep, &wr, buf, len);
+	return vrb_send_buf(&ep->base_ep, &wr, buf, len, NULL);
 }
 
 static ssize_t

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -99,7 +99,8 @@ vrb_msg_ep_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		wr.opcode = IBV_WR_RDMA_WRITE;
 	}
 
-	return vrb_send_msg(ep, &wr, msg, flags);
+	return vrb_send_iov_flags(ep, &wr, msg->msg_iov, msg->desc,
+				  msg->iov_count, flags);
 }
 
 static ssize_t
@@ -339,7 +340,8 @@ vrb_msg_xrc_ep_rma_writemsg(struct fid_ep *ep_fid,
 		wr.opcode = IBV_WR_RDMA_WRITE;
 	}
 
-	return vrb_send_msg(&ep->base_ep, &wr, msg, flags);
+	return vrb_send_iov_flags(&ep->base_ep, &wr, msg->msg_iov, msg->desc,
+				  msg->iov_count, flags);
 }
 
 static ssize_t

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -135,8 +135,7 @@ vrb_msg_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov, void **desc
 		.num_sge = count,
 	};
 
-	vrb_set_sge_iov(wr.sg_list, iov, count, desc);
-
+	vrb_iov_dupa(wr.sg_list, iov, desc, count);
 	return vrb_post_send(ep, &wr, 0);
 }
 
@@ -154,8 +153,7 @@ vrb_msg_ep_rma_readmsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		.num_sge = msg->iov_count,
 	};
 
-	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
-
+	vrb_iov_dupa(wr.sg_list, msg->msg_iov, msg->desc, msg->iov_count);
 	return vrb_post_send(ep, &wr, 0);
 }
 
@@ -380,8 +378,7 @@ vrb_msg_xrc_ep_rma_readv(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	vrb_set_sge_iov(wr.sg_list, iov, count, desc);
-
+	vrb_iov_dupa(wr.sg_list, iov, desc, count);
 	return vrb_post_send(&ep->base_ep, &wr, 0);
 }
 
@@ -402,8 +399,7 @@ vrb_msg_xrc_ep_rma_readmsg(struct fid_ep *ep_fid,
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	vrb_set_sge_iov(wr.sg_list, msg->msg_iov, msg->iov_count, msg->desc);
-
+	vrb_iov_dupa(wr.sg_list, msg->msg_iov, msg->desc, msg->iov_count);
 	return vrb_post_send(&ep->base_ep, &wr, flags);
 }
 

--- a/prov/verbs/src/verbs_rma.c
+++ b/prov/verbs/src/verbs_rma.c
@@ -76,8 +76,8 @@ vrb_msg_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov, void **des
 		.wr.rdma.rkey = (uint32_t)key,
 	};
 
-	return vrb_send_iov_flags(ep, &wr, iov, desc, count,
-				  ep->util_ep.tx_op_flags);
+	return vrb_send_iov(ep, &wr, iov, desc, count,
+			    ep->util_ep.tx_op_flags);
 }
 
 static ssize_t
@@ -99,8 +99,8 @@ vrb_msg_ep_rma_writemsg(struct fid_ep *ep_fid, const struct fi_msg_rma *msg,
 		wr.opcode = IBV_WR_RDMA_WRITE;
 	}
 
-	return vrb_send_iov_flags(ep, &wr, msg->msg_iov, msg->desc,
-				  msg->iov_count, flags);
+	return vrb_send_iov(ep, &wr, msg->msg_iov, msg->desc,
+			    msg->iov_count, flags);
 }
 
 static ssize_t
@@ -315,8 +315,8 @@ vrb_msg_xrc_ep_rma_writev(struct fid_ep *ep_fid, const struct iovec *iov,
 
 	VRB_SET_REMOTE_SRQN(wr, ep->peer_srqn);
 
-	return vrb_send_iov_flags(&ep->base_ep, &wr, iov, desc, count,
-				  ep->base_ep.util_ep.tx_op_flags);
+	return vrb_send_iov(&ep->base_ep, &wr, iov, desc, count,
+			    ep->base_ep.util_ep.tx_op_flags);
 }
 
 static ssize_t
@@ -340,8 +340,8 @@ vrb_msg_xrc_ep_rma_writemsg(struct fid_ep *ep_fid,
 		wr.opcode = IBV_WR_RDMA_WRITE;
 	}
 
-	return vrb_send_iov_flags(&ep->base_ep, &wr, msg->msg_iov, msg->desc,
-				  msg->iov_count, flags);
+	return vrb_send_iov(&ep->base_ep, &wr, msg->msg_iov, msg->desc,
+			    msg->iov_count, flags);
 }
 
 static ssize_t


### PR DESCRIPTION
This series of patches are the result of debugging a segfault that occurred while running fabtests over rxm+tcp.  The segfault occurs if the client program is run without starting the server first, and waiting several seconds.

See #6414 and #6204 

The underlying issues are severe.  First if an app passing in a count > 1 to fi_cq_read, the returned completions will all be written to the first array entry passed in.  From the app's view, completions will be lost and/or corrupted.  Second, the attempts to handle CQ overrun by making use of an overflow queue were incorrect.  That could have resulted in returning successful completions as errors, if both successful and error completions were on the overflow queue.  Additional data corruptions could also occur, as seen by the app.  This is what caused the segfault running a fabtest client without the server running.

There are a series of patches created on the path to discovering and fixing these issues.  Most of the initial patches are cleanups to rxm.  However, a fix to the AV was added to prevent a division by 0 error which showed up after enabling support for shared receive contexts.

Additional cleanups were added to the util CQ code, followed by a re-design of how the overflow queue is being used.  The overflow queue was renamed to an auxiliary queue.  When entries are added to the auxiliary queue, an empty placeholder is maintained in the main CQ circular queue.  This maintains consistency in that the placeholder entries never have valid entries, versus before where they might.  Placeholder entries are simply flagged with an 'AUX' flag, which replaces the error and overflow flags.  Auxiliary entries are self-contained and indicate if they are a valid completion (resulting from overflow) or are an error entry.

As part of this change, the smr provider completion code was re-worked to use the util abstractions.  That replaces the open coding of those calls.

Opening this PR to start review.  The tcp provider is passing fabtests with these changes, but smr is not yet.  Additional work is still needed to support calling fi_cq_read with count > 1.  The current code simply caps the number of completions returned to 1.