### PR TITLE
prov/efa: fix compilation warning

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -395,8 +395,9 @@ bool efa_ep_support_rdma_read(struct fid_ep *ep_fid)
 static inline
 bool efa_ep_support_rnr_retry_modify(struct fid_ep *ep_fid)
 {
-	struct efa_ep *efa_ep;
 #ifdef HAVE_CAPS_RNR_RETRY
+	struct efa_ep *efa_ep;
+
 	efa_ep = container_of(ep_fid, struct efa_ep, util_ep.ep_fid);
 	return efa_ep->domain->ctx->device_caps & EFADV_DEVICE_ATTR_CAPS_RNR_RETRY;
 #else

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -468,7 +468,7 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 	struct fi_msg_rma msg;
 	struct efa_ep *efa_ep;
 	struct rxr_peer *peer;
-	fi_addr_t shm_fiaddr;
+	fi_addr_t shm_fiaddr = FI_ADDR_NOTAVAIL;
 
 	assert(read_entry->iov_count > 0);
 	assert(read_entry->rma_iov_count > 0);


### PR DESCRIPTION
This patch fix issues in function
	efa_ep_support_rnr_retry_modify() and
	rxr_read_post()
that cause compiler warning

Signed-off-by: Wei Zhang <wzam@amazon.com>