### PR TITLE
util/av: Return requested AV size if current size is 0

### DIFF
--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -425,7 +425,9 @@ int ofi_av_close(struct util_av *av)
 
 size_t ofi_av_size(struct util_av *av)
 {
-	return av->av_entry_pool->entry_cnt;
+	return av->av_entry_pool->entry_cnt ?
+	       av->av_entry_pool->entry_cnt :
+	       av->av_entry_pool->attr.chunk_cnt;
 }
 
 static int util_verify_av_util_attr(struct util_domain *domain,


### PR DESCRIPTION
If we attempt to get the size of the AV prior to the first
address being added, the return value will be 0.  That can
lead to a division by 0 error in rxm_conn_get_rx_size(),
for example.

Add a check to ofi_av_size(), and if the current size is 0,
return the size that was assigned to the AV through the
av attributes when it was created.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>