### PR TITLE
fabtests: Remove possible invalid use of FI_INJECT

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2655,7 +2655,7 @@ int ft_finalize_ep(struct fid_ep *ep)
 
 		FT_POST(fi_tsendmsg, ft_progress, txcq, tx_seq,
 			&tx_cq_cntr, "tsendmsg", ep, &tmsg,
-			FI_INJECT | FI_TRANSMIT_COMPLETE);
+			FI_TRANSMIT_COMPLETE);
 	} else {
 		struct fi_msg msg;
 
@@ -2668,7 +2668,7 @@ int ft_finalize_ep(struct fid_ep *ep)
 
 		FT_POST(fi_sendmsg, ft_progress, txcq, tx_seq,
 			&tx_cq_cntr, "sendmsg", ep, &msg,
-			FI_INJECT | FI_TRANSMIT_COMPLETE);
+			FI_TRANSMIT_COMPLETE);
 	}
 
 	ret = ft_get_tx_comp(tx_seq);


### PR DESCRIPTION
ft_finalize_ep() assumes that underlying providers always
support an inject size 4 + the prefix size.  However, some
providers do not support any inject size at all.

This shows up over verbs with the hfi device, which does not
support INLINE data.

Since there's no need for using inject in finalize, simply
remove the flag.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>