### PR TITLE
prov/rxm: Always use eager bounce buffers

### DIFF
--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -478,13 +478,18 @@ struct ofi_ops_dynamic_rbuf rxm_dynamic_rbuf = {
 
 static void rxm_config_dyn_rbuf(struct rxm_domain *domain, struct fi_info *info)
 {
-	int ret = 1;
+	/* int ret = 1; */
+
+	/* Force disabling of dynamic receive buffers until issues are
+	 * resolved.
+	 */
+	domain->dyn_rbuf = false;
+	return;
 
 	/* Collective support requires rxm generated and consumed messages.
 	 * Although we could update the code to handle receiving collective
 	 * messages, collective support is mostly for development purposes.
 	 * So, fallback to bounce buffers when enabled.
-	 */
 	if (info->caps & FI_COLLECTIVE)
 		return;
 
@@ -500,6 +505,7 @@ static void rxm_config_dyn_rbuf(struct rxm_domain *domain, struct fi_info *info)
 	if (domain->dyn_rbuf) {
 		domain->rx_buf_post_size = sizeof(struct rxm_pkt);
 	}
+	 */
 }
 
 int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1471,12 +1471,15 @@ unlock:
 static bool
 rxm_use_direct_send(struct rxm_ep *ep, size_t iov_count, uint64_t flags)
 {
+	/* Always use bounce buffers until issues are resolved.
 	struct rxm_domain *domain;
 
 	domain = container_of(ep->util_ep.domain, struct rxm_domain,
 			      util_domain);
 	return !(flags & FI_INJECT) && !(domain->mr_local) &&
 		(iov_count < ep->msg_info->tx_attr->iov_limit);
+	*/
+	return false;
 }
 
 static ssize_t


### PR DESCRIPTION
Disable dynamic receive buffering and direct sends until
all issues have been resolved.  This, unfortunately, masks
issues handling differences in verbs devices, as well as
bugs in a couple of fabtests.  The changes will be reverted
once CI is passing with fixes in place.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>