### PR TITLE
prov/efa: adjust frequency of flush

### DIFF
--- a/prov/efa/src/efa_mr.c
+++ b/prov/efa/src/efa_mr.c
@@ -152,6 +152,7 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	struct ofi_mr_entry *entry;
 	int ret;
 	static const int EFA_MR_CACHE_FLUSH_CHECK = 512;
+	static size_t reg_counter = 0;
 
 	if (flags & OFI_MR_NOCACHE) {
 		ret = efa_mr_regattr(fid, attr, flags, mr_fid);
@@ -167,7 +168,8 @@ static int efa_mr_cache_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	domain = container_of(fid, struct efa_domain,
 			      util_domain.domain_fid.fid);
 
-	if (domain->cache->cached_cnt > 0 && domain->cache->cached_cnt % EFA_MR_CACHE_FLUSH_CHECK==0) {
+	reg_counter += 1;
+	if (reg_counter % EFA_MR_CACHE_FLUSH_CHECK==0) {
 		ofi_mr_cache_flush(domain->cache, false);
 	}
 


### PR DESCRIPTION
Currently, efa_mr_cache_regattr() call ofi_mr_cache_flush() when
cache->cached_cnt is multiple of EFA_MR_CACHE_FLUSH_CHECK.
The problem with this approach is that cache->cached_cnt can
go up and down depend on application's behavoir.

This patch address the issue by using a static call_counter, which
ensures that efa_mr_cached_regattr() is called more regularly.

Signed-off-by: Wei Zhang <wzam@amazon.com>