### PR TITLE
prov/efa: Fix a Bug in rxr_pkt_handle_receipt_recv

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -170,6 +170,12 @@ static inline void rxr_poison_mem_region(uint32_t *ptr, size_t size)
 #define RXR_RECEIPT_RECEIVED BIT_ULL(7)
 
 /*
+ * Flag to tell that
+ * long message protocol is used
+ */
+#define RXR_LONGCTS_PROTOCOL BIT_ULL(8)
+
+/*
  * OFI flags
  * The 64-bit flag field is used as follows:
  * 1-grow up    common (usable with multiple operations)

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -251,6 +251,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		return err;
 
 	ctrl_type = delivery_complete_requested ? RXR_DC_LONG_MSGRTM_PKT : RXR_LONG_MSGRTM_PKT;
+	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;
 	return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
 					  ctrl_type + tagged, 0);
 }

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -647,13 +647,7 @@ void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
 	}
 
 	tx_entry->rxr_flags |= RXR_RECEIPT_RECEIVED;
-	if (!(tx_entry->bytes_acked > 0)) {
-		/* For eager and medium delivery_complete messages,
-		 * bytes_acked is not updated,
-		 * so it is always 0.
-		 */
-		rxr_cq_handle_tx_completion(ep, tx_entry);
-	} else {
+	if (tx_entry->rxr_flags & RXR_LONGCTS_PROTOCOL) {
 		/*
 		 * For long message protocol, when FI_DELIVERY_COMPLETE
 		 * is requested, we have to write tx completions
@@ -664,6 +658,8 @@ void rxr_pkt_handle_receipt_recv(struct rxr_ep *ep,
 		 */
 		if (tx_entry->total_len == tx_entry->bytes_acked)
 			rxr_cq_handle_tx_completion(ep, tx_entry);
+	} else {
+		rxr_cq_handle_tx_completion(ep, tx_entry);
 	}
 
 	rxr_pkt_entry_release_rx(ep, pkt_entry);

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -469,6 +469,7 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 
 	ctrl_type = delivery_complete_requested ?
 		RXR_DC_LONG_RTW_PKT : RXR_LONG_RTW_PKT;
+	tx_entry->rxr_flags |= RXR_LONGCTS_PROTOCOL;
 	return rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, ctrl_type, 0);
 }
 


### PR DESCRIPTION
Currently, in function `rxr_pkt_handle_receipt_recv()`,
`tx_entry->bytes_acked` > 0 is used to determine whether
long cts protocols are used.
    
This is wrong because for long cts protocols, receipt can
arrive before the completion of the LONG_RTW/LONG_RTM
and DATA packet.
    
If that happens, `tx_entry->bytes_acked` would be 0 even for
long cts protocols.

Given the above situation, this patch does the following
changes:
    
1. Introduced a flag called `RXR_LONGCTS_PROTOCOL`, which
shows whether the sender side is using long cts protocols
    
2. In `rxr_pkt_handle_receipt_recv()`, we use the
`RXR_LONGCTS_PROTOCOL` flag to determine whether long cts
protocols are used instead of checking `tx_entry->bytes_acked`.
    
Signed-off-by: Ao Li <aolia@amazon.com>