### PR TITLE
build/osx: Update travis.yml to reference xcode 12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ compiler:
 os:
     - linux
     - osx
+      osx_image: xcode12.2
 addons:
     apt:
         packages:


### PR DESCRIPTION
    
The travis OS X build hangs, printing a warning that the
default xcode is no longer supported by the app store.  Force
update to the latest OS X version as of this patch.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>