### PR TITLE
travis: set osx_image to a later (supported) version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ compiler:
 os:
     - linux
     - osx
+      osx_image: xcode12.2
 addons:
     apt:
         packages:


### PR DESCRIPTION
Re-enable support for dynamic receive buffering.  This
provides an optimization over the tcp provider to
avoid intermediate data copies through rxm bounce
buffers.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>