### PR TITLE
prov/shm: Add CMA check for endpoint itself

### DIFF
--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -222,7 +222,8 @@ struct smr_region {
 	uint8_t		resv;
 	uint16_t	flags;
 	int		pid;
-	uint8_t		cma_cap;
+	uint8_t		cma_cap_peer;
+	uint8_t		cma_cap_self;
 	void		*base_addr;
 	fastlock_t	lock; /* lock for shm access
 				 Must hold smr->lock before tx/rx cq locks

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -332,8 +332,10 @@ void smr_ep_progress(struct util_ep *util_ep);
 static inline bool smr_cma_enabled(struct smr_ep *ep,
 				   struct smr_region *peer_smr)
 {
-	return ep->region->cma_cap == SMR_CMA_CAP_ON ||
-	       ep->region == peer_smr;
+	if (ep->region == peer_smr)
+		return ep->region->cma_cap_self == SMR_CMA_CAP_ON;
+	else
+		return ep->region->cma_cap_peer == SMR_CMA_CAP_ON;
 }
 
 static inline int smr_cma_loop(pid_t pid, struct iovec *local,


### PR DESCRIPTION
We can not assume CMA always works when sending to self.
In the container context, CMA to self is not permitted because
the syscalls are already blocked by dropping CAP_SYS_PTRACE
https://docs.docker.com/engine/security/seccomp/.

Fix the issue by enabling CMA check for endpoint itself.
Field 'cma_cap' is changed into flags: High 4 bits for peer
CMA cap, while low 4 bits for self CMA cap. Since self CMA
cap and peer CMA cap might be different, we can not use
field 'cma_cap' as struct iovec in the test CMA call any more,
use field 'pid' instead.

Signed-off-by: Jie Zhang <zhngaj@amazon.com>