### PR TITLE
prov/tcp: implement fi_cancel() for TX and RX queues

### DIFF
--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -198,6 +198,34 @@ static void tcpx_ep_flush_pending_xfers(struct tcpx_ep *ep)
 	}
 }
 
+static void tcpx_ep_release_queue(struct slist *queue,
+				  struct tcpx_cq *tcpx_cq)
+{
+	struct tcpx_xfer_entry *xfer_entry;
+
+	while (!slist_empty(queue)) {
+		xfer_entry = container_of(queue->head, struct tcpx_xfer_entry,
+					  entry);
+		slist_remove_head(queue);
+		tcpx_cq_report_error(&tcpx_cq->util_cq, xfer_entry, FI_ECANCELED);
+		tcpx_xfer_entry_release(tcpx_cq, xfer_entry);
+	}
+}
+
+/* must hold ep->lock */
+static void tcpx_ep_tx_rx_queues_release(struct tcpx_ep *ep)
+{
+	struct tcpx_cq *tcpx_cq;
+
+	tcpx_cq = container_of(ep->util_ep.tx_cq, struct tcpx_cq, util_cq);
+	tcpx_ep_release_queue(&ep->tx_queue, tcpx_cq);
+	tcpx_ep_release_queue(&ep->rma_read_queue, tcpx_cq);
+	tcpx_ep_release_queue(&ep->tx_rsp_pend_queue, tcpx_cq);
+
+	tcpx_cq = container_of(ep->util_ep.rx_cq, struct tcpx_cq, util_cq);
+	tcpx_ep_release_queue(&ep->rx_queue, tcpx_cq);
+}
+
 /* must hold ep->lock */
 void tcpx_ep_disable(struct tcpx_ep *ep, int cm_err)
 {
@@ -233,6 +261,8 @@ void tcpx_ep_disable(struct tcpx_ep *ep, int cm_err)
 	default:
 		return;
 	}
+
+	tcpx_ep_tx_rx_queues_release(ep);
 
 	if (cm_err) {
 		err_entry.fid = &ep->util_ep.ep_fid.fid;
@@ -404,35 +434,6 @@ void tcpx_rx_msg_release(struct tcpx_xfer_entry *rx_entry)
 	}
 }
 
-static void tcpx_ep_release_queue(struct slist *queue,
-				  struct tcpx_cq *tcpx_cq)
-{
-	struct tcpx_xfer_entry *xfer_entry;
-
-	while (!slist_empty(queue)) {
-		xfer_entry = container_of(queue->head, struct tcpx_xfer_entry,
-					  entry);
-		slist_remove_head(queue);
-		tcpx_cq_report_error(&tcpx_cq->util_cq, xfer_entry, FI_ECANCELED);
-		tcpx_xfer_entry_release(tcpx_cq, xfer_entry);
-	}
-}
-
-static void tcpx_ep_tx_rx_queues_release(struct tcpx_ep *ep)
-{
-	struct tcpx_cq *tcpx_cq;
-
-	fastlock_acquire(&ep->lock);
-	tcpx_cq = container_of(ep->util_ep.tx_cq, struct tcpx_cq, util_cq);
-	tcpx_ep_release_queue(&ep->tx_queue, tcpx_cq);
-	tcpx_ep_release_queue(&ep->rma_read_queue, tcpx_cq);
-	tcpx_ep_release_queue(&ep->tx_rsp_pend_queue, tcpx_cq);
-
-	tcpx_cq = container_of(ep->util_ep.rx_cq, struct tcpx_cq, util_cq);
-	tcpx_ep_release_queue(&ep->rx_queue, tcpx_cq);
-	fastlock_release(&ep->lock);
-}
-
 static int tcpx_match_ctx(struct slist_entry *item, const void *arg)
 {
 	struct tcpx_xfer_entry *xfer_entry;
@@ -510,7 +511,9 @@ static int tcpx_ep_close(struct fid *fid)
 	if (eq)
 		fastlock_release(&eq->close_lock);
 
+	fastlock_acquire(&ep->lock);
 	tcpx_ep_tx_rx_queues_release(ep);
+	fastlock_release(&ep->lock);
 
 	if (eq) {
 		ofi_eq_remove_fid_events(ep->util_ep.eq,


### PR DESCRIPTION
fi_cancel() attempts to cancel a pending TX/RX request and generate
an event to the corresponding CQ if the cancellation is successful.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>