### PR TITLE
prov/verbs: skip devices with NULL contexts

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -1052,7 +1052,12 @@ static int vrb_get_sib(struct dlist_entry *verbs_devs)
 		return -errno;
 
 	for (int dev = 0; dev < num_devices; dev++) {
+		if (!devices[dev])
+			continue;
+
 		context = ibv_open_device(devices[dev]);
+		if (!context)
+			continue;
 
 		ret = ibv_query_device(context, &device_attr);
 		if (ret)
@@ -1364,6 +1369,14 @@ int vrb_init_info(const struct fi_info **all_infos)
 	}
 
 	for (i = 0; i < num_devices; i++) {
+		if (!ctx_list[i]) {
+			FI_INFO(&vrb_prov, FI_LOG_FABRIC,
+				"skipping device: %d, "
+				"the interface may be down, faulty or disabled\n",
+				i);
+			continue;
+		}
+
 		for (j = 0; j < dom_count; j++) {
 			if (ep_type[j]->type == FI_EP_MSG &&
 			    !vrb_device_has_ipoib_addr(ctx_list[i]->device->name)) {


### PR DESCRIPTION
I've recently got the case where libfabric tried to execute
ibv_query_device() with a NULL context (struct ibv_context *),
which caused the process to segv with the following call stack:

ibv_query_device  [/lib/x86_64-linux-gnu/libibverbs.so.1, 0x7ffff7f79000]
vrb_init_info  [xxx, 0x555555554000]
fi_verbs_ini  [xxx, 0x555555554000]
fi_ini  [xxx, 0x555555554000]
fi_getinfo  [xxx, 0x555555554000]

That crash happened because one network port was somehow malfunctioning
and its verbs context was NULL. The root cause of that malfunctioning
port is unknown but rebooting the node seems to have fixed the problem.

Below is an ibstat output for the faulty port:
ibpanic: [38248] main: stat of IB device 'mlx5_3' failed: Resource temporarily unavailable

As a fix, we should just skip the interfaces that report a NULL context
instead of crashing. That's especially true as the faulty network device
is not necessarily the one the end-user wants to use with libfabric.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>