### PR TITLE
sendmmsg() for progress on multiple entries

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,7 +56,7 @@ AC_DEFINE_UNQUOTED([BUILD_ID],["$with_build_id"],
 
 # Override autoconf default CFLAG settings (e.g. "-g -O2") while still
 # allowing the user to explicitly set CFLAGS=""
-: ${CFLAGS="-fvisibility=hidden ${base_c_warn_flags}"}
+: ${CFLAGS="-march=native -flto -fvisibility=hidden ${base_c_warn_flags}"}
 
 # AM_PROG_AS would set CFLAGS="-g -O2" by default if not set already so it
 # should not be called earlier

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -296,7 +296,6 @@ void tcpx_cq_report_error(struct util_cq *cq,
 ssize_t tcpx_recv_hdr(SOCKET sock, struct stage_buf *stage_buf,
 		      struct tcpx_cur_rx_msg *cur_rx_msg);
 int tcpx_recv_msg_data(struct tcpx_xfer_entry *recv_entry);
-int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry);
 int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf);
 
 struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq,

--- a/prov/tcp/src/tcpx_comm.c
+++ b/prov/tcp/src/tcpx_comm.c
@@ -37,26 +37,6 @@
 #include <ofi_iov.h>
 #include "tcpx.h"
 
-int tcpx_send_msg(struct tcpx_xfer_entry *tx_entry)
-{
-	ssize_t bytes_sent;
-	struct msghdr msg = {0};
-
-	msg.msg_iov = tx_entry->iov;
-	msg.msg_iovlen = tx_entry->iov_cnt;
-
-	bytes_sent = ofi_sendmsg_tcp(tx_entry->ep->sock, &msg, MSG_NOSIGNAL);
-	if (bytes_sent < 0)
-		return ofi_sockerr() == EPIPE ? -FI_ENOTCONN : -ofi_sockerr();
-
-	tx_entry->rem_len -= bytes_sent;
-	if (tx_entry->rem_len) {
-		ofi_consume_iov(tx_entry->iov, &tx_entry->iov_cnt, bytes_sent);
-		return -FI_EAGAIN;
-	}
-	return FI_SUCCESS;
-}
-
 static ssize_t tcpx_read_from_buffer(struct stage_buf *stage_buf,
 				     uint8_t *buf, size_t len)
 {


### PR DESCRIPTION
This may help with inject rate for large sizes, but I am not sure how to get a good measurement.

I can observe with strace -c a reduction of sendmsg() syscalls on larger transfers (using fi_msg_bw), but
the bandwidth numbers are all over the place (order of magnitude difference over 100, 50k iteration runs for example on 100 Gb NIC).

So call this a RFC for now. If someone can point me to a sane way to gauge BW or latency I will go do that and post numbers.