### PR TITLE
[v1.11.x] prov/efa: fix MR leak and incorrect message queuing

### DIFF
--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -140,9 +140,9 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 	tx_entry->msg_id = (peer->next_msg_id != ~0) ?
 			    peer->next_msg_id++ : ++peer->next_msg_id;
 
-	err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY,
-					tx_entry, req_pkt_type_list[op],
-					0);
+	err = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY,
+				tx_entry, req_pkt_type_list[op],
+				0);
 
 	if (OFI_UNLIKELY(err)) {
 		rxr_release_tx_entry(rxr_ep, tx_entry);

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -235,6 +235,7 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 	tx_entry->msg_id = peer->next_msg_id++;
 	err = rxr_msg_post_rtm(rxr_ep, tx_entry);
 	if (OFI_UNLIKELY(err)) {
+		rxr_tx_entry_mr_dereg(tx_entry);
 		rxr_release_tx_entry(rxr_ep, tx_entry);
 		peer->next_msg_id--;
 	}

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -168,8 +168,14 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 */
 		if (tx_entry->desc[0] || efa_is_cache_available(efa_domain))
 			rxr_ep_tx_init_mr_desc(rxr_domain, tx_entry, 0, FI_SEND);
-		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
-					 RXR_MEDIUM_MSGRTM_PKT + tagged, 0);
+
+		/*
+		 * we have to queue message RTM because data is sent as multiple
+		 * medium RTM packets. It could happend that the first several packets
+		 * were sent successfully, but the following packet encountered -FI_EAGAIN
+		 */
+		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
+		                                  RXR_MEDIUM_MSGRTM_PKT + tagged, 0);
 	}
 
 	if (tx_entry->total_len >= rxr_env.efa_min_read_msg_size &&

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -71,8 +71,8 @@ ssize_t rxr_msg_post_cuda_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	assert(tagged == 0 || tagged == 1);
 
 	if (tx_entry->total_len == 0)
-		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
-							  RXR_EAGER_MSGRTM_PKT + tagged, 0);
+		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
+					 RXR_EAGER_MSGRTM_PKT + tagged, 0);
 
 	/* Currently cuda data must be sent using read message protocol.
 	 * However, because read message protocol is an extra feature, we cannot
@@ -94,8 +94,8 @@ ssize_t rxr_msg_post_cuda_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 		return -FI_EOPNOTSUPP;
 	}
 
-	return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
-					  RXR_READ_MSGRTM_PKT + tagged, 0);
+	return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
+				 RXR_READ_MSGRTM_PKT + tagged, 0);
 }
 
 ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
@@ -136,7 +136,7 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		int rtm_type = (tx_entry->total_len <= max_rtm_data_size) ? RXR_EAGER_MSGRTM_PKT
 									  : RXR_READ_MSGRTM_PKT;
 
-		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry, rtm_type + tagged, 0);
+		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry, rtm_type + tagged, 0);
 	}
 
 	if (rxr_ep->use_zcpy_rx) {
@@ -159,8 +159,8 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 
 	/* inter instance message */
 	if (tx_entry->total_len <= max_rtm_data_size)
-		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
-						  RXR_EAGER_MSGRTM_PKT + tagged, 0);
+		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
+					 RXR_EAGER_MSGRTM_PKT + tagged, 0);
 
 	if (tx_entry->total_len <= rxr_env.efa_max_medium_msg_size) {
 		/* we do not check the return value of rxr_ep_init_mr_desc()
@@ -168,16 +168,16 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 		 */
 		if (tx_entry->desc[0] || efa_is_cache_available(efa_domain))
 			rxr_ep_tx_init_mr_desc(rxr_domain, tx_entry, 0, FI_SEND);
-		return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
-						  RXR_MEDIUM_MSGRTM_PKT + tagged, 0);
+		return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
+					 RXR_MEDIUM_MSGRTM_PKT + tagged, 0);
 	}
 
 	if (tx_entry->total_len >= rxr_env.efa_min_read_msg_size &&
 	    efa_both_support_rdma_read(rxr_ep, peer) &&
 	    (tx_entry->desc[0] || efa_is_cache_available(efa_domain))) {
 		/* use read message protocol */
-		err = rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
-						 RXR_READ_MSGRTM_PKT + tagged, 0);
+		err = rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
+					RXR_READ_MSGRTM_PKT + tagged, 0);
 
 		if (err != -FI_ENOMEM)
 			return err;
@@ -192,8 +192,8 @@ ssize_t rxr_msg_post_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_entry)
 	if (OFI_UNLIKELY(err))
 		return err;
 
-	return rxr_pkt_post_ctrl_or_queue(rxr_ep, RXR_TX_ENTRY, tx_entry,
-					  RXR_LONG_MSGRTM_PKT + tagged, 0);
+	return rxr_pkt_post_ctrl(rxr_ep, RXR_TX_ENTRY, tx_entry,
+				 RXR_LONG_MSGRTM_PKT + tagged, 0);
 }
 
 ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -267,7 +267,7 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 	tx_entry->rma_loc_rx_id = rx_entry->rx_id;
 
 	if (tx_entry->total_len < ep->mtu_size - sizeof(struct rxr_readrsp_hdr)) {
-		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_SHORT_RTR_PKT, 0);
+		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_SHORT_RTR_PKT, 0);
 	} else {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
 		assert(peer);
@@ -280,7 +280,7 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 		rx_entry->window = window;
 		rx_entry->credit_cts = credits;
 		tx_entry->rma_window = rx_entry->window;
-		err = rxr_pkt_post_ctrl_or_queue(ep, RXR_TX_ENTRY, tx_entry, RXR_LONG_RTR_PKT, 0);
+		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_LONG_RTR_PKT, 0);
 	}
 
 	return err;

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -455,8 +455,10 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 	}
 
 	err = rxr_rma_post_write(rxr_ep, tx_entry);
-	if (OFI_UNLIKELY(err))
+	if (OFI_UNLIKELY(err)) {
+		rxr_tx_entry_mr_dereg(tx_entry);
 		rxr_release_tx_entry(rxr_ep, tx_entry);
+	}
 out:
 	fastlock_release(&rxr_ep->util_ep.lock);
 	rxr_perfset_end(rxr_ep, perf_rxr_tx);


### PR DESCRIPTION
This PR back ports two bug fixes to the v1.11.x branch: 

1. use rxr_ep_post_ctrl to post REQ packets

2. fix a memory registration leak in error handling path.