### PR TITLE
prov/efa: move efa_atfork_callback install to fabric init

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -998,6 +998,15 @@ int efa_fabric(struct fi_fabric_attr *attr, struct fid_fabric **fabric_fid,
 	const struct fi_info *info;
 	struct efa_fabric *fab;
 	int ret = 0;
+
+	ret = pthread_atfork(efa_atfork_callback, NULL, NULL);
+	if (ret) {
+		EFA_WARN(FI_LOG_FABRIC,
+			 "Unable to register atfork callback: %s\n",
+			 strerror(-ret));
+		return -ret;
+	}
+
 	fab = calloc(1, sizeof(*fab));
 	if (!fab)
 		return -FI_ENOMEM;
@@ -1117,13 +1126,6 @@ struct fi_provider *init_lower_efa_prov()
 		}
 
 		efa_set_rdmav_hugepages_safe = 1;
-	}
-
-	err = pthread_atfork(efa_atfork_callback, NULL, NULL);
-	if (err) {
-		EFA_WARN(FI_LOG_FABRIC,
-			 "Unable to register atfork callback\n");
-		return NULL;
 	}
 
 	if (efa_init_info(&efa_util_prov.info))


### PR DESCRIPTION
The fork handler install was moved in commit ff72bf48a9 when fixing a
bug where the rdma-core hugepage environment variable was set too late.

However, this causes the fork handler to be installed if an EFA device
is not present or if EFA is not used. We only risk corruption with fork
when it is called after the bounce buffers are allocated, registered,
and pinned, so delay installing this handler to validate that fork can
be called safely until then.

Signed-off-by: Robert Wespetal <wesper@amazon.com>

Test description: Added a fork() to fi_pingpong and verified the handler is installed when EFA is used, and it is not installed when UDP is used.