### PR TITLE
prov/verbs: Remove XRC QP temporary reservation dead code

### DIFF
--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -784,7 +784,6 @@ void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn);
 int vrb_get_shared_ini_conn(struct vrb_xrc_ep *ep,
 			       struct vrb_ini_shared_conn **ini_conn);
 void vrb_put_shared_ini_conn(struct vrb_xrc_ep *ep);
-int vrb_reserve_qpn(struct vrb_xrc_ep *ep, struct ibv_qp **qp);
 
 void vrb_save_priv_data(struct vrb_xrc_ep *ep, const void *data,
 			   size_t len);

--- a/prov/verbs/src/verbs_domain_xrc.c
+++ b/prov/verbs/src/verbs_domain_xrc.c
@@ -45,38 +45,6 @@ struct vrb_ini_conn_key {
 static int vrb_process_ini_conn(struct vrb_xrc_ep *ep,int reciprocal,
 				   void *param, size_t paramlen);
 
-/*
- * This routine is a work around that creates a QP for the only purpose of
- * reserving the QP number. The QP is not transitioned out of the RESET state.
- */
-int vrb_reserve_qpn(struct vrb_xrc_ep *ep, struct ibv_qp **qp)
-{
-	struct vrb_domain *domain = vrb_ep_to_domain(&ep->base_ep);
-	struct vrb_cq *cq = container_of(ep->base_ep.util_ep.tx_cq,
-					    struct vrb_cq, util_cq);
-	struct ibv_qp_init_attr attr = { 0 };
-	int ret;
-
-	/* Limit library allocated resources and do not INIT QP */
-	attr.cap.max_send_wr = 1;
-	attr.cap.max_send_sge = 1;
-	attr.cap.max_recv_wr = 0;
-	attr.cap.max_recv_sge = 0;
-	attr.cap.max_inline_data = 0;
-	attr.send_cq = cq->cq;
-	attr.recv_cq = cq->cq;
-	attr.qp_type = IBV_QPT_RC;
-
-	*qp = ibv_create_qp(domain->pd, &attr);
-	if (OFI_UNLIKELY(!*qp)) {
-		ret = -errno;
-		VERBS_WARN(FI_LOG_EP_CTRL,
-			   "Reservation QP create failed %d\n", -ret);
-		return ret;
-	}
-	return FI_SUCCESS;
-}
-
 static int vrb_create_ini_qp(struct vrb_xrc_ep *ep)
 {
 #if VERBS_HAVE_XRC


### PR DESCRIPTION
This code was deprecated with the SIDR connection setup
implementation for shared XRC connections and should have
been removed. No rush.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>