### PR TITLE
[v1.11.x] util/shm: add O_EXCL flag to shm_open

### DIFF
--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -151,7 +151,7 @@ int smr_create(const struct fi_provider *prov, struct smr_map *map,
 					&sar_pool_offset, &peer_data_offset,
 					&name_offset);
 
-	fd = shm_open(attr->name, O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
+	fd = shm_open(attr->name, O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
 	if (fd < 0) {
 		FI_WARN(prov, FI_LOG_EP_CTRL, "shm_open error\n");
 		return -errno;


### PR DESCRIPTION
Adding the O_EXCL flag forces the shm_open call to fail
if the shared memory region already exists. This prevents
a segfault/miscommunication which can occur when two peers
try to open an endpoint/shared memory region with the same name.

Cherry picked from commit c403cc4f

Signed-off-by: aingerson <alexia.ingerson@intel.com>