### PR TITLE
[v1.11.x] prov/efa: fix bugs in rma and atomic

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -199,6 +199,7 @@ struct rxr_env {
 	int shm_max_medium_size;
 	int recvwin_size;
 	int readcopy_pool_size;
+	int atomrsp_pool_size;
 	int cq_size;
 	size_t max_memcpy_size;
 	size_t mtu_size;
@@ -403,8 +404,7 @@ struct rxr_rx_entry {
 	struct rxr_rx_entry *master_entry;
 
 	struct rxr_pkt_entry *unexp_pkt;
-	struct rxr_pkt_entry *atomrsp_pkt;
-	char *atomrsp_buf;
+	char *atomrsp_data;
 
 #if ENABLE_DEBUG
 	/* linked with rx_pending_list in rxr_ep */
@@ -607,6 +607,11 @@ struct rxr_ep {
 	struct ofi_bufpool *map_entry_pool;
 	/* rxr medium message pkt_entry to rx_entry map */
 	struct rxr_pkt_rx_map *pkt_rx_map;
+	/*
+	 * buffer pool for atomic response data, used by
+	 * emulated fetch and compare atomic.
+	 */
+	struct ofi_bufpool *rx_atomrsp_pool;
 	/* rx_entries with recv buf */
 	struct dlist_entry rx_list;
 	/* rx_entries without recv buf (unexpected message) */

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1252,6 +1252,14 @@ int rxr_ep_init(struct rxr_ep *ep)
 	if (ret)
 		goto err_free_rx_entry_pool;
 
+	ret = ofi_bufpool_create(&ep->rx_atomrsp_pool,
+				 ep->mtu_size,
+				 RXR_BUF_POOL_ALIGNMENT,
+				 RXR_MAX_RX_QUEUE_SIZE,
+				 rxr_env.atomrsp_pool_size, 0);
+	if (ret)
+		goto err_free_map_entry_pool;
+
 	/* create pkt pool for shm */
 	if (ep->use_shm) {
 		ret = ofi_bufpool_create(&ep->tx_pkt_shm_pool,
@@ -1260,7 +1268,7 @@ int rxr_ep_init(struct rxr_ep *ep)
 					 shm_info->tx_attr->size,
 					 shm_info->tx_attr->size, 0);
 		if (ret)
-			goto err_free_map_entry_pool;
+			goto err_free_atomrsp_pool;
 
 		ret = ofi_bufpool_create(&ep->rx_pkt_shm_pool,
 					 entry_sz,
@@ -1298,6 +1306,9 @@ int rxr_ep_init(struct rxr_ep *ep)
 err_free_tx_pkt_shm_pool:
 	if (ep->tx_pkt_shm_pool)
 		ofi_bufpool_destroy(ep->tx_pkt_shm_pool);
+err_free_atomrsp_pool:
+	if (ep->rx_atomrsp_pool)
+		ofi_bufpool_destroy(ep->rx_atomrsp_pool);
 err_free_map_entry_pool:
 	if (ep->map_entry_pool)
 		ofi_bufpool_destroy(ep->map_entry_pool);

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -57,6 +57,7 @@ struct rxr_env rxr_env = {
 	.shm_max_medium_size = 4096,
 	.recvwin_size = RXR_RECVWIN_SIZE,
 	.readcopy_pool_size = 256,
+	.atomrsp_pool_size = 1024,
 	.cq_size = RXR_DEF_CQ_SIZE,
 	.max_memcpy_size = 4096,
 	.mtu_size = 0,

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -534,7 +534,7 @@ int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 {
 	struct rxr_atomrsp_hdr *atomrsp_hdr;
 
-	assert(rx_entry->atomrsp_pkt);
+	assert(rx_entry->atomrsp_data);
 	pkt_entry->addr = rx_entry->addr;
 	pkt_entry->x_entry = rx_entry;
 
@@ -548,8 +548,8 @@ int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 
 	assert(RXR_ATOMRSP_HDR_SIZE + atomrsp_hdr->seg_size < ep->mtu_size);
 
-	/* rx_entry->atomrsp_buf was filled in rxr_pkt_handle_req_recv() */
-	memcpy((char*)pkt_entry->pkt + RXR_ATOMRSP_HDR_SIZE, rx_entry->atomrsp_buf, atomrsp_hdr->seg_size);
+	/* rx_entry->atomrsp_data was filled in rxr_pkt_handle_req_recv() */
+	memcpy((char*)pkt_entry->pkt + RXR_ATOMRSP_HDR_SIZE, rx_entry->atomrsp_data, atomrsp_hdr->seg_size);
 	pkt_entry->pkt_size = RXR_ATOMRSP_HDR_SIZE + atomrsp_hdr->seg_size;
 	return 0;
 }
@@ -563,7 +563,8 @@ void rxr_pkt_handle_atomrsp_send_completion(struct rxr_ep *ep, struct rxr_pkt_en
 	struct rxr_rx_entry *rx_entry;
 	
 	rx_entry = (struct rxr_rx_entry *)pkt_entry->x_entry;
-	rxr_pkt_entry_release_tx(ep, rx_entry->atomrsp_pkt);
+	ofi_buf_free(rx_entry->atomrsp_data);
+	rx_entry->atomrsp_data = NULL;
 	rxr_release_rx_entry(ep, rx_entry);
 }
 

--- a/prov/efa/src/rxr/rxr_pkt_type_misc.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_misc.c
@@ -532,12 +532,9 @@ void rxr_pkt_handle_eor_recv(struct rxr_ep *ep,
 int rxr_pkt_init_atomrsp(struct rxr_ep *ep, struct rxr_rx_entry *rx_entry,
 			 struct rxr_pkt_entry *pkt_entry)
 {
-	size_t pkt_size;
 	struct rxr_atomrsp_hdr *atomrsp_hdr;
 
 	assert(rx_entry->atomrsp_pkt);
-	pkt_size = rx_entry->atomrsp_pkt->pkt_size;
-	pkt_entry->pkt_size = pkt_size;
 	pkt_entry->addr = rx_entry->addr;
 	pkt_entry->x_entry = rx_entry;
 

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -1759,7 +1759,7 @@ struct rxr_rx_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pk
 	rx_entry->tx_id = rta_hdr->tx_id;
 	rx_entry->total_len = ofi_total_iov_len(rx_entry->iov, rx_entry->iov_count);
 	/*
-	 * prepare a pkt entry to temporarily hold response data.
+	 * prepare a buffer to hold response data.
 	 * Atomic_op operates on 3 data buffers:
 	 *          local_data (input/output),
 	 *          request_data (input),
@@ -1767,13 +1767,13 @@ struct rxr_rx_entry *rxr_pkt_alloc_rta_rx_entry(struct rxr_ep *ep, struct rxr_pk
 	 * The fact local data will be changed by atomic_op means
 	 * response_data is not reproducible.
 	 * Because sending response packet can fail due to
-	 * -FI_EAGAIN, we need a temporary buffer to hold response_data.
-	 * This packet entry will be release in rxr_handle_atomrsp_send_completion()
+	 * -FI_EAGAIN, we need a buffer to hold response_data.
+	 * The buffer will be release in rxr_handle_atomrsp_send_completion()
 	 */
-	rx_entry->atomrsp_pkt = rxr_pkt_entry_alloc(ep, ep->tx_pkt_efa_pool);
-	if (!rx_entry->atomrsp_pkt) {
+	rx_entry->atomrsp_data = ofi_buf_alloc(ep->rx_atomrsp_pool);
+	if (!rx_entry->atomrsp_data) {
 		FI_WARN(&rxr_prov, FI_LOG_CQ,
-			"pkt entries exhausted.\n");
+			"atomic repsonse buffer pool exhausted.\n");
 		rxr_release_rx_entry(ep, rx_entry);
 		return NULL;
 	}
@@ -1800,13 +1800,12 @@ int rxr_pkt_proc_fetch_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	dtsize = ofi_datatype_size(rx_entry->atomic_hdr.datatype);
 
 	data = (char *)pkt_entry->pkt + rxr_pkt_req_hdr_size(pkt_entry);
-	rx_entry->atomrsp_buf = (char *)rx_entry->atomrsp_pkt->pkt + sizeof(struct rxr_atomrsp_hdr);
 
 	offset = 0;
 	for (i = 0; i < rx_entry->iov_count; ++i) {
 		ofi_atomic_readwrite_handlers[op][dt](rx_entry->iov[i].iov_base,
 						      data + offset,
-						      rx_entry->atomrsp_buf + offset,
+						      rx_entry->atomrsp_data + offset,
 						      rx_entry->iov[i].iov_len / dtsize);
 		offset += rx_entry->iov[i].iov_len;
 	}
@@ -1842,14 +1841,13 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 
 	src_data = (char *)pkt_entry->pkt + rxr_pkt_req_hdr_size(pkt_entry);
 	cmp_data = src_data + rx_entry->total_len;
-	rx_entry->atomrsp_buf = (char *)rx_entry->atomrsp_pkt->pkt + sizeof(struct rxr_atomrsp_hdr);
 
 	offset = 0;
 	for (i = 0; i < rx_entry->iov_count; ++i) {
 		ofi_atomic_swap_handlers[op - FI_CSWAP][dt](rx_entry->iov[i].iov_base,
 							    src_data + offset,
 							    cmp_data + offset,
-							    rx_entry->atomrsp_buf + offset,
+							    rx_entry->atomrsp_data + offset,
 							    rx_entry->iov[i].iov_len / dtsize);
 		offset += rx_entry->iov[i].iov_len;
 	}
@@ -1857,7 +1855,7 @@ int rxr_pkt_proc_compare_rta(struct rxr_ep *ep, struct rxr_pkt_entry *pkt_entry)
 	err = rxr_pkt_post_ctrl_or_queue(ep, RXR_RX_ENTRY, rx_entry, RXR_ATOMRSP_PKT, 0);
 	if (OFI_UNLIKELY(err)) {
 		efa_eq_write_error(&ep->util_ep, FI_EIO, err);
-		rxr_pkt_entry_release_tx(ep, rx_entry->atomrsp_pkt);
+		ofi_buf_free(rx_entry->atomrsp_data);
 		rxr_release_rx_entry(ep, rx_entry);
 		rxr_pkt_entry_release_rx(ep, pkt_entry);
 		return err;


### PR DESCRIPTION
Fix 2 bugs:

1. memory leak in emulated read protocol
2. use rx_atomrsp_pool for atomic response data.