### PR TITLE
prov/shm, src/hmem_ze: add IPC support for ZE

### DIFF
--- a/fabtests/common/hmem_ze.c
+++ b/fabtests/common/hmem_ze.c
@@ -71,12 +71,6 @@ static const ze_device_mem_alloc_desc_t device_desc = {
 	.ordinal	= 0,
 };
 
-static const ze_host_mem_alloc_desc_t host_desc = {
-	.stype		= ZE_STRUCTURE_TYPE_HOST_MEM_ALLOC_DESC,
-	.pNext		= NULL,
-	.flags		= 0,
-};
-
 int ft_ze_init(void)
 {
 	ze_driver_handle_t driver;
@@ -137,9 +131,8 @@ int ft_ze_cleanup(void)
 
 int ft_ze_alloc(uint64_t device, void **buf, size_t size)
 {
-	return zeMemAllocShared(context, &device_desc, &host_desc,
-				size, 16, devices[device], buf) ?
-				-FI_EINVAL : 0;
+	return zeMemAllocDevice(context, &device_desc, size, 16,
+				devices[device], buf) ? -FI_EINVAL : 0;
 }
 
 int ft_ze_free(void *buf)

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -123,6 +123,10 @@ int ze_hmem_cleanup(void);
 bool ze_is_addr_valid(const void *addr);
 int ze_hmem_get_handle(void *dev_buf, void **handle);
 int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr);
+int ze_hmem_get_shared_handle(int dev_fd, void *dev_buf, int *ze_fd,
+			      void **handle);
+int ze_hmem_open_shared_handle(int dev_fd, void **handle, int *ze_fd,
+			       uint64_t device, void **ipc_ptr);
 int ze_hmem_close_handle(void *ipc_ptr);
 bool ze_hmem_p2p_enabled(void);
 int ze_hmem_get_base_addr(const void *ptr, void **base);

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -116,6 +116,7 @@ int cuda_gdrcopy_hmem_cleanup(void);
 int cuda_gdrcopy_dev_register(struct fi_mr_attr *mr_attr, uint64_t *handle);
 int cuda_gdrcopy_dev_unregister(uint64_t handle);
 
+#define ZE_MAX_DEVICES 4
 int ze_hmem_copy(uint64_t device, void *dst, const void *src, size_t size);
 int ze_hmem_init(void);
 int ze_hmem_cleanup(void);

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2020-2021 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -123,6 +123,7 @@ bool ze_is_addr_valid(const void *addr);
 int ze_hmem_get_handle(void *dev_buf, void **handle);
 int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr);
 int ze_hmem_close_handle(void *ipc_ptr);
+bool ze_hmem_p2p_enabled(void);
 
 static inline int ofi_memcpy(uint64_t device, void *dest, const void *src,
 			     size_t size)

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -124,6 +124,7 @@ int ze_hmem_get_handle(void *dev_buf, void **handle);
 int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr);
 int ze_hmem_close_handle(void *ipc_ptr);
 bool ze_hmem_p2p_enabled(void);
+int ze_hmem_get_base_addr(const void *ptr, void **base);
 
 static inline int ofi_memcpy(uint64_t device, void *dest, const void *src,
 			     size_t size)
@@ -167,6 +168,11 @@ static inline int ofi_hmem_host_unregister_noop(void *ptr)
 	return FI_SUCCESS;
 }
 
+static inline int ofi_hmem_no_base_addr(const void *ptr, void **base)
+{
+	return -FI_ENOSYS;
+}
+
 ssize_t ofi_copy_from_hmem_iov(void *dest, size_t size,
 			       enum fi_hmem_iface hmem_iface, uint64_t device,
 			       const struct iovec *hmem_iov,
@@ -181,6 +187,8 @@ int ofi_hmem_get_handle(enum fi_hmem_iface iface, void *dev_buf, void **handle);
 int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
 			 uint64_t device, void **ipc_ptr);
 int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *ipc_ptr);
+int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *ptr,
+			   void **base);
 
 void ofi_hmem_init(void);
 void ofi_hmem_cleanup(void);

--- a/include/ofi_hmem.h
+++ b/include/ofi_hmem.h
@@ -125,6 +125,7 @@ int ze_hmem_open_handle(void **handle, uint64_t device, void **ipc_ptr);
 int ze_hmem_close_handle(void *ipc_ptr);
 bool ze_hmem_p2p_enabled(void);
 int ze_hmem_get_base_addr(const void *ptr, void **base);
+int *ze_hmem_get_dev_fds(int *nfds);
 
 static inline int ofi_memcpy(uint64_t device, void *dest, const void *src,
 			     size_t size)

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -132,7 +132,12 @@ struct smr_msg_hdr {
 struct smr_ipc_info {
 	uint64_t	iface;
 	union {
-		uint8_t	ipc_handle[IPC_HANDLE_SIZE];
+		uint8_t		ipc_handle[IPC_HANDLE_SIZE];
+		struct {
+			uint64_t	device;
+			uint64_t	offset;
+			uint64_t	fd_handle;
+		};
 	};
 };
 

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -66,6 +66,8 @@ extern "C" {
 #define SMR_FLAG_DEBUG	(0 << 1)
 #endif
 
+#define SMR_FLAG_IPC_SOCK (1 << 2)
+
 #define SMR_CMD_SIZE		128	/* align with 64-byte cache line */
 
 /* SMR op_src: Specifies data source location */

--- a/include/ofi_shm.h
+++ b/include/ofi_shm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Intel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -129,6 +129,7 @@ struct smr_tx_entry {
 	struct smr_ep_name *map_name;
 	enum fi_hmem_iface	iface;
 	uint64_t		device;
+	int			fd;
 };
 
 struct smr_sar_entry {
@@ -323,6 +324,10 @@ void smr_format_inject(struct smr_cmd *cmd, enum fi_hmem_iface iface, uint64_t d
 void smr_format_iov(struct smr_cmd *cmd, const struct iovec *iov, size_t count,
 		    size_t total_len, struct smr_region *smr,
 		    struct smr_resp *resp);
+int smr_format_ze_ipc(struct smr_ep *ep, int64_t id, struct smr_cmd *cmd,
+		      const struct iovec *iov, uint64_t device,
+		      size_t total_len, struct smr_region *smr,
+		      struct smr_resp *resp, struct smr_tx_entry *pend);
 int smr_format_mmap(struct smr_ep *ep, struct smr_cmd *cmd,
 		    const struct iovec *iov, size_t count, size_t total_len,
 		    struct smr_tx_entry *pend, struct smr_resp *resp);
@@ -373,6 +378,13 @@ static inline bool smr_cma_enabled(struct smr_ep *ep,
 		return ep->region->cma_cap_self == SMR_CMA_CAP_ON;
 	else
 		return ep->region->cma_cap_peer == SMR_CMA_CAP_ON;
+}
+
+static inline bool smr_ze_ipc_enabled(struct smr_region *smr,
+				      struct smr_region *peer_smr)
+{
+	return (smr->flags & SMR_FLAG_IPC_SOCK) &&
+	       (peer_smr->flags & SMR_FLAG_IPC_SOCK);
 }
 
 static inline int smr_cma_loop(pid_t pid, struct iovec *local,

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel Corporation, Inc.  All rights reserved.
+ * Copyright (c) 2015-2021 Intel Corporation, Inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved
+ * Copyright (c) 2013-2021 Intel Corporation. All rights reserved
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -654,6 +654,12 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 		ret = smr_create(&smr_prov, av->smr_map, &attr, &ep->region);
 		if (ret)
 			return ret;
+
+		if (ep->util_ep.caps & FI_HMEM) {
+			ep->region->cma_cap_peer = SMR_CMA_CAP_OFF;
+			ep->region->cma_cap_self = SMR_CMA_CAP_OFF;
+		}
+
 		smr_exchange_all_peers(ep->region);
 		break;
 	default:

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/uio.h>
+#include <sys/un.h>
 
 #include "ofi_iov.h"
 #include "ofi_hmem.h"
@@ -42,6 +43,8 @@ extern struct fi_ops_msg smr_msg_ops;
 extern struct fi_ops_tagged smr_tagged_ops;
 extern struct fi_ops_rma smr_rma_ops;
 extern struct fi_ops_atomic smr_atomic_ops;
+DEFINE_LIST(sock_name_list);
+pthread_mutex_t sock_list_lock = PTHREAD_MUTEX_INITIALIZER;
 
 int smr_setname(fid_t fid, void *addr, size_t addrlen)
 {
@@ -509,11 +512,26 @@ void smr_format_sar(struct smr_cmd *cmd, enum fi_hmem_iface iface, uint64_t devi
 				&pending->bytes_done, &pending->next);
 }
 
+static void smr_cleanup_epoll(struct smr_sock_info *sock_info)
+{
+	fd_signal_free(&sock_info->signal);
+	ofi_epoll_close(sock_info->epollfd);
+}
+
 static int smr_ep_close(struct fid *fid)
 {
 	struct smr_ep *ep;
 
 	ep = container_of(fid, struct smr_ep, util_ep.ep_fid.fid);
+
+	if (ep->sock_info) {
+		fd_signal_set(&ep->sock_info->signal);
+		pthread_join(ep->sock_info->listener_thread, NULL);
+		close(ep->sock_info->listen_sock);
+		unlink(ep->sock_info->name);
+		smr_cleanup_epoll(ep->sock_info);
+		free(ep->sock_info);
+	}
 
 	ofi_endpoint_close(&ep->util_ep);
 
@@ -631,6 +649,336 @@ static int smr_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 	return ret;
 }
 
+static int smr_sendmsg_fd(int sock, int64_t id, int64_t peer_id,
+			  int *fds, int nfds)
+{
+	struct msghdr msg;
+	struct cmsghdr *cmsg;
+	struct iovec iov;
+	char *ctrl_buf;
+	size_t ctrl_size;
+	int ret;
+
+	ctrl_size = sizeof(*fds) * nfds;
+	ctrl_buf = calloc(CMSG_SPACE(ctrl_size), 1);
+	if (!ctrl_buf)
+		return -FI_ENOMEM;
+
+	iov.iov_base = &peer_id;
+	iov.iov_len = sizeof(peer_id);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_control = ctrl_buf;
+	msg.msg_controllen = CMSG_SPACE(ctrl_size);
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_RIGHTS;
+	cmsg->cmsg_len = CMSG_LEN(ctrl_size);
+	memcpy(CMSG_DATA(cmsg), fds, ctrl_size);
+
+	ret = sendmsg(sock, &msg, 0);
+	if (ret == sizeof(peer_id)) {
+		ret = FI_SUCCESS;
+	} else {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "sendmsg error\n");
+		ret = -FI_EIO;
+	}
+
+	free(ctrl_buf);
+	return ret;
+}
+
+static int smr_recvmsg_fd(int sock, int64_t *peer_id, int *fds, int nfds)
+{
+	struct msghdr msg;
+	struct cmsghdr *cmsg;
+	struct iovec iov;
+	char *ctrl_buf;
+	size_t ctrl_size;
+	int ret;
+
+	ctrl_size = sizeof(*fds) * nfds;
+	ctrl_buf = calloc(CMSG_SPACE(ctrl_size), 1);
+	if (!ctrl_buf)
+		return -FI_ENOMEM;
+
+	iov.iov_base = peer_id;
+	iov.iov_len = sizeof(*peer_id);
+
+	memset(&msg, 0, sizeof(msg));
+	msg.msg_control = ctrl_buf;
+	msg.msg_controllen = CMSG_SPACE(ctrl_size);
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	ret = recvmsg(sock, &msg, 0);
+	if (ret == sizeof(*peer_id)) {
+		ret = FI_SUCCESS;
+	} else {
+		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "recvmsg error\n");
+		ret = -FI_EIO;
+		goto out;
+	}
+
+	assert(!(msg.msg_flags & (MSG_TRUNC | MSG_CTRUNC)));
+	cmsg = CMSG_FIRSTHDR(&msg);
+	assert(cmsg && cmsg->cmsg_len == CMSG_LEN(ctrl_size) &&
+	       cmsg->cmsg_level == SOL_SOCKET &&
+	       cmsg->cmsg_type == SCM_RIGHTS);
+	memcpy(fds, CMSG_DATA(cmsg), ctrl_size);
+out:
+	free(ctrl_buf);
+	return ret;
+}
+
+static void *smr_start_listener(void *args)
+{
+	struct smr_ep *ep = (struct smr_ep *) args;
+	struct sockaddr_un sockaddr;
+	void *ctx[SMR_MAX_PEERS + 1];
+	int i, ret, poll_fds, sock = -1;
+	int peer_fds[ZE_MAX_DEVICES];
+	socklen_t len;
+	int64_t id, peer_id;
+
+	ep->region->flags |= SMR_FLAG_IPC_SOCK;
+	while (1) {
+		poll_fds = ofi_epoll_wait(ep->sock_info->epollfd, ctx,
+					  SMR_MAX_PEERS + 1, -1);
+
+		if (poll_fds < 0) {
+			FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+				"epoll error\n");
+			continue;
+		}
+
+		for (i = 0; i < poll_fds; i++) {
+			if (!ctx[i])
+				goto out;
+
+			sock = accept(ep->sock_info->listen_sock,
+				      (struct sockaddr *) &sockaddr, &len);
+			if (sock < 0) {
+				FI_WARN(&smr_prov, FI_LOG_EP_CTRL,
+					"accept error\n");
+				continue;
+			}
+
+			FI_DBG(&smr_prov, FI_LOG_EP_CTRL,
+			       "EP accepted connection request from %s\n",
+			       sockaddr.sun_path);
+
+			ret = smr_recvmsg_fd(sock, &id, peer_fds,
+					     ep->sock_info->nfds);
+			if (!ret) {
+				memcpy(ep->sock_info->peers[id].device_fds,
+				       peer_fds, sizeof(*peer_fds) *
+				       ep->sock_info->nfds);
+
+				peer_id = smr_peer_data(ep->region)[id].addr.id;
+				ret = smr_sendmsg_fd(sock, id, peer_id,
+						ep->sock_info->my_fds,
+						ep->sock_info->nfds);
+				ep->sock_info->peers[id].state =
+					ret ? SMR_CMAP_FAILED :
+					SMR_CMAP_SUCCESS;
+			}
+
+			close(sock);
+			sock = -1;
+			unlink(sockaddr.sun_path);
+		}
+	}
+out:
+	close(ep->sock_info->listen_sock);
+	unlink(ep->sock_info->name);
+	return NULL;
+}
+
+static int smr_init_epoll(struct smr_sock_info *sock_info)
+{
+	int ret;
+
+	ret = ofi_epoll_create(&sock_info->epollfd);
+	if (ret < 0)
+		return ret;
+
+	ret = fd_signal_init(&sock_info->signal);
+	if (ret < 0)
+		goto err2;
+
+	ret = ofi_epoll_add(sock_info->epollfd,
+	                    sock_info->signal.fd[FI_READ_FD],
+	                    OFI_EPOLL_IN, NULL);
+	if (ret != 0)
+		goto err1;
+
+	ret = ofi_epoll_add(sock_info->epollfd, sock_info->listen_sock,
+			    OFI_EPOLL_IN, sock_info);
+	if (ret != 0)
+		goto err1;
+
+	return FI_SUCCESS;
+err1:
+	ofi_epoll_close(sock_info->epollfd);
+err2:
+	fd_signal_free(&sock_info->signal);
+	return ret;
+}
+
+void smr_ep_exchange_fds(struct smr_ep *ep, int64_t id)
+{
+	struct smr_region *peer_smr = smr_peer_region(ep->region, id);
+	struct sockaddr_un server_sockaddr = {0}, client_sockaddr = {0};
+	char *name1, *name2;
+	int ret = -1, sock = -1;
+	int64_t peer_id;
+	int peer_fds[ZE_MAX_DEVICES];
+
+	if (peer_smr->pid == ep->region->pid ||
+	    !(peer_smr->flags & SMR_FLAG_IPC_SOCK))
+		goto out;
+
+	sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sock < 0)
+		goto out;
+
+	if (strcmp(smr_sock_name(ep->region), smr_sock_name(peer_smr)) < 1) {
+		name1 = smr_sock_name(ep->region);
+		name2 = smr_sock_name(peer_smr);
+	} else {
+		name1 = smr_sock_name(peer_smr);
+		name2 = smr_sock_name(ep->region);
+	}
+	client_sockaddr.sun_family = AF_UNIX;
+	snprintf(client_sockaddr.sun_path, SMR_SOCK_NAME_MAX, "%s%s:%s",
+		 SMR_ZE_SOCK_PATH, name1, name2);
+
+	ret = bind(sock, (struct sockaddr *) &client_sockaddr,
+		  (socklen_t) sizeof(client_sockaddr));
+	if (ret == -1) {
+		if (errno != EADDRINUSE) {
+			FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "bind error\n");
+			ep->sock_info->peers[id].state = SMR_CMAP_FAILED;
+		}
+		close(sock);
+		return;
+	}
+
+	server_sockaddr.sun_family = AF_UNIX;
+	snprintf(server_sockaddr.sun_path, SMR_SOCK_NAME_MAX, "%s%s",
+		 SMR_ZE_SOCK_PATH, smr_sock_name(peer_smr));
+
+	ret = connect(sock, (struct sockaddr *) &server_sockaddr,
+		      sizeof(server_sockaddr));
+	if (ret == -1)
+		goto cleanup;
+
+	FI_DBG(&smr_prov, FI_LOG_EP_CTRL, "EP connected to UNIX socket %s\n",
+	       server_sockaddr.sun_path);
+
+	peer_id = smr_peer_data(ep->region)[id].addr.id;
+	ret = smr_sendmsg_fd(sock, id, peer_id, ep->sock_info->my_fds,
+			     ep->sock_info->nfds);
+	if (ret)
+		goto cleanup;
+
+	ret = smr_recvmsg_fd(sock, &id, peer_fds, ep->sock_info->nfds);
+	if (ret)
+		goto cleanup;
+
+	memcpy(ep->sock_info->peers[id].device_fds, peer_fds,
+	       sizeof(*peer_fds) * ep->sock_info->nfds);
+
+cleanup:
+	close(sock);
+	unlink(client_sockaddr.sun_path);
+out:
+	ep->sock_info->peers[id].state = ret ?
+		SMR_CMAP_FAILED : SMR_CMAP_SUCCESS;
+}
+
+static void smr_init_ipc_socket(struct smr_ep *ep)
+{
+	struct smr_domain *domain;
+	struct smr_sock_name *sock_name;
+	struct sockaddr_un sockaddr = {0};
+	int ret;
+
+	ep->sock_info = calloc(1, sizeof(*ep->sock_info));
+	if (!ep->sock_info)
+		goto err_out;
+
+	ep->sock_info->listen_sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (ep->sock_info->listen_sock < 0)
+		goto free;
+
+	domain = container_of(ep->util_ep.domain, struct smr_domain, util_domain);
+	snprintf(smr_sock_name(ep->region), SMR_SOCK_NAME_MAX,
+		 "%ld:%d:%d", (long) ep->region->pid, domain->dom_idx,
+		 ep->ep_idx);
+
+	sockaddr.sun_family = AF_UNIX;
+	snprintf(sockaddr.sun_path, SMR_SOCK_NAME_MAX,
+		 "%s%s", SMR_ZE_SOCK_PATH, smr_sock_name(ep->region));
+
+	ret = bind(ep->sock_info->listen_sock, (struct sockaddr *) &sockaddr,
+		   (socklen_t) sizeof(sockaddr));
+	if (ret)
+		goto close;
+
+	ret = listen(ep->sock_info->listen_sock, SMR_MAX_PEERS);
+	if (ret)
+		goto close;
+
+	FI_DBG(&smr_prov, FI_LOG_EP_CTRL, "EP listening on UNIX socket %s\n",
+	       sockaddr.sun_path);
+
+	ret = smr_init_epoll(ep->sock_info);
+	if (ret)
+		goto close;
+
+	sock_name = calloc(1, sizeof(*sock_name));
+	if (!sock_name)
+		goto cleanup;
+
+	memcpy(sock_name->name, sockaddr.sun_path, strlen(sockaddr.sun_path));
+	memcpy(ep->sock_info->name, sockaddr.sun_path,
+	       strlen(sockaddr.sun_path));
+
+	pthread_mutex_lock(&sock_list_lock);
+	dlist_insert_tail(&sock_name->entry, &sock_name_list);
+	pthread_mutex_unlock(&sock_list_lock);
+
+	ep->sock_info->my_fds = ze_hmem_get_dev_fds(&ep->sock_info->nfds);
+	ret = pthread_create(&ep->sock_info->listener_thread, NULL,
+			     &smr_start_listener, ep);
+	if (ret)
+		goto remove;
+
+	return;
+
+remove:
+	pthread_mutex_lock(&sock_list_lock);
+	dlist_remove(&sock_name->entry);
+	pthread_mutex_unlock(&sock_list_lock);
+	free(sock_name);
+cleanup:
+	smr_cleanup_epoll(ep->sock_info);
+close:
+	close(ep->sock_info->listen_sock);
+	unlink(sockaddr.sun_path);
+free:
+	free(ep->sock_info);
+	ep->sock_info = NULL;
+err_out:
+	FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "Unable to initialize IPC socket."
+		"Defaulting to SAR for device transfers\n");
+}
+
 static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 {
 	struct smr_attr attr;
@@ -658,6 +1006,8 @@ static int smr_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (ep->util_ep.caps & FI_HMEM) {
 			ep->region->cma_cap_peer = SMR_CMA_CAP_OFF;
 			ep->region->cma_cap_self = SMR_CMA_CAP_OFF;
+			if (ze_hmem_p2p_enabled())
+				smr_init_ipc_socket(ep);
 		}
 
 		smr_exchange_all_peers(ep->region);
@@ -699,7 +1049,7 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 {
 	struct smr_ep *ep;
 	struct smr_domain *smr_domain;
-	int ret, ep_idx;
+	int ret;
 	char name[SMR_NAME_MAX];
 
 	ep = calloc(1, sizeof(*ep));
@@ -709,13 +1059,12 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 	smr_domain = container_of(domain, struct smr_domain, util_domain.domain_fid);
 
 	fastlock_acquire(&smr_domain->util_domain.lock);
-	ep_idx = smr_domain->ep_idx++;
+	ep->ep_idx = smr_domain->ep_idx++;
 	fastlock_release(&smr_domain->util_domain.lock);
 	ret = smr_endpoint_name(name, info->src_addr, info->src_addrlen,
-			        smr_domain->dom_idx, ep_idx);
+			        smr_domain->dom_idx, ep->ep_idx);
 	if (ret)
 		goto err2;
-
 	ret = smr_setname(&ep->util_ep.ep_fid.fid, name, SMR_NAME_MAX);
 	if (ret)
 		goto err2;

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -99,7 +99,8 @@ static int smr_shm_space_check(size_t tx_count, size_t rx_count)
 	shm_size_needed = num_of_core *
 			  smr_calculate_size_offsets(tx_count, rx_count,
 						     NULL, NULL, NULL,
-						     NULL, NULL, NULL);
+						     NULL, NULL, NULL,
+						     NULL);
 	err = statvfs(shm_fs, &stat);
 	if (err) {
 		FI_WARN(&smr_prov, FI_LOG_CORE,

--- a/prov/shm/src/smr_init.c
+++ b/prov/shm/src/smr_init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2015-2021 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved
+ * Copyright (c) 2013-2021 Intel Corporation. All rights reserved
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -213,8 +213,13 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
 				       resp);
 		} else {
-			if (total_len <= smr_env.sar_threshold ||
-			    iface != FI_HMEM_SYSTEM) {
+			if (iface == FI_HMEM_ZE && iov_count == 1 &&
+			    smr_ze_ipc_enabled(ep->region, peer_smr)) {
+				ret = smr_format_ze_ipc(ep, id, cmd, iov,
+					device, total_len, ep->region,
+					resp, pend);
+			} else if (total_len <= smr_env.sar_threshold ||
+				   iface != FI_HMEM_SYSTEM) {
 				if (!peer_smr->sar_cnt) {
 					ret = -FI_EAGAIN;
 				} else {

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel Corporation. All rights reserved
+ * Copyright (c) 2013-2021 Intel Corporation. All rights reserved
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -181,7 +181,12 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
 				       resp);
 		} else {
-			if (total_len <= smr_env.sar_threshold ||
+			if (iface == FI_HMEM_ZE && iov_count == 1 &&
+			    smr_ze_ipc_enabled(ep->region, peer_smr)) {
+				ret = smr_format_ze_ipc(ep, id, cmd, iov,
+					device, total_len, ep->region,
+					resp, pend);
+			} else if (total_len <= smr_env.sar_threshold ||
 			    iface != FI_HMEM_SYSTEM) {
 				if (!peer_smr->sar_cnt) {
 					ret = -FI_EAGAIN;

--- a/prov/shm/src/smr_signal.h
+++ b/prov/shm/src/smr_signal.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019 Amazon.com, Inc. or its affiliates.
+ * Copyright (c) 2020-2021 Intel Corporation.
  * All rights reserved.
  *
  * This software is available to you under a choice of one of two

--- a/prov/shm/src/smr_signal.h
+++ b/prov/shm/src/smr_signal.h
@@ -41,11 +41,16 @@ struct sigaction *old_action;
 static void smr_handle_signal(int signum, siginfo_t *info, void *ucontext)
 {
 	struct smr_ep_name *ep_name;
+	struct smr_sock_name *sock_name;
 	int ret;
 
 	dlist_foreach_container(&ep_name_list, struct smr_ep_name,
 				ep_name, entry) {
 		shm_unlink(ep_name->name);
+	}
+	dlist_foreach_container(&sock_name_list, struct smr_sock_name,
+				sock_name, entry) {
+		unlink(sock_name->name);
 	}
 
 	/* Register the original signum handler, SIG_DFL or otherwise */

--- a/prov/util/src/util_shm.c
+++ b/prov/util/src/util_shm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017 Intel Corporation. All rights reserved.
+ * Copyright (c) 2016-2021 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -1,5 +1,6 @@
 /*
  * (C) Copyright 2020 Hewlett Packard Enterprise Development LP
+ * (C) Copyright 2020-2021 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/src/hmem.c
+++ b/src/hmem.c
@@ -52,6 +52,7 @@ struct ofi_hmem_ops {
 	int (*close_handle)(void *ipc_ptr);
 	int (*host_register)(void *ptr, size_t size);
 	int (*host_unregister)(void *ptr);
+	int (*get_base_addr)(const void *ptr, void **base);
 };
 
 static struct ofi_hmem_ops hmem_ops[] = {
@@ -66,6 +67,7 @@ static struct ofi_hmem_ops hmem_ops[] = {
 		.close_handle = ofi_hmem_no_close_handle,
 		.host_register = ofi_hmem_register_noop,
 		.host_unregister = ofi_hmem_host_unregister_noop,
+		.get_base_addr = ofi_hmem_no_base_addr,
 	},
 	[FI_HMEM_CUDA] = {
 		.initialized = false,
@@ -79,6 +81,7 @@ static struct ofi_hmem_ops hmem_ops[] = {
 		.close_handle = ofi_hmem_no_close_handle,
 		.host_register = cuda_host_register,
 		.host_unregister = cuda_host_unregister,
+		.get_base_addr = ofi_hmem_no_base_addr,
 	},
 	[FI_HMEM_ROCR] = {
 		.initialized = false,
@@ -92,6 +95,7 @@ static struct ofi_hmem_ops hmem_ops[] = {
 		.close_handle = ofi_hmem_no_close_handle,
 		.host_register = rocr_host_register,
 		.host_unregister = rocr_host_unregister,
+		.get_base_addr = ofi_hmem_no_base_addr,
 	},
 	[FI_HMEM_ZE] = {
 		.initialized = false,
@@ -105,6 +109,7 @@ static struct ofi_hmem_ops hmem_ops[] = {
 		.close_handle = ze_hmem_close_handle,
 		.host_register = ofi_hmem_register_noop,
 		.host_unregister = ofi_hmem_host_unregister_noop,
+		.get_base_addr = ze_hmem_get_base_addr,
 	},
 };
 
@@ -199,6 +204,12 @@ int ofi_hmem_open_handle(enum fi_hmem_iface iface, void **handle,
 int ofi_hmem_close_handle(enum fi_hmem_iface iface, void *ipc_ptr)
 {
 	return hmem_ops[iface].close_handle(ipc_ptr);
+}
+
+int ofi_hmem_get_base_addr(enum fi_hmem_iface iface, const void *ptr,
+			   void **base)
+{
+	return hmem_ops[iface].get_base_addr(ptr, base);
 }
 
 void ofi_hmem_init(void)

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -42,8 +42,6 @@
 #include <dirent.h>
 #include <level_zero/ze_api.h>
 
-#define ZE_MAX_DEVICES 4
-
 static ze_context_handle_t context;
 static ze_device_handle_t devices[ZE_MAX_DEVICES];
 static ze_command_queue_handle_t cmd_queue[ZE_MAX_DEVICES];

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -234,6 +234,20 @@ bool ze_hmem_p2p_enabled(void)
 	return p2p_enabled;
 }
 
+int ze_hmem_get_base_addr(const void *ptr, void **base)
+{
+	ze_result_t ze_ret;
+	size_t size;
+
+	ze_ret = zeMemGetAddressRange(context, ptr, base, &size);
+	if (ze_ret) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"Could not get base addr\n");
+		return -FI_EINVAL;
+	}
+	return FI_SUCCESS;
+}
+
 #else
 
 int ze_hmem_init(void)
@@ -274,6 +288,11 @@ int ze_hmem_close_handle(void *ipc_ptr)
 bool ze_hmem_p2p_enabled(void)
 {
 	return false;
+}
+
+int ze_hmem_get_base_addr(const void *ptr, void **base)
+{
+	return -FI_ENOSYS;
 }
 
 #endif /* HAVE_LIBZE */

--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Intel Corporation. All rights reserved.
+ * Copyright (c) 2020-2021 Intel Corporation. All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU


### PR DESCRIPTION
First draft of various fixes/additions for shm L0 IPC support.

Fabtests:
- Change Shared allocation to Device allocation for L0 interface

HMEM:
- Add get base address function for interfaces that require base address in IPC use

L0:
- Add p2p check for L0
- Add shareable handle get and open functions

shm:
- Disable CMA when HMEM interfaces are enabled
- Add shm unix socket name to shm region
- Add unix domain socket when L0 interfaces are enabled for device fd exchange
- Add L0 IPC protocol