### PR TITLE
prov/efa: switch to userfaultd monitor for MR cache

### DIFF
--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -212,7 +212,7 @@ int efa_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	bool app_mr_local;
 	int ret;
 	struct ofi_mem_monitor *memory_monitors[OFI_HMEM_MAX] = {
-		[FI_HMEM_SYSTEM] = memhooks_monitor,
+		[FI_HMEM_SYSTEM] = uffd_monitor,
 	};
 
 	fi = efa_get_efa_info(info->domain_attr->name);


### PR DESCRIPTION
Currently, EFA uses memhooks monitor for MR cache.

The Open MPI btl/ofi component uses the same memhook
monitor for its own MR cache, and only one set of
memhooks can be registered for the memory operations.
In this case, btl/ofi's memhooks were overwritten
by libfabric's memhooks, causing data corruption.

Note, EFA used to use userfaultd monitor but switched
to memhooks monitor in commit 7fcf46c to address
the dereg-after-free issue, which is that userfaulted
requires MR cache to defer memory de-registration to
after memory was freed. However, the fork support in
rdma-core assumes memory regions are deregistered before
they are freed, and fork support + dereg-after-free
would cause data corruption.

We implemented the dereg-before-free behavior and switched
to use memhooks monitor. but later found out such a combination
would cause hang on certain glibc version. So we had
to revert the behavior back to dereg-after-free in 2c96a52.

Also, we added a commit to abort if rdma-core fork() support
has been enabled.

With these changes, there is no real advantage of using memhooks
monitor over using userfaulted monitor.

To address the double memhook issue, this patch switch to use
userfaultd monitor for MR cache.
Signed-off-by: Wei Zhang <wzam@amazon.com>