### PR TITLE
includ/ofi.h : fix a bug in ofi_get_page_bytes()

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -266,8 +266,13 @@ static inline void *ofi_get_page_end(const void *addr, size_t page_size)
 static inline size_t
 ofi_get_page_bytes(const void *addr, size_t len, size_t page_size)
 {
-	return (char *)ofi_get_page_end((const char *) addr + len, page_size) -
-	       (char *)ofi_get_page_start(addr, page_size);
+	char *start = ofi_get_page_start(addr, page_size);
+	char *end = (char *)ofi_get_page_start((const char*)addr + len - 1, page_size)
+		    + page_size;
+	size_t result = end - start;
+
+	assert(result % page_size == 0);
+	return result;
 }
 
 #define FI_TAG_GENERIC	0xAAAAAAAAAAAAAAAAULL


### PR DESCRIPTION
The function ofi_get_page_bytes() is expected to return a value
which is multiple of page_size, but it is not doing that currently.

This is because a recent change to function ofi_get_page_end(),
which is used by ofi_get_page_bytes().

Ths patch address the issue by not using ofi_get_page_end() to
calcuated the ending address.

Signed-off-by: Wei Zhang <wzam@amazon.com>