### PR TITLE
prov/efa: handle cq error with read entry

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -246,6 +246,7 @@ enum rxr_lower_ep_type {
 enum rxr_x_entry_type {
 	RXR_TX_ENTRY = 1,
 	RXR_RX_ENTRY,
+	RXR_READ_ENTRY,
 };
 
 enum rxr_tx_comm_type {

--- a/prov/efa/src/rxr/rxr_cq.c
+++ b/prov/efa/src/rxr/rxr_cq.c
@@ -40,6 +40,7 @@
 #include "rxr_rma.h"
 #include "rxr_msg.h"
 #include "rxr_cntr.h"
+#include "rxr_read.h"
 #include "rxr_atomic.h"
 #include "efa.h"
 
@@ -305,6 +306,7 @@ int rxr_cq_handle_cq_error(struct rxr_ep *ep, ssize_t err)
 	struct rxr_pkt_entry *pkt_entry;
 	struct rxr_rx_entry *rx_entry;
 	struct rxr_tx_entry *tx_entry;
+	struct rxr_read_entry *read_entry;
 	struct rxr_peer *peer;
 	ssize_t ret;
 
@@ -427,6 +429,14 @@ int rxr_cq_handle_cq_error(struct rxr_ep *ep, ssize_t err)
 					  &ep->rx_entry_queued_list);
 		}
 		return 0;
+	} else if (RXR_GET_X_ENTRY_TYPE(pkt_entry) == RXR_READ_ENTRY) {
+		read_entry = (struct rxr_read_entry *)pkt_entry->x_entry;
+		/* read requests is not expected to get RNR, so we call
+		 * rxr_read_handle_error() to handle general error here.
+		 */
+		ret = rxr_read_handle_error(ep, read_entry, err_entry.prov_errno);
+		rxr_pkt_entry_release_tx(ep, pkt_entry);
+		return ret;
 	}
 
 	FI_WARN(&rxr_prov, FI_LOG_CQ,

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1712,6 +1712,7 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 		if (OFI_UNLIKELY(ret))
 			goto read_err;
 
+		read_entry->state = RXR_RDMA_ENTRY_SUBMITTED;
 		dlist_remove(&read_entry->pending_entry);
 	}
 

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -205,6 +205,7 @@ struct rxr_read_entry *rxr_read_alloc_entry(struct rxr_ep *ep, int entry_type, v
 		return NULL;
 	}
 
+	read_entry->type = RXR_READ_ENTRY;
 	read_entry->read_id = ofi_buf_index(read_entry);
 	read_entry->state = RXR_RDMA_ENTRY_CREATED;
 

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -622,7 +622,8 @@ int rxr_read_handle_error(struct rxr_ep *ep, struct rxr_read_entry *read_entry, 
 		ret = rxr_cq_handle_rx_error(ep, rx_entry, ret);
 	}
 
-	dlist_remove(&read_entry->pending_entry);
+	if (read_entry->state == RXR_RDMA_ENTRY_PENDING)
+		dlist_remove(&read_entry->pending_entry);
 	return ret;
 }
 

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -75,6 +75,7 @@ enum rxr_read_entry_state {
  * rxr_read_entry contains the information of a read request
  */
 struct rxr_read_entry {
+	enum rxr_x_entry_type type;
 	int read_id;
 	enum rxr_lower_ep_type lower_ep_type;
 

--- a/prov/efa/src/rxr/rxr_read.h
+++ b/prov/efa/src/rxr/rxr_read.h
@@ -68,7 +68,8 @@ enum rxr_read_context_type {
 enum rxr_read_entry_state {
 	RXR_RDMA_ENTRY_FREE = 0,
 	RXR_RDMA_ENTRY_CREATED,
-	RXR_RDMA_ENTRY_PENDING
+	RXR_RDMA_ENTRY_PENDING,
+	RXR_RDMA_ENTRY_SUBMITTED,
 };
 
 /*


### PR DESCRIPTION
This PR contains 4 commits that correctly handle the case when lower provider returned an error cq entry and the pkt_entry->x_entry is of type rxr_read_entry.