### PR TITLE
prov/tcp: Flush outstanding operations when disabling the EP

### DIFF
--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -301,15 +301,13 @@ int tcpx_read_to_buffer(SOCKET sock, struct stage_buf *stage_buf);
 
 struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *cq,
 					      enum tcpx_xfer_op_codes type);
-
-void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
-			     struct tcpx_xfer_entry *xfer_entry);
-void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
-			   struct tcpx_xfer_entry *xfer_entry);
-
-void tcpx_rx_msg_release(struct tcpx_xfer_entry *rx_entry);
-struct tcpx_xfer_entry *tcpx_srx_get_entry(struct tcpx_rx_ctx *srx_ctx,
-					   struct tcpx_ep *ep);
+struct tcpx_xfer_entry *tcpx_srx_entry_alloc(struct tcpx_rx_ctx *srx_ctx,
+					     struct tcpx_ep *ep);
+void tcpx_xfer_entry_free(struct tcpx_cq *tcpx_cq,
+			  struct tcpx_xfer_entry *xfer_entry);
+void tcpx_srx_entry_free(struct tcpx_rx_ctx *srx_ctx,
+			 struct tcpx_xfer_entry *xfer_entry);
+void tcpx_rx_entry_free(struct tcpx_xfer_entry *rx_entry);
 
 void tcpx_progress_tx(struct tcpx_ep *ep);
 void tcpx_progress_rx(struct tcpx_ep *ep);

--- a/prov/tcp/src/tcpx_cq.c
+++ b/prov/tcp/src/tcpx_cq.c
@@ -125,8 +125,8 @@ struct tcpx_xfer_entry *tcpx_xfer_entry_alloc(struct tcpx_cq *tcpx_cq,
 	return xfer_entry;
 }
 
-void tcpx_xfer_entry_release(struct tcpx_cq *tcpx_cq,
-			     struct tcpx_xfer_entry *xfer_entry)
+void tcpx_xfer_entry_free(struct tcpx_cq *tcpx_cq,
+			  struct tcpx_xfer_entry *xfer_entry)
 {
 	if (xfer_entry->ep->cur_rx_entry == xfer_entry)
 		xfer_entry->ep->cur_rx_entry = NULL;

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -193,7 +193,7 @@ static void tcpx_ep_flush_queue(struct slist *queue,
 					  entry);
 		slist_remove_head(queue);
 		tcpx_cq_report_error(&tcpx_cq->util_cq, xfer_entry, FI_ECANCELED);
-		tcpx_xfer_entry_release(tcpx_cq, xfer_entry);
+		tcpx_xfer_entry_free(tcpx_cq, xfer_entry);
 	}
 }
 
@@ -406,18 +406,18 @@ static struct fi_ops_cm tcpx_cm_ops = {
 	.join = fi_no_join,
 };
 
-void tcpx_rx_msg_release(struct tcpx_xfer_entry *rx_entry)
+void tcpx_rx_entry_free(struct tcpx_xfer_entry *rx_entry)
 {
 	struct tcpx_cq *tcpx_cq;
 
 	assert(rx_entry->hdr.base_hdr.op_data == TCPX_OP_MSG_RECV);
 
 	if (rx_entry->ep->srx_ctx) {
-		tcpx_srx_xfer_release(rx_entry->ep->srx_ctx, rx_entry);
+		tcpx_srx_entry_free(rx_entry->ep->srx_ctx, rx_entry);
 	} else {
 		tcpx_cq = container_of(rx_entry->ep->util_ep.rx_cq,
 				       struct tcpx_cq, util_cq);
-		tcpx_xfer_entry_release(tcpx_cq, rx_entry);
+		tcpx_xfer_entry_free(tcpx_cq, rx_entry);
 	}
 }
 

--- a/prov/tcp/src/tcpx_progress.c
+++ b/prov/tcp/src/tcpx_progress.c
@@ -58,7 +58,6 @@ static void tcpx_process_tx_entry(struct tcpx_xfer_entry *tx_entry)
 
 	if (ret) {
 		FI_WARN(&tcpx_prov, FI_LOG_DOMAIN, "msg send failed\n");
-		tcpx_ep_disable(tx_entry->ep, 0);
 		tcpx_cq_report_error(tx_entry->ep->util_ep.tx_cq,
 				     tx_entry, -ret);
 	} else {

--- a/prov/tcp/src/tcpx_rma.c
+++ b/prov/tcp/src/tcpx_rma.c
@@ -111,7 +111,7 @@ static ssize_t tcpx_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg,
 
 	recv_entry = tcpx_xfer_entry_alloc(tcpx_cq, TCPX_OP_READ_RSP);
 	if (!recv_entry) {
-		tcpx_xfer_entry_release(tcpx_cq, send_entry);
+		tcpx_xfer_entry_free(tcpx_cq, send_entry);
 		return -FI_EAGAIN;
 	}
 	tcpx_rma_read_send_entry_fill(send_entry, tcpx_ep, msg);

--- a/prov/tcp/src/tcpx_shared_ctx.c
+++ b/prov/tcp/src/tcpx_shared_ctx.c
@@ -38,8 +38,8 @@
 #include <unistd.h>
 #include <ofi_iov.h>
 
-void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
-			   struct tcpx_xfer_entry *xfer_entry)
+void tcpx_srx_entry_free(struct tcpx_rx_ctx *srx_ctx,
+			 struct tcpx_xfer_entry *xfer_entry)
 {
 	if (xfer_entry->ep->cur_rx_entry == xfer_entry)
 		xfer_entry->ep->cur_rx_entry = NULL;
@@ -50,7 +50,7 @@ void tcpx_srx_xfer_release(struct tcpx_rx_ctx *srx_ctx,
 }
 
 struct tcpx_xfer_entry *
-tcpx_srx_get_entry(struct tcpx_rx_ctx *srx_ctx, struct tcpx_ep *ep)
+tcpx_srx_entry_alloc(struct tcpx_rx_ctx *srx_ctx, struct tcpx_ep *ep)
 {
 	struct tcpx_xfer_entry *rx_entry = NULL;
 


### PR DESCRIPTION
This is derived from PR #6454.  The main difference is that I removed the flush_pending_xfers function as part of the change, as it is no longer needed.  Other differences are merely function renames, so I can more easily figure out what the various calls are doing without always needing to read the implementation.