### PR TITLE
prov/efa: return EAGAIN when pkts are exhausted sending segments

### DIFF
--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1688,6 +1688,8 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 			ret = rxr_pkt_post_data(ep, tx_entry);
 			if (OFI_UNLIKELY(ret)) {
 				tx_entry->send_flags &= ~FI_MORE;
+				if (ret == -FI_EAGAIN)
+					goto out;
 				goto tx_err;
 			}
 		}

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -59,8 +59,12 @@ ssize_t rxr_pkt_post_data(struct rxr_ep *rxr_ep,
 	ssize_t ret;
 
 	pkt_entry = rxr_pkt_entry_alloc(rxr_ep, rxr_ep->tx_pkt_efa_pool);
-	if (OFI_UNLIKELY(!pkt_entry))
-		return -FI_ENOMEM;
+	if (OFI_UNLIKELY(!pkt_entry)) {
+		FI_DBG(&rxr_prov, FI_LOG_EP_DATA,
+		       "TX packets exhausted, current packets in flight %lu",
+		       rxr_ep->tx_pending);
+		return -FI_EAGAIN;
+	}
 
 	pkt_entry->x_entry = (void *)tx_entry;
 	pkt_entry->addr = tx_entry->addr;


### PR DESCRIPTION
Return EAGAIN instead of ENOMEM when unable to allocate a TX packet
in the segmented send path.

The tx_pending counter check used to ensure that rxr_pkt_post_data was only
called when a TX packet is available, however packets may be queued
during RNR/peer backoff and are not pending on the NIC.

Signed-off-by: Robert Wespetal <wesper@amazon.com>