### PR TITLE
prov/efa: RNR queuing fixes and cleanup

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -339,7 +339,6 @@ int efa_av_insert_addr(struct efa_av *av, struct efa_ep_addr *addr,
 		util_ep = container_of(ep_list_entry, struct util_ep, av_entry);
 		rxr_ep = container_of(util_ep, struct rxr_ep, util_ep);
 		peer = rxr_ep_get_peer(rxr_ep, *fi_addr);
-		assert(peer);
 		peer->is_self = efa_is_same_addr((struct efa_ep_addr *)rxr_ep->core_addr,
 						 addr);
 	}

--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -260,10 +260,6 @@ enum rxr_tx_comm_type {
 	RXR_TX_SENT_READRSP,	/* tx_entry (on remote EP) sent
 				 * read response (FI_READ only)
 				 */
-	RXR_TX_QUEUED_READRSP, /* tx_entry (on remote EP) was
-				* unable to send read response
-				* (FI_READ only)
-				*/
 	RXR_TX_WAIT_READ_FINISH, /* tx_entry (on initiating EP) wait
 				  * for rx_entry to finish receiving
 				  * (FI_READ only)

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -132,6 +132,11 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 
+	if (peer->flags & RXR_PEER_IN_BACKOFF) {
+		err = -FI_EAGAIN;
+		goto out;
+	}
+
 	tx_entry = rxr_atomic_alloc_tx_entry(rxr_ep, msg, atomic_ex, op, flags);
 	if (OFI_UNLIKELY(!tx_entry)) {
 		err = -FI_EAGAIN;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -592,7 +592,7 @@ int rxr_ep_set_tx_credit_request(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_
 	int pending;
 
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
-	assert(peer);
+
 	/*
 	 * Init tx state for this peer. The rx state and reorder buffers will be
 	 * initialized on the first recv so as to not allocate resources unless

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1618,6 +1618,11 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->rx_entry_queued_list,
 				     struct rxr_rx_entry,
 				     rx_entry, queued_entry, tmp) {
+		peer = rxr_ep_get_peer(ep, rx_entry->addr);
+
+		if (peer->flags & RXR_PEER_IN_BACKOFF)
+			continue;
+
 		if (rx_entry->state == RXR_RX_QUEUED_CTRL) {
 			/*
 			 * We should only have one packet pending at a time for
@@ -1644,6 +1649,11 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->tx_entry_queued_list,
 				     struct rxr_tx_entry,
 				     tx_entry, queued_entry, tmp) {
+		peer = rxr_ep_get_peer(ep, tx_entry->addr);
+
+		if (peer->flags & RXR_PEER_IN_BACKOFF)
+			continue;
+
 		/*
 		 * It is possible to receive an RNR after we queue this
 		 * tx_entry if we run out of resources in the medium message
@@ -1690,6 +1700,10 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container(&ep->tx_pending_list, struct rxr_tx_entry,
 				tx_entry, entry) {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
+
+		if (peer->flags & RXR_PEER_IN_BACKOFF)
+			continue;
+
 		if (tx_entry->window > 0)
 			tx_entry->send_flags |= FI_MORE;
 		else
@@ -1724,6 +1738,11 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	 */
 	dlist_foreach_container_safe(&ep->read_pending_list, struct rxr_read_entry,
 				     read_entry, pending_entry, tmp) {
+		peer = rxr_ep_get_peer(ep, read_entry->addr);
+
+		if (peer->flags & RXR_PEER_IN_BACKOFF)
+			continue;
+
 		/*
 		 * The core's TX queue is full so we can't do any
 		 * additional work.

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1618,13 +1618,20 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->rx_entry_queued_list,
 				     struct rxr_rx_entry,
 				     rx_entry, queued_entry, tmp) {
-		if (rx_entry->state == RXR_RX_QUEUED_CTRL)
+		if (rx_entry->state == RXR_RX_QUEUED_CTRL) {
+			/*
+			 * We should only have one packet pending at a time for
+			 * rx_entry. Either the send failed due to RNR or the
+			 * rx_entry is queued but not both.
+			 */
+			assert(dlist_empty(&rx_entry->queued_pkts));
 			ret = rxr_pkt_post_ctrl(ep, RXR_RX_ENTRY, rx_entry,
 						rx_entry->queued_ctrl.type,
 						rx_entry->queued_ctrl.inject);
-		else
-			ret = rxr_ep_send_queued_pkts(ep,
-						      &rx_entry->queued_pkts);
+		} else {
+			ret = rxr_ep_send_queued_pkts(ep, &rx_entry->queued_pkts);
+		}
+
 		if (ret == -FI_EAGAIN)
 			break;
 		if (OFI_UNLIKELY(ret))
@@ -1637,26 +1644,43 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->tx_entry_queued_list,
 				     struct rxr_tx_entry,
 				     tx_entry, queued_entry, tmp) {
-		if (tx_entry->state == RXR_TX_QUEUED_CTRL)
-			ret = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry,
-						tx_entry->queued_ctrl.type,
-						tx_entry->queued_ctrl.inject);
-		else
-			ret = rxr_ep_send_queued_pkts(ep, &tx_entry->queued_pkts);
-
+		/*
+		 * It is possible to receive an RNR after we queue this
+		 * tx_entry if we run out of resources in the medium message
+		 * protocol. Ensure all queued packets are posted before
+		 * continuing to post additional control messages.
+		 */
+		ret = rxr_ep_send_queued_pkts(ep, &tx_entry->queued_pkts);
 		if (ret == -FI_EAGAIN)
 			break;
 		if (OFI_UNLIKELY(ret))
 			goto tx_err;
 
+		if (tx_entry->state == RXR_TX_QUEUED_CTRL) {
+			ret = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry,
+						tx_entry->queued_ctrl.type,
+						tx_entry->queued_ctrl.inject);
+			if (ret == -FI_EAGAIN)
+				break;
+			if (OFI_UNLIKELY(ret))
+				goto tx_err;
+		}
+
 		dlist_remove(&tx_entry->queued_entry);
 
-		if (tx_entry->state == RXR_TX_QUEUED_REQ_RNR)
+		if (tx_entry->state == RXR_TX_QUEUED_REQ_RNR ||
+		    tx_entry->state == RXR_TX_QUEUED_CTRL) {
 			tx_entry->state = RXR_TX_REQ;
-		else if (tx_entry->state == RXR_TX_QUEUED_DATA_RNR) {
+		} else if (tx_entry->state == RXR_TX_QUEUED_DATA_RNR) {
 			tx_entry->state = RXR_TX_SEND;
 			dlist_insert_tail(&tx_entry->entry,
 					  &ep->tx_pending_list);
+		} else {
+			FI_WARN(&rxr_prov, FI_LOG_CQ,
+			        "Unknown queued tx_entry state: %d\n",
+				tx_entry->state);
+			ret = -FI_EIO;
+			goto tx_err;
 		}
 	}
 

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -87,7 +87,7 @@ ssize_t rxr_msg_post_cuda_rtm(struct rxr_ep *rxr_ep, struct rxr_tx_entry *tx_ent
 	 * from the receiver, so here we call rxr_pkt_wait_handshake().
 	 */
 	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
-	assert(peer);
+
 	err = rxr_pkt_wait_handshake(rxr_ep, tx_entry->addr, peer);
 	if (OFI_UNLIKELY(err)) {
 		FI_WARN(&rxr_prov, FI_LOG_EP_CTRL, "waiting for handshake packet failed!\n");

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -283,6 +283,13 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 		goto out;
 	}
 
+	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
+
+	if (peer->flags & RXR_PEER_IN_BACKOFF) {
+		err = -FI_EAGAIN;
+		goto out;
+	}
+
 	tx_entry = rxr_ep_alloc_tx_entry(rxr_ep, msg, op, tag, flags);
 
 	if (OFI_UNLIKELY(!tx_entry)) {
@@ -293,8 +300,6 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 
 	assert(tx_entry->op == ofi_op_msg || tx_entry->op == ofi_op_tagged);
 
-	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
-	assert(peer);
 	tx_entry->msg_id = peer->next_msg_id++;
 	err = rxr_msg_post_rtm(rxr_ep, tx_entry);
 	if (OFI_UNLIKELY(err)) {

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -388,6 +388,8 @@ ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_en
 	if (err == -FI_EAGAIN) {
 		if (entry_type == RXR_TX_ENTRY) {
 			tx_entry = (struct rxr_tx_entry *)x_entry;
+			assert(tx_entry->state != RXR_TX_QUEUED_CTRL ||
+			       tx_entry->state != RXR_TX_QUEUED_REQ_RNR);
 			tx_entry->state = RXR_TX_QUEUED_CTRL;
 			tx_entry->queued_ctrl.type = ctrl_type;
 			tx_entry->queued_ctrl.inject = inject;
@@ -396,6 +398,8 @@ ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_en
 		} else {
 			assert(entry_type == RXR_RX_ENTRY);
 			rx_entry = (struct rxr_rx_entry *)x_entry;
+			assert(rx_entry->state != RXR_RX_QUEUED_CTRL ||
+			       rx_entry->state != RXR_RX_QUEUED_CTS_RNR);
 			rx_entry->state = RXR_RX_QUEUED_CTRL;
 			rx_entry->queued_ctrl.type = ctrl_type;
 			rx_entry->queued_ctrl.inject = inject;

--- a/prov/efa/src/rxr/rxr_pkt_entry.c
+++ b/prov/efa/src/rxr/rxr_pkt_entry.c
@@ -176,7 +176,7 @@ void rxr_pkt_entry_release_rx(struct rxr_ep *ep,
 		struct rxr_peer *peer;
 
 		peer = rxr_ep_get_peer(ep, pkt_entry->addr);
-		assert(peer);
+
 		if (peer->is_local)
 			ep->rx_bufs_shm_to_post++;
 		else
@@ -408,7 +408,7 @@ ssize_t rxr_pkt_entry_inject(struct rxr_ep *ep,
 
 	/* currently only EOR packet is injected using shm ep */
 	peer = rxr_ep_get_peer(ep, addr);
-	assert(peer);
+
 	assert(ep->use_shm && peer->is_local);
 	return fi_inject(ep->shm_ep, rxr_pkt_start(pkt_entry), pkt_entry->pkt_size,
 			 peer->shm_fiaddr);

--- a/prov/efa/src/rxr/rxr_pkt_type_req.c
+++ b/prov/efa/src/rxr/rxr_pkt_type_req.c
@@ -118,7 +118,7 @@ void rxr_pkt_init_req_hdr(struct rxr_ep *ep,
 	base_hdr->flags = 0;
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
-	assert(peer);
+
 	if (OFI_UNLIKELY(!(peer->flags & RXR_PEER_HANDSHAKE_RECEIVED))) {
 		/*
 		 * This is the first communication with this peer on this
@@ -272,7 +272,6 @@ size_t rxr_pkt_req_max_data_size(struct rxr_ep *ep, fi_addr_t addr, int pkt_type
 	struct rxr_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, addr);
-	assert(peer);
 
 	if (peer->is_local) {
 		assert(ep->use_shm);
@@ -1228,7 +1227,7 @@ void rxr_pkt_handle_rtm_rta_recv(struct rxr_ep *ep,
 
 	need_ordering = false;
 	peer = rxr_ep_get_peer(ep, pkt_entry->addr);
-	assert(peer);
+
 	if (!peer->is_local) {
 		/*
  		 * only need to reorder msg for efa_ep

--- a/prov/efa/src/rxr/rxr_read.c
+++ b/prov/efa/src/rxr/rxr_read.c
@@ -331,7 +331,6 @@ int rxr_read_post_remote_read_or_queue(struct rxr_ep *ep, int entry_type, void *
 		peer = rxr_ep_get_peer(ep, ((struct rxr_rx_entry *)x_entry)->addr);
 	}
 
-	assert(peer);
 	lower_ep_type = (peer->is_local) ? SHM_EP : EFA_EP;
 	read_entry = rxr_read_alloc_entry(ep, entry_type, x_entry, lower_ep_type);
 	if (!read_entry) {
@@ -411,7 +410,6 @@ int rxr_read_init_iov(struct rxr_ep *ep,
 	struct rxr_peer *peer;
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
-	assert(peer);
 
 	for (i = 0; i < tx_entry->iov_count; ++i) {
 		read_iov[i].addr = (uint64_t)tx_entry->iov[i].iov_base;
@@ -489,7 +487,7 @@ int rxr_read_post(struct rxr_ep *ep, struct rxr_read_entry *read_entry)
 	}
 
 	peer = rxr_ep_get_peer(ep, read_entry->addr);
-	assert(peer);
+
 	if (read_entry->lower_ep_type == SHM_EP)
 		shm_fiaddr = peer->shm_fiaddr;
 

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -268,7 +268,7 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 		err = rxr_pkt_post_ctrl(ep, RXR_TX_ENTRY, tx_entry, RXR_SHORT_RTR_PKT, 0);
 	} else {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
-		assert(peer);
+
 		rxr_pkt_calc_cts_window_credits(ep, peer,
 						tx_entry->total_len,
 						tx_entry->credit_request,
@@ -313,7 +313,6 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 	}
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
-	assert(peer);
 
 	if (peer->flags & RXR_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
@@ -411,7 +410,7 @@ ssize_t rxr_rma_post_write(struct rxr_ep *ep, struct rxr_tx_entry *tx_entry)
 				  util_domain.domain_fid);
 
 	peer = rxr_ep_get_peer(ep, tx_entry->addr);
-	assert(peer);
+
 	if (peer->is_local)
 		return rxr_rma_post_shm_write(ep, tx_entry);
 


### PR DESCRIPTION
A handful of fixes to the queuing logic. This fixes a hang when using the medium message protocol when RNR backoff is handled by the host stack. The one sided/atomic queuing is still suspect and will likely need some testing and changes.