### PR TITLE
prov/tcp: PEP socket is non-blocking

### DIFF
--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -143,6 +143,8 @@ static inline int ofi_close_socket(SOCKET socket)
 
 int fi_fd_nonblock(int fd);
 
+int fi_fd_block(int fd);
+
 static inline int ofi_sockerr(void)
 {
 	return errno;

--- a/include/unix/osd.h
+++ b/include/unix/osd.h
@@ -73,6 +73,10 @@
 	(((err) == EAGAIN)	||		\
 	 ((err) == EWOULDBLOCK))
 
+#define OFI_SOCK_TRY_ACCEPT_AGAIN(err)		\
+	(((err) == EAGAIN)	||		\
+	 ((err) == EWOULDBLOCK))
+
 #define OFI_SOCK_TRY_CONN_AGAIN(err)	\
 	((err) == EINPROGRESS)
 

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -226,6 +226,10 @@ extern "C" {
 	 ((err) == EWOULDBLOCK)		||	\
 	 ((err) == EAGAIN))
 
+#define OFI_SOCK_TRY_ACCEPT_AGAIN(err)		\
+	(((err) == EAGAIN)		||	\
+	 ((err) == EWOULDBLOCK))
+
 #define OFI_SOCK_TRY_CONN_AGAIN(err)		\
 	(((err) == EWOULDBLOCK)		||	\
 	 ((err) == EINPROGRESS))

--- a/include/windows/osd.h
+++ b/include/windows/osd.h
@@ -792,6 +792,12 @@ static inline int fi_fd_nonblock(SOCKET fd)
 	return ioctlsocket(fd, FIONBIO, &argp) ? -WSAGetLastError() : 0;
 }
 
+static inline int fi_fd_block(SOCKET fd)
+{
+	u_long argp = 0;
+	return ioctlsocket(fd, FIONBIO, &argp) ? -WSAGetLastError() : 0;
+}
+
 /* Note: Use static variable `errno` for libc routines
  * (such as fopen, lseek and etc)
  * If you need to define which function/variable is needed

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -342,6 +342,14 @@ static int tcpx_pep_sock_create(struct tcpx_pep *pep)
 	if (ret) {
 		goto err;
 	}
+
+	ret = fi_fd_nonblock(pep->sock);
+	if (ret) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"failed to set listener socket to nonblocking\n");
+		goto err;
+	}
+
 	if (ofi_addr_get_port(pep->info->src_addr) != 0 || port_range.high == 0) {
 		ret = bind(pep->sock, pep->info->src_addr,
 			  (socklen_t) pep->info->src_addrlen);

--- a/src/unix/osd.c
+++ b/src/unix/osd.c
@@ -91,6 +91,21 @@ int fi_fd_nonblock(int fd)
 	return 0;
 }
 
+int fi_fd_block(int fd)
+{
+	long flags = 0;
+
+	flags = fcntl(fd, F_GETFL);
+	if (flags < 0) {
+		return -errno;
+	}
+
+	if(fcntl(fd, F_SETFL, flags & ~O_NONBLOCK))
+		return -errno;
+
+	return 0;
+}
+
 int fi_wait_cond(pthread_cond_t *cond, pthread_mutex_t *mut, int timeout_ms)
 {
 	uint64_t t;


### PR DESCRIPTION
As described in the issue #6493, there is a situation where the call
to accept() would block is the peer aborts the connection in the
middle of the connection handshake.

Here is how Sean describes the problem:
"If a connection request is received, the listening socket would
be marked with POLLIN. If that connection is aborted by the peer
before the thread that checks POLLIN can call accept, it would
find nothing to accept."

Passive EndPoint (PEP) socket now becomes non-blocking so the call
to accept() never blocks.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>