### PR TITLE
prov/efa: revert recent rnr queuing changes

### DIFF
--- a/prov/efa/src/rxr/rxr.h
+++ b/prov/efa/src/rxr/rxr.h
@@ -260,6 +260,10 @@ enum rxr_tx_comm_type {
 	RXR_TX_SENT_READRSP,	/* tx_entry (on remote EP) sent
 				 * read response (FI_READ only)
 				 */
+	RXR_TX_QUEUED_READRSP, /* tx_entry (on remote EP) was
+				* unable to send read response
+				* (FI_READ only)
+				*/
 	RXR_TX_WAIT_READ_FINISH, /* tx_entry (on initiating EP) wait
 				  * for rx_entry to finish receiving
 				  * (FI_READ only)

--- a/prov/efa/src/rxr/rxr_atomic.c
+++ b/prov/efa/src/rxr/rxr_atomic.c
@@ -132,11 +132,6 @@ ssize_t rxr_atomic_generic_efa(struct rxr_ep *rxr_ep,
 
 	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 
-	if (peer->flags & RXR_PEER_IN_BACKOFF) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
-
 	tx_entry = rxr_atomic_alloc_tx_entry(rxr_ep, msg, atomic_ex, op, flags);
 	if (OFI_UNLIKELY(!tx_entry)) {
 		err = -FI_EAGAIN;

--- a/prov/efa/src/rxr/rxr_ep.c
+++ b/prov/efa/src/rxr/rxr_ep.c
@@ -1618,11 +1618,6 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->rx_entry_queued_list,
 				     struct rxr_rx_entry,
 				     rx_entry, queued_entry, tmp) {
-		peer = rxr_ep_get_peer(ep, rx_entry->addr);
-
-		if (peer->flags & RXR_PEER_IN_BACKOFF)
-			continue;
-
 		if (rx_entry->state == RXR_RX_QUEUED_CTRL) {
 			/*
 			 * We should only have one packet pending at a time for
@@ -1649,11 +1644,6 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container_safe(&ep->tx_entry_queued_list,
 				     struct rxr_tx_entry,
 				     tx_entry, queued_entry, tmp) {
-		peer = rxr_ep_get_peer(ep, tx_entry->addr);
-
-		if (peer->flags & RXR_PEER_IN_BACKOFF)
-			continue;
-
 		/*
 		 * It is possible to receive an RNR after we queue this
 		 * tx_entry if we run out of resources in the medium message
@@ -1700,10 +1690,6 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	dlist_foreach_container(&ep->tx_pending_list, struct rxr_tx_entry,
 				tx_entry, entry) {
 		peer = rxr_ep_get_peer(ep, tx_entry->addr);
-
-		if (peer->flags & RXR_PEER_IN_BACKOFF)
-			continue;
-
 		if (tx_entry->window > 0)
 			tx_entry->send_flags |= FI_MORE;
 		else
@@ -1738,11 +1724,6 @@ void rxr_ep_progress_internal(struct rxr_ep *ep)
 	 */
 	dlist_foreach_container_safe(&ep->read_pending_list, struct rxr_read_entry,
 				     read_entry, pending_entry, tmp) {
-		peer = rxr_ep_get_peer(ep, read_entry->addr);
-
-		if (peer->flags & RXR_PEER_IN_BACKOFF)
-			continue;
-
 		/*
 		 * The core's TX queue is full so we can't do any
 		 * additional work.

--- a/prov/efa/src/rxr/rxr_msg.c
+++ b/prov/efa/src/rxr/rxr_msg.c
@@ -283,13 +283,6 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 		goto out;
 	}
 
-	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
-
-	if (peer->flags & RXR_PEER_IN_BACKOFF) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
-
 	tx_entry = rxr_ep_alloc_tx_entry(rxr_ep, msg, op, tag, flags);
 
 	if (OFI_UNLIKELY(!tx_entry)) {
@@ -300,6 +293,7 @@ ssize_t rxr_msg_generic_send(struct fid_ep *ep, const struct fi_msg *msg,
 
 	assert(tx_entry->op == ofi_op_msg || tx_entry->op == ofi_op_tagged);
 
+	peer = rxr_ep_get_peer(rxr_ep, tx_entry->addr);
 	tx_entry->msg_id = peer->next_msg_id++;
 	err = rxr_msg_post_rtm(rxr_ep, tx_entry);
 	if (OFI_UNLIKELY(err)) {

--- a/prov/efa/src/rxr/rxr_pkt_cmd.c
+++ b/prov/efa/src/rxr/rxr_pkt_cmd.c
@@ -388,8 +388,6 @@ ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_en
 	if (err == -FI_EAGAIN) {
 		if (entry_type == RXR_TX_ENTRY) {
 			tx_entry = (struct rxr_tx_entry *)x_entry;
-			assert(tx_entry->state != RXR_TX_QUEUED_CTRL ||
-			       tx_entry->state != RXR_TX_QUEUED_REQ_RNR);
 			tx_entry->state = RXR_TX_QUEUED_CTRL;
 			tx_entry->queued_ctrl.type = ctrl_type;
 			tx_entry->queued_ctrl.inject = inject;
@@ -398,8 +396,6 @@ ssize_t rxr_pkt_post_ctrl_or_queue(struct rxr_ep *ep, int entry_type, void *x_en
 		} else {
 			assert(entry_type == RXR_RX_ENTRY);
 			rx_entry = (struct rxr_rx_entry *)x_entry;
-			assert(rx_entry->state != RXR_RX_QUEUED_CTRL ||
-			       rx_entry->state != RXR_RX_QUEUED_CTS_RNR);
 			rx_entry->state = RXR_RX_QUEUED_CTRL;
 			rx_entry->queued_ctrl.type = ctrl_type;
 			rx_entry->queued_ctrl.inject = inject;

--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -312,19 +312,14 @@ ssize_t rxr_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uint64_
 		goto out;
 	}
 
-	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
-
-	if (peer->flags & RXR_PEER_IN_BACKOFF) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
-
 	tx_entry = rxr_rma_alloc_tx_entry(rxr_ep, msg, ofi_op_read_req, flags);
 	if (OFI_UNLIKELY(!tx_entry)) {
 		rxr_ep_progress_internal(rxr_ep);
 		err = -FI_EAGAIN;
 		goto out;
 	}
+
+	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
 
 	use_lower_ep_read = false;
 	if (peer->is_local) {
@@ -484,7 +479,6 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 			 uint64_t flags)
 {
 	ssize_t err;
-	struct rxr_peer *peer;
 	struct rxr_ep *rxr_ep;
 	struct rxr_tx_entry *tx_entry;
 
@@ -498,13 +492,6 @@ ssize_t rxr_rma_writemsg(struct fid_ep *ep,
 
 	rxr_perfset_start(rxr_ep, perf_rxr_tx);
 	fastlock_acquire(&rxr_ep->util_ep.lock);
-
-	peer = rxr_ep_get_peer(rxr_ep, msg->addr);
-
-	if (peer->flags & RXR_PEER_IN_BACKOFF) {
-		err = -FI_EAGAIN;
-		goto out;
-	}
 
 	tx_entry = rxr_rma_alloc_tx_entry(rxr_ep, msg, ofi_op_write, flags);
 	if (OFI_UNLIKELY(!tx_entry)) {


### PR DESCRIPTION
These changes caused some unexpected test failures in our internal CI. Revert them for now so we don't hold up the 1.12 release.