### PR TITLE
[v1.11.x] prov/rxm: Call ofi_mem_fini when built as DL provider

### DIFF
--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -364,7 +364,9 @@ static int rxm_getinfo(uint32_t version, const char *node, const char *service,
 
 static void rxm_fini(void)
 {
-	/* yawn */
+#if HAVE_RXM_DL
+	ofi_mem_fini();
+#endif
 }
 
 struct fi_provider rxm_prov = {
@@ -487,7 +489,7 @@ RXM_INI
 			"(FI_OFI_RXM_DATA_AUTO_PROGRESS = 1), domain threading "
 			"level would be set to FI_THREAD_SAFE\n");
 
-#ifdef HAVE_RXM_DL
+#if HAVE_RXM_DL
 	ofi_mem_init();
 #endif
 


### PR DESCRIPTION
This fixes a small memory leak when building rxm as a
DL provider.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>