### PR TITLE
prov/tcp: Use nonblocking sockets during CM message exchange

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -136,7 +136,7 @@ The ofi_rxm provider checks for the following environment variables.
   endpoint provider.  This feature allows direct placement of received
   message data into application buffers, bypassing RxM bounce buffers.
   This feature targets providers that provide internal network buffering,
-  such as the tcp provider.  (default: true)
+  such as the tcp provider.  (default: false)
 
 *FI_OFI_RXM_SAR_LIMIT*
 : Set this environment variable to control the RxM SAR (Segmentation And Reassembly)

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -480,21 +480,20 @@ struct ofi_ops_dynamic_rbuf rxm_dynamic_rbuf = {
 	.get_rbuf = rxm_get_dyn_rbuf,
 };
 
-static void rxm_config_dyn_rbuf(struct rxm_domain *domain, struct fi_info *info)
+static void rxm_config_dyn_rbuf(struct rxm_domain *domain, struct fi_info *info,
+				struct fi_info *msg_info)
 {
-	/* int ret = 1; */
-
-	/* Force disabling of dynamic receive buffers until issues are
-	 * resolved.
-	 */
-	domain->dyn_rbuf = false;
-	return;
+	int ret = 0;
 
 	/* Collective support requires rxm generated and consumed messages.
 	 * Although we could update the code to handle receiving collective
 	 * messages, collective support is mostly for development purposes.
 	 * So, fallback to bounce buffers when enabled.
-	if (info->caps & FI_COLLECTIVE)
+	 * We also can't pass through HMEM buffers, unless the lower layer
+	 * can handle them.
+	 */
+	if ((info->caps & FI_COLLECTIVE) ||
+	    ((info->caps & FI_HMEM) && !(msg_info->caps & FI_HMEM)))
 		return;
 
 	fi_param_get_bool(&rxm_prov, "enable_dyn_rbuf", &ret);
@@ -509,7 +508,6 @@ static void rxm_config_dyn_rbuf(struct rxm_domain *domain, struct fi_info *info)
 	if (domain->dyn_rbuf) {
 		domain->rx_buf_post_size = sizeof(struct rxm_pkt);
 	}
-	 */
 }
 
 int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
@@ -569,7 +567,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	if (ret)
 		goto err4;
 
-	rxm_config_dyn_rbuf(rxm_domain, info);
+	rxm_config_dyn_rbuf(rxm_domain, info, msg_info);
 
 	fi_freeinfo(msg_info);
 	return 0;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1635,8 +1635,8 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 			      tx_buf->hdr.desc, 0, tx_buf);
 		if (ret) {
 			if (ret != -FI_EAGAIN) {
-				rxm_ep_sar_handle_segment_failure(def_tx_entry, ret);
-				goto sar_finish;
+				rxm_ep_sar_handle_segment_failure(def_tx_entry,
+								  ret);
 			}
 			return ret;
 		}
@@ -1648,7 +1648,7 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 		    def_tx_entry->sar_seg.segs_cnt) {
 			assert(rxm_sar_get_seg_type(&tx_buf->pkt.ctrl_hdr) ==
 			       RXM_SAR_SEG_LAST);
-			goto sar_finish;
+			return 0;
 		}
 	}
 
@@ -1674,8 +1674,8 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 				def_tx_entry->sar_seg.device);
 		if (ret) {
 			if (ret != -FI_EAGAIN) {
-				rxm_ep_sar_handle_segment_failure(def_tx_entry, ret);
-				goto sar_finish;
+				rxm_ep_sar_handle_segment_failure(def_tx_entry,
+								  ret);
 			}
 
 			return ret;
@@ -1684,11 +1684,7 @@ rxm_ep_progress_sar_deferred_segments(struct rxm_deferred_tx_entry *def_tx_entry
 		def_tx_entry->sar_seg.remain_len -= rxm_eager_limit;
 	}
 
-sar_finish:
-	rxm_ep_dequeue_deferred_tx_queue(def_tx_entry);
-	free(def_tx_entry);
-
-	return ret;
+	return 0;
 }
 
 void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
@@ -1716,7 +1712,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 				      0, def_tx_entry->rndv_ack.rx_buf);
 			if (ret) {
 				if (ret == -FI_EAGAIN)
-					break;
+					return;
 				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.rx_cq,
 						   def_tx_entry->rxm_ep->util_ep.rx_cntr,
 						   def_tx_entry->rndv_ack.rx_buf->
@@ -1732,8 +1728,6 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 				RXM_UPDATE_STATE(FI_LOG_EP_DATA,
 						 def_tx_entry->rndv_ack.rx_buf,
 						 RXM_RNDV_WRITE_DATA_SENT);
-			rxm_ep_dequeue_deferred_tx_queue(def_tx_entry);
-			free(def_tx_entry);
 			break;
 		case RXM_DEFERRED_TX_RNDV_DONE:
 			ret = fi_send(def_tx_entry->rxm_conn->msg_ep,
@@ -1743,7 +1737,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 				      0, def_tx_entry->rndv_done.tx_buf);
 			if (ret) {
 				if (ret == -FI_EAGAIN)
-					break;
+					return;
 				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.tx_cq,
 						   def_tx_entry->rxm_ep->util_ep.tx_cntr,
 						   def_tx_entry->rndv_done.tx_buf, ret);
@@ -1751,8 +1745,6 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			RXM_UPDATE_STATE(FI_LOG_EP_DATA,
 					 def_tx_entry->rndv_done.tx_buf,
 					 RXM_RNDV_WRITE_DONE_SENT);
-			rxm_ep_dequeue_deferred_tx_queue(def_tx_entry);
-			free(def_tx_entry);
 			break;
 		case RXM_DEFERRED_TX_RNDV_READ:
 			ret = rxm_ep->rndv_ops->xfer(
@@ -1765,14 +1757,12 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 				def_tx_entry->rndv_read.rx_buf);
 			if (ret) {
 				if (ret == -FI_EAGAIN)
-					break;
+					return;
 				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.rx_cq,
 						   def_tx_entry->rxm_ep->util_ep.rx_cntr,
 						   def_tx_entry->rndv_read.rx_buf->
 							recv_entry->context, ret);
 			}
-			rxm_ep_dequeue_deferred_tx_queue(def_tx_entry);
-			free(def_tx_entry);
 			break;
 		case RXM_DEFERRED_TX_RNDV_WRITE:
 			ret = rxm_ep->rndv_ops->xfer(
@@ -1785,27 +1775,24 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 				def_tx_entry->rndv_write.tx_buf);
 			if (ret) {
 				if (ret == -FI_EAGAIN)
-					break;
+					return;
 				rxm_cq_write_error(def_tx_entry->rxm_ep->util_ep.rx_cq,
 						   def_tx_entry->rxm_ep->util_ep.rx_cntr,
 						   def_tx_entry->rndv_write.tx_buf, ret);
 			}
-			rxm_ep_dequeue_deferred_tx_queue(def_tx_entry);
-			free(def_tx_entry);
 			break;
 		case RXM_DEFERRED_TX_SAR_SEG:
 			ret = rxm_ep_progress_sar_deferred_segments(def_tx_entry);
+			if (ret == -FI_EAGAIN)
+				return;
 			break;
 		case RXM_DEFERRED_TX_ATOMIC_RESP:
 			ret = rxm_atomic_send_respmsg(rxm_ep,
 					def_tx_entry->rxm_conn,
 					def_tx_entry->atomic_resp.tx_buf,
 					def_tx_entry->atomic_resp.len);
-			if (ret)
-				if (ret == -FI_EAGAIN)
-					break;
-			rxm_ep_dequeue_deferred_tx_queue(def_tx_entry);
-			free(def_tx_entry);
+			if (ret == -FI_EAGAIN)
+				return;
 			break;
 		case RXM_DEFERRED_TX_CREDIT_SEND:
 			iov.iov_base = &def_tx_entry->credit_msg.tx_buf->pkt;
@@ -1821,19 +1808,20 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 			ret = fi_sendmsg(def_tx_entry->rxm_conn->msg_ep, &msg,
 					 FI_PRIORITY);
 			if (ret) {
-				if (ret == -FI_EAGAIN)
-					break;
-				rxm_cq_write_error(
-					def_tx_entry->rxm_ep->util_ep.rx_cq,
-					def_tx_entry->rxm_ep->util_ep.rx_cntr,
-					def_tx_entry->rndv_read.rx_buf->
-						recv_entry->context, ret);
-				break;
+				if (ret != -FI_EAGAIN) {
+					rxm_cq_write_error(
+						def_tx_entry->rxm_ep->util_ep.rx_cq,
+						def_tx_entry->rxm_ep->util_ep.rx_cntr,
+						def_tx_entry->rndv_read.rx_buf->
+							recv_entry->context, ret);
+				}
+				return;
 			}
-			rxm_ep_dequeue_deferred_tx_queue(def_tx_entry);
-			free(def_tx_entry);
 			break;
 		}
+
+		rxm_ep_dequeue_deferred_tx_queue(def_tx_entry);
+		free(def_tx_entry);
 	}
 }
 

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -525,7 +525,7 @@ RXM_INI
 			"This allows direct placement of received messages "
 			"into application buffers, bypassing RxM bounce "
 			"buffers.  This feature targets using tcp sockets "
-			"for the message transport.  (default: true)");
+			"for the message transport.  (default: false)");
 
 	rxm_init_infos();
 	fi_param_get_size_t(&rxm_prov, "msg_tx_size", &rxm_msg_tx_size);

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -95,13 +95,15 @@ enum tcpx_xfer_op_codes {
 	TCPX_OP_CODE_MAX,
 };
 
-enum tcpx_cm_event_type {
-	SERVER_SOCK_ACCEPT,
-	CLIENT_SEND_CONNREQ,
-	SERVER_RECV_CONNREQ,
-	SERVER_SEND_CM_ACCEPT,
-	CLIENT_RECV_CONNRESP,
-	CLIENT_SERVER_ERROR,
+enum tcpx_cm_state {
+	TCPX_CM_LISTENING,
+	TCPX_CM_CONNECTING,
+	TCPX_CM_WAIT_REQ,
+	TCPX_CM_REQ_SENT,
+	TCPX_CM_REQ_RVCD,
+	TCPX_CM_RESP_READY,
+	/* CM context is freed once connected */
+	TCPX_CM_ERROR,
 };
 
 struct tcpx_cm_msg {
@@ -111,7 +113,7 @@ struct tcpx_cm_msg {
 
 struct tcpx_cm_context {
 	fid_t			fid;
-	enum tcpx_cm_event_type	type;
+	enum tcpx_cm_state	state;
 	size_t			cm_data_sz;
 	struct tcpx_cm_msg	msg;
 };

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -103,7 +103,6 @@ enum tcpx_cm_state {
 	TCPX_CM_REQ_RVCD,
 	TCPX_CM_RESP_READY,
 	/* CM context is freed once connected */
-	TCPX_CM_ERROR,
 };
 
 struct tcpx_cm_msg {

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -104,11 +104,16 @@ enum tcpx_cm_event_type {
 	CLIENT_SERVER_ERROR,
 };
 
+struct tcpx_cm_msg {
+	struct ofi_ctrl_hdr hdr;
+	char data[TCPX_MAX_CM_DATA_SIZE];
+};
+
 struct tcpx_cm_context {
 	fid_t			fid;
 	enum tcpx_cm_event_type	type;
 	size_t			cm_data_sz;
-	char			cm_data[TCPX_MAX_CM_DATA_SIZE];
+	struct tcpx_cm_msg	msg;
 };
 
 struct tcpx_port_range {

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -93,6 +93,13 @@ static int tcpx_setup_socket(SOCKET sock, struct fi_info *info)
 		return -ofi_sockerr();
 	}
 
+	ret = fi_fd_nonblock(sock);
+	if (ret) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"failed to set socket to nonblocking\n");
+		return ret;
+	}
+
 	return 0;
 }
 

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -124,7 +124,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	}
 
 	cm_ctx->fid = &tcpx_ep->util_ep.ep_fid.fid;
-	cm_ctx->type = CLIENT_SEND_CONNREQ;
+	cm_ctx->state = TCPX_CM_CONNECTING;
 
 	if (paramlen) {
 		cm_ctx->cm_data_sz = paramlen;
@@ -163,7 +163,7 @@ static int tcpx_ep_accept(struct fid_ep *ep, const void *param, size_t paramlen)
 
 	tcpx_ep->state = TCPX_ACCEPTING;
 	cm_ctx->fid = &tcpx_ep->util_ep.ep_fid.fid;
-	cm_ctx->type = SERVER_SEND_CM_ACCEPT;
+	cm_ctx->state = TCPX_CM_RESP_READY;
 	if (paramlen) {
 		cm_ctx->cm_data_sz = paramlen;
 		memcpy(cm_ctx->msg.data, param, paramlen);
@@ -920,7 +920,7 @@ int tcpx_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 	}
 
 	_pep->cm_ctx.fid = &_pep->util_pep.pep_fid.fid;
-	_pep->cm_ctx.type = SERVER_SOCK_ACCEPT;
+	_pep->cm_ctx.state = TCPX_CM_LISTENING;
 	_pep->cm_ctx.cm_data_sz = 0;
 	_pep->sock = INVALID_SOCKET;
 


### PR DESCRIPTION
Simplify progressing the deferred queue.
Use a single send call to transfer CM messages.
Rename the CM states.

CM changes are part of a broader attempt to remove blocking send/recv calls during CM message exchange to nonblocking.

Additional updates, plus patch to make sockets nonblocking always.  This avoids potentially long delays blocking progress while waiting for a socket to become ready for sending/receiving data in order to exchange CM messages.