### PR TITLE
configure: Hard fail when CUDA package detection fails

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -500,7 +500,7 @@ AS_IF([test x"$with_cuda" != x"no"],
 			      [])],
 	    [])
 
-AS_IF([test "$with_cuda" = "yes" && test "$have_libcuda" = "0" ],
+AS_IF([test x"$with_cuda" != x"no" && test -n "$with_cuda" && test "$have_libcuda" = "0" ],
 	[AC_MSG_ERROR([CUDA support requested but CUDA runtime not available.])],
 	[])
 AC_DEFINE_UNQUOTED([HAVE_LIBCUDA], [$have_libcuda], [Whether we have CUDA runtime or not])


### PR DESCRIPTION
There is a bug in the existing logic which only fails configure if the
default search path is used (--with-cuda) and the CUDA runtime in not
found. The package check silently fails and proceeds with configuration
if a custom path is provided yet no CUDA runtime is found
(--with-cuda=/foo/bar) due to the erroneous AS_IF condition. This was
silently disabling FI_HMEM_CUDA support despite the explicit
configuration.

Signed-off-by: Raghu Raja <craghun@amazon.com>