### PR TITLE
Revert "prov/rxm: adjust rx/tx and buffer pool sizes" (for CI verification

### DIFF
--- a/prov/rxm/src/rxm_attr.c
+++ b/prov/rxm/src/rxm_attr.c
@@ -53,7 +53,7 @@ struct fi_tx_attr rxm_tx_attr = {
 	.op_flags = RXM_PASSTHRU_TX_OP_FLAGS | RXM_TX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = 65536,
+	.size = 1024,
 	.iov_limit = RXM_IOV_LIMIT,
 	.rma_iov_limit = RXM_IOV_LIMIT,
 };
@@ -63,7 +63,7 @@ struct fi_rx_attr rxm_rx_attr = {
 	.op_flags = RXM_PASSTHRU_RX_OP_FLAGS | RXM_RX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = 65536,
+	.size = 1024,
 	.iov_limit= RXM_IOV_LIMIT,
 };
 
@@ -72,7 +72,7 @@ struct fi_tx_attr rxm_tx_attr_coll = {
 	.op_flags = RXM_PASSTHRU_TX_OP_FLAGS | RXM_TX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = 65536,
+	.size = 1024,
 	.iov_limit = RXM_IOV_LIMIT,
 	.rma_iov_limit = RXM_IOV_LIMIT,
 };
@@ -82,7 +82,7 @@ struct fi_rx_attr rxm_rx_attr_coll = {
 	.op_flags = RXM_PASSTHRU_RX_OP_FLAGS | RXM_RX_OP_FLAGS,
 	.msg_order = ~0x0ULL,
 	.comp_order = FI_ORDER_NONE,
-	.size = 65536,
+	.size = 1024,
 	.iov_limit= RXM_IOV_LIMIT,
 };
 

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -381,6 +381,19 @@ static void rxm_recv_queue_close(struct rxm_recv_queue *recv_queue)
 static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 {
 	int ret, i;
+	size_t queue_sizes[] = {
+		[RXM_BUF_POOL_RX] = rxm_ep->msg_info->rx_attr->size,
+		[RXM_BUF_POOL_TX] = rxm_ep->msg_info->tx_attr->size,
+		[RXM_BUF_POOL_TX_INJECT] = rxm_ep->msg_info->tx_attr->size,
+		[RXM_BUF_POOL_TX_RNDV_RD_DONE] = rxm_ep->msg_info->tx_attr->size,
+		[RXM_BUF_POOL_TX_RNDV_WR_DONE] = rxm_ep->msg_info->tx_attr->size,
+		[RXM_BUF_POOL_TX_RNDV_REQ] = rxm_ep->msg_info->tx_attr->size,
+		[RXM_BUF_POOL_TX_RNDV_WR_DATA] = rxm_ep->msg_info->tx_attr->size,
+		[RXM_BUF_POOL_TX_ATOMIC] = rxm_ep->msg_info->tx_attr->size,
+		[RXM_BUF_POOL_TX_SAR] = rxm_ep->msg_info->tx_attr->size,
+		[RXM_BUF_POOL_TX_CREDIT] = rxm_ep->msg_info->tx_attr->size,
+		[RXM_BUF_POOL_RMA] = rxm_ep->msg_info->tx_attr->size,
+	};
 	size_t entry_sizes[] = {
 		[RXM_BUF_POOL_RX] = rxm_eager_limit +
 				    sizeof(struct rxm_rx_buf),
@@ -420,7 +433,7 @@ static int rxm_ep_txrx_pool_create(struct rxm_ep *rxm_ep)
 					  (i == RXM_BUF_POOL_RX ||
 					   i == RXM_BUF_POOL_TX_ATOMIC) ? 0 :
 					  rxm_ep->rxm_info->tx_attr->size,
-					  1024,
+					  queue_sizes[i],
 					  &rxm_ep->buf_pools[i], i);
 		if (ret)
 			goto err;

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -483,10 +483,10 @@ RXM_INI
 			"latency as a side-effect.");
 
 	fi_param_define(&rxm_prov, "tx_size", FI_PARAM_SIZE_T,
-			"Defines default tx context size (default: 65536).");
+			"Defines default tx context size (default: 1024).");
 
 	fi_param_define(&rxm_prov, "rx_size", FI_PARAM_SIZE_T,
-			"Defines default rx context size (default: 65536).");
+			"Defines default rx context size (default: 1024).");
 
 	fi_param_define(&rxm_prov, "msg_tx_size", FI_PARAM_SIZE_T,
 			"Defines FI_EP_MSG tx size that would be requested "


### PR DESCRIPTION
Intel CI is experiencing aborts.  Reverting the most recent change that affects the failing test to see if the CI passes.

This reverts commit bbadda9da672d7cffeef8d5ecbc25a32c6c7a576.

This change removes the upper limit on buffer pool sizes to allow
growth beyond the tx/rx size.  The initial size remains fairly low but
the pools may now expand as necessary, enabling better scalability

The default tx/rx sizes are also bumped up to more sensible
values for RxM

Signed-off-by: Stephen Oost <stephen.oost@intel.com>
Signed-off-by: Sean Hefty <sean.hefty@intel.com>