### PR TITLE
fabtests: Fix function declaration to remove build warning

### DIFF
--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -42,12 +42,12 @@ int ft_ze_free(void *buf);
 int ft_ze_memset(uint64_t device, void *buf, int value, size_t size);
 int ft_ze_copy(uint64_t device, void *dst, const void *src, size_t size);
 
-static inline int ft_host_init()
+static inline int ft_host_init(void)
 {
 	return FI_SUCCESS;
 }
 
-static inline int ft_host_cleanup()
+static inline int ft_host_cleanup(void)
 {
 	return FI_SUCCESS;
 }


### PR DESCRIPTION
Windows build has a minor quibble with mismatched function
declarations.  Add (void) to the function declaration.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>