### PR TITLE
prov/psm2: Move default uuid from fabric to domain

### DIFF
--- a/prov/psm2/src/psmx2.h
+++ b/prov/psm2/src/psmx2.h
@@ -476,7 +476,6 @@ struct psmx2_multi_recv {
 
 struct psmx2_fid_fabric {
 	struct util_fabric	util_fabric;
-	psm2_uuid_t		uuid;
 	struct util_ns		name_server;
 
 	/* list of all opened domains */
@@ -543,6 +542,7 @@ struct psmx2_fid_domain {
 	struct psmx2_fid_fabric	*fabric;
 	uint64_t		mode;
 	uint64_t		caps;
+	psm2_uuid_t		uuid;
 
 	enum fi_mr_mode		mr_mode;
 	fastlock_t		mr_lock;

--- a/prov/psm2/src/psmx2_domain.c
+++ b/prov/psm2/src/psmx2_domain.c
@@ -370,6 +370,21 @@ int psmx2_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 		goto err_out;
 	}
 
+	psmx2_get_uuid(domain_priv->uuid);
+	if (info->ep_attr && info->ep_attr->auth_key) {
+		if (info->ep_attr->auth_key_size != sizeof(psm2_uuid_t)) {
+			FI_WARN(&psmx2_prov, FI_LOG_DOMAIN,
+				"Invalid auth_key_len %"PRIu64
+				", should be %"PRIu64".\n",
+				info->ep_attr->auth_key_size,
+				sizeof(psm2_uuid_t));
+			err = -FI_EINVAL;
+			goto err_out_free_domain;
+		}
+		memcpy(domain_priv->uuid, info->ep_attr->auth_key,
+		       sizeof(psm2_uuid_t));
+	}
+
 	err = ofi_domain_init(fabric, info, &domain_priv->util_domain, context);
 	if (err)
 		goto err_out_free_domain;

--- a/prov/psm2/src/psmx2_fabric.c
+++ b/prov/psm2/src/psmx2_fabric.c
@@ -105,9 +105,11 @@ int psmx2_fabric(struct fi_fabric_attr *attr,
 	fastlock_init(&fabric_priv->domain_lock);
 	dlist_init(&fabric_priv->domain_list);
 
-	psmx2_get_uuid(fabric_priv->uuid);
 	if (psmx2_env.name_server) {
-		fabric_priv->name_server.port = psmx2_uuid_to_port(fabric_priv->uuid);
+		psm2_uuid_t uuid;
+
+		psmx2_get_uuid(uuid);
+		fabric_priv->name_server.port = psmx2_uuid_to_port(uuid);
 		fabric_priv->name_server.name_len = sizeof(struct psmx2_ep_name);
 		fabric_priv->name_server.service_len = sizeof(int);
 		fabric_priv->name_server.service_cmp = psmx2_ns_service_cmp;

--- a/prov/psm2/src/psmx2_trx_ctxt.c
+++ b/prov/psm2/src/psmx2_trx_ctxt.c
@@ -248,7 +248,7 @@ struct psmx2_trx_ctxt *psmx2_trx_ctxt_alloc(struct psmx2_fid_domain *domain,
 	int compatible_flags = ~asked_flags & PSMX2_TX_RX;
 
 	if (!uuid)
-		uuid = domain->fabric->uuid;
+		uuid = domain->uuid;
 
 	/* Check existing allocations first if only Tx or Rx is needed */
 	if (compatible_flags) {


### PR DESCRIPTION
The calls for creating shared contexts accept fi_tx_attr, which unlike
fi_ep_attr, doesn't have the auth_key. As the result, the default uuid
is used as the job key. Previously the default uuid was stored in the
fabric object. The problem was that the auth_key was also unavailable
when the fabric object is created. Therefore, the default uuid can only
be set via environment variables. This creates discrepancies between
shared contexts and endpoints w.r.t. job key setting. Moving the default
uuid to the domain object solves the issue.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>