### PR TITLE
prov/rxm: Add env var to re-enable direct send feature

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -282,7 +282,6 @@ struct rxm_domain {
 	size_t max_atomic_size;
 	size_t rx_buf_post_size;
 	uint64_t mr_key;
-	bool mr_local;
 	bool dyn_rbuf;
 	struct ofi_ops_flow_ctrl *flow_ctrl_ops;
 	struct ofi_bufpool *amo_bufpool;
@@ -741,6 +740,7 @@ struct rxm_ep {
 	bool			msg_mr_local;
 	bool			rdm_mr_local;
 	bool			do_progress;
+	bool			enable_direct_send;
 
 	size_t			min_multi_recv_size;
 	size_t			buffered_min;

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -554,8 +554,6 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	(*domain)->mr = &rxm_domain_mr_ops;
 	(*domain)->ops = &rxm_domain_ops;
 
-	rxm_domain->mr_local = ofi_mr_local(msg_info) && !ofi_mr_local(info);
-
 	ret = ofi_bufpool_create(&rxm_domain->amo_bufpool,
 				 rxm_domain->max_atomic_size, 64, 0, 0, 0);
 	if (ret)

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1458,15 +1458,8 @@ unlock:
 static bool
 rxm_use_direct_send(struct rxm_ep *ep, size_t iov_count, uint64_t flags)
 {
-	/* Always use bounce buffers until issues are resolved.
-	struct rxm_domain *domain;
-
-	domain = container_of(ep->util_ep.domain, struct rxm_domain,
-			      util_domain);
-	return !(flags & FI_INJECT) && !(domain->mr_local) &&
+	return ep->enable_direct_send && !(flags & FI_INJECT) &&
 		(iov_count < ep->msg_info->tx_attr->iov_limit);
-	*/
-	return false;
 }
 
 static ssize_t
@@ -2624,6 +2617,17 @@ static void rxm_ep_sar_init(struct rxm_ep *rxm_ep)
 	}
 }
 
+static void rxm_config_direct_send(struct rxm_ep *ep)
+{
+	int ret = 0;
+
+	if (ep->msg_mr_local == ep->rdm_mr_local)
+		fi_param_get_bool(&rxm_prov, "enable_direct_send", &ret);
+
+	ep->enable_direct_send = (ret != 0);
+}
+
+
 static void rxm_ep_settings_init(struct rxm_ep *rxm_ep)
 {
 	size_t max_prog_val;
@@ -2659,6 +2663,7 @@ static void rxm_ep_settings_init(struct rxm_ep *rxm_ep)
 	rxm_ep->buffered_limit = rxm_eager_limit;
 
 	rxm_ep_sar_init(rxm_ep);
+	rxm_config_direct_send(rxm_ep);
 
  	FI_INFO(&rxm_prov, FI_LOG_CORE,
 		"Settings:\n"

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -529,6 +529,14 @@ RXM_INI
 			"buffers.  This feature targets using tcp sockets "
 			"for the message transport.  (default: false)");
 
+	fi_param_define(&rxm_prov, "enable_direct_send", FI_PARAM_BOOL,
+			"Enable support to pass application buffers directly "
+			"to the core provider when possible.  This avoids "
+			"copying application buffers through bounce buffers "
+			"before passing them to the core provider.  This "
+			"feature targets small to medium size message "
+			"transfers over the tcp provider.  (default: false)");
+
 	rxm_init_infos();
 	fi_param_get_size_t(&rxm_prov, "msg_tx_size", &rxm_msg_tx_size);
 	fi_param_get_size_t(&rxm_prov, "msg_rx_size", &rxm_msg_rx_size);

--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -133,7 +133,13 @@ static int tx_cm_data(SOCKET fd, uint8_t type, struct tcpx_cm_context *cm_ctx)
 
 static int tcpx_ep_enable(struct tcpx_ep *ep)
 {
-	int ret;
+	int ret = 0;
+
+	if (!ep->util_ep.rx_cq && !ep->util_ep.tx_cq) {
+		FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
+			"ep must be bound to cq's\n");
+		return -FI_ENOCQ;
+	}
 
 	fastlock_acquire(&ep->lock);
 	if (ep->state != TCPX_CONNECTING && ep->state != TCPX_ACCEPTING) {

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -633,7 +633,7 @@ int ofi_cq_init(const struct fi_provider *prov, struct fid_domain *domain,
 	return 0;
 
 cleanup:
-	ofi_cq_cleanup(cq);
+	(void) ofi_cq_cleanup(cq);
 	return ret;
 }
 


### PR DESCRIPTION
Plus 2 patches to address coverity warnings