### PR TITLE
prov/rxm: prioritize credit exchange in the deferred queue

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -884,6 +884,15 @@ rxm_ep_enqueue_deferred_tx_queue(struct rxm_deferred_tx_entry *tx_entry)
 }
 
 static inline void
+rxm_ep_enqueue_deferred_tx_queue_priority(struct rxm_deferred_tx_entry *tx_entry)
+{
+	if (dlist_empty(&tx_entry->rxm_conn->deferred_tx_queue))
+		dlist_insert_head(&tx_entry->rxm_conn->deferred_conn_entry,
+				  &tx_entry->rxm_ep->deferred_tx_conn_queue);
+	dlist_insert_head(&tx_entry->entry, &tx_entry->rxm_conn->deferred_tx_queue);
+}
+
+static inline void
 rxm_ep_dequeue_deferred_tx_queue(struct rxm_deferred_tx_entry *tx_entry)
 {
 	dlist_remove_init(&tx_entry->entry);

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -426,7 +426,7 @@ defer:
 	}
 
 	def_tx_entry->credit_msg.tx_buf = tx_buf;
-	rxm_ep_enqueue_deferred_tx_queue(def_tx_entry);
+	rxm_ep_enqueue_deferred_tx_queue_priority(def_tx_entry);
 	return FI_SUCCESS;
 }
 


### PR DESCRIPTION
In certain situations, credit messages could get stuck behind
lower priority messages, which could in turn block progress
of the deferred queue due to lack of credits.  Pushing credit
messages to the front of the queue will prevent this 'deadlock'.

Signed-off-by: Stephen Oost <stephen.oost@intel.com>