### PR TITLE
fabtests & rxm: Address build warnings

### DIFF
--- a/fabtests/functional/msg_sockets.c
+++ b/fabtests/functional/msg_sockets.c
@@ -54,6 +54,9 @@ union sockaddr_any {
 static union sockaddr_any bound_addr;
 static size_t bound_addr_len = sizeof bound_addr;
 
+/* string format is [%s]:%s */
+#define MAXADDRSTR	((BUFSIZ * 2) + 4)
+
 
 /* Wrapper for memcmp for sockaddr.  Note that the sockaddr structure may
  * contain holes, so sockaddr's are expected to have been initialized to all
@@ -113,7 +116,7 @@ sockaddrstr(const union sockaddr_any *addr, socklen_t len, char *buf, size_t buf
 
 static int check_address(struct fid *fid, const char *message)
 {
-	char buf1[BUFSIZ], buf2[BUFSIZ];
+	char buf1[MAXADDRSTR], buf2[MAXADDRSTR];
 	union sockaddr_any tmp;
 	size_t tmplen;
 	const char *ep_addr, *addr_expected;
@@ -127,13 +130,14 @@ static int check_address(struct fid *fid, const char *message)
 	}
 
 	if (sockaddrcmp(&tmp, tmplen, &bound_addr, bound_addr_len)) {
-		ep_addr = sockaddrstr(&tmp, tmplen, buf1, BUFSIZ);
+		ep_addr = sockaddrstr(&tmp, tmplen, buf1, sizeof buf1);
 		if (!ep_addr) {
 			FT_ERR("Unable to get ep_addr as string!");
 			return -FI_EINVAL;
 		}
 
-		addr_expected = sockaddrstr(&bound_addr, bound_addr_len, buf2, BUFSIZ);
+		addr_expected = sockaddrstr(&bound_addr, bound_addr_len, buf2,
+					    sizeof buf2);
 		if (!addr_expected) {
 			FT_ERR("Unable to get addr_expected as string!");
 			return -FI_EINVAL;
@@ -302,7 +306,7 @@ static int client_connect(void)
 
 static int setup_handle(void)
 {
-	static char buf[BUFSIZ];
+	static char buf[MAXADDRSTR];
 	struct addrinfo *ai, aihints;
 	const char *bound_addr_str;
 	char *saved_addr;
@@ -398,7 +402,8 @@ static int setup_handle(void)
 		break;
 	}
 
-	bound_addr_str = sockaddrstr(&bound_addr, bound_addr_len, buf, BUFSIZ);
+	bound_addr_str = sockaddrstr(&bound_addr, bound_addr_len, buf,
+				     sizeof buf);
 	if (!bound_addr_str) {
 		FT_ERR("Unable to get bound_addr as string!");
 		ret = -FI_EINVAL;

--- a/fabtests/ubertest/config.c
+++ b/fabtests/ubertest/config.c
@@ -265,12 +265,12 @@ static int ft_parse_num(char *str, int len, struct key_t *key, void *buf)
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_SENDDATA, enum ft_class_function, buf);
 
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_WRITE, enum ft_class_function, buf);
-		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_WRITEV, enum ft_class_function, buf);	
+		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_WRITEV, enum ft_class_function, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_WRITEMSG, enum ft_class_function, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_WRITEDATA, enum ft_class_function, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_INJECT_WRITE, enum ft_class_function, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_INJECT_WRITEDATA, enum ft_class_function, buf);
-		
+
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_READ, enum ft_class_function, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_READV, enum ft_class_function, buf);
 		TEST_ENUM_SET_N_RETURN(str, len, FT_FUNC_READMSG, enum ft_class_function, buf);
@@ -504,8 +504,8 @@ static int ft_parse_config(char *config, int size,
 	 * 	JSMN_STRING
 	 * 	JSMN_STRING : <key>
 	 * 	JSMN_STRING : <value>
-	 * In our case, JSMN_OBJECT would represent a ft_set structure. The rest 
-	 * of the tokens would be treated as key-value pairs. The first JSMN_STRING 
+	 * In our case, JSMN_OBJECT would represent a ft_set structure. The rest
+	 * of the tokens would be treated as key-value pairs. The first JSMN_STRING
 	 * would represent a key and the next would represent a value. A value
 	 * can also be an array. jsmntok_t.size would represent the length of
 	 * the array.
@@ -853,16 +853,17 @@ void fts_cur_info(struct ft_series *series, struct ft_info *info)
 	info->cntr_wait_obj = set->cntr_wait_obj[series->cur_cntr_wait_obj];
 
 	if (set->node[0])
-		strncpy(info->node, set->node, sizeof(info->node) - 1);
+		strncpy(info->node, set->node, sizeof(info->node));
 	else if (opts.dst_addr)
-		strncpy(info->node, opts.dst_addr, sizeof(info->node) - 1);
-	if (set->service[0])
-		strncpy(info->service, set->service, sizeof(info->service) - 1);
-	else if (opts.dst_port)
-		strncpy(info->service, opts.dst_port, sizeof(info->service) - 1);
-	strncpy(info->prov_name, set->prov_name, sizeof(info->prov_name) - 1);
-
+		strncpy(info->node, opts.dst_addr, sizeof(info->node));
 	info->node[sizeof(info->node) - 1] = '\0';
+
+	if (set->service[0])
+		strncpy(info->service, set->service, sizeof(info->service));
+	else if (opts.dst_port)
+		strncpy(info->service, opts.dst_port, sizeof(info->service));
 	info->service[sizeof(info->service) - 1] = '\0';
+
+	strncpy(info->prov_name, set->prov_name, sizeof(info->prov_name));
 	info->prov_name[sizeof(info->prov_name) - 1] = '\0';
 }


### PR DESCRIPTION
Handle build warnings (hopefully, my compiler doesn't produce them) around string functions in fabtests.

Rework the error handling in rxm atomic response handling to handle build warning around an unused variable (used in debug build).