### PR TITLE
util/util_av : do not use huge pages for av_entry_pool

### DIFF
--- a/prov/util/src/util_av.c
+++ b/prov/util/src/util_av.c
@@ -460,8 +460,7 @@ static int util_av_init(struct util_av *av, const struct fi_av_attr *attr,
 		.max_cnt	= 0,
 		/* Don't use track of buffer, because user can close
 		 * the AV without prior deletion of addresses */
-		.flags		= OFI_BUFPOOL_NO_TRACK | OFI_BUFPOOL_INDEXED |
-				  OFI_BUFPOOL_HUGEPAGES,
+		.flags		= OFI_BUFPOOL_NO_TRACK | OFI_BUFPOOL_INDEXED,
 	};
 
 	/* TODO: Handle FI_READ */


### PR DESCRIPTION
Huge pages allocation requires user to reserve some
memory, which cannot be used by normal allocation.
Therefore, we want to reserve as little huge pages as
possible, and use it only for performance critical pools.

This patch removed the HUGEPAGES flags for av_entry_pool
because it does not fall into that category.

Signed-off-by: Wei Zhang <wzam@amazon.com>