### PR TITLE
prov/efa: exclude EFA when FI_HMEM and FI_LOCAL_COMM are selected

### DIFF
--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -407,21 +407,21 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 		if (hints->caps & FI_HMEM) {
 
 			if (!efa_device_support_rdma_read()) {
-				FI_INFO(&rxr_prov, FI_LOG_CORE,
+				FI_WARN(&rxr_prov, FI_LOG_CORE,
 				        "FI_HMEM capability requires RDMA, which this device does not support.\n");
 				return -FI_ENODATA;
 
 			}
 
 			if (!rxr_env.use_device_rdma) {
-				FI_INFO(&rxr_prov, FI_LOG_CORE,
+				FI_WARN(&rxr_prov, FI_LOG_CORE,
 				        "FI_HMEM capability requires RDMA, which is turned off. You can turn it on by set environment variable FI_EFA_USE_DEVICE_RDMA to 1.\n");
 				return -FI_ENODATA;
 			}
 
 			if (hints->domain_attr &&
 			    !(hints->domain_attr->mr_mode & FI_MR_HMEM)) {
-				FI_INFO(&rxr_prov, FI_LOG_CORE,
+				FI_WARN(&rxr_prov, FI_LOG_CORE,
 				        "FI_HMEM capability requires device registrations (FI_MR_HMEM)\n");
 				return -FI_ENODATA;
 			}

--- a/prov/efa/src/rxr/rxr_init.c
+++ b/prov/efa/src/rxr/rxr_init.c
@@ -405,6 +405,17 @@ static int rxr_info_to_rxr(uint32_t version, const struct fi_info *core_info,
 		 * which means FI_MR_HMEM implies FI_MR_LOCAL for cuda buffer
 		 */
 		if (hints->caps & FI_HMEM) {
+			/*
+			 * XXX: remove this once CUDA IPC is supported by SHM
+			 * and we have a fallback path to use the device when
+			 * SHM doesn't support CUDA IPC.
+			 */
+			if (hints->caps & FI_LOCAL_COMM) {
+				FI_WARN(&rxr_prov, FI_LOG_CORE,
+				        "FI_HMEM is currently not supported by the EFA provider when FI_LOCAL_COMM is requested.\n");
+				return -FI_ENODATA;
+			}
+			info->caps &= ~FI_LOCAL_COMM;
 
 			if (!efa_device_support_rdma_read()) {
 				FI_WARN(&rxr_prov, FI_LOG_CORE,


### PR DESCRIPTION
Loopback CUDA transfers do not currently work with EFA. NCCL does not require FI_LOCAL_COMM so we can safely add this check until we can support loopback via device transfers or SHM CUDA IPC support. Also fix some warning prints while we're here.

Test description: Verified FI_LOCAL_COMM is dropped when FI_HMEM is requested and that the provider is not selected when both FI_LOCAL_COMM and FI_HMEM are requested. Ran a NCCL perftest and MPI ring_c to verify EFA is still selected.