### PR TITLE
[v1.11.x] prov/efa: Fix a bug in rxr_rma_post_efa_emulated_read

### DIFF
--- a/prov/efa/src/rxr/rxr_rma.c
+++ b/prov/efa/src/rxr/rxr_rma.c
@@ -282,6 +282,10 @@ ssize_t rxr_rma_post_efa_emulated_read(struct rxr_ep *ep, struct rxr_tx_entry *t
 	}
 
 	if (OFI_UNLIKELY(err)) {
+#if ENABLE_DEBUG
+	        dlist_remove(&rx_entry->rx_pending_entry);
+		ep->rx_pending--;
+#endif
 		rxr_release_rx_entry(ep, rx_entry);
 	}
 


### PR DESCRIPTION
When "ENABLE_DEBUG" is defined, the "rx_entry->rx_pending_entry" is
inserted into "ep->rx_pending_list" each time rxr_rma_post_efa_emulated_read
is called. When there is an error from rxr_pkt_post_crtl, the rx_entry is
released by rxr_release_rx_entry, but its rx_pending_entry is not removed
from ep->rx_pending_list. This makes the ep->rx_pending_list has a released
entry that will be used by later dlist_insert_tail calls, which could cause
segmentation fault when memory poisoning is enabled.
This patch fixes this issue by removing the rx_pending_entry from
ep->rx_pending_list before its rx_entry is released.

Signed-off-by: Shi Jin <sjina@amazon.com>