### PR TITLE
prov/rxm: More cleanups in completion handling code paths

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1496,7 +1496,7 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 		return 0;
 	case RXM_INJECT_TX:
 		assert(0);
-		return -FI_EOPBADSTATE;
+		return 0;
 	case RXM_RMA:
 		rma_buf = comp->op_context;
 		assert((comp->flags & (FI_WRITE | FI_RMA)) ||
@@ -1551,7 +1551,7 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 	case RXM_RNDV_READ_DONE_WAIT:
 	case RXM_RNDV_WRITE_DATA_WAIT:
 		assert(0);
-		return -FI_EOPBADSTATE;
+		return 0;
 	case RXM_RNDV_READ:
 		rx_buf = comp->op_context;
 		assert(comp->flags & FI_READ);
@@ -1588,7 +1588,7 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 		return 0;
 	case RXM_RNDV_FINISH:
 		assert(0);
-		return -FI_EOPBADSTATE;
+		return 0;
 	case RXM_ATOMIC_RESP_WAIT:
 		/* Optional atomic request completion; TX completion
 		 * processing is performed when atomic response is received */
@@ -1601,7 +1601,7 @@ ssize_t rxm_handle_comp(struct rxm_ep *rxm_ep, struct fi_cq_data_entry *comp)
 		return 0;
 	default:
 		assert(0);
-		return -FI_EOPBADSTATE;
+		return 0;
 	}
 }
 


### PR DESCRIPTION
These cleanups simplify the code paths for the rendezvous protocol messages.  The inject path optimizations are removed.  Code is restructured to reduce line lengths and improve readability.  Errors are converted into asserts, with notes that most of fatal to the protocol and should be used to tear down communication with the peer.  The changes remove more of the possible unaffiliated completions that could be generated to the application.

More work is needed to fully address the rxm_handle_comp() error paths.  The remaining work is in handling receive completions (RXM_RX buffer state).