### PR TITLE
spec: use make_install instead of makeinstall

### DIFF
--- a/libfabric.spec.in
+++ b/libfabric.spec.in
@@ -78,7 +78,7 @@ EOF
 %endif
 %endif
 
-%makeinstall installdirs
+%make_install installdirs
 # remove unpackaged files from the buildroot
 rm -f %{buildroot}%{_libdir}/*.la
 %if 0%{?_version_symbolic_link:1}


### PR DESCRIPTION
Removes to following warning when building rpm:
'warning: %makeinstall is deprecated, try %make_install instead'

Signed-off-by: Goldman, Adam <adam.goldman@intel.com>