### PR TITLE
include/ofi_rbuf, prov/util: fix util cq issue and rename ofi_cirq function

### DIFF
--- a/include/ofi_rbuf.h
+++ b/include/ofi_rbuf.h
@@ -92,8 +92,10 @@ void dummy ## name (void) /* work-around global ; scope */
 
 #define ofi_cirque_rindex(cq)		((cq)->rcnt & (cq)->size_mask)
 #define ofi_cirque_windex(cq)		((cq)->wcnt & (cq)->size_mask)
+#define ofi_cirque_tindex(cq)		(((cq)->wcnt - 1) & (cq)->size_mask)
 #define ofi_cirque_head(cq)		(&(cq)->buf[ofi_cirque_rindex(cq)])
-#define ofi_cirque_tail(cq)		(&(cq)->buf[ofi_cirque_windex(cq)])
+#define ofi_cirque_tail(cq)		(&(cq)->buf[ofi_cirque_tindex(cq)])
+#define ofi_cirque_next(cq)		(&(cq)->buf[ofi_cirque_windex(cq)])
 #define ofi_cirque_insert(cq, x)	(cq)->buf[(cq)->wcnt++ & (cq)->size_mask] = x
 #define ofi_cirque_remove(cq)		(&(cq)->buf[(cq)->rcnt++ & (cq)->size_mask])
 #define ofi_cirque_discard(cq)		((cq)->rcnt++)

--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -546,7 +546,7 @@ static inline void
 ofi_cq_write_entry(struct util_cq *cq, void *context, uint64_t flags,
 		   size_t len, void *buf, uint64_t data, uint64_t tag)
 {
-	struct fi_cq_tagged_entry *comp = ofi_cirque_tail(cq->cirq);
+	struct fi_cq_tagged_entry *comp = ofi_cirque_next(cq->cirq);
 	comp->op_context = context;
 	comp->flags = flags;
 	comp->len = len;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -173,7 +173,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 		goto unlock_cq;
 	}
 
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	total_len = ofi_datatype_size(datatype) * ofi_total_ioc_cnt(ioc, count);
 
 	switch (op) {
@@ -221,7 +221,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 				ret = -FI_EAGAIN;
 				goto unlock_cq;
 			}
-			resp = ofi_cirque_tail(smr_resp_queue(ep->region));
+			resp = ofi_cirque_next(smr_resp_queue(ep->region));
 			pend = ofi_freestack_pop(ep->pend_fs);
 			smr_format_pend_resp(pend, cmd, context, iface, device, result_iov,
 					     result_count, id, resp);
@@ -248,7 +248,7 @@ static ssize_t smr_generic_atomic(struct smr_ep *ep,
 		}
 	}
 
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	smr_format_rma_ioc(cmd, rma_ioc, rma_count);
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
@@ -346,7 +346,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto unlock_region;
 	}
 
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	total_len = count * ofi_datatype_size(datatype);
 
 	iov.iov_base = (void *) buf;
@@ -369,7 +369,7 @@ static ssize_t smr_atomic_inject(struct fid_ep *ep_fid, const void *buf,
 
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	smr_format_rma_ioc(cmd, &rma_ioc, 1);
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -195,7 +195,7 @@ static void smr_send_name(struct smr_ep *ep, int64_t id)
 	if (smr_peer_data(ep->region)[id].name_sent || !peer_smr->cmd_cnt)
 		goto out;
 
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 
 	cmd->msg.hdr.op = SMR_OP_MAX + ofi_ctrl_connreq;
 	cmd->msg.hdr.id = id;

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -193,7 +193,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 
 	total_len = ofi_total_iov_len(iov, iov_count);
 
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
 
 	if (total_len <= SMR_MSG_DATA_LEN && !(op_flags & FI_DELIVERY_COMPLETE)) {
@@ -207,7 +207,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 			ret = -FI_EAGAIN;
 			goto unlock_cq;
 		}
-		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
+		resp = ofi_cirque_next(smr_resp_queue(ep->region));
 		pend = ofi_freestack_pop(ep->pend_fs);
 		if (smr_cma_enabled(ep, peer_smr) && iface == FI_HMEM_SYSTEM) {
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
@@ -334,7 +334,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 		goto unlock;
 	}
 
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	smr_generic_format(cmd, peer_id, op, tag, data, op_flags);
 
 	if (len <= SMR_MSG_DATA_LEN) {

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -133,7 +133,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 		goto unlock_cq;
 	}
 
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 
 	if (cmds == 1) {
 		err = smr_rma_fast(peer_smr, cmd, iov, iov_count, rma_iov,
@@ -162,7 +162,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 				goto unlock_cq;
 			}
 			cmd->msg.hdr.op_flags |= SMR_RMA_REQ;
-			resp = ofi_cirque_tail(smr_resp_queue(ep->region));
+			resp = ofi_cirque_next(smr_resp_queue(ep->region));
 			pend = ofi_freestack_pop(ep->pend_fs);
 			smr_format_pend_resp(pend, cmd, context, iface, device, iov,
 					     iov_count, id, resp);
@@ -175,7 +175,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 			ret = -FI_EAGAIN;
 			goto unlock_cq;
 		}
-		resp = ofi_cirque_tail(smr_resp_queue(ep->region));
+		resp = ofi_cirque_next(smr_resp_queue(ep->region));
 		pend = ofi_freestack_pop(ep->pend_fs);
 		if (smr_cma_enabled(ep, peer_smr) && iface == FI_HMEM_SYSTEM) {
 			smr_format_iov(cmd, iov, iov_count, total_len, ep->region,
@@ -218,7 +218,7 @@ ssize_t smr_generic_rma(struct smr_ep *ep, const struct iovec *iov,
 	comp_flags = cmd->msg.hdr.op_flags;
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	smr_format_rma_iov(cmd, rma_iov, rma_count);
 
 commit_comp:
@@ -388,7 +388,7 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 	rma_iov.len = len;
 	rma_iov.key = key;
 
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 
 	if (cmds == 1) {
 		ret = smr_rma_fast(peer_smr, cmd, &iov, 1, &rma_iov, 1, NULL,
@@ -409,7 +409,7 @@ ssize_t smr_generic_rma_inject(struct fid_ep *ep_fid, const void *buf,
 
 	ofi_cirque_commit(smr_cmd_queue(peer_smr));
 	peer_smr->cmd_cnt--;
-	cmd = ofi_cirque_tail(smr_cmd_queue(peer_smr));
+	cmd = ofi_cirque_next(smr_cmd_queue(peer_smr));
 	smr_format_rma_iov(cmd, &rma_iov, 1);
 
 commit:

--- a/prov/udp/src/udpx_ep.c
+++ b/prov/udp/src/udpx_ep.c
@@ -219,7 +219,7 @@ static void udpx_tx_comp(struct udpx_ep *ep, void *context)
 {
 	struct fi_cq_tagged_entry *comp;
 
-	comp = ofi_cirque_tail(ep->util_ep.tx_cq->cirq);
+	comp = ofi_cirque_next(ep->util_ep.tx_cq->cirq);
 	comp->op_context = context;
 	comp->flags = FI_SEND;
 	comp->len = 0;
@@ -239,7 +239,7 @@ static void udpx_rx_comp(struct udpx_ep *ep, void *context, uint64_t flags,
 {
 	struct fi_cq_tagged_entry *comp;
 
-	comp = ofi_cirque_tail(ep->util_ep.rx_cq->cirq);
+	comp = ofi_cirque_next(ep->util_ep.rx_cq->cirq);
 	comp->op_context = context;
 	comp->flags = FI_RECV | flags;
 	comp->len = len;
@@ -316,7 +316,7 @@ static ssize_t udpx_recvmsg(struct fid_ep *ep_fid, const struct fi_msg *msg,
 		goto out;
 	}
 
-	entry = ofi_cirque_tail(ep->rxq);
+	entry = ofi_cirque_next(ep->rxq);
 	entry->context = msg->context;
 	for (entry->iov_count = 0; entry->iov_count < msg->iov_count;
 	     entry->iov_count++) {
@@ -357,7 +357,7 @@ static ssize_t udpx_recv(struct fid_ep *ep_fid, void *buf, size_t len,
 		goto out;
 	}
 
-	entry = ofi_cirque_tail(ep->rxq);
+	entry = ofi_cirque_next(ep->rxq);
 	entry->context = context;
 	entry->iov_count = 1;
 	entry->iov[0].iov_base = buf;

--- a/prov/util/src/util_cq.c
+++ b/prov/util/src/util_cq.c
@@ -45,12 +45,12 @@
 static void ofi_cq_insert_aux(struct util_cq *cq,
 			      struct util_cq_aux_entry *entry)
 {
+	if (!ofi_cirque_isfull(cq->cirq))
+		ofi_cirque_commit(cq->cirq);
+
 	entry->cq_slot = ofi_cirque_tail(cq->cirq);
 	entry->cq_slot->flags = UTIL_FLAG_AUX;
 	slist_insert_tail(&entry->list_entry, &cq->aux_queue);
-
-	if (!ofi_cirque_isfull(cq->cirq))
-		ofi_cirque_commit(cq->cirq);
 }
 
 /* Caller must hold 'cq lock' */


### PR DESCRIPTION
There is an issue in the util cq aux code path where the insert_aux call should be adding all auxillary entries to the last committed cirq entry but it's calling ofi_cirque_tail which returns the next free entry.

The ofi_cirque_tail function is misleading so this patch renames it to ofi_cirque_next and redfines ofi_cirque_tail to return the last committed entry. All calls to ofi_cirque_tail are renamed in this patch except for the problematic insert_aux call which remains with the redfined ofi_cirque_tail call.

The second patch moves the commit call in insert_aux to make sure that the last committed entry exists.