### PR TITLE
prov/shm: fix a bug in smr_progress_resp_entry

### DIFF
--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -74,6 +74,7 @@ static int smr_progress_resp_entry(struct smr_ep *ep, struct smr_resp *resp,
 
 	switch (pending->cmd.msg.hdr.op_src) {
 	case smr_src_iov:
+		break;
 	case smr_src_ipc:
 		close(pending->fd);
 		break;


### PR DESCRIPTION
Currently, in smr_progress_resp_entry close(tx_entry->fd) is called
for both smr_src_iov and smr_src_ipc. This is wrong because
pending->fd is only used by IPC.

This patch fix the issue by not close(pending->fd) for smr_src_ipc.

Signed-off-by: Wei Zhang <wzam@amazon.com>