### PR TITLE
prov/efa: Fail fi_getinfo if FI_SOURCE given with node and service null

### DIFF
--- a/prov/efa/src/efa_fabric.c
+++ b/prov/efa/src/efa_fabric.c
@@ -890,6 +890,9 @@ int efa_getinfo(uint32_t version, const char *node, const char *service,
 {
 	int ret;
 
+	if ((flags & FI_SOURCE) && !node && !service)
+		return -FI_EINVAL;
+
 	if (!(flags & FI_SOURCE) && hints && hints->src_addr &&
 	    hints->src_addrlen != EFA_EP_ADDR_LEN)
 		return -FI_ENODATA;


### PR DESCRIPTION
According to the man page, if FI_SOURCE is specified, then either
the node and/or service parameter must be non-null.  Fail fi_getinfo
calls in this case.

This patch is to check that CI is not assuming that the use of FI_SOURCE
with null node/service parameters.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

fabtests is handling FI_SOURCE incorrectly when using OOB address exchange.  Fixing fabtests results in breaking CI.  This patch aligns EFA with the API, but I suspect will break the AWS CI.  Checking CI results to determine the next course of action.