### PR TITLE
build: Add configure option to enable ASAN, fabtests: minor updates to 2 tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl
 dnl Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2019 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2019-2021 Intel, Inc.  All rights reserved.
 dnl Copyright (c) 2019-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
 dnl (C) Copyright 2020 Hewlett Packard Enterprise Development LP
 dnl
@@ -131,6 +131,16 @@ AS_IF([test x"$enable_debug" != x"no"],
 
 AC_DEFINE_UNQUOTED([ENABLE_DEBUG],[$dbg],
                    [defined to 1 if libfabric was configured with --enable-debug, 0 otherwise])
+
+AC_ARG_ENABLE([asan],
+	      [AS_HELP_STRING([--enable-asan],
+			      [Enable address sanitizer @<:@default=no@:>@])
+	      ],
+	      [],
+	      [enable_asan=no])
+
+AS_IF([test x"$enable_asan" != x"no"],
+      [CFLAGS="-fsanitize=address $CFLAGS"])
 
 dnl Checks for header files.
 AC_HEADER_STDC

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -1,6 +1,6 @@
 dnl
 dnl Copyright (c) 2016-2017 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2018-2020 Intel Corporation, Inc.  All rights reserved.
+dnl Copyright (c) 2018-2021 Intel Corporation, Inc.  All rights reserved.
 dnl
 dnl Process this file with autoconf to produce a configure script.
 
@@ -50,6 +50,16 @@ AC_ARG_ENABLE([debug],
 
 AC_DEFINE_UNQUOTED([ENABLE_DEBUG], [$dbg],
 	[defined to 1 if configured with --enable-debug])
+
+AC_ARG_ENABLE([asan],
+	      [AS_HELP_STRING([--enable-asan],
+			      [Enable address sanitizer @<:@default=no@:>@])
+	      ],
+	      [],
+	      [enable_asan=no])
+
+AS_IF([test x"$enable_asan" != x"no"],
+      [CFLAGS="-fsanitize=address $CFLAGS"])
 
 dnl Fix autoconf's habit of adding -g -O2 by default
 AS_IF([test -z "$CFLAGS"],

--- a/fabtests/functional/cm_data.c
+++ b/fabtests/functional/cm_data.c
@@ -448,6 +448,7 @@ err1:
 	ft_sock_shutdown(sock);
 err2:
 	free(entry);
+	free(cm_data);
 	return ret;
 }
 
@@ -456,7 +457,7 @@ int main(int argc, char **argv)
 	int op, ret;
 
 	opts = INIT_OPTS;
-	opts.options |= FT_OPT_SIZE | FT_OPT_SKIP_REG_MR;
+	opts.options |= FT_OPT_SIZE | FT_OPT_SKIP_REG_MR | FT_OPT_SKIP_MSG_ALLOC;
 
 	hints = fi_allocinfo();
 	if (!hints)

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -227,42 +227,24 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "m:i:c:vdSh" ADDR_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt(argc, argv, "CM:h" CS_OPTS INFO_OPTS)) != -1) {
 		switch (op) {
 		default:
+			ft_parsecsopts(op, optarg, &opts);
 			ft_parse_addr_opts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints, &opts);
 			break;
-		case 'c':
-			concurrent_msgs = strtoul(optarg, NULL, 0);
-			break;
-		case 'i':
-			num_iters = strtoul(optarg, NULL, 0);
-			break;
-		case 'S':
-			opts.comp_method = FT_COMP_SREAD;
-			break;
-		case 'v':
-			opts.options |= FT_OPT_VERIFY_DATA;
-			break;
-		case 'm':
-			opts.transfer_size = strtoul(optarg, NULL, 0);
-			break;
-		case 'd':
+		case 'C':
 			send_data = true;
+			break;
+		case 'M':
+			concurrent_msgs = strtoul(optarg, NULL, 0);
 			break;
 		case '?':
 		case 'h':
-			ft_usage(argv[0], "Unexpected message functional test");
-			FT_PRINT_OPTS_USAGE("-c <int>",
-				"Concurrent messages per iteration ");
-			FT_PRINT_OPTS_USAGE("-v", "Enable data verification");
-			FT_PRINT_OPTS_USAGE("-i <int>", "Number of iterations");
-			FT_PRINT_OPTS_USAGE("-S",
-				"Use fi_cq_sread instead of polling fi_cq_read");
-			FT_PRINT_OPTS_USAGE("-m <size>",
-				"Size of unexpected messages");
-			FT_PRINT_OPTS_USAGE("-d", "Send remote CQ data");
+			ft_csusage(argv[0], "Unexpected message handling test.");
+			FT_PRINT_OPTS_USAGE("-C", "transfer remote CQ data");
+			FT_PRINT_OPTS_USAGE("-M <count>", "number of concurrent msgs");
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/scripts/runfabtests.sh
+++ b/fabtests/scripts/runfabtests.sh
@@ -129,8 +129,6 @@ functional_tests=(
 	"fi_recv_cancel -e rdm -V"
 	"fi_unexpected_msg -e msg -i 10"
 	"fi_unexpected_msg -e rdm -i 10"
-	"fi_unexpected_msg -e msg -S -i 10"
-	"fi_unexpected_msg -e rdm -S -i 10"
 	"fi_inj_complete -e msg"
 	"fi_inj_complete -e rdm"
 	"fi_inj_complete -e dgram"


### PR DESCRIPTION
Use common command line options to align with other fabtests.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>