### PR TITLE
prov/rxm: FI_MULTI_RECV fixes

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -757,6 +757,7 @@ struct rxm_ep {
 
 	struct rxm_recv_queue	recv_queue;
 	struct rxm_recv_queue	trecv_queue;
+	struct ofi_bufpool	*multi_recv_pool;
 
 	struct rxm_eager_ops	*eager_ops;
 	struct rxm_rndv_ops	*rndv_ops;
@@ -995,10 +996,12 @@ rxm_rx_buf_free(struct rxm_rx_buf *rx_buf)
 }
 
 static inline void
-rxm_recv_entry_release(struct rxm_recv_queue *queue, struct rxm_recv_entry *entry)
+rxm_recv_entry_release(struct rxm_recv_entry *entry)
 {
-	entry->total_len = 0;
-	ofi_freestack_push(queue->fs, entry);
+	if (entry->recv_queue)
+		ofi_freestack_push(entry->recv_queue->fs, entry);
+	else
+		ofi_buf_free(entry);
 }
 
 static inline void
@@ -1018,4 +1021,9 @@ rxm_cq_write_recv_comp(struct rxm_rx_buf *rx_buf, void *context, uint64_t flags,
 
 struct rxm_mr *rxm_mr_get_map_entry(struct rxm_domain *domain, uint64_t key);
 
+struct rxm_recv_entry *
+rxm_multi_recv_entry_get(struct rxm_ep *rxm_ep, const struct iovec *iov,
+		   void **desc, size_t count, fi_addr_t src_addr,
+		   uint64_t tag, uint64_t ignore, void *context,
+		   uint64_t flags);
 #endif

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -964,8 +964,7 @@ static int rxm_conn_reprocess_directed_recvs(struct rxm_recv_queue *recv_queue)
 			rxm_rx_buf_free(rx_buf);
 
 			if (!(rx_buf->recv_entry->flags & FI_MULTI_RECV))
-				rxm_recv_entry_release(recv_queue,
-						       rx_buf->recv_entry);
+				rxm_recv_entry_release(rx_buf->recv_entry);
 		}
 		count++;
 	}

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -198,7 +198,7 @@ static void rxm_finish_recv(struct rxm_rx_buf *rx_buf, size_t done_len)
 	}
 
 release:
-	rxm_recv_entry_release(recv_entry->recv_queue, recv_entry);
+	rxm_recv_entry_release(recv_entry);
 free_buf:
 	rxm_rx_buf_free(rx_buf);
 }
@@ -683,8 +683,7 @@ void rxm_handle_coll_eager(struct rxm_rx_buf *rx_buf)
 		ofi_coll_handle_xfer_comp(rx_buf->pkt.hdr.tag,
 				rx_buf->recv_entry->context);
 		rxm_rx_buf_free(rx_buf);
-		rxm_recv_entry_release(rx_buf->recv_entry->recv_queue,
-				rx_buf->recv_entry);
+		rxm_recv_entry_release(rx_buf->recv_entry);
 	} else {
 		rxm_finish_recv(rx_buf, done_len);
 	}

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -831,8 +831,10 @@ rxm_recv_entry_get(struct rxm_ep *rxm_ep, const struct iovec *iov,
 	for (i = 0; i < count; i++) {
 		recv_entry->rxm_iov.iov[i] = iov[i];
 		recv_entry->total_len += iov[i].iov_len;
-		if (desc)
+		if (desc && desc[i])
 			recv_entry->rxm_iov.desc[i] = desc[i];
+		else
+			recv_entry->rxm_iov.desc[i] = NULL;
 	}
 
 	return recv_entry;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -444,6 +444,22 @@ static void rxm_ep_txrx_pool_destroy(struct rxm_ep *rxm_ep)
 	free(rxm_ep->buf_pools);
 }
 
+static int rxm_multi_recv_pool_init(struct rxm_ep *rxm_ep)
+{
+	struct ofi_bufpool_attr attr = {
+		.size		= sizeof(struct rxm_recv_entry),
+		.alignment	= 16,
+		.max_cnt	= 0,
+		.chunk_cnt	= 16,
+		.alloc_fn	= NULL,
+		.init_fn	= NULL,
+		.context	= rxm_ep,
+		.flags		= OFI_BUFPOOL_NO_TRACK,
+	};
+
+	return ofi_bufpool_create_attr(&attr, &rxm_ep->multi_recv_pool);
+}
+
 static int rxm_ep_rx_queue_init(struct rxm_ep *rxm_ep)
 {
 	int ret;
@@ -460,8 +476,14 @@ static int rxm_ep_rx_queue_init(struct rxm_ep *rxm_ep)
 	if (ret)
 		goto err_recv_tag;
 
+	ret = rxm_multi_recv_pool_init(rxm_ep);
+	if (ret)
+		goto err_multi;
+
 	return FI_SUCCESS;
 
+err_multi:
+	rxm_recv_queue_close(&rxm_ep->trecv_queue);
 err_recv_tag:
 	rxm_recv_queue_close(&rxm_ep->recv_queue);
 	return ret;
@@ -478,6 +500,8 @@ static void rxm_ep_rx_queue_close(struct rxm_ep *rxm_ep)
 static void rxm_ep_txrx_res_close(struct rxm_ep *rxm_ep)
 {
 	rxm_ep_rx_queue_close(rxm_ep);
+	if (rxm_ep->multi_recv_pool)
+		ofi_bufpool_destroy(rxm_ep->multi_recv_pool);
 	if (rxm_ep->buf_pools)
 		rxm_ep_txrx_pool_destroy(rxm_ep);
 }
@@ -556,7 +580,7 @@ static bool rxm_ep_cancel_recv(struct rxm_ep *rxm_ep,
 	err_entry.tag = recv_entry->tag;
 	err_entry.err = FI_ECANCELED;
 	err_entry.prov_errno = -FI_ECANCELED;
-	rxm_recv_entry_release(recv_queue, recv_entry);
+	rxm_recv_entry_release(recv_entry);
 	ret = ofi_cq_write_error(rxm_ep->util_ep.rx_cq, &err_entry);
 	if (ret) {
 		FI_WARN(&rxm_prov, FI_LOG_CQ, "Error writing to CQ\n");
@@ -806,27 +830,25 @@ rxm_ep_peek_recv(struct rxm_ep *rxm_ep, fi_addr_t addr, uint64_t tag,
 		     rx_buf->pkt.hdr.data, rx_buf->pkt.hdr.tag);
 }
 
-static struct rxm_recv_entry *
-rxm_recv_entry_get(struct rxm_ep *rxm_ep, const struct iovec *iov,
-		   void **desc, size_t count, fi_addr_t src_addr,
-		   uint64_t tag, uint64_t ignore, void *context,
-		   uint64_t flags, struct rxm_recv_queue *recv_queue)
+static void rxm_recv_entry_init_common(struct rxm_recv_entry *recv_entry,
+		const struct iovec *iov, void **desc, size_t count,
+		fi_addr_t src_addr, uint64_t tag, uint64_t ignore,
+		void *context, uint64_t flags,
+		struct rxm_recv_queue *recv_queue)
 {
-	struct rxm_recv_entry *recv_entry;
 	size_t i;
 
-	if (ofi_freestack_isempty(recv_queue->fs))
-		return NULL;
-
-	recv_entry = ofi_freestack_pop(recv_queue->fs);
 	assert(!recv_entry->rndv.tx_buf);
-
 	recv_entry->rxm_iov.count = (uint8_t) count;
 	recv_entry->addr = src_addr;
 	recv_entry->context = context;
 	recv_entry->flags = flags;
 	recv_entry->ignore = ignore;
 	recv_entry->tag = tag;
+
+	recv_entry->sar.msg_id = RXM_SAR_RX_INIT;
+	recv_entry->sar.total_recv_len = 0;
+	recv_entry->total_len = 0;
 
 	for (i = 0; i < count; i++) {
 		recv_entry->rxm_iov.iov[i] = iov[i];
@@ -836,7 +858,41 @@ rxm_recv_entry_get(struct rxm_ep *rxm_ep, const struct iovec *iov,
 		else
 			recv_entry->rxm_iov.desc[i] = NULL;
 	}
+}
 
+static struct rxm_recv_entry *
+rxm_recv_entry_get(struct rxm_ep *rxm_ep, const struct iovec *iov,
+		   void **desc, size_t count, fi_addr_t src_addr,
+		   uint64_t tag, uint64_t ignore, void *context,
+		   uint64_t flags, struct rxm_recv_queue *recv_queue)
+{
+	struct rxm_recv_entry *recv_entry;
+
+	if (ofi_freestack_isempty(recv_queue->fs))
+		return NULL;
+
+	recv_entry = ofi_freestack_pop(recv_queue->fs);
+
+	rxm_recv_entry_init_common(recv_entry, iov, desc, count, src_addr, tag,
+			    ignore, context, flags, recv_queue);
+
+	return recv_entry;
+}
+
+struct rxm_recv_entry *
+rxm_multi_recv_entry_get(struct rxm_ep *rxm_ep, const struct iovec *iov,
+		   void **desc, size_t count, fi_addr_t src_addr,
+		   uint64_t tag, uint64_t ignore, void *context,
+		   uint64_t flags)
+{
+	struct rxm_recv_entry *recv_entry;
+
+	recv_entry = ofi_buf_alloc(rxm_ep->multi_recv_pool);
+
+	rxm_recv_entry_init_common(recv_entry, iov, desc, count, src_addr, tag,
+			    ignore, context, flags, NULL);
+
+	recv_entry->comp_flags = FI_MSG | FI_RECV;
 	return recv_entry;
 }
 


### PR DESCRIPTION
Various patches to fix FI_MULTI_RECV for rxm. The provider was delaying the reposting of the FI_MULTI_RECV buffers and not adjusting them correctly, causing hangs when FI_MULTI_RECV was used for SAR or rendezvous messages.