### PR TITLE
prov/rxm: Use eager, sar, and buffer sizes correctly

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -64,10 +64,9 @@
 #define RXM_OP_VERSION		3
 #define RXM_CTRL_VERSION	4
 
-#define RXM_BUF_SIZE	16384
 extern size_t rxm_eager_limit;
+extern size_t rxm_buffer_size;
 
-#define RXM_SAR_LIMIT	131072
 #define RXM_SAR_TX_ERROR	UINT64_MAX
 #define RXM_SAR_RX_INIT		UINT64_MAX
 
@@ -280,7 +279,7 @@ struct rxm_domain {
 	struct util_domain util_domain;
 	struct fid_domain *msg_domain;
 	size_t max_atomic_size;
-	size_t rx_buf_post_size;
+	size_t rx_post_size;
 	uint64_t mr_key;
 	bool dyn_rbuf;
 	struct ofi_ops_flow_ctrl *flow_ctrl_ops;
@@ -746,7 +745,6 @@ struct rxm_ep {
 	size_t			buffered_min;
 	size_t			buffered_limit;
 	size_t			inject_limit;
-	size_t			eager_limit;
 	size_t			sar_limit;
 
 	struct rxm_buf_pool	*buf_pools;
@@ -833,11 +831,11 @@ void rxm_rndv_hdr_init(struct rxm_ep *rxm_ep, void *buf,
 			      const struct iovec *iov, size_t count,
 			      struct fid_mr **mr);
 
+
 static inline size_t rxm_ep_max_atomic_size(struct fi_info *info)
 {
-	size_t overhead = sizeof(struct rxm_atomic_hdr) +
-			  sizeof(struct rxm_pkt);
-	return rxm_eager_limit > overhead ? rxm_eager_limit - overhead : 0;
+	assert(rxm_eager_limit >= sizeof(struct rxm_atomic_hdr));
+	return rxm_eager_limit - sizeof(struct rxm_atomic_hdr);
 }
 
 static inline ssize_t

--- a/prov/rxm/src/rxm_atomic.c
+++ b/prov/rxm/src/rxm_atomic.c
@@ -144,7 +144,7 @@ rxm_ep_atomic_common(struct rxm_ep *rxm_ep, struct rxm_conn *rxm_conn,
 	tot_len = buf_len + cmp_len + sizeof(struct rxm_atomic_hdr) +
 			sizeof(struct rxm_pkt);
 
-	if (tot_len > rxm_eager_limit) {
+	if (tot_len > rxm_buffer_size) {
 		FI_WARN(&rxm_prov, FI_LOG_EP_DATA,
 			"atomic data too large %zu\n", tot_len);
 		return -FI_EINVAL;

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1803,7 +1803,7 @@ static int rxm_post_recv(struct rxm_rx_buf *rx_buf)
 	domain = container_of(rx_buf->ep->util_ep.domain,
 			      struct rxm_domain, util_domain);
 	ret = (int) fi_recv(rx_buf->rx_ep, &rx_buf->pkt,
-			    domain->rx_buf_post_size, rx_buf->hdr.desc,
+			    domain->rx_post_size, rx_buf->hdr.desc,
 			    FI_ADDR_UNSPEC, rx_buf);
 	if (!ret)
 		return 0;

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -506,7 +506,7 @@ static void rxm_config_dyn_rbuf(struct rxm_domain *domain, struct fi_info *info,
 	domain->dyn_rbuf = (ret == FI_SUCCESS);
 
 	if (domain->dyn_rbuf) {
-		domain->rx_buf_post_size = sizeof(struct rxm_pkt);
+		domain->rx_post_size = sizeof(struct rxm_pkt);
 	}
 }
 
@@ -546,7 +546,7 @@ int rxm_domain_open(struct fid_fabric *fabric, struct fi_info *info,
 	rxm_domain->util_domain.mr_map.mode &= ~FI_MR_PROV_KEY;
 
 	rxm_domain->max_atomic_size = rxm_ep_max_atomic_size(info);
-	rxm_domain->rx_buf_post_size = sizeof(struct rxm_pkt) + rxm_eager_limit;
+	rxm_domain->rx_post_size = rxm_buffer_size;
 
 	*domain = &rxm_domain->util_domain.domain_fid;
 	(*domain)->fid.ops = &rxm_domain_fi_ops;


### PR DESCRIPTION
Users can specify an eager message size through environment
variables.  However, what's not clear to the user is that rxm
silently reserves a portion of that size of internal headers.
Because the eager size may be used elsewhere by the application,
this can result in non-optimal transfers.

For example, when multi-recv buffers are used, the application
can indicate how much free space remains before the buffer
should be released.  MPI sets this equal to the receive buffer
size (16K).  It then uses the multi-recv buffer to receive
transfers up to 16k in size.  However, the actual eager size
is slightly less than 16k, due to the rxm packet header.  The
result is that 16k transfers from MPI end up being transfered
using either the SAR or rendezvous protocols.  This results
in failures, as multi-recv handling isn't prepared to handle
rendezvous messages.

Rework the handling around eager and sar sizes.  Hide all
header space from the application.  Eager size now refers to the
eager space as viewed by the application.  This aligns with the
'buffer size' environment variable.  Maintain a separate size
for the actual buffers used for send and receives.  Update
SAR tracking to align with eager sizes.  Update checks in the
code to ensure that all values are aligned and reasonable.

This simplifies user's expections, as they no longer need to
be concerned with a header size that they have no visibility into.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>