### PR TITLE
prov/rxm: properly track the recv_entry mr for later rndv processing

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -609,11 +609,11 @@ static ssize_t rxm_handle_rndv(struct rxm_rx_buf *rx_buf)
 		}
 	} else {
 		struct rxm_mr *mr;
-
 		for (i = 0; i < rx_buf->recv_entry->rxm_iov.count; i++) {
 			mr = rx_buf->recv_entry->rxm_iov.desc[i];
+			rx_buf->mr[i] = mr->msg_mr;
 			rx_buf->recv_entry->rxm_iov.desc[i] =
-				fi_mr_desc(mr->msg_mr);
+				fi_mr_desc(rx_buf->mr[i]);
 		}
 	}
 


### PR DESCRIPTION
When recv_entry MR information was shifted to use the rxm_mr,
the tracking of the recv_entry mr info in the RNDV path was broken

Signed-off-by: Stephen Oost <stephen.oost@intel.com>