### PR TITLE
bufpool: check for buffer overruns, idm: add callback to handle cleanup

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -133,8 +133,6 @@ static inline int ofi_val32_ge(uint32_t x, uint32_t y) {
 #define ofi_val64_inrange(start, length, value) \
     ofi_val64_ge(value, start) && ofi_val64_lt(value, start + length)
 
-#define OFI_MAGIC_64 (0x0F1C0DE0F1C0DE64)
-
 #ifndef BIT
 #define BIT(nr) (1UL << (nr))
 #endif

--- a/include/ofi_indexer.h
+++ b/include/ofi_indexer.h
@@ -126,7 +126,7 @@ struct index_map
 
 int ofi_idm_set(struct index_map *idm, int index, void *item);
 void *ofi_idm_clear(struct index_map *idm, int index);
-void ofi_idm_reset(struct index_map *idm);
+void ofi_idm_reset(struct index_map *idm, void (*callback)(void *item));
 
 static inline void *ofi_idm_at(struct index_map *idm, int index)
 {

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -330,9 +330,7 @@ struct ofi_bufpool_region {
 	void 				*context;
 	struct ofi_bufpool 		*pool;
 	int				flags;
-#ifndef NDEBUG
-	size_t 				use_cnt;
-#endif
+	OFI_DBG_VAR(size_t,		use_cnt)
 };
 
 struct ofi_bufpool_hdr {

--- a/include/ofi_mem.h
+++ b/include/ofi_mem.h
@@ -333,6 +333,10 @@ struct ofi_bufpool_region {
 	OFI_DBG_VAR(size_t,		use_cnt)
 };
 
+struct ofi_bufpool_ftr {
+	size_t				magic;
+};
+
 struct ofi_bufpool_hdr {
 	union {
 		struct slist_entry	slist;
@@ -340,6 +344,9 @@ struct ofi_bufpool_hdr {
 	} entry;
 	struct ofi_bufpool_region	*region;
 	size_t 				index;
+
+	OFI_DBG_VAR(struct ofi_bufpool_ftr *, ftr)
+	OFI_DBG_VAR(size_t,		magic)
 };
 
 int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
@@ -391,6 +398,9 @@ static inline void ofi_buf_free(void *buf)
 {
 	assert(ofi_buf_region(buf)->use_cnt--);
 	assert(!(ofi_buf_pool(buf)->attr.flags & OFI_BUFPOOL_INDEXED));
+	assert(ofi_buf_hdr(buf)->magic == OFI_MAGIC_SIZE_T);
+	assert(ofi_buf_hdr(buf)->ftr->magic == OFI_MAGIC_SIZE_T);
+
 	slist_insert_head(&ofi_buf_hdr(buf)->entry.slist,
 			  &ofi_buf_pool(buf)->free_list.entries);
 }
@@ -402,13 +412,15 @@ static inline void ofi_ibuf_free(void *buf)
 {
 	struct ofi_bufpool_hdr *buf_hdr;
 
-	assert(ofi_buf_pool(buf)->attr.flags & OFI_BUFPOOL_INDEXED);
-	assert(ofi_buf_region(buf)->use_cnt--);
 	buf_hdr = ofi_buf_hdr(buf);
+
+	assert(ofi_buf_region(buf)->use_cnt--);
+	assert(ofi_buf_pool(buf)->attr.flags & OFI_BUFPOOL_INDEXED);
+	assert(buf_hdr->magic == OFI_MAGIC_SIZE_T);
+	assert(buf_hdr->ftr->magic == OFI_MAGIC_SIZE_T);
 
 	dlist_insert_order(&buf_hdr->region->free_list,
 			   ofi_ibuf_is_lower, &buf_hdr->entry.dlist);
-
 	if (dlist_empty(&buf_hdr->region->entry)) {
 		dlist_insert_order(&buf_hdr->region->pool->free_list.regions,
 				   ofi_ibufpool_region_is_lower,

--- a/include/ofi_osd.h
+++ b/include/ofi_osd.h
@@ -107,4 +107,18 @@ static inline int ofi_detect_endianness(void)
 	}
 }
 
+#define OFI_MAGIC_64 (0x0F1C0DE0F1C0DE64)
+#define OFI_MAGIC_PTR ((void *) (uintptr_t) OFI_MAGIC_64)
+#define OFI_MAGIC_SIZE_T ((size_t) OFI_MAGIC_64)
+
+#ifndef NDEBUG
+#define OFI_DBG_VAR(type, name) type name;
+#define OFI_DBG_SET(name, val) name = val
+#define OFI_DBG_ADD(name, val) name += val
+#else
+#define OFI_DBG_VAR(type, name)
+#define OFI_DBG_SET(name, val)
+#define OFI_DBG_ADD(name, val)
+#endif
+
 #endif /* _OFI_OSD_H_ */

--- a/prov/rxd/src/rxd_av.c
+++ b/prov/rxd/src/rxd_av.c
@@ -390,7 +390,7 @@ static int rxd_av_close(struct fid *fid)
 
 	ofi_idx_reset(&(av->fi_addr_idx));
 	ofi_idx_reset(&(av->rxdaddr_dg_idx));
-	ofi_idm_reset(&(av->rxdaddr_fi_idm));
+	ofi_idm_reset(&(av->rxdaddr_fi_idm), NULL);
 
 	free(av);
 	return 0;

--- a/prov/rxd/src/rxd_ep.c
+++ b/prov/rxd/src/rxd_ep.c
@@ -462,7 +462,7 @@ static ssize_t rxd_ep_send_rts(struct rxd_ep *rxd_ep, fi_addr_t rxd_addr)
 
 	rxd_ep_send_pkt(rxd_ep, pkt_entry);
 	rxd_insert_unacked(rxd_ep, rxd_addr, pkt_entry);
-	dlist_insert_tail(&(rxd_peer(rxd_ep, rxd_addr)->entry), 
+	dlist_insert_tail(&(rxd_peer(rxd_ep, rxd_addr)->entry),
 			  &rxd_ep->rts_sent_list);
 
 	return 0;
@@ -695,8 +695,8 @@ static int rxd_ep_close(struct fid *fid)
 				pkt_entry, d_entry);
 		ofi_buf_free(pkt_entry);
 	}
-	
-	ofi_idm_reset(&(ep->peers_idm));	
+
+	ofi_idm_reset(&(ep->peers_idm), free);
 	rxd_ep_free_res(ep);
 	ofi_endpoint_close(&ep->util_ep);
 	free(ep);
@@ -1147,10 +1147,11 @@ err:
 int rxd_create_peer(struct rxd_ep *ep, uint64_t rxd_addr)
 {
 
-	struct rxd_peer *peer;	
+	struct rxd_peer *peer;
+
 	peer = calloc(1, sizeof(struct rxd_peer));
 	if (!peer)
-		return -FI_ENOMEM;	
+		return -FI_ENOMEM;
 
 	peer->peer_addr = RXD_ADDR_INVALID;
 	peer->tx_seq_no = 0;
@@ -1167,12 +1168,12 @@ int rxd_create_peer(struct rxd_ep *ep, uint64_t rxd_addr)
 	dlist_init(&(peer->rx_list));
 	dlist_init(&(peer->rma_rx_list));
 	dlist_init(&(peer->buf_pkts));
-		
+
 	if (ofi_idm_set(&(ep->peers_idm), rxd_addr, peer) < 0)
 		goto err;
-	
+
 	return 0;
-err:	
+err:
 	free(peer);
 	return -FI_ENOMEM;
 }
@@ -1185,10 +1186,7 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 	struct rxd_ep *rxd_ep;
 	int ret;
 
-
-
 	rxd_ep = calloc(1, sizeof(*rxd_ep));
-
 	if (!rxd_ep)
 		return -FI_ENOMEM;
 
@@ -1229,9 +1227,9 @@ int rxd_endpoint(struct fid_domain *domain, struct fi_info *info,
 	ret = rxd_ep_init_res(rxd_ep, info);
 	if (ret)
 		goto err3;
-	
+
 	memset(&(rxd_ep->peers_idm), 0, sizeof(rxd_ep->peers_idm));
-	
+
 	rxd_ep->util_ep.ep_fid.fid.ops = &rxd_ep_fi_ops;
 	rxd_ep->util_ep.ep_fid.cm = &rxd_ep_cm;
 	rxd_ep->util_ep.ep_fid.ops = &rxd_ops_ep;

--- a/prov/sockets/src/sock_ep.c
+++ b/prov/sockets/src/sock_ep.c
@@ -726,7 +726,7 @@ static int sock_ep_close(struct fid *fid)
 		free(sock_ep->attr->dest_addr);
 
 	fastlock_acquire(&sock_ep->attr->domain->pe->lock);
-	ofi_idm_reset(&sock_ep->attr->av_idm);
+	ofi_idm_reset(&sock_ep->attr->av_idm, NULL);
 	sock_conn_map_destroy(sock_ep->attr);
 	fastlock_release(&sock_ep->attr->domain->pe->lock);
 

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -115,25 +115,11 @@ retry:
 		buf_hdr->region = buf_region;
 		buf_hdr->index = pool->entry_cnt + i;
 		if (pool->attr.init_fn) {
-#if ENABLE_DEBUG
-			if (pool->attr.flags & OFI_BUFPOOL_INDEXED) {
-				buf_hdr->entry.dlist.next = (void *) OFI_MAGIC_64;
-				buf_hdr->entry.dlist.prev = (void *) OFI_MAGIC_64;
-
-				pool->attr.init_fn(buf_region, buf);
-
-				assert((buf_hdr->entry.dlist.next == (void *) OFI_MAGIC_64) &&
-				       (buf_hdr->entry.dlist.prev == (void *) OFI_MAGIC_64));
-			} else {
-				buf_hdr->entry.slist.next = (void *) OFI_MAGIC_64;
-
-				pool->attr.init_fn(buf_region, buf);
-
-				assert(buf_hdr->entry.slist.next == (void *) OFI_MAGIC_64);
-			}
-#else
+			OFI_DBG_SET(buf_hdr->entry.dlist.next, OFI_MAGIC_PTR);
+			OFI_DBG_SET(buf_hdr->entry.dlist.prev, OFI_MAGIC_PTR);
 			pool->attr.init_fn(buf_region, buf);
-#endif
+			assert((buf_hdr->entry.dlist.next == OFI_MAGIC_PTR) &&
+			       (buf_hdr->entry.dlist.prev == OFI_MAGIC_PTR));
 		}
 		if (pool->attr.flags & OFI_BUFPOOL_INDEXED) {
 			dlist_insert_tail(&buf_hdr->entry.dlist,

--- a/prov/util/src/util_buf.c
+++ b/prov/util/src/util_buf.c
@@ -114,6 +114,12 @@ retry:
 		buf_hdr = ofi_buf_hdr(buf);
 		buf_hdr->region = buf_region;
 		buf_hdr->index = pool->entry_cnt + i;
+		OFI_DBG_SET(buf_hdr->magic, OFI_MAGIC_SIZE_T);
+		OFI_DBG_SET(buf_hdr->ftr,
+			    (struct ofi_bufpool_ftr *) ((char *) buf +
+			    pool->entry_size - sizeof(struct ofi_bufpool_ftr)));
+		OFI_DBG_SET(buf_hdr->ftr->magic, OFI_MAGIC_SIZE_T);
+
 		if (pool->attr.init_fn) {
 			OFI_DBG_SET(buf_hdr->entry.dlist.next, OFI_MAGIC_PTR);
 			OFI_DBG_SET(buf_hdr->entry.dlist.prev, OFI_MAGIC_PTR);
@@ -163,6 +169,7 @@ int ofi_bufpool_create_attr(struct ofi_bufpool_attr *attr,
 	pool->attr = *attr;
 
 	entry_sz = (attr->size + sizeof(struct ofi_bufpool_hdr));
+	OFI_DBG_ADD(entry_sz, sizeof(struct ofi_bufpool_ftr));
 	pool->entry_size = ofi_get_aligned_size(entry_sz, attr->alignment);
 
 	if (!attr->chunk_cnt) {


### PR DESCRIPTION
The rxd provider allocates and stores a data structure in an index map.  Although the map is reset during cleanup, the allocated structures are lost, resulting in a memory leak.  The latter usually only happens during application exit, but does show up using ASAN.  Add a callback when resetting the idm, so that the structures can be freed.

Enhance the buffer pool to wrap the user's buffer with magic values.  Check that the values are intact whenever the buffers are freed.  This is just to help catch buffer overruns.  No overruns have been detected so far with the checks in place.