### PR TITLE
prov/tcp: fixed hang on windows

### DIFF
--- a/prov/tcp/src/tcpx_conn_mgr.c
+++ b/prov/tcp/src/tcpx_conn_mgr.c
@@ -77,8 +77,7 @@ static int rx_cm_data(SOCKET fd, int type, struct tcpx_cm_context *cm_ctx)
 		if (data_size > TCPX_MAX_CM_DATA_SIZE)
 			data_size = TCPX_MAX_CM_DATA_SIZE;
 
-		ret = ofi_recv_socket(fd, cm_ctx->msg.data, data_size,
-				      MSG_WAITALL);
+		ret = ofi_recv_socket(fd, cm_ctx->msg.data, data_size, 0);
 		if ((size_t) ret != data_size) {
 			FI_WARN(&tcpx_prov, FI_LOG_EP_CTRL,
 				"Failed to read cm data\n");

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -124,7 +124,7 @@ static int tcpx_ep_connect(struct fid_ep *ep, const void *addr,
 	tcpx_ep->state = TCPX_CONNECTING;
 	ret = connect(tcpx_ep->sock, (struct sockaddr *) addr,
 		      (socklen_t) ofi_sizeofaddr(addr));
-	if (ret && ofi_sockerr() != FI_EINPROGRESS) {
+	if (ret && !OFI_SOCK_TRY_CONN_AGAIN(ofi_sockerr())) {
 		tcpx_ep->state = TCPX_IDLE;
 		ret =  -ofi_sockerr();
 		goto free;


### PR DESCRIPTION
There are some differences with non-blocking sockets between Linux and
Windows:
1) connect() on Windows may return EWOULDBLOCK, not EINPROGRESS
2) recv() with MSG_WAITALL flag returns EOPNOTSUPP

Signed-off-by: Andrey Lobanov <andrey.lobanov@intel.com>