### PR TITLE
prov/psm3: Only export fi_psm3_ini when building into libfabric

### DIFF
--- a/prov/psm3/Makefile.include
+++ b/prov/psm3/Makefile.include
@@ -309,6 +309,18 @@ libpsm3_la_LDFLAGS = $(psm3_LDFLAGS)
 libpsm3_la_LIBADD = $(psm3_LIBS) $(_psm3_LIBS)
 src_libfabric_la_LIBADD += libpsm3.la
 src_libfabric_la_DEPENDENCIES += libpsm3.la
+
+.libs/libpsm3_full.lo: $(libpsm3_la_OBJECTS) $(libpsm3_la_DEPENDENCIES) $(EXTRA_libpsm3_la_DEPENDENCIES)
+	$(AM_V_CCLD)$(libpsm3_la_LINK) -r $(am_libpsm3_la_rpath) $(libpsm3_la_OBJECTS) libpsm3i.la
+
+.libs/libpsm3_exp.o: .libs/libpsm3_full.lo
+	@objcopy --keep-global-symbol=fi_psm3_ini .libs/libpsm3_full.o .libs/libpsm3_exp.o
+
+libpsm3.la: .libs/libpsm3_exp.o
+	$(AM_V_CCLD)$(libpsm3_la_LINK) $(am_libpsm3_la_rpath) $(libpsm3_la_OBJECTS) $(libpsm3_la_LIBADD) $(LIBS); \
+	rm -f .libs/libpsm3.a libpsm3.a; \
+	ar cru .libs/libpsm3.a  .libs/libpsm3_exp.o
+
 endif !HAVE_PSM3_DL
 
 prov_install_man_pages += man/man7/fi_psm3.7


### PR DESCRIPTION
Before building the provider library, 3 steps are inserted into the make
dependency tree:
 1) link all objects/archives in provider into single libpsm3_full.lo
 2) using objcopy tool, remove all but fi_psm3_ini from global symbols
 3) repack new .o file into libpsm3.a (and make libpsm3.la wrapper)

This will effectively isolate the psm3 provider code to not allow name
collisions with other providers with similar function names when linked
into single libfabric library. As well as preserve function names for
debugging.

Signed-off-by: Goldman, Adam <adam.goldman@intel.com>