### PR TITLE
prov/rxm,verbs: Simplify XRC connection establishment prototype/experimental 

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1055,6 +1055,22 @@ struct ofi_ops_dynamic_rbuf {
 			    size_t *count);
 };
 
+/* Extend CM support for FI_EP_MSG endpoints that connect using a simplex
+ * transport protocol to allow duplex data transfer between peer endpoints.
+ * This helper enables a single simplex based endpoint to both initiate a
+ * connection and accept a connection request. The CM fi_accept() call is
+ * extended to pass connection request fi_info to an existing endpoint.
+ *
+ * accept - Initiate an accept for a connection request associated with the
+ *	fi_info passed.
+ */
+#define OFI_OPS_SIMPLEX_CM "ofix_simplex_cm_v1"
+
+struct ofi_ops_simplex_cm {
+	int (*accept)(struct fid_ep *ep, struct fi_info *info,
+		      const void *param, size_t paramlen);
+};
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -251,7 +251,6 @@ union rxm_cm_data {
 };
 
 int rxm_cmap_alloc_handle(struct rxm_cmap *cmap, fi_addr_t fi_addr,
-			  enum rxm_cmap_state state,
 			  struct rxm_cmap_handle **handle);
 struct rxm_cmap_handle *rxm_cmap_key2handle(struct rxm_cmap *cmap, uint64_t key);
 int rxm_cmap_update(struct rxm_cmap *cmap, const void *addr, fi_addr_t fi_addr);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -170,9 +170,9 @@ extern char *rxm_cm_state_str[];
 	do {								\
 		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "[CM] handle: "	\
 		       "%p %s -> %s\n",	handle,				\
-		       rxm_cm_state_str[handle->state],			\
+		       rxm_cm_state_str[(handle)->state],		\
 		       rxm_cm_state_str[new_state]);			\
-		handle->state = new_state;				\
+		(handle)->state = new_state;				\
 	} while (0)
 
 struct rxm_cmap_handle {

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -166,18 +166,28 @@ enum rxm_cmap_state {
 
 extern char *rxm_cm_state_str[];
 
-#define RXM_CM_UPDATE_STATE(handle, new_state)				\
+#define RXM_CM_UPDATE_TX_STATE(handle, new_state)			\
 	do {								\
 		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "[CM] handle: "	\
-		       "%p %s -> %s\n",	handle,				\
-		       rxm_cm_state_str[(handle)->state],		\
+		       "TX %p %s -> %s\n",	handle,			\
+		       rxm_cm_state_str[(handle)->tx_state],		\
 		       rxm_cm_state_str[new_state]);			\
-		(handle)->state = new_state;				\
+		(handle)->tx_state = new_state;				\
+	} while (0)
+
+#define RXM_CM_UPDATE_RX_STATE(handle, new_state)			\
+	do {								\
+		FI_DBG(&rxm_prov, FI_LOG_EP_CTRL, "[CM] handle: "	\
+		       "RX %p %s -> %s\n",	handle,			\
+		       rxm_cm_state_str[(handle)->rx_state],		\
+		       rxm_cm_state_str[new_state]);			\
+		(handle)->rx_state = new_state;				\
 	} while (0)
 
 struct rxm_cmap_handle {
 	struct rxm_cmap *cmap;
-	enum rxm_cmap_state state;
+	enum rxm_cmap_state tx_state;
+	enum rxm_cmap_state rx_state;
 	/* Unique identifier for a connection. Can be exchanged with a peer
 	 * during connection setup and can later be used in a message header
 	 * to identify the source of the message (Used for FI_SOURCE, RNDV

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1815,7 +1815,7 @@ static int rxm_post_recv(struct rxm_rx_buf *rx_buf)
 		return 0;
 
 	if (ret != -FI_EAGAIN) {
-		level = (rx_buf->conn->handle.state == RXM_CMAP_SHUTDOWN) ?
+		level = (rx_buf->conn->handle.rx_state == RXM_CMAP_SHUTDOWN) ?
 			FI_LOG_DEBUG : FI_LOG_WARN;
 		FI_LOG(&rxm_prov, level, FI_LOG_EP_CTRL,
 		       "unable to post recv buf: %d\n", ret);

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -403,7 +403,7 @@ static ssize_t rxm_send_credits(struct fid_ep *ep, size_t credits)
 	tx_buf->pkt.ctrl_hdr.msg_id = ofi_buf_index(tx_buf);
 	tx_buf->pkt.ctrl_hdr.ctrl_data = credits;
 
-	if (rxm_conn->handle.state != RXM_CMAP_CONNECTED)
+	if (rxm_conn->handle.tx_state != RXM_CMAP_CONNECTED)
 		goto defer;
 
 	iov.iov_base = &tx_buf->pkt;

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -1643,7 +1643,7 @@ void rxm_ep_progress_deferred_queue(struct rxm_ep *rxm_ep,
 	struct fi_msg msg;
 	ssize_t ret = 0;
 
-	if (rxm_conn->handle.state != RXM_CMAP_CONNECTED)
+	if (rxm_conn->handle.tx_state != RXM_CMAP_CONNECTED)
 		return;
 
 	while (!dlist_empty(&rxm_conn->deferred_tx_queue) && !ret) {

--- a/prov/verbs/src/fi_verbs.h
+++ b/prov/verbs/src/fi_verbs.h
@@ -604,9 +604,6 @@ struct vrb_xrc_ep {
 	uint16_t			remote_pep_port;
 	struct ofi_rbnode		*conn_map_node;
 
-	bool				ini_disconnect_sent;
-	bool				tgt_disconnect_sent;
-
 	/* The following state is allocated during XRC bidirectional setup and
 	 * freed once the connection is established. */
 	struct vrb_xrc_ep_conn_setup	*conn_setup;
@@ -721,7 +718,7 @@ int vrb_accept_xrc(struct vrb_xrc_ep *ep, struct fi_info *info,
 int vrb_resend_shared_accept_xrc(struct vrb_xrc_ep *ep,
 				    struct vrb_connreq *connreq,
 				    struct rdma_cm_id *id);
-void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect);
+void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep);
 void vrb_add_pending_ini_conn(struct vrb_xrc_ep *ep, void *conn_param,
 			      size_t conn_paramlen);
 void vrb_sched_ini_conn(struct vrb_ini_shared_conn *ini_conn);

--- a/prov/verbs/src/verbs_cm_xrc.c
+++ b/prov/verbs/src/verbs_cm_xrc.c
@@ -123,30 +123,13 @@ int vrb_create_xrc_cm_event(struct vrb_xrc_ep *ep, uint32_t event)
 }
 
 /* Caller must hold eq:lock */
-void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep, int disconnect)
+void vrb_free_xrc_conn_setup(struct vrb_xrc_ep *ep)
 {
-	/* A disconnect is requested on the RX (target) side to release
-	 * CM ID resources, it does not tear down the connection. */
-	if (disconnect) {
-		assert(ep->tgt_id);
-		assert(!ep->tgt_id->qp);
-
-		if (ep->tgt_id->ps == RDMA_PS_UDP) {
-			rdma_destroy_id(ep->tgt_id);
-			ep->tgt_id = NULL;
-		} else {
-			rdma_disconnect(ep->tgt_id);
-			ep->tgt_disconnect_sent = true;
-		}
-	}
-
-	if (!disconnect) {
-		free(ep->conn_setup);
-		ep->conn_setup = NULL;
-		free(ep->base_ep.info_attr.src_addr);
-		ep->base_ep.info_attr.src_addr = NULL;
-		ep->base_ep.info_attr.src_addrlen = 0;
-	}
+	free(ep->conn_setup);
+	ep->conn_setup = NULL;
+	free(ep->base_ep.info_attr.src_addr);
+	ep->base_ep.info_attr.src_addr = NULL;
+	ep->base_ep.info_attr.src_addrlen = 0;
 }
 
 int vrb_connect_xrc(struct vrb_xrc_ep *ep, struct sockaddr *addr,
@@ -259,9 +242,6 @@ vrb_xrc_connreq_init(struct vrb_ep *ep, struct vrb_connreq *connreq)
 	struct vrb_xrc_ep *xrc_ep = container_of(ep, struct vrb_xrc_ep,
 						 base_ep);
 	int ret;
-
-	assert(ep->info_attr.src_addr);
-	assert(ep->info_attr.dest_addr);
 
 	xrc_ep->tgt_id = connreq->id;
 	xrc_ep->tgt_id->context = &ep->util_ep.ep_fid.fid;

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -76,15 +76,27 @@ struct ofi_ops_flow_ctrl vrb_ops_flow_ctrl = {
 	.set_send_handler = vrb_set_credit_handler,
 };
 
+struct ofi_ops_simplex_cm vrb_ops_simplex_cm = {
+	.accept = vrb_msg_xrc_ep_simplex_accept,
+};
+
 static int
 vrb_domain_ops_open(struct fid *fid, const char *name, uint64_t flags,
 		    void **ops, void *context)
 {
+	struct vrb_domain *domain = container_of(fid, struct vrb_domain,
+						 util_domain.domain_fid.fid);
+
 	if (flags)
 		return -FI_EBADFLAGS;
 
 	if (!strcasecmp(name, OFI_OPS_FLOW_CTRL)) {
 		*ops = &vrb_ops_flow_ctrl;
+		return 0;
+	}
+	if (!strcasecmp(name, OFI_OPS_SIMPLEX_CM) &&
+	    (domain->ext_flags & VRB_USE_XRC)) {
+		*ops = &vrb_ops_simplex_cm;
 		return 0;
 	}
 

--- a/prov/verbs/src/verbs_ep.c
+++ b/prov/verbs/src/verbs_ep.c
@@ -438,7 +438,7 @@ static void vrb_ep_xrc_close(struct vrb_ep *ep)
 						 base_ep);
 
 	assert(fastlock_held(&ep->eq->lock));
-	vrb_free_xrc_conn_setup(xrc_ep, 0);
+	vrb_free_xrc_conn_setup(xrc_ep);
 	if (xrc_ep->conn_map_node)
 		vrb_eq_remove_sidr_conn(xrc_ep);
 


### PR DESCRIPTION
This set of commits is an experimental/prototype for reducing the complexity of the Verbs provider XRC transport connection setup. The XRC transport connects an XRC initiator (send) QP to a remote XRC target (receive) QP, establishing simplex operation. In the current implementation, the Verbs provider hides this simplex nature from RxM by creating the connection in the reverse direction as part of the RxM connect request.

This code removes this hidden reciprocal connection from the Verbs provider, and allows RxM which already knows the address to EP mapping to drive a connection operation in both directions. To do this the notion of a simplex transport based EP is introduced and defined to allow a single EP to both connect and accept a connection (to establish duplex operation). Support of the OFI_OPS_SIMPLEX_CM ops by the core provider indicates this behavior and extends the fi_accept() operation to pass
connection request fi_info to an existing EP.

The advantages of this approach:
- Maintainability, it significantly reduces the amount of XRC setup code while only minimally adding to the RxM code complexity
- Reduces the connect time in that the connection request does not have to delay waiting for the reverse connection to setup
- Maintaining use of a single EP for duplex operation keeps from increasing memory consumption

The commit on the tip of this PR removes the XRC logic that releases RDMA CM IDs after physical connections are established. The value of this commit must be examined at greater scale and determined if appropriate. While it reduces the number of CM
messages exchanged during connection setup, it requires a greater number of RDMA CM IDs exist during steady state operation. There are previous versions of MOFED that have limitations in port space that restricted scale. NOTE: This commit may be removed independent of the others to compare operation while still releasing RDMA CM ID resources.
