### PR TITLE
src/hmem_ze: Fix a bug that may overwrite device handle with NULL

### DIFF
--- a/src/hmem_ze.c
+++ b/src/hmem_ze.c
@@ -223,11 +223,12 @@ bool ze_is_addr_valid(const void *addr)
 {
 	ze_result_t ze_ret;
 	ze_memory_allocation_properties_t mem_prop;
+	ze_device_handle_t device;
 	int i;
 
 	for (i = 0; i < num_devices; i++) {
 		ze_ret = zeMemGetAllocProperties(context, addr, &mem_prop,
-						 &devices[i]);
+						 &device);
 		if (!ze_ret && mem_prop.type == ZE_MEMORY_TYPE_DEVICE)
 			return true;
 	}


### PR DESCRIPTION
The global device handle array is overwritten whenever the function
ze_is_addr_valid() is called. This is fine for device memory pointers
since the device handles are always the same. However, if the address
being checked is not a device memory pointer, the retrieved device handle
is NULL. Subsequent calls to ofi_copy_*() function will cause segfault
until another successful check is performed.

There is no need to update the global array here, use a local variable
instead.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>