### PR TITLE
prov/rxm: Minor fixes for dynamic receive buffer handling

### DIFF
--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1535,6 +1535,8 @@ static int rxm_get_recv_entry(struct rxm_rx_buf *rx_buf)
 		if (entry) {
 			rx_buf->recv_entry = container_of(entry,
 						struct rxm_recv_entry, entry);
+			if (rx_buf->recv_entry->flags & FI_MULTI_RECV)
+				rxm_adjust_multi_recv(rx_buf);
 		} else {
 			recv_queue->dyn_rbuf_unexp_cnt++;
 		}

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -1517,6 +1517,7 @@ static int rxm_get_recv_entry(struct rxm_rx_buf *rx_buf)
 		match_attr.addr = FI_ADDR_UNSPEC;
 	}
 
+	match_attr.ignore = 0;
 	if (rx_buf->pkt.hdr.op == ofi_op_msg) {
 		match_attr.tag = 0;
 		recv_queue = &rx_buf->ep->recv_queue;

--- a/prov/tcp/src/tcpx.h
+++ b/prov/tcp/src/tcpx.h
@@ -222,6 +222,8 @@ struct tcpx_fabric {
 	struct util_fabric	util_fabric;
 };
 
+#define TCPX_NEED_DYN_RBUF 	BIT_ULL(61)
+
 struct tcpx_xfer_entry {
 	struct slist_entry	entry;
 	union {

--- a/src/iov.c
+++ b/src/iov.c
@@ -129,7 +129,7 @@ int ofi_truncate_iov(struct iovec *iov, size_t *iov_count, size_t new_size)
 		}
 		new_size -= iov[i].iov_len;
 	}
-	return -FI_ETRUNC;
+	return new_size ? -FI_ETRUNC : FI_SUCCESS;
 }
 
 /* Copy 'len' bytes worth of src iovec to dst */


### PR DESCRIPTION
Not that these make things work, but should improve the code.

Fallback to unexpected msg handling for multi-recv buffers.
Initialize the ignore bits when matching buffers.