### PR TITLE
prov/psm3/rv: Handle location change of rv header

### DIFF
--- a/prov/psm3/configure.ac
+++ b/prov/psm3/configure.ac
@@ -53,30 +53,61 @@ AC_ARG_WITH([psm3-rv],
             [AS_HELP_STRING([--with-psm3-rv],
                             [Enable RV module use @<:@default=check@:>@])])
 AS_IF([test x$with_psm3_rv = xno],
+      [CPPFLAGS="$CPPFLAGS -URNDV_MOD"],
       [
-	CPPFLAGS="$CPPFLAGS -URNDV_MOD"
-      ],[
 	AS_IF([test "x$with_psm3_rv" = "x"],
 	      [
 		psm3_rv_check=1
-		with_psm3_rv=/usr/include/uapi
-	      ])
+		with_psm3_rv=/usr/include
+	      ],[psm3_rv_check=0])
+	psm3_rv_old_header=0
+	save_CPPFLAGS=$CPPFLAGS
+	CPPFLAGS="$CPPFLAGS -I$with_psm3_rv"
+	dnl Check for /usr/include/rdma/rv_user_ioctls.h first
 	_FI_CHECK_PACKAGE_HEADER([psm3_rv],
-	                         [$with_psm3_rv/rdma/rv_user_ioctls.h],
+	                         [rdma/rv_user_ioctls.h],
 	                         [],
 	                         [psm3_rv_happy=1],
 	                         [psm3_rv_happy=0])
-	AS_IF([test "$psm3_rv_happy" -eq 0 && test "$psm3_rv_check" -eq 0],
+
+	AS_IF([test $psm3_rv_happy -eq 0], [
+		AS_IF([test "$psm3_rv_check" -eq 1],
+		      [with_psm3_rv=/usr/include/uapi])
+		CPPFLAGS="$save_CPPFLAGS -I$with_psm3_rv"
+		_FI_CHECK_PACKAGE_HEADER([psm3_rv],
+		                         [rv/rv_user_ioctls.h],
+		                         [],
+		                         [psm3_rv_happy=1
+		                          psm3_rv_old_header=1],
+		                         [psm3_rv_happy=0])
+	      ])
+	CPPFLAGS=$save_CPPFLAGS
+	AS_IF([test "$psm3_rv_happy" -eq 0],
 	      [
-		AC_MSG_ERROR([RV Module headers requested but <rdma/rv_user_ioctls.h> not found.])
-	      ],
-	      [
-		AS_IF([test "$psm3_rv_happy" -eq 1],
-		      [
-			CPPFLAGS="$CPPFLAGS -DRNDV_MOD -I$with_psm3_rv"
-		      ], [
-			CPPFLAGS="$CPPFLAGS -URNDV_MOD"
-		      ])
+		AS_IF([test "$psm3_rv_check" -eq 0], [
+			psm3_happy=0
+			AC_MSG_ERROR([RV Module headers requested but rv_user_ioctls.h not found.])
+		])
+		CPPFLAGS="$CPPFLAGS -URNDV_MOD"
+	      ],[
+		CPPFLAGS="$CPPFLAGS -DRNDV_MOD -I$with_psm3_rv"
+		AS_IF([test "$psm3_rv_old_header" -eq 1],
+		      [CPPFLAGS="$CPPFLAGS -DHAVE_OLD_RV_HEADER"])
+	      ])
+	AS_IF([test "$psm3_rv_happy" -eq 1], [
+		AC_MSG_CHECKING([for RV support for ring.overflow_cnt])
+		AC_COMPILE_IFELSE(
+			[AC_LANG_PROGRAM(
+				[[#include <sys/types.h>
+				  #include <stdint.h>
+				  #include <rdma/rv_user_ioctls.h>
+				]],[[struct rv_ring_header ring; ring.overflow_cnt=0;]])
+			],[
+				AC_MSG_RESULT(yes)
+			],[
+				AC_MSG_RESULT(no)
+				CPPFLAGS="$CPPFLAGS -DHAVE_NO_PSM3_RV_OVERFLOW_CNT"
+			])
 	      ])
       ])
 AC_ARG_WITH([psm-headers],

--- a/prov/psm3/psm3/psm_rndv_mod.c
+++ b/prov/psm3/psm3/psm_rndv_mod.c
@@ -102,7 +102,12 @@ struct irdma_mem_reg_req {
 static int rv_map_event_ring(psm2_rv_t rv, struct rv_event_ring* ring,
 				int entries, int offset)
 {
+#ifdef RV_RING_ALLOC_LEN
 	ring->len = RV_RING_ALLOC_LEN(entries);
+#else /* older version of RV header */
+	ring->len = RING_ALLOC_LEN(entries);
+#endif
+
 
 	//printf("Calling mmap for offset: %d len:%d\n", offset, ring->len);
 
@@ -825,7 +830,10 @@ int __psm2_rv_cq_overflowed(psm2_rv_t rv)
 		errno = EINVAL;
 		return -1;
 	}
+#ifndef HAVE_NO_PSM3_RV_OVERFLOW_CNT
 	return (rv->events.hdr->overflow_cnt != 0);
+#else
+	return 0;
+#endif
 }
-
 #endif // RNDV_MOD

--- a/prov/psm3/psm3/psm_rndv_mod.h
+++ b/prov/psm3/psm3/psm_rndv_mod.h
@@ -60,7 +60,11 @@
 #include <sys/types.h>
 //#include <sys/socket.h>
 //#include <rdma/rdma_verbs.h>
+#ifndef HAVE_OLD_RV_HEADER
 #include <rdma/rv_user_ioctls.h>
+#else
+#include <rv/rv_user_ioctls.h>
+#endif
 
 struct local_info {
 	uint32_t mr_cache_size;	// in MBs


### PR DESCRIPTION
Detect location of RV header automatically if not passed in.

Check locations in following order:
  /usr/include/rdma/rv_user_ioctls.h
  /usr/include/uapi/rv/rv_user_ioctls.h
  /usr/include/rv/rv_user_ioctls.h

If not found in newer rdma dir define and use HAVE_OLD_RV_HEADER.
If found, indicate older location and header are available.

Also added compile test for detecting overflow_cnt field.
define HAVE_NO_PSM3_RV_OVERFLOW_CNT if not found.

Address RV_RING_ALLOC_LEN vs RING_ALLOC_LEN differences

Reviewed-by: Kaike Wan <kaike.wan@intel.com>
Reviewed-by: Todd Rimmer <todd.rimmer@intel.com>
Signed-off-by: Goldman, Adam <adam.goldman@intel.com>