### PR TITLE
prov/psm3: Add missing RNDV_MOD ifdefs

### DIFF
--- a/prov/psm3/psm3/psm_verbs_mr.h
+++ b/prov/psm3/psm3/psm_verbs_mr.h
@@ -62,7 +62,9 @@
 #define _PSMI_VERBS_MR_H
 
 #include <infiniband/verbs.h>
+#ifdef RNDV_MOD
 #include <psm_rndv_mod.h>
+#endif
 
 #define MR_CACHE_MODE_NONE 0	// user space MRs, but no caching
 #define MR_CACHE_MODE_KERNEL 1	// kernel MR cache in rendezvous module

--- a/prov/psm3/psm3/ptl_ips/ips_proto_connect.c
+++ b/prov/psm3/psm3/ptl_ips/ips_proto_connect.c
@@ -392,8 +392,10 @@ ips_ipsaddr_set_req_params(struct ips_proto *proto,
 #endif // RNDV_MOD
 	if (ipsaddr->rc_qp) {
 		psmi_assert(IPS_PROTOEXP_FLAG_USER_RC_QP(proto->ep->rdmamode));
+#ifdef RNDV_MOD
 		psmi_assert(proto->ep->verbs_ep.rv
 					|| proto->ep->mr_cache_mode != MR_CACHE_MODE_KERNEL);
+#endif
 		if (! req->qp_attr.qpn) {
 			_HFI_ERROR("mismatched PSM3_RDMA config, remote end not in mode 2 or 3\n");
 			return PSM2_INTERNAL_ERR;


### PR DESCRIPTION
Both cases are not required, but cleaner to have them.
Ifdef around include will just stop the include of an empty file.
Ifdef around assert will always be false as those fields are only set
inside an ifdef.

Signed-off-by: Goldman, Adam <adam.goldman@intel.com>