### PR TITLE
core/mr_cache: introduce deferred_cnt/size and include it in when to flush MR cache

### DIFF
--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -292,6 +292,8 @@ struct ofi_mr_cache {
 	size_t				cached_size;
 	size_t				uncached_cnt;
 	size_t				uncached_size;
+	size_t				deferred_cnt;
+	size_t				deferred_size;
 	size_t				search_cnt;
 	size_t				delete_cnt;
 	size_t				hit_cnt;

--- a/include/ofi_mr.h
+++ b/include/ofi_mr.h
@@ -285,7 +285,7 @@ struct ofi_mr_cache {
 
 	struct ofi_rbmap		tree;
 	struct dlist_entry		lru_list;
-	struct dlist_entry		flush_list;
+	struct dlist_entry		deferred_list;
 	pthread_mutex_t 		lock;
 
 	size_t				cached_cnt;

--- a/prov/util/src/util_mr_cache.c
+++ b/prov/util/src/util_mr_cache.c
@@ -347,8 +347,8 @@ int ofi_mr_cache_search(struct ofi_mr_cache *cache, const struct fi_mr_attr *att
 	do {
 		pthread_mutex_lock(&mm_lock);
 
-		if ((cache->cached_cnt >= cache_params.max_cnt) ||
-		    (cache->cached_size >= cache_params.max_size)) {
+		if ((cache->cached_cnt + cache->deferred_cnt >= cache_params.max_cnt) ||
+		    (cache->cached_size + cache->deferred_size >= cache_params.max_size)) {
 			pthread_mutex_unlock(&mm_lock);
 			ofi_mr_cache_flush(cache, true);
 			pthread_mutex_lock(&mm_lock);


### PR DESCRIPTION
This patch series address an issue of MR cache, which is deferred memory registration count/size was not included in considering when to flush MR cache.

To address the issue, it introduced deferred_cnt/deferred_size to MR cache, and included it in the condition to flush MR cache.