### PR TITLE
configure.ac: fix behavior of gdrcopy library checking and usage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -602,15 +602,30 @@ AC_ARG_WITH([gdrcopy],
 			    and runtime libraries are installed.])],
 	    [], [])
 
-FI_CHECK_PACKAGE([gdrcopy],
-		 [gdrapi.h],
-		 [gdrapi],
-		 [gdr_open],
-		 [-lgdrapi],
-		 [$with_gdrcopy],
-		 [],
-		 [AC_DEFINE([HAVE_GDRCOPY], [1],[gdrcopy support])],
-		 [], [])
+AS_IF([test -n "$with_gdrcopy" && test x"$with_gdrcopy" != x"no" && test "$have_libcuda" == "0"],
+	[AC_MSG_ERROR([gdrcopy is requested but cuda is not requested or cuda runtime is not available.])],
+	[])
+
+have_gdrcopy=0
+AS_IF([test "$have_libcuda" == "1" && test x"$with_gdrcopy" != x"no"],
+	[AS_IF([test x"$with_gdrcopy" == x"yes"],[gdrcopy_dir=""],[gdrcopy_dir=$with_gdrcopy])
+	 FI_CHECK_PACKAGE([gdrcopy],
+			  [gdrapi.h],
+			  [gdrapi],
+			  [gdr_open],
+			  [],
+			  [$gdrcopy_dir],
+			  [],
+			  [have_gdrcopy=1],
+			  [],
+			  [])],
+	[])
+
+AS_IF([test x"$with_gdrcopy" != x"no" && test -n "$with_gdrcopy" && test "$have_gdrcopy" = "0" ],
+	[AC_MSG_ERROR([gdrcopy support requested but gdrcopy development library is not available.])],
+	[])
+
+AC_DEFINE_UNQUOTED([HAVE_GDRCOPY], [$have_gdrcopy], [Whether we have gdrcopy development library or not])
 
 AC_ARG_ENABLE([gdrcopy-dlopen],
     [AS_HELP_STRING([--enable-gdrcopy-dlopen],

--- a/src/hmem_cuda_gdrcopy.c
+++ b/src/hmem_cuda_gdrcopy.c
@@ -38,7 +38,7 @@
 #include "ofi_hmem.h"
 #include "ofi.h"
 
-#ifdef HAVE_GDRCOPY
+#if HAVE_GDRCOPY
 
 #include <pthread.h>
 #include <gdrapi.h>


### PR DESCRIPTION
Currently, gdrcopy library is always checked and used in if it exists,
even if user specified --without-gdrcopy or --with-gdrcopy=no.

This patch adjust beavior of gdrcopy library checking to the following

1. If cuda library is not available, do not check gdrcopy. This is
   because gdrcopy without cuda does not work. If user asked for gdrcopy
   by --with-gdrcopy, fail the configure and print error message.

2. If cuda library is available:
   2a. If user specify --without-gdrcopy or --with-gdrcopy=no, do not
       checkout gdrcopy.
   2b. Otherwise check gdrcopy. If gdrcopy does not exist and user asked
       for gdrcopy, fail and print error message.

Signed-off-by: Wei Zhang <wzam@amazon.com>