### PR TITLE
v1.12.0 release - CI validation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@ v1.12.0, Mon Mar 8, 2021
 - Support gdrcopy in addition to cudaMemcpy to avoid deadlocks
 - Properly mark if addresses support only local communication
 - Prevent providers from layering over each other non-optimally
+- Fix pollfds abstraction to fix possible use after free
 
 ## EFA
 - Added support for FI_DELIVERY_COMPLETE via an acknowledgment packet in the
@@ -57,7 +58,9 @@ v1.12.0, Mon Mar 8, 2021
 
 ## PSM3
 
-- New Intel provider optimized for verbs UD QPs
+- New core provider for psm3.x protocol over verbs UD interfaces, with
+  additional features over Intel E810 RoCEv2 capable NICs
+- See fi_psm3.7 man page for more details
 
 ## RxD
 
@@ -109,6 +112,7 @@ v1.12.0, Mon Mar 8, 2021
 - Handle FI_SYNC_ERR flag on AV insert
 - Improve destination IP address checks
 - Minor coding cleanups based on static code analysis
+- Fix possible use after free access in Rx progress handling
 
 ## TCP
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,7 +7,7 @@ dnl
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.60])
-AC_INIT([libfabric], [1.12.0rc3], [ofiwg@lists.openfabrics.org])
+AC_INIT([libfabric], [1.12.0], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_SRCDIR([src/fabric.c])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)

--- a/fabtests/COPYING
+++ b/fabtests/COPYING
@@ -7,7 +7,7 @@ Some parts of the source are 3rd party code which uses MIT license.
 The description and requirements of the license are available in
 later part of this file.
 
-Copyright (c) 2015-2020 Intel Corporation.  All rights reserved.
+Copyright (c) 2015-2021 Intel Corporation.  All rights reserved.
 Copyright (c) 2016-2018 Cisco Systems, Inc.  All rights reserved.
 
 ==================================================================

--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -5,7 +5,7 @@ dnl
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT([fabtests], [1.12.0rc3], [ofiwg@lists.openfabrics.org])
+AC_INIT([fabtests], [1.12.0], [ofiwg@lists.openfabrics.org])
 AC_CONFIG_AUX_DIR(config)
 AC_CONFIG_MACRO_DIR(config)
 AC_CONFIG_HEADERS(config.h)

--- a/include/ofi_epoll.h
+++ b/include/ofi_epoll.h
@@ -63,7 +63,6 @@ struct ofi_pollfds {
 	int		nfds;
 	struct pollfd	*fds;
 	void		**context;
-	int		index;
 	struct fd_signal signal;
 	struct slist	work_item_list;
 	fastlock_t	lock;

--- a/include/windows/config.h
+++ b/include/windows/config.h
@@ -165,7 +165,7 @@
 #define PACKAGE_TARNAME PACKAGE
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.12.0rc3"
+#define PACKAGE_VERSION "1.12.0"
 
 /* Define to the full name and version of this package. */
 #define PACKAGE_STRING PACKAGE_NAME " " PACKAGE_VERSION

--- a/prov/psm3/Makefile.include
+++ b/prov/psm3/Makefile.include
@@ -31,9 +31,7 @@ chksum_srcs = $(_psm3_files)
 if HAVE_PSM3_SRC
 _psm3_cflags = -mavx2
 #include prov/psm3/psm3/Makefile.include
-_psm3_files += \
-	prov/psm3/src/psm3_revision.c
-chksum_srcs += \
+_nodist_psm3_files = \
 	prov/psm3/src/psm3_revision.c
 
 # builddir is for nodist config headers: See nodist_libpsm3i_la_SOURCES
@@ -298,6 +296,7 @@ endif HAVE_PSM3_SRC
 if HAVE_PSM3_DL
 pkglib_LTLIBRARIES += libpsm3-fi.la
 libpsm3_fi_la_SOURCES = $(_psm3_files) $(common_srcs)
+nodist_libpsm3_fi_la_SOURCES = $(_nodist_psm3_files)
 libpsm3_fi_la_CFLAGS = $(AM_CFLAGS) $(psm3_CFLAGS) $(_psm3_cflags)
 libpsm3_fi_la_CPPFLAGS = $(AM_CPPFLAGS) $(psm3_CPPFLAGS) $(_psm3_cppflags)
 libpsm3_fi_la_LDFLAGS = \
@@ -308,6 +307,7 @@ libpsm3_fi_la_DEPENDENCIES = $(linkback)
 else !HAVE_PSM3_DL
 noinst_LTLIBRARIES += libpsm3.la
 libpsm3_la_SOURCES = $(_psm3_files)
+nodist_libpsm3_la_SOURCES = $(_nodist_psm3_files)
 libpsm3_la_CFLAGS = $(src_libfabric_la_CFLAGS) $(psm3_CFLAGS) $(_psm3_cflags)
 libpsm3_la_CPPFLAGS = $(src_libfabric_la_CPPFLAGS) $(psm3_CPPFLAGS) $(_psm3_cppflags)
 libpsm3_la_LDFLAGS = $(psm3_LDFLAGS)

--- a/prov/psm3/Makefile.include
+++ b/prov/psm3/Makefile.include
@@ -35,8 +35,11 @@ _psm3_files += \
 	prov/psm3/src/psm3_revision.c
 chksum_srcs += \
 	prov/psm3/src/psm3_revision.c
+
+# builddir is for nodist config headers: See nodist_libpsm3i_la_SOURCES
 _psm3_cppflags += \
 	-I$(top_srcdir)/prov/psm3/psm3 \
+	-I$(top_builddir)/prov/psm3/psm3 \
 	-I$(top_srcdir)/prov/psm3/psm3/ptl_ips/ \
 	-I$(top_srcdir)/prov/psm3/psm3/include/ \
 	-I$(top_srcdir)/prov/psm3/psm3/include/linux-i386/ \
@@ -235,8 +238,6 @@ libpsm3i_la_SOURCES = \
 	prov/psm3/psm3/psm2_am.h \
 	prov/psm3/psm3/psm2_hal.c \
 	prov/psm3/psm3/psm2_hal.h \
-	prov/psm3/psm3/psm2_hal_inlines_i.h \
-	prov/psm3/psm3/psm2_hal_inlines_d.h \
 	prov/psm3/psm3/psm2_hal_inline_t.h \
 	prov/psm3/psm3/psm2_mq.h \
 	prov/psm3/psm3/ptl.h
@@ -245,6 +246,10 @@ libpsm3i_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) $(psm3_CPPFLAGS) $(_psm3_cppflags)
 libpsm3i_la_CFLAGS = \
 	$(AM_CFLAGS) $(psm3_CFLAGS) $(_psm3_cflags)
+
+nodist_libpsm3i_la_SOURCES = \
+	prov/psm3/psm3/psm2_hal_inlines_i.h \
+	prov/psm3/psm3/psm2_hal_inlines_d.h
 
 libpsm3i_la_LIBADD = \
 	libopa.la \

--- a/prov/tcp/src/tcpx_ep.c
+++ b/prov/tcp/src/tcpx_ep.c
@@ -452,7 +452,7 @@ static void tcpx_ep_cancel_rx(struct tcpx_ep *ep, void *context)
 	slist_foreach(&ep->rx_queue, cur, prev) {
 		xfer_entry = container_of(cur, struct tcpx_xfer_entry, entry);
 		if (xfer_entry->context == context) {
-			if (ep->cur_rx_entry == xfer_entry)
+			if (ep->cur_rx_entry != xfer_entry)
 				goto found;
 			break;
 		}


### PR DESCRIPTION
We can only cancel a receive if it's not active.  However, the
current check only allows cancel to proceed if it is.  Fix the
check to look for inactive receives.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>